### PR TITLE
drivers.md: Require Ubuntu >=18.04

### DIFF
--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -21,6 +21,11 @@ the host PATH:
 The KVM2 driver is intended to replace KVM driver.
 The KVM2 driver is maintained by the minikube team, and is built, tested and released with minikube.
 
+NOTE: Currently the following instruction doesn't work for
+Ubuntu prior to 18.04 because the docker-machine-driver-kvm2 binary
+provided by the URL needs libvirt 3.0.0 or later.
+You can workaround it by building the binary by yourself.
+
 To install the KVM2 driver, first install and configure the prereqs:
 
 ```shell


### PR DESCRIPTION
Stop pretending to support old versions of Ubuntu.
The instruction in this section doesn't work on Ubuntu xenial
becuase the provided driver binary requires a later version of libvirt.

    % ./docker-machine-driver-kvm2
    ./docker-machine-driver-kvm2: /usr/lib/x86_64-linux-gnu/libvirt-lxc.so.0: version `LIBVIRT_LXC_2.0.0' not found (required by ./docker-machine-driver-kvm2)
    ./docker-machine-driver-kvm2: /usr/lib/x86_64-linux-gnu/libvirt.so.0: version `LIBVIRT_2.2.0' not found (required by ./docker-machine-driver-kvm2)
    ./docker-machine-driver-kvm2: /usr/lib/x86_64-linux-gnu/libvirt.so.0: version `LIBVIRT_3.0.0' not found (required by ./docker-machine-driver-kvm2)
    ./docker-machine-driver-kvm2: /usr/lib/x86_64-linux-gnu/libvirt.so.0: version `LIBVIRT_1.3.3' not found (required by ./docker-machine-driver-kvm2)
    ./docker-machine-driver-kvm2: /usr/lib/x86_64-linux-gnu/libvirt.so.0: version `LIBVIRT_2.0.0' not found (required by ./docker-machine-driver-kvm2)
    %