### PR TITLE
WIP: Add prefix for the kubeconfig context and the VM name

### DIFF
--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -96,15 +96,18 @@ func decode(r io.Reader) (MinikubeConfig, error) {
 
 // GetMachineName gets the machine name for the VM
 func GetMachineName() string {
-	if viper.GetString(MachineProfile) == "" {
+	if viper.GetString(MachineProfile) == "" || viper.GetString(MachineProfile) == constants.DefaultMachineName {
 		return constants.DefaultMachineName
 	}
-	return viper.GetString(MachineProfile)
+	return fmt.Sprintf("%s-%s", constants.MinikubePrefix, viper.GetString(MachineProfile))
 }
 
 // Load loads the kubernetes and machine config for the current machine
 func Load() (*Config, error) {
-	return DefaultLoader.LoadConfigFromFile(GetMachineName())
+	if viper.GetString(MachineProfile) == "" {
+		return DefaultLoader.LoadConfigFromFile(viper.GetString(constants.DefaultMachineName))
+	}
+	return DefaultLoader.LoadConfigFromFile(viper.GetString(MachineProfile))
 }
 
 // Loader loads the kubernetes and machine config based on the machine profile name

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -113,6 +113,9 @@ var KubeconfigPath = clientcmd.RecommendedHomeFile
 // KubeconfigEnvVar is the env var to check for the Kubernetes client config
 var KubeconfigEnvVar = clientcmd.RecommendedConfigPathEnvVar
 
+// MinikubePrefix is the prefix for the kubeconfig context and the VM name
+const MinikubePrefix = "minikube"
+
 // MinikubeContext is the kubeconfig context name used for minikube
 const MinikubeContext = "minikube"
 

--- a/pkg/minikube/service/service.go
+++ b/pkg/minikube/service/service.go
@@ -28,7 +28,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/pkg/browser"
 	"github.com/pkg/errors"
-	"github.com/spf13/viper"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -72,11 +71,11 @@ func (k *K8sClientGetter) GetCoreClient() (typed_core.CoreV1Interface, error) {
 // GetClientset returns a clientset
 func (*K8sClientGetter) GetClientset(timeout time.Duration) (*kubernetes.Clientset, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	profile := viper.GetString(config.MachineProfile)
+	contextName := config.GetMachineName()
 	configOverrides := &clientcmd.ConfigOverrides{
 		Context: clientcmdapi.Context{
-			Cluster:  profile,
-			AuthInfo: profile,
+			Cluster:  contextName,
+			AuthInfo: contextName,
 		},
 	}
 	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)


### PR DESCRIPTION
This PR added a prefix `minikube-` for the kubeconfig context and the VM name. In addition, if minikube starts by default, it will not add the prefix.

Fixes #4680.

/cc @medyagh 