### PR TITLE
Add a command to retrieve the running IP.

### DIFF
--- a/cmd/minikube/cmd/ip.go
+++ b/cmd/minikube/cmd/ip.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/docker/machine/libmachine"
+	"k8s.io/minikube/pkg/minikube/constants"
+
+	"github.com/spf13/cobra"
+)
+
+// ipCmd represents the ip command
+var ipCmd = &cobra.Command{
+	Use:   "ip",
+	Short: "Retrieve the IP address of the running cluster.",
+	Long:  `Retrieves the IP address of the running cluster, and writes it to STDOUT.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
+		defer api.Close()
+		host, err := api.Load(constants.MachineName)
+		if err != nil {
+			log.Println("Error getting IP: ", err)
+			os.Exit(1)
+		}
+		ip, err := host.Driver.GetIP()
+		if err != nil {
+			log.Println("Error getting IP: ", err)
+			os.Exit(1)
+		}
+		fmt.Println(ip)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(ipCmd)
+}

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -20,7 +20,9 @@ package integration
 
 import (
 	"flag"
+	"net"
 	"os"
+	"strings"
 	"testing"
 
 	"k8s.io/minikube/test/integration/util"
@@ -36,6 +38,12 @@ func TestStartStop(t *testing.T) {
 
 	runner.RunCommand("start", true)
 	runner.CheckStatus("Running")
+
+	ip := runner.RunCommand("ip", true)
+	ip = strings.TrimRight(ip, "\n")
+	if net.ParseIP(ip) == nil {
+		t.Fatalf("IP command returned an invalid address: %s", ip)
+	}
 
 	runner.RunCommand("stop", true)
 	runner.CheckStatus("Stopped")


### PR DESCRIPTION
This can be used for diagnostics and scripting:

Something like:
IP=$(minikube ip)
curl http://$IP:$NODEPORT