### PR TITLE
SSHRunner: include stdout/stderr with error message

### DIFF
--- a/pkg/minikube/command/exec_runner.go
+++ b/pkg/minikube/command/exec_runner.go
@@ -75,7 +75,7 @@ func (*ExecRunner) RunCmd(cmd *exec.Cmd) (*RunResult, error) {
 		return rr, nil
 	}
 
-	return rr, fmt.Errorf("%s: %v\nstdout: %s\nstderr: %s", rr.Command(), err, rr.Stdout.String(), rr.Stderr.String())
+	return rr, fmt.Errorf("%s: %v\nstdout:\n%s\nstderr:\n%s", rr.Command(), err, rr.Stdout.String(), rr.Stderr.String())
 }
 
 // Copy copies a file and its permissions

--- a/pkg/minikube/command/exec_runner.go
+++ b/pkg/minikube/command/exec_runner.go
@@ -69,7 +69,7 @@ func (*ExecRunner) RunCmd(cmd *exec.Cmd) (*RunResult, error) {
 	}
 	// Decrease log spam
 	if elapsed > (1 * time.Second) {
-		glog.Infof("Exit %d for %v: (%s)", rr.Command(), elapsed)
+		glog.Infof("Completed: %s: (%s)", rr.Command(), elapsed)
 	}
 	if err == nil {
 		return rr, nil

--- a/pkg/minikube/command/ssh_runner.go
+++ b/pkg/minikube/command/ssh_runner.go
@@ -145,7 +145,7 @@ func (s *SSHRunner) RunCmd(cmd *exec.Cmd) (*RunResult, error) {
 		return rr, nil
 	}
 
-	return rr, fmt.Errorf("%s: %v\nstdout: %s\nstderr: %s", rr.Command(), err, rr.Stdout.String(), rr.Stderr.String())
+	return rr, fmt.Errorf("%s: %v\nstdout:\n%s\nstderr:\n%s", rr.Command(), err, rr.Stdout.String(), rr.Stderr.String())
 }
 
 // Copy copies a file to the remote over SSH.

--- a/pkg/minikube/command/ssh_runner.go
+++ b/pkg/minikube/command/ssh_runner.go
@@ -139,7 +139,7 @@ func (s *SSHRunner) RunCmd(cmd *exec.Cmd) (*RunResult, error) {
 	}
 	// Decrease log spam
 	if elapsed > (1 * time.Second) {
-		glog.Infof("Exit %d for %v: (%s)", rr.Command(), elapsed)
+		glog.Infof("Completed: %s: (%s)", rr.Command(), elapsed)
 	}
 	if err == nil {
 		return rr, nil


### PR DESCRIPTION
With the recent runner refactor, SSHRunner was no longer returning stdout/stderr with the error, but ExecRunner was. This PR makes both behave identically. Example output, admittedly for a command with no output:

```
I1114 19:38:36.826497   58306 kubeadm.go:212] /data/minikube skipping compat symlinks: sudo test -d /data/minikube: Process exited with status 1
stdout: 
stderr: 
```

Issue seen in #5858
