### PR TITLE
Add localkube releasing jobs to makefile

### DIFF
--- a/deploy/minikube/k8s_releases.json
+++ b/deploy/minikube/k8s_releases.json
@@ -1,12 +1,6 @@
 [
   {
-    "version": "v1.5.0-alpha.2"
-  },
-  {
-    "version": "v1.5.0-alpha.1"
-  },
-  {
-    "version": "v1.5.0-alpha.0"
+    "version": "v1.5.0-beta.1"
   },
   {
     "version": "v1.4.5"

--- a/hack/get_k8s_version.py
+++ b/hack/get_k8s_version.py
@@ -45,6 +45,8 @@ def get_tree_state():
   return 'gitTreeState=%s' % result
 
 def main():
+  if len(sys.argv) > 1 and sys.argv[1] == "--k8s-version-only":
+      return get_from_godep('Comment')
   args = [get_rev(), get_version(), get_tree_state()]
   return ' '.join([X_ARG_BASE + arg for arg in args])
 


### PR DESCRIPTION
Update releases to reflect v1.5.0-beta.1


I added some makefile utilities to push localkube releases.  In the future, we can just call these from jenkins jobs if we need to.