### PR TITLE
logs: Add container status & cruntime logs

### DIFF
--- a/cmd/minikube/cmd/logs.go
+++ b/cmd/minikube/cmd/logs.go
@@ -97,5 +97,5 @@ var logsCmd = &cobra.Command{
 func init() {
 	logsCmd.Flags().BoolVarP(&followLogs, "follow", "f", false, "Show only the most recent journal entries, and continuously print new entries as they are appended to the journal.")
 	logsCmd.Flags().BoolVar(&showProblems, "problems", false, "Show only log entries which point to known problems")
-	logsCmd.Flags().IntVarP(&numberOfLines, "length", "n", 50, "Number of lines back to go within the log")
+	logsCmd.Flags().IntVarP(&numberOfLines, "length", "n", 30, "Number of lines back to go within the log")
 }

--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -136,3 +136,8 @@ func (r *Containerd) StopContainers(ids []string) error {
 func (r *Containerd) ContainerLogCmd(id string, len int, follow bool) string {
 	return criContainerLogCmd(id, len, follow)
 }
+
+// SystemLogCmd returns the command to retrieve system logs
+func (r *Containerd) SystemLogCmd(len int) string {
+	return fmt.Sprintf("sudo journalctl -u containerd -n %d", len)
+}

--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -133,3 +133,8 @@ func (r *CRIO) StopContainers(ids []string) error {
 func (r *CRIO) ContainerLogCmd(id string, len int, follow bool) string {
 	return criContainerLogCmd(id, len, follow)
 }
+
+// SystemLogCmd returns the command to retrieve system logs
+func (r *CRIO) SystemLogCmd(len int) string {
+	return fmt.Sprintf("sudo journalctl -u crio -n %d", len)
+}

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -66,6 +66,8 @@ type Manager interface {
 	StopContainers([]string) error
 	// ContainerLogCmd returns the command to retrieve the log for a container based on ID
 	ContainerLogCmd(string, int, bool) string
+	// SystemLogCmd returns the command to return the system logs
+	SystemLogCmd(int) string
 }
 
 // Config is runtime configuration

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -153,3 +153,8 @@ func (r *Docker) ContainerLogCmd(id string, len int, follow bool) string {
 	cmd.WriteString(id)
 	return cmd.String()
 }
+
+// SystemLogCmd returns the command to retrieve system logs
+func (r *Docker) SystemLogCmd(len int) string {
+	return fmt.Sprintf("sudo journalctl -u docker -n %d", len)
+}

--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -113,11 +113,6 @@ func OutputProblems(problems map[string][]string, maxLines int) {
 // Output displays logs from multiple sources in tail(1) format
 func Output(r cruntime.Manager, bs bootstrapper.Bootstrapper, runner command.Runner, lines int) error {
 	cmds := logCommands(r, bs, lines, false)
-
-	// These are not technically logs, but are useful to have in bug reports.
-	cmds["kernel"] = "uptime && uname -a"
-
-	cmds := logCommands(r, bs, lines, false)
 	cmds["kernel"] = "uptime && uname -a && grep PRETTY /etc/os-release"
 	names := []string{}
 	for k := range cmds {

--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -117,12 +117,14 @@ func Output(r cruntime.Manager, bs bootstrapper.Bootstrapper, runner command.Run
 	// These are not technically logs, but are useful to have in bug reports.
 	cmds["kernel"] = "uptime && uname -a"
 
+	cmds := logCommands(r, bs, lines, false)
+	cmds["kernel"] = "uptime && uname -a && grep PRETTY /etc/os-release"
 	names := []string{}
 	for k := range cmds {
 		names = append(names, k)
 	}
-	sort.Strings(names)
 
+	sort.Strings(names)
 	failed := []string{}
 	for i, name := range names {
 		if i > 0 {
@@ -130,6 +132,7 @@ func Output(r cruntime.Manager, bs bootstrapper.Bootstrapper, runner command.Run
 		}
 		out.T(out.Empty, "==> {{.name}} <==", out.V{"name": name})
 		var b bytes.Buffer
+
 		err := runner.CombinedOutputTo(cmds[name], &b)
 		if err != nil {
 			glog.Errorf("failed: %v", err)
@@ -141,6 +144,7 @@ func Output(r cruntime.Manager, bs bootstrapper.Bootstrapper, runner command.Run
 			out.T(out.Empty, scanner.Text())
 		}
 	}
+
 	if len(failed) > 0 {
 		return fmt.Errorf("unable to fetch logs for: %s", strings.Join(failed, ", "))
 	}
@@ -163,5 +167,8 @@ func logCommands(r cruntime.Manager, bs bootstrapper.Bootstrapper, length int, f
 		}
 		cmds[pod] = r.ContainerLogCmd(ids[0], length, follow)
 	}
+	cmds[r.Name()] = r.SystemLogCmd(length)
+	// Works across container runtimes with good formatting
+	cmds["container status"] = "sudo crictl ps -a"
 	return cmds
 }


### PR DESCRIPTION
Also decrease default log length from 50 to 30 to decrease log spam.

Example output:

```
==> container status <==
CONTAINER ID        IMAGE               CREATED              STATE               NAME                       ATTEMPT             POD ID
307e90d0e23a5       4d86ff7d49886       36 seconds ago       Running             nginx-ingress-controller   0                   8c634193971f1
8380f640d1b28       f9aed6605b814       About a minute ago   Running             kubernetes-dashboard       0                   f1ad00355a566
3dbba93d11679       f78e46173de89       About a minute ago   Running             gvisor                     0                   f47b2c03cd389
45a58debe8c1a       4689081edb103       About a minute ago   Running             storage-provisioner        0                   9a703e0f6f625
b0a71f29b3565       eb516548c180f       About a minute ago   Running             coredns                    0                   85a855564150c
0ee1d4be21d4e       eb516548c180f       About a minute ago   Running             coredns                    0                   abf716bbce8d0
eaa45a6122c70       89a062da739d3       About a minute ago   Running             kube-proxy                 0                   083285393f0ad
5e4cb381a0541       119701e77cbc4       About a minute ago   Running             kube-addon-manager         0                   996c1e9057b10
bff23c2c2ecc9       b0b3c4c404da5       About a minute ago   Running             kube-scheduler             0                   7ed16039156bf
2c3592a9d9cda       2c4adeb21b4ff       About a minute ago   Running             etcd                       0                   78e719be1cfdb
5287e048ab7f4       68c3eb07bfc3f       About a minute ago   Running             kube-apiserver             0                   23bde6adfe425
d49482e316b54       d75082f1d1216       About a minute ago   Running             kube-controller-manager    0                   743da82adef40

==> containerd <==
-- Logs begin at Fri 2019-08-02 14:48:23 PDT, end at Fri 2019-08-02 14:51:06 PDT. --
Aug 02 14:50:27 minikube containerd[4775]: time="2019-08-02T14:50:27.582417468-07:00" level=info msg="TaskExit event &TaskExit{ContainerID:2c3592a9d9cdafecbb4aed08fe6b7bf1982820ce5b0ef8b893fd50ec5b52a1f4,ID:aeb874f1bf07c903102cae6f600084df8830305854d6bce6fde068ced061a147,Pid:5349,ExitStatus:0,ExitedAt:2019-08-02 21:50:27.547108004 +0000 UTC,}"
Aug 02 14:50:27 minikube containerd[4775]: time="2019-08-02T14:50:27.597716763-07:00" level=info msg="ExecSync for "2c3592a9d9cdafecbb4aed08fe6b7bf1982820ce5b0ef8b893fd50ec5b52a1f4" returns with exit code 0"
Aug 02 14:50:30 minikube containerd[4775]: time="2019-08-02T14:50:30.679805553-07:00" level=info msg="ImageUpdate event &ImageUpdate{Name:sha256:4d86ff7d4988693ef53611dec59362384842b61498f78238ac6afb44d8b623cb,Labels:map[string]string{io.cri-containerd.image: managed,},}"
Aug 02 14:50:30 minikube containerd[4775]: time="2019-08-02T14:50:30.683679547-07:00" level=info msg="ImageUpdate event &ImageUpdate{Name:quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.25.0,Labels:map[string]string{io.cri-containerd.image: managed,},}"
Aug 02 14:50:30 minikube containerd[4775]: time="2019-08-02T14:50:30.683985105-07:00" level=info msg="PullImage "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.25.0" returns image reference "sha256:4d86ff7d4988693ef53611dec59362384842b61498f78238ac6afb44d8b623cb""
Aug 02 14:50:30 minikube containerd[4775]: time="2019-08-02T14:50:30.688232163-07:00" level=info msg="CreateContainer within sandbox "8c634193971f1a7edf10fff45365844e6a67808bd2954ddcf9acac1181df8122" for container &ContainerMetadata{Name:nginx-ingress-controller,Attempt:0,}"
Aug 02 14:50:30 minikube containerd[4775]: time="2019-08-02T14:50:30.758121613-07:00" level=info msg="CreateContainer within sandbox "8c634193971f1a7edf10fff45365844e6a67808bd2954ddcf9acac1181df8122" for &ContainerMetadata{Name:nginx-ingress-controller,Attempt:0,} returns container id "307e90d0e23a50f1bd96bf80107babb8e86cc64266d2cd4fb2b6d3247a5a1764""
Aug 02 14:50:30 minikube containerd[4775]: time="2019-08-02T14:50:30.758587091-07:00" level=info msg="StartContainer for "307e90d0e23a50f1bd96bf80107babb8e86cc64266d2cd4fb2b6d3247a5a1764""
Aug 02 14:50:30 minikube containerd[4775]: time="2019-08-02T14:50:30.761611157-07:00" level=info msg="shim gvisor-containerd-shim started" address="/containerd-shim/k8s.io/307e90d0e23a50f1bd96bf80107babb8e86cc64266d2cd4fb2b6d3247a5a1764/shim.sock" debug=true pid=5403
Aug 02 14:50:30 minikube containerd[4775]: time="2019-08-02T14:50:30-07:00" level=debug msg="registering ttrpc server"
Aug 02 14:50:30 minikube containerd[4775]: time="2019-08-02T14:50:30-07:00" level=debug msg="serving api on unix socket" socket="[inherited from parent]"
Aug 02 14:50:30 minikube containerd[4775]: time="2019-08-02T14:50:30.857185509-07:00" level=info msg="StartContainer for "307e90d0e23a50f1bd96bf80107babb8e86cc64266d2cd4fb2b6d3247a5a1764" returns successfully"
Aug 02 14:50:37 minikube containerd[4775]: time="2019-08-02T14:50:37.420629874-07:00" level=info msg="ExecSync for "2c3592a9d9cdafecbb4aed08fe6b7bf1982820ce5b0ef8b893fd50ec5b52a1f4" with command [/bin/sh -ec ETCDCTL_API=3 etcdctl --endpoints=https://[127.0.0.1]:2379 --cacert=/var/lib/minikube/certs//etcd/ca.crt --cert=/var/lib/minikube/certs//etcd/healthcheck-client.crt --key=/var/lib/minikube/certs//etcd/healthcheck-client.key get foo] and timeout 15 (s)"
Aug 02 14:50:37 minikube containerd[4775]: time="2019-08-02T14:50:37.505514998-07:00" level=info msg="Finish piping "stderr" of container exec "78d4cf75e721f26007ec2bb587bac65daf13555f242f60ce80317cf8b54068fd""
Aug 02 14:50:37 minikube containerd[4775]: time="2019-08-02T14:50:37.505694400-07:00" level=info msg="Finish piping "stdout" of container exec "78d4cf75e721f26007ec2bb587bac65daf13555f242f60ce80317cf8b54068fd""
Aug 02 14:50:37 minikube containerd[4775]: time="2019-08-02T14:50:37.505998272-07:00" level=info msg="Exec process "78d4cf75e721f26007ec2bb587bac65daf13555f242f60ce80317cf8b54068fd" exits with exit code 0 and error <nil>"
Aug 02 14:50:37 minikube containerd[4775]: time="2019-08-02T14:50:37.526686942-07:00" level=info msg="TaskExit event &TaskExit{ContainerID:2c3592a9d9cdafecbb4aed08fe6b7bf1982820ce5b0ef8b893fd50ec5b52a1f4,ID:78d4cf75e721f26007ec2bb587bac65daf13555f242f60ce80317cf8b54068fd,Pid:5658,ExitStatus:0,ExitedAt:2019-08-02 21:50:37.505878285 +0000 UTC,}"
Aug 02 14:50:37 minikube containerd[4775]: time="2019-08-02T14:50:37.540905570-07:00" level=info msg="ExecSync for "2c3592a9d9cdafecbb4aed08fe6b7bf1982820ce5b0ef8b893fd50ec5b52a1f4" returns with exit code 0"
Aug 02 14:50:47 minikube containerd[4775]: time="2019-08-02T14:50:47.420603739-07:00" level=info msg="ExecSync for "2c3592a9d9cdafecbb4aed08fe6b7bf1982820ce5b0ef8b893fd50ec5b52a1f4" with command [/bin/sh -ec ETCDCTL_API=3 etcdctl --endpoints=https://[127.0.0.1]:2379 --cacert=/var/lib/minikube/certs//etcd/ca.crt --cert=/var/lib/minikube/certs//etcd/healthcheck-client.crt --key=/var/lib/minikube/certs//etcd/healthcheck-client.key get foo] and timeout 15 (s)"
Aug 02 14:50:47 minikube containerd[4775]: time="2019-08-02T14:50:47.496159634-07:00" level=info msg="Finish piping "stderr" of container exec "73f06322c4ca1a38249c9230f0928a04d6e99fcbc01134e28f3ad0dab408d216""
Aug 02 14:50:47 minikube containerd[4775]: time="2019-08-02T14:50:47.496760315-07:00" level=info msg="Finish piping "stdout" of container exec "73f06322c4ca1a38249c9230f0928a04d6e99fcbc01134e28f3ad0dab408d216""
Aug 02 14:50:47 minikube containerd[4775]: time="2019-08-02T14:50:47.496877831-07:00" level=info msg="Exec process "73f06322c4ca1a38249c9230f0928a04d6e99fcbc01134e28f3ad0dab408d216" exits with exit code 0 and error <nil>"
Aug 02 14:50:47 minikube containerd[4775]: time="2019-08-02T14:50:47.520897481-07:00" level=info msg="TaskExit event &TaskExit{ContainerID:2c3592a9d9cdafecbb4aed08fe6b7bf1982820ce5b0ef8b893fd50ec5b52a1f4,ID:73f06322c4ca1a38249c9230f0928a04d6e99fcbc01134e28f3ad0dab408d216,Pid:5754,ExitStatus:0,ExitedAt:2019-08-02 21:50:47.496503865 +0000 UTC,}"
Aug 02 14:50:47 minikube containerd[4775]: time="2019-08-02T14:50:47.522826786-07:00" level=info msg="ExecSync for "2c3592a9d9cdafecbb4aed08fe6b7bf1982820ce5b0ef8b893fd50ec5b52a1f4" returns with exit code 0"
Aug 02 14:50:57 minikube containerd[4775]: time="2019-08-02T14:50:57.420570743-07:00" level=info msg="ExecSync for "2c3592a9d9cdafecbb4aed08fe6b7bf1982820ce5b0ef8b893fd50ec5b52a1f4" with command [/bin/sh -ec ETCDCTL_API=3 etcdctl --endpoints=https://[127.0.0.1]:2379 --cacert=/var/lib/minikube/certs//etcd/ca.crt --cert=/var/lib/minikube/certs//etcd/healthcheck-client.crt --key=/var/lib/minikube/certs//etcd/healthcheck-client.key get foo] and timeout 15 (s)"
Aug 02 14:50:57 minikube containerd[4775]: time="2019-08-02T14:50:57.500768468-07:00" level=info msg="Finish piping "stderr" of container exec "e3bbf3aad37929fb0d2151dd5b4d0b700dc81d101b7ab486e96d6b661ace45c9""
Aug 02 14:50:57 minikube containerd[4775]: time="2019-08-02T14:50:57.500808258-07:00" level=info msg="Finish piping "stdout" of container exec "e3bbf3aad37929fb0d2151dd5b4d0b700dc81d101b7ab486e96d6b661ace45c9""
Aug 02 14:50:57 minikube containerd[4775]: time="2019-08-02T14:50:57.501161188-07:00" level=info msg="Exec process "e3bbf3aad37929fb0d2151dd5b4d0b700dc81d101b7ab486e96d6b661ace45c9" exits with exit code 0 and error <nil>"
Aug 02 14:50:57 minikube containerd[4775]: time="2019-08-02T14:50:57.523854095-07:00" level=info msg="TaskExit event &TaskExit{ContainerID:2c3592a9d9cdafecbb4aed08fe6b7bf1982820ce5b0ef8b893fd50ec5b52a1f4,ID:e3bbf3aad37929fb0d2151dd5b4d0b700dc81d101b7ab486e96d6b661ace45c9,Pid:5893,ExitStatus:0,ExitedAt:2019-08-02 21:50:57.501018705 +0000 UTC,}"
Aug 02 14:50:57 minikube containerd[4775]: time="2019-08-02T14:50:57.532617006-07:00" level=info msg="ExecSync for "2c3592a9d9cdafecbb4aed08fe6b7bf1982820ce5b0ef8b893fd50ec5b52a1f4" returns with exit code 0"

==> coredns <==
.:53
2019-08-02T21:49:53.986Z [INFO] CoreDNS-1.3.1
2019-08-02T21:49:53.986Z [INFO] linux/amd64, go1.11.4, 6b56a9c
CoreDNS-1.3.1
linux/amd64, go1.11.4, 6b56a9c
2019-08-02T21:49:53.986Z [INFO] plugin/reload: Running configuration MD5 = 5d5369fbc12f985709b924e721217843
...
```