### PR TITLE
Change DefaultMountVersion to 9p2000.L

### DIFF
--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -161,7 +161,7 @@ const (
 	DefaultUfsDebugLvl   = 0
 	DefaultMountEndpoint = "/minikube-host"
 	DefaultMsize         = 262144
-	DefaultMountVersion  = "9p2000.u"
+	DefaultMountVersion  = "9p2000.L"
 )
 
 func GetKubernetesReleaseURL(binaryName, version string) string {


### PR DESCRIPTION
9p2000.u is a legacy protocol version. This upgrades us to the most recent version with better permissions handling. From the Linux kernel docs: https://landley.net/kdocs/Documentation/filesystems/9p.txt

```
Around 2003 Plan 9 was open sourced, which led to the development of an
extended version of the protocol, "9p2000.U" (for Unix) providing full posix
semantics .... The current protocol version, "9p2000.L" (for Linux) was developed for v9fs
after a few years of real world experience. It tailors the protocol to Linux
with support for ACLs, file locking, more efficient directory listing, corner
cases in things like file deletion, and so on. 
```

Fixes #2290