### PR TITLE
Ensure specific golang version everywhere in CI based on Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ ISO_VERSION ?= v$(VERSION_MAJOR).$(VERSION_MINOR).0
 VERSION ?= v$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_BUILD)
 DEB_VERSION ?= $(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_BUILD)
 RPM_VERSION ?= $(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_BUILD)
-# used by hack/jenkins/release_build_and_upload.sh and KVM_BUILD_IMAGE, see also BUILD_IMAGE bellow
+# used by hack/jenkins/release_build_and_upload.sh and KVM_BUILD_IMAGE, see also BUILD_IMAGE below
 GO_VERSION ?= 1.12.8
 
 INSTALL_SIZE ?= $(shell du out/minikube-windows-amd64.exe | cut -f1)

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ ISO_VERSION ?= v$(VERSION_MAJOR).$(VERSION_MINOR).0
 VERSION ?= v$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_BUILD)
 DEB_VERSION ?= $(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_BUILD)
 RPM_VERSION ?= $(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_BUILD)
+# used by hack/jenkins/release_build_and_upload.sh and KVM_BUILD_IMAGE, see also BUILD_IMAGE bellow
+GO_VERSION ?= 1.12.8
+
 INSTALL_SIZE ?= $(shell du out/minikube-windows-amd64.exe | cut -f1)
 BUILDROOT_BRANCH ?= 2018.05.3
 REGISTRY?=gcr.io/k8s-minikube
@@ -31,8 +34,8 @@ COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
 COMMIT ?= $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}")
 
 HYPERKIT_BUILD_IMAGE 	?= karalabe/xgo-1.12.x
-# NOTE: "latest" as of 2019-07-12. kube-cross images aren't updated as often as Kubernetes
-BUILD_IMAGE 	?= k8s.gcr.io/kube-cross:v1.12.7-1
+# NOTE: "latest" as of 2019-08-15. kube-cross images aren't updated as often as Kubernetes
+BUILD_IMAGE 	?= k8s.gcr.io/kube-cross:v$(GO_VERSION)-1
 ISO_BUILD_IMAGE ?= $(REGISTRY)/buildroot-image
 KVM_BUILD_IMAGE ?= $(REGISTRY)/kvm-build-image:$(GO_VERSION)
 
@@ -44,10 +47,7 @@ MINIKUBE_UPLOAD_LOCATION := gs://${MINIKUBE_BUCKET}
 MINIKUBE_RELEASES_URL=https://github.com/kubernetes/minikube/releases/download
 
 KERNEL_VERSION ?= 4.15
-
-# Currently *only* used for the KVM_BUILD_IMAGE, see also BUILD_IMAGE above
-GO_VERSION ?= 1.12.7
-
+# latest from https://github.com/golangci/golangci-lint/releases
 GOLINT_VERSION ?= v1.17.1
 # Limit number of default jobs, to avoid the CI builds running out of memory
 GOLINT_JOBS ?= 4

--- a/hack/jenkins/install_golang.sh
+++ b/hack/jenkins/install_golang.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This script installs the exact golang version if not already installed
+# this script is meant to be used by jenkins build agent and works only linux
+
+set -e
+
+VERSION_TO_INSTALL=${1:-"1.12.8"}  
+INSTALL_PATH=${2:-"/usr/local"} 
+
+
+# installs or updates golang if right version doesn't exists
+function check_and_install_golang() {
+	if ! go version &> /dev/null
+	then
+		echo "WARNING: No golang installation found in your enviroment."
+    install_golang $VERSION_TO_INSTALL $INSTALL_PATH
+    return
+	fi
+	
+	# golang has been installed and check its version
+	if [[ $(go version) =~ (([0-9]+)\.([0-9]+).([0-9]+).([\.0-9]*)) ]]
+	then
+		host_golang_version=${BASH_REMATCH[1]}	
+    if [ $host_golang_version = $VERSION_TO_INSTALL ]; then
+      echo "go version on the host looks good : $host_golang_version"
+    else
+      echo "WARNING: expected go version to be $VERSION_TO_INSTALL but got $host_golang_version"
+      install_golang $VERSION_TO_INSTALL $INSTALL_PATH
+    fi
+  	
+  
+  else
+  	warn "Failed to parse golang version."
+		return
+	fi
+}
+
+# install_golang takes two parameters version and path to install.
+function install_golang {
+    echo "Installing golang version: $1 on $2"  
+    pushd /tmp >/dev/null
+    curl -qL -O "https://storage.googleapis.com/golang/go${version_to_install}.linux-amd64.tar.gz" &&
+      tar xfa go${version_to_install}.linux-amd64.tar.gz &&
+      rm -rf "${INSTALL_PATH}/go" &&
+      mv go "${INSTALL_PATH}/" &&
+    popd >/dev/null
+
+    pushd "${INSTALL_PATH}/go/src/go/types" > /dev/null
+    echo "Installing gotype linter"
+    go build gotype.go
+    cp gotype "${INSTALL_PATH}/go/bin"
+    popd >/dev/null
+}
+
+
+check_and_install_golang

--- a/hack/jenkins/installers/check_install_golang.sh
+++ b/hack/jenkins/installers/check_install_golang.sh
@@ -1,65 +1,67 @@
-#!/bin/bash
+  #!/bin/bash
 
-# Copyright 2019 The Kubernetes Authors All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+  # Copyright 2019 The Kubernetes Authors All rights reserved.
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
 
+  # This script installs the exact golang version if not already installed
+  # this script is meant to be used by jenkins build agent and works only linux
 
-# This script installs the exact golang version if not already installed
-# this script is meant to be used by jenkins build agent and works only linux
+  set -eux -o pipefail
 
-set -e
+  if (($# < 2)); then
+    echo "ERROR: given ! ($#) number of parameters but expect 2."
+    echo "USAGE: ./check_and_install_golang.sh VERSION_TO_INSTALL INSTALL_PATH"
+    exit 1
+  fi
 
-# default values if not provided 
-VERSION_TO_INSTALL=${1:-"1.12.8"}  
-INSTALL_PATH=${2:-"/usr/local"} 
+  VERSION_TO_INSTALL=${1}
+  INSTALL_PATH=${2}
 
-
-# installs or updates golang if right version doesn't exists
-function check_and_install_golang() {
-	if ! go version &> /dev/null
-	then
-		echo "WARNING: No golang installation found in your enviroment."
-    install_golang "$VERSION_TO_INSTALL" "$INSTALL_PATH"
-    return
-	fi
-	
-	# golang has been installed and check its version
-	if [[ $(go version) =~ (([0-9]+)\.([0-9]+).([0-9]+).([\.0-9]*)) ]]
-	then
-		HOST_VERSION=${BASH_REMATCH[1]}	
-    if [ $HOST_VERSION = $VERSION_TO_INSTALL ]; then
-      echo "go version on the host looks good : $HOST_VERSION"
-    else
-      echo "WARNING: expected go version to be $VERSION_TO_INSTALL but got $HOST_VERSION"
+  # installs or updates golang if right version doesn't exists
+  function check_and_install_golang() {
+    if ! go version &>/dev/null; then
+      echo "WARNING: No golang installation found in your enviroment."
       install_golang "$VERSION_TO_INSTALL" "$INSTALL_PATH"
-    fi 	  
-  else
-  	echo "ERROR: Failed to parse golang version."
-		return
-	fi
-}
+      return
+    fi
 
-# install_golang takes two parameters version and path to install.
-function install_golang {
-    echo "Installing golang version: $1 on $2"  
+    # golang has been installed and check its version
+    if [[ $(go version) =~ (([0-9]+)\.([0-9]+).([0-9]+).([\.0-9]*)) ]]; then
+      HOST_VERSION=${BASH_REMATCH[1]}
+      if [ $HOST_VERSION = $VERSION_TO_INSTALL ]; then
+        echo "go version on the host looks good : $HOST_VERSION"
+      else
+        echo "WARNING: expected go version to be $VERSION_TO_INSTALL but got $HOST_VERSION"
+        install_golang "$VERSION_TO_INSTALL" "$INSTALL_PATH"
+      fi
+    else
+      echo "ERROR: Failed to parse golang version: $HOST_VERSION"
+      return
+    fi
+  }
+
+  # install_golang takes two parameters version and path to install.
+  function install_golang() {
+    echo "Installing golang version: $1 on $2"
     pushd /tmp >/dev/null
+    # using sudo because previously installed versions might have been installed by a different user.
+    # as it was the case on jenkins VM.
     sudo curl -qL -O "https://storage.googleapis.com/golang/go${1}.linux-amd64.tar.gz" &&
-    sudo tar xfa go${1}.linux-amd64.tar.gz &&
-    sudo rm -rf "${2}/go" &&
-    sudo mv go "${2}/" && sudo chown -R $(whoami): ${2}/go
+      sudo tar xfa go${1}.linux-amd64.tar.gz &&
+      sudo rm -rf "${2}/go" &&
+      sudo mv go "${2}/" && sudo chown -R $(whoami): ${2}/go
     popd >/dev/null
-}
+  }
 
-
-check_and_install_golang
+  check_and_install_golang

--- a/hack/jenkins/installers/check_install_golang.sh
+++ b/hack/jenkins/installers/check_install_golang.sh
@@ -20,6 +20,7 @@
 
 set -e
 
+# default values if not provided 
 VERSION_TO_INSTALL=${1:-"1.12.8"}  
 INSTALL_PATH=${2:-"/usr/local"} 
 

--- a/hack/jenkins/installers/check_install_golang.sh
+++ b/hack/jenkins/installers/check_install_golang.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2016 The Kubernetes Authors All rights reserved.
+# Copyright 2019 The Kubernetes Authors All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/jenkins/installers/check_install_golang.sh
+++ b/hack/jenkins/installers/check_install_golang.sh
@@ -54,15 +54,9 @@ function install_golang {
     echo "Installing golang version: $1 on $2"  
     pushd /tmp >/dev/null
     sudo curl -qL -O "https://storage.googleapis.com/golang/go${1}.linux-amd64.tar.gz" &&
-      sudo tar xfa go${1}.linux-amd64.tar.gz &&
-      sudo rm -rf "${2}/go" &&
-      sudo mv go "${2}/" &&
-    popd >/dev/null
-
-    pushd "${2}/go/src/go/types" > /dev/null
-    echo "Installing gotype linter"
-    sudo go build gotype.go
-    sudo cp gotype "${2}/go/bin"
+    sudo tar xfa go${1}.linux-amd64.tar.gz &&
+    sudo rm -rf "${2}/go" &&
+    sudo mv go "${2}/" && sudo chown -R $(whoami): ${2}/go
     popd >/dev/null
 }
 

--- a/hack/jenkins/installers/check_install_golang.sh
+++ b/hack/jenkins/installers/check_install_golang.sh
@@ -29,24 +29,22 @@ function check_and_install_golang() {
 	if ! go version &> /dev/null
 	then
 		echo "WARNING: No golang installation found in your enviroment."
-    install_golang $VERSION_TO_INSTALL $INSTALL_PATH
+    install_golang "$VERSION_TO_INSTALL" "$INSTALL_PATH"
     return
 	fi
 	
 	# golang has been installed and check its version
 	if [[ $(go version) =~ (([0-9]+)\.([0-9]+).([0-9]+).([\.0-9]*)) ]]
 	then
-		host_golang_version=${BASH_REMATCH[1]}	
-    if [ $host_golang_version = $VERSION_TO_INSTALL ]; then
-      echo "go version on the host looks good : $host_golang_version"
+		HOST_VERSION=${BASH_REMATCH[1]}	
+    if [ "$HOST_VERSION" = "$VERSION_TO_INSTALL" ]; then
+      echo "go version on the host looks good : $HOST_VERSION"
     else
-      echo "WARNING: expected go version to be $VERSION_TO_INSTALL but got $host_golang_version"
-      install_golang $VERSION_TO_INSTALL $INSTALL_PATH
-    fi
-  	
-  
+      echo "WARNING: expected go version to be $VERSION_TO_INSTALL but got $HOST_VERSION"
+      install_golang "$VERSION_TO_INSTALL" "$INSTALL_PATH"
+    fi 	  
   else
-  	warn "Failed to parse golang version."
+  	echo "ERROR: Failed to parse golang version."
 		return
 	fi
 }
@@ -55,16 +53,16 @@ function check_and_install_golang() {
 function install_golang {
     echo "Installing golang version: $1 on $2"  
     pushd /tmp >/dev/null
-    curl -qL -O "https://storage.googleapis.com/golang/go${version_to_install}.linux-amd64.tar.gz" &&
-      tar xfa go${version_to_install}.linux-amd64.tar.gz &&
-      rm -rf "${INSTALL_PATH}/go" &&
-      mv go "${INSTALL_PATH}/" &&
+    sudo curl -qL -O "https://storage.googleapis.com/golang/go${1}.linux-amd64.tar.gz" &&
+      sudo tar xfa go${1}.linux-amd64.tar.gz &&
+      sudo rm -rf "${2}/go" &&
+      sudo mv go "${2}/" &&
     popd >/dev/null
 
-    pushd "${INSTALL_PATH}/go/src/go/types" > /dev/null
+    pushd "${2}/go/src/go/types" > /dev/null
     echo "Installing gotype linter"
-    go build gotype.go
-    cp gotype "${INSTALL_PATH}/go/bin"
+    sudo go build gotype.go
+    sudo cp gotype "${2}/go/bin"
     popd >/dev/null
 }
 

--- a/hack/jenkins/installers/check_install_golang.sh
+++ b/hack/jenkins/installers/check_install_golang.sh
@@ -1,67 +1,64 @@
-  #!/bin/bash
+#!/bin/bash
 
-  # Copyright 2019 The Kubernetes Authors All rights reserved.
-  #
-  # Licensed under the Apache License, Version 2.0 (the "License");
-  # you may not use this file except in compliance with the License.
-  # You may obtain a copy of the License at
-  #
-  #     http://www.apache.org/licenses/LICENSE-2.0
-  #
-  # Unless required by applicable law or agreed to in writing, software
-  # distributed under the License is distributed on an "AS IS" BASIS,
-  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  # See the License for the specific language governing permissions and
-  # limitations under the License.
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-  # This script installs the exact golang version if not already installed
-  # this script is meant to be used by jenkins build agent and works only linux
+set -eux -o pipefail
 
-  set -eux -o pipefail
+if (($# < 2)); then
+  echo "ERROR: given ! ($#) number of parameters but expect 2."
+  echo "USAGE: ./check_and_install_golang.sh VERSION_TO_INSTALL INSTALL_PATH"
+  exit 1
+fi
 
-  if (($# < 2)); then
-    echo "ERROR: given ! ($#) number of parameters but expect 2."
-    echo "USAGE: ./check_and_install_golang.sh VERSION_TO_INSTALL INSTALL_PATH"
-    exit 1
+VERSION_TO_INSTALL=${1}
+INSTALL_PATH=${2}
+
+# installs or updates golang if right version doesn't exists
+function check_and_install_golang() {
+  if ! go version &>/dev/null; then
+    echo "WARNING: No golang installation found in your enviroment."
+    install_golang "$VERSION_TO_INSTALL" "$INSTALL_PATH"
+    return
   fi
 
-  VERSION_TO_INSTALL=${1}
-  INSTALL_PATH=${2}
-
-  # installs or updates golang if right version doesn't exists
-  function check_and_install_golang() {
-    if ! go version &>/dev/null; then
-      echo "WARNING: No golang installation found in your enviroment."
-      install_golang "$VERSION_TO_INSTALL" "$INSTALL_PATH"
-      return
-    fi
-
-    # golang has been installed and check its version
-    if [[ $(go version) =~ (([0-9]+)\.([0-9]+).([0-9]+).([\.0-9]*)) ]]; then
-      HOST_VERSION=${BASH_REMATCH[1]}
-      if [ $HOST_VERSION = $VERSION_TO_INSTALL ]; then
-        echo "go version on the host looks good : $HOST_VERSION"
-      else
-        echo "WARNING: expected go version to be $VERSION_TO_INSTALL but got $HOST_VERSION"
-        install_golang "$VERSION_TO_INSTALL" "$INSTALL_PATH"
-      fi
+  # golang has been installed and check its version
+  if [[ $(go version) =~ (([0-9]+)\.([0-9]+).([0-9]+).([\.0-9]*)) ]]; then
+    HOST_VERSION=${BASH_REMATCH[1]}
+    if [ $HOST_VERSION = $VERSION_TO_INSTALL ]; then
+      echo "go version on the host looks good : $HOST_VERSION"
     else
-      echo "ERROR: Failed to parse golang version: $HOST_VERSION"
-      return
+      echo "WARNING: expected go version to be $VERSION_TO_INSTALL but got $HOST_VERSION"
+      install_golang "$VERSION_TO_INSTALL" "$INSTALL_PATH"
     fi
-  }
+  else
+    echo "ERROR: Failed to parse golang version: $HOST_VERSION"
+    return
+  fi
+}
 
-  # install_golang takes two parameters version and path to install.
-  function install_golang() {
-    echo "Installing golang version: $1 on $2"
-    pushd /tmp >/dev/null
-    # using sudo because previously installed versions might have been installed by a different user.
-    # as it was the case on jenkins VM.
-    sudo curl -qL -O "https://storage.googleapis.com/golang/go${1}.linux-amd64.tar.gz" &&
-      sudo tar xfa go${1}.linux-amd64.tar.gz &&
-      sudo rm -rf "${2}/go" &&
-      sudo mv go "${2}/" && sudo chown -R $(whoami): ${2}/go
-    popd >/dev/null
-  }
+# install_golang takes two parameters version and path to install.
+function install_golang() {
+  echo "Installing golang version: $1 on $2"
+  pushd /tmp >/dev/null
+  # using sudo because previously installed versions might have been installed by a different user.
+  # as it was the case on jenkins VM.
+  sudo curl -qL -O "https://storage.googleapis.com/golang/go${1}.linux-amd64.tar.gz" &&
+    sudo tar xfa go${1}.linux-amd64.tar.gz &&
+    sudo rm -rf "${2}/go" &&
+    sudo mv go "${2}/" && sudo chown -R $(whoami): ${2}/go
+  popd >/dev/null
+}
 
-  check_and_install_golang
+check_and_install_golang

--- a/hack/jenkins/installers/check_install_golang.sh
+++ b/hack/jenkins/installers/check_install_golang.sh
@@ -37,7 +37,7 @@ function check_and_install_golang() {
 	if [[ $(go version) =~ (([0-9]+)\.([0-9]+).([0-9]+).([\.0-9]*)) ]]
 	then
 		HOST_VERSION=${BASH_REMATCH[1]}	
-    if [ "$HOST_VERSION" = "$VERSION_TO_INSTALL" ]; then
+    if [ $HOST_VERSION = $VERSION_TO_INSTALL ]; then
       echo "go version on the host looks good : $HOST_VERSION"
     else
       echo "WARNING: expected go version to be $VERSION_TO_INSTALL but got $HOST_VERSION"

--- a/hack/jenkins/minikube_cross_build_and_upload.sh
+++ b/hack/jenkins/minikube_cross_build_and_upload.sh
@@ -25,6 +25,11 @@ set -eux -o pipefail
 
 readonly bucket="minikube-builds"
 
+# Make sure the right golang version is installed based on Makefile
+EXPCECTED_GOLANG_VERSION=$(cat Makefile | grep "GO_VERSION ?=" | awk -F"= " '{print $2}')
+source ./hack/jenkins/installers/check_install_golang.sh $EXPCECTED_GOLANG_VERSION
+
+
 declare -rx BUILD_IN_DOCKER=y
 declare -rx GOPATH=/var/lib/jenkins/go
 declare -rx ISO_BUCKET="${bucket}/${ghprbPullId}"

--- a/hack/jenkins/minikube_cross_build_and_upload.sh
+++ b/hack/jenkins/minikube_cross_build_and_upload.sh
@@ -26,8 +26,8 @@ set -eux -o pipefail
 readonly bucket="minikube-builds"
 
 # Make sure the right golang version is installed based on Makefile
-EXPCECTED_GOLANG_VERSION=$(cat Makefile | grep "GO_VERSION ?=" | awk -F"= " '{print $2}')
-source ./hack/jenkins/installers/check_install_golang.sh $EXPCECTED_GOLANG_VERSION
+WANT_GOLANG_VERSION=$(grep '^GO_VERSION' Makefile | awk '{ print $3 }')
+./hack/jenkins/installers/check_install_golang.sh $WANT_GOLANG_VERSION /usr/local
 
 
 declare -rx BUILD_IN_DOCKER=y

--- a/hack/jenkins/release_build_and_upload.sh
+++ b/hack/jenkins/release_build_and_upload.sh
@@ -31,6 +31,11 @@ export DEB_VERSION=${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BUILD}
 export RPM_VERSION=${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BUILD}
 export GOPATH=~/go
 
+# Make sure the right golang version is installed based on Makefile
+EXPCECTED_GOLANG_VERSION=$(cat Makefile | grep "GO_VERSION ?=" | awk -F"= " '{print $2}')
+GOLANG_INSTALL_PATH="/usr/local/"
+source ./install_golang.sh $GOLANG_VERSION $GOLANG_INSTALL_PATH 
+
 # Make sure the tag matches the Makefile
 cat Makefile | grep "VERSION_MAJOR ?=" | grep $VERSION_MAJOR
 cat Makefile | grep "VERSION_MINOR ?=" | grep $VERSION_MINOR
@@ -46,3 +51,6 @@ gsutil -m cp out/* gs://$BUCKET/releases/$TAGNAME/
 
 # Bump latest
 gsutil cp -r gs://$BUCKET/releases/$TAGNAME/* gs://$BUCKET/releases/latest/
+
+
+

--- a/hack/jenkins/release_build_and_upload.sh
+++ b/hack/jenkins/release_build_and_upload.sh
@@ -52,5 +52,3 @@ gsutil -m cp out/* gs://$BUCKET/releases/$TAGNAME/
 # Bump latest
 gsutil cp -r gs://$BUCKET/releases/$TAGNAME/* gs://$BUCKET/releases/latest/
 
-
-

--- a/hack/jenkins/release_build_and_upload.sh
+++ b/hack/jenkins/release_build_and_upload.sh
@@ -51,4 +51,3 @@ gsutil -m cp out/* gs://$BUCKET/releases/$TAGNAME/
 
 # Bump latest
 gsutil cp -r gs://$BUCKET/releases/$TAGNAME/* gs://$BUCKET/releases/latest/
-

--- a/hack/jenkins/release_build_and_upload.sh
+++ b/hack/jenkins/release_build_and_upload.sh
@@ -33,8 +33,8 @@ export GOPATH=~/go
 
 # Make sure the right golang version is installed based on Makefile
 EXPCECTED_GOLANG_VERSION=$(cat Makefile | grep "GO_VERSION ?=" | awk -F"= " '{print $2}')
-GOLANG_INSTALL_PATH="/usr/local/"
-source ./install_golang.sh $GOLANG_VERSION $GOLANG_INSTALL_PATH 
+source ./hack/jenkins/installers/check_install_golang.sh $EXPCECTED_GOLANG_VERSION
+
 
 # Make sure the tag matches the Makefile
 cat Makefile | grep "VERSION_MAJOR ?=" | grep $VERSION_MAJOR

--- a/hack/jenkins/release_build_and_upload.sh
+++ b/hack/jenkins/release_build_and_upload.sh
@@ -32,8 +32,8 @@ export RPM_VERSION=${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BUILD}
 export GOPATH=~/go
 
 # Make sure the right golang version is installed based on Makefile
-EXPCECTED_GOLANG_VERSION=$(cat Makefile | grep "GO_VERSION ?=" | awk -F"= " '{print $2}')
-source ./hack/jenkins/installers/check_install_golang.sh $EXPCECTED_GOLANG_VERSION
+WANT_GOLANG_VERSION=$(grep '^GO_VERSION' Makefile | awk '{ print $3 }')
+./hack/jenkins/installers/check_install_golang.sh $WANT_GOLANG_VERSION /usr/local
 
 
 # Make sure the tag matches the Makefile


### PR DESCRIPTION
- Single source of truth for go version based on Makefile
- Installs right version golang (if not already) on jenkins build agent
- Bump the golang version to 1.12.8
- Also addresses multiple golang CVEs  closes https://github.com/kubernetes/minikube/issues/5087 also closes https://github.com/kubernetes/minikube/issues/4895

---- 

#### Before this PR run on the jenkins box:
```
jenkins@jenkins:~$ go version
go version go1.12.5 linux/
```

on the first run of this PR if wrong verison of golang is installed, it will warn and then install the right version:

when the golang version is not same as Makefile jenkins will warn and then install the right version

```
14:36:06 WARNING: expected go version to be 1.12.8 but got 1.12.5
```

here is the output:

```
15:01:27 ++ install_golang 1.12.8 /usr/local
15:01:27 ++ echo 'Installing golang version: 1.12.8 on /usr/local'
15:01:27 Installing golang version: 1.12.8 on /usr/local
15:01:27 ++ pushd /tmp
15:01:27 ++ sudo curl -qL -O https://storage.googleapis.com/golang/go1.12.8.linux-amd64.tar.gz
15:01:27   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
15:01:27                                  Dload  Upload   Total   Spent    Left  Speed
15:01:27 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
 88  122M   88  107M    0     0   190M      0 --:--:-- --:--:-- --:--:--  190M
100  122M  100  122M    0     0   196M      0 --:--:-- --:--:-- --:--:--  196M
15:01:28 ++ sudo tar xfa go1.12.8.linux-amd64.tar.gz
15:01:32 ++ sudo rm -rf /usr/local/go
15:01:32 ++ sudo mv go /usr/local/
15:01:32 +++ whoami
15:01:32 ++ sudo chown -R jenkins: /usr/local/go
15:01:32 ++ popd
15:01:32 ++ return

```


after the first run I can see in the jenkins box ssh:

```
jenkins@jenkins:~$ go version
go version go1.12.8 linux/amd64
jenkins@jenkins:~$ which go
/usr/local/go/bin/go
jenkins@jenkins:~$ ls -lah /usr/local/go/bin/go
-rwxr-xr-x 1 jenkins jenkins 14M Aug 13 09:59 /usr/local/go/bin/go
jenkins@jenkins:~$ 


$ ls -lah /usr/local/go/bin/go
-rwxr-xr-x 1 jenkins jenkins 14M Aug 13 09:59 /usr/local/go/bin/go
jenkins@jenkins:~$ 
jenkins@jenkins:~$ 
jenkins@jenkins:~$ go env
GOARCH="amd64"
GOBIN=""
GOCACHE="/var/lib/jenkins/.cache/go-build"
GOEXE=""
GOFLAGS=""
GOHOSTARCH="amd64"
GOHOSTOS="linux"
GOOS="linux"
GOPATH="/var/lib/jenkins/go"
GOPROXY=""
GORACE=""
GOROOT="/usr/local/go"
GOTMPDIR=""
GOTOOLDIR="/usr/local/go/pkg/tool/linux_amd64"
GCCGO="/usr/bin/gccgo"
CC="gcc"
CXX="g++"
CGO_ENABLED="1"
GOMOD=""
CGO_CFLAGS="-g -O2"
CGO_CPPFLAGS=""
CGO_CXXFLAGS="-g -O2"
CGO_FFLAGS="-g -O2"
CGO_LDFLAGS="-g -O2"
PKG_CONFIG="pkg-config"
GOGCCFLAGS="-fPIC -m64 -pthread -fmessage-length=0 -fdebug-prefix-map=/tmp/go-build458013956=/tmp/go-build -gno-rec
ord-gcc-switches"
```



and also when the right version is already installed it won't re-install but lets you know it is good !

```
15:13:27 ++ check_and_install_golang
15:13:27 ++ echo 'go version on the host looks good : 1.12.8 '
15:13:27 go version on the host looks good : 1.12.8 
```
