### PR TITLE
Windows: Use path.Join for VM paths, fall-back to anon image downloads

### DIFF
--- a/pkg/minikube/assets/vm_assets.go
+++ b/pkg/minikube/assets/vm_assets.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"path/filepath"
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"

--- a/pkg/minikube/assets/vm_assets.go
+++ b/pkg/minikube/assets/vm_assets.go
@@ -80,7 +80,7 @@ func NewMemoryAssetTarget(d []byte, targetPath, permissions string) *MemoryAsset
 
 // NewFileAsset creates a new FileAsset
 func NewFileAsset(src, targetDir, targetName, permissions string) (*FileAsset, error) {
-	glog.Infof("NewFileAsset: %s -> %s", src, filepath.Join(targetDir, targetName))
+	glog.Infof("NewFileAsset: %s -> %s", src, path.Join(targetDir, targetName))
 	f, err := os.Open(src)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error opening file asset: %s", src)

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -19,10 +19,12 @@ package kubeadm
 import (
 	"bytes"
 	"crypto/tls"
+
+	// WARNING: Do not use filepath here unless you want bizarre paths to be used in Windows
 	"fmt"
 	"net"
 	"net/http"
-	"path/filepath"
+	"path"
 	"runtime"
 	"strings"
 	"time"
@@ -95,7 +97,7 @@ var PodsByLayer = []pod{
 }
 
 // yamlConfigPath is the path to the kubeadm configuration
-var yamlConfigPath = filepath.Join(constants.GuestEphemeralDir, "kubeadm.yaml")
+var yamlConfigPath = path.Join(constants.GuestEphemeralDir, "kubeadm.yaml")
 
 // SkipAdditionalPreflights are additional preflights we skip depending on the runtime in use.
 var SkipAdditionalPreflights = map[string][]string{}
@@ -200,7 +202,7 @@ func createFlagsFromExtraArgs(extraOptions config.ExtraOptionSlice) string {
 
 // etcdDataDir is where etcd data is stored.
 func etcdDataDir() string {
-	return filepath.Join(constants.GuestPersistentDir, "etcd")
+	return path.Join(constants.GuestPersistentDir, "etcd")
 }
 
 // createCompatSymlinks creates compatibility symlinks to transition running services to new directory structures
@@ -538,7 +540,7 @@ func NewKubeletConfig(k8s config.KubernetesConfig, r cruntime.Manager) ([]byte, 
 	}{
 		ExtraOptions:     convertToFlags(extraOpts),
 		ContainerRuntime: k8s.ContainerRuntime,
-		KubeletPath:      filepath.Join(binRoot(k8s.KubernetesVersion), "kubelet"),
+		KubeletPath:      path.Join(binRoot(k8s.KubernetesVersion), "kubelet"),
 	}
 	if err := kubeletSystemdTemplate.Execute(&b, opts); err != nil {
 		return nil, err
@@ -700,7 +702,7 @@ func generateConfig(k8s config.KubernetesConfig, r cruntime.Manager) ([]byte, er
 // NewKubeletService returns a generated systemd unit file for the kubelet
 func NewKubeletService(cfg config.KubernetesConfig) ([]byte, error) {
 	var b bytes.Buffer
-	opts := struct{ KubeletPath string }{KubeletPath: filepath.Join(binRoot(cfg.KubernetesVersion), "kubelet")}
+	opts := struct{ KubeletPath string }{KubeletPath: path.Join(binRoot(cfg.KubernetesVersion), "kubelet")}
 	if err := kubeletServiceTemplate.Execute(&b, opts); err != nil {
 		return nil, errors.Wrap(err, "template execute")
 	}
@@ -725,7 +727,7 @@ func configFiles(cfg config.KubernetesConfig, kubeadm []byte, kubelet []byte, ku
 
 // binDir returns the persistent path binaries are stored in
 func binRoot(version string) string {
-	return filepath.Join(constants.GuestPersistentDir, "binaries", version)
+	return path.Join(constants.GuestPersistentDir, "binaries", version)
 }
 
 // invokeKubeadm returns the invocation command for Kubeadm
@@ -744,7 +746,7 @@ func transferBinaries(cfg config.KubernetesConfig, c command.Runner) error {
 				return errors.Wrapf(err, "downloading %s", name)
 			}
 
-			dst := filepath.Join(binRoot(cfg.KubernetesVersion), name)
+			dst := path.Join(binRoot(cfg.KubernetesVersion), name)
 			if err := machine.CopyBinary(c, src, dst); err != nil {
 				return errors.Wrapf(err, "copybinary %s -> %s", src, dst)
 			}

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -20,10 +20,11 @@ import (
 	"bytes"
 	"crypto/tls"
 
-	// WARNING: Do not use filepath here unless you want bizarre paths to be used in Windows
 	"fmt"
 	"net"
 	"net/http"
+
+	// WARNING: Do not use path/filepath in this package unless you want bizarre Windows paths
 	"path"
 	"runtime"
 	"strings"

--- a/pkg/minikube/command/command_runner.go
+++ b/pkg/minikube/command/command_runner.go
@@ -19,7 +19,7 @@ package command
 import (
 	"fmt"
 	"io"
-	"path/filepath"
+	"path"
 
 	"k8s.io/minikube/pkg/minikube/assets"
 )
@@ -54,5 +54,5 @@ type Runner interface {
 }
 
 func getDeleteFileCommand(f assets.CopyableFile) string {
-	return fmt.Sprintf("sudo rm %s", filepath.Join(f.GetTargetDir(), f.GetTargetName()))
+	return fmt.Sprintf("sudo rm %s", path.Join(f.GetTargetDir(), f.GetTargetName()))
 }

--- a/pkg/minikube/command/exec_runner.go
+++ b/pkg/minikube/command/exec_runner.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strconv"
 
@@ -76,7 +77,7 @@ func (*ExecRunner) Copy(f assets.CopyableFile) error {
 	if err := os.MkdirAll(f.GetTargetDir(), os.ModePerm); err != nil {
 		return errors.Wrapf(err, "error making dirs for %s", f.GetTargetDir())
 	}
-	targetPath := filepath.Join(f.GetTargetDir(), f.GetTargetName())
+	targetPath := path.Join(f.GetTargetDir(), f.GetTargetName())
 	if _, err := os.Stat(targetPath); err == nil {
 		if err := os.Remove(targetPath); err != nil {
 			return errors.Wrapf(err, "error removing file %s", targetPath)

--- a/pkg/minikube/command/ssh_runner.go
+++ b/pkg/minikube/command/ssh_runner.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"path"
-	"path/filepath"
 	"sync"
 
 	"github.com/golang/glog"
@@ -167,7 +166,7 @@ func (s *SSHRunner) Copy(f assets.CopyableFile) error {
 	// StdinPipe is closed. But let's use errgroup to make it explicit.
 	var g errgroup.Group
 	var copied int64
-	dst := filepath.Join(path.Join(f.GetTargetDir(), f.GetTargetName()))
+	dst := path.Join(path.Join(f.GetTargetDir(), f.GetTargetName()))
 	glog.Infof("Transferring %d bytes to %s", f.GetLength(), dst)
 
 	g.Go(func() error {

--- a/pkg/minikube/machine/cache_binaries.go
+++ b/pkg/minikube/machine/cache_binaries.go
@@ -20,7 +20,6 @@ import (
 	"crypto"
 	"os"
 	"path"
-	"path/filepath"
 	"runtime"
 
 	"github.com/golang/glog"
@@ -93,7 +92,7 @@ func CacheBinary(binary, version, osName, archName string) (string, error) {
 
 // CopyBinary copies a locally cached binary to the guest VM
 func CopyBinary(cr command.Runner, src string, dest string) error {
-	f, err := assets.NewFileAsset(src, filepath.Dir(dest), filepath.Base(dest), "0755")
+	f, err := assets.NewFileAsset(src, path.Dir(dest), path.Base(dest), "0755")
 	if err != nil {
 		return errors.Wrap(err, "new file asset")
 	}

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -44,7 +44,7 @@ import (
 )
 
 // loadRoot is where images should be loaded from within the guest VM
-var loadRoot = filepath.Join(constants.GuestPersistentDir, "images")
+var loadRoot = path.Join(constants.GuestPersistentDir, "images")
 
 var getWindowsVolumeName = getWindowsVolumeNameCmd
 

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -355,12 +355,13 @@ func retrieveImage(ref name.Reference) (v1.Image, error) {
 	}
 	glog.Infof("daemon image for %+v: %v", img, err)
 	img, err = remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
-	if img, err != nil {
-		glog.Warningf("failed authn download for %+v (trying anon): %+v", ref, err)
-		img, err = remote.Image(ref)
-		if err != nil {
-			glog.Warningf("failed anon download for %+v: %+v", ref, err)
-		}
+	if err == nil {
+		return img, err
+	}
+	glog.Warningf("failed authn download for %+v (trying anon): %+v", ref, err)
+	img, err = remote.Image(ref)
+	if err != nil {
+		glog.Warningf("failed anon download for %+v: %+v", ref, err)
 	}
 	return img, err
 }

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -76,6 +76,7 @@ func CacheImages(images []string, cacheDir string) error {
 			dst := filepath.Join(cacheDir, image)
 			dst = sanitizeCacheDir(dst)
 			if err := CacheImage(image, dst); err != nil {
+				glog.Errorf("CacheImage %s -> %s failed: %v", image, dst, err)
 				return errors.Wrapf(err, "caching image %s", dst)
 			}
 			glog.Infof("CacheImage %s -> %s succeeded", image, dst)

--- a/test/integration/util/minikube_runner.go
+++ b/test/integration/util/minikube_runner.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -50,7 +51,7 @@ type MinikubeRunner struct {
 
 // Remove removes a file
 func (m *MinikubeRunner) Remove(f assets.CopyableFile) error {
-	_, err := m.SSH(fmt.Sprintf("rm -rf %s", filepath.Join(f.GetTargetDir(), f.GetTargetName())))
+	_, err := m.SSH(fmt.Sprintf("rm -rf %s", path.Join(f.GetTargetDir(), f.GetTargetName())))
 	return err
 }
 


### PR DESCRIPTION
With kubeadm, we are generating paths that must be valid inside of the Linux VM.

On Windows, `filepath.Join` uses \ instead of /

The image download fallback was required for unknown reasons on our CI machine.