### PR TITLE
[WIP] Support external drivers in minikube

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -27,6 +28,7 @@ import (
 	units "github.com/docker/go-units"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/golang/glog"
+	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -34,9 +36,12 @@ import (
 	"k8s.io/minikube/pkg/minikube/cluster"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/kubeconfig"
+	configCmd "k8s.io/minikube/cmd/minikube/cmd/config"
 	"k8s.io/minikube/pkg/minikube/machine"
 	"k8s.io/minikube/pkg/util"
 	pkgutil "k8s.io/minikube/pkg/util"
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/docker/machine/libmachine/mcnflag"
 )
 
 const (
@@ -204,6 +209,154 @@ func calculateDiskSizeInMB(humanReadableDiskSize string) int {
 	return int(diskSize / units.MB)
 }
 
+// Peek into the command line args to see if a driver is set
+func flagHackLookup(flagName string) string {
+	for i, arg := range os.Args {
+		// format '--vm-driver foo'
+		if arg == flagName {
+			if i+1 < len(os.Args) {
+				return os.Args[i+1]
+			}
+		}
+		// format '--vm-driver=foo'
+		if strings.HasPrefix(arg, flagName+"=") {
+			return strings.Split(arg, "=")[1]
+		}
+	}
+	return ""
+}
+
+// Instantiate the specific driver, get the list of flags and add them to the start command
+func initDriverFlags(cmd *cobra.Command) error {
+	const (
+		flagLookupMachineName = "flag-lookup"
+	)
+
+	// We didn't recognize the driver name.
+	driverName := flagHackLookup("--vm-driver")
+	if driverName == "" {
+		//TODO: Check Environment have to include flagHackLookup function.
+		driverName = os.Getenv("MACHINE_DRIVER")
+		if driverName == "" {
+			driverName = "virtualbox"
+		}
+	}
+
+	// TODO: Fix hacky JSON solution
+	rawDriver, err := json.Marshal(&drivers.BaseDriver{
+		MachineName: flagLookupMachineName,
+	})
+	if err != nil {
+		return fmt.Errorf("Error attempting to marshal bare driver data: %s", err)
+	}
+
+	clientType := machine.ClientTypeLocal
+	if configCmd.IsValidDriver("", driverName) != nil {
+		clientType = machine.ClientTypeRPC
+	}
+	api, err := machine.NewAPIClient(clientType)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error getting client: %s\n", err)
+		os.Exit(1)
+	}
+	defer api.Close()
+
+	h, err := api.NewHost(driverName, rawDriver)
+	if err != nil {
+		return err
+	}
+
+	// Walk through the flags we get from the driver and add them so they
+	// show up as options under --start command
+	mcnFlags := h.Driver.GetCreateFlags()
+	for _, f := range mcnFlags {
+		switch t := f.(type) {
+		case mcnflag.BoolFlag:
+			f := f.(mcnflag.BoolFlag)
+			val := false
+			if f.EnvVar != "" {
+				for _, envVar := range strings.Split(f.EnvVar, ",") {
+					envVar = strings.TrimSpace(envVar)
+					if envVal := os.Getenv(envVar); envVal != "" {
+						val = cast.ToBool(envVal)
+						break
+					}
+				}
+			}
+			cmd.Flags().Bool(f.Name, val, f.Usage)
+		case mcnflag.IntFlag:
+			f := f.(mcnflag.IntFlag)
+			val := f.Value
+			if f.EnvVar != "" {
+				for _, envVar := range strings.Split(f.EnvVar, ",") {
+					envVar = strings.TrimSpace(envVar)
+					if envVal := os.Getenv(envVar); envVal != "" {
+						val = cast.ToInt(envVal)
+						break
+					}
+				}
+			}
+			cmd.Flags().Int(f.Name, val, f.Usage)
+		case mcnflag.StringFlag:
+			f := f.(mcnflag.StringFlag)
+			val := f.Value
+			if f.EnvVar != "" {
+				for _, envVar := range strings.Split(f.EnvVar, ",") {
+					envVar = strings.TrimSpace(envVar)
+					if envVal := os.Getenv(envVar); envVal != "" {
+						val = envVal
+						break
+					}
+				}
+			}
+			cmd.Flags().String(f.Name, val, f.Usage)
+		case *mcnflag.BoolFlag:
+			f := f.(*mcnflag.BoolFlag)
+			val := false
+			if f.EnvVar != "" {
+				for _, envVar := range strings.Split(f.EnvVar, ",") {
+					envVar = strings.TrimSpace(envVar)
+					if envVal := os.Getenv(envVar); envVal != "" {
+						val = cast.ToBool(envVal)
+						break
+					}
+				}
+			}
+			cmd.Flags().Bool(f.Name, val, f.Usage)
+		case *mcnflag.IntFlag:
+			f := f.(*mcnflag.IntFlag)
+			val := f.Value
+			if f.EnvVar != "" {
+				for _, envVar := range strings.Split(f.EnvVar, ",") {
+					envVar = strings.TrimSpace(envVar)
+					if envVal := os.Getenv(envVar); envVal != "" {
+						val = cast.ToInt(envVal)
+						break
+					}
+				}
+			}
+			cmd.Flags().Int(f.Name, val, f.Usage)
+		case *mcnflag.StringFlag:
+			f := f.(*mcnflag.StringFlag)
+			val := f.Value
+			if f.EnvVar != "" {
+				for _, envVar := range strings.Split(f.EnvVar, ",") {
+					envVar = strings.TrimSpace(envVar)
+					if envVal := os.Getenv(envVar); envVal != "" {
+						val = envVal
+						break
+					}
+				}
+			}
+			cmd.Flags().String(f.Name, val, f.Usage)
+		default:
+			glog.V(10).Infof("Unrecognized flag %#v of type: %T\n", f, t)
+		}
+	}
+
+	return nil
+}
+
 func init() {
 	startCmd.Flags().Bool(keepContext, constants.DefaultKeepContext, "This will keep the existing kubectl context and will create a minikube context.")
 	startCmd.Flags().String(isoURL, constants.DefaultIsoUrl, "Location of the minikube iso")
@@ -227,6 +380,9 @@ func init() {
 		`A set of key=value pairs that describe configuration that may be passed to different components.
 		The key should be '.' separated, and the first part before the dot is the component to apply the configuration to.
 		Valid components are: kubelet, apiserver, controller-manager, etcd, proxy, scheduler.`)
+
+	initDriverFlags(startCmd)
 	viper.BindPFlags(startCmd.Flags())
+
 	RootCmd.AddCommand(startCmd)
 }

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -34,11 +34,14 @@ import (
 	"github.com/docker/machine/libmachine/state"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"github.com/spf13/viper"
 
 	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/sshutil"
 	"k8s.io/minikube/pkg/util"
+	"github.com/docker/machine/libmachine/mcnflag"
+	"github.com/docker/machine/libmachine/drivers/rpc"
 )
 
 var (
@@ -299,6 +302,61 @@ func createVirtualboxHost(config MachineConfig) drivers.Driver {
 	return d
 }
 
+func getDriverOpts(mcnflags []mcnflag.Flag) drivers.DriverOptions {
+	// TODO: This function is pretty damn YOLO and would benefit from some
+	// sanity checking around types and assertions.
+	//
+	// But, we need it so that we can actually send the flags for creating
+	// a machine over the wire (cli.Context is a no go since there is so
+	// much stuff in it).
+	driverOpts := rpcdriver.RPCFlags{
+		Values: make(map[string]interface{}),
+	}
+
+	for _, f := range mcnflags {
+		key := f.String()
+		driverOpts.Values[key] = f.Default()
+
+		// Hardcoded logic for boolean... :(
+		if f.Default() == nil {
+			driverOpts.Values[key] = false
+		}
+
+		if viper.IsSet(key) {
+			switch t := f.(type) {
+			case mcnflag.BoolFlag:
+				driverOpts.Values[key] = viper.GetBool(key)
+			case mcnflag.IntFlag:
+				driverOpts.Values[key] = viper.GetInt(key)
+			case mcnflag.StringFlag:
+				driverOpts.Values[key] = viper.GetString(key)
+			case *mcnflag.BoolFlag:
+				driverOpts.Values[key] = viper.GetBool(key)
+			case *mcnflag.IntFlag:
+				driverOpts.Values[key] = viper.GetInt(key)
+			case *mcnflag.StringFlag:
+				driverOpts.Values[key] = viper.GetString(key)
+			default:
+				glog.V(10).Infof("Unrecognized flag %#v of type: %T\n", f, t)
+			}
+		}
+	}
+	return driverOpts
+}
+
+type externalDriver struct {
+	*drivers.BaseDriver
+}
+
+func createExternalDriver() *externalDriver {
+	return &externalDriver{
+		BaseDriver: &drivers.BaseDriver{
+			MachineName: constants.MachineName,
+			StorePath:   constants.GetMinipath(),
+		},
+	}
+}
+
 func createHost(api libmachine.API, config MachineConfig) (*host.Host, error) {
 	var driver interface{}
 
@@ -318,7 +376,7 @@ func createHost(api libmachine.API, config MachineConfig) (*host.Host, error) {
 	case "hyperv":
 		driver = createHypervHost(config)
 	default:
-		glog.Exitf("Unsupported driver: %s\n", config.VMDriver)
+		driver = createExternalDriver()
 	}
 
 	data, err := json.Marshal(driver)
@@ -334,6 +392,16 @@ func createHost(api libmachine.API, config MachineConfig) (*host.Host, error) {
 	h.HostOptions.AuthOptions.CertDir = constants.GetMinipath()
 	h.HostOptions.AuthOptions.StorePath = constants.GetMinipath()
 	h.HostOptions.EngineOptions = engineOptions(config)
+
+	// driverOpts is the actual data we send over the wire to set the
+	// driver parameters (an interface fulfilling drivers.DriverOptions,
+	// concrete type rpcdriver.RpcFlags).
+	mcnFlags := h.Driver.GetCreateFlags()
+	driverOpts := getDriverOpts(mcnFlags)
+
+	if err := h.Driver.SetConfigFromFlags(driverOpts); err != nil {
+		return nil, fmt.Errorf("Error setting machine configuration from flags provided: %s", err)
+	}
 
 	if err := api.Create(h); err != nil {
 		// Wait for all the logs to reach the client

--- a/pkg/minikube/machine/client_darwin.go
+++ b/pkg/minikube/machine/client_darwin.go
@@ -58,6 +58,6 @@ func registerDriver(driverName string) {
 	case "vmwarefusion":
 		plugin.RegisterDriver(vmwarefusion.NewDriver("", ""))
 	default:
-		glog.Exitf("Unsupported driver: %s\n", driverName)
+		glog.Infof("Unsupported driver - not registered: %s\n", driverName)
 	}
 }

--- a/pkg/util/downloader.go
+++ b/pkg/util/downloader.go
@@ -72,7 +72,7 @@ func (f DefaultDownloader) CacheMinikubeISOFromURL(isoURL string) error {
 		options.ChecksumHash = crypto.SHA256
 	}
 
-	fmt.Println("Downloading Minikube ISO")
+	fmt.Println("Downloading Minikube ISO from %s", isoURL)
 	if err := download.ToFile(isoURL, f.GetISOCacheFilepath(isoURL), options); err != nil {
 		return errors.Wrap(err, "Error downloading Minikube ISO")
 	}


### PR DESCRIPTION
Copy some ideas/code from the docker machine to prototype support for external driver. This PR allows the drivers to not only inject their own flags so that they show up for example when one runs `minikube --vm-driver local start --help` (where `local` is an external docker driver in a binary named `docker-machine-driver-local`), but also passes these flags down to the external driver via the existing docker machine Driver interface. 

Currently testing this with:
https://github.com/dims/docker-machine-local/

I'd like to end up getting this working with OpenStack/DevStack:
https://github.com/openstack/docker-machine-openstack/