### PR TITLE
Add dependency files, faster partial make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ out/minikube$(IS_EXE): out/minikube-$(GOOS)-$(GOARCH)$(IS_EXE)
 out/localkube.d:
 	$(MAKEDEPEND) out/localkube k8s.io $(LOCALKUBEFILES) $^ > $@
 
-include out/localkube.d
+-include out/localkube.d
 out/localkube:
 ifeq ($(LOCALKUBE_BUILD_IN_DOCKER),y)
 	$(call DOCKER,$(BUILD_IMAGE),/usr/bin/make $@)
@@ -114,7 +114,7 @@ out/minikube-windows-amd64.exe: out/minikube-windows-amd64
 out/minikube.d: pkg/minikube/assets/assets.go
 	$(MAKEDEPEND) out/minikube-$(GOOS)-$(GOARCH) k8s.io $(MINIKUBEFILES) $^ > $@
 
-include out/minikube.d
+-include out/minikube.d
 out/minikube-%-amd64: pkg/minikube/assets/assets.go
 ifeq ($(MINIKUBE_BUILD_IN_DOCKER),y)
 	$(call DOCKER,$(BUILD_IMAGE),/usr/bin/make $@)
@@ -196,7 +196,7 @@ integration-versioned: out/minikube
 out/test.d: pkg/minikube/assets/assets.go
 	$(MAKEDEPEND) -t test k8s.io $(MINIKUBE_TEST_FILES) $^ > $@
 
-include out/test.d
+-include out/test.d
 test:
 	./test.sh
 
@@ -272,7 +272,7 @@ out/minikube-installer.exe: out/minikube-windows-amd64.exe
 out/docker-machine-driver-hyperkit.d:
 	$(MAKEDEPEND) out/docker-machine-driver-hyperkit k8s.io $(HYPERKIT_FILES) $^ > $@
 
-include out/docker-machine-driver-hyperkit.d
+-include out/docker-machine-driver-hyperkit.d
 out/docker-machine-driver-hyperkit:
 ifeq ($(MINIKUBE_BUILD_IN_DOCKER),y)
 	$(call DOCKER,$(HYPERKIT_BUILD_IMAGE),CC=o64-clang CXX=o64-clang++ /usr/bin/make $@)
@@ -329,7 +329,7 @@ $(ISO_BUILD_IMAGE): deploy/iso/minikube-iso/Dockerfile
 out/storage-provisioner.d:
 	$(MAKEDEPEND) out/storage-provisioner k8s.io $(STORAGE_PROVISIONER_FILES) $^ > $@
 
-include out/storage-provisioner.d
+-include out/storage-provisioner.d
 out/storage-provisioner:
 	GOOS=linux go build -o $(BUILD_DIR)/storage-provisioner -ldflags=$(LOCALKUBE_LDFLAGS) cmd/storage-provisioner/main.go
 
@@ -349,7 +349,7 @@ release-iso: minikube_iso checksum
 out/docker-machine-driver-kvm2.d:
 	$(MAKEDEPEND) out/docker-machine-driver-kvm2 k8s.io $(KVM_DRIVER_FILES) $^ > $@
 
-include out/docker-machine-driver-kvm2.d
+-include out/docker-machine-driver-kvm2.d
 out/docker-machine-driver-kvm2:
 	go build 																		\
 		-installsuffix "static" 													\

--- a/Makefile
+++ b/Makefile
@@ -54,13 +54,15 @@ K8S_VERSION_LDFLAGS := $(shell $(PYTHON) hack/get_k8s_version.py 2>&1)
 MINIKUBE_LDFLAGS := -X k8s.io/minikube/pkg/version.version=$(VERSION) -X k8s.io/minikube/pkg/version.isoVersion=$(ISO_VERSION) -X k8s.io/minikube/pkg/version.isoPath=$(ISO_BUCKET)
 LOCALKUBE_LDFLAGS := "$(K8S_VERSION_LDFLAGS) $(MINIKUBE_LDFLAGS) -s -w -extldflags '-static'"
 
-LOCALKUBEFILES := GOPATH=$(GOPATH) go list -f '{{join .Deps "\n"}}' ./cmd/localkube/ | grep k8s.io | GOPATH=$(GOPATH) xargs go list -f '{{ range $$file := .GoFiles }} {{$$.Dir}}/{{$$file}}{{"\n"}}{{end}}'
-MINIKUBEFILES := GOPATH=$(GOPATH) go list -f '{{join .Deps "\n"}}' ./cmd/minikube/ | grep k8s.io | GOPATH=$(GOPATH) xargs go list -f '{{ range $$file := .GoFiles }} {{$$.Dir}}/{{$$file}}{{"\n"}}{{end}}'
-HYPERKIT_FILES := GOPATH=$(GOPATH) go list -f '{{join .Deps "\n"}}' ./cmd/drivers/hyperkit | grep k8s.io | GOPATH=$(GOPATH) xargs go list -f '{{ range $$file := .GoFiles }} {{$$.Dir}}/{{$$file}}{{"\n"}}{{end}}'
-STORAGE_PROVISIONER_FILES := GOPATH=$(GOPATH) go list -f '{{join .Deps "\n"}}' ./cmd/storage-provisioner | grep k8s.io | GOPATH=$(GOPATH) xargs go list -f '{{ range $$file := .GoFiles }} {{$$.Dir}}/{{$$file}}{{"\n"}}{{end}}'
-KVM_DRIVER_FILES := GOPATH=$(GOPATH) go list -f '{{join .Deps "\n"}}' ./cmd/drivers/kvm/ | grep k8s.io | GOPATH=$(GOPATH) xargs go list -f '{{ range $$file := .GoFiles }} {{$$.Dir}}/{{$$file}}{{"\n"}}{{end}}'
+MAKEDEPEND := GOPATH=$(GOPATH) ./makedepend.sh
 
-MINIKUBE_TEST_FILES := GOPATH=$(GOPATH) go list -f '{{ if .TestGoFiles }} {{.ImportPath}} {{end}}' ./... | grep k8s.io | GOPATH=$(GOPATH) xargs go list -f '{{ range $$file := .GoFiles }} {{$$.Dir}}/{{$$file}}{{"\n"}}{{end}}'
+LOCALKUBEFILES := ./cmd/localkube/
+MINIKUBEFILES := ./cmd/minikube/
+HYPERKIT_FILES := ./cmd/drivers/hyperkit
+STORAGE_PROVISIONER_FILES := ./cmd/storage-provisioner
+KVM_DRIVER_FILES := ./cmd/drivers/kvm/
+
+MINIKUBE_TEST_FILES := ./...
 
 MINIKUBE_BUILD_TAGS := container_image_ostree_stub containers_image_openpgp
 MINIKUBE_INTEGRATION_BUILD_TAGS := integration $(MINIKUBE_BUILD_TAGS)
@@ -95,7 +97,11 @@ endif
 out/minikube$(IS_EXE): out/minikube-$(GOOS)-$(GOARCH)$(IS_EXE)
 	cp $< $@
 
-out/localkube: $(shell $(LOCALKUBEFILES))
+out/localkube.d:
+	$(MAKEDEPEND) out/localkube k8s.io $(LOCALKUBEFILES) $^ > $@
+
+include out/localkube.d
+out/localkube:
 ifeq ($(LOCALKUBE_BUILD_IN_DOCKER),y)
 	$(call DOCKER,$(BUILD_IMAGE),/usr/bin/make $@)
 else
@@ -105,7 +111,11 @@ endif
 out/minikube-windows-amd64.exe: out/minikube-windows-amd64
 	cp out/minikube-windows-amd64 out/minikube-windows-amd64.exe
 
-out/minikube-%-amd64: pkg/minikube/assets/assets.go $(shell $(MINIKUBEFILES))
+out/minikube.d: pkg/minikube/assets/assets.go
+	$(MAKEDEPEND) out/minikube-$(GOOS)-$(GOARCH) k8s.io $(MINIKUBEFILES) $^ > $@
+
+include out/minikube.d
+out/minikube-%-amd64: pkg/minikube/assets/assets.go
 ifeq ($(MINIKUBE_BUILD_IN_DOCKER),y)
 	$(call DOCKER,$(BUILD_IMAGE),/usr/bin/make $@)
 else
@@ -155,6 +165,9 @@ test-iso:
 test-pkg/%:
 	go test -v -test.timeout=30m $(REPOPATH)/$* --tags="$(MINIKUBE_BUILD_TAGS)"
 
+.PHONY: depend
+depend: out/localkube.d out/minikube.d out/test.d out/docker-machine-driver-hyperkit.d out/storage-provisioner.d out/docker-machine-driver-kvm2.d
+
 .PHONY: all
 all: cross drivers e2e-cross images out/localkube
 
@@ -180,7 +193,11 @@ integration-versioned: out/minikube
 	go test -v -test.timeout=30m $(REPOPATH)/test/integration --tags="$(MINIKUBE_INTEGRATION_BUILD_TAGS) versioned" $(TEST_ARGS)
 
 .PHONY: test
-test: pkg/minikube/assets/assets.go $(shell $(MINIKUBE_TEST_FILES))
+out/test.d: pkg/minikube/assets/assets.go
+	$(MAKEDEPEND) -t test k8s.io $(MINIKUBE_TEST_FILES) $^ > $@
+
+include out/test.d
+test:
 	./test.sh
 
 pkg/minikube/assets/assets.go: $(GOPATH)/bin/go-bindata $(shell find deploy/addons -type f)
@@ -252,7 +269,11 @@ out/minikube-installer.exe: out/minikube-windows-amd64.exe
 	mv out/windows_tmp/minikube-installer.exe out/minikube-installer.exe
 	rm -rf out/windows_tmp
 
-out/docker-machine-driver-hyperkit: $(shell $(HYPERKIT_FILES))
+out/docker-machine-driver-hyperkit.d:
+	$(MAKEDEPEND) out/docker-machine-driver-hyperkit k8s.io $(HYPERKIT_FILES) $^ > $@
+
+include out/docker-machine-driver-hyperkit.d
+out/docker-machine-driver-hyperkit:
 ifeq ($(MINIKUBE_BUILD_IN_DOCKER),y)
 	$(call DOCKER,$(HYPERKIT_BUILD_IMAGE),CC=o64-clang CXX=o64-clang++ /usr/bin/make $@)
 else
@@ -305,7 +326,11 @@ $(ISO_BUILD_IMAGE): deploy/iso/minikube-iso/Dockerfile
 	@echo ""
 	@echo "$(@) successfully built"
 
-out/storage-provisioner: $(shell $(STORAGE_PROVISIONER_FILES))
+out/storage-provisioner.d:
+	$(MAKEDEPEND) out/storage-provisioner k8s.io $(STORAGE_PROVISIONER_FILES) $^ > $@
+
+include out/storage-provisioner.d
+out/storage-provisioner:
 	GOOS=linux go build -o $(BUILD_DIR)/storage-provisioner -ldflags=$(LOCALKUBE_LDFLAGS) cmd/storage-provisioner/main.go
 
 .PHONY: storage-provisioner-image
@@ -321,7 +346,11 @@ release-iso: minikube_iso checksum
 	gsutil cp out/minikube.iso gs://$(ISO_BUCKET)/minikube-$(ISO_VERSION).iso
 	gsutil cp out/minikube.iso.sha256 gs://$(ISO_BUCKET)/minikube-$(ISO_VERSION).iso.sha256
 
-out/docker-machine-driver-kvm2: $(shell $(KVM_DRIVER_FILES))
+out/docker-machine-driver-kvm2.d:
+	$(MAKEDEPEND) out/docker-machine-driver-kvm2 k8s.io $(KVM_DRIVER_FILES) $^ > $@
+
+include out/docker-machine-driver-kvm2.d
+out/docker-machine-driver-kvm2:
 	go build 																		\
 		-installsuffix "static" 													\
 		-ldflags "-X k8s.io/minikube/pkg/drivers/kvm/version.VERSION=$(VERSION)" 	\

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ out/minikube$(IS_EXE): out/minikube-$(GOOS)-$(GOARCH)$(IS_EXE)
 	cp $< $@
 
 out/localkube.d:
-	$(MAKEDEPEND) out/localkube k8s.io $(LOCALKUBEFILES) $^ > $@
+	$(MAKEDEPEND) out/localkube $(ORG) $(LOCALKUBEFILES) $^ > $@
 
 -include out/localkube.d
 out/localkube:
@@ -112,7 +112,7 @@ out/minikube-windows-amd64.exe: out/minikube-windows-amd64
 	cp out/minikube-windows-amd64 out/minikube-windows-amd64.exe
 
 out/minikube.d: pkg/minikube/assets/assets.go
-	$(MAKEDEPEND) out/minikube-$(GOOS)-$(GOARCH) k8s.io $(MINIKUBEFILES) $^ > $@
+	$(MAKEDEPEND) out/minikube-$(GOOS)-$(GOARCH) $(ORG) $(MINIKUBEFILES) $^ > $@
 
 -include out/minikube.d
 out/minikube-%-amd64: pkg/minikube/assets/assets.go
@@ -194,7 +194,7 @@ integration-versioned: out/minikube
 
 .PHONY: test
 out/test.d: pkg/minikube/assets/assets.go
-	$(MAKEDEPEND) -t test k8s.io $(MINIKUBE_TEST_FILES) $^ > $@
+	$(MAKEDEPEND) -t test $(ORG) $(MINIKUBE_TEST_FILES) $^ > $@
 
 -include out/test.d
 test:
@@ -270,7 +270,7 @@ out/minikube-installer.exe: out/minikube-windows-amd64.exe
 	rm -rf out/windows_tmp
 
 out/docker-machine-driver-hyperkit.d:
-	$(MAKEDEPEND) out/docker-machine-driver-hyperkit k8s.io $(HYPERKIT_FILES) $^ > $@
+	$(MAKEDEPEND) out/docker-machine-driver-hyperkit $(ORG) $(HYPERKIT_FILES) $^ > $@
 
 -include out/docker-machine-driver-hyperkit.d
 out/docker-machine-driver-hyperkit:
@@ -327,7 +327,7 @@ $(ISO_BUILD_IMAGE): deploy/iso/minikube-iso/Dockerfile
 	@echo "$(@) successfully built"
 
 out/storage-provisioner.d:
-	$(MAKEDEPEND) out/storage-provisioner k8s.io $(STORAGE_PROVISIONER_FILES) $^ > $@
+	$(MAKEDEPEND) out/storage-provisioner $(ORG) $(STORAGE_PROVISIONER_FILES) $^ > $@
 
 -include out/storage-provisioner.d
 out/storage-provisioner:
@@ -347,7 +347,7 @@ release-iso: minikube_iso checksum
 	gsutil cp out/minikube.iso.sha256 gs://$(ISO_BUCKET)/minikube-$(ISO_VERSION).iso.sha256
 
 out/docker-machine-driver-kvm2.d:
-	$(MAKEDEPEND) out/docker-machine-driver-kvm2 k8s.io $(KVM_DRIVER_FILES) $^ > $@
+	$(MAKEDEPEND) out/docker-machine-driver-kvm2 $(ORG) $(KVM_DRIVER_FILES) $^ > $@
 
 -include out/docker-machine-driver-kvm2.d
 out/docker-machine-driver-kvm2:

--- a/makedepend.sh
+++ b/makedepend.sh
@@ -3,7 +3,7 @@
 # Generate go dependencies, for make. Uses `go list".
 # Usage: makedepend.sh [-t] output package path [extra]
 
-PATH_FORMAT='{{join .Deps "\n"}}'
+PATH_FORMAT='{{ .ImportPath }}{{"\n"}}{{join .Deps "\n"}}'
 FILE_FORMAT='{{ range $file := .GoFiles }} {{$.Dir}}/{{$file}}{{"\n"}}{{end}}'
 
 if [ "$1" = "-t" ]

--- a/makedepend.sh
+++ b/makedepend.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# Generate go dependencies, for make. Uses `go list".
+# Usage: makedepend.sh [-t] output package path [extra]
+
+PATH_FORMAT='{{join .Deps "\n"}}'
+FILE_FORMAT='{{ range $file := .GoFiles }} {{$.Dir}}/{{$file}}{{"\n"}}{{end}}'
+
+if [ "$1" = "-t" ]
+then
+  PATH_FORMAT='{{ if .TestGoFiles }} {{.ImportPath}} {{end}}'
+  shift
+fi
+
+out=$1
+pkg=$2
+path=$3
+extra=$4
+
+# check for mandatory parameters
+test -n "$out$pkg$path" || exit 1
+
+echo "$out: $extra\\"
+go list -f "$PATH_FORMAT" $path |
+  grep "$pkg" |
+  xargs go list -f "$FILE_FORMAT" |
+  sed -e "s|^ ${GOPATH}| \$(GOPATH)|;s/$/ \\\\/"
+echo " #"

--- a/makedepend.sh
+++ b/makedepend.sh
@@ -1,5 +1,19 @@
 #!/bin/sh
 
+# Copyright 2018 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Generate go dependencies, for make. Uses `go list".
 # Usage: makedepend.sh [-t] output package path [extra]
 


### PR DESCRIPTION
This is a half-way approach, between:

* the current way of _always_ calling `go list`.
* the suggestion in #2524 to _never_ call it

On my machine, it takes 60 seconds for make to generate all the files (with `go list`)
And it takes about 30 seconds to rebuild minikube (with `go build`) without any changes