### PR TITLE
Tell user given driver has been igored if exising VM has a different …

### DIFF
--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -78,7 +78,7 @@ func StartHost(api libmachine.API, config cfg.MachineConfig) (*host.Host, error)
 		return nil, errors.Wrap(err, "Error loading existing host. Please try running [minikube delete], then run [minikube start] again.")
 	}
 
-	if h.Driver.DriverName() != "none" && h.Driver.DriverName() != config.VMDriver {
+	if h.Driver.DriverName() != config.VMDriver {
 		fmt.Printf("Skipping %s driver, existing host has %s driver.\n", config.VMDriver, h.Driver.DriverName())
 	}
 

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -78,6 +78,10 @@ func StartHost(api libmachine.API, config cfg.MachineConfig) (*host.Host, error)
 		return nil, errors.Wrap(err, "Error loading existing host. Please try running [minikube delete], then run [minikube start] again.")
 	}
 
+	if h.Driver.DriverName() != "none" && h.Driver.DriverName() != config.VMDriver {
+		fmt.Printf("Skipping %s driver, existing host has %s driver.\n", config.VMDriver, h.Driver.DriverName())
+	}
+
 	s, err := h.Driver.GetState()
 	glog.Infoln("Machine state: ", s)
 	if err != nil {


### PR DESCRIPTION
Currently, if user start minikube with a different driver in the 2nd time, VM will start to run with the previous driver silently, this patch will tell user that given driver parameter has been ignored.