### PR TITLE
Move kubecfg utils from minikube to util.

### DIFF
--- a/cmd/localkube/cmd/options.go
+++ b/cmd/localkube/cmd/options.go
@@ -37,7 +37,7 @@ func NewLocalkubeServer() *localkube.LocalkubeServer {
 		LocalkubeDirectory:       util.DefaultLocalkubeDirectory,
 		ServiceClusterIPRange:    *defaultServiceClusterIPRange,
 		APIServerAddress:         net.ParseIP("0.0.0.0"),
-		APIServerPort:            constants.APIServerPort,
+		APIServerPort:            util.APIServerPort,
 		APIServerInsecureAddress: net.ParseIP("127.0.0.1"),
 		APIServerInsecurePort:    8080,
 		APIServerName:            constants.APIServerName,

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -35,11 +35,11 @@ import (
 	"k8s.io/minikube/pkg/minikube/cluster"
 	cfg "k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
-	"k8s.io/minikube/pkg/minikube/kubeconfig"
 	"k8s.io/minikube/pkg/minikube/kubernetes_versions"
 	"k8s.io/minikube/pkg/minikube/machine"
 	"k8s.io/minikube/pkg/util"
 	pkgutil "k8s.io/minikube/pkg/util"
+	"k8s.io/minikube/pkg/util/kubeconfig"
 )
 
 const (
@@ -177,7 +177,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		glog.Errorln("Error connecting to cluster: ", err)
 	}
 	kubeHost = strings.Replace(kubeHost, "tcp://", "https://", -1)
-	kubeHost = strings.Replace(kubeHost, ":2376", ":"+strconv.Itoa(constants.APIServerPort), -1)
+	kubeHost = strings.Replace(kubeHost, ":2376", ":"+strconv.Itoa(pkgutil.APIServerPort), -1)
 
 	fmt.Println("Setting up kubeconfig...")
 	// setup kubeconfig
@@ -257,7 +257,7 @@ You will need to move the files to the appropriate location and then set the cor
 	sudo chgrp -R $USER $HOME/.minikube 
 This can also be done automatically by setting the env var CHANGE_MINIKUBE_NONE_USER=true`)
 		}
-		if err := cmdUtil.MaybeChownDirRecursiveToMinikubeUser(constants.GetMinipath()); err != nil {
+		if err := util.MaybeChownDirRecursiveToMinikubeUser(constants.GetMinipath()); err != nil {
 			glog.Errorf("Error recursively changing ownership of directory %s: %s",
 				constants.GetMinipath(), err)
 			cmdUtil.MaybeReportErrorAndExit(err)

--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -26,9 +26,10 @@ import (
 	"github.com/spf13/cobra"
 	cmdUtil "k8s.io/minikube/cmd/util"
 	"k8s.io/minikube/pkg/minikube/cluster"
+	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
-	kcfg "k8s.io/minikube/pkg/minikube/kubeconfig"
 	"k8s.io/minikube/pkg/minikube/machine"
+	"k8s.io/minikube/pkg/util/kubeconfig"
 )
 
 var statusFormat string
@@ -71,7 +72,7 @@ var statusCmd = &cobra.Command{
 				glog.Errorln("Error host driver ip status:", err)
 				cmdUtil.MaybeReportErrorAndExit(err)
 			}
-			kstatus, err := kcfg.GetKubeConfigStatus(ip, constants.KubeconfigPath)
+			kstatus, err := kubeconfig.GetKubeConfigStatus(ip, constants.KubeconfigPath, config.GetMachineName())
 			if err != nil {
 				glog.Errorln("Error kubeconfig status:", err)
 				cmdUtil.MaybeReportErrorAndExit(err)

--- a/cmd/minikube/cmd/update-context.go
+++ b/cmd/minikube/cmd/update-context.go
@@ -24,9 +24,10 @@ import (
 	"github.com/spf13/cobra"
 	cmdUtil "k8s.io/minikube/cmd/util"
 	"k8s.io/minikube/pkg/minikube/cluster"
+	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
-	kcfg "k8s.io/minikube/pkg/minikube/kubeconfig"
 	"k8s.io/minikube/pkg/minikube/machine"
+	kcfg "k8s.io/minikube/pkg/util/kubeconfig"
 )
 
 // updateContextCmd represents the update-context command
@@ -47,7 +48,7 @@ var updateContextCmd = &cobra.Command{
 			glog.Errorln("Error host driver ip status:", err)
 			cmdUtil.MaybeReportErrorAndExit(err)
 		}
-		kstatus, err := kcfg.UpdateKubeconfigIP(ip, constants.KubeconfigPath)
+		kstatus, err := kcfg.UpdateKubeconfigIP(ip, constants.KubeconfigPath, config.GetMachineName())
 		if err != nil {
 			glog.Errorln("Error kubeconfig status:", err)
 			cmdUtil.MaybeReportErrorAndExit(err)

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -27,7 +27,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -246,35 +245,4 @@ func KillMountProcess() error {
 		return errors.Wrap(err, "error converting mount string to pid")
 	}
 	return mountProc.Kill()
-}
-
-func MaybeChownDirRecursiveToMinikubeUser(dir string) error {
-	if os.Getenv("CHANGE_MINIKUBE_NONE_USER") != "" && os.Getenv("SUDO_USER") != "" {
-		username := os.Getenv("SUDO_USER")
-		usr, err := user.Lookup(username)
-		if err != nil {
-			return errors.Wrap(err, "Error looking up user")
-		}
-		uid, err := strconv.Atoi(usr.Uid)
-		if err != nil {
-			return errors.Wrapf(err, "Error parsing uid for user: %s", username)
-		}
-		gid, err := strconv.Atoi(usr.Gid)
-		if err != nil {
-			return errors.Wrapf(err, "Error parsing gid for user: %s", username)
-		}
-		if err := ChownR(dir, uid, gid); err != nil {
-			return errors.Wrapf(err, "Error changing ownership for: %s", dir)
-		}
-	}
-	return nil
-}
-
-func ChownR(path string, uid, gid int) error {
-	return filepath.Walk(path, func(name string, info os.FileInfo, err error) error {
-		if err == nil {
-			err = os.Chown(name, uid, gid)
-		}
-		return err
-	})
 }

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -29,7 +29,6 @@ import (
 
 // APIServerPort is the port that the API server should listen on.
 const (
-	APIServerPort    = 8443
 	APIServerName    = "minikubeCA"
 	ClusterDNSDomain = "cluster.local"
 )

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -18,6 +18,7 @@ package util
 
 // These constants are used by both minikube and localkube
 const (
+	APIServerPort             = 8443
 	DefaultLocalkubeDirectory = "/var/lib/localkube"
 	DefaultCertPath           = DefaultLocalkubeDirectory + "/certs/"
 	DefaultServiceClusterIP   = "10.0.0.1"

--- a/pkg/util/kubeconfig/config_test.go
+++ b/pkg/util/kubeconfig/config_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 
 	"k8s.io/client-go/tools/clientcmd/api"
-	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/util"
 )
 
 var fakeKubeCfg = []byte(`
@@ -211,7 +211,7 @@ func TestGetKubeConfigStatus(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			t.Parallel()
 			configFilename := tempFile(t, test.existing)
-			statusActual, err := GetKubeConfigStatus(test.ip, configFilename)
+			statusActual, err := GetKubeConfigStatus(test.ip, configFilename, "minikube")
 			if err != nil && !test.err {
 				t.Errorf("Got unexpected error: %s", err)
 			}
@@ -268,7 +268,7 @@ func TestUpdateKubeconfigIP(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			t.Parallel()
 			configFilename := tempFile(t, test.existing)
-			statusActual, err := UpdateKubeconfigIP(test.ip, configFilename)
+			statusActual, err := UpdateKubeconfigIP(test.ip, configFilename, "minikube")
 			if err != nil && !test.err {
 				t.Errorf("Got unexpected error: %s", err)
 			}
@@ -355,7 +355,7 @@ func TestGetIPFromKubeConfig(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			configFilename := tempFile(t, test.cfg)
-			ip, err := getIPFromKubeConfig(configFilename)
+			ip, err := getIPFromKubeConfig(configFilename, "minikube")
 			if err != nil && !test.err {
 				t.Errorf("Got unexpected error: %s", err)
 			}
@@ -395,7 +395,7 @@ func minikubeConfig(config *api.Config) {
 	// cluster
 	clusterName := "minikube"
 	cluster := api.NewCluster()
-	cluster.Server = "https://192.168.99.100:" + strconv.Itoa(constants.APIServerPort)
+	cluster.Server = "https://192.168.99.100:" + strconv.Itoa(util.APIServerPort)
 	cluster.CertificateAuthority = "/home/tux/.minikube/apiserver.crt"
 	config.Clusters[clusterName] = cluster
 

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -23,6 +23,9 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -170,4 +173,35 @@ func IsDirectory(path string) (bool, error) {
 		return false, errors.Wrapf(err, "Error calling os.Stat on file %s", path)
 	}
 	return fileInfo.IsDir(), nil
+}
+
+func ChownR(path string, uid, gid int) error {
+	return filepath.Walk(path, func(name string, info os.FileInfo, err error) error {
+		if err == nil {
+			err = os.Chown(name, uid, gid)
+		}
+		return err
+	})
+}
+
+func MaybeChownDirRecursiveToMinikubeUser(dir string) error {
+	if os.Getenv("CHANGE_MINIKUBE_NONE_USER") != "" && os.Getenv("SUDO_USER") != "" {
+		username := os.Getenv("SUDO_USER")
+		usr, err := user.Lookup(username)
+		if err != nil {
+			return errors.Wrap(err, "Error looking up user")
+		}
+		uid, err := strconv.Atoi(usr.Uid)
+		if err != nil {
+			return errors.Wrapf(err, "Error parsing uid for user: %s", username)
+		}
+		gid, err := strconv.Atoi(usr.Gid)
+		if err != nil {
+			return errors.Wrapf(err, "Error parsing gid for user: %s", username)
+		}
+		if err := ChownR(dir, uid, gid); err != nil {
+			return errors.Wrapf(err, "Error changing ownership for: %s", dir)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
We'll need to also write a kubecfg inside the VM going forward as we remove the InsecureServing path.

Ref #1628 