### PR TITLE
Check minimum disksize before creating minikube VM

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -75,11 +75,20 @@ func runStart(cmd *cobra.Command, args []string) {
 	api := libmachine.NewClient(constants.Minipath, constants.MakeMiniPath("certs"))
 	defer api.Close()
 
+	diskSize := viper.GetString(humanReadableDiskSize)
+	diskSizeMB := calculateDiskSizeInMB(diskSize)
+
+	if diskSizeMB < constants.MinimumDiskSizeMB {
+		err := fmt.Errorf("Disk Size %dMB (%s) is too small, the minimum disk size is %dMB", diskSizeMB, diskSize, constants.MinimumDiskSizeMB)
+		glog.Errorln("Error parsing disk size:", err)
+		os.Exit(1)
+	}
+
 	config := cluster.MachineConfig{
 		MinikubeISO:         viper.GetString(isoURL),
 		Memory:              viper.GetInt(memory),
 		CPUs:                viper.GetInt(cpus),
-		DiskSize:            calculateDiskSizeInMB(viper.GetString(humanReadableDiskSize)),
+		DiskSize:            diskSizeMB,
 		VMDriver:            viper.GetString(vmDriver),
 		DockerEnv:           dockerEnv,
 		InsecureRegistry:    insecureRegistry,

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -66,6 +66,7 @@ const (
 	DefaultMemory       = 2048
 	DefaultCPUS         = 2
 	DefaultDiskSize     = "20g"
+	MinimumDiskSizeMB   = 2000
 	DefaultVMDriver     = "virtualbox"
 	DefaultStatusFormat = "minikubeVM: {{.MinikubeStatus}}\n" +
 		"localkube: {{.LocalkubeStatus}}\n"


### PR DESCRIPTION
We use docker/go-units for human readable disk sizes on the --disk-size
flag.  However, sometime a user use wrong syntax and specify a disk
size that they didn't mean.  Fixes #976