### PR TITLE
WIP: Add warnings & integration testing for newest/oldest supported --kubernetes-version

### DIFF
--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -127,7 +127,14 @@ kubectl: {{.Kubeconfig}}`
 var DefaultIsoUrl = fmt.Sprintf("https://storage.googleapis.com/%s/minikube-%s.iso", minikubeVersion.GetIsoPath(), minikubeVersion.GetIsoVersion())
 var DefaultIsoShaUrl = DefaultIsoUrl + ShaSuffix
 
-var DefaultKubernetesVersion = "v1.12.4"
+// LatestKubernetesVersion is the most recent version of Kubernetes that we've tested with
+var LatestKubernetesVersion = semver.MustParse("1.13.1")
+
+// DefaultKubernetesVersion is the default installed, and should generally match LatestKubernetesVersion
+var DefaultKubernetesVersion = LatestKubernetesVersion
+
+// OldestKubernetesVersion is the oldest version of Kubernetes we won't complain about
+var OldestKubernetesVersion = semver.MustParse("1.10.12")
 
 var ConfigFilePath = MakeMiniPath("config")
 var ConfigFile = MakeMiniPath("config", "config.json")

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -131,10 +131,10 @@ var DefaultIsoShaUrl = DefaultIsoUrl + ShaSuffix
 var LatestKubernetesVersion = semver.MustParse("1.13.1")
 
 // DefaultKubernetesVersion is the default installed, and should generally match LatestKubernetesVersion
-var DefaultKubernetesVersion = LatestKubernetesVersion
+var DefaultKubernetesVersion = semver.MustParse("v1.12.4")
 
 // OldestKubernetesVersion is the oldest version of Kubernetes we won't complain about
-var OldestKubernetesVersion = semver.MustParse("1.10.12")
+var OldestKubernetesVersion = semver.MustParse("v1.10.12")
 
 var ConfigFilePath = MakeMiniPath("config")
 var ConfigFile = MakeMiniPath("config", "config.json")

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -131,10 +131,10 @@ var DefaultIsoShaUrl = DefaultIsoUrl + ShaSuffix
 var LatestKubernetesVersion = semver.MustParse("1.13.1")
 
 // DefaultKubernetesVersion is the default installed, and should generally match LatestKubernetesVersion
-var DefaultKubernetesVersion = semver.MustParse("v1.12.4")
+var DefaultKubernetesVersion = semver.MustParse("1.12.4")
 
 // OldestKubernetesVersion is the oldest version of Kubernetes we won't complain about
-var OldestKubernetesVersion = semver.MustParse("v1.10.12")
+var OldestKubernetesVersion = semver.MustParse("1.10.12")
 
 var ConfigFilePath = MakeMiniPath("config")
 var ConfigFile = MakeMiniPath("config", "config.json")

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -65,7 +65,7 @@ func (m *MinikubeRunner) Run(cmd string) error {
 func (m *MinikubeRunner) Copy(f assets.CopyableFile) error {
 	path, _ := filepath.Abs(m.BinaryPath)
 	cmd := exec.Command("/bin/bash", "-c", path, "ssh", "--", fmt.Sprintf("cat >> %s", filepath.Join(f.GetTargetDir(), f.GetTargetName())))
-	Logf("Running: %s", cmd)
+	Logf("Running: %v", cmd)
 	return cmd.Run()
 }
 
@@ -153,9 +153,14 @@ func (m *MinikubeRunner) RunDaemon(command string) (*exec.Cmd, *bufio.Reader) {
 
 }
 
-// SetRuntime saves the runtime backend
+// SetRuntime sets the runtime backend
 func (m *MinikubeRunner) SetRuntime(runtime string) {
 	m.Runtime = runtime
+}
+
+// SetExtraStartArgs sets start arguments to use
+func (m *MinikubeRunner) SetStartArgs(args string) {
+	m.StartArgs = args
 }
 
 func (m *MinikubeRunner) SSH(command string) (string, error) {


### PR DESCRIPTION
- Explicitly fail early if --kubernetes-version cannot be parsed (#3253)
- Expliictly fail if a downgrade is attempted (#3379)
- Output a warning if --kubernetes-version falls outside of the currently supported version for a given minikube release.
- Add integration tests for --kubernetes-version=(newest|oldest)
