### PR TITLE
changed permission for hyperkit driver

### DIFF
--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -93,7 +93,7 @@ curl -Lo docker-machine-driver-hyperkit https://storage.googleapis.com/minikube/
 && sudo cp docker-machine-driver-hyperkit /usr/local/bin/ \
 && rm docker-machine-driver-hyperkit \
 && sudo chown root:wheel /usr/local/bin/docker-machine-driver-hyperkit \
-&& sudo chmod u+s /usr/local/bin/docker-machine-driver-hyperkit
+&& sudo chmod u+s+x /usr/local/bin/docker-machine-driver-hyperkit
 ```
 
 The hyperkit driver currently requires running as root to use the vmnet framework to setup networking.


### PR DESCRIPTION
when installing minikube on brand new machine and following instructions I ran into the issue with permissions:

```
minikube start --vm-driver=hyperkit -v5
Starting local Kubernetes v1.10.0 cluster...
Starting VM...
Downloading Minikube ISO
 160.27 MB / 160.27 MB [============================================] 100.00% 0s
Error starting plugin binary: fork/exec /usr/local/bin/docker-machine-driver-hyperkit: permission denied
```
```
ls -la /usr/local/bin/docker-machine-driver-hyperkit
-rws------  1 root  wheel  26811748 Aug  9 12:01 /usr/local/bin/docker-machine-driver-hyperkit```
After changing permissions

```
sudo chmod +x /usr/local/bin/docker-machine-driver-hyperkit
```

problem was solved.
