### PR TITLE
Refactor get download url for minikube

### DIFF
--- a/deploy/minikube/release_sanity_test.go
+++ b/deploy/minikube/release_sanity_test.go
@@ -32,19 +32,6 @@ import (
 	"k8s.io/minikube/pkg/util"
 )
 
-const (
-	downloadURL = "https://storage.googleapis.com/minikube/releases/%s/minikube-%s-amd64%s"
-)
-
-func getDownloadURL(version, platform string) string {
-	switch platform {
-	case "windows":
-		return fmt.Sprintf(downloadURL, version, platform, ".exe")
-	default:
-		return fmt.Sprintf(downloadURL, version, platform, "")
-	}
-}
-
 func getShaFromURL(url string) (string, error) {
 	fmt.Println("Downloading: ", url)
 	r, err := http.Get(url)
@@ -71,7 +58,7 @@ func TestReleasesJson(t *testing.T) {
 		fmt.Printf("Checking release: %s\n", r.Name)
 		for platform, sha := range r.Checksums {
 			fmt.Printf("Checking SHA for %s.\n", platform)
-			actualSha, err := getShaFromURL(getDownloadURL(r.Name, platform))
+			actualSha, err := getShaFromURL(util.GetBinaryDownloadURL(r.Name, platform))
 			if err != nil {
 				t.Errorf("Error calcuating SHA for %s-%s. Error: %s", r.Name, platform, err)
 				continue

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -38,6 +38,10 @@ import (
 	"k8s.io/minikube/pkg/version"
 )
 
+const (
+	downloadURL = "https://storage.googleapis.com/minikube/releases/%s/minikube-%s-amd64%s"
+)
+
 type RetriableError struct {
 	Err error
 }
@@ -153,6 +157,15 @@ func ParseSHAFromURL(url string) (string, error) {
 	}
 
 	return strings.Trim(string(body), "\n"), nil
+}
+
+func GetBinaryDownloadURL(version, platform string) string {
+	switch platform {
+	case "windows":
+		return fmt.Sprintf(downloadURL, version, platform, ".exe")
+	default:
+		return fmt.Sprintf(downloadURL, version, platform, "")
+	}
 }
 
 type MultiError struct {

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -162,3 +162,23 @@ Error 2`
 		t.Fatalf("Unexpected error: %s", err)
 	}
 }
+
+func TestGetBinaryDownloadURL(t *testing.T) {
+	testData := []struct {
+		version     string
+		platform    string
+		expectedURL string
+	}{
+		{"v0.0.1", "linux", "https://storage.googleapis.com/minikube/releases/v0.0.1/minikube-linux-amd64"},
+		{"v0.0.1", "darwin", "https://storage.googleapis.com/minikube/releases/v0.0.1/minikube-darwin-amd64"},
+		{"v0.0.1", "windows", "https://storage.googleapis.com/minikube/releases/v0.0.1/minikube-windows-amd64.exe"},
+	}
+
+	for _, tt := range testData {
+		url := GetBinaryDownloadURL(tt.version, tt.platform)
+		if url != tt.expectedURL {
+			t.Fatalf("Expected '%s' but got '%s'", tt.expectedURL, url)
+		}
+	}
+
+}


### PR DESCRIPTION
Refactored the `getDownloadURL` as it can be used later on.