### PR TITLE
Silence virtualbox registry check

### DIFF
--- a/pkg/minikube/driver/driver_windows.go
+++ b/pkg/minikube/driver/driver_windows.go
@@ -80,7 +80,6 @@ func findVBoxInstallDirInRegistry() (string, error) {
 	installDir, _, err := registryKey.GetStringValue("InstallDir")
 	if err != nil {
 		errorMessage := fmt.Sprintf("Can't find InstallDir registry key within VirtualBox registries entries, is VirtualBox really installed properly? %v", err)
-		glog.Errorf(errorMessage)
 		return "", errors.New(errorMessage)
 	}
 


### PR DESCRIPTION
As seen in #5838 

Functions should either log errors, or pass them upwards, but not both.