### PR TITLE
More storage provisioner fixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ LOCALKUBE_VERSION := $(shell $(PYTHON) hack/get_k8s_version.py --k8s-version-onl
 LOCALKUBE_BUCKET ?= minikube/k8sReleases
 LOCALKUBE_UPLOAD_LOCATION := gs://${LOCALKUBE_BUCKET}
 TAG ?= $(LOCALKUBE_VERSION)
+STORAGE_PROVISIONER_TAG := v1.8.1
 
 # Set the version information for the Kubernetes servers, and build localkube statically
 K8S_VERSION_LDFLAGS := $(shell $(PYTHON) hack/get_k8s_version.py 2>&1)
@@ -305,11 +306,11 @@ out/storage-provisioner: $(shell $(STORAGE_PROVISIONER_FILES))
 
 .PHONY: storage-provisioner-image
 storage-provisioner-image: out/storage-provisioner
-	docker build -t $(REGISTRY)/storage-provisioner:$(TAG) -f deploy/storage-provisioner/Dockerfile .
+	docker build -t $(REGISTRY)/storage-provisioner:$(STORAGE_PROVISIONER_TAG) -f deploy/storage-provisioner/Dockerfile .
 
 .PHONY: push-storage-provisioner-image
 push-storage-provisioner-image: storage-provisioner-image
-	gcloud docker -- push $(REGISTRY)/storage-provisioner:$(TAG)
+	gcloud docker -- push $(REGISTRY)/storage-provisioner:$(STORAGE_PROVISIONER_TAG)
 
 .PHONY: release-iso
 release-iso: minikube_iso checksum

--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,7 @@ $(ISO_BUILD_IMAGE): deploy/iso/minikube-iso/Dockerfile
 	@echo "$(@) successfully built"
 
 out/storage-provisioner: $(shell $(STORAGE_PROVISIONER_FILES))
-	go build GOOS=linux -o $(BUILD_DIR)/storage-provisioner -ldflags=$(LOCALKUBE_LDFLAGS) cmd/storage-provisioner/main.go
+	GOOS=linux go build -o $(BUILD_DIR)/storage-provisioner -ldflags=$(LOCALKUBE_LDFLAGS) cmd/storage-provisioner/main.go
 
 .PHONY: storage-provisioner-image
 storage-provisioner-image: out/storage-provisioner

--- a/cmd/storage-provisioner/main.go
+++ b/cmd/storage-provisioner/main.go
@@ -18,11 +18,19 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"os"
+
 	"github.com/golang/glog"
 	"k8s.io/minikube/pkg/localkube"
 )
 
 func main() {
+	// Glog requires that /tmp exists.
+	if err := os.MkdirAll("/tmp", 0755); err != nil {
+		fmt.Printf("Error creating tmpdir: %s\n", err)
+		os.Exit(1)
+	}
 	flag.Parse()
 
 	if err := localkube.StartStorageProvisioner(); err != nil {

--- a/deploy/addons/storage-provisioner/storage-provisioner.yaml
+++ b/deploy/addons/storage-provisioner/storage-provisioner.yaml
@@ -24,5 +24,5 @@ spec:
   hostNetwork: true
   containers:
   - name: storage-provisioner
-    image: gcr.io/k8s-minikube/storage-provisioner:v1.8.0
+    image: gcr.io/k8s-minikube/storage-provisioner:v1.8.1
     imagePullPolicy: IfNotPresent


### PR DESCRIPTION
I'm not sure of a better way to ensure /tmp exists in a from scratch container,
but glog appears to just explode without it.