### PR TITLE
Switch the DNS test to use GCR instead of dockerhub.

### DIFF
--- a/test/integration/testdata/busybox.yaml
+++ b/test/integration/testdata/busybox.yaml
@@ -4,7 +4,7 @@ metadata:
   name: busybox
 spec:
   containers:
-  - image: busybox
+  - image: gcr.io/google-containers/busybox
     command:
       - sleep
       - "3600"


### PR DESCRIPTION
I'm not sure if there was a dockerhub outage, but we had an integration test run fail because we couldn't pull busybox.