### PR TITLE
clean vendor on make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,6 +209,7 @@ checksum:
 clean:
 	rm -rf $(BUILD_DIR)
 	rm -f pkg/minikube/assets/assets.go
+	rm -rf ./vendor
 
 .PHONY: gendocs
 gendocs: out/docs/minikube.md


### PR DESCRIPTION
To fix the build issue when there is there a vendor folder conflicting with gomod