### PR TITLE
Improve code readability: rename config unit tests 

### DIFF
--- a/pkg/minikube/config/config_test.go
+++ b/pkg/minikube/config/config_test.go
@@ -70,7 +70,7 @@ func Test_decode(t *testing.T) {
 	}
 }
 
-func TestGet(t *testing.T) {
+func Test_get(t *testing.T) {
 	cfg := `{
 		"key": "val"
 	}`

--- a/pkg/minikube/config/config_test.go
+++ b/pkg/minikube/config/config_test.go
@@ -60,7 +60,7 @@ var configTestCases = []configTestCase{
 	},
 }
 
-func TestReadConfig(t *testing.T) {
+func Test_decode(t *testing.T) {
 	for _, tt := range configTestCases {
 		r := bytes.NewBufferString(tt.data)
 		config, err := decode(r)


### PR DESCRIPTION
I've renamed two tests in the config package to what they are actually testing. Using the convention `Test_xxx` for tests of unexported methods.