### PR TITLE
Add validation checking for minikube profile

### DIFF
--- a/cmd/minikube/cmd/config/profile.go
+++ b/cmd/minikube/cmd/config/profile.go
@@ -45,6 +45,15 @@ var ProfileCmd = &cobra.Command{
 		}
 
 		profile := args[0]
+		/**
+		we need to add code over here to check whether the profile
+		name is in the list of reserved keywords
+		*/
+		if pkgConfig.ProfileNameInReservedKeywords(profile) {
+			out.ErrT(out.FailureType, `Profile name "{{.profilename}}" is minikube keyword. To delete profile use command minikube delete -p <profile name>  `, out.V{"profilename": profile})
+			os.Exit(0)
+		}
+
 		if profile == "default" {
 			profile = "minikube"
 		} else {

--- a/pkg/minikube/config/profile.go
+++ b/pkg/minikube/config/profile.go
@@ -21,18 +21,20 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/golang/glog"
 	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/util/lock"
 )
 
+var keywords = []string{"start", "stop", "status", "delete", "config", "open", "profile", "addons", "cache", "logs"}
+
 // IsValid checks if the profile has the essential info needed for a profile
 func (p *Profile) IsValid() bool {
 	if p.Config == nil {
 		return false
 	}
-
 	if p.Config.MachineConfig.VMDriver == "" {
 		return false
 	}
@@ -40,6 +42,16 @@ func (p *Profile) IsValid() bool {
 		return false
 	}
 	return true
+}
+
+// check if the profile is an internal keywords
+func ProfileNameInReservedKeywords(name string) bool {
+	for _, v := range keywords {
+		if strings.EqualFold(v, name) {
+			return true
+		}
+	}
+	return false
 }
 
 // ProfileExists returns true if there is a profile config (regardless of being valid)

--- a/pkg/minikube/config/profile_test.go
+++ b/pkg/minikube/config/profile_test.go
@@ -72,6 +72,32 @@ func TestListProfiles(t *testing.T) {
 	}
 }
 
+func TestProfileNameInReservedKeywords(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		expected bool
+	}{
+		{"start", true},
+		{"stop", true},
+		{"status", true},
+		{"delete", true},
+		{"config", true},
+		{"open", true},
+		{"profile", true},
+		{"addons", true},
+		{"cache", true},
+		{"logs", true},
+		{"myprofile", false},
+		{"log", false},
+	}
+	for _, tt := range testCases {
+		got := ProfileNameInReservedKeywords(tt.name)
+		if got != tt.expected {
+			t.Errorf("expected ProfileNameInReservedKeywords(%s)=%t but got %t ", tt.name, tt.expected, got)
+		}
+	}
+}
+
 func TestProfileExists(t *testing.T) {
 	miniDir, err := filepath.Abs("./testdata/.minikube2")
 	if err != nil {


### PR DESCRIPTION
Fixes : #4883

New function ProfileNameInReservedKeywords(..) has been added inside
pkg/minikube/config/profile.go

The new function perform validation to make sure the profile name is not
in the list of keywords.

Following are the keywords that are used:

> start, stop, status, delete, config, open, profile, addons, cache, logs


The checking is case insensitive to cover combo of upper and lower case

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
