### PR TITLE
Fail jenkins job when make cross fails

### DIFF
--- a/hack/jenkins/minikube_cross_build_and_upload.sh
+++ b/hack/jenkins/minikube_cross_build_and_upload.sh
@@ -21,6 +21,8 @@
 # ghprbPullId: The pull request ID, injected from the ghpbr plugin.
 # ghprbActualCommit: The commit hash, injected from the ghpbr plugin.
 
+set -e
+
 gsutil cp gs://minikube-builds/logs/index.html gs://minikube-builds/logs/${ghprbPullId}/index.html
 
 # Build all platforms (Windows, Linux, OSX)


### PR DESCRIPTION
#1050 and #1053 failed cross build and still triggered downstream jobs.  