### PR TITLE
Skip "pull" command if using Kubernetes 1.10, which does not support it.

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -318,11 +318,13 @@ func (k *KubeadmBootstrapper) PullImages(k8s config.KubernetesConfig) error {
 	if err != nil {
 		return errors.Wrap(err, "parsing kubernetes version")
 	}
+
+	cFlag := "config"
 	if version.LT(semver.MustParse("1.11.0")) {
-		return fmt.Errorf("pull command is not supported by kubeadm v%s", version)
+		cFlag := "kubeconfig"
 	}
 
-	cmd := fmt.Sprintf("sudo kubeadm config images pull --config %s", constants.KubeadmConfigFile)
+	cmd := fmt.Sprintf("sudo kubeadm config images pull --%s %s", cFlag, constants.KubeadmConfigFile)
 	if err := k.c.Run(cmd); err != nil {
 		return errors.Wrapf(err, "running cmd: %s", cmd)
 	}

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -318,13 +318,11 @@ func (k *KubeadmBootstrapper) PullImages(k8s config.KubernetesConfig) error {
 	if err != nil {
 		return errors.Wrap(err, "parsing kubernetes version")
 	}
-
-	cFlag := "config"
 	if version.LT(semver.MustParse("1.11.0")) {
-		cFlag := "kubeconfig"
+		return fmt.Errorf("pull command is not supported by kubeadm v%s", version)
 	}
 
-	cmd := fmt.Sprintf("sudo kubeadm config images pull --%s %s", cFlag, constants.KubeadmConfigFile)
+	cmd := fmt.Sprintf("sudo kubeadm config images pull --config %s", constants.KubeadmConfigFile)
 	if err := k.c.Run(cmd); err != nil {
 		return errors.Wrapf(err, "running cmd: %s", cmd)
 	}

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -314,6 +314,14 @@ func (k *KubeadmBootstrapper) DeleteCluster(k8s config.KubernetesConfig) error {
 
 // PullImages downloads images that will be used by RestartCluster
 func (k *KubeadmBootstrapper) PullImages(k8s config.KubernetesConfig) error {
+	version, err := ParseKubernetesVersion(k8s.KubernetesVersion)
+	if err != nil {
+		return errors.Wrap(err, "parsing kubernetes version")
+	}
+	if version.LT(semver.MustParse("1.11.0")) {
+		return fmt.Errorf("pull command is not supported by kubeadm v%s", version)
+	}
+
 	cmd := fmt.Sprintf("sudo kubeadm config images pull --config %s", constants.KubeadmConfigFile)
 	if err := k.c.Run(cmd); err != nil {
 		return errors.Wrapf(err, "running cmd: %s", cmd)


### PR DESCRIPTION
kubeadm v1.10.x doesn't support it. Here's how it gets displayed with this PR:

```
✨  Preparing Kubernetes environment ...
🚜  Pulling images required by Kubernetes v1.10.0 ...
❌  Unable to pull images, which may be OK: pull command is not supported by kubeadm v1.10.0
🔄  Relaunching Kubernetes v1.10.0 using kubeadm ... 
```

Closes #3824
