### PR TITLE
Complete the cruntime implementation for CRI runtimes

### DIFF
--- a/deploy/iso/minikube-iso/package/crio-bin/crio.service
+++ b/deploy/iso/minikube-iso/package/crio-bin/crio.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Open Container Initiative Daemon
-Documentation=https://github.com/kubernetes-incubator/cri-o
+Documentation=https://github.com/kubernetes-sigs/cri-o
 After=network-online.target minikube-automount.service
 Requires=minikube-automount.service
 

--- a/docs/alternative_runtimes.md
+++ b/docs/alternative_runtimes.md
@@ -9,7 +9,7 @@ $ minikube start --container-runtime=rkt
 
 ### Using CRI-O
 
-To use [CRI-O](https://github.com/kubernetes-incubator/cri-o) as the container runtime, run:
+To use [CRI-O](https://github.com/kubernetes-sigs/cri-o) as the container runtime, run:
 
 ```shell
 $ minikube start --container-runtime=cri-o

--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -79,7 +79,8 @@ func (r *Containerd) Disable() error {
 
 // LoadImage loads an image into this runtime
 func (r *Containerd) LoadImage(path string) error {
-	return pullImageCRI(r.Runner, path)
+	glog.Infof("Loading image: %s", path)
+	return r.Runner.Run(fmt.Sprintf("sudo ctr cri load %s", path))
 }
 
 // KubeletOptions returns kubelet options for a containerd

--- a/pkg/minikube/cruntime/cri.go
+++ b/pkg/minikube/cruntime/cri.go
@@ -21,20 +21,12 @@ import (
 	"fmt"
 	"html/template"
 	"path"
-
-	"github.com/golang/glog"
 )
 
 // listCRIContainers returns a list of containers using crictl
 func listCRIContainers(_ CommandRunner, _ string) ([]string, error) {
 	// Should use crictl ps -a, but needs some massaging and testing.
 	return []string{}, fmt.Errorf("unimplemented")
-}
-
-// pullImageCRI uses ctr to pull images into a CRI runtime
-func pullImageCRI(cr CommandRunner, path string) error {
-	glog.Infof("Loading image: %s", path)
-	return cr.Run(fmt.Sprintf("sudo ctr cri load %s", path))
 }
 
 // criCRIContainers kills a list of containers using crictl

--- a/pkg/minikube/cruntime/cri.go
+++ b/pkg/minikube/cruntime/cri.go
@@ -21,22 +21,26 @@ import (
 	"fmt"
 	"html/template"
 	"path"
+	"strings"
 )
 
 // listCRIContainers returns a list of containers using crictl
-func listCRIContainers(_ CommandRunner, _ string) ([]string, error) {
-	// Should use crictl ps -a, but needs some massaging and testing.
-	return []string{}, fmt.Errorf("unimplemented")
+func listCRIContainers(cr CommandRunner, filter string) ([]string, error) {
+	content, err := cr.CombinedOutput(fmt.Sprintf(`sudo crictl ps -a --name=%s --quiet`, filter))
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(content, "\n"), nil
 }
 
 // criCRIContainers kills a list of containers using crictl
-func killCRIContainers(CommandRunner, []string) error {
-	return fmt.Errorf("unimplemented")
+func killCRIContainers(cr CommandRunner, ids []string) error {
+	return cr.Run(fmt.Sprintf("sudo crictl rm %s", strings.Join(ids, " ")))
 }
 
 // stopCRIContainers stops containers using crictl
-func stopCRIContainers(CommandRunner, []string) error {
-	return fmt.Errorf("unimplemented")
+func stopCRIContainers(cr CommandRunner, ids []string) error {
+	return cr.Run(fmt.Sprintf("sudo crictl stop %s", strings.Join(ids, " ")))
 }
 
 // populateCRIConfig sets up /etc/crictl.yaml

--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -78,9 +78,8 @@ func (r *CRIO) Disable() error {
 
 // LoadImage loads an image into this runtime
 func (r *CRIO) LoadImage(path string) error {
-	// This should use ctr via pullImageCRI once we sort out why api.v1.CRIPluginService is unimplemented.
+	glog.Infof("Loading image: %s", path)
 	return r.Runner.Run(fmt.Sprintf("sudo podman load -i %s", path))
-
 }
 
 // KubeletOptions returns kubelet options for a runtime.

--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -30,7 +30,7 @@ type CRIO struct {
 
 // Name is a human readable name for CRIO
 func (r *CRIO) Name() string {
-	return "CRIO"
+	return "CRI-O"
 }
 
 // SocketPath returns the path to the socket file for CRIO

--- a/pkg/minikube/cruntime/cruntime_test.go
+++ b/pkg/minikube/cruntime/cruntime_test.go
@@ -31,8 +31,8 @@ func TestName(t *testing.T) {
 	}{
 		{"", "Docker"},
 		{"docker", "Docker"},
-		{"crio", "CRIO"},
-		{"cri-o", "CRIO"},
+		{"crio", "CRI-O"},
+		{"cri-o", "CRI-O"},
 		{"containerd", "containerd"},
 	}
 	for _, tc := range tests {

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -209,7 +209,7 @@ func (m *MinikubeRunner) Start() {
 	case "containerd":
 		opts = "--container-runtime=containerd --docker-opt containerd=/var/run/containerd/containerd.sock"
 	case "crio":
-		opts = "--container-runtime=crio"
+		opts = "--container-runtime=cri-o"
 	}
 	m.RunCommand(fmt.Sprintf("start %s %s %s --alsologtostderr --v=5", m.StartArgs, m.Args, opts), true)
 


### PR DESCRIPTION
This should implement the following `Manager` interfaces:

``` go
        // Load an image idempotently into the runtime on a host
        LoadImage(string) error

        // ListContainers returns a list of managed by this container runtime
        ListContainers(string) ([]string, error)
        // KillContainers removes containers based on ID
        KillContainers([]string) error
        // StopContainers stops containers based on ID
        StopContainers([]string) error
```

Need to use runtime-specific code, to load images from path.

Unfortunately the standard only covers pulling from a registry.