### PR TITLE
Switch the DNS etcd port from 9090.

### DIFF
--- a/pkg/localkube/dns.go
+++ b/pkg/localkube/dns.go
@@ -56,7 +56,7 @@ type DNSServer struct {
 func (lk LocalkubeServer) NewDNSServer(rootDomain, clusterIP, kubeAPIServer string) (*DNSServer, error) {
 	// setup backing etcd store
 	peerURLs := []string{"http://localhost:9256"}
-	DNSEtcdURLs := []string{"http://localhost:9090"}
+	DNSEtcdURLs := []string{"http://localhost:49090"}
 
 	publicIP, err := lk.GetHostIP()
 	if err != nil {


### PR DESCRIPTION
Fixes #389. I switched the port to 49090, open to anything.

I verified DNS still works. I ran a "hello world" container behind a service, then created a busybox pod, execed into it and ran:

```shell
$ nslookup hello-node
Server:    10.0.0.10
Address 1: 10.0.0.10

Name:      hello-node
Address 1: 10.0.0.249

```