### PR TITLE
Check that a style exists for all runtimes

### DIFF
--- a/pkg/minikube/console/console.go
+++ b/pkg/minikube/console/console.go
@@ -63,6 +63,11 @@ type fdWriter interface {
 	Fd() uintptr
 }
 
+// HasStyle checks if a style exists
+func HasStyle(style string) bool {
+	return hasStyle(style)
+}
+
 // OutStyle writes a stylized and formatted message to stdout
 func OutStyle(style, format string, a ...interface{}) error {
 	OutStyle, err := applyStyle(style, useColor, fmt.Sprintf(format, a...))

--- a/pkg/minikube/console/style.go
+++ b/pkg/minikube/console/style.go
@@ -66,7 +66,7 @@ var styles = map[string]style{
 	"celebrate":         {Prefix: "🎉  "},
 	"container-runtime": {Prefix: "🎁  "},
 	"Docker":            {Prefix: "🐳  "},
-	"CRIO":              {Prefix: "🎁  "}, // This should be a snow-flake, but the emoji has a strange width on macOS
+	"CRI-O":             {Prefix: "🎁  "}, // This should be a snow-flake, but the emoji has a strange width on macOS
 	"containerd":        {Prefix: "📦  "},
 	"permissions":       {Prefix: "🔑  "},
 	"enabling":          {Prefix: "🔌  "},
@@ -86,6 +86,11 @@ func applyPrefix(prefix, format string) string {
 	}
 	// TODO(tstromberg): Ensure compatibility with RTL languages.
 	return prefix + format
+}
+
+func hasStyle(style string) bool {
+	_, exists := styles[style]
+	return exists
 }
 
 // Apply styling to a format string

--- a/pkg/minikube/cruntime/cruntime_test.go
+++ b/pkg/minikube/cruntime/cruntime_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"k8s.io/minikube/pkg/minikube/console"
 )
 
 func TestName(t *testing.T) {
@@ -44,6 +45,9 @@ func TestName(t *testing.T) {
 			got := r.Name()
 			if got != tc.want {
 				t.Errorf("Name(%s) = %q, want: %q", tc.runtime, got, tc.want)
+			}
+			if !console.HasStyle(got) {
+				t.Fatalf("console.HasStyle(%s): %v", got, false)
 			}
 		})
 	}


### PR DESCRIPTION
Including CRI-O, which recently got a "new" name...

It is loaded at runtime, so could break otherwise.