### PR TITLE
Only pass the --node-ip flag to localkube if specified

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -44,6 +44,7 @@ const (
 	hostOnlyCIDR          = "host-only-cidr"
 	containerRuntime      = "container-runtime"
 	networkPlugin         = "network-plugin"
+	nodeIP                = "node-ip"
 )
 
 var (
@@ -92,14 +93,9 @@ func runStart(cmd *cobra.Command, args []string) {
 		util.MaybeReportErrorAndExit(err)
 	}
 
-	ip, err := host.Driver.GetIP()
-	if err != nil {
-		glog.Errorln("Error starting host: ", err)
-		util.MaybeReportErrorAndExit(err)
-	}
 	kubernetesConfig := cluster.KubernetesConfig{
 		KubernetesVersion: viper.GetString(kubernetesVersion),
-		NodeIP:            ip,
+		NodeIP:            viper.GetString(nodeIP),
 		ContainerRuntime:  viper.GetString(containerRuntime),
 		NetworkPlugin:     viper.GetString(networkPlugin),
 	}

--- a/pkg/localkube/kubelet.go
+++ b/pkg/localkube/kubelet.go
@@ -41,7 +41,9 @@ func StartKubeletServer(lk LocalkubeServer) func() error {
 	config.ClusterDomain = lk.DNSDomain
 	config.ClusterDNS = lk.DNSIP.String()
 
-	config.NodeIP = lk.NodeIP.String()
+	if lk.NodeIP.String() != "" {
+		config.NodeIP = lk.NodeIP.String()
+	}
 
 	if lk.NetworkPlugin != "" {
 		config.NetworkPluginName = lk.NetworkPlugin

--- a/pkg/minikube/cluster/commands.go
+++ b/pkg/minikube/cluster/commands.go
@@ -29,7 +29,7 @@ var stopCommand = "sudo killall localkube || true"
 
 var startCommandFmtStr = `
 # Run with nohup so it stays up. Redirect logs to useful places.
-sudo sh -c 'PATH=/usr/local/sbin:$PATH nohup /usr/local/bin/localkube %s --generate-certs=false --logtostderr=true --node-ip=%s > %s 2> %s < /dev/null & echo $! > %s &'
+sudo sh -c 'PATH=/usr/local/sbin:$PATH nohup /usr/local/bin/localkube %s --generate-certs=false --logtostderr=true > %s 2> %s < /dev/null & echo $! > %s &'
 `
 var logsCommand = fmt.Sprintf("tail -n +1 %s %s", constants.RemoteLocalKubeErrPath, constants.RemoteLocalKubeOutPath)
 
@@ -39,6 +39,10 @@ func GetStartCommand(kubernetesConfig KubernetesConfig) string {
 		if logVal := gflag.Lookup(logFlag); logVal != nil && logVal.Value.String() != logVal.DefValue {
 			flagVals = append(flagVals, fmt.Sprintf("--%s %s", logFlag, logVal.Value.String()))
 		}
+	}
+
+	if kubernetesConfig.NodeIP != "" {
+		flagVals = append(flagVals, "--node-ip="+kubernetesConfig.NodeIP)
 	}
 
 	if kubernetesConfig.ContainerRuntime != "" {
@@ -54,7 +58,6 @@ func GetStartCommand(kubernetesConfig KubernetesConfig) string {
 	return fmt.Sprintf(
 		startCommandFmtStr,
 		flags,
-		kubernetesConfig.NodeIP,
 		constants.RemoteLocalKubeErrPath,
 		constants.RemoteLocalKubeOutPath,
 		constants.LocalkubePIDPath,


### PR DESCRIPTION
Since previous versions of kubernetes don't know about the node-ip
flag, if we always pass it in, then it will break those versions.

ref https://github.com/kubernetes/minikube/issues/599