### PR TITLE
update kubernetes godep restore command

### DIFF
--- a/UPDATE_KUBERNETES.md
+++ b/UPDATE_KUBERNETES.md
@@ -44,7 +44,7 @@ Make sure to also fetch tags, as Godep relies on these.
 
  ```shell
  git checkout $DESIREDTAG
- godep restore ./...
+ ./hack/godep-restore.sh
  ```
 
 4. Build and test minikube, making any manual changes necessary to build.


### PR DESCRIPTION
As of k8s v1.6.0-rc.1, `godep restore ./...` no longer works and the recommended path is to use
./hack/godep-restore.sh to restore go dependencies.

See https://github.com/kubernetes/kubernetes/issues/42403