### PR TITLE
Move supported drivers per platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,7 +288,7 @@ mdlint:
 	@$(MARKDOWNLINT) $(MINIKUBE_MARKDOWN_FILES)
 
 out/docs/minikube.md: $(shell find cmd) $(shell find pkg/minikube/constants) pkg/minikube/assets/assets.go pkg/minikube/translate/translations.go
-	go run -ldflags="$(MINIKUBE_LDFLAGS)" hack/help_text/gen_help_text.go
+	go run -ldflags="$(MINIKUBE_LDFLAGS)" -tags gendocs hack/help_text/gen_help_text.go
 
 out/minikube_$(DEB_VERSION).deb: out/minikube-linux-amd64
 	cp -r installers/linux/deb/minikube_deb_template out/minikube_$(DEB_VERSION)

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -89,21 +89,6 @@ const DriverXhyve = "xhyve"
 // DriverParallels is the parallels driver option name
 const DriverParallels = "parallels"
 
-// SupportedVMDrivers is a list of supported drivers on all platforms. Currently
-// used in gendocs.
-var SupportedVMDrivers = [...]string{
-	DriverVirtualbox,
-	DriverParallels,
-	DriverVmwareFusion,
-	DriverKvmOld,
-	DriverXhyve,
-	DriverHyperv,
-	DriverHyperkit,
-	DriverKvm2,
-	DriverVmware,
-	DriverNone,
-}
-
 // DefaultMinipath is the default Minikube path (under the home directory)
 var DefaultMinipath = filepath.Join(homedir.HomeDir(), ".minikube")
 

--- a/pkg/minikube/constants/constants_gendocs.go
+++ b/pkg/minikube/constants/constants_gendocs.go
@@ -1,4 +1,4 @@
-// +build darwin, !gendocs
+// +build gendocs
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.
@@ -18,14 +18,18 @@ limitations under the License.
 
 package constants
 
-var DefaultMountDir = "/Users"
+var DefaultMountDir = "$HOME"
 
-// SupportedVMDrivers is a list of supported drivers on Darwin.
+// SupportedVMDrivers is a list of supported drivers on all platforms.
 var SupportedVMDrivers = [...]string{
 	DriverVirtualbox,
 	DriverParallels,
 	DriverVmwareFusion,
+	DriverKvmOld,
 	DriverXhyve,
-	DriverHyperKit,
+	DriverHyperv,
+	DriverHyperkit,
+	DriverKvm2,
 	DriverVmware,
+	DriverNone,
 }

--- a/pkg/minikube/constants/constants_linux.go
+++ b/pkg/minikube/constants/constants_linux.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux, !gendocs
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.
@@ -24,3 +24,14 @@ import (
 
 // DefaultMountDir is the default mount dir
 var DefaultMountDir = homedir.HomeDir()
+
+// SupportedVMDrivers is a list of supported drivers on Linux.
+var SupportedVMDrivers = [...]string{
+	DriverVirtualbox,
+	DriverParallels,
+	DriverVmwareFusion,
+	DriverKvmOld,
+	DriverKvm2,
+	DriverVmware,
+	DriverNone,
+}

--- a/pkg/minikube/constants/constants_windows.go
+++ b/pkg/minikube/constants/constants_windows.go
@@ -1,4 +1,4 @@
-// +build windows
+// +build windows, !gendocs
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.
@@ -23,3 +23,11 @@ import (
 )
 
 var DefaultMountDir = homedir.HomeDir()
+
+// SupportedVMDrivers is a list of supported drivers on Windows.
+var SupportedVMDrivers = [...]string{
+	DriverVirtualbox,
+	DriverVmwareFusion,
+	DriverHyperv,
+	DriverVmware,
+}


### PR DESCRIPTION
This is something `minishift` do and is pretty useful. Wdyt?