### PR TITLE
Disable SystemVerification preflight on Kubernetes releases <1.13

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -211,8 +211,8 @@ func (k *Bootstrapper) StartCluster(k8s config.KubernetesConfig) error {
 		"FileAvailable--etc-kubernetes-manifests-kube-apiserver.yaml",
 		"FileAvailable--etc-kubernetes-manifests-kube-controller-manager.yaml",
 		"FileAvailable--etc-kubernetes-manifests-etcd.yaml",
-		//		"Port-10250", // Kubelet
-		"Swap", // For "none" driver users
+		"Port-10250", // For "none" users who already have a kubelet online
+		"Swap",       // For "none" users who have swap configured
 	}
 	ignore = append(ignore, SkipAdditionalPreflights[r.Name()]...)
 

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -218,6 +218,7 @@ func (k *Bootstrapper) StartCluster(k8s config.KubernetesConfig) error {
 
 	// Allow older kubeadm versions to function with newer Docker releases.
 	if version.LT(semver.MustParse("1.13.0")) {
+		glog.Infof("Older Kubernetes release detected (%s), disabling SystemVerification check.", version)
 		ignore = append(ignore, "SystemVerification")
 	}
 

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -73,24 +73,6 @@ var KubeadmExtraArgsWhitelist = map[int][]string{
 	},
 }
 
-// SkipPreflights are preflight checks we always skip.
-var SkipPreflights = []string{
-	// We use --ignore-preflight-errors=DirAvailable since we have our own custom addons
-	// that we also stick in /etc/kubernetes/manifests
-	"DirAvailable--etc-kubernetes-manifests",
-	"DirAvailable--data-minikube",
-	"Port-10250",
-	"FileAvailable--etc-kubernetes-manifests-kube-scheduler.yaml",
-	"FileAvailable--etc-kubernetes-manifests-kube-apiserver.yaml",
-	"FileAvailable--etc-kubernetes-manifests-kube-controller-manager.yaml",
-	"FileAvailable--etc-kubernetes-manifests-etcd.yaml",
-	// So that "none" driver users don't have to reconfigure their machine
-	"Swap",
-	// We use --ignore-preflight-errors=CRI since /var/run/dockershim.sock is not present.
-	// (because we start kubelet with an invalid config)
-	"CRI",
-}
-
 type pod struct {
 	// Human friendly name
 	name  string
@@ -221,30 +203,29 @@ func (k *Bootstrapper) StartCluster(k8s config.KubernetesConfig) error {
 	if err != nil {
 		return err
 	}
-	b := bytes.Buffer{}
-	preflights := SkipPreflights
-	preflights = append(preflights, SkipAdditionalPreflights[r.Name()]...)
 
-	templateContext := struct {
-		KubeadmConfigFile   string
-		SkipPreflightChecks bool
-		Preflights          []string
-		ExtraOptions        string
-	}{
-		KubeadmConfigFile: constants.KubeadmConfigFile,
-		SkipPreflightChecks: !VersionIsBetween(version,
-			semver.MustParse("1.9.0-alpha.0"),
-			semver.Version{}),
-		Preflights:   preflights,
-		ExtraOptions: extraFlags,
+	ignore := []string{
+		"DirAvailable--etc-kubernetes-manifests", // Addons are stored in /etc/kubernetes/manifests
+		"DirAvailable--data-minikube",
+		"FileAvailable--etc-kubernetes-manifests-kube-scheduler.yaml",
+		"FileAvailable--etc-kubernetes-manifests-kube-apiserver.yaml",
+		"FileAvailable--etc-kubernetes-manifests-kube-controller-manager.yaml",
+		"FileAvailable--etc-kubernetes-manifests-etcd.yaml",
+		//		"Port-10250", // Kubelet
+		"Swap", // For "none" driver users
 	}
-	if err := kubeadmInitTemplate.Execute(&b, templateContext); err != nil {
-		return err
+	ignore = append(ignore, SkipAdditionalPreflights[r.Name()]...)
+
+	// Allow older kubeadm versions to function with newer Docker releases.
+	if version.GTE(semver.MustParse("1.13.0")) {
+		ignore = append(ignore, "SystemVerification")
 	}
 
-	out, err := k.c.CombinedOutput(b.String())
+	cmd := fmt.Sprintf("sudo /usr/bin/kubeadm init --config %s %s --ignore-preflight-errors=%s",
+		constants.KubeadmConfigFile, extraFlags, strings.Join(ignore, ","))
+	out, err := k.c.CombinedOutput(cmd)
 	if err != nil {
-		return errors.Wrapf(err, "kubeadm init: %s\n%s\n", b.String(), out)
+		return errors.Wrapf(err, "cmd failed: %s\n%s\n", cmd, out)
 	}
 
 	if version.LT(semver.MustParse("1.10.0-alpha.0")) {

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -217,7 +217,7 @@ func (k *Bootstrapper) StartCluster(k8s config.KubernetesConfig) error {
 	ignore = append(ignore, SkipAdditionalPreflights[r.Name()]...)
 
 	// Allow older kubeadm versions to function with newer Docker releases.
-	if version.GTE(semver.MustParse("1.13.0")) {
+	if version.LT(semver.MustParse("1.13.0")) {
 		ignore = append(ignore, "SystemVerification")
 	}
 

--- a/pkg/minikube/bootstrapper/kubeadm/templates.go
+++ b/pkg/minikube/bootstrapper/kubeadm/templates.go
@@ -177,10 +177,6 @@ RestartSec=10
 WantedBy=multi-user.target
 `
 
-var kubeadmInitTemplate = template.Must(template.New("kubeadmInitTemplate").Parse(`
-sudo /usr/bin/kubeadm init --config {{.KubeadmConfigFile}} {{.ExtraOptions}} {{if .SkipPreflightChecks}}--skip-preflight-checks{{else}}{{range .Preflights}}--ignore-preflight-errors={{.}} {{end}}{{end}}
-`))
-
 // printMapInOrder sorts the keys and prints the map in order, combining key
 // value pairs with the separator character
 //


### PR DESCRIPTION
This also simplifies `kubeadm init` command generation so that it is trivial to reason about. Example command line generated:

`Run with output: sudo /usr/bin/kubeadm init --config /var/lib/kubeadm.yaml  --ignore-preflight-errors=DirAvailable--etc-kubernetes-manifests,DirAvailable--data-minikube,FileAvailable--etc-kubernetes-manifests-kube-scheduler.yaml,FileAvailable--etc-kubernetes-manifests-kube-apiserver.yaml,FileAvailable--etc-kubernetes-manifests-kube-controller-manager.yaml,FileAvailable--etc-kubernetes-manifests-etcd.yaml,Swap`

This fixes #4304