### PR TITLE
[addons] Update ingress rc image version to latest release

### DIFF
--- a/deploy/addons/ingress/ingress-rc.yaml
+++ b/deploy/addons/ingress/ingress-rc.yaml
@@ -36,7 +36,7 @@ spec:
         # Any image is permissable as long as:
         # 1. It serves a 404 page at /
         # 2. It serves 200 on a /healthz endpoint
-        image: gcr.io/google_containers/defaultbackend:1.0
+        image: gcr.io/google_containers/defaultbackend:1.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -77,7 +77,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.14
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.15
         name: nginx-ingress-controller
         imagePullPolicy: IfNotPresent
         readinessProbe:


### PR DESCRIPTION
Refer https://github.com/kubernetes/ingress-nginx/pull/1487 PR to update image version. This PR has been tested on v0.22.2.