### PR TITLE
Initial support for Kubernetes 1.12+

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -126,7 +126,7 @@ func (k *KubeadmBootstrapper) StartCluster(k8s config.KubernetesConfig) error {
 			semver.MustParse("1.9.0-alpha.0"),
 			semver.Version{}),
 		Preflights: constants.Preflights,
-		DNSAddon: "kube-dns",
+		DNSAddon:   "kube-dns",
 	}
 	if version.GTE(semver.MustParse("1.12.0")) {
 		templateContext.DNSAddon = "coredns"

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -119,12 +119,17 @@ func (k *KubeadmBootstrapper) StartCluster(k8s config.KubernetesConfig) error {
 		KubeadmConfigFile   string
 		SkipPreflightChecks bool
 		Preflights          []string
+		DNSAddon            string
 	}{
 		KubeadmConfigFile: constants.KubeadmConfigFile,
 		SkipPreflightChecks: !VersionIsBetween(version,
 			semver.MustParse("1.9.0-alpha.0"),
 			semver.Version{}),
 		Preflights: constants.Preflights,
+		DNSAddon: "kube-dns",
+	}
+	if version.GTE(semver.MustParse("1.12.0")) {
+		templateContext.DNSAddon = "coredns"
 	}
 	if err := kubeadmInitTemplate.Execute(&b, templateContext); err != nil {
 		return err
@@ -380,7 +385,7 @@ func generateConfig(k8s config.KubernetesConfig) (string, error) {
 		NodeName:          k8s.NodeName,
 		ExtraArgs:         extraComponentConfig,
 		FeatureArgs:       kubeadmFeatureArgs,
-		NoTaintMaster:     false,
+		NoTaintMaster:     false, // That does not work with k8s 1.12+
 	}
 
 	if version.GTE(semver.MustParse("1.10.0-alpha.0")) {
@@ -388,6 +393,10 @@ func generateConfig(k8s config.KubernetesConfig) (string, error) {
 	}
 
 	b := bytes.Buffer{}
+	kubeadmConfigTemplate := kubeadmConfigTemplateV1Alpha1
+	if version.GTE(semver.MustParse("1.12.0")) {
+		kubeadmConfigTemplate = kubeadmConfigTemplateV1Alpha3
+	}
 	if err := kubeadmConfigTemplate.Execute(&b, opts); err != nil {
 		return "", err
 	}

--- a/pkg/minikube/bootstrapper/kubeadm/templates.go
+++ b/pkg/minikube/bootstrapper/kubeadm/templates.go
@@ -22,7 +22,7 @@ import (
 	"text/template"
 )
 
-var kubeadmConfigTemplate = template.Must(template.New("kubeadmConfigTemplate").Funcs(template.FuncMap{
+var kubeadmConfigTemplateV1Alpha1 = template.Must(template.New("kubeadmConfigTemplate-v1alpha1").Funcs(template.FuncMap{
 	"printMapInOrder": printMapInOrder,
 }).Parse(`apiVersion: kubeadm.k8s.io/v1alpha1
 kind: MasterConfiguration
@@ -43,6 +43,45 @@ nodeName: {{.NodeName}}
 {{end}}{{if .FeatureArgs}}featureGates: {{range $i, $val := .FeatureArgs}}
   {{$i}}: {{$val}}{{end}}
 {{end}}`))
+
+var kubeadmConfigTemplateV1Alpha3 = template.Must(template.New("kubeadmConfigTemplate-v1alpha3").Funcs(template.FuncMap{
+  "printMapInOrder": printMapInOrder,
+}).Parse(`apiEndpoint:
+  advertiseAddress: {{.AdvertiseAddress}}
+  bindPort: {{.APIServerPort}}
+apiVersion: kubeadm.k8s.io/v1alpha3
+bootstrapTokens:
+- groups:
+  - system:bootstrappers:kubeadm:default-node-token
+  token: 599s02.8i3w2yyyay8t0onm
+  ttl: 24h0m0s
+  usages:
+  - signing
+  - authentication
+kind: InitConfiguration
+nodeRegistration:
+  criSocket: /var/run/dockershim.sock
+  name: {{.NodeName}}
+  taints: []
+---
+{{range .ExtraArgs}}{{.Component}}:{{range $i, $val := printMapInOrder .Options ": " }}
+  {{$val}}{{end}}
+{{end}}{{if .FeatureArgs}}featureGates: {{range $i, $val := .FeatureArgs}}
+  {{$i}}: {{$val}}{{end}}
+{{end}}
+apiVersion: kubeadm.k8s.io/v1alpha3
+certificatesDir: {{.CertDir}}
+clusterName: kubernetes
+controlPlaneEndpoint: localhost:{{.APIServerPort}}
+etcd:
+  local:
+    dataDir: {{.EtcdDataDir}}
+kind: ClusterConfiguration
+kubernetesVersion: {{.KubernetesVersion}}
+networking:
+  dnsDomain: cluster.local
+  podSubnet: ""
+  serviceSubnet: {{.ServiceCIDR}}`))
 
 var kubeletSystemdTemplate = template.Must(template.New("kubeletSystemdTemplate").Parse(`
 [Unit]
@@ -79,7 +118,7 @@ sudo /usr/bin/kubeadm alpha phase etcd local --config {{.KubeadmConfigFile}}
 
 var kubeadmInitTemplate = template.Must(template.New("kubeadmInitTemplate").Parse(`
 sudo /usr/bin/kubeadm init --config {{.KubeadmConfigFile}} {{if .SkipPreflightChecks}}--skip-preflight-checks{{else}}{{range .Preflights}}--ignore-preflight-errors={{.}} {{end}}{{end}} &&
-sudo /usr/bin/kubeadm alpha phase addon kube-dns
+sudo /usr/bin/kubeadm alpha phase addon {{ .DNSAddon }}
 `))
 
 // printMapInOrder sorts the keys and prints the map in order, combining key

--- a/pkg/minikube/bootstrapper/kubeadm/templates.go
+++ b/pkg/minikube/bootstrapper/kubeadm/templates.go
@@ -45,7 +45,7 @@ nodeName: {{.NodeName}}
 {{end}}`))
 
 var kubeadmConfigTemplateV1Alpha3 = template.Must(template.New("kubeadmConfigTemplate-v1alpha3").Funcs(template.FuncMap{
-  "printMapInOrder": printMapInOrder,
+	"printMapInOrder": printMapInOrder,
 }).Parse(`apiEndpoint:
   advertiseAddress: {{.AdvertiseAddress}}
   bindPort: {{.APIServerPort}}

--- a/pkg/minikube/bootstrapper/kubeadm/templates.go
+++ b/pkg/minikube/bootstrapper/kubeadm/templates.go
@@ -53,7 +53,6 @@ apiVersion: kubeadm.k8s.io/v1alpha3
 bootstrapTokens:
 - groups:
   - system:bootstrappers:kubeadm:default-node-token
-  token: 599s02.8i3w2yyyay8t0onm
   ttl: 24h0m0s
   usages:
   - signing

--- a/pkg/minikube/bootstrapper/kubeadm/versions.go
+++ b/pkg/minikube/bootstrapper/kubeadm/versions.go
@@ -260,7 +260,7 @@ var versionSpecificOpts = []VersionedExtraOption{
 		GreaterThanOrEqual: semver.MustParse("1.11.0-alpha.0"),
 	},
 	{
- 		Option: util.ExtraOption{
+		Option: util.ExtraOption{
 			Component: Kubelet,
 			Key:       "cadvisor-port",
 			Value:     "0",

--- a/pkg/minikube/bootstrapper/kubeadm/versions.go
+++ b/pkg/minikube/bootstrapper/kubeadm/versions.go
@@ -241,7 +241,6 @@ var versionSpecificOpts = []VersionedExtraOption{
 	NewUnversionedOption(Kubelet, "client-ca-file", path.Join(util.DefaultCertPath, "ca.crt")),
 
 	// Cgroup args
-	NewUnversionedOption(Kubelet, "cadvisor-port", "0"),
 	NewUnversionedOption(Kubelet, "cgroup-driver", "cgroupfs"),
 	{
 		Option: util.ExtraOption{
@@ -259,6 +258,14 @@ var versionSpecificOpts = []VersionedExtraOption{
 			Value:     strings.Join(util.DefaultAdmissionControllers, ","),
 		},
 		GreaterThanOrEqual: semver.MustParse("1.11.0-alpha.0"),
+	},
+	{
+ 		Option: util.ExtraOption{
+			Component: Kubelet,
+			Key:       "cadvisor-port",
+			Value:     "0",
+		},
+		LessThanOrEqual: semver.MustParse("1.11.1000"),
 	},
 }
 

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -119,7 +119,7 @@ const (
 var DefaultIsoUrl = fmt.Sprintf("https://storage.googleapis.com/%s/minikube-%s.iso", minikubeVersion.GetIsoPath(), minikubeVersion.GetIsoVersion())
 var DefaultIsoShaUrl = DefaultIsoUrl + ShaSuffix
 
-var DefaultKubernetesVersion = "v1.10.0"
+var DefaultKubernetesVersion = "v1.12.0"
 
 var ConfigFilePath = MakeMiniPath("config")
 var ConfigFile = MakeMiniPath("config", "config.json")

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -119,7 +119,7 @@ const (
 var DefaultIsoUrl = fmt.Sprintf("https://storage.googleapis.com/%s/minikube-%s.iso", minikubeVersion.GetIsoPath(), minikubeVersion.GetIsoVersion())
 var DefaultIsoShaUrl = DefaultIsoUrl + ShaSuffix
 
-var DefaultKubernetesVersion = "v1.12.0"
+var DefaultKubernetesVersion = "v1.10.0"
 
 var ConfigFilePath = MakeMiniPath("config")
 var ConfigFile = MakeMiniPath("config", "config.json")


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/3164

Support for k8s 1.12+, also keeping support for old versions of k8s.

See this comment for the list of incompatibilities with 1.12 https://github.com/kubernetes/minikube/issues/3164#issuecomment-425327164

1. It uses `kubeadm.k8s.io/v1alpha1` for kubeadm. Kubernetes 1.12 does not support version `v1alpha1`. Only `v1alpha2`. The recommended version is `v1alpha3`. I used `kubeadm config  upgrade ...` to convert v1alpha1 to v1alpha1 and to v1alpha3.

2. This addon is not available `/usr/bin/kubeadm alpha phase addon kube-dns`, I guess it should use `coredns` instead (change in kubeadm to change `kube-dns` to `coredns `)

3. The argument `cadvisor-port` is not available in k8s-1.12