### PR TITLE
Make Kubernetes v1.11.6 the default

### DIFF
--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -127,7 +127,7 @@ kubectl: {{.Kubeconfig}}`
 var DefaultIsoUrl = fmt.Sprintf("https://storage.googleapis.com/%s/minikube-%s.iso", minikubeVersion.GetIsoPath(), minikubeVersion.GetIsoVersion())
 var DefaultIsoShaUrl = DefaultIsoUrl + ShaSuffix
 
-var DefaultKubernetesVersion = "v1.10.0"
+var DefaultKubernetesVersion = "v1.11.6"
 
 var ConfigFilePath = MakeMiniPath("config")
 var ConfigFile = MakeMiniPath("config", "config.json")


### PR DESCRIPTION
In case the v1.12.x mounting tests go poorly.
