### PR TITLE
Fixed url for issues.

### DIFF
--- a/pkg/minikube/problem/problem.go
+++ b/pkg/minikube/problem/problem.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/console"
 )
 
-const issueBase = "https://github.com/kubernetes/minikube/issue"
+const issueBase = "https://github.com/kubernetes/minikube/issues"
 
 // Problem represents a known problem in minikube.
 type Problem struct {


### PR DESCRIPTION
The url for issues is https://github.com/kubernetes/minikube/issues, not https://github.com/kubernetes/minikube/issue.