### PR TITLE
Add addon-manager, dashboard, and storage-provisioner to minikube logs

### DIFF
--- a/pkg/minikube/cruntime/cruntime_test.go
+++ b/pkg/minikube/cruntime/cruntime_test.go
@@ -445,9 +445,6 @@ func TestContainerFunctions(t *testing.T) {
 				"fgh1": prefix + "coredns",
 				"xyz2": prefix + "storage",
 			}
-			if tc.runtime == "docker" {
-				runner.containers["zzz"] = "unrelated"
-			}
 			cr, err := New(Config{Type: tc.runtime, Runner: runner})
 			if err != nil {
 				t.Fatalf("New(%s): %v", tc.runtime, err)

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -24,9 +24,6 @@ import (
 	"github.com/golang/glog"
 )
 
-// KubernetesContainerPrefix is the prefix of each kubernetes container
-const KubernetesContainerPrefix = "k8s_"
-
 // Docker contains Docker runtime state
 type Docker struct {
 	Socket string
@@ -99,7 +96,6 @@ func (r *Docker) KubeletOptions() map[string]string {
 
 // ListContainers returns a list of containers
 func (r *Docker) ListContainers(filter string) ([]string, error) {
-	filter = KubernetesContainerPrefix + filter
 	content, err := r.Runner.CombinedOutput(fmt.Sprintf(`docker ps -a --filter="name=%s" --format="{{.ID}}"`, filter))
 	if err != nil {
 		return nil, err

--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -41,6 +41,9 @@ var importantPods = []string{
 	"coredns",
 	"kube-scheduler",
 	"kube-proxy",
+	"kube-addon-manager",
+	"kubernetes-dashboard",
+	"storage-provisioner",
 }
 
 // lookbackwardsCount is how far back to look in a log for problems. This should be large enough to


### PR DESCRIPTION
Helpful for debugging issues like #3972 

This also opens the filter up slightly so that we can see non-system pods, such as the dashboard.
