### PR TITLE
Add support for private docker registry in registry-creds

### DIFF
--- a/cmd/minikube/cmd/config/util.go
+++ b/cmd/minikube/cmd/config/util.go
@@ -204,6 +204,7 @@ func EnableOrDisableAddon(name string, val string) error {
 		// Cleanup existing secrets
 		service.DeleteSecret("kube-system", "registry-creds-ecr")
 		service.DeleteSecret("kube-system", "registry-creds-gcr")
+		service.DeleteSecret("kube-system", "registry-creds-dpr")
 	}
 
 	//TODO(r2d4): config package should not reference API, pull this out

--- a/cmd/minikube/cmd/config/util.go
+++ b/cmd/minikube/cmd/config/util.go
@@ -109,6 +109,9 @@ func EnableOrDisableAddon(name string, val string) error {
 			awsRegion := "changeme"
 			awsAccount := "changeme"
 			gcrApplicationDefaultCredentials := "changeme"
+			dockerServer := "changeme"
+			dockerUser := "changeme"
+			dockerPass := "changeme"
 
 			enableAWSECR := AskForYesNoConfirmation("\nDo you want to enable AWS Elastic Container Registry?", posResponses, negResponses)
 			if enableAWSECR {
@@ -130,6 +133,13 @@ func EnableOrDisableAddon(name string, val string) error {
 				} else {
 					gcrApplicationDefaultCredentials = string(dat)
 				}
+			}
+
+			enableDR := AskForYesNoConfirmation("\nDo you want to enable Docker Registry?", posResponses, negResponses)
+			if enableDR {
+				dockerServer = AskForStaticValue("-- Enter docker registry server url: ")
+				dockerUser = AskForStaticValue("-- Enter docker registry username: ")
+				dockerPass = AskForStaticValue("-- Enter docker registry password: ")
 			}
 
 			// Create ECR Secret
@@ -167,6 +177,25 @@ func EnableOrDisableAddon(name string, val string) error {
 
 			if err != nil {
 				fmt.Println("ERROR creating `registry-creds-gcr` secret")
+			}
+
+			// Create Docker Secret
+			err = service.CreateSecret(
+				"kube-system",
+				"registry-creds-dpr",
+				map[string]string{
+					"DOCKER_PRIVATE_REGISTRY_SERVER":   dockerServer,
+					"DOCKER_PRIVATE_REGISTRY_USER":     dockerUser,
+					"DOCKER_PRIVATE_REGISTRY_PASSWORD": dockerPass,
+				},
+				map[string]string{
+					"app":   "registry-creds",
+					"cloud": "dpr",
+					"kubernetes.io/minikube-addons": "registry-creds",
+				})
+
+			if err != nil {
+				fmt.Println("ERROR creating `registry-creds-dpr` secret")
 			}
 
 			break

--- a/deploy/addons/registry-creds/registry-creds-rc.yaml
+++ b/deploy/addons/registry-creds/registry-creds-rc.yaml
@@ -4,24 +4,24 @@ metadata:
   name: registry-creds
   namespace: kube-system
   labels:
-    version: v1.6
+    version: v1.7
     kubernetes.io/cluster-service: "true"
     kubernetes.io/minikube-addons: registry-creds
 spec:
   replicas: 1
   selector:
     name: registry-creds
-    version: v1.6
+    version: v1.7
     kubernetes.io/cluster-service: "true"
   template:
     metadata:
       labels:
         name: registry-creds
-        version: v1.6
+        version: v1.7
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-      - image: upmcenterprises/registry-creds:1.6
+      - image: upmcenterprises/registry-creds:1.7
         name: registry-creds
         imagePullPolicy: Always
         env:
@@ -45,6 +45,21 @@ spec:
               secretKeyRef:
                 name: registry-creds-ecr
                 key: aws-region
+          - name: DOCKER_PRIVATE_REGISTRY_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: registry-creds-dpr
+                key: DOCKER_PRIVATE_REGISTRY_PASSWORD
+          - name: DOCKER_PRIVATE_REGISTRY_SERVER
+            valueFrom:
+              secretKeyRef:
+                name: registry-creds-dpr
+                key: DOCKER_PRIVATE_REGISTRY_SERVER
+          - name: DOCKER_PRIVATE_REGISTRY_USER
+            valueFrom:
+              secretKeyRef:
+                name: registry-creds-dpr
+                key: DOCKER_PRIVATE_REGISTRY_USER
         volumeMounts:
         - name: gcr-creds
           mountPath: "/root/.config/gcloud"


### PR DESCRIPTION
Registry-Creds now has support for private docker registries. This adds support to enter credentials for that registry in addition to ECR and GCR. 

Also, registry-creds now watches namespaces and will update pull secrets for any new namespace. 