### PR TITLE
pkg: fix host IP address for KVM driver for 9pfs mount

### DIFF
--- a/pkg/minikube/cluster/cluster_linux.go
+++ b/pkg/minikube/cluster/cluster_linux.go
@@ -52,7 +52,7 @@ func getVMHostIP(host *host.Host) (net.IP, error) {
 	case "virtualbox":
 		return net.ParseIP("10.0.2.2"), nil
 	case "kvm":
-		return net.ParseIP("10.0.2.2"), nil
+		return net.ParseIP("192.168.42.1"), nil
 	default:
 		return []byte{}, errors.New("Error, attempted to get host ip address for unsupported driver")
 	}


### PR DESCRIPTION
In case of KVM driver, `"minikube mount"` does not work, when mounting any host directory via 9pfs. That's because in case of the KVM driver, a different IP address is assigned to the host, `192.168.42.1`, while other drivers assign `10.0.2.2`. That's why the following command hangs forever inside the VM.

```
$ sudo mount -t 9p -o trans=tcp -o port=5640 10.0.2.2 /mount-9p
```

Fix it by changing the host IP address for the KVM driver.

/cc @aaron-prindle 