### PR TITLE
Add missing newline chars to error messages

### DIFF
--- a/cmd/minikube/cmd/config/open.go
+++ b/cmd/minikube/cmd/config/open.go
@@ -88,13 +88,14 @@ minikube addons enable %s`, addonName, addonName))
 
 		serviceList, err := cluster.GetServiceListByLabel(namespace, key, addonName)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error getting service with namespace: %s and labels %s:%s: %s", namespace, key, addonName, err)
+			fmt.Fprintf(os.Stderr, "Error getting service with namespace: %s and labels %s:%s: %s\n", namespace, key, addonName, err)
 			os.Exit(1)
 		}
 		if len(serviceList.Items) == 0 {
 			fmt.Fprintf(os.Stdout, `
 This addon does not have an endpoint defined for the 'addons open' command
-You can add one by annotating a service with the label %s:%s`, key, addonName)
+You can add one by annotating a service with the label %s:%s
+`, key, addonName)
 			os.Exit(0)
 		}
 		for i := range serviceList.Items {

--- a/cmd/minikube/cmd/config/unset.go
+++ b/cmd/minikube/cmd/config/unset.go
@@ -31,7 +31,7 @@ var configUnsetCmd = &cobra.Command{
 	Long:  "unsets PROPERTY_NAME from the minikube config file.  Can be overwritten by flags or environmental variables",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 1 {
-			fmt.Fprintf(os.Stdout, "usage: minikube config unset PROPERTY_NAME")
+			fmt.Fprintln(os.Stdout, "usage: minikube config unset PROPERTY_NAME")
 			os.Exit(1)
 		}
 		err := unset(args[0])


### PR DESCRIPTION
Several error messages don't print out newline characters at the end, for example:

```
$ minikube addons open dashboard
This addon does not have an endpoint defined for the 'addons open' command
You can add one by annotating a service with the label kubernetes.io/minikube-addons-endpoint:dashboard$
```