### PR TITLE
Check HTTP Response status when trying to download minikube.iso

### DIFF
--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -308,6 +308,8 @@ func (m *MachineConfig) CacheMinikubeISOFromURL() error {
 	response, err := http.Get(m.MinikubeISO)
 	if err != nil {
 		return err
+	} else if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("Received %d response from %s while trying to download minikube.iso", response.StatusCode, m.MinikubeISO)
 	} else {
 		out, err := os.Create(m.GetISOCacheFilepath())
 		if err != nil {

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -308,18 +308,21 @@ func (m *MachineConfig) CacheMinikubeISOFromURL() error {
 	response, err := http.Get(m.MinikubeISO)
 	if err != nil {
 		return err
-	} else if response.StatusCode != http.StatusOK {
+	}
+
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
 		return fmt.Errorf("Received %d response from %s while trying to download minikube.iso", response.StatusCode, m.MinikubeISO)
-	} else {
-		out, err := os.Create(m.GetISOCacheFilepath())
-		if err != nil {
-			return err
-		}
-		defer out.Close()
-		defer response.Body.Close()
-		if _, err = io.Copy(out, response.Body); err != nil {
-			return err
-		}
+	}
+
+	out, err := os.Create(m.GetISOCacheFilepath())
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err = io.Copy(out, response.Body); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
Check the response so that we don't actually download an error page or
something other than the ISO we're looking for.

This might catch some (maybe not all) of the errors we've seen with #471