### PR TITLE
Make it possible to use custom GCS with environment variables

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -354,7 +354,7 @@ This can also be done automatically by setting the env var CHANGE_MINIKUBE_NONE_
 }
 
 func validateK8sVersion(version string) {
-	validVersion, err := kubernetes_versions.IsValidLocalkubeVersion(version, constants.KubernetesVersionGCSURL)
+	validVersion, err := kubernetes_versions.IsValidLocalkubeVersionFromGCS(version)
 	if err != nil {
 		glog.Errorln("Error getting valid kubernetes versions", err)
 		os.Exit(1)

--- a/pkg/minikube/kubernetes_versions/kubernetes_versions.go
+++ b/pkg/minikube/kubernetes_versions/kubernetes_versions.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 
 	"k8s.io/minikube/pkg/minikube/constants"
@@ -29,8 +30,16 @@ import (
 	"github.com/pkg/errors"
 )
 
+func getGCSURL() string {
+	url := os.Getenv("MINIKUBE_LOCALKUBE_GCS")
+	if url == "" {
+		url = constants.KubernetesVersionGCSURL
+	}
+	return url
+}
+
 func PrintKubernetesVersionsFromGCS(output io.Writer) {
-	PrintKubernetesVersions(output, constants.KubernetesVersionGCSURL)
+	PrintKubernetesVersions(output, getGCSURL())
 }
 
 func PrintKubernetesVersions(output io.Writer, url string) {
@@ -78,6 +87,10 @@ func GetK8sVersionsFromURL(url string) (K8sReleases, error) {
 
 	cachedK8sVersions = k8sVersions
 	return k8sVersions, nil
+}
+
+func IsValidLocalkubeVersionFromGCS(v string) (bool, error) {
+	return IsValidLocalkubeVersion(v, getGCSURL())
 }
 
 func IsValidLocalkubeVersion(v string, url string) (bool, error) {

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -125,7 +125,7 @@ func GetLocalkubeDownloadURL(versionOrURL string, filename string) (string, erro
 		// no 'v' prefix in input, need to prepend it to version
 		versionOrURL = "v" + versionOrURL
 	}
-	isValidVersion, err := kubernetes_versions.IsValidLocalkubeVersion(versionOrURL, constants.KubernetesVersionGCSURL)
+	isValidVersion, err := kubernetes_versions.IsValidLocalkubeVersionFromGCS(versionOrURL)
 	if err != nil {
 		return "", errors.Wrap(err, "Error getting valid localkube versions")
 	}
@@ -135,7 +135,11 @@ func GetLocalkubeDownloadURL(versionOrURL string, filename string) (string, erro
 	if _, err = semver.Make(strings.TrimPrefix(versionOrURL, version.VersionPrefix)); err != nil {
 		return "", errors.Wrap(err, "Error creating semver version from localkube version input string")
 	}
-	return fmt.Sprintf("%s%s/%s", constants.LocalkubeDownloadURLPrefix, versionOrURL, filename), nil
+	prefix := os.Getenv("MINIKUBE_LOCALKUBE_URL")
+	if prefix == "" {
+		prefix = constants.LocalkubeDownloadURLPrefix
+	}
+	return fmt.Sprintf("%s%s/%s", prefix, versionOrURL, filename), nil
 }
 
 func ParseSHAFromURL(url string) (string, error) {


### PR DESCRIPTION

I know that "localkube" is deprecated, and that there are no official versions of localkube since v1.8.0:
#2134

But since the list of releases is hardcoded, I can't make any custom localkube builds (of 1.8.x) either:
#2156


Plan to move to "kubeadm" eventually (1.9+), but am *not* ready to do it for kubernetes version 1.8

And besides, using docker-machine and localkube still works fine - unless it is hardcoded/blocked...
