### PR TITLE
Dedupe minikube addons open subcommand

### DIFF
--- a/cmd/minikube/cmd/config/open.go
+++ b/cmd/minikube/cmd/config/open.go
@@ -108,7 +108,6 @@ minikube addons enable %s`, addonName, addonName))
 }
 
 func init() {
-	AddonsCmd.AddCommand(addonsOpenCmd)
 	addonsOpenCmd.Flags().BoolVar(&addonsURLMode, "url", false, "Display the kubernetes addons URL in the CLI instead of opening it in the default browser")
 	addonsOpenCmd.Flags().BoolVar(&https, "https", false, "Open the addons URL with https instead of http")
 

--- a/docs/bash-completion
+++ b/docs/bash-completion
@@ -346,37 +346,6 @@ _minikube_addons_open()
     noun_aliases=()
 }
 
-_minikube_addons_open()
-{
-    last_command="minikube_addons_open"
-    commands=()
-
-    flags=()
-    two_word_flags=()
-    local_nonpersistent_flags=()
-    flags_with_completion=()
-    flags_completion=()
-
-    flags+=("--format=")
-    flags+=("--https")
-    local_nonpersistent_flags+=("--https")
-    flags+=("--url")
-    local_nonpersistent_flags+=("--url")
-    flags+=("--alsologtostderr")
-    flags+=("--log_backtrace_at=")
-    flags+=("--log_dir=")
-    flags+=("--logtostderr")
-    flags+=("--show-libmachine-logs")
-    flags+=("--stderrthreshold=")
-    flags+=("--v=")
-    two_word_flags+=("-v")
-    flags+=("--vmodule=")
-
-    must_have_one_flag=()
-    must_have_one_noun=()
-    noun_aliases=()
-}
-
 _minikube_addons()
 {
     last_command="minikube_addons"
@@ -384,7 +353,6 @@ _minikube_addons()
     commands+=("disable")
     commands+=("enable")
     commands+=("list")
-    commands+=("open")
     commands+=("open")
 
     flags=()

--- a/docs/minikube_addons.md
+++ b/docs/minikube_addons.md
@@ -38,5 +38,4 @@ For the list of accessible variables for the template, see the struct values her
 * [minikube addons enable](minikube_addons_enable.md)	 - Enables the addon w/ADDON_NAME within minikube (example: minikube addons enable dashboard). For a list of available addons use: minikube addons list 
 * [minikube addons list](minikube_addons_list.md)	 - Lists all available minikube addons as well as there current status (enabled/disabled)
 * [minikube addons open](minikube_addons_open.md)	 - Opens the addon w/ADDON_NAME within minikube (example: minikube addons open dashboard). For a list of available addons use: minikube addons list 
-* [minikube addons open](minikube_addons_open.md)	 - Opens the addon w/ADDON_NAME within minikube (example: minikube addons open dashboard). For a list of available addons use: minikube addons list 
 


### PR DESCRIPTION
```
Available Commands:
  disable     Disables the addon w/ADDON_NAME within minikube (example: minikube addons disable dashboard). For a list of available addons use: minikube addons list 
  enable      Enables the addon w/ADDON_NAME within minikube (example: minikube addons enable dashboard). For a list of available addons use: minikube addons list 
  list        Lists all available minikube addons as well as there current status (enabled/disabled)
  open        Opens the addon w/ADDON_NAME within minikube (example: minikube addons open dashboard). For a list of available addons use: minikube addons list 
  open        Opens the addon w/ADDON_NAME within minikube (example: minikube addons open dashboard). For a list of available addons use: minikube addons list 
```
The command was getting registered twice