### PR TITLE
tee party: Stream cmd output to tests when -v is enabled, and stream SSH output to logs

### DIFF
--- a/pkg/minikube/bootstrapper/ssh_runner.go
+++ b/pkg/minikube/bootstrapper/ssh_runner.go
@@ -80,13 +80,13 @@ func teeSSH(s *ssh.Session, cmd string, outB io.Writer, errB io.Writer) error {
 	wg.Add(2)
 
 	go func() {
-		if err := util.TeeWithPrefix(util.ErrPrefix, errPipe, errB, glog.Infof); err != nil {
+		if err := util.TeePrefix(util.ErrPrefix, errPipe, errB, glog.Infof); err != nil {
 			glog.Errorf("tee stderr: %v", err)
 		}
 		wg.Done()
 	}()
 	go func() {
-		if err := util.TeeWithPrefix(util.OutPrefix, outPipe, outB, glog.Infof); err != nil {
+		if err := util.TeePrefix(util.OutPrefix, outPipe, outB, glog.Infof); err != nil {
 			glog.Errorf("tee stdout: %v", err)
 		}
 		wg.Done()

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -205,10 +205,9 @@ func MaybeChownDirRecursiveToMinikubeUser(dir string) error {
 	return nil
 }
 
-// TeeWithPrefix logs new lines from a reader. Designed to be run in the background.
-func TeeWithPrefix(prefix string, r io.Reader, w io.Writer, logger func(format string, args ...interface{})) error {
+// TeePrefix copies bytes from a reader to writer, logging each new line.
+func TeePrefix(prefix string, r io.Reader, w io.Writer, logger func(format string, args ...interface{})) error {
 	scanner := bufio.NewScanner(r)
-	// Collect individual bytes so that we don't accidentally strip newlines required by callers.
 	scanner.Split(bufio.ScanBytes)
 	var line bytes.Buffer
 

--- a/test/integration/docker_test.go
+++ b/test/integration/docker_test.go
@@ -41,31 +41,31 @@ func TestDocker(t *testing.T) {
 
 	startCmd := fmt.Sprintf("start %s %s %s", mk.StartArgs, mk.Args,
 		"--docker-env=FOO=BAR --docker-env=BAZ=BAT --docker-opt=debug --docker-opt=icc=true")
-	out, err := mk.RunWithContext(ctx, startCmd)
+	stdout, stderr, err := mk.RunWithContext(ctx, startCmd)
 	if err != nil {
-		t.Fatalf("start: %v\nstart out: %s", err, out)
+		t.Fatalf("start: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
 	}
 
 	mk.EnsureRunning()
 
-	out, err = mk.RunWithContext(ctx, "ssh -- systemctl show docker --property=Environment --no-pager")
+	stdout, stderr, err = mk.RunWithContext(ctx, "ssh -- systemctl show docker --property=Environment --no-pager")
 	if err != nil {
-		t.Errorf("docker env: %v\ndocker env out: %s", err, out)
+		t.Errorf("docker env: %v\nstderr: %s", err, stderr)
 	}
 
 	for _, envVar := range []string{"FOO=BAR", "BAZ=BAT"} {
-		if !strings.Contains(string(out), envVar) {
-			t.Errorf("Env var %s missing: %s.", envVar, out)
+		if !strings.Contains(stdout, envVar) {
+			t.Errorf("Env var %s missing: %s.", envVar, stdout)
 		}
 	}
 
-	out, err = mk.RunWithContext(ctx, "ssh -- systemctl show docker --property=ExecStart --no-pager")
+	stdout, stderr, err = mk.RunWithContext(ctx, "ssh -- systemctl show docker --property=ExecStart --no-pager")
 	if err != nil {
-		t.Errorf("ssh show docker: %v\nshow docker out: %s", err, out)
+		t.Errorf("ssh show docker: %v\nstderr: %s", err, stderr)
 	}
 	for _, opt := range []string{"--debug", "--icc=true"} {
-		if !strings.Contains(string(out), opt) {
-			t.Fatalf("Option %s missing from ExecStart: %s.", opt, out)
+		if !strings.Contains(stdout, opt) {
+			t.Fatalf("Option %s missing from ExecStart: %s.", opt, stdout)
 		}
 	}
 }

--- a/test/integration/docker_test.go
+++ b/test/integration/docker_test.go
@@ -40,7 +40,7 @@ func TestDocker(t *testing.T) {
 	mk.RunWithContext(ctx, "delete")
 
 	startCmd := fmt.Sprintf("start %s %s %s", mk.StartArgs, mk.Args,
-		"--docker-env=FOO=BAR --docker-env=BAZ=BAT --docker-opt=debug --docker-opt=icc=true")
+		"--docker-env=FOO=BAR --docker-env=BAZ=BAT --docker-opt=debug --docker-opt=icc=true --alsologtostderr --v=5")
 	stdout, stderr, err := mk.RunWithContext(ctx, startCmd)
 	if err != nil {
 		t.Fatalf("start: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -95,13 +95,13 @@ func (m *MinikubeRunner) teeRun(cmd *exec.Cmd) (string, string, error) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
-		if err := commonutil.TeeWithPrefix(commonutil.ErrPrefix, errPipe, &errB, Logf); err != nil {
+		if err := commonutil.TeePrefix(commonutil.ErrPrefix, errPipe, &errB, Logf); err != nil {
 			m.T.Logf("tee: %v", err)
 		}
 		wg.Done()
 	}()
 	go func() {
-		if err := commonutil.TeeWithPrefix(commonutil.OutPrefix, outPipe, &outB, Logf); err != nil {
+		if err := commonutil.TeePrefix(commonutil.OutPrefix, outPipe, &outB, Logf); err != nil {
 			m.T.Logf("tee: %v", err)
 		}
 		wg.Done()

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -175,9 +175,9 @@ func (m *MinikubeRunner) Start() {
 	switch r := m.Runtime; r {
 	case constants.ContainerdRuntime:
 		containerdFlags := "--container-runtime=containerd --network-plugin=cni --docker-opt containerd=/var/run/containerd/containerd.sock"
-		m.RunCommand(fmt.Sprintf("start %s %s %s --alsologtostderr --v=6", m.StartArgs, m.Args, containerdFlags), true)
+		m.RunCommand(fmt.Sprintf("start %s %s %s --alsologtostderr --v=5", m.StartArgs, m.Args, containerdFlags), true)
 	default:
-		m.RunCommand(fmt.Sprintf("start %s %s --alsologtostderr --v=6", m.StartArgs, m.Args), true)
+		m.RunCommand(fmt.Sprintf("start %s %s --alsologtostderr --v=5", m.StartArgs, m.Args), true)
 	}
 }
 


### PR DESCRIPTION
*Impact on tests*:

When verbose mode is enabled (-v), the integration tests will stream minikube output line-by-line to stdout. This is compatible with the default behavior of goverbose mode, which logs all tests as they are run. See https://golang.org/cmd/go/#hdr-Testing_flags for details.

*Impact on minikube*:

When commands are executed over SSH, the output is streamed line-by-line to glog.Infof(). 

*Impact on integration tests*:

Significantly more test output, but hopfeully much easier to debug mystery problems.