### PR TITLE
Enable awsecr-creds addon 

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ $ minikube addons list
 - dashboard: enabled
 - kube-dns: enabled
 - heapster: disabled
+- awsecr-creds: disabled
 
 # minikube must be running for these commands to take effect
 $ minikube addons enable heapster
@@ -294,6 +295,7 @@ The currently supported addons include:
 * [Kubernetes Dashboard](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/dashboard)
 * [Kube-dns](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/dns)
 * [Heapster](https://github.com/kubernetes/heapster): [Troubleshooting Guide](https://github.com/kubernetes/heapster/blob/master/docs/influxdb.md) Note:You will need to login to Grafana as admin/admin in order to access the console
+* [AWS ECR Credentials](https://github.com/upmc-enterprises/awsecr-creds): Allow for AWS ECR credentials to be refreshed inside your Kubernetes cluster via ImagePullSecrets [NOTE: Requires k8s secret to function](https://github.com/upmc-enterprises/awsecr-creds/blob/master/k8s/secret.yaml)
 
 If you would like to have minikube properly start/restart custom addons, place the addon(s) you wish to be launched with minikube in the `.minikube/addons` directory.  Addons in this folder will be moved to the minikubeVM and launched each time minikube is started/restarted.
 

--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -142,6 +142,12 @@ var settings = []Setting{
 		validations: []setFn{IsValidAddon},
 		callbacks:   []setFn{EnableOrDisableAddon},
 	},
+	{
+		name:        "awsecr-creds",
+		set:         SetBool,
+		validations: []setFn{IsValidAddon},
+		callbacks:   []setFn{EnableOrDisableAddon},
+	},
 }
 
 var ConfigCmd = &cobra.Command{

--- a/deploy/addons/awsecr-creds/awsecr-creds-rc.yaml
+++ b/deploy/addons/awsecr-creds/awsecr-creds-rc.yaml
@@ -1,0 +1,44 @@
+
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: awsecr-creds
+  namespace: kube-system
+  labels:
+    app: awsecr-creds
+    version: v1.1
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/minikube-addons: awsecr-creds
+spec:
+  replicas: 1
+  selector:
+    app: awsecr-creds
+    version: v1.1
+    kubernetes.io/cluster-service: "true"
+  template:
+    metadata:
+      labels:
+        app: awsecr-creds
+        version: v1.1
+        kubernetes.io/cluster-service: "true"
+    spec:
+      containers:
+      - image: upmcenterprises/awsecr-creds:1.1
+        name: awsecr-creds
+        imagePullPolicy: Always
+        env:
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: awsecr-creds
+                key: AWS_ACCESS_KEY_ID
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: awsecr-creds
+                key: AWS_SECRET_ACCESS_KEY
+          - name: awsaccount
+            valueFrom:
+              secretKeyRef:
+                name: awsecr-creds
+                key: aws-account

--- a/docs/minikube_config.md
+++ b/docs/minikube_config.md
@@ -27,6 +27,7 @@ Configurable fields:
  * kube-dns
  * heapster
  * ingress
+ * awsecr-creds
 
 ```
 minikube config SUBCOMMAND [flags]

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -130,6 +130,13 @@ var Addons = map[string]*Addon{
 			"ingress-svc.yaml",
 			"0640"),
 	}, false, "ingress"),
+	"awsecr-creds": NewAddon([]*MemoryAsset{
+		NewMemoryAsset(
+			"deploy/addons/awsecr-creds/awsecr-creds-rc.yaml",
+			constants.AddonsPath,
+			"awsecr-creds-rc.yaml",
+			"0640"),
+	}, false, "awsecr-creds"),
 }
 
 func AddMinikubeAddonsDirToAssets(assetList *[]CopyableFile) {


### PR DESCRIPTION
This addon will automatically setup credentials to allow for minikube to pull images from an ECR docker registry running on AWS. 

It requires a secret to be created to function. That secret contains the AWS_ACCESS_ID, AWS_SECRET_ACCESS_KEY as well as the AWS Account Id. 

This resolves #366 