### PR TITLE
Add cache list support

### DIFF
--- a/cmd/minikube/cmd/cache_list.go
+++ b/cmd/minikube/cmd/cache_list.go
@@ -26,10 +26,10 @@ import (
 	"k8s.io/minikube/pkg/minikube/constants"
 )
 
-const cacheListFormat = "- {{.CacheImageName}}\n"
+var cacheListFormat string
 
 type CacheListTemplate struct {
-	CacheImageName string
+	CacheImage string
 }
 
 // listCacheCmd represents the cache list command
@@ -52,17 +52,20 @@ var listCacheCmd = &cobra.Command{
 }
 
 func init() {
+	listCacheCmd.Flags().StringVar(&cacheListFormat, "format", constants.DefaultCacheListFormat,
+		`Go template format string for the cache list output.  The format for Go templates can be found here: https://golang.org/pkg/text/template/
+For the list of accessible variables for the template, see the struct values here: https://godoc.org/k8s.io/minikube/cmd/minikube/cmd#CacheListTemplate`)
 	cacheCmd.AddCommand(listCacheCmd)
 }
 
-func cacheList(images map[string]interface{}) error {
-	for imageName := range images {
+func cacheList(images []string) error {
+	for _, image := range images {
 		tmpl, err := template.New("list").Parse(cacheListFormat)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating list template: %s\n", err)
 			os.Exit(1)
 		}
-		listTmplt := CacheListTemplate{imageName}
+		listTmplt := CacheListTemplate{image}
 		err = tmpl.Execute(os.Stdout, listTmplt)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error executing list template: %s\n", err)

--- a/cmd/minikube/cmd/cache_list.go
+++ b/cmd/minikube/cmd/cache_list.go
@@ -53,7 +53,6 @@ var listCacheCmd = &cobra.Command{
 
 func init() {
 	cacheCmd.AddCommand(listCacheCmd)
-	RootCmd.AddCommand(cacheCmd)
 }
 
 func cacheList(images map[string]interface{}) error {

--- a/cmd/minikube/cmd/cache_list.go
+++ b/cmd/minikube/cmd/cache_list.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"text/template"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	cmdConfig "k8s.io/minikube/cmd/minikube/cmd/config"
+	"k8s.io/minikube/pkg/minikube/constants"
+)
+
+const cacheListFormat = "- {{.CacheImageName}}\n"
+
+type CacheListTemplate struct {
+	CacheImageName   string
+}
+
+// listCacheCmd represents the cache list command
+var listCacheCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all available images from the local cache.",
+	Long:  "List all available images from the local cache.",
+	Run: func(cmd *cobra.Command, args []string) {
+		// list images from config file
+		images, err := cmdConfig.ListConfigMap(constants.Cache)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error listing images: %s\n", err)
+			os.Exit(1)
+		}
+		if err := cacheList(images); err != nil {
+			fmt.Fprintf(os.Stderr, "Error listing images: %s\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	cacheCmd.AddCommand(listCacheCmd)
+	RootCmd.AddCommand(cacheCmd)
+}
+
+func cacheList(images map[string]interface{}) error {
+	for imageName := range images {
+		tmpl, err := template.New("list").Parse(cacheListFormat)
+		if err != nil {
+			glog.Errorln("Error creating list template:", err)
+			os.Exit(1)
+		}
+		listTmplt := CacheListTemplate{imageName}
+		err = tmpl.Execute(os.Stdout, listTmplt)
+		if err != nil {
+			glog.Errorln("Error executing list template:", err)
+			os.Exit(1)
+		}
+	}
+	return nil
+}

--- a/cmd/minikube/cmd/cache_list.go
+++ b/cmd/minikube/cmd/cache_list.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"text/template"
 
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	cmdConfig "k8s.io/minikube/cmd/minikube/cmd/config"
 	"k8s.io/minikube/pkg/minikube/constants"
@@ -30,7 +29,7 @@ import (
 const cacheListFormat = "- {{.CacheImageName}}\n"
 
 type CacheListTemplate struct {
-	CacheImageName   string
+	CacheImageName string
 }
 
 // listCacheCmd represents the cache list command
@@ -42,7 +41,7 @@ var listCacheCmd = &cobra.Command{
 		// list images from config file
 		images, err := cmdConfig.ListConfigMap(constants.Cache)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error listing images: %s\n", err)
+			fmt.Fprintf(os.Stderr, "Error listing image entries from config: %s\n", err)
 			os.Exit(1)
 		}
 		if err := cacheList(images); err != nil {
@@ -61,13 +60,13 @@ func cacheList(images map[string]interface{}) error {
 	for imageName := range images {
 		tmpl, err := template.New("list").Parse(cacheListFormat)
 		if err != nil {
-			glog.Errorln("Error creating list template:", err)
+			fmt.Fprintf(os.Stderr, "Error creating list template: %s\n", err)
 			os.Exit(1)
 		}
 		listTmplt := CacheListTemplate{imageName}
 		err = tmpl.Execute(os.Stdout, listTmplt)
 		if err != nil {
-			glog.Errorln("Error executing list template:", err)
+			fmt.Fprintf(os.Stderr, "Error executing list template: %s\n", err)
 			os.Exit(1)
 		}
 	}

--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -220,18 +220,18 @@ func configurableFields() string {
 }
 
 // ListConfigMap list entries from config file
-func ListConfigMap(name string) (map[string]interface{}, error) {
+func ListConfigMap(name string) ([]string, error) {
 	configFile, err := config.ReadConfig()
 	if err != nil {
 		return nil, err
 	}
-	newImages := make(map[string]interface{})
+	var images []string
 	if values, ok := configFile[name].(map[string]interface{}); ok {
 		for key := range values {
-			newImages[key] = nil
+			images = append(images, key)
 		}
 	}
-	return newImages, nil
+	return images, nil
 }
 
 // AddToConfigMap adds entries to a map in the config file

--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -219,6 +219,21 @@ func configurableFields() string {
 	return strings.Join(fields, "\n")
 }
 
+// ListConfigMap list entries from config file
+func ListConfigMap(name string) (map[string]interface{}, error) {
+	configFile, err := config.ReadConfig()
+	if err != nil {
+		return nil, err
+	}
+	newImages := make(map[string]interface{})
+	if values, ok := configFile[name].(map[string]interface{}); ok {
+		for key := range values {
+			newImages[key] = nil
+		}
+	}
+	return newImages, nil
+}
+
 // AddToConfigMap adds entries to a map in the config file
 func AddToConfigMap(name string, images []string) error {
 	s, err := findSetting(name)

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -2,4 +2,15 @@
 
 Minikube supports caching non-minikube images using the `minikube cache` command. Images can be added to the cache by running `minikube cache add <img>`, and deleted by running `minikube cache delete <img>`.
 
-Images in the cache will be loaded on `minikube start`.
+Images in the cache will be loaded on `minikube start`. If you want to list all available cached images, you can use `minikube cache list` command to list. Below is an example of this functionality:
+
+```shell
+# cache a image into $HOME/.minikube/cache/images
+$ minikube cache add ubuntu:16.04
+$ minikube cache add redis:3
+
+# list cached images
+$ minikube cache list
+- redis:3
+- ubuntu:16.04
+```

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -96,6 +96,7 @@ const (
 		"cluster: {{.ClusterStatus}}\n" + "kubectl: {{.KubeconfigStatus}}\n"
 	DefaultAddonListFormat     = "- {{.AddonName}}: {{.AddonStatus}}\n"
 	DefaultConfigViewFormat    = "- {{.ConfigKey}}: {{.ConfigValue}}\n"
+	DefaultCacheListFormat     = "{{.CacheImage}}\n"
 	GithubMinikubeReleasesURL  = "https://storage.googleapis.com/minikube/releases.json"
 	KubernetesVersionGCSURL    = "https://storage.googleapis.com/minikube/k8s_releases.json"
 	DefaultWait                = 20


### PR DESCRIPTION
This commit added cache list support. Because currently cannot know which images are cached.

For command result as below:
```sh
$ ./out/minikube cache add ubuntu:16.04 redis:3
$ ./out/minikube cache list
redis:3
ubuntu:16.04
```