### PR TITLE
Add a configurator that can be used to set arbitrary config values in Kubernetes components via flags.

### DIFF
--- a/cmd/localkube/cmd/options.go
+++ b/cmd/localkube/cmd/options.go
@@ -44,6 +44,7 @@ func NewLocalkubeServer() *localkube.LocalkubeServer {
 		ShouldGenerateCerts:      true,
 		ShowVersion:              false,
 		RuntimeConfig:            map[string]string{"api/all": "true"},
+		ExtraConfig:              util.ExtraOptionSlice{},
 	}
 }
 
@@ -65,6 +66,7 @@ func AddFlags(s *localkube.LocalkubeServer) {
 	flag.IPVar(&s.NodeIP, "node-ip", s.NodeIP, "IP address of the node. If set, kubelet will use this IP address for the node.")
 	flag.StringVar(&s.ContainerRuntime, "container-runtime", "", "The container runtime to be used")
 	flag.StringVar(&s.NetworkPlugin, "network-plugin", "", "The name of the network plugin")
+	flag.Var(&s.ExtraConfig, "extra-config", "A set of key=value pairs that describe configuration that may be passed to different components. The key should be '.' separated, and the first part before the dot is the component to apply the configuration to.")
 
 	// These two come from vendor/ packages that use flags. We should hide them
 	flag.CommandLine.MarkHidden("google-json-key")

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -50,6 +50,7 @@ var (
 	registryMirror   []string
 	dockerEnv        []string
 	insecureRegistry []string
+	extraOptions     util.ExtraOptionSlice
 )
 
 // startCmd represents the start command
@@ -102,6 +103,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		NodeIP:            ip,
 		ContainerRuntime:  viper.GetString(containerRuntime),
 		NetworkPlugin:     viper.GetString(networkPlugin),
+		ExtraOptions:      extraOptions,
 	}
 	if err := cluster.UpdateCluster(host, host.Driver, kubernetesConfig); err != nil {
 		glog.Errorln("Error updating cluster: ", err)
@@ -200,6 +202,10 @@ func init() {
 	startCmd.Flags().String(kubernetesVersion, constants.DefaultKubernetesVersion, "The kubernetes version that the minikube VM will (ex: v1.2.3) \n OR a URI which contains a localkube binary (ex: https://storage.googleapis.com/minikube/k8sReleases/v1.3.0/localkube-linux-amd64)")
 	startCmd.Flags().String(containerRuntime, "", "The container runtime to be used")
 	startCmd.Flags().String(networkPlugin, "", "The name of the network plugin")
+	startCmd.Flags().Var(&extraOptions, "extra-config",
+		`A set of key=value pairs that describe configuration that may be passed to different components.
+		The key should be '.' separated, and the first part before the dot is the component to apply the configuration to.
+		Valid components are: kubelet, apiserver, controller-manager, etcd, proxy, scheduler.`)
 	viper.BindPFlags(startCmd.Flags())
 	RootCmd.AddCommand(startCmd)
 }

--- a/docs/minikube_start.md
+++ b/docs/minikube_start.md
@@ -19,6 +19,9 @@ minikube start
       --cpus int                        Number of CPUs allocated to the minikube VM (default 1)
       --disk-size string                Disk size allocated to the minikube VM (format: <number>[<unit>], where unit = b, k, m or g) (default "20g")
       --docker-env stringSlice          Environment variables to pass to the Docker daemon. (format: key=value)
+      --extra-config ExtraOption        A set of key=value pairs that describe configuration that may be passed to different components.
+		The key should be '.' separated, and the first part before the dot is the component to apply the configuration to.
+		Valid components are: kubelet, apiserver, controller-manager, etcd, proxy, scheduler.
       --host-only-cidr string           The CIDR to be used for the minikube VM (only supported with Virtualbox driver) (default "192.168.99.1/24")
       --insecure-registry stringSlice   Insecure Docker registries to pass to the Docker daemon
       --iso-url string                  Location of the minikube iso (default "https://storage.googleapis.com/minikube/minikube-0.7.iso")

--- a/pkg/localkube/apiserver.go
+++ b/pkg/localkube/apiserver.go
@@ -59,6 +59,8 @@ func StartAPIServer(lk LocalkubeServer) func() error {
 
 	config.RuntimeConfig = lk.RuntimeConfig
 
+	lk.SetExtraConfigForComponent("apiserver", &config)
+
 	return func() error {
 		return apiserver.Run(config)
 	}

--- a/pkg/localkube/controller-manager.go
+++ b/pkg/localkube/controller-manager.go
@@ -41,6 +41,8 @@ func StartControllerManagerServer(lk LocalkubeServer) func() error {
 	config.ServiceAccountKeyFile = lk.GetPrivateKeyCertPath()
 	config.RootCAFile = lk.GetCAPublicKeyCertPath()
 
+	lk.SetExtraConfigForComponent("controller-manager", &config)
+
 	return func() error {
 		return controllerManager.Run(config)
 	}

--- a/pkg/localkube/etcd.go
+++ b/pkg/localkube/etcd.go
@@ -80,6 +80,8 @@ func (lk LocalkubeServer) NewEtcd(clientURLStrs, peerURLStrs []string, name, dat
 		ElectionTicks: 10,
 	}
 
+	lk.SetExtraConfigForComponent(EtcdName, &config)
+
 	return &EtcdServer{
 		config: config,
 	}, nil

--- a/pkg/localkube/kubelet.go
+++ b/pkg/localkube/kubelet.go
@@ -51,6 +51,7 @@ func StartKubeletServer(lk LocalkubeServer) func() error {
 	if lk.ContainerRuntime != "" {
 		config.ContainerRuntime = lk.ContainerRuntime
 	}
+	lk.SetExtraConfigForComponent("kubelet", &config)
 
 	// Use the host's resolver config
 	if lk.Containerized {

--- a/pkg/localkube/proxy.go
+++ b/pkg/localkube/proxy.go
@@ -44,6 +44,8 @@ func StartProxyServer(lk LocalkubeServer) func() error {
 	config.OOMScoreAdj = &OOMScoreAdj
 	config.IPTablesMasqueradeBit = &MasqueradeBit
 
+	lk.SetExtraConfigForComponent("proxy", &config)
+
 	server, err := kubeproxy.NewProxyServerDefault(config)
 	if err != nil {
 		panic(err)

--- a/pkg/localkube/scheduler.go
+++ b/pkg/localkube/scheduler.go
@@ -34,6 +34,8 @@ func StartSchedulerServer(lk LocalkubeServer) func() error {
 	// defaults from command
 	config.EnableProfiling = true
 
+	lk.SetExtraConfigForComponent("scheduler", &config)
+
 	return func() error {
 		return scheduler.Run(config)
 	}

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -192,11 +192,16 @@ type KubernetesConfig struct {
 	NodeIP            string
 	ContainerRuntime  string
 	NetworkPlugin     string
+	ExtraOptions      util.ExtraOptionSlice
 }
 
 // StartCluster starts a k8s cluster on the specified Host.
 func StartCluster(h sshAble, kubernetesConfig KubernetesConfig) error {
-	commands := []string{stopCommand, GetStartCommand(kubernetesConfig)}
+	startCommand, err := GetStartCommand(kubernetesConfig)
+	if err != nil {
+		return errors.Wrapf(err, "Error generating start command: %s", err)
+	}
+	commands := []string{stopCommand, startCommand}
 
 	for _, cmd := range commands {
 		glog.Infoln(cmd)

--- a/pkg/minikube/cluster/cluster_test.go
+++ b/pkg/minikube/cluster/cluster_test.go
@@ -88,11 +88,16 @@ func TestStartCluster(t *testing.T) {
 	}
 
 	err := StartCluster(h, kubernetesConfig)
+
 	if err != nil {
 		t.Fatalf("Error starting cluster: %s", err)
 	}
 
-	for _, cmd := range []string{stopCommand, GetStartCommand(kubernetesConfig)} {
+	startCommand, err := GetStartCommand(kubernetesConfig)
+	if err != nil {
+		t.Fatalf("Error getting start command: %s", err)
+	}
+	for _, cmd := range []string{stopCommand, startCommand} {
 		if _, ok := h.Commands[cmd]; !ok {
 			t.Fatalf("Expected command not run: %s. Commands run: %v", cmd, h.Commands)
 		}
@@ -108,6 +113,7 @@ func TestStartClusterError(t *testing.T) {
 	}
 
 	err := StartCluster(h, kubernetesConfig)
+
 	if err == nil {
 		t.Fatal("Error not thrown starting cluster.")
 	}

--- a/pkg/util/config_test.go
+++ b/pkg/util/config_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"math"
+	"testing"
+)
+
+type testConfig struct {
+	A string
+	B int
+	C float32
+	D subConfig1
+	E *subConfig2
+}
+
+type subConfig1 struct {
+	F string
+	G int
+	H float32
+	I subConfig3
+}
+
+type subConfig2 struct {
+	J string
+	K int
+	L float32
+}
+
+type subConfig3 struct {
+	M string
+	N int
+	O float32
+	P bool
+}
+
+func buildConfig() testConfig {
+	return testConfig{
+		A: "foo",
+		B: 1,
+		C: 1.1,
+		D: subConfig1{
+			F: "bar",
+			G: 2,
+			H: 2.2,
+			I: subConfig3{
+				M: "baz",
+				N: 3,
+				O: 3.3,
+			},
+		},
+		E: &subConfig2{
+			J: "bat",
+			K: 4,
+			L: 4.4,
+		},
+	}
+}
+
+func TestFindNestedStrings(t *testing.T) {
+	a := buildConfig()
+	for _, tc := range []struct {
+		input  string
+		output string
+	}{
+		{"A", "foo"},
+		{"D.F", "bar"},
+		{"D.I.M", "baz"},
+		{"E.J", "bat"},
+	} {
+		v, err := findNestedElement(tc.input, &a)
+		if err != nil {
+			t.Fatalf("Did not expect error. Got: %s", err)
+		}
+		if v.String() != tc.output {
+			t.Fatalf("Expected: %s, got %s", tc.output, v.String())
+		}
+	}
+}
+
+func TestFindNestedInts(t *testing.T) {
+	a := buildConfig()
+
+	for _, tc := range []struct {
+		input  string
+		output int64
+	}{
+		{"B", 1},
+		{"D.G", 2},
+		{"D.I.N", 3},
+		{"E.K", 4},
+	} {
+		v, err := findNestedElement(tc.input, &a)
+		if err != nil {
+			t.Fatalf("Did not expect error. Got: %s", err)
+		}
+		if v.Int() != tc.output {
+			t.Fatalf("Expected: %d, got %d", tc.output, v.Int())
+		}
+	}
+}
+
+func checkFloats(f1, f2 float64) bool {
+	return math.Abs(f1-f2) < .00001
+}
+
+func TestFindNestedFloats(t *testing.T) {
+	a := buildConfig()
+	for _, tc := range []struct {
+		input  string
+		output float64
+	}{
+		{"C", 1.1},
+		{"D.H", 2.2},
+		{"D.I.O", 3.3},
+		{"E.L", 4.4},
+	} {
+		v, err := findNestedElement(tc.input, &a)
+		if err != nil {
+			t.Fatalf("Did not expect error. Got: %s", err)
+		}
+
+		// Floating point comparison is tricky.
+		if !checkFloats(tc.output, v.Float()) {
+			t.Fatalf("Expected: %v, got %v", tc.output, v.Float())
+		}
+	}
+}
+
+func TestSetElement(t *testing.T) {
+	for _, tc := range []struct {
+		path    string
+		newval  string
+		checker func(testConfig) bool
+	}{
+		{"A", "newstring", func(t testConfig) bool { return t.A == "newstring" }},
+		{"B", "13", func(t testConfig) bool { return t.B == 13 }},
+		{"C", "3.14", func(t testConfig) bool { return checkFloats(float64(t.C), 3.14) }},
+		{"D.F", "fizzbuzz", func(t testConfig) bool { return t.D.F == "fizzbuzz" }},
+		{"D.G", "4", func(t testConfig) bool { return t.D.G == 4 }},
+		{"D.H", "7.3", func(t testConfig) bool { return checkFloats(float64(t.D.H), 7.3) }},
+		{"E.J", "otherstring", func(t testConfig) bool { return t.E.J == "otherstring" }},
+		{"E.K", "17", func(t testConfig) bool { return t.E.K == 17 }},
+		{"E.L", "1.234", func(t testConfig) bool { return checkFloats(float64(t.E.L), 1.234) }},
+		{"D.I.P", "true", func(t testConfig) bool { return bool(t.D.I.P) == true }},
+		{"D.I.P", "false", func(t testConfig) bool { return bool(t.D.I.P) == false }},
+	} {
+		a := buildConfig()
+		if err := FindAndSet(tc.path, &a, tc.newval); err != nil {
+			t.Fatalf("Error setting value: %s", err)
+		}
+		if !tc.checker(a) {
+			t.Fatalf("Error, values not correct: %v, %s, %s", a, tc.newval, tc.path)
+		}
+
+	}
+}

--- a/pkg/util/extra_options.go
+++ b/pkg/util/extra_options.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ExtraOption struct {
+	Component string
+	Key       string
+	Value     string
+}
+
+func (e *ExtraOption) String() string {
+	return fmt.Sprintf("%s.%s=%s", e.Component, e.Key, e.Value)
+}
+
+type ExtraOptionSlice []ExtraOption
+
+func (es *ExtraOptionSlice) Set(value string) error {
+	// The component is the value before the first dot.
+	componentSplit := strings.SplitN(value, ".", 2)
+	if len(componentSplit) < 2 {
+		return fmt.Errorf("Invalid value for ExtraOption flag. Value must contain at least one period: %s", value)
+	}
+
+	remainder := strings.Join(componentSplit[1:], "")
+
+	keySplit := strings.SplitN(remainder, "=", 2)
+	if len(keySplit) != 2 {
+		return fmt.Errorf("Invalid value for ExtraOption flag. Value must contain one equal sign: %s", value)
+	}
+
+	e := ExtraOption{
+		Component: componentSplit[0],
+		Key:       keySplit[0],
+		Value:     keySplit[1],
+	}
+	*es = append(*es, e)
+	return nil
+}
+
+func (es *ExtraOptionSlice) String() string {
+	s := []string{}
+	for _, e := range *es {
+		s = append(s, e.String())
+	}
+	return strings.Join(s, " ")
+}
+
+func (es *ExtraOptionSlice) Type() string {
+	return "ExtraOption"
+}

--- a/pkg/util/extra_options_test.go
+++ b/pkg/util/extra_options_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"flag"
+	"reflect"
+	"testing"
+)
+
+func TestInvalidFlags(t *testing.T) {
+	for _, tc := range [][]string{
+		{"-e", "foo"},
+		{"-e", "foo.bar"},
+		{"-e", "foo.bar.baz"},
+		{"-e", "foo=bar"},
+		{"-e", "foo=bar.baz"},
+		// Multiple flags
+		{"-e", "foo", "-e", "foo"},
+		{"-e", "foo", "-e", "foo", "-e", "foo"},
+		{"-e", "foo", "-e", "foo.bar=baz"},
+		{"-e", "foo", "-e", "foo.bar=baz"},
+	} {
+		var flags flag.FlagSet
+		flags.Init("test", flag.ContinueOnError)
+
+		var e ExtraOptionSlice
+		flags.Var(&e, "e", "usage")
+		if err := flags.Parse(tc); err == nil {
+			t.Errorf("Expected error, got nil: %s", tc)
+		}
+	}
+}
+
+func TestValidFlags(t *testing.T) {
+	for _, tc := range []struct {
+		args   []string
+		values ExtraOptionSlice
+	}{
+		{
+			[]string{"-e", "foo.bar=baz"},
+			ExtraOptionSlice{ExtraOption{Component: "foo", Key: "bar", Value: "baz"}},
+		},
+		{
+			[]string{"-e", "foo.bar.baz=bat"},
+			ExtraOptionSlice{ExtraOption{Component: "foo", Key: "bar.baz", Value: "bat"}},
+		},
+		{
+			[]string{"-e", "foo.bar=baz", "-e", "foo.bar.baz=bat"},
+			ExtraOptionSlice{ExtraOption{Component: "foo", Key: "bar", Value: "baz"}, ExtraOption{Component: "foo", Key: "bar.baz", Value: "bat"}},
+		},
+	} {
+		var flags flag.FlagSet
+		flags.Init("test", flag.ContinueOnError)
+
+		var e ExtraOptionSlice
+		flags.Var(&e, "e", "usage")
+		if err := flags.Parse(tc.args); err != nil {
+			t.Errorf("Unexpected error: %s for %s.", err, tc)
+		}
+
+		if !reflect.DeepEqual(e, tc.values) {
+			t.Errorf("Wrong parsed value. Expected %s, got %s", tc.values, e)
+		}
+	}
+}


### PR DESCRIPTION
This adds a few utilities and types:

- A config type useful for setting values on arbitrary structs. These values are given by paths as dot-separated strings and string values. The string values are coerced into whatever the type is required at the path before being set. For example:
`kubelet.foo.bar=bat` will be parsed as "set KubeletConfig.foo.bar to 'bat'.

- A flag type used to store these config maps in three parts:

1. The component (kubelet, apiserver, dns, etc.)
2. The path (foo.bar).
3 The value.

Minikube then parses these flags, and passes them along to localkube. This lets you set anything on localkube. To extend this in the future, we'd only need to add support for more types, not each new value. For example, we could add a `net.IP` parser to allow setting struct values as net.IP.