### PR TITLE
Get current profile if no arguments given

### DIFF
--- a/cmd/minikube/cmd/config/profile.go
+++ b/cmd/minikube/cmd/config/profile.go
@@ -17,7 +17,10 @@ limitations under the License.
 package config
 
 import (
+	"os"
+	
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	pkgConfig "k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/console"
 	"k8s.io/minikube/pkg/minikube/exit"
@@ -25,12 +28,16 @@ import (
 
 // ProfileCmd represents the profile command
 var ProfileCmd = &cobra.Command{
-	Use:   "profile MINIKUBE_PROFILE_NAME.  You can return to the default minikube profile by running `minikube profile default`",
-	Short: "Profile sets the current minikube profile",
-	Long:  "profile sets the current minikube profile.  This is used to run and manage multiple minikube instance.  You can return to the default minikube profile by running `minikube profile default`",
+	Use:   "profile [MINIKUBE_PROFILE_NAME].  You can return to the default minikube profile by running `minikube profile default`",
+	Short: "Profile gets or sets the current minikube profile",
+	Long:  "profile sets the current minikube profile, or gets the current profile if no arguments are provided.  This is used to run and manage multiple minikube instance.  You can return to the default minikube profile by running `minikube profile default`",
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) != 1 {
-			exit.Usage("usage: minikube profile MINIKUBE_PROFILE_NAME")
+		if len(args) == 0 {
+			profile := viper.GetString(pkgConfig.MachineProfile)
+			console.OutLn("%s", profile)
+			os.Exit(0)
+		} else if len(args) != 1 {
+			exit.Usage("usage: minikube profile [MINIKUBE_PROFILE_NAME]")
 		}
 
 		profile := args[0]

--- a/cmd/minikube/cmd/config/profile.go
+++ b/cmd/minikube/cmd/config/profile.go
@@ -36,7 +36,9 @@ var ProfileCmd = &cobra.Command{
 			profile := viper.GetString(pkgConfig.MachineProfile)
 			console.OutLn("%s", profile)
 			os.Exit(0)
-		} else if len(args) != 1 {
+		}
+		
+		if len(args) > 1 {
 			exit.Usage("usage: minikube profile [MINIKUBE_PROFILE_NAME]")
 		}
 

--- a/cmd/minikube/cmd/config/profile.go
+++ b/cmd/minikube/cmd/config/profile.go
@@ -18,7 +18,7 @@ package config
 
 import (
 	"os"
-	
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	pkgConfig "k8s.io/minikube/pkg/minikube/config"
@@ -37,7 +37,7 @@ var ProfileCmd = &cobra.Command{
 			console.OutLn("%s", profile)
 			os.Exit(0)
 		}
-		
+
 		if len(args) > 1 {
 			exit.Usage("usage: minikube profile [MINIKUBE_PROFILE_NAME]")
 		}


### PR DESCRIPTION
[As mentioned in #2371](https://github.com/kubernetes/minikube/issues/2371#issuecomment-462216099) there's currently no way to get the currently-active machine profile, which makes some automation I'm doing break when using different profiles. This fix just returns the current profile when no arguments are provided to the profile command, and updates the corresponding documentation.