### PR TITLE
README: add anchor for rkt container instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ Stopping local Kubernetes cluster...
 Stopping "minikube"...
 ```
 
-To use [rkt](https://github.com/coreos/rkt) as the container runtime, execute:
+### Using rkt container engine
+
+To use [rkt](https://github.com/coreos/rkt) as the container runtime run:
 
 ```shell
 $ minikube start \


### PR DESCRIPTION
I want to link to this part of the doc from [this blog post](https://tectonic.com/blog/minikube-and-rkt.html) and need a header anchor to do that.