### PR TITLE
Retry StartHost only 3 times: 5 is excessive

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -868,7 +868,7 @@ func startHost(api libmachine.API, mc cfg.MachineConfig) (*host.Host, bool) {
 		return err
 	}
 
-	if err = retry.Expo(start, 2*time.Second, 3*time.Minute, 5); err != nil {
+	if err = retry.Expo(start, 5*time.Second, 3*time.Minute, 3); err != nil {
 		exit.WithError("Unable to start VM", err)
 	}
 	return host, exists


### PR DESCRIPTION
This causes a less jarring experience when the user doesn't have VirtualBox installed.