### PR TITLE
Restart kube-proxy using kubeadm & add bootstrapper.WaitCluster

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -154,7 +154,6 @@ func init() {
 	startCmd.Flags().Bool(noVTXCheck, false, "Disable checking for the availability of hardware virtualization before the vm is started (virtualbox)")
 	if err := viper.BindPFlags(startCmd.Flags()); err != nil {
 		exit.WithError("unable to bind flags", err)
-
 	}
 	RootCmd.AddCommand(startCmd)
 }

--- a/pkg/minikube/bootstrapper/bootstrapper.go
+++ b/pkg/minikube/bootstrapper/bootstrapper.go
@@ -39,6 +39,7 @@ type Bootstrapper interface {
 	UpdateCluster(config.KubernetesConfig) error
 	RestartCluster(config.KubernetesConfig) error
 	DeleteCluster(config.KubernetesConfig) error
+	WaitCluster(config.KubernetesConfig) error
 	// LogCommands returns a map of log type to a command which will display that log.
 	LogCommands(LogOptions) map[string]string
 	SetupCerts(cfg config.KubernetesConfig) error

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -327,7 +327,6 @@ func (k *Bootstrapper) RestartCluster(k8s config.KubernetesConfig) error {
 // waitForAPIServer waits for the apiserver to start up
 func (k *Bootstrapper) waitForAPIServer(k8s config.KubernetesConfig) error {
 	glog.Infof("Waiting for apiserver ...")
-	defer glog.Infof("Done waiting for apiserver ...")
 	return wait.PollImmediate(time.Millisecond*200, time.Minute*1, func() (bool, error) {
 		status, err := k.GetAPIServerStatus(net.ParseIP(k8s.NodeIP), k8s.NodePort)
 		glog.Infof("status: %s, err: %v", status, err)

--- a/pkg/minikube/bootstrapper/kubeadm/util.go
+++ b/pkg/minikube/bootstrapper/kubeadm/util.go
@@ -17,11 +17,8 @@ limitations under the License.
 package kubeadm
 
 import (
-	"bytes"
 	"encoding/json"
-	"html/template"
 	"net"
-	"strings"
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
@@ -29,10 +26,8 @@ import (
 	rbac "k8s.io/api/rbac/v1beta1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
-	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/service"
 	"k8s.io/minikube/pkg/util"
@@ -128,100 +123,5 @@ func elevateKubeSystemPrivileges() error {
 		}
 		return errors.Wrap(err, "creating clusterrolebinding")
 	}
-	return nil
-}
-
-const (
-	kubeconfigConf         = "kubeconfig.conf"
-	kubeProxyConfigmapTmpl = `apiVersion: v1
-kind: Config
-clusters:
-- cluster:
-    certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    server: https://{{.AdvertiseAddress}}:{{.APIServerPort}}
-  name: default
-contexts:
-- context:
-    cluster: default
-    namespace: default
-    user: default
-  name: default
-current-context: default
-users:
-- name: default
-  user:
-    tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-`
-)
-
-// updateKubeProxyConfigMap updates the IP & port kube-proxy listens on, and restarts it.
-func updateKubeProxyConfigMap(k8s config.KubernetesConfig) error {
-	client, err := util.GetClient()
-	if err != nil {
-		return errors.Wrap(err, "getting k8s client")
-	}
-
-	selector := labels.SelectorFromSet(labels.Set(map[string]string{"k8s-app": "kube-proxy"}))
-	if err := util.WaitForPodsWithLabelRunning(client, "kube-system", selector); err != nil {
-		return errors.Wrap(err, "kube-proxy not running")
-	}
-
-	cfgMap, err := client.CoreV1().ConfigMaps("kube-system").Get("kube-proxy", meta.GetOptions{})
-	if err != nil {
-		return &util.RetriableError{Err: errors.Wrap(err, "getting kube-proxy configmap")}
-	}
-	glog.Infof("kube-proxy config: %v", cfgMap.Data[kubeconfigConf])
-	t := template.Must(template.New("kubeProxyTmpl").Parse(kubeProxyConfigmapTmpl))
-	opts := struct {
-		AdvertiseAddress string
-		APIServerPort    int
-	}{
-		AdvertiseAddress: k8s.NodeIP,
-		APIServerPort:    k8s.NodePort,
-	}
-
-	kubeconfig := bytes.Buffer{}
-	if err := t.Execute(&kubeconfig, opts); err != nil {
-		return errors.Wrap(err, "executing kube proxy configmap template")
-	}
-
-	if cfgMap.Data == nil {
-		cfgMap.Data = map[string]string{}
-	}
-
-	updated := strings.TrimSuffix(kubeconfig.String(), "\n")
-	glog.Infof("updated kube-proxy config: %s", updated)
-
-	// An optimization, but also one that's unlikely, as kubeadm writes the address as 'localhost'
-	if cfgMap.Data[kubeconfigConf] == updated {
-		glog.Infof("kube-proxy config appears to require no change, not restarting kube-proxy")
-		return nil
-	}
-	cfgMap.Data[kubeconfigConf] = updated
-
-	// Make this step retriable, as it can fail with:
-	// "Operation cannot be fulfilled on configmaps "kube-proxy": the object has been modified; please apply your changes to the latest version and try again"
-	if _, err := client.CoreV1().ConfigMaps("kube-system").Update(cfgMap); err != nil {
-		return &util.RetriableError{Err: errors.Wrap(err, "updating configmap")}
-	}
-
-	pods, err := client.CoreV1().Pods("kube-system").List(meta.ListOptions{
-		LabelSelector: "k8s-app=kube-proxy",
-	})
-	if err != nil {
-		return errors.Wrap(err, "listing kube-proxy pods")
-	}
-	for _, pod := range pods.Items {
-		// Retriable, as known to fail with: pods "<name>" not found
-		if err := client.CoreV1().Pods(pod.Namespace).Delete(pod.Name, &meta.DeleteOptions{}); err != nil {
-			return &util.RetriableError{Err: errors.Wrapf(err, "deleting pod %+v", pod)}
-		}
-	}
-
-	// Wait for the scheduler to restart kube-proxy
-	if err := util.WaitForPodsWithLabelRunning(client, "kube-system", selector); err != nil {
-		return errors.Wrap(err, "kube-proxy not running")
-	}
-
 	return nil
 }


### PR DESCRIPTION
The logic in `updateKubeProxyConfigMap` was broken: there is no need for kube-proxy to be online to update the config map for it.  This PR lets kubeadm handle the kube-proxy restart instead, which apparently does things correctly on newer Kubernetes versions.
 
Full credit goes to @liubog2008 who proposed a similar approach in #4014

NOTE: This PR also moves `validateCluster` to `bootstrapper.WaitCluster` to allow for more a more tuned implementation.

This fixes #3843
