### PR TITLE
Fix addon config

### DIFF
--- a/site/content/en/docs/Contributing/addons.en.md
+++ b/site/content/en/docs/Contributing/addons.en.md
@@ -43,19 +43,22 @@ To add a new addon to minikube the following steps are required:
     "efk": NewAddon([]*BinAsset{
       MustBinAsset(
         "deploy/addons/efk/efk-configmap.yaml",
-        constants.AddonsPath,
+        constants.GuestAddonsDir,
         "efk-configmap.yaml",
-        "0640"),
+        "0640", 
+        false),
       MustBinAsset(
         "deploy/addons/efk/efk-rc.yaml",
-        constants.AddonsPath,
+        constants.GuestAddonsDir,
         "efk-rc.yaml",
-        "0640"),
+        "0640", 
+        false),
       MustBinAsset(
         "deploy/addons/efk/efk-svc.yaml",
-        constants.AddonsPath,
+        constants.GuestAddonsDir,
         "efk-svc.yaml",
-        "0640"),
+        "0640",
+        false),
     }, false, "efk"),
   }
   ```


### PR DESCRIPTION
`constants. AddonsPath` doesn't exist and isn't used by the example efk plugin. `constants.GuestAddonsDir` seems more appropriate. Docs are missing argument for whether or not plugin file is template.