### PR TITLE
CI experiment: Move gvisor testing behind a flag, double timeout

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -262,6 +262,7 @@ ${SUDO_PREFIX}${E2E_BIN} \
   -expected-default-driver="${EXPECTED_DEFAULT_DRIVER}" \
   -test.timeout=60m \
   -test.parallel=${PARALLEL_COUNT} \
+  ${EXTRA_TEST_ARGS} \
   -binary="${MINIKUBE_BIN}" && result=$? || result=$?
 set +x
 echo ">> ${E2E_BIN} exited with ${result} at $(date)"

--- a/hack/jenkins/linux_integration_tests_kvm.sh
+++ b/hack/jenkins/linux_integration_tests_kvm.sh
@@ -31,5 +31,8 @@ JOB_NAME="KVM_Linux"
 PARALLEL_COUNT=4
 EXPECTED_DEFAULT_DRIVER="kvm2"
 
+# We pick kvm as our gvisor testbed because it is fast & reliable
+EXTRA_TEST_ARGS="-gvisor"
+
 # Download files and set permissions
 source ./common.sh

--- a/test/integration/gvisor_addon_test.go
+++ b/test/integration/gvisor_addon_test.go
@@ -30,10 +30,14 @@ func TestGvisorAddon(t *testing.T) {
 	if NoneDriver() {
 		t.Skip("Can't run containerd backend with none driver")
 	}
+	if !*enableGvisor {
+		t.Skip("skipping test because --gvisor=false")
+	}
+
 	MaybeSlowParallel(t)
 
 	profile := UniqueProfileName("gvisor")
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Minute)
 	defer func() {
 		if t.Failed() {
 			rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "logs", "gvisor", "-n", "kube-system"))

--- a/test/integration/main.go
+++ b/test/integration/main.go
@@ -32,6 +32,7 @@ var defaultDriver = flag.String("expected-default-driver", "", "Expected default
 // Flags for faster local integration testing
 var forceProfile = flag.String("profile", "", "force tests to run against a particular profile")
 var cleanup = flag.Bool("cleanup", true, "cleanup failed test run")
+var enableGvisor = flag.Bool("gvisor", false, "run gvisor integration test (slow)")
 var postMortemLogs = flag.Bool("postmortem-logs", true, "show logs after a failed test run")
 
 // Paths to files - normally set for CI


### PR DESCRIPTION
gvisor tests run slowly, and don't need to run on every hypervisor. This keeps the test running on kvm2 CI, but not by default elsewhere.