### PR TITLE
Downgrade dashboard back to v1.4.2

### DIFF
--- a/deploy/addons/dashboard-rc.yaml
+++ b/deploy/addons/dashboard-rc.yaml
@@ -19,25 +19,25 @@ metadata:
   namespace: kube-system
   labels:
     app: kubernetes-dashboard
-    version: v1.5.0
+    version: v1.4.2
     kubernetes.io/cluster-service: "true"
     kubernetes.io/minikube-addons: dashboard
 spec:
   replicas: 1
   selector:
     app: kubernetes-dashboard
-    version: v1.5.0
+    version: v1.4.2
     kubernetes.io/cluster-service: "true"
   template:
     metadata:
       labels:
         app: kubernetes-dashboard
-        version: v1.5.0
+        version: v1.4.2
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.0
+        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.4.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9090


### PR DESCRIPTION
PetSets aren't supported at all in dashboard v1.5, however they are
still valid in minikube since minikube runs k8s v1.4.6 at the moment.

We can upgrade to dashboard v1.5 once we merge the k8s-v1.5 branch and
upgrade minikube to k8s v1.5

Fixes #884