### PR TITLE
removing Windows check temporarily

### DIFF
--- a/hack/jenkins/minikube_set_pending.sh
+++ b/hack/jenkins/minikube_set_pending.sh
@@ -32,7 +32,7 @@ if [ "${ghprbPullId}" == "master" ]; then
   exit 0
 fi
 
-for job in "OSX-Virtualbox" "OSX-Hyperkit" "Linux-Virtualbox" "Linux-KVM" "Linux-None" "Windows-Virtualbox"; do
+for job in "OSX-Virtualbox" "OSX-Hyperkit" "Linux-Virtualbox" "Linux-KVM" "Linux-None"; do
   target_url="https://storage.googleapis.com/minikube-builds/logs/${ghprbPullId}/${job}.txt"
   curl "https://api.github.com/repos/kubernetes/minikube/statuses/${ghprbActualCommit}?access_token=$access_token" \
     -H "Content-Type: application/json" \


### PR DESCRIPTION
This removes the "Pending" check for "Windows Virtualbox" - until we fix Windows (https://github.com/kubernetes/minikube/issues/3336)