### PR TITLE
Fix for Minikube #3495

### DIFF
--- a/deploy/addons/storageclass/storageclass.yaml
+++ b/deploy/addons/storageclass/storageclass.yaml
@@ -6,6 +6,6 @@ metadata:
   annotations:
     storageclass.beta.kubernetes.io/is-default-class: "true"
   labels:
-    addonmanager.kubernetes.io/mode: Reconcile
+    addonmanager.kubernetes.io/mode: EnsureExists
 
 provisioner: k8s.io/minikube-hostpath


### PR DESCRIPTION
Change the policy for the minikube-hostpath storage class addon from Reconcile to EnsureExists. When it's set to reconcile, it's impossible to change the default storage class in Minikube because it will keep setting the minikube-hostpath storageclass to default.

Ported from https://github.com/kubernetes/kubernetes/pull/66235
