### PR TITLE
Make buildah --no-pivot default, using env var

### DIFF
--- a/deploy/iso/minikube-iso/package/podman/buildah.profile
+++ b/deploy/iso/minikube-iso/package/podman/buildah.profile
@@ -1,0 +1,3 @@
+# BUILDAH_NOPIVOT=true disables pivot_root in Buildah, using MS_MOVE instead.
+# (Buildah is used by Podman for building container images using a Dockerfile)
+export BUILDAH_NOPIVOT=true

--- a/deploy/iso/minikube-iso/package/podman/podman.mk
+++ b/deploy/iso/minikube-iso/package/podman/podman.mk
@@ -29,6 +29,7 @@ endef
 
 define PODMAN_INSTALL_TARGET_CMDS
 	$(INSTALL) -Dm755 $(@D)/bin/podman $(TARGET_DIR)/usr/bin/podman
+	$(INSTALL) -Dm644 $(BR2_EXTERNAL_MINIKUBE_PATH)/package/podman/buildah.profile $(TARGET_DIR)/etc/profile.d/podman.sh
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
Needed for doing "podman build" (uses buildah) when running on rootfs.

This environment variable has the same affect as DOCKER_RAMDISK does.