### PR TITLE
update-context is confusing with profiles

### DIFF
--- a/cmd/minikube/cmd/update-context.go
+++ b/cmd/minikube/cmd/update-context.go
@@ -49,9 +49,9 @@ var updateContextCmd = &cobra.Command{
 			exit.WithError("update config", err)
 		}
 		if updated {
-			console.OutStyle("celebrate", "IP has been updated to point at %s", ip)
+			console.OutStyle("celebrate", "%s IP has been updated to point at %s", machineName, ip)
 		} else {
-			console.OutStyle("meh", "IP was already correctly configured for %s", ip)
+			console.OutStyle("meh", "%s IP was already correctly configured for %s", machineName, ip)
 		}
 
 	},


### PR DESCRIPTION
update-context is confusing with profiles: "IP was already configured"
fixes https://github.com/kubernetes/minikube/issues/3983