### PR TITLE
Revert "Remove untainting logic."

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -135,6 +135,14 @@ func (k *KubeadmBootstrapper) StartCluster(k8s config.KubernetesConfig) error {
 		return errors.Wrapf(err, "kubeadm init error %s running command: %s", b.String(), out)
 	}
 
+	if version.LT(semver.MustParse("1.10.0-alpha.0")) {
+		//TODO(r2d4): get rid of global here
+		master = k8s.NodeName
+		if err := util.RetryAfter(200, unmarkMaster, time.Second*1); err != nil {
+			return errors.Wrap(err, "timed out waiting to unmark master")
+		}
+	}
+
 	if err := util.RetryAfter(100, elevateKubeSystemPrivileges, time.Millisecond*500); err != nil {
 		return errors.Wrap(err, "timed out waiting to elevate kube-system RBAC privileges")
 	}


### PR DESCRIPTION
This reverts a part of commit eec47aaa714411df451b111e4a3b8ce7c08674a0.
Restore the logic for untainting old k8s-clusters
https://github.com/kubernetes/minikube/issues/3028