### PR TITLE
Build socat as part of the iso build.

### DIFF
--- a/iso/Dockerfile
+++ b/iso/Dockerfile
@@ -8,6 +8,7 @@ ENV DOCKER_SHA 8824f8a67fbe55d1e52dcbebc74219ba8090006e
 
 # Add other dependencies here to $ROOTFS/
 ADD nsenter $ROOTFS/usr/bin/
+ADD socat $ROOTFS/usr/bin
 
 # Get a specific version of Docker. This will overwrite the binary installed
 # in the base image.

--- a/iso/Dockerfile.socat
+++ b/iso/Dockerfile.socat
@@ -1,0 +1,8 @@
+FROM golang:1.6
+
+RUN apt-get update && apt-get install libssl-dev -q	-y
+
+ENV SOCAT socat-2.0.0-b8
+RUN wget http://www.dest-unreach.org/socat/download/$SOCAT.tar.gz
+RUN tar -zvxf $SOCAT.tar.gz
+RUN cd $SOCAT && ./configure --disable-readline && make && mv ./socat /go/

--- a/iso/build.sh
+++ b/iso/build.sh
@@ -7,8 +7,14 @@ echo "Building in $tmpdir."
 cp -r . $tmpdir/
 
 pushd $tmpdir
+
 # Get nsenter.
 docker run --rm jpetazzo/nsenter cat /nsenter > $tmpdir/nsenter && chmod +x $tmpdir/nsenter
+
+# Get socat
+docker build -t socat -f Dockerfile.socat .
+docker run socat cat socat > $tmpdir/socat
+chmod +x $tmpdir/socat
 
 # Do the build.
 docker build -t iso .


### PR DESCRIPTION
This should address #68.

@runseb Thanks again for the skippbox pointer. I already had nsenter in there, inspired by your repo. I tried to use your build script for socat but couldn't get the 1.7 version to compile :(