### PR TITLE
Minor improvement to driver download display

### DIFF
--- a/pkg/drivers/drivers.go
+++ b/pkg/drivers/drivers.go
@@ -194,7 +194,7 @@ func download(driver, destination string) error {
 		return nil
 	}
 
-	out.T(out.Happy, "Downloading driver {{.driver}}:", out.V{"driver": driver})
+	out.T(out.FileDownload, "Downloading driver {{.driver}}:", out.V{"driver": driver})
 
 	targetFilepath := path.Join(destination, driver)
 	os.Remove(targetFilepath)
@@ -252,8 +252,8 @@ func ExtractVMDriverVersion(s string) string {
 }
 
 func setHyperKitPermissions(driverPath string) error {
-	msg := fmt.Sprintf("A new hyperkit driver was installed. It needs elevated permissions to run. The following commands will be executed\nsudo chown root:wheel %s\nsudo chmod u+s %s", driverPath, driverPath)
-	out.T(out.Happy, msg, out.V{})
+	msg := fmt.Sprintf("A new hyperkit driver was installed. It needs elevated permissions to run. The following commands will be executed:\n  sudo chown root:wheel %s\n  sudo chmod u+s %s", driverPath, driverPath)
+	out.T(out.Permissions, msg, out.V{})
 
 	cmd := exec.Command("sudo", "chown", "root:wheel", driverPath)
 	err := cmd.Run()


### PR DESCRIPTION
- Use colon before commands
- Indent commands
- More appropriate emoji use

Before:

```
😄  minikube v1.4.0-beta.2 on Darwin 10.14.6
😄  Downloading driver docker-machine-driver-hyperkit:
docker-machine-driver-hyperkit: 10.79 MiB / 10.79 MiB  100.00% 40.82 MiB p/s 1s
😄  A new hyperkit driver was installed. It needs elevated permissions to run. The following commands will be executed
sudo chown root:wheel /Users/tstromberg/.minikube/bin/docker-machine-driver-hyperkit
sudo chmod u+s /Users/tstromberg/.minikube/bin/docker-machine-driver-hyperkit
Password: 
```

After:

```
😄  minikube v1.4.0-beta.2 on Darwin 10.14.6
💾  Downloading driver docker-machine-driver-hyperkit:
docker-machine-driver-hyperkit: 10.79 MiB / 10.79 MiB  100.00% 16.30 MiB p/s 1s
🔑  A new hyperkit driver was installed. It needs elevated permissions to run. The following commands will be executed:
  sudo chown root:wheel /Users/tstromberg/.minikube/bin/docker-machine-driver-hyperkit
  sudo chmod u+s /Users/tstromberg/.minikube/bin/docker-machine-driver-hyperkit
Password: 
```