### PR TITLE
Clean up localkube-image makefile rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ deploy/iso/minikube-iso/board/coreos/minikube/rootfs-overlay/etc/VERSION
 
 /pkg/minikube/assets/assets.go
 /minikube
+.localkube-image
 
 .DS_Store
 


### PR DESCRIPTION
renamed it from out/localkube-image to localkube-image and added another rule so that we could cache the docker build result independent of docker's caching