### PR TITLE
Update gendocs, disable ufs flag

### DIFF
--- a/docs/bash-completion
+++ b/docs/bash-completion
@@ -237,6 +237,33 @@ __handle_word()
     __handle_word
 }
 
+_minikube_addons_configure()
+{
+    last_command="minikube_addons_configure"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--alsologtostderr")
+    flags+=("--log_backtrace_at=")
+    flags+=("--log_dir=")
+    flags+=("--logtostderr")
+    flags+=("--show-libmachine-logs")
+    flags+=("--stderrthreshold=")
+    flags+=("--use-vendored-driver")
+    flags+=("--v=")
+    two_word_flags+=("-v")
+    flags+=("--vmodule=")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _minikube_addons_disable()
 {
     last_command="minikube_addons_disable"
@@ -354,6 +381,7 @@ _minikube_addons()
 {
     last_command="minikube_addons"
     commands=()
+    commands+=("configure")
     commands+=("disable")
     commands+=("enable")
     commands+=("list")
@@ -865,6 +893,8 @@ _minikube_start()
     local_nonpersistent_flags+=("--cpus=")
     flags+=("--disk-size=")
     local_nonpersistent_flags+=("--disk-size=")
+    flags+=("--dns-domain=")
+    local_nonpersistent_flags+=("--dns-domain=")
     flags+=("--docker-env=")
     local_nonpersistent_flags+=("--docker-env=")
     flags+=("--docker-opt=")

--- a/docs/minikube_addons.md
+++ b/docs/minikube_addons.md
@@ -35,6 +35,7 @@ For the list of accessible variables for the template, see the struct values her
 
 ### SEE ALSO
 * [minikube](minikube.md)	 - Minikube is a tool for managing local Kubernetes clusters.
+* [minikube addons configure](minikube_addons_configure.md)	 - Configures the addon w/ADDON_NAME within minikube (example: minikube addons configure registry-creds). For a list of available addons use: minikube addons list 
 * [minikube addons disable](minikube_addons_disable.md)	 - Disables the addon w/ADDON_NAME within minikube (example: minikube addons disable dashboard). For a list of available addons use: minikube addons list 
 * [minikube addons enable](minikube_addons_enable.md)	 - Enables the addon w/ADDON_NAME within minikube (example: minikube addons enable dashboard). For a list of available addons use: minikube addons list 
 * [minikube addons list](minikube_addons_list.md)	 - Lists all available minikube addons as well as there current status (enabled/disabled)

--- a/docs/minikube_addons_configure.md
+++ b/docs/minikube_addons_configure.md
@@ -1,0 +1,30 @@
+## minikube addons configure
+
+Configures the addon w/ADDON_NAME within minikube (example: minikube addons configure registry-creds). For a list of available addons use: minikube addons list 
+
+### Synopsis
+
+
+Configures the addon w/ADDON_NAME within minikube (example: minikube addons configure registry-creds). For a list of available addons use: minikube addons list 
+
+```
+minikube addons configure ADDON_NAME
+```
+
+### Options inherited from parent commands
+
+```
+      --alsologtostderr                  log to standard error as well as files
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory (default "")
+      --logtostderr                      log to standard error instead of files
+      --show-libmachine-logs             Deprecated: To enable libmachine logs, set --v=3 or higher
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+      --use-vendored-driver              Use the vendored in drivers instead of RPC
+  -v, --v Level                          log level for V logs
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+```
+
+### SEE ALSO
+* [minikube addons](minikube_addons.md)	 - Modify minikube's kubernetes addons
+

--- a/docs/minikube_config.md
+++ b/docs/minikube_config.md
@@ -28,6 +28,7 @@ Configurable fields:
  * heapster
  * ingress
  * registry-creds
+ * default-storageclass
  * hyperv-virtual-switch
  * use-vendored-driver
 

--- a/docs/minikube_start.md
+++ b/docs/minikube_start.md
@@ -19,6 +19,7 @@ minikube start
       --container-runtime string        The container runtime to be used
       --cpus int                        Number of CPUs allocated to the minikube VM (default 2)
       --disk-size string                Disk size allocated to the minikube VM (format: <number>[<unit>], where unit = b, k, m or g) (default "20g")
+      --dns-domain string               The cluster dns domain name used in the kubernetes cluster
       --docker-env stringArray          Environment variables to pass to the Docker daemon. (format: key=value)
       --docker-opt stringArray          Specify arbitrary flags to pass to the Docker daemon. (format: key=value)
       --extra-config ExtraOption        A set of key=value pairs that describe configuration that may be passed to different components.

--- a/third_party/go9p/ufs.go
+++ b/third_party/go9p/ufs.go
@@ -5,7 +5,6 @@
 package go9p
 
 import (
-	"flag"
 	"io"
 	"log"
 	"os"
@@ -478,4 +477,11 @@ func lookup(uid string, group bool) (uint32, *Error) {
 /* enables "Akaros" capabilities, which right now means
  * a sane error message format.
  */
-var Akaros = flag.Bool("akaros", false, "Akaros extensions")
+
+// (r2d4): We don't want this exposed in minikube right now
+// var Akaros = flag.Bool("akaros", false, "Akaros extensions")
+var Akaros = boolPointer(false)
+
+func boolPointer(b bool) *bool {
+	return &b
+}


### PR DESCRIPTION
Removing a debugging flag from the 9p library, since it registers
itself globally in minikube.  Also running `make gendocs` to catch some
older changes.

