### PR TITLE
Download gluster from OpenPKG while RH is having issues

### DIFF
--- a/deploy/iso/minikube-iso/package/gluster/gluster.mk
+++ b/deploy/iso/minikube-iso/package/gluster/gluster.mk
@@ -5,7 +5,10 @@
 ################################################################################
 
 GLUSTER_VERSION = 4.1.5
-GLUSTER_SITE = https://download.gluster.org/pub/gluster/glusterfs/4.1/$(GLUSTER_VERSION)
+# Official gluster site has SSL problems
+# https://bugzilla.redhat.com/show_bug.cgi?id=1572944
+# GLUSTER_SITE = https://download.gluster.org/pub/gluster/glusterfs/4.1/$(GLUSTER_VERSION)
+GLUSTER_SITE =  http://download.openpkg.org/components/cache/glusterfs/
 GLUSTER_SOURCE = glusterfs-$(GLUSTER_VERSION).tar.gz
 GLUSTER_CONF_OPTS = --disable-tiering --disable-ec-dynamic --disable-xmltest --disable-crypt-xlator --disable-georeplication --disable-ibverbs --disable-glupy --disable-gnfs --disable-cmocka --without-server
 GLUSTER_INSTALL_TARGET_OPTS = DESTDIR=$(TARGET_DIR) install

--- a/deploy/iso/minikube-iso/package/gluster/gluster.mk
+++ b/deploy/iso/minikube-iso/package/gluster/gluster.mk
@@ -8,7 +8,7 @@ GLUSTER_VERSION = 4.1.5
 # Official gluster site has SSL problems
 # https://bugzilla.redhat.com/show_bug.cgi?id=1572944
 # GLUSTER_SITE = https://download.gluster.org/pub/gluster/glusterfs/4.1/$(GLUSTER_VERSION)
-GLUSTER_SITE =  http://download.openpkg.org/components/cache/glusterfs/
+GLUSTER_SITE =  http://download.openpkg.org/components/cache/glusterfs
 GLUSTER_SOURCE = glusterfs-$(GLUSTER_VERSION).tar.gz
 GLUSTER_CONF_OPTS = --disable-tiering --disable-ec-dynamic --disable-xmltest --disable-crypt-xlator --disable-georeplication --disable-ibverbs --disable-glupy --disable-gnfs --disable-cmocka --without-server
 GLUSTER_INSTALL_TARGET_OPTS = DESTDIR=$(TARGET_DIR) install


### PR DESCRIPTION
gluster's official download URL is having issues. 

```
wget https://download.gluster.org/pub/gluster/glusterfs/4.1/4.1.10/glusterfs-4.1.10.tar.gz
--2019-10-16 16:01:01--  https://download.gluster.org/pub/gluster/glusterfs/4.1/4.1.10/glusterfs-4.1.10.tar.gz
Resolving download.gluster.org (download.gluster.org)... 8.43.85.185
Connecting to download.gluster.org (download.gluster.org)|8.43.85.185|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 7839313 (7.5M) [application/x-gzip]
Saving to: ‘glusterfs-4.1.10.tar.gz’

glusterfs-4.1.10.   0%[            ]  47.62K  --.-KB/s    in 0.07s   

2019-10-16 16:01:01 (684 KB/s) - Read error at byte 48758/7839313 (Error decoding the received TLS packet.). Retrying.
```