### PR TITLE
typo: Fix typo in err_map key

### DIFF
--- a/pkg/minikube/problem/err_map.go
+++ b/pkg/minikube/problem/err_map.go
@@ -400,7 +400,7 @@ var osProblems = map[string]match{
 
 // stateProblems are issues relating to local state
 var stateProblems = map[string]match{
-	"MACHINE_DOES_NOT_EXST": {
+	"MACHINE_DOES_NOT_EXIST": {
 		Regexp:         re(`Error getting state for host: machine does not exist`),
 		Advice:         "Run 'minikube delete' to delete the stale VM",
 		Issues:         []int{3864},


### PR DESCRIPTION
Change "MACHINE_DOES_NOT_EXST" to "MACHINE_DOES_NOT_EXIST".

Please disregard if not valid.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
