### PR TITLE
Fix pods not being scheduled when ingress deployment is patched

### DIFF
--- a/deploy/addons/ingress/ingress-dp.yaml.tmpl
+++ b/deploy/addons/ingress/ingress-dp.yaml.tmpl
@@ -24,6 +24,12 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # maxUnavailable needs to be 1 so that port conflicts between the old and new pod doesn't happen when using hostPort
+      maxUnavailable: 1
+      maxSurge: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx-ingress-controller
@@ -42,7 +48,7 @@ spec:
       serviceAccountName: nginx-ingress
       terminationGracePeriodSeconds: 60
       containers:
-      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller{{.ExoticArch}}:0.25.1
+      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller{{.ExoticArch}}:0.26.1
         name: nginx-ingress-controller
         imagePullPolicy: IfNotPresent
         readinessProbe:


### PR DESCRIPTION
This issue resolves https://github.com/kubernetes/minikube/issues/5518
Also update nginx-ingress-controller to 0.26.1 which resolves some other inconsistency issues