### PR TITLE
Adding a driver check for existing machines

### DIFF
--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -79,6 +79,18 @@ func StartHost(api libmachine.API, config MachineConfig) (*host.Host, error) {
 	}
 
 	s, err := h.Driver.GetState()
+
+	// This is the name of the driver passed in
+	// through a flag, env, or config file (if any)
+	driverSpecified := config.VMDriver
+
+	// This is the name of the driver that is currently used with minikube
+	currentDriver := h.Driver.DriverName()
+
+	if driverSpecified != "" && driverSpecified != currentDriver {
+		return nil, fmt.Errorf("Error: Specified driver %s but there is already a machine configured with driver %s.  Please do a [minikube delete] then a [minikube start] to use these settings.", driverSpecified, currentDriver)
+	}
+
 	glog.Infoln("Machine state: ", s)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error getting state for host")


### PR DESCRIPTION
Not really sure if this the right way to fix this, but I thought I'd start a discussion.

This prevents minikube from silently falling back to the previously
configured driver instead of the one you've specified.

Right now, `minikube start` will silently fall back to an existing machine on subsequent calls.  For example, if you had previously run a `minikube start --vm-driver=virtualbox` then a `minikube start --vm-driver=kvm` would ignore the flag and restart the virtualbox based minikube.

On the flip side, this could be annoying if you run `minikube start --vm-driver=kvm` and then `minikube start` would give you an error text thinking that you meant to use the default (virtualbox).  Of course, this is slightly alleviated now that you can use a config or env var to specify your vm-driver.

nit: I used an os.Exit instead of a glog.Errorf because we run this function in a retry loop and it would print this message 3 times otherwise.

ref #519  not the underlying issue, but might have helped alert the user something was up