### PR TITLE
Fix interactive shell when using native-client

### DIFF
--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -534,7 +534,7 @@ func CreateSSHShell(api libmachine.API, args []string) error {
 	if err != nil {
 		return errors.Wrap(err, "Error creating ssh client")
 	}
-	return client.Shell(strings.Join(args, " "))
+	return client.Shell(args...)
 }
 
 // EnsureMinikubeRunningOrExit checks that minikube has a status available and that


### PR DESCRIPTION
This fixes the way the `ssh` command is invoking the shell, and will therefore allow interactive use with the Go native client.

Steps to reproduce:
```
$ sudo mv /usr/bin/ssh /usr/bin/-ssh
$ minikube start
$ minikube ssh
$ 
```

Expected:
```
$ sudo mv /usr/bin/ssh /usr/bin/-ssh
$ minikube start
$ minikube ssh 
                        ##         .
                  ## ## ##        ==
               ## ## ## ## ##    ===
           /"""""""""""""""""\___/ ===
      ~~~ {~~ ~~~~ ~~~ ~~~~ ~~~ ~ /  ===- ~~~
           \______ o           __/
             \    \         __/
              \____\_______/
 docker@minikube:~$
```

Due to #1531 I am unable to verify the build myself...

We invoke the shell as follows https://github.com/kubernetes/minikube/blob/master/pkg/minikube/cluster/cluster.go#L537
```go
	return client.Shell(strings.Join(args, " "))
```
What happens is that we provide an empty string instead of no value: https://play.golang.org/p/z7DDUWnuYm You can verify this with:

```go
package main

import (
	"strings"
	"fmt"
	
)

func main() {
	args := []string {}
	command := strings.Join(args, " ")
	fmt.Printf("Type: %T, Length: %v, Value: %v.\n", command, len(command), command)
}
```

At https://github.com/docker/machine/blob/master/libmachine/ssh/client.go#L269 the use of `args ...string` will result in args having a length of 1.

```go
func (client *NativeClient) Shell(args ...string) error {
```

this means that the check at https://github.com/docker/machine/blob/master/libmachine/ssh/client.go#L318 wrongly assumes that arguments are given, and it will execute https://github.com/docker/machine/blob/master/libmachine/ssh/client.go#L324

```go
		session.Run(strings.Join(args, " "))
```

Docker machine itself uses a different way to invoke the shell https://github.com/docker/machine/blob/e1a03348ad83d8e8adb19d696bc7bcfb18ccd770/commands/ssh.go#L50

```go
	return client.Shell(c.Args().Tail()...)
```

Therefore fixing this with:
```go
	return client.Shell(args...)
```