### PR TITLE
Bump heapster to v1.5.0

### DIFF
--- a/deploy/addons/heapster/heapster-rc.yaml
+++ b/deploy/addons/heapster/heapster-rc.yaml
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: heapster
-        image: gcr.io/google_containers/heapster-amd64:v1.5.0-beta.2
+        image: gcr.io/google_containers/heapster-amd64:v1.5.0
         imagePullPolicy: IfNotPresent
         command:
         - /heapster


### PR DESCRIPTION
Update `rc.yaml` use v1.5.0, this is a GA release for Heapster. I have been tested on v0.24.1.