### PR TITLE
Resolve all staging dirs automatically and remove from Godeps

### DIFF
--- a/hack/godeps/utils.sh
+++ b/hack/godeps/utils.sh
@@ -53,5 +53,5 @@ done
 }
 
 godep::remove_staging_from_json() {
-  go run ${MINIKUBE_ROOT}/hack/godeps/godeps-json-updater.go --godeps-file ${MINIKUBE_ROOT}/Godeps/Godeps.json
+  go run ${MINIKUBE_ROOT}/hack/godeps/godeps-json-updater.go --godeps-file ${MINIKUBE_ROOT}/Godeps/Godeps.json --kubernetes-dir ${KUBE_ROOT}
 }


### PR DESCRIPTION
Remove all the staged repositories from our Godeps file, as is done
upstream.

Instead of a not-always-complete hardcoded list, resolve the staging repositories directly by looking at the staging directory.

Note: this is a merge against the 1.7 branch