### PR TITLE
Update build scripts to handle alpha/beta releases

### DIFF
--- a/hack/jenkins/release_build_and_upload.sh
+++ b/hack/jenkins/release_build_and_upload.sh
@@ -24,30 +24,33 @@
 # BUCKET: The GCP bucket the build files should be uploaded to.
 # GITHUB_TOKEN: The Github API access token. Injected by the Jenkins credential provider.
 
-set -e
-
-export TAGNAME=v${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BUILD}
-export DEB_VERSION=${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BUILD}
-export RPM_VERSION=${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BUILD}
-export GOPATH=~/go
-
-# Make sure the right golang version is installed based on Makefile
-WANT_GOLANG_VERSION=$(grep '^GO_VERSION' Makefile | awk '{ print $3 }')
-./hack/jenkins/installers/check_install_golang.sh $WANT_GOLANG_VERSION /usr/local
-
+set -eux -o pipefail
+readonly VERSION="${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BUILD}"
+readonly TAGNAME="v${VERSION}"
 
 # Make sure the tag matches the Makefile
-cat Makefile | grep "VERSION_MAJOR ?=" | grep $VERSION_MAJOR
-cat Makefile | grep "VERSION_MINOR ?=" | grep $VERSION_MINOR
-cat Makefile | grep "VERSION_BUILD ?=" | grep $VERSION_BUILD
+grep -E "^VERSION_MAJOR \\?=" Makefile | grep "${VERSION_MAJOR}"
+grep -E "^VERSION_MINOR \\?=" Makefile | grep "${VERSION_MINOR}"
+grep -E "^VERSION_BUILD \\?=" Makefile | grep "${VERSION_BUILD}"
 
 # Build and upload
-BUILD_IN_DOCKER=y make -j 16 all out/minikube-installer.exe \
-out/minikube_${DEB_VERSION}.deb out/minikube-${RPM_VERSION}.rpm \
-out/docker-machine-driver-kvm2_${DEB_VERSION}.deb out/docker-machine-driver-kvm2-${RPM_VERSION}.rpm
+env BUILD_IN_DOCKER=y \
+  make -j 16 \
+  all \
+  out/minikube-installer.exe \
+  "out/minikube_${VERSION}.deb" \
+  "out/minikube-${VERSION}.rpm" \
+  "out/docker-machine-driver-kvm2_${VERSION}.deb" \
+  "out/docker-machine-driver-kvm2-${VERSION}.rpm"
+
 make checksum
 
-gsutil -m cp out/* gs://$BUCKET/releases/$TAGNAME/
+gsutil -m cp out/* "gs://$BUCKET/releases/$TAGNAME/"
 
-# Bump latest
-gsutil cp -r gs://$BUCKET/releases/$TAGNAME/* gs://$BUCKET/releases/latest/
+# Update "latest" release for non-beta/non-alpha builds
+if ! [[ ${VERSION_BUILD} =~ ^[0-9]+$ ]]; then
+  echo "NOTE: ${VERSION} appears to be a non-standard release, not updating /releases/latest"
+else
+  echo "Updating latest bucket for ${VERSION} release"
+  gsutil cp -r "gs://${BUCKET}/releases/${TAGNAME}/*" "gs://${BUCKET}/releases/latest/"
+fi

--- a/hack/jenkins/release_github_page.sh
+++ b/hack/jenkins/release_github_page.sh
@@ -24,91 +24,44 @@
 # ISO_SHA256: The sha 256 of the minikube-iso for the current release.
 # GITHUB_TOKEN: The Github API access token. Injected by the Jenkins credential provider.
 
-set -e
-export TAGNAME=v${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BUILD}
-export DEB_VERSION=${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BUILD}
-export RPM_VERSION=${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BUILD}
+set -eux -o pipefail
+readonly VERSION="${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BUILD}"
+readonly TAGNAME="v${VERSION}"
 
-export GITHUB_ORGANIZATION="kubernetes"
-export GITHUB_REPO="minikube"
-export PROJECT_NAME="minikube"
-export DARWIN_SHA256=$(cat out/minikube-darwin-amd64.sha256)
-export LINUX_SHA256=$(cat out/minikube-linux-amd64.sha256)
-export WINDOWS_SHA256=$(cat out/minikube-windows-amd64.exe.sha256)
+readonly GITHUB_ORGANIZATION="kubernetes"
+readonly GITHUB_REPO="minikube"
+readonly PROJECT_NAME="${GITHUB_REPO}"
 
-# Description could be moved into file on machine or fetched via URL.  Doing this for now as it is the simplest, portable solution.
-# ================================================================================
-export DESCRIPTION="# Minikube ${TAGNAME}
-Minikube is still under active development, and features may change at any time. Release notes are available [here](https://github.com/kubernetes/minikube/blob/${TAGNAME}/CHANGELOG.md).
+RELEASE_NOTES=$(perl -e "\$p=0; while(<>) { if(/^## Version ${VERSION}/) { \$p=1 } elsif (/^##/) { \$p=0 }; if (\$p) { print }}" < CHANGELOG.md)
+if [[ "${RELEASE_NOTES}" = "" ]]; then
+  RELEASE_NOTES="(missing for ${VERSION})"
+fi
 
-## Distribution
-Minikube is distributed in binary form for Linux, OSX, and Windows systems for the ${TAGNAME} release. Please note that Windows support is currently experimental and may have issues.  Binaries are available through GitHub or on Google Cloud Storage. The direct GCS links are:
-[Darwin/amd64](https://storage.googleapis.com/minikube/releases/${TAGNAME}/minikube-darwin-amd64)
-[Linux/amd64](https://storage.googleapis.com/minikube/releases/${TAGNAME}/minikube-linux-amd64)
-[Windows/amd64](https://storage.googleapis.com/minikube/releases/${TAGNAME}/minikube-windows-amd64.exe)
+readonly DESCRIPTION="## Release Notes
+
+${RELEASE_NOTES}
 
 ## Installation
-### OSX
-\`\`\`shell
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/${TAGNAME}/minikube-darwin-amd64 && chmod +x minikube && sudo cp minikube /usr/local/bin/ && rm minikube
-\`\`\`
-Feel free to leave off \`\`\`sudo cp minikube /usr/local/bin/ && rm minikube\`\`\` if you would like to add minikube to your path manually.
 
-Or you can install via homebrew with \`brew cask install minikube\`.
+See [https://minikube.sigs.k8s.io/docs/start/](Getting Started)
 
-### Linux
-\`\`\`shell
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/${TAGNAME}/minikube-linux-amd64 && chmod +x minikube && sudo cp minikube /usr/local/bin/ && rm minikube
-\`\`\`
-Feel free to leave off \`\`\`sudo cp minikube /usr/local/bin/ && rm minikube\`\`\` if you would like to add minikube to your path manually.
+## ISO Checksum
 
-### Debian Package (.deb) [Experimental]
-Download the \`minikube_${DEB_VERSION}.deb\` file, and install it using \`sudo dpkg -i minikube_${DEB_VERSION}.deb\`
+\`${ISO_SHA256}\`"
 
-### RPM Package (.rpm) [Experimental]
-Download the \`minikube-${RPM_VERSION}.rpm\` file, and install it using \`sudo rpm -i minikube-${RPM_VERSION}.rpm\`
-
-### Windows [Experimental]
-Download the \`minikube-windows-amd64.exe\` file, rename it to \`minikube.exe\` and add it to your path.
-
-### Windows Installer [Experimental]
-Download the \`minikube-installer.exe\` file, and execute the installer.  This will automatically add minikube.exe to your path with an uninstaller available as well.
-
-## Usage
-Documentation is available [here](https://github.com/kubernetes/minikube/blob/${TAGNAME}/README.md).
-
-## Checksums
-Minikube consists of a binary executable and a VM image in ISO format. To verify the contents of your distribution, you can compare sha256 hashes with these values:
-
-\`\`\`
-$ tail -n +1 -- out/*.sha256
-==> out/minikube-darwin-amd64.sha256 <==
-${DARWIN_SHA256}
-
-==> out/minikube-linux-amd64.sha256 <==
-${LINUX_SHA256}
-
-==> out/minikube-windows-amd64.exe.sha256 <==
-${WINDOWS_SHA256}
-\`\`\`
-
-### ISO
-\`\`\`shell
-$ openssl sha256 minikube.iso
-SHA256(minikube.iso)=
-${ISO_SHA256}
-\`\`\`
-"
 # ================================================================================
-
 # Deleting release from github before creating new one
-github-release delete --user ${GITHUB_ORGANIZATION} --repo ${GITHUB_REPO} --tag ${TAGNAME} || true
+github-release delete \
+  --user "${GITHUB_ORGANIZATION}" \
+  --repo "${GITHUB_REPO}" \
+  --tag "${TAGNAME}" \
+  || true
 
 # Creating a new release in github
 github-release release \
-    --user ${GITHUB_ORGANIZATION} \
-    --repo ${GITHUB_REPO} \
-    --tag ${TAGNAME} \
+    --user "${GITHUB_ORGANIZATION}" \
+    --repo "${GITHUB_REPO}" \
+    --tag "${TAGNAME}" \
     --name "${TAGNAME}" \
     --description "${DESCRIPTION}"
 
@@ -134,7 +87,12 @@ do
     n=0
     until [ $n -ge 5 ]
     do
-        github-release upload --user ${GITHUB_ORGANIZATION} --repo ${GITHUB_REPO} --tag ${TAGNAME} --name $UPLOAD --file out/$UPLOAD && break
+        github-release upload \
+          --user "${GITHUB_ORGANIZATION}" \
+          --repo "${GITHUB_REPO}" \
+          --tag "${TAGNAME}" \
+          --name "$UPLOAD" \
+          --file "out/$UPLOAD" && break
         n=$[$n+1]
         sleep 15
     done


### PR DESCRIPTION
Most importantly, alpha/beta should not update the /latest/ binary bucket that folks use.