### PR TITLE
make: Check for go-bindata in PATH, not only in GOPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,11 +200,9 @@ out/test.d: pkg/minikube/assets/assets.go
 test:
 	./test.sh
 
-pkg/minikube/assets/assets.go: $(GOPATH)/bin/go-bindata $(shell find deploy/addons -type f)
-	$(GOPATH)/bin/go-bindata -nomemcopy -o pkg/minikube/assets/assets.go -pkg assets deploy/addons/...
-
-$(GOPATH)/bin/go-bindata:
-	GOBIN=$(GOPATH)/bin go get github.com/jteeuwen/go-bindata/...
+pkg/minikube/assets/assets.go: $(shell find deploy/addons -type f)
+	which go-bindata || GOBIN=$(GOPATH)/bin go get github.com/jteeuwen/go-bindata/...
+	PATH=$(PATH):$(GOPATH)/bin go-bindata -nomemcopy -o pkg/minikube/assets/assets.go -pkg assets deploy/addons/...
 
 .PHONY: cross
 cross: out/minikube-linux-amd64 out/minikube-darwin-amd64 out/minikube-windows-amd64.exe


### PR DESCRIPTION
Some Linux distributions package go-bindata and don't allow to
download any code or binaries during build time.