### PR TITLE
Add config.ConfigurationMap to configurator

### DIFF
--- a/pkg/util/config.go
+++ b/pkg/util/config.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 
+	"k8s.io/kubernetes/pkg/util/config"
 	utilnet "k8s.io/kubernetes/pkg/util/net"
 )
 
@@ -80,6 +81,13 @@ func setElement(e reflect.Value, v string) error {
 			return fmt.Errorf("Error converting input %s to PortRange: %s", v, err)
 		}
 		e.Set(reflect.ValueOf(*pr))
+	case config.ConfigurationMap:
+		c := config.ConfigurationMap{}
+		err := c.Set(v)
+		if err != nil {
+			return fmt.Errorf("Error converting input %s to ConfigurationMap: %s", v, err)
+		}
+		e.Set(reflect.ValueOf(c))
 	default:
 		return fmt.Errorf("Unable to set type %T.", t)
 	}


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/blob/master/pkg/genericapiserver/options/server_run_options.go#L55


RuntimeConfig is now type ConfigurationMap, which is easily supported in the configurator

before:
```
Unable to set GenericServerRunOptions.RuntimeConfig to api/all=true,rbac.authorization.k8s.io/v1alpha1. Error: Unable to set type config.ConfigurationMap
```

after:

```
3503 localkube.go:116] Setting GenericServerRunOptions.RuntimeConfig to api/all=true on apiserver.
```