### PR TITLE
```#compdef``` must be the first line

### DIFF
--- a/cmd/minikube/cmd/completion.go
+++ b/cmd/minikube/cmd/completion.go
@@ -105,8 +105,10 @@ func GenerateBashCompletion(w io.Writer, cmd *cobra.Command) error {
 
 // GenerateZshCompletion generates the completion for the zsh shell
 func GenerateZshCompletion(out io.Writer, cmd *cobra.Command) error {
-	zshInitialization := `#compdef minikube
+	zshAutoloadTag := `#compdef minikube
+`
 
+	zshInitialization := `
 __minikube_bash_source() {
 	alias shopt=':'
 	alias _expand=_bash_expand
@@ -239,7 +241,12 @@ __minikube_convert_bash_to_zsh() {
 	<<'BASH_COMPLETION_EOF'
 `
 
-	_, err := out.Write([]byte(boilerPlate))
+	_, err := out.Write([]byte(zshAutoloadTag))
+	if err != nil {
+		return err
+	}
+
+	_, err = out.Write([]byte(boilerPlate))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
According to the [document](http://zsh.sourceforge.net/Doc/Release/Completion-System.html#Autoloaded-files):

> When compinit is run, it searches all such files accessible via fpath/FPATH and reads the first line of each of them. This line should contain one of the tags described below. Files whose first line does not start with one of these tags are not considered to be part of the completion system and will not be treated specially.

So ```#compdef``` must be the first line of a completion script.