### PR TITLE
Simplifies Linux installation instructions by using install(1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ brew cask install minikube
 ```
 
 ### Linux
+
 ```shell
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo cp minikube /usr/local/bin/ && rm minikube
+curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 \
+  && sudo install minikube-linux-amd64 /usr/local/bin/minikube
 ```
 
 ### Windows


### PR DESCRIPTION
Makes documentation easier to read on narrower screens, and makes the command-line less scary looking. Leaves deletion of the downloaded file as an exercise for the reader. It's typically not done in installation instructions.

Instructions still assume x86-64 architecture, which is the common case, but less than ideal.