### PR TITLE
Updated example how to enable RBAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ To change the `MaxPods` setting to 5 on the Kubelet, pass this flag: `--extra-co
 
 This feature also supports nested structs. To change the `LeaderElection.LeaderElect` setting to `true` on the scheduler, pass this flag: `--extra-config=scheduler.LeaderElection.LeaderElect=true`.
 
-To set the `AuthorizationMode` on the `apiserver` to `RBAC`, you can use: `--extra-config=apiserver.GenericServerRunOptions.AuthorizationMode=RBAC`.
+To set the `AuthorizationMode` on the `apiserver` to `RBAC`, you can use: `--extra-config=apiserver.Authorization.Mode=RBAC`.
 
 To enable all alpha feature gates, you can use: `--feature-gates=AllAlpha=true`
 


### PR DESCRIPTION
Tested with k8s v1.6.0 and minikube v0.18.0

The extra-config should be `--extra-config=apiserver.Authorization.Mode=RBAC`