### PR TITLE
fixed metrics-server and  added integration tests

### DIFF
--- a/deploy/addons/metrics-server/metrics-server-deployment.yaml.tmpl
+++ b/deploy/addons/metrics-server/metrics-server-deployment.yaml.tmpl
@@ -23,4 +23,4 @@ spec:
         imagePullPolicy: Always
         command:
         - /metrics-server
-        - --source=kubernetes.summary_api:''
+        - --source=kubernetes.summary_api:https://kubernetes.default?kubeletHttps=true&kubeletPort=10250&insecure=true

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -42,7 +42,7 @@ func TestAddons(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Minute)
 	defer CleanupWithLogs(t, profile, cancel)
 
-	args := append([]string{"start", "-p", profile, "--wait=false", "--memory=2600", "--alsologtostderr", "-v=1", "--addons=ingress", "--addons=registry"}, StartArgs()...)
+	args := append([]string{"start", "-p", profile, "--wait=false", "--memory=2600", "--alsologtostderr", "-v=1", "--addons=ingress", "--addons=registry", "--addons=metrics-server"}, StartArgs()...)
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
 		t.Fatalf("%s failed: %v", rr.Args, err)
@@ -56,6 +56,7 @@ func TestAddons(t *testing.T) {
 		}{
 			{"Registry", validateRegistryAddon},
 			{"Ingress", validateIngressAddon},
+			{"MetricsServer", validateMetricsServerAddon},
 		}
 		for _, tc := range tests {
 			tc := tc
@@ -204,6 +205,48 @@ func validateRegistryAddon(ctx context.Context, t *testing.T, profile string) {
 	}
 
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "addons", "disable", "registry", "--alsologtostderr", "-v=1"))
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Args, err)
+	}
+}
+
+func validateMetricsServerAddon(ctx context.Context, t *testing.T, profile string) {
+	client, err := kapi.Client(profile)
+	if err != nil {
+		t.Fatalf("kubernetes client: %v", client)
+	}
+
+	start := time.Now()
+	if err := kapi.WaitForDeploymentToStabilize(client, "kube-system", "metrics-server", 6*time.Minute); err != nil {
+		t.Errorf("waiting for metrics-server deployment to stabilize: %v", err)
+	}
+	t.Logf("metrics-server stabilized in %s", time.Since(start))
+
+	if _, err := PodWait(ctx, t, profile, "kube-system", "k8s-app=metrics-server", 6*time.Minute); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+
+	want := "CPU(cores)"
+	checkMetricsServer := func() error {
+		rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "top", "pods", "-n", "kube-system"))
+		if err != nil {
+			return err
+		}
+		if rr.Stderr.String() != "" {
+			t.Logf("%v: unexpected stderr: %s", rr.Args, rr.Stderr)
+		}
+		if !strings.Contains(rr.Stdout.String(), want) {
+			return fmt.Errorf("%v stdout = %q, want %q", rr.Args, rr.Stdout, want)
+		}
+		return nil
+	}
+
+	// metrics-server takes some time to be able to collect metrics
+	if err := retry.Expo(checkMetricsServer, time.Minute, 5*time.Minute); err != nil {
+		t.Errorf(err.Error())
+	}
+
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "addons", "disable", "metrics-server", "--alsologtostderr", "-v=1"))
 	if err != nil {
 		t.Errorf("%s failed: %v", rr.Args, err)
 	}


### PR DESCRIPTION
### What type of PR is this?
/kind bug

### What this PR does / why we need it:

The metrics server haven't worked since minikube v1.5.x~ due to changing kubelet version.
This PR fixes the metrics server to be able to work correctly.

### Which issue(s) this PR fixes:
Fixes #5859

### Does this PR introduce a user-facing change?

Yes. 
This PR fixes bug in order to the metrics server addons works successfully.

**Before this PR, the metrics server fails because it cannot connect to kubelet**
```
I1107 10:40:32.667494       1 heapster.go:71] /metrics-server --source=kubernetes.summary_api:''
I1107 10:40:32.667545       1 heapster.go:72] Metrics Server version v0.2.1
I1107 10:40:32.667715       1 configs.go:61] Using Kubernetes client with master "https://10.96.0.1:443" and version
I1107 10:40:32.667723       1 configs.go:62] Using kubelet port 10255
I1107 10:40:32.668514       1 heapster.go:128] Starting with Metric Sink
I1107 10:40:33.181569       1 serving.go:308] Generated self-signed cert (apiserver.local.config/certificates/apiserver.crt, apiserver.local.config/certificates/apiserver.key)
I1107 10:40:33.326747       1 heapster.go:101] Starting Heapster API server...
[restful] 2019/11/07 10:40:33 log.go:33: [restful/swagger] listing is available at https:///swaggerapi
[restful] 2019/11/07 10:40:33 log.go:33: [restful/swagger] https:///swaggerui/ is mapped to folder /swagger-ui/
I1107 10:40:33.327930       1 serve.go:85] Serving securely on 0.0.0.0:443
E1107 10:41:05.007656       1 summary.go:97] error while getting metrics summary from Kubelet minikube(192.168.64.44:10255): Get http://192.168.64.44:10255/stats/summary/: dial tcp 192.168.64.44:10255: getsockopt: connection refused
```

**After this PR, the metrics server works successfully via kubernetes service**
```
I1107 10:40:32.667494       1 heapster.go:71] /metrics-server --source=kubernetes.summary_api:''
I1107 10:40:32.667545       1 heapster.go:72] Metrics Server version v0.2.1
I1107 10:40:32.667715       1 configs.go:61] Using Kubernetes client with master "https://10.96.0.1:443" and version
I1107 10:40:32.667723       1 configs.go:62] Using kubelet port 10255
I1107 10:40:32.668514       1 heapster.go:128] Starting with Metric Sink
I1107 10:40:33.181569       1 serving.go:308] Generated self-signed cert (apiserver.local.config/certificates/apiserver.crt, apiserver.local.config/certificates/apiserver.key)
I1107 10:40:33.326747       1 heapster.go:101] Starting Heapster API server...
[restful] 2019/11/07 10:40:33 log.go:33: [restful/swagger] listing is available at https:///swaggerapi
[restful] 2019/11/07 10:40:33 log.go:33: [restful/swagger] https:///swaggerui/ is mapped to folder /swagger-ui/
I1107 10:40:33.327930       1 serve.go:85] Serving securely on 0.0.0.0:443
```

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```