### PR TITLE
Ensure we use the native SSH driver with docker machine.

### DIFF
--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -34,6 +34,7 @@ import (
 	"github.com/docker/machine/libmachine/engine"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/mcnerror"
+	"github.com/docker/machine/libmachine/ssh"
 	"github.com/docker/machine/libmachine/state"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
@@ -56,6 +57,8 @@ const fileScheme = "file"
 //see: https://github.com/kubernetes/kubernetes/blob/master/pkg/util/logs/logs.go#L32-34
 func init() {
 	flag.Set("logtostderr", "false")
+	// Setting the default client to native gives much better performance.
+	ssh.SetDefaultClient(ssh.Native)
 }
 
 // StartHost starts a host VM.


### PR DESCRIPTION
This gives me a huge speedup with the xhyve driver. I think some of the slowdown is host (laptop) dependent, but for me it's pretty massive.

The external SSH client is typically configured to try several different auth mechanisms, and the ssh server (the minikube VM) seems to penalize the SSH client by making it wait between auth retries.

Note though that we also need to set this inside standalone driver executables for the full performance benefit.

(output of time minikube start with the xhyve driver)

Both Native:
real	0m39.730s

Minikube with native, xhyve with external:
real	3m31.423s

Both External:
real	9m1.192s
