### PR TITLE
CI: adding time to to commit description

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -272,7 +272,7 @@ set +x
 echo ">> ${E2E_BIN} exited with ${result} at $(date)"
 echo ""
 e2e_end_time="$(date -u +%s)"
-elapsed=$(($end_time-$start_time))
+elapsed=$(($e2e_end_time-$e2e_start_time))
 elapsed=$(bc <<< "scale=2;$elapsed/60")
 description="Finished in ${elapsed} minute(s)."
 echo $description

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -280,9 +280,12 @@ else
   echo "minikube: FAIL"
 fi
 
+## caclucate the time took to finish running e2e binary test.
 e2e_end_time="$(date -u +%s)"
 elapsed=$(($e2e_end_time-$e2e_start_time))
-elapsed=$(bc <<< "scale=2;$elapsed/60")
+min=$(($elapsed/60))
+sec=$(tail -c 3 <<< $((${elapsed}00/60)))
+elapsed=$min.$sec
 description="completed with ${status} in ${elapsed} minute(s)."
 echo $description
 

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -271,11 +271,6 @@ ${SUDO_PREFIX}${E2E_BIN} \
 set +x
 echo ">> ${E2E_BIN} exited with ${result} at $(date)"
 echo ""
-e2e_end_time="$(date -u +%s)"
-elapsed=$(($e2e_end_time-$e2e_start_time))
-elapsed=$(bc <<< "scale=2;$elapsed/60")
-description="Finished in ${elapsed} minute(s)."
-echo $description
 
 if [[ $result -eq 0 ]]; then
   status="success"
@@ -284,6 +279,13 @@ else
   status="failure"
   echo "minikube: FAIL"
 fi
+
+e2e_end_time="$(date -u +%s)"
+elapsed=$(($e2e_end_time-$e2e_start_time))
+elapsed=$(bc <<< "scale=2;$elapsed/60")
+description="completed with ${status} in ${elapsed} minute(s)."
+echo $description
+
 
 echo ">> Cleaning up after ourselves ..."
 ${SUDO_PREFIX}${MINIKUBE_BIN} tunnel --cleanup || true

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -258,6 +258,7 @@ if [[ "${LOAD}" -gt 2 ]]; then
   uptime
 fi
 
+e2e_start_time="$(date -u +%s)"
 echo ""
 echo ">> Starting ${E2E_BIN} at $(date)"
 set -x
@@ -270,6 +271,11 @@ ${SUDO_PREFIX}${E2E_BIN} \
 set +x
 echo ">> ${E2E_BIN} exited with ${result} at $(date)"
 echo ""
+e2e_end_time="$(date -u +%s)"
+elapsed=$(($end_time-$start_time))
+elapsed=$(bc <<< "scale=2;$elapsed/60")
+description="Finished in ${elapsed} minute(s)."
+echo $description
 
 if [[ $result -eq 0 ]]; then
   status="success"
@@ -300,6 +306,7 @@ function retry_github_status() {
   local state=$3
   local token=$4
   local target=$5
+  local desc=$6
 
    # Retry in case we hit our GitHub API quota or fail other ways.
   local attempt=0
@@ -312,7 +319,7 @@ function retry_github_status() {
       "https://api.github.com/repos/kubernetes/minikube/statuses/${commit}?access_token=${token}" \
       -H "Content-Type: application/json" \
       -X POST \
-      -d "{\"state\": \"${state}\", \"description\": \"Jenkins\", \"target_url\": \"${target}\", \"context\": \"${context}\"}" || echo 999)
+      -d "{\"state\": \"${state}\", \"description\": \"Jenkins: ${desc}\", \"target_url\": \"${target}\", \"context\": \"${context}\"}" || echo 999)
 
     # 2xx HTTP codes
     if [[ "${code}" =~ ^2 ]]; then
@@ -327,5 +334,7 @@ function retry_github_status() {
   done
 }
 
-retry_github_status "${COMMIT}" "${JOB_NAME}" "${status}" "${access_token}" "https://storage.googleapis.com/minikube-builds/logs/${MINIKUBE_LOCATION}/${JOB_NAME}.txt"
+
+
+retry_github_status "${COMMIT}" "${JOB_NAME}" "${status}" "${access_token}" "https://storage.googleapis.com/minikube-builds/logs/${MINIKUBE_LOCATION}/${JOB_NAME}.txt" "${description}"
 exit $result


### PR DESCRIPTION
will add a description to the commit status for the PR integration tests showing how much time it took to finish.

before this PR it looked liked this:
![Screen Shot 2019-12-10 at 2 46 23 PM](https://user-images.githubusercontent.com/4564227/70575694-e66b7f80-1b5b-11ea-9e5f-e84830fd2dcd.png)

After this PR: 

<img width="744" alt="Screen Shot 2019-12-10 at 4 31 57 PM" src="https://user-images.githubusercontent.com/4564227/70581024-a1027e80-1b6a-11ea-81d5-4cccf77b9ee1.png">
