### PR TITLE
Change the cri-o socket location to upstream default

### DIFF
--- a/cmd/localkube/cmd/start.go
+++ b/cmd/localkube/cmd/start.go
@@ -64,13 +64,13 @@ func SetupServer(s *localkube.LocalkubeServer) {
 	if s.ContainerRuntime == "remote" && s.RemoteRuntimeEndpoint == "" {
 		panic("Failed to connect to --container-runtime='remote' with no --container-runtime-endpoint")
 	}
-	// localkube flags can handle `--container-runtime=remote --remote-runtime-endpoint=/var/run/crio.sock --remote-image-endpoint=/var/run/crio.sock`,
+	// localkube flags can handle `--container-runtime=remote --remote-runtime-endpoint=/var/run/crio/crio.sock --remote-image-endpoint=/var/run/crio/crio.sock`,
 	// but this allows for a convenience of just e.g.`--container-runtime=crio` and the same for minikube
 	switch s.ContainerRuntime {
 	case "crio", "cri-o":
 		s.ContainerRuntime = "remote"
-		s.RemoteRuntimeEndpoint = "unix:///var/run/crio.sock"
-		s.RemoteImageEndpoint = "unix:///var/run/crio.sock"
+		s.RemoteRuntimeEndpoint = "unix:///var/run/crio/crio.sock"
+		s.RemoteImageEndpoint = "unix:///var/run/crio/crio.sock"
 	}
 
 	if s.ShouldGenerateCerts {

--- a/deploy/iso/minikube-iso/board/coreos/minikube/rootfs-overlay/var/run/crio.sock
+++ b/deploy/iso/minikube-iso/board/coreos/minikube/rootfs-overlay/var/run/crio.sock
@@ -1,0 +1,1 @@
+crio/crio.sock

--- a/deploy/iso/minikube-iso/package/crio-bin/crio.conf
+++ b/deploy/iso/minikube-iso/package/crio-bin/crio.conf
@@ -23,7 +23,7 @@ storage_option = [
 [crio.api]
 
 # listen is the path to the AF_LOCAL socket on which crio will listen.
-listen = "/var/run/crio.sock"
+listen = "/var/run/crio/crio.sock"
 
 # stream_address is the IP address on which the stream server will listen
 stream_address = ""

--- a/docs/alternative_runtimes.md
+++ b/docs/alternative_runtimes.md
@@ -26,7 +26,7 @@ Or you can use the extended version:
 $ minikube start \
     --network-plugin=cni \
     --extra-config=kubelet.container-runtime=remote \
-    --extra-config=kubelet.container-runtime-endpoint=/var/run/crio.sock \
-    --extra-config=kubelet.image-service-endpoint=/var/run/crio.sock \
+    --extra-config=kubelet.container-runtime-endpoint=/var/run/crio/crio.sock \
+    --extra-config=kubelet.image-service-endpoint=/var/run/crio/crio.sock \
     --bootstrapper=kubeadm
 ```

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -198,8 +198,8 @@ func SetContainerRuntime(cfg map[string]string, runtime string) map[string]strin
 	switch runtime {
 	case "crio", "cri-o":
 		cfg["container-runtime"] = "remote"
-		cfg["container-runtime-endpoint"] = "/var/run/crio.sock"
-		cfg["image-service-endpoint"] = "/var/run/crio.sock"
+		cfg["container-runtime-endpoint"] = "/var/run/crio/crio.sock"
+		cfg["image-service-endpoint"] = "/var/run/crio/crio.sock"
 		cfg["runtime-request-timeout"] = "15m"
 	default:
 		cfg["container-runtime"] = runtime


### PR DESCRIPTION
Right now the cri-o socket is placed in `/var/run/crio.sock`, this
commit changes it to `/var/run/crio/crio.sock` which is similar to
upstream.

Fixes https://github.com/kubernetes/minikube/issues/2261