### PR TITLE
Add warning when no groupMeta exists for verison

### DIFF
--- a/hack/godeps/godep-save.sh
+++ b/hack/godeps/godep-save.sh
@@ -31,3 +31,5 @@ godep save ./...
 
 godep::remove_staging_from_json
 git checkout -- ${MINIKUBE_ROOT}/vendor/golang.org/x/sys/windows
+
+git apply ${MINIKUBE_ROOT}/hack/tpr-patch.diff

--- a/hack/tpr-patch.diff
+++ b/hack/tpr-patch.diff
@@ -1,0 +1,17 @@
+diff --git a/vendor/k8s.io/apimachinery/pkg/apimachinery/registered/registered.go b/vendor/k8s.io/apimachinery/pkg/apimachinery/registered/registered.go
+index f2e32c88c..f1c96c43d 100644
+--- a/vendor/k8s.io/apimachinery/pkg/apimachinery/registered/registered.go
++++ b/vendor/k8s.io/apimachinery/pkg/apimachinery/registered/registered.go
+@@ -282,7 +282,11 @@ func (m *APIRegistrationManager) RESTMapper(versionPatterns ...schema.GroupVersi
+ 	for enabledVersion := range m.enabledVersions {
+ 		if !unionedGroups.Has(enabledVersion.Group) {
+ 			unionedGroups.Insert(enabledVersion.Group)
+-			groupMeta := m.groupMetaMap[enabledVersion.Group]
++			groupMeta, found := m.groupMetaMap[enabledVersion.Group]
++			// TODO(r2d4): hack until tprs are decoupled from restMapper
++			if !found {
++				glog.Warningf("Could not find groupMeta for %s", enabledVersion.Group)
++			}
+ 			unionMapper = append(unionMapper, groupMeta.RESTMapper)
+ 		}
+ 	}

--- a/vendor/k8s.io/apimachinery/pkg/apimachinery/registered/registered.go
+++ b/vendor/k8s.io/apimachinery/pkg/apimachinery/registered/registered.go
@@ -282,7 +282,11 @@ func (m *APIRegistrationManager) RESTMapper(versionPatterns ...schema.GroupVersi
 	for enabledVersion := range m.enabledVersions {
 		if !unionedGroups.Has(enabledVersion.Group) {
 			unionedGroups.Insert(enabledVersion.Group)
-			groupMeta := m.groupMetaMap[enabledVersion.Group]
+			groupMeta, found := m.groupMetaMap[enabledVersion.Group]
+			// TODO(r2d4): hack until tprs are decoupled from restMapper
+			if !found {
+				glog.Warningf("Could not find groupMeta for %s", enabledVersion.Group)
+			}
 			unionMapper = append(unionMapper, groupMeta.RESTMapper)
 		}
 	}


### PR DESCRIPTION
Reference: https://github.com/kubernetes/kubernetes/pull/44771

Fixes https://github.com/kubernetes/minikube/issues/1252

TPRs are incorrectly coupled with the RestMapper right now.  The real
solution is for TPRs to not register themselves with the RestMapper.
This is a short term patch for minikube until the work is done
upstream.  On start/stop, the namespace controller and the garbage
collector controller both call this code and panic since TPRs have
registered themselves with enabled versions but have no group metadata.