### PR TITLE
Add static_build tag for localkube

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ out/minikube$(IS_EXE): out/minikube-$(GOOS)-$(GOARCH)$(IS_EXE)
 
 out/localkube: $(GOPATH)/src/$(ORG) $(shell $(LOCALKUBEFILES))
 ifeq ($(BUILD_OS),Linux)
-	CGO_ENABLED=1 go build -ldflags=$(LOCALKUBE_LDFLAGS) -o $(BUILD_DIR)/localkube ./cmd/localkube
+	CGO_ENABLED=1 go build -tags static_build -ldflags=$(LOCALKUBE_LDFLAGS) -o $(BUILD_DIR)/localkube ./cmd/localkube
 else
 	docker run -w /go/src/$(REPOPATH) -e IN_DOCKER=1 -v $(shell pwd):/go/src/$(REPOPATH) $(BUILD_IMAGE) make out/localkube
 endif


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/1422

godbus requires the static_build tag when building.  Normal static
compliation doesn't add this go build tag automatically.

Looks like other binaries have manually added this tag also
https://github.com/moby/moby/blob/305601bb31b56b8a0b0380131f8ea157aa8dce55/hack/make.sh#L152

I confirmed that this does pickup the static version of homedir.go, by using `go build -x`
