### PR TITLE
use --dns-domain for k8s API server cert generation

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -157,7 +157,7 @@ func runStart(cmd *cobra.Command, args []string) {
 	}
 
 	fmt.Println("Setting up certs...")
-	if err := cluster.SetupCerts(host.Driver, kubernetesConfig.APIServerName); err != nil {
+	if err := cluster.SetupCerts(host.Driver, kubernetesConfig.APIServerName, kubernetesConfig.DNSDomain); err != nil {
 		glog.Errorln("Error configuring authentication: ", err)
 		cmdUtil.MaybeReportErrorAndExit(err)
 	}
@@ -292,7 +292,7 @@ func init() {
 	startCmd.Flags().StringArrayVar(&dockerEnv, "docker-env", nil, "Environment variables to pass to the Docker daemon. (format: key=value)")
 	startCmd.Flags().StringArrayVar(&dockerOpt, "docker-opt", nil, "Specify arbitrary flags to pass to the Docker daemon. (format: key=value)")
 	startCmd.Flags().String(apiServerName, constants.APIServerName, "The apiserver name which is used in the generated certificate for localkube/kubernetes.  This can be used if you want to make the apiserver available from outside the machine")
-	startCmd.Flags().String(dnsDomain, "", "The cluster dns domain name used in the kubernetes cluster")
+	startCmd.Flags().String(dnsDomain, constants.ClusterDNSDomain, "The cluster dns domain name used in the kubernetes cluster")
 	startCmd.Flags().StringSliceVar(&insecureRegistry, "insecure-registry", nil, "Insecure Docker registries to pass to the Docker daemon")
 	startCmd.Flags().StringSliceVar(&registryMirror, "registry-mirror", nil, "Registry mirrors to pass to the Docker daemon")
 	startCmd.Flags().String(kubernetesVersion, constants.DefaultKubernetesVersion, "The kubernetes version that the minikube VM will use (ex: v1.2.3) \n OR a URI which contains a localkube binary (ex: https://storage.googleapis.com/minikube/k8sReleases/v1.3.0/localkube-linux-amd64)")

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -247,7 +247,7 @@ func localkubeURIWasSpecified(config KubernetesConfig) bool {
 }
 
 // SetupCerts gets the generated credentials required to talk to the APIServer.
-func SetupCerts(d drivers.Driver, apiServerName string) error {
+func SetupCerts(d drivers.Driver, apiServerName string, clusterDnsDomain string) error {
 	localPath := constants.GetMinipath()
 	ipStr, err := d.GetIP()
 	if err != nil {
@@ -260,7 +260,7 @@ func SetupCerts(d drivers.Driver, apiServerName string) error {
 	caKey := filepath.Join(localPath, "ca.key")
 	publicPath := filepath.Join(localPath, "apiserver.crt")
 	privatePath := filepath.Join(localPath, "apiserver.key")
-	if err := GenerateCerts(caCert, caKey, publicPath, privatePath, ip, apiServerName); err != nil {
+	if err := GenerateCerts(caCert, caKey, publicPath, privatePath, ip, apiServerName, clusterDnsDomain); err != nil {
 		return errors.Wrap(err, "Error generating certs")
 	}
 

--- a/pkg/minikube/cluster/cluster_test.go
+++ b/pkg/minikube/cluster/cluster_test.go
@@ -436,7 +436,7 @@ func TestSetupCerts(t *testing.T) {
 	tempDir := tests.MakeTempDir()
 	defer os.RemoveAll(tempDir)
 
-	if err := SetupCerts(d, constants.APIServerName); err != nil {
+	if err := SetupCerts(d, constants.APIServerName, constants.ClusterDNSDomain); err != nil {
 		t.Fatalf("Error starting cluster: %s", err)
 	}
 

--- a/pkg/minikube/cluster/credentials.go
+++ b/pkg/minikube/cluster/credentials.go
@@ -28,7 +28,7 @@ var (
 	internalIP = net.ParseIP(util.DefaultServiceClusterIP)
 )
 
-func GenerateCerts(caCert, caKey, pub, priv string, ip net.IP, name string) error {
+func GenerateCerts(caCert, caKey, pub, priv string, ip net.IP, name string, dnsDomain string) error {
 	if !(util.CanReadFile(caCert) && util.CanReadFile(caKey)) {
 		if err := util.GenerateCACert(caCert, caKey, name); err != nil {
 			return errors.Wrap(err, "Error generating certificate")
@@ -36,7 +36,7 @@ func GenerateCerts(caCert, caKey, pub, priv string, ip net.IP, name string) erro
 	}
 
 	ips := []net.IP{ip, internalIP}
-	if err := util.GenerateSignedCert(pub, priv, ips, util.GetAlternateDNS(util.DefaultDNSDomain), caCert, caKey); err != nil {
+	if err := util.GenerateSignedCert(pub, priv, ips, util.GetAlternateDNS(dnsDomain), caCert, caKey); err != nil {
 		return errors.Wrap(err, "Error generating signed cert")
 	}
 	return nil

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -29,8 +29,8 @@ import (
 
 // APIServerPort is the port that the API server should listen on.
 const (
-	APIServerPort = 8443
-	APIServerName = "minikubeCA"
+	APIServerPort    = 8443
+	APIServerName    = "minikubeCA"
 	ClusterDNSDomain = "cluster.local"
 )
 

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -31,6 +31,7 @@ import (
 const (
 	APIServerPort = 8443
 	APIServerName = "minikubeCA"
+	ClusterDNSDomain = "cluster.local"
 )
 
 const MinikubeHome = "MINIKUBE_HOME"


### PR DESCRIPTION
Fixes #1588 