### PR TITLE
wip: change ubuntu to alpine in gvisor test dockerfile

### DIFF
--- a/test/integration/testdata/gvisor-addon-Dockerfile
+++ b/test/integration/testdata/gvisor-addon-Dockerfile
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:18.04
-RUN apt-get update && \
-    apt-get install -y kmod gcc wget xz-utils libc6-dev bc libelf-dev bison flex openssl libssl-dev libidn2-0 sudo libcap2 && \
-    rm -rf /var/lib/apt/lists/*
-COPY gvisor-addon /gvisor-addon
+# Need an image with chroot
+FROM alpine:3
+COPY out/gvisor-addon /gvisor-addon
 CMD ["/gvisor-addon"]

--- a/test/integration/testdata/gvisor-addon-Dockerfile
+++ b/test/integration/testdata/gvisor-addon-Dockerfile
@@ -14,5 +14,5 @@
 
 # Need an image with chroot
 FROM alpine:3
-COPY out/gvisor-addon /gvisor-addon
+COPY gvisor-addon /gvisor-addon
 CMD ["/gvisor-addon"]


### PR DESCRIPTION
I noticed in the integration test logs, it is still building a big ubuntu image:
```
22:54:03 Sending build context to Docker daemon  210.4MB

22:54:03 Step 1/4 : FROM ubuntu:18.04
22:54:03  ---> 4c108a37151f
22:54:03 Step 2/4 : RUN apt-get update &&     apt-get install -y kmod gcc wget xz-utils libc6-dev bc libelf-dev bison flex openssl libssl-dev libidn2-0 sudo libcap2 &&     rm -rf /var/lib/apt/lists/*
22:54:03  ---> Using cache
22:54:03  ---> 1fd0811e2ff3
22:54:03 Step 3/4 : COPY gvisor-addon /gvisor-addon
22:54:04  ---> f185c5047461
22:54:04 Step 4/4 : CMD ["/gvisor-addon"]
22:54:04  ---> Running in 1db26e775224
22:54:04 Removing intermediate container 1db26e775224
22:54:04  ---> 7cb41af9b424
22:54:04 Successfully built 7cb41af9b424
22:54:04 Successfully tagged gcr.io/k8s-minikube/gvisor-addon:2
22:54:04 
```

the gvisor dockefile was changed to alpine but the test data one was not changed .
