### PR TITLE
Added missing dependency to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Minikube is a tool that makes it easy to run Kubernetes locally. Minikube runs a
 ### macOS
 ```shell
 brew cask install minikube
+brew install kubernetes-cli
 ```
 
 ### Linux


### PR DESCRIPTION
Othervise you can face with errors like this:

```
$ eval $(minikube docker-env)
========================================
kubectl could not be found on your path. kubectl is a requirement for using minikube
To install kubectl, please run the following:

curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.10.0/bin/darwin/amd64/kubectl && chmod +x kubectl && sudo cp kubectl /usr/local/bin/ && rm kubectl

To disable this message, run the following:

minikube config set WantKubectlDownloadMsg false
========================================
Error getting host: Machine does not exist for api.Exists(minikube)
```