### PR TITLE
Windows installer using installation path for x64 applications

### DIFF
--- a/installers/windows/minikube.nsi
+++ b/installers/windows/minikube.nsi
@@ -25,7 +25,7 @@
 
 RequestExecutionLevel admin ;Require admin rights on NT6+ (When UAC is turned on)
 
-InstallDir "$PROGRAMFILES\${COMPANYNAME}\${APPNAME}"
+InstallDir "$PROGRAMFILES64\${COMPANYNAME}\${APPNAME}"
 !define UNINSTALLDIR "Software\Microsoft\Windows\CurrentVersion\Uninstall\${COMPANYNAME} ${APPNAME}"
 BrandingText " "
 


### PR DESCRIPTION
minikube is a 64-bit application and should be installed in the x64 applications folder `C:\Program Files\` instead of `C:\Program Files (x86)\`
Fixes #2670 