### PR TITLE
Add 0.24.0 checksums to releases.json

### DIFF
--- a/deploy/minikube/releases.json
+++ b/deploy/minikube/releases.json
@@ -8,6 +8,14 @@
       }
   },
   {
+        "name": "v0.24.0",
+        "checksums": {
+            "darwin": "7db2045495db05a885c3ad9a0e5e7ff017ae1f2f1a835d9151142df0c6f1d192",
+            "linux": "fb624bfda432c764d19212fcaab2a368db8bb0e8427b7ff04b5b684faab0b463",
+            "windows": "46510a457658e7aee492cc0f1807b3b57c61b1d7154e7ee5b4da607fe681347f"
+        }
+  },
+  {
       "name": "v0.23.0",
       "checksums": {
           "darwin": "3d0c5581cd14f85637fb888c1e2e124152c4c9643a257ba90c8cd929d2c2b8b3",


### PR DESCRIPTION
This weren't uploaded since the release job wasn't fully working for 0.24.0 release.