### PR TITLE
kvm2: Set group executable bit on machine-specific directory and up

### DIFF
--- a/pkg/drivers/kvm/kvm.go
+++ b/pkg/drivers/kvm/kvm.go
@@ -269,9 +269,9 @@ func (d *Driver) Create() error {
 			return err
 		}
 		mode := info.Mode()
-		if mode&0001 != 1 {
+		if mode&0011 != 1 {
 			log.Debugf("Setting executable bit set on %s", dir)
-			mode |= 0001
+			mode |= 0011
 			os.Chmod(dir, mode)
 		}
 	}


### PR DESCRIPTION
Ensure that the directories leading to the KVM image have enough
permission for libvirt/QEMU to traverse, especially in the case where
libvirt/QEMU group is set to to kvm/users.

This is a port of https://github.com/dhiltgen/docker-machine-kvm/pull/51
to the kvm2 driver.  See also
https://github.com/dhiltgen/docker-machine-kvm/issues/46.