### PR TITLE
Add v1.5.2 and v1.6.0-alpha.0 releases

### DIFF
--- a/deploy/minikube/k8s_releases.json
+++ b/deploy/minikube/k8s_releases.json
@@ -1,5 +1,11 @@
 [
   {
+    "version": "v1.6.0-alpha.0"
+  },
+  {
+    "version": "v1.5.2"
+  },
+  {
     "version": "v1.5.1"
   },
   {


### PR DESCRIPTION
I've pushed everything to the storage bucket already with `make release-localkube`