### PR TITLE
Validate k8s version before starting VM

### DIFF
--- a/pkg/minikube/kubernetes_versions/kubernetes_versions.go
+++ b/pkg/minikube/kubernetes_versions/kubernetes_versions.go
@@ -65,7 +65,6 @@ var cachedK8sVersions = make(K8sReleases, 0)
 
 func GetK8sVersionsFromURL(url string) (K8sReleases, error) {
 	if len(cachedK8sVersions) != 0 {
-		glog.Infof("Using cached localkube versions: %v", cachedK8sVersions)
 		return cachedK8sVersions, nil
 	}
 	var k8sVersions K8sReleases
@@ -76,7 +75,6 @@ func GetK8sVersionsFromURL(url string) (K8sReleases, error) {
 		return K8sReleases{}, errors.Errorf("There were no json k8s Releases at the url specified: %s", url)
 	}
 
-	glog.Infoln("Caching localkube versions")
 	cachedK8sVersions = k8sVersions
 	return k8sVersions, nil
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -113,6 +113,9 @@ func GetLocalkubeDownloadURL(versionOrURL string, filename string) (string, erro
 		versionOrURL = "v" + versionOrURL
 	}
 	isValidVersion, err := kubernetes_versions.IsValidLocalkubeVersion(versionOrURL, constants.KubernetesVersionGCSURL)
+	if err != nil {
+		return "", errors.Wrap(err, "Error getting valid localkube versions")
+	}
 	if !isValidVersion {
 		return "", errors.New("Not a valid localkube version to download")
 	}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -112,19 +112,9 @@ func GetLocalkubeDownloadURL(versionOrURL string, filename string) (string, erro
 		// no 'v' prefix in input, need to prepend it to version
 		versionOrURL = "v" + versionOrURL
 	}
-	if k8sReleases, err := kubernetes_versions.GetK8sVersionsFromURL(constants.KubernetesVersionGCSURL); err != nil {
-		return "", errors.Wrap(err, "Error validating the localkube version")
-	} else {
-		isValidVersion := false
-		for _, version := range k8sReleases {
-			if version.Version == versionOrURL {
-				isValidVersion = true
-				break
-			}
-		}
-		if !isValidVersion {
-			return "", errors.New("Invalid localkube version")
-		}
+	isValidVersion, err := kubernetes_versions.IsValidLocalkubeVersion(versionOrURL, constants.KubernetesVersionGCSURL)
+	if !isValidVersion {
+		return "", errors.New("Not a valid localkube version to download")
 	}
 	if _, err = semver.Make(strings.TrimPrefix(versionOrURL, version.VersionPrefix)); err != nil {
 		return "", errors.Wrap(err, "Error creating semver version from localkube version input string")


### PR DESCRIPTION
Also, cache in memory localkube versions in multiple calls to the GCS
bucket.  These versions will not change during the life of the minikube
process once fetched and are used multiple times.