### PR TITLE
Added instructions how to build using docker

### DIFF
--- a/docs/contributors/build_guide.md
+++ b/docs/contributors/build_guide.md
@@ -21,6 +21,23 @@ $ cd $GOPATH/src/k8s.io/minikube
 $ make
 ```
 
+### Building from Source in Docker (using Debian stretch image with golang)
+Clone minikube:
+```shell
+$ git clone https://github.com/kubernetes/minikube.git
+```
+Build using make:
+```shell
+$ cd minikube
+$ docker run --rm -v "$PWD":/go/src/k8s.io/minikube -w /go/src/k8s.io/minikube golang:stretch make
+```
+Check "out" directory:
+```shell
+$ ls out/
+docker-machine-driver-hyperkit.d	minikube				minikube.d				test.d
+docker-machine-driver-kvm2.d		minikube-linux-amd64			storage-provisioner.d
+```
+
 ### Run Instructions
 
 Start the cluster using your built minikube with:

--- a/docs/contributors/build_guide.md
+++ b/docs/contributors/build_guide.md
@@ -26,10 +26,10 @@ Clone minikube:
 ```shell
 $ git clone https://github.com/kubernetes/minikube.git
 ```
-Build using make:
+Build (cross complile for linux / OS X and Windows) using make:
 ```shell
 $ cd minikube
-$ docker run --rm -v "$PWD":/go/src/k8s.io/minikube -w /go/src/k8s.io/minikube golang:stretch make
+$ docker run --rm -v "$PWD":/go/src/k8s.io/minikube -w /go/src/k8s.io/minikube golang:stretch make cross
 ```
 Check "out" directory:
 ```shell


### PR DESCRIPTION
Added instructions how to build using docker golang stretch image (in my case using OS X) as base OS. It will be nice if someone will add instructions how to get minikube binary for OS X.