### PR TITLE
Static localkube and some other things

### DIFF
--- a/.cobra.yaml
+++ b/.cobra.yaml
@@ -1,2 +1,0 @@
-author: The Kubernetes Authors 
-license: Apache 2.0

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Use the native vendor/ dependency system
+export GO15VENDOREXPERIMENT=1
+
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 BUILD_DIR ?= ./out
+REPOPATH ?= k8s.io/minikube
+BUILD_IMAGE ?= gcr.io/google_containers/kube-cross:v1.6.2-1
 
 ifeq ($(IN_DOCKER),1)
 	GOPATH := /go
@@ -22,11 +27,8 @@ else
 	GOPATH := $(shell pwd)/_gopath
 endif
 
-REPOPATH ?= k8s.io/minikube
-export GO15VENDOREXPERIMENT=1
-
-# Set the version information in kubernetes.
-LD_FLAGS = "-s -w $(shell python hack/get_k8s_version.py)"
+# Set the version information for the Kubernetes servers, and build localkube statically
+LD_FLAGS = "-s -extldflags '-static' -w $(shell docker run --rm -it -v $(shell pwd):/minikube -w /minikube python python hack/get_k8s_version.py)"
 
 clean:
 	rm -rf $(GOPATH)
@@ -45,7 +47,7 @@ out/localkube: $(LOCALKUBEFILES)
 ifeq ($(GOOS),linux)
 	CGO_ENABLED=1 go build -ldflags=$(LD_FLAGS) -o $(BUILD_DIR)/localkube ./cmd/localkube
 else
-	docker run -w /go/src/$(REPOPATH) -e IN_DOCKER=1 -v $(shell pwd):/go/src/$(REPOPATH) golang:1.6 make out/localkube
+	docker run -w /go/src/$(REPOPATH) -e IN_DOCKER=1 -v $(shell pwd):/go/src/$(REPOPATH) $(BUILD_IMAGE) make out/localkube
 endif
 
 out/minikube-$(GOOS)-$(GOARCH): $(MINIKUBEFILES) pkg/minikube/cluster/localkubecontents.go

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ else
 endif
 
 # Set the version information for the Kubernetes servers, and build localkube statically
-LD_FLAGS = "-s -extldflags '-static' -w $(shell docker run --rm -it -v $(shell pwd):/minikube -w /minikube python python hack/get_k8s_version.py)"
+VERSION_LDFLAGS := $(shell docker run --rm -it -v $(shell pwd):/minikube -w /minikube python python hack/get_k8s_version.py)
+LDFLAGS := "$(VERSION_LDFLAGS) -s -w -extldflags '-static'"
 
 clean:
 	rm -rf $(GOPATH)
@@ -45,7 +46,7 @@ out/minikube: out/minikube-$(GOOS)-$(GOARCH)
 out/localkube: $(LOCALKUBEFILES)
 	$(MKGOPATH)
 ifeq ($(GOOS),linux)
-	CGO_ENABLED=1 go build -ldflags=$(LD_FLAGS) -o $(BUILD_DIR)/localkube ./cmd/localkube
+	CGO_ENABLED=1 go build -ldflags=$(LDFLAGS) -o $(BUILD_DIR)/localkube ./cmd/localkube
 else
 	docker run -w /go/src/$(REPOPATH) -e IN_DOCKER=1 -v $(shell pwd):/go/src/$(REPOPATH) $(BUILD_IMAGE) make out/localkube
 endif

--- a/cmd/localkube/cmd/options.go
+++ b/cmd/localkube/cmd/options.go
@@ -27,14 +27,14 @@ import (
 
 func NewLocalkubeServer() *localkube.LocalkubeServer {
 	// net.ParseCIDR returns multiple values. Use the IPNet return value
-	_, defaultServiceClusterIPRange, _ := net.ParseCIDR("10.0.0.1/24")
+	_, defaultServiceClusterIPRange, _ := net.ParseCIDR(util.DefaultServiceClusterIP + "/24")
 
 	return &localkube.LocalkubeServer{
 		Containerized:            false,
 		EnableDNS:                true,
-		DNSDomain:                util.DNSDomain,
-		DNSIP:                    net.ParseIP("10.0.0.10"),
-		LocalkubeDirectory:       util.LocalkubeDirectory,
+		DNSDomain:                util.DefaultDNSDomain,
+		DNSIP:                    net.ParseIP(util.DefaultDNSIP),
+		LocalkubeDirectory:       util.DefaultLocalkubeDirectory,
 		ServiceClusterIPRange:    *defaultServiceClusterIPRange,
 		APIServerAddress:         net.ParseIP("0.0.0.0"),
 		APIServerPort:            443,

--- a/cmd/localkube/cmd/version.go
+++ b/cmd/localkube/cmd/version.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/minikube/pkg/version"
 )
 
-var VersionCmd = &cobra.Command{
+var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version of localkube.",
 	Long:  `Print the version of localkube.`,
@@ -35,5 +35,5 @@ var VersionCmd = &cobra.Command{
 }
 
 func init() {
-	RootCmd.AddCommand(VersionCmd)
+	RootCmd.AddCommand(versionCmd)
 }

--- a/cmd/minikube/cmd/version.go
+++ b/cmd/minikube/cmd/version.go
@@ -14,7 +14,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package version
+package cmd
 
-// The current version of the minikube and localkube
-const Version = "0.0.1-developing"
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/minikube/pkg/version"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version of minikube.",
+	Long:  `Print the version of minikube.`,
+	Run: func(command *cobra.Command, args []string) {
+
+		fmt.Println("Version: ", version.Version)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(versionCmd)
+}

--- a/hack/get_k8s_version.py
+++ b/hack/get_k8s_version.py
@@ -18,6 +18,7 @@
 
 import json
 import subprocess
+import sys
 
 K8S_PACKAGE = 'k8s.io/kubernetes/'
 X_ARG_BASE = '-X k8s.io/minikube/vendor/k8s.io/kubernetes/pkg/version.'
@@ -46,4 +47,4 @@ def main():
   return ' '.join([X_ARG_BASE + arg for arg in args])
 
 if __name__ == '__main__':
-  print main()
+  sys.exit(main())

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -205,7 +205,7 @@ func SetupCerts(d drivers.Driver) error {
 		if err != nil {
 			return err
 		}
-		if err := sshutil.Transfer(data, util.CertPath, cert, "0644", client); err != nil {
+		if err := sshutil.Transfer(data, util.DefaultCertPath, cert, "0644", client); err != nil {
 			return err
 		}
 	}

--- a/pkg/minikube/cluster/credentials.go
+++ b/pkg/minikube/cluster/credentials.go
@@ -24,12 +24,12 @@ import (
 
 var (
 	// This is the internalIP the the API server and other components communicate on.
-	internalIP = net.ParseIP("10.0.0.1")
+	internalIP = net.ParseIP(util.DefaultServiceClusterIP)
 )
 
 func GenerateCerts(pub, priv string, ip net.IP) error {
 	ips := []net.IP{ip, internalIP}
-	if err := util.GenerateSelfSignedCert(pub, priv, ips, util.GetAlternateDNS(util.DNSDomain)); err != nil {
+	if err := util.GenerateSelfSignedCert(pub, priv, ips, util.GetAlternateDNS(util.DefaultDNSDomain)); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -16,14 +16,15 @@ limitations under the License.
 
 package util
 
-import "fmt"
-
+// These constants are used by both minikube and localkube
 const (
-	LocalkubeDirectory = "/var/lib/localkube"
-	DNSDomain          = "cluster.local"
-	CertPath           = "/var/lib/localkube/certs/"
+	DefaultLocalkubeDirectory = "/var/lib/localkube"
+	DefaultCertPath           = DefaultLocalkubeDirectory + "/certs/"
+	DefaultServiceClusterIP   = "10.0.0.1"
+	DefaultDNSDomain          = "cluster.local"
+	DefaultDNSIP              = "10.0.0.10"
 )
 
 func GetAlternateDNS(domain string) []string {
-	return []string{fmt.Sprintf("%s.%s", "kubernetes.default.svc", domain), "kubernetes.default.svc", "kubernetes.default", "kubernetes"}
+	return []string{"kubernetes.default.svc." + domain, "kubernetes.default.svc", "kubernetes.default", "kubernetes"}
 }

--- a/test.sh
+++ b/test.sh
@@ -17,8 +17,10 @@
 set -e
 
 REPO_PATH="k8s.io/minikube"
+PYTHON=${PYTHON:-"docker run --rm -it -v $(pwd):/minikube -w /minikube python python"}
 
 # Run "go test" on packages that have test files.
+echo "Running go tests..."
 cd ${GOPATH}/src/${REPO_PATH}
 TESTS=$(go list -f '{{ if .TestGoFiles }} {{.ImportPath}} {{end}}' ./...)
 go test -v ${TESTS}
@@ -35,7 +37,7 @@ echo "Checking boilerplate..."
 BOILERPLATEDIR=./hack/boilerplate
 # Grep returns a non-zero exit code if we don't match anything, which is good in this case.
 set +e
-files=$(python ${BOILERPLATEDIR}/boilerplate.py --rootdir . --boilerplate-dir ${BOILERPLATEDIR} | grep -v $ignore)
+files=$(${PYTHON} ${BOILERPLATEDIR}/boilerplate.py --rootdir . --boilerplate-dir ${BOILERPLATEDIR} | grep -v $ignore)
 set -e
 if [ ! -z ${files} ]; then
 	echo "Boilerplate missing in: ${files}."


### PR DESCRIPTION
Commits:
 - Build localkube statically, use a python container to remove the python dep on the build env, and use kube-cross for building on non-linux
 - Remove cobra.yaml, as it's not used anymore
 - Add a version command to minikube too
 - Rename some constants in constants.go to Default..., and break out more constants

@dlorenc 