### PR TITLE
Improve usage message when there is no profile found

### DIFF
--- a/cmd/minikube/cmd/config/profile_list.go
+++ b/cmd/minikube/cmd/config/profile_list.go
@@ -32,7 +32,7 @@ import (
 var profileListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "Lists all minikube profiles.",
-	Long:  "Lists all minikube profiles.",
+	Long:  "Lists all valid minikube profiles and detects all possible invalid profiles.",
 	Run: func(cmd *cobra.Command, args []string) {
 
 		var validData [][]string
@@ -44,6 +44,9 @@ var profileListCmd = &cobra.Command{
 		table.SetCenterSeparator("|")
 		validProfiles, invalidProfiles, err := config.ListProfiles()
 
+		if len(validProfiles) == 0 {
+			exit.UsageT("No minikube profile was found. you could create one using: `minikube start`")
+		}
 		for _, p := range validProfiles {
 			validData = append(validData, []string{p.Name, p.Config.MachineConfig.VMDriver, p.Config.KubernetesConfig.NodeIP, strconv.Itoa(p.Config.KubernetesConfig.NodePort), p.Config.KubernetesConfig.KubernetesVersion})
 		}

--- a/cmd/minikube/cmd/config/profile_list.go
+++ b/cmd/minikube/cmd/config/profile_list.go
@@ -44,7 +44,7 @@ var profileListCmd = &cobra.Command{
 		table.SetCenterSeparator("|")
 		validProfiles, invalidProfiles, err := config.ListProfiles()
 
-		if len(validProfiles) == 0 {
+		if len(validProfiles) == 0 || err == nil {
 			exit.UsageT("No minikube profile was found. you could create one using: `minikube start`")
 		}
 		for _, p := range validProfiles {


### PR DESCRIPTION
change this 
```

./out/minikube profile list
|---------|-----------|--------|-----------|--------------------|
| Profile | VM Driver | NodeIP | Node Port | Kubernetes Version |
|---------|-----------|--------|-----------|--------------------|
|---------|-----------|--------|-----------|--------------------|
💣  error loading profiles: open /Us
```

to this
```
./out/minikube profile list
💡  No minikube profile was found. you could create one using: `minikube start`
```