### PR TITLE
Recover "awsregion" parameter for registry-creds addon

### DIFF
--- a/deploy/addons/registry-creds/registry-creds-rc.yaml
+++ b/deploy/addons/registry-creds/registry-creds-rc.yaml
@@ -45,11 +45,11 @@ spec:
               secretKeyRef:
                 name: registry-creds-ecr
                 key: aws-assume-role
-          - name: awsaccount
+          - name: awsregion
             valueFrom:
               secretKeyRef:
                 name: registry-creds-ecr
-                key: aws-account
+                key: aws-region
           - name: DOCKER_PRIVATE_REGISTRY_PASSWORD
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
It seems the "awsregion" parameter was removed in 8ba6f478761fdf30806aba2b20bc48b0bba86efe (#1711) unexpectedly.
It caused making incorrect awsecr-cred with unexpected aws region.

see also: https://github.com/kubernetes/minikube/issues/1757#issuecomment-318352439