### PR TITLE
Update used dashboard version to 1.4.2

### DIFF
--- a/deploy/addons/dashboard-rc.yaml
+++ b/deploy/addons/dashboard-rc.yaml
@@ -19,24 +19,24 @@ metadata:
   namespace: kube-system
   labels:
     app: kubernetes-dashboard
-    version: v1.4.0
+    version: v1.4.2
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
   selector:
     app: kubernetes-dashboard
-    version: v1.4.0
+    version: v1.4.2
     kubernetes.io/cluster-service: "true"
   template:
     metadata:
       labels:
         app: kubernetes-dashboard
-        version: v1.4.0
+        version: v1.4.2
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.4.0
+        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.4.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9090


### PR DESCRIPTION
Dashboard 1.4.2 contains a fix for an XSS security bug, so I think it would be prudent to update the Dashboard version 'shipped' with minikube to this version