### PR TITLE
Clean up running containers for none driver

### DIFF
--- a/hack/jenkins/linux_integration_tests_none.sh
+++ b/hack/jenkins/linux_integration_tests_none.sh
@@ -33,5 +33,9 @@ EXTRA_BUILD_ARGS="$EXTRA_BUILD_ARGS --use-vendored-driver"
 SUDO_PREFIX="sudo -E "
 export KUBECONFIG="/root/.kube/config"
 
+# Clean up running docker containers on the test slave
+docker stop $(docker ps -aq) || true
+docker rm $(docker ps -aq) || true
+
 # Download files and set permissions
 source common.sh


### PR DESCRIPTION
If containers are running from a previous run of the none driver, the
subsequent test runs will fail.