### PR TITLE
Update dashboard version to v1.10.0

### DIFF
--- a/deploy/addons/dashboard/dashboard-dp.yaml
+++ b/deploy/addons/dashboard/dashboard-dp.yaml
@@ -18,7 +18,7 @@ metadata:
   name: kubernetes-dashboard
   namespace: kube-system
   labels:
-    version: v1.8.1
+    version: v1.10.0
     addonmanager.kubernetes.io/mode: Reconcile
     kubernetes.io/minikube-addons: dashboard
 spec:
@@ -26,18 +26,18 @@ spec:
   selector:
     matchLabels:
       app: kubernetes-dashboard
-      version: v1.8.1
+      version: v1.10.0
       addonmanager.kubernetes.io/mode: Reconcile
   template:
     metadata:
       labels:
         app: kubernetes-dashboard
-        version: v1.8.1
+        version: v1.10.0
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.8.1
+        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9090

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -229,7 +229,7 @@ func GetKubeadmCachedImages(kubernetesVersionStr string) []string {
 	}
 
 	images = append(images, []string{
-		"k8s.gcr.io/kubernetes-dashboard-amd64:v1.8.1",
+		"k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.0",
 		"k8s.gcr.io/kube-addon-manager:v8.6",
 		"gcr.io/k8s-minikube/storage-provisioner:v1.8.1",
 	}...)


### PR DESCRIPTION
Hey all! There's a new version of the dashboard available (v1.10.0). This PR updates minikube's references from v1.8.1 to use the new version. :)

Let me know if I missed anything. Thanks!