### PR TITLE
Use a NodeName separate from the MachineName within the VM (continued)

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -211,7 +211,7 @@ func runStart(cmd *cobra.Command, args []string) {
 	kubernetesConfig := cfg.KubernetesConfig{
 		KubernetesVersion:      selectedKubernetesVersion,
 		NodeIP:                 ip,
-		NodeName:               cfg.GetMachineName(),
+		NodeName:               constants.DefaultNodeName,
 		APIServerName:          viper.GetString(apiServerName),
 		APIServerNames:         apiServerNames,
 		APIServerIPs:           apiServerIPs,

--- a/pkg/minikube/bootstrapper/kubeadm/versions.go
+++ b/pkg/minikube/bootstrapper/kubeadm/versions.go
@@ -26,6 +26,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"k8s.io/minikube/pkg/util"
+	"k8s.io/minikube/pkg/minikube/constants"
 )
 
 // These are the components that can be configured
@@ -181,7 +182,7 @@ var versionSpecificOpts = []VersionedExtraOption{
 		},
 		LessThanOrEqual: semver.MustParse("1.9.10"),
 	},
-	NewUnversionedOption(Kubelet, "hostname-override", "minikube"),
+	NewUnversionedOption(Kubelet, "hostname-override", constants.DefaultNodeName),
 
 	// System pods args
 	NewUnversionedOption(Kubelet, "pod-manifest-path", "/etc/kubernetes/manifests"),

--- a/pkg/minikube/bootstrapper/kubeadm/versions.go
+++ b/pkg/minikube/bootstrapper/kubeadm/versions.go
@@ -25,8 +25,8 @@ import (
 	"github.com/blang/semver"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
-	"k8s.io/minikube/pkg/util"
 	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/util"
 )
 
 // These are the components that can be configured

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -79,6 +79,9 @@ const MinikubeEnvPrefix = "MINIKUBE"
 // DefaultMachineName is the default name for the VM
 const DefaultMachineName = "minikube"
 
+// DefaultNodeName is the default name for the kubeadm node within the VM
+const DefaultNodeName = "minikube"
+
 // The name of the default storage class provisioner
 const DefaultStorageClassProvisioner = "standard"
 


### PR DESCRIPTION
Continued from #2722 (changed the source branch from my fork).

Fix for #2717 

## Summary:

The kubelets are hard-coded to look for a node called `minikube`. However, currently the `NodeName` is set to be the `MachineName` which is set to the profile name. This means that when the profile is not `minikube`, the cluster fails to start.

This pull requests solves the issue by fixing the `NodeName` of the kubeadm node to `minikube` regardless of the profile.

An alternative solution is to remove the `hostname-override` completely so that the kubelets *should* also look for a node with the same name as the profile name. However, in this case, profile names with spaces cause the cluster to fail. A first pass at fixing the issue can be seen here: https://github.com/petertrotman/minikube/tree/hostname-override but more work needs to be done.

## Next Steps:

Currently, `profile` functionality is completely broken due to this issue. I believe that simply setting the `NodeName` to `minikube` is a complete and fuss-free solution - I don't see any particular reason why the user cares about the cluster's internal `NodeName`. However, I am happy to do a bit of work to make removing `hostname-override` viable, if that is what the maintainers want. So I would like a decision of either 'yes this pull request will do' or 'no we need to do this by removing `hostname-override` so make that happen instead'.