### PR TITLE
Increase waiting time for integration tests

### DIFF
--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -65,7 +65,7 @@ func TestAddons(t *testing.T) {
 		return &commonutil.RetriableError{Err: fmt.Errorf("Addon manager not found. Found pods: %v", pods)}
 	}
 
-	if err := commonutil.RetryAfter(20, checkAddon, 5*time.Second); err != nil {
+	if err := commonutil.RetryAfter(25, checkAddon, 20*time.Second); err != nil {
 		t.Fatalf("Addon Manager pod is unhealthy: %s", err)
 	}
 }

--- a/test/integration/persistence_test.go
+++ b/test/integration/persistence_test.go
@@ -76,7 +76,7 @@ func TestPersistence(t *testing.T) {
 
 	// Make sure the dashboard is running before we stop the VM.
 	// On slow networks it can take several minutes to pull the addon-manager then the dashboard image.
-	if err := commonutil.RetryAfter(30, checkDashboard, 6*time.Second); err != nil {
+	if err := commonutil.RetryAfter(25, checkDashboard, 20*time.Second); err != nil {
 		t.Fatalf("Dashboard pod is not healthy: %s", err)
 	}
 


### PR DESCRIPTION
There have been flakes on the integration tests where the dashboard pod has been getting ready but the test does not wait long enough and fails.