### PR TITLE
Add ingress controller to addons

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -136,6 +136,12 @@ var settings = []Setting{
 		validations: []setFn{IsValidAddon},
 		callbacks:   []setFn{EnableOrDisableAddon},
 	},
+	{
+		name:        "ingress",
+		set:         SetBool,
+		validations: []setFn{IsValidAddon},
+		callbacks:   []setFn{EnableOrDisableAddon},
+	},
 }
 
 var ConfigCmd = &cobra.Command{

--- a/deploy/addons/ingress/ingress-configmap.yaml
+++ b/deploy/addons/ingress/ingress-configmap.yaml
@@ -1,0 +1,23 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+data:
+  map-hash-bucket-size: "128"
+kind: ConfigMap
+metadata:
+  name: nginx-load-balancer-conf
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"

--- a/deploy/addons/ingress/ingress-rc.yaml
+++ b/deploy/addons/ingress/ingress-rc.yaml
@@ -1,0 +1,118 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: default-http-backend
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+spec:
+  replicas: 1
+  selector:
+    app: default-http-backend
+    kubernetes.io/cluster-service: "true"
+  template:
+    metadata:
+      labels:
+        app: default-http-backend
+        kubernetes.io/cluster-service: "true"
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+      - name: default-http-backend
+        # Any image is permissable as long as:
+        # 1. It serves a 404 page at /
+        # 2. It serves 200 on a /healthz endpoint
+        image: gcr.io/google_containers/defaultbackend:1.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 10m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: nginx-ingress-controller
+  namespace: kube-system
+  labels:
+    app: nginx-ingress-lb
+    kubernetes.io/cluster-service: "true"
+spec:
+  replicas: 1
+  selector:
+    app: nginx-ingress-lb
+    kubernetes.io/cluster-service: "true"
+  template:
+    metadata:
+      labels:
+        app: nginx-ingress-lb
+        name: nginx-ingress-lb
+        kubernetes.io/cluster-service: "true"
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+        # TODO(r2d4): Use official k8s/ingress controller 
+      - image: gcr.io/k8s-minikube/nginx-ingress-controller:0.8.4
+        name: nginx-ingress-lb
+        imagePullPolicy: IfNotPresent
+        readinessProbe:
+          httpGet:
+            path: /ingress-controller-healthz
+            port: 80
+            scheme: HTTP
+        livenessProbe:
+          httpGet:
+            path: /ingress-controller-healthz
+            port: 80
+            scheme: HTTP
+          initialDelaySeconds: 10
+          timeoutSeconds: 1
+        # use downward API
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        ports:
+        - containerPort: 80
+          hostPort: 80
+        - containerPort: 443
+          hostPort: 443
+        # we expose 18080 to access nginx stats in url /nginx-status
+        # this is optional
+        - containerPort: 18080
+          hostPort: 18080
+        args:
+        - /nginx-ingress-controller
+        - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
+        - --nginx-configmap=$(POD_NAMESPACE)/nginx-load-balancer-conf

--- a/deploy/addons/ingress/ingress-svc.yaml
+++ b/deploy/addons/ingress/ingress-svc.yaml
@@ -1,0 +1,30 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-http-backend
+  namespace: kube-system
+  labels:
+    app: default-http-backend
+    kubernetes.io/cluster-service: "true"
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    targetPort: 8080
+    nodePort: 30001
+  selector:
+    app: default-http-backend

--- a/docs/minikube_config.md
+++ b/docs/minikube_config.md
@@ -26,6 +26,7 @@ Configurable fields:
  * addon-manager
  * kube-dns
  * heapster
+ * ingress
 
 ```
 minikube config SUBCOMMAND [flags]

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -113,6 +113,23 @@ var Addons = map[string]*Addon{
 			"heapster-svc.yaml",
 			"0640"),
 	}, false, "heapster"),
+	"ingress": NewAddon([]*MemoryAsset{
+		NewMemoryAsset(
+			"deploy/addons/ingress/ingress-configmap.yaml",
+			constants.AddonsPath,
+			"ingress-configmap.yaml",
+			"0640"),
+		NewMemoryAsset(
+			"deploy/addons/ingress/ingress-rc.yaml",
+			constants.AddonsPath,
+			"ingress-rc.yaml",
+			"0640"),
+		NewMemoryAsset(
+			"deploy/addons/ingress/ingress-svc.yaml",
+			constants.AddonsPath,
+			"ingress-svc.yaml",
+			"0640"),
+	}, false, "ingress"),
 }
 
 func AddMinikubeAddonsDirToAssets(assetList *[]CopyableFile) {


### PR DESCRIPTION
This uses a custom version of the ingress controller.  We should move
it over to the official one when it is released.

TODO: When I add some integration tests, then we can consider turning it on by default?