### PR TITLE
Add skeleton for gvisor image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,6 +303,14 @@ storage-provisioner-image: out/storage-provisioner
 push-storage-provisioner-image: storage-provisioner-image
 	gcloud docker -- push $(REGISTRY)/storage-provisioner:$(STORAGE_PROVISIONER_TAG)
 
+.PHONY: out/gvisor
+out/gvisor:
+	GOOS=linux CGO_ENABLED=0 go build -o $@ cmd/gvisor/gvisor.go
+ 
+ .PHONY: gvisor-image
+gvisor-image: out/gvisor
+	docker build -t $(REGISTRY)/gvisor:latest -f deploy/gvisor/Dockerfile .
+
 .PHONY: release-iso
 release-iso: minikube_iso checksum
 	gsutil cp out/minikube.iso gs://$(ISO_BUCKET)/minikube-$(ISO_VERSION).iso

--- a/cmd/gvisor/gvisor.go
+++ b/cmd/gvisor/gvisor.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+
+	"k8s.io/minikube/pkg/gvisor"
+)
+
+var (
+	disable bool
+)
+
+func init() {
+	flag.BoolVar(&disable, "disable", false, "set to disable gvisor")
+	flag.Parse()
+}
+
+func main() {
+	if err := execute(); err != nil {
+		log.Print(err)
+		os.Exit(1)
+	}
+}
+
+func execute() error {
+	if disable {
+		return gvisor.Disable()
+	}
+	return gvisor.Enable()
+}

--- a/deploy/gvisor/Dockerfile
+++ b/deploy/gvisor/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:18.04
+RUN apt-get update && \
+    apt-get install -y kmod gcc wget xz-utils libc6-dev bc libelf-dev bison flex openssl libssl-dev libidn2-0 sudo libcap2 && \
+    rm -rf /var/lib/apt/lists/*
+COPY out/gvisor /gvisor
+CMD /gvisor

--- a/pkg/gvisor/disable.go
+++ b/pkg/gvisor/disable.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gvisor
+
+// Disable returns config files to their original states and
+// restarts containerd to disable gvisor in minikube
+func Disable() error {
+	// TODO: priyawadhwa@ to fill this out
+	return nil
+}

--- a/pkg/gvisor/enable.go
+++ b/pkg/gvisor/enable.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gvisor
+
+// Enable downloads the necessary binaries, changes config files, and restarts
+// containerd to enable gvisor in minikube
+func Enable() error {
+	// TODO: priyawadhwa@ to fill this out
+	return nil
+}


### PR DESCRIPTION
Add skeleton for the gvisor image that will be run when the addon is
enabled. Added two Makefile rules and the Dockerfile that will build the
image.