### PR TITLE
Move update notification out of PersistentPreRun, improve update UI

### DIFF
--- a/pkg/minikube/notify/notify.go
+++ b/pkg/minikube/notify/notify.go
@@ -42,33 +42,35 @@ var (
 )
 
 // MaybePrintUpdateTextFromGithub prints update text if needed, from github
-func MaybePrintUpdateTextFromGithub() {
-	MaybePrintUpdateText(constants.GithubMinikubeReleasesURL, lastUpdateCheckFilePath)
+func MaybePrintUpdateTextFromGithub() bool {
+	return MaybePrintUpdateText(constants.GithubMinikubeReleasesURL, lastUpdateCheckFilePath)
 }
 
-// MaybePrintUpdateText prints update text if needed
-func MaybePrintUpdateText(url string, lastUpdatePath string) {
+// MaybePrintUpdateText prints update text, returns a bool if life is good.
+func MaybePrintUpdateText(url string, lastUpdatePath string) bool {
 	if !shouldCheckURLVersion(lastUpdatePath) {
-		return
+		return false
 	}
 	latestVersion, err := getLatestVersionFromURL(url)
 	if err != nil {
 		glog.Warning(err)
-		return
+		return true
 	}
 	localVersion, err := version.GetSemverVersion()
 	if err != nil {
 		glog.Warning(err)
-		return
+		return true
 	}
 	if localVersion.Compare(latestVersion) < 0 {
 		if err := writeTimeToFile(lastUpdateCheckFilePath, time.Now().UTC()); err != nil {
 			glog.Errorf("write time failed: %v", err)
 		}
 		url := "https://github.com/kubernetes/minikube/releases/tag/v" + latestVersion.String()
-		out.ErrT(out.WarningType, `minikube {{.version}} is available! Download it: {{.url}}`, out.V{"version": latestVersion, "url": url})
-		out.ErrT(out.Tip, "To disable this notice, run: 'minikube config set WantUpdateNotification false'")
+		out.ErrT(out.Celebrate, `minikube {{.version}} is available! Download it: {{.url}}`, out.V{"version": latestVersion, "url": url})
+		out.ErrT(out.Tip, "To disable this notice, run: 'minikube config set WantUpdateNotification false'\n")
+		return true
 	}
+	return false
 }
 
 func shouldCheckURLVersion(filePath string) bool {


### PR DESCRIPTION
For unknown reasons, this fixes the machine driver log spam issue by moving the first stderr call to a `Run` rather than `PersistentPreRun` call. 

Even if that issue didn't exist, I prefer the cleaner output. One subtle tweak is that the happy-face turns to a meh face if there is an ignored update. =)

Before:

```
⚠️  minikube 1.3.1 is available! Download it: https://github.com/kubernetes/minikube/releases/tag/v1.3.1
💡  To disable this notice, run: 'minikube config set WantUpdateNotification false'
😄  minikube v1.2.0-beta.1 on Darwin 10.14.6
```

After:

```
🎉  minikube 1.3.1 is available! Download it: https://github.com/kubernetes/minikube/releases/tag/v1.3.1
💡  To disable this notice, run: 'minikube config set WantUpdateNotification false'

🙄  minikube v1.2.0-beta.1 on Darwin 10.14.6
```

This improves upon and obsoletes #5297
This fixes #5278