### PR TITLE
Enable CNI for alternative runtimes

### DIFF
--- a/cmd/minikube/cmd/config/validations.go
+++ b/cmd/minikube/cmd/config/validations.go
@@ -142,7 +142,7 @@ minikube stop
 
 and then start minikube again with the following flags:
 
-minikube start --container-runtime=containerd  --docker-opt containerd=/var/run/containerd/containerd.sock --network-plugin=cni`)
+minikube start --container-runtime=containerd --docker-opt containerd=/var/run/containerd/containerd.sock`)
 	}
 
 	return nil

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -219,9 +219,12 @@ func runStart(cmd *cobra.Command, args []string) {
 		cmdutil.MaybeReportErrorAndExit(err)
 	}
 
+	selectedContainerRuntime := viper.GetString(containerRuntime)
+	selectedNetworkPlugin := viper.GetString(networkPlugin)
+	selectedEnableDefaultCNI := viper.GetBool(enableDefaultCNI)
+
 	// common config (currently none)
 	var cricfg = map[string]string{}
-	selectedContainerRuntime := viper.GetString(containerRuntime)
 	if cricfg := SetContainerRuntime(cricfg, selectedContainerRuntime); cricfg != nil {
 		var command string
 		fmt.Println("Writing crictl config...")
@@ -267,11 +270,11 @@ func runStart(cmd *cobra.Command, args []string) {
 		FeatureGates:           viper.GetString(featureGates),
 		ContainerRuntime:       selectedContainerRuntime,
 		CRISocket:              viper.GetString(criSocket),
-		NetworkPlugin:          viper.GetString(networkPlugin),
+		NetworkPlugin:          selectedNetworkPlugin,
 		ServiceCIDR:            viper.GetString(serviceCIDR),
 		ExtraOptions:           extraOptions,
 		ShouldLoadCachedImages: shouldCacheImages,
-		EnableDefaultCNI:       viper.GetBool(enableDefaultCNI),
+		EnableDefaultCNI:       selectedEnableDefaultCNI,
 	}
 
 	k8sBootstrapper, err := GetClusterBootstrapper(api, clusterBootstrapper)

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -237,9 +237,9 @@ func runStart(cmd *cobra.Command, args []string) {
 	}
 	// default network plugin (cni)
 	if selectedContainerRuntime != "" {
-		if !viper.IsSet(networkPlugin) {
+		if !cmd.Flags().Changed(networkPlugin) {
 			selectedNetworkPlugin = "cni"
-			if !viper.IsSet(enableDefaultCNI) {
+			if !cmd.Flags().Changed(enableDefaultCNI) {
 				selectedEnableDefaultCNI = true
 			}
 		}

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -235,6 +235,15 @@ func runStart(cmd *cobra.Command, args []string) {
 			glog.Errorln("Error writing crictl config: ", err)
 		}
 	}
+	// default network plugin (cni)
+	if selectedContainerRuntime != "" {
+		if !viper.IsSet(networkPlugin) {
+			selectedNetworkPlugin = "cni"
+			if !viper.IsSet(enableDefaultCNI) {
+				selectedEnableDefaultCNI = true
+			}
+		}
+	}
 
 	selectedKubernetesVersion := viper.GetString(kubernetesVersion)
 	if strings.Compare(selectedKubernetesVersion, "") == 0 {

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -209,7 +209,8 @@ func runStart(cmd *cobra.Command, args []string) {
 	selectedEnableDefaultCNI := viper.GetBool(enableDefaultCNI)
 
 	// default network plugin (cni)
-	if selectedContainerRuntime != "" {
+	r, err := cruntime.New(cruntime.Config{Type: selectedContainerRuntime})
+	if err == nil && r.DefaultCNI() {
 		if !cmd.Flags().Changed(networkPlugin) {
 			selectedNetworkPlugin = "cni"
 			if !cmd.Flags().Changed(enableDefaultCNI) {

--- a/deploy/addons/gvisor/README.md
+++ b/deploy/addons/gvisor/README.md
@@ -7,8 +7,7 @@ When starting minikube, specify the following flags, along with any additional d
 
 ```shell
 $ minikube start --container-runtime=containerd  \
-    --docker-opt containerd=/var/run/containerd/containerd.sock \
-    --network-plugin=cni --enable-default-cni
+    --docker-opt containerd=/var/run/containerd/containerd.sock
 ```
 
 ### Enabling gVisor

--- a/docs/alternative_runtimes.md
+++ b/docs/alternative_runtimes.md
@@ -3,10 +3,7 @@
 To use [rkt](https://github.com/coreos/rkt) as the container runtime run:
 
 ```shell
-$ minikube start \
-    --network-plugin=cni \
-    --enable-default-cni \
-    --container-runtime=rkt
+$ minikube start --container-runtime=rkt
 ```
 
 
@@ -15,19 +12,15 @@ $ minikube start \
 To use [CRI-O](https://github.com/kubernetes-incubator/cri-o) as the container runtime, run:
 
 ```shell
-$ minikube start \
-    --network-plugin=cni \
-    --enable-default-cni \
-    --container-runtime=cri-o
+$ minikube start --container-runtime=cri-o
 ```
 
 Or you can use the extended version:
 
 ```shell
-$ minikube start \
+$ minikube start --container-runtime=cri-o \
     --network-plugin=cni \
     --enable-default-cni \
-    --container-runtime=cri-o \
     --cri-socket=/var/run/crio/crio.sock \
     --extra-config=kubelet.container-runtime=remote \
     --extra-config=kubelet.container-runtime-endpoint=unix:///var/run/crio/crio.sock \
@@ -39,19 +32,15 @@ $ minikube start \
 To use [containerd](https://github.com/containerd/containerd) as the container runtime, run:
 
 ```shell
-$ minikube start \
-    --network-plugin=cni \
-    --enable-default-cni \
-    --container-runtime=containerd
+$ minikube start --container-runtime=containerd
 ```
 
 Or you can use the extended version:
 
 ```shell
-$ minikube start \
+$ minikube start --container-runtime=containerd \
     --network-plugin=cni \
     --enable-default-cni \
-    --container-runtime=containerd \
     --cri-socket=/run/containerd/containerd.sock \
     --extra-config=kubelet.container-runtime=remote \
     --extra-config=kubelet.container-runtime-endpoint=unix:///run/containerd/containerd.sock \

--- a/docs/contributors/minikube_iso.md
+++ b/docs/contributors/minikube_iso.md
@@ -39,8 +39,6 @@ The bootable ISO image will be available in `out/minikube.iso`.
 ```shell
 $ ./out/minikube start \
     --container-runtime=rkt \
-    --network-plugin=cni \
-    --enable-default-cni \
     --iso-url=file://$GOPATH/src/k8s.io/minikube/out/minikube.iso
 ```
 

--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -41,6 +41,11 @@ func (r *Containerd) SocketPath() string {
 	return "/run/containerd/containerd.sock"
 }
 
+// DefaultCNI returns whether to use CNI networking by default
+func (r *Containerd) DefaultCNI() bool {
+	return true
+}
+
 // Active returns if containerd is active on the host
 func (r *Containerd) Active() bool {
 	err := r.Runner.Run("systemctl is-active --quiet service containerd")

--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -41,6 +41,11 @@ func (r *CRIO) SocketPath() string {
 	return "/var/run/crio/crio.sock"
 }
 
+// DefaultCNI returns whether to use CNI networking by default
+func (r *CRIO) DefaultCNI() bool {
+	return true
+}
+
 // Available returns an error if it is not possible to use this runtime on a host
 func (r *CRIO) Available() error {
 	return r.Runner.Run("command -v crio")

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -49,6 +49,8 @@ type Manager interface {
 	KubeletOptions() map[string]string
 	// SocketPath returns the path to the socket file for a given runtime
 	SocketPath() string
+	// DefaultCNI returns whether to use CNI networking by default
+	DefaultCNI() bool
 
 	// Load an image idempotently into the runtime on a host
 	LoadImage(string) error

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -40,6 +40,11 @@ func (r *Docker) SocketPath() string {
 	return r.Socket
 }
 
+// DefaultCNI returns whether to use CNI networking by default
+func (r *Docker) DefaultCNI() bool {
+	return false
+}
+
 // Available returns an error if it is not possible to use this runtime on a host
 func (r *Docker) Available() error {
 	_, err := exec.LookPath("docker")

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -208,9 +208,9 @@ func (m *MinikubeRunner) Start() {
 	// TODO(tstromberg): Deprecate this in favor of making it possible for tests to define explicit flags.
 	switch r := m.Runtime; r {
 	case constants.ContainerdRuntime:
-		opts = "--container-runtime=containerd --network-plugin=cni --enable-default-cni --docker-opt containerd=/var/run/containerd/containerd.sock"
+		opts = "--container-runtime=containerd --docker-opt containerd=/var/run/containerd/containerd.sock"
 	case constants.CrioRuntime:
-		opts = "--container-runtime=crio --network-plugin=cni --enable-default-cni"
+		opts = "--container-runtime=crio"
 	}
 	m.RunCommand(fmt.Sprintf("start %s %s %s --alsologtostderr --v=5", m.StartArgs, m.Args, opts), true)
 


### PR DESCRIPTION

Add `--network-plugin=cni` and `--enable-default-cni` by default, when setting `--container-runtime`

It is still possible for the user to choose different values (if required), by providing the needed flags explicitly.

Closes #3567