### PR TITLE
Enable cache image for Windows

### DIFF
--- a/pkg/minikube/machine/cache_images_test.go
+++ b/pkg/minikube/machine/cache_images_test.go
@@ -17,6 +17,10 @@ limitations under the License.
 package machine
 
 import (
+	"io/ioutil"
+	"os"
+	"runtime"
+	"strings"
 	"testing"
 
 	"k8s.io/minikube/pkg/minikube/constants"
@@ -26,6 +30,72 @@ func TestGetSrcRef(t *testing.T) {
 	for _, image := range constants.LocalkubeCachedImages {
 		if _, err := getSrcRef(image); err != nil {
 			t.Errorf("Error getting src ref for %s: %s", image, err)
+		}
+	}
+}
+
+func TestGetDstRef(t *testing.T) {
+	paths := []struct {
+		path, separator string
+	}{
+		{`/Users/foo/.minikube/cache/images`, `/`},
+		{`/home/foo/.minikube/cache/images`, `/`},
+		{`\\?\Volume{aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee}\Users\foo\.minikube\cache\images`, `\`},
+		{`\\?\Volume{aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee}\minikube\.minikube\cache\images`, `\`},
+	}
+
+	cases := []struct {
+		image, dst string
+	}{}
+	for _, tp := range paths {
+		for _, image := range constants.LocalkubeCachedImages {
+			dst := strings.Join([]string{tp.path, strings.Replace(image, ":", "_", -1)}, tp.separator)
+			cases = append(cases, struct{ image, dst string }{image, dst})
+		}
+	}
+
+	for _, tc := range cases {
+		if _, err := _getDstRef(tc.image, tc.dst); err != nil {
+			t.Errorf("Error getting dst ref for %s: %s", tc.dst, err)
+		}
+	}
+}
+
+func TestReplaceWinDriveLetterToVolumeName(t *testing.T) {
+	path, err := ioutil.TempDir("", "repwindl2vn")
+	if err != nil {
+		t.Fatalf("Error make tmp directory: %s", err)
+	}
+	defer os.RemoveAll(path)
+
+	if runtime.GOOS != "windows" {
+		// Replace to fake func.
+		getWindowsVolumeName = func(d string) (string, error) {
+			return `/`, nil
+		}
+		// Add dummy Windows drive letter.
+		path = `C:` + path
+	}
+
+	if _, err := replaceWinDriveLetterToVolumeName(path); err != nil {
+		t.Errorf("Error replace a Windows drive letter to a volume name: %s", err)
+	}
+}
+
+func TestHasWindowsDriveLetter(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{`C:\Users\Foo\.minikube`, true},
+		{`D:\minikube\.minikube`, true},
+		{`C\Foo\Bar\.minikube`, false},
+		{`/home/foo/.minikube`, false},
+	}
+
+	for _, tc := range cases {
+		if hasWindowsDriveLetter(tc.path) != tc.want {
+			t.Errorf("%s have a Windows drive letter: %t", tc.path, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
Enable the cache image feature disabled by PR kubernetes/minikube/pull/1982.

Use the wmic command to change a drive letter to a volume name (`C:\ -> \\?\Volume{GUID}\`).