### PR TITLE
Add build date to localkube

### DIFF
--- a/hack/get_k8s_version.py
+++ b/hack/get_k8s_version.py
@@ -19,6 +19,7 @@
 import json
 import subprocess
 import sys
+from datetime import datetime
 
 K8S_PACKAGE = 'k8s.io/kubernetes/'
 X_ARG_BASE = '-X k8s.io/minikube/vendor/k8s.io/kubernetes/pkg/version.'
@@ -44,10 +45,13 @@ def get_tree_state():
     result = 'clean'
   return 'gitTreeState=%s' % result
 
+def get_build_date():
+  return 'buildDate=%s' % datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ')
+
 def main():
   if len(sys.argv) > 1 and sys.argv[1] == "--k8s-version-only":
       return get_from_godep('Comment')
-  args = [get_rev(), get_version(), get_tree_state()]
+  args = [get_rev(), get_version(), get_tree_state(), get_build_date()]
   return ' '.join([X_ARG_BASE + arg for arg in args])
 
 if __name__ == '__main__':


### PR DESCRIPTION
fixes #1270

this fix won't be cherry-picked to existing versions of localkube, but everything 1.6 and higher will have it

```
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"6+", GitVersion:"v1.6.0-beta.4", GitCommit:"b202120be3a97e5f8a5e20da51d0b6f5a1eebd31", GitTreeState:"clean", BuildDate:"2017
-03-17T17:54:01Z", GoVersion:"go1.7.5", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"5", GitVersion:"v1.5.3", GitCommit:"029c3a408176b55c30846f0faedf56aae5992e9b", GitTreeState:"dirty", BuildDate:"2017-03-21T0
9:54:43Z", GoVersion:"go1.7", Compiler:"gc", Platform:"linux/amd64"}
```