### PR TITLE
[performance] add Makefile rule and code skeleton for mkcmp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -551,3 +551,7 @@ site: site/themes/docsy/assets/vendor/bootstrap/package.js out/hugo/hugo
 	  --navigateToChanged \
 	  --ignoreCache \
 	  --buildFuture)
+
+.PHONY: out/mkcmp
+out/mkcmp:
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o $@ cmd/performance/main.go

--- a/cmd/performance/cmd/mkcmp.go
+++ b/cmd/performance/cmd/mkcmp.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "mkcmp [path to first binary] [path to second binary]",
+	Short: "mkcmp is used to compare performance of two minikube binaries",
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return validateArgs(args)
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		return
+	},
+}
+
+func validateArgs(args []string) error {
+	if len(args) != 2 {
+		return errors.New("mkcmp requries two minikube binaries to compare: mkcmp [path to first binary] [path to second binary]")
+	}
+	return nil
+}
+
+// Execute runs the mkcmp command
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/cmd/performance/cmd/mkcmp.go
+++ b/cmd/performance/cmd/mkcmp.go
@@ -30,14 +30,12 @@ var rootCmd = &cobra.Command{
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		return validateArgs(args)
 	},
-	Run: func(cmd *cobra.Command, args []string) {
-		return
-	},
+	Run: func(cmd *cobra.Command, args []string) {},
 }
 
 func validateArgs(args []string) error {
 	if len(args) != 2 {
-		return errors.New("mkcmp requries two minikube binaries to compare: mkcmp [path to first binary] [path to second binary]")
+		return errors.New("mkcmp requires two minikube binaries to compare: mkcmp [path to first binary] [path to second binary]")
 	}
 	return nil
 }

--- a/cmd/performance/cmd/mkcmp.go
+++ b/cmd/performance/cmd/mkcmp.go
@@ -1,9 +1,12 @@
 /*
-Copyright 2016 The Kubernetes Authors All rights reserved.
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cmd/performance/main.go
+++ b/cmd/performance/main.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "k8s.io/minikube/cmd/performance/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/cmd/performance/main.go
+++ b/cmd/performance/main.go
@@ -1,9 +1,12 @@
 /*
-Copyright 2016 The Kubernetes Authors All rights reserved.
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
This PR adds a skeleton for mkcmp, a binary to compare the performance
of two versions of minikube. It adds a Makefile rule out/mkcmp which
builds the binary.

