### PR TITLE
Fixes nil dereference on error and addons open

### DIFF
--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -760,8 +760,6 @@ func getServiceListFromServicesByLabel(services corev1.ServiceInterface, key str
 	if err != nil {
 		return &v1.ServiceList{}, &util.RetriableError{Err: err}
 	}
-	if len(serviceList.Items) == 0 {
-		return &v1.ServiceList{}, &util.RetriableError{Err: err}
-	}
+
 	return serviceList, nil
 }

--- a/pkg/minikube/cluster/cluster_test.go
+++ b/pkg/minikube/cluster/cluster_test.go
@@ -876,8 +876,8 @@ func TestGetServiceListFromServicesByLabel(t *testing.T) {
 	serviceIface := ServiceInterfaceMock{
 		ServiceList: serviceList,
 	}
-	if _, err := getServiceListFromServicesByLabel(serviceIface, "shouldError", "shouldError"); err == nil {
-		t.Fatalf("Service had no label match but getServiceListFromServicesByLabel did not return an error")
+	if _, err := getServiceListFromServicesByLabel(serviceIface, "nothing", "nothing"); err != nil {
+		t.Fatalf("Service had no label match, but getServiceListFromServicesByLabel returned an error")
 	}
 
 	if _, err := getServiceListFromServicesByLabel(serviceIface, "foo", "bar"); err != nil {


### PR DESCRIPTION
Some addons don't have a 'minikube addons open' endpoint defined, so
don't retry and wait for them.

Fixes #1013 in two ways

1. The segfault was coming from this line https://github.com/kubernetes/minikube/blob/master/pkg/minikube/cluster/cluster.go#L764

The Err field points to a nil err.  I've change the function to not return an error if no services are found.  This is the only caller of the function so it shouldn't need additional changes.  Returning an error for an empty list would make it hard to inspect whether the call to `get services` failed or there are no services.

2. Removing waiting for 120 seconds for the service to be present.  We already wait in WaitAndMaybeOpenService, so theres no need to wait here.  In the case of the ingress service, there isn't actually an endpoint, so it waits for without erroring out.  

In a different PR I can add an addon endpoint for the rest of the addons we currently have