### PR TITLE
Previous boilerplate fix break make test

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -35,6 +35,7 @@ then
     echo "= boilerplate ==========================================================="
     readonly ROOT_DIR=$(pwd)
     readonly BDIR="${ROOT_DIR}/hack/boilerplate"
+    pushd . >/dev/null
     cd ${BDIR}
     missing="$(go run boilerplate.go -rootdir ${ROOT_DIR} -boilerplate-dir ${BDIR} | egrep -v '/assets.go|/translations.go|/site/themes/|/site/node_modules|\./out|/hugo/' || true)"
     if [[ -n "${missing}" ]]; then
@@ -44,6 +45,7 @@ then
     else
         echo "ok"
     fi
+    popd >/dev/null
 fi
 
 


### PR DESCRIPTION
The fix change to boilerplate directory but did not change back
to the original directory.

Use pushd and popd to store the directory within the context of
the boilerplate script
