### PR TITLE
crio: use official kube pause image from gcr

### DIFF
--- a/deploy/iso/minikube-iso/package/crio-bin/crio.conf
+++ b/deploy/iso/minikube-iso/package/crio-bin/crio.conf
@@ -122,7 +122,7 @@ log_size_max = -1
 default_transport = "docker://"
 
 # pause_image is the image which we use to instantiate infra containers.
-pause_image = "kubernetes/pause"
+pause_image = "k8s.gcr.io/pause:3.1"
 
 # pause_command is the command to run in a pause_image to have a container just
 # sit there.  If the image contains the necessary information, this value need


### PR DESCRIPTION
Same as https://github.com/kubernetes-sigs/cri-o/commit/3e9011a7a828032c9ad50e054fae22c34ee990aa

Avoids this scenario:
``` console
$ sudo crictl images | grep pause
docker.io/kubernetes/pause                 latest              f9d5de0795395       251kB
k8s.gcr.io/pause                           3.1                 da86e6ba6ca19       746kB
k8s.gcr.io/pause-amd64                     3.1                 da86e6ba6ca19       746kB
```

Still not sure where that "pause-amd64" came from.