### PR TITLE
Install upstream runc into /usr/bin/docker-runc

### DIFF
--- a/deploy/iso/minikube-iso/package/docker-bin/docker-bin.mk
+++ b/deploy/iso/minikube-iso/package/docker-bin/docker-bin.mk
@@ -21,11 +21,13 @@ define DOCKER_BIN_INSTALL_TARGET_CMDS
 		$(@D)/docker-containerd-shim \
 		$(TARGET_DIR)/bin/docker-containerd-shim
 
+	# TODO(tstromberg): Remove once we can upgrade to docker 18.09, which can call standard containerd.
 	$(INSTALL) -D -m 0755 \
 		$(@D)/docker-containerd \
 		$(TARGET_DIR)/bin/docker-containerd
 
 	# As of 2019-01, we use upstream runc so that we may update it independently of docker.
+	# TODO(tstromberg): Remove once we can upgrade to docker 18.09, which can call standard runc.
 	$(INSTALL) -D -m 0755 \
 		$(@D)/docker-runc \
 		$(TARGET_DIR)/bin/docker-runc.orig

--- a/deploy/iso/minikube-iso/package/docker-bin/docker-bin.mk
+++ b/deploy/iso/minikube-iso/package/docker-bin/docker-bin.mk
@@ -25,9 +25,10 @@ define DOCKER_BIN_INSTALL_TARGET_CMDS
 		$(@D)/docker-containerd \
 		$(TARGET_DIR)/bin/docker-containerd
 
+	# As of 2019-01, we use upstream runc so that we may update it independently of docker.
 	$(INSTALL) -D -m 0755 \
 		$(@D)/docker-runc \
-		$(TARGET_DIR)/bin/docker-runc
+		$(TARGET_DIR)/bin/docker-runc.orig
 
 	$(INSTALL) -D -m 0755 \
 		$(@D)/docker-containerd-ctr \

--- a/deploy/iso/minikube-iso/package/runc-master/runc-master.mk
+++ b/deploy/iso/minikube-iso/package/runc-master/runc-master.mk
@@ -47,6 +47,8 @@ endef
 
 define RUNC_MASTER_INSTALL_TARGET_CMDS
 	$(INSTALL) -D -m 0755 $(@D)/bin/runc $(TARGET_DIR)/usr/bin/runc
+	# Install the binary in the location where Docker expects it, so that we can keep runc releases in sync.
+	ln $(@D)/bin/runc $(TARGET_DIR)/usr/bin/docker-runc
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
This links runc to docker-runc is so that Docker inside of the guest VM can get the latest runc security update.

Docker's runc doesn't have it yet, and even if it did, the latest Docker versions are not compatible with all supported Kubernetes versions. This allows us to update runc without being beholden to docker-ce release schedules and Kubernetes->docker version incompatibilities.

This will keep the actual docker-runc installed into /usr/bin/docker-runc.orig just as a reminder that strange things are afoot. 

Once we move to Docker 18.09, we can drop this hack as it prefers the upstream runc binary.