### PR TITLE
Update build guide

### DIFF
--- a/docs/contributors/build_guide.md
+++ b/docs/contributors/build_guide.md
@@ -16,7 +16,7 @@ $ sudo dnf install -y glibc-static
 Clone minikube into your go path under `$GOPATH/src/k8s.io`
 
 ```
-$ git clone https://github.com/kubernetes/minikube.git $GOPATH/src/k8s.io
+$ git clone https://github.com/kubernetes/minikube.git $GOPATH/src/k8s.io/minikube
 $ cd $GOPATH/src/k8s.io/minikube
 $ make
 ```
@@ -73,4 +73,3 @@ For example, to run the test `should update annotations on modification [Conform
 ```shell
 go run hack/e2e.go -v --test --test_args="--ginkgo.focus=should\supdate\sannotations\son\smodification" --check_version_skew=false --check_node_count=false
 ```
-


### PR DESCRIPTION
In this guide, the clone action will download project to `$GOPATH/src/k8s.io` path, but project is not under `$GOPATH/src/k8s.io/minikube` path, so we will get an error occurred while running `cd $GOPATH/src/k8s.io/minikube`:
```sh
$ cd $GOPATH/src/k8s.io/minikube
cd: no such file or directory: /home/ubuntu/go/src/k8s.io/minikube
```

Modify path to `cd $GOPATH/src/k8s.io/minikube` can be resolved.