### PR TITLE
Revert "Travis build status link should go to master"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![BuildStatus Widget]][BuildStatus Result]
 [![GoReport Widget]][GoReport Status]
 
-[BuildStatus Result]: https://travis-ci.org/kubernetes/minikube/branches
+[BuildStatus Result]: https://travis-ci.org/kubernetes/minikube
 [BuildStatus Widget]: https://travis-ci.org/kubernetes/minikube.svg?branch=master
 
 [GoReport Status]: https://goreportcard.com/report/github.com/kubernetes/minikube


### PR DESCRIPTION
This reverts commit 9daa3d3e785dd96f4453cb9b1502bfd96b938c48.

As noted in #4918, I was mistaken. Changing to "branches" made it worse, not better.

It is still available as a tab if you do want build history, but the link did **not** show PRs...