### PR TITLE
Disable brew cask updater

### DIFF
--- a/hack/jenkins/release_update_brew.sh
+++ b/hack/jenkins/release_update_brew.sh
@@ -39,6 +39,11 @@ if [ -z "${NEW_SHA256}" ]; then
   exit 1
 fi
 
+echo "***********************************************************************"
+echo "Sorry, this script has not yet been updated to support non-cask updates"
+echo "See https://github.com/kubernetes/minikube/issues/5779"
+echo "***********************************************************************"
+
 git config --global user.name "${GITHUB_USER}"
 git config --global user.email "${GITHUB_USER}@google.com"
 

--- a/hack/jenkins/release_update_brew.sh
+++ b/hack/jenkins/release_update_brew.sh
@@ -43,6 +43,7 @@ echo "***********************************************************************"
 echo "Sorry, this script has not yet been updated to support non-cask updates"
 echo "See https://github.com/kubernetes/minikube/issues/5779"
 echo "***********************************************************************"
+exit 99
 
 git config --global user.name "${GITHUB_USER}"
 git config --global user.email "${GITHUB_USER}@google.com"


### PR DESCRIPTION
minikube is now in brew proper, rather than Cask.

This script will need to be updated or replaced with an update for brew proper.

See #5779
