### PR TITLE
Reduce kubectl restart time from 10 seconds to 600ms

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/templates.go
+++ b/pkg/minikube/bootstrapper/kubeadm/templates.go
@@ -171,7 +171,8 @@ Documentation=http://kubernetes.io/docs/
 ExecStart=/usr/bin/kubelet
 Restart=always
 StartLimitInterval=0
-RestartSec=10
+# Tuned for local dev: faster than upstream default (10s), but slower than systemd default (100ms)
+RestartSec=600ms
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR reduces VM start time by up to 9 seconds.

For complicated reasons, the kubelet has to be running before kubeadm, but will kill itself as it has not yet been configured. Inspired by kind, this adjusts the restart delay to fit better with a single-node dev cluster use case.

To go from "Starting kubelet" to "Watching apiserver":

10s (current): 26s
1s (kind): 19s
750ms: 18s
600ms: 17s
250ms: 17s

