### PR TITLE
Do not override node hostname to ensure node IP is correct in node resource addresses

### DIFF
--- a/pkg/localkube/kubelet.go
+++ b/pkg/localkube/kubelet.go
@@ -21,10 +21,6 @@ import (
 	"k8s.io/kubernetes/cmd/kubelet/app/options"
 )
 
-const (
-	HostnameOverride = "127.0.0.1"
-)
-
 func (lk LocalkubeServer) NewKubeletServer() Server {
 	return NewSimpleServer("kubelet", serverInterval, StartKubeletServer(lk))
 }
@@ -44,7 +40,6 @@ func StartKubeletServer(lk LocalkubeServer) func() error {
 	// Networking
 	config.ClusterDomain = lk.DNSDomain
 	config.ClusterDNS = lk.DNSIP.String()
-	config.HostnameOverride = HostnameOverride
 
 	// Use the host's resolver config
 	if lk.Containerized {


### PR DESCRIPTION
This means the node name will be `minikubevm` & that the node address is set to the public IP, which is important for anything that tries to discover stuff from the API server (e.g. Prometheus node discovery, fabric8 service IP discovery using node ports, etc).