### PR TITLE
fix(config): make ARN of AWS role input optional

### DIFF
--- a/cmd/minikube/cmd/config/configure.go
+++ b/cmd/minikube/cmd/config/configure.go
@@ -61,7 +61,7 @@ var addonsConfigureCmd = &cobra.Command{
 				awsAccessKey = AskForStaticValue("-- Enter AWS Secret Access Key: ")
 				awsRegion = AskForStaticValue("-- Enter AWS Region: ")
 				awsAccount = AskForStaticValue("-- Enter 12 digit AWS Account ID: ")
-				awsRole = AskForStaticValue("-- (Optional) Enter ARN of AWS role to assume: ")
+				awsRole = AskForStaticValueOptional("-- (Optional) Enter ARN of AWS role to assume: ")
 			}
 
 			enableGCR := AskForYesNoConfirmation("\nDo you want to enable Google Container Registry?", posResponses, negResponses)

--- a/cmd/minikube/cmd/config/prompt.go
+++ b/cmd/minikube/cmd/config/prompt.go
@@ -19,11 +19,12 @@ package config
 import (
 	"bufio"
 	"fmt"
-	"golang.org/x/crypto/ssh/terminal"
 	"io"
 	"log"
 	"os"
 	"strings"
+
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 // AskForYesNoConfirmation asks the user for confirmation. A user must type in "yes" or "no" and
@@ -59,22 +60,34 @@ func AskForStaticValue(s string) string {
 	reader := bufio.NewReader(os.Stdin)
 
 	for {
-		fmt.Printf("%s", s)
-
-		response, err := reader.ReadString('\n')
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		response = strings.TrimSpace(response)
+		response := getStaticValue(reader, s)
 
 		// Can't have zero length
 		if len(response) == 0 {
 			fmt.Println("--Error, please enter a value:")
-			return AskForStaticValue(s)
+			continue
 		}
 		return response
 	}
+}
+
+// AskForStaticValueOptional asks for a optional single value to enter, can just skip enter
+func AskForStaticValueOptional(s string) string {
+	reader := bufio.NewReader(os.Stdin)
+
+	return getStaticValue(reader, s)
+}
+
+func getStaticValue(reader *bufio.Reader, s string) string {
+	fmt.Printf("%s", s)
+
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	response = strings.TrimSpace(response)
+	return response
 }
 
 func concealableAskForStaticValue(readWriter io.ReadWriter, promptString string, hidden bool) (string, error) {


### PR DESCRIPTION
I use `minikube addons configure registry-creds`, the prompt `(Optional) Enter ARN of AWS role to assume:` is not really optional, like below:

```
-- (Optional) Enter ARN of AWS role to assume:
--Error, please enter a value:
-- (Optional) Enter ARN of AWS role to assume:
--Error, please enter a value:
-- (Optional) Enter ARN of AWS role to assume:
--Error, please enter a value:
-- (Optional) Enter ARN of AWS role to assume:
--Error, please enter a value:
-- (Optional) Enter ARN of AWS role to assume:
--Error, please enter a value:
```

When I check the source code, `AskForStaticValue` function has no optional feature, so I try to add this PR to fix this issue.

https://github.com/kubernetes/minikube/blob/master/cmd/minikube/cmd/config/configure.go#L64

```
if enableAWSECR {
    awsAccessID = AskForStaticValue("-- Enter AWS Access Key ID: ")
    awsAccessKey = AskForStaticValue("-- Enter AWS Secret Access Key: ")
    awsRegion = AskForStaticValue("-- Enter AWS Region: ")
    awsAccount = AskForStaticValue("-- Enter 12 digit AWS Account ID: ")
    awsRole = AskForStaticValue("-- (Optional) Enter ARN of AWS role to assume: ")
 }
```