### PR TITLE
Updated docs to add how to develop addons link

### DIFF
--- a/site/content/en/docs/Tasks/addons.md
+++ b/site/content/en/docs/Tasks/addons.md
@@ -69,4 +69,4 @@ minikube addons disable <name>
 
 ## Custom Addons
 
-If you would like to have minikube properly start/restart custom addons, place the addon(s) _.yaml_ you wish to be launched with minikube in the `.minikube/addons` directory. Addons in this folder will be moved to the minikube VM and launched each time minikube is started/restarted. Read the guidance to learn [how to develop minikube addons](../Contributing/addons.en.md).
+If you would like to have minikube properly start/restart custom addons, place the addon(s) _.yaml_ you wish to be launched with minikube in the `.minikube/addons` directory. Addons in this folder will be moved to the minikube VM and launched each time minikube is started/restarted. Read the guidance to learn [how to develop minikube addons](/docs/tasks/Contributing/addons).

--- a/site/content/en/docs/Tasks/addons.md
+++ b/site/content/en/docs/Tasks/addons.md
@@ -69,4 +69,4 @@ minikube addons disable <name>
 
 ## Custom Addons
 
-If you would like to have minikube properly start/restart custom addons, place the addon(s) _.yaml_ you wish to be launched with minikube in the `.minikube/addons` directory. Addons in this folder will be moved to the minikube VM and launched each time minikube is started/restarted. Learn [how to develop minikube addons](https://minikube.sigs.k8s.io/docs/contributing/addons/).
+If you would like to have minikube properly start/restart custom addons, place the addon(s) _.yaml_ you wish to be launched with minikube in the `.minikube/addons` directory. Addons in this folder will be moved to the minikube VM and launched each time minikube is started/restarted. Learn [how to develop minikube addons]({{< ref "/docs/contributing/addons.en.md" >}}).

--- a/site/content/en/docs/Tasks/addons.md
+++ b/site/content/en/docs/Tasks/addons.md
@@ -69,4 +69,4 @@ minikube addons disable <name>
 
 ## Custom Addons
 
-If you would like to have minikube properly start/restart custom addons, place the addon(s) you wish to be launched with minikube in the `.minikube/addons` directory. Addons in this folder will be moved to the minikube VM and launched each time minikube is started/restarted.
+If you would like to have minikube properly start/restart custom addons, place the addon(s) _.yaml_ you wish to be launched with minikube in the `.minikube/addons` directory. Addons in this folder will be moved to the minikube VM and launched each time minikube is started/restarted. Read the guidance to learn [how to develop minikube addons](../Contributing/addons.en.md).

--- a/site/content/en/docs/Tasks/addons.md
+++ b/site/content/en/docs/Tasks/addons.md
@@ -69,4 +69,4 @@ minikube addons disable <name>
 
 ## Custom Addons
 
-If you would like to have minikube properly start/restart custom addons, place the addon(s) _.yaml_ you wish to be launched with minikube in the `.minikube/addons` directory. Addons in this folder will be moved to the minikube VM and launched each time minikube is started/restarted. Read the guidance to learn [how to develop minikube addons](/docs/tasks/Contributing/addons).
+If you would like to have minikube properly start/restart custom addons, place the addon(s) _.yaml_ you wish to be launched with minikube in the `.minikube/addons` directory. Addons in this folder will be moved to the minikube VM and launched each time minikube is started/restarted. Learn [how to develop minikube addons](https://minikube.sigs.k8s.io/docs/contributing/addons/).


### PR DESCRIPTION
Fixes issue #5091
Updated the addons description page to add link with how to develop minikube addons
