### PR TITLE
WIP: Remove unneccesary test script vars (EXTRA_ARGS, PARALLEL_COUNT, etc)

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -23,8 +23,6 @@
 # EXTRA_START_ARGS: additional flags to pass into minikube start
 # EXTRA_ARGS: additional flags to pass into minikube
 # JOB_NAME: the name of the logfile and check name to update on github
-# PARALLEL_COUNT: number of tests to run in parallel
-
 
 readonly TEST_ROOT="${HOME}/minikube-integration"
 readonly TEST_HOME="${TEST_ROOT}/${OS_ARCH}-${VM_DRIVER}-${MINIKUBE_LOCATION}-$$-${COMMIT}"
@@ -276,7 +274,6 @@ echo ">> Starting ${E2E_BIN} at $(date)"
 ${SUDO_PREFIX}${E2E_BIN} \
   -minikube-start-args="--vm-driver=${VM_DRIVER} ${EXTRA_START_ARGS}" \
   -test.timeout=60m \
-  -test.parallel=${PARALLEL_COUNT} \
   -binary="${MINIKUBE_BIN}" && result=$? || result=$?
 echo ">> ${E2E_BIN} exited with ${result} at $(date)"
 echo ""

--- a/hack/jenkins/linux_integration_tests_kvm.sh
+++ b/hack/jenkins/linux_integration_tests_kvm.sh
@@ -28,7 +28,6 @@ set -e
 OS_ARCH="linux-amd64"
 VM_DRIVER="kvm2"
 JOB_NAME="KVM_Linux"
-PARALLEL_COUNT=4
 
 # Download files and set permissions
 source ./common.sh

--- a/hack/jenkins/linux_integration_tests_none.sh
+++ b/hack/jenkins/linux_integration_tests_none.sh
@@ -29,11 +29,7 @@ set -e
 OS_ARCH="linux-amd64"
 VM_DRIVER="none"
 JOB_NAME="none_Linux"
-EXTRA_ARGS="--bootstrapper=kubeadm"
-PARALLEL_COUNT=1
-
 SUDO_PREFIX="sudo -E "
-export KUBECONFIG="/root/.kube/config"
 
 # "none" driver specific cleanup from previous runs.
 

--- a/hack/jenkins/linux_integration_tests_virtualbox.sh
+++ b/hack/jenkins/linux_integration_tests_virtualbox.sh
@@ -28,7 +28,6 @@ set -e
 OS_ARCH="linux-amd64"
 VM_DRIVER="virtualbox"
 JOB_NAME="VirtualBox_Linux"
-PARALLEL_COUNT=4
 
 # Download files and set permissions
 source ./common.sh

--- a/hack/jenkins/osx_integration_tests_hyperkit.sh
+++ b/hack/jenkins/osx_integration_tests_hyperkit.sh
@@ -29,9 +29,6 @@ set -e
 OS_ARCH="darwin-amd64"
 VM_DRIVER="hyperkit"
 JOB_NAME="HyperKit_macOS"
-EXTRA_ARGS="--bootstrapper=kubeadm"
-EXTRA_START_ARGS=""
-PARALLEL_COUNT=3
 
 # Download files and set permissions
 source common.sh

--- a/hack/jenkins/osx_integration_tests_virtualbox.sh
+++ b/hack/jenkins/osx_integration_tests_virtualbox.sh
@@ -28,8 +28,6 @@ set -e
 OS_ARCH="darwin-amd64"
 VM_DRIVER="virtualbox"
 JOB_NAME="VirtualBox_macOS"
-EXTRA_ARGS="--bootstrapper=kubeadm"
-PARALLEL_COUNT=3
 
 # Download files and set permissions
 source common.sh


### PR DESCRIPTION
Will update this description with any performance differences from the removal of `PARALLEL_COUNT`. 

Normally it's best to let Go scale parallelism by default, but this is a special case, as the hypervisor core management is out of Go's hands.