### PR TITLE
Support RBAC by default with kube-dns addon

### DIFF
--- a/deploy/addons/kube-dns/kube-dns-account.yaml
+++ b/deploy/addons/kube-dns/kube-dns-account.yaml
@@ -1,0 +1,22 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists
+    

--- a/deploy/addons/kube-dns/kube-dns-controller.yaml
+++ b/deploy/addons/kube-dns/kube-dns-controller.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      serviceAccount: kube-dns
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"


### PR DESCRIPTION
A step toward #1722

Kubernetes already pre-defines a ClusterRoleBinding `system:kube-dns` which gives the `kube-dns` ServiceAccount the required rules to operate in a cluster with RBAC enabled, i.e.:

```
$ kubectl get clusterrole -n kube-system system:kube-dns -o yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  annotations:
    rbac.authorization.kubernetes.io/autoupdate: "true"
  labels:
    kubernetes.io/bootstrapping: rbac-defaults
  name: system:kube-dns
rules:
- apiGroups:
  - ""
  resources:
  - endpoints
  - services
  verbs:
  - list
  - watch

```