### PR TITLE
CI: Use print preserve whitespace between interface names

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -165,7 +165,7 @@ if type -P vboxmanage; then
     vboxmanage unregistervm "${guid}" || true
   done
 
-  ifaces=$(vboxmanage list hostonlyifs | grep -E "^Name:" | awk '{ printf $2 }')
+  ifaces=$(vboxmanage list hostonlyifs | grep -E "^Name:" | awk '{ print $2 }')
   for if in $ifaces; do
     vboxmanage hostonlyif remove "${if}" || true
   done


### PR DESCRIPTION
Fixes problem seen with cleanup at https://storage.googleapis.com/minikube-builds/logs/5700/KVM_Linux.txt

`VBoxManage: error: The host network interface named 'vboxnet1vboxnet19vboxnet6vboxnet21vboxnet15vboxnet22vboxnet14vboxnet9vboxnet12vboxnet5vboxnet3vboxnet8vboxnet7vboxnet10vboxnet13vboxnet16vboxnet2vboxnet20vboxnet0vboxnet11vboxnet17vboxnet18vboxnet4' could not be found`