### PR TITLE
Replace server name in updateKubeConfig if --apiserver-name exists #3878

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -443,6 +443,9 @@ func updateKubeConfig(h *host.Host, c *cfg.Config) *kubeconfig.KubeConfigSetup {
 	}
 	addr = strings.Replace(addr, "tcp://", "https://", -1)
 	addr = strings.Replace(addr, ":2376", ":"+strconv.Itoa(c.KubernetesConfig.NodePort), -1)
+	if c.KubernetesConfig.APIServerName != constants.APIServerName {
+		addr = strings.Replace(addr, c.KubernetesConfig.NodeIP, c.KubernetesConfig.APIServerName, -1)
+	}
 
 	kcs := &kubeconfig.KubeConfigSetup{
 		ClusterName:          cfg.GetMachineName(),


### PR DESCRIPTION
fix #3878 
Please merge it, if it looks good for you.