### PR TITLE
Add ethtool to the built image.

### DIFF
--- a/iso/Dockerfile
+++ b/iso/Dockerfile
@@ -9,6 +9,7 @@ ENV DOCKER_SHA 8824f8a67fbe55d1e52dcbebc74219ba8090006e
 # Add other dependencies here to $ROOTFS/
 ADD nsenter $ROOTFS/usr/bin/
 ADD socat $ROOTFS/usr/bin
+ADD ethtool $ROOTFS/usr/bin
 
 # Get a specific version of Docker. This will overwrite the binary installed
 # in the base image.

--- a/iso/Dockerfile.ethtool
+++ b/iso/Dockerfile.ethtool
@@ -1,0 +1,5 @@
+FROM golang:1.6
+ENV ETHTOOL ethtool-3.16
+RUN wget https://www.kernel.org/pub/software/network/ethtool/$ETHTOOL.tar.gz
+RUN tar -xvzf $ETHTOOL.tar.gz
+RUN cd $ETHTOOL && ./configure LDFLAGS=-static && make && cp ethtool /go/

--- a/iso/build.sh
+++ b/iso/build.sh
@@ -16,6 +16,11 @@ docker build -t socat -f Dockerfile.socat .
 docker run socat cat socat > $tmpdir/socat
 chmod +x $tmpdir/socat
 
+# Get ethotool
+docker build -t ethtool -f Dockerfile.ethtool .
+docker run ethtool cat ethtool > $tmpdir/ethtool
+chmod +x $tmpdir/ethtool
+
 # Do the build.
 docker build -t iso .
 


### PR DESCRIPTION
I'm running conformance tests, and I see this error frequently coming out of localkube running in the VM:
I0515 02:03:20.055672    1362 hairpin.go:51] Unable to find pair interface, setting up all interfaces: exec: "ethtool": executable file not found in $PATH