### PR TITLE
Improve error handling for versions without `v` prefix

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -427,6 +427,11 @@ func validateKubernetesVersions(old *cfg.Config) string {
 	if nv == "" {
 		nv = constants.DefaultKubernetesVersion
 	}
+
+	if nv[0] != version.VersionPrefix {
+		exit.WithCode(exit.Usage, "the --kubernetes-version flag requires the version to start with a 'v'")
+	}
+
 	nvs, err := semver.Make(strings.TrimPrefix(nv, version.VersionPrefix))
 	if err != nil {
 		exit.WithCode(exit.Data, "Unable to parse %q: %v", nv, err)

--- a/pkg/minikube/bootstrapper/kubeadm/versions.go
+++ b/pkg/minikube/bootstrapper/kubeadm/versions.go
@@ -161,7 +161,7 @@ func Supports(featureName string) bool {
 
 // ParseKubernetesVersion validates the kubernetes version as legitimate
 func ParseKubernetesVersion(input string) (semver.Version, error) {
-	if input[0] != version.VersionPrefix {
+	if !strings.HasPrefix(input, version.VersionPrefix) {
 		return semver.Version{}, fmt.Errorf("version numbers must begin with %v", version.VersionPrefix)
 	}
 

--- a/pkg/minikube/bootstrapper/kubeadm/versions.go
+++ b/pkg/minikube/bootstrapper/kubeadm/versions.go
@@ -25,11 +25,11 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/golang/glog"
-	"github.com/kubernetes/minikube/pkg/version"
 	"github.com/pkg/errors"
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/util"
+	"k8s.io/minikube/pkg/version"
 )
 
 // These are the components that can be configured

--- a/pkg/minikube/bootstrapper/kubeadm/versions.go
+++ b/pkg/minikube/bootstrapper/kubeadm/versions.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/golang/glog"
+	"github.com/kubernetes/minikube/pkg/version"
 	"github.com/pkg/errors"
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	"k8s.io/minikube/pkg/minikube/constants"
@@ -158,10 +159,13 @@ func Supports(featureName string) bool {
 	return false
 }
 
-// ParseKubernetesVersion parses the kubernetes version
-func ParseKubernetesVersion(version string) (semver.Version, error) {
-	// Strip leading 'v' prefix from version for semver parsing
-	v, err := semver.Make(version[1:])
+// ParseKubernetesVersion validates the kubernetes version as legitimate
+func ParseKubernetesVersion(input string) (semver.Version, error) {
+	if input[0] != version.VersionPrefix {
+		return semver.Version{}, fmt.Errorf("version numbers must begin with %v", version.VersionPrefix)
+	}
+
+	v, err := semver.Make(strings.TrimPrefix(input, version.VersionPrefix))
 	if err != nil {
 		return semver.Version{}, errors.Wrap(err, "invalid version, must begin with 'v'")
 	}

--- a/pkg/minikube/bootstrapper/kubeadm/versions_test.go
+++ b/pkg/minikube/bootstrapper/kubeadm/versions_test.go
@@ -94,12 +94,45 @@ func TestVersionIsBetween(t *testing.T) {
 }
 
 func TestParseKubernetesVersion(t *testing.T) {
-	version, err := ParseKubernetesVersion("v1.8.0-alpha.5")
-	if err != nil {
-		t.Fatalf("Error parsing version: %v", err)
+	tests := []struct {
+		description string
+		version     string
+		comparison  string
+		expected    boolean
+	}{
+		{
+			description: "regular 1.x.x version",
+			version:     "1.8.0",
+			comparison:  "1.8.0",
+			expected:    true,
+		},
+		{
+			description: "alpha version",
+			version:     "v1.8.0-alpha.5",
+			comparison:  "1.8.0-alpha.5",
+			expected:    true,
+		},
+		{
+			description: "missing `v` prefix: considered invalid",
+			version:     "1.8.0",
+			comparison:  "1.8.0",
+			expected:    false,
+		},
 	}
-	if version.NE(semver.MustParse("1.8.0-alpha.5")) {
-		t.Errorf("Expected: %s, Actual:%s", "1.8.0-alpha.5", version)
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			version, err := ParseKubernetesVersion(test.input)
+			if err != nil {
+				t.Fatalf("Error parsing version: %v", err)
+			}
+
+			comparison := semver.MustParse(test.comparison)
+
+			if version.NE(comparison) == test.expected {
+				t.Errorf("Expected: %s, Actual: %s", test.expected, version)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
I always forget whether the v is required syntax.  When you start minikube without the v, it currently looks like this:

```
$ minikube start --kubernetes-version 1.10.0
Starting local Kubernetes 1.10.0 cluster...
Starting VM...
Getting VM IP address...
Moving files into cluster...
E0227 14:07:52.609622  117027 start.go:302] Error updating cluster:  generating kubeadm cfg: parsing kubernetes version: parsing kubernetes version: strconv.ParseUint: parsing "": invalid syntax


minikube failed :( exiting with error code 1
```

I added a test or two and tried to make the error message clearer, since, after all, it isn't `""` that I passed so I (as the user) don't have much to go on to understand what it's talking about in the current error.


That said.. I would be happy to just fix things up to allow either the `v` or the no-`v` versions accepted for this flag.  I only didn't do so because I was unsure if this was some kind of design choice.  In the two places in the code (both edited in this PR) where the version is used, it is immediately stripped of its `v` anyway.