### PR TITLE
Fix addon broken and integration test for Ingress

### DIFF
--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -204,9 +204,9 @@ var Addons = map[string]*Addon{
 			"ingress-configmap.yaml",
 			"0640"),
 		NewBinDataAsset(
-			"deploy/addons/ingress/ingress-rc.yaml",
+			"deploy/addons/ingress/ingress-dp.yaml",
 			constants.AddonsPath,
-			"ingress-rc.yaml",
+			"ingress-dp.yaml",
 			"0640"),
 		NewBinDataAsset(
 			"deploy/addons/ingress/ingress-svc.yaml",

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -269,8 +269,8 @@ func WaitForIngressControllerRunning(t *testing.T) error {
 		return errors.Wrap(err, "getting kubernetes client")
 	}
 
-	if err := commonutil.WaitForRCToStabilize(client, "kube-system", "nginx-ingress-controller", time.Minute*10); err != nil {
-		return errors.Wrap(err, "waiting for ingress-controller RC to stabilize")
+	if err := commonutil.WaitForDeploymentToStabilize(client, "kube-system", "nginx-ingress-controller", time.Minute*10); err != nil {
+		return errors.Wrap(err, "waiting for ingress-controller deployment to stabilize")
 	}
 
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{"app": "nginx-ingress-controller"}))
@@ -287,8 +287,8 @@ func WaitForIngressDefaultBackendRunning(t *testing.T) error {
 		return errors.Wrap(err, "getting kubernetes client")
 	}
 
-	if err := commonutil.WaitForRCToStabilize(client, "kube-system", "default-http-backend", time.Minute*10); err != nil {
-		return errors.Wrap(err, "waiting for default-http-backend RC to stabilize")
+	if err := commonutil.WaitForDeploymentToStabilize(client, "kube-system", "default-http-backend", time.Minute*10); err != nil {
+		return errors.Wrap(err, "waiting for default-http-backend deployment to stabilize")
 	}
 
 	if err := commonutil.WaitForService(client, "kube-system", "default-http-backend", true, time.Millisecond*500, time.Minute*10); err != nil {


### PR DESCRIPTION
Test result:
```sh
go test -v -test.timeout=30m k8s.io/minikube/test/integration --tags="integration container_image_ostree_stub containers_image_openpgp"
=== RUN   TestDocker
Environment=DOCKER_RAMDISK=yes FOO=BAR BAZ=BAT

ExecStart={ path=/usr/bin/dockerd ; argv[]=/usr/bin/dockerd -H tcp://0.0.0.0:2376 -H unix:///var/run/docker.sock --tlsverify --tlscacert /etc/docker/ca.pem --tlscert /etc/docker/server.pem --tlskey /etc/docker/server-key.pem --label provider=virtualbox --insecure-registry 10.96.0.0/12 --debug --icc=true ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }

--- PASS: TestDocker (140.63s)
=== RUN   TestFunctional
=== RUN   TestFunctional/Status
=== RUN   TestFunctional/DNS
=== RUN   TestFunctional/Logs
=== RUN   TestFunctional/Addons
=== RUN   TestFunctional/Dashboard
=== RUN   TestFunctional/ServicesList
=== RUN   TestFunctional/Provisioning
=== RUN   TestFunctional/EnvVars
=== RUN   TestFunctional/SSH
=== RUN   TestFunctional/IngressController
--- PASS: TestFunctional (1.51s)
    --- PASS: TestFunctional/Status (0.20s)
    	cluster_status_test.go:35: Checking if cluster is healthy.
    	cluster_status_test.go:45: Component: , Healthy: True.
    	cluster_status_test.go:45: Component: , Healthy: True.
    	cluster_status_test.go:45: Component: , Healthy: True.
    --- PASS: TestFunctional/SSH (0.51s)
    --- PASS: TestFunctional/ServicesList (0.75s)
    --- PASS: TestFunctional/EnvVars (0.70s)
    --- PASS: TestFunctional/Logs (1.88s)
    --- PASS: TestFunctional/Dashboard (7.89s)
    --- PASS: TestFunctional/Provisioning (8.67s)
    	util.go:329: Error: No default StorageClass yet., Retrying in 5s. 20 Retries remaining.
    --- PASS: TestFunctional/Addons (41.64s)
    --- PASS: TestFunctional/IngressController (54.31s)
    	util.go:329: Error: ExpectedStr sshCmdOutput to be: Welcome to nginx!. Output was: <html>
    		<head><title>503 Service Temporarily Unavailable</title></head>
    		<body bgcolor="white">
    		<center><h1>503 Service Temporarily Unavailable</h1></center>
    		<hr><center>nginx/1.13.12</center>
    		</body>
    		</html>
    		, Retrying in 3s. 5 Retries remaining.
    --- PASS: TestFunctional/DNS (56.72s)
=== RUN   TestPersistence
--- PASS: TestPersistence (89.78s)
=== RUN   TestStartStop
--- PASS: TestStartStop (236.93s)
PASS
ok  	k8s.io/minikube/test/integration	525.609s
```