### PR TITLE
Add env variables for viper controlled vars

### DIFF
--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -81,6 +81,11 @@ func init() {
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
 	configPath := constants.MakeMiniPath("config")
+
+	// Bind all viper values to env variables
+	viper.SetEnvPrefix(constants.MinikubeEnvPrefix)
+	viper.AutomaticEnv()
+
 	viper.SetConfigName("config")
 	viper.AddConfigPath(configPath)
 	err := viper.ReadInConfig()

--- a/cmd/minikube/cmd/root_test.go
+++ b/cmd/minikube/cmd/root_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/tests"
 )
 
@@ -42,5 +44,18 @@ func TestPreRunDirectories(t *testing.T) {
 		if os.IsNotExist(err) {
 			t.Fatalf("Directory %s does not exist.", dir)
 		}
+	}
+}
+
+func getEnvVarName(name string) string {
+	return constants.MinikubeEnvPrefix + name
+}
+
+func TestEnvVariable(t *testing.T) {
+	defer os.Unsetenv("WANTUPDATENOTIFICATION")
+	initConfig()
+	os.Setenv(getEnvVarName("WANTUPDATENOTIFICATION"), "true")
+	if !viper.GetBool("WantUpdateNotification") {
+		t.Fatalf("Viper did not respect environment variable")
 	}
 }

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -39,6 +39,9 @@ var KubeconfigPath = clientcmd.RecommendedHomeFile
 // MinikubeContext is the kubeconfig context name used for minikube
 const MinikubeContext = "minikube"
 
+// MinikubeEnvPrefix is the prefix for the environmental variables
+const MinikubeEnvPrefix = "MINIKUBE"
+
 // MakeMiniPath is a utility to calculate a relative path to our directory.
 func MakeMiniPath(fileName ...string) string {
 	args := []string{Minipath}

--- a/pkg/minikube/notify/notify.go
+++ b/pkg/minikube/notify/notify.go
@@ -99,6 +99,7 @@ func getJson(url string, target *releases) error {
 
 func getLatestVersionFromURL(url string) (semver.Version, error) {
 	var releases releases
+	glog.Infof("Checking for updates...")
 	if err := getJson(url, &releases); err != nil {
 		return semver.Version{}, err
 	}


### PR DESCRIPTION
Minikube will now read from env variables with the MINIKUBE_ prefix.
These variables will be read on every viper.Get() and will overwrite default
variables.  When we add binding to pflags, flags will overwrite env
variables.  At this time, only notification settings are controlled by
viper.

This is a result of the discussion from #479

As a side note, this should be merged before #469.  That PR uses viper for many more commands and I'll have to make sure to write some additional tests and merge these changes into that.