### PR TITLE
update libvirtd

### DIFF
--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -25,9 +25,9 @@ To install the KVM2 driver, first install and configure the prereqs:
 ```
 Enable,start, and verify the libvirtd service has started. 
 ```shell
-systemctl enable libvirtd.service
-systemctl start libvirtd.service
-systemctl status libvirtd.service
+sudo systemctl enable libvirtd.service
+sudo systemctl start libvirtd.service
+sudo systemctl status libvirtd.service
 ```
 
 
@@ -44,7 +44,7 @@ Now install the driver:
 ```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-kvm2 \
   && sudo install docker-machine-driver-kvm2 /usr/local/bin/
-
+```
 
 
 NOTE: Ubuntu users on a release older than 18.04, or anyone experiencing [#3206: Error creating new host: dial tcp: missing address.](https://github.com/kubernetes/minikube/issues/3206) you will need to build your own driver until [#3689](https://github.com/kubernetes/minikube/issues/3689) is resolved. Building this binary will require [Go v1.11](https://golang.org/dl/) or newer to be installed. 
@@ -63,6 +63,18 @@ To use the kvm2 driver:
 
 ```shell
 minikube start --vm-driver kvm2
+```
+
+or, to use kvm2 as a default driver:
+
+```shell
+minikube config set vm-driver kvm2
+```
+
+and run minikube as usual:
+
+```shell
+minikube start
 ```
 
 #### Hyperkit driver

--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -30,6 +30,7 @@ systemctl start libvirtd.service
 systemctl status libvirtd.service
 ```
 
+
 Then you will need to add yourself to libvirt group (older distributions may use libvirtd instead)
 
 `sudo usermod -a -G libvirt $(whoami)`

--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -22,7 +22,6 @@ To install the KVM2 driver, first install and configure the prereqs:
 * Ubuntu 16.x or older: `sudo apt install libvirt-bin libvirt-daemon-system qemu-kvm`
 * Fedora/CentOS/RHEL: `sudo yum install libvirt-daemon-kvm qemu-kvm`
 
-```
 Enable,start, and verify the libvirtd service has started. 
 ```shell
 sudo systemctl enable libvirtd.service

--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -36,6 +36,12 @@ Now install the driver:
 curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-kvm2 \
   && sudo install docker-machine-driver-kvm2 /usr/local/bin/
 ```
+Enable and start the libvirtd service. 
+```shell
+systemctl enable libvirtd.service
+systemctl start libvirtd.service
+```
+
 
 NOTE: Ubuntu users on a release older than 18.04, or anyone experiencing [#3206: Error creating new host: dial tcp: missing address.](https://github.com/kubernetes/minikube/issues/3206) you will need to build your own driver until [#3689](https://github.com/kubernetes/minikube/issues/3689) is resolved. Building this binary will require [Go v1.11](https://golang.org/dl/) or newer to be installed. 
 

--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -22,6 +22,14 @@ To install the KVM2 driver, first install and configure the prereqs:
 * Ubuntu 16.x or older: `sudo apt install libvirt-bin libvirt-daemon-system qemu-kvm`
 * Fedora/CentOS/RHEL: `sudo yum install libvirt-daemon-kvm qemu-kvm`
 
+```
+Enable,start, and verify the libvirtd service has started. 
+```shell
+systemctl enable libvirtd.service
+systemctl start libvirtd.service
+systemctl status libvirtd.service
+```
+
 Then you will need to add yourself to libvirt group (older distributions may use libvirtd instead)
 
 `sudo usermod -a -G libvirt $(whoami)`
@@ -35,12 +43,7 @@ Now install the driver:
 ```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-kvm2 \
   && sudo install docker-machine-driver-kvm2 /usr/local/bin/
-```
-Enable and start the libvirtd service. 
-```shell
-systemctl enable libvirtd.service
-systemctl start libvirtd.service
-```
+
 
 
 NOTE: Ubuntu users on a release older than 18.04, or anyone experiencing [#3206: Error creating new host: dial tcp: missing address.](https://github.com/kubernetes/minikube/issues/3206) you will need to build your own driver until [#3689](https://github.com/kubernetes/minikube/issues/3689) is resolved. Building this binary will require [Go v1.11](https://golang.org/dl/) or newer to be installed. 


### PR DESCRIPTION
libvirtd must be started before you run minikube. Failure to do so will result in the below error 
Failed to connect socket to '/var/run/libvirt/libvirt-sock'
I believe this should be noted in the documentation to assist other users.  
Added lines 40-43