### PR TITLE
Update github issues URL now that we have issue templates

### DIFF
--- a/pkg/minikube/exit/exit.go
+++ b/pkg/minikube/exit/exit.go
@@ -75,7 +75,7 @@ func WithProblem(msg string, p *problem.Problem) {
 	p.Display()
 	console.Err("\n")
 	console.ErrStyle(console.Sad, "If the above advice does not help, please let us know: ")
-	console.ErrStyle(console.URL, "https://github.com/kubernetes/minikube/issues/new")
+	console.ErrStyle(console.URL, "https://github.com/kubernetes/minikube/issues/new/choose")
 	os.Exit(Config)
 }
 
@@ -102,5 +102,5 @@ func displayError(msg string, err error) {
 	console.Fatal("%s: %v", msg, err)
 	console.Err("\n")
 	console.ErrStyle(console.Sad, "Sorry that minikube crashed. If this was unexpected, we would love to hear from you:")
-	console.ErrStyle(console.URL, "https://github.com/kubernetes/minikube/issues/new")
+	console.ErrStyle(console.URL, "https://github.com/kubernetes/minikube/issues/new/choose")
 }


### PR DESCRIPTION
Now that we support issue templates, https://github.com/kubernetes/minikube/issues/new points to a blank template. This switches the URL to the template chooser.

This PR makes me sad.