### PR TITLE
Unset current-context only if the profile is the current context

### DIFF
--- a/pkg/util/kubeconfig.go
+++ b/pkg/util/kubeconfig.go
@@ -319,10 +319,16 @@ func UnsetCurrentContext(filename, machineName string) error {
 	if err != nil {
 		return errors.Wrap(err, "Error getting kubeconfig status")
 	}
-	confg.CurrentContext = ""
-	if err := WriteConfig(confg, filename); err != nil {
-		return errors.Wrap(err, "writing kubeconfig")
+
+	// Unset current-context only if profile is the current-context
+	if confg.CurrentContext == machineName {
+		confg.CurrentContext = ""
+		if err := WriteConfig(confg, filename); err != nil {
+			return errors.Wrap(err, "writing kubeconfig")
+		}
+		return nil
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
This pull request is intended as a fix for the situation described in #4476 . `minikube stop` unsets the current-context if it is the profile that is being stopped.