### PR TITLE
WIP:  add mailing list and groups details to community page

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -116,9 +116,19 @@ no = 'Sorry to hear that. Please <a href="https://github.com/kubernetes/minikube
 	icon = "fab fa-slack"
     desc = "Chat with other minikube users & developers"
 
+	name = "minikube-users mailing list"
+	url = "https://groups.google.com/forum/#!forum/minikube-users"
+	icon = "fa fa-envelope"
+	desc = "Minikube mailing list for users"
+
 # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
 [[params.links.developer]]
 	name = "GitHub"
 	url = "https://github.com/kubernetes/minikube"
 	icon = "fab fa-github"
         desc = "Development takes place here!"
+
+	name = "minikube-dev mailing list"
+	url = "https://groups.google.com/forum/#!forum/minikube-dev"
+	icon = "fa fa-envelope"
+	desc = "Minikube mailing list for developers"


### PR DESCRIPTION
Site: add mailing list and groups details to community page
fixes https://github.com/kubernetes/minikube/issues/5132