### PR TITLE
Add timeout to testDashboard, skip testTunnel if sudo password is required.

### DIFF
--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -74,17 +74,14 @@ func readLineWithTimeout(b *bufio.Reader, timeout time.Duration) (string, error)
 func testDashboard(t *testing.T) {
 	t.Parallel()
 	minikubeRunner := NewMinikubeRunner(t)
-	t.Logf("Launching dashboard ...")
 	cmd, out := minikubeRunner.RunDaemon("dashboard --url")
 	defer func() {
-		t.Logf("Killing dashboard ...")
 		err := cmd.Process.Kill()
 		if err != nil {
 			t.Logf("Failed to kill dashboard command: %v", err)
 		}
 	}()
 
-	t.Logf("Waiting for URL to be output by minikube dashboard...")
 	s, err := readLineWithTimeout(out, 180*time.Second)
 	if err != nil {
 		t.Fatalf("failed to read url: %v", err)

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package integration
 
 import (
+	"bufio"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -46,19 +47,45 @@ func testAddons(t *testing.T) {
 	}
 }
 
+func readLineWithTimeout(b *bufio.Reader, timeout time.Duration) (string, error) {
+	s := make(chan string)
+	e := make(chan error)
+	go func() {
+		read, err := b.ReadString('\n')
+		if err != nil {
+			e <- err
+		} else {
+			s <- read
+		}
+		close(s)
+		close(e)
+	}()
+
+	select {
+	case line := <-s:
+		return line, nil
+	case err := <-e:
+		return "", err
+	case <-time.After(timeout):
+		return "", fmt.Errorf("timeout after %s", timeout)
+	}
+}
+
 func testDashboard(t *testing.T) {
 	t.Parallel()
 	minikubeRunner := NewMinikubeRunner(t)
-
+	t.Logf("Launching dashboard ...")
 	cmd, out := minikubeRunner.RunDaemon("dashboard --url")
 	defer func() {
+		t.Logf("Killing dashboard ...")
 		err := cmd.Process.Kill()
 		if err != nil {
-			t.Logf("Failed to kill mount command: %v", err)
+			t.Logf("Failed to kill dashboard command: %v", err)
 		}
 	}()
 
-	s, err := out.ReadString('\n')
+	t.Logf("Waiting for URL to be output by minikube dashboard...")
+	s, err := readLineWithTimeout(out, 180*time.Second)
 	if err != nil {
 		t.Fatalf("failed to read url: %v", err)
 	}

--- a/test/integration/mount_test.go
+++ b/test/integration/mount_test.go
@@ -34,13 +34,14 @@ import (
 )
 
 func testMounting(t *testing.T) {
-	t.Parallel()
 	if runtime.GOOS == "darwin" {
 		t.Skip("mount tests disabled in darwin due to timeout (issue#3200)")
 	}
 	if strings.Contains(*args, "--vm-driver=none") {
 		t.Skip("skipping test for none driver as it does not need mount")
 	}
+
+	t.Parallel()
 	minikubeRunner := NewMinikubeRunner(t)
 
 	tempDir, err := ioutil.TempDir("", "mounttest")

--- a/test/integration/tunnel_test.go
+++ b/test/integration/tunnel_test.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -33,6 +35,13 @@ import (
 )
 
 func testTunnel(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		// Otherwise minikube fails waiting for a password.
+		if err := exec.Command("sudo", "-n", "route").Run(); err != nil {
+			t.Skipf("password required to execute 'route', skipping testTunnel: %v", err)
+		}
+	}
+
 	t.Log("starting tunnel test...")
 	runner := NewMinikubeRunner(t)
 	go func() {


### PR DESCRIPTION
This may help to address issues we're seeing with panic timeouts on OSX, such as #3203