### PR TITLE
Assert that docker has started rather than explicitly restarting it 

### DIFF
--- a/pkg/minikube/cruntime/cruntime_test.go
+++ b/pkg/minikube/cruntime/cruntime_test.go
@@ -381,7 +381,7 @@ func TestEnable(t *testing.T) {
 		want    map[string]serviceState
 	}{
 		{"docker", map[string]serviceState{
-			"docker":        Restarted,
+			"docker":        Running,
 			"docker.socket": Running,
 			"containerd":    Exited,
 			"crio":          Exited,

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -73,7 +73,7 @@ func (r *Docker) Enable() error {
 	if err := disableOthers(r, r.Runner); err != nil {
 		glog.Warningf("disableOthers: %v", err)
 	}
-	return r.Runner.Run("sudo systemctl restart docker")
+	return r.Runner.Run("sudo systemctl start docker")
 }
 
 // Disable idempotently disables Docker on a host


### PR DESCRIPTION
I am not sure why we restart instead of start docker.

I mean, do we expect it to be in a broken state ?

Removing this 16 bits from the code made things start 10 seconds quicker.

I am not sure if restart is needed for other drivers.


Same as https://github.com/kubernetes/minikube/pull/4114

