### PR TITLE
Python code linters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 os: linux
 language: go
 go:
@@ -8,15 +9,15 @@ env:
 matrix:
   include:
     - language: python
-      name: Check Boilerplate 
+      name: Check Boilerplate
       env:
         - TESTSUITE=boilerplate
-      before_install: 
-          - pip install flake8 && flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      before_install:
+        - pip install flake8 && flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       script: make test
 
     - language: go
-      name: Code Lint 
+      name: Code Lint
       go: 1.12.9
       env:
         - TESTSUITE=lint
@@ -35,10 +36,10 @@ matrix:
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 notifications:
-    webhooks: 
-      urls: 
-        - https://www.travisbuddy.com?only=failed,errored
-      on_success: never  # don't comment on successful builds.
-      on_failure: always
-      on_cancel:  always
-      on_error:   always
+  webhooks:
+    urls:
+      - https://www.travisbuddy.com?only=failed,errored
+    on_success: never  # don't comment on successful builds.
+    on_failure: always
+    on_cancel: always
+    on_error: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,23 @@ env:
 matrix:
   include:
     - language: python
+      name: Code lint - python
+      before_install:
+        - pip install flake8 black
+      script:
+        - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        - black ./hack --check
+
+    - language: python
       name: Check Boilerplate
       env:
         - TESTSUITE=boilerplate
       before_install:
-        - pip install flake8 && flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        - pip install flake8
       script: make test
 
     - language: go
-      name: Code Lint
+      name: Code Lint - go
       go: 1.12.9
       env:
         - TESTSUITE=lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,11 @@ matrix:
     - language: python
       name: Code lint - python
       before_install:
-        - pip install flake8 black
+        - pip install flake8 black bandit
       script:
-        - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        - bandit ./hack
         - black ./hack --check
+        - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 
     - language: python
       name: Check Boilerplate

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -25,7 +25,9 @@ import re
 import sys
 
 parser = argparse.ArgumentParser()
-parser.add_argument("filenames", help="list of files to check, all files if unspecified", nargs='*')
+parser.add_argument(
+    "filenames", help="list of files to check, all files if unspecified", nargs="*"
+)
 
 rootdir = os.path.dirname(__file__) + "/../../"
 rootdir = os.path.abspath(rootdir)
@@ -42,16 +44,17 @@ def get_refs():
     for path in glob.glob(os.path.join(args.boilerplate_dir, "boilerplate.*.txt")):
         extension = os.path.basename(path).split(".")[1]
 
-        ref_file = open(path, 'r')
+        ref_file = open(path, "r")
         ref = ref_file.read().splitlines()
         ref_file.close()
         refs[extension] = ref
 
     return refs
 
+
 def file_passes(filename, refs, regexs):
     try:
-        f = open(filename, 'r')
+        f = open(filename, "r")
     except:
         return False
 
@@ -82,7 +85,7 @@ def file_passes(filename, refs, regexs):
         return False
 
     # trim our file to the same number of lines as the reference file
-    data = data[:len(ref)]
+    data = data[: len(ref)]
 
     p = regexs["year"]
     for d in data:
@@ -92,7 +95,7 @@ def file_passes(filename, refs, regexs):
     # Replace all occurrences of the regex "2018|2017|2016|2015|2014" with "YEAR"
     p = regexs["date"]
     for i, d in enumerate(data):
-        (data[i], found) = p.subn('YEAR', d)
+        (data[i], found) = p.subn("YEAR", d)
         if found != 0:
             break
 
@@ -102,10 +105,22 @@ def file_passes(filename, refs, regexs):
 
     return True
 
+
 def file_extension(filename):
     return os.path.splitext(filename)[1].split(".")[-1].lower()
 
-skipped_dirs = ['Godeps', 'third_party', '_gopath', '_output', '.git', 'cluster/env.sh', "vendor", "test/e2e/generated/bindata.go"]
+
+skipped_dirs = [
+    "Godeps",
+    "third_party",
+    "_gopath",
+    "_output",
+    ".git",
+    "cluster/env.sh",
+    "vendor",
+    "test/e2e/generated/bindata.go",
+]
+
 
 def normalize_files(files):
     newfiles = []
@@ -117,6 +132,7 @@ def normalize_files(files):
         if not os.path.isabs(pathname):
             newfiles[i] = os.path.join(rootdir, pathname)
     return newfiles
+
 
 def get_files(extensions):
     files = []
@@ -145,17 +161,19 @@ def get_files(extensions):
             outfiles.append(pathname)
     return outfiles
 
+
 def get_regexs():
     regexs = {}
     # Search for "YEAR" which exists in the boilerplate, but shouldn't in the real thing
-    regexs["year"] = re.compile( 'YEAR' )
+    regexs["year"] = re.compile("YEAR")
     # dates can be 2010 to 2039
-    regexs["date"] = re.compile( '(20[123]\d)' )
+    regexs["date"] = re.compile("(20[123]\d)")
     # strip // +build \n\n build constraints
     regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n", re.MULTILINE)
     # strip #!.* from shell scripts
     regexs["shebang"] = re.compile(r"^(#!.*\n)\n*", re.MULTILINE)
     return regexs
+
 
 def main():
     regexs = get_regexs()
@@ -166,5 +184,6 @@ def main():
         if not file_passes(filename, refs, regexs):
             print(filename, file=sys.stdout)
 
+
 if __name__ == "__main__":
-  sys.exit(main())
+    sys.exit(main())

--- a/hack/get_k8s_version.py
+++ b/hack/get_k8s_version.py
@@ -24,61 +24,80 @@ import sys
 import time
 from datetime import datetime
 
-K8S_PACKAGE = 'k8s.io/kubernetes/'
-X_ARGS = ['-X k8s.io/minikube/vendor/k8s.io/kubernetes/pkg/version.', '-X k8s.io/minikube/vendor/k8s.io/client-go/pkg/version.']
+K8S_PACKAGE = "k8s.io/kubernetes/"
+X_ARGS = [
+    "-X k8s.io/minikube/vendor/k8s.io/kubernetes/pkg/version.",
+    "-X k8s.io/minikube/vendor/k8s.io/client-go/pkg/version.",
+]
+
 
 def get_commit():
-  return 'gitCommit=%s' % get_from_godep('Rev')
+    return "gitCommit=%s" % get_from_godep("Rev")
+
 
 def get_version():
-    return 'gitVersion=%s' % get_from_godep('Comment')
+    return "gitVersion=%s" % get_from_godep("Comment")
+
 
 def get_major_and_minor():
-    major = ''
-    minor = ''
-    version = get_from_godep('Comment')
+    major = ""
+    minor = ""
+    version = get_from_godep("Comment")
     # [kubernetes/hack/lib/version.sh]:
     # Try to match the "git describe" output to a regex to try to extract
     # the "major" and "minor" versions and whether this is the exact tagged
     # version or whether the tree is between two tagged versions.
-    m = re.match('^v([0-9]+)\.([0-9]+)(\.[0-9]+)?([-].*)?$', version)
+    m = re.match("^v([0-9]+)\.([0-9]+)(\.[0-9]+)?([-].*)?$", version)
     if m:
         major = m.group(1)
         minor = m.group(2)
         if m.group(4):
             minor += "+"
-    return ('gitMajor=%s' % major, 'gitMinor=%s' % minor)
+    return ("gitMajor=%s" % major, "gitMinor=%s" % minor)
+
 
 def get_from_godep(key):
-  with open('./Godeps/Godeps.json') as f:
-    contents = json.load(f)
-    for dep in contents['Deps']:
-      if dep['ImportPath'].startswith(K8S_PACKAGE):
-        return dep[key]
+    with open("./Godeps/Godeps.json") as f:
+        contents = json.load(f)
+        for dep in contents["Deps"]:
+            if dep["ImportPath"].startswith(K8S_PACKAGE):
+                return dep[key]
+
 
 def get_tree_state():
-  git_status = subprocess.check_output(['git', 'status', '--porcelain'])
-  if git_status:
-    result = 'dirty'
-  else :
-    result = 'clean'
-  return 'gitTreeState=%s' % result
+    git_status = subprocess.check_output(["git", "status", "--porcelain"])
+    if git_status:
+        result = "dirty"
+    else:
+        result = "clean"
+    return "gitTreeState=%s" % result
+
 
 def get_build_date():
-  build_date = datetime.utcfromtimestamp(int(os.environ.get('SOURCE_DATE_EPOCH', time.time())))
-  return 'buildDate=%s' % build_date.strftime('%Y-%m-%dT%H:%M:%SZ')
+    build_date = datetime.utcfromtimestamp(
+        int(os.environ.get("SOURCE_DATE_EPOCH", time.time()))
+    )
+    return "buildDate=%s" % build_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+
 
 def main():
-  if len(sys.argv) > 1 and sys.argv[1] == "--k8s-version-only":
-      return get_from_godep('Comment')
-  major, minor = get_major_and_minor()
-  args = [get_commit(), get_tree_state(), get_version(),
-          major, minor, get_build_date()]
-  ret = ''
-  for xarg in X_ARGS:
-    for arg in args:
-      ret += xarg + arg + " "
-  return ret
+    if len(sys.argv) > 1 and sys.argv[1] == "--k8s-version-only":
+        return get_from_godep("Comment")
+    major, minor = get_major_and_minor()
+    args = [
+        get_commit(),
+        get_tree_state(),
+        get_version(),
+        major,
+        minor,
+        get_build_date(),
+    ]
+    ret = ""
+    for xarg in X_ARGS:
+        for arg in args:
+            ret += xarg + arg + " "
+    return ret
 
-if __name__ == '__main__':
-  sys.exit(main())
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hack/prow/run_tests.py
+++ b/hack/prow/run_tests.py
@@ -23,13 +23,15 @@
 from __future__ import print_function
 import os, sys, json, re, argparse, calendar, time, subprocess, shlex
 
+
 def get_classname(test_script):
-  """ parse out the test classname from the full path of the test script"""
-  classname = os.path.basename(test_script).split('.')[0]
-  return classname
+    """ parse out the test classname from the full path of the test script"""
+    classname = os.path.basename(test_script).split(".")[0]
+    return classname
+
 
 def write_results(outdir, started, finished, test_results):
-  """ write current results into artifacts/junit_runner.xml
+    """ write current results into artifacts/junit_runner.xml
       format:
       <testsuite failures="XXX" tests="YYY" time="ZZZ">
          <testcase classname="SUITENAME" name="TESTNAME" time="ZZZ1" />
@@ -51,32 +53,39 @@ def write_results(outdir, started, finished, test_results):
        finished: a dict containing the finished data
        tests_results: a list of dicts containing test results
   """
-  started_json = open(os.path.join(outdir, "started.json"), 'w')
-  finished_json = open(os.path.join(outdir, "finished.json"), 'w')
-  junit_xml = open(os.path.join(outdir, "artifacts", "junit_runner.xml"), 'w')
+    started_json = open(os.path.join(outdir, "started.json"), "w")
+    finished_json = open(os.path.join(outdir, "finished.json"), "w")
+    junit_xml = open(os.path.join(outdir, "artifacts", "junit_runner.xml"), "w")
 
-  failures = 0
-  testxml = ""
-  for test in test_results:
-    testxml += '<testcase classname="%s" name="%s" time="%s">' % (test['classname'], test['name'], test['time'])
-    if test['status'] == 'FAIL':
-        failures += 1
-        testxml += '<failure message="Test Failed" />'
-    testxml += '</testcase>\n'
-  junit_xml.write('<testsuite failures="%s" tests="%s">\n' % (failures, len(test_results)))
-  junit_xml.write(testxml)
-  junit_xml.write('</testsuite>')
-  junit_xml.close()
+    failures = 0
+    testxml = ""
+    for test in test_results:
+        testxml += '<testcase classname="%s" name="%s" time="%s">' % (
+            test["classname"],
+            test["name"],
+            test["time"],
+        )
+        if test["status"] == "FAIL":
+            failures += 1
+            testxml += '<failure message="Test Failed" />'
+        testxml += "</testcase>\n"
+    junit_xml.write(
+        '<testsuite failures="%s" tests="%s">\n' % (failures, len(test_results))
+    )
+    junit_xml.write(testxml)
+    junit_xml.write("</testsuite>")
+    junit_xml.close()
 
-  started_json.write(json.dumps(started))
-  started_json.close()
-  finished_json.write(json.dumps(finished))
-  finished_json.close()
+    started_json.write(json.dumps(started))
+    started_json.close()
+    finished_json.write(json.dumps(finished))
+    finished_json.close()
 
-  return
+    return
+
 
 def upload_results(outdir, test_script, buildnum, bucket):
-  """ push the contents of gcs_out/* into bucket/test/logs/buildnum
+    """ push the contents of gcs_out/* into bucket/test/logs/buildnum
 
       Args:
        outdir: a string containing the results storage directory
@@ -84,14 +93,17 @@ def upload_results(outdir, test_script, buildnum, bucket):
        buildnum: a string containing the buildnum
        bucket: a string containing the bucket to upload results to
   """
-  classname = get_classname(test_script)
-  args = shlex.split("gsutil cp -R gcs_out/ gs://%s/logs/%s/%s" % (bucket, classname, buildnum))
-  p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-  for line in str(p.stdout):
-    print(line)
+    classname = get_classname(test_script)
+    args = shlex.split(
+        "gsutil cp -R gcs_out/ gs://%s/logs/%s/%s" % (bucket, classname, buildnum)
+    )
+    p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    for line in str(p.stdout):
+        print(line)
+
 
 def run_tests(test_script, log_path, exit_status, started, finished, test_results):
-  """ execute the test script, grab the start time, finish time, build logs and exit status
+    """ execute the test script, grab the start time, finish time, build logs and exit status
       Pull test results and important information out of the build log
       test results format should be:
       === RUN   TestFunctional/Mounting
@@ -107,54 +119,91 @@ def run_tests(test_script, log_path, exit_status, started, finished, test_result
        finished: a dict containing the finished data
        tests_results: a list of dicts containing test results
   """
-  classname = get_classname(test_script)
-  build_log_file = open(log_path, 'w')
-  p = subprocess.Popen(['bash','-x',test_script], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-  for line in str(p.stdout):
-    build_log_file.write(line)
-    print(line.rstrip())
-    if '--- PASS' in line:
-      match = re.match('.*--- PASS: ([^ ]+) \(([0-9.]+)s\)', line)
-      (name, seconds) = match.group(1, 2)
-      test_results.append({"name":name, "classname":classname, "time":seconds, "status":"PASS"})
-    if '--- FAIL' in line:
-      match = re.match('.*--- FAIL: ([^ ]+) \(([0-9.]+)s\)', line)
-      (name, seconds) = match.group(1, 2)
-      test_results.append({"name":name, "classname":classname, "time":seconds, "status":"FAIL"})
-  build_log_file.close()
-  return
+    classname = get_classname(test_script)
+    build_log_file = open(log_path, "w")
+    p = subprocess.Popen(
+        ["bash", "-x", test_script], stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+    )
+    for line in str(p.stdout):
+        build_log_file.write(line)
+        print(line.rstrip())
+        if "--- PASS" in line:
+            match = re.match(".*--- PASS: ([^ ]+) \(([0-9.]+)s\)", line)
+            (name, seconds) = match.group(1, 2)
+            test_results.append(
+                {
+                    "name": name,
+                    "classname": classname,
+                    "time": seconds,
+                    "status": "PASS",
+                }
+            )
+        if "--- FAIL" in line:
+            match = re.match(".*--- FAIL: ([^ ]+) \(([0-9.]+)s\)", line)
+            (name, seconds) = match.group(1, 2)
+            test_results.append(
+                {
+                    "name": name,
+                    "classname": classname,
+                    "time": seconds,
+                    "status": "FAIL",
+                }
+            )
+    build_log_file.close()
+    return
+
 
 def main(argv):
 
-  parser = argparse.ArgumentParser(description='Run tests and upload results to GCS bucket', usage='./run_tests.py --test path/to/test.sh')
-  parser.add_argument('--test', required=True, help='full path to test script you want to run')
-  parser.add_argument('--build-num', dest="buildnum", required=True, help='buildnumber for uploading to GCS')
-  parser.add_argument('--bucket', default="k8s-minikube-prow", help='Name of the GCS bucket to upload to.  Default: k8s-minkube-prow')
-  parser.add_argument('--out-dir', dest="outdir", default="gcs_out", help='Path of the directory to store all results, artifacts, and logs')
-  args = parser.parse_args()
+    parser = argparse.ArgumentParser(
+        description="Run tests and upload results to GCS bucket",
+        usage="./run_tests.py --test path/to/test.sh",
+    )
+    parser.add_argument(
+        "--test", required=True, help="full path to test script you want to run"
+    )
+    parser.add_argument(
+        "--build-num",
+        dest="buildnum",
+        required=True,
+        help="buildnumber for uploading to GCS",
+    )
+    parser.add_argument(
+        "--bucket",
+        default="k8s-minikube-prow",
+        help="Name of the GCS bucket to upload to.  Default: k8s-minkube-prow",
+    )
+    parser.add_argument(
+        "--out-dir",
+        dest="outdir",
+        default="gcs_out",
+        help="Path of the directory to store all results, artifacts, and logs",
+    )
+    args = parser.parse_args()
 
-  if not os.path.exists(args.outdir):
-    os.makedirs(os.path.join(args.outdir, "artifacts"))
+    if not os.path.exists(args.outdir):
+        os.makedirs(os.path.join(args.outdir, "artifacts"))
 
-  build_log = os.path.join(args.outdir, "build_log.txt")
-  exit_status = ""
-  started = {"timestamp":calendar.timegm(time.gmtime())}
-  finished = {}
-  test_results = []
+    build_log = os.path.join(args.outdir, "build_log.txt")
+    exit_status = ""
+    started = {"timestamp": calendar.timegm(time.gmtime())}
+    finished = {}
+    test_results = []
 
-  run_tests(args.test, build_log, exit_status, started, finished, test_results)
+    run_tests(args.test, build_log, exit_status, started, finished, test_results)
 
-  finished['timestamp'] = calendar.timegm(time.gmtime())
-  #if the test script in run_tests exits with a non-zero status then mark the test run as FAILED
-  if exit_status != "0":
-    finished['passed'] = "false"
-    finished['result'] = "FAIL"
-  else:
-    finished['passed'] = "true"
-    finished['result'] = "SUCCESS"
+    finished["timestamp"] = calendar.timegm(time.gmtime())
+    # if the test script in run_tests exits with a non-zero status then mark the test run as FAILED
+    if exit_status != "0":
+        finished["passed"] = "false"
+        finished["result"] = "FAIL"
+    else:
+        finished["passed"] = "true"
+        finished["result"] = "SUCCESS"
 
-  write_results(args.outdir, started, finished, test_results)
-  upload_results(args.outdir, args.test, args.buildnum, args.bucket)
+    write_results(args.outdir, started, finished, test_results)
+    upload_results(args.outdir, args.test, args.buildnum, args.bucket)
 
-if __name__ == '__main__':
-  main(sys.argv)
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
Python code in minukube is not following pep8 standard.

1) Run automatic python formater on existing python scripts.
2) Add python linters to CI
3) Fix linting in `.travis.yaml`

All python files were modified by `black ./hack`. No logic change happened.

Anyway, are you interested in refactor for python scripts in minikube?

I believe stuff like:
```python
-- 42 def get_major_and_minor():                                                                                              
   43     major = ""                                                                                                          
   44     minor = ""                                                                                                          
   45     version = get_from_godep("Comment")                                                                                 
   46     # [kubernetes/hack/lib/version.sh]:                                                                                 
   47     # Try to match the "git describe" output to a regex to try to extract                                               
   48     # the "major" and "minor" versions and whether this is the exact tagged                                             
   49     # version or whether the tree is between two tagged versions.                                                       
-- 50     m = re.match("^v([0-9]+)\.([0-9]+)(\.[0-9]+)?([-].*)?$", version)                                                   
   51     if m:                                                                                                               
   52         major = m.group(1)                                                                                              
   53         minor = m.group(2)                                                                                              
   54         if m.group(4):                                                                                                  
   55             minor += "+"                                                                                                
   56     return ("gitMajor=%s" % major, "gitMinor=%s" % minor)                     
```
can be optimalized with liblaries like `semver`