### PR TITLE
Rework version handling to be less brittle and more consistent.

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -84,8 +84,9 @@ var settings = []Setting{
 		validations: []setFn{IsValidPath},
 	},
 	{
-		name: "kubernetes-version",
-		set:  SetString,
+		name:        "kubernetes-version",
+		set:         SetString,
+		validations: []setFn{IsValidVersion},
 	},
 	{
 		name:        "iso-url",

--- a/cmd/minikube/cmd/config/validations.go
+++ b/cmd/minikube/cmd/config/validations.go
@@ -22,11 +22,14 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 
+	"github.com/blang/semver"
 	units "github.com/docker/go-units"
 	"github.com/pkg/errors"
 	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/version"
 )
 
 func IsValidDriver(string, driver string) error {
@@ -91,4 +94,12 @@ func IsValidAddon(name string, val string) error {
 		return nil
 	}
 	return errors.Errorf("Cannot enable/disable invalid addon %s", name)
+}
+
+func IsValidVersion(name string, val string) error {
+	_, err := semver.Make(strings.TrimPrefix(val, version.VersionPrefix))
+	if err != nil {
+		return fmt.Errorf("%s is not a valid Kubernetes version", val)
+	}
+	return nil
 }

--- a/cmd/minikube/cmd/config/validations_test.go
+++ b/cmd/minikube/cmd/config/validations_test.go
@@ -94,3 +94,42 @@ func TestValidCIDR(t *testing.T) {
 
 	runValidations(t, tests, "cidr", IsValidCIDR)
 }
+
+func TestValidVersion(t *testing.T) {
+	var tests = []validationTest{
+		{
+			value:     "v1.12.1",
+			shouldErr: false,
+		},
+		{
+			value:     "1.12.1",
+			shouldErr: false,
+		},
+		{
+			value:     "1.8.0-alpha.5",
+			shouldErr: false,
+		},
+		{
+			value:     "v1.8.0-alpha.5",
+			shouldErr: false,
+		},
+		{
+			value:     "x99",
+			shouldErr: true,
+		},
+		{
+			value:     "12.1",
+			shouldErr: true,
+		},
+		{
+			value:     "fnord",
+			shouldErr: true,
+		},
+		{
+			value:     "this.that.theother",
+			shouldErr: true,
+		},
+	}
+
+	runValidations(t, tests, "version", IsValidVersion)
+}

--- a/pkg/minikube/bootstrapper/bootstrapper.go
+++ b/pkg/minikube/bootstrapper/bootstrapper.go
@@ -19,6 +19,7 @@ package bootstrapper
 import (
 	"io"
 
+	"github.com/blang/semver"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 )
@@ -37,7 +38,7 @@ const (
 	BootstrapperTypeKubeadm = "kubeadm"
 )
 
-func GetCachedImageList(version string, bootstrapper string) []string {
+func GetCachedImageList(version semver.Version, bootstrapper string) []string {
 	switch bootstrapper {
 	case BootstrapperTypeKubeadm:
 		return constants.GetKubeadmCachedImages(version)

--- a/pkg/minikube/bootstrapper/kubeadm/templates.go
+++ b/pkg/minikube/bootstrapper/kubeadm/templates.go
@@ -31,7 +31,7 @@ api:
   advertiseAddress: {{.AdvertiseAddress}}
   bindPort: {{.APIServerPort}}
   controlPlaneEndpoint: localhost
-kubernetesVersion: {{.KubernetesVersion}}
+kubernetesVersion: v{{.KubernetesVersion}}
 certificatesDir: {{.CertDir}}
 networking:
   serviceSubnet: {{.ServiceCIDR}}
@@ -76,7 +76,7 @@ etcd:
   local:
     dataDir: {{.EtcdDataDir}}
 kind: ClusterConfiguration
-kubernetesVersion: {{.KubernetesVersion}}
+kubernetesVersion: v{{.KubernetesVersion}}
 networking:
   dnsDomain: cluster.local
   podSubnet: ""

--- a/pkg/minikube/bootstrapper/kubeadm/versions.go
+++ b/pkg/minikube/bootstrapper/kubeadm/versions.go
@@ -152,16 +152,6 @@ func Supports(featureName string) bool {
 	return false
 }
 
-func ParseKubernetesVersion(version string) (semver.Version, error) {
-	// Strip leading 'v' prefix from version for semver parsing
-	v, err := semver.Make(version[1:])
-	if err != nil {
-		return semver.Version{}, errors.Wrap(err, "parsing kubernetes version")
-	}
-
-	return v, nil
-}
-
 func convertToFlags(opts map[string]string) string {
 	var flags []string
 	for k, v := range opts {

--- a/pkg/minikube/bootstrapper/kubeadm/versions_test.go
+++ b/pkg/minikube/bootstrapper/kubeadm/versions_test.go
@@ -93,16 +93,6 @@ func TestVersionIsBetween(t *testing.T) {
 	}
 }
 
-func TestParseKubernetesVersion(t *testing.T) {
-	version, err := ParseKubernetesVersion("v1.8.0-alpha.5")
-	if err != nil {
-		t.Fatalf("Error parsing version: %s", err)
-	}
-	if version.NE(semver.MustParse("1.8.0-alpha.5")) {
-		t.Errorf("Expected: %s, Actual:%s", "1.8.0-alpha.5", version)
-	}
-}
-
 func TestParseFeatureArgs(t *testing.T) {
 	tests := []struct {
 		description                  string

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -18,8 +18,11 @@ package config
 
 import (
 	"net"
+	"strings"
 
+	"github.com/blang/semver"
 	"k8s.io/minikube/pkg/util"
+	"k8s.io/minikube/pkg/version"
 )
 
 // Config contains machine and k8s config
@@ -69,4 +72,10 @@ type KubernetesConfig struct {
 	ExtraOptions      util.ExtraOptionSlice
 
 	ShouldLoadCachedImages bool
+}
+
+// KubernetesSemVer gives us the semver object corresponding to the requested
+// Kubernetes version or panics.
+func (kcfg KubernetesConfig) KubernetesSemVer() semver.Version {
+	return semver.MustParse(strings.TrimPrefix(kcfg.KubernetesVersion, version.VersionPrefix))
 }

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -168,11 +168,11 @@ const (
 	DefaultMountVersion  = "9p2000.u"
 )
 
-func GetKubernetesReleaseURL(binaryName, version string) string {
-	return fmt.Sprintf("https://storage.googleapis.com/kubernetes-release/release/%s/bin/linux/amd64/%s", version, binaryName)
+func GetKubernetesReleaseURL(binaryName string, version semver.Version) string {
+	return fmt.Sprintf("https://storage.googleapis.com/kubernetes-release/release/v%s/bin/linux/amd64/%s", version, binaryName)
 }
 
-func GetKubernetesReleaseURLSha1(binaryName, version string) string {
+func GetKubernetesReleaseURLSha1(binaryName string, version semver.Version) string {
 	return fmt.Sprintf("%s.sha1", GetKubernetesReleaseURL(binaryName, version))
 }
 
@@ -180,7 +180,8 @@ const IsMinikubeChildProcess = "IS_MINIKUBE_CHILD_PROCESS"
 const DriverNone = "none"
 const FileScheme = "file"
 
-func GetKubeadmCachedImages(kubernetesVersionStr string) []string {
+func GetKubeadmCachedImages(kubernetesVersion semver.Version) []string {
+	kubernetesVersionStr := fmt.Sprintf("v%s", kubernetesVersion)
 
 	var images = []string{
 		"k8s.gcr.io/kube-proxy-amd64:" + kubernetesVersionStr,

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -25,6 +25,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/blang/semver"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -48,7 +49,7 @@ const tempLoadDir = "/tmp"
 
 var getWindowsVolumeName = getWindowsVolumeNameCmd
 
-func CacheImagesForBootstrapper(version string, clusterBootstrapper string) error {
+func CacheImagesForBootstrapper(version semver.Version, clusterBootstrapper string) error {
 	images := bootstrapper.GetCachedImageList(version, clusterBootstrapper)
 
 	if err := CacheImages(images, constants.ImageCacheDir); err != nil {


### PR DESCRIPTION
Version was generally being passed around as a string, I suspect due to
the use of JSON as a configuration store and wanting it to map to certain
configuration structures. This unfortunately led to issues where it was
implicitly required that all Kubernetes versions be specified with a
leading 'v' prefix or various operations would fail.

This patch:
- Replaces as many instances of string-based versions with semver.Version
  objects as possible.
- Makes version parsing more reliable by consistently using
  strings.TrimPrefix to remove the 'v' prefix when needed.
- Kubernetes versions stored in profiles are normalised to not having the
  'v' prefix. Existing profile configurations with a 'v' prefix will still
  work.
- Validates versions being passed in to make sure they'll parse.

Fixes #3253