### PR TITLE
Escape systemd special chars in docker-env

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -250,3 +250,26 @@ func TeePrefix(prefix string, r io.Reader, w io.Writer, logger func(format strin
 	}
 	return nil
 }
+
+// ReplaceChars returns a copy of the src slice with each string modified by the replacer
+func ReplaceChars(src []string, replacer *strings.Replacer) []string {
+	ret := make([]string, len(src))
+	for i, s := range src {
+		ret[i] = replacer.Replace(s)
+	}
+	return ret
+}
+
+// ConcatStrings concatenates each string in the src slice with prefix and postfix and returns a new slice
+func ConcatStrings(src []string, prefix string, postfix string) []string {
+	var buf bytes.Buffer
+	ret := make([]string, len(src))
+	for i, s := range src {
+		buf.WriteString(prefix)
+		buf.WriteString(s)
+		buf.WriteString(postfix)
+		ret[i] = buf.String()
+		buf.Reset()
+	}
+	return ret
+}

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -197,3 +197,43 @@ func TestTeePrefix(t *testing.T) {
 		t.Errorf("log=%q, want: %q", gotLog, wantLog)
 	}
 }
+
+func TestReplaceChars(t *testing.T) {
+	testData := []struct {
+		src         []string
+		replacer    *strings.Replacer
+		expectedRes []string
+	}{
+		{[]string{"abc%def", "%Y%"}, strings.NewReplacer("%", "X"), []string{"abcXdef", "XYX"}},
+	}
+
+	for _, tt := range testData {
+		res := ReplaceChars(tt.src, tt.replacer)
+		for i, val := range res {
+			if val != tt.expectedRes[i] {
+				t.Fatalf("Expected '%s' but got '%s'", tt.expectedRes, res)
+			}
+		}
+	}
+}
+
+func TestConcatStrings(t *testing.T) {
+	testData := []struct {
+		src         []string
+		prefix      string
+		postfix     string
+		expectedRes []string
+	}{
+		{[]string{"abc", ""}, "xx", "yy", []string{"xxabcyy", "xxyy"}},
+		{[]string{"abc", ""}, "", "", []string{"abc", ""}},
+	}
+
+	for _, tt := range testData {
+		res := ConcatStrings(tt.src, tt.prefix, tt.postfix)
+		for i, val := range res {
+			if val != tt.expectedRes[i] {
+				t.Fatalf("Expected '%s' but got '%s'", tt.expectedRes, res)
+			}
+		}
+	}
+}


### PR DESCRIPTION
The --docker-env param is interpolated into systemd unit file for docker engine. Any special characters that systemd provides for use in templates will be interpreted by systemd. Since minikube does not support these special characters in docker-env, we must escape them so that systemd does not interpret them as special chars. 
See examples in the below issue.

Note: this PR deals only with the docker-env param which gets inserted into the Environment option of the systemd unit file. Other parts of the file are omitted.

Closes #3812 