### PR TITLE
Call RootCmd's persistentPreRun from svc cmd

### DIFF
--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -49,6 +49,8 @@ var serviceCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		serviceURLTemplate = t
+
+		RootCmd.PersistentPreRun(cmd, args)
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 || len(args) > 1 {


### PR DESCRIPTION
Currently the service command overwrites the RootCmd's persistent pre
run.  Now it will run the rootcmd's persistent pre run after it runs
its own.