### PR TITLE
Add metrics-server as an addon

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -203,6 +203,12 @@ var settings = []Setting{
 		callbacks:   []setFn{EnableOrDisableAddon},
 	},
 	{
+		name:        "metrics-server",
+		set:         SetBool,
+		validations: []setFn{IsValidAddon},
+		callbacks:   []setFn{EnableOrDisableAddon},
+	},
+	{
 		name: "hyperv-virtual-switch",
 		set:  SetString,
 	},

--- a/deploy/addons/metrics-server/metrics-apiservice.yaml
+++ b/deploy/addons/metrics-server/metrics-apiservice.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1beta1.metrics.k8s.io
+  labels:
+    kubernetes.io/minikube-addons: metrics-server
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  service:
+    name: metrics-server
+    namespace: kube-system
+  group: metrics.k8s.io
+  version: v1beta1
+  insecureSkipTLSVerify: true
+  groupPriorityMinimum: 100
+  versionPriority: 100

--- a/deploy/addons/metrics-server/metrics-server-deployment.yaml
+++ b/deploy/addons/metrics-server/metrics-server-deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    k8s-app: metrics-server
+    kubernetes.io/minikube-addons: metrics-server
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  selector:
+    matchLabels:
+      k8s-app: metrics-server
+  template:
+    metadata:
+      name: metrics-server
+      labels:
+        k8s-app: metrics-server
+    spec:
+      containers:
+      - name: metrics-server
+        image: gcr.io/google_containers/metrics-server-amd64:v0.2.1
+        imagePullPolicy: Always
+        command:
+        - /metrics-server
+        - --source=kubernetes.summary_api:''

--- a/deploy/addons/metrics-server/metrics-server-service.yaml
+++ b/deploy/addons/metrics-server/metrics-server-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    kubernetes.io/name: "Metrics-server"
+    kubernetes.io/minikube-addons: metrics-server
+    kubernetes.io/minikube-addons-endpoint: metrics-server
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  selector:
+    k8s-app: metrics-server
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 443

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -214,6 +214,23 @@ var Addons = map[string]*Addon{
 			"ingress-svc.yaml",
 			"0640"),
 	}, false, "ingress"),
+	"metrics-server": NewAddon([]*BinDataAsset{
+		NewBinDataAsset(
+			"deploy/addons/metrics-server/metrics-apiservice.yaml",
+			constants.AddonsPath,
+			"metrics-apiservice.yaml",
+			"0640"),
+		NewBinDataAsset(
+			"deploy/addons/metrics-server/metrics-server-deployment.yaml",
+			constants.AddonsPath,
+			"metrics-server-deployment.yaml",
+			"0640"),
+		NewBinDataAsset(
+			"deploy/addons/metrics-server/metrics-server-service.yaml",
+			constants.AddonsPath,
+			"metrics-server-service.yaml",
+			"0640"),
+	}, false, "metrics-server"),
 	"registry": NewAddon([]*BinDataAsset{
 		NewBinDataAsset(
 			"deploy/addons/registry/registry-rc.yaml",


### PR DESCRIPTION
Since K8s 1.9, `metrics-server` is by default used for getting metrics for HPAs, replacing the same function originally supplied by Heapster. While there is a flag to change this behavior and use Heapster for HPAs, it may be simpler to just add `metrics-server` as an addon.