### PR TITLE
Fix profile list json command output

### DIFF
--- a/cmd/minikube/cmd/config/profile_list.go
+++ b/cmd/minikube/cmd/config/profile_list.go
@@ -112,7 +112,7 @@ var printProfilesJSON = func() {
 
 	var body = map[string]interface{}{}
 
-	if err == nil {
+	if err == nil || os.IsNotExist(err) {
 		body["valid"] = valid
 		body["invalid"] = invalid
 		jsonString, _ := json.Marshal(body)


### PR DESCRIPTION
Fixes #5898

Behavior of `minikube profile list -o json` was dependent whether or not the `$MINIKUBE_HOME/profiles` folder exists or not.

This small update simply checks if the error is due to the folder not existing, and if so, simply returns the normal empty array results with a normal exit code

Before:
```
$ ls ~/.minikube/profiles
ls: cannot access '/home/adam/.minikube/profiles': No such file or directory
$ minikube profile list -o json
{"error":{"Op":"open","Path":"/root/.minikube/profiles","Err":2}}
$ echo $?
1
$ mkdir ~/.minikube/profiles
$ minikube profile list -o json
{"invalid":[],"valid":[]}
$ echo $?
0
```

After:
```
$ ls ~/.minikube/profiles
ls: cannot access '/home/adam/.minikube/profiles': No such file or directory
$ minikube profile list -o json
{"invalid":[],"valid":[]}
$ echo $?
0
$ mkdir ~/.minikube/profiles
$ minikube profile list -o json
{"invalid":[],"valid":[]}
$ echo $?
0
```