### PR TITLE
logs: Add kube-proxy, dmesg, uptime, uname + newlines between log sources

### DIFF
--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -40,6 +40,7 @@ var importantPods = []string{
 	"kube-apiserver",
 	"coredns",
 	"kube-scheduler",
+	"kube-proxy",
 }
 
 // lookbackwardsCount is how far back to look in a log for problems. This should be large enough to
@@ -105,6 +106,10 @@ func OutputProblems(problems map[string][]string, maxLines int) {
 // Output displays logs from multiple sources in tail(1) format
 func Output(r cruntime.Manager, bs bootstrapper.Bootstrapper, runner bootstrapper.CommandRunner, lines int) error {
 	cmds := logCommands(r, bs, lines, false)
+
+	// These are not technically logs, but are useful to have in bug reports.
+	cmds["kernel"] = "uptime && uname -a"
+
 	names := []string{}
 	for k := range cmds {
 		names = append(names, k)
@@ -112,7 +117,10 @@ func Output(r cruntime.Manager, bs bootstrapper.Bootstrapper, runner bootstrappe
 	sort.Strings(names)
 
 	failed := []string{}
-	for _, name := range names {
+	for i, name := range names {
+		if i > 0 {
+			console.OutLn("")
+		}
 		console.OutLn("==> %s <==", name)
 		var b bytes.Buffer
 		err := runner.CombinedOutputTo(cmds[name], &b)


### PR DESCRIPTION
These are log sources that I would have found useful for debugging recently submitted issues. 