### PR TITLE
Update kubedns to 1.14.2.

### DIFF
--- a/deploy/addons/kube-dns/kube-dns-controller.yaml
+++ b/deploy/addons/kube-dns/kube-dns-controller.yaml
@@ -44,7 +44,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.1
+        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.2
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -76,7 +76,7 @@ spec:
         args:
         - --domain=cluster.local.
         - --dns-port=10053
-        - --config-dir=/kube-dns-config
+        - --config-map=kube-dns
         - --v=2
         env:
         - name: PROMETHEUS_PORT
@@ -95,7 +95,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.1
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.2
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -131,7 +131,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.1
+        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.2
         livenessProbe:
           httpGet:
             path: /metrics

--- a/test/integration/cluster_dns_test.go
+++ b/test/integration/cluster_dns_test.go
@@ -59,7 +59,7 @@ func testClusterDNS(t *testing.T) {
 		}
 
 		dnsByteArr, err := kubectlRunner.RunCommand([]string{"exec", podName,
-			"nslookup", "kubernetes.default"})
+			"nslookup", "kubernetes"})
 		dnsOutput := string(dnsByteArr)
 		if err != nil {
 			return &commonutil.RetriableError{Err: err}


### PR DESCRIPTION
Should fix #1501 

With this update:

```shell
kubectl exec -it busybox nslookup kubernetes
Server:    10.0.0.10
Address 1: 10.0.0.10 kube-dns.kube-system.svc.cluster.local

Name:      kubernetes
```

Without:
```shell
$ kubectl exec -it busybox nslookup kubernetes
Server:    10.0.0.10
Address 1: 10.0.0.10

nslookup: can't resolve 'kubernetes'
```