### PR TITLE
Re-remove kube-dns addon

### DIFF
--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -111,23 +111,6 @@ var Addons = map[string]*Addon{
 			"storage-privisioner-glusterfile.yaml",
 			"0640"),
 	}, false, "storage-provisioner-gluster"),
-	"kube-dns": NewAddon([]*BinDataAsset{
-		NewBinDataAsset(
-			"deploy/addons/kube-dns/kube-dns-controller.yaml",
-			constants.AddonsPath,
-			"kube-dns-controller.yaml",
-			"0640"),
-		NewBinDataAsset(
-			"deploy/addons/kube-dns/kube-dns-cm.yaml",
-			constants.AddonsPath,
-			"kube-dns-cm.yaml",
-			"0640"),
-		NewBinDataAsset(
-			"deploy/addons/kube-dns/kube-dns-svc.yaml",
-			constants.AddonsPath,
-			"kube-dns-svc.yaml",
-			"0640"),
-	}, false, "kube-dns"),
 	"heapster": NewAddon([]*BinDataAsset{
 		NewBinDataAsset(
 			"deploy/addons/heapster/influx-grafana-rc.yaml",


### PR DESCRIPTION
`2091f8c` on 11/13/18 removed kube-dns addon
`3c3b736` on 8/8/18 added back in the reference in addons.go (accidentally?) but didn't add deploy/addons/kube-dns/* files referenced
`8bc8816` on 1/15/19 merged in PR #3521 

Now when running `minikube addons list` I see:

```
...snip...
- kube-dns: disabled
...snip
```

and when I run `minikube addons enable kube-dns` I see:

```
Property name kube-dns not found
```

This PR attempts to re-remove `kube-dns` from the addons list.