### PR TITLE
Add make target for building a rpm file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ ISO_VERSION ?= v$(VERSION_MAJOR).$(VERSION_MINOR).0
 
 VERSION ?= v$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_BUILD)
 DEB_VERSION ?= $(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_BUILD)
+RPM_VERSION ?= $(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_BUILD)
 INSTALL_SIZE ?= $(shell du out/minikube-windows-amd64.exe | cut -f1)
 BUILDROOT_BRANCH ?= 2018.05
 REGISTRY?=gcr.io/k8s-minikube
@@ -237,6 +238,14 @@ out/minikube_$(DEB_VERSION).deb: out/minikube-linux-amd64
 	cp out/minikube-linux-amd64 out/minikube_$(DEB_VERSION)/usr/bin/minikube
 	fakeroot dpkg-deb --build out/minikube_$(DEB_VERSION)
 	rm -rf out/minikube_$(DEB_VERSION)
+
+out/minikube-$(RPM_VERSION).rpm: out/minikube-linux-amd64
+	cp -r installers/linux/rpm/minikube_rpm_template out/minikube-$(RPM_VERSION)
+	sed -E -i 's/--VERSION--/'$(RPM_VERSION)'/g' out/minikube-$(RPM_VERSION)/minikube.spec
+	sed -E -i 's|--OUT--|'$(PWD)/out'|g' out/minikube-$(RPM_VERSION)/minikube.spec
+	rpmbuild -bb -D "_rpmdir $(PWD)/out" -D "_rpmfilename minikube-$(RPM_VERSION).rpm" \
+		 out/minikube-$(RPM_VERSION)/minikube.spec
+	rm -rf out/minikube-$(RPM_VERSION)
 
 .SECONDEXPANSION:
 TAR_TARGETS_linux   := out/minikube-linux-amd64 out/docker-machine-driver-kvm2

--- a/hack/jenkins/release_build_and_upload.sh
+++ b/hack/jenkins/release_build_and_upload.sh
@@ -28,6 +28,7 @@ set -e
 
 export TAGNAME=v${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BUILD}
 export DEB_VERSION=${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BUILD}
+export RPM_VERSION=${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BUILD}
 export GOPATH=~/go
 
 # Make sure the tag matches the Makefile
@@ -36,7 +37,7 @@ cat Makefile | grep "VERSION_MINOR ?=" | grep $VERSION_MINOR
 cat Makefile | grep "VERSION_BUILD ?=" | grep $VERSION_BUILD
 
 # Build and upload
-BUILD_IN_DOCKER=y make -j 16 all out/minikube-installer.exe out/minikube_${DEB_VERSION}.deb
+BUILD_IN_DOCKER=y make -j 16 all out/minikube-installer.exe out/minikube_${DEB_VERSION}.deb out/minikube-${RPM_VERSION}.rpm
 make checksum
 
 gsutil -m cp out/* gs://$BUCKET/releases/$TAGNAME/

--- a/hack/jenkins/release_github_page.sh
+++ b/hack/jenkins/release_github_page.sh
@@ -64,6 +64,9 @@ Feel free to leave off \`\`\`sudo cp minikube /usr/local/bin/ && rm minikube\`\`
 ### Debian Package (.deb) [Experimental]
 Download the \`minikube_${DEB_VERSION}.deb\` file, and install it using \`sudo dpkg -i minikube_$(DEB_VERSION).deb\`
 
+### RPM Package (.rpm) [Experimental]
+Download the \`minikube-${RPM_VERSION}.rpm\` file, and install it using \`sudo rpm -i minikube-$(RPM_VERSION).rpm\`
+
 ### Windows [Experimental]
 Download the \`minikube-windows-amd64.exe\` file, rename it to \`minikube.exe\` and add it to your path.
 

--- a/installers/linux/rpm/minikube_rpm_template/minikube.spec
+++ b/installers/linux/rpm/minikube_rpm_template/minikube.spec
@@ -1,0 +1,29 @@
+Name: minikube
+Version: --VERSION--
+Release: 0
+Summary: Run Kubernetes locally
+License: ASL 2.0
+Group: Development/Tools
+URL: https://github.com/kubernetes/minikube
+
+# Needed for older versions of RPM
+BuildRoot: %{_tmppath}%{name}-buildroot
+
+%description
+Minikube is a tool that makes it easy to run Kubernetes locally.
+Minikube runs a single-node Kubernetes cluster inside a VM on your
+laptop for users looking to try out Kubernetes or develop with it 
+day-to-day.
+
+%prep
+mkdir -p %{name}-%{version}
+cd %{name}-%{version}
+cp --OUT--/minikube-linux-amd64 .
+
+%install
+cd %{name}-%{version}
+mkdir -p %{buildroot}%{_bindir}
+install -m 755 minikube-linux-amd64 %{buildroot}%{_bindir}/%{name}
+
+%files
+%{_bindir}/%{name}


### PR DESCRIPTION
Similar to the deb, it just packages the standard binary...

It does not build from source, and not for any distribution.