### PR TITLE
Use backticks inline instead of $(shell ...) in rkt-bin.mk

### DIFF
--- a/deploy/iso/minikube-iso/package/rkt-bin/rkt-bin.mk
+++ b/deploy/iso/minikube-iso/package/rkt-bin/rkt-bin.mk
@@ -21,7 +21,7 @@ define RKT_BIN_BUILD_CMDS
 	gpg2 --import $(BR2_DL_DIR)/app-signing-pubkey.gpg
 
 	gpg2 \
-		--trusted-key $(shell gpg2 --with-colons --keyid-format LONG -k security@coreos.com | egrep ^pub | cut -d ':' -f5) \
+		--trusted-key `gpg2 --with-colons --keyid-format long -k security@coreos.com | egrep ^pub | cut -d ':' -f5` \
 		--verify-files $(BR2_DL_DIR)/rkt-v$(RKT_BIN_VERSION).tar.gz.asc
 
 	mkdir -p $(TARGET_DIR)/var/lib/rkt


### PR DESCRIPTION
While working on a container to run the minikube-iso build the run would always produce this failure in the `>>> rkt-bin 1.23.0 Building` stage of the build:

```
gpg2 --trusted-key --verify-files "/usr/local/src/out/buildroot/dl"/rkt-v1.23.0.tar.gz.asc
gpg: `--verify-files' is not a valid long keyID
```

Some discussion in the minikube slack indicated it was not entirely unknown that a first-run build might fail if there is no default keyring, and some discussion in the #buildroot IRC channel led to using the backticks.