### PR TITLE
Separate make lint targets for developers vs travis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,9 @@ KERNEL_VERSION ?= 4.16.14
 GO_VERSION ?= $(shell go version | cut -d' ' -f3 | sed -e 's/go//')
 GOLINT_VERSION ?= v1.17.1
 # Limit number of default jobs, to avoid the CI builds running out of memory
-GOLINT_JOBS ?= 1
+GOLINT_JOBS ?= 2
 # see https://github.com/golangci/golangci-lint#memory-usage-of-golangci-lint
-GOLINT_GOGC ?= 8
+GOLINT_GOGC ?= 5
 
 export GO111MODULE := on
 

--- a/Makefile
+++ b/Makefile
@@ -280,6 +280,16 @@ out/linters/golangci-lint:
 
 .PHONY: lint
 lint: pkg/minikube/assets/assets.go pkg/minikube/translate/translations.go out/linters/golangci-lint
+	GOGC=100 ./out/linters/golangci-lint run \
+	  --deadline 4m \
+	  --build-tags "${MINIKUBE_INTEGRATION_BUILD_TAGS}" \
+	  --enable goimports,gocritic,golint,gocyclo,interfacer,misspell,nakedret,stylecheck,unconvert,unparam \
+	  --exclude 'variable on range scope.*in function literal|ifElseChain' \
+	  ./...
+
+# lint-ci is slower than lint and is meant to be used in ci (travis) to avoid out of memory leaks.
+.PHONY: lint-ci
+lint-ci: pkg/minikube/assets/assets.go pkg/minikube/translate/translations.go out/linters/golangci-lint
 	GOGC=${GOLINT_GOGC} ./out/linters/golangci-lint run \
 	  --concurrency ${GOLINT_JOBS} \
 	  --deadline 4m \

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ GOLINT_VERSION ?= v1.17.1
 # Limit number of default jobs, to avoid the CI builds running out of memory
 GOLINT_JOBS ?= 1
 # see https://github.com/golangci/golangci-lint#memory-usage-of-golangci-lint
-GOLINT_GOGC ?= 10
+GOLINT_GOGC ?= 8
 
 export GO111MODULE := on
 

--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,9 @@ KERNEL_VERSION ?= 4.16.14
 GO_VERSION ?= $(shell go version | cut -d' ' -f3 | sed -e 's/go//')
 GOLINT_VERSION ?= v1.17.1
 # Limit number of default jobs, to avoid the CI builds running out of memory
-GOLINT_JOBS ?= 2
+GOLINT_JOBS ?= 4
 # see https://github.com/golangci/golangci-lint#memory-usage-of-golangci-lint
-GOLINT_GOGC ?= 5
+GOLINT_GOGC ?= 8
 
 export GO111MODULE := on
 

--- a/test.sh
+++ b/test.sh
@@ -20,10 +20,10 @@ exitcode=0
 
 echo "= go mod ================================================================"
 go mod download 2>&1 | grep -v "go: finding" || true
-go mod tidy -v && echo ok || ((exitcode+=2))
+go mod tidy -v && echo ok || ((exitcode += 2))
 
 echo "= make lint ============================================================="
-make -s lint-travis && echo ok || ((exitcode+=4))
+make -s lint-ci && echo ok || ((exitcode += 4))
 
 echo "= boilerplate ==========================================================="
 readonly PYTHON=$(type -P python || echo docker run --rm -it -v $(pwd):/minikube -w /minikube python python)
@@ -32,24 +32,24 @@ missing="$($PYTHON ${BDIR}/boilerplate.py --rootdir . --boilerplate-dir ${BDIR} 
 if [[ -n "${missing}" ]]; then
     echo "boilerplate missing: $missing"
     echo "consider running: ${BDIR}/fix.sh"
-    ((exitcode+=4))
+    ((exitcode += 4))
 else
     echo "ok"
 fi
 
 echo "= schema_check =========================================================="
-go run deploy/minikube/schema_check.go >/dev/null && echo ok || ((exitcode+=8))
+go run deploy/minikube/schema_check.go >/dev/null && echo ok || ((exitcode += 8))
 
 echo "= go test ==============================================================="
 cov_tmp="$(mktemp)"
 readonly COVERAGE_PATH=./out/coverage.txt
-echo "mode: count" > "${COVERAGE_PATH}"
+echo "mode: count" >"${COVERAGE_PATH}"
 pkgs=$(go list -f '{{ if .TestGoFiles }}{{.ImportPath}}{{end}}' ./cmd/... ./pkg/... | xargs)
 go test \
     -tags "container_image_ostree_stub containers_image_openpgp" \
     -covermode=count \
     -coverprofile="${cov_tmp}" \
-    ${pkgs} && echo ok || ((exitcode+=16))
-tail -n +2 "${cov_tmp}" >> "${COVERAGE_PATH}"
+    ${pkgs} && echo ok || ((exitcode += 16))
+tail -n +2 "${cov_tmp}" >>"${COVERAGE_PATH}"
 
 exit "${exitcode}"

--- a/test.sh
+++ b/test.sh
@@ -23,7 +23,7 @@ go mod download 2>&1 | grep -v "go: finding" || true
 go mod tidy -v && echo ok || ((exitcode+=2))
 
 echo "= make lint ============================================================="
-make -s lint && echo ok || ((exitcode+=4))
+make -s lint-travis && echo ok || ((exitcode+=4))
 
 echo "= boilerplate ==========================================================="
 readonly PYTHON=$(type -P python || echo docker run --rm -it -v $(pwd):/minikube -w /minikube python python)


### PR DESCRIPTION
Hopefully closes https://github.com/kubernetes/minikube/issues/4851 without making the 10 minutes. 
address the golangci-lint out of memory flaky fails

currently it runs at  5 min 57 sec