### PR TITLE
Clean up Linux install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ brew cask install minikube
 ### Linux
 
 ```shell
-curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 \
-  && sudo install minikube-linux-amd64 /usr/local/bin/minikube
+curl -L https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 |
+  sudo install /dev/stdin /usr/local/bin/minikube
 ```
 
 ### Windows
@@ -72,8 +72,8 @@ Download the [minikube-windows-amd64.exe](https://storage.googleapis.com/minikub
 ### Linux Continuous Integration without VM Support
 Example with kubectl installation:
 ```shell
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo cp minikube /usr/local/bin/ && rm minikube
-curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x kubectl && sudo cp kubectl /usr/local/bin/ && rm kubectl
+curl -L https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 | sudo install /dev/stdin /usr/local/bin/minikube
+curl -L https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl | sudo install /dev/stdin /usr/local/bin/kubectl
 
 export MINIKUBE_WANTUPDATENOTIFICATION=false
 export MINIKUBE_WANTREPORTERRORPROMPT=false

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -191,7 +191,7 @@ func MaybePrintKubectlDownloadMsg(goos string, out io.Writer) {
 	}
 
 	verb := "run"
-	installInstructions := "curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/%s/bin/%s/%s/kubectl && chmod +x kubectl && sudo cp kubectl /usr/local/bin/ && rm kubectl"
+	installInstructions := "curl -L https://storage.googleapis.com/kubernetes-release/release/%s/bin/%s/%s/kubectl | sudo install /dev/stdin /usr/local/bin/kubectl"
 	if goos == "windows" {
 		verb = "do"
 		installInstructions = `download kubectl from:

--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -41,8 +41,8 @@ $ newgrp libvirt
 Then install the driver itself:
 
 ```shell
-curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-kvm2 \
-  && sudo install docker-machine-driver-kvm2 /usr/local/bin/
+curl -L https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-kvm2 |
+  sudo install /dev/stdin /usr/local/bin/docker-machine-driver-kvm2
 ```
 
 To use the driver you would do:
@@ -86,8 +86,8 @@ It is built from the minikube source tree, and uses [moby/hyperkit](http://githu
 To install the hyperkit driver:
 
 ```shell
-curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-hyperkit \
-&& sudo install -o root -g root -m 4755 docker-machine-driver-hyperkit /usr/local/bin/
+curl -L https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-hyperkit |
+  sudo install -o root -g root -m 4755 /dev/stdin /usr/local/bin/docker-machine-driver-hyperkit
 ```
 
 The hyperkit driver currently requires running as root to use the vmnet framework to setup networking.

--- a/hack/jenkins/release_github_page.sh
+++ b/hack/jenkins/release_github_page.sh
@@ -49,17 +49,17 @@ Minikube is distributed in binary form for Linux, OSX, and Windows systems for t
 ## Installation
 ### OSX
 \`\`\`shell
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/${TAGNAME}/minikube-darwin-amd64 && chmod +x minikube && sudo cp minikube /usr/local/bin/ && rm minikube
+curl -L https://storage.googleapis.com/minikube/releases/${TAGNAME}/minikube-darwin-amd64 | sudo install /dev/stdin /usr/local/bin/minikube
 \`\`\`
-Feel free to leave off \`\`\`sudo cp minikube /usr/local/bin/ && rm minikube\`\`\` if you would like to add minikube to your path manually.
+Feel free to download the file manually if you would like to add minikube to your \`\$PATH\` yourself.
 
 Or you can install via homebrew with \`brew cask install minikube\`.
 
 ### Linux
 \`\`\`shell
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/${TAGNAME}/minikube-linux-amd64 && chmod +x minikube && sudo cp minikube /usr/local/bin/ && rm minikube
+curl -L https://storage.googleapis.com/minikube/releases/${TAGNAME}/minikube-linux-amd64 | sudo install /dev/stdin /usr/local/bin/minikube
 \`\`\`
-Feel free to leave off \`\`\`sudo cp minikube /usr/local/bin/ && rm minikube\`\`\` if you would like to add minikube to your path manually.
+Feel free to download the file manually if you would like to add minikube to your \`\$PATH\` yourself.
 
 ### Debian Package (.deb) [Experimental]
 Download the \`minikube_${DEB_VERSION}.deb\` file, and install it using \`sudo dpkg -i minikube_$(DEB_VERSION).deb\`


### PR DESCRIPTION
I see some changes have been made to the Linux install method recently. I think they're great, I was thinking about using `install(1)` also earlier.

Though I don't like that the current method leaves a dangling file at the current directory. It's then up to the user to clean that up.

Therefore I provide this patch, as a method to avoid leaving the downloaded file at two locations. I think it will be best only leave it at the install destination.