### PR TITLE
Change default docker storage driver to overlay2

### DIFF
--- a/pkg/minikube/machine/client.go
+++ b/pkg/minikube/machine/client.go
@@ -110,7 +110,7 @@ func (api *LocalClient) NewHost(driverName string, rawDriver []byte) (*host.Host
 				ServerKeyPath:    filepath.Join(api.GetMachinesDir(), "server-key.pem"),
 			},
 			EngineOptions: &engine.Options{
-				StorageDriver: "aufs",
+				StorageDriver: "overlay2",
 				TLSVerify:     true,
 			},
 			SwarmOptions: &swarm.Options{},


### PR DESCRIPTION
The "aufs" storage driver has been deprecated,
changed in Docker 17.09 for "overlay2" instead.

See https://github.com/docker/machine/pull/4558

This only affects the "boot2docker" provisioner,
since it is already being used by "buildroot".

Closes #3078