### PR TITLE
CI: Save test output for each commit, add status placeholders

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,14 +21,11 @@ require (
 	github.com/docker/machine v0.7.1-0.20190718054102-a555e4f7a8f5 // version is 0.7.1 to pin to a555e4f7a8f5
 	github.com/elazarl/goproxy v0.0.0-20190421051319-9d40249d3c2f
 	github.com/elazarl/goproxy/ext v0.0.0-20190421051319-9d40249d3c2f // indirect
-	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
-	github.com/google/btree v1.0.0 // indirect
 	github.com/google/go-cmp v0.3.0
 	github.com/gorilla/mux v1.7.1 // indirect
-	github.com/grpc-ecosystem/grpc-gateway v1.5.0 // indirect
 	github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce // indirect
 	github.com/hashicorp/go-getter v1.4.0
 	github.com/hashicorp/go-multierror v0.0.0-20160811015721-8c5f0ad93604 // indirect

--- a/hack/jenkins/minikube_set_pending.sh
+++ b/hack/jenkins/minikube_set_pending.sh
@@ -42,11 +42,15 @@ jobs=(
      'none_Linux'
 )
 
+
+
 for j in ${jobs[@]}; do
-  target_url="https://storage.googleapis.com/minikube-builds/logs/${ghprbPullId}/${j}.txt"
+  target_url="https://storage.googleapis.com/minikube-builds/logs/${ghprbPullId}/${j}/${ghprbActualCommit}.txt"
   curl "https://api.github.com/repos/kubernetes/minikube/statuses/${ghprbActualCommit}?access_token=$access_token" \
     -H "Content-Type: application/json" \
     -X POST \
     -d "{\"state\": \"pending\", \"description\": \"Jenkins\", \"target_url\": \"${target_url}\", \"context\": \"${j}\"}"
+
+  echo "Pending as of $(date)" gsutil cp - "${target_url}" || echo "Unable to upload placeholder"
 done
 

--- a/hack/jenkins/minikube_set_pending.sh
+++ b/hack/jenkins/minikube_set_pending.sh
@@ -51,6 +51,6 @@ for j in ${jobs[@]}; do
     -X POST \
     -d "{\"state\": \"pending\", \"description\": \"Jenkins\", \"target_url\": \"${target_url}\", \"context\": \"${j}\"}"
 
-  echo "Pending as of $(date)" gsutil cp - "${target_url}" || echo "Unable to upload placeholder"
+  echo "Pending as of $(date)" | gsutil cp - "${target_url}"
 done
 


### PR DESCRIPTION
The question often a rises when reviewing a PR: is this test output stale? Is the test still running?

This attempts to address this question by:

- Giving each commit it's own output file
- Putting status placeholders in until the final results are uploaded

NOTE: This still requires updating the URL that Jenkins uses to update the final statuts result, so don't be surprised if GitHub doesn't show full logs at this URL.

