### PR TITLE
[addon] Bump ingress to 0.9.0-beta.16, and add minikube-addons endpoint

### DIFF
--- a/deploy/addons/ingress/ingress-rc.yaml
+++ b/deploy/addons/ingress/ingress-rc.yaml
@@ -36,7 +36,7 @@ spec:
         # Any image is permissable as long as:
         # 1. It serves a 404 page at /
         # 2. It serves 200 on a /healthz endpoint
-        image: gcr.io/google_containers/defaultbackend:1.3
+        image: gcr.io/google_containers/defaultbackend:1.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -77,7 +77,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.15
+      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0-beta.16
         name: nginx-ingress-controller
         imagePullPolicy: IfNotPresent
         readinessProbe:

--- a/deploy/addons/ingress/ingress-svc.yaml
+++ b/deploy/addons/ingress/ingress-svc.yaml
@@ -19,6 +19,8 @@ metadata:
   namespace: kube-system
   labels:
     app: default-http-backend
+    kubernetes.io/minikube-addons: ingress
+    kubernetes.io/minikube-addons-endpoint: ingress
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   type: NodePort


### PR DESCRIPTION
This PR has been tested on latest(https://github.com/kubernetes/minikube/commit/7e0131e1de4ad552e3235467bd399601c98b78b6) build minikube.iso and localkube.
```sh
$ kubectl -n kube-system get po
NAME                             READY     STATUS    RESTARTS   AGE
default-http-backend-z746h       1/1       Running   0          15s
kube-addon-manager-minikube      1/1       Running   0          1m
kube-dns-6fc954457d-2n8tb        3/3       Running   0          1m
kubernetes-dashboard-nxpd7       1/1       Running   0          1m
nginx-ingress-controller-rxfnd   1/1       Running   0          17s

$ ./out/minikube addons open ingress   
Opening kubernetes service kube-system/default-http-backend in default browser...
Created new window in existing browser session.
```

![](https://i.imgur.com/PNWKWGz.png)