### PR TITLE
Poweroff VMs before unregistering and deleting

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -43,6 +43,12 @@ virsh -c qemu:///system list --all \
 vboxmanage list vms \
       | cut -d "{" -f2 \
       | cut -d "}" -f1 \
+      | xargs -I {} sh -c "vboxmanage controlvm {} poweroff" \
+      || true
+
+vboxmanage list vms \
+      | cut -d "{" -f2 \
+      | cut -d "}" -f1 \
       | xargs -I {} sh -c "vboxmanage unregistervm {} --delete" \
       || true
 


### PR DESCRIPTION
Trying to unregister the virtualbox vm seems to cause issues on OSX when the VM is still running.