### PR TITLE
Add an install option to kubectl command

### DIFF
--- a/cmd/minikube/cmd/kubectl.go
+++ b/cmd/minikube/cmd/kubectl.go
@@ -37,7 +37,7 @@ import (
 var (
 	kubectlInstallMode   bool
 	kubectlInstallPrefix string
-	kubectlPathMode      bool
+	kubectlPrintMode     bool
 )
 
 const defaultPrefix = "/usr/local"
@@ -80,7 +80,7 @@ var kubectlCmd = &cobra.Command{
 			return
 		}
 
-		if kubectlPathMode {
+		if kubectlPrintMode {
 			console.OutLn(path)
 			return
 		}
@@ -131,6 +131,6 @@ func installKubectl(binary, version, path, prefix string) {
 func init() {
 	kubectlCmd.Flags().BoolVar(&kubectlInstallMode, "install", false, "Install kubectl and exit")
 	kubectlCmd.Flags().StringVar(&kubectlInstallPrefix, "prefix", defaultPrefix, "Installation prefix")
-	kubectlCmd.Flags().BoolVar(&kubectlPathMode, "path", false, "Display kubectl path instead of running it")
+	kubectlCmd.Flags().BoolVar(&kubectlPrintMode, "print", false, "Print kubectl path instead of running it")
 	RootCmd.AddCommand(kubectlCmd)
 }

--- a/cmd/minikube/cmd/kubectl.go
+++ b/cmd/minikube/cmd/kubectl.go
@@ -37,6 +37,7 @@ import (
 var (
 	kubectlInstallMode   bool
 	kubectlInstallPrefix string
+	kubectlPathMode      bool
 )
 
 const defaultPrefix = "/usr/local"
@@ -76,6 +77,11 @@ var kubectlCmd = &cobra.Command{
 
 		if kubectlInstallMode {
 			installKubectl(binary, version, path, kubectlInstallPrefix)
+			return
+		}
+
+		if kubectlPathMode {
+			console.OutLn(path)
 			return
 		}
 
@@ -120,5 +126,6 @@ func installKubectl(binary, version, path, prefix string) {
 func init() {
 	kubectlCmd.Flags().BoolVar(&kubectlInstallMode, "install", false, "Install kubectl and exit")
 	kubectlCmd.Flags().StringVar(&kubectlInstallPrefix, "prefix", defaultPrefix, "Installation prefix")
+	kubectlCmd.Flags().BoolVar(&kubectlPathMode, "path", false, "Display kubectl path instead of running it")
 	RootCmd.AddCommand(kubectlCmd)
 }

--- a/cmd/minikube/cmd/kubectl.go
+++ b/cmd/minikube/cmd/kubectl.go
@@ -119,6 +119,11 @@ func installKubectl(binary, version, path, prefix string) {
 	}
 	err = ioutil.WriteFile(installpath, data, 0755)
 	if err != nil {
+		if os.IsPermission(err) {
+			// Permission denied (common error) is *not* a crash...
+			console.Fatal("%s: %v", "Failed to write kubectl", err)
+			os.Exit(exit.Software)
+		}
 		exit.WithError("Failed to write kubectl", err)
 	}
 }


### PR DESCRIPTION

* Add --install option to minikube kubectl command
* Add --path option to minikube kubectl command

```
Usage:
  minikube kubectl [flags]

Flags:
  -h, --help            help for kubectl
      --install         Install kubectl and exit
      --path            Display kubectl path instead of running it
      --prefix string   Installation prefix (default "/usr/local")
```

For #4697 

