### PR TITLE
Don't glog top level command error message

### DIFF
--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -111,9 +111,7 @@ Please use --v=3 to show libmachine logs, and --v=7 for debug level libmachine l
 // Execute adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		glog.Exitln(err)
-	}
+	_ = RootCmd.Execute()
 }
 
 // Handle config values for flags used in external packages (e.g. glog)


### PR DESCRIPTION
This is already printed to stderr through RootCmd.Execute().  We could
save to this the glog logs by supressing the RootCmd.Execute() error
output, but this displays a more user friendly error (i.e. no log
prepended info)

Fixes #1282 