### PR TITLE
Add integration test for ingress addon

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -33,6 +33,7 @@ gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/e2e-${OS_ARCH} out/
 gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/testdata/busybox.yaml testdata/
 gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/testdata/pvc.yaml testdata/
 gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/testdata/busybox-mount-test.yaml testdata/
+gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/testdata/nginx-ing.yaml testdata/
 
 export MINIKUBE_WANTREPORTERRORPROMPT=False
 sudo ./out/minikube-${OS_ARCH} delete || true

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -33,6 +33,7 @@ gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/e2e-${OS_ARCH} out/
 gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/testdata/busybox.yaml testdata/
 gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/testdata/pvc.yaml testdata/
 gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/testdata/busybox-mount-test.yaml testdata/
+gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/testdata/nginx-pod-svc.yaml testdata/
 gsutil cp gs://minikube-builds/${MINIKUBE_LOCATION}/testdata/nginx-ing.yaml testdata/
 
 export MINIKUBE_WANTREPORTERRORPROMPT=False

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -66,6 +67,53 @@ func testDashboard(t *testing.T) {
 	if port != "30000" {
 		t.Fatalf("Dashboard is exposed on wrong port, expected 30000, actual %s", port)
 	}
+}
+
+func testIngressController(t *testing.T) {
+	t.Parallel()
+	minikubeRunner := NewMinikubeRunner(t)
+	kubectlRunner := util.NewKubectlRunner(t)
+
+	minikubeRunner.RunCommand("addons enable ingress", true)
+	if err := util.WaitForIngressControllerRunning(t); err != nil {
+		t.Fatalf("waiting for ingress-controller to be up: %s", err)
+	}
+
+	if err := util.WaitForIngressDefaultBackendRunning(t); err != nil {
+		t.Fatalf("waiting for default-http-backend to be up: %s", err)
+	}
+
+	ingressPath, _ := filepath.Abs("testdata/nginx-ing.yaml")
+	if _, err := kubectlRunner.RunCommand([]string{"create", "-f", ingressPath}); err != nil {
+		t.Fatalf("creating nginx ingress resource: %s", err)
+	}
+
+	podName := "nginx"
+	args := []string{"run", podName, "--image=nginx:alpine", "--port=80", "--restart=Never"}
+	if _, err := kubectlRunner.RunCommand(args); err != nil {
+		t.Fatalf("failed to create nginx pods: %s", err)
+	}
+
+	args = []string{"expose", "pod", podName, "--target-port=80"}
+	if _, err := kubectlRunner.RunCommand(args); err != nil {
+		t.Fatalf("failed to create nginx service: %s", err)
+	}
+
+	if err := util.WaitForNginxRunning(t); err != nil {
+		t.Fatalf("waiting for nginx to be up: %s", err)
+	}
+
+	expectedStr := "Welcome to nginx!"
+	runCmd := fmt.Sprintf("curl http://127.0.0.1:80 -H 'Host: nginx.example.com'")
+	sshCmdOutput, _ := minikubeRunner.SSH(runCmd)
+	if !strings.Contains(sshCmdOutput, expectedStr) {
+		t.Fatalf("ExpectedStr sshCmdOutput to be: %s. Output was: %s", expectedStr, sshCmdOutput)
+	}
+
+	defer kubectlRunner.RunCommand([]string{"delete", "pod", podName})
+	defer kubectlRunner.RunCommand([]string{"delete", "svc", podName})
+	defer kubectlRunner.RunCommand([]string{"delete", "-f", ingressPath})
+	minikubeRunner.RunCommand("addons disable ingress", true)
 }
 
 func testServicesList(t *testing.T) {

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -88,15 +88,9 @@ func testIngressController(t *testing.T) {
 		t.Fatalf("creating nginx ingress resource: %s", err)
 	}
 
-	podName := "nginx"
-	args := []string{"run", podName, "--image=nginx:alpine", "--port=80", "--restart=Never"}
-	if _, err := kubectlRunner.RunCommand(args); err != nil {
-		t.Fatalf("failed to create nginx pods: %s", err)
-	}
-
-	args = []string{"expose", "pod", podName, "--target-port=80"}
-	if _, err := kubectlRunner.RunCommand(args); err != nil {
-		t.Fatalf("failed to create nginx service: %s", err)
+	podPath, _ := filepath.Abs("testdata/nginx-pod-svc.yaml")
+	if _, err := kubectlRunner.RunCommand([]string{"create", "-f", podPath}); err != nil {
+		t.Fatalf("creating nginx ingress resource: %s", err)
 	}
 
 	if err := util.WaitForNginxRunning(t); err != nil {
@@ -110,8 +104,7 @@ func testIngressController(t *testing.T) {
 		t.Fatalf("ExpectedStr sshCmdOutput to be: %s. Output was: %s", expectedStr, sshCmdOutput)
 	}
 
-	defer kubectlRunner.RunCommand([]string{"delete", "pod", podName})
-	defer kubectlRunner.RunCommand([]string{"delete", "svc", podName})
+	defer kubectlRunner.RunCommand([]string{"delete", "-f", podPath})
 	defer kubectlRunner.RunCommand([]string{"delete", "-f", ingressPath})
 	minikubeRunner.RunCommand("addons disable ingress", true)
 }

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -34,13 +34,13 @@ func TestFunctional(t *testing.T) {
 	t.Run("Logs", testClusterLogs)
 	t.Run("Addons", testAddons)
 	t.Run("Dashboard", testDashboard)
-	t.Run("IngressController", testIngressController)
 	t.Run("ServicesList", testServicesList)
 	t.Run("Provisioning", testProvisioning)
 
 	if !strings.Contains(minikubeRunner.StartArgs, "--vm-driver=none") {
 		t.Run("EnvVars", testClusterEnv)
 		t.Run("SSH", testClusterSSH)
+		t.Run("IngressController", testIngressController)
 		// t.Run("Mounting", testMounting)
 	}
 }

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -34,6 +34,7 @@ func TestFunctional(t *testing.T) {
 	t.Run("Logs", testClusterLogs)
 	t.Run("Addons", testAddons)
 	t.Run("Dashboard", testDashboard)
+	t.Run("IngressController", testIngressController)
 	t.Run("ServicesList", testServicesList)
 	t.Run("Provisioning", testProvisioning)
 

--- a/test/integration/testdata/nginx-ing.yaml
+++ b/test/integration/testdata/nginx-ing.yaml
@@ -1,0 +1,15 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: nginx-ingress
+  labels:
+    integration-test: ingress
+spec:
+  rules:
+  - host: nginx.example.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: nginx
+          servicePort: 80

--- a/test/integration/testdata/nginx-pod-svc.yaml
+++ b/test/integration/testdata/nginx-pod-svc.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    run: nginx
+  name: nginx
+  namespace: default
+spec:
+  containers:
+  - name: nginx
+    image: nginx:alpine
+    ports:
+    - containerPort: 80
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    run: nginx
+  name: nginx
+  namespace: default
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    run: nginx
+  sessionAffinity: None
+  type: ClusterIP

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -263,6 +263,63 @@ func WaitForDashboardRunning(t *testing.T) error {
 	return nil
 }
 
+func WaitForIngressControllerRunning(t *testing.T) error {
+	client, err := commonutil.GetClient()
+	if err != nil {
+		return errors.Wrap(err, "getting kubernetes client")
+	}
+
+	if err := commonutil.WaitForRCToStabilize(client, "kube-system", "nginx-ingress-controller", time.Minute*10); err != nil {
+		return errors.Wrap(err, "waiting for ingress-controller RC to stabilize")
+	}
+
+	selector := labels.SelectorFromSet(labels.Set(map[string]string{"app": "nginx-ingress-controller"}))
+	if err := commonutil.WaitForPodsWithLabelRunning(client, "kube-system", selector); err != nil {
+		return errors.Wrap(err, "waiting for ingress-controller pods")
+	}
+
+	return nil
+}
+
+func WaitForIngressDefaultBackendRunning(t *testing.T) error {
+	client, err := commonutil.GetClient()
+	if err != nil {
+		return errors.Wrap(err, "getting kubernetes client")
+	}
+
+	if err := commonutil.WaitForRCToStabilize(client, "kube-system", "default-http-backend", time.Minute*10); err != nil {
+		return errors.Wrap(err, "waiting for default-http-backend RC to stabilize")
+	}
+
+	if err := commonutil.WaitForService(client, "kube-system", "default-http-backend", true, time.Millisecond*500, time.Minute*10); err != nil {
+		return errors.Wrap(err, "waiting for default-http-backend service to be up")
+	}
+
+	if err := commonutil.WaitForServiceEndpointsNum(client, "kube-system", "default-http-backend", 1, time.Second*3, time.Minute*10); err != nil {
+		return errors.Wrap(err, "waiting for one default-http-backend endpoint to be up")
+	}
+
+	return nil
+}
+
+func WaitForNginxRunning(t *testing.T) error {
+	client, err := commonutil.GetClient()
+
+	if err != nil {
+		return errors.Wrap(err, "getting kubernetes client")
+	}
+
+	selector := labels.SelectorFromSet(labels.Set(map[string]string{"run": "nginx"}))
+	if err := commonutil.WaitForPodsWithLabelRunning(client, "default", selector); err != nil {
+		return errors.Wrap(err, "waiting for nginx pods")
+	}
+
+	if err := commonutil.WaitForService(client, "default", "nginx", true, time.Millisecond*500, time.Minute*10); err != nil {
+		t.Errorf("Error waiting for nginx service to be up")
+	}
+	return nil
+}
+
 func Retry(t *testing.T, callback func() error, d time.Duration, attempts int) (err error) {
 	for i := 0; i < attempts; i++ {
 		err = callback()


### PR DESCRIPTION
The commit added test codes for Ingress addon, the feature request from #2174. This test will create a  ingress binding `nginx.example.com` domain name, and resolve to nginx service, finally use HTTP request to check response content.

For test result as below:
```sh
$ make integration
cp ./out/minikube-linux-amd64 ./out/minikube
go test -v -test.timeout=30m k8s.io/minikube/test/integration --tags="integration container_image_ostree_stub containers_image_openpgp" 
=== RUN   TestDocker
Environment=DOCKER_RAMDISK=yes FOO=BAR BAZ=BAT

ExecStart={ path=/usr/bin/dockerd ; argv[]=/usr/bin/dockerd -H tcp://0.0.0.0:2376 -H unix:///var/run/docker.sock --tlsverify --tlscacert /etc/docker/ca.pem --tlscert /etc/docker/server.pem --tlskey /etc/docker/server-key.pem --label provider=virtualbox --insecure-registry 10.96.0.0/12 --debug --icc=true ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }

--- PASS: TestDocker (73.77s)
=== RUN   TestFunctional
=== RUN   TestFunctional/Status
=== RUN   TestFunctional/DNS
=== RUN   TestFunctional/Logs
=== RUN   TestFunctional/Addons
=== RUN   TestFunctional/Dashboard
=== RUN   TestFunctional/IngressController
=== RUN   TestFunctional/ServicesList
=== RUN   TestFunctional/Provisioning
=== RUN   TestFunctional/EnvVars
=== RUN   TestFunctional/SSH
--- PASS: TestFunctional (16.45s)
    --- PASS: TestFunctional/Status (15.46s)
    	cluster_status_test.go:35: Checking if cluster is healthy.
    	cluster_status_test.go:45: Component: , Healthy: True.
    	cluster_status_test.go:45: Component: , Healthy: True.
    	cluster_status_test.go:45: Component: , Healthy: True.
    --- PASS: TestFunctional/Addons (0.24s)
    --- PASS: TestFunctional/SSH (0.55s)
    --- PASS: TestFunctional/EnvVars (0.81s)
    --- PASS: TestFunctional/ServicesList (1.05s)
    --- PASS: TestFunctional/Provisioning (1.39s)
    --- PASS: TestFunctional/Logs (2.15s)
    --- PASS: TestFunctional/Dashboard (9.78s)
    --- PASS: TestFunctional/DNS (12.18s)
    --- PASS: TestFunctional/IngressController (88.20s)
=== RUN   TestPersistence
--- PASS: TestPersistence (84.68s)
=== RUN   TestStartStop
--- PASS: TestStartStop (143.71s)
PASS
ok  	k8s.io/minikube/test/integration	406.872s
```

/cc @r2d4 