### PR TITLE
Added command to generate the documentation

### DIFF
--- a/cmd/minikube/cmd/generate-docs.go
+++ b/cmd/minikube/cmd/generate-docs.go
@@ -33,6 +33,7 @@ var generateDocs = &cobra.Command{
 	Short:   "Populates the specified folder with documentation in markdown about minikube",
 	Long:    "Populates the specified folder with documentation in markdown about minikube",
 	Example: "minikube generate-docs --path <FOLDER_PATH>",
+	Hidden: true,
 	Run: func(cmd *cobra.Command, args []string) {
 
 		// if directory does not exist

--- a/cmd/minikube/cmd/generate-docs.go
+++ b/cmd/minikube/cmd/generate-docs.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+	"k8s.io/minikube/pkg/minikube/exit"
+	"k8s.io/minikube/pkg/minikube/out"
+	"os"
+)
+
+var path string
+
+// generateDocs represents the generate-docs command
+var generateDocs = &cobra.Command{
+	Use:   "generate-docs",
+	Short: "Populates the specified folder with documentation in markdown about minikube",
+	Long:  "Populates the specified folder with documentation in markdown about minikube",
+	Example: "minikube generate-docs --path <FOLDER_PATH>",
+	Run: func(cmd *cobra.Command, args []string) {
+
+		// if directory does not exist
+		docsPath, err := os.Stat(path)
+		if err != nil || !docsPath.IsDir() {
+			exit.UsageT("Unable to generate the documentation. Please ensure that the path specified is a directory, exists & you have permission to write to it.")
+		}
+
+		// generate docs
+		if err := doc.GenMarkdownTree(RootCmd,path); err != nil {
+			exit.WithError("Unable to generate docs", err)
+		}
+		out.T(out.Documentation,"Docs have been saved at - {{.path}}",out.V{"path":path})
+	},
+
+}
+
+func init() {
+	generateDocs.Flags().StringVar(&path,"path","","The path on the file system where the docs in markdown need to be saved")
+	RootCmd.AddCommand(generateDocs)
+}

--- a/cmd/minikube/cmd/generate-docs.go
+++ b/cmd/minikube/cmd/generate-docs.go
@@ -1,20 +1,37 @@
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/out"
-	"os"
 )
 
 var path string
 
 // generateDocs represents the generate-docs command
 var generateDocs = &cobra.Command{
-	Use:   "generate-docs",
-	Short: "Populates the specified folder with documentation in markdown about minikube",
-	Long:  "Populates the specified folder with documentation in markdown about minikube",
+	Use:     "generate-docs",
+	Short:   "Populates the specified folder with documentation in markdown about minikube",
+	Long:    "Populates the specified folder with documentation in markdown about minikube",
 	Example: "minikube generate-docs --path <FOLDER_PATH>",
 	Run: func(cmd *cobra.Command, args []string) {
 
@@ -25,15 +42,14 @@ var generateDocs = &cobra.Command{
 		}
 
 		// generate docs
-		if err := doc.GenMarkdownTree(RootCmd,path); err != nil {
+		if err := doc.GenMarkdownTree(RootCmd, path); err != nil {
 			exit.WithError("Unable to generate docs", err)
 		}
-		out.T(out.Documentation,"Docs have been saved at - {{.path}}",out.V{"path":path})
+		out.T(out.Documentation, "Docs have been saved at - {{.path}}", out.V{"path": path})
 	},
-
 }
 
 func init() {
-	generateDocs.Flags().StringVar(&path,"path","","The path on the file system where the docs in markdown need to be saved")
+	generateDocs.Flags().StringVar(&path, "path", "", "The path on the file system where the docs in markdown need to be saved")
 	RootCmd.AddCommand(generateDocs)
 }


### PR DESCRIPTION
Fixes #4727 

- Adds a new command -`generate-docs`
- It accepts a `--path` argument and saves all the documentation in the path provided it is valid and accessible.

-Pranav