### PR TITLE
Remove 30 second wait from start stop

### DIFF
--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -47,10 +47,6 @@ func TestStartStop(t *testing.T) {
 		t.Fatalf("IP command returned an invalid address: %s", ip)
 	}
 
-	// TODO:r2d4 The KVM driver can't handle
-	// starting and stopping immediately
-	time.Sleep(30 * time.Second)
-
 	checkStop := func() error {
 		runner.RunCommand("stop", true)
 		return runner.CheckStatusNoFail(state.Stopped.String())


### PR DESCRIPTION
I removed this awhile ago, but I'm not sure how it snuck back in.
The original issue was that the VM was getting a new IP, but the driver
was parsing the leases file and still picking the old IP.  So the only
way to fix it was to wait for the old lease to expire.