### PR TITLE
brew cask install minikube

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Minikube is a tool that makes it easy to run Kubernetes locally. Minikube runs a
 ## Installation
 ### macOS
 ```shell
-brew install minikube
+brew cask install minikube
 ```
 
 ### Linux


### PR DESCRIPTION
The minikube brew install is actually done with a brew-cask, which is brew, but for prebuilt binaries.
We use a 'cask' because minikube has a isn't super easy to build from source in a homebrew file.

Fixes #1449 