### PR TITLE
Use host's name when running determining VM host IP

### DIFF
--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -324,7 +324,7 @@ func GetVMHostIP(host *host.Host) (net.IP, error) {
 		}
 		return ip, nil
 	case "virtualbox":
-		out, err := exec.Command(detectVBoxManageCmd(), "showvminfo", "minikube", "--machinereadable").Output()
+		out, err := exec.Command(detectVBoxManageCmd(), "showvminfo", host.Name, "--machinereadable").Output()
 		if err != nil {
 			return []byte{}, errors.Wrap(err, "Error running vboxmanage command")
 		}


### PR DESCRIPTION
Currently, `minibox mount` does not work properly when running a non-default profile (via the `-p` flag) and the virtualbox driver. This is due to `minikube` being hard-coded in the command used to determine the VM host IP. This change fixes this issue by using the host's name (profile) when running the VBox manage command used to determine the host's IP.

Fixes #2080 