### PR TITLE
Enhance the Ingress Addon

### DIFF
--- a/deploy/addons/ingress/ingress-configmap.yaml
+++ b/deploy/addons/ingress/ingress-configmap.yaml
@@ -29,9 +29,13 @@ kind: ConfigMap
 metadata:
   name: tcp-services
   namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: udp-services
   namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists

--- a/deploy/addons/ingress/ingress-dp.yaml
+++ b/deploy/addons/ingress/ingress-dp.yaml
@@ -18,17 +18,19 @@ metadata:
   name: default-http-backend
   namespace: kube-system
   labels:
+    app.kubernetes.io/name: default-http-backend
+    app.kubernetes.io/part-of: kube-system
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: default-http-backend
+      app.kubernetes.io/name: default-http-backend
       addonmanager.kubernetes.io/mode: Reconcile
   template:
     metadata:
       labels:
-        app: default-http-backend
+        app.kubernetes.io/name: default-http-backend
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       terminationGracePeriodSeconds: 60
@@ -37,7 +39,7 @@ spec:
         # Any image is permissible as long as:
         # 1. It serves a 404 page at /
         # 2. It serves 200 on a /healthz endpoint
-        image: k8s.gcr.io/defaultbackend:1.4
+        image: gcr.io/google_containers/defaultbackend:1.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -50,11 +52,11 @@ spec:
         - containerPort: 8080
         resources:
           limits:
-            cpu: 10m
-            memory: 20Mi
+            cpu: 20m
+            memory: 30Mi
           requests:
-            cpu: 10m
-            memory: 20Mi
+            cpu: 20m
+            memory: 30Mi
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -62,24 +64,30 @@ metadata:
   name: nginx-ingress-controller
   namespace: kube-system
   labels:
-    app: nginx-ingress-controller
+    app.kubernetes.io/name: nginx-ingress-controller
+    app.kubernetes.io/part-of: kube-system
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: nginx-ingress-controller
+      app.kubernetes.io/name: nginx-ingress-controller
+      app.kubernetes.io/part-of: kube-system
       addonmanager.kubernetes.io/mode: Reconcile
   template:
     metadata:
       labels:
-        app: nginx-ingress-controller
-        name: nginx-ingress-controller
+        app.kubernetes.io/name: nginx-ingress-controller
+        app.kubernetes.io/part-of: kube-system
         addonmanager.kubernetes.io/mode: Reconcile
+      annotations:
+        prometheus.io/port: '10254'
+        prometheus.io/scrape: 'true'
     spec:
+      serviceAccountName: nginx-ingress
       terminationGracePeriodSeconds: 60
       containers:
-      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.16.2
+      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.19.0
         name: nginx-ingress-controller
         imagePullPolicy: IfNotPresent
         readinessProbe:
@@ -108,8 +116,7 @@ spec:
           hostPort: 80
         - containerPort: 443
           hostPort: 443
-        # we expose 18080 to access nginx stats in url /nginx-status
-        # this is optional
+        # (Optional) we expose 18080 to access nginx stats in url /nginx-status
         - containerPort: 18080
           hostPort: 18080
         args:
@@ -118,6 +125,7 @@ spec:
         - --configmap=$(POD_NAMESPACE)/nginx-load-balancer-conf
         - --tcp-services-configmap=$(POD_NAMESPACE)/tcp-services
         - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
+        - --annotations-prefix=nginx.ingress.kubernetes.io
         # use minikube IP address in ingress status field
         - --report-node-internal-ip-address
         securityContext:

--- a/deploy/addons/ingress/ingress-rbac.yaml
+++ b/deploy/addons/ingress/ingress-rbac.yaml
@@ -1,0 +1,149 @@
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nginx-ingress
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: system:nginx-ingress
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - nodes
+  - pods
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "extensions"
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - "extensions"
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: system::nginx-ingress-role
+  namespace: kube-system
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  # Defaults to "<election-id>-<ingress-class>"
+  # Here: "<ingress-controller-leader>-<nginx>"
+  # This has to be adapted if you change either parameter
+  # when launching the nginx-ingress-controller.
+  - ingress-controller-leader-nginx
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: system::nginx-ingress-role-binding
+  namespace: kube-system
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+    addonmanager.kubernetes.io/mode: EnsureExists
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system::nginx-ingress-role
+subjects:
+- kind: ServiceAccount
+  name: nginx-ingress
+  namespace: kube-system
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: system:nginx-ingress
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+    addonmanager.kubernetes.io/mode: EnsureExists
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:nginx-ingress
+subjects:
+- kind: ServiceAccount
+  name: nginx-ingress
+  namespace: kube-system

--- a/deploy/addons/ingress/ingress-svc.yaml
+++ b/deploy/addons/ingress/ingress-svc.yaml
@@ -18,7 +18,8 @@ metadata:
   name: default-http-backend
   namespace: kube-system
   labels:
-    app: default-http-backend
+    app.kubernetes.io/name: default-http-backend
+    app.kubernetes.io/part-of: kube-system
     kubernetes.io/minikube-addons: ingress
     kubernetes.io/minikube-addons-endpoint: ingress
     addonmanager.kubernetes.io/mode: Reconcile
@@ -29,4 +30,4 @@ spec:
     targetPort: 8080
     nodePort: 30001
   selector:
-    app: default-http-backend
+    app.kubernetes.io/name: default-http-backend

--- a/docs/contributors/build_guide.md
+++ b/docs/contributors/build_guide.md
@@ -21,6 +21,9 @@ $ cd $GOPATH/src/k8s.io/minikube
 $ make
 ```
 
+Note: Make sure that you uninstall any previous versions of minikube before building
+from the source.
+
 ### Building from Source in Docker (using Debian stretch image with golang)
 Clone minikube:
 ```shell

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -204,6 +204,11 @@ var Addons = map[string]*Addon{
 			"ingress-configmap.yaml",
 			"0640"),
 		NewBinDataAsset(
+			"deploy/addons/ingress/ingress-rbac.yaml",
+			constants.AddonsPath,
+			"ingress-rbac.yaml",
+			"0640"),
+		NewBinDataAsset(
 			"deploy/addons/ingress/ingress-dp.yaml",
 			constants.AddonsPath,
 			"ingress-dp.yaml",

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -247,7 +247,7 @@ func WaitForIngressControllerRunning(t *testing.T) error {
 		return errors.Wrap(err, "waiting for ingress-controller deployment to stabilize")
 	}
 
-	selector := labels.SelectorFromSet(labels.Set(map[string]string{"app": "nginx-ingress-controller"}))
+	selector := labels.SelectorFromSet(labels.Set(map[string]string{"app.kubernetes.io/name": "nginx-ingress-controller"}))
 	if err := commonutil.WaitForPodsWithLabelRunning(client, "kube-system", selector); err != nil {
 		return errors.Wrap(err, "waiting for ingress-controller pods")
 	}


### PR DESCRIPTION
Adds a few updates to the Ingress Addon.

- Updates Ingress-Controller Version to 0.19.0
- Adds Service Account for Ingress-Controller
- Adds Support for Prometheus
- Fixes bug with TCP/UDP ConfigMaps not Loading
- Adds more resource limits to default-backend
- Use new ingress class name
- Use app.kubernetes.io/xxxxxxxxxxx labels