### PR TITLE
Set apiserver oom_adj to -10 to avoid OOMing before other pods

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -228,6 +228,30 @@ func (k *Bootstrapper) StartCluster(k8s config.KubernetesConfig) error {
 		return errors.Wrap(err, "wait")
 	}
 
+	if err := k.adjustResourceLimits(); err != nil {
+		glog.Warningf("unable to adjust resource limits: %v", err)
+	}
+	return nil
+}
+
+// adjustResourceLimits makes fine adjustments to pod resources that aren't possible via kubeadm config.
+func (k *Bootstrapper) adjustResourceLimits() error {
+	score, err := k.c.CombinedOutput("cat /proc/$(pgrep kube-apiserver)/oom_adj")
+	if err != nil {
+		return errors.Wrap(err, "oom_adj check")
+	}
+	glog.Infof("apiserver oom_adj: %s", score)
+	// oom_adj is already a negative number
+	if strings.HasPrefix(score, "-") {
+		return nil
+	}
+	glog.Infof("adjusting apiserver oom_adj to -10")
+
+	// Prevent the apiserver from OOM'ing before other pods, as it is our gateway into the cluster.
+	// It'd be preferable to do this via Kubernetes, but kubeadm doesn't have a way to set pod QoS.
+	if err := k.c.Run("echo -10 | sudo tee /proc/$(pgrep kube-apiserver)/oom_adj"); err != nil {
+		return errors.Wrap(err, "oom_adj adjust")
+	}
 	return nil
 }
 
@@ -336,6 +360,9 @@ func (k *Bootstrapper) RestartCluster(k8s config.KubernetesConfig) error {
 		return errors.Wrap(err, "wait")
 	}
 
+	if err := k.adjustResourceLimits(); err != nil {
+		glog.Warningf("unable to adjust resource limits: %v", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
This will allow users to be able to continue to run `kubectl` to diagnose a cluster that has OOM'd.

I'm open to other suggestions: apparently kubeadm doesn't let me set resource limits on pods in order to get placed into the guaranteed QoS class.

For reference, kubelet is configured for -16. 

Example log messages:

```
I0517 07:50:08.225437   41021 ssh_runner.go:137] Run with output: cat /proc/$(pgrep kube-apiserver)/oom_adj
I0517 07:50:08.234262   41021 utils.go:240] > 16
I0517 07:50:08.234291   41021 kubeadm.go:234] apiserver oom_adj: 16
I0517 07:50:08.234299   41021 kubeadm.go:239] adjusting apiserver oom_adj to -10
I0517 07:50:08.234306   41021 ssh_runner.go:101] SSH: echo -10 | sudo tee /proc/$(pgrep kube-apiserver)/oom_adj
I0517 07:50:08.248105   41021 utils.go:240] > -10
```