### PR TITLE
Add format flag to service command

### DIFF
--- a/cmd/minikube/cmd/dashboard.go
+++ b/cmd/minikube/cmd/dashboard.go
@@ -24,7 +24,7 @@ import (
 	"github.com/docker/machine/libmachine"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
-	cmdUtil "k8s.io/minikube/cmd/util"
+	cmdutil "k8s.io/minikube/cmd/util"
 	"k8s.io/minikube/pkg/minikube/cluster"
 	"k8s.io/minikube/pkg/minikube/constants"
 
@@ -49,15 +49,15 @@ var dashboardCmd = &cobra.Command{
 		service := "kubernetes-dashboard"
 
 		if err := commonutil.RetryAfter(20, func() error { return CheckService(namespace, service) }, 6*time.Second); err != nil {
-			fmt.Fprintln(os.Stderr, "Could not find finalized endpoint being pointed to by %s: %s", service, err)
-			cmdUtil.MaybeReportErrorAndExit(err)
+			fmt.Fprintf(os.Stderr, "Could not find finalized endpoint being pointed to by %s: %s\n", service, err)
+			cmdutil.MaybeReportErrorAndExit(err)
 		}
 
-		url, err := cluster.GetServiceURL(api, namespace, service)
+		url, err := cluster.GetServiceURL(api, namespace, service, nil)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			fmt.Fprintln(os.Stderr, "Check that minikube is running.")
-			cmdUtil.MaybeReportErrorAndExit(err)
+			cmdutil.MaybeReportErrorAndExit(err)
 		}
 		if dashboardURLMode {
 			fmt.Fprintln(os.Stdout, url)

--- a/docs/minikube_service.md
+++ b/docs/minikube_service.md
@@ -14,6 +14,7 @@ minikube service [flags] SERVICE
 ### Options
 
 ```
+      --format string      Format to output service URL in (default "http://{{.IP}}:{{.Port}}")
       --https              Open the service URL with https instead of http
   -n, --namespace string   The service namespace (default "default")
       --url                Display the kubernetes service URL in the CLI instead of opening it in the default browser


### PR DESCRIPTION
This allows to add more to the returned URL path, to change scheme (or drop scheme altogether
as we needed for some Docker client integration), etc. Defaults to same previous template,
`http://ip:port`.