### PR TITLE
Remove newline at the start of zsh completion file

### DIFF
--- a/cmd/minikube/cmd/completion.go
+++ b/cmd/minikube/cmd/completion.go
@@ -106,8 +106,7 @@ func GenerateBashCompletion(w io.Writer, cmd *cobra.Command) error {
 }
 
 func GenerateZshCompletion(out io.Writer, cmd *cobra.Command) error {
-	zsh_initialization := `
-#compdef minikube
+	zsh_initialization := `#compdef minikube
 
 __minikube_bash_source() {
 	alias shopt=':'


### PR DESCRIPTION
Because of this initial newline, zsh isn't parsing the file as a completion file.