### PR TITLE
Don't cache images when --vmdriver=none

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -187,7 +187,6 @@ func runStart(cmd *cobra.Command, args []string) {
 		`docker load -i ~/.minikube/cache/some_images` is unecessary and takes time.
 		As a bonus, we save disk space.
 		*/
-		console.OutStyle("starting-none", "Caching of container images is disabled when --vm-driver=none")
 		viper.Set(cacheImages, false)
 	}
 

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -175,18 +175,7 @@ func runStart(cmd *cobra.Command, args []string) {
 	}
 
 	if viper.GetString(vmDriver) == constants.DriverNone {
-		/*
-		Caching images means:
-			- minikube download the images
-			- minikube saves them in ~/.minikube/cache
-			- minikube loads them to the host machine with `docker load -i ~/.minikube/cache/some_images`
-
-		This makes complete sense, except that when --vm-driver=none, the host machine is the local machine.
-		That means once the images is loaded into docker, it stays there even after reboots and `minikube delete`.
-		That means they are already cached and nothing needs to be done. Not only that, loading the container with
-		`docker load -i ~/.minikube/cache/some_images` is unecessary and takes time.
-		As a bonus, we save disk space.
-		*/
+		// Optimization: images will be persistently loaded into host Docker, so no need to duplicate work.
 		viper.Set(cacheImages, false)
 	}
 

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -175,6 +175,18 @@ func runStart(cmd *cobra.Command, args []string) {
 	}
 
 	if viper.GetString(vmDriver) == constants.DriverNone {
+		/*
+		Caching images means:
+			- minikube download the images
+			- minikube saves them in ~/.minikube/cache
+			- minikube loads them to the host machine with `docker load -i ~/.minikube/cache/some_images`
+
+		This makes complete sense, except that when --vm-driver=none, the host machine is the local machine.
+		That means once the images is loaded into docker, it stays there even after reboots and `minikube delete`.
+		That means they are already cached and nothing needs to be done. Not only that, loading the container with
+		`docker load -i ~/.minikube/cache/some_images` is unecessary and takes time.
+		As a bonus, we save disk space.
+		*/
 		console.OutStyle("starting-none", "Caching of container images is disabled when --vm-driver=none")
 		viper.Set(cacheImages, false)
 	}

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -175,7 +175,7 @@ func runStart(cmd *cobra.Command, args []string) {
 	}
 
 	if viper.GetString(vmDriver) == constants.DriverNone {
-		// Optimization: images will be persistently loaded into host Docker, so no need to duplicate work.
+		// Optimization: images will be persistently loaded into the host's container runtime, so no need to duplicate work.
 		viper.Set(cacheImages, false)
 	}
 

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -135,7 +135,7 @@ func init() {
 	startCmd.Flags().String(networkPlugin, "", "The name of the network plugin")
 	startCmd.Flags().Bool(enableDefaultCNI, false, "Enable the default CNI plugin (/etc/cni/net.d/k8s.conf). Used in conjunction with \"--network-plugin=cni\"")
 	startCmd.Flags().String(featureGates, "", "A set of key=value pairs that describe feature gates for alpha/experimental features.")
-	startCmd.Flags().Bool(cacheImages, true, "If true, cache docker images for the current bootstrapper and load them into the machine.")
+	startCmd.Flags().Bool(cacheImages, true, "If true, cache docker images for the current bootstrapper and load them into the machine. Always false with --vm-driver=none.")
 	startCmd.Flags().Var(&extraOptions, "extra-config",
 		`A set of key=value pairs that describe configuration that may be passed to different components.
 		The key should be '.' separated, and the first part before the dot is the component to apply the configuration to.
@@ -172,6 +172,11 @@ func runStart(cmd *cobra.Command, args []string) {
 	config, err := generateConfig(cmd, k8sVersion)
 	if err != nil {
 		exit.WithError("Failed to generate config", err)
+	}
+
+	if viper.GetString(vmDriver) == constants.DriverNone {
+		console.OutStyle("starting-none", "Caching of container images is disabled when --vm-driver=none")
+		viper.Set(cacheImages, false)
 	}
 
 	var cacheGroup errgroup.Group


### PR DESCRIPTION
Since https://github.com/kubernetes/minikube/pull/3917, images are cached by default.

That is great, except that it does not make sense when `--vmdriver=none`.
When cache is enabled, 
 - `minikube` download the images to `~/.minikube/cache`
 - `minikube` loads them (`docker load -i ~/.minikube/cache/someimage`)

When `--vmdriver=none`, the machine's docker is used, so any loaded image will be stored there "forever" anyway. Hence they are already cached. And setting the cache enable has actually two downsides:

- it uses local disk space unnecessarily
- on every `minikube` launch it will load images from `~/.minikube/cache/someimage` to docker, even though they are there already.

So these 5 lines of code do speedup the launch!