### PR TITLE
Change cleanup command to accomodate swap disk

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -52,8 +52,8 @@ vboxmanage list vms \
 
 # Clean up xhyve disks
 hdiutil info \
-      | grep -v /dev/disk0 \
-      | grep /dev/ \
+      | egrep \/dev\/disk[1-9][^s] \
+      | awk '{print $1}' \
       | xargs -I {} sh -c "hdiutil detach {}" \
       || true
 


### PR DESCRIPTION
Hyperkit was mounting swap disks, which we can't detach with the
hdiutil util like we're using.  Its sufficient to just hdiutil detach
/dev/disk1

```
/dev/disk1	FDisk_partition_scheme
/dev/disk1s1	Linux
/dev/disk1s2	Linux_Swap
```