### PR TITLE
Try caching the go/pkg/mod directory in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ os: linux
 language: go
 go:
   - 1.12.12
+cache:
+  directories:
+    - $GOPATH/pkg/mod
 env:
   global:
     - GOPROXY=https://proxy.golang.org


### PR DESCRIPTION
Currently downloading modules for every build.
Try caching the source directory between builds.

Don't want to run incremental builds just yet...
(as in $GOCACHE) Since that has some issues