### PR TITLE
Disable dnsmasq on minikube-net network for kvm driver

### DIFF
--- a/pkg/drivers/kvm/network.go
+++ b/pkg/drivers/kvm/network.go
@@ -34,6 +34,7 @@ import (
 const networkTmpl = `
 <network>
   <name>{{.PrivateNetwork}}</name>
+  <dns enable='no'/>
   <ip address='192.168.39.1' netmask='255.255.255.0'>
     <dhcp>
       <range start='192.168.39.2' end='192.168.39.254'/>


### PR DESCRIPTION
We disable dnsmasq on private minikube-net network to avoid `REFUSED` when trying to resolve names from inside of minikube via this NS.