### PR TITLE
Add a log level threshold to libmachine debug logs

### DIFF
--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -70,8 +70,9 @@ var RootCmd = &cobra.Command{
 		}
 
 		shouldShowLibmachineLogs := viper.GetBool(showLibmachineLogs)
-
-		log.SetDebug(shouldShowLibmachineLogs)
+		if glog.V(3) {
+			log.SetDebug(true)
+		}
 		if !shouldShowLibmachineLogs {
 			log.SetOutWriter(ioutil.Discard)
 			log.SetErrWriter(ioutil.Discard)


### PR DESCRIPTION
Anything over v=3 will trigger debug level logging when
show-libmachine-logs is also enabled.

Probably the lowest friction way to control the verbosity of libmachine for now