### PR TITLE
Only copy over the files we need from test bucket

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This script downloads the test files from the build bucket and makes some executable.
+
+# The script expects the following env variabls:
+# OS_ARCH: The operating system and the architecture separated by a hyphen '-' (e.g. darwin-amd64, linux-amd64, windows-amd64)
+
+
+# Copy only the files we need to this workspace
+mkdir -p out/ testdata/
+gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/minikube-${OS_ARCH} out/
+gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/e2e-${OS_ARCH} out/
+gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/testdata/busybox.yaml testdata/
+
+# Set the executible bit on the e2e binary and out binary
+chmod +x out/e2e-${OS_ARCH}
+chmod +x out/minikube-${OS_ARCH}
+

--- a/hack/jenkins/linux_integration_tests_kvm.sh
+++ b/hack/jenkins/linux_integration_tests_kvm.sh
@@ -25,23 +25,19 @@
 
 set -e
 
-# Copy only the files we need to this workspace
-mkdir -p out/
-gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/minikube-linux-amd64 out/
-gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/e2e-linux-amd64 out/
-gsutil cp -r gs://minikube-builds/${MINIKUBE_LOCATION}/testdata .
+OS_ARCH="linux-amd64"
 
-chmod +x out/e2e-linux-amd64
-chmod +x out/minikube-linux-amd64
+# Download files and set permissions
+source common.sh
 
 MINIKUBE_WANTREPORTERRORPROMPT=False \
-	./out/minikube-linux-amd64 delete || true
+	./out/minikube-${OS_ARCH} delete || true
     
 rm -rf $HOME/.minikube || true
 
 # Allow this to fail, we'll switch on the return code below.
 set +e
-out/e2e-linux-amd64 -minikube-args="--vm-driver=kvm --cpus=4 --show-libmachine-logs --v=100 ${EXTRA_BUILD_ARGS}" -test.v -test.timeout=30m -binary=out/minikube-linux-amd64
+out/e2e-${OS_ARCH} -minikube-args="--vm-driver=kvm --cpus=4 --show-libmachine-logs --v=100 ${EXTRA_BUILD_ARGS}" -test.v -test.timeout=30m -binary=out/minikube-${OS_ARCH}
 result=$?
 set -e
 

--- a/hack/jenkins/linux_integration_tests_virtualbox.sh
+++ b/hack/jenkins/linux_integration_tests_virtualbox.sh
@@ -25,24 +25,20 @@
 
 set -e
 
-# Copy only the files we need to this workspace
-mkdir -p out/
-gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/minikube-linux-amd64 out/
-gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/e2e-linux-amd64 out/
-gsutil cp -r gs://minikube-builds/${MINIKUBE_LOCATION}/testdata .
+OS_ARCH="linux-amd64"
 
-chmod +x out/e2e-linux-amd64
-chmod +x out/minikube-linux-amd64
+# Download files and set permissions
+source common.sh
 
 MINIKUBE_WANTREPORTERRORPROMPT=False \
-	./out/minikube-linux-amd64 delete || true
+	./out/minikube-${OS_ARCH} delete || true
     
 rm -rf $HOME/.minikube || true
 rm -rf $HOME/.docker || true
 
 # Allow this to fail, we'll switch on the return code below.
 set +e
-out/e2e-linux-amd64 -minikube-args="--vm-driver=virtualbox --cpus=4 --show-libmachine-logs --v=100 ${EXTRA_BUILD_ARGS}" -test.v -test.timeout=30m -binary=out/minikube-linux-amd64
+out/e2e-${OS_ARCH} -minikube-args="--vm-driver=virtualbox --cpus=4 --show-libmachine-logs --v=100 ${EXTRA_BUILD_ARGS}" -test.v -test.timeout=30m -binary=out/minikube-${OS_ARCH}
 result=$?
 set -e
 

--- a/hack/jenkins/osx_integration_tests_virtualbox.sh
+++ b/hack/jenkins/osx_integration_tests_virtualbox.sh
@@ -25,17 +25,17 @@
 
 
 set -e
-chmod +x out/e2e-darwin-amd64
-chmod +x out/minikube-darwin-amd64
-cp -r out/testdata ./
+OS_ARCH="darwin-amd64"
 
+# Download files and set permissions
+source common.sh
 
-./out/minikube-darwin-amd64 delete || true
+./out/minikube-${OS_ARCH} delete || true
 rm -rf $HOME/.minikube || true
 
 # Allow this to fail, we'll switch on the return code below.
 set +e
-out/e2e-darwin-amd64 -minikube-args="--vm-driver=virtualbox --cpus=4 --show-libmachine-logs --v=100 ${EXTRA_BUILD_ARGS}" -test.v -test.timeout=30m -binary=out/minikube-darwin-amd64
+out/e2e-${OS_ARCH} -minikube-args="--vm-driver=virtualbox --cpus=4 --show-libmachine-logs --v=100 ${EXTRA_BUILD_ARGS}" -test.v -test.timeout=30m -binary=out/minikube-${OS_ARCH}
 result=$?
 set -e
 

--- a/hack/jenkins/osx_integration_tests_virtualbox_systemd.sh
+++ b/hack/jenkins/osx_integration_tests_virtualbox_systemd.sh
@@ -25,17 +25,17 @@
 
 
 set -e
-chmod +x out/e2e-darwin-amd64
-chmod +x out/minikube-darwin-amd64
-cp -r out/testdata ./
+OS_ARCH="darwin-amd64"
 
+# Download files and set permissions
+source common.sh
 
-./out/minikube-darwin-amd64 delete || true
+./out/minikube-${OS_ARCH} delete || true
 rm -rf $HOME/.minikube || true
 
 # Allow this to fail, we'll switch on the return code below.
 set +e
-out/e2e-darwin-amd64 -minikube-args="--vm-driver=virtualbox --cpus=4 --show-libmachine-logs --v=100 ${EXTRA_BUILD_ARGS} --iso-url=http://storage.googleapis.com/minikube/iso/buildroot/minikube-v0.0.5.iso" -test.v -test.timeout=60m -binary=out/minikube-darwin-amd64
+out/e2e-${OS_ARCH} -minikube-args="--vm-driver=virtualbox --cpus=4 --show-libmachine-logs --v=100 ${EXTRA_BUILD_ARGS} --iso-url=http://storage.googleapis.com/minikube/iso/buildroot/minikube-v0.0.5.iso" -test.v -test.timeout=60m -binary=out/minikube-${OS_ARCH}
 result=$?
 set -e
 

--- a/hack/jenkins/osx_integration_tests_xhyve.sh
+++ b/hack/jenkins/osx_integration_tests_xhyve.sh
@@ -25,17 +25,18 @@
 
 
 set -e
-chmod +x out/e2e-darwin-amd64
-chmod +x out/minikube-darwin-amd64
-cp -r out/testdata ./
 
+OS_ARCH="darwin-amd64"
+
+# Download files and set permissions
+source common.sh
 
 ./out/minikube-darwin-amd64 delete || true
 rm -rf $HOME/.minikube || true
 
 # Allow this to fail, we'll switch on the return code below.
 set +e
-out/e2e-darwin-amd64 -minikube-args="--vm-driver=xhyve --cpus=4 --show-libmachine-logs --v=100 ${EXTRA_BUILD_ARGS}" -test.v -test.timeout=30m -binary=out/minikube-darwin-amd64
+out/e2e-${OS_ARCH} -minikube-args="--vm-driver=xhyve --cpus=4 --show-libmachine-logs --v=100 ${EXTRA_BUILD_ARGS}" -test.v -test.timeout=30m -binary=out/minikube-${OS_ARCH}
 result=$?
 set -e
 


### PR DESCRIPTION
Sometimes gsutil cp -r can miss files.  We also don't need to copy over
every file.  Additionally, I started to abstract the OS_ARCH away so
that we can more easily template the jenkins OS tests.