### PR TITLE
Add docker-init binary to package, bundled tini

### DIFF
--- a/deploy/iso/minikube-iso/package/docker-bin/docker-bin.mk
+++ b/deploy/iso/minikube-iso/package/docker-bin/docker-bin.mk
@@ -28,6 +28,10 @@ define DOCKER_BIN_INSTALL_TARGET_CMDS
 		$(TARGET_DIR)/bin/dockerd
 
 	$(INSTALL) -D -m 0755 \
+		$(@D)/docker-init \
+		$(TARGET_DIR)/bin/docker-init
+
+	$(INSTALL) -D -m 0755 \
 		$(@D)/docker-proxy \
 		$(TARGET_DIR)/bin/docker-proxy
 endef


### PR DESCRIPTION
Used only for `docker run --init`, as far as I know.

https://github.com/krallin/tini