### PR TITLE
fix incorrect style name mount

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -553,7 +553,7 @@ func configureMounts() {
 		return
 	}
 
-	console.OutStyle("mount", "Creating mount %s ...", viper.GetString(mountString))
+	console.OutStyle("mounting", "Creating mount %s ...", viper.GetString(mountString))
 	path := os.Args[0]
 	mountDebugVal := 0
 	if glog.V(8) {


### PR DESCRIPTION
when running minikube `start` with the `--mount` flag an error occurs due to incorrect style name.
log:
```
(☸ |minikube) ➜  minikube git:(master) ✗ ./out/minikube-linux-amd64 start --vm-driver kvm2 --mount
😄  minikube v0.34.1 on linux (amd64)
💡  Tip: Use 'minikube start -p <name>' to create a new cluster, or 'minikube delete' to delete this one.
🔄  Restarting existing kvm2 VM for "minikube" ...
⌛  Waiting for SSH access ...
📶  "minikube" IP address is XXX ...
🐳  Configuring Docker as the container runtime ...
✨  Preparing Kubernetes environment ...
🚜  Pulling images required by Kubernetes v1.13.3 ...
🔄  Relaunching Kubernetes v1.13.3 using kubeadm ...
⌛  Waiting for pods: apiserver proxy etcd scheduler controller addon-manager dns
📯  Updating kube-proxy configuration ...
🤔  Verifying component health ......
E0304 23:52:22.034088   28575 console.go:75] applyStyle(mount): unknown style: "mount"
Creating mount /home/XXX:/minikube-host ...
💗  kubectl is now configured to use "minikube"
🏄  Done! Thank you for using minikube!
```

might be best to add constants for those, wasn't sure if that was desired.