### PR TITLE
Added --memory flag to minikube start so that users can configure the…

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -34,6 +34,7 @@ import (
 
 var (
 	minikubeISO string
+	memory      int
 	vmDriver    string
 )
 
@@ -53,6 +54,7 @@ func runStart(cmd *cobra.Command, args []string) {
 
 	config := cluster.MachineConfig{
 		MinikubeISO: minikubeISO,
+		Memory:      memory,
 		VMDriver:    vmDriver,
 	}
 
@@ -153,5 +155,6 @@ func setupKubeconfig(name, server, certAuth, cliCert, cliKey string) (activeCont
 func init() {
 	startCmd.Flags().StringVarP(&minikubeISO, "iso-url", "", constants.DefaultIsoUrl, "Location of the minikube iso")
 	startCmd.Flags().StringVarP(&vmDriver, "vm-driver", "", constants.DefaultVMDriver, fmt.Sprintf("VM driver is one of: %v", constants.SupportedVMDrivers))
+	startCmd.Flags().IntVarP(&memory, "memory", "", constants.DefaultMemory, "Amount of RAM allocated to the minikube VM")
 	RootCmd.AddCommand(startCmd)
 }

--- a/docs/minikube_start.md
+++ b/docs/minikube_start.md
@@ -16,6 +16,7 @@ minikube start
 
 ```
       --iso-url="https://storage.googleapis.com/minikube/minikube-0.3.iso": Location of the minikube iso
+      --memory=1024: Amount of RAM allocated to the minikube VM
       --vm-driver="virtualbox": VM driver is one of: [virtualbox vmwarefusion]
 ```
 

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -155,6 +155,7 @@ type sshAble interface {
 // MachineConfig contains the parameters used to start a cluster.
 type MachineConfig struct {
 	MinikubeISO string
+	Memory      int
 	VMDriver    string
 }
 
@@ -268,6 +269,7 @@ func createHost(api libmachine.API, config MachineConfig) (*host.Host, error) {
 	case "virtualbox":
 		d := virtualbox.NewDriver(constants.MachineName, constants.Minipath)
 		d.Boot2DockerURL = config.MinikubeISO
+		d.Memory = config.Memory
 		driver = d
 	case "vmwarefusion":
 		driver = createVMwareFusionHost(config)

--- a/pkg/minikube/cluster/cluster_darwin.go
+++ b/pkg/minikube/cluster/cluster_darwin.go
@@ -25,6 +25,7 @@ import (
 func createVMwareFusionHost(config MachineConfig) drivers.Driver {
 	d := vmwarefusion.NewDriver(constants.MachineName, constants.Minipath).(*vmwarefusion.Driver)
 	d.Boot2DockerURL = config.MinikubeISO
+	d.Memory = config.Memory
 
 	// TODO(philips): push these defaults upstream to fixup this driver
 	d.CPU = 1

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -45,13 +45,16 @@ var LogFlags = [...]string{
 	"vmodule",
 }
 
-const DefaultIsoUrl = "https://storage.googleapis.com/minikube/minikube-0.3.iso"
-const DefaultVMDriver = "virtualbox"
-
 var SupportedVMDrivers = [...]string{
 	"virtualbox",
 	"vmwarefusion",
 }
+
+const (
+	DefaultIsoUrl   = "https://storage.googleapis.com/minikube/minikube-0.3.iso"
+	DefaultMemory   = 1024
+	DefaultVMDriver = "virtualbox"
+)
 
 const (
 	RemoteLocalKubeErrPath = "/var/log/localkube.err"


### PR DESCRIPTION
… ram of the vm

Example:
minikube start --memory 2048

#192 