### PR TITLE
Pass minikube stdin to the kubectl command

### DIFF
--- a/cmd/minikube/cmd/kubectl.go
+++ b/cmd/minikube/cmd/kubectl.go
@@ -67,6 +67,7 @@ var kubectlCmd = &cobra.Command{
 
 		glog.Infof("Running %s %v", path, args)
 		c := exec.Command(path, args...)
+		c.Stdin = os.Stdin
 		c.Stdout = os.Stdout
 		c.Stderr = os.Stderr
 		if err := c.Run(); err != nil {


### PR DESCRIPTION
This is needed for doing e.g. "apply -f -"

Closes #4333