### PR TITLE
Make default output of 'minikube start' consume fewer lines in the terminal

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -258,7 +258,7 @@ func showKubectlConnectInfo(kubeconfig *pkgutil.KubeConfigSetup) {
 	if kubeconfig.KeepContext {
 		console.OutStyle("kubectl", "To connect to this cluster, use: kubectl --context=%s", kubeconfig.ClusterName)
 	} else {
-		console.OutStyle("kubectl", "Done! kubectl is now configured to use %q", cfg.GetMachineName())
+		console.OutStyle("ready", "Done! kubectl is now configured to use %q", cfg.GetMachineName())
 	}
 	_, err := exec.LookPath("kubectl")
 	if err != nil {
@@ -590,7 +590,6 @@ func bootstrapCluster(bs bootstrapper.Bootstrapper, r cruntime.Manager, runner b
 func validateCluster(bs bootstrapper.Bootstrapper, r cruntime.Manager, runner bootstrapper.CommandRunner, ip string, apiserverPort int) {
 	k8sStat := func() (err error) {
 		st, err := bs.GetKubeletStatus()
-		console.Out(".")
 		if err != nil || st != state.Running.String() {
 			return &pkgutil.RetriableError{Err: fmt.Errorf("kubelet unhealthy: %v: %s", err, st)}
 		}
@@ -602,7 +601,6 @@ func validateCluster(bs bootstrapper.Bootstrapper, r cruntime.Manager, runner bo
 	}
 	aStat := func() (err error) {
 		st, err := bs.GetAPIServerStatus(net.ParseIP(ip), apiserverPort)
-		console.Out(".")
 		if err != nil || st != state.Running.String() {
 			return &pkgutil.RetriableError{Err: fmt.Errorf("apiserver status=%s err=%v", st, err)}
 		}

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -227,7 +227,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		exit.WithError("Failed to get command runner", err)
 	}
 
-	cr := configureRuntimes(host, runner,k8sVersion)
+	cr := configureRuntimes(host, runner, k8sVersion)
 
 	// prepareHostEnvironment uses the downloaded images, so we need to wait for background task completion.
 	waitCacheImages(&cacheGroup)
@@ -251,7 +251,7 @@ func runStart(cmd *cobra.Command, args []string) {
 	}
 
 	showKubectlConnectInfo(kubeconfig)
-	
+
 }
 
 func showKubectlConnectInfo(kubeconfig *pkgutil.KubeConfigSetup) {
@@ -544,7 +544,7 @@ func configureRuntimes(h *host.Host, runner bootstrapper.CommandRunner, k8sVersi
 		exit.WithError(fmt.Sprintf("Failed runtime for %+v", config), err)
 	}
 	version, _ := cr.Version()
-	console.OutStyle(cr.Name(), "Configuring environment for Kubernetes %s on %s %s", k8sVersion,cr.Name(),version)
+	console.OutStyle(cr.Name(), "Configuring environment for Kubernetes %s on %s %s", k8sVersion, cr.Name(), version)
 	for _, v := range dockerOpt {
 		console.OutStyle("option", "opt %s", v)
 	}

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -217,7 +217,7 @@ func (k *Bootstrapper) StartCluster(k8s config.KubernetesConfig) error {
 		return errors.Wrap(err, "wait")
 	}
 
-	console.OutStyle("permissions", "Configuring cluster permissions ...")
+	glog.Infof("Configuring cluster permissions ...")
 	if err := util.RetryAfter(100, elevateKubeSystemPrivileges, time.Millisecond*500); err != nil {
 		return errors.Wrap(err, "timed out waiting to elevate kube-system RBAC privileges")
 	}

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -267,7 +267,7 @@ func waitForPods(k8s config.KubernetesConfig, quiet bool) error {
 	componentsOnly := k8s.NetworkPlugin == "cni"
 
 	if !quiet {
-		console.OutStyle("waiting-pods", "Waiting for pods:")
+		console.OutStyle("waiting-pods", "Waiting for:")
 	}
 	client, err := util.GetClient()
 	if err != nil {


### PR DESCRIPTION
This PR fixes #4187 