### PR TITLE
Store the toolbox on the disk instead of rootfs

### DIFF
--- a/deploy/iso/minikube-iso/package/automount/minikube-automount
+++ b/deploy/iso/minikube-iso/package/automount/minikube-automount
@@ -163,6 +163,10 @@ if [ -n "$BOOT2DOCKER_DATA" ]; then
     mkdir /var/lib/minikube
     mount --bind /mnt/$PARTNAME/var/lib/minikube /var/lib/minikube
 
+    mkdir -p /mnt/$PARTNAME/var/lib/toolbox
+    mkdir /var/lib/toolbox
+    mount --bind /mnt/$PARTNAME/var/lib/toolbox /var/lib/toolbox
+
     mkdir -p /mnt/$PARTNAME/var/lib/minishift
     mkdir /var/lib/minishift
     mount --bind /mnt/$PARTNAME/var/lib/minishift /var/lib/minishift

--- a/test/integration/iso_test.go
+++ b/test/integration/iso_test.go
@@ -89,6 +89,7 @@ func testPersistence(t *testing.T) {
 		"/var/lib/cni",
 		"/var/lib/kubelet",
 		"/var/lib/minikube",
+		"/var/lib/toolbox",
 		"/var/lib/rkt",
 		"/var/lib/boot2docker",
 	} {


### PR DESCRIPTION
There was a lack of "disk" space, when using memory.

This also makes the toolbox persistent over reboots.

Closes #3880

Closes #2889