### PR TITLE
Delete the hyperlink of docker-env command.

### DIFF
--- a/docs/reusing_the_docker_daemon.md
+++ b/docs/reusing_the_docker_daemon.md
@@ -2,7 +2,7 @@
 
 When using a single VM of kubernetes it's really handy to reuse the Docker daemon inside the VM; as this means you don't have to build on your host machine and push the image into a docker registry - you can just build inside the same docker daemon as minikube which speeds up local experiments.
 
-To be able to work with the docker daemon on your mac/linux host use the [docker-env command](./docs/minikube_docker-env.md) in your shell:
+To be able to work with the docker daemon on your mac/linux host use the docker-env command in your shell:
 
 ```
 eval $(minikube docker-env)


### PR DESCRIPTION
"https://github.com/kubernetes/minikube/blob/master/docs/docs/minikube_docker-env.md" is gone.