### PR TITLE
Integration de-flake: expand lock scopes, sync clock at creation

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -478,8 +478,12 @@ func (k *Bootstrapper) waitForAPIServer(k8s config.KubernetesConfig) error {
 			return false, nil
 		}
 		return true, nil
+
+		// TODO: Check apiserver/kubelet logs for fatal errors so that users don't
+		// need to wait minutes to find out their flag didn't work.
+
 	}
-	err = wait.PollImmediate(kconst.APICallRetryInterval, kconst.DefaultControlPlaneTimeout, f)
+	err = wait.PollImmediate(kconst.APICallRetryInterval, 2*kconst.DefaultControlPlaneTimeout, f)
 	return err
 }
 

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -470,7 +470,10 @@ func createHost(api libmachine.API, config cfg.MachineConfig) (*host.Host, error
 	if err := api.Save(h); err != nil {
 		return nil, errors.Wrap(err, "save")
 	}
-	return h, nil
+
+	// Ensure that even new VM's have proper time synchronization up front
+	// It's 2019, and I can't believe I am still dealing with time desync as a problem.
+	return h, ensureSyncedGuestClock(h)
 }
 
 // GetHostDockerEnv gets the necessary docker env variables to allow the use of docker through minikube's vm

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -463,6 +463,11 @@ func createHost(api libmachine.API, config cfg.MachineConfig) (*host.Host, error
 
 	if !localDriver(config.VMDriver) {
 		showRemoteOsRelease(h.Driver)
+		// Ensure that even new VM's have proper time synchronization up front
+		// It's 2019, and I can't believe I am still dealing with time desync as a problem.
+		if err := ensureSyncedGuestClock(h); err != nil {
+			return h, err
+		}
 	} else {
 		showLocalOsRelease()
 	}
@@ -470,10 +475,7 @@ func createHost(api libmachine.API, config cfg.MachineConfig) (*host.Host, error
 	if err := api.Save(h); err != nil {
 		return nil, errors.Wrap(err, "save")
 	}
-
-	// Ensure that even new VM's have proper time synchronization up front
-	// It's 2019, and I can't believe I am still dealing with time desync as a problem.
-	return h, ensureSyncedGuestClock(h)
+	return h, nil
 }
 
 // GetHostDockerEnv gets the necessary docker env variables to allow the use of docker through minikube's vm

--- a/pkg/minikube/cluster/cluster_test.go
+++ b/pkg/minikube/cluster/cluster_test.go
@@ -76,6 +76,7 @@ func TestCreateHost(t *testing.T) {
 	if exists {
 		t.Fatal("Machine already exists.")
 	}
+
 	_, err := createHost(api, defaultMachineConfig)
 	if err != nil {
 		t.Fatalf("Error creating host: %v", err)
@@ -215,7 +216,7 @@ func TestStartHostConfig(t *testing.T) {
 	provision.SetDetector(md)
 
 	config := config.MachineConfig{
-		VMDriver:   constants.DefaultVMDriver,
+		VMDriver:   constants.DriverMock,
 		DockerEnv:  []string{"FOO=BAR"},
 		DockerOpt:  []string{"param=value"},
 		Downloader: MockDownloader{},

--- a/pkg/minikube/config/profile.go
+++ b/pkg/minikube/config/profile.go
@@ -62,8 +62,8 @@ func CreateProfile(name string, cfg *Config, miniHome ...string) error {
 	if err != nil {
 		return err
 	}
-	glog.Infof("Saving config:\n%s", data)
 	path := profileFilePath(name, miniHome...)
+	glog.Infof("Saving config to %s ...", path)
 	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 		return err
 	}


### PR DESCRIPTION
- Expand cert locking scope from `updateCerts` to `SetupCerts`. This is necessary because an update could still trample the certs between the update and the transfer.
- Add lock around entire `kubeconfig.Update` call. This is necessary because the method needs to read, update, and write the file contents in a single atomic step.
- elevateKubeSystemPrivileges now uses the same micro-managed client as the rest of kubeadm.
- Force time sync on creation.

Fixes #5347
May fix #5333 and #4967
