### PR TITLE
Move gen_helptext out of top level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,10 +141,10 @@ clean:
 	rm -f pkg/minikube/assets/assets.go
 
 .PHONY: gendocs
-gendocs: docs/minikube.md
+gendocs: out/docs/minikube.md
 
-docs/minikube.md: $(GOPATH)/src/$(ORG) $(shell find cmd) $(shell find pkg/minikube/constants) pkg/minikube/assets/assets.go
-	cd $(GOPATH)/src/$(REPOPATH) && go run -ldflags="$(K8S_VERSION_LDFLAGS) $(MINIKUBE_LDFLAGS)" -tags gendocs gen_help_text.go
+out/docs/minikube.md: $(GOPATH)/src/$(ORG) $(shell find cmd) $(shell find pkg/minikube/constants) pkg/minikube/assets/assets.go
+	cd $(GOPATH)/src/$(REPOPATH) && go run -ldflags="$(K8S_VERSION_LDFLAGS) $(MINIKUBE_LDFLAGS)" -tags gendocs hack/gen_help_text.go
 
 out/minikube_$(DEB_VERSION).deb: out/minikube-linux-amd64
 	cp -r installers/linux/deb/minikube_deb_template out/minikube_$(DEB_VERSION)

--- a/hack/gen_help_text.go
+++ b/hack/gen_help_text.go
@@ -25,10 +25,11 @@ import (
 )
 
 func main() {
+	os.MkdirAll("./out/docs", os.FileMode(0755))
 	cmd.RootCmd.DisableAutoGenTag = true
-	doc.GenMarkdownTree(cmd.RootCmd, "./docs")
+	doc.GenMarkdownTree(cmd.RootCmd, "./out/docs")
 
-	f, err := os.Create("./docs/bash-completion")
+	f, err := os.Create("./out/docs/bash-completion")
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
Output docs to out/docs instead of ./docs since we have real
documentation in that folder now.