### PR TITLE
Implement CRI method ContainerLogCmd for rkt

### DIFF
--- a/pkg/minikube/cruntime/rkt.go
+++ b/pkg/minikube/cruntime/rkt.go
@@ -119,3 +119,8 @@ func (r *Rkt) KillContainers(ids []string) error {
 func (r *Rkt) StopContainers(ids []string) error {
 	return stopCRIContainers(r.Runner, ids)
 }
+
+// ContainerLogCmd returns the command to retrieve the log for a container based on ID
+func (r *Rkt) ContainerLogCmd(id string, len int, follow bool) string {
+	return criContainerLogCmd(id, len, follow)
+}


### PR DESCRIPTION
Fixes the breakage from #3678, didn't re-test properly before merging