### PR TITLE
Use configured DNS domain in bootstrapper kubeadm templates

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -698,6 +698,7 @@ func generateConfig(k8s config.KubernetesConfig, r cruntime.Manager) ([]byte, er
 		KubernetesVersion string
 		EtcdDataDir       string
 		NodeName          string
+		DNSDomain         string
 		CRISocket         string
 		ImageRepository   string
 		ExtraArgs         []ComponentExtraArgs
@@ -717,6 +718,7 @@ func generateConfig(k8s config.KubernetesConfig, r cruntime.Manager) ([]byte, er
 		ExtraArgs:         extraComponentConfig,
 		FeatureArgs:       kubeadmFeatureArgs,
 		NoTaintMaster:     false, // That does not work with k8s 1.12+
+		DNSDomain:         k8s.DNSDomain,
 	}
 
 	if k8s.ServiceCIDR != "" {

--- a/pkg/minikube/bootstrapper/kubeadm/templates.go
+++ b/pkg/minikube/bootstrapper/kubeadm/templates.go
@@ -84,7 +84,7 @@ etcd:
     dataDir: {{.EtcdDataDir}}
 kubernetesVersion: {{.KubernetesVersion}}
 networking:
-  dnsDomain: cluster.local
+  dnsDomain: {{if .DNSDomain}}{{.DNSDomain}}{{else}}cluster.local{{end}}
   podSubnet: {{if .PodSubnet}}{{.PodSubnet}}{{else}}""{{end}}
   serviceSubnet: {{.ServiceCIDR}}
 ---
@@ -138,7 +138,7 @@ etcd:
     dataDir: {{.EtcdDataDir}}
 kubernetesVersion: {{.KubernetesVersion}}
 networking:
-  dnsDomain: cluster.local
+  dnsDomain: {{if .DNSDomain}}{{.DNSDomain}}{{else}}cluster.local{{end}}
   podSubnet: ""
   serviceSubnet: {{.ServiceCIDR}}
 ---

--- a/pkg/minikube/bootstrapper/kubeadm/testdata/v1.12/dns.yaml
+++ b/pkg/minikube/bootstrapper/kubeadm/testdata/v1.12/dns.yaml
@@ -1,0 +1,39 @@
+apiVersion: kubeadm.k8s.io/v1alpha3
+kind: InitConfiguration
+apiEndpoint:
+  advertiseAddress: 1.1.1.1
+  bindPort: 8443
+bootstrapTokens:
+  - groups:
+      - system:bootstrappers:kubeadm:default-node-token
+    ttl: 24h0m0s
+    usages:
+      - signing
+      - authentication
+nodeRegistration:
+  criSocket: /var/run/dockershim.sock
+  name: mk
+  taints: []
+---
+apiVersion: kubeadm.k8s.io/v1alpha3
+kind: ClusterConfiguration
+apiServerExtraArgs:
+  enable-admission-plugins: "Initializers,NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
+certificatesDir: /var/lib/minikube/certs
+clusterName: kubernetes
+controlPlaneEndpoint: localhost:8443
+etcd:
+  local:
+    dataDir: /var/lib/minikube/etcd
+kubernetesVersion: v1.12.0
+networking:
+  dnsDomain: 1.1.1.1
+  podSubnet: ""
+  serviceSubnet: 10.96.0.0/12
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+evictionHard:
+  nodefs.available: "0%"
+  nodefs.inodesFree: "0%"
+  imagefs.available: "0%"

--- a/pkg/minikube/bootstrapper/kubeadm/testdata/v1.13/dns.yaml
+++ b/pkg/minikube/bootstrapper/kubeadm/testdata/v1.13/dns.yaml
@@ -1,0 +1,39 @@
+apiVersion: kubeadm.k8s.io/v1alpha3
+kind: InitConfiguration
+apiEndpoint:
+  advertiseAddress: 1.1.1.1
+  bindPort: 8443
+bootstrapTokens:
+  - groups:
+      - system:bootstrappers:kubeadm:default-node-token
+    ttl: 24h0m0s
+    usages:
+      - signing
+      - authentication
+nodeRegistration:
+  criSocket: /var/run/dockershim.sock
+  name: mk
+  taints: []
+---
+apiVersion: kubeadm.k8s.io/v1alpha3
+kind: ClusterConfiguration
+apiServerExtraArgs:
+  enable-admission-plugins: "Initializers,NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
+certificatesDir: /var/lib/minikube/certs
+clusterName: kubernetes
+controlPlaneEndpoint: localhost:8443
+etcd:
+  local:
+    dataDir: /var/lib/minikube/etcd
+kubernetesVersion: v1.13.0
+networking:
+  dnsDomain: 1.1.1.1
+  podSubnet: ""
+  serviceSubnet: 10.96.0.0/12
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+evictionHard:
+  nodefs.available: "0%"
+  nodefs.inodesFree: "0%"
+  imagefs.available: "0%"

--- a/pkg/minikube/bootstrapper/kubeadm/testdata/v1.14/dns.yaml
+++ b/pkg/minikube/bootstrapper/kubeadm/testdata/v1.14/dns.yaml
@@ -1,0 +1,43 @@
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: 1.1.1.1
+  bindPort: 8443
+bootstrapTokens:
+  - groups:
+      - system:bootstrappers:kubeadm:default-node-token
+    ttl: 24h0m0s
+    usages:
+      - signing
+      - authentication
+nodeRegistration:
+  criSocket: /var/run/dockershim.sock
+  name: mk
+  taints: []
+---
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: ClusterConfiguration
+apiServer:
+  extraArgs:
+    enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
+certificatesDir: /var/lib/minikube/certs
+clusterName: kubernetes
+controlPlaneEndpoint: localhost:8443
+dns:
+  type: CoreDNS
+etcd:
+  local:
+    dataDir: /var/lib/minikube/etcd
+kubernetesVersion: v1.14.0
+networking:
+  dnsDomain: 1.1.1.1
+  podSubnet: ""
+  serviceSubnet: 10.96.0.0/12
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+imageGCHighThresholdPercent: 100
+evictionHard:
+  nodefs.available: "0%"
+  nodefs.inodesFree: "0%"
+  imagefs.available: "0%"

--- a/pkg/minikube/bootstrapper/kubeadm/testdata/v1.15/dns.yaml
+++ b/pkg/minikube/bootstrapper/kubeadm/testdata/v1.15/dns.yaml
@@ -1,0 +1,43 @@
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: 1.1.1.1
+  bindPort: 8443
+bootstrapTokens:
+  - groups:
+      - system:bootstrappers:kubeadm:default-node-token
+    ttl: 24h0m0s
+    usages:
+      - signing
+      - authentication
+nodeRegistration:
+  criSocket: /var/run/dockershim.sock
+  name: mk
+  taints: []
+---
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: ClusterConfiguration
+apiServer:
+  extraArgs:
+    enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
+certificatesDir: /var/lib/minikube/certs
+clusterName: kubernetes
+controlPlaneEndpoint: localhost:8443
+dns:
+  type: CoreDNS
+etcd:
+  local:
+    dataDir: /var/lib/minikube/etcd
+kubernetesVersion: v1.15.0
+networking:
+  dnsDomain: 1.1.1.1
+  podSubnet: ""
+  serviceSubnet: 10.96.0.0/12
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+imageGCHighThresholdPercent: 100
+evictionHard:
+  nodefs.available: "0%"
+  nodefs.inodesFree: "0%"
+  imagefs.available: "0%"

--- a/pkg/minikube/bootstrapper/kubeadm/testdata/v1.16/dns.yaml
+++ b/pkg/minikube/bootstrapper/kubeadm/testdata/v1.16/dns.yaml
@@ -1,0 +1,43 @@
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: 1.1.1.1
+  bindPort: 8443
+bootstrapTokens:
+  - groups:
+      - system:bootstrappers:kubeadm:default-node-token
+    ttl: 24h0m0s
+    usages:
+      - signing
+      - authentication
+nodeRegistration:
+  criSocket: /var/run/dockershim.sock
+  name: mk
+  taints: []
+---
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: ClusterConfiguration
+apiServer:
+  extraArgs:
+    enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
+certificatesDir: /var/lib/minikube/certs
+clusterName: kubernetes
+controlPlaneEndpoint: localhost:8443
+dns:
+  type: CoreDNS
+etcd:
+  local:
+    dataDir: /var/lib/minikube/etcd
+kubernetesVersion: v1.16.0
+networking:
+  dnsDomain: 1.1.1.1
+  podSubnet: ""
+  serviceSubnet: 10.96.0.0/12
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+imageGCHighThresholdPercent: 100
+evictionHard:
+  nodefs.available: "0%"
+  nodefs.inodesFree: "0%"
+  imagefs.available: "0%"

--- a/site/content/en/docs/Reference/Networking/dns.md
+++ b/site/content/en/docs/Reference/Networking/dns.md
@@ -1,0 +1,58 @@
+---
+title: "DNS Domain"
+linkTitle: "DNS Domain"
+weight: 6
+date: 2019-10-09
+description: >
+  Use configured DNS domain in bootstrapper kubeadm
+---
+
+minikube by default uses **cluster.local** if none is specified via the start flag --dns-domain. The configuration file used by kubeadm are found inside **/var/tmp/minikube/kubeadm.yaml** directory inside minikube.
+
+Default DNS configuration will look like below
+
+```
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: InitConfiguration
+localAPIEndpoint:
+......
+......
+---
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: ClusterConfiguration
+.....
+.....
+kubernetesVersion: v1.16.0
+networking:
+  dnsDomain: cluster.local
+  podSubnet: ""
+  serviceSubnet: 10.96.0.0/12
+---
+```
+
+To change the dns pass the value when starting minikube 
+
+```
+minikube start --dns-domain bla.blah.blah   
+```
+
+the dns now changed to bla.blah.blah
+
+```
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: InitConfiguration
+localAPIEndpoint:
+......
+......
+---
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: ClusterConfiguration
+.....
+.....
+kubernetesVersion: v1.16.0
+networking:
+  dnsDomain: bla.blah.blah
+  podSubnet: ""
+  serviceSubnet: 10.96.0.0/12
+---
+```


### PR DESCRIPTION
Fixes #4963

Following are the file changes:

kubeadm.go --> Add DNSDomain as one the field
kubeadm_test.go --> Add new test case to test the dns changes
templates.go --> Add the new DNSDomain into the template

Add new testdata for the kubeadm_test.go

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
