### PR TITLE
Fix busybox version in integration tests

### DIFF
--- a/test/integration/testdata/busybox-mount-test.yaml
+++ b/test/integration/testdata/busybox-mount-test.yaml
@@ -6,7 +6,7 @@ metadata:
     integration-test: busybox-mount
 spec:
   containers:
-  - image: busybox:glibc
+  - image: busybox:1.28.4-glibc
     command: [ "/bin/sh", "-c", "--" ]
     args: [ "cat /mount-9p/fromhost; echo test > /mount-9p/frompod; rm /mount-9p/fromhostremove; echo test > /mount-9p/frompodremove;" ]
     name: busybox

--- a/test/integration/testdata/busybox.yaml
+++ b/test/integration/testdata/busybox.yaml
@@ -6,7 +6,7 @@ metadata:
     integration-test: busybox
 spec:
   containers:
-  - image: busybox:glibc
+  - image: busybox:1.28.4-glibc
     command:
       - sleep
       - "3600"


### PR DESCRIPTION
fix #4475 
To resolve domain name with nslookup , we should use  busybox:1.28.4 instead of latest in the integration tests.
c.f. https://github.com/docker-library/busybox/issues/48
