### PR TITLE
libvirt group for Fedora/CentOS/RHEL

### DIFF
--- a/DRIVERS.md
+++ b/DRIVERS.md
@@ -29,10 +29,16 @@ $ sudo apt install libvirt-bin qemu-kvm
 $ sudo yum install libvirt-daemon-kvm kvm
 
 # Add yourself to the libvirtd group (use libvirt group for rpm based distros) so you don't need to sudo
+# Debian/Ubuntu
 $ sudo usermod -a -G libvirtd $(whoami)
+# Fedora/CentOS/RHEL
+$ sudo usermod -a -G libvirt $(whoami)
 
 # Update your current session for the group change to take effect
+# Debian/Ubuntu
 $ newgrp libvirtd
+# Fedora/CentOS/RHEL
+$ newgrp libvirt
 ```
 
 #### xhyve driver


### PR DESCRIPTION
For Fedora/CentOS/RHEL the group name should be `libvirt`. 