### PR TITLE
Make sure to enable docker, to please kubeadm

### DIFF
--- a/pkg/provision/buildroot.go
+++ b/pkg/provision/buildroot.go
@@ -297,6 +297,10 @@ func configureAuth(p *BuildrootProvisioner) error {
 		return err
 	}
 
+	if err := p.Service("docker", serviceaction.Enable); err != nil {
+		return err
+	}
+
 	if err := p.Service("docker", serviceaction.Restart); err != nil {
 		return err
 	}


### PR DESCRIPTION
The kubeadm preflight looks if the docker service is enabled,
rather than checking the docker socket... So make it happy.