### PR TITLE
Fix "mount failed: File exists" issue when unmount fails

### DIFF
--- a/pkg/minikube/cluster/mount.go
+++ b/pkg/minikube/cluster/mount.go
@@ -132,12 +132,15 @@ func mntCmd(source string, target string, c *MountConfig) string {
 
 // umountCmd returns a command for unmounting
 func umountCmd(target string, force bool) string {
-	flag := ""
+	// Call fuser before unmount, for killing the processes using the mount point. Notes: don't use 'lsof' to avoid the innocents
+	flag1 := fmt.Sprintf("sudo fuser -km %s;", target)
+	flag2 := ""
 	if force {
-		flag = "-f "
+		flag1 = ""
+		flag2 = "-f "
 	}
 	// grep because findmnt will also display the parent!
-	return fmt.Sprintf("findmnt -T %s | grep %s && sudo umount %s%s || true", target, target, flag, target)
+	return fmt.Sprintf("[ \"x$(findmnt -T %s | grep %s)\" != \"x\" ] && { %s sudo umount %s%s; } || echo ", target, target, flag1, flag2, target)
 }
 
 // Unmount unmounts a path

--- a/pkg/minikube/cluster/mount_test.go
+++ b/pkg/minikube/cluster/mount_test.go
@@ -54,7 +54,7 @@ func TestMount(t *testing.T) {
 			target: "target",
 			cfg:    &MountConfig{Type: "9p", Mode: os.FileMode(0700)},
 			want: []string{
-				"findmnt -T target | grep target && sudo umount target || true",
+				"[ \"x$(findmnt -T target | grep target)\" != \"x\" ] && { sudo fuser -km target; sudo umount target; } || echo ",
 				"sudo mkdir -m 700 -p target && sudo mount -t 9p -o dfltgid=0,dfltuid=0 src target",
 			},
 		},
@@ -64,7 +64,7 @@ func TestMount(t *testing.T) {
 			target: "target",
 			cfg:    &MountConfig{Type: "9p", Mode: os.FileMode(0700), UID: "docker", GID: "docker"},
 			want: []string{
-				"findmnt -T target | grep target && sudo umount target || true",
+				"[ \"x$(findmnt -T target | grep target)\" != \"x\" ] && { sudo fuser -km target; sudo umount target; } || echo ",
 				"sudo mkdir -m 700 -p target && sudo mount -t 9p -o dfltgid=$(grep ^docker: /etc/group | cut -d: -f3),dfltuid=$(id -u docker) src target",
 			},
 		},
@@ -77,7 +77,7 @@ func TestMount(t *testing.T) {
 				"cache":    "fscache",
 			}},
 			want: []string{
-				"findmnt -T /target | grep /target && sudo umount /target || true",
+				"[ \"x$(findmnt -T /target | grep /target)\" != \"x\" ] && { sudo fuser -km /target; sudo umount /target; } || echo ",
 				"sudo mkdir -m 777 -p /target && sudo mount -t 9p -o cache=fscache,dfltgid=72,dfltuid=82,noextend,version=9p2000.u 10.0.0.1 /target",
 			},
 		},
@@ -89,7 +89,7 @@ func TestMount(t *testing.T) {
 				"version": "9p2000.L",
 			}},
 			want: []string{
-				"findmnt -T tgt | grep tgt && sudo umount tgt || true",
+				"[ \"x$(findmnt -T tgt | grep tgt)\" != \"x\" ] && { sudo fuser -km tgt; sudo umount tgt; } || echo ",
 				"sudo mkdir -m 700 -p tgt && sudo mount -t 9p -o dfltgid=0,dfltuid=0,version=9p2000.L src tgt",
 			},
 		},
@@ -115,7 +115,7 @@ func TestUnmount(t *testing.T) {
 		t.Fatalf("Unmount(/mnt): %v", err)
 	}
 
-	want := []string{"findmnt -T /mnt | grep /mnt && sudo umount /mnt || true"}
+	want := []string{"[ \"x$(findmnt -T /mnt | grep /mnt)\" != \"x\" ] && { sudo fuser -km /mnt; sudo umount /mnt; } || echo "}
 	if diff := cmp.Diff(r.cmds, want); diff != "" {
 		t.Errorf("command diff (-want +got): %s", diff)
 	}


### PR DESCRIPTION
- Fix for #4239

- Why this fix:
Before the fix, the unmount will be always return success, that will cause: a) unmount err message cannot be reported timely. b) force unmount will be never ran.

The fixes including: a) fix above error b) delete corpse processes before unmount.

- My UT cases: PASS
case-1: a) minikube mount b) minikube ssh; cd <mount point> c) Ctrl+c  d) 'minikube mount' again.
case-2: a) minikube mount b) minikube ssh; run script under mount point dir  c) Ctrl+c  d) 'minikube mount' again.

/assign @tstromberg
Could you please help review? Thanks.