### PR TITLE
Fix kvm trobleshoot documentation

### DIFF
--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -92,6 +92,7 @@ In case the default network doesn't exist you can define it.
 ```shell
 curl https://raw.githubusercontent.com/libvirt/libvirt/master/src/network/default.xml > kvm-default.xml
 virsh net-define kvm-default.xml
+virsh net-start default
 ```
 
 ## Hyperkit driver


### PR DESCRIPTION
Sorry! I forgot to add `net-start` on the documentation. When using `net-define` it creates a persistent network but doesn't start it, different from `net-create` that creates a transient network and starts it (minikube doesn't work with a transient network)