### PR TITLE
Fix systemd dependencies when using containerd

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm_test.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm_test.go
@@ -75,6 +75,25 @@ ExecStart=/usr/bin/kubelet --authorization-mode=Webhook --bootstrap-kubeconfig=/
 `,
 		},
 		{
+			description: "default containerd runtime",
+			cfg: config.KubernetesConfig{
+				NodeIP:            "192.168.1.100",
+				KubernetesVersion: constants.DefaultKubernetesVersion,
+				NodeName:          "minikube",
+				ContainerRuntime:  "containerd",
+			},
+			expected: `
+[Unit]
+Wants=containerd.service
+
+[Service]
+ExecStart=
+ExecStart=/usr/bin/kubelet --authorization-mode=Webhook --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --cgroup-driver=cgroupfs --client-ca-file=/var/lib/minikube/certs/ca.crt --cluster-dns=10.96.0.10 --cluster-domain=cluster.local --container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --fail-swap-on=false --hostname-override=minikube --image-service-endpoint=unix:///run/containerd/containerd.sock --kubeconfig=/etc/kubernetes/kubelet.conf --pod-manifest-path=/etc/kubernetes/manifests --runtime-request-timeout=15m
+
+[Install]
+`,
+		},
+		{
 			description: "docker with custom image repository",
 			cfg: config.KubernetesConfig{
 				NodeIP:            "192.168.1.100",

--- a/pkg/minikube/bootstrapper/kubeadm/templates.go
+++ b/pkg/minikube/bootstrapper/kubeadm/templates.go
@@ -153,7 +153,7 @@ evictionHard:
 
 var kubeletSystemdTemplate = template.Must(template.New("kubeletSystemdTemplate").Parse(`
 [Unit]
-{{if or (eq .ContainerRuntime "cri-o") (eq .ContainerRuntime "cri")}}Wants=crio.service{{else}}Wants=docker.socket{{end}}
+{{if or (eq .ContainerRuntime "cri-o") (eq .ContainerRuntime "cri")}}Wants=crio.service{{else if eq .ContainerRuntime "containerd"}}Wants=containerd.service{{else}}Wants=docker.socket{{end}}
 
 [Service]
 ExecStart=


### PR DESCRIPTION
There is a template bug in the kubelet.service creation,
which causes it to start dockerd instead of containerd.