### PR TITLE
Altered root user check for vm-driver=none

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -503,7 +503,7 @@ func validateUser() {
 	d := viper.GetString(vmDriver)
 	// Check if minikube needs to run with sudo or not.
 	if err == nil {
-		if d == constants.DriverNone && u.Name != "root" {
+		if d == constants.DriverNone && u.Username != "root" {
 			exit.UsageT(`Please run with sudo. the vm-driver "{{.driver_name}}" requires sudo.`, out.V{"driver_name": constants.DriverNone})
 		} else if u.Name == "root" && !(d == constants.DriverHyperv || d == constants.DriverNone) {
 			out.T(out.WarningType, "Please don't run minikube as root or with 'sudo' privileges. It isn't necessary with {{.driver}} driver.", out.V{"driver": d})


### PR DESCRIPTION
Altered current user check to use user.Username as some distro's don't have the "Name" set. This caused me to "add" root to the root user on ArchLinux:

root:x:0:0:**thiscanbeanything**:/root:/bin/bash