### PR TITLE
Fix data races in unit tests

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -177,8 +177,9 @@ func runStart(cmd *cobra.Command, args []string) {
 		ClientKey:            constants.MakeMiniPath("apiserver.key"),
 		CertificateAuthority: constants.MakeMiniPath("ca.crt"),
 		KeepContext:          viper.GetBool(keepContext),
-		KubeConfigFile:       kubeConfigFile,
 	}
+	kubeCfgSetup.SetKubeConfigFile(kubeConfigFile)
+
 	if err := kubeconfig.SetupKubeConfig(kubeCfgSetup); err != nil {
 		glog.Errorln("Error setting up kubeconfig: ", err)
 		cmdUtil.MaybeReportErrorAndExit(err)

--- a/pkg/minikube/cluster/cluster_test.go
+++ b/pkg/minikube/cluster/cluster_test.go
@@ -355,23 +355,23 @@ func TestGetLocalkubeStatus(t *testing.T) {
 	}
 	api.Hosts[constants.MachineName] = &host.Host{Driver: d}
 
-	s.CommandToOutput = map[string]string{
+	s.SetCommandToOutput(map[string]string{
 		localkubeStatusCommand: state.Running.String(),
-	}
+	})
 	if _, err := GetLocalkubeStatus(api); err != nil {
 		t.Fatalf("Error getting localkube status: %s", err)
 	}
 
-	s.CommandToOutput = map[string]string{
+	s.SetCommandToOutput(map[string]string{
 		localkubeStatusCommand: state.Stopped.String(),
-	}
+	})
 	if _, err := GetLocalkubeStatus(api); err != nil {
 		t.Fatalf("Error getting localkube status: %s", err)
 	}
 
-	s.CommandToOutput = map[string]string{
+	s.SetCommandToOutput(map[string]string{
 		localkubeStatusCommand: "Bad Output",
-	}
+	})
 	if _, err := GetLocalkubeStatus(api); err == nil {
 		t.Fatalf("Expected error in getting localkube status as ssh returned bad output")
 	}

--- a/pkg/minikube/cluster/cluster_test.go
+++ b/pkg/minikube/cluster/cluster_test.go
@@ -520,7 +520,7 @@ func TestCreateSSHShell(t *testing.T) {
 		t.Fatalf("Error running ssh command: %s", err)
 	}
 
-	if !s.HadASessionRequested {
+	if !s.IsSessionRequested() {
 		t.Fatalf("Expected ssh session to be run")
 	}
 }

--- a/pkg/minikube/kubeconfig/config_test.go
+++ b/pkg/minikube/kubeconfig/config_test.go
@@ -100,9 +100,9 @@ func TestSetupKubeConfig(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Error making temp directory %s", err)
 			}
-			test.cfg.KubeConfigFile = filepath.Join(tmpDir, "kubeconfig")
+			test.cfg.SetKubeConfigFile(filepath.Join(tmpDir, "kubeconfig"))
 			if len(test.existingCfg) != 0 {
-				ioutil.WriteFile(test.cfg.KubeConfigFile, test.existingCfg, 0600)
+				ioutil.WriteFile(test.cfg.GetKubeConfigFile(), test.existingCfg, 0600)
 			}
 			err = SetupKubeConfig(test.cfg)
 			if err != nil && !test.err {
@@ -111,7 +111,7 @@ func TestSetupKubeConfig(t *testing.T) {
 			if err == nil && test.err {
 				t.Errorf("Expected error but got none")
 			}
-			config, err := ReadConfigOrNew(test.cfg.KubeConfigFile)
+			config, err := ReadConfigOrNew(test.cfg.GetKubeConfigFile())
 			if err != nil {
 				t.Errorf("Error reading kubeconfig file: %s", err)
 			}


### PR DESCRIPTION
`TestCreateSSHShell`, `TestGetLocalkubeStatus`, and `TestSetupKubeConfig` fail when running `"go test --race"`, because of concurrent accesses from multiple goroutines.

For example:

```
WARNING: DATA RACE
Read at 0x00c42025b730 by goroutine 42:
k8s.io/minikube/pkg/minikube/cluster.TestCreateSSHShell()
    k8s.io/minikube/pkg/minikube/cluster/cluster_test.go:523 +0x543
testing.tRunner()
    /usr/local/golang/src/testing/testing.go:657 +0x107

Previous write at 0x00c42025b730 by goroutine 49:
k8s.io/minikube/pkg/minikube/tests.(*SSHServer).Start.func1.1()
    k8s.io/minikube/pkg/minikube/tests/ssh_mock.go:95 +0x743
```

To fix those, introduce atomic variables and helper functions, e.g. `SetSessionRequested()`, `IsSessionRequested()`, etc. Callers should run the helpers, instead of direct access to the variables.