### PR TITLE
Fix docs merge breakage: Call initTabs() to activate tabs UI

### DIFF
--- a/site/layouts/partials/hooks/body-end.html
+++ b/site/layouts/partials/hooks/body-end.html
@@ -1,2 +1,3 @@
 <!-- start: minikube override body-end partial -->
+<script language="javascript">initTabs();</script>
 <!-- end: minikube override body-end partial -->

--- a/site/layouts/partials/hooks/head-end.html
+++ b/site/layouts/partials/hooks/head-end.html
@@ -1,3 +1,4 @@
-<!-- tabs implementation, borrowed from skaffold -->
+<!-- start: minikube override head-end partial -->
 <link href="/css/tabs.css" rel="stylesheet">
 <script src="/js/tabs.js"></script>
+<!-- end: minikube override head-end partial -->


### PR DESCRIPTION
Required to make the installation tabs appear at http://localhost:1313/docs/getting-started/linux/
