### PR TITLE
Improve message when selected driver is incompatible with existing cluster

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -616,7 +616,7 @@ func selectDriver(oldConfig *cfg.Config) string {
 		return name
 	}
 
-	out.ErrT(out.Conflict, `The existing "{{.profile_name}}" cluster that was created using the "{{.old_driver}}" driver, and cannot be started using the "{{.driver}}" driver.`,
+	out.ErrT(out.Conflict, `The existing "{{.profile_name}}" cluster was created using the "{{.old_driver}}" driver, and cannot be started using the "{{.driver}}" driver.`,
 		out.V{"profile_name": cfg.GetMachineName(), "driver": name, "old_driver": h.Driver.DriverName()})
 
 	out.ErrT(out.Workaround, `To proceed, either:

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -616,14 +616,19 @@ func selectDriver(oldConfig *cfg.Config) string {
 		return name
 	}
 
-	out.ErrT(out.Conflict, `The existing "{{.profile_name}}" VM that was created using the "{{.old_driver}}" driver, and is incompatible with the "{{.driver}}" driver.`,
+	out.ErrT(out.Conflict, `The existing "{{.profile_name}}" cluster that was created using the "{{.old_driver}}" driver, and cannot be started using the "{{.driver}}" driver.`,
 		out.V{"profile_name": cfg.GetMachineName(), "driver": name, "old_driver": h.Driver.DriverName()})
 
 	out.ErrT(out.Workaround, `To proceed, either:
-      1) Delete the existing VM using: '{{.command}} delete'
-      or
-      2) Restart with the existing driver: '{{.command}} start --vm-driver={{.old_driver}}'`, out.V{"command": minikubeCmd(), "old_driver": h.Driver.DriverName()})
-	exit.WithCodeT(exit.Config, "Exiting due to driver incompatibility")
+
+    1) Delete the existing "{{.profile_name}}" cluster using: '{{.command}} delete'
+
+    * or *
+
+    2) Start the existing "{{.profile_name}}" cluster using: '{{.command}} start --vm-driver={{.old_driver}}'
+	`, out.V{"command": minikubeCmd(), "old_driver": h.Driver.DriverName(), "profile_name": cfg.GetMachineName()})
+
+	exit.WithCodeT(exit.Config, "Exiting.")
 	return ""
 }
 


### PR DESCRIPTION
## Before:

```
😄  minikube v1.5.2 on Debian rodete
💥  The existing "minikube" VM that was created using the "kvm2" driver, and is incompatible with the "none" driver.
👉  To proceed, either:
      1) Delete the existing VM using: 'minikube delete'
      or
      2) Restart with the existing driver: 'minikube start --vm-driver=kvm2'
```

## After:

```
😄  minikube v1.5.2 on Debian rodete
💥  The existing "minikube" cluster was created using the "kvm2" driver, and cannot be started using the "none" driver.
👉  To proceed, either:

    1) Delete the existing "minikube" cluster using: 'minikube delete'

    * or *

    2) Start the existing "minikube" cluster using: 'minikube start --vm-driver=kvm2'
	
💣  Exiting.

```

I believe the previous message may have been confusing to users, based on the context in #5828 

/cc @a1exus 