### PR TITLE
test: check stopped status repeatedly

### DIFF
--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -111,10 +111,17 @@ func (m *MinikubeRunner) GetStatus() string {
 }
 
 func (m *MinikubeRunner) CheckStatus(desired string) {
+	if err := m.CheckStatusNoFail(desired); err != nil {
+		m.T.Fatalf("%v", err)
+	}
+}
+
+func (m *MinikubeRunner) CheckStatusNoFail(desired string) error {
 	s := m.GetStatus()
 	if s != desired {
-		m.T.Fatalf("Machine is in the wrong state: %s, expected  %s", s, desired)
+		return fmt.Errorf("Machine is in the wrong state: %s, expected  %s", s, desired)
 	}
+	return nil
 }
 
 type KubectlRunner struct {


### PR DESCRIPTION
In `TestStartStop()`, check for stopped status once in 5 seconds, up to 30 seconds, instead of always sleeping for 30 seconds before stopping it. That way we can reduce duration of the test.

To do that, we need to split out `MinikubeRunner.CheckStatus()` into `CheckStatusNoFail()` that doesn't lead to `T.Fatalf()`. Other call sites of `CheckStatus()` would not be then affected.