### PR TITLE
Feature: `xhyve` driver: Allow setting up multiple Virtio9p shares on `minikube start`

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -55,6 +55,8 @@ const (
 	xhyveDiskDriver       = "xhyve-disk-driver"
 	xhyveNFSSharesRoot    = "xhyve-nfs-shares-root"
 	xhyveNFSShare         = "xhyve-nfs-share"
+	xhyveVirtio9pRoot     = "xhyve-virtio-9p-root"
+	xhyveVirtio9p         = "xhyve-virtio-9p"
 	kubernetesVersion     = "kubernetes-version"
 	hostOnlyCIDR          = "host-only-cidr"
 	containerRuntime      = "container-runtime"
@@ -140,6 +142,8 @@ func runStart(cmd *cobra.Command, args []string) {
 		DisableDriverMounts: viper.GetBool(disableDriverMounts),
 		XhyveNFSShares:      viper.GetStringSlice(xhyveNFSShare),
 		XhyveNFSSharesRoot:  viper.GetString(xhyveNFSSharesRoot),
+		XhyveVirtio9p:       viper.GetStringSlice(xhyveVirtio9p),
+		XhyveVirtio9pRoot:   viper.GetString(xhyveVirtio9pRoot),
 	}
 
 	fmt.Printf("Starting local Kubernetes %s cluster...\n", viper.GetString(kubernetesVersion))
@@ -378,6 +382,8 @@ func init() {
 		Valid components are: kubelet, apiserver, controller-manager, etcd, proxy, scheduler.`)
 	startCmd.Flags().StringSlice(xhyveNFSShare, []string{}, "Local folders to share with the Guest via NFS mounts")
 	startCmd.Flags().String(xhyveNFSSharesRoot, "/xhyve-nfsshares", "Where to root the NFS Shares")
+	startCmd.Flags().StringSlice(xhyveVirtio9p, []string{}, "Local folders to share with the Guest via Virtio9p mounts")
+	startCmd.Flags().String(xhyveVirtio9pRoot, "/xhyve-virtio9p", "Where to root the Virtio9p Shares")
 	viper.BindPFlags(startCmd.Flags())
 	RootCmd.AddCommand(startCmd)
 }

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -53,6 +53,8 @@ const (
 	humanReadableDiskSize = "disk-size"
 	vmDriver              = "vm-driver"
 	xhyveDiskDriver       = "xhyve-disk-driver"
+	xhyveNFSSharesRoot    = "xhyve-nfs-shares-root"
+	xhyveNFSShare         = "xhyve-nfs-share"
 	kubernetesVersion     = "kubernetes-version"
 	hostOnlyCIDR          = "host-only-cidr"
 	containerRuntime      = "container-runtime"
@@ -136,6 +138,8 @@ func runStart(cmd *cobra.Command, args []string) {
 		KvmNetwork:          viper.GetString(kvmNetwork),
 		Downloader:          pkgutil.DefaultDownloader{},
 		DisableDriverMounts: viper.GetBool(disableDriverMounts),
+		XhyveNFSShares:      viper.GetStringSlice(xhyveNFSShare),
+		XhyveNFSSharesRoot:  viper.GetString(xhyveNFSSharesRoot),
 	}
 
 	fmt.Printf("Starting local Kubernetes %s cluster...\n", viper.GetString(kubernetesVersion))
@@ -372,6 +376,8 @@ func init() {
 		`A set of key=value pairs that describe configuration that may be passed to different components.
 		The key should be '.' separated, and the first part before the dot is the component to apply the configuration to.
 		Valid components are: kubelet, apiserver, controller-manager, etcd, proxy, scheduler.`)
+	startCmd.Flags().StringSlice(xhyveNFSShare, []string{}, "Local folders to share with the Guest via NFS mounts")
+	startCmd.Flags().String(xhyveNFSSharesRoot, "/xhyve-nfsshares", "Where to root the NFS Shares")
 	viper.BindPFlags(startCmd.Flags())
 	RootCmd.AddCommand(startCmd)
 }

--- a/pkg/minikube/cluster/cluster_darwin.go
+++ b/pkg/minikube/cluster/cluster_darwin.go
@@ -54,8 +54,8 @@ type xhyveDriver struct {
 	NFSShares      []string
 	NFSSharesRoot  string
 	DiskNumber     int
-	Virtio9p       bool
-	Virtio9pFolder string
+	Virtio9p       []string
+	Virtio9pRoot   string
 	QCow2          bool
 	RawDisk        bool
 }
@@ -76,7 +76,6 @@ func createHyperkitHost(config MachineConfig) *hyperkit.Driver {
 }
 
 func createXhyveHost(config MachineConfig) *xhyveDriver {
-	useVirtio9p := !config.DisableDriverMounts
 	return &xhyveDriver{
 		BaseDriver: &drivers.BaseDriver{
 			MachineName: cfg.GetMachineName(),
@@ -87,8 +86,8 @@ func createXhyveHost(config MachineConfig) *xhyveDriver {
 		Boot2DockerURL: config.Downloader.GetISOFileURI(config.MinikubeISO),
 		BootCmd:        "loglevel=3 user=docker console=ttyS0 console=tty0 noembed nomodeset norestore waitusb=10 systemd.legacy_systemd_cgroup_controller=yes base host=" + cfg.GetMachineName(),
 		DiskSize:       int64(config.DiskSize),
-		Virtio9p:       useVirtio9p,
-		Virtio9pFolder: "/Users",
+		Virtio9p:       config.XhyveVirtio9p,
+		Virtio9pRoot:   config.XhyveVirtio9pRoot,
 		NFSShareEnable: true,
 		NFSSharesRoot:  config.XhyveNFSSharesRoot,
 		NFSShares:      config.XhyveNFSShares,

--- a/pkg/minikube/cluster/cluster_darwin.go
+++ b/pkg/minikube/cluster/cluster_darwin.go
@@ -50,7 +50,9 @@ type xhyveDriver struct {
 	Memory         int
 	PrivateKeyPath string
 	UUID           string
-	NFSShare       bool
+	NFSShareEnable bool
+	NFSShares      []string
+	NFSSharesRoot  string
 	DiskNumber     int
 	Virtio9p       bool
 	Virtio9pFolder string
@@ -87,6 +89,9 @@ func createXhyveHost(config MachineConfig) *xhyveDriver {
 		DiskSize:       int64(config.DiskSize),
 		Virtio9p:       useVirtio9p,
 		Virtio9pFolder: "/Users",
+		NFSShareEnable: true,
+		NFSSharesRoot:  config.XhyveNFSSharesRoot,
+		NFSShares:      config.XhyveNFSShares,
 		QCow2:          false,
 		RawDisk:        config.XhyveDiskDriver == "virtio-blk",
 	}

--- a/pkg/minikube/cluster/types.go
+++ b/pkg/minikube/cluster/types.go
@@ -40,6 +40,8 @@ type MachineConfig struct {
 	DisableDriverMounts bool               // Only used by virtualbox and xhyve
 	XhyveNFSShares      []string
 	XhyveNFSSharesRoot  string
+	XhyveVirtio9p       []string
+	XhyveVirtio9pRoot   string
 }
 
 // Config contains machine and k8s config

--- a/pkg/minikube/cluster/types.go
+++ b/pkg/minikube/cluster/types.go
@@ -38,6 +38,8 @@ type MachineConfig struct {
 	Downloader          util.ISODownloader `json:"-"`
 	DockerOpt           []string           // Each entry is formatted as KEY=VALUE.
 	DisableDriverMounts bool               // Only used by virtualbox and xhyve
+	XhyveNFSShares      []string
+	XhyveNFSSharesRoot  string
 }
 
 // Config contains machine and k8s config


### PR DESCRIPTION
Note: This PR is dependent on the merging of a PR in the `xhyve`'s driver project: https://github.com/zchee/docker-machine-driver-xhyve/pull/194

Once https://github.com/zchee/docker-machine-driver-xhyve/pull/194 is merged, this PR will give the opportunity to `minikube` users to share multiple Host folders inside the `minikube` Guest using `virtio9p`