### PR TITLE
Use config when flags are not set for logging

### DIFF
--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -44,6 +44,10 @@ const (
 	showLibmachineLogs = "show-libmachine-logs"
 )
 
+var (
+	enableUpdateNotification = true
+)
+
 var viperWhiteList = []string{
 	"v",
 	"alsologtostderr",
@@ -62,12 +66,17 @@ var RootCmd = &cobra.Command{
 			}
 		}
 
-		log.SetDebug(viper.Get(showLibmachineLogs))
-		if !viper.GetBool(showLibmachineLogs) {
+		shouldShowLibmachineLogs := viper.GetBool(showLibmachineLogs)
+
+		log.SetDebug(shouldShowLibmachineLogs)
+		if !shouldShowLibmachineLogs {
 			log.SetOutWriter(ioutil.Discard)
 			log.SetErrWriter(ioutil.Discard)
 		}
-		notify.MaybePrintUpdateTextFromGithub(os.Stdout)
+
+		if enableUpdateNotification {
+			notify.MaybePrintUpdateTextFromGithub(os.Stdout)
+		}
 	},
 }
 

--- a/cmd/minikube/cmd/root_test.go
+++ b/cmd/minikube/cmd/root_test.go
@@ -35,8 +35,6 @@ log_dir: "/etc/hosts"
 log-flush-frequency: "3s"
 `)
 
-const configName = ".test_minikube_config.yml"
-
 type configTest struct {
 	Name          string
 	EnvValue      string

--- a/cmd/minikube/cmd/version.go
+++ b/cmd/minikube/cmd/version.go
@@ -20,9 +20,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
-	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/version"
 )
 
@@ -32,7 +30,7 @@ var versionCmd = &cobra.Command{
 	Long:  `Print the version of minikube.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		// Explicitly disable update checking for the version command
-		viper.Set(config.WantUpdateNotification, "false")
+		enableUpdateNotification = false
 
 		RootCmd.PersistentPreRun(cmd, args)
 	},

--- a/cmd/minikube/cmd/version.go
+++ b/cmd/minikube/cmd/version.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
+	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/version"
 )
 
@@ -29,8 +31,10 @@ var versionCmd = &cobra.Command{
 	Short: "Print the version of minikube.",
 	Long:  `Print the version of minikube.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		// Empty func to override parent pre-run - don't want to perform
-		// check for new version.
+		// Explicitly disable update checking for the version command
+		viper.Set(config.WantUpdateNotification, "false")
+
+		RootCmd.PersistentPreRun(cmd, args)
 	},
 	Run: func(command *cobra.Command, args []string) {
 


### PR DESCRIPTION
Use viper in addition to flags for logging options.  Since these flags
are used in glog, we can't directly use viper.  Instead, we use viper's
built in precedence logic (https://github.com/spf13/viper#why-viper)
to set the flags directly.

After we add these for some of the other commands, maybe we can use cobra's built in doc generator to generate an example config file to include for reference.