### PR TITLE
Print update notification to stderr

### DIFF
--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -93,7 +93,7 @@ Please use --v=3 to show libmachine logs, and --v=7 for debug level libmachine l
 		}
 
 		if enableUpdateNotification {
-			notify.MaybePrintUpdateTextFromGithub(os.Stdout)
+			notify.MaybePrintUpdateTextFromGithub(os.Stderr)
 		}
 		if enableKubectlDownloadMsg {
 			util.MaybePrintKubectlDownloadMsg()


### PR DESCRIPTION
This change sends the update notification out of `stderr` instead of `stdout`.

When the notification comes out of `stdout`, it breaks the `minikube completion ...` command, as the update notification ends up getting parsed by the shell.

Note: I decided open a PR directly (instead of an issue), since it is such a small change that I think is easy to evaluate directly as code.  Hope that's ok.