### PR TITLE
Only copy new or modified files into VM on restart

### DIFF
--- a/pkg/minikube/assets/vm_assets.go
+++ b/pkg/minikube/assets/vm_assets.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
@@ -36,6 +37,7 @@ type CopyableFile interface {
 	GetTargetDir() string
 	GetTargetName() string
 	GetPermissions() string
+	GetModTime() time.Time
 }
 
 // BaseAsset is the base asset class
@@ -64,6 +66,11 @@ func (b *BaseAsset) GetTargetName() string {
 // GetPermissions returns permissions
 func (b *BaseAsset) GetPermissions() string {
 	return b.Permissions
+}
+
+// GetModTime returns mod time
+func (b *BaseAsset) GetModTime() time.Time {
+	return time.Time{}
 }
 
 // FileAsset is an asset using a file
@@ -102,6 +109,15 @@ func (f *FileAsset) GetLength() (flen int) {
 		return 0
 	}
 	return int(fi.Size())
+}
+
+// GetModTime returns modification time of the file
+func (f *FileAsset) GetModTime() time.Time {
+	fi, err := os.Stat(f.AssetName)
+	if err != nil {
+		return time.Time{}
+	}
+	return fi.ModTime()
 }
 
 func (f *FileAsset) Read(p []byte) (int, error) {

--- a/pkg/minikube/assets/vm_assets.go
+++ b/pkg/minikube/assets/vm_assets.go
@@ -37,7 +37,7 @@ type CopyableFile interface {
 	GetTargetDir() string
 	GetTargetName() string
 	GetPermissions() string
-	GetModTime() time.Time
+	GetModTime() (time.Time, error)
 }
 
 // BaseAsset is the base asset class
@@ -69,8 +69,8 @@ func (b *BaseAsset) GetPermissions() string {
 }
 
 // GetModTime returns mod time
-func (b *BaseAsset) GetModTime() time.Time {
-	return time.Time{}
+func (b *BaseAsset) GetModTime() (time.Time, error) {
+	return time.Time{}, errors.New("modtime isn't available for this asset")
 }
 
 // FileAsset is an asset using a file
@@ -112,12 +112,12 @@ func (f *FileAsset) GetLength() (flen int) {
 }
 
 // GetModTime returns modification time of the file
-func (f *FileAsset) GetModTime() time.Time {
+func (f *FileAsset) GetModTime() (time.Time, error) {
 	fi, err := os.Stat(f.AssetName)
 	if err != nil {
-		return time.Time{}
+		return time.Time{}, err
 	}
-	return fi.ModTime()
+	return fi.ModTime(), nil
 }
 
 func (f *FileAsset) Read(p []byte) (int, error) {

--- a/pkg/minikube/assets/vm_assets.go
+++ b/pkg/minikube/assets/vm_assets.go
@@ -70,7 +70,7 @@ func (b *BaseAsset) GetPermissions() string {
 
 // GetModTime returns mod time
 func (b *BaseAsset) GetModTime() (time.Time, error) {
-	return time.Time{}, errors.New("modtime isn't available for this asset")
+	return time.Time{}, nil
 }
 
 // FileAsset is an asset using a file
@@ -114,10 +114,7 @@ func (f *FileAsset) GetLength() (flen int) {
 // GetModTime returns modification time of the file
 func (f *FileAsset) GetModTime() (time.Time, error) {
 	fi, err := os.Stat(f.AssetName)
-	if err != nil {
-		return time.Time{}, err
-	}
-	return fi.ModTime(), nil
+	return fi.ModTime(), err
 }
 
 func (f *FileAsset) Read(p []byte) (int, error) {


### PR DESCRIPTION
When minikube restarts, we can save time by only copying over files that
have changes or don't exist in the VM. The code in this PR first checks
if the file already exists in the VM, and skips copying it over again if
it does.

Relevant logs on restart w/ this change:

<details>

```shell
I1107 13:47:50.618240  140681 ssh_runner.go:150] Skipping copying /usr/local/google/home/priyawadhwa/.minikube/cache/v1.16.2/kubeadm as it already exists
I1107 13:47:50.619329  140681 ssh_runner.go:150] Skipping copying /usr/local/google/home/priyawadhwa/.minikube/cache/v1.16.2/kubelet as it already exists
I1107 13:47:50.622824  140681 ssh_runner.go:167] Transferring 1146 bytes to /var/tmp/minikube/kubeadm.yaml
I1107 13:47:50.623198  140681 ssh_runner.go:186] kubeadm.yaml: copied 1146 bytes
I1107 13:47:50.634250  140681 ssh_runner.go:167] Transferring 561 bytes to /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
I1107 13:47:50.634687  140681 ssh_runner.go:186] 10-kubeadm.conf: copied 561 bytes
I1107 13:47:50.646033  140681 ssh_runner.go:167] Transferring 349 bytes to /lib/systemd/system/kubelet.service
I1107 13:47:50.646465  140681 ssh_runner.go:186] kubelet.service: copied 349 bytes
I1107 13:47:50.658771  140681 ssh_runner.go:167] Transferring 1532 bytes to /etc/kubernetes/manifests/addon-manager.yaml.tmpl
I1107 13:47:50.659606  140681 ssh_runner.go:186] addon-manager.yaml.tmpl: copied 1532 bytes
I1107 13:47:50.672420  140681 ssh_runner.go:167] Transferring 1709 bytes to /etc/kubernetes/addons/storage-provisioner.yaml
I1107 13:47:50.673033  140681 ssh_runner.go:186] storage-provisioner.yaml: copied 1709 bytes
I1107 13:47:50.689584  140681 ssh_runner.go:167] Transferring 271 bytes to /etc/kubernetes/addons/storageclass.yaml
I1107 13:47:50.690156  140681 ssh_runner.go:186] storageclass.yaml: copied 271 bytes
I1107 13:47:50.700486  140681 ssh_runner.go:98] (SSHRunner) Run:  /bin/bash -c "sudo systemctl daemon-reload && sudo systemctl start kubelet"
I1107 13:47:50.783600  140681 certs.go:75] acquiring lock: {Name:setupCerts Clock:{} Delay:15s Timeout:0s Cancel:<nil>}
I1107 13:47:50.783780  140681 certs.go:83] Setting up /usr/local/google/home/priyawadhwa/.minikube for IP: 192.168.39.206
I1107 13:47:50.783902  140681 crypto.go:69] Generating cert /usr/local/google/home/priyawadhwa/.minikube/client.crt with IP's: []
I1107 13:47:50.789069  140681 crypto.go:157] Writing cert to /usr/local/google/home/priyawadhwa/.minikube/client.crt ...
I1107 13:47:50.789100  140681 lock.go:41] attempting to write to file "/usr/local/google/home/priyawadhwa/.minikube/client.crt" with filemode -rw-r--r--
I1107 13:47:50.789384  140681 crypto.go:165] Writing key to /usr/local/google/home/priyawadhwa/.minikube/client.key ...
I1107 13:47:50.789405  140681 lock.go:41] attempting to write to file "/usr/local/google/home/priyawadhwa/.minikube/client.key" with filemode -rw-------
I1107 13:47:50.789582  140681 crypto.go:69] Generating cert /usr/local/google/home/priyawadhwa/.minikube/apiserver.crt with IP's: [192.168.39.206 10.96.0.1 10.0.0.1]
I1107 13:47:50.793944  140681 crypto.go:157] Writing cert to /usr/local/google/home/priyawadhwa/.minikube/apiserver.crt ...
I1107 13:47:50.793971  140681 lock.go:41] attempting to write to file "/usr/local/google/home/priyawadhwa/.minikube/apiserver.crt" with filemode -rw-r--r--
I1107 13:47:50.794207  140681 crypto.go:165] Writing key to /usr/local/google/home/priyawadhwa/.minikube/apiserver.key ...
I1107 13:47:50.794227  140681 lock.go:41] attempting to write to file "/usr/local/google/home/priyawadhwa/.minikube/apiserver.key" with filemode -rw-------
I1107 13:47:50.794401  140681 crypto.go:69] Generating cert /usr/local/google/home/priyawadhwa/.minikube/proxy-client.crt with IP's: []
I1107 13:47:50.798704  140681 crypto.go:157] Writing cert to /usr/local/google/home/priyawadhwa/.minikube/proxy-client.crt ...
I1107 13:47:50.798732  140681 lock.go:41] attempting to write to file "/usr/local/google/home/priyawadhwa/.minikube/proxy-client.crt" with filemode -rw-r--r--
I1107 13:47:50.798954  140681 crypto.go:165] Writing key to /usr/local/google/home/priyawadhwa/.minikube/proxy-client.key ...
I1107 13:47:50.798974  140681 lock.go:41] attempting to write to file "/usr/local/google/home/priyawadhwa/.minikube/proxy-client.key" with filemode -rw-------
I1107 13:47:50.809628  140681 ssh_runner.go:150] Skipping copying /usr/local/google/home/priyawadhwa/.minikube/ca.crt as it already exists
I1107 13:47:50.816440  140681 ssh_runner.go:150] Skipping copying /usr/local/google/home/priyawadhwa/.minikube/ca.key as it already exists
I1107 13:47:50.827031  140681 ssh_runner.go:167] Transferring 1298 bytes to /var/lib/minikube/certs/apiserver.crt
I1107 13:47:50.827574  140681 ssh_runner.go:186] apiserver.crt: copied 1298 bytes
I1107 13:47:50.851183  140681 ssh_runner.go:167] Transferring 1675 bytes to /var/lib/minikube/certs/apiserver.key
I1107 13:47:50.851816  140681 ssh_runner.go:186] apiserver.key: copied 1675 bytes
I1107 13:47:50.866694  140681 ssh_runner.go:150] Skipping copying /usr/local/google/home/priyawadhwa/.minikube/proxy-client-ca.crt as it already exists
I1107 13:47:50.873270  140681 ssh_runner.go:150] Skipping copying /usr/local/google/home/priyawadhwa/.minikube/proxy-client-ca.key as it already exists
I1107 13:47:50.887705  140681 ssh_runner.go:167] Transferring 1103 bytes to /var/lib/minikube/certs/proxy-client.crt
I1107 13:47:50.888300  140681 ssh_runner.go:186] proxy-client.crt: copied 1103 bytes
I1107 13:47:50.903875  140681 ssh_runner.go:167] Transferring 1675 bytes to /var/lib/minikube/certs/proxy-client.key
I1107 13:47:50.906373  140681 ssh_runner.go:186] proxy-client.key: copied 1675 bytes
I1107 13:47:50.920302  140681 ssh_runner.go:167] Transferring 1066 bytes to /usr/share/ca-certificates/minikubeCA.pem
I1107 13:47:50.920692  140681 ssh_runner.go:186] minikubeCA.pem: copied 1066 bytes
I1107 13:47:50.939007  140681 ssh_runner.go:150] Skipping copying  as it already exists

```

</details>

Right now, mkcmp only tracks performance for `minikube start` after a `minikube delete`. I'll either update mkcmp to also look at restarts, or comment w/ timings from my local machine (this would be much faster).