### PR TITLE
Add option to specify network name for KVM.

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -47,6 +47,7 @@ const (
 	containerRuntime      = "container-runtime"
 	networkPlugin         = "network-plugin"
 	hypervVirtualSwitch   = "hyperv-virtual-switch"
+	kvmNetwork            = "kvm-network"
 )
 
 var (
@@ -81,6 +82,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		RegistryMirror:      registryMirror,
 		HostOnlyCIDR:        viper.GetString(hostOnlyCIDR),
 		HypervVirtualSwitch: viper.GetString(hypervVirtualSwitch),
+		KvmNetwork:          viper.GetString(kvmNetwork),
 	}
 
 	var host *host.Host
@@ -206,7 +208,8 @@ func init() {
 	startCmd.Flags().Int(cpus, constants.DefaultCPUS, "Number of CPUs allocated to the minikube VM")
 	startCmd.Flags().String(humanReadableDiskSize, constants.DefaultDiskSize, "Disk size allocated to the minikube VM (format: <number>[<unit>], where unit = b, k, m or g)")
 	startCmd.Flags().String(hostOnlyCIDR, "192.168.99.1/24", "The CIDR to be used for the minikube VM (only supported with Virtualbox driver)")
-	startCmd.Flags().String(hypervVirtualSwitch, "", "The hyperv virtual switch name. Defaults to first found. (only supported with  driver)")
+	startCmd.Flags().String(hypervVirtualSwitch, "", "The hyperv virtual switch name. Defaults to first found. (only supported with HyperV driver)")
+	startCmd.Flags().String(kvmNetwork, "default", "The KVM network name. (only supported with KVM driver)")
 	startCmd.Flags().StringSliceVar(&dockerEnv, "docker-env", nil, "Environment variables to pass to the Docker daemon. (format: key=value)")
 	startCmd.Flags().StringSliceVar(&insecureRegistry, "insecure-registry", nil, "Insecure Docker registries to pass to the Docker daemon")
 	startCmd.Flags().StringSliceVar(&registryMirror, "registry-mirror", nil, "Registry mirrors to pass to the Docker daemon")

--- a/docs/minikube_start.md
+++ b/docs/minikube_start.md
@@ -23,11 +23,12 @@ minikube start
 		The key should be '.' separated, and the first part before the dot is the component to apply the configuration to.
 		Valid components are: kubelet, apiserver, controller-manager, etcd, proxy, scheduler.
       --host-only-cidr string          The CIDR to be used for the minikube VM (only supported with Virtualbox driver) (default "192.168.99.1/24")
-      --hyperv-virtual-switch string   The hyperv virtual switch name. Defaults to first found. (only supported with  driver)
+      --hyperv-virtual-switch string   The hyperv virtual switch name. Defaults to first found. (only supported with HyperV driver)
       --insecure-registry value        Insecure Docker registries to pass to the Docker daemon (default [])
       --iso-url string                 Location of the minikube iso (default "https://storage.googleapis.com/minikube/minikube-0.7.iso")
       --kubernetes-version string      The kubernetes version that the minikube VM will (ex: v1.2.3) 
  OR a URI which contains a localkube binary (ex: https://storage.googleapis.com/minikube/k8sReleases/v1.3.0/localkube-linux-amd64) (default "v1.4.3")
+      --kvm-network string             The KVM network name. (only supported with KVM driver) (default "default")
       --memory int                     Amount of RAM allocated to the minikube VM (default 2048)
       --network-plugin string          The name of the network plugin
       --registry-mirror value          Registry mirrors to pass to the Docker daemon (default [])

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -189,6 +189,7 @@ type MachineConfig struct {
 	RegistryMirror      []string
 	HostOnlyCIDR        string // Only used by the virtualbox driver
 	HypervVirtualSwitch string
+	KvmNetwork          string // Only used by the KVM driver
 }
 
 // KubernetesConfig contains the parameters used to configure the VM Kubernetes.

--- a/pkg/minikube/cluster/cluster_linux.go
+++ b/pkg/minikube/cluster/cluster_linux.go
@@ -47,7 +47,7 @@ func createKVMHost(config MachineConfig) *kvmDriver {
 		},
 		Memory:         config.Memory,
 		CPU:            config.CPUs,
-		Network:        "default",
+		Network:        config.KvmNetwork,
 		PrivateNetwork: "docker-machines",
 		Boot2DockerURL: config.GetISOFileURI(),
 		DiskSize:       config.DiskSize,


### PR DESCRIPTION
The allows for another network name to be specified. Useful when the network "default" doesn't exist or has different usage.

Still defaults to "default".

Usage, the network in this case is `NAT` instead of `default`:
```
minikube start --vm-driver kvm --kvm-network NAT
```