### PR TITLE
VirtualBox VM's audio support is NOT required (additional emulation overhead) for minikube use case

### DIFF
--- a/vendor/github.com/docker/machine/drivers/virtualbox/virtualbox.go
+++ b/vendor/github.com/docker/machine/drivers/virtualbox/virtualbox.go
@@ -400,6 +400,7 @@ func (d *Driver) CreateVM() error {
 		"--largepages", "on",
 		"--vtxvpid", "on",
 		"--accelerate3d", "off",
+		"--audio", "none",
 		"--boot1", "dvd"}
 
 	if runtime.GOOS == "windows" && runtime.GOARCH == "386" {


### PR DESCRIPTION
As described in issue #3664 VirtualBox VM's Audio support is NOT required for `minikube` use case, every CPU timeslice counts ;-)

The same may be applied to other hypervisors (KVM, Xen, etc.) as well when `minikube start` creates new VMs.

Code change is simple - 1 line (added it after accelerate3d - video audio together -> VAIO?)
```go
--- a/vendor/github.com/docker/machine/drivers/virtualbox/virtualbox.go
+++ b/vendor/github.com/docker/machine/drivers/virtualbox/virtualbox.go
@@ -400,6 +400,7 @@ func (d *Driver) CreateVM() error {
                "--largepages", "on",
                "--vtxvpid", "on",
                "--accelerate3d", "off",
+               "--audio", "none",
                "--boot1", "dvd"}

        if runtime.GOOS == "windows" && runtime.GOARCH == "386" {
``` 

Code has been built and tested on macOS, working as expected.

```bash
 ./minikube-darwin-amd64 start
😄  minikube v0.33.1 on darwin (amd64)
🔥  Creating virtualbox VM (CPUs=2, Memory=2048MB, Disk=20000MB) ...
💿  Downloading Minikube ISO ...
 181.48 MB / 181.48 MB [============================================] 100.00% 0s
📶  "minikube" IP address is 192.168.99.109
🐳  Configuring Docker as your container runtime ...
✨  Preparing Kubernetes environment ...
💾  Downloading kubeadm v1.13.3
💾  Downloading kubelet v1.13.3
🚜  Pulling images used by Kubernetes v1.13.3 ...
🚀  Launching Kubernetes v1.13.3 using kubeadm ...
🔑  Configuring cluster permissions ...
🤔  Verifying component health .....
💗  kubectl is now configured to use "minikube"
🏄  Done! Thank you for using minikube!
```

The minikube VM newly created now is with Audio support disabled. No more unnecessary emulation overhead.

```bash
Name:                        minikube
Groups:                      /
Guest OS:                    Linux 2.6 / 3.x / 4.x (64-bit)
...


3D Acceleration:             disabled
2D Video Acceleration:       disabled

...

Audio:                       disabled
Audio playback:              disabled
Audio capture:               disabled
```

Hooray!