### PR TITLE
storageclass no longer beta #4148

### DIFF
--- a/deploy/addons/storageclass/storageclass.yaml
+++ b/deploy/addons/storageclass/storageclass.yaml
@@ -4,7 +4,7 @@ metadata:
   namespace: kube-system
   name: standard
   annotations:
-    storageclass.beta.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "true"
   labels:
     addonmanager.kubernetes.io/mode: EnsureExists
 


### PR DESCRIPTION
I changed for this pr #4148

- https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/storage-class/local/default.yaml