### PR TITLE
fix CHANGE_MINIKUBE_NONE_USER regression from recent changes

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -208,6 +208,11 @@ func runStart(cmd *cobra.Command, args []string) {
 		console.Failure("Unable to load cached images from config file.")
 	}
 
+	if config.MachineConfig.VMDriver == constants.DriverNone {
+		console.OutStyle("starting-none", "Configuring local host environment ...")
+		prepareNone()
+	}
+
 	if kubeconfig.KeepContext {
 		console.OutStyle("kubectl", "To connect to this cluster, use: kubectl --context=%s", kubeconfig.ClusterName)
 	} else {
@@ -341,10 +346,6 @@ func startHost(api libmachine.API, mc cfg.MachineConfig) (*host.Host, bool) {
 	exists, err := api.Exists(cfg.GetMachineName())
 	if err != nil {
 		exit.WithError("Failed to check if machine exists", err)
-	}
-	if mc.VMDriver == constants.DriverNone {
-		console.OutStyle("starting-none", "Configuring local host environment ...")
-		prepareNone()
 	}
 
 	var host *host.Host


### PR DESCRIPTION
6c480485386d546bbb714517e2061298c5e30485 changed the order of the startup script so that now the CHANGE_MINIKUBE_NONE_USER `chown` doesn't actually kick in after the files are added. I didn't re-add it exactly where it was before (right before `bootstrapCluster`), but after the provisioning is complete.

I believe #3751 is this issue, as well.