### PR TITLE
added debug logging for show-libmachine-logs

### DIFF
--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -56,6 +56,7 @@ var RootCmd = &cobra.Command{
 			}
 		}
 
+		log.SetDebug(showLibmachineLogs)
 		if !showLibmachineLogs {
 			log.SetOutWriter(ioutil.Discard)
 			log.SetErrWriter(ioutil.Discard)


### PR DESCRIPTION
This helped me debug the hyperv driver, thought I should add it here