### PR TITLE
Fix `kube-dns` deployment for RBAC

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -321,8 +321,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		if viper.GetBool(cfg.WantNoneDriverWarning) {
 			fmt.Println(`===================
 WARNING: IT IS RECOMMENDED NOT TO RUN THE NONE DRIVER ON PERSONAL WORKSTATIONS
-	The 'none' driver will run an insecure kubernetes apiserver as root that may leave the host vulnerable to CSRF attacks
-`)
+	The 'none' driver will run an insecure kubernetes apiserver as root that may leave the host vulnerable to CSRF attacks`)
 		}
 
 		if os.Getenv("CHANGE_MINIKUBE_NONE_USER") == "" {

--- a/deploy/addons/kube-dns/kube-dns-controller.yaml
+++ b/deploy/addons/kube-dns/kube-dns-controller.yaml
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -20,7 +18,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: kube-dns
-    version: v20
+    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   replicas: 1
@@ -34,6 +32,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: system-cluster-critical
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"
@@ -44,7 +43,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.5
+        image: k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.8
         imagePullPolicy: IfNotPresent
         resources:
           # TODO: Set memory limits when we've profiled the container for large
@@ -77,7 +76,7 @@ spec:
         args:
         - --domain=cluster.local.
         - --dns-port=10053
-        - --config-map=kube-dns
+        - --config-dir=/kube-dns-config
         - --v=2
         env:
         - name: PROMETHEUS_PORT
@@ -96,7 +95,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.5
+        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.8
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -135,7 +134,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.5
+        image: k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.8
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -160,3 +159,4 @@ spec:
             memory: 20Mi
             cpu: 10m
       dnsPolicy: Default  # Don't use cluster DNS.
+      serviceAccountName: kube-dns

--- a/deploy/addons/kube-dns/kube-dns-sa.yaml
+++ b/deploy/addons/kube-dns/kube-dns-sa.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile

--- a/deploy/addons/kube-dns/kube-dns-svc.yaml
+++ b/deploy/addons/kube-dns/kube-dns-svc.yaml
@@ -21,6 +21,7 @@ metadata:
     k8s-app: kube-dns
     addonmanager.kubernetes.io/mode: Reconcile
     kubernetes.io/name: "KubeDNS"
+    kubernetes.io/cluster-service: "true"
 spec:
   selector:
     k8s-app: kube-dns

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -137,6 +137,11 @@ var Addons = map[string]*Addon{
 			constants.AddonsPath,
 			"kube-dns-svc.yaml",
 			"0640"),
+		NewBinDataAsset(
+			"deploy/addons/kube-dns/kube-dns-sa.yaml",
+			constants.AddonsPath,
+			"kube-dns-sa.yaml",
+			"0640"),
 	}, true, "kube-dns"),
 	"heapster": NewAddon([]*BinDataAsset{
 		NewBinDataAsset(

--- a/pkg/minikube/bootstrapper/localkube/localkube_test.go
+++ b/pkg/minikube/bootstrapper/localkube/localkube_test.go
@@ -65,6 +65,7 @@ func TestUpdateCluster(t *testing.T) {
 	}
 	defaultAddons := []string{
 		"deploy/addons/kube-dns/kube-dns-cm.yaml",
+		"deploy/addons/kube-dns/kube-dns-sa.yaml",
 		"deploy/addons/kube-dns/kube-dns-svc.yaml",
 		"deploy/addons/addon-manager.yaml",
 		"deploy/addons/dashboard/dashboard-rc.yaml",


### PR DESCRIPTION
* Make `kube-dns` use the `system:kube-dns` service account,
* Fix `system:kube-dns` cluster-role requiring `configmaps` resource `list`
verb action by making the `kube-dns` use a config instead of listing the configmaps,
* Backport from kubernetes git repository branch `release-1.9`'s kube-dns base

Ref: https://github.com/kubernetes/kubernetes/blob/release-1.9/cluster/addons/dns/kube-dns.yaml.base
Ref: https://github.com/kubernetes/kubernetes/pull/61291#issuecomment-373791721


<!-- Thanks for filing an issue! Before hitting the button, please answer these questions.-->

**Is this a BUG REPORT or FEATURE REQUEST?** (choose one): BUG REPORT

<!--
If this is a BUG REPORT, please:
  - Fill in as much of the template below as you can.  If you leave out
    information, we can't help you as well.

If this is a FEATURE REQUEST, please:
  - Describe *in detail* the feature/behavior/change you'd like to see.

In both cases, be ready for followup questions, and please respond in a timely
manner.  If we can't reproduce a bug or think a feature already exists, we
might close your issue.  If we're wrong, PLEASE feel free to reopen it and
explain why.
-->

Please provide the following details:

**Environment**:

**Minikube version** (use `minikube version`):
- **OS** (e.g. from /etc/os-release): 

```
NAME="Linux Mint"
VERSION="18.3 (Sylvia)"
ID=linuxmint
ID_LIKE=ubuntu
PRETTY_NAME="Linux Mint 18.3"
VERSION_ID="18.3"
HOME_URL="http://www.linuxmint.com/"
SUPPORT_URL="http://forums.linuxmint.com/"
BUG_REPORT_URL="http://bugs.launchpad.net/linuxmint/"
VERSION_CODENAME=sylvia
UBUNTU_CODENAME=xenial
```

- **VM Driver** (e.g. `cat ~/.minikube/machines/minikube/config.json | grep DriverName`):

```
    "DriverName": "virtualbox",

```

- **ISO version** (e.g. `cat ~/.minikube/machines/minikube/config.json | grep -i ISO` or `minikube ssh cat /etc/VERSION`):

```
❯ sudo minikube ssh cat /etc/VERSION
v0.25.1
```

- **Install tools**: 

Installed `minikube` following https://github.com/kubernetes/minikube#linux .


**What happened**:

Does not bootstrap due to lack of permissions. Bad logs:

```
I0317 00:50:27.777567       1 server.go:176] Starting SkyDNS server (0.0.0.0:10053)
I0317 00:50:27.777695       1 server.go:198] Skydns metrics enabled (/metrics:10055)
I0317 00:50:27.777710       1 dns.go:147] Starting endpointsController
I0317 00:50:27.777712       1 dns.go:150] Starting serviceController
I0317 00:50:27.778004       1 logs.go:41] skydns: ready for queries on cluster.local. for tcp://0.0.0.0:10053 [rcache 0]
I0317 00:50:27.778019       1 logs.go:41] skydns: ready for queries on cluster.local. for udp://0.0.0.0:10053 [rcache 0]
E0317 00:50:27.790694       1 reflector.go:199] k8s.io/dns/vendor/k8s.io/client-go/tools/cache/reflector.go:94: Failed to list *v1.Endpoints: endpoints is forbidden: User "system:serviceaccount:kube-system:default
" cannot list endpoints at the cluster scope
E0317 00:50:27.790826       1 sync_configmap.go:86] Error getting ConfigMap kube-system:kube-dns err: configmaps "kube-dns" is forbidden: User "system:serviceaccount:kube-system:default" cannot get configmaps in t
he namespace "kube-system"
E0317 00:50:27.790846       1 dns.go:183] Error getting initial ConfigMap: configmaps "kube-dns" is forbidden: User "system:serviceaccount:kube-system:default" cannot get configmaps in the namespace "kube-system",
 starting with default values
E0317 00:50:27.791654       1 reflector.go:199] k8s.io/dns/vendor/k8s.io/client-go/tools/cache/reflector.go:94: Failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:kube-system:defaul
t" cannot list configmaps in the namespace "kube-system"
E0317 00:50:27.792146       1 reflector.go:199] k8s.io/dns/vendor/k8s.io/client-go/tools/cache/reflector.go:94: Failed to list *v1.Service: services is forbidden: User "system:serviceaccount:kube-system:default" c
annot list services at the cluster scope
I0317 00:50:28.292146       1 dns.go:174] Waiting for services and endpoints to be initialized from apiserver...
I0317 00:50:28.791232       1 dns.go:174] Waiting for services and endpoints to be initialized from apiserver...
```


**What you expected to happen**:

Bootstraps fine. Good logs:

```
I0317 00:12:17.821474       1 server.go:201] Starting SkyDNS server (0.0.0.0:10053)
I0317 00:12:17.821627       1 server.go:220] Skydns metrics enabled (/metrics:10055)
I0317 00:12:17.821646       1 dns.go:146] Starting endpointsController
I0317 00:12:17.821648       1 dns.go:149] Starting serviceController
I0317 00:12:17.836677       1 logs.go:41] skydns: ready for queries on cluster.local. for tcp://0.0.0.0:10053 [rcache 0]
I0317 00:12:17.836722       1 logs.go:41] skydns: ready for queries on cluster.local. for udp://0.0.0.0:10053 [rcache 0]
I0317 00:12:18.322707       1 dns.go:170] Initialized services and endpoints from apiserver
I0317 00:12:18.322768       1 server.go:135] Setting up Healthz Handler (/readiness)
I0317 00:12:18.322790       1 server.go:140] Setting up cache handler (/cache)
I0317 00:12:18.322814       1 server.go:126] Status HTTP port 8081
```


**How to reproduce it** (as minimally and precisely as possible):

Enable explicitly the `kube-dns` addon via:

```
❯ sudo minikube addons enable kube-dns
```

Start a Minikube bootstrap with RBAC enabled via:

```shell
❯ sudo minikube start --extra-config=apiserver.Authorization.Mode=RBAC
``` 

Explicitly have `kubectl` use the newly started minikube k8s cluster's context.
Commonly created as a `minikube` context. (*may differ for you*):

```
❯ sudo kubectl config use-context minikube
```

Observe the logs of the started `kube-dns` pod container `kubedns` (*pod may die due to health check and you must wait for a new one to start*) :

```
❯ kubectl logs -n kube-system -f `kubectl get -n kube-system pod --selector k8s-app=kube-dns -o json | jq -r '.items[0].metadata.name'` -c kubedns
```


**Output of `minikube logs` (if applicable)**: Not applicable.

**Anything else do we need to know**: Just a step in the direction of being able to have RBAC enabled in `minikube` without the enabled by default addons breaking.