### PR TITLE
Add a new entry in travis.yml to build on Power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: go
-os: linux
+
+os: 
+  - linux
+  - linux-ppc64le
+
 sudo: required
 
 go:
@@ -11,4 +15,4 @@ install:
 script:
   - make test
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+- bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This commit adds a new entry into the travis.yml file to enable building on IBM Power (ppc64le).