### PR TITLE
Fix links by using Hugo modules tag

### DIFF
--- a/deploy/addons/layouts/gvisor/single.html
+++ b/deploy/addons/layouts/gvisor/single.html
@@ -1,0 +1,5 @@
+{{ define "main" }}
+   <div style="padding-top:20px">
+      {{ .Render "content" }}
+   </div>
+{{ end }}

--- a/deploy/addons/layouts/helm-tiller/single.html
+++ b/deploy/addons/layouts/helm-tiller/single.html
@@ -1,0 +1,5 @@
+{{ define "main" }}
+   <div style="padding-top:20px">
+      {{ .Render "content" }}
+   </div>
+{{ end }}

--- a/deploy/addons/layouts/ingress-dns/single.html
+++ b/deploy/addons/layouts/ingress-dns/single.html
@@ -1,0 +1,5 @@
+{{ define "main" }}
+   <div style="padding-top:60px">
+      {{ .Render "content" }}
+   </div>
+{{ end }}

--- a/deploy/addons/layouts/storage-provisioner-gluster/single.html
+++ b/deploy/addons/layouts/storage-provisioner-gluster/single.html
@@ -1,0 +1,5 @@
+{{ define "main" }}
+   <div style="padding-top:20px">
+      {{ .Render "content" }}
+   </div>
+{{ end }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ publish = "site/public/"
 command = "pwd && cd themes/docsy && git submodule update -f --init && cd ../.. && hugo"
 
 [build.environment]
-HUGO_VERSION = "0.55.6"
+HUGO_VERSION = "0.59.0"
 
 [context.production.environment]
 HUGO_ENV = "production"

--- a/site/config.toml
+++ b/site/config.toml
@@ -9,7 +9,7 @@ theme = ["docsy"]
 enableGitInfo = true
 
 # Language settings
-contentDir = "content/en" 
+contentDir = "content/en"
 defaultContentLanguage = "en"
 defaultContentLanguageInSubdir = false
 # Useful when translating.
@@ -32,6 +32,30 @@ pygmentsStyle = "tango"
 # Configure how URLs look like per section.
 [permalinks]
 blog = "/:section/:year/:month/:day/:slug/"
+
+[module]
+  [[module.mounts]]
+    source = "../deploy/addons/gvisor/"
+    target = "content/gvisor/"
+  [[module.mounts]]
+    source = "../deploy/addons/helm-tiller/"
+    target = "content/helm-tiller/"
+  [[module.mounts]]
+    source = "../deploy/addons/ingress-dns/"
+    target = "content/ingress-dns/"
+  [[module.mounts]]
+    source = "../deploy/addons/storage-provisioner-gluster/"
+    target = "content/storage-provisioner-gluster/"
+  [[module.mounts]]
+    source = "../deploy/addons/layouts/"
+    target = "layouts"
+
+  [[module.mounts]]
+    source = "content/en"
+    target = "content"
+  [[module.mounts]]
+    source = "layouts"
+    target = "layouts"
 
 ## Configuration for BlackFriday markdown parser: https://github.com/russross/blackfriday
 [blackfriday]

--- a/site/content/en/docs/Tasks/addons.md
+++ b/site/content/en/docs/Tasks/addons.md
@@ -20,10 +20,10 @@ minikube has a set of built-in addons that, when enabled, can be used within Kub
 * [nvidia-driver-installer](https://github.com/GoogleCloudPlatform/container-engine-accelerators/tree/master/nvidia-driver-installer/minikube)
 * [nvidia-gpu-device-plugin](https://github.com/GoogleCloudPlatform/container-engine-accelerators/tree/master/cmd/nvidia_gpu)
 * [logviewer](https://github.com/ivans3/minikube-log-viewer)
-* [gvisor](../deploy/addons/gvisor/README.md)
-* [storage-provisioner-gluster](../deploy/addons/storage-provisioner-gluster/README.md)
-* [helm-tiller](../deploy/addons/helm-tiller/README.md)
-* [ingress-dns](../deploy/addons/ingress-dns/README.md)
+* [gvisor](../../../gvisor/readme/)
+* [storage-provisioner-gluster](../../../storage-provisioner-gluster/readme)
+* [helm-tiller](../../../helm-tiller/readme)
+* [ingress-dns](../../../ingress-dns/readme)
 
 ## Listing available addons
 


### PR DESCRIPTION
fixes #5696

The link is broken as the config.toml is not using module.mounts.

To fix this need to add [module] section to point to the deploy/ folder as the README.md files are inside that folder
