### PR TITLE
Fix spelling of HTML for golint on bindata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,6 +261,8 @@ endif
 	-gofmt -s -w $@
 	@#golint: Dns should be DNS (compat sed)
 	@sed -i -e 's/Dns/DNS/g' $@ && rm -f ./-e
+	@#golint: Html should be HTML (compat sed)
+	@sed -i -e 's/Html/HTML/g' $@ && rm -f ./-e
 
 pkg/minikube/translate/translations.go: $(shell find "translations/" -type f)
 ifeq ($(MINIKUBE_BUILD_IN_DOCKER),y)


### PR DESCRIPTION
Missed one addition to the assets.go, in the previous PR (#5679)