### PR TITLE
Cruntime version

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -479,8 +479,8 @@ func configureRuntimes(h *host.Host, runner bootstrapper.CommandRunner) cruntime
 	if err != nil {
 		exit.WithError("Failed to enable container runtime", err)
 	}
-	version := cr.Version()
-	if version != "" {
+	version, err := cr.Version()
+	if err == nil {
 		console.OutStyle(cr.Name(), "Version of container runtime is %s", version)
 	}
 	return cr

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -479,6 +479,10 @@ func configureRuntimes(h *host.Host, runner bootstrapper.CommandRunner) cruntime
 	if err != nil {
 		exit.WithError("Failed to enable container runtime", err)
 	}
+	version := cr.Version()
+	if version != "" {
+		console.OutStyle(cr.Name(), "Version of container runtime is %s", version)
+	}
 	return cr
 }
 

--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -18,6 +18,7 @@ package cruntime
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/golang/glog"
 )
@@ -31,6 +32,21 @@ type Containerd struct {
 // Name is a human readable name for containerd
 func (r *Containerd) Name() string {
 	return "containerd"
+}
+
+// Version retrieves the current version of this runtime
+func (r *Containerd) Version() string {
+	ver, err := r.Runner.CombinedOutput("containerd --version")
+	if err != nil {
+		return ""
+	}
+
+	// containerd github.com/containerd/containerd v1.2.0 c4446665cb9c30056f4998ed953e6d4ff22c7c39
+	words := strings.Split(ver, " ")
+	if len(words) >= 4 && words[0] == "containerd" {
+		return strings.Replace(words[2], "v", "", 1)
+	}
+	return ""
 }
 
 // SocketPath returns the path to the socket file for containerd

--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -35,18 +35,18 @@ func (r *Containerd) Name() string {
 }
 
 // Version retrieves the current version of this runtime
-func (r *Containerd) Version() string {
+func (r *Containerd) Version() (string, error) {
 	ver, err := r.Runner.CombinedOutput("containerd --version")
 	if err != nil {
-		return ""
+		return "", err
 	}
 
 	// containerd github.com/containerd/containerd v1.2.0 c4446665cb9c30056f4998ed953e6d4ff22c7c39
 	words := strings.Split(ver, " ")
 	if len(words) >= 4 && words[0] == "containerd" {
-		return strings.Replace(words[2], "v", "", 1)
+		return strings.Replace(words[2], "v", "", 1), nil
 	}
-	return ""
+	return "", fmt.Errorf("unknown version: %q", ver)
 }
 
 // SocketPath returns the path to the socket file for containerd

--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -18,6 +18,7 @@ package cruntime
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/golang/glog"
 )
@@ -31,6 +32,19 @@ type CRIO struct {
 // Name is a human readable name for CRIO
 func (r *CRIO) Name() string {
 	return "CRI-O"
+}
+
+// Version retrieves the current version of this runtime
+func (r *CRIO) Version() string {
+	ver, err := r.Runner.CombinedOutput("crio --version")
+	if err != nil {
+		return ""
+	}
+
+	// crio version 1.13.0
+	// commit: ""
+	line := strings.Split(ver, "\n")[0]
+	return strings.Replace(line, "crio version ", "", 1)
 }
 
 // SocketPath returns the path to the socket file for CRIO

--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -35,16 +35,16 @@ func (r *CRIO) Name() string {
 }
 
 // Version retrieves the current version of this runtime
-func (r *CRIO) Version() string {
+func (r *CRIO) Version() (string, error) {
 	ver, err := r.Runner.CombinedOutput("crio --version")
 	if err != nil {
-		return ""
+		return "", err
 	}
 
 	// crio version 1.13.0
 	// commit: ""
 	line := strings.Split(ver, "\n")[0]
-	return strings.Replace(line, "crio version ", "", 1)
+	return strings.Replace(line, "crio version ", "", 1), nil
 }
 
 // SocketPath returns the path to the socket file for CRIO

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -35,7 +35,7 @@ type Manager interface {
 	// Name is a human readable name for a runtime
 	Name() string
 	// Version retrieves the current version of this runtime
-	Version() string
+	Version() (string, error)
 	// Enable idempotently enables this runtime on a host
 	Enable() error
 	// Disable idempotently disables this runtime on a host

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -34,6 +34,8 @@ type CommandRunner interface {
 type Manager interface {
 	// Name is a human readable name for a runtime
 	Name() string
+	// Version retrieves the current version of this runtime
+	Version() string
 	// Enable idempotently enables this runtime on a host
 	Enable() error
 	// Disable idempotently disables this runtime on a host

--- a/pkg/minikube/cruntime/cruntime_test.go
+++ b/pkg/minikube/cruntime/cruntime_test.go
@@ -134,6 +134,10 @@ func (f *FakeRunner) CombinedOutput(cmd string) (string, error) {
 		return f.docker(args, root)
 	case "crictl":
 		return f.crictl(args, root)
+	case "crio":
+		return f.crio(args, root)
+	case "containerd":
+		return f.containerd(args, root)
 	default:
 		return "", nil
 	}
@@ -181,7 +185,29 @@ func (f *FakeRunner) docker(args []string, root bool) (string, error) {
 			delete(f.containers, id)
 
 		}
+	case "version":
+		if args[1] == "--format" && args[2] == "'{{.Server.Version}}'" {
+			return "18.06.2-ce", nil
+		}
 
+	}
+	return "", nil
+}
+
+// crio is a fake implementation of crio
+func (f *FakeRunner) crio(args []string, root bool) (string, error) {
+	switch cmd := args[0]; cmd {
+	case "--version":
+		return "crio version 1.13.0", nil
+	}
+	return "", nil
+}
+
+// containerd is a fake implementation of containerd
+func (f *FakeRunner) containerd(args []string, root bool) (string, error) {
+	switch cmd := args[0]; cmd {
+	case "--version":
+		return "containerd github.com/containerd/containerd v1.2.0 c4446665cb9c30056f4998ed953e6d4ff22c7c39", nil
 	}
 	return "", nil
 }
@@ -282,6 +308,33 @@ func (f *FakeRunner) systemctl(args []string, root bool) (string, error) {
 		}
 	}
 	return out, nil
+}
+
+func TestVersion(t *testing.T) {
+	var tests = []struct {
+		runtime string
+		want    string
+	}{
+		{"docker", "18.06.2-ce"},
+		{"cri-o", "1.13.0"},
+		{"containerd", "1.2.0"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.runtime, func(t *testing.T) {
+			runner := NewFakeRunner(t)
+			r, err := New(Config{Type: tc.runtime, Runner: runner})
+			if err != nil {
+				t.Fatalf("New(%s): %v", tc.runtime, err)
+			}
+			got, err := r.Version()
+			if err != nil {
+				t.Fatalf("Version(%s): %v", tc.runtime, err)
+			}
+			if got != tc.want {
+				t.Errorf("Version(%s) = %q, want: %q", tc.runtime, got, tc.want)
+			}
+		})
+	}
 }
 
 // defaultServices reflects the default boot state for the minikube VM

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -38,14 +38,14 @@ func (r *Docker) Name() string {
 }
 
 // Version retrieves the current version of this runtime
-func (r *Docker) Version() string {
+func (r *Docker) Version() (string, error) {
 	// Note: the server daemon has to be running, for this call to return successfully
 	ver, err := r.Runner.CombinedOutput("docker version --format '{{.Server.Version}}'")
 	if err != nil {
-		return ""
+		return "", err
 	}
 
-	return strings.Split(ver, "\n")[0]
+	return strings.Split(ver, "\n")[0], nil
 }
 
 // SocketPath returns the path to the socket file for Docker

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -37,6 +37,17 @@ func (r *Docker) Name() string {
 	return "Docker"
 }
 
+// Version retrieves the current version of this runtime
+func (r *Docker) Version() string {
+	// Note: the server daemon has to be running, for this call to return successfully
+	ver, err := r.Runner.CombinedOutput("docker version --format '{{.Server.Version}}'")
+	if err != nil {
+		return ""
+	}
+
+	return strings.Split(ver, "\n")[0]
+}
+
 // SocketPath returns the path to the socket file for Docker
 func (r *Docker) SocketPath() string {
 	return r.Socket

--- a/pkg/minikube/cruntime/rkt.go
+++ b/pkg/minikube/cruntime/rkt.go
@@ -35,16 +35,16 @@ func (r *Rkt) Name() string {
 }
 
 // Version retrieves the current version of this runtime
-func (r *Rkt) Version() string {
+func (r *Rkt) Version() (string, error) {
 	ver, err := r.Runner.CombinedOutput("rkt version")
 	if err != nil {
-		return ""
+		return "", err
 	}
 
 	// rkt Version: 1.24.0
 	// appc Version: 0.8.10
 	line := strings.Split(ver, "\n")[0]
-	return strings.Replace(line, "rkt Version: ", "", 1)
+	return strings.Replace(line, "rkt Version: ", "", 1), nil
 }
 
 // SocketPath returns the path to the socket file for rkt/rktlet

--- a/pkg/minikube/cruntime/rkt.go
+++ b/pkg/minikube/cruntime/rkt.go
@@ -18,6 +18,7 @@ package cruntime
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/golang/glog"
 )
@@ -31,6 +32,19 @@ type Rkt struct {
 // Name is a human readable name for rkt
 func (r *Rkt) Name() string {
 	return "rkt"
+}
+
+// Version retrieves the current version of this runtime
+func (r *Rkt) Version() string {
+	ver, err := r.Runner.CombinedOutput("rkt version")
+	if err != nil {
+		return ""
+	}
+
+	// rkt Version: 1.24.0
+	// appc Version: 0.8.10
+	line := strings.Split(ver, "\n")[0]
+	return strings.Replace(line, "rkt Version: ", "", 1)
 }
 
 // SocketPath returns the path to the socket file for rkt/rktlet


### PR DESCRIPTION
Output the container runtime version, for weird setups (like `none` custom VMs or older ISO, or similar)