### PR TITLE
deactivated hsts by default

### DIFF
--- a/deploy/addons/ingress/ingress-configmap.yaml
+++ b/deploy/addons/ingress/ingress-configmap.yaml
@@ -15,6 +15,7 @@
 apiVersion: v1
 data:
   map-hash-bucket-size: "128"
+  hsts: "false"
 kind: ConfigMap
 metadata:
   name: nginx-load-balancer-conf

--- a/deploy/addons/ingress/ingress-configmap.yaml
+++ b/deploy/addons/ingress/ingress-configmap.yaml
@@ -14,6 +14,7 @@
 
 apiVersion: v1
 data:
+  # see https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/configmap.md for all possible options and their description
   map-hash-bucket-size: "128"
   hsts: "false"
 kind: ConfigMap

--- a/docs/addons.md
+++ b/docs/addons.md
@@ -40,3 +40,5 @@ The currently supported addons include:
 If you would like to have minikube properly start/restart custom addons, place the addon(s) you wish to be launched with minikube in the `.minikube/addons` directory. Addons in this folder will be moved to the minikube VM and launched each time minikube is started/restarted.
 
 If you have a request for an addon in minikube, please open an issue with the name and preferably a link to the addon with a description of its purpose and why it should be added.  You can also attempt to add the addon to minikube by following the guide at [Adding an Addon](contributors/adding_an_addon.md)
+
+**Note:** If you want to have a look at the default configuration for the addons, see [deploy/addons](https://github.com/kubernetes/minikube/tree/master/deploy/addons).


### PR DESCRIPTION
HSTS has been deactivated explicitly by default for the ingress controller in minikube, because it causes trouble for local development. Minikube is intended for local development (where e.g. getting let's-encrypt-certificates is not an option), so this feature should not be turned on by default.