### PR TITLE
docs: make hyperkit installation commands readable

### DIFF
--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -82,7 +82,11 @@ It is built from the minikube source tree, and uses [moby/hyperkit](http://githu
 To install the hyperkit driver:
 
 ```
-curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-hyperkit && chmod +x docker-machine-driver-hyperkit && sudo mv docker-machine-driver-hyperkit /usr/local/bin/ && sudo chown root:wheel /usr/local/bin/docker-machine-driver-hyperkit && sudo chmod u+s /usr/local/bin/docker-machine-driver-hyperkit
+curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-hyperkit \
+&& chmod +x docker-machine-driver-hyperkit \
+&& sudo mv docker-machine-driver-hyperkit /usr/local/bin/ \
+&& sudo chown root:wheel /usr/local/bin/docker-machine-driver-hyperkit \
+&& sudo chmod u+s /usr/local/bin/docker-machine-driver-hyperkit
 ```
 
 The hyperkit driver currently requires running as root to use the vmnet framework to setup networking.


### PR DESCRIPTION
Hello!

It is quite hard to read and copy the hyperkit driver installation commands from the current docs/drivers.md view.
If it is possible, could you please divide these command into few lines?

Thanks.