### PR TITLE
Use configured DNS domain in bootstrapper templates.

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -573,6 +573,7 @@ func generateConfig(k8s config.KubernetesConfig, r cruntime.Manager) (string, er
 	opts := struct {
 		CertDir           string
 		ServiceCIDR       string
+		DNSDomain         string
 		PodSubnet         string
 		AdvertiseAddress  string
 		APIServerPort     int
@@ -587,6 +588,7 @@ func generateConfig(k8s config.KubernetesConfig, r cruntime.Manager) (string, er
 	}{
 		CertDir:           util.DefaultCertPath,
 		ServiceCIDR:       util.DefaultServiceCIDR,
+		DNSDomain:         k8s.DNSDomain,
 		PodSubnet:         k8s.ExtraOptions.Get("pod-network-cidr", Kubeadm),
 		AdvertiseAddress:  k8s.NodeIP,
 		APIServerPort:     nodePort,

--- a/pkg/minikube/bootstrapper/kubeadm/templates.go
+++ b/pkg/minikube/bootstrapper/kubeadm/templates.go
@@ -84,7 +84,7 @@ etcd:
     dataDir: {{.EtcdDataDir}}
 kubernetesVersion: {{.KubernetesVersion}}
 networking:
-  dnsDomain: cluster.local
+  dnsDomain: {{.DNSDomain}}
   podSubnet: {{if .PodSubnet}}{{.PodSubnet}}{{else}}""{{end}}
   serviceSubnet: {{.ServiceCIDR}}
 ---
@@ -138,7 +138,7 @@ etcd:
     dataDir: {{.EtcdDataDir}}
 kubernetesVersion: {{.KubernetesVersion}}
 networking:
-  dnsDomain: cluster.local
+  dnsDomain: {{.DNSDomain}}
   podSubnet: ""
   serviceSubnet: {{.ServiceCIDR}}
 ---


### PR DESCRIPTION
Tested, by verifying that the generated `ClusterConfiguration` entry in the `kubeadm-config` ConfigMap now gets the custom DNS domain value if one was passed with `--dns-domain` to `minikube start`.