### PR TITLE
introduce the "registry" addon

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -152,6 +152,12 @@ var settings = []Setting{
 		callbacks:   []setFn{EnableOrDisableAddon},
 	},
 	{
+		name:        "registry",
+		set:         SetBool,
+		validations: []setFn{IsValidAddon},
+		callbacks:   []setFn{EnableOrDisableAddon},
+	},
+	{
 		name:        "registry-creds",
 		set:         SetBool,
 		validations: []setFn{IsValidAddon},

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -293,7 +293,7 @@ func init() {
 	startCmd.Flags().StringArrayVar(&dockerOpt, "docker-opt", nil, "Specify arbitrary flags to pass to the Docker daemon. (format: key=value)")
 	startCmd.Flags().String(apiServerName, constants.APIServerName, "The apiserver name which is used in the generated certificate for localkube/kubernetes.  This can be used if you want to make the apiserver available from outside the machine")
 	startCmd.Flags().String(dnsDomain, constants.ClusterDNSDomain, "The cluster dns domain name used in the kubernetes cluster")
-	startCmd.Flags().StringSliceVar(&insecureRegistry, "insecure-registry", nil, "Insecure Docker registries to pass to the Docker daemon")
+	startCmd.Flags().StringSliceVar(&insecureRegistry, "insecure-registry", []string{util.DefaultServiceClusterIP + "/24"}, "Insecure Docker registries to pass to the Docker daemon")
 	startCmd.Flags().StringSliceVar(&registryMirror, "registry-mirror", nil, "Registry mirrors to pass to the Docker daemon")
 	startCmd.Flags().String(kubernetesVersion, constants.DefaultKubernetesVersion, "The kubernetes version that the minikube VM will use (ex: v1.2.3) \n OR a URI which contains a localkube binary (ex: https://storage.googleapis.com/minikube/k8sReleases/v1.3.0/localkube-linux-amd64)")
 	startCmd.Flags().String(containerRuntime, "", "The container runtime to be used")

--- a/deploy/addons/registry/registry-rc.yaml
+++ b/deploy/addons/registry/registry-rc.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  labels:
+    kubernetes.io/minikube-addons: registry
+    addonmanager.kubernetes.io/mode: Reconcile
+  name: registry
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    addonmanager.kubernetes.io/mode: Reconcile
+  template:
+    metadata:
+      labels:
+        addonmanager.kubernetes.io/mode: Reconcile
+    spec:
+      containers:
+      - image: registry:2.6.1
+        imagePullPolicy: IfNotPresent
+        name: registry
+        ports:
+        - containerPort: 5000
+          protocol: TCP

--- a/deploy/addons/registry/registry-svc.yaml
+++ b/deploy/addons/registry/registry-svc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    kubernetes.io/minikube-addons: registry
+    addonmanager.kubernetes.io/mode: Reconcile
+  name: registry
+  namespace: kube-system
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 5000
+  selector:
+    kubernetes.io/minikube-addons: registry

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -142,6 +142,18 @@ var Addons = map[string]*Addon{
 			"ingress-svc.yaml",
 			"0640"),
 	}, false, "ingress"),
+	"registry": NewAddon([]*MemoryAsset{
+		NewMemoryAsset(
+			"deploy/addons/registry/registry-rc.yaml",
+			constants.AddonsPath,
+			"registry-rc.yaml",
+			"0640"),
+		NewMemoryAsset(
+			"deploy/addons/registry/registry-svc.yaml",
+			constants.AddonsPath,
+			"registry-svc.yaml",
+			"0640"),
+	}, false, "registry"),
 	"registry-creds": NewAddon([]*MemoryAsset{
 		NewMemoryAsset(
 			"deploy/addons/registry-creds/registry-creds-rc.yaml",


### PR DESCRIPTION
This addon installs a docker registry into kube-system and exposes it on port 80 through the service.

A separate commit was also added to add 10.0.0.0/24 to the `--insecure-registry` flag by default so that the kubelets can communicate with the registry addon. I tested this functionality via

```
$ kubectl -n kube-system get svc registry -o jsonpath="{.spec.clusterIP}"
10.0.0.240
$ minikube ssh
$ docker pull busybox
$ docker tag busybox 10.0.0.240/busybox
$ docker push 10.0.0.240/busybox
```