### PR TITLE
jenkins: Resilient VirtualBox VM and test directory cleanup

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -134,11 +134,13 @@ if type -P virsh; then
 fi
 
 if type -P vboxmanage; then
-  vboxmanage list vms || true
   vboxmanage list vms \
     | egrep -o '{.*?}' \
-    | xargs -I {} sh -c "vboxmanage startvm {} --type emergencystop; vboxmanage unregistervm {} --delete" \
-    || true
+    | xargs -I{} vboxmanage startvm {} --type emergencystop || true
+
+  vboxmanage list vms \
+    | egrep -o '{.*?}' \
+    | xargs -I{} vboxmanage unregistervm {} || true
 
   echo ">> VirtualBox VM list after clean up (should be empty):"
   vboxmanage list vms || true

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -145,6 +145,12 @@ if type -P vboxmanage; then
     vboxmanage startvm $guid --type emergencystop || true
     vboxmanage unregistervm $guid || true
   done
+
+  vboxmanage list hostonlyifs \
+    | grep "^Name:" \
+    | awk '{ print $2 }' \
+    | xargs -n1 vboxmanage hostonlyif remove || true
+
   echo ">> VirtualBox VM list after clean up (should be empty):"
   vboxmanage list vms || true
 fi

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -134,14 +134,11 @@ if type -P virsh; then
 fi
 
 if type -P vboxmanage; then
-  vboxmanage list vms \
-    | egrep -o '{.*?}' \
-    | xargs -I{} vboxmanage startvm {} --type emergencystop || true
-
-  vboxmanage list vms \
-    | egrep -o '{.*?}' \
-    | xargs -I{} vboxmanage unregistervm {} || true
-
+  for guid in $(vboxmanage list vms | egrep -Eo '\{[-a-Z0-9]+\}'); do
+    echo "- Removing stale VirtualBox VM: $guid"
+    vboxmanage startvm $guid --type emergencystop || true
+    vboxmanage unregistervm $guid || true
+  done
   echo ">> VirtualBox VM list after clean up (should be empty):"
   vboxmanage list vms || true
 fi


### PR DESCRIPTION
- Make sure that "list vms" regex only matches guid portion
- Add logging
- unregistervm still called if startvm fails

Related: #5583 