### PR TITLE
Extend Jenkins integration test timeout from 30m to 50m.

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -197,7 +197,7 @@ echo ">> Starting ${E2E_BIN} at $(date)"
 ${SUDO_PREFIX}${E2E_BIN} \
   -minikube-start-args="--vm-driver=${VM_DRIVER} ${EXTRA_START_ARGS}" \
   -minikube-args="--v=10 --logtostderr ${EXTRA_ARGS}" \
-  -test.v -test.timeout=30m -binary="${MINIKUBE_BIN}" && result=$? || result=$?
+  -test.v -test.timeout=50m -binary="${MINIKUBE_BIN}" && result=$? || result=$?
 echo ">> ${E2E_BIN} exited with ${result} at $(date)"
 echo ""
 


### PR DESCRIPTION
We've recently added TestFunctionalContainerd, which can take 10-15
minutes, pushing us over the edge in many cases.