### PR TITLE
Use NewMinikubeRunner in TestVersionUpgrade to get correct VM driver

### DIFF
--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/minikube/pkg/minikube/constants"
 	pkgutil "k8s.io/minikube/pkg/util"
-	"k8s.io/minikube/test/integration/util"
 )
 
 func TestVersionUpgrade(t *testing.T) {
@@ -65,7 +64,8 @@ func TestVersionUpgrade(t *testing.T) {
 		}
 	}
 
-	releaseRunner := util.MinikubeRunner{BinaryPath: tf.Name(), T: t}
+	releaseRunner := NewMinikubeRunner(t)
+	releaseRunner.BinaryPath = tf.Name()
 	// For full coverage: also test upgrading from oldest to newest supported k8s release
 	releaseRunner.Start(fmt.Sprintf("--kubernetes-version=%s", constants.OldestKubernetesVersion))
 	releaseRunner.CheckStatus(state.Running.String())


### PR DESCRIPTION
Fixes broken integration test:

```
17:44:08 | ! I0520 17:44:08.090462 17914 utils.go:122] non-retriable error: create: precreate: VirtualBox is configured with multiple host-only adapters with the same IP "192.168.99.1". Please remove one
17:44:08 | ! W0520 17:44:08.091323 17914 exit.go:99] Unable to start VM: create: precreate: VirtualBox is configured with multiple host-only adapters with the same IP "192.168.99.1". Please remove one
17:44:08 | ! ! Unable to start VM: create: precreate: VirtualBox is configured with multiple host-only adapters with the same IP "192.168.99.1". Please remove one
--- FAIL: TestVersionUpgrade (11.85s)
```