### PR TITLE
use better package name

### DIFF
--- a/pkg/localkube/storage_provisioner.go
+++ b/pkg/localkube/storage_provisioner.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/r2d4/external-storage/lib/controller"
 	"k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -67,7 +67,7 @@ func (p *hostPathProvisioner) Provision(options controller.VolumeOptions) (*v1.P
 	}
 
 	pv := &v1.PersistentVolume{
-		ObjectMeta: meta_v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: options.PVName,
 			Annotations: map[string]string{
 				"hostPathProvisionerIdentity": string(p.identity),

--- a/pkg/minikube/service/service.go
+++ b/pkg/minikube/service/service.go
@@ -28,7 +28,7 @@ import (
 	"github.com/pkg/browser"
 	"github.com/pkg/errors"
 	"k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/clientcmd"
@@ -114,7 +114,7 @@ func GetServiceURLs(api libmachine.API, namespace string, t *template.Template) 
 
 	serviceInterface := client.Services(namespace)
 
-	svcs, err := serviceInterface.List(meta_v1.ListOptions{})
+	svcs, err := serviceInterface.List(metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +158,7 @@ func printURLsForService(c corev1.CoreV1Interface, ip, service, namespace string
 	}
 
 	s := c.Services(namespace)
-	svc, err := s.Get(service, meta_v1.GetOptions{})
+	svc, err := s.Get(service, metav1.GetOptions{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "service '%s' could not be found running", service)
 	}
@@ -211,14 +211,14 @@ func CheckService(namespace string, service string) error {
 }
 
 func validateService(s corev1.ServiceInterface, service string) error {
-	if _, err := s.Get(service, meta_v1.GetOptions{}); err != nil {
+	if _, err := s.Get(service, metav1.GetOptions{}); err != nil {
 		return errors.Wrapf(err, "Error getting service %s", service)
 	}
 	return nil
 }
 
 func checkEndpointReady(endpoints corev1.EndpointsInterface, service string) error {
-	endpoint, err := endpoints.Get(service, meta_v1.GetOptions{})
+	endpoint, err := endpoints.Get(service, metav1.GetOptions{})
 	if err != nil {
 		return &util.RetriableError{Err: errors.Errorf("Error getting endpoints for service %s", service)}
 	}
@@ -274,7 +274,7 @@ func GetServiceListByLabel(namespace string, key string, value string) (*v1.Serv
 
 func getServiceListFromServicesByLabel(services corev1.ServiceInterface, key string, value string) (*v1.ServiceList, error) {
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{key: value}))
-	serviceList, err := services.List(meta_v1.ListOptions{LabelSelector: selector.String()})
+	serviceList, err := services.List(metav1.ListOptions{LabelSelector: selector.String()})
 	if err != nil {
 		return &v1.ServiceList{}, &util.RetriableError{Err: err}
 	}
@@ -293,7 +293,7 @@ func CreateSecret(namespace, name string, dataValues map[string]string, labels m
 		return &util.RetriableError{Err: err}
 	}
 
-	secret, _ := secrets.Get(name, meta_v1.GetOptions{})
+	secret, _ := secrets.Get(name, metav1.GetOptions{})
 
 	// Delete existing secret
 	if len(secret.Name) > 0 {
@@ -311,7 +311,7 @@ func CreateSecret(namespace, name string, dataValues map[string]string, labels m
 
 	// Create Secret
 	secretObj := &v1.Secret{
-		ObjectMeta: meta_v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
 			Labels: labels,
 		},
@@ -340,7 +340,7 @@ func DeleteSecret(namespace, name string) error {
 		return &util.RetriableError{Err: err}
 	}
 
-	err = secrets.Delete(name, &meta_v1.DeleteOptions{})
+	err = secrets.Delete(name, &metav1.DeleteOptions{})
 	if err != nil {
 		return &util.RetriableError{Err: err}
 	}

--- a/pkg/minikube/service/service_test.go
+++ b/pkg/minikube/service/service_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/docker/machine/libmachine/host"
 	"github.com/pkg/errors"
 	"k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/kubernetes/typed/core/v1/fake"
@@ -61,7 +61,7 @@ var defaultNamespaceServiceInterface = &MockServiceInterface{
 	ServiceList: &v1.ServiceList{
 		Items: []v1.Service{
 			{
-				ObjectMeta: meta_v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "mock-dashboard",
 					Namespace: "default",
 				},
@@ -73,7 +73,7 @@ var defaultNamespaceServiceInterface = &MockServiceInterface{
 				},
 			},
 			{
-				ObjectMeta: meta_v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "mock-dashboard-no-ports",
 					Namespace: "default",
 				},
@@ -125,7 +125,7 @@ var endpointMap = map[string]*v1.Endpoints{
 	},
 }
 
-func (e MockEndpointsInterface) Get(name string, _ meta_v1.GetOptions) (*v1.Endpoints, error) {
+func (e MockEndpointsInterface) Get(name string, _ metav1.GetOptions) (*v1.Endpoints, error) {
 	endpoint, ok := endpointMap[name]
 	if !ok {
 		return nil, errors.New("Endpoint not found")
@@ -176,7 +176,7 @@ type MockServiceInterface struct {
 	ServiceList *v1.ServiceList
 }
 
-func (s MockServiceInterface) List(opts meta_v1.ListOptions) (*v1.ServiceList, error) {
+func (s MockServiceInterface) List(opts metav1.ListOptions) (*v1.ServiceList, error) {
 	serviceList := &v1.ServiceList{
 		Items: []v1.Service{},
 	}
@@ -195,7 +195,7 @@ func (s MockServiceInterface) List(opts meta_v1.ListOptions) (*v1.ServiceList, e
 	return s.ServiceList, nil
 }
 
-func (s MockServiceInterface) Get(name string, _ meta_v1.GetOptions) (*v1.Service, error) {
+func (s MockServiceInterface) Get(name string, _ metav1.GetOptions) (*v1.Service, error) {
 	for _, svc := range s.ServiceList.Items {
 		if svc.ObjectMeta.Name == name {
 			return &svc, nil

--- a/pkg/minikube/storageclass/storageclass.go
+++ b/pkg/minikube/storageclass/storageclass.go
@@ -18,7 +18,7 @@ package storageclass
 
 import (
 	"github.com/pkg/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"k8s.io/client-go/tools/clientcmd"
@@ -39,7 +39,7 @@ func DisableDefaultStorageClass() error {
 		return errors.Wrap(err, "Error creating new client from kubeConfig.ClientConfig()")
 	}
 
-	err = client.Storage().StorageClasses().Delete(constants.DefaultStorageClassProvisioner, &meta_v1.DeleteOptions{})
+	err = client.Storage().StorageClasses().Delete(constants.DefaultStorageClassProvisioner, &metav1.DeleteOptions{})
 	if err != nil {
 		return errors.Wrapf(err, "Error deleting default storage class %s", constants.DefaultStorageClassProvisioner)
 	}


### PR DESCRIPTION
According to https://blog.golang.org/package-names:
>The style of names typical of another language might not be idiomatic in a Go program. Here are two examples of names that might be good style in other languages but do not fit well in Go:
>- computeServiceClient
>- priority_queue

package name meatv1 is better than meat_v1,and I suggest we refer this style in later code.