### PR TITLE
Bump minikube-nvidia-driver-installer version to make it work again.

### DIFF
--- a/deploy/addons/gpu/nvidia-driver-installer.yaml
+++ b/deploy/addons/gpu/nvidia-driver-installer.yaml
@@ -50,7 +50,7 @@ spec:
         hostPath:
           path: /
       initContainers:
-      - image: k8s.gcr.io/minikube-nvidia-driver-installer@sha256:85cbeadb8bee62a96079823e81915955af0959063ff522ec01522e4edda28f33
+      - image: k8s.gcr.io/minikube-nvidia-driver-installer@sha256:492d46f2bc768d6610ec5940b6c3c33c75e03e201cc8786e04cc488659fd6342
         name: nvidia-driver-installer
         resources:
           requests:


### PR DESCRIPTION
This incorporates the fix from GoogleCloudPlatform/container-engine-accelerators#85.

That bug got exposed when we switched the kernel version from 4.16.14 to 4.15 in #2986