### PR TITLE
Check for Username instead of Name for root

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -471,9 +471,9 @@ func validateUser() {
 	d := viper.GetString(vmDriver)
 	// Check if minikube needs to run with sudo or not.
 	if err == nil {
-		if d == constants.DriverNone && u.Name != "root" {
+		if d == constants.DriverNone && u.Username != "root" {
 			exit.UsageT(`Please run with sudo. the vm-driver "{{.driver_name}}" requires sudo.`, out.V{"driver_name": constants.DriverNone})
-		} else if u.Name == "root" && !(d == constants.DriverHyperv || d == constants.DriverNone) {
+		} else if u.Username == "root" && !(d == constants.DriverHyperv || d == constants.DriverNone) {
 			out.T(out.WarningType, "Please don't run minikube as root or with 'sudo' privileges. It isn't necessary with {{.driver}} driver.", out.V{"driver": d})
 		}
 


### PR DESCRIPTION
for "--vm-driver=none":
user.Name may be empty as per https://golang.org/pkg/os/user/#User which happens to be true on Manjaro 18.0.4 for root. Actually checking for the Username instead (display-) Name seems to be more reasonable.