### PR TITLE
delete: Clean up machine directory if DeleteHost fails to

### DIFF
--- a/pkg/minikube/machine/client.go
+++ b/pkg/minikube/machine/client.go
@@ -123,7 +123,7 @@ func (api *LocalClient) NewHost(driverName string, rawDriver []byte) (*host.Host
 func (api *LocalClient) Load(name string) (*host.Host, error) {
 	h, err := api.Filestore.Load(name)
 	if err != nil {
-		return nil, errors.Wrap(err, "filestore")
+		return nil, errors.Wrapf(err, "filestore %q", name)
 	}
 
 	var def registry.DriverDef


### PR DESCRIPTION
There are some situations where DeleteHost won't succeed. This outputs a warning, and tries to cleanup the directory anyways.

## Old behavior with truncated `config.json`:

```
💣  Failed to delete cluster: Error getting migrated host: unexpected end of JSON input

😿  Sorry that minikube crashed. If this was unexpected, we would love to hear from you:
👉  https://github.com/kubernetes/minikube/issues/new/choose
```

## New behavior with truncated `config.json`:

```
❌  Failed to delete cluster: load: filestore "minikube": Error getting migrated host: unexpected end of JSON input
📌  You may need to manually remove the "minikube" VM from your hypervisor
🔥  Removing /Users/tstromberg/.minikube/machines/minikube ...
💔  The "minikube" cluster has been deleted.
```

Closes #4286 and #5046
