### PR TITLE
fix(cli): `minikube start --mount --mountsting` without write permission

### DIFF
--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -403,7 +403,7 @@ func GetMountCleanupCommand(path string) string {
 var mountTemplate = `
 sudo mkdir -p {{.Path}} || true;
 sudo mount -t 9p -o trans=tcp,port={{.Port}},dfltuid={{.UID}},dfltgid={{.GID}},version={{.Version}},msize={{.Msize}} {{.IP}} {{.Path}};
-sudo chmod 775 {{.Path}};`
+sudo chmod 775 {{.Path}} || true;`
 
 func GetMountCommand(ip net.IP, path, port, mountVersion string, uid, gid, msize int) (string, error) {
 	t := template.Must(template.New("mountCommand").Parse(mountTemplate))


### PR DESCRIPTION
fix #2661 

```
var mountTemplate = `
sudo mkdir -p {{.Path}} || true;
sudo mount -t 9p -o trans=tcp,port={{.Port}},dfltuid={{.UID}},dfltgid={{.GID}},version={{.Version}},msize={{.Msize}} {{.IP}} {{.Path}};
sudo chmod 775 {{.Path}}`
```

The last command (`sudo chmod 775 {{.Path}}`) can be failed silently when we mount `/Users` into the VM.