### PR TITLE
Fix typo in integration test readme

### DIFF
--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -10,7 +10,7 @@ To run all tests from the minikube root directory:
 
 Run a single test on an active cluster:
 
-`make integration -e TEST_ARGS="-test.v -test.run TestFunctional/parallel/MountCmd --profile=minikube --cleanup=false"`
+`make integration -e TEST_ARGS="-test.run TestFunctional/parallel/MountCmd --profile=minikube --cleanup=false"`
 
 WARNING: For this to work repeatedly, the test must be written so that it cleans up after itself.
 


### PR DESCRIPTION
-test.v : gives this error: it is because it is already set in Makefile
```
go test: v flag may be set only once
run "go help test" or "go help testflag" for more information
make: *** [Makefile:233: integration] Error 2
go test: v flag may be set only once
run "go help test" or "go help testflag" for more information
```