### PR TITLE
Run one go build at a time when building cri-o

### DIFF
--- a/deploy/iso/minikube-iso/package/crio-bin/crio-bin.mk
+++ b/deploy/iso/minikube-iso/package/crio-bin/crio-bin.mk
@@ -29,7 +29,8 @@ endef
 
 define CRIO_BIN_BUILD_CMDS
 	mkdir -p $(@D)/bin
-	$(CRIO_BIN_ENV) $(MAKE) $(TARGET_CONFIGURE_OPTS) -C $(@D) GIT_COMMIT=$(CRIO_BIN_COMMIT) PREFIX=/usr binaries
+	# Only run one go build at a time, because of race conditions
+	$(CRIO_BIN_ENV) $(MAKE1) $(TARGET_CONFIGURE_OPTS) -C $(@D) GIT_COMMIT=$(CRIO_BIN_COMMIT) PREFIX=/usr binaries
 endef
 
 define CRIO_BIN_INSTALL_TARGET_CMDS


### PR DESCRIPTION
Apparently there is a race condition when running multiple
`go build -i` at the same time, and buildroot defaults to
BR2_JLEVEL=0 which means use 2 * CPU number of make jobs.
So run the package build with `make -j 1` to avoid this.

Closes #4345