### PR TITLE
zh-CN: Use non-unicode percent signs for proper interpolation

### DIFF
--- a/pkg/minikube/translate/translations/zh-CN.json
+++ b/pkg/minikube/translate/translations/zh-CN.json
@@ -22,7 +22,7 @@
 	"Check that minikube is running and that you have specified the correct namespace (-n flag) if required.": "",
 	"Configuring environment for Kubernetes %s on %s %s": "开始为Kubernetes %s，%s %s 配置环境变量",
 	"Configuring local host environment ...": "",
-	"Creating %s VM (CPUs=%d, Memory=%dMB, Disk=%dMB) ...": "正在创建%s虚拟机（CPU =％d，内存=％dMB，磁盘=％dMB）...",
+	"Creating %s VM (CPUs=%d, Memory=%dMB, Disk=%dMB) ...": "正在创建%s虚拟机（CPU=%d，内存=%dMB，磁盘=%dMB）...",
 	"Creating mount %s ...": "",
 	"Deleting %q from %s ...": "",
 	"Documentation: %s": "",


### PR DESCRIPTION
Fixes issue where zh-CN translation appears as:

`🔥  正在创建virtualbox虚拟机（CPU =％d，内存=％dMB，磁盘=％dMB）...%!(EXTRA number.Formatter=2, number.Formatter=2048, number.Formatter=20000)`

With this PR, it appears as:

`🔥  正在创建virtualbox虚拟机（CPU=2，内存=2048MB，磁盘=20000MB）...`
