### PR TITLE
Set the k8s version strings during build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,6 @@ endif
 REPOPATH ?= k8s.io/minikube
 export GO15VENDOREXPERIMENT=1
 
-# Update this to match the vendored version of k8s in godeps.json
-K8S_VERSION := v1.3.0-alpha.3-838+ba170aa191f8c7
-
 # Set the version information in kubernetes.
 LD_FLAGS = "-s -w $(shell python hack/get_k8s_version.py)"
 

--- a/Makefile
+++ b/Makefile
@@ -23,13 +23,13 @@ else
 endif
 
 REPOPATH ?= k8s.io/minikube
-K8S_VENDOR_PATH := $(REPOPATH)/vendor/k8s.io/kubernetes
 export GO15VENDOREXPERIMENT=1
 
 # Update this to match the vendored version of k8s in godeps.json
 K8S_VERSION := v1.3.0-alpha.3-838+ba170aa191f8c7
+
 # Set the version information in kubernetes.
-LD_FLAGS = "-s -w -X $(K8S_VENDOR_PATH)/pkg/version.gitVersion=$(K8S_VERSION) -X $(K8S_VENDOR_PATH)/pkg/version.gitCommit=$(shell git rev-parse HEAD)"
+LD_FLAGS = "-s -w $(shell python hack/get_k8s_version.py)"
 
 clean:
 	rm -rf $(GOPATH)

--- a/hack/get_k8s_version.py
+++ b/hack/get_k8s_version.py
@@ -1,0 +1,49 @@
+"""
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"This package gets the LD flags used to set the version of kubernetes."
+
+import json
+import subprocess
+
+K8S_PACKAGE = 'k8s.io/kubernetes/'
+X_ARG_BASE = '-X k8s.io/minikube/vendor/k8s.io/kubernetes/pkg/version.'
+
+def get_rev():
+  with open('./Godeps/Godeps.json') as f:
+    contents = json.load(f)
+    for dep in contents['Deps']:
+      if dep['ImportPath'].startswith(K8S_PACKAGE):
+        return 'gitCommit=%s' % dep['Rev']
+
+def get_version():
+  # Update when vendor/k8s.io/kubernetes is updated.
+  return 'gitVersion=v1.3.0-alpha.3-838+ba170aa191f8c7'
+
+def get_tree_state():
+  git_status = subprocess.check_output(['git', 'status', '--porcelain'])
+  if git_status:
+    result = 'dirty'
+  else :
+    result = 'clean'
+  return 'gitTreeState=%s' % result
+
+def main():
+  args = [get_rev(), get_version(), get_tree_state()]
+  return ' '.join([X_ARG_BASE + arg for arg in args])
+
+if __name__ == '__main__':
+  print main()


### PR DESCRIPTION
This is also required for conformance tests. They hang with something like:
```
May 14 19:26:33.516: INFO: update-demo-nautilus-5mpag is running right image but validator function failed: Unable to parse server version "v0.0.0-master+$Format:%h$": Invalid character(s) found in build meta data "$Format:%h$"
```
If the value in pkg/version/base.go isn't set. I've verified that with this set we get:
```
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"2", GitVersion:"v1.2.3", GitCommit:"882d296a99218da8f6b2a340eb0e81c69e66ecc7", GitTreeState:"clean"}
Server Version: version.Info{Major:"", Minor:"", GitVersion:"v0.1-master+alpha", GitCommit:"a3ff9d751ec71e41f8b09b52963e4f16e0e778a9", GitTreeState:"not a git tree"}
```