### PR TITLE
CoreDNS pull image from gcr.io

### DIFF
--- a/deploy/addons/coredns/coreDNS-controller.yaml
+++ b/deploy/addons/coredns/coreDNS-controller.yaml
@@ -29,7 +29,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: coredns
-        image: registry.hub.docker.com/coredns/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:


### PR DESCRIPTION
CoreDNS now pulls image from gcr.io.