### PR TITLE
Fix order of parameters to CurrentContext funcs

### DIFF
--- a/cmd/minikube/cmd/config/profile.go
+++ b/cmd/minikube/cmd/config/profile.go
@@ -71,7 +71,7 @@ var ProfileCmd = &cobra.Command{
 				out.SuccessT("Skipped switching kubectl context for {{.profile_name}} because --keep-context was set.", out.V{"profile_name": profile})
 				out.SuccessT("To connect to this cluster, use: kubectl --context={{.profile_name}}", out.V{"profile_name": profile})
 			} else {
-				err := kubeconfig.SetCurrentContext(constants.KubeconfigPath, profile)
+				err := kubeconfig.SetCurrentContext(profile, constants.KubeconfigPath)
 				if err != nil {
 					out.ErrT(out.Sad, `Error while setting kubectl current context :  {{.error}}`, out.V{"error": err})
 				}

--- a/cmd/minikube/cmd/stop.go
+++ b/cmd/minikube/cmd/stop.go
@@ -77,7 +77,7 @@ func runStop(cmd *cobra.Command, args []string) {
 	}
 
 	machineName := pkg_config.GetMachineName()
-	err = kubeconfig.UnsetCurrentContext(constants.KubeconfigPath, machineName)
+	err = kubeconfig.UnsetCurrentContext(machineName, constants.KubeconfigPath)
 	if err != nil {
 		exit.WithError("update config", err)
 	}


### PR DESCRIPTION
Apparently it is easy to get name and path swapped around.

Fixes #5436

Also fixes the issue where "stop" didn't unset the current-context (due to profile name not matching).