### PR TITLE
Documentation: Cite CRI-O as available container runtime.

### DIFF
--- a/docs/alternative_runtimes.md
+++ b/docs/alternative_runtimes.md
@@ -7,3 +7,25 @@ $ minikube start \
     --network-plugin=cni \
     --container-runtime=rkt
 ```
+
+
+### Using CRI-O
+
+To use [CRI-O](https://github.com/kubernetes-incubator/cri-o) as the container runtime, run:
+
+```bash
+$ minikube start \
+    --network-plugin=cni \
+    --container-runtime=cri-o \
+    --bootstrapper=kubeadm
+```
+
+Or you can use the extended version:
+
+```bash
+$ minikube start \
+    --network-plugin=cni \
+    --extra-config=kubelet.container-runtime=remote \
+    --extra-config=kubelet.container-runtime-endpoint=/var/run/crio.sock \
+    --extra-config=image-service-endpoint=/var/run/crio.sock
+```

--- a/docs/contributors/minikube_iso.md
+++ b/docs/contributors/minikube_iso.md
@@ -6,6 +6,7 @@ It includes:
 - systemd as the init system
 - rkt
 - docker
+- CRI-O
 
 ## Hacking
 


### PR DESCRIPTION
Signed-off-by: Lorenzo Fontana <lo@linux.com>