### PR TITLE
Avoid out directory, when listing test files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ HYPERKIT_FILES := ./cmd/drivers/hyperkit
 STORAGE_PROVISIONER_FILES := ./cmd/storage-provisioner
 KVM_DRIVER_FILES := ./cmd/drivers/kvm/
 
-MINIKUBE_TEST_FILES := ./...
+MINIKUBE_TEST_FILES := ./cmd/... ./pkg/...
 
 MINIKUBE_BUILD_TAGS := container_image_ostree_stub containers_image_openpgp
 MINIKUBE_INTEGRATION_BUILD_TAGS := integration $(MINIKUBE_BUILD_TAGS)
@@ -93,7 +93,7 @@ out/minikube-windows-amd64.exe: out/minikube-windows-amd64
 	cp out/minikube-windows-amd64 out/minikube-windows-amd64.exe
 
 out/minikube.d: pkg/minikube/assets/assets.go
-	$(MAKEDEPEND) out/minikube-$(GOOS)-$(GOARCH) $(ORG) $(MINIKUBEFILES) $^ > $@
+	$(MAKEDEPEND) out/minikube-$(GOOS)-$(GOARCH) $(ORG) $^ $(MINIKUBEFILES) > $@
 
 -include out/minikube.d
 out/minikube-%-$(GOARCH): pkg/minikube/assets/assets.go
@@ -188,7 +188,7 @@ integration-versioned: out/minikube
 
 .PHONY: test
 out/test.d: pkg/minikube/assets/assets.go
-	$(MAKEDEPEND) -t test $(ORG) $(MINIKUBE_TEST_FILES) $^ > $@
+	$(MAKEDEPEND) -t test $(ORG) $^ $(MINIKUBE_TEST_FILES) > $@
 
 -include out/test.d
 test:
@@ -262,7 +262,7 @@ out/minikube-installer.exe: out/minikube-windows-amd64.exe
 	rm -rf out/windows_tmp
 
 out/docker-machine-driver-hyperkit.d:
-	$(MAKEDEPEND) out/docker-machine-driver-hyperkit $(ORG) $(HYPERKIT_FILES) $^ > $@
+	$(MAKEDEPEND) out/docker-machine-driver-hyperkit $(ORG) $^ $(HYPERKIT_FILES) > $@
 
 -include out/docker-machine-driver-hyperkit.d
 out/docker-machine-driver-hyperkit:
@@ -289,7 +289,7 @@ $(ISO_BUILD_IMAGE): deploy/iso/minikube-iso/Dockerfile
 	@echo "$(@) successfully built"
 
 out/storage-provisioner.d:
-	$(MAKEDEPEND) out/storage-provisioner $(ORG) $(STORAGE_PROVISIONER_FILES) $^ > $@
+	$(MAKEDEPEND) out/storage-provisioner $(ORG) $^ $(STORAGE_PROVISIONER_FILES) > $@
 
 -include out/storage-provisioner.d
 out/storage-provisioner:
@@ -314,7 +314,7 @@ release-minikube: out/minikube checksum
 	gsutil cp out/minikube-$(GOOS)-$(GOARCH).sha256 $(MINIKUBE_UPLOAD_LOCATION)/$(MINIKUBE_VERSION)/minikube-$(GOOS)-$(GOARCH).sha256
 
 out/docker-machine-driver-kvm2.d:
-	$(MAKEDEPEND) out/docker-machine-driver-kvm2 $(ORG) $(KVM_DRIVER_FILES) $^ > $@
+	$(MAKEDEPEND) out/docker-machine-driver-kvm2 $(ORG) $^ $(KVM_DRIVER_FILES) > $@
 
 -include out/docker-machine-driver-kvm2.d
 out/docker-machine-driver-kvm2:

--- a/makedepend.sh
+++ b/makedepend.sh
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Generate go dependencies, for make. Uses `go list".
-# Usage: makedepend.sh [-t] output package path [extra]
+# Generate go dependencies, for make. Uses `go list`.
+# Usage: makedepend.sh [-t] output package extra path...
 
 PATH_FORMAT='{{ .ImportPath }}{{"\n"}}{{join .Deps "\n"}}'
 FILE_FORMAT='{{ range $file := .GoFiles }} {{$.Dir}}/{{$file}}{{"\n"}}{{end}}'
@@ -28,14 +28,14 @@ fi
 
 out=$1
 pkg=$2
-path=$3
-extra=$4
+extra=$3
+paths="$4 $5 $6"
 
 # check for mandatory parameters
-test -n "$out$pkg$path" || exit 1
+test -n "$out$pkg$paths" || exit 1
 
 echo "$out: $extra\\"
-go list -f "$PATH_FORMAT" $path |
+go list -f "$PATH_FORMAT" $paths |
   grep "$pkg" |
   xargs go list -f "$FILE_FORMAT" |
   sed -e "s|^ ${GOPATH}| \$(GOPATH)|;s/$/ \\\\/"

--- a/test.sh
+++ b/test.sh
@@ -34,7 +34,7 @@ echo "Running go tests..."
 cd ${GOPATH}/src/${REPO_PATH}
 rm -f out/$COV_FILE || true
 echo "mode: count" > out/$COV_FILE
-for pkg in $(go list -f '{{ if .TestGoFiles }} {{.ImportPath}} {{end}}' ./...); do
+for pkg in $(go list -f '{{ if .TestGoFiles }} {{.ImportPath}} {{end}}' ./cmd/... ./pkg/...); do
     go test -tags "container_image_ostree_stub containers_image_openpgp" -v $pkg -covermode=count -coverprofile=out/$COV_TMP_FILE
     # tail -n +2 skips the first line of the file
     # for coverprofile the first line is the `mode: count` line which we only want once in our file


### PR DESCRIPTION
Especially out/buildroot takes ages to "go list".
Literally 5 minutes, for my 16 GB directory...

So list "cmd" and "pkg" explicitly, to avoid "out".
Unfortunately only "vendor" is allowed to exclude.