### PR TITLE
Upgrade default Kubernetes release to v1.14.2

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/testdata/containerd-api-port__default.yaml
+++ b/pkg/minikube/bootstrapper/kubeadm/testdata/containerd-api-port__default.yaml
@@ -28,7 +28,7 @@ dns:
 etcd:
   local:
     dataDir: /data/minikube
-kubernetesVersion: v1.14.1
+kubernetesVersion: v1.14.2
 networking:
   dnsDomain: cluster.local
   podSubnet: ""

--- a/pkg/minikube/bootstrapper/kubeadm/testdata/containerd__default.yaml
+++ b/pkg/minikube/bootstrapper/kubeadm/testdata/containerd__default.yaml
@@ -28,7 +28,7 @@ dns:
 etcd:
   local:
     dataDir: /data/minikube
-kubernetesVersion: v1.14.1
+kubernetesVersion: v1.14.2
 networking:
   dnsDomain: cluster.local
   podSubnet: ""

--- a/pkg/minikube/bootstrapper/kubeadm/testdata/crio-options-gates__default.yaml
+++ b/pkg/minikube/bootstrapper/kubeadm/testdata/crio-options-gates__default.yaml
@@ -41,7 +41,7 @@ dns:
 etcd:
   local:
     dataDir: /data/minikube
-kubernetesVersion: v1.14.1
+kubernetesVersion: v1.14.2
 networking:
   dnsDomain: cluster.local
   podSubnet: ""

--- a/pkg/minikube/bootstrapper/kubeadm/testdata/crio__default.yaml
+++ b/pkg/minikube/bootstrapper/kubeadm/testdata/crio__default.yaml
@@ -28,7 +28,7 @@ dns:
 etcd:
   local:
     dataDir: /data/minikube
-kubernetesVersion: v1.14.1
+kubernetesVersion: v1.14.2
 networking:
   dnsDomain: cluster.local
   podSubnet: ""

--- a/pkg/minikube/bootstrapper/kubeadm/testdata/default__default.yaml
+++ b/pkg/minikube/bootstrapper/kubeadm/testdata/default__default.yaml
@@ -28,7 +28,7 @@ dns:
 etcd:
   local:
     dataDir: /data/minikube
-kubernetesVersion: v1.14.1
+kubernetesVersion: v1.14.2
 networking:
   dnsDomain: cluster.local
   podSubnet: ""

--- a/pkg/minikube/bootstrapper/kubeadm/testdata/image-repository__default.yaml
+++ b/pkg/minikube/bootstrapper/kubeadm/testdata/image-repository__default.yaml
@@ -29,7 +29,7 @@ dns:
 etcd:
   local:
     dataDir: /data/minikube
-kubernetesVersion: v1.14.1
+kubernetesVersion: v1.14.2
 networking:
   dnsDomain: cluster.local
   podSubnet: ""

--- a/pkg/minikube/bootstrapper/kubeadm/testdata/options__default.yaml
+++ b/pkg/minikube/bootstrapper/kubeadm/testdata/options__default.yaml
@@ -35,7 +35,7 @@ dns:
 etcd:
   local:
     dataDir: /data/minikube
-kubernetesVersion: v1.14.1
+kubernetesVersion: v1.14.2
 networking:
   dnsDomain: cluster.local
   podSubnet: ""

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -162,10 +162,10 @@ var DefaultISOURL = fmt.Sprintf("https://storage.googleapis.com/%s/minikube-%s.i
 var DefaultISOSHAURL = DefaultISOURL + SHASuffix
 
 // DefaultKubernetesVersion is the default kubernetes version
-var DefaultKubernetesVersion = "v1.14.1"
+var DefaultKubernetesVersion = "v1.14.2"
 
 // NewestKubernetesVersion is the newest Kubernetes version to test against
-var NewestKubernetesVersion = "v1.14.1"
+var NewestKubernetesVersion = "v1.14.2"
 
 // OldestKubernetesVersion is the oldest Kubernetes version to test against
 var OldestKubernetesVersion = "v1.10.13"


### PR DESCRIPTION
Generated using:

`go run update_kubernetes_version.go v1.14.2`