### PR TITLE
Remove show-libmachine-logs, use-vendored-driver

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -29,8 +29,6 @@ import (
 	"k8s.io/minikube/pkg/minikube/constants"
 )
 
-const useVendoredDriver = "use-vendored-driver"
-
 type setFn func(string, string) error
 
 type Setting struct {
@@ -172,10 +170,6 @@ var settings = []Setting{
 	{
 		name: "hyperv-virtual-switch",
 		set:  SetString,
-	},
-	{
-		name: useVendoredDriver,
-		set:  SetBool,
 	},
 	{
 		name: "disable-driver-mounts",

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	goflag "flag"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"runtime"
@@ -47,11 +46,6 @@ var dirs = [...]string{
 	constants.MakeMiniPath("addons"),
 	constants.MakeMiniPath("logs"),
 }
-
-const (
-	showLibmachineLogs = "show-libmachine-logs"
-	useVendoredDriver  = "use-vendored-driver"
-)
 
 var (
 	enableUpdateNotification = true
@@ -84,13 +78,6 @@ var RootCmd = &cobra.Command{
 		// Log level 7 or greater enables debug level logs
 		if glog.V(7) {
 			log.SetDebug(true)
-		}
-
-		if viper.GetBool(showLibmachineLogs) {
-			fmt.Println(`
---show-libmachine-logs is deprecated.
-Please use --v=3 to show libmachine logs, and --v=7 for debug level libmachine logs
-`)
 		}
 
 		logDir := pflag.Lookup("log_dir")
@@ -129,8 +116,6 @@ func setFlagsUsingViper() {
 }
 
 func init() {
-	RootCmd.PersistentFlags().Bool(showLibmachineLogs, false, "Deprecated: To enable libmachine logs, set --v=3 or higher")
-	RootCmd.PersistentFlags().Bool(useVendoredDriver, false, "Use the vendored in drivers instead of RPC")
 	RootCmd.PersistentFlags().StringP(config.MachineProfile, "p", constants.DefaultMachineName, `The name of the minikube VM being used.  
 	This can be modified to allow for multiple minikube instances to be run independently`)
 	RootCmd.AddCommand(configCmd.ConfigCmd)


### PR DESCRIPTION
These flags don't do anything anymore.

`show-libmachine-logs` behavior is triggered by the log level `--v`

`use-vendored-driver` was a feature flag and now we default to vendored
drivers automatically when we can.