### PR TITLE
Correct proxy doc - docker-env equals formatting vars

### DIFF
--- a/docs/http_proxy.md
+++ b/docs/http_proxy.md
@@ -9,8 +9,8 @@ To do this, pass the required environment variables as flags during `minikube st
 For example:
 
 ```shell
-$ minikube start --docker-env HTTP_PROXY=http://$YOURPROXY:PORT \
-                 --docker-env HTTPS_PROXY=https://$YOURPROXY:PORT
+$ minikube start --docker-env=HTTP_PROXY=http://$YOURPROXY:PORT \
+                 --docker-env=HTTPS_PROXY=https://$YOURPROXY:PORT
 ```
 
 If your Virtual Machine address is 192.168.99.100, then chances are your proxy settings will prevent kubectl from directly reaching it.


### PR DESCRIPTION
To pass docker-env vars, you must put equal sign between `--docker-env` and your var

As it is described into test/integration/docker_test.go :
`--docker-env=FOO=BAR --docker-env=BAZ=BAT --docker-opt=debug --docker-opt=icc=true`

So `--docker-env HTTP_PROXY=http://$YOURPROXY:PORT` becomes
`--docker-env=HTTP_PROXY=http://$YOURPROXY:PORT`
and so on.