### PR TITLE
Use faster build for the default minikube target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ else
 endif
 
 
-out/minikube$(IS_EXE): $(SOURCE_GENERATED) $(SOURCE_FILES)
+out/minikube$(IS_EXE): $(SOURCE_GENERATED) $(SOURCE_FILES) go.mod
 	go build -tags "$(MINIKUBE_BUILD_TAGS)" -ldflags="$(MINIKUBE_LDFLAGS)" -o $@ k8s.io/minikube/cmd/minikube
 
 out/minikube-windows-amd64.exe: out/minikube-windows-amd64

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,11 @@ endif
 
 
 out/minikube$(IS_EXE): $(SOURCE_GENERATED) $(SOURCE_FILES) go.mod
+ifeq ($(MINIKUBE_BUILD_IN_DOCKER),y)
+	$(call DOCKER,$(BUILD_IMAGE),GOOS=$(GOOS) GOARCH=$(GOARCH) /usr/bin/make $@)
+else
 	go build -tags "$(MINIKUBE_BUILD_TAGS)" -ldflags="$(MINIKUBE_LDFLAGS)" -o $@ k8s.io/minikube/cmd/minikube
+endif
 
 out/minikube-windows-amd64.exe: out/minikube-windows-amd64
 	cp $< $@


### PR DESCRIPTION
When we are doing the "cross" compile targets, we
force rebuilding all packages (up-to-date or not).

For the default native target "out/minikube", we
can do a much faster build (10x!), for development.

Leaving all the cross target to rebuild, as before.

Also the _test.go files are only used for unit tests.

----

On my machine it takes about 50 seconds, to rebuild all the 645 packages...

```
real	0m47.801s
user	2m36.732s
sys	0m8.620s
```

Doing an incremental build takes only 6 seconds, and is **much** more usable.

```
real	0m6.077s
user	0m7.368s
sys	0m0.928s
```

Interesting flags to `go build`:

```
The build flags are shared by the build, clean, get, install, list, run,
and test commands:

	-a
		force rebuilding of packages that are already up-to-date.
	-n
		print the commands but do not run them.
	-v
		print the names of packages as they are compiled.
	-x
		print the commands.
```

I used -v to get the 645 lines.