### PR TITLE
Disable mount tests in Darwin to workaround panic: timeout bug

### DIFF
--- a/test/integration/mount_test.go
+++ b/test/integration/mount_test.go
@@ -34,6 +34,9 @@ import (
 
 func testMounting(t *testing.T) {
 	t.Parallel()
+	if runtime.GOOS == "darwin" {
+		t.Skip("mount tests disabled in darwin due to timeout (issue#3200)")
+	}
 	if strings.Contains(*args, "--vm-driver=none") {
 		t.Skip("skipping test for none driver as it does not need mount")
 	}

--- a/test/integration/mount_test.go
+++ b/test/integration/mount_test.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"


### PR DESCRIPTION
These tests reliably cause a "panic: timed out" condition due to
hitherto unknown reasons. See issue #3200 for context.

dlorenc mentioned that this test never worked, so when I re-enabled it
recently for all platforms in af61bf790c1c3374907fce1ad6d86dd7694ef31a,
it introduced a persistent test failure for darwin.

I'll leave issue #3200 open until we are able to re-enable this test.