### PR TITLE
Lint Python code for syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: go
 os: linux
-sudo: required
 
-go:
-  - 1.x
+matrix:
+  include:
+    - go: 1.x
+    - language: python
+      before_install: pip install flake8
+      script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 
 before_install:
   - sudo apt-get install -y libvirt-dev


### PR DESCRIPTION
Blocked by #4762.

Lint Python code for issues like  #4741 and  #4762.

Also, the Travis CI __sudo:__ tag is now deprecated.