### PR TITLE
Setting authorization mode to RBAC by default

### DIFF
--- a/pkg/localkube/apiserver.go
+++ b/pkg/localkube/apiserver.go
@@ -46,6 +46,8 @@ func StartAPIServer(lk LocalkubeServer) func() error {
 
 	config.Authentication.ClientCert.ClientCA = lk.GetCAPublicKeyCertPath()
 
+	config.Authorization.Mode = "RBAC"
+
 	config.SecureServing.ServerCert.CertKey.CertFile = lk.GetPublicKeyCertPath()
 	config.SecureServing.ServerCert.CertKey.KeyFile = lk.GetPrivateKeyCertPath()
 	config.Admission.PluginNames = []string{

--- a/pkg/minikube/bootstrapper/localkube/privileges.go
+++ b/pkg/minikube/bootstrapper/localkube/privileges.go
@@ -2,11 +2,7 @@ package localkube
 
 import (
 	"github.com/pkg/errors"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/strategicpatch"
-	clientv1 "k8s.io/client-go/pkg/api/v1"
 	rbacv1beta1 "k8s.io/client-go/pkg/apis/rbac/v1beta1"
 	"k8s.io/minikube/pkg/minikube/service"
 )

--- a/pkg/minikube/bootstrapper/localkube/privileges.go
+++ b/pkg/minikube/bootstrapper/localkube/privileges.go
@@ -1,0 +1,41 @@
+package localkube
+
+import (
+	"github.com/pkg/errors"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	clientv1 "k8s.io/client-go/pkg/api/v1"
+	rbacv1beta1 "k8s.io/client-go/pkg/apis/rbac/v1beta1"
+	"k8s.io/minikube/pkg/minikube/service"
+)
+
+func elevateKubeSystemPrivileges() error {
+	k8s := service.K8sClientGetter{}
+	client, err := k8s.GetRBACV1Beta1Client()
+	if err != nil {
+		return err
+	}
+	clusterRoleBinding := &rbacv1beta1.ClusterRoleBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "minikube-rbac",
+		},
+		Subjects: []rbacv1beta1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "default",
+				Namespace: "kube-system",
+			},
+		},
+		RoleRef: rbacv1beta1.RoleRef{
+			Kind: "ClusterRole",
+			Name: "cluster-admin",
+		},
+	}
+
+	if _, err := client.ClusterRoleBindings().Create(clusterRoleBinding); err != nil {
+		return errors.Wrap(err, "creating clusterrolebinding")
+	}
+	return nil
+}


### PR DESCRIPTION
Fixes #1722

Before this change, `kubectl get clusterrole` and `kubectl get clusterrolebinding` -- both indicators that RBAC auth is enabled in the cluster -- returned nothing. After this change, the `./out/minikube start` command creates a cluster in which the following commands indicate that RBAC is turned on:

```console
$ k get clusterrole
NAME                                           AGE
admin                                          4m
cluster-admin                                  4m
edit                                           4m
system:auth-delegator                          4m
system:basic-user                              4m
system:controller:attachdetach-controller      4m
system:controller:certificate-controller       4m
system:controller:cronjob-controller           4m
system:controller:daemon-set-controller        4m
system:controller:deployment-controller        4m
system:controller:disruption-controller        4m
system:controller:endpoint-controller          4m
system:controller:generic-garbage-collector    4m
system:controller:horizontal-pod-autoscaler    4m
system:controller:job-controller               4m
system:controller:namespace-controller         4m
system:controller:node-controller              4m
system:controller:persistent-volume-binder     4m
system:controller:pod-garbage-collector        4m
system:controller:replicaset-controller        4m
system:controller:replication-controller       4m
system:controller:resourcequota-controller     4m
system:controller:route-controller             4m
system:controller:service-account-controller   4m
system:controller:service-controller           4m
system:controller:statefulset-controller       4m
system:controller:ttl-controller               4m
system:discovery                               4m
system:heapster                                4m
system:kube-aggregator                         4m
system:kube-controller-manager                 4m
system:kube-dns                                4m
system:kube-scheduler                          4m
system:node                                    4m
system:node-bootstrapper                       4m
system:node-problem-detector                   4m
system:node-proxier                            4m
system:persistent-volume-provisioner           4m
view                                           4m
$ kubectl get clusterrolebinding
NAME                                           AGE
cluster-admin                                  6m
system:basic-user                              6m
system:controller:attachdetach-controller      6m
system:controller:certificate-controller       6m
system:controller:cronjob-controller           6m
system:controller:daemon-set-controller        6m
system:controller:deployment-controller        6m
system:controller:disruption-controller        6m
system:controller:endpoint-controller          6m
system:controller:generic-garbage-collector    6m
system:controller:horizontal-pod-autoscaler    6m
system:controller:job-controller               6m
system:controller:namespace-controller         6m
system:controller:node-controller              6m
system:controller:persistent-volume-binder     6m
system:controller:pod-garbage-collector        6m
system:controller:replicaset-controller        6m
system:controller:replication-controller       6m
system:controller:resourcequota-controller     6m
system:controller:route-controller             6m
system:controller:service-account-controller   6m
system:controller:service-controller           6m
system:controller:statefulset-controller       6m
system:controller:ttl-controller               6m
system:discovery                               6m
system:kube-controller-manager                 6m
system:kube-dns                                6m
system:kube-scheduler                          6m
system:node                                    6m
system:node-proxier                            6m
```

This patch would slightly improve the [service-catalog installation process](https://github.com/kubernetes-incubator/service-catalog/blob/master/docs/install-1.7.md#rbac) which currently has to instruct users to pass `--extra-config=apiserver.Authorization.Mode=RBAC` to minikube installations. If minikube turned on RBAC by default, we could remove the minikube-specific section altogether, and the first-time installation process would be smoother for minikube users.