### PR TITLE
Don't default to kubenet network plugin

### DIFF
--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -152,6 +152,5 @@ func setupViper() {
 	viper.SetDefault(config.WantReportError, false)
 	viper.SetDefault(config.WantReportErrorPrompt, true)
 	viper.SetDefault(config.WantKubectlDownloadMsg, true)
-	viper.SetDefault("network-plugin", "kubenet")
 	setFlagsUsingViper()
 }


### PR DESCRIPTION
Hostports seem to require extra CNI configuration and the CNI hostport
plugin installed to work properly with kubenet.