### PR TITLE
Add a note on how to run a single conformance test.

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,14 @@ export KUBERNETES_CONFORMANCE_TEST=y
 go run hack/e2e.go -v --test --test_args="--ginkgo.focus=\[Conformance\]" --check_version_skew=false --check_node_count=false
 ```
 
+To run a specific Conformance Test, you can use the `ginkgo.focus` flag to filter the set using a regular expression.
+The hack/e2e.go wrapper and the e2e.sh wrappers have a little trouble with quoting spaces though, so use the `\s` regular expression character instead.
+For example, to run the test `should update annotations on modification [Conformance]`, use this command:
+
+```shell
+go run hack/e2e.go -v --test --test_args="--ginkgo.focus=should\supdate\sannotations\son\smodification" --check_version_skew=false --check_node_count=false
+```
+
 #### Adding a New Dependency
 
 Minikube uses `Godep` to manage vendored dependencies.


### PR DESCRIPTION
cc @pwittrock @vishh 

Do you know of a better way to run a single conformance test? It looks like the quoting in here:
https://github.com/kubernetes/kubernetes/blob/master/hack/ginkgo-e2e.sh#L109

causes trouble with spaces. If I echo the final command, like:

`echo "${ginkgo}" "${ginkgo_args[@]:+${ginkgo_args[@]}}" "${e2e_test}" -- \
  "${auth_config[@]:+${auth_config[@]}}" \
  --host="${KUBE_MASTER_URL}" \
  --provider="${KUBERNETES_PROVIDER}" \
  --gce-project="${PROJECT:-}" \
  --gce-zone="${ZONE:-}" \
  --gce-service-account="${GCE_SERVICE_ACCOUNT:-}" \
  --gke-cluster="${CLUSTER_NAME:-}" \
  --kube-master="${KUBE_MASTER:-}" \
  --cluster-tag="${CLUSTER_ID:-}" \
  --repo-root="${KUBE_ROOT}" \
  --node-instance-group="${NODE_INSTANCE_GROUP:-}" \
  --prefix="${KUBE_GCE_INSTANCE_PREFIX:-e2e}" \
  ${OS_DISTRIBUTION:+"--os-distro=${OS_DISTRIBUTION}"} \
  ${NUM_NODES:+"--num-nodes=${NUM_NODES}"} \
  ${E2E_CLEAN_START:+"--clean-start=true"} \
  ${E2E_MIN_STARTUP_PODS:+"--minStartupPods=${E2E_MIN_STARTUP_PODS}"} \
  ${E2E_REPORT_DIR:+"--report-dir=${E2E_REPORT_DIR}"} \
  ${E2E_REPORT_PREFIX:+"--report-prefix=${E2E_REPORT_PREFIX}"} \
  "${@:-}"
`

Then copy/paste/execute that output the test runs correctly. But if I just let ginkgo-e2e.sh run the test directly it won't run.