### PR TITLE
Used fixed uid/gid for the default user account

### DIFF
--- a/deploy/iso/minikube-iso/board/coreos/minikube/users
+++ b/deploy/iso/minikube-iso/board/coreos/minikube/users
@@ -1,1 +1,1 @@
-docker -1 docker -1 =tcuser /home/docker /bin/bash wheel,vboxsf -
+docker 1000 docker 1000 =tcuser /home/docker /bin/bash wheel,vboxsf -


### PR DESCRIPTION
Buildroot now defaults to allocating the package users first,
and the defined users later which means they get higher ids.

In order for the default "docker" user to have the uid/gid as
in previous versions, set it explicitly (to the first: 1000)

Closes #5755 
Tested locally.