### PR TITLE
Fix docker-env integration test

### DIFF
--- a/test/integration/docker_env_test.go
+++ b/test/integration/docker_env_test.go
@@ -33,7 +33,9 @@ func TestDockerEnv(t *testing.T) {
 		T:          t}
 
 	minikubeRunner.RunCommand("delete", true)
-	minikubeRunner.RunCommand("start --docker-env=FOO=BAR --docker-env=BAZ=BAT", true)
+
+	startCmd := fmt.Sprintf("start %s %s", minikubeRunner.Args, "--docker-env=FOO=BAR --docker-env=BAZ=BAT")
+	minikubeRunner.RunCommand(startCmd, true)
 	minikubeRunner.EnsureRunning()
 
 	profileContents := minikubeRunner.RunCommand("ssh cat /var/lib/boot2docker/profile", true)


### PR DESCRIPTION
Make sure that --minikube-args are passed through to the start command
in our docker-env integration test

This test has been falling back to the default (virtualbox) on xhyve integration tests