### PR TITLE
Fixes broken Overview: links as per #5156

### DIFF
--- a/site/content/en/docs/Overview/_index.md
+++ b/site/content/en/docs/Overview/_index.md
@@ -45,5 +45,5 @@ Then minikube is for you.
 
 ## Where should I go next?
 
-* [Getting Started](/start/): Get started with minikube
-* [Examples](/examples/): Check out some minikube examples!
+* [Getting Started](/docs/start/): Get started with minikube
+* [Examples](/docs/examples/): Check out some minikube examples!


### PR DESCRIPTION
Changed links in overview page to include `/docs` for the broken links. This fixes issue #5156 