### PR TITLE
Fix race condition in cluster setup.

### DIFF
--- a/cmd/localkube/cmd/options.go
+++ b/cmd/localkube/cmd/options.go
@@ -22,6 +22,7 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"k8s.io/minikube/pkg/localkube"
+	"k8s.io/minikube/pkg/util"
 )
 
 func NewLocalkubeServer() *localkube.LocalkubeServer {
@@ -31,14 +32,15 @@ func NewLocalkubeServer() *localkube.LocalkubeServer {
 	return &localkube.LocalkubeServer{
 		Containerized:            false,
 		EnableDNS:                true,
-		DNSDomain:                "cluster.local",
+		DNSDomain:                util.DNSDomain,
 		DNSIP:                    net.ParseIP("10.0.0.10"),
-		LocalkubeDirectory:       "/var/lib/localkube",
+		LocalkubeDirectory:       util.LocalkubeDirectory,
 		ServiceClusterIPRange:    *defaultServiceClusterIPRange,
 		APIServerAddress:         net.ParseIP("0.0.0.0"),
 		APIServerPort:            443,
 		APIServerInsecureAddress: net.ParseIP("127.0.0.1"),
 		APIServerInsecurePort:    8080,
+		ShouldGenerateCerts:      true,
 	}
 }
 
@@ -54,6 +56,7 @@ func AddFlags(s *localkube.LocalkubeServer) {
 	flag.IntVar(&s.APIServerPort, "apiserver-port", s.APIServerPort, "The port the apiserver will listen securely on")
 	flag.IPVar(&s.APIServerInsecureAddress, "apiserver-insecure-address", s.APIServerInsecureAddress, "The address the apiserver will listen insecurely on")
 	flag.IntVar(&s.APIServerInsecurePort, "apiserver-insecure-port", s.APIServerInsecurePort, "The port the apiserver will listen insecurely on")
+	flag.BoolVar(&s.ShouldGenerateCerts, "generate-certs", s.ShouldGenerateCerts, "If localkube should generate it's own certificates")
 
 	// These two come from vendor/ packages that use flags. We should hide them
 	flag.CommandLine.MarkHidden("google-json-key")

--- a/cmd/localkube/cmd/start.go
+++ b/cmd/localkube/cmd/start.go
@@ -55,12 +55,12 @@ func init() {
 }
 
 func SetupServer(s *localkube.LocalkubeServer) {
-
-	if err := s.GenerateCerts(); err != nil {
-		fmt.Println("Failed to create certificates!")
-		panic(err)
+	if s.ShouldGenerateCerts {
+		if err := s.GenerateCerts(); err != nil {
+			fmt.Println("Failed to create certificates!")
+			panic(err)
+		}
 	}
-
 	// setup etcd
 	etcd, err := s.NewEtcd(localkube.KubeEtcdClientURLs, localkube.KubeEtcdPeerURLs, "kubeetcd", s.GetEtcdDataDirectory())
 	if err != nil {

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -64,6 +64,11 @@ func runStart(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
+	if err := cluster.SetupCerts(host.Driver); err != nil {
+		log.Println("Error configuring authentication: ", err)
+		os.Exit(1)
+	}
+
 	if err := cluster.StartCluster(host); err != nil {
 		log.Println("Error starting cluster: ", err)
 		os.Exit(1)
@@ -88,11 +93,6 @@ func runStart(cmd *cobra.Command, args []string) {
 	} else if !active {
 		fmt.Println("Run this command to use the cluster: ")
 		fmt.Printf("kubectl config use-context %s\n", name)
-	}
-
-	if err := cluster.GetCreds(host); err != nil {
-		log.Println("Error configuring authentication: ", err)
-		os.Exit(1)
 	}
 }
 

--- a/pkg/localkube/localkube.go
+++ b/pkg/localkube/localkube.go
@@ -47,6 +47,7 @@ type LocalkubeServer struct {
 	APIServerPort            int
 	APIServerInsecureAddress net.IP
 	APIServerInsecurePort    int
+	ShouldGenerateCerts      bool
 }
 
 func (lk *LocalkubeServer) AddServer(server Server) {
@@ -153,9 +154,8 @@ func (lk LocalkubeServer) GenerateCerts() error {
 		return nil
 	}
 	fmt.Println("Creating cert with IPs: ", ips)
-	alternateDNS := []string{fmt.Sprintf("%s.%s", "kubernetes.default.svc", lk.DNSDomain), "kubernetes.default.svc", "kubernetes.default", "kubernetes"}
 
-	if err := GenerateSelfSignedCert(lk.GetPublicKeyCertPath(), lk.GetPrivateKeyCertPath(), ips, alternateDNS); err != nil {
+	if err := util.GenerateSelfSignedCert(lk.GetPublicKeyCertPath(), lk.GetPrivateKeyCertPath(), ips, util.GetAlternateDNS(lk.DNSDomain)); err != nil {
 		fmt.Println("Failed to create certs: ", err)
 		return err
 	}

--- a/pkg/minikube/cluster/commands.go
+++ b/pkg/minikube/cluster/commands.go
@@ -2,9 +2,5 @@ package cluster
 
 var startCommand = `
 # Run with nohup so it stays up. Redirect logs to useful places.
-PATH=/usr/local/sbin:$PATH nohup sudo /usr/local/bin/localkube start > /var/log/localkube.out 2> /var/log/localkube.err < /dev/null &
+PATH=/usr/local/sbin:$PATH nohup sudo /usr/local/bin/localkube start --generate-certs=false > /var/log/localkube.out 2> /var/log/localkube.err < /dev/null &
 `
-
-func getStartCommand() string {
-	return startCommand
-}

--- a/pkg/minikube/cluster/credentials.go
+++ b/pkg/minikube/cluster/credentials.go
@@ -1,0 +1,15 @@
+package cluster
+
+import (
+	"net"
+
+	"k8s.io/minikube/pkg/util"
+)
+
+func GenerateCerts(pub, priv string, ip net.IP) error {
+	ips := []net.IP{ip}
+	if err := util.GenerateSelfSignedCert(pub, priv, ips, util.GetAlternateDNS(util.DNSDomain)); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/minikube/sshutil/sshutil.go
+++ b/pkg/minikube/sshutil/sshutil.go
@@ -62,8 +62,11 @@ func NewSSHClient(d drivers.Driver) (*ssh.Client, error) {
 func Transfer(data []byte, remotedir, filename string, perm string, c *ssh.Client) error {
 	// Delete the old file first. This makes sure permissions get reset.
 	deleteCmd := fmt.Sprintf("sudo rm -f %s", filepath.Join(remotedir, filename))
-	if err := RunCommand(c, deleteCmd); err != nil {
-		return err
+	mkdirCmd := fmt.Sprintf("sudo mkdir -p %s", remotedir)
+	for _, cmd := range []string{deleteCmd, mkdirCmd} {
+		if err := RunCommand(c, cmd); err != nil {
+			return err
+		}
 	}
 
 	s, err := c.NewSession()

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -1,0 +1,13 @@
+package util
+
+import "fmt"
+
+const (
+	LocalkubeDirectory = "/var/lib/localkube"
+	DNSDomain          = "cluster.local"
+	CertPath           = "/var/lib/localkube/certs/"
+)
+
+func GetAlternateDNS(domain string) []string {
+	return []string{fmt.Sprintf("%s.%s", "kubernetes.default.svc", domain), "kubernetes.default.svc", "kubernetes.default", "kubernetes"}
+}

--- a/pkg/util/crypto.go
+++ b/pkg/util/crypto.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package localkube
+package util
 
 import (
 	"bytes"

--- a/test/integration/cluster_status_test.go
+++ b/test/integration/cluster_status_test.go
@@ -27,11 +27,11 @@ import (
 )
 
 func TestCluster(t *testing.T) {
-	kubectlRunner := util.NewKubectlRunner(t)
-
 	minikubeRunner := util.MinikubeRunner{BinaryPath: *binaryPath, T: t}
+	minikubeRunner.RunCommand("start", true)
 	minikubeRunner.CheckStatus("Running")
 
+	kubectlRunner := util.NewKubectlRunner(t)
 	cs := api.ComponentStatusList{}
 	kubectlRunner.RunCommand([]string{"get", "cs"}, &cs)
 


### PR DESCRIPTION
We now explicitly generate certs before starting the cluster. This way we can be sure the certs exist when we copy them.

This fixes #85 