### PR TITLE
Update CoreDNS deployment

### DIFF
--- a/deploy/addons/coredns/coreDNS-controller.yaml
+++ b/deploy/addons/coredns/coreDNS-controller.yaml
@@ -41,6 +41,7 @@ spec:
         volumeMounts:
         - name: config-volume
           mountPath: /etc/coredns
+          readOnly: true
         ports:
         - containerPort: 53
           name: dns
@@ -51,6 +52,14 @@ spec:
         - containerPort: 9153
           name: metrics
           protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - all
+          readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
             path: /health


### PR DESCRIPTION
Make CoreDNS run in read-only mode and drop all unneeded privileges 