### PR TITLE
~/.minikube/files as rootfs "layer"

### DIFF
--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -225,9 +225,14 @@ func addMinikubeDirToAssets(basedir, vmpath string, assets *[]CopyableFile) erro
 				rPath = filepath.Dir(rPath)
 				vmpath = filepath.Join("/", rPath)
 			}
-			// While not technically correct, we add a leading 0 here (this won't account for the higher order permissions)
-			// Since the leading 0 is stripped when converting to octal.
-			f, err := NewFileAsset(hostpath, vmpath, filepath.Base(hostpath), fmt.Sprintf("0%o", info.Mode().Perm()))
+			permString := fmt.Sprintf("%o", info.Mode().Perm())
+			// The conversion will strip the leading 0 if present, so add it back
+			// if we need to.
+			if len(permString) == 3 {
+				permString = fmt.Sprintf("0%s", permString)
+			}
+
+			f, err := NewFileAsset(hostpath, vmpath, filepath.Base(hostpath), permString)
 			if err != nil {
 				return errors.Wrapf(err, "creating file asset for %s", hostpath)
 			}

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/golang/glog"
+	"github.com/pkg/errors"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/util"
@@ -196,22 +196,48 @@ var Addons = map[string]*Addon{
 	}, false, "registry-creds"),
 }
 
-func AddMinikubeDirToAssets(minipath string, vmpath string, assetList *[]CopyableFile) {
-	// loop over $MINIKUBE_HOME/minipath and add them to assets
-	searchDir := constants.MakeMiniPath(minipath)
-	err := filepath.Walk(searchDir, func(miniFile string, f os.FileInfo, err error) error {
-		isDir, err := util.IsDirectory(miniFile)
-		if err == nil && !isDir {
-			f, err := NewFileAsset(miniFile, vmpath, filepath.Base(miniFile), "0640")
-			if err == nil {
-				*assetList = append(*assetList, f)
-			}
-		} else if err != nil {
-			glog.Infoln(fmt.Sprintf("Error encountered while walking %s: ", searchDir), err)
+func AddMinikubeDirAssets(assets *[]CopyableFile) error {
+	if err := addMinikubeDirToAssets(constants.MakeMiniPath("addons"), constants.AddonsPath, assets); err != nil {
+		return errors.Wrap(err, "adding addons folder to assets")
+	}
+	if err := addMinikubeDirToAssets(constants.MakeMiniPath("files"), "", assets); err != nil {
+		return errors.Wrap(err, "adding files rootfs to assets")
+	}
+
+	return nil
+}
+
+// AddMinikubeDirToAssets adds all the files in the basedir argument to the list
+// of files to be copied to the vm.  If vmpath is left blank, the files will be
+// transferred to the location according to their relative minikube folder path.
+func addMinikubeDirToAssets(basedir, vmpath string, assets *[]CopyableFile) error {
+	err := filepath.Walk(basedir, func(hostpath string, info os.FileInfo, err error) error {
+		isDir, err := util.IsDirectory(hostpath)
+		if err != nil {
+			return errors.Wrapf(err, "checking if %s is directory", hostpath)
 		}
+		if !isDir {
+			if vmpath == "" {
+				rPath, err := filepath.Rel(basedir, hostpath)
+				if err != nil {
+					return errors.Wrap(err, "generating relative path")
+				}
+				rPath = filepath.Dir(rPath)
+				vmpath = filepath.Join("/", rPath)
+			}
+			// While not technically correct, we add a leading 0 here (this won't account for the higher order permissions)
+			// Since the leading 0 is stripped when converting to octal.
+			f, err := NewFileAsset(hostpath, vmpath, filepath.Base(hostpath), fmt.Sprintf("0%o", info.Mode().Perm()))
+			if err != nil {
+				return errors.Wrapf(err, "creating file asset for %s", hostpath)
+			}
+			*assets = append(*assets, f)
+		}
+
 		return nil
 	})
 	if err != nil {
-		glog.Infoln(fmt.Sprintf("Error encountered while walking %s: ", searchDir), err)
+		return errors.Wrap(err, "walking filepath")
 	}
+	return nil
 }

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -132,7 +132,9 @@ func (k *KubeadmBootstrapper) StartCluster(k8s bootstrapper.KubernetesConfig) er
 func addAddons(files *[]assets.CopyableFile) error {
 	// add addons to file list
 	// custom addons
-	assets.AddMinikubeDirToAssets("addons", constants.AddonsPath, files)
+	if err := assets.AddMinikubeDirAssets(files); err != nil {
+		return errors.Wrap(err, "adding minikube dir assets")
+	}
 	// bundled addons
 	for addonName, addonBundle := range assets.Addons {
 		// TODO(r2d4): Kubeadm ignores the kube-dns addon and uses its own.

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -261,15 +261,6 @@ func (k *KubeadmBootstrapper) UpdateCluster(cfg bootstrapper.KubernetesConfig) e
 		assets.NewMemoryAssetTarget([]byte(kubeadmCfg), constants.KubeadmConfigFile, "0640"),
 	}
 
-	if err := addAddons(&files); err != nil {
-		return errors.Wrap(err, "adding addons to copyable files")
-	}
-
-	for _, f := range files {
-		if err := k.c.Copy(f); err != nil {
-			return errors.Wrapf(err, "transferring kubeadm file: %+v", f)
-		}
-	}
 	var g errgroup.Group
 	for _, bin := range []string{"kubelet", "kubeadm"} {
 		bin := bin
@@ -290,6 +281,16 @@ func (k *KubeadmBootstrapper) UpdateCluster(cfg bootstrapper.KubernetesConfig) e
 	}
 	if err := g.Wait(); err != nil {
 		return errors.Wrap(err, "downloading binaries")
+	}
+
+	if err := addAddons(&files); err != nil {
+		return errors.Wrap(err, "adding addons to copyable files")
+	}
+
+	for _, f := range files {
+		if err := k.c.Copy(f); err != nil {
+			return errors.Wrapf(err, "transferring kubeadm file: %+v", f)
+		}
 	}
 
 	err = k.c.Run(`

--- a/pkg/minikube/bootstrapper/localkube/localkube.go
+++ b/pkg/minikube/bootstrapper/localkube/localkube.go
@@ -123,11 +123,10 @@ func (lk *LocalkubeBootstrapper) UpdateCluster(config bootstrapper.KubernetesCon
 	}
 	copyableFiles = append(copyableFiles, localkubeFile)
 
-	// user added files
-	assets.AddMinikubeDirToAssets("files", constants.FilesPath, &copyableFiles)
-
 	// custom addons
-	assets.AddMinikubeDirToAssets("addons", constants.AddonsPath, &copyableFiles)
+	if err := assets.AddMinikubeDirAssets(&copyableFiles); err != nil {
+		return errors.Wrap(err, "adding minikube dir assets")
+	}
 	// bundled addons
 	for _, addonBundle := range assets.Addons {
 		if isEnabled, err := addonBundle.IsEnabled(); err == nil && isEnabled {

--- a/pkg/minikube/bootstrapper/ssh_runner.go
+++ b/pkg/minikube/bootstrapper/ssh_runner.go
@@ -112,8 +112,9 @@ func (s *SSHRunner) Copy(f assets.CopyableFile) error {
 	}()
 
 	scpcmd := fmt.Sprintf("sudo scp -t %s", f.GetTargetDir())
-	if err := sess.Run(scpcmd); err != nil {
-		return errors.Wrapf(err, "Error running scp command: %s", scpcmd)
+	out, err := sess.CombinedOutput(scpcmd)
+	if err != nil {
+		return errors.Wrapf(err, "Error running scp command: %s output: %s", scpcmd, out)
 	}
 	wg.Wait()
 


### PR DESCRIPTION
This PR applies the `~/.minikube/files` directory as a rootfs rather than just scp-ing the files into `/files`.  The VM path will be calculated relatively to the `~/.minikube/files` folder.  

Some examples when `MINIKUBE_HOME=~/.minikube`

A file at `~/.minikube/files/var/log/testing` will show up in the VM at `/var/log/testing`.

On the surface this doesn't seem to useful, but you can use it to symlink binaries and utilities:

`ln -s ~/go/src/k8s.io/kubernetes/_output/bin/kubelet ~/.minikube/files/usr/bin/kubelet` will let you use a custom kubelet in your minikube cluster.

I don't think this will work on windows, since that would equate to translating a windows path to a linux path, which should probably not work.  If the test fails, I'll figure out how best to handle that.
