### PR TITLE
Fix kvm remove when domain is not running

### DIFF
--- a/pkg/drivers/kvm/kvm.go
+++ b/pkg/drivers/kvm/kvm.go
@@ -461,7 +461,7 @@ func (d *Driver) Remove() error {
 func (d *Driver) destroyRunningDomain(dom *libvirt.Domain) error {
 	state, reason, err := dom.GetState()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "getting domain state")
 	}
 
 	if state == libvirt.DOMAIN_SHUTOFF && reason == int(libvirt.DOMAIN_SHUTOFF_DESTROYED) {

--- a/pkg/drivers/kvm/kvm.go
+++ b/pkg/drivers/kvm/kvm.go
@@ -451,11 +451,7 @@ func (d *Driver) Remove() error {
 		return errors.Wrap(err, "destroying running domain")
 	}
 
-	if err := dom.Undefine(); err != nil {
-		return err
-	}
-
-	return nil
+	return dom.Undefine()
 }
 
 func (d *Driver) destroyRunningDomain(dom *libvirt.Domain) error {


### PR DESCRIPTION
Fix for https://github.com/kubernetes/minikube/issues/4319

This PR is considering only the case when the running domain was deleted, with `virsh destroy DOMAIN_NAME`, and not the problem of undefining a domain, I'll create a separate PR for that to simplify review.