### PR TITLE
correct url of reference code

### DIFF
--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -47,7 +47,7 @@ import (
 
 //This init function is used to set the logtostderr variable to false so that INFO level log info does not clutter the CLI
 //INFO lvl logging is displayed due to the kubernetes api calling flag.Set("logtostderr", "true") in its init()
-//see: https://github.com/kubernetes/kubernetes/blob/master/pkg/util/logs/logs.go#L32-34
+//see: https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/util/logs/logs.go#L32-L34
 func init() {
 	flag.Set("logtostderr", "false")
 	// Setting the default client to native gives much better performance.


### PR DESCRIPTION
Hi, the url https://github.com/kubernetes/kubernetes/blob/master/pkg/util/logs/logs.go#L32-34 is invalid in https://github.com/kubernetes/minikube/blob/master/pkg/minikube/cluster/cluster.go#L50. So I search [kubernetes](https://github.com/kubernetes/kubernetes) and correct it.
Signed-off-by: adolphlwq <kenan3015@gmail.com>