### PR TITLE
Fix Kubernetes 1.11 builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ KERNEL_VERSION ?= 4.16.14
 
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
+GOPATH ?= $(shell go env GOPATH)
 BUILD_DIR ?= ./out
 $(shell mkdir -p $(BUILD_DIR))
 
@@ -208,7 +209,7 @@ out/test.d: pkg/minikube/assets/assets.go
 
 -include out/test.d
 test:
-	./test.sh
+	GOPATH=$(GOPATH) ./test.sh
 
 pkg/minikube/assets/assets.go: $(shell find deploy/addons -type f)
 	which go-bindata || GOBIN=$(GOPATH)/bin go get github.com/jteeuwen/go-bindata/...

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm_test.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm_test.go
@@ -42,6 +42,7 @@ kind: MasterConfiguration
 api:
   advertiseAddress: 192.168.1.100
   bindPort: 8443
+  controlPlaneEndpoint: localhost
 kubernetesVersion: v1.10.0
 certificatesDir: /var/lib/localkube/certs/
 networking:
@@ -82,6 +83,7 @@ kind: MasterConfiguration
 api:
   advertiseAddress: 192.168.1.101
   bindPort: 8443
+  controlPlaneEndpoint: localhost
 kubernetesVersion: v1.10.0-alpha.0
 certificatesDir: /var/lib/localkube/certs/
 networking:
@@ -122,6 +124,7 @@ kind: MasterConfiguration
 api:
   advertiseAddress: 192.168.1.101
   bindPort: 8443
+  controlPlaneEndpoint: localhost
 kubernetesVersion: v1.10.0-alpha.0
 certificatesDir: /var/lib/localkube/certs/
 networking:
@@ -148,6 +151,7 @@ kind: MasterConfiguration
 api:
   advertiseAddress: 192.168.1.101
   bindPort: 8443
+  controlPlaneEndpoint: localhost
 kubernetesVersion: v1.10.0-alpha.0
 certificatesDir: /var/lib/localkube/certs/
 networking:
@@ -184,6 +188,7 @@ kind: MasterConfiguration
 api:
   advertiseAddress: 192.168.1.101
   bindPort: 8443
+  controlPlaneEndpoint: localhost
 kubernetesVersion: v1.10.0-alpha.0
 certificatesDir: /var/lib/localkube/certs/
 networking:

--- a/pkg/minikube/bootstrapper/kubeadm/templates.go
+++ b/pkg/minikube/bootstrapper/kubeadm/templates.go
@@ -29,6 +29,7 @@ kind: MasterConfiguration
 api:
   advertiseAddress: {{.AdvertiseAddress}}
   bindPort: {{.APIServerPort}}
+  controlPlaneEndpoint: localhost
 kubernetesVersion: {{.KubernetesVersion}}
 certificatesDir: {{.CertDir}}
 networking:
@@ -75,7 +76,7 @@ sudo /usr/bin/kubeadm alpha phase etcd local --config {{.KubeadmConfigFile}}
 
 var kubeadmInitTemplate = template.Must(template.New("kubeadmInitTemplate").Parse(`
 sudo /usr/bin/kubeadm init --config {{.KubeadmConfigFile}} {{if .SkipPreflightChecks}}--skip-preflight-checks{{else}}{{range .Preflights}}--ignore-preflight-errors={{.}} {{end}}{{end}} &&
-sudo /usr/bin/kubeadm alpha phase addon all
+sudo /usr/bin/kubeadm alpha phase addon kube-dns
 `))
 
 // printMapInOrder sorts the keys and prints the map in order, combining key

--- a/pkg/minikube/bootstrapper/kubeadm/templates.go
+++ b/pkg/minikube/bootstrapper/kubeadm/templates.go
@@ -73,8 +73,10 @@ sudo /usr/bin/kubeadm alpha phase controlplane all --config {{.KubeadmConfigFile
 sudo /usr/bin/kubeadm alpha phase etcd local --config {{.KubeadmConfigFile}}
 `))
 
-var kubeadmInitTemplate = template.Must(template.New("kubeadmInitTemplate").Parse(
-	"sudo /usr/bin/kubeadm init --config {{.KubeadmConfigFile}} {{if .SkipPreflightChecks}}--skip-preflight-checks{{else}}{{range .Preflights}}--ignore-preflight-errors={{.}} {{end}}{{end}}"))
+var kubeadmInitTemplate = template.Must(template.New("kubeadmInitTemplate").Parse(`
+sudo /usr/bin/kubeadm init --config {{.KubeadmConfigFile}} {{if .SkipPreflightChecks}}--skip-preflight-checks{{else}}{{range .Preflights}}--ignore-preflight-errors={{.}} {{end}}{{end}} &&
+sudo /usr/bin/kubeadm alpha phase addon all
+`))
 
 // printMapInOrder sorts the keys and prints the map in order, combining key
 // value pairs with the separator character

--- a/pkg/minikube/bootstrapper/kubeadm/versions.go
+++ b/pkg/minikube/bootstrapper/kubeadm/versions.go
@@ -205,7 +205,16 @@ var versionSpecificOpts = []VersionedExtraOption{
 			Key:       "admission-control",
 			Value:     strings.Join(util.DefaultAdmissionControllers, ","),
 		},
+		LessThanOrEqual:    semver.MustParse("1.10.10"),
 		GreaterThanOrEqual: semver.MustParse("1.9.0-alpha.0"),
+	},
+	{
+		Option: util.ExtraOption{
+			Component: Apiserver,
+			Key:       "enable-admission-plugins",
+			Value:     strings.Join(util.DefaultAdmissionControllers, ","),
+		},
+		GreaterThanOrEqual: semver.MustParse("1.11.0-alpha.0"),
 	},
 }
 

--- a/pkg/minikube/bootstrapper/kubeadm/versions.go
+++ b/pkg/minikube/bootstrapper/kubeadm/versions.go
@@ -205,7 +205,7 @@ var versionSpecificOpts = []VersionedExtraOption{
 			Key:       "admission-control",
 			Value:     strings.Join(util.DefaultAdmissionControllers, ","),
 		},
-		LessThanOrEqual:    semver.MustParse("1.10.10"),
+		LessThanOrEqual:    semver.MustParse("1.10.1000"), // Semver doesn't support wildcards.
 		GreaterThanOrEqual: semver.MustParse("1.9.0-alpha.0"),
 	},
 	{


### PR DESCRIPTION
Add a versioned flag for the enable-admission-control flags
Add a second step to call "kubeadm alpha phase addon all" which seems to be required now to get coredns running.

I tested this all the way back to 1.9.0.

This should fix #2942 