### PR TITLE
Feature: `xhyve` driver: Allow setting up multiple NFS shares on `minikube start`

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -52,6 +52,8 @@ const (
 	humanReadableDiskSize = "disk-size"
 	vmDriver              = "vm-driver"
 	xhyveDiskDriver       = "xhyve-disk-driver"
+	xhyveNFSSharesRoot    = "xhyve-nfs-shares-root"
+	xhyveNFSShare         = "xhyve-nfs-share"
 	kubernetesVersion     = "kubernetes-version"
 	hostOnlyCIDR          = "host-only-cidr"
 	containerRuntime      = "container-runtime"
@@ -121,6 +123,8 @@ func runStart(cmd *cobra.Command, args []string) {
 		KvmNetwork:          viper.GetString(kvmNetwork),
 		Downloader:          pkgutil.DefaultDownloader{},
 		DisableDriverMounts: viper.GetBool(disableDriverMounts),
+		XhyveNFSShares:      viper.GetStringSlice(xhyveNFSShare),
+		XhyveNFSSharesRoot:  viper.GetString(xhyveNFSSharesRoot),
 	}
 
 	fmt.Printf("Starting local Kubernetes %s cluster...\n", viper.GetString(kubernetesVersion))
@@ -348,6 +352,8 @@ func init() {
 		`A set of key=value pairs that describe configuration that may be passed to different components.
 		The key should be '.' separated, and the first part before the dot is the component to apply the configuration to.
 		Valid components are: kubelet, apiserver, controller-manager, etcd, proxy, scheduler.`)
+	startCmd.Flags().StringSlice(xhyveNFSShare, []string{}, "Local folders to share with the Guest via NFS mounts")
+	startCmd.Flags().String(xhyveNFSSharesRoot, "/xhyve-nfsshares", "Where to root the NFS Shares")
 	viper.BindPFlags(startCmd.Flags())
 	RootCmd.AddCommand(startCmd)
 }

--- a/pkg/minikube/cluster/cluster_darwin.go
+++ b/pkg/minikube/cluster/cluster_darwin.go
@@ -49,7 +49,9 @@ type xhyveDriver struct {
 	Memory         int
 	PrivateKeyPath string
 	UUID           string
-	NFSShare       bool
+	NFSShareEnable bool
+	NFSShares      []string
+	NFSSharesRoot  string
 	DiskNumber     int
 	Virtio9p       bool
 	Virtio9pFolder string
@@ -71,6 +73,9 @@ func createXhyveHost(config MachineConfig) *xhyveDriver {
 		DiskSize:       int64(config.DiskSize),
 		Virtio9p:       useVirtio9p,
 		Virtio9pFolder: "/Users",
+		NFSShareEnable: true,
+		NFSSharesRoot:  config.XhyveNFSSharesRoot,
+		NFSShares:      config.XhyveNFSShares,
 		QCow2:          false,
 		RawDisk:        config.XhyveDiskDriver == "virtio-blk",
 	}

--- a/pkg/minikube/cluster/types.go
+++ b/pkg/minikube/cluster/types.go
@@ -35,6 +35,8 @@ type MachineConfig struct {
 	Downloader          util.ISODownloader `json:"-"`
 	DockerOpt           []string           // Each entry is formatted as KEY=VALUE.
 	DisableDriverMounts bool               // Only used by virtualbox and xhyve
+	XhyveNFSShares      []string
+	XhyveNFSSharesRoot  string
 }
 
 // KubernetesConfig contains the parameters used to configure the VM Kubernetes.


### PR DESCRIPTION
The `xhyve` driver recently added the possibility of mounting multiple NFS shares inside a docker-machine (https://github.com/zchee/docker-machine-driver-xhyve/pull/121)

This PR allows `minikube` users to share multiple Host folders inside the `minikube` Guest via NFS.

However, it might be wise to wait for a PR in the `xhyve` driver (https://github.com/zchee/docker-machine-driver-xhyve/pull/195) to be merged first before merging this PR.

https://github.com/zchee/docker-machine-driver-xhyve/pull/195 fixes a bug in `xhyve` that makes it so that a `minikube` user using `xhyve` will only see her NFS mounts after doing a `minikube stop` followed by a `minikube start`.
