### PR TITLE
When copying assets from .minikube/files on windows, directories get squashed during transfer. ie /etc/ssl/certs/test.pem becomes ~minikube/etcsslcerts/test.pem. This pull request ensures any window style directories are converted into unix style.

### DIFF
--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -19,8 +19,8 @@ package assets
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"path"
+	"path/filepath"
 	"strconv"
 
 	"github.com/pkg/errors"

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"path"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -305,7 +306,8 @@ func addMinikubeDirToAssets(basedir, vmpath string, assets *[]CopyableFile) erro
 					return errors.Wrap(err, "generating relative path")
 				}
 				rPath = filepath.Dir(rPath)
-				vmpath = filepath.Join("/", rPath)
+				rPath = filepath.ToSlash(rPath)
+				vmpath = path.Join("/", rPath)
 			}
 			permString := fmt.Sprintf("%o", info.Mode().Perm())
 			// The conversion will strip the leading 0 if present, so add it back


### PR DESCRIPTION
review https://github.com/kubernetes/minikube/issues/2768 by converting \ in directory string to / and using `path.Join` instead of `filepath.Join` which uses Unix format instead of using he current OS directory delimeter.

May not be BP but it works for me.