### PR TITLE
Integration test cleanup 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,15 +152,15 @@ test-iso:
 
 .PHONY: integration
 integration: out/minikube
-	go test -v -test.timeout=30m $(REPOPATH)/test/integration --tags="$(MINIKUBE_INTEGRATION_BUILD_TAGS)" --minikube-args="$(MINIKUBE_ARGS)"
+	go test -v -test.timeout=30m $(REPOPATH)/test/integration --tags="$(MINIKUBE_INTEGRATION_BUILD_TAGS)" $(TEST_ARGS)
 
 .PHONY: integration-none-driver
 integration-none-driver: e2e-linux-amd64 out/minikube-linux-amd64
-	sudo -E out/e2e-linux-amd64 -testdata-dir "test/integration/testdata" -minikube-args="--vm-driver=none --alsologtostderr" -test.v -test.timeout=30m -binary=out/minikube-linux-amd64
+	sudo -E out/e2e-linux-amd64 -testdata-dir "test/integration/testdata" -minikube-start-args="--vm-driver=none" -test.v -test.timeout=30m -binary=out/minikube-linux-amd64 $(TEST_ARGS)
 
 .PHONY: integration-versioned
 integration-versioned: out/minikube
-	go test -v -test.timeout=30m $(REPOPATH)/test/integration --tags="$(MINIKUBE_INTEGRATION_BUILD_TAGS) versioned" --minikube-args="$(MINIKUBE_ARGS)"
+	go test -v -test.timeout=30m $(REPOPATH)/test/integration --tags="$(MINIKUBE_INTEGRATION_BUILD_TAGS) versioned" $(TEST_ARGS)
 
 .PHONY: test
 test: pkg/minikube/assets/assets.go

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -83,7 +83,7 @@ find ~/.minikube || true
 
 # Allow this to fail, we'll switch on the return code below.
 set +e
-${SUDO_PREFIX}out/e2e-${OS_ARCH} -minikube-args="--vm-driver=${VM_DRIVER} --v=10 --logtostderr" -test.v -test.timeout=30m -binary=out/minikube-${OS_ARCH}
+${SUDO_PREFIX}out/e2e-${OS_ARCH} -minikube-start-args="--vm-driver=${VM_DRIVER}" -minikube-args="--v=10 --logtostderr ${EXTRA_ARGS}" -test.v -test.timeout=30m -binary=out/minikube-${OS_ARCH}
 result=$?
 set -e
 

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -44,11 +44,7 @@ func testAddons(t *testing.T) {
 
 func testDashboard(t *testing.T) {
 	t.Parallel()
-	minikubeRunner := util.MinikubeRunner{
-		BinaryPath: *binaryPath,
-		Args:       *args,
-		T:          t,
-	}
+	minikubeRunner := NewMinikubeRunner(t)
 
 	if err := util.WaitForDashboardRunning(t); err != nil {
 		t.Fatalf("waiting for dashboard to be up: %s", err)
@@ -73,10 +69,7 @@ func testDashboard(t *testing.T) {
 
 func testServicesList(t *testing.T) {
 	t.Parallel()
-	minikubeRunner := util.MinikubeRunner{
-		BinaryPath: *binaryPath,
-		Args:       *args,
-		T:          t}
+	minikubeRunner := NewMinikubeRunner(t)
 
 	checkServices := func() error {
 		output := minikubeRunner.RunCommand("service list", false)

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -27,17 +27,18 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
+	pkgutil "k8s.io/minikube/pkg/util"
 	"k8s.io/minikube/test/integration/util"
 )
 
 func testAddons(t *testing.T) {
 	t.Parallel()
-	client, err := util.GetClient()
+	client, err := pkgutil.GetClient()
 	if err != nil {
 		t.Fatalf("Could not get kubernetes client: %s", err)
 	}
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{"component": "kube-addon-manager"}))
-	if err := util.WaitForPodsWithLabelRunning(client, "kube-system", selector); err != nil {
+	if err := pkgutil.WaitForPodsWithLabelRunning(client, "kube-system", selector); err != nil {
 		t.Errorf("Error waiting for addon manager to be up")
 	}
 }

--- a/test/integration/cluster_env_test.go
+++ b/test/integration/cluster_env_test.go
@@ -29,10 +29,7 @@ import (
 func testClusterEnv(t *testing.T) {
 	t.Parallel()
 
-	minikubeRunner := util.MinikubeRunner{
-		Args:       *args,
-		BinaryPath: *binaryPath,
-		T:          t}
+	minikubeRunner := NewMinikubeRunner(t)
 
 	dockerEnvVars := minikubeRunner.RunCommand("docker-env", true)
 	if err := minikubeRunner.SetEnvFromEnvCmdOutput(dockerEnvVars); err != nil {

--- a/test/integration/cluster_logs_test.go
+++ b/test/integration/cluster_logs_test.go
@@ -21,19 +21,14 @@ package integration
 import (
 	"strings"
 	"testing"
-
-	"k8s.io/minikube/test/integration/util"
 )
 
 func testClusterLogs(t *testing.T) {
 	t.Parallel()
-	minikubeRunner := util.MinikubeRunner{
-		Args:       *args,
-		BinaryPath: *binaryPath,
-		T:          t}
+	minikubeRunner := NewMinikubeRunner(t)
 	minikubeRunner.EnsureRunning()
+	logsCmdOutput := minikubeRunner.GetLogs()
 
-	logsCmdOutput := minikubeRunner.RunCommand("logs", true)
 	//check for # of lines or check for strings
 	logWords := []string{"minikube", ".go"}
 	for _, logWord := range logWords {

--- a/test/integration/cluster_ssh_test.go
+++ b/test/integration/cluster_ssh_test.go
@@ -21,17 +21,11 @@ package integration
 import (
 	"strings"
 	"testing"
-
-	"k8s.io/minikube/test/integration/util"
 )
 
 func testClusterSSH(t *testing.T) {
 	t.Parallel()
-	minikubeRunner := util.MinikubeRunner{
-		Args:       *args,
-		BinaryPath: *binaryPath,
-		T:          t}
-
+	minikubeRunner := NewMinikubeRunner(t)
 	expectedStr := "hello"
 	sshCmdOutput := minikubeRunner.RunCommand("ssh echo "+expectedStr, true)
 	if !strings.Contains(sshCmdOutput, expectedStr) {

--- a/test/integration/docker_test.go
+++ b/test/integration/docker_test.go
@@ -22,22 +22,17 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-
-	"k8s.io/minikube/test/integration/util"
 )
 
 func TestDocker(t *testing.T) {
-	minikubeRunner := util.MinikubeRunner{
-		Args:       *args,
-		BinaryPath: *binaryPath,
-		T:          t}
+	minikubeRunner := NewMinikubeRunner(t)
 
-	if strings.Contains(*args, "--vm-driver=none") {
+	if strings.Contains(minikubeRunner.StartArgs, "--vm-driver=none") {
 		t.Skip("skipping test as none driver does not bundle docker")
 	}
 
 	minikubeRunner.RunCommand("delete", false)
-	startCmd := fmt.Sprintf("start %s %s", minikubeRunner.Args, "--docker-env=FOO=BAR --docker-env=BAZ=BAT --docker-opt=debug --docker-opt=icc=true")
+	startCmd := fmt.Sprintf("start %s %s %s", minikubeRunner.StartArgs, minikubeRunner.Args, "--docker-env=FOO=BAR --docker-env=BAZ=BAT --docker-opt=debug --docker-opt=icc=true")
 	minikubeRunner.RunCommand(startCmd, true)
 	minikubeRunner.EnsureRunning()
 

--- a/test/integration/flags.go
+++ b/test/integration/flags.go
@@ -20,6 +20,8 @@ import (
 	"flag"
 	"os"
 	"testing"
+
+	"k8s.io/minikube/test/integration/util"
 )
 
 func TestMain(m *testing.M) {
@@ -29,4 +31,14 @@ func TestMain(m *testing.M) {
 
 var binaryPath = flag.String("binary", "../../out/minikube", "path to minikube binary")
 var args = flag.String("minikube-args", "", "Arguments to pass to minikube")
+var startArgs = flag.String("minikube-start-args", "", "Arguments to pass to minikube start")
 var testdataDir = flag.String("testdata-dir", "testdata", "the directory relative to test/integration where the testdata lives")
+
+func NewMinikubeRunner(t *testing.T) util.MinikubeRunner {
+	return util.MinikubeRunner{
+		Args:       *args,
+		BinaryPath: *binaryPath,
+		StartArgs:  *startArgs,
+		T:          t,
+	}
+}

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -24,14 +24,10 @@ import (
 
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/machine"
-	"k8s.io/minikube/test/integration/util"
 )
 
 func TestFunctional(t *testing.T) {
-	minikubeRunner := util.MinikubeRunner{
-		BinaryPath: *binaryPath,
-		Args:       *args,
-		T:          t}
+	minikubeRunner := NewMinikubeRunner(t)
 	minikubeRunner.EnsureRunning()
 	integrationTestImages := []string{"busybox:glibc"}
 	if err := machine.CacheImages(integrationTestImages, constants.ImageCacheDir); err != nil {
@@ -51,7 +47,7 @@ func TestFunctional(t *testing.T) {
 	t.Run("ServicesList", testServicesList)
 	t.Run("Provisioning", testProvisioning)
 
-	if !strings.Contains(*args, "--vm-driver=none") {
+	if !strings.Contains(minikubeRunner.StartArgs, "--vm-driver=none") {
 		t.Run("EnvVars", testClusterEnv)
 		t.Run("SSH", testClusterSSH)
 		// t.Run("Mounting", testMounting)

--- a/test/integration/iso_test.go
+++ b/test/integration/iso_test.go
@@ -22,16 +22,11 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-
-	"k8s.io/minikube/test/integration/util"
 )
 
 func TestISO(t *testing.T) {
 
-	minikubeRunner := util.MinikubeRunner{
-		Args:       *args,
-		BinaryPath: *binaryPath,
-		T:          t}
+	minikubeRunner := NewMinikubeRunner(t)
 
 	minikubeRunner.RunCommand("delete", true)
 	minikubeRunner.Start()
@@ -42,10 +37,7 @@ func TestISO(t *testing.T) {
 }
 
 func testMountPermissions(t *testing.T) {
-	minikubeRunner := util.MinikubeRunner{
-		Args:       *args,
-		BinaryPath: *binaryPath,
-		T:          t}
+	minikubeRunner := NewMinikubeRunner(t)
 	// test mount permissions
 	mountPoints := []string{"/Users", "/hosthome"}
 	perms := "drwxr-xr-x"
@@ -67,10 +59,7 @@ func testMountPermissions(t *testing.T) {
 }
 
 func testPackages(t *testing.T) {
-	minikubeRunner := util.MinikubeRunner{
-		Args:       *args,
-		BinaryPath: *binaryPath,
-		T:          t}
+	minikubeRunner := NewMinikubeRunner(t)
 
 	packages := []string{
 		"git",
@@ -92,10 +81,7 @@ func testPackages(t *testing.T) {
 }
 
 func testPersistence(t *testing.T) {
-	minikubeRunner := util.MinikubeRunner{
-		Args:       *args,
-		BinaryPath: *binaryPath,
-		T:          t}
+	minikubeRunner := NewMinikubeRunner(t)
 
 	for _, dir := range []string{
 		"/data",

--- a/test/integration/mount_test.go
+++ b/test/integration/mount_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
+	pkgutil "k8s.io/minikube/pkg/util"
 	"k8s.io/minikube/test/integration/util"
 )
 
@@ -76,12 +77,12 @@ func testMounting(t *testing.T) {
 		t.Fatal("mountTest failed with error:", err)
 	}
 
-	client, err := util.GetClient()
+	client, err := pkgutil.GetClient()
 	if err != nil {
 		t.Fatalf("getting kubernetes client: %s", err)
 	}
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{"integration-test": "busybox-mount"}))
-	if err := util.WaitForPodsWithLabelRunning(client, "default", selector); err != nil {
+	if err := pkgutil.WaitForPodsWithLabelRunning(client, "default", selector); err != nil {
 		t.Fatalf("Error waiting for busybox mount pod to be up: %s", err)
 	}
 

--- a/test/integration/mount_test.go
+++ b/test/integration/mount_test.go
@@ -36,10 +36,7 @@ func testMounting(t *testing.T) {
 	if strings.Contains(*args, "--vm-driver=none") {
 		t.Skip("skipping test for none driver as it does not need mount")
 	}
-	minikubeRunner := util.MinikubeRunner{
-		Args:       *args,
-		BinaryPath: *binaryPath,
-		T:          t}
+	minikubeRunner := NewMinikubeRunner(t)
 
 	tempDir, err := ioutil.TempDir("", "mounttest")
 	if err != nil {

--- a/test/integration/persistence_test.go
+++ b/test/integration/persistence_test.go
@@ -34,11 +34,8 @@ func TestPersistence(t *testing.T) {
 	kubectlRunner := util.NewKubectlRunner(t)
 	podPath, _ := filepath.Abs("testdata/busybox.yaml")
 
-	podNamespace := kubectlRunner.CreateRandomNamespace()
-	defer kubectlRunner.DeleteNamespace(podNamespace)
-
 	// Create a pod and wait for it to be running.
-	if _, err := kubectlRunner.RunCommand([]string{"create", "-f", podPath, "--namespace=" + podNamespace}); err != nil {
+	if _, err := kubectlRunner.RunCommand([]string{"create", "-f", podPath}); err != nil {
 		t.Fatalf("Error creating test pod: %s", err)
 	}
 
@@ -47,7 +44,7 @@ func TestPersistence(t *testing.T) {
 			t.Fatalf("waiting for dashboard to be up: %s", err)
 		}
 
-		if err := util.WaitForBusyboxRunning(t, podNamespace); err != nil {
+		if err := util.WaitForBusyboxRunning(t, "default"); err != nil {
 			t.Fatalf("waiting for busybox to be up: %s", err)
 		}
 

--- a/test/integration/persistence_test.go
+++ b/test/integration/persistence_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestPersistence(t *testing.T) {
-	minikubeRunner := util.MinikubeRunner{BinaryPath: *binaryPath, T: t}
+	minikubeRunner := NewMinikubeRunner(t)
 	minikubeRunner.EnsureRunning()
 
 	kubectlRunner := util.NewKubectlRunner(t)

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -30,10 +30,7 @@ import (
 
 func TestStartStop(t *testing.T) {
 
-	runner := util.MinikubeRunner{
-		Args:       *args,
-		BinaryPath: *binaryPath,
-		T:          t}
+	runner := NewMinikubeRunner(t)
 	runner.RunCommand("delete", false)
 	runner.CheckStatus(state.None.String())
 

--- a/test/integration/testdata/busybox.yaml
+++ b/test/integration/testdata/busybox.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: busybox
+  generateName: busybox-
   labels:
     integration-test: busybox
 spec:

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -217,26 +217,26 @@ func (k *KubectlRunner) DeleteNamespace(namespace string) error {
 }
 
 func WaitForBusyboxRunning(t *testing.T, namespace string) error {
-	client, err := GetClient()
+	client, err := commonutil.GetClient()
 	if err != nil {
 		return errors.Wrap(err, "getting kubernetes client")
 	}
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{"integration-test": "busybox"}))
-	return WaitForPodsWithLabelRunning(client, namespace, selector)
+	return commonutil.WaitForPodsWithLabelRunning(client, namespace, selector)
 }
 
 func WaitForDNSRunning(t *testing.T) error {
-	client, err := GetClient()
+	client, err := commonutil.GetClient()
 	if err != nil {
 		return errors.Wrap(err, "getting kubernetes client")
 	}
 
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{"k8s-app": "kube-dns"}))
-	if err := WaitForPodsWithLabelRunning(client, "kube-system", selector); err != nil {
+	if err := commonutil.WaitForPodsWithLabelRunning(client, "kube-system", selector); err != nil {
 		return errors.Wrap(err, "waiting for kube-dns pods")
 	}
 
-	if err := WaitForService(t, client, "kube-system", "kube-dns", true, time.Millisecond*500, time.Minute*10); err != nil {
+	if err := commonutil.WaitForService(client, "kube-system", "kube-dns", true, time.Millisecond*500, time.Minute*10); err != nil {
 		t.Errorf("Error waiting for kube-dns service to be up")
 	}
 
@@ -244,19 +244,19 @@ func WaitForDNSRunning(t *testing.T) error {
 }
 
 func WaitForDashboardRunning(t *testing.T) error {
-	client, err := GetClient()
+	client, err := commonutil.GetClient()
 	if err != nil {
 		return errors.Wrap(err, "getting kubernetes client")
 	}
-	if err := WaitForRCToStabilize(t, client, "kube-system", "kubernetes-dashboard", time.Minute*10); err != nil {
+	if err := commonutil.WaitForRCToStabilize(client, "kube-system", "kubernetes-dashboard", time.Minute*10); err != nil {
 		return errors.Wrap(err, "waiting for dashboard RC to stabilize")
 	}
 
-	if err := WaitForService(t, client, "kube-system", "kubernetes-dashboard", true, time.Millisecond*500, time.Minute*10); err != nil {
+	if err := commonutil.WaitForService(client, "kube-system", "kubernetes-dashboard", true, time.Millisecond*500, time.Minute*10); err != nil {
 		return errors.Wrap(err, "waiting for dashboard service to be up")
 	}
 
-	if err := WaitForServiceEndpointsNum(t, client, "kube-system", "kubernetes-dashboard", 1, time.Second*3, time.Minute*10); err != nil {
+	if err := commonutil.WaitForServiceEndpointsNum(client, "kube-system", "kubernetes-dashboard", 1, time.Second*3, time.Minute*10); err != nil {
 		return errors.Wrap(err, "waiting for one dashboard endpoint to be up")
 	}
 

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -42,6 +42,7 @@ type MinikubeRunner struct {
 	T          *testing.T
 	BinaryPath string
 	Args       string
+	StartArgs  string
 }
 
 func (m *MinikubeRunner) Run(cmd string) error {
@@ -103,7 +104,7 @@ func (m *MinikubeRunner) SSH(command string) (string, error) {
 }
 
 func (m *MinikubeRunner) Start() {
-	m.RunCommand(fmt.Sprintf("start %s", m.Args), true)
+	m.RunCommand(fmt.Sprintf("start %s %s", m.StartArgs, m.Args), true)
 }
 
 func (m *MinikubeRunner) EnsureRunning() {
@@ -129,7 +130,11 @@ func (m *MinikubeRunner) SetEnvFromEnvCmdOutput(dockerEnvVars string) error {
 }
 
 func (m *MinikubeRunner) GetStatus() string {
-	return m.RunCommand("status --format={{.MinikubeStatus}}", true)
+	return m.RunCommand(fmt.Sprintf("status --format={{.MinikubeStatus}} %s", m.Args), true)
+}
+
+func (m *MinikubeRunner) GetLogs() string {
+	return m.RunCommand(fmt.Sprintf("logs %s", m.Args), true)
 }
 
 func (m *MinikubeRunner) CheckStatus(desired string) {

--- a/test/integration/versioned_functional_test.go
+++ b/test/integration/versioned_functional_test.go
@@ -36,10 +36,7 @@ func TestVersionedFunctional(t *testing.T) {
 	var minikubeRunner util.MinikubeRunner
 	for _, version := range k8sVersions {
 		vArgs := fmt.Sprintf("%s --kubernetes-version %s", *args, version.Version)
-		minikubeRunner = util.MinikubeRunner{
-			BinaryPath: *binaryPath,
-			Args:       vArgs,
-			T:          t}
+		minikubeRunner = NewMinikubeRunner(t)
 		minikubeRunner.EnsureRunning()
 
 		t.Run("Status", testClusterStatus)


### PR DESCRIPTION
A few changes to the integration tests needed for #1903 

* Persistence Test: Don't start up busybox pod in random namespace, since there won't be sufficient RBAC permissions created.  

* Use a randomly generated name for busybox.  If the TestFunctional/DNS ends too closely with TestPersistence, it could try to create a busybox pod, while the one from the DNS test hasn't deleted yet.  Using a randomly generate name prevents this, but we have to query the name after we create it in TestFunctional/DNS so that we can exec into it afterwards.

* Move the kubernetes WaitFor... utils to `pkg/util` and out of the integration tests.  I want to use some of them in #1903 and they might be generally useful outside of the integration tests.  One of these functions also had to change, since the kubernetes library it used was printing things to stdout.

* Split up minikube start args from root args.  We need to pass certain flags to all commands in the integration tests (verbosity, logtostderr, bootstrapper) which we weren't currently before.  Now, all commands will append `-minikube-args` to the command, while `start` will additionally use `minikube-start-args`.

* Add the NewMinikubeRunner helper function to set the flags on the struct correctly.  This removes a lot of code.