### PR TITLE
Update KERNEL_VERSION to match buildroot config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ MINIKUBE_BUCKET ?= minikube/releases
 MINIKUBE_UPLOAD_LOCATION := gs://${MINIKUBE_BUCKET}
 MINIKUBE_RELEASES_URL=https://github.com/kubernetes/minikube/releases/download
 
-KERNEL_VERSION ?= 4.16.14
+KERNEL_VERSION ?= 4.15
 
 GO_VERSION ?= $(shell go version | cut -d' ' -f3 | sed -e 's/go//')
 GOLINT_VERSION ?= v1.17.1


### PR DESCRIPTION
We downgraded the kernel (to 4.15) in 2be51dc,
but never updated the Makefile from 4c4cd31...

The default kernel in Buildroot 2018.05.x was
4.16.13, but upgraded in Minikube to 4.16.14