### PR TITLE
Allow certificates to be optionally embedded in .kube/config

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -237,6 +237,10 @@ var settings = []Setting{
 		set:    SetConfigMap,
 		setMap: SetMap,
 	},
+	{
+		name: "embed-certs",
+		set:  SetBool,
+	},
 }
 
 var ConfigCmd = &cobra.Command{

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -72,6 +72,7 @@ const (
 	vpnkitSock            = "hyperkit-vpnkit-sock"
 	vsockPorts            = "hyperkit-vsock-ports"
 	gpu                   = "gpu"
+	embedCerts            = "embed-certs"
 )
 
 var (
@@ -280,6 +281,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		ClientKey:            constants.MakeMiniPath("client.key"),
 		CertificateAuthority: constants.MakeMiniPath("ca.crt"),
 		KeepContext:          viper.GetBool(keepContext),
+		EmbedCerts:           viper.GetBool(embedCerts),
 	}
 	kubeCfgSetup.SetKubeConfigFile(kubeConfigFile)
 

--- a/pkg/minikube/bootstrapper/certs.go
+++ b/pkg/minikube/bootstrapper/certs.go
@@ -75,7 +75,10 @@ func SetupCerts(cmd CommandRunner, k8s config.KubernetesConfig) error {
 	}
 
 	kubeCfg := api.NewConfig()
-	kubeconfig.PopulateKubeConfig(kubeCfgSetup, kubeCfg)
+	err := kubeconfig.PopulateKubeConfig(kubeCfgSetup, kubeCfg)
+	if err != nil {
+		return errors.Wrap(err, "populating kubeconfig")
+	}
 	data, err := runtime.Encode(latest.Codec, kubeCfg)
 	if err != nil {
 		return errors.Wrap(err, "encoding kubeconfig")

--- a/pkg/util/kubeconfig/config.go
+++ b/pkg/util/kubeconfig/config.go
@@ -53,6 +53,9 @@ type KubeConfigSetup struct {
 	// Should the current context be kept when setting up this one
 	KeepContext bool
 
+	// Should the certificate files be embedded instead of referenced by path
+	EmbedCerts bool
+
 	// kubeConfigFile is the path where the kube config is stored
 	// Only access this with atomic ops
 	kubeConfigFile atomic.Value
@@ -67,18 +70,37 @@ func (k *KubeConfigSetup) GetKubeConfigFile() string {
 }
 
 // PopulateKubeConfig populates an api.Config object.
-func PopulateKubeConfig(cfg *KubeConfigSetup, kubecfg *api.Config) {
+func PopulateKubeConfig(cfg *KubeConfigSetup, kubecfg *api.Config) error {
+	var err error
 	clusterName := cfg.ClusterName
 	cluster := api.NewCluster()
 	cluster.Server = cfg.ClusterServerAddress
-	cluster.CertificateAuthority = cfg.CertificateAuthority
+	if cfg.EmbedCerts {
+		cluster.CertificateAuthorityData, err = ioutil.ReadFile(cfg.CertificateAuthority)
+		if err != nil {
+			return err
+		}
+	} else {
+		cluster.CertificateAuthority = cfg.CertificateAuthority
+	}
 	kubecfg.Clusters[clusterName] = cluster
 
 	// user
 	userName := cfg.ClusterName
 	user := api.NewAuthInfo()
-	user.ClientCertificate = cfg.ClientCertificate
-	user.ClientKey = cfg.ClientKey
+	if cfg.EmbedCerts {
+		user.ClientCertificateData, err = ioutil.ReadFile(cfg.ClientCertificate)
+		if err != nil {
+			return err
+		}
+		user.ClientKeyData, err = ioutil.ReadFile(cfg.ClientKey)
+		if err != nil {
+			return err
+		}
+	} else {
+		user.ClientCertificate = cfg.ClientCertificate
+		user.ClientKey = cfg.ClientKey
+	}
 	kubecfg.AuthInfos[userName] = user
 
 	// context
@@ -92,6 +114,8 @@ func PopulateKubeConfig(cfg *KubeConfigSetup, kubecfg *api.Config) {
 	if !cfg.KeepContext {
 		kubecfg.CurrentContext = cfg.ClusterName
 	}
+
+	return nil
 }
 
 // SetupKubeConfig reads config from disk, adds the minikube settings, and writes it back.
@@ -106,7 +130,10 @@ func SetupKubeConfig(cfg *KubeConfigSetup) error {
 		return err
 	}
 
-	PopulateKubeConfig(cfg, config)
+	err = PopulateKubeConfig(cfg, config)
+	if err != nil {
+		return err
+	}
 
 	// write back to disk
 	if err := WriteConfig(config, cfg.GetKubeConfigFile()); err != nil {


### PR DESCRIPTION
Opt-in with `minikube config set embed-certs true`. Similar to the
behaviour of `kubectl config set-credentials --embed-certs`.

Enables Minikube on Windows to produce a .kube/config file that
can be shared directly with kubectl inside the Windows Subsystem
for Linux (WSL) without needing to perform additional translation
of the certificate paths within the configuration file.

Fixes #3064 