### PR TITLE
Warn if incompatible kubectl version is in use

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/url"
@@ -129,6 +130,17 @@ var (
 	apiServerIPs     []net.IP
 	extraOptions     cfg.ExtraOptionSlice
 )
+
+type kubectlversion struct {
+	CVersion ClientVersion `json:"clientVersion"`
+	SVersion ClientVersion `json:"serverVersion"`
+}
+
+type ClientVersion struct {
+	Major      string `json:"major"`
+	Minor      string `json:"minor"`
+	GitVersion string `json:"gitVersion"`
+}
 
 func init() {
 	initMinikubeFlags()
@@ -477,15 +489,56 @@ func showVersionInfo(k8sVersion string, cr cruntime.Manager) {
 	}
 }
 
+/**
+Function to check for kubectl. The checking is to compare
+the version reported by both the client and server. It is
+that kubectl will be of the same version or 1 lower than
+the kubernetes version.
+*/
 func showKubectlConnectInfo(kcs *kubeconfig.Settings) {
+	var output []byte
+	clientVersion := kubectlversion{}
+	serverVersion := kubectlversion{}
+
+	path, err := exec.LookPath("kubectl")
+
+	if err != nil {
+		out.T(out.Tip, "For best results, install kubectl: https://kubernetes.io/docs/tasks/tools/install-kubectl/")
+	} else {
+		glog.Infof("Kubectl found at the following location %s. Let's execute and get the result", path)
+		output, err = exec.Command(path, "version", "--output=json").Output()
+
+		// ...once we get something back do some version checking
+		if err == nil {
+			glog.Infof("Received output from kubectl %s", output)
+
+			// unmarshal both the {client}
+			clientjsonErr := json.Unmarshal(output, &clientVersion)
+
+			// .......  and {server} json
+			serverjsonErr := json.Unmarshal(output, &serverVersion)
+
+			if (clientjsonErr != nil) || (serverjsonErr != nil) {
+				glog.Infof("There was an error processing the json output")
+			} else {
+				// obtain the minor version for both
+				serverMinor, _ := strconv.Atoi(serverVersion.SVersion.Minor)
+				clientMinor, _ := strconv.Atoi(serverVersion.CVersion.Minor)
+
+				if clientMinor < serverMinor {
+					out.T(out.Tip, "The version of kubectl {{.kubectl}} installed is incompatible with your Kubernetes {{.kubernetes}}  deployment. Please upgrade/downgrade as necessary, or use minikube kubectlto connect to your cluster",
+						out.V{"kubectl": clientVersion.CVersion.GitVersion, "kubernetes": serverVersion.SVersion.GitVersion})
+				}
+			}
+		} else {
+			out.T(out.Tip, "For best results, install kubectl: https://kubernetes.io/docs/tasks/tools/install-kubectl/")
+		}
+	}
+
 	if kcs.KeepContext {
 		out.T(out.Kubectl, "To connect to this cluster, use: kubectl --context={{.name}}", out.V{"name": kcs.ClusterName})
 	} else {
 		out.T(out.Ready, `Done! kubectl is now configured to use "{{.name}}"`, out.V{"name": cfg.GetMachineName()})
-	}
-	_, err := exec.LookPath("kubectl")
-	if err != nil {
-		out.T(out.Tip, "For best results, install kubectl: https://kubernetes.io/docs/tasks/tools/install-kubectl/")
 	}
 }
 


### PR DESCRIPTION
Fixes: #3329

Modification is done inside start.go where additional checking on the
version returned via the kubectl CLI is checked.

Running 'kubectl version --output=json' will return both client
and server information.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
