### PR TITLE
Fix 1.9.x versions of Kubernetes.

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/templates.go
+++ b/pkg/minikube/bootstrapper/kubeadm/templates.go
@@ -41,12 +41,14 @@ nodeName: {{.NodeName}}
 {{end}}`))
 
 var kubeletSystemdTemplate = template.Must(template.New("kubeletSystemdTemplate").Parse(`
+[Unit]
+{{if or (eq .ContainerRuntime "cri-o") (eq .ContainerRuntime "cri")}}Wants=crio.service{{else}}Wants=docker.socket{{end}}
+
 [Service]
 ExecStart=
 ExecStart=/usr/bin/kubelet {{.ExtraOptions}} {{if .FeatureGates}}--feature-gates={{.FeatureGates}}{{end}}
 
 [Install]
-{{if or (eq .ContainerRuntime "cri-o") (eq .ContainerRuntime "cri")}}Wants=crio.service{{else}}Wants=docker.socket{{end}}
 `))
 
 const kubeletService = `

--- a/pkg/minikube/bootstrapper/kubeadm/versions.go
+++ b/pkg/minikube/bootstrapper/kubeadm/versions.go
@@ -175,7 +175,7 @@ var versionSpecificOpts = []VersionedExtraOption{
 	NewUnversionedOption(Kubelet, "bootstrap-kubeconfig", "/etc/kubernetes/bootstrap-kubelet.conf"),
 	{
 		Option: util.ExtraOption{
-			Component: Apiserver,
+			Component: Kubelet,
 			Key:       "require-kubeconfig",
 			Value:     "true",
 		},


### PR DESCRIPTION
This was a silly typo on my part.

I can confirm 1.9.6 starts on my mac at HEAD with this change.