### PR TITLE
ingress: Add support for tcp and udp services

### DIFF
--- a/deploy/addons/ingress/ingress-rc.yaml
+++ b/deploy/addons/ingress/ingress-rc.yaml
@@ -114,3 +114,5 @@ spec:
         - /nginx-ingress-controller
         - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
         - --configmap=$(POD_NAMESPACE)/nginx-load-balancer-conf
+        - --tcp-services-configmap=$(POD_NAMESPACE)/tcp-services
+        - --udp-services-configmap=$(POD_NAMESPACE)/udp-services


### PR DESCRIPTION
This patch adds awareness for TCP and UDP services.
We need this as a preparation to support KubeVirt on minikube (i.e. we need to export a SPICE proxy).