### PR TITLE
fix test case TestCacheBinary/ok_kubeadm to download linux kubeadm binary

### DIFF
--- a/pkg/minikube/machine/cache_binaries_test.go
+++ b/pkg/minikube/machine/cache_binaries_test.go
@@ -136,7 +136,7 @@ func TestCacheBinary(t *testing.T) {
 		{
 			desc:         "ok kubeadm",
 			version:      "v1.16.0",
-			osName:       runtime.GOOS,
+			osName:       "linux",
 			archName:     runtime.GOARCH,
 			binary:       "kubeadm",
 			err:          false,


### PR DESCRIPTION
### What type of PR is this?
/kind bug
/kind failing-test

### What this PR does / why we need it:

If we use darwin(macOS), the test case will try to download darwin kubeadm binary.
But test case will fail, because darwin binary file is not prepared for kubeadm.

this PR fix unit test fail in TestCacheBinary/ok_kubeadm.

### Which issue(s) this PR fixes:

Fixes #5661

### Does this PR introduce a user-facing change?

No. This PR changes test case only.

**Before, TestCacheBinary/ok_kubeadm sucess or fail.**

It depends on developer's OS environment.
So, the test succeeds or fails sometimes.

```
{
	desc:         "ok kubeadm",
	version:      "v1.16.0",
	osName:       runtime.GOOS,
	archName:     runtime.GOARCH,
	binary:       "kubeadm",
	err:          false,
	minikubeHome: minikubeHome,
}
```

**After this PR, TestCacheBinary/ok_kubeadm sucess**

In my commit, the osName in test case is changed.
runtime.GOOS → "linux"

```
{
	desc:         "ok kubeadm",
	version:      "v1.16.0",
	osName:       "linux",
	archName:     runtime.GOARCH,
	binary:       "kubeadm",
	err:          false,
	minikubeHome: minikubeHome,
}
```

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```