### PR TITLE
Offset integration tests which start clusters by 5s

### DIFF
--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -36,7 +36,7 @@ import (
 
 // TestAddons tests addons that require no special environment -- in parallel
 func TestAddons(t *testing.T) {
-	MaybeParallel(t)
+	MaybeSlowParallel(t)
 
 	profile := UniqueProfileName("addons")
 	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Minute)

--- a/test/integration/docker_test.go
+++ b/test/integration/docker_test.go
@@ -30,7 +30,7 @@ func TestDockerFlags(t *testing.T) {
 	if NoneDriver() {
 		t.Skip("skipping: none driver does not support ssh or bundle docker")
 	}
-	MaybeParallel(t)
+	MaybeSlowParallel(t)
 
 	profile := UniqueProfileName("docker-flags")
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)

--- a/test/integration/guest_env_test.go
+++ b/test/integration/guest_env_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestGuestEnvironment(t *testing.T) {
-	MaybeParallel(t)
+	MaybeSlowParallel(t)
 	profile := UniqueProfileName("guest")
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer CleanupWithLogs(t, profile, cancel)

--- a/test/integration/gvisor_addon_test.go
+++ b/test/integration/gvisor_addon_test.go
@@ -33,7 +33,7 @@ func TestGvisorAddon(t *testing.T) {
 	if NoneDriver() {
 		t.Skip("Can't run containerd backend with none driver")
 	}
-	MaybeParallel(t)
+	MaybeSlowParallel(t)
 
 	profile := UniqueProfileName("gvisor")
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -74,7 +74,7 @@ func TestStartStop(t *testing.T) {
 		for _, tc := range tests {
 			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
-				MaybeParallel(t)
+				MaybeSlowParallel(t)
 
 				if !strings.Contains(tc.name, "docker") && NoneDriver() {
 					t.Skipf("skipping %s - incompatible with none driver", t.Name())

--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -41,7 +41,7 @@ import (
 func TestVersionUpgrade(t *testing.T) {
 	profile := UniqueProfileName("vupgrade")
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-	MaybeParallel(t)
+	MaybeSlowParallel(t)
 
 	defer CleanupWithLogs(t, profile, cancel)
 


### PR DESCRIPTION
Adds `MaybeSlowParallel`, which offsets parallel test startup by 5 seconds. 

This is used to avoid race conditions in tests which create a cluster. My instinct says that 5 seconds should be enough time to offset sensitive steps, such as manipulating certificates. 

https://github.com/kubernetes/minikube/issues/5368
https://github.com/kubernetes/minikube/issues/5153
https://github.com/kubernetes/minikube/issues/4967