### PR TITLE
Output the gofmt diff as well as the affected files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os: linux
 sudo: required
 
 go:
-  - 1.10.x
+  - 1.x
 go_import_path: k8s.io/minikube
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os: linux
 sudo: required
 
 go:
-  - 1.x
+  - 1.10.x
 go_import_path: k8s.io/minikube
 
 install:

--- a/test.sh
+++ b/test.sh
@@ -53,7 +53,6 @@ set -e
 if [[ $files ]]; then
   gofmt -d ${files}
   echo "Gofmt errors in files: $files"
-
   exit 1
 fi
 

--- a/test.sh
+++ b/test.sh
@@ -48,10 +48,12 @@ ignore="vendor\|\_gopath\|assets.go\|out"
 # Check gofmt
 echo "Checking gofmt..."
 set +e
-files=$(gofmt -d -s . | grep -v ${ignore})
+files=$(gofmt -l -s . | grep -v ${ignore})
 set -e
 if [[ $files ]]; then
+  gofmt -d ${files}
   echo "Gofmt errors in files: $files"
+
   exit 1
 fi
 

--- a/test.sh
+++ b/test.sh
@@ -48,7 +48,7 @@ ignore="vendor\|\_gopath\|assets.go\|out"
 # Check gofmt
 echo "Checking gofmt..."
 set +e
-files=$(gofmt -l -s . | grep -v ${ignore})
+files=$(gofmt -d -s . | grep -v ${ignore})
 set -e
 if [[ $files ]]; then
   echo "Gofmt errors in files: $files"


### PR DESCRIPTION
This makes it easier for contributors to debug gofmt issues, particularly when their version of gofmt differs from what is configured in Travis.