### PR TITLE
Reduce code smell reported by SonarCloud

### DIFF
--- a/cmd/minikube/cmd/config/prompt.go
+++ b/cmd/minikube/cmd/config/prompt.go
@@ -151,5 +151,5 @@ func posString(slice []string, element string) int {
 
 // containsString returns true if slice contains element
 func containsString(slice []string, element string) bool {
-	return !(posString(slice, element) == -1)
+	return posString(slice, element) != -1
 }

--- a/pkg/drivers/kvm/network_test.go
+++ b/pkg/drivers/kvm/network_test.go
@@ -46,7 +46,7 @@ var (
 	]`)
 )
 
-func Test_parseStatusAndReturnIp(t *testing.T) {
+func TestParseStatusAndReturnIp(t *testing.T) {
 	type args struct {
 		mac      string
 		statuses []byte

--- a/pkg/minikube/config/config_test.go
+++ b/pkg/minikube/config/config_test.go
@@ -174,7 +174,7 @@ func TestWriteConfig(t *testing.T) {
 	}
 }
 
-func Test_encode(t *testing.T) {
+func TestEncode(t *testing.T) {
 	var b bytes.Buffer
 	for _, tt := range configTestCases {
 		err := encode(&b, tt.config)


### PR DESCRIPTION
Ref. issue: #5577 

Two changes:
1. Use opposite operator: `a != b` instead of `!(a == b)`
2. Rename couple of methods to match the convention.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
