### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/hack/get_k8s_version.py
+++ b/hack/get_k8s_version.py
@@ -17,9 +17,11 @@
 "This package gets the LD flags used to set the version of kubernetes."
 
 import json
+import os
 import re
 import subprocess
 import sys
+import time
 from datetime import datetime
 
 K8S_PACKAGE = 'k8s.io/kubernetes/'
@@ -63,7 +65,8 @@ def get_tree_state():
   return 'gitTreeState=%s' % result
 
 def get_build_date():
-  return 'buildDate=%s' % datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ')
+  build_date = datetime.utcfromtimestamp(int(os.environ.get('SOURCE_DATE_EPOCH', time.time())))
+  return 'buildDate=%s' % build_date.strftime('%Y-%m-%dT%H:%M:%SZ')
 
 def main():
   if len(sys.argv) > 1 and sys.argv[1] == "--k8s-version-only":


### PR DESCRIPTION
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

Fixes #3005