### PR TITLE
Add explicit kvm2 flag for hidden KVM signature

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -84,6 +84,7 @@ const (
 	vpnkitSock            = "hyperkit-vpnkit-sock"
 	vsockPorts            = "hyperkit-vsock-ports"
 	gpu                   = "gpu"
+	hidden                = "hidden"
 	embedCerts            = "embed-certs"
 	noVTXCheck            = "no-vtx-check"
 )
@@ -143,6 +144,7 @@ func init() {
 	startCmd.Flags().String(vpnkitSock, "", "Location of the VPNKit socket used for networking. If empty, disables Hyperkit VPNKitSock, if 'auto' uses Docker for Mac VPNKit connection, otherwise uses the specified VSock.")
 	startCmd.Flags().StringSlice(vsockPorts, []string{}, "List of guest VSock ports that should be exposed as sockets on the host (Only supported on with hyperkit now).")
 	startCmd.Flags().Bool(gpu, false, "Enable experimental NVIDIA GPU support in minikube (works only with kvm2 driver on Linux)")
+	startCmd.Flags().Bool(hidden, false, "Hide the hypervisor signature from the guest in minikube (works only with kvm2 driver on Linux)")
 	startCmd.Flags().Bool(noVTXCheck, false, "Disable checking for the availability of hardware virtualization before the vm is started (virtualbox)")
 	viper.BindPFlags(startCmd.Flags())
 	RootCmd.AddCommand(startCmd)
@@ -238,6 +240,9 @@ func validateConfig() {
 	if viper.GetBool(gpu) && viper.GetString(vmDriver) != "kvm2" {
 		exit.Usage("Sorry, the --gpu feature is currently only supported with --vm-driver=kvm2")
 	}
+	if viper.GetBool(hidden) && viper.GetString(vmDriver) != "kvm2" {
+		exit.Usage("Sorry, the --hidden feature is currently only supported with --vm-driver=kvm2")
+	}
 }
 
 // beginCacheImages caches Docker images in the background
@@ -303,6 +308,7 @@ func generateConfig(cmd *cobra.Command, k8sVersion string) (cfg.Config, error) {
 			DisableDriverMounts: viper.GetBool(disableDriverMounts),
 			UUID:                viper.GetString(uuid),
 			GPU:                 viper.GetBool(gpu),
+			Hidden:              viper.GetBool(hidden),
 			NoVTXCheck:          viper.GetBool(noVTXCheck),
 		},
 		KubernetesConfig: cfg.KubernetesConfig{

--- a/pkg/drivers/kvm/domain.go
+++ b/pkg/drivers/kvm/domain.go
@@ -36,9 +36,11 @@ const domainTmpl = `
     <acpi/>
     <apic/>
     <pae/>
+    {{if .Hidden}}
     <kvm>
       <hidden state='on'/>
     </kvm>
+    {{end}}
   </features>
   <cpu mode='host-passthrough'/>
   <os>

--- a/pkg/drivers/kvm/kvm.go
+++ b/pkg/drivers/kvm/kvm.go
@@ -74,6 +74,9 @@ type Driver struct {
 	// Whether to passthrough GPU devices from the host to the VM.
 	GPU bool
 
+	// Whether to hide the KVM hypervisor signature from the guest
+	Hidden bool
+
 	// XML that needs to be added to passthrough GPU devices.
 	DevicesXML string
 }

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -52,6 +52,7 @@ type MachineConfig struct {
 	NFSSharesRoot       string
 	UUID                string // Only used by hyperkit to restore the mac address
 	GPU                 bool   // Only used by kvm2
+	Hidden              bool   // Only used by kvm2
 	NoVTXCheck          bool   // Only used by virtualbox
 }
 

--- a/pkg/minikube/drivers/kvm2/driver.go
+++ b/pkg/minikube/drivers/kvm2/driver.go
@@ -50,6 +50,7 @@ type kvmDriver struct {
 	Boot2DockerURL string
 	DiskPath       string
 	GPU            bool
+	Hidden         bool
 }
 
 func createKVM2Host(config cfg.MachineConfig) interface{} {
@@ -68,5 +69,6 @@ func createKVM2Host(config cfg.MachineConfig) interface{} {
 		DiskPath:       filepath.Join(constants.GetMinipath(), "machines", cfg.GetMachineName(), fmt.Sprintf("%s.rawdisk", cfg.GetMachineName())),
 		ISO:            filepath.Join(constants.GetMinipath(), "machines", cfg.GetMachineName(), "boot2docker.iso"),
 		GPU:            config.GPU,
+		Hidden:         config.Hidden,
 	}
 }


### PR DESCRIPTION
Add a configuration option, for both domain.xml configurations...

Hiding the signature, for unsupported Nvidia GPU models: #3459

Not hiding the signature, where not availalable in KVM: #3586

Have it default to off, and require explicit `--gpu --hidden` params.