### PR TITLE
Fix issue 1981

### DIFF
--- a/pkg/minikube/bootstrapper/certs.go
+++ b/pkg/minikube/bootstrapper/certs.go
@@ -18,6 +18,7 @@ package bootstrapper
 
 import (
 	"net"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -44,7 +45,7 @@ var (
 // SetupCerts gets the generated credentials required to talk to the APIServer.
 func SetupCerts(cmd CommandRunner, k8s KubernetesConfig) error {
 	localPath := constants.GetMinipath()
-	glog.Infoln("Setting up certificates for IP: %s", k8s.NodeIP)
+	glog.Infof("Setting up certificates for IP: %s\n", k8s.NodeIP)
 
 	if err := generateCerts(k8s); err != nil {
 		return errors.Wrap(err, "Error generating certs")
@@ -68,9 +69,9 @@ func SetupCerts(cmd CommandRunner, k8s KubernetesConfig) error {
 	kubeCfgSetup := &kubeconfig.KubeConfigSetup{
 		ClusterName:          k8s.NodeName,
 		ClusterServerAddress: "https://localhost:8443",
-		ClientCertificate:    filepath.Join(util.DefaultCertPath, "apiserver.crt"),
-		ClientKey:            filepath.Join(util.DefaultCertPath, "apiserver.key"),
-		CertificateAuthority: filepath.Join(util.DefaultCertPath, "ca.crt"),
+		ClientCertificate:    path.Join(util.DefaultCertPath, "apiserver.crt"),
+		ClientKey:            path.Join(util.DefaultCertPath, "apiserver.key"),
+		CertificateAuthority: path.Join(util.DefaultCertPath, "ca.crt"),
 		KeepContext:          false,
 	}
 


### PR DESCRIPTION
Fix issue kubernetes/minikube/issues/1981.

Path to the cert file in /var/lib/localkube/kubeconfig on a minikube VM was broken.

```
apiVersion: v1
clusters:
- cluster:
    certificate-authority: \var\lib\localkube\certs\ca.crt
    server: https://localhost:8443
  name: minikube
contexts:
- context:
    cluster: minikube
    user: minikube
  name: minikube
current-context: minikube
kind: Config
preferences: {}
users:
- name: minikube
  user:
    client-certificate: \var\lib\localkube\certs\apiserver.crt
    client-key: \var\lib\localkube\certs\apiserver.key
```

Fixed it.

And fixed create location of a image cache folder for Windows.
But, ParseReference does not support Windows drive letter.
If contains Windows drive letter, it disable caching image for now.