### PR TITLE
Assorted fixes for `--vm-driver=none`

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -347,13 +347,13 @@ WARNING: IT IS RECOMMENDED NOT TO RUN THE NONE DRIVER ON PERSONAL WORKSTATIONS
 			fmt.Println(`When using the none driver, the kubectl config and credentials generated will be root owned and will appear in the root home directory.
 You will need to move the files to the appropriate location and then set the correct permissions.  An example of this is below:
 
-	sudo mv /root/.kube $HOME/.kube # this will write over any previous configuration
-	sudo chown -R $USER $HOME/.kube
-	sudo chgrp -R $USER $HOME/.kube
+	sudo cp -a /root/.kube $HOME/.kube # this will write over any previous configuration
+	sudo rm -rf /root/.kube
+	sudo chown -R $USER: $HOME/.kube
 
-	sudo mv /root/.minikube $HOME/.minikube # this will write over any previous configuration
-	sudo chown -R $USER $HOME/.minikube
-	sudo chgrp -R $USER $HOME/.minikube
+	sudo cp -a /root/.minikube $HOME/.minikube # this will write over any previous configuration
+	sudo rm -rf /root/.minikube
+	sudo chown -R $USER: $HOME/.minikube
 
 This can also be done automatically by setting the env var CHANGE_MINIKUBE_NONE_USER=true`)
 		}

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -344,6 +344,9 @@ WARNING: IT IS RECOMMENDED NOT TO RUN THE NONE DRIVER ON PERSONAL WORKSTATIONS
 		}
 
 		if os.Geteuid() == 0 {
+			fmt.Println(`===================
+WARNING: IT IS NOT NECESSARY NOR RECOMMENNDED TO RUN MINIKUBE AS ROOT WITH --vm-driver=none ANYMORE` + "\n")
+
 			if os.Getenv("CHANGE_MINIKUBE_NONE_USER") == "" {
 				fmt.Println(`When running minikube as root, the kubectl config and credentials generated will be root owned and will appear in the root home directory.
 You will need to move the files to the appropriate location and then set the correct permissions.  An example of this is below:

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -343,24 +343,26 @@ WARNING: IT IS RECOMMENDED NOT TO RUN THE NONE DRIVER ON PERSONAL WORKSTATIONS
 	The 'none' driver will run an insecure kubernetes apiserver as root that may leave the host vulnerable to CSRF attacks` + "\n")
 		}
 
-		if os.Getenv("CHANGE_MINIKUBE_NONE_USER") == "" {
-			fmt.Println(`When using the none driver, the kubectl config and credentials generated will be root owned and will appear in the root home directory.
+		if os.Geteuid() == 0 {
+			if os.Getenv("CHANGE_MINIKUBE_NONE_USER") == "" {
+				fmt.Println(`When running minikube as root, the kubectl config and credentials generated will be root owned and will appear in the root home directory.
 You will need to move the files to the appropriate location and then set the correct permissions.  An example of this is below:
 
-	sudo cp -a /root/.kube $HOME/.kube # this will write over any previous configuration
+	sudo cp -aT /root/.kube $HOME/.kube # this will write over any previous configuration
 	sudo rm -rf /root/.kube
 	sudo chown -R $USER: $HOME/.kube
 
-	sudo cp -a /root/.minikube $HOME/.minikube # this will write over any previous configuration
+	sudo cp -aT /root/.minikube $HOME/.minikube # this will write over any previous configuration
 	sudo rm -rf /root/.minikube
 	sudo chown -R $USER: $HOME/.minikube
 
 This can also be done automatically by setting the env var CHANGE_MINIKUBE_NONE_USER=true`)
-		}
-		if err := pkgutil.MaybeChownDirRecursiveToMinikubeUser(constants.GetMinipath()); err != nil {
-			glog.Errorf("Error recursively changing ownership of directory %s: %s",
-				constants.GetMinipath(), err)
-			cmdutil.MaybeReportErrorAndExit(err)
+			}
+			if err := pkgutil.MaybeChownDirRecursiveToMinikubeUser(constants.GetMinipath()); err != nil {
+				glog.Errorf("Error recursively changing ownership of directory %s: %s",
+					constants.GetMinipath(), err)
+				cmdutil.MaybeReportErrorAndExit(err)
+			}
 		}
 	}
 

--- a/pkg/drivers/none/none.go
+++ b/pkg/drivers/none/none.go
@@ -134,7 +134,7 @@ func (d *Driver) Remove() error {
 	rmCmd := `sudo systemctl stop kubelet.service
 	sudo rm -rf /data/minikube
 	sudo rm -rf /etc/kubernetes/manifests
-	sudo rm -rf /var/lib/minikube || true`
+	sudo rm -rf /var/lib/minikube`
 
 	for _, cmdStr := range []string{rmCmd, dockerkillcmd} {
 		if out, err := runCommand(cmdStr, true); err != nil {

--- a/pkg/drivers/none/none.go
+++ b/pkg/drivers/none/none.go
@@ -100,20 +100,20 @@ func (d *Driver) GetURL() (string, error) {
 }
 
 func (d *Driver) GetState() (state.State, error) {
-	var statuscmd = fmt.Sprintf(
-		`sudo systemctl is-active kubelet &>/dev/null && echo "Running" || echo "Stopped"`)
+	const statusCmd = `systemctl is-active kubelet || true` // is-active returns status via exit-code, we don't need that
 
-	out, err := runCommand(statuscmd, true)
+	out, err := runCommand(statusCmd, true)
 	if err != nil {
 		return state.None, err
 	}
-	s := strings.TrimSpace(out)
-	if state.Running.String() == s {
+
+	out = strings.TrimSpace(out)
+	if "active" == out {
 		return state.Running, nil
-	} else if state.Stopped.String() == s {
+	} else if "inactive" == out {
 		return state.Stopped, nil
 	} else {
-		return state.None, fmt.Errorf("Error: Unrecognize output from GetState: %s", s)
+		return state.None, fmt.Errorf("Invalid `systemctl is-active` output: %s", out)
 	}
 }
 

--- a/pkg/drivers/none/none.go
+++ b/pkg/drivers/none/none.go
@@ -32,7 +32,7 @@ import (
 )
 
 const driverName = "none"
-const dockerstopcmd = `docker kill $(docker ps -a --filter="name=k8s_" --format="{{.ID}}")`
+const dockerstopcmd = `docker kill $(docker ps -a --filter="name=k8s_" -q")`
 
 var dockerkillcmd = fmt.Sprintf(`docker rm $(%s)`, dockerstopcmd)
 

--- a/pkg/drivers/none/none.go
+++ b/pkg/drivers/none/none.go
@@ -131,10 +131,10 @@ func (d *Driver) Kill() error {
 }
 
 func (d *Driver) Remove() error {
-	rmCmd := `sudo systemctl stop kubelet.service
-	sudo rm -rf /data/minikube
-	sudo rm -rf /etc/kubernetes/manifests
-	sudo rm -rf /var/lib/minikube`
+	rmCmd := `systemctl stop kubelet.service
+	rm -rf /data/minikube
+	rm -rf /etc/kubernetes/manifests
+	rm -rf /var/lib/minikube`
 
 	for _, cmdStr := range []string{rmCmd, dockerkillcmd} {
 		if out, err := runCommand(cmdStr, true); err != nil {

--- a/pkg/drivers/none/none.go
+++ b/pkg/drivers/none/none.go
@@ -19,6 +19,7 @@ package none
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -27,7 +28,6 @@ import (
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/state"
 	"github.com/pkg/errors"
-	"k8s.io/apimachinery/pkg/util/net"
 	pkgdrivers "k8s.io/minikube/pkg/drivers"
 )
 
@@ -77,11 +77,11 @@ func (d *Driver) DriverName() string {
 }
 
 func (d *Driver) GetIP() (string, error) {
-	ip, err := net.ChooseBindAddress(nil)
-	if err != nil {
-		return "", err
+	if hostIP, ok := os.LookupEnv("MINIKUBE_IP"); ok {
+		return hostIP, nil
+	} else {
+		return "127.0.0.1", nil
 	}
-	return ip.String(), nil
 }
 
 func (d *Driver) GetSSHHostname() (string, error) {

--- a/pkg/drivers/none/none.go
+++ b/pkg/drivers/none/none.go
@@ -202,17 +202,19 @@ func (d *Driver) RunSSHCommandFromDriver() error {
 }
 
 func runCommand(command string, sudo bool) (string, error) {
-	cmd := exec.Command("/bin/bash", "-c", command)
+	var cmd *exec.Cmd
 	if sudo {
 		cmd = exec.Command("sudo", "/bin/bash", "-c", command)
+	} else {
+		cmd = exec.Command("/bin/bash", "-c", command)
 	}
-	var out bytes.Buffer
+	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	cmd.Stdout = &out
+	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	if err != nil {
-		return "", errors.Wrap(err, stderr.String())
+		return stdout.String(), errors.Wrap(err, stderr.String())
 	}
-	return out.String(), nil
+	return stdout.String(), nil
 }

--- a/pkg/minikube/bootstrapper/command_runner.go
+++ b/pkg/minikube/bootstrapper/command_runner.go
@@ -26,25 +26,25 @@ import (
 
 // CommandRunner represents an interface to run commands.
 type CommandRunner interface {
-	// Run starts the specified command and waits for it to complete.
+	// Run starts the specified command in a bash shell and waits for it to complete.
 	Run(cmd string) error
 
-	// CombinedOutputTo runs the command and stores both command
-	// output and error to out. A typical usage is:
+	// RunWithOutputTo runs the command (as in Run()) and redirects both its
+	// stdout and stderr to `out`. A typical usage is:
 	//
 	//          var b bytes.Buffer
-	//          CombinedOutput(cmd, &b)
+	//          RunWithOutputTo(cmd, &b)
 	//          fmt.Println(b.Bytes())
 	//
 	// Or, you can set out to os.Stdout, the command output and
 	// error would show on your terminal immediately before you
 	// cmd exit. This is useful for a long run command such as
 	// continuously print running logs.
-	CombinedOutputTo(cmd string, out io.Writer) error
+	RunWithOutputTo(cmd string, out io.Writer) error
 
-	// CombinedOutput runs the command and returns its combined standard
+	// RunWithOutput runs the command (as in Run()) and returns its combined standard
 	// output and standard error.
-	CombinedOutput(cmd string) (string, error)
+	RunWithOutput(cmd string) (string, error)
 
 	// Copy is a convenience method that runs a command to copy a file
 	Copy(assets.CopyableFile) error

--- a/pkg/minikube/bootstrapper/command_runner.go
+++ b/pkg/minikube/bootstrapper/command_runner.go
@@ -54,5 +54,9 @@ type CommandRunner interface {
 }
 
 func getDeleteFileCommand(f assets.CopyableFile) string {
-	return fmt.Sprintf("sudo rm %s", filepath.Join(f.GetTargetDir(), f.GetTargetName()))
+	return fmt.Sprintf("sudo rm -f %s", filepath.Join(f.GetTargetDir(), f.GetTargetName()))
+}
+
+func getMkDirCommand(f assets.CopyableFile) string {
+	return fmt.Sprintf("sudo mkdir -p %s", f.GetTargetDir())
 }

--- a/pkg/minikube/bootstrapper/exec_runner.go
+++ b/pkg/minikube/bootstrapper/exec_runner.go
@@ -44,9 +44,9 @@ func (*ExecRunner) Run(cmd string) error {
 	return nil
 }
 
-// CombinedOutputTo runs the command and stores both command
-// output and error to out.
-func (*ExecRunner) CombinedOutputTo(cmd string, out io.Writer) error {
+// RunWithOutputTo runs the command (as in Run()) and redirects both its
+// stdout and stderr to `out`.
+func (*ExecRunner) RunWithOutputTo(cmd string, out io.Writer) error {
 	glog.Infoln("Run with output:", cmd)
 	c := exec.Command("/bin/bash", "-c", cmd)
 	c.Stdout = out
@@ -59,11 +59,11 @@ func (*ExecRunner) CombinedOutputTo(cmd string, out io.Writer) error {
 	return nil
 }
 
-// CombinedOutput runs the command  in a bash shell and returns its
+// RunWithOutput runs the command  in a bash shell and returns its
 // combined standard output and standard error.
-func (e *ExecRunner) CombinedOutput(cmd string) (string, error) {
+func (e *ExecRunner) RunWithOutput(cmd string) (string, error) {
 	var b bytes.Buffer
-	err := e.CombinedOutputTo(cmd, &b)
+	err := e.RunWithOutputTo(cmd, &b)
 	if err != nil {
 		return "", errors.Wrapf(err, "running command: %s\n output: %s", cmd, b.Bytes())
 	}

--- a/pkg/minikube/bootstrapper/fake_runner.go
+++ b/pkg/minikube/bootstrapper/fake_runner.go
@@ -45,13 +45,13 @@ func NewFakeCommandRunner() *FakeCommandRunner {
 
 // Run returns nil if output has been set for the given command text.
 func (f *FakeCommandRunner) Run(cmd string) error {
-	_, err := f.CombinedOutput(cmd)
+	_, err := f.RunWithOutput(cmd)
 	return err
 }
 
-// CombinedOutputTo runs the command and stores both command
+// RunWithOutputTo runs the command and stores both command
 // output and error to out.
-func (f *FakeCommandRunner) CombinedOutputTo(cmd string, out io.Writer) error {
+func (f *FakeCommandRunner) RunWithOutputTo(cmd string, out io.Writer) error {
 	value, ok := f.cmdMap.Load(cmd)
 	if !ok {
 		return fmt.Errorf("unavailable command: %s", cmd)
@@ -64,8 +64,8 @@ func (f *FakeCommandRunner) CombinedOutputTo(cmd string, out io.Writer) error {
 	return nil
 }
 
-// CombinedOutput returns the set output for a given command text.
-func (f *FakeCommandRunner) CombinedOutput(cmd string) (string, error) {
+// RunWithOutput returns the set output for a given command text.
+func (f *FakeCommandRunner) RunWithOutput(cmd string) (string, error) {
 	out, ok := f.cmdMap.Load(cmd)
 	if !ok {
 		return "", fmt.Errorf("unavailable command: %s", cmd)

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -293,7 +293,7 @@ func (k *KubeadmBootstrapper) UpdateCluster(cfg config.KubernetesConfig) error {
 			if err != nil {
 				return errors.Wrapf(err, "downloading %s", bin)
 			}
-			f, err := assets.NewFileAsset(path, "/usr/bin", bin, "0641")
+			f, err := assets.NewFileAsset(path, "/usr/bin", bin, "0750")
 			if err != nil {
 				return errors.Wrap(err, "making new file asset")
 			}

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -131,7 +131,9 @@ func (k *KubeadmBootstrapper) StartCluster(k8s config.KubernetesConfig) error {
 	}
 
 	if out, err := k.c.RunWithOutput(b.String()); err != nil {
-		return errors.Wrapf(err, "kubeadm init error %s running command: %s", b.String(), out)
+		// kubeadm is noisy -- only show its output if there was a problem
+		fmt.Fprint(os.Stderr, out)
+		return errors.Wrapf(err, "failed to init kubeadm")
 	}
 
 	if err := util.RetryAfter(100, elevateKubeSystemPrivileges, time.Millisecond*500); err != nil {

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -70,7 +70,7 @@ func NewKubeadmBootstrapper(api libmachine.API) (*KubeadmBootstrapper, error) {
 //TODO(r2d4): This should most likely check the health of the apiserver
 func (k *KubeadmBootstrapper) GetClusterStatus() (string, error) {
 	statusCmd := `sudo systemctl is-active kubelet`
-	status, err := k.c.CombinedOutput(statusCmd)
+	status, err := k.c.RunWithOutput(statusCmd)
 	if err != nil {
 		return "", errors.Wrap(err, "getting status")
 	}
@@ -94,12 +94,12 @@ func (k *KubeadmBootstrapper) GetClusterLogsTo(follow bool, out io.Writer) error
 	logsCommand := fmt.Sprintf("sudo journalctl %s -u kubelet", strings.Join(flags, " "))
 
 	if follow {
-		if err := k.c.CombinedOutputTo(logsCommand, out); err != nil {
+		if err := k.c.RunWithOutputTo(logsCommand, out); err != nil {
 			return errors.Wrap(err, "getting cluster logs")
 		}
 	} else {
 
-		logs, err := k.c.CombinedOutput(logsCommand)
+		logs, err := k.c.RunWithOutput(logsCommand)
 		if err != nil {
 			return errors.Wrap(err, "getting cluster logs")
 		}
@@ -130,8 +130,7 @@ func (k *KubeadmBootstrapper) StartCluster(k8s config.KubernetesConfig) error {
 		return err
 	}
 
-	out, err := k.c.CombinedOutput(b.String())
-	if err != nil {
+	if out, err := k.c.RunWithOutput(b.String()); err != nil {
 		return errors.Wrapf(err, "kubeadm init error %s running command: %s", b.String(), out)
 	}
 

--- a/pkg/minikube/bootstrapper/ssh_runner.go
+++ b/pkg/minikube/bootstrapper/ssh_runner.go
@@ -63,10 +63,10 @@ func (s *SSHRunner) Run(cmd string) error {
 	return sess.Run(cmd)
 }
 
-// CombinedOutputTo runs the command and stores both command
-// output and error to out.
-func (s *SSHRunner) CombinedOutputTo(cmd string, out io.Writer) error {
-	b, err := s.CombinedOutput(cmd)
+// RunWithOutputTo runs the command (as in Run()) and writes both its stdout
+// and stderr to `out`.
+func (s *SSHRunner) RunWithOutputTo(cmd string, out io.Writer) error {
+	b, err := s.RunWithOutput(cmd)
 	if err != nil {
 		return errors.Wrapf(err, "running command: %s\n.", cmd)
 	}
@@ -74,9 +74,9 @@ func (s *SSHRunner) CombinedOutputTo(cmd string, out io.Writer) error {
 	return err
 }
 
-// CombinedOutput runs the command on the remote and returns its combined
+// RunWithOutput runs the command (as in Run()) and returns its combined
 // standard output and standard error.
-func (s *SSHRunner) CombinedOutput(cmd string) (string, error) {
+func (s *SSHRunner) RunWithOutput(cmd string) (string, error) {
 	glog.Infoln("Run with output:", cmd)
 	sess, err := s.c.NewSession()
 	if err != nil {


### PR DESCRIPTION
This pull-request includes various fixes to Minikube, all related in some extent to its `--vm-driver=none` mode which I've been exclusively using.

There also are some refactorings that I've been doing in the process of understanding the code, they are not strictly necessary but I believe they make the code clearer a bit.

Besides refactorings, there are two major changes:
- ExecRunner is changed to use sudo internally, thus it is not required to run `minikube` as root anymore;
- `--vm-driver=none` now uses 127.0.0.1 instead of the host's external IP.

I'm not entirely positive on the last change, but binding to the host's external IP is unforgivable (because it is bound to change, and I hated to restart the cluster whenever I changed networks on my workstation laptop). I suspected that the host's external IP is used here because it gets propagated inside some containers (which obviously won't work with a loopback address), but I've perused the code lightly and couldn't find any places where this would matter.

Anyway, 127.0.0.1 seems to work, and I tried to ask on #minikube in Slack to confirm this but got no response. If someone explains how exactly it is wrong to use 127.0.0.1, I'll change this to add a throwaway private IP to the host's loopback interface and use it.