### PR TITLE
Add wait-timeout flag to start command and refactor util/kubernetes

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/bootstrapper/kubeadm"
 	"k8s.io/minikube/pkg/minikube/cluster"
 	"k8s.io/minikube/pkg/minikube/command"
+	"k8s.io/minikube/pkg/minikube/config"
 	cfg "k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/cruntime"
@@ -111,7 +112,7 @@ var (
 	insecureRegistry []string
 	apiServerNames   []string
 	apiServerIPs     []net.IP
-	extraOptions     pkgutil.ExtraOptionSlice
+	extraOptions     config.ExtraOptionSlice
 )
 
 func init() {
@@ -538,8 +539,8 @@ func validateConfig() {
 
 	// check that kubeadm extra args contain only whitelisted parameters
 	for param := range extraOptions.AsMap().Get(kubeadm.Kubeadm) {
-		if !pkgutil.ContainsString(kubeadm.KubeadmExtraArgsWhitelist[kubeadm.KubeadmCmdParam], param) &&
-			!pkgutil.ContainsString(kubeadm.KubeadmExtraArgsWhitelist[kubeadm.KubeadmConfigParam], param) {
+		if !cfg.ContainsParam(kubeadm.KubeadmExtraArgsWhitelist[kubeadm.KubeadmCmdParam], param) &&
+			!cfg.ContainsParam(kubeadm.KubeadmExtraArgsWhitelist[kubeadm.KubeadmConfigParam], param) {
 			exit.UsageT("Sorry, the kubeadm.{{.parameter_name}} parameter is currently not supported by --extra-config", out.V{"parameter_name": param})
 		}
 	}

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -103,6 +103,7 @@ const (
 	dnsProxy              = "dns-proxy"
 	hostDNSResolver       = "host-dns-resolver"
 	waitUntilHealthy      = "wait"
+	waitTimeout           = "wait-timeout"
 )
 
 var (
@@ -149,6 +150,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().String(networkPlugin, "", "The name of the network plugin.")
 	startCmd.Flags().Bool(enableDefaultCNI, false, "Enable the default CNI plugin (/etc/cni/net.d/k8s.conf). Used in conjunction with \"--network-plugin=cni\".")
 	startCmd.Flags().Bool(waitUntilHealthy, true, "Wait until Kubernetes core services are healthy before exiting.")
+	startCmd.Flags().Duration(waitTimeout, 3*time.Minute, "max time to wait for Kubernetes core services to be healthy.")
 }
 
 // initKubernetesFlags inits the commandline flags for kubernetes related options
@@ -322,7 +324,7 @@ func runStart(cmd *cobra.Command, args []string) {
 	// special ops for none driver, like change minikube directory.
 	prepareNone(viper.GetString(vmDriver))
 	if viper.GetBool(waitUntilHealthy) {
-		if err := bs.WaitCluster(config.KubernetesConfig); err != nil {
+		if err := bs.WaitCluster(config.KubernetesConfig, viper.GetDuration(waitTimeout)); err != nil {
 			exit.WithError("Wait failed", err)
 		}
 	}

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -150,7 +150,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().String(networkPlugin, "", "The name of the network plugin.")
 	startCmd.Flags().Bool(enableDefaultCNI, false, "Enable the default CNI plugin (/etc/cni/net.d/k8s.conf). Used in conjunction with \"--network-plugin=cni\".")
 	startCmd.Flags().Bool(waitUntilHealthy, true, "Wait until Kubernetes core services are healthy before exiting.")
-	startCmd.Flags().Duration(waitTimeout, 3*time.Minute, "max time to wait for Kubernetes core services to be healthy.")
+	startCmd.Flags().Duration(waitTimeout, 3*time.Minute, "max time to wait per Kubernetes core services to be healthy.")
 }
 
 // initKubernetesFlags inits the commandline flags for kubernetes related options

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -279,9 +279,6 @@ ${SUDO_PREFIX} rm -f "${KUBECONFIG}" || true
 rmdir "${TEST_HOME}"
 echo ">> ${TEST_HOME} completed at $(date)"
 
-# Build the gvisor image. This will be copied into minikube and loaded by ctr.
-docker build -t gcr.io/k8s-minikube/gvisor-addon:latest -f testdata/gvisor-addon-Dockerfile out
-
 if [[ "${MINIKUBE_LOCATION}" != "master" ]]; then
   readonly target_url="https://storage.googleapis.com/minikube-builds/logs/${MINIKUBE_LOCATION}/${JOB_NAME}.txt"
   curl -s "https://api.github.com/repos/kubernetes/minikube/statuses/${COMMIT}?access_token=$access_token" \

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -241,6 +241,11 @@ export MINIKUBE_HOME="${TEST_HOME}/.minikube"
 export MINIKUBE_WANTREPORTERRORPROMPT=False
 export KUBECONFIG="${TEST_HOME}/kubeconfig"
 
+# Build the gvisor image. This will be copied into minikube and loaded by ctr.
+# Used by TestContainerd for Gvisor Test.
+docker build -t gcr.io/k8s-minikube/gvisor-addon:latest -f testdata/gvisor-addon-Dockerfile out
+
+
 # Display the default image URL
 echo ""
 echo ">> ISO URL"

--- a/pkg/kapi/kapi.go
+++ b/pkg/kapi/kapi.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kube
+package kapi
 
 import (
 	"context"
@@ -77,7 +77,7 @@ func WaitForPodsWithLabelRunning(c kubernetes.Interface, ns string, label labels
 		listOpts := meta.ListOptions{LabelSelector: label.String()}
 		pods, err := c.CoreV1().Pods(ns).List(listOpts)
 		if err != nil {
-			glog.Infof("temproary error: getting Pods with label selector %q : [%v]\n", label.String(), err)
+			glog.Infof("temporary error: getting Pods with label selector %q : [%v]\n", label.String(), err)
 			return false, nil
 		}
 
@@ -92,7 +92,7 @@ func WaitForPodsWithLabelRunning(c kubernetes.Interface, ns string, label labels
 
 		for _, pod := range pods.Items {
 			if pod.Status.Phase != core.PodRunning {
-				glog.Infof("temporary error: for Pod with label %q expected status to be running but got %s : [%v]\n", label.String(), pod.Status.Phase, err)
+				glog.Infof("waiting for pod %q, current state: %s: [%v]\n", label.String(), pod.Status.Phase, err)
 				return false, nil
 			}
 		}
@@ -104,8 +104,7 @@ func WaitForPodsWithLabelRunning(c kubernetes.Interface, ns string, label labels
 		t = timeOut[0]
 	}
 	err := wait.PollImmediate(kconst.APICallRetryInterval, t, f)
-	elapsed := time.Since(start)
-	glog.Infof("duration metric: took %s to wait for %s ...", elapsed, label)
+	glog.Infof("duration metric: took %s to wait for %s ...", time.Since(start), label)
 	return err
 }
 

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package kube
 
 import (
 	"context"
@@ -29,12 +29,10 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	watchtools "k8s.io/client-go/tools/watch"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -45,33 +43,11 @@ var (
 	// ReasonableMutateTime is how long to wait for basic object mutations, such as deletions, to show up
 	ReasonableMutateTime = time.Minute * 2
 	// ReasonableStartTime is how long to wait for pods to start
-	ReasonableStartTime = time.Minute * 5
+	ReasonableStartTime = time.Minute * 6
 )
 
-// PodStore stores pods
-type PodStore struct {
-	cache.Store
-	stopCh    chan struct{}
-	Reflector *cache.Reflector
-}
-
-// List lists the pods
-func (s *PodStore) List() []*core.Pod {
-	objects := s.Store.List()
-	pods := make([]*core.Pod, 0)
-	for _, o := range objects {
-		pods = append(pods, o.(*core.Pod))
-	}
-	return pods
-}
-
-// Stop stops the pods
-func (s *PodStore) Stop() {
-	close(s.stopCh)
-}
-
-// GetClient gets the client from config
-func GetClient(kubectlContext ...string) (kubernetes.Interface, error) {
+// Client gets the kuberentes client from default kubeconfig
+func Client(kubectlContext ...string) (kubernetes.Interface, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	configOverrides := &clientcmd.ConfigOverrides{}
 	if kubectlContext != nil {
@@ -92,41 +68,6 @@ func GetClient(kubectlContext ...string) (kubernetes.Interface, error) {
 	return client, nil
 }
 
-// NewPodStore creates a new PodStore
-func NewPodStore(c kubernetes.Interface, namespace string, label fmt.Stringer, field fmt.Stringer) *PodStore {
-	lw := &cache.ListWatch{
-		ListFunc: func(options meta.ListOptions) (runtime.Object, error) {
-			options.LabelSelector = label.String()
-			options.FieldSelector = field.String()
-			obj, err := c.CoreV1().Pods(namespace).List(options)
-			return runtime.Object(obj), err
-		},
-		WatchFunc: func(options meta.ListOptions) (watch.Interface, error) {
-			options.LabelSelector = label.String()
-			options.FieldSelector = field.String()
-			return c.CoreV1().Pods(namespace).Watch(options)
-		},
-	}
-	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
-	stopCh := make(chan struct{})
-	reflector := cache.NewReflector(lw, &core.Pod{}, store, 0)
-	go reflector.Run(stopCh)
-	return &PodStore{Store: store, stopCh: stopCh, Reflector: reflector}
-}
-
-// StartPods starts all pods
-func StartPods(c kubernetes.Interface, namespace string, pod core.Pod, waitForRunning bool) error {
-	pod.ObjectMeta.Labels["name"] = pod.Name
-	if waitForRunning {
-		label := labels.SelectorFromSet(labels.Set(map[string]string{"name": pod.Name}))
-		err := WaitForPodsWithLabelRunning(c, namespace, label)
-		if err != nil {
-			return fmt.Errorf("error waiting for pod %s to be running: %v", pod.Name, err)
-		}
-	}
-	return nil
-}
-
 // WaitForPodsWithLabelRunning waits for all matching pods to become Running and at least one matching pod exists.
 func WaitForPodsWithLabelRunning(c kubernetes.Interface, ns string, label labels.Selector) error {
 	glog.Infof("Waiting for pod with label %q in ns %q ...", ns, label)
@@ -135,7 +76,7 @@ func WaitForPodsWithLabelRunning(c kubernetes.Interface, ns string, label labels
 		listOpts := meta.ListOptions{LabelSelector: label.String()}
 		pods, err := c.CoreV1().Pods(ns).List(listOpts)
 		if err != nil {
-			glog.Infof("error getting Pods with label selector %q [%v]\n", label.String(), err)
+			glog.Errorf("error getting Pods with label selector %q [%v]\n", label.String(), err)
 			return false, nil
 		}
 
@@ -155,36 +96,6 @@ func WaitForPodsWithLabelRunning(c kubernetes.Interface, ns string, label labels
 		}
 
 		return true, nil
-	})
-}
-
-// WaitForPodDelete waits for a pod to be deleted
-func WaitForPodDelete(c kubernetes.Interface, ns string, label fmt.Stringer) error {
-	return wait.PollImmediate(constants.APICallRetryInterval, ReasonableMutateTime, func() (bool, error) {
-		listOpts := meta.ListOptions{LabelSelector: label.String()}
-		pods, err := c.CoreV1().Pods(ns).List(listOpts)
-		if err != nil {
-			glog.Infof("error getting Pods with label selector %q [%v]\n", label.String(), err)
-			return false, nil
-		}
-		return len(pods.Items) == 0, nil
-	})
-}
-
-// WaitForEvent waits for the given event to appear
-func WaitForEvent(c kubernetes.Interface, ns string, reason string) error {
-	return wait.PollImmediate(constants.APICallRetryInterval, ReasonableMutateTime, func() (bool, error) {
-		events, err := c.EventsV1beta1().Events("default").List(meta.ListOptions{})
-		if err != nil {
-			glog.Infof("error getting events: %v", err)
-			return false, nil
-		}
-		for _, e := range events.Items {
-			if e.Reason == reason {
-				return true, nil
-			}
-		}
-		return false, nil
 	})
 }
 
@@ -279,32 +190,6 @@ func WaitForService(c kubernetes.Interface, namespace, name string, exist bool, 
 		return fmt.Errorf("error waiting for service %s/%s %s: %v", namespace, name, stateMsg[exist], err)
 	}
 	return nil
-}
-
-// WaitForServiceEndpointsNum waits until the amount of endpoints that implement service to expectNum.
-func WaitForServiceEndpointsNum(c kubernetes.Interface, namespace, serviceName string, expectNum int, interval, timeout time.Duration) error {
-	return wait.Poll(interval, timeout, func() (bool, error) {
-		glog.Infof("Waiting for amount of service:%s endpoints to be %d", serviceName, expectNum)
-		list, err := c.CoreV1().Endpoints(namespace).List(meta.ListOptions{})
-		if err != nil {
-			return false, err
-		}
-
-		for _, e := range list.Items {
-			if e.Name == serviceName && countEndpointsNum(&e) == expectNum {
-				return true, nil
-			}
-		}
-		return false, nil
-	})
-}
-
-func countEndpointsNum(e *core.Endpoints) int {
-	num := 0
-	for _, sub := range e.Subsets {
-		num += len(sub.Addresses)
-	}
-	return num
 }
 
 // IsRetryableAPIError returns if this error is retryable or not

--- a/pkg/minikube/bootstrapper/bootstrapper.go
+++ b/pkg/minikube/bootstrapper/bootstrapper.go
@@ -18,6 +18,7 @@ package bootstrapper
 
 import (
 	"net"
+	"time"
 
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
@@ -39,7 +40,7 @@ type Bootstrapper interface {
 	UpdateCluster(config.KubernetesConfig) error
 	RestartCluster(config.KubernetesConfig) error
 	DeleteCluster(config.KubernetesConfig) error
-	WaitCluster(config.KubernetesConfig) error
+	WaitCluster(config.KubernetesConfig, time.Duration) error
 	// LogCommands returns a map of log type to a command which will display that log.
 	LogCommands(LogOptions) map[string]string
 	SetupCerts(cfg config.KubernetesConfig) error

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -35,7 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	kconst "k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/minikube/pkg/kube"
+	"k8s.io/minikube/pkg/kapi"
 	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/bootstrapper"
 	"k8s.io/minikube/pkg/minikube/command"
@@ -311,7 +311,7 @@ func (k *Bootstrapper) WaitCluster(k8s config.KubernetesConfig, timeout time.Dur
 	// up. Otherwise, minikube won't start, as "k8s-app" pods are not ready.
 	componentsOnly := k8s.NetworkPlugin == "cni"
 	out.T(out.WaitingPods, "Waiting for:")
-	client, err := kube.Client()
+	client, err := kapi.Client()
 	if err != nil {
 		return errors.Wrap(err, "k8s client")
 	}
@@ -329,7 +329,7 @@ func (k *Bootstrapper) WaitCluster(k8s config.KubernetesConfig, timeout time.Dur
 		}
 		out.String(" %s", p.name)
 		selector := labels.SelectorFromSet(labels.Set(map[string]string{p.key: p.value}))
-		if err := kube.WaitForPodsWithLabelRunning(client, "kube-system", selector, timeout); err != nil {
+		if err := kapi.WaitForPodsWithLabelRunning(client, "kube-system", selector, timeout); err != nil {
 			return errors.Wrap(err, fmt.Sprintf("waiting for %s=%s", p.key, p.value))
 		}
 	}
@@ -398,8 +398,7 @@ func (k *Bootstrapper) waitForAPIServer(k8s config.KubernetesConfig) error {
 		return true, nil
 	}
 	err := wait.PollImmediate(kconst.APICallRetryInterval, kconst.DefaultControlPlaneTimeout, f)
-	elapsed := time.Since(start)
-	glog.Infof("duration metric: took %s to wait for apiserver status ...", elapsed)
+	glog.Infof("duration metric: took %s to wait for apiserver status ...", time.Since(start))
 	return err
 }
 

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -305,7 +305,7 @@ func addAddons(files *[]assets.CopyableFile, data interface{}) error {
 }
 
 // WaitCluster blocks until Kubernetes appears to be healthy.
-func (k *Bootstrapper) WaitCluster(k8s config.KubernetesConfig) error {
+func (k *Bootstrapper) WaitCluster(k8s config.KubernetesConfig, timeout time.Duration) error {
 	// Do not wait for "k8s-app" pods in the case of CNI, as they are managed
 	// by a CNI plugin which is usually started after minikube has been brought
 	// up. Otherwise, minikube won't start, as "k8s-app" pods are not ready.
@@ -329,7 +329,7 @@ func (k *Bootstrapper) WaitCluster(k8s config.KubernetesConfig) error {
 		}
 		out.String(" %s", p.name)
 		selector := labels.SelectorFromSet(labels.Set(map[string]string{p.key: p.value}))
-		if err := kube.WaitForPodsWithLabelRunning(client, "kube-system", selector); err != nil {
+		if err := kube.WaitForPodsWithLabelRunning(client, "kube-system", selector, timeout); err != nil {
 			return errors.Wrap(err, fmt.Sprintf("waiting for %s=%s", p.key, p.value))
 		}
 	}

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm_test.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/cruntime"
-	"k8s.io/minikube/pkg/util"
 )
 
 func TestGenerateKubeletConfig(t *testing.T) {
@@ -149,29 +148,29 @@ ExecStart=/usr/bin/kubelet --authorization-mode=Webhook --bootstrap-kubeconfig=/
 	}
 }
 
-func getExtraOpts() []util.ExtraOption {
-	return util.ExtraOptionSlice{
-		util.ExtraOption{
+func getExtraOpts() []config.ExtraOption {
+	return config.ExtraOptionSlice{
+		config.ExtraOption{
 			Component: Apiserver,
 			Key:       "fail-no-swap",
 			Value:     "true",
 		},
-		util.ExtraOption{
+		config.ExtraOption{
 			Component: ControllerManager,
 			Key:       "kube-api-burst",
 			Value:     "32",
 		},
-		util.ExtraOption{
+		config.ExtraOption{
 			Component: Scheduler,
 			Key:       "scheduler-name",
 			Value:     "mini-scheduler",
 		},
-		util.ExtraOption{
+		config.ExtraOption{
 			Component: Kubeadm,
 			Key:       "ignore-preflight-errors",
 			Value:     "true",
 		},
-		util.ExtraOption{
+		config.ExtraOption{
 			Component: Kubeadm,
 			Key:       "dry-run",
 			Value:     "true",
@@ -179,9 +178,9 @@ func getExtraOpts() []util.ExtraOption {
 	}
 }
 
-func getExtraOptsPodCidr() []util.ExtraOption {
-	return util.ExtraOptionSlice{
-		util.ExtraOption{
+func getExtraOptsPodCidr() []config.ExtraOption {
+	return config.ExtraOptionSlice{
+		config.ExtraOption{
 			Component: Kubeadm,
 			Key:       "pod-network-cidr",
 			Value:     "192.168.32.0/20",
@@ -233,7 +232,7 @@ func TestGenerateConfig(t *testing.T) {
 		{"crio", "crio", false, config.KubernetesConfig{}},
 		{"options", "docker", false, config.KubernetesConfig{ExtraOptions: extraOpts}},
 		{"crio-options-gates", "crio", false, config.KubernetesConfig{ExtraOptions: extraOpts, FeatureGates: "a=b"}},
-		{"unknown-component", "docker", true, config.KubernetesConfig{ExtraOptions: util.ExtraOptionSlice{util.ExtraOption{Component: "not-a-real-component", Key: "killswitch", Value: "true"}}}},
+		{"unknown-component", "docker", true, config.KubernetesConfig{ExtraOptions: config.ExtraOptionSlice{config.ExtraOption{Component: "not-a-real-component", Key: "killswitch", Value: "true"}}}},
 		{"containerd-api-port", "containerd", false, config.KubernetesConfig{NodePort: 12345}},
 		{"containerd-pod-network-cidr", "containerd", false, config.KubernetesConfig{ExtraOptions: extraOptsPodCidr}},
 		{"image-repository", "docker", false, config.KubernetesConfig{ImageRepository: "test/repo"}},

--- a/pkg/minikube/bootstrapper/kubeadm/versions.go
+++ b/pkg/minikube/bootstrapper/kubeadm/versions.go
@@ -159,7 +159,7 @@ func Supports(featureName string) bool {
 	return false
 }
 
-// arseKubernetesVersion parses the kubernetes version
+// parseKubernetesVersion parses the kubernetes version
 func parseKubernetesVersion(version string) (semver.Version, error) {
 	// Strip leading 'v' prefix from version for semver parsing
 	v, err := semver.Make(version[1:])

--- a/pkg/minikube/bootstrapper/kubeadm/versions.go
+++ b/pkg/minikube/bootstrapper/kubeadm/versions.go
@@ -27,6 +27,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
+	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/util"
 )
@@ -43,7 +44,7 @@ const (
 
 // ExtraConfigForComponent generates a map of flagname-value pairs for a k8s
 // component.
-func ExtraConfigForComponent(component string, opts util.ExtraOptionSlice, version semver.Version) (map[string]string, error) {
+func ExtraConfigForComponent(component string, opts config.ExtraOptionSlice, version semver.Version) (map[string]string, error) {
 	versionedOpts, err := DefaultOptionsForComponentAndVersion(component, version)
 	if err != nil {
 		return nil, errors.Wrapf(err, "setting version specific options for %s", component)
@@ -78,7 +79,7 @@ var componentToKubeadmConfigKey = map[string]string{
 }
 
 // NewComponentExtraArgs creates a new ComponentExtraArgs
-func NewComponentExtraArgs(opts util.ExtraOptionSlice, version semver.Version, featureGates string) ([]ComponentExtraArgs, error) {
+func NewComponentExtraArgs(opts config.ExtraOptionSlice, version semver.Version, featureGates string) ([]ComponentExtraArgs, error) {
 	var kubeadmExtraArgs []ComponentExtraArgs
 	for _, extraOpt := range opts {
 		if _, ok := componentToKubeadmConfigKey[extraOpt.Component]; !ok {
@@ -158,8 +159,8 @@ func Supports(featureName string) bool {
 	return false
 }
 
-// ParseKubernetesVersion parses the kubernetes version
-func ParseKubernetesVersion(version string) (semver.Version, error) {
+// arseKubernetesVersion parses the kubernetes version
+func parseKubernetesVersion(version string) (semver.Version, error) {
 	// Strip leading 'v' prefix from version for semver parsing
 	v, err := semver.Make(version[1:])
 	if err != nil {
@@ -182,45 +183,9 @@ func convertToFlags(opts map[string]string) string {
 	return strings.Join(flags, " ")
 }
 
-// VersionedExtraOption holds information on flags to apply to a specific range
-// of versions
-type VersionedExtraOption struct {
-	// Special Cases:
-	//
-	// If LessThanOrEqual and GreaterThanOrEqual are both nil, the flag will be applied
-	// to all versions
-	//
-	// If LessThanOrEqual == GreaterThanOrEqual, the flag will only be applied to that
-	// specific version
-
-	// The flag and component that will be set
-	Option util.ExtraOption
-
-	// This flag will only be applied to versions before or equal to this version
-	// If it is the default value, it will have no upper bound on versions the
-	// flag is applied to
-	LessThanOrEqual semver.Version
-
-	// The flag will only be applied to versions after or equal to this version
-	// If it is the default value, it will have no lower bound on versions the
-	// flag is applied to
-	GreaterThanOrEqual semver.Version
-}
-
-// NewUnversionedOption returns a VersionedExtraOption that applies to all versions.
-func NewUnversionedOption(component, k, v string) VersionedExtraOption {
-	return VersionedExtraOption{
-		Option: util.ExtraOption{
-			Component: component,
-			Key:       k,
-			Value:     v,
-		},
-	}
-}
-
-var versionSpecificOpts = []VersionedExtraOption{
+var versionSpecificOpts = []config.VersionedExtraOption{
 	{
-		Option: util.ExtraOption{
+		Option: config.ExtraOption{
 			Component: Kubelet,
 			Key:       "fail-swap-on",
 			Value:     "false",
@@ -228,22 +193,22 @@ var versionSpecificOpts = []VersionedExtraOption{
 		GreaterThanOrEqual: semver.MustParse("1.8.0-alpha.0"),
 	},
 	// Kubeconfig args
-	NewUnversionedOption(Kubelet, "kubeconfig", "/etc/kubernetes/kubelet.conf"),
-	NewUnversionedOption(Kubelet, "bootstrap-kubeconfig", "/etc/kubernetes/bootstrap-kubelet.conf"),
+	config.NewUnversionedOption(Kubelet, "kubeconfig", "/etc/kubernetes/kubelet.conf"),
+	config.NewUnversionedOption(Kubelet, "bootstrap-kubeconfig", "/etc/kubernetes/bootstrap-kubelet.conf"),
 	{
-		Option: util.ExtraOption{
+		Option: config.ExtraOption{
 			Component: Kubelet,
 			Key:       "require-kubeconfig",
 			Value:     "true",
 		},
 		LessThanOrEqual: semver.MustParse("1.9.10"),
 	},
-	NewUnversionedOption(Kubelet, "hostname-override", constants.DefaultNodeName),
+	config.NewUnversionedOption(Kubelet, "hostname-override", constants.DefaultNodeName),
 
 	// System pods args
-	NewUnversionedOption(Kubelet, "pod-manifest-path", "/etc/kubernetes/manifests"),
+	config.NewUnversionedOption(Kubelet, "pod-manifest-path", "/etc/kubernetes/manifests"),
 	{
-		Option: util.ExtraOption{
+		Option: config.ExtraOption{
 			Component: Kubelet,
 			Key:       "allow-privileged",
 			Value:     "true",
@@ -252,17 +217,17 @@ var versionSpecificOpts = []VersionedExtraOption{
 	},
 
 	// Network args
-	NewUnversionedOption(Kubelet, "cluster-dns", "10.96.0.10"),
-	NewUnversionedOption(Kubelet, "cluster-domain", "cluster.local"),
+	config.NewUnversionedOption(Kubelet, "cluster-dns", "10.96.0.10"),
+	config.NewUnversionedOption(Kubelet, "cluster-domain", "cluster.local"),
 
 	// Auth args
-	NewUnversionedOption(Kubelet, "authorization-mode", "Webhook"),
-	NewUnversionedOption(Kubelet, "client-ca-file", path.Join(util.DefaultCertPath, "ca.crt")),
+	config.NewUnversionedOption(Kubelet, "authorization-mode", "Webhook"),
+	config.NewUnversionedOption(Kubelet, "client-ca-file", path.Join(util.DefaultCertPath, "ca.crt")),
 
 	// Cgroup args
-	NewUnversionedOption(Kubelet, "cgroup-driver", "cgroupfs"),
+	config.NewUnversionedOption(Kubelet, "cgroup-driver", "cgroupfs"),
 	{
-		Option: util.ExtraOption{
+		Option: config.ExtraOption{
 			Component: Apiserver,
 			Key:       "admission-control",
 			Value:     strings.Join(util.DefaultLegacyAdmissionControllers, ","),
@@ -271,7 +236,7 @@ var versionSpecificOpts = []VersionedExtraOption{
 		GreaterThanOrEqual: semver.MustParse("1.9.0-alpha.0"),
 	},
 	{
-		Option: util.ExtraOption{
+		Option: config.ExtraOption{
 			Component: Apiserver,
 			Key:       "enable-admission-plugins",
 			Value:     strings.Join(util.DefaultLegacyAdmissionControllers, ","),
@@ -280,7 +245,7 @@ var versionSpecificOpts = []VersionedExtraOption{
 		LessThanOrEqual:    semver.MustParse("1.13.1000"),
 	},
 	{
-		Option: util.ExtraOption{
+		Option: config.ExtraOption{
 			Component: Apiserver,
 			Key:       "enable-admission-plugins",
 			Value:     strings.Join(util.DefaultV114AdmissionControllers, ","),
@@ -289,7 +254,7 @@ var versionSpecificOpts = []VersionedExtraOption{
 	},
 
 	{
-		Option: util.ExtraOption{
+		Option: config.ExtraOption{
 			Component: Kubelet,
 			Key:       "cadvisor-port",
 			Value:     "0",

--- a/pkg/minikube/bootstrapper/kubeadm/versions_test.go
+++ b/pkg/minikube/bootstrapper/kubeadm/versions_test.go
@@ -94,7 +94,7 @@ func TestVersionIsBetween(t *testing.T) {
 }
 
 func TestParseKubernetesVersion(t *testing.T) {
-	version, err := ParseKubernetesVersion("v1.8.0-alpha.5")
+	version, err := parseKubernetesVersion("v1.8.0-alpha.5")
 	if err != nil {
 		t.Fatalf("Error parsing version: %v", err)
 	}

--- a/pkg/minikube/config/extra_options.go
+++ b/pkg/minikube/config/extra_options.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors All rights reserved.
+Copyright 2019 The Kubernetes Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package config
 
 import (
 	"fmt"
@@ -76,7 +76,7 @@ func (es *ExtraOptionSlice) String() string {
 // component is not specified, all of the components are used.
 func (es *ExtraOptionSlice) Get(key string, component ...string) string {
 	for _, opt := range *es {
-		if component == nil || ContainsString(component, opt.Component) {
+		if component == nil || ContainsParam(component, opt.Component) {
 			if opt.Key == key {
 				return opt.Value
 			}
@@ -106,4 +106,26 @@ func (es *ExtraOptionSlice) Type() string {
 // Get returns the extra option map of keys to values for the specified component
 func (cm ComponentExtraOptionMap) Get(component string) map[string]string {
 	return cm[component]
+}
+
+// ContainsParam checks if a given slice of strings contains the provided string.
+// If a modifier func is provided, it is called with the slice item before the comparation.
+func ContainsParam(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}
+
+// NewUnversionedOption returns a VersionedExtraOption that applies to all versions.
+func NewUnversionedOption(component, k, v string) VersionedExtraOption {
+	return VersionedExtraOption{
+		Option: ExtraOption{
+			Component: component,
+			Key:       k,
+			Value:     v,
+		},
+	}
 }

--- a/pkg/minikube/config/extra_options_test.go
+++ b/pkg/minikube/config/extra_options_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package config
 
 import (
 	"flag"

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -19,6 +19,7 @@ package config
 import (
 	"net"
 
+	"github.com/blang/semver"
 	"k8s.io/minikube/pkg/util"
 )
 
@@ -82,8 +83,33 @@ type KubernetesConfig struct {
 	FeatureGates      string
 	ServiceCIDR       string
 	ImageRepository   string
-	ExtraOptions      util.ExtraOptionSlice
+	ExtraOptions      ExtraOptionSlice
 
 	ShouldLoadCachedImages bool
 	EnableDefaultCNI       bool
+}
+
+// VersionedExtraOption holds information on flags to apply to a specific range
+// of versions
+type VersionedExtraOption struct {
+	// Special Cases:
+	//
+	// If LessThanOrEqual and GreaterThanOrEqual are both nil, the flag will be applied
+	// to all versions
+	//
+	// If LessThanOrEqual == GreaterThanOrEqual, the flag will only be applied to that
+	// specific version
+
+	// The flag and component that will be set
+	Option ExtraOption
+
+	// This flag will only be applied to versions before or equal to this version
+	// If it is the default value, it will have no upper bound on versions the
+	// flag is applied to
+	LessThanOrEqual semver.Version
+
+	// The flag will only be applied to versions after or equal to this version
+	// If it is the default value, it will have no lower bound on versions the
+	// flag is applied to
+	GreaterThanOrEqual semver.Version
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -200,14 +200,3 @@ func ConcatStrings(src []string, prefix string, postfix string) []string {
 	}
 	return ret
 }
-
-// ContainsString checks if a given slice of strings contains the provided string.
-// If a modifier func is provided, it is called with the slice item before the comparation.
-func ContainsString(slice []string, s string) bool {
-	for _, item := range slice {
-		if item == s {
-			return true
-		}
-	}
-	return false
-}

--- a/test/integration/containerd_test.go
+++ b/test/integration/containerd_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/docker/machine/libmachine/state"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	commonutil "k8s.io/minikube/pkg/util"
+	"k8s.io/minikube/pkg/kube"
 	"k8s.io/minikube/test/integration/util"
 )
 
@@ -107,13 +107,13 @@ func deleteUntrustedWorkload(t *testing.T, profile string) {
 
 // waitForGvisorControllerRunning waits for the gvisor controller pod to be running
 func waitForGvisorControllerRunning(p string) error {
-	client, err := commonutil.GetClient(p)
+	client, err := kube.Client(p)
 	if err != nil {
 		return errors.Wrap(err, "getting kubernetes client")
 	}
 
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{"kubernetes.io/minikube-addons": "gvisor"}))
-	if err := commonutil.WaitForPodsWithLabelRunning(client, "kube-system", selector); err != nil {
+	if err := kube.WaitForPodsWithLabelRunning(client, "kube-system", selector); err != nil {
 		return errors.Wrap(err, "waiting for gvisor controller pod to stabilize")
 	}
 	return nil
@@ -121,13 +121,13 @@ func waitForGvisorControllerRunning(p string) error {
 
 // waitForUntrustedNginxRunning waits for the untrusted nginx pod to start running
 func waitForUntrustedNginxRunning(miniProfile string) error {
-	client, err := commonutil.GetClient(miniProfile)
+	client, err := kube.Client(miniProfile)
 	if err != nil {
 		return errors.Wrap(err, "getting kubernetes client")
 	}
 
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{"run": "nginx"}))
-	if err := commonutil.WaitForPodsWithLabelRunning(client, "default", selector); err != nil {
+	if err := kube.WaitForPodsWithLabelRunning(client, "default", selector); err != nil {
 		return errors.Wrap(err, "waiting for nginx pods")
 	}
 	return nil

--- a/test/integration/containerd_test.go
+++ b/test/integration/containerd_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/docker/machine/libmachine/state"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/minikube/pkg/kube"
+	"k8s.io/minikube/pkg/kapi"
 	"k8s.io/minikube/test/integration/util"
 )
 
@@ -107,13 +107,13 @@ func deleteUntrustedWorkload(t *testing.T, profile string) {
 
 // waitForGvisorControllerRunning waits for the gvisor controller pod to be running
 func waitForGvisorControllerRunning(p string) error {
-	client, err := kube.Client(p)
+	client, err := kapi.Client(p)
 	if err != nil {
 		return errors.Wrap(err, "getting kubernetes client")
 	}
 
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{"kubernetes.io/minikube-addons": "gvisor"}))
-	if err := kube.WaitForPodsWithLabelRunning(client, "kube-system", selector); err != nil {
+	if err := kapi.WaitForPodsWithLabelRunning(client, "kube-system", selector); err != nil {
 		return errors.Wrap(err, "waiting for gvisor controller pod to stabilize")
 	}
 	return nil
@@ -121,13 +121,13 @@ func waitForGvisorControllerRunning(p string) error {
 
 // waitForUntrustedNginxRunning waits for the untrusted nginx pod to start running
 func waitForUntrustedNginxRunning(miniProfile string) error {
-	client, err := kube.Client(miniProfile)
+	client, err := kapi.Client(miniProfile)
 	if err != nil {
 		return errors.Wrap(err, "getting kubernetes client")
 	}
 
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{"run": "nginx"}))
-	if err := kube.WaitForPodsWithLabelRunning(client, "default", selector); err != nil {
+	if err := kapi.WaitForPodsWithLabelRunning(client, "default", selector); err != nil {
 		return errors.Wrap(err, "waiting for nginx pods")
 	}
 	return nil

--- a/test/integration/flags.go
+++ b/test/integration/flags.go
@@ -18,7 +18,6 @@ package integration
 
 import (
 	"flag"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -46,7 +45,7 @@ func NewMinikubeRunner(t *testing.T, profile string, extraStartArgs ...string) u
 	return util.MinikubeRunner{
 		Profile:      profile,
 		BinaryPath:   *binaryPath,
-		StartArgs:    *startArgs + fmt.Sprintf(" --wait-timeout=%s ", *startTimeout/2) + strings.Join(extraStartArgs, " "), // adding timeout per component
+		StartArgs:    *startArgs + " --wait-timeout=13m " + strings.Join(extraStartArgs, " "), // adding timeout per component
 		GlobalArgs:   *globalArgs,
 		MountArgs:    *mountArgs,
 		TimeOutStart: *startTimeout, // timeout for all start

--- a/test/integration/flags.go
+++ b/test/integration/flags.go
@@ -18,6 +18,7 @@ package integration
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -32,7 +33,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-var startTimeout = flag.Int("timeout", 25, "number of minutes to wait for minikube start")
+var startTimeout = flag.Duration("timeout", 25*time.Minute, "max duration to wait for a full minikube start")
 var binaryPath = flag.String("binary", "../../out/minikube", "path to minikube binary")
 var globalArgs = flag.String("minikube-args", "", "Arguments to pass to minikube")
 var startArgs = flag.String("minikube-start-args", "", "Arguments to pass to minikube start")
@@ -45,10 +46,10 @@ func NewMinikubeRunner(t *testing.T, profile string, extraStartArgs ...string) u
 	return util.MinikubeRunner{
 		Profile:      profile,
 		BinaryPath:   *binaryPath,
-		StartArgs:    *startArgs + " " + strings.Join(extraStartArgs, " "),
+		StartArgs:    *startArgs + fmt.Sprintf(" --wait-timeout=%s ", *startTimeout/2) + strings.Join(extraStartArgs, " "), // adding timeout per component
 		GlobalArgs:   *globalArgs,
 		MountArgs:    *mountArgs,
-		TimeOutStart: time.Duration(*startTimeout) * time.Minute,
+		TimeOutStart: *startTimeout, // timeout for all start
 		T:            t,
 	}
 }

--- a/test/integration/fn_addons.go
+++ b/test/integration/fn_addons.go
@@ -34,8 +34,7 @@ import (
 
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	"k8s.io/apimachinery/pkg/labels"
-	commonutil "k8s.io/minikube/pkg/util"
-	pkgutil "k8s.io/minikube/pkg/util"
+	"k8s.io/minikube/pkg/kube"
 	"k8s.io/minikube/pkg/util/retry"
 	"k8s.io/minikube/test/integration/util"
 )
@@ -43,12 +42,12 @@ import (
 func testAddons(t *testing.T) {
 	t.Parallel()
 	p := profileName(t)
-	client, err := pkgutil.GetClient(p)
+	client, err := kube.Client(p)
 	if err != nil {
 		t.Fatalf("Could not get kubernetes client: %v", err)
 	}
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{"component": "kube-addon-manager"}))
-	if err := pkgutil.WaitForPodsWithLabelRunning(client, "kube-system", selector); err != nil {
+	if err := kube.WaitForPodsWithLabelRunning(client, "kube-system", selector); err != nil {
 		t.Errorf("Error waiting for addon manager to be up")
 	}
 }
@@ -193,22 +192,22 @@ func testRegistry(t *testing.T) {
 	p := profileName(t)
 	mk := NewMinikubeRunner(t, p)
 	mk.RunCommand("addons enable registry", true)
-	client, err := pkgutil.GetClient(p)
+	client, err := kube.Client(p)
 	if err != nil {
 		t.Fatalf("getting kubernetes client: %v", err)
 	}
-	if err := pkgutil.WaitForRCToStabilize(client, "kube-system", "registry", time.Minute*5); err != nil {
+	if err := kube.WaitForRCToStabilize(client, "kube-system", "registry", time.Minute*5); err != nil {
 		t.Fatalf("waiting for registry replicacontroller to stabilize: %v", err)
 	}
 	rs := labels.SelectorFromSet(labels.Set(map[string]string{"actual-registry": "true"}))
-	if err := pkgutil.WaitForPodsWithLabelRunning(client, "kube-system", rs); err != nil {
+	if err := kube.WaitForPodsWithLabelRunning(client, "kube-system", rs); err != nil {
 		t.Fatalf("waiting for registry pods: %v", err)
 	}
 	ps, err := labels.Parse("kubernetes.io/minikube-addons=registry,actual-registry!=true")
 	if err != nil {
 		t.Fatalf("Unable to parse selector: %v", err)
 	}
-	if err := pkgutil.WaitForPodsWithLabelRunning(client, "kube-system", ps); err != nil {
+	if err := kube.WaitForPodsWithLabelRunning(client, "kube-system", ps); err != nil {
 		t.Fatalf("waiting for registry-proxy pods: %v", err)
 	}
 	ip, stderr := mk.RunCommand("ip", true)
@@ -265,18 +264,18 @@ func testRegistry(t *testing.T) {
 
 // waitForNginxRunning waits for nginx service to be up
 func waitForNginxRunning(t *testing.T, miniProfile string) error {
-	client, err := commonutil.GetClient(miniProfile)
+	client, err := kube.Client(miniProfile)
 
 	if err != nil {
 		return errors.Wrap(err, "getting kubernetes client")
 	}
 
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{"run": "nginx"}))
-	if err := commonutil.WaitForPodsWithLabelRunning(client, "default", selector); err != nil {
+	if err := kube.WaitForPodsWithLabelRunning(client, "default", selector); err != nil {
 		return errors.Wrap(err, "waiting for nginx pods")
 	}
 
-	if err := commonutil.WaitForService(client, "default", "nginx", true, time.Millisecond*500, time.Minute*10); err != nil {
+	if err := kube.WaitForService(client, "default", "nginx", true, time.Millisecond*500, time.Minute*10); err != nil {
 		t.Errorf("Error waiting for nginx service to be up")
 	}
 	return nil
@@ -284,17 +283,17 @@ func waitForNginxRunning(t *testing.T, miniProfile string) error {
 
 // waitForIngressControllerRunning waits until ingress controller pod to be running
 func waitForIngressControllerRunning(miniProfile string) error {
-	client, err := commonutil.GetClient(miniProfile)
+	client, err := kube.Client(miniProfile)
 	if err != nil {
 		return errors.Wrap(err, "getting kubernetes client")
 	}
 
-	if err := commonutil.WaitForDeploymentToStabilize(client, "kube-system", "nginx-ingress-controller", time.Minute*10); err != nil {
+	if err := kube.WaitForDeploymentToStabilize(client, "kube-system", "nginx-ingress-controller", time.Minute*10); err != nil {
 		return errors.Wrap(err, "waiting for ingress-controller deployment to stabilize")
 	}
 
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{"app.kubernetes.io/name": "nginx-ingress-controller"}))
-	if err := commonutil.WaitForPodsWithLabelRunning(client, "kube-system", selector); err != nil {
+	if err := kube.WaitForPodsWithLabelRunning(client, "kube-system", selector); err != nil {
 		return errors.Wrap(err, "waiting for ingress-controller pods")
 	}
 

--- a/test/integration/fn_cluster_dns.go
+++ b/test/integration/fn_cluster_dns.go
@@ -26,7 +26,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/minikube/pkg/kube"
+	"k8s.io/minikube/pkg/kapi"
 	"k8s.io/minikube/pkg/util/retry"
 	"k8s.io/minikube/test/integration/util"
 )
@@ -34,7 +34,7 @@ import (
 func testClusterDNS(t *testing.T) {
 	t.Parallel()
 	p := profileName(t)
-	client, err := kube.Client(p)
+	client, err := kapi.Client(p)
 	if err != nil {
 		t.Fatalf("Error getting kubernetes client %v", err)
 	}

--- a/test/integration/fn_cluster_dns.go
+++ b/test/integration/fn_cluster_dns.go
@@ -26,7 +26,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	pkgutil "k8s.io/minikube/pkg/util"
+	"k8s.io/minikube/pkg/kube"
 	"k8s.io/minikube/pkg/util/retry"
 	"k8s.io/minikube/test/integration/util"
 )
@@ -34,7 +34,7 @@ import (
 func testClusterDNS(t *testing.T) {
 	t.Parallel()
 	p := profileName(t)
-	client, err := pkgutil.GetClient(p)
+	client, err := kube.Client(p)
 	if err != nil {
 		t.Fatalf("Error getting kubernetes client %v", err)
 	}

--- a/test/integration/fn_mount.go
+++ b/test/integration/fn_mount.go
@@ -29,7 +29,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
-	pkgutil "k8s.io/minikube/pkg/util"
+	"k8s.io/minikube/pkg/kube"
 	"k8s.io/minikube/pkg/util/lock"
 	"k8s.io/minikube/pkg/util/retry"
 	"k8s.io/minikube/test/integration/util"
@@ -132,12 +132,12 @@ func writeFilesFromHost(mountedDir string, files []string, content string) error
 }
 
 func waitForPods(s map[string]string, profile string) error {
-	client, err := pkgutil.GetClient(profile)
+	client, err := kube.Client(profile)
 	if err != nil {
 		return fmt.Errorf("getting kubernetes client: %v", err)
 	}
 	selector := labels.SelectorFromSet(labels.Set(s))
-	if err := pkgutil.WaitForPodsWithLabelRunning(client, "default", selector); err != nil {
+	if err := kube.WaitForPodsWithLabelRunning(client, "default", selector); err != nil {
 		return err
 	}
 	return nil

--- a/test/integration/fn_mount.go
+++ b/test/integration/fn_mount.go
@@ -29,7 +29,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/minikube/pkg/kube"
+	"k8s.io/minikube/pkg/kapi"
 	"k8s.io/minikube/pkg/util/lock"
 	"k8s.io/minikube/pkg/util/retry"
 	"k8s.io/minikube/test/integration/util"
@@ -132,12 +132,12 @@ func writeFilesFromHost(mountedDir string, files []string, content string) error
 }
 
 func waitForPods(s map[string]string, profile string) error {
-	client, err := kube.Client(profile)
+	client, err := kapi.Client(profile)
 	if err != nil {
 		return fmt.Errorf("getting kubernetes client: %v", err)
 	}
 	selector := labels.SelectorFromSet(labels.Set(s))
-	if err := kube.WaitForPodsWithLabelRunning(client, "default", selector); err != nil {
+	if err := kapi.WaitForPodsWithLabelRunning(client, "default", selector); err != nil {
 		return err
 	}
 	return nil

--- a/test/integration/fn_pv.go
+++ b/test/integration/fn_pv.go
@@ -29,7 +29,7 @@ import (
 	core "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	commonutil "k8s.io/minikube/pkg/util"
+	"k8s.io/minikube/pkg/kube"
 	"k8s.io/minikube/pkg/util/retry"
 	"k8s.io/minikube/test/integration/util"
 )
@@ -73,13 +73,13 @@ func testProvisioning(t *testing.T) {
 	// Check that the storage provisioner pod is running
 
 	checkPodRunning := func() error {
-		client, err := commonutil.GetClient(p)
+		client, err := kube.Client(p)
 		if err != nil {
 			return errors.Wrap(err, "getting kubernetes client")
 		}
 		selector := labels.SelectorFromSet(labels.Set(map[string]string{"integration-test": "storage-provisioner"}))
 
-		if err := commonutil.WaitForPodsWithLabelRunning(client, "kube-system", selector); err != nil {
+		if err := kube.WaitForPodsWithLabelRunning(client, "kube-system", selector); err != nil {
 			return err
 		}
 		return nil

--- a/test/integration/fn_pv.go
+++ b/test/integration/fn_pv.go
@@ -29,7 +29,7 @@ import (
 	core "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/minikube/pkg/kube"
+	"k8s.io/minikube/pkg/kapi"
 	"k8s.io/minikube/pkg/util/retry"
 	"k8s.io/minikube/test/integration/util"
 )
@@ -73,13 +73,13 @@ func testProvisioning(t *testing.T) {
 	// Check that the storage provisioner pod is running
 
 	checkPodRunning := func() error {
-		client, err := kube.Client(p)
+		client, err := kapi.Client(p)
 		if err != nil {
 			return errors.Wrap(err, "getting kubernetes client")
 		}
 		selector := labels.SelectorFromSet(labels.Set(map[string]string{"integration-test": "storage-provisioner"}))
 
-		if err := kube.WaitForPodsWithLabelRunning(client, "kube-system", selector); err != nil {
+		if err := kapi.WaitForPodsWithLabelRunning(client, "kube-system", selector); err != nil {
 			return err
 		}
 		return nil

--- a/test/integration/fn_tunnel.go
+++ b/test/integration/fn_tunnel.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/minikube/pkg/kube"
+	"k8s.io/minikube/pkg/kapi"
 	"k8s.io/minikube/pkg/minikube/tunnel"
 	"k8s.io/minikube/pkg/util/retry"
 	"k8s.io/minikube/test/integration/util"
@@ -70,18 +70,18 @@ func testTunnel(t *testing.T) {
 		t.Fatalf("creating nginx ingress resource: %s", err)
 	}
 
-	client, err := kube.Client(p)
+	client, err := kapi.Client(p)
 
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "getting kubernetes client"))
 	}
 
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{"run": "nginx-svc"}))
-	if err := kube.WaitForPodsWithLabelRunning(client, "default", selector); err != nil {
+	if err := kapi.WaitForPodsWithLabelRunning(client, "default", selector); err != nil {
 		t.Fatal(errors.Wrap(err, "waiting for nginx pods"))
 	}
 
-	if err := kube.WaitForService(client, "default", "nginx-svc", true, 1*time.Second, 2*time.Minute); err != nil {
+	if err := kapi.WaitForService(client, "default", "nginx-svc", true, 1*time.Second, 2*time.Minute); err != nil {
 		t.Fatal(errors.Wrap(err, "Error waiting for nginx service to be up"))
 	}
 
@@ -121,7 +121,7 @@ func getIngress(kr *util.KubectlRunner) (string, error) {
 		case err == nil:
 			nginxIP = string(stdout)
 			return len(stdout) != 0, nil
-		case !kube.IsRetryableAPIError(err):
+		case !kapi.IsRetryableAPIError(err):
 			ret = fmt.Errorf("`%s` failed with non retriable error: %v", cmd, err)
 			return false, err
 		default:

--- a/test/integration/util/common.go
+++ b/test/integration/util/common.go
@@ -23,17 +23,17 @@ import (
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/minikube/pkg/kube"
+	"k8s.io/minikube/pkg/kapi"
 )
 
 // WaitForBusyboxRunning waits until busybox pod to be running
 func WaitForBusyboxRunning(t *testing.T, namespace string, miniProfile string) error {
-	client, err := kube.Client(miniProfile)
+	client, err := kapi.Client(miniProfile)
 	if err != nil {
 		return errors.Wrap(err, "getting kubernetes client")
 	}
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{"integration-test": "busybox"}))
-	return kube.WaitForPodsWithLabelRunning(client, namespace, selector)
+	return kapi.WaitForPodsWithLabelRunning(client, namespace, selector)
 }
 
 // Logf writes logs to stdout if -v is set.

--- a/test/integration/util/common.go
+++ b/test/integration/util/common.go
@@ -23,17 +23,17 @@ import (
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	commonutil "k8s.io/minikube/pkg/util"
+	"k8s.io/minikube/pkg/kube"
 )
 
 // WaitForBusyboxRunning waits until busybox pod to be running
 func WaitForBusyboxRunning(t *testing.T, namespace string, miniProfile string) error {
-	client, err := commonutil.GetClient(miniProfile)
+	client, err := kube.Client(miniProfile)
 	if err != nil {
 		return errors.Wrap(err, "getting kubernetes client")
 	}
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{"integration-test": "busybox"}))
-	return commonutil.WaitForPodsWithLabelRunning(client, namespace, selector)
+	return kube.WaitForPodsWithLabelRunning(client, namespace, selector)
 }
 
 // Logf writes logs to stdout if -v is set.

--- a/test/integration/util/minikube_runner.go
+++ b/test/integration/util/minikube_runner.go
@@ -244,7 +244,7 @@ func (m *MinikubeRunner) TearDown(t *testing.T) {
 	profileArg := fmt.Sprintf("-p=%s", m.Profile)
 	path, _ := filepath.Abs(m.BinaryPath)
 	cmd := exec.Command(path, profileArg, "delete")
-	err := cmd.Start()
+	err := cmd.Start() // don't wait for it to finish
 	if err != nil {
 		t.Errorf("error tearing down minikube %s : %v", profileArg, err)
 	}


### PR DESCRIPTION
 - Removes more than a few unused functions such as :
    - NewPodStore, StartPods, WaitForPodDelete, WaitForEvent , WaitForServiceEndpointsNum, VersionedExtraOption
-  Moves funcs out of `pkg/utils` into `pgk/kube`.
-  Moves `ExtraOptions` type and its funcs from `pkg/util` to `pkg/minikube/config` package. and Rename  func `.ContainsString` to `.ContainsParam`
- Choose better timeout based on [kubernetes consts](https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/constants/constants.go#L187)
- Added logs for how long it took for each component and k8s-app to come up ( to be used later to fine-tune our default waiting time) which will appear in the logs like  : 
     ```
      kube.go:103] duration metric: took 1m17.514019465s to wait for component=etcd ...
      kube.go:103] duration metric: took 7.289066ms to wait for component=kube-scheduler ...
    ```

- Added a new flag for start cmd  `wait-timeout` that specifies max `wait per component`.
- Reduced the default `wait per component` from 5 minutes to 3 minutes for end users
- Increase default `wait per component` from 5 minutes to  13 minutes for parallel integration tests. 
- Parameterized integration tests to accept `wait-timeout`
- Fixed the test setup for givsor test which was put after the e2e test run. moved up the script.

Closes https://github.com/kubernetes/minikube/issues/5122
and Hopefully reduces some test flakes due to timeout  


---
topics I like to know the reviewer's opinion on :
- name of the package, "kube" vs "kubernetes"
- path of package,  current: "k8s.io/minikube/pkg/kube" vs "k8s.io/minikube/pkg/util/kube"

--- 
### Golang Parallel Test logging gotcha! :

I was hoping to see the duration metric logs in the tests ! 
```
	elapsed := time.Since(start)
       glog.Infof("duration metric: took %s to wait for %s ...", elapsed, label)
```

but I found out sometimes it doesn't log at all and sometimes logs at most 2 sets of them. 

- KMV logs shows only two sets of duration metrics https://storage.googleapis.com/minikube-builds/logs/5121/KVM_Linux.txt
- Hyperkit logs showed no duration metric at all !!! https://storage.googleapis.com/minikube-builds/logs/5121/HyperKit_macOS.txt   (the logs might be overwritten by the next commit)

That makes me believe golang only outputs the not PAUSED Tests and the paused tests (which their VM still are running and our wait for running func is still working on them) will not output to the logs.  I created an issue in golang to track this : https://github.com/golang/go/issues/33706