### PR TITLE
Linux install: Set owner to root

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ brew cask install minikube
 
 ### Linux
 ```shell
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo cp minikube /usr/local/bin/ && rm minikube
 ```
 
 ### Windows
@@ -36,8 +36,8 @@ Download the [minikube-windows-amd64.exe](https://storage.googleapis.com/minikub
 ### Linux Continuous Integration without VM Support
 Example with kubectl installation:
 ```shell
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube
-curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x kubectl
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo cp minikube /usr/local/bin/ && rm minikube
+curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x kubectl && sudo cp minikube /usr/local/bin/ && rm minikube
 
 export MINIKUBE_WANTUPDATENOTIFICATION=false
 export MINIKUBE_WANTREPORTERRORPROMPT=false

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -191,7 +191,7 @@ func MaybePrintKubectlDownloadMsg(goos string, out io.Writer) {
 	}
 
 	verb := "run"
-	installInstructions := "curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/%s/bin/%s/%s/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/"
+	installInstructions := "curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/%s/bin/%s/%s/kubectl && chmod +x kubectl && sudo cp kubectl /usr/local/bin/ && rm kubectl"
 	if goos == "windows" {
 		verb = "do"
 		installInstructions = `download kubectl from:

--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -45,7 +45,10 @@ $ newgrp libvirt
 Then install the driver itself:
 
 ```shell
-curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-kvm2 && chmod +x docker-machine-driver-kvm2 && sudo mv docker-machine-driver-kvm2 /usr/local/bin/
+curl -Lo docker-machine-driver-kvm2 https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-kvm2 \
+&& chmod +x docker-machine-driver-kvm2 \
+&& sudo cp docker-machine-driver-kvm2 /usr/local/bin/ \
+&& rm docker-machine-driver-kvm2
 ```
 
 To use the driver you would do:
@@ -94,9 +97,10 @@ It is built from the minikube source tree, and uses [moby/hyperkit](http://githu
 To install the hyperkit driver:
 
 ```shell
-curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-hyperkit \
+curl -Lo docker-machine-driver-hyperkit https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-hyperkit \
 && chmod +x docker-machine-driver-hyperkit \
-&& sudo mv docker-machine-driver-hyperkit /usr/local/bin/ \
+&& sudo cp docker-machine-driver-hyperkit /usr/local/bin/ \
+&& rm docker-machine-driver-hyperkit \
 && sudo chown root:wheel /usr/local/bin/docker-machine-driver-hyperkit \
 && sudo chmod u+s /usr/local/bin/docker-machine-driver-hyperkit
 ```

--- a/hack/jenkins/release_github_page.sh
+++ b/hack/jenkins/release_github_page.sh
@@ -49,17 +49,17 @@ Minikube is distributed in binary form for Linux, OSX, and Windows systems for t
 ## Installation
 ### OSX
 \`\`\`shell
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/${TAGNAME}/minikube-darwin-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/${TAGNAME}/minikube-darwin-amd64 && chmod +x minikube && sudo cp minikube /usr/local/bin/ && rm minikube
 \`\`\`
-Feel free to leave off the \`\`\`sudo mv minikube /usr/local/bin\`\`\` if you would like to add minikube to your path manually.
+Feel free to leave off \`\`\`sudo cp minikube /usr/local/bin/ && rm minikube\`\`\` if you would like to add minikube to your path manually.
 
 Or you can install via homebrew with \`brew cask install minikube\`.
 
 ### Linux
 \`\`\`shell
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/${TAGNAME}/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/${TAGNAME}/minikube-linux-amd64 && chmod +x minikube && sudo cp minikube /usr/local/bin/ && rm minikube
 \`\`\`
-Feel free to leave off the \`\`\`sudo mv minikube /usr/local/bin\`\`\` if you would like to add minikube to your path manually.
+Feel free to leave off \`\`\`sudo cp minikube /usr/local/bin/ && rm minikube\`\`\` if you would like to add minikube to your path manually.
 
 ### Debian Package (.deb) [Experimental]
 Download the \`minikube_${DEB_VERSION}.deb\` file, and install it using \`sudo dpkg -i minikube_$(DEB_VERSION).deb\`


### PR DESCRIPTION
Previously, files installed to `/usr/local/bin/` would be owned by the user executing the command, not root. This change makes these installed files owned by root instead. Improving security is the goal.

I've updated all install references I found, though there might be places I missed. So do tell if you know any I missed.