### PR TITLE
Makefile: add platform specific phony targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ out/minikube$(IS_EXE): out/minikube-$(GOOS)-$(GOARCH)$(IS_EXE)
 	cp $< $@
 
 out/minikube-windows-amd64.exe: out/minikube-windows-amd64
-	cp out/minikube-windows-amd64 out/minikube-windows-amd64.exe
+	mv out/minikube-windows-amd64 out/minikube-windows-amd64.exe
 
 out/minikube-%: pkg/minikube/assets/assets.go $(shell find $(CMD_SOURCE_DIRS) -type f -name "*.go")
 ifeq ($(MINIKUBE_BUILD_IN_DOCKER),y)
@@ -193,6 +193,15 @@ pkg/minikube/assets/assets.go: $(shell find deploy/addons -type f)
 
 .PHONY: cross
 cross: out/minikube-linux-$(GOARCH) out/minikube-darwin-amd64 out/minikube-windows-amd64.exe
+
+.PHONY: windows
+windows: out/minikube-windows-amd64.exe
+
+.PHONY: darwin
+darwin: out/minikube-darwin-amd64
+
+.PHONY: linux
+linux: out/minikube-linux-$(GOARCH)
 
 .PHONY: e2e-cross
 e2e-cross: e2e-linux-amd64 e2e-darwin-amd64 e2e-windows-amd64.exe

--- a/docs/contributors/build_guide.md
+++ b/docs/contributors/build_guide.md
@@ -46,6 +46,11 @@ $ ls out/
 minikube-darwin-amd64  minikube-linux-amd64  minikube-windows-amd64.exe
 ```
 
+You can also build platform specific executables like below:
+    1. `make windows` will build the binary for Windows platform
+    2. `make linux` will build the binary for Linux platform
+    3. `make darwin` will build the binary for Darwin/Mac platform
+
 ### Run Instructions
 
 Start the cluster using your built minikube with:


### PR DESCRIPTION
1. Added platform specific Phony targets (Linux, Windows & Darwin)
2. Added Documentation in the build instructions about this.
3. Changed `cp` to `mv` to remove a duplicate file.

Fixes #4458 