### PR TITLE
Make TestNewSSHClient and ssh_mock race-proof

### DIFF
--- a/pkg/minikube/cluster/cluster_test.go
+++ b/pkg/minikube/cluster/cluster_test.go
@@ -359,7 +359,7 @@ func TestGetHostDockerEnvIPv6(t *testing.T) {
 func TestCreateSSHShell(t *testing.T) {
 	api := tests.NewMockAPI()
 
-	s, _ := tests.NewSSHServer()
+	s, _ := tests.NewSSHServer(t)
 	port, err := s.Start()
 	if err != nil {
 		t.Fatalf("Error starting ssh server: %v", err)

--- a/pkg/minikube/sshutil/sshutil_test.go
+++ b/pkg/minikube/sshutil/sshutil_test.go
@@ -25,15 +25,15 @@ import (
 )
 
 func TestNewSSHClient(t *testing.T) {
-	s, err := tests.NewSSHServer()
+	s, err := tests.NewSSHServer(t)
 	if err != nil {
 		t.Fatalf("NewSSHServer: %v", err)
 	}
-	l, port, err := s.Start()
+	port, err := s.Start()
 	if err != nil {
 		t.Fatalf("Error starting ssh server: %v", err)
 	}
-	defer l.Close()
+	defer s.Stop()
 
 	d := &tests.MockDriver{
 		Port: port,
@@ -41,7 +41,6 @@ func TestNewSSHClient(t *testing.T) {
 			IPAddress:  "127.0.0.1",
 			SSHKeyPath: "",
 		},
-		T: t,
 	}
 	c, err := NewSSHClient(d)
 	if err != nil {

--- a/pkg/minikube/sshutil/sshutil_test.go
+++ b/pkg/minikube/sshutil/sshutil_test.go
@@ -25,37 +25,43 @@ import (
 )
 
 func TestNewSSHClient(t *testing.T) {
-	s, _ := tests.NewSSHServer()
-	port, err := s.Start()
+	s, err := tests.NewSSHServer()
+	if err != nil {
+		t.Fatalf("NewSSHServer: %v", err)
+	}
+	l, port, err := s.Start()
 	if err != nil {
 		t.Fatalf("Error starting ssh server: %v", err)
 	}
+	defer l.Close()
+
 	d := &tests.MockDriver{
 		Port: port,
 		BaseDriver: drivers.BaseDriver{
 			IPAddress:  "127.0.0.1",
 			SSHKeyPath: "",
 		},
+		T: t,
 	}
 	c, err := NewSSHClient(d)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
+	defer c.Close()
 
-	cmd := "foo"
 	sess, err := c.NewSession()
 	if err != nil {
 		t.Fatal("Error creating new session for ssh client")
 	}
 	defer sess.Close()
 
+	cmd := "foo"
 	if err := sess.Run(cmd); err != nil {
-		t.Fatalf("Error running command: %s", cmd)
+		t.Fatalf("Error running %q: %v", cmd, err)
 	}
 	if !s.Connected {
-		t.Fatalf("Error!")
+		t.Fatalf("Server not connected")
 	}
-
 	if _, ok := s.Commands[cmd]; !ok {
 		t.Fatalf("Expected command: %s", cmd)
 	}

--- a/pkg/minikube/tests/ssh_mock.go
+++ b/pkg/minikube/tests/ssh_mock.go
@@ -44,9 +44,9 @@ type SSHServer struct {
 	// Only access this with atomic ops
 	commandToOutput atomic.Value
 
-	quit bool
+	quit     bool
 	listener net.Listener
-	t *testing.T
+	t        *testing.T
 }
 
 // NewSSHServer returns a NewSSHServer instance, ready for use.

--- a/pkg/minikube/tests/ssh_mock.go
+++ b/pkg/minikube/tests/ssh_mock.go
@@ -25,8 +25,8 @@ import (
 	"net"
 	"strconv"
 	"sync/atomic"
+	"testing"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 )
@@ -43,16 +43,21 @@ type SSHServer struct {
 	// commandsToOutput can be used to mock what the SSHServer returns for a given command
 	// Only access this with atomic ops
 	commandToOutput atomic.Value
+
+	quit bool
+	listener net.Listener
+	t *testing.T
 }
 
 // NewSSHServer returns a NewSSHServer instance, ready for use.
-func NewSSHServer() (*SSHServer, error) {
-	s := &SSHServer{}
-	s.Transfers = &bytes.Buffer{}
-	s.Config = &ssh.ServerConfig{
-		NoClientAuth: true,
+func NewSSHServer(t *testing.T) (*SSHServer, error) {
+	t.Helper()
+	s := &SSHServer{
+		Transfers: &bytes.Buffer{},
+		Config:    &ssh.ServerConfig{NoClientAuth: true},
+		Commands:  map[string]int{},
+		t:         t,
 	}
-	s.Commands = make(map[string]int)
 
 	private, err := rsa.GenerateKey(rand.Reader, 2014)
 	if err != nil {
@@ -72,102 +77,103 @@ type execRequest struct {
 	Command string
 }
 
-// Main loop, listen for connections and store the commands.
-func (s *SSHServer) mainLoop(listener net.Listener) {
-	go func() {
-		for {
-			nConn, err := listener.Accept()
-			go func() {
-				if err != nil {
-					return
-				}
-
-				_, chans, reqs, err := ssh.NewServerConn(nConn, s.Config)
-				if err != nil {
-					return
-				}
-				// The incoming Request channel must be serviced.
-				go ssh.DiscardRequests(reqs)
-
-				// Service the incoming Channel channel.
-				for newChannel := range chans {
-					if newChannel.ChannelType() == "session" {
-						s.SetSessionRequested(true)
-					}
-					channel, requests, err := newChannel.Accept()
-					s.Connected = true
-					if err != nil {
-						return
-					}
-
-					for req := range requests {
-						glog.Infoln("Got Req: ", req.Type)
-						// Store anything that comes in over stdin.
-						s.handleRequest(channel, req)
-					}
-				}
-			}()
+// Serve loop, listen for connections and store the commands.
+func (s *SSHServer) serve() {
+	for {
+		s.t.Logf("Accepting...")
+		c, err := s.listener.Accept()
+		if s.quit {
+			return
 		}
-	}()
+		if err != nil {
+			s.t.Errorf("Listener: %v", err)
+			return
+		}
+		go s.handleIncomingConnection(c)
+	}
+}
+
+// handle an incoming ssh connection
+func (s *SSHServer) handleIncomingConnection(c net.Conn) {
+	_, chans, reqs, err := ssh.NewServerConn(c, s.Config)
+	if err != nil {
+		s.t.Logf("newserverconn error: %v", err)
+		return
+	}
+	// The incoming Request channel must be serviced.
+	go ssh.DiscardRequests(reqs)
+
+	// Service the incoming Channel channel.
+	for newChannel := range chans {
+		if newChannel.ChannelType() == "session" {
+			s.SetSessionRequested(true)
+		}
+		channel, requests, err := newChannel.Accept()
+		if err != nil {
+			s.t.Logf("ch accept err: %v", err)
+			return
+		}
+		s.Connected = true
+		for req := range requests {
+			s.handleRequest(channel, req)
+		}
+	}
 }
 
 func (s *SSHServer) handleRequest(channel ssh.Channel, req *ssh.Request) {
 	go func() {
 		if _, err := io.Copy(s.Transfers, channel); err != nil {
-			panic(fmt.Sprintf("copy failed: %v", err))
+			s.t.Errorf("copy failed: %v", err)
 		}
 		channel.Close()
 	}()
 	switch req.Type {
 	case "exec":
+		s.t.Logf("exec request received: %+v", req)
 		if err := req.Reply(true, nil); err != nil {
-			panic(fmt.Sprintf("reply failed: %v", err))
+			s.t.Errorf("reply failed: %v", err)
 		}
 
 		// Note: string(req.Payload) adds additional characters to start of input.
 		var cmd execRequest
 		if err := ssh.Unmarshal(req.Payload, &cmd); err != nil {
-			glog.Errorf("Unmarshall encountered error: %v with req: %v", err, req.Type)
-			return
+			s.t.Errorf("unmarshal failed: %v", err)
 		}
 		s.Commands[cmd.Command] = 1
 
 		// Write specified command output as mocked ssh output
 		if val, err := s.GetCommandToOutput(cmd.Command); err == nil {
 			if _, err := channel.Write([]byte(val)); err != nil {
-				glog.Errorf("Write failed: %v", err)
-				return
+				s.t.Errorf("Write failed: %v", err)
 			}
 		}
 		if _, err := channel.SendRequest("exit-status", false, []byte{0, 0, 0, 0}); err != nil {
-			glog.Errorf("SendRequest failed: %v", err)
-			return
+			s.t.Errorf("SendRequest failed: %v", err)
 		}
 
 	case "pty-req":
+		s.t.Logf("pty request received: %+v", req)
 		if err := req.Reply(true, nil); err != nil {
-			glog.Errorf("Reply failed: %v", err)
-			return
+			s.t.Errorf("Reply failed: %v", err)
 		}
 
 		if _, err := channel.SendRequest("exit-status", false, []byte{0, 0, 0, 0}); err != nil {
-			glog.Errorf("SendRequest failed: %v", err)
-			return
+			s.t.Errorf("SendRequest failed: %v", err)
 		}
 	}
 }
 
-// Start starts the mock SSH Server, and returns the port it's listening on.
+// Start the mock SSH Server
 func (s *SSHServer) Start() (int, error) {
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return 0, errors.Wrap(err, "Error creating tcp listener for ssh server")
 	}
+	s.listener = l
+	s.t.Logf("Listening on %s", s.listener.Addr())
+	go s.serve()
 
-	s.mainLoop(listener)
-
-	// Parse and return the port.
-	_, p, err := net.SplitHostPort(listener.Addr().String())
+	_, p, err := net.SplitHostPort(s.listener.Addr().String())
 	if err != nil {
 		return 0, errors.Wrap(err, "Error splitting host port")
 	}
@@ -176,6 +182,13 @@ func (s *SSHServer) Start() (int, error) {
 		return 0, errors.Wrap(err, "Error converting port string to integer")
 	}
 	return port, nil
+}
+
+// Stop the mock SSH server
+func (s *SSHServer) Stop() {
+	s.t.Logf("Stopping")
+	s.quit = true
+	s.listener.Close()
 }
 
 // SetCommandToOutput sets command to output


### PR DESCRIPTION
This updates TestNewSSHClient and it's mock so that it can reliably survive `-race -count 1000`

One behavioral change is that issues within the mock now raise test errors rather than log them.

Closes #4346
