### PR TITLE
Update golangci-lint to v1.18.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ MINIKUBE_RELEASES_URL=https://github.com/kubernetes/minikube/releases/download
 
 KERNEL_VERSION ?= 4.15
 # latest from https://github.com/golangci/golangci-lint/releases
-GOLINT_VERSION ?= v1.17.1
+GOLINT_VERSION ?= v1.18.0
 # Limit number of default jobs, to avoid the CI builds running out of memory
 GOLINT_JOBS ?= 4
 # see https://github.com/golangci/golangci-lint#memory-usage-of-golangci-lint
@@ -319,14 +319,15 @@ golint:
 gocyclo:
 	@gocyclo -over 15 `find $(SOURCE_DIRS) -type f -name "*.go"`
 
-out/linters/golangci-lint:
+out/linters/golangci-lint-$(GOLINT_VERSION):
 	mkdir -p out/linters
 	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b out/linters $(GOLINT_VERSION)
+	mv out/linters/golangci-lint out/linters/golangci-lint-$(GOLINT_VERSION)
 
 # this one is meant for local use
 .PHONY: lint
-lint: pkg/minikube/assets/assets.go pkg/minikube/translate/translations.go out/linters/golangci-lint
-	./out/linters/golangci-lint run ${GOLINT_OPTIONS} ./...
+lint: pkg/minikube/assets/assets.go pkg/minikube/translate/translations.go out/linters/golangci-lint-$(GOLINT_VERSION)
+	./out/linters/golangci-lint-$(GOLINT_VERSION) run ${GOLINT_OPTIONS} ./...
 
 # lint-ci is slower version of lint and is meant to be used in ci (travis) to avoid out of memory leaks.
 .PHONY: lint-ci

--- a/Makefile
+++ b/Makefile
@@ -331,8 +331,8 @@ lint: pkg/minikube/assets/assets.go pkg/minikube/translate/translations.go out/l
 
 # lint-ci is slower version of lint and is meant to be used in ci (travis) to avoid out of memory leaks.
 .PHONY: lint-ci
-lint-ci: pkg/minikube/assets/assets.go pkg/minikube/translate/translations.go out/linters/golangci-lint
-	GOGC=${GOLINT_GOGC} ./out/linters/golangci-lint run \
+lint-ci: pkg/minikube/assets/assets.go pkg/minikube/translate/translations.go out/linters/golangci-lint-$(GOLINT_VERSION)
+	GOGC=${GOLINT_GOGC} ./out/linters/golangci-lint-$(GOLINT_VERSION) run \
 	--concurrency ${GOLINT_JOBS} ${GOLINT_OPTIONS} ./...
 
 .PHONY: reportcard


### PR DESCRIPTION
## Changelog

bb82273 Add funlen linter (#603)
91e90eb Add support for bash completions (#640)
a8f2c27 Add user supplied error messages in depguard issues (#662)
f84095a Build FreeBSD binaries (#613)
e87a1cf Fix a false-positive from 'unused' (#585)
338e3fb Fix install script on Windows (#626)
0b49095 Make generation of demo.svg deterministic (#625)
eabe43a Provide pre-built binary for ARM arch (#607)
375a5a8 Speed up linting: use deduplicated packages (#667)
6163a8a Support go1.13 (#670)
e1a7422 Update gochecknoglobals to support version exception (#601)
f8a5a8c Update depguard version to 1.0.0 (Performance improvements)
97fcafd Update format of junit xml output to mark failures as such (#632)
22d1ef6 Update pkg/errors to v0.8.1.
4ed1349 add kubeedge (#636)
d2b1eea bodyclose: fix race condition
f312a0f fix #416: Add skip-dirs-use-default (#630)
c5b0f95 fix cuncurrent [read/]write panic
cdeefb5 fix invalid dependencies (#605)
e175825 fix possible race in line cache
7e170af fix: body close panic.
136b271 update bodyclose: use upstream version (#666)
e39e8fb update x/tools