### PR TITLE
delete boilerplate site page

### DIFF
--- a/site/content/en/docs/Concepts/_index.md
+++ b/site/content/en/docs/Concepts/_index.md
@@ -5,13 +5,3 @@ weight: 4
 description: >
    Concepts that users and contributors should be aware of.
 ---
-
-{{% pageinfo %}}
-This is a placeholder page that shows you how to use this template site.
-{{% /pageinfo %}}
-
-For many projects, users may not need much information beyond the information in the [Overview](/docs/overview/), so this section is **optional**. However if there are areas where your users will need a more detailed understanding of a given term or feature in order to do anything useful with your project (or to not make mistakes when using it) put that information in this section. For example, you may want to add some conceptual pages if you have a large project with many components and a complex architecture.
-
-Remember to focus on what the user needs to know, not just what you think is interesting about your project! If they don’t need to understand your original design decisions to use or contribute to the project, don’t put them in, or include your design docs in your repo and link to them. Similarly, most users will probably need to know more about how features work when in use rather than how they are implemented. Consider a separate architecture page for more detailed implementation and system design information that potential project contributors can consult.
-
-


### PR DESCRIPTION
there is a leftover website boilerplate when you click on concepts. https://minikube.sigs.k8s.io/docs/concepts/

<img width="871" alt="Screen Shot 2019-11-07 at 10 25 33 AM" src="https://user-images.githubusercontent.com/4564227/68416246-f6510780-0148-11ea-8127-efb2994aea13.png">
