### PR TITLE
Fix flag.Parse error logging

### DIFF
--- a/cmd/minikube/main.go
+++ b/cmd/minikube/main.go
@@ -25,6 +25,11 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/pkg/profile"
+
+	// initflag must be imported before any other minikube pkg.
+	// Fix for https://github.com/kubernetes/minikube/issues/4866
+	_ "k8s.io/minikube/pkg/initflag"
+
 	"k8s.io/minikube/cmd/minikube/cmd"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/machine"

--- a/pkg/initflag/initflag.go
+++ b/pkg/initflag/initflag.go
@@ -1,0 +1,11 @@
+package initflag
+
+import (
+	"flag"
+)
+
+func init() {
+	// Workaround for "ERROR: logging before flag.Parse"
+	// See: https://github.com/kubernetes/kubernetes/issues/17162
+	flag.CommandLine.Parse([]string{})
+}

--- a/pkg/initflag/initflag.go
+++ b/pkg/initflag/initflag.go
@@ -7,5 +7,5 @@ import (
 func init() {
 	// Workaround for "ERROR: logging before flag.Parse"
 	// See: https://github.com/kubernetes/kubernetes/issues/17162
-	flag.CommandLine.Parse([]string{})
+	_ = flag.CommandLine.Parse([]string{})
 }

--- a/pkg/initflag/initflag.go
+++ b/pkg/initflag/initflag.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package initflag
 
 import (

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -31,6 +31,8 @@ import (
 	"testing"
 	"time"
 
+	_ "k8s.io/minikube/pkg/initflag"
+
 	"github.com/docker/machine/libmachine/state"
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	"k8s.io/apimachinery/pkg/labels"

--- a/test/integration/cluster_dns_test.go
+++ b/test/integration/cluster_dns_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	_ "k8s.io/minikube/pkg/initflag"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	pkgutil "k8s.io/minikube/pkg/util"

--- a/test/integration/cluster_env_test.go
+++ b/test/integration/cluster_env_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	_ "k8s.io/minikube/pkg/initflag"
+
 	"k8s.io/minikube/test/integration/util"
 )
 

--- a/test/integration/cluster_status_test.go
+++ b/test/integration/cluster_status_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	_ "k8s.io/minikube/pkg/initflag"
+
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/minikube/test/integration/util"
 )

--- a/test/integration/flags.go
+++ b/test/integration/flags.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"testing"
 
+	_ "k8s.io/minikube/pkg/initflag"
+
 	"k8s.io/minikube/test/integration/util"
 )
 

--- a/test/integration/flags.go
+++ b/test/integration/flags.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"testing"
 
+	// initflag must be imported before any other minikube pkg.
+	// Fix for https://github.com/kubernetes/minikube/issues/4866
 	_ "k8s.io/minikube/pkg/initflag"
 
 	"k8s.io/minikube/test/integration/util"

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"testing"
 
+	_ "k8s.io/minikube/pkg/initflag"
+
 	"github.com/docker/machine/libmachine/state"
 	"k8s.io/minikube/test/integration/util"
 )

--- a/test/integration/mount_test.go
+++ b/test/integration/mount_test.go
@@ -29,6 +29,8 @@ import (
 	"testing"
 	"time"
 
+	_ "k8s.io/minikube/pkg/initflag"
+
 	"k8s.io/apimachinery/pkg/labels"
 	pkgutil "k8s.io/minikube/pkg/util"
 	"k8s.io/minikube/test/integration/util"

--- a/test/integration/persistence_test.go
+++ b/test/integration/persistence_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	_ "k8s.io/minikube/pkg/initflag"
+
 	"github.com/docker/machine/libmachine/state"
 	"k8s.io/minikube/test/integration/util"
 )

--- a/test/integration/proxy_test.go
+++ b/test/integration/proxy_test.go
@@ -30,6 +30,8 @@ import (
 	"net/http"
 	"net/url"
 
+	_ "k8s.io/minikube/pkg/initflag"
+
 	"github.com/elazarl/goproxy"
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	"github.com/phayes/freeport"

--- a/test/integration/pv_test.go
+++ b/test/integration/pv_test.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	_ "k8s.io/minikube/pkg/initflag"
+
 	core "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	_ "k8s.io/minikube/pkg/initflag"
+
 	"github.com/docker/machine/libmachine/state"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/test/integration/util"

--- a/test/integration/tunnel_test.go
+++ b/test/integration/tunnel_test.go
@@ -28,6 +28,8 @@ import (
 	"testing"
 	"time"
 
+	_ "k8s.io/minikube/pkg/initflag"
+
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/pkg/errors"

--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"testing"
 
+	_ "k8s.io/minikube/pkg/initflag"
+
 	"github.com/docker/machine/libmachine/state"
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	"github.com/pkg/errors"


### PR DESCRIPTION
Fix for https://github.com/kubernetes/minikube/issues/4866

As minikube/main import some packages that use `glog` on init, and package variables, adding the fix only on the main method won't do. That's why I'm using a package that is imported before others to do the workaround.