### PR TITLE
Fix `minikube start` in order to be able to  start VM even if machine does not exist

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1089,6 +1089,13 @@ func startHost(api libmachine.API, mc config.MachineConfig) (*host.Host, bool) {
 
 	host, err := cluster.StartHost(api, mc)
 	if err != nil {
+		// If virtual machine does not exist due to user interrupt cancel(i.e. Ctrl + C), initialize exists flag
+		if err == cluster.ErrorMachineNotExist {
+			// If Machine does not exist, of course the machine does not have kubeadm config files
+			// In order not to determine the machine has kubeadm config files, initialize exists flag
+			// ※ If exists flag is true, minikube determines the machine has kubeadm config files
+			return host, false
+		}
 		exit.WithError("Unable to start VM. Please investigate and run 'minikube delete' if possible", err)
 	}
 	return host, exists

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -1,12 +1,9 @@
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/minikube/cluster/cluster_test.go
+++ b/pkg/minikube/cluster/cluster_test.go
@@ -149,13 +149,13 @@ func TestStartHostExists(t *testing.T) {
 func TestStartHostErrMachineNotExist(t *testing.T) {
 	RegisterMockDriver(t)
 	api := tests.NewMockAPI(t)
-
 	// Create an incomplete host with machine does not exist error(i.e. User Interrupt Cancel)
 	api.NotExistError = true
 	_, err := createHost(api, defaultMachineConfig)
 	if err != nil {
 		t.Fatalf("Error creating host: %v", err)
 	}
+
 	md := &tests.MockDetector{Provisioner: &tests.MockProvisioner{}}
 	provision.SetDetector(md)
 

--- a/pkg/minikube/cluster/fix.go
+++ b/pkg/minikube/cluster/fix.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/machine/drivers/virtualbox"
+
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/provision"
@@ -46,6 +48,11 @@ const (
 	maxClockDesyncSeconds = 2.1
 )
 
+var (
+	// ErrorMachineNotExist is returned when virtual machine does not exist due to user interrupt cancel(i.e. Ctrl + C)
+	ErrorMachineNotExist = errors.New("machine does not exist")
+)
+
 // fixHost fixes up a previously configured VM so that it is ready to run Kubernetes
 func fixHost(api libmachine.API, mc config.MachineConfig) (*host.Host, error) {
 	out.T(out.Waiting, "Reconfiguring existing host ...")
@@ -62,8 +69,35 @@ func fixHost(api libmachine.API, mc config.MachineConfig) (*host.Host, error) {
 	}
 
 	s, err := h.Driver.GetState()
-	if err != nil {
-		return h, errors.Wrap(err, "Error getting state for host")
+	if err != nil || s == state.Stopped || s == state.None {
+		// If virtual machine does not exist due to user interrupt cancel(i.e. Ctrl + C), recreate virtual machine
+		me, err := machineExists(h.Driver.DriverName(), s, err)
+		if !me {
+			// If the error is that virtual machine does not exist error, handle error(recreate virtual machine)
+			if err == ErrorMachineNotExist {
+				// remove virtual machine
+				if err := h.Driver.Remove(); err != nil {
+					// skip returning error since it may be before docker image pulling(so, no host exist)
+					if h.Driver.DriverName() != driver.Docker {
+						return nil, errors.Wrap(err, "host remove")
+					}
+				}
+				// remove machine config directory
+				if err := api.Remove(mc.Name); err != nil {
+					return nil, errors.Wrap(err, "api remove")
+				}
+				// recreate virtual machine
+				out.T(out.Meh, "machine '{{.name}}' does not exist. Proceeding ahead with recreating VM.", out.V{"name": mc.Name})
+				h, err = createHost(api, mc)
+				if err != nil {
+					return nil, errors.Wrap(err, "Error recreating VM")
+				}
+				// return ErrMachineNotExist err to initialize preExists flag
+				return h, ErrorMachineNotExist
+			}
+			// If the error is not that virtual machine does not exist error, return error
+			return nil, errors.Wrap(err, "Error getting state for host")
+		}
 	}
 
 	if s == state.Running {
@@ -160,4 +194,67 @@ func adjustGuestClock(h hostRunner, t time.Time) error {
 	out, err := h.RunSSHCommand(fmt.Sprintf("sudo date -s @%d", t.Unix()))
 	glog.Infof("clock set: %s (err=%v)", out, err)
 	return err
+}
+
+// machineExists checks if virtual machine does not exist
+// if the virtual machine exists, return true
+func machineExists(vmDriver string, s state.State, err error) (bool, error) {
+	switch vmDriver {
+	case driver.HyperKit:
+		if s == state.Stopped || err.Error() == "connection is shut down" {
+			return false, ErrorMachineNotExist
+		}
+		return true, err
+	case driver.HyperV:
+		if s == state.None {
+			return false, ErrorMachineNotExist
+		}
+		return true, err
+	case driver.KVM2:
+		if s == state.None || s == state.Stopped {
+			return false, ErrorMachineNotExist
+		}
+		return true, err
+	case driver.None:
+		if s == state.Stopped {
+			return false, ErrorMachineNotExist
+		}
+		return true, err
+	case driver.Parallels:
+		if err.Error() == "machine does not exist" {
+			return false, ErrorMachineNotExist
+		}
+		return true, err
+	case driver.VirtualBox:
+		if err == virtualbox.ErrMachineNotExist {
+			return false, ErrorMachineNotExist
+		}
+		return true, err
+	case driver.VMware:
+		if s == state.None || s == state.Stopped {
+			return false, ErrorMachineNotExist
+		}
+		return true, err
+	case driver.VMwareFusion:
+		if s == state.Stopped {
+			return false, ErrorMachineNotExist
+		}
+		return true, err
+	case driver.Docker:
+		if s == state.Error {
+			// if the kic image is not present on the host machine, when user cancel `minikube start`, state.Error will be return
+			return false, ErrorMachineNotExist
+		} else if s == state.None {
+			// if the kic image is present on the host machine, when user cancel `minikube start`, state.None will be return
+			return false, ErrorMachineNotExist
+		}
+		return true, err
+	case driver.Mock:
+		if s == state.Error {
+			return false, ErrorMachineNotExist
+		}
+		return true, err
+	default:
+		return true, err
+	}
 }

--- a/pkg/minikube/tests/api_mock.go
+++ b/pkg/minikube/tests/api_mock.go
@@ -33,10 +33,11 @@ import (
 // MockAPI is a struct used to mock out libmachine.API
 type MockAPI struct {
 	FakeStore
-	CreateError bool
-	RemoveError bool
-	SaveCalled  bool
-	t           *testing.T
+	CreateError   bool
+	RemoveError   bool
+	NotExistError bool
+	SaveCalled    bool
+	t             *testing.T
 }
 
 // NewMockAPI returns a new MockAPI
@@ -108,6 +109,12 @@ func (api *MockAPI) Create(h *host.Host) error {
 	drv, ok := h.Driver.(*MockDriver)
 	if ok {
 		drv.T = api.t
+	}
+	if api.NotExistError {
+		// initialize api.NotExistError
+		api.NotExistError = false
+		// reproduce ErrMachineNotExist
+		drv.NotExistError = true
 	}
 	return h.Driver.Create()
 }

--- a/pkg/minikube/tests/driver_mock.go
+++ b/pkg/minikube/tests/driver_mock.go
@@ -99,6 +99,7 @@ func (d *MockDriver) GetState() (state.State, error) {
 	d.Logf("MockDriver.GetState: %v", d.CurrentState)
 	if d.NotExistError {
 		d.CurrentState = state.Error
+		// don't use cluster.ErrorMachineNotExist to avoid import cycle
 		return d.CurrentState, errors.New("machine does not exist")
 	}
 	return d.CurrentState, nil

--- a/pkg/minikube/tests/driver_mock.go
+++ b/pkg/minikube/tests/driver_mock.go
@@ -29,12 +29,13 @@ import (
 // MockDriver is a struct used to mock out libmachine.Driver
 type MockDriver struct {
 	drivers.BaseDriver
-	CurrentState state.State
-	RemoveError  bool
-	HostError    bool
-	Port         int
-	IP           string
-	T            *testing.T
+	CurrentState  state.State
+	RemoveError   bool
+	NotExistError bool
+	HostError     bool
+	Port          int
+	IP            string
+	T             *testing.T
 }
 
 // Logf logs mock interactions
@@ -49,6 +50,11 @@ func (d *MockDriver) Logf(format string, args ...interface{}) {
 // Create creates a MockDriver instance
 func (d *MockDriver) Create() error {
 	d.Logf("MockDriver.Create")
+	if d.NotExistError {
+		d.Logf("MockDriver.Create but machine does not exist")
+		d.CurrentState = state.Error
+		return nil
+	}
 	d.CurrentState = state.Running
 	return nil
 }
@@ -91,6 +97,10 @@ func (d *MockDriver) GetSSHKeyPath() string {
 // GetState returns the state of the driver
 func (d *MockDriver) GetState() (state.State, error) {
 	d.Logf("MockDriver.GetState: %v", d.CurrentState)
+	if d.NotExistError {
+		d.CurrentState = state.Error
+		return d.CurrentState, errors.New("machine does not exist")
+	}
 	return d.CurrentState, nil
 }
 


### PR DESCRIPTION
### What type of PR is this?
/kind bug

### What this PR does / why we need it:

When minikube machine does not exist, the Virtual Machine fails starting.
If the host config exists but machine does not exist, we should start recreate VM automatically.
This PR fixes out of control error.

### Which issue(s) this PR fixes:
Fixes #5509

### Does this PR introduce a user-facing change?

Yes. 
This PR fixes bug in order to `minikube start` command work successfully even if machine does not exist.

**Before this PR, `minikube start` command fails, when machine does not exist**
```
1. minikube start (and stop command by Ctrl + C after this)
minikube start
😄  minikube v1.4.0 on Darwin 10.14.6
🔥  Creating virtualbox VM (CPUs=2, Memory=6500MB, Disk=20000MB) ...
^C

# Restart Minikube
2. minikube start
😄  minikube v1.4.0 on Darwin 10.14.6
💡  Tip: Use 'minikube start -p <name>' to create a new cluster, or 'minikube delete' to delete this one.
🔄  Retriable failure: Error getting state for host: machine does not exist
```

**After this PR, `minikube start` command success, even if machine does not exist**
```
1. minikube start (and stop command by Ctrl + C after this)
$ out/minikube start
😄  minikube v1.5.0-beta.0 on Darwin 10.14.6
🔥  Creating virtualbox VM (CPUs=2, Memory=2000MB, Disk=20000MB) ...
^C

# Restart Minikube
2. out/minikube start
😄  minikube v1.5.0-beta.0 on Darwin 10.14.5
💡  Tip: Use 'minikube start -p <name>' to create a new cluster, or 'minikube delete' to delete this one.
🙄  "machine minikube" does not exist. Proceeding ahead with recreating VM.
🔥  Creating virtualbox VM (CPUs=2, Memory=2000MB, Disk=20000MB) ...
```

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```