### PR TITLE
UI: Indent driver download and sudo command display

### DIFF
--- a/pkg/drivers/drivers.go
+++ b/pkg/drivers/drivers.go
@@ -250,7 +250,7 @@ func ExtractVMDriverVersion(s string) string {
 }
 
 func setHyperKitPermissions(driverPath string) error {
-	msg := fmt.Sprintf("A new hyperkit driver was installed. It needs elevated permissions to run. The following commands will be executed:\n  sudo chown root:wheel %s\n  sudo chmod u+s %s", driverPath, driverPath)
+	msg := fmt.Sprintf("A new hyperkit driver was installed. It needs elevated permissions to run. The following commands will be executed:\n\n    $ sudo chown root:wheel %s\n    $ sudo chmod u+s %s\n", driverPath, driverPath)
 	out.T(out.Permissions, msg, out.V{})
 
 	cmd := exec.Command("sudo", "chown", "root:wheel", driverPath)

--- a/pkg/util/progressbar.go
+++ b/pkg/util/progressbar.go
@@ -46,7 +46,7 @@ func (cpb *progressBar) TrackProgress(src string, currentSize, totalSize int64, 
 		cpb.progress = pb.New64(totalSize)
 	}
 	p := pb.Full.Start64(totalSize)
-	p.Set("prefix", filepath.Base(src+": "))
+	p.Set("prefix", "    > "+filepath.Base(src+": "))
 	p.SetCurrent(currentSize)
 	p.Set(pb.Bytes, true)
 


### PR DESCRIPTION
Old:

```
😄  minikube v1.4.0-beta.2 on Darwin 10.14.6
💾  Downloading driver docker-machine-driver-hyperkit:
docker-machine-driver-hyperkit.sha256: 65 B / 65 B [---------] 100.00% ? p/s 0s
docker-machine-driver-hyperkit: 28.84 MiB / 28.84 MiB  100.00% 10.25 MiB p/s 3s
🔑  A new hyperkit driver was installed. It needs elevated permissions to run. The following commands will be executed:
  sudo chown root:wheel /Users/tstromberg/.minikube/bin/docker-machine-driver-hyperkit
  sudo chmod u+s /Users/tstromberg/.minikube/bin/docker-machine-driver-hyperkit
🔥  Creating hyperkit VM (CPUs=2, Memory=2000MB, Disk=20000MB) ...
```

New:

```
🙄  "minikube" cluster does not exist
💔  The "minikube" cluster has been deleted.
😄  minikube v1.4.0-beta.2 on Darwin 10.14.6
💾  Downloading driver docker-machine-driver-hyperkit:
    > docker-machine-driver-hyperkit.sha256: 65 B / 65 B [---] 100.00% ? p/s 0s
    > docker-machine-driver-hyperkit: 28.84 MiB / 28.84 MiB  100.00% 15.69 MiB 
🔑  A new hyperkit driver was installed. It needs elevated permissions to run. The following commands will be executed:

    $ sudo chown root:wheel /Users/tstromberg/.minikube/bin/docker-machine-driver-hyperkit
    $ sudo chmod u+s /Users/tstromberg/.minikube/bin/docker-machine-driver-hyperkit

🔥  Creating hyperkit VM (CPUs=2, Memory=2000MB, Disk=20000MB) ...
```
