### PR TITLE
Add missing dash before the image arch

### DIFF
--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -420,7 +420,7 @@ func GenerateTemplateData(cfg config.KubernetesConfig) interface{} {
 	// for  less common architectures blank suffix for amd64
 	ea := ""
 	if runtime.GOARCH != "amd64" {
-		ea = runtime.GOARCH
+		ea = "-" + runtime.GOARCH
 	}
 	opts := struct {
 		Arch            string


### PR DESCRIPTION
This character (-) was removed by mistake, in 5fa6714

It is supposed to be "" for amd64, "-arm64" for arm64.

Closes #5668