### PR TITLE
Switch ingress replication controller to deployment

### DIFF
--- a/deploy/addons/ingress/ingress-dp.yaml
+++ b/deploy/addons/ingress/ingress-dp.yaml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
-kind: ReplicationController
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: default-http-backend
   namespace: kube-system
@@ -22,8 +22,9 @@ metadata:
 spec:
   replicas: 1
   selector:
-    app: default-http-backend
-    addonmanager.kubernetes.io/mode: Reconcile
+    matchLabels:
+      app: default-http-backend
+      addonmanager.kubernetes.io/mode: Reconcile
   template:
     metadata:
       labels:
@@ -55,8 +56,8 @@ spec:
             cpu: 10m
             memory: 20Mi
 ---
-apiVersion: v1
-kind: ReplicationController
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: nginx-ingress-controller
   namespace: kube-system
@@ -66,8 +67,9 @@ metadata:
 spec:
   replicas: 1
   selector:
-    app: nginx-ingress-controller
-    addonmanager.kubernetes.io/mode: Reconcile
+    matchLabels:
+      app: nginx-ingress-controller
+      addonmanager.kubernetes.io/mode: Reconcile
   template:
     metadata:
       labels:


### PR DESCRIPTION
This change helps when minikube is used in the development workflow of the ingress controller itself running a rolling update when the image is changed