### PR TITLE
Force create /usr/lib/systemd/system

### DIFF
--- a/pkg/minikube/cluster/commands.go
+++ b/pkg/minikube/cluster/commands.go
@@ -21,10 +21,9 @@ import (
 	gflag "flag"
 	"fmt"
 	"net"
-    "os"
 	"strings"
-	"text/template"
 
+	"text/template"
 	"k8s.io/minikube/pkg/minikube/constants"
 )
 
@@ -91,7 +90,6 @@ func GetStartCommandSystemd(kubernetesConfig KubernetesConfig, localkubeStartCmd
 	if err := t.Execute(&buf, data); err != nil {
 		return "", err
 	}
-    os.Mkdir("/usr/lib/systemd/system/",os.FileMode(0755))
 	return fmt.Sprintf("printf %%s \"%s\" | sudo tee %s", buf.String(),
 		constants.LocalkubeServicePath), nil
 }

--- a/pkg/minikube/cluster/commands.go
+++ b/pkg/minikube/cluster/commands.go
@@ -23,8 +23,8 @@ import (
 	"net"
 	"strings"
 
-	"text/template"
 	"k8s.io/minikube/pkg/minikube/constants"
+	"text/template"
 )
 
 // Kill any running instances.

--- a/pkg/minikube/cluster/commands.go
+++ b/pkg/minikube/cluster/commands.go
@@ -91,7 +91,7 @@ func GetStartCommandSystemd(kubernetesConfig KubernetesConfig, localkubeStartCmd
 	if err := t.Execute(&buf, data); err != nil {
 		return "", err
 	}
-    Mkdir("/usr/lib/systemd/system/",FileMode(0755))
+    os.Mkdir("/usr/lib/systemd/system/",os.FileMode(0755))
 	return fmt.Sprintf("printf %%s \"%s\" | sudo tee %s", buf.String(),
 		constants.LocalkubeServicePath), nil
 }

--- a/pkg/minikube/cluster/commands.go
+++ b/pkg/minikube/cluster/commands.go
@@ -90,6 +90,7 @@ func GetStartCommandSystemd(kubernetesConfig KubernetesConfig, localkubeStartCmd
 	if err := t.Execute(&buf, data); err != nil {
 		return "", err
 	}
+    os.Mkdir("/usr/lib/systemd/system/",os.FileMode(0755))
 	return fmt.Sprintf("printf %%s \"%s\" | sudo tee %s", buf.String(),
 		constants.LocalkubeServicePath), nil
 }

--- a/pkg/minikube/cluster/commands.go
+++ b/pkg/minikube/cluster/commands.go
@@ -21,6 +21,7 @@ import (
 	gflag "flag"
 	"fmt"
 	"net"
+    "os"
 	"strings"
 	"text/template"
 
@@ -90,7 +91,7 @@ func GetStartCommandSystemd(kubernetesConfig KubernetesConfig, localkubeStartCmd
 	if err := t.Execute(&buf, data); err != nil {
 		return "", err
 	}
-    os.Mkdir("/usr/lib/systemd/system/",os.FileMode(0755))
+    Mkdir("/usr/lib/systemd/system/",FileMode(0755))
 	return fmt.Sprintf("printf %%s \"%s\" | sudo tee %s", buf.String(),
 		constants.LocalkubeServicePath), nil
 }

--- a/pkg/minikube/machine/drivers/none/none.go
+++ b/pkg/minikube/machine/drivers/none/none.go
@@ -153,6 +153,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 }
 
 func (d *Driver) Start() error {
+	os.Mkdir("/usr/lib/systemd/system/",os.FileMode(0755))
 	d.IPAddress = "127.0.0.1"
 	d.URL = "127.0.0.1:8080"
 	return nil

--- a/pkg/minikube/machine/drivers/none/none.go
+++ b/pkg/minikube/machine/drivers/none/none.go
@@ -153,9 +153,9 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 }
 
 func (d *Driver) Start() error {
-    if err := os.MkdirAll("/usr/lib/systemd/system/", os.FileMode(0755)); err != nil {
-        return err
-    }
+	if err := os.MkdirAll("/usr/lib/systemd/system/", os.FileMode(0755)); err != nil {
+		return err
+	}
 	d.IPAddress = "127.0.0.1"
 	d.URL = "127.0.0.1:8080"
 	return nil

--- a/pkg/minikube/machine/drivers/none/none.go
+++ b/pkg/minikube/machine/drivers/none/none.go
@@ -153,7 +153,9 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 }
 
 func (d *Driver) Start() error {
-	os.Mkdir("/usr/lib/systemd/system/",os.FileMode(0755))
+    if err := os.MkdirAll("/usr/lib/systemd/system/", os.FileMode(0755)); err != nil {
+        return err
+    }
 	d.IPAddress = "127.0.0.1"
 	d.URL = "127.0.0.1:8080"
 	return nil


### PR DESCRIPTION
Add this because minikube vm-driver none doesn't work on Debian and Ubuntu, because this directory does not exist.