### PR TITLE
[addon] Update heapster to v1.5.0

### DIFF
--- a/deploy/addons/heapster/grafana-svc.yaml
+++ b/deploy/addons/heapster/grafana-svc.yaml
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,4 +31,4 @@ spec:
     targetPort: ui
   selector:
     addonmanager.kubernetes.io/mode: Reconcile
-    name: influxGrafana
+    k8s-app: influx-grafana

--- a/deploy/addons/heapster/heapster-rc.yaml
+++ b/deploy/addons/heapster/heapster-rc.yaml
@@ -1,31 +1,44 @@
+# Copyright 2017 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: ReplicationController
 metadata:
   labels:
-    addonmanager.kubernetes.io/mode: Reconcile
     k8s-app: heapster
-    name: heapster
     kubernetes.io/minikube-addons: heapster
+    addonmanager.kubernetes.io/mode: Reconcile
   name: heapster
   namespace: kube-system
 spec:
   replicas: 1
   selector:
-    addonmanager.kubernetes.io/mode: Reconcile
     k8s-app: heapster
+    addonmanager.kubernetes.io/mode: Reconcile
   template:
     metadata:
       labels:
-        addonmanager.kubernetes.io/mode: Reconcile
         k8s-app: heapster
+        addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:
       - name: heapster
-        image: gcr.io/google_containers/heapster:v1.4.3
+        image: gcr.io/google_containers/heapster-amd64:v1.5.0-beta.0
         imagePullPolicy: IfNotPresent
         command:
         - /heapster
-        - --source=kubernetes
+        - --source=kubernetes.summary_api:''
         - --sink=influxdb:http://monitoring-influxdb:8086
         - --metric_resolution=60s
         volumeMounts:

--- a/deploy/addons/heapster/heapster-svc.yaml
+++ b/deploy/addons/heapster/heapster-svc.yaml
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,7 +22,6 @@ metadata:
   name: heapster
   namespace: kube-system
 spec:
-  type: NodePort
   ports:
   - port: 80
     targetPort: 8082

--- a/deploy/addons/heapster/influx-grafana-rc.yaml
+++ b/deploy/addons/heapster/influx-grafana-rc.yaml
@@ -1,4 +1,4 @@
-# Copyright 2016 The Kubernetes Authors All rights reserved.
+# Copyright 2017 The Kubernetes Authors All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,21 +15,21 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  labels:
-    name: influxGrafana
-    addonmanager.kubernetes.io/mode: Reconcile
-    kubernetes.io/minikube-addons: heapster
   name: influxdb-grafana
+  labels:
+    k8s-app: influx-grafana
+    kubernetes.io/minikube-addons: heapster
+    addonmanager.kubernetes.io/mode: Reconcile
   namespace: kube-system
 spec:
   replicas: 1
   selector:
+    k8s-app: influx-grafana
     addonmanager.kubernetes.io/mode: Reconcile
-    name: influxGrafana
   template:
     metadata:
       labels:
-        name: influxGrafana
+        k8s-app: influx-grafana
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:

--- a/deploy/addons/heapster/influxdb-svc.yaml
+++ b/deploy/addons/heapster/influxdb-svc.yaml
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,4 +31,4 @@ spec:
     targetPort: 8086
   selector:
     addonmanager.kubernetes.io/mode: Reconcile
-    name: influxGrafana
+    k8s-app: influx-grafana

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -140,7 +140,7 @@ var Addons = map[string]*Addon{
 	}, true, "kube-dns"),
 	"heapster": NewAddon([]*BinDataAsset{
 		NewBinDataAsset(
-			"deploy/addons/heapster/influxGrafana-rc.yaml",
+			"deploy/addons/heapster/influx-grafana-rc.yaml",
 			constants.AddonsPath,
 			"influxGrafana-rc.yaml",
 			"0640"),


### PR DESCRIPTION
Update heapster to v1.5.0, and fix some YAML fields. This PR has tested on upstream localkube, more detail as below:
```sh
$ ./out/minikube addons enable heapster
heapster was successfully enabled

$ kubectl -n kube-system get po,svc
NAME                             READY     STATUS    RESTARTS   AGE
po/heapster-2chhx                1/1       Running   0          1m
po/influxdb-grafana-5qzh8        2/2       Running   0          1m
po/kube-addon-manager-minikube   1/1       Running   0          1h
po/kube-dns-86f6f55dd5-tnssj     3/3       Running   0          1h
po/storage-provisioner           1/1       Running   0          1h

NAME                      TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
svc/heapster              ClusterIP   10.103.226.188   <none>        80/TCP              1m
svc/kube-dns              ClusterIP   10.96.0.10       <none>        53/UDP,53/TCP       1h
svc/monitoring-grafana    NodePort    10.104.237.56    <none>        80:30002/TCP        1m
svc/monitoring-influxdb   ClusterIP   10.111.229.93    <none>        8083/TCP,8086/TCP   1m

$ ./out/minikube addons open heapster
Opening kubernetes service kube-system/monitoring-grafana in default browser...
```

 A preview:
![](https://i.imgur.com/PjF075z.png)