### PR TITLE
Do tagging in a direct clone of upstream

### DIFF
--- a/docs/contributors/releasing_minikube.md
+++ b/docs/contributors/releasing_minikube.md
@@ -55,12 +55,14 @@ Merge the output into CHANGELOG.md. See [PR#3175](https://github.com/kubernetes/
 
 NOTE: Confirm that all release-related PR's have been submitted before doing this step. 
 
-From your own fork of minikube, run:
+Do this in a direct clone of the upstream kubernetes/minikube repository (not your fork!):
 
 ```
-git checkout master
-git tag -a v<version> -m "<version> Release"
-git push upstream v<version>
+git fetch \
+  && git checkout master \
+  && git pull \
+  && git tag -a v<version> -m "<version> Release" \
+  && git push origin v<version>
 ```
 
 ## Build the Release


### PR DESCRIPTION
Otherwise you may run into:

`error: src refspec v0.33.1 matches more than one` errors pushing.