### PR TITLE
Add option for virtualbox users to set nat-nic-type 

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -121,6 +121,8 @@ const (
 	minimumCPUS           = 2
 	minimumDiskSize       = "2000mb"
 	autoUpdate            = "auto-update-drivers"
+	hostOnlyNicType       = "host-only-nic-type"
+	natNicType            = "nat-nic-type"
 )
 
 var (
@@ -208,6 +210,8 @@ func initDriverFlags() {
 	startCmd.Flags().Bool(dnsProxy, false, "Enable proxy for NAT DNS requests (virtualbox driver only)")
 	startCmd.Flags().Bool(hostDNSResolver, true, "Enable host resolver for NAT DNS requests (virtualbox driver only)")
 	startCmd.Flags().Bool(noVTXCheck, false, "Disable checking for the availability of hardware virtualization before the vm is started (virtualbox driver only)")
+	startCmd.Flags().String(hostOnlyNicType, "virtio", "NIC Type used for host only network. One of Am79C970A, Am79C973, 82540EM, 82543GC, 82545EM, or virtio (virtualbox driver only)")
+	startCmd.Flags().String(natNicType, "virtio", "NIC Type used for host only network. One of Am79C970A, Am79C973, 82540EM, 82543GC, 82545EM, or virtio (virtualbox driver only)")
 
 	// hyperkit
 	startCmd.Flags().StringSlice(vsockPorts, []string{}, "List of guest VSock ports that should be exposed as sockets on the host (hyperkit driver only)")
@@ -912,6 +916,8 @@ func generateCfgFromFlags(cmd *cobra.Command, k8sVersion string, drvName string)
 		NoVTXCheck:          viper.GetBool(noVTXCheck),
 		DNSProxy:            viper.GetBool(dnsProxy),
 		HostDNSResolver:     viper.GetBool(hostDNSResolver),
+		HostOnlyNicType:     viper.GetString(hostOnlyNicType),
+		NatNicType:          viper.GetString(natNicType),
 		KubernetesConfig: cfg.KubernetesConfig{
 			KubernetesVersion:      k8sVersion,
 			NodePort:               viper.GetInt(apiServerPort),

--- a/go.mod
+++ b/go.mod
@@ -21,11 +21,14 @@ require (
 	github.com/docker/machine v0.7.1-0.20190718054102-a555e4f7a8f5 // version is 0.7.1 to pin to a555e4f7a8f5
 	github.com/elazarl/goproxy v0.0.0-20190421051319-9d40249d3c2f
 	github.com/elazarl/goproxy/ext v0.0.0-20190421051319-9d40249d3c2f // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/google/btree v1.0.0 // indirect
 	github.com/google/go-cmp v0.3.0
 	github.com/gorilla/mux v1.7.1 // indirect
+	github.com/grpc-ecosystem/grpc-gateway v1.5.0 // indirect
 	github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce // indirect
 	github.com/hashicorp/go-getter v1.4.0
 	github.com/hashicorp/go-multierror v0.0.0-20160811015721-8c5f0ad93604 // indirect

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -61,6 +61,8 @@ type MachineConfig struct {
 	DNSProxy            bool   // Only used by virtualbox
 	HostDNSResolver     bool   // Only used by virtualbox
 	KubernetesConfig    KubernetesConfig
+	HostOnlyNicType     string // Only used by virtualbox
+	NatNicType          string // Only used by virtualbox
 }
 
 // KubernetesConfig contains the parameters used to configure the VM Kubernetes.

--- a/pkg/minikube/registry/drvs/virtualbox/virtualbox.go
+++ b/pkg/minikube/registry/drvs/virtualbox/virtualbox.go
@@ -31,8 +31,7 @@ import (
 )
 
 const (
-	defaultVirtualboxNicType = "virtio"
-	docURL                   = "https://minikube.sigs.k8s.io/docs/reference/drivers/virtualbox/"
+	docURL = "https://minikube.sigs.k8s.io/docs/reference/drivers/virtualbox/"
 )
 
 func init() {
@@ -57,8 +56,8 @@ func configure(mc config.MachineConfig) interface{} {
 	d.HostOnlyCIDR = mc.HostOnlyCIDR
 	d.NoShare = mc.DisableDriverMounts
 	d.NoVTXCheck = mc.NoVTXCheck
-	d.NatNicType = defaultVirtualboxNicType
-	d.HostOnlyNicType = defaultVirtualboxNicType
+	d.NatNicType = mc.NatNicType
+	d.HostOnlyNicType = mc.HostOnlyNicType
 	d.DNSProxy = mc.DNSProxy
 	d.HostDNSResolver = mc.HostDNSResolver
 	return d


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

Fixes #5959 

Before:

`minikube start --vm-driver=virtualbox`

After:

`minikube start --vm-driver=virtualbox --nat-nic-type=82545EM`

OR

`minikube start --vm-driver=virtualbox --host-only-nic-type=82545EM`

OR

`minikube start --vm-driver=virtualbox --host-only-nic-type=82545EM --nat-nic-type=82545EM`

Default behavior is unchanged and `virtio` will be used as NIC type for both networks when the arguments are not supplied.