### PR TITLE
Clean up lint and other small report card issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ MINIKUBE_MARKDOWN_FILES := README.md docs CONTRIBUTING.md CHANGELOG.md
 MINIKUBE_BUILD_TAGS := container_image_ostree_stub containers_image_openpgp
 MINIKUBE_INTEGRATION_BUILD_TAGS := integration $(MINIKUBE_BUILD_TAGS)
 SOURCE_DIRS = cmd pkg test
+SOURCE_PACKAGES = ./cmd/... ./pkg/... ./test/...
 
 # $(call DOCKER, image, command)
 define DOCKER
@@ -236,9 +237,13 @@ gendocs: out/docs/minikube.md
 fmt:
 	@gofmt -l -s -w $(SOURCE_DIRS)
 
+.PHONY: vet
+vet:
+	@go vet $(SOURCE_PACKAGES)
+
 .PHONY: lint
 lint:
-	@golint $(MINIKUBE_TEST_FILES)
+	@golint -set_exit_status $(SOURCE_PACKAGES)
 
 .PHONY: reportcard
 reportcard:

--- a/docs/contributors/build_guide.md
+++ b/docs/contributors/build_guide.md
@@ -57,7 +57,7 @@ $ ./out/minikube start
 
 ## Running Tests
 
-#### Unit Tests
+### Unit Tests
 
 Unit tests are run on Travis before code is merged. To run as part of a development cycle:
 

--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -36,7 +36,7 @@ sudo apt install libvirt-bin libvirt-daemon-system qemu-kvm
 sudo yum install libvirt-daemon-kvm qemu-kvm
 ```
 
-Enable,start, and verify the `libvirtd` service has started. 
+Enable,start, and verify the `libvirtd` service has started.
 
 ```shell
 sudo systemctl enable libvirtd.service

--- a/pkg/minikube/assets/vm_assets.go
+++ b/pkg/minikube/assets/vm_assets.go
@@ -200,10 +200,12 @@ func (m *BinDataAsset) loadData(isTemplate bool) error {
 	return nil
 }
 
+// IsTemplate returns if the asset is a template
 func (m *BinDataAsset) IsTemplate() bool {
 	return m.template != nil
 }
 
+// Evaluate evaluates the template to a new asset
 func (m *BinDataAsset) Evaluate(data interface{}) (*MemoryAsset, error) {
 	if !m.IsTemplate() {
 		return nil, errors.Errorf("the asset %s is not a template", m.AssetName)

--- a/pkg/minikube/cluster/mount_test.go
+++ b/pkg/minikube/cluster/mount_test.go
@@ -28,7 +28,7 @@ type mockMountHost struct {
 	T    *testing.T
 }
 
-func NewMockMountHost(t *testing.T) *mockMountHost {
+func newMockMountHost(t *testing.T) *mockMountHost {
 	return &mockMountHost{
 		T:    t,
 		cmds: []string{},
@@ -86,7 +86,7 @@ func TestMount(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			h := NewMockMountHost(t)
+			h := newMockMountHost(t)
 			err := Mount(h, tc.source, tc.target, tc.cfg)
 			if err != nil {
 				t.Fatalf("Mount(%s, %s, %+v): %v", tc.source, tc.target, tc.cfg, err)
@@ -99,7 +99,7 @@ func TestMount(t *testing.T) {
 }
 
 func TestUnmount(t *testing.T) {
-	h := NewMockMountHost(t)
+	h := newMockMountHost(t)
 	err := Unmount(h, "/mnt")
 	if err != nil {
 		t.Fatalf("Unmount(/mnt): %v", err)

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -245,7 +245,7 @@ func GetKubeadmCachedImages(imageRepository string, kubernetesVersionStr string)
 		imageRepository + "kube-apiserver-amd64:" + kubernetesVersionStr,
 	}
 
-	ge_v1_14 := semver.MustParseRange(">=1.14.0")
+	v1_14plus := semver.MustParseRange(">=1.14.0")
 	v1_13 := semver.MustParseRange(">=1.13.0 <1.14.0")
 	v1_12 := semver.MustParseRange(">=1.12.0 <1.13.0")
 	v1_11 := semver.MustParseRange(">=1.11.0 <1.12.0")
@@ -259,7 +259,7 @@ func GetKubeadmCachedImages(imageRepository string, kubernetesVersionStr string)
 	}
 
 	var podInfraContainerImage string
-	if ge_v1_14(kubernetesVersion) {
+	if v1_14plus(kubernetesVersion) {
 		podInfraContainerImage = imageRepository + "pause-amd64:3.1"
 		images = append(images, []string{
 			podInfraContainerImage,

--- a/pkg/minikube/tests/provision_mock.go
+++ b/pkg/minikube/tests/provision_mock.go
@@ -84,7 +84,7 @@ func (provisioner *MockProvisioner) GetOsReleaseInfo() (*provision.OsRelease, er
 	return nil, nil
 }
 
-// AttemptIPContact attemps to contact an IP and port
+// AttemptIPContact attempts to contact an IP and port
 func (provisioner *MockProvisioner) AttemptIPContact(dockerPort int) {
 }
 


### PR DESCRIPTION
Also return an exit code from golint (why is this not default?)

```
pkg/minikube/cluster/mount_test.go:31:37: exported func NewMockMountHost returns unexported type *cluster.mockMountHost, which can be annoying to use
pkg/minikube/constants/constants.go:237:2: don't use underscores in Go names; var ge_v1_14 should be geV1_14

docs/contributors/build_guide.md: 60: MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h3; Actual: h4]
docs/drivers.md: 39: MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 1]

pkg/minikube/tests/provision_mock.go:87:20: "attemps" is a misspelling of "attempts"
```