### PR TITLE
Replace BR2_EXTERNAL_MINIKUBE_PATH with PKGDIR.

### DIFF
--- a/deploy/iso/minikube-iso/package/automount/automount.mk
+++ b/deploy/iso/minikube-iso/package/automount/automount.mk
@@ -6,7 +6,7 @@
 
 define AUTOMOUNT_INSTALL_INIT_SYSTEMD
 	$(INSTALL) -D -m 644 \
-		$(BR2_EXTERNAL_MINIKUBE_PATH)/package/automount/minikube-automount.service \
+		$(AUTOMOUNT_PKGDIR)/minikube-automount.service \
 		$(TARGET_DIR)/usr/lib/systemd/system/minikube-automount.service
 
 	ln -fs /usr/lib/systemd/system/minikube-automount.service \
@@ -15,7 +15,7 @@ endef
 
 define AUTOMOUNT_INSTALL_TARGET_CMDS
 	$(INSTALL) -Dm755 \
-		$(BR2_EXTERNAL_MINIKUBE_PATH)/package/automount/minikube-automount \
+		$(AUTOMOUNT_PKGDIR)/minikube-automount \
 		$(TARGET_DIR)/usr/sbin/minikube-automount
 endef
 

--- a/deploy/iso/minikube-iso/package/containerd-bin/containerd-bin.mk
+++ b/deploy/iso/minikube-iso/package/containerd-bin/containerd-bin.mk
@@ -42,13 +42,13 @@ define CONTAINERD_BIN_INSTALL_TARGET_CMDS
 		$(@D)/bin/ctr \
 		$(TARGET_DIR)/usr/bin
 	$(INSTALL) -Dm644 \
-		$(BR2_EXTERNAL_MINIKUBE_PATH)/package/containerd-bin/config.toml \
+		$(CONTAINERD_BIN_PKGDIR)/config.toml \
 		$(TARGET_DIR)/etc/containerd/config.toml
 endef
 
 define CONTAINERD_BIN_INSTALL_INIT_SYSTEMD
 	$(INSTALL) -Dm755 \
-		$(BR2_EXTERNAL_MINIKUBE_PATH)/package/containerd-bin/containerd.service \
+		$(CONTAINERD_BIN_PKGDIR)/containerd.service \
 		$(TARGET_DIR)/usr/lib/systemd/system/containerd.service
 	$(call link-service,containerd.service)
 	$(call link-service,containerd-shutdown.service)

--- a/deploy/iso/minikube-iso/package/crio-bin/crio-bin.mk
+++ b/deploy/iso/minikube-iso/package/crio-bin/crio-bin.mk
@@ -26,7 +26,7 @@ define CRIO_BIN_CONFIGURE_CMDS
 	mkdir -p $(CRIO_BIN_GOPATH)/src/github.com/cri-o
 	ln -sf $(@D) $(CRIO_BIN_GOPATH)/src/github.com/cri-o/cri-o
 	# Copy pre-generated conmon/config.h - see <https://github.com/cri-o/cri-o/issues/2575>
-	cp $(BR2_EXTERNAL_MINIKUBE_PATH)/package/crio-bin/conmon-config.h $(@D)/conmon/config.h
+	cp $(CRIO_BIN_PKGDIR)/conmon-config.h $(@D)/conmon/config.h
 endef
 
 define CRIO_BIN_BUILD_CMDS
@@ -48,13 +48,13 @@ define CRIO_BIN_INSTALL_TARGET_CMDS
 		$(@D)/bin/pause \
 		$(TARGET_DIR)/usr/libexec/crio/pause
 	$(INSTALL) -Dm644 \
-		$(BR2_EXTERNAL_MINIKUBE_PATH)/package/crio-bin/crio.conf \
+		$(CRIO_BIN_PKGDIR)/crio.conf \
 		$(TARGET_DIR)/etc/crio/crio.conf
 	$(INSTALL) -Dm644 \
-		$(BR2_EXTERNAL_MINIKUBE_PATH)/package/crio-bin/policy.json \
+		$(CRIO_BIN_PKGDIR)/policy.json \
 		$(TARGET_DIR)/etc/containers/policy.json
 	$(INSTALL) -Dm644 \
-		$(BR2_EXTERNAL_MINIKUBE_PATH)/package/crio-bin/registries.conf \
+		$(CRIO_BIN_PKGDIR)/registries.conf \
 		$(TARGET_DIR)/etc/containers/registries.conf
 
 	mkdir -p $(TARGET_DIR)/etc/sysconfig
@@ -64,7 +64,7 @@ endef
 define CRIO_BIN_INSTALL_INIT_SYSTEMD
 	$(MAKE) $(TARGET_CONFIGURE_OPTS) -C $(@D) install.systemd DESTDIR=$(TARGET_DIR) PREFIX=$(TARGET_DIR)/usr
 	$(INSTALL) -Dm644 \
-		$(BR2_EXTERNAL_MINIKUBE_PATH)/package/crio-bin/crio.service \
+		$(CRIO_BIN_PKGDIR)/crio.service \
 		$(TARGET_DIR)/usr/lib/systemd/system/crio.service
 	$(call link-service,crio.service)
 	$(call link-service,crio-shutdown.service)

--- a/deploy/iso/minikube-iso/package/docker-bin/docker-bin.mk
+++ b/deploy/iso/minikube-iso/package/docker-bin/docker-bin.mk
@@ -38,7 +38,7 @@ define DOCKER_BIN_INSTALL_INIT_SYSTEMD
 		$(TARGET_DIR)/usr/lib/systemd/system/docker.socket
 
 	$(INSTALL) -D -m 644 \
-		$(BR2_EXTERNAL_MINIKUBE_PATH)/package/docker-bin/forward.conf \
+		$(DOCKER_BIN_PKGDIR)/forward.conf \
 		$(TARGET_DIR)/etc/sysctl.d/forward.conf
 endef
 

--- a/deploy/iso/minikube-iso/package/hyperv-daemons/hyperv-daemons.mk
+++ b/deploy/iso/minikube-iso/package/hyperv-daemons/hyperv-daemons.mk
@@ -37,23 +37,23 @@ endef
 
 define HYPERV_DAEMONS_INSTALL_INIT_SYSTEMD
 	$(INSTALL) -D -m 644 \
-		$(BR2_EXTERNAL_MINIKUBE_PATH)/package/hyperv-daemons/70-hv_fcopy.rules \
+		$(HYPERV_DAEMONS_PKGDIR)/70-hv_fcopy.rules \
 		$(TARGET_DIR)/etc/udev/rules.d/70-hv_fcopy.rules
 	$(INSTALL) -D -m 644 \
-		$(BR2_EXTERNAL_MINIKUBE_PATH)/package/hyperv-daemons/70-hv_kvp.rules \
+		$(HYPERV_DAEMONS_PKGDIR)/70-hv_kvp.rules \
 		$(TARGET_DIR)/etc/udev/rules.d/70-hv_kvp.rules
 	$(INSTALL) -D -m 644 \
-		$(BR2_EXTERNAL_MINIKUBE_PATH)/package/hyperv-daemons/70-hv_vss.rules \
+		$(HYPERV_DAEMONS_PKGDIR)/70-hv_vss.rules \
 		$(TARGET_DIR)/etc/udev/rules.d/70-hv_vss.rules
 
 	$(INSTALL) -D -m 644 \
-		$(BR2_EXTERNAL_MINIKUBE_PATH)/package/hyperv-daemons/hv_fcopy_daemon.service \
+		$(HYPERV_DAEMONS_PKGDIR)/hv_fcopy_daemon.service \
 		$(TARGET_DIR)/usr/lib/systemd/system/hv_fcopy_daemon.service
 	$(INSTALL) -D -m 644 \
-		$(BR2_EXTERNAL_MINIKUBE_PATH)/package/hyperv-daemons/hv_kvp_daemon.service \
+		$(HYPERV_DAEMONS_PKGDIR)/hv_kvp_daemon.service \
 		$(TARGET_DIR)/usr/lib/systemd/system/hv_kvp_daemon.service
 	$(INSTALL) -D -m 644 \
-		$(BR2_EXTERNAL_MINIKUBE_PATH)/package/hyperv-daemons/hv_vss_daemon.service \
+		$(HYPERV_DAEMONS_PKGDIR)/hv_vss_daemon.service \
 		$(TARGET_DIR)/usr/lib/systemd/system/hv_vss_daemon.service
 
 	ln -fs /usr/lib/systemd/system/hv_fcopy_daemon.service \

--- a/deploy/iso/minikube-iso/package/vbox-guest/vbox-guest.mk
+++ b/deploy/iso/minikube-iso/package/vbox-guest/vbox-guest.mk
@@ -28,7 +28,7 @@ endef
 
 define VBOX_GUEST_INSTALL_INIT_SYSTEMD
 	$(INSTALL) -D -m 644 \
-		$(BR2_EXTERNAL_MINIKUBE_PATH)/package/vbox-guest/vboxservice.service \
+		$(VBOX_GUEST_PKGDIR)/vboxservice.service \
 		$(TARGET_DIR)/usr/lib/systemd/system/vboxservice.service
 
 	ln -fs /usr/lib/systemd/system/vboxservice.service \


### PR DESCRIPTION
Buildroot support the `_PKGDIR` variable to refer to the package
configuration directory. This means that we can replace all uses
of `BR2_EXTERNAL_MINIKUBE_PATH/package/foo` with `FOO_PKGDIR`.