### PR TITLE
show status in profile list

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,14 +21,11 @@ require (
 	github.com/docker/machine v0.7.1-0.20190718054102-a555e4f7a8f5 // version is 0.7.1 to pin to a555e4f7a8f5
 	github.com/elazarl/goproxy v0.0.0-20190421051319-9d40249d3c2f
 	github.com/elazarl/goproxy/ext v0.0.0-20190421051319-9d40249d3c2f // indirect
-	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
-	github.com/google/btree v1.0.0 // indirect
 	github.com/google/go-cmp v0.3.0
 	github.com/gorilla/mux v1.7.1 // indirect
-	github.com/grpc-ecosystem/grpc-gateway v1.5.0 // indirect
 	github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce // indirect
 	github.com/hashicorp/go-getter v1.4.0
 	github.com/hashicorp/go-multierror v0.0.0-20160811015721-8c5f0ad93604 // indirect

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -26,6 +26,7 @@ import (
 // Profile represents a minikube profile
 type Profile struct {
 	Name   string
+	Status string // running, stopped
 	Config []*MachineConfig
 }
 


### PR DESCRIPTION
This PR adds a new feature to see the status of a minikube profile (cluster) in the profile list command.

### before this PR:
```
 $ ./out/minikube profile list
|---------|-----------|----------------|-----------|--------------------|
| Profile | VM Driver |     NodeIP     | Node Port | Kubernetes Version |
|---------|-----------|----------------|-----------|--------------------|
| p1      | hyperkit  | 192.168.64.165 |      8443 | v1.17.0-rc.1       |
|---------|-----------|----------------|-----------|--------------------|
```

### after this PR:

$ make out/minikube && ./out/minikube profile list -o=table
```
|---------|-----------|----------------|-----------|--------------------|---------|
| Profile | VM Driver |     NodeIP     | Node Port | Kubernetes Version | Status  |
|---------|-----------|----------------|-----------|--------------------|---------|
| p1      | hyperkit  | 192.168.64.168 |      8443 | v1.17.0-rc.1       | Running |
| p2      | hyperkit  | 192.168.64.169 |      8443 | v1.17.0-rc.1       | Stopped |
|---------|-----------|----------------|-----------|--------------------|---------|
```

and also it added a status field to the json output

```
$ ./out/minikube profile list -o=json
{"invalid":[],"valid":[{"Name":"p1","Status":"Running","Config":[{"Name":"p1","KeepContext":false,"EmbedCerts":false,"MinikubeISO":"https://storage.googleapis.com/minikube/iso/minikube-v1.6.0-beta.1.iso","Memory":2000,"CPUs":2,"DiskSize":20000,"VMDriver":"hyperkit","ContainerRuntime":"docker","HyperkitVpnKitSock":"","HyperkitVSockPorts":[],"DockerEnv":null,"InsecureRegistry":null,"RegistryMirror":null,"HostOnlyCIDR":"192.168.99.1/24","HypervVirtualSwitch":"","KVMNetwork":"default","KVMQemuURI":"qemu:///system","KVMGPU":false,"KVMHidden":false,"DockerOpt":null,"DisableDriverMounts":false,"NFSShare":[],"NFSSharesRoot":"/nfsshares","UUID":"","NoVTXCheck":false,"DNSProxy":false,"HostDNSResolver":true,"KubernetesConfig":{"KubernetesVersion":"v1.17.0-rc.1","NodeIP":"192.168.64.168","NodePort":8443,"NodeName":"minikube","APIServerName":"minikubeCA","APIServerNames":null,"APIServerIPs":null,"DNSDomain":"cluster.local","ContainerRuntime":"docker","CRISocket":"","NetworkPlugin":"","FeatureGates":"","ServiceCIDR":"10.96.0.0/12","ImageRepository":"","ExtraOptions":null,"ShouldLoadCachedImages":true,"EnableDefaultCNI":false},"HostOnlyNicType":"virtio","NatNicType":"virtio"}]},{"Name":"p2","Status":"Running","Config":[{"Name":"p2","KeepContext":false,"EmbedCerts":false,"MinikubeISO":"https://storage.googleapis.com/minikube/iso/minikube-v1.6.0-beta.1.iso","Memory":2000,"CPUs":2,"DiskSize":20000,"VMDriver":"hyperkit","ContainerRuntime":"docker","HyperkitVpnKitSock":"","HyperkitVSockPorts":[],"DockerEnv":null,"InsecureRegistry":null,"RegistryMirror":null,"HostOnlyCIDR":"192.168.99.1/24","HypervVirtualSwitch":"","KVMNetwork":"default","KVMQemuURI":"qemu:///system","KVMGPU":false,"KVMHidden":false,"DockerOpt":null,"DisableDriverMounts":false,"NFSShare":[],"NFSSharesRoot":"/nfsshares","UUID":"","NoVTXCheck":false,"DNSProxy":false,"HostDNSResolver":true,"KubernetesConfig":{"KubernetesVersion":"v1.17.0-rc.1","NodeIP":"192.168.64.169","NodePort":8443,"NodeName":"minikube","APIServerName":"minikubeCA","APIServerNames":null,"APIServerIPs":null,"DNSDomain":"cluster.local","ContainerRuntime":"docker","CRISocket":"","NetworkPlugin":"","FeatureGates":"","ServiceCIDR":"10.96.0.0/12","ImageRepository":"","ExtraOptions":null,"ShouldLoadCachedImages":true,"EnableDefaultCNI":false},"HostOnlyNicType":"virtio","NatNicType":"virtio"}]}]}
```
