### PR TITLE
Add integration test for CNI deployments

### DIFF
--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -39,9 +39,11 @@ func TestStartStop(t *testing.T) {
 			"--cache-images=false",
 			fmt.Sprintf("--kubernetes-version=%s", constants.OldestKubernetesVersion),
 		}},
-		{"feature_gates_newest", []string{
+		{"feature_gates_newest_cni", []string{
 			"--feature-gates",
 			"ServerSideApply=true",
+			"--network-plugin=cni",
+			"--extra-config=kubelet.network-plugin=cni",
 			fmt.Sprintf("--kubernetes-version=%s", constants.NewestKubernetesVersion),
 		}},
 		{"containerd", []string{


### PR DESCRIPTION
We currently don't test CNI flags anywhere. This adds testing for them without slowing down our integration testing, by including them with the newest test. 

Once this merges, we can safely close #3852
