### PR TITLE
Fixed status checking with non-default apiserver-port.

### DIFF
--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -92,7 +92,13 @@ var statusCmd = &cobra.Command{
 				glog.Errorln("Error host driver ip status:", err)
 			}
 
-			apiserverSt, err = clusterBootstrapper.GetAPIServerStatus(ip)
+			apiserverPort, err := pkgutil.GetPortFromKubeConfig(util.GetKubeConfigPath(), config.GetMachineName())
+			if err != nil {
+				// Fallback to presuming default apiserver port
+				apiserverPort = pkgutil.APIServerPort
+			}
+
+			apiserverSt, err = clusterBootstrapper.GetAPIServerStatus(ip, apiserverPort)
 			if err != nil {
 				glog.Errorln("Error apiserver status:", err)
 			} else if apiserverSt != state.Running.String() {

--- a/pkg/minikube/bootstrapper/bootstrapper.go
+++ b/pkg/minikube/bootstrapper/bootstrapper.go
@@ -43,7 +43,7 @@ type Bootstrapper interface {
 	LogCommands(LogOptions) map[string]string
 	SetupCerts(cfg config.KubernetesConfig) error
 	GetKubeletStatus() (string, error)
-	GetAPIServerStatus(net.IP) (string, error)
+	GetAPIServerStatus(net.IP, int) (string, error)
 }
 
 const (

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -122,8 +122,8 @@ func (k *Bootstrapper) GetKubeletStatus() (string, error) {
 }
 
 // GetAPIServerStatus returns the api-server status
-func (k *Bootstrapper) GetAPIServerStatus(ip net.IP) (string, error) {
-	url := fmt.Sprintf("https://%s:%d/healthz", ip, util.APIServerPort)
+func (k *Bootstrapper) GetAPIServerStatus(ip net.IP, apiserverPort int) (string, error) {
+	url := fmt.Sprintf("https://%s:%d/healthz", ip, apiserverPort)
 	// To avoid: x509: certificate signed by unknown authority
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},

--- a/pkg/util/kubeconfig.go
+++ b/pkg/util/kubeconfig.go
@@ -251,7 +251,7 @@ func UpdateKubeconfigIP(ip net.IP, filename string, machineName string) (bool, e
 	if kip.Equal(ip) {
 		return false, nil
 	}
-	kport, err := getPortFromKubeConfig(filename, machineName)
+	kport, err := GetPortFromKubeConfig(filename, machineName)
 	if err != nil {
 		return false, err
 	}
@@ -291,8 +291,8 @@ func getIPFromKubeConfig(filename, machineName string) (net.IP, error) {
 	return ip, nil
 }
 
-// getPortFromKubeConfig returns the Port number stored for minikube in the kubeconfig specified
-func getPortFromKubeConfig(filename, machineName string) (int, error) {
+// GetPortFromKubeConfig returns the Port number stored for minikube in the kubeconfig specified
+func GetPortFromKubeConfig(filename, machineName string) (int, error) {
 	con, err := ReadConfigOrNew(filename)
 	if err != nil {
 		return 0, errors.Wrap(err, "Error getting kubeconfig status")

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -46,17 +46,15 @@ func TestStartStop(t *testing.T) {
 			"--extra-config=kubelet.network-plugin=cni",
 			fmt.Sprintf("--kubernetes-version=%s", constants.NewestKubernetesVersion),
 		}},
-		{"containerd", []string{
+		{"containerd_and_non_default_apiserver_port", []string{
 			"--container-runtime=containerd",
 			"--docker-opt containerd=/var/run/containerd/containerd.sock",
+			"--apiserver-port=8444",
 		}},
 		{"crio_ignore_preflights", []string{
 			"--container-runtime=crio",
 			"--extra-config",
 			"kubeadm.ignore-preflight-errors=SystemVerification",
-		}},
-		{"apiserver_port_non_default", []string{
-			"--apiserver-port=8444",
 		}},
 	}
 

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -55,6 +55,9 @@ func TestStartStop(t *testing.T) {
 			"--extra-config",
 			"kubeadm.ignore-preflight-errors=SystemVerification",
 		}},
+		{"apiserver_port_non_default", []string{
+			"--apiserver-port=8444",
+		}},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This is a fix for #4057.

Component health checking as part of "start" and "status" now respect non-default apiserver port settings from the command line and kubeconfig file, respectively. The functionality is now verified with an integration test.