### PR TITLE
minikube is a brew cask package

### DIFF
--- a/site/content/en/docs/Start/macos.md
+++ b/site/content/en/docs/Start/macos.md
@@ -17,7 +17,7 @@ weight: 2
 If the [Brew Package Manager](https://brew.sh/) is installed, use it to download and install minikube:
 
 ```shell
-brew install minikube
+brew cask install minikube
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
`brew install minikube` doesn't work for me at least, on my machine - it's reported as a cask and has been for a while.