### PR TITLE
Stay in same line

### DIFF
--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -155,7 +155,7 @@ To opt out of these messages, run the command:
 
 func getInput(input chan string, r io.Reader) {
 	reader := bufio.NewReader(r)
-	fmt.Print("Please enter your response [Y/n]: \n")
+	fmt.Print("Please enter your response [Y/n]: ")
 	response, err := reader.ReadString('\n')
 	if err != nil {
 		glog.Errorf(err.Error())


### PR DESCRIPTION
Because it just looks pretty when cursor stays in the same line.

```bash
Please enter your response [Y/n]:
y
```

to ->
```bash
Please enter your response [Y/n]: y
```