### PR TITLE
Make sure we stop the localkube binary before starting another instance.

### DIFF
--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -148,7 +148,7 @@ type MachineConfig struct {
 
 // StartCluster starts a k8s cluster on the specified Host.
 func StartCluster(h sshAble) error {
-	commands := []string{startCommand}
+	commands := []string{stopCommand, startCommand}
 
 	for _, cmd := range commands {
 		output, err := h.RunSSHCommand(cmd)

--- a/pkg/minikube/cluster/cluster_test.go
+++ b/pkg/minikube/cluster/cluster_test.go
@@ -96,7 +96,7 @@ func TestStartCluster(t *testing.T) {
 		t.Fatalf("Error starting cluster: %s", err)
 	}
 
-	for _, cmd := range []string{startCommand} {
+	for _, cmd := range []string{stopCommand, startCommand} {
 		if _, ok := h.Commands[cmd]; !ok {
 			t.Fatalf("Expected command not run: %s. Commands run: %s", cmd, h.Commands)
 		}

--- a/pkg/minikube/cluster/commands.go
+++ b/pkg/minikube/cluster/commands.go
@@ -20,3 +20,6 @@ var startCommand = `
 # Run with nohup so it stays up. Redirect logs to useful places.
 PATH=/usr/local/sbin:$PATH nohup sudo /usr/local/bin/localkube start --generate-certs=false > /var/log/localkube.out 2> /var/log/localkube.err < /dev/null &
 `
+
+// Kill any running instances.
+var stopCommand = "killall localkube | true"


### PR DESCRIPTION
This makes "minikube start" re-entrant. There are a few cases where calling start multiple times in a row (without a stop) causes trouble.