### PR TITLE
Fix to run sudo -E minikube start --vm-driver=none

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -326,6 +326,34 @@ func runStart(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	if config.VMDriver == constants.DriverNone {
+		if viper.GetBool(cfg.WantNoneDriverWarning) {
+			fmt.Println(`===================
+WARNING: IT IS RECOMMENDED NOT TO RUN THE NONE DRIVER ON PERSONAL WORKSTATIONS
+	The 'none' driver will run an insecure kubernetes apiserver as root that may leave the host vulnerable to CSRF attacks` + "\n")
+		}
+
+		if os.Getenv("CHANGE_MINIKUBE_NONE_USER") == "" {
+			fmt.Println(`When using the none driver, the kubectl config and credentials generated will be root owned and will appear in the root home directory.
+You will need to move the files to the appropriate location and then set the correct permissions.  An example of this is below:
+
+	sudo mv /root/.kube $HOME/.kube # this will write over any previous configuration
+	sudo chown -R $USER $HOME/.kube
+	sudo chgrp -R $USER $HOME/.kube
+
+	sudo mv /root/.minikube $HOME/.minikube # this will write over any previous configuration
+	sudo chown -R $USER $HOME/.minikube
+	sudo chgrp -R $USER $HOME/.minikube
+
+This can also be done automatically by setting the env var CHANGE_MINIKUBE_NONE_USER=true`)
+		}
+		if err := pkgutil.MaybeChownDirRecursiveToMinikubeUser(constants.GetMinipath()); err != nil {
+			glog.Errorf("Error recursively changing ownership of directory %s: %s",
+				constants.GetMinipath(), err)
+			cmdutil.MaybeReportErrorAndExit(err)
+		}
+	}
+
 	if !exists || config.VMDriver == constants.DriverNone {
 		fmt.Println("Starting cluster components...")
 		if err := k8sBootstrapper.StartCluster(kubernetesConfig); err != nil {
@@ -372,34 +400,6 @@ func runStart(cmd *cobra.Command, args []string) {
 			kubeCfgSetup.ClusterName)
 	} else {
 		fmt.Println("Kubectl is now configured to use the cluster.")
-	}
-
-	if config.VMDriver == "none" {
-		if viper.GetBool(cfg.WantNoneDriverWarning) {
-			fmt.Println(`===================
-WARNING: IT IS RECOMMENDED NOT TO RUN THE NONE DRIVER ON PERSONAL WORKSTATIONS
-	The 'none' driver will run an insecure kubernetes apiserver as root that may leave the host vulnerable to CSRF attacks` + "\n")
-		}
-
-		if os.Getenv("CHANGE_MINIKUBE_NONE_USER") == "" {
-			fmt.Println(`When using the none driver, the kubectl config and credentials generated will be root owned and will appear in the root home directory.
-You will need to move the files to the appropriate location and then set the correct permissions.  An example of this is below:
-
-	sudo mv /root/.kube $HOME/.kube # this will write over any previous configuration
-	sudo chown -R $USER $HOME/.kube
-	sudo chgrp -R $USER $HOME/.kube
-
-	sudo mv /root/.minikube $HOME/.minikube # this will write over any previous configuration
-	sudo chown -R $USER $HOME/.minikube
-	sudo chgrp -R $USER $HOME/.minikube
-
-This can also be done automatically by setting the env var CHANGE_MINIKUBE_NONE_USER=true`)
-		}
-		if err := pkgutil.MaybeChownDirRecursiveToMinikubeUser(constants.GetMinipath()); err != nil {
-			glog.Errorf("Error recursively changing ownership of directory %s: %s",
-				constants.GetMinipath(), err)
-			cmdutil.MaybeReportErrorAndExit(err)
-		}
 	}
 
 	fmt.Println("Loading cached images from config file.")


### PR DESCRIPTION
sudo -E minikube start --vm-driver=none does not change directory owner when CHANGE_MINIKUBE_NONE_USER=true.

This patch fixes to change directory owner when CHANGE_MINIKUBE_NONE_USER=true.

Fixes #3277 
