### PR TITLE
Markdown Lint (for docs)

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,8 @@
 {
   "no-inline-html": false,
   "no-trailing-punctuation": false,
+  "blanks-around-fences": false,
+  "commands-show-output": false,
   "ul-style": false,
-  "line_length": false
+  "line-length": false
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+  "no-inline-html": false,
+  "no-trailing-punctuation": false,
+  "ul-style": false,
+  "line_length": false
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Minikube Release Notes
 
-# Version 0.35.0 - 2019-03-06
+## Version 0.35.0 - 2019-03-06
 
 * Update default Kubernetes version to v1.13.4 (latest stable) [#3807](https://github.com/kubernetes/minikube/pull/3807)
 * Update docker/machine to fix the AMD bug [#3809](https://github.com/kubernetes/minikube/pull/3809)
@@ -34,7 +34,7 @@ Thank you to the following contributors who made this release possible:
 - Yaroslav Skopets
 - Yoan Blanc
 
-# Version 0.34.1 - 2019-02-16
+## Version 0.34.1 - 2019-02-16
 
 * Make non-zero ssh error codes less dramatic [#3703](https://github.com/kubernetes/minikube/pull/3703)
 * Only call trySSHPowerOff if we are using hyperv [#3702](https://github.com/kubernetes/minikube/pull/3702)
@@ -48,7 +48,7 @@ Thank you to the folks who contributed to this bugfix release:
 - Joerg Schad
 - Thomas Strömberg
 
-# Version 0.34.0 - 2019-02-15
+## Version 0.34.0 - 2019-02-15
 
 * Initial implementation of 'console' package for stylized & localized console output 😂 [#3638](https://github.com/kubernetes/minikube/pull/3638)
 * Podman 1.0.0 [#3584](https://github.com/kubernetes/minikube/pull/3584)
@@ -82,6 +82,7 @@ Thank you to the folks who contributed to this bugfix release:
 * Fix for issue #3044 - mounted timestamps incorrect with windows host [#3285](https://github.com/kubernetes/minikube/pull/3285)
 
 Huge thank you for this release towards our contributors:
+
 - Abhilash Pallerlamudi
 - Alberto Alvarez
 - Anders Björklund
@@ -107,11 +108,11 @@ Huge thank you for this release towards our contributors:
 - Yugo Horie
 - Zhongcheng Lao
 
-# Version 0.33.1 - 2019-01-18
+## Version 0.33.1 - 2019-01-18
 
 * Install upstream runc into /usr/bin/docker-runc [#3545](https://github.com/kubernetes/minikube/pull/3545)
 
-# Version 0.33.0 - 2019-01-17
+## Version 0.33.0 - 2019-01-17
 
 * Set default Kubernetes version to v1.13.2 (latest stable) [#3527](https://github.com/kubernetes/minikube/pull/3527)
 * Update to opencontainers/runc HEAD as of 2019-01-15 [#3535](https://github.com/kubernetes/minikube/pull/3535)
@@ -159,7 +160,7 @@ Thank you to all to everyone who contributed to this massive release:
 - Thomas Strömberg
 - wujeff
 
-# Version 0.32.0 - 12/21/2018
+## Version 0.32.0 - 12/21/2018
 
 * Make Kubernetes v1.12.4 the default [#3482](https://github.com/kubernetes/minikube/pull/3482)
 * Update kubeadm restart commands to support v1.13.x [#3483](https://github.com/kubernetes/minikube/pull/3483)
@@ -187,7 +188,7 @@ Shout-out to the amazing members of the minikube community who made this release
 - RA489
 - Thomas Strömberg
 
-# Version 0.31.0 - 12/08/2018
+## Version 0.31.0 - 12/08/2018
 
 * Enable gvisor addon in minikube [#3399](https://github.com/kubernetes/minikube/pull/3399)
 * LoadBalancer emulation with `minikube tunnel` [#3015](https://github.com/kubernetes/minikube/pull/3015)
@@ -200,17 +201,17 @@ Shout-out to the amazing members of the minikube community who made this release
 * Include ISO URL and reduce stutter in download error message [#3221](https://github.com/kubernetes/minikube/pull/3221)
 * Add apiserver check to "status", and block "start" until it's healthy. [#3401](https://github.com/kubernetes/minikube/pull/3401)
 * Containerd improvements
-  *  Only restart docker service if container runtime is docker [#3426](https://github.com/kubernetes/minikube/pull/3426)
+  * Only restart docker service if container runtime is docker [#3426](https://github.com/kubernetes/minikube/pull/3426)
   * Restart containerd after stopping alternate runtimes [#3343](https://github.com/kubernetes/minikube/pull/3343)
 * CRI-O improvements
   * Stop docker daemon, when running cri-o [#3211](https://github.com/kubernetes/minikube/pull/3211)
-  *  Upgrade to crio v1.11.8 [#3313](https://github.com/kubernetes/minikube/pull/3313)
+  * Upgrade to crio v1.11.8 [#3313](https://github.com/kubernetes/minikube/pull/3313)
   * Add config parameter for the cri socket path [#3154](https://github.com/kubernetes/minikube/pull/3154)
-
-* Ton of Build and CI improvements 
+* Ton of Build and CI improvements
 * Ton of documentation updates
 
-Huge thank you for this release towards our contributors: 
+Huge thank you for this release towards our contributors:
+
 - Akihiro Suda
 - Alexander Ilyin
 - Anders Björklund
@@ -234,8 +235,7 @@ Huge thank you for this release towards our contributors:
 - xichengliudui
 - Yongkun Anfernee Gui
 
-
-# Version 0.30.0 - 10/04/2018
+## Version 0.30.0 - 10/04/2018
 
 * **Fix for [CVE-2018-1002103](https://github.com/kubernetes/minikube/issues/3208): Dashboard vulnerable to DNS rebinding attack** [#3210](https://github.com/kubernetes/minikube/pull/3210)
 * Initial support for Kubernetes 1.12+ [#3180](https://github.com/kubernetes/minikube/pull/3180)
@@ -250,6 +250,7 @@ Huge thank you for this release towards our contributors:
 * Significant improvements to kvm2 networking [#3148](https://github.com/kubernetes/minikube/pull/3148)
 
 Huge thank you for this release towards our contributors:
+
 - Anders F Björklund
 - Bob Killen
 - David Genest
@@ -264,7 +265,8 @@ Huge thank you for this release towards our contributors:
 - Sven Anderson
 - Thomas Strömberg
 
-# Version 0.29.0 - 09/27/2018
+## Version 0.29.0 - 09/27/2018
+
 * Issue #3037 change dependency management to dep [#3136](https://github.com/kubernetes/minikube/pull/3136)
 * Update dashboard version to v1.10.0 [#3122](https://github.com/kubernetes/minikube/pull/3122)
 * fix: --format outputs any string, --https only subsitute http URL scheme [#3114](https://github.com/kubernetes/minikube/pull/3114)
@@ -285,7 +287,7 @@ Huge thank you for this release towards our contributors:
 * Update to go 1.10.1 everywhere. [#2777](https://github.com/kubernetes/minikube/pull/2777)
 * Allow to override build date with SOURCE_DATE_EPOCH [#3009](https://github.com/kubernetes/minikube/pull/3009)
 
-Huge Thank You for this release to our contributors: 
+Huge Thank You for this release to our contributors:
 
 - Aaron Prindle
 - AdamDang
@@ -319,10 +321,12 @@ Huge Thank You for this release to our contributors:
 - wangxy518
 - yanxuean
 
-# Version 0.28.2 - 7/20/2018
+## Version 0.28.2 - 7/20/2018
+
 * Nvidia driver installation fixed [#2996](https://github.com/kubernetes/minikube/pull/2986)
 
-# Version 0.28.1 - 7/16/2018
+## Version 0.28.1 - 7/16/2018
+
 * vboxsf Host Mounting fixed (Linux Kernel version downgraded to 4.15 from 4.16) [#2986](https://github.com/kubernetes/minikube/pull/2986)
 * cri-tools udpated to 1.11.1 [#2986](https://github.com/kubernetes/minikube/pull/2986)
 * Feature Gates support added to kubeadm bootstrapper [#2951](https://github.com/kubernetes/minikube/pull/2951)
@@ -331,7 +335,8 @@ Huge Thank You for this release to our contributors:
 * nginx ingress controller updated to 0.16.2 [#2930](https://github.com/kubernetes/minikube/pull/2930)
 * heketi and gluster dependencies added to minikube ISO [#2925](https://github.com/kubernetes/minikube/pull/2925)
 
-# Version 0.28.0 - 6/12/2018
+## Version 0.28.0 - 6/12/2018
+
 * Minikube status command fixes [#2894](https://github.com/kubernetes/minikube/pull/2894)
 * Boot changes to support virsh console [#2887](https://github.com/kubernetes/minikube/pull/2887)
 * ISO changes to update to Linux 4.16 [#2883](https://github.com/kubernetes/minikube/pull/2883)
@@ -344,20 +349,23 @@ Huge Thank You for this release to our contributors:
 * Heapster updated to 1.5.3 [#2821](https://github.com/kubernetes/minikube/pull/2821)
 * Fix for clock skew in certificate creation [#2823](https://github.com/kubernetes/minikube/pull/2823)
 
-# Version 0.27.0 - 5/14/2018
+## Version 0.27.0 - 5/14/2018
+
 * Start the default network for the kvm2 driver [#2806](https://github.com/kubernetes/minikube/pull/2806)
 * Fix 1.9.x versions of Kubernetes with the kubeadm bootstrapper [#2791](https://github.com/kubernetes/minikube/pull/2791)
 * Switch the ingress addon from an RC to a Deployment [#2788](https://github.com/kubernetes/minikube/pull/2788)
 * Update nginx ingress controller to 0.14.0 [#2780](https://github.com/kubernetes/minikube/pull/2780)
 * Disable dnsmasq on network for kvm driver [#2745](https://github.com/kubernetes/minikube/pull/2745)
 
-# Version 0.26.1 - 4/17/2018
+## Version 0.26.1 - 4/17/2018
+
 * Mark hyperkit, kvm2 and none drivers as supported [#2734](https://github.com/kubernetes/minikube/pull/2723) and [#2728](https://github.com/kubernetes/minikube/pull/2728)
 * Bug fix for hyper-v driver [#2719](https://github.com/kubernetes/minikube/pull/2719)
 * Add back CRI preflight ignore [#2723](https://github.com/kubernetes/minikube/pull/2723)
 * Fix preflight checks on clusters <1.9 [#2721](https://github.com/kubernetes/minikube/pull/2721)
 
-# Version 0.26.0 - 4/3/2018
+## Version 0.26.0 - 4/3/2018
+
 * Update to Kubernetes 1.10 [#2657](https://github.com/kubernetes/minikube/pull/2657)
 * Update Nginx Ingress Plugin to 0.12.0 [#2644](https://github.com/kubernetes/minikube/pull/2644)
 * [Minikube ISO] Add SSHFS Support to the Minikube ISO [#2600](https://github.com/kubernetes/minikube/pull/2600)
@@ -372,7 +380,8 @@ Huge Thank You for this release to our contributors:
 * [Minikube ISO] Add Netfilter module to the ISO for Calico [#2490](https://github.com/kubernetes/minikube/pull/2490)
 * Add memory and request limit to EFK Addon [#2465](https://github.com/kubernetes/minikube/pull/2465)
 
-# Version 0.25.0 - 1/26/2018
+## Version 0.25.0 - 1/26/2018
+
 * Add freshpod addon [#2423](https://github.com/kubernetes/minikube/pull/2423)
 * List addons in consistent sort order [#2446](https://github.com/kubernetes/minikube/pull/2446)
 * [Minikube ISO] Upgrade Docker to 17.09 [#2427](https://github.com/kubernetes/minikube/pull/2427)
@@ -389,11 +398,13 @@ Huge Thank You for this release to our contributors:
 * Upgrade to Kubernetes 1.9 [#2343](https://github.com/kubernetes/minikube/pull/2343)
 * [hyperkit] Support NFS Sharing [#2337](https://github.com/kubernetes/minikube/pull/2337)
 
-# Version 0.24.1 - 11/30/2017
+## Version 0.24.1 - 11/30/2017
+
 * Add checksum verification for localkube
 * Bump minikube iso to v0.23.6
 
-# Version 0.24.0 - 11/29/2017
+## Version 0.24.0 - 11/29/2017
+
 * Deprecated xhyve and kvm drivers [#2227](https://github.com/kubernetes/minikube/pull/2227)
 * Added support for a "rootfs" layer in .minikube/files [#2110](https://github.com/kubernetes/minikube/pull/2110)
 * Added a `cache` command to cache non-minikube images [#2203](https://github.com/kubernetes/minikube/pull/2203)
@@ -406,7 +417,8 @@ Huge Thank You for this release to our contributors:
 * Bug fix to use the minikube context instead of the current kubectl context [#2128](https://github.com/kubernetes/minikube/pull/2128)
 * Added zsh autocompletion [#2194](https://github.com/kubernetes/minikube/pull/2194)
 
-# Version 0.23.0 - 10/26/2017
+## Version 0.23.0 - 10/26/2017
+
 * Upgraded to go 1.9 [#2113](https://github.com/kubernetes/minikube/pull/2113)
 * Localkube is no longer packaged in minikube bin-data [#2089](https://github.com/kubernetes/minikube/pull/2089)
 * Upgraded to Kubernetes 1.8 [#2088](https://github.com/kubernetes/minikube/pull/2088)
@@ -423,7 +435,8 @@ Huge Thank You for this release to our contributors:
 * [Minikube ISO] Upgraded to Docker 17.05-ce [#1542](https://github.com/kubernetes/minikube/pull/1542)
 * [Minikube ISO] Upgraded to CRI-O v1.0.0 [#2069](https://github.com/kubernetes/minikube/pull/2069)
 
-# Version 0.22.3 - 10/3/2017
+## Version 0.22.3 - 10/3/2017
+
 * Update dnsmasq to 1.14.5 [2022](https://github.com/kubernetes/minikube/pull/2022)
 * Windows cache path fix [2000](https://github.com/kubernetes/minikube/pull/2000)
 * Windows path fix [1981](https://github.com/kubernetes/minikube/pull/1982)
@@ -433,15 +446,18 @@ Huge Thank You for this release to our contributors:
 
 * [MINIKUBE ISO] Added cri-o runtime [1998](https://github.com/kubernetes/minikube/pull/1998)
 
-# Version 0.22.2 - 9/15/2017
+## Version 0.22.2 - 9/15/2017
+
 * Fix path issue on windows [1954](https://github.com/kubernetes/minikube/pull/1959)
 * Added experimental kubeadm bootstrapper [1903](https://github.com/kubernetes/minikube/pull/1903)
 * Fixed Hyper-V KVP daemon [1958](https://github.com/kubernetes/minikube/pull/1958)
 
-# Version 0.22.1 - 9/6/2017
+## Version 0.22.1 - 9/6/2017
+
 * Fix for chmod error on windows [1933](https://github.com/kubernetes/minikube/pull/1933)
 
-# Version 0.22.0 - 9/6/2017
+## Version 0.22.0 - 9/6/2017
+
 * Made secure serving the default for all components and disabled insecure serving [#1694](https://github.com/kubernetes/minikube/pull/1694)
 * Increased minikube boot speed by caching docker images [#1881](https://github.com/kubernetes/minikube/pull/1881)
 * Added .minikube/files directory which gets moved into the VM at /files each VM start[#1917](https://github.com/kubernetes/minikube/pull/1917)
@@ -452,7 +468,8 @@ Huge Thank You for this release to our contributors:
 
 * [MINIKUBE ISO] Update cni-bin to v0.6.0-rc1 [#1760](https://github.com/kubernetes/minikube/pull/1760)
 
-# Version 0.21.0 - 7/25/2017
+## Version 0.21.0 - 7/25/2017
+
 * Added check for extra arguments to minikube delete [#1718](https://github.com/kubernetes/minikube/pull/1718)
 * Add GCR URL Env Var to Registry-Creds addon [#1436](https://github.com/kubernetes/minikube/pull/1436)
 * Bump version of Registry-Creds addon to v1.8 [#1711](https://github.com/kubernetes/minikube/pull/1711)
@@ -482,6 +499,7 @@ Huge Thank You for this release to our contributors:
 * [Minikube ISO] Add ebtables util and enable kernel module [#1713](https://github.com/kubernetes/minikube/pull/1713)
 
 ## Version 0.20.0 - 6/17/2017
+
 * Updated default Kubernetes version to 1.6.4
 * Added Local Registry Addon `minikube addons enable registry` [#1583](https://github.com/kubernetes/minikube/pull/1583)
 * Fixed kube-DNS addon failures
@@ -500,6 +518,7 @@ Huge Thank You for this release to our contributors:
 * [Minikube ISO] Use buildroot branch 2017-02
 
 ## Version 0.19.1 - 5/30/2017
+
 * Fixed issue where using TPRs could cause localkube to crash
 * Added mount daemon that can be started using `minikube start --mount --mount-string="/path/to/mount"`.  Cleanup of mount handled by `minikube delete`
 * Added minikube "none" driver which does not require a VM but instead launches k8s components on the host.  This allows minikube to be used in cloud environments that don't support nested virtualizations.  This can be launched by running `sudo minikube start --vm-driver=none --use-vendored-driver`
@@ -509,6 +528,7 @@ Huge Thank You for this release to our contributors:
 * Fixed vbox interface issue with minikube mount
 
 ## Version 0.19.0 - 5/3/2017
+
 * Updated nginx ingress to v0.9-beta.4
 * Updated kube-dns to 1.14.1
 * Added optional `--profile` flag to all `minikube` commands to support multiple minikube instances
@@ -517,6 +537,7 @@ Huge Thank You for this release to our contributors:
 * Fixed issue where using TPRs could cause localkube to crash
 
 ## Version 0.18.0 - 4/6/2017
+
 * Upgraded default kubernetes version to v1.6.0
 * Mount command on macOS xhyve
 * Pods can now write to files mounted by `minikube mount`
@@ -541,6 +562,7 @@ Huge Thank You for this release to our contributors:
 * [Minikube ISO] Added CIFS-utils
 
 ## Version 0.17.1 - 3/2/2017
+
 * Removed vendored KVM driver so minikube doesn't have a dependency on libvirt-bin
 
 * [Minikube ISO] Added ethtool
@@ -551,6 +573,7 @@ Huge Thank You for this release to our contributors:
 * [Minikube ISO] `/tmp/hostpath_pv` and `/tmp/hostpath-provisioner` are now persisted
 
 ## Version 0.17.0 - 3/2/2017
+
 * Added external hostpath provisioner to localkube
 * Added unit test coverage
 * Added API Name as configuration option
@@ -561,6 +584,7 @@ Huge Thank You for this release to our contributors:
 * Added `minikube mount` command for 9p server
 
 ## Version 0.16.0 - 2/2/2017
+
 * Updated minikube ISO to [v1.0.6](https://github.com/kubernetes/minikube/tree/v0.16.0/deploy/iso/minikube-iso/CHANGELOG.md)
 * Updated Registry Creds addon to v1.5
 * Added check for minimum disk size
@@ -577,6 +601,7 @@ Huge Thank You for this release to our contributors:
 * [Minikube ISO] Fixed vboxFS permission error
 
 ## Version 0.15.0 - 1/10/2017
+
 * Update Dashboard to v1.5.1, fixes a CSRF vulnerability in the dashboard
 * Updated Kube-DNS addon to v1.9
 * Now supports kubenet as a network plugin
@@ -588,6 +613,7 @@ Huge Thank You for this release to our contributors:
 * Switched integration tests to use golang subtest framework
 
 ## Version 0.14.0 - 12/14/2016
+
 * Update to k8s v1.5.1
 * Update Addon-manager to v6.1
 * Update Dashboard to v1.5
@@ -598,10 +624,12 @@ Huge Thank You for this release to our contributors:
 * Refactor integration tests
 
 ## Version 0.13.1 - 12/5/2016
+
 * Fix `service list` command
 * Dashboard dowgnraded to v1.4.2, correctly shows PetSets again
 
 ## Version 0.13.0 - 12/1/2016
+
 * Added heapster addon, disabled by default
 * Added `minikube addon open` command
 * Added Linux Virtualbox Integration tests
@@ -614,11 +642,13 @@ Huge Thank You for this release to our contributors:
 * Update dashboard version to 1.5.0
 
 ## Version 0.12.2 - 10/31/2016
+
 * Fixed dashboard command
 * Added support for net.IP to the configurator
 * Updated dashboard version to 1.4.2
 
 ## Version 0.12.1 - 10/28/2016
+
 * Added docker-env support to the buildroot provisioner
 * `minikube service` command now supports multiple ports
 * Added `minikube service list` command
@@ -629,6 +659,7 @@ Huge Thank You for this release to our contributors:
 * Add option to specify network name for KVM
 
 ## Version 0.12.0 - 10/21/2016
+
 * Added support for the KUBECONFIG env var during 'minikube start'
 * Updated default k8s version to v1.4.3
 * Updated addon-manager to v5.1
@@ -641,6 +672,7 @@ Huge Thank You for this release to our contributors:
 * Added support for IPv6 addresses in docker env
 
 ## Version 0.11.0 - 10/6/2016
+
 * Added a "configurator" allowing users to configure the Kubernetes components with arbitrary values.
 * Made Kubernetes v1.4.0 the default version in minikube
 * Pre-built binaries are now built with go 1.7.1
@@ -648,6 +680,7 @@ Huge Thank You for this release to our contributors:
 * Bug fixes
 
 ## Version 0.10.0 - 9/15/2016
+
 * Updated the Kubernetes dashboard to v1.4.0
 * Added experimental rkt support
 * Enabled DynamicProvisioning of volumes
@@ -657,6 +690,7 @@ Huge Thank You for this release to our contributors:
 * Renamed the created VM from minikubeVM to minikube
 
 ## Version 0.9.0 - 9/1/2016
+
 * Added Hyper-V support for Windows
 * Added debug-level logging for show-libmachine-logs
 * Added ISO checksum validation for cached ISOs
@@ -665,6 +699,7 @@ Huge Thank You for this release to our contributors:
 * xhyve driver will now receive the same IP across starts/delete
 
 ## Version 0.8.0 - 8/17/2016
+
 * Added a --registry-mirror flag to `minikube start`.
 * Updated Kubernetes components to v1.3.5.
 * Changed the `dashboard` and `service` commands to wait for the underlying services to be ready.
@@ -677,9 +712,11 @@ Huge Thank You for this release to our contributors:
 * Minikube will now cache downloaded localkube versions.
 
 ## Version 0.7.1 - 7/27/2016
+
 * Fixed a filepath issue which caused `minikube start` to not work properly on Windows
 
 ## Version 0.7.0 - 7/26/2016
+
 * Added experimental support for Windows.
 * Changed the etc DNS port to avoid a conflict with deis/router.
 * Added a `insecure-registry` flag to `minikube start` to support insecure docker registries.
@@ -692,6 +729,7 @@ Huge Thank You for this release to our contributors:
 * Added additional supported shells for `minikube docker-env` (fish, cmd, powershell, tcsh, bash, zsh).
 
 ## Version 0.6.0 - 7/13/2016
+
 * Added a `--disk-size` flag to `minikube start`.
 * Fixed a bug regarding auth tokens not being reconfigured properly after VM restart
 * Added a new `get-k8s-versions` command, to get the available kubernetes versions so that users know what versions are available when trying to select the kubernetes version to use
@@ -699,6 +737,7 @@ Huge Thank You for this release to our contributors:
 * Documentation Updates
 
 ## Version 0.5.0 - 7/6/2016
+
 * Updated Kubernetes components to v1.3.0
 * Added experimental support for KVM and XHyve based drivers. See the [drivers documentation](DRIVERS.md) for usage.
 * Fixed a bug causing cluster state to be deleted after a `minikube stop`.
@@ -707,6 +746,7 @@ Huge Thank You for this release to our contributors:
 * Added a `--cpus` flag to `minikube start`.
 
 ## Version 0.4.0 - 6/27/2016
+
 * Updated Kubernetes components to v1.3.0-beta.1
 * Updated the Kubernetes Dashboard to v1.1.0
 * Added a check for updates to minikube.
@@ -717,20 +757,22 @@ Huge Thank You for this release to our contributors:
   regenerated whenever `minikube start` is run.
 
 ## Version 0.3.0 - 6/10/2016
- * Added a `minikube dashboard` command to open the Kubernetes Dashboard.
- * Updated Docker to version 1.11.1.
- * Updated Kubernetes components to v1.3.0-alpha.5-330-g760c563.
- * Generated documentation for all commands. Documentation [is here](https://github.com/kubernetes/minikube/blob/master/docs/minikube.md).
 
+* Added a `minikube dashboard` command to open the Kubernetes Dashboard.
+* Updated Docker to version 1.11.1.
+* Updated Kubernetes components to v1.3.0-alpha.5-330-g760c563.
+* Generated documentation for all commands. Documentation [is here](https://github.com/kubernetes/minikube/blob/master/docs/minikube.md).
 
 ## Version 0.2.0 - 6/3/2016
- * conntrack is now bundled in the ISO.
- * DNS is now working.
- * Minikube now uses the iptables based proxy mode.
- * Internal libmachine logging is now hidden by default.
- * There is a new `minikube ssh` command to ssh into the minikube VM.
- * Dramatically improved integration test coverage
- * Switched to glog instead of fmt.Print*
+
+* conntrack is now bundled in the ISO.
+* DNS is now working.
+* Minikube now uses the iptables based proxy mode.
+* Internal libmachine logging is now hidden by default.
+* There is a new `minikube ssh` command to ssh into the minikube VM.
+* Dramatically improved integration test coverage
+* Switched to glog instead of fmt.Print*
 
 ## Version 0.1.0 - 5/29/2016
- * Initial minikube release.
+
+* Initial minikube release.

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,11 @@ KVM_DRIVER_FILES := ./cmd/drivers/kvm/
 
 MINIKUBE_TEST_FILES := ./cmd/... ./pkg/...
 
+# npm install -g markdownlint-cli
+MARKDOWNLINT ?= markdownlint
+
+MINIKUBE_MARKDOWN_FILES := README.md docs CONTRIBUTING.md CHANGELOG.md
+
 MINIKUBE_BUILD_TAGS := container_image_ostree_stub containers_image_openpgp
 MINIKUBE_INTEGRATION_BUILD_TAGS := integration $(MINIKUBE_BUILD_TAGS)
 SOURCE_DIRS = cmd pkg test
@@ -226,6 +231,10 @@ gendocs: out/docs/minikube.md
 .PHONY: fmt
 fmt:
 	@gofmt -l -s -w $(SOURCE_DIRS)
+
+.PHONY: mdlint
+mdlint:
+	@$(MARKDOWNLINT) $(MINIKUBE_MARKDOWN_FILES)
 
 out/docs/minikube.md: $(shell find cmd) $(shell find pkg/minikube/constants) pkg/minikube/assets/assets.go
 	cd $(GOPATH)/src/$(REPOPATH) && go run -ldflags="$(MINIKUBE_LDFLAGS)" hack/gen_help_text.go

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## What is minikube?
 
-minikube implements a local Kubernetes cluster on macOS, Linux, and Windows. 
+minikube implements a local Kubernetes cluster on macOS, Linux, and Windows.
 
 <img src="https://github.com/kubernetes/minikube/raw/master/images/start.jpg" width="800">
 
@@ -31,7 +31,7 @@ Our [goal](https://github.com/kubernetes/minikube/blob/master/docs/contributors/
 
 minikube runs the official stable release of Kubernetes, with support for standard Kubernetes features like:
 
-* [LoadBalancer](https://github.com/kubernetes/minikube/blob/master/docs/tunnel.md) - using `minikube tunnel` 
+* [LoadBalancer](https://github.com/kubernetes/minikube/blob/master/docs/tunnel.md) - using `minikube tunnel`
 * Multi-cluster - using `minikube start -p <name>`
 * NodePorts - using `minikube service`
 * [Persistent Volumes](https://github.com/kubernetes/minikube/blob/master/docs/persistent_volumes.md)
@@ -56,7 +56,7 @@ As well as developer-friendly features:
 
 ## Community
 
-minikube is a Kubernetes [#sig-cluster-lifecycle](https://github.com/kubernetes/community/tree/master/sig-cluster-lifecycle)  project. 
+minikube is a Kubernetes [#sig-cluster-lifecycle](https://github.com/kubernetes/community/tree/master/sig-cluster-lifecycle)  project.
 
 * [**#minikube on Kubernetes Slack**](https://kubernetes.slack.com) - Live chat with minikube developers!
 * [minikube-users mailing list](https://groups.google.com/forum/#!forum/minikube-users)
@@ -81,7 +81,7 @@ See the [installation guide](https://kubernetes.io/docs/tasks/tools/install-mini
   * using [chocolatey](https://chocolatey.org/) `choco install minikube`
   * manually: Download and run the [installer](https://storage.googleapis.com/minikube/releases/latest/minikube-installer.exe)
 
-* *Linux* 
+* *Linux*
   * Requires either the [kvm2 driver](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm2-driver) (recommended), or VirtualBox
   * VT-x/AMD-v virtualization must be enabled in BIOS
   * manually:  `curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && sudo install minikube-linux-amd64 /usr/local/bin/minikube`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-## Advanced Topics and Tutorials
+# Advanced Topics and Tutorials
 
-### Cluster Configuration
+## Cluster Configuration
 
 * **Alternative Runtimes** ([alternative_runtimes.md](alternative_runtimes.md)): How to run minikube with rkt as the container runtime
 

--- a/docs/accessing_etcd.md
+++ b/docs/accessing_etcd.md
@@ -1,6 +1,9 @@
-## Accessing Host Resources From Inside A Pod
-### When you have a VirtualBox driver
+# Accessing Host Resources From Inside A Pod
+
+## When you have a VirtualBox driver
+
 In order to access host resources from inside a pod, run the following command to determine the host IP you can use:
+
 ```shell
 ip addr
 ```

--- a/docs/addons.md
+++ b/docs/addons.md
@@ -1,6 +1,7 @@
-## Add-ons
+# Add-ons
 
 Minikube has a set of built in addons that can be used enabled, disabled, and opened inside of the local k8s environment. Below is an example of this functionality for the `heapster` addon:
+
 ```shell
 $ minikube addons list
 - registry: disabled
@@ -26,6 +27,7 @@ Waiting, endpoint for service is not ready yet...
 Waiting, endpoint for service is not ready yet...
 Created new window in existing browser session.
 ```
+
 The currently supported addons include:
 
 * [Kubernetes Dashboard](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/dashboard)

--- a/docs/alternative_runtimes.md
+++ b/docs/alternative_runtimes.md
@@ -1,4 +1,6 @@
-### Using rkt container engine
+# Alternative runtimes
+
+## Using rkt container engine
 
 To use [rkt](https://github.com/coreos/rkt) as the container runtime run:
 
@@ -6,8 +8,7 @@ To use [rkt](https://github.com/coreos/rkt) as the container runtime run:
 $ minikube start --container-runtime=rkt
 ```
 
-
-### Using CRI-O
+## Using CRI-O
 
 To use [CRI-O](https://github.com/kubernetes-sigs/cri-o) as the container runtime, run:
 
@@ -27,7 +28,7 @@ $ minikube start --container-runtime=cri-o \
     --extra-config=kubelet.image-service-endpoint=unix:///var/run/crio/crio.sock
 ```
 
-### Using containerd
+## Using containerd
 
 To use [containerd](https://github.com/containerd/containerd) as the container runtime, run:
 

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -1,4 +1,4 @@
-## Caching Images
+# Caching Images
 
 Minikube supports caching non-minikube images using the `minikube cache` command. Images can be added to the cache by running `minikube cache add <img>`, and deleted by running `minikube cache delete <img>`.
 

--- a/docs/configuring_kubernetes.md
+++ b/docs/configuring_kubernetes.md
@@ -1,11 +1,11 @@
-## Configuring Kubernetes
+# Configuring Kubernetes
 
 Minikube has a "configurator" feature that allows users to configure the Kubernetes components with arbitrary values.
 To use this feature, you can use the `--extra-config` flag on the `minikube start` command.
 
 This flag is repeated, so you can pass it several times with several different values to set multiple options.
 
-### Kubeadm bootstrapper
+## Kubeadm bootstrapper
 
 The kubeadm bootstrapper can be configured by the `--extra-config` flag on the `minikube start` command.  It takes a string of the form `component.key=value` where `component` is one of the strings
 

--- a/docs/contributors/README.md
+++ b/docs/contributors/README.md
@@ -1,10 +1,11 @@
-## Contributing
+# Contributing
 
 * **New contributors** ([contributors.md](https://github.com/kubernetes/minikube/blob/master/CONTRIBUTING.md)): Process for new contributors, CLA instructions
 
 * **Roadmap** ([roadmap.md](roadmap.md)): The roadmap for future minikube development
 
 ## New Features and Dependencies
+
 * **Adding a dependency** ([adding_a_dependency.md](adding_a_dependency.md)): How to add or update vendored code
 
 * **Adding a new addon** ([adding_an_addon.md](adding_an_addon.md)): How to add a new addon to minikube for `minikube addons`
@@ -12,6 +13,7 @@
 * **Adding a new driver** ([adding_driver.md](adding_driver.md)): How to add a new driver to minikube for `minikube create --vm-driver=<driver>`
 
 ## Building and Releasing
+
 * **Build Guide** ([build_guide.md](build_guide.md)): How to build minikube from source
 
 * **ISO Build Guide** ([minikube_iso.md](minikube_iso.md)): How to build and hack on the ISO image that minikube uses

--- a/docs/contributors/adding_a_dependency.md
+++ b/docs/contributors/adding_a_dependency.md
@@ -1,4 +1,5 @@
-#### Adding a New Dependency
+# Adding a New Dependency
+
 Minikube uses `dep` to manage vendored dependencies.
 
 See the `dep` [documentation](https://golang.github.io/dep/docs/introduction.html) for installation and usage instructions.

--- a/docs/contributors/adding_an_addon.md
+++ b/docs/contributors/adding_an_addon.md
@@ -1,4 +1,5 @@
-#### Adding a New Addon
+# Adding a New Addon
+
 To add a new addon to minikube the following steps are required:
 
 * For the new addon's .yaml file(s):
@@ -15,12 +16,12 @@ To add a new addon to minikube the following steps are required:
   var settings = []Setting{
     ...,
     // add other addon setting
-  	{
-  		name:        "efk",
-  		set:         SetBool,
-  		validations: []setFn{IsValidAddon},
-  		callbacks:   []setFn{EnableOrDisableAddon},
-  	},
+    {
+      name:        "efk",
+      set:         SetBool,
+      validations: []setFn{IsValidAddon},
+      callbacks:   []setFn{EnableOrDisableAddon},
+    },
   }
   ```
 
@@ -32,22 +33,22 @@ To add a new addon to minikube the following steps are required:
     ...,
     // add other addon asset
     "efk": NewAddon([]*BinDataAsset{
-  		NewBinDataAsset(
-  			"deploy/addons/efk/efk-configmap.yaml",
-  			constants.AddonsPath,
-  			"efk-configmap.yaml",
-  			"0640"),
-  		NewBinDataAsset(
-  			"deploy/addons/efk/efk-rc.yaml",
-  			constants.AddonsPath,
-  			"efk-rc.yaml",
-  			"0640"),
-  		NewBinDataAsset(
-  			"deploy/addons/efk/efk-svc.yaml",
-  			constants.AddonsPath,
-  			"efk-svc.yaml",
-  			"0640"),
-  	}, false, "efk"),
+      NewBinDataAsset(
+        "deploy/addons/efk/efk-configmap.yaml",
+        constants.AddonsPath,
+        "efk-configmap.yaml",
+        "0640"),
+      NewBinDataAsset(
+        "deploy/addons/efk/efk-rc.yaml",
+        constants.AddonsPath,
+        "efk-rc.yaml",
+        "0640"),
+      NewBinDataAsset(
+        "deploy/addons/efk/efk-svc.yaml",
+        constants.AddonsPath,
+        "efk-svc.yaml",
+        "0640"),
+    }, false, "efk"),
   }
   ```
 

--- a/docs/contributors/adding_driver.md
+++ b/docs/contributors/adding_driver.md
@@ -1,6 +1,6 @@
 # Adding new driver (Deprecated)
 
-New drivers should be added into https://github.com/machine-drivers
+New drivers should be added into <https://github.com/machine-drivers>
 
 Minikube relies on docker machine drivers to manage machines. This document talks about how to
 add an existing docker machine driver into minikube registry, so that minikube can use the driver
@@ -26,7 +26,7 @@ Registry is what minikube uses to register all the supported drivers. The driver
 their drivers in registry, and minikube runtime will look at the registry to find a driver and use the
 driver metadata to determine what workflow to apply while those drivers are being used.
 
-The godoc of registry is available here: https://godoc.org/k8s.io/minikube/pkg/minikube/registry
+The godoc of registry is available here: <https://godoc.org/k8s.io/minikube/pkg/minikube/registry>
 
 [DriverDef](https://godoc.org/k8s.io/minikube/pkg/minikube/registry#DriverDef) is the main
 struct to define a driver metadata. Essentially, you need to define 4 things at most, which is
@@ -52,33 +52,33 @@ All drivers are located in `k8s.io/minikube/pkg/minikube/drivers`. Take `vmwaref
 package vmwarefusion
 
 import (
-	"github.com/docker/machine/drivers/vmwarefusion"
-	"github.com/docker/machine/libmachine/drivers"
-	cfg "k8s.io/minikube/pkg/minikube/config"
-	"k8s.io/minikube/pkg/minikube/constants"
-	"k8s.io/minikube/pkg/minikube/registry"
+    "github.com/docker/machine/drivers/vmwarefusion"
+    "github.com/docker/machine/libmachine/drivers"
+    cfg "k8s.io/minikube/pkg/minikube/config"
+    "k8s.io/minikube/pkg/minikube/constants"
+    "k8s.io/minikube/pkg/minikube/registry"
 )
 
 func init() {
-	registry.Register(registry.DriverDef{
-		Name:          "vmwarefusion",
-		Builtin:       true,
-		ConfigCreator: createVMwareFusionHost,
-		DriverCreator: func() drivers.Driver {
-			return vmwarefusion.NewDriver("", "")
-		},
-	})
+    registry.Register(registry.DriverDef{
+        Name:          "vmwarefusion",
+        Builtin:       true,
+        ConfigCreator: createVMwareFusionHost,
+        DriverCreator: func() drivers.Driver {
+            return vmwarefusion.NewDriver("", "")
+        },
+    })
 }
 
 func createVMwareFusionHost(config cfg.MachineConfig) interface{} {
-	d := vmwarefusion.NewDriver(cfg.GetMachineName(), constants.GetMinipath()).(*vmwarefusion.Driver)
-	d.Boot2DockerURL = config.Downloader.GetISOFileURI(config.MinikubeISO)
-	d.Memory = config.Memory
-	d.CPU = config.CPUs
-	d.DiskSize = config.DiskSize
-	d.SSHPort = 22
-	d.ISO = d.ResolveStorePath("boot2docker.iso")
-	return d
+    d := vmwarefusion.NewDriver(cfg.GetMachineName(), constants.GetMinipath()).(*vmwarefusion.Driver)
+    d.Boot2DockerURL = config.Downloader.GetISOFileURI(config.MinikubeISO)
+    d.Memory = config.Memory
+    d.CPU = config.CPUs
+    d.DiskSize = config.DiskSize
+    d.SSHPort = 22
+    d.ISO = d.ResolveStorePath("boot2docker.iso")
+    return d
 }
 ```
 
@@ -98,4 +98,3 @@ In summary, the process includes the following steps:
 2. Add import in `pkg/minikube/cluster/default_drivers.go`
 
 Any Questions: please ping your friend [@anfernee](https://github.com/anfernee)
-

--- a/docs/contributors/build_guide.md
+++ b/docs/contributors/build_guide.md
@@ -1,20 +1,23 @@
-### Build Requirements
+# Build Guide
+
+## Build Requirements
+
 * A recent Go distribution (>=1.12)
 * If you're not on Linux, you'll need a Docker installation
 * minikube requires at least 4GB of RAM to compile, which can be problematic when using docker-machine
 
-#### Prerequisites for different GNU/Linux distributions
+### Prerequisites for different GNU/Linux distributions
 
-##### Fedora
+#### Fedora
+
 On Fedora you need to install _glibc-static_
-
 ```shell
 $ sudo dnf install -y glibc-static
 ```
 
 ### Building from Source
-Clone minikube into your go path under `$GOPATH/src/k8s.io`
 
+Clone minikube into your go path under `$GOPATH/src/k8s.io`
 ```shell
 $ git clone https://github.com/kubernetes/minikube.git $GOPATH/src/k8s.io/minikube
 $ cd $GOPATH/src/k8s.io/minikube
@@ -25,20 +28,23 @@ Note: Make sure that you uninstall any previous versions of minikube before buil
 from the source.
 
 ### Building from Source in Docker (using Debian stretch image with golang)
+
 Clone minikube:
 ```shell
 $ git clone https://github.com/kubernetes/minikube.git
 ```
+
 Build (cross compile for linux / OS X and Windows) using make:
 ```shell
 $ cd minikube
 $ docker run --rm -v "$PWD":/go/src/k8s.io/minikube -w /go/src/k8s.io/minikube golang:stretch make cross
 ```
+
 Check "out" directory:
 ```shell
 $ ls out/
-docker-machine-driver-hyperkit.d	minikube				minikube.d				test.d
-docker-machine-driver-kvm2.d		minikube-linux-amd64			storage-provisioner.d
+docker-machine-driver-hyperkit.d    minikube                minikube.d             test.d
+docker-machine-driver-kvm2.d        minikube-linux-amd64            storage-provisioner.d
 ```
 
 ### Run Instructions
@@ -77,11 +83,14 @@ You can run these against minikube by following these steps:
 * Run `make quick-release` in the k8s repo.
 * Start up a minikube cluster with: `minikube start`.
 * Set following two environment variables:
+
 ```shell
 export KUBECONFIG=$HOME/.kube/config
 export KUBERNETES_CONFORMANCE_TEST=y
 ```
+
 * Run the tests (from the k8s repo):
+
 ```shell
 go run hack/e2e.go -v --test --test_args="--ginkgo.focus=\[Conformance\]" --check-version-skew=false
 ```

--- a/docs/contributors/ci_builds.md
+++ b/docs/contributors/ci_builds.md
@@ -1,9 +1,11 @@
-### CI Builds
+# CI Builds
 
 We publish CI builds of minikube, built at every Pull Request. Builds are available at (substitute in the relevant PR number):
-- https://storage.googleapis.com/minikube-builds/PR_NUMBER/minikube-darwin-amd64
-- https://storage.googleapis.com/minikube-builds/PR_NUMBER/minikube-linux-amd64
-- https://storage.googleapis.com/minikube-builds/PR_NUMBER/minikube-windows-amd64.exe
+
+- <https://storage.googleapis.com/minikube-builds/PR_NUMBER/minikube-darwin-amd64>
+- <https://storage.googleapis.com/minikube-builds/PR_NUMBER/minikube-linux-amd64>
+- <https://storage.googleapis.com/minikube-builds/PR_NUMBER/minikube-windows-amd64.exe>
 
 We also publish CI builds of minikube-iso, built at every Pull Request that touches deploy/iso/minikube-iso.  Builds are available at:
-- https://storage.googleapis.com/minikube-builds/PR_NUMBER/minikube-testing.iso
+
+- <https://storage.googleapis.com/minikube-builds/PR_NUMBER/minikube-testing.iso>

--- a/docs/contributors/minikube_iso.md
+++ b/docs/contributors/minikube_iso.md
@@ -1,8 +1,9 @@
-## minikube ISO image
+# minikube ISO image
 
 This includes the configuration for an alternative bootable ISO image meant to be used in conjunction with minikube.
 
 It includes:
+
 - systemd as the init system
 - rkt
 - docker
@@ -13,9 +14,10 @@ It includes:
 ### Requirements
 
 * Linux
+
 ```shell
 sudo apt-get install build-essential gnupg2 p7zip-full git wget cpio python \
-	unzip bc gcc-multilib automake libtool locales
+    unzip bc gcc-multilib automake libtool locales
 ```
 
 Either import your private key or generate a sign-only key using `gpg2 --gen-key`.
@@ -68,7 +70,6 @@ $ git status
 ```
 
 ### Saving buildroot/kernel configuration changes
-
 
 To make any kernel configuration changes and save them, execute:
 

--- a/docs/contributors/principles.md
+++ b/docs/contributors/principles.md
@@ -22,5 +22,4 @@ Here are some specific minikube features that align with our goal:
 ## Non-Goals
 
 * Simplifying Kubernetes production deployment experience
- * Supporting all possible deployment configurations of Kubernetes like various types of storage, networking, etc.
-
+* Supporting all possible deployment configurations of Kubernetes like various types of storage, networking, etc.

--- a/docs/contributors/releasing_minikube.md
+++ b/docs/contributors/releasing_minikube.md
@@ -7,16 +7,16 @@
 
 ## Build a new ISO
 
-Major releases always get a new ISO. Minor bugfixes may or may not require it: check for changes in the `deploy/iso` folder. 
+Major releases always get a new ISO. Minor bugfixes may or may not require it: check for changes in the `deploy/iso` folder.
 
 Note: you can build the ISO using the `hack/jenkins/build_iso.sh` script locally.
 
- * navigate to the minikube ISO jenkins job
- * Ensure that you are logged in (top right)
- * Click "▶️ Build with Parameters" (left)
- * For `ISO_VERSION`, type in the intended release version (same as the minikube binary's version)
- * For `ISO_BUCKET`, type in `minikube/iso`
- * Click *Build*
+* navigate to the minikube ISO jenkins job
+* Ensure that you are logged in (top right)
+* Click "▶️ Build with Parameters" (left)
+* For `ISO_VERSION`, type in the intended release version (same as the minikube binary's version)
+* For `ISO_BUCKET`, type in `minikube/iso`
+* Click *Build*
 
 The build will take roughly 50 minutes.
 
@@ -47,7 +47,7 @@ env BUILD_IN_DOCKER=y make cross checksum
 
 Once submitted, HEAD will use the new ISO. Please pay attention to test failures, as this is our integration test across platforms. If there are known acceptable failures, please add a PR comment linking to the appropriate issue.
 
-## Update Release Notes 
+## Update Release Notes
 
 Run the following script to update the release notes:
 
@@ -59,11 +59,11 @@ Merge the output into CHANGELOG.md. See [PR#3175](https://github.com/kubernetes/
 
 ## Tag the Release
 
-NOTE: Confirm that all release-related PR's have been submitted before doing this step. 
+NOTE: Confirm that all release-related PR's have been submitted before doing this step.
 
 Do this in a direct clone of the upstream kubernetes/minikube repository (not your fork!):
 
-```
+```shell
 version=<new version number>
 git fetch
 git checkout master
@@ -76,12 +76,12 @@ git push origin v$version
 
 This step uses the git tag to publish new binaries to GCS and create a github release:
 
- * navigate to the minikube "Release" jenkins job
- * Ensure that you are logged in (top right)
- * Click "▶️ Build with Parameters" (left)
- * `VERSION_MAJOR`, `VERSION_MINOR`, and `VERSION_BUILD` should reflect the values in your Makefile
- * For `ISO_SHA256`, run: `gsutil cat gs://minikube/iso/minikube-v<version>.iso.sha256`
- * Click *Build*
+* navigate to the minikube "Release" jenkins job
+* Ensure that you are logged in (top right)
+* Click "▶️ Build with Parameters" (left)
+* `VERSION_MAJOR`, `VERSION_MINOR`, and `VERSION_BUILD` should reflect the values in your Makefile
+* For `ISO_SHA256`, run: `gsutil cat gs://minikube/iso/minikube-v<version>.iso.sha256`
+* Click *Build*
 
 ## Check releases.json
 
@@ -95,8 +95,8 @@ These are downstream packages that are being maintained by others and how to upg
 
 | Package Manager | URL | TODO |
 | --- | --- | --- |
-| Arch Linux AUR | https://aur.archlinux.org/packages/minikube/ | "Flag as package out-of-date"
-| Brew Cask | https://github.com/Homebrew/homebrew-cask/blob/master/Casks/minikube.rb | The release job creates a new PR in [Homebrew/homebrew-cask](https://github.com/Homebrew/homebrew-cask) with an updated version and SHA256, double check that it's created.
+| Arch Linux AUR | <https://aur.archlinux.org/packages/minikube/> | "Flag as package out-of-date"
+| Brew Cask | <https://github.com/Homebrew/homebrew-cask/blob/master/Casks/minikube.rb> | The release job creates a new PR in [Homebrew/homebrew-cask](https://github.com/Homebrew/homebrew-cask) with an updated version and SHA256, double check that it's created.
 
 ## Verification
 
@@ -104,7 +104,7 @@ Verify release checksums by running`make check-release`
 
 ## Update docs
 
-If there are major changes, please send a PR to update https://kubernetes.io/docs/setup/minikube/
+If there are major changes, please send a PR to update <https://kubernetes.io/docs/setup/minikube/>
 
 ## Announce!
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,5 +1,7 @@
-### Debugging Issues With Minikube
+# Debugging Issues With Minikube
+
 To debug issues with minikube (not *Kubernetes* but **minikube** itself), you can use the `-v` flag to see debug level info.  The specified values for `-v` will do the following (the values are all encompassing in that higher values will give you all lower value outputs as well):
+
 * `--v=0` will output **INFO** level logs
 * `--v=1` will output **WARNING** level logs
 * `--v=2` will output **ERROR** level logs
@@ -10,7 +12,6 @@ Example:
 `minikube start --v=1` Will start minikube and output all warnings to stdout.
 
 If you need to access additional tools for debugging, minikube also includes the [CoreOS toolbox](https://github.com/coreos/toolbox)
-
 
 You can ssh into the toolbox and access these additional commands using:
 `minikube ssh toolbox`

--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -14,7 +14,7 @@ the host PATH:
 * [HyperV](#hyperv-driver)
 * [VMware](#vmware-unified-driver)
 
-#### KVM2 driver
+## KVM2 driver
 
 To install the KVM2 driver, first install and configure the prereqs:
 
@@ -36,13 +36,13 @@ sudo apt install libvirt-bin libvirt-daemon-system qemu-kvm
 sudo yum install libvirt-daemon-kvm qemu-kvm
 ```
 
-Enable,start, and verify the libvirtd service has started. 
+Enable,start, and verify the libvirtd service has started.
+
 ```shell
 sudo systemctl enable libvirtd.service
 sudo systemctl start libvirtd.service
 sudo systemctl status libvirtd.service
 ```
-
 
 Then you will need to add yourself to libvirt group (older distributions may use libvirtd instead)
 
@@ -59,8 +59,7 @@ curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-
   && sudo install docker-machine-driver-kvm2 /usr/local/bin/
 ```
 
-
-NOTE: Ubuntu users on a release older than 18.04, or anyone experiencing [#3206: Error creating new host: dial tcp: missing address.](https://github.com/kubernetes/minikube/issues/3206) you will need to build your own driver until [#3689](https://github.com/kubernetes/minikube/issues/3689) is resolved. Building this binary will require [Go v1.11](https://golang.org/dl/) or newer to be installed. 
+NOTE: Ubuntu users on a release older than 18.04, or anyone experiencing [#3206: Error creating new host: dial tcp: missing address.](https://github.com/kubernetes/minikube/issues/3206) you will need to build your own driver until [#3689](https://github.com/kubernetes/minikube/issues/3689) is resolved. Building this binary will require [Go v1.11](https://golang.org/dl/) or newer to be installed.
 
 ```shell
 sudo apt install libvirt-dev
@@ -90,18 +89,17 @@ and run minikube as usual:
 minikube start
 ```
 
-#### Hyperkit driver
+## Hyperkit driver
 
 The Hyperkit driver will eventually replace the existing xhyve driver.
 It is built from the minikube source tree, and uses [moby/hyperkit](http://github.com/moby/hyperkit) as a Go library.
 
 To install the hyperkit driver via brew:
 
-
 ```shell
 brew install docker-machine-driver-hyperkit
 
-# docker-machine-driver-hyperkit need root owner and uid 
+# docker-machine-driver-hyperkit need root owner and uid
 sudo chown root:wheel /usr/local/opt/docker-machine-driver-hyperkit/bin/docker-machine-driver-hyperkit
 sudo chmod u+s /usr/local/opt/docker-machine-driver-hyperkit/bin/docker-machine-driver-hyperkit
 ```
@@ -139,7 +137,7 @@ and run minikube as usual:
 minikube start
 ```
 
-#### HyperV driver
+## HyperV driver
 
 Hyper-v users may need to create a new external network switch as described [here](https://docs.docker.com/machine/drivers/hyper-v/). This step may prevent a problem in which `minikube start` hangs indefinitely, unable to ssh into the minikube virtual machine. In this add, add the `--hyperv-virtual-switch=switch-name` argument to the `minikube start` command.
 
@@ -150,6 +148,7 @@ To use the driver:
 ```shell
 minikube start --vm-driver hyperv --hyperv-virtual-switch=switch-name
 ```
+
 or, to use hyperv as a default driver:
 
 ```shell
@@ -162,12 +161,12 @@ and run minikube as usual:
 minikube start
 ```
 
-#### VMware unified driver
+## VMware unified driver
 
 The VMware unified driver will eventually replace the existing vmwarefusion driver.
 The new unified driver supports both VMware Fusion (on macOS) and VMware Workstation (on Linux and Windows)
 
-To install the vmware unified driver, head over at https://github.com/machine-drivers/docker-machine-driver-vmware/releases and download the release for your operating system. 
+To install the vmware unified driver, head over at <https://github.com/machine-drivers/docker-machine-driver-vmware/releases> and download the release for your operating system.
 
 The driver must be:
 
@@ -201,4 +200,3 @@ and run minikube as usual:
 ```shell
 minikube start
 ```
-

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -3,7 +3,7 @@
 
 ## Config option variables
 
-minikube supports passing environment variables instead of flags for every value listed in `minikube config list`.  This is done by passing an environment variable with the prefix `MINIKUBE_`. 
+minikube supports passing environment variables instead of flags for every value listed in `minikube config list`.  This is done by passing an environment variable with the prefix `MINIKUBE_`.
 
 For example the `minikube start --iso-url="$ISO_URL"` flag can also be set by setting the `MINIKUBE_ISO_URL="$ISO_URL"` environment variable.
 
@@ -46,7 +46,7 @@ MINIKUBE_ENABLE_PROFILING=1 minikube start
 
 Output:
 
-```
+``` text
 2017/01/09 13:18:00 profile: cpu profiling enabled, /tmp/profile933201292/cpu.pprof
 Starting local Kubernetes cluster...
 Kubectl is now configured to use the cluster.

--- a/docs/gpu.md
+++ b/docs/gpu.md
@@ -32,34 +32,37 @@ host to the minikube VM. Doing so has a few prerequisites:
 
 - Once you reboot the system after doing the above, you should be ready to use
   GPUs with kvm2. Run the following command to start minikube:
-  ```
+  ```shell
   minikube start --vm-driver kvm2 --gpu
   ```
+
   This command will check if all the above conditions are satisfied and
   passthrough spare GPUs found on the host to the VM.
 
   If this succeeded, run the following commands:
-  ```
+  ```shell
   minikube addons enable nvidia-gpu-device-plugin
   minikube addons enable nvidia-driver-installer
   ```
+
   This will install the NVIDIA driver (that works for GeForce/Quadro cards)
   on the VM.
 
 - If everything succeeded, you should be able to see `nvidia.com/gpu` in the
   capacity:
-  ```
+  ```shell
   kubectl get nodes -ojson | jq .items[].status.capacity
   ```
 
 ### Where can I learn more about GPU passthrough?
+
 See the excellent documentation at
-https://wiki.archlinux.org/index.php/PCI_passthrough_via_OVMF
+<https://wiki.archlinux.org/index.php/PCI_passthrough_via_OVMF>
 
 ### Why are so many manual steps required to use GPUs with kvm2 on minikube?
+
 These steps require elevated privileges which minikube doesn't run with and they
 are disruptive to the host, so we decided to not do them automatically.
-
 
 ## Using NVIDIA GPU on minikube on Linux with `--vm-driver=none`
 
@@ -70,26 +73,28 @@ to expose GPUs with `--vm-driver=kvm2`. Please don't mix these instructions.
 
 - Install the nvidia driver, nvidia-docker and configure docker with nvidia as
   the default runtime. See instructions at
-  https://github.com/NVIDIA/nvidia-docker
+  <https://github.com/NVIDIA/nvidia-docker>
 
 - Start minikube:
-  ```
+  ```shell
   minikube start --vm-driver=none --apiserver-ips 127.0.0.1 --apiserver-name localhost
   ```
 
 - Install NVIDIA's device plugin:
-  ```
+  ```shell
   kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v1.10/nvidia-device-plugin.yml
   ```
 
-
 ## Why does minikube not support NVIDIA GPUs on macOS?
+
 VM drivers supported by minikube for macOS doesn't support GPU passthrough:
+
 - [mist64/xhyve#108](https://github.com/mist64/xhyve/issues/108)
 - [moby/hyperkit#159](https://github.com/moby/hyperkit/issues/159)
 - [VirtualBox docs](http://www.virtualbox.org/manual/ch09.html#pcipassthrough)
 
 Also:
+
 - For quite a while, all Mac hardware (both laptops and desktops) have come with
   Intel or AMD GPUs (and not with NVIDIA GPUs). Recently, Apple added [support
   for eGPUs](https://support.apple.com/en-us/HT208544), but even then all the
@@ -98,8 +103,8 @@ Also:
 - nvidia-docker [doesn't support
   macOS](https://github.com/NVIDIA/nvidia-docker/issues/101) either.
 
-
 ## Why does minikube not support NVIDIA GPUs on Windows?
+
 minikube supports Windows host through Hyper-V or VirtualBox.
 
 - VirtualBox doesn't support PCI passthrough for [Windows

--- a/docs/host_folder_mount.md
+++ b/docs/host_folder_mount.md
@@ -1,5 +1,5 @@
+# Mounting Host Folders
 
-## Mounting Host Folders
 `minikube mount /path/to/dir/to/mount:/vm-mount-path` is the recommended way to mount directories into minikube so that they can be used in your local Kubernetes cluster. The command works on all supported platforms. Below is an example workflow for using `minikube mount`:
 
 ```shell

--- a/docs/http_proxy.md
+++ b/docs/http_proxy.md
@@ -1,4 +1,4 @@
-## Using Minikube with an HTTP Proxy
+# Using Minikube with an HTTP Proxy
 
 minikube requires access to the internet via HTTP, HTTPS, and DNS protocols. If a HTTP proxy is required to access the internet, you may need to pass the proxy connection information to both minikube and Docker using environment variables:
 
@@ -17,7 +17,7 @@ One important note: If NO_PROXY is required by non-Kubernetes applications, such
 
 ### macOS and Linux
 
-```
+```shell
 export HTTP_PROXY=http://<proxy hostname:port>
 export HTTPS_PROXY=https://<proxy hostname:port>
 export NO_PROXY=localhost,127.0.0.1,10.96.0.0/12,192.168.99.1/24
@@ -30,7 +30,7 @@ To make the exported variables permanent, consider adding the declarations to ~/
 
 ### Windows
 
-```
+```shell
 set HTTP_PROXY=http://<proxy hostname:port>
 set HTTPS_PROXY=https://<proxy hostname:port>
 set NO_PROXY=localhost,127.0.0.1,10.96.0.0/12,192.168.99.1/24
@@ -45,7 +45,7 @@ To set these environment variables permanently, consider adding these to your [s
 
 ### unable to cache ISO... connection refused
 
-```
+```text
 Unable to start VM: unable to cache ISO: https://storage.googleapis.com/minikube/iso/minikube.iso:
 failed to download: failed to download to temp file: download failed: 5 error(s) occurred:
 
@@ -57,8 +57,8 @@ This error indicates that the host:port combination defined by HTTPS_PROXY or HT
 
 ## Unable to pull images..Client.Timeout exceeded while awaiting headers
 
-```
-Unable to pull images, which may be OK: 
+```text
+Unable to pull images, which may be OK:
 
 failed to pull image "k8s.gcr.io/kube-apiserver:v1.13.3": output: Error response from daemon:
 Get https://k8s.gcr.io/v2/: net/http: request canceled while waiting for connection
@@ -69,7 +69,7 @@ This error indicates that the container runtime running within the VM does not h
 
 ## x509: certificate signed by unknown authority
 
-```
+```text
 [ERROR ImagePull]: failed to pull image k8s.gcr.io/kube-apiserver:v1.13.3:
 output: Error response from daemon:
 Get https://k8s.gcr.io/v2/: x509: certificate signed by unknown authority
@@ -83,7 +83,6 @@ Ask your IT department for the appropriate PEM file, and add it to:
 
 Then run `minikube delete` and `minikube start`.
 
-
 ## Additional Information
 
-- [Configure Docker to use a proxy server](https://docs.docker.com/network/proxy/)
+* [Configure Docker to use a proxy server](https://docs.docker.com/network/proxy/)

--- a/docs/insecure_registry.md
+++ b/docs/insecure_registry.md
@@ -1,4 +1,4 @@
-## Enabling Docker Insecure Registry
+# Enabling Docker Insecure Registry
 
 Minikube allows users to configure the docker engine's `--insecure-registry` flag. You can use the `--insecure-registry` flag on the
 `minikube start` command to enable insecure communication between the docker engine and registries listening to requests from the CIDR range.
@@ -8,7 +8,9 @@ with TLS certificates. Because the default service cluster IP is known to be ava
 deployed inside the cluster by creating the cluster with `minikube start --insecure-registry "10.0.0.0/24"`.
 
 ## Private Container Registries
+
 **GCR/ECR/Docker**: Minikube has an addon, `registry-creds` which maps credentials into Minikube to support pulling from Google Container Registry (GCR), Amazon's EC2 Container Registry (ECR), and Private Docker registries.  You will need to run `minikube addons configure registry-creds` and `minikube addons enable registry-creds` to get up and running.  An example of this is below:
+
 ```shell
 $ minikube addons configure registry-creds
 Do you want to enable AWS Elastic Container Registry? [y/n]: n

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -1,4 +1,4 @@
-## Networking
+# Networking
 
 The minikube VM is exposed to the host system via a host-only IP address, that can be obtained with the `minikube ip` command.
 Any services of type `NodePort` can be accessed over that IP address, on the NodePort.
@@ -11,52 +11,52 @@ We also have a shortcut for fetching the minikube IP and a service's `NodePort`:
 
 `minikube service --url $SERVICE`
 
-### LoadBalancer emulation (`minikube tunnel`)
+## LoadBalancer emulation (`minikube tunnel`)
 
-Services of type `LoadBalancer` can be exposed via the `minikube tunnel` command. 
+Services of type `LoadBalancer` can be exposed via the `minikube tunnel` command.
 
 ````shell
 minikube tunnel
-```` 
+````
 
 Will output:
 
-```
+```text
 out/minikube tunnel
 Password: *****
-Status: 
+Status:
         machine: minikube
         pid: 59088
         route: 10.96.0.0/12 -> 192.168.99.101
         minikube: Running
         services: []
-    errors: 
+    errors:
                 minikube: no errors
                 router: no errors
                 loadbalancer emulator: no errors
 
 
-```` 
+````
 
 Tunnel might ask you for password for creating and deleting network routes.
- 
-# Cleaning up orphaned routes 
+
+## Cleaning up orphaned routes
 
 If the `minikube tunnel` shuts down in an unclean way, it might leave a network route around.
-This case the ~/.minikube/tunnels.json file will contain an entry for that tunnel. 
-To cleanup orphaned routes, run: 
-````
+This case the ~/.minikube/tunnels.json file will contain an entry for that tunnel.
+To cleanup orphaned routes, run:
+
+````shell
 minikube tunnel --cleanup
 ````
 
-# (Advanced) Running tunnel as root to avoid entering password multiple times 
+## (Advanced) Running tunnel as root to avoid entering password multiple times
 
-`minikube tunnel` runs as a separate daemon, creates a network route on the host to the service CIDR of the cluster using the cluster's IP address as a gateway. 
-Adding a route requires root privileges for the user, and thus there are differences in how to run `minikube tunnel` depending on the OS.    
+`minikube tunnel` runs as a separate daemon, creates a network route on the host to the service CIDR of the cluster using the cluster's IP address as a gateway.
+Adding a route requires root privileges for the user, and thus there are differences in how to run `minikube tunnel` depending on the OS.
 
-Recommended way to use on Linux with KVM2 driver and MacOSX with Hyperkit driver: 
+Recommended way to use on Linux with KVM2 driver and MacOSX with Hyperkit driver:
 
 `sudo -E minikube tunnel`
 
-Using VirtualBox on Windows, Mac and Linux _both_ `minikube start` and `minikube tunnel` needs to be started from the same Administrator user session otherwise [VBoxManage can't recognize the created VM](https://forums.virtualbox.org/viewtopic.php?f=6&t=81551).     
-
+Using VirtualBox on Windows, Mac and Linux _both_ `minikube start` and `minikube tunnel` needs to be started from the same Administrator user session otherwise [VBoxManage can't recognize the created VM](https://forums.virtualbox.org/viewtopic.php?f=6&t=81551).

--- a/docs/openid_connect_auth.md
+++ b/docs/openid_connect_auth.md
@@ -2,8 +2,7 @@
 
 Minikube `kube-apiserver` can be configured to support OpenID Connect Authentication.
 
-Read more about OpenID Connect Authentication for Kubernetes here: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens
-
+Read more about OpenID Connect Authentication for Kubernetes here: <https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens>
 
 ## Configuring the API Server
 
@@ -21,7 +20,7 @@ minikube start \
 
 ## Configuring kubectl
 
-You can use the kubectl `oidc` authenticator to create a kubeconfig as shown in the Kubernetes docs: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#option-1-oidc-authenticator
+You can use the kubectl `oidc` authenticator to create a kubeconfig as shown in the Kubernetes docs: <https://kubernetes.io/docs/reference/access-authn-authz/authentication/#option-1-oidc-authenticator>
 
 `minikube start` already creates a kubeconfig that includes a `cluster`, in order to use it with your `oidc` authenticator kubeconfig, you can run:
 

--- a/docs/persistent_volumes.md
+++ b/docs/persistent_volumes.md
@@ -1,7 +1,8 @@
-## Persistent Volumes
+# Persistent Volumes
+
 Minikube supports [PersistentVolumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) of type `hostPath` out of the box.  These PersistentVolumes are mapped to a directory inside the running Minikube instance (usually a VM, unless you use `--vm-driver=none`).  For more information on how this works, read the Dynamic Provisioning section below.
 
-### A note on mounts, persistence, and Minikube hosts
+## A note on mounts, persistence, and Minikube hosts
 
 Minikube is configured to persist files stored under the following directories, which are made in the Minikube VM (or on your localhost if running on bare metal).  You may lose data from other directories on reboots.
 

--- a/docs/reusing_the_docker_daemon.md
+++ b/docs/reusing_the_docker_daemon.md
@@ -1,4 +1,4 @@
-### Reusing the Docker daemon
+# Reusing the Docker daemon
 
 When using a single VM of Kubernetes it's really handy to reuse the Docker daemon inside the VM; as this means you don't have to build on your host machine and push the image into a docker registry - you can just build inside the same docker daemon as minikube which speeds up local experiments.
 
@@ -7,7 +7,9 @@ To be able to work with the docker daemon on your mac/linux host use the docker-
 ```shell
 eval $(minikube docker-env)
 ```
+
 You should now be able to use docker on the command line on your host mac/linux machine talking to the docker daemon inside the minikube VM:
+
 ```shell
 docker ps
 ```

--- a/docs/tunnel.md
+++ b/docs/tunnel.md
@@ -57,7 +57,7 @@ and deleted via:
 sudo ip route delete 10.0.0.0/8
 ```
 
-The routing table can be queried with `netstat -nr -f inet` 
+The routing table can be queried with `netstat -nr -f inet`
 
 ### OSX
 
@@ -87,41 +87,41 @@ route ADD 10.0.0.0 MASK 255.0.0.0 <minikube ip>
 and deleted via:
 
 ```shell
-route DELETE 10.0.0.0 
+route DELETE 10.0.0.0
 ```
 
 The routing table can be queried with `route print -4`
 
-### Handling unclean shutdowns 
+### Handling unclean shutdowns
 
-Unclean shutdowns of the tunnel process can result in partially executed cleanup process, leaving network routes in the routing table. 
-We will keep track of the routes created by each tunnel in a centralized location in the main minikube config directory. 
-This list serves as a registry for tunnels containing information about 
-- machine profile 
-- process ID 
+Unclean shutdowns of the tunnel process can result in partially executed cleanup process, leaving network routes in the routing table.
+We will keep track of the routes created by each tunnel in a centralized location in the main minikube config directory.
+This list serves as a registry for tunnels containing information about
+
+- machine profile
+- process ID
 - and the route that was created
 
-The cleanup command cleans the routes from both the routing table and the registry for tunnels that are not running: 
- 
-``` 
+The cleanup command cleans the routes from both the routing table and the registry for tunnels that are not running:
+
+```shell
 minikube tunnel --cleanup
 ```
 
-Updating the tunnel registry and the routing table is an atomic transaction: 
+Updating the tunnel registry and the routing table is an atomic transaction:
 
-- create route in the routing table + create registry entry if both are successful, otherwise rollback  
-- delete route in the routing table + remove registry entry if both are successful, otherwise rollback 
+- create route in the routing table + create registry entry if both are successful, otherwise rollback
+- delete route in the routing table + remove registry entry if both are successful, otherwise rollback
 
-*Note*: because we don't support currently real multi cluster setup (due to overlapping CIDRs), the handling of running/not-running processes is not strictly required however it is forward looking.  
+*Note*: because we don't support currently real multi cluster setup (due to overlapping CIDRs), the handling of running/not-running processes is not strictly required however it is forward looking.
 
-### Handling routing table conflicts  
+### Handling routing table conflicts
 
-A routing table conflict happens when a destination CIDR of the route required by the tunnel overlaps with an existing route. 
-Minikube tunnel will warn the user if this happens and should not create the rule. 
+A routing table conflict happens when a destination CIDR of the route required by the tunnel overlaps with an existing route.
+Minikube tunnel will warn the user if this happens and should not create the rule.
 There should not be any automated removal of conflicting routes.
 
-*Note*: If the user removes the minikube config directory, this might leave conflicting rules in the network routing table that will have to be cleaned up manually.  
-
+*Note*: If the user removes the minikube config directory, this might leave conflicting rules in the network routing table that will have to be cleaned up manually.
 
 ## Load Balancer Controller
 
@@ -138,7 +138,7 @@ sleep
 
 Note that the Minikube ClusterIP can change over time (during system reboots) and this loop should also handle reconciliation of those changes.
 
-## Handling multiple clusters 
+## Handling multiple clusters
 
-Multiple clusters are currently not supported due to our inability to specify ServiceCIDR. 
+Multiple clusters are currently not supported due to our inability to specify ServiceCIDR.
 This causes conflicting routes having the same destination CIDR.

--- a/docs/vmdriver-none.md
+++ b/docs/vmdriver-none.md
@@ -14,7 +14,7 @@ The `none` driver supports releases of Debian, Ubuntu, and Fedora that are less 
 
 Most continuous integration environments are already running inside a VM, and may not supported nested virtualization. The `none` driver was designed for this use case. Here is an example, that runs minikube from a non-root user, and ensures that the latest stable kubectl is installed:
 
-```
+```shell
 curl -Lo minikube \
   https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 \
   && sudo install minikube /usr/local/bin/


### PR DESCRIPTION
See https://github.com/DavidAnson/markdownlint

``` console
$ sudo npm install -g markdownlint-cli
```

I removed the line-length warning about 80 characters,
since some of our text files (markdown) didn't even try.

`make mdlint`