### PR TITLE
Check APIServerName against default

### DIFF
--- a/pkg/minikube/cluster/commands.go
+++ b/pkg/minikube/cluster/commands.go
@@ -154,7 +154,7 @@ func GenLocalkubeStartCmd(kubernetesConfig KubernetesConfig) (string, error) {
 		flagVals = append(flagVals, "--feature-gates="+kubernetesConfig.FeatureGates)
 	}
 
-	if kubernetesConfig.APIServerName != "" {
+	if kubernetesConfig.APIServerName != constants.APIServerName {
 		flagVals = append(flagVals, "--apiserver-name="+kubernetesConfig.APIServerName)
 	}
 


### PR DESCRIPTION
If the apiserver is something other than the default, pass in the flag.
 This won't be compatible with the old versions of localkube.  Old
versions of localkube will work as long as apiserver-name is not
specified in minikube, always using the default.

Fixes #1281 #1220