### PR TITLE
adding memory request and limit to efk addon

### DIFF
--- a/deploy/addons/efk/elasticsearch-rc.yaml
+++ b/deploy/addons/efk/elasticsearch-rc.yaml
@@ -38,8 +38,10 @@ spec:
         resources:
           limits:
             cpu: 500m
+            memory: 2400Mi
           requests:
             cpu: 100m
+            memory: 2350Mi
         ports:
         - containerPort: 9200
           name: db


### PR DESCRIPTION
 - running efk with minikube default memory (2048Mi) was running the set
   out of resources. Seemed like it should at least be aware it didn't
   have sufficient resources for the elasticSearch portion, so adding a
   request and limit based on cAdvisor observation of a running system.