### PR TITLE
Deprecate show-libmachine-logs flag

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -80,10 +80,6 @@ var settings = []Setting{
 		callbacks:   []setFn{RequiresRestartMsg},
 	},
 	{
-		name: "show-libmachine-logs",
-		set:  SetBool,
-	},
-	{
 		name:        "log_dir",
 		set:         SetString,
 		validations: []setFn{IsValidPath},

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	goflag "flag"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -73,13 +74,22 @@ var RootCmd = &cobra.Command{
 			}
 		}
 
-		shouldShowLibmachineLogs := viper.GetBool(showLibmachineLogs)
-		if glog.V(3) {
-			log.SetDebug(true)
+		if viper.GetBool(showLibmachineLogs) {
+			fmt.Println(`
+--show-libmachine-logs is deprecated.
+Please use --v=3 to show libmachine logs, and --v=7 for debug level libmachine logs
+`)
 		}
-		if !shouldShowLibmachineLogs {
+
+		// Log level 3 or greater enables libmachine logs
+		if !glog.V(3) {
 			log.SetOutWriter(ioutil.Discard)
 			log.SetErrWriter(ioutil.Discard)
+		}
+
+		// Log level 7 or greater enables debug level logs
+		if glog.V(7) {
+			log.SetDebug(true)
 		}
 
 		if enableUpdateNotification {
@@ -117,7 +127,7 @@ func setFlagsUsingViper() {
 }
 
 func init() {
-	RootCmd.PersistentFlags().Bool(showLibmachineLogs, false, "Whether or not to show logs from libmachine.")
+	RootCmd.PersistentFlags().Bool(showLibmachineLogs, false, "Deprecated: To enable libmachine logs, set --v=3 or higher")
 	RootCmd.AddCommand(configCmd.ConfigCmd)
 	RootCmd.AddCommand(configCmd.AddonsCmd)
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
@@ -144,7 +154,7 @@ func initConfig() {
 func setupViper() {
 	viper.SetEnvPrefix(constants.MinikubeEnvPrefix)
 	// Replaces '-' in flags with '_' in env variables
-	// e.g. show-libmachine-logs => $ENVPREFIX_SHOW_LIBMACHINE_LOGS
+	// e.g. iso-url => $ENVPREFIX_ISO_URL
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
 

--- a/docs/minikube.md
+++ b/docs/minikube.md
@@ -14,7 +14,7 @@ Minikube is a CLI tool that provisions and manages single-node Kubernetes cluste
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory (default "")
       --logtostderr                      log to standard error instead of files
-      --show-libmachine-logs             Whether or not to show logs from libmachine.
+      --show-libmachine-logs             Deprecated: To enable libmachine logs, set --v=3 or higher
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

--- a/docs/minikube_addons.md
+++ b/docs/minikube_addons.md
@@ -26,7 +26,7 @@ For the list of accessible variables for the template, see the struct values her
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory (default "")
       --logtostderr                      log to standard error instead of files
-      --show-libmachine-logs             Whether or not to show logs from libmachine.
+      --show-libmachine-logs             Deprecated: To enable libmachine logs, set --v=3 or higher
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

--- a/docs/minikube_addons_disable.md
+++ b/docs/minikube_addons_disable.md
@@ -18,7 +18,7 @@ minikube addons disable ADDON_NAME
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory (default "")
       --logtostderr                      log to standard error instead of files
-      --show-libmachine-logs             Whether or not to show logs from libmachine.
+      --show-libmachine-logs             Deprecated: To enable libmachine logs, set --v=3 or higher
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

--- a/docs/minikube_addons_enable.md
+++ b/docs/minikube_addons_enable.md
@@ -18,7 +18,7 @@ minikube addons enable ADDON_NAME
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory (default "")
       --logtostderr                      log to standard error instead of files
-      --show-libmachine-logs             Whether or not to show logs from libmachine.
+      --show-libmachine-logs             Deprecated: To enable libmachine logs, set --v=3 or higher
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

--- a/docs/minikube_addons_list.md
+++ b/docs/minikube_addons_list.md
@@ -18,7 +18,7 @@ minikube addons list
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory (default "")
       --logtostderr                      log to standard error instead of files
-      --show-libmachine-logs             Whether or not to show logs from libmachine.
+      --show-libmachine-logs             Deprecated: To enable libmachine logs, set --v=3 or higher
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

--- a/docs/minikube_addons_open.md
+++ b/docs/minikube_addons_open.md
@@ -26,7 +26,7 @@ minikube addons open ADDON_NAME
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory (default "")
       --logtostderr                      log to standard error instead of files
-      --show-libmachine-logs             Whether or not to show logs from libmachine.
+      --show-libmachine-logs             Deprecated: To enable libmachine logs, set --v=3 or higher
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

--- a/docs/minikube_completion.md
+++ b/docs/minikube_completion.md
@@ -33,7 +33,7 @@ minikube completion SHELL
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory (default "")
       --logtostderr                      log to standard error instead of files
-      --show-libmachine-logs             Whether or not to show logs from libmachine.
+      --show-libmachine-logs             Deprecated: To enable libmachine logs, set --v=3 or higher
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

--- a/docs/minikube_config.md
+++ b/docs/minikube_config.md
@@ -14,7 +14,6 @@ Configurable fields:
  * disk-size
  * host-only-cidr
  * memory
- * show-libmachine-logs
  * log_dir
  * kubernetes-version
  * WantUpdateNotification
@@ -38,7 +37,7 @@ minikube config SUBCOMMAND [flags]
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory (default "")
       --logtostderr                      log to standard error instead of files
-      --show-libmachine-logs             Whether or not to show logs from libmachine.
+      --show-libmachine-logs             Deprecated: To enable libmachine logs, set --v=3 or higher
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

--- a/docs/minikube_config_get.md
+++ b/docs/minikube_config_get.md
@@ -18,7 +18,7 @@ minikube config get PROPERTY_NAME
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory (default "")
       --logtostderr                      log to standard error instead of files
-      --show-libmachine-logs             Whether or not to show logs from libmachine.
+      --show-libmachine-logs             Deprecated: To enable libmachine logs, set --v=3 or higher
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

--- a/docs/minikube_config_set.md
+++ b/docs/minikube_config_set.md
@@ -19,7 +19,7 @@ minikube config set PROPERTY_NAME PROPERTY_VALUE
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory (default "")
       --logtostderr                      log to standard error instead of files
-      --show-libmachine-logs             Whether or not to show logs from libmachine.
+      --show-libmachine-logs             Deprecated: To enable libmachine logs, set --v=3 or higher
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

--- a/docs/minikube_config_unset.md
+++ b/docs/minikube_config_unset.md
@@ -18,7 +18,7 @@ minikube config unset PROPERTY_NAME
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory (default "")
       --logtostderr                      log to standard error instead of files
-      --show-libmachine-logs             Whether or not to show logs from libmachine.
+      --show-libmachine-logs             Deprecated: To enable libmachine logs, set --v=3 or higher
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

--- a/docs/minikube_config_view.md
+++ b/docs/minikube_config_view.md
@@ -26,7 +26,7 @@ For the list of accessible variables for the template, see the struct values her
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory (default "")
       --logtostderr                      log to standard error instead of files
-      --show-libmachine-logs             Whether or not to show logs from libmachine.
+      --show-libmachine-logs             Deprecated: To enable libmachine logs, set --v=3 or higher
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

--- a/docs/minikube_dashboard.md
+++ b/docs/minikube_dashboard.md
@@ -24,7 +24,7 @@ minikube dashboard
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory (default "")
       --logtostderr                      log to standard error instead of files
-      --show-libmachine-logs             Whether or not to show logs from libmachine.
+      --show-libmachine-logs             Deprecated: To enable libmachine logs, set --v=3 or higher
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

--- a/docs/minikube_delete.md
+++ b/docs/minikube_delete.md
@@ -19,7 +19,7 @@ minikube delete
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory (default "")
       --logtostderr                      log to standard error instead of files
-      --show-libmachine-logs             Whether or not to show logs from libmachine.
+      --show-libmachine-logs             Deprecated: To enable libmachine logs, set --v=3 or higher
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

--- a/docs/minikube_docker-env.md
+++ b/docs/minikube_docker-env.md
@@ -26,7 +26,7 @@ minikube docker-env
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory (default "")
       --logtostderr                      log to standard error instead of files
-      --show-libmachine-logs             Whether or not to show logs from libmachine.
+      --show-libmachine-logs             Deprecated: To enable libmachine logs, set --v=3 or higher
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

--- a/docs/minikube_get-k8s-versions.md
+++ b/docs/minikube_get-k8s-versions.md
@@ -18,7 +18,7 @@ minikube get-k8s-versions
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory (default "")
       --logtostderr                      log to standard error instead of files
-      --show-libmachine-logs             Whether or not to show logs from libmachine.
+      --show-libmachine-logs             Deprecated: To enable libmachine logs, set --v=3 or higher
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

--- a/docs/minikube_ip.md
+++ b/docs/minikube_ip.md
@@ -18,7 +18,7 @@ minikube ip
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory (default "")
       --logtostderr                      log to standard error instead of files
-      --show-libmachine-logs             Whether or not to show logs from libmachine.
+      --show-libmachine-logs             Deprecated: To enable libmachine logs, set --v=3 or higher
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

--- a/docs/minikube_logs.md
+++ b/docs/minikube_logs.md
@@ -18,7 +18,7 @@ minikube logs
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory (default "")
       --logtostderr                      log to standard error instead of files
-      --show-libmachine-logs             Whether or not to show logs from libmachine.
+      --show-libmachine-logs             Deprecated: To enable libmachine logs, set --v=3 or higher
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

--- a/docs/minikube_service.md
+++ b/docs/minikube_service.md
@@ -27,7 +27,7 @@ minikube service [flags] SERVICE
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory (default "")
       --logtostderr                      log to standard error instead of files
-      --show-libmachine-logs             Whether or not to show logs from libmachine.
+      --show-libmachine-logs             Deprecated: To enable libmachine logs, set --v=3 or higher
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

--- a/docs/minikube_service_list.md
+++ b/docs/minikube_service_list.md
@@ -25,7 +25,7 @@ minikube service list [flags]
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory (default "")
       --logtostderr                      log to standard error instead of files
-      --show-libmachine-logs             Whether or not to show logs from libmachine.
+      --show-libmachine-logs             Deprecated: To enable libmachine logs, set --v=3 or higher
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

--- a/docs/minikube_ssh.md
+++ b/docs/minikube_ssh.md
@@ -18,7 +18,7 @@ minikube ssh
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory (default "")
       --logtostderr                      log to standard error instead of files
-      --show-libmachine-logs             Whether or not to show logs from libmachine.
+      --show-libmachine-logs             Deprecated: To enable libmachine logs, set --v=3 or higher
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

--- a/docs/minikube_start.md
+++ b/docs/minikube_start.md
@@ -42,7 +42,7 @@ minikube start
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory (default "")
       --logtostderr                      log to standard error instead of files
-      --show-libmachine-logs             Whether or not to show logs from libmachine.
+      --show-libmachine-logs             Deprecated: To enable libmachine logs, set --v=3 or higher
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

--- a/docs/minikube_status.md
+++ b/docs/minikube_status.md
@@ -27,7 +27,7 @@ localkube: {{.LocalkubeStatus}}
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory (default "")
       --logtostderr                      log to standard error instead of files
-      --show-libmachine-logs             Whether or not to show logs from libmachine.
+      --show-libmachine-logs             Deprecated: To enable libmachine logs, set --v=3 or higher
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

--- a/docs/minikube_stop.md
+++ b/docs/minikube_stop.md
@@ -19,7 +19,7 @@ minikube stop
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory (default "")
       --logtostderr                      log to standard error instead of files
-      --show-libmachine-logs             Whether or not to show logs from libmachine.
+      --show-libmachine-logs             Deprecated: To enable libmachine logs, set --v=3 or higher
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

--- a/docs/minikube_version.md
+++ b/docs/minikube_version.md
@@ -18,7 +18,7 @@ minikube version
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory (default "")
       --logtostderr                      log to standard error instead of files
-      --show-libmachine-logs             Whether or not to show logs from libmachine.
+      --show-libmachine-logs             Deprecated: To enable libmachine logs, set --v=3 or higher
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging


### PR DESCRIPTION
Libmachine logs can be enabled with --v=3 or higher.  --v=7 turns on
debug level info.  This will simplify the debugging ui and
allow us to transition off of libmachine logs in the future.

Fixes https://github.com/kubernetes/minikube/issues/814