### PR TITLE
Provide actionable feedback when running an incompatible driver with root

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -593,8 +593,12 @@ func validateUser(driver string) {
 	}
 
 	out.T(out.Stopped, `The "{{.driver_name}}" driver should not be used with root privileges.`, out.V{"driver_name": driver})
-	out.T(out.Tip, "If you are running minikube within a VM, consider using '--vm-driver=none': https://minikube.sigs.k8s.io/docs/reference/drivers/none/")
+	out.T(out.Tip, "If you are running minikube within a VM, consider using --vm-driver=none:")
+	out.T(out.Documentation, "  https://minikube.sigs.k8s.io/docs/reference/drivers/none/")
 
+	if !useForce {
+		os.Exit(exit.Permissions)
+	}
 	_, err = cfg.Load()
 	if err == nil || !os.IsNotExist(err) {
 		out.T(out.Tip, "Tip: To remove this root owned cluster, run: sudo {{.cmd}} delete", out.V{"cmd": minikubeCmd()})

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -561,7 +561,8 @@ func validateUser() {
 		return
 	}
 
-	out.T(out.Stopped, "The {{.driver_name}} driver should not be used with root privileges.", out.V{"driver_name": d})
+	out.T(out.Stopped, `The "{{.driver_name}}" driver should not be used with root privileges.`, out.V{"driver_name": d})
+	out.T(out.Tip, "If you are running minikube within a VM, consider using '--vm-driver=none': https://minikube.sigs.k8s.io/docs/reference/drivers/none/")
 
 	_, err = cfg.Load()
 	if err == nil || !os.IsNotExist(err) {


### PR DESCRIPTION
Old output:

```
😄  minikube v1.4.0-beta.1 on Debian rodete
🛑  The virtualbox driver should not be used with root privileges.
💡  Tip: To remove this root owned cluster, run: sudo minikube delete
💣  Exiting
```

New output:

```
😄  minikube v1.4.0-beta.2 on Debian rodete
🛑  The "kvm2" driver should not be used with root privileges.
💡  If you are running minikube within a VM, consider using --vm-driver=none:
📘    https://minikube.sigs.k8s.io/docs/reference/drivers/none/
```