### PR TITLE
Remove .gitattributes, update gendocs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-* text eol=lf

--- a/docs/minikube_start.md
+++ b/docs/minikube_start.md
@@ -29,7 +29,7 @@ minikube start
       --host-only-cidr string           The CIDR to be used for the minikube VM (only supported with Virtualbox driver) (default "192.168.99.1/24")
       --hyperv-virtual-switch string    The hyperv virtual switch name. Defaults to first found. (only supported with HyperV driver)
       --insecure-registry stringSlice   Insecure Docker registries to pass to the Docker daemon
-      --iso-url string                  Location of the minikube iso (default "https://storage.googleapis.com/minikube/iso/minikube-v1.0.7.iso")
+      --iso-url string                  Location of the minikube iso (default "https://storage.googleapis.com/minikube/iso/minikube-v0.18.0.iso")
       --keep-context                    This will keep the existing kubectl context and will create a minikube context.
       --kubernetes-version string       The kubernetes version that the minikube VM will use (ex: v1.2.3) 
  OR a URI which contains a localkube binary (ex: https://storage.googleapis.com/minikube/k8sReleases/v1.3.0/localkube-linux-amd64) (default "v1.6.0")


### PR DESCRIPTION
Remove gitattributes forcing linux line endings everywhere.  This was putting us in a dirty state, so the gendocs check wasn't actually going through.  This PR also updates gendocs.

ref #1342 