### PR TITLE
Fixes from gometalinter

### DIFF
--- a/cmd/minikube/cmd/completion.go
+++ b/cmd/minikube/cmd/completion.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	cmdutil "k8s.io/minikube/cmd/util"
 )
@@ -86,7 +87,7 @@ func GenerateBashCompletion(w io.Writer, cmd *cobra.Command) error {
 
 	err = cmd.GenBashCompletion(w)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "Error generating bash completion")
 	}
 
 	return nil

--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -29,10 +29,6 @@ import (
 	"k8s.io/minikube/pkg/minikube/constants"
 )
 
-type configFile interface {
-	io.ReadWriter
-}
-
 type setFn func(string, string) error
 
 type Setting struct {

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -215,7 +215,7 @@ func setupKubeconfig(name, server, certAuth, cliCert, cliKey string, keepContext
 	config.Contexts[contextName] = context
 
 	// Only set current context to minikube if the user has not used the keepContext flag
-	if keepContext != true {
+	if !keepContext {
 		config.CurrentContext = contextName
 	}
 

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -108,7 +108,7 @@ func UploadError(b []byte, url string) error {
 	if err != nil {
 		return errors.Wrap(err, "")
 	} else if resp.StatusCode != 200 {
-		return errors.Errorf("Error sending error report to %s, got response code %s", url, resp.StatusCode)
+		return errors.Errorf("Error sending error report to %s, got response code %d", url, resp.StatusCode)
 	}
 	return nil
 }

--- a/pkg/localkube/apiserver.go
+++ b/pkg/localkube/apiserver.go
@@ -17,10 +17,6 @@ limitations under the License.
 package localkube
 
 import (
-	"strings"
-
-	"k8s.io/client-go/1.5/kubernetes"
-	"k8s.io/client-go/1.5/rest"
 	apiserver "k8s.io/kubernetes/cmd/kube-apiserver/app"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
 
@@ -64,23 +60,4 @@ func StartAPIServer(lk LocalkubeServer) func() error {
 	return func() error {
 		return apiserver.Run(config)
 	}
-}
-
-// notFoundErr returns true if the passed error is an API server object not found error
-func notFoundErr(err error) bool {
-	if err == nil {
-		return false
-	}
-	return strings.HasSuffix(err.Error(), "not found")
-}
-
-func kubeClient() *kubernetes.Clientset {
-	config := &rest.Config{
-		Host: "http://localhost:8080", // TODO: Make configurable
-	}
-	client, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		panic(err)
-	}
-	return client
 }

--- a/pkg/minikube/cluster/cluster_test.go
+++ b/pkg/minikube/cluster/cluster_test.go
@@ -519,7 +519,7 @@ func TestCreateSSHShell(t *testing.T) {
 		t.Fatalf("Error running ssh command: %s", err)
 	}
 
-	if s.HadASessionRequested != true {
+	if !s.HadASessionRequested {
 		t.Fatalf("Expected ssh session to be run")
 	}
 }
@@ -679,12 +679,6 @@ func TestUpdateKubernetesVersion(t *testing.T) {
 		t.Fatalf("File not copied. Expected transfers to contain: %s. It was: %s", contents, transferred)
 	}
 }
-
-type nopCloser struct {
-	io.Reader
-}
-
-func (nopCloser) Close() error { return nil }
 
 func TestIsLocalkubeCached(t *testing.T) {
 	tempDir := tests.MakeTempDir()

--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -34,19 +34,7 @@ const (
 	WantKubectlDownloadMsg    = "WantKubectlDownloadMsg"
 )
 
-type configFile interface {
-	io.ReadWriter
-}
-
-type setFn func(string, string) error
 type MinikubeConfig map[string]interface{}
-
-type Setting struct {
-	name        string
-	set         func(MinikubeConfig, string, string) error
-	validations []setFn
-	callbacks   []setFn
-}
 
 func Get(name string) (string, error) {
 	m, err := ReadConfig()

--- a/pkg/minikube/kubeconfig/config_test.go
+++ b/pkg/minikube/kubeconfig/config_test.go
@@ -198,7 +198,7 @@ func configEquals(a, b *api.Config) bool {
 			aContext.Cluster != bContext.Cluster ||
 			aContext.AuthInfo != bContext.AuthInfo ||
 			aContext.Namespace != bContext.Namespace ||
-			len(aContext.Extensions) != len(aContext.Extensions) {
+			len(aContext.Extensions) != len(bContext.Extensions) {
 			return false
 		}
 

--- a/pkg/minikube/notify/notify_test.go
+++ b/pkg/minikube/notify/notify_test.go
@@ -48,21 +48,21 @@ func TestShouldCheckURL(t *testing.T) {
 
 	// test that if users want update notification, the URL version does get checked
 	viper.Set(config.WantUpdateNotification, true)
-	if shouldCheckURLVersion(lastUpdateCheckFilePath) == false {
+	if !shouldCheckURLVersion(lastUpdateCheckFilePath) {
 		t.Fatalf("shouldCheckURLVersion returned false even though there was no last_update_check file")
 	}
 
 	// test that update notifications get triggered if it has been longer than 24 hours
 	viper.Set(config.ReminderWaitPeriodInHours, 24)
 	writeTimeToFile(lastUpdateCheckFilePath, time.Time{}) //time.Time{} returns time -> January 1, year 1, 00:00:00.000000000 UTC.
-	if shouldCheckURLVersion(lastUpdateCheckFilePath) == false {
+	if !shouldCheckURLVersion(lastUpdateCheckFilePath) {
 		t.Fatalf("shouldCheckURLVersion returned false even though longer than 24 hours since last update")
 	}
 
 	// test that update notifications do not get triggered if it has been less than 24 hours
 	writeTimeToFile(lastUpdateCheckFilePath, time.Now().UTC())
-	if shouldCheckURLVersion(lastUpdateCheckFilePath) == true {
-		t.Fatalf("shouldCheckURLVersion returned false even though longer than 24 hours since last update")
+	if shouldCheckURLVersion(lastUpdateCheckFilePath) {
+		t.Fatalf("shouldCheckURLVersion returned true even though less than 24 hours since last update")
 	}
 
 }

--- a/test/integration/cluster_dns_test.go
+++ b/test/integration/cluster_dns_test.go
@@ -64,6 +64,6 @@ func testClusterDNS(t *testing.T) {
 	}
 
 	if err := commonutil.RetryAfter(40, dnsTest, 5*time.Second); err != nil {
-		t.Fatalf("DNS lookup failed with error:", err)
+		t.Fatal("DNS lookup failed with error:", err)
 	}
 }

--- a/test/integration/vm_systemd.go
+++ b/test/integration/vm_systemd.go
@@ -39,6 +39,6 @@ func testVMSystemd(t *testing.T) {
 	expectedStr := "0 loaded units listed"
 	sshCmdOutput := minikubeRunner.RunCommand("ssh -- systemctl --state=failed --all", true)
 	if !strings.Contains(sshCmdOutput, expectedStr) {
-		t.Logf("Expected no systemd units to be failed got:\n %s", expectedStr, sshCmdOutput)
+		t.Logf("Expected no systemd units to be failed got:\n %s", sshCmdOutput)
 	}
 }


### PR DESCRIPTION
Ran `gometalinter` (runs many go linters in paralell) to get rid of unused code and confusing constructs.  These were the errors that stuck out at me