### PR TITLE
Update linux libvirt-bin dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Minikube is a tool that makes it easy to run Kubernetes locally. Minikube runs a
     * [xhyve driver](./DRIVERS.md#xhyve-driver), [VirtualBox](https://www.virtualbox.org/wiki/Downloads) or [VMware Fusion](https://www.vmware.com/products/fusion) installation
 * Linux
     * [VirtualBox](https://www.virtualbox.org/wiki/Downloads) or [KVM](http://www.linux-kvm.org/) installation,
+    * libvirt-bin
 * Windows
     * [Hyper-V](./DRIVERS.md#hyperv-driver)
 * VT-x/AMD-v virtualization must be enabled in BIOS


### PR DESCRIPTION
Since we compile with CGO on linux now, there is a dependency on
libvirt-bin, since minikube is now dynamically linked to libvirt.so.
This is unfortunate if you're using virtualbox on linux, but should
require no changes if you're using KVM already.

For better UX, we should probably just default linux to KVM for now,
until we have a no-vm driver.