### PR TITLE
remove r2d4 from brew PR comment

### DIFF
--- a/hack/jenkins/release_update_installers.sh
+++ b/hack/jenkins/release_update_installers.sh
@@ -81,7 +81,7 @@ EOF
     "title": "Update minikube to ${REPLACE_PKG_VERSION}",
     "head": "minikube-bot:${REPLACE_PKG_VERSION}",
     "base": "master",
-    "body": "cc @r2d4"
+    "body": "cc @balopat"
 }
 
 EOF


### PR DESCRIPTION
This is part of the release code that automatically sends a homebrew package update upstream. We add a cc here for the homebrew maintainers as courtesy if the update process needs a human contact.