### PR TITLE
gvisor: Use chroot instead of LD_LIBRARY_PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,8 @@ GOLINT_OPTIONS = --timeout 4m \
 	  --enable goimports,gocritic,golint,gocyclo,misspell,nakedret,stylecheck,unconvert,unparam,dogsled \
 	  --exclude 'variable on range scope.*in function literal|ifElseChain'
 
+# Major version of gvisor image. Increment when there are breaking changes.
+GVISOR_IMAGE_VERSION ?= 2
 
 export GO111MODULE := on
 
@@ -480,11 +482,11 @@ out/gvisor-addon: pkg/minikube/assets/assets.go pkg/minikube/translate/translati
 
 .PHONY: gvisor-addon-image
 gvisor-addon-image: out/gvisor-addon
-	docker build -t $(REGISTRY)/gvisor-addon:latest -f deploy/gvisor/Dockerfile .
+	docker build -t $(REGISTRY)/gvisor-addon:$(GVISOR_IMAGE_VERSION) -f deploy/gvisor/Dockerfile .
 
 .PHONY: push-gvisor-addon-image
 push-gvisor-addon-image: gvisor-addon-image
-	gcloud docker -- push $(REGISTRY)/gvisor-addon:2
+	gcloud docker -- push $(REGISTRY)/gvisor-addon:$(GVISOR_IMAGE_VERSION)
 
 .PHONY: release-iso
 release-iso: minikube_iso checksum

--- a/Makefile
+++ b/Makefile
@@ -484,7 +484,7 @@ gvisor-addon-image: out/gvisor-addon
 
 .PHONY: push-gvisor-addon-image
 push-gvisor-addon-image: gvisor-addon-image
-	gcloud docker -- push $(REGISTRY)/gvisor-addon:latest
+	gcloud docker -- push $(REGISTRY)/gvisor-addon:2
 
 .PHONY: release-iso
 release-iso: minikube_iso checksum

--- a/cmd/gvisor/gvisor.go
+++ b/cmd/gvisor/gvisor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"flag"
 	"log"
 	"os"
 
@@ -24,6 +25,8 @@ import (
 )
 
 func main() {
+	flag.Parse()
+
 	if err := gvisor.Enable(); err != nil {
 		log.Print(err)
 		os.Exit(1)

--- a/cmd/gvisor/gvisor.go
+++ b/cmd/gvisor/gvisor.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"flag"
 	"log"
 	"os"
 
@@ -25,8 +24,6 @@ import (
 )
 
 func main() {
-	flag.Parse()
-
 	if err := gvisor.Enable(); err != nil {
 		log.Print(err)
 		os.Exit(1)

--- a/deploy/addons/gvisor/gvisor-pod.yaml.tmpl
+++ b/deploy/addons/gvisor/gvisor-pod.yaml.tmpl
@@ -29,45 +29,23 @@ spec:
         privileged: true
       volumeMounts:
       - mountPath: /node/
-        name: node
-      - mountPath: /usr/libexec/sudo
-        name: sudo
-      - mountPath: /var/run
-        name: varrun
-      - mountPath: /usr/bin
-        name: usrbin
-      - mountPath: /usr/lib
-        name: usrlib
-      - mountPath: /bin
-        name: bin
+        name: node-root
+      - mountPath: /node/run
+        name: node-run
       - mountPath: /tmp/gvisor
-        name: gvisor
+        name: node-tmp
       env:
-        - name: PATH
-          value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/node/bin
         - name: SYSTEMD_IGNORE_CHROOT
           value: "yes"
       imagePullPolicy: IfNotPresent
   volumes:
-  - name: node
+  - name: node-root
     hostPath:
       path: /
-  - name: sudo
+  - name: node-run
     hostPath:
-      path: /usr/libexec/sudo
-  - name: varrun
-    hostPath:
-      path: /var/run
-  - name: usrlib
-    hostPath:
-      path: /usr/lib
-  - name: usrbin
-    hostPath:
-      path: /usr/bin
-  - name: bin
-    hostPath:
-      path: /bin
-  - name: gvisor
+      path: /run
+  - name: node-tmp
     hostPath:
       path: /tmp/gvisor
   restartPolicy: Always

--- a/deploy/addons/gvisor/gvisor-pod.yaml.tmpl
+++ b/deploy/addons/gvisor/gvisor-pod.yaml.tmpl
@@ -24,7 +24,7 @@ spec:
   hostPID: true
   containers:
     - name: gvisor
-      image: {{default "gcr.io/k8s-minikube" .ImageRepository}}/gvisor-addon:latest
+      image: {{default "gcr.io/k8s-minikube" .ImageRepository}}/gvisor-addon:2
       securityContext:
         privileged: true
       volumeMounts:

--- a/deploy/gvisor/Dockerfile
+++ b/deploy/gvisor/Dockerfile
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:18.04
-RUN apt-get update && \
-    apt-get install -y kmod gcc wget xz-utils libc6-dev bc libelf-dev bison flex openssl libssl-dev libidn2-0 sudo libcap2 && \
-    rm -rf /var/lib/apt/lists/*
+# Need an image with chroot
+FROM alpine:3
 COPY out/gvisor-addon /gvisor-addon
 CMD ["/gvisor-addon"]

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -245,13 +245,13 @@ mkdir -p "${TEST_HOME}"
 export MINIKUBE_HOME="${TEST_HOME}/.minikube"
 export KUBECONFIG="${TEST_HOME}/kubeconfig"
 
-# Build the gvisor image. This will be copied into minikube and loaded by ctr.
-# Used by TestContainerd for Gvisor Test.
-# TODO: move this to integration test setup.
+
+# Build the gvisor image so that we can integration test changes to pkg/gvisor
 chmod +x ./testdata/gvisor-addon
 # skipping gvisor mac because ofg https://github.com/kubernetes/minikube/issues/5137
 if [ "$(uname)" != "Darwin" ]; then
-  docker build -t gcr.io/k8s-minikube/gvisor-addon:latest -f testdata/gvisor-addon-Dockerfile ./testdata
+  # Should match GVISOR_IMAGE_VERSION in Makefile
+  docker build -t gcr.io/k8s-minikube/gvisor-addon:2 -f testdata/gvisor-addon-Dockerfile ./testdata
 fi
 
 echo ""

--- a/test/integration/gvisor_addon_test.go
+++ b/test/integration/gvisor_addon_test.go
@@ -35,6 +35,13 @@ func TestGvisorAddon(t *testing.T) {
 	profile := UniqueProfileName("gvisor")
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer func() {
+		if t.Failed() {
+			rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "logs", "gvisor", "-n", "kube-system"))
+			if err != nil {
+				t.Logf("failed to get gvisor post-mortem logs: %v", err)
+			}
+			t.Logf("gvisor post-mortem: %s:\n%s\n", rr.Command(), rr.Output())
+		}
 		CleanupWithLogs(t, profile, cancel)
 	}()
 


### PR DESCRIPTION
Replaces brittle `LD_LIBRARY_PATH` hack with `chroot` to restart node services from the pod.

This was previously using the Ubuntu `sudo` binary with libraries from the ISO image, which was safe until we updated the ISO image to a new glibc.

Fixes #5724