### PR TITLE
Fix validation of container-runtime config

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -51,7 +51,7 @@ var settings = []Setting{
 	{
 		name:        "container-runtime",
 		set:         SetString,
-		validations: []setFn{IsContainerdRuntime},
+		validations: []setFn{IsValidRuntime},
 		callbacks:   []setFn{RequiresRestartMsg},
 	},
 	{

--- a/cmd/minikube/cmd/config/validations.go
+++ b/cmd/minikube/cmd/config/validations.go
@@ -147,6 +147,15 @@ func IsValidAddon(name string, val string) error {
 	return errors.Errorf("Cannot enable/disable invalid addon %s", name)
 }
 
+// IsValidRuntime checks if a string is a valid runtime
+func IsValidRuntime(name string, runtime string) error {
+	_, err := cruntime.New(cruntime.Config{Type: runtime})
+	if err != nil {
+		return fmt.Errorf("invalid runtime: %v", err)
+	}
+	return nil
+}
+
 // IsContainerdRuntime is a validator which returns an error if the current runtime is not containerd
 func IsContainerdRuntime(_, _ string) error {
 	config, err := config.Load()

--- a/cmd/minikube/cmd/config/validations_test.go
+++ b/cmd/minikube/cmd/config/validations_test.go
@@ -98,6 +98,33 @@ func TestValidCIDR(t *testing.T) {
 	runValidations(t, tests, "cidr", IsValidCIDR)
 }
 
+func TestValidRuntime(t *testing.T) {
+	var tests = []validationTest{
+		{
+			value:     "", // default
+			shouldErr: false,
+		},
+		{
+			value:     "invalid",
+			shouldErr: true,
+		},
+		{
+			value:     "containerd",
+			shouldErr: false,
+		},
+		{
+			value:     "crio",
+			shouldErr: false,
+		},
+		{
+			value:     "docker",
+			shouldErr: false,
+		},
+	}
+
+	runValidations(t, tests, "container-runtime", IsValidRuntime)
+}
+
 func TestIsURLExists(t *testing.T) {
 
 	self, err := os.Executable()


### PR DESCRIPTION
It was trying to load (non-existing) config,
and also confusingly looking for containerd.

Add a unit test as well.

Closes ##5961