### PR TITLE
golint, go vet, etc. changes

### DIFF
--- a/cmd/minikube/cmd/config/open.go
+++ b/cmd/minikube/cmd/config/open.go
@@ -30,7 +30,6 @@ import (
 )
 
 var (
-	namespace         string
 	https             bool
 	addonsURLMode     bool
 	addonsURLFormat   string

--- a/cmd/minikube/cmd/env_test.go
+++ b/cmd/minikube/cmd/env_test.go
@@ -35,10 +35,6 @@ func (f FakeShellDetector) GetShell(_ string) (string, error) {
 	return f.Shell, nil
 }
 
-type FakeUsageHinter struct{}
-
-func (FakeUsageHinter) GenerateUsageHint(_ string) string { return "" }
-
 type FakeNoProxyGetter struct {
 	NoProxyVar   string
 	NoProxyValue string

--- a/cmd/minikube/cmd/root_test.go
+++ b/cmd/minikube/cmd/root_test.go
@@ -29,12 +29,6 @@ import (
 	"k8s.io/minikube/pkg/minikube/tests"
 )
 
-var jsonExampleConfig = []byte(`{
-    "v": "100",
-    "alsologtostderr": "true",
-    "log_dir": "/etc/hosts",
-}`)
-
 type configTest struct {
 	Name          string
 	EnvValue      string

--- a/pkg/drivers/kvm/kvm.go
+++ b/pkg/drivers/kvm/kvm.go
@@ -362,8 +362,11 @@ func (d *Driver) Remove() error {
 	defer conn.Close()
 
 	//Tear down network and disk if they exist
-	network, _ := conn.LookupNetworkByName(d.PrivateNetwork)
 	log.Debug("Checking if the network needs to be deleted")
+	network, err := conn.LookupNetworkByName(d.PrivateNetwork)
+	if err != nil {
+		log.Warn("Network %s does not exist, nothing to clean up...", d.PrivateNetwork)
+	}
 	if network != nil {
 		log.Infof("Network %s exists, removing...", d.PrivateNetwork)
 		network.Destroy()
@@ -372,6 +375,9 @@ func (d *Driver) Remove() error {
 
 	log.Debug("Checking if the domain needs to be deleted")
 	dom, err := conn.LookupDomainByName(d.MachineName)
+	if err != nil {
+		log.Warn("Domain %s does not exist, nothing to clean up...", d.MachineName)
+	}
 	if dom != nil {
 		log.Infof("Domain %s exists, removing...", d.MachineName)
 		dom.Destroy()

--- a/pkg/drivers/kvm/network.go
+++ b/pkg/drivers/kvm/network.go
@@ -59,12 +59,11 @@ func (d *Driver) createNetwork() error {
 	}
 
 	//Check if network already exists
-	network, err := conn.LookupNetworkByName(d.PrivateNetwork)
-	if err == nil {
+	if _, err := conn.LookupNetworkByName(d.PrivateNetwork); err == nil {
 		return nil
 	}
 
-	network, err = conn.NetworkDefineXML(networkXML.String())
+	network, err := conn.NetworkDefineXML(networkXML.String())
 	if err != nil {
 		return errors.Wrapf(err, "defining network from xml: %s", networkXML.String())
 	}

--- a/pkg/drivers/kvm/storage.go
+++ b/pkg/drivers/kvm/storage.go
@@ -20,6 +20,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"math"
 	"os"
@@ -47,7 +48,6 @@ func createRawDiskImage(dest string, size int) error {
 
 func (d *Driver) buildDiskImage() error {
 	diskPath := d.ResolveStorePath(fmt.Sprintf("%s.img", d.MachineName))
-	err := createRawDiskImage(diskPath, d.DiskSize)
 	if err := createRawDiskImage(diskPath, d.DiskSize); err != nil {
 		return errors.Wrap(err, "creating raw disk image")
 	}
@@ -61,7 +61,7 @@ func (d *Driver) buildDiskImage() error {
 	}
 	defer f.Close()
 
-	f.Seek(0, os.SEEK_SET)
+	f.Seek(0, io.SeekStart)
 	_, err = f.Write(tarBuf.Bytes())
 	if err != nil {
 		return errors.Wrap(err, "wrting cert bundle to disk image")

--- a/pkg/localkube/etcd.go
+++ b/pkg/localkube/etcd.go
@@ -71,5 +71,5 @@ func (e *EtcdServer) Stop() {
 
 // Name returns the servers unique name
 func (e EtcdServer) Name() string {
-	return e.Name()
+	return e.Config.Name
 }

--- a/pkg/localkube/storage_provisioner.go
+++ b/pkg/localkube/storage_provisioner.go
@@ -17,13 +17,13 @@ limitations under the License.
 package localkube
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path"
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
 	"github.com/r2d4/external-storage/lib/controller"
 	"github.com/r2d4/external-storage/lib/leaderelection"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -110,7 +110,7 @@ func (p *hostPathProvisioner) Delete(volume *v1.PersistentVolume) error {
 
 	path := path.Join(p.pvDir, volume.Name)
 	if err := os.RemoveAll(path); err != nil {
-		return err
+		return errors.Wrap(err, "removing hostpath PV")
 	}
 
 	return nil

--- a/pkg/minikube/bootstrapper/localkube/localkube_caching.go
+++ b/pkg/minikube/bootstrapper/localkube/localkube_caching.go
@@ -55,7 +55,6 @@ func (l *localkubeCacher) isLocalkubeCached() bool {
 }
 
 func (l *localkubeCacher) downloadAndCacheLocalkube() error {
-	err := errors.New("")
 	url, err := util.GetLocalkubeDownloadURL(l.k8sConf.KubernetesVersion, constants.LocalkubeLinuxFilename)
 	if err != nil {
 		return errors.Wrap(err, "Error getting localkube download url")

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -45,8 +45,6 @@ import (
 	"k8s.io/minikube/pkg/util"
 )
 
-const fileScheme = "file"
-
 //This init function is used to set the logtostderr variable to false so that INFO level log info does not clutter the CLI
 //INFO lvl logging is displayed due to the kubernetes api calling flag.Set("logtostderr", "true") in its init()
 //see: https://github.com/kubernetes/kubernetes/blob/master/pkg/util/logs/logs.go#L32-34
@@ -279,7 +277,7 @@ func MountHost(api libmachine.API, ip net.IP, path, port, mountVersion string, u
 	}
 	_, err = host.RunSSHCommand(mountCmd)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "running mount host command")
 	}
 	return nil
 }

--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -49,9 +49,8 @@ func Get(name string) (string, error) {
 func get(name string, config MinikubeConfig) (string, error) {
 	if val, ok := config[name]; ok {
 		return fmt.Sprintf("%v", val), nil
-	} else {
-		return "", errors.New("specified key could not be found in config")
 	}
+	return "", errors.New("specified key could not be found in config")
 }
 
 // ReadConfig reads in the JSON minikube config

--- a/pkg/minikube/drivers/hyperkit/disk.go
+++ b/pkg/minikube/drivers/hyperkit/disk.go
@@ -17,6 +17,7 @@ limitations under the License.
 package hyperkit
 
 import (
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/cloudflare/cfssl/log"
 	"github.com/docker/machine/libmachine/mcnutils"
+	"github.com/pkg/errors"
 )
 
 func createDiskImage(sshKeyPath, diskPath string, diskSizeMb int) error {
@@ -37,7 +39,7 @@ func createDiskImage(sshKeyPath, diskPath string, diskSizeMb int) error {
 		return err
 	}
 	defer file.Close()
-	file.Seek(0, os.SEEK_SET)
+	file.Seek(0, io.SeekStart)
 
 	if _, err := file.Write(tarBuf.Bytes()); err != nil {
 		return err
@@ -45,7 +47,7 @@ func createDiskImage(sshKeyPath, diskPath string, diskSizeMb int) error {
 	file.Close()
 
 	if err := os.Truncate(diskPath, int64(diskSizeMb*1000000)); err != nil {
-		return err
+		return errors.Wrap(err, "creating disk")
 	}
 	return nil
 }

--- a/pkg/minikube/machine/client.go
+++ b/pkg/minikube/machine/client.go
@@ -37,7 +37,6 @@ import (
 	"github.com/docker/machine/libmachine/check"
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/drivers/plugin/localbinary"
-	rpcdriver "github.com/docker/machine/libmachine/drivers/rpc"
 	"github.com/docker/machine/libmachine/engine"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/mcnutils"
@@ -91,10 +90,6 @@ func getVirtualboxDriver(rawDriver []byte) (drivers.Driver, error) {
 		return nil, errors.Wrapf(err, "Error unmarshalling virtualbox driver %s", string(rawDriver))
 	}
 	return driver, nil
-}
-
-func getDriverRPC(driverName string, rawDriver []byte) (drivers.Driver, error) {
-	return rpcdriver.NewRPCClientDriverFactory().NewRPCClientDriver(driverName, rawDriver)
 }
 
 // LocalClient is a non-RPC implemenation

--- a/pkg/minikube/machine/client_test.go
+++ b/pkg/minikube/machine/client_test.go
@@ -32,10 +32,6 @@ import (
 	"k8s.io/minikube/pkg/minikube/constants"
 )
 
-var expectedDrivers = map[string]drivers.Driver{
-	vboxConfig: virtualbox.NewDriver("", ""),
-}
-
 const vboxConfig = `
 {
         "IPAddress": "192.168.99.101",

--- a/pkg/minikube/machine/drivers/none/none.go
+++ b/pkg/minikube/machine/drivers/none/none.go
@@ -126,11 +126,11 @@ fi
 func (d *Driver) Kill() error {
 	cmd := exec.Command("sudo", "systemctl", "stop", "localkube.service")
 	if err := cmd.Start(); err != nil {
-		return err
+		return errors.Wrap(err, "stopping the localkube service")
 	}
 	cmd = exec.Command("sudo", "rm", "-rf", "/var/lib/localkube")
 	if err := cmd.Start(); err != nil {
-		return err
+		return errors.Wrap(err, "removing localkube")
 	}
 	return nil
 }
@@ -138,11 +138,11 @@ func (d *Driver) Kill() error {
 func (d *Driver) Remove() error {
 	cmd := exec.Command("sudo", "systemctl", "stop", "localkube.service")
 	if err := cmd.Start(); err != nil {
-		return err
+		return errors.Wrap(err, "stopping localkube service")
 	}
 	cmd = exec.Command("sudo", "rm", "-rf", "/var/lib/localkube")
 	if err := cmd.Start(); err != nil {
-		return err
+		return errors.Wrap(err, "removing localkube")
 	}
 	return nil
 }

--- a/pkg/minikube/notify/notify.go
+++ b/pkg/minikube/notify/notify.go
@@ -76,10 +76,7 @@ func shouldCheckURLVersion(filePath string) bool {
 		return false
 	}
 	lastUpdateTime := getTimeFromFileIfExists(filePath)
-	if time.Since(lastUpdateTime).Hours() < viper.GetFloat64(config.ReminderWaitPeriodInHours) {
-		return false
-	}
-	return true
+	return time.Since(lastUpdateTime).Hours() >= viper.GetFloat64(config.ReminderWaitPeriodInHours)
 }
 
 type Release struct {

--- a/pkg/util/kubeconfig/config.go
+++ b/pkg/util/kubeconfig/config.go
@@ -110,7 +110,7 @@ func SetupKubeConfig(cfg *KubeConfigSetup) error {
 
 	// write back to disk
 	if err := WriteConfig(config, cfg.GetKubeConfigFile()); err != nil {
-		return err
+		return errors.Wrap(err, "writing kubeconfig")
 	}
 	return nil
 }

--- a/test/integration/mount_test.go
+++ b/test/integration/mount_test.go
@@ -110,7 +110,7 @@ func testMounting(t *testing.T) {
 		// test that fromhostremove was deleted by the pod from the mount via rm /mount-9p/fromhostremove
 		path = filepath.Join(tempDir, "fromhostremove")
 		if _, err := os.Stat(path); err == nil {
-			t.Fatalf("Expected file %s to be removed", path, expected, out)
+			t.Fatalf("Expected file %s to be removed", path)
 		}
 
 		// test that frompodremove can be deleted on the host


### PR DESCRIPTION
remove some dead code, unchecked errors, use io.SeekStart instead of os.SEEK_SET (deprecated apparently), fmt strings