### PR TITLE
Add minikube logs request to ISSUE_TEMPLATE

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -32,8 +32,8 @@ explain why.
 
 **What you expected to happen**:
 
-
 **How to reproduce it** (as minimally and precisely as possible):
 
+**Output of `minikube logs` (if applicable)**:
 
 **Anything else do we need to know**:


### PR DESCRIPTION
This is usually the first thing that we ask users after they submit bug
reports.  In the future it might make sense to provide a convenience
method that uploads the logs to a GCS bucket, since they are sometimes
pretty long.