### PR TITLE
Avoid double unlock of image load mutex

### DIFF
--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -223,7 +223,6 @@ func LoadFromCacheBlocking(cr bootstrapper.CommandRunner, k8s config.KubernetesC
 	if err != nil {
 		return errors.Wrapf(err, "%s load %s", r.Name(), dst)
 	}
-	loadImageLock.Unlock()
 
 	if err := cr.Run("sudo rm -rf " + dst); err != nil {
 		return errors.Wrap(err, "deleting temp docker image location")


### PR DESCRIPTION
Causes a runtime crash, with --cache-images:

"fatal error: sync: unlock of unlocked mutex"