### PR TITLE
WIP: Add release-iso Makefile rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ DEB_VERSION ?= $(VERSION_MAJOR).$(VERSION_MINOR)-$(VERSION_BUILD)
 INSTALL_SIZE ?= $(shell du out/minikube-windows-amd64.exe | cut -f1)
 BUILDROOT_BRANCH ?= 2016.08
 
+ISO_VERSION ?= v1.0.3
+
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 BUILD_DIR ?= ./out
@@ -45,9 +47,11 @@ BUILD_OS := $(shell uname -s)
 LOCALKUBE_VERSION := $(shell $(PYTHON) hack/get_k8s_version.py --k8s-version-only 2>&1)
 LOCALKUBE_BUCKET := gs://minikube/k8sReleases
 
+ISO_BUCKET := gs://minikube/iso
+
 # Set the version information for the Kubernetes servers, and build localkube statically
 K8S_VERSION_LDFLAGS := $(shell $(PYTHON) hack/get_k8s_version.py 2>&1)
-MINIKUBE_LDFLAGS := -X k8s.io/minikube/pkg/version.version=$(VERSION)
+MINIKUBE_LDFLAGS := -X k8s.io/minikube/pkg/version.version=$(VERSION) -X k8s.io/minikube/pkg/version.isoVersion=$(ISO_VERSION)
 LOCALKUBE_LDFLAGS := "$(K8S_VERSION_LDFLAGS) $(MINIKUBE_LDFLAGS) -s -w -extldflags '-static'"
 
 LOCALKUBEFILES := GOPATH=$(GOPATH) go list  -f '{{join .Deps "\n"}}' ./cmd/localkube/ | grep k8s.io | GOPATH=$(GOPATH) xargs go list -f '{{ range $$file := .GoFiles }} {{$$.Dir}}/{{$$file}}{{"\n"}}{{end}}'
@@ -81,13 +85,14 @@ localkube-image: out/localkube
 iso:
 	cd deploy/iso/boot2docker && ./build.sh
 
-minikube-iso:
+minikube_iso:
 	if [ ! -d $(BUILD_DIR)/buildroot ]; then \
 		mkdir -p $(BUILD_DIR); \
 		git clone --branch=$(BUILDROOT_BRANCH) https://github.com/buildroot/buildroot $(BUILD_DIR)/buildroot; \
 	fi;
 	$(MAKE) BR2_EXTERNAL=../../deploy/iso/minikube-iso minikube_defconfig -C $(BUILD_DIR)/buildroot
 	$(MAKE) -C $(BUILD_DIR)/buildroot
+	mv $(BUILD_DIR)/buildroot/output/images/rootfs.iso9660 $(BUILD_DIR)/minikube.iso
 
 .PHONY: integration
 integration: out/minikube
@@ -106,9 +111,9 @@ $(GOPATH)/bin/go-bindata: $(GOPATH)/src/$(ORG)
 .PHONY: cross
 cross: out/localkube out/minikube-linux-amd64 out/minikube-darwin-amd64 out/minikube-windows-amd64.exe
 
-.PHONE: checksum
+.PHONY: checksum
 checksum:
-	for f in out/localkube out/minikube-linux-amd64 out/minikube-darwin-amd64 out/minikube-windows-amd64.exe ; do \
+	for f in out/localkube out/minikube-linux-amd64 out/minikube-darwin-amd64 out/minikube-windows-amd64.exe out/minikube.iso; do \
 		if [ -f "$${f}" ]; then \
 			openssl sha256 "$${f}" | awk '{print $$2}' > "$${f}.sha256" ; \
 		fi ; \
@@ -168,4 +173,9 @@ release-localkube: out/localkube checksum
 .PHONY: update-releases
 update-releases: 
 	gsutil cp deploy/minikube/k8s_releases.json gs://minikube/k8s_releases.json
+
+.PHONY: release-iso
+release-iso: minikube_iso checksum
+	gsutil cp out/minikube.iso $(ISO_BUCKET)/minikube-$(ISO_VERSION).iso
+	gsutil cp out/minikube.iso.sha256 $(ISO_BUCKET)/minikube-$(ISO_VERSION).iso.sha256
 

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -17,11 +17,13 @@ limitations under the License.
 package constants
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	"k8s.io/kubernetes/pkg/util/homedir"
 	"k8s.io/kubernetes/pkg/version"
+	minikubeVersion "k8s.io/minikube/pkg/version"
 )
 
 // MachineName is the name to use for the VM.
@@ -60,9 +62,7 @@ var LogFlags = [...]string{
 
 const (
 	DefaultKeepContext  = false
-	DefaultIsoUrl       = "https://storage.googleapis.com/minikube/iso/minikube-v1.0.2.iso"
 	ShaSuffix           = ".sha256"
-	DefaultIsoShaUrl    = DefaultIsoUrl + ShaSuffix
 	DefaultMemory       = 2048
 	DefaultCPUS         = 2
 	DefaultDiskSize     = "20g"
@@ -74,6 +74,9 @@ const (
 	GithubMinikubeReleasesURL = "https://storage.googleapis.com/minikube/releases.json"
 	KubernetesVersionGCSURL   = "https://storage.googleapis.com/minikube/k8s_releases.json"
 )
+
+var DefaultIsoUrl = fmt.Sprintf("https://storage.googleapis.com/minikube/iso/minikube-%s.iso", minikubeVersion.GetIsoVersion())
+var DefaultIsoShaUrl = DefaultIsoUrl + ShaSuffix
 
 var DefaultKubernetesVersion = version.Get().GitVersion
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -28,8 +28,14 @@ const VersionPrefix = "v"
 
 var version = "v0.0.0-unset"
 
+var isoVersion = "v0.0.0-unset"
+
 func GetVersion() string {
 	return version
+}
+
+func GetIsoVersion() string {
+	return isoVersion
 }
 
 func GetSemverVersion() (semver.Version, error) {


### PR DESCRIPTION
This also tracks the ISO version in the makefile and passes it with
ldflags to automatically bump the default version in the minikube
binary.