### PR TITLE
highlight shell samples quoted in docs

### DIFF
--- a/docs/alternative_runtimes.md
+++ b/docs/alternative_runtimes.md
@@ -13,7 +13,7 @@ $ minikube start \
 
 To use [CRI-O](https://github.com/kubernetes-incubator/cri-o) as the container runtime, run:
 
-```bash
+```shell
 $ minikube start \
     --network-plugin=cni \
     --container-runtime=cri-o \
@@ -22,7 +22,7 @@ $ minikube start \
 
 Or you can use the extended version:
 
-```bash
+```shell
 $ minikube start \
     --network-plugin=cni \
     --extra-config=kubelet.container-runtime=remote \

--- a/docs/configuring_kubernetes.md
+++ b/docs/configuring_kubernetes.md
@@ -16,7 +16,7 @@ The kubeadm bootstrapper can be configured by the `--extra-config` flag on the `
 
 and `key=value` is a flag=value pair for the component being configured.  For example,
 
-```
+```shell
 minikube start --extra-config=apiserver.v=10 --extra-config=kubelet.max-pods=100
 ```
 

--- a/docs/contributors/build_guide.md
+++ b/docs/contributors/build_guide.md
@@ -15,7 +15,7 @@ $ sudo dnf install -y glibc-static
 ### Building from Source
 Clone minikube into your go path under `$GOPATH/src/k8s.io`
 
-```
+```shell
 $ git clone https://github.com/kubernetes/minikube.git $GOPATH/src/k8s.io/minikube
 $ cd $GOPATH/src/k8s.io/minikube
 $ make

--- a/docs/contributors/minikube_iso.md
+++ b/docs/contributors/minikube_iso.md
@@ -13,7 +13,7 @@ It includes:
 ### Requirements
 
 * Linux
-```
+```shell
 sudo apt-get install build-essential gnupg2 p7zip-full git wget cpio python \
 	unzip bc gcc-multilib automake libtool locales
 ```
@@ -23,7 +23,7 @@ Also be sure to have an UTF-8 locale set up in order to build the ISO.
 
 ### Build instructions
 
-```
+```shell
 $ git clone https://github.com/kubernetes/minikube
 $ cd minikube
 $ make buildroot-image
@@ -36,7 +36,7 @@ The bootable ISO image will be available in `out/minikube.iso`.
 
 ### Testing local minikube-iso changes
 
-```
+```shell
 $ ./out/minikube start \
     --container-runtime=rkt \
     --network-plugin=cni \
@@ -47,7 +47,7 @@ $ ./out/minikube start \
 
 To change the buildroot configuration, execute:
 
-```
+```shell
 $ cd out/buildroot
 $ make menuconfig
 $ make
@@ -55,14 +55,14 @@ $ make
 
 To save any buildroot configuration changes made with `make menuconfig`, execute:
 
-```
+```shell
 $ cd out/buildroot
 $ make savedefconfig
 ```
 
 The changes will be reflected in the `minikube-iso/configs/minikube_defconfig` file.
 
-```
+```shell
 $ git status
 ## master
  M deploy/iso/minikube-iso/configs/minikube_defconfig
@@ -73,7 +73,7 @@ $ git status
 
 To make any kernel configuration changes and save them, execute:
 
-```
+```shell
 $ make linux-menuconfig
 ```
 

--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -22,7 +22,7 @@ The KVM2 driver is maintained by the minikube team, and is built, tested and rel
 
 To install the KVM2 driver, first install and configure the prereqs:
 
-```
+```shell
 # Install libvirt and qemu-kvm on your system, e.g.
 # Debian/Ubuntu (for Debian Stretch libvirt-bin it's been replaced with libvirt-clients and libvirt-daemon-system)
 $ sudo apt install libvirt-bin qemu-kvm
@@ -44,13 +44,13 @@ $ newgrp libvirt
 
 Then install the driver itself:
 
-```
+```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-kvm2 && chmod +x docker-machine-driver-kvm2 && sudo mv docker-machine-driver-kvm2 /usr/bin/
 ```
 
 To use the driver you would do:
 
-```
+```shell
 minikube start --vm-driver kvm2
 ```
 
@@ -59,7 +59,7 @@ minikube start --vm-driver kvm2
 Minikube is currently tested against [`docker-machine-driver-kvm` v0.10.0](https://github.com/dhiltgen/docker-machine-kvm/releases).
 
 After following the instructions on the KVM driver releases page, you need to make sure that have the necessary packages and permissions by following these instructions:
-```
+```shell
 
 # Install libvirt and qemu-kvm on your system, e.g.
 # Debian/Ubuntu (for Debian Stretch libvirt-bin it's been replaced with libvirt-clients and libvirt-daemon-system)
@@ -82,7 +82,7 @@ $ newgrp libvirt
 
 To use the driver you would do:
 
-```
+```shell
 minikube start --vm-driver kvm
 ```
 
@@ -93,7 +93,7 @@ It is built from the minikube source tree, and uses [moby/hyperkit](http://githu
 
 To install the hyperkit driver:
 
-```
+```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-hyperkit \
 && chmod +x docker-machine-driver-hyperkit \
 && sudo mv docker-machine-driver-hyperkit /usr/local/bin/ \
@@ -109,7 +109,7 @@ If you encountered errors like `Could not find hyperkit executable`, you might n
 
 From https://github.com/zchee/docker-machine-driver-xhyve#install:
 
-```
+```shell
 $ brew install docker-machine-driver-xhyve
 
 # docker-machine-driver-xhyve need root owner and uid

--- a/docs/host_folder_mount.md
+++ b/docs/host_folder_mount.md
@@ -2,7 +2,7 @@
 ## Mounting Host Folders
 `minikube mount /path/to/dir/to/mount:/vm-mount-path` is the recommended way to mount directories into minikube so that they can be used in your local Kubernetes cluster. The command works on all supported platforms. Below is an example workflow for using `minikube mount`:
 
-```
+```shell
 # terminal 1
 $ mkdir ~/mount-dir
 $ minikube mount ~/mount-dir:/mount-9p
@@ -12,7 +12,7 @@ ufs starting
 # This process has to stay open, so in another terminal...
 ```
 
-```
+```shell
 # terminal 2
 $ echo "hello from host" > ~/mount-dir/hello-from-host
 $ kubectl run -i --rm --tty ubuntu --overrides='
@@ -50,7 +50,7 @@ $ kubectl run -i --rm --tty ubuntu --overrides='
     ]
   }
 }
-'  --image=ubuntu:14.04 --restart=Never -- bash
+' --image=ubuntu:14.04 --restart=Never -- bash
 
 Waiting for pod default/ubuntu to be running, status is Pending, pod ready: false
 Waiting for pod default/ubuntu to be running, status is Running, pod ready: false

--- a/docs/reusing_the_docker_daemon.md
+++ b/docs/reusing_the_docker_daemon.md
@@ -4,23 +4,23 @@ When using a single VM of kubernetes it's really handy to reuse the Docker daemo
 
 To be able to work with the docker daemon on your mac/linux host use the docker-env command in your shell:
 
-```
+```shell
 eval $(minikube docker-env)
 ```
 you should now be able to use docker on the command line on your host mac/linux machine talking to the docker daemon inside the minikube VM:
-```
+```shell
 docker ps
 ```
 
 On Centos 7, docker may report the following error:
 
-```
+```shell
 Could not read CA certificate "/etc/docker/ca.pem": open /etc/docker/ca.pem: no such file or directory
 ```
 
 The fix is to update /etc/sysconfig/docker to ensure that minikube's environment changes are respected:
 
-```
+```diff
 < DOCKER_CERT_PATH=/etc/docker
 ---
 > if [ -z "${DOCKER_CERT_PATH}" ]; then


### PR DESCRIPTION
this makes docs more readable, for example, comment are in a different color :
https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm2-driver
vs
https://github.com/jouve/minikube/blob/docs/docs/drivers.md#kvm2-driver

