### PR TITLE
localkube-dind: Fix readme.

### DIFF
--- a/deploy/docker/localkube-dind/README.md
+++ b/deploy/docker/localkube-dind/README.md
@@ -5,7 +5,7 @@
 #### How to build
 From root minikube/ directory run:
 ```console
-$ make localkube-image #optional env-vars: TAG=LOCALKUBE_VERSION REGISTRY=gcr.io/k8s-minikube
+$ make localkube-dind-image #optional env-vars: TAG=LOCALKUBE_VERSION REGISTRY=gcr.io/k8s-minikube
 ```
 
 #### How to run
@@ -17,7 +17,7 @@ $ docker run -it \
   -p 127.0.0.1:8080:8080 \
   -v /boot:/boot \
   -v /lib/modules:/lib/modules \
-  gcr.io/k8s-minikube/localkube-image:v1.7.0 \
+  gcr.io/k8s-minikube/localkube-dind-image:v1.7.0 \
   /start.sh
 ```
 


### PR DESCRIPTION
Fix the image name from localkube-image to localkube-dind-image in the readme.