### PR TITLE
Include ISO files as part of a GitHub release

### DIFF
--- a/hack/jenkins/release_github_page.sh
+++ b/hack/jenkins/release_github_page.sh
@@ -28,7 +28,7 @@ set -eux -o pipefail
 readonly VERSION="${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BUILD}"
 readonly DEB_VERSION="${VERSION/-/\~}"
 readonly RPM_VERSION="${DEB_VERSION}"
-
+readonly ISO_BUCKET="minikube/iso"
 readonly TAGNAME="v${VERSION}"
 
 readonly GITHUB_ORGANIZATION="kubernetes"
@@ -40,7 +40,7 @@ if ! [[ ${VERSION_BUILD} =~ ^[0-9]+$ ]]; then
   RELEASE_FLAGS="-p"
 fi
 
-RELEASE_NOTES=$(perl -e "\$p=0; while(<>) { if(/^## Version ${VERSION}/) { \$p=1 } elsif (/^##/) { \$p=0 }; if (\$p) { print }}" < CHANGELOG.md)
+RELEASE_NOTES=$(perl -e "\$p=0; while(<>) { if(/^## Version ${VERSION} -/) { \$p=1 } elsif (/^##/) { \$p=0 }; if (\$p) { print }}" < CHANGELOG.md)
 if [[ "${RELEASE_NOTES}" = "" ]]; then
   RELEASE_NOTES="(missing for ${VERSION})"
 fi
@@ -90,6 +90,15 @@ FILES_TO_UPLOAD=(
     'docker-machine-driver-hyperkit.sha256'
 )
 
+# ISO files are special, as they are generated pre-release tagging
+ISO_FILES=("minikube-v${VERSION}.iso" "minikube-v${VERSION}.iso.sha256")
+for DOWNLOAD in "${ISO_FILES[@]}"
+do
+  gsutil cp "gs://${ISO_BUCKET}/${DOWNLOAD}" out/ \
+    && FILES_TO_UPLOAD+=($DOWNLOAD) \
+    || echo "${DOWNLOAD} was not generated for this release"
+done
+
 for UPLOAD in "${FILES_TO_UPLOAD[@]}"
 do
     n=0
@@ -105,3 +114,4 @@ do
         sleep 15
     done
 done
+

--- a/hack/jenkins/release_github_page.sh
+++ b/hack/jenkins/release_github_page.sh
@@ -95,7 +95,7 @@ ISO_FILES=("minikube-v${VERSION}.iso" "minikube-v${VERSION}.iso.sha256")
 for DOWNLOAD in "${ISO_FILES[@]}"
 do
   gsutil cp "gs://${ISO_BUCKET}/${DOWNLOAD}" out/ \
-    && FILES_TO_UPLOAD+=($DOWNLOAD) \
+    && FILES_TO_UPLOAD+=("${DOWNLOAD}") \
     || echo "${DOWNLOAD} was not generated for this release"
 done
 
@@ -110,7 +110,7 @@ do
           --tag "${TAGNAME}" \
           --name "$UPLOAD" \
           --file "out/$UPLOAD" && break
-        n=$[$n+1]
+        n=$((n+1))
         sleep 15
     done
 done

--- a/hack/jenkins/release_github_page.sh
+++ b/hack/jenkins/release_github_page.sh
@@ -114,4 +114,3 @@ do
         sleep 15
     done
 done
-


### PR DESCRIPTION
Partially addresses #4774 - but needs auto-download capability first

One quirk is that we currently generate ISO releases in advance of the tag. I've decided not to change the ISO release process yet, but just copy the ISO files to GitHub.