### PR TITLE
Do dockerized builds for minikube and localkube

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,11 @@ DEB_VERSION ?= $(VERSION_MAJOR).$(VERSION_MINOR)-$(VERSION_BUILD)
 INSTALL_SIZE ?= $(shell du out/minikube-windows-amd64.exe | cut -f1)
 BUILDROOT_BRANCH ?= 2017.02
 REGISTRY?=gcr.io/k8s-minikube
-DARWIN_BUILD_IMAGE ?= karalabe/xgo-1.8.3
+
+MINIKUBE_BUILD_IMAGE 	?= karalabe/xgo-1.8.3
+LOCALKUBE_BUILD_IMAGE 	?= gcr.io/google_containers/kube-cross:v1.7.1-0
 ISO_BUILD_IMAGE ?= $(REGISTRY)/buildroot-image
 
-# The iso will be versioned the same as minikube
 ISO_VERSION ?= v0.20.0
 ISO_BUCKET ?= minikube/iso
 
@@ -33,13 +34,6 @@ GOARCH ?= $(shell go env GOARCH)
 BUILD_DIR ?= ./out
 ORG := k8s.io
 REPOPATH ?= $(ORG)/minikube
-BUILD_IMAGE ?= gcr.io/google_containers/kube-cross:v1.7.1-0
-IS_EXE ?=
-
-ifeq ($(IN_DOCKER),1)
-	GOPATH := /go
-	export GOPATH
-endif
 
 # Use system python if it exists, otherwise use Docker.
 PYTHON := $(shell command -v python || echo "docker run --rm -it -v $(shell pwd):/minikube -w /minikube python python")
@@ -58,31 +52,58 @@ LOCALKUBE_LDFLAGS := "$(K8S_VERSION_LDFLAGS) $(MINIKUBE_LDFLAGS) -s -w -extldfla
 LOCALKUBEFILES := GOPATH=$(GOPATH) go list  -f '{{join .Deps "\n"}}' ./cmd/localkube/ | grep k8s.io | GOPATH=$(GOPATH) xargs go list -f '{{ range $$file := .GoFiles }} {{$$.Dir}}/{{$$file}}{{"\n"}}{{end}}'
 MINIKUBEFILES := GOPATH=$(GOPATH) go list  -f '{{join .Deps "\n"}}' ./cmd/minikube/ | grep k8s.io | GOPATH=$(GOPATH) xargs go list -f '{{ range $$file := .GoFiles }} {{$$.Dir}}/{{$$file}}{{"\n"}}{{end}}'
 
+MINIKUBE_ENV_LINUX   := CGO_ENABLED=1 GOARCH=amd64 GOOS=linux
+MINIKUBE_ENV_DARWIN  := CC=o64-clang CXX=o64-clang++ CGO_ENABLED=1 GOARCH=amd64 GOOS=darwin
+MINIKUBE_ENV_WINDOWS := CGO_ENABLED=0 GOARCH=amd64 GOOS=windows
+
+MINIKUBE_DOCKER_CMD := docker run -e IN_DOCKER=1 --user $(shell id -u):$(shell id -g) --workdir /go/src/$(REPOPATH) --entrypoint /bin/bash -v $(PWD):/go/src/$(REPOPATH) $(MINIKUBE_BUILD_IMAGE) -c
+KUBE_CROSS_DOCKER_CMD := docker run -w /go/src/$(REPOPATH) --user $(shell id -u):$(shell id -g) -e IN_DOCKER=1 -v $(shell pwd):/go/src/$(REPOPATH) $(LOCALKUBE_BUILD_IMAGE)
+
+# $(call MINIKUBE_GO_BUILD_CMD, output file, OS)
+define MINIKUBE_GO_BUILD_CMD
+	$($(shell echo MINIKUBE_ENV_$(2) | tr a-z A-Z)) go build --installsuffix cgo -ldflags="$(MINIKUBE_LDFLAGS) $(K8S_VERSION_LDFLAGS)" -a -o $(1) k8s.io/minikube/cmd/minikube
+endef
+
+ifeq ($(BUILD_IN_DOCKER),y)
+	MINIKUBE_BUILD_IN_DOCKER=y
+	LOCALKUBE_BUILD_IN_DOCKER=y
+endif
+
+# If not on linux, localkube must be built in docker
+ifneq ($(BUILD_OS),Linux)
+	LOCALKUBE_BUILD_IN_DOCKER=y
+endif
+
+# If we are already running in docker, 
+# prevent recursion by unsetting the BUILD_IN_DOCKER directives.
+# The _BUILD_IN_DOCKER variables should not be modified after this conditional.
+ifeq ($(IN_DOCKER),1)
+	MINIKUBE_BUILD_IN_DOCKER=n
+	LOCALKUBE_BUILD_IN_DOCKER=n
+endif
+
 ifeq ($(GOOS),windows)
 	IS_EXE = ".exe"
 endif
 out/minikube$(IS_EXE): out/minikube-$(GOOS)-$(GOARCH)$(IS_EXE)
-	cp $(BUILD_DIR)/minikube-$(GOOS)-$(GOARCH)$(IS_EXE) $(BUILD_DIR)/minikube$(IS_EXE)
+	cp $(BUILD_DIR)/minikube-$(GOOS)-$(GOARCH) $(BUILD_DIR)/minikube$(IS_EXE)
 
 out/localkube: $(shell $(LOCALKUBEFILES))
-ifeq ($(BUILD_OS),Linux)
+ifeq ($(LOCALKUBE_BUILD_IN_DOCKER),y)
+	$(KUBE_CROSS_DOCKER_CMD) make $@
+else
 	CGO_ENABLED=1 go build -tags static_build -ldflags=$(LOCALKUBE_LDFLAGS) -o $(BUILD_DIR)/localkube ./cmd/localkube
-else
-	docker run -w /go/src/$(REPOPATH) -e IN_DOCKER=1 -v $(shell pwd):/go/src/$(REPOPATH) $(BUILD_IMAGE) make out/localkube
 endif
 
-out/minikube-darwin-amd64: pkg/minikube/assets/assets.go $(shell $(MINIKUBEFILES))
-ifeq ($(IN_DOCKER),1)
-	CC=o64-clang CXX=o64-clang++ CGO_ENABLED=1 GOARCH=amd64 GOOS=darwin go build --installsuffix cgo -ldflags="$(MINIKUBE_LDFLAGS) $(K8S_VERSION_LDFLAGS)" -a -o $(BUILD_DIR)/minikube-darwin-amd64 k8s.io/minikube/cmd/minikube
+out/minikube-windows-amd64.exe: out/minikube-windows-amd64
+	mv out/minikube-windows-amd64 out/minikube-windows-amd64.exe
+
+out/minikube-%-amd64: pkg/minikube/assets/assets.go $(shell $(MINIKUBEFILES))
+ifeq ($(MINIKUBE_BUILD_IN_DOCKER),y)
+	$(MINIKUBE_DOCKER_CMD) '$(call MINIKUBE_GO_BUILD_CMD,$@,$*)'
 else
-	docker run -e IN_DOCKER=1 --workdir /go/src/$(REPOPATH) --entrypoint /usr/bin/make -v $(PWD):/go/src/$(REPOPATH) $(DARWIN_BUILD_IMAGE) out/minikube-darwin-amd64
+	$(call MINIKUBE_GO_BUILD_CMD,$@,$*)
 endif
-
-out/minikube-linux-amd64: pkg/minikube/assets/assets.go $(shell $(MINIKUBEFILES))
-	CGO_ENABLED=1 GOARCH=amd64 GOOS=linux go build --installsuffix cgo -ldflags="$(MINIKUBE_LDFLAGS) $(K8S_VERSION_LDFLAGS)" -a -o $(BUILD_DIR)/minikube-linux-amd64 k8s.io/minikube/cmd/minikube
-
-out/minikube-windows-amd64.exe: pkg/minikube/assets/assets.go $(shell $(MINIKUBEFILES))
-	CGO_ENABLED=0 GOARCH=amd64 GOOS=windows go build --installsuffix cgo -ldflags="$(MINIKUBE_LDFLAGS) $(K8S_VERSION_LDFLAGS)" -a -o $(BUILD_DIR)/minikube-windows-amd64.exe k8s.io/minikube/cmd/minikube
 
 minikube_iso: # old target kept for making tests happy
 	echo $(ISO_VERSION) > deploy/iso/minikube-iso/board/coreos/minikube/rootfs-overlay/etc/VERSION

--- a/docs/contributors/releasing_minikube.md
+++ b/docs/contributors/releasing_minikube.md
@@ -40,7 +40,7 @@ Send a PR for the Makefile change and wait until it is merged.  Once the commit 
 Run this command:
 
 ```shell
-make cross checksum
+BUILD_IN_DOCKER=y make cross checksum
 ```
 
 ## Add the version to the releases.json file

--- a/hack/jenkins/minikube_cross_build_and_upload.sh
+++ b/hack/jenkins/minikube_cross_build_and_upload.sh
@@ -38,7 +38,7 @@ fi
 export GOPATH=~/go
 
 # Build all platforms (Windows, Linux, OSX)
-make cross
+BUILD_IN_DOCKER=y make cross
 
 # Build the e2e test target for Darwin and Linux. We don't run tests on Windows yet.
 # We build these on Linux, but run the tests on different platforms.

--- a/hack/jenkins/release_build_and_upload.sh
+++ b/hack/jenkins/release_build_and_upload.sh
@@ -38,7 +38,7 @@ cat Makefile | grep "VERSION_MINOR ?=" | grep $VERSION_MINOR
 cat Makefile | grep "VERSION_BUILD ?=" | grep $VERSION_BUILD
 
 # Build and upload
-make cross checksum
+BUILD_IN_DOCKER=y make cross checksum
 
 gsutil cp out/minikube-linux-amd64 gs://$BUCKET/releases/$TAGNAME/
 gsutil cp out/minikube-linux-amd64.sha256 gs://$BUCKET/releases/$TAGNAME/


### PR DESCRIPTION
BUILD_IN_DOCKER=y will build both localkube and minikube in docker
LOCALKUBE_BUILD_IN_DOCKER=y, MINIKUBE_BUILD_IN_DOCKER=y will toggle docker builds for each
respective binary

Regardless of the options provided, if you attempt to build localkube on a
non-linux platform, it will run in docker.  This ensures that `make`
still works as expected on darwin.

The only thing that I couldn't get working was the extra platform detection when cross building.  So BUILD_IN_DOCKER=y is required when `make cross`.  Any suggestions on how to avoid that would be great

I originally planned something like `ifneq(,$(or $(filter $(MINIKUBE_BUILD_IN_DOCKER),y),$(filter-out $(BUILD_OS),$*)))`, but automatic variables like `$*` aren't expanded in GNU make conditionals.  

We might want to just move a lot of this to bash for simplicity and debugging.