### PR TITLE
kubeadm: Check for GetClientset error

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/util.go
+++ b/pkg/minikube/bootstrapper/kubeadm/util.go
@@ -95,6 +95,9 @@ func unmarkMaster() error {
 func elevateKubeSystemPrivileges() error {
 	k8s := service.K8s
 	client, err := k8s.GetClientset()
+	if err != nil {
+		return errors.Wrap(err, "getting clientset")
+	}
 	clusterRoleBinding := &rbacv1beta1.ClusterRoleBinding{
 		ObjectMeta: v1.ObjectMeta{
 			Name: rbacName,


### PR DESCRIPTION
`elevateKubeSystemPrivileges` was using `GetClientset` function
and getting the err object from, but err wasn't checked.