### PR TITLE
Fix Makefile deploy rule dependency and improve error checking for invalid assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ out/test.d: pkg/minikube/assets/assets.go
 test:
 	GOPATH=$(GOPATH) ./test.sh
 
-pkg/minikube/assets/assets.go: $(shell find deploy/addons -type f)
+pkg/minikube/assets/assets.go: $(DEPLOYS)
 	which go-bindata || GOBIN=$(GOPATH)/bin go get github.com/jteeuwen/go-bindata/...
 	PATH="$(PATH):$(GOPATH)/bin" go-bindata -nomemcopy -o pkg/minikube/assets/assets.go -pkg assets deploy/addons/...
 

--- a/docs/contributors/adding_an_addon.md
+++ b/docs/contributors/adding_an_addon.md
@@ -32,18 +32,18 @@ To add a new addon to minikube the following steps are required:
   var Addons = map[string]*Addon{
     ...,
     // add other addon asset
-    "efk": NewAddon([]*BinDataAsset{
-      NewBinDataAsset(
+    "efk": NewAddon([]*BinAsset{
+      MustBinAsset(
         "deploy/addons/efk/efk-configmap.yaml",
         constants.AddonsPath,
         "efk-configmap.yaml",
         "0640"),
-      NewBinDataAsset(
+      MustBinAsset(
         "deploy/addons/efk/efk-rc.yaml",
         constants.AddonsPath,
         "efk-rc.yaml",
         "0640"),
-      NewBinDataAsset(
+      MustBinAsset(
         "deploy/addons/efk/efk-svc.yaml",
         constants.AddonsPath,
         "efk-svc.yaml",

--- a/pkg/gvisor/enable.go
+++ b/pkg/gvisor/enable.go
@@ -171,7 +171,7 @@ func copyConfigFiles() error {
 }
 
 func copyAssetToDest(targetName, dest string) error {
-	var asset *assets.BinDataAsset
+	var asset *assets.BinAsset
 	for _, a := range assets.Addons["gvisor"].Assets {
 		if a.GetTargetName() == targetName {
 			asset = a

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -31,13 +31,13 @@ import (
 
 // Addon is a named list of assets, that can be enabled
 type Addon struct {
-	Assets    []*BinDataAsset
+	Assets    []*BinAsset
 	enabled   bool
 	addonName string
 }
 
 // NewAddon creates a new Addon
-func NewAddon(assets []*BinDataAsset, enabled bool, addonName string) *Addon {
+func NewAddon(assets []*BinAsset, enabled bool, addonName string) *Addon {
 	a := &Addon{
 		Assets:    assets,
 		enabled:   enabled,
@@ -61,260 +61,260 @@ func (a *Addon) IsEnabled() (bool, error) {
 
 // Addons is the list of addons
 var Addons = map[string]*Addon{
-	"addon-manager": NewAddon([]*BinDataAsset{
-		NewBinDataAsset(
+	"addon-manager": NewAddon([]*BinAsset{
+		MustBinAsset(
 			"deploy/addons/addon-manager.yaml",
 			"/etc/kubernetes/manifests/",
 			"addon-manager.yaml",
 			"0640",
 			true),
 	}, true, "addon-manager"),
-	"dashboard": NewAddon([]*BinDataAsset{
-		NewBinDataAsset(
+	"dashboard": NewAddon([]*BinAsset{
+		MustBinAsset(
 			"deploy/addons/dashboard/dashboard-dp.yaml",
 			constants.AddonsPath,
 			"dashboard-dp.yaml",
 			"0640",
 			true),
-		NewBinDataAsset(
+		MustBinAsset(
 			"deploy/addons/dashboard/dashboard-svc.yaml",
 			constants.AddonsPath,
 			"dashboard-svc.yaml",
 			"0640",
 			false),
 	}, false, "dashboard"),
-	"default-storageclass": NewAddon([]*BinDataAsset{
-		NewBinDataAsset(
+	"default-storageclass": NewAddon([]*BinAsset{
+		MustBinAsset(
 			"deploy/addons/storageclass/storageclass.yaml",
 			constants.AddonsPath,
 			"storageclass.yaml",
 			"0640",
 			false),
 	}, true, "default-storageclass"),
-	"storage-provisioner": NewAddon([]*BinDataAsset{
-		NewBinDataAsset(
+	"storage-provisioner": NewAddon([]*BinAsset{
+		MustBinAsset(
 			"deploy/addons/storage-provisioner/storage-provisioner.yaml",
 			constants.AddonsPath,
 			"storage-provisioner.yaml",
 			"0640",
 			true),
 	}, true, "storage-provisioner"),
-	"storage-provisioner-gluster": NewAddon([]*BinDataAsset{
-		NewBinDataAsset(
+	"storage-provisioner-gluster": NewAddon([]*BinAsset{
+		MustBinAsset(
 			"deploy/addons/storage-provisioner-gluster/storage-gluster-ns.yaml",
 			constants.AddonsPath,
 			"storage-gluster-ns.yaml",
 			"0640",
 			false),
-		NewBinDataAsset(
+		MustBinAsset(
 			"deploy/addons/storage-provisioner-gluster/glusterfs-daemonset.yaml",
 			constants.AddonsPath,
 			"glusterfs-daemonset.yaml",
 			"0640",
 			false),
-		NewBinDataAsset(
+		MustBinAsset(
 			"deploy/addons/storage-provisioner-gluster/heketi-deployment.yaml",
 			constants.AddonsPath,
 			"heketi-deployment.yaml",
 			"0640",
 			false),
-		NewBinDataAsset(
+		MustBinAsset(
 			"deploy/addons/storage-provisioner-gluster/storage-provisioner-glusterfile.yaml",
 			constants.AddonsPath,
 			"storage-privisioner-glusterfile.yaml",
 			"0640",
 			false),
 	}, false, "storage-provisioner-gluster"),
-	"heapster": NewAddon([]*BinDataAsset{
-		NewBinDataAsset(
+	"heapster": NewAddon([]*BinAsset{
+		MustBinAsset(
 			"deploy/addons/heapster/influx-grafana-rc.yaml",
 			constants.AddonsPath,
 			"influxGrafana-rc.yaml",
 			"0640",
 			true),
-		NewBinDataAsset(
+		MustBinAsset(
 			"deploy/addons/heapster/grafana-svc.yaml",
 			constants.AddonsPath,
 			"grafana-svc.yaml",
 			"0640",
 			false),
-		NewBinDataAsset(
+		MustBinAsset(
 			"deploy/addons/heapster/influxdb-svc.yaml",
 			constants.AddonsPath,
 			"influxdb-svc.yaml",
 			"0640",
 			false),
-		NewBinDataAsset(
+		MustBinAsset(
 			"deploy/addons/heapster/heapster-rc.yaml",
 			constants.AddonsPath,
 			"heapster-rc.yaml",
 			"0640",
 			true),
-		NewBinDataAsset(
+		MustBinAsset(
 			"deploy/addons/heapster/heapster-svc.yaml",
 			constants.AddonsPath,
 			"heapster-svc.yaml",
 			"0640",
 			false),
 	}, false, "heapster"),
-	"efk": NewAddon([]*BinDataAsset{
-		NewBinDataAsset(
+	"efk": NewAddon([]*BinAsset{
+		MustBinAsset(
 			"deploy/addons/efk/elasticsearch-rc.yaml",
 			constants.AddonsPath,
 			"elasticsearch-rc.yaml",
 			"0640",
 			true),
-		NewBinDataAsset(
+		MustBinAsset(
 			"deploy/addons/efk/elasticsearch-svc.yaml",
 			constants.AddonsPath,
 			"elasticsearch-svc.yaml",
 			"0640",
 			false),
-		NewBinDataAsset(
+		MustBinAsset(
 			"deploy/addons/efk/fluentd-es-rc.yaml",
 			constants.AddonsPath,
 			"fluentd-es-rc.yaml",
 			"0640",
 			true),
-		NewBinDataAsset(
+		MustBinAsset(
 			"deploy/addons/efk/fluentd-es-configmap.yaml",
 			constants.AddonsPath,
 			"fluentd-es-configmap.yaml",
 			"0640",
 			false),
-		NewBinDataAsset(
+		MustBinAsset(
 			"deploy/addons/efk/kibana-rc.yaml",
 			constants.AddonsPath,
 			"kibana-rc.yaml",
 			"0640",
 			false),
-		NewBinDataAsset(
+		MustBinAsset(
 			"deploy/addons/efk/kibana-svc.yaml",
 			constants.AddonsPath,
 			"kibana-svc.yaml",
 			"0640",
 			false),
 	}, false, "efk"),
-	"ingress": NewAddon([]*BinDataAsset{
-		NewBinDataAsset(
+	"ingress": NewAddon([]*BinAsset{
+		MustBinAsset(
 			"deploy/addons/ingress/ingress-configmap.yaml",
 			constants.AddonsPath,
 			"ingress-configmap.yaml",
 			"0640",
 			false),
-		NewBinDataAsset(
+		MustBinAsset(
 			"deploy/addons/ingress/ingress-rbac.yaml",
 			constants.AddonsPath,
 			"ingress-rbac.yaml",
 			"0640",
 			false),
-		NewBinDataAsset(
+		MustBinAsset(
 			"deploy/addons/ingress/ingress-dp.yaml",
 			constants.AddonsPath,
 			"ingress-dp.yaml",
 			"0640",
 			true),
-		NewBinDataAsset(
+		MustBinAsset(
 			"deploy/addons/ingress/ingress-svc.yaml",
 			constants.AddonsPath,
 			"ingress-svc.yaml",
 			"0640",
 			false),
 	}, false, "ingress"),
-	"metrics-server": NewAddon([]*BinDataAsset{
-		NewBinDataAsset(
+	"metrics-server": NewAddon([]*BinAsset{
+		MustBinAsset(
 			"deploy/addons/metrics-server/metrics-apiservice.yaml",
 			constants.AddonsPath,
 			"metrics-apiservice.yaml",
 			"0640",
 			false),
-		NewBinDataAsset(
+		MustBinAsset(
 			"deploy/addons/metrics-server/metrics-server-deployment.yaml",
 			constants.AddonsPath,
 			"metrics-server-deployment.yaml",
 			"0640",
 			true),
-		NewBinDataAsset(
+		MustBinAsset(
 			"deploy/addons/metrics-server/metrics-server-service.yaml",
 			constants.AddonsPath,
 			"metrics-server-service.yaml",
 			"0640",
 			false),
 	}, false, "metrics-server"),
-	"registry": NewAddon([]*BinDataAsset{
-		NewBinDataAsset(
+	"registry": NewAddon([]*BinAsset{
+		MustBinAsset(
 			"deploy/addons/registry/registry-rc.yaml",
 			constants.AddonsPath,
 			"registry-rc.yaml",
 			"0640",
 			false),
-		NewBinDataAsset(
+		MustBinAsset(
 			"deploy/addons/registry/registry-svc.yaml",
 			constants.AddonsPath,
 			"registry-svc.yaml",
 			"0640",
 			false),
 	}, false, "registry"),
-	"registry-creds": NewAddon([]*BinDataAsset{
-		NewBinDataAsset(
+	"registry-creds": NewAddon([]*BinAsset{
+		MustBinAsset(
 			"deploy/addons/registry-creds/registry-creds-rc.yaml",
 			constants.AddonsPath,
 			"registry-creds-rc.yaml",
 			"0640",
 			false),
 	}, false, "registry-creds"),
-	"freshpod": NewAddon([]*BinDataAsset{
-		NewBinDataAsset(
+	"freshpod": NewAddon([]*BinAsset{
+		MustBinAsset(
 			"deploy/addons/freshpod/freshpod-rc.yaml",
 			constants.AddonsPath,
 			"freshpod-rc.yaml",
 			"0640",
 			true),
 	}, false, "freshpod"),
-	"nvidia-driver-installer": NewAddon([]*BinDataAsset{
-		NewBinDataAsset(
+	"nvidia-driver-installer": NewAddon([]*BinAsset{
+		MustBinAsset(
 			"deploy/addons/gpu/nvidia-driver-installer.yaml",
 			constants.AddonsPath,
 			"nvidia-driver-installer.yaml",
 			"0640",
 			true),
 	}, false, "nvidia-driver-installer"),
-	"nvidia-gpu-device-plugin": NewAddon([]*BinDataAsset{
-		NewBinDataAsset(
+	"nvidia-gpu-device-plugin": NewAddon([]*BinAsset{
+		MustBinAsset(
 			"deploy/addons/gpu/nvidia-gpu-device-plugin.yaml",
 			constants.AddonsPath,
 			"nvidia-gpu-device-plugin.yaml",
 			"0640",
 			true),
 	}, false, "nvidia-gpu-device-plugin"),
-	"logviewer": NewAddon([]*BinDataAsset{
-		NewBinDataAsset(
+	"logviewer": NewAddon([]*BinAsset{
+		MustBinAsset(
 			"deploy/addons/logviewer/logviewer-dp-and-svc.yaml",
 			constants.AddonsPath,
 			"logviewer-dp-and-svc.yaml",
 			"0640",
 			false),
-		NewBinDataAsset(
+		MustBinAsset(
 			"deploy/addons/logviewer/logviewer-rbac.yaml",
 			constants.AddonsPath,
 			"logviewer-rbac.yaml",
 			"0640",
 			false),
 	}, false, "logviewer"),
-	"gvisor": NewAddon([]*BinDataAsset{
-		NewBinDataAsset(
+	"gvisor": NewAddon([]*BinAsset{
+		MustBinAsset(
 			"deploy/addons/gvisor/gvisor-pod.yaml",
 			constants.AddonsPath,
 			"gvisor-pod.yaml",
 			"0640",
 			true),
-		NewBinDataAsset(
+		MustBinAsset(
 			"deploy/addons/gvisor/gvisor-config.toml",
 			constants.GvisorFilesPath,
 			constants.GvisorConfigTomlTargetName,
 			"0640",
 			true),
-		NewBinDataAsset(
+		MustBinAsset(
 			"deploy/addons/gvisor/gvisor-containerd-shim.toml",
 			constants.GvisorFilesPath,
 			constants.GvisorContainerdShimTargetName,

--- a/pkg/minikube/assets/vm_assets.go
+++ b/pkg/minikube/assets/vm_assets.go
@@ -18,11 +18,13 @@ package assets
 
 import (
 	"bytes"
+	"fmt"
 	"html/template"
 	"io"
 	"os"
 	"path"
 
+	"github.com/golang/glog"
 	"github.com/pkg/errors"
 )
 
@@ -197,6 +199,10 @@ func (m *BinDataAsset) loadData(isTemplate bool) error {
 	m.data = contents
 	m.Length = len(contents)
 	m.reader = bytes.NewReader(m.data)
+	glog.Infof("Created asset %s with %d bytes", m.AssetName, m.Length)
+	if m.Length == 0 {
+		return fmt.Errorf("%s is an empty asset", m.AssetName)
+	}
 	return nil
 }
 
@@ -227,5 +233,8 @@ func (m *BinDataAsset) GetLength() int {
 
 // Read reads the asset
 func (m *BinDataAsset) Read(p []byte) (int, error) {
+	if m.Length == 0 {
+		return 0, fmt.Errorf("attempted read from a 0 length asset")
+	}
 	return m.reader.Read(p)
 }

--- a/pkg/minikube/assets/vm_assets.go
+++ b/pkg/minikube/assets/vm_assets.go
@@ -149,25 +149,34 @@ func NewMemoryAsset(d []byte, targetDir, targetName, permissions string) *Memory
 	return m
 }
 
-// BinDataAsset is a bindata (binary data) asset
-type BinDataAsset struct {
+// BinAsset is a bindata (binary data) asset
+type BinAsset struct {
 	BaseAsset
 	template *template.Template
 }
 
-// NewBinDataAsset creates a new BinDataAsset
-func NewBinDataAsset(assetName, targetDir, targetName, permissions string, isTemplate bool) *BinDataAsset {
-	m := &BinDataAsset{
+// MustBinAsset creates a new BinAsset, or panics if invalid
+func MustBinAsset(name, targetDir, targetName, permissions string, isTemplate bool) *BinAsset {
+	asset, err := NewBinAsset(name, targetDir, targetName, permissions, isTemplate)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to define asset %s: %v", name, err))
+	}
+	return asset
+}
+
+// NewBinAsset creates a new BinAsset
+func NewBinAsset(name, targetDir, targetName, permissions string, isTemplate bool) (*BinAsset, error) {
+	m := &BinAsset{
 		BaseAsset: BaseAsset{
-			AssetName:   assetName,
+			AssetName:   name,
 			TargetDir:   targetDir,
 			TargetName:  targetName,
 			Permissions: permissions,
 		},
 		template: nil,
 	}
-	m.loadData(isTemplate)
-	return m
+	err := m.loadData(isTemplate)
+	return m, err
 }
 
 func defaultValue(defValue string, val interface{}) string {
@@ -181,7 +190,7 @@ func defaultValue(defValue string, val interface{}) string {
 	return strVal
 }
 
-func (m *BinDataAsset) loadData(isTemplate bool) error {
+func (m *BinAsset) loadData(isTemplate bool) error {
 	contents, err := Asset(m.AssetName)
 	if err != nil {
 		return err
@@ -207,12 +216,12 @@ func (m *BinDataAsset) loadData(isTemplate bool) error {
 }
 
 // IsTemplate returns if the asset is a template
-func (m *BinDataAsset) IsTemplate() bool {
+func (m *BinAsset) IsTemplate() bool {
 	return m.template != nil
 }
 
 // Evaluate evaluates the template to a new asset
-func (m *BinDataAsset) Evaluate(data interface{}) (*MemoryAsset, error) {
+func (m *BinAsset) Evaluate(data interface{}) (*MemoryAsset, error) {
 	if !m.IsTemplate() {
 		return nil, errors.Errorf("the asset %s is not a template", m.AssetName)
 
@@ -227,12 +236,12 @@ func (m *BinDataAsset) Evaluate(data interface{}) (*MemoryAsset, error) {
 }
 
 // GetLength returns length
-func (m *BinDataAsset) GetLength() int {
+func (m *BinAsset) GetLength() int {
 	return m.Length
 }
 
 // Read reads the asset
-func (m *BinDataAsset) Read(p []byte) (int, error) {
+func (m *BinAsset) Read(p []byte) (int, error) {
 	if m.Length == 0 {
 		return 0, fmt.Errorf("attempted read from a 0 length asset")
 	}


### PR DESCRIPTION
Instead of an obscure runtime read panic, minikube will now panic on initialization if it has been compiled with invalid assets:

```
panic: Failed to define asset deploy/addons/addon-manager.yaml: Asset deploy/addons/addon-manager.yaml not found
```
or:

```
panic: Failed to define asset deploy/addons/addon-manager.yaml: deploy/addons/addon-manager.yaml is an empty asset
````

Closes #3555 
