### PR TITLE
hyperv: Run "sudo poweroff" before stopping VM

### DIFF
--- a/cmd/minikube/cmd/stop.go
+++ b/cmd/minikube/cmd/stop.go
@@ -52,7 +52,6 @@ func runStop(cmd *cobra.Command, args []string) {
 	defer api.Close()
 
 	nonexistent := false
-
 	stop := func() (err error) {
 		err = cluster.StopHost(api)
 		switch err := errors.Cause(err).(type) {
@@ -64,9 +63,10 @@ func runStop(cmd *cobra.Command, args []string) {
 			return err
 		}
 	}
-	if err := pkgutil.RetryAfter(5, stop, 2*time.Second); err != nil {
+	if err := pkgutil.RetryAfter(3, stop, 2*time.Second); err != nil {
 		exit.WithError("Unable to stop VM", err)
 	}
+
 	if !nonexistent {
 		out.T(out.Stopped, `"{{.profile_name}}" stopped.`, out.V{"profile_name": profile})
 	}

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -225,8 +225,8 @@ func adjustGuestClock(h hostRunner, t time.Time) error {
 	return err
 }
 
-// TrySSHPowerOff runs the poweroff command on the guest VM to speed up deletion
-func TrySSHPowerOff(h *host.Host) error {
+// trySSHPowerOff runs the poweroff command on the guest VM to speed up deletion
+func trySSHPowerOff(h *host.Host) error {
 	s, err := h.Driver.GetState()
 	if err != nil {
 		glog.Warningf("unable to get state: %v", err)
@@ -254,8 +254,8 @@ func StopHost(api libmachine.API) error {
 	out.T(out.Stopping, `Stopping "{{.profile_name}}" in {{.driver_name}} ...`, out.V{"profile_name": cfg.GetMachineName(), "driver_name": host.DriverName})
 	if host.DriverName == constants.DriverHyperv {
 		glog.Infof("As there are issues with stopping Hyper-V VMs using API, trying to shut down using SSH")
-		if err := TrySSHPowerOff(host); err != nil {
-			return errors.Wrapf(err, "Unable to Power off cluster on %q using SSH", host.DriverName)
+		if err := trySSHPowerOff(host); err != nil {
+			return errors.Wrap(err, "ssh power off")
 		}
 	}
 
@@ -277,8 +277,8 @@ func DeleteHost(api libmachine.API) error {
 	}
 	// This is slow if SSH is not responding, but HyperV hangs otherwise, See issue #2914
 	if host.Driver.DriverName() == constants.DriverHyperv {
-		if err := TrySSHPowerOff(host); err != nil {
-			return errors.Wrap(err, "Unable to power off minikube because the host was not found.")
+		if err := trySSHPowerOff(host); err != nil {
+			glog.Infof("Unable to power off minikube because the host was not found.")
 		}
 	}
 


### PR DESCRIPTION
Fixes #4661 #2914 

- If the driver is Hyper-V, `minikube stop` will first run `sudo poweroff` via SSH into the minikube Virtual Machine and then proceed ahead with the normal stop related procedures.
- Reduced the number of retries from 5 to 3. 5 seems to be quite high.