### PR TITLE
Retry for configureAuth on minikube start

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	units "github.com/docker/go-units"
 	"github.com/docker/machine/libmachine"
@@ -89,11 +90,11 @@ func runStart(cmd *cobra.Command, args []string) {
 	start := func() (err error) {
 		host, err = cluster.StartHost(api, config)
 		if err != nil {
-			glog.Errorf("Error starting host: %s. Retrying.\n", err)
+			glog.Errorf("Error starting host: %s.\n\n Retrying.\n", err)
 		}
 		return err
 	}
-	err := util.Retry(3, start)
+	err := util.RetryAfter(5, start, 2*time.Second)
 	if err != nil {
 		glog.Errorln("Error starting host: ", err)
 		cmdUtil.MaybeReportErrorAndExit(err)

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -95,7 +95,7 @@ func StartHost(api libmachine.API, config MachineConfig) (*host.Host, error) {
 	}
 
 	if err := h.ConfigureAuth(); err != nil {
-		return nil, errors.Wrap(&util.RetriableError{Err: err}, "Error configuring auth on host")
+		return nil, &util.RetriableError{Err: errors.Wrap(err, "Error configuring auth on host")}
 	}
 	return h, nil
 }


### PR DESCRIPTION
Sometimes the docker daemon isn't ready and on a restart and libmachine
times out while trying to reach it.  This retries when it isn't ready.

This fixes timeout problems in our virtualbox integration tests.