### PR TITLE
Parameterize jenkins jobs

### DIFF
--- a/hack/jenkins/linux_integration_tests_kvm.sh
+++ b/hack/jenkins/linux_integration_tests_kvm.sh
@@ -26,33 +26,9 @@
 set -e
 
 OS_ARCH="linux-amd64"
+VM_DRIVER="kvm"
+JOB_NAME="Linux-KVM"
+
 
 # Download files and set permissions
 source common.sh
-
-MINIKUBE_WANTREPORTERRORPROMPT=False \
-	./out/minikube-${OS_ARCH} delete || true
-    
-rm -rf $HOME/.minikube || true
-
-# Allow this to fail, we'll switch on the return code below.
-set +e
-out/e2e-${OS_ARCH} -minikube-args="--vm-driver=kvm --cpus=4 --show-libmachine-logs --v=100 ${EXTRA_BUILD_ARGS}" -test.v -test.timeout=30m -binary=out/minikube-${OS_ARCH}
-result=$?
-set -e
-
-if [[ $result -eq 0 ]]; then
-  status="success"
-else
-  status="failure"
-fi
-
-set +x
-target_url="https://storage.googleapis.com/minikube-builds/logs/${MINIKUBE_LOCATION}/Linux-KVM.txt"
-curl "https://api.github.com/repos/kubernetes/minikube/statuses/${COMMIT}?access_token=$access_token" \
-  -H "Content-Type: application/json" \
-  -X POST \
-  -d "{\"state\": \"$status\", \"description\": \"Jenkins\", \"target_url\": \"$target_url\", \"context\": \"Linux-KVM\"}"
-set -x
-
-exit $result

--- a/hack/jenkins/linux_integration_tests_virtualbox.sh
+++ b/hack/jenkins/linux_integration_tests_virtualbox.sh
@@ -26,34 +26,8 @@
 set -e
 
 OS_ARCH="linux-amd64"
+VM_DRIVER="virtualbox"
+JOB_NAME="Linux-VirtualBox"
 
 # Download files and set permissions
 source common.sh
-
-MINIKUBE_WANTREPORTERRORPROMPT=False \
-	./out/minikube-${OS_ARCH} delete || true
-    
-rm -rf $HOME/.minikube || true
-rm -rf $HOME/.docker || true
-
-# Allow this to fail, we'll switch on the return code below.
-set +e
-out/e2e-${OS_ARCH} -minikube-args="--vm-driver=virtualbox --cpus=4 --show-libmachine-logs --v=100 ${EXTRA_BUILD_ARGS}" -test.v -test.timeout=30m -binary=out/minikube-${OS_ARCH}
-result=$?
-set -e
-
-if [[ $result -eq 0 ]]; then
-  status="success"
-else
-  status="failure"
-fi
-
-set +x
-target_url="https://storage.googleapis.com/minikube-builds/logs/${MINIKUBE_LOCATION}/Linux-VirtualBox.txt"
-curl "https://api.github.com/repos/kubernetes/minikube/statuses/${COMMIT}?access_token=$access_token" \
-  -H "Content-Type: application/json" \
-  -X POST \
-  -d "{\"state\": \"$status\", \"description\": \"Jenkins\", \"target_url\": \"$target_url\", \"context\": \"Linux-VirtualBox\"}"
-set -x
-
-exit $result

--- a/hack/jenkins/osx_integration_tests_virtualbox.sh
+++ b/hack/jenkins/osx_integration_tests_virtualbox.sh
@@ -26,31 +26,8 @@
 
 set -e
 OS_ARCH="darwin-amd64"
+VM_DRIVER="virtualbox"
+JOB_NAME="OSX-Virtualbox"
 
 # Download files and set permissions
 source common.sh
-
-./out/minikube-${OS_ARCH} delete || true
-rm -rf $HOME/.minikube || true
-
-# Allow this to fail, we'll switch on the return code below.
-set +e
-out/e2e-${OS_ARCH} -minikube-args="--vm-driver=virtualbox --cpus=4 --show-libmachine-logs --v=100 ${EXTRA_BUILD_ARGS}" -test.v -test.timeout=30m -binary=out/minikube-${OS_ARCH}
-result=$?
-set -e
-
-if [[ $result -eq 0 ]]; then
-  status="success"
-else
-  status="failure"
-fi
-
-set +x
-target_url="https://storage.googleapis.com/minikube-builds/logs/${MINIKUBE_LOCATION}/OSX-Virtualbox.txt"
-curl "https://api.github.com/repos/kubernetes/minikube/statuses/${COMMIT}?access_token=$access_token" \
-  -H "Content-Type: application/json" \
-  -X POST \
-  -d "{\"state\": \"$status\", \"description\": \"Jenkins\", \"target_url\": \"$target_url\", \"context\": \"OSX-VirtualBox\"}"
-set -x
-
-exit $result

--- a/hack/jenkins/osx_integration_tests_xhyve.sh
+++ b/hack/jenkins/osx_integration_tests_xhyve.sh
@@ -27,31 +27,9 @@
 set -e
 
 OS_ARCH="darwin-amd64"
+VM_DRIVER="xhyve"
+JOB_NAME="OSX-Xhyve"
+
 
 # Download files and set permissions
 source common.sh
-
-./out/minikube-darwin-amd64 delete || true
-rm -rf $HOME/.minikube || true
-
-# Allow this to fail, we'll switch on the return code below.
-set +e
-out/e2e-${OS_ARCH} -minikube-args="--vm-driver=xhyve --cpus=4 --show-libmachine-logs --v=100 ${EXTRA_BUILD_ARGS}" -test.v -test.timeout=30m -binary=out/minikube-${OS_ARCH}
-result=$?
-set -e
-
-if [[ $result -eq 0 ]]; then
-  status="success"
-else
-  status="failure"
-fi
-
-set +x
-target_url="https://storage.googleapis.com/minikube-builds/logs/${MINIKUBE_LOCATION}/OSX-XHyve.txt"
-curl "https://api.github.com/repos/kubernetes/minikube/statuses/${COMMIT}?access_token=$access_token" \
-  -H "Content-Type: application/json" \
-  -X POST \
-  -d "{\"state\": \"$status\", \"description\": \"Jenkins\", \"target_url\": \"$target_url\", \"context\": \"OSX-XHyve\"}"
-set -x
-
-exit $result


### PR DESCRIPTION
If this works well, I will just change the main minikube job to run a single parameterized job `Integration Test` that runs `common.sh` and passes in the arguments as predefined build parameters.  

For now, the windows tests wont change, as they run in powershell.