### PR TITLE
Change kubernetes-dashboard from RC to deployment

### DIFF
--- a/deploy/addons/dashboard/dashboard-dp.yaml
+++ b/deploy/addons/dashboard/dashboard-dp.yaml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: kubernetes-dashboard
   namespace: kube-system
@@ -24,9 +24,10 @@ metadata:
 spec:
   replicas: 1
   selector:
-    app: kubernetes-dashboard
-    version: v1.8.1
-    addonmanager.kubernetes.io/mode: Reconcile
+    matchLabels:
+      app: kubernetes-dashboard
+      version: v1.8.1
+      addonmanager.kubernetes.io/mode: Reconcile
   template:
     metadata:
       labels:

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -65,9 +65,9 @@ var Addons = map[string]*Addon{
 	}, true, "addon-manager"),
 	"dashboard": NewAddon([]*BinDataAsset{
 		NewBinDataAsset(
-			"deploy/addons/dashboard/dashboard-rc.yaml",
+			"deploy/addons/dashboard/dashboard-dp.yaml",
 			constants.AddonsPath,
-			"dashboard-rc.yaml",
+			"dashboard-dp.yaml",
 			"0640"),
 		NewBinDataAsset(
 			"deploy/addons/dashboard/dashboard-svc.yaml",

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -168,7 +168,7 @@ const FileScheme = "file"
 
 var LocalkubeCachedImages = []string{
 	// Dashboard
-	"k8s.gcr.io/kubernetes-dashboard-amd64:v1.6.3",
+	"k8s.gcr.io/kubernetes-dashboard-amd64:v1.8.1",
 
 	// DNS
 	"k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.5",
@@ -188,7 +188,7 @@ var LocalkubeCachedImages = []string{
 func GetKubeadmCachedImages(version string) []string {
 	return []string{
 		// Dashboard
-		"k8s.gcr.io/kubernetes-dashboard-amd64:v1.6.3",
+		"k8s.gcr.io/kubernetes-dashboard-amd64:v1.8.1",
 
 		// Addon Manager
 		"gcr.io/google-containers/kube-addon-manager:v6.5",

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -248,8 +248,8 @@ func WaitForDashboardRunning(t *testing.T) error {
 	if err != nil {
 		return errors.Wrap(err, "getting kubernetes client")
 	}
-	if err := commonutil.WaitForRCToStabilize(client, "kube-system", "kubernetes-dashboard", time.Minute*10); err != nil {
-		return errors.Wrap(err, "waiting for dashboard RC to stabilize")
+	if err := commonutil.WaitForDeploymentToStabilize(client, "kube-system", "kubernetes-dashboard", time.Minute*10); err != nil {
+		return errors.Wrap(err, "waiting for dashboard deployment to stabilize")
 	}
 
 	if err := commonutil.WaitForService(client, "kube-system", "kubernetes-dashboard", true, time.Millisecond*500, time.Minute*10); err != nil {


### PR DESCRIPTION
The commit changed kubernetes-dashboard from RC to deployment, the feature request from #2389. This PR has been tested on v1.9.0(https://github.com/kubernetes/minikube/commit/b1091853cc55edc36946382a66392c686439eb76), more command output detail as below:
```sh
$ kubectl get node
NAME       STATUS    ROLES     AGE       VERSION
minikube   Ready     <none>    42s       v1.9.0

$ kubectl -n kube-system get po
NAME                                    READY     STATUS    RESTARTS   AGE
kube-addon-manager-minikube             1/1       Running   0          40s
kube-dns-54cccfbdf8-28cds               3/3       Running   0          36s
kubernetes-dashboard-77d8b98585-xxmxz   1/1       Running   0          36s
storage-provisioner                     1/1       Running   0          37s

$ kubectl -n kube-system get deploy
NAME                   DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
kube-dns               1         1         1            1           38s
kubernetes-dashboard   1         1         1            1           38s

$ ./out/minikube addons open dashboard
Opening kubernetes service kube-system/kubernetes-dashboard in default browser..
```

Dashboard's preview:
![](https://i.imgur.com/SvFyfUi.png)

Integration testing result:
```sh
$ make integration
cp ./out/minikube-darwin-amd64 ./out/minikube
go test -v -test.timeout=30m k8s.io/minikube/test/integration --tags="integration container_image_ostree_stub containers_image_openpgp"
=== RUN   TestDocker
Environment=DOCKER_RAMDISK=yes FOO=BAR BAZ=BAT

ExecStart={ path=/usr/bin/dockerd ; argv[]=/usr/bin/dockerd -H tcp://0.0.0.0:2376 -H unix:///var/run/docker.sock --tlsverify --tlscacert /etc/docker/ca.pem --tlscert /etc/docker/server.pem --tlskey /etc/docker/server-key.pem --label provider=virtualbox --insecure-registry 10.96.0.0/12 --debug --icc=true ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }

--- PASS: TestDocker (76.73s)
=== RUN   TestFunctional
=== RUN   TestFunctional/Status
=== RUN   TestFunctional/DNS
=== RUN   TestFunctional/Logs
=== RUN   TestFunctional/Addons
=== RUN   TestFunctional/Dashboard
=== RUN   TestFunctional/ServicesList
=== RUN   TestFunctional/Provisioning
=== RUN   TestFunctional/EnvVars
=== RUN   TestFunctional/SSH
=== RUN   TestFunctional/IngressController
--- PASS: TestFunctional (1.69s)
    --- PASS: TestFunctional/Status (0.40s)
    	cluster_status_test.go:35: Checking if cluster is healthy.
    	cluster_status_test.go:45: Component: , Healthy: True.
    	cluster_status_test.go:45: Component: , Healthy: True.
    	cluster_status_test.go:45: Component: , Healthy: True.
    --- PASS: TestFunctional/SSH (0.59s)
    --- PASS: TestFunctional/ServicesList (0.78s)
    --- PASS: TestFunctional/EnvVars (0.82s)
    --- PASS: TestFunctional/Logs (1.89s)
    --- PASS: TestFunctional/Addons (9.06s)
    --- PASS: TestFunctional/Dashboard (15.40s)
    --- PASS: TestFunctional/Provisioning (35.81s)
    	util.go:329: Error: No default StorageClass yet., Retrying in 5s. 20 Retries remaining.
    	util.go:329: Error: No default StorageClass yet., Retrying in 5s. 19 Retries remaining.
    	util.go:329: Error: No default StorageClass yet., Retrying in 5s. 18 Retries remaining.
    --- PASS: TestFunctional/DNS (45.57s)
    --- PASS: TestFunctional/IngressController (54.50s)
=== RUN   TestPersistence
--- PASS: TestPersistence (70.31s)
=== RUN   TestStartStop
--- PASS: TestStartStop (112.78s)
PASS
ok  	k8s.io/minikube/test/integration	316.073s
```