### PR TITLE
Adding docs for OpenID Connect Authentication

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,8 @@
 
 * **GPUs** ([gpu.md](gpu.md)): Using NVIDIA GPUs on minikube
 
+* **OpenID Connect Authentication** ([openid_connect_auth](openid_connect_auth)): Using OIDC Authentication on minikube
+
 ### Installation and debugging
 
 * **Driver installation** ([drivers.md](drivers.md)): In depth instructions for installing the various hypervisor drivers

--- a/docs/contributors/openid_connect_auth.md
+++ b/docs/contributors/openid_connect_auth.md
@@ -1,0 +1,34 @@
+# OpenID Connect Authentication
+
+Minikube `kube-apiserver` can be configured to support OpenID Connect Authentication.
+
+Read more about OpenID Connect Authentication for Kubernetes here: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens
+
+
+## Configuring the API Server
+
+Configuration values can be passed to the API server using the `--extra-config` flag on the `minikube start` command. See [configuring_kubernetes.md](configuring_kubernetes.md) for more details.
+
+The following example configures your Minikube cluster to support RBAC and OIDC:
+
+```shell
+minikube start \
+  --extra-config=apiserver.authorization-mode=RBAC \
+  --extra-config=apiserver.oidc-issuer-url=https://example.com \
+  --extra-config=apiserver.oidc-username-claim=email \
+  --extra-config=apiserver.oidc-client-id="kubernetes-local"
+```
+
+## Configuring kubectl
+
+You can use the kubectl `oidc` authenticator to create a kubeconfig as shown in the Kubernetes docs: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#option-1-oidc-authenticator
+
+`minikube start` already creates a kubeconfig that includes a `cluster`, in order to use it with your `oidc` authenticator kubeconfig, you can run:
+
+```shell
+kubectl config set-context kubernetes-local-oidc --cluster=minikube --user username@example.com
+Context "kubernetes-local-oidc" created.
+kubectl config use-context kubernetes-local-oidc
+```
+
+For the new context to work you will need to create, at the very minimum, a `Role` and a `RoleBinding` in your cluster to grant permissions to the `subjects` included in your `oidc-username-claim`.

--- a/docs/openid_connect_auth.md
+++ b/docs/openid_connect_auth.md
@@ -7,7 +7,7 @@ Read more about OpenID Connect Authentication for Kubernetes here: https://kuber
 
 ## Configuring the API Server
 
-Configuration values can be passed to the API server using the `--extra-config` flag on the `minikube start` command. See [configuring_kubernetes.md](configuring_kubernetes.md) for more details.
+Configuration values can be passed to the API server using the `--extra-config` flag on the `minikube start` command. See [configuring_kubernetes.md](https://github.com/kubernetes/minikube/blob/master/docs/configuring_kubernetes.md) for more details.
 
 The following example configures your Minikube cluster to support RBAC and OIDC:
 
@@ -16,7 +16,7 @@ minikube start \
   --extra-config=apiserver.authorization-mode=RBAC \
   --extra-config=apiserver.oidc-issuer-url=https://example.com \
   --extra-config=apiserver.oidc-username-claim=email \
-  --extra-config=apiserver.oidc-client-id="kubernetes-local"
+  --extra-config=apiserver.oidc-client-id=kubernetes-local
 ```
 
 ## Configuring kubectl


### PR DESCRIPTION
While setting up OIDC on my Minikube cluster, I found the issue https://github.com/kubernetes/minikube/issues/2852 which contains some of the config parameters that need to be passed to the `kube-apiserver` in order to enable OIDC Auth. These are no longer valid, and there are a lot of references on the internet to legacy config parameters like `apiserver.Authentication.OIDC.IssuerURL` that no longer work in the newer versions of Minikube.

OpenID connect is a common authentication method in Kubernetes so having clearer docs should help those like me that are testing authentication strategies in Minikube. 