### PR TITLE
Increase retries for persistence test, add logging

### DIFF
--- a/test/integration/persistence_test.go
+++ b/test/integration/persistence_test.go
@@ -48,7 +48,7 @@ func TestPersistence(t *testing.T) {
 
 	checkPod := func() error {
 		p := kubectlRunner.GetPod(podName, podNamespace)
-		if util.IsPodReady(p) {
+		if kubectlRunner.IsPodReady(p) {
 			return nil
 		}
 		return &commonutil.RetriableError{Err: fmt.Errorf("Pod %s is not ready yet.", podName)}
@@ -68,7 +68,7 @@ func TestPersistence(t *testing.T) {
 			return &commonutil.RetriableError{Err: fmt.Errorf("No pods found matching query: %v", cmd)}
 		}
 		db := pods.Items[0]
-		if util.IsPodReady(&db) {
+		if kubectlRunner.IsPodReady(&db) {
 			return nil
 		}
 		return &commonutil.RetriableError{Err: fmt.Errorf("Dashboard pod is not ready yet.")}
@@ -76,7 +76,7 @@ func TestPersistence(t *testing.T) {
 
 	// Make sure the dashboard is running before we stop the VM.
 	// On slow networks it can take several minutes to pull the addon-manager then the dashboard image.
-	if err := commonutil.RetryAfter(20, checkDashboard, 6*time.Second); err != nil {
+	if err := commonutil.RetryAfter(30, checkDashboard, 6*time.Second); err != nil {
 		t.Fatalf("Dashboard pod is not healthy: %s", err)
 	}
 

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -31,8 +31,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/machine/libmachine/log"
-
 	"k8s.io/kubernetes/pkg/api"
 	commonutil "k8s.io/minikube/pkg/util"
 )
@@ -43,17 +41,17 @@ type MinikubeRunner struct {
 	Args       string
 }
 
-func IsPodReady(p *api.Pod) bool {
+func (k *KubectlRunner) IsPodReady(p *api.Pod) bool {
 	for _, cond := range p.Status.Conditions {
 		if cond.Type == "Ready" {
 			if cond.Status == "True" {
 				return true
 			}
-			log.Debugf("Pod %s not ready. Ready: %s. Reason: %s", p.Name, cond.Status, cond.Reason)
+			k.T.Logf("Pod %s not ready. Ready: %s. Reason: %s", p.Name, cond.Status, cond.Reason)
 			return false /**/
 		}
 	}
-	log.Debugf("Unable to find ready pod condition: %v", p.Status.Conditions)
+	k.T.Logf("Unable to find ready pod condition: %v", p.Status.Conditions)
 	return false
 }
 
@@ -141,7 +139,7 @@ func (k *KubectlRunner) RunCommand(args []string) (stdout []byte, err error) {
 		cmd := exec.Command(k.BinaryPath, args...)
 		stdout, err = cmd.CombinedOutput()
 		if err != nil {
-			log.Errorf("Error %s running command %s. Return code: %s", stdout, args, err)
+			k.T.Logf("Error %s running command %s. Return code: %s", stdout, args, err)
 			return &commonutil.RetriableError{Err: fmt.Errorf("Error running command. Error  %s. Output: %s", err, stdout)}
 		}
 		return nil


### PR DESCRIPTION
Bumped up the retries for persistence test, because I think we might need to wait a little longer once we start adding kube-dns as a cluster addon (#738)

(flake here https://storage.googleapis.com/minikube-builds/logs/738/OSX-Virtualbox.txt)

Additionally, I changed the logging messages to the test context instead of libmachine/logs for the pod ready helper function


