### PR TITLE
add https flag to minikube command for services that run over ssl/tls

### DIFF
--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/docker/machine/libmachine"
@@ -33,6 +34,7 @@ import (
 
 var (
 	namespace      string
+	https          bool
 	serviceURLMode bool
 )
 
@@ -63,6 +65,9 @@ var serviceCmd = &cobra.Command{
 			fmt.Fprintln(os.Stderr, "Check that minikube is running and that you have specified the correct namespace (-n flag).")
 			os.Exit(1)
 		}
+		if https {
+			url = strings.Replace(url, "http", "https", 1)
+		}
 		if serviceURLMode {
 			fmt.Fprintln(os.Stdout, url)
 		} else {
@@ -75,6 +80,7 @@ var serviceCmd = &cobra.Command{
 func init() {
 	serviceCmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "The service namespace")
 	serviceCmd.Flags().BoolVar(&serviceURLMode, "url", false, "Display the kubernetes service URL in the CLI instead of opening it in the default browser")
+	serviceCmd.Flags().BoolVar(&https, "https", false, "Open the service URL with https instead of http")
 	RootCmd.AddCommand(serviceCmd)
 }
 

--- a/docs/minikube_service.md
+++ b/docs/minikube_service.md
@@ -14,6 +14,7 @@ minikube service [flags] SERVICE
 ### Options
 
 ```
+      --https[=false]: Open the service URL with https instead of http
   -n, --namespace="default": The service namespace
       --url[=false]: Display the kubernetes service URL in the CLI instead of opening it in the default browser
 ```


### PR DESCRIPTION
This would allow users to run `minikube --https [service-name]` and have the browser use https instead of http.