### PR TITLE
Refactor status command

### DIFF
--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -18,47 +18,28 @@ package cmd
 
 import (
 	"os"
-	"text/template"
 
 	"github.com/docker/machine/libmachine/state"
 	"github.com/golang/glog"
+	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	cmdcfg "k8s.io/minikube/cmd/minikube/cmd/config"
 	"k8s.io/minikube/cmd/util"
 	"k8s.io/minikube/pkg/minikube/cluster"
 	"k8s.io/minikube/pkg/minikube/config"
-	"k8s.io/minikube/pkg/minikube/constants"
+	pkg_config "k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/machine"
 	pkgutil "k8s.io/minikube/pkg/util"
-)
-
-var statusFormat string
-
-// Status represents the status
-type Status struct {
-	Host       string
-	Kubelet    string
-	APIServer  string
-	Kubeconfig string
-}
-
-const (
-	minikubeNotRunningStatusFlag = 1 << 0
-	clusterNotRunningStatusFlag  = 1 << 1
-	k8sNotRunningStatusFlag      = 1 << 2
 )
 
 // statusCmd represents the status command
 var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Gets the status of a local kubernetes cluster",
-	Long: `Gets the status of a local kubernetes cluster.
-	Exit status contains the status of minikube's VM, cluster and kubernetes encoded on it's bits in this order from right to left.
-	Eg: 7 meaning: 1 (for minikube NOK) + 2 (for cluster NOK) + 4 (for kubernetes NOK)`,
+	Long:  `Gets the status of a local kubernetes cluster.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		var returnCode = 0
 		api, err := machine.NewAPIClient()
 		if err != nil {
 			exit.WithCode(exit.Unavailable, "Error getting client: %v", err)
@@ -79,12 +60,10 @@ var statusCmd = &cobra.Command{
 			if err != nil {
 				exit.WithError("Error getting bootstrapper", err)
 			}
+
 			kubeletSt, err = clusterBootstrapper.GetKubeletStatus()
 			if err != nil {
 				glog.Warningf("kubelet err: %v", err)
-				returnCode |= clusterNotRunningStatusFlag
-			} else if kubeletSt != state.Running.String() {
-				returnCode |= clusterNotRunningStatusFlag
 			}
 
 			ip, err := cluster.GetHostDriverIP(api, config.GetMachineName())
@@ -101,47 +80,34 @@ var statusCmd = &cobra.Command{
 			apiserverSt, err = clusterBootstrapper.GetAPIServerStatus(ip, apiserverPort)
 			if err != nil {
 				glog.Errorln("Error apiserver status:", err)
-			} else if apiserverSt != state.Running.String() {
-				returnCode |= clusterNotRunningStatusFlag
 			}
 
 			ks, err := pkgutil.GetKubeConfigStatus(ip, util.GetKubeConfigPath(), config.GetMachineName())
 			if err != nil {
 				glog.Errorln("Error kubeconfig status:", err)
 			}
+
 			if ks {
 				kubeconfigSt = "Correctly Configured: pointing to minikube-vm at " + ip.String()
 			} else {
 				kubeconfigSt = "Misconfigured: pointing to stale minikube-vm." +
 					"\nTo fix the kubectl context, run minikube update-context"
-				returnCode |= k8sNotRunningStatusFlag
 			}
-		} else {
-			returnCode |= minikubeNotRunningStatusFlag
 		}
 
-		status := Status{
-			Host:       hostSt,
-			Kubelet:    kubeletSt,
-			APIServer:  apiserverSt,
-			Kubeconfig: kubeconfigSt,
-		}
-		tmpl, err := template.New("status").Parse(statusFormat)
-		if err != nil {
-			exit.WithError("Error creating status template", err)
-		}
-		err = tmpl.Execute(os.Stdout, status)
-		if err != nil {
-			exit.WithError("Error executing status template", err)
-		}
+		var data [][]string
+		data = append(data, []string{pkg_config.GetMachineName(), hostSt, kubeletSt, apiserverSt, kubeconfigSt})
 
-		os.Exit(returnCode)
+		table := tablewriter.NewWriter(os.Stdout)
+		table.SetHeader([]string{"Profile", "Host", "Kubelet", "APIServer", "Kubectl"})
+		table.SetAutoFormatHeaders(false)
+		table.SetBorders(tablewriter.Border{Left: true, Top: true, Right: true, Bottom: true})
+		table.SetCenterSeparator("|")
+		table.AppendBulk(data) // Add Bulk Data
+		table.Render()
 	},
 }
 
 func init() {
-	statusCmd.Flags().StringVar(&statusFormat, "format", constants.DefaultStatusFormat,
-		`Go template format string for the status output.  The format for Go templates can be found here: https://golang.org/pkg/text/template/
-For the list accessible variables for the template, see the struct values here: https://godoc.org/k8s.io/minikube/cmd/minikube/cmd#Status`)
 	RootCmd.AddCommand(statusCmd)
 }

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -163,12 +163,6 @@ const (
 	MinimumDiskSize = "2000mb"
 	// DefaultVMDriver is the default virtual machine driver name
 	DefaultVMDriver = DriverVirtualbox
-	// DefaultStatusFormat is the default format of a host
-	DefaultStatusFormat = `host: {{.Host}}
-kubelet: {{.Kubelet}}
-apiserver: {{.APIServer}}
-kubectl: {{.Kubeconfig}}
-`
 	// DefaultAddonListFormat is the default format of addon list
 	DefaultAddonListFormat = "- {{.AddonName}}: {{.AddonStatus}}\n"
 	// DefaultConfigViewFormat is the default format of config view


### PR DESCRIPTION
I want to support the `--all` flag on the status command. https://github.com/kubernetes/minikube/issues/4598 To support this change, I've started to refactor the status command, but it ended up very different.

The reasoning here is:

- I don't think to have an exit status that sums up lots of information is useful for the end user. (how would the status for all profiles be?)
- I don't think custom format here brings a lot of value
- I really like the table structure, especially if we had the `-all` flag, it would show all profiles

The current version of status returns:
```
minikube status
host: Running
kubelet: Running
apiserver: Running
kubectl: Correctly Configured: pointing to minikube-vm at 192.168.39.228
```

This PR change it to:
```
minikube status
|----------|---------|---------|-----------|--------------------------------|
| PROFILE  |  HOST   | KUBELET | APISERVER |           KUBECONFIG           |
|----------|---------|---------|-----------|--------------------------------|
| minikube | Running | Running | Running   | Correctly Configured:          |
|          |         |         |           | pointing to minikube-vm at     |
|          |         |         |           | 192.168.39.228                 |
|----------|---------|---------|-----------|--------------------------------|
```

Let me know if none of this makes sense.