### PR TITLE
WIP: Enable dynamic host path provisioning as default storage class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,8 @@ integration: out/minikube
 test: $(GOPATH)/src/$(ORG) pkg/minikube/assets/assets.go
 	./test.sh
 
-pkg/minikube/assets/assets.go: out/localkube $(GOPATH)/bin/go-bindata deploy/iso/addon-manager.yaml deploy/addons/dashboard-rc.yaml deploy/addons/dashboard-svc.yaml
-	$(GOPATH)/bin/go-bindata -nomemcopy -o pkg/minikube/assets/assets.go -pkg assets ./out/localkube deploy/iso/addon-manager.yaml deploy/addons/dashboard-rc.yaml deploy/addons/dashboard-svc.yaml
+pkg/minikube/assets/assets.go: out/localkube $(GOPATH)/bin/go-bindata deploy/iso/addon-manager.yaml deploy/addons/dashboard-rc.yaml deploy/addons/dashboard-svc.yaml deploy/addons/hostpath-storageclass.yaml
+	$(GOPATH)/bin/go-bindata -nomemcopy -o pkg/minikube/assets/assets.go -pkg assets ./out/localkube deploy/iso/addon-manager.yaml deploy/addons/dashboard-rc.yaml deploy/addons/dashboard-svc.yaml deploy/addons/hostpath-storageclass.yaml
 
 $(GOPATH)/bin/go-bindata: $(GOPATH)/src/$(ORG)
 	GOBIN=$(GOPATH)/bin go get github.com/jteeuwen/go-bindata/...

--- a/deploy/addons/hostpath-storageclass.yaml
+++ b/deploy/addons/hostpath-storageclass.yaml
@@ -1,0 +1,9 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: hostpath
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "true"
+  labels:
+    kubernetes.io/cluster-service: "true"
+provisioner: kubernetes.io/host-path

--- a/deploy/iso/addon-manager.yaml
+++ b/deploy/iso/addon-manager.yaml
@@ -8,7 +8,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-addon-manager
-    image: gcr.io/google-containers/kube-addon-manager-amd64:v2
+    image: gcr.io/google-containers/kube-addon-manager-amd64:v5.2
     resources:
       requests:
         cpu: 5m

--- a/deploy/iso/bootlocal.sh
+++ b/deploy/iso/bootlocal.sh
@@ -21,8 +21,9 @@ PARTNAME=`echo "$BOOT2DOCKER_DATA" | sed 's/.*\///'`
 mkdir -p /mnt/$PARTNAME/var/lib/localkube
 ln -s /mnt/$PARTNAME/var/lib/localkube /var/lib/localkube
 
-mkdir -p /mnt/$PARTNAME/data
+mkdir -p /mnt/$PARTNAME/data/hostpath_pv
 ln -s /mnt/$PARTNAME/data /data
+ln -s /mnt/$PARTNAME/data/hostpath_pv /tmp/hostpath_pv
 
 mkdir -p /mnt/$PARTNAME/var/lib/kubelet
 ln -s /mnt/$PARTNAME/var/lib/kubelet /var/lib/kubelet

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -74,6 +74,13 @@ var Addons = map[string]*Addon{
 			"dashboard-svc.yaml",
 			"0640"),
 	}, true, "dashboard"),
+	"hostpath-storageclass": NewAddon([]*MemoryAsset{
+		NewMemoryAsset(
+			"deploy/addons/hostpath-storageclass.yaml",
+			constants.AddonsPath,
+			"hostpath-storageclass.yaml",
+			"0640"),
+	}, true, "hostpath-storageclass"),
 }
 
 func AddMinikubeAddonsDirToAssets(assetList *[]CopyableFile) {


### PR DESCRIPTION
This enables users to just specify PVCs & host paths will be created & bound dynamically.

Requires a release of addon-manager - see kubernetes/kubernetes#34639
