### PR TITLE
Set Docker open-files limit ( 'ulimit -n') to be consistent with other runtimes

### DIFF
--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -25,6 +25,11 @@ import (
 	"k8s.io/minikube/pkg/minikube/out"
 )
 
+const (
+	// OpenFilesMax is the maximum number of open files allowed by container runtimes. Arbitrary, but commonly used.
+	OpenFilesMax = 1048576
+)
+
 // CommandRunner is the subset of command.Runner this package consumes
 type CommandRunner interface {
 	Run(string) error

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -25,11 +25,6 @@ import (
 	"k8s.io/minikube/pkg/minikube/out"
 )
 
-const (
-	// OpenFilesMax is the maximum number of open files allowed by container runtimes. Arbitrary, but commonly used.
-	OpenFilesMax = 1048576
-)
-
 // CommandRunner is the subset of command.Runner this package consumes
 type CommandRunner interface {
 	Run(string) error

--- a/pkg/provision/buildroot.go
+++ b/pkg/provision/buildroot.go
@@ -109,7 +109,7 @@ Requires= minikube-automount.service docker.socket
 Type=notify
 
 # Automatically set options
-Environment=default-ulimit=nofile=99997:99997
+Environment=default-ulimit=nofile=1048576:1048576
 `
 	if noPivot {
 		log.Warn("Using fundamentally insecure --no-pivot option")
@@ -136,7 +136,7 @@ ExecReload=/bin/kill -s HUP $MAINPID
 
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.
-LimitNOFILE=1048576
+LimitNOFILE=infinity
 LimitNPROC=infinity
 LimitCORE=infinity
 

--- a/pkg/provision/buildroot.go
+++ b/pkg/provision/buildroot.go
@@ -126,6 +126,9 @@ Environment=DOCKER_RAMDISK=yes
 # a sequence of commands, which is not the desired behavior, nor is it valid -- systemd
 # will catch this invalid input and refuse to start the service with an error like:
 #  Service has more than one ExecStart= setting, which is only allowed for Type=oneshot services.
+
+# NOTE: default-ulimit=nofile is set to an arbitrary number for consistency with other
+# container runtimes. If left unlimited, it may result in OOM issues with MySQL.
 ExecStart=
 ExecStart=/usr/bin/dockerd -H tcp://0.0.0.0:{{.DockerPort}} -H unix:///var/run/docker.sock --default-ulimit=nofile=1048576:1048576 --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}} {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
 ExecReload=/bin/kill -s HUP $MAINPID
@@ -159,7 +162,6 @@ WantedBy=multi-user.target
 		DockerPort:    dockerPort,
 		AuthOptions:   p.AuthOptions,
 		EngineOptions: p.EngineOptions,
-		//	OpenFilesMax:  cruntime.OpenFilesLimit,
 	}
 
 	escapeSystemdDirectives(&engineConfigContext)

--- a/pkg/provision/buildroot.go
+++ b/pkg/provision/buildroot.go
@@ -107,9 +107,6 @@ Requires= minikube-automount.service docker.socket
 
 [Service]
 Type=notify
-
-# Automatically set options
-Environment=default-ulimit=nofile=1048576:1048576
 `
 	if noPivot {
 		log.Warn("Using fundamentally insecure --no-pivot option")
@@ -119,7 +116,6 @@ Environment=DOCKER_RAMDISK=yes
 `
 	}
 	engineConfigTmpl += `
-# Passed in-options
 {{range .EngineOptions.Env}}Environment={{.}}
 {{end}}
 
@@ -131,7 +127,7 @@ Environment=DOCKER_RAMDISK=yes
 # will catch this invalid input and refuse to start the service with an error like:
 #  Service has more than one ExecStart= setting, which is only allowed for Type=oneshot services.
 ExecStart=
-ExecStart=/usr/bin/dockerd -H tcp://0.0.0.0:{{.DockerPort}} -H unix:///var/run/docker.sock --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}} {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
+ExecStart=/usr/bin/dockerd -H tcp://0.0.0.0:{{.DockerPort}} -H unix:///var/run/docker.sock --default-ulimit=nofile=1048576:1048576 --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}} {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
 ExecReload=/bin/kill -s HUP $MAINPID
 
 # Having non-zero Limit*s causes performance problems due to accounting overhead

--- a/pkg/provision/buildroot.go
+++ b/pkg/provision/buildroot.go
@@ -108,6 +108,8 @@ Requires= minikube-automount.service docker.socket
 [Service]
 Type=notify
 
+# Automatically set options
+Environment=default-ulimit=nofile=99997:99997
 `
 	if noPivot {
 		log.Warn("Using fundamentally insecure --no-pivot option")
@@ -117,6 +119,7 @@ Environment=DOCKER_RAMDISK=yes
 `
 	}
 	engineConfigTmpl += `
+# Passed in-options
 {{range .EngineOptions.Env}}Environment={{.}}
 {{end}}
 
@@ -133,7 +136,7 @@ ExecReload=/bin/kill -s HUP $MAINPID
 
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.
-LimitNOFILE=infinity
+LimitNOFILE=1048576
 LimitNPROC=infinity
 LimitCORE=infinity
 
@@ -160,6 +163,7 @@ WantedBy=multi-user.target
 		DockerPort:    dockerPort,
 		AuthOptions:   p.AuthOptions,
 		EngineOptions: p.EngineOptions,
+		//	OpenFilesMax:  cruntime.OpenFilesLimit,
 	}
 
 	escapeSystemdDirectives(&engineConfigContext)

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -93,6 +93,7 @@ func TestFunctional(t *testing.T) {
 			{"PersistentVolumeClaim", validatePersistentVolumeClaim},
 			{"TunnelCmd", validateTunnelCmd},
 			{"SSHCmd", validateSSHCmd},
+			{"MySQL", validateMySQL},
 		}
 		for _, tc := range tests {
 			tc := tc
@@ -284,7 +285,7 @@ func validateCacheCmd(ctx context.Context, t *testing.T, profile string) {
 	if NoneDriver() {
 		t.Skipf("skipping: cache unsupported by none")
 	}
-	for _, img := range []string{"busybox", "busybox:1.28.4-glibc"} {
+	for _, img := range []string{"busybox", "busybox:1.28.4-glibc", "mysql:5.6"} {
 		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "cache", "add", img))
 		if err != nil {
 			t.Errorf("%s failed: %v", rr.Args, err)
@@ -462,6 +463,24 @@ func validateSSHCmd(ctx context.Context, t *testing.T, profile string) {
 	}
 	if rr.Stdout.String() != want {
 		t.Errorf("%v = %q, want = %q", rr.Args, rr.Stdout.String(), want)
+	}
+}
+
+// validateMySQL validates a minimalist MySQL deployment
+func validateMySQL(ctx context.Context, t *testing.T, profile string) {
+	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "replace", "--force", "-f", filepath.Join(*testdataDir, "mysql.yaml")))
+	if err != nil {
+		t.Fatalf("%s failed: %v", rr.Args, err)
+	}
+
+	names, err := PodWait(ctx, t, profile, "default", "app=mysql", 2*time.Minute)
+	if err != nil {
+		t.Errorf("nginx: %v", err)
+	}
+
+	rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "exec", names[0], "--", "mysql", "-ppassword", "-e", "show databases;"))
+	if err != nil {
+		t.Fatalf("%s failed: %v", rr.Args, err)
 	}
 }
 

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -123,7 +123,7 @@ func TestStartStop(t *testing.T) {
 					// Arbitrary value set by some container runtimes. If higher, apps like MySQL may make bad decisions.
 					expected := int64(cruntime.OpenFilesMax)
 					if got != expected {
-						t.Errorf("got max-files=%d, expected %d", got, expected)
+						t.Errorf("'ulimit -n' returned %d, expected %d", got, expected)
 					}
 				}
 

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/docker/machine/libmachine/state"
 	"k8s.io/minikube/pkg/minikube/constants"
-	"k8s.io/minikube/pkg/minikube/cruntime"
 )
 
 func TestStartStop(t *testing.T) {
@@ -121,7 +120,7 @@ func TestStartStop(t *testing.T) {
 					}
 
 					// Arbitrary value set by some container runtimes. If higher, apps like MySQL may make bad decisions.
-					expected := int64(cruntime.OpenFilesMax)
+					expected := int64(1048576)
 					if got != expected {
 						t.Errorf("'ulimit -n' returned %d, expected %d", got, expected)
 					}

--- a/test/integration/testdata/mysql.yaml
+++ b/test/integration/testdata/mysql.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+spec:
+  ports:
+  - port: 3306
+  selector:
+    app: mysql
+---
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+kind: Deployment
+metadata:
+  name: mysql
+spec:
+  selector:
+    matchLabels:
+      app: mysql
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+      - image: mysql:5.6
+        name: mysql
+        env:
+          # Use secret in real usage
+        - name: MYSQL_ROOT_PASSWORD
+          value: password
+        ports:
+        - containerPort: 3306
+          name: mysql


### PR DESCRIPTION
Work in progress, designed to fix #5751

Unfortunately, there did not appear to be a viable approach that does not involve programming each container runtime. Thankfully, it seems like only Docker diverged.