### PR TITLE
Fixed issue with wrong static-pods location in Makefile

### DIFF
--- a/deploy/docker/Makefile
+++ b/deploy/docker/Makefile
@@ -24,7 +24,7 @@ ifndef VERSION
 endif
 
 	cp -r ./* $(TEMP_DIR)
-	cp -r ../addons ../static-pods $(TEMP_DIR)
+	cp -r ../addons ./static-pods $(TEMP_DIR)
 	cp ../../out/localkube $(TEMP_DIR)
 	chmod +x $(TEMP_DIR)/localkube
 


### PR DESCRIPTION
Make fails due to wrong static-pods relative location