### PR TITLE
Fix typo in start command.

### DIFF
--- a/pkg/minikube/cluster/commands.go
+++ b/pkg/minikube/cluster/commands.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Kill any running instances.
-var stopCommand = "sudo killall localkube | true"
+var stopCommand = "sudo killall localkube || true"
 
 var startCommandFmtStr = `
 # Run with nohup so it stays up. Redirect logs to useful places.


### PR DESCRIPTION
This was harmless but made the minikube logs output look ugly.