### PR TITLE
 Only restart docker service if container runtime is docker

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -161,6 +161,15 @@ func runStart(cmd *cobra.Command, args []string) {
 		GPU:                 viper.GetBool(gpu),
 	}
 
+	// Write profile cluster configuration to file
+	clusterConfig := cfg.Config{
+		MachineConfig: config,
+	}
+
+	if err := saveConfig(clusterConfig); err != nil {
+		glog.Errorln("Error saving profile cluster configuration: ", err)
+	}
+
 	fmt.Printf("Starting local Kubernetes %s cluster...\n", viper.GetString(kubernetesVersion))
 	fmt.Println("Starting VM...")
 	var host *host.Host
@@ -235,7 +244,7 @@ func runStart(cmd *cobra.Command, args []string) {
 	}
 
 	// Write profile cluster configuration to file
-	clusterConfig := cfg.Config{
+	clusterConfig = cfg.Config{
 		MachineConfig:    config,
 		KubernetesConfig: kubernetesConfig,
 	}

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -118,7 +118,18 @@ func (k *KubeadmBootstrapper) StartCluster(k8s config.KubernetesConfig) error {
 	preflights := constants.Preflights
 	if k8s.ContainerRuntime != "" {
 		preflights = constants.AlternateRuntimePreflights
+		out, err := k.c.CombinedOutput("sudo modprobe br_netfilter")
+		if err != nil {
+			glog.Infoln(out)
+			return errors.Wrap(err, "sudo modprobe br_netfilter")
+		}
+		out, err = k.c.CombinedOutput("sudo sh -c \"echo '1' > /proc/sys/net/ipv4/ip_forward\"")
+		if err != nil {
+			glog.Infoln(out)
+			return errors.Wrap(err, "creating /proc/sys/net/ipv4/ip_forward")
+		}
 	}
+
 	templateContext := struct {
 		KubeadmConfigFile   string
 		SkipPreflightChecks bool

--- a/pkg/provision/buildroot.go
+++ b/pkg/provision/buildroot.go
@@ -294,7 +294,7 @@ func configureAuth(p *BuildrootProvisioner) error {
 		return errors.Wrap(err, "getting cluster config")
 	}
 
-	if config.KubernetesConfig.ContainerRuntime != "" {
+	if config.MachineConfig.ContainerRuntime != "" {
 		return nil
 	}
 

--- a/pkg/provision/buildroot.go
+++ b/pkg/provision/buildroot.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/bootstrapper"
+	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/sshutil"
 	"k8s.io/minikube/pkg/util"
 )
@@ -286,6 +287,15 @@ func configureAuth(p *BuildrootProvisioner) error {
 		if err := sshRunner.Copy(f); err != nil {
 			return errors.Wrapf(err, "transferring file to machine %v", f)
 		}
+	}
+
+	config, err := config.Load()
+	if err != nil {
+		return errors.Wrap(err, "getting cluster config")
+	}
+
+	if config.KubernetesConfig.ContainerRuntime != "" {
+		return nil
 	}
 
 	dockerCfg, err := p.GenerateDockerOptions(engine.DefaultPort)


### PR DESCRIPTION
Only allow the buildroot provisioner to restart docker if the container
runtime is docker. This change should fix the bug in #3424, since now
docker will not be restarted if the container runtime is containerd.

Also, Added files to fix FileContent--proc-sys-net-bridge-bridge-nf-call-ip-tables precheck error. From this issue: kubernetes/kubeadm#1062
these files need to be added to prevent this precheck error (which occurs when running any container runtime that isn't docker).