### PR TITLE
[WIP] Enable gvisor addon in minikube

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,6 +303,18 @@ storage-provisioner-image: out/storage-provisioner
 push-storage-provisioner-image: storage-provisioner-image
 	gcloud docker -- push $(REGISTRY)/storage-provisioner:$(STORAGE_PROVISIONER_TAG)
 
+.PHONY: out/gvisor-addon
+out/gvisor-addon:
+	GOOS=linux CGO_ENABLED=0 go build -o $@ cmd/gvisor/gvisor.go
+
+.PHONY: gvisor-addon-image
+gvisor-addon-image: out/gvisor-addon
+	docker build -t $(REGISTRY)/gvisor-addon:latest -f deploy/gvisor/Dockerfile .
+
+.PHONY: push-gvisor-addon-image
+push-gvisor-addon-image: gvisor-addon-image
+	gcloud docker -- push $(REGISTRY)/gvisor-addon:latest
+
 .PHONY: release-iso
 release-iso: minikube_iso checksum
 	gsutil cp out/minikube.iso gs://$(ISO_BUCKET)/minikube-$(ISO_VERSION).iso

--- a/cmd/gvisor/gvisor.go
+++ b/cmd/gvisor/gvisor.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+
+	"k8s.io/minikube/pkg/gvisor"
+)
+
+var (
+	disable bool
+)
+
+func init() {
+	flag.BoolVar(&disable, "disable", false, "disable gvisor addon")
+	flag.Parse()
+}
+
+func main() {
+	if err := execute(); err != nil {
+		log.Print(err)
+		os.Exit(1)
+	}
+}
+
+func execute() error {
+	if disable {
+		return gvisor.Disable()
+	}
+	return gvisor.Enable()
+}

--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -225,6 +225,12 @@ var settings = []Setting{
 		callbacks:   []setFn{EnableOrDisableAddon},
 	},
 	{
+		name:        "gvisor",
+		set:         SetBool,
+		validations: []setFn{IsValidAddon},
+		callbacks:   []setFn{EnableOrDisableAddon},
+	},
+	{
 		name: "hyperv-virtual-switch",
 		set:  SetString,
 	},

--- a/deploy/addons/gvisor/config.toml
+++ b/deploy/addons/gvisor/config.toml
@@ -1,0 +1,69 @@
+root = "/var/lib/containerd"
+state = "/run/containerd"
+oom_score = 0
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+  uid = 0
+  gid = 0
+  max_recv_message_size = 16777216
+  max_send_message_size = 16777216
+
+[debug]
+  address = ""
+  uid = 0
+  gid = 0
+  level = ""
+
+[metrics]
+  address = ""
+  grpc_histogram = false
+
+[cgroup]
+  path = ""
+
+[plugins]
+  [plugins.cgroups]
+    no_prometheus = false
+  [plugins.cri]
+    stream_server_address = ""
+    stream_server_port = "10010"
+    enable_selinux = false
+    sandbox_image = "k8s.gcr.io/pause:3.1"
+    stats_collect_period = 10
+    systemd_cgroup = false
+    enable_tls_streaming = false
+    max_container_log_line_size = 16384
+    [plugins.cri.containerd]
+      snapshotter = "overlayfs"
+      no_pivot = true
+      [plugins.cri.containerd.default_runtime]
+        runtime_type = "io.containerd.runtime.v1.linux"
+        runtime_engine = ""
+        runtime_root = ""
+      [plugins.cri.containerd.untrusted_workload_runtime]
+        runtime_type = ""
+        runtime_engine = ""
+        runtime_root = ""
+    [plugins.cri.cni]
+      bin_dir = "/opt/cni/bin"
+      conf_dir = "/etc/cni/net.d"
+      conf_template = ""
+    [plugins.cri.registry]
+      [plugins.cri.registry.mirrors]
+        [plugins.cri.registry.mirrors."docker.io"]
+          endpoint = ["https://registry-1.docker.io"]
+  [plugins.diff-service]
+    default = ["walking"]
+  [plugins.linux]
+    shim = "containerd-shim"
+    runtime = "runc"
+    runtime_root = ""
+    no_shim = false
+    shim_debug = false
+  [plugins.scheduler]
+    pause_threshold = 0.02
+    deletion_threshold = 0
+    mutation_threshold = 100
+    schedule_delay = "0s"
+    startup_delay = "100ms"

--- a/deploy/addons/gvisor/gvisor-config.toml
+++ b/deploy/addons/gvisor/gvisor-config.toml
@@ -1,0 +1,69 @@
+root = "/var/lib/containerd"
+state = "/run/containerd"
+oom_score = 0
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+  uid = 0
+  gid = 0
+  max_recv_message_size = 16777216
+  max_send_message_size = 16777216
+
+[debug]
+  address = ""
+  uid = 0
+  gid = 0
+  level = ""
+
+[metrics]
+  address = ""
+  grpc_histogram = false
+
+[cgroup]
+  path = ""
+
+[plugins]
+  [plugins.cgroups]
+    no_prometheus = false
+  [plugins.cri]
+    stream_server_address = ""
+    stream_server_port = "10010"
+    enable_selinux = false
+    sandbox_image = "k8s.gcr.io/pause:3.1"
+    stats_collect_period = 10
+    systemd_cgroup = false
+    enable_tls_streaming = false
+    max_container_log_line_size = 16384
+    [plugins.cri.containerd]
+      snapshotter = "overlayfs"
+      no_pivot = true
+      [plugins.cri.containerd.default_runtime]
+        runtime_type = "io.containerd.runtime.v1.linux"
+        runtime_engine = ""
+        runtime_root = ""
+      [plugins.cri.containerd.untrusted_workload_runtime]
+        runtime_type = "io.containerd.runtime.v1.linux"
+        runtime_engine = "/usr/local/bin/runsc"
+          runtime_root = "/run/containerd/runsc"
+    [plugins.cri.cni]
+      bin_dir = "/opt/cni/bin"
+      conf_dir = "/etc/cni/net.d"
+      conf_template = ""
+    [plugins.cri.registry]
+      [plugins.cri.registry.mirrors]
+        [plugins.cri.registry.mirrors."docker.io"]
+          endpoint = ["https://registry-1.docker.io"]
+  [plugins.diff-service]
+    default = ["walking"]
+  [plugins.linux]
+    shim = "gvisor-containerd-shim"
+    runtime = "runc"
+    runtime_root = ""
+    no_shim = false
+    shim_debug = true
+  [plugins.scheduler]
+    pause_threshold = 0.02
+    deletion_threshold = 0
+    mutation_threshold = 100
+    schedule_delay = "0s"
+    startup_delay = "100ms"

--- a/deploy/addons/gvisor/gvisor-containerd-shim.toml
+++ b/deploy/addons/gvisor/gvisor-containerd-shim.toml
@@ -1,0 +1,5 @@
+runc_shim = "/bin/containerd-shim"
+[runsc_config]
+ debug-log="/tmp/runsc/"
+ debug="true"
+ log="/tmp/runsc/out.log"

--- a/deploy/addons/gvisor/gvisor-pod.yaml
+++ b/deploy/addons/gvisor/gvisor-pod.yaml
@@ -1,0 +1,75 @@
+# Copyright 2018 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata: 
+  name: gvisor
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+spec: 
+  hostPID: true
+  containers: 
+    - name: gvisor
+      image: gcr.io/k8s-minikube/gvisor-addon:latest
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /node/
+        name: node
+      - mountPath: /usr/libexec/sudo
+        name: sudo
+      - mountPath: /var/run
+        name: varrun
+      - mountPath: /usr/bin
+        name: usrbin
+      - mountPath: /usr/lib
+        name: usrlib
+      - mountPath: /bin
+        name: bin
+      - mountPath: /tmp/gvisor
+        name: gvisor
+      env:
+        - name: PATH
+          value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/node/bin
+        - name: SYSTEMD_IGNORE_CHROOT
+          value: "yes"
+      lifecycle:
+        preStop:
+          exec:
+            command: ["/gvisor-addon","-disable"]
+  volumes:
+  - name: node
+    hostPath:
+      path: /
+  - name: sudo
+    hostPath:
+      path: /usr/libexec/sudo
+  - name: varrun
+    hostPath:
+      path: /var/run
+  - name: usrlib
+    hostPath:
+      path: /usr/lib
+  - name: usrbin
+    hostPath:
+      path: /usr/bin
+  - name: bin
+    hostPath:
+      path: /bin
+  - name: gvisor
+    hostPath:
+      path: /tmp/gvisor
+  restartPolicy: Never

--- a/deploy/gvisor/Dockerfile
+++ b/deploy/gvisor/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:18.04
+RUN apt-get update && \
+    apt-get install -y kmod gcc wget xz-utils libc6-dev bc libelf-dev bison flex openssl libssl-dev libidn2-0 sudo libcap2 && \
+    rm -rf /var/lib/apt/lists/*
+COPY out/gvisor-addon /gvisor-addon
+CMD /gvisor-addon

--- a/pkg/gvisor/disable.go
+++ b/pkg/gvisor/disable.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gvisor
+
+import (
+	"log"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"k8s.io/minikube/pkg/minikube/constants"
+)
+
+// Disable reverts containerd config files and restarts containerd
+func Disable() error {
+	log.Print("Disabling gvisor...")
+	if err := copyAssetToDest(constants.DefaultConfigTomlTargetName, filepath.Join(nodeDir, constants.ContainerdConfigTomlPath)); err != nil {
+		return errors.Wrap(err, "reverting config.toml to default")
+	}
+	// restart containerd
+	if err := restartContainerd(); err != nil {
+		return errors.Wrap(err, "restarting containerd")
+	}
+	return nil
+}

--- a/pkg/gvisor/enable.go
+++ b/pkg/gvisor/enable.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gvisor
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"k8s.io/minikube/pkg/minikube/constants"
+
+	"github.com/pkg/errors"
+	"k8s.io/minikube/pkg/minikube/assets"
+)
+
+const (
+	nodeDir = "/node"
+)
+
+// Enable follows these steps for enabling gvisor in minikube:
+//   1. creates necessary directories for storing binaries and runsc logs
+//   2. downloads runsc and gvisor-containerd-shim
+//   3. copies necessary containerd config files
+//   4. restarts containerd
+func Enable() error {
+	if err := makeDirs(); err != nil {
+		return errors.Wrap(err, "creating directories on node")
+	}
+	if err := downloadBinaries(); err != nil {
+		return errors.Wrap(err, "downloading binaries")
+	}
+	if err := copyFiles(); err != nil {
+		return errors.Wrap(err, "copying files")
+	}
+	if err := restartContainerd(); err != nil {
+		return errors.Wrap(err, "restarting containerd")
+	}
+	// sleep for one year so the pod continuously runs
+	time.Sleep(24 * 7 * 52 * time.Hour)
+	return nil
+}
+
+// makeDirs creates necessary directories on the node
+func makeDirs() error {
+	// Make /run/containerd/runsc to hold logs
+	fp := filepath.Join(nodeDir, "run/containerd/runsc")
+	if err := os.MkdirAll(fp, 0755); err != nil {
+		return errors.Wrap(err, "creating runsc dir")
+	}
+
+	// Make /usr/local/bin to store the runsc binary
+	fp = filepath.Join(nodeDir, "usr/local/bin")
+	if err := os.MkdirAll(fp, 0755); err != nil {
+		return errors.Wrap(err, "creating usr/local/bin dir")
+	}
+
+	// Make /tmp/runsc to also hold logs
+	fp = filepath.Join(nodeDir, "tmp/runsc")
+	if err := os.MkdirAll(fp, 0755); err != nil {
+		return errors.Wrap(err, "creating runsc logs dir")
+	}
+
+	return nil
+}
+
+func downloadBinaries() error {
+	if err := runsc(); err != nil {
+		return errors.Wrap(err, "downloading runsc")
+	}
+	if err := gvisorContainerdShim(); err != nil {
+		return errors.Wrap(err, "downloading gvisor-containerd-shim")
+	}
+	return nil
+}
+
+// downloads the gvisor-containerd-shim
+func gvisorContainerdShim() error {
+	dest := filepath.Join(nodeDir, "usr/bin/gvisor-containerd-shim")
+	// TODO: priyawadhwa@, replace with official release
+	return downloadFileToDest("http://storage.googleapis.com/balintp-minikube/gvisor-containerd-shim", dest)
+}
+
+// downloads the runsc binary and returns a path to the binary
+func runsc() error {
+	dest := filepath.Join(nodeDir, "usr/local/bin/runsc")
+	return downloadFileToDest("http://storage.googleapis.com/gvisor/releases/nightly/latest/runsc", dest)
+}
+
+// downloadFileToDest downlaods the given file to the dest
+// if something already exists at dest, first remove it
+func downloadFileToDest(url, dest string) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if _, err := os.Stat(dest); err == nil {
+		if err := os.Remove(dest); err != nil {
+			return errors.Wrapf(err, "removing %s for overwrite", dest)
+		}
+	}
+	fi, err := os.Create(dest)
+	if err != nil {
+		return errors.Wrapf(err, "creating %s", dest)
+	}
+	defer fi.Close()
+	if _, err := io.Copy(fi, resp.Body); err != nil {
+		return errors.Wrap(err, "copying binary")
+	}
+	if err := fi.Chmod(0777); err != nil {
+		return errors.Wrap(err, "fixing perms")
+	}
+	return nil
+}
+
+// Must write the following files:
+//    1. gvisor-containerd-shim.toml
+//    2. gvisor containerd config.toml
+func copyFiles() error {
+	log.Print("Copying gvisor-containerd-shim.toml...")
+	if err := copyAssetToDest(constants.GvisorContainerdShimTargetName, filepath.Join(nodeDir, constants.GvisorContainerdShimTomlPath)); err != nil {
+		return errors.Wrap(err, "copying gvisor-containerd-shim.toml")
+	}
+	log.Print("Copying containerd config.toml with gvisor...")
+	if err := copyAssetToDest(constants.GvisorConfigTomlTargetName, filepath.Join(nodeDir, constants.ContainerdConfigTomlPath)); err != nil {
+		return errors.Wrap(err, "copying gvisor version of config.toml")
+	}
+	return nil
+}
+
+func copyAssetToDest(targetName, dest string) error {
+	var asset *assets.BinDataAsset
+	for _, a := range assets.Addons["gvisor"].Assets {
+		if a.GetTargetName() == targetName {
+			asset = a
+		}
+	}
+	// Now, copy the data from this asset to dest
+	src := filepath.Join(constants.GvisorFilesPath, asset.GetTargetName())
+	contents, err := ioutil.ReadFile(src)
+	if err != nil {
+		return errors.Wrapf(err, "getting contents of %s", asset.GetAssetName())
+	}
+	if _, err := os.Stat(dest); err == nil {
+		if err := os.Remove(dest); err != nil {
+			return errors.Wrapf(err, "removing %s", dest)
+		}
+	}
+	f, err := os.Create(dest)
+	if err != nil {
+		return errors.Wrapf(err, "creating %s", dest)
+	}
+	if _, err := f.Write(contents); err != nil {
+		return errors.Wrapf(err, "writing contents to %s", f.Name())
+	}
+	return nil
+}
+
+func restartContainerd() error {
+	dir := filepath.Join(nodeDir, "usr/libexec/sudo")
+	if err := os.Setenv("LD_LIBRARY_PATH", dir); err != nil {
+		return errors.Wrap(err, dir)
+	}
+
+	log.Print("Stopping rpc-statd.service...")
+	// first, stop  rpc-statd.service
+	cmd := exec.Command("sudo", "-E", "systemctl", "stop", "rpc-statd.service")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Println(string(out))
+		return errors.Wrap(err, "stopping rpc-statd.service")
+	}
+	// restart containerd
+	log.Print("Restarting containerd...")
+	cmd = exec.Command("sudo", "-E", "systemctl", "restart", "containerd")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		log.Print(string(out))
+		return errors.Wrap(err, "restarting containerd")
+	}
+	// start rpc-statd.service
+	log.Print("Starting rpc-statd...")
+	cmd = exec.Command("sudo", "-E", "systemctl", "start", "rpc-statd.service")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		log.Print(string(out))
+		return errors.Wrap(err, "restarting rpc-statd.service")
+	}
+	log.Print("containerd restart complete")
+	return nil
+}

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -276,6 +276,28 @@ var Addons = map[string]*Addon{
 			"nvidia-gpu-device-plugin.yaml",
 			"0640"),
 	}, false, "nvidia-gpu-device-plugin"),
+	"gvisor": NewAddon([]*BinDataAsset{
+		NewBinDataAsset(
+			"deploy/addons/gvisor/gvisor-pod.yaml",
+			constants.AddonsPath,
+			"gvisor-pod.yaml",
+			"0640"),
+		NewBinDataAsset(
+			"deploy/addons/gvisor/gvisor-config.toml",
+			constants.GvisorFilesPath,
+			constants.GvisorConfigTomlTargetName,
+			"0640"),
+		NewBinDataAsset(
+			"deploy/addons/gvisor/gvisor-containerd-shim.toml",
+			constants.GvisorFilesPath,
+			constants.GvisorContainerdShimTargetName,
+			"0640"),
+		NewBinDataAsset(
+			"deploy/addons/gvisor/config.toml",
+			constants.GvisorFilesPath,
+			constants.DefaultConfigTomlTargetName,
+			"0640"),
+	}, false, "gvisor"),
 }
 
 func AddMinikubeDirAssets(assets *[]CopyableFile) error {

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -23,12 +23,13 @@ import (
 	"runtime"
 	"strings"
 
+	"time"
+
 	"github.com/blang/semver"
 	"github.com/golang/glog"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
 	minikubeVersion "k8s.io/minikube/pkg/version"
-	"time"
 )
 
 // APIServerPort is the port that the API server should listen on.
@@ -261,3 +262,19 @@ func GetKubeadmCachedImages(kubernetesVersionStr string) []string {
 }
 
 var ImageCacheDir = MakeMiniPath("cache", "images")
+
+const (
+	// GvisorFilesPath is the path to the gvisor files saved by go-bindata
+	GvisorFilesPath = "/tmp/gvisor"
+	// ContainerdConfigTomlPath is the path to the containerd config.toml
+	ContainerdConfigTomlPath = "/etc/containerd/config.toml"
+	// GvisorContainerdShimTomlPath is the path to givosr-containerd-shim.toml
+	GvisorContainerdShimTomlPath = "/etc/containerd/gvisor-containerd-shim.toml"
+
+	//GvisorConfigTomlTargetName is the go-bindata target name for the gvisor config.toml
+	GvisorConfigTomlTargetName = "gvisor-config.toml"
+	// GvisorContainerdShimTargetName is the go-bindata target name for gvisor-containerd-shim
+	GvisorContainerdShimTargetName = "gvisor-containerd-shim.toml"
+	// DefaultConfigTomlTargetName is the go-bindata target name for the default config.toml
+	DefaultConfigTomlTargetName = "config.toml"
+)


### PR DESCRIPTION
This PR adds the code for enabling gvisor in minikube. It adds the pod
that will run when the addon is enabled, and the code for the image
which will run when this happens.

When gvisor is enabled, the pod will download runsc and the
gvisor-containerd-shim. It will replace the containerd config.toml and
restart containerd.

When gvisor is disabled, the pod will be deleted by the addon manager.
This will trigger a pre-stop hook which will revert the config.toml to
it's original state and restart containerd.

TODO:
- [ ] Add integration test
- [ ] Add docs 