### PR TITLE
wip: Improve minikube cache

### DIFF
--- a/cmd/minikube/cmd/cache.go
+++ b/cmd/minikube/cmd/cache.go
@@ -19,10 +19,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 	cmdConfig "k8s.io/minikube/cmd/minikube/cmd/config"
-	"k8s.io/minikube/pkg/minikube/config"
-	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/exit"
-	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/minikube/machine"
 )
 
@@ -68,33 +65,6 @@ var deleteCacheCmd = &cobra.Command{
 			exit.WithError("Failed to delete images", err)
 		}
 	},
-}
-
-func imagesInConfigFile() ([]string, error) {
-	configFile, err := config.ReadConfig(localpath.ConfigFile)
-	if err != nil {
-		return nil, err
-	}
-	if values, ok := configFile[cacheImageConfigKey]; ok {
-		var images []string
-		for key := range values.(map[string]interface{}) {
-			images = append(images, key)
-		}
-		return images, nil
-	}
-	return []string{}, nil
-}
-
-// CacheImagesInConfigFile caches the images currently in the config file (minikube start)
-func CacheImagesInConfigFile() error {
-	images, err := imagesInConfigFile()
-	if err != nil {
-		return err
-	}
-	if len(images) == 0 {
-		return nil
-	}
-	return machine.CacheImages(images, constants.ImageCacheDir)
 }
 
 func init() {

--- a/cmd/minikube/cmd/cache.go
+++ b/cmd/minikube/cmd/cache.go
@@ -97,18 +97,6 @@ func CacheImagesInConfigFile() error {
 	return machine.CacheImages(images, constants.ImageCacheDir)
 }
 
-// loadCachedImagesInConfigFile loads the images currently in the config file (minikube start)
-func loadCachedImagesInConfigFile() error {
-	images, err := imagesInConfigFile()
-	if err != nil {
-		return err
-	}
-	if len(images) == 0 {
-		return nil
-	}
-	return machine.CacheAndLoadImages(images)
-}
-
 func init() {
 	cacheCmd.AddCommand(addCacheCmd)
 	cacheCmd.AddCommand(deleteCacheCmd)

--- a/cmd/minikube/cmd/cache_list.go
+++ b/cmd/minikube/cmd/cache_list.go
@@ -54,11 +54,11 @@ var listCacheCmd = &cobra.Command{
 			glog.Info("no old config found for cache")
 		}
 
-		if len(imagsInOldConfig) > 0 { // TODO handle migration automaticly
+		if len(imagsInOldConfig) > 0 { // TODO handle migration automatically
 			out.WarningT(`Warning:
-	Images {{.imgs}} were cached using older version minikube.
-	Please consider re-caching them again using "minikube cache add" commmand.			
-	Caches are now per-profile.`, out.V{"imgs": imagsInOldConfig})
+	- Images {{.imgs}} were cached using older version minikube.
+	- Please consider re-caching them again using "minikube cache add" command.		
+	- Caches are now per-profile.`, out.V{"imgs": imagsInOldConfig})
 		}
 		var imgs []string
 		for k := range config.CachedImages {

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -361,9 +361,7 @@ func runStart(cmd *cobra.Command, args []string) {
 	// enable addons with start command
 	enableAddons()
 
-	if err = loadCachedImagesInConfigFile(); err != nil {
-		out.T(out.FailureType, "Unable to load cached images from config file.")
-	}
+	cacheUserImages(&config)
 
 	// special ops for none , like change minikube directory.
 	if driverName == driver.None {
@@ -378,6 +376,12 @@ func runStart(cmd *cobra.Command, args []string) {
 	}
 	if err := showKubectlInfo(kubeconfig, k8sVersion, config.Name); err != nil {
 		glog.Errorf("kubectl info: %v", err)
+	}
+}
+
+func cacheUserImages(c *cfg.MachineConfig) {
+	if err := machine.CacheAndLoadImages(c.CachedImages); err != nil {
+		out.T(out.FailureType, "Unable to load cached images from config file.")
 	}
 }
 

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -379,6 +379,7 @@ func runStart(cmd *cobra.Command, args []string) {
 	}
 }
 
+// cache and load the images that user added to profile
 func cacheUserImages(c *cfg.MachineConfig) {
 	if err := machine.CacheAndLoadImages(c.CachedImages); err != nil {
 		out.T(out.FailureType, "Unable to load cached images from config file.")
@@ -403,6 +404,7 @@ func enableAddons() {
 	}
 }
 
+// displayVersion displays minikube version and platform
 func displayVersion(version string) {
 	prefix := ""
 	if viper.GetString(cfg.MachineProfile) != constants.DefaultMachineName {
@@ -475,12 +477,12 @@ func handleDownloadOnly(cacheGroup *errgroup.Group, c *cfg.MachineConfig) {
 
 }
 
-func startMachine(config *cfg.MachineConfig) (runner command.Runner, preExists bool, machineAPI libmachine.API, host *host.Host) {
+func startMachine(c *cfg.MachineConfig) (runner command.Runner, preExists bool, machineAPI libmachine.API, host *host.Host) {
 	m, err := machine.NewAPIClient()
 	if err != nil {
 		exit.WithError("Failed to get machine client", err)
 	}
-	host, preExists = startHost(m, *config)
+	host, preExists = startHost(m, *c)
 	runner, err = machine.CommandRunner(host)
 	if err != nil {
 		exit.WithError("Failed to get command runner", err)
@@ -493,8 +495,8 @@ func startMachine(config *cfg.MachineConfig) (runner command.Runner, preExists b
 		out.ErrT(out.FailureType, "Failed to set NO_PROXY Env. Please use `export NO_PROXY=$NO_PROXY,{{.ip}}`.", out.V{"ip": ip})
 	}
 	// Save IP to configuration file for subsequent use
-	config.KubernetesConfig.NodeIP = ip
-	if err := saveConfig(config); err != nil {
+	c.KubernetesConfig.NodeIP = ip
+	if err := saveConfig(c); err != nil {
 		exit.WithError("Failed to save config", err)
 	}
 
@@ -1261,6 +1263,6 @@ func configureMounts() {
 }
 
 // saveConfig saves profile cluster configuration in $MINIKUBE_HOME/profiles/<profilename>/config.json
-func saveConfig(clusterCfg *cfg.MachineConfig) error {
-	return cfg.CreateProfile(viper.GetString(cfg.MachineProfile), clusterCfg)
+func saveConfig(c *cfg.MachineConfig) error {
+	return cfg.CreateProfile(viper.GetString(cfg.MachineProfile), c)
 }

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -381,8 +381,12 @@ func runStart(cmd *cobra.Command, args []string) {
 
 // cache and load the images that user added to profile
 func cacheUserImages(c *cfg.MachineConfig) {
-	if err := machine.CacheAndLoadImages(c.CachedImages); err != nil {
-		out.T(out.FailureType, "Unable to load cached images from config file.")
+	var imgs []string
+	for k := range c.CachedImages {
+		imgs = append(imgs, k)
+	}
+	if err := machine.CacheAndLoadImages(imgs); err != nil {
+		out.T(out.FailureType, "Unable to load cached images.")
 	}
 }
 
@@ -468,8 +472,11 @@ func handleDownloadOnly(cacheGroup *errgroup.Group, c *cfg.MachineConfig) {
 		exit.WithError("Failed to cache binaries", err)
 	}
 	waitCacheImages(cacheGroup)
-
-	if err := machine.CacheImages(c.CachedImages, constants.ImageCacheDir); err != nil {
+	var imgs []string
+	for k := range c.CachedImages {
+		imgs = append(imgs, k)
+	}
+	if err := machine.CacheImages(imgs, constants.ImageCacheDir); err != nil {
 		exit.WithError("Failed to cache images", err)
 	}
 	out.T(out.Check, "Download complete!")

--- a/go.mod
+++ b/go.mod
@@ -21,14 +21,11 @@ require (
 	github.com/docker/machine v0.7.1-0.20190718054102-a555e4f7a8f5 // version is 0.7.1 to pin to a555e4f7a8f5
 	github.com/elazarl/goproxy v0.0.0-20190421051319-9d40249d3c2f
 	github.com/elazarl/goproxy/ext v0.0.0-20190421051319-9d40249d3c2f // indirect
-	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
-	github.com/google/btree v1.0.0 // indirect
 	github.com/google/go-cmp v0.3.0
 	github.com/gorilla/mux v1.7.1 // indirect
-	github.com/grpc-ecosystem/grpc-gateway v1.5.0 // indirect
 	github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce // indirect
 	github.com/hashicorp/go-getter v1.4.0
 	github.com/hashicorp/go-multierror v0.0.0-20160811015721-8c5f0ad93604 // indirect

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -40,7 +40,7 @@ type MachineConfig struct {
 	DiskSize            int
 	VMDriver            string
 	ContainerRuntime    string
-	CachedImages        []string
+	CachedImages        []string // images that user added by `cache add`
 	HyperkitVpnKitSock  string   // Only used by the Hyperkit driver
 	HyperkitVSockPorts  []string // Only used by the Hyperkit driver
 	DockerEnv           []string // Each entry is formatted as KEY=VALUE.

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -40,6 +40,7 @@ type MachineConfig struct {
 	DiskSize            int
 	VMDriver            string
 	ContainerRuntime    string
+	CachedImages        []string
 	HyperkitVpnKitSock  string   // Only used by the Hyperkit driver
 	HyperkitVSockPorts  []string // Only used by the Hyperkit driver
 	DockerEnv           []string // Each entry is formatted as KEY=VALUE.

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -40,10 +40,10 @@ type MachineConfig struct {
 	DiskSize            int
 	VMDriver            string
 	ContainerRuntime    string
-	CachedImages        []string // images that user added by `cache add`
-	HyperkitVpnKitSock  string   // Only used by the Hyperkit driver
-	HyperkitVSockPorts  []string // Only used by the Hyperkit driver
-	DockerEnv           []string // Each entry is formatted as KEY=VALUE.
+	CachedImages        map[string]string // images that user added by `cache add` key is image name, value could be hash
+	HyperkitVpnKitSock  string            // Only used by the Hyperkit driver
+	HyperkitVSockPorts  []string          // Only used by the Hyperkit driver
+	DockerEnv           []string          // Each entry is formatted as KEY=VALUE.
 	InsecureRegistry    []string
 	RegistryMirror      []string
 	HostOnlyCIDR        string // Only used by the virtualbox driver

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -328,6 +328,12 @@ func CacheImage(image, dst string) error {
 
 	glog.Infoln("OPENING: ", dstPath)
 	f, err := ioutil.TempFile(filepath.Dir(dstPath), filepath.Base(dstPath)+".*.tmp")
+	defer func() {
+		err := os.Remove(f.Name())
+		if err != nil {
+			glog.Infof("Failed to clean up the temp file %s : %v", f.Name(), err)
+		}
+	}()
 	if err != nil {
 		return err
 	}

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -313,12 +313,20 @@ func validateCacheCmd(ctx context.Context, t *testing.T, profile string) {
 		}
 	}
 
-	_, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "cache", "delete", "busybox:1.28.4-glibc"))
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "docker", "images"))
+	if err != nil {
+		t.Errorf("failed to get docker images through ssh %v", err)
+
+	}
+	if !strings.Contains(rr.Output(), "busybox:1.28.4-glibc") {
+		t.Errorf("expected busybox:1.28.4-glibc to be loaded by docker inside minikube node. but got %s", rr.Output())
+	}
+	_, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "cache", "delete", "busybox:1.28.4-glibc"))
 	if err != nil {
 		t.Errorf("failed to delete image busybox:1.28.4-glibc from cache: %v", err)
 	}
 
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "cache", "list"))
+	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "cache", "list"))
 	if err != nil {
 		t.Errorf("cache list failed: %v", err)
 	}

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -306,7 +306,7 @@ func validateCacheCmd(ctx context.Context, t *testing.T, profile string) {
 	if NoneDriver() {
 		t.Skipf("skipping: cache unsupported by none")
 	}
-	for _, img := range []string{"busybox", "busybox:1.28.4-glibc", "k8s.gcr.io/echoserver:1.4"} {
+	for _, img := range []string{"busybox", "busybox:1.28.4-glibc", "k8s.gcr.io/pause:latest"} {
 		_, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "cache", "add", img))
 		if err != nil {
 			t.Errorf("failed to add %q to cache", img)
@@ -330,8 +330,8 @@ func validateCacheCmd(ctx context.Context, t *testing.T, profile string) {
 	if err != nil {
 		t.Errorf("cache list failed: %v", err)
 	}
-	if !strings.Contains(rr.Output(), "k8s.gcr.io/echoserver:1.4") {
-		t.Errorf("cache list did not include k8s.gcr.io/echoserver:1.4")
+	if !strings.Contains(rr.Output(), "k8s.gcr.io/pause") {
+		t.Errorf("cache list did not include k8s.gcr.io/pause")
 	}
 	if strings.Contains(rr.Output(), "busybox:1.28.4-glibc") {
 		t.Errorf("cache list should not include busybox:1.28.4-glibc")


### PR DESCRIPTION
before this PR
cache add was not consistent as described in this bug: https://github.com/kubernetes/minikube/issues/5974

This will be a breaking change !

- `cache add` command will be per profile ! 
- new field in machine config for user Cached Images 
- added integration tests for (cache add, cache delete and cache list, and check image loaded inside node)
- choose smaller images for in integration tests ( 6 mb instead of 655 mb)
- clean up the temporary files

### before this PR 

```
 $ cat ~/.minikube/config/config.json 
{
    "cache": {
        "gcr.io/hello-minikube-zero-install/hello-node": null,
        "k8s.gcr.io/echoserver:1.4": null,
        "med": null
    }
}
```

### after this PR 
- will be new map in profile config
```
{
    "Name": "minikube",
    "KeepContext": false,
    "EmbedCerts": false,
    "MinikubeISO": "https://storage.googleapis.com/minikube/iso/minikube-v1.5.1.iso",
    "Memory": 2000,
    "CPUs": 2,
    "DiskSize": 20000,
    "VMDriver": "hyperkit",
    "ContainerRuntime": "docker",
    "CachedImages": {
        "busybox": "loaded",
        "e4": "loaded",
        "k8s.gcr.io/echoserver:1.4": "loaded",
        "med": "loaded"
    },
...
...
...
```

- will warn if there is a older cache in global config
```
$ ./out/minikube cache list
⚠️  Warning:
        Images [gcr.io/hello-minikube-zero-install/hello-node k8s.gcr.io/echoserver:1.4 med] were cached using older version minikube.
        Please consider re-caching them again using "minikube cache add" commmand.
        Caches are now per-profile.
busybox
e4
k8s.gcr.io/echoserver:1.4
med
```


## TODO: 

1- load image only if it is not already loaded.
2- move the cache logics from machine package to its own package
3- store the image sha in the config map,
4- cache even if minikube is not runninng