### PR TITLE
gsutil: Remove trailing slashes, rsync instead of cp

### DIFF
--- a/hack/jenkins/minikube_cross_build_and_upload.sh
+++ b/hack/jenkins/minikube_cross_build_and_upload.sh
@@ -63,4 +63,9 @@ cp -r test/integration/testdata out/
 # Don't upload the buildroot artifacts if they exist
 rm -r out/buildroot || true
 
-gsutil -m cp -r out/ "gs://${bucket}/${ghprbPullId}/"
+# At this point, the out directory contains the jenkins scripts (populated by jenkins),
+# testdata, and our build output. Push the changes to GCS so that worker nodes can re-use them.
+
+# -d: delete remote files that don't exist (removed test files, for instance)
+# -J: gzip compression
+gsutil -m rsync -dJ out "gs://${bucket}/${ghprbPullId}"


### PR DESCRIPTION
Fixes #5605 

Test output:

```
$ gsutil -m rsync -dJ out gs://minikube-builds/mystery-test
Building synchronization state...
Starting synchronization...
Copying file://out/coverage.txt [Content-Type=text/plain]...
Copying file://out/minikube [Content-Type=application/octet-stream]...          
Copying file://out/minikube-linux-amd64 [Content-Type=application/octet-stream]...
Copying file://out/gvisor-addon [Content-Type=application/octet-stream]...
/ [4/4 files][137.6 MiB/137.6 MiB] 100% Done                                    
Operation completed over 4 objects/137.6 MiB.                                    

$ gsutil -m rsync -dJ out gs://minikube-builds/mystery-test
Building synchronization state...
Starting synchronization...
```
