### PR TITLE
Use correct binary name in .deb package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ out/minikube_$(DEB_VERSION).deb: out/minikube-linux-amd64
 	chmod 0755 out/minikube_$(DEB_VERSION)/DEBIAN
 	sed -E -i 's/--VERSION--/'$(DEB_VERSION)'/g' out/minikube_$(DEB_VERSION)/DEBIAN/control
 	mkdir -p out/minikube_$(DEB_VERSION)/usr/bin
-	cp out/minikube-linux-amd64 out/minikube_$(DEB_VERSION)/usr/bin
+	cp out/minikube-linux-amd64 out/minikube_$(DEB_VERSION)/usr/bin/minikube
 	dpkg-deb --build out/minikube_$(DEB_VERSION)
 	rm -rf out/minikube_$(DEB_VERSION)
 


### PR DESCRIPTION
Before this change, the binary was named `minikube-linux-amd64`,
which is the platform specific artifact name.

When installed through the .deb package, a user expects to have
the `minikube` directly on the `$PATH`.

This change populates the binary as `minikube` in the resulting .deb file.