### PR TITLE
Fix cached images not loading on Windows

### DIFF
--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -198,7 +199,7 @@ func LoadFromCacheBlocking(cmd bootstrapper.CommandRunner, src string) error {
 			break
 		}
 	}
-	dst := filepath.Join(tempLoadDir, filename)
+	dst := path.Join(tempLoadDir, filename)
 	f, err := assets.NewFileAsset(src, tempLoadDir, filename, "0777")
 	if err != nil {
 		return errors.Wrapf(err, "creating copyable file asset: %s", filename)


### PR DESCRIPTION
It appears that cached images aren't being used on Windows.

The `docker load -i imagePath` command is being issued with a path constructed for the host OS, resulting in bad paths and failure to load from cached files when they mismatch the guest (e.g. Windows hosts).

This "host OS path format used in guest OS" bug is similar to https://github.com/kubernetes/minikube/pull/2702/files

Failing format:
```
I0519 23:05:41.920473   10296 ssh_runner.go:58] Run: docker load -i \tmp\k8s-dns-sidecar-amd64_1.14.8
```
Corrected format:
```
I0519 23:17:19.473500    5724 ssh_runner.go:58] Run: docker load -i /tmp/k8s-dns-sidecar-amd64_1.14.8
```