### PR TITLE
Explicitly use localkube bootstrapper and binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ test-pkg/%:
 	go test -v -test.timeout=30m $(REPOPATH)/$* --tags="$(MINIKUBE_BUILD_TAGS)"
 
 .PHONY: all
-all: cross drivers e2e-cross images
+all: cross drivers e2e-cross images out/localkube
 
 .PHONY: drivers
 drivers: out/docker-machine-driver-hyperkit out/docker-machine-driver-kvm2
@@ -189,7 +189,7 @@ $(GOPATH)/bin/go-bindata:
 	GOBIN=$(GOPATH)/bin go get github.com/jteeuwen/go-bindata/...
 
 .PHONY: cross
-cross: out/localkube out/minikube-linux-amd64 out/minikube-darwin-amd64 out/minikube-windows-amd64.exe
+cross: out/minikube-linux-amd64 out/minikube-darwin-amd64 out/minikube-windows-amd64.exe
 
 .PHONY: e2e-cross
 e2e-cross: e2e-linux-amd64 e2e-darwin-amd64 e2e-windows-amd64.exe

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -27,6 +27,7 @@
 # Copy only the files we need to this workspace
 mkdir -p out/ testdata/
 gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/minikube-${OS_ARCH} out/
+gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/localkube out/
 gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/docker-machine-driver-* out/
 gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/e2e-${OS_ARCH} out/
 gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/testdata/busybox.yaml testdata/

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -83,7 +83,7 @@ find ~/.minikube || true
 
 # Allow this to fail, we'll switch on the return code below.
 set +e
-${SUDO_PREFIX}out/e2e-${OS_ARCH} -minikube-start-args="--vm-driver=${VM_DRIVER}" -minikube-args="--v=10 --logtostderr ${EXTRA_ARGS}" -test.v -test.timeout=30m -binary=out/minikube-${OS_ARCH}
+${SUDO_PREFIX}out/e2e-${OS_ARCH} -minikube-start-args="--vm-driver=${VM_DRIVER} ${EXTRA_START_ARGS}" -minikube-args="--v=10 --logtostderr ${EXTRA_ARGS}" -test.v -test.timeout=30m -binary=out/minikube-${OS_ARCH}
 result=$?
 set -e
 

--- a/hack/jenkins/linux_integration_tests_kvm.sh
+++ b/hack/jenkins/linux_integration_tests_kvm.sh
@@ -28,7 +28,8 @@ set -e
 OS_ARCH="linux-amd64"
 VM_DRIVER="kvm"
 JOB_NAME="Linux-KVM"
-
+EXTRA_ARGS="--bootstrapper=localkube"
+EXTRA_START_ARGS="--kubernetes-version=file://$PWD/out/localkube"
 
 # Download files and set permissions
 source common.sh

--- a/hack/jenkins/linux_integration_tests_kvm_alt.sh
+++ b/hack/jenkins/linux_integration_tests_kvm_alt.sh
@@ -28,6 +28,8 @@ set -e
 OS_ARCH="linux-amd64"
 VM_DRIVER="kvm2"
 JOB_NAME="Linux-KVM-Alt"
+EXTRA_ARGS="--bootstrapper=localkube"
+EXTRA_START_ARGS="--kubernetes-version=file://$PWD/out/localkube"
 
 # Download files and set permissions
 source common.sh

--- a/hack/jenkins/linux_integration_tests_none.sh
+++ b/hack/jenkins/linux_integration_tests_none.sh
@@ -29,7 +29,9 @@ set -e
 OS_ARCH="linux-amd64"
 VM_DRIVER="none"
 JOB_NAME="Linux-None"
-EXTRA_BUILD_ARGS="$EXTRA_BUILD_ARGS --use-vendored-driver"
+EXTRA_ARGS="--bootstrapper=localkube"
+EXTRA_START_ARGS="--kubernetes-version=file://$PWD/out/localkube"
+
 SUDO_PREFIX="sudo -E "
 export KUBECONFIG="/root/.kube/config"
 

--- a/hack/jenkins/linux_integration_tests_virtualbox.sh
+++ b/hack/jenkins/linux_integration_tests_virtualbox.sh
@@ -28,6 +28,8 @@ set -e
 OS_ARCH="linux-amd64"
 VM_DRIVER="virtualbox"
 JOB_NAME="Linux-VirtualBox"
+EXTRA_ARGS="--bootstrapper=localkube"
+EXTRA_START_ARGS="--kubernetes-version=file://$PWD/out/localkube"
 
 # Download files and set permissions
 source common.sh

--- a/hack/jenkins/osx_integration_tests_hyperkit.sh
+++ b/hack/jenkins/osx_integration_tests_hyperkit.sh
@@ -29,6 +29,8 @@ set -e
 OS_ARCH="darwin-amd64"
 VM_DRIVER="hyperkit"
 JOB_NAME="OSX-Hyperkit"
+EXTRA_ARGS="--bootstrapper=localkube"
+EXTRA_START_ARGS="--kubernetes-version=file://$PWD/out/localkube"
 
 
 # Download files and set permissions

--- a/hack/jenkins/osx_integration_tests_virtualbox.sh
+++ b/hack/jenkins/osx_integration_tests_virtualbox.sh
@@ -28,6 +28,8 @@ set -e
 OS_ARCH="darwin-amd64"
 VM_DRIVER="virtualbox"
 JOB_NAME="OSX-Virtualbox"
+EXTRA_ARGS="--bootstrapper=localkube"
+EXTRA_START_ARGS="--kubernetes-version=file://$PWD/out/localkube"
 
 # Download files and set permissions
 source common.sh

--- a/hack/jenkins/osx_integration_tests_virtualbox_kubeadm.sh
+++ b/hack/jenkins/osx_integration_tests_virtualbox_kubeadm.sh
@@ -28,7 +28,8 @@ set -e
 OS_ARCH="darwin-amd64"
 VM_DRIVER="virtualbox"
 JOB_NAME="OSX-Virtualbox-Kubeadm"
-EXTRA_ARGS="--bootstrapper=kubeadm"
+EXTRA_ARGS="--bootstrapper=localkube"
+EXTRA_START_ARGS="--kubernetes-version=file://$PWD/out/localkube"
 
 # Download files and set permissions
 source common.sh

--- a/hack/jenkins/osx_integration_tests_xhyve.sh
+++ b/hack/jenkins/osx_integration_tests_xhyve.sh
@@ -29,6 +29,8 @@ set -e
 OS_ARCH="darwin-amd64"
 VM_DRIVER="xhyve"
 JOB_NAME="OSX-Xhyve"
+EXTRA_ARGS="--bootstrapper=localkube"
+EXTRA_START_ARGS="--kubernetes-version=file://$PWD/out/localkube"
 
 
 # Download files and set permissions

--- a/hack/jenkins/windows_integration_test_virtualbox.ps1
+++ b/hack/jenkins/windows_integration_test_virtualbox.ps1
@@ -14,15 +14,14 @@
 
 mkdir -p out
 gsutil.cmd cp gs://minikube-builds/$env:MINIKUBE_LOCATION/minikube-windows-amd64.exe out/
+gsutil.cmd cp gs://minikube-builds/$env:MINIKUBE_LOCATION/localkube out/
 gsutil.cmd cp gs://minikube-builds/$env:MINIKUBE_LOCATION/e2e-windows-amd64.exe out/
 gsutil.cmd cp -r gs://minikube-builds/$env:MINIKUBE_LOCATION/testdata .
-
 
 ./out/minikube-windows-amd64.exe delete
 Remove-Item -Recurse -Force C:\Users\jenkins\.minikube
 
-out/e2e-windows-amd64.exe --% -minikube-start-args="--vm-driver=virtualbox --kubernetes-version=file://./out/localkube " -minikube-args="--v=10 --logtostderr" -test.v -test.timeout=30m -binary=out/minikube-windows-amd64.exe
-
+out/e2e-windows-amd64.exe -minikube-start-args="--vm-driver=virtualbox --kubernetes-version=https://storage.googleapis.com/minikube-builds/$env:MINIKUBE_LOCATION/localkube" -minikube-args="--v=10 --logtostderr" -binary=out/minikube-windows-amd64.exe -test.v -test.timeout=30m
 $env:result=$lastexitcode
 # If the last exit code was 0->success, x>0->error
 If($env:result -eq 0){$env:status="success"}

--- a/hack/jenkins/windows_integration_test_virtualbox.ps1
+++ b/hack/jenkins/windows_integration_test_virtualbox.ps1
@@ -21,7 +21,7 @@ gsutil.cmd cp -r gs://minikube-builds/$env:MINIKUBE_LOCATION/testdata .
 ./out/minikube-windows-amd64.exe delete
 Remove-Item -Recurse -Force C:\Users\jenkins\.minikube
 
-out/e2e-windows-amd64.exe --% -minikube-start-args="--vm-driver=virtualbox" -minikube-args="--v=10 --logtostderr $env:EXTRA_BUILD_ARGS" -test.v -test.timeout=30m -binary=out/minikube-windows-amd64.exe
+out/e2e-windows-amd64.exe --% -minikube-start-args="--vm-driver=virtualbox --kubernetes-version=file://./out/localkube " -minikube-args="--v=10 --logtostderr" -test.v -test.timeout=30m -binary=out/minikube-windows-amd64.exe
 
 $env:result=$lastexitcode
 # If the last exit code was 0->success, x>0->error

--- a/pkg/minikube/kubernetes_versions/kubernetes_versions.go
+++ b/pkg/minikube/kubernetes_versions/kubernetes_versions.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"k8s.io/minikube/pkg/minikube/constants"
 
@@ -80,6 +81,9 @@ func GetK8sVersionsFromURL(url string) (K8sReleases, error) {
 }
 
 func IsValidLocalkubeVersion(v string, url string) (bool, error) {
+	if strings.HasPrefix(v, "file://") {
+		return true, nil
+	}
 	k8sReleases, err := GetK8sVersionsFromURL(url)
 	glog.Infoln(k8sReleases)
 	if err != nil {

--- a/pkg/minikube/kubernetes_versions/kubernetes_versions.go
+++ b/pkg/minikube/kubernetes_versions/kubernetes_versions.go
@@ -81,7 +81,7 @@ func GetK8sVersionsFromURL(url string) (K8sReleases, error) {
 }
 
 func IsValidLocalkubeVersion(v string, url string) (bool, error) {
-	if strings.HasPrefix(v, "file://") {
+	if strings.HasPrefix(v, "file://") || strings.HasPrefix(v, "http") {
 		return true, nil
 	}
 	k8sReleases, err := GetK8sVersionsFromURL(url)


### PR DESCRIPTION
Use the localkube binary built from CI in the integration tests.

Needed since https://github.com/kubernetes/minikube/pull/2089