### PR TITLE
refactoring and simplifying start command

### DIFF
--- a/cmd/minikube/cmd/cache.go
+++ b/cmd/minikube/cmd/cache.go
@@ -93,8 +93,8 @@ func CacheImagesInConfigFile() error {
 	return machine.CacheImages(images, constants.ImageCacheDir)
 }
 
-// LoadCachedImagesInConfigFile loads the images currently in the config file (minikube start)
-func LoadCachedImagesInConfigFile() error {
+// loadCachedImagesInConfigFile loads the images currently in the config file (minikube start)
+func loadCachedImagesInConfigFile() error {
 	images, err := imagesInConfigFile()
 	if err != nil {
 		return err

--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -96,7 +96,7 @@ func runDelete(cmd *cobra.Command, args []string) {
 
 func uninstallKubernetes(api libmachine.API, kc pkg_config.KubernetesConfig, bsName string) {
 	console.OutStyle(console.Resetting, "Uninstalling Kubernetes %s using %s ...", kc.KubernetesVersion, bsName)
-	clusterBootstrapper, err := GetClusterBootstrapper(api, bsName)
+	clusterBootstrapper, err := getClusterBootstrapper(api, bsName)
 	if err != nil {
 		console.ErrLn("Unable to get bootstrapper: %v", err)
 	} else if err = clusterBootstrapper.DeleteCluster(kc); err != nil {

--- a/cmd/minikube/cmd/logs.go
+++ b/cmd/minikube/cmd/logs.go
@@ -66,7 +66,7 @@ var logsCmd = &cobra.Command{
 		if err != nil {
 			exit.WithError("command runner", err)
 		}
-		bs, err := GetClusterBootstrapper(api, viper.GetString(cmdcfg.Bootstrapper))
+		bs, err := getClusterBootstrapper(api, viper.GetString(cmdcfg.Bootstrapper))
 		if err != nil {
 			exit.WithError("Error getting cluster bootstrapper", err)
 		}

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -170,8 +170,8 @@ func setupViper() {
 	setFlagsUsingViper()
 }
 
-// GetClusterBootstrapper returns a new bootstrapper for the cluster
-func GetClusterBootstrapper(api libmachine.API, bootstrapperName string) (bootstrapper.Bootstrapper, error) {
+// getClusterBootstrapper returns a new bootstrapper for the cluster
+func getClusterBootstrapper(api libmachine.API, bootstrapperName string) (bootstrapper.Bootstrapper, error) {
 	var b bootstrapper.Bootstrapper
 	var err error
 	switch bootstrapperName {

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -131,17 +131,16 @@ func initMinikubeFlags() {
 	startCmd.Flags().Int(cpus, constants.DefaultCPUS, "Number of CPUs allocated to the minikube VM")
 	startCmd.Flags().String(memory, constants.DefaultMemorySize, "Amount of RAM allocated to the minikube VM (format: <number>[<unit>], where unit = b, k, m or g)")
 	startCmd.Flags().String(humanReadableDiskSize, constants.DefaultDiskSize, "Disk size allocated to the minikube VM (format: <number>[<unit>], where unit = b, k, m or g)")
+	startCmd.Flags().Bool(downloadOnly, false, "If true, only download and cache files for later use - don't install or start anything.")
+	startCmd.Flags().Bool(cacheImages, true, "If true, cache docker images for the current bootstrapper and load them into the machine. Always false with --vm-driver=none.")
+	startCmd.Flags().String(isoURL, constants.DefaultISOURL, "Location of the minikube iso")
 	startCmd.Flags().Bool(keepContext, constants.DefaultKeepContext, "This will keep the existing kubectl context and will create a minikube context.")
+	startCmd.Flags().String(containerRuntime, "docker", "The container runtime to be used (docker, crio, containerd)")
 	startCmd.Flags().Bool(createMount, false, "This will start the mount daemon and automatically mount files into minikube")
 	startCmd.Flags().String(mountString, constants.DefaultMountDir+":"+constants.DefaultMountEndpoint, "The argument to pass the minikube mount command on start")
-	startCmd.Flags().String(isoURL, constants.DefaultISOURL, "Location of the minikube iso")
-	startCmd.Flags().String(containerRuntime, "docker", "The container runtime to be used (docker, crio, containerd)")
 	startCmd.Flags().String(criSocket, "", "The cri socket path to be used")
 	startCmd.Flags().String(networkPlugin, "", "The name of the network plugin")
 	startCmd.Flags().Bool(enableDefaultCNI, false, "Enable the default CNI plugin (/etc/cni/net.d/k8s.conf). Used in conjunction with \"--network-plugin=cni\"")
-	startCmd.Flags().Bool(downloadOnly, false, "If true, only download and cache files for later use - don't install or start anything.")
-	startCmd.Flags().Bool(cacheImages, true, "If true, cache docker images for the current bootstrapper and load them into the machine. Always false with --vm-driver=none.")
-
 }
 
 // initKubernetesFlags inits the commandline flags for kubernetes related options

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -298,13 +298,10 @@ func downloadISO(config cfg.Config) {
 }
 
 func skipCache(config *cfg.Config) {
-	fmt.Println("inside skip cache")
-	config.KubernetesConfig.ShouldLoadCachedImages = false
 	if viper.GetString(vmDriver) == constants.DriverNone {
 		viper.Set(cacheImages, false)
 		config.KubernetesConfig.ShouldLoadCachedImages = false
 	}
-	fmt.Printf("inside skip cache %t", config.KubernetesConfig.ShouldLoadCachedImages)
 }
 
 func showVersionInfo(k8sVersion string, cr cruntime.Manager) {

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -118,7 +118,7 @@ func init() {
 	initMinikubeFlags()
 	initKubernetesFlags()
 	initDriverFlags()
-	initNetowrkingFlags()
+	initNetworkingFlags()
 	if err := viper.BindPFlags(startCmd.Flags()); err != nil {
 		exit.WithError("unable to bind flags", err)
 	}
@@ -191,8 +191,8 @@ func initDriverFlags() {
 
 }
 
-// initNetowrkingFlags inits the commandline flags for connectivity related flags for start
-func initNetowrkingFlags() {
+// initNetworkingFlags inits the commandline flags for connectivity related flags for start
+func initNetworkingFlags() {
 	startCmd.Flags().StringSliceVar(&insecureRegistry, "insecure-registry", nil, "Insecure Docker registries to pass to the Docker daemon.  The default service CIDR range will automatically be added.")
 	startCmd.Flags().StringSliceVar(&registryMirror, "registry-mirror", nil, "Registry mirrors to pass to the Docker daemon")
 	startCmd.Flags().String(imageRepository, "", "Alternative image repository to pull docker images from. This can be used when you have limited access to gcr.io. Set it to \"auto\" to let minikube decide one for you. For Chinese mainland users, you may use local gcr.io mirrors such as registry.cn-hangzhou.aliyuncs.com/google_containers")

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -212,12 +212,13 @@ func runStart(cmd *cobra.Command, args []string) {
 	handleDownloadOnly(&cacheGroup, k8sVersion)
 	mRunner, preExists, machineAPI, host := startMachine(config)
 	defer machineAPI.Close()
+	// configure the runtime (docker, containerd, crio)
 	cr := configureRuntimes(mRunner)
 	showVersionInfo(k8sVersion, cr)
 	waitCacheImages(&cacheGroup)
+
 	// setup kube adm and certs and return bootstrapperx
 	bs := setupKubeAdm(machineAPI, config.KubernetesConfig)
-
 	// The kube config must be update must come before bootstrapping, otherwise health checks may use a stale IP
 	kubeconfig := updateKubeConfig(host, &config)
 	// pull images or restart cluster

--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -75,7 +75,7 @@ var statusCmd = &cobra.Command{
 		apiserverSt := state.None.String()
 
 		if hostSt == state.Running.String() {
-			clusterBootstrapper, err := GetClusterBootstrapper(api, viper.GetString(cmdcfg.Bootstrapper))
+			clusterBootstrapper, err := getClusterBootstrapper(api, viper.GetString(cmdcfg.Bootstrapper))
 			if err != nil {
 				exit.WithError("Error getting bootstrapper", err)
 			}


### PR DESCRIPTION
our start command is getting long and longer and with newer functionally coming, I felt it is a time to make it more readable using helper functions. this PR does:
- add more helper functions to start
- fix the skipCache by passing pointer.


unrelated but while doing this refactor I noticed "loadCachedImagesInConfigFile()"  function is getting called after cluster pulls the images. which I believe was meant to be before. but I leave that for another PR if my suspicion is right.