### PR TITLE
Fixed the certification generation to use the correct IP.

### DIFF
--- a/pkg/localkube/localkube.go
+++ b/pkg/localkube/localkube.go
@@ -180,7 +180,7 @@ func (lk LocalkubeServer) shouldGenerateCACerts() bool {
 }
 
 func (lk LocalkubeServer) getAllIPs() ([]net.IP, error) {
-	ips := []net.IP{lk.ServiceClusterIPRange.IP}
+	ips := []net.IP{net.ParseIP(util.DefaultServiceClusterIP)}
 	addrs, err := net.InterfaceAddrs()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When invoking localkube a certificate is not correctly generated for the
target ip. For example, when network 10.0.0.1/24 is parsed it generates
a certificate for 10.0.0.0 instead of 10.0.0.1.

Fixed #1215. (with @mhbauer)