### PR TITLE
Fix certificate handling.

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -69,8 +69,8 @@ func runStart(cmd *cobra.Command, args []string) {
 	kubeHost = strings.Replace(kubeHost, ":2376", ":443", -1)
 	fmt.Printf("Kubernetes is available at %s.\n", kubeHost)
 	fmt.Println("Run this command to use the cluster: ")
-	fmt.Printf("kubectl config set-cluster minikube --server=%s --certificate-authority=$HOME/.minikube/ca.crt\n", kubeHost)
-	fmt.Println("kubectl config set-credentials minikube --client-certificate=$HOME/.minikube/kubecfg.crt --client-key=$HOME/.minikube/kubecfg.key")
+	fmt.Printf("kubectl config set-cluster minikube --server=%s --certificate-authority=$HOME/.minikube/apiserver.crt\n", kubeHost)
+	fmt.Println("kubectl config set-credentials minikube --client-certificate=$HOME/.minikube/apiserver.crt --client-key=$HOME/.minikube/apiserver.key")
 	fmt.Println("kubectl config set-context minikube --cluster=minikube --user=minikube")
 	fmt.Println("kubectl config use-context minikube")
 

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -33,11 +33,11 @@ import (
 )
 
 const (
-	remotePath = "/srv/kubernetes/certs"
+	remotePath = "/var/lib/localkube/certs"
 )
 
 var (
-	certs = []string{"ca.crt", "kubecfg.key", "kubecfg.crt"}
+	certs = []string{"apiserver.crt", "apiserver.key"}
 )
 
 // StartHost starts a host VM.
@@ -161,7 +161,7 @@ func GetCreds(h sshAble) error {
 	for _, cert := range certs {
 		remoteCertPath := filepath.Join(remotePath, cert)
 		localCertPath := filepath.Join(localPath, cert)
-		data, err := h.RunSSHCommand(fmt.Sprintf("cat %s", remoteCertPath))
+		data, err := h.RunSSHCommand(fmt.Sprintf("sudo cat %s", remoteCertPath))
 		if err != nil {
 			return err
 		}

--- a/pkg/minikube/cluster/cluster_test.go
+++ b/pkg/minikube/cluster/cluster_test.go
@@ -283,7 +283,7 @@ func TestGetHostStatus(t *testing.T) {
 func TestGetCreds(t *testing.T) {
 	m := make(map[string]string)
 	for _, cert := range certs {
-		m[fmt.Sprintf("cat %s/%s", remotePath, cert)] = cert
+		m[fmt.Sprintf("sudo cat %s/%s", remotePath, cert)] = cert
 	}
 
 	h := mockHost{CommandOutput: m}

--- a/vendor/k8s.io/kubernetes/pkg/util/crypto.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/crypto.go
@@ -54,7 +54,7 @@ func GenerateSelfSignedCert(host, certPath, keyPath string, alternateIPs []net.I
 		NotAfter:  time.Now().Add(time.Hour * 24 * 365),
 
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		BasicConstraintsValid: true,
 		IsCA: true,
 	}


### PR DESCRIPTION
Start now outputs the correct commands
We add all the IPs to the certificate at creation time.
The certificate is created with ClientAuth extension.
We copy the correct certificates.