### PR TITLE
Added wait and interval time flags to minikube service command

### DIFF
--- a/cmd/minikube/cmd/config/open.go
+++ b/cmd/minikube/cmd/config/open.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/cluster"
+	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/machine"
 	"k8s.io/minikube/pkg/minikube/service"
 )
@@ -34,6 +35,8 @@ var (
 	addonsURLMode     bool
 	addonsURLFormat   string
 	addonsURLTemplate *template.Template
+	wait              int
+	interval          int
 )
 
 const defaultAddonsFormatTemplate = "http://{{.IP}}:{{.Port}}"
@@ -101,7 +104,8 @@ You can add one by annotating a service with the label %s:%s
 		}
 		for i := range serviceList.Items {
 			svc := serviceList.Items[i].ObjectMeta.Name
-			service.WaitAndMaybeOpenService(api, namespace, svc, addonsURLTemplate, addonsURLMode, https)
+			service.WaitAndMaybeOpenService(api, namespace, svc, addonsURLTemplate,
+				addonsURLMode, https, wait, interval)
 
 		}
 	},
@@ -110,7 +114,8 @@ You can add one by annotating a service with the label %s:%s
 func init() {
 	addonsOpenCmd.Flags().BoolVar(&addonsURLMode, "url", false, "Display the kubernetes addons URL in the CLI instead of opening it in the default browser")
 	addonsOpenCmd.Flags().BoolVar(&https, "https", false, "Open the addons URL with https instead of http")
-
+	addonsOpenCmd.Flags().IntVar(&wait, "wait", constants.DefaultWait, "Amount of time to wait for service in seconds")
+	addonsOpenCmd.Flags().IntVar(&interval, "interval", constants.DefaultInterval, "The time interval for each check that wait performs in seconds")
 	addonsOpenCmd.PersistentFlags().StringVar(&addonsURLFormat, "format", defaultAddonsFormatTemplate, "Format to output addons URL in.  This format will be applied to each url individually and they will be printed one at a time.")
 	AddonsCmd.AddCommand(addonsOpenCmd)
 }

--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/minikube/pkg/minikube/cluster"
+	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/machine"
 	"k8s.io/minikube/pkg/minikube/service"
 )
@@ -35,6 +36,8 @@ var (
 	serviceURLMode     bool
 	serviceURLFormat   string
 	serviceURLTemplate *template.Template
+	wait               int
+	interval           int
 )
 
 // serviceCmd represents the service command
@@ -68,7 +71,8 @@ var serviceCmd = &cobra.Command{
 		defer api.Close()
 
 		cluster.EnsureMinikubeRunningOrExit(api, 1)
-		err = service.WaitAndMaybeOpenService(api, namespace, svc, serviceURLTemplate, serviceURLMode, https)
+		err = service.WaitAndMaybeOpenService(api, namespace, svc,
+			serviceURLTemplate, serviceURLMode, https, wait, interval)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error opening service: %s\n", err)
 			os.Exit(1)
@@ -80,6 +84,8 @@ func init() {
 	serviceCmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "The service namespace")
 	serviceCmd.Flags().BoolVar(&serviceURLMode, "url", false, "Display the kubernetes service URL in the CLI instead of opening it in the default browser")
 	serviceCmd.Flags().BoolVar(&https, "https", false, "Open the service URL with https instead of http")
+	serviceCmd.Flags().IntVar(&wait, "wait", constants.DefaultWait, "Amount of time to wait for a service in seconds")
+	serviceCmd.Flags().IntVar(&interval, "interval", constants.DefaultWait, "The time interval for each check that wait performs in seconds")
 
 	serviceCmd.PersistentFlags().StringVar(&serviceURLFormat, "format", defaultServiceFormatTemplate, "Format to output service URL in. This format will be applied to each url individually and they will be printed one at a time.")
 

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -96,6 +96,8 @@ const (
 	DefaultConfigViewFormat   = "- {{.ConfigKey}}: {{.ConfigValue}}\n"
 	GithubMinikubeReleasesURL = "https://storage.googleapis.com/minikube/releases.json"
 	KubernetesVersionGCSURL   = "https://storage.googleapis.com/minikube/k8s_releases.json"
+	DefaultWait               = 20
+	DefaultInterval           = 6
 )
 
 var DefaultIsoUrl = fmt.Sprintf("https://storage.googleapis.com/%s/minikube-%s.iso", minikubeVersion.GetIsoPath(), minikubeVersion.GetIsoVersion())

--- a/pkg/minikube/service/service.go
+++ b/pkg/minikube/service/service.go
@@ -217,8 +217,9 @@ func checkEndpointReady(endpoints corev1.EndpointsInterface, service string) err
 	return nil
 }
 
-func WaitAndMaybeOpenService(api libmachine.API, namespace string, service string, urlTemplate *template.Template, urlMode bool, https bool) error {
-	if err := util.RetryAfter(20, func() error { return CheckService(namespace, service) }, 6*time.Second); err != nil {
+func WaitAndMaybeOpenService(api libmachine.API, namespace string, service string, urlTemplate *template.Template, urlMode bool, https bool,
+	wait int, interval int) error {
+	if err := util.RetryAfter(wait, func() error { return CheckService(namespace, service) }, time.Duration(interval)*time.Second); err != nil {
 		return errors.Wrapf(err, "Could not find finalized endpoint being pointed to by %s", service)
 	}
 


### PR DESCRIPTION
This might be useful for users trying to automate services coming up with minikube.