### PR TITLE
Link to the actual kubeadm code, not the issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ minikube service [-n NAMESPACE] [--url] NAME
 
 ## Design
 
-Minikube uses [libmachine](https://github.com/docker/machine/tree/master/libmachine) for provisioning VMs, and [kubeadm](https://github.com/kubernetes/kubeadm) to provision a kubernetes cluster
+Minikube uses [libmachine](https://github.com/docker/machine/tree/master/libmachine) for provisioning VMs, and [kubeadm](https://github.com/kubernetes/kubernetes/tree/master/cmd/kubeadm) to provision a kubernetes cluster
 
 For more information about Minikube, see the [proposal](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/cluster-lifecycle/local-cluster-ux.md).
 


### PR DESCRIPTION
The "kubeadm" repository is just a placeholder, for aggregating GitHub bug reports.

* https://github.com/kubernetes/kubeadm

* https://github.com/kubernetes/kubernetes

Probably _should_ link to Docker Machine and Kubernetes Kubeadm documentation as well ?

* https://docs.docker.com/machine/overview/

* https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm/

A lot of minikube issues are actually better off handled in the sub-components projects directly.