### PR TITLE
fix usage of errors.Wrap()

### DIFF
--- a/cmd/minikube/cmd/env.go
+++ b/cmd/minikube/cmd/env.go
@@ -106,12 +106,12 @@ func shellCfgSet(api libmachine.API) (*ShellConfig, error) {
 
 		host, err := api.Load(constants.MachineName)
 		if err != nil {
-			return nil, errors.Wrap(err, "Error getting IP: ")
+			return nil, errors.Wrap(err, "Error getting IP")
 		}
 
 		ip, err := host.Driver.GetIP()
 		if err != nil {
-			return nil, errors.Wrap(err, "Error getting host IP: %s")
+			return nil, errors.Wrap(err, "Error getting host IP")
 		}
 
 		noProxyVar, noProxyValue := findNoProxyFromEnv()

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -95,7 +95,7 @@ func StartHost(api libmachine.API, config MachineConfig) (*host.Host, error) {
 	}
 
 	if err := h.ConfigureAuth(); err != nil {
-		return nil, errors.Wrap(&util.RetriableError{Err: err}, "Error configuring auth on host: %s")
+		return nil, errors.Wrap(&util.RetriableError{Err: err}, "Error configuring auth on host")
 	}
 	return h, nil
 }
@@ -418,7 +418,7 @@ func createHost(api libmachine.API, config MachineConfig) (*host.Host, error) {
 
 	h, err := api.NewHost(config.VMDriver, data)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error creating new host: %s")
+		return nil, errors.Wrap(err, "Error creating new host")
 	}
 
 	h.HostOptions.AuthOptions.CertDir = constants.Minipath


### PR DESCRIPTION
Format strings are not supported by errors.Wrap, so cleanup
them from error output where it is not needed.

This improves error messages like below:
```console
$ minikube start --docker-env HTTP_PROXY=$http_proxy --docker-env HTTPS_PROXY=$https_proxy --vm-driver xhyve
Starting local Kubernetes cluster...
E1028 14:14:32.812638   29731 start.go:90] Error starting host: Error creating new host: %s: Driver "xhyve" not found. Do you have the plugin binary accessible in your PATH?. Retrying.
```