### PR TITLE
Detect and test against ISO changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ INSTALL_SIZE ?= $(shell du out/minikube-windows-amd64.exe | cut -f1)
 BUILDROOT_BRANCH ?= 2016.08
 
 ISO_VERSION ?= v1.0.6
+ISO_BUCKET ?= minikube/iso
 
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
@@ -47,11 +48,9 @@ BUILD_OS := $(shell uname -s)
 LOCALKUBE_VERSION := $(shell $(PYTHON) hack/get_k8s_version.py --k8s-version-only 2>&1)
 LOCALKUBE_BUCKET := gs://minikube/k8sReleases
 
-ISO_BUCKET := gs://minikube/iso
-
 # Set the version information for the Kubernetes servers, and build localkube statically
 K8S_VERSION_LDFLAGS := $(shell $(PYTHON) hack/get_k8s_version.py 2>&1)
-MINIKUBE_LDFLAGS := -X k8s.io/minikube/pkg/version.version=$(VERSION) -X k8s.io/minikube/pkg/version.isoVersion=$(ISO_VERSION)
+MINIKUBE_LDFLAGS := -X k8s.io/minikube/pkg/version.version=$(VERSION) -X k8s.io/minikube/pkg/version.isoVersion=$(ISO_VERSION) -X k8s.io/minikube/pkg/version.isoPath=$(ISO_BUCKET)
 LOCALKUBE_LDFLAGS := "$(K8S_VERSION_LDFLAGS) $(MINIKUBE_LDFLAGS) -s -w -extldflags '-static'"
 
 LOCALKUBEFILES := GOPATH=$(GOPATH) go list  -f '{{join .Deps "\n"}}' ./cmd/localkube/ | grep k8s.io | GOPATH=$(GOPATH) xargs go list -f '{{ range $$file := .GoFiles }} {{$$.Dir}}/{{$$file}}{{"\n"}}{{end}}'
@@ -179,6 +178,6 @@ update-releases:
 
 .PHONY: release-iso
 release-iso: minikube_iso checksum
-	gsutil cp out/minikube.iso $(ISO_BUCKET)/minikube-$(ISO_VERSION).iso
-	gsutil cp out/minikube.iso.sha256 $(ISO_BUCKET)/minikube-$(ISO_VERSION).iso.sha256
+	gsutil cp out/minikube.iso gs://$(ISO_BUCKET)/minikube-$(ISO_VERSION).iso
+	gsutil cp out/minikube.iso.sha256 gs://$(ISO_BUCKET)/minikube-$(ISO_VERSION).iso.sha256
 

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -39,6 +39,9 @@ MINIKUBE_WANTREPORTERRORPROMPT=False \
 
 rm -rf $HOME/.minikube || true
 
+# See the default image
+./out/minikube-${OS_ARCH} start -h | grep iso
+
 # Allow this to fail, we'll switch on the return code below.
 set +e
 out/e2e-${OS_ARCH} -minikube-args="--vm-driver=${VM_DRIVER} --cpus=4 --v=100 ${EXTRA_BUILD_ARGS}" -test.v -test.timeout=30m -binary=out/minikube-${OS_ARCH}

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -89,7 +89,7 @@ const (
 	KubernetesVersionGCSURL   = "https://storage.googleapis.com/minikube/k8s_releases.json"
 )
 
-var DefaultIsoUrl = fmt.Sprintf("https://storage.googleapis.com/minikube/iso/minikube-%s.iso", minikubeVersion.GetIsoVersion())
+var DefaultIsoUrl = fmt.Sprintf("https://storage.googleapis.com/%s/minikube-%s.iso", minikubeVersion.GetIsoPath(), minikubeVersion.GetIsoVersion())
 var DefaultIsoShaUrl = DefaultIsoUrl + ShaSuffix
 
 var DefaultKubernetesVersion = version.Get().GitVersion

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -30,12 +30,18 @@ var version = "v0.0.0-unset"
 
 var isoVersion = "v0.0.0-unset"
 
+var isoPath = "minikube/iso"
+
 func GetVersion() string {
 	return version
 }
 
 func GetIsoVersion() string {
 	return isoVersion
+}
+
+func GetIsoPath() string {
+	return isoPath
 }
 
 func GetSemverVersion() (semver.Version, error) {


### PR DESCRIPTION
    Detect and test against ISO changes
    
    When changes are made to the ISO folder, rebuild and upload the newly
    modified image.  Use this uploaded image as the default in the e2e test
    binaries, so that the e2e test suite runs against the PR's changes.
    
    TODO: Subsequent PRs (no changes to ISO) will still run against the
    default version in the makefile.  We should figure out if we want to
    always run tests against the "latest" image.
