### PR TITLE
Fix pod list retry, reset start timer

### DIFF
--- a/test/integration/helpers.go
+++ b/test/integration/helpers.go
@@ -228,7 +228,9 @@ func PodWait(ctx context.Context, t *testing.T, profile string, ns string, selec
 		pods, err := client.CoreV1().Pods(ns).List(listOpts)
 		if err != nil {
 			t.Logf("WARNING: pod list for %q %q returned: %v", ns, selector, err)
-			return false, err
+			// Don't return the error upwards so that this is retried, in case the apiserver is rescheduled
+			podStart = time.Time{}
+			return false, nil
 		}
 		if len(pods.Items) == 0 {
 			podStart = time.Time{}


### PR DESCRIPTION
Because pod.List was returning an error, it wasn't being retried.

Addresses issue seen on https://storage.googleapis.com/minikube-builds/logs/5790/none_Linux.txt - where the apiserver may be restarting with the none driver when calling start/stop. 