### PR TITLE
Add release-iso Makefile rule

### DIFF
--- a/deploy/iso/minikube-iso/README.md
+++ b/deploy/iso/minikube-iso/README.md
@@ -40,10 +40,10 @@ Either import your private key or generate a sign-only key using `gpg2 --gen-key
 ```
 $ git clone https://github.com/kubernetes/minikube
 $ cd minikube
-$ make minikube-iso
+$ make minikube_iso
 ```
 
-The bootable ISO image will be available in `out/buildroot/output/images/rootfs.iso9660`.
+The bootable ISO image will be available in `out/minikube.iso`.
 
 ### Testing local minikube-iso changes
 

--- a/hack/jenkins/build_iso.sh
+++ b/hack/jenkins/build_iso.sh
@@ -17,7 +17,7 @@
 
 set -e
 ISO="out/buildroot/output/images/rootfs.iso9660"
-make minikube-iso
+make minikube_iso
 openssl sha256 ${ISO} | awk '{print $2}' > "${ISO}.sha256"
 gsutil cp "${ISO}" "${DEST}"
 gsutil cp "${ISO}.sha256" "${DEST}.sha256"

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -17,11 +17,13 @@ limitations under the License.
 package constants
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	"k8s.io/kubernetes/pkg/util/homedir"
 	"k8s.io/kubernetes/pkg/version"
+	minikubeVersion "k8s.io/minikube/pkg/version"
 )
 
 // MachineName is the name to use for the VM.
@@ -60,9 +62,7 @@ var LogFlags = [...]string{
 
 const (
 	DefaultKeepContext  = false
-	DefaultIsoUrl       = "https://storage.googleapis.com/minikube/iso/minikube-v1.0.6.iso"
 	ShaSuffix           = ".sha256"
-	DefaultIsoShaUrl    = DefaultIsoUrl + ShaSuffix
 	DefaultMemory       = 2048
 	DefaultCPUS         = 2
 	DefaultDiskSize     = "20g"
@@ -75,6 +75,9 @@ const (
 	GithubMinikubeReleasesURL = "https://storage.googleapis.com/minikube/releases.json"
 	KubernetesVersionGCSURL   = "https://storage.googleapis.com/minikube/k8s_releases.json"
 )
+
+var DefaultIsoUrl = fmt.Sprintf("https://storage.googleapis.com/minikube/iso/minikube-%s.iso", minikubeVersion.GetIsoVersion())
+var DefaultIsoShaUrl = DefaultIsoUrl + ShaSuffix
 
 var DefaultKubernetesVersion = version.Get().GitVersion
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -28,8 +28,14 @@ const VersionPrefix = "v"
 
 var version = "v0.0.0-unset"
 
+var isoVersion = "v0.0.0-unset"
+
 func GetVersion() string {
 	return version
+}
+
+func GetIsoVersion() string {
+	return isoVersion
 }
 
 func GetSemverVersion() (semver.Version, error) {


### PR DESCRIPTION
This also tracks the ISO version in the makefile and passes it with
ldflags to automatically bump the default version in the minikube
binary.


I rebased this to get the PR that doesn't download the ISO during tests.