### PR TITLE
Update docker/machine dependencies for minikube to pull in fix for #1328

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -862,158 +862,158 @@
 		},
 		{
 			"ImportPath": "github.com/docker/machine/commands/mcndirs",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/drivers/errdriver",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/drivers/hyperv",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/drivers/none",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/drivers/virtualbox",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/drivers/vmwarefusion",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/auth",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/cert",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/check",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/drivers",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/drivers/plugin",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/drivers/plugin/localbinary",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/drivers/rpc",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/engine",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/host",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/log",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/mcndockerclient",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/mcnerror",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/mcnflag",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/mcnutils",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/persist",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/provision",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/provision/pkgaction",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/provision/serviceaction",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/shell",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/ssh",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/state",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/swarm",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/libmachine/version",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/machine/version",
-			"Comment": "docs-v0.8.2-2016-09-26-11-g91e368eb",
-			"Rev": "91e368eb7422665278b1d5665139ee0f9980b588"
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		},
 		{
 			"ImportPath": "github.com/docker/spdystream",
@@ -6438,6 +6438,46 @@
 		{
 			"ImportPath": "k8s.io/metrics/pkg/client/custom_metrics",
 			"Rev": "fd2415bb9381a6731027b48a8c6b78f28e13f876"
+		},
+		{
+			"ImportPath": "github.com/docker/machine/vendor/github.com/docker/docker/pkg/term",
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
+		},
+		{
+			"ImportPath": "github.com/docker/machine/vendor/golang.org/x/crypto/ssh",
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
+		},
+		{
+			"ImportPath": "github.com/docker/machine/vendor/golang.org/x/crypto/ssh/terminal",
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
+		},
+		{
+			"ImportPath": "github.com/docker/machine/vendor/golang.org/x/crypto/curve25519",
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
+		},
+		{
+			"ImportPath": "github.com/docker/machine/vendor/golang.org/x/sys/windows/registry",
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
+		},
+		{
+			"ImportPath": "github.com/docker/machine/libmachine/versioncmp",
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
+		},
+		{
+			"ImportPath": "github.com/docker/machine/vendor/github.com/samalba/dockerclient",
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
+		},
+		{
+			"ImportPath": "github.com/docker/machine/vendor/github.com/docker/go-units",
+			"Comment": "docs-v0.8.2-2016-09-26-183-g07d63b6f",
+			"Rev": "07d63b6ff555ddec6f0458c5a4af3cc711aea75d"
 		}
 	]
 }

--- a/pkg/provision/buildroot.go
+++ b/pkg/provision/buildroot.go
@@ -73,6 +73,13 @@ Environment=DOCKER_RAMDISK=yes
 {{range .EngineOptions.Env}}Environment={{.}}
 {{end}}
 
+# This file is a systemd drop-in unit that inherits from the base dockerd configuration.
+# The base configuration already specifies an 'ExecStart=...' command. The first directive
+# here is to clear out that command inherited from the base configuration. Without this,
+# the command from the base configuration and the command specified here are treated as
+# a sequence of commands, which is not the desired behavior, nor is it valid -- systemd
+# will catch this invalid input and refuse to start the service with an error like:
+#  Service has more than one ExecStart= setting, which is only allowed for Type=oneshot services.
 ExecStart=
 ExecStart=/usr/bin/docker daemon -H tcp://0.0.0.0:{{.DockerPort}} -H unix:///var/run/docker.sock --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}} {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
 ExecReload=/bin/kill -s HUP $MAINPID

--- a/pkg/provision/buildroot.go
+++ b/pkg/provision/buildroot.go
@@ -72,6 +72,8 @@ Type=notify
 Environment=DOCKER_RAMDISK=yes
 {{range .EngineOptions.Env}}Environment={{.}}
 {{end}}
+
+ExecStart=
 ExecStart=/usr/bin/docker daemon -H tcp://0.0.0.0:{{.DockerPort}} -H unix:///var/run/docker.sock --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}} {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
 ExecReload=/bin/kill -s HUP $MAINPID
 

--- a/test/integration/docker_test.go
+++ b/test/integration/docker_test.go
@@ -38,18 +38,19 @@ func TestDocker(t *testing.T) {
 	minikubeRunner.RunCommand(startCmd, true)
 	minikubeRunner.EnsureRunning()
 
-	filename := "/etc/systemd/system/docker.service"
-
-	profileContents := minikubeRunner.RunCommand(fmt.Sprintf("ssh sudo cat %s", filename), true)
-	fmt.Println(profileContents)
+	dockerdEnvironment := minikubeRunner.RunCommand("ssh -- systemctl show docker --property=Environment", true)
+	fmt.Println(dockerdEnvironment)
 	for _, envVar := range []string{"FOO=BAR", "BAZ=BAT"} {
-		if !strings.Contains(profileContents, envVar) {
-			t.Fatalf("Env var %s missing from file: %s.", envVar, profileContents)
+		if !strings.Contains(dockerdEnvironment, envVar) {
+			t.Fatalf("Env var %s missing from Environment: %s.", envVar, dockerdEnvironment)
 		}
 	}
+
+	dockerdExecStart := minikubeRunner.RunCommand("ssh -- systemctl show docker --property=ExecStart", true)
+	fmt.Println(dockerdExecStart)
 	for _, opt := range []string{"--debug", "--icc=true"} {
-		if !strings.Contains(profileContents, opt) {
-			t.Fatalf("Option %s missing from file: %s.", opt, profileContents)
+		if !strings.Contains(dockerdExecStart, opt) {
+			t.Fatalf("Option %s missing from ExecStart: %s.", opt, dockerdExecStart)
 		}
 	}
 }

--- a/test/integration/docker_test.go
+++ b/test/integration/docker_test.go
@@ -38,7 +38,7 @@ func TestDocker(t *testing.T) {
 	minikubeRunner.RunCommand(startCmd, true)
 	minikubeRunner.EnsureRunning()
 
-	dockerdEnvironment := minikubeRunner.RunCommand("ssh -- systemctl show docker --property=Environment", true)
+	dockerdEnvironment := minikubeRunner.RunCommand("ssh -- systemctl show docker --property=Environment --no-pager", true)
 	fmt.Println(dockerdEnvironment)
 	for _, envVar := range []string{"FOO=BAR", "BAZ=BAT"} {
 		if !strings.Contains(dockerdEnvironment, envVar) {
@@ -46,7 +46,7 @@ func TestDocker(t *testing.T) {
 		}
 	}
 
-	dockerdExecStart := minikubeRunner.RunCommand("ssh -- systemctl show docker --property=ExecStart", true)
+	dockerdExecStart := minikubeRunner.RunCommand("ssh -- systemctl show docker --property=ExecStart --no-pager", true)
 	fmt.Println(dockerdExecStart)
 	for _, opt := range []string{"--debug", "--icc=true"} {
 		if !strings.Contains(dockerdExecStart, opt) {

--- a/vendor/github.com/docker/machine/drivers/hyperv/hyperv.go
+++ b/vendor/github.com/docker/machine/drivers/hyperv/hyperv.go
@@ -428,7 +428,7 @@ func (d *Driver) generateDiskImage() (string, error) {
 	diskImage := d.ResolveStorePath("disk.vhd")
 	fixed := d.ResolveStorePath("fixed.vhd")
 
-	// Resizing vhds requires administrator priviledges
+	// Resizing vhds requires administrator privileges
 	// incase the user is only a hyper-v admin then create the disk at the target size to avoid resizing.
 	isWindowsAdmin, err := isWindowsAdministrator()
 	if err != nil {

--- a/vendor/github.com/docker/machine/drivers/virtualbox/network.go
+++ b/vendor/github.com/docker/machine/drivers/virtualbox/network.go
@@ -140,13 +140,13 @@ func listHostOnlyAdapters(vbox VBoxManager) (map[string]*hostOnlyNetwork, error)
 			n.NetworkName = val
 
 			if _, present := byName[n.NetworkName]; present {
-				return fmt.Errorf("VirtualBox is configured with multiple host-only adapters with the same name %q. Please remove one.", n.NetworkName)
+				return fmt.Errorf("VirtualBox is configured with multiple host-only adapters with the same name %q. Please remove one", n.NetworkName)
 			}
 			byName[n.NetworkName] = n
 
 			if len(n.IPv4.IP) != 0 {
 				if _, present := byIP[n.IPv4.IP.String()]; present {
-					return fmt.Errorf("VirtualBox is configured with multiple host-only adapters with the same IP %q. Please remove one.", n.IPv4.IP)
+					return fmt.Errorf("VirtualBox is configured with multiple host-only adapters with the same IP %q. Please remove one", n.IPv4.IP)
 				}
 				byIP[n.IPv4.IP.String()] = n
 			}

--- a/vendor/github.com/docker/machine/drivers/virtualbox/virtualbox_freebsd.go
+++ b/vendor/github.com/docker/machine/drivers/virtualbox/virtualbox_freebsd.go
@@ -1,0 +1,45 @@
+package virtualbox
+
+import (
+	"bytes"
+	"io/ioutil"
+
+	"github.com/docker/machine/libmachine/log"
+)
+
+// IsVTXDisabled checks if VT-X is disabled in the BIOS. If it is, the vm will fail to start.
+// If we can't be sure it is disabled, we carry on and will check the vm logs after it's started.
+// We want to check that either vmx or svm flags are present in /proc/cpuinfo.
+func (d *Driver) IsVTXDisabled() bool {
+	cpuinfo, err := ioutil.ReadFile("/proc/cpuinfo")
+	if err != nil {
+		log.Debugf("Couldn't check that VT-X/AMD-v is enabled. Will check that the vm is properly created: %v", err)
+		return false
+	}
+	return isVTXDisabled(cpuinfo)
+}
+
+func isVTXDisabled(cpuinfo []byte) bool {
+	features := [2][]byte{
+		{'v', 'm', 'x'},
+		{'s', 'v', 'm'},
+	}
+	for _, v := range features {
+		if bytes.Contains(cpuinfo, v) {
+			return false
+		}
+	}
+	return true
+}
+
+func detectVBoxManageCmd() string {
+	return detectVBoxManageCmdInPath()
+}
+
+func getShareDriveAndName() (string, string) {
+	return "hosthome", "/home"
+}
+
+func isHyperVInstalled() bool {
+	return false
+}

--- a/vendor/github.com/docker/machine/drivers/vmwarefusion/fusion_darwin.go
+++ b/vendor/github.com/docker/machine/drivers/vmwarefusion/fusion_darwin.go
@@ -319,7 +319,7 @@ func (d *Driver) Create() error {
 	d.IPAddress = ip
 
 	// Do not execute the rest of boot2docker specific configuration
-	// The uplaod of the public ssh key uses a ssh connection,
+	// The upload of the public ssh key uses a ssh connection,
 	// this works without installed vmware client tools
 	if d.ConfigDriveURL != "" {
 		var keyfh *os.File
@@ -564,7 +564,7 @@ func (d *Driver) getIPfromVmnetConfigurationFile(conffile, macaddr string) (stri
 			continue
 		}
 
-		// we are only in intressted in endings if we in a block. Otherwise we will count
+		// we are only in interested in endings if we in a block. Otherwise we will count
 		// ending of non host blocks as well
 		if matches := hostend.FindStringSubmatch(line); blockdepth > 0 && matches != nil {
 			blockdepth = blockdepth - 1

--- a/vendor/github.com/docker/machine/libmachine/cert/bootstrap.go
+++ b/vendor/github.com/docker/machine/libmachine/cert/bootstrap.go
@@ -40,7 +40,7 @@ func BootstrapCertificates(authOptions *auth.Options) error {
 
 		// check if the key path exists; if so, error
 		if _, err := os.Stat(caPrivateKeyPath); err == nil {
-			return errors.New("The CA key already exists.  Please remove it or specify a different key/cert.")
+			return errors.New("certificate authority key already exists")
 		}
 
 		if err := GenerateCACertificate(caCertPath, caPrivateKeyPath, caOrg, bits); err != nil {
@@ -54,7 +54,7 @@ func BootstrapCertificates(authOptions *auth.Options) error {
 		if _, err := os.Stat(certDir); err != nil {
 			if os.IsNotExist(err) {
 				if err := os.Mkdir(certDir, 0700); err != nil {
-					return fmt.Errorf("Creating machine client cert dir failed: %s", err)
+					return fmt.Errorf("failure creating machine client cert dir: %s", err)
 				}
 			} else {
 				return err
@@ -63,7 +63,7 @@ func BootstrapCertificates(authOptions *auth.Options) error {
 
 		// check if the key path exists; if so, error
 		if _, err := os.Stat(clientKeyPath); err == nil {
-			return errors.New("The client key already exists.  Please remove it or specify a different key/cert.")
+			return errors.New("client key already exists")
 		}
 
 		// Used to generate the client certificate.
@@ -79,7 +79,7 @@ func BootstrapCertificates(authOptions *auth.Options) error {
 		}
 
 		if err := GenerateCert(certOptions); err != nil {
-			return fmt.Errorf("Generating client certificate failed: %s", err)
+			return fmt.Errorf("failure generating client certificate: %s", err)
 		}
 	}
 

--- a/vendor/github.com/docker/machine/libmachine/cert/cert.go
+++ b/vendor/github.com/docker/machine/libmachine/cert/cert.go
@@ -257,7 +257,7 @@ func (xcg *X509CertGenerator) ValidateCertificate(addr string, authOptions *auth
 	}
 
 	dialer := &net.Dialer{
-		Timeout: time.Second * 2,
+		Timeout: time.Second * 20,
 	}
 
 	_, err = tls.DialWithDialer(dialer, "tcp", addr, tlsConfig)

--- a/vendor/github.com/docker/machine/libmachine/drivers/plugin/localbinary/plugin.go
+++ b/vendor/github.com/docker/machine/libmachine/drivers/plugin/localbinary/plugin.go
@@ -17,7 +17,7 @@ var (
 	// plugin server.
 	defaultTimeout               = 10 * time.Second
 	CurrentBinaryIsDockerMachine = false
-	CoreDrivers                  = [...]string{"amazonec2", "azure", "digitalocean",
+	CoreDrivers                  = []string{"amazonec2", "azure", "digitalocean",
 		"exoscale", "generic", "google", "hyperv", "none", "openstack",
 		"rackspace", "softlayer", "virtualbox", "vmwarefusion",
 		"vmwarevcloudair", "vmwarevsphere"}
@@ -85,10 +85,11 @@ type Executor struct {
 
 type ErrPluginBinaryNotFound struct {
 	driverName string
+	driverPath string
 }
 
 func (e ErrPluginBinaryNotFound) Error() string {
-	return fmt.Sprintf("Driver %q not found. Do you have the plugin binary accessible in your PATH?", e.driverName)
+	return fmt.Sprintf("Driver %q not found. Do you have the plugin binary %q accessible in your PATH?", e.driverName, e.driverPath)
 }
 
 // driverPath finds the path of a driver binary by its name.
@@ -114,7 +115,7 @@ func NewPlugin(driverName string) (*Plugin, error) {
 	driverPath := driverPath(driverName)
 	binaryPath, err := exec.LookPath(driverPath)
 	if err != nil {
-		return nil, ErrPluginBinaryNotFound{driverName}
+		return nil, ErrPluginBinaryNotFound{driverName, driverPath}
 	}
 
 	log.Debugf("Found binary path at %s", binaryPath)

--- a/vendor/github.com/docker/machine/libmachine/drivers/rpc/client_driver.go
+++ b/vendor/github.com/docker/machine/libmachine/drivers/rpc/client_driver.go
@@ -213,10 +213,11 @@ func (c *RPCClientDriver) close() error {
 	log.Debug("Making call to close driver server")
 
 	if err := c.Client.Call(CloseMethod, struct{}{}, nil); err != nil {
-		return err
+		log.Debugf("Failed to make call to close driver server: %s", err)
+	} else {
+		log.Debug("Successfully made call to close driver server")
 	}
 
-	log.Debug("Successfully made call to close driver server")
 	log.Debug("Making call to close connection to plugin binary")
 
 	return c.plugin.Close()

--- a/vendor/github.com/docker/machine/libmachine/drivers/utils.go
+++ b/vendor/github.com/docker/machine/libmachine/drivers/utils.go
@@ -44,11 +44,10 @@ func RunSSHCommandFromDriver(d Driver, command string) (string, error) {
 	output, err := client.Output(command)
 	log.Debugf("SSH cmd err, output: %v: %s", err, output)
 	if err != nil {
-		return "", fmt.Errorf(`Something went wrong running an SSH command!
+		return "", fmt.Errorf(`ssh command error:
 command : %s
 err     : %v
-output  : %s
-`, command, err, output)
+output  : %s`, command, err, output)
 	}
 
 	return output, nil

--- a/vendor/github.com/docker/machine/libmachine/host/host.go
+++ b/vendor/github.com/docker/machine/libmachine/host/host.go
@@ -1,13 +1,13 @@
 package host
 
 import (
-	"errors"
 	"regexp"
 
 	"github.com/docker/machine/libmachine/auth"
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/engine"
 	"github.com/docker/machine/libmachine/log"
+	"github.com/docker/machine/libmachine/mcndockerclient"
 	"github.com/docker/machine/libmachine/mcnerror"
 	"github.com/docker/machine/libmachine/mcnutils"
 	"github.com/docker/machine/libmachine/provision"
@@ -16,12 +16,12 @@ import (
 	"github.com/docker/machine/libmachine/ssh"
 	"github.com/docker/machine/libmachine/state"
 	"github.com/docker/machine/libmachine/swarm"
+	"github.com/docker/machine/libmachine/versioncmp"
 )
 
 var (
-	validHostNamePattern                               = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9\-\.]*$`)
-	errMachineMustBeRunningForUpgrade                  = errors.New("Error: machine must be running to upgrade.")
-	stdSSHClientCreator               SSHClientCreator = &StandardSSHClientCreator{}
+	validHostNamePattern                  = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9\-\.]*$`)
+	stdSSHClientCreator  SSHClientCreator = &StandardSSHClientCreator{}
 )
 
 type SSHClientCreator interface {
@@ -164,6 +164,24 @@ func (h *Host) Restart() error {
 	return h.WaitForDocker()
 }
 
+func (h *Host) DockerVersion() (string, error) {
+	url, err := h.Driver.GetURL()
+	if err != nil {
+		return "", err
+	}
+
+	dockerHost := &mcndockerclient.RemoteDocker{
+		HostURL:    url,
+		AuthOption: h.AuthOptions(),
+	}
+	dockerVersion, err := mcndockerclient.DockerVersion(dockerHost)
+	if err != nil {
+		return "", err
+	}
+
+	return dockerVersion, nil
+}
+
 func (h *Host) Upgrade() error {
 	machineState, err := h.Driver.GetState()
 	if err != nil {
@@ -171,12 +189,48 @@ func (h *Host) Upgrade() error {
 	}
 
 	if machineState != state.Running {
-		return errMachineMustBeRunningForUpgrade
+		log.Info("Starting machine so machine can be upgraded...")
+		if err := h.Start(); err != nil {
+			return err
+		}
 	}
 
 	provisioner, err := provision.DetectProvisioner(h.Driver)
 	if err != nil {
 		return err
+	}
+
+	dockerVersion, err := h.DockerVersion()
+	if err != nil {
+		return err
+	}
+
+	// If we're upgrading from a pre-CE (e.g., 1.13.1) release to a CE
+	// release (e.g., 17.03.0-ce), we should simply uninstall and
+	// re-install from scratch, since the official package names will
+	// change from 'docker-engine' to 'docker-ce'.
+	if versioncmp.LessThanOrEqualTo(dockerVersion, provision.LastReleaseBeforeCEVersioning) &&
+		// RancherOS and boot2docker, being 'static ISO builds', have
+		// an upgrade process which simply grabs the latest if it's
+		// different, and so do not need to jump through this hoop to
+		// upgrade safely.
+		provisioner.String() != "rancheros" &&
+		provisioner.String() != "boot2docker" {
+
+		// Name of pacakge 'docker-engine' will fall through in this
+		// case, so that we execute, e.g.,
+		//
+		// 'sudo apt-get purge -y docker-engine'
+		if err := provisioner.Package("docker-engine", pkgaction.Purge); err != nil {
+			return err
+		}
+
+		// Then we kick off the normal provisioning process which will
+		// go off and install Docker (get.docker.com script should work
+		// fine to install Docker from scratch after removing the old
+		// packages, and images/containers etc. should be preserved in
+		// /var/lib/docker)
+		return h.Provision()
 	}
 
 	log.Info("Upgrading docker...")

--- a/vendor/github.com/docker/machine/libmachine/host/migrate.go
+++ b/vendor/github.com/docker/machine/libmachine/host/migrate.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	errConfigFromFuture = errors.New("Config version is from the future, please upgrade your Docker Machine client.")
+	errConfigFromFuture = errors.New("config version is from the future -- you should upgrade your Docker Machine client")
 )
 
 type RawDataDriver struct {

--- a/vendor/github.com/docker/machine/libmachine/mcnutils/b2d.go
+++ b/vendor/github.com/docker/machine/libmachine/mcnutils/b2d.go
@@ -33,8 +33,7 @@ var (
 )
 
 var (
-	errGitHubAPIResponse = errors.New(`Error getting a version tag from the Github API response.
-You may be getting rate limited by Github.`)
+	errGitHubAPIResponse = errors.New(`failure getting a version tag from the Github API response (are you getting rate limited by Github?)`)
 )
 
 var (

--- a/vendor/github.com/docker/machine/libmachine/provision/arch.go
+++ b/vendor/github.com/docker/machine/libmachine/provision/arch.go
@@ -43,16 +43,16 @@ func (provisioner *ArchProvisioner) Package(name string, action pkgaction.Packag
 	updateMetadata := true
 
 	switch action {
-	case pkgaction.Install:
+	case pkgaction.Install, pkgaction.Upgrade:
 		packageAction = "S"
 	case pkgaction.Remove:
 		packageAction = "R"
 		updateMetadata = false
-	case pkgaction.Upgrade:
-		packageAction = "U"
 	}
 
 	switch name {
+	case "docker-engine":
+		name = "docker"
 	case "docker":
 		name = "docker"
 	}

--- a/vendor/github.com/docker/machine/libmachine/provision/coreos.go
+++ b/vendor/github.com/docker/machine/libmachine/provision/coreos.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/machine/libmachine/log"
 	"github.com/docker/machine/libmachine/provision/pkgaction"
 	"github.com/docker/machine/libmachine/swarm"
+	"github.com/docker/machine/libmachine/versioncmp"
 )
 
 const (
@@ -64,22 +65,21 @@ func (provisioner *CoreOSProvisioner) GenerateDockerOptions(dockerPort int) (*Do
 	driverNameLabel := fmt.Sprintf("provider=%s", provisioner.Driver.DriverName())
 	provisioner.EngineOptions.Labels = append(provisioner.EngineOptions.Labels, driverNameLabel)
 
-	engineConfigTmpl := `[Unit]
-Description=Docker Socket for the API
-After=docker.socket early-docker.target network.target
-Requires=docker.socket early-docker.target
+	dockerVersion, err := DockerClientVersion(provisioner)
+	if err != nil {
+		return nil, err
+	}
 
-[Service]
+	arg := "daemon"
+	if versioncmp.GreaterThanOrEqualTo(dockerVersion, "1.12.0") {
+		arg = ""
+	}
+
+	engineConfigTmpl := `[Service]
 Environment=TMPDIR=/var/tmp
-EnvironmentFile=-/run/flannel_docker_opts.env
-MountFlags=slave
-LimitNOFILE=1048576
-LimitNPROC=1048576
-ExecStart=/usr/lib/coreos/dockerd daemon --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:{{.DockerPort}} --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}}{{ range .EngineOptions.Labels }} --label {{.}}{{ end }}{{ range .EngineOptions.InsecureRegistry }} --insecure-registry {{.}}{{ end }}{{ range .EngineOptions.RegistryMirror }} --registry-mirror {{.}}{{ end }}{{ range .EngineOptions.ArbitraryFlags }} --{{.}}{{ end }} \$DOCKER_OPTS \$DOCKER_OPT_BIP \$DOCKER_OPT_MTU \$DOCKER_OPT_IPMASQ
+ExecStart=
+ExecStart=/usr/lib/coreos/dockerd ` + arg + ` --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:{{.DockerPort}} --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}}{{ range .EngineOptions.Labels }} --label {{.}}{{ end }}{{ range .EngineOptions.InsecureRegistry }} --insecure-registry {{.}}{{ end }}{{ range .EngineOptions.RegistryMirror }} --registry-mirror {{.}}{{ end }}{{ range .EngineOptions.ArbitraryFlags }} --{{.}}{{ end }} \$DOCKER_OPTS \$DOCKER_OPT_BIP \$DOCKER_OPT_MTU \$DOCKER_OPT_IPMASQ
 Environment={{range .EngineOptions.Env}}{{ printf "%q" . }} {{end}}
-
-[Install]
-WantedBy=multi-user.target
 `
 
 	t, err := template.New("engineConfig").Parse(engineConfigTmpl)

--- a/vendor/github.com/docker/machine/libmachine/provision/debian.go
+++ b/vendor/github.com/docker/machine/libmachine/provision/debian.go
@@ -44,6 +44,9 @@ func (provisioner *DebianProvisioner) Package(name string, action pkgaction.Pack
 	case pkgaction.Remove:
 		packageAction = "remove"
 		updateMetadata = false
+	case pkgaction.Purge:
+		packageAction = "purge"
+		updateMetadata = false
 	}
 
 	switch name {
@@ -52,7 +55,7 @@ func (provisioner *DebianProvisioner) Package(name string, action pkgaction.Pack
 	}
 
 	if updateMetadata {
-		if _, err := provisioner.SSHCommand("sudo apt-get update"); err != nil {
+		if err := waitForLockAptGetUpdate(provisioner); err != nil {
 			return err
 		}
 	}

--- a/vendor/github.com/docker/machine/libmachine/provision/pkgaction/pkg_action.go
+++ b/vendor/github.com/docker/machine/libmachine/provision/pkgaction/pkg_action.go
@@ -6,12 +6,14 @@ const (
 	Install PackageAction = iota
 	Remove
 	Upgrade
+	Purge
 )
 
 var packageActions = []string{
 	"install",
 	"remove",
 	"upgrade",
+	"purge",
 }
 
 func (s PackageAction) String() string {

--- a/vendor/github.com/docker/machine/libmachine/provision/provisioner.go
+++ b/vendor/github.com/docker/machine/libmachine/provision/provisioner.go
@@ -17,6 +17,10 @@ var (
 	detector     Detector = &StandardDetector{}
 )
 
+const (
+	LastReleaseBeforeCEVersioning = "1.13.1"
+)
+
 type SSHCommander interface {
 	// Short-hand for accessing an SSH command from the driver.
 	SSHCommand(args string) (string, error)

--- a/vendor/github.com/docker/machine/libmachine/provision/redhat_ssh_commander.go
+++ b/vendor/github.com/docker/machine/libmachine/provision/redhat_ssh_commander.go
@@ -35,11 +35,10 @@ func (sshCmder RedHatSSHCommander) SSHCommand(args string) (string, error) {
 
 	log.Debugf("SSH cmd err, output: %v: %s", err, output)
 	if err != nil {
-		return "", fmt.Errorf(`Something went wrong running an SSH command!
+		return "", fmt.Errorf(`something went wrong running an SSH command
 command : %s
 err     : %v
-output  : %s
-`, args, err, output)
+output  : %s`, args, err, output)
 	}
 
 	return output, nil

--- a/vendor/github.com/docker/machine/libmachine/provision/ubuntu_systemd.go
+++ b/vendor/github.com/docker/machine/libmachine/provision/ubuntu_systemd.go
@@ -60,15 +60,18 @@ func (provisioner *UbuntuSystemdProvisioner) Package(name string, action pkgacti
 	case pkgaction.Remove:
 		packageAction = "remove"
 		updateMetadata = false
+	case pkgaction.Purge:
+		packageAction = "purge"
+		updateMetadata = false
 	}
 
 	switch name {
 	case "docker":
-		name = "docker-engine"
+		name = "docker-ce"
 	}
 
 	if updateMetadata {
-		if _, err := provisioner.SSHCommand("sudo apt-get update"); err != nil {
+		if err := waitForLockAptGetUpdate(provisioner); err != nil {
 			return err
 		}
 	}

--- a/vendor/github.com/docker/machine/libmachine/provision/ubuntu_upstart.go
+++ b/vendor/github.com/docker/machine/libmachine/provision/ubuntu_upstart.go
@@ -87,7 +87,7 @@ func (provisioner *UbuntuProvisioner) Package(name string, action pkgaction.Pack
 	}
 
 	if updateMetadata {
-		if _, err := provisioner.SSHCommand("sudo apt-get update"); err != nil {
+		if err := waitForLockAptGetUpdate(provisioner); err != nil {
 			return err
 		}
 	}

--- a/vendor/github.com/docker/machine/libmachine/provision/utils.go
+++ b/vendor/github.com/docker/machine/libmachine/provision/utils.go
@@ -28,7 +28,7 @@ func installDockerGeneric(p Provisioner, baseURL string) error {
 	// install docker - until cloudinit we use ubuntu everywhere so we
 	// just install it using the docker repos
 	if output, err := p.SSHCommand(fmt.Sprintf("if ! type docker; then curl -sSL %s | sh -; fi", baseURL)); err != nil {
-		return fmt.Errorf("error installing docker: %s\n", output)
+		return fmt.Errorf("error installing docker: %s", output)
 	}
 
 	return nil
@@ -181,7 +181,7 @@ func ConfigureAuth(p Provisioner) error {
 
 	log.Info("Setting Docker configuration on the remote daemon...")
 
-	if _, err = p.SSHCommand(fmt.Sprintf("printf %%s \"%s\" | sudo tee %s", dkrcfg.EngineOptions, dkrcfg.EngineOptionsPath)); err != nil {
+	if _, err = p.SSHCommand(fmt.Sprintf("sudo mkdir -p %s && printf %%s \"%s\" | sudo tee %s", path.Dir(dkrcfg.EngineOptionsPath), dkrcfg.EngineOptions, dkrcfg.EngineOptionsPath)); err != nil {
 		return err
 	}
 
@@ -270,5 +270,49 @@ func WaitForDocker(p Provisioner, dockerPort int) error {
 		return NewErrDaemonAvailable(err)
 	}
 
+	return nil
+}
+
+// DockerClientVersion returns the version of the Docker client on the host
+// that ssh is connected to, e.g. "1.12.1".
+func DockerClientVersion(ssh SSHCommander) (string, error) {
+	// `docker version --format {{.Client.Version}}` would be preferable, but
+	// that fails if the server isn't running yet.
+	//
+	// output is expected to be something like
+	//
+	//     Docker version 1.12.1, build 7a86f89
+	output, err := ssh.SSHCommand("docker --version")
+	if err != nil {
+		return "", err
+	}
+
+	words := strings.Fields(output)
+	if len(words) < 3 || words[0] != "Docker" || words[1] != "version" {
+		return "", fmt.Errorf("DockerClientVersion: cannot parse version string from %q", output)
+	}
+
+	return strings.TrimRight(words[2], ","), nil
+}
+
+func waitForLockAptGetUpdate(ssh SSHCommander) error {
+	var sshErr error
+	err := mcnutils.WaitFor(func() bool {
+		_, sshErr = ssh.SSHCommand("sudo apt-get update")
+		if sshErr != nil {
+			if strings.Contains(sshErr.Error(), "Could not get lock") {
+				sshErr = nil
+				return false
+			}
+			return true
+		}
+		return true
+	})
+	if sshErr != nil {
+		return fmt.Errorf("Error running apt-get update: %s", sshErr)
+	}
+	if err != nil {
+		return fmt.Errorf("Failed to obtain apt-get update lock: %s", err)
+	}
 	return nil
 }

--- a/vendor/github.com/docker/machine/libmachine/ssh/keys.go
+++ b/vendor/github.com/docker/machine/libmachine/ssh/keys.go
@@ -82,7 +82,7 @@ func (kp *KeyPair) WriteToFile(privateKeyPath string, publicKeyPath string) erro
 
 		// windows does not support chmod
 		switch runtime.GOOS {
-		case "darwin", "linux":
+		case "darwin", "linux", "freebsd":
 			if err := f.Chmod(0600); err != nil {
 				return err
 			}

--- a/vendor/github.com/docker/machine/libmachine/versioncmp/compare.go
+++ b/vendor/github.com/docker/machine/libmachine/versioncmp/compare.go
@@ -1,0 +1,121 @@
+// Package versioncmp provides functions for comparing version strings.
+//
+// Version strings are dot-separated integers with an optional
+// pre-release suffix. A pre-release suffix is an arbitrary string with a
+// leading dash character. All functions ignore these suffixes, so "1.2" and
+// "1.2-rc" are considered equivalent.
+package versioncmp
+
+import (
+	"strconv"
+	"strings"
+)
+
+const (
+	rcString  = "-rc"
+	ceEdition = "-ce"
+)
+
+// compare compares two versions of Docker to decipher which came first.
+//
+// compare returns -1 if v1 < v2, 1 if v1 > v2, 0 otherwise.
+func compare(v1, v2 string) int {
+	// Replace RC string with "." to make the RC number appear as simply
+	// another sub-version.
+	v1 = strings.Replace(v1, rcString, ".", -1)
+	v2 = strings.Replace(v2, rcString, ".", -1)
+
+	// All releases before the community edition (differentiated by
+	// presence of the "ce" string in the version string) are "less than"
+	// any community edition release (first occuring in March 2017).
+	if strings.Contains(v1, ceEdition) && !strings.Contains(v2, ceEdition) {
+		return -1
+	}
+	if !strings.Contains(v1, ceEdition) && strings.Contains(v2, ceEdition) {
+		return 1
+	}
+
+	// Without this tag, both are pre-CE versions.
+	if !strings.Contains(v1, ceEdition) && !strings.Contains(v2, ceEdition) {
+		return compareNumeric(v1, v2)
+	}
+
+	return compareCE(v1, v2)
+}
+
+// compareCE ("Community Edition") will differentiate between versions of
+// Docker that use the versioning scheme
+// {{release-year}}.{{release-month}}-{{ce|ee}}-{{rcnum|""}}
+//
+// This will be every release after 1.13.1.
+func compareCE(v1, v2 string) int {
+	return compareNumeric(
+		strings.Replace(v1, ceEdition, "", -1),
+		strings.Replace(v2, ceEdition, "", -1),
+	)
+}
+
+// compareNumeric compares two version that use pre-17.03 Docker.
+//
+// Non-numeric segments in either argument are considered equal, so
+// compare("1.a", "1.b") == 0, but compare("2.a", "1.b") == 1.
+func compareNumeric(v1, v2 string) int {
+	if n := strings.IndexByte(v1, '-'); n != -1 {
+		v1 = v1[:n]
+	}
+	if n := strings.IndexByte(v2, '-'); n != -1 {
+		v2 = v2[:n]
+	}
+	var (
+		currTab  = strings.Split(v1, ".")
+		otherTab = strings.Split(v2, ".")
+	)
+
+	max := len(currTab)
+	if len(otherTab) > max {
+		max = len(otherTab)
+	}
+	for i := 0; i < max; i++ {
+		var currInt, otherInt int
+
+		if len(currTab) > i {
+			currInt, _ = strconv.Atoi(currTab[i])
+		}
+		if len(otherTab) > i {
+			otherInt, _ = strconv.Atoi(otherTab[i])
+		}
+		if currInt > otherInt {
+			return 1
+		}
+		if otherInt > currInt {
+			return -1
+		}
+	}
+	return 0
+}
+
+// LessThan checks if a version is less than another.
+func LessThan(v, other string) bool {
+	return compare(v, other) == -1
+}
+
+// LessThanOrEqualTo checks if a version is less than or equal to another.
+func LessThanOrEqualTo(v, other string) bool {
+	return compare(v, other) <= 0
+}
+
+// GreaterThan checks if a version is greater than another.
+func GreaterThan(v, other string) bool {
+	return compare(v, other) == 1
+}
+
+// GreaterThanOrEqualTo checks if a version is greater than or equal to
+// another.
+func GreaterThanOrEqualTo(v, other string) bool {
+	return compare(v, other) >= 0
+}
+
+// Equal checks if a version is equal to another.
+func Equal(v, other string) bool {
+	return compare(v, other) == 0
+}

--- a/vendor/github.com/docker/machine/version/version.go
+++ b/vendor/github.com/docker/machine/version/version.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	// Version should be updated by hand at each release
-	Version = "0.8.2"
+	Version = "0.10.0"
 
 	// GitCommit will be overwritten automatically by the build system
 	GitCommit = "HEAD"


### PR DESCRIPTION
This change updates the docker/machine Godeps to the latest version, which includes a fix for #1328. 

Due to changes with the updated docker/machine in how it creates the systemd config for dockerd, a couple of minor changes were required in the [provisioning code](https://github.com/kubernetes/minikube/commit/f2b2dad63603203f6180b54b95b637de76015208) and corresponding [integration test](https://github.com/kubernetes/minikube/commit/2d307d0799b0a02079501f1aa831f791e02cf7be).