### PR TITLE
Add documentation for accessing host resources

### DIFF
--- a/docs/accessing_etcd.md
+++ b/docs/accessing_etcd.md
@@ -9,5 +9,6 @@ You can use the host-ip:`10.0.2.15` to access localkube's resources, for example
 ```shell
 curl -L -X PUT http://10.0.2.15:2379/v2/keys/message -d value="Hello"
 ```
+
 ## Accessing Host Resources From Inside A Pod
 In order to access host resources from inside a pod, IP address `192.168.99.1` must be used.

--- a/docs/accessing_etcd.md
+++ b/docs/accessing_etcd.md
@@ -9,3 +9,5 @@ You can use the host-ip:`10.0.2.15` to access localkube's resources, for example
 ```shell
 curl -L -X PUT http://10.0.2.15:2379/v2/keys/message -d value="Hello"
 ```
+## Accessing Host Resources From Inside A Pod
+In order to access host resources from inside a pod, IP address `192.168.99.1` must be used.

--- a/docs/accessing_etcd.md
+++ b/docs/accessing_etcd.md
@@ -11,6 +11,7 @@ curl -L -X PUT http://10.0.2.15:2379/v2/keys/message -d value="Hello"
 ```
 
 ## Accessing Host Resources From Inside A Pod
+### When you have a VirtualBox driver
 In order to access host resources from inside a pod, run the following command to determine the host IP you can use:
 ```shell
 ip addr

--- a/docs/accessing_etcd.md
+++ b/docs/accessing_etcd.md
@@ -11,4 +11,9 @@ curl -L -X PUT http://10.0.2.15:2379/v2/keys/message -d value="Hello"
 ```
 
 ## Accessing Host Resources From Inside A Pod
-In order to access host resources from inside a pod, IP address `192.168.99.1` must be used.
+In order to access host resources from inside a pod, run the following command to determine the host IP you can use:
+```shell
+ip addr
+```
+
+The IP address under `vboxnet1` is the IP that you need to access the host from within a pod.


### PR DESCRIPTION
Add documentation to indicate that IP address `192.168.99.1` should be used to access host machine from within a pod. This PR fixes #1393 