### PR TITLE
Add documentation for CI iso builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ We publish CI builds of minikube, built at every Pull Request. Builds are availa
 - https://storage.googleapis.com/minikube-builds/PR_NUMBER/minikube-linux-amd64
 - https://storage.googleapis.com/minikube-builds/PR_NUMBER/minikube-windows-amd64.exe
 
+We also publish CI builds of minikube-iso, built at every Pull Request that touches deploy/iso/minikube-iso.  Builds are available at:
+- https://storage.googleapis.com/minikube-builds/PR_NUMBER/minikube-testing.iso
 
 ## Quickstart
 


### PR DESCRIPTION
This will be helpful for people who immediately want to start using an iso change.