### PR TITLE
Add service account to kube-dns addon

### DIFF
--- a/deploy/addons/kube-dns/kube-dns-controller.yaml
+++ b/deploy/addons/kube-dns/kube-dns-controller.yaml
@@ -160,3 +160,4 @@ spec:
             memory: 20Mi
             cpu: 10m
       dnsPolicy: Default  # Don't use cluster DNS.
+      serviceAccountName: kube-dns

--- a/deploy/addons/kube-dns/kube-dns-sa.yaml
+++ b/deploy/addons/kube-dns/kube-dns-sa.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile


### PR DESCRIPTION
From https://github.com/kubernetes/kubernetes/issues/52487.

kube-dns will not be funcitoning without service account when RBAC is enabled.

And seems like we are setting authorization mode to RBAC by default: ref https://github.com/kubernetes/minikube/pull/1904.

cc @vadimeisenbergibm