### PR TITLE
Fix to not execute clusterBootstrapper.Delete when clusterBootstrappe…

### DIFF
--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -59,7 +59,7 @@ associated files.`,
 			bsName := viper.GetString(cmdcfg.Bootstrapper) // Name ?
 			console.OutStyle("resetting", "Reverting Kubernetes %s using %s ...", kc.KubernetesVersion, bsName)
 			clusterBootstrapper, err := GetClusterBootstrapper(api, viper.GetString(cmdcfg.Bootstrapper))
-			if err != nil {
+			if err == nil {
 				if err = clusterBootstrapper.DeleteCluster(kc); err != nil {
 					console.ErrLn("Failed to delete cluster: %v", err)
 				}


### PR DESCRIPTION
Fix to not execute clusterBootstrapper.Delete when clusterBootstrapper is nil #3662 
https://github.com/kubernetes/minikube/issues/3662#issuecomment-463011767