### PR TITLE
CI: clean up stale hyperkit and none process and stale inaccessible vbox

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -188,9 +188,9 @@ fi
     for p in $none_procs
     do
     echo "Kiling stale none driver:  $p"
-    sudo ps -f -p $p || true
-    sudo kill $p || true
-    sudo kill -9 $p || true
+    sudo -E ps -f -p $p || true
+    sudo -E kill $p || true
+    sudo -E kill -9 $p || true
     done
   fi
 

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -238,7 +238,7 @@ echo ">> Starting ${E2E_BIN} at $(date)"
 ${SUDO_PREFIX}${E2E_BIN} \
   -minikube-start-args="--vm-driver=${VM_DRIVER} ${EXTRA_START_ARGS}" \
   -minikube-args="--v=10 --logtostderr ${EXTRA_ARGS}" \
-  -test.v -test.timeout=90m -binary="${MINIKUBE_BIN}" && result=$? || result=$?
+  -test.v -test.timeout=100m -binary="${MINIKUBE_BIN}" && result=$? || result=$?
 echo ">> ${E2E_BIN} exited with ${result} at $(date)"
 echo ""
 

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -130,6 +130,8 @@ if type -P virsh; then
     | awk '{ print $2 }' \
     | xargs -I {} sh -c "virsh -c qemu:///system destroy {}; virsh -c qemu:///system undefine {}" \
     || true
+  # list again after clean up
+  virsh -c qemu:///system list --all
 fi
 
 if type -P vboxmanage; then
@@ -146,6 +148,8 @@ if type -P vboxmanage; then
     | cut -d'"' -f3 \
     | xargs -I {} sh -c "vboxmanage startvm {} --type emergencystop; vboxmanage unregistervm {} --delete" \
     || true
+  # list them again after clean up
+  vboxmanage list vms || true
 fi
 
 if type -P hdiutil; then

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -139,6 +139,13 @@ if type -P vboxmanage; then
     | cut -d'"' -f2 \
     | xargs -I {} sh -c "vboxmanage startvm {} --type emergencystop; vboxmanage unregistervm {} --delete" \
     || true
+
+  # remove inaccessible stale VMs https://github.com/kubernetes/minikube/issues/4872
+  vboxmanage list vms \
+    | grep inaccessible \
+    | cut -d'"' -f3 \
+    | xargs -I {} sh -c "vboxmanage startvm {} --type emergencystop; vboxmanage unregistervm {} --delete" \
+    || true
 fi
 
 if type -P hdiutil; then

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -164,7 +164,7 @@ fi
 # cleaning up stale hyperkits
 if type -P hyperkit; then
   # find all hyperkits excluding com.docker
-  hyper_procs=$(ps aux | grep hyperkit | grep -v com.docker | grep -v grep | awk '{print $2}' || true)
+  hyper_procs=$(ps aux | grep hyperkit | grep -v com.docker | grep -v grep | grep -v osx_integration_tests_hyperkit.sh | awk '{print $2}' || true)
   if [[ "${hyper_procs}" != "" ]]; then
     echo "Found stale hyperkits test processes to kill : "
     for p in $hyper_procs


### PR DESCRIPTION
improves the CI pre clean up:

- delete stale hyperkit vms : related to https://github.com/kubernetes/minikube/issues/4892
- delete virtualbox inaccessible vms : closes https://github.com/kubernetes/minikube/issues/4872
- release the left over bound ports from none driver