### PR TITLE
 Add convenience container-runtime flag for kubeadm 

### DIFF
--- a/hack/jenkins/minikube_set_pending.sh
+++ b/hack/jenkins/minikube_set_pending.sh
@@ -27,7 +27,7 @@
 set -e
 set +x
 
-for job in "Linux-KVM-Kubeadm" "OSX-Virtualbox-Kubeadm" "OSX-Virtualbox" "OSX-XHyve" "OSX-Hyperkit" "Linux-Virtualbox" "Linux-KVM" "Linux-KVM-Alt" "Linux-None" "Windows-Virtualbox" "Linux-Container"; do
+for job in "Linux-KVM-Kubeadm" "OSX-Virtualbox-Kubeadm" "OSX-Virtualbox" "OSX-XHyve" "OSX-Hyperkit" "Linux-Virtualbox" "Linux-KVM" "Linux-KVM-Alt" "Linux-None" "Windows-Virtualbox" "Windows-Kubeadm-CRI-O" "Linux-Container"; do
   target_url="https://storage.googleapis.com/minikube-builds/logs/${ghprbPullId}/${job}.txt"
   curl "https://api.github.com/repos/kubernetes/minikube/statuses/${ghprbActualCommit}?access_token=$access_token" \
     -H "Content-Type: application/json" \

--- a/hack/jenkins/windows_integration_test_virtualbox_kubeadm_crio.ps1
+++ b/hack/jenkins/windows_integration_test_virtualbox_kubeadm_crio.ps1
@@ -1,0 +1,35 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+mkdir -p out
+gsutil.cmd cp gs://minikube-builds/$env:MINIKUBE_LOCATION/minikube-windows-amd64.exe out/
+gsutil.cmd cp gs://minikube-builds/$env:MINIKUBE_LOCATION/e2e-windows-amd64.exe out/
+gsutil.cmd cp -r gs://minikube-builds/$env:MINIKUBE_LOCATION/testdata .
+
+
+./out/minikube-windows-amd64.exe delete
+Remove-Item -Recurse -Force C:\Users\jenkins\.minikube
+
+out/e2e-windows-amd64.exe --% -minikube-start-args="--vm-driver=virtualbox --container-runtime=cri-o" -minikube-args="--v=10 --logtostderr --bootstrapper=kubeadm" -test.v -test.timeout=30m -binary=out/minikube-windows-amd64.exe
+
+$env:result=$lastexitcode
+# If the last exit code was 0->success, x>0->error
+If($env:result -eq 0){$env:status="success"}
+Else {$env:status="failure"}
+
+$env:target_url="https://storage.googleapis.com/minikube-builds/logs/$env:MINIKUBE_LOCATION/Windows-Kubeadm-CRI-O.txt"
+$json = "{`"state`": `"$env:status`", `"description`": `"Jenkins`", `"target_url`": `"$env:target_url`", `"context`": `"Windows-Kubeadm-CRI-O`"}"
+Invoke-WebRequest -Uri "https://api.github.com/repos/kubernetes/minikube/statuses/$env:COMMIT`?access_token=$env:access_token" -Body $json -ContentType "application/json" -Method Post -usebasicparsing
+
+Exit $env:result

--- a/pkg/minikube/assets/vm_assets.go
+++ b/pkg/minikube/assets/vm_assets.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"io"
 	"os"
-	"path/filepath"
+	"path"
 
 	"github.com/pkg/errors"
 )
@@ -65,7 +65,7 @@ type FileAsset struct {
 }
 
 func NewMemoryAssetTarget(d []byte, targetPath, permissions string) *MemoryAsset {
-	return NewMemoryAsset(d, filepath.Dir(targetPath), filepath.Base(targetPath), permissions)
+	return NewMemoryAsset(d, path.Dir(targetPath), path.Base(targetPath), permissions)
 }
 
 func NewFileAsset(assetName, targetDir, targetName, permissions string) (*FileAsset, error) {

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -21,7 +21,7 @@ import (
 	"crypto"
 	"fmt"
 	"os"
-	"path/filepath"
+	"path"
 	"strings"
 	"time"
 
@@ -361,7 +361,7 @@ func generateConfig(k8s bootstrapper.KubernetesConfig) (string, error) {
 
 func maybeDownloadAndCache(binary, version string) (string, error) {
 	targetDir := constants.MakeMiniPath("cache", version)
-	targetFilepath := filepath.Join(targetDir, binary)
+	targetFilepath := path.Join(targetDir, binary)
 
 	_, err := os.Stat(targetFilepath)
 	// If it exists, do no verification and continue

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -302,23 +302,6 @@ sudo systemctl start kubelet
 	return nil
 }
 
-func parseFeatureGates(featureGates string) (map[string]string, error) {
-	if featureGates == "" {
-		return nil, nil
-	}
-	fgMap := map[string]string{}
-	fg := strings.Split(featureGates, ",")
-	for _, f := range fg {
-		kv := strings.SplitN(f, "=", 2)
-		if len(kv) != 2 {
-			return nil, fmt.Errorf("Invalid feature gate format: %s", f)
-		}
-		fgMap[kv[0]] = kv[1]
-	}
-
-	return fgMap, nil
-}
-
 func generateConfig(k8s bootstrapper.KubernetesConfig) (string, error) {
 	version, err := ParseKubernetesVersion(k8s.KubernetesVersion)
 	if err != nil {

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm_test.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm_test.go
@@ -89,11 +89,11 @@ etcd:
   dataDir: /data
 nodeName: extra-args-minikube
 apiServerExtraArgs:
-  fail-no-swap: true
+  fail-no-swap: "true"
 controllerManagerExtraArgs:
-  kube-api-burst: 32
+  kube-api-burst: "32"
 schedulerExtraArgs:
-  scheduler-name: mini-scheduler
+  scheduler-name: "mini-scheduler"
 `,
 		},
 		{
@@ -128,8 +128,8 @@ etcd:
   dataDir: /data
 nodeName: extra-args-minikube
 apiServerExtraArgs:
-  fail-no-swap: true
-  kube-api-burst: 32
+  fail-no-swap: "true"
+  kube-api-burst: "32"
 `,
 		},
 		{
@@ -153,11 +153,11 @@ etcd:
   dataDir: /data
 nodeName: extra-args-minikube
 apiServerExtraArgs:
-  feature-gates: HugePages=true,OtherFeature=false
+  feature-gates: "HugePages=true,OtherFeature=false"
 controllerManagerExtraArgs:
-  feature-gates: HugePages=true,OtherFeature=false
+  feature-gates: "HugePages=true,OtherFeature=false"
 schedulerExtraArgs:
-  feature-gates: HugePages=true,OtherFeature=false
+  feature-gates: "HugePages=true,OtherFeature=false"
 `,
 		},
 		{
@@ -188,12 +188,12 @@ etcd:
   dataDir: /data
 nodeName: extra-args-minikube
 apiServerExtraArgs:
-  fail-no-swap: true
-  feature-gates: HugePages=true,OtherFeature=false
+  fail-no-swap: "true"
+  feature-gates: "HugePages=true,OtherFeature=false"
 controllerManagerExtraArgs:
-  feature-gates: HugePages=true,OtherFeature=false
+  feature-gates: "HugePages=true,OtherFeature=false"
 schedulerExtraArgs:
-  feature-gates: HugePages=true,OtherFeature=false
+  feature-gates: "HugePages=true,OtherFeature=false"
 `,
 		},
 		{

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm_test.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kubeadm
 
 import (
-	"reflect"
 	"testing"
 
 	"k8s.io/minikube/pkg/minikube/bootstrapper"
@@ -229,57 +228,6 @@ schedulerExtraArgs:
 			if actualCfg != test.expectedCfg {
 				t.Errorf("actual config does not match expected.  actual:\n%sexpected:\n%s", actualCfg, test.expectedCfg)
 				return
-			}
-		})
-	}
-}
-
-func TestParseFeatureGates(t *testing.T) {
-	tests := []struct {
-		description string
-		fg          string
-		expected    map[string]string
-		shouldErr   bool
-	}{
-		{
-			description: "no feature gates",
-		},
-		{
-			description: "one feature gate",
-			fg:          "AppArmor=true",
-			expected: map[string]string{
-				"AppArmor": "true",
-			},
-		},
-		{
-			description: "two feature gates",
-			fg:          "AppArmor=true,HugePages=true",
-			expected: map[string]string{
-				"AppArmor":  "true",
-				"HugePages": "true",
-			},
-		},
-		{
-			description: "missing value pair",
-			fg:          "AppArmor=true,HugePages",
-			shouldErr:   true,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.description, func(t *testing.T) {
-			actual, err := parseFeatureGates(test.fg)
-			t.Logf("%+v", actual)
-			if err == nil && test.shouldErr {
-				t.Errorf("Expected error but got none: fg: %v", actual)
-				return
-			}
-			if err != nil && !test.shouldErr {
-				t.Errorf("Unexpected error: %s", err)
-				return
-			}
-			if !reflect.DeepEqual(actual, test.expected) {
-				t.Errorf("Actual not equal expected: Actual: %v Expected: %v", actual, test.expected)
 			}
 		})
 	}

--- a/pkg/minikube/bootstrapper/kubeadm/templates.go
+++ b/pkg/minikube/bootstrapper/kubeadm/templates.go
@@ -18,8 +18,8 @@ package kubeadm
 
 import (
 	"fmt"
-	"html/template"
 	"sort"
+	"text/template"
 )
 
 var kubeadmConfigTemplate = template.Must(template.New("kubeadmConfigTemplate").Funcs(template.FuncMap{
@@ -89,7 +89,7 @@ func printMapInOrder(m map[string]string, sep string) []string {
 	}
 	sort.Strings(keys)
 	for i, k := range keys {
-		keys[i] = fmt.Sprintf("%s%s%s", k, sep, m[k])
+		keys[i] = fmt.Sprintf("%s%s\"%s\"", k, sep, m[k])
 	}
 	return keys
 }

--- a/pkg/minikube/bootstrapper/kubeadm/templates_test.go
+++ b/pkg/minikube/bootstrapper/kubeadm/templates_test.go
@@ -34,7 +34,7 @@ func TestPrintMapInOrder(t *testing.T) {
 			m: map[string]string{
 				"a": "1",
 			},
-			expected: []string{"a: 1"},
+			expected: []string{`a: "1"`},
 		},
 		{
 			description: "two kv",
@@ -43,7 +43,7 @@ func TestPrintMapInOrder(t *testing.T) {
 				"b": "2",
 				"a": "1",
 			},
-			expected: []string{"a=1", "b=2"},
+			expected: []string{`a="1"`, `b="2"`},
 		},
 		{
 			description: "no kv",

--- a/pkg/minikube/bootstrapper/kubeadm/templates_test.go
+++ b/pkg/minikube/bootstrapper/kubeadm/templates_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeadm
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPrintMapInOrder(t *testing.T) {
+	tests := []struct {
+		description string
+		m           map[string]string
+		sep         string
+		expected    []string
+	}{
+		{
+			description: "single kv",
+			sep:         ": ",
+			m: map[string]string{
+				"a": "1",
+			},
+			expected: []string{"a: 1"},
+		},
+		{
+			description: "two kv",
+			sep:         "=",
+			m: map[string]string{
+				"b": "2",
+				"a": "1",
+			},
+			expected: []string{"a=1", "b=2"},
+		},
+		{
+			description: "no kv",
+			sep:         ",",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			actual := printMapInOrder(test.m, test.sep)
+			if !reflect.DeepEqual(actual, test.expected) {
+				t.Errorf("Actual: %v, Expected: %v", actual, test.expected)
+			}
+		})
+	}
+}

--- a/pkg/minikube/bootstrapper/kubeadm/versions.go
+++ b/pkg/minikube/bootstrapper/kubeadm/versions.go
@@ -149,6 +149,17 @@ type VersionedExtraOption struct {
 	GreaterThanOrEqual semver.Version
 }
 
+// NewUnversionedOption returns a VersionedExtraOption that applies to all versions.
+func NewUnversionedOption(component, k, v string) VersionedExtraOption {
+	return VersionedExtraOption{
+		Option: util.ExtraOption{
+			Component: component,
+			Key:       k,
+			Value:     v,
+		},
+	}
+}
+
 var versionSpecificOpts = []VersionedExtraOption{
 	{
 		Option: util.ExtraOption{
@@ -158,6 +169,14 @@ var versionSpecificOpts = []VersionedExtraOption{
 		},
 		GreaterThanOrEqual: semver.MustParse("1.8.0-alpha.0"),
 	},
+	NewUnversionedOption(Kubelet, "kubeconfig", "/etc/kubernetes/kubelet.conf"),
+	NewUnversionedOption(Kubelet, "require-kubeconfig", "true"),
+	NewUnversionedOption(Kubelet, "pod-manifest-path", "/etc/kubernetes/manifests"),
+	NewUnversionedOption(Kubelet, "allow-privileged", "true"),
+	NewUnversionedOption(Kubelet, "cluster-dns", "10.0.0.10"),
+	NewUnversionedOption(Kubelet, "cluster-domain", "cluster.local"),
+	NewUnversionedOption(Kubelet, "cadvisor-port", "0"),
+	NewUnversionedOption(Kubelet, "cgroup-driver", "cgroupfs"),
 }
 
 func VersionIsBetween(version, gte, lte semver.Version) bool {

--- a/pkg/minikube/bootstrapper/kubeadm/versions.go
+++ b/pkg/minikube/bootstrapper/kubeadm/versions.go
@@ -65,6 +65,8 @@ var componentToKubeadmConfigKey = map[string]string{
 	Apiserver:         "apiServerExtraArgs",
 	ControllerManager: "controllerManagerExtraArgs",
 	Scheduler:         "schedulerExtraArgs",
+	// The Kubelet is not configured in kubeadm, only in systemd.
+	Kubelet: "",
 }
 
 func NewComponentExtraArgs(opts util.ExtraOptionSlice, version semver.Version, featureGates string) ([]ComponentExtraArgs, error) {
@@ -83,6 +85,9 @@ func NewComponentExtraArgs(opts util.ExtraOptionSlice, version semver.Version, f
 
 	for _, component := range keys {
 		kubeadmComponentKey := componentToKubeadmConfigKey[component]
+		if kubeadmComponentKey == "" {
+			continue
+		}
 		extraConfig, err := ExtraConfigForComponent(component, opts, version)
 		if err != nil {
 			return nil, errors.Wrapf(err, "getting kubeadm extra args for %s", component)


### PR DESCRIPTION
Depends on #2037 

To enable the cri-o runtime you may now just use

```
minikube start --container-runtime=cri-o --bootstrapper=kubeadm
```
or
```
minikube start --container-runtiume=crio --bootstrapper=kubeadm
```
or
```
minikube start --extra-config=kubelet.container-runtime=remote
--extra-config=kubelet.container-runtime-endpoint=/var/run/crio.sock
--extra-config=image-service-endpoint=/var/run/crio.sock
```