### PR TITLE
Make it possible to recover from a previously aborted StartCluster (Ctrl-C)

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1210,22 +1210,11 @@ func configureRuntimes(runner cruntime.CommandRunner, drvName string, k8s cfg.Ku
 
 // bootstrapCluster starts Kubernetes using the chosen bootstrapper
 func bootstrapCluster(bs bootstrapper.Bootstrapper, r cruntime.Manager, runner command.Runner, kc cfg.KubernetesConfig, preexisting bool, isUpgrade bool) {
-	// hum. bootstrapper.Bootstrapper should probably have a Name function.
-	bsName := viper.GetString(cmdcfg.Bootstrapper)
-
 	if isUpgrade || !preexisting {
 		out.T(out.Pulling, "Pulling images ...")
 		if err := bs.PullImages(kc); err != nil {
 			out.T(out.FailureType, "Unable to pull images, which may be OK: {{.error}}", out.V{"error": err})
 		}
-	}
-
-	if preexisting {
-		out.T(out.Restarting, "Relaunching Kubernetes using {{.bootstrapper}} ... ", out.V{"bootstrapper": bsName})
-		if err := bs.RestartCluster(kc); err != nil {
-			exit.WithLogEntries("Error restarting cluster", err, logs.FindProblems(r, bs, runner))
-		}
-		return
 	}
 
 	out.T(out.Launch, "Launching Kubernetes ... ")

--- a/pkg/minikube/bootstrapper/bootstrapper.go
+++ b/pkg/minikube/bootstrapper/bootstrapper.go
@@ -39,7 +39,6 @@ type Bootstrapper interface {
 	PullImages(config.KubernetesConfig) error
 	StartCluster(config.KubernetesConfig) error
 	UpdateCluster(config.KubernetesConfig) error
-	RestartCluster(config.KubernetesConfig) error
 	DeleteCluster(config.KubernetesConfig) error
 	WaitForCluster(config.KubernetesConfig, time.Duration) error
 	// LogCommands returns a map of log type to a command which will display that log.

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -266,7 +266,7 @@ func (k *Bootstrapper) StartCluster(k8s config.KubernetesConfig) error {
 	ignore := []string{
 		fmt.Sprintf("DirAvailable-%s", strings.Replace(vmpath.GuestManifestsDir, "/", "-", -1)),
 		fmt.Sprintf("DirAvailable-%s", strings.Replace(vmpath.GuestPersistentDir, "/", "-", -1)),
-		fmt.Sprintf("DirAvailable-%s", strings.Replace(path.Join(vmpath.GuestPersistentDir, "etcd"), "/", "-", -1)),
+		fmt.Sprintf("DirAvailable-%s", etcdDataDir(), "/", "-", -1)),
 		"FileAvailable--etc-kubernetes-manifests-kube-scheduler.yaml",
 		"FileAvailable--etc-kubernetes-manifests-kube-apiserver.yaml",
 		"FileAvailable--etc-kubernetes-manifests-kube-controller-manager.yaml",

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -242,10 +242,9 @@ func (k *Bootstrapper) existingConfig() error {
 func (k *Bootstrapper) StartCluster(k8s config.KubernetesConfig) error {
 	err := k.existingConfig()
 	if err == nil {
-		return k.RestartCluster(k8s)
-	} else {
-		glog.Infof("existence check: %v", err)
+		return k.restartCluster(k8s)
 	}
+	glog.Infof("existence check: %v", err)
 
 	start := time.Now()
 	glog.Infof("StartCluster: %+v", k8s)
@@ -475,13 +474,13 @@ func (k *Bootstrapper) WaitForCluster(k8s config.KubernetesConfig, timeout time.
 	return k.waitForSystemPods(start, k8s, timeout)
 }
 
-// RestartCluster restarts the Kubernetes cluster configured by kubeadm
-func (k *Bootstrapper) RestartCluster(k8s config.KubernetesConfig) error {
-	glog.Infof("RestartCluster start")
+// restartCluster restarts the Kubernetes cluster configured by kubeadm
+func (k *Bootstrapper) restartCluster(k8s config.KubernetesConfig) error {
+	glog.Infof("restartCluster start")
 
 	start := time.Now()
 	defer func() {
-		glog.Infof("RestartCluster took %s", time.Since(start))
+		glog.Infof("restartCluster took %s", time.Since(start))
 	}()
 
 	version, err := parseKubernetesVersion(k8s.KubernetesVersion)
@@ -554,7 +553,7 @@ func (k *Bootstrapper) DeleteCluster(k8s config.KubernetesConfig) error {
 	return nil
 }
 
-// PullImages downloads images that will be used by RestartCluster
+// PullImages downloads images that will be used by Kubernetes
 func (k *Bootstrapper) PullImages(k8s config.KubernetesConfig) error {
 	version, err := parseKubernetesVersion(k8s.KubernetesVersion)
 	if err != nil {

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -266,6 +266,7 @@ func (k *Bootstrapper) StartCluster(k8s config.KubernetesConfig) error {
 	ignore := []string{
 		fmt.Sprintf("DirAvailable-%s", strings.Replace(vmpath.GuestManifestsDir, "/", "-", -1)),
 		fmt.Sprintf("DirAvailable-%s", strings.Replace(vmpath.GuestPersistentDir, "/", "-", -1)),
+		fmt.Sprintf("DirAvailable-%s", strings.Replace(path.Join(vmpath.GuestPersistentDir, "etcd"), "/", "-", -1)),
 		"FileAvailable--etc-kubernetes-manifests-kube-scheduler.yaml",
 		"FileAvailable--etc-kubernetes-manifests-kube-apiserver.yaml",
 		"FileAvailable--etc-kubernetes-manifests-kube-controller-manager.yaml",


### PR DESCRIPTION
I ran into an issue earlier today where minikube was failing:

```
W1114 14:23:00.947646   38011 exit.go:101] Error restarting cluster: apiserver healthz: apiserver healthz never reported healthy

💣  Error restarting cluster: apiserver healthz: apiserver healthz never reported healthy
```

This was because the kubelet was crash-looping due to a missing file, probably because I hit Ctrl-C on a previous run:

```
Nov 14 22:19:36 minikube kubelet[2939]: F1114 22:19:36.393394    2939 server.go:196] failed to load Kubelet config file /var/lib/kubelet/config.yaml, error failed to read kubelet config file "/var/lib/kubelet/config.yaml", error: open /var/lib/kubelet/config.yaml: no such file or directory
```


```