### PR TITLE
Add JSON output for addons list

### DIFF
--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -360,6 +360,17 @@ func validateAddonsCmd(ctx context.Context, t *testing.T, profile string) {
 			t.Errorf("Plugin output did not match expected custom format. Got: %s", line)
 		}
 	}
+
+	// Json output
+	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "addons", "list", "-o", "json"))
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Args, err)
+	}
+	var jsonObject map[string]interface{}
+	err = json.Unmarshal(rr.Stdout.Bytes(), &jsonObject)
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Args, err)
+	}
 }
 
 // validateSSHCmd asserts basic "ssh" command functionality


### PR DESCRIPTION
Depends on https://github.com/kubernetes/minikube/pull/5555

## Before
Command:
```shell
minikube addons list -o json
```
Output:
```text
Error: unknown shorthand flag: 'o' in -o


Usage:
  minikube addons list [flags] [options]

Use "minikube addons options" for a list of global command-line options (applies to all commands).
```

## After
Command:
```shell
minikube addons list -o json
```
Output:
```text
{"addon-manager":{"Status":"enabled"},"dashboard":{"Status":"enabled"},"default-storageclass":{"Status":"enabled"},"efk":{"Status":"disabled"},"freshpod":{"Status":"disabled"},"gvisor":{"Status":"disabled"},"heapster":{"Status":"disabled"},"helm-tiller":{"Status":"disabled"},"ingress":{"Status":"enabled"},"ingress-dns":{"Status":"enabled"},"logviewer":{"Status":"disabled"},"metrics-server":{"Status":"enabled"},"nvidia-driver-installer":{"Status":"disabled"},"nvidia-gpu-device-plugin":{"Status":"disabled"},"registry":{"Status":"disabled"},"registry-creds":{"Status":"disabled"},"storage-provisioner":{"Status":"enabled"},"storage-provisioner-gluster":{"Status":"disabled"}}
```

### Output and Format options cannot both be used at the same time
Command:
```shell
minikube addons list -o json -f "hello"
```
Output:
```text
💡  Cannot use both --output and --format options
```