### PR TITLE
Setting travis-ci notification settings explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,5 +35,10 @@ matrix:
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 notifications:
-    webhooks: https://www.travisbuddy.com/
-    on_success: never # travisbuddy don't comment on successful 
+    webhooks: 
+      urls: 
+        - https://www.travisbuddy.com?only=failed,errored
+      on_success: never  # don't comment on successful builds.
+      on_failure: always
+      on_cancel:  always
+      on_error:   always


### PR DESCRIPTION
To make sure the travis-buddy comments only on failed builds and not make noise when things are okay ! seems like it is a travis-ci issue not respecting the "never" https://github.com/bluzi/travis-buddy/issues/153