### PR TITLE
Address the low-hanging fruit on report card

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,6 +227,12 @@ gendocs: out/docs/minikube.md
 fmt:
 	@gofmt -l -s -w $(SOURCE_DIRS)
 
+.PHONY: reportcard
+reportcard:
+	goreportcard-cli -v
+	# "disabling misspell on large repo..."
+	-misspell -error $(SOURCE_DIRS)
+
 out/docs/minikube.md: $(shell find cmd) $(shell find pkg/minikube/constants) pkg/minikube/assets/assets.go
 	cd $(GOPATH)/src/$(REPOPATH) && go run -ldflags="$(MINIKUBE_LDFLAGS)" hack/gen_help_text.go
 

--- a/cmd/drivers/hyperkit/main.go
+++ b/cmd/drivers/hyperkit/main.go
@@ -1,3 +1,5 @@
+// +build darwin
+
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.
 

--- a/cmd/minikube/cmd/env.go
+++ b/cmd/minikube/cmd/env.go
@@ -328,6 +328,9 @@ var dockerEnvCmd = &cobra.Command{
 			exit.WithCode(exit.Unavailable, `The docker host is currently not running`)
 		}
 		docker, err := GetDockerActive(host)
+		if err != nil {
+			exit.WithError("Error getting service status", err)
+		}
 		if !docker {
 			exit.WithCode(exit.Unavailable, `The docker service is currently not active`)
 		}

--- a/pkg/gvisor/enable.go
+++ b/pkg/gvisor/enable.go
@@ -117,7 +117,7 @@ func runsc() error {
 	return downloadFileToDest(constants.GvisorURL, dest)
 }
 
-// downloadFileToDest downlaods the given file to the dest
+// downloadFileToDest downloads the given file to the dest
 // if something already exists at dest, first remove it
 func downloadFileToDest(url, dest string) error {
 	client := &http.Client{}

--- a/pkg/minikube/console/style.go
+++ b/pkg/minikube/console/style.go
@@ -93,7 +93,7 @@ var styles = map[string]style{
 	"verifying-noline":  {Prefix: "🤔  ", OmitNewline: true},
 	"kubectl":           {Prefix: "💗  ", LowPrefix: "+   "},
 	"meh":               {Prefix: "🙄  ", LowPrefix: "?   "},
-	"embarassed":        {Prefix: "🤦  ", LowPrefix: "*   "},
+	"embarrassed":       {Prefix: "🤦  ", LowPrefix: "*   "},
 	"tip":               {Prefix: "💡  ", LowPrefix: "i   "},
 }
 

--- a/pkg/minikube/tunnel/registry.go
+++ b/pkg/minikube/tunnel/registry.go
@@ -70,7 +70,7 @@ func (r *persistentRegistry) IsAlreadyDefinedAndRunning(tunnel *ID) (*ID, error)
 	return nil, nil
 }
 
-func (r *persistentRegistry) Register(tunnel *ID) error {
+func (r *persistentRegistry) Register(tunnel *ID) (rerr error) {
 	glog.V(3).Infof("registering tunnel: %s", tunnel)
 	if tunnel.Route == nil {
 		return errors.New("tunnel.Route should not be nil")
@@ -121,7 +121,7 @@ func (r *persistentRegistry) Register(tunnel *ID) error {
 	defer func() {
 		err := f.Close()
 		if err != nil {
-			fmt.Errorf("error closing registry file: %s", err)
+			rerr = fmt.Errorf("error closing registry file: %s", err)
 		}
 	}()
 
@@ -133,7 +133,7 @@ func (r *persistentRegistry) Register(tunnel *ID) error {
 	return nil
 }
 
-func (r *persistentRegistry) Remove(route *Route) error {
+func (r *persistentRegistry) Remove(route *Route) (rerr error) {
 	glog.V(3).Infof("removing tunnel from registry: %s", route)
 	tunnels, err := r.List()
 	if err != nil {
@@ -158,7 +158,7 @@ func (r *persistentRegistry) Remove(route *Route) error {
 	defer func() {
 		err := f.Close()
 		if err != nil {
-			fmt.Errorf("error closing tunnel registry file: %s", err)
+			rerr = fmt.Errorf("error closing tunnel registry file: %s", err)
 		}
 	}()
 

--- a/pkg/storage/storage_provisioner.go
+++ b/pkg/storage/storage_provisioner.go
@@ -99,7 +99,7 @@ func (p *hostPathProvisioner) Delete(volume *v1.PersistentVolume) error {
 		return errors.New("identity annotation not found on PV")
 	}
 	if ann != string(p.identity) {
-		return &controller.IgnoredError{"identity annotation on PV does not match ours"}
+		return &controller.IgnoredError{Reason: "identity annotation on PV does not match ours"}
 	}
 
 	path := path.Join(p.pvDir, volume.Name)

--- a/third_party/go9p/srv_conn.go
+++ b/third_party/go9p/srv_conn.go
@@ -210,8 +210,6 @@ func (conn *Conn) send() {
 			}
 		}
 	}
-
-	panic("unreached")
 }
 
 func (conn *Conn) RemoteAddr() net.Addr {
@@ -259,5 +257,4 @@ func (srv *Srv) StartListener(l net.Listener) error {
 
 		srv.NewConn(c)
 	}
-	return nil
 }

--- a/third_party/go9p/ufs_linux.go
+++ b/third_party/go9p/ufs_linux.go
@@ -19,14 +19,12 @@ func atime(stat *syscall.Stat_t) time.Time {
 func isBlock(d os.FileInfo) bool {
 	stat := d.Sys().(*syscall.Stat_t)
 	return (stat.Mode & syscall.S_IFMT) == syscall.S_IFBLK
-	return true
 }
 
 // IsChar reports if the file is a character device
 func isChar(d os.FileInfo) bool {
 	stat := d.Sys().(*syscall.Stat_t)
 	return (stat.Mode & syscall.S_IFMT) == syscall.S_IFCHR
-	return true
 }
 
 func dir2Qid(d os.FileInfo) *Qid {
@@ -42,11 +40,11 @@ func dir2Qid(d os.FileInfo) *Qid {
 func dir2Dir(path string, d os.FileInfo, dotu bool, upool Users) (*Dir, error) {
 	if r := recover(); r != nil {
 		fmt.Print("stat failed: ", r)
-		return nil, &os.PathError{"dir2Dir", path, nil}
+		return nil, &os.PathError{Op: "dir2Dir", Path: path, Err: nil}
 	}
 	sysif := d.Sys()
 	if sysif == nil {
-		return nil, &os.PathError{"dir2Dir: sysif is nil", path, nil}
+		return nil, &os.PathError{Op: "dir2Dir: sysif is nil", Path: path, Err: nil}
 	}
 	sysMode := sysif.(*syscall.Stat_t)
 


### PR DESCRIPTION
Should fix the 99% on https://goreportcard.com/report/github.com/kubernetes/minikube:

```
minikube/pkg/minikube/tunnel/registry.go
Line 124: error: result of fmt.Errorf call not used (vet)
Line 161: error: result of fmt.Errorf call not used (vet)

minikube/cmd/minikube/cmd/env.go
Line 330: warning: ineffectual assignment to err (ineffassign)

minikube/pkg/gvisor/enable.go
Line 120: warning: "downlaods" is a misspelling of "downloads" (misspell)
minikube/pkg/minikube/console/style.go
Line 96: warning: "embarassed" is a misspelling of "embarrassed" (misspell)
```

The "gocyclo" complexitiies are left to do, as is "golint" (which even got a separate #3839).

* https://github.com/fzipp/gocyclo