### PR TITLE
cmd/minikube: delete accept no arguments

### DIFF
--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -33,6 +33,11 @@ var deleteCmd = &cobra.Command{
 	Long: `Deletes a local kubernetes cluster. This command deletes the VM, and removes all
 associated files.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) > 0 {
+			fmt.Fprintln(os.Stderr, "usage: minikube delete")
+			os.Exit(1)
+		}
+
 		fmt.Println("Deleting local Kubernetes cluster...")
 		api, err := machine.NewAPIClient()
 		if err != nil {


### PR DESCRIPTION
This changeset makes it necessary to pass a profile/machine name in order
to delete. This would help avoid accidental deletion of machine by just
delete command.

Fixes #1683 