### PR TITLE
Add 'native-ssh' flag to 'minikube start' and 'minikube ssh'

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -265,6 +265,10 @@ var settings = []Setting{
 		name: "embed-certs",
 		set:  SetBool,
 	},
+	{
+		name: "native-ssh",
+		set:  SetBool,
+	},
 }
 
 // ConfigCmd represents the config command

--- a/cmd/minikube/cmd/ssh.go
+++ b/cmd/minikube/cmd/ssh.go
@@ -19,7 +19,10 @@ package cmd
 import (
 	"os"
 
+	"github.com/docker/machine/libmachine/ssh"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
 	"k8s.io/minikube/pkg/minikube/cluster"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
@@ -46,6 +49,12 @@ var sshCmd = &cobra.Command{
 		if host.Driver.DriverName() == constants.DriverNone {
 			exit.UsageT("'none' driver does not support 'minikube ssh' command")
 		}
+		if viper.GetBool(nativeSSH) {
+			ssh.SetDefaultClient(ssh.Native)
+		} else {
+			ssh.SetDefaultClient(ssh.External)
+		}
+
 		err = cluster.CreateSSHShell(api, args)
 		if err != nil {
 			// This is typically due to a non-zero exit code, so no need for flourish.
@@ -54,4 +63,8 @@ var sshCmd = &cobra.Command{
 			os.Exit(exit.Failure)
 		}
 	},
+}
+
+func init() {
+	sshCmd.Flags().Bool(nativeSSH, true, "Use native Golang SSH client (default true). Set to 'false' to use the command line 'ssh' command when accessing the docker machine. Useful for the machine drivers when they will not start with 'Waiting for SSH'.")
 }

--- a/go.sum
+++ b/go.sum
@@ -8,7 +8,6 @@ dmitri.shuralyov.com/app/changes v0.0.0-20180602232624-0a106ad413e3/go.mod h1:Yl
 dmitri.shuralyov.com/html/belt v0.0.0-20180602232347-f7d459c86be0/go.mod h1:JLBrvjyP0v+ecvNYvCpyZgu5/xkfAUhi6wJj28eUfSU=
 dmitri.shuralyov.com/service/change v0.0.0-20181023043359-a85b471d5412/go.mod h1:a1inKt/atXimZ4Mv927x+r7UpyzRUf4emIoiiSC2TN4=
 dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D6DFvNNtx+9ybjezNCa8XF0xaYcETyp6rHWU=
-github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/Azure/azure-sdk-for-go v21.4.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
@@ -37,6 +36,7 @@ github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrU
 github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdcM=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
+github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=


### PR DESCRIPTION
Docker machine gives an option for sshing into a running container of using the Golang SSH native client or using the external 'ssh' command line executable.

Normally, "docker-machine ssh" uses the "external" client by default and a "--native-ssh" flag must be passed to enable the native client.

Minikube by set the client to native by default with no option to change this behavior.  This causes issues with some VM drivers.

Though the native SSH client for Golang is more efficient than the command line 'ssh' command, there are times in which using the 'ssh' CLI is necessary.

This PR adds a "--no-native-ssh" flag to the `minikube start` command an and associated "no-native-ssh" config option (through `minikube config set no-native-ssh true`.
