### PR TITLE
issue# 3499: minikube status missing newline at end of output

### DIFF
--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -111,7 +111,7 @@ var statusCmd = &cobra.Command{
 				cmdUtil.MaybeReportErrorAndExitWithCode(err, internalErrorCode)
 			}
 			if ks {
-				kubeconfigSt = "Correctly Configured: pointing to minikube-vm at " + ip.String()
+				kubeconfigSt = "Correctly Configured: pointing to minikube-vm at " + ip.String() + "\n"
 			} else {
 				kubeconfigSt = "Misconfigured: pointing to stale minikube-vm." +
 					"\nTo fix the kubectl context, run minikube update-context"


### PR DESCRIPTION
Done code changes to display newline at the end of the status message