### PR TITLE
WIP: Add example script to setup minikube with none driver on Debian

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -e
+
+if [ "$EUID" -eq 0 ]
+  then echo "Run without sudo/root"
+  exit
+fi
+
+# Install Docker dependencies
+sudo apt-get -y install apt-transport-https ca-certificates curl gnupg-agent software-properties-common
+sleep 1
+
+# Add Docker key (Ubuntu Bionic/Linux Mint) - TODO: Pass parameter to add key based on distro type
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(. /etc/os-release; echo "$UBUNTU_CODENAME") stable"
+sudo apt-get update
+
+# Install Docker
+sudo apt-get -y install docker-ce docker-ce-cli containerd.io
+sleep 1
+
+# Add user to docker group
+sudo usermod -aG docker $USER
+sleep 1
+
+# Install kubectl
+sudo curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+sudo chmod +x ./kubectl
+sudo mv ./kubectl /usr/local/bin/kubectl
+sudo rm -rf kubectl
+kubectl version
+sleep 1
+
+# Download latest version of minikube and install - TODO: Get the latest version of minikube instead of hard coding the url
+sudo curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.2.0/minikube-linux-amd64
+sudo chmod +x minikube 
+sudo cp minikube /usr/local/bin/
+sudo rm -rf minikube
+sleep 1
+
+# Set env variable for minikube
+export CHANGE_MINIKUBE_NONE_USER=true
+
+# Start minikube using none driver (Linux) - TODO: Receive driver type as script parameter and other parameters as well
+sudo minikube start --vm-driver=none
+sleep 1
+
+# Set minikube user chown permissions
+sudo chown -R $USER $HOME/.kube $HOME/.minikube
+sudo chown -R $USER $HOME/.minikube
+sleep 1
+
+# Enable minikube dashboard addon
+sudo minikube addons enable dashboard
+sleep 1
+
+# Switch to use local docker daemon (needed if not using none driver)
+eval $(minikube docker-env)
+sleep 1
+
+# Get minikube status
+minikube status
+
+# Start minikube dashboard
+minikube dashboard &
+
+

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,16 @@
 #!/bin/bash
+#
+# Script for minikube full installation on Debian/Ubuntu/Mint
+# Install minikube dependencies (Docker and kubectl)
+# Start minikube and minikube dashboard
+# Options for minikube start (--vm-driver): virtualbox, kvm, none
+# Usage: 
+#   ./setup.sh
+#   ./setup.sh none
+#   ./setup.sh virtualbox
+#   ./setup.sh kvm
+#
+
 set -e
 
 if [ "$EUID" -eq 0 ]
@@ -6,9 +18,18 @@ if [ "$EUID" -eq 0 ]
   exit
 fi
 
+# Check minikube driver (virtualbox, kvm, none)
+if [ $1 = "none" ]; then
+  DRIVER="--vm-driver=none"
+elif [ $1 = "virtualbox" ]; then
+  DRIVER="--vm-driver=virtualbox"
+elif [ $1 = "kvm" ]; then
+  DRIVER="--vm-driver=kvm"
+fi
+
 # Install Docker dependencies
+echo "Installing Docker dependencies.."
 sudo apt-get -y install apt-transport-https ca-certificates curl gnupg-agent software-properties-common
-sleep 1
 
 # Add Docker key (Ubuntu Bionic/Linux Mint) - TODO: Pass parameter to add key based on distro type
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
@@ -16,52 +37,50 @@ sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubun
 sudo apt-get update
 
 # Install Docker
+echo "Installing Docker.."
 sudo apt-get -y install docker-ce docker-ce-cli containerd.io
-sleep 1
 
 # Add user to docker group
 sudo usermod -aG docker $USER
-sleep 1
 
 # Install kubectl
+echo "Installing kubectl.."
 sudo curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
 sudo chmod +x ./kubectl
 sudo mv ./kubectl /usr/local/bin/kubectl
 sudo rm -rf kubectl
-kubectl version
-sleep 1
 
-# Download latest version of minikube and install - TODO: Get the latest version of minikube instead of hard coding the url
-sudo curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.2.0/minikube-linux-amd64
+# Download latest version of minikube
+echo "Installing minikube.."
+sudo curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
 sudo chmod +x minikube 
 sudo cp minikube /usr/local/bin/
 sudo rm -rf minikube
-sleep 1
+minikube version
+kubectl version
 
 # Set env variable for minikube
 export CHANGE_MINIKUBE_NONE_USER=true
 
-# Start minikube using none driver (Linux) - TODO: Receive driver type as script parameter and other parameters as well
-sudo minikube start --vm-driver=none
-sleep 1
+# Start minikube
+echo "Starting minikube using driver ${DRIVER}.."
+sudo minikube start ${DRIVER}
 
 # Set minikube user chown permissions
 sudo chown -R $USER $HOME/.kube $HOME/.minikube
 sudo chown -R $USER $HOME/.minikube
-sleep 1
 
 # Enable minikube dashboard addon
 sudo minikube addons enable dashboard
-sleep 1
 
 # Switch to use local docker daemon (needed if not using none driver)
 eval $(minikube docker-env)
-sleep 1
 
 # Get minikube status
 minikube status
 
+# Set kubectl minikube context
+kubectl config use-context minikube
+
 # Start minikube dashboard
 minikube dashboard &
-
-


### PR DESCRIPTION
Installs minikube, docker, docker dependencies and kubectl.
Starts minikube using none-driver and minikube dashboard.

sudo chmod +x setup.sh
./setup.sh

Tested on Ubuntu Bionic and Linux Mint.