### PR TITLE
integration: Change --postmortem-logs to --postmortem-log-lines, default to 5

### DIFF
--- a/test/integration/helpers.go
+++ b/test/integration/helpers.go
@@ -175,9 +175,9 @@ func Cleanup(t *testing.T, profile string, cancel context.CancelFunc) {
 // CleanupWithLogs cleans up after a test run, fetching logs and deleting the profile
 func CleanupWithLogs(t *testing.T, profile string, cancel context.CancelFunc) {
 	t.Helper()
-	if t.Failed() && *postMortemLogs {
+	if t.Failed() && *postMortemLogLines > 0 {
 		t.Logf("%s failed, collecting logs ...", t.Name())
-		rr, err := Run(t, exec.Command(Target(), "-p", profile, "logs", "-n", "100"))
+		rr, err := Run(t, exec.Command(Target(), "-p", profile, "logs", fmt.Sprintf("-n%d", *postMortemLogLines)))
 		if err != nil {
 			t.Logf("failed logs error: %v", err)
 		}

--- a/test/integration/main.go
+++ b/test/integration/main.go
@@ -32,7 +32,7 @@ var defaultDriver = flag.String("expected-default-driver", "", "Expected default
 // Flags for faster local integration testing
 var forceProfile = flag.String("profile", "", "force tests to run against a particular profile")
 var cleanup = flag.Bool("cleanup", true, "cleanup failed test run")
-var postMortemLogs = flag.Bool("postmortem-logs", true, "show logs after a failed test run")
+var postMortemLogLines = flag.Int("postmortem-log-lines", 5, "how many lines of logs to show during post-mortem, set to 0 to disable")
 
 // Paths to files - normally set for CI
 var binaryPath = flag.String("binary", "../../out/minikube", "path to minikube binary")


### PR DESCRIPTION
5 is just enough to hint that there was an OOM, without flooding you with crap log lines.
