### PR TITLE
Undefined name 'test' in run_tests.py

### DIFF
--- a/hack/prow/run_tests.py
+++ b/hack/prow/run_tests.py
@@ -25,7 +25,7 @@ import os, sys, json, re, argparse, calendar, time, subprocess, shlex
 
 def get_classname(test_script):
   """ parse out the test classname from the full path of the test script"""
-  classname = os.path.basename(test).split('.')[0]
+  classname = os.path.basename(test_script).split('.')[0]
   return classname
 
 def write_results(outdir, started, finished, test_results):


### PR DESCRIPTION
This issue was hidden by the syntax error in #4741

$ __time flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./hack/prow/run_tests.py:28:32: F821 undefined name 'test'
  classname = os.path.basename(test).split('.')[0]
                               ^
1     F821 undefined name 'test'
1
```