### PR TITLE
Add test to config.ReadConfig

### DIFF
--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -71,7 +71,11 @@ func get(name string, config MinikubeConfig) (string, error) {
 
 // ReadConfig reads in the JSON minikube config
 func ReadConfig() (MinikubeConfig, error) {
-	f, err := os.Open(constants.ConfigFile)
+	return readConfig(constants.ConfigFile)
+}
+
+func readConfig(configFile string) (MinikubeConfig, error) {
+	f, err := os.Open(configFile)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return make(map[string]interface{}), nil

--- a/pkg/minikube/config/config_test.go
+++ b/pkg/minikube/config/config_test.go
@@ -101,3 +101,43 @@ func TestGet(t *testing.T) {
 		}
 	}
 }
+
+func Test_readConfig(t *testing.T) {
+	// non existing file
+	mkConfig, err := readConfig("non_existing_file")
+	if err != nil {
+		t.Fatalf("Error not exepected but got %v", err)
+	}
+
+	if len(mkConfig) != 0 {
+		t.Errorf("Expected empty map but got %v", mkConfig)
+	}
+
+	// invalid config file
+	mkConfig, err = readConfig("./testdata/.minikube/config/invalid_config.json")
+	if err == nil {
+		t.Fatalf("Error expected but got none")
+	}
+
+	if mkConfig != nil {
+		t.Errorf("Expected nil but got %v", mkConfig)
+	}
+
+	// valid config file
+	mkConfig, err = readConfig("./testdata/.minikube/config/valid_config.json")
+	if err != nil {
+		t.Fatalf("Error not expected but got %v", err)
+	}
+
+	expectedConfig := map[string]interface{}{
+		"vm-driver":            constants.DriverKvm2,
+		"cpus":                 4,
+		"disk-size":            "20g",
+		"show-libmachine-logs": true,
+		"log_dir":              "/etc/hosts",
+	}
+
+	if reflect.DeepEqual(expectedConfig, mkConfig) || err != nil {
+		t.Errorf("Did not read config correctly,\n\n wanted %+v, \n\n got %+v", expectedConfig, mkConfig)
+	}
+}

--- a/pkg/minikube/config/testdata/.minikube/config/invalid_config.json
+++ b/pkg/minikube/config/testdata/.minikube/config/invalid_config.json
@@ -1,0 +1,2 @@
+{
+      "vm-driver": "kvm2"

--- a/pkg/minikube/config/testdata/.minikube/config/valid_config.json
+++ b/pkg/minikube/config/testdata/.minikube/config/valid_config.json
@@ -1,0 +1,7 @@
+{
+  "vm-driver": "kvm2",
+  "cpus": 4,
+  "disk-size": "20g",
+  "show-libmachine-logs": true,
+  "log_dir": "/etc/hosts"
+}


### PR DESCRIPTION
Extracting `ReadConfig` core to a nonpublic function so we can test it properly + add tests.