### PR TITLE
Add ability to specify CIDR for Virtualbox minikube

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -43,6 +43,7 @@ var (
 	dockerEnv         []string
 	insecureRegistry  []string
 	kubernetesVersion string
+	hostOnlyCIDR      string
 )
 
 // startCmd represents the start command
@@ -67,6 +68,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		VMDriver:         vmDriver,
 		DockerEnv:        dockerEnv,
 		InsecureRegistry: insecureRegistry,
+		HostOnlyCIDR:     hostOnlyCIDR,
 	}
 	kubernetesConfig := cluster.KubernetesConfig{
 		KubernetesVersion: kubernetesVersion,
@@ -167,6 +169,7 @@ func init() {
 	startCmd.Flags().IntVar(&cpus, "cpus", constants.DefaultCPUS, "Number of CPUs allocated to the minikube VM")
 	diskFlag := startCmd.Flags().VarPF(disk, "disk-size", "", "Disk size allocated to the minikube VM (format: <number>[<unit>], where unit = b, k, m or g)")
 	diskFlag.DefValue = constants.DefaultDiskSize
+	startCmd.Flags().StringVar(&hostOnlyCIDR, "host-only-cidr", "192.168.99.1/24", "The CIDR to be used for the minikube VM (only supported with Virtualbox driver)")
 	startCmd.Flags().StringSliceVar(&dockerEnv, "docker-env", nil, "Environment variables to pass to the Docker daemon. (format: key=value)")
 	startCmd.Flags().StringSliceVar(&insecureRegistry, "insecure-registry", nil, "Insecure Docker registries to pass to the Docker daemon")
 	startCmd.Flags().StringVar(&kubernetesVersion, "kubernetes-version", constants.DefaultKubernetesVersion, "The kubernetes version that the minikube VM will (ex: v1.2.3) \n OR a URI which contains a localkube binary (ex: https://storage.googleapis.com/minikube/k8sReleases/v1.3.0/localkube-linux-amd64)")

--- a/docs/minikube_start.md
+++ b/docs/minikube_start.md
@@ -18,6 +18,7 @@ minikube start
       --cpus=1: Number of CPUs allocated to the minikube VM
       --disk-size=20g: Disk size allocated to the minikube VM (format: <number>[<unit>], where unit = b, k, m or g)
       --docker-env=[]: Environment variables to pass to the Docker daemon. (format: key=value)
+      --host-only-cidr="192.168.99.1/24": The CIDR to be used for the minikube VM (only supported with Virtualbox driver)
       --insecure-registry=[]: Insecure Docker registries to pass to the Docker daemon
       --iso-url="https://storage.googleapis.com/minikube/minikube-0.5.iso": Location of the minikube iso
       --kubernetes-version="v1.3.3": The kubernetes version that the minikube VM will (ex: v1.2.3) 

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -178,6 +178,7 @@ type MachineConfig struct {
 	VMDriver         string
 	DockerEnv        []string // Each entry is formatted as KEY=VALUE.
 	InsecureRegistry []string
+	HostOnlyCIDR     string // Only used by the virtualbox driver
 }
 
 // KubernetesConfig contains the parameters used to configure the VM Kubernetes.
@@ -354,6 +355,7 @@ func createVirtualboxHost(config MachineConfig) drivers.Driver {
 	d.Memory = config.Memory
 	d.CPU = config.CPUs
 	d.DiskSize = int(config.DiskSize)
+	d.HostOnlyCIDR = config.HostOnlyCIDR
 	return d
 }
 


### PR DESCRIPTION
Fixes #323 by adding a flag to the start command for specifying the host CIDR.