### PR TITLE
This statically compiles socat so it actually works in our iso.

### DIFF
--- a/iso/Dockerfile.socat
+++ b/iso/Dockerfile.socat
@@ -2,7 +2,23 @@ FROM golang:1.6
 
 RUN apt-get update && apt-get install libssl-dev -q	-y
 
-ENV SOCAT socat-2.0.0-b8
+# Musl
+ENV MUSL_VERSION 1.1.10
+RUN wget http://www.musl-libc.org/releases/musl-${MUSL_VERSION}.tar.gz
+RUN tar zxvf musl-${MUSL_VERSION}.tar.gz
+RUN cd musl-${MUSL_VERSION} && ./configure && make -j4 && make install
+
+# OpenSSL
+ENV OPENSSL_VERSION 1.0.2h
+RUN wget https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
+RUN tar zxvf openssl-${OPENSSL_VERSION}.tar.gz
+RUN cd openssl-${OPENSSL_VERSION} && CC='/usr/local/musl/bin/musl-gcc -static' ./Configure no-shared linux-x86_64 && make
+
+ENV SOCAT socat-1.7.3.0
 RUN wget http://www.dest-unreach.org/socat/download/$SOCAT.tar.gz
 RUN tar -zvxf $SOCAT.tar.gz
-RUN cd $SOCAT && ./configure --disable-readline && make && mv ./socat /go/
+RUN cd $SOCAT && CC='/usr/local/musl/bin/musl-gcc -static' \
+    CFLAGS='-fPIC' \
+    CPPFLAGS='-I/build -I/build/openssl-1.0.2/include -DNETDB_INTERNAL=-1' \
+    LDFLAGS="-L/build/openssl-${OPENSSL_VERSION}" \
+    ./configure && make -j4 && strip socat && mv ./socat /go/


### PR DESCRIPTION
This is for #68. The existing socat build completes, but the binary won't actually run on our VM. This statically compiles it.