### PR TITLE
Universally redirect stdlog messages to glog

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -424,7 +424,7 @@ func generateConfig(cmd *cobra.Command, k8sVersion string) (cfg.Config, error) {
 	repository := viper.GetString(imageRepository)
 	mirrorCountry := strings.ToLower(viper.GetString(imageMirrorCountry))
 	if strings.ToLower(repository) == "auto" || mirrorCountry != "" {
-		console.OutStyle(console.Connectivity, "checking main repository and mirrors for images")
+		// console.OutStyle(console.Connectivity, "checking main repository and mirrors for images")
 		found, autoSelectedRepository, err := selectImageRepository(mirrorCountry, k8sVersion)
 		if err != nil {
 			exit.WithError("Failed to check main repository and mirrors for images for images", err)

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -291,6 +291,7 @@ func showKubectlConnectInfo(kubeconfig *pkgutil.KubeConfigSetup) {
 func selectImageRepository(mirrorCountry string, k8sVersion string) (bool, string, error) {
 	var tryCountries []string
 	var fallback string
+	glog.Infof("selecting image repository for country %s ...", mirrorCountry)
 
 	if mirrorCountry != "" {
 		localRepos, ok := constants.ImageRepositories[mirrorCountry]
@@ -424,7 +425,6 @@ func generateConfig(cmd *cobra.Command, k8sVersion string) (cfg.Config, error) {
 	repository := viper.GetString(imageRepository)
 	mirrorCountry := strings.ToLower(viper.GetString(imageMirrorCountry))
 	if strings.ToLower(repository) == "auto" || mirrorCountry != "" {
-		// console.OutStyle(console.Connectivity, "checking main repository and mirrors for images")
 		found, autoSelectedRepository, err := selectImageRepository(mirrorCountry, k8sVersion)
 		if err != nil {
 			exit.WithError("Failed to check main repository and mirrors for images for images", err)

--- a/cmd/minikube/main.go
+++ b/cmd/minikube/main.go
@@ -17,7 +17,11 @@ limitations under the License.
 package main
 
 import (
+	"bytes"
+	"fmt"
+	"log"
 	"os"
+	"strconv"
 
 	"github.com/golang/glog"
 	"github.com/pkg/profile"
@@ -32,7 +36,9 @@ import (
 const minikubeEnableProfile = "MINIKUBE_ENABLE_PROFILING"
 
 func main() {
+	captureStdLogMessages()
 	defer glog.Flush()
+
 	if os.Getenv(minikubeEnableProfile) == "1" {
 		defer profile.Start(profile.TraceProfile).Stop()
 	}
@@ -43,4 +49,32 @@ func main() {
 	console.SetErrFile(os.Stderr)
 	translate.DetermineLocale()
 	cmd.Execute()
+}
+
+// captureStdLogMessages arranges for messages written to the Go "log" package's to appear in glog
+func captureStdLogMessages() {
+	log.SetFlags(log.Lshortfile)
+	log.SetOutput(logBridge{})
+}
+
+type logBridge struct{}
+
+// Write parses the standard logging line and passes its components to glog
+func (lb logBridge) Write(b []byte) (n int, err error) {
+	// Split "d.go:23: message" into "d.go", "23", and "message".
+	parts := bytes.SplitN(b, []byte{':'}, 3)
+	if len(parts) != 3 || len(parts[0]) < 1 || len(parts[2]) < 1 {
+		glog.Errorf("bad log format: %s", b)
+		return
+	}
+
+	file := string(parts[0])
+	text := string(parts[2][1:]) // skip leading space
+	line, err := strconv.Atoi(string(parts[1]))
+	if err != nil {
+		text = fmt.Sprintf("bad line number: %s", b)
+		line = 0
+	}
+	glog.Infof("stdlog: %s:%d %s", file, line, text)
+	return len(b), nil
 }

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -102,4 +102,3 @@ func GetKubeConfigPath() string {
 	}
 	return filepath.SplitList(kubeConfigEnv)[0]
 }
-

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -102,3 +102,4 @@ func GetKubeConfigPath() string {
 	}
 	return filepath.SplitList(kubeConfigEnv)[0]
 }
+

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -17,10 +17,7 @@ limitations under the License.
 package machine
 
 import (
-	"bytes"
-	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"os/exec"
 	"path"
@@ -285,23 +282,6 @@ func getDstPath(dst string) (string, error) {
 
 // CacheImage caches an image
 func CacheImage(image, dst string) error {
-	// There are go-containerregistry calls here that result in
-	// ugly log messages getting printed to stdout. Capture
-	// stdout instead and writing it to info.
-	r, w, err := os.Pipe()
-	if err != nil {
-		return errors.Wrap(err, "opening writing buffer")
-	}
-	log.SetOutput(w)
-	defer func() {
-		log.SetOutput(os.Stdout)
-		var buf bytes.Buffer
-		if _, err := io.Copy(&buf, r); err != nil {
-			glog.Errorf("output copy failed: %v", err)
-		}
-		glog.Infof(buf.String())
-	}()
-
 	glog.Infof("Attempting to cache image: %s at %s\n", image, dst)
 	if _, err := os.Stat(dst); err == nil {
 		return nil


### PR DESCRIPTION
selectImageRepository() was noisy due to go-containerregistry lookups. This was hitting a different set of calls than what we had already masked in cache_images.go. This makes it universal for all libraries.

The code was based on glog.CopyStandardLogTo(), except that the upstream version also copies the message to stdout, which is what we are trying to avoid.