### PR TITLE
common.sh tune-up: Add load warning, fix profile deletion, fix lint errors and noise

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -159,7 +159,7 @@ if type -P virsh; then
 fi
 
 if type -P vboxmanage; then
-  for guid in $(vboxmanage list vms | grep -Eo '\{[-a-Z0-9]+\}'); do
+  for guid in $(vboxmanage list vms | grep -Eo '\{[a-zA-Z0-9-]+\}'); do
     echo "- Removing stale VirtualBox VM: $guid"
     vboxmanage startvm "${guid}" --type emergencystop || true
     vboxmanage unregistervm "${guid}" || true

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -109,27 +109,29 @@ mkdir -p "${TEST_ROOT}"
 echo ""
 echo ">> Cleaning up after previous test runs ..."
 for entry in $(ls ${TEST_ROOT}); do
-  echo "* Cleaning stale test path: ${entry}"
-  for tunnel in $(find ${TEST_ROOT}/${entry} -name tunnels.json -type f); do
+  test_path="${TEST_ROOT}/${entry}"
+  ls -lad "${test_path}" || continue
+
+  echo "* Cleaning stale test path: ${test_path}"
+  for tunnel in $(find ${test_path} -name tunnels.json -type f); do
     env MINIKUBE_HOME="$(dirname ${tunnel})" ${MINIKUBE_BIN} tunnel --cleanup || true
   done
 
-  for home in $(find ${TEST_ROOT}/${entry} -name .minikube -type d); do
+  for home in $(find ${test_path} -name .minikube -type d); do
     env MINIKUBE_HOME="$(dirname ${home})" ${MINIKUBE_BIN} delete --all || true
     sudo rm -Rf "${home}"
   done
 
-  for kconfig in $(find ${entry} -name kubeconfig -type f); do
+  for kconfig in $(find ${test_path} -name kubeconfig -type f); do
     sudo rm -f "${kconfig}"
   done
 
   # Be very specific to avoid accidentally deleting other items, like wildcards or devices
-  if [[ -d "${entry}" ]]; then
-    rm -Rf "${entry}" || true
-  elif [[ -f "${entry}" ]]; then
-    rm -f "${entry}" || true
+  if [[ -d "${test_path}" ]]; then
+    rm -Rf "${test_path}" || true
+  elif [[ -f "${test_path}" ]]; then
+    rm -f "${test_path}" || true
   fi
-
 done
 
 # sometimes tests left over zombie procs that won't exit

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -45,9 +45,15 @@ echo "docker:    $(docker version --format '{{ .Client.Version }}')"
 readonly LOAD=$(uptime | egrep -o "load average.*: [0-9]" | cut -d" " -f3)
 if [[ "${LOAD}" -gt 2 ]]; then
   echo ""
-  echo "******************************* LOAD WARNING **************************"
-  echo "Load average is very high (${LOAD}), which may cause failures"
-  echo "******************************* LOAD WARNING **************************"
+  echo "********************** LOAD WARNING ********************************"
+  echo "Load average is very high (${LOAD}), which may cause failures. Top:"
+  if [[ "$(uname)" == "Darwin" ]]; then
+    # Two samples, macOS does not calculate CPU usage on the first one
+    top -l 2 -o cpu -n 5 | tail -n 15
+  else
+    top -b -n1 | head -n 15
+  fi
+  echo "********************** LOAD WARNING ********************************"
   echo ""
 fi
 


### PR DESCRIPTION
- Adds output of `uptime`
- Adds load warning (if handy, we can make this a fatal issue later)
- Fixes cleanup, where in a recent refactor I neglected to add the parent directory to the path
- Combines and removes errant `minikube delete --all` call that did not have a MINIKUBE_HOME set.
- VirtualBox hostonlyifs cleanup will no longer try to cleanup an empty list of interfaces
- Fix lint errors mentioned by `shellcheck`