### PR TITLE
Fix the Data Loss section of vmdriver-none.md: kubectl -> kubelet

### DIFF
--- a/docs/vmdriver-none.md
+++ b/docs/vmdriver-none.md
@@ -73,7 +73,7 @@ We'll cover these in detail below:
 With the `none` driver, minikube will overwrite the following system paths:
 
 * /usr/bin/kubeadm - Updated to match the exact version of Kubernetes selected
-* /usr/bin/kubectl - Updated to match the exact version of Kubernetes selected
+* /usr/bin/kubelet - Updated to match the exact version of Kubernetes selected
 * /etc/kubernetes - configuration files
 
 These paths will be erased when running `minikube delete`:


### PR DESCRIPTION
It does not look like `minikube` with the `none` driver does anything to `kubectl`, but it does install `kubelet` along with `kubeadm`.