### PR TITLE
Add josedonizetti as minikube approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -14,6 +14,7 @@ approvers:
   - sharifelgamal
   - RA489
   - medyagh
+  - josedonizetti
 emeritus_approvers:
   - dlorenc
   - luxas


### PR DESCRIPTION
It's been 3 months since we've added Jose as a reviewer, so it's about time to add him as an approver.