### PR TITLE
Defer dashboard deployment until "minikube dashboard" is executed

### DIFF
--- a/cmd/minikube/cmd/dashboard.go
+++ b/cmd/minikube/cmd/dashboard.go
@@ -65,26 +65,30 @@ var dashboardCmd = &cobra.Command{
 		}
 		cluster.EnsureMinikubeRunningOrExit(api, 1)
 
+		fmt.Fprintln(os.Stderr, "Enabling dashboard ...")
 		// Enable the dashboard add-on
 		err = configcmd.Set("dashboard", "true")
 		if err != nil {
-			fmt.Fprintf(os.Stdout, "Unable to enable dashboard: %v", err)
+			fmt.Fprintf(os.Stderr, "Unable to enable dashboard: %v\n", err)
 			os.Exit(1)
 		}
 
 		ns := "kube-system"
 		svc := "kubernetes-dashboard"
+		fmt.Fprintln(os.Stderr, "Verifying dashboard health ...")
 		if err = util.RetryAfter(30, func() error { return service.CheckService(ns, svc) }, 1*time.Second); err != nil {
 			fmt.Fprintf(os.Stderr, "%s:%s is not running: %v\n", ns, svc, err)
 			os.Exit(1)
 		}
 
+		fmt.Fprintln(os.Stderr, "Launching proxy ...")
 		p, hostPort, err := kubectlProxy()
 		if err != nil {
 			glog.Fatalf("kubectl proxy: %v", err)
 		}
 		url := dashboardURL(hostPort, ns, svc)
 
+		fmt.Fprintln(os.Stderr, "Verifying proxy health ...")
 		if err = util.RetryAfter(60, func() error { return checkURL(url) }, 1*time.Second); err != nil {
 			fmt.Fprintf(os.Stderr, "%s is not responding properly: %v\n", url, err)
 			os.Exit(1)

--- a/cmd/minikube/cmd/dashboard.go
+++ b/cmd/minikube/cmd/dashboard.go
@@ -30,11 +30,11 @@ import (
 	"github.com/pkg/browser"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	configcmd "k8s.io/minikube/cmd/minikube/cmd/config"
 	"k8s.io/minikube/pkg/minikube/cluster"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/machine"
 	"k8s.io/minikube/pkg/minikube/service"
-
 	"k8s.io/minikube/pkg/util"
 )
 
@@ -64,6 +64,13 @@ var dashboardCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		cluster.EnsureMinikubeRunningOrExit(api, 1)
+
+		// Enable the dashboard add-on
+		err = configcmd.Set("dashboard", "true")
+		if err != nil {
+			fmt.Fprintf(os.Stdout, "Unable to enable dashboard: %v", err)
+			os.Exit(1)
+		}
 
 		ns := "kube-system"
 		svc := "kubernetes-dashboard"

--- a/cmd/minikube/cmd/dashboard.go
+++ b/cmd/minikube/cmd/dashboard.go
@@ -76,7 +76,7 @@ var dashboardCmd = &cobra.Command{
 		ns := "kube-system"
 		svc := "kubernetes-dashboard"
 		fmt.Fprintln(os.Stderr, "Verifying dashboard health ...")
-		if err = util.RetryAfter(30, func() error { return service.CheckService(ns, svc) }, 1*time.Second); err != nil {
+		if err = util.RetryAfter(180, func() error { return service.CheckService(ns, svc) }, 1*time.Second); err != nil {
 			fmt.Fprintf(os.Stderr, "%s:%s is not running: %v\n", ns, svc, err)
 			os.Exit(1)
 		}

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -74,7 +74,7 @@ var Addons = map[string]*Addon{
 			constants.AddonsPath,
 			"dashboard-svc.yaml",
 			"0640"),
-	}, true, "dashboard"),
+	}, false, "dashboard"),
 	"default-storageclass": NewAddon([]*BinDataAsset{
 		NewBinDataAsset(
 			"deploy/addons/storageclass/storageclass.yaml",

--- a/test/integration/persistence_test.go
+++ b/test/integration/persistence_test.go
@@ -44,10 +44,6 @@ func TestPersistence(t *testing.T) {
 	}
 
 	verify := func(t *testing.T) {
-		if err := util.WaitForDashboardRunning(t); err != nil {
-			t.Fatalf("waiting for dashboard to be up: %v", err)
-		}
-
 		if err := util.WaitForBusyboxRunning(t, "default"); err != nil {
 			t.Fatalf("waiting for busybox to be up: %v", err)
 		}

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -295,18 +295,6 @@ func WaitForBusyboxRunning(t *testing.T, namespace string) error {
 	return commonutil.WaitForPodsWithLabelRunning(client, namespace, selector)
 }
 
-func WaitForDashboardRunning(t *testing.T) error {
-	client, err := commonutil.GetClient()
-	if err != nil {
-		return errors.Wrap(err, "getting kubernetes client")
-	}
-	if err := commonutil.WaitForDeploymentToStabilize(client, "kube-system", "kubernetes-dashboard", time.Minute*10); err != nil {
-		return errors.Wrap(err, "waiting for dashboard deployment to stabilize")
-	}
-
-	return nil
-}
-
 func WaitForIngressControllerRunning(t *testing.T) error {
 	client, err := commonutil.GetClient()
 	if err != nil {


### PR DESCRIPTION
This simplifies cluster startup, and saves about 20MB resident memory (1% of our default VM size). More importantly, it avoids starting unused services, downloading unnecessary files, and gumming the logs up with possibly unimportant error messages relating to them.

This PR doesn't change the behavior substantially, as currently minikube starts the dashboard pod, but only blocks until it's healthy when the "dashboard" command is executed. This PR simply defers the startup as well as the health check.