### PR TITLE
Remove redundant newline in `minikube status`

### DIFF
--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -111,7 +111,7 @@ var statusCmd = &cobra.Command{
 				cmdUtil.MaybeReportErrorAndExitWithCode(err, internalErrorCode)
 			}
 			if ks {
-				kubeconfigSt = "Correctly Configured: pointing to minikube-vm at " + ip.String() + "\n"
+				kubeconfigSt = "Correctly Configured: pointing to minikube-vm at " + ip.String()
 			} else {
 				kubeconfigSt = "Misconfigured: pointing to stale minikube-vm." +
 					"\nTo fix the kubectl context, run minikube update-context"


### PR DESCRIPTION
Both #3502 (which this commit reverts) and #3523 attempted to fix the same issue.
Keeping the change from the latter PR since it fixes it at the source template.