### PR TITLE
Added --name flag and MINIKUBE_NAME env var for vm machine name

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -112,6 +112,10 @@ var settings = []Setting{
 		set:  SetBool,
 	},
 	{
+		name: config.MachineName,
+		set:  SetString,
+	},
+	{
 		name:        "dashboard",
 		set:         SetBool,
 		validations: []setFn{IsValidAddon},

--- a/cmd/minikube/cmd/env.go
+++ b/cmd/minikube/cmd/env.go
@@ -32,6 +32,7 @@ import (
 	"github.com/spf13/cobra"
 	cmdUtil "k8s.io/minikube/cmd/util"
 	"k8s.io/minikube/pkg/minikube/cluster"
+	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/machine"
 )
@@ -160,7 +161,7 @@ func shellCfgSet(api libmachine.API) (*ShellConfig, error) {
 	}
 
 	if noProxy {
-		host, err := api.Load(constants.MachineName)
+		host, err := api.Load(config.GetMachineName())
 		if err != nil {
 			return nil, errors.Wrap(err, "Error getting IP")
 		}

--- a/cmd/minikube/cmd/env_test.go
+++ b/cmd/minikube/cmd/env_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/host"
+	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/tests"
 )
@@ -49,8 +50,8 @@ func (f FakeNoProxyGetter) GetNoProxyVar() (string, string) {
 
 var defaultAPI = &tests.MockAPI{
 	Hosts: map[string]*host.Host{
-		constants.MachineName: {
-			Name:   constants.MachineName,
+		config.GetMachineName(): {
+			Name:   config.GetMachineName(),
 			Driver: &tests.MockDriver{},
 		},
 	},

--- a/cmd/minikube/cmd/ip.go
+++ b/cmd/minikube/cmd/ip.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
-	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/machine"
 )
 
@@ -38,7 +38,7 @@ var ipCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		defer api.Close()
-		host, err := api.Load(constants.MachineName)
+		host, err := api.Load(config.GetMachineName())
 		if err != nil {
 			glog.Errorln("Error getting IP: ", err)
 			os.Exit(1)

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -113,6 +113,8 @@ func setFlagsUsingViper() {
 func init() {
 	RootCmd.PersistentFlags().Bool(showLibmachineLogs, false, "Deprecated: To enable libmachine logs, set --v=3 or higher")
 	RootCmd.PersistentFlags().Bool(useVendoredDriver, false, "Use the vendored in drivers instead of RPC")
+	RootCmd.PersistentFlags().String(config.MachineName, constants.DefaultMachineName, `The name of the minikube VM being used.  
+	This can be modified to allow for multiple minikube instances to be run independently`)
 	RootCmd.AddCommand(configCmd.ConfigCmd)
 	RootCmd.AddCommand(configCmd.AddonsCmd)
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -32,6 +32,7 @@ import (
 
 	cmdUtil "k8s.io/minikube/cmd/util"
 	"k8s.io/minikube/pkg/minikube/cluster"
+	cfg "k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/kubeconfig"
 	"k8s.io/minikube/pkg/minikube/machine"
@@ -177,7 +178,7 @@ func runStart(cmd *cobra.Command, args []string) {
 	}
 
 	kubeCfgSetup := &kubeconfig.KubeConfigSetup{
-		ClusterName:          constants.MinikubeContext,
+		ClusterName:          cfg.GetMachineName(),
 		ClusterServerAddress: kubeHost,
 		ClientCertificate:    constants.MakeMiniPath("apiserver.crt"),
 		ClientKey:            constants.MakeMiniPath("apiserver.key"),

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pkg/errors"
 
 	"k8s.io/minikube/pkg/minikube/assets"
+	cfg "k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/sshutil"
 	"k8s.io/minikube/pkg/util"
@@ -56,16 +57,16 @@ func init() {
 
 // StartHost starts a host VM.
 func StartHost(api libmachine.API, config MachineConfig) (*host.Host, error) {
-	exists, err := api.Exists(constants.MachineName)
+	exists, err := api.Exists(cfg.GetMachineName())
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error checking if host exists: %s", constants.MachineName)
+		return nil, errors.Wrapf(err, "Error checking if host exists: %s", cfg.GetMachineName())
 	}
 	if !exists {
 		return createHost(api, config)
 	}
 
 	glog.Infoln("Machine exists!")
-	h, err := api.Load(constants.MachineName)
+	h, err := api.Load(cfg.GetMachineName())
 	if err != nil {
 		return nil, errors.Wrap(err, "Error loading existing host. Please try running [minikube delete], then run [minikube start] again.")
 	}
@@ -93,42 +94,42 @@ func StartHost(api libmachine.API, config MachineConfig) (*host.Host, error) {
 
 // StopHost stops the host VM.
 func StopHost(api libmachine.API) error {
-	host, err := api.Load(constants.MachineName)
+	host, err := api.Load(cfg.GetMachineName())
 	if err != nil {
-		return errors.Wrapf(err, "Error loading host: %s", constants.MachineName)
+		return errors.Wrapf(err, "Error loading host: %s", cfg.GetMachineName())
 	}
 	if err := host.Stop(); err != nil {
-		return errors.Wrapf(err, "Error stopping host: %s", constants.MachineName)
+		return errors.Wrapf(err, "Error stopping host: %s", cfg.GetMachineName())
 	}
 	return nil
 }
 
 // DeleteHost deletes the host VM.
 func DeleteHost(api libmachine.API) error {
-	host, err := api.Load(constants.MachineName)
+	host, err := api.Load(cfg.GetMachineName())
 	if err != nil {
-		return errors.Wrapf(err, "Error deleting host: %s", constants.MachineName)
+		return errors.Wrapf(err, "Error deleting host: %s", cfg.GetMachineName())
 	}
 	m := util.MultiError{}
 	m.Collect(host.Driver.Remove())
-	m.Collect(api.Remove(constants.MachineName))
+	m.Collect(api.Remove(cfg.GetMachineName()))
 	return m.ToError()
 }
 
 // GetHostStatus gets the status of the host VM.
 func GetHostStatus(api libmachine.API) (string, error) {
 	dne := "Does Not Exist"
-	exists, err := api.Exists(constants.MachineName)
+	exists, err := api.Exists(cfg.GetMachineName())
 	if err != nil {
-		return "", errors.Wrapf(err, "Error checking that api exists for: %s", constants.MachineName)
+		return "", errors.Wrapf(err, "Error checking that api exists for: %s", cfg.GetMachineName())
 	}
 	if !exists {
 		return dne, nil
 	}
 
-	host, err := api.Load(constants.MachineName)
+	host, err := api.Load(cfg.GetMachineName())
 	if err != nil {
-		return "", errors.Wrapf(err, "Error loading api for: %s", constants.MachineName)
+		return "", errors.Wrapf(err, "Error loading api for: %s", cfg.GetMachineName())
 	}
 
 	s, err := host.Driver.GetState()
@@ -290,7 +291,7 @@ func engineOptions(config MachineConfig) *engine.Options {
 }
 
 func createVirtualboxHost(config MachineConfig) drivers.Driver {
-	d := virtualbox.NewDriver(constants.MachineName, constants.GetMinipath())
+	d := virtualbox.NewDriver(cfg.GetMachineName(), constants.GetMinipath())
 	d.Boot2DockerURL = config.Downloader.GetISOFileURI(config.MinikubeISO)
 	d.Memory = config.Memory
 	d.CPU = config.CPUs
@@ -417,17 +418,17 @@ func Mount9pHost(api libmachine.API) error {
 }
 
 func CheckIfApiExistsAndLoad(api libmachine.API) (*host.Host, error) {
-	exists, err := api.Exists(constants.MachineName)
+	exists, err := api.Exists(cfg.GetMachineName())
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error checking that api exists for: %s", constants.MachineName)
+		return nil, errors.Wrapf(err, "Error checking that api exists for: %s", cfg.GetMachineName())
 	}
 	if !exists {
-		return nil, errors.Errorf("Machine does not exist for api.Exists(%s)", constants.MachineName)
+		return nil, errors.Errorf("Machine does not exist for api.Exists(%s)", cfg.GetMachineName())
 	}
 
-	host, err := api.Load(constants.MachineName)
+	host, err := api.Load(cfg.GetMachineName())
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error loading api for: %s", constants.MachineName)
+		return nil, errors.Wrapf(err, "Error loading api for: %s", cfg.GetMachineName())
 	}
 	return host, nil
 }
@@ -444,7 +445,7 @@ func CreateSSHShell(api libmachine.API, args []string) error {
 	}
 
 	if currentState != state.Running {
-		return errors.Errorf("Error: Cannot run ssh command: Host %q is not running", constants.MachineName)
+		return errors.Errorf("Error: Cannot run ssh command: Host %q is not running", cfg.GetMachineName())
 	}
 
 	client, err := host.CreateSSHClient()

--- a/pkg/minikube/cluster/cluster_darwin.go
+++ b/pkg/minikube/cluster/cluster_darwin.go
@@ -23,11 +23,12 @@ import (
 	"github.com/docker/machine/drivers/vmwarefusion"
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/host"
+	cfg "k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 )
 
 func createVMwareFusionHost(config MachineConfig) drivers.Driver {
-	d := vmwarefusion.NewDriver(constants.MachineName, constants.GetMinipath()).(*vmwarefusion.Driver)
+	d := vmwarefusion.NewDriver(cfg.GetMachineName(), constants.GetMinipath()).(*vmwarefusion.Driver)
 	d.Boot2DockerURL = config.Downloader.GetISOFileURI(config.MinikubeISO)
 	d.Memory = config.Memory
 	d.CPU = config.CPUs
@@ -59,13 +60,13 @@ type xhyveDriver struct {
 func createXhyveHost(config MachineConfig) *xhyveDriver {
 	return &xhyveDriver{
 		BaseDriver: &drivers.BaseDriver{
-			MachineName: constants.MachineName,
+			MachineName: cfg.GetMachineName(),
 			StorePath:   constants.GetMinipath(),
 		},
 		Memory:         config.Memory,
 		CPU:            config.CPUs,
 		Boot2DockerURL: config.Downloader.GetISOFileURI(config.MinikubeISO),
-		BootCmd:        "loglevel=3 user=docker console=ttyS0 console=tty0 noembed nomodeset norestore waitusb=10 base host=" + constants.MachineName,
+		BootCmd:        "loglevel=3 user=docker console=ttyS0 console=tty0 noembed nomodeset norestore waitusb=10 base host=" + cfg.GetMachineName(),
 		DiskSize:       int64(config.DiskSize),
 		Virtio9p:       true,
 		Virtio9pFolder: "/Users",

--- a/pkg/minikube/cluster/cluster_linux.go
+++ b/pkg/minikube/cluster/cluster_linux.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/host"
+	cfg "k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 )
 
@@ -45,7 +46,7 @@ type kvmDriver struct {
 func createKVMHost(config MachineConfig) *kvmDriver {
 	return &kvmDriver{
 		BaseDriver: &drivers.BaseDriver{
-			MachineName: constants.MachineName,
+			MachineName: cfg.GetMachineName(),
 			StorePath:   constants.GetMinipath(),
 		},
 		Memory:         config.Memory,
@@ -54,8 +55,8 @@ func createKVMHost(config MachineConfig) *kvmDriver {
 		PrivateNetwork: "docker-machines",
 		Boot2DockerURL: config.Downloader.GetISOFileURI(config.MinikubeISO),
 		DiskSize:       config.DiskSize,
-		DiskPath:       filepath.Join(constants.GetMinipath(), "machines", constants.MachineName, fmt.Sprintf("%s.img", constants.MachineName)),
-		ISO:            filepath.Join(constants.GetMinipath(), "machines", constants.MachineName, "boot2docker.iso"),
+		DiskPath:       filepath.Join(constants.GetMinipath(), "machines", cfg.GetMachineName(), fmt.Sprintf("%s.img", cfg.GetMachineName())),
+		ISO:            filepath.Join(constants.GetMinipath(), "machines", cfg.GetMachineName(), "boot2docker.iso"),
 		CacheMode:      "default",
 		IOMode:         "threads",
 	}

--- a/pkg/minikube/cluster/cluster_test.go
+++ b/pkg/minikube/cluster/cluster_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/docker/machine/libmachine/provision"
 	"github.com/docker/machine/libmachine/state"
 	"k8s.io/minikube/pkg/minikube/assets"
+	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/tests"
 )
@@ -50,7 +51,7 @@ var defaultMachineConfig = MachineConfig{
 func TestCreateHost(t *testing.T) {
 	api := tests.NewMockAPI()
 
-	exists, _ := api.Exists(constants.MachineName)
+	exists, _ := api.Exists(config.GetMachineName())
 	if exists {
 		t.Fatal("Machine already exists.")
 	}
@@ -58,12 +59,12 @@ func TestCreateHost(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating host: %v", err)
 	}
-	exists, _ = api.Exists(constants.MachineName)
+	exists, _ = api.Exists(config.GetMachineName())
 	if !exists {
 		t.Fatal("Machine does not exist, but should.")
 	}
 
-	h, err := api.Load(constants.MachineName)
+	h, err := api.Load(config.GetMachineName())
 	if err != nil {
 		t.Fatalf("Error loading machine: %v", err)
 	}
@@ -146,7 +147,7 @@ func TestStartHostExists(t *testing.T) {
 	if err != nil {
 		t.Fatal("Error starting host.")
 	}
-	if h.Name != constants.MachineName {
+	if h.Name != config.GetMachineName() {
 		t.Fatalf("Machine created with incorrect name: %s", h.Name)
 	}
 	if s, _ := h.Driver.GetState(); s != state.Running {
@@ -174,7 +175,7 @@ func TestStartStoppedHost(t *testing.T) {
 	if err != nil {
 		t.Fatal("Error starting host.")
 	}
-	if h.Name != constants.MachineName {
+	if h.Name != config.GetMachineName() {
 		t.Fatalf("Machine created with incorrect name: %s", h.Name)
 	}
 
@@ -201,7 +202,7 @@ func TestStartHost(t *testing.T) {
 	if err != nil {
 		t.Fatal("Error starting host.")
 	}
-	if h.Name != constants.MachineName {
+	if h.Name != config.GetMachineName() {
 		t.Fatalf("Machine created with incorrect name: %s", h.Name)
 	}
 	if exists, _ := api.Exists(h.Name); !exists {
@@ -315,7 +316,7 @@ func TestDeleteHostMultipleErrors(t *testing.T) {
 		t.Fatal("Expected error deleting host, didn't get one.")
 	}
 
-	expectedErrors := []string{"Error removing " + constants.MachineName, "Error deleting machine"}
+	expectedErrors := []string{"Error removing " + config.GetMachineName(), "Error deleting machine"}
 	for _, expectedError := range expectedErrors {
 		if !strings.Contains(err.Error(), expectedError) {
 			t.Fatalf("Error %s expected to contain: %s.", err, expectedError)
@@ -361,7 +362,7 @@ func TestGetLocalkubeStatus(t *testing.T) {
 			SSHKeyPath: "",
 		},
 	}
-	api.Hosts[constants.MachineName] = &host.Host{Driver: d}
+	api.Hosts[config.GetMachineName()] = &host.Host{Driver: d}
 
 	s.SetCommandToOutput(map[string]string{
 		localkubeStatusCommand: state.Running.String(),
@@ -493,7 +494,7 @@ func TestHostGetLogs(t *testing.T) {
 			SSHKeyPath: "",
 		},
 	}
-	api.Hosts[constants.MachineName] = &host.Host{Driver: d}
+	api.Hosts[config.GetMachineName()] = &host.Host{Driver: d}
 
 	tests := []struct {
 		description string
@@ -542,7 +543,7 @@ func TestCreateSSHShell(t *testing.T) {
 			SSHKeyPath: "",
 		},
 	}
-	api.Hosts[constants.MachineName] = &host.Host{Driver: d}
+	api.Hosts[config.GetMachineName()] = &host.Host{Driver: d}
 
 	cliArgs := []string{"exit"}
 	if err := CreateSSHShell(api, cliArgs); err != nil {

--- a/pkg/minikube/cluster/cluster_windows.go
+++ b/pkg/minikube/cluster/cluster_windows.go
@@ -26,11 +26,12 @@ import (
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/pkg/errors"
+	cfg "k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 )
 
 func createHypervHost(config MachineConfig) drivers.Driver {
-	d := hyperv.NewDriver(constants.MachineName, constants.GetMinipath())
+	d := hyperv.NewDriver(cfg.GetMachineName(), constants.GetMinipath())
 	d.Boot2DockerURL = config.Downloader.GetISOFileURI(config.MinikubeISO)
 	d.VSwitch = config.HypervVirtualSwitch
 	d.MemSize = config.Memory

--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/constants"
 )
 
@@ -32,6 +33,7 @@ const (
 	WantReportError           = "WantReportError"
 	WantReportErrorPrompt     = "WantReportErrorPrompt"
 	WantKubectlDownloadMsg    = "WantKubectlDownloadMsg"
+	MachineName               = "name"
 )
 
 type MinikubeConfig map[string]interface{}
@@ -73,4 +75,12 @@ func decode(r io.Reader) (MinikubeConfig, error) {
 	var data MinikubeConfig
 	err := json.NewDecoder(r).Decode(&data)
 	return data, err
+}
+
+// GetMachineName gets the machine name for the VM
+func GetMachineName() string {
+	if viper.GetString(MachineName) == "" {
+		return constants.DefaultMachineName
+	}
+	return viper.GetString(MachineName)
 }

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -27,9 +27,6 @@ import (
 	minikubeVersion "k8s.io/minikube/pkg/version"
 )
 
-// MachineName is the name to use for the VM.
-const MachineName = "minikube"
-
 // APIServerPort is the port that the API server should listen on.
 const (
 	APIServerPort = 8443
@@ -62,6 +59,9 @@ const MinikubeContext = "minikube"
 
 // MinikubeEnvPrefix is the prefix for the environmental variables
 const MinikubeEnvPrefix = "MINIKUBE"
+
+// DefaultMachineName is the default name for the VM
+const DefaultMachineName = "minikube"
 
 // The name of the default storage class provisioner
 const DefaultStorageClassProvisioner = "standard"

--- a/pkg/minikube/service/service_test.go
+++ b/pkg/minikube/service/service_test.go
@@ -29,7 +29,7 @@ import (
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/kubernetes/typed/core/v1/fake"
 	"k8s.io/client-go/pkg/api/v1"
-	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/tests"
 )
 
@@ -277,8 +277,8 @@ func TestPrintURLsForService(t *testing.T) {
 func TestGetServiceURLs(t *testing.T) {
 	defaultAPI := &tests.MockAPI{
 		Hosts: map[string]*host.Host{
-			constants.MachineName: {
-				Name:   constants.MachineName,
+			config.GetMachineName(): {
+				Name:   config.GetMachineName(),
 				Driver: &tests.MockDriver{},
 			},
 		},
@@ -344,8 +344,8 @@ func TestGetServiceURLs(t *testing.T) {
 func TestGetServiceURLsForService(t *testing.T) {
 	defaultAPI := &tests.MockAPI{
 		Hosts: map[string]*host.Host{
-			constants.MachineName: {
-				Name:   constants.MachineName,
+			config.GetMachineName(): {
+				Name:   config.GetMachineName(),
 				Driver: &tests.MockDriver{},
 			},
 		},


### PR DESCRIPTION
This allows users to specify the vm name for minikube to allow for multiple minikubeVMs to be created.  This enables multiple minikubes to be managed on a single machine.

Example use:
```
$ minikube start --name=test
$ minikube start --name=test2
#VM created w/ name test
$ minikube status --name=test
$ minikube status --name=test2
$ minikube delete --name=test
$ minikube delete --name=test2
```
```
$ minikube start --name=test
$ minikube start --name=test2
$ minikube config set name test
$ minikube status
$ minikube logs
....
$ minikube config set name test2
$ minikube status
$ minikube logs
....
```