### PR TITLE
Save minikube options on create

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -25,13 +25,21 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"k8s.io/minikube/pkg/minikube/cluster"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/util"
 )
 
 type configFile interface {
 	io.ReadWriter
 }
+
+const (
+	kubernetesVersion = "kubernetes-version"
+	containerRuntime  = "container-runtime"
+	networkPlugin     = "network-plugin"
+)
 
 type setFn func(string, string) error
 
@@ -152,6 +160,16 @@ func WriteConfig(m config.MinikubeConfig) error {
 		return fmt.Errorf("Error encoding config %s: %s", constants.ConfigFile, err)
 	}
 	return nil
+}
+
+// Writes the kubernetes config parameters in `minikube start`
+// to the config file
+func SaveKubernetesConfig(k cluster.KubernetesConfig) error {
+	m := util.MultiError{}
+	m.Collect(Set(kubernetesVersion, k.KubernetesVersion))
+	m.Collect(Set(containerRuntime, k.ContainerRuntime))
+	m.Collect(Set(networkPlugin, k.NetworkPlugin))
+	return m.ToError()
 }
 
 func encode(w io.Writer, m config.MinikubeConfig) error {

--- a/pkg/minikube/cluster/cluster_test.go
+++ b/pkg/minikube/cluster/cluster_test.go
@@ -52,7 +52,7 @@ func TestCreateHost(t *testing.T) {
 	if exists {
 		t.Fatal("Machine already exists.")
 	}
-	_, err := createHost(api, defaultMachineConfig)
+	_, err := CreateHost(api, defaultMachineConfig)
 	if err != nil {
 		t.Fatalf("Error creating host: %v", err)
 	}
@@ -125,7 +125,7 @@ func TestStartClusterError(t *testing.T) {
 func TestStartHostExists(t *testing.T) {
 	api := tests.NewMockAPI()
 	// Create an initial host.
-	_, err := createHost(api, defaultMachineConfig)
+	_, err := CreateHost(api, defaultMachineConfig)
 	if err != nil {
 		t.Fatalf("Error creating host: %v", err)
 	}
@@ -158,7 +158,7 @@ func TestStartHostExists(t *testing.T) {
 func TestStartStoppedHost(t *testing.T) {
 	api := tests.NewMockAPI()
 	// Create an initial host.
-	h, err := createHost(api, defaultMachineConfig)
+	h, err := CreateHost(api, defaultMachineConfig)
 	if err != nil {
 		t.Fatalf("Error creating host: %v", err)
 	}
@@ -189,13 +189,13 @@ func TestStartStoppedHost(t *testing.T) {
 	}
 }
 
-func TestStartHost(t *testing.T) {
+func TestCreateHostProvision(t *testing.T) {
 	api := tests.NewMockAPI()
 
 	md := &tests.MockDetector{Provisioner: &tests.MockProvisioner{}}
 	provision.SetDetector(md)
 
-	h, err := StartHost(api, defaultMachineConfig)
+	h, err := CreateHost(api, defaultMachineConfig)
 	if err != nil {
 		t.Fatal("Error starting host.")
 	}
@@ -216,7 +216,7 @@ func TestStartHost(t *testing.T) {
 	}
 }
 
-func TestStartHostConfig(t *testing.T) {
+func TestCreateHostConfig(t *testing.T) {
 	api := tests.NewMockAPI()
 
 	md := &tests.MockDetector{Provisioner: &tests.MockProvisioner{}}
@@ -227,7 +227,7 @@ func TestStartHostConfig(t *testing.T) {
 		DockerEnv: []string{"FOO=BAR"},
 	}
 
-	h, err := StartHost(api, config)
+	h, err := CreateHost(api, config)
 	if err != nil {
 		t.Fatal("Error starting host.")
 	}
@@ -248,7 +248,7 @@ func TestStopHostError(t *testing.T) {
 
 func TestStopHost(t *testing.T) {
 	api := tests.NewMockAPI()
-	h, _ := createHost(api, defaultMachineConfig)
+	h, _ := CreateHost(api, defaultMachineConfig)
 	if err := StopHost(api); err != nil {
 		t.Fatal("An error should be thrown when stopping non-existing machine.")
 	}
@@ -259,7 +259,7 @@ func TestStopHost(t *testing.T) {
 
 func TestDeleteHost(t *testing.T) {
 	api := tests.NewMockAPI()
-	createHost(api, defaultMachineConfig)
+	CreateHost(api, defaultMachineConfig)
 
 	if err := DeleteHost(api); err != nil {
 		t.Fatalf("Unexpected error deleting host: %s", err)
@@ -268,7 +268,7 @@ func TestDeleteHost(t *testing.T) {
 
 func TestDeleteHostErrorDeletingVM(t *testing.T) {
 	api := tests.NewMockAPI()
-	h, _ := createHost(api, defaultMachineConfig)
+	h, _ := CreateHost(api, defaultMachineConfig)
 
 	d := &tests.MockDriver{RemoveError: true}
 
@@ -282,7 +282,7 @@ func TestDeleteHostErrorDeletingVM(t *testing.T) {
 func TestDeleteHostErrorDeletingFiles(t *testing.T) {
 	api := tests.NewMockAPI()
 	api.RemoveError = true
-	createHost(api, defaultMachineConfig)
+	CreateHost(api, defaultMachineConfig)
 
 	if err := DeleteHost(api); err == nil {
 		t.Fatal("Expected error deleting host.")
@@ -292,7 +292,7 @@ func TestDeleteHostErrorDeletingFiles(t *testing.T) {
 func TestDeleteHostMultipleErrors(t *testing.T) {
 	api := tests.NewMockAPI()
 	api.RemoveError = true
-	h, _ := createHost(api, defaultMachineConfig)
+	h, _ := CreateHost(api, defaultMachineConfig)
 
 	d := &tests.MockDriver{RemoveError: true}
 
@@ -327,7 +327,7 @@ func TestGetHostStatus(t *testing.T) {
 
 	checkState("Does Not Exist")
 
-	createHost(api, defaultMachineConfig)
+	CreateHost(api, defaultMachineConfig)
 	checkState(state.Running.String())
 
 	StopHost(api)
@@ -410,7 +410,7 @@ func TestGetHostDockerEnv(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	api := tests.NewMockAPI()
-	h, err := createHost(api, defaultMachineConfig)
+	h, err := CreateHost(api, defaultMachineConfig)
 	if err != nil {
 		t.Fatalf("Error creating host: %v", err)
 	}
@@ -443,7 +443,7 @@ func TestGetHostDockerEnvIPv6(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	api := tests.NewMockAPI()
-	h, err := createHost(api, defaultMachineConfig)
+	h, err := CreateHost(api, defaultMachineConfig)
 	if err != nil {
 		t.Fatalf("Error creating host: %v", err)
 	}


### PR DESCRIPTION
This commit saves the minikube options specified on create of a VM.  In
order to do this, cluster.StartHost was split into two separate
functions - StartHost and CreateHost instead of having responsibility
for both.  In addition, this also refactors the log messages for start.

TBD 
- What should be the behavior of `minikube delete` wrt to the config?  Right now, it leaves the config as is, but it could also be made to delete the config by default or with a flag.
- Its a little awkward that the settings related to localkube (kubernetes-version, cni, container-runtime) are written directly<sup>[1](https://github.com/r2d4/minikube/blob/edfec2df9af7a670ac4b90cc114e54365f3a2aac/cmd/minikube/cmd/start.go#L134-L136)</sup> because they can be modified without a VM restart.  Suggestions welcome on not doing it like its grossly proposed here. 

for log messages, fixes #486 
