### PR TITLE
Set dist:precise on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 os: linux
+dist: precise
 
 go:
   - 1.8.3


### PR DESCRIPTION
We've encountered some flakes on the new travis trust build slaves.
Setting it back to dist:precise to see if this fixes them.