### PR TITLE
Added map[string]string argument parsing for eviction-like arguments

### DIFF
--- a/pkg/util/config.go
+++ b/pkg/util/config.go
@@ -84,6 +84,8 @@ func setElement(e reflect.Value, v string) error {
 	case []string:
 		vals := strings.Split(v, ",")
 		e.Set(reflect.ValueOf(vals))
+  case map[string]string:
+    return convertMap(e, v)
 	default:
 		// Last ditch attempt to convert anything based on its underlying kind.
 		// This covers any types that are aliased to a native type
@@ -102,6 +104,19 @@ func setElement(e reflect.Value, v string) error {
 	}
 
 	return nil
+}
+
+func convertMap(e reflect.Value, v string) error {
+  vals := strings.Split(v, ",")
+  for _, subitem := range vals {
+    // only deals with eviction thresholds in the "eviction.signal<value" format
+    subvals := strings.Split(subitem, "<")
+    if len(subvals) != 2 {
+      return fmt.Errorf("Unparsable %s", v)
+    }
+    e.SetMapIndex(reflect.ValueOf(subvals[0]), reflect.ValueOf(subvals[1]))
+  }
+  return nil
 }
 
 func convertInt(e reflect.Value, v string) error {

--- a/pkg/util/config.go
+++ b/pkg/util/config.go
@@ -84,8 +84,8 @@ func setElement(e reflect.Value, v string) error {
 	case []string:
 		vals := strings.Split(v, ",")
 		e.Set(reflect.ValueOf(vals))
-  case map[string]string:
-    return convertMap(e, v)
+	case map[string]string:
+		return convertMap(e, v)
 	default:
 		// Last ditch attempt to convert anything based on its underlying kind.
 		// This covers any types that are aliased to a native type
@@ -107,16 +107,16 @@ func setElement(e reflect.Value, v string) error {
 }
 
 func convertMap(e reflect.Value, v string) error {
-  vals := strings.Split(v, ",")
-  for _, subitem := range vals {
-    // only deals with eviction thresholds in the "eviction.signal<value" format
-    subvals := strings.Split(subitem, "<")
-    if len(subvals) != 2 {
-      return fmt.Errorf("Unparsable %s", v)
-    }
-    e.SetMapIndex(reflect.ValueOf(subvals[0]), reflect.ValueOf(subvals[1]))
-  }
-  return nil
+	vals := strings.Split(v, ",")
+	for _, subitem := range vals {
+		// only deals with eviction thresholds in the "eviction.signal<value" format
+		subvals := strings.Split(subitem, "<")
+		if len(subvals) != 2 {
+			return fmt.Errorf("Unparsable %s", v)
+		}
+		e.SetMapIndex(reflect.ValueOf(subvals[0]), reflect.ValueOf(subvals[1]))
+	}
+	return nil
 }
 
 func convertInt(e reflect.Value, v string) error {


### PR DESCRIPTION
This P/R resolves the issue when parsing eviction arguements like `--extra-config=kubelet.EvictionHard="imagefs.available<1Mi"` as described in #2594

```
localkube[14042]: I0309 21:29:52.250226   14042 localkube.go:175] Setting EvictionHard to imagefs.available<1Mi on kubelet.
localkube[14042]: W0309 21:29:52.250245   14042 localkube.go:177] Unable to set EvictionHard to imagefs.available<1Mi. Error: Unable to set type reflect.Kind.

```

Proposed P/R only deals with "value<theshold" string parsing as I'm not sure any other case exists in localkube cmd line.