### PR TITLE
Do not check sshd for the none driver

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -974,7 +974,7 @@ func validateNetwork(h *host.Host, r command.Runner) string {
 		}
 	}
 
-	if driver.BareMetal(h.Driver.DriverName()) {
+	if !driver.BareMetal(h.Driver.DriverName()) {
 		sshAddr := fmt.Sprintf("%s:22", ip)
 		conn, err := net.Dial("tcp", sshAddr)
 		if err != nil {


### PR DESCRIPTION
Fixes #5756

We missed this in integration testing, as our integration test servers run sshd on port 22.