### PR TITLE
Hide KVM signature when using GPU passthrough to support more GPU models

### DIFF
--- a/pkg/drivers/kvm/domain.go
+++ b/pkg/drivers/kvm/domain.go
@@ -36,6 +36,9 @@ const domainTmpl = `
     <acpi/>
     <apic/>
     <pae/>
+    <kvm>
+      <hidden state='on'/>
+    </kvm>
   </features>
   <cpu mode='host-passthrough'/>
   <os>


### PR DESCRIPTION
Currently, when using the GPU passthrough mode, certain GPU models such as Titan X will not work. To reproduce the error:

1) Use a GPU such as Titan X Pascal.
2) Start minikube with `minikube start --vm-driver kvm2  --gpu`
3) Install the NVIDIA driver: `minikube addons enable nvidia-driver-installer`

The driver installation will then fail. Further investigation shows that this is because the command `nvidia-smi` fails with the error `Unable to determine the device handle for GPU 0000:0X:00.0: Unknown Error`.

The error occurs because NVIDIA doesn't seem to support GPU passthrough for certain lower-end models such as the Titan X family.

The fix for this is to hide the KVM hypervisor signature (see [here](https://www.redhat.com/archives/libvir-list/2014-August/msg00744.html)). I have tested this fix with Titan X Pascal and the NVIDIA driver was installed successfully and the GPU works well without any problem in Minikube. As far as I can tell, I don't think there is any negative side effects of hiding the KVM signature. 