### PR TITLE
WIP: Run `kubeadm init phase addon all` to ensure kube-proxy is up in v1.13+

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -318,6 +318,10 @@ func (k *Bootstrapper) RestartCluster(k8s config.KubernetesConfig) error {
 		fmt.Sprintf("sudo kubeadm %s phase etcd local --config %s", phase, constants.KubeadmConfigFile),
 	}
 
+	if version.GTE(semver.MustParse("1.13.0")) {
+		cmds = append(cmds, fmt.Sprintf("sudo kubeadm init phase addon all --config %s", constants.KubeadmConfigFile))
+	}
+
 	// Run commands one at a time so that it is easier to root cause failures.
 	for _, cmd := range cmds {
 		if err := k.c.Run(cmd); err != nil {


### PR DESCRIPTION
fix #3936 #3843

I find that kube-proxy is not created after `minikube start`(restart) so that `waitForPods` always waits until timeout.

`kubeadm init phase addon all` can generate kube-proxy before `waitForPods`.

---
How to reproduce:
1. minikube start
2. ctrl+c after vm is created
3. minikube start again