### PR TITLE
Add a test for checking SHAs.

### DIFF
--- a/deploy/minikube/release_sanity_test.go
+++ b/deploy/minikube/release_sanity_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package minikube
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/notify"
+)
+
+const (
+	downloadURL = "https://storage.googleapis.com/minikube/releases/%s/minikube-%s-amd64%s"
+)
+
+func getDownloadURL(version, platform string) string {
+	switch platform {
+	case "windows":
+		return fmt.Sprintf(downloadURL, version, platform, ".exe")
+	default:
+		return fmt.Sprintf(downloadURL, version, platform, "")
+	}
+}
+
+func getShaFromURL(url string) (string, error) {
+	fmt.Println("Downloading: ", url)
+	r, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer r.Body.Close()
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return "", err
+	}
+
+	b := sha256.Sum256(body)
+	return hex.EncodeToString(b[:]), nil
+}
+
+func TestReleasesJson(t *testing.T) {
+	releases, err := notify.GetAllVersionsFromURL(constants.GithubMinikubeReleasesURL)
+	if err != nil {
+		t.Fatalf("Error getting releases.json: %s", err)
+	}
+
+	for _, r := range releases {
+		fmt.Printf("Checking release: %s\n", r.Name)
+		for platform, sha := range r.Checksums {
+			fmt.Printf("Checking SHA for %s.\n", platform)
+			actualSha, err := getShaFromURL(getDownloadURL(r.Name, platform))
+			if err != nil {
+				t.Errorf("Error calcuating SHA for %s-%s. Error: %s", r.Name, platform, err)
+			}
+			if actualSha != sha {
+				t.Errorf("ERROR: SHA does not match for version %s, platform %s. Expected %s, got %s.", r.Name, platform, sha, actualSha)
+			}
+		}
+	}
+}

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -64,6 +64,7 @@ const (
 	DefaultVMDriver     = "virtualbox"
 	DefaultStatusFormat = "minikubeVM: {{.MinikubeStatus}}\n" +
 		"localkube: {{.LocalkubeStatus}}\n"
+	GithubMinikubeReleasesURL = "https://storage.googleapis.com/minikube/releases.json"
 )
 
 var DefaultKubernetesVersion = version.Get().GitVersion

--- a/pkg/minikube/notify/notify_test.go
+++ b/pkg/minikube/notify/notify_test.go
@@ -68,7 +68,7 @@ func TestShouldCheckURL(t *testing.T) {
 }
 
 type URLHandlerCorrect struct {
-	releases releases
+	releases Releases
 }
 
 func (h *URLHandlerCorrect) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -85,7 +85,7 @@ func TestGetLatestVersionFromURLCorrect(t *testing.T) {
 	// test that the version is correctly parsed if returned if valid JSON is returned the url endpoint
 	latestVersionFromURL := "0.0.0-dev"
 	handler := &URLHandlerCorrect{
-		releases: []release{{Name: version.VersionPrefix + latestVersionFromURL}},
+		releases: []Release{{Name: version.VersionPrefix + latestVersionFromURL}},
 	}
 	server := httptest.NewServer(handler)
 
@@ -146,9 +146,10 @@ func TestMaybePrintUpdateText(t *testing.T) {
 	// test that no update text is printed if the latest version is lower/equal to the current version
 	latestVersionFromURL := "0.0.0-dev"
 	handler := &URLHandlerCorrect{
-		releases: []release{{Name: version.VersionPrefix + latestVersionFromURL}},
+		releases: []Release{{Name: version.VersionPrefix + latestVersionFromURL}},
 	}
 	server := httptest.NewServer(handler)
+	defer server.Close()
 
 	MaybePrintUpdateText(&outputBuffer, server.URL, lastUpdateCheckFilePath)
 	if len(outputBuffer.String()) != 0 {
@@ -159,9 +160,10 @@ func TestMaybePrintUpdateText(t *testing.T) {
 	// test that update text is printed if the latest version is greater than the current version
 	latestVersionFromURL = "100.0.0-dev"
 	handler = &URLHandlerCorrect{
-		releases: []release{{Name: version.VersionPrefix + latestVersionFromURL}},
+		releases: []Release{{Name: version.VersionPrefix + latestVersionFromURL}},
 	}
 	server = httptest.NewServer(handler)
+	defer server.Close()
 
 	MaybePrintUpdateText(&outputBuffer, server.URL, lastUpdateCheckFilePath)
 	if len(outputBuffer.String()) == 0 {


### PR DESCRIPTION
Minor refactor of notify.go to share logic for downloading/parsing the releases.json.