### PR TITLE
Remove unused enableUpdateNotification variable

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -120,15 +120,14 @@ const (
 )
 
 var (
-	registryMirror           []string
-	dockerEnv                []string
-	dockerOpt                []string
-	insecureRegistry         []string
-	apiServerNames           []string
-	addonList                []string
-	apiServerIPs             []net.IP
-	extraOptions             cfg.ExtraOptionSlice
-	enableUpdateNotification = true
+	registryMirror   []string
+	dockerEnv        []string
+	dockerOpt        []string
+	insecureRegistry []string
+	apiServerNames   []string
+	addonList        []string
+	apiServerIPs     []net.IP
+	extraOptions     cfg.ExtraOptionSlice
 )
 
 func init() {

--- a/cmd/minikube/cmd/update-check.go
+++ b/cmd/minikube/cmd/update-check.go
@@ -28,10 +28,6 @@ var updateCheckCmd = &cobra.Command{
 	Use:   "update-check",
 	Short: "Print current and latest version number",
 	Long:  `Print current and latest version number`,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		// Explicitly disable update checking for the version command
-		enableUpdateNotification = false
-	},
 	Run: func(command *cobra.Command, args []string) {
 		url := notify.GithubMinikubeReleasesURL
 		r, err := notify.GetAllVersionsFromURL(url)

--- a/cmd/minikube/cmd/version.go
+++ b/cmd/minikube/cmd/version.go
@@ -26,10 +26,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version of minikube",
 	Long:  `Print the version of minikube.`,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		// Explicitly disable update checking for the version command
-		enableUpdateNotification = false
-	},
 	Run: func(command *cobra.Command, args []string) {
 		out.Ln("minikube version: %v", version.GetVersion())
 		gitCommitID := version.GetGitCommitID()


### PR DESCRIPTION
This is no longer necessary as we now only check for updates during `minikube start`.