### PR TITLE
Correction in KVM2 installation instructions

### DIFF
--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -45,7 +45,7 @@ $ newgrp libvirt
 Then install the driver itself:
 
 ```shell
-curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-kvm2 && chmod +x docker-machine-driver-kvm2 && sudo mv docker-machine-driver-kvm2 /usr/bin/
+curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-kvm2 && chmod +x docker-machine-driver-kvm2 && sudo mv docker-machine-driver-kvm2 /usr/local/bin/
 ```
 
 To use the driver you would do:


### PR DESCRIPTION
The /usr/bin/ folder should not be cluttered with manually installed binaries. Those should be installed in /usr/local/bin/ instead, just as the kubectl and minikube binaries.