### PR TITLE
Fix placement of backticks in github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -35,11 +35,10 @@ cat /etc/os-release
 echo "";
 echo "VM driver": 
 grep DriverName ~/.minikube/machines/minikube/config.json
-```
-
 echo "";
 echo "ISO version";
 grep -i ISO ~/.minikube/machines/minikube/config.json
+```
 
 **What happened**:
 


### PR DESCRIPTION
Right now the backticks are misplaced, this commit fixes them and places
them in right place so that the commands can be copied rightfully.