### PR TITLE
Issue #3253, improve kubernetes-version error string

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/versions.go
+++ b/pkg/minikube/bootstrapper/kubeadm/versions.go
@@ -156,7 +156,7 @@ func ParseKubernetesVersion(version string) (semver.Version, error) {
 	// Strip leading 'v' prefix from version for semver parsing
 	v, err := semver.Make(version[1:])
 	if err != nil {
-		return semver.Version{}, errors.Wrap(err, "parsing kubernetes version")
+		return semver.Version{}, errors.Wrap(err, "invalid version, must begin with 'v'")
 	}
 
 	return v, nil


### PR DESCRIPTION
Since the kubernetes version is used in creating the URLs to grab binaries, not including the 'v' would require adding it back in certain places. Simply adding a better error message.