### PR TITLE
mount: Allow names to be passed in for gid/uid 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 # Bump these on release - and please check ISO_VERSION for correctness.
-VERSION_MAJOR ?= 0
-VERSION_MINOR ?= 35
+VERSION_MAJOR ?= 1
+VERSION_MINOR ?= 0
 VERSION_BUILD ?= 0
 # Default to .0 for higher cache hit rates, as build increments typically don't require new ISO versions
 ISO_VERSION ?= v$(VERSION_MAJOR).$(VERSION_MINOR).0

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 # Bump these on release - and please check ISO_VERSION for correctness.
-VERSION_MAJOR ?= 1
-VERSION_MINOR ?= 0
+VERSION_MAJOR ?= 0
+VERSION_MINOR ?= 35
 VERSION_BUILD ?= 0
 # Default to .0 for higher cache hit rates, as build increments typically don't require new ISO versions
 ISO_VERSION ?= v$(VERSION_MAJOR).$(VERSION_MINOR).0

--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -45,8 +45,8 @@ var mountIP string
 var mountVersion string
 var mountType string
 var isKill bool
-var uid int
-var gid int
+var uid string
+var gid string
 var mSize int
 var options []string
 var mode uint
@@ -144,8 +144,8 @@ var mountCmd = &cobra.Command{
 		console.OutStyle("mounting", "Mounting host path %s into VM as %s ...", hostPath, vmPath)
 		console.OutStyle("mount-options", "Mount options:")
 		console.OutStyle("option", "Type:     %s", cfg.Type)
-		console.OutStyle("option", "UID:      %d", cfg.UID)
-		console.OutStyle("option", "GID:      %d", cfg.GID)
+		console.OutStyle("option", "UID:      %s", cfg.UID)
+		console.OutStyle("option", "GID:      %s", cfg.GID)
 		console.OutStyle("option", "Version:  %s", cfg.Version)
 		console.OutStyle("option", "MSize:    %d", cfg.MSize)
 		console.OutStyle("option", "Mode:     %o (%s)", cfg.Mode, cfg.Mode)
@@ -194,8 +194,8 @@ func init() {
 	mountCmd.Flags().StringVar(&mountType, "type", nineP, "Specify the mount filesystem type (supported types: 9p)")
 	mountCmd.Flags().StringVar(&mountVersion, "9p-version", constants.DefaultMountVersion, "Specify the 9p version that the mount should use")
 	mountCmd.Flags().BoolVar(&isKill, "kill", false, "Kill the mount process spawned by minikube start")
-	mountCmd.Flags().IntVar(&uid, "uid", 1001, "Default user id used for the mount")
-	mountCmd.Flags().IntVar(&gid, "gid", 1001, "Default group id used for the mount")
+	mountCmd.Flags().StringVar(&uid, "uid", "docker", "Default user id used for the mount")
+	mountCmd.Flags().StringVar(&gid, "gid", "docker", "Default group id used for the mount")
 	mountCmd.Flags().UintVar(&mode, "mode", 0755, "File permissions used for the mount")
 	mountCmd.Flags().StringSliceVar(&options, "options", []string{}, "Additional mount options, such as cache=fscache")
 	mountCmd.Flags().IntVar(&mSize, "msize", constants.DefaultMsize, "The number of bytes to use for 9p packet payload")

--- a/pkg/minikube/cluster/mount_test.go
+++ b/pkg/minikube/cluster/mount_test.go
@@ -59,10 +59,20 @@ func TestMount(t *testing.T) {
 			},
 		},
 		{
+			name:   "named uid",
+			source: "src",
+			target: "target",
+			cfg:    &MountConfig{Type: "9p", Mode: os.FileMode(0700), UID: "docker", GID: "docker"},
+			want: []string{
+				"findmnt -T target && sudo umount target || true",
+				"sudo mkdir -m 700 -p target && sudo mount -t 9p -o dfltgid=$(grep ^docker: /etc/group | cut -d: -f3),dfltuid=$(id -u docker) src target",
+			},
+		},
+		{
 			name:   "everything",
 			source: "10.0.0.1",
 			target: "/target",
-			cfg: &MountConfig{Type: "9p", Mode: os.FileMode(0777), UID: 82, GID: 72, Version: "9p2000.u", Options: map[string]string{
+			cfg: &MountConfig{Type: "9p", Mode: os.FileMode(0777), UID: "82", GID: "72", Version: "9p2000.u", Options: map[string]string{
 				"noextend": "",
 				"cache":    "fscache",
 			}},


### PR DESCRIPTION
This makes the mount command resistant against uid/gid changes, like what we just ran into with Docker.

Closes #3987