### PR TITLE
Pass network-plugin value to kubelet

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -299,6 +299,11 @@ func NewKubeletConfig(k8s config.KubernetesConfig) (string, error) {
 	}
 
 	extraOpts = SetContainerRuntime(extraOpts, k8s.ContainerRuntime)
+
+	if k8s.NetworkPlugin != "" {
+		extraOpts["network-plugin"] = k8s.NetworkPlugin
+	}
+
 	extraFlags := convertToFlags(extraOpts)
 
 	// parses a map of the feature gates for kubelet


### PR DESCRIPTION
Previously, when `minikube start` has been invoked with `--network-plugin=<..>`, the value was not passed to kubelet. Therefore, the additional param `--extra-config=kubelet.network-plugin=<..>` was required.

This PR ensures that the value is being passed to kubelet, so the `extra-config` value is no longer needed.

Fixes #2828.