### PR TITLE
Update release_github_page.sh

### DIFF
--- a/hack/jenkins/release_github_page.sh
+++ b/hack/jenkins/release_github_page.sh
@@ -53,7 +53,7 @@ curl -Lo minikube https://storage.googleapis.com/minikube/releases/${TAGNAME}/mi
 \`\`\`
 Feel free to leave off the \`\`\`sudo mv minikube /usr/local/bin\`\`\` if you would like to add minikube to your path manually.
 
-Or you can install via homebrew with `brew cask install minikube`.
+Or you can install via homebrew with \`brew cask install minikube\`.
 
 ### Linux
 \`\`\`shell


### PR DESCRIPTION
Back ticks need to be escaped otherwise the enclosed
text won't show up.