### PR TITLE
add archlinux PKGBUILD

### DIFF
--- a/installers/linux/PKGBUILD
+++ b/installers/linux/PKGBUILD
@@ -1,0 +1,26 @@
+# vim: ts=2 sts=2 sw=2 et ft=sh
+# Maintainer: 
+
+pkgname=minikube
+pkgver=0.9.0
+pkgrel=1
+pkgdesc="Minikube is a tool that makes it easy to run Kubernetes locally"
+url="https://github.com/kubernetes/minikube"
+license=('Apache')
+arch=('x86_64')
+depends=(
+  'virtualbox'
+)
+optdepends=(
+  'kubectl-bin: to manage the cluster'
+)
+makedepends=()
+
+source=(minikube_$pkgver::https://storage.googleapis.com/minikube/releases/v$pkgver/minikube-linux-amd64)
+sha512sums=('64f3cdb666dad72f1939497b3b0a3fb9943c54a185a76d5db2858fd935a15c634dbf31c90bdc55ab00b70cec33b83fd88c139e4b2645533a774ae56e01d24c19')
+
+package() {
+  cd "$srcdir"
+  install -d "$pkgdir/usr/bin"
+  install -m755 minikube_$pkgver "$pkgdir/usr/bin/minikube"
+}


### PR DESCRIPTION
As discussed with @r2d4 about moving the home of the PKGBUILD for https://aur.archlinux.org/packages/minikube/ to this repo.