### PR TITLE
Don't treat stopping stopped hosts as error

### DIFF
--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -33,6 +33,7 @@ import (
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/engine"
 	"github.com/docker/machine/libmachine/host"
+	"github.com/docker/machine/libmachine/mcnerror"
 	"github.com/docker/machine/libmachine/state"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
@@ -103,6 +104,10 @@ func StopHost(api libmachine.API) error {
 		return errors.Wrapf(err, "Error loading host: %s", cfg.GetMachineName())
 	}
 	if err := host.Stop(); err != nil {
+		alreadyInStateError, ok := err.(mcnerror.ErrHostAlreadyInState)
+		if ok && alreadyInStateError.State == state.Stopped {
+			return nil
+		}
 		return errors.Wrapf(err, "Error stopping host: %s", cfg.GetMachineName())
 	}
 	return nil


### PR DESCRIPTION
Running `minikube stop` while nothing is running results in a crash. This patch makes `cluster.StopHost()` swallow the stop-while-stopped error libmachine returns.

There are couple of other ways to do this, namely catching the error in cmd and changing `libmachine` itself. I figured this is the best place to make the change. Please let me know if the other options are better, 