### PR TITLE
Refactor service package and add test coverage

### DIFF
--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -68,12 +68,11 @@ var serviceCmd = &cobra.Command{
 		defer api.Close()
 
 		cluster.EnsureMinikubeRunningOrExit(api, 1)
-		if err := service.ValidateService(namespace, svc); err != nil {
-			fmt.Fprintln(os.Stderr, fmt.Sprintf("service '%s' could not be found running in namespace '%s' within kubernetes",
-				svc, namespace))
+		err = service.WaitAndMaybeOpenService(api, namespace, svc, serviceURLTemplate, serviceURLMode, https)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error opening service: %s\n", err)
 			os.Exit(1)
 		}
-		service.WaitAndMaybeOpenService(api, namespace, svc, serviceURLTemplate, serviceURLMode, https)
 	},
 }
 

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -36,8 +36,6 @@ import (
 	"github.com/docker/machine/libmachine/state"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
-	"k8s.io/client-go/1.5/kubernetes"
-	"k8s.io/client-go/1.5/tools/clientcmd"
 
 	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/constants"
@@ -408,21 +406,6 @@ func CreateSSHShell(api libmachine.API, args []string) error {
 		return errors.Wrap(err, "Error creating ssh client")
 	}
 	return client.Shell(strings.Join(args, " "))
-}
-
-func GetKubernetesClient() (*kubernetes.Clientset, error) {
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	configOverrides := &clientcmd.ConfigOverrides{}
-	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
-	config, err := kubeConfig.ClientConfig()
-	if err != nil {
-		return nil, fmt.Errorf("Error creating kubeConfig: %s", err)
-	}
-	client, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, errors.Wrap(err, "Error creating new client from kubeConfig.ClientConfig()")
-	}
-	return client, nil
 }
 
 // EnsureMinikubeRunningOrExit checks that minikube has a status available and that


### PR DESCRIPTION
Additionally, now all the client-go dependencies have been removed from pkg/cluster

While the level of abstraction may look a little unwieldy, I think its necessary to have this package unit-testable because of the constant breaking changes in client-go.  The testing abstractions will also make it easy to extend tests to the functions not covered.