### PR TITLE
local/generic ssh driver for minikube

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -43,6 +43,11 @@ rm -rf $HOME/.minikube || true
 # See the default image
 ./out/minikube-${OS_ARCH} start -h | grep iso
 
+# Force use-vendored-driver for local driver job
+if [ "$JOB_NAME" = "Linux-Local" ]; then
+    ./out/minikube-${OS_ARCH} config set use-vendored-driver true
+fi
+
 # Allow this to fail, we'll switch on the return code below.
 set +e
 out/e2e-${OS_ARCH} -minikube-args="--vm-driver=${VM_DRIVER} --cpus=4 --v=100 ${EXTRA_BUILD_ARGS}" -test.v -test.timeout=30m -binary=out/minikube-${OS_ARCH}

--- a/hack/jenkins/linux_integration_tests_local.sh
+++ b/hack/jenkins/linux_integration_tests_local.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This script runs the integration tests on a Linux machine for the Local Driver
+
+# The script expects the following env variables:
+# MINIKUBE_LOCATION: GIT_COMMIT from upstream build.
+# COMMIT: Actual commit ID from upstream build
+# EXTRA_BUILD_ARGS (optional): Extra args to be passed into the minikube integrations tests
+# access_token: The Github API access token. Injected by the Jenkins credential provider. 
+
+set -e
+
+OS_ARCH="linux-amd64"
+VM_DRIVER="local"
+JOB_NAME="Linux-Local"
+
+# Debug information
+# print jenkins environment info
+env
+# see if the keys needed for local driver are present in the environment
+ls -altr ~/.ssh/
+
+ssh -tt -o BatchMode=yes -o StrictHostKeyChecking=no -o CheckHostIP=no -o UserKnownHostsFile=/dev/null 127.0.0.1 <<EOF
+    echo "`whoami` ALL=(ALL) NOPASSWD: ALL" | sudo tee -a /etc/sudoers
+EOF
+
+# test if a ssh actually works, if this does not work local driver
+# wont work either as it depends on using ~/.ssh/id_rsa to ssh into localhost
+# and needs authorized_keys to be setup correctly as well.
+ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o CheckHostIP=no -o UserKnownHostsFile=/dev/null 127.0.0.1 ls -altr ~
+
+# Download files and set permissions
+source common.sh

--- a/hack/jenkins/minikube_set_pending.sh
+++ b/hack/jenkins/minikube_set_pending.sh
@@ -27,6 +27,10 @@
 set -e
 set +x
 
+# NOTE(dims): We should add "Linux-Local" to the list below after the CI system
+# supports password-less sudo as the local driver needs to ssh and run sudo to
+# install and start for example the localkube service.
+
 for job in "OSX-Virtualbox" "OSX-XHyve" "Linux-Virtualbox" "Linux-KVM" "Windows-HyperV"; do
   target_url="https://storage.googleapis.com/minikube-builds/logs/${ghprbPullId}/${job}.txt"
   curl "https://api.github.com/repos/kubernetes/minikube/statuses/${ghprbActualCommit}?access_token=$access_token" \

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -284,6 +284,7 @@ func engineOptions(config MachineConfig) *engine.Options {
 		Env:              config.DockerEnv,
 		InsecureRegistry: config.InsecureRegistry,
 		RegistryMirror:   config.RegistryMirror,
+		InstallURL:       drivers.DefaultEngineInstallURL,
 	}
 	return &o
 }
@@ -301,8 +302,10 @@ func createVirtualboxHost(config MachineConfig) drivers.Driver {
 func createHost(api libmachine.API, config MachineConfig) (*host.Host, error) {
 	var driver interface{}
 
-	if err := config.Downloader.CacheMinikubeISOFromURL(config.MinikubeISO); err != nil {
-		return nil, errors.Wrap(err, "Error attempting to cache minikube ISO from URL")
+	if config.VMDriver != "local" {
+		if err := config.Downloader.CacheMinikubeISOFromURL(config.MinikubeISO); err != nil {
+			return nil, errors.Wrap(err, "Error attempting to cache minikube ISO from URL")
+		}
 	}
 
 	switch config.VMDriver {
@@ -314,6 +317,8 @@ func createHost(api libmachine.API, config MachineConfig) (*host.Host, error) {
 		driver = createKVMHost(config)
 	case "xhyve":
 		driver = createXhyveHost(config)
+	case "local":
+		driver = createLocalHost(config)
 	case "hyperv":
 		driver = createHypervHost(config)
 	default:

--- a/pkg/minikube/cluster/cluster_linux.go
+++ b/pkg/minikube/cluster/cluster_linux.go
@@ -23,7 +23,10 @@ import (
 	"path/filepath"
 
 	"github.com/docker/machine/libmachine/drivers"
+	"github.com/docker/machine/libmachine/engine"
 	"github.com/docker/machine/libmachine/host"
+	"github.com/docker/machine/libmachine/mcnutils"
+	"k8s.io/minikube/pkg/minikube/cluster/local"
 	"k8s.io/minikube/pkg/minikube/constants"
 )
 
@@ -69,5 +72,19 @@ func getVMHostIP(host *host.Host) (net.IP, error) {
 		return net.ParseIP("192.168.42.1"), nil
 	default:
 		return []byte{}, errors.New("Error, attempted to get host ip address for unsupported driver")
+	}
+}
+
+func createLocalHost(config MachineConfig) *local.Driver {
+	return &local.Driver{
+		EnginePort: engine.DefaultPort,
+		BaseDriver: &drivers.BaseDriver{
+			MachineName: constants.MachineName,
+			StorePath:   constants.GetMinipath(),
+			IPAddress:   "127.0.0.1",
+			SSHUser:     mcnutils.GetUsername(),
+			SSHPort:     22,
+			SSHKeyPath:  filepath.Join(mcnutils.GetHomeDir(), ".ssh", "id_rsa"),
+		},
 	}
 }

--- a/pkg/minikube/cluster/cluster_non_linux_panic.go
+++ b/pkg/minikube/cluster/cluster_non_linux_panic.go
@@ -23,3 +23,7 @@ import "github.com/docker/machine/libmachine/drivers"
 func createKVMHost(config MachineConfig) drivers.Driver {
 	panic("kvm not supported")
 }
+
+func createLocalHost(config MachineConfig) drivers.Driver {
+	panic("local not supported")
+}

--- a/pkg/minikube/cluster/local/local.go
+++ b/pkg/minikube/cluster/local/local.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package local
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path"
+	"strconv"
+	"time"
+
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/docker/machine/libmachine/log"
+	"github.com/docker/machine/libmachine/mcnflag"
+	"github.com/docker/machine/libmachine/mcnutils"
+	"github.com/docker/machine/libmachine/state"
+)
+
+type Driver struct {
+	*drivers.BaseDriver
+	EnginePort int
+	SSHKey     string
+}
+
+const (
+	defaultTimeout = 1 * time.Second
+)
+
+// GetCreateFlags registers the flags this driver adds to
+// "docker hosts create"
+func (d *Driver) GetCreateFlags() []mcnflag.Flag {
+	return nil
+}
+
+// DriverName returns the name of the driver
+func (d *Driver) DriverName() string {
+	return "local"
+}
+
+func (d *Driver) GetSSHHostname() (string, error) {
+	return d.GetIP()
+}
+
+func (d *Driver) GetSSHUsername() string {
+	return d.SSHUser
+}
+
+func (d *Driver) GetSSHKeyPath() string {
+	return d.SSHKeyPath
+}
+
+func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
+	return nil
+}
+
+func (d *Driver) PreCreateCheck() error {
+	if d.SSHKey != "" {
+		if _, err := os.Stat(d.SSHKey); os.IsNotExist(err) {
+			return fmt.Errorf("SSH key does not exist: %q", d.SSHKey)
+		}
+
+		// TODO: validate the key is a valid key
+	}
+
+	return nil
+}
+
+func (d *Driver) Create() error {
+	if d.SSHKey == "" {
+		log.Info("No SSH key specified. Assuming an existing key at the default location.")
+	} else {
+		log.Info("Importing SSH key...")
+
+		d.SSHKeyPath = d.ResolveStorePath(path.Base(d.SSHKey))
+		if err := copySSHKey(d.SSHKey, d.SSHKeyPath); err != nil {
+			return err
+		}
+
+		if err := copySSHKey(d.SSHKey+".pub", d.SSHKeyPath+".pub"); err != nil {
+			log.Infof("Couldn't copy SSH public key : %s", err)
+		}
+	}
+
+	log.Debugf("IP: %s", d.IPAddress)
+
+	return nil
+}
+
+func (d *Driver) GetURL() (string, error) {
+	if err := drivers.MustBeRunning(d); err != nil {
+		return "", err
+	}
+
+	ip, err := d.GetIP()
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("tcp://%s", net.JoinHostPort(ip, strconv.Itoa(d.EnginePort))), nil
+}
+
+func (d *Driver) GetState() (state.State, error) {
+	address := net.JoinHostPort(d.IPAddress, strconv.Itoa(d.SSHPort))
+
+	_, err := net.DialTimeout("tcp", address, defaultTimeout)
+	if err != nil {
+		return state.Stopped, nil
+	}
+
+	return state.Running, nil
+}
+
+func (d *Driver) Start() error {
+	return errors.New("generic driver does not support start")
+}
+
+func (d *Driver) Stop() error {
+	return errors.New("generic driver does not support stop")
+}
+
+func (d *Driver) Restart() error {
+	_, err := drivers.RunSSHCommandFromDriver(d, "sudo shutdown -r now")
+	return err
+}
+
+func (d *Driver) Kill() error {
+	return errors.New("generic driver does not support kill")
+}
+
+func (d *Driver) Remove() error {
+	return nil
+}
+
+func copySSHKey(src, dst string) error {
+	if err := mcnutils.CopyFile(src, dst); err != nil {
+		return fmt.Errorf("unable to copy ssh key: %s", err)
+	}
+
+	if err := os.Chmod(dst, 0600); err != nil {
+		return fmt.Errorf("unable to set permissions on the ssh key: %s", err)
+	}
+
+	return nil
+}

--- a/pkg/minikube/machine/client_linux.go
+++ b/pkg/minikube/machine/client_linux.go
@@ -17,16 +17,20 @@ limitations under the License.
 package machine
 
 import (
+	"encoding/json"
+
 	"github.com/docker/machine/drivers/virtualbox"
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/drivers/plugin"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"k8s.io/minikube/pkg/minikube/cluster/local"
 )
 
 var driverMap = map[string]driverGetter{
 	"kvm":        getKVMDriver,
 	"virtualbox": getVirtualboxDriver,
+	"local":      getLocalDriver,
 }
 
 func getKVMDriver(rawDriver []byte) (drivers.Driver, error) {
@@ -34,6 +38,15 @@ func getKVMDriver(rawDriver []byte) (drivers.Driver, error) {
 The KVM driver is not included in minikube yet.  Please follow the direction at
 https://github.com/kubernetes/minikube/blob/master/DRIVERS.md#kvm-driver
 `)
+}
+
+func getLocalDriver(rawDriver []byte) (drivers.Driver, error) {
+	var driver drivers.Driver
+	driver = &local.Driver{}
+	if err := json.Unmarshal(rawDriver, &driver); err != nil {
+		return nil, errors.Wrap(err, "Error unmarshalling local driver")
+	}
+	return driver, nil
 }
 
 // StartDriver starts the desired machine driver if necessary.

--- a/vendor/k8s.io/kubernetes/pkg/genericapiserver/options/server_run_options.go
+++ b/vendor/k8s.io/kubernetes/pkg/genericapiserver/options/server_run_options.go
@@ -241,7 +241,7 @@ func (s *ServerRunOptions) NewSelfClientConfig(token string) (*restclient.Config
 		clientConfig.CAFile = s.TLSCAFile
 		clientConfig.BearerToken = token
 	} else if s.InsecurePort > 0 {
-		clientConfig.Host = net.JoinHostPort(s.InsecureBindAddress.String(), strconv.Itoa(s.InsecurePort))
+		clientConfig.Host = "http://" + net.JoinHostPort(s.InsecureBindAddress.String(), strconv.Itoa(s.InsecurePort))
 	} else {
 		return nil, errors.New("Unable to set url for apiserver local client")
 	}


### PR DESCRIPTION
Just scp the minikube into VM or host and run:
out/minikube --v=9 start --logtostderr --vm-driver=local

* We do not need the minikube ISO, so don't download it.
* Use 127.0.0.1 as the IP
* Get the user name and the SSH id_rsa from the environment.
* Support only Linux for the moment.
* Initial code picked up from:
  https://github.com/docker/machine/blob/master/drivers/generic/generic.go

Earlier and ongoing discussions, point to overriding SSH in the
libmachine layer somehow. This PR takes the approach of of reusing
the information already available in the environment to support
the no-vm use case.

Note that it would be easy to supply the IP, id_rsa via command line
to even support a remote host/vm case if necessary.