### PR TITLE
skip gvisor test setup on mac

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -72,7 +72,7 @@ gsutil -qm cp \
   "gs://minikube-builds/${MINIKUBE_LOCATION}/minikube-${OS_ARCH}" \
   "gs://minikube-builds/${MINIKUBE_LOCATION}/docker-machine-driver"-* \
   "gs://minikube-builds/${MINIKUBE_LOCATION}/e2e-${OS_ARCH}" \
-  "gs://minikube-builds/${MINIKUBE_LOCATION}/gvisor-addon" out
+  "gs://minikube-builds/${MINIKUBE_LOCATION}/gvisor-addon" testdata/
 
 gsutil -qm cp "gs://minikube-builds/${MINIKUBE_LOCATION}/testdata"/* testdata/
 
@@ -266,7 +266,7 @@ export KUBECONFIG="${TEST_HOME}/kubeconfig"
 # Used by TestContainerd for Gvisor Test.
 # TODO: move this to integration test setup.
 chmod +x ./out/gvisor-addon
-docker build -t gcr.io/k8s-minikube/gvisor-addon:latest -f testdata/gvisor-addon-Dockerfile ./out
+docker build -t gcr.io/k8s-minikube/gvisor-addon:latest -f testdata/gvisor-addon-Dockerfile ./testdata
 
 
 # Display the default image URL

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -267,10 +267,10 @@ export KUBECONFIG="${TEST_HOME}/kubeconfig"
 # Used by TestContainerd for Gvisor Test.
 # TODO: move this to integration test setup.
 chmod +x ./testdata/gvisor-addon
-# skipping gvisor setup on mac because ofg https://github.com/kubernetes/minikube/issues/5137
-# if [ "$(uname)" != "Darwin" ]; then
-cd testdata && docker build -t gcr.io/k8s-minikube/gvisor-addon:latest -f gvisor-addon-Dockerfile .
-# fi
+# skipping gvisor mac because ofg https://github.com/kubernetes/minikube/issues/5137
+if [ "$(uname)" != "Darwin" ]; then
+  docker build -t gcr.io/k8s-minikube/gvisor-addon:latest -f testdata/gvisor-addon-Dockerfile ./testdata
+fi
 
 
 # Display the default image URL

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -264,7 +264,9 @@ export KUBECONFIG="${TEST_HOME}/kubeconfig"
 
 # Build the gvisor image. This will be copied into minikube and loaded by ctr.
 # Used by TestContainerd for Gvisor Test.
-docker build -t gcr.io/k8s-minikube/gvisor-addon:latest -f testdata/gvisor-addon-Dockerfile out
+# TODO: move this to integration test setup.
+chmod +x ./out/gvisor-addon
+docker build -t gcr.io/k8s-minikube/gvisor-addon:latest -f testdata/gvisor-addon-Dockerfile ./out
 
 
 # Display the default image URL

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -267,7 +267,10 @@ export KUBECONFIG="${TEST_HOME}/kubeconfig"
 # Used by TestContainerd for Gvisor Test.
 # TODO: move this to integration test setup.
 chmod +x ./testdata/gvisor-addon
-docker build -t gcr.io/k8s-minikube/gvisor-addon:latest -f testdata/gvisor-addon-Dockerfile ./testdata
+# skipping gvisor setup on mac because ofg https://github.com/kubernetes/minikube/issues/5137
+# if [ "$(uname)" != "Darwin" ]; then
+cd testdata && docker build -t gcr.io/k8s-minikube/gvisor-addon:latest -f gvisor-addon-Dockerfile 
+# fi
 
 
 # Display the default image URL

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -71,10 +71,11 @@ echo ">> Downloading test inputs from ${MINIKUBE_LOCATION} ..."
 gsutil -qm cp \
   "gs://minikube-builds/${MINIKUBE_LOCATION}/minikube-${OS_ARCH}" \
   "gs://minikube-builds/${MINIKUBE_LOCATION}/docker-machine-driver"-* \
-  "gs://minikube-builds/${MINIKUBE_LOCATION}/e2e-${OS_ARCH}" \
-  "gs://minikube-builds/${MINIKUBE_LOCATION}/gvisor-addon" testdata/
+  "gs://minikube-builds/${MINIKUBE_LOCATION}/e2e-${OS_ARCH}" out
 
 gsutil -qm cp "gs://minikube-builds/${MINIKUBE_LOCATION}/testdata"/* testdata/
+
+gsutil -qm cp "gs://minikube-builds/${MINIKUBE_LOCATION}/gvisor-addon" testdata/
 
 
 # Set the executable bit on the e2e binary and out binary

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -266,7 +266,7 @@ export KUBECONFIG="${TEST_HOME}/kubeconfig"
 # Build the gvisor image. This will be copied into minikube and loaded by ctr.
 # Used by TestContainerd for Gvisor Test.
 # TODO: move this to integration test setup.
-chmod +x ./out/gvisor-addon
+chmod +x ./testdata/gvisor-addon
 docker build -t gcr.io/k8s-minikube/gvisor-addon:latest -f testdata/gvisor-addon-Dockerfile ./testdata
 
 

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -269,7 +269,7 @@ export KUBECONFIG="${TEST_HOME}/kubeconfig"
 chmod +x ./testdata/gvisor-addon
 # skipping gvisor setup on mac because ofg https://github.com/kubernetes/minikube/issues/5137
 # if [ "$(uname)" != "Darwin" ]; then
-cd testdata && docker build -t gcr.io/k8s-minikube/gvisor-addon:latest -f gvisor-addon-Dockerfile 
+cd testdata && docker build -t gcr.io/k8s-minikube/gvisor-addon:latest -f gvisor-addon-Dockerfile .
 # fi
 
 


### PR DESCRIPTION
side effect of https://github.com/kubernetes/minikube/pull/4717

for now have to skip givsor setup for mac. (note it was not running before) this fix will make at least run for linux hosts

hopefully fixes https://github.com/kubernetes/minikube/issues/5137