### PR TITLE
CI: kill VboxHeadless processes, move load warning until after cleanup

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -42,21 +42,6 @@ echo "uptime:    $(uptime)"
 echo "kubectl:   $(env KUBECONFIG=${TEST_HOME} kubectl version --client --short=true)"
 echo "docker:    $(docker version --format '{{ .Client.Version }}')"
 
-readonly LOAD=$(uptime | egrep -o "load average.*: [0-9]" | cut -d" " -f3)
-if [[ "${LOAD}" -gt 2 ]]; then
-  echo ""
-  echo "********************** LOAD WARNING ********************************"
-  echo "Load average is very high (${LOAD}), which may cause failures. Top:"
-  if [[ "$(uname)" == "Darwin" ]]; then
-    # Two samples, macOS does not calculate CPU usage on the first one
-    top -l 2 -o cpu -n 5 | tail -n 15
-  else
-    top -b -n1 | head -n 15
-  fi
-  echo "********************** LOAD WARNING ********************************"
-  echo ""
-fi
-
 case "${VM_DRIVER}" in
   kvm2)
     echo "virsh:     $(virsh --version)"
@@ -159,6 +144,10 @@ if type -P virsh; then
 fi
 
 if type -P vboxmanage; then
+  killall VBoxHeadless || true
+  sleep 1
+  killall -9 VBoxHeadless || true
+
   for guid in $(vboxmanage list vms | grep -Eo '\{[a-zA-Z0-9-]+\}'); do
     echo "- Removing stale VirtualBox VM: $guid"
     vboxmanage startvm "${guid}" --type emergencystop || true
@@ -253,6 +242,25 @@ if [ "$(uname)" != "Darwin" ]; then
   # Should match GVISOR_IMAGE_VERSION in Makefile
   docker build -t gcr.io/k8s-minikube/gvisor-addon:2 -f testdata/gvisor-addon-Dockerfile ./testdata
 fi
+
+readonly LOAD=$(uptime | egrep -o "load average.*: [0-9]" | cut -d" " -f3)
+if [[ "${LOAD}" -gt 2 ]]; then
+  echo ""
+  echo "********************** LOAD WARNING ********************************"
+  echo "Load average is very high (${LOAD}), which may cause failures. Top:"
+  if [[ "$(uname)" == "Darwin" ]]; then
+    # Two samples, macOS does not calculate CPU usage on the first one
+    top -l 2 -o cpu -n 5 | tail -n 15
+  else
+    top -b -n1 | head -n 15
+  fi
+  echo "********************** LOAD WARNING ********************************"
+  echo ""
+  echo "Sleeping 30s to see if load goes down ...."
+  sleep 30
+  uptime
+fi
+
 
 echo ""
 echo ">> Starting ${E2E_BIN} at $(date)"


### PR DESCRIPTION
Addresses issues seen on kvm-4 in https://storage.googleapis.com/minikube-builds/logs/5782/KVM_Linux.txt

The VirtualBox machines couldn't be removed:

```
- Removing stale VirtualBox VM: {fd3ac818-f5a8-4876-b402-453d5573124f}
VBoxManage: error: Cannot unregister the machine 'functional-20191029T200241.950005188-26134' while it is locked
VBoxManage: error: Details: code VBOX_E_INVALID_OBJECT_STATE (0x80bb0007), component MachineWrap, interface IMachine, callee nsISupports
VBoxManage: error: Context: "Unregister(CleanupMode_DetachAllReturnHardDisksOnly, ComSafeArrayAsOutParam(aMedia))" at line 157 of file VBoxManageMisc.cpp
- Removing stale VirtualBox VM: {bcebd014-23e6-47cb-953a-a83ce75fa8ea}
VBoxManage: error: Cannot unregister the machine 'addons-20191029T201008.785359865-26134' while it is locked
VBoxManage: error: Details: code VBOX_E_INVALID_OBJECT_STATE (0x80bb0007), component MachineWrap, interface IMachine, callee nsISupports
VBoxManage: error: Context: "Unregister(CleanupMode_DetachAllReturnHardDisksOnly, ComSafeArrayAsOutParam(aMedia))" at line 157 of file VBoxManageMisc.cpp
- Removing stale VirtualBox VM: {c1216c1d-9ccc-4f9a-9659-b20610c6384c}
VBoxManage: error: Cannot unregister the machine 'docker-20191029T202302.672022203-26134' while it is locked
VBoxManage: error: Details: code VBOX_E_INVALID_OBJECT_STATE (0x80bb0007), component MachineWrap, interface IMachine, callee nsISupports
VBoxManage: error: Context: "Unregister(CleanupMode_DetachAllReturnHardDisksOnly, ComSafeArrayAsOutParam(aMedia))" at line 157 of file VBoxManageMisc.cpp
- Removing stale VirtualBox VM: {881c3bc7-0f23-4eba-9b39-59509e926184}
VBoxManage: error: Cannot unregister the machine 'crio-20191029T202646.864114594-26134' while it is locked
VBoxManage: error: Details: code VBOX_E_INVALID_OBJECT_STATE (0x80bb0007), component MachineWrap, interface IMachine, callee nsISupports
VBoxManage: error: Context: "Unregister(CleanupMode_DetachAllReturnHardDisksOnly, ComSafeArrayAsOutParam(aMedia))" at line 157 of file VBoxManageMisc.cpp
- Removing stale VirtualBox VM: {30cdab36-5195-4f0c-a943-2dd89650491a}
VBoxManage: error: Cannot unregister the machine 'containerd-20191029T204022.525468888-26134' while it is locked
VBoxManage: error: Details: code VBOX_E_INVALID_OBJECT_STATE (0x80bb0007), component MachineWrap, interface IMachine, callee nsISupports
VBoxManage: error: Context: "Unregister(CleanupMode_DetachAllReturnHardDisksOnly, ComSafeArrayAsOutParam(aMedia))" at line 157 of file VBoxManageMisc.cpp
- Removing stale VirtualBox VM: {16e8dfc4-ec19-46fb-aa0d-5914f30acb4a}
VBoxManage: error: Cannot unregister the machine 'cni-20191029T205947.515644781-26134' while it is locked
VBoxManage: error: Details: code VBOX_E_INVALID_OBJECT_STATE (0x80bb0007), component MachineWrap, interface IMachine, callee nsISupports
VBoxManage: error: Context: "Unregister(CleanupMode_DetachAllReturnHardDisksOnly, ComSafeArrayAsOutParam(aMedia))" at line 157 of file VBoxManageMisc.cpp
0%...10%...20%...30%...40%...50%...60%...70%...80%...90%...100%
>> VirtualBox VM list after clean up (should be empty):
"functional-20191029T200241.950005188-26134" {fd3ac818-f5a8-4876-b402-453d5573124f}
"addons-20191029T201008.785359865-26134" {bcebd014-23e6-47cb-953a-a83ce75fa8ea}
"docker-20191029T202302.672022203-26134" {c1216c1d-9ccc-4f9a-9659-b20610c6384c}
"crio-20191029T202646.864114594-26134" {881c3bc7-0f23-4eba-9b39-59509e926184}
"containerd-20191029T204022.525468888-26134" {30cdab36-5195-4f0c-a943-2dd89650491a}
"cni-20191029T205947.515644781-26134" {16e8dfc4-ec19-46fb-aa0d-5914f30acb4a}
```

But they were taking up load for the last 16 hours:

```
top - 22:53:05 up 5 days,  7:45,  1 user,  load average: 10.04, 10.15, 7.62
Tasks: 159 total,   1 running, 155 sleeping,   0 stopped,   3 zombie
%Cpu(s):  2.2 us, 24.7 sy,  0.0 ni, 72.4 id,  0.6 wa,  0.0 hi,  0.1 si,  0.0 st
KiB Mem : 21597300 total,  3990232 free, 11395696 used,  6211372 buff/cache
KiB Swap:        0 total,        0 free,        0 used.  9624276 avail Mem 

  PID USER      PR  NI    VIRT    RES    SHR S  %CPU %MEM     TIME+ COMMAND                                                                                                                                                                                                           
25342 jenkins   20   0 3600164  92588  46860 S 177.8  0.4  17:37.74 VBoxHeadless                                                                                                                                                                                                      
25207 jenkins   20   0 3602212  92452  46812 S 166.7  0.4  16:40.64 VBoxHeadless                                                                                                                                                                                                      
25471 jenkins   20   0 3606308  91872  46540 S 166.7  0.4  16:55.80 VBoxHeadless                                                                                                                                                                                                      
26386 jenkins   20   0 3600164  92240  47328 S  94.4  0.4  10:58.57 VBoxHeadless                                                                                                                                                                                                      
24850 jenkins   20   0 3596068  92336  47240 S  88.9  0.4  15:41.79 VBoxHeadless  
```