### PR TITLE
Replace registry-creds addon ReplicationController with Deployment

### DIFF
--- a/deploy/addons/registry-creds/registry-creds-rc.yaml.tmpl
+++ b/deploy/addons/registry-creds/registry-creds-rc.yaml.tmpl
@@ -1,27 +1,24 @@
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: registry-creds
   namespace: kube-system
   labels:
-    version: v1.9
     addonmanager.kubernetes.io/mode: Reconcile
     kubernetes.io/minikube-addons: registry-creds
 spec:
   replicas: 1
   selector:
-    name: registry-creds
-    version: v1.9
-    addonmanager.kubernetes.io/mode: Reconcile
+    matchLabels:
+        name: registry-creds
   template:
     metadata:
       labels:
         name: registry-creds
-        version: v1.9
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:
-      - image: registry.hub.docker.com/upmcenterprises/registry-creds:1.9
+      - image: upmcenterprises/registry-creds:1.9
         name: registry-creds
         imagePullPolicy: Always
         env:


### PR DESCRIPTION
As the official k8s docs state:

> Note: A Deployment that configures a ReplicaSet is now the recommended way to set up replication.

https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
