### PR TITLE
Improve kvm connection error message

### DIFF
--- a/pkg/drivers/kvm/domain.go
+++ b/pkg/drivers/kvm/domain.go
@@ -88,26 +88,6 @@ const domainTmpl = `
 </domain>
 `
 
-const connectionErrorText = `
-Error connecting to libvirt socket.  Have you set up libvirt correctly?
-
-# Install libvirt and qemu-kvm on your system, e.g.
-# Debian/Ubuntu (for older Debian/Ubuntu versions, you may have to use libvirt-bin instead of libvirt-clients and libvirt-daemon-system)
-$ sudo apt install libvirt-clients libvirt-daemon-system qemu-kvm
-# Fedora/CentOS/RHEL
-$ sudo yum install libvirt-daemon-kvm qemu-kvm
-
-# Add yourself to the libvirt group so you don't need to sudo
-# NOTE: For older Debian/Ubuntu versions change the group to [libvirtd]
-$ sudo usermod -a -G libvirt $(whoami)
-
-# Update your current session for the group change to take effect
-# NOTE: For older Debian/Ubuntu versions change the group to [libvirtd]
-$ newgrp libvirt
-
-Visit https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm2-driver for more information.
-`
-
 func randomMAC() (net.HardwareAddr, error) {
 	buf := make([]byte, 6)
 	_, err := rand.Read(buf)
@@ -144,7 +124,7 @@ func (d *Driver) getDomain() (*libvirt.Domain, *libvirt.Connect, error) {
 func getConnection(connectionURI string) (*libvirt.Connect, error) {
 	conn, err := libvirt.NewConnect(connectionURI)
 	if err != nil {
-		return nil, errors.Wrap(err, connectionErrorText)
+		return nil, errors.Wrap(err, "error connecting to libvirt socket.")
 	}
 
 	return conn, nil

--- a/pkg/minikube/problem/err_map.go
+++ b/pkg/minikube/problem/err_map.go
@@ -119,6 +119,11 @@ var vmProblems = map[string]match{
 		URL:    "http://mikko.repolainen.fi/documents/virtualization-with-kvm",
 		Issues: []int{2991},
 	},
+	"KVM_CONNECTION_ERROR": {
+		Regexp: re(`error connecting to libvirt socket`),
+		Advice: "Have you set up libvirt correctly?",
+		URL:    "https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm2-driver",
+	},
 	"DRIVER_CRASHED": {
 		Regexp: re(`Error attempting to get plugin server address for RPC`),
 		Advice: "The VM driver exited with an error, and may be corrupt. Run 'minikube start' with --alsologtostderr -v=8 to see the error",


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/4640

- I think it's best to have one source of truth about the kvm installation, instead of having information on the code + [doc/drives.md](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm2-driver), with this change we have only the [doc/drives.md](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm2-driver)
- The error message is less verbose (and less scary)
```
X Unable to start VM
* Error:         [KVM_CONNECTION_ERROR] Error getting state for host: getting connection: getting domain: error connecting to libvirt socket.: virError(Code=38, Domain=7, Message='Failed to connect socket to '/var/run/libvirt/libvirt-sock': No such file or directory')
* Advice:        Have you set up libvirt correctly?
* Documentation: https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm2-driver
```