### PR TITLE
Add kubectl examples

### DIFF
--- a/cmd/minikube/cmd/kubectl.go
+++ b/cmd/minikube/cmd/kubectl.go
@@ -36,7 +36,10 @@ import (
 var kubectlCmd = &cobra.Command{
 	Use:   "kubectl",
 	Short: "Run kubectl",
-	Long:  `Run the kubernetes client, download it if necessary.`,
+	Long: `Run the kubernetes client, download it if necessary.
+Examples:
+minikube kubectl -- --help
+kubectl get pods --namespace kube-system`,
 	Run: func(cmd *cobra.Command, args []string) {
 		api, err := machine.NewAPIClient()
 		if err != nil {


### PR DESCRIPTION
Fix for https://github.com/kubernetes/minikube/issues/4684

@afbjorklund I've added some examples instead of adding something to `Use`. When changing `Use` the cobra help was displayed wrongly `Run kubectl -- [flags]`.

wdyt?