### PR TITLE
Enable host path provisioner

### DIFF
--- a/pkg/localkube/controller-manager.go
+++ b/pkg/localkube/controller-manager.go
@@ -34,6 +34,7 @@ func StartControllerManagerServer(lk LocalkubeServer) func() error {
 	config.DeletingPodsQps = 0.1
 	config.DeletingPodsBurst = 10
 	config.EnableProfiling = true
+	config.VolumeConfiguration.EnableHostPathProvisioning = true
 	config.ServiceAccountKeyFile = lk.GetPrivateKeyCertPath()
 	config.RootCAFile = lk.GetCAPublicKeyCertPath()
 


### PR DESCRIPTION
With the addition of PVC dynamic provisioners the Host Path Provisioner was added for cases just like MiniKube. Users can now test their deployments with ephemeral volumes locally and leverage persistent disks when using a cloud provider.

In the [kubernetes/charts project](https://github.com/kubernetes/charts) we are moving to a model that allows charts to have persistence enabled by default. In the 1.4 timeframe, GCE, AWS and Host Path are supported. As chart maintainers and creators, we would like to be able to test charts using minikube when possible.