### PR TITLE
 Remove "Ignoring --vm-driver" warning

### DIFF
--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -104,8 +104,8 @@ func StartHost(api libmachine.API, config cfg.MachineConfig) (*host.Host, error)
 
 	if h.Driver.DriverName() != config.VMDriver {
 		out.T(out.Empty, "\n")
-		out.WarningT(`Ignoring --vm-driver={{.driver_name}}, as the existing "{{.profile_name}}" VM was created using the {{.driver_name2}} driver.`,
-			out.V{"driver_name": config.VMDriver, "profile_name": cfg.GetMachineName(), "driver_name2": h.Driver.DriverName()})
+		exit.WithCodeT(exit.Config, `The existing "{{.profile_name}}" VM was created using the {{.driver_name}} driver.`,
+			out.V{"profile_name": cfg.GetMachineName(), "driver_name": config.VMDriver})
 		out.WarningT("To switch drivers, you may create a new VM using `minikube start -p <name> --vm-driver={{.driver_name}}`", out.V{"driver_name": config.VMDriver})
 		out.WarningT("Alternatively, you may delete the existing VM using `minikube delete -p {{.profile_name}}`", out.V{"profile_name": cfg.GetMachineName()})
 		out.T(out.Empty, "\n")
@@ -120,9 +120,9 @@ func StartHost(api libmachine.API, config cfg.MachineConfig) (*host.Host, error)
 	}
 
 	if s == state.Running {
-		out.T(out.Running, `Using the running {{.driver_name}} "{{.profile_name}}" VM ...`, out.V{"driver_name": h.Driver.DriverName(), "profile_name": cfg.GetMachineName()})
+		out.T(out.Running, `Using the running {{.driver_name}} "{{.profile_name}}" VM ...`, out.V{"driver_name": config.VMDriver, "profile_name": cfg.GetMachineName()})
 	} else {
-		out.T(out.Restarting, `Starting existing {{.driver_name}} VM for "{{.profile_name}}" ...`, out.V{"driver_name": h.Driver.DriverName(), "profile_name": cfg.GetMachineName()})
+		out.T(out.Restarting, `Starting existing {{.driver_name}} VM for "{{.profile_name}}" ...`, out.V{"driver_name": config.VMDriver, "profile_name": cfg.GetMachineName()})
 		if err := h.Driver.Start(); err != nil {
 			return nil, errors.Wrap(err, "start")
 		}


### PR DESCRIPTION
Remove "Ignoring --vm-driver" warning.
fixes https://github.com/kubernetes/minikube/issues/4998

```
./out/minikube start --vm-driver=kvm2
😄  minikube v1.3.0 on Ubuntu 16.04
⚠️  Please don't run minikube as root or with 'sudo' privileges. It isn't necessary with kvm2 driver.


⚠️  The existing "minikube" VM was created using the kvm2 driver.
⚠️  To switch drivers, you may create a new VM using `minikube start -p <name> --vm-driver=kvm2`
⚠️  Alternatively, you may delete the existing VM using `minikube delete -p minikube`


🔄  Starting existing kvm2 VM for "minikube" ...
⌛  Waiting for the host to be provisioned ...
🐳  Preparing Kubernetes v1.15.2 on Docker 18.09.8 ...
🔄  Relaunching Kubernetes using kubeadm ... 
⌛  Waiting for: apiserver proxy etcd scheduler controller dns
🏄  Done! kubectl is now configured to use "minikube"

```