### PR TITLE
Use mac instead of hostname to find IP

### DIFF
--- a/pkg/drivers/kvm/kvm.go
+++ b/pkg/drivers/kvm/kvm.go
@@ -66,7 +66,13 @@ type Driver struct {
 
 	// The location of the iso to boot from
 	ISO string
+
+	// The randomly generated MAC Address
+	// If empty, a random MAC will be generated.
+	MAC string
 }
+
+const defaultNetworkName = "minikube-net"
 
 func NewDriver(hostName, storePath string) *Driver {
 	return &Driver{

--- a/pkg/drivers/kvm/network.go
+++ b/pkg/drivers/kvm/network.go
@@ -42,9 +42,14 @@ const networkTmpl = `
 </network>
 `
 
-const defaultNetworkName = "minikube-net"
-
 func (d *Driver) createNetwork() error {
+	if d.MAC == "" {
+		mac, err := randomMAC()
+		if err != nil {
+			return errors.Wrap(err, "generating mac address")
+		}
+		d.MAC = mac.String()
+	}
 	conn, err := getConnection()
 	if err != nil {
 		return errors.Wrap(err, "getting libvirt connection")
@@ -154,7 +159,7 @@ func (d *Driver) lookupIPFromLeasesFile() (string, error) {
 		if len(entry) != 5 {
 			return "", fmt.Errorf("Malformed leases entry: %s", entry)
 		}
-		if entry[3] == d.MachineName {
+		if entry[1] == d.MAC {
 			ipAddress = entry[2]
 		}
 	}


### PR DESCRIPTION
A more reliable way to find machines.

The KVM2 driver now takes a mac address if you want to provide one, otherwise it will generate a random one for you.