### PR TITLE
Add hyperv as a supported driver in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ the following drivers:
 * vmwarefusion
 * kvm ([driver installation](./DRIVERS.md#kvm-driver))
 * xhyve ([driver installation](./DRIVERS.md#xhyve-driver))
+* hyperv
 
 Note that the IP below is dynamic and can change. It can be retrieved with `minikube ip`.
 


### PR DESCRIPTION
Minikube has support for Hyper-V as VM driver on Windows but it was not listed in supported drivers in the list of drivers in README. This change fixes that.