### PR TITLE
Decrease ReasonableStartTime from 10 minutes to 5 minutes

### DIFF
--- a/pkg/util/kubernetes.go
+++ b/pkg/util/kubernetes.go
@@ -44,8 +44,8 @@ import (
 var (
 	// ReasonableMutateTime is how long to wait for basic object mutations, such as deletions, to show up
 	ReasonableMutateTime = time.Minute * 2
-	// ReasonableStartTime is how long to wait for pods to start, considering dependency chains & slow networks.
-	ReasonableStartTime = time.Minute * 10
+	// ReasonableStartTime is how long to wait for pods to start
+	ReasonableStartTime = time.Minute * 5
 )
 
 // PodStore stores pods


### PR DESCRIPTION
Now that minikube deploys pods from pre-loaded images, we can safely reduce ReasonableStartTime so that users no longer need to wait 10 minutes if services are in a crash-loop due to invalid flags.

See #4806