### PR TITLE
Document overrides to the crio.conf

### DIFF
--- a/deploy/iso/minikube-iso/package/crio-bin/crio.conf
+++ b/deploy/iso/minikube-iso/package/crio-bin/crio.conf
@@ -25,7 +25,6 @@ storage_driver = "overlay"
 # List to pass options to the storage driver. Please refer to
 # containers-storage.conf(5) to see all available storage options.
 #storage_option = [
-#	"overlay.override_kernel_check=true",
 #]
 
 # If set to false, in-memory locking will be used instead of file-based locking.
@@ -64,6 +63,12 @@ stream_tls_key = ""
 # automatically pick up the changes within 5 minutes.
 stream_tls_ca = ""
 
+# Maximum grpc send message size in bytes. If not set or <=0, then CRI-O will default to 16 * 1024 * 1024.
+grpc_max_send_msg_size = 16777216
+
+# Maximum grpc receive message size. If not set or <= 0, then CRI-O will default to 16 * 1024 * 1024.
+grpc_max_recv_msg_size = 16777216
+
 # The crio.runtime table contains settings pertaining to the OCI runtime used
 # and options for how to set up and manage the OCI runtime.
 [crio.runtime]
@@ -75,55 +80,9 @@ stream_tls_ca = ""
 #default_ulimits = [
 #]
 
-# Path to the OCI compatible runtime used for trusted container workloads. This
-# is a mandatory setting as this runtime will be the default and will also be
-# used for untrusted container workloads if runtime_untrusted_workload is not
-# set.
-#
-# DEPRECATED: use Runtimes instead.
-#
-# runtime = ""
-
 # default_runtime is the _name_ of the OCI runtime to be used as the default.
 # The name is matched against the runtimes map below.
 default_runtime = "runc"
-
-# Path to OCI compatible runtime used for untrusted container workloads. This
-# is an optional setting, except if default_container_trust is set to
-# "untrusted".
-# DEPRECATED: use "crio.runtime.runtimes" instead. If provided, this
-#     runtime is mapped to the runtime handler named 'untrusted'. It is
-#     a configuration error to provide both the (now deprecated)
-#     runtime_untrusted_workload and a handler in the Runtimes handler
-#     map (below) for 'untrusted' workloads at the same time. Please
-#     provide one or the other.
-#     The support of this option will continue through versions 1.12 and 1.13.
-#     By version 1.14, this option will no longer exist.
-#runtime_untrusted_workload = ""
-
-# Default level of trust CRI-O puts in container workloads. It can either be
-# "trusted" or "untrusted", and the default is "trusted". Containers can be run
-# through different container runtimes, depending on the trust hints we receive
-# from kubelet:
-#
-#   - If kubelet tags a container workload as untrusted, CRI-O will try first
-#     to run it through the untrusted container workload runtime. If it is not
-#     set, CRI-O will use the trusted runtime.
-#
-#   - If kubelet does not provide any information about the container workload
-#     trust level, the selected runtime will depend on the default_container_trust
-#     setting. If it is set to untrusted, then all containers except for the host
-#     privileged ones, will be run by the runtime_untrusted_workload runtime. Host
-#     privileged containers are by definition trusted and will always use the
-#     trusted container runtime. If default_container_trust is set to "trusted",
-#     CRI-O will use the trusted container runtime for all containers.
-#
-# DEPRECATED: The runtime handler should provide a key to the map of runtimes,
-#     avoiding the need to rely on the level of trust of the workload to choose
-#     an appropriate runtime.
-#     The support of this option will continue through versions 1.12 and 1.13.
-#     By version 1.14, this option will no longer exist.
-#default_workload_trust = ""
 
 # If true, the runtime will not use pivot_root, but instead use MS_MOVE.
 no_pivot = true
@@ -213,6 +172,9 @@ pids_limit = 1024
 # limit is never exceeded.
 log_size_max = -1
 
+# Whether container output should be logged to journald in addition to the kuberentes log file
+log_to_journald = false
+
 # Path to directory in which container exit files are written to by conmon.
 container_exits_dir = "/var/run/crio/exits"
 
@@ -247,6 +209,7 @@ ctr_stop_timeout = 0
   
   [crio.runtime.runtimes.runc]
   runtime_path = "/usr/bin/runc"
+  runtime_type = "oci"
   
 
 
@@ -254,7 +217,7 @@ ctr_stop_timeout = 0
 #
 # CRI-O reads its configured registries defaults from the system wide
 # containers-registries.conf(5) located in /etc/containers/registries.conf. If
-# you want to modify just CRI-O, you can change the registies configuration in
+# you want to modify just CRI-O, you can change the registries configuration in
 # this file. Otherwise, leave insecure_registries and registries commented out to
 # use the system's defaults from /etc/containers/registries.conf.
 [crio.image]
@@ -264,6 +227,10 @@ default_transport = "docker://"
 
 # The image used to instantiate infra containers.
 pause_image = "k8s.gcr.io/pause:3.1"
+
+# If not empty, the path to a docker/config.json-like file containing credentials
+# necessary for pulling the image specified by pause_image above.
+pause_image_auth_file = ""
 
 # The command to run to have a container stay in the paused state.
 pause_command = "/pause"
@@ -296,5 +263,7 @@ registries = [
 # Path to the directory where CNI configuration files are located.
 network_dir = "/etc/cni/net.d/"
 
-# Path to directory where CNI plugin binaries are located.
-plugin_dir = "/opt/cni/bin/"
+# Paths to directories where CNI plugin binaries are located.
+plugin_dir = [
+	"/opt/cni/bin/",
+]

--- a/deploy/iso/minikube-iso/package/crio-bin/crio.conf
+++ b/deploy/iso/minikube-iso/package/crio-bin/crio.conf
@@ -173,8 +173,16 @@ default_capabilities = [
 default_sysctls = [
 ]
 
-# Path to the OCI hooks directory for automatically executed hooks.
-hooks_dir_path = "/usr/share/containers/oci/hooks.d"
+# List of additional devices. specified as
+# "<device-on-host>:<device-on-container>:<permissions>", for example: "--device=/dev/sdc:/dev/xvdc:rwm".
+#If it is empty or commented out, only the devices
+# defined in the container json file by the user/kube will be added.
+additional_devices = [
+]
+
+# Path to OCI hooks directories for automatically executed hooks.
+hooks_dir = [
+]
 
 # List of default mounts for each container. **Deprecated:** this option will
 # be removed in future versions in favor of default_mounts_file.

--- a/deploy/iso/minikube-iso/package/crio-bin/crio.conf
+++ b/deploy/iso/minikube-iso/package/crio-bin/crio.conf
@@ -1,157 +1,292 @@
 
-# The "crio" table contains all of the server options.
+# The CRI-O configuration file specifies all of the available configuration
+# options and command-line flags for the crio(8) OCI Kubernetes Container Runtime
+# daemon, but in a TOML format that can be more easily modified and versioned.
+#
+# Please refer to crio.conf(5) for details of all configuration options.
+
+# CRI-O reads its storage defaults from the containers-storage.conf(5) file
+# located at /etc/containers/storage.conf. Modify this storage configuration if
+# you want to change the system's defaults. If you want to modify storage just
+# for CRI-O, you can change the storage configuration options here.
 [crio]
 
-# root is a path to the "root directory". CRIO stores all of its data,
-# including container images, in this directory.
+# Path to the "root directory". CRI-O stores all of its data, including
+# containers images, in this directory.
 root = "/var/lib/containers/storage"
 
-# run is a path to the "run directory". CRIO stores all of its state
-# in this directory.
+# Path to the "run directory". CRI-O stores all of its state in this directory.
 runroot = "/var/run/containers/storage"
 
-# storage_driver select which storage driver is used to manage storage
-# of images and containers.
+# Storage driver used to manage the storage of images and containers. Please
+# refer to containers-storage.conf(5) to see all available storage drivers.
 storage_driver = "overlay"
 
-# storage_option is used to pass an option to the storage driver.
-storage_option = [
-]
+# List to pass options to the storage driver. Please refer to
+# containers-storage.conf(5) to see all available storage options.
+#storage_option = [
+#	"overlay.override_kernel_check=true",
+#]
 
-# The "crio.api" table contains settings for the kubelet/gRPC interface.
-[crio.api]
-
-# listen is the path to the AF_LOCAL socket on which crio will listen.
-listen = "/var/run/crio/crio.sock"
-
-# stream_address is the IP address on which the stream server will listen
-stream_address = ""
-
-# stream_port is the port on which the stream server will listen
-stream_port = "10010"
-
-# file_locking is whether file-based locking will be used instead of
-# in-memory locking
+# If set to false, in-memory locking will be used instead of file-based locking.
 file_locking = true
 
-# The "crio.runtime" table contains settings pertaining to the OCI
-# runtime used and options for how to set up and manage the OCI runtime.
+# Path to the lock file.
+file_locking_path = "/run/crio.lock"
+
+
+# The crio.api table contains settings for the kubelet/gRPC interface.
+[crio.api]
+
+# Path to AF_LOCAL socket on which CRI-O will listen.
+listen = "/var/run/crio/crio.sock"
+
+# IP address on which the stream server will listen.
+stream_address = "127.0.0.1"
+
+# The port on which the stream server will listen.
+stream_port = "0"
+
+# Enable encrypted TLS transport of the stream server.
+stream_enable_tls = false
+
+# Path to the x509 certificate file used to serve the encrypted stream. This
+# file can change, and CRI-O will automatically pick up the changes within 5
+# minutes.
+stream_tls_cert = ""
+
+# Path to the key file used to serve the encrypted stream. This file can
+# change, and CRI-O will automatically pick up the changes within 5 minutes.
+stream_tls_key = ""
+
+# Path to the x509 CA(s) file used to verify and authenticate client
+# communication with the encrypted stream. This file can change, and CRI-O will
+# automatically pick up the changes within 5 minutes.
+stream_tls_ca = ""
+
+# The crio.runtime table contains settings pertaining to the OCI runtime used
+# and options for how to set up and manage the OCI runtime.
 [crio.runtime]
 
-# runtime is the OCI compatible runtime used for trusted container workloads.
-# This is a mandatory setting as this runtime will be the default one
-# and will also be used for untrusted container workloads if
-# runtime_untrusted_workload is not set.
-runtime = "/usr/bin/runc"
+# A list of ulimits to be set in containers by default, specified as
+# "<ulimit name>=<soft limit>:<hard limit>", for example:
+# "nofile=1024:2048"
+# If nothing is set here, settings will be inherited from the CRI-O daemon
+#default_ulimits = [
+#]
 
-# runtime_untrusted_workload is the OCI compatible runtime used for untrusted
-# container workloads. This is an optional setting, except if
-# default_container_trust is set to "untrusted".
-runtime_untrusted_workload = ""
+# Path to the OCI compatible runtime used for trusted container workloads. This
+# is a mandatory setting as this runtime will be the default and will also be
+# used for untrusted container workloads if runtime_untrusted_workload is not
+# set.
+#
+# DEPRECATED: use Runtimes instead.
+#
+# runtime = ""
 
-# default_workload_trust is the default level of trust crio puts in container
-# workloads. It can either be "trusted" or "untrusted", and the default
-# is "trusted".
-# Containers can be run through different container runtimes, depending on
-# the trust hints we receive from kubelet:
-# - If kubelet tags a container workload as untrusted, crio will try first to
-# run it through the untrusted container workload runtime. If it is not set,
-# crio will use the trusted runtime.
-# - If kubelet does not provide any information about the container workload trust
-# level, the selected runtime will depend on the default_container_trust setting.
-# If it is set to "untrusted", then all containers except for the host privileged
-# ones, will be run by the runtime_untrusted_workload runtime. Host privileged
-# containers are by definition trusted and will always use the trusted container
-# runtime. If default_container_trust is set to "trusted", crio will use the trusted
-# container runtime for all containers.
-default_workload_trust = "trusted"
+# default_runtime is the _name_ of the OCI runtime to be used as the default.
+# The name is matched against the runtimes map below.
+default_runtime = "runc"
 
-# no_pivot instructs the runtime to not use pivot_root, but instead use MS_MOVE
+# Path to OCI compatible runtime used for untrusted container workloads. This
+# is an optional setting, except if default_container_trust is set to
+# "untrusted".
+# DEPRECATED: use "crio.runtime.runtimes" instead. If provided, this
+#     runtime is mapped to the runtime handler named 'untrusted'. It is
+#     a configuration error to provide both the (now deprecated)
+#     runtime_untrusted_workload and a handler in the Runtimes handler
+#     map (below) for 'untrusted' workloads at the same time. Please
+#     provide one or the other.
+#     The support of this option will continue through versions 1.12 and 1.13.
+#     By version 1.14, this option will no longer exist.
+#runtime_untrusted_workload = ""
+
+# Default level of trust CRI-O puts in container workloads. It can either be
+# "trusted" or "untrusted", and the default is "trusted". Containers can be run
+# through different container runtimes, depending on the trust hints we receive
+# from kubelet:
+#
+#   - If kubelet tags a container workload as untrusted, CRI-O will try first
+#     to run it through the untrusted container workload runtime. If it is not
+#     set, CRI-O will use the trusted runtime.
+#
+#   - If kubelet does not provide any information about the container workload
+#     trust level, the selected runtime will depend on the default_container_trust
+#     setting. If it is set to untrusted, then all containers except for the host
+#     privileged ones, will be run by the runtime_untrusted_workload runtime. Host
+#     privileged containers are by definition trusted and will always use the
+#     trusted container runtime. If default_container_trust is set to "trusted",
+#     CRI-O will use the trusted container runtime for all containers.
+#
+# DEPRECATED: The runtime handler should provide a key to the map of runtimes,
+#     avoiding the need to rely on the level of trust of the workload to choose
+#     an appropriate runtime.
+#     The support of this option will continue through versions 1.12 and 1.13.
+#     By version 1.14, this option will no longer exist.
+#default_workload_trust = ""
+
+# If true, the runtime will not use pivot_root, but instead use MS_MOVE.
 no_pivot = true
 
-# conmon is the path to conmon binary, used for managing the runtime.
+# Path to the conmon binary, used for monitoring the OCI runtime.
 conmon = "/usr/libexec/crio/conmon"
 
-# conmon_env is the environment variable list for conmon process,
-# used for passing necessary environment variable to conmon or runtime.
+# Environment variable list for the conmon process, used for passing necessary
+# environment variables to conmon or the runtime.
 conmon_env = [
 	"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 ]
 
-# selinux indicates whether or not SELinux will be used for pod
-# separation on the host. If you enable this flag, SELinux must be running
-# on the host.
+# If true, SELinux will be used for pod separation on the host.
 selinux = false
 
-# seccomp_profile is the seccomp json profile path which is used as the
-# default for the runtime.
+# Path to the seccomp.json profile which is used as the default seccomp profile
+# for the runtime.
 seccomp_profile = "/etc/crio/seccomp.json"
 
-# apparmor_profile is the apparmor profile name which is used as the
-# default for the runtime.
+# Used to change the name of the default AppArmor profile of CRI-O. The default
+# profile name is "crio-default-" followed by the version string of CRI-O.
 apparmor_profile = "crio-default"
 
-# cgroup_manager is the cgroup management implementation to be used
-# for the runtime.
+# Cgroup management implementation used for the runtime.
 cgroup_manager = "cgroupfs"
 
-# hooks_dir_path is the oci hooks directory for automatically executed hooks
+# List of default capabilities for containers. If it is empty or commented out,
+# only the capabilities defined in the containers json file by the user/kube
+# will be added.
+default_capabilities = [
+	"CHOWN", 
+	"DAC_OVERRIDE", 
+	"FSETID", 
+	"FOWNER", 
+	"NET_RAW", 
+	"SETGID", 
+	"SETUID", 
+	"SETPCAP", 
+	"NET_BIND_SERVICE", 
+	"SYS_CHROOT", 
+	"KILL", 
+]
+
+# List of default sysctls. If it is empty or commented out, only the sysctls
+# defined in the container json file by the user/kube will be added.
+default_sysctls = [
+]
+
+# Path to the OCI hooks directory for automatically executed hooks.
 hooks_dir_path = "/usr/share/containers/oci/hooks.d"
 
-# default_mounts is the mounts list to be mounted for the container when created
+# List of default mounts for each container. **Deprecated:** this option will
+# be removed in future versions in favor of default_mounts_file.
 default_mounts = [
 ]
 
-# pids_limit is the number of processes allowed in a container
+# Path to the file specifying the defaults mounts for each container. The
+# format of the config is /SRC:/DST, one mount per line. Notice that CRI-O reads
+# its default mounts from the following two files:
+#
+#   1) /etc/containers/mounts.conf (i.e., default_mounts_file): This is the
+#      override file, where users can either add in their own default mounts, or
+#      override the default mounts shipped with the package.
+#
+#   2) /usr/share/containers/mounts.conf: This is the default file read for
+#      mounts. If you want CRI-O to read from a different, specific mounts file,
+#      you can change the default_mounts_file. Note, if this is done, CRI-O will
+#      only add mounts it finds in this file.
+#
+#default_mounts_file = ""
+
+# Maximum number of processes allowed in a container.
 pids_limit = 1024
 
-# log_size_max is the max limit for the container log size in bytes.
-# Negative values indicate that no limit is imposed.
+# Maximum sized allowed for the container log file. Negative numbers indicate
+# that no size limit is imposed. If it is positive, it must be >= 8192 to
+# match/exceed conmon's read buffer. The file is truncated and re-opened so the
+# limit is never exceeded.
 log_size_max = -1
 
-# The "crio.image" table contains settings pertaining to the
-# management of OCI images.
+# Path to directory in which container exit files are written to by conmon.
+container_exits_dir = "/var/run/crio/exits"
+
+# Path to directory for container attach sockets.
+container_attach_socket_dir = "/var/run/crio"
+
+# If set to true, all containers will run in read-only mode.
+read_only = false
+
+# Changes the verbosity of the logs based on the level it is set to. Options
+# are fatal, panic, error, warn, info, and debug.
+log_level = "error"
+
+# The UID mappings for the user namespace of each container. A range is
+# specified in the form containerUID:HostUID:Size. Multiple ranges must be
+# separated by comma.
+uid_mappings = ""
+
+# The GID mappings for the user namespace of each container. A range is
+# specified in the form containerGID:HostGID:Size. Multiple ranges must be
+# separated by comma.
+gid_mappings = ""
+
+# The minimal amount of time in seconds to wait before issuing a timeout
+# regarding the proper termination of the container.
+ctr_stop_timeout = 0
+
+  # The "crio.runtime.runtimes" table defines a list of OCI compatible runtimes.
+  # The runtime to use is picked based on the runtime_handler provided by the CRI.
+  # If no runtime_handler is provided, the runtime will be picked based on the level
+  # of trust of the workload.
+  
+  [crio.runtime.runtimes.runc]
+  runtime_path = "/usr/bin/runc"
+  
+
+
+# The crio.image table contains settings pertaining to the management of OCI images.
+#
+# CRI-O reads its configured registries defaults from the system wide
+# containers-registries.conf(5) located in /etc/containers/registries.conf. If
+# you want to modify just CRI-O, you can change the registies configuration in
+# this file. Otherwise, leave insecure_registries and registries commented out to
+# use the system's defaults from /etc/containers/registries.conf.
 [crio.image]
 
-# default_transport is the prefix we try prepending to an image name if the
-# image name as we receive it can't be parsed as a valid source reference
+# Default transport for pulling images from a remote container storage.
 default_transport = "docker://"
 
-# pause_image is the image which we use to instantiate infra containers.
+# The image used to instantiate infra containers.
 pause_image = "k8s.gcr.io/pause:3.1"
 
-# pause_command is the command to run in a pause_image to have a container just
-# sit there.  If the image contains the necessary information, this value need
-# not be specified.
+# The command to run to have a container stay in the paused state.
 pause_command = "/pause"
 
-# signature_policy is the name of the file which decides what sort of policy we
-# use when deciding whether or not to trust an image that we've pulled.
-# Outside of testing situations, it is strongly advised that this be left
-# unspecified so that the default system-wide policy will be used.
+# Path to the file which decides what sort of policy we use when deciding
+# whether or not to trust an image that we've pulled. It is not recommended that
+# this option be used, as the default behavior of using the system-wide default
+# policy (i.e., /etc/containers/policy.json) is most often preferred. Please
+# refer to containers-policy.json(5) for more details.
 signature_policy = ""
 
-# image_volumes controls how image volumes are handled.
-# The valid values are mkdir and ignore.
+# Controls how image volumes are handled. The valid values are mkdir, bind and
+# ignore; the latter will ignore volumes entirely.
 image_volumes = "mkdir"
 
-# insecure_registries is used to skip TLS verification when pulling images.
-insecure_registries = [
-]
-
-# registries is used to specify a comma separated list of registries to be used
-# when pulling an unqualified image (e.g. fedora:rawhide).
+# List of registries to be used when pulling an unqualified image (e.g.,
+# "alpine:latest"). By default, registries is set to "docker.io" for
+# compatibility reasons. Depending on your workload and usecase you may add more
+# registries (e.g., "quay.io", "registry.fedoraproject.org",
+# "registry.opensuse.org", etc.).
 registries = [
 	"docker.io"
 ]
 
-# The "crio.network" table contains settings pertaining to the
-# management of CNI plugins.
+
+# The crio.network table containers settings pertaining to the management of
+# CNI plugins.
 [crio.network]
 
-# network_dir is is where CNI network configuration
-# files are stored.
+# Path to the directory where CNI configuration files are located.
 network_dir = "/etc/cni/net.d/"
 
-# plugin_dir is is where CNI plugin binaries are stored.
+# Path to directory where CNI plugin binaries are located.
 plugin_dir = "/opt/cni/bin/"

--- a/deploy/iso/minikube-iso/package/crio-bin/crio.conf.default
+++ b/deploy/iso/minikube-iso/package/crio-bin/crio.conf.default
@@ -12,7 +12,7 @@ runroot = "/var/run/containers/storage"
 
 # storage_driver select which storage driver is used to manage storage
 # of images and containers.
-storage_driver = "overlay"
+storage_driver = ""
 
 # storage_option is used to pass an option to the storage driver.
 storage_option = [
@@ -67,10 +67,10 @@ runtime_untrusted_workload = ""
 default_workload_trust = "trusted"
 
 # no_pivot instructs the runtime to not use pivot_root, but instead use MS_MOVE
-no_pivot = true
+no_pivot = false
 
 # conmon is the path to conmon binary, used for managing the runtime.
-conmon = "/usr/libexec/crio/conmon"
+conmon = "/usr/local/libexec/crio/conmon"
 
 # conmon_env is the environment variable list for conmon process,
 # used for passing necessary environment variable to conmon or runtime.
@@ -118,7 +118,7 @@ log_size_max = -1
 default_transport = "docker://"
 
 # pause_image is the image which we use to instantiate infra containers.
-pause_image = "k8s.gcr.io/pause:3.1"
+pause_image = "kubernetes/pause"
 
 # pause_command is the command to run in a pause_image to have a container just
 # sit there.  If the image contains the necessary information, this value need
@@ -142,7 +142,6 @@ insecure_registries = [
 # registries is used to specify a comma separated list of registries to be used
 # when pulling an unqualified image (e.g. fedora:rawhide).
 registries = [
-	"docker.io"
 ]
 
 # The "crio.network" table contains settings pertaining to the

--- a/deploy/iso/minikube-iso/package/crio-bin/crio.conf.default
+++ b/deploy/iso/minikube-iso/package/crio-bin/crio.conf.default
@@ -1,156 +1,291 @@
 
-# The "crio" table contains all of the server options.
+# The CRI-O configuration file specifies all of the available configuration
+# options and command-line flags for the crio(8) OCI Kubernetes Container Runtime
+# daemon, but in a TOML format that can be more easily modified and versioned.
+#
+# Please refer to crio.conf(5) for details of all configuration options.
+
+# CRI-O reads its storage defaults from the containers-storage.conf(5) file
+# located at /etc/containers/storage.conf. Modify this storage configuration if
+# you want to change the system's defaults. If you want to modify storage just
+# for CRI-O, you can change the storage configuration options here.
 [crio]
 
-# root is a path to the "root directory". CRIO stores all of its data,
-# including container images, in this directory.
-root = "/var/lib/containers/storage"
+# Path to the "root directory". CRI-O stores all of its data, including
+# containers images, in this directory.
+#root = "/var/lib/containers/storage"
 
-# run is a path to the "run directory". CRIO stores all of its state
-# in this directory.
-runroot = "/var/run/containers/storage"
+# Path to the "run directory". CRI-O stores all of its state in this directory.
+#runroot = "/var/run/containers/storage"
 
-# storage_driver select which storage driver is used to manage storage
-# of images and containers.
-storage_driver = ""
+# Storage driver used to manage the storage of images and containers. Please
+# refer to containers-storage.conf(5) to see all available storage drivers.
+#storage_driver = "overlay"
 
-# storage_option is used to pass an option to the storage driver.
-storage_option = [
-]
+# List to pass options to the storage driver. Please refer to
+# containers-storage.conf(5) to see all available storage options.
+#storage_option = [
+#	"overlay.override_kernel_check=true",
+#]
 
-# The "crio.api" table contains settings for the kubelet/gRPC interface.
-[crio.api]
-
-# listen is the path to the AF_LOCAL socket on which crio will listen.
-listen = "/var/run/crio/crio.sock"
-
-# stream_address is the IP address on which the stream server will listen
-stream_address = ""
-
-# stream_port is the port on which the stream server will listen
-stream_port = "10010"
-
-# file_locking is whether file-based locking will be used instead of
-# in-memory locking
+# If set to false, in-memory locking will be used instead of file-based locking.
 file_locking = true
 
-# The "crio.runtime" table contains settings pertaining to the OCI
-# runtime used and options for how to set up and manage the OCI runtime.
+# Path to the lock file.
+file_locking_path = "/run/crio.lock"
+
+
+# The crio.api table contains settings for the kubelet/gRPC interface.
+[crio.api]
+
+# Path to AF_LOCAL socket on which CRI-O will listen.
+listen = "/var/run/crio/crio.sock"
+
+# IP address on which the stream server will listen.
+stream_address = "127.0.0.1"
+
+# The port on which the stream server will listen.
+stream_port = "0"
+
+# Enable encrypted TLS transport of the stream server.
+stream_enable_tls = false
+
+# Path to the x509 certificate file used to serve the encrypted stream. This
+# file can change, and CRI-O will automatically pick up the changes within 5
+# minutes.
+stream_tls_cert = ""
+
+# Path to the key file used to serve the encrypted stream. This file can
+# change, and CRI-O will automatically pick up the changes within 5 minutes.
+stream_tls_key = ""
+
+# Path to the x509 CA(s) file used to verify and authenticate client
+# communication with the encrypted stream. This file can change, and CRI-O will
+# automatically pick up the changes within 5 minutes.
+stream_tls_ca = ""
+
+# The crio.runtime table contains settings pertaining to the OCI runtime used
+# and options for how to set up and manage the OCI runtime.
 [crio.runtime]
 
-# runtime is the OCI compatible runtime used for trusted container workloads.
-# This is a mandatory setting as this runtime will be the default one
-# and will also be used for untrusted container workloads if
-# runtime_untrusted_workload is not set.
-runtime = "/usr/bin/runc"
+# A list of ulimits to be set in containers by default, specified as
+# "<ulimit name>=<soft limit>:<hard limit>", for example:
+# "nofile=1024:2048"
+# If nothing is set here, settings will be inherited from the CRI-O daemon
+#default_ulimits = [
+#]
 
-# runtime_untrusted_workload is the OCI compatible runtime used for untrusted
-# container workloads. This is an optional setting, except if
-# default_container_trust is set to "untrusted".
-runtime_untrusted_workload = ""
+# Path to the OCI compatible runtime used for trusted container workloads. This
+# is a mandatory setting as this runtime will be the default and will also be
+# used for untrusted container workloads if runtime_untrusted_workload is not
+# set.
+#
+# DEPRECATED: use Runtimes instead.
+#
+# runtime = ""
 
-# default_workload_trust is the default level of trust crio puts in container
-# workloads. It can either be "trusted" or "untrusted", and the default
-# is "trusted".
-# Containers can be run through different container runtimes, depending on
-# the trust hints we receive from kubelet:
-# - If kubelet tags a container workload as untrusted, crio will try first to
-# run it through the untrusted container workload runtime. If it is not set,
-# crio will use the trusted runtime.
-# - If kubelet does not provide any information about the container workload trust
-# level, the selected runtime will depend on the default_container_trust setting.
-# If it is set to "untrusted", then all containers except for the host privileged
-# ones, will be run by the runtime_untrusted_workload runtime. Host privileged
-# containers are by definition trusted and will always use the trusted container
-# runtime. If default_container_trust is set to "trusted", crio will use the trusted
-# container runtime for all containers.
-default_workload_trust = "trusted"
+# default_runtime is the _name_ of the OCI runtime to be used as the default.
+# The name is matched against the runtimes map below.
+default_runtime = "runc"
 
-# no_pivot instructs the runtime to not use pivot_root, but instead use MS_MOVE
+# Path to OCI compatible runtime used for untrusted container workloads. This
+# is an optional setting, except if default_container_trust is set to
+# "untrusted".
+# DEPRECATED: use "crio.runtime.runtimes" instead. If provided, this
+#     runtime is mapped to the runtime handler named 'untrusted'. It is
+#     a configuration error to provide both the (now deprecated)
+#     runtime_untrusted_workload and a handler in the Runtimes handler
+#     map (below) for 'untrusted' workloads at the same time. Please
+#     provide one or the other.
+#     The support of this option will continue through versions 1.12 and 1.13.
+#     By version 1.14, this option will no longer exist.
+#runtime_untrusted_workload = ""
+
+# Default level of trust CRI-O puts in container workloads. It can either be
+# "trusted" or "untrusted", and the default is "trusted". Containers can be run
+# through different container runtimes, depending on the trust hints we receive
+# from kubelet:
+#
+#   - If kubelet tags a container workload as untrusted, CRI-O will try first
+#     to run it through the untrusted container workload runtime. If it is not
+#     set, CRI-O will use the trusted runtime.
+#
+#   - If kubelet does not provide any information about the container workload
+#     trust level, the selected runtime will depend on the default_container_trust
+#     setting. If it is set to untrusted, then all containers except for the host
+#     privileged ones, will be run by the runtime_untrusted_workload runtime. Host
+#     privileged containers are by definition trusted and will always use the
+#     trusted container runtime. If default_container_trust is set to "trusted",
+#     CRI-O will use the trusted container runtime for all containers.
+#
+# DEPRECATED: The runtime handler should provide a key to the map of runtimes,
+#     avoiding the need to rely on the level of trust of the workload to choose
+#     an appropriate runtime.
+#     The support of this option will continue through versions 1.12 and 1.13.
+#     By version 1.14, this option will no longer exist.
+#default_workload_trust = ""
+
+# If true, the runtime will not use pivot_root, but instead use MS_MOVE.
 no_pivot = false
 
-# conmon is the path to conmon binary, used for managing the runtime.
+# Path to the conmon binary, used for monitoring the OCI runtime.
 conmon = "/usr/local/libexec/crio/conmon"
 
-# conmon_env is the environment variable list for conmon process,
-# used for passing necessary environment variable to conmon or runtime.
+# Environment variable list for the conmon process, used for passing necessary
+# environment variables to conmon or the runtime.
 conmon_env = [
 	"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 ]
 
-# selinux indicates whether or not SELinux will be used for pod
-# separation on the host. If you enable this flag, SELinux must be running
-# on the host.
+# If true, SELinux will be used for pod separation on the host.
 selinux = false
 
-# seccomp_profile is the seccomp json profile path which is used as the
-# default for the runtime.
+# Path to the seccomp.json profile which is used as the default seccomp profile
+# for the runtime.
 seccomp_profile = "/etc/crio/seccomp.json"
 
-# apparmor_profile is the apparmor profile name which is used as the
-# default for the runtime.
+# Used to change the name of the default AppArmor profile of CRI-O. The default
+# profile name is "crio-default-" followed by the version string of CRI-O.
 apparmor_profile = "crio-default"
 
-# cgroup_manager is the cgroup management implementation to be used
-# for the runtime.
+# Cgroup management implementation used for the runtime.
 cgroup_manager = "cgroupfs"
 
-# hooks_dir_path is the oci hooks directory for automatically executed hooks
+# List of default capabilities for containers. If it is empty or commented out,
+# only the capabilities defined in the containers json file by the user/kube
+# will be added.
+default_capabilities = [
+	"CHOWN", 
+	"DAC_OVERRIDE", 
+	"FSETID", 
+	"FOWNER", 
+	"NET_RAW", 
+	"SETGID", 
+	"SETUID", 
+	"SETPCAP", 
+	"NET_BIND_SERVICE", 
+	"SYS_CHROOT", 
+	"KILL", 
+]
+
+# List of default sysctls. If it is empty or commented out, only the sysctls
+# defined in the container json file by the user/kube will be added.
+default_sysctls = [
+]
+
+# Path to the OCI hooks directory for automatically executed hooks.
 hooks_dir_path = "/usr/share/containers/oci/hooks.d"
 
-# default_mounts is the mounts list to be mounted for the container when created
+# List of default mounts for each container. **Deprecated:** this option will
+# be removed in future versions in favor of default_mounts_file.
 default_mounts = [
 ]
 
-# pids_limit is the number of processes allowed in a container
+# Path to the file specifying the defaults mounts for each container. The
+# format of the config is /SRC:/DST, one mount per line. Notice that CRI-O reads
+# its default mounts from the following two files:
+#
+#   1) /etc/containers/mounts.conf (i.e., default_mounts_file): This is the
+#      override file, where users can either add in their own default mounts, or
+#      override the default mounts shipped with the package.
+#
+#   2) /usr/share/containers/mounts.conf: This is the default file read for
+#      mounts. If you want CRI-O to read from a different, specific mounts file,
+#      you can change the default_mounts_file. Note, if this is done, CRI-O will
+#      only add mounts it finds in this file.
+#
+#default_mounts_file = ""
+
+# Maximum number of processes allowed in a container.
 pids_limit = 1024
 
-# log_size_max is the max limit for the container log size in bytes.
-# Negative values indicate that no limit is imposed.
+# Maximum sized allowed for the container log file. Negative numbers indicate
+# that no size limit is imposed. If it is positive, it must be >= 8192 to
+# match/exceed conmon's read buffer. The file is truncated and re-opened so the
+# limit is never exceeded.
 log_size_max = -1
 
-# The "crio.image" table contains settings pertaining to the
-# management of OCI images.
+# Path to directory in which container exit files are written to by conmon.
+container_exits_dir = "/var/run/crio/exits"
+
+# Path to directory for container attach sockets.
+container_attach_socket_dir = "/var/run/crio"
+
+# If set to true, all containers will run in read-only mode.
+read_only = false
+
+# Changes the verbosity of the logs based on the level it is set to. Options
+# are fatal, panic, error, warn, info, and debug.
+log_level = "error"
+
+# The UID mappings for the user namespace of each container. A range is
+# specified in the form containerUID:HostUID:Size. Multiple ranges must be
+# separated by comma.
+uid_mappings = ""
+
+# The GID mappings for the user namespace of each container. A range is
+# specified in the form containerGID:HostGID:Size. Multiple ranges must be
+# separated by comma.
+gid_mappings = ""
+
+# The minimal amount of time in seconds to wait before issuing a timeout
+# regarding the proper termination of the container.
+ctr_stop_timeout = 0
+
+  # The "crio.runtime.runtimes" table defines a list of OCI compatible runtimes.
+  # The runtime to use is picked based on the runtime_handler provided by the CRI.
+  # If no runtime_handler is provided, the runtime will be picked based on the level
+  # of trust of the workload.
+  
+  [crio.runtime.runtimes.runc]
+  runtime_path = "/usr/bin/runc"
+  
+
+
+# The crio.image table contains settings pertaining to the management of OCI images.
+#
+# CRI-O reads its configured registries defaults from the system wide
+# containers-registries.conf(5) located in /etc/containers/registries.conf. If
+# you want to modify just CRI-O, you can change the registies configuration in
+# this file. Otherwise, leave insecure_registries and registries commented out to
+# use the system's defaults from /etc/containers/registries.conf.
 [crio.image]
 
-# default_transport is the prefix we try prepending to an image name if the
-# image name as we receive it can't be parsed as a valid source reference
+# Default transport for pulling images from a remote container storage.
 default_transport = "docker://"
 
-# pause_image is the image which we use to instantiate infra containers.
-pause_image = "kubernetes/pause"
+# The image used to instantiate infra containers.
+pause_image = "k8s.gcr.io/pause:3.1"
 
-# pause_command is the command to run in a pause_image to have a container just
-# sit there.  If the image contains the necessary information, this value need
-# not be specified.
+# The command to run to have a container stay in the paused state.
 pause_command = "/pause"
 
-# signature_policy is the name of the file which decides what sort of policy we
-# use when deciding whether or not to trust an image that we've pulled.
-# Outside of testing situations, it is strongly advised that this be left
-# unspecified so that the default system-wide policy will be used.
+# Path to the file which decides what sort of policy we use when deciding
+# whether or not to trust an image that we've pulled. It is not recommended that
+# this option be used, as the default behavior of using the system-wide default
+# policy (i.e., /etc/containers/policy.json) is most often preferred. Please
+# refer to containers-policy.json(5) for more details.
 signature_policy = ""
 
-# image_volumes controls how image volumes are handled.
-# The valid values are mkdir and ignore.
+# Controls how image volumes are handled. The valid values are mkdir, bind and
+# ignore; the latter will ignore volumes entirely.
 image_volumes = "mkdir"
 
-# insecure_registries is used to skip TLS verification when pulling images.
-insecure_registries = [
-]
+# List of registries to be used when pulling an unqualified image (e.g.,
+# "alpine:latest"). By default, registries is set to "docker.io" for
+# compatibility reasons. Depending on your workload and usecase you may add more
+# registries (e.g., "quay.io", "registry.fedoraproject.org",
+# "registry.opensuse.org", etc.).
+#registries = [
+# ]
 
-# registries is used to specify a comma separated list of registries to be used
-# when pulling an unqualified image (e.g. fedora:rawhide).
-registries = [
-]
 
-# The "crio.network" table contains settings pertaining to the
-# management of CNI plugins.
+# The crio.network table containers settings pertaining to the management of
+# CNI plugins.
 [crio.network]
 
-# network_dir is is where CNI network configuration
-# files are stored.
+# Path to the directory where CNI configuration files are located.
 network_dir = "/etc/cni/net.d/"
 
-# plugin_dir is is where CNI plugin binaries are stored.
+# Path to directory where CNI plugin binaries are located.
 plugin_dir = "/opt/cni/bin/"

--- a/deploy/iso/minikube-iso/package/crio-bin/crio.conf.default
+++ b/deploy/iso/minikube-iso/package/crio-bin/crio.conf.default
@@ -173,8 +173,16 @@ default_capabilities = [
 default_sysctls = [
 ]
 
-# Path to the OCI hooks directory for automatically executed hooks.
-hooks_dir_path = "/usr/share/containers/oci/hooks.d"
+# List of additional devices. specified as
+# "<device-on-host>:<device-on-container>:<permissions>", for example: "--device=/dev/sdc:/dev/xvdc:rwm".
+#If it is empty or commented out, only the devices
+# defined in the container json file by the user/kube will be added.
+additional_devices = [
+]
+
+# Path to OCI hooks directories for automatically executed hooks.
+hooks_dir = [
+]
 
 # List of default mounts for each container. **Deprecated:** this option will
 # be removed in future versions in favor of default_mounts_file.

--- a/deploy/iso/minikube-iso/package/crio-bin/crio.conf.default
+++ b/deploy/iso/minikube-iso/package/crio-bin/crio.conf.default
@@ -25,7 +25,6 @@
 # List to pass options to the storage driver. Please refer to
 # containers-storage.conf(5) to see all available storage options.
 #storage_option = [
-#	"overlay.override_kernel_check=true",
 #]
 
 # If set to false, in-memory locking will be used instead of file-based locking.
@@ -64,6 +63,12 @@ stream_tls_key = ""
 # automatically pick up the changes within 5 minutes.
 stream_tls_ca = ""
 
+# Maximum grpc send message size in bytes. If not set or <=0, then CRI-O will default to 16 * 1024 * 1024.
+grpc_max_send_msg_size = 16777216
+
+# Maximum grpc receive message size. If not set or <= 0, then CRI-O will default to 16 * 1024 * 1024.
+grpc_max_recv_msg_size = 16777216
+
 # The crio.runtime table contains settings pertaining to the OCI runtime used
 # and options for how to set up and manage the OCI runtime.
 [crio.runtime]
@@ -75,55 +80,9 @@ stream_tls_ca = ""
 #default_ulimits = [
 #]
 
-# Path to the OCI compatible runtime used for trusted container workloads. This
-# is a mandatory setting as this runtime will be the default and will also be
-# used for untrusted container workloads if runtime_untrusted_workload is not
-# set.
-#
-# DEPRECATED: use Runtimes instead.
-#
-# runtime = ""
-
 # default_runtime is the _name_ of the OCI runtime to be used as the default.
 # The name is matched against the runtimes map below.
 default_runtime = "runc"
-
-# Path to OCI compatible runtime used for untrusted container workloads. This
-# is an optional setting, except if default_container_trust is set to
-# "untrusted".
-# DEPRECATED: use "crio.runtime.runtimes" instead. If provided, this
-#     runtime is mapped to the runtime handler named 'untrusted'. It is
-#     a configuration error to provide both the (now deprecated)
-#     runtime_untrusted_workload and a handler in the Runtimes handler
-#     map (below) for 'untrusted' workloads at the same time. Please
-#     provide one or the other.
-#     The support of this option will continue through versions 1.12 and 1.13.
-#     By version 1.14, this option will no longer exist.
-#runtime_untrusted_workload = ""
-
-# Default level of trust CRI-O puts in container workloads. It can either be
-# "trusted" or "untrusted", and the default is "trusted". Containers can be run
-# through different container runtimes, depending on the trust hints we receive
-# from kubelet:
-#
-#   - If kubelet tags a container workload as untrusted, CRI-O will try first
-#     to run it through the untrusted container workload runtime. If it is not
-#     set, CRI-O will use the trusted runtime.
-#
-#   - If kubelet does not provide any information about the container workload
-#     trust level, the selected runtime will depend on the default_container_trust
-#     setting. If it is set to untrusted, then all containers except for the host
-#     privileged ones, will be run by the runtime_untrusted_workload runtime. Host
-#     privileged containers are by definition trusted and will always use the
-#     trusted container runtime. If default_container_trust is set to "trusted",
-#     CRI-O will use the trusted container runtime for all containers.
-#
-# DEPRECATED: The runtime handler should provide a key to the map of runtimes,
-#     avoiding the need to rely on the level of trust of the workload to choose
-#     an appropriate runtime.
-#     The support of this option will continue through versions 1.12 and 1.13.
-#     By version 1.14, this option will no longer exist.
-#default_workload_trust = ""
 
 # If true, the runtime will not use pivot_root, but instead use MS_MOVE.
 no_pivot = false
@@ -213,6 +172,9 @@ pids_limit = 1024
 # limit is never exceeded.
 log_size_max = -1
 
+# Whether container output should be logged to journald in addition to the kuberentes log file
+log_to_journald = false
+
 # Path to directory in which container exit files are written to by conmon.
 container_exits_dir = "/var/run/crio/exits"
 
@@ -247,6 +209,7 @@ ctr_stop_timeout = 0
   
   [crio.runtime.runtimes.runc]
   runtime_path = "/usr/bin/runc"
+  runtime_type = "oci"
   
 
 
@@ -254,7 +217,7 @@ ctr_stop_timeout = 0
 #
 # CRI-O reads its configured registries defaults from the system wide
 # containers-registries.conf(5) located in /etc/containers/registries.conf. If
-# you want to modify just CRI-O, you can change the registies configuration in
+# you want to modify just CRI-O, you can change the registries configuration in
 # this file. Otherwise, leave insecure_registries and registries commented out to
 # use the system's defaults from /etc/containers/registries.conf.
 [crio.image]
@@ -264,6 +227,10 @@ default_transport = "docker://"
 
 # The image used to instantiate infra containers.
 pause_image = "k8s.gcr.io/pause:3.1"
+
+# If not empty, the path to a docker/config.json-like file containing credentials
+# necessary for pulling the image specified by pause_image above.
+pause_image_auth_file = ""
 
 # The command to run to have a container stay in the paused state.
 pause_command = "/pause"
@@ -295,5 +262,7 @@ image_volumes = "mkdir"
 # Path to the directory where CNI configuration files are located.
 network_dir = "/etc/cni/net.d/"
 
-# Path to directory where CNI plugin binaries are located.
-plugin_dir = "/opt/cni/bin/"
+# Paths to directories where CNI plugin binaries are located.
+plugin_dir = [
+	"/opt/cni/bin/",
+]


### PR DESCRIPTION
The current configuration file is based on `v1.10.0`, which makes it hard to see _what_ has been changed:

``` diff
@@ -12,7 +12,7 @@
 
 # storage_driver select which storage driver is used to manage storage
 # of images and containers.
-storage_driver = ""
+storage_driver = "overlay"
 
 # storage_option is used to pass an option to the storage driver.
 storage_option = [
@@ -67,10 +67,10 @@
 default_workload_trust = "trusted"
 
 # no_pivot instructs the runtime to not use pivot_root, but instead use MS_MOVE
-no_pivot = false
+no_pivot = true
 
 # conmon is the path to conmon binary, used for managing the runtime.
-conmon = "/usr/local/libexec/crio/conmon"
+conmon = "/usr/libexec/crio/conmon"
 
 # conmon_env is the environment variable list for conmon process,
 # used for passing necessary environment variable to conmon or runtime.
@@ -118,7 +118,7 @@
 default_transport = "docker://"
 
 # pause_image is the image which we use to instantiate infra containers.
-pause_image = "kubernetes/pause"
+pause_image = "k8s.gcr.io/pause:3.1"
 
 # pause_command is the command to run in a pause_image to have a container just
 # sit there.  If the image contains the necessary information, this value need
@@ -142,6 +142,7 @@
 # registries is used to specify a comma separated list of registries to be used
 # when pulling an unqualified image (e.g. fedora:rawhide).
 registries = [
+	"docker.io"
 ]
 
 # The "crio.network" table contains settings pertaining to the
```

Add the default configuration file, and then upgrade it - first to `v1.13.1` but eventually (#4205) to `v1.14.0`