### PR TITLE
Refactor of retries in integration tests.

### DIFF
--- a/test/integration/cluster_dns_test.go
+++ b/test/integration/cluster_dns_test.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
-	commonutil "k8s.io/minikube/pkg/util"
 	"k8s.io/minikube/test/integration/util"
 )
 
@@ -44,7 +43,7 @@ func testClusterDNS(t *testing.T) {
 		return nil
 	}
 
-	if err := commonutil.RetryAfter(20, setupTest, 2*time.Second); err != nil {
+	if err := util.Retry(t, setupTest, 2*time.Second, 20); err != nil {
 		t.Fatal("Error setting up DNS test.")
 	}
 
@@ -54,7 +53,7 @@ func testClusterDNS(t *testing.T) {
 			var err error
 			p, err = kubectlRunner.GetPod(podName, "default")
 			if err != nil {
-				return &commonutil.RetriableError{Err: err}
+				return err
 			}
 		}
 
@@ -62,7 +61,7 @@ func testClusterDNS(t *testing.T) {
 			"nslookup", "kubernetes"})
 		dnsOutput := string(dnsByteArr)
 		if err != nil {
-			return &commonutil.RetriableError{Err: err}
+			return err
 		}
 
 		if !strings.Contains(dnsOutput, "10.0.0.1") || !strings.Contains(dnsOutput, "10.0.0.10") {
@@ -71,7 +70,7 @@ func testClusterDNS(t *testing.T) {
 		return nil
 	}
 
-	if err := commonutil.RetryAfter(40, dnsTest, 5*time.Second); err != nil {
+	if err := util.Retry(t, dnsTest, 5*time.Second, 20); err != nil {
 		t.Fatal("DNS lookup failed with error:", err)
 	}
 }

--- a/test/integration/cluster_env_test.go
+++ b/test/integration/cluster_env_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	commonutil "k8s.io/minikube/pkg/util"
 	"k8s.io/minikube/test/integration/util"
 )
 
@@ -46,11 +45,11 @@ func testClusterEnv(t *testing.T) {
 		cmd := exec.Command(path, "ps")
 		output, err = cmd.CombinedOutput()
 		if err != nil {
-			return &commonutil.RetriableError{Err: err}
+			return err
 		}
 		return nil
 	}
-	if err := commonutil.RetryAfter(5, dockerPs, 3*time.Second); err != nil {
+	if err := util.Retry(t, dockerPs, 3*time.Second, 5); err != nil {
 		t.Fatalf("Error running command: %s. Error: %s Output: %s", "docker ps", err, output)
 	}
 }

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -35,6 +35,7 @@ func TestFunctional(t *testing.T) {
 	// This one is not parallel, and ensures the cluster comes up
 	// before we run any other tests.
 	t.Run("Status", testClusterStatus)
+
 	t.Run("DNS", testClusterDNS)
 	t.Run("Logs", testClusterLogs)
 	t.Run("Addons", testAddons)

--- a/test/integration/pv_test.go
+++ b/test/integration/pv_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package integration
 
 import (
-	"errors"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -27,7 +26,6 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/storage"
-	commonutil "k8s.io/minikube/pkg/util"
 	"k8s.io/minikube/test/integration/util"
 )
 
@@ -53,10 +51,10 @@ func testProvisioning(t *testing.T) {
 		if len(scl.Items) > 0 {
 			return nil
 		}
-		return &commonutil.RetriableError{Err: errors.New("No default StorageClass yet.")}
+		return fmt.Errorf("No default StorageClass yet.")
 	}
 
-	if err := commonutil.RetryAfter(20, checkStorageClass, 5*time.Second); err != nil {
+	if err := util.Retry(t, checkStorageClass, 5*time.Second, 20); err != nil {
 		t.Fatalf("No default storage class: %s", err)
 	}
 
@@ -70,16 +68,16 @@ func testProvisioning(t *testing.T) {
 	checkStorage := func() error {
 		pvc := api.PersistentVolumeClaim{}
 		if err := kubectlRunner.RunCommandParseOutput(pvcCmd, &pvc); err != nil {
-			return &commonutil.RetriableError{Err: err}
+			return err
 		}
 		// The test passes if the volume claim gets bound.
 		if pvc.Status.Phase == "Bound" {
 			return nil
 		}
-		return &commonutil.RetriableError{Err: fmt.Errorf("PV not attached to PVC: %v", pvc)}
+		return fmt.Errorf("PV not attached to PVC: %v", pvc)
 	}
 
-	if err := commonutil.RetryAfter(5, checkStorage, 2*time.Second); err != nil {
+	if err := util.Retry(t, checkStorage, 2*time.Second, 5); err != nil {
 		t.Fatal("PV Creation failed with error:", err)
 	}
 

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/docker/machine/libmachine/state"
-	commonutil "k8s.io/minikube/pkg/util"
 	"k8s.io/minikube/test/integration/util"
 )
 
@@ -52,7 +51,7 @@ func TestStartStop(t *testing.T) {
 		return runner.CheckStatusNoFail(state.Stopped.String())
 	}
 
-	if err := commonutil.RetryAfter(6, checkStop, 5*time.Second); err != nil {
+	if err := util.Retry(t, checkStop, 5*time.Second, 6); err != nil {
 		t.Fatalf("timed out while checking stopped status: %s", err)
 	}
 

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -207,3 +207,15 @@ func (k *KubectlRunner) GetPod(name, namespace string) (*api.Pod, error) {
 	err := k.RunCommandParseOutput([]string{"get", "pod", name, "--namespace=" + namespace}, p)
 	return p, err
 }
+
+func Retry(t *testing.T, callback func() error, d time.Duration, attempts int) (err error) {
+	for i := 0; i < attempts; i++ {
+		err = callback()
+		if err == nil {
+			return nil
+		}
+		t.Logf("Error: %s, Retrying in %s. %d Retries remaining.", err, d, attempts-i)
+		time.Sleep(d)
+	}
+	return err
+}


### PR DESCRIPTION
This creates a new Retry method just for integration tests that doesn't rely on RetriableError. It also unifies logging so we should be able to get a much better idea of how long steps are taking in our runs.