### PR TITLE
Replace kubernetes-users mailing list links with discuss forum link

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,5 +216,5 @@ For more information about Minikube, see the [proposal](https://github.com/kuber
 ## Community
 
 * [**#minikube on Kubernetes Slack**](https://kubernetes.slack.com)
-* [**kubernetes-users mailing list** ](https://groups.google.com/forum/#!forum/kubernetes-users)
-(If you are posting to the list, please prefix your subject with "minikube: ")
+* [**Kubernetes Official Forum** ](https://discuss.kubernetes.io)
+(If you are posting to the forum, please tag your post with "minikube")


### PR DESCRIPTION
This PR updates the link in [README.md](https://github.com/kubernetes/minikube/blob/master/README.md)  that currently point to the [Google Groups Kubernetes Mailing List](https://groups.google.com/forum/#!forum/kubernetes-users) to the new [discuss.kubernetes.io](https://discuss.kubernetes.io) forum. 

The mailing list has been archived and set to read only. For more information on this, see issue https://github.com/kubernetes/community/issues/2492

/cc @castrojo 