### PR TITLE
Don't require VirtualBox

### DIFF
--- a/installers/linux/deb/minikube_deb_template/DEBIAN/control
+++ b/installers/linux/deb/minikube_deb_template/DEBIAN/control
@@ -3,7 +3,7 @@ Version: --VERSION--
 Section: base
 Priority: optional
 Architecture: amd64
-Depends: virtualbox
+Recommends: virtualbox
 Maintainer: Aaron Prindle <aaprindle@gmail.com>
 Description: Minikube
  Minikube is a tool that makes it easy to run Kubernetes locally.


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/2321

Since `virtualbox` is not required for `--vm-driver=none`, or when there are any of the other virtualization plugins, change this section to only recommend virtualbox. Policy docs are [here](https://www.debian.org/doc/debian-policy/#binary-dependencies-depends-recommends-suggests-enhances-pre-depends).