### PR TITLE
Only warn when can't get all localkube versions

### DIFF
--- a/pkg/minikube/notify/notify.go
+++ b/pkg/minikube/notify/notify.go
@@ -51,12 +51,12 @@ func MaybePrintUpdateText(output io.Writer, url string, lastUpdatePath string) {
 	}
 	latestVersion, err := getLatestVersionFromURL(url)
 	if err != nil {
-		glog.Errorln(err)
+		glog.Warning(err)
 		return
 	}
 	localVersion, err := version.GetSemverVersion()
 	if err != nil {
-		glog.Errorln(err)
+		glog.Warning(err)
 		return
 	}
 	if localVersion.Compare(latestVersion) < 0 {


### PR DESCRIPTION
We don't actually throw any error here, so things can continue normally, but don't print out any message to the user without verbosity.

https://github.com/kubernetes/minikube/issues/652#issuecomment-329565958