### PR TITLE
pin go version for boilerplate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
   include:
     - language: go
       name: Check Boilerplate 
+      go: 1.12.12
       env:
         - TESTSUITE=boilerplate
       script: make test
@@ -34,6 +35,8 @@ matrix:
       script: make test
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+travisBuddy:	
+    regex: (FAIL:|\.go:\d+:|^panic:|failed$)	
 notifications:
   webhooks:
     urls:


### PR DESCRIPTION
1- pin the go version for the boilerplate that was recently translated to go.

2- trying to make travis-buddy only to print the error (which might not work but won't hurt)
https://github.com/bluzi/travis-buddy/issues/155