### PR TITLE
Update Dashboard version to v1.5.0

### DIFF
--- a/deploy/addons/dashboard-rc.yaml
+++ b/deploy/addons/dashboard-rc.yaml
@@ -19,25 +19,25 @@ metadata:
   namespace: kube-system
   labels:
     app: kubernetes-dashboard
-    version: v1.4.2
+    version: v1.5.0
     kubernetes.io/cluster-service: "true"
     kubernetes.io/minikube-addons: dashboard
 spec:
   replicas: 1
   selector:
     app: kubernetes-dashboard
-    version: v1.4.2
+    version: v1.5.0
     kubernetes.io/cluster-service: "true"
   template:
     metadata:
       labels:
         app: kubernetes-dashboard
-        version: v1.4.2
+        version: v1.5.0
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.4.2
+        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9090


### PR DESCRIPTION
We created our 1.5.0 release to be ready for the 1.5.0 release of kubernetes 1.5.0, please see the changelog at https://github.com/kubernetes/dashboard/releases/tag/v1.5.0