### PR TITLE
Allow addon enabling and disabling when minikube is not running

### DIFF
--- a/cmd/minikube/cmd/config/disable_test.go
+++ b/cmd/minikube/cmd/config/disable_test.go
@@ -16,10 +16,24 @@ limitations under the License.
 
 package config
 
-import "testing"
+import (
+	"testing"
+
+	"gotest.tools/assert"
+	pkgConfig "k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/localpath"
+)
 
 func TestDisableUnknownAddon(t *testing.T) {
 	if err := Set("InvalidAddon", "false"); err == nil {
 		t.Fatalf("Disable did not return error for unknown addon")
 	}
+}
+
+func TestDisableAddon(t *testing.T) {
+	if err := Set("dashboard", "false"); err != nil {
+		t.Fatalf("Disable returned unexpected error: " + err.Error())
+	}
+	config, _ := pkgConfig.ReadConfig(localpath.ConfigFile)
+	assert.Equal(t, config["dashboard"], false)
 }

--- a/cmd/minikube/cmd/config/enable_test.go
+++ b/cmd/minikube/cmd/config/enable_test.go
@@ -16,10 +16,24 @@ limitations under the License.
 
 package config
 
-import "testing"
+import (
+	"testing"
+
+	"gotest.tools/assert"
+	pkgConfig "k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/localpath"
+)
 
 func TestEnableUnknownAddon(t *testing.T) {
 	if err := Set("InvalidAddon", "false"); err == nil {
 		t.Fatalf("Enable did not return error for unknown addon")
 	}
+}
+
+func TestEnableAddon(t *testing.T) {
+	if err := Set("ingress", "true"); err != nil {
+		t.Fatalf("Enable returned unexpected error: " + err.Error())
+	}
+	config, _ := pkgConfig.ReadConfig(localpath.ConfigFile)
+	assert.Equal(t, config["ingress"], true)
 }

--- a/cmd/minikube/cmd/config/open.go
+++ b/cmd/minikube/cmd/config/open.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"os"
 	"text/template"
 
 	"github.com/spf13/cobra"
@@ -62,7 +63,9 @@ var addonsOpenCmd = &cobra.Command{
 		}
 		defer api.Close()
 
-		cluster.EnsureMinikubeRunningOrExit(api, 1)
+		if !cluster.IsMinikubeRunning(api) {
+			os.Exit(1)
+		}
 		addon, ok := assets.Addons[addonName] // validate addon input
 		if !ok {
 			exit.WithCodeT(exit.Data, `addon '{{.name}}' is not a valid addon packaged with minikube.

--- a/cmd/minikube/cmd/config/util_test.go
+++ b/cmd/minikube/cmd/config/util_test.go
@@ -85,15 +85,12 @@ func TestSetBool(t *testing.T) {
 func TestIsAddonAlreadySet(t *testing.T) {
 	testCases := []struct {
 		addonName string
-		expectErr string
 	}{
 		{
 			addonName: "ingress",
-			expectErr: "addon ingress was already ",
 		},
 		{
 			addonName: "heapster",
-			expectErr: "addon heapster was already ",
 		},
 	}
 
@@ -101,13 +98,16 @@ func TestIsAddonAlreadySet(t *testing.T) {
 		addon := assets.Addons[test.addonName]
 		addonStatus, _ := addon.IsEnabled()
 
-		expectMsg := test.expectErr + "enabled"
-		if !addonStatus {
-			expectMsg = test.expectErr + "disabled"
+		alreadySet, err := isAddonAlreadySet(addon, addonStatus)
+		if !alreadySet {
+			if addonStatus {
+				t.Errorf("Did not get expected status, \n\n expected %+v already enabled", test.addonName)
+			} else {
+				t.Errorf("Did not get expected status, \n\n expected %+v already disabled", test.addonName)
+			}
 		}
-		err := isAddonAlreadySet(addon, addonStatus)
-		if err.Error() != expectMsg {
-			t.Errorf("Did not get expected error, \n\n expected: %+v \n\n actual: %+v", expectMsg, err)
+		if err != nil {
+			t.Errorf("Got unexpected error: %+v", err)
 		}
 	}
 }

--- a/cmd/minikube/cmd/dashboard.go
+++ b/cmd/minikube/cmd/dashboard.go
@@ -93,7 +93,9 @@ var dashboardCmd = &cobra.Command{
 			exit.WithCodeT(exit.NoInput, "kubectl not found in PATH, but is required for the dashboard. Installation guide: https://kubernetes.io/docs/tasks/tools/install-kubectl/")
 		}
 
-		cluster.EnsureMinikubeRunningOrExit(api, 1)
+		if !cluster.IsMinikubeRunning(api) {
+			os.Exit(1)
+		}
 
 		// Check dashboard status before enabling it
 		dashboardAddon := assets.Addons["dashboard"]

--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"os"
 	"text/template"
 
 	"github.com/spf13/cobra"
@@ -64,7 +65,9 @@ var serviceCmd = &cobra.Command{
 		}
 		defer api.Close()
 
-		cluster.EnsureMinikubeRunningOrExit(api, 1)
+		if !cluster.IsMinikubeRunning(api) {
+			os.Exit(1)
+		}
 		err = service.WaitAndMaybeOpenService(api, namespace, svc,
 			serviceURLTemplate, serviceURLMode, https, wait, interval)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,7 @@ require (
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 // indirect
+	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v0.0.0

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -604,12 +604,13 @@ func CreateSSHShell(api libmachine.API, args []string) error {
 
 // EnsureMinikubeRunningOrExit checks that minikube has a status available and that
 // the status is `Running`, otherwise it will exit
-func EnsureMinikubeRunningOrExit(api libmachine.API, exitStatus int) {
+func IsMinikubeRunning(api libmachine.API) bool {
 	s, err := GetHostStatus(api)
 	if err != nil {
-		exit.WithError("Error getting machine status", err)
+		return false
 	}
 	if s != state.Running.String() {
-		exit.WithCodeT(exit.Unavailable, "minikube is not running, so the service cannot be accessed")
+		return false
 	}
+	return true
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
Fixes #5510
Currently, if you try to enable an addon while minikube is not up, an error is returned saying
>  minikube is not running, so the service cannot be accessed

This PR attempts to support addon disabling/enabling even when minikube is not running. All feedback and suggestions are welcome.
