### PR TITLE
Add json output for status

### DIFF
--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -183,11 +183,11 @@ func validateStatusCmd(ctx context.Context, t *testing.T, profile string) {
 	}
 
 	// Custom format
-	rr, err = Run(t, exec.CommandContext(ctx, Target(), "status", "-f", "host:{{.Host}},kublet:{{.Kubelet}},apiserver:{{.APIServer}},kubectl:{{.Kubeconfig}}"))
+	rr, err = Run(t, exec.CommandContext(ctx, Target(), "status", "-f", "host:{{.Host}},kublet:{{.Kubelet}},apiserver:{{.APIServer}},kubeconfig:{{.Kubeconfig}}"))
 	if err != nil {
 		t.Errorf("%s failed: %v", rr.Args, err)
 	}
-	match, _ := regexp.MatchString(`host:([A-z]+),kublet:([A-z]+),apiserver:([A-z]+),kubectl:([A-z]|[\s]|:|-|[0-9]|.)+`, rr.Stdout.String())
+	match, _ := regexp.MatchString(`host:([A-z]+),kublet:([A-z]+),apiserver:([A-z]+),kubeconfig:([A-z]+)`, rr.Stdout.String())
 	if !match {
 		t.Errorf("%s failed: %v. Output for custom format did not match", rr.Args, err)
 	}

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -84,6 +84,7 @@ func TestFunctional(t *testing.T) {
 			{"ConfigCmd", validateConfigCmd},
 			{"DashboardCmd", validateDashboardCmd},
 			{"DNS", validateDNS},
+			{"StatusCmd", validateStatusCmd},
 			{"LogsCmd", validateLogsCmd},
 			{"MountCmd", validateMountCmd},
 			{"ProfileCmd", validateProfileCmd},
@@ -172,6 +173,46 @@ func validateComponentHealth(ctx context.Context, t *testing.T, profile string) 
 		if status != api.ConditionTrue {
 			t.Errorf("unexpected status: %v - item: %+v", status, i)
 		}
+	}
+}
+
+func validateStatusCmd(ctx context.Context, t *testing.T, profile string) {
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), "status"))
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Args, err)
+	}
+
+	// Custom format
+	rr, err = Run(t, exec.CommandContext(ctx, Target(), "status", "-f", "host:{{.Host}},kublet:{{.Kubelet}},apiserver:{{.APIServer}},kubectl:{{.Kubeconfig}}"))
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Args, err)
+	}
+	match, _ := regexp.MatchString(`host:([A-z]+),kublet:([A-z]+),apiserver:([A-z]+),kubectl:([A-z]|[\s]|:|-|[0-9]|.)+`, rr.Stdout.String())
+	if !match {
+		t.Errorf("%s failed: %v. Output for custom format did not match", rr.Args, err)
+	}
+
+	// Json output
+	rr, err = Run(t, exec.CommandContext(ctx, Target(), "status", "-o", "json"))
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Args, err)
+	}
+	var jsonObject map[string]interface{}
+	err = json.Unmarshal(rr.Stdout.Bytes(), &jsonObject)
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Args, err)
+	}
+	if _, ok := jsonObject["Host"]; !ok {
+		t.Errorf("%s failed: %v. Missing key %s in json object", rr.Args, err, "Host")
+	}
+	if _, ok := jsonObject["Kubelet"]; !ok {
+		t.Errorf("%s failed: %v. Missing key %s in json object", rr.Args, err, "Kubelet")
+	}
+	if _, ok := jsonObject["APIServer"]; !ok {
+		t.Errorf("%s failed: %v. Missing key %s in json object", rr.Args, err, "APIServer")
+	}
+	if _, ok := jsonObject["Kubeconfig"]; !ok {
+		t.Errorf("%s failed: %v. Missing key %s in json object", rr.Args, err, "Kubeconfig")
 	}
 }
 

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -177,13 +177,13 @@ func validateComponentHealth(ctx context.Context, t *testing.T, profile string) 
 }
 
 func validateStatusCmd(ctx context.Context, t *testing.T, profile string) {
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), "status"))
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "status"))
 	if err != nil {
 		t.Errorf("%s failed: %v", rr.Args, err)
 	}
 
 	// Custom format
-	rr, err = Run(t, exec.CommandContext(ctx, Target(), "status", "-f", "host:{{.Host}},kublet:{{.Kubelet}},apiserver:{{.APIServer}},kubeconfig:{{.Kubeconfig}}"))
+	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "status", "-f", "host:{{.Host}},kublet:{{.Kubelet}},apiserver:{{.APIServer}},kubeconfig:{{.Kubeconfig}}"))
 	if err != nil {
 		t.Errorf("%s failed: %v", rr.Args, err)
 	}
@@ -193,7 +193,7 @@ func validateStatusCmd(ctx context.Context, t *testing.T, profile string) {
 	}
 
 	// Json output
-	rr, err = Run(t, exec.CommandContext(ctx, Target(), "status", "-o", "json"))
+	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "status", "-o", "json"))
 	if err != nil {
 		t.Errorf("%s failed: %v", rr.Args, err)
 	}


### PR DESCRIPTION
Adds json output for `minikube status` command
Adds shorthand argument for format option

## Before
Command:
```shell
minikube status -o json
```
Output:
```text
Error: unknown shorthand flag: 'o' in -o


Options:
      --format='host: {{.Host}}
kubelet: {{.Kubelet}}
apiserver: {{.APIServer}}
kubectl: {{.Kubeconfig}}
': Go template format string for the status output.  The format for Go templates can be found here: https://golang.org/pkg/text/template/
For the list accessible variables for the template, see the struct values here: https://godoc.org/k8s.io/minikube/cmd/minikube/cmd#Status

Usage:
  minikube status [flags] [options]

Use "minikube status options" for a list of global command-line options (applies to all commands).
```

## After

### Adds json output
Command:
```shell
minikube status -o json
```
Output:
```text
{"APIServer":"Running","Host":"Running","Kubeconfig":{"Correct":true,"IP":"192.168.99.189"},"Kubelet":"Running"}
```

### Adds shorthand for format option
Command:
```shell
minikube status --help
```
Output:
```text
Gets the status of a local kubernetes cluster.
        Exit status contains the status of minikube's VM, cluster and kubernetes encoded on it's bits in this order from right
to left.
        Eg: 7 meaning: 1 (for minikube NOK) + 2 (for cluster NOK) + 4 (for kubernetes NOK)

Options:
  -f, --format='host: {{.Host}}
kubelet: {{.Kubelet}}
apiserver: {{.APIServer}}
kubectl: {{.Kubeconfig}}
': Go template format string for the status output.  The format for Go templates can be found here:
https://golang.org/pkg/text/template/
For the list accessible variables for the template, see the struct values here:
https://godoc.org/k8s.io/minikube/cmd/minikube/cmd#Status
  -o, --output='text': minikube status --output OUTPUT. json, text

Usage:
  minikube status [flags] [options]

Use "minikube status options" for a list of global command-line options (applies to all commands).
```

### Output and Format options cannot both be used at the same time
Command:
```shell
minikube status -o json -f "hello"
```
Output:
```text
💡  Cannot use both --output and --format options
```

Fixes #5080