### PR TITLE
fix "minikube update-context" command fail

### DIFF
--- a/cmd/minikube/cmd/update-context.go
+++ b/cmd/minikube/cmd/update-context.go
@@ -44,7 +44,7 @@ var updateContextCmd = &cobra.Command{
 		if err != nil {
 			exit.WithError("Error host driver ip status", err)
 		}
-		updated, err := kubeconfig.UpdateIP(ip, constants.KubeconfigPath, machineName)
+		updated, err := kubeconfig.UpdateIP(ip, machineName, constants.KubeconfigPath)
 		if err != nil {
 			exit.WithError("update config", err)
 		}


### PR DESCRIPTION
### What type of PR is this?
/kind bug

### What this PR does / why we need it:
In minikube v1.4.0, `minikube update-context` command always fails.

This PR fixes this bug of the command fail.

### Which issue(s) this PR fixes:
Fixes #5497

### Does this PR introduce a user-facing change?

Yes. this PR fixes bug in order to `minikube update-context` command work successfully.

**Before this PR, `minikube update-context` command always fails**
```
1. minikube update-context(error)
update config: Kubeconfig does not have a record of the machine cluster
```

**After this PR, `minikube update-context` command works**
```
1. minikube update-context(success)
minikube IP was already correctly configured for xxx.xxx.xxx.xxx
(or)
minikube IP has been updated to point at xxx.xxx.xxx.xxx
```

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```