### PR TITLE
Revert "Make k8s v1.12.3 the default"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,7 @@ BUILDROOT_BRANCH ?= 2018.05
 REGISTRY?=gcr.io/k8s-minikube
 
 HYPERKIT_BUILD_IMAGE 	?= karalabe/xgo-1.10.x
-# NOTE: "latest" as of 2018-12-04. kube-cross images aren't updated as often as Kubernetes
-BUILD_IMAGE 	?= k8s.gcr.io/kube-cross:v1.11.1-1
+BUILD_IMAGE 	?= k8s.gcr.io/kube-cross:v1.10.1-1
 ISO_BUILD_IMAGE ?= $(REGISTRY)/buildroot-image
 
 ISO_VERSION ?= v0.30.0

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -22,13 +22,13 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"time"
 
 	"github.com/blang/semver"
 	"github.com/golang/glog"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
 	minikubeVersion "k8s.io/minikube/pkg/version"
+	"time"
 )
 
 // APIServerPort is the port that the API server should listen on.
@@ -125,7 +125,7 @@ const (
 var DefaultIsoUrl = fmt.Sprintf("https://storage.googleapis.com/%s/minikube-%s.iso", minikubeVersion.GetIsoPath(), minikubeVersion.GetIsoVersion())
 var DefaultIsoShaUrl = DefaultIsoUrl + ShaSuffix
 
-var DefaultKubernetesVersion = "v1.12.3"
+var DefaultKubernetesVersion = "v1.10.0"
 
 var ConfigFilePath = MakeMiniPath("config")
 var ConfigFile = MakeMiniPath("config", "config.json")


### PR DESCRIPTION
Reverts kubernetes/minikube#3402

v1.12 takes ~3X longer to start, causing test timeouts. We need to take more exact measurements and understand if there is anything we can do to speed it up.

Related issue: https://github.com/kubernetes/minikube/issues/3386