### PR TITLE
Update NO_PROXY example for Windows

### DIFF
--- a/site/content/en/docs/Reference/Networking/proxy.md
+++ b/site/content/en/docs/Reference/Networking/proxy.md
@@ -40,7 +40,7 @@ To make the exported variables permanent, consider adding the declarations to ~/
 ```shell
 set HTTP_PROXY=http://<proxy hostname:port>
 set HTTPS_PROXY=https://<proxy hostname:port>
-set NO_PROXY=localhost,127.0.0.1,10.96.0.0/12,192.168.99.1/24,192.168.39.0/24
+set NO_PROXY=localhost,127.0.0.1,10.96.0.0/12,192.168.99.0/24,192.168.39.0/24
 
 minikube start
 ```


### PR DESCRIPTION
A wrong IP was used in the example for windows, ending in .1 instead of .0.