### PR TITLE
Allow building minikube for any architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ out/minikube.d: pkg/minikube/assets/assets.go
 	$(MAKEDEPEND) out/minikube-$(GOOS)-$(GOARCH) $(ORG) $^ $(MINIKUBEFILES) > $@
 
 -include out/minikube.d
-out/minikube-%-$(GOARCH): pkg/minikube/assets/assets.go
+out/minikube-%: pkg/minikube/assets/assets.go
 ifeq ($(MINIKUBE_BUILD_IN_DOCKER),y)
 	$(call DOCKER,$(BUILD_IMAGE),/usr/bin/make $@)
 else
@@ -114,7 +114,7 @@ ifneq ($(GOPATH)/src/$(REPOPATH),$(CURDIR))
 	$(warning https://github.com/kubernetes/minikube/blob/master/docs/contributors/build_guide.md)
 	$(warning ******************************************************************************)
 endif
-	GOOS=$* GOARCH=$(GOARCH) go build -tags "$(MINIKUBE_BUILD_TAGS)" -ldflags="$(MINIKUBE_LDFLAGS)" -a -o $@ k8s.io/minikube/cmd/minikube
+	GOOS="$(firstword $(subst -, ,$*))" GOARCH="$(lastword $(subst -, ,$*))" go build -tags "$(MINIKUBE_BUILD_TAGS)" -ldflags="$(MINIKUBE_LDFLAGS)" -a -o $@ k8s.io/minikube/cmd/minikube
 endif
 
 .PHONY: e2e-%-amd64


### PR DESCRIPTION
Currently it is hardcoded to build for any GOOS, but same GOARCH.

Change this to allow building for any combination of: `minikube-*-*`

Example:
```
out/minikube-linux-arm:   ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, not stripped
out/minikube-linux-arm64: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, not stripped
```
