### PR TITLE
Write /etc/crictl.yaml when starting

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -99,6 +99,22 @@ assumes you have already installed one of the VM drivers: virtualbox/vmwarefusio
 	Run: runStart,
 }
 
+// SetContainerRuntime possibly sets the container runtime
+func SetContainerRuntime(cfg map[string]string, runtime string) map[string]string {
+	switch runtime {
+	case "crio", "cri-o":
+		cfg["runtime-endpoint"] = "unix:///var/run/crio/crio.sock"
+		cfg["image-endpoint"] = "unix:///var/run/crio/crio.sock"
+	case "containerd":
+		cfg["runtime-endpoint"] = "unix:///run/containerd/containerd.sock"
+		cfg["image-endpoint"] = "unix:///run/containerd/containerd.sock"
+	default:
+		return nil
+	}
+
+	return cfg
+}
+
 func runStart(cmd *cobra.Command, args []string) {
 	if glog.V(8) {
 		glog.Infoln("Viper configuration:")
@@ -203,6 +219,20 @@ func runStart(cmd *cobra.Command, args []string) {
 		cmdutil.MaybeReportErrorAndExit(err)
 	}
 
+	// common config (currently none)
+	var cricfg = map[string]string{}
+	selectedContainerRuntime := viper.GetString(containerRuntime)
+	if cricfg := SetContainerRuntime(cricfg, selectedContainerRuntime); cricfg != nil {
+		var command string
+		fmt.Println("Writing crictl config...")
+		if command, err = cmdutil.GetCrictlConfigCommand(cricfg); err == nil {
+			_, err = host.RunSSHCommand(command)
+		}
+		if err != nil {
+			glog.Errorln("Error writing crictl config: ", err)
+		}
+	}
+
 	selectedKubernetesVersion := viper.GetString(kubernetesVersion)
 	if strings.Compare(selectedKubernetesVersion, "") == 0 {
 		selectedKubernetesVersion = constants.DefaultKubernetesVersion
@@ -235,7 +265,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		APIServerIPs:           apiServerIPs,
 		DNSDomain:              viper.GetString(dnsDomain),
 		FeatureGates:           viper.GetString(featureGates),
-		ContainerRuntime:       viper.GetString(containerRuntime),
+		ContainerRuntime:       selectedContainerRuntime,
 		CRISocket:              viper.GetString(criSocket),
 		NetworkPlugin:          viper.GetString(networkPlugin),
 		ServiceCIDR:            viper.GetString(serviceCIDR),
@@ -310,8 +340,7 @@ func runStart(cmd *cobra.Command, args []string) {
 
 	fmt.Println("Stopping extra container runtimes...")
 
-	containerRuntime := viper.GetString(containerRuntime)
-	if config.VMDriver != constants.DriverNone && containerRuntime != "" {
+	if config.VMDriver != constants.DriverNone && selectedContainerRuntime != "" {
 		if _, err := host.RunSSHCommand("sudo systemctl stop docker"); err == nil {
 			_, err = host.RunSSHCommand("sudo systemctl stop docker.socket")
 		}
@@ -319,12 +348,12 @@ func runStart(cmd *cobra.Command, args []string) {
 			glog.Errorf("Error stopping docker: %v", err)
 		}
 	}
-	if config.VMDriver != constants.DriverNone && (containerRuntime != constants.CrioRuntime && containerRuntime != constants.Cri_oRuntime) {
+	if config.VMDriver != constants.DriverNone && (selectedContainerRuntime != constants.CrioRuntime && selectedContainerRuntime != constants.Cri_oRuntime) {
 		if _, err := host.RunSSHCommand("sudo systemctl stop crio"); err != nil {
 			glog.Errorf("Error stopping crio: %v", err)
 		}
 	}
-	if config.VMDriver != constants.DriverNone && containerRuntime != constants.RktRuntime {
+	if config.VMDriver != constants.DriverNone && selectedContainerRuntime != constants.RktRuntime {
 		if _, err := host.RunSSHCommand("sudo systemctl stop rkt-api"); err == nil {
 			_, err = host.RunSSHCommand("sudo systemctl stop rkt-metadata")
 		}
@@ -333,7 +362,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	if config.VMDriver != constants.DriverNone && containerRuntime == constants.ContainerdRuntime {
+	if config.VMDriver != constants.DriverNone && selectedContainerRuntime == constants.ContainerdRuntime {
 		fmt.Println("Restarting containerd runtime...")
 		// restart containerd so that it can install all plugins
 		if _, err := host.RunSSHCommand("sudo systemctl restart containerd"); err != nil {

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -27,9 +27,11 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"text/template"
 	"time"
 
 	"strconv"
@@ -218,6 +220,33 @@ minikube config set WantKubectlDownloadMsg false
 `,
 			verb, fmt.Sprintf(installInstructions, constants.DefaultKubernetesVersion, goos, runtime.GOARCH))
 	}
+}
+
+// Return a command to run, that will generate the crictl config file
+func GetCrictlConfigCommand(cfg map[string]string) (string, error) {
+	var (
+		crictlYamlTmpl = `runtime-endpoint: {{.RuntimeEndpoint}}
+image-endpoint: {{.ImageEndpoint}}
+`
+		crictlYamlPath = "/etc/crictl.yaml"
+	)
+	t, err := template.New("crictlYaml").Parse(crictlYamlTmpl)
+	if err != nil {
+		return "", err
+	}
+	opts := struct {
+		RuntimeEndpoint string
+		ImageEndpoint   string
+	}{
+		RuntimeEndpoint: cfg["runtime-endpoint"],
+		ImageEndpoint:   cfg["image-endpoint"],
+	}
+	var crictlYamlBuf bytes.Buffer
+	if err := t.Execute(&crictlYamlBuf, opts); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("sudo mkdir -p %s && printf %%s \"%s\" | sudo tee %s", path.Dir(crictlYamlPath), crictlYamlBuf.String(), crictlYamlPath), nil
 }
 
 // Ask the kernel for a free open port that is ready to use

--- a/docs/alternative_runtimes.md
+++ b/docs/alternative_runtimes.md
@@ -27,6 +27,7 @@ Or you can use the extended version:
 $ minikube start \
     --network-plugin=cni \
     --enable-default-cni \
+    --container-runtime=cri-o \
     --cri-socket=/var/run/crio/crio.sock \
     --extra-config=kubelet.container-runtime=remote \
     --extra-config=kubelet.container-runtime-endpoint=unix:///var/run/crio/crio.sock \
@@ -50,6 +51,7 @@ Or you can use the extended version:
 $ minikube start \
     --network-plugin=cni \
     --enable-default-cni \
+    --container-runtime=containerd \
     --cri-socket=/run/containerd/containerd.sock \
     --extra-config=kubelet.container-runtime=remote \
     --extra-config=kubelet.container-runtime-endpoint=unix:///run/containerd/containerd.sock \


### PR DESCRIPTION
This cannot be done by the provisioner (buildroot), since it only knows docker

And it needs to be done before the bootstrapper (kubeadm), as a pre-requisite

Closes #3043