### PR TITLE
Fix docker-machine{-driver,}-parallels doc typo

### DIFF
--- a/site/content/en/docs/Reference/Drivers/includes/parallels_usage.inc
+++ b/site/content/en/docs/Reference/Drivers/includes/parallels_usage.inc
@@ -7,7 +7,7 @@
 If the [Brew Package Manager](https://brew.sh/) is installed, run:
 
 ```shell
-brew install docker-machine-driver-parallels
+brew install docker-machine-parallels
 ```
 
 Otherwise:


### PR DESCRIPTION
I tried:
    brew install docker-machine-driver-parallels
which didn't work.  I went to https://github.com/Parallels/docker-machine-parallels
and saw the above should have been:
    brew install docker-machine-parallels
which I tried and it worked.