### PR TITLE
CI: kill hung proc with sudo and release port

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -161,8 +161,11 @@ kprocs=$(pgrep kubectl || true)
 if [[ "${kprocs}" != "" ]]; then
   echo "error: killing hung kubectl processes ..."
   ps -f -p ${kprocs} || true
-  ${SUDO_PREFIX} kill ${kprocs} || true
+  sudo -E kill ${kprocs} || true
 fi
+
+# clean up none drivers binding on 8443
+lsof -P | grep ':8443' | awk '{print $2}' | xargs sudo -E kill -9
 
 function cleanup_stale_routes() {
   local show="netstat -rn -f inet"


### PR DESCRIPTION
Reason: 
https://github.com/kubernetes/minikube/blob/87802b2c778ccb862ffa89c5c58e2cdff3612cc2/hack/jenkins/common.sh#L164

the parent script passes the sudo prefix (for example for kvm we pass empty) because dont need sudo for kvm but for kill it is better to use sudo regardless, because there might be a none test that had ran before kvm test, and we wanna clean up before we start test

to address https://github.com/kubernetes/minikube/issues/4881 , also maybe 
https://github.com/kubernetes/minikube/issues/4418