### PR TITLE
vendor: Better deal with failures under golang 1.8

### DIFF
--- a/UPDATE_KUBERNETES.md
+++ b/UPDATE_KUBERNETES.md
@@ -88,3 +88,6 @@ git commit -m "Manual changes to update Kubernetes to foo"
 
 As a final part of updating kubernetes, a new version of localkube should be uploaded to GCS so that users can select this version of kubernetes/localkube in later minikube/localkube builds.  For instructions on how to do this, see [LOCALKUBE_RELEASING.md](https://github.com/kubernetes/minikube/blob/master/LOCALKUBE_RELEASING.md)
 
+#### Note on bugfix from Kubernetes
+
+In case that specific bugfix patches have been applied to the k8s vendor tree, the patches could be at some point overwritten by next Kubernetes updates. So contributors should check if the vendor tree still contains the bugfixes even after having updated the vendor tree.

--- a/vendor/k8s.io/kubernetes/pkg/client/restclient/url_utils.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/restclient/url_utils.go
@@ -33,10 +33,7 @@ func DefaultServerURL(host, apiPath string, groupVersion unversioned.GroupVersio
 	}
 	base := host
 	hostURL, err := url.Parse(base)
-	if err != nil {
-		return nil, "", err
-	}
-	if hostURL.Scheme == "" || hostURL.Host == "" {
+	if err != nil || hostURL.Scheme == "" || hostURL.Host == "" {
 		scheme := "http://"
 		if defaultTLS {
 			scheme = "https://"


### PR DESCRIPTION
If minikube is built with go 1.8 or newer, localkube panics immediately with the following message:

```
Feb 21 15:04:05 minikube localkube[3566]: I0221 15:04:05.712095    3566 services.go:51] Setting service IP to "10.0.0.1" (read-write).
Feb 21 15:04:05 minikube localkube[3566]: panic: parse 127.0.0.1:8080: first path segment in URL cannot contain colon
Feb 21 15:04:05 minikube localkube[3566]: goroutine 151 [running]:
Feb 21 15:04:05 minikube localkube[3566]: k8s.io/minikube/vendor/k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion.NewForConfigOrDie(0xc420c75380, 0xc420d04d40)
```

This issue was already reported to Kubernetes, https://github.com/kubernetes/kubernetes/issues/38380. That was already fixed in Kubernetes, but it's not included in Minikube yet.
So let's cherry-pick the commit to minikube, to avoid the panic.

Original commit message from https://github.com/kubernetes/kubernetes/pull/38519

```
If there is any error in the initial parsing then we should just try adding the scheme.

url.Parse(base) has changed in 1.8. Please see the following change https://github.com/golang/go/commit/c5ccbdd22bdbdc43d541b7e7d4ed66ceb559030e

Fixes https://github.com/kubernetes/kubernetes/issues/38380
```

/cc @dims 