### PR TITLE
Add deployment cleanup to minikube quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ client_address=192.168.99.1
 command=GET
 real path=/
 ...
+$ kubectl delete deployment hello-minikube
+deployment "hello-minikube" deleted
 $ minikube stop
 Stopping local Kubernetes cluster...
 Machine stopped.


### PR DESCRIPTION
This change adds explicit cleanup of the example deployment created in the Quickstart documentation in the interest of enhancing developer first-run experience for novices to Kubernetes.

Fixes #2152