### PR TITLE
Remove a statement to skip over adding the kube-dns addon

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -157,12 +157,8 @@ func addAddons(files *[]assets.CopyableFile) error {
 		return errors.Wrap(err, "adding minikube dir assets")
 	}
 	// bundled addons
-	for addonName, addonBundle := range assets.Addons {
-		// TODO(r2d4): Kubeadm ignores the kube-dns addon and uses its own.
-		// expose this in a better way
-		if addonName == "kube-dns" {
-			continue
-		}
+	for _, addonBundle := range assets.Addons {
+
 		if isEnabled, err := addonBundle.IsEnabled(); err == nil && isEnabled {
 			for _, addon := range addonBundle.Assets {
 				*files = append(*files, addon)


### PR DESCRIPTION
This should fix issue: https://github.com/kubernetes/minikube/issues/2808

However it seems to create a new issue as `kubeadm` creates a DNS deployment by itself. Based on the documentation found here: https://kubernetes.io/docs/tasks/administer-cluster/coredns/ it seems like you're only able to switch between `kube-dns` and `core-dns` and not disable the deployment. @r2d4 Do you have any thoughts how we could fix this?

NVM ~@dlorenc I'm curious if by merging https://github.com/kubernetes/minikube/pull/3073 we have 2 core-dns deployments on kubernetes version: `v1.11.0` or higher?~