### PR TITLE
Enable host DNS resolution in virtualbox driver by default

### DIFF
--- a/pkg/minikube/drivers/virtualbox/driver.go
+++ b/pkg/minikube/drivers/virtualbox/driver.go
@@ -48,6 +48,8 @@ func createVirtualboxHost(config cfg.MachineConfig) interface{} {
 	d.NoShare = config.DisableDriverMounts
 	d.NatNicType = defaultVirtualboxNicType
 	d.HostOnlyNicType = defaultVirtualboxNicType
+	d.DNSProxy = false
+	d.HostDNSResolver = true
 
 	return d
 }


### PR DESCRIPTION
Addresses #3451; as such, there is more context over there.

The [default settings for the VirtualBox machine](https://github.com/docker/machine/blob/master/drivers/virtualbox/virtualbox.go#L76) enables `DNSProxy` and disables `HostDNSResolver`.  I'd like to propose reversing these settings.  If the host is used for DNS resolution, we can enable the kubernetes cluster to resolve registry URLs like `registry.kube-system.svc.cluster.local:80`, assuming that the host has properly configured a `cluster.local` resolver that routes traffic to the minikube network.

This should not cause any backwards-incompatible issues (so far as I can tell) and should be a drop-in replacement for what folks are already using.  I am, of course, open to putting this behind some sort of runtime configuration flag.