### PR TITLE
Add additional config options for registry-creds addon / Bump version

### DIFF
--- a/cmd/minikube/cmd/config/configure.go
+++ b/cmd/minikube/cmd/config/configure.go
@@ -48,6 +48,7 @@ var addonsConfigureCmd = &cobra.Command{
 			awsAccessKey := "changeme"
 			awsRegion := "changeme"
 			awsAccount := "changeme"
+			awsRole := "changeme"
 			gcrApplicationDefaultCredentials := "changeme"
 			dockerServer := "changeme"
 			dockerUser := "changeme"
@@ -59,6 +60,7 @@ var addonsConfigureCmd = &cobra.Command{
 				awsAccessKey = AskForStaticValue("-- Enter AWS Secret Access Key: ")
 				awsRegion = AskForStaticValue("-- Enter AWS Region: ")
 				awsAccount = AskForStaticValue("-- Enter 12 digit AWS Account ID: ")
+				awsRole = AskForStaticValue("-- (Optional) Enter ARN of AWS role to assume: ")
 			}
 
 			enableGCR := AskForYesNoConfirmation("\nDo you want to enable Google Container Registry?", posResponses, negResponses)
@@ -91,6 +93,7 @@ var addonsConfigureCmd = &cobra.Command{
 					"AWS_SECRET_ACCESS_KEY": awsAccessKey,
 					"aws-account":           awsAccount,
 					"aws-region":            awsRegion,
+					"aws-assume-role":       awsRole,
 				},
 				map[string]string{
 					"app":   "registry-creds",

--- a/deploy/addons/registry-creds/registry-creds-rc.yaml
+++ b/deploy/addons/registry-creds/registry-creds-rc.yaml
@@ -4,24 +4,24 @@ metadata:
   name: registry-creds
   namespace: kube-system
   labels:
-    version: v1.7
+    version: v1.8
     addonmanager.kubernetes.io/mode: Reconcile
     kubernetes.io/minikube-addons: registry-creds
 spec:
   replicas: 1
   selector:
     name: registry-creds
-    version: v1.7
+    version: v1.8
     addonmanager.kubernetes.io/mode: Reconcile
   template:
     metadata:
       labels:
         name: registry-creds
-        version: v1.7
+        version: v1.8
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:
-      - image: upmcenterprises/registry-creds:1.7
+      - image: upmcenterprises/registry-creds:1.8
         name: registry-creds
         imagePullPolicy: Always
         env:
@@ -40,11 +40,16 @@ spec:
               secretKeyRef:
                 name: registry-creds-ecr
                 key: aws-account
-          - name: awsregion
+          - name: aws_assume_role
             valueFrom:
               secretKeyRef:
                 name: registry-creds-ecr
-                key: aws-region
+                key: aws-assume-role
+          - name: awsaccount
+            valueFrom:
+              secretKeyRef:
+                name: registry-creds-ecr
+                key: aws-account
           - name: DOCKER_PRIVATE_REGISTRY_PASSWORD
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
There was a recent PR to registry-creds addon for AWS that allows you to assume an IAM role. This PR adds those config options to minikube as well as updates the version to include this change. 