### PR TITLE
Make virtualbox optional dependency for arch linux installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 _obj
 _test
 
+#Don't ignore arch linux .SRCINFO
+!.SRCINFO
+
 # Architecture specific extensions/prefixes
 *.[568vq]
 [568vq].out

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "installers/linux/archlinux/minikube"]
-	name = archlinux
-	path = installers/linux/archlinux/minikube
-	url = https://aur.archlinux.org/minikube.git

--- a/installers/linux/archlinux/.SRCINFO
+++ b/installers/linux/archlinux/.SRCINFO
@@ -1,0 +1,16 @@
+pkgbase = minikube
+	pkgdesc = Minikube is a tool that makes it easy to run Kubernetes locally
+	pkgver = 0.12.2
+	pkgrel = 1
+	url = https://github.com/kubernetes/minikube
+	arch = x86_64
+	license = Apache
+	depends = net-tools
+	optdepends = virtualbox
+	optdepends = docker-machine-kvm
+	optdepends = kubectl-bin: to manage the cluster
+	source = minikube_0.12.2::https://storage.googleapis.com/minikube/releases/v0.12.2/minikube-linux-amd64
+	sha512sums = 35444b1d867f07cca40337d09e0a8f58313c6ddf85214d84d087ca9fdf803ebe6a23e69b98776e08e40916feb62fe4a052c4afeb7dde3ffc71e03d0233bb7409
+
+pkgname = minikube
+

--- a/installers/linux/archlinux/PKGBUILD
+++ b/installers/linux/archlinux/PKGBUILD
@@ -1,0 +1,28 @@
+# vim: ts=2 sts=2 sw=2 et ft=sh
+# Maintainer: Matt Rickard <mrick@google.com> 
+
+pkgname=minikube
+pkgver=0.12.2
+pkgrel=1
+pkgdesc="Minikube is a tool that makes it easy to run Kubernetes locally"
+url="https://github.com/kubernetes/minikube"
+license=('Apache')
+arch=('x86_64')
+depends=(
+  'net-tools'
+)
+optdepends=(
+  'kubectl-bin: to manage the cluster'
+  'virtualbox'
+  'docker-machine-kvm'
+)
+makedepends=()
+
+source=(minikube_$pkgver::https://storage.googleapis.com/minikube/releases/v$pkgver/minikube-linux-amd64)
+sha512sums=('35444b1d867f07cca40337d09e0a8f58313c6ddf85214d84d087ca9fdf803ebe6a23e69b98776e08e40916feb62fe4a052c4afeb7dde3ffc71e03d0233bb7409')
+
+package() {
+  cd "$srcdir"
+  install -d "$pkgdir/usr/bin"
+  install -m755 minikube_$pkgver "$pkgdir/usr/bin/minikube"
+}


### PR DESCRIPTION

> appelgriebsch commented on 2016-11-17 05:44
> Please make virtualbox an optional dependency. Minikube also works well with kvm as hypervisor. I just created a docker-machine-kvm AUR package to address the missing docker-machine driver for it. You might refer to this package as optional dependency as well. ;)



https://aur.archlinux.org/packages/minikube/