### PR TITLE
Make CoreDNS default addon

### DIFF
--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -120,7 +120,7 @@ var Addons = map[string]*Addon{
 			constants.AddonsPath,
 			"coreDNS-clusterrole.yaml",
 			"0640"),
-	}, false, "coredns"),
+	}, true, "coredns"),
 	"kube-dns": NewAddon([]*BinDataAsset{
 		NewBinDataAsset(
 			"deploy/addons/kube-dns/kube-dns-controller.yaml",
@@ -137,7 +137,7 @@ var Addons = map[string]*Addon{
 			constants.AddonsPath,
 			"kube-dns-svc.yaml",
 			"0640"),
-	}, true, "kube-dns"),
+	}, false, "kube-dns"),
 	"heapster": NewAddon([]*BinDataAsset{
 		NewBinDataAsset(
 			"deploy/addons/heapster/influx-grafana-rc.yaml",


### PR DESCRIPTION
Following the KEP defined:
https://github.com/kubernetes/community/blob/master/keps/sig-network/0012-20180518-coredns-default-proposal.md

Enabling CoreDNS by default and disabling kube-dns.