### PR TITLE
Prepend hyper-v module name to fix cmdlet collision with vmware powercli

### DIFF
--- a/vendor/github.com/docker/machine/drivers/hyperv/hyperv.go
+++ b/vendor/github.com/docker/machine/drivers/hyperv/hyperv.go
@@ -128,7 +128,7 @@ func (d *Driver) GetURL() (string, error) {
 }
 
 func (d *Driver) GetState() (state.State, error) {
-	stdout, err := cmdOut("(", "Get-VM", d.MachineName, ").state")
+	stdout, err := cmdOut("(", "hyper-v\\Get-VM", d.MachineName, ").state")
 	if err != nil {
 		return state.None, fmt.Errorf("Failed to find the VM status")
 	}
@@ -205,7 +205,7 @@ func (d *Driver) Create() error {
 		return err
 	}
 
-	if err := cmd("New-VM",
+	if err := cmd("hyper-v\\New-VM",
 		d.MachineName,
 		"-Path", fmt.Sprintf("'%s'", d.ResolveStorePath(".")),
 		"-SwitchName", quote(virtualSwitch),
@@ -214,7 +214,7 @@ func (d *Driver) Create() error {
 	}
 
 	if d.CPU > 1 {
-		if err := cmd("Set-VMProcessor",
+		if err := cmd("hyper-v\\Set-VMProcessor",
 			d.MachineName,
 			"-Count", fmt.Sprintf("%d", d.CPU)); err != nil {
 			return err
@@ -222,7 +222,7 @@ func (d *Driver) Create() error {
 	}
 
 	if d.MacAddr != "" {
-		if err := cmd("Set-VMNetworkAdapter",
+		if err := cmd("hyper-v\\Set-VMNetworkAdapter",
 			"-VMName", d.MachineName,
 			"-StaticMacAddress", fmt.Sprintf("\"%s\"", d.MacAddr)); err != nil {
 			return err
@@ -230,7 +230,7 @@ func (d *Driver) Create() error {
 	}
 
 	if d.VLanID > 0 {
-		if err := cmd("Set-VMNetworkAdapterVlan",
+		if err := cmd("hyper-v\\Set-VMNetworkAdapterVlan",
 			"-VMName", d.MachineName,
 			"-Access",
 			"-VlanId", fmt.Sprintf("%d", d.VLanID)); err != nil {
@@ -238,13 +238,13 @@ func (d *Driver) Create() error {
 		}
 	}
 
-	if err := cmd("Set-VMDvdDrive",
+	if err := cmd("hyper-v\\Set-VMDvdDrive",
 		"-VMName", d.MachineName,
 		"-Path", quote(d.ResolveStorePath("boot2docker.iso"))); err != nil {
 		return err
 	}
 
-	if err := cmd("Add-VMHardDiskDrive",
+	if err := cmd("hyper-v\\Add-VMHardDiskDrive",
 		"-VMName", d.MachineName,
 		"-Path", quote(diskImage)); err != nil {
 		return err
@@ -255,20 +255,28 @@ func (d *Driver) Create() error {
 }
 
 func (d *Driver) chooseVirtualSwitch() (string, error) {
-	stdout, err := cmdOut("(Get-VMSwitch).Name")
+	if d.VSwitch == "" {
+		// Default to the first external switche and in the process avoid DockerNAT
+		stdout, err := cmdOut("(hyper-v\\Get-VMSwitch -SwitchType External).Name")
+		if err != nil {
+			return "", err
+		}
+
+		switches := parseLines(stdout)
+
+		if len(switches) < 1 {
+			return "", fmt.Errorf("no External vswitch found. A valid vswitch must be available for this command to run. Check https://docs.docker.com/machine/drivers/hyper-v/")
+		}
+
+		return switches[0], nil
+	}
+
+	stdout, err := cmdOut("(hyper-v\\Get-VMSwitch).Name")
 	if err != nil {
 		return "", err
 	}
 
 	switches := parseLines(stdout)
-
-	if d.VSwitch == "" {
-		if len(switches) < 1 {
-			return "", fmt.Errorf("no vswitch found. A valid vswitch must be available for this command to run. Check https://docs.docker.com/machine/drivers/hyper-v/")
-		}
-
-		return switches[0], nil
-	}
 
 	found := false
 	for _, name := range switches {
@@ -319,7 +327,7 @@ func (d *Driver) waitStopped() error {
 
 // Start starts an host
 func (d *Driver) Start() error {
-	if err := cmd("Start-VM", d.MachineName); err != nil {
+	if err := cmd("hyper-v\\Start-VM", d.MachineName); err != nil {
 		return err
 	}
 
@@ -335,7 +343,7 @@ func (d *Driver) Start() error {
 
 // Stop stops an host
 func (d *Driver) Stop() error {
-	if err := cmd("Stop-VM", d.MachineName); err != nil {
+	if err := cmd("hyper-v\\Stop-VM", d.MachineName); err != nil {
 		return err
 	}
 
@@ -361,7 +369,7 @@ func (d *Driver) Remove() error {
 		}
 	}
 
-	return cmd("Remove-VM", d.MachineName, "-Force")
+	return cmd("hyper-v\\Remove-VM", d.MachineName, "-Force")
 }
 
 // Restart stops and starts an host
@@ -376,7 +384,7 @@ func (d *Driver) Restart() error {
 
 // Kill force stops an host
 func (d *Driver) Kill() error {
-	if err := cmd("Stop-VM", d.MachineName, "-TurnOff"); err != nil {
+	if err := cmd("hyper-v\\Stop-VM", d.MachineName, "-TurnOff"); err != nil {
 		return err
 	}
 
@@ -398,7 +406,7 @@ func (d *Driver) GetIP() (string, error) {
 		return "", drivers.ErrHostIsNotRunning
 	}
 
-	stdout, err := cmdOut("((", "Get-VM", d.MachineName, ").networkadapters[0]).ipaddresses[0]")
+	stdout, err := cmdOut("((", "hyper-v\\Get-VM", d.MachineName, ").networkadapters[0]).ipaddresses[0]")
 	if err != nil {
 		return "", err
 	}
@@ -432,7 +440,7 @@ func (d *Driver) generateDiskImage() (string, error) {
 	}
 
 	log.Infof("Creating VHD")
-	if err := cmd("New-VHD", "-Path", quote(fixed), "-SizeBytes", fixedDiskSize, "-Fixed"); err != nil {
+	if err := cmd("hyper-v\\New-VHD", "-Path", quote(fixed), "-SizeBytes", fixedDiskSize, "-Fixed"); err != nil {
 		return "", err
 	}
 
@@ -454,12 +462,12 @@ func (d *Driver) generateDiskImage() (string, error) {
 	}
 	file.Close()
 
-	if err := cmd("Convert-VHD", "-Path", quote(fixed), "-DestinationPath", quote(diskImage), "-VHDType", "Dynamic", "-DeleteSource"); err != nil {
+	if err := cmd("hyper-v\\Convert-VHD", "-Path", quote(fixed), "-DestinationPath", quote(diskImage), "-VHDType", "Dynamic", "-DeleteSource"); err != nil {
 		return "", err
 	}
 
 	if isWindowsAdmin {
-		if err := cmd("Resize-VHD", "-Path", quote(diskImage), "-SizeBytes", toMb(d.DiskSize)); err != nil {
+		if err := cmd("hyper-v\\Resize-VHD", "-Path", quote(diskImage), "-SizeBytes", toMb(d.DiskSize)); err != nil {
 			return "", err
 		}
 	}

--- a/vendor/github.com/docker/machine/drivers/hyperv/powershell.go
+++ b/vendor/github.com/docker/machine/drivers/hyperv/powershell.go
@@ -55,7 +55,7 @@ func parseLines(stdout string) []string {
 }
 
 func hypervAvailable() error {
-	stdout, err := cmdOut("@(Get-Command Get-VM).ModuleName")
+	stdout, err := cmdOut("@(Get-Command hyper-v\\Get-VM).ModuleName")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #2226

When VMware PowerCLI is installed alongside Hyper-V, there are multiple command collisions which prevent the hyperv Docker machine driver from working as expected.  I fixed the underlying Docker Machine issue in https://github.com/docker/machine/pull/4404 by prepending the hyper-v module name to ensure the correct module is used.

This pull request contains the latest hyperv machine driver code from the Docker Machine repo, which also includes code to help select the correct V-Switch if one is not specified.

Signed-off-by: Dave May <dave.may@tresta.com>