### PR TITLE
Rename awsecr-creds to registry-creds & update version

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ $ minikube addons list
 - dashboard: enabled
 - kube-dns: enabled
 - heapster: disabled
-- awsecr-creds: disabled
+- registry-creds: disabled
 
 # minikube must be running for these commands to take effect
 $ minikube addons enable heapster
@@ -314,7 +314,7 @@ The currently supported addons include:
 * [Kubernetes Dashboard](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/dashboard)
 * [Kube-dns](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/dns)
 * [Heapster](https://github.com/kubernetes/heapster): [Troubleshooting Guide](https://github.com/kubernetes/heapster/blob/master/docs/influxdb.md) Note:You will need to login to Grafana as admin/admin in order to access the console
-* [AWS ECR Credentials](https://github.com/upmc-enterprises/awsecr-creds): Allow for AWS ECR credentials to be refreshed inside your Kubernetes cluster via ImagePullSecrets [NOTE: Requires k8s secret to function](https://github.com/upmc-enterprises/awsecr-creds/blob/master/k8s/secret.yaml)
+* [Registry Credentials](https://github.com/upmc-enterprises/registry-creds)
 
 If you would like to have minikube properly start/restart custom addons, place the addon(s) you wish to be launched with minikube in the `.minikube/addons` directory.  Addons in this folder will be moved to the minikubeVM and launched each time minikube is started/restarted.
 

--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -144,7 +144,7 @@ var settings = []Setting{
 		callbacks:   []setFn{EnableOrDisableAddon},
 	},
 	{
-		name:        "awsecr-creds",
+		name:        "registry-creds",
 		set:         SetBool,
 		validations: []setFn{IsValidAddon},
 		callbacks:   []setFn{EnableOrDisableAddon},

--- a/deploy/addons/registry-creds/registry-creds-rc.yaml
+++ b/deploy/addons/registry-creds/registry-creds-rc.yaml
@@ -2,43 +2,43 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: awsecr-creds
+  name: registry-creds
   namespace: kube-system
   labels:
-    app: awsecr-creds
+    app: registry-creds
     version: v1.1
     kubernetes.io/cluster-service: "true"
-    kubernetes.io/minikube-addons: awsecr-creds
+    kubernetes.io/minikube-addons: registry-creds
 spec:
   replicas: 1
   selector:
-    app: awsecr-creds
-    version: v1.1
+    app: registry-creds
+    version: v1.4
     kubernetes.io/cluster-service: "true"
   template:
     metadata:
       labels:
-        app: awsecr-creds
-        version: v1.1
+        app: registry-creds
+        version: v1.4
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-      - image: upmcenterprises/awsecr-creds:1.1
-        name: awsecr-creds
+      - image: upmcenterprises/registry-creds:1.4
+        name: registry-creds
         imagePullPolicy: Always
         env:
           - name: AWS_ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:
-                name: awsecr-creds
+                name: registry-creds
                 key: AWS_ACCESS_KEY_ID
           - name: AWS_SECRET_ACCESS_KEY
             valueFrom:
               secretKeyRef:
-                name: awsecr-creds
+                name: registry-creds
                 key: AWS_SECRET_ACCESS_KEY
           - name: awsaccount
             valueFrom:
               secretKeyRef:
-                name: awsecr-creds
+                name: registry-creds
                 key: aws-account

--- a/docs/minikube_config.md
+++ b/docs/minikube_config.md
@@ -27,7 +27,7 @@ Configurable fields:
  * kube-dns
  * heapster
  * ingress
- * awsecr-creds
+ * registry-creds
  * hyperv-virtual-switch
 
 ```

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -130,13 +130,13 @@ var Addons = map[string]*Addon{
 			"ingress-svc.yaml",
 			"0640"),
 	}, false, "ingress"),
-	"awsecr-creds": NewAddon([]*MemoryAsset{
+	"registry-creds": NewAddon([]*MemoryAsset{
 		NewMemoryAsset(
-			"deploy/addons/awsecr-creds/awsecr-creds-rc.yaml",
+			"deploy/addons/registry-creds/registry-creds-rc.yaml",
 			constants.AddonsPath,
-			"awsecr-creds-rc.yaml",
+			"registry-creds-rc.yaml",
 			"0640"),
-	}, false, "awsecr-creds"),
+	}, false, "registry-creds"),
 }
 
 func AddMinikubeAddonsDirToAssets(assetList *[]CopyableFile) {


### PR DESCRIPTION
- Renamed awsecr-creds addon to registry-creds
- Updated version to 1.4 which now supports Google Registry