### PR TITLE
explicitly set GOBIN based on GOPATH in case it is set externally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,6 @@ else
 	GOPATH := $(shell pwd)/_gopath
 endif
 
-
 # Use system python if it exists, otherwise use Docker.
 PYTHON := $(shell command -v python || echo "docker run --rm -it -v $(shell pwd):/minikube -w /minikube python python")
 BUILD_OS := $(shell uname -s)
@@ -80,7 +79,7 @@ pkg/minikube/cluster/assets.go: out/localkube $(GOPATH)/bin/go-bindata deploy/is
 
 $(GOPATH)/bin/go-bindata:
 	$(MKGOPATH)
-	go get github.com/jteeuwen/go-bindata/...
+	GOBIN=$(GOPATH)/bin go get github.com/jteeuwen/go-bindata/...
 
 clean:
 	rm -rf $(GOPATH)


### PR DESCRIPTION
if gobin is set by the user, that will be overridden, and the 'go-bindata' command will be installed out of the expected GOPATH.