### PR TITLE
Improve reliability of TestStartStop with none driver

### DIFF
--- a/hack/jenkins/linux_integration_tests_none.sh
+++ b/hack/jenkins/linux_integration_tests_none.sh
@@ -37,9 +37,10 @@ SUDO_PREFIX="sudo -E "
 export KUBECONFIG="/root/.kube/config"
 
 # "none" driver specific cleanup from previous runs.
+sudo kubeadm reset -f || true
+# kubeadm reset may not stop pods immediately
+docker rm -f $(docker ps -aq) >/dev/null 2>&1 || true
 
-# Try without -f first, primarily because older kubeadm versions (v1.10) don't support it anyways.
-sudo kubeadm reset || sudo kubeadm reset -f || true
 # Cleanup data directory
 sudo rm -rf /data/*
 # Cleanup old Kubernetes configs

--- a/test/integration/helpers.go
+++ b/test/integration/helpers.go
@@ -227,9 +227,8 @@ func PodWait(ctx context.Context, t *testing.T, profile string, ns string, selec
 	f := func() (bool, error) {
 		pods, err := client.CoreV1().Pods(ns).List(listOpts)
 		if err != nil {
-			t.Logf("Pod(%s).List(%v) returned error: %v", ns, selector, err)
-			// Don't bother to retry: something is very wrong.
-			return true, err
+			t.Logf("WARNING: Pod(%s).List(%v) returned error: %v", ns, selector, err)
+			return false, err
 		}
 		if len(pods.Items) == 0 {
 			podStart = time.Time{}

--- a/test/integration/helpers.go
+++ b/test/integration/helpers.go
@@ -227,7 +227,7 @@ func PodWait(ctx context.Context, t *testing.T, profile string, ns string, selec
 	f := func() (bool, error) {
 		pods, err := client.CoreV1().Pods(ns).List(listOpts)
 		if err != nil {
-			t.Logf("WARNING: Pod(%s).List(%v) returned error: %v", ns, selector, err)
+			t.Logf("WARNING: pod list for %q %q returned: %v", ns, selector, err)
 			return false, err
 		}
 		if len(pods.Items) == 0 {

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -103,7 +103,7 @@ func TestStartStop(t *testing.T) {
 						t.Fatalf("%s failed: %v", rr.Args, err)
 					}
 
-					names, err := PodWait(ctx, t, profile, "default", "integration-test=busybox", 4*time.Minute);
+					names, err := PodWait(ctx, t, profile, "default", "integration-test=busybox", 4*time.Minute)
 					if err != nil {
 						t.Fatalf("wait: %v", err)
 					}

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -103,7 +103,8 @@ func TestStartStop(t *testing.T) {
 						t.Fatalf("%s failed: %v", rr.Args, err)
 					}
 
-					if _, err := PodWait(ctx, t, profile, "default", "integration-test=busybox", 4*time.Minute); err != nil {
+					names, err := PodWait(ctx, t, profile, "default", "integration-test=busybox", 4*time.Minute);
+					if err != nil {
 						t.Fatalf("wait: %v", err)
 					}
 

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -85,7 +85,7 @@ func TestStartStop(t *testing.T) {
 				ctx, cancel := context.WithTimeout(context.Background(), 40*time.Minute)
 				defer CleanupWithLogs(t, profile, cancel)
 
-				startArgs := append([]string{"start", "-p", profile, "--alsologtostderr", "-v=3", "--wait"}, tc.args...)
+				startArgs := append([]string{"start", "-p", profile, "--alsologtostderr", "-v=3", "--wait=true"}, tc.args...)
 				startArgs = append(startArgs, StartArgs()...)
 				rr, err := Run(t, exec.CommandContext(ctx, Target(), startArgs...))
 				if err != nil {

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -85,7 +85,7 @@ func TestStartStop(t *testing.T) {
 				ctx, cancel := context.WithTimeout(context.Background(), 40*time.Minute)
 				defer CleanupWithLogs(t, profile, cancel)
 
-				startArgs := append([]string{"start", "-p", profile, "--alsologtostderr", "-v=3"}, tc.args...)
+				startArgs := append([]string{"start", "-p", profile, "--alsologtostderr", "-v=3", "--wait"}, tc.args...)
 				startArgs = append(startArgs, StartArgs()...)
 				rr, err := Run(t, exec.CommandContext(ctx, Target(), startArgs...))
 				if err != nil {
@@ -103,8 +103,7 @@ func TestStartStop(t *testing.T) {
 						t.Fatalf("%s failed: %v", rr.Args, err)
 					}
 
-					names, err := PodWait(ctx, t, profile, "default", "integration-test=busybox", 2*time.Minute)
-					if err != nil {
+					if _, err := PodWait(ctx, t, profile, "default", "integration-test=busybox", 4*time.Minute); err != nil {
 						t.Fatalf("wait: %v", err)
 					}
 


### PR DESCRIPTION
When you restart a `none` cluster, the old apiserver may be running for a moment, and get rescheduled with the new config. Add `--wait` so that the delay is a bit longer, and retry the List operation if it fails.