### PR TITLE
Add warning message for failure to read conf

### DIFF
--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -80,11 +80,12 @@ func init() {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
+	configPath := constants.MakeMiniPath("config")
 	viper.SetConfigName("config")
-	viper.AddConfigPath(constants.MakeMiniPath("config"))
+	viper.AddConfigPath(configPath)
 	err := viper.ReadInConfig()
 	if err != nil {
-		glog.Warningf("Error reading config file: %s", err)
+		glog.Warningf("Error reading config file at %s: %s", configPath, err)
 	}
 	viper.SetDefault(config.WantUpdateNotification, true)
 	viper.SetDefault(config.ReminderWaitPeriodInHours, 24)

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -82,7 +82,10 @@ func init() {
 func initConfig() {
 	viper.SetConfigName("config")
 	viper.AddConfigPath(constants.MakeMiniPath("config"))
-	viper.ReadInConfig()
+	err := viper.ReadInConfig()
+	if err != nil {
+		glog.Warningf("Error reading config file: %s", err)
+	}
 	viper.SetDefault(config.WantUpdateNotification, true)
 	viper.SetDefault(config.ReminderWaitPeriodInHours, 24)
 }


### PR DESCRIPTION
The configuration file is optional, however when/if we move more
options to be configurable through the viper yaml file, this would be
nice to see when debugging.