### PR TITLE
Removing the "no buildable source files" error on non-linux machines

### DIFF
--- a/cmd/drivers/kvm/main-nolinux.go
+++ b/cmd/drivers/kvm/main-nolinux.go
@@ -1,5 +1,21 @@
 // +build !linux
 
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/cmd/drivers/kvm/main-nolinux.go
+++ b/cmd/drivers/kvm/main-nolinux.go
@@ -1,0 +1,17 @@
+// +build !linux
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Println(
+		"this driver was built on a non-linux machine, so it is " +
+			"unavailable. Please re-build minikube on a linux machine to enable " +
+			"it.",
+	)
+	os.Exit(1)
+}


### PR DESCRIPTION
Before this patch, builds & tests did not fail, but showed this error when building on non-linux operating systems:

```
can't load package: package k8s.io/minikube/cmd/drivers/kvm: no buildable Go source files in /Users/aaschles/gocode/src/k8s.io/minikube/cmd/drivers/kvm
```

The issue was occurring because the only source file in `./cmd/drivers/kvm` had a linux-only build flag (`// +build linux`) on it. Effectively, that meant that there was an empty file in that directory on non-linux machines, and so that error arose.

This PR simply adds a Go file that exists on all _non_ linux builds. It builds a KVM driver binary that simply prints an error message and exit 1.