### PR TITLE
remove kvm hidden state from KVM domain spec

### DIFF
--- a/pkg/drivers/kvm/domain.go
+++ b/pkg/drivers/kvm/domain.go
@@ -36,9 +36,6 @@ const domainTmpl = `
     <acpi/>
     <apic/>
     <pae/>
-    <kvm>
-      <hidden state='on'/>
-    </kvm>
   </features>
   <cpu mode='host-passthrough'/>
   <os>


### PR DESCRIPTION
This change removes a KVM feature spec that is not present and will not be in CentOS or RHEL.
The presence of this section prevented minikube from starting in KVM on those hosts.

This prior commit introduced the feature spec, breaking CentOS and RHEL: https://github.com/kubernetes/minikube/commit/7ba01b40a9fa911f05fa0141cb8c564953ec3dfd

Unfortunately, RH has decided not to enable the VM hiding feature in KVM on RHEL and CentOS:
https://bugzilla.redhat.com/show_bug.cgi?id=1492173

ISSUE REFERENCE: https://github.com/kubernetes/minikube/issues/3546



