### PR TITLE
Change instructions for completion bash on OS X

### DIFF
--- a/cmd/minikube/cmd/completion.go
+++ b/cmd/minikube/cmd/completion.go
@@ -32,7 +32,8 @@ const longDescription = `
 	OS X:
 		$ brew install bash-completion
 		$ source $(brew --prefix)/etc/bash_completion
-		$ source <(minikube completion bash)
+		$ minikube completion bash > ~/.minikube-completion
+		$ source ~/.minikube-completion
 	Ubuntu:
 		$ apt-get install bash-completion
 		$ source /etc/bash-completion

--- a/docs/minikube_completion.md
+++ b/docs/minikube_completion.md
@@ -12,7 +12,8 @@ Outputs minikube shell completion for the given shell (bash)
 	OS X:
 		$ brew install bash-completion
 		$ source $(brew --prefix)/etc/bash_completion
-		$ source <(minikube completion bash)
+		$ minikube completion bash > ~/.minikube-completion
+		$ source ~/.minikube-completion
 	Ubuntu:
 		$ apt-get install bash-completion
 		$ source /etc/bash-completion


### PR DESCRIPTION
OS X default version of bash doesn't support process substitution.
https://github.com/kubernetes/minikube/issues/844#issuecomment-262587570

I will create an issue and fix this upstream in k8s/k8s also

Fixes https://github.com/kubernetes/minikube/issues/844