### PR TITLE
Improve failure output when kubeadm init fails

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -341,7 +341,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		fmt.Println("Starting cluster components...")
 		if err := k8sBootstrapper.StartCluster(kubernetesConfig); err != nil {
 			glog.Errorln("Error starting cluster: ", err)
-			cmdutil.MaybeReportErrorAndExit(err)
+			cmdutil.MaybeReportErrorAndExit(fmt.Errorf("%s\nYou may be able to failure logs using: 'minikube logs'\n"))
 		}
 	} else {
 		fmt.Println("Machine exists, restarting cluster components...")

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -340,8 +340,8 @@ func runStart(cmd *cobra.Command, args []string) {
 	if !exists || config.VMDriver == constants.DriverNone {
 		fmt.Println("Starting cluster components...")
 		if err := k8sBootstrapper.StartCluster(kubernetesConfig); err != nil {
-			glog.Errorln("Error starting cluster: ", err)
-			cmdutil.MaybeReportErrorAndExit(fmt.Errorf("%s\nYou may be able to failure logs using: 'minikube logs'\n"))
+			glog.Errorf("Error starting cluster: %v", err)
+			cmdutil.MaybeReportErrorAndExit(err)
 		}
 	} else {
 		fmt.Println("Machine exists, restarting cluster components...")

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -139,17 +139,22 @@ func MaybeReportErrorAndExitWithCode(errToReport error, returnCode int) {
 			`================================================================================
 An error has occurred. Would you like to opt in to sending anonymized crash
 information to minikube to help prevent future errors?
-To opt out of these messages, run the command:
-	minikube config set WantReportErrorPrompt false
+
+To disable this prompt, run: 'minikube config set WantReportErrorPrompt false'
 ================================================================================`)
 		if PromptUserForAccept(os.Stdin) {
-			minikubeConfig.Set(config.WantReportError, "true")
-			err = ReportError(errToReport, constants.ReportingURL)
+			err = minikubeConfig.Set(config.WantReportError, "true")
+			if err == nil {
+				err = ReportError(errToReport, constants.ReportingURL)
+			}
+		} else {
+			fmt.Println("Bummer, perhaps next time!")
 		}
 	}
 	if err != nil {
 		glog.Errorf(err.Error())
 	}
+	fmt.Printf("\n\nminikube failed :( exiting with error code %d\n", returnCode)
 	os.Exit(returnCode)
 }
 
@@ -181,6 +186,7 @@ func PromptUserForAccept(r io.Reader) bool {
 			return false
 		}
 	case <-time.After(30 * time.Second):
+		fmt.Println("Prompt timed out.")
 		return false
 	}
 }

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -130,6 +130,7 @@ func MaybeReportErrorAndExit(errToReport error) {
 	MaybeReportErrorAndExitWithCode(errToReport, 1)
 }
 
+// MaybeReportErrorAndExitWithCode prompts the user if they would like to report a stack trace, and exits.
 func MaybeReportErrorAndExitWithCode(errToReport error, returnCode int) {
 	var err error
 	if viper.GetBool(config.WantReportError) {
@@ -151,8 +152,10 @@ To disable this prompt, run: 'minikube config set WantReportErrorPrompt false'
 			fmt.Println("Bummer, perhaps next time!")
 		}
 	}
+
+	// This happens when the error was created without errors.Wrap(), and thus has no trace data.
 	if err != nil {
-		glog.Errorf(err.Error())
+		glog.Infof("report error failed: %v", err)
 	}
 	fmt.Printf("\n\nminikube failed :( exiting with error code %d\n", returnCode)
 	os.Exit(returnCode)

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -170,7 +170,7 @@ func (k *KubeadmBootstrapper) StartCluster(k8s config.KubernetesConfig) error {
 
 	out, err := k.c.CombinedOutput(b.String())
 	if err != nil {
-		return errors.Wrapf(err, "kubeadm init error %s running command: %s", b.String(), out)
+		return errors.Wrapf(err, "kubeadm init failed: %s\n%s\n", b.String(), out)
 	}
 
 	if version.LT(semver.MustParse("1.10.0-alpha.0")) {

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -170,7 +170,7 @@ func (k *KubeadmBootstrapper) StartCluster(k8s config.KubernetesConfig) error {
 
 	out, err := k.c.CombinedOutput(b.String())
 	if err != nil {
-		return errors.Wrapf(err, "kubeadm init failed: %s\n%s\n", b.String(), out)
+		return errors.Wrapf(err, "kubeadm init: %s\n%s\n", b.String(), out)
 	}
 
 	if version.LT(semver.MustParse("1.10.0-alpha.0")) {

--- a/pkg/minikube/bootstrapper/ssh_runner.go
+++ b/pkg/minikube/bootstrapper/ssh_runner.go
@@ -145,7 +145,7 @@ func (s *SSHRunner) CombinedOutput(cmd string) (string, error) {
 	err = teeSSH(sess, cmd, &combined, &combined)
 	out := combined.b.String()
 	if err != nil {
-		return "", err
+		return out, err
 	}
 	return out, nil
 }


### PR DESCRIPTION
Example output from a run where I passed a bad command-line flag  in:

```
Connecting to cluster...
Setting up kubeconfig...
Stopping extra container runtimes...
Starting cluster components...
E0116 12:11:58.288561  225876 start.go:343] Error starting cluster: kubeadm init: 
sudo /usr/bin/kubeadm init --config /var/lib/kubeadm.yaml --ignore-preflight-errors=DirAvailable--etc-kubernetes-manifests --ignore-preflight-errors=DirAvailable--data-minikube --ignore-preflight-errors=Port-10250 --ignore-preflight-errors=FileAvailable--etc-kubernetes-manifests-kube-scheduler.yaml --ignore-preflight-errors=FileAvailable--etc-kubernetes-manifests-kube-apiserver.yaml --ignore-preflight-errors=FileAvailable--etc-kubernetes-manifests-kube-controller-manager.yaml --ignore-preflight-errors=FileAvailable--etc-kubernetes-manifests-etcd.yaml --ignore-preflight-errors=Swap --ignore-preflight-errors=CRI 

[init] Using Kubernetes version: v1.13.2
[preflight] Running pre-flight checks
        [WARNING Swap]: running with swap on is not supported. Please disable swap
[preflight] Pulling images required for setting up a Kubernetes cluster
[preflight] This might take a minute or two, depending on the speed of your internet connection
[preflight] You can also perform this action in beforehand using 'kubeadm config images pull'
[kubelet-start] Writing kubelet environment file with flags to file "/var/lib/kubelet/kubeadm-flags.env"
[kubelet-start] Writing kubelet configuration to file "/var/lib/kubelet/config.yaml"
[kubelet-start] Activating the kubelet service
[certs] Using certificateDir folder "/var/lib/minikube/certs/"
[certs] Generating "front-proxy-ca" certificate and key
[certs] Generating "front-proxy-client" certificate and key
[certs] Generating "etcd/ca" certificate and key
[certs] Generating "etcd/server" certificate and key
[certs] etcd/server serving cert is signed for DNS names [minikube localhost] and IPs [192.168.39.183 127.0.0.1 ::1]
[certs] Generating "etcd/healthcheck-client" certificate and key
[certs] Generating "etcd/peer" certificate and key
[certs] etcd/peer serving cert is signed for DNS names [minikube localhost] and IPs [192.168.39.183 127.0.0.1 ::1]
[certs] Generating "apiserver-etcd-client" certificate and key
[certs] Using existing ca certificate authority
[certs] Using existing apiserver certificate and key on disk
[certs] Generating "apiserver-kubelet-client" certificate and key
[certs] Generating "sa" key and public key
[kubeconfig] Using kubeconfig folder "/etc/kubernetes"
[kubeconfig] Writing "admin.conf" kubeconfig file
[kubeconfig] Writing "kubelet.conf" kubeconfig file
[kubeconfig] Writing "controller-manager.conf" kubeconfig file
[kubeconfig] Writing "scheduler.conf" kubeconfig file
[control-plane] Using manifest folder "/etc/kubernetes/manifests"
[control-plane] Creating static Pod manifest for "kube-apiserver"
[control-plane] Creating static Pod manifest for "kube-controller-manager"
[control-plane] Creating static Pod manifest for "kube-scheduler"
[etcd] Creating static Pod manifest for local etcd in "/etc/kubernetes/manifests"
[wait-control-plane] Waiting for the kubelet to boot up the control plane as static Pods from directory "/etc/kubernetes/manifests". This can take up to 4m0s
[kubelet-check] Initial timeout of 40s passed.

Unfortunately, an error has occurred:
        timed out waiting for the condition

This error is likely caused by:
        - The kubelet is not running
        - The kubelet is unhealthy due to a misconfiguration of the node in some way (required cgroups disabled)

If you are on a systemd-powered system, you can try to troubleshoot the error with the following commands:
        - 'systemctl status kubelet'
        - 'journalctl -xeu kubelet'

Additionally, a control plane component may have crashed or exited when started by the container runtime.
To troubleshoot, list all containers using your preferred container runtimes CLI, e.g. docker.
Here is one example how you may list all Kubernetes containers running in docker:
        - 'docker ps -a | grep kube | grep -v pause'
        Once you have found the failing container, you can inspect its logs with:
        - 'docker logs CONTAINERID'
error execution phase wait-control-plane: couldn't initialize a Kubernetes cluster

: Process exited with status 1

minikube failed :( exiting with error code 1
```