### PR TITLE
Fix site documentation links to docker_daemon.md

### DIFF
--- a/site/content/en/docs/Tasks/building.md
+++ b/site/content/en/docs/Tasks/building.md
@@ -10,7 +10,7 @@ When using a single VM of Kubernetes it's really handy to build inside the VM; a
 
 ## Docker (containerd)
 
-For Docker, you can either set up your host docker client to communicate by [reusing the docker daemon](docker_daemon.md).
+For Docker, you can either set up your host docker client to communicate by [reusing the docker daemon]({{< ref "/docs/tasks/docker_daemon.md" >}}).
 
 Or you can use `minikube ssh` to connect to the virtual machine, and run the `docker build` there:
 

--- a/site/content/en/docs/Tasks/docker_registry.md
+++ b/site/content/en/docs/Tasks/docker_registry.md
@@ -7,7 +7,7 @@ description: >
   How to access the Docker registry within minikube
 ---
 
-As an alternative to [reusing the Docker daemon](docker_daemon.md), you may enable the registry addon to push images directly into registry. 
+As an alternative to [reusing the Docker daemon]({{< ref "/docs/tasks/docker_daemon.md" >}}), you may enable the registry addon to push images directly into registry.
 
 Steps are as follows:
 


### PR DESCRIPTION
* https://minikube.sigs.k8s.io/docs/tasks/building/

* https://minikube.sigs.k8s.io/docs/tasks/docker_registry/

https://minikube.sigs.k8s.io/docs/tasks/building/docker_daemon.md

> **Not found**
> Oops! This page doesn't exist. Try going back to our home page.