### PR TITLE
Add kvm2 --version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,7 +366,7 @@ release-minikube: out/minikube checksum
 out/docker-machine-driver-kvm2:
 	go build 																		\
 		-installsuffix "static" 													\
-		-ldflags "-X k8s.io/minikube/pkg/drivers/kvm/version.VERSION=$(VERSION)" 	\
+		-ldflags "-X k8s.io/minikube/pkg/drivers/kvm.version=$(VERSION)" 	\
 		-tags libvirt.1.3.1 														\
 		-o $(BUILD_DIR)/docker-machine-driver-kvm2 									\
 		k8s.io/minikube/cmd/drivers/kvm

--- a/pkg/drivers/kvm/version.go
+++ b/pkg/drivers/kvm/version.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.
 
@@ -16,21 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package kvm
 
-import (
-	"fmt"
-	"os"
+// The current version of the docker-machine-driver-kvm2
 
-	"github.com/docker/machine/libmachine/drivers/plugin"
-	"k8s.io/minikube/pkg/drivers/kvm"
-)
+// version is a private field and should be set when compiling with --ldflags="-X k8s.io/minikube/pkg/drivers/kvm.version=vX.Y.Z"
+var version = "v0.0.0-unset"
 
-func main() {
-	if len(os.Args) > 1 && os.Args[1] == "--version" {
-		fmt.Println(kvm.GetVersion())
-		return
-	}
-
-	plugin.RegisterDriver(kvm.NewDriver("", ""))
+// GetVersion returns the current docker-machine-driver-kvm2 version
+func GetVersion() string {
+	return version
 }


### PR DESCRIPTION
FIx https://github.com/kubernetes/minikube/issues/4387

Considerations:

- I've added a version.go to the kvm driver instead of importing `minikube/version`
- As we are only supporting `--version`, I didn't use cobra/viper

Let me know what you think. I'll add it to hyperkit, once this one was approved.