### PR TITLE
Bump kube-addon-manager to v6.5

### DIFF
--- a/deploy/addons/addon-manager.yaml
+++ b/deploy/addons/addon-manager.yaml
@@ -19,13 +19,13 @@ metadata:
   namespace: kube-system
   labels:
     component: kube-addon-manager
-    version: v6.4
+    version: v6.5
     kubernetes.io/minikube-addons: addon-manager
 spec:
   hostNetwork: true
   containers:
   - name: kube-addon-manager
-    image: gcr.io/google-containers/kube-addon-manager:v6.4-beta.2
+    image: gcr.io/google-containers/kube-addon-manager:v6.5
     env:
     - name: KUBECONFIG
       value: /var/lib/localkube/kubeconfig

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -66,13 +66,13 @@ metadata:
   namespace: kube-system
   labels:
     component: kube-addon-manager
-    version: v6.4
+    version: v6.5
     kubernetes.io/minikube-addons: addon-manager
 spec:
   hostNetwork: true
   containers:
   - name: kube-addon-manager
-    image: gcr.io/google-containers/kube-addon-manager:v6.4-beta.2
+    image: gcr.io/google-containers/kube-addon-manager:v6.5
     imagePullPolicy: IfNotPresent
     resources:
       requests:

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -176,7 +176,7 @@ var LocalkubeCachedImages = []string{
 	"k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.5",
 
 	// Addon Manager
-	"gcr.io/google-containers/kube-addon-manager:v6.4-beta.2",
+	"gcr.io/google-containers/kube-addon-manager:v6.5",
 
 	// Pause
 	"k8s.gcr.io/pause-amd64:3.0",
@@ -191,7 +191,7 @@ func GetKubeadmCachedImages(version string) []string {
 		"k8s.gcr.io/kubernetes-dashboard-amd64:v1.6.3",
 
 		// Addon Manager
-		"gcr.io/google-containers/kube-addon-manager:v6.4-beta.2",
+		"gcr.io/google-containers/kube-addon-manager:v6.5",
 
 		// Pause
 		"k8s.gcr.io/pause-amd64:3.0",

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -58,8 +58,8 @@ func CacheImagesForBootstrapper(version string, clusterBootstrapper string) erro
 // CacheImages will cache images on the host
 //
 // The cache directory currently caches images using the imagename_tag
-// For example, gcr.io/google-containers-kube-addon-manager:v6.4-beta.2 would be
-// stored at $CACHE_DIR/gcr.io/google-containers/kube-addon-manager_v6.4-beta.2
+// For example, gcr.io/google-containers-kube-addon-manager:v6.5 would be
+// stored at $CACHE_DIR/gcr.io/google-containers/kube-addon-manager_v6.5
 func CacheImages(images []string, cacheDir string) error {
 	var g errgroup.Group
 	for _, image := range images {


### PR DESCRIPTION
The commit bumped kube-addon-manager to v6.5, I have been tested on v1.9(last commit build).

For integration test result as below:
```sh
--- PASS: TestDocker (60.31s)
=== RUN   TestFunctional
=== RUN   TestFunctional/Status
=== RUN   TestFunctional/DNS
=== RUN   TestFunctional/Logs
=== RUN   TestFunctional/Addons
=== RUN   TestFunctional/Dashboard
=== RUN   TestFunctional/ServicesList
=== RUN   TestFunctional/Provisioning
=== RUN   TestFunctional/EnvVars
=== RUN   TestFunctional/SSH
=== RUN   TestFunctional/IngressController
--- PASS: TestFunctional (2.12s)
    --- PASS: TestFunctional/Status (1.20s)
    	cluster_status_test.go:35: Checking if cluster is healthy.
    	cluster_status_test.go:45: Component: , Healthy: False.
    	cluster_status_test.go:50: Retrying, %s Component  is not Healthy! Status: False
    	util.go:329: Error: Component  is not Healthy! Status: False, Retrying in 1s. 5 Retries remaining.
    	cluster_status_test.go:35: Checking if cluster is healthy.
    	cluster_status_test.go:45: Component: , Healthy: True.
    	cluster_status_test.go:45: Component: , Healthy: True.
    	cluster_status_test.go:45: Component: , Healthy: True.
    --- PASS: TestFunctional/SSH (0.38s)
    --- PASS: TestFunctional/ServicesList (0.51s)
    --- PASS: TestFunctional/EnvVars (0.59s)
    --- PASS: TestFunctional/Logs (1.12s)
    --- PASS: TestFunctional/Addons (9.53s)
    --- PASS: TestFunctional/Provisioning (21.15s)
    	util.go:329: Error: No default StorageClass yet., Retrying in 5s. 20 Retries remaining.
    	util.go:329: Error: No default StorageClass yet., Retrying in 5s. 19 Retries remaining.
    	util.go:329: Error: No default StorageClass yet., Retrying in 5s. 18 Retries remaining.
    	util.go:329: Error: No default StorageClass yet., Retrying in 5s. 17 Retries remaining.
    --- PASS: TestFunctional/Dashboard (32.28s)
    --- PASS: TestFunctional/DNS (71.64s)
    --- PASS: TestFunctional/IngressController (80.33s)
=== RUN   TestPersistence
--- PASS: TestPersistence (65.62s)
=== RUN   TestStartStop
--- PASS: TestStartStop (109.49s)
PASS
ok  	k8s.io/minikube/test/integration	317.932s
```