### PR TITLE
Fix minikube logs for other container runtimes

### DIFF
--- a/pkg/drivers/none/none.go
+++ b/pkg/drivers/none/none.go
@@ -134,7 +134,7 @@ func (d *Driver) Kill() error {
 	}
 
 	// First try to gracefully stop containers
-	containers, err := d.runtime.ListContainers(cruntime.MinikubeContainerPrefix)
+	containers, err := d.runtime.ListContainers("")
 	if err != nil {
 		return errors.Wrap(err, "containers")
 	}
@@ -146,7 +146,7 @@ func (d *Driver) Kill() error {
 		return errors.Wrap(err, "stop")
 	}
 
-	containers, err = d.runtime.ListContainers(cruntime.MinikubeContainerPrefix)
+	containers, err = d.runtime.ListContainers("")
 	if err != nil {
 		return errors.Wrap(err, "containers")
 	}
@@ -196,7 +196,7 @@ func (d *Driver) Stop() error {
 	if err := stopKubelet(d.exec); err != nil {
 		return err
 	}
-	containers, err := d.runtime.ListContainers(cruntime.MinikubeContainerPrefix)
+	containers, err := d.runtime.ListContainers("")
 	if err != nil {
 		return errors.Wrap(err, "containers")
 	}

--- a/pkg/minikube/cruntime/cri.go
+++ b/pkg/minikube/cruntime/cri.go
@@ -28,7 +28,14 @@ import (
 
 // listCRIContainers returns a list of containers using crictl
 func listCRIContainers(cr CommandRunner, filter string) ([]string, error) {
-	content, err := cr.CombinedOutput(fmt.Sprintf(`sudo crictl ps -a --name=%s --quiet`, filter))
+	var content string
+	var err error
+	state := "Running"
+	if filter != "" {
+		content, err = cr.CombinedOutput(fmt.Sprintf(`sudo crictl ps -a --name=%s --state=%s --quiet`, filter, state))
+	} else {
+		content, err = cr.CombinedOutput(fmt.Sprintf(`sudo crictl ps -a --state=%s --quiet`, state))
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +87,7 @@ image-endpoint: unix://{{.Socket}}
 // criContainerLogCmd returns the command to retrieve the log for a container based on ID
 func criContainerLogCmd(id string, len int, follow bool) string {
 	var cmd strings.Builder
-	cmd.WriteString("crictl logs ")
+	cmd.WriteString("sudo crictl logs ")
 	if len > 0 {
 		cmd.WriteString(fmt.Sprintf("--tail %d ", len))
 	}

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -24,8 +24,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const MinikubeContainerPrefix = "k8s_"
-
 // CommandRunner is the subset of bootstrapper.CommandRunner this package consumes
 type CommandRunner interface {
 	Run(string) error

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -24,6 +24,8 @@ import (
 	"github.com/golang/glog"
 )
 
+const KubernetesContainerPrefix = "k8s_"
+
 // Docker contains Docker runtime state
 type Docker struct {
 	Socket string
@@ -85,6 +87,7 @@ func (r *Docker) KubeletOptions() map[string]string {
 
 // ListContainers returns a list of containers
 func (r *Docker) ListContainers(filter string) ([]string, error) {
+	filter = KubernetesContainerPrefix + filter
 	content, err := r.Runner.CombinedOutput(fmt.Sprintf(`docker ps -a --filter="name=%s" --format="{{.ID}}"`, filter))
 	if err != nil {
 		return nil, err

--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -37,9 +37,9 @@ var rootCauseRe = regexp.MustCompile(`^error: |eviction manager: pods.* evicted|
 
 // importantPods are a list of pods to retrieve logs for, in addition to the bootstrapper logs.
 var importantPods = []string{
-	"k8s_kube-apiserver",
-	"k8s_coredns_coredns",
-	"k8s_kube-scheduler",
+	"kube-apiserver",
+	"coredns",
+	"kube-scheduler",
 }
 
 // lookbackwardsCount is how far back to look in a log for problems. This should be large enough to
@@ -143,7 +143,7 @@ func logCommands(r cruntime.Manager, bs bootstrapper.Bootstrapper, length int, f
 		}
 		glog.Infof("%d containers: %s", len(ids), ids)
 		if len(ids) == 0 {
-			cmds[pod] = fmt.Sprintf("No container was found matching %q", pod)
+			glog.Warningf("No container was found matching %q", pod)
 			continue
 		}
 		cmds[pod] = r.ContainerLogCmd(ids[0], length, follow)


### PR DESCRIPTION
It is only Docker that adds the "k8s_" prefix, since CRI
only handles containers that are used by Kubernetes anyway.

Also need to use "sudo" when running all crictl commands,
including logs. And only list containers that are running.

Fixes #3744