### PR TITLE
Specify full path to minikube in "Linux Continuous Integration without VM Support" instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ mkdir -p $HOME/.kube
 touch $HOME/.kube/config
 
 export KUBECONFIG=$HOME/.kube/config
-sudo -E minikube start --vm-driver=none
+sudo -E /usr/local/bin/minikube start --vm-driver=none
 
 # this for loop waits until kubectl can access the api server that Minikube has created
 for i in {1..150}; do # timeout for 5 minutes


### PR DESCRIPTION
On many Linux systems `/usr/local/bin/` is not in root's `$PATH`. On some Linux systems (e.g. Debian) `sudo -E` does not forward the `$PATH` environment variable. https://unix.stackexchange.com/questions/83191/how-to-make-sudo-preserve-path

Specifying the absolute path allows sudo find the minikube executable.