### PR TITLE
Update latest kubernetes version to v1.15.2

### DIFF
--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -176,10 +176,10 @@ var DefaultISOURL = fmt.Sprintf("https://storage.googleapis.com/%s/minikube-%s.i
 var DefaultISOSHAURL = DefaultISOURL + SHASuffix
 
 // DefaultKubernetesVersion is the default kubernetes version
-var DefaultKubernetesVersion = "v1.15.1"
+var DefaultKubernetesVersion = "v1.15.2"
 
 // NewestKubernetesVersion is the newest Kubernetes version to test against
-var NewestKubernetesVersion = "v1.15.1"
+var NewestKubernetesVersion = "v1.15.2"
 
 // OldestKubernetesVersion is the oldest Kubernetes version to test against
 var OldestKubernetesVersion = "v1.10.13"


### PR DESCRIPTION
No documented difference from v1.15.1 other than fixes for two CVE's: 

https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.15.md/#v1152

```
https://github.com/kubernetes/kubernetes/pull/80436

Fix CVE-2019-11249: Incomplete fixes for CVE-2019-1002101 and CVE-2019-11246, kubectl cp potential directory traversal

https://github.com/kubernetes/kubernetes/pull/80750

Fix CVE-2019-11247: API server allows access to custom resources via wrong scope
```