### PR TITLE
Update dashboard to 2.0.0b8 and pre-cache it again

### DIFF
--- a/deploy/addons/dashboard/dashboard-dp.yaml
+++ b/deploy/addons/dashboard/dashboard-dp.yaml
@@ -89,7 +89,8 @@ spec:
     spec:
       containers:
         - name: kubernetes-dashboard
-          image: kubernetesui/dashboard:v2.0.0-beta6
+          # WARNING: This must match pkg/minikube/bootstrapper/images/images.go
+          image: kubernetesui/dashboard:v2.0.0-beta8
           ports:
             - containerPort: 9090
               protocol: TCP

--- a/pkg/minikube/bootstrapper/images/images.go
+++ b/pkg/minikube/bootstrapper/images/images.go
@@ -144,6 +144,8 @@ func CachedImages(imageRepositoryStr string, kubernetesVersionStr string) []stri
 	}
 
 	images = append(images, []string{
+		// This must match deploy/addons/dashboard/dashboard-dp.yaml
+		"kubernetesui/dashboard:v2.0.0-beta8",
 		imageRepository + "kube-addon-manager" + ArchTag(false) + "v9.0",
 		minikubeRepository + "storage-provisioner" + ArchTag(false) + "v1.8.1",
 	}...)


### PR DESCRIPTION
I wasn't sure how to pre-cache their docker-hub based images, but this seems to work.

<img width="556" alt="Screen Shot 2019-12-09 at 2 19 07 PM" src="https://user-images.githubusercontent.com/101424/70478009-ee112280-1a8e-11ea-8922-e36acc0b7b13.png">
