### PR TITLE
fix ShowDriverDeprecationNotification config setting

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -132,6 +132,10 @@ var settings = []Setting{
 		set:  SetString, //TODO(r2d4): more validation here?
 	},
 	{
+		name: config.ShowDriverDeprecationNotification,
+		set:  SetBool,
+	},
+	{
 		name: config.ShowBootstrapperDeprecationNotification,
 		set:  SetBool,
 	},

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -325,21 +325,21 @@ func preCreateHost(config *cfg.MachineConfig) {
 			console.Warning(`The kvm driver is deprecated and support for it will be removed in a future release.
 				Please consider switching to the kvm2 driver, which is intended to replace the kvm driver.
 				See https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm2-driver for more information.
-				To disable this message, run [minikube config set WantShowDriverDeprecationNotification false]`)
+				To disable this message, run [minikube config set ShowDriverDeprecationNotification false]`)
 		}
 	case "xhyve":
 		if viper.GetBool(cfg.ShowDriverDeprecationNotification) {
 			console.Warning(`The xhyve driver is deprecated and support for it will be removed in a future release.
 Please consider switching to the hyperkit driver, which is intended to replace the xhyve driver.
 See https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#hyperkit-driver for more information.
-To disable this message, run [minikube config set WantShowDriverDeprecationNotification false]`)
+To disable this message, run [minikube config set ShowDriverDeprecationNotification false]`)
 		}
 	case "vmwarefusion":
 		if viper.GetBool(cfg.ShowDriverDeprecationNotification) {
 			console.Warning(`The vmwarefusion driver is deprecated and support for it will be removed in a future release.
 				Please consider switching to the new vmware unified driver, which is intended to replace the vmwarefusion driver.
 				See https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#vmware-unified-driver for more information.
-				To disable this message, run [minikube config set WantShowDriverDeprecationNotification false]`)
+				To disable this message, run [minikube config set ShowDriverDeprecationNotification false]`)
 		}
 	}
 }


### PR DESCRIPTION
fix #4161:
WantShowDriverDeprecationNotification property seems like a mistype in the console message. The real setting is ShowDriverDeprecationNotification but it needs to be added in the list of configurable settings (the variable settings in config.go). I could have renamed everything to WantShowDriverDeprecationNotification but it seems easier and still very readable that way.

User test:

![#4161](https://user-images.githubusercontent.com/9560087/58992906-53d4d700-87ec-11e9-9474-2261925219c5.png)
