### PR TITLE
Fix broken TestFunctional/EnvVars test when run under non-bash shell.

### DIFF
--- a/test/integration/cluster_env_test.go
+++ b/test/integration/cluster_env_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package integration
 
 import (
+	"os"
 	"os/exec"
 	"testing"
 	"time"
@@ -26,16 +27,30 @@ import (
 	"k8s.io/minikube/test/integration/util"
 )
 
+// Assert that docker-env subcommand outputs usable information for "docker ps"
 func testClusterEnv(t *testing.T) {
 	t.Parallel()
 
-	minikubeRunner := NewMinikubeRunner(t)
+	r := NewMinikubeRunner(t)
 
-	dockerEnvVars := minikubeRunner.RunCommand("docker-env", true)
-	if err := minikubeRunner.SetEnvFromEnvCmdOutput(dockerEnvVars); err != nil {
-		t.Fatalf("Error parsing output: %s", err)
+	// Set a specific shell syntax so that we don't have to handle every possible user shell
+	envOut := r.RunCommand("docker-env --shell=bash", true)
+	vars := r.ParseEnvCmdOutput(envOut)
+	if len(vars) == 0 {
+		t.Fatalf("Failed to parse env vars:\n%s", envOut)
 	}
+	for k, v := range vars {
+		t.Logf("Found: %s=%s", k, v)
+		if err := os.Setenv(k, v); err != nil {
+			t.Errorf("failed to set %s=%s: %v", k, v, err)
+		}
+	}
+
 	path, err := exec.LookPath("docker")
+	if err != nil {
+		t.Fatalf("Unable to complete test: docker is not installed in PATH")
+	}
+	t.Logf("Using docker installed at %s", path)
 
 	var output []byte
 	dockerPs := func() error {

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -114,19 +113,14 @@ func (m *MinikubeRunner) EnsureRunning() {
 	m.CheckStatus("Running")
 }
 
-func (m *MinikubeRunner) SetEnvFromEnvCmdOutput(dockerEnvVars string) error {
+// ParseEnvCmdOutput parses the output of `env` (assumes bash)
+func (m *MinikubeRunner) ParseEnvCmdOutput(out string) map[string]string {
+	env := map[string]string{}
 	re := regexp.MustCompile(`(\w+?) ?= ?"?(.+?)"?\n`)
-	matches := re.FindAllStringSubmatch(dockerEnvVars, -1)
-	seenEnvVar := false
-	for _, m := range matches {
-		seenEnvVar = true
-		key, val := m[1], m[2]
-		os.Setenv(key, val)
+	for _, m := range re.FindAllStringSubmatch(out, -1) {
+		env[m[1]] = m[2]
 	}
-	if !seenEnvVar {
-		return fmt.Errorf("Error: No environment variables were found in docker-env command output: %s", dockerEnvVars)
-	}
-	return nil
+	return env
 }
 
 func (m *MinikubeRunner) GetStatus() string {


### PR DESCRIPTION
Make future failures to this test easier to debug. Here's an example of
the test failure I ran into:

    --- FAIL: TestFunctional/EnvVars (0.58s)
        cluster_env_test.go:36: SetEnvFromEnvCmdOutput: Error: No variables were parsed from docker-env output:
            set -gx DOCKER_TLS_VERIFY "1";
            set -gx DOCKER_HOST "tcp://192.168.39.199:2376";
            set -gx DOCKER_CERT_PATH "/usr/local/google/home/tstromberg/.minikube/certs";
            set -gx DOCKER_API_VERSION "1.35";
            # Run this command to configure your shell:
            # eval (minikube docker-env)