### PR TITLE
removed label selector for registry-proxy daemonset

### DIFF
--- a/deploy/addons/registry/registry-proxy.yaml.tmpl
+++ b/deploy/addons/registry/registry-proxy.yaml.tmpl
@@ -10,7 +10,6 @@ spec:
   template:
     metadata:
       labels:
-        kubernetes.io/minikube-addons: registry
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:


### PR DESCRIPTION
Fix issue specified in #4627. Where because the `registry-proxy` `DaemoSet` has the same label as the `registry` the `Service` will loadbalance across both, causing errors for internal consumers.