### PR TITLE
Add support for passing CIDRs to config

### DIFF
--- a/pkg/util/config.go
+++ b/pkg/util/config.go
@@ -76,7 +76,13 @@ func setElement(e reflect.Value, v string) error {
 				return fmt.Errorf("Error converting input %s to an IP.", v)
 			}
 			e.Set(reflect.ValueOf(ip))
-		case utilnet.PortRange:
+    	case net.IPNet:
+    		_, cidr, err := net.ParseCIDR(v)
+    		if err != nil {
+    			return fmt.Errorf("Error converting input %s to a CIDR: %s", v, err)
+    		}
+    		e.Set(reflect.ValueOf(*cidr))
+   		case utilnet.PortRange:
 			pr, err := utilnet.ParsePortRange(v)
 			if err != nil {
 				return fmt.Errorf("Error converting input %s to PortRange: %s", v, err)

--- a/pkg/util/config.go
+++ b/pkg/util/config.go
@@ -76,13 +76,13 @@ func setElement(e reflect.Value, v string) error {
 				return fmt.Errorf("Error converting input %s to an IP.", v)
 			}
 			e.Set(reflect.ValueOf(ip))
-    	case net.IPNet:
-    		_, cidr, err := net.ParseCIDR(v)
-    		if err != nil {
-    			return fmt.Errorf("Error converting input %s to a CIDR: %s", v, err)
-    		}
-    		e.Set(reflect.ValueOf(*cidr))
-   		case utilnet.PortRange:
+		case net.IPNet:
+			_, cidr, err := net.ParseCIDR(v)
+			if err != nil {
+				return fmt.Errorf("Error converting input %s to a CIDR: %s", v, err)
+			}
+			e.Set(reflect.ValueOf(*cidr))
+		case utilnet.PortRange:
 			pr, err := utilnet.ParsePortRange(v)
 			if err != nil {
 				return fmt.Errorf("Error converting input %s to PortRange: %s", v, err)

--- a/pkg/util/config_test.go
+++ b/pkg/util/config_test.go
@@ -61,6 +61,7 @@ type subConfig3 struct {
 }
 
 func buildConfig() testConfig {
+	_, cidr, _ := net.ParseCIDR("12.34.56.78/16")
 	return testConfig{
 		A: "foo",
 		B: 1,
@@ -76,7 +77,7 @@ func buildConfig() testConfig {
 				P: false,
 				Q: net.ParseIP("12.34.56.78"),
 				R: utilnet.PortRange{Base: 2, Size: 4},
-				T: net.ParseCIDR("12.34.0.0/16")[1],
+				T: *cidr,
 			},
 		},
 		E: &subConfig2{
@@ -178,7 +179,7 @@ func TestSetElement(t *testing.T) {
 		{"D.I.R", "7-11", func(t testConfig) bool { return t.D.I.R.Base == 7 && t.D.I.R.Size == 5 }},
 		{"D.I.S", "a,b", func(t testConfig) bool { return reflect.DeepEqual(t.D.I.S, []string{"a", "b"}) }},
 		{"D.I.T", "foo", func(t testConfig) bool { return t.D.I.T == "foo" }},
-		{"D.I.U", "11.22.0.0/16", func(t testConfig) bool { return t.D.I.U.Network.Equal(net.ParseCIDR("11.22.0.0/16").Network) }},
+		{"D.I.U", "11.22.0.0/16", func(t testConfig) bool { return t.D.I.U.String() == "11.22.0.0/16" }},
 	} {
 		a := buildConfig()
 		if err := FindAndSet(tc.path, &a, tc.newval); err != nil {

--- a/pkg/util/config_test.go
+++ b/pkg/util/config_test.go
@@ -57,6 +57,7 @@ type subConfig3 struct {
 	R utilnet.PortRange
 	S []string
 	T aliasedString
+	U net.IPNet
 }
 
 func buildConfig() testConfig {
@@ -75,6 +76,7 @@ func buildConfig() testConfig {
 				P: false,
 				Q: net.ParseIP("12.34.56.78"),
 				R: utilnet.PortRange{Base: 2, Size: 4},
+				T: net.ParseCIDR("12.34.0.0/16")[1],
 			},
 		},
 		E: &subConfig2{
@@ -176,6 +178,7 @@ func TestSetElement(t *testing.T) {
 		{"D.I.R", "7-11", func(t testConfig) bool { return t.D.I.R.Base == 7 && t.D.I.R.Size == 5 }},
 		{"D.I.S", "a,b", func(t testConfig) bool { return reflect.DeepEqual(t.D.I.S, []string{"a", "b"}) }},
 		{"D.I.T", "foo", func(t testConfig) bool { return t.D.I.T == "foo" }},
+		{"D.I.U", "11.22.0.0/16", func(t testConfig) bool { return t.D.I.U.Network.Equal(net.ParseCIDR("11.22.0.0/16").Network) }},
 	} {
 		a := buildConfig()
 		if err := FindAndSet(tc.path, &a, tc.newval); err != nil {

--- a/pkg/util/config_test.go
+++ b/pkg/util/config_test.go
@@ -77,7 +77,7 @@ func buildConfig() testConfig {
 				P: false,
 				Q: net.ParseIP("12.34.56.78"),
 				R: utilnet.PortRange{Base: 2, Size: 4},
-				T: *cidr,
+				U: *cidr,
 			},
 		},
 		E: &subConfig2{


### PR DESCRIPTION
Currently you cannot pass CIDR objects using extraopts.

I want to be able to override GenericServerRunOptions.ServiceClusterIPRange, which is a CIDR.

This is because the default service CIDR address conflicts with some networks we use internally, and I want to be able to make the service CIDR host-routeable. 

For example:

```
minikube start --extra-config apiserver.GenericServerRunOptions.ServiceClusterIPRange=172.80.0.0/16 --extra-config kubelet.ClusterDNS=172.80.0.10
```

Currently, it's complaining because it can't parse net.IPNet objects. So, let's add support for that.