### PR TITLE
Revise leftover VM cleanup in integration tests

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -111,8 +111,7 @@ for stale_dir in ${TEST_ROOT}/*; do
     sudo rm -f "${kconfig}"
   done
 
-  # test.out, test.json, etc.
-  rm "${stale_dir}/test*" || true
+  rm -f "${stale_dir}/*" || true
   rmdir "${stale_dir}" || ls "${stale_dir}"
 done
 

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -126,7 +126,6 @@ fi
 
 if type -P virsh; then
   virsh -c qemu:///system list --all --uuid \
-    | awk '{ print $2 }' \
     | xargs -I {} sh -c "virsh -c qemu:///system destroy {}; virsh -c qemu:///system undefine {}" \
     || true
   echo ">> virsh VM list after clean up (should be empty):"

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -111,6 +111,8 @@ for stale_dir in ${TEST_ROOT}/*; do
     sudo rm -f "${kconfig}"
   done
 
+  # test.out, test.json, etc.
+  rm "${stale_dir}/test*" || true
   rmdir "${stale_dir}" || ls "${stale_dir}"
 done
 

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -125,7 +125,7 @@ if [[ "${zombie_defuncts}" != "" ]]; then
 fi
 
 if type -P virsh; then
-  virsh -c qemu:///system list --all \
+  virsh -c qemu:///system list --all --uuid \
     | awk '{ print $2 }' \
     | xargs -I {} sh -c "virsh -c qemu:///system destroy {}; virsh -c qemu:///system undefine {}" \
     || true
@@ -136,6 +136,7 @@ fi
 if type -P vboxmanage; then
   vboxmanage list vms || true
   vboxmanage list vms \
+    | egrep -o '{.*?}' \
     | xargs -I {} sh -c "vboxmanage startvm {} --type emergencystop; vboxmanage unregistervm {} --delete" \
     || true
 


### PR DESCRIPTION
With our recent refactor, we've changed how VM's are named. This PR takes that change into account and attempts to simplify the cleanup as much as possible.

Closes #5376
