### PR TITLE
Consistent short description for commands

### DIFF
--- a/cmd/minikube/cmd/config/profile.go
+++ b/cmd/minikube/cmd/config/profile.go
@@ -26,8 +26,8 @@ import (
 
 var ProfileCmd = &cobra.Command{
 	Use:   "profile MINIKUBE_PROFILE_NAME.  You can return the the default minikube name by running `minikube profile default`",
-	Short: "profile sets the current minikube profile.  This is used to run and manage multiple minikube instance.  You can return the the default minikube name by running `minikube profile default`",
-	Long:  "profile sets the current minikube profile.  This is used to run and manage multiple minikube instance.  You can return the the default minikube name by running `minikube profile default`",
+	Short: "Profile sets the current minikube profile",
+	Long:  "profile sets the current minikube profile.  This is used to run and manage multiple minikube instance.  You can return to the default minikube name by running `minikube profile default`",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 1 {
 			fmt.Fprintln(os.Stderr, "usage: minikube profile MINIKUBE_PROFILE_NAME")

--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -28,7 +28,7 @@ import (
 // deleteCmd represents the delete command
 var deleteCmd = &cobra.Command{
 	Use:   "delete",
-	Short: "Deletes a local kubernetes cluster.",
+	Short: "Deletes a local kubernetes cluster",
 	Long: `Deletes a local kubernetes cluster. This command deletes the VM, and removes all
 associated files.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/minikube/cmd/env.go
+++ b/cmd/minikube/cmd/env.go
@@ -282,7 +282,7 @@ func (EnvNoProxyGetter) GetNoProxyVar() (string, string) {
 // envCmd represents the docker-env command
 var dockerEnvCmd = &cobra.Command{
 	Use:   "docker-env",
-	Short: "sets up docker env variables; similar to '$(docker-machine env)'",
+	Short: "Sets up docker env variables; similar to '$(docker-machine env)'",
 	Long:  `sets up docker env variables; similar to '$(docker-machine env)'`,
 	Run: func(cmd *cobra.Command, args []string) {
 

--- a/cmd/minikube/cmd/get_kubernetes_versions.go
+++ b/cmd/minikube/cmd/get_kubernetes_versions.go
@@ -26,7 +26,7 @@ import (
 // getK8sVersionsCmd represents the ip command
 var getK8sVersionsCmd = &cobra.Command{
 	Use:   "get-k8s-versions",
-	Short: "Gets the list of available kubernetes versions available for minikube.",
+	Short: "Gets the list of available kubernetes versions available for minikube",
 	Long:  `Gets the list of available kubernetes versions available for minikube.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		kubernetes_versions.PrintKubernetesVersionsFromGCS(os.Stdout)

--- a/cmd/minikube/cmd/logs.go
+++ b/cmd/minikube/cmd/logs.go
@@ -34,7 +34,7 @@ var (
 // logsCmd represents the logs command
 var logsCmd = &cobra.Command{
 	Use:   "logs",
-	Short: "Gets the logs of the running localkube instance, used for debugging minikube, not user code.",
+	Short: "Gets the logs of the running localkube instance, used for debugging minikube, not user code",
 	Long:  `Gets the logs of the running localkube instance, used for debugging minikube, not user code.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		api, err := machine.NewAPIClient(clientType)

--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -36,7 +36,7 @@ import (
 // mountCmd represents the mount command
 var mountCmd = &cobra.Command{
 	Use:   "mount [flags] MOUNT_DIRECTORY(ex:\"/home\")",
-	Short: "Mounts the specified directory into minikube.",
+	Short: "Mounts the specified directory into minikube",
 	Long:  `Mounts the specified directory into minikube.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 1 {

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -70,7 +70,7 @@ var (
 // startCmd represents the start command
 var startCmd = &cobra.Command{
 	Use:   "start",
-	Short: "Starts a local kubernetes cluster.",
+	Short: "Starts a local kubernetes cluster",
 	Long: `Starts a local kubernetes cluster using VM. This command
 assumes you have already installed one of the VM drivers: virtualbox/vmwarefusion/kvm/xhyve/hyperv.`,
 	Run: runStart,

--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -40,7 +40,7 @@ type Status struct {
 // statusCmd represents the status command
 var statusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Gets the status of a local kubernetes cluster.",
+	Short: "Gets the status of a local kubernetes cluster",
 	Long:  `Gets the status of a local kubernetes cluster.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		api, err := machine.NewAPIClient(clientType)

--- a/cmd/minikube/cmd/stop.go
+++ b/cmd/minikube/cmd/stop.go
@@ -29,7 +29,7 @@ import (
 // stopCmd represents the stop command
 var stopCmd = &cobra.Command{
 	Use:   "stop",
-	Short: "Stops a running local kubernetes cluster.",
+	Short: "Stops a running local kubernetes cluster",
 	Long: `Stops a local kubernetes cluster running in Virtualbox. This command stops the VM
 itself, leaving all files intact. The cluster can be started again with the "start" command.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/minikube/cmd/version.go
+++ b/cmd/minikube/cmd/version.go
@@ -26,7 +26,7 @@ import (
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Print the version of minikube.",
+	Short: "Print the version of minikube",
 	Long:  `Print the version of minikube.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		// Explicitly disable update checking for the version command


### PR DESCRIPTION
Fixes the consistency in short description of commands

```
$ ./out/minikube -h
Minikube is a CLI tool that provisions and manages single-node Kubernetes clusters optimized for development workflows.

Usage:
  minikube [command]

Available Commands:
  addons           Modify minikube's kubernetes addons
  completion       Outputs minikube shell completion for the given shell (bash)
  config           Modify minikube config
  dashboard        Opens/displays the kubernetes dashboard URL for your local cluster
  delete           Deletes a local kubernetes cluster
  docker-env       sets up docker env variables; similar to '$(docker-machine env)'
  get-k8s-versions Gets the list of available kubernetes versions available for minikube
  ip               Retrieve the IP address of the running cluster.
  logs             Gets the logs of the running localkube instance, used for debugging minikube, not user code
  mount            Mounts the specified directory into minikube
  profile          Profile sets the current minikube profile
  service          Gets the kubernetes URL(s) for the specified service in your local cluster
  ssh              Log into or run a command on a machine with SSH; similar to 'docker-machine ssh'
  start            Starts a local kubernetes cluster
  status           Gets the status of a local kubernetes cluster
  stop             Stops a running local kubernetes cluster
  version          Print the version of minikube
```