### PR TITLE
Add timeout when reading dashboard host:port from kubectl

### DIFF
--- a/cmd/minikube/cmd/dashboard.go
+++ b/cmd/minikube/cmd/dashboard.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -141,7 +142,7 @@ func kubectlProxy() (*exec.Cmd, string, error) {
 }
 
 // readWithTimeout returns a rune from a reader or an indicator that a timeout has occurred.
-func readWithTimeout(r *bufio.Reader, timeout time.Duration) (byte, bool, error) {
+func readWithTimeout(r io.ByteReader, timeout time.Duration) (byte, bool, error) {
 	bc := make(chan byte)
 	ec := make(chan error)
 	go func() {

--- a/cmd/minikube/cmd/dashboard.go
+++ b/cmd/minikube/cmd/dashboard.go
@@ -126,7 +126,7 @@ func kubectlProxy() (*exec.Cmd, string, error) {
 	for {
 		r, timedOut, err := readByteWithTimeout(reader, 5*time.Second)
 		if err != nil {
-			return cmd, "", fmt.Errorf("readRuneWithTimeout: %v", err)
+			return cmd, "", fmt.Errorf("readByteWithTimeout: %v", err)
 		}
 		if r == byte('\n') {
 			break

--- a/cmd/minikube/cmd/dashboard.go
+++ b/cmd/minikube/cmd/dashboard.go
@@ -91,7 +91,7 @@ var dashboardCmd = &cobra.Command{
 			}
 		}
 
-		glog.Infof("Waiting forever for kubectl proxy to exit ...")
+		glog.Infof("Success! I will now quietly sit around until kubectl proxy exits!")
 		if err = p.Wait(); err != nil {
 			glog.Errorf("Wait: %v", err)
 		}
@@ -117,14 +117,51 @@ func kubectlProxy() (*exec.Cmd, string, error) {
 	if err := cmd.Start(); err != nil {
 		return nil, "", errors.Wrap(err, "proxy start")
 	}
+
+	glog.Infof("Waiting for kubectl to output host:port ...")
 	reader := bufio.NewReader(stdoutPipe)
-	glog.Infof("proxy started, reading stdout pipe ...")
-	out, err := reader.ReadString('\n')
-	if err != nil {
-		return nil, "", errors.Wrap(err, "reading stdout pipe")
+
+	var out []byte
+	for {
+		r, timedOut, err := readWithTimeout(reader, 5*time.Second)
+		if err != nil {
+			return cmd, "", fmt.Errorf("readRuneWithTimeout: %v", err)
+		}
+		if r == byte('\n') {
+			break
+		}
+		if timedOut {
+			glog.Infof("timed out waiting for input: possibly due to an old kubectl version.")
+			break
+		}
+		out = append(out, r)
 	}
-	glog.Infof("proxy stdout: %s", out)
-	return cmd, hostPortRe.FindString(out), nil
+	glog.Infof("proxy stdout: %s", string(out))
+	return cmd, hostPortRe.FindString(string(out)), nil
+}
+
+// readWithTimeout returns a rune from a reader or an indicator that a timeout has occurred.
+func readWithTimeout(r *bufio.Reader, timeout time.Duration) (byte, bool, error) {
+	bc := make(chan byte)
+	ec := make(chan error)
+	go func() {
+		b, err := r.ReadByte()
+		if err != nil {
+			ec <- err
+		} else {
+			bc <- b
+		}
+		close(bc)
+		close(ec)
+	}()
+	select {
+	case b := <-bc:
+		return b, false, nil
+	case err := <-ec:
+		return byte(' '), false, err
+	case <-time.After(timeout):
+		return byte(' '), true, nil
+	}
 }
 
 // dashboardURL generates a URL for accessing the dashboard service

--- a/cmd/minikube/cmd/dashboard.go
+++ b/cmd/minikube/cmd/dashboard.go
@@ -124,7 +124,7 @@ func kubectlProxy() (*exec.Cmd, string, error) {
 
 	var out []byte
 	for {
-		r, timedOut, err := readWithTimeout(reader, 5*time.Second)
+		r, timedOut, err := readByteWithTimeout(reader, 5*time.Second)
 		if err != nil {
 			return cmd, "", fmt.Errorf("readRuneWithTimeout: %v", err)
 		}
@@ -141,8 +141,8 @@ func kubectlProxy() (*exec.Cmd, string, error) {
 	return cmd, hostPortRe.FindString(string(out)), nil
 }
 
-// readWithTimeout returns a rune from a reader or an indicator that a timeout has occurred.
-func readWithTimeout(r io.ByteReader, timeout time.Duration) (byte, bool, error) {
+// readByteWithTimeout returns a byte from a reader or an indicator that a timeout has occurred.
+func readByteWithTimeout(r io.ByteReader, timeout time.Duration) (byte, bool, error) {
 	bc := make(chan byte)
 	ec := make(chan error)
 	go func() {


### PR DESCRIPTION
kubectl releases older than August 2017 don't include a newline, which effectively results in there being no signal that output has completed. For these cases, we timeout reading after 5 seconds and pass whatever we received into the appropriate regexp.

This resolves the test timeout panics we have seen on the Mac Mini (kubectl v1.6.1) such as #3203.

Tested on kubectl v1.6.1 (no newline), v1.10.1 (newline), and a custom shell script which just sleeps forever.

