### PR TITLE
Improve reporting when docker host/service is down

### DIFF
--- a/cmd/minikube/cmd/env.go
+++ b/cmd/minikube/cmd/env.go
@@ -28,6 +28,7 @@ import (
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/shell"
+	"github.com/docker/machine/libmachine/state"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/minikube/pkg/minikube/cluster"
@@ -319,9 +320,16 @@ var dockerEnvCmd = &cobra.Command{
 		if host.Driver.DriverName() == "none" {
 			exit.Usage(`'none' driver does not support 'minikube docker-env' command`)
 		}
+		hostSt, err := cluster.GetHostStatus(api)
+		if err != nil {
+			exit.WithError("Error getting host status", err)
+		}
+		if hostSt != state.Running.String() {
+			exit.WithCode(exit.Unavailable, `The docker host is currently not running`)
+		}
 		docker, err := GetDockerActive(host)
 		if !docker {
-			exit.WithCode(exit.Unavailable, `# The docker service is currently not active`)
+			exit.WithCode(exit.Unavailable, `The docker service is currently not active`)
 		}
 
 		var shellCfg *ShellConfig


### PR DESCRIPTION
Don't just wait for a timeout, when SSH is not running.

Also improve the message, don't need to comment stderr.

----

Also improved the output, to match the new "console":

``` console
$ ./out/minikube docker-env
💣  The docker service is currently not active
$ ./out/minikube stop
✋  Stopping "minikube" in virtualbox ...
🛑  "minikube" stopped.
$ ./out/minikube docker-env
💣  The docker host is currently not running
```

Closes #3697 

(docker service wasn't running since I used CRI-O...)