### PR TITLE
Add env variable for default ES_JAVA_OPTS

### DIFF
--- a/deploy/addons/efk/elasticsearch-rc.yaml
+++ b/deploy/addons/efk/elasticsearch-rc.yaml
@@ -59,6 +59,8 @@ spec:
               fieldPath: metadata.namespace
         - name: MINIMUM_MASTER_NODES
           value: "1"
+        - name: ES_JAVA_OPTS
+          value: "-Xms1024m -Xmx1024m"
       initContainers:
       - image: registry.hub.docker.com/library/alpine:3.6
         command: ["/sbin/sysctl", "-w", "vm.max_map_count=262144"]


### PR DESCRIPTION
The default configuration here for ES_JAVA_OPTS will pretty much always fail as is, making this addon useless and broken unless modified. Since this is deployed automatically when addon is enabled, it seems like providing a value that works is the best option here, otherwise in a minikube the pod(s) deployed will continually fail to start.