### PR TITLE
List KVM2 driver in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ the following drivers:
 
 * virtualbox
 * vmwarefusion
-* [KVM](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm-driver)
+* [KVM2](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm2-driver)
+* [KVM (deprecated in favor of KVM2)](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm-driver)
 * [hyperkit](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#hyperkit-driver)
 * [xhyve](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#xhyve-driver)
 * [Hyper-V](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#hyperV-driver)


### PR DESCRIPTION
Update the minikube README to make it more clear that the
KVM driver is deprecated in favor of the KVM2 driver.