### PR TITLE
Add some cleanup commands to the integration tests

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -32,6 +32,30 @@ gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/testdata/busybox.yaml testda
 gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/testdata/pvc.yaml testdata/
 gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/testdata/busybox-mount-test.yaml testdata/
 
+# Linux cleanup
+virsh -c qemu:///system list --all \
+      | sed -n '3,$ p' \
+      | cut -d' ' -f 7 \
+      | xargs -I {} sh -c "virsh -c qemu:///system destroy {}; virsh -c qemu:///system undefine {}"  \
+      || true
+
+# Clean up virtualbox VMs
+vboxmanage list vms \
+      | cut -d "{" -f2 \
+      | cut -d "}" -f1 \
+      | xargs -I {} sh -c "vboxmanage unregistervm {} --delete" \
+      || true
+
+# Clean up xhyve disks
+hdiutil info \
+      | grep -v /dev/disk0 \
+      | grep /dev/ \
+      | xargs -I {} sh -c "hdiutil detach {}" \
+      || true
+
+# Clean up xhyve processes
+pgrep xhyve | xargs kill || true
+
 # Set the executable bit on the e2e binary and out binary
 chmod +x out/e2e-${OS_ARCH}
 chmod +x out/minikube-${OS_ARCH}

--- a/hack/jenkins/linux_integration_tests_kvm_alt.sh
+++ b/hack/jenkins/linux_integration_tests_kvm_alt.sh
@@ -29,22 +29,5 @@ OS_ARCH="linux-amd64"
 VM_DRIVER="kvm"
 JOB_NAME="Linux-KVM-Alt"
 
-# Use a checksum here instead of a released version
-# until the driver is stable
-SHA="ba50f204ccf62c2f1f521fd60aa8eb68c39bcd2f"
-
-pushd "$GOPATH/src/github.com/r2d4/docker-machine-driver-kvm" >/dev/null
-    git fetch origin
-    git checkout ${SHA}
-
-    # Make will run `go install` and put the binary in $GOBIN
-    make
-popd >/dev/null
-
-echo "Using driver $(which docker-machine-driver-kvm)"
-
 # Download files and set permissions
 source common.sh
-
-# Clean up the driver, so that we use the other KVM driver by default.
-rm $GOPATH/bin/docker-machine-driver-kvm


### PR DESCRIPTION
Bad tests that panic won't clean themselves up properly.  By putting
these cleanup commands before we run the minikube integration tests, we
ensure that minikube will have a clean environment to run.

These all run in common.sh to make sure that even hypervisors that they
arent testing don't interfere with their own test.  OS specific
commands will fail silently.