### PR TITLE
Fix Jenkins Cross script to copy testdata properly

### DIFF
--- a/hack/jenkins/minikube_cross_build_and_upload.sh
+++ b/hack/jenkins/minikube_cross_build_and_upload.sh
@@ -63,4 +63,4 @@ cp -r test/integration/testdata out/
 # Don't upload the buildroot artifacts if they exist
 rm -r out/buildroot || true
 
-gsutil -m cp -r out/* "gs://${bucket}/${ghprbPullId}/"
+gsutil -m cp -r out/ "gs://${bucket}/${ghprbPullId}/"


### PR DESCRIPTION
`gsutil` changed its cp behavior starting with version 4.46, we need to change how we call it in order to preserve the directory structure our tests are expecting.

Fixes #5560 