### PR TITLE
Remove --skip-preflight-checks, ignore unwanted checks

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -103,8 +103,10 @@ func (k *KubeadmBootstrapper) GetClusterLogs(follow bool) (string, error) {
 }
 
 func (k *KubeadmBootstrapper) StartCluster(k8s bootstrapper.KubernetesConfig) error {
-	// We use --skip-preflight-checks since we have our own custom addons
+	// We use --ignore-preflight-errors=DirAvailable since we have our own custom addons
 	// that we also stick in /etc/kubernetes/manifests
+	// We use --ignore-preflight-errors=Swap since minikube.iso allocates a swap partition.
+	// (it should probably stop doing this, though...)
 	b := bytes.Buffer{}
 	if err := kubeadmInitTemplate.Execute(&b, struct{ KubeadmConfigFile string }{constants.KubeadmConfigFile}); err != nil {
 		return err

--- a/pkg/minikube/bootstrapper/kubeadm/templates.go
+++ b/pkg/minikube/bootstrapper/kubeadm/templates.go
@@ -71,7 +71,7 @@ sudo /usr/bin/kubeadm alpha phase controlplane all --config {{.KubeadmConfigFile
 sudo /usr/bin/kubeadm alpha phase etcd local --config {{.KubeadmConfigFile}}
 `))
 
-var kubeadmInitTemplate = template.Must(template.New("kubeadmInitTemplate").Parse("sudo /usr/bin/kubeadm init --config {{.KubeadmConfigFile}} --skip-preflight-checks"))
+var kubeadmInitTemplate = template.Must(template.New("kubeadmInitTemplate").Parse("sudo /usr/bin/kubeadm init --config {{.KubeadmConfigFile}} --ignore-preflight-errors=DirAvailable--etc-kubernetes-manifests --ignore-preflight-errors=Swap"))
 
 // printMapInOrder sorts the keys and prints the map in order, combining key
 // value pairs with the separator character


### PR DESCRIPTION
Better to ignore the checks that we don't want, rather than
disabling all of them in case something important appears...

Currently known failing checks:
	[WARNING SystemVerification]: docker version is greater than
the most recently validated version. Docker version: 17.06.0-ce. Max validated version: 17.03
	[WARNING FileExisting-crictl]: crictl not found in system path
	[WARNING Service-Docker]: docker service is not enabled, please run 'systemctl enable docker.service'
	[ERROR DirAvailable--etc-kubernetes-manifests]: /etc/kubernetes/manifests is not empty
	[ERROR Swap]: running with swap on is not supported. Please disable swap
  
----
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.9.md
> The kubeadm --skip-preflight-checks flag is now deprecated and will be removed in a future release.

