### PR TITLE
Add DeleteCluster to bootstrapper

### DIFF
--- a/pkg/minikube/bootstrapper/bootstrapper.go
+++ b/pkg/minikube/bootstrapper/bootstrapper.go
@@ -31,6 +31,7 @@ type Bootstrapper interface {
 	StartCluster(config.KubernetesConfig) error
 	UpdateCluster(config.KubernetesConfig) error
 	RestartCluster(config.KubernetesConfig) error
+	DeleteCluster(config.KubernetesConfig) error
 	GetClusterLogsTo(follow bool, out io.Writer) error
 	SetupCerts(cfg config.KubernetesConfig) error
 	GetKubeletStatus() (string, error)

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -253,6 +253,16 @@ func (k *KubeadmBootstrapper) RestartCluster(k8s config.KubernetesConfig) error 
 	return nil
 }
 
+// DeleteCluster removes the components that were started earlier
+func (k *KubeadmBootstrapper) DeleteCluster(k8s config.KubernetesConfig) error {
+	cmd := fmt.Sprintf("sudo kubeadm reset --config %s", constants.KubeadmConfigFile)
+	if err := k.c.Run(cmd); err != nil {
+		return errors.Wrapf(err, "running cmd: %s", cmd)
+	}
+
+	return nil
+}
+
 // PullImages downloads images that will be used by RestartCluster
 func (k *KubeadmBootstrapper) PullImages(k8s config.KubernetesConfig) error {
 	cmd := fmt.Sprintf("sudo kubeadm config images pull --config %s", constants.KubeadmConfigFile)

--- a/pkg/minikube/console/style.go
+++ b/pkg/minikube/console/style.go
@@ -57,6 +57,7 @@ var styles = map[string]style{
 	"caching":           {Prefix: "🤹  "},
 	"starting-vm":       {Prefix: "🔥  "},
 	"starting-none":     {Prefix: "🤹  "},
+	"resetting":         {Prefix: "🔄  "},
 	"deleting-vm":       {Prefix: "🔥  "},
 	"copying":           {Prefix: "✨  "},
 	"connectivity":      {Prefix: "📶  "},


### PR DESCRIPTION
This matches StartCluster, and is used to revert
the changes done to reset the VM machine state.

Even if it fails, continue to deleting the VM...
Make sure to handle the case of missing config.

Closes #3637