### PR TITLE
Fix exe suffix and missing checksum for windows binary

### DIFF
--- a/hack/jenkins/release_github_page.sh
+++ b/hack/jenkins/release_github_page.sh
@@ -117,8 +117,8 @@ FILES_TO_UPLOAD=(
     'minikube-linux-amd64.sha256'
     'minikube-darwin-amd64'
     'minikube-darwin-amd64.sha256'
-    'minikube-windows-amd64'
-    'minikube-windows-amd64.sha256'
+    'minikube-windows-amd64.exe'
+    'minikube-windows-amd64.exe.sha256'
     'minikube-installer.exe'
     "minikube_${DEB_VERSION}.deb"
     'docker-machine-driver-kvm2'


### PR DESCRIPTION
Windows needs that DOS suffix, so we make a copy