### PR TITLE
Fix TestValidateProfile Fail

### DIFF
--- a/cmd/minikube/cmd/config/util_test.go
+++ b/cmd/minikube/cmd/config/util_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"fmt"
 	"testing"
 
 	"k8s.io/minikube/pkg/minikube/assets"
@@ -116,22 +115,23 @@ func TestIsAddonAlreadySet(t *testing.T) {
 
 func TestValidateProfile(t *testing.T) {
 	testCases := []struct {
-		profileName string
+		profileName, expectedMsg string
 	}{
 		{
 			profileName: "82374328742_2974224498",
+			expectedMsg: "profile \"82374328742_2974224498\" not found",
 		},
 		{
 			profileName: "minikube",
+			expectedMsg: "\"minikube\" is an invalid profile",
 		},
 	}
 
 	for _, test := range testCases {
 		profileNam := test.profileName
-		expectedMsg := fmt.Sprintf("profile %q not found", test.profileName)
 
 		err, ok := ValidateProfile(profileNam)
-		if !ok && err.Error() != expectedMsg {
+		if !ok && err.Error() != test.expectedMsg {
 			t.Errorf("Didnt receive expected message")
 		}
 	}


### PR DESCRIPTION
### What type of PR is this?
/kind failing-test

### What this PR does / why we need it:

This PR fix unit test case TestValidateProfile fail.

### Which issue(s) this PR fixes:

Fixes #5922

### Does this PR introduce a user-facing change?

No. This PR changes test case only.

**Before, TestValidateProfile fail.**


```
{
    profileName: "82374328742_2974224498",
},
{
    profileName: "minikube",
},
```

**After this PR, TestValidateProfile sucess.**

```
{
    profileName: "82374328742_2974224498",
    expectedMsg: "profile \"82374328742_2974224498\" not found",
},
{
    profileName: "minikube",
    expectedMsg: "\"minikube\" is an invalid profile",
},
```

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```