### PR TITLE
adding continuous build logic

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -115,6 +115,11 @@ else
   source print-debug-info.sh
 fi
 
+if [ "${MINIKUBE_LOCATION}" == "master" ]; then
+  echo "not setting github status for continuous builds"
+  exit $result
+fi
+
 set +x
 target_url="https://storage.googleapis.com/minikube-builds/logs/${MINIKUBE_LOCATION}/${JOB_NAME}.txt"
 curl "https://api.github.com/repos/kubernetes/minikube/statuses/${COMMIT}?access_token=$access_token" \

--- a/hack/jenkins/minikube_set_pending.sh
+++ b/hack/jenkins/minikube_set_pending.sh
@@ -27,6 +27,11 @@
 set -e
 set +x
 
+if [ "${ghprbPullId}" == "master" ]; then
+  echo "not setting github status for continuous builds"
+  exit 0
+fi
+
 for job in "Minishift-Linux-KVM" "OSX-Virtualbox" "OSX-Hyperkit" "Linux-Virtualbox" "Linux-KVM" "Linux-None" "Windows-Virtualbox" "Windows-Kubeadm-CRI-O" "Linux-Container"; do
   target_url="https://storage.googleapis.com/minikube-builds/logs/${ghprbPullId}/${job}.txt"
   curl "https://api.github.com/repos/kubernetes/minikube/statuses/${ghprbActualCommit}?access_token=$access_token" \


### PR DESCRIPTION
to reuse the same jenkins jobs, I just added extra logic into the
current scripts, namely: for cases when `$ghprbPullId` equals "master",
we ignore setting the github statuses.
Closes #3338. 