### PR TITLE
Fix registry addon ReplicationController template

### DIFF
--- a/deploy/addons/registry/registry-rc.yaml.tmpl
+++ b/deploy/addons/registry/registry-rc.yaml.tmpl
@@ -25,4 +25,4 @@ spec:
           protocol: TCP
         env:
         - name: REGISTRY_STORAGE_DELETE_ENABLED
-          value: true  
+          value: "true"


### PR DESCRIPTION
Running the `minikube addons enable registry` yields `registry was successfully enabled` but no `registry` Pod ends up being run.

I've narrowed it down to this `env` entry not being quoted.

Logs from `kube-addon-manager-minikube` Pod show this error:

```
Error from server (BadRequest): error when creating "/etc/kubernetes/addons/registry-rc.yaml": ReplicationController in version "v1" cannot be handled as a ReplicationController: v1.ReplicationController.Spec: v1.ReplicationControllerSpec.Template: v1.PodTemplateSpec.Spec: v1.PodSpec.Containers: []v1.Container: v1.Container.Env: []v1.EnvVar: v1.EnvVar.Value: ReadString: expects " or n, but found t, error found in #10 byte of ...|,"value":true}],"ima|..., bigger context ...|"name":"REGISTRY_STORAGE_DELETE_ENABLED","value":true}],"image":"registry.hub.docker.com/library/reg|...
```