### PR TITLE
Use latest echoserver release

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Connecting to cluster...
 Setting up kubeconfig...
 Kubectl is now configured to use the cluster.
 
-$ kubectl run hello-minikube --image=gcr.io/google_containers/echoserver:1.4 --port=8080
+$ kubectl run hello-minikube --image=gcr.io/google_containers/echoserver:1.8 --port=8080
 deployment "hello-minikube" created
 $ kubectl expose deployment hello-minikube --type=NodePort
 service "hello-minikube" exposed


### PR DESCRIPTION
Following the README instructions, I wasn't able to get an echoserver pod running. I eventually figured out that the 1.4 version was so old it had been removed from gcr.io/google_containers/echoserver - updating allowed it to work.