### PR TITLE
cleanup: lock.go error message typo fix

### DIFF
--- a/pkg/util/lock/lock.go
+++ b/pkg/util/lock/lock.go
@@ -36,7 +36,7 @@ func WriteFile(filename string, data []byte, perm os.FileMode) (err error) {
 		lockErr := lock.TryLock()
 		if lockErr != nil {
 			glog.Warningf("temporary error : %v", lockErr.Error())
-			return errors.Wrapf(lockErr, "falied to acquire lock for %s > ", filename)
+			return errors.Wrapf(lockErr, "failed to acquire lock for %s > ", filename)
 		}
 		return nil
 	}


### PR DESCRIPTION
Signed-off-by: Guangming Wang <guangming.wang@daocloud.io>