### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ _testmain.go
 
 /pkg/minikube/cluster/assets.go
 /minikube
+
+.DS_Store


### PR DESCRIPTION
This makes the localkube "gitTreeState" "dirty" when building in a Mac through Docker.