### PR TITLE
Specify domains in dnsmasq configuration

### DIFF
--- a/deploy/addons/kube-dns/kube-dns-controller.yaml
+++ b/deploy/addons/kube-dns/kube-dns-controller.yaml
@@ -114,7 +114,9 @@ spec:
         - -k
         - --cache-size=1000
         - --log-facility=-
-        - --server=127.0.0.1#10053
+        - --server=/cluster.local/127.0.0.1#10053
+        - --server=/in-addr.arpa/127.0.0.1#10053
+        - --server=/ip6.arpa/127.0.0.1#10053
         ports:
         - containerPort: 53
           name: dns


### PR DESCRIPTION
Flags after the `--` are passed directly to dnsmasq in the dnsmasq-nanny container.  When upgrading to kube-dns 1.14.1, the first version this container appeared, I incorrectly assumed that we could leave out the optional domain parameter.  However, it looks like we need it.  

I've tested this locally and it has been running for 15 minutes without restarting.  I'm not opposed to adding a longer running integration test to identify an issue like this, since it only occurs after a few minutes (due to the initial delay on the liveness probe)