### PR TITLE
Speed up RNG initialization on new systemd

### DIFF
--- a/deploy/iso/minikube-iso/board/coreos/minikube/isolinux.cfg
+++ b/deploy/iso/minikube-iso/board/coreos/minikube/isolinux.cfg
@@ -2,4 +2,4 @@ default 1
 label 1
       kernel /boot/bzImage
       initrd /boot/initrd
-      append root=/dev/sr0 loglevel=3 console=ttyS0 noembed nomodeset norestore waitusb=10 systemd.legacy_systemd_cgroup_controller=yes
+      append root=/dev/sr0 loglevel=3 console=ttyS0 noembed nomodeset norestore waitusb=10 random.trust_cpu=on hw_rng_model=virtio systemd.legacy_systemd_cgroup_controller=yes

--- a/pkg/minikube/drivers/hyperkit/driver.go
+++ b/pkg/minikube/drivers/hyperkit/driver.go
@@ -61,6 +61,6 @@ func createHyperkitHost(config cfg.MachineConfig) interface{} {
 		UUID:           uuID,
 		VpnKitSock:     config.HyperkitVpnKitSock,
 		VSockPorts:     config.HyperkitVSockPorts,
-		Cmdline:        "loglevel=3 user=docker console=ttyS0 console=tty0 noembed nomodeset norestore waitusb=10 systemd.legacy_systemd_cgroup_controller=yes base host=" + cfg.GetMachineName(),
+		Cmdline:        "loglevel=3 console=ttyS0 console=tty0 noembed nomodeset norestore waitusb=10 systemd.legacy_systemd_cgroup_controller=yes random.trust_cpu=on hw_rng_model=virtio base host=" + cfg.GetMachineName(),
 	}
 }


### PR DESCRIPTION
With the v1.5.0-beta.0 kernel, this change reduces sshd startup time after system boot by about 2 minutes on hyperkit. It previously blocked sshd from running with:

`random: crng init done`

Changes to the kernel command line:

- `random.trust_cpu=on`:  Trust the emulated CPU as a source of randomization
- `hw_rng_model=virtio`: Plumb in VirtIO RNG devices if available

For hyperkit:


- Remove `user=docker` argument, which differed from other VM drivers
