### PR TITLE
Disable the default provisioner addon

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -148,6 +148,12 @@ var settings = []Setting{
 		callbacks:   []setFn{EnableOrDisableAddon},
 	},
 	{
+		name:        "default-storageclass",
+		set:         SetBool,
+		validations: []setFn{IsValidAddon},
+		callbacks:   []setFn{EnableOrDisableDefaultStorageClass},
+	},
+	{
 		name: "hyperv-virtual-switch",
 		set:  SetString,
 	},

--- a/cmd/minikube/cmd/config/util.go
+++ b/cmd/minikube/cmd/config/util.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/machine"
 	"k8s.io/minikube/pkg/minikube/service"
 	"k8s.io/minikube/pkg/minikube/sshutil"
+	"k8s.io/minikube/pkg/minikube/storageclass"
 )
 
 // Runs all the validation or callback functions and collects errors
@@ -253,4 +254,20 @@ func transferAddonViaDriver(addon *assets.Addon, d drivers.Driver) error {
 		return err
 	}
 	return nil
+}
+
+func EnableOrDisableDefaultStorageClass(name, val string) error {
+	enable, err := strconv.ParseBool(val)
+	if err != nil {
+		return errors.Wrap(err, "Error parsing boolean")
+	}
+
+	// Special logic to disable the default storage class
+	if !enable {
+		err := storageclass.DisableDefaultStorageClass()
+		if err != nil {
+			return errors.Wrap(err, "Error disabling default storage class")
+		}
+	}
+	return EnableOrDisableAddon(name, val)
 }

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -63,6 +63,9 @@ const MinikubeContext = "minikube"
 // MinikubeEnvPrefix is the prefix for the environmental variables
 const MinikubeEnvPrefix = "MINIKUBE"
 
+// The name of the default storage class provisioner
+const DefaultStorageClassProvisioner = "standard"
+
 // MakeMiniPath is a utility to calculate a relative path to our directory.
 func MakeMiniPath(fileName ...string) string {
 	args := []string{GetMinipath()}

--- a/pkg/minikube/storageclass/storageclass.go
+++ b/pkg/minikube/storageclass/storageclass.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storageclass
+
+import (
+	"github.com/pkg/errors"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/minikube/pkg/minikube/constants"
+)
+
+// DisableDefaultStorageClass disables the default storage class provisioner
+// The addon-manager and kubectl apply cannot delete storageclasses
+func DisableDefaultStorageClass() error {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
+	config, err := kubeConfig.ClientConfig()
+	if err != nil {
+		return errors.Wrap(err, "Error creating kubeConfig")
+	}
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return errors.Wrap(err, "Error creating new client from kubeConfig.ClientConfig()")
+	}
+
+	err = client.StorageClasses().Delete(constants.DefaultStorageClassProvisioner, &v1.DeleteOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "Error deleting default storage class %s", constants.DefaultStorageClassProvisioner)
+	}
+
+	return nil
+}


### PR DESCRIPTION
We have to do this through client-go directly, since the addon manager
and kubectl ignore the storageclass resource.


Fixes #1244