### PR TITLE
Fix infinite loop when failing on caching

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -199,8 +199,8 @@ func runStart(cmd *cobra.Command, args []string) {
 	}
 
 	cr := configureRuntimes(host, runner)
-	bs := prepareHostEnvironment(m, config.KubernetesConfig)
 	waitCacheImages(&cacheGroup)
+	bs := prepareHostEnvironment(m, config.KubernetesConfig)
 
 	// The kube config must be update must come before bootstrapping, otherwise health checks may use a stale IP
 	kubeconfig := updateKubeConfig(host, &config)

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -202,10 +202,8 @@ func getWindowsVolumeNameCmd(d string) (string, error) {
 func LoadFromCacheBlocking(cr bootstrapper.CommandRunner, k8s config.KubernetesConfig, src string) error {
 	glog.Infoln("Loading image from cache at ", src)
 	filename := filepath.Base(src)
-	for {
-		if _, err := os.Stat(src); err == nil {
-			break
-		}
+	if _, err := os.Stat(src); err != nil {
+		return err
 	}
 	dst := path.Join(tempLoadDir, filename)
 	f, err := assets.NewFileAsset(src, tempLoadDir, filename, "0777")


### PR DESCRIPTION
waitCacheImages is called after prepareHostEnvironment at the
moment, which may cause
 1. Incompleted image file to be loaded if downloading speed is
    not fast enough
 2. Infinite loop when image file is not cached on the disk due to
    failures as minikube keeps checking the image file

This moves to waitCacheImages ahead of prepareHostEnvironment to
ensure at least image caching completes (either succeeds or fails)
when trying to load the cached images inside the VM.