### PR TITLE
Add 'none' shell for docker-env output

### DIFF
--- a/cmd/minikube/cmd/env.go
+++ b/cmd/minikube/cmd/env.go
@@ -79,6 +79,10 @@ const (
 	bashUnsetPfx   = "unset "
 	bashUnsetSfx   = "\n"
 	bashUnsetDelim = ""
+
+	nonePfx   = ""
+	noneSfx   = "\n"
+	noneDelim = "="
 )
 
 var usageHintMap = map[string]string{
@@ -204,6 +208,11 @@ func shellCfgSet(api libmachine.API) (*ShellConfig, error) {
 		shellCfg.Prefix = emacsSetPfx
 		shellCfg.Suffix = emacsSetSfx
 		shellCfg.Delimiter = emacsSetDelim
+	case "none":
+		shellCfg.Prefix = nonePfx
+		shellCfg.Suffix = noneSfx
+		shellCfg.Delimiter = noneDelim
+		shellCfg.UsageHint = ""
 	default:
 		shellCfg.Prefix = bashSetPfx
 		shellCfg.Suffix = bashSetSfx
@@ -245,6 +254,11 @@ func shellCfgUnset() (*ShellConfig, error) {
 		shellCfg.Prefix = emacsUnsetPfx
 		shellCfg.Suffix = emacsUnsetSfx
 		shellCfg.Delimiter = emacsUnsetDelim
+	case "none":
+		shellCfg.Prefix = nonePfx
+		shellCfg.Suffix = noneSfx
+		shellCfg.Delimiter = noneDelim
+		shellCfg.UsageHint = ""
 	default:
 		shellCfg.Prefix = bashUnsetPfx
 		shellCfg.Suffix = bashUnsetSfx


### PR DESCRIPTION
This is for consumers who want the key/value output, but don't need the
shell directives.

Sample output

```
$ minikube docker-env --shell none
DOCKER_TLS_VERIFY=1
DOCKER_HOST=tcp://192.168.39.124:2376
DOCKER_CERT_PATH=/home/mrick/.minikube/certs
DOCKER_API_VERSION=1.23

$ minikube docker-env --shell none -u
DOCKER_TLS_VERIFY=
DOCKER_HOST=
DOCKER_CERT_PATH=
DOCKER_API_VERSION=
```

cc @loosebazooka