### PR TITLE
Minor output changes to reduce string size or improve clarity

### DIFF
--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -88,7 +88,7 @@ associated files.`,
 			}
 			exit.WithError("Failed to remove profile", err)
 		}
-		console.OutStyle("crushed", "The %q cluster is now deleted. I hope you are happy.", profile)
+		console.OutStyle("crushed", "The %q cluster has been deleted.", profile)
 	},
 }
 

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -457,7 +457,7 @@ func configureRuntimes(h *host.Host, runner bootstrapper.CommandRunner) cruntime
 	if err != nil {
 		exit.WithError(fmt.Sprintf("Failed runtime for %+v", config), err)
 	}
-	console.OutStyle(cr.Name(), "Configuring %s as your container runtime ...", cr.Name())
+	console.OutStyle(cr.Name(), "Configuring %s as the container runtime ...", cr.Name())
 	for _, v := range dockerOpt {
 		console.OutStyle("option", "opt %s", v)
 	}
@@ -485,7 +485,7 @@ func waitCacheImages(g *errgroup.Group) {
 
 // bootstrapCluster starts Kubernetes using the chosen bootstrapper
 func bootstrapCluster(bs bootstrapper.Bootstrapper, r cruntime.Manager, runner bootstrapper.CommandRunner, kc cfg.KubernetesConfig, preexisting bool) {
-	console.OutStyle("pulling", "Pulling images used by Kubernetes %s ...", kc.KubernetesVersion)
+	console.OutStyle("pulling", "Pulling images required by Kubernetes %s ...", kc.KubernetesVersion)
 	if err := bs.PullImages(kc); err != nil {
 		console.OutStyle("failure", "Unable to pull images, which may be OK: %v", err)
 	}

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -233,7 +233,7 @@ func (k *KubeadmBootstrapper) RestartCluster(k8s config.KubernetesConfig) error 
 	}
 
 	// NOTE: Perhaps now would be a good time to check apiserver health?
-	console.OutStyle("waiting", "Restarting kube-proxy ...")
+	console.OutStyle("waiting", "Waiting for kube-proxy to come back up ...")
 	if err := restartKubeProxy(k8s); err != nil {
 		return errors.Wrap(err, "restarting kube-proxy")
 	}

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -87,7 +87,7 @@ func StartHost(api libmachine.API, config cfg.MachineConfig) (*host.Host, error)
 		console.Warning("Alternatively, you may delete the existing VM using `minikube delete -p %s`", cfg.GetMachineName())
 		console.Out("\n")
 	} else if exists && cfg.GetMachineName() == constants.DefaultMachineName {
-		console.OutStyle("tip", "Tip: To create a new cluster, use 'minikube start -p <new name>' or use 'minikube delete' to delete this one.")
+		console.OutStyle("tip", "Tip: Use 'minikube start -p <name>' to create a new cluster, or 'minikube delete' to delete this one.")
 	}
 
 	s, err := h.Driver.GetState()


### PR DESCRIPTION
Example output:

```
😄  minikube v0.33.1 on darwin (amd64)
🏃  Re-using the currently running hyperkit VM for "minikube" ...
⌛  Waiting for SSH access ...
📶  "minikube" IP address is 192.168.64.19
🐳  Configuring Docker as the container runtime ...
✨  Preparing Kubernetes environment ...
🚜  Pulling images required by Kubernetes v1.13.3 ...
🔄  Relaunching Kubernetes v1.13.3 using kubeadm ... 
⌛  Waiting for kube-proxy to come back up ...
🤔  Verifying component health ......
💗  kubectl is now configured to use "minikube"
🏄  Done! Thank you for using minikube!
```