### PR TITLE
Fix regression caused by registry-proxy

### DIFF
--- a/deploy/addons/registry/registry-proxy.yaml.tmpl
+++ b/deploy/addons/registry/registry-proxy.yaml.tmpl
@@ -2,7 +2,7 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   labels:
-    kubernetes.io/minikube-addons: registry-proxy
+    kubernetes.io/minikube-addons: registry
     addonmanager.kubernetes.io/mode: Reconcile
   name: registry-proxy
   namespace: kube-system
@@ -10,7 +10,7 @@ spec:
   template:
     metadata:
       labels:
-        kubernetes.io/minikube-addons: registry-proxy
+        kubernetes.io/minikube-addons: registry
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:

--- a/deploy/addons/registry/registry-rc.yaml.tmpl
+++ b/deploy/addons/registry/registry-rc.yaml.tmpl
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       labels:
+        actual-registry: "true"
         kubernetes.io/minikube-addons: registry
         addonmanager.kubernetes.io/mode: Reconcile
     spec:

--- a/deploy/addons/registry/registry-svc.yaml.tmpl
+++ b/deploy/addons/registry/registry-svc.yaml.tmpl
@@ -12,4 +12,5 @@ spec:
   - port: 80
     targetPort: 5000
   selector:
+    actual-registry: "true"
     kubernetes.io/minikube-addons: registry


### PR DESCRIPTION
This PR addresses #4604 by adding a new selector to concerned svc/rc only.
This also reverts `kubernetes.io/minikube-addons` to `registy` for registry-proxy
so that addon manager can deploy registry-proxy when registry addon is enabled.