### PR TITLE
readme: remove vendored driver flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ mkdir $HOME/.kube || true
 touch $HOME/.kube/config
 
 export KUBECONFIG=$HOME/.kube/config
-sudo -E ./minikube start --vm-driver=none --use-vendored-driver
+sudo -E ./minikube start --vm-driver=none
 
 # this for loop waits until kubectl can access the api server that minikube has created
 for i in {1..150} # timeout for 5 minutes


### PR DESCRIPTION
 `--use-vendored-driver` has been removed in `v0.21.0`