### PR TITLE
Fix broken TestDownloadOnly test, remove broken Test_defaultDiskSize test.

### DIFF
--- a/pkg/drivers/hyperkit/driver_test.go
+++ b/pkg/drivers/hyperkit/driver_test.go
@@ -20,10 +20,6 @@ package hyperkit
 
 import (
 	"testing"
-
-	"k8s.io/minikube/pkg/minikube/constants"
-
-	commonutil "k8s.io/minikube/pkg/util"
 )
 
 func Test_portExtraction(t *testing.T) {
@@ -63,15 +59,6 @@ func Test_portExtraction(t *testing.T) {
 		if gotErr != tt.wantErr {
 			t.Errorf("extractVSockPorts() gotErr: %s, wantErr: %s", gotErr.Error(), tt.wantErr.Error())
 		}
-	}
-}
-
-func Test_defaultDiskSize(t *testing.T) {
-	expectedDefaultDiscSize := commonutil.CalculateSizeInMB(constants.DefaultDiskSize)
-	driver := NewDriver("", "")
-	got := driver.DiskSize
-	if got != expectedDefaultDiscSize {
-		t.Errorf("Unexpected default disk size got: %v, want: %v", got, expectedDefaultDiscSize)
 	}
 }
 

--- a/test/integration/a_download_only_test.go
+++ b/test/integration/a_download_only_test.go
@@ -65,7 +65,7 @@ func TestDownloadOnly(t *testing.T) {
 				}
 
 				// checking binaries downloaded (kubelet,kubeadm)
-				for _, bin := range constants.GetKubeadmCachedBinaries() {
+				for _, bin := range constants.KubeadmBinaries {
 					fp := filepath.Join(minHome, "cache", v, bin)
 					_, err := os.Stat(fp)
 					if err != nil {


### PR DESCRIPTION
I suspect the hyperkit test broke when we seperated the hyperkit driver out from minikube's infrastructure. It didn't make a whole lot of sense to me anyways.

Closes #5176