### PR TITLE
Remove localkube from bindata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,7 @@ out/minikube-installer.exe: out/minikube-windows-amd64.exe
 
 out/docker-machine-driver-hyperkit: $(shell $(HYPERKIT_FILES))
 ifeq ($(MINIKUBE_BUILD_IN_DOCKER),y)
-	$(call DOCKER,$(HYPERKIT_BUILD_IMAGE),/usr/bin/make $@)
+	$(call DOCKER,$(HYPERKIT_BUILD_IMAGE),CC=o64-clang CXX=o64-clang++ /usr/bin/make $@)
 else
 	GOOS=darwin CGO_ENABLED=1 go build -o $(BUILD_DIR)/docker-machine-driver-hyperkit k8s.io/minikube/cmd/drivers/hyperkit
 endif

--- a/pkg/drivers/hyperkit/driver.go
+++ b/pkg/drivers/hyperkit/driver.go
@@ -32,7 +32,6 @@ import (
 	hyperkit "github.com/moby/hyperkit/go"
 	"github.com/pborman/uuid"
 	"github.com/pkg/errors"
-	vmnet "github.com/zchee/go-vmnet"
 	pkgdrivers "k8s.io/minikube/pkg/drivers"
 	commonutil "k8s.io/minikube/pkg/util"
 )
@@ -159,7 +158,7 @@ func (d *Driver) Start() error {
 	// Set UUID
 	h.UUID = uuid.NewUUID().String()
 	log.Infof("Generated UUID %s", h.UUID)
-	mac, err := vmnet.GetMACAddressFromUUID(h.UUID)
+	mac, err := GetMACAddressFromUUID(h.UUID)
 	if err != nil {
 		return err
 	}

--- a/pkg/drivers/hyperkit/vmnet.go
+++ b/pkg/drivers/hyperkit/vmnet.go
@@ -1,0 +1,25 @@
+// +build darwin,cgo
+
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hyperkit
+
+import vmnet "github.com/zchee/go-vmnet"
+
+func GetMACAddressFromUUID(UUID string) (string, error) {
+	return vmnet.GetMACAddressFromUUID(UUID)
+}

--- a/pkg/drivers/hyperkit/vmnet_stub.go
+++ b/pkg/drivers/hyperkit/vmnet_stub.go
@@ -1,0 +1,25 @@
+// +build darwin,!cgo
+
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hyperkit
+
+import "fmt"
+
+func GetMACAddressFromUUID(UUID string) (string, error) {
+	return "", fmt.Error("Function not supported on CGO_ENABLED=0 binaries")
+}

--- a/pkg/drivers/hyperkit/vmnet_stub.go
+++ b/pkg/drivers/hyperkit/vmnet_stub.go
@@ -18,8 +18,8 @@ limitations under the License.
 
 package hyperkit
 
-import "fmt"
+import "errors"
 
 func GetMACAddressFromUUID(UUID string) (string, error) {
-	return "", fmt.Error("Function not supported on CGO_ENABLED=0 binaries")
+	return "", errors.New("Function not supported on CGO_ENABLED=0 binaries")
 }

--- a/pkg/minikube/bootstrapper/localkube/localkube.go
+++ b/pkg/minikube/bootstrapper/localkube/localkube.go
@@ -116,14 +116,10 @@ func (lk *LocalkubeBootstrapper) UpdateCluster(config bootstrapper.KubernetesCon
 	var err error
 
 	//add url/file/bundled localkube to file list
-	if localkubeURIWasSpecified(config) && config.KubernetesVersion != constants.DefaultKubernetesVersion {
-		lCacher := localkubeCacher{config}
-		localkubeFile, err = lCacher.fetchLocalkubeFromURI()
-		if err != nil {
-			return errors.Wrap(err, "Error updating localkube from uri")
-		}
-	} else {
-		localkubeFile = assets.NewBinDataAsset("out/localkube", "/usr/local/bin", "localkube", "0777")
+	lCacher := localkubeCacher{config}
+	localkubeFile, err = lCacher.fetchLocalkubeFromURI()
+	if err != nil {
+		return errors.Wrap(err, "Error updating localkube from uri")
 	}
 	copyableFiles = append(copyableFiles, localkubeFile)
 

--- a/test.sh
+++ b/test.sh
@@ -32,7 +32,7 @@ COV_TMP_FILE=coverage_tmp.txt
 # Run "go test" on packages that have test files.  Also create coverage profile
 echo "Running go tests..."
 cd ${GOPATH}/src/${REPO_PATH}
-rm -f out/$COV_FILE
+rm -f out/$COV_FILE || true
 echo "mode: count" > out/$COV_FILE
 for pkg in $(go list -f '{{ if .TestGoFiles }} {{.ImportPath}} {{end}}' ./...); do
     go test -tags "container_image_ostree_stub containers_image_openpgp" -v $pkg -covermode=count -coverprofile=out/$COV_TMP_FILE


### PR DESCRIPTION
This makes the minikube build simpler and the the binary smaller.
Localkube will always be remotely fetched and locally cached on the
host.