### PR TITLE
Clearer output when re-using VM's so that users know what they are waiting on

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -329,12 +329,6 @@ func startHost(api libmachine.API, mc cfg.MachineConfig) (*host.Host, bool) {
 	if mc.VMDriver == constants.DriverNone {
 		console.OutStyle("starting-none", "Configuring local host environment ...")
 		prepareNone()
-	} else {
-		if exists {
-			console.OutStyle("waiting", "Spinning up existing VM for %q ...", cfg.GetMachineName())
-		} else {
-			console.OutStyle("starting-vm", "Creating %s VM (CPUs=%d, Memory=%dMB, Disk=%dMB) ...", mc.VMDriver, mc.CPUs, mc.Memory, mc.DiskSize)
-		}
 	}
 
 	var host *host.Host

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -96,7 +96,10 @@ func StartHost(api libmachine.API, config cfg.MachineConfig) (*host.Host, error)
 		return nil, errors.Wrap(err, "Error getting state for host")
 	}
 
-	if s != state.Running {
+	if s == state.Running {
+		console.OutStyle("running", "Re-using the currently running %s VM for %q ...", h.Driver.DriverName(), cfg.GetMachineName())
+	} else {
+		console.OutStyle("restarting", "Restarting existing %s VM for %q ...", h.Driver.DriverName(), cfg.GetMachineName())
 		if err := h.Driver.Start(); err != nil {
 			return nil, errors.Wrap(err, "start")
 		}
@@ -106,6 +109,11 @@ func StartHost(api libmachine.API, config cfg.MachineConfig) (*host.Host, error)
 	}
 
 	e := engineOptions(config)
+	glog.Infof("engine options: %+v", e)
+
+	// Slightly counter-intuitive, but this is what DetectProvisioner & ConfigureAuth block on.
+	console.OutStyle("waiting", "Waiting for SSH access ...")
+
 	if len(e.Env) > 0 {
 		h.HostOptions.EngineOptions.Env = e.Env
 		provisioner, err := provision.DetectProvisioner(h.Driver)
@@ -240,6 +248,7 @@ func createHost(api libmachine.API, config cfg.MachineConfig) (*host.Host, error
 		return nil, err
 	}
 
+	console.OutStyle("starting-vm", "Creating %s VM (CPUs=%d, Memory=%dMB, Disk=%dMB) ...", config.VMDriver, config.CPUs, config.Memory, config.DiskSize)
 	def, err := registry.Driver(config.VMDriver)
 	if err != nil {
 		if err == registry.ErrDriverNotFound {

--- a/pkg/minikube/console/style.go
+++ b/pkg/minikube/console/style.go
@@ -33,23 +33,25 @@ type style struct {
 // styles is a map of style name to style struct
 // For consistency, ensure that emojis added render with the same width across platforms.
 var styles = map[string]style{
-	"happy":      {Prefix: "😄  "},
-	"success":    {Prefix: "✅  "},
-	"failure":    {Prefix: "❌  "},
-	"conflict":   {Prefix: "💥  "},
-	"fatal":      {Prefix: "💣  "},
-	"notice":     {Prefix: "📌  "},
-	"ready":      {Prefix: "🏄  "},
-	"restarting": {Prefix: "🔄  "},
-	"stopping":   {Prefix: "✋  "},
-	"stopped":    {Prefix: "🛑  "},
-	"warning":    {Prefix: "⚠️  "},
-	"waiting":    {Prefix: "⌛  "},
-	"usage":      {Prefix: "💡  "},
-	"launch":     {Prefix: "🚀  "},
-	"thumbs-up":  {Prefix: "👍  "},
-	"option":     {Prefix: "    ▪ "}, // Indented bullet
-	"crushed":    {Prefix: "💔  "},
+	"happy":        {Prefix: "😄  "},
+	"success":      {Prefix: "✅  "},
+	"failure":      {Prefix: "❌  "},
+	"conflict":     {Prefix: "💥  "},
+	"fatal":        {Prefix: "💣  "},
+	"notice":       {Prefix: "📌  "},
+	"ready":        {Prefix: "🏄  "},
+	"restarting":   {Prefix: "🔄  "},
+	"running":      {Prefix: "🏃  "},
+	"provisioning": {Prefix: "🌱  "},
+	"stopping":     {Prefix: "✋  "},
+	"stopped":      {Prefix: "🛑  "},
+	"warning":      {Prefix: "⚠️  "},
+	"waiting":      {Prefix: "⌛  "},
+	"usage":        {Prefix: "💡  "},
+	"launch":       {Prefix: "🚀  "},
+	"thumbs-up":    {Prefix: "👍  "},
+	"option":       {Prefix: "    ▪ "}, // Indented bullet
+	"crushed":      {Prefix: "💔  "},
 
 	// Specialized purpose styles
 	"iso-download":      {Prefix: "💿  "},


### PR DESCRIPTION
I was blocked on waiting for SSH to happen, but couldn't tell that from the existing output.

Also, made the order of output messages more logical, particularly when we warn about using a VM from a different hypervisor.