### PR TITLE
Bump golangci-lint to v1.20.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,13 +51,13 @@ MINIKUBE_RELEASES_URL=https://github.com/kubernetes/minikube/releases/download
 
 KERNEL_VERSION ?= 4.15
 # latest from https://github.com/golangci/golangci-lint/releases
-GOLINT_VERSION ?= v1.18.0
+GOLINT_VERSION ?= v1.20.0
 # Limit number of default jobs, to avoid the CI builds running out of memory
 GOLINT_JOBS ?= 4
 # see https://github.com/golangci/golangci-lint#memory-usage-of-golangci-lint
-GOLINT_GOGC ?= 8
+GOLINT_GOGC ?= 100
 # options for lint (golangci-lint)
-GOLINT_OPTIONS = --deadline 4m \
+GOLINT_OPTIONS = --timeout 4m \
 	  --build-tags "${MINIKUBE_INTEGRATION_BUILD_TAGS}" \
 	  --enable goimports,gocritic,golint,gocyclo,interfacer,misspell,nakedret,stylecheck,unconvert,unparam \
 	  --exclude 'variable on range scope.*in function literal|ifElseChain'

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -119,14 +119,13 @@ const (
 )
 
 var (
-	registryMirror           []string
-	dockerEnv                []string
-	dockerOpt                []string
-	insecureRegistry         []string
-	apiServerNames           []string
-	apiServerIPs             []net.IP
-	extraOptions             cfg.ExtraOptionSlice
-	enableUpdateNotification = true
+	registryMirror   []string
+	dockerEnv        []string
+	dockerOpt        []string
+	insecureRegistry []string
+	apiServerNames   []string
+	apiServerIPs     []net.IP
+	extraOptions     cfg.ExtraOptionSlice
 )
 
 func init() {

--- a/cmd/minikube/cmd/update-check.go
+++ b/cmd/minikube/cmd/update-check.go
@@ -28,10 +28,6 @@ var updateCheckCmd = &cobra.Command{
 	Use:   "update-check",
 	Short: "Print current and latest version number",
 	Long:  `Print current and latest version number`,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		// Explicitly disable update checking for the version command
-		enableUpdateNotification = false
-	},
 	Run: func(command *cobra.Command, args []string) {
 		url := notify.GithubMinikubeReleasesURL
 		r, err := notify.GetAllVersionsFromURL(url)

--- a/cmd/minikube/cmd/version.go
+++ b/cmd/minikube/cmd/version.go
@@ -26,10 +26,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version of minikube",
 	Long:  `Print the version of minikube.`,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		// Explicitly disable update checking for the version command
-		enableUpdateNotification = false
-	},
 	Run: func(command *cobra.Command, args []string) {
 		out.Ln("minikube version: %v", version.GetVersion())
 		gitCommitID := version.GetGitCommitID()

--- a/pkg/minikube/extract/extract.go
+++ b/pkg/minikube/extract/extract.go
@@ -385,7 +385,7 @@ func checkKeyValueExpression(kvp *ast.KeyValueExpr, e *state) {
 
 		// Ok now this is just a mess
 		if help, ok := kvp.Value.(*ast.BinaryExpr); ok {
-			s := checkBinaryExpression(help, e)
+			s := checkBinaryExpression(help)
 			if s != "" {
 				e.translations[s] = ""
 			}
@@ -394,7 +394,7 @@ func checkKeyValueExpression(kvp *ast.KeyValueExpr, e *state) {
 }
 
 // checkBinaryExpression checks binary expressions, stuff of the form x + y, for strings and concats them
-func checkBinaryExpression(b *ast.BinaryExpr, e *state) string {
+func checkBinaryExpression(b *ast.BinaryExpr) string {
 	// Check the left side
 	var s string
 	if l, ok := b.X.(*ast.BasicLit); ok {
@@ -410,7 +410,7 @@ func checkBinaryExpression(b *ast.BinaryExpr, e *state) string {
 	}
 
 	if b1, ok := b.X.(*ast.BinaryExpr); ok {
-		if x := checkBinaryExpression(b1, e); x != "" {
+		if x := checkBinaryExpression(b1); x != "" {
 			s += x
 		}
 	}
@@ -429,7 +429,7 @@ func checkBinaryExpression(b *ast.BinaryExpr, e *state) string {
 	}
 
 	if b1, ok := b.Y.(*ast.BinaryExpr); ok {
-		if x := checkBinaryExpression(b1, e); x != "" {
+		if x := checkBinaryExpression(b1); x != "" {
 			s += x
 		}
 	}

--- a/pkg/minikube/tunnel/tunnel_manager.go
+++ b/pkg/minikube/tunnel/tunnel_manager.go
@@ -122,8 +122,8 @@ func (mgr *Manager) run(ctx context.Context, t controller, ready, check, done ch
 	}
 }
 
-func (mgr *Manager) cleanup(t controller) *Status {
-	return t.cleanup()
+func (mgr *Manager) cleanup(t controller) {
+	t.cleanup()
 }
 
 // CleanupNotRunningTunnels cleans up tunnels that are not running


### PR DESCRIPTION
This version of golangci-lint comes with significant memory improvements, making some
adjustments for small memory footprint in the CI obsolete.

See https://github.com/golangci/golangci-lint/issues/337
