### PR TITLE
Set /O=system:masters for the admin certificate DN

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ To change the `MaxPods` setting to 5 on the Kubelet, pass this flag: `--extra-co
 
 This feature also supports nested structs. To change the `LeaderElection.LeaderElect` setting to `true` on the scheduler, pass this flag: `--extra-config=scheduler.LeaderElection.LeaderElect=true`.
 
-To set the `AuthorizationMode` on the `apiserver` to `RBAC`, you can use: `--extra-config=apiserver.GenericServerRunOptions.AuthorizationMode=RBAC`. You should use `--extra-config=apiserver.GenericServerRunOptions.AuthorizationRBAC,SuperUser=minikube` as well in that case.
+To set the `AuthorizationMode` on the `apiserver` to `RBAC`, you can use: `--extra-config=apiserver.GenericServerRunOptions.AuthorizationMode=RBAC`.
 
 To enable all alpha feature gates, you can use: `--feature-gates=AllAlpha=true`
 

--- a/pkg/util/crypto.go
+++ b/pkg/util/crypto.go
@@ -89,7 +89,8 @@ func GenerateSignedCert(certPath, keyPath string, ips []net.IP, alternateDNS []s
 	template := x509.Certificate{
 		SerialNumber: big.NewInt(2),
 		Subject: pkix.Name{
-			CommonName: "minikube",
+			CommonName:   "minikube",
+			Organization: []string{"system:masters"},
 		},
 		NotBefore: time.Now(),
 		NotAfter:  time.Now().Add(time.Hour * 24 * 365),


### PR DESCRIPTION
As per https://kubernetes.io/docs/admin/authorization/#rbac-mode:

> When bootstrapping, superuser credentials should include the system:masters group, for example by creating a client cert with /O=system:masters. This gives those credentials full access to the API and allows an admin to then set up bindings for other users.

This removes the need for the super user command line argument, which is scheduled to be removed in k8s 1.6. 

Tested locally with kubectl 1.5.1/server 1.5.3:
- with super-user argument and without the patch I'm able to create resources in the cluster
- without super-user argument and without the patch I'm seeing permission-denied errors when creating resources
- without super-user argument and with the patch I again can create these resources

FWIW: This is related to a similar PR in kube-aws, https://github.com/coreos/kube-aws/issues/344