### PR TITLE
Fix HyperV driver anchor link's by lowercasing

### DIFF
--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -11,7 +11,7 @@ the host PATH:
 
 * [KVM](#kvm-driver)
 * [xhyve](#xhyve-driver)
-* [HyperV](#HyperV-driver)
+* [HyperV](#hyperv-driver)
 
 #### KVM driver
 


### PR DESCRIPTION
Currently, clicking on that anchor doesn't take you to the right section.

Using

    https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#hyperv-driver

instead of

    https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#HyperV-driver

fixes that.