### PR TITLE
Add ebtables package to localkube container

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -17,6 +17,7 @@ FROM debian:jessie
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y \
     && DEBIAN_FRONTEND=noninteractive apt-get -yy -q install \
     iptables \
+    ebtables \
     ethtool \
     ca-certificates \
     util-linux \


### PR DESCRIPTION
ebtables is needed for the kubenet network plugin.