### PR TITLE
Update homebrew-cask release process: remove `checkpoint`

### DIFF
--- a/docs/contributors/releasing_minikube.md
+++ b/docs/contributors/releasing_minikube.md
@@ -100,7 +100,7 @@ These are downstream packages that are being maintained by others and how to upg
 | Package Manager | URL | TODO |
 | --- | --- | --- |
 | Arch Linux AUR | https://aur.archlinux.org/packages/minikube/ | "Flag as package out-of-date"
-| Brew Cask | https://github.com/caskroom/homebrew-cask/blob/master/Casks/minikube.rb | Create a new PR in [caskroom/homebrew-cask](https://github.com/caskroom/homebrew-cask) with an updated version and SHA256
+| Brew Cask | https://github.com/Homebrew/homebrew-cask/blob/master/Casks/minikube.rb | Create a new PR in [Homebrew/homebrew-cask](https://github.com/Homebrew/homebrew-cask) with an updated version and SHA256
 
 #### Updating the arch linux package
 The Arch Linux AUR is maintained at https://aur.archlinux.org/packages/minikube/.  The installer PKGBUILD is hosted in its own repository.  The public read-only repository is hosted here `https://aur.archlinux.org/minikube.git` and the private read-write repository is hosted here `ssh://aur@aur.archlinux.org/minikube.git`

--- a/docs/contributors/releasing_minikube.md
+++ b/docs/contributors/releasing_minikube.md
@@ -100,10 +100,7 @@ These are downstream packages that are being maintained by others and how to upg
 | Package Manager | URL | TODO |
 | --- | --- | --- |
 | Arch Linux AUR | https://aur.archlinux.org/packages/minikube/ | "Flag as package out-of-date"
-| Brew Cask | https://github.com/caskroom/homebrew-cask/blob/master/Casks/minikube.rb | Create a new PR in [caskroom/homebrew-cask](https://github.com/caskroom/homebrew-cask) with an updated version and appcast checkpoint
-
-#### [How to Generate an Appcast Checkpoint for Homebrew](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/appcast.md)
-`curl --compressed --location --user-agent 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36' "https://github.com/kubernetes/minikube/releases.atom" | sed 's|<pubDate>[^<]*</pubDate>||g' | shasum --algorithm 256`
+| Brew Cask | https://github.com/caskroom/homebrew-cask/blob/master/Casks/minikube.rb | Create a new PR in [caskroom/homebrew-cask](https://github.com/caskroom/homebrew-cask) with an updated version and SHA256
 
 #### Updating the arch linux package
 The Arch Linux AUR is maintained at https://aur.archlinux.org/packages/minikube/.  The installer PKGBUILD is hosted in its own repository.  The public read-only repository is hosted here `https://aur.archlinux.org/minikube.git` and the private read-write repository is hosted here `ssh://aur@aur.archlinux.org/minikube.git`

--- a/hack/jenkins/release_update_installers.sh
+++ b/hack/jenkins/release_update_installers.sh
@@ -21,13 +21,6 @@ REPLACE_PKG_VERSION=${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BUILD}
 REPLACE_MINIKUBE_LINUX_SHA256=$(awk '{ print $1 }' out/minikube-linux-amd64.sha256)
 REPLACE_MINIKUBE_DRIVER_KVM_SHA256=$(awk '{ print $1 }' out/docker-machine-driver-kvm2.sha256)
 REPLACE_MINIKUBE_DARWIN_SHA256=$(awk '{ print $1 }' out/minikube-darwin-amd64.sha256)
-REPLACE_CASK_CHECKPOINT=$(curl \
-                        --compressed \
-                        --location   \
-                        --user-agent 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36' \
-                        https://github.com/kubernetes/minikube/releases.atom \
-                        | sed 's|<pubDate>[^<]*</pubDate>||g' \
-                        | shasum -a 256 | awk '{ print $1 }')
 MINIKUBE_ROOT=$PWD
 
 git clone ssh://aur@aur.archlinux.org/minikube.git aur-minikube
@@ -70,7 +63,6 @@ pushd homebrew-cask >/dev/null
     git checkout -b ${REPLACE_PKG_VERSION}
     sed -e "s/\$PKG_VERSION/${REPLACE_PKG_VERSION}/g" \
         -e "s/\$MINIKUBE_DARWIN_SHA256/${REPLACE_MINIKUBE_DARWIN_SHA256}/g" \
-        -e "s/\$CASK_CHECKPOINT/${REPLACE_CASK_CHECKPOINT}/g" \
         $MINIKUBE_ROOT/installers/darwin/brew-cask/minikube.rb.tmpl > Casks/minikube.rb
     git add Casks/minikube.rb
     git commit -F- <<EOF

--- a/hack/jenkins/release_update_installers.sh
+++ b/hack/jenkins/release_update_installers.sh
@@ -57,7 +57,7 @@ popd >/dev/null
 git clone --depth 1 git@github.com:minikube-bot/homebrew-cask.git # don't pull entire history
 
 pushd homebrew-cask >/dev/null
-    git remote add upstream https://github.com/caskroom/homebrew-cask.git
+    git remote add upstream https://github.com/Homebrew/homebrew-cask.git
     git fetch upstream
     git checkout upstream/master
     git checkout -b ${REPLACE_PKG_VERSION}
@@ -74,7 +74,7 @@ Update minikube to ${REPLACE_PKG_VERSION}
 
 EOF
     git push origin ${REPLACE_PKG_VERSION}
-    curl -v -k -u minikube-bot:${BOT_PASSWORD} -X POST https://api.github.com/repos/caskroom/homebrew-cask/pulls \
+    curl -v -k -u minikube-bot:${BOT_PASSWORD} -X POST https://api.github.com/repos/Homebrew/homebrew-cask/pulls \
     -d @- <<EOF
 
 {

--- a/installers/darwin/brew-cask/minikube.rb.tmpl
+++ b/installers/darwin/brew-cask/minikube.rb.tmpl
@@ -4,8 +4,7 @@ cask 'minikube' do
 
   # storage.googleapis.com/minikube was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/minikube/releases/v#{version}/minikube-darwin-amd64"
-  appcast 'https://github.com/kubernetes/minikube/releases.atom',
-          checkpoint: '$CASK_CHECKPOINT'
+  appcast 'https://github.com/kubernetes/minikube/releases.atom'
   name 'Minikube'
   homepage 'https://github.com/kubernetes/minikube'
 


### PR DESCRIPTION
Appcast `checkpoint`s have been removed from Homebrew-Cask.

This updates the docs, release script and template accordingly.

cc @r2d4

Also, update caskroom -> Homebrew references.