### PR TITLE
Add solution catalog to help users who run into known problems

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -525,14 +525,14 @@ func bootstrapCluster(bs bootstrapper.Bootstrapper, r cruntime.Manager, runner b
 	if preexisting {
 		console.OutStyle("restarting", "Relaunching Kubernetes %s using %s ... ", kc.KubernetesVersion, bsName)
 		if err := bs.RestartCluster(kc); err != nil {
-			exit.WithProblems("Error restarting cluster", err, logs.FindProblems(r, bs, runner))
+			exit.WithLogEntries("Error restarting cluster", err, logs.FindProblems(r, bs, runner))
 		}
 		return
 	}
 
 	console.OutStyle("launch", "Launching Kubernetes %s using %s ... ", kc.KubernetesVersion, bsName)
 	if err := bs.StartCluster(kc); err != nil {
-		exit.WithProblems("Error starting cluster", err, logs.FindProblems(r, bs, runner))
+		exit.WithLogEntries("Error starting cluster", err, logs.FindProblems(r, bs, runner))
 	}
 }
 
@@ -549,7 +549,7 @@ func validateCluster(bs bootstrapper.Bootstrapper, r cruntime.Manager, runner bo
 	}
 	err := pkgutil.RetryAfter(20, k8sStat, 3*time.Second)
 	if err != nil {
-		exit.WithProblems("kubelet checks failed", err, logs.FindProblems(r, bs, runner))
+		exit.WithLogEntries("kubelet checks failed", err, logs.FindProblems(r, bs, runner))
 	}
 	aStat := func() (err error) {
 		st, err := bs.GetAPIServerStatus(net.ParseIP(ip))
@@ -562,7 +562,7 @@ func validateCluster(bs bootstrapper.Bootstrapper, r cruntime.Manager, runner bo
 
 	err = pkgutil.RetryAfter(30, aStat, 10*time.Second)
 	if err != nil {
-		exit.WithProblems("apiserver checks failed", err, logs.FindProblems(r, bs, runner))
+		exit.WithLogEntries("apiserver checks failed", err, logs.FindProblems(r, bs, runner))
 	}
 	console.OutLn("")
 }

--- a/pkg/minikube/console/style.go
+++ b/pkg/minikube/console/style.go
@@ -66,8 +66,9 @@ var styles = map[string]style{
 	"log-entry":     {Prefix: "    "},   // Indent
 	"crushed":       {Prefix: "💔  "},
 	"url":           {Prefix: "👉  "},
-	"solution":      {Prefix: "> "},
-	"related-issue": {Prefix: "  - "},
+	"documentation": {Prefix: "🗎   "},
+	"issues":        {Prefix: "📚  "},
+	"issue":         {Prefix: "    ▪ "}, // Indented bullet
 
 	// Specialized purpose styles
 	"iso-download":      {Prefix: "💿  ", LowPrefix: "@   "},

--- a/pkg/minikube/console/style.go
+++ b/pkg/minikube/console/style.go
@@ -66,6 +66,8 @@ var styles = map[string]style{
 	"log-entry":     {Prefix: "    "},   // Indent
 	"crushed":       {Prefix: "💔  "},
 	"url":           {Prefix: "👉  "},
+	"solution":      {Prefix: "> "},
+	"related-issue": {Prefix: "  - "},
 
 	// Specialized purpose styles
 	"iso-download":      {Prefix: "💿  ", LowPrefix: "@   "},

--- a/pkg/minikube/exit/exit.go
+++ b/pkg/minikube/exit/exit.go
@@ -20,11 +20,10 @@ package exit
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"k8s.io/minikube/pkg/minikube/console"
+	"k8s.io/minikube/pkg/minikube/problem"
 )
 
 // Exit codes based on sysexits(3)
@@ -40,8 +39,8 @@ const (
 	Config      = 78 // Config represents an unconfigured or misconfigured state
 	Permissions = 77 // Permissions represents a permissions error
 
-	// MaxProblems controls the number of problems to show for each source
-	MaxProblems = 3
+	// MaxLogEntries controls the number of log entries to show for each source
+	MaxLogEntries = 3
 )
 
 // Usage outputs a usage error and exits with error code 64
@@ -67,14 +66,14 @@ func WithError(msg string, err error) {
 	os.Exit(Software)
 }
 
-// WithProblems outputs an error along with any autodetected problems, and exits.
-func WithProblems(msg string, err error, problems map[string][]string) {
+// WithLogEntries outputs an error along with any important log entries, and exits.
+func WithLogEntries(msg string, err error, entries map[string][]string) {
 	displayError(msg, err)
 
-	for name, lines := range problems {
+	for name, lines := range entries {
 		console.OutStyle("failure", "Problems detected in %q:", name)
-		if len(lines) > MaxProblems {
-			lines = lines[:MaxProblems]
+		if len(lines) > MaxLogEntries {
+			lines = lines[:MaxLogEntries]
 		}
 		for _, l := range lines {
 			console.OutStyle("log-entry", l)
@@ -86,17 +85,22 @@ func WithProblems(msg string, err error, problems map[string][]string) {
 func displayError(msg string, err error) {
 	// use Warning because Error will display a duplicate message to stderr
 	glog.Warningf(fmt.Sprintf("%s: %v", msg, err))
+	p := problem.FromError(err)
+
+	if p != nil {
+		console.Err("\n")
+		console.Fatal(msg)
+		p.Display()
+		console.Err("\n")
+		console.ErrStyle("sad", "If the solution does not help, please let us know:")
+		console.ErrStyle("url", "https://github.com/kubernetes/minikube/issues/new")
+		return
+	}
+
+	console.Err("\n")
 	console.Fatal(msg+": %v", err)
 	console.Err("\n")
-	// unfortunately Cause only supports one level of actual error wrapping
-	cause := errors.Cause(err)
-	text := cause.Error()
-	if strings.Contains(text, "VBoxManage not found. Make sure VirtualBox is installed and VBoxManage is in the path") ||
-		strings.Contains(text, "Driver \"kvm2\" not found. Do you have the plugin binary \"docker-machine-driver-kvm2\" accessible in your PATH?") {
-		console.ErrStyle("usage", "Make sure to install all necessary requirements, according to the documentation:")
-		console.ErrStyle("url", "https://kubernetes.io/docs/tasks/tools/install-minikube/")
-	} else {
-		console.ErrStyle("sad", "Sorry that minikube crashed. If this was unexpected, we would love to hear from you:")
-		console.ErrStyle("url", "https://github.com/kubernetes/minikube/issues/new")
-	}
+	console.ErrStyle("sad", "Sorry that minikube crashed. If this was unexpected, we would love to hear from you:")
+	console.ErrStyle("url", "https://github.com/kubernetes/minikube/issues/new")
+
 }

--- a/pkg/minikube/exit/exit.go
+++ b/pkg/minikube/exit/exit.go
@@ -92,7 +92,7 @@ func displayError(msg string, err error) {
 		console.Fatal(msg)
 		p.Display()
 		console.Err("\n")
-		console.ErrStyle("sad", "If the solution does not help, please let us know:")
+		console.ErrStyle("sad", "If the advice does not help, please let us know: ")
 		console.ErrStyle("url", "https://github.com/kubernetes/minikube/issues/new")
 		return
 	}

--- a/pkg/minikube/exit/exit.go
+++ b/pkg/minikube/exit/exit.go
@@ -59,11 +59,23 @@ func WithCode(code int, format string, a ...interface{}) {
 
 // WithError outputs an error and exits.
 func WithError(msg string, err error) {
+	p := problem.FromError(err)
+	if p != nil {
+		WithProblem(msg, p)
+	}
 	displayError(msg, err)
-	// Here is where we would insert code to optionally upload a stack trace.
-
-	// We can be smarter about guessing exit codes, but EX_SOFTWARE should suffice.
 	os.Exit(Software)
+}
+
+// WithProblem outputs info related to a known problem and exits.
+func WithProblem(msg string, p *problem.Problem) {
+	console.Err("\n")
+	console.Fatal(msg)
+	p.Display()
+	console.Err("\n")
+	console.ErrStyle("sad", "If the advice does not help, please let us know: ")
+	console.ErrStyle("url", "https://github.com/kubernetes/minikube/issues/new")
+	os.Exit(Config)
 }
 
 // WithLogEntries outputs an error along with any important log entries, and exits.
@@ -85,22 +97,9 @@ func WithLogEntries(msg string, err error, entries map[string][]string) {
 func displayError(msg string, err error) {
 	// use Warning because Error will display a duplicate message to stderr
 	glog.Warningf(fmt.Sprintf("%s: %v", msg, err))
-	p := problem.FromError(err)
-
-	if p != nil {
-		console.Err("\n")
-		console.Fatal(msg)
-		p.Display()
-		console.Err("\n")
-		console.ErrStyle("sad", "If the advice does not help, please let us know: ")
-		console.ErrStyle("url", "https://github.com/kubernetes/minikube/issues/new")
-		return
-	}
-
 	console.Err("\n")
 	console.Fatal(msg+": %v", err)
 	console.Err("\n")
 	console.ErrStyle("sad", "Sorry that minikube crashed. If this was unexpected, we would love to hear from you:")
 	console.ErrStyle("url", "https://github.com/kubernetes/minikube/issues/new")
-
 }

--- a/pkg/minikube/problem/err_map.go
+++ b/pkg/minikube/problem/err_map.go
@@ -9,33 +9,33 @@ func r(s string) *regexp.Regexp {
 
 // vmProblems are VM related problems
 var vmProblems = map[string]match{
-	"VBOX_NOT_FOUND": match{
+	"VBOX_NOT_FOUND": {
 		Regexp:   r(`VBoxManage not found. Make sure VirtualBox is installed and VBoxManage is in the path`),
 		Solution: "Install VirtualBox, ensure that VBoxManage is executable and in path, or select an alternative value for --vm-driver",
 		URL:      "https://www.virtualbox.org/wiki/Downloads",
 		Issues:   []int{3784, 3776},
 	},
-	"VBOX_VTX_DISABLED": match{
+	"VBOX_VTX_DISABLED": {
 		Regexp:   r(`This computer doesn't have VT-X/AMD-v enabled`),
 		Solution: "In some environments, this message is incorrect. Try 'minikube start --no-vtx-check'",
 		Issues:   []int{3900},
 	},
-	"KVM2_NOT_FOUND": match{
+	"KVM2_NOT_FOUND": {
 		Regexp:   r(`Driver "kvm2" not found. Do you have the plugin binary .* accessible in your PATH`),
 		Solution: "Please install the minikube kvm2 VM driver, or select an alternative --vm-driver",
 		URL:      "https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm2-driver",
 	},
-	"KVM2_NO_IP": match{
+	"KVM2_NO_IP": {
 		Regexp:   r(`Error starting stopped host: Machine didn't return an IP after 120 seconds`),
 		Solution: "The KVM driver is unable to ressurect this old VM. Please run `minikube delete` to delete it and try again.",
 		Issues:   []int{3901, 3566, 3434},
 	},
-	"VM_DOES_NOT_EXIST": match{
+	"VM_DOES_NOT_EXIST": {
 		Regexp:   r(`Error getting state for host: machine does not exist`),
 		Solution: "Your system no longer knows about the VM previously created by minikube. Run 'minikube delete' to reset your local state.",
 		Issues:   []int{3864},
 	},
-	"VM_IP_NOT_FOUND": match{
+	"VM_IP_NOT_FOUND": {
 		Regexp:   r(`Error getting ssh host name for driver: IP not found`),
 		Solution: "The minikube VM is offline. Please run 'minikube start' to start it again.",
 		Issues:   []int{3849, 3648},
@@ -47,48 +47,48 @@ const proxyDoc = "https://github.com/kubernetes/minikube/blob/master/docs/http_p
 
 // netProblems are network related problems.
 var netProblems = map[string]match{
-	"GCR_UNAVAILABLE": match{
+	"GCR_UNAVAILABLE": {
 		Regexp:   r(`gcr.io.*443: connect: invalid argument`),
 		Solution: "minikube is unable to access the Google Container Registry. You may need to configure it to use a HTTP proxy.",
 		URL:      proxyDoc,
 		Issues:   []int{3860},
 	},
-	"DOWNLOAD_RESET_BY_PEER": match{
+	"DOWNLOAD_RESET_BY_PEER": {
 		Regexp:   r(`Error downloading .*connection reset by peer`),
 		Solution: "A firewall is likely blocking minikube from reaching the internet. You may need to configure minikube to use a proxy.",
 		URL:      proxyDoc,
 		Issues:   []int{3909},
 	},
-	"DOWNLOAD_IO_TIMEOUT": match{
+	"DOWNLOAD_IO_TIMEOUT": {
 		Regexp:   r(`Error downloading .*timeout`),
 		Solution: "A firewall is likely blocking minikube from reaching the internet. You may need to configure minikube to use a proxy.",
 		URL:      proxyDoc,
 		Issues:   []int{3846},
 	},
-	"DOWNLOAD_TLS_OVERSIZED": match{
+	"DOWNLOAD_TLS_OVERSIZED": {
 		Regexp:   r(`failed to download.*tls: oversized record received with length`),
 		Solution: "A firewall is interfering with minikube's ability to make outgoing HTTPS requests. You may need to configure minikube to use a proxy.",
 		URL:      proxyDoc,
 		Issues:   []int{3857, 3759},
 	},
-	"ISO_DOWNLOAD_FAILED": match{
+	"ISO_DOWNLOAD_FAILED": {
 		Regexp:   r(`iso: failed to download`),
 		Solution: "A firewall is likely blocking minikube from reaching the internet. You may need to configure minikube to use a proxy.",
 		URL:      proxyDoc,
 		Issues:   []int{3922},
 	},
-	"PULL_TIMEOUT_EXCEEDED": match{
+	"PULL_TIMEOUT_EXCEEDED": {
 		Regexp:   r(`failed to pull image k8s.gcr.io.*Client.Timeout exceeded while awaiting headers`),
 		Solution: "A firewall is blocking Docker within the minikube VM from reaching the internet. You may need to configure it to use a proxy.",
 		URL:      proxyDoc,
 		Issues:   []int{3898},
 	},
-	"SSH_AUTH_FAILURE": match{
+	"SSH_AUTH_FAILURE": {
 		Regexp:   r(`ssh: handshake failed: ssh: unable to authenticate.*, no supported methods remain`),
 		Solution: "Your host is failing to route packets to the minikube VM. If you have VPN software, try turning it off or configuring it so that it does not re-route traffic to the VM IP. If not, check your VM environment routing options.",
 		Issues:   []int{3930},
 	},
-	"SSH_TCP_FAILURE": match{
+	"SSH_TCP_FAILURE": {
 		Regexp:   r(`dial tcp .*:22: connectex: A connection attempt failed because the connected party did not properly respond`),
 		Solution: "Your host is failing to route packets to the minikube VM. If you have VPN software, try turning it off or configuring it so that it does not re-route traffic to the VM IP. If not, check your VM environment routing options.",
 		Issues:   []int{3388},

--- a/pkg/minikube/problem/err_map.go
+++ b/pkg/minikube/problem/err_map.go
@@ -1,0 +1,92 @@
+package problem
+
+import "regexp"
+
+// r is a shortcut around regexp.MustCompile
+func r(s string) *regexp.Regexp {
+	return regexp.MustCompile(s)
+}
+
+// vmProblems are VM related problems
+var vmProblems = map[string]match{
+	"VBOX_NOT_FOUND": match{
+		Regexp:   r(`VBoxManage not found. Make sure VirtualBox is installed and VBoxManage is in the path`),
+		Solution: "Install VirtualBox, ensure that VBoxManage is executable and in path, or select an alternative value for --vm-driver",
+		URL:      "https://www.virtualbox.org/wiki/Downloads",
+		Issues:   []int{3784, 3776},
+	},
+	"VBOX_VTX_DISABLED": match{
+		Regexp:   r(`This computer doesn't have VT-X/AMD-v enabled`),
+		Solution: "In some environments, this message is incorrect. Try 'minikube start --no-vtx-check'",
+		Issues:   []int{3900},
+	},
+	"KVM2_NOT_FOUND": match{
+		Regexp:   r(`Driver "kvm2" not found. Do you have the plugin binary .* accessible in your PATH`),
+		Solution: "Please install the minikube kvm2 VM driver, or select an alternative --vm-driver",
+		URL:      "https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm2-driver",
+	},
+	"KVM2_NO_IP": match{
+		Regexp:   r(`Error starting stopped host: Machine didn't return an IP after 120 seconds`),
+		Solution: "The KVM driver is unable to ressurect this old VM. Please run `minikube delete` to delete it and try again.",
+		Issues:   []int{3901, 3566, 3434},
+	},
+	"VM_DOES_NOT_EXIST": match{
+		Regexp:   r(`Error getting state for host: machine does not exist`),
+		Solution: "Your system no longer knows about the VM previously created by minikube. Run 'minikube delete' to reset your local state.",
+		Issues:   []int{3864},
+	},
+	"VM_IP_NOT_FOUND": match{
+		Regexp:   r(`Error getting ssh host name for driver: IP not found`),
+		Solution: "The minikube VM is offline. Please run 'minikube start' to start it again.",
+		Issues:   []int{3849, 3648},
+	},
+}
+
+// proxyDoc is the URL to proxy documentation
+const proxyDoc = "https://github.com/kubernetes/minikube/blob/master/docs/http_proxy.md"
+
+// netProblems are network related problems.
+var netProblems = map[string]match{
+	"GCR_UNAVAILABLE": match{
+		Regexp:   r(`gcr.io.*443: connect: invalid argument`),
+		Solution: "minikube is unable to access the Google Container Registry. You may need to configure it to use a HTTP proxy.",
+		URL:      proxyDoc,
+		Issues:   []int{3860},
+	},
+	"DOWNLOAD_RESET_BY_PEER": match{
+		Regexp:   r(`Error downloading .*connection reset by peer`),
+		Solution: "A firewall is likely blocking minikube from reaching the internet. You may need to configure minikube to use a proxy.",
+		URL:      proxyDoc,
+		Issues:   []int{3909},
+	},
+	"DOWNLOAD_IO_TIMEOUT": match{
+		Regexp:   r(`Error downloading .*timeout`),
+		Solution: "A firewall is likely blocking minikube from reaching the internet. You may need to configure minikube to use a proxy.",
+		URL:      proxyDoc,
+		Issues:   []int{3846},
+	},
+	"DOWNLOAD_TLS_OVERSIZED": match{
+		Regexp:   r(`failed to download.*tls: oversized record received with length`),
+		Solution: "A firewall is interfering with minikube's ability to make outgoing HTTPS requests. You may need to configure minikube to use a proxy.",
+		URL:      proxyDoc,
+		Issues:   []int{3857, 3759},
+	},
+	"ISO_DOWNLOAD_FAILED": match{
+		Regexp:   r(`iso: failed to download`),
+		Solution: "A firewall is likely blocking minikube from reaching the internet. You may need to configure minikube to use a proxy.",
+		URL:      proxyDoc,
+		Issues:   []int{3922},
+	},
+	"PULL_TIMEOUT_EXCEEDED": match{
+		Regexp:   r(`failed to pull image k8s.gcr.io.*Client.Timeout exceeded while awaiting headers`),
+		Solution: "A firewall is blocking Docker within the minikube VM from reaching the internet. You may need to configure it to use a proxy.",
+		URL:      proxyDoc,
+		Issues:   []int{3898},
+	},
+}
+
+// deployProblems are Kubernetes deployment problems.
+var deployProblems = map[string]match{
+	// This space intentionally left empty.
+
+}

--- a/pkg/minikube/problem/err_map.go
+++ b/pkg/minikube/problem/err_map.go
@@ -2,43 +2,43 @@ package problem
 
 import "regexp"
 
-// r is a shortcut around regexp.MustCompile
-func r(s string) *regexp.Regexp {
+// re is a shortcut around regexp.MustCompile
+func re(s string) *regexp.Regexp {
 	return regexp.MustCompile(s)
 }
 
 // vmProblems are VM related problems
 var vmProblems = map[string]match{
 	"VBOX_NOT_FOUND": {
-		Regexp:   r(`VBoxManage not found. Make sure VirtualBox is installed and VBoxManage is in the path`),
-		Solution: "Install VirtualBox, ensure that VBoxManage is executable and in path, or select an alternative value for --vm-driver",
-		URL:      "https://www.virtualbox.org/wiki/Downloads",
-		Issues:   []int{3784, 3776},
+		Regexp: re(`VBoxManage not found. Make sure VirtualBox is installed and VBoxManage is in the path`),
+		Advice: "Install VirtualBox, ensure that VBoxManage is executable and in path, or select an alternative value for --vm-driver",
+		URL:    "https://www.virtualbox.org/wiki/Downloads",
+		Issues: []int{3784, 3776},
 	},
 	"VBOX_VTX_DISABLED": {
-		Regexp:   r(`This computer doesn't have VT-X/AMD-v enabled`),
-		Solution: "In some environments, this message is incorrect. Try 'minikube start --no-vtx-check'",
-		Issues:   []int{3900},
+		Regexp: re(`This computer doesn't have VT-X/AMD-v enabled`),
+		Advice: "In some environments, this message is incorrect. Try 'minikube start --no-vtx-check'",
+		Issues: []int{3900},
 	},
 	"KVM2_NOT_FOUND": {
-		Regexp:   r(`Driver "kvm2" not found. Do you have the plugin binary .* accessible in your PATH`),
-		Solution: "Please install the minikube kvm2 VM driver, or select an alternative --vm-driver",
-		URL:      "https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm2-driver",
+		Regexp: re(`Driver "kvm2" not found. Do you have the plugin binary .* accessible in your PATH`),
+		Advice: "Please install the minikube kvm2 VM driver, or select an alternative --vm-driver",
+		URL:    "https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm2-driver",
 	},
 	"KVM2_NO_IP": {
-		Regexp:   r(`Error starting stopped host: Machine didn't return an IP after 120 seconds`),
-		Solution: "The KVM driver is unable to ressurect this old VM. Please run `minikube delete` to delete it and try again.",
-		Issues:   []int{3901, 3566, 3434},
+		Regexp: re(`Error starting stopped host: Machine didn't return an IP after 120 seconds`),
+		Advice: "The KVM driver is unable to ressurect this old VM. Please run `minikube delete` to delete it and try again.",
+		Issues: []int{3901, 3566, 3434},
 	},
 	"VM_DOES_NOT_EXIST": {
-		Regexp:   r(`Error getting state for host: machine does not exist`),
-		Solution: "Your system no longer knows about the VM previously created by minikube. Run 'minikube delete' to reset your local state.",
-		Issues:   []int{3864},
+		Regexp: re(`Error getting state for host: machine does not exist`),
+		Advice: "Your system no longer knows about the VM previously created by minikube. Run 'minikube delete' to reset your local state.",
+		Issues: []int{3864},
 	},
 	"VM_IP_NOT_FOUND": {
-		Regexp:   r(`Error getting ssh host name for driver: IP not found`),
-		Solution: "The minikube VM is offline. Please run 'minikube start' to start it again.",
-		Issues:   []int{3849, 3648},
+		Regexp: re(`Error getting ssh host name for driver: IP not found`),
+		Advice: "The minikube VM is offline. Please run 'minikube start' to start it again.",
+		Issues: []int{3849, 3648},
 	},
 }
 
@@ -48,55 +48,75 @@ const proxyDoc = "https://github.com/kubernetes/minikube/blob/master/docs/http_p
 // netProblems are network related problems.
 var netProblems = map[string]match{
 	"GCR_UNAVAILABLE": {
-		Regexp:   r(`gcr.io.*443: connect: invalid argument`),
-		Solution: "minikube is unable to access the Google Container Registry. You may need to configure it to use a HTTP proxy.",
-		URL:      proxyDoc,
-		Issues:   []int{3860},
+		Regexp: re(`gcr.io.*443: connect: invalid argument`),
+		Advice: "minikube is unable to access the Google Container Registry. You may need to configure it to use a HTTP proxy.",
+		URL:    proxyDoc,
+		Issues: []int{3860},
 	},
 	"DOWNLOAD_RESET_BY_PEER": {
-		Regexp:   r(`Error downloading .*connection reset by peer`),
-		Solution: "A firewall is likely blocking minikube from reaching the internet. You may need to configure minikube to use a proxy.",
-		URL:      proxyDoc,
-		Issues:   []int{3909},
+		Regexp: re(`Error downloading .*connection reset by peer`),
+		Advice: "A firewall is likely blocking minikube from reaching the internet. You may need to configure minikube to use a proxy.",
+		URL:    proxyDoc,
+		Issues: []int{3909},
 	},
 	"DOWNLOAD_IO_TIMEOUT": {
-		Regexp:   r(`Error downloading .*timeout`),
-		Solution: "A firewall is likely blocking minikube from reaching the internet. You may need to configure minikube to use a proxy.",
-		URL:      proxyDoc,
-		Issues:   []int{3846},
+		Regexp: re(`Error downloading .*timeout`),
+		Advice: "A firewall is likely blocking minikube from reaching the internet. You may need to configure minikube to use a proxy.",
+		URL:    proxyDoc,
+		Issues: []int{3846},
 	},
 	"DOWNLOAD_TLS_OVERSIZED": {
-		Regexp:   r(`failed to download.*tls: oversized record received with length`),
-		Solution: "A firewall is interfering with minikube's ability to make outgoing HTTPS requests. You may need to configure minikube to use a proxy.",
-		URL:      proxyDoc,
-		Issues:   []int{3857, 3759},
+		Regexp: re(`failed to download.*tls: oversized record received with length`),
+		Advice: "A firewall is interfering with minikube's ability to make outgoing HTTPS requests. You may need to configure minikube to use a proxy.",
+		URL:    proxyDoc,
+		Issues: []int{3857, 3759},
 	},
 	"ISO_DOWNLOAD_FAILED": {
-		Regexp:   r(`iso: failed to download`),
-		Solution: "A firewall is likely blocking minikube from reaching the internet. You may need to configure minikube to use a proxy.",
-		URL:      proxyDoc,
-		Issues:   []int{3922},
+		Regexp: re(`iso: failed to download`),
+		Advice: "A firewall is likely blocking minikube from reaching the internet. You may need to configure minikube to use a proxy.",
+		URL:    proxyDoc,
+		Issues: []int{3922},
 	},
 	"PULL_TIMEOUT_EXCEEDED": {
-		Regexp:   r(`failed to pull image k8s.gcr.io.*Client.Timeout exceeded while awaiting headers`),
-		Solution: "A firewall is blocking Docker within the minikube VM from reaching the internet. You may need to configure it to use a proxy.",
-		URL:      proxyDoc,
-		Issues:   []int{3898},
+		Regexp: re(`failed to pull image k8s.gcr.io.*Client.Timeout exceeded while awaiting headers`),
+		Advice: "A firewall is blocking Docker within the minikube VM from reaching the internet. You may need to configure it to use a proxy.",
+		URL:    proxyDoc,
+		Issues: []int{3898},
 	},
 	"SSH_AUTH_FAILURE": {
-		Regexp:   r(`ssh: handshake failed: ssh: unable to authenticate.*, no supported methods remain`),
-		Solution: "Your host is failing to route packets to the minikube VM. If you have VPN software, try turning it off or configuring it so that it does not re-route traffic to the VM IP. If not, check your VM environment routing options.",
-		Issues:   []int{3930},
+		Regexp: re(`ssh: handshake failed: ssh: unable to authenticate.*, no supported methods remain`),
+		Advice: "Your host is failing to route packets to the minikube VM. If you have VPN software, try turning it off or configuring it so that it does not re-route traffic to the VM IP. If not, check your VM environment routing options.",
+		Issues: []int{3930},
 	},
 	"SSH_TCP_FAILURE": {
-		Regexp:   r(`dial tcp .*:22: connectex: A connection attempt failed because the connected party did not properly respond`),
-		Solution: "Your host is failing to route packets to the minikube VM. If you have VPN software, try turning it off or configuring it so that it does not re-route traffic to the VM IP. If not, check your VM environment routing options.",
-		Issues:   []int{3388},
+		Regexp: re(`dial tcp .*:22: connectex: A connection attempt failed because the connected party did not properly respond`),
+		Advice: "Your host is failing to route packets to the minikube VM. If you have VPN software, try turning it off or configuring it so that it does not re-route traffic to the VM IP. If not, check your VM environment routing options.",
+		Issues: []int{3388},
 	},
 }
 
 // deployProblems are Kubernetes deployment problems.
 var deployProblems = map[string]match{
-	// This space intentionally left empty.
+	"DOCKER_UNAVAILABLE": {
+		Regexp: re(`Error configuring auth on host: OS type not recognized`),
+		Advice: "Docker inside the VM is unavailable. Try running 'minikube delete' to reset the VM.",
+		Issues: []int{3952},
+	},
+	"INVALID_KUBERNETES_VERSION": {
+		Regexp: re(`No Major.Minor.Patch elements found`),
+		Advice: "Specify --kubernetes-version in v<major>.<minor.<build> form. example: 'v1.1.14'",
+	},
+	"KUBERNETES_VERSION_MISSING_V": {
+		Regexp: re(`strconv.ParseUint: parsing "": invalid syntax`),
+		Advice: "Check that your --kubernetes-version has a leading 'v'. For example: 'v1.1.14'",
+	},
+}
 
+// osProblems are operating-system specific issues
+var osProblems = map[string]match{
+	"NON_C_DRIVE": {
+		Regexp: re(`.iso: The system cannot find the path specified.`),
+		Advice: "Run minikube from the C: drive.",
+		Issues: []int{1574},
+	},
 }

--- a/pkg/minikube/problem/err_map.go
+++ b/pkg/minikube/problem/err_map.go
@@ -83,6 +83,16 @@ var netProblems = map[string]match{
 		URL:      proxyDoc,
 		Issues:   []int{3898},
 	},
+	"SSH_AUTH_FAILURE": match{
+		Regexp:   r(`ssh: handshake failed: ssh: unable to authenticate.*, no supported methods remain`),
+		Solution: "Your host is failing to route packets to the minikube VM. If you have VPN software, try turning it off or configuring it so that it does not re-route traffic to the VM IP. If not, check your VM environment routing options.",
+		Issues:   []int{3930},
+	},
+	"SSH_TCP_FAILURE": match{
+		Regexp:   r(`dial tcp .*:22: connectex: A connection attempt failed because the connected party did not properly respond`),
+		Solution: "Your host is failing to route packets to the minikube VM. If you have VPN software, try turning it off or configuring it so that it does not re-route traffic to the VM IP. If not, check your VM environment routing options.",
+		Issues:   []int{3388},
+	},
 }
 
 // deployProblems are Kubernetes deployment problems.

--- a/pkg/minikube/problem/err_map.go
+++ b/pkg/minikube/problem/err_map.go
@@ -109,6 +109,11 @@ var netProblems = map[string]match{
 		Advice: "Your host is failing to route packets to the minikube VM. If you have VPN software, try turning it off or configuring it so that it does not re-route traffic to the VM IP. If not, check your VM environment routing options.",
 		Issues: []int{3388},
 	},
+	"INVALID_PROXY_HOSTNAME": {
+		Regexp: re(`dial tcp: lookup.*: no such host`),
+		Advice: "Verify that your HTTP_PROXY and HTTPS_PROXY environment variables are set correctly.",
+		URL:    proxyDoc,
+	},
 }
 
 // deployProblems are Kubernetes deployment problems.

--- a/pkg/minikube/problem/err_map.go
+++ b/pkg/minikube/problem/err_map.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package problem
 
 import "regexp"

--- a/pkg/minikube/problem/problem.go
+++ b/pkg/minikube/problem/problem.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package problem helps deliver actionable feedback to a user based on an error message.
 package problem
 

--- a/pkg/minikube/problem/problem.go
+++ b/pkg/minikube/problem/problem.go
@@ -11,26 +11,29 @@ const issueBase = "https://github.com/kubernetes/minikube/issue"
 
 // Problem represents a known problem in minikube.
 type Problem struct {
-	ID       string
-	Err      error
-	Solution string
-	URL      string
-	Issues   []int
+	ID     string
+	Err    error
+	Advice string
+	URL    string
+	Issues []int
 }
 
 // match maps a regular expression to problem metadata.
 type match struct {
-	Regexp   *regexp.Regexp
-	Solution string
-	URL      string
-	Issues   []int
+	Regexp *regexp.Regexp
+	Advice string
+	URL    string
+	Issues []int
 }
 
 // Display problem metadata to the console
 func (p *Problem) Display() {
-	console.ErrStyle("solution", "Error:         [%s] %v", p.ID, p.Err)
-	console.ErrStyle("solution", "Solution:      %s", p.Solution)
-	console.ErrStyle("solution", "Documentation: %s", p.URL)
+	console.ErrStyle("failure", "Error:       [%s] %v", p.ID, p.Err)
+	console.ErrStyle("tip", "Advice:        %s", p.Advice)
+	console.ErrStyle("documentation", "Documentation: %s", p.URL)
+	console.ErrStyle("issues", "Related issues:")
+	//	if p.URL != "" {
+	//	}
 	if len(p.Issues) == 0 {
 		return
 	}
@@ -38,15 +41,15 @@ func (p *Problem) Display() {
 	if len(issues) > 3 {
 		issues = issues[0:3]
 	}
-	console.ErrStyle("solution", "Related issues:")
 	for _, i := range issues {
-		console.ErrStyle("related-issue", "%s/%d", issueBase, i)
+		console.ErrStyle("issue", "%s/%d", issueBase, i)
 	}
 }
 
 // FromError returns a known problem from an error.
 func FromError(err error) *Problem {
 	maps := []map[string]match{
+		osProblems,
 		vmProblems,
 		netProblems,
 		deployProblems,
@@ -55,11 +58,11 @@ func FromError(err error) *Problem {
 		for k, v := range m {
 			if v.Regexp.MatchString(err.Error()) {
 				return &Problem{
-					Err:      err,
-					Solution: v.Solution,
-					URL:      v.URL,
-					ID:       k,
-					Issues:   v.Issues,
+					Err:    err,
+					Advice: v.Advice,
+					URL:    v.URL,
+					ID:     k,
+					Issues: v.Issues,
 				}
 			}
 		}

--- a/pkg/minikube/problem/problem.go
+++ b/pkg/minikube/problem/problem.go
@@ -44,15 +44,15 @@ type match struct {
 
 // Display problem metadata to the console
 func (p *Problem) Display() {
-	console.ErrStyle("failure", "Error:       [%s] %v", p.ID, p.Err)
+	console.ErrStyle("failure", "Error:         [%s] %v", p.ID, p.Err)
 	console.ErrStyle("tip", "Advice:        %s", p.Advice)
-	console.ErrStyle("documentation", "Documentation: %s", p.URL)
-	console.ErrStyle("issues", "Related issues:")
-	//	if p.URL != "" {
-	//	}
+	if p.URL != "" {
+		console.ErrStyle("documentation", "Documentation: %s", p.URL)
+	}
 	if len(p.Issues) == 0 {
 		return
 	}
+	console.ErrStyle("issues", "Related issues:")
 	issues := p.Issues
 	if len(issues) > 3 {
 		issues = issues[0:3]

--- a/pkg/minikube/problem/problem.go
+++ b/pkg/minikube/problem/problem.go
@@ -1,0 +1,68 @@
+// Package problem helps deliver actionable feedback to a user based on an error message.
+package problem
+
+import (
+	"regexp"
+
+	"k8s.io/minikube/pkg/minikube/console"
+)
+
+const issueBase = "https://github.com/kubernetes/minikube/issue"
+
+// Problem represents a known problem in minikube.
+type Problem struct {
+	ID       string
+	Err      error
+	Solution string
+	URL      string
+	Issues   []int
+}
+
+// match maps a regular expression to problem metadata.
+type match struct {
+	Regexp   *regexp.Regexp
+	Solution string
+	URL      string
+	Issues   []int
+}
+
+// Display problem metadata to the console
+func (p *Problem) Display() {
+	console.ErrStyle("solution", "Error:         [%s] %v", p.ID, p.Err)
+	console.ErrStyle("solution", "Solution:      %s", p.Solution)
+	console.ErrStyle("solution", "Documentation: %s", p.URL)
+	if len(p.Issues) == 0 {
+		return
+	}
+	issues := p.Issues
+	if len(issues) > 3 {
+		issues = issues[0:3]
+	}
+	console.ErrStyle("solution", "Related issues:")
+	for _, i := range issues {
+		console.ErrStyle("related-issue", "%s/%d", issueBase, i)
+	}
+}
+
+// FromError returns a known problem from an error.
+func FromError(err error) *Problem {
+	maps := []map[string]match{
+		vmProblems,
+		netProblems,
+		deployProblems,
+	}
+	for _, m := range maps {
+		for k, v := range m {
+			if v.Regexp.MatchString(err.Error()) {
+				return &Problem{
+					Err:      err,
+					Solution: v.Solution,
+					URL:      v.URL,
+					ID:       k,
+					Issues:   v.Issues,
+				}
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This extracts the nascent problem detection code from exit.go, and formalizes it in into a package that we can use for the upcoming network preflights (#3145). 

Example output:

```
😄  minikube v0.35.0 on darwin (amd64)
🤹  Downloading Kubernetes v1.13.4 images in the background ...
🔥  Creating virtualbox VM (CPUs=2, Memory=2048MB, Disk=20000MB) ...

💣  Unable to start VM
> Error:         [VBOX_NOT_FOUND] create: precreate: VBoxManage not found. Make sure VirtualBox is installed and VBoxManage is in the path
> Solution:      Install VirtualBox, ensure that VBoxManage is executable and in path, or select an alternative value for --vm-driver
> Documentation: https://www.virtualbox.org/wiki/Downloads
> Related issues:
  - https://github.com/kubernetes/minikube/issue/3784
  - https://github.com/kubernetes/minikube/issue/3776

😿  If the solution does not help, please let us know:
👉  https://github.com/kubernetes/minikube/issues/new
```

This also renames exit.WithProblems to exit.WithLogEntries to avoid the terminology mismatch.