### PR TITLE
Dockerized build for minikube-iso

### DIFF
--- a/deploy/iso/minikube-iso/Dockerfile
+++ b/deploy/iso/minikube-iso/Dockerfile
@@ -1,0 +1,44 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Beware ubuntu:16.10 and debian:testing have been tested and failed
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y \
+		build-essential \
+		git \
+		wget \
+		cpio \
+		python \
+		unzip \
+		bc \
+		gcc-multilib \
+		automake \
+		libtool \
+		gnupg2 \
+		p7zip-full \
+		locales \
+		&& rm -rf /var/lib/apt/lists/*
+
+RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+ENV LANG en_US.utf8
+
+# dumb init will allow us to interrupt the build with ^C
+RUN wget -O - https://github.com/Yelp/dumb-init/archive/v1.2.0.tar.gz | tar xvzf - \
+	&& make -C dumb-init-1.2.0 \
+	&& mv dumb-init-1.2.0/dumb-init /usr/bin \
+	&& rm -rf dumb-init-1.2.0
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["/bin/bash"]

--- a/deploy/iso/minikube-iso/README.md
+++ b/deploy/iso/minikube-iso/README.md
@@ -42,9 +42,12 @@ Also be sure to have an UTF-8 locale set up in order to build the ISO.
 ```
 $ git clone https://github.com/kubernetes/minikube
 $ cd minikube
-$ make minikube_iso
+$ make buildroot-image
+$ make out/minikube.iso
 ```
 
+The build will occurs inside a docker container, if you want to do this
+baremetal, replace `make out/minikube.iso` with `IN_DOCKER=1 make out/minikube.iso`.
 The bootable ISO image will be available in `out/minikube.iso`.
 
 ### Testing local minikube-iso changes


### PR DESCRIPTION
Dockerized build:

	$ make buildroot-image
	$ make out/minikube.iso

- Add en entry in the Makefile for building the container: buildroot-image
- Modify the minikube-iso target to out/minikube.iso to comply with the way
makefiles work.
- Also force the use of a docker container. If not needed
just run IN_DOCKER=1 make out/minikube.iso to avoid the invokation of a docker
container.
- Add some doc.
- The tag added to the generated image will allow to bypass the build of the
image as soon as the container is pushed to the minikube registry.

Close: #1110