### PR TITLE
Removed the adding a dependency from the contributing guide

### DIFF
--- a/docs/contributors/README.md
+++ b/docs/contributors/README.md
@@ -6,8 +6,6 @@
 
 ## New Features and Dependencies
 
-* **Adding a dependency** ([adding_a_dependency.md](adding_a_dependency.md)): How to add or update vendored code
-
 * **Adding a new addon** ([adding_an_addon.md](adding_an_addon.md)): How to add a new addon to minikube for `minikube addons`
 
 * **Adding a new driver** ([adding_driver.md](adding_driver.md)): How to add a new driver to minikube for `minikube create --vm-driver=<driver>`

--- a/docs/contributors/adding_a_dependency.md
+++ b/docs/contributors/adding_a_dependency.md
@@ -1,8 +1,0 @@
-# Adding a New Dependency
-
-Minikube uses `dep` to manage vendored dependencies.
-
-See the `dep` [documentation](https://golang.github.io/dep/docs/introduction.html) for installation and usage instructions.
-
-If you are introducing a large dependency change, please commit the vendor/ directory changes separately.
-This makes review easier in GitHub.


### PR DESCRIPTION
Fixes #4623 

This PR removes the "Adding a depedency" part from the Contributing Guide.

**Changes Made**

- Updated _docs/contributors/README.md_ to no longer link to _adding_a_dependency.md_ 
- Removed _docs/contributors/adding_a_dependency.md_