### PR TITLE
Fix the spelling of API in the template as well

### DIFF
--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -126,7 +126,7 @@ const (
 	// DefaultStatusFormat is the default format of a host
 	DefaultStatusFormat = `host: {{.Host}}
 kubelet: {{.Kubelet}}
-apiserver: {{.ApiServer}}
+apiserver: {{.APIServer}}
 kubectl: {{.Kubeconfig}}
 `
 	// DefaultAddonListFormat is the default format of addon list


### PR DESCRIPTION
The matching code was changed in commit 46640ce

Closes #3933