### PR TITLE
logs container status: fallback to docker if crictl fails (none)

### DIFF
--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -165,6 +165,7 @@ func logCommands(r cruntime.Manager, bs bootstrapper.Bootstrapper, length int, f
 	}
 	cmds[r.Name()] = r.SystemLogCmd(length)
 	// Works across container runtimes with good formatting
-	cmds["container status"] = "sudo crictl ps -a"
+	// Fallback to 'docker ps' if it fails (none driver)
+	cmds["container status"] = "sudo crictl ps -a || sudo docker ps -a"
 	return cmds
 }


### PR DESCRIPTION
Users of the `none` driver may not have `crictl` installed. 