### PR TITLE
Fix rough edges in documentation presentation

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -71,12 +71,12 @@ privacy_policy = ""
 version_menu = "Releases"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
-github_repo = "http://github.com/minikube/kubernetes"
+github_repo = "http://github.com/kubernetes/minikube"
 # An optional link to a related project repo. For example, the sibling repository where your product code lives.
 github_project_repo = ""
 
 # Specify a value here if your content directory is not in your repo's root directory
-github_subdir = "/site/content"
+github_subdir = "site"
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
 gcs_engine_id = "005331096405080631692:s7c4yfpw9sy"
@@ -84,7 +84,7 @@ gcs_engine_id = "005331096405080631692:s7c4yfpw9sy"
 # User interface configuration
 [params.ui]
 # Enable to show the side bar menu in its compact state.
-sidebar_menu_compact = false
+sidebar_menu_compact = true
 #  Set to true to disable breadcrumb navigation.
 breadcrumb_disable = false
 #  Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)
@@ -99,8 +99,8 @@ navbar_logo = true
 [params.ui.feedback]
 enable = true
 # The responses that the user sees after clicking "yes" (the page was helpful) or "no" (the page was not helpful).
-yes = 'Glad to hear it! Please <a href="https://github.com/kubernetes/minikube/issues/new">tell us how we can improve</a>.'
-no = 'Sorry to hear that. Please <a href="https://github.com/kubernetes/minikube/issues/new">tell us how we can improve</a>.'
+yes = 'Glad to hear it! Please <a href="https://github.com/kubernetes/minikube/issues/new/choose">tell us how we can improve</a>.'
+no = 'Sorry to hear that. Please <a href="https://github.com/kubernetes/minikube/issues/new/choose">tell us how we can improve</a>.'
 
 [params.links]
 # End user relevant links. These will show up on left side of footer and in the community page if you have one.

--- a/site/content/en/docs/Overview/_index.md
+++ b/site/content/en/docs/Overview/_index.md
@@ -40,11 +40,10 @@ If you would like to develop Kubernetes applications:
 Then minikube is for you.
 
 * **What is it good for?** Developing local Kubernetes applications
-* **What is it not good for?** Production deployments of Kubernetes applications
+* **What is it not good for?** Production Kubernetes deployments
 * **What is it *not yet* good for?** Environments which do not allow VM's
 
 ## Where should I go next?
 
-* [Getting Started](/getting-started/): Get started with minikube
+* [Getting Started](/start/): Get started with minikube
 * [Examples](/examples/): Check out some minikube examples!
-* 

--- a/site/content/en/docs/Reference/_index.md
+++ b/site/content/en/docs/Reference/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Reference"
 linkTitle: "Reference"
-weight: 3
+weight: 5
 description: >
   Low level reference docs
 ---

--- a/site/content/en/docs/Tasks/_index.md
+++ b/site/content/en/docs/Tasks/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Core Tasks"
 linkTitle: "Core Tasks"
-weight: 6
+weight: 4
 date: 2017-01-05
 description: >
   What can you do with minikube?

--- a/site/content/en/docs/Tutorials/_index.md
+++ b/site/content/en/docs/Tutorials/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Tutorials"
 linkTitle: "Tutorials"
-weight: 8
+weight: 4
 date: 2017-01-04
 description: >
   Contributed end-to-end tutorials using minikube


### PR DESCRIPTION
config:

* Fix incorrect `github_repo` and `github_subdir`
* Set `sidebar_menu_compact = true` to avoid overwhelming menu selection on front page
* Fix bug URL text to point to chooser

overview:
* Improve text, point to new getting started URL

other pages:
* Set weights so that items appear logically  in the menu