### PR TITLE
Add addons flag to 'minikube start' in order to enable specified addons

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -164,7 +164,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().String(containerRuntime, "docker", "The container runtime to be used (docker, crio, containerd).")
 	startCmd.Flags().Bool(createMount, false, "This will start the mount daemon and automatically mount files into minikube.")
 	startCmd.Flags().String(mountString, constants.DefaultMountDir+":/minikube-host", "The argument to pass the minikube mount command on start.")
-	startCmd.Flags().StringArrayVar(&addonList, addons, nil, "Enable addons. see addon list if you want to check them `minikube addons list`")
+	startCmd.Flags().StringArrayVar(&addonList, addons, nil, "Enable addons. see `minikube addons list` if you want to check")
 	startCmd.Flags().String(criSocket, "", "The cri socket path to be used.")
 	startCmd.Flags().String(networkPlugin, "", "The name of the network plugin.")
 	startCmd.Flags().Bool(enableDefaultCNI, false, "Enable the default CNI plugin (/etc/cni/net.d/k8s.conf). Used in conjunction with \"--network-plugin=cni\".")

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -164,7 +164,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().String(containerRuntime, "docker", "The container runtime to be used (docker, crio, containerd).")
 	startCmd.Flags().Bool(createMount, false, "This will start the mount daemon and automatically mount files into minikube.")
 	startCmd.Flags().String(mountString, constants.DefaultMountDir+":/minikube-host", "The argument to pass the minikube mount command on start.")
-	startCmd.Flags().StringArrayVar(&addonList, addons, nil, "Enable addons. see `minikube addons list` if you want to check")
+	startCmd.Flags().StringArrayVar(&addonList, addons, nil, "Enable addons. see `minikube addons list` for a list of valid addon names.")
 	startCmd.Flags().String(criSocket, "", "The cri socket path to be used.")
 	startCmd.Flags().String(networkPlugin, "", "The name of the network plugin.")
 	startCmd.Flags().Bool(enableDefaultCNI, false, "Enable the default CNI plugin (/etc/cni/net.d/k8s.conf). Used in conjunction with \"--network-plugin=cni\".")
@@ -347,8 +347,8 @@ func runStart(cmd *cobra.Command, args []string) {
 	configureMounts()
 
 	// enable addons with start command
-	for _, addonName := range addonList {
-		err = cmdcfg.Set(addonName, "true")
+	for _, a := range addonList {
+		err = cmdcfg.Set(a, "true")
 		if err != nil {
 			exit.WithError("addon enable failed", err)
 		}

--- a/site/content/en/docs/Reference/Commands/addons.md
+++ b/site/content/en/docs/Reference/Commands/addons.md
@@ -39,6 +39,12 @@ Enables the addon w/ADDON_NAME within minikube (example: minikube addons enable 
 minikube addons enable ADDON_NAME [flags]
 ```
 
+or
+
+```
+minikube start --addons ADDON_NAME [flags]
+```
+
 ## minikube addons list
 
 Lists all available minikube addons as well as their current statuses (enabled/disabled)

--- a/site/content/en/docs/Reference/Commands/start.md
+++ b/site/content/en/docs/Reference/Commands/start.md
@@ -16,6 +16,7 @@ minikube start [flags]
 ### Options
 
 ```
+--addons                            Enable addons. see `minikube addons list` if you want to check
 --apiserver-ips ipSlice             A set of apiserver IP Addresses which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine (default [])
 --apiserver-name string             The apiserver name which is used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine (default "minikubeCA")
 --apiserver-names stringArray       A set of apiserver names which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine

--- a/site/content/en/docs/Reference/Commands/start.md
+++ b/site/content/en/docs/Reference/Commands/start.md
@@ -16,7 +16,7 @@ minikube start [flags]
 ### Options
 
 ```
---addons                            Enable addons. see `minikube addons list` if you want to check
+--addons                            Enable addons. see `minikube addons list` for a list of valid addon names.
 --apiserver-ips ipSlice             A set of apiserver IP Addresses which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine (default [])
 --apiserver-name string             The apiserver name which is used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine (default "minikubeCA")
 --apiserver-names stringArray       A set of apiserver names which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine

--- a/site/content/en/docs/Tasks/addons.md
+++ b/site/content/en/docs/Tasks/addons.md
@@ -55,6 +55,12 @@ Example output:
 minikube addons enable <name>
 ```
 
+or
+
+```shell
+minikube start --addons <name>
+```
+
 ## Interacting with an addon
 
 For addons that expose a browser endpoint, use:

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -42,7 +42,7 @@ func TestAddons(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Minute)
 	defer CleanupWithLogs(t, profile, cancel)
 
-	args := append([]string{"start", "-p", profile, "--wait=false", "--memory=2600", "--alsologtostderr", "-v=1"}, StartArgs()...)
+	args := append([]string{"start", "-p", profile, "--wait=false", "--memory=2600", "--alsologtostderr", "-v=1", "--addons=ingress", "--addons=registry"}, StartArgs()...)
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
 		t.Fatalf("%s failed: %v", rr.Args, err)
@@ -72,11 +72,6 @@ func validateIngressAddon(ctx context.Context, t *testing.T, profile string) {
 		t.Skipf("skipping: ssh unsupported by none")
 	}
 
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "addons", "enable", "ingress"))
-	if err != nil {
-		t.Fatalf("%s failed: %v", rr.Args, err)
-	}
-
 	client, err := kapi.Client(profile)
 	if err != nil {
 		t.Fatalf("kubernetes client: %v", client)
@@ -89,7 +84,7 @@ func validateIngressAddon(ctx context.Context, t *testing.T, profile string) {
 		t.Fatalf("wait: %v", err)
 	}
 
-	rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "replace", "--force", "-f", filepath.Join(*testdataDir, "nginx-ing.yaml")))
+	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "replace", "--force", "-f", filepath.Join(*testdataDir, "nginx-ing.yaml")))
 	if err != nil {
 		t.Errorf("%s failed: %v", rr.Args, err)
 	}
@@ -131,11 +126,6 @@ func validateIngressAddon(ctx context.Context, t *testing.T, profile string) {
 }
 
 func validateRegistryAddon(ctx context.Context, t *testing.T, profile string) {
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "addons", "enable", "registry"))
-	if err != nil {
-		t.Fatalf("%s failed: %v", rr.Args, err)
-	}
-
 	client, err := kapi.Client(profile)
 	if err != nil {
 		t.Fatalf("kubernetes client: %v", client)
@@ -155,7 +145,7 @@ func validateRegistryAddon(ctx context.Context, t *testing.T, profile string) {
 	}
 
 	// Test from inside the cluster (no curl available on busybox)
-	rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "delete", "po", "-l", "run=registry-test", "--now"))
+	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "delete", "po", "-l", "run=registry-test", "--now"))
 	if err != nil {
 		t.Logf("pre-cleanup %s failed: %v (not a problem)", rr.Args, err)
 	}


### PR DESCRIPTION
### What type of PR is this?
/kind feature

### What this PR does / why we need it:
So far we have to use the `minikube addons enable` command to enable the addons.
Now, this PR enables us to use addons with `minikube start --addons` command flag without `minikube addons enable`.

### Which issue(s) this PR fixes:
Fixes #5503

### Does this PR introduce a user-facing change?
Yes. this PR add flag option to `minikube start` command .

**Before this PR, addons flow to enable  is following**
```
1. Search the available addons
minikube addons list

2. Enable addons
minikube addons enable <name>

3. Start minikube
minikube start
```

**After this PR, addons flow to enable  is following**
```
1. Search the available addons
minikube addons list

2. Start minikube with available addons
minikube addons --addons <name1> --addons <name2> --addons <nameN>
```

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```