### PR TITLE
Travis build status link should go to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![BuildStatus Widget]][BuildStatus Result]
 [![GoReport Widget]][GoReport Status]
 
-[BuildStatus Result]: https://travis-ci.org/kubernetes/minikube
+[BuildStatus Result]: https://travis-ci.org/kubernetes/minikube/branches
 [BuildStatus Widget]: https://travis-ci.org/kubernetes/minikube.svg?branch=master
 
 [GoReport Status]: https://goreportcard.com/report/github.com/kubernetes/minikube


### PR DESCRIPTION
Currently it goes to the latest Pull Request instead.
The status widget (image) shows `master` though.


But at least it shows "Default Branch" at the top:

https://travis-ci.org/kubernetes/minikube/branches

----

We have a _lot_ of stale old branches there...
Maybe some of them could be cleaned up ?

Currently have **16 branches**, that's not very CI:
https://github.com/kubernetes/minikube/branches/all