### PR TITLE
Disable virtualbox host mounting by default

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -177,6 +177,10 @@ var settings = []Setting{
 		name: useVendoredDriver,
 		set:  SetBool,
 	},
+	{
+		name: "disable-driver-mounts",
+		set:  SetBool,
+	},
 }
 
 var ConfigCmd = &cobra.Command{

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -61,6 +61,7 @@ const (
 	apiServerName         = "apiserver-name"
 	dnsDomain             = "dns-domain"
 	mountString           = "mount-string"
+	disableDriverMounts   = "disable-driver-mounts"
 )
 
 var (
@@ -116,6 +117,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		HypervVirtualSwitch: viper.GetString(hypervVirtualSwitch),
 		KvmNetwork:          viper.GetString(kvmNetwork),
 		Downloader:          pkgutil.DefaultDownloader{},
+		DisableDriverMounts: viper.GetBool(disableDriverMounts),
 	}
 
 	fmt.Printf("Starting local Kubernetes %s cluster...\n", viper.GetString(kubernetesVersion))
@@ -288,6 +290,7 @@ func init() {
 	startCmd.Flags().Bool(keepContext, constants.DefaultKeepContext, "This will keep the existing kubectl context and will create a minikube context.")
 	startCmd.Flags().Bool(createMount, false, "This will start the mount daemon and automatically mount files into minikube")
 	startCmd.Flags().String(mountString, constants.DefaultMountDir+":"+constants.DefaultMountEndpoint, "The argument to pass the minikube mount command on start")
+	startCmd.Flags().Bool(disableDriverMounts, false, "Disables the filesystem mounts provided by the hypervisors (vboxfs, xhyve-9p)")
 	startCmd.Flags().String(isoURL, constants.DefaultIsoUrl, "Location of the minikube iso")
 	startCmd.Flags().String(vmDriver, constants.DefaultVMDriver, fmt.Sprintf("VM driver is one of: %v", constants.SupportedVMDrivers))
 	startCmd.Flags().Int(memory, constants.DefaultMemory, "Amount of RAM allocated to the minikube VM")

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -341,6 +341,7 @@ func createVirtualboxHost(config MachineConfig) drivers.Driver {
 	d.CPU = config.CPUs
 	d.DiskSize = int(config.DiskSize)
 	d.HostOnlyCIDR = config.HostOnlyCIDR
+	d.NoShare = config.DisableDriverMounts
 	return d
 }
 

--- a/pkg/minikube/cluster/cluster_darwin.go
+++ b/pkg/minikube/cluster/cluster_darwin.go
@@ -58,6 +58,7 @@ type xhyveDriver struct {
 }
 
 func createXhyveHost(config MachineConfig) *xhyveDriver {
+	useVirtio9p := !config.DisableDriverMounts
 	return &xhyveDriver{
 		BaseDriver: &drivers.BaseDriver{
 			MachineName: cfg.GetMachineName(),
@@ -68,6 +69,8 @@ func createXhyveHost(config MachineConfig) *xhyveDriver {
 		Boot2DockerURL: config.Downloader.GetISOFileURI(config.MinikubeISO),
 		BootCmd:        "loglevel=3 user=docker console=ttyS0 console=tty0 noembed nomodeset norestore waitusb=10 systemd.legacy_systemd_cgroup_controller=yes base host=" + cfg.GetMachineName(),
 		DiskSize:       int64(config.DiskSize),
+		Virtio9p:       useVirtio9p,
+		Virtio9pFolder: "/Users",
 		QCow2:          false,
 		RawDisk:        config.XhyveDiskDriver == "virtio-blk",
 	}

--- a/pkg/minikube/cluster/types.go
+++ b/pkg/minikube/cluster/types.go
@@ -34,6 +34,7 @@ type MachineConfig struct {
 	KvmNetwork          string // Only used by the KVM driver
 	Downloader          util.ISODownloader
 	DockerOpt           []string // Each entry is formatted as KEY=VALUE.
+	DisableDriverMounts bool     // Only used by virtualbox and xhyve
 }
 
 // KubernetesConfig contains the parameters used to configure the VM Kubernetes.


### PR DESCRIPTION
Users can still set up manual mounts through vbox using the vboxmanage
command or GUI.  Users can also utilized the built in `minikube mount`
command.

This is a bit of a hack, since the mounting is attempted in the driver, but it won't work without these extra steps in the image.

Fixes #1645 