### PR TITLE
Enable registry-proxy

### DIFF
--- a/deploy/addons/registry/registry-proxy.yaml.tmpl
+++ b/deploy/addons/registry/registry-proxy.yaml.tmpl
@@ -1,0 +1,28 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels:
+    kubernetes.io/minikube-addons: registry
+    addonmanager.kubernetes.io/mode: Reconcile
+  name: registry-proxy
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      labels:
+        kubernetes.io/minikube-addons: registry
+        addonmanager.kubernetes.io/mode: Reconcile
+    spec:
+      containers:
+      - image: gcr.io/google_containers/kube-registry-proxy:0.4
+        imagePullPolicy: IfNotPresent
+        name: registry-proxy
+        ports:
+        - name: registry
+          containerPort: 80
+          hostPort: 5000
+        env:
+        - name: REGISTRY_HOST
+          value: registry.kube-system.svc.cluster.local
+        - name: REGISTRY_PORT
+          value: "80"


### PR DESCRIPTION
As per [this blog](https://blog.hasura.io/sharing-a-local-registry-for-minikube-37c7240d0615) and [this gist](https://gist.github.com/coco98/b750b3debc6d517308596c248daf3bb1), we need to deploy a registry-proxy
which will expose docker registry on the minikube host.

Once this daemon set is deployed on minikube, one can access registry on `$(minikube ip):5000`.
This has been tested with minikube v1.0.1 with none driver. With this, one will not have to use
`kubectl port-forward`. I was able to push a container image to registry using
```
docker push $(minikube ip):5000/test-img
```
And then ran it in minikube using
```
kubectl run -i -t test-img --image=$(minikube ip):5000/test-img --restart=Never
```