### PR TITLE
Added glog in place of log.*-and-fmt.Error* for cmd/minikube,

### DIFF
--- a/cmd/minikube/cmd/env.go
+++ b/cmd/minikube/cmd/env.go
@@ -18,10 +18,10 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/docker/machine/libmachine"
+	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"k8s.io/minikube/pkg/minikube/cluster"
 	"k8s.io/minikube/pkg/minikube/constants"
@@ -38,7 +38,7 @@ var dockerEnvCmd = &cobra.Command{
 
 		envMap, err := cluster.GetHostDockerEnv(api)
 		if err != nil {
-			log.Println("Error setting machine env variable(s):", err)
+			glog.Errorln("Error setting machine env variable(s):", err)
 			os.Exit(1)
 		}
 		fmt.Fprintln(os.Stdout, buildDockerEnvShellOutput(envMap))

--- a/cmd/minikube/cmd/ip.go
+++ b/cmd/minikube/cmd/ip.go
@@ -18,10 +18,10 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/docker/machine/libmachine"
+	"github.com/golang/glog"
 	"k8s.io/minikube/pkg/minikube/constants"
 
 	"github.com/spf13/cobra"
@@ -37,12 +37,12 @@ var ipCmd = &cobra.Command{
 		defer api.Close()
 		host, err := api.Load(constants.MachineName)
 		if err != nil {
-			log.Println("Error getting IP: ", err)
+			glog.Errorln("Error getting IP: ", err)
 			os.Exit(1)
 		}
 		ip, err := host.Driver.GetIP()
 		if err != nil {
-			log.Println("Error getting IP: ", err)
+			glog.Errorln("Error getting IP: ", err)
 			os.Exit(1)
 		}
 		fmt.Println(ip)

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -17,11 +17,12 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
-	"log"
+	goflag "flag"
 	"os"
 
+	"github.com/golang/glog"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"k8s.io/minikube/pkg/minikube/constants"
 )
 
@@ -38,7 +39,7 @@ var RootCmd = &cobra.Command{
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		for _, path := range dirs {
 			if err := os.MkdirAll(path, 0777); err != nil {
-				log.Panicf("Error creating minikube directory: %s", err)
+				glog.Exitf("Error creating minikube directory: %s", err)
 			}
 		}
 	},
@@ -48,12 +49,12 @@ var RootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(-1)
+		glog.Exitln(err)
 	}
 }
 
 func init() {
+	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	cobra.OnInitialize(initConfig)
 }
 

--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -18,10 +18,10 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/docker/machine/libmachine"
+	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"k8s.io/minikube/pkg/minikube/cluster"
 	"k8s.io/minikube/pkg/minikube/constants"
@@ -37,7 +37,7 @@ var statusCmd = &cobra.Command{
 		defer api.Close()
 		s, err := cluster.GetHostStatus(api)
 		if err != nil {
-			log.Println("Error getting machine status:", err)
+			glog.Errorln("Error getting machine status:", err)
 			os.Exit(1)
 		}
 		fmt.Fprintln(os.Stdout, s)

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net"
 	"path/filepath"
 	"strings"
@@ -31,6 +30,7 @@ import (
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/state"
+	"github.com/golang/glog"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/sshutil"
 	"k8s.io/minikube/pkg/util"
@@ -45,7 +45,7 @@ func StartHost(api libmachine.API, config MachineConfig) (*host.Host, error) {
 	if exists, err := api.Exists(constants.MachineName); err != nil {
 		return nil, fmt.Errorf("Error checking if host exists: %s", err)
 	} else if exists {
-		log.Println("Machine exists!")
+		glog.Infoln("Machine exists!")
 		h, err := api.Load(constants.MachineName)
 		if err != nil {
 			return nil, fmt.Errorf("Error loading existing host: %s", err)
@@ -148,11 +148,11 @@ type MachineConfig struct {
 
 // StartCluster starts a k8s cluster on the specified Host.
 func StartCluster(h sshAble) error {
-	commands := []string{stopCommand, startCommand}
+	commands := []string{stopCommand, GetStartCommand()}
 
 	for _, cmd := range commands {
 		output, err := h.RunSSHCommand(cmd)
-		log.Println(output)
+		glog.Infoln(output)
 		if err != nil {
 			return err
 		}
@@ -164,7 +164,7 @@ func StartCluster(h sshAble) error {
 func UpdateCluster(d drivers.Driver) error {
 	localkube, err := Asset("out/localkube")
 	if err != nil {
-		log.Println("Error loading localkube: ", err)
+		glog.Infoln("Error loading localkube: ", err)
 		return err
 	}
 

--- a/pkg/minikube/cluster/cluster_test.go
+++ b/pkg/minikube/cluster/cluster_test.go
@@ -96,7 +96,7 @@ func TestStartCluster(t *testing.T) {
 		t.Fatalf("Error starting cluster: %s", err)
 	}
 
-	for _, cmd := range []string{stopCommand, startCommand} {
+	for _, cmd := range []string{stopCommand, GetStartCommand()} {
 		if _, ok := h.Commands[cmd]; !ok {
 			t.Fatalf("Expected command not run: %s. Commands run: %s", cmd, h.Commands)
 		}

--- a/pkg/minikube/cluster/commands_test.go
+++ b/pkg/minikube/cluster/commands_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	gflag "flag"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestGetStartCommandDefaultValues(t *testing.T) {
+	flagMap := map[string]string{
+		"logtostderr":      "false",
+		"alsologtostderr":  "false",
+		"stderrthreshold":  "2",
+		"log_dir":          "",
+		"log_backtrace_at": ":0",
+		"v":                "0",
+		"vmodule":          "",
+	}
+	flagMapToSetFlags(flagMap)
+	startCommand := GetStartCommand()
+	for flag, val := range flagMap {
+		if val != "" {
+			if expectedFlag := getSingleFlagValue(flag, val); !strings.Contains(startCommand, getSingleFlagValue(flag, val)) {
+				t.Fatalf("Expected GetStartCommand to contain: %s.", expectedFlag)
+			}
+		}
+	}
+}
+
+func TestGetStartCommandCustomValues(t *testing.T) {
+	flagMap := map[string]string{
+		"logtostderr":      "true",
+		"alsologtostderr":  "true",
+		"stderrthreshold":  "3",
+		"log_dir":          "/var/",
+		"log_backtrace_at": "cluster.go:123",
+		"v":                "10",
+		"vmodule":          "cluster*=5",
+	}
+	flagMapToSetFlags(flagMap)
+	startCommand := GetStartCommand()
+	for flag, val := range flagMap {
+		if val != "" {
+			if expectedFlag := getSingleFlagValue(flag, val); !strings.Contains(startCommand, getSingleFlagValue(flag, val)) {
+				t.Fatalf("Expected GetStartCommand to contain: %s.", expectedFlag)
+			}
+		}
+	}
+}
+
+func flagMapToSetFlags(flagMap map[string]string) {
+	for flag, val := range flagMap {
+		gflag.Set(flag, val)
+	}
+}
+func getSingleFlagValue(flag, val string) string {
+	return fmt.Sprintf("--%s %s", flag, val)
+}

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -39,4 +39,14 @@ func MakeMiniPath(fileName string) string {
 	return filepath.Join(Minipath, fileName)
 }
 
+var LogFlags = [...]string{
+	"logtostderr",
+	"alsologtostderr",
+	"stderrthreshold",
+	"log_dir",
+	"log_backtrace_at",
+	"v",
+	"vmodule",
+}
+
 const DefaultIsoUrl = "https://storage.googleapis.com/minikube/minikube-0.1.iso"

--- a/pkg/minikube/kubeconfig/config.go
+++ b/pkg/minikube/kubeconfig/config.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api/latest"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -61,7 +62,7 @@ func ReadConfigOrNew(filename string) (*api.Config, error) {
 // If the file exists, it's contents will be overwritten.
 func WriteConfig(config *api.Config, filename string) error {
 	if config == nil {
-		fmt.Errorf("could not write to '%s': config can't be nil", filename)
+		glog.Errorf("could not write to '%s': config can't be nil", filename)
 	}
 
 	// encode config to YAML

--- a/pkg/minikube/machine/client.go
+++ b/pkg/minikube/machine/client.go
@@ -17,12 +17,12 @@ limitations under the License.
 package machine
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/docker/machine/drivers/virtualbox"
 	"github.com/docker/machine/libmachine/drivers/plugin"
 	"github.com/docker/machine/libmachine/drivers/plugin/localbinary"
+	"github.com/golang/glog"
 )
 
 // StartDriver starts the desired machine driver if necessary.
@@ -33,8 +33,7 @@ func StartDriver() {
 		case "virtualbox":
 			plugin.RegisterDriver(virtualbox.NewDriver("", ""))
 		default:
-			fmt.Fprintf(os.Stderr, "Unsupported driver: %s\n", driverName)
-			os.Exit(1)
+			glog.Exitf("Unsupported driver: %s\n", driverName)
 		}
 		return
 	}


### PR DESCRIPTION
cmd/localkube, pkg/minikube and pkg/localkube
#56 

I was unable to get one line changed to use glog due to a "glog" importing issue I was having. I could not import "glog" into the file cmd/localkube/main.go. I still need to test the logging with localkube and write tests but the startcommand for localkube should have the correct flags, I'm just not sure what the default directory is for glog