### PR TITLE
Prevent minikube from crashing if namespace or service doesn't exist

### DIFF
--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -104,7 +104,7 @@ var serviceCmd = &cobra.Command{
 
 		urls, err := service.WaitForService(api, namespace, svc, serviceURLTemplate, serviceURLMode, https, wait, interval)
 		if err != nil {
-			exit.WithError("Error opening service", err)
+			exit.WithCodeT(exit.Data, fmt.Sprintf("Error opening service: %s", err))
 		}
 
 		openURLs(svc, urls)

--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -56,6 +57,14 @@ var (
 	wait               int
 	interval           int
 )
+
+// type serviceNotFoundError struct {
+// 	Err error
+// }
+
+// func (t serviceNotFoundError) Error() string {
+// 	return "Service not found: " + t.Err.Error()
+// }
 
 // serviceCmd represents the service command
 var serviceCmd = &cobra.Command{
@@ -104,7 +113,8 @@ var serviceCmd = &cobra.Command{
 
 		urls, err := service.WaitForService(api, namespace, svc, serviceURLTemplate, serviceURLMode, https, wait, interval)
 		if err != nil {
-			if err.Error() == "Service not found in namespace" {
+			var s *service.SVCNotFoundError
+			if errors.As(err, &s) {
 				exit.WithCodeT(exit.Data, `Service '{{.service}}' was not found in '{{.namespace}}' namespace.
 You may select another namespace by using 'minikube service {{.service}} -n <namespace>'. Or list out all the services using 'minikube service list'`, out.V{"service": svc, "namespace": namespace})
 			}

--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -104,7 +104,7 @@ var serviceCmd = &cobra.Command{
 
 		urls, err := service.WaitForService(api, namespace, svc, serviceURLTemplate, serviceURLMode, https, wait, interval)
 		if err != nil {
-			exit.WithCodeT(exit.Data, fmt.Sprintf("Error opening service: %s", err))
+			exit.WithCodeT(exit.Data, `Error opening service: {{.error}}`, out.V{"error": err})
 		}
 
 		openURLs(svc, urls)

--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -58,14 +58,6 @@ var (
 	interval           int
 )
 
-// type serviceNotFoundError struct {
-// 	Err error
-// }
-
-// func (t serviceNotFoundError) Error() string {
-// 	return "Service not found: " + t.Err.Error()
-// }
-
 // serviceCmd represents the service command
 var serviceCmd = &cobra.Command{
 	Use:   "service [flags] SERVICE",

--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -104,7 +104,11 @@ var serviceCmd = &cobra.Command{
 
 		urls, err := service.WaitForService(api, namespace, svc, serviceURLTemplate, serviceURLMode, https, wait, interval)
 		if err != nil {
-			exit.WithCodeT(exit.Data, `Error opening service: {{.error}}`, out.V{"error": err})
+			if err.Error() == "Service not found in namespace" {
+				exit.WithCodeT(exit.Data, `Service '{{.service}}' was not found in '{{.namespace}}' namespace.
+You may select another namespace by using 'minikube service {{.service}} -n <namespace>'. Or list out all the services using 'minikube service list'`, out.V{"service": svc, "namespace": namespace})
+			}
+			exit.WithError("Error opening service", err)
 		}
 
 		openURLs(svc, urls)

--- a/pkg/minikube/service/service.go
+++ b/pkg/minikube/service/service.go
@@ -276,7 +276,7 @@ func WaitForService(api libmachine.API, namespace string, service string, urlTem
 	chkSVC := func() error { return CheckService(namespace, service) }
 
 	if err := retry.Expo(chkSVC, time.Duration(interval)*time.Second, time.Duration(wait)*time.Second); err != nil {
-		return urlList, errors.Wrapf(err, "Service %s was not found in %q namespace. You may select another namespace by using 'minikube service %s -n <namespace>", service, namespace, service)
+		return urlList, errors.Wrapf(err, "Service %s was not found in %q namespace. You may select another namespace by using 'minikube service %s -n <namespace>'. Or list out all the services using 'minikube service list'", service, namespace, service)
 	}
 
 	serviceURL, err := GetServiceURLsForService(api, namespace, service, urlTemplate)

--- a/pkg/minikube/service/service.go
+++ b/pkg/minikube/service/service.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"net/url"
 	"os"
-	"sort"
 	"strings"
 	"text/template"
 	"time"
@@ -283,12 +282,9 @@ func WaitForService(api libmachine.API, namespace string, service string, urlTem
 	if interval == 0 {
 		interval = 1
 	}
-	services, err := GetServiceURLs(api, namespace, urlTemplate)
+
+	err := CheckService(namespace, service)
 	if err != nil {
-		return nil, err
-	}
-	searchServices := sort.Search(len(services), func(i int) bool { return services[i].Name == service })
-	if searchServices == len(services) {
 		return nil, &SVCNotFoundError{err}
 	}
 

--- a/pkg/minikube/service/service.go
+++ b/pkg/minikube/service/service.go
@@ -276,8 +276,7 @@ func WaitForService(api libmachine.API, namespace string, service string, urlTem
 	chkSVC := func() error { return CheckService(namespace, service) }
 
 	if err := retry.Expo(chkSVC, time.Duration(interval)*time.Second, time.Duration(wait)*time.Second); err != nil {
-		return urlList, errors.Errorf(`Service %s was not found in %q namespace. 
-You may select another namespace by using 'minikube service %s -n <namespace>'. Or list out all the services using 'minikube service list'`, service, namespace, service)
+		return nil, errors.New("Service not found in namespace")
 	}
 
 	serviceURL, err := GetServiceURLsForService(api, namespace, service, urlTemplate)

--- a/pkg/minikube/service/service.go
+++ b/pkg/minikube/service/service.go
@@ -276,7 +276,8 @@ func WaitForService(api libmachine.API, namespace string, service string, urlTem
 	chkSVC := func() error { return CheckService(namespace, service) }
 
 	if err := retry.Expo(chkSVC, time.Duration(interval)*time.Second, time.Duration(wait)*time.Second); err != nil {
-		return urlList, errors.Wrapf(err, "Service %s was not found in %q namespace. You may select another namespace by using 'minikube service %s -n <namespace>'. Or list out all the services using 'minikube service list'", service, namespace, service)
+		return urlList, errors.Errorf(`Service %s was not found in %q namespace. 
+You may select another namespace by using 'minikube service %s -n <namespace>'. Or list out all the services using 'minikube service list'`, service, namespace, service)
 	}
 
 	serviceURL, err := GetServiceURLsForService(api, namespace, service, urlTemplate)


### PR DESCRIPTION
Fixes issue #5836 

## Old behavior
```
$ minikube service newservice -n unknown --url

💣 Error opening service: Service newservice was not found in "unknown" namespace. You may select another namespace by using 'minikube service newservice -n : Temporary Error: Error getting service newservice: services "newservice" not found

😿 Sorry that minikube crashed. If this was unexpected, we would love to hear from you:
👉 https://github.com/kubernetes/minikube/issues/new/choose
```

## New behaviour
```
$ minikube service newservice -n unknown --url

💣  Error opening service: Service newservice was not found in "unknown" namespace. You may select another namespace by using 'minikube service newservice -n <namespace>'. Or list out all the services using 'minikube service list': Temporary Error: Error getting service newservice: services "newservice" not found
```
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

PS: Hey! This is my first contribution to K8s 🎉. Pardon me if there are any blunders 😅 