### PR TITLE
Bump version and update manifest CoreDNS

### DIFF
--- a/deploy/addons/coredns/coreDNS-configmap.yaml
+++ b/deploy/addons/coredns/coreDNS-configmap.yaml
@@ -11,11 +11,12 @@ data:
         errors
         log
         health
-        kubernetes cluster.local 10.0.0.0/24 {
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
             pods insecure
-            upstream /etc/resolv.conf
+            upstream
+            fallthrough in-addr.arpa ip6.arpa
         }
-        prometheus
+        prometheus :9153
         proxy . /etc/resolv.conf
         cache 30
     }

--- a/deploy/addons/coredns/coreDNS-controller.yaml
+++ b/deploy/addons/coredns/coreDNS-controller.yaml
@@ -9,6 +9,10 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   selector:
     matchLabels:
       k8s-app: kube-dns
@@ -25,7 +29,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: coredns
-        image: registry.hub.docker.com/coredns/coredns:1.0.2
+        image: registry.hub.docker.com/coredns/coredns:1.0.6
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -43,9 +47,6 @@ spec:
           protocol: UDP
         - containerPort: 53
           name: dns-tcp
-          protocol: TCP
-        - containerPort: 9153
-          name: metrics
           protocol: TCP
         livenessProbe:
           httpGet:

--- a/deploy/addons/coredns/coreDNS-svc.yaml
+++ b/deploy/addons/coredns/coreDNS-svc.yaml
@@ -18,6 +18,3 @@ spec:
   - name: dns-tcp
     port: 53
     protocol: TCP
-  - name: metrics
-    port: 9153
-    protocol: TCP


### PR DESCRIPTION
Updating the CoreDNS manifests to have the latest configuration and bumping the version to 1.0.6