### PR TITLE
docs(alternative runtime): fix extra config flag

### DIFF
--- a/docs/alternative_runtimes.md
+++ b/docs/alternative_runtimes.md
@@ -27,5 +27,5 @@ $ minikube start \
     --network-plugin=cni \
     --extra-config=kubelet.container-runtime=remote \
     --extra-config=kubelet.container-runtime-endpoint=/var/run/crio.sock \
-    --extra-config=image-service-endpoint=/var/run/crio.sock
+    --extra-config=kubelet.image-service-endpoint=/var/run/crio.sock
 ```


### PR DESCRIPTION
Add `kubelet` to `-extra-config` which is missing causing it to
be wrong command.