### PR TITLE
Stop containerd from running, if it is not desired

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -367,6 +367,14 @@ func runStart(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	if config.VMDriver != constants.DriverNone && (selectedContainerRuntime == constants.CrioRuntime || selectedContainerRuntime == constants.Cri_oRuntime) {
+		fmt.Println("Restarting crio runtime...")
+		// restart crio so that it can monitor all hook dirs
+		if _, err := host.RunSSHCommand("sudo systemctl restart crio"); err != nil {
+			glog.Errorf("Error restarting crio: %v", err)
+		}
+	}
+
 	if config.VMDriver != constants.DriverNone && selectedContainerRuntime == constants.ContainerdRuntime {
 		fmt.Println("Restarting containerd runtime...")
 		// restart containerd so that it can install all plugins

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -361,6 +361,11 @@ func runStart(cmd *cobra.Command, args []string) {
 			glog.Errorf("Error stopping rkt: %v", err)
 		}
 	}
+	if config.VMDriver != constants.DriverNone && selectedContainerRuntime != constants.ContainerdRuntime {
+		if _, err = host.RunSSHCommand("sudo systemctl stop containerd"); err != nil {
+			glog.Errorf("Error stopping containerd: %v", err)
+		}
+	}
 
 	if config.VMDriver != constants.DriverNone && selectedContainerRuntime == constants.ContainerdRuntime {
 		fmt.Println("Restarting containerd runtime...")


### PR DESCRIPTION
Apparently some grpc services are conflicting with crio

"Failed to start streaming server: listen tcp 10.0.2.15:10010: bind: address already in use"