### PR TITLE
Add message before waiting for the VM IP address

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -136,9 +136,10 @@ func runStart(cmd *cobra.Command, args []string) {
 		cmdUtil.MaybeReportErrorAndExit(err)
 	}
 
+	fmt.Println("Getting VM IP address...")
 	ip, err := host.Driver.GetIP()
 	if err != nil {
-		glog.Errorln("Error starting host: ", err)
+		glog.Errorln("Error getting VM IP address: ", err)
 		cmdUtil.MaybeReportErrorAndExit(err)
 	}
 	kubernetesConfig := cluster.KubernetesConfig{


### PR DESCRIPTION
Retrieving the IP address depends on guest/host communication channels (e.g. KVP on Hyper-V) that might fail.
This commit adds a message that can help the user in troubleshooting potential issues: #1598