### PR TITLE
Add note for bare-metal driver

### DIFF
--- a/site/content/en/docs/Examples/_index.md
+++ b/site/content/en/docs/Examples/_index.md
@@ -28,7 +28,7 @@ minikube makes it easy to open this exposed endpoint in your browser:
 
 `minikube service hello-minikube`
 
-Start a second local cluster:
+Start a second local cluster (_note: This will not work if minikube is using the bare-metal/none driver_):
 
 `minikube start -p cluster2`
 


### PR DESCRIPTION
I open an issue (#5308) while trying the command to create the second local cluster.  It turns out that this operation isn't supported with a bare-metal (none) driver and the code is being changed to catch this restriction early.

I thought it might be nice to add a warning to the examples page as well.