### PR TITLE
Configure capabilities explicitly before starting localkube.

### DIFF
--- a/cmd/localkube/cmd/start.go
+++ b/cmd/localkube/cmd/start.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"k8s.io/kubernetes/pkg/capabilities"
+	"k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/minikube/pkg/localkube"
 )
 
@@ -61,6 +63,19 @@ func SetupServer(s *localkube.LocalkubeServer) {
 			panic(err)
 		}
 	}
+
+	// Setup capabilities. This can only be done once per binary.
+	allSources, _ := types.GetValidatedSources([]string{types.AllSource})
+	c := capabilities.Capabilities{
+		AllowPrivileged: true,
+		PrivilegedSources: capabilities.PrivilegedSources{
+			HostNetworkSources: allSources,
+			HostIPCSources:     allSources,
+			HostPIDSources:     allSources,
+		},
+	}
+	capabilities.Initialize(c)
+
 	// setup etcd
 	etcd, err := s.NewEtcd(localkube.KubeEtcdClientURLs, localkube.KubeEtcdPeerURLs, "kubeetcd", s.GetEtcdDataDirectory())
 	if err != nil {

--- a/pkg/localkube/kubelet.go
+++ b/pkg/localkube/kubelet.go
@@ -39,6 +39,7 @@ func StartKubeletServer(lk LocalkubeServer) func() error {
 	config.Containerized = lk.Containerized
 
 	config.AllowPrivileged = true
+	config.Config = "/etc/kubernetes/manifests"
 
 	// Networking
 	config.ClusterDomain = lk.DNSDomain


### PR DESCRIPTION
There's a race condition in the current capability initialization. These
can only be configured once per binary, so if the APIServer goroutine
sets it first the kubelet goroutine can never change this value.