### PR TITLE
Substitute dashes for tildes when generating Linux packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,15 @@
 VERSION_MAJOR ?= 1
 VERSION_MINOR ?= 4
 VERSION_BUILD ?= 0-beta.0
+RAW_VERSION=$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_BUILD)
+VERSION ?= v$(RAW_VERSION)
+
 # Default to .0 for higher cache hit rates, as build increments typically don't require new ISO versions
 ISO_VERSION ?= v$(VERSION_MAJOR).$(VERSION_MINOR).${VERSION_BUILD}
+# Dashes are valid in semver, but not Linux packaging. Use ~ to delimit alpha/beta
+DEB_VERSION ?= $(subst -,~,$(RAW_VERSION))
+RPM_VERSION ?= $(DEB_VERSION)
 
-VERSION ?= v$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_BUILD)
-DEB_VERSION ?= $(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_BUILD)
-RPM_VERSION ?= $(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_BUILD)
 # used by hack/jenkins/release_build_and_upload.sh and KVM_BUILD_IMAGE, see also BUILD_IMAGE below
 GO_VERSION ?= 1.12.9
 

--- a/hack/jenkins/release_github_page.sh
+++ b/hack/jenkins/release_github_page.sh
@@ -26,6 +26,9 @@
 
 set -eux -o pipefail
 readonly VERSION="${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BUILD}"
+readonly DEB_VERSION="${VERSION/-/\~}"
+readonly RPM_VERSION="${DEB_VERSION}"
+
 readonly TAGNAME="v${VERSION}"
 
 readonly GITHUB_ORGANIZATION="kubernetes"


### PR DESCRIPTION
Fixes beta release issue:

```
10:50:18 rpmbuild -bb -D "_rpmdir /var/lib/jenkins/go/src/k8s.io/minikube/out" -D "_rpmfilename docker-machine-driver-kvm2-1.4.0-beta.0.rpm" \
10:50:18 	out/docker-machine-driver-kvm2-1.4.0-beta.0/docker-machine-driver-kvm2.spec
10:50:18 fakeroot dpkg-deb --build out/docker-machine-driver-kvm2_1.4.0-beta.0
10:50:19 error: line 2: Illegal char '-' in: Version: 1.4.0-beta.0
10:50:19 Makefile:505: recipe for target 'out/docker-machine-driver-kvm2-1.4.0-beta.0.rpm' failed
10:50:19 make: *** [out/docker-machine-driver-kvm2-1.4.0-beta.0.rpm] Error 1
10:50:19 make: *** Waiting for unfinished jobs....
10:50:20 dpkg-deb: building package 'docker-machine-dr
```
