### PR TITLE
more vm-driver=none documentation on resolve.conf

### DIFF
--- a/docs/vmdriver-none.md
+++ b/docs/vmdriver-none.md
@@ -101,5 +101,12 @@ Some environment variables may be useful for using the `none` driver:
 * minikube with the `none` driver has a confusing permissions model, as some commands need to be run as root ("start"), and others by a regular user ("dashboard")
 * CoreDNS detects resolver loop, goes into CrashloopBackoff - [#3511](https://github.com/kubernetes/minikube/issues/3511)
 * Some versions of Linux have a version of docker that is newer then what Kubernetes expects. To overwrite this, run minikube with the following parameters: `sudo -E minikube start --vm-driver=none --kubernetes-version v1.11.8 --extra-config kubeadm.ignore-preflight-errors=SystemVerification`
-* On Ubuntu 18.04 (and probably others), because of how `systemd-resolve` is configured by default, one needs to bypass the default `resolv.conf` file and use a different one instead: `sudo -E minikube --vm-driver=none start --extra-config=kubelet.resolv-conf=/run/systemd/resolve/resolv.conf`
+* On Ubuntu 18.04 (and probably others), because of how `systemd-resolve` is configured by default, one needs to bypass the default `resolv.conf` file and use a different one instead.
+  - In this case, you should use this file: `/run/systemd/resolve/resolv.conf`
+  - `sudo -E minikube --vm-driver=none start --extra-config=kubelet.resolv-conf=/run/systemd/resolve/resolv.conf`
+  - Apperently, though, if `resolve.conf` is too big (about 10 lines!!!), one gets the following error: `Waiting for pods: apiserver proxy! Error restarting cluster: wait: waiting for k8s-app=kube-proxy: timed out waiting for the condition`
+  - This error happens in Kubernetes 0.11.x, 0.12.x and 0.13.x, but *not* in 0.14.x
+  - If that's your case, try this:
+  - `grep -E "^nameserver" /run/systemd/resolve/resolv.conf  |head -n 3 > /tmp/resolv.conf && sudo -E minikube --vm-driver=none start --extra-config=kubelet.resolv-conf=/tmp/resolv.conf`
+
 * [Full list of open 'none' driver issues](https://github.com/kubernetes/minikube/labels/co%2Fnone-driver)


### PR DESCRIPTION
Very interesting issue...

On a new box in AWS, minikube was not working unless I used `/run/systemd/resolve/resolv.conf` as the `resolv.conf` (which was by the way solved in kubernetes itself here: https://github.com/kubernetes/kubernetes/pull/63691/files )

But VirtualBox, the same scripts that were provisioning the box in aws were failing if I used k8s v0.11.x, v0.12.x or v0.13.x. (Things did work on k8s v0.14.0)

`grep -E "^nameserver" /run/systemd/resolve/resolv.conf  |head -n 3 > /tmp/resolv.conf && sudo -E minikube --vm-driver=none start --extra-config=kubelet.resolv-conf=/tmp/resolv.conf`

Did solve the problem, but of course it took me 3 days to find out. Therefore I want to share the knowledge and save other people's time.

At first I though this would be to specific to my setup, but my test was done with a new VirtualBox machine provisioning from the official ubuntu 18.04.02 iso, all that done with scripts, so I can replicate the problem and the solution and my local environment should have nothing to do with it. If more users could test this before it get's merged, maybe that's  good idea.


