### PR TITLE
Fix windows integration test script

### DIFF
--- a/hack/jenkins/windows_integration_test_hyperv.ps1
+++ b/hack/jenkins/windows_integration_test_hyperv.ps1
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 mkdir -p out
-gsutil.cmd cp gs://minikube-builds/${MINIKUBE_LOCATION}/minikube-windows-amd64.exe out/
-gsutil.cmd cp gs://minikube-builds/${MINIKUBE_LOCATION}/e2e-windows-amd64.exe out/
-gsutil.cmd cp -r gs://minikube-builds/${MINIKUBE_LOCATION}/testdata .
+gsutil.cmd cp gs://minikube-builds/$env:MINIKUBE_LOCATION/minikube-windows-amd64.exe out/
+gsutil.cmd cp gs://minikube-builds/$env:MINIKUBE_LOCATION/e2e-windows-amd64.exe out/
+gsutil.cmd cp -r gs://minikube-builds/$env:MINIKUBE_LOCATION/testdata .
 
 ./out/minikube-windows-amd64.exe delete
 


### PR DESCRIPTION
The windows integration tests have been failing because the env vars are being referenced in the bash way in a section of the script