### PR TITLE
Make lock names uid and path specific to avoid conflicts

### DIFF
--- a/cmd/minikube/cmd/config/util_test.go
+++ b/cmd/minikube/cmd/config/util_test.go
@@ -122,17 +122,16 @@ func TestValidateProfile(t *testing.T) {
 			profileName: "82374328742_2974224498",
 		},
 		{
-			profileName: "minikube",
+			profileName: "validate_test",
 		},
 	}
 
 	for _, test := range testCases {
 		profileNam := test.profileName
-		expectedMsg := fmt.Sprintf("profile %q not found", test.profileName)
-
+		expected := fmt.Sprintf("profile %q not found", test.profileName)
 		err, ok := ValidateProfile(profileNam)
-		if !ok && err.Error() != expectedMsg {
-			t.Errorf("Didnt receive expected message")
+		if !ok && err.Error() != expected {
+			t.Errorf("got error %q, expected %q", err, expected)
 		}
 	}
 }

--- a/pkg/minikube/config/profile.go
+++ b/pkg/minikube/config/profile.go
@@ -105,7 +105,7 @@ func CreateProfile(name string, cfg *MachineConfig, miniHome ...string) error {
 	}
 	defer os.Remove(tf.Name())
 
-	if err = lock.WriteFile(tf.Name(), data, 0600); err != nil {
+	if err = ioutil.WriteFile(tf.Name(), data, 0600); err != nil {
 		return err
 	}
 

--- a/pkg/util/lock/lock_test.go
+++ b/pkg/util/lock/lock_test.go
@@ -18,7 +18,9 @@ package lock
 
 import "testing"
 
-func TestGetMutexName(t *testing.T) {
+func TestUserMutexSpec(t *testing.T) {
+	forceID = "test"
+
 	var tests = []struct {
 		description string
 		path        string
@@ -27,40 +29,40 @@ func TestGetMutexName(t *testing.T) {
 		{
 			description: "standard",
 			path:        "/foo/bar",
-			expected:    "foo-bar",
+			expected:    "mfoo-bar-test",
 		},
 		{
 			description: "deep directory",
 			path:        "/foo/bar/baz/bat",
-			expected:    "baz-bat",
+			expected:    "mfoo-bar-baz-bat-test",
 		},
 		{
 			description: "underscores",
 			path:        "/foo_bar/baz",
-			expected:    "foo-bar-baz",
+			expected:    "mfoo-bar-baz-test",
 		},
 		{
 			description: "starts with number",
 			path:        "/foo/2bar/baz",
-			expected:    "m2bar-baz",
+			expected:    "mfoo-2bar-baz-test",
 		},
 		{
 			description: "starts with punctuation",
 			path:        "/.foo/bar",
-			expected:    "foo-bar",
+			expected:    "mfoo-bar-test",
 		},
 		{
 			description: "long filename",
 			path:        "/very-very-very-very-very-very-very-very-long/bar",
-			expected:    "very-very-very-very-very-very-very-very",
+			expected:    "m-very-very-very-very-very-long-bar-test",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
-			got := getMutexName(tc.path)
-			if got != tc.expected {
-				t.Errorf("Unexpected mutex name for path %s. got: %s, expected: %s", tc.path, got, tc.expected)
+			got := UserMutexSpec(tc.path)
+			if got.Name != tc.expected {
+				t.Errorf("%s mutex name = %q, expected %q", tc.path, got.Name, tc.expected)
 			}
 		})
 	}


### PR DESCRIPTION
This does now mean that if multiple users try to modify a locked file, that it will proceed rather than complain about permissions to a common lock file.

Fixes #5911
