### PR TITLE
Add kvm prefix to flags only used by kvm

### DIFF
--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -47,14 +47,14 @@ type MachineConfig struct {
 	HypervVirtualSwitch string
 	KVMNetwork          string             // Only used by the KVM driver
 	KVMQemuURI          string             // Only used by kvm2
+	KVMGPU              bool               // Only used by kvm2
+	KVMHidden           bool               // Only used by kvm2
 	Downloader          util.ISODownloader `json:"-"`
 	DockerOpt           []string           // Each entry is formatted as KEY=VALUE.
 	DisableDriverMounts bool               // Only used by virtualbox and xhyve
 	NFSShare            []string
 	NFSSharesRoot       string
 	UUID                string // Only used by hyperkit to restore the mac address
-	GPU                 bool   // Only used by kvm2
-	Hidden              bool   // Only used by kvm2
 	NoVTXCheck          bool   // Only used by virtualbox
 	DNSProxy            bool   // Only used by virtualbox
 	HostDNSResolver     bool   // Only used by virtualbox

--- a/pkg/minikube/drivers/kvm2/driver.go
+++ b/pkg/minikube/drivers/kvm2/driver.go
@@ -71,8 +71,8 @@ func createKVM2Host(config cfg.MachineConfig) interface{} {
 		DiskSize:       config.DiskSize,
 		DiskPath:       filepath.Join(constants.GetMinipath(), "machines", cfg.GetMachineName(), fmt.Sprintf("%s.rawdisk", cfg.GetMachineName())),
 		ISO:            filepath.Join(constants.GetMinipath(), "machines", cfg.GetMachineName(), "boot2docker.iso"),
-		GPU:            config.GPU,
-		Hidden:         config.Hidden,
+		GPU:            config.KVMGPU,
+		Hidden:         config.KVMHidden,
 		ConnectionURI:  config.KVMQemuURI,
 	}
 }


### PR DESCRIPTION
As both flags `hidden` and `gpu` are kvm only, I feel we should prefix it to make it explicit instead of having it only on the flag documentation.

wdyt?