### PR TITLE
Fix logs Integration test

### DIFF
--- a/deploy/iso/minikube-iso/package/automount/minikube-automount
+++ b/deploy/iso/minikube-iso/package/automount/minikube-automount
@@ -117,6 +117,9 @@ if [ -n "$BOOT2DOCKER_DATA" ]; then
     mkdir -p /mnt/$PARTNAME/var/lib/docker
     ln -s /mnt/$PARTNAME/var/lib/docker /var/lib/docker
 
+    mkdir -p /mnt/$PARTNAME/var/log
+    ln -s /mnt/$PARTNAME/var/log /var/log
+
     mkdir -p /mnt/$PARTNAME/var/lib/kubelet
     ln -s /mnt/$PARTNAME/var/lib/kubelet /var/lib/kubelet
 


### PR DESCRIPTION
Journalctl has not been logging properly in the minikube-iso because of
the absence of /var/log on startup.  This is an issue now that we are
using systemd for localkube.  This commit links and persists the directory
/var/log like we do for other folders.