### PR TITLE
Use recreate rollout strategy on ingress controller

### DIFF
--- a/deploy/addons/ingress/ingress-dp.yaml
+++ b/deploy/addons/ingress/ingress-dp.yaml
@@ -69,6 +69,8 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx-ingress-controller


### PR DESCRIPTION
Due to issue #3915, I think the recreate strategy fits better in minikube. For a production cluster this shouldn't apply as there should be 'free' space to rollout the nginx ingress controller over several nodes.