### PR TITLE
Fix `minikube addons open heapster`

### DIFF
--- a/deploy/addons/heapster/heapster-svc.yaml
+++ b/deploy/addons/heapster/heapster-svc.yaml
@@ -19,6 +19,7 @@ metadata:
     kubernetes.io/name: heapster
     kubernetes.io/minikube-addons: heapster
     addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/minikube-addons-endpoint: heapster
   name: heapster
   namespace: kube-system
 spec:


### PR DESCRIPTION
In the default installation of minikube 0.35.0 I get the following error when trying to open heapster:
```
$ minikube addons open heapster
💣  This addon does not have an endpoint defined for the 'addons open' command.
You can add one by annotating a service with the label kubernetes.io/minikube-addons-endpoint:heapster
```
This PR is simply implementing the suggested fix by adding the aforementioned label to the heapster service.