### PR TITLE
Make it known that get-k8s-versions is only relevant when using localkube

### DIFF
--- a/cmd/minikube/cmd/get_kubernetes_versions.go
+++ b/cmd/minikube/cmd/get_kubernetes_versions.go
@@ -26,8 +26,8 @@ import (
 // getK8sVersionsCmd represents the ip command
 var getK8sVersionsCmd = &cobra.Command{
 	Use:   "get-k8s-versions",
-	Short: "Gets the list of available kubernetes versions available for minikube",
-	Long:  `Gets the list of available kubernetes versions available for minikube.`,
+	Short: "Gets the list of Kubernetes versions available for minikube when using the localkube bootstrapper",
+	Long:  `Gets the list of Kubernetes versions available for minikube when using the localkube bootstrapper.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		kubernetes_versions.PrintKubernetesVersionsFromGCS(os.Stdout)
 	},

--- a/pkg/minikube/kubernetes_versions/kubernetes_versions.go
+++ b/pkg/minikube/kubernetes_versions/kubernetes_versions.go
@@ -39,7 +39,7 @@ func PrintKubernetesVersions(output io.Writer, url string) {
 		glog.Errorln(err)
 		return
 	}
-	fmt.Fprint(output, "The following Kubernetes versions are available: \n")
+	fmt.Fprint(output, "The following Kubernetes versions are available when using the localkube bootstrapper: \n")
 
 	for _, k8sVersion := range k8sVersions {
 		fmt.Fprintf(output, "\t- %s\n", k8sVersion.Version)


### PR DESCRIPTION
Added a reference to localkube in the help text and in the output from
the command.

(Also removed the redundant word "available" and changed the capitalization of Kubernetes.)