### PR TITLE
Make the ISO url configurable for testing new ISO builds.

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -88,6 +88,5 @@ func runStart(cmd *cobra.Command, args []string) {
 
 func init() {
 	startCmd.Flags().StringVarP(&minikubeISO, "iso-url", "", "https://storage.googleapis.com/tinykube/minikube.iso", "Location of the minikube iso")
-	startCmd.Flags().MarkHidden("iso-url")
 	RootCmd.AddCommand(startCmd)
 }

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -38,7 +38,7 @@ assumes you already have Virtualbox installed.`,
 }
 
 var (
-	localkubeURL string
+	minikubeISO string
 )
 
 func runStart(cmd *cobra.Command, args []string) {
@@ -46,14 +46,15 @@ func runStart(cmd *cobra.Command, args []string) {
 	fmt.Println("Starting local Kubernetes cluster...")
 	api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
 	defer api.Close()
-	host, err := cluster.StartHost(api)
+
+	config := cluster.MachineConfig{
+		MinikubeISO: minikubeISO,
+	}
+
+	host, err := cluster.StartHost(api, config)
 	if err != nil {
 		log.Println("Error starting host: ", err)
 		os.Exit(1)
-	}
-
-	config := cluster.KubernetesConfig{
-		LocalkubeURL: localkubeURL,
 	}
 
 	if err := cluster.UpdateCluster(host.Driver); err != nil {
@@ -61,7 +62,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	if err := cluster.StartCluster(host, config); err != nil {
+	if err := cluster.StartCluster(host); err != nil {
 		log.Println("Error starting cluster: ", err)
 		os.Exit(1)
 	}
@@ -86,7 +87,7 @@ func runStart(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	startCmd.Flags().StringVarP(&localkubeURL, "localkube-url", "", "https://storage.googleapis.com/tinykube/localkube", "Location of the localkube binary")
-	startCmd.Flags().MarkHidden("localkube-url")
+	startCmd.Flags().StringVarP(&minikubeISO, "iso-url", "", "https://storage.googleapis.com/tinykube/minikube.iso", "Location of the minikube iso")
+	startCmd.Flags().MarkHidden("iso-url")
 	RootCmd.AddCommand(startCmd)
 }

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -43,7 +43,7 @@ var (
 )
 
 // StartHost starts a host VM.
-func StartHost(api libmachine.API) (*host.Host, error) {
+func StartHost(api libmachine.API, config KubernetesConfig) (*host.Host, error) {
 	if exists, err := api.Exists(constants.MachineName); err != nil {
 		return nil, fmt.Errorf("Error checking if host exists: %s", err)
 	} else if exists {
@@ -63,7 +63,7 @@ func StartHost(api libmachine.API) (*host.Host, error) {
 		}
 		return h, nil
 	} else {
-		return createHost(api)
+		return createHost(api, config)
 	}
 }
 
@@ -140,13 +140,13 @@ type sshAble interface {
 	RunSSHCommand(string) (string, error)
 }
 
-// KubernetesConfig contains the parameters used to start a cluster.
-type KubernetesConfig struct {
-	LocalkubeURL string
+// MachineConfig contains the parameters used to start a cluster.
+type MachineConfig struct {
+	MinikubeISO string
 }
 
 // StartCluster starts a k8s cluster on the specified Host.
-func StartCluster(h sshAble, config KubernetesConfig) error {
+func StartCluster(h sshAble) error {
 	output, err := h.RunSSHCommand(getStartCommand())
 	log.Println(output)
 	if err != nil {
@@ -192,9 +192,9 @@ func GetCreds(h sshAble) error {
 	return nil
 }
 
-func createHost(api libmachine.API) (*host.Host, error) {
+func createHost(api libmachine.API, config MachineConfig) (*host.Host, error) {
 	driver := virtualbox.NewDriver(constants.MachineName, constants.Minipath)
-	driver.Boot2DockerURL = "https://storage.googleapis.com/tinykube/boot2docker.iso"
+	driver.Boot2DockerURL = config.MinikubeISO
 	data, err := json.Marshal(driver)
 	if err != nil {
 		return nil, err

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -43,7 +43,7 @@ var (
 )
 
 // StartHost starts a host VM.
-func StartHost(api libmachine.API, config KubernetesConfig) (*host.Host, error) {
+func StartHost(api libmachine.API, config MachineConfig) (*host.Host, error) {
 	if exists, err := api.Exists(constants.MachineName); err != nil {
 		return nil, fmt.Errorf("Error checking if host exists: %s", err)
 	} else if exists {

--- a/pkg/minikube/cluster/cluster_test.go
+++ b/pkg/minikube/cluster/cluster_test.go
@@ -38,7 +38,7 @@ func TestCreateHost(t *testing.T) {
 	if exists {
 		t.Fatal("Machine already exists.")
 	}
-	_, err := createHost(api)
+	_, err := createHost(api, MachineConfig{})
 	if err != nil {
 		t.Fatalf("Error creating host: %v", err)
 	}
@@ -82,7 +82,7 @@ func (m mockHost) RunSSHCommand(cmd string) (string, error) {
 
 func TestStartCluster(t *testing.T) {
 	h := mockHost{}
-	err := StartCluster(h, KubernetesConfig{})
+	err := StartCluster(h)
 	if err != nil {
 		t.Fatalf("Error starting cluster: %s", err)
 	}
@@ -90,7 +90,7 @@ func TestStartCluster(t *testing.T) {
 
 func TestStartClusterError(t *testing.T) {
 	h := mockHost{Error: "error"}
-	err := StartCluster(h, KubernetesConfig{})
+	err := StartCluster(h)
 	if err == nil {
 		t.Fatal("Error not thrown starting cluster.")
 	}
@@ -99,7 +99,7 @@ func TestStartClusterError(t *testing.T) {
 func TestStartHostExists(t *testing.T) {
 	api := &tests.MockAPI{}
 	// Create an initial host.
-	_, err := createHost(api)
+	_, err := createHost(api, MachineConfig{})
 	if err != nil {
 		t.Fatalf("Error creating host: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestStartHostExists(t *testing.T) {
 	}
 
 	// This should pass without calling Create because the host exists already.
-	h, err := StartHost(api)
+	h, err := StartHost(api, MachineConfig{})
 	if err != nil {
 		t.Fatal("Error starting host.")
 	}
@@ -126,7 +126,7 @@ func TestStartHostExists(t *testing.T) {
 func TestStartStoppedHost(t *testing.T) {
 	api := &tests.MockAPI{}
 	// Create an initial host.
-	h, err := createHost(api)
+	h, err := createHost(api, MachineConfig{})
 	if err != nil {
 		t.Fatalf("Error creating host: %v", err)
 	}
@@ -134,7 +134,7 @@ func TestStartStoppedHost(t *testing.T) {
 	h.Driver = &d
 	d.CurrentState = state.Stopped
 
-	h, err = StartHost(api)
+	h, err = StartHost(api, MachineConfig{})
 	if err != nil {
 		t.Fatal("Error starting host.")
 	}
@@ -150,7 +150,7 @@ func TestStartStoppedHost(t *testing.T) {
 func TestStartHost(t *testing.T) {
 	api := &tests.MockAPI{}
 
-	h, err := StartHost(api)
+	h, err := StartHost(api, MachineConfig{})
 	if err != nil {
 		t.Fatal("Error starting host.")
 	}
@@ -174,7 +174,7 @@ func TestStopHostError(t *testing.T) {
 
 func TestStopHost(t *testing.T) {
 	api := &tests.MockAPI{}
-	h, _ := createHost(api)
+	h, _ := createHost(api, MachineConfig{})
 	if err := StopHost(api); err != nil {
 		t.Fatal("An error should be thrown when stopping non-existing machine.")
 	}
@@ -205,7 +205,7 @@ Error 2`
 
 func TestDeleteHost(t *testing.T) {
 	api := &tests.MockAPI{}
-	createHost(api)
+	createHost(api, MachineConfig{})
 
 	if err := DeleteHost(api); err != nil {
 		t.Fatalf("Unexpected error deleting host: %s", err)
@@ -214,7 +214,7 @@ func TestDeleteHost(t *testing.T) {
 
 func TestDeleteHostErrorDeletingVM(t *testing.T) {
 	api := &tests.MockAPI{}
-	h, _ := createHost(api)
+	h, _ := createHost(api, MachineConfig{})
 
 	d := &tests.MockDriver{RemoveError: true}
 
@@ -227,7 +227,7 @@ func TestDeleteHostErrorDeletingVM(t *testing.T) {
 
 func TestDeleteHostErrorDeletingFiles(t *testing.T) {
 	api := &tests.MockAPI{RemoveError: true}
-	createHost(api)
+	createHost(api, MachineConfig{})
 
 	if err := DeleteHost(api); err == nil {
 		t.Fatal("Expected error deleting host.")
@@ -238,7 +238,7 @@ func TestDeleteHostMultipleErrors(t *testing.T) {
 	api := &tests.MockAPI{
 		RemoveError: true,
 	}
-	h, _ := createHost(api)
+	h, _ := createHost(api, MachineConfig{})
 
 	d := &tests.MockDriver{RemoveError: true}
 
@@ -273,7 +273,7 @@ func TestGetHostStatus(t *testing.T) {
 
 	checkState("Does Not Exist")
 
-	createHost(api)
+	createHost(api, MachineConfig{})
 	checkState(state.Running.String())
 
 	StopHost(api)

--- a/test.sh
+++ b/test.sh
@@ -17,7 +17,7 @@ set -e
 REPO_PATH="k8s.io/minikube"
 
 # Run all test files.
-for TEST in $(find -name "*.go" | grep -v vendor | grep -v integration | grep _test.go | cut -d/ -f2- | sed 's|/\w*.go||g' | uniq); do
+for TEST in $(find -name "*.go" | grep -v vendor | grep -v integration | grep _test.go | grep -v go-bindata | cut -d/ -f2- | sed 's|/\w*.go||g' | uniq); do
   echo $TEST
   go test -v ${REPO_PATH}/${TEST}
 done

--- a/test.sh
+++ b/test.sh
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+set -e
 
 REPO_PATH="k8s.io/minikube"
 


### PR DESCRIPTION
Also delete the old flag, since it's unused.

This is for #29 and #68 