### PR TITLE
--extra-config now work for kubeadm as well

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -135,7 +135,7 @@ func init() {
 	startCmd.Flags().Var(&extraOptions, "extra-config",
 		`A set of key=value pairs that describe configuration that may be passed to different components.
 		The key should be '.' separated, and the first part before the dot is the component to apply the configuration to.
-		Valid components are: kubelet, apiserver, controller-manager, etcd, proxy, scheduler.`)
+		Valid components are: kubelet, kubeadm, apiserver, controller-manager, etcd, proxy, scheduler.`)
 	startCmd.Flags().String(uuid, "", "Provide VM UUID to restore MAC address (only supported with Hyperkit driver).")
 	startCmd.Flags().String(vpnkitSock, "", "Location of the VPNKit socket used for networking. If empty, disables Hyperkit VPNKitSock, if 'auto' uses Docker for Mac VPNKit connection, otherwise uses the specified VSock.")
 	startCmd.Flags().StringSlice(vsockPorts, []string{}, "List of guest VSock ports that should be exposed as sockets on the host (Only supported on with hyperkit now).")

--- a/docs/configuring_kubernetes.md
+++ b/docs/configuring_kubernetes.md
@@ -9,6 +9,7 @@ This flag is repeated, so you can pass it several times with several different v
 
 The kubeadm bootstrapper can be configured by the `--extra-config` flag on the `minikube start` command.  It takes a string of the form `component.key=value` where `component` is one of the strings
 
+* kubeadm
 * kubelet
 * apiserver
 * controller-manager
@@ -18,4 +19,6 @@ and `key=value` is a flag=value pair for the component being configured.  For ex
 
 ```shell
 minikube start --extra-config=apiserver.v=10 --extra-config=kubelet.max-pods=100
+
+minikube start --extra-config=kubeadm.ignore-preflight-errors=SystemVerification # allows any version of docker
 ```

--- a/docs/vmdriver-none.md
+++ b/docs/vmdriver-none.md
@@ -23,7 +23,7 @@ kv=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.tx
 curl -Lo kubectl \
   https://storage.googleapis.com/kubernetes-release/release/$kv/bin/linux/amd64/kubectl \
   && sudo install kubectl /usr/local/bin/
-  
+
 export MINIKUBE_WANTUPDATENOTIFICATION=false
 export MINIKUBE_WANTREPORTERRORPROMPT=false
 export MINIKUBE_HOME=$HOME
@@ -100,4 +100,5 @@ Some environment variables may be useful for using the `none` driver:
 * Many `minikube` commands are not supported, such as: `dashboard`, `mount`, `ssh`
 * minikube with the `none` driver has a confusing permissions model, as some commands need to be run as root ("start"), and others by a regular user ("dashboard")
 * CoreDNS detects resolver loop, goes into CrashloopBackoff - [#3511](https://github.com/kubernetes/minikube/issues/3511)
+* Some versions of Linux have a version of docker that is newer then what Kubernetes expects. To overwrite this, run minikube with the following parameters: `sudo -E minikube start --vm-driver=none --kubernetes-version v1.11.8 --extra-config kubeadm.ignore-preflight-errors=SystemVerification`
 * [Full list of open 'none' driver issues](https://github.com/kubernetes/minikube/labels/co%2Fnone-driver)

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm_test.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm_test.go
@@ -237,6 +237,8 @@ apiServerExtraArgs:
   feature-gates: "HugePages=true,OtherFeature=false"
 controllerManagerExtraArgs:
   feature-gates: "HugePages=true,OtherFeature=false"
+kubeadmExtraArgs:
+  feature-gates: "HugePages=true,OtherFeature=false"
 schedulerExtraArgs:
   feature-gates: "HugePages=true,OtherFeature=false"
 `,
@@ -275,6 +277,8 @@ apiServerExtraArgs:
   fail-no-swap: "true"
   feature-gates: "HugePages=true,OtherFeature=false"
 controllerManagerExtraArgs:
+  feature-gates: "HugePages=true,OtherFeature=false"
+kubeadmExtraArgs:
   feature-gates: "HugePages=true,OtherFeature=false"
 schedulerExtraArgs:
   feature-gates: "HugePages=true,OtherFeature=false"

--- a/pkg/minikube/bootstrapper/kubeadm/templates.go
+++ b/pkg/minikube/bootstrapper/kubeadm/templates.go
@@ -171,7 +171,7 @@ WantedBy=multi-user.target
 `
 
 var kubeadmInitTemplate = template.Must(template.New("kubeadmInitTemplate").Parse(`
-sudo /usr/bin/kubeadm init --config {{.KubeadmConfigFile}} {{if .SkipPreflightChecks}}--skip-preflight-checks{{else}}{{range .Preflights}}--ignore-preflight-errors={{.}} {{end}}{{end}}
+sudo /usr/bin/kubeadm init --config {{.KubeadmConfigFile}} {{.ExtraOptions}} {{if .SkipPreflightChecks}}--skip-preflight-checks{{else}}{{range .Preflights}}--ignore-preflight-errors={{.}} {{end}}{{end}}
 `))
 
 // printMapInOrder sorts the keys and prints the map in order, combining key

--- a/pkg/minikube/bootstrapper/kubeadm/versions.go
+++ b/pkg/minikube/bootstrapper/kubeadm/versions.go
@@ -35,6 +35,7 @@ import (
 // through the "extra-config"
 const (
 	Kubelet           = "kubelet"
+	Kubeadm           = "kubeadm"
 	Apiserver         = "apiserver"
 	Scheduler         = "scheduler"
 	ControllerManager = "controller-manager"
@@ -70,6 +71,7 @@ var componentToKubeadmConfigKey = map[string]string{
 	Apiserver:         "apiServer",
 	ControllerManager: "controllerManager",
 	Scheduler:         "scheduler",
+	Kubeadm:           "kubeadm",
 	// The Kubelet is not configured in kubeadm, only in systemd.
 	Kubelet: "",
 }

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -34,6 +34,7 @@ func TestStartStop(t *testing.T) {
 		args []string
 	}{
 		{"docker+cache", []string{"--container-runtime=docker", "--cache-images"}},
+		{"docker+cache+ignore_verifications", []string{"--container-runtime=docker", "--cache-images", "--extra-config", "kubeadm.ignore-preflight-errors=SystemVerification"}},
 		{"containerd+cache", []string{"--container-runtime=containerd", "--docker-opt containerd=/var/run/containerd/containerd.sock", "--cache-images"}},
 		{"crio+cache", []string{"--container-runtime=crio", "--cache-images"}},
 	}


### PR DESCRIPTION
This small patch allows us to use `--extra-config` also with `kubeadm`.

My primary motivation is to run `minikube` with the `none` vm driver in any version of docker.

This patch allows one to do so like this: `sudo -E minikube start --vm-driver=none --kubernetes-version v1.11.8 --extra-config kubeadm.ignore-preflight-errors=SystemVerification `