### PR TITLE
Use glog instead of logrus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/russross/blackfriday v0.0.0-20151117072312-300106c228d5 // indirect
 	github.com/samalba/dockerclient v0.0.0-20160414174713-91d7393ff859 // indirect
 	github.com/shurcooL/sanitized_anchor_name v0.0.0-20151028001915-10ef21a441db // indirect
-	github.com/sirupsen/logrus v1.4.1
+	github.com/sirupsen/logrus v1.4.1 // indirect
 	github.com/spf13/afero v0.0.0-20160816080757-b28a7effac97 // indirect
 	github.com/spf13/cast v0.0.0-20160730092037-e31f36ffc91a // indirect
 	github.com/spf13/cobra v0.0.0-20180228053838-6644d46b81fa

--- a/hack/release_notes/listpullreqs.go
+++ b/hack/release_notes/listpullreqs.go
@@ -50,7 +50,7 @@ func main() {
 	rootCmd.Flags().StringVar(&fromTag, "fromTag", "", "comparison of commits is based on this tag (defaults to the latest tag in the repo)")
 	rootCmd.Flags().StringVar(&toTag, "toTag", "master", "this is the commit that is compared with fromTag")
 	if err := rootCmd.Execute(); err != nil {
-		glog.FatalF("Failed to execute: %v", err)
+		glog.Fatalf("Failed to execute: %v", err)
 	}
 }
 
@@ -59,7 +59,7 @@ func printPullRequests() {
 
 	releases, _, err := client.Repositories.ListReleases(context.Background(), org, repo, &github.ListOptions{})
 	if err != nil {
-		glog.FatalF("Failed to list releases: %v", err)
+		glog.Fatalf("Failed to list releases: %v", err)
 	}
 	lastReleaseTime := *releases[0].PublishedAt
 	fmt.Println(fmt.Sprintf("Collecting pull request that were merged since the last release: %s (%s)", *releases[0].TagName, lastReleaseTime))
@@ -76,7 +76,7 @@ func printPullRequests() {
 			},
 		})
 		if err != nil {
-			glog.FatalF("Failed to list pull requests: %v", err)
+			glog.Fatalf("Failed to list pull requests: %v", err)
 		}
 
 		seen := 0

--- a/hack/release_notes/listpullreqs.go
+++ b/hack/release_notes/listpullreqs.go
@@ -21,8 +21,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/golang/glog"
 	"github.com/google/go-github/v25/github"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
 )
@@ -50,7 +50,7 @@ func main() {
 	rootCmd.Flags().StringVar(&fromTag, "fromTag", "", "comparison of commits is based on this tag (defaults to the latest tag in the repo)")
 	rootCmd.Flags().StringVar(&toTag, "toTag", "master", "this is the commit that is compared with fromTag")
 	if err := rootCmd.Execute(); err != nil {
-		logrus.Fatal(err)
+		glog.FatalF("Failed to execute: %v", err)
 	}
 }
 
@@ -59,7 +59,7 @@ func printPullRequests() {
 
 	releases, _, err := client.Repositories.ListReleases(context.Background(), org, repo, &github.ListOptions{})
 	if err != nil {
-		logrus.Fatal(err)
+		glog.FatalF("Failed to list releases: %v", err)
 	}
 	lastReleaseTime := *releases[0].PublishedAt
 	fmt.Println(fmt.Sprintf("Collecting pull request that were merged since the last release: %s (%s)", *releases[0].TagName, lastReleaseTime))
@@ -76,7 +76,7 @@ func printPullRequests() {
 			},
 		})
 		if err != nil {
-			logrus.Fatal(err)
+			glog.FatalF("Failed to list pull requests: %v", err)
 		}
 
 		seen := 0


### PR DESCRIPTION
glog is everywhere in repo, 

try to remove logrus dependency in go.mod but failed,  as docker relies on it (go mod why).

at least by changing logrus.Fatal to glog.Fatalf can make logrus as an indirect dependency