### PR TITLE
Make sure to look for vmrun, for vmware

### DIFF
--- a/pkg/minikube/registry/drvs/vmware/vmware.go
+++ b/pkg/minikube/registry/drvs/vmware/vmware.go
@@ -57,5 +57,9 @@ func status() registry.State {
 	if err != nil {
 		return registry.State{Error: err, Fix: "Install docker-machine-driver-vmware", Doc: "https://minikube.sigs.k8s.io/docs/reference/drivers/vmware/"}
 	}
+	_, err := exec.LookPath("vmrun")
+	if err != nil {
+		return registry.State{Error: err, Fix: "Install vmrun", Doc: "https://minikube.sigs.k8s.io/docs/reference/drivers/vmware/"}
+	}
 	return registry.State{Installed: true, Healthy: true}
 }


### PR DESCRIPTION
Otherwise you risk trying to run VMware, just because the
`docker-machine-driver-vmware` driver has been installed...

Unfortunately VMware Workstation (275€) has a _higher_ prio
than the usual Oracle VirtualBox that previously was default.

Closes #5746 