### PR TITLE
Fix missing a line break for minikube status

### DIFF
--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -113,7 +113,8 @@ const (
 	DefaultStatusFormat = `host: {{.Host}}
 kubelet: {{.Kubelet}}
 apiserver: {{.ApiServer}}
-kubectl: {{.Kubeconfig}}`
+kubectl: {{.Kubeconfig}}
+`
 	DefaultAddonListFormat     = "- {{.AddonName}}: {{.AddonStatus}}\n"
 	DefaultConfigViewFormat    = "- {{.ConfigKey}}: {{.ConfigValue}}\n"
 	DefaultCacheListFormat     = "{{.CacheImage}}\n"


### PR DESCRIPTION
This PR adds a line break at the end of the output of `minikube status` command.

```
$ minikube status
host: Running
kubelet: Running
apiserver: Running
kubectl: Correctly Configured: pointing to minikube-vm at 192.168.99.100<-- missing a linebreak
```