### PR TITLE
Don't check error on hack/ remove docker images

### DIFF
--- a/hack/jenkins/minikube_cross_build_and_upload.sh
+++ b/hack/jenkins/minikube_cross_build_and_upload.sh
@@ -24,7 +24,7 @@
 set -e
 
 # Clean up exited containers
-docker rm $(docker ps -q -f status=exited)
+docker rm $(docker ps -q -f status=exited) || true
 
 gsutil cp gs://minikube-builds/logs/index.html gs://minikube-builds/logs/${ghprbPullId}/index.html
 


### PR DESCRIPTION
Sometimes there aren't any to remove.

Since we've added a few new jobs that don't get run on every PR yet, sometimes this command runs without any image being produced, and makes jenkins cross build fail.