### PR TITLE
Add lgtm.co configuration

### DIFF
--- a/.lgtm
+++ b/.lgtm
@@ -1,0 +1,1 @@
+approvals = 1

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,4 @@
+Dan Lorenc <dlorenc@google.com> (@dlorenc)
+Lucas Käldström <lucas.kaldstrom@hotmail.co.uk> (@luxas)
+Aaron Prindle <aaprindle@gmail.com> (@aaron-prindle)
+Jimmi Dyson <jimmidyson@gmail.com> (@jimmidyson)


### PR DESCRIPTION
This is a suggestion to use the small, but very useful, service at https://lgtm.co to track LGTM comments from maintainers on minikube to make it easier to notice when PRs are LGTMed before merge (shows as a Github status check). This requires a project admin (@dlorenc?) to enable the service by visiting https://lgtm.co & clicking activate for minikube. It's normally best to enable master branch as protected as well.

I've used this on a few different projects & really like it personally. What do you think?