### PR TITLE
Fix the none driver with insecure serving.

### DIFF
--- a/deploy/addons/addon-manager.yaml
+++ b/deploy/addons/addon-manager.yaml
@@ -46,5 +46,5 @@ spec:
       path: /etc/kubernetes/
     name: addons
   - hostPath:
-      path: /var/lib/localkube
+      path: /var/lib/localkube/
     name: kubeconfig


### PR DESCRIPTION
There's a race condition where the kubelet starts up before this directory
gets created. If you create a HostPath volume without a trailing / on a path
that doesn't exist, it looks like something treats it as a file instead of a
directory.