### PR TITLE
[kubeadm] Pass features gates to components

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm_test.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm_test.go
@@ -89,11 +89,11 @@ etcd:
   dataDir: /data
 nodeName: extra-args-minikube
 apiServerExtraArgs:
-  fail-no-swap: true
+  fail-no-swap: "true"
 controllerManagerExtraArgs:
-  kube-api-burst: 32
+  kube-api-burst: "32"
 schedulerExtraArgs:
-  scheduler-name: mini-scheduler
+  scheduler-name: "mini-scheduler"
 `,
 		},
 		{
@@ -128,8 +128,8 @@ etcd:
   dataDir: /data
 nodeName: extra-args-minikube
 apiServerExtraArgs:
-  fail-no-swap: true
-  kube-api-burst: 32
+  fail-no-swap: "true"
+  kube-api-burst: "32"
 `,
 		},
 		{
@@ -153,11 +153,11 @@ etcd:
   dataDir: /data
 nodeName: extra-args-minikube
 apiServerExtraArgs:
-  feature-gates: HugePages=true,OtherFeature=false
+  feature-gates: "HugePages=true,OtherFeature=false"
 controllerManagerExtraArgs:
-  feature-gates: HugePages=true,OtherFeature=false
+  feature-gates: "HugePages=true,OtherFeature=false"
 schedulerExtraArgs:
-  feature-gates: HugePages=true,OtherFeature=false
+  feature-gates: "HugePages=true,OtherFeature=false"
 `,
 		},
 		{
@@ -188,12 +188,12 @@ etcd:
   dataDir: /data
 nodeName: extra-args-minikube
 apiServerExtraArgs:
-  fail-no-swap: true
-  feature-gates: HugePages=true,OtherFeature=false
+  fail-no-swap: "true"
+  feature-gates: "HugePages=true,OtherFeature=false"
 controllerManagerExtraArgs:
-  feature-gates: HugePages=true,OtherFeature=false
+  feature-gates: "HugePages=true,OtherFeature=false"
 schedulerExtraArgs:
-  feature-gates: HugePages=true,OtherFeature=false
+  feature-gates: "HugePages=true,OtherFeature=false"
 `,
 		},
 		{

--- a/pkg/minikube/bootstrapper/kubeadm/templates.go
+++ b/pkg/minikube/bootstrapper/kubeadm/templates.go
@@ -18,8 +18,8 @@ package kubeadm
 
 import (
 	"fmt"
-	"html/template"
 	"sort"
+	"text/template"
 )
 
 var kubeadmConfigTemplate = template.Must(template.New("kubeadmConfigTemplate").Funcs(template.FuncMap{
@@ -89,7 +89,7 @@ func printMapInOrder(m map[string]string, sep string) []string {
 	}
 	sort.Strings(keys)
 	for i, k := range keys {
-		keys[i] = fmt.Sprintf("%s%s%s", k, sep, m[k])
+		keys[i] = fmt.Sprintf("%s%s\"%s\"", k, sep, m[k])
 	}
 	return keys
 }

--- a/pkg/minikube/bootstrapper/kubeadm/templates_test.go
+++ b/pkg/minikube/bootstrapper/kubeadm/templates_test.go
@@ -34,7 +34,7 @@ func TestPrintMapInOrder(t *testing.T) {
 			m: map[string]string{
 				"a": "1",
 			},
-			expected: []string{"a: 1"},
+			expected: []string{`a: "1"`},
 		},
 		{
 			description: "two kv",
@@ -43,7 +43,7 @@ func TestPrintMapInOrder(t *testing.T) {
 				"b": "2",
 				"a": "1",
 			},
-			expected: []string{"a=1", "b=2"},
+			expected: []string{`a="1"`, `b="2"`},
 		},
 		{
 			description: "no kv",

--- a/pkg/minikube/bootstrapper/kubeadm/templates_test.go
+++ b/pkg/minikube/bootstrapper/kubeadm/templates_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeadm
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPrintMapInOrder(t *testing.T) {
+	tests := []struct {
+		description string
+		m           map[string]string
+		sep         string
+		expected    []string
+	}{
+		{
+			description: "single kv",
+			sep:         ": ",
+			m: map[string]string{
+				"a": "1",
+			},
+			expected: []string{"a: 1"},
+		},
+		{
+			description: "two kv",
+			sep:         "=",
+			m: map[string]string{
+				"b": "2",
+				"a": "1",
+			},
+			expected: []string{"a=1", "b=2"},
+		},
+		{
+			description: "no kv",
+			sep:         ",",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			actual := printMapInOrder(test.m, test.sep)
+			if !reflect.DeepEqual(actual, test.expected) {
+				t.Errorf("Actual: %v, Expected: %v", actual, test.expected)
+			}
+		})
+	}
+}

--- a/pkg/minikube/bootstrapper/kubeadm/versions.go
+++ b/pkg/minikube/bootstrapper/kubeadm/versions.go
@@ -65,6 +65,8 @@ var componentToKubeadmConfigKey = map[string]string{
 	Apiserver:         "apiServerExtraArgs",
 	ControllerManager: "controllerManagerExtraArgs",
 	Scheduler:         "schedulerExtraArgs",
+	// The Kubelet is not configured in kubeadm, only in systemd.
+	Kubelet: "",
 }
 
 func NewComponentExtraArgs(opts util.ExtraOptionSlice, version semver.Version, featureGates string) ([]ComponentExtraArgs, error) {
@@ -83,6 +85,9 @@ func NewComponentExtraArgs(opts util.ExtraOptionSlice, version semver.Version, f
 
 	for _, component := range keys {
 		kubeadmComponentKey := componentToKubeadmConfigKey[component]
+		if kubeadmComponentKey == "" {
+			continue
+		}
 		extraConfig, err := ExtraConfigForComponent(component, opts, version)
 		if err != nil {
 			return nil, errors.Wrapf(err, "getting kubeadm extra args for %s", component)


### PR DESCRIPTION
Passes feature gates properly to apiserver, scheduler, controller-manager, and kubelet for the kubeadm bootstrapper.