### PR TITLE
Add golint and gocyclo smaller make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,12 @@ gendocs: out/docs/minikube.md
 
 .PHONY: fmt
 fmt:
-	@gofmt -l -s -w $(SOURCE_DIRS)
+	@gofmt -s -w $(SOURCE_DIRS)
+
+.PHONY: gofmt
+gofmt:
+	@gofmt -s -l $(SOURCE_DIRS)
+	@test -z "`gofmt -s -l $(SOURCE_DIRS)`"
 
 .PHONY: vet
 vet:

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ MINIKUBE_BUILD_TAGS := container_image_ostree_stub containers_image_openpgp
 MINIKUBE_INTEGRATION_BUILD_TAGS := integration $(MINIKUBE_BUILD_TAGS)
 
 CMD_SOURCE_DIRS = cmd pkg
-SOURCE_DIRS = $(SOURCE_DIRS) test
+SOURCE_DIRS = $(CMD_SOURCE_DIRS) test
 SOURCE_PACKAGES = ./cmd/... ./pkg/... ./test/...
 
 # $(call DOCKER, image, command)
@@ -222,6 +222,14 @@ fmt:
 .PHONY: vet
 vet:
 	@go vet $(SOURCE_PACKAGES)
+
+.PHONY: golint
+golint:
+	@golint -set_exit_status $(SOURCE_PACKAGES)
+
+.PHONY: gocyclo
+gocyclo:
+	@gocyclo -over 15 `find $(SOURCE_DIRS) -type f -name "*.go"`
 
 out/linters/golangci-lint:
 	mkdir -p out/linters


### PR DESCRIPTION
The new `lint` target is quite big, takes a long time to run.

The end result is that people don't use it, until at the end...

Also fix the broken `fmt` and `reportcard` ones:

`Recursive variable 'SOURCE_DIRS' references itself (eventually).`