### PR TITLE
Fix docker-machine-driver-kvm2 version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,9 @@ CMD_SOURCE_DIRS = cmd pkg
 SOURCE_DIRS = $(CMD_SOURCE_DIRS) test
 SOURCE_PACKAGES = ./cmd/... ./pkg/... ./test/...
 
+# kvm2 ldflags
+KVM2_LDFLAGS := -X k8s.io/minikube/pkg/drivers/kvm.version=$(VERSION) -X k8s.io/minikube/pkg/drivers/kvm.gitCommitID=$(COMMIT) 
+
 # $(call DOCKER, image, command)
 define DOCKER
 	docker run --rm -e GOCACHE=/app/.cache -e IN_DOCKER=1 --user $(shell id -u):$(shell id -g) -w /app -v $(PWD):/app -v $(GOPATH):/go --entrypoint /bin/bash $(1) -c '$(2)'
@@ -387,11 +390,11 @@ release-minikube: out/minikube checksum
 	gsutil cp out/minikube-$(GOOS)-$(GOARCH).sha256 $(MINIKUBE_UPLOAD_LOCATION)/$(MINIKUBE_VERSION)/minikube-$(GOOS)-$(GOARCH).sha256
 
 out/docker-machine-driver-kvm2:
-	go build 																		\
-		-installsuffix "static" 													\
-		-ldflags "-X k8s.io/minikube/pkg/drivers/kvm.version=$(VERSION)" 	\
+	go build 																					\
+		-installsuffix "static" 												\
+		-ldflags="$(KVM2_LDFLAGS)" 											\
 		-tags libvirt.1.3.1 														\
-		-o $(BUILD_DIR)/docker-machine-driver-kvm2 									\
+		-o $(BUILD_DIR)/docker-machine-driver-kvm2 			\
 		k8s.io/minikube/cmd/drivers/kvm
 	chmod +X $@
 

--- a/cmd/drivers/kvm/main.go
+++ b/cmd/drivers/kvm/main.go
@@ -27,7 +27,7 @@ import (
 )
 
 func main() {
-	if len(os.Args) > 1 && os.Args[1] == "--version" {
+	if len(os.Args) > 1 && os.Args[1] == "version" {
 		fmt.Println(kvm.GetVersion())
 		return
 	}

--- a/cmd/drivers/kvm/main.go
+++ b/cmd/drivers/kvm/main.go
@@ -28,7 +28,8 @@ import (
 
 func main() {
 	if len(os.Args) > 1 && os.Args[1] == "version" {
-		fmt.Println(kvm.GetVersion())
+		fmt.Println("version:", kvm.GetVersion())
+		fmt.Println("commit:", kvm.GetGitCommitID())
 		return
 	}
 

--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -99,7 +99,7 @@ virsh net-start default
 Make sure you are running the lastest version of your driver.
 
  ```shell
-docker-machine-driver-kvm2 --version
+docker-machine-driver-kvm2 version
 ```
 
 ## Hyperkit driver

--- a/pkg/drivers/kvm/version.go
+++ b/pkg/drivers/kvm/version.go
@@ -21,7 +21,15 @@ package kvm
 // version is a private field and should be set when compiling with --ldflags="-X k8s.io/minikube/pkg/drivers/kvm.version=vX.Y.Z"
 var version = "v0.0.0-unset"
 
+// gitCommitID is a private field and should be set when compiling with --ldflags="-X k8s.io/minikube/pkg/drivers/kvm.gitCommitID=<commit-id>"
+var gitCommitID = ""
+
 // GetVersion returns the current docker-machine-driver-kvm2 version
 func GetVersion() string {
 	return version
+}
+
+// GetGitCommitID returns the git commit id from which it is being built
+func GetGitCommitID() string {
+	return gitCommitID
 }


### PR DESCRIPTION
Change kvm2 version flag, to match minikube as suggested: https://github.com/kubernetes/minikube/pull/4593#discussion_r297356533

WIP: still waiting on the decision of which version to use for the drivers `minikube version` or `commitID`.
discussion at: https://github.com/kubernetes/minikube/pull/4593#discussion_r297310439