### PR TITLE
Update ingress controller, and fix integration test

### DIFF
--- a/deploy/addons/ingress/ingress-rc.yaml
+++ b/deploy/addons/ingress/ingress-rc.yaml
@@ -77,7 +77,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0-beta.17
+      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0
         name: nginx-ingress-controller
         imagePullPolicy: IfNotPresent
         readinessProbe:

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -170,11 +170,6 @@ var LocalkubeCachedImages = []string{
 	// Dashboard
 	"gcr.io/google_containers/kubernetes-dashboard-amd64:v1.6.3",
 
-	// Ingress Controller
-	"nginx:alpine",
-	"gcr.io/google_containers/defaultbackend:1.4",
-	"quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0",
-
 	// DNS
 	"gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.5",
 	"gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5",
@@ -194,11 +189,6 @@ func GetKubeadmCachedImages(version string) []string {
 	return []string{
 		// Dashboard
 		"gcr.io/google_containers/kubernetes-dashboard-amd64:v1.6.3",
-
-		// Ingress Controller
-		"nginx:alpine",
-		"gcr.io/google_containers/defaultbackend:1.4",
-		"quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0",
 
 		// Addon Manager
 		"gcr.io/google-containers/kube-addon-manager:v6.4-beta.2",

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -170,6 +170,11 @@ var LocalkubeCachedImages = []string{
 	// Dashboard
 	"gcr.io/google_containers/kubernetes-dashboard-amd64:v1.6.3",
 
+	// Ingress Controller
+	"nginx:alpine",
+	"gcr.io/google_containers/defaultbackend:1.4",
+	"quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0",
+
 	// DNS
 	"gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.5",
 	"gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5",
@@ -189,6 +194,11 @@ func GetKubeadmCachedImages(version string) []string {
 	return []string{
 		// Dashboard
 		"gcr.io/google_containers/kubernetes-dashboard-amd64:v1.6.3",
+
+		// Ingress Controller
+		"nginx:alpine",
+		"gcr.io/google_containers/defaultbackend:1.4",
+		"quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0",
 
 		// Addon Manager
 		"gcr.io/google-containers/kube-addon-manager:v6.4-beta.2",


### PR DESCRIPTION
In the recent observation, I found the ingress integration test failed in some environment, I think the reason that test fails is that ingress pod not ready yet, so this commit use `Retry()` to make sure that the test not only run once. 

In addition update image for Ingress controller.

/cc @r2d4 @dlorenc 