### PR TITLE
Add environment variable to disable style prefix

### DIFF
--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -13,6 +13,8 @@ Some features can only be accessed by environment variables, here is a list of t
 
 * **MINIKUBE_HOME** - (string) sets the path for the .minikube directory that minikube uses for state/configuration
 
+* **MINIKUBE_NO_STYLE** - disable the style prefix completely
+
 * **MINIKUBE_IN_STYLE** - (bool) manually sets whether or not emoji and colors should appear in minikube. Set to false or 0 to disable this feature, true or 1 to force it to be turned on.
 
 * **MINIKUBE_WANTUPDATENOTIFICATION** - (bool) sets whether the user wants an update notification for new minikube versions

--- a/pkg/minikube/console/console_test.go
+++ b/pkg/minikube/console/console_test.go
@@ -78,6 +78,7 @@ func TestOutStyle(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.style+"-"+tc.envValue, func(t *testing.T) {
+			os.Unsetenv(DisableEnv)
 			os.Setenv(OverrideEnv, tc.envValue)
 			f := newFakeFile()
 			SetOutFile(f)
@@ -92,7 +93,25 @@ func TestOutStyle(t *testing.T) {
 	}
 }
 
+func TestDisableStyle(t *testing.T) {
+	os.Setenv(DisableEnv, "")
+	os.Unsetenv(OverrideEnv)
+	f := newFakeFile()
+	SetOutFile(f)
+	if err := OutStyle("happy", "hello"); err != nil {
+		t.Errorf("unexpected error: %q", err)
+	}
+
+	got := f.String()
+	want := "hello\n"
+
+	if got != want {
+		t.Errorf("OutStyle() = %q, want %q", got, want)
+	}
+}
+
 func TestOut(t *testing.T) {
+	os.Unsetenv(DisableEnv)
 	os.Setenv(OverrideEnv, "")
 	// An example translation just to assert that this code path is executed.
 	err := message.SetString(language.Arabic, "Installing Kubernetes version %s ...", "... %s تثبيت Kubernetes الإصدار")
@@ -129,6 +148,7 @@ func TestOut(t *testing.T) {
 }
 
 func TestErr(t *testing.T) {
+	os.Unsetenv(DisableEnv)
 	os.Setenv(OverrideEnv, "0")
 	f := newFakeFile()
 	SetErrFile(f)
@@ -146,6 +166,7 @@ func TestErr(t *testing.T) {
 }
 
 func TestErrStyle(t *testing.T) {
+	os.Unsetenv(DisableEnv)
 	os.Setenv(OverrideEnv, "1")
 	f := newFakeFile()
 	SetErrFile(f)
@@ -160,6 +181,7 @@ func TestErrStyle(t *testing.T) {
 }
 
 func TestSetPreferredLanguage(t *testing.T) {
+	os.Unsetenv(DisableEnv)
 	os.Setenv(OverrideEnv, "0")
 	var tests = []struct {
 		input string

--- a/pkg/minikube/console/style.go
+++ b/pkg/minikube/console/style.go
@@ -129,7 +129,7 @@ func lowPrefix(s style) string {
 }
 
 // Apply styling to a format string
-func applyStyle(style string, useColor bool, format string, a ...interface{}) (string, error) {
+func applyStyle(style string, usePrefix bool, useColor bool, format string, a ...interface{}) (string, error) {
 	p := message.NewPrinter(preferredLanguage)
 	out := p.Sprintf(format, a...)
 
@@ -143,8 +143,11 @@ func applyStyle(style string, useColor bool, format string, a ...interface{}) (s
 		return p.Sprintf(format, a...), fmt.Errorf("unknown style: %q", style)
 	}
 
-	if !useColor {
-		return applyPrefix(lowPrefix(s), out), nil
+	if usePrefix {
+		if !useColor {
+			return applyPrefix(lowPrefix(s), out), nil
+		}
+		return applyPrefix(s.Prefix, out), nil
 	}
-	return applyPrefix(s.Prefix, out), nil
+	return out, nil
 }


### PR DESCRIPTION
Some people find the "style" prefix distracting and confusing,
whether it is shown in color emoji or in 7-bit compatible text.

So add a way to opt-out from the console prefix completely, this
will just show the message text starting from the first column.


From discussion in #3724