### PR TITLE
upgrade go version 1.12.9 -> 1.12.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 os: linux
 language: go
 go:
-  - 1.12.9
+  - 1.12.12
 env:
   global:
     - GOPROXY=https://proxy.golang.org
@@ -19,7 +19,7 @@ matrix:
 
     - language: go
       name: Code Lint
-      go: 1.12.9
+      go: 1.12.12
       env:
         - TESTSUITE=lint
       before_install:
@@ -28,7 +28,7 @@ matrix:
 
     - language: go
       name: Unit Test
-      go: 1.12.9
+      go: 1.12.12
       env:
         - TESTSUITE=unittest
       before_install:

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ DEB_VERSION ?= $(subst -,~,$(RAW_VERSION))
 RPM_VERSION ?= $(DEB_VERSION)
 
 # used by hack/jenkins/release_build_and_upload.sh and KVM_BUILD_IMAGE, see also BUILD_IMAGE below
-GO_VERSION ?= 1.12.9
+GO_VERSION ?= 1.12.12
 
 INSTALL_SIZE ?= $(shell du out/minikube-windows-amd64.exe | cut -f1)
 BUILDROOT_BRANCH ?= 2019.02.6


### PR DESCRIPTION
There is a CVE for Go and this vulnerability is fixed in 1.12.12. We should update it.
See: https://nvd.nist.gov/vuln/detail/CVE-2019-16276

See issue golang/go#34540
Seems this is fixed in 1.12.12. I suggest we should update to 1.12.12 first


/kind bug
/priority important-soon

Fixes#5675