### PR TITLE
Pick some lint from the recent master commits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,12 @@ endif
 
 ifeq ($(GOOS),windows)
 	IS_EXE = .exe
+	DIRSEP_ = \\
+	DIRSEP = $(strip $(DIRSEP_))
+	PATHSEP = ;
+else
+	DIRSEP = /
+	PATHSEP = :
 endif
 
 
@@ -239,28 +245,18 @@ extract:
 pkg/minikube/assets/assets.go: $(shell find "deploy/addons" -type f)
 ifeq ($(MINIKUBE_BUILD_IN_DOCKER),y)
 	$(call DOCKER,$(BUILD_IMAGE),/usr/bin/make $@)
-else ifeq ($(GOOS),windows)
-	which go-bindata || GO111MODULE=off GOBIN="$(GOPATH)\bin" go get github.com/jteeuwen/go-bindata/...
-	PATH="$(PATH);$(GOPATH)\bin" go-bindata -nomemcopy -o $@ -pkg assets deploy/addons/...
-	-gofmt -s -w $@
-else
-	which go-bindata || GO111MODULE=off GOBIN=$(GOPATH)/bin go get github.com/jteeuwen/go-bindata/...
-	PATH="$(PATH):$(GOPATH)/bin" go-bindata -nomemcopy -o $@ -pkg assets deploy/addons/...
-	-gofmt -s -w $@
 endif
+	which go-bindata || GO111MODULE=off GOBIN="$(GOPATH)$(DIRSEP)bin" go get github.com/jteeuwen/go-bindata/...
+	PATH="$(PATH)$(PATHSEP)$(GOPATH)$(DIRSEP)bin" go-bindata -nomemcopy -o $@ -pkg assets deploy/addons/...
+	-gofmt -s -w $@
 
 pkg/minikube/translate/translations.go: $(shell find "translations/" -type f)
 ifeq ($(MINIKUBE_BUILD_IN_DOCKER),y)
 	$(call DOCKER,$(BUILD_IMAGE),/usr/bin/make $@)
-else ifeq ($(GOOS),windows)
-	which go-bindata || GO111MODULE=off GOBIN="$(GOPATH)\bin" go get github.com/jteeuwen/go-bindata/...
-	PATH="$(PATH);$(GOPATH)\bin" go-bindata -nomemcopy -o $@ -pkg translate translations/...
-	-gofmt -s -w $@
-else
-	which go-bindata || GO111MODULE=off GOBIN=$(GOPATH)/bin go get github.com/jteeuwen/go-bindata/...
-	PATH="$(PATH):$(GOPATH)/bin" go-bindata -nomemcopy -o $@ -pkg translate translations/...
-	-gofmt -s -w $@
 endif
+	which go-bindata || GO111MODULE=off GOBIN="$(GOPATH)$(DIRSEP)bin" go get github.com/jteeuwen/go-bindata/...
+	PATH="$(PATH)$(PATHSEP)$(GOPATH)$(DIRSEP)bin" go-bindata -nomemcopy -o $@ -pkg translate translations/...
+	-gofmt -s -w $@
 	@#golint: Json should be JSON (compat sed)
 	@sed -i -e 's/Json/JSON/' $@ && rm -f ./-e
 

--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,8 @@ endif
 	which go-bindata || GO111MODULE=off GOBIN="$(GOPATH)$(DIRSEP)bin" go get github.com/jteeuwen/go-bindata/...
 	PATH="$(PATH)$(PATHSEP)$(GOPATH)$(DIRSEP)bin" go-bindata -nomemcopy -o $@ -pkg assets deploy/addons/...
 	-gofmt -s -w $@
+	@#golint: Dns should be DNS (compat sed)
+	@sed -i -e 's/Dns/DNS/g' $@ && rm -f ./-e
 
 pkg/minikube/translate/translations.go: $(shell find "translations/" -type f)
 ifeq ($(MINIKUBE_BUILD_IN_DOCKER),y)
@@ -308,7 +310,7 @@ vet:
 	@go vet $(SOURCE_PACKAGES)
 
 .PHONY: golint
-golint:
+golint: pkg/minikube/assets/assets.go pkg/minikube/translate/translations.go
 	@golint -set_exit_status $(SOURCE_PACKAGES)
 
 .PHONY: gocyclo

--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -56,11 +56,15 @@ associated files.`,
 type typeOfError int
 
 const (
-	Fatal          typeOfError = 0
+	// Fatal is a type of DeletionError
+	Fatal typeOfError = 0
+	// MissingProfile is a type of DeletionError
 	MissingProfile typeOfError = 1
+	// MissingCluster is a type of DeletionError
 	MissingCluster typeOfError = 2
 )
 
+// DeletionError can be returned from DeleteProfiles
 type DeletionError struct {
 	Err     error
 	Errtype typeOfError
@@ -118,7 +122,7 @@ func runDelete(cmd *cobra.Command, args []string) {
 	}
 }
 
-// Deletes one or more profiles
+// DeleteProfiles deletes one or more profiles
 func DeleteProfiles(profiles []*pkg_config.Profile) []error {
 	var errs []error
 	for _, profile := range profiles {
@@ -246,7 +250,7 @@ func uninstallKubernetes(api libmachine.API, kc pkg_config.KubernetesConfig, bsN
 	return nil
 }
 
-// Handles deletion error from DeleteProfiles
+// HandleDeletionErrors handles deletion errors from DeleteProfiles
 func HandleDeletionErrors(errors []error) {
 	if len(errors) == 1 {
 		handleSingleDeletionError(errors[0])

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -137,6 +137,7 @@ type kubectlversion struct {
 	SVersion VersionInfo `json:"serverVersion"`
 }
 
+// VersionInfo holds version information
 type VersionInfo struct {
 	Major      string `json:"major"`
 	Minor      string `json:"minor"`

--- a/pkg/minikube/bootstrapper/images/images.go
+++ b/pkg/minikube/bootstrapper/images/images.go
@@ -26,7 +26,9 @@ import (
 )
 
 const (
-	DefaultImageRepo    = "k8s.gcr.io"
+	// DefaultImageRepo is the default repository for images
+	DefaultImageRepo = "k8s.gcr.io"
+	// DefaultMinikubeRepo is the default repository for minikube
 	DefaultMinikubeRepo = "gcr.io/k8s-minikube"
 )
 

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -604,8 +604,8 @@ func CreateSSHShell(api libmachine.API, args []string) error {
 	return client.Shell(args...)
 }
 
-// EnsureMinikubeRunningOrExit checks that minikube has a status available and that
-// the status is `Running`, otherwise it will exit
+// IsMinikubeRunning checks that minikube has a status available and that
+// the status is `Running`
 func IsMinikubeRunning(api libmachine.API) bool {
 	s, err := GetHostStatus(api)
 	if err != nil {

--- a/pkg/minikube/cluster/machine.go
+++ b/pkg/minikube/cluster/machine.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/machine"
 )
 
+// Machine contains information about a machine
 type Machine struct {
 	*host.Host
 }
@@ -58,7 +59,7 @@ func (h *Machine) IsValid() bool {
 	return true
 }
 
-// ListsMachines return all valid and invalid machines
+// ListMachines return all valid and invalid machines
 // If a machine is valid or invalid is determined by the cluster.IsValid function
 func ListMachines(miniHome ...string) (validMachines []*Machine, inValidMachines []*Machine, err error) {
 	pDirs, err := machineDirs(miniHome...)
@@ -80,7 +81,7 @@ func ListMachines(miniHome ...string) (validMachines []*Machine, inValidMachines
 	return validMachines, inValidMachines, nil
 }
 
-// Loads a machine or throws an error if the machine could not be loadedG
+// LoadMachine loads a machine or throws an error if the machine could not be loadedG
 func LoadMachine(name string) (*Machine, error) {
 	api, err := machine.NewAPIClient()
 	if err != nil {

--- a/pkg/minikube/config/profile.go
+++ b/pkg/minikube/config/profile.go
@@ -136,7 +136,7 @@ func ListProfiles(miniHome ...string) (validPs []*Profile, inValidPs []*Profile,
 	return validPs, inValidPs, nil
 }
 
-// loadProfile loads type Profile based on its name
+// LoadProfile loads type Profile based on its name
 func LoadProfile(name string, miniHome ...string) (*Profile, error) {
 	cfg, err := DefaultLoader.LoadConfigFromFile(name, miniHome...)
 	p := &Profile{


### PR DESCRIPTION
Also removed some duplication from the windows GOOS

Currently that rule is broken, since it should be the **host** OS ?
But fortunately linux comes before windows in the cross target.

That means that when it builds for windows, it's already generated.

----

Fixed these:
```
golint: 97%
	cmd/minikube/cmd/start.go
		Line 140: warning: exported type VersionInfo should have comment or be unexported (golint)
	pkg/minikube/bootstrapper/images/images.go
		Line 29: warning: exported const DefaultImageRepo should have comment (or a comment on this block) or be unexported (golint)
	pkg/minikube/cluster/cluster.go
		Line 607: warning: comment on exported function IsMinikubeRunning should be of the form "IsMinikubeRunning ..." (golint)
	pkg/minikube/cluster/machine.go
		Line 29: warning: exported type Machine should have comment or be unexported (golint)
		Line 61: warning: comment on exported function ListMachines should be of the form "ListMachines ..." (golint)
		Line 83: warning: comment on exported function LoadMachine should be of the form "LoadMachine ..." (golint)
	pkg/minikube/config/profile.go
		Line 139: warning: comment on exported function LoadProfile should be of the form "LoadProfile ..." (golint)
	cmd/minikube/cmd/delete.go
		Line 59: warning: exported const Fatal should have comment (or a comment on this block) or be unexported (golint)
		Line 64: warning: exported type DeletionError should have comment or be unexported (golint)
		Line 121: warning: comment on exported function DeleteProfiles should be of the form "DeleteProfiles ..." (golint)
		Line 249: warning: comment on exported function HandleDeletionErrors should be of the form "HandleDeletionErrors ..." (golint)
```
