### PR TITLE
Docker v1.12.0

### DIFF
--- a/deploy/iso/Dockerfile
+++ b/deploy/iso/Dockerfile
@@ -17,8 +17,8 @@
 FROM boot2docker/boot2docker
 
 # Set the version of Docker and the expected sha.
-RUN echo "1.11.1" > $ROOTFS/etc/version
-ENV DOCKER_SHA b7d6025beb6440341741ea9324655a267fba83f7
+RUN echo "1.12.0" > $ROOTFS/etc/version
+ENV DOCKER_SHA 92839410a37ed1940b7a93dcd21fd9aa85d673a1 
 
 # Add other dependencies here to $ROOTFS/
 ADD nsenter $ROOTFS/usr/bin/


### PR DESCRIPTION
Upgrading docker to v1.12.0 which was released a few days ago https://github.com/boot2docker/boot2docker/releases/tag/v1.12.0