### PR TITLE
Make k8s v1.12.4 the default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ BUILDROOT_BRANCH ?= 2018.05
 REGISTRY?=gcr.io/k8s-minikube
 
 HYPERKIT_BUILD_IMAGE 	?= karalabe/xgo-1.10.x
-BUILD_IMAGE 	?= k8s.gcr.io/kube-cross:v1.10.1-1
+# NOTE: "latest" as of 2018-12-04. kube-cross images aren't updated as often as Kubernetes
+BUILD_IMAGE 	?= k8s.gcr.io/kube-cross:v1.11.1-1
 ISO_BUILD_IMAGE ?= $(REGISTRY)/buildroot-image
 
 ISO_VERSION ?= v0.31.0

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -127,7 +127,7 @@ kubectl: {{.Kubeconfig}}`
 var DefaultIsoUrl = fmt.Sprintf("https://storage.googleapis.com/%s/minikube-%s.iso", minikubeVersion.GetIsoPath(), minikubeVersion.GetIsoVersion())
 var DefaultIsoShaUrl = DefaultIsoUrl + ShaSuffix
 
-var DefaultKubernetesVersion = "v1.10.0"
+var DefaultKubernetesVersion = "v1.12.3"
 
 var ConfigFilePath = MakeMiniPath("config")
 var ConfigFile = MakeMiniPath("config", "config.json")


### PR DESCRIPTION
Reverts kubernetes/minikube#3423

I can confirm that v1.12.3 runs just as fast as v1.10.0: 1m45s on kvm2.

The question is whether or not this is compatible with containerd/gvisor. We'll see in the tests!