### PR TITLE
WIP: update docs about config list (needs CLA)

### DIFF
--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -3,7 +3,7 @@
 
 ## Config option variables
 
-minikube supports passing environment variables instead of flags for every value listed in `minikube config list`.  This is done by passing an environment variable with the prefix `MINIKUBE_`.
+minikube supports passing environment variables instead of flags for every value listed in `minikube config`.  This is done by passing an environment variable with the prefix `MINIKUBE_`.
 
 For example the `minikube start --iso-url="$ISO_URL"` flag can also be set by setting the `MINIKUBE_ISO_URL="$ISO_URL"` environment variable.
 


### PR DESCRIPTION
As of minikube version: v1.1.0, `minikube config list` no longer works.  `minikube config` lists values.