### PR TITLE
Validate kvm network exists

### DIFF
--- a/pkg/drivers/kvm/network.go
+++ b/pkg/drivers/kvm/network.go
@@ -117,9 +117,11 @@ func (d *Driver) createNetwork() error {
 
 	// network: default
 	// It is assumed that the libvirt/kvm installation has already created this network
+	if _, err := conn.LookupNetworkByName(d.Network); err != nil {
+		return errors.Wrapf(err, "network %s doesn't exist", d.Network)
+	}
 
 	// network: private
-
 	// Only create the private network if it does not already exist
 	if _, err := conn.LookupNetworkByName(d.PrivateNetwork); err != nil {
 		// create the XML for the private network from our networkTmpl


### PR DESCRIPTION
Minikube isn't validating if the kvm network exists, in the case the `default` one isn't created or the user passed a custom one `--kvm-network` and it doesn't exist the code will go on creating the PrivateNetwork to only raise an error at the end. This PR adds validation for this case, so it fails fast instead of moving on with other resources creation.
