### PR TITLE
Add v1.4.0 k8s release, remove v1.4.0-beta.10

### DIFF
--- a/deploy/minikube/k8s_releases.json
+++ b/deploy/minikube/k8s_releases.json
@@ -1,6 +1,6 @@
 [
   {
-    "version": "v1.4.0-beta.10"
+    "version": "v1.4.0"
   },
   {
     "version": "v1.3.7"


### PR DESCRIPTION
We should do this programmatically as part of finishing the automation for @minikube-bot

ref #629 should be merged first, but not necessary as the v1.4.0 localkube binary is already published