### PR TITLE
Add advice if crash on hyperkit not installed

### DIFF
--- a/cmd/minikube/cmd/config/profile.go
+++ b/cmd/minikube/cmd/config/profile.go
@@ -28,7 +28,6 @@ import (
 	pkgutil "k8s.io/minikube/pkg/util"
 )
 
-// TODO: add --all
 // ProfileCmd represents the profile command
 var ProfileCmd = &cobra.Command{
 	Use:   "profile [MINIKUBE_PROFILE_NAME].  You can return to the default minikube profile by running `minikube profile default`",

--- a/cmd/minikube/cmd/config/profile.go
+++ b/cmd/minikube/cmd/config/profile.go
@@ -28,6 +28,7 @@ import (
 	pkgutil "k8s.io/minikube/pkg/util"
 )
 
+// TODO: add --all
 // ProfileCmd represents the profile command
 var ProfileCmd = &cobra.Command{
 	Use:   "profile [MINIKUBE_PROFILE_NAME].  You can return to the default minikube profile by running `minikube profile default`",

--- a/pkg/minikube/problem/err_map.go
+++ b/pkg/minikube/problem/err_map.go
@@ -91,6 +91,11 @@ var vmProblems = map[string]match{
 		Advice: "Please install the minikube kvm2 VM driver, or select an alternative --vm-driver",
 		URL:    "https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm2-driver",
 	},
+	"HYPERKIT_NOT_FOUND": {
+		Regexp: re(`Driver "hyperkit" not found. Do you have the plugin binary .* accessible in your PATH?`),
+		Advice: "Please install the minikube hyperkit VM driver, or select an alternative --vm-driver",
+		URL:    "https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#hyperkit-driver",
+	},
 	"KVM2_RESTART_NO_IP": {
 		Regexp: re(`Error starting stopped host: Machine didn't return an IP after 120 seconds`),
 		Advice: "The KVM driver is unable to resurrect this old VM. Please run `minikube delete` to delete it and try again.",


### PR DESCRIPTION
changes this crash error : 
```
$ ./out/minikube start -p1 --vm-driver=hyperkit
😄  minikube v1.2.0 on darwin (amd64)
💿  Downloading Minikube ISO ...
 129.33 MB / 129.33 MB [============================================] 100.00% 0s
🔥  Creating hyperkit VM (CPUs=2, Memory=2000MB, Disk=20000MB) ...
E0717 12:52:38.128789   71990 start.go:669] StartHost: new host: Driver "hyperkit" not found. Do you have the plugin binary "docker-machine-driver-hyperkit" accessible in your PATH?

💣  Unable to start VM: new host: Driver "hyperkit" not found. Do you have the plugin binary "docker-machine-driver-hyperkit" accessible in your PATH?

😿  Sorry that minikube crashed. If this was unexpected, we would love to hear from you:
👉  https://github.com/kubernetes/minikube/issues/new/choose
```


to this with link to docs : 

```
/out/minikube start -p1 --vm-driver=hyperkit
😄  minikube v1.2.0 on darwin (amd64)
🔥  Creating hyperkit VM (CPUs=2, Memory=2000MB, Disk=20000MB) ...
E0717 12:57:53.908198   73940 start.go:669] StartHost: new host: Driver "hyperkit" not found. Do you have the plugin binary "docker-machine-driver-hyperkit" accessible in your PATH?

💣  Unable to start VM
❌  Error:         [HYPERKIT_NOT_FOUND] new host: Driver "hyperkit" not found. Do you have the plugin binary "docker-machine-driver-hyperkit" accessible in your PATH?
💡  Advice:        Please install the minikube hyperkit VM driver, or select an alternative --vm-driver
📘  Documentation: https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#hyperkit-driver

😿  If the above advice does not help, please let us know: 
👉  https://github.com/kubernetes/minikube/issues/new/choose
```
