### PR TITLE
Refactor config env var test and add string replacer for automatic env

### DIFF
--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	goflag "flag"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/docker/machine/libmachine/log"
 	"github.com/golang/glog"
@@ -129,6 +130,9 @@ func initConfig() {
 
 func setupViper() {
 	viper.SetEnvPrefix(constants.MinikubeEnvPrefix)
+	// Replaces '-' in flags with '_' in env variables
+	// e.g. show-libmachine-logs => $ENVPREFIX_SHOW_LIBMACHINE_LOGS
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
 
 	viper.SetDefault(config.WantUpdateNotification, true)


### PR DESCRIPTION
- Changes - to _ for environmental variables built from flags (show-libmachine-logs, disk-size, etc.)

- Additionally, one of these tests is a little broken - this one test would fail if you had certain environment variables set because its testing environment variables.  The hacky solution is to just temporarily unset them and then defer reset them.  

Let me know if anyone has a better idea on how to mock these out 