### PR TITLE
Improve the default crio-bin configuration

### DIFF
--- a/deploy/iso/minikube-iso/package/automount/minikube-automount
+++ b/deploy/iso/minikube-iso/package/automount/minikube-automount
@@ -124,6 +124,10 @@ if [ -n "$BOOT2DOCKER_DATA" ]; then
     mkdir -p /var/lib/docker
     mount --bind /mnt/$PARTNAME/var/lib/docker /var/lib/docker
 
+    mkdir -p /mnt/$PARTNAME/var/lib/containers
+    mkdir -p /var/lib/containers
+    mount --bind /mnt/$PARTNAME/var/lib/containers /var/lib/containers
+
     mkdir -p /mnt/$PARTNAME/var/log
     mkdir /var/log
     mount --bind /mnt/$PARTNAME/var/log /var/log

--- a/deploy/iso/minikube-iso/package/crio-bin/crio-bin.mk
+++ b/deploy/iso/minikube-iso/package/crio-bin/crio-bin.mk
@@ -58,7 +58,7 @@ define CRIO_BIN_INSTALL_TARGET_CMDS
 		$(TARGET_DIR)/etc/containers/policy.json
 
 	mkdir -p $(TARGET_DIR)/etc/sysconfig
-	echo 'CRIO_OPTIONS="--storage-driver=overlay2 --log-level=debug"' > $(TARGET_DIR)/etc/sysconfig/crio
+	echo 'CRIO_OPTIONS="--log-level=debug"' > $(TARGET_DIR)/etc/sysconfig/crio
 endef
 
 define CRIO_BIN_INSTALL_INIT_SYSTEMD

--- a/deploy/iso/minikube-iso/package/crio-bin/crio.conf
+++ b/deploy/iso/minikube-iso/package/crio-bin/crio.conf
@@ -146,6 +146,7 @@ insecure_registries = [
 # registries is used to specify a comma separated list of registries to be used
 # when pulling an unqualified image (e.g. fedora:rawhide).
 registries = [
+	"docker.io"
 ]
 
 # The "crio.network" table contains settings pertaining to the

--- a/deploy/iso/minikube-iso/package/crio-bin/crio.conf
+++ b/deploy/iso/minikube-iso/package/crio-bin/crio.conf
@@ -12,7 +12,7 @@ runroot = "/var/run/containers/storage"
 
 # storage_driver select which storage driver is used to manage storage
 # of images and containers.
-storage_driver = ""
+storage_driver = "overlay"
 
 # storage_option is used to pass an option to the storage driver.
 storage_option = [

--- a/deploy/iso/minikube-iso/package/crio-bin/crio.service
+++ b/deploy/iso/minikube-iso/package/crio-bin/crio.service
@@ -10,11 +10,9 @@ EnvironmentFile=-/etc/sysconfig/crio
 EnvironmentFile=-/etc/sysconfig/crio.minikube
 EnvironmentFile=/var/run/minikube/env
 Environment=GOTRACEBACK=crash
-ExecStartPre=/bin/mkdir -p ${PERSISTENT_DIR}/var/lib/containers
 ExecStart=/usr/bin/crio \
     $CRIO_OPTIONS \
-    $CRIO_MINIKUBE_OPTIONS \
-    --root ${PERSISTENT_DIR}/var/lib/containers
+    $CRIO_MINIKUBE_OPTIONS
 ExecReload=/bin/kill -s HUP $MAINPID
 TasksMax=8192
 LimitNOFILE=1048576


### PR DESCRIPTION
Cherry-picked some of the podman changes, since they are really for crio-bin. (#2757)

* use the standard directory and a bind-mount, instead of a prefixed storage directory

* add the standard docker registry, so that you can run/pull images (like e.g. busybox)

We also need the crictl.yaml fixes, but that needs to be versioned on the CRI (#3043)
