### PR TITLE
Make soft link of minikube into $GOPATH/bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ MINIKUBEFILES := go list  -f '{{join .Deps "\n"}}' ./cmd/minikube/ | grep k8s.io
 
 out/minikube: out/minikube-$(GOOS)-$(GOARCH)
 	cp $(BUILD_DIR)/minikube-$(GOOS)-$(GOARCH) $(BUILD_DIR)/minikube
+	ln -s $(BUILD_DIR)/minikube $(GOPATH)/bin/minikube
 
 out/localkube: $(shell $(LOCALKUBEFILES))
 	$(MKGOPATH)


### PR DESCRIPTION
As I found that minikube binary is created at `./out/minikube` path on `make` command which forces developer to run as `./out/minikube <command>`, creating a soft link would be good approach to get it directly after `make`  command.

My workflow now:
```
➜  minikube git:(master) ✗ make
if [ ! -e /home/budhram/gowork/src/k8s.io/minikube/_gopath/src/k8s.io ]; then mkdir -p /home/budhram/gowork/src/k8s.io/minikube/_gopath/src/k8s.io && ln -s -f /home/budhram/gowork/src/k8s.io/minikube /home/budhram/gowork/src/k8s.io/minikube/_gopath/src/k8s.io; fi
CGO_ENABLED=0 go build -ldflags="-X k8s.io/minikube/vendor/k8s.io/kubernetes/pkg/version.gitCommit=b0deb2eb8f4037421077f77cb163dbb4c0a2a9f5 -X k8s.io/minikube/vendor/k8s.io/kubernetes/pkg/version.gitVersion=v1.3.5 -X k8s.io/minikube/vendor/k8s.io/kubernetes/pkg/version.gitTreeState=dirty -X k8s.io/minikube/pkg/version.version=v0.9.0 -s -w -extldflags '-static'" -o ./out/localkube ./cmd/localkube
if [ ! -e /home/budhram/gowork/src/k8s.io/minikube/_gopath/src/k8s.io ]; then mkdir -p /home/budhram/gowork/src/k8s.io/minikube/_gopath/src/k8s.io && ln -s -f /home/budhram/gowork/src/k8s.io/minikube /home/budhram/gowork/src/k8s.io/minikube/_gopath/src/k8s.io; fi
GOBIN=/home/budhram/gowork/src/k8s.io/minikube/_gopath/bin go get github.com/jteeuwen/go-bindata/...
/home/budhram/gowork/src/k8s.io/minikube/_gopath/bin/go-bindata -nomemcopy -o pkg/minikube/cluster/assets.go -pkg cluster ./out/localkube deploy/iso/addon-manager.yaml deploy/addons/dashboard-rc.yaml deploy/addons/dashboard-svc.yaml
if [ ! -e /home/budhram/gowork/src/k8s.io/minikube/_gopath/src/k8s.io ]; then mkdir -p /home/budhram/gowork/src/k8s.io/minikube/_gopath/src/k8s.io && ln -s -f /home/budhram/gowork/src/k8s.io/minikube /home/budhram/gowork/src/k8s.io/minikube/_gopath/src/k8s.io; fi
CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build --installsuffix cgo -ldflags="-X k8s.io/minikube/pkg/version.version=v0.9.0" -a -o ./out/minikube-linux-amd64 ./cmd/minikube
cp ./out/minikube-linux-amd64 ./out/minikube
ln -s ./out/minikube /home/budhram/gowork/src/k8s.io/minikube/_gopath/bin/minikube

➜  minikube git:(master) ✗ which minikube
~/gowork/bin/minikube

➜  minikube git:(master) ✗ minikube version
minikube version: v0.9.0
```