### PR TITLE
Fix gendocs, constant DefaultMountDir was missing

### DIFF
--- a/pkg/minikube/constants/constants_gendocs.go
+++ b/pkg/minikube/constants/constants_gendocs.go
@@ -18,6 +18,10 @@ limitations under the License.
 
 package constants
 
+import (
+	"k8s.io/client-go/util/homedir"
+)
+
 var SupportedVMDrivers = [...]string{
 	"virtualbox",
 	"vmwarefusion",
@@ -25,3 +29,5 @@ var SupportedVMDrivers = [...]string{
 	"xhyve",
 	"hyperv",
 }
+
+var DefaultMountDir = homedir.HomeDir()


### PR DESCRIPTION
`cmd/minikube/cmd/start.go:372:39: undefined: constants.DefaultMountDir`