### PR TITLE
WIP: Fix default cni config

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/default_cni.go
+++ b/pkg/minikube/bootstrapper/kubeadm/default_cni.go
@@ -22,23 +22,32 @@ package kubeadm
 // The config is being written to /etc/cni/net.d/k8s.conf.
 const defaultCNIConfig = `
 {
-  "cniVersion": "0.3.0",
-  "name": "rkt.kubernetes.io",
-  "type": "bridge",
-  "bridge": "mybridge",
-  "mtu": 1460,
-  "addIf": "true",
-  "isGateway": true,
-  "ipMasq": true,
-  "ipam": {
-    "type": "host-local",
-    "subnet": "10.1.0.0/16",
-    "gateway": "10.1.0.1",
-    "routes": [
-      {
-        "dst": "0.0.0.0/0"
-      }
+    "cniVersion": "0.3.1",
+    "name": "rkt.kubernetes.io",
+    "plugins": [
+        {
+            "type": "bridge",
+            "bridge": "mybridge",
+            "mtu": 1460,
+            "addIf": "true",
+            "isGateway": true,
+            "ipMasq": true,
+            "ipam": {
+                "type": "host-local",
+                "subnet": "10.1.0.0/16",
+                "gateway": "10.1.0.1",
+                "routes": [
+                    {
+                        "dst": "0.0.0.0/0"
+                    }
+                ]
+            }
+        },
+        {
+            "type": "portmap",
+            "capabilities": {"portMappings": true},
+            "externalSetMarkChain": "KUBE-MARK-MASQ"
+        }
     ]
-  }
 }
 `


### PR DESCRIPTION
fixes #3056 
Not sure how to test. Probably I don't know what I'm doing but I get this output when trying to run on Ubuntu 18.04.03
<details>
<pre>
john@john-doe-vm:~/Projects/OpenSource/minikube$ ./out/minikube start --vm-driver kvm2 --network-plugin=cni --extra-config=kubelet.network-plugin=cni --extra-config=kubelet.cni-conf-dir=/etc/cni/net.d --extra-config=kubelet.cni-bin-dir=/opt/cni/bin
😄  minikube v1.4.0 on Ubuntu 18.04
💾  Downloading driver docker-machine-driver-kvm2:
    > docker-machine-driver-kvm2.sha256: 65 B / 65 B [-------] 100.00% ? p/s 0s
    > docker-machine-driver-kvm2: 32.00 MiB / 32.00 MiB  100.00% 7.11 MiB p/s 4
🔥  Creating kvm2 VM (CPUs=2, Memory=2000MB, Disk=20000MB) ...
🔄  Retriable failure: new host: dial tcp: missing address
🔥  Creating kvm2 VM (CPUs=2, Memory=2000MB, Disk=20000MB) ...
🔄  Retriable failure: new host: dial tcp: missing address
^C
</pre>
</details>
However, even though I can't test it, based on these articles:

https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/
https://github.com/containernetworking/plugins/blob/master/plugins/meta/portmap/README.md

I think our current configuration is completely invalid. 