### PR TITLE
Adding a default NFS mount for /Users with xhyve

### DIFF
--- a/pkg/minikube/cluster/cluster_darwin.go
+++ b/pkg/minikube/cluster/cluster_darwin.go
@@ -62,5 +62,7 @@ func createXhyveHost(config MachineConfig) *xhyveDriver {
 		Boot2DockerURL: config.GetISOFileURI(),
 		BootCmd:        "loglevel=3 user=docker console=ttyS0 console=tty0 noembed nomodeset norestore waitusb=10 base host=boot2docker",
 		DiskSize:       int64(config.DiskSize),
+		Virtio9p:       true,
+		Virtio9pFolder: "/Users",
 	}
 }


### PR DESCRIPTION
Removing the Virtio9p flags from the xhyve-driver struct because they
require custom configuration of the boot2docker iso and thus won't
work.  See this note for more information
https://github.com/zchee/docker-machine-driver-xhyve#usage

This resolves issue #423 

Additionally, let me know if anyone thinks we should keep around the virtio9p flags for now or if we should not mount the folder by default and instead have to pass a flag or something.