### PR TITLE
Update link to drives docs in xhyve driver

### DIFF
--- a/pkg/minikube/drivers/xhyve/driver.go
+++ b/pkg/minikube/drivers/xhyve/driver.go
@@ -30,7 +30,7 @@ import (
 
 const errMsg = `
 The Xhyve driver is not included in minikube yet.  Please follow the directions at
-https://github.com/kubernetes/minikube/blob/master/DRIVERS.md#xhyve-driver
+https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#xhyve-driver
 `
 
 func init() {


### PR DESCRIPTION
Update link to drives docs in xhyve driver

Other drivers are already fixed, see [KVM](https://github.com/kubernetes/minikube/blob/master/pkg/drivers/kvm/domain.go#L104)