### PR TITLE
Update docker env during minikube start if VM has already been created

### DIFF
--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -99,10 +99,10 @@ func StartHost(api libmachine.API, config cfg.MachineConfig) (*host.Host, error)
 		h.HostOptions.EngineOptions.Env = e.Env
 		provisioner, err := provision.DetectProvisioner(h.Driver)
 		if err != nil {
-			return nil, errors.Wrap(err, "Error detecting OS")
+			return nil, errors.Wrap(err, "detecting provisioner")
 		}
 		if err := provisioner.Provision(*h.HostOptions.SwarmOptions, *h.HostOptions.AuthOptions, *h.HostOptions.EngineOptions); err != nil {
-			return nil, errors.Wrap(err, "Error running provisioning")
+			return nil, errors.Wrap(err, "provision")
 		}
 	}
 


### PR DESCRIPTION
Fixes #3276 - HTTP_PROXY doesn't update when minikube start with different proxy

Update docker env during minikube start if VM has already been created
- keep original docker env if minikube start without --docker-env parameter
- overwrite docker env if minikube start with --docker-env parameter