### PR TITLE
Fix the new site installation instructions

### DIFF
--- a/site/content/en/docs/Getting started/linux.md
+++ b/site/content/en/docs/Getting started/linux.md
@@ -16,7 +16,7 @@ Download and install minikube to /usr/local/bin:
    && sudo install minikube-linux-amd64 /usr/local/bin/minikube
 ```
 {{% /tab %}}
-{{% tab "Debian/Ubuntu (apt)" %}}
+{{% tab "Debian/Ubuntu (deb)" %}}
 
 Download and install minikube:
 

--- a/site/content/en/docs/Getting started/linux.md
+++ b/site/content/en/docs/Getting started/linux.md
@@ -32,8 +32,8 @@ curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_{{< la
 Download and install minikube:
 
 ```shell
-curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_{{< latest >}}.rpm \
- && sudo rpm -ivh minikube_{{< latest >}}.rpm
+curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-{{< latest >}}.rpm \
+ && sudo rpm -ivh minikube-{{< latest >}}.rpm
  ```
 
 {{% /tab %}}

--- a/site/content/en/docs/Getting started/linux.md
+++ b/site/content/en/docs/Getting started/linux.md
@@ -22,7 +22,7 @@ Download and install minikube:
 
 ```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_{{< latest >}}.deb \
- && dpkg -i minikube_{{< latest >}}.deb
+ && sudo dpkg -i minikube_{{< latest >}}.deb
  ```
 
 {{% /tab %}}
@@ -33,7 +33,7 @@ Download and install minikube:
 
 ```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_{{< latest >}}.rpm \
- && rpm -ivh minikube_{{< latest >}}.rpm
+ && sudo rpm -ivh minikube_{{< latest >}}.rpm
  ```
 
 {{% /tab %}}


### PR DESCRIPTION
The new instructions didn't really work, that were changed ("copied") in #4935