### PR TITLE
Fix home directory on windows

### DIFF
--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -29,8 +29,9 @@ const MachineName = "minikubeVM"
 // APIServerPort is the port that the API server should listen on.
 const APIServerPort = 8443
 
-// Fix for windows
-var Minipath = filepath.Join(homedir.HomeDir(), ".minikube")
+// Fix for windows: the home dir contains forward slashes, which results
+// in an error when using url.Parse
+var Minipath = filepath.ToSlash(filepath.Join(homedir.HomeDir(), ".minikube"))
 
 // TODO: Fix for windows
 // KubeconfigPath is the path to the Kubernetes client config


### PR DESCRIPTION
Initial work for #405 

I was able to narrow the issue down by building a small executable that replicates the `minikube` start command. 

What's happening is that the home directory on windows contains forward slashes, which causes problems when the `isoURL` is parsed [in docker/machine](https://github.com/docker/machine/blob/6002b411ce820eaf03ac972a7fb354bb56f7aa95/libmachine/mcnutils/b2d.go#L196.) using `url.Parse`. Given that the error is not handled in `docker/machine`, we actually get a panic when doing `u.Scheme`.

I have added a call to `filepath.ToSlash` to remove forward slashes from the home dir.

I'd like to test this on my windows box, but I've been unable to build for `GOOS=windows`