### PR TITLE
More logs: exited containers, controller manager, double line count

### DIFF
--- a/cmd/minikube/cmd/logs.go
+++ b/cmd/minikube/cmd/logs.go
@@ -97,5 +97,5 @@ var logsCmd = &cobra.Command{
 func init() {
 	logsCmd.Flags().BoolVarP(&followLogs, "follow", "f", false, "Show only the most recent journal entries, and continuously print new entries as they are appended to the journal.")
 	logsCmd.Flags().BoolVar(&showProblems, "problems", false, "Show only log entries which point to known problems")
-	logsCmd.Flags().IntVarP(&numberOfLines, "length", "n", 30, "Number of lines back to go within the log")
+	logsCmd.Flags().IntVarP(&numberOfLines, "length", "n", 60, "Number of lines back to go within the log")
 }

--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -36,7 +36,7 @@ import (
 // rootCauseRe is a regular expression that matches known failure root causes
 var rootCauseRe = regexp.MustCompile(`^error: |eviction manager: pods.* evicted|unknown flag: --|forbidden.*no providers available|eviction manager:.*evicted|tls: bad certificate|kubelet.*no API client|kubelet.*No api server|STDIN.*127.0.0.1:8080`)
 
-// ignoreRe is a regular expression that matches spurious errors to not surface
+// ignoreCauseRe is a regular expression that matches spurious errors to not surface
 var ignoreCauseRe = regexp.MustCompile("error: no objects passed to apply")
 
 // importantPods are a list of pods to retrieve logs for, in addition to the bootstrapper logs.
@@ -48,6 +48,7 @@ var importantPods = []string{
 	"kube-addon-manager",
 	"kubernetes-dashboard",
 	"storage-provisioner",
+	"kube-controller-manager",
 }
 
 // lookbackwardsCount is how far back to look in a log for problems. This should be large enough to
@@ -161,7 +162,10 @@ func logCommands(r cruntime.Manager, bs bootstrapper.Bootstrapper, length int, f
 			glog.Warningf("No container was found matching %q", pod)
 			continue
 		}
-		cmds[pod] = r.ContainerLogCmd(ids[0], length, follow)
+		for _, i := range ids {
+			key := fmt.Sprintf("%s [%s]", pod, i)
+			cmds[key] = r.ContainerLogCmd(i, length, follow)
+		}
 	}
 	cmds[r.Name()] = r.SystemLogCmd(length)
 	// Works across container runtimes with good formatting


### PR DESCRIPTION
This PR is intended to make the "logs" command more useful for solving tricky issue reports:

- Double the line count, as often many minutes occur between the failed run and "minikube logs"
- Include logs for `kube-controller-manager`
* Include logs for all containers that match, not just the first one. This includes exited containers.

Closes #5248 