### PR TITLE
Build minikube for arm64 (aarch64) as well

### DIFF
--- a/installers/linux/deb/minikube_deb_template/DEBIAN/control
+++ b/installers/linux/deb/minikube_deb_template/DEBIAN/control
@@ -2,7 +2,7 @@ Package: minikube
 Version: --VERSION--
 Section: base
 Priority: optional
-Architecture: amd64
+Architecture: --ARCH--
 Recommends: virtualbox
 Maintainer: Thomas Strömberg <t+minikube@stromberg.org>
 Description: Minikube

--- a/installers/linux/rpm/minikube_rpm_template/minikube.spec
+++ b/installers/linux/rpm/minikube_rpm_template/minikube.spec
@@ -18,12 +18,12 @@ day-to-day.
 %prep
 mkdir -p %{name}-%{version}
 cd %{name}-%{version}
-cp --OUT--/minikube-linux-amd64 .
+cp --OUT--/minikube-linux-%{_arch} minikube
 
 %install
 cd %{name}-%{version}
 mkdir -p %{buildroot}%{_bindir}
-install -m 755 minikube-linux-amd64 %{buildroot}%{_bindir}/%{name}
+install -m 755 minikube %{buildroot}%{_bindir}/%{name}
 
 %files
 %{_bindir}/%{name}


### PR DESCRIPTION
This a pure build target, no test done (yet)
No virtualization supported on this platform

Adopt packaging to handle multiple arch, but
don't package anything extra by default yet.