### PR TITLE
Add test case to test file sync between host and VM.

### DIFF
--- a/test/integration/testdata/sync.test
+++ b/test/integration/testdata/sync.test
@@ -1,0 +1,1 @@
+Test file for checking file sync process


### PR DESCRIPTION
#5835  

Executing 'minikube start' when it is currently running
will allow user to sync folder under MINIKUBE_HOME/files
to the VM.

The test case will copy a file to the MINIKUBE_HOME/files/etc
folder to be copied to the VM /etc/ folder.