### PR TITLE
Restore some kube-proxy defaults

### DIFF
--- a/pkg/localkube/proxy.go
+++ b/pkg/localkube/proxy.go
@@ -19,6 +19,9 @@ package localkube
 import (
 	kubeproxy "k8s.io/kubernetes/cmd/kube-proxy/app"
 
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/apis/componentconfig"
 	"k8s.io/kubernetes/pkg/kubelet/qos"
@@ -36,8 +39,15 @@ func (lk LocalkubeServer) NewProxyServer() Server {
 func StartProxyServer(lk LocalkubeServer) func() error {
 	config := &componentconfig.KubeProxyConfiguration{
 		OOMScoreAdj: &OOMScoreAdj,
+		ClientConnection: componentconfig.ClientConnectionConfiguration{
+			Burst: 10,
+			QPS:   5,
+		},
+		ConfigSyncPeriod: v1.Duration{Duration: 15 * time.Minute},
 		IPTables: componentconfig.KubeProxyIPTablesConfiguration{
 			MasqueradeBit: &MasqueradeBit,
+			SyncPeriod:    v1.Duration{Duration: 30 * time.Second},
+			MinSyncPeriod: v1.Duration{Duration: 5 * time.Second},
 		},
 		BindAddress:  lk.APIServerInsecureAddress.String(),
 		Mode:         componentconfig.ProxyModeIPTables,


### PR DESCRIPTION
Set some kube-proxy defaults that got unset through the new way of
configuring kube-proxy.  Add more delay to the ip tables syncing reduces
idle CPU load a lot.

See
https://github.com/kubernetes/minikube/issues/1158#issuecomment-315308205

`$ ps uaxS | grep localkube`

Without these options
```
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root      3643 89.3 19.7 11469032 404500 ?     Ssl  18:04   0:55 /usr/local/bin/localkube --dns-domain=cluster.local --node-ip=192.168.99.101 --generate-certs=false --logtostderr
=true --enable-dns=false
```

With
```
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root      3901 13.4 13.0 11403508 267744 ?     Ssl  17:52   1:00 /usr/local/bin/localkube --dns-domain=cluster.local --node-ip=192.168.99.101 --generate-certs=false --logtostderr
=true --enable-dns=false
```