### PR TITLE
fix(cmd/start): prevent k8s version downgrades

### DIFF
--- a/pkg/minikube/cluster/types.go
+++ b/pkg/minikube/cluster/types.go
@@ -31,10 +31,10 @@ type MachineConfig struct {
 	RegistryMirror      []string
 	HostOnlyCIDR        string // Only used by the virtualbox driver
 	HypervVirtualSwitch string
-	KvmNetwork          string // Only used by the KVM driver
-	Downloader          util.ISODownloader
-	DockerOpt           []string // Each entry is formatted as KEY=VALUE.
-	DisableDriverMounts bool     // Only used by virtualbox and xhyve
+	KvmNetwork          string             // Only used by the KVM driver
+	Downloader          util.ISODownloader `json:"-"`
+	DockerOpt           []string           // Each entry is formatted as KEY=VALUE.
+	DisableDriverMounts bool               // Only used by virtualbox and xhyve
 }
 
 // KubernetesConfig contains the parameters used to configure the VM Kubernetes.
@@ -47,4 +47,10 @@ type KubernetesConfig struct {
 	NetworkPlugin     string
 	FeatureGates      string
 	ExtraOptions      util.ExtraOptionSlice
+}
+
+// Config contains machine and k8s config
+type Config struct {
+	MachineConfig    MachineConfig
+	KubernetesConfig KubernetesConfig
 }

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -107,6 +107,11 @@ var DefaultKubernetesVersion = version.Get().GitVersion
 var ConfigFilePath = MakeMiniPath("config")
 var ConfigFile = MakeMiniPath("config", "config.json")
 
+// GetProfileFile returns the Minikube profile config file
+func GetProfileFile(profile string) string {
+	return filepath.Join(GetMinipath(), "profiles", profile, "config.json")
+}
+
 var LocalkubeDownloadURLPrefix = "https://storage.googleapis.com/minikube/k8sReleases/"
 var LocalkubeLinuxFilename = "localkube-linux-amd64"
 


### PR DESCRIPTION
- Create Config struct to store MachineConfig and KubernetesConfig as cluster
configuration.
- Write cluster configuration under $MINIKUBE_HOME/profiles/ directory
when a cluster is launched.
- Load the cluster configuration at `start` and compare the loaded k8s
version with the requested version. Prevent any version downgrade requests.

Proposing this as a solution for preventing cluster downgrade issue #1765 . This involves creating
`$MINIKUBE_HOME/profiles/` directory which, if accepted, can be helpful in tracking profiles #1716 .

```
$ ./out/minikube start --kubernetes-version v1.6.4
Starting local Kubernetes v1.6.4 cluster...
Starting VM...
Getting VM IP address...
Kubernetes version downgrade is not supported. Using version: v1.7.0
Moving files into cluster...
Setting up certs...
Starting cluster components...
Connecting to cluster...
Setting up kubeconfig...
Kubectl is now configured to use the cluster.
```

Fixes #1765 