### PR TITLE
Fix TestStartStop so that none tests are executed

### DIFF
--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -40,7 +40,7 @@ func TestStartStop(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.runtime, func(t *testing.T) {
 			runner := NewMinikubeRunner(t)
-			if test.runtime != "" && usingNoneDriver(runner) {
+			if test.runtime != "docker" && usingNoneDriver(runner) {
 				t.Skipf("skipping, can't use %s with none driver", test.runtime)
 			}
 


### PR DESCRIPTION
The runtime string previously read "", but I changed it to "docker" for clarity.