### PR TITLE
Restart containerd after stopping alternate runtimes

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -295,31 +295,39 @@ func runStart(cmd *cobra.Command, args []string) {
 	fmt.Println("Stopping extra container runtimes...")
 
 	containerRuntime := viper.GetString(containerRuntime)
-	if config.VMDriver != "none" && containerRuntime != "" {
+	if config.VMDriver != constants.DriverNone && containerRuntime != "" {
 		if _, err := host.RunSSHCommand("sudo systemctl stop docker"); err == nil {
 			_, err = host.RunSSHCommand("sudo systemctl stop docker.socket")
 		}
 		if err != nil {
-			glog.Errorf("Error stopping docker", err)
+			glog.Errorf("Error stopping docker: %v", err)
 		}
 	}
-	if config.VMDriver != "none" && (containerRuntime != "crio" && containerRuntime != "cri-o") {
+	if config.VMDriver != constants.DriverNone && (containerRuntime != constants.CrioRuntime && containerRuntime != constants.Cri_oRuntime) {
 		if _, err := host.RunSSHCommand("sudo systemctl stop crio"); err != nil {
-			glog.Errorf("Error stopping crio", err)
+			glog.Errorf("Error stopping crio: %v", err)
 		}
 	}
-	if config.VMDriver != "none" && containerRuntime != "rkt" {
+	if config.VMDriver != constants.DriverNone && containerRuntime != constants.RktRuntime {
 		if _, err := host.RunSSHCommand("sudo systemctl stop rkt-api"); err == nil {
 			_, err = host.RunSSHCommand("sudo systemctl stop rkt-metadata")
 		}
 		if err != nil {
-			glog.Errorf("Error stopping rkt", err)
+			glog.Errorf("Error stopping rkt: %v", err)
+		}
+	}
+
+	if config.VMDriver != constants.DriverNone && containerRuntime == constants.ContainerdRuntime {
+		fmt.Println("Restarting containerd runtime...")
+		// restart containerd so that it can install all plugins
+		if _, err := host.RunSSHCommand("sudo systemctl restart containerd"); err != nil {
+			glog.Errorf("Error restarting containerd: %v", err)
 		}
 	}
 
 	fmt.Println("Starting cluster components...")
 
-	if !exists || config.VMDriver == "none" {
+	if !exists || config.VMDriver == constants.DriverNone {
 		if err := k8sBootstrapper.StartCluster(kubernetesConfig); err != nil {
 			glog.Errorln("Error starting cluster: ", err)
 			cmdutil.MaybeReportErrorAndExit(err)

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -115,6 +115,10 @@ func (k *KubeadmBootstrapper) StartCluster(k8s config.KubernetesConfig) error {
 	}
 
 	b := bytes.Buffer{}
+	preflights := constants.Preflights
+	if k8s.ContainerRuntime != "" {
+		preflights = constants.AlternateRuntimePreflights
+	}
 	templateContext := struct {
 		KubeadmConfigFile   string
 		SkipPreflightChecks bool
@@ -125,7 +129,7 @@ func (k *KubeadmBootstrapper) StartCluster(k8s config.KubernetesConfig) error {
 		SkipPreflightChecks: !VersionIsBetween(version,
 			semver.MustParse("1.9.0-alpha.0"),
 			semver.Version{}),
-		Preflights: constants.Preflights,
+		Preflights: preflights,
 		DNSAddon:   "kube-dns",
 	}
 	if version.GTE(semver.MustParse("1.12.0")) {

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -164,6 +164,23 @@ var Preflights = []string{
 	"CRI",
 }
 
+// AlternateRuntimePreflights are additional preflight checks applied when running
+// any container runtime that isn't Docker
+var AlternateRuntimePreflights = append(Preflights, []string{
+	"Service-Docker",
+	"Port-8443",
+	"Port-10251",
+	"Port-10252",
+	"Port-2379",
+}...)
+
+const (
+	ContainerdRuntime = "containerd"
+	RktRuntime        = "rkt"
+	CrioRuntime       = "crio"
+	Cri_oRuntime      = "cri-o"
+)
+
 const (
 	DefaultUfsPort       = "5640"
 	DefaultUfsDebugLvl   = 0


### PR DESCRIPTION
After stopping any runtimes that aren't being used, if we're using
containerd then we need to restart it. This is because it competes with
cri-o to listen on port 10010, causing a necesary plugin to not be
installed. After stopping cri-o, we need to restart containerd so that
the plugin is installed.

I also added some preflight checks when using alternative runtimes.
kubeadm checks to make sure the Docker service is running, so I disabled
that. It also checks if a few ports are available; these are ports that
containerd uses, so I also added them to the ignore list.

This should finish the work started in #3211, which stopped alternative
runtimes but didn't restart containerd. I was able to run "minikube
start" with containerd locally with this change.