### PR TITLE
Make Kubernetes version sticky for a cluster instead of auto-upgrading

### DIFF
--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -22,8 +22,63 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	cfg "k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 )
+
+func TestGetKuberneterVersion(t *testing.T) {
+	var tests = []struct {
+		description     string
+		expectedVersion string
+		paramVersion    string
+		upgrade         bool
+		cfg             *cfg.MachineConfig
+	}{
+		{
+			description:     "kubernetes-version not given, no config",
+			expectedVersion: constants.DefaultKubernetesVersion,
+			paramVersion:    "",
+			upgrade:         false,
+		},
+		{
+			description:     "kubernetes-version not given, config available",
+			expectedVersion: "v1.15.0",
+			paramVersion:    "",
+			upgrade:         false,
+			cfg:             &cfg.MachineConfig{KubernetesConfig: cfg.KubernetesConfig{KubernetesVersion: "v1.15.0"}},
+		},
+		{
+			description:     "kubernetes-version given, no config",
+			expectedVersion: "v1.15.0",
+			paramVersion:    "v1.15.0",
+			upgrade:         false,
+		},
+		{
+			description:     "kubernetes-version given, config available",
+			expectedVersion: "v1.16.0",
+			paramVersion:    "v1.16.0",
+			upgrade:         true,
+			cfg:             &cfg.MachineConfig{KubernetesConfig: cfg.KubernetesConfig{KubernetesVersion: "v1.15.0"}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			viper.SetDefault(kubernetesVersion, test.paramVersion)
+			version, upgrade := getKubernetesVersion(test.cfg)
+
+			// check whether we are getting the expected version
+			if version != test.expectedVersion {
+				t.Fatalf("test failed because the expected version %s is not returned", test.expectedVersion)
+			}
+
+			// check whether the upgrade flag is correct
+			if test.upgrade != upgrade {
+				t.Fatalf("test failed expected upgrade is %t", test.upgrade)
+			}
+		})
+	}
+}
 
 func TestGenerateCfgFromFlagsHTTPProxyHandling(t *testing.T) {
 	viper.SetDefault(memory, defaultMemorySize)


### PR DESCRIPTION
#2570 

The fix should do the following 

* Not specifying the --kubernetes-version flag means just use the currently deployed version.
* If an update is available inform the user that they may use --kubernetes-version=<version>.
* When --kubernetes-version is specifically set, upgrade the cluster.