### PR TITLE
pkg/minikube: print error messages to stderr

### DIFF
--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -462,7 +462,7 @@ func EnsureMinikubeRunningOrExit(api libmachine.API, exitStatus int) {
 		os.Exit(1)
 	}
 	if s != state.Running.String() {
-		fmt.Fprintln(os.Stdout, "minikube is not currently running so the service cannot be accessed")
+		fmt.Fprintln(os.Stderr, "minikube is not currently running so the service cannot be accessed")
 		os.Exit(exitStatus)
 	}
 }

--- a/pkg/minikube/service/service.go
+++ b/pkg/minikube/service/service.go
@@ -232,7 +232,7 @@ func WaitAndMaybeOpenService(api libmachine.API, namespace string, service strin
 		if urlMode || !strings.HasPrefix(url, "http") {
 			fmt.Fprintln(os.Stdout, url)
 		} else {
-			fmt.Fprintln(os.Stdout, "Opening kubernetes service "+namespace+"/"+service+" in default browser...")
+			fmt.Fprintln(os.Stderr, "Opening kubernetes service "+namespace+"/"+service+" in default browser...")
 			browser.OpenURL(url)
 		}
 	}


### PR DESCRIPTION
Some tutorials capture the stdout of commands like `minikube service`. E.g. https://github.com/coreos/etcd-operator#create-and-destroy-an-etcd-cluster

I hit one of these errors and it accidentally got captured instead of going to stderr. Does this seem like a reasonable change?