### PR TITLE
Remove the "kubernetes is now available" line from start.

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -109,7 +109,6 @@ func runStart(cmd *cobra.Command, args []string) {
 	}
 	kubeHost = strings.Replace(kubeHost, "tcp://", "https://", -1)
 	kubeHost = strings.Replace(kubeHost, ":2376", ":"+strconv.Itoa(constants.APIServerPort), -1)
-	fmt.Printf("Kubernetes is available at %s.\n", kubeHost)
 
 	// setup kubeconfig
 	name := constants.MinikubeContext


### PR DESCRIPTION
This was confusing to users who would try to access this in their browser.