### PR TITLE
Added info for using KVM driver on Fedora

### DIFF
--- a/DRIVERS.md
+++ b/DRIVERS.md
@@ -23,9 +23,12 @@ $ sudo curl -L https://github.com/dhiltgen/docker-machine-kvm/releases/download/
 $ sudo chmod +x /usr/local/bin/docker-machine-driver-kvm
 
 # Install libvirt and qemu-kvm on your system, e.g.
+# Debian/Ubuntu
 $ sudo apt install libvirt-bin qemu-kvm
+# Fedora/CentOS/RHEL
+$ sudo yum install libvirt-daemon-kvm kvm
 
-# Add yourself to the libvirtd group (may vary by linux distro) so you don't need to sudo
+# Add yourself to the libvirtd group (use libvirt group for rpm based distros) so you don't need to sudo
 $ sudo usermod -a -G libvirtd $(whoami)
 
 # Update your current session for the group change to take effect


### PR DESCRIPTION
Just a few lines to install KVM for people on rpm distros.

May need more debugging as one of my Fedora 25 systems wouldn't start but my laptop (also f25) worked without a problem.