### PR TITLE
Make the /var/lib/localkube directory persistent.

### DIFF
--- a/deploy/iso/Dockerfile
+++ b/deploy/iso/Dockerfile
@@ -25,6 +25,8 @@ ADD nsenter $ROOTFS/usr/bin/
 ADD socat $ROOTFS/usr/bin
 ADD ethtool $ROOTFS/usr/bin
 ADD conntrack $ROOTFS/usr/bin
+ADD bootlocal.sh $ROOTFS/tmp/bootlocal.sh
+RUN cat $ROOTFS/tmp/bootlocal.sh >> $ROOTFS/etc/rc.d/automount
 
 # Get a specific version of Docker. This will overwrite the binary installed
 # in the base image.

--- a/deploy/iso/bootlocal.sh
+++ b/deploy/iso/bootlocal.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Setup a persistent directory for /var/lib/localkube
+BOOT2DOCKER_DATA=`blkid -o device -l -t LABEL=boot2docker-data`
+PARTNAME=`echo "$BOOT2DOCKER_DATA" | sed 's/.*\///'`
+
+mkdir -p /mnt/$PARTNAME/var/lib/localkube
+ln -s /mnt/$PARTNAME/var/lib/localkube /var/lib/localkube


### PR DESCRIPTION
This will require a new ISO release. Once that goes out, we should add an integration test that will verify this behavior.

Fixes #237 