### PR TITLE
WIP: Re-organize $MINIKUBE_HOME to be race-proof and OS-idiomatic

### DIFF
--- a/cmd/minikube/cmd/cache.go
+++ b/cmd/minikube/cmd/cache.go
@@ -20,7 +20,6 @@ import (
 	"github.com/spf13/cobra"
 	cmdConfig "k8s.io/minikube/cmd/minikube/cmd/config"
 	"k8s.io/minikube/pkg/minikube/config"
-	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/minikube/machine"
@@ -71,7 +70,7 @@ var deleteCacheCmd = &cobra.Command{
 }
 
 func imagesInConfigFile() ([]string, error) {
-	configFile, err := config.ReadConfig(localpath.ConfigFile)
+	configFile, err := config.ReadConfig(localpath.GlobalConfig())
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +93,7 @@ func CacheImagesInConfigFile() error {
 	if len(images) == 0 {
 		return nil
 	}
-	return machine.CacheImages(images, constants.ImageCacheDir)
+	return machine.CacheImages(images, localpath.ContainerImages())
 }
 
 // loadCachedImagesInConfigFile loads the images currently in the config file (minikube start)

--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -306,7 +306,7 @@ func configurableFields() string {
 
 // ListConfigMap list entries from config file
 func ListConfigMap(name string) ([]string, error) {
-	configFile, err := config.ReadConfig(localpath.ConfigFile)
+	configFile, err := config.ReadConfig(localpath.GlobalConfig())
 	if err != nil {
 		return nil, err
 	}
@@ -326,7 +326,7 @@ func AddToConfigMap(name string, images []string) error {
 		return err
 	}
 	// Set the values
-	cfg, err := config.ReadConfig(localpath.ConfigFile)
+	cfg, err := config.ReadConfig(localpath.GlobalConfig())
 	if err != nil {
 		return err
 	}
@@ -343,7 +343,7 @@ func AddToConfigMap(name string, images []string) error {
 		return err
 	}
 	// Write the values
-	return config.WriteConfig(localpath.ConfigFile, cfg)
+	return config.WriteConfig(localpath.GlobalConfig(), cfg)
 }
 
 // DeleteFromConfigMap deletes entries from a map in the config file
@@ -353,7 +353,7 @@ func DeleteFromConfigMap(name string, images []string) error {
 		return err
 	}
 	// Set the values
-	cfg, err := config.ReadConfig(localpath.ConfigFile)
+	cfg, err := config.ReadConfig(localpath.GlobalConfig())
 	if err != nil {
 		return err
 	}
@@ -368,5 +368,5 @@ func DeleteFromConfigMap(name string, images []string) error {
 		return err
 	}
 	// Write the values
-	return config.WriteConfig(localpath.ConfigFile, cfg)
+	return config.WriteConfig(localpath.GlobalConfig(), cfg)
 }

--- a/cmd/minikube/cmd/config/set.go
+++ b/cmd/minikube/cmd/config/set.go
@@ -60,7 +60,7 @@ func Set(name string, value string) error {
 	}
 
 	// Set the value
-	config, err := pkgConfig.ReadConfig(localpath.ConfigFile)
+	config, err := pkgConfig.ReadConfig(localpath.GlobalConfig())
 	if err != nil {
 		return err
 	}
@@ -76,5 +76,5 @@ func Set(name string, value string) error {
 	}
 
 	// Write the value
-	return pkgConfig.WriteConfig(localpath.ConfigFile, config)
+	return pkgConfig.WriteConfig(localpath.GlobalConfig(), config)
 }

--- a/cmd/minikube/cmd/config/unset.go
+++ b/cmd/minikube/cmd/config/unset.go
@@ -44,10 +44,10 @@ func init() {
 
 // Unset unsets a property
 func Unset(name string) error {
-	m, err := pkgConfig.ReadConfig(localpath.ConfigFile)
+	m, err := pkgConfig.ReadConfig(localpath.GlobalConfig())
 	if err != nil {
 		return err
 	}
 	delete(m, name)
-	return pkgConfig.WriteConfig(localpath.ConfigFile, m)
+	return pkgConfig.WriteConfig(localpath.GlobalConfig(), m)
 }

--- a/cmd/minikube/cmd/config/view.go
+++ b/cmd/minikube/cmd/config/view.go
@@ -57,7 +57,7 @@ For the list of accessible variables for the template, see the struct values her
 
 // View displays the current config
 func View() error {
-	cfg, err := config.ReadConfig(localpath.ConfigFile)
+	cfg, err := config.ReadConfig(localpath.GlobalConfig())
 	if err != nil {
 		return err
 	}

--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strconv"
 
 	"github.com/docker/machine/libmachine/mcnerror"
@@ -119,20 +118,21 @@ func uninstallKubernetes(api libmachine.API, kc pkg_config.KubernetesConfig, bsN
 	}
 }
 
-func deleteProfileDirectory(profile string) {
-	machineDir := filepath.Join(localpath.MiniPath(), "machines", profile)
-	if _, err := os.Stat(machineDir); err == nil {
-		out.T(out.DeletingHost, `Removing {{.directory}} ...`, out.V{"directory": machineDir})
-		err := os.RemoveAll(machineDir)
+func deleteProfileDirectory(name string) {
+	profileDir := localpath.Profile(name)
+	if _, err := os.Stat(profileDir); err == nil {
+		out.T(out.DeletingHost, `Removing {{.directory}} ...`, out.V{"directory": profileDir})
+		err := os.RemoveAll(profileDir)
 		if err != nil {
-			exit.WithError("Unable to remove machine directory: %v", err)
+			exit.WithError("Unable to remove profile directory: %v", err)
 		}
 	}
 }
 
 // killMountProcess kills the mount process, if it is running
 func killMountProcess() error {
-	pidPath := filepath.Join(localpath.MiniPath(), constants.MountProcessFileName)
+	profile := viper.GetString(pkg_config.MachineProfile)
+	pidPath := localpath.MountPid(profile)
 	if _, err := os.Stat(pidPath); os.IsNotExist(err) {
 		return nil
 	}

--- a/cmd/minikube/cmd/env_test.go
+++ b/cmd/minikube/cmd/env_test.go
@@ -57,7 +57,7 @@ var defaultAPI = &tests.MockAPI{
 // Most of the shell cfg isn't configurable
 func newShellCfg(shell, prefix, suffix, delim string) *ShellConfig {
 	return &ShellConfig{
-		DockerCertPath:  localpath.MakeMiniPath("certs"),
+		DockerCertPath:  localpath.MachineCerts(name),
 		DockerTLSVerify: "1",
 		DockerHost:      "tcp://127.0.0.1:2376",
 		UsageHint:       generateUsageHint(shell),
@@ -139,7 +139,7 @@ func TestShellCfgSet(t *testing.T) {
 			noProxyValue: "",
 			noProxyFlag:  true,
 			expectedShellCfg: &ShellConfig{
-				DockerCertPath:  localpath.MakeMiniPath("certs"),
+				DockerCertPath:  localpath.MachineCerts(name),
 				DockerTLSVerify: "1",
 				DockerHost:      "tcp://127.0.0.1:2376",
 				UsageHint:       usageHintMap["bash"],
@@ -158,7 +158,7 @@ func TestShellCfgSet(t *testing.T) {
 			noProxyValue: "",
 			noProxyFlag:  true,
 			expectedShellCfg: &ShellConfig{
-				DockerCertPath:  localpath.MakeMiniPath("certs"),
+				DockerCertPath:  localpath.MachineCerts(name),
 				DockerTLSVerify: "1",
 				DockerHost:      "tcp://127.0.0.1:2376",
 				UsageHint:       usageHintMap["bash"],
@@ -177,7 +177,7 @@ func TestShellCfgSet(t *testing.T) {
 			noProxyValue: "127.0.0.1",
 			noProxyFlag:  true,
 			expectedShellCfg: &ShellConfig{
-				DockerCertPath:  localpath.MakeMiniPath("certs"),
+				DockerCertPath:  localpath.MachineCerts(name),
 				DockerTLSVerify: "1",
 				DockerHost:      "tcp://127.0.0.1:2376",
 				UsageHint:       usageHintMap["bash"],
@@ -196,7 +196,7 @@ func TestShellCfgSet(t *testing.T) {
 			noProxyValue: "0.0.0.0",
 			noProxyFlag:  true,
 			expectedShellCfg: &ShellConfig{
-				DockerCertPath:  localpath.MakeMiniPath("certs"),
+				DockerCertPath:  localpath.MachineCerts(name),
 				DockerTLSVerify: "1",
 				DockerHost:      "tcp://127.0.0.1:2376",
 				UsageHint:       usageHintMap["bash"],
@@ -215,7 +215,7 @@ func TestShellCfgSet(t *testing.T) {
 			noProxyValue: "0.0.0.0,127.0.0.1",
 			noProxyFlag:  true,
 			expectedShellCfg: &ShellConfig{
-				DockerCertPath:  localpath.MakeMiniPath("certs"),
+				DockerCertPath:  localpath.MachineCerts(name),
 				DockerTLSVerify: "1",
 				DockerHost:      "tcp://127.0.0.1:2376",
 				UsageHint:       usageHintMap["bash"],

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -59,9 +59,7 @@ var RootCmd = &cobra.Command{
 		}
 		glog.Infof("populate result: %v", result)
 		for src, dst := range result {
-			if dst == "" {
-				out.T(out.Arrow, "Created {{.src}}", out.V{"src": src})
-			} else {
+			if dst != "" {
 				out.T(out.Arrow, "Migrated {{.src}} to {{.dst}}", out.V{"src": src, "dst": dst})
 			}
 		}

--- a/cmd/minikube/cmd/root_test.go
+++ b/cmd/minikube/cmd/root_test.go
@@ -114,7 +114,7 @@ func hideEnv(t *testing.T) func(t *testing.T) {
 
 func TestPreRunDirectories(t *testing.T) {
 	// Make sure we create the required directories.
-	tempDir := tests.MakeTempDir()
+	tempDir := tests.TempMinikubeDir()
 	defer os.RemoveAll(tempDir)
 
 	runCommand(RootCmd.PersistentPreRun)

--- a/cmd/minikube/cmd/ssh-key.go
+++ b/cmd/minikube/cmd/ssh-key.go
@@ -17,8 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"path/filepath"
-
 	"github.com/spf13/cobra"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/localpath"
@@ -31,6 +29,6 @@ var sshKeyCmd = &cobra.Command{
 	Short: "Retrieve the ssh identity key path of the specified cluster",
 	Long:  "Retrieve the ssh identity key path of the specified cluster.",
 	Run: func(cmd *cobra.Command, args []string) {
-		out.Ln(filepath.Join(localpath.MiniPath(), "machines", config.GetMachineName(), "id_rsa"))
+		out.Ln(localpath.SSHKey(config.GetMachineName()))
 	},
 }

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -522,6 +522,7 @@ func selectDriver(oldConfig *cfg.Config) string {
 		return driver
 	}
 
+	glog.Infof("machine drivers claims that there is a host for %s", cfg.GetMachineName())
 	h, err := api.Load(cfg.GetMachineName())
 	if err != nil {
 		glog.Infof("selectDriver api.Load: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -46,10 +46,12 @@ require (
 	github.com/juju/version v0.0.0-20180108022336-b64dbd566305 // indirect
 	github.com/libvirt/libvirt-go v3.4.0+incompatible
 	github.com/machine-drivers/docker-machine-driver-vmware v0.1.1
+	github.com/machine-drivers/machine v0.16.1 // indirect
 	github.com/mattn/go-isatty v0.0.8
 	github.com/mitchellh/go-ps v0.0.0-20170309133038-4fdf99ab2936
 	github.com/moby/hyperkit v0.0.0-20171020124204-a12cd7250bcd
 	github.com/olekukonko/tablewriter v0.0.0-20160923125401-bdcc175572fd
+	github.com/otiai10/copy v1.0.2
 	github.com/pborman/uuid v1.2.0
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/pkg/browser v0.0.0-20160118053552-9302be274faa

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,6 @@ require (
 	github.com/juju/version v0.0.0-20180108022336-b64dbd566305 // indirect
 	github.com/libvirt/libvirt-go v3.4.0+incompatible
 	github.com/machine-drivers/docker-machine-driver-vmware v0.1.1
-	github.com/machine-drivers/machine v0.16.1 // indirect
 	github.com/mattn/go-isatty v0.0.8
 	github.com/mitchellh/go-ps v0.0.0-20170309133038-4fdf99ab2936
 	github.com/moby/hyperkit v0.0.0-20171020124204-a12cd7250bcd

--- a/go.sum
+++ b/go.sum
@@ -316,6 +316,8 @@ github.com/machine-drivers/docker-machine-driver-vmware v0.1.1 h1:+E1IKKk+6kaQrC
 github.com/machine-drivers/docker-machine-driver-vmware v0.1.1/go.mod h1:ej014C83EmSnxJeJ8PtVb8OLJ91PJKO1Q8Y7sM5CK0o=
 github.com/machine-drivers/machine v0.7.1-0.20190910053320-21bd2f51b8ea h1:HVlxRL2rDz7hmchX5ZtvCArWmki1Z4pQg19FHrwQCgw=
 github.com/machine-drivers/machine v0.7.1-0.20190910053320-21bd2f51b8ea/go.mod h1:79Uwa2hGd5S39LDJt58s8JZcIhGEK6pkq9bsuTbFWbk=
+github.com/machine-drivers/machine v0.16.1 h1:q2QW23oQIo++kqoSF8Ll4G8yDVSjn0x0NditGayEwE4=
+github.com/machine-drivers/machine v0.16.1/go.mod h1:79Uwa2hGd5S39LDJt58s8JZcIhGEK6pkq9bsuTbFWbk=
 github.com/magiconair/properties v0.0.0-20160816085511-61b492c03cf4/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -383,6 +385,10 @@ github.com/opencontainers/runc v0.0.0-20181113202123-f000fe11ece1/go.mod h1:qT5X
 github.com/opencontainers/runtime-spec v1.0.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v0.0.0-20170621221121-4a2974bf1ee9/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
+github.com/otiai10/copy v1.0.2 h1:DDNipYy6RkIkjMwy+AWzgKiNTyj2RUI9yEMeETEpVyc=
+github.com/otiai10/copy v1.0.2/go.mod h1:c7RpqBkwMom4bYTSkLSym4VSJz/XtncWRAj/J4PEIMY=
+github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
+github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.0.1/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -657,6 +663,7 @@ k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30 h1:TRb4wNWoBVrH9plmkp2q86
 k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/kubernetes v1.15.2 h1:RO9EuRw5vlN3oa/lnmPxmywOoJRtg9o40KcklHXNIAQ=
 k8s.io/kubernetes v1.15.2/go.mod h1:3RE5ikMc73WK+dSxk4pQuQ6ZaJcPXiZX2dj98RcdCuM=
+k8s.io/kubernetes v1.16.1 h1:5Ys1P0p+OkGMq+/RQWa3/gs2hlGfaNkVPsVY+vyZWqQ=
 k8s.io/kubernetes/staging/src/k8s.io/api v0.0.0-20190623232353-8c3b7d7679cc h1:vZ5+77WP1yImZo23wc75vV5b5zCGq9gv484q8Yw5sBw=
 k8s.io/kubernetes/staging/src/k8s.io/api v0.0.0-20190623232353-8c3b7d7679cc/go.mod h1:pU9hbGZc8Z6+6HlNLEFY1GiNGzcCykU1Glsd4vEea2U=
 k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver v0.0.0-20190623232353-8c3b7d7679cc/go.mod h1:Q49J/iUBV6A9nn8loyV72DK2EXhN8sqCR8FyfxIFDA4=
@@ -667,6 +674,7 @@ k8s.io/kubernetes/staging/src/k8s.io/apiserver v0.0.0-20190623232353-8c3b7d7679c
 k8s.io/kubernetes/staging/src/k8s.io/cli-runtime v0.0.0-20190623232353-8c3b7d7679cc/go.mod h1:YZQFNMZSNiRALChwxrRkzjVrmmJWNlSl4StwOETTIYI=
 k8s.io/kubernetes/staging/src/k8s.io/client-go v0.0.0-20190623232353-8c3b7d7679cc h1:NkZ6eBWe3aFn6wCHgMBPfcjVSji1Nz/EcwGpFQjcT0c=
 k8s.io/kubernetes/staging/src/k8s.io/client-go v0.0.0-20190623232353-8c3b7d7679cc/go.mod h1:O+HAJNvEkq6MA64VSkhBp2oKeuSVWtTgc9O3z7AgDfA=
+k8s.io/kubernetes/staging/src/k8s.io/client-go v0.0.0-20191011020052-5e0f48acf83c h1:62TdXObLPJBuX4joRs7rYdxmWA/EcajOKCMZMep5riM=
 k8s.io/kubernetes/staging/src/k8s.io/cloud-provider v0.0.0-20190623232353-8c3b7d7679cc/go.mod h1:rQUOm/XLTGmz4tguTc3V1Ee8zCf5BZ2lCh7nv6dXTzA=
 k8s.io/kubernetes/staging/src/k8s.io/cluster-bootstrap v0.0.0-20190623232353-8c3b7d7679cc h1:RvTiGzEJ1/k72+BZMjwkGCF6gYMBxn0zeeiE8Yu6f/I=
 k8s.io/kubernetes/staging/src/k8s.io/cluster-bootstrap v0.0.0-20190623232353-8c3b7d7679cc/go.mod h1:8RJmS4bkGaaevegssxZX5h3eMJzW3smzE67LISltg+k=

--- a/go.sum
+++ b/go.sum
@@ -316,8 +316,6 @@ github.com/machine-drivers/docker-machine-driver-vmware v0.1.1 h1:+E1IKKk+6kaQrC
 github.com/machine-drivers/docker-machine-driver-vmware v0.1.1/go.mod h1:ej014C83EmSnxJeJ8PtVb8OLJ91PJKO1Q8Y7sM5CK0o=
 github.com/machine-drivers/machine v0.7.1-0.20190910053320-21bd2f51b8ea h1:HVlxRL2rDz7hmchX5ZtvCArWmki1Z4pQg19FHrwQCgw=
 github.com/machine-drivers/machine v0.7.1-0.20190910053320-21bd2f51b8ea/go.mod h1:79Uwa2hGd5S39LDJt58s8JZcIhGEK6pkq9bsuTbFWbk=
-github.com/machine-drivers/machine v0.16.1 h1:q2QW23oQIo++kqoSF8Ll4G8yDVSjn0x0NditGayEwE4=
-github.com/machine-drivers/machine v0.16.1/go.mod h1:79Uwa2hGd5S39LDJt58s8JZcIhGEK6pkq9bsuTbFWbk=
 github.com/magiconair/properties v0.0.0-20160816085511-61b492c03cf4/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -387,7 +385,9 @@ github.com/opencontainers/selinux v0.0.0-20170621221121-4a2974bf1ee9/go.mod h1:+
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/otiai10/copy v1.0.2 h1:DDNipYy6RkIkjMwy+AWzgKiNTyj2RUI9yEMeETEpVyc=
 github.com/otiai10/copy v1.0.2/go.mod h1:c7RpqBkwMom4bYTSkLSym4VSJz/XtncWRAj/J4PEIMY=
+github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95 h1:+OLn68pqasWca0z5ryit9KGfp3sUsW4Lqg32iRMJyzs=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
+github.com/otiai10/mint v1.3.0 h1:Ady6MKVezQwHBkGzLFbrsywyp09Ah7rkmfjV3Bcr5uc=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
@@ -663,7 +663,6 @@ k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30 h1:TRb4wNWoBVrH9plmkp2q86
 k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/kubernetes v1.15.2 h1:RO9EuRw5vlN3oa/lnmPxmywOoJRtg9o40KcklHXNIAQ=
 k8s.io/kubernetes v1.15.2/go.mod h1:3RE5ikMc73WK+dSxk4pQuQ6ZaJcPXiZX2dj98RcdCuM=
-k8s.io/kubernetes v1.16.1 h1:5Ys1P0p+OkGMq+/RQWa3/gs2hlGfaNkVPsVY+vyZWqQ=
 k8s.io/kubernetes/staging/src/k8s.io/api v0.0.0-20190623232353-8c3b7d7679cc h1:vZ5+77WP1yImZo23wc75vV5b5zCGq9gv484q8Yw5sBw=
 k8s.io/kubernetes/staging/src/k8s.io/api v0.0.0-20190623232353-8c3b7d7679cc/go.mod h1:pU9hbGZc8Z6+6HlNLEFY1GiNGzcCykU1Glsd4vEea2U=
 k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver v0.0.0-20190623232353-8c3b7d7679cc/go.mod h1:Q49J/iUBV6A9nn8loyV72DK2EXhN8sqCR8FyfxIFDA4=
@@ -674,7 +673,6 @@ k8s.io/kubernetes/staging/src/k8s.io/apiserver v0.0.0-20190623232353-8c3b7d7679c
 k8s.io/kubernetes/staging/src/k8s.io/cli-runtime v0.0.0-20190623232353-8c3b7d7679cc/go.mod h1:YZQFNMZSNiRALChwxrRkzjVrmmJWNlSl4StwOETTIYI=
 k8s.io/kubernetes/staging/src/k8s.io/client-go v0.0.0-20190623232353-8c3b7d7679cc h1:NkZ6eBWe3aFn6wCHgMBPfcjVSji1Nz/EcwGpFQjcT0c=
 k8s.io/kubernetes/staging/src/k8s.io/client-go v0.0.0-20190623232353-8c3b7d7679cc/go.mod h1:O+HAJNvEkq6MA64VSkhBp2oKeuSVWtTgc9O3z7AgDfA=
-k8s.io/kubernetes/staging/src/k8s.io/client-go v0.0.0-20191011020052-5e0f48acf83c h1:62TdXObLPJBuX4joRs7rYdxmWA/EcajOKCMZMep5riM=
 k8s.io/kubernetes/staging/src/k8s.io/cloud-provider v0.0.0-20190623232353-8c3b7d7679cc/go.mod h1:rQUOm/XLTGmz4tguTc3V1Ee8zCf5BZ2lCh7nv6dXTzA=
 k8s.io/kubernetes/staging/src/k8s.io/cluster-bootstrap v0.0.0-20190623232353-8c3b7d7679cc h1:RvTiGzEJ1/k72+BZMjwkGCF6gYMBxn0zeeiE8Yu6f/I=
 k8s.io/kubernetes/staging/src/k8s.io/cluster-bootstrap v0.0.0-20190623232353-8c3b7d7679cc/go.mod h1:8RJmS4bkGaaevegssxZX5h3eMJzW3smzE67LISltg+k=

--- a/pkg/drivers/drivers_test.go
+++ b/pkg/drivers/drivers_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func Test_createDiskImage(t *testing.T) {
-	tmpdir := tests.MakeTempDir()
+	tmpdir := tests.TempMinikubeDir()
 	defer os.RemoveAll(tmpdir)
 
 	sshPath := filepath.Join(tmpdir, "ssh")

--- a/pkg/drivers/hyperkit/network_test.go
+++ b/pkg/drivers/hyperkit/network_test.go
@@ -50,7 +50,7 @@ var validLeases = []byte(`{
 }`)
 
 func Test_getIpAddressFromFile(t *testing.T) {
-	tmpdir := tests.MakeTempDir()
+	tmpdir := tests.TempMinikubeDir()
 	defer os.RemoveAll(tmpdir)
 
 	dhcpFile := filepath.Join(tmpdir, "dhcp")

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -379,10 +379,10 @@ var Addons = map[string]*Addon{
 // AddMinikubeDirAssets adds all addons and files to the list
 // of files to be copied to the vm.
 func AddMinikubeDirAssets(assets *[]CopyableFile) error {
-	if err := addMinikubeDirToAssets(localpath.MakeMiniPath("addons"), vmpath.GuestAddonsDir, assets); err != nil {
+	if err := addMinikubeDirToAssets(localpath.Addons(), vmpath.GuestAddonsDir, assets); err != nil {
 		return errors.Wrap(err, "adding addons folder to assets")
 	}
-	if err := addMinikubeDirToAssets(localpath.MakeMiniPath("files"), "", assets); err != nil {
+	if err := addMinikubeDirToAssets(localpath.FileSync(), "", assets); err != nil {
 		return errors.Wrap(err, "adding files rootfs to assets")
 	}
 

--- a/pkg/minikube/assets/addons_test.go
+++ b/pkg/minikube/assets/addons_test.go
@@ -33,7 +33,7 @@ func setupTestDir() (string, error) {
 		return "", err
 	}
 
-	os.Setenv(localpath.MinikubeHome, path)
+	os.Setenv(localpath.OverrideVar, path)
 	return path, err
 }
 

--- a/pkg/minikube/bootstrapper/certs_test.go
+++ b/pkg/minikube/bootstrapper/certs_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func TestSetupCerts(t *testing.T) {
-	tempDir := tests.MakeTempDir()
+	tempDir := tests.TempMinikubeDir()
 	defer os.RemoveAll(tempDir)
 
 	k8s := config.KubernetesConfig{
@@ -58,10 +58,10 @@ func TestSetupCerts(t *testing.T) {
 	}
 	certFilenames := map[string]string{"ca.crt": "minikubeCA.pem", "mycert.pem": "mycert.pem"}
 	for _, dst := range certFilenames {
-		certFile := path.Join(CACertificatesDir, dst)
-		certStorePath := path.Join(SSLCertStoreDir, dst)
+		certFile := path.Join(guestCACertsDir, dst)
+		certStorePath := path.Join(guestSSLCertsDir, dst)
 		certNameHash := "abcdef"
-		remoteCertHashLink := path.Join(SSLCertStoreDir, fmt.Sprintf("%s.0", certNameHash))
+		remoteCertHashLink := path.Join(guestSSLCertsDir, fmt.Sprintf("%s.0", certNameHash))
 		cmdMap[fmt.Sprintf("sudo ln -s '%s' '%s'", certFile, certStorePath)] = "1"
 		cmdMap[fmt.Sprintf("openssl x509 -hash -noout -in '%s'", certFile)] = certNameHash
 		cmdMap[fmt.Sprintf("sudo ln -s '%s' '%s'", certStorePath, remoteCertHashLink)] = "1"

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -48,6 +48,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/cruntime"
+	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/minikube/machine"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/vmpath"
@@ -535,7 +536,7 @@ func (k *Bootstrapper) PullImages(k8s config.KubernetesConfig) error {
 
 // SetupCerts sets up certificates within the cluster.
 func (k *Bootstrapper) SetupCerts(k8s config.KubernetesConfig) error {
-	return bootstrapper.SetupCerts(k.c, k8s)
+	return bootstrapper.SetupCerts(config.GetMachineName(), k.c, k8s)
 }
 
 // NewKubeletConfig generates a new systemd unit containing a configured kubelet
@@ -597,7 +598,7 @@ func NewKubeletConfig(k8s config.KubernetesConfig, r cruntime.Manager) ([]byte, 
 func (k *Bootstrapper) UpdateCluster(cfg config.KubernetesConfig) error {
 	images := images.CachedImages(cfg.ImageRepository, cfg.KubernetesVersion)
 	if cfg.ShouldLoadCachedImages {
-		if err := machine.LoadImages(k.c, images, constants.ImageCacheDir); err != nil {
+		if err := machine.LoadImages(k.c, images, localpath.ContainerImages()); err != nil {
 			out.FailureT("Unable to load cached images: {{.error}}", out.V{"error": err})
 		}
 	}

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -455,8 +455,9 @@ func createHost(api libmachine.API, config cfg.MachineConfig) (*host.Host, error
 		return nil, errors.Wrap(err, "new host")
 	}
 
-	h.HostOptions.AuthOptions.CertDir = localpath.MiniPath()
-	h.HostOptions.AuthOptions.StorePath = localpath.MiniPath()
+	name := cfg.GetMachineName()
+	h.HostOptions.AuthOptions.CertDir = localpath.MachineCerts(name)
+	h.HostOptions.AuthOptions.StorePath = localpath.Store(name)
 	h.HostOptions.EngineOptions = engineOptions(config)
 
 	if err := api.Create(h); err != nil {
@@ -484,7 +485,8 @@ func createHost(api libmachine.API, config cfg.MachineConfig) (*host.Host, error
 
 // GetHostDockerEnv gets the necessary docker env variables to allow the use of docker through minikube's vm
 func GetHostDockerEnv(api libmachine.API) (map[string]string, error) {
-	host, err := CheckIfHostExistsAndLoad(api, cfg.GetMachineName())
+	name := cfg.GetMachineName()
+	host, err := CheckIfHostExistsAndLoad(api, name)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error checking that api exists and loading it")
 	}
@@ -499,7 +501,7 @@ func GetHostDockerEnv(api libmachine.API) (map[string]string, error) {
 	envMap := map[string]string{
 		"DOCKER_TLS_VERIFY": "1",
 		"DOCKER_HOST":       tcpPrefix + net.JoinHostPort(ip, port),
-		"DOCKER_CERT_PATH":  localpath.MakeMiniPath("certs"),
+		"DOCKER_CERT_PATH":  localpath.MachineCerts(name),
 	}
 	return envMap, nil
 }

--- a/pkg/minikube/cluster/cluster_test.go
+++ b/pkg/minikube/cluster/cluster_test.go
@@ -336,7 +336,7 @@ func TestGetHostStatus(t *testing.T) {
 
 func TestGetHostDockerEnv(t *testing.T) {
 	RegisterMockDriver(t)
-	tempDir := tests.MakeTempDir()
+	tempDir := tests.TempMinikubeDir()
 	defer os.RemoveAll(tempDir)
 
 	api := tests.NewMockAPI(t)
@@ -370,7 +370,7 @@ func TestGetHostDockerEnv(t *testing.T) {
 }
 
 func TestGetHostDockerEnvIPv6(t *testing.T) {
-	tempDir := tests.MakeTempDir()
+	tempDir := tests.TempMinikubeDir()
 	defer os.RemoveAll(tempDir)
 
 	api := tests.NewMockAPI(t)

--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -60,7 +60,7 @@ type MinikubeConfig map[string]interface{}
 
 // Get gets a named value from config
 func Get(name string) (string, error) {
-	m, err := ReadConfig(localpath.ConfigFile)
+	m, err := ReadConfig(localpath.GlobalConfig())
 	if err != nil {
 		return "", err
 	}
@@ -95,13 +95,13 @@ func ReadConfig(configFile string) (MinikubeConfig, error) {
 		if os.IsNotExist(err) {
 			return make(map[string]interface{}), nil
 		}
-		return nil, fmt.Errorf("open %s: %v", localpath.ConfigFile, err)
+		return nil, fmt.Errorf("open %s: %v", localpath.GlobalConfig(), err)
 	}
 	defer f.Close()
 
 	m, err := decode(f)
 	if err != nil {
-		return nil, fmt.Errorf("decode %s: %v", localpath.ConfigFile, err)
+		return nil, fmt.Errorf("decode %s: %v", localpath.GlobalConfig(), err)
 	}
 
 	return m, nil
@@ -140,7 +140,7 @@ func Load() (*Config, error) {
 
 // Loader loads the kubernetes and machine config based on the machine profile name
 type Loader interface {
-	LoadConfigFromFile(profile string, miniHome ...string) (*Config, error)
+	LoadConfigFromFile(profile string) (*Config, error)
 }
 
 type simpleConfigLoader struct{}
@@ -148,10 +148,9 @@ type simpleConfigLoader struct{}
 // DefaultLoader is the default config loader
 var DefaultLoader Loader = &simpleConfigLoader{}
 
-func (c *simpleConfigLoader) LoadConfigFromFile(profileName string, miniHome ...string) (*Config, error) {
+func (c *simpleConfigLoader) LoadConfigFromFile(name string) (*Config, error) {
 	var cc Config
-	// Move to profile package
-	path := profileFilePath(profileName, miniHome...)
+	path := localpath.ProfileConfig(name)
 
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return nil, err

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -38,7 +38,6 @@ type Config struct {
 // MachineConfig contains the parameters used to start a cluster.
 type MachineConfig struct {
 	KeepContext         bool // used by start and profile command to or not to switch kubectl's current context
-	EmbedCerts          bool // used by kubeconfig.Setup
 	MinikubeISO         string
 	Memory              int
 	CPUs                int

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -18,11 +18,8 @@ package constants
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/homedir"
-	"k8s.io/minikube/pkg/minikube/localpath"
 	minikubeVersion "k8s.io/minikube/pkg/version"
 )
 
@@ -62,9 +59,6 @@ const DriverHyperv = "hyperv"
 // DriverParallels is the parallels driver option name
 const DriverParallels = "parallels"
 
-// DefaultMinipath is the default Minikube path (under the home directory)
-var DefaultMinipath = filepath.Join(homedir.HomeDir(), ".minikube")
-
 // KubeconfigPath is the path to the Kubernetes client config
 var KubeconfigPath = clientcmd.RecommendedHomeFile
 
@@ -76,9 +70,6 @@ const DefaultMachineName = "minikube"
 
 // DefaultNodeName is the default name for the kubeadm node within the VM
 const DefaultNodeName = "minikube"
-
-// MountProcessFileName is the filename of the mount process
-var MountProcessFileName = ".mount-process"
 
 const (
 	// SHASuffix is the suffix of a SHA-256 checksum file
@@ -113,9 +104,6 @@ var ImageRepositories = map[string][]string{
 
 // KubeadmBinaries are Kubernetes release binaries required for kubeadm
 var KubeadmBinaries = []string{"kubelet", "kubeadm"}
-
-// ImageCacheDir is the path to the image cache directory
-var ImageCacheDir = localpath.MakeMiniPath("cache", "images")
 
 const (
 	// GvisorFilesPath is the path to the gvisor files saved by go-bindata

--- a/pkg/minikube/drivers/hyperkit/driver.go
+++ b/pkg/minikube/drivers/hyperkit/driver.go
@@ -46,10 +46,11 @@ func createHyperkitHost(config cfg.MachineConfig) interface{} {
 		uuID = uuid.NewUUID().String()
 	}
 
+	name := cfg.GetMachineName()
 	return &hyperkit.Driver{
 		BaseDriver: &drivers.BaseDriver{
-			MachineName: cfg.GetMachineName(),
-			StorePath:   localpath.MiniPath(),
+			MachineName: name,
+			StorePath:   localpath.Store(name),
 			SSHUser:     "docker",
 		},
 		Boot2DockerURL: config.Downloader.GetISOFileURI(config.MinikubeISO),

--- a/pkg/minikube/drivers/hyperv/driver.go
+++ b/pkg/minikube/drivers/hyperv/driver.go
@@ -39,8 +39,8 @@ func init() {
 }
 
 func createHypervHost(config cfg.MachineConfig) interface{} {
-	d := hyperv.NewDriver(cfg.GetMachineName(), localpath.MiniPath())
-
+	name := cfg.GetMachineName()
+	d := hyperv.NewDriver(name, localpath.Store(name))
 	d.Boot2DockerURL = config.Downloader.GetISOFileURI(config.MinikubeISO)
 	d.VSwitch = config.HypervVirtualSwitch
 	d.MemSize = config.Memory

--- a/pkg/minikube/drivers/kvm2/driver.go
+++ b/pkg/minikube/drivers/kvm2/driver.go
@@ -58,10 +58,11 @@ type kvmDriver struct {
 }
 
 func createKVM2Host(config cfg.MachineConfig) interface{} {
+	name := cfg.GetMachineName()
 	return &kvmDriver{
 		BaseDriver: &drivers.BaseDriver{
-			MachineName: cfg.GetMachineName(),
-			StorePath:   localpath.MiniPath(),
+			MachineName: name,
+			StorePath:   filepath.Store(),
 			SSHUser:     "docker",
 		},
 		Memory:         config.Memory,
@@ -70,8 +71,8 @@ func createKVM2Host(config cfg.MachineConfig) interface{} {
 		PrivateNetwork: "minikube-net",
 		Boot2DockerURL: config.Downloader.GetISOFileURI(config.MinikubeISO),
 		DiskSize:       config.DiskSize,
-		DiskPath:       filepath.Join(localpath.MiniPath(), "machines", cfg.GetMachineName(), fmt.Sprintf("%s.rawdisk", cfg.GetMachineName())),
-		ISO:            filepath.Join(localpath.MiniPath(), "machines", cfg.GetMachineName(), "boot2docker.iso"),
+		DiskPath:       filepath.Join(localpath.Machine(name), fmt.Sprintf("%s.rawdisk", name),
+		ISO:            filepath.Join(localpath.Machine(name), "boot2docker.iso"),
 		GPU:            config.KVMGPU,
 		Hidden:         config.KVMHidden,
 		ConnectionURI:  config.KVMQemuURI,

--- a/pkg/minikube/drivers/none/driver.go
+++ b/pkg/minikube/drivers/none/driver.go
@@ -43,9 +43,10 @@ func init() {
 
 // createNoneHost creates a none Driver from a MachineConfig
 func createNoneHost(config cfg.MachineConfig) interface{} {
+	name := cfg.GetMachineName()
 	return none.NewDriver(none.Config{
-		MachineName:      cfg.GetMachineName(),
-		StorePath:        localpath.MiniPath(),
+		MachineName:      name,
+		StorePath:        localpath.Store(name),
 		ContainerRuntime: config.ContainerRuntime,
 	})
 }

--- a/pkg/minikube/drivers/parallels/driver.go
+++ b/pkg/minikube/drivers/parallels/driver.go
@@ -45,7 +45,8 @@ func init() {
 }
 
 func createParallelsHost(config cfg.MachineConfig) interface{} {
-	d := parallels.NewDriver(cfg.GetMachineName(), localpath.MiniPath()).(*parallels.Driver)
+	name := cfg.GetMachineName()
+	d := parallels.NewDriver(name, localpath.Store(name)).(*parallels.Driver)
 	d.Boot2DockerURL = config.Downloader.GetISOFileURI(config.MinikubeISO)
 	d.Memory = config.Memory
 	d.CPU = config.CPUs

--- a/pkg/minikube/drivers/virtualbox/driver.go
+++ b/pkg/minikube/drivers/virtualbox/driver.go
@@ -44,8 +44,8 @@ func init() {
 }
 
 func createVirtualboxHost(config cfg.MachineConfig) interface{} {
-	d := virtualbox.NewDriver(cfg.GetMachineName(), localpath.MiniPath())
-
+	name := cfg.GetMachineName()
+	d := virtualbox.NewDriver(name, localpath.Store(name))
 	d.Boot2DockerURL = config.Downloader.GetISOFileURI(config.MinikubeISO)
 	d.Memory = config.Memory
 	d.CPU = config.CPUs

--- a/pkg/minikube/drivers/vmware/driver.go
+++ b/pkg/minikube/drivers/vmware/driver.go
@@ -38,7 +38,8 @@ func init() {
 }
 
 func createVMwareHost(config cfg.MachineConfig) interface{} {
-	d := vmwcfg.NewConfig(cfg.GetMachineName(), localpath.MiniPath())
+	name := cfg.GetMachineName()
+	d := vmwcfg.NewConfig(name, localpath.Store(name))
 	d.Boot2DockerURL = config.Downloader.GetISOFileURI(config.MinikubeISO)
 	d.Memory = config.Memory
 	d.CPU = config.CPUs

--- a/pkg/minikube/drivers/vmwarefusion/driver.go
+++ b/pkg/minikube/drivers/vmwarefusion/driver.go
@@ -43,7 +43,8 @@ func init() {
 }
 
 func createVMwareFusionHost(config cfg.MachineConfig) interface{} {
-	d := vmwarefusion.NewDriver(cfg.GetMachineName(), localpath.MiniPath()).(*vmwarefusion.Driver)
+	name := cfg.GetMachineName()
+	d := vmwarefusion.NewDriver(name, localpath.Store(name)).(*vmwarefusion.Driver)
 	d.Boot2DockerURL = config.Downloader.GetISOFileURI(config.MinikubeISO)
 	d.Memory = config.Memory
 	d.CPU = config.CPUs

--- a/pkg/minikube/kubeconfig/kubeconfig.go
+++ b/pkg/minikube/kubeconfig/kubeconfig.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/tools/clientcmd/api/latest"
 	"k8s.io/minikube/pkg/minikube/constants"
-	pkgutil "k8s.io/minikube/pkg/util"
+	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/util/lock"
 )
 
@@ -191,7 +191,7 @@ func writeToFile(config runtime.Object, configPath ...string) error {
 		return errors.Wrapf(err, "Error writing file %s", fPath)
 	}
 
-	if err := pkgutil.MaybeChownDirRecursiveToMinikubeUser(dir); err != nil {
+	if err := localpath.ChownToSudoUser(dir); err != nil {
 		return errors.Wrapf(err, "Error recursively changing ownership for dir: %s", dir)
 	}
 

--- a/pkg/minikube/kubeconfig/settings.go
+++ b/pkg/minikube/kubeconfig/settings.go
@@ -48,12 +48,13 @@ type Settings struct {
 	// Should the current context be kept when setting up this one
 	KeepContext bool
 
-	// Should the certificate files be embedded instead of referenced by path
-	EmbedCerts bool
-
 	// kubeConfigFile is the path where the kube config is stored
 	// Only access this with atomic ops
 	kubeConfigFile atomic.Value
+
+	// Should the certificate files be embedded instead of referenced by path.
+	// This is the default locally, but not remotely.
+	EmbedCerts bool
 }
 
 // SetPath sets the setting for kubeconfig filepath
@@ -85,18 +86,13 @@ func PopulateFromSettings(cfg *Settings, apiCfg *api.Config) error {
 	// user
 	userName := cfg.ClusterName
 	user := api.NewAuthInfo()
-	if cfg.EmbedCerts {
-		user.ClientCertificateData, err = ioutil.ReadFile(cfg.ClientCertificate)
-		if err != nil {
-			return errors.Wrapf(err, "reading ClientCertificate %s", cfg.ClientCertificate)
-		}
-		user.ClientKeyData, err = ioutil.ReadFile(cfg.ClientKey)
-		if err != nil {
-			return errors.Wrapf(err, "reading ClientKey %s", cfg.ClientKey)
-		}
-	} else {
-		user.ClientCertificate = cfg.ClientCertificate
-		user.ClientKey = cfg.ClientKey
+	user.ClientCertificateData, err = ioutil.ReadFile(cfg.ClientCertificate)
+	if err != nil {
+		return errors.Wrapf(err, "reading ClientCertificate %s", cfg.ClientCertificate)
+	}
+	user.ClientKeyData, err = ioutil.ReadFile(cfg.ClientKey)
+	if err != nil {
+		return errors.Wrapf(err, "reading ClientKey %s", cfg.ClientKey)
 	}
 	apiCfg.AuthInfos[userName] = user
 

--- a/pkg/minikube/kubeconfig/settings.go
+++ b/pkg/minikube/kubeconfig/settings.go
@@ -51,10 +51,6 @@ type Settings struct {
 	// kubeConfigFile is the path where the kube config is stored
 	// Only access this with atomic ops
 	kubeConfigFile atomic.Value
-
-	// Should the certificate files be embedded instead of referenced by path.
-	// This is the default locally, but not remotely.
-	EmbedCerts bool
 }
 
 // SetPath sets the setting for kubeconfig filepath
@@ -73,13 +69,9 @@ func PopulateFromSettings(cfg *Settings, apiCfg *api.Config) error {
 	clusterName := cfg.ClusterName
 	cluster := api.NewCluster()
 	cluster.Server = cfg.ClusterServerAddress
-	if cfg.EmbedCerts {
-		cluster.CertificateAuthorityData, err = ioutil.ReadFile(cfg.CertificateAuthority)
-		if err != nil {
-			return errors.Wrapf(err, "reading CertificateAuthority %s", cfg.CertificateAuthority)
-		}
-	} else {
-		cluster.CertificateAuthority = cfg.CertificateAuthority
+	cluster.CertificateAuthorityData, err = ioutil.ReadFile(cfg.CertificateAuthority)
+	if err != nil {
+		return errors.Wrapf(err, "reading CertificateAuthority %s", cfg.CertificateAuthority)
 	}
 	apiCfg.Clusters[clusterName] = cluster
 

--- a/pkg/minikube/localpath/chown.go
+++ b/pkg/minikube/localpath/chown.go
@@ -1,0 +1,60 @@
+package localpath
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+func chownR(path string, uid, gid int) error {
+	return filepath.Walk(path, func(name string, info os.FileInfo, err error) error {
+		if err == nil {
+			err = os.Chown(name, uid, gid)
+		}
+		return err
+	})
+}
+
+// ChownToSudoUser chowns a directory to be owned by SUDO_USER
+func ChownToSudoUser(dir string) error {
+	if os.Getenv("CHANGE_MINIKUBE_NONE_USER") == "" {
+		return nil
+	}
+
+	if os.Getenv("SUDO_USER") == "" {
+		return nil
+	}
+
+	username := os.Getenv("SUDO_USER")
+	usr, err := user.Lookup(username)
+	if err != nil {
+		return errors.Wrap(err, "Error looking up user")
+	}
+	uid, err := strconv.Atoi(usr.Uid)
+	if err != nil {
+		return errors.Wrapf(err, "Error parsing uid for user: %s", username)
+	}
+	gid, err := strconv.Atoi(usr.Gid)
+	if err != nil {
+		return errors.Wrapf(err, "Error parsing gid for user: %s", username)
+	}
+
+	if err := chownR(dir, uid, gid); err != nil {
+		return errors.Wrapf(err, "Error changing ownership for: %s", dir)
+	}
+	return nil
+}
+
+// ChownLocalDataToSudoUser chowns all local data to the SUDO_USER
+func ChownLocalDataToSudoUser() error {
+	for _, d := range []string{cacheDir(), configDir(), dataDir()} {
+		err := ChownToSudoUser(d)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/minikube/localpath/localpath.go
+++ b/pkg/minikube/localpath/localpath.go
@@ -19,30 +19,178 @@ package localpath
 import (
 	"os"
 	"path/filepath"
-
-	"k8s.io/client-go/util/homedir"
 )
 
-// MinikubeHome is the name of the minikube home directory variable.
-const MinikubeHome = "MINIKUBE_HOME"
+const (
+	// OverrideVar is the name of the minikube home directory variable.
+	OverrideVar = "MINIKUBE_HOME"
 
-// ConfigFile is the path of the config file
-var ConfigFile = MakeMiniPath("config", "config.json")
+	// Subdirectory to store data in.
+	appDir = "minikube"
+)
 
-// MiniPath returns the path to the user's minikube dir
-func MiniPath() string {
-	if os.Getenv(MinikubeHome) == "" {
-		return filepath.Join(homedir.HomeDir(), ".minikube")
+// CreateDirs creates directories, possibly migrating from an old disk layout
+func CreateDirs() (map[string]string, error) {
+	result := map[string]string{}
+	for _, d := range []string{cacheDir(), configDir(), dataDir()} {
+		if _, err := os.Stat(d); err == nil {
+			if err := os.MkdirAll(d, 0700); err != nil {
+				return result, err
+			}
+			result[d] = ""
+		}
 	}
-	if filepath.Base(os.Getenv(MinikubeHome)) == ".minikube" {
-		return os.Getenv(MinikubeHome)
+
+	oldHome := existingHome()
+	if oldHome != "" {
+		me, err := migrateLegacyPaths(oldHome)
+		if err != nil {
+			return result, err
+		}
+		for k, v := range me {
+			result[k] = v
+		}
 	}
-	return filepath.Join(os.Getenv(MinikubeHome), ".minikube")
+	return result, nil
 }
 
-// MakeMiniPath is a utility to calculate a relative path to our directory.
-func MakeMiniPath(fileName ...string) string {
-	args := []string{MiniPath()}
-	args = append(args, fileName...)
-	return filepath.Join(args...)
+// Machine return the location of a machine directory
+func Machine(name string) string {
+	return filepath.Join(Store(name), "machines", name)
+}
+
+// Store return the location of the libmachine store
+func Store(name string) string {
+	return filepath.Join(dataDir(), "stores", name)
+}
+
+// Profile return the location of a profile directory
+func Profile(name string) string {
+	return filepath.Join(Profiles(), name)
+}
+
+// Profile return the location of the profiles directory
+func Profiles() string {
+	return filepath.Join(dataDir(), "profiles")
+}
+
+// ProfileConfig return the location of a profile configuration file
+func ProfileConfig(name string) string {
+	return filepath.Join(Profile(name), "config.json")
+}
+
+// MachineCerts returns the location of the machine certificates directory
+func MachineCerts(name string) string {
+	return filepath.Join(Machine(name), "certs")
+}
+
+// KubernetesCerts returns the location of the Kubernetes certificates directory
+func KubernetesCerts(name string) string {
+	return filepath.Join(Profile(name), "kubernetes")
+}
+
+// SSHKey returns the location of the ssh key
+func SSHKey(name string) string {
+	return filepath.Join(Machine(name), "id_rsa")
+}
+
+// MountPid returns the path of the mount process pid
+func MountPid(name string) string {
+	return filepath.Join(Profile(name), "mount.pid")
+}
+
+// UpdateCheck returns the path of the update check file
+func UpdateCheck() string {
+	return filepath.Join(dataDir(), "last_update_check")
+}
+
+// ContainerImages returns the location of the container images directory
+func ContainerImages() string {
+	return filepath.Join(cacheDir(), "images")
+}
+
+// DiskImages returns the location of the disk images directory
+func DiskImages() string {
+	return filepath.Join(cacheDir(), "iso")
+}
+
+// Addons returns the location of the addons directory
+func Addons() string {
+	return filepath.Join(dataDir(), "addons")
+}
+
+// FileSync returns the location of the file sync directory
+func FileSync() string {
+	return filepath.Join(dataDir(), "files")
+}
+
+// Binaries returns the location of the binaries directory
+func Binaries() string {
+	return filepath.Join(cacheDir(), "binaries")
+}
+
+// Drivers returns the location of the drivers directory
+func Drivers() string {
+	return filepath.Join(dataDir(), "bin")
+}
+
+// Logs returns the location of the logs directory
+func Logs() string {
+	return filepath.Join(dataDir(), "logs")
+}
+
+// TunnelRegistry returns the location of the tunnel registry
+func TunnelRegistry() string {
+	return filepath.Join(dataDir(), "tunnels.json")
+}
+
+// GlobalConfig returns the path to the global config file
+func GlobalConfig() string {
+	return filepath.Join(configDir(), "config.json")
+}
+
+func dataDir() string {
+	if dir := overrideHome(); dir != "" {
+		return filepath.Join(dir, "data")
+	}
+	// See https://github.com/golang/go/issues/29960
+	if dir := os.Getenv("XDG_DATA_HOME"); dir != "" {
+		return filepath.Join(dir, appDir)
+	}
+	if dir, err := os.UserConfigDir(); err == nil {
+		return filepath.Join(dir, appDir, "data")
+	}
+	return legacyHome()
+}
+
+func cacheDir() string {
+	if dir := overrideHome(); dir != "" {
+		return filepath.Join(dir, "cache")
+	}
+
+	if dir, err := os.UserCacheDir(); err == nil {
+		return filepath.Join(dir, appDir)
+	}
+	return filepath.Join(legacyHome(), "cache")
+}
+
+func configDir() string {
+	if dir := overrideHome(); dir != "" {
+		return filepath.Join(dir, "config")
+	}
+	if dir, err := os.UserConfigDir(); err == nil {
+		return filepath.Join(dir, appDir)
+	}
+	return legacyHome()
+}
+
+func overrideHome() string {
+	val := os.Getenv(OverrideVar)
+	if val == "" {
+		return ""
+	}
+	if filepath.Base(val) == ".minikube" {
+		return val
+	}
+	return filepath.Join(val, ".minikube")
 }

--- a/pkg/minikube/localpath/localpath.go
+++ b/pkg/minikube/localpath/localpath.go
@@ -71,7 +71,7 @@ func Profile(name string) string {
 
 // Profile return the location of the profiles directory
 func Profiles() string {
-	return filepath.Join(dataDir(), "profiles")
+	return filepath.Join(configDir(), "profiles")
 }
 
 // ProfileConfig return the location of a profile configuration file
@@ -81,7 +81,7 @@ func ProfileConfig(name string) string {
 
 // MachineCerts returns the location of the machine certificates directory
 func MachineCerts(name string) string {
-	return filepath.Join(Machine(name), "certs")
+	return filepath.Join(Store(name), "certs")
 }
 
 // KubernetesCerts returns the location of the Kubernetes certificates directory

--- a/pkg/minikube/localpath/migrate.go
+++ b/pkg/minikube/localpath/migrate.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package localpath
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/golang/glog"
+	"github.com/otiai10/copy"
+	"k8s.io/client-go/util/homedir"
+)
+
+// migrateLegacyPaths converts legacy (pre-v1.5.0) paths to modern race-free paths
+func migrateLegacyPaths(oldHome string) (map[string]string, error) {
+	summary := map[string]string{}
+	if oldHome == "" {
+		glog.Infof("No existing home directory to migrate")
+		return summary, nil
+	}
+
+	plans, err := migrationPlan(oldHome)
+	if err != nil {
+		return summary, err
+	}
+	for src, dst := range plans {
+		if src == dst {
+			return summary, fmt.Errorf("src == dst: %s", src)
+		}
+		glog.Infof("copying %s -> %s", src, dst)
+		err := copy.Copy(src, dst)
+		if err != nil {
+			return summary, err
+		}
+	}
+
+	// A simplified version of the plan, to communicate to users.
+	summary = map[string]string{
+		filepath.Join(oldHome, "cache"):  cacheDir(),
+		filepath.Join(oldHome, "config"): configDir(),
+		oldHome:                          dataDir(),
+	}
+
+	// At this point, we should be confident that every file has been copied. Do a sanity check, though.
+	if err := validateCopies(oldHome, []string{cacheDir(), configDir(), dataDir()}); err != nil {
+		return summary, err
+	}
+
+	// TODO: rewrite kubeconfig!
+	return summary, nil
+
+	//	return summary, os.RemoveAll(oldHome)
+}
+
+// legacyHome calculates the default root directory exactly like old versions of minikube
+func legacyHome() string {
+	return filepath.Join(homedir.HomeDir(), ".minikube")
+}
+
+// existingHome returns an existing root directory
+func existingHome() string {
+	for _, dir := range []string{overrideHome(), legacyHome()} {
+		if dir != "" {
+			if _, err := os.Stat(dir); err == nil {
+				return dir
+			}
+		}
+	}
+	return ""
+}
+
+// migrationPlan return a plan of events to migrate files from old locations
+func migrationPlan(root string) (map[string]string, error) {
+	toCopy := map[string]string{
+		filepath.Join(root, "cache"):    cacheDir(),
+		filepath.Join(root, "config"):   configDir(),
+		filepath.Join(root, "profiles"): Profiles(),
+	}
+
+	ms, err := legacyMachineList(root)
+	if err != nil {
+		return toCopy, err
+	}
+
+	// Move each machine and set of certificates into its own store
+	for _, m := range ms {
+		toCopy[filepath.Join(root, "machines", m)] = Machine(m)
+		toCopy[filepath.Join(root, "certs")] = filepath.Join(Store(m), "certs")
+	}
+
+	// Copy common machine files into each store to make them race-proof
+	mf, err := filepath.Glob(filepath.Join(root, "machines/*.*"))
+	if err != nil {
+		return toCopy, err
+	}
+	for _, f := range mf {
+		rp, err := filepath.Rel(root, f)
+		if err != nil {
+			return toCopy, err
+		}
+		for _, m := range ms {
+			toCopy[f] = filepath.Join(Store(m), rp)
+		}
+	}
+
+	// Move everything else in the root directory
+	of, err := filepath.Glob(filepath.Join(root, "*"))
+	if err != nil {
+		return toCopy, err
+	}
+	for _, f := range of {
+		rp, err := filepath.Rel(root, f)
+		if err != nil {
+			return toCopy, err
+		}
+
+		if toCopy[f] != "" {
+			continue
+		}
+		ext := filepath.Ext(f)
+		if ext == ".key" || ext == ".crt" || ext == ".pem" {
+			for _, m := range ms {
+				toCopy[f] = filepath.Join(KubernetesCerts(m), rp)
+			}
+			continue
+		}
+		toCopy[f] = filepath.Join(dataDir(), rp)
+	}
+	return toCopy, nil
+}
+
+func legacyMachineList(root string) ([]string, error) {
+	result := []string{}
+	lp := filepath.Join(root, "machines")
+	_, err := os.Stat(lp)
+	if os.IsNotExist(err) {
+		return result, nil
+	}
+
+	m, err := ioutil.ReadDir(lp)
+	if err != nil {
+		return result, err
+	}
+	for _, fi := range m {
+		if fi.IsDir() {
+			result = append(result, fi.Name())
+		}
+	}
+	return result, nil
+}
+
+type foundFile struct {
+	Path string
+	Info os.FileInfo
+}
+
+// validateCopies validates that all files in src exist in dests
+func validateCopies(src string, dests []string) error {
+	// Record everything found in the destination folders
+	found := map[string][]foundFile{}
+	for _, d := range dests {
+		err := filepath.Walk(d, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			f := foundFile{Path: path, Info: info}
+			base := filepath.Base(path)
+			_, ok := found[base]
+			if !ok {
+				found[base] = []foundFile{f}
+			} else {
+				found[base] = append(found[base], f)
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	// Compare the source folder against the destinations
+	err := filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		base := filepath.Base(path)
+		matches, ok := found[base]
+		if !ok {
+			return fmt.Errorf("%s: No file named %s exists in %v", path, base, dests)
+		}
+		for _, m := range matches {
+			if m.Info.Size() == info.Size() && m.Info.Mode() == info.Mode() {
+				glog.Infof("%s was copied to %s", path, m.Path)
+				return nil
+			} else {
+				glog.Infof("%s size=%d, mode=%v is different than %s size=%d, mode=%v", path, info.Size(), info.Mode(), m.Path, m.Info.Size(), m.Info.Mode())
+			}
+		}
+		return fmt.Errorf("%s: No file named %s has a length of %d and mode of %v in %v", path, base, info.Size(), info.Mode(), dests)
+	})
+
+	return err
+}

--- a/pkg/minikube/machine/cache_binaries.go
+++ b/pkg/minikube/machine/cache_binaries.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"runtime"
 
 	"github.com/golang/glog"
@@ -63,7 +64,7 @@ func KubernetesReleaseURLSHA1(binaryName, version, osName, archName string) stri
 
 // CacheBinary will cache a binary on the host
 func CacheBinary(binary, version, osName, archName string) (string, error) {
-	targetDir := localpath.MakeMiniPath("cache", version)
+	targetDir := filepath.Join(localpath.Binaries(), version)
 	targetFilepath := path.Join(targetDir, binary)
 
 	url := KubernetesReleaseURL(binary, version, osName, archName)

--- a/pkg/minikube/machine/client.go
+++ b/pkg/minikube/machine/client.go
@@ -41,6 +41,7 @@ import (
 	"github.com/docker/machine/libmachine/version"
 	"github.com/pkg/errors"
 	"k8s.io/minikube/pkg/minikube/command"
+	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/localpath"
@@ -59,8 +60,9 @@ func NewRPCClient(storePath, certsDir string) libmachine.API {
 
 // NewAPIClient gets a new client.
 func NewAPIClient() (libmachine.API, error) {
-	storePath := localpath.MiniPath()
-	certsDir := localpath.MakeMiniPath("certs")
+	name := config.GetMachineName()
+	storePath := localpath.Store(name)
+	certsDir := localpath.MachineCerts(name)
 
 	return &LocalClient{
 		certsDir:     certsDir,

--- a/pkg/minikube/machine/client_test.go
+++ b/pkg/minikube/machine/client_test.go
@@ -112,18 +112,8 @@ func TestLocalClientNewHost(t *testing.T) {
 	}
 }
 
-func makeTempDir() string {
-	tempDir, err := ioutil.TempDir("", "minipath")
-	if err != nil {
-		log.Fatal(err)
-	}
-	tempDir = filepath.Join(tempDir, ".minikube")
-	os.Setenv(localpath.MinikubeHome, tempDir)
-	return localpath.MiniPath()
-}
-
 func TestRunNotDriver(t *testing.T) {
-	tempDir := makeTempDir()
+	tempDir := tests.TempMinikubeDir()
 	defer os.RemoveAll(tempDir)
 	StartDriver()
 	if !localbinary.CurrentBinaryIsDockerMachine {
@@ -134,7 +124,7 @@ func TestRunNotDriver(t *testing.T) {
 func TestRunDriver(t *testing.T) {
 	// This test is a bit complicated. It verifies that when the root command is
 	// called with the proper environment variables, we setup the libmachine driver.
-	tempDir := makeTempDir()
+	tempDir := tests.TempMinikubeDir()
 	defer os.RemoveAll(tempDir)
 
 	os.Setenv(localbinary.PluginEnvKey, localbinary.PluginEnvVal)

--- a/pkg/minikube/notify/notify.go
+++ b/pkg/minikube/notify/notify.go
@@ -37,13 +37,12 @@ import (
 )
 
 var (
-	timeLayout              = time.RFC1123
-	lastUpdateCheckFilePath = localpath.MakeMiniPath("last_update_check")
+	timeLayout = time.RFC1123
 )
 
 // MaybePrintUpdateTextFromGithub prints update text if needed, from github
 func MaybePrintUpdateTextFromGithub() bool {
-	return MaybePrintUpdateText(GithubMinikubeReleasesURL, lastUpdateCheckFilePath)
+	return MaybePrintUpdateText(GithubMinikubeReleasesURL, localpath.UpdateCheck())
 }
 
 // MaybePrintUpdateText prints update text, returns a bool if life is good.
@@ -62,7 +61,7 @@ func MaybePrintUpdateText(url string, lastUpdatePath string) bool {
 		return true
 	}
 	if localVersion.Compare(latestVersion) < 0 {
-		if err := writeTimeToFile(lastUpdateCheckFilePath, time.Now().UTC()); err != nil {
+		if err := writeTimeToFile(lastUpdatePath, time.Now().UTC()); err != nil {
 			glog.Errorf("write time failed: %v", err)
 		}
 		url := "https://github.com/kubernetes/minikube/releases/tag/v" + latestVersion.String()

--- a/pkg/minikube/out/style.go
+++ b/pkg/minikube/out/style.go
@@ -81,6 +81,7 @@ var styles = map[StyleEnum]style{
 	Check:         {Prefix: "✅  "},
 	Celebration:   {Prefix: "🎉  "},
 	Workaround:    {Prefix: "👉  ", LowPrefix: lowIndent},
+	Arrow:         {Prefix: "➡️   "},
 
 	// Specialized purpose styles
 	ISODownload:      {Prefix: "💿  "},

--- a/pkg/minikube/out/style_enum.go
+++ b/pkg/minikube/out/style_enum.go
@@ -83,4 +83,5 @@ const (
 	Fileserver
 	Empty
 	Workaround
+	Arrow
 )

--- a/pkg/minikube/tests/dir_utils.go
+++ b/pkg/minikube/tests/dir_utils.go
@@ -26,8 +26,8 @@ import (
 	"k8s.io/minikube/pkg/minikube/localpath"
 )
 
-// MakeTempDir creates the temp dir and returns the path
-func MakeTempDir() string {
+// TempMinikubeDir creates the temp dir, sets the environmental override, and returns the path
+func TempMinikubeDir() string {
 	tempDir, err := ioutil.TempDir("", "minipath")
 	if err != nil {
 		log.Fatal(err)
@@ -41,8 +41,8 @@ func MakeTempDir() string {
 	if err != nil {
 		log.Fatal(err)
 	}
-	os.Setenv(localpath.MinikubeHome, tempDir)
-	return localpath.MiniPath()
+	os.Setenv(localpath.OverrideVar, tempDir)
+	return tempDir
 }
 
 // FakeFile satisfies fdWriter

--- a/pkg/minikube/tunnel/tunnel_manager.go
+++ b/pkg/minikube/tunnel/tunnel_manager.go
@@ -17,7 +17,6 @@ limitations under the License.
 package tunnel
 
 import (
-	"path/filepath"
 	"time"
 
 	"context"
@@ -42,17 +41,12 @@ type Manager struct {
 // stateCheckInterval defines how frequently the cluster and route states are checked
 const stateCheckInterval = 5 * time.Second
 
-// RegistryPath returns the path to the runnel registry file
-func RegistryPath() string {
-	return filepath.Join(localpath.MiniPath(), "tunnels.json")
-}
-
 // NewManager creates a new Manager
 func NewManager() *Manager {
 	return &Manager{
 		delay: stateCheckInterval,
 		registry: &persistentRegistry{
-			path: RegistryPath(),
+			path: localpath.TunnelRegistry(),
 		},
 		router: &osRouter{},
 	}

--- a/pkg/util/downloader.go
+++ b/pkg/util/downloader.go
@@ -49,7 +49,7 @@ func (f DefaultDownloader) GetISOFileURI(isoURL string) string {
 	if urlObj.Scheme == fileScheme {
 		return isoURL
 	}
-	isoPath := filepath.Join(localpath.MiniPath(), "cache", "iso", filepath.Base(isoURL))
+	isoPath := filepath.Join(localpath.DiskImages(), filepath.Base(isoURL))
 	// As this is a file URL there should be no backslashes regardless of platform running on.
 	return "file://" + filepath.ToSlash(isoPath)
 }
@@ -105,7 +105,7 @@ func (f DefaultDownloader) ShouldCacheMinikubeISO(isoURL string) bool {
 
 // GetISOCacheFilepath returns the path of an ISO in the local cache
 func (f DefaultDownloader) GetISOCacheFilepath(isoURL string) string {
-	return filepath.Join(localpath.MiniPath(), "cache", "iso", filepath.Base(isoURL))
+	return filepath.Join(localpath.DiskImages(), filepath.Base(isoURL))
 }
 
 // IsMinikubeISOCached returns if an ISO exists in the local cache

--- a/pkg/util/downloader_test.go
+++ b/pkg/util/downloader_test.go
@@ -35,7 +35,7 @@ func TestGetISOFileURI(t *testing.T) {
 
 	tests := map[string]string{
 		"file:///test/path/minikube-test.iso":                           "file:///test/path/minikube-test.iso",
-		"https://storage.googleapis.com/minikube/iso/minikube-test.iso": "file://" + filepath.ToSlash(filepath.Join(localpath.MiniPath(), "cache", "iso", "minikube-test.iso")),
+		"https://storage.googleapis.com/minikube/iso/minikube-test.iso": "file://" + filepath.ToSlash(filepath.Join(localpath.DiskImages(), "minikube-test.iso")),
 	}
 
 	for input, expected := range tests {
@@ -49,10 +49,10 @@ func TestGetISOFileURI(t *testing.T) {
 var testISOString = "hello"
 
 func TestCacheMinikubeISOFromURL(t *testing.T) {
-	tempDir := tests.MakeTempDir()
+	tempDir := tests.TempMinikubeDir()
 	defer os.RemoveAll(tempDir)
 	dler := DefaultDownloader{}
-	isoPath := filepath.Join(localpath.MiniPath(), "cache", "iso", "minikube-test.iso")
+	isoPath := filepath.Join(localpath.DiskImages(), "minikube-test.iso")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if _, err := io.WriteString(w, testISOString); err != nil {
@@ -93,7 +93,7 @@ func TestShouldCacheMinikubeISO(t *testing.T) {
 }
 
 func TestIsMinikubeISOCached(t *testing.T) {
-	tempDir := tests.MakeTempDir()
+	tempDir := tests.TempMinikubeDir()
 	defer os.RemoveAll(tempDir)
 
 	dler := DefaultDownloader{}
@@ -105,7 +105,8 @@ func TestIsMinikubeISOCached(t *testing.T) {
 		t.Fatalf("Expected IsMinikubeISOCached with input %s to return %t but instead got: %t", testFileURI, expected, out)
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(localpath.MiniPath(), "cache", "iso", "minikube-test.iso"), []byte(testISOString), os.FileMode(int(0644))); err != nil {
+	path := filepath.Join(localpath.DiskImages(), "minikube-test.iso")
+	if err := ioutil.WriteFile(path, []byte(testISOString), os.FileMode(int(0644))); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -22,8 +22,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/user"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -115,39 +113,6 @@ func IsDirectory(path string) (bool, error) {
 		return false, errors.Wrapf(err, "Error calling os.Stat on file %s", path)
 	}
 	return fileInfo.IsDir(), nil
-}
-
-// ChownR does a recursive os.Chown
-func ChownR(path string, uid, gid int) error {
-	return filepath.Walk(path, func(name string, info os.FileInfo, err error) error {
-		if err == nil {
-			err = os.Chown(name, uid, gid)
-		}
-		return err
-	})
-}
-
-// MaybeChownDirRecursiveToMinikubeUser changes ownership of a dir, if requested
-func MaybeChownDirRecursiveToMinikubeUser(dir string) error {
-	if os.Getenv("CHANGE_MINIKUBE_NONE_USER") != "" && os.Getenv("SUDO_USER") != "" {
-		username := os.Getenv("SUDO_USER")
-		usr, err := user.Lookup(username)
-		if err != nil {
-			return errors.Wrap(err, "Error looking up user")
-		}
-		uid, err := strconv.Atoi(usr.Uid)
-		if err != nil {
-			return errors.Wrapf(err, "Error parsing uid for user: %s", username)
-		}
-		gid, err := strconv.Atoi(usr.Gid)
-		if err != nil {
-			return errors.Wrapf(err, "Error parsing gid for user: %s", username)
-		}
-		if err := ChownR(dir, uid, gid); err != nil {
-			return errors.Wrapf(err, "Error changing ownership for: %s", dir)
-		}
-	}
-	return nil
 }
 
 // TeePrefix copies bytes from a reader to writer, logging each new line.

--- a/site/content/en/docs/Contributing/drivers.en.md
+++ b/site/content/en/docs/Contributing/drivers.en.md
@@ -8,11 +8,11 @@ description: >
 
 This document is written for contributors who are familiar with minikube, who would like to add support for a new VM driver.
 
-minikube relies on docker-machine drivers to manage machines. This document discusses how to modify minikube, so that this driver may be used by `minikube start --vm-driver=<new_driver>`. 
+minikube relies on docker-machine drivers to manage machines. This document discusses how to modify minikube, so that this driver may be used by `minikube start --vm-driver=<new_driver>`.
 
 ## Creating a new driver
 
-See https://github.com/machine-drivers, the fork where all new docker-machine drivers are located.
+See <https://github.com/machine-drivers>, the fork where all new docker-machine drivers are located.
 
 ## Builtin vs External Drivers
 
@@ -35,7 +35,7 @@ The integration process is effectively 3 steps.
 
 ### The driver shim
 
-The primary duty of the driver shim is to register a VM driver with minikube, and translate minikube VM hardware configuration into a format that the driver understands. 
+The primary duty of the driver shim is to register a VM driver with minikube, and translate minikube VM hardware configuration into a format that the driver understands.
 
 ### Registering your driver
 
@@ -54,7 +54,6 @@ pretty simple once you understand your driver well:
 on your `$USER/.minikube` directory. Most likely the driver config is the driver itself.
 
 - DriverCreator: Only needed when driver is builtin, to instantiate the driver instance.
-
 
 ## Integration example: vmwarefusion
 
@@ -86,7 +85,8 @@ func init() {
 }
 
 func createVMwareFusionHost(config cfg.MachineConfig) interface{} {
-    d := vmwarefusion.NewDriver(cfg.GetMachineName(), localpath.MiniPath()).(*vmwarefusion.Driver)
+    name := cfg.GetMachineName()
+    d := vmwarefusion.NewDriver(name, localpath.Store(name)).(*vmwarefusion.Driver)
     d.Boot2DockerURL = config.Downloader.GetISOFileURI(config.MinikubeISO)
     d.Memory = config.Memory
     d.CPU = config.CPUs
@@ -103,7 +103,4 @@ earlier, it's builtin, so you also need to specify `DriverCreator` to tell minik
 runs on MacOS, so that the releases on Windows and Linux won't have this driver in registry.
 - Last but not least, import the driver in `pkg/minikube/cluster/default_drivers.go` to include it in build.
 
-
-
 Any Questions: please ping your friend [@anfernee](https://github.com/anfernee) or the #minikube Slack channel.
-


### PR DESCRIPTION
Major changes:

- libmachine stores are now per-profile. Previously, libmachine used $MINIKUBE_HOME as it's store.
- As a side effect, certificates are now per-profile. Fixes #5353 
- $MINIKUBE_HOME now defaults to idiomatic locations based on the operating system.
  * Uses `os.UserConfigDir` for configuration, `os.UserCacheDir` for cache.  
  * On Windows, instead of C:\Users\username.minikube, this uses %AppData%/minikube, for instance. 
  * On macOS, this means ~/Application Support/minikube
  * On Linux, this means ~/.config/minikube
- This PR provides a forward migration path, but not a backwards one if users downgrade.

Closes #4109 and #5353 