### PR TITLE
Fix missing else statement in addonsEnableCmd

### DIFF
--- a/cmd/minikube/cmd/config/enable.go
+++ b/cmd/minikube/cmd/config/enable.go
@@ -37,8 +37,9 @@ var addonsEnableCmd = &cobra.Command{
 		err := Set(addon, "true")
 		if err != nil {
 			fmt.Fprintln(os.Stdout, err)
+		} else {
+			fmt.Fprintln(os.Stdout, fmt.Sprintf("%s was successfully enabled", addon))
 		}
-		fmt.Fprintln(os.Stdout, fmt.Sprintf("%s was successfully enabled", addon))
 	},
 }
 


### PR DESCRIPTION
Trying to enable an addon currently always returns a success message even though an error occurred:

```bash
glaubitz@ikarus:~$ minikube addons enable dummy
Property name dummy not found
dummy was successfully enabled
glaubitz@ikarus:~$
```

This is caused by a missing `else` statement which is fixed by this PR.