### PR TITLE
Typo fix "file sever"->"file server"

### DIFF
--- a/third_party/go9p/clnt_mount.go
+++ b/third_party/go9p/clnt_mount.go
@@ -84,7 +84,7 @@ func MountConn(c net.Conn, aname string, msize uint32, user User) (*Clnt, error)
 	return clnt, nil
 }
 
-// Closes the connection to the file sever.
+// Closes the connection to the file server.
 func (clnt *Clnt) Unmount() {
 	clnt.Lock()
 	clnt.err = &Error{"connection closed", EIO}


### PR DESCRIPTION
line 87: "file sever" should be replaced with "file server"