### PR TITLE
Cross build debug and split drivers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ else
 endif
 
 .PHONY: e2e-%-amd64
-e2e-%-amd64:
+e2e-%-amd64: out/minikube-%-amd64
 	GOOS=$* GOARCH=amd64 go test -c k8s.io/minikube/test/integration --tags="$(MINIKUBE_INTEGRATION_BUILD_TAGS)" -o out/$@
 
 e2e-windows-amd64.exe: e2e-windows-amd64
@@ -153,6 +153,18 @@ test-iso:
 .PHONY: test-pkg
 test-pkg/%:
 	go test -v -test.timeout=30m $(REPOPATH)/$* --tags="$(MINIKUBE_BUILD_TAGS)"
+
+.PHONY: all
+all: cross drivers e2e-cross images
+
+.PHONY: drivers
+drivers: out/docker-machine-driver-hyperkit out/docker-machine-driver-kvm2
+
+.PHONY: images
+images: localkube-image localkube-dind-image localkube-dind-image-devshell
+	gcloud docker -- push gcr.io/k8s-minikube/localkube-image:$(TAG)
+	gcloud docker -- push gcr.io/k8s-minikube/localkube-dind-image:$(TAG)
+	gcloud docker -- push gcr.io/k8s-minikube/localkube-dind-image-devshell:$(TAG)
 
 .PHONY: integration
 integration: out/minikube

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ $(GOPATH)/bin/go-bindata:
 	GOBIN=$(GOPATH)/bin go get github.com/jteeuwen/go-bindata/...
 
 .PHONY: cross
-cross: out/localkube out/minikube-linux-amd64 out/minikube-darwin-amd64 out/minikube-windows-amd64.exe out/docker-machine-driver-hyperkit out/docker-machine-driver-kvm2
+cross: out/localkube out/minikube-linux-amd64 out/minikube-darwin-amd64 out/minikube-windows-amd64.exe
 
 .PHONY: e2e-cross
 e2e-cross: e2e-linux-amd64 e2e-darwin-amd64 e2e-windows-amd64.exe

--- a/hack/jenkins/minikube_cross_build_and_upload.sh
+++ b/hack/jenkins/minikube_cross_build_and_upload.sh
@@ -23,8 +23,14 @@
 
 set -e
 
+export BUILD_IN_DOCKER=y
+export TAG=$ghprbActualCommit
+export GOPATH=/var/lib/jenkins/go
+
+make -j 16 all
+
 # Clean up exited containers
-docker rm $(docker ps -q -f status=exited) || true
+docker kill $(docker ps -q) || true
 
 gsutil cp gs://minikube-builds/logs/index.html gs://minikube-builds/logs/${ghprbPullId}/index.html
 
@@ -38,31 +44,10 @@ if out="$(git diff ${ghprbActualCommit} --name-only $(git merge-base origin/mast
 	make release-iso
 fi
 
-export GOPATH=~/go
-
-# Build the e2e test target for Darwin and Linux. We don't run tests on Windows yet.
-# We build these on Linux, but run the tests on different platforms.
-# This makes it easier to provision slaves, since they don't need to have a go toolchain.'
-# Cross also builds the hyperkit and kvm2 drivers.
-BUILD_IN_DOCKER=y make cross 
-BUILD_IN_DOCKER=y make e2e-cross
 cp -r test/integration/testdata out/
-
-BUILD_IN_DOCKER=y make out/docker-machine-driver-hyperkit
-BUILD_IN_DOCKER=y make out/docker-machine-driver-kvm2
 
 # Don't upload the buildroot artifacts if they exist
 rm -r out/buildroot || true
 
 # Upload everything we built to Cloud Storage.
 gsutil -m cp -r out/* gs://minikube-builds/${ghprbPullId}/
-
-# Upload containers for the PR:
-TAG=$ghprbActualCommit make localkube-image
-gcloud docker -- push gcr.io/k8s-minikube/localkube-image:$ghprbActualCommit
-
-TAG=$ghprbActualCommit make localkube-dind-image
-gcloud docker -- push gcr.io/k8s-minikube/localkube-dind-image:$ghprbActualCommit
-
-TAG=$ghprbActualCommit make localkube-dind-image-devshell
-gcloud docker -- push gcr.io/k8s-minikube/localkube-dind-image-devshell:$ghprbActualCommit

--- a/hack/jenkins/minikube_cross_build_and_upload.sh
+++ b/hack/jenkins/minikube_cross_build_and_upload.sh
@@ -44,8 +44,12 @@ export GOPATH=~/go
 # We build these on Linux, but run the tests on different platforms.
 # This makes it easier to provision slaves, since they don't need to have a go toolchain.'
 # Cross also builds the hyperkit and kvm2 drivers.
-BUILD_IN_DOCKER=y make cross e2e-cross
+BUILD_IN_DOCKER=y make cross 
+BUILD_IN_DOCKER=y make e2e-cross
 cp -r test/integration/testdata out/
+
+BUILD_IN_DOCKER=y make out/docker-machine-driver-hyperkit
+BUILD_IN_DOCKER=y make out/docker-machine-driver-kvm2
 
 # Don't upload the buildroot artifacts if they exist
 rm -r out/buildroot || true


### PR DESCRIPTION
This will help us figure out why the cross builds suddenly are taking so long

Also fixes #2030 by splitting out the drivers from the cross rule