### PR TITLE
machine: add parallels support

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -95,7 +95,7 @@ var startCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Starts a local kubernetes cluster",
 	Long: `Starts a local kubernetes cluster using VM. This command
-assumes you have already installed one of the VM drivers: virtualbox/vmwarefusion/kvm/xhyve/hyperv.`,
+assumes you have already installed one of the VM drivers: virtualbox/parallels/vmwarefusion/kvm/xhyve/hyperv.`,
 	Run: runStart,
 }
 

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -54,6 +54,7 @@ func GetMinipath() string {
 // used in gendocs.
 var SupportedVMDrivers = [...]string{
 	"virtualbox",
+	"parallels",
 	"vmwarefusion",
 	"kvm",
 	"xhyve",

--- a/pkg/minikube/drivers/parallels/doc.go
+++ b/pkg/minikube/drivers/parallels/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parallels

--- a/pkg/minikube/drivers/parallels/driver.go
+++ b/pkg/minikube/drivers/parallels/driver.go
@@ -1,0 +1,48 @@
+// +build darwin
+
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parallels
+
+import (
+	parallels "github.com/Parallels/docker-machine-parallels"
+	"github.com/docker/machine/libmachine/drivers"
+	cfg "k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/registry"
+)
+
+func init() {
+	registry.Register(registry.DriverDef{
+		Name:          "parallels",
+		Builtin:       true,
+		ConfigCreator: createParallelsHost,
+		DriverCreator: func() drivers.Driver {
+			return parallels.NewDriver("", "")
+		},
+	})
+}
+
+func createParallelsHost(config cfg.MachineConfig) interface{} {
+	d := parallels.NewDriver(cfg.GetMachineName(), constants.GetMinipath()).(*parallels.Driver)
+	d.Boot2DockerURL = config.Downloader.GetISOFileURI(config.MinikubeISO)
+	d.Memory = config.Memory
+	d.CPU = config.CPUs
+	d.DiskSize = config.DiskSize
+	d.ISO = d.ResolveStorePath("boot2docker.iso")
+	return d
+}


### PR DESCRIPTION
xhyve will not work on older iMac, CPU core the presence of support VT-d will not help. Paralells works along with VMware Fusion.

1) xhyve will not working without the `Hypervisor.framework`.
2) `Hypervisor.framework` will not working VT-x without (_EPT_ & _Unrestricted Mode_)

> #### Hypervisor.framework
> Generally, machines with an Intel VT-x feature set that includes **Extended Page Tables (EPT)** and **Unrestricted Mode** are supported. You can determine the availability of Hypervisor APIs on a particular machine at runtime with the sysctl(8) command, passing kern.hv_support as an argument.

* https://developer.apple.com/reference/hypervisor
* https://discussions.apple.com/thread/7663673
* https://twitter.com/couac/status/730119794020732929
* Jenkins - https://github.com/Parallels/jenkins-parallels
* kubernetes/minikube#261