### PR TITLE
kvm2: Add support for --kvm-network to ensureNetwork

### DIFF
--- a/pkg/drivers/kvm/network.go
+++ b/pkg/drivers/kvm/network.go
@@ -91,8 +91,8 @@ func (d *Driver) ensureNetwork() error {
 
 	// Start the default network
 	// It is assumed that the libvirt/kvm installation has already created this network
-	log.Infof("Ensuring network %s is active", defaultNetworkName)
-	if err := setupNetwork(conn, defaultNetworkName); err != nil {
+	log.Infof("Ensuring network %s is active", d.Network)
+	if err := setupNetwork(conn, d.Network); err != nil {
 		return err
 	}
 

--- a/pkg/drivers/kvm/network.go
+++ b/pkg/drivers/kvm/network.go
@@ -89,7 +89,6 @@ func (d *Driver) ensureNetwork() error {
 
 	// network: default
 
-	// Start the default network
 	// It is assumed that the libvirt/kvm installation has already created this network
 	log.Infof("Ensuring network %s is active", d.Network)
 	if err := setupNetwork(conn, d.Network); err != nil {

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -38,6 +38,7 @@ func TestStartStop(t *testing.T) {
 		{"nocache_oldest", []string{
 			"--cache-images=false",
 			fmt.Sprintf("--kubernetes-version=%s", constants.OldestKubernetesVersion),
+			"--kvm-network=default",
 		}},
 		{"feature_gates_newest_cni", []string{
 			"--feature-gates",

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -38,7 +38,9 @@ func TestStartStop(t *testing.T) {
 		{"nocache_oldest", []string{
 			"--cache-images=false",
 			fmt.Sprintf("--kubernetes-version=%s", constants.OldestKubernetesVersion),
-			"--kvm-network=test-net",
+			// default is the network created by libvirt, if we change the name minikube won't boot
+			// because the given network doesn't exist
+			"--kvm-network=default",
 		}},
 		{"feature_gates_newest_cni", []string{
 			"--feature-gates",

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -38,7 +38,7 @@ func TestStartStop(t *testing.T) {
 		{"nocache_oldest", []string{
 			"--cache-images=false",
 			fmt.Sprintf("--kubernetes-version=%s", constants.OldestKubernetesVersion),
-			"--kvm-network=default",
+			"--kvm-network=test-net",
 		}},
 		{"feature_gates_newest_cni", []string{
 			"--feature-gates",


### PR DESCRIPTION
kvm `ensureNetwork` is directly checking for the constant `defaultNetworkName` which is a problem when a user is passing a custom network through the option `--kvm-network`.

Kvm drivers pass the `Network` to be the same as the flag `--kvm-network`.
https://github.com/kubernetes/minikube/blob/master/pkg/minikube/drivers/kvm/driver.go#L67
https://github.com/kubernetes/minikube/blob/master/pkg/minikube/drivers/kvm2/driver.go#L67

Even the default Host creation sets up the `Network`:
https://github.com/kubernetes/minikube/blob/master/pkg/drivers/kvm/kvm.go#L107

The PR changes `ensureNetwork` to use the given network instead of hardcoded constant.