### PR TITLE
Unmark the DNS Service and Endpoint as cluster-services.

### DIFF
--- a/pkg/localkube/dns.go
+++ b/pkg/localkube/dns.go
@@ -122,9 +122,8 @@ func (dns *DNSServer) Start() {
 			Name:      DNSServiceName,
 			Namespace: DNSServiceNamespace,
 			Labels: map[string]string{
-				"k8s-app":                       "kube-dns",
-				"kubernetes.io/cluster-service": "true",
-				"kubernetes.io/name":            "KubeDNS",
+				"k8s-app":            "kube-dns",
+				"kubernetes.io/name": "KubeDNS",
 			},
 		}
 


### PR DESCRIPTION
This label causes the addon-manager to delete them. We can't let the addon-manager
create these either, because it doesn't support endpoints.