### PR TITLE
Make non-zero ssh error codes less dramatic

### DIFF
--- a/cmd/minikube/cmd/ssh.go
+++ b/cmd/minikube/cmd/ssh.go
@@ -17,9 +17,12 @@ limitations under the License.
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 	"k8s.io/minikube/pkg/minikube/cluster"
 	"k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/console"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/machine"
 )
@@ -44,7 +47,10 @@ var sshCmd = &cobra.Command{
 		}
 		err = cluster.CreateSSHShell(api, args)
 		if err != nil {
-			exit.WithError("Error creating SSH shell", err)
+			// This is typically due to a non-zero exit code, so no need for flourish.
+			console.ErrLn("ssh: %v", err)
+			// It'd be nice if we could pass up the correct error code here :(
+			os.Exit(exit.Failure)
 		}
 	},
 }


### PR DESCRIPTION
Old output:

```
ls: cannot access '/xxx': No such file or directory
💣  Error creating SSH shell: Process exited with status 2

😿  Sorry that minikube crashed. If this was unexpected, we would love to hear from you:
👉  https://github.com/kubernetes/minikube/issues/new
```

New output:

```
ls: cannot access '/xxx': No such file or directory
ssh: Process exited with status 2
```

Closes #3700
