### PR TITLE
Adding optional aws_session_token to configuration options for registry-creds

### DIFF
--- a/cmd/minikube/cmd/config/configure.go
+++ b/cmd/minikube/cmd/config/configure.go
@@ -46,6 +46,7 @@ var addonsConfigureCmd = &cobra.Command{
 			// Default values
 			awsAccessID := "changeme"
 			awsAccessKey := "changeme"
+			awsSessionToken := ""
 			awsRegion := "changeme"
 			awsAccount := "changeme"
 			awsRole := "changeme"
@@ -59,6 +60,7 @@ var addonsConfigureCmd = &cobra.Command{
 			if enableAWSECR {
 				awsAccessID = AskForStaticValue("-- Enter AWS Access Key ID: ")
 				awsAccessKey = AskForStaticValue("-- Enter AWS Secret Access Key: ")
+				awsSessionToken = AskForStaticValueOptional("-- (Optional) Enter AWS Session Token: ")
 				awsRegion = AskForStaticValue("-- Enter AWS Region: ")
 				awsAccount = AskForStaticValue("-- Enter 12 digit AWS Account ID: ")
 				awsRole = AskForStaticValueOptional("-- (Optional) Enter ARN of AWS role to assume: ")
@@ -97,6 +99,7 @@ var addonsConfigureCmd = &cobra.Command{
 				map[string]string{
 					"AWS_ACCESS_KEY_ID":     awsAccessID,
 					"AWS_SECRET_ACCESS_KEY": awsAccessKey,
+					"AWS_SESSION_TOKEN":     awsSessionToken,
 					"aws-account":           awsAccount,
 					"aws-region":            awsRegion,
 					"aws-assume-role":       awsRole,

--- a/deploy/addons/registry-creds/registry-creds-rc.yaml
+++ b/deploy/addons/registry-creds/registry-creds-rc.yaml
@@ -35,6 +35,16 @@ spec:
               secretKeyRef:
                 name: registry-creds-ecr
                 key: AWS_SECRET_ACCESS_KEY
+          - name: AWS_SESSION_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: registry-creds-ecr
+                key: AWS_SESSION_TOKEN
+          - name: awsregion
+            valueFrom:
+              secretKeyRef:
+                name: registry-creds-ecr
+                key: aws-region
           - name: awsaccount
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
- Passthrough aws region to registry-creds plugin
- Add optional aws_session_token to configuration options for registry-creds for aws sts credentials