### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Install manually: Download the [minikube-windows-amd64.exe](https://storage.goog
 Example with kubectl installation:
 ```shell
 curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo cp minikube /usr/local/bin/ && rm minikube
-curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x kubectl && sudo cp minikube /usr/local/bin/ && rm minikube
+curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x kubectl && sudo cp kubectl /usr/local/bin/ && rm kubectl
 
 export MINIKUBE_WANTUPDATENOTIFICATION=false
 export MINIKUBE_WANTREPORTERRORPROMPT=false


### PR DESCRIPTION
There was a typo in 5a78ac92f6660b8d27b11f432f9554c0eca6f48f.
It was on this line: https://github.com/kubernetes/minikube/pull/3021/commits/37627136bdffaba5173f8f1913a6e1107d60b7df#diff-04c6e90faac2675aa89e2176d2eec7d8R46.