### PR TITLE
Increase the timeout on the addon manager pod.

### DIFF
--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -56,7 +56,7 @@ func TestAddons(t *testing.T) {
 		return nil
 	}
 
-	if err := commonutil.RetryAfter(10, checkAddon, 5*time.Second); err != nil {
+	if err := commonutil.RetryAfter(20, checkAddon, 5*time.Second); err != nil {
 		t.Fatalf("Addon Manager pod is unhealthy: %s", err)
 	}
 }


### PR DESCRIPTION
I'm setting up an integration server, and this test failed with: 

```shell
--- FAIL: TestAddons (121.83s)
	addons_test.go:60: Addon Manager pod is unhealthy: Pod is not Running. Status: Pending
```