### PR TITLE
service: fix --url mode, add integration tests

### DIFF
--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -83,7 +83,7 @@ var serviceCmd = &cobra.Command{
 		for _, u := range urls {
 			_, err := url.Parse(u)
 			if err != nil {
-				glog.Warningf("unable to parse %s: %v (will not open)", u, err)
+				glog.Warningf("failed to parse url %q: %v (will not open)", u, err)
 				out.String(fmt.Sprintf("%s\n", u))
 				continue
 			}

--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -18,17 +18,18 @@ package cmd
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"text/template"
 
+	"github.com/golang/glog"
 	"github.com/pkg/browser"
-
-	"k8s.io/minikube/pkg/minikube/out"
-
 	"github.com/spf13/cobra"
+
 	"k8s.io/minikube/pkg/minikube/cluster"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/machine"
+	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/service"
 )
 
@@ -74,21 +75,26 @@ var serviceCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		var urlString []string
-
-		urlString, err = service.WaitForService(api, namespace, svc,
-			serviceURLTemplate, serviceURLMode, https, wait, interval)
+		urls, err := service.WaitForService(api, namespace, svc, serviceURLTemplate, serviceURLMode, https, wait, interval)
 		if err != nil {
 			exit.WithError("Error opening service", err)
 		}
 
-		if len(urlString) != 0 {
-			out.T(out.Celebrate, "Opening kubernetes service  {{.namespace_name}}/{{.service_name}} in default browser...", out.V{"namespace_name": namespace, "service_name": svc})
+		for _, u := range urls {
+			_, err := url.Parse(u)
+			if err != nil {
+				glog.Warning("could not parse %v (will not open)", u, err)
+				out.String(u)
+				continue
+			}
 
-			for _, url := range urlString {
-				if err := browser.OpenURL(url); err != nil {
-					exit.WithError(fmt.Sprintf("browser failed to open url %s", url), err)
-				}
+			if serviceURLMode {
+				out.String(u)
+				continue
+			}
+			out.T(out.Celebrate, "Opening service {{.namespace_name}}/{{.service_name}} in default browser...", out.V{"namespace_name": namespace, "service_name": svc})
+			if err := browser.OpenURL(u); err != nil {
+				exit.WithError(fmt.Sprintf("open url failed: %s", u), err)
 			}
 		}
 	},

--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -83,7 +83,7 @@ var serviceCmd = &cobra.Command{
 		for _, u := range urls {
 			_, err := url.Parse(u)
 			if err != nil {
-				glog.Warning("could not parse %v (will not open)", u, err)
+				glog.Warning("unable to parse %s: %v (will not open)", u, err)
 				out.String(fmt.Sprintf("%s\n", u))
 				continue
 			}

--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -83,7 +83,7 @@ var serviceCmd = &cobra.Command{
 		for _, u := range urls {
 			_, err := url.Parse(u)
 			if err != nil {
-				glog.Warning("unable to parse %s: %v (will not open)", u, err)
+				glog.Warningf("unable to parse %s: %v (will not open)", u, err)
 				out.String(fmt.Sprintf("%s\n", u))
 				continue
 			}

--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -84,12 +84,12 @@ var serviceCmd = &cobra.Command{
 			_, err := url.Parse(u)
 			if err != nil {
 				glog.Warning("could not parse %v (will not open)", u, err)
-				out.String(u)
+				out.String(fmt.Sprintf("%s\n", u))
 				continue
 			}
 
 			if serviceURLMode {
-				out.String(u)
+				out.String(fmt.Sprintf("%s\n", u))
 				continue
 			}
 			out.T(out.Celebrate, "Opening service {{.namespace_name}}/{{.service_name}} in default browser...", out.V{"namespace_name": namespace, "service_name": svc})

--- a/pkg/minikube/service/service.go
+++ b/pkg/minikube/service/service.go
@@ -300,12 +300,8 @@ func WaitForService(api libmachine.API, namespace string, service string, urlTem
 	}
 
 	for _, bareURLString := range serviceURL.URLs {
-		url, isHTTPSchemedURL := OptionallyHTTPSFormattedURLString(bareURLString, https)
-
-		if urlMode || !isHTTPSchemedURL {
-			out.T(out.Empty, url)
-			urlList = append(urlList, url)
-		}
+		url, _ := OptionallyHTTPSFormattedURLString(bareURLString, https)
+		urlList = append(urlList, url)
 	}
 	return urlList, nil
 }


### PR DESCRIPTION
The service command was opening URL's, even if `--url` mode was specified. This was caused by a subtle regression in #5718

Fixes #5789