### PR TITLE
Make handling of stale mount pid files more robust

### DIFF
--- a/cmd/minikube/cmd/stop.go
+++ b/cmd/minikube/cmd/stop.go
@@ -67,7 +67,7 @@ itself, leaving all files intact. The cluster can be started again with the "sta
 		}
 
 		if err := cmdUtil.KillMountProcess(); err != nil {
-			exit.WithError("Unable to kill mount process", err)
+			console.OutStyle("warning", "Unable to kill mount process: %s", err)
 		}
 	},
 }


### PR DESCRIPTION
This makes several updates around KillMountProcess:

- Non-running pids no longer emit an error
- Remove the pid file so that it is not forever stale
- Failures emit a warning rather than crashing "stop"

This closes #4168

