### PR TITLE
Add cache command to cache non-minikube images

### DIFF
--- a/cmd/minikube/cmd/cache.go
+++ b/cmd/minikube/cmd/cache.go
@@ -20,11 +20,9 @@ import (
 	"fmt"
 	"github.com/spf13/cobra"
 	cmdConfig "k8s.io/minikube/cmd/minikube/cmd/config"
-	"k8s.io/minikube/pkg/minikube/bootstrapper"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/machine"
-	"k8s.io/minikube/pkg/minikube/sshutil"
 	"os"
 )
 
@@ -42,14 +40,12 @@ var addCacheCmd = &cobra.Command{
 	Long:  "Add an image to local cache.",
 	Run: func(cmd *cobra.Command, args []string) {
 		// Cache and load images into docker daemon
-		err := cacheAndLoadImages(args)
-		if err != nil {
+		if err := machine.CacheAndLoadImages(args); err != nil {
 			fmt.Fprintf(os.Stderr, "Error caching and loading images: %s\n", err)
 			os.Exit(1)
 		}
 		// Add images to config file
-		err = cmdConfig.AddToConfigArray("cache", args)
-		if err != nil {
+		if err := cmdConfig.AddToConfigMap(constants.Cache, args); err != nil {
 			fmt.Fprintf(os.Stderr, "Error adding cached images to config file: %s\n", err)
 			os.Exit(1)
 		}
@@ -62,25 +58,16 @@ var deleteCacheCmd = &cobra.Command{
 	Short: "Delete an image from the local cache.",
 	Long:  "Delete an image from the local cache.",
 	Run: func(cmd *cobra.Command, args []string) {
-
-		cmdRunner, err := getCommandRunner()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error getting command runner: %s\n", err)
-			os.Exit(1)
-		}
-		// Delete images from docker daemon
-		err = machine.DeleteImages(cmdRunner, args)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error deleting images: %s\n", err)
-			os.Exit(1)
-		}
 		// Delete images from config file
-		err = cmdConfig.DeleteFromConfigArray("cache", args)
-		if err != nil {
+		if err := cmdConfig.DeleteFromConfigMap(constants.Cache, args); err != nil {
 			fmt.Fprintf(os.Stderr, "Error deleting images from config file: %s\n", err)
 			os.Exit(1)
 		}
-
+		// Delete images from cache/images directory
+		if err := machine.DeleteFromImageCacheDir(args); err != nil {
+			fmt.Fprintf(os.Stderr, "Error deleting images: %s\n", err)
+			os.Exit(1)
+		}
 	},
 }
 
@@ -90,56 +77,14 @@ func LoadCachedImagesInConfigFile() error {
 	if err != nil {
 		return err
 	}
-
-	values := configFile["cache"]
-
-	if values == nil {
-		return nil
+	if values, ok := configFile[constants.Cache]; ok {
+		var images []string
+		for key := range values.(map[string]interface{}) {
+			images = append(images, key)
+		}
+		return machine.CacheAndLoadImages(images)
 	}
-
-	var images []string
-
-	for _, v := range values.([]interface{}) {
-		images = append(images, v.(string))
-	}
-
-	return cacheAndLoadImages(images)
-
-}
-
-func cacheAndLoadImages(images []string) error {
-
-	err := machine.CacheImages(images, constants.ImageCacheDir)
-	if err != nil {
-		return err
-	}
-
-	cmdRunner, err := getCommandRunner()
-	if err != nil {
-		return err
-	}
-
-	return machine.LoadImages(cmdRunner, images, constants.ImageCacheDir)
-
-}
-
-func getCommandRunner() (*bootstrapper.SSHRunner, error) {
-	api, err := machine.NewAPIClient()
-	if err != nil {
-		return nil, err
-	}
-	defer api.Close()
-	h, err := api.Load(config.GetMachineName())
-	if err != nil {
-		return nil, err
-	}
-
-	client, err := sshutil.NewSSHClient(h.Driver)
-	if err != nil {
-		return nil, err
-	}
-	return bootstrapper.NewSSHRunner(client), nil
-
+	return nil
 }
 
 func init() {

--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -196,6 +196,7 @@ var settings = []Setting{
 	},
 	{
 		name:   "cache",
+		set:    SetConfigMap,
 		setMap: SetMap,
 	},
 }

--- a/cmd/minikube/cmd/config/util.go
+++ b/cmd/minikube/cmd/config/util.go
@@ -60,7 +60,7 @@ func SetString(m config.MinikubeConfig, name string, val string) error {
 	return nil
 }
 
-func SetStringArray(m config.MinikubeConfig, name string, val []string) error {
+func SetMap(m config.MinikubeConfig, name string, val map[string]interface{}) error {
 	m[name] = val
 	return nil
 }

--- a/cmd/minikube/cmd/config/util.go
+++ b/cmd/minikube/cmd/config/util.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 	"k8s.io/minikube/pkg/minikube/assets"
@@ -62,6 +63,16 @@ func SetString(m config.MinikubeConfig, name string, val string) error {
 
 func SetMap(m config.MinikubeConfig, name string, val map[string]interface{}) error {
 	m[name] = val
+	return nil
+}
+
+func SetConfigMap(m config.MinikubeConfig, name string, val string) error {
+	list := strings.Split(val, ",")
+	v := make(map[string]interface{})
+	for _, s := range list {
+		v[s] = nil
+	}
+	m[name] = v
 	return nil
 }
 

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -338,7 +338,6 @@ This can also be done automatically by setting the env var CHANGE_MINIKUBE_NONE_
 	if err != nil {
 		fmt.Println("Unable to load cached images from config file.")
 	}
-
 }
 
 func validateK8sVersion(version string) {

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -66,6 +66,9 @@ const DefaultMachineName = "minikube"
 // The name of the default storage class provisioner
 const DefaultStorageClassProvisioner = "standard"
 
+// Used to modify the cache field in the config file
+const Cache = "cache"
+
 // MakeMiniPath is a utility to calculate a relative path to our directory.
 func MakeMiniPath(fileName ...string) string {
 	args := []string{GetMinipath()}

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -212,7 +212,7 @@ func LoadFromCacheBlocking(cmd bootstrapper.CommandRunner, src string) error {
 		return errors.Wrapf(err, "loading docker image: %s", dst)
 	}
 
-	if err := cmd.Run("rm -rf " + dst); err != nil {
+	if err := cmd.Run("sudo rm -rf " + dst); err != nil {
 		return errors.Wrap(err, "deleting temp docker image location")
 	}
 

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -27,7 +27,9 @@ import (
 
 	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/bootstrapper"
+	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/sshutil"
 
 	"github.com/containers/image/copy"
 	"github.com/containers/image/docker"
@@ -97,25 +99,30 @@ func LoadImages(cmd bootstrapper.CommandRunner, images []string, cacheDir string
 	return nil
 }
 
-// DeleteImages deletes images from local daemon
-func DeleteImages(cmd bootstrapper.CommandRunner, images []string) error {
-	var g errgroup.Group
-	for _, image := range images {
-		image := image
-		g.Go(func() error {
-			dockerDeleteCmd := "docker rmi " + image
-			if err := cmd.Run(dockerDeleteCmd); err != nil {
-				return errors.Wrapf(err, "deleting docker image: %s", image)
-			}
-			return nil
-		})
+func CacheAndLoadImages(images []string) error {
+	if err := CacheImages(images, constants.ImageCacheDir); err != nil {
+		return err
 	}
-	if err := g.Wait(); err != nil {
-		return errors.Wrap(err, "deleting cached images")
+	api, err := NewAPIClient()
+	if err != nil {
+		return err
 	}
-	glog.Infoln("Successfully deleted cached images.")
-	return nil
+	defer api.Close()
+	h, err := api.Load(config.GetMachineName())
+	if err != nil {
+		return err
+	}
 
+	client, err := sshutil.NewSSHClient(h.Driver)
+	if err != nil {
+		return err
+	}
+	cmdRunner, err := bootstrapper.NewSSHRunner(client), nil
+	if err != nil {
+		return err
+	}
+
+	return LoadImages(cmdRunner, images, constants.ImageCacheDir)
 }
 
 // # ParseReference cannot have a : in the directory path
@@ -205,12 +212,49 @@ func LoadFromCacheBlocking(cmd bootstrapper.CommandRunner, src string) error {
 		return errors.Wrapf(err, "loading docker image: %s", dst)
 	}
 
-	if err := cmd.Run("sudo rm -rf " + dst); err != nil {
+	if err := cmd.Run("rm -rf " + dst); err != nil {
 		return errors.Wrap(err, "deleting temp docker image location")
 	}
 
 	glog.Infof("Successfully loaded image %s from cache", src)
 	return nil
+}
+
+func DeleteFromImageCacheDir(images []string) error {
+	for _, image := range images {
+		path := filepath.Join(constants.ImageCacheDir, image)
+		glog.Infoln("Deleting image in cache at ", path)
+		if err := os.Remove(path); err != nil {
+			return err
+		}
+	}
+	return cleanImageCacheDir()
+}
+
+func cleanImageCacheDir() error {
+	err := filepath.Walk(constants.ImageCacheDir, func(path string, info os.FileInfo, err error) error {
+		// If error is not nil, it's because the path was already deleted and doesn't exist
+		// Move on to next path
+		if err != nil {
+			return nil
+		}
+		// Check if path is directory
+		if !info.IsDir() {
+			return nil
+		}
+		// If directory is empty, delete it
+		entries, err := ioutil.ReadDir(path)
+		if err != nil {
+			return err
+		}
+		if len(entries) == 0 {
+			if err = os.Remove(path); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	return err
 }
 
 func getSrcRef(image string) (types.ImageReference, error) {


### PR DESCRIPTION
The cache command adds and deletes images through the cache add and cache delete subcommands. The list of cached images is stored as a string array in the config file, so that it can be loaded into the docker daemon on minikube start.

#2065 