### PR TITLE
Add memory and wait longer for TestFunctional tests, include node logs

### DIFF
--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -562,7 +562,7 @@ func validateMySQL(ctx context.Context, t *testing.T, profile string) {
 		rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "exec", names[0], "--", "mysql", "-ppassword", "-e", "show databases;"))
 		return err
 	}
-	if err = retry.Expo(mysql, 10*time.Second, 60*time.Second); err != nil {
+	if err = retry.Expo(mysql, 3*time.Second, 60*time.Second); err != nil {
 		t.Errorf("mysql failing: %v", err)
 	}
 }

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -300,7 +300,7 @@ func validateCacheCmd(ctx context.Context, t *testing.T, profile string) {
 	if NoneDriver() {
 		t.Skipf("skipping: cache unsupported by none")
 	}
-	for _, img := range []string{"busybox", "busybox:1.28.4-glibc", "mysql:5.6"} {
+	for _, img := range []string{"busybox", "busybox:1.28.4-glibc", "mysql:5.6", "gcr.io/hello-minikube-zero-install/hello-node"} {
 		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "cache", "add", img))
 		if err != nil {
 			t.Errorf("%s failed: %v", rr.Args, err)
@@ -562,7 +562,7 @@ func validateMySQL(ctx context.Context, t *testing.T, profile string) {
 		rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "exec", names[0], "--", "mysql", "-ppassword", "-e", "show databases;"))
 		return err
 	}
-	if err = retry.Expo(mysql, 3*time.Second, 60*time.Second); err != nil {
+	if err = retry.Expo(mysql, 5*time.Second, 180*time.Second); err != nil {
 		t.Errorf("mysql failing: %v", err)
 	}
 }

--- a/test/integration/helpers.go
+++ b/test/integration/helpers.go
@@ -177,14 +177,17 @@ func Cleanup(t *testing.T, profile string, cancel context.CancelFunc) {
 // CleanupWithLogs cleans up after a test run, fetching logs and deleting the profile
 func CleanupWithLogs(t *testing.T, profile string, cancel context.CancelFunc) {
 	t.Helper()
-	if t.Failed() && *postMortemLogs {
-		t.Logf("%s failed, collecting logs ...", t.Name())
-		rr, err := Run(t, exec.Command(Target(), "-p", profile, "logs", "--problems"))
-		if err != nil {
-			t.Logf("failed logs error: %v", err)
+	if t.Failed() {
+		t.Logf("*** %s FAILED at %s", t.Name(), time.Now())
+		if *postMortemLogs {
+			t.Logf(">>> %s FAILED: start of post-mortem logs >>>", t.Name())
+			rr, err := Run(t, exec.Command(Target(), "-p", profile, "logs", "--problems"))
+			if err != nil {
+				t.Logf("failed logs error: %v", err)
+			}
+			t.Logf("%s logs: %s", t.Name(), rr.Stdout)
+			t.Logf("<<< %s FAILED: end of post-mortem logs <<<", t.Name())
 		}
-		t.Logf("%s logs: %s", t.Name(), rr.Stdout)
-		t.Logf("Sorry that %s failed :(", t.Name())
 	}
 	Cleanup(t, profile, cancel)
 }
@@ -225,11 +228,11 @@ func PodWait(ctx context.Context, t *testing.T, profile string, ns string, selec
 	lastMsg := ""
 
 	start := time.Now()
-	t.Logf("(dbg) waiting for pods with labels %q in namespace %q ...", selector, ns)
+	t.Logf("(dbg) %s: waiting %s for pods matching %q in namespace %q ...", t.Name(), timeout, selector, ns)
 	f := func() (bool, error) {
 		pods, err := client.CoreV1().Pods(ns).List(listOpts)
 		if err != nil {
-			t.Logf("WARNING: pod list for %q %q returned: %v", ns, selector, err)
+			t.Logf("%s: WARNING: pod list for %q %q returned: %v", t.Name(), ns, selector, err)
 			// Don't return the error upwards so that this is retried, in case the apiserver is rescheduled
 			podStart = time.Time{}
 			return false, nil
@@ -254,7 +257,7 @@ func PodWait(ctx context.Context, t *testing.T, profile string, ns string, selec
 			// Long-running process state
 			if pod.Status.Phase != core.PodRunning {
 				if !podStart.IsZero() {
-					t.Logf("WARNING: %s was running %s ago - may be unstable", selector, time.Since(podStart))
+					t.Logf("%s: WARNING: %s was running %s ago - may be unstable", t.Name(), selector, time.Since(podStart))
 				}
 				podStart = time.Time{}
 				return false, nil
@@ -271,24 +274,25 @@ func PodWait(ctx context.Context, t *testing.T, profile string, ns string, selec
 		return false, nil
 	}
 
-	err = wait.PollImmediate(500*time.Millisecond, timeout, f)
+	err = wait.PollImmediate(1*time.Second, timeout, f)
 	names := []string{}
 	for n := range foundNames {
 		names = append(names, n)
 	}
 
 	if err == nil {
-		t.Logf("(dbg) pods %s up and healthy within %s", selector, time.Since(start))
+		t.Logf("(dbg) %s: %s healthy within %s", t.Name(), selector, time.Since(start))
 		return names, nil
 	}
 
-	t.Logf("pod %q failed to start: %v", selector, err)
+	t.Logf("***** %s: pod %q failed to start within %s: %v ****", t.Name(), selector, timeout, err)
 	showPodLogs(ctx, t, profile, ns, names)
 	return names, fmt.Errorf("%s: %v", fmt.Sprintf("%s within %s", selector, timeout), err)
 }
 
 // showPodLogs logs debug info for pods
 func showPodLogs(ctx context.Context, t *testing.T, profile string, ns string, names []string) {
+	t.Logf("%s: showing logs for failed pods as of %s", t.Name(), time.Now())
 	rr, rerr := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "get", "po", "-A", "--show-labels"))
 	if rerr != nil {
 		t.Logf("%s: %v", rr.Command(), rerr)
@@ -311,6 +315,13 @@ func showPodLogs(ctx context.Context, t *testing.T, profile string, ns string, n
 		} else {
 			t.Logf("(dbg) %s:\n%s", rr.Command(), rr.Stdout)
 		}
+	}
+
+	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "describe", "node"))
+	if err != nil {
+		t.Logf("%s: %v", rr.Command(), err)
+	} else {
+		t.Logf("(dbg) %s:\n%s", rr.Command(), rr.Stdout)
 	}
 }
 


### PR DESCRIPTION
This is my attempt to address, or at least make it easier to debug a failure seen at https://storage.googleapis.com/minikube-builds/logs/5845/KVM_Linux.txt

```
--- FAIL: TestFunctional (1108.40s)
    --- FAIL: TestFunctional/parallel (0.00s)
        --- FAIL: TestFunctional/parallel/ServiceCmd (247.55s)
            functional_test.go:401: (dbg) Run:  kubectl --context functional-20191106T184708.612171223-5083 create deployment hello-node --image=gcr.io/hello-minikube-zero-install/hello-node
            functional_test.go:401: (dbg) Done: kubectl --context functional-20191106T184708.612171223-5083 create deployment hello-node --image=gcr.io/hello-minikube-zero-install/hello-node: (1.254451042s)
            functional_test.go:405: (dbg) Run:  kubectl --context functional-20191106T184708.612171223-5083 expose deployment hello-node --type=NodePort --port=8080
            functional_test.go:405: (dbg) Done: kubectl --context functional-20191106T184708.612171223-5083 expose deployment hello-node --type=NodePort --port=8080: (3.561272622s)
            functional_test.go:410: (dbg) waiting for pods with labels "app=hello-node" in namespace "default" ...
            helpers.go:247: "hello-node-7676b5fb8d-snnft" [c70b0f59-1ae8-4f80-9120-22b6eadc421e] Pending
            helpers.go:247: "hello-node-7676b5fb8d-snnft" [c70b0f59-1ae8-4f80-9120-22b6eadc421e] Pending / Ready:ContainersNotReady (containers with unready status: [hello-node]) / ContainersReady:ContainersNotReady (containers with unready status: [hello-node])
            functional_test.go:410: pod "app=hello-node" failed to start: timed out waiting for the condition
            helpers.go:292: (dbg) Run:  kubectl --context functional-20191106T184708.612171223-5083 get po -A --show-labels
            helpers.go:298: (dbg) kubectl --context functional-20191106T184708.612171223-5083 get po -A --show-labels:
                NAMESPACE              NAME                                         READY   STATUS              RESTARTS   AGE     LABELS
                default                busybox                                      1/1     Running             0          2m48s   integration-test=busybox
                default                busybox-mount                                0/1     Completed           0          111s    integration-test=busybox-mount
                default                hello-node-7676b5fb8d-snnft                  0/1     ContainerCreating   0          4m2s    app=hello-node,pod-template-hash=7676b5fb8d
                default                mysql-5787d7b5fc-4sjk4                       1/1     Running             0          7m4s    app=mysql,pod-template-hash=5787d7b5fc
                default                nginx-svc                                    1/1     Running             0          5m23s   run=nginx-svc
                kube-system            coredns-5644d7b6d9-sdvrw                     1/1     Running             0          15m     k8s-app=kube-dns,pod-template-hash=5644d7b6d9
                kube-system            coredns-5644d7b6d9-wzhdg                     1/1     Running             0          15m     k8s-app=kube-dns,pod-template-hash=5644d7b6d9
                kube-system            etcd-minikube                                1/1     Running             0          14m     component=etcd,tier=control-plane
                kube-system            kube-addon-manager-minikube                  1/1     Running             0          15m     component=kube-addon-manager,kubernetes.io/minikube-addons=addon-manager,version=v9.0.2
                kube-system            kube-apiserver-minikube                      1/1     Running             0          14m     component=kube-apiserver,tier=control-plane
                kube-system            kube-controller-manager-minikube             1/1     Running             0          14m     component=kube-controller-manager,tier=control-plane
                kube-system            kube-proxy-6b6kz                             1/1     Running             0          15m     controller-revision-hash=56ffd4ff47,k8s-app=kube-proxy,pod-template-generation=1
                kube-system            kube-scheduler-minikube                      1/1     Running             0          14m     component=kube-scheduler,tier=control-plane
                kube-system            storage-provisioner                          1/1     Running             0          15m     addonmanager.kubernetes.io/mode=Reconcile,integration-test=storage-provisioner
                kubernetes-dashboard   dashboard-metrics-scraper-76585494d8-tt46m   0/1     ContainerCreating   0          46s     k8s-app=dashboard-metrics-scraper,pod-template-hash=76585494d8
                kubernetes-dashboard   kubernetes-dashboard-57f4cb4545-94lpv        0/1     ContainerCreating   0          46s     k8s-app=kubernetes-dashboard,pod-template-hash=57f4cb4545
````
