### PR TITLE
Skip http proxy localhost for docker env

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -688,6 +688,12 @@ func generateCfgFromFlags(cmd *cobra.Command, k8sVersion string) (cfg.Config, er
 					// convert https_proxy to HTTPS_PROXY for linux
 					// TODO (@medyagh): if user has both http_proxy & HTTPS_PROXY set merge them.
 					k = strings.ToUpper(k)
+					if k == "HTTP_PROXY" || k == "HTTPS_PROXY" {
+						if strings.HasPrefix(v, "localhost") || strings.HasPrefix(v, "127.0") {
+							out.WarningT("Not passing {{.name}}={{.value}} to docker env.", out.V{"name": k, "value": v})
+							continue
+						}
+					}
 					dockerEnv = append(dockerEnv, fmt.Sprintf("%s=%s", k, v))
 				}
 			}

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -17,7 +17,11 @@ limitations under the License.
 package cmd
 
 import (
+	"os"
 	"testing"
+
+	"github.com/spf13/cobra"
+	"k8s.io/minikube/pkg/minikube/constants"
 )
 
 func Test_extractVMDriverVersion(t *testing.T) {
@@ -41,5 +45,57 @@ func Test_extractVMDriverVersion(t *testing.T) {
 	v = extractVMDriverVersion("version: 1.2.3")
 	if expectedVersion != v {
 		t.Errorf("Expected version: %s, got: %s", expectedVersion, v)
+	}
+}
+
+func TestGenerateCfgFromFlagsHTTPProxyHandling(t *testing.T) {
+	originalEnv := os.Getenv("HTTP_PROXY")
+	defer func() {
+		err := os.Setenv("HTTP_PROXY", originalEnv)
+		if err != nil {
+			t.Fatalf("Error reverting env HTTP_PROXY to it's original value. Got err (%s)", err)
+		}
+	}()
+	k8sVersion := constants.NewestKubernetesVersion
+	var tests = []struct {
+		description  string
+		proxy        string
+		proxyIgnored bool
+	}{
+		{
+			description: "no http_proxy",
+		},
+		{
+			description:  "http_proxy=127.0.0.1:3128",
+			proxy:        "127.0.0.1:3128",
+			proxyIgnored: true,
+		},
+		{
+			description:  "http_proxy=localhost:3128",
+			proxy:        "localhost:3128",
+			proxyIgnored: true,
+		},
+		{
+			description: "http_proxy=1.2.3.4:3128",
+			proxy:       "1.2.3.4:3128",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			cmd := cobra.Command{}
+			if err := os.Setenv("HTTP_PROXY", test.proxy); err != nil {
+				t.Fatalf("Unexpected error setting HTTP_PROXY: %v", err)
+			}
+			config, err := generateCfgFromFlags(&cmd, k8sVersion)
+			if err != nil {
+				t.Fatalf("Got unexpected error %v during config generation", err)
+			}
+			// ignored proxy should not be in config
+			for _, v := range config.MachineConfig.DockerEnv {
+				if v == test.proxy && test.proxyIgnored {
+					t.Fatalf("Value %v not expected in dockerEnv but occured", v)
+				}
+			}
+		})
 	}
 }

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -93,7 +93,7 @@ func TestGenerateCfgFromFlagsHTTPProxyHandling(t *testing.T) {
 			// ignored proxy should not be in config
 			for _, v := range config.MachineConfig.DockerEnv {
 				if v == test.proxy && test.proxyIgnored {
-					t.Fatalf("Value %v not expected in dockerEnv but occured", v)
+					t.Fatalf("Value %v not expected in dockerEnv but occurred", v)
 				}
 			}
 		})


### PR DESCRIPTION
Some people are using `ntlm` in the work office and `cntlm` to proxy traffic from terminal via some proxy. Very common setup is `HTTP{,S}_PROXY=localhost:${PORT}`.  Assuming user is running `minikube start`, the network configuration will be passed to minikube. 

 ```n0npax@narrenturm  ~/workspace   minikube start -p test-1
😄  minikube v1.2.0 on linux (amd64)
🔥  Creating virtualbox VM (CPUs=2, Memory=2048MB, Disk=20000MB) ...
🌐  Found network options:
    ▪ HTTP_PROXY=localhost:3128
⚠️  You appear to be using a proxy, but your NO_PROXY environment does not include the minikube IP (192.168.99.106). Please see https://github.com/kubernetes/minikube/blob/master/docs/http_proxy.md for more details
    ▪ HTTPS_PROXY=localhost:3128
🐳  Configuring environment for Kubernetes v1.15.0 on Docker 18.09.6
    ▪ env HTTP_PROXY=localhost:3128
    ▪ env HTTPS_PROXY=localhost:3128
🚜  Pulling images ...
🚀  Launching Kubernetes ...
⌛  Verifying: apiserver proxy etcd scheduler controller dns
🏄  Done! kubectl is now configured to use "test-1"
```

This is causing issues with fetching images. In example
```
Warning  Failed     19s (x2 over 31s)  kubelet, minikube  Failed to pull image "nginx": rpc error: code = Unknown desc = Error response from daemon: Get https://registry-1.docker.io/v2/: proxyconnect tcp: dial tcp 127.0.0.1:3128: connect: connection refused
```
-------------------------------------------------------------
Proposed solution:
If `HTTP{s,}_PROXY` is pointing to `localhost` print warning and ignore it for dockerEnvs

```
😄  [test-1] minikube v1.4.0-beta.0 on Ubuntu 18.04
⚠️  Not passing HTTP_PROXY=localhost:3128 to docker env. <------- This is new part!
⚠️  Not passing HTTPS_PROXY=localhost:3128 to docker env.
⚠️  Not passing HTTP_PROXY=localhost:3128 to docker env.
⚠️  Not passing HTTPS_PROXY=localhost:3128 to docker env.
🔄  Starting existing virtualbox VM for "test-1" ...
Check network to re-create if needed...
Waiting for an IP...
⌛  Waiting for the host to be provisioned ...
Waiting for SSH to be available...
Detecting the provisioner...
Setting Docker configuration on the remote daemon...
🌐  Found network options:
    ▪ HTTP_PROXY=localhost:3128
⚠️  You appear to be using a proxy, but your NO_PROXY environment does not include the minikube IP (192.168.99.108). Please see https://minikube.sigs.k8s.io/docs/reference/networking/proxy/ for more detail
s
    ▪ HTTPS_PROXY=localhost:3128
    ▪ http_proxy=localhost:3128
    ▪ https_proxy=localhost:3128
🐳  Preparing Kubernetes v1.16.0-beta.1 on Docker 18.09.8 ...
🔄  Relaunching Kubernetes using kubeadm ...
⌛  Waiting for: apiserver proxy etcd scheduler controller dns
🏄  Done! kubectl is now configured to use "test-1"
```