### PR TITLE
Bump CoreDNS version and update manifest

### DIFF
--- a/deploy/addons/coredns/coreDNS-configmap.yaml
+++ b/deploy/addons/coredns/coreDNS-configmap.yaml
@@ -11,7 +11,10 @@ data:
         errors
         log
         health
-        kubernetes cluster.local 10.0.0.0/24
+        kubernetes cluster.local 10.0.0.0/24 {
+            pods insecure
+            upstream /etc/resolv.conf
+        }
         prometheus
         proxy . /etc/resolv.conf
         cache 30

--- a/deploy/addons/coredns/coreDNS-controller.yaml
+++ b/deploy/addons/coredns/coreDNS-controller.yaml
@@ -25,7 +25,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: coredns
-        image: registry.hub.docker.com/coredns/coredns:0.9.10
+        image: registry.hub.docker.com/coredns/coredns:1.0.2
         imagePullPolicy: IfNotPresent
         resources:
           limits:


### PR DESCRIPTION
This PR updates the CoreDNS version to 1.0.2 and also updates the corefile to be in sync with the latest deployment yaml.