### PR TITLE
Remove sudo:required from travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 os: linux
-sudo: required
 
 go:
   - 1.8.3


### PR DESCRIPTION
I'm hypothesizing that #1868 could have been causing our travis
troubles.

I'll let this run a few times and see if it breaks travis.  Not requiring sudo on our builds should speed up travis a lot.