### PR TITLE
Genericized caching for localkube binary and minikube iso

### DIFF
--- a/pkg/util/cache.go
+++ b/pkg/util/cache.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+)
+
+type FileCache interface {
+	GetFile(CacheItem) (*os.File, error)
+	SetFile(CacheItem, *[]byte) error
+}
+
+type CacheItem struct {
+	FilePath string
+	URL      string
+	ShaURL   string
+}
+
+type DiskCache struct{}
+
+func (d *DiskCache) GetFile(c CacheItem) (*os.File, error) {
+	if c.isFileCached() {
+		return os.Open(c.FilePath)
+	}
+
+	urlObj, err := url.Parse(c.URL)
+	if err != nil {
+		glog.Errorf("Error parsing URI: %v", err)
+	}
+
+	// No need to cache if its a local file
+	if urlObj.Scheme == "file" {
+		return os.Open(c.URL)
+	}
+
+	data, err := c.getFromURL()
+	if err != nil {
+		return nil, err
+	}
+
+	if !c.isSha256ValidFromURL(&data) {
+		glog.Warningf("Warning: Unable to verify checksum of file %s", c.FilePath)
+	}
+
+	err = d.SetFile(c, data)
+	if err != nil {
+		return nil, err
+	}
+
+	return os.Open(c.FilePath)
+}
+
+func (d *DiskCache) SetFile(c CacheItem, b []byte) error {
+	os.MkdirAll(path.Dir(c.FilePath), 0777)
+	out, err := os.Create(c.FilePath)
+	if err != nil {
+		return errors.Wrapf(err, "Error caching file %s", c.FilePath)
+	}
+	defer out.Close()
+	_, err = out.Write(b)
+	if err != nil {
+		return errors.Wrapf(err, "Error writing to cache %s", c.FilePath)
+	}
+	return nil
+}
+
+func (c *CacheItem) isSha256ValidFromURL(data *[]byte) bool {
+	r, err := http.Get(c.ShaURL)
+	if err != nil {
+		glog.Infof("Error downloading checksum: %s", err)
+		return false
+	} else if r.StatusCode != http.StatusOK {
+		glog.Infof("Error downloading checksum. Got HTTP Error: %s", r.Status)
+		return false
+	}
+
+	defer r.Body.Close()
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		glog.Errorf("Error reading checksum: %s", err)
+		return false
+	}
+
+	expectedSum := strings.Trim(string(body), "\n")
+
+	b := sha256.Sum256(*data)
+	actualSum := hex.EncodeToString(b[:])
+	if string(expectedSum) != actualSum {
+		glog.Infof("Downloaded checksum does not match expected value. Actual: %s. Expected: %s", actualSum, expectedSum)
+		return false
+	}
+	return true
+}
+
+func (c *CacheItem) getFromURL() ([]byte, error) {
+	response, err := http.Get(c.URL)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error getting file at %s via http", c.URL)
+	}
+
+	data, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error getting file at %s via http", c.URL)
+	}
+
+	return data, nil
+}
+
+func (c *CacheItem) isFileCached() bool {
+	if _, err := os.Stat(c.FilePath); os.IsNotExist(err) {
+		return false
+	}
+
+	return true
+}

--- a/pkg/util/cache_test.go
+++ b/pkg/util/cache_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"strings"
+	"testing"
+)
+
+type httpHandler struct{}
+
+// The test HTTP handler returns the request url path
+// or the sha256 of the request url path if .sha256 is the suffix
+func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if strings.HasSuffix(r.URL.Path, ".sha256") {
+		spl := strings.Split(r.URL.Path, ".")
+		b := sha256.Sum256([]byte(spl[0]))
+		actualSum := hex.EncodeToString(b[:])
+		w.Write([]byte(actualSum))
+	} else {
+		w.Write([]byte(r.URL.Path))
+	}
+}
+
+func setupFakeServer() *httptest.Server {
+	handler := &httpHandler{}
+	return httptest.NewServer(handler)
+}
+
+func TestChecksumValidation(t *testing.T) {
+	server := setupFakeServer()
+	defer server.Close()
+
+	var checksumTests = []struct {
+		c       CacheItem
+		data    []byte
+		isValid bool
+	}{
+		{
+			CacheItem{
+				ShaURL: server.URL + "/test1.sha256",
+			},
+			[]byte("/test1"),
+			true,
+		},
+		{
+			CacheItem{
+				URL:    server.URL + "/test2",
+				ShaURL: server.URL + "/incorrect_sha.sha256",
+			},
+			[]byte("/test2"),
+			false,
+		},
+	}
+	for _, test := range checksumTests {
+		valid := test.c.isSha256ValidFromURL(&test.data)
+		if valid && !test.isValid {
+			t.Errorf("Checksum validation returned true when actually false %v", test)
+
+		}
+		if !valid && test.isValid {
+			t.Errorf("Checksum validation failed even though was valid %v", test)
+		}
+	}
+}
+
+func TestGetCachedFile(t *testing.T) {
+	s := setupFakeServer()
+	defer s.Close()
+	dir, _ := ioutil.TempDir("", "")
+	defer os.RemoveAll(dir)
+
+	d := DiskCache{}
+
+	cacheTests := []CacheItem{
+		{
+			FilePath: path.Join(dir, "testfile"),
+			URL:      s.URL + "/testfile",
+			ShaURL:   s.URL + "/testfile.sha256",
+		},
+		{
+			FilePath: path.Join(dir, "testfile2"),
+			URL:      s.URL + "/testfile2",
+			ShaURL:   "incorrect sha but should still cache",
+		},
+	}
+	for _, c := range cacheTests {
+		f, err := d.GetFile(c)
+		defer f.Close()
+		if err != nil {
+			t.Errorf("Error caching file, %v", err)
+		}
+		var b []byte
+		f.Read(b)
+		data := strings.Split(c.URL, "/")
+		if data[1] != string(b) {
+			t.Errorf("Contents of cached file were incorrect, expected %s, got %s", data[1], string(b))
+		}
+	}
+}


### PR DESCRIPTION
This also adds checksum checking for localkube versions.  We will need
to upload an additional localkube-linux-amd64.sha256 file as we do for
the iso releases.

ref #599 #602 