### PR TITLE
Download version appropriate driver, add sha256 checksum check

### DIFF
--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -290,6 +290,7 @@ func getClusterBootstrapper(api libmachine.API, bootstrapperName string) (bootst
 }
 
 func addToPath(dir string) {
-	path := os.Getenv("PATH")
-	os.Setenv("PATH", fmt.Sprintf("%s:%s", dir, path))
+	new := fmt.Sprintf("%s:%s", dir, os.Getenv("PATH"))
+	glog.Infof("Updating PATH: %s", dir)
+	os.Setenv("PATH", new)
 }

--- a/pkg/drivers/drivers.go
+++ b/pkg/drivers/drivers.go
@@ -203,19 +203,18 @@ func download(driver, destination string) error {
 	out.T(out.Happy, "Downloading driver {{.driver}}:", out.V{"driver": driver})
 	targetFilepath := path.Join(destination, driver)
 	os.Remove(targetFilepath)
-
-	opts := []getter.ClientOption{getter.WithProgress(util.DefaultProgressBar)}
+	url := driverWithChecksumURL(driver, version.GetVersion())
 	client := &getter.Client{
-		Src:     driverWithChecksumURL(driver, version.GetVersion()),
+		Src:     url,
 		Dst:     targetFilepath,
 		Mode:    getter.ClientModeFile,
-		Options: opts,
+		Options: []getter.ClientOption{getter.WithProgress(util.DefaultProgressBar)},
 	}
 
 	glog.Infof("Downloading: %+v", client)
 
 	if err := client.Get(); err != nil {
-		return errors.Wrapf(err, "download failed")
+		return errors.Wrapf(err, "download failed: %s", url)
 	}
 
 	err := os.Chmod(targetFilepath, 0755)

--- a/test/integration/driver_install_or_update_test.go
+++ b/test/integration/driver_install_or_update_test.go
@@ -70,7 +70,7 @@ func TestDriverInstallOrUpdate(t *testing.T) {
 		}
 
 		// change permission to allow driver to be executable
-		err = os.Chmod(filepath.Join(path, "docker-machine-driver-kvm2"), 0777)
+		err = os.Chmod(filepath.Join(path, "docker-machine-driver-kvm2"), 0700)
 		if err != nil {
 			t.Fatalf("Expected not expected when changing driver permission. test: %s, got: %v", tc.name, err)
 		}

--- a/test/integration/driver_install_or_update_test.go
+++ b/test/integration/driver_install_or_update_test.go
@@ -77,7 +77,8 @@ func TestDriverInstallOrUpdate(t *testing.T) {
 
 		os.Setenv("PATH", fmt.Sprintf("%s:%s", path, originalPath))
 
-		newerVersion, err := semver.Make("1.1.3")
+		// NOTE: This should be a real version, as it impacts the downloaded URL
+		newerVersion, err := semver.Make("1.3.0")
 		if err != nil {
 			t.Fatalf("Expected new semver. test: %v, got: %v", tc.name, err)
 		}

--- a/test/integration/driver_install_or_update_test.go
+++ b/test/integration/driver_install_or_update_test.go
@@ -84,7 +84,7 @@ func TestDriverInstallOrUpdate(t *testing.T) {
 
 		err = drivers.InstallOrUpdate("docker-machine-driver-kvm2", dir, newerVersion)
 		if err != nil {
-			t.Fatalf("Expected to update driver. test: %s, got: %v", tc.name, err)
+			t.Fatalf("Failed to update driver to %v. test: %s, got: %v", newerVersion, tc.name, err)
 		}
 
 		_, err = os.Stat(filepath.Join(dir, "docker-machine-driver-kvm2"))


### PR DESCRIPTION
The driver download currently downloads the driver from the latest official release. 

When one is running a beta version of minikube, this results in constantly downloading an older release of the driver.

Also, while I was here, add sha256 checking, and a lot of logging.