### PR TITLE
Add e2e tests for minikube's GPU support. 

### DIFF
--- a/pkg/util/kubernetes.go
+++ b/pkg/util/kubernetes.go
@@ -111,6 +111,16 @@ func StartPods(c kubernetes.Interface, namespace string, pod v1.Pod, waitForRunn
 // Wait up to 10 minutes for all matching pods to become Running and at least one
 // matching pod exists.
 func WaitForPodsWithLabelRunning(c kubernetes.Interface, ns string, label labels.Selector) error {
+	return waitForPodsWithLabel(c, ns, label, v1.PodRunning)
+}
+
+// Wait up to 10 minutes for all matching pods to become Succeded and at least one
+// matching pod exists.
+func WaitForPodsWithLabelSucceeded(c kubernetes.Interface, ns string, label labels.Selector) error {
+	return waitForPodsWithLabel(c, ns, label, v1.PodSucceeded)
+}
+
+func waitForPodsWithLabel(c kubernetes.Interface, ns string, label labels.Selector, status v1.PodPhase) error {
 	lastKnownPodNumber := -1
 	return wait.PollImmediate(constants.APICallRetryInterval, time.Minute*10, func() (bool, error) {
 		listOpts := metav1.ListOptions{LabelSelector: label.String()}
@@ -130,7 +140,7 @@ func WaitForPodsWithLabelRunning(c kubernetes.Interface, ns string, label labels
 		}
 
 		for _, pod := range pods.Items {
-			if pod.Status.Phase != v1.PodRunning {
+			if pod.Status.Phase != status {
 				return false, nil
 			}
 		}

--- a/test/integration/cluster_status_test.go
+++ b/test/integration/cluster_status_test.go
@@ -47,7 +47,7 @@ func testClusterStatus(t *testing.T) {
 			}
 			if status != api.ConditionTrue {
 				err := fmt.Errorf("Component %s is not Healthy! Status: %s", i.GetName(), status)
-				t.Log("Retrying, %s", err)
+				t.Logf("Retrying, %s", err)
 				return err
 			}
 		}

--- a/test/integration/gpu_test.go
+++ b/test/integration/gpu_test.go
@@ -1,0 +1,109 @@
+// +build integration
+
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+	"net"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/docker/machine/libmachine/state"
+	api "k8s.io/api/core/v1"
+	"k8s.io/minikube/test/integration/util"
+)
+
+func TestGpu(t *testing.T) {
+
+	runner := NewMinikubeRunner(t)
+	runner.RunCommand("config set WantReportErrorPrompt false", true)
+	runner.RunCommand("delete", false)
+	runner.CheckStatus(state.None.String())
+
+	// Check that we can bring up VM with --gpu flag.
+	runner.Start()
+	runner.CheckStatus(state.Running.String())
+
+	ip := runner.RunCommand("ip", true)
+	ip = strings.TrimRight(ip, "\n")
+	if net.ParseIP(ip) == nil {
+		t.Fatalf("IP command returned an invalid address: %s", ip)
+	}
+
+	// Enable the addons that install the NVIDIA driver and expose the GPU resources.
+	runner.RunCommand("addons enable nvidia-driver-installer", true)
+	runner.RunCommand("addons enable nvidia-gpu-device-plugin", true)
+
+	// Wait for the device plugin and driver installer to become running.
+	if err := util.WaitForNvidiaDriverInstallerRunning(t); err != nil {
+		t.Errorf("waiting for nvidia-driver-installer to be up: %s", err)
+	}
+	if err := util.WaitForNvidiaGpuDevicePluginRunning(t); err != nil {
+		t.Errorf("waiting for nvidia-gpu-device-plugin to be up: %s", err)
+	}
+
+	kubectlRunner := util.NewKubectlRunner(t)
+
+	// Wait for the 'nvidia.com/gpu' capacity to show up in the nodes.
+	// If this completes successfully, we can be sure that driver installation was successful.
+	checkCapacity := func() error {
+		nodes := api.NodeList{}
+		if err := kubectlRunner.RunCommandParseOutput([]string{"get", "nodes"}, &nodes); err != nil {
+			return fmt.Errorf("parsing 'kubectl get nodes' output")
+		}
+		for _, node := range nodes.Items {
+			if _, ok := node.Status.Capacity["nvidia.com/gpu"]; !ok {
+				return fmt.Errorf("nvidia.com/gpu not present in capacity.")
+			}
+		}
+		return nil
+	}
+	if err := util.Retry(t, checkCapacity, 10*time.Second, 30); err != nil {
+		t.Errorf("timed out waiting for driver installation to finish: %v", err)
+	}
+
+	// Make sure that CUDA workload can run.
+	workloadPath, err := filepath.Abs("testdata/cuda.yaml")
+	if err != nil {
+		t.Errorf("constructing path to cuda workload manifest: %v", err)
+	}
+	if _, err := kubectlRunner.RunCommand([]string{"create", "-f", workloadPath}); err != nil {
+		t.Errorf("creating cuda workload: %s", err)
+	}
+	if err := util.WaitForCudaSuccess(t); err != nil {
+		t.Errorf("waiting for cuda-vector-add to be done: %s", err)
+	}
+
+	// Check that stopping and restarting works when using --gpu.
+	checkStop := func() error {
+		runner.RunCommand("stop", true)
+		return runner.CheckStatusNoFail(state.Stopped.String())
+	}
+	if err := util.Retry(t, checkStop, 5*time.Second, 6); err != nil {
+		t.Fatalf("timed out while checking stopped status: %s", err)
+	}
+
+	runner.Start()
+	runner.CheckStatus(state.Running.String())
+
+	runner.RunCommand("delete", true)
+	runner.CheckStatus(state.None.String())
+}

--- a/test/integration/testdata/cuda.yaml
+++ b/test/integration/testdata/cuda.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cuda-vector-add
+  labels:
+    name: cuda-vector-add
+spec:
+  restartPolicy: Never
+  containers:
+    - name: cuda-vector-add
+      image: "k8s.gcr.io/cuda-vector-add:v0.1"
+      resources:
+        limits:
+          nvidia.com/gpu: 1

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -294,6 +294,48 @@ func WaitForNginxRunning(t *testing.T) error {
 	return nil
 }
 
+func WaitForNvidiaDriverInstallerRunning(t *testing.T) error {
+	client, err := commonutil.GetClient()
+	if err != nil {
+		return errors.Wrap(err, "getting kubernetes client")
+	}
+
+	selector := labels.SelectorFromSet(labels.Set(map[string]string{"k8s-app": "nvidia-driver-installer"}))
+	if err := commonutil.WaitForPodsWithLabelRunning(client, "kube-system", selector); err != nil {
+		return errors.Wrap(err, "waiting for nvidia-driver-installer")
+	}
+
+	return nil
+}
+
+func WaitForNvidiaGpuDevicePluginRunning(t *testing.T) error {
+	client, err := commonutil.GetClient()
+	if err != nil {
+		return errors.Wrap(err, "getting kubernetes client")
+	}
+
+	selector := labels.SelectorFromSet(labels.Set(map[string]string{"k8s-app": "nvidia-gpu-device-plugin"}))
+	if err := commonutil.WaitForPodsWithLabelRunning(client, "kube-system", selector); err != nil {
+		return errors.Wrap(err, "waiting for nvidia-gpu-device-plugin")
+	}
+
+	return nil
+}
+
+func WaitForCudaSuccess(t *testing.T) error {
+	client, err := commonutil.GetClient()
+	if err != nil {
+		return errors.Wrap(err, "getting kubernetes client")
+	}
+
+	selector := labels.SelectorFromSet(labels.Set(map[string]string{"name": "cuda-vector-add"}))
+	if err := commonutil.WaitForPodsWithLabelSucceeded(client, "default", selector); err != nil {
+		return errors.Wrap(err, "waiting for cuda-vector-add")
+	}
+
+	return nil
+}
+
 func Retry(t *testing.T, callback func() error, d time.Duration, attempts int) (err error) {
 	for i := 0; i < attempts; i++ {
 		err = callback()


### PR DESCRIPTION
Here's how I ran these locally:

    # Go to the directory with minikube src
    cd ~/go/src/k8s.io/minikube

    # Build the test binary
    make e2e-linux-amd64

    # Go the test/integration directory.
    # This was needed to get testdata working.
    cd test/integration

    # Run the tests.
    ../../out/e2e-linux-amd64 \
        -minikube-start-args="--vm-driver=kvm2 --gpu" \
        -minikube-args="--v=10 --logtostderr" \
        -test.v \
        -test.timeout=30m \
        -test.run .*Gpu.* \
        -binary=../../out/minikube-linux-amd64

@balopat @dlorenc @vishh @aaron-prindle 