### PR TITLE
Use double brackets instead of single for boilerplate script

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -56,7 +56,7 @@ BOILERPLATEDIR=./hack/boilerplate
 set +e
 files=$(${PYTHON} ${BOILERPLATEDIR}/boilerplate.py --rootdir . --boilerplate-dir ${BOILERPLATEDIR} | grep -v $ignore)
 set -e
-if [ ! -z ${files} ]; then
+if [[ ! -z ${files} ]]; then
 	echo "Boilerplate missing in: ${files}."
 	exit 1
 fi


### PR DESCRIPTION
If you have multiple files without the boilerplate text, single
brackets won't print it out properly.  

Test - make two files without boilerplate

then from your minikube directory

`if [ ! -z $(python ./hack/boilerplate/boilerplate.py --rootdir . --boilerplate-dir ./hack/boilerplate) ]; then echo "1"; fi`

`if [[ ! -z $(python ./hack/boilerplate/boilerplate.py --rootdir . --boilerplate-dir ./hack/boilerplate) ]]; then echo "1"; fi`

Single bracket:
```
Checking boilerplate...
./test.sh: line 59: [: ././cmd/minikube/cmd/test1.go: binary operator expected
```

Double
```
Boilerplate missing in: ././cmd/minikube/cmd/test1.go
././cmd/minikube/cmd/test2.go.
```
