### PR TITLE
First try "kubeadm reset" without -f, primarily for older versions.

### DIFF
--- a/hack/jenkins/linux_integration_tests_none.sh
+++ b/hack/jenkins/linux_integration_tests_none.sh
@@ -35,8 +35,9 @@ SUDO_PREFIX="sudo -E "
 export KUBECONFIG="/root/.kube/config"
 
 # "none" driver specific cleanup from previous runs.
-# kubeadm
-sudo kubeadm reset -f || true
+
+# Try without -f first, primarily because older kubeadm versions (v1.10) don't support it anyways.
+sudo kubeadm reset || sudo kubeadm reset -f || true
 # Cleanup data directory
 sudo rm -rf /data/*
 # Cleanup old Kubernetes configs


### PR DESCRIPTION
For newer versions, it seems more pleasant anyways. This approach is at
least less ugly than parsing JSON from a shell script to version sniff.

May reduce occurrences of flake #3381
