### PR TITLE
Add makefile rule for linux-defconfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,13 @@ minikube_iso: # old target kept for making tests happy
 	$(MAKE) -C $(BUILD_DIR)/buildroot
 	mv $(BUILD_DIR)/buildroot/output/images/rootfs.iso9660 $(BUILD_DIR)/minikube.iso
 
+# Change the kernel configuration for the minikube ISO
+.PHONY: linux-menuconfig
+linux-menuconfig:
+	$(MAKE) -C $(BUILD_DIR)/buildroot linux-menuconfig
+	$(MAKE) -C $(BUILD_DIR)/buildroot linux-savedefconfig
+	cp $(BUILD_DIR)/buildroot/output/build/linux-4.9.13/defconfig deploy/iso/minikube-iso/board/coreos/minikube/linux-4.9_defconfig
+
 out/minikube.iso: $(shell find deploy/iso/minikube-iso -type f)
 ifeq ($(IN_DOCKER),1)
 	$(MAKE) minikube_iso

--- a/docs/contributors/minikube_iso.md
+++ b/docs/contributors/minikube_iso.md
@@ -52,18 +52,6 @@ $ make menuconfig
 $ make
 ```
 
-To change the kernel configuration, execute:
-
-```
-$ cd out/buildroot
-$ make linux-menuconfig
-$ make
-```
-
-The last commands copies changes made to the kernel configuration to the minikube-iso defconfig.
-
-### Saving buildroot/kernel configuration changes
-
 To save any buildroot configuration changes made with `make menuconfig`, execute:
 
 ```
@@ -79,13 +67,14 @@ $ git status
  M deploy/iso/minikube-iso/configs/minikube_defconfig
 ```
 
-To save any kernel configuration changes made with `make linux-menuconfig`, execute:
+### Saving buildroot/kernel configuration changes
+
+
+To make any kernel configuration changes and save them, execute:
 
 ```
-$ cd out/buildroot
-$ make linux-savedefconfig
-$ cp output/build/linux-4.9.13/defconfig \
-    ../../deploy/iso/minikube-iso/board/coreos/minikube/linux-4.9_defconfig
+$ make linux-menuconfig
 ```
 
-The changes will be reflected in the `deploy/iso/minikube-iso/configs/minikube_defconfig` file.
+This will open the kernel configuration menu, and then save your changes to our
+iso directory after they've been selected.


### PR DESCRIPTION
I find myself referencing this documentation every time I make kernel
configuration changes.  I've added a simple rule to open the kernel
configuration menu, and then save your changes to the right directory.