### PR TITLE
networking: support port forwarding

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -10,3 +10,43 @@ To determine the NodePort for your service, you can use a `kubectl` command like
 We also have a shortcut for fetching the minikube IP and a service's `NodePort`:
 
 `minikube service --url $SERVICE`
+
+The same works for accessing addons:
+
+`minikube addons open --url $ADDON`
+
+As a shortcut, the dashboard addon also has its own command:
+
+`minikube dashboard --url`
+
+All three commands will open the URL automatically in the default web
+browser when leaving out the `--url` parameter. For this to work, the
+web browser must run on the same host as the minikube VM.
+
+Minikube supports port forwarding to make the minikube VM ports
+available outside of the local host. When requested via the
+``--proxy`` parameter, minikube changes the URL so
+that the local host is specified in the URL and acts as proxy:
+
+`minikube dashboard --proxy --url`
+
+Minikube keeps running and forwarding connections until
+interupted. The default is to listen on all interfaces, pick a random
+port and use the local host name in the modified URL. When a specific
+port is desired and/or a specific interface should be used, then
+``--proxyaddress`` can be used:
+
+```
+--proxyaddress :8080
+--proxyaddress 192.168.1.1:0
+--proxyaddress my-host:8080
+```
+
+Note that the host name in ``--proxyaddress`` will be resolved on the
+local host before listening on the port, so the resulting URL will
+have a fixed IP address. This is also useful when the default, the
+local host name, cannot be resolved outside of the local host.
+
+A fixed port in `--proxyaddress` only works when opening exactly one
+URL. `minikube service` and `minikube addon open` can potentially open
+multiple URLs, in which case the port has to be chosen automatically.

--- a/pkg/util/proxy.go
+++ b/pkg/util/proxy.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"io"
+	"net"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/golang/glog"
+)
+
+// Proxy will listen at the given address on the "tcp" network
+// and forward all incoming connections to the host and port
+// specified by the url. It rewrites the URL so that it
+// refers to the proxy and returns that.
+//
+// Forwarding is active as long as the program runs.
+func Proxy(listenAddress string, targetURL string) (proxyURL string, err error) {
+	u, err := url.Parse(targetURL)
+	if err != nil {
+		return "", err
+	}
+	host := u.Hostname()
+	port := u.Port()
+	if port == "" {
+		if u.Scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+
+	// Start listening.
+	listener, err := net.Listen("tcp", listenAddress)
+	if err != nil {
+		return "", err
+	}
+
+	// Keep listening for incoming connections in the background
+	// and forward the data both ways.
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				glog.Fatalf("Failed to accept connection: %v", err)
+			}
+			go func() {
+				client, err := net.Dial("tcp", host+":"+port)
+				if err != nil {
+					glog.Fatalf("Failed to connect: %v", err)
+				}
+				go func() {
+					defer client.Close()
+					defer conn.Close()
+					io.Copy(client, conn)
+				}()
+				go func() {
+					defer client.Close()
+					defer conn.Close()
+					io.Copy(conn, client)
+				}()
+			}()
+		}
+	}()
+
+	// Rewrite URL.
+	addr := listener.Addr().String()
+	// Here we have to rely on the observation that Addr has [::] as prefix when Listen
+	// was called without a specific address. This is not actually documented.
+	if strings.HasPrefix(addr, "[::]:") {
+		// Just a port number. For the URL to be useful outside of the local machine, we have to add
+		// some kind of hostname. A very elaborate scheme would look up local IP addresses, but
+		// simply picking the hostname should give reasonable results in a local LAN and is much simpler.
+		addr = addr[4:]
+		hostname, err := os.Hostname()
+		if err != nil {
+			hostname = "localhost"
+		}
+		addr = hostname + addr
+	}
+	u.Host = addr
+	return u.String(), nil
+}
+
+// RunTillBreak sleeps until interupted by SIGINT/TERM. Useful in
+// a program which has set up port forwarding with Proxy.
+func RunTillBreak() {
+	exitSignal := make(chan os.Signal)
+	signal.Notify(exitSignal, syscall.SIGINT, syscall.SIGTERM)
+	<-exitSignal
+}


### PR DESCRIPTION
I just started using minikube on a headless workstation into which I log in with ssh + X forwarding from a Linux laptop. In this setup, "minikube dashboard" fails:
- it invokes firefox on the workstation
- that firefox instance tells the firefox instance on the laptop to open the URL
- the URL can't be accessed because the IP address is local to the workstation

The other two commands where minikube prints or opens URLs are affected the same way. One can of course forward ports manually (ssh, socat, etc.), but I found it more convenient to let minikube do that automatically, so here's a PR which adds --proxy and --proxyaddress parameters to all three commands. Documentation is in doc/networking.md.

I've contributed to other open source projects before, but not yet to k8s and not in Go, so please beware that there might be novice mistakes - sorry for that in advance!
