### PR TITLE
Wrap shell command in backquotes

### DIFF
--- a/site/content/en/docs/Contributing/addons.en.md
+++ b/site/content/en/docs/Contributing/addons.en.md
@@ -60,5 +60,5 @@ To add a new addon to minikube the following steps are required:
   }
   ```
 
-* Rebuild minikube using make out/minikube.  This will put the addon's .yaml binary files into the minikube binary using go-bindata.
+* Rebuild minikube using `make out/minikube`.  This will put the addon's .yaml binary files into the minikube binary using go-bindata.
 * Test addon using `minikube addons enable <NEW_ADDON_NAME>` command to start service.


### PR DESCRIPTION
This clarifies that `make out/minikube` is a shell command.