### PR TITLE
Add script to automate localkube upgrades

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,8 @@ PYTHON := $(shell command -v python || echo "docker run --rm -it -v $(shell pwd)
 BUILD_OS := $(shell uname -s)
 
 LOCALKUBE_VERSION := $(shell $(PYTHON) hack/get_k8s_version.py --k8s-version-only 2>&1)
-LOCALKUBE_BUCKET := gs://minikube/k8sReleases
+LOCALKUBE_BUCKET ?= minikube/k8sReleases
+LOCALKUBE_UPLOAD_LOCATION := gs://${LOCALKUBE_BUCKET}
 TAG ?= $(LOCALKUBE_VERSION)
 
 # Set the version information for the Kubernetes servers, and build localkube statically
@@ -182,8 +183,8 @@ check-release:
 
 .PHONY: release-localkube
 release-localkube: out/localkube checksum
-	gsutil cp out/localkube $(LOCALKUBE_BUCKET)/$(LOCALKUBE_VERSION)/localkube-linux-amd64
-	gsutil cp out/localkube.sha256 $(LOCALKUBE_BUCKET)/$(LOCALKUBE_VERSION)/localkube-linux-amd64.sha256
+	gsutil cp out/localkube $(LOCALKUBE_UPLOAD_LOCATION)/$(LOCALKUBE_VERSION)/localkube-linux-amd64
+	gsutil cp out/localkube.sha256 $(LOCALKUBE_UPLOAD_LOCATION)/$(LOCALKUBE_VERSION)/localkube-linux-amd64.sha256
 
 .PHONY: update-releases
 update-releases:

--- a/hack/godeps/upgrade-k8s.sh
+++ b/hack/godeps/upgrade-k8s.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script expects 
+# K8S_VERSION = the version of kubernetes to be upgraded
+# REMOTE = the name of the git remote repository
+
+KUBE_ORG_ROOT=$GOPATH/src/k8s.io
+KUBE_ROOT=${KUBE_ORG_ROOT}/kubernetes
+MINIKUBE_ROOT=${KUBE_ORG_ROOT}/minikube
+
+UPSTREAM_REMOTE=${REMOTE:-origin}
+
+echo "Restoring old dependencies..."
+${MINIKUBE_ROOT}/hack/godeps/godep-restore.sh
+
+# Upgrade kubernetes
+pushd ${KUBE_ROOT} >/dev/null
+  echo "Upgrading to version ${K8S_VERSION}..."
+  git fetch ${UPSTREAM_REMOTE}
+  git checkout ${K8S_VERSION}
+  ./hack/godep-restore.sh
+popd >/dev/null
+
+echo "Saving new minikube dependencies..."
+${MINIKUBE_ROOT}/hack/godeps/godep-save.sh
+
+LOCALKUBE_BUCKET="minikube-builds/localkube-builds/${K8S_VERSION}" make release-localkube
+


### PR DESCRIPTION
I haven't wired this into jenkins yet since I'm not actually sure how we want to run it.  

Checking for new k8s versions isn't trivial, since we don't build all releases and there are still patches being applied before and after the semver stable release (e.g. 1.5.x, 1.6.x, and 1.7.0-x) and they are sometimes released at the same time (so we can't just grab the newest one)

I figure we can trigger this script with jenkins manually for now, and figure out how we can do it more automatically going forward (or switch to kubeadm or bootkube)

example invocation used to make the 1.6.3 upgrade PR
`$ K8S_VERSION=v1.6.3 REMOTE=upstream hack/godeps/upgrade-k8s.sh` 