### PR TITLE
Improve test coverage for proxy package

### DIFF
--- a/pkg/minikube/proxy/proxy.go
+++ b/pkg/minikube/proxy/proxy.go
@@ -57,6 +57,11 @@ func isInBlock(ip string, block string) (bool, error) {
 
 // ExcludeIP will exclude the ip from the http(s)_proxy
 func ExcludeIP(ip string) error {
+	if netIp := net.ParseIP(ip); netIp == nil {
+		if _, _, err := net.ParseCIDR(ip); err != nil {
+			return fmt.Errorf("ExcludeIP(%v) requires IP as a parameter or CIDR", ip)
+		}
+	}
 	return updateEnv(ip, "NO_PROXY")
 }
 

--- a/pkg/minikube/proxy/proxy.go
+++ b/pkg/minikube/proxy/proxy.go
@@ -55,7 +55,7 @@ func isInBlock(ip string, block string) (bool, error) {
 	return false, errors.Wrapf(err, "Error ip not in block")
 }
 
-// ExcludeIP takes ip or CIDR as string and excludes the it from the http(s)_proxy
+// ExcludeIP takes ip or CIDR as string and excludes it from the http(s)_proxy
 func ExcludeIP(ip string) error {
 	if netIP := net.ParseIP(ip); netIP == nil {
 		if _, _, err := net.ParseCIDR(ip); err != nil {

--- a/pkg/minikube/proxy/proxy.go
+++ b/pkg/minikube/proxy/proxy.go
@@ -55,7 +55,7 @@ func isInBlock(ip string, block string) (bool, error) {
 	return false, errors.Wrapf(err, "Error ip not in block")
 }
 
-// ExcludeIP will exclude the ip from the http(s)_proxy
+// ExcludeIP takes ip or CIDR as string and excludes the it from the http(s)_proxy
 func ExcludeIP(ip string) error {
 	if netIP := net.ParseIP(ip); netIP == nil {
 		if _, _, err := net.ParseCIDR(ip); err != nil {

--- a/pkg/minikube/proxy/proxy.go
+++ b/pkg/minikube/proxy/proxy.go
@@ -57,9 +57,9 @@ func isInBlock(ip string, block string) (bool, error) {
 
 // ExcludeIP will exclude the ip from the http(s)_proxy
 func ExcludeIP(ip string) error {
-	if netIp := net.ParseIP(ip); netIp == nil {
+	if netIP := net.ParseIP(ip); netIP == nil {
 		if _, _, err := net.ParseCIDR(ip); err != nil {
-			return fmt.Errorf("ExcludeIP(%v) requires IP as a parameter or CIDR", ip)
+			return fmt.Errorf("ExcludeIP(%v) requires IP or CIDR as a parameter", ip)
 		}
 	}
 	return updateEnv(ip, "NO_PROXY")

--- a/pkg/minikube/proxy/proxy_test.go
+++ b/pkg/minikube/proxy/proxy_test.go
@@ -36,11 +36,9 @@ func TestIsValidEnv(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.env, func(t *testing.T) {
-			got := isValidEnv(tc.env)
-			if got != tc.want {
+			if got := isValidEnv(tc.env); got != tc.want {
 				t.Errorf("isValidEnv(\"%v\") got %v; want %v", tc.env, got, tc.want)
 			}
-
 		})
 	}
 
@@ -140,16 +138,12 @@ func TestCheckEnv(t *testing.T) {
 				}
 			}()
 
-			// defer os.Setenv(tc.envName, originalEnv)
-			err := os.Setenv(tc.envName, tc.mockEnvValue) // setting up the test case
-			if err != nil {
+			if err := os.Setenv(tc.envName, tc.mockEnvValue); err != nil {
 				t.Error("Error setting env var for taste case")
 			}
-			got := checkEnv(tc.ip, tc.envName)
-			if got != tc.want {
+			if got := checkEnv(tc.ip, tc.envName); got != tc.want {
 				t.Errorf("CheckEnv(%v,%v) got  %v ; want is %v", tc.ip, tc.envName, got, tc.want)
 			}
-
 		})
 	}
 

--- a/pkg/minikube/proxy/proxy_test.go
+++ b/pkg/minikube/proxy/proxy_test.go
@@ -59,7 +59,7 @@ func TestIsInBlock(t *testing.T) {
 		{"192.168.0.1", "foo", false, true},
 	}
 	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("%s in %s", tc.ip, tc.block), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s in %s Want: %t WantAErr: %t", tc.ip, tc.block, tc.want, tc.wanntAErr), func(t *testing.T) {
 			got, err := isInBlock(tc.ip, tc.block)
 			gotErr := false
 			if err != nil {
@@ -90,7 +90,7 @@ func TestUpdateEnv(t *testing.T) {
 		{"192.168.0.13", "NPROXY", true},
 	}
 	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("%s in %s", tc.ip, tc.env), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s in %s WantAErr: %t", tc.ip, tc.env, tc.wantErr), func(t *testing.T) {
 			origVal := os.Getenv(tc.env)
 			gotErr := false
 			err := updateEnv(tc.ip, tc.env)

--- a/pkg/minikube/proxy/proxy_test.go
+++ b/pkg/minikube/proxy/proxy_test.go
@@ -162,14 +162,14 @@ func TestIsIPExcluded(t *testing.T) {
 		{"foo", "1.2.3.4", false},
 	}
 	for _, tc := range testCases {
+		originalEnv := os.Getenv("NO_PROXY")
+		defer func() { // revert to pre-test env var
+			err := os.Setenv("NO_PROXY", originalEnv)
+			if err != nil {
+				t.Fatalf("Error reverting env NO_PROXY to its original value (%s) var after test ", originalEnv)
+			}
+		}()
 		t.Run(fmt.Sprintf("exclude %s NO_PROXY(%v)", tc.ip, tc.env), func(t *testing.T) {
-			originalEnv := os.Getenv("NO_PROXY")
-			defer func() { // revert to pre-test env var
-				err := os.Setenv("NO_PROXY", originalEnv)
-				if err != nil {
-					t.Fatalf("Error reverting env NO_PROXY to its original value (%s) var after test ", originalEnv)
-				}
-			}()
 			if err := os.Setenv("NO_PROXY", tc.env); err != nil {
 				t.Errorf("Error during setting env: %v", err)
 			}
@@ -192,15 +192,15 @@ func TestExcludeIP(t *testing.T) {
 		{"foo", "", true},
 		{"foo", "1.2.3.4", true},
 	}
+	originalEnv := os.Getenv("NO_PROXY")
+	defer func() { // revert to pre-test env var
+		err := os.Setenv("NO_PROXY", originalEnv)
+		if err != nil {
+			t.Fatalf("Error reverting env NO_PROXY to its original value (%s) var after test ", originalEnv)
+		}
+	}()
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("exclude %s NO_PROXY(%s)", tc.ip, tc.env), func(t *testing.T) {
-			originalEnv := os.Getenv("NO_PROXY")
-			defer func() { // revert to pre-test env var
-				err := os.Setenv("NO_PROXY", originalEnv)
-				if err != nil {
-					t.Fatalf("Error reverting env NO_PROXY to its original value (%s) var after test ", originalEnv)
-				}
-			}()
 			if err := os.Setenv("NO_PROXY", tc.env); err != nil {
 				t.Errorf("Error during setting env: %v", err)
 			}


### PR DESCRIPTION
Improve test coverage in `proxy` package.
Change `ExcludeIP` to return an error if the passed argument is not `IP` or `CIDR`.