### PR TITLE
Add config to avoid warning about the none driver

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -113,6 +113,10 @@ var settings = []Setting{
 		set:  SetBool,
 	},
 	{
+		name: config.WantNoneDriverWarning,
+		set:  SetBool,
+	},
+	{
 		name: config.MachineProfile,
 		set:  SetString,
 	},

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -162,6 +162,7 @@ func setupViper() {
 	viper.SetDefault(config.WantReportError, false)
 	viper.SetDefault(config.WantReportErrorPrompt, true)
 	viper.SetDefault(config.WantKubectlDownloadMsg, true)
+	viper.SetDefault(config.WantNoneDriverWarning, true)
 	viper.SetDefault(config.ShowDriverDeprecationNotification, true)
 	setFlagsUsingViper()
 }

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -307,10 +307,12 @@ func runStart(cmd *cobra.Command, args []string) {
 	}
 
 	if config.VMDriver == "none" {
-		fmt.Println(`===================
+		if viper.GetBool(cfg.WantNoneDriverWarning) {
+			fmt.Println(`===================
 WARNING: IT IS RECOMMENDED NOT TO RUN THE NONE DRIVER ON PERSONAL WORKSTATIONS
 	The 'none' driver will run an insecure kubernetes apiserver as root that may leave the host vulnerable to CSRF attacks
 `)
+		}
 
 		if os.Getenv("CHANGE_MINIKUBE_NONE_USER") == "" {
 			fmt.Println(`When using the none driver, the kubectl config and credentials generated will be root owned and will appear in the root home directory.

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -14,6 +14,7 @@ Some features can only be accessed by environment variables, here is a list of t
 * **MINIKUBE_WANTREPORTERRORPROMPT** - (bool) sets whether the user wants to be prompted on an error that they can report them to help improve minikube
 
 * **MINIKUBE_WANTKUBECTLDOWNLOADMSG** - (bool) sets whether minikube should tell a user that `kubectl` cannot be found on there path
+* **MINIKUBE_WANTNONEDRIVERWARNING** - (bool) sets whether minikube should warn a user about running the 'none' driver (CSRF attacks)
 
 * **MINIKUBE_ENABLE_PROFILING** - (int, `1` enables it) enables trace profiling to be generated for minikube which can be analyzed via:
 

--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -33,6 +33,7 @@ const (
 	WantReportError                   = "WantReportError"
 	WantReportErrorPrompt             = "WantReportErrorPrompt"
 	WantKubectlDownloadMsg            = "WantKubectlDownloadMsg"
+	WantNoneDriverWarning             = "WantNoneDriverWarning"
 	MachineProfile                    = "profile"
 	ShowDriverDeprecationNotification = "ShowDriverDeprecationNotification"
 )


### PR DESCRIPTION
Even when starting up minikube in a dedicated virtual machine,
there will be a warning against running it on your workstation.