### PR TITLE
LXD driver for minikube

### DIFF
--- a/cmd/drivers/lxd/main-nolinux.go
+++ b/cmd/drivers/lxd/main-nolinux.go
@@ -1,3 +1,5 @@
+// +build !linux
+
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.
 
@@ -14,16 +16,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cluster
+package main
 
 import (
-	_ "k8s.io/minikube/pkg/minikube/drivers/hyperkit"
-	_ "k8s.io/minikube/pkg/minikube/drivers/hyperv"
-	_ "k8s.io/minikube/pkg/minikube/drivers/kvm"
-	_ "k8s.io/minikube/pkg/minikube/drivers/kvm2"
-	_ "k8s.io/minikube/pkg/minikube/drivers/lxd"
-	_ "k8s.io/minikube/pkg/minikube/drivers/none"
-	_ "k8s.io/minikube/pkg/minikube/drivers/virtualbox"
-	_ "k8s.io/minikube/pkg/minikube/drivers/vmwarefusion"
-	_ "k8s.io/minikube/pkg/minikube/drivers/xhyve"
+	"fmt"
+	"os"
 )
+
+func main() {
+	fmt.Println(
+		"this driver was built on a non-linux machine, so it is " +
+			"unavailable. Please re-build minikube on a linux machine to enable " +
+			"it.",
+	)
+	os.Exit(1)
+}

--- a/cmd/drivers/lxd/main.go
+++ b/cmd/drivers/lxd/main.go
@@ -1,3 +1,5 @@
+// +build linux
+
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.
 
@@ -14,16 +16,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cluster
+package main
 
 import (
-	_ "k8s.io/minikube/pkg/minikube/drivers/hyperkit"
-	_ "k8s.io/minikube/pkg/minikube/drivers/hyperv"
-	_ "k8s.io/minikube/pkg/minikube/drivers/kvm"
-	_ "k8s.io/minikube/pkg/minikube/drivers/kvm2"
-	_ "k8s.io/minikube/pkg/minikube/drivers/lxd"
-	_ "k8s.io/minikube/pkg/minikube/drivers/none"
-	_ "k8s.io/minikube/pkg/minikube/drivers/virtualbox"
-	_ "k8s.io/minikube/pkg/minikube/drivers/vmwarefusion"
-	_ "k8s.io/minikube/pkg/minikube/drivers/xhyve"
+	"github.com/docker/machine/libmachine/drivers/plugin"
+	"k8s.io/minikube/pkg/drivers/lxd"
 )
+
+func main() {
+	plugin.RegisterDriver(lxd.NewDriver("", ""))
+}

--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -60,7 +60,7 @@ associated files.`,
 		}
 
 		if err := os.Remove(constants.GetProfileFile(viper.GetString(pkg_config.MachineProfile))); err != nil {
-			fmt.Println("Error deleting machine profile config")
+			fmt.Println("Error deleting machine profile config: ", err)
 			os.Exit(1)
 		}
 	},

--- a/pkg/drivers/lxd/lxd.go
+++ b/pkg/drivers/lxd/lxd.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lxd
+
+import (
+	"fmt"
+
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/docker/machine/libmachine/state"
+	lxd "github.com/lxc/lxd/client"
+	"github.com/pkg/errors"
+	pkgdrivers "k8s.io/minikube/pkg/drivers"
+)
+
+const driverName = "lxd"
+
+// lxd Driver is for running minikube inside LXD
+type Driver struct {
+	*drivers.BaseDriver
+	*pkgdrivers.CommonDriver
+	URL string
+}
+
+func NewDriver(hostName, storePath string) *Driver {
+	return &Driver{
+		BaseDriver: &drivers.BaseDriver{
+			MachineName: hostName,
+			StorePath:   storePath,
+		},
+	}
+}
+
+// PreCreateCheck checks for correct privileges and dependencies
+func (d *Driver) PreCreateCheck() error {
+	fmt.Println("LXD: pre create check")
+	if _, err := getConnection(); err != nil {
+		return errors.Wrap(err, "Error connecting to LXD API. Is your LXD service running?")
+	}
+	return nil
+}
+
+func (d *Driver) Create() error {
+	fmt.Println("LXD: create ")
+	// creation for the none driver is handled by commands.go
+	return nil
+}
+
+// DriverName returns the name of the driver
+func (d *Driver) DriverName() string {
+	return driverName
+}
+
+func (d *Driver) GetIP() (string, error) {
+	fmt.Println("LXD: get ip ")
+	return "127.0.0.1", nil
+}
+
+func (d *Driver) GetSSHHostname() (string, error) {
+	fmt.Println("LXD: get ssh hostname ")
+	return "minikube", nil
+}
+
+func (d *Driver) GetSSHPort() (int, error) {
+	fmt.Println("LXD: get ssh port ")
+	return 2222, nil
+}
+
+func (d *Driver) GetURL() (string, error) {
+	fmt.Println("LXD: get url ")
+	return "lxd://minikube", nil
+}
+
+func (d *Driver) GetState() (state.State, error) {
+	fmt.Println("LXD: get state ")
+	return state.None, nil
+}
+
+func (d *Driver) Kill() error {
+	fmt.Println("LXD: kill ")
+	return nil
+}
+
+func (d *Driver) Remove() error {
+	fmt.Println("LXD: delete ")
+	return nil
+}
+
+func (d *Driver) Restart() error {
+	fmt.Println("LXD: restarting ")
+	return nil
+}
+
+func (d *Driver) Start() error {
+	fmt.Println("LXD: starting ")
+	return nil
+}
+
+func (d *Driver) Stop() error {
+	fmt.Println("LXD: stopping ")
+	return nil
+}
+
+func (d *Driver) RunSSHCommandFromDriver() error {
+	return fmt.Errorf("LXD: driver does not support ssh commands")
+}
+
+func getConnection() (lxd.ContainerServer, error) {
+	c, err := lxd.ConnectLXDUnix("", nil)
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -59,6 +59,7 @@ var SupportedVMDrivers = [...]string{
 	"hyperkit",
 	"kvm2",
 	"none",
+	"lxd",
 }
 
 var DefaultMinipath = filepath.Join(homedir.HomeDir(), ".minikube")

--- a/pkg/minikube/drivers/lxd/doc.go
+++ b/pkg/minikube/drivers/lxd/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors All rights reserved.
+Copyright 2018 The Kubernetes Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,16 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cluster
-
-import (
-	_ "k8s.io/minikube/pkg/minikube/drivers/hyperkit"
-	_ "k8s.io/minikube/pkg/minikube/drivers/hyperv"
-	_ "k8s.io/minikube/pkg/minikube/drivers/kvm"
-	_ "k8s.io/minikube/pkg/minikube/drivers/kvm2"
-	_ "k8s.io/minikube/pkg/minikube/drivers/lxd"
-	_ "k8s.io/minikube/pkg/minikube/drivers/none"
-	_ "k8s.io/minikube/pkg/minikube/drivers/virtualbox"
-	_ "k8s.io/minikube/pkg/minikube/drivers/vmwarefusion"
-	_ "k8s.io/minikube/pkg/minikube/drivers/xhyve"
-)
+package lxd

--- a/pkg/minikube/drivers/lxd/driver.go
+++ b/pkg/minikube/drivers/lxd/driver.go
@@ -1,0 +1,44 @@
+// +build linux
+
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lxd
+
+import (
+	"github.com/docker/machine/libmachine/drivers"
+	"k8s.io/minikube/pkg/drivers/lxd"
+	cfg "k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/registry"
+)
+
+func init() {
+	registry.Register(registry.DriverDef{
+		Name:          "lxd",
+		Builtin:       false,
+		ConfigCreator: createLXDHost,
+	})
+}
+
+func createLXDHost(config cfg.MachineConfig) interface{} {
+	return &lxd.Driver{
+		BaseDriver: &drivers.BaseDriver{
+			MachineName: cfg.GetMachineName(),
+			StorePath:   constants.GetMinipath(),
+		},
+	}
+}


### PR DESCRIPTION
I've been using kvm for minikube, but it's just too flaky with all the moving parts and breaks easily. I think we can get a much more stable minikube on Linux using lxd, without spending very much effort doing so.
I've added a driver to use minikube with lxd. This is still a WIP, but I want to get feedback and help at this point which is why I'm opening the PR now already.
The lxd driver is actually super simple (so far) because lxd has a rest api that uses a unix socket and has a go client implementing the api.
What I've implemented so far:
- lifecycle: create, start, stop, delete etc.
- ssh: relies on $HOME/.ssh/id_rsa_lxd key existing
Currently the driver expects an lxd image aliased `base-minikube` to exist that has docker installed and ssh configured with $HOME/.ssh/id_rsa_lxd.pub (setup using the default lxd profile).
For networking, the driver is hardcoded to return the first eth0 inet address.

I used an image based off of ubuntu:16.04 and installed docker-ce
starting minikube with this config gets to the step of `Starting cluster components...` and bombs out with error 
```
Error starting cluster:  kubeadm init error sudo /usr/bin/kubeadm init --config /var/lib/kubeadm.yaml ... 
...
Process exited with status 2
```
The first time I got ssh to work it actually got further than this, it got to the point where it was trying to connect to the apiserver, but I couldn't see any docker containers running `docker ps` in the lxd container.

So what we really need at this point is a prebaked image that works with current minikube infrastructure.
Ideally we use an image based off of the minikube image in this repo that is built using buildroot. I have no experience with that however and it doesn't seem very noob friendly. I tried just building the image locally and after a couple of hours the build failed because it ran out of disk space. So I assume buildroot compiles the entire system from scratch? I'd ideally not have to build an entire system from scratch. If anyone with buildroot experience or lxd image building experience or both can help me over this obstacle that would be awesome. There also isn't too much info on creating an lxd image reproducibly. It's very easy to create an image from an existing container, but I don't think that's how we want to build a minikube image.

Anyway I hope some other people are interested in this that can work with me on the image part. If we can get an image working then the rest is very easy to clean up and finish off.