### PR TITLE
Pass legacy systemd boot parameter in xhyve driver.

### DIFF
--- a/pkg/minikube/cluster/cluster_darwin.go
+++ b/pkg/minikube/cluster/cluster_darwin.go
@@ -66,7 +66,7 @@ func createXhyveHost(config MachineConfig) *xhyveDriver {
 		Memory:         config.Memory,
 		CPU:            config.CPUs,
 		Boot2DockerURL: config.Downloader.GetISOFileURI(config.MinikubeISO),
-		BootCmd:        "loglevel=3 user=docker console=ttyS0 console=tty0 noembed nomodeset norestore waitusb=10 base host=" + cfg.GetMachineName(),
+		BootCmd:        "loglevel=3 user=docker console=ttyS0 console=tty0 noembed nomodeset norestore waitusb=10 systemd.legacy_systemd_cgroup_controller=yes base host=" + cfg.GetMachineName(),
 		DiskSize:       int64(config.DiskSize),
 		Virtio9p:       true,
 		Virtio9pFolder: "/Users",


### PR DESCRIPTION
This flag was added as part of our iso upgrade to fix a docker/systemd version issue in https://github.com/kubernetes/minikube/pull/1412

However the xhyve driver passes in it's own boot parameters.