### PR TITLE
Remove fake _gopath

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,12 +38,8 @@ IS_EXE ?=
 
 ifeq ($(IN_DOCKER),1)
 	GOPATH := /go
-else
-	GOPATH := $(shell pwd)/_gopath
+	export GOPATH
 endif
-
-export GOPATH
-
 
 # Use system python if it exists, otherwise use Docker.
 PYTHON := $(shell command -v python || echo "docker run --rm -it -v $(shell pwd):/minikube -w /minikube python python")
@@ -68,24 +64,24 @@ endif
 out/minikube$(IS_EXE): out/minikube-$(GOOS)-$(GOARCH)$(IS_EXE)
 	cp $(BUILD_DIR)/minikube-$(GOOS)-$(GOARCH)$(IS_EXE) $(BUILD_DIR)/minikube$(IS_EXE)
 
-out/localkube: $(GOPATH)/src/$(ORG) $(shell $(LOCALKUBEFILES))
+out/localkube: $(shell $(LOCALKUBEFILES))
 ifeq ($(BUILD_OS),Linux)
 	CGO_ENABLED=1 go build -tags static_build -ldflags=$(LOCALKUBE_LDFLAGS) -o $(BUILD_DIR)/localkube ./cmd/localkube
 else
 	docker run -w /go/src/$(REPOPATH) -e IN_DOCKER=1 -v $(shell pwd):/go/src/$(REPOPATH) $(BUILD_IMAGE) make out/localkube
 endif
 
-out/minikube-darwin-amd64: $(GOPATH)/src/$(ORG) pkg/minikube/assets/assets.go $(shell $(MINIKUBEFILES))
+out/minikube-darwin-amd64: pkg/minikube/assets/assets.go $(shell $(MINIKUBEFILES))
 ifeq ($(IN_DOCKER),1)
 	CC=o64-clang CXX=o64-clang++ CGO_ENABLED=1 GOARCH=amd64 GOOS=darwin go build --installsuffix cgo -ldflags="$(MINIKUBE_LDFLAGS) $(K8S_VERSION_LDFLAGS)" -a -o $(BUILD_DIR)/minikube-darwin-amd64 k8s.io/minikube/cmd/minikube
 else
 	docker run -e IN_DOCKER=1 --workdir /go/src/$(REPOPATH) --entrypoint /usr/bin/make -v $(PWD):/go/src/$(REPOPATH) $(DARWIN_BUILD_IMAGE) out/minikube-darwin-amd64
 endif
 
-out/minikube-linux-amd64: $(GOPATH)/src/$(ORG) pkg/minikube/assets/assets.go $(shell $(MINIKUBEFILES))
+out/minikube-linux-amd64: pkg/minikube/assets/assets.go $(shell $(MINIKUBEFILES))
 	CGO_ENABLED=1 GOARCH=amd64 GOOS=linux go build --installsuffix cgo -ldflags="$(MINIKUBE_LDFLAGS) $(K8S_VERSION_LDFLAGS)" -a -o $(BUILD_DIR)/minikube-linux-amd64 k8s.io/minikube/cmd/minikube
 
-out/minikube-windows-amd64.exe: $(GOPATH)/src/$(ORG) pkg/minikube/assets/assets.go $(shell $(MINIKUBEFILES))
+out/minikube-windows-amd64.exe: pkg/minikube/assets/assets.go $(shell $(MINIKUBEFILES))
 	CGO_ENABLED=0 GOARCH=amd64 GOOS=windows go build --installsuffix cgo -ldflags="$(MINIKUBE_LDFLAGS) $(K8S_VERSION_LDFLAGS)" -a -o $(BUILD_DIR)/minikube-windows-amd64.exe k8s.io/minikube/cmd/minikube
 
 minikube_iso: # old target kept for making tests happy
@@ -119,13 +115,13 @@ integration-versioned: out/minikube
 	go test -v -test.timeout=30m $(REPOPATH)/test/integration --tags="integration versioned" --minikube-args="$(MINIKUBE_ARGS)"
 
 .PHONY: test
-test: $(GOPATH)/src/$(ORG) pkg/minikube/assets/assets.go
+test: pkg/minikube/assets/assets.go
 	./test.sh
 
 pkg/minikube/assets/assets.go: out/localkube $(GOPATH)/bin/go-bindata $(shell find deploy/addons -type f)
 	$(GOPATH)/bin/go-bindata -nomemcopy -o pkg/minikube/assets/assets.go -pkg assets ./out/localkube deploy/addons/...
 
-$(GOPATH)/bin/go-bindata: $(GOPATH)/src/$(ORG)
+$(GOPATH)/bin/go-bindata:
 	GOBIN=$(GOPATH)/bin go get github.com/jteeuwen/go-bindata/...
 
 .PHONY: cross
@@ -141,14 +137,13 @@ checksum:
 
 .PHONY: clean
 clean:
-	rm -rf $(GOPATH)
 	rm -rf $(BUILD_DIR)
 	rm -f pkg/minikube/assets/assets.go
 
 .PHONY: gendocs
 gendocs: out/docs/minikube.md
 
-out/docs/minikube.md: $(GOPATH)/src/$(ORG) $(shell find cmd) $(shell find pkg/minikube/constants) pkg/minikube/assets/assets.go
+out/docs/minikube.md: $(shell find cmd) $(shell find pkg/minikube/constants) pkg/minikube/assets/assets.go
 	cd $(GOPATH)/src/$(REPOPATH) && go run -ldflags="$(K8S_VERSION_LDFLAGS) $(MINIKUBE_LDFLAGS)" -tags gendocs hack/gen_help_text.go
 
 out/minikube_$(DEB_VERSION).deb: out/minikube-linux-amd64
@@ -174,13 +169,6 @@ out/minikube-installer.exe: out/minikube-windows-amd64.exe
 	mv out/windows_tmp/minikube-installer.exe out/minikube-installer.exe
 	rm -rf out/windows_tmp
 
-.PHONY: gopath
-gopath: $(GOPATH)/src/$(ORG)
-
-$(GOPATH)/src/$(ORG):
-	mkdir -p $(GOPATH)/src/$(ORG)
-	ln -s -f $(shell pwd) $(GOPATH)/src/$(ORG)
-
 .PHONY: check-release
 check-release:
 	go test -v ./deploy/minikube/release_sanity_test.go -tags=release
@@ -199,7 +187,7 @@ localkube-image: out/localkube
 	docker build -t $(REGISTRY)/localkube-image:$(TAG) -f deploy/docker/Dockerfile .
 	@echo ""
 	@echo "${REGISTRY}/localkube-image:$(TAG) succesfully built"
-	@echo "See https://github.com/kubernetes/minikube/tree/master/deploy/docker for instrucions on how to run image"
+	@echo "See https://github.com/kubernetes/minikube/tree/master/deploy/docker for instructions on how to run image"
 
 buildroot-image: $(ISO_BUILD_IMAGE) # convenient alias to build the docker container
 $(ISO_BUILD_IMAGE): deploy/iso/minikube-iso/Dockerfile

--- a/docs/contributors/build_guide.md
+++ b/docs/contributors/build_guide.md
@@ -12,10 +12,13 @@ On Fedora you need to install _glibc-static_
 $ sudo dnf install -y glibc-static
 ```
 
-### Build Instructions
+### Building from Source
+Clone minikube into your go path under `$GOPATH/src/k8s.io`
 
-```shell
-make
+```
+$ git clone https://github.com/kubernetes/minikube.git $GOPATH/src/k8s.io
+$ cd $GOPATH/src/k8s.io/minikube
+$ make
 ```
 
 ### Run Instructions

--- a/hack/jenkins/minikube_cross_build_and_upload.sh
+++ b/hack/jenkins/minikube_cross_build_and_upload.sh
@@ -35,6 +35,7 @@ if out="$(git diff ${ghprbActualCommit} --name-only $(git merge-base origin/mast
 	make release-iso
 fi
 
+export GOPATH=~/go
 
 # Build all platforms (Windows, Linux, OSX)
 make cross
@@ -42,9 +43,9 @@ make cross
 # Build the e2e test target for Darwin and Linux. We don't run tests on Windows yet.
 # We build these on Linux, but run the tests on different platforms.
 # This makes it easier to provision slaves, since they don't need to have a go toolchain.'
-GOPATH=$(pwd)/_gopath GOOS=darwin GOARCH=amd64 go test -c k8s.io/minikube/test/integration --tags=integration -o out/e2e-darwin-amd64
-GOPATH=$(pwd)/_gopath GOOS=linux GOARCH=amd64 go test -c k8s.io/minikube/test/integration --tags=integration -o out/e2e-linux-amd64
-GOPATH=$(pwd)/_gopath GOOS=windows GOARCH=amd64 go test -c k8s.io/minikube/test/integration --tags=integration -o out/e2e-windows-amd64.exe
+GOOS=darwin GOARCH=amd64 go test -c k8s.io/minikube/test/integration --tags=integration -o out/e2e-darwin-amd64
+GOOS=linux GOARCH=amd64 go test -c k8s.io/minikube/test/integration --tags=integration -o out/e2e-linux-amd64
+GOOS=windows GOARCH=amd64 go test -c k8s.io/minikube/test/integration --tags=integration -o out/e2e-windows-amd64.exe
 cp -r test/integration/testdata out/
 
 # Don't upload the buildroot artifacts if they exist


### PR DESCRIPTION
Don't symlink into fake gopath, just use normal gopath.  This removes a
lot of the misleading warning messages from building minikube.