### PR TITLE
Fixed flags to use 9p syntax for uid and gid

### DIFF
--- a/pkg/minikube/cluster/commands.go
+++ b/pkg/minikube/cluster/commands.go
@@ -233,7 +233,7 @@ func GetMountCleanupCommand(path string) string {
 
 var mountTemplate = `
 sudo mkdir -p {{.Path}} || true;
-sudo mount -t 9p -o trans=tcp -o port={{.Port}} -o uid={{.UID}} -o gid={{.GID}} {{.IP}} {{.Path}};
+sudo mount -t 9p -o trans=tcp -o port={{.Port}} -o dfltuid={{.UID}} -o dfltgid={{.GID}} {{.IP}} {{.Path}};
 sudo chmod 775 {{.Path}};`
 
 func GetMountCommand(ip net.IP, path, port string, uid, gid int) (string, error) {


### PR DESCRIPTION
It seems that 9p uses a different syntax for the UID and GID than other protocols.  With this change, the mounted directories correctly owned by the docker user in the VM and not "none".  The GID value does not appear to be respected though (still "none"), this might require additional tweaks to the server.