### PR TITLE
Issue #2416 keep ip address on restart using vm-driver hyperkit

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -68,6 +68,7 @@ const (
 	mountString           = "mount-string"
 	disableDriverMounts   = "disable-driver-mounts"
 	cacheImages           = "cache-images"
+	uuid                  = "uuid"
 )
 
 var (
@@ -143,6 +144,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		KvmNetwork:          viper.GetString(kvmNetwork),
 		Downloader:          pkgutil.DefaultDownloader{},
 		DisableDriverMounts: viper.GetBool(disableDriverMounts),
+		UUID:                viper.GetString(uuid),
 	}
 
 	fmt.Printf("Starting local Kubernetes %s cluster...\n", viper.GetString(kubernetesVersion))

--- a/pkg/drivers/hyperkit/driver.go
+++ b/pkg/drivers/hyperkit/driver.go
@@ -34,7 +34,6 @@ import (
 	"github.com/docker/machine/libmachine/state"
 	nfsexports "github.com/johanneswuerbach/nfsexports"
 	hyperkit "github.com/moby/hyperkit/go"
-	"github.com/pborman/uuid"
 	"github.com/pkg/errors"
 	pkgdrivers "k8s.io/minikube/pkg/drivers"
 	commonutil "k8s.io/minikube/pkg/util"
@@ -59,6 +58,7 @@ type Driver struct {
 	Cmdline        string
 	NFSShares      []string
 	NFSSharesRoot  string
+	UUID           string
 }
 
 func NewDriver(hostName, storePath string) *Driver {
@@ -177,10 +177,9 @@ func (d *Driver) Start() error {
 	h.Console = hyperkit.ConsoleFile
 	h.CPUs = d.CPU
 	h.Memory = d.Memory
+	h.UUID = d.UUID
 
-	// Set UUID
-	h.UUID = uuid.NewUUID().String()
-	log.Infof("Generated UUID %s", h.UUID)
+	log.Infof("Using UUID %s", h.UUID)
 	mac, err := GetMACAddressFromUUID(h.UUID)
 	if err != nil {
 		return err

--- a/pkg/minikube/cluster/cluster_darwin.go
+++ b/pkg/minikube/cluster/cluster_darwin.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/docker/machine/drivers/vmwarefusion"
 	"github.com/docker/machine/libmachine/drivers"
+	"github.com/pborman/uuid"
 	"k8s.io/minikube/pkg/drivers/hyperkit"
 	cfg "k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
@@ -71,6 +72,7 @@ func createHyperkitHost(config MachineConfig) *hyperkit.Driver {
 		CPU:            config.CPUs,
 		NFSShares:      config.NFSShare,
 		NFSSharesRoot:  config.NFSSharesRoot,
+		UUID:           uuid.NewUUID().String(),
 		Cmdline:        "loglevel=3 user=docker console=ttyS0 console=tty0 noembed nomodeset norestore waitusb=10 systemd.legacy_systemd_cgroup_controller=yes base host=" + cfg.GetMachineName(),
 	}
 }

--- a/pkg/minikube/cluster/types.go
+++ b/pkg/minikube/cluster/types.go
@@ -40,6 +40,7 @@ type MachineConfig struct {
 	DisableDriverMounts bool               // Only used by virtualbox and xhyve
 	NFSShare            []string
 	NFSSharesRoot       string
+	UUID                string // Only used by hyperkit to restore the mac address
 }
 
 // Config contains machine and k8s config


### PR DESCRIPTION
Added UUID to hyperkit driver section in minikube configuration to be able to regenerate the same mac address for the machine after restarts to give DHCP a change of assigning the previously used IP address.