### PR TITLE
Rename MINIKUBE_IN_COLOR to MINIKUBE_IN_STYLE

### DIFF
--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -13,7 +13,7 @@ Some features can only be accessed by environment variables, here is a list of t
 
 * **MINIKUBE_HOME** - (string) sets the path for the .minikube directory that minikube uses for state/configuration
 
-* **MINIKUBE_IN_COLOR** - (bool) manually sets whether or not emoji and colors should appear in minikube. Set to false or 0 to disable this feature, true or 1 to force it to be turned on.
+* **MINIKUBE_IN_STYLE** - (bool) manually sets whether or not emoji and colors should appear in minikube. Set to false or 0 to disable this feature, true or 1 to force it to be turned on.
 
 * **MINIKUBE_WANTUPDATENOTIFICATION** - (bool) sets whether the user wants an update notification for new minikube versions
 
@@ -34,7 +34,7 @@ To make the exported variables permanent:
 ### Example: Disabling emoji
 
 ```shell
-export MINIKUBE_IN_COLOR=false
+export MINIKUBE_IN_STYLE=false
 minikube start
 ```
 

--- a/docs/vmdriver-none.md
+++ b/docs/vmdriver-none.md
@@ -92,7 +92,7 @@ Some environment variables may be useful for using the `none` driver:
 * **MINIKUBE_HOME**: Saves all files to this directory instead of $HOME
 * **MINIKUBE_WANTUPDATENOTIFICATION**: Toggles the notification that your version of minikube is obsolete
 * **MINIKUBE_WANTREPORTERRORPROMPT**: Toggles the error reporting prompt
-* **MINIKUBE_IN_COLOR**: Toggles color output and emoji usage
+* **MINIKUBE_IN_STYLE**: Toggles color output and emoji usage
 
 ## Known Issues
 

--- a/pkg/minikube/console/console.go
+++ b/pkg/minikube/console/console.go
@@ -40,7 +40,7 @@ import (
 // console.SetErrFile(os.Stderr)
 // console.Fatal("Oh no, everything failed.")
 
-// NOTE: If you do not want colorized output, set MINIKUBE_IN_COLOR=false in your environment.
+// NOTE: If you do not want colorized output, set MINIKUBE_IN_STYLE=false in your environment.
 
 var (
 	// outFile is where Out* functions send output to. Set using SetOutFile()
@@ -54,7 +54,7 @@ var (
 	// useColor is whether or not color output should be used, updated by Set*Writer.
 	useColor = false
 	// OverrideEnv is the environment variable used to override color/emoji usage
-	OverrideEnv = "MINIKUBE_IN_COLOR"
+	OverrideEnv = "MINIKUBE_IN_STYLE"
 )
 
 // fdWriter is the subset of file.File that implements io.Writer and Fd()
@@ -192,8 +192,8 @@ func SetErrFile(w fdWriter) {
 func wantsColor(fd uintptr) bool {
 	// First process the environment: we allow users to force colors on or off.
 	//
-	// MINIKUBE_IN_COLOR=[1, T, true, TRUE]
-	// MINIKUBE_IN_COLOR=[0, f, false, FALSE]
+	// MINIKUBE_IN_STYLE=[1, T, true, TRUE]
+	// MINIKUBE_IN_STYLE=[0, f, false, FALSE]
 	//
 	// If unset, we try to automatically determine suitability from the environment.
 	val := os.Getenv(OverrideEnv)


### PR DESCRIPTION
This name is more meaningful, particularly as:

- minikube currently has no color outside of colored emoji icons
- not all terminal environments render the emoji icons in color

Since this is a minor breaking change, I figured we should do it before 1.0. 