### PR TITLE
Use normal kubectl for integration tests

### DIFF
--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -33,7 +33,7 @@ import (
 	commonutil "k8s.io/minikube/pkg/util"
 )
 
-const kubectlBinary = "kubectl-v1.6.0-alpha.1"
+const kubectlBinary = "kubectl"
 
 type MinikubeRunner struct {
 	T          *testing.T


### PR DESCRIPTION
We were using an alpha v1.6 kubectl to run 1.5 and 1.6 branches of
minikube at the same time.  Since we've merged in 1.6, we will always
use 1.6 kubectl.  I've updated the slaves to have it.