### PR TITLE
Add registry-mirror option to minikube start

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -42,6 +42,7 @@ var (
 	vmDriver          string
 	dockerEnv         []string
 	insecureRegistry  []string
+	registryMirror    []string
 	kubernetesVersion string
 	hostOnlyCIDR      string
 )
@@ -68,6 +69,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		VMDriver:         vmDriver,
 		DockerEnv:        dockerEnv,
 		InsecureRegistry: insecureRegistry,
+		RegistryMirror:   registryMirror,
 		HostOnlyCIDR:     hostOnlyCIDR,
 	}
 	kubernetesConfig := cluster.KubernetesConfig{
@@ -174,6 +176,7 @@ func init() {
 	startCmd.Flags().StringVar(&hostOnlyCIDR, "host-only-cidr", "192.168.99.1/24", "The CIDR to be used for the minikube VM (only supported with Virtualbox driver)")
 	startCmd.Flags().StringSliceVar(&dockerEnv, "docker-env", nil, "Environment variables to pass to the Docker daemon. (format: key=value)")
 	startCmd.Flags().StringSliceVar(&insecureRegistry, "insecure-registry", nil, "Insecure Docker registries to pass to the Docker daemon")
+	startCmd.Flags().StringSliceVar(&registryMirror, "registry-mirror", nil, "Registry mirrors to pass to the Docker daemon")
 	startCmd.Flags().StringVar(&kubernetesVersion, "kubernetes-version", constants.DefaultKubernetesVersion, "The kubernetes version that the minikube VM will (ex: v1.2.3) \n OR a URI which contains a localkube binary (ex: https://storage.googleapis.com/minikube/k8sReleases/v1.3.0/localkube-linux-amd64)")
 	RootCmd.AddCommand(startCmd)
 }

--- a/docs/minikube_start.md
+++ b/docs/minikube_start.md
@@ -24,6 +24,7 @@ minikube start
       --kubernetes-version="v1.3.4": The kubernetes version that the minikube VM will (ex: v1.2.3) 
  OR a URI which contains a localkube binary (ex: https://storage.googleapis.com/minikube/k8sReleases/v1.3.0/localkube-linux-amd64)
       --memory=1024: Amount of RAM allocated to the minikube VM
+      --registry-mirror=[]: Registry mirrors to pass to the Docker daemon
       --vm-driver="virtualbox": VM driver is one of: [virtualbox vmwarefusion kvm xhyve]
 ```
 

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -157,6 +157,7 @@ type MachineConfig struct {
 	VMDriver         string
 	DockerEnv        []string // Each entry is formatted as KEY=VALUE.
 	InsecureRegistry []string
+	RegistryMirror   []string
 	HostOnlyCIDR     string // Only used by the virtualbox driver
 }
 
@@ -289,6 +290,7 @@ func engineOptions(config MachineConfig) *engine.Options {
 	o := engine.Options{
 		Env:              config.DockerEnv,
 		InsecureRegistry: config.InsecureRegistry,
+		RegistryMirror:   config.RegistryMirror,
 	}
 	return &o
 }


### PR DESCRIPTION
Allow using registry mirrors to speed up image download.