### PR TITLE
Add support for QEMU driver (without libvirt)

### DIFF
--- a/cmd/localkube/cmd/options.go
+++ b/cmd/localkube/cmd/options.go
@@ -33,7 +33,7 @@ func NewLocalkubeServer() *localkube.LocalkubeServer {
 		DNSDomain:                util.DefaultDNSDomain,
 		LocalkubeDirectory:       util.DefaultLocalkubeDirectory,
 		APIServerAddress:         net.ParseIP("0.0.0.0"),
-		APIServerPort:            util.APIServerPort,
+		APIServerPort:            util.DefaultAPIServerPort,
 		APIServerInsecureAddress: net.ParseIP("127.0.0.1"),
 		APIServerInsecurePort:    0,
 		APIServerName:            constants.APIServerName,

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -246,8 +247,13 @@ func runStart(cmd *cobra.Command, args []string) {
 	if err != nil {
 		glog.Errorln("Error connecting to cluster: ", err)
 	}
+	dockerPort := 2376
+	re := regexp.MustCompile(":([0-9]+)$")
+	if matches := re.FindStringSubmatch(kubeHost); matches != nil {
+		dockerPort, err = strconv.Atoi(matches[1])
+	}
 	kubeHost = strings.Replace(kubeHost, "tcp://", "https://", -1)
-	kubeHost = strings.Replace(kubeHost, ":2376", ":"+strconv.Itoa(pkgutil.APIServerPort), -1)
+	kubeHost = strings.Replace(kubeHost, ":"+strconv.Itoa(dockerPort), ":"+strconv.Itoa(pkgutil.APIServerPort), -1)
 
 	fmt.Println("Setting up kubeconfig...")
 	// setup kubeconfig

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -198,6 +198,32 @@ func runStart(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	glog.Infof("APIServerPort %d", cc.HostConfig.APIServerPort)
+	if cc.HostConfig.APIServerPort != 0 {
+		pkgutil.APIServerPort = cc.HostConfig.APIServerPort
+	} else if host.Driver.DriverName() == "qemu" {
+		port, err := cmdutil.GetPort()
+		if err != nil {
+			glog.Errorln("Error getting port number: ", err)
+		}
+		pkgutil.APIServerPort, err = strconv.Atoi(port)
+	}
+	glog.Infof("DashboardPort %d", cc.HostConfig.DashboardPort)
+	if cc.HostConfig.DashboardPort != 0 {
+		pkgutil.DashboardPort = cc.HostConfig.DashboardPort
+	} else if host.Driver.DriverName() == "qemu" {
+		port, err := cmdutil.GetPort()
+		if err != nil {
+			glog.Errorln("Error getting port number: ", err)
+		}
+		pkgutil.DashboardPort, err = strconv.Atoi(port)
+	}
+
+	hostConfig := cfg.HostConfig{
+		APIServerPort: pkgutil.APIServerPort,
+		DashboardPort: pkgutil.DashboardPort,
+	}
+
 	kubernetesConfig := cfg.KubernetesConfig{
 		KubernetesVersion:      selectedKubernetesVersion,
 		NodeIP:                 ip,
@@ -221,6 +247,7 @@ func runStart(cmd *cobra.Command, args []string) {
 
 	// Write profile cluster configuration to file
 	clusterConfig := cfg.Config{
+		HostConfig:       hostConfig,
 		MachineConfig:    config,
 		KubernetesConfig: kubernetesConfig,
 	}
@@ -407,4 +434,3 @@ func init() {
 	viper.BindPFlags(startCmd.Flags())
 	RootCmd.AddCommand(startCmd)
 }
-

--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/machine"
-	pkgutil "k8s.io/minikube/pkg/util"
 	"k8s.io/minikube/pkg/util/kubeconfig"
 )
 
@@ -94,7 +93,11 @@ var statusCmd = &cobra.Command{
 				glog.Errorln("Error host driver ip status:", err)
 				cmdUtil.MaybeReportErrorAndExitWithCode(err, internalErrorCode)
 			}
-			port := pkgutil.APIServerPort
+			port, err := cluster.GetHostDriverPort(api)
+			if err != nil {
+				glog.Errorln("Error host driver port number:", err)
+				cmdUtil.MaybeReportErrorAndExitWithCode(err, internalErrorCode)
+			}
 			kstatus, err := kubeconfig.GetKubeConfigStatus(ip, port, cmdUtil.GetKubeConfigPath(), config.GetMachineName())
 			if err != nil {
 				glog.Errorln("Error kubeconfig status:", err)

--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/machine"
+	pkgutil "k8s.io/minikube/pkg/util"
 	"k8s.io/minikube/pkg/util/kubeconfig"
 )
 
@@ -93,7 +94,8 @@ var statusCmd = &cobra.Command{
 				glog.Errorln("Error host driver ip status:", err)
 				cmdUtil.MaybeReportErrorAndExitWithCode(err, internalErrorCode)
 			}
-			kstatus, err := kubeconfig.GetKubeConfigStatus(ip, cmdUtil.GetKubeConfigPath(), config.GetMachineName())
+			port := pkgutil.APIServerPort
+			kstatus, err := kubeconfig.GetKubeConfigStatus(ip, port, cmdUtil.GetKubeConfigPath(), config.GetMachineName())
 			if err != nil {
 				glog.Errorln("Error kubeconfig status:", err)
 				cmdUtil.MaybeReportErrorAndExitWithCode(err, internalErrorCode)

--- a/cmd/minikube/cmd/update-context.go
+++ b/cmd/minikube/cmd/update-context.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/machine"
-	pkgutil "k8s.io/minikube/pkg/util"
 	kcfg "k8s.io/minikube/pkg/util/kubeconfig"
 )
 
@@ -49,7 +48,12 @@ var updateContextCmd = &cobra.Command{
 			glog.Errorln("Error host driver ip status:", err)
 			cmdUtil.MaybeReportErrorAndExit(err)
 		}
-		port := pkgutil.APIServerPort
+		port, err := cluster.GetHostDriverPort(api)
+		if err != nil {
+			glog.Errorln("Error host driver port number:", err)
+			cmdUtil.MaybeReportErrorAndExitWithCode(err, internalErrorCode)
+		}
+
 		kstatus, err := kcfg.UpdateKubeconfigHost(ip, port, constants.KubeconfigPath, config.GetMachineName())
 		if err != nil {
 			glog.Errorln("Error kubeconfig status:", err)

--- a/cmd/minikube/cmd/update-context.go
+++ b/cmd/minikube/cmd/update-context.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/machine"
+	pkgutil "k8s.io/minikube/pkg/util"
 	kcfg "k8s.io/minikube/pkg/util/kubeconfig"
 )
 
@@ -48,7 +49,8 @@ var updateContextCmd = &cobra.Command{
 			glog.Errorln("Error host driver ip status:", err)
 			cmdUtil.MaybeReportErrorAndExit(err)
 		}
-		kstatus, err := kcfg.UpdateKubeconfigIP(ip, constants.KubeconfigPath, config.GetMachineName())
+		port := pkgutil.APIServerPort
+		kstatus, err := kcfg.UpdateKubeconfigHost(ip, port, constants.KubeconfigPath, config.GetMachineName())
 		if err != nil {
 			glog.Errorln("Error kubeconfig status:", err)
 			cmdUtil.MaybeReportErrorAndExit(err)

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -141,9 +141,9 @@ func (k *KubeadmBootstrapper) StartCluster(k8s config.KubernetesConfig) error {
 
 	if k.d.DriverName() == "qemu" {
 		// tunnel apiserver
-		k.x.Shell("-f", "-NTL", "8443:localhost:8443")
+		k.x.Shell("-f", "-NTL", fmt.Sprintf("%d:localhost:8443", util.APIServerPort))
 		// tunnel dashboard
-		k.x.Shell("-f", "-NTL", "30000:localhost:30000")
+		k.x.Shell("-f", "-NTL", fmt.Sprintf("%d:localhost:30000", util.DashboardPort))
 	}
 
 	//TODO(r2d4): get rid of global here

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -361,7 +361,7 @@ func generateConfig(k8s config.KubernetesConfig) (string, error) {
 		CertDir:           util.DefaultCertPath,
 		ServiceCIDR:       util.DefaultServiceCIDR,
 		AdvertiseAddress:  k8s.NodeIP,
-		APIServerPort:     util.APIServerPort,
+		APIServerPort:     util.DefaultAPIServerPort,
 		KubernetesVersion: k8s.KubernetesVersion,
 		EtcdDataDir:       "/data", //TODO(r2d4): change to something else persisted
 		NodeName:          k8s.NodeName,

--- a/pkg/minikube/bootstrapper/kubeadm/util.go
+++ b/pkg/minikube/bootstrapper/kubeadm/util.go
@@ -168,7 +168,7 @@ func restartKubeProxy(k8s config.KubernetesConfig) error {
 		APIServerPort    int
 	}{
 		AdvertiseAddress: k8s.NodeIP,
-		APIServerPort:    util.APIServerPort,
+		APIServerPort:    util.DefaultAPIServerPort,
 	}
 
 	kubeconfig := bytes.Buffer{}

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -259,9 +259,17 @@ func GetHostDockerEnv(api libmachine.API) (map[string]string, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "Error getting ip from host")
 	}
+	url, err := host.Driver.GetURL()
+	if err != nil {
+		return nil, errors.Wrap(err, "Error getting url from host")
+	}
 
 	tcpPrefix := "tcp://"
 	port := "2376"
+	re := regexp.MustCompile(":([0-9]+)$")
+	if matches := re.FindStringSubmatch(url); matches != nil {
+		port = matches[1]
+	}
 
 	envMap := map[string]string{
 		"DOCKER_TLS_VERIFY": "1",

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -169,6 +169,22 @@ func GetHostDriverIP(api libmachine.API) (net.IP, error) {
 	return ip, nil
 }
 
+// GetHostDriverPort gets the port number of the current minikube cluster
+func GetHostDriverPort(api libmachine.API) (int, error) {
+	cc, err := LoadConfigFromFile(viper.GetString(cfg.MachineProfile))
+	if err != nil && !os.IsNotExist(err) {
+		return 0, errors.Wrap(err, "Error loading config")
+	}
+
+	var port int
+	if cc.HostConfig.APIServerPort != 0 {
+		port = cc.HostConfig.APIServerPort
+	} else {
+		port = util.APIServerPort
+	}
+	return port, nil
+}
+
 func engineOptions(config cfg.MachineConfig) *engine.Options {
 	o := engine.Options{
 		Env:              config.DockerEnv,

--- a/pkg/minikube/cluster/config.go
+++ b/pkg/minikube/cluster/config.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/viper"
+
+	cfg "k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/constants"
+)
+
+// SaveConfig saves profile cluster configuration in
+// $MINIKUBE_HOME/profiles/<profilename>/config.json
+func SaveConfig(clusterConfig cfg.Config) error {
+	data, err := json.MarshalIndent(clusterConfig, "", "    ")
+	if err != nil {
+		return err
+	}
+
+	profileConfigFile := constants.GetProfileFile(viper.GetString(cfg.MachineProfile))
+
+	if err := os.MkdirAll(filepath.Dir(profileConfigFile), 0700); err != nil {
+		return err
+	}
+
+	if err := SaveConfigToFile(data, profileConfigFile); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func SaveConfigToFile(data []byte, file string) error {
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		return ioutil.WriteFile(file, data, 0600)
+	}
+
+	tmpfi, err := ioutil.TempFile(filepath.Dir(file), "config.json.tmp")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmpfi.Name())
+
+	if err = ioutil.WriteFile(tmpfi.Name(), data, 0600); err != nil {
+		return err
+	}
+
+	if err = tmpfi.Close(); err != nil {
+		return err
+	}
+
+	if err = os.Remove(file); err != nil {
+		return err
+	}
+
+	if err = os.Rename(tmpfi.Name(), file); err != nil {
+		return err
+	}
+	return nil
+}
+
+func LoadConfigFromFile(profile string) (cfg.Config, error) {
+	var cc cfg.Config
+
+	profileConfigFile := constants.GetProfileFile(profile)
+
+	if _, err := os.Stat(profileConfigFile); os.IsNotExist(err) {
+		return cc, err
+	}
+
+	data, err := ioutil.ReadFile(profileConfigFile)
+	if err != nil {
+		return cc, err
+	}
+
+	if err := json.Unmarshal(data, &cc); err != nil {
+		return cc, err
+	}
+	return cc, nil
+}

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -24,8 +24,15 @@ import (
 
 // Config contains machine and k8s config
 type Config struct {
+	HostConfig       HostConfig
 	MachineConfig    MachineConfig
 	KubernetesConfig KubernetesConfig
+}
+
+// HostConfig stores configuration for the local connecting host.
+type HostConfig struct {
+	APIServerPort int
+	DashboardPort int
 }
 
 // MachineConfig contains the parameters used to start a cluster.

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -52,6 +52,7 @@ var SupportedVMDrivers = [...]string{
 	"virtualbox",
 	"vmwarefusion",
 	"kvm",
+	"qemu",
 	"xhyve",
 	"hyperv",
 }

--- a/pkg/minikube/drivers/qemu/doc.go
+++ b/pkg/minikube/drivers/qemu/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors All rights reserved.
+Copyright 2018 The Kubernetes Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,16 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cluster
-
-import (
-	_ "k8s.io/minikube/pkg/minikube/drivers/hyperkit"
-	_ "k8s.io/minikube/pkg/minikube/drivers/hyperv"
-	_ "k8s.io/minikube/pkg/minikube/drivers/kvm"
-	_ "k8s.io/minikube/pkg/minikube/drivers/kvm2"
-	_ "k8s.io/minikube/pkg/minikube/drivers/none"
-	_ "k8s.io/minikube/pkg/minikube/drivers/qemu"
-	_ "k8s.io/minikube/pkg/minikube/drivers/virtualbox"
-	_ "k8s.io/minikube/pkg/minikube/drivers/vmwarefusion"
-	_ "k8s.io/minikube/pkg/minikube/drivers/xhyve"
-)
+package qemu

--- a/pkg/minikube/drivers/qemu/driver.go
+++ b/pkg/minikube/drivers/qemu/driver.go
@@ -1,0 +1,72 @@
+// +build linux
+
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package qemu
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/docker/machine/libmachine/drivers"
+	cfg "k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/registry"
+)
+
+func init() {
+	registry.Register(registry.DriverDef{
+		Name:          "qemu",
+		Builtin:       false,
+		ConfigCreator: createQemuHost,
+	})
+}
+
+type qemuDriver struct {
+	*drivers.BaseDriver
+
+	Memory         int
+	DiskSize       int
+	CPU            int
+	Program        string
+	Network        string
+	SSHPort        int
+	EnginePort     int
+	ISO            string
+	Boot2DockerURL string
+	DiskPath       string
+}
+
+func createQemuHost(config cfg.MachineConfig) interface{} {
+	return &qemuDriver{
+		BaseDriver: &drivers.BaseDriver{
+			MachineName: cfg.GetMachineName(),
+			StorePath:   constants.GetMinipath(),
+			SSHUser:     "docker",
+		},
+		Memory:         config.Memory,
+		CPU:            config.CPUs,
+		Boot2DockerURL: config.Downloader.GetISOFileURI(config.MinikubeISO),
+		DiskSize:       config.DiskSize,
+		Program:        "qemu-system-x86_64",
+		Network:        "user",
+		SSHPort:        22,
+		EnginePort:     2376,
+		DiskPath:       filepath.Join(constants.GetMinipath(), "machines", cfg.GetMachineName(), fmt.Sprintf("%s.qcow2", cfg.GetMachineName())),
+		ISO:            filepath.Join(constants.GetMinipath(), "machines", cfg.GetMachineName(), "boot2docker.iso"),
+	}
+}

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -24,8 +24,8 @@ import (
 
 // These constants are used by both minikube and localkube
 const (
-	APIServerPort             = 8443
-	DashboardPort             = 30000
+	DefaultAPIServerPort      = 8443
+	DefaultDashboardPort      = 30000
 	DefaultLocalkubeDirectory = "/var/lib/localkube"
 	DefaultCertPath           = DefaultLocalkubeDirectory + "/certs/"
 	DefaultKubeConfigPath     = DefaultLocalkubeDirectory + "/kubeconfig"

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -25,6 +25,7 @@ import (
 // These constants are used by both minikube and localkube
 const (
 	APIServerPort             = 8443
+	DashboardPort             = 30000
 	DefaultLocalkubeDirectory = "/var/lib/localkube"
 	DefaultCertPath           = DefaultLocalkubeDirectory + "/certs/"
 	DefaultKubeConfigPath     = DefaultLocalkubeDirectory + "/kubeconfig"

--- a/pkg/util/variables.go
+++ b/pkg/util/variables.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+var APIServerPort int = DefaultAPIServerPort
+var DashboardPort int = DefaultDashboardPort


### PR DESCRIPTION
This adds support for the "qemu" vm driver, as detailed in the proposal #2399

In order to do so, it must also add support for dynamic ports and for host config.

This driver tunnels *all* ports, not only SSH, so it cannot hardcode any ports.
Applies to both Docker (2376), but also apiserver and dashboard (and services)

In order to store which dynamic ports are being used for which minikube profile,
a new "HostConfig" object is introduced to store this (much like EngineConfig)

There is no support for `9p` mounts yet, so `sshfs` mounts are being used instead.

Support for ports and for forward have been submitted to docker-machine earlier.