### PR TITLE
Automate updates to AUR and brew-cask

### DIFF
--- a/hack/jenkins/release_update_installers.sh
+++ b/hack/jenkins/release_update_installers.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+git config user.name "minikube-bot"
+git config user.email "minikube-bot@google.com"
+
+REPLACE_PKG_VERSION=${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BUILD}
+REPLACE_MINIKUBE_LINUX_SHA256=$(awk '{ print $1 }' out/minikube-linux-amd64.sha256)
+REPLACE_MINIKUBE_DARWIN_SHA256=$(awk '{ print $1 }' out/minikube-darwin-amd64.sha256)
+REPLACE_CASK_CHECKPOINT=$(curl \
+                        --compressed \
+                        --location   \
+                        --user-agent 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36' \
+                        https://github.com/kubernetes/minikube/releases.atom \
+                        | sed 's|<pubDate>[^<]*</pubDate>||g' \
+                        | shasum -a 256 | awk '{ print $1 }')
+MINIKUBE_ROOT=$PWD
+
+GIT_SSH_COMMAND='ssh -i $ARCH_SSH_KEY' git clone ssh://aur@aur.archlinux.org/minikube.git aur-minikube
+pushd aur-minikube >/dev/null
+    sed -e "s/\$PKG_VERSION/${REPLACE_PKG_VERSION}/g" \
+        -e "s/\$MINIKUBE_LINUX_SHA256/${REPLACE_MINIKUBE_LINUX_SHA256}/g" \
+        $MINIKUBE_ROOT/installers/linux/archlinux/PKGBUILD > PKGBUILD
+    sed -e "s/\$PKG_VERSION/${REPLACE_PKG_VERSION}/g" \
+        -e "s/\$MINIKUBE_LINUX_SHA256/${REPLACE_MINIKUBE_LINUX_SHA256}/g" \
+        $MINIKUBE_ROOT/installers/linux/archlinux/.SRCINFO > .SRCINFO
+    git add PKGBUILD .SRCINFO
+    git commit -m "Upgrade to version ${REPLACE_PKG_VERSION}"
+
+    GIT_SSH_COMMAND='ssh -i $ARCH_SSH_KEY' git push origin master
+
+popd >/dev/null
+
+git clone --depth 1 git@github.com:minikube-bot/homebrew-cask.git # dont't pull entire history
+
+pushd homebrew-cask >/dev/null
+    git checkout -b ${REPLACE_PKG_VERSION}
+    sed -e "s/\$PKG_VERSION/${REPLACE_PKG_VERSION}/g" \
+        -e "s/\$MINIKUBE_DARWIN_SHA256/${REPLACE_MINIKUBE_DARWIN_SHA256}/g" \
+        -e "s/\$CASK_CHECKPOINT/${REPLACE_CASK_CHECKPOINT}/g" \
+        $MINIKUBE_ROOT/installers/darwin/brew-cask/minikube.rb.tmpl > Casks/minikube.rb
+    git add Casks/minikube.rb
+    git commit -F- <<EOF
+Update minikube to ${REPLACE_PKG_VERSION}
+
+- [x] brew cask audit --download {{cask_file}} is error-free.
+- [x] brew cask style --fix {{cask_file}} reports no offenses.
+- [x] The commit message includes the cask’s name and version.
+
+EOF
+    git push origin ${REPLACE_PKG_VERSION}
+    curl -v -k -u minikube-bot:${BOT_PASSWORD} -X POST https://api.github.com/repos/caskroom/homebrew-cask/pulls \
+    -d @- <<EOF
+
+{
+    "title": "Update minikube to ${REPLACE_PKG_VERSION}",
+    "head": "minikube-bot:${REPLACE_PKG_VERSION}",
+    "base": "master"
+}
+
+EOF
+popd >/dev/null
+
+rm -rf aur-minikube homebrew-cask

--- a/installers/darwin/brew-cask/minikube.rb.tmpl
+++ b/installers/darwin/brew-cask/minikube.rb.tmpl
@@ -1,0 +1,18 @@
+cask 'minikube' do
+  version '$PKG_VERSION'
+  sha256 '$MINIKUBE_DARWIN_SHA256'
+
+  # storage.googleapis.com/minikube was verified as official when first introduced to the cask
+  url "https://storage.googleapis.com/minikube/releases/v#{version}/minikube-darwin-amd64"
+  appcast 'https://github.com/kubernetes/minikube/releases.atom',
+          checkpoint: '$CASK_CHECKPOINT'
+  name 'Minikube'
+  homepage 'https://github.com/kubernetes/minikube'
+
+  depends_on formula: 'kubernetes-cli'
+  container type: :naked
+
+  binary 'minikube-darwin-amd64', target: 'minikube'
+
+  zap delete: '~/.minikube'
+end

--- a/installers/linux/archlinux/.SRCINFO
+++ b/installers/linux/archlinux/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = minikube
 	pkgdesc = Minikube is a tool that makes it easy to run Kubernetes locally
-	pkgver = 0.18.0
+	pkgver = $PKG_VERSION
 	pkgrel = 1
 	url = https://github.com/kubernetes/minikube
 	arch = x86_64
@@ -9,8 +9,8 @@ pkgbase = minikube
 	optdepends = kubectl-bin: to manage the cluster
 	optdepends = virtualbox
 	optdepends = docker-machine-kvm
-	source = minikube_0.17.1::https://storage.googleapis.com/minikube/releases/v0.17.1/minikube-linux-amd64
-	sha256sums = c1dd2eb704ec29000d2c6080ca18660b862eedf0eb1c933aed746e93e6e5adea
+	source = minikube_$PKG_VERSION::https://storage.googleapis.com/minikube/releases/v$PKG_VERSION/minikube-linux-amd64
+	sha256sums = $MINIKUBE_LINUX_SHA256
 
 pkgname = minikube
 

--- a/installers/linux/archlinux/PKGBUILD
+++ b/installers/linux/archlinux/PKGBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Matt Rickard <mrick@google.com> 
 
 pkgname=minikube
-pkgver=0.18.0
+pkgver=$PKG_VERSION
 pkgrel=1
 pkgdesc="Minikube is a tool that makes it easy to run Kubernetes locally"
 url="https://github.com/kubernetes/minikube"
@@ -19,7 +19,7 @@ optdepends=(
 makedepends=()
 
 source=(minikube_$pkgver::https://storage.googleapis.com/minikube/releases/v$pkgver/minikube-linux-amd64)
-sha256sums=('c1dd2eb704ec29000d2c6080ca18660b862eedf0eb1c933aed746e93e6e5adea')
+sha256sums=('$MINIKUBE_LINUX_SHA256')
 package() {
   cd "$srcdir"
   install -d "$pkgdir/usr/bin"


### PR DESCRIPTION
Automatically updates the AUR installer and pushes the new package.
Updates the brew installer and sends a PR to the brew package repo.

I've tested this as much as I can locally. I wasn't able to test to the actual PR curl request.

I think we can add this at the end of our release job. 