### PR TITLE
Update nginx-ingress-controller to 0.9-beta.17

### DIFF
--- a/deploy/addons/ingress/ingress-rc.yaml
+++ b/deploy/addons/ingress/ingress-rc.yaml
@@ -77,7 +77,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0-beta.16
+      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0-beta.17
         name: nginx-ingress-controller
         imagePullPolicy: IfNotPresent
         readinessProbe:
@@ -116,3 +116,5 @@ spec:
         - --configmap=$(POD_NAMESPACE)/nginx-load-balancer-conf
         - --tcp-services-configmap=$(POD_NAMESPACE)/tcp-services
         - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
+        # use minikube IP address in ingress status field
+        - --report-node-internal-ip-address


### PR DESCRIPTION
Update ingress controller version and add flag `--report-node-internal-ip-address` to use minikube IP address in ingress status field