### PR TITLE
Add release notes for package manager

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -79,3 +79,13 @@ gsutil cp deploy/minikube/releases.json gs://minikube/releases.json
 ```shell
 gsutil cp -r gs://minikube/releases/$RELEASE/* gs://minikube/releases/latest/
 ```
+
+## Package managers which include minikube
+
+These are downstream packages that are being maintained by others and how to upgrade them to make sure they have the latest versions
+
+Arch Linux AUR - "Flag as package out-of-date"
+https://aur.archlinux.org/packages/minikube/
+
+Brew Cask - Update Cask Formula
+https://github.com/caskroom/homebrew-cask/blob/master/Casks/minikube.rb

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -84,8 +84,10 @@ gsutil cp -r gs://minikube/releases/$RELEASE/* gs://minikube/releases/latest/
 
 These are downstream packages that are being maintained by others and how to upgrade them to make sure they have the latest versions
 
-Arch Linux AUR - "Flag as package out-of-date"
-https://aur.archlinux.org/packages/minikube/
+| Package Manager | URL | TODO |
+| --- | --- | --- |
+| Arch Linux AUR | https://aur.archlinux.org/packages/minikube/ | "Flag as package out-of-date"
+| Brew Cask | https://github.com/caskroom/homebrew-cask/blob/master/Casks/minikube.rb | Create a new PR in [caskroom/homebrew-cask](https://github.com/caskroom/homebrew-cask) with an updated version and appcast checkpoint
 
-Brew Cask - Update Cask Formula
-https://github.com/caskroom/homebrew-cask/blob/master/Casks/minikube.rb
+#### [How to Generate an Appcast Checkpoint for Homebrew](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/appcast.md)
+`curl --compressed --location --user-agent 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36' "https://github.com/kubernetes/minikube/releases.atom" | sed 's|<pubDate>[^<]*</pubDate>||g' | shasum --algorithm 256`


### PR DESCRIPTION
Just to keep track of where minikube is being served from besides the
places we explicitly own.  For releases it might be useful to have these in the same place so that we can quickly do the needful.

Added the brew formula as well as the arch user repository.

Some more notes:

AFAIK we can't do much about the Arch AUR besides flag it for update,
but we can submit pull requests for new brew formulas through the
homebrew-core repository.

