### PR TITLE
Add a "--minikube-args" flag to the integration tests.

### DIFF
--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -36,7 +36,11 @@ var (
 )
 
 func TestAddons(t *testing.T) {
-	minikubeRunner := util.MinikubeRunner{BinaryPath: *binaryPath, T: t}
+	minikubeRunner := util.MinikubeRunner{
+		BinaryPath: *binaryPath,
+		Args:       *args,
+		T:          t}
+
 	minikubeRunner.EnsureRunning()
 	kubectlRunner := util.NewKubectlRunner(t)
 
@@ -58,8 +62,11 @@ func TestAddons(t *testing.T) {
 }
 
 func TestDashboard(t *testing.T) {
-	minikubeRunner := util.MinikubeRunner{BinaryPath: *binaryPath, T: t}
-	minikubeRunner.RunCommand("start", true)
+	minikubeRunner := util.MinikubeRunner{
+		BinaryPath: *binaryPath,
+		Args:       *args,
+		T:          t}
+	minikubeRunner.Start()
 	minikubeRunner.CheckStatus("Running")
 	kubectlRunner := util.NewKubectlRunner(t)
 

--- a/test/integration/cluster_dns_test.go
+++ b/test/integration/cluster_dns_test.go
@@ -31,7 +31,10 @@ import (
 )
 
 func TestClusterDNS(t *testing.T) {
-	minikubeRunner := util.MinikubeRunner{BinaryPath: *binaryPath, T: t}
+	minikubeRunner := util.MinikubeRunner{
+		BinaryPath: *binaryPath,
+		Args:       *args,
+		T:          t}
 	minikubeRunner.EnsureRunning()
 
 	kubectlRunner := util.NewKubectlRunner(t)

--- a/test/integration/cluster_env_test.go
+++ b/test/integration/cluster_env_test.go
@@ -28,7 +28,10 @@ import (
 )
 
 func TestClusterEnv(t *testing.T) {
-	minikubeRunner := util.MinikubeRunner{BinaryPath: *binaryPath, T: t}
+	minikubeRunner := util.MinikubeRunner{
+		Args:       *args,
+		BinaryPath: *binaryPath,
+		T:          t}
 	minikubeRunner.EnsureRunning()
 
 	dockerEnvVars := minikubeRunner.RunCommand("docker-env", true)

--- a/test/integration/cluster_ssh_test.go
+++ b/test/integration/cluster_ssh_test.go
@@ -25,7 +25,10 @@ import (
 )
 
 func TestClusterSSH(t *testing.T) {
-	minikubeRunner := util.MinikubeRunner{BinaryPath: *binaryPath, T: t}
+	minikubeRunner := util.MinikubeRunner{
+		Args:       *args,
+		BinaryPath: *binaryPath,
+		T:          t}
 	minikubeRunner.EnsureRunning()
 
 	expectedStr := "hello"

--- a/test/integration/cluster_status_test.go
+++ b/test/integration/cluster_status_test.go
@@ -29,7 +29,10 @@ import (
 )
 
 func TestClusterStatus(t *testing.T) {
-	minikubeRunner := util.MinikubeRunner{BinaryPath: *binaryPath, T: t}
+	minikubeRunner := util.MinikubeRunner{
+		Args:       *args,
+		BinaryPath: *binaryPath,
+		T:          t}
 	minikubeRunner.EnsureRunning()
 
 	kubectlRunner := util.NewKubectlRunner(t)

--- a/test/integration/flags.go
+++ b/test/integration/flags.go
@@ -19,25 +19,15 @@ limitations under the License.
 package integration
 
 import (
-	"k8s.io/minikube/pkg/minikube/constants"
-	"k8s.io/minikube/test/integration/util"
-	"strings"
+	"flag"
+	"os"
 	"testing"
 )
 
-func TestClusterLogs(t *testing.T) {
-	minikubeRunner := util.MinikubeRunner{
-		Args:       *args,
-		BinaryPath: *binaryPath,
-		T:          t}
-	minikubeRunner.EnsureRunning()
-
-	logsCmdOutput := minikubeRunner.RunCommand("logs", true)
-	//check for # of lines or check for strings
-	logFiles := []string{constants.RemoteLocalKubeErrPath, constants.RemoteLocalKubeOutPath}
-	for _, logFile := range logFiles {
-		if !strings.Contains(logsCmdOutput, logFile) {
-			t.Fatalf("Error in logsCmdOutput, expected to find: %s. Output: %s", logFile, logsCmdOutput)
-		}
-	}
+func TestMain(m *testing.M) {
+	flag.Parse()
+	os.Exit(m.Run())
 }
+
+var binaryPath = flag.String("binary", "../../out/minikube", "path to minikube binary")
+var args = flag.String("minikube-args", "", "Arguments to pass to minikube")

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -19,24 +19,23 @@ limitations under the License.
 package integration
 
 import (
-	"flag"
 	"net"
-	"os"
 	"strings"
 	"testing"
 
 	"k8s.io/minikube/test/integration/util"
 )
 
-var binaryPath = flag.String("binary", "../../out/minikube", "path to minikube binary")
-
 func TestStartStop(t *testing.T) {
 
-	runner := util.MinikubeRunner{T: t, BinaryPath: *binaryPath}
+	runner := util.MinikubeRunner{
+		Args:       *args,
+		BinaryPath: *binaryPath,
+		T:          t}
 	runner.RunCommand("delete", false)
 	runner.CheckStatus("Does Not Exist")
 
-	runner.RunCommand("start", true)
+	runner.Start()
 	runner.CheckStatus("Running")
 
 	ip := runner.RunCommand("ip", true)
@@ -48,14 +47,9 @@ func TestStartStop(t *testing.T) {
 	runner.RunCommand("stop", true)
 	runner.CheckStatus("Stopped")
 
-	runner.RunCommand("start", true)
+	runner.Start()
 	runner.CheckStatus("Running")
 
 	runner.RunCommand("delete", true)
 	runner.CheckStatus("Does Not Exist")
-}
-
-func TestMain(m *testing.M) {
-	flag.Parse()
-	os.Exit(m.Run())
 }

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -34,6 +34,7 @@ import (
 type MinikubeRunner struct {
 	T          *testing.T
 	BinaryPath string
+	Args       string
 }
 
 func (m *MinikubeRunner) RunCommand(command string, checkError bool) string {
@@ -52,9 +53,13 @@ func (m *MinikubeRunner) RunCommand(command string, checkError bool) string {
 	return string(stdout)
 }
 
+func (m *MinikubeRunner) Start() {
+	m.RunCommand(fmt.Sprintf("start %s", m.Args), true)
+}
+
 func (m *MinikubeRunner) EnsureRunning() {
 	if m.GetStatus() != "Running" {
-		m.RunCommand("start", true)
+		m.Start()
 	}
 	m.CheckStatus("Running")
 }


### PR DESCRIPTION
This flag lets you pass arbitrary flags to minikube start. For now,
this is useful for testing different iso URLs and VM drivers.