### PR TITLE
Remove the explicit --bootstrapper=kubeadm in docs

### DIFF
--- a/docs/alternative_runtimes.md
+++ b/docs/alternative_runtimes.md
@@ -16,8 +16,7 @@ To use [CRI-O](https://github.com/kubernetes-incubator/cri-o) as the container r
 ```shell
 $ minikube start \
     --network-plugin=cni \
-    --container-runtime=cri-o \
-    --bootstrapper=kubeadm
+    --container-runtime=cri-o
 ```
 
 Or you can use the extended version:
@@ -27,8 +26,7 @@ $ minikube start \
     --network-plugin=cni \
     --extra-config=kubelet.container-runtime=remote \
     --extra-config=kubelet.container-runtime-endpoint=/var/run/crio/crio.sock \
-    --extra-config=kubelet.image-service-endpoint=/var/run/crio/crio.sock \
-    --bootstrapper=kubeadm
+    --extra-config=kubelet.image-service-endpoint=/var/run/crio/crio.sock
 ```
 
 ### Using containerd
@@ -38,8 +36,7 @@ To use [containerd](https://github.com/containerd/containerd) as the container r
 ```shell
 $ minikube start \
     --network-plugin=cni \
-    --container-runtime=containerd \
-    --bootstrapper=kubeadm
+    --container-runtime=containerd
 ```
 
 Or you can use the extended version:
@@ -49,6 +46,5 @@ $ minikube start \
     --network-plugin=cni \
     --extra-config=kubelet.container-runtime=remote \
     --extra-config=kubelet.container-runtime-endpoint=unix:///run/containerd/containerd.sock \
-    --extra-config=kubelet.image-service-endpoint=unix:///run/containerd/containerd.sock \
-    --bootstrapper=kubeadm
+    --extra-config=kubelet.image-service-endpoint=unix:///run/containerd/containerd.sock
 ```


### PR DESCRIPTION
There is only one bootstrapper left anyway