### PR TITLE
Allow --kubernetes-version to be specified without the leading v

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -586,15 +586,17 @@ func validateNetwork(h *host.Host) string {
 
 // validateKubernetesVersions ensures that the requested version is reasonable
 func validateKubernetesVersions(old *cfg.Config) (string, bool) {
-	nv := viper.GetString(kubernetesVersion)
+	rawVersion := viper.GetString(kubernetesVersion)
 	isUpgrade := false
-	if nv == "" {
-		nv = constants.DefaultKubernetesVersion
+	if rawVersion == "" {
+		rawVersion = constants.DefaultKubernetesVersion
 	}
-	nvs, err := semver.Make(strings.TrimPrefix(nv, version.VersionPrefix))
+
+	nvs, err := semver.Make(strings.TrimPrefix(rawVersion, version.VersionPrefix))
 	if err != nil {
-		exit.WithCode(exit.Data, "Unable to parse %q: %v", nv, err)
+		exit.WithCode(exit.Data, "Unable to parse %q: %v", rawVersion, err)
 	}
+	nv := version.VersionPrefix + nvs.String()
 
 	if old == nil || old.KubernetesConfig.KubernetesVersion == "" {
 		return nv, isUpgrade

--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"os"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/docker/machine/libmachine/state"
@@ -82,8 +83,8 @@ func TestVersionUpgrade(t *testing.T) {
 	releaseRunner.RunCommand("stop", true)
 	releaseRunner.CheckStatus(state.Stopped.String())
 
-	// Trim the leading "v" prefix to assert that we handle  it properly.
-	currentRunner.Start(fmt.Sprintf("--kubernetes-version=%s", strings.TrimPrefix(constants.NewestKubernetesVersion, "v"))
+	// Trim the leading "v" prefix to assert that we handle it properly.
+	currentRunner.Start(fmt.Sprintf("--kubernetes-version=%s", strings.TrimPrefix(constants.NewestKubernetesVersion, "v")))
 	currentRunner.CheckStatus(state.Running.String())
 	currentRunner.RunCommand("delete", true)
 	currentRunner.CheckStatus(state.None.String())

--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -82,7 +82,8 @@ func TestVersionUpgrade(t *testing.T) {
 	releaseRunner.RunCommand("stop", true)
 	releaseRunner.CheckStatus(state.Stopped.String())
 
-	currentRunner.Start(fmt.Sprintf("--kubernetes-version=%s", constants.NewestKubernetesVersion))
+	// Trim the leading "v" prefix to assert that we handle  it properly.
+	currentRunner.Start(fmt.Sprintf("--kubernetes-version=%s", strings.TrimPrefix(constants.NewestKubernetesVersion, "v"))
 	currentRunner.CheckStatus(state.Running.String())
 	currentRunner.RunCommand("delete", true)
 	currentRunner.CheckStatus(state.None.String())


### PR DESCRIPTION
I bumped into this issue when preparing for the demo at KubeCon.

With this PR, minikube allows both `--kubernetes-version=v1.15.0` and `--kubernetes-version=1.15.0`. Otherwise, it fails later when it tries to cache images.

This PR was inspired by @dimitropoulos's work in #3766 - but rather than raising an early error if v is omitted, allows both formats.