### PR TITLE
none UX: Reword warnings and other strings for accuracy

### DIFF
--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -61,7 +61,9 @@ associated files.`,
 			bsName := viper.GetString(cmdcfg.Bootstrapper)
 			console.OutStyle("resetting", "Uninstalling Kubernetes %s using %s ...", kc.KubernetesVersion, bsName)
 			clusterBootstrapper, err := GetClusterBootstrapper(api, viper.GetString(cmdcfg.Bootstrapper))
-			if err == nil {
+			if err != nil {
+				console.ErrLn("Unable to get bootstrapper: %v", err)
+			} else {
 				if err = clusterBootstrapper.DeleteCluster(kc); err != nil {
 					console.ErrLn("Failed to delete cluster: %v", err)
 				}
@@ -71,9 +73,9 @@ associated files.`,
 		if err = cluster.DeleteHost(api); err != nil {
 			switch err := errors.Cause(err).(type) {
 			case mcnerror.ErrHostDoesNotExist:
-				console.OutStyle("meh", "%q VM does not exist", profile)
+				console.OutStyle("meh", "%q cluster does not exist", profile)
 			default:
-				exit.WithError("Failed to delete VM", err)
+				exit.WithError("Failed to delete cluster", err)
 			}
 		}
 
@@ -88,7 +90,7 @@ associated files.`,
 			}
 			exit.WithError("Failed to remove profile", err)
 		}
-		console.OutStyle("crushed", "The %q cluster is now deleted. I hope you are happy.", profile)
+		console.OutStyle("crushed", "The %q cluster is now deleted.", profile)
 	},
 }
 

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"runtime"
 	"strings"
 
 	"github.com/docker/machine/libmachine"
@@ -32,7 +31,6 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	configCmd "k8s.io/minikube/cmd/minikube/cmd/config"
-	"k8s.io/minikube/cmd/util"
 	"k8s.io/minikube/pkg/minikube/bootstrapper"
 	"k8s.io/minikube/pkg/minikube/bootstrapper/kubeadm"
 	"k8s.io/minikube/pkg/minikube/config"
@@ -94,7 +92,6 @@ var RootCmd = &cobra.Command{
 		if enableUpdateNotification {
 			notify.MaybePrintUpdateTextFromGithub(os.Stderr)
 		}
-		util.MaybePrintKubectlDownloadMsg(runtime.GOOS, os.Stderr)
 	},
 }
 

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -298,22 +298,21 @@ func generateConfig(cmd *cobra.Command, kVersion string) (cfg.Config, error) {
 // prepareNone prepares the user and host for the joy of the "none" driver
 func prepareNone() {
 	if viper.GetBool(cfg.WantNoneDriverWarning) {
-		console.ErrLn(`===================
-WARNING: IT IS RECOMMENDED NOT TO RUN THE NONE DRIVER ON PERSONAL WORKSTATIONS
-The 'none' driver will run an insecure kubernetes apiserver as root that may leave the host vulnerable to CSRF attacks` + "\n")
+		console.OutLn("")
+		console.Warning("The 'none' driver provides limited isolation and may reduce system security and reliability.")
+		console.OutStyle("url", "https://github.com/kubernetes/minikube/blob/master/docs/vmdriver-none.md")
+		console.OutLn("")
 	}
 
 	if os.Getenv("CHANGE_MINIKUBE_NONE_USER") == "" {
-		console.Fatal(`When using the none driver, the kubectl config and credentials generated will be root owned and will appear in the root home directory.
-You will need to move the files to the appropriate location and then set the correct permissions.  An example of this is below:
+		console.Warning("kubectl and minikube configuration will be stored in %s", os.Getenv("HOME"))
+		console.Warning("To use kubectl or minikube commands as your own user, you may")
+		console.Warning("need to relocate them. For example, to overwrite your own settings:")
 
-sudo mv /root/.kube $HOME/.kube # this will write over any previous configuration
-sudo chown -R $USER:$USER $HOME/.kube
+		console.OutStyle("command", "sudo mv %s/.kube %s/.minikube $HOME", os.Getenv("HOME"))
+		console.OutStyle("command", "sudo chown -R $USER %s/.kube %s/.minikube", os.Getenv("HOME"))
 
-sudo mv /root/.minikube $HOME/.minikube # this will write over any previous configuration
-sudo chown -R $USER:$USER $HOME/.minikube
-
-This can also be done automatically by setting the env var CHANGE_MINIKUBE_NONE_USER=true`)
+		console.OutStyle("tip", "This can also be done automatically by setting the env var CHANGE_MINIKUBE_NONE_USER=true")
 	}
 
 	if err := pkgutil.MaybeChownDirRecursiveToMinikubeUser(constants.GetMinipath()); err != nil {

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -211,6 +211,10 @@ func runStart(cmd *cobra.Command, args []string) {
 	} else {
 		console.OutStyle("kubectl", "kubectl is now configured to use %q", cfg.GetMachineName())
 	}
+	_, err = exec.LookPath("kubectl")
+	if err != nil {
+		console.OutStyle("tip", "For best results, install kubectl: https://kubernetes.io/docs/tasks/tools/install-kubectl/")
+	}
 	console.OutStyle("ready", "Done! Thank you for using minikube!")
 }
 
@@ -305,17 +309,21 @@ func prepareNone() {
 	if viper.GetBool(cfg.WantNoneDriverWarning) {
 		console.OutLn("")
 		console.Warning("The 'none' driver provides limited isolation and may reduce system security and reliability.")
+		console.Warning("For more information, see:")
 		console.OutStyle("url", "https://github.com/kubernetes/minikube/blob/master/docs/vmdriver-none.md")
 		console.OutLn("")
 	}
 
 	if os.Getenv("CHANGE_MINIKUBE_NONE_USER") == "" {
-		console.Warning("kubectl and minikube configuration will be stored in %s", os.Getenv("HOME"))
+		home := os.Getenv("HOME")
+		console.Warning("kubectl and minikube configuration will be stored in %s", home)
 		console.Warning("To use kubectl or minikube commands as your own user, you may")
 		console.Warning("need to relocate them. For example, to overwrite your own settings:")
 
-		console.OutStyle("command", "sudo mv %s/.kube %s/.minikube $HOME", os.Getenv("HOME"))
-		console.OutStyle("command", "sudo chown -R $USER %s/.kube %s/.minikube", os.Getenv("HOME"))
+		console.OutLn("")
+		console.OutStyle("command", "sudo mv %s/.kube %s/.minikube $HOME", home, home)
+		console.OutStyle("command", "sudo chown -R $USER %s/.kube %s/.minikube", home, home)
+		console.OutLn("")
 
 		console.OutStyle("tip", "This can also be done automatically by setting the env var CHANGE_MINIKUBE_NONE_USER=true")
 	}

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -18,69 +18,15 @@ limitations under the License.
 package util
 
 import (
-	"fmt"
-	"io"
 	"io/ioutil"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strconv"
 
 	"github.com/pkg/errors"
-	"github.com/spf13/viper"
-	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 )
-
-type ServiceContext struct {
-	Service string `json:"service"`
-	Version string `json:"version"`
-}
-
-type LookPath func(filename string) (string, error)
-
-var lookPath LookPath
-
-func init() {
-	lookPath = exec.LookPath
-}
-
-func MaybePrintKubectlDownloadMsg(goos string, out io.Writer) {
-	if !viper.GetBool(config.WantKubectlDownloadMsg) {
-		return
-	}
-
-	verb := "run"
-	installInstructions := "curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/%s/bin/%s/%s/kubectl && chmod +x kubectl && sudo cp kubectl /usr/local/bin/ && rm kubectl"
-	if goos == "windows" {
-		verb = "do"
-		installInstructions = `download kubectl from:
-https://storage.googleapis.com/kubernetes-release/release/%s/bin/%s/%s/kubectl.exe
-Add kubectl to your system PATH`
-	}
-
-	_, err := lookPath("kubectl")
-	if err != nil && goos == "windows" {
-		_, err = lookPath("kubectl.exe")
-	}
-	if err != nil {
-		fmt.Fprintf(out,
-			`========================================
-kubectl could not be found on your path. kubectl is a requirement for using minikube
-To install kubectl, please %s the following:
-
-%s
-
-To disable this message, run the following:
-
-minikube config set WantKubectlDownloadMsg false
-========================================
-`,
-			verb, fmt.Sprintf(installInstructions, constants.DefaultKubernetesVersion, goos, runtime.GOARCH))
-	}
-}
 
 // Ask the kernel for a free open port that is ready to use
 func GetPort() (string, error) {

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -255,8 +255,7 @@ func (k *KubeadmBootstrapper) DeleteCluster(k8s config.KubernetesConfig) error {
 // PullImages downloads images that will be used by RestartCluster
 func (k *KubeadmBootstrapper) PullImages(k8s config.KubernetesConfig) error {
 	cmd := fmt.Sprintf("sudo kubeadm config images pull --config %s", constants.KubeadmConfigFile)
-	// Use CombinedOutput instead of Run to avoid spamming stdout/stderr
-	if _, err := k.c.CombinedOutput(cmd); err != nil {
+	if err := k.c.Run(cmd); err != nil {
 		return errors.Wrapf(err, "running cmd: %s", cmd)
 	}
 	return nil

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -255,7 +255,8 @@ func (k *KubeadmBootstrapper) DeleteCluster(k8s config.KubernetesConfig) error {
 // PullImages downloads images that will be used by RestartCluster
 func (k *KubeadmBootstrapper) PullImages(k8s config.KubernetesConfig) error {
 	cmd := fmt.Sprintf("sudo kubeadm config images pull --config %s", constants.KubeadmConfigFile)
-	if err := k.c.Run(cmd); err != nil {
+	// Use CombinedOutput instead of Run to avoid spamming stdout/stderr
+	if _, err := k.c.CombinedOutput(cmd); err != nil {
 		return errors.Wrapf(err, "running cmd: %s", cmd)
 	}
 	return nil

--- a/pkg/minikube/console/style.go
+++ b/pkg/minikube/console/style.go
@@ -49,6 +49,7 @@ var styles = map[string]style{
 	"launch":       {Prefix: "🚀  "},
 	"thumbs-up":    {Prefix: "👍  "},
 	"option":       {Prefix: "    ▪ "}, // Indented bullet
+	"command":      {Prefix: "    ▪ "}, // Indented bullet
 	"log-entry":    {Prefix: "    "},   // Indent
 	"crushed":      {Prefix: "💔  "},
 	"running":      {Prefix: "🏃  "},


### PR DESCRIPTION
Minor display fixes I noticed while battle-testing minikube with the none driver:

- Remove kubectl download guidance when minikube is run without `kubectl` in path, as is often the case when run as root. The installation guidance provided conflicted with the offficial instructions anyways.
- The giant none warning was no longer accurate. Linked to doc for more information. 
- Make chown command work when there is no group named $USER
- The dashboard will now exit much earlier if kubectl is missing.
- Log an error if the bootstrapper can't be initialized
- Some mentions of VM should actually be cluster, particularly when used with none.

Sample output:

```
😄  minikube v0.33.1 on linux (amd64)
🤹  Configuring local host environment ...

⚠️  The 'none' driver provides limited isolation and may reduce system security and reliability.
⚠️  For more information, see:
👉  https://github.com/kubernetes/minikube/blob/master/docs/vmdriver-none.md

⚠️  kubectl and minikube configuration will be stored in /root
⚠️  To use kubectl or minikube commands as your own user, you may
⚠️  need to relocate them. For example, to overwrite your own settings:

    ▪ sudo mv /root/.kube /root/.minikube $HOME
    ▪ sudo chown -R $USER $HOME/.kube $HOME/.minikube

💡  This can also be done automatically by setting the env var CHANGE_MINIKUBE_NONE_USER=true
💡  Tip: To create a new cluster, use 'minikube start -p <new name>' or use 'minikube delete' to delete this one.
🏃  Re-using the currently running none VM for "minikube" ...
⌛  Waiting for SSH access ...
📶  "minikube" IP address is 172.31.148.205
🐳  Configuring Docker as your container runtime ...
✨  Preparing Kubernetes environment ...
🚜  Pulling images used by Kubernetes v1.13.3 ...
🔄  Relaunching Kubernetes v1.13.3 using kubeadm ... 
⌛  Restarting kube-proxy ...
```

This resolves #3429 and #3263