### PR TITLE
Run travis tests in parallel VMs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,1 +1,7 @@
-comment: false
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: no        # [yes :: must have a base report to post]
+  require_head: yes       # [yes :: must have a head report to post]
+  branches: null          # branch names that can post comment

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ os: linux
 language: go
 go:
   - 1.12.9
-
 env:
   global:
     - GOPROXY=https://proxy.golang.org
@@ -33,10 +32,8 @@ matrix:
       before_install:
         - sudo apt-get install -y libvirt-dev
       script: make test
-
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-
 notifications:
     webhooks: https://www.travisbuddy.com/
     on_success: never # travisbuddy don't comment on successful 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
   include:
     - language: python
       env:
-        - TESTSUITE_BOILERPLATE=true
+        - TESTSUITE=boilerplate
       before_install: 
           - pip install flake8 && flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       script: make test
@@ -18,7 +18,7 @@ matrix:
     - language: go
       go: 1.12.9
       env:
-        - TESTSUITE_LINT=true
+        - TESTSUITE=lint
       before_install:
         - sudo apt-get install -y libvirt-dev
       script: make test
@@ -26,7 +26,7 @@ matrix:
     - language: go
       go: 1.12.9
       env:
-        - TESTSUITE_UNIT=true
+        - TESTSUITE=unittest
       before_install:
         - sudo apt-get install -y libvirt-dev
       script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ go:
 env:
   global:
     - GOPROXY=https://proxy.golang.org
-
 matrix:
   include:
     - language: python
@@ -22,14 +21,16 @@ matrix:
       go: 1.12.9
       env:
         - TESTSUITE_LINT=true
+      before_install:
+        - sudo apt-get install -y libvirt-dev
       script: make test
 
     - language: go
       go: 1.12.9
       env:
         - TESTSUITE_UNIT=true
-      # before_install:
-      #   - sudo apt-get install -y libvirt-dev
+      before_install:
+        - sudo apt-get install -y libvirt-dev
       script: make test
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ go:
 env:
   global:
     - GOPROXY=https://proxy.golang.org
-  matrix:
-    - TESTSUITE_LINT=true
-    - TESTSUITE_BOILERPLATE=true
-    - TESTSUITE_UNIT=true
 
 matrix:
   include:
@@ -17,14 +13,28 @@ matrix:
       before_install: pip install flake8
       script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 
-before_install:
-  - sudo apt-get install -y libvirt-dev
-install:
-  - echo "Don't run anything."
-script:
-  - make test
+    - language: python
+      env:
+        - TESTSUITE_BOILERPLATE=true
+      script: make test
+
+    - language: go
+      go: 1.12.9
+      env:
+        - TESTSUITE_LINT=true
+      script: make test
+
+    - language: go
+      go: 1.12.9
+      env:
+        - TESTSUITE_UNIT=true
+      # before_install:
+      #   - sudo apt-get install -y libvirt-dev
+      script: make test
+
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+
 notifications:
     webhooks: https://www.travisbuddy.com/
     on_success: never # travisbuddy don't comment on successful 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: go
 os: linux
-
 env:
-  - GOPROXY=https://proxy.golang.org
+  global:
+    - GOPROXY=https://proxy.golang.org
+  matrix:
+    - TESTSUITE_LINT=true
+    - TESTSUITE_BOILERPLATE=true
+    - TESTSUITE_UNIT=true
+
 matrix:
   include:
     - go: 1.12.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+os: linux
+language: go
+go:
+  - 1.12.9
+
 env:
   global:
     - GOPROXY=https://proxy.golang.org
@@ -8,8 +13,6 @@ env:
 
 matrix:
   include:
-    - os: linux
-    - go: 1.12.9
     - language: python
       before_install: pip install flake8
       script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
 matrix:
   include:
     - language: python
+      name: Check Boilerplate 
       env:
         - TESTSUITE=boilerplate
       before_install: 
@@ -16,6 +17,7 @@ matrix:
       script: make test
 
     - language: go
+      name: Code Lint 
       go: 1.12.9
       env:
         - TESTSUITE=lint
@@ -24,6 +26,7 @@ matrix:
       script: make test
 
     - language: go
+      name: Unit Test
       go: 1.12.9
       env:
         - TESTSUITE=unittest

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,10 @@ env:
 matrix:
   include:
     - language: python
-      before_install: pip install flake8
-      script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-
-    - language: python
       env:
         - TESTSUITE_BOILERPLATE=true
+      before_install: 
+          - pip install flake8 && flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       script: make test
 
     - language: go

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-language: go
-os: linux
 env:
   global:
     - GOPROXY=https://proxy.golang.org
@@ -10,6 +8,7 @@ env:
 
 matrix:
   include:
+    - os: linux
     - go: 1.12.9
     - language: python
       before_install: pip install flake8

--- a/test.sh
+++ b/test.sh
@@ -15,41 +15,49 @@
 # limitations under the License.
 
 set -eu -o pipefail
-
+# TODO: fix exit code numbers 
+# TODO: make test should work locally as it was before
 exitcode=0
 
 echo "= go mod ================================================================"
 go mod download 2>&1 | grep -v "go: finding" || true
 go mod tidy -v && echo ok || ((exitcode += 2))
 
-echo "= make lint ============================================================="
-make -s lint-ci && echo ok || ((exitcode += 4))
-
-echo "= boilerplate ==========================================================="
-readonly PYTHON=$(type -P python || echo docker run --rm -it -v $(pwd):/minikube -w /minikube python python)
-readonly BDIR="./hack/boilerplate"
-missing="$($PYTHON ${BDIR}/boilerplate.py --rootdir . --boilerplate-dir ${BDIR} | egrep -v '/assets.go|/translations.go|/site/themes/|/site/node_modules|\./out|/hugo/' || true)"
-if [[ -n "${missing}" ]]; then
-    echo "boilerplate missing: $missing"
-    echo "consider running: ${BDIR}/fix.sh"
-    ((exitcode += 4))
-else
-    echo "ok"
+if [ ! -z "$TESTSUITE_LINT"] then 
+    echo "= make lint ============================================================="
+    make -s lint-ci && echo ok || ((exitcode += 4))
 fi
 
-echo "= schema_check =========================================================="
-go run deploy/minikube/schema_check.go >/dev/null && echo ok || ((exitcode += 8))
 
-echo "= go test ==============================================================="
-cov_tmp="$(mktemp)"
-readonly COVERAGE_PATH=./out/coverage.txt
-echo "mode: count" >"${COVERAGE_PATH}"
-pkgs=$(go list -f '{{ if .TestGoFiles }}{{.ImportPath}}{{end}}' ./cmd/... ./pkg/... | xargs)
-go test \
-    -tags "container_image_ostree_stub containers_image_openpgp" \
-    -covermode=count \
-    -coverprofile="${cov_tmp}" \
-    ${pkgs} && echo ok || ((exitcode += 16))
-tail -n +2 "${cov_tmp}" >>"${COVERAGE_PATH}"
+if [ ! -z "$TESTSUITE_BOILERPLATE"] then 
+    echo "= boilerplate ==========================================================="
+    readonly PYTHON=$(type -P python || echo docker run --rm -it -v $(pwd):/minikube -w /minikube python python)
+    readonly BDIR="./hack/boilerplate"
+    missing="$($PYTHON ${BDIR}/boilerplate.py --rootdir . --boilerplate-dir ${BDIR} | egrep -v '/assets.go|/translations.go|/site/themes/|/site/node_modules|\./out|/hugo/' || true)"
+    if [[ -n "${missing}" ]]; then
+        echo "boilerplate missing: $missing"
+        echo "consider running: ${BDIR}/fix.sh"
+        ((exitcode += 4))
+    else
+        echo "ok"
+    fi
+    echo "= schema_check =========================================================="
+    go run deploy/minikube/schema_check.go >/dev/null && echo ok || ((exitcode += 8))
+fi
+
+
+if [ ! -z "$TESTSUITE_UNIT"] then 
+    echo "= go test ==============================================================="
+    cov_tmp="$(mktemp)"
+    readonly COVERAGE_PATH=./out/coverage.txt
+    echo "mode: count" >"${COVERAGE_PATH}"
+    pkgs=$(go list -f '{{ if .TestGoFiles }}{{.ImportPath}}{{end}}' ./cmd/... ./pkg/... | xargs)
+    go test \
+        -tags "container_image_ostree_stub containers_image_openpgp" \
+        -covermode=count \
+        -coverprofile="${cov_tmp}" \
+        ${pkgs} && echo ok || ((exitcode += 16))
+    tail -n +2 "${cov_tmp}" >>"${COVERAGE_PATH}"
+fi
 
 exit "${exitcode}"

--- a/test.sh
+++ b/test.sh
@@ -16,7 +16,7 @@
 
 set -eu -o pipefail
 
-TESTSUITE="${TESTSUITE:-all}"
+TESTSUITE="${TESTSUITE:-all}" # if env variable not set run all the tests
 exitcode=0
 
 if [ "$TESTSUITE" = "lint" ] || [ "$TESTSUITE" = "all" ]

--- a/test.sh
+++ b/test.sh
@@ -55,13 +55,14 @@ then
     else
         echo "ok"
     fi
-    echo "= schema_check =========================================================="
-    go run deploy/minikube/schema_check.go >/dev/null && echo ok || ((exitcode += 8))
 fi
 
 
 if [[ ! -z "$TESTSUITE_UNIT" ]]
 then 
+    echo "= schema_check =========================================================="
+    go run deploy/minikube/schema_check.go >/dev/null && echo ok || ((exitcode += 8))
+
     echo "= go test ==============================================================="
     cov_tmp="$(mktemp)"
     readonly COVERAGE_PATH=./out/coverage.txt

--- a/test.sh
+++ b/test.sh
@@ -19,7 +19,7 @@ set -eu -o pipefail
 TESTSUITE="${TESTSUITE:-all}" # if env variable not set run all the tests
 exitcode=0
 
-if [ "$TESTSUITE" = "lint" ] || [ "$TESTSUITE" = "all" ]
+if [[ "$TESTSUITE" = "lint" ]] || [[ "$TESTSUITE" = "all" ]]
 then 
     echo "= make lint ============================================================="
     make -s lint-ci && echo ok || ((exitcode += 4))
@@ -30,7 +30,7 @@ fi
 
 
 
-if [ "$TESTSUITE" = "boilerplate" ] || [ "$TESTSUITE" = "all" ]
+if [[ "$TESTSUITE" = "boilerplate" ]] || [[ "$TESTSUITE" = "all" ]]
 then
     echo "= boilerplate ==========================================================="
     readonly PYTHON=$(type -P python || echo docker run --rm -it -v $(pwd):/minikube -w /minikube python python)
@@ -46,7 +46,7 @@ then
 fi
 
 
-if [ "$TESTSUITE" = "unittest" ] || [ "$TESTSUITE" = "all" ]
+if [[ "$TESTSUITE" = "unittest" ]] || [[ "$TESTSUITE" = "all" ]]
 then 
     echo "= schema_check =========================================================="
     go run deploy/minikube/schema_check.go >/dev/null && echo ok || ((exitcode += 16))

--- a/test.sh
+++ b/test.sh
@@ -16,7 +16,6 @@
 
 set -e -o pipefail
 # TODO: fix exit code numbers 
-# TODO: make test should work locally as it was before
 if [[ -z "$TESTSUITE_LINT" && -z "$TESTSUITE_UNIT" && -z "$TESTSUITE_BOILERPLATE" ]]  
 then # if all of them are not set then it is a local run
     TESTSUITE_LINT=true


### PR DESCRIPTION
This PR :
- break down the travis tests to 3 tests 
   - check boilerplate
   - code lint
   - unit tests
- Run each tests in its own travis VM in  parallel 
- Give name to each sub-build 
- Cut down the current test time a by 3 minutes.
- Also enable codecov bot to comment on PRs on how the PR changes the unit tests
![Screenshot_2019-09-25_11-35-30](https://user-images.githubusercontent.com/4564227/65629676-9fbcaf00-df88-11e9-8257-0aa9cd2bc082.png)


one thing worth noting. in travis you will see

```
 Ran for 5 min 4 sec
 Total time 11 min 20 sec
```

the Total time is the time across all VMs which ran in parallel.  unfortunately the one that shows in the list is the Total time, which is mis-leading, the one that needs to be looked at is, "Ran For" which is the duration from start of job to end of job.