### PR TITLE
Various improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ install:
 - echo "Don't run anything."
 
 # Don't test vendored code.
-script: go test $(go list ./... | grep -v /vendor/)
+script: ./test.sh

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,5 +1,5 @@
 {
-	"ImportPath": "github.com/kubernetes/minikube",
+	"ImportPath": "k8s.io/minikube",
 	"GoVersion": "go1.6",
 	"GodepVersion": "v62",
 	"Packages": [

--- a/README.md
+++ b/README.md
@@ -34,28 +34,32 @@ For more information about minikube, see the [proposal](https://github.com/kuber
 
 ## Build Instructions
 
-    go build -o minikube cli/main.go
+```shell
+./build.sh
+```
 
 ## Run Instructions
 
 Start the cluster with:
 
-    ./minikube start
-    Starting local Kubernetes cluster...
-    2016/04/19 11:41:26 Machine exists!
-    2016/04/19 11:41:27 Kubernetes is available at http://192.168.99.100:8080.
-    2016/04/19 11:41:27 Run this command to use the cluster: 
-    2016/04/19 11:41:27 kubectl config set-cluster minikube --insecure-skip-tls-verify=true --server=http://192.168.99.100:8080
+```console
+$ ./minikube start
+Starting local Kubernetes cluster...
+2016/04/19 11:41:26 Machine exists!
+2016/04/19 11:41:27 Kubernetes is available at http://192.168.99.100:8080.
+2016/04/19 11:41:27 Run this command to use the cluster: 
+2016/04/19 11:41:27 kubectl config set-cluster minikube --insecure-skip-tls-verify=true --server=http://192.168.99.100:8080
+```
 
-Access the cluster with:
+Access the cluster by adding `-s=http://192.168.x.x:8080` to every `kubectl` command, or run the commands below:
 
- First run the command from above:
+```shell
+kubectl config set-cluster minikube --insecure-skip-tls-verify=true --server=http://192.168.99.100:8080
+kubectl config set-context minikube --cluster=minikube
+kubectl config use-context minikube
+```
 
-    kubectl config set-cluster minikube --insecure-skip-tls-verify=true --server=http://192.168.99.100:8080
-
-Then use kubectl normally:
-
-    kubectl get pods --cluster=minikube
+by running those commands, you may use `kubectl` normally
 
 ## Development
 
@@ -67,15 +71,16 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for an overview of how to send pull reque
 
 Unit tests are run on Travis before code is merged. To run as part of a development cycle:
 
-	go test $(go list ./... | grep -v /vendor/)
+```shell
+go test $(go list ./... | grep -v /vendor/)
+```
 
 #### Integration Tests
 
-Integration tests are currently run manually. To run them, first build the binary:
-	
-	go build -o minikube cli/main.go
+Integration tests are currently run manually. 
+To run them, build the binary and run the tests:
 
-Then test it:
-
-	go test ./integration --tags=integration
-
+```shell
+./build.sh
+go test ./integration --tags=integration
+```

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for an overview of how to send pull reque
 Unit tests are run on Travis before code is merged. To run as part of a development cycle:
 
 ```shell
-go test $(go list ./... | grep -v /vendor/)
+./test.sh
 ```
 
 #### Integration Tests

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+REPO_PATH="github.com/kubernetes/minikube"
+
+export GOPATH=${PWD}/gopath
+export GO15VENDOREXPERIMENT=1
+export OS=${OS:-$(go env GOOS)}
+export ARCH=${ARCH:-$(go env GOARCH)}
+
+rm -f ${GOPATH}/src/${REPO_PATH}
+mkdir -p $(dirname ${GOPATH}/src/${REPO_PATH})
+ln -s ${PWD} $GOPATH/src/${REPO_PATH}
+
+CGO_ENABLED=0 GOARCH=${ARCH} GOOS=${OS} go build --installsuffix cgo -a -o minikube cli/main.go

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-REPO_PATH="github.com/kubernetes/minikube"
+REPO_PATH="k8s.io/minikube"
 
 export GOPATH=${PWD}/gopath
 export GO15VENDOREXPERIMENT=1

--- a/cli/cluster/cluster.go
+++ b/cli/cluster/cluster.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 The Kubernetes Authors All rights reserved.
+Copyright 2016 The Kubernetes Authors All rights reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/cli/cluster/cluster.go
+++ b/cli/cluster/cluster.go
@@ -24,7 +24,7 @@ import (
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/state"
-	"github.com/kubernetes/minikube/cli/constants"
+	"k8s.io/minikube/cli/constants"
 )
 
 // StartHost starts a host VM.

--- a/cli/cluster/cluster_test.go
+++ b/cli/cluster/cluster_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/state"
-	"github.com/kubernetes/minikube/cli/constants"
-	"github.com/kubernetes/minikube/cli/tests"
+	"k8s.io/minikube/cli/constants"
+	"k8s.io/minikube/cli/tests"
 )
 
 func TestCreateHost(t *testing.T) {

--- a/cli/cmd/delete.go
+++ b/cli/cmd/delete.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 The Kubernetes Authors All rights reserved.
+Copyright 2016 The Kubernetes Authors All rights reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/cli/cmd/delete.go
+++ b/cli/cmd/delete.go
@@ -18,9 +18,9 @@ import (
 	"os"
 
 	"github.com/docker/machine/libmachine"
+	"github.com/spf13/cobra"
 	"k8s.io/minikube/cli/cluster"
 	"k8s.io/minikube/cli/constants"
-	"github.com/spf13/cobra"
 )
 
 // deleteCmd represents the delete command

--- a/cli/cmd/delete.go
+++ b/cli/cmd/delete.go
@@ -18,8 +18,8 @@ import (
 	"os"
 
 	"github.com/docker/machine/libmachine"
-	"github.com/kubernetes/minikube/cli/cluster"
-	"github.com/kubernetes/minikube/cli/constants"
+	"k8s.io/minikube/cli/cluster"
+	"k8s.io/minikube/cli/constants"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -18,8 +18,8 @@ import (
 	"log"
 	"os"
 
-	"k8s.io/minikube/cli/constants"
 	"github.com/spf13/cobra"
+	"k8s.io/minikube/cli/constants"
 )
 
 var dirs = [...]string{

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 The Kubernetes Authors All rights reserved.
+Copyright 2016 The Kubernetes Authors All rights reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -18,7 +18,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/kubernetes/minikube/cli/constants"
+	"k8s.io/minikube/cli/constants"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -29,11 +29,9 @@ var dirs = [...]string{
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
-	Use:   "cli",
+	Use:   "minikube",
 	Short: "Minikube is a tool for managing local Kubernetes clusters.",
-	Long: `Minikube is a CLI tool that provisions and manages single-node Kubernetes
-clusters optimized for development workflows.
-	`,
+	Long: `Minikube is a CLI tool that provisions and manages single-node Kubernetes clusters optimized for development workflows.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		for _, path := range dirs {
 			if err := os.MkdirAll(path, 0777); err != nil {

--- a/cli/cmd/root_test.go
+++ b/cli/cmd/root_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/kubernetes/minikube/cli/constants"
+	"k8s.io/minikube/cli/constants"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/root_test.go
+++ b/cli/cmd/root_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
-	"k8s.io/minikube/cli/constants"
 	"github.com/spf13/cobra"
+	"k8s.io/minikube/cli/constants"
 )
 
 func makeTempDir() string {

--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -20,9 +20,9 @@ import (
 	"strings"
 
 	"github.com/docker/machine/libmachine"
+	"github.com/spf13/cobra"
 	"k8s.io/minikube/cli/cluster"
 	"k8s.io/minikube/cli/constants"
-	"github.com/spf13/cobra"
 )
 
 // startCmd represents the start command

--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 The Kubernetes Authors All rights reserved.
+Copyright 2016 The Kubernetes Authors All rights reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -20,8 +20,8 @@ import (
 	"strings"
 
 	"github.com/docker/machine/libmachine"
-	"github.com/kubernetes/minikube/cli/cluster"
-	"github.com/kubernetes/minikube/cli/constants"
+	"k8s.io/minikube/cli/cluster"
+	"k8s.io/minikube/cli/constants"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -19,9 +19,9 @@ import (
 	"os"
 
 	"github.com/docker/machine/libmachine"
+	"github.com/spf13/cobra"
 	"k8s.io/minikube/cli/cluster"
 	"k8s.io/minikube/cli/constants"
-	"github.com/spf13/cobra"
 )
 
 // statusCmd represents the status command

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -19,8 +19,8 @@ import (
 	"os"
 
 	"github.com/docker/machine/libmachine"
-	"github.com/kubernetes/minikube/cli/cluster"
-	"github.com/kubernetes/minikube/cli/constants"
+	"k8s.io/minikube/cli/cluster"
+	"k8s.io/minikube/cli/constants"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 The Kubernetes Authors All rights reserved.
+Copyright 2016 The Kubernetes Authors All rights reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/cli/cmd/stop.go
+++ b/cli/cmd/stop.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 The Kubernetes Authors All rights reserved.
+Copyright 2016 The Kubernetes Authors All rights reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/cli/cmd/stop.go
+++ b/cli/cmd/stop.go
@@ -18,9 +18,9 @@ import (
 	"os"
 
 	"github.com/docker/machine/libmachine"
+	"github.com/spf13/cobra"
 	"k8s.io/minikube/cli/cluster"
 	"k8s.io/minikube/cli/constants"
-	"github.com/spf13/cobra"
 )
 
 // stopCmd represents the stop command

--- a/cli/cmd/stop.go
+++ b/cli/cmd/stop.go
@@ -18,8 +18,8 @@ import (
 	"os"
 
 	"github.com/docker/machine/libmachine"
-	"github.com/kubernetes/minikube/cli/cluster"
-	"github.com/kubernetes/minikube/cli/constants"
+	"k8s.io/minikube/cli/cluster"
+	"k8s.io/minikube/cli/constants"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/machine/client.go
+++ b/cli/machine/client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 The Kubernetes Authors All rights reserved.
+Copyright 2016 The Kubernetes Authors All rights reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/cli/machine/client_test.go
+++ b/cli/machine/client_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/docker/machine/libmachine/drivers/plugin/localbinary"
-	"github.com/kubernetes/minikube/cli/constants"
+	"k8s.io/minikube/cli/constants"
 )
 
 func makeTempDir() string {

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 The Kubernetes Authors All rights reserved.
+Copyright 2016 The Kubernetes Authors All rights reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/cli/main.go
+++ b/cli/main.go
@@ -14,8 +14,8 @@ limitations under the License.
 package main
 
 import (
-	"github.com/kubernetes/minikube/cli/cmd"
-	"github.com/kubernetes/minikube/cli/machine"
+	"k8s.io/minikube/cli/cmd"
+	"k8s.io/minikube/cli/machine"
 )
 
 func main() {

--- a/cli/main.go
+++ b/cli/main.go
@@ -21,5 +21,4 @@ import (
 func main() {
 	machine.StartDriver()
 	cmd.Execute()
-
 }

--- a/integration/start_stop_delete_test.go
+++ b/integration/start_stop_delete_test.go
@@ -1,7 +1,7 @@
 // +build integration
 
 /*
-Copyright 2015 The Kubernetes Authors All rights reserved.
+Copyright 2016 The Kubernetes Authors All rights reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/test.sh
+++ b/test.sh
@@ -13,17 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cd "$( dirname "${BASH_SOURCE[0]}" )"
+# First, build the binary
+source ./build.sh
 
-REPO_PATH="k8s.io/minikube"
+# Then run all test files
+for TEST in $(find -name "*.go" | grep -v vendor | grep -v integration | grep _test.go | cut -d/ -f2- | sed 's|/\w*.go||g' | uniq); do
+	echo $TEST
+	go test -v ${REPO_PATH}/${TEST}
+done
 
-export GOPATH=${PWD}/.gopath
-export GO15VENDOREXPERIMENT=1
-export OS=${OS:-$(go env GOOS)}
-export ARCH=${ARCH:-$(go env GOARCH)}
-
-rm -f ${GOPATH}/src/${REPO_PATH}
-mkdir -p $(dirname ${GOPATH}/src/${REPO_PATH})
-ln -s ${PWD} $GOPATH/src/${REPO_PATH}
-
-CGO_ENABLED=0 GOARCH=${ARCH} GOOS=${OS} go build --installsuffix cgo -a -o minikube cli/main.go


### PR DESCRIPTION
Commits:
1. Add a build script to make it easy to build (one does not have to git clone to a special place or remember a long list of commands)
2. Rename all refs to `github.com/kubernetes` to `k8s.io` as the main project
3. Update the readme with new formatting and information
4. Run `gofmt -s -w .`. There were two files too in vendor, but I excluded them from the commit.
5. Update the copyright year to 2016
6. Update cobra `Use: "cli"` to `Use: "minikube"` and some various formatting
7. Add a `test.sh` script that runs both unit and integration tests

Please review the commits separately.
@dlorenc @vishh 