### PR TITLE
Set default log_dir to ~/.minikube/logs

### DIFF
--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -42,6 +42,7 @@ var dirs = [...]string{
 	constants.MakeMiniPath("cache", "localkube"),
 	constants.MakeMiniPath("config"),
 	constants.MakeMiniPath("addons"),
+	constants.MakeMiniPath("logs"),
 }
 
 const (
@@ -106,6 +107,7 @@ func setFlagsUsingViper() {
 		// Viper will give precedence first to calls to the Set command,
 		// then to values from the config.yml
 		a.Value.Set(viper.GetString(a.Name))
+		a.Changed = true
 	}
 }
 
@@ -114,6 +116,10 @@ func init() {
 	RootCmd.AddCommand(configCmd.ConfigCmd)
 	RootCmd.AddCommand(configCmd.AddonsCmd)
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+	logDir := pflag.Lookup("log_dir")
+	if !logDir.Changed {
+		logDir.Value.Set(constants.MakeMiniPath("logs"))
+	}
 	viper.BindPFlags(RootCmd.PersistentFlags())
 	cobra.OnInitialize(initConfig)
 }


### PR DESCRIPTION
A hack around specifying the default log dir for glog.  Since we can't
set it without modifying the flag, we check if the flag has been
changed.  If not, we set it to our default value.

fixes https://github.com/kubernetes/minikube/issues/468

The logDir variable is not exported in glog, so the only way to set a default is to set the flag directly if it hasn't been changed. https://github.com/golang/glog/blob/master/glog_file.go#L41

Since we wouldn't be storing these in `/tmp` anymore, its something to note that the default max size in glog is https://github.com/golang/glog/blob/master/glog_file.go#L34 but we can configure that if we want.