### PR TITLE
Documentation - Updating golang requirement to 1.11

### DIFF
--- a/docs/contributors/build_guide.md
+++ b/docs/contributors/build_guide.md
@@ -1,5 +1,5 @@
 ### Build Requirements
-* A recent Go distribution (>1.11)
+* A recent Go distribution (>=1.11)
 * If you're not on Linux, you'll need a Docker installation
 * Minikube requires at least 4GB of RAM to compile, which can be problematic when using docker-machine
 

--- a/docs/contributors/build_guide.md
+++ b/docs/contributors/build_guide.md
@@ -1,5 +1,5 @@
 ### Build Requirements
-* A recent Go distribution (>1.8)
+* A recent Go distribution (>1.11)
 * If you're not on Linux, you'll need a Docker installation
 * Minikube requires at least 4GB of RAM to compile, which can be problematic when using docker-machine
 


### PR DESCRIPTION
When running
```
make test
```
golang 1.11 is required due to:

- strings.Builder in https://github.com/kubernetes/minikube/blob/master/pkg/util/utils_test.go#L169
-- strings.Builder was introduced in go 1.10 https://golang.org/pkg/strings/#Builder
- gofmt 1.11 is required for gofmt formatting check step in tests