### PR TITLE
docs: brew install should be brew cask install

### DIFF
--- a/site/content/en/docs/Start/macos.md
+++ b/site/content/en/docs/Start/macos.md
@@ -17,7 +17,7 @@ weight: 2
 If the [Brew Package Manager](https://brew.sh/) is installed, use it to download and install minikube:
 
 ```shell
-brew install minikube
+brew cask install minikube
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
macOS: `brew install` should be `brew cask install`