### PR TITLE
Download ISO image before Docker images, as it's required first

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -176,17 +176,17 @@ func runStart(cmd *cobra.Command, args []string) {
 		exit.WithError("Failed to generate config", err)
 	}
 
-	// The ISO is required to boot the VM, so block on completion before pulling images.
+	// For non-"none", the ISO is required to boot, so block until it is downloaded
 	if viper.GetString(vmDriver) != constants.DriverNone {
 		if err := cluster.CacheISO(config.MachineConfig); err != nil {
 			exit.WithError("Failed to cache ISO", err)
 		}
 	} else {
-		// With "none", images are  persistently loaded into Docker, so it's unneccessary to cache them in a second location.
+		// With "none", images are persistently stored in Docker, so internal caching isn't necessary.
 		viper.Set(cacheImages, false)
 	}
 
-	// Now that the ISO is downloaded, we pull images in the backgfround while the VM boots.
+	// Now that the ISO is downloaded, pull images in the background while the VM boots.
 	var cacheGroup errgroup.Group
 	beginCacheImages(&cacheGroup, k8sVersion)
 

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -301,13 +301,7 @@ func createHost(api libmachine.API, config cfg.MachineConfig) (*host.Host, error
 		exit.WithError("error getting driver", err)
 	}
 
-	err = CacheISO(config)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to cache ISO")
-	}
-
 	driver := def.ConfigCreator(config)
-
 	data, err := json.Marshal(driver)
 	if err != nil {
 		return nil, errors.Wrap(err, "marshal")


### PR DESCRIPTION
In minikube v1.0.0, we download Docker images before the ISO image.

It turns out that this isn't a very good use of our time, as the ISO image is required to start the VM.

This PR changes the behavior so that startup blocks until the ISO is downloaded, so that we can download Docker images while we wait for the VM to boot up.

This resolves #4035 and helps address an issue raised in #4039 