### PR TITLE
Add workaround for dnsmasq and hyperkit users to drivers readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,6 @@ We also released a Debian package and Windows installer on our [releases page](h
 * [kubectl](https://kubernetes.io/docs/tasks/kubectl/install/)
 * macOS
     * [Hyperkit driver](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#hyperkit-driver), [xhyve driver](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#xhyve-driver), [VirtualBox](https://www.virtualbox.org/wiki/Downloads), or [VMware Fusion](https://www.vmware.com/products/fusion)
-    * [dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html) `brew install dnsmasq` (add `listen-address=192.168.64.1` to `dnsmasq.conf`)
-    
 * Linux
     * [VirtualBox](https://www.virtualbox.org/wiki/Downloads) or [KVM](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm-driver)
     * **NOTE:** Minikube also supports a `--vm-driver=none` option that runs the Kubernetes components on the host and not in a VM. Docker is required to use this driver but no hypervisor. If you use `--vm-driver=none`, be sure to specify a [bridge network](https://docs.docker.com/network/bridge/#configure-the-default-bridge-network) for docker. Otherwise it might change between network restarts, causing loss of connectivity to your cluster.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ We also released a Debian package and Windows installer on our [releases page](h
 * [kubectl](https://kubernetes.io/docs/tasks/kubectl/install/)
 * macOS
     * [Hyperkit driver](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#hyperkit-driver), [xhyve driver](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#xhyve-driver), [VirtualBox](https://www.virtualbox.org/wiki/Downloads), or [VMware Fusion](https://www.vmware.com/products/fusion)
+    * [dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html) `brew install dnsmasq` (add `listen-address=192.168.64.1` to `dnsmasq.conf`)
+    
 * Linux
     * [VirtualBox](https://www.virtualbox.org/wiki/Downloads) or [KVM](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm-driver)
     * **NOTE:** Minikube also supports a `--vm-driver=none` option that runs the Kubernetes components on the host and not in a VM. Docker is required to use this driver but no hypervisor. If you use `--vm-driver=none`, be sure to specify a [bridge network](https://docs.docker.com/network/bridge/#configure-the-default-bridge-network) for docker. Otherwise it might change between network restarts, causing loss of connectivity to your cluster.

--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -96,6 +96,10 @@ The hyperkit driver currently requires running as root to use the vmnet framewor
 
 If you encountered errors like `Could not find hyperkit executable`, you might need to install [Docker for Mac](https://store.docker.com/editions/community/docker-ce-desktop-mac)
 
+If you are using [dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html) in your setup and cluster creation fails (stuck at kube-dns initialization) you might need to add `listen-address=192.168.64.1` to `dnsmasq.conf`.
+
+*Note: If `dnsmasq.conf` contains `listen-address=127.0.0.1` kubernetes discovers dns at 127.0.0.1:53 and tries to use it using bridge ip address, but dnsmasq replies only to reqests from 127.0.0.1*
+
 #### xhyve driver
 
 From https://github.com/zchee/docker-machine-driver-xhyve#install:


### PR DESCRIPTION
Kubernetes expects dns server at 192.168.64.1 and we need to provide it to him. Failing to do so will make cluster creation impossible.

I updated readme so this common problem is easier resolved.