### PR TITLE
Regenerate docker certs on startup.

### DIFF
--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -29,6 +29,7 @@ import (
 	"github.com/docker/machine/drivers/virtualbox"
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/drivers"
+	"github.com/docker/machine/libmachine/engine"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/state"
 	"github.com/golang/glog"
@@ -72,6 +73,9 @@ func StartHost(api libmachine.API, config MachineConfig) (*host.Host, error) {
 			if err := api.Save(h); err != nil {
 				return nil, fmt.Errorf("Error saving started host: %s", err)
 			}
+		}
+		if err := h.ConfigureAuth(); err != nil {
+			return nil, fmt.Errorf("Error configuring auth on host: %s", err)
 		}
 		return h, nil
 	} else {
@@ -289,6 +293,7 @@ func createHost(api libmachine.API, config MachineConfig) (*host.Host, error) {
 
 	h.HostOptions.AuthOptions.CertDir = constants.Minipath
 	h.HostOptions.AuthOptions.StorePath = constants.Minipath
+	h.HostOptions.EngineOptions = &engine.Options{}
 
 	if err := api.Create(h); err != nil {
 		// Wait for all the logs to reach the client

--- a/pkg/minikube/tests/host_mock.go
+++ b/pkg/minikube/tests/host_mock.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import "fmt"
+
+// MockHost used for testing. When commands are run, the output from CommandOutput
+// is used, if present. Then the output from Error is used, if present. Finally,
+// "", nil is returned.
+type MockHost struct {
+	CommandOutput map[string]string
+	Error         string
+	Commands      map[string]int
+}
+
+func NewMockHost() *MockHost {
+	return &MockHost{
+		CommandOutput: make(map[string]string),
+		Commands:      make(map[string]int),
+	}
+}
+
+func (m MockHost) RunSSHCommand(cmd string) (string, error) {
+	m.Commands[cmd] = 1
+	output, ok := m.CommandOutput[cmd]
+	if ok {
+		return output, nil
+	}
+	if m.Error != "" {
+		return "", fmt.Errorf(m.Error)
+	}
+	return "", nil
+}

--- a/pkg/minikube/tests/provision_mock.go
+++ b/pkg/minikube/tests/provision_mock.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"github.com/docker/machine/libmachine/auth"
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/docker/machine/libmachine/engine"
+	"github.com/docker/machine/libmachine/provision"
+	"github.com/docker/machine/libmachine/provision/pkgaction"
+	"github.com/docker/machine/libmachine/provision/serviceaction"
+	"github.com/docker/machine/libmachine/swarm"
+)
+
+// Provisioner defines distribution specific actions
+type MockProvisioner struct {
+	Provisioned bool
+}
+
+func (provisioner *MockProvisioner) String() string {
+	return "mock"
+}
+
+func (provisioner *MockProvisioner) Service(name string, action serviceaction.ServiceAction) error {
+	return nil
+}
+
+func (provisioner *MockProvisioner) Package(name string, action pkgaction.PackageAction) error {
+	return nil
+}
+
+func (provisioner *MockProvisioner) Hostname() (string, error) {
+	return "mockhostname", nil
+}
+
+func (provisioner *MockProvisioner) SetHostname(hostname string) error {
+	return nil
+}
+
+func (provisioner *MockProvisioner) GetDockerOptionsDir() string {
+	return "/mockdirectory"
+}
+
+func (provisioner *MockProvisioner) GetAuthOptions() auth.Options {
+	return auth.Options{}
+}
+
+func (provisioner *MockProvisioner) GenerateDockerOptions(dockerPort int) (*provision.DockerOptions, error) {
+	return &provision.DockerOptions{}, nil
+}
+
+func (provisioner *MockProvisioner) CompatibleWithHost() bool {
+	return true
+}
+
+func (provisioner *MockProvisioner) SetOsReleaseInfo(info *provision.OsRelease) {
+}
+
+func (provisioner *MockProvisioner) GetOsReleaseInfo() (*provision.OsRelease, error) {
+	return nil, nil
+}
+
+func (provisioner *MockProvisioner) AttemptIPContact(dockerPort int) {
+}
+
+func (provisioner *MockProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error {
+	provisioner.Provisioned = true
+	return nil
+}
+
+func (provisioner *MockProvisioner) SSHCommand(args string) (string, error) {
+	return "", nil
+}
+
+func (provisioner *MockProvisioner) GetDriver() drivers.Driver {
+	return &MockDriver{}
+}
+
+type MockDetector struct {
+	Provisioner *MockProvisioner
+}
+
+func (m *MockDetector) DetectProvisioner(d drivers.Driver) (provision.Provisioner, error) {
+	return m.Provisioner, nil
+}


### PR DESCRIPTION
A few other cleanups:

Move host_mock to it's own file
Define a new provision_mock type for testing provisioners

Fixes #208.