### PR TITLE
Added check for kubectl to each command (in root.go)  This prompts user

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -109,6 +109,10 @@ var settings = []Setting{
 		set:  SetBool,
 	},
 	{
+		name: config.WantKubectlDownloadMsg,
+		set:  SetBool,
+	},
+	{
 		name:        "dashboard",
 		set:         SetBool,
 		validations: []setFn{IsValidAddon},

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -28,6 +28,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	configCmd "k8s.io/minikube/cmd/minikube/cmd/config"
+	"k8s.io/minikube/cmd/util"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/notify"
@@ -51,6 +52,7 @@ const (
 
 var (
 	enableUpdateNotification = true
+	enableKubectlDownloadMsg = true
 )
 
 var viperWhiteList = []string{
@@ -82,6 +84,9 @@ var RootCmd = &cobra.Command{
 
 		if enableUpdateNotification {
 			notify.MaybePrintUpdateTextFromGithub(os.Stdout)
+		}
+		if enableKubectlDownloadMsg {
+			util.MaybePrintKubectlDownloadMsg()
 		}
 	},
 }
@@ -147,5 +152,6 @@ func setupViper() {
 	viper.SetDefault(config.ReminderWaitPeriodInHours, 24)
 	viper.SetDefault(config.WantReportError, false)
 	viper.SetDefault(config.WantReportErrorPrompt, true)
+	viper.SetDefault(config.WantKubectlDownloadMsg, true)
 	setFlagsUsingViper()
 }

--- a/docs/minikube_config.md
+++ b/docs/minikube_config.md
@@ -21,6 +21,7 @@ Configurable fields:
  * ReminderWaitPeriodInHours
  * WantReportError
  * WantReportErrorPrompt
+ * WantKubectlDownloadMsg
  * dashboard
  * addon-manager
  * kube-dns

--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -31,6 +31,7 @@ const (
 	ReminderWaitPeriodInHours = "ReminderWaitPeriodInHours"
 	WantReportError           = "WantReportError"
 	WantReportErrorPrompt     = "WantReportErrorPrompt"
+	WantKubectlDownloadMsg    = "WantKubectlDownloadMsg"
 )
 
 type configFile interface {


### PR DESCRIPTION
with kubectl install one-liner for latest kubectl version.  Also added
config for enable/disable.  Still need to add tests.

Ref: #762 