### PR TITLE
Bump registry-creds version

### DIFF
--- a/cmd/minikube/cmd/config/configure.go
+++ b/cmd/minikube/cmd/config/configure.go
@@ -62,7 +62,7 @@ var addonsConfigureCmd = &cobra.Command{
 				awsAccessKey = AskForStaticValue("-- Enter AWS Secret Access Key: ")
 				awsSessionToken = AskForStaticValueOptional("-- (Optional) Enter AWS Session Token: ")
 				awsRegion = AskForStaticValue("-- Enter AWS Region: ")
-				awsAccount = AskForStaticValue("-- Enter 12 digit AWS Account ID: ")
+				awsAccount = AskForStaticValue("-- Enter 12 digit AWS Account ID (Comma seperated list): ")
 				awsRole = AskForStaticValueOptional("-- (Optional) Enter ARN of AWS role to assume: ")
 			}
 

--- a/deploy/addons/registry-creds/registry-creds-rc.yaml
+++ b/deploy/addons/registry-creds/registry-creds-rc.yaml
@@ -4,14 +4,14 @@ metadata:
   name: registry-creds
   namespace: kube-system
   labels:
-    version: v1.8
+    version: v1.9
     addonmanager.kubernetes.io/mode: Reconcile
     kubernetes.io/minikube-addons: registry-creds
 spec:
   replicas: 1
   selector:
     name: registry-creds
-    version: v1.8
+    version: v1.9
     addonmanager.kubernetes.io/mode: Reconcile
   template:
     metadata:
@@ -21,7 +21,7 @@ spec:
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:
-      - image: registry.hub.docker.com/upmcenterprises/registry-creds:1.8
+      - image: registry.hub.docker.com/upmcenterprises/registry-creds:1.9
         name: registry-creds
         imagePullPolicy: Always
         env:


### PR DESCRIPTION
This updates the registry-creds addon to v1.9 which allows users to specify multiple accountIds. 

// ref: upmc-enterprises/registry-creds#58