### PR TITLE
Fix Windows cache path issues with directory hierarchies and lower-case drive letters

### DIFF
--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -144,7 +144,7 @@ func hasWindowsDriveLetter(s string) bool {
 	}
 
 	drive := s[:3]
-	for _, b := range "CDEFGHIJKLMNOPQRSTUVWXYZAB" {
+	for _, b := range "CDEFGHIJKLMNOPQRSTUVWXYZABcdefghijklmnopqrstuvwxyzab" {
 		if d := string(b) + ":"; drive == d+`\` || drive == d+`/` {
 			return true
 		}
@@ -160,9 +160,6 @@ func replaceWinDriveLetterToVolumeName(s string) (string, error) {
 		return "", err
 	}
 	path := vname + s[3:]
-	if _, err := os.Stat(filepath.Dir(path)); err != nil {
-		return "", err
-	}
 
 	return path, nil
 }


### PR DESCRIPTION
Fixes the issues related to image caching which are noted in https://github.com/kubernetes/minikube/issues/3250. Specifically, image caching fails due to: (1) failing to cache an image with multiple levels in its hierachy e.g.  ...\cache\images\gcr.io\k8s-minikube\storage-provisioner_v1.8.1; 2) failing to cache an image when a lowercase drive letter is used in the cache's path.

