### PR TITLE
Ignore ./out folder in gofmt test

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -43,7 +43,7 @@ done
 rm out/$COV_TMP_FILE
 
 # Ignore these paths in the following tests.
-ignore="vendor\|\_gopath\|assets.go"
+ignore="vendor\|\_gopath\|assets.go\|out"
 
 # Check gofmt
 echo "Checking gofmt..."


### PR DESCRIPTION
test.sh does not like the buildroot build artifacts 