### PR TITLE
use consistent path for localkube.service

### DIFF
--- a/pkg/drivers/none/none.go
+++ b/pkg/drivers/none/none.go
@@ -19,7 +19,6 @@ package none
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 
@@ -150,9 +149,6 @@ func (d *Driver) Restart() error {
 }
 
 func (d *Driver) Start() error {
-	if err := os.MkdirAll("/usr/lib/systemd/system/", os.FileMode(0755)); err != nil {
-		return err
-	}
 	d.IPAddress = "127.0.0.1"
 	d.URL = "127.0.0.1:8080"
 	return nil

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -137,7 +137,7 @@ const (
 )
 
 const (
-	LocalkubeServicePath = "/usr/lib/systemd/system/localkube.service"
+	LocalkubeServicePath = "/etc/systemd/system/localkube.service"
 	LocalkubeRunning     = "active"
 	LocalkubeStopped     = "inactive"
 )


### PR DESCRIPTION
/usr/lib/systemd/system is not consistent across different distribution
/etc/systemd/system should be used.

See issue: #2098 