### PR TITLE
Fix Update Kubernetes Procedure + Docs

### DIFF
--- a/docs/contributors/updating_kubernetes.md
+++ b/docs/contributors/updating_kubernetes.md
@@ -44,7 +44,7 @@ Make sure to also fetch tags, as Godep relies on these.
 
  ```shell
  git checkout $DESIREDTAG
- ./hack/godeps/godep-restore.sh
+ ./hack/godep-restore.sh
  ```
 
 4. Build and test minikube, making any manual changes necessary to build.

--- a/hack/godeps/godep-restore.sh
+++ b/hack/godeps/godep-restore.sh
@@ -33,6 +33,7 @@ if [ ! -d "${KUBE_ROOT}" ]; then
 fi
 
 godep::restore_kubernetes
+godep::remove_staging_from_json
 
 pushd ${MINIKUBE_ROOT} >/dev/null
     godep restore ./...


### PR DESCRIPTION
**Problem**

The contributor guide [instructions](https://github.com/kubernetes/minikube/blob/master/docs/contributors/updating_kubernetes.md) for updating k8s do not work out of the box. Step 2 is broken:

> cd minikube
./hack/godeps/godep-restore.sh

This step cannot work because the commits [referenced](https://github.com/kubernetes/minikube/blob/master/Godeps/Godeps.json) in `Godeps.json` do not actually exist in upstream repositories. They are generated on the local disk of the maintainer by the [utility script](https://github.com/kubernetes/minikube/blob/master/hack/godeps/utils.sh#L49).

If you try to run Minikube's `godep-restore.sh` you will get similar errors:

```
# cd /go/src/k8s.io/api; git pull --ff-only
fatal: No remote repository specified.  Please, specify either a URL or a
remote name from which new revisions should be fetched.
```

```
# cd /go/src/k8s.io/client-go; git checkout fd59f93b7574e389d897810805348182e136776a
fatal: reference is not a tree: fd59f93b7574e389d897810805348182e136776a
```

**Solution**

1. Remove staging dependencies from `Godeps.json` during `godep-restore.sh`
1. Update docs to reference the correct path to Kubernetes' `godep-restore.sh` [script](https://github.com/kubernetes/kubernetes/blob/master/hack/godep-restore.sh).






