### PR TITLE
Improve reliability of kube-proxy configmap updates (retry, block until pods are up)

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -289,7 +289,7 @@ func (k *KubeadmBootstrapper) RestartCluster(k8s config.KubernetesConfig) error 
 		return errors.Wrap(err, "wait")
 	}
 
-	console.OutStyle("waiting", "Updating kube-proxy configmap ...")
+	console.OutStyle("reconfiguring", "Reconfiguring kube-proxy ...")
 	if err := restartKubeProxy(k8s); err != nil {
 		return errors.Wrap(err, "restarting kube-proxy")
 	}

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -77,11 +77,10 @@ var PodsByLayer = []pod{
 	{"apiserver", "component", "kube-apiserver"},
 	{"proxy", "k8s-app", "kube-proxy"},
 	{"etcd", "component", "etcd"},
-	{"dns", "k8s-app", "kube-dns"},
-	{"controller", "component", "kube-controller-manager"},
 	{"scheduler", "component", "kube-scheduler"},
-	{"storage-provisioner", "integration-test", "storage-provisioner"},
+	{"controller", "component", "kube-controller-manager"},
 	{"addon-manager", "component", "kube-addon-manager"},
+	{"dns", "k8s-app", "kube-dns"},
 }
 
 // SkipAdditionalPreflights are additional preflights we skip depending on the runtime in use.
@@ -289,8 +288,8 @@ func (k *KubeadmBootstrapper) RestartCluster(k8s config.KubernetesConfig) error 
 		return errors.Wrap(err, "wait")
 	}
 
-	console.OutStyle("reconfiguring", "Reconfiguring kube-proxy ...")
-	if err := restartKubeProxy(k8s); err != nil {
+	console.OutStyle("reconfiguring", "Updating kube-proxy configuration ...")
+	if err = util.RetryAfter(5, func() error { return updateKubeProxyConfigMap(k8s) }, 5*time.Second); err != nil {
 		return errors.Wrap(err, "restarting kube-proxy")
 	}
 

--- a/pkg/minikube/bootstrapper/kubeadm/util.go
+++ b/pkg/minikube/bootstrapper/kubeadm/util.go
@@ -155,7 +155,8 @@ users:
 `
 )
 
-func restartKubeProxy(k8s config.KubernetesConfig) error {
+// updateKubeProxyConfigMap updates the IP & port kube-proxy listens on, and restarts it.
+func updateKubeProxyConfigMap(k8s config.KubernetesConfig) error {
 	client, err := util.GetClient()
 	if err != nil {
 		return errors.Wrap(err, "getting k8s client")
@@ -168,9 +169,9 @@ func restartKubeProxy(k8s config.KubernetesConfig) error {
 
 	cfgMap, err := client.CoreV1().ConfigMaps("kube-system").Get("kube-proxy", metav1.GetOptions{})
 	if err != nil {
-		return errors.Wrap(err, "getting kube-proxy configmap")
+		return &util.RetriableError{Err: errors.Wrap(err, "getting kube-proxy configmap")}
 	}
-
+	glog.Infof("kube-proxy config: %v", cfgMap.Data[kubeconfigConf])
 	t := template.Must(template.New("kubeProxyTmpl").Parse(kubeProxyConfigmapTmpl))
 	opts := struct {
 		AdvertiseAddress string
@@ -188,10 +189,19 @@ func restartKubeProxy(k8s config.KubernetesConfig) error {
 	if cfgMap.Data == nil {
 		cfgMap.Data = map[string]string{}
 	}
-	cfgMap.Data[kubeconfigConf] = strings.TrimSuffix(kubeconfig.String(), "\n")
 
+	updated := strings.TrimSuffix(kubeconfig.String(), "\n")
+	glog.Infof("updated kube-proxy config: %s", updated)
+	if cfgMap.Data[kubeconfigConf] == updated {
+		glog.Infof("kube-proxy config appears to require no change, not restarting kube-proxy")
+		return nil
+	}
+	cfgMap.Data[kubeconfigConf] = updated
+
+	// Make this step retriable, as it can fail with:
+	// "Operation cannot be fulfilled on configmaps "kube-proxy": the object has been modified; please apply your changes to the latest version and try again"
 	if _, err := client.CoreV1().ConfigMaps("kube-system").Update(cfgMap); err != nil {
-		return errors.Wrap(err, "updating configmap")
+		return &util.RetriableError{Err: errors.Wrap(err, "updating configmap")}
 	}
 
 	pods, err := client.CoreV1().Pods("kube-system").List(metav1.ListOptions{
@@ -201,9 +211,15 @@ func restartKubeProxy(k8s config.KubernetesConfig) error {
 		return errors.Wrap(err, "listing kube-proxy pods")
 	}
 	for _, pod := range pods.Items {
+		// Retriable, as known to fail with: pods "<name>" not found
 		if err := client.CoreV1().Pods(pod.Namespace).Delete(pod.Name, &metav1.DeleteOptions{}); err != nil {
-			return errors.Wrapf(err, "deleting pod %+v", pod)
+			return &util.RetriableError{Err: errors.Wrapf(err, "deleting pod %+v", pod)}
 		}
+	}
+
+	// Wait for the scheduler to restart kube-proxy
+	if err := util.WaitForPodsWithLabelRunning(client, "kube-system", selector); err != nil {
+		return errors.Wrap(err, "kube-proxy not running")
 	}
 
 	return nil

--- a/pkg/minikube/bootstrapper/kubeadm/util.go
+++ b/pkg/minikube/bootstrapper/kubeadm/util.go
@@ -192,6 +192,8 @@ func updateKubeProxyConfigMap(k8s config.KubernetesConfig) error {
 
 	updated := strings.TrimSuffix(kubeconfig.String(), "\n")
 	glog.Infof("updated kube-proxy config: %s", updated)
+
+	// An optimization, but also one that's unlikely, as kubeadm writes the address as 'localhost'
 	if cfgMap.Data[kubeconfigConf] == updated {
 		glog.Infof("kube-proxy config appears to require no change, not restarting kube-proxy")
 		return nil

--- a/pkg/minikube/bootstrapper/kubeadm/util.go
+++ b/pkg/minikube/bootstrapper/kubeadm/util.go
@@ -28,8 +28,8 @@ import (
 	clientv1 "k8s.io/api/core/v1"
 	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
@@ -163,7 +163,7 @@ func restartKubeProxy(k8s config.KubernetesConfig) error {
 
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{"k8s-app": "kube-proxy"}))
 	if err := util.WaitForPodsWithLabelRunning(client, "kube-system", selector); err != nil {
-		return errors.Wrap(err, "waiting for kube-proxy to be up for configmap update")
+		return errors.Wrap(err, "kube-proxy not running")
 	}
 
 	cfgMap, err := client.CoreV1().ConfigMaps("kube-system").Get("kube-proxy", metav1.GetOptions{})

--- a/pkg/minikube/console/style.go
+++ b/pkg/minikube/console/style.go
@@ -41,30 +41,31 @@ type style struct {
 // styles is a map of style name to style struct
 // For consistency, ensure that emojis added render with the same width across platforms.
 var styles = map[string]style{
-	"happy":        {Prefix: "😄  ", LowPrefix: "o   "},
-	"success":      {Prefix: "✅  "},
-	"failure":      {Prefix: "❌  ", LowPrefix: "X   "},
-	"conflict":     {Prefix: "💥  ", LowPrefix: "x   "},
-	"fatal":        {Prefix: "💣  ", LowPrefix: "!   "},
-	"notice":       {Prefix: "📌  ", LowPrefix: "*   "},
-	"ready":        {Prefix: "🏄  ", LowPrefix: "=   "},
-	"running":      {Prefix: "🏃  ", LowPrefix: ":   "},
-	"provisioning": {Prefix: "🌱  ", LowPrefix: ">   "},
-	"restarting":   {Prefix: "🔄  ", LowPrefix: ":   "},
-	"stopping":     {Prefix: "✋  ", LowPrefix: ":   "},
-	"stopped":      {Prefix: "🛑  "},
-	"warning":      {Prefix: "⚠️  ", LowPrefix: "!   "},
-	"waiting":      {Prefix: "⌛  ", LowPrefix: ":   "},
-	"waiting-pods": {Prefix: "⌛  ", LowPrefix: ":   ", OmitNewline: true},
-	"usage":        {Prefix: "💡  "},
-	"launch":       {Prefix: "🚀  "},
-	"sad":          {Prefix: "😿  ", LowPrefix: "*   "},
-	"thumbs-up":    {Prefix: "👍  "},
-	"option":       {Prefix: "    ▪ "}, // Indented bullet
-	"command":      {Prefix: "    ▪ "}, // Indented bullet
-	"log-entry":    {Prefix: "    "},   // Indent
-	"crushed":      {Prefix: "💔  "},
-	"url":          {Prefix: "👉  "},
+	"happy":         {Prefix: "😄  ", LowPrefix: "o   "},
+	"success":       {Prefix: "✅  "},
+	"failure":       {Prefix: "❌  ", LowPrefix: "X   "},
+	"conflict":      {Prefix: "💥  ", LowPrefix: "x   "},
+	"fatal":         {Prefix: "💣  ", LowPrefix: "!   "},
+	"notice":        {Prefix: "📌  ", LowPrefix: "*   "},
+	"ready":         {Prefix: "🏄  ", LowPrefix: "=   "},
+	"running":       {Prefix: "🏃  ", LowPrefix: ":   "},
+	"provisioning":  {Prefix: "🌱  ", LowPrefix: ">   "},
+	"restarting":    {Prefix: "🔄  ", LowPrefix: ":   "},
+	"reconfiguring": {Prefix: "📯  ", LowPrefix: ":   "},
+	"stopping":      {Prefix: "✋  ", LowPrefix: ":   "},
+	"stopped":       {Prefix: "🛑  "},
+	"warning":       {Prefix: "⚠️  ", LowPrefix: "!   "},
+	"waiting":       {Prefix: "⌛  ", LowPrefix: ":   "},
+	"waiting-pods":  {Prefix: "⌛  ", LowPrefix: ":   ", OmitNewline: true},
+	"usage":         {Prefix: "💡  "},
+	"launch":        {Prefix: "🚀  "},
+	"sad":           {Prefix: "😿  ", LowPrefix: "*   "},
+	"thumbs-up":     {Prefix: "👍  "},
+	"option":        {Prefix: "    ▪ "}, // Indented bullet
+	"command":       {Prefix: "    ▪ "}, // Indented bullet
+	"log-entry":     {Prefix: "    "},   // Indent
+	"crushed":       {Prefix: "💔  "},
+	"url":           {Prefix: "👉  "},
 
 	// Specialized purpose styles
 	"iso-download":      {Prefix: "💿  ", LowPrefix: "@   "},

--- a/pkg/minikube/console/style.go
+++ b/pkg/minikube/console/style.go
@@ -55,6 +55,7 @@ var styles = map[string]style{
 	"stopped":      {Prefix: "🛑  "},
 	"warning":      {Prefix: "⚠️  ", LowPrefix: "!   "},
 	"waiting":      {Prefix: "⌛  ", LowPrefix: ":   "},
+	"waiting-pods": {Prefix: "⌛  ", LowPrefix: ":   ", OmitNewline: true},
 	"usage":        {Prefix: "💡  "},
 	"launch":       {Prefix: "🚀  "},
 	"sad":          {Prefix: "😿  ", LowPrefix: "*   "},

--- a/pkg/util/kubernetes.go
+++ b/pkg/util/kubernetes.go
@@ -42,7 +42,7 @@ var (
 	// ReasonableMutateTime is how long to wait for basic object mutations, such as deletions, to show up
 	ReasonableMutateTime = time.Minute * 1
 	// ReasonableStartTime is how long to wait for pods to start, considering dependency chains & slow networks.
-	ReasonableStartTime = time.Minute * 9
+	ReasonableStartTime = time.Minute * 8
 )
 
 type PodStore struct {

--- a/pkg/util/kubernetes.go
+++ b/pkg/util/kubernetes.go
@@ -23,7 +23,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -39,8 +39,10 @@ import (
 )
 
 var (
+	// ReasonableMutateTime is how long to wait for basic object mutations, such as deletions, to show up
 	ReasonableMutateTime = time.Minute * 1
-	ReasonableStartTime  = time.Minute * 5
+	// ReasonableStartTime is how long to wait for pods to start, considering dependency chains & slow networks.
+	ReasonableStartTime = time.Minute * 9
 )
 
 type PodStore struct {

--- a/pkg/util/kubernetes.go
+++ b/pkg/util/kubernetes.go
@@ -42,7 +42,7 @@ var (
 	// ReasonableMutateTime is how long to wait for basic object mutations, such as deletions, to show up
 	ReasonableMutateTime = time.Minute * 1
 	// ReasonableStartTime is how long to wait for pods to start, considering dependency chains & slow networks.
-	ReasonableStartTime = time.Minute * 8
+	ReasonableStartTime = time.Minute * 10
 )
 
 type PodStore struct {


### PR DESCRIPTION
Today I ran into "waiting for kube-proxy to be up for configmap update", and noticed that kube-proxy came up ~50 seconds after the current timeout, so I extended the timeout by 3 minutes.

I then began on a mission to fix other related bugs by making sure that StartCluster/RestartCluster block until all of the pods are healthy. While this may extend start times on broken configs somewhat, it should result in less flakiness overall.

Example start:

```
📶  "waitaminute" IP address is 192.168.39.253
🐳  Configuring Docker as the container runtime ...
✨  Preparing Kubernetes environment ...
🚜  Pulling images required by Kubernetes v1.13.3 ...
🚀  Launching Kubernetes v1.13.3 using kubeadm ... 
⌛  Waiting for pods: apiserver proxy etcd dns controller scheduler storage-provisioner addon-manager
🔑  Configuring cluster permissions ...
🤔  Verifying component health .....
💗  kubectl is now configured to use "waitaminute"
🏄  Done! Thank you for using minikube!
```

Example restart:

```
🏃  Re-using the currently running kvm2 VM for "waitaminute" ...
⌛  Waiting for SSH access ...
📶  "waitaminute" IP address is 192.168.39.253
🐳  Configuring Docker as the container runtime ...
✨  Preparing Kubernetes environment ...
🚜  Pulling images required by Kubernetes v1.13.3 ...
🔄  Relaunching Kubernetes v1.13.3 using kubeadm ... 
⌛  Waiting for pods: apiserver proxy etcd dns controller scheduler storage-provisioner addon-manager
📯  Reconfiguring kube-proxy ...
🤔  Verifying component health .....
💗  kubectl is now configured to use "waitaminute"
🏄  Done! Thank you for using minikube!
```

Issues this PR may affect: #3031 #2726 #3765 #3511
