### PR TITLE
Fix issue 2513

### DIFF
--- a/pkg/drivers/kvm/domain.go
+++ b/pkg/drivers/kvm/domain.go
@@ -98,7 +98,7 @@ $ sudo usermod -a -G libvirt $(whoami)
 # NOTE: For older Debian/Ubuntu versions change the group to [libvirtd]
 $ newgrp libvirt
 
-Visit https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm-driver for more information.
+Visit https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm2-driver for more information.
 `
 
 func randomMAC() (net.HardwareAddr, error) {

--- a/pkg/drivers/kvm/domain.go
+++ b/pkg/drivers/kvm/domain.go
@@ -62,7 +62,7 @@ const domainTmpl = `
     </interface>
     <interface type='network'>
       <source network='{{.PrivateNetwork}}'/>
-      <mac address='{{.MAC}}'/>
+      <mac address='{{.PrivateMAC}}'/>
       <model type='virtio'/>
     </interface>
     <serial type='pty'>
@@ -153,13 +153,20 @@ func closeDomain(dom *libvirt.Domain, conn *libvirt.Connect) error {
 
 func (d *Driver) createDomain() (*libvirt.Domain, error) {
 	// create random MAC addresses first for our NICs
-	// TODO: we use the same MAC addresses for both NICs
 	if d.MAC == "" {
 		mac, err := randomMAC()
 		if err != nil {
 			return nil, errors.Wrap(err, "generating mac address")
 		}
 		d.MAC = mac.String()
+	}
+
+	if d.PrivateMAC == "" {
+		mac, err := randomMAC()
+		if err != nil {
+			return nil, errors.Wrap(err, "generating mac address")
+		}
+		d.PrivateMAC = mac.String()
 	}
 
 	// create the XML for the domain using our domainTmpl template

--- a/pkg/drivers/kvm/kvm.go
+++ b/pkg/drivers/kvm/kvm.go
@@ -211,6 +211,12 @@ func (d *Driver) Restart() error {
 }
 
 func (d *Driver) Start() error {
+	log.Info("Ensuring networks are active...")
+	err := d.ensureNetwork()
+	if err != nil {
+		return errors.Wrap(err, "ensuring active networks")
+	}
+
 	log.Info("Getting domain xml...")
 	dom, conn, err := d.getDomain()
 	if err != nil {

--- a/pkg/drivers/kvm/kvm.go
+++ b/pkg/drivers/kvm/kvm.go
@@ -369,8 +369,7 @@ func (d *Driver) Remove() error {
 
 	// Tear down network if it exists and is not in use by another minikube instance
 	log.Debug("Trying to delete the networks (if possible)")
-	err = d.deleteNetwork()
-	if err != nil {
+	if err := d.deleteNetwork(); err != nil {
 		log.Warnf("Deleting of networks failed: %s", err.Error())
 	} else {
 		log.Info("Successfully deleted networks")

--- a/pkg/drivers/kvm/kvm.go
+++ b/pkg/drivers/kvm/kvm.go
@@ -66,6 +66,10 @@ type Driver struct {
 	// If empty, a random MAC will be generated.
 	MAC string
 
+	// The randomly generated MAC Address for the NIC attached to the private network
+	// If empty, a random MAC will be generated.
+	PrivateMAC string
+
 	// Whether to passthrough GPU devices from the host to the VM.
 	GPU bool
 

--- a/pkg/drivers/kvm/kvm.go
+++ b/pkg/drivers/kvm/kvm.go
@@ -215,8 +215,17 @@ func (d *Driver) Restart() error {
 }
 
 func (d *Driver) Start() error {
+	// if somebody/something deleted the network in the meantime,
+	// we might need to recreate it. It's (nearly) a noop if the network exists.
+	log.Info("Creating network...")
+	err := d.createNetwork()
+	if err != nil {
+		return errors.Wrap(err, "creating network")
+	}
+
+	// this call ensures that all networks are active
 	log.Info("Ensuring networks are active...")
-	err := d.ensureNetwork()
+	err = d.ensureNetwork()
 	if err != nil {
 		return errors.Wrap(err, "ensuring active networks")
 	}
@@ -358,18 +367,16 @@ func (d *Driver) Remove() error {
 	}
 	defer conn.Close()
 
-	//Tear down network and disk if they exist
-	log.Debug("Checking if the network needs to be deleted")
-	network, err := conn.LookupNetworkByName(d.PrivateNetwork)
+	// Tear down network if it exists and is not in use by another minikube instance
+	log.Debug("Trying to delete the networks (if possible)")
+	err = d.deleteNetwork()
 	if err != nil {
-		log.Warn("Network %s does not exist, nothing to clean up...", d.PrivateNetwork)
-	}
-	if network != nil {
-		log.Infof("Network %s exists, removing...", d.PrivateNetwork)
-		network.Destroy()
-		network.Undefine()
+		log.Warnf("Deleting of networks failed: %s", err.Error())
+	} else {
+		log.Info("Successfully deleted networks")
 	}
 
+	// Tear down the domain now
 	log.Debug("Checking if the domain needs to be deleted")
 	dom, err := conn.LookupDomainByName(d.MachineName)
 	if err != nil {

--- a/pkg/drivers/kvm/network.go
+++ b/pkg/drivers/kvm/network.go
@@ -187,7 +187,7 @@ func (d *Driver) deleteNetwork() error {
 
 	// fail if there are 0 domains
 	if len(doms) == 0 {
-		return fmt.Errorf("list of domains is 0 lenght")
+		log.Warn("list of domains is 0 length")
 	}
 
 	for _, dom := range doms {

--- a/pkg/drivers/kvm/network.go
+++ b/pkg/drivers/kvm/network.go
@@ -190,7 +190,7 @@ func (d *Driver) lookupIPFromStatusFile(conn *libvirt.Connect) (string, error) {
 
 	ipAddress := ""
 	for _, status := range statusEntries {
-		if status.MacAddress == d.MAC {
+		if status.MacAddress == d.PrivateMAC {
 			ipAddress = status.IPAddress
 		}
 	}
@@ -215,7 +215,7 @@ func (d *Driver) lookupIPFromLeasesFile() (string, error) {
 		if len(entry) != 5 {
 			return "", fmt.Errorf("Malformed leases entry: %s", entry)
 		}
-		if entry[1] == d.MAC {
+		if entry[1] == d.PrivateMAC {
 			ipAddress = entry[2]
 		}
 	}


### PR DESCRIPTION
This fixes issue #2513, and also effectively does the following:
- fixes creation of the private network
- separates activation and creation of networks
- ensures to generates separate MACs for the NICs
- fixed the documentation link
- hardens the deletion of the network: checks if it really is not used by any other VM, and only deletes it if this instance of the minikube VM is the last one using it

It's been a while that I've written these fixes, and because of the big delay on our company's side with signing the CNCF CLA, this PR comes rather late. I'm happy it's sorted out though, and I can create the PR. Looking over the code again though, it looks like everything is in place.

@tstromberg, fyi, as you wanted to be referenced