### PR TITLE
Ensures that we get the same IP between start/delete

### DIFF
--- a/pkg/minikube/cluster/cluster_darwin.go
+++ b/pkg/minikube/cluster/cluster_darwin.go
@@ -22,6 +22,9 @@ import (
 	"k8s.io/minikube/pkg/minikube/constants"
 )
 
+// Ensures that we get assigned the same IP across deletes/starts
+const xhyveUUID = "57FD2012-FA4A-4FF7-AEFF-26E1A1D76847"
+
 func createVMwareFusionHost(config MachineConfig) drivers.Driver {
 	d := vmwarefusion.NewDriver(constants.MachineName, constants.Minipath).(*vmwarefusion.Driver)
 	d.Boot2DockerURL = config.GetISOFileURI()
@@ -64,5 +67,6 @@ func createXhyveHost(config MachineConfig) *xhyveDriver {
 		DiskSize:       int64(config.DiskSize),
 		Virtio9p:       true,
 		Virtio9pFolder: "/Users",
+		UUID:           xhyveUUID,
 	}
 }


### PR DESCRIPTION
The xhyve driver added support for the UUID flag in xhyve
https://github.com/zchee/docker-machine-driver-xhyve/pull/133

Fixes https://github.com/kubernetes/minikube/issues/516

It would be nice to add an integration test for this once (if) we can get this behavior with the other drivers.