### PR TITLE
Make heapster service available via NodePort.

### DIFF
--- a/deploy/addons/heapster/heapster-svc.yaml
+++ b/deploy/addons/heapster/heapster-svc.yaml
@@ -8,6 +8,7 @@ metadata:
   name: heapster
   namespace: kube-system
 spec:
+  type: NodePort
   ports:
   - port: 80
     targetPort: 8082


### PR DESCRIPTION
The following PR makes heapster's REST API available via NodePort when the heapster addon is enabled on minikube, as described in https://github.com/kubernetes/minikube/issues/1070.