### PR TITLE
None driver

### DIFF
--- a/cmd/minikube/cmd/config/disable_test.go
+++ b/cmd/minikube/cmd/config/disable_test.go
@@ -36,7 +36,7 @@ func TestDisableUnknownAddon(t *testing.T) {
 	}
 }
 
-func TestDisableValidAddonNoVM(t *testing.T) {
+func TestDisableValidAddonLocal(t *testing.T) {
 	tempDir := tests.MakeTempDir()
 	defer os.RemoveAll(tempDir)
 
@@ -60,7 +60,7 @@ func TestDisableValidAddonNoVM(t *testing.T) {
 	}
 }
 
-func TestDeleteAddonViaDriver(t *testing.T) {
+func TestDeleteAddonSSH(t *testing.T) {
 	s, _ := tests.NewSSHServer()
 	port, err := s.Start()
 	if err != nil {
@@ -76,7 +76,7 @@ func TestDeleteAddonViaDriver(t *testing.T) {
 	}
 
 	dashboard := assets.Addons["dashboard"]
-	if err := deleteAddonViaDriver(dashboard, d); err != nil {
+	if err := deleteAddonSSH(dashboard, d); err != nil {
 		t.Fatalf("Unexpected error %s deleting addon", err)
 	}
 	// check command(s) were run

--- a/cmd/minikube/cmd/config/enable_test.go
+++ b/cmd/minikube/cmd/config/enable_test.go
@@ -36,7 +36,7 @@ func TestEnableUnknownAddon(t *testing.T) {
 	}
 }
 
-func TestEnableValidAddonNoVM(t *testing.T) {
+func TestEnableValidAddonLocal(t *testing.T) {
 	tempDir := tests.MakeTempDir()
 	defer os.RemoveAll(tempDir)
 
@@ -59,7 +59,7 @@ func TestEnableValidAddonNoVM(t *testing.T) {
 	}
 }
 
-func TestTransferAddonViaDriver(t *testing.T) {
+func TestTransferAddonSSH(t *testing.T) {
 	s, _ := tests.NewSSHServer()
 	port, err := s.Start()
 	if err != nil {
@@ -75,7 +75,7 @@ func TestTransferAddonViaDriver(t *testing.T) {
 	}
 
 	dashboard := assets.Addons["dashboard"]
-	if err := transferAddonViaDriver(dashboard, d); err != nil {
+	if err := transferAddonSSH(dashboard, d); err != nil {
 		t.Fatalf("Unexpected error %s transferring addon", err)
 	}
 	// check contents

--- a/cmd/minikube/cmd/env.go
+++ b/cmd/minikube/cmd/env.go
@@ -292,6 +292,15 @@ var dockerEnvCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		defer api.Close()
+		host, err := cluster.CheckIfApiExistsAndLoad(api)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error getting host: %s\n", err)
+			os.Exit(1)
+		}
+		if host.Driver.DriverName() == "none" {
+			fmt.Println(`'none' driver does not support 'minikube docker-env' command`)
+			os.Exit(0)
+		}
 
 		var shellCfg *ShellConfig
 

--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -97,6 +97,10 @@ var mountCmd = &cobra.Command{
 			glog.Errorln("Error loading api: ", err)
 			os.Exit(1)
 		}
+		if host.Driver.DriverName() == "none" {
+			fmt.Println(`'none' driver does not support 'minikube mount' command`)
+			os.Exit(0)
+		}
 		var ip net.IP
 		if mountIP == "" {
 			ip, err = cluster.GetVMHostIP(host)

--- a/cmd/minikube/cmd/ssh.go
+++ b/cmd/minikube/cmd/ssh.go
@@ -39,6 +39,15 @@ var sshCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		defer api.Close()
+		host, err := cluster.CheckIfApiExistsAndLoad(api)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error getting host: %s\n", err)
+			os.Exit(1)
+		}
+		if host.Driver.DriverName() == "none" {
+			fmt.Println(`'none' driver does not support 'minikube ssh' command`)
+			os.Exit(0)
+		}
 		err = cluster.CreateSSHShell(api, args)
 		if err != nil {
 			glog.Errorln(errors.Wrap(err, "Error attempting to ssh/run-ssh-command"))

--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -49,18 +49,20 @@ var statusCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		defer api.Close()
+
 		ms, err := cluster.GetHostStatus(api)
 		if err != nil {
 			glog.Errorln("Error getting machine status:", err)
 			cmdUtil.MaybeReportErrorAndExit(err)
 		}
-		ls := "N/A"
+
+		ls := state.None.String()
 		if ms == state.Running.String() {
 			ls, err = cluster.GetLocalkubeStatus(api)
-		}
-		if err != nil {
-			glog.Errorln("Error getting machine status:", err)
-			cmdUtil.MaybeReportErrorAndExit(err)
+			if err != nil {
+				glog.Errorln("Error localkube status:", err)
+				cmdUtil.MaybeReportErrorAndExit(err)
+			}
 		}
 		status := Status{ms, ls}
 

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -40,13 +40,14 @@ MINIKUBE_WANTREPORTERRORPROMPT=False sudo ./out/minikube-${OS_ARCH} delete \
 || MINIKUBE_WANTREPORTERRORPROMPT=False ./out/minikube-${OS_ARCH} delete \
 || true
 sudo rm -rf $HOME/.minikube || true
+sudo rm -rf $HOME/.kube || true
 
 # See the default image
 ./out/minikube-${OS_ARCH} start -h | grep iso
 
 # Allow this to fail, we'll switch on the return code below.
 set +e
-out/e2e-${OS_ARCH} -minikube-args="--vm-driver=${VM_DRIVER} --v=10" -test.v -test.timeout=30m -binary=out/minikube-${OS_ARCH}
+${SUDO_PREFIX}out/e2e-${OS_ARCH} -minikube-args="--vm-driver=${VM_DRIVER} --v=10" -test.v -test.timeout=30m -binary=out/minikube-${OS_ARCH}
 result=$?
 set -e
 
@@ -54,6 +55,7 @@ MINIKUBE_WANTREPORTERRORPROMPT=False sudo ./out/minikube-${OS_ARCH} delete \
 || MINIKUBE_WANTREPORTERRORPROMPT=False ./out/minikube-${OS_ARCH} delete \
 || true
 sudo rm -rf $HOME/.minikube || true
+sudo rm -rf $HOME/.kube || true
 
 if [[ $result -eq 0 ]]; then
   status="success"

--- a/hack/jenkins/linux_integration_tests_none.sh
+++ b/hack/jenkins/linux_integration_tests_none.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This script downloads the test files from the build bucket and makes some executable.
+
+# The script expects the following env variables:
+# OS_ARCH: The operating system and the architecture separated by a hyphen '-' (e.g. darwin-amd64, linux-amd64, windows-amd64)
+# VM_DRIVER: the vm-driver to use for the test
+# EXTRA_BUILD_ARGS: additional flags to pass into minikube start
+# JOB_NAME: the name of the logfile and check name to update on github
+
+set -e
+
+OS_ARCH="linux-amd64"
+VM_DRIVER="none"
+JOB_NAME="Linux-None"
+EXTRA_BUILD_ARGS="$EXTRA_BUILD_ARGS --use-vendored-driver"
+MINIKUBE_HOME="$HOME"
+
+# Copy only the files we need to this workspace
+mkdir -p out/ testdata/
+gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/minikube-${OS_ARCH} out/
+gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/e2e-${OS_ARCH} out/
+gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/testdata/busybox.yaml testdata/
+gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/testdata/pvc.yaml testdata/
+gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/testdata/busybox-mount-test.yaml testdata/
+
+# Set the executable bit on the e2e binary and out binary
+chmod +x out/e2e-${OS_ARCH}
+chmod +x out/minikube-${OS_ARCH}
+
+MINIKUBE_WANTREPORTERRORPROMPT=False \
+	./out/minikube-${OS_ARCH} delete || true
+
+rm -rf $HOME/.minikube || true
+
+# See the default image
+./out/minikube-${OS_ARCH} start -h | grep iso
+
+# Allow this to fail, we'll switch on the return code below.
+set +e
+sudo -E out/e2e-${OS_ARCH} -minikube-args="--vm-driver=${VM_DRIVER} --v=100 ${EXTRA_BUILD_ARGS}" -test.v -test.timeout=30m -binary=out/minikube-${OS_ARCH}
+result=$?
+set -e
+
+if [[ $result -eq 0 ]]; then
+  status="success"
+else
+  status="failure"
+fi
+
+set +x
+target_url="https://storage.googleapis.com/minikube-builds/logs/${MINIKUBE_LOCATION}/${JOB_NAME}.txt"
+curl "https://api.github.com/repos/kubernetes/minikube/statuses/${COMMIT}?access_token=$access_token" \
+  -H "Content-Type: application/json" \
+  -X POST \
+  -d "{\"state\": \"$status\", \"description\": \"Jenkins\", \"target_url\": \"$target_url\", \"context\": \"${JOB_NAME}\"}"
+set -x
+
+exit $result

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -88,8 +88,10 @@ func StartHost(api libmachine.API, config MachineConfig) (*host.Host, error) {
 		}
 	}
 
-	if err := h.ConfigureAuth(); err != nil {
-		return nil, &util.RetriableError{Err: errors.Wrap(err, "Error configuring auth on host")}
+	if h.Driver.DriverName() != "none" {
+		if err := h.ConfigureAuth(); err != nil {
+			return nil, &util.RetriableError{Err: errors.Wrap(err, "Error configuring auth on host")}
+		}
 	}
 	return h, nil
 }
@@ -120,13 +122,12 @@ func DeleteHost(api libmachine.API) error {
 
 // GetHostStatus gets the status of the host VM.
 func GetHostStatus(api libmachine.API) (string, error) {
-	dne := "Does Not Exist"
 	exists, err := api.Exists(cfg.GetMachineName())
 	if err != nil {
 		return "", errors.Wrapf(err, "Error checking that api exists for: %s", cfg.GetMachineName())
 	}
 	if !exists {
-		return dne, nil
+		return state.None.String(), nil
 	}
 
 	host, err := api.Load(cfg.GetMachineName())
@@ -135,9 +136,6 @@ func GetHostStatus(api libmachine.API) (string, error) {
 	}
 
 	s, err := host.Driver.GetState()
-	if s.String() == "" {
-		return dne, nil
-	}
 	if err != nil {
 		return "", errors.Wrap(err, "Error getting host state")
 	}
@@ -150,7 +148,10 @@ func GetLocalkubeStatus(api libmachine.API) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	s, err := h.RunSSHCommand(localkubeStatusCommand)
+
+	statusCmd := localkubeStatusCommand
+
+	s, err := RunCommand(h, statusCmd, false)
 	if err != nil {
 		return "", err
 	}
@@ -169,7 +170,39 @@ type sshAble interface {
 }
 
 // StartCluster starts a k8s cluster on the specified Host.
-func StartCluster(h sshAble, kubernetesConfig KubernetesConfig) error {
+func StartClusterLocal(h *host.Host, kubernetesConfig KubernetesConfig) error {
+	startCommand, err := GetStartCommand(kubernetesConfig)
+	if err != nil {
+		return errors.Wrapf(err, "Error generating start command: %s", err)
+	}
+	glog.Infoln(startCommand)
+	output, err := RunCommand(h, startCommand, true)
+	glog.Infoln(output)
+	if err != nil {
+		return errors.Wrapf(err, "Error running ssh command: %s", startCommand)
+	}
+
+	checkRunning := func() error {
+		s, err := h.Driver.GetState()
+		glog.Infoln("Machine state: ", s)
+		if err != nil {
+			return errors.Wrap(err, "Error getting state for host")
+		}
+		if s != state.Running {
+			return fmt.Errorf("Machine is in the wrong state: %s, expected  %s", s, state.Running)
+		}
+		return nil
+	}
+
+	if err := util.RetryAfter(6, checkRunning, 5*time.Second); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// StartCluster starts a k8s cluster on the specified Host.
+func StartClusterSSH(h sshAble, kubernetesConfig KubernetesConfig) error {
 	startCommand, err := GetStartCommand(kubernetesConfig)
 	if err != nil {
 		return errors.Wrapf(err, "Error generating start command: %s", err)
@@ -213,6 +246,16 @@ func UpdateCluster(h sshAble, d drivers.Driver, config KubernetesConfig) error {
 		} else if err != nil {
 			return err
 		}
+	}
+
+	if d.DriverName() == "none" {
+		// transfer files to correct place on filesystem
+		for _, f := range copyableFiles {
+			if err := assets.CopyFileLocal(f); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 
 	// transfer files to vm via SSH
@@ -267,6 +310,16 @@ func SetupCerts(d drivers.Driver, apiServerName string) error {
 		copyableFiles = append(copyableFiles, certFile)
 	}
 
+	if d.DriverName() == "none" {
+		// transfer files to correct place on filesystem
+		for _, f := range copyableFiles {
+			if err := assets.CopyFileLocal(f); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
 	// transfer files to vm via SSH
 	client, err := sshutil.NewSSHClient(d)
 	if err != nil {
@@ -305,8 +358,10 @@ func createVirtualboxHost(config MachineConfig) drivers.Driver {
 func createHost(api libmachine.API, config MachineConfig) (*host.Host, error) {
 	var driver interface{}
 
-	if err := config.Downloader.CacheMinikubeISOFromURL(config.MinikubeISO); err != nil {
-		return nil, errors.Wrap(err, "Error attempting to cache minikube ISO from URL")
+	if config.VMDriver != "none" {
+		if err := config.Downloader.CacheMinikubeISOFromURL(config.MinikubeISO); err != nil {
+			return nil, errors.Wrap(err, "Error attempting to cache minikube ISO from URL")
+		}
 	}
 
 	switch config.VMDriver {
@@ -320,6 +375,8 @@ func createHost(api libmachine.API, config MachineConfig) (*host.Host, error) {
 		driver = createXhyveHost(config)
 	case "hyperv":
 		driver = createHypervHost(config)
+	case "none":
+		driver = createNoneHost(config)
 	default:
 		glog.Exitf("Unsupported driver: %s\n", config.VMDriver)
 	}
@@ -394,7 +451,8 @@ func GetHostLogs(api libmachine.API, follow bool) (string, error) {
 		}
 		return "", err
 	}
-	s, err := h.RunSSHCommand(logsCommand)
+	s, err := RunCommand(h, logsCommand, false)
+
 	if err != nil {
 		return "", err
 	}
@@ -522,4 +580,20 @@ func EnsureMinikubeRunningOrExit(api libmachine.API, exitStatus int) {
 		fmt.Fprintln(os.Stderr, "minikube is not currently running so the service cannot be accessed")
 		os.Exit(exitStatus)
 	}
+}
+
+// RunCommand executes commands for both the local and driver implementations
+func RunCommand(h *host.Host, command string, sudo bool) (string, error) {
+	if h.Driver.DriverName() == "none" {
+		cmd := exec.Command("/bin/sh", "-c", command)
+		if sudo {
+			cmd = exec.Command("sudo", "/bin/sh", "-c", command)
+		}
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return "", err
+		}
+		return string(out), nil
+	}
+	return h.RunSSHCommand(command)
 }

--- a/pkg/minikube/cluster/cluster_linux.go
+++ b/pkg/minikube/cluster/cluster_linux.go
@@ -24,6 +24,7 @@ import (
 	"github.com/docker/machine/libmachine/drivers"
 	cfg "k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
+	pkgDrivers "k8s.io/minikube/pkg/minikube/machine/drivers"
 )
 
 type kvmDriver struct {
@@ -66,4 +67,13 @@ func detectVBoxManageCmd() string {
 		return path
 	}
 	return cmd
+}
+
+func createNoneHost(config MachineConfig) *pkgDrivers.Driver {
+	return &pkgDrivers.Driver{
+		BaseDriver: &drivers.BaseDriver{
+			MachineName: cfg.GetMachineName(),
+			StorePath:   constants.GetMinipath(),
+		},
+	}
 }

--- a/pkg/minikube/cluster/cluster_non_linux_panic.go
+++ b/pkg/minikube/cluster/cluster_non_linux_panic.go
@@ -23,3 +23,7 @@ import "github.com/docker/machine/libmachine/drivers"
 func createKVMHost(config MachineConfig) drivers.Driver {
 	panic("kvm not supported")
 }
+
+func createNoneHost(config MachineConfig) drivers.Driver {
+	panic("no-vm not supported")
+}

--- a/pkg/minikube/cluster/cluster_test.go
+++ b/pkg/minikube/cluster/cluster_test.go
@@ -86,14 +86,30 @@ func TestCreateHost(t *testing.T) {
 	}
 }
 
-func TestStartClusterSSH(t *testing.T) {
-	h := tests.NewMockHost()
-	ip, _ := h.Driver.GetIP()
-	kubernetesConfig := KubernetesConfig{
-		NodeIP: ip,
+func TestStartCluster(t *testing.T) {
+	api := tests.NewMockAPI()
+
+	s, _ := tests.NewSSHServer()
+	port, err := s.Start()
+	if err != nil {
+		t.Fatalf("Error starting ssh server: %s", err)
 	}
 
-	err := StartClusterSSH(h, kubernetesConfig)
+	d := &tests.MockDriver{
+		Port: port,
+		BaseDriver: drivers.BaseDriver{
+			IPAddress:  "127.0.0.1",
+			SSHKeyPath: "",
+		},
+		CurrentState: state.Running,
+	}
+	api.Hosts[config.GetMachineName()] = &host.Host{Driver: d}
+
+	kubernetesConfig := KubernetesConfig{
+		NodeIP: "",
+	}
+
+	err = StartCluster(api, kubernetesConfig)
 
 	if err != nil {
 		t.Fatalf("Error starting cluster: %s", err)
@@ -104,21 +120,37 @@ func TestStartClusterSSH(t *testing.T) {
 		t.Fatalf("Error getting start command: %s", err)
 	}
 	for _, cmd := range []string{startCommand} {
-		if _, ok := h.Commands[cmd]; !ok {
-			t.Fatalf("Expected command not run: %s. Commands run: %v", cmd, h.Commands)
+		if _, ok := s.Commands[cmd]; !ok {
+			t.Fatalf("Expected command not run: %s. Commands run: %v", cmd, s.Commands)
 		}
 	}
 }
 
 func TestStartClusterError(t *testing.T) {
-	h := tests.NewMockHost()
-	h.Error = "error"
-	ip, _ := h.Driver.GetIP()
-	kubernetesConfig := KubernetesConfig{
-		NodeIP: ip,
+	api := tests.NewMockAPI()
+
+	s, _ := tests.NewSSHServer()
+	port, err := s.Start()
+	if err != nil {
+		t.Fatalf("Error starting ssh server: %s", err)
 	}
 
-	err := StartClusterSSH(h, kubernetesConfig)
+	d := &tests.MockDriver{
+		Port: port,
+		BaseDriver: drivers.BaseDriver{
+			IPAddress:  "127.0.0.1",
+			SSHKeyPath: "",
+		},
+		CurrentState: state.Running,
+		HostError:    true,
+	}
+	api.Hosts[config.GetMachineName()] = &host.Host{Driver: d}
+
+	kubernetesConfig := KubernetesConfig{
+		NodeIP: "192",
+	}
+
+	err = StartCluster(api, kubernetesConfig)
 
 	if err == nil {
 		t.Fatal("Error not thrown starting cluster.")
@@ -562,7 +594,6 @@ func TestUpdateDefault(t *testing.T) {
 		t.Fatalf("Error starting ssh server: %s", err)
 	}
 
-	h := tests.NewMockHost()
 	d := &tests.MockDriver{
 		Port: port,
 		BaseDriver: drivers.BaseDriver{
@@ -575,7 +606,7 @@ func TestUpdateDefault(t *testing.T) {
 		KubernetesVersion: constants.DefaultKubernetesVersion,
 	}
 
-	if err := UpdateCluster(h, d, kubernetesConfig); err != nil {
+	if err := UpdateCluster(d, kubernetesConfig); err != nil {
 		t.Fatalf("Error updating cluster: %s", err)
 	}
 	transferred := s.Transfers.Bytes()
@@ -618,7 +649,6 @@ func TestUpdateKubernetesVersion(t *testing.T) {
 		t.Fatalf("Error starting ssh server: %s", err)
 	}
 
-	h := tests.NewMockHost()
 	d := &tests.MockDriver{
 		Port: port,
 		BaseDriver: drivers.BaseDriver{
@@ -632,7 +662,7 @@ func TestUpdateKubernetesVersion(t *testing.T) {
 	kubernetesConfig := KubernetesConfig{
 		KubernetesVersion: server.URL,
 	}
-	if err := UpdateCluster(h, d, kubernetesConfig); err != nil {
+	if err := UpdateCluster(d, kubernetesConfig); err != nil {
 		t.Fatalf("Error updating cluster: %s", err)
 	}
 	transferred := s.Transfers.Bytes()
@@ -698,7 +728,6 @@ func TestUpdateCustomAddons(t *testing.T) {
 		t.Fatalf("Error starting ssh server: %s", err)
 	}
 
-	h := tests.NewMockHost()
 	d := &tests.MockDriver{
 		Port: port,
 		BaseDriver: drivers.BaseDriver{
@@ -726,7 +755,7 @@ func TestUpdateCustomAddons(t *testing.T) {
 	kubernetesConfig := KubernetesConfig{
 		KubernetesVersion: constants.DefaultKubernetesVersion,
 	}
-	if err := UpdateCluster(h, d, kubernetesConfig); err != nil {
+	if err := UpdateCluster(d, kubernetesConfig); err != nil {
 		t.Fatalf("Error updating cluster: %s", err)
 	}
 	transferred := s.Transfers.Bytes()

--- a/pkg/minikube/cluster/cluster_test.go
+++ b/pkg/minikube/cluster/cluster_test.go
@@ -86,14 +86,14 @@ func TestCreateHost(t *testing.T) {
 	}
 }
 
-func TestStartCluster(t *testing.T) {
+func TestStartClusterSSH(t *testing.T) {
 	h := tests.NewMockHost()
 	ip, _ := h.Driver.GetIP()
 	kubernetesConfig := KubernetesConfig{
 		NodeIP: ip,
 	}
 
-	err := StartCluster(h, kubernetesConfig)
+	err := StartClusterSSH(h, kubernetesConfig)
 
 	if err != nil {
 		t.Fatalf("Error starting cluster: %s", err)
@@ -118,7 +118,7 @@ func TestStartClusterError(t *testing.T) {
 		NodeIP: ip,
 	}
 
-	err := StartCluster(h, kubernetesConfig)
+	err := StartClusterSSH(h, kubernetesConfig)
 
 	if err == nil {
 		t.Fatal("Error not thrown starting cluster.")
@@ -337,7 +337,7 @@ func TestGetHostStatus(t *testing.T) {
 		}
 	}
 
-	checkState("Does Not Exist")
+	checkState(state.None.String())
 
 	createHost(api, defaultMachineConfig)
 	checkState(state.Running.String())

--- a/pkg/minikube/cluster/commands.go
+++ b/pkg/minikube/cluster/commands.go
@@ -28,8 +28,7 @@ import (
 )
 
 // Kill any running instances.
-
-var localkubeStartCmdTemplate = "/usr/local/bin/localkube {{.Flags}} --generate-certs=false --logtostderr=true --enable-dns=false --node-ip={{.NodeIP}}"
+var localkubeStartCmdTemplate = "/usr/local/bin/localkube {{.Flags}} --generate-certs=false --logtostderr=true --enable-dns=false"
 
 var localkubeSystemdTmpl = `[Unit]
 Description=Localkube
@@ -123,20 +122,22 @@ func GenLocalkubeStartCmd(kubernetesConfig KubernetesConfig) (string, error) {
 		flagVals = append(flagVals, "--dns-domain="+kubernetesConfig.DNSDomain)
 	}
 
+	if kubernetesConfig.NodeIP != "127.0.0.1" {
+		flagVals = append(flagVals, "--node-ip="+kubernetesConfig.NodeIP)
+	}
+
 	for _, e := range kubernetesConfig.ExtraOptions {
 		flagVals = append(flagVals, fmt.Sprintf("--extra-config=%s", e.String()))
 	}
 	flags := strings.Join(flagVals, " ")
-
-	t := template.Must(template.New("localkubeStartCmd").Parse(localkubeStartCmdTemplate))
+	localkubeTemplate := localkubeStartCmdTemplate
+	t := template.Must(template.New("localkubeStartCmd").Parse(localkubeTemplate))
 	buf := bytes.Buffer{}
 	data := struct {
 		Flags         string
-		NodeIP        string
 		APIServerName string
 	}{
 		Flags:         flags,
-		NodeIP:        kubernetesConfig.NodeIP,
 		APIServerName: kubernetesConfig.APIServerName,
 	}
 	if err := t.Execute(&buf, data); err != nil {

--- a/pkg/minikube/cluster/commands.go
+++ b/pkg/minikube/cluster/commands.go
@@ -130,8 +130,7 @@ func GenLocalkubeStartCmd(kubernetesConfig KubernetesConfig) (string, error) {
 		flagVals = append(flagVals, fmt.Sprintf("--extra-config=%s", e.String()))
 	}
 	flags := strings.Join(flagVals, " ")
-	localkubeTemplate := localkubeStartCmdTemplate
-	t := template.Must(template.New("localkubeStartCmd").Parse(localkubeTemplate))
+	t := template.Must(template.New("localkubeStartCmd").Parse(localkubeStartCmdTemplate))
 	buf := bytes.Buffer{}
 	data := struct {
 		Flags         string

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -89,7 +89,7 @@ const (
 	DefaultDiskSize     = "20g"
 	MinimumDiskSizeMB   = 2000
 	DefaultVMDriver     = "virtualbox"
-	DefaultStatusFormat = "minikubeVM: {{.MinikubeStatus}}\n" +
+	DefaultStatusFormat = "minikube: {{.MinikubeStatus}}\n" +
 		"localkube: {{.LocalkubeStatus}}\n"
 	DefaultAddonListFormat    = "- {{.AddonName}}: {{.AddonStatus}}\n"
 	DefaultConfigViewFormat   = "- {{.ConfigKey}}: {{.ConfigValue}}\n"
@@ -118,6 +118,7 @@ const AddonsPath = "/etc/kubernetes/addons"
 const (
 	RemoteLocalKubeErrPath = "/var/lib/localkube/localkube.err"
 	RemoteLocalKubeOutPath = "/var/lib/localkube/localkube.out"
+	LocalkubePIDPath       = "/var/run/localkube.pid"
 )
 
 const (

--- a/pkg/minikube/constants/constants_linux.go
+++ b/pkg/minikube/constants/constants_linux.go
@@ -25,6 +25,7 @@ import (
 var SupportedVMDrivers = [...]string{
 	"virtualbox",
 	"kvm",
+	"none",
 }
 
 var DefaultMountDir = homedir.HomeDir()

--- a/pkg/minikube/machine/client.go
+++ b/pkg/minikube/machine/client.go
@@ -204,12 +204,18 @@ func (api *LocalClient) Create(h *host.Host) error {
 		{
 			"Waiting for VM to start.",
 			func() error {
+				if h.Driver.DriverName() == "none" {
+					return nil
+				}
 				return mcnutils.WaitFor(drivers.MachineInState(h.Driver, state.Running))
 			},
 		},
 		{
 			"Provisioning VM.",
-			func() error {==
+			func() error {
+				if h.Driver.DriverName() == "none" {
+					return nil
+				}
 				pv := provision.NewBuildrootProvisioner(h.Driver)
 				return pv.Provision(*h.HostOptions.SwarmOptions, *h.HostOptions.AuthOptions, *h.HostOptions.EngineOptions)
 			},

--- a/pkg/minikube/machine/client.go
+++ b/pkg/minikube/machine/client.go
@@ -35,7 +35,7 @@ import (
 	"github.com/docker/machine/libmachine/check"
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/drivers/plugin/localbinary"
-	"github.com/docker/machine/libmachine/drivers/rpc"
+	rpcdriver "github.com/docker/machine/libmachine/drivers/rpc"
 	"github.com/docker/machine/libmachine/engine"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/mcnutils"
@@ -73,6 +73,7 @@ func (*rpcClientFactory) NewClient(storePath, certsDir string) libmachine.API {
 }
 
 var clientFactories = map[ClientType]clientFactory{
+	//	ClientTypeNative: &nativeClientFactory{},
 	ClientTypeLocal: &localClientFactory{},
 	ClientTypeRPC:   &rpcClientFactory{},
 }
@@ -80,6 +81,8 @@ var clientFactories = map[ClientType]clientFactory{
 const (
 	ClientTypeLocal ClientType = iota
 	ClientTypeRPC
+
+//	ClientTypeNative
 )
 
 // Gets a new client depending on the clientType specified
@@ -206,7 +209,7 @@ func (api *LocalClient) Create(h *host.Host) error {
 		},
 		{
 			"Provisioning VM.",
-			func() error {
+			func() error {==
 				pv := provision.NewBuildrootProvisioner(h.Driver)
 				return pv.Provision(*h.HostOptions.SwarmOptions, *h.HostOptions.AuthOptions, *h.HostOptions.EngineOptions)
 			},

--- a/pkg/minikube/machine/drivers/none-driver.go
+++ b/pkg/minikube/machine/drivers/none-driver.go
@@ -17,19 +17,18 @@ limitations under the License.
 package drivers
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
 	"strings"
-
-	"k8s.io/minikube/pkg/minikube/constants"
 
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/mcnflag"
 	"github.com/docker/machine/libmachine/state"
+	"k8s.io/minikube/pkg/minikube/constants"
 )
 
 const driverName = "none"
@@ -49,12 +48,21 @@ func NewDriver(hostName, storePath string) *Driver {
 	}
 }
 
+// PreCreateCheck checks that VBoxManage exists and works
+func (d *Driver) PreCreateCheck() error {
+	// check that systemd is installed as it is a requirement
+	if _, err := exec.LookPath("systemctl"); err != nil {
+		return errors.New("systemd is a requirement in order to use the none driver")
+	}
+	return nil
+}
+
 func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	return []mcnflag.Flag{}
 }
 
 func (d *Driver) Create() error {
-	// creation is handled by commands.go
+	// creation for the none driver is handled by commands.go
 	return nil
 }
 
@@ -68,7 +76,7 @@ func (d *Driver) GetIP() (string, error) {
 }
 
 func (d *Driver) GetSSHHostname() (string, error) {
-	return "", nil
+	return "", fmt.Errorf("driver does not support ssh commands")
 }
 
 func (d *Driver) GetSSHKeyPath() string {
@@ -76,12 +84,11 @@ func (d *Driver) GetSSHKeyPath() string {
 }
 
 func (d *Driver) GetSSHPort() (int, error) {
-	return 22, nil
+	return 0, fmt.Errorf("driver does not support ssh commands")
 }
 
 func (d *Driver) GetSSHUsername() string {
-	usr, _ := user.Current()
-	return usr.Username
+	return ""
 }
 
 func (d *Driver) GetURL() (string, error) {

--- a/pkg/minikube/machine/drivers/none-driver.go
+++ b/pkg/minikube/machine/drivers/none-driver.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package drivers
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/minikube/pkg/minikube/constants"
+
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/docker/machine/libmachine/mcnflag"
+	"github.com/docker/machine/libmachine/state"
+)
+
+const driverName = "none"
+
+// none Driver is a driver designed to run localkube w/o a VM
+type Driver struct {
+	*drivers.BaseDriver
+	URL string
+}
+
+func NewDriver(hostName, storePath string) *Driver {
+	return &Driver{
+		BaseDriver: &drivers.BaseDriver{
+			MachineName: hostName,
+			StorePath:   storePath,
+		},
+	}
+}
+
+func (d *Driver) GetCreateFlags() []mcnflag.Flag {
+	return []mcnflag.Flag{}
+}
+
+func (d *Driver) Create() error {
+	// creation is handled by commands.go
+	return nil
+}
+
+// DriverName returns the name of the driver
+func (d *Driver) DriverName() string {
+	return driverName
+}
+
+func (d *Driver) GetIP() (string, error) {
+	return "127.0.0.1", nil
+}
+
+func (d *Driver) GetSSHHostname() (string, error) {
+	return "", nil
+}
+
+func (d *Driver) GetSSHKeyPath() string {
+	return ""
+}
+
+func (d *Driver) GetSSHPort() (int, error) {
+	return 22, nil
+}
+
+func (d *Driver) GetSSHUsername() string {
+	usr, _ := user.Current()
+	return usr.Username
+}
+
+func (d *Driver) GetURL() (string, error) {
+	return "127.0.0.1:8080", nil
+}
+
+func (d *Driver) GetState() (state.State, error) {
+	command := `sudo systemctl is-active localkube 2>&1 1>/dev/null && echo "Running" || echo "Stopped"`
+
+	path := filepath.Join(constants.GetMinipath(), "tmp-cmd")
+	ioutil.WriteFile(filepath.Join(constants.GetMinipath(), "tmp-cmd"), []byte(command), os.FileMode(0644))
+	defer os.Remove(path)
+	cmd := exec.Command("sudo", "/bin/sh", path)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return state.None, err
+	}
+	s := strings.TrimSpace(string(out))
+	if state.Running.String() == s {
+		return state.Running, nil
+	} else if state.Stopped.String() == s {
+		return state.Stopped, nil
+	} else {
+		return state.None, fmt.Errorf("Error: Unrecognize output from GetLocalkubeStatus: %s", s)
+	}
+}
+
+func (d *Driver) Kill() error {
+	cmd := exec.Command("sudo", "systemctl", "stop", "localkube.service")
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	cmd = exec.Command("sudo", "rm", "-rf", "/var/lib/localkube")
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *Driver) Remove() error {
+	cmd := exec.Command("sudo", "systemctl", "stop", "localkube.service")
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	cmd = exec.Command("sudo", "rm", "-rf", "/var/lib/localkube")
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *Driver) Restart() error {
+	cmd := exec.Command("sudo", "systemctl", "restart", "localkube.service")
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
+	return nil
+}
+
+func (d *Driver) Start() error {
+	d.IPAddress = "127.0.0.1"
+	d.URL = "127.0.0.1:8080"
+	return nil
+}
+
+func (d *Driver) Stop() error {
+	cmd := exec.Command("sudo", "systemctl", "stop", "localkube.service")
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	for {
+		s, err := d.GetState()
+		if err != nil {
+			return err
+		}
+		if s != state.Running {
+			break
+		}
+	}
+	return nil
+}
+
+func (d *Driver) RunSSHCommandFromDriver() error {
+	return fmt.Errorf("driver does not support ssh commands")
+}

--- a/test/integration/cluster_env_test.go
+++ b/test/integration/cluster_env_test.go
@@ -20,7 +20,6 @@ package integration
 
 import (
 	"os/exec"
-	"strings"
 	"testing"
 	"time"
 
@@ -30,9 +29,6 @@ import (
 
 func testClusterEnv(t *testing.T) {
 	t.Parallel()
-	if strings.Contains(*args, "--vm-driver=none") {
-		t.Skip("skipping test for none driver as it does not support ssh")
-	}
 
 	minikubeRunner := util.MinikubeRunner{
 		Args:       *args,

--- a/test/integration/cluster_env_test.go
+++ b/test/integration/cluster_env_test.go
@@ -20,6 +20,7 @@ package integration
 
 import (
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,6 +30,10 @@ import (
 
 func testClusterEnv(t *testing.T) {
 	t.Parallel()
+	if strings.Contains(*args, "--vm-driver=none") {
+		t.Skip("skipping test for none driver as it does not support ssh")
+	}
+
 	minikubeRunner := util.MinikubeRunner{
 		Args:       *args,
 		BinaryPath: *binaryPath,

--- a/test/integration/cluster_ssh_test.go
+++ b/test/integration/cluster_ssh_test.go
@@ -27,6 +27,9 @@ import (
 
 func testClusterSSH(t *testing.T) {
 	t.Parallel()
+	if strings.Contains(*args, "--vm-driver=none") {
+		t.Skip("skipping test for none driver as it does not support ssh")
+	}
 	minikubeRunner := util.MinikubeRunner{
 		Args:       *args,
 		BinaryPath: *binaryPath,

--- a/test/integration/cluster_ssh_test.go
+++ b/test/integration/cluster_ssh_test.go
@@ -27,9 +27,6 @@ import (
 
 func testClusterSSH(t *testing.T) {
 	t.Parallel()
-	if strings.Contains(*args, "--vm-driver=none") {
-		t.Skip("skipping test for none driver as it does not support ssh")
-	}
 	minikubeRunner := util.MinikubeRunner{
 		Args:       *args,
 		BinaryPath: *binaryPath,

--- a/test/integration/docker_test.go
+++ b/test/integration/docker_test.go
@@ -33,7 +33,7 @@ func TestDocker(t *testing.T) {
 		T:          t}
 
 	if strings.Contains(*args, "--vm-driver=none") {
-		t.Skip("skipping test for none driver as it does not bundle docker")
+		t.Skip("skipping test as none driver does not bundle docker")
 	}
 
 	minikubeRunner.RunCommand("delete", false)

--- a/test/integration/docker_test.go
+++ b/test/integration/docker_test.go
@@ -32,8 +32,11 @@ func TestDocker(t *testing.T) {
 		BinaryPath: *binaryPath,
 		T:          t}
 
-	minikubeRunner.RunCommand("delete", false)
+	if strings.Contains(*args, "--vm-driver=none") {
+		t.Skip("skipping test for none driver as it does not bundle docker")
+	}
 
+	minikubeRunner.RunCommand("delete", false)
 	startCmd := fmt.Sprintf("start %s %s", minikubeRunner.Args, "--docker-env=FOO=BAR --docker-env=BAZ=BAT --docker-opt=debug --docker-opt=icc=true")
 	minikubeRunner.RunCommand(startCmd, true)
 	minikubeRunner.EnsureRunning()

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -19,6 +19,8 @@ limitations under the License.
 package integration
 
 import (
+	"runtime"
+	"strings"
 	"testing"
 
 	"k8s.io/minikube/test/integration/util"
@@ -34,15 +36,20 @@ func TestFunctional(t *testing.T) {
 	// This one is not parallel, and ensures the cluster comes up
 	// before we run any other tests.
 	t.Run("Status", testClusterStatus)
-
 	t.Run("DNS", testClusterDNS)
-	t.Run("EnvVars", testClusterEnv)
 	t.Run("Logs", testClusterLogs)
-	t.Run("SSH", testClusterSSH)
-	t.Run("Systemd", testVMSystemd)
 	t.Run("Addons", testAddons)
 	t.Run("Dashboard", testDashboard)
 	t.Run("ServicesList", testServicesList)
 	t.Run("Provisioning", testProvisioning)
-	// t.Run("Mounting", testMounting)
+
+	if !strings.Contains(*args, "--vm-driver=none") {
+		t.Run("EnvVars", testClusterEnv)
+		t.Run("SSH", testClusterSSH)
+		if runtime.GOOS != "windows" {
+			t.Run("Systemd", testVMSystemd)
+
+		}
+		// t.Run("Mounting", testMounting)
+	}
 }

--- a/test/integration/mount_test.go
+++ b/test/integration/mount_test.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -33,6 +34,9 @@ import (
 
 func testMounting(t *testing.T) {
 	t.Parallel()
+	if strings.Contains(*args, "--vm-driver=none") {
+		t.Skip("skipping test for none driver as it does not need mount")
+	}
 	minikubeRunner := util.MinikubeRunner{
 		Args:       *args,
 		BinaryPath: *binaryPath,

--- a/test/integration/persistence_test.go
+++ b/test/integration/persistence_test.go
@@ -84,8 +84,16 @@ func TestPersistence(t *testing.T) {
 	}
 
 	// Now restart minikube and make sure the pod is still there.
-	minikubeRunner.RunCommand("stop", true)
-	minikubeRunner.CheckStatus("Stopped")
+	// minikubeRunner.RunCommand("stop", true)
+	// minikubeRunner.CheckStatus("Stopped")
+	checkStop := func() error {
+		minikubeRunner.RunCommand("stop", true)
+		return minikubeRunner.CheckStatusNoFail(state.Stopped.String())
+	}
+
+	if err := commonutil.RetryAfter(6, checkStop, 5*time.Second); err != nil {
+		t.Fatalf("timed out while checking stopped status: %s", err)
+	}
 
 	minikubeRunner.Start()
 	minikubeRunner.CheckStatus(state.Running.String())

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/machine/libmachine/state"
 	commonutil "k8s.io/minikube/pkg/util"
 	"k8s.io/minikube/test/integration/util"
 )
@@ -35,10 +36,10 @@ func TestStartStop(t *testing.T) {
 		BinaryPath: *binaryPath,
 		T:          t}
 	runner.RunCommand("delete", false)
-	runner.CheckStatus("Does Not Exist")
+	runner.CheckStatus(state.None.String())
 
 	runner.Start()
-	runner.CheckStatus("Running")
+	runner.CheckStatus(state.Running.String())
 
 	ip := runner.RunCommand("ip", true)
 	ip = strings.TrimRight(ip, "\n")
@@ -52,7 +53,7 @@ func TestStartStop(t *testing.T) {
 
 	checkStop := func() error {
 		runner.RunCommand("stop", true)
-		return runner.CheckStatusNoFail("Stopped")
+		return runner.CheckStatusNoFail(state.Stopped.String())
 	}
 
 	if err := commonutil.RetryAfter(6, checkStop, 5*time.Second); err != nil {
@@ -60,8 +61,8 @@ func TestStartStop(t *testing.T) {
 	}
 
 	runner.Start()
-	runner.CheckStatus("Running")
+	runner.CheckStatus(state.Running.String())
 
 	runner.RunCommand("delete", true)
-	runner.CheckStatus("Does Not Exist")
+	runner.CheckStatus(state.None.String())
 }

--- a/test/integration/vm_systemd.go
+++ b/test/integration/vm_systemd.go
@@ -31,6 +31,10 @@ func testVMSystemd(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping test in windows as it doesn't exit properly")
 	}
+	if strings.Contains(*args, "--vm-driver=none") {
+		t.Skip("skipping test for none driver as it does not boot systemd")
+	}
+
 	minikubeRunner := util.MinikubeRunner{
 		Args:       *args,
 		BinaryPath: *binaryPath,

--- a/test/integration/vm_systemd.go
+++ b/test/integration/vm_systemd.go
@@ -31,9 +31,6 @@ func testVMSystemd(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping test in windows as it doesn't exit properly")
 	}
-	if strings.Contains(*args, "--vm-driver=none") {
-		t.Skip("skipping test for none driver as it does not boot systemd")
-	}
 
 	minikubeRunner := util.MinikubeRunner{
 		Args:       *args,


### PR DESCRIPTION
This is a rough prototype of a minikube no-vm driver which moves all files into local locations and runs them as it does in the vm.  All CLI commands are preserved.  Currently the MINIKUBE_HOME directory needs to be configured and `minikube start` needs to be run as root. 
To test:
```
export MINIKUBE_HOME=$HOME #REQUIRED TO PROPERLY CONFIGURE .kube and .minikube dir
export CHANGE_MINIKUBE_NONE_USER=true #REQUIRED TO CHANGE OWNERSHIP FROM root to the original $SUDO_USER
sudo /usr/local/bin/minikube start --vm-driver=none --use-vendored-driver
kubectl get po --all-namespaces
#The following commands are to show that the minikube CLI still works
minikube logs
minikube status
minikube ssh
minikube addons disable dashboard
minikube delete
```

Note: This requires requires docker installed on the host