### PR TITLE
Improve the release tarballs with compression and checksum

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,8 @@ $(shell mkdir -p $(BUILD_DIR))
 PYTHON := $(shell command -v python || echo "docker run --rm -it -v $(shell pwd):/minikube -w /minikube python python")
 BUILD_OS := $(shell uname -s)
 
+SHA512SUM=$(shell command -v sha512sum || echo "shasum -a 512")
+
 STORAGE_PROVISIONER_TAG := v1.8.1
 
 # Set the version information for the Kubernetes servers
@@ -359,6 +361,7 @@ out/minikube-%-amd64.tar.gz: $$(TAR_TARGETS_$$*)
 
 .PHONY: cross-tars
 cross-tars: out/minikube-windows-amd64.tar.gz out/minikube-linux-amd64.tar.gz out/minikube-darwin-amd64.tar.gz
+	-cd out && $(SHA512SUM) *.tar.gz > SHA512SUM
 
 out/minikube-installer.exe: out/minikube-windows-amd64.exe
 	rm -rf out/windows_tmp

--- a/Makefile
+++ b/Makefile
@@ -356,7 +356,7 @@ TAR_TARGETS_darwin  := out/minikube-darwin-amd64
 TAR_TARGETS_windows := out/minikube-windows-amd64.exe
 TAR_TARGETS_ALL     := $(shell find deploy/addons -type f)
 out/minikube-%-amd64.tar.gz: $$(TAR_TARGETS_$$*) $(TAR_TARGETS_ALL)
-	tar -cvf $@ $^
+	tar -cvzf $@ $^
 
 .PHONY: cross-tars
 cross-tars: out/minikube-windows-amd64.tar.gz out/minikube-linux-amd64.tar.gz out/minikube-darwin-amd64.tar.gz


### PR DESCRIPTION
* Make sure to actually gzip the tarballs (.tar.gz)
* Don't include the add-ons, but do include hyperkit

~* Add proper docker target for building kvm driver~ (--> PR #4779)
~* Improve libvirt linking and check ABI version (#4555)~  (--> PR #4779)

* Checksum the tarballs, ~and include in the release (#4699)~
