### PR TITLE
Fix lint error: File is not `goimports` -ed

### DIFF
--- a/pkg/minikube/registry/drvs/hyperkit/driver.go
+++ b/pkg/minikube/registry/drvs/hyperkit/driver.go
@@ -25,9 +25,9 @@ import (
 	"github.com/pborman/uuid"
 	"k8s.io/minikube/pkg/drivers/hyperkit"
 	cfg "k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/minikube/registry"
-	"k8s.io/minikube/pkg/minikube/driver"
 )
 
 func init() {

--- a/pkg/minikube/registry/drvs/vmwarefusion/driver.go
+++ b/pkg/minikube/registry/drvs/vmwarefusion/driver.go
@@ -24,10 +24,9 @@ import (
 	"github.com/docker/machine/drivers/vmwarefusion"
 	"github.com/docker/machine/libmachine/drivers"
 	cfg "k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/minikube/registry"
-	"k8s.io/minikube/pkg/minikube/driver"
-
 )
 
 func init() {


### PR DESCRIPTION
### What type of PR is this?
/kind bug
/kind failing-test

### What this PR does / why we need it:

There is lint error. `File is not goimports -ed`.
This PR fixes its lint error.

### Which issue(s) this PR fixes:

Fixes #5720

### Does this PR introduce a user-facing change?

No. This PR changes goimports only.

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```