### PR TITLE
Change the front page to link to the /release page

### DIFF
--- a/site/content/en/_index.html
+++ b/site/content/en/_index.html
@@ -30,8 +30,8 @@ resources:
 				<a class="btn btn-lg btn-primary mr-3 mb-4" href="/docs/start">
 					Get Started <i class="fas fa-arrow-alt-circle-right ml-2"></i>
  				</a>
-  			    <a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://github.com/kubernetes/minikube">
-				    View Repository <i class="fab fa-github ml-2 "></i>
+  			    <a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://github.com/kubernetes/minikube/releases">
+				    Download Latest<i class="fab fa-github ml-2 "></i>
                 </a>
 			</div>
 			<div class="col">


### PR DESCRIPTION
#5832

To make it easier for user the front page link will now point to the
/release page
