### PR TITLE
docs: extra-config with flags requires kubeadm

### DIFF
--- a/docs/alternative_runtimes.md
+++ b/docs/alternative_runtimes.md
@@ -27,5 +27,6 @@ $ minikube start \
     --network-plugin=cni \
     --extra-config=kubelet.container-runtime=remote \
     --extra-config=kubelet.container-runtime-endpoint=/var/run/crio.sock \
-    --extra-config=kubelet.image-service-endpoint=/var/run/crio.sock
+    --extra-config=kubelet.image-service-endpoint=/var/run/crio.sock \
+    --bootstrapper=kubeadm
 ```


### PR DESCRIPTION
To use the extra-config options with flags (instead of struct fields),
the kubeadm bootstrapper needs to be used.

Fixes #2224 