### PR TITLE
Fix Selector to use heapster, influxdb and grafana on Minikube

### DIFF
--- a/deploy/addons/heapster/grafana-svc.yaml
+++ b/deploy/addons/heapster/grafana-svc.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    kubernetes.io/cluster-service: 'true'
     kubernetes.io/name: monitoring-grafana
     kubernetes.io/minikube-addons: heapster
     kubernetes.io/minikube-addons-endpoint: heapster

--- a/deploy/addons/heapster/heapster-rc.yaml
+++ b/deploy/addons/heapster/heapster-rc.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ReplicationController
 metadata:
   labels:
-    kubernetes.io/cluster-service: 'true'
     k8s-app: heapster
     name: heapster
     kubernetes.io/minikube-addons: heapster
@@ -16,7 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        kubernetes.io/cluster-service: 'true'
+        addonmanager.kubernetes.io/mode: Reconcile
         k8s-app: heapster
     spec:
       containers:

--- a/deploy/addons/heapster/heapster-svc.yaml
+++ b/deploy/addons/heapster/heapster-svc.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    kubernetes.io/cluster-service: 'true'
     kubernetes.io/name: heapster
     kubernetes.io/minikube-addons: heapster
   name: heapster

--- a/deploy/addons/heapster/influxGrafana-rc.yaml
+++ b/deploy/addons/heapster/influxGrafana-rc.yaml
@@ -16,7 +16,6 @@ apiVersion: v1
 kind: ReplicationController
 metadata:
   labels:
-    kubernetes.io/cluster-service: 'true'
     name: influxGrafana
     kubernetes.io/minikube-addons: heapster
   name: influxdb-grafana
@@ -26,11 +25,12 @@ spec:
   selector:
     addonmanager.kubernetes.io/mode: Reconcile
     name: influxGrafana
+    #name: influxdb-grafana
   template:
     metadata:
       labels:
-        kubernetes.io/cluster-service: 'true'
         name: influxGrafana
+        addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:
       - name: influxdb

--- a/deploy/addons/heapster/influxdb-svc.yaml
+++ b/deploy/addons/heapster/influxdb-svc.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    kubernetes.io/cluster-service: 'true'
     kubernetes.io/name: monitoring-influxdb
     kubernetes.io/minikube-addons: heapster
   name: monitoring-influxdb


### PR DESCRIPTION
With the last selector add, it is impossible to deploy heapster addons correctly.