### PR TITLE
Add support to build minikube binary on AArch64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ endif
 out/minikube-windows-amd64.exe: out/minikube-windows-amd64
 	cp out/minikube-windows-amd64 out/minikube-windows-amd64.exe
 
-out/minikube-%-amd64: pkg/minikube/assets/assets.go $(shell $(MINIKUBEFILES))
+out/minikube-%-$(GOARCH): pkg/minikube/assets/assets.go $(shell $(MINIKUBEFILES))
 ifeq ($(MINIKUBE_BUILD_IN_DOCKER),y)
 	$(call DOCKER,$(BUILD_IMAGE),/usr/bin/make $@)
 else
@@ -199,7 +199,7 @@ e2e-cross: e2e-linux-amd64 e2e-darwin-amd64 e2e-windows-amd64.exe
 
 .PHONY: checksum
 checksum:
-	for f in out/localkube out/minikube-linux-amd64 out/minikube-darwin-amd64 out/minikube-windows-amd64.exe out/minikube.iso; do \
+	for f in out/localkube out/minikube-$(GOOS)-$(GOARCH)$(IS_EXE) out/minikube.iso; do \
 		if [ -f "$${f}" ]; then \
 			openssl sha256 "$${f}" | awk '{print $$2}' > "$${f}.sha256" ; \
 		fi ; \


### PR DESCRIPTION
Current Makefile can only support build `minikube` bin on
{linux, darwin, windows}/amd64 system. This PR is used to
build the binary on linux/arm64 platform.

Fix #2454

Signed-off-by: Dennis Chen <dennis.chen@arm.com>