### PR TITLE
Remove depreacted annotation storageclass.beta.kubernetes.io

### DIFF
--- a/deploy/addons/storage-provisioner-gluster/storage-provisioner-glusterfile.yaml.tmpl
+++ b/deploy/addons/storage-provisioner-gluster/storage-provisioner-glusterfile.yaml.tmpl
@@ -8,7 +8,7 @@ metadata:
     kubernetes.io/minikube-addons: storage-provisioner-gluster
     addonmanager.kubernetes.io/mode: EnsureExists
   annotations:
-    storageclass.beta.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "true"
 provisioner: gluster.org/glusterfile
 reclaimPolicy: Delete
 parameters:

--- a/pkg/minikube/storageclass/storageclass.go
+++ b/pkg/minikube/storageclass/storageclass.go
@@ -29,7 +29,7 @@ import (
 
 func annotateDefaultStorageClass(storage storagev1.StorageV1Interface, class *v1.StorageClass, enable bool) error {
 	isDefault := strconv.FormatBool(enable)
-	metav1.SetMetaDataAnnotation(&class.ObjectMeta, "storageclass.beta.kubernetes.io/is-default-class", isDefault)
+	metav1.SetMetaDataAnnotation(&class.ObjectMeta, "storageclass.kubernetes.io/is-default-class", isDefault)
 	_, err := storage.StorageClasses().Update(class)
 
 	return err


### PR DESCRIPTION
Replaces `storageclass.beta.kubernetes.io/is-default-class` is replaced by `storageclass.kubernetes.io/is-default-class`.

`storageclass.beta.kubernetes.io/is-default-class` is deprecated since k8s 1.6 (cf https://github.com/kubernetes/kubernetes/pull/40088) and Minikube supports k8s versions [>= 1.11](https://minikube.sigs.k8s.io/docs/reference/configuration/kubernetes/).

Fixes #5953