### PR TITLE
UI: improve minikube help output by grouping into categories

### DIFF
--- a/cmd/minikube/cmd/cache.go
+++ b/cmd/minikube/cmd/cache.go
@@ -108,5 +108,4 @@ func loadCachedImagesInConfigFile() error {
 func init() {
 	cacheCmd.AddCommand(addCacheCmd)
 	cacheCmd.AddCommand(deleteCacheCmd)
-	RootCmd.AddCommand(cacheCmd)
 }

--- a/cmd/minikube/cmd/completion.go
+++ b/cmd/minikube/cmd/completion.go
@@ -279,7 +279,3 @@ __minikube_bash_source <(__minikube_convert_bash_to_zsh)
 
 	return nil
 }
-
-func init() {
-	RootCmd.AddCommand(completionCmd)
-}

--- a/cmd/minikube/cmd/dashboard.go
+++ b/cmd/minikube/cmd/dashboard.go
@@ -228,5 +228,4 @@ func checkURL(url string) error {
 
 func init() {
 	dashboardCmd.Flags().BoolVar(&dashboardURLMode, "url", false, "Display dashboard URL instead of opening a browser")
-	RootCmd.AddCommand(dashboardCmd)
 }

--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -103,7 +103,3 @@ func uninstallKubernetes(api libmachine.API, kc pkg_config.KubernetesConfig, bsN
 		out.ErrT(out.Empty, "Failed to delete cluster: {{.error}}", out.V{"error": err})
 	}
 }
-
-func init() {
-	RootCmd.AddCommand(deleteCmd)
-}

--- a/cmd/minikube/cmd/env.go
+++ b/cmd/minikube/cmd/env.go
@@ -382,7 +382,6 @@ var dockerEnvCmd = &cobra.Command{
 }
 
 func init() {
-	RootCmd.AddCommand(dockerEnvCmd)
 	defaultShellDetector = &LibmachineShellDetector{}
 	defaultNoProxyGetter = &EnvNoProxyGetter{}
 	dockerEnvCmd.Flags().BoolVar(&noProxy, "no-proxy", false, "Add machine IP to NO_PROXY environment variable")

--- a/cmd/minikube/cmd/ip.go
+++ b/cmd/minikube/cmd/ip.go
@@ -54,7 +54,3 @@ var ipCmd = &cobra.Command{
 		out.Ln(ip)
 	},
 }
-
-func init() {
-	RootCmd.AddCommand(ipCmd)
-}

--- a/cmd/minikube/cmd/kubectl.go
+++ b/cmd/minikube/cmd/kubectl.go
@@ -86,7 +86,3 @@ kubectl get pods --namespace kube-system`,
 		}
 	},
 }
-
-func init() {
-	RootCmd.AddCommand(kubectlCmd)
-}

--- a/cmd/minikube/cmd/logs.go
+++ b/cmd/minikube/cmd/logs.go
@@ -98,5 +98,4 @@ func init() {
 	logsCmd.Flags().BoolVarP(&followLogs, "follow", "f", false, "Show only the most recent journal entries, and continuously print new entries as they are appended to the journal.")
 	logsCmd.Flags().BoolVar(&showProblems, "problems", false, "Show only log entries which point to known problems")
 	logsCmd.Flags().IntVarP(&numberOfLines, "length", "n", 50, "Number of lines back to go within the log")
-	RootCmd.AddCommand(logsCmd)
 }

--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -209,5 +209,4 @@ func init() {
 	mountCmd.Flags().UintVar(&mode, "mode", 0755, "File permissions used for the mount")
 	mountCmd.Flags().StringSliceVar(&options, "options", []string{}, "Additional mount options, such as cache=fscache")
 	mountCmd.Flags().IntVar(&mSize, "msize", constants.DefaultMsize, "The number of bytes to use for 9p packet payload")
-	RootCmd.AddCommand(mountCmd)
 }

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -132,17 +132,16 @@ func init() {
 
 	groups := templates.CommandGroups{
 		{
-			Message: "Basic Commands",
+			Message: "Basic Commands:",
 			Commands: []*cobra.Command{
 				startCmd,
 				statusCmd,
 				stopCmd,
 				deleteCmd,
-				dashboardCmd,
 			},
 		},
 		{
-			Message: "Images Commands",
+			Message: "Images Commands:",
 			Commands: []*cobra.Command{
 				dockerEnvCmd,
 				cacheCmd,
@@ -150,8 +149,9 @@ func init() {
 		},
 
 		{
-			Message: "Usability Commands",
+			Message: "Usability Commands:",
 			Commands: []*cobra.Command{
+				dashboardCmd,
 				serviceCmd,
 				configCmd.AddonsCmd,
 				configCmd.ConfigCmd,
@@ -168,7 +168,7 @@ func init() {
 			},
 		},
 		{
-			Message: "Troubleshooting Commands",
+			Message: "Troubleshooting Commands:",
 			Commands: []*cobra.Command{
 				updateContextCmd,
 				sshKeyCmd,

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -138,6 +138,7 @@ func init() {
 				statusCmd,
 				stopCmd,
 				deleteCmd,
+				dashboardCmd,
 			},
 		},
 		{
@@ -147,21 +148,25 @@ func init() {
 				cacheCmd,
 			},
 		},
-
 		{
-			Message: "Usability Commands:",
+			Message: "Configuration and Management Commands:",
 			Commands: []*cobra.Command{
-				dashboardCmd,
-				serviceCmd,
 				configCmd.AddonsCmd,
 				configCmd.ConfigCmd,
 				configCmd.ProfileCmd,
+				updateContextCmd,
+			},
+		},
+		{
+			Message: "Networking and Connectivity Commands:",
+			Commands: []*cobra.Command{
+				serviceCmd,
+				tunnelCmd,
 			},
 		},
 		{
 			Message: "Advanced Commands:",
 			Commands: []*cobra.Command{
-				tunnelCmd,
 				mountCmd,
 				sshCmd,
 				kubectlCmd,
@@ -170,12 +175,11 @@ func init() {
 		{
 			Message: "Troubleshooting Commands:",
 			Commands: []*cobra.Command{
-				updateContextCmd,
 				sshKeyCmd,
 				ipCmd,
 				logsCmd,
-				versionCmd,
 				updateCheckCmd,
+				versionCmd,
 			},
 		},
 	}

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -30,6 +30,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"k8s.io/kubectl/pkg/util/templates"
 	configCmd "k8s.io/minikube/cmd/minikube/cmd/config"
 	"k8s.io/minikube/pkg/minikube/bootstrapper"
 	"k8s.io/minikube/pkg/minikube/bootstrapper/kubeadm"
@@ -128,9 +129,62 @@ func setFlagsUsingViper() {
 func init() {
 	RootCmd.PersistentFlags().StringP(config.MachineProfile, "p", constants.DefaultMachineName, `The name of the minikube VM being used. This can be set to allow having multiple instances of minikube independently.`)
 	RootCmd.PersistentFlags().StringP(configCmd.Bootstrapper, "b", constants.DefaultClusterBootstrapper, "The name of the cluster bootstrapper that will set up the kubernetes cluster.")
-	RootCmd.AddCommand(configCmd.ConfigCmd)
-	RootCmd.AddCommand(configCmd.AddonsCmd)
-	RootCmd.AddCommand(configCmd.ProfileCmd)
+
+	groups := templates.CommandGroups{
+		{
+			Message: "Basic Commands",
+			Commands: []*cobra.Command{
+				startCmd,
+				statusCmd,
+				stopCmd,
+				deleteCmd,
+				dashboardCmd,
+			},
+		},
+		{
+			Message: "Images Commands",
+			Commands: []*cobra.Command{
+				dockerEnvCmd,
+				cacheCmd,
+			},
+		},
+
+		{
+			Message: "Usability Commands",
+			Commands: []*cobra.Command{
+				serviceCmd,
+				configCmd.AddonsCmd,
+				configCmd.ConfigCmd,
+				configCmd.ProfileCmd,
+			},
+		},
+		{
+			Message: "Advanced Commands:",
+			Commands: []*cobra.Command{
+				tunnelCmd,
+				mountCmd,
+				sshCmd,
+				kubectlCmd,
+			},
+		},
+		{
+			Message: "Troubleshooting Commands",
+			Commands: []*cobra.Command{
+				updateContextCmd,
+				sshKeyCmd,
+				ipCmd,
+				logsCmd,
+				versionCmd,
+				updateCheckCmd,
+			},
+		},
+	}
+	groups.Add(RootCmd)
+
+	// any not grouped command will show in Other Commands group.
+	RootCmd.AddCommand(completionCmd)
+	templates.ActsAsRootCommand(RootCmd, []string{"options"}, groups...)
+
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	if err := viper.BindPFlags(RootCmd.PersistentFlags()); err != nil {
 		exit.WithError("Unable to bind flags", err)

--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -83,5 +83,4 @@ func init() {
 
 	serviceCmd.PersistentFlags().StringVar(&serviceURLFormat, "format", defaultServiceFormatTemplate, "Format to output service URL in. This format will be applied to each url individually and they will be printed one at a time.")
 
-	RootCmd.AddCommand(serviceCmd)
 }

--- a/cmd/minikube/cmd/ssh-key.go
+++ b/cmd/minikube/cmd/ssh-key.go
@@ -34,7 +34,3 @@ var sshKeyCmd = &cobra.Command{
 		out.Ln(filepath.Join(constants.GetMinipath(), "machines", config.GetMachineName(), "id_rsa"))
 	},
 }
-
-func init() {
-	RootCmd.AddCommand(sshKeyCmd)
-}

--- a/cmd/minikube/cmd/ssh.go
+++ b/cmd/minikube/cmd/ssh.go
@@ -55,7 +55,3 @@ var sshCmd = &cobra.Command{
 		}
 	},
 }
-
-func init() {
-	RootCmd.AddCommand(sshCmd)
-}

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -123,7 +123,6 @@ func init() {
 		exit.WithError("unable to bind flags", err)
 	}
 
-	RootCmd.AddCommand(startCmd)
 }
 
 // initMinikubeFlags includes commandline flags for minikube.

--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -144,5 +144,4 @@ func init() {
 	statusCmd.Flags().StringVar(&statusFormat, "format", constants.DefaultStatusFormat,
 		`Go template format string for the status output.  The format for Go templates can be found here: https://golang.org/pkg/text/template/
 For the list accessible variables for the template, see the struct values here: https://godoc.org/k8s.io/minikube/cmd/minikube/cmd#Status`)
-	RootCmd.AddCommand(statusCmd)
 }

--- a/cmd/minikube/cmd/stop.go
+++ b/cmd/minikube/cmd/stop.go
@@ -81,7 +81,3 @@ func runStop(cmd *cobra.Command, args []string) {
 		exit.WithError("update config", err)
 	}
 }
-
-func init() {
-	RootCmd.AddCommand(stopCmd)
-}

--- a/cmd/minikube/cmd/tunnel.go
+++ b/cmd/minikube/cmd/tunnel.go
@@ -86,5 +86,4 @@ var tunnelCmd = &cobra.Command{
 
 func init() {
 	tunnelCmd.Flags().BoolVarP(&cleanup, "cleanup", "c", false, "call with cleanup=true to remove old tunnels")
-	RootCmd.AddCommand(tunnelCmd)
 }

--- a/cmd/minikube/cmd/update-check.go
+++ b/cmd/minikube/cmd/update-check.go
@@ -48,7 +48,3 @@ var updateCheckCmd = &cobra.Command{
 		out.Ln("LatestVersion: %s", r[0].Name)
 	},
 }
-
-func init() {
-	RootCmd.AddCommand(updateCheckCmd)
-}

--- a/cmd/minikube/cmd/update-context.go
+++ b/cmd/minikube/cmd/update-context.go
@@ -56,7 +56,3 @@ var updateContextCmd = &cobra.Command{
 
 	},
 }
-
-func init() {
-	RootCmd.AddCommand(updateContextCmd)
-}

--- a/cmd/minikube/cmd/version.go
+++ b/cmd/minikube/cmd/version.go
@@ -38,7 +38,3 @@ var versionCmd = &cobra.Command{
 		}
 	},
 }
-
-func init() {
-	RootCmd.AddCommand(versionCmd)
-}

--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,7 @@ require (
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v0.0.0
+	k8s.io/kubectl v0.0.0-00010101000000-000000000000
 	k8s.io/kubernetes v1.15.0
 	sigs.k8s.io/sig-storage-lib-external-provisioner v4.0.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,7 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20181220005116-f8e995905100/go.mod h1:iroGtC8B3tQiqtds1l+mgk/BBOrxbqjH+eUfFQYRc14=
 github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab/go.mod h1:3VYc5hodBMJ5+l/7J4xAyMeuM2PNuepvHlGs8yilUCA=
+github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd h1:sjQovDkwrZp8u+gxLtPgKGjk5hCxuy2hrRejBTA9xFU=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
@@ -88,6 +89,7 @@ github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/docker/libnetwork v0.0.0-20180830151422-a9cd636e3789/go.mod h1:93m0aTqz6z+g32wla4l4WxTrdtvBRmVzYRkYvasA5Z8=
 github.com/docker/machine v0.16.1-0.20190718054102-a555e4f7a8f5 h1:5OiV/JwT55JRKNJsM9HZrTlJH/TRp97Ee89ahtB78+w=
 github.com/docker/machine v0.16.1-0.20190718054102-a555e4f7a8f5/go.mod h1:I8mPNDeK1uH+JTcUU7X0ZW8KiYz0jyAgNaeSJ1rCfDI=
+github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 h1:cenwrSVm+Z7QLSV/BsnenAOcDXdX4cMv4wP0B/5QbPg=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20190421051319-9d40249d3c2f h1:8GDPb0tCY8LQ+OJ3dbHb5sA6YZWXFORQYZx5sdsTlMs=
@@ -260,6 +262,8 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/go-ps v0.0.0-20170309133038-4fdf99ab2936 h1:kw1v0NlnN+GZcU8Ma8CLF2Zzgjfx95gs3/GN3vYAPpo=
 github.com/mitchellh/go-ps v0.0.0-20170309133038-4fdf99ab2936/go.mod h1:r1VsdOzOPt1ZSrGZWFoNhsAedKnEd6r9Np1+5blZCWk=
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
+github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
+github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/moby/hyperkit v0.0.0-20171020124204-a12cd7250bcd h1:WDG9l//UGcGx4lqqEDY23+mRnQMKFY+8LD83OxQllRk=
@@ -515,6 +519,8 @@ k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator v0.0.0-20190623232353-8c3b7
 k8s.io/kubernetes/staging/src/k8s.io/kube-controller-manager v0.0.0-20190623232353-8c3b7d7679cc/go.mod h1:o6aAFW1lCnr5CJm1riWnhQskrAHhyt8btyv5UHhgZ6c=
 k8s.io/kubernetes/staging/src/k8s.io/kube-proxy v0.0.0-20190623232353-8c3b7d7679cc/go.mod h1:y0hpsQGN8h3HcNqYbpSZEH4yC1ohi45N35c8ma9yg6M=
 k8s.io/kubernetes/staging/src/k8s.io/kube-scheduler v0.0.0-20190623232353-8c3b7d7679cc/go.mod h1:/hbCTKdfutEO2iTQv8NuYcnAxd8Tuu4mMEymYv/EZHk=
+k8s.io/kubernetes/staging/src/k8s.io/kubectl v0.0.0-20190623232353-8c3b7d7679cc h1:Bsljf/3UDy91qqLkevAiq6y+wl0qJrkLjWfBCQs9rss=
+k8s.io/kubernetes/staging/src/k8s.io/kubectl v0.0.0-20190623232353-8c3b7d7679cc/go.mod h1:Vg6Q3IDU3hfYMICKyb43lClOXWtCtOBh2o1FfuQw8mQ=
 k8s.io/kubernetes/staging/src/k8s.io/kubelet v0.0.0-20190623232353-8c3b7d7679cc/go.mod h1:9UInPlSttlDwZBFNMAsqhTtl7zH00dE2M88B9Z0Ennc=
 k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20190623232353-8c3b7d7679cc/go.mod h1:xlTRb77uaXbuT6evILwFescWPMENFKYGYj3a/kOjYQE=
 k8s.io/kubernetes/staging/src/k8s.io/metrics v0.0.0-20190623232353-8c3b7d7679cc/go.mod h1:6Cs3k9ccbWbJo3CQOrGDu2QEVLwsWbBlu9HitjPhuSk=


### PR DESCRIPTION
This PR Improves minikube help output by grouping the commands into categories (also matches kubectl's help style)
the new minikube help output will look like :

```
Minikube is a CLI tool that provisions and manages single-node Kubernetes clusters optimized for development workflows.

Basic Commands:
  start          Starts a local kubernetes cluster
  status         Gets the status of a local kubernetes cluster
  stop           Stops a running local kubernetes cluster
  delete         Deletes a local kubernetes cluster
  dashboard      Access the kubernetes dashboard running within the minikube cluster

Images Commands:
  docker-env     Sets up docker env variables; similar to '$(docker-machine env)'
  cache          Add or delete an image from the local cache.

Configuration and Management Commands:
  addons         Modify minikube's kubernetes addons
  config         Modify minikube config
  profile        Profile gets or sets the current minikube profile
  update-context Verify the IP address of the running cluster in kubeconfig.

Networking and Connectivity Commands:
  service        Gets the kubernetes URL(s) for the specified service in your local cluster
  tunnel         tunnel makes services of type LoadBalancer accessible on localhost

Advanced Commands:
  mount          Mounts the specified directory into minikube
  ssh            Log into or run a command on a machine with SSH; similar to 'docker-machine ssh'
  kubectl        Run kubectl

Troubleshooting Commands:
  ssh-key        Retrieve the ssh identity key path of the specified cluster
  ip             Retrieves the IP address of the running cluster
  logs           Gets the logs of the running instance, used for debugging minikube, not user code
  update-check   Print current and latest version number
  version        Print the version of minikube

Other Commands:
  completion     Outputs minikube shell completion for the given shell (bash or zsh)

Use "minikube <command> --help" for more information about a given command.

```

for a reference to compare, it currently looks like this (before this PR): 

```
Minikube is a CLI tool that provisions and manages single-node Kubernetes clusters optimized for development workflows.

Usage:
  minikube [command]

Available Commands:
  addons         Modify minikube's kubernetes addons
  cache          Add or delete an image from the local cache.
  completion     Outputs minikube shell completion for the given shell (bash or zsh)
  config         Modify minikube config
  dashboard      Access the kubernetes dashboard running within the minikube cluster
  delete         Deletes a local kubernetes cluster
  docker-env     Sets up docker env variables; similar to '$(docker-machine env)'
  help           Help about any command
  ip             Retrieves the IP address of the running cluster
  kubectl        Run kubectl
  logs           Gets the logs of the running instance, used for debugging minikube, not user code
  mount          Mounts the specified directory into minikube
  profile        Profile gets or sets the current minikube profile
  service        Gets the kubernetes URL(s) for the specified service in your local cluster
  ssh            Log into or run a command on a machine with SSH; similar to 'docker-machine ssh'
  ssh-key        Retrieve the ssh identity key path of the specified cluster
  start          Starts a local kubernetes cluster
  status         Gets the status of a local kubernetes cluster
  stop           Stops a running local kubernetes cluster
  tunnel         tunnel makes services of type LoadBalancer accessible on localhost
  update-check   Print current and latest version number
  update-context Verify the IP address of the running cluster in kubeconfig.
  version        Print the version of minikube

Flags:
      --alsologtostderr                  log to standard error as well as files
  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the kubernetes cluster. (default "kubeadm")
  -h, --help                             help for minikube
      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory
      --logtostderr                      log to standard error instead of files
  -p, --profile string                   The name of the minikube VM being used.  
                                         	This can be modified to allow for multiple minikube instances to be run independently (default "minikube")
      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
  -v, --v Level                          log level for V logs
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

Use "minikube [command] --help" for more information about a command.

```

I am open to suggestion for the group names and what belong in what group, I made the categories without putting much thinking really.

 closes https://github.com/kubernetes/minikube/issues/4878