### PR TITLE
adding feature to reload cache 

### DIFF
--- a/cmd/minikube/cmd/cache.go
+++ b/cmd/minikube/cmd/cache.go
@@ -65,7 +65,7 @@ var deleteCacheCmd = &cobra.Command{
 			exit.WithError("Failed to delete images from config", err)
 		}
 		// Delete images from cache/images directory
-		if err := image.DeleteFromImageCacheDir(args); err != nil {
+		if err := image.DeleteFromCacheDir(args); err != nil {
 			exit.WithError("Failed to delete images", err)
 		}
 	},

--- a/cmd/minikube/cmd/cache.go
+++ b/cmd/minikube/cmd/cache.go
@@ -85,8 +85,8 @@ func imagesInConfigFile() ([]string, error) {
 	return []string{}, nil
 }
 
-// CacheImagesInConfigFile caches the images currently in the config file (minikube start)
-func CacheImagesInConfigFile() error {
+// cacheImagesInConfigFile caches the images currently in the config file (minikube start)
+func cacheImagesInConfigFile() error {
 	images, err := imagesInConfigFile()
 	if err != nil {
 		return err

--- a/cmd/minikube/cmd/cache.go
+++ b/cmd/minikube/cmd/cache.go
@@ -95,7 +95,7 @@ func saveImagesToTarFromConfig() error {
 	if len(images) == 0 {
 		return nil
 	}
-	return machine.CacheImagesToHostDisk(images, constants.ImageCacheDir)
+	return machine.CacheImagesToTar(images, constants.ImageCacheDir)
 }
 
 // loadCachedImagesInConfigFile loads the images currently in the config file (minikube start)

--- a/cmd/minikube/cmd/cache.go
+++ b/cmd/minikube/cmd/cache.go
@@ -70,6 +70,16 @@ var deleteCacheCmd = &cobra.Command{
 	},
 }
 
+// reloadCacheCmd represents the cache reload command
+var reloadCacheCmd = &cobra.Command{
+	Use:   "reload",
+	Short: "reload cached images.",
+	Long:  "reloads the cached images specificed by user in the config file.",
+	Run: func(cmd *cobra.Command, args []string) {
+		cacheAndLoadImagesInConfig()
+	},
+}
+
 func imagesInConfigFile() ([]string, error) {
 	configFile, err := config.ReadConfig(localpath.ConfigFile)
 	if err != nil {
@@ -98,8 +108,9 @@ func saveImagesToTarFromConfig() error {
 	return machine.CacheImagesToTar(images, constants.ImageCacheDir)
 }
 
-// loadCachedImagesInConfigFile loads the images currently in the config file (minikube start)
-func loadCachedImagesInConfigFile() error {
+// cacheAndLoadImagesInConfig loads the images currently in the config file
+// called by 'start' and 'cache reload' commands.
+func cacheAndLoadImagesInConfig() error {
 	images, err := imagesInConfigFile()
 	if err != nil {
 		return err
@@ -113,4 +124,5 @@ func loadCachedImagesInConfigFile() error {
 func init() {
 	cacheCmd.AddCommand(addCacheCmd)
 	cacheCmd.AddCommand(deleteCacheCmd)
+	cacheCmd.AddCommand(reloadCacheCmd)
 }

--- a/cmd/minikube/cmd/cache.go
+++ b/cmd/minikube/cmd/cache.go
@@ -76,7 +76,10 @@ var reloadCacheCmd = &cobra.Command{
 	Short: "reload cached images.",
 	Long:  "reloads the cached images specificed by user in the config file.",
 	Run: func(cmd *cobra.Command, args []string) {
-		cacheAndLoadImagesInConfig()
+		err := cacheAndLoadImagesInConfig()
+		if err != nil {
+			exit.WithError("Failed to reload cached images", err)
+		}
 	},
 }
 

--- a/cmd/minikube/cmd/cache.go
+++ b/cmd/minikube/cmd/cache.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/exit"
+	"k8s.io/minikube/pkg/minikube/image"
 	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/minikube/machine"
 )
@@ -64,7 +65,7 @@ var deleteCacheCmd = &cobra.Command{
 			exit.WithError("Failed to delete images from config", err)
 		}
 		// Delete images from cache/images directory
-		if err := machine.DeleteFromImageCacheDir(args); err != nil {
+		if err := image.DeleteFromImageCacheDir(args); err != nil {
 			exit.WithError("Failed to delete images", err)
 		}
 	},
@@ -108,7 +109,7 @@ func saveImagesToTarFromConfig() error {
 	if len(images) == 0 {
 		return nil
 	}
-	return machine.CacheImagesToTar(images, constants.ImageCacheDir)
+	return image.CacheImagesToTar(images, constants.ImageCacheDir)
 }
 
 // cacheAndLoadImagesInConfig loads the images currently in the config file

--- a/cmd/minikube/cmd/cache.go
+++ b/cmd/minikube/cmd/cache.go
@@ -109,7 +109,7 @@ func saveImagesToTarFromConfig() error {
 	if len(images) == 0 {
 		return nil
 	}
-	return image.CacheImagesToTar(images, constants.ImageCacheDir)
+	return image.SaveToDir(images, constants.ImageCacheDir)
 }
 
 // cacheAndLoadImagesInConfig loads the images currently in the config file

--- a/cmd/minikube/cmd/cache.go
+++ b/cmd/minikube/cmd/cache.go
@@ -74,7 +74,7 @@ var deleteCacheCmd = &cobra.Command{
 var reloadCacheCmd = &cobra.Command{
 	Use:   "reload",
 	Short: "reload cached images.",
-	Long:  "reloads the cached images specificed by user in the config file.",
+	Long:  "reloads images previously added using the 'cache add' subcommand",
 	Run: func(cmd *cobra.Command, args []string) {
 		err := cacheAndLoadImagesInConfig()
 		if err != nil {

--- a/cmd/minikube/cmd/cache.go
+++ b/cmd/minikube/cmd/cache.go
@@ -85,8 +85,9 @@ func imagesInConfigFile() ([]string, error) {
 	return []string{}, nil
 }
 
-// cacheImagesInConfigFile caches the images currently in the config file (minikube start)
-func cacheImagesInConfigFile() error {
+// saveImagesToTarFromConfig saves images to tar in cache which specified in config file.
+// currently only used by download-only option
+func saveImagesToTarFromConfig() error {
 	images, err := imagesInConfigFile()
 	if err != nil {
 		return err

--- a/cmd/minikube/cmd/cache.go
+++ b/cmd/minikube/cmd/cache.go
@@ -94,7 +94,7 @@ func cacheImagesInConfigFile() error {
 	if len(images) == 0 {
 		return nil
 	}
-	return machine.CacheImages(images, constants.ImageCacheDir)
+	return machine.CacheImagesToHostDisk(images, constants.ImageCacheDir)
 }
 
 // loadCachedImagesInConfigFile loads the images currently in the config file (minikube start)

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -820,7 +820,7 @@ func doCacheBinaries(k8sVersion string) error {
 	return machine.CacheBinariesForBootstrapper(k8sVersion, viper.GetString(cmdcfg.Bootstrapper))
 }
 
-// beginCacheRequiredImages caches images required for kuberntes version in the background
+// beginCacheRequiredImages caches images required for kubernetes version in the background
 func beginCacheRequiredImages(g *errgroup.Group, imageRepository string, k8sVersion string) {
 	if !viper.GetBool(cacheImages) {
 		return

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -461,8 +461,8 @@ func handleDownloadOnly(cacheGroup *errgroup.Group, k8sVersion string) {
 		exit.WithError("Failed to cache binaries", err)
 	}
 	waitCacheRequiredImages(cacheGroup)
-	if err := cacheImagesInConfigFile(); err != nil {
-		exit.WithError("Failed to cache images", err)
+	if err := saveImagesToTarFromConfig(); err != nil {
+		exit.WithError("Failed to cache images to tar", err)
 	}
 	out.T(out.Check, "Download complete!")
 	os.Exit(0)

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -327,7 +327,7 @@ func runStart(cmd *cobra.Command, args []string) {
 
 	// Now that the ISO is downloaded, pull images in the background while the VM boots.
 	var cacheGroup errgroup.Group
-	beginCacheImages(&cacheGroup, config.KubernetesConfig.ImageRepository, k8sVersion)
+	beginCacheRequiredImages(&cacheGroup, config.KubernetesConfig.ImageRepository, k8sVersion)
 
 	// Abstraction leakage alert: startHost requires the config to be saved, to satistfy pkg/provision/buildroot.
 	// Hence, saveConfig must be called before startHost, and again afterwards when we know the IP.
@@ -342,7 +342,7 @@ func runStart(cmd *cobra.Command, args []string) {
 	// configure the runtime (docker, containerd, crio)
 	cr := configureRuntimes(mRunner, driverName, config.KubernetesConfig)
 	showVersionInfo(k8sVersion, cr)
-	waitCacheImages(&cacheGroup)
+	waitCacheRequiredImages(&cacheGroup)
 
 	// Must be written before bootstrap, otherwise health checks may flake due to stale IP
 	kubeconfig, err := setupKubeconfig(host, &config, config.Name)
@@ -460,7 +460,7 @@ func handleDownloadOnly(cacheGroup *errgroup.Group, k8sVersion string) {
 	if err := doCacheBinaries(k8sVersion); err != nil {
 		exit.WithError("Failed to cache binaries", err)
 	}
-	waitCacheImages(cacheGroup)
+	waitCacheRequiredImages(cacheGroup)
 	if err := cacheImagesInConfigFile(); err != nil {
 		exit.WithError("Failed to cache images", err)
 	}
@@ -820,8 +820,8 @@ func doCacheBinaries(k8sVersion string) error {
 	return machine.CacheBinariesForBootstrapper(k8sVersion, viper.GetString(cmdcfg.Bootstrapper))
 }
 
-// beginCacheImages caches Docker images in the background
-func beginCacheImages(g *errgroup.Group, imageRepository string, k8sVersion string) {
+// beginCacheRequiredImages caches images required for kuberntes version in the background
+func beginCacheRequiredImages(g *errgroup.Group, imageRepository string, k8sVersion string) {
 	if !viper.GetBool(cacheImages) {
 		return
 	}
@@ -831,8 +831,8 @@ func beginCacheImages(g *errgroup.Group, imageRepository string, k8sVersion stri
 	})
 }
 
-// waitCacheImages blocks until the image cache jobs complete
-func waitCacheImages(g *errgroup.Group) {
+// waitCacheRequiredImages blocks until the required images are all cached.
+func waitCacheRequiredImages(g *errgroup.Group) {
 	if !viper.GetBool(cacheImages) {
 		return
 	}

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -461,7 +461,7 @@ func handleDownloadOnly(cacheGroup *errgroup.Group, k8sVersion string) {
 		exit.WithError("Failed to cache binaries", err)
 	}
 	waitCacheImages(cacheGroup)
-	if err := CacheImagesInConfigFile(); err != nil {
+	if err := cacheImagesInConfigFile(); err != nil {
 		exit.WithError("Failed to cache images", err)
 	}
 	out.T(out.Check, "Download complete!")

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -360,7 +360,7 @@ func runStart(cmd *cobra.Command, args []string) {
 	// enable addons with start command
 	enableAddons()
 
-	if err = loadCachedImagesInConfigFile(); err != nil {
+	if err = cacheAndLoadImagesInConfig(); err != nil {
 		out.T(out.FailureType, "Unable to load cached images from config file.")
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/cheggaaa/pb/v3 v3.0.1
 	github.com/cloudfoundry-attic/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21
 	github.com/cloudfoundry/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21 // indirect
-	github.com/docker/docker v1.13.1 // indirect
+	github.com/docker/docker v1.13.1
 	github.com/docker/go-units v0.3.3
 	github.com/docker/machine v0.7.1-0.20190718054102-a555e4f7a8f5 // version is 0.7.1 to pin to a555e4f7a8f5
 	github.com/elazarl/goproxy v0.0.0-20190421051319-9d40249d3c2f

--- a/pkg/minikube/image/cache.go
+++ b/pkg/minikube/image/cache.go
@@ -1,0 +1,108 @@
+package image
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+	"k8s.io/minikube/pkg/minikube/localpath"
+)
+
+// CacheImagesToTar will cache images on the host
+//
+// The cache directory currently caches images using the imagename_tag
+// For example, k8s.gcr.io/kube-addon-manager:v6.5 would be
+// stored at $CACHE_DIR/k8s.gcr.io/kube-addon-manager_v6.5
+func CacheImagesToTar(images []string, cacheDir string) error {
+	var g errgroup.Group
+	for _, image := range images {
+		image := image
+		g.Go(func() error {
+			dst := filepath.Join(cacheDir, image)
+			dst = localpath.SanitizeCacheDir(dst)
+			if err := cacheImageToTarFile(image, dst); err != nil {
+				glog.Errorf("CacheImage %s -> %s failed: %v", image, dst, err)
+				return errors.Wrapf(err, "caching image %q", dst)
+			}
+			glog.Infof("CacheImage %s -> %s succeeded", image, dst)
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return errors.Wrap(err, "caching images")
+	}
+	glog.Infoln("Successfully cached all images.")
+	return nil
+}
+
+// cacheImageToTarFile caches an image
+func cacheImageToTarFile(image, dst string) error {
+	start := time.Now()
+	glog.Infof("CacheImage: %s -> %s", image, dst)
+	defer func() {
+		glog.Infof("CacheImage: %s -> %s completed in %s", image, dst, time.Since(start))
+	}()
+
+	if _, err := os.Stat(dst); err == nil {
+		glog.Infof("%s exists", dst)
+		return nil
+	}
+
+	dstPath, err := localpath.DstPath(dst)
+	if err != nil {
+		return errors.Wrap(err, "getting destination path")
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dstPath), 0777); err != nil {
+		return errors.Wrapf(err, "making cache image directory: %s", dst)
+	}
+
+	ref, err := name.ParseReference(image, name.WeakValidation)
+	if err != nil {
+		return errors.Wrapf(err, "parsing image ref name for %s", image)
+	}
+
+	img, err := retrieveImage(ref)
+	if err != nil {
+		glog.Warningf("unable to retrieve image: %v", err)
+	}
+	glog.Infoln("OPENING: ", dstPath)
+	f, err := ioutil.TempFile(filepath.Dir(dstPath), filepath.Base(dstPath)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		// If we left behind a temp file, remove it.
+		_, err := os.Stat(f.Name())
+		if err == nil {
+			os.Remove(f.Name())
+			if err != nil {
+				glog.Warningf("Failed to clean up the temp file %s: %v", f.Name(), err)
+			}
+		}
+	}()
+	tag, err := name.NewTag(image, name.WeakValidation)
+	if err != nil {
+		return errors.Wrap(err, "newtag")
+	}
+	err = tarball.Write(tag, img, &tarball.WriteOptions{}, f)
+	if err != nil {
+		return errors.Wrap(err, "write")
+	}
+	err = f.Close()
+	if err != nil {
+		return errors.Wrap(err, "close")
+	}
+	err = os.Rename(f.Name(), dstPath)
+	if err != nil {
+		return errors.Wrap(err, "rename")
+	}
+	glog.Infof("%s exists", dst)
+	return nil
+}

--- a/pkg/minikube/image/cache.go
+++ b/pkg/minikube/image/cache.go
@@ -110,9 +110,9 @@ func saveToTarFile(image, dst string) error {
 		// If we left behind a temp file, remove it.
 		_, err := os.Stat(f.Name())
 		if err == nil {
-			os.Remove(f.Name())
+			err = os.Remove(f.Name())
 			if err != nil {
-				glog.Warningf("Failed to clean up the temp file %s: %v", f.Name(), err)
+				glog.Warningf("failed to clean up the temp file %s: %v", f.Name(), err)
 			}
 		}
 	}()

--- a/pkg/minikube/image/cache.go
+++ b/pkg/minikube/image/cache.go
@@ -44,12 +44,12 @@ func DeleteFromCacheDir(images []string) error {
 	return cleanImageCacheDir()
 }
 
-// CacheImagesToTar will cache images on the host
+// SaveToDir will cache images on the host
 //
 // The cache directory currently caches images using the imagename_tag
 // For example, k8s.gcr.io/kube-addon-manager:v6.5 would be
 // stored at $CACHE_DIR/k8s.gcr.io/kube-addon-manager_v6.5
-func CacheImagesToTar(images []string, cacheDir string) error {
+func SaveToDir(images []string, cacheDir string) error {
 	var g errgroup.Group
 	for _, image := range images {
 		image := image
@@ -57,26 +57,25 @@ func CacheImagesToTar(images []string, cacheDir string) error {
 			dst := filepath.Join(cacheDir, image)
 			dst = localpath.SanitizeCacheDir(dst)
 			if err := saveToTarFile(image, dst); err != nil {
-				glog.Errorf("CacheImage %s -> %s failed: %v", image, dst, err)
+				glog.Errorf("save image to file %q -> %q failed: %v", image, dst, err)
 				return errors.Wrapf(err, "caching image %q", dst)
 			}
-			glog.Infof("CacheImage %s -> %s succeeded", image, dst)
+			glog.Infof("save to tar file %s -> %s succeeded", image, dst)
 			return nil
 		})
 	}
 	if err := g.Wait(); err != nil {
 		return errors.Wrap(err, "caching images")
 	}
-	glog.Infoln("Successfully cached all images.")
+	glog.Infoln("Successfully saved all images to host disk.")
 	return nil
 }
 
 // saveToTarFile caches an image
 func saveToTarFile(image, dst string) error {
 	start := time.Now()
-	glog.Infof("CacheImage: %s -> %s", image, dst)
 	defer func() {
-		glog.Infof("CacheImage: %s -> %s completed in %s", image, dst, time.Since(start))
+		glog.Infof("cache image %q -> %s to local destination -> %q", image, dst, time.Since(start))
 	}()
 
 	if _, err := os.Stat(dst); err == nil {

--- a/pkg/minikube/image/image.go
+++ b/pkg/minikube/image/image.go
@@ -33,8 +33,9 @@ import (
 	"k8s.io/minikube/pkg/minikube/constants"
 )
 
-// DigestByLocalDaemon uses client by docker lib
-func DigestByLocalDaemon(imgClient *client.Client, imgName string) string {
+// DigestByDockerLib uses client by docker lib to return image digest
+// img.ID in as same as image digest
+func DigestByDockerLib(imgClient *client.Client, imgName string) string {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 	img, _, err := imgClient.ImageInspectWithRaw(ctx, imgName)
@@ -45,9 +46,9 @@ func DigestByLocalDaemon(imgClient *client.Client, imgName string) string {
 	return img.ID
 }
 
-// DigestByRetrieve gets image digest uses go-containerregistry lib
+// DigestByGoLib gets image digest uses go-containerregistry lib
 // which is 4s slower thabn local daemon per lookup https://github.com/google/go-containerregistry/issues/627
-func DigestByRetrieve(imgName string) string {
+func DigestByGoLib(imgName string) string {
 	ref, err := name.ParseReference(imgName, name.WeakValidation)
 	if err != nil {
 		glog.Infof("error parsing image name %s ref %v ", imgName, err)

--- a/pkg/minikube/image/image.go
+++ b/pkg/minikube/image/image.go
@@ -1,0 +1,115 @@
+package image
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/docker/docker/client"
+	"github.com/golang/glog"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/daemon"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/localpath"
+)
+
+// DigestByLocalDaemon uses client by docker lib
+func DigestByLocalDaemon(imgClient *client.Client, imgName string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+	img, _, err := imgClient.ImageInspectWithRaw(ctx, imgName)
+	if err != nil && !client.IsErrImageNotFound(err) {
+		glog.Infof("couldn't find image digest %s from local daemon: %v ", imgName, err)
+		return ""
+	}
+	return img.ID
+}
+
+// DigestByRetrieve gets image digest uses go-containerregistry lib
+// which is 4s slower thabn local daemon per lookup https://github.com/google/go-containerregistry/issues/627
+func DigestByRetrieve(imgName string) string {
+	ref, err := name.ParseReference(imgName, name.WeakValidation)
+	if err != nil {
+		glog.Infof("error parsing image name %s ref %v ", imgName, err)
+		return ""
+	}
+
+	img, err := retrieveImage(ref)
+	if err != nil {
+		glog.Infof("error retrieve Image %s ref %v ", imgName, err)
+		return ""
+	}
+
+	cf, err := img.ConfigName()
+	if err != nil {
+		glog.Infof("error getting Image config name %s %v ", imgName, err)
+		return cf.Hex
+	}
+	return cf.Hex
+}
+
+func retrieveImage(ref name.Reference) (v1.Image, error) {
+	glog.Infof("retrieving image: %+v", ref)
+	img, err := daemon.Image(ref)
+	if err == nil {
+		glog.Infof("found %s locally: %+v", ref.Name(), img)
+		return img, nil
+	}
+	// reference does not exist in the local daemon
+	if err != nil {
+		glog.Infof("daemon lookup for %+v: %v", ref, err)
+	}
+
+	img, err = remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err == nil {
+		return img, nil
+	}
+
+	glog.Warningf("authn lookup for %+v (trying anon): %+v", ref, err)
+	img, err = remote.Image(ref)
+	return img, err
+}
+
+// DeleteFromImageCacheDir deletes images from the cache
+func DeleteFromImageCacheDir(images []string) error {
+	for _, image := range images {
+		path := filepath.Join(constants.ImageCacheDir, image)
+		path = localpath.SanitizeCacheDir(path)
+		glog.Infoln("Deleting image in cache at ", path)
+		if err := os.Remove(path); err != nil {
+			return err
+		}
+	}
+	return cleanImageCacheDir()
+}
+
+func cleanImageCacheDir() error {
+	err := filepath.Walk(constants.ImageCacheDir, func(path string, info os.FileInfo, err error) error {
+		// If error is not nil, it's because the path was already deleted and doesn't exist
+		// Move on to next path
+		if err != nil {
+			return nil
+		}
+		// Check if path is directory
+		if !info.IsDir() {
+			return nil
+		}
+		// If directory is empty, delete it
+		entries, err := ioutil.ReadDir(path)
+		if err != nil {
+			return err
+		}
+		if len(entries) == 0 {
+			if err = os.Remove(path); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	return err
+}

--- a/pkg/minikube/image/image.go
+++ b/pkg/minikube/image/image.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package image
 
 import (
@@ -15,7 +31,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/daemon"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"k8s.io/minikube/pkg/minikube/constants"
-	"k8s.io/minikube/pkg/minikube/localpath"
 )
 
 // DigestByLocalDaemon uses client by docker lib
@@ -73,19 +88,6 @@ func retrieveImage(ref name.Reference) (v1.Image, error) {
 	glog.Warningf("authn lookup for %+v (trying anon): %+v", ref, err)
 	img, err = remote.Image(ref)
 	return img, err
-}
-
-// DeleteFromImageCacheDir deletes images from the cache
-func DeleteFromImageCacheDir(images []string) error {
-	for _, image := range images {
-		path := filepath.Join(constants.ImageCacheDir, image)
-		path = localpath.SanitizeCacheDir(path)
-		glog.Infoln("Deleting image in cache at ", path)
-		if err := os.Remove(path); err != nil {
-			return err
-		}
-	}
-	return cleanImageCacheDir()
 }
 
 func cleanImageCacheDir() error {

--- a/pkg/minikube/localpath/localpath.go
+++ b/pkg/minikube/localpath/localpath.go
@@ -18,8 +18,13 @@ package localpath
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
 	"k8s.io/client-go/util/homedir"
 )
 
@@ -55,3 +60,82 @@ func MachinePath(machine string, miniHome ...string) string {
 	}
 	return filepath.Join(miniPath, "machines", machine)
 }
+
+// SanitizeCacheDir
+// # ParseReference cannot have a : in the directory path
+func SanitizeCacheDir(image string) string {
+	if runtime.GOOS == "windows" && hasWindowsDriveLetter(image) {
+		// not sanitize Windows drive letter.
+		s := image[:2] + strings.Replace(image[2:], ":", "_", -1)
+		glog.Infof("windows sanitize: %s -> %s", image, s)
+		return s
+	}
+	return strings.Replace(image, ":", "_", -1)
+}
+
+func hasWindowsDriveLetter(s string) bool {
+	if len(s) < 3 {
+		return false
+	}
+
+	drive := s[:3]
+	for _, b := range "CDEFGHIJKLMNOPQRSTUVWXYZABcdefghijklmnopqrstuvwxyzab" {
+		if d := string(b) + ":"; drive == d+`\` || drive == d+`/` {
+			return true
+		}
+	}
+
+	return false
+}
+
+// DstPath returns an os specific
+func DstPath(dst string) (string, error) {
+	if runtime.GOOS == "windows" && hasWindowsDriveLetter(dst) {
+		// ParseReference does not support a Windows drive letter.
+		// Therefore, will replace the drive letter to a volume name.
+		var err error
+		if dst, err = replaceWinDriveLetterToVolumeName(dst); err != nil {
+			return "", errors.Wrap(err, "parsing docker archive dst ref: replace a Win drive letter to a volume name")
+		}
+	}
+	return dst, nil
+}
+
+// Replace a drive letter to a volume name.
+func replaceWinDriveLetterToVolumeName(s string) (string, error) {
+	vname, err := getWindowsVolumeName(s[:1])
+	if err != nil {
+		return "", err
+	}
+	path := vname + s[3:]
+
+	return path, nil
+}
+
+func getWindowsVolumeNameCmd(d string) (string, error) {
+	cmd := exec.Command("wmic", "volume", "where", "DriveLetter = '"+d+":'", "get", "DeviceID")
+
+	stdout, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	outs := strings.Split(strings.Replace(string(stdout), "\r", "", -1), "\n")
+
+	var vname string
+	for _, l := range outs {
+		s := strings.TrimSpace(l)
+		if strings.HasPrefix(s, `\\?\Volume{`) && strings.HasSuffix(s, `}\`) {
+			vname = s
+			break
+		}
+	}
+
+	if vname == "" {
+		return "", errors.New("failed to get a volume GUID")
+	}
+
+	return vname, nil
+}
+
+var getWindowsVolumeName = getWindowsVolumeNameCmd

--- a/pkg/minikube/localpath/localpath_test.go
+++ b/pkg/minikube/localpath/localpath_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package machine
+package localpath
 
 import (
 	"io/ioutil"

--- a/pkg/minikube/machine/cache_binaries.go
+++ b/pkg/minikube/machine/cache_binaries.go
@@ -43,7 +43,7 @@ func CacheBinariesForBootstrapper(version string, clusterBootstrapper string) er
 		bin := bin // https://golang.org/doc/faq#closures_and_goroutines
 		g.Go(func() error {
 			if _, err := CacheBinary(bin, version, "linux", runtime.GOARCH); err != nil {
-				return errors.Wrapf(err, "caching image %s", bin)
+				return errors.Wrapf(err, "caching binary %s", bin)
 			}
 			return nil
 		})

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -17,27 +17,15 @@ limitations under the License.
 package machine
 
 import (
-	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
-	"runtime"
-	"strings"
 	"sync"
-	"time"
 
 	"github.com/docker/docker/client"
 	"github.com/docker/machine/libmachine/state"
 	"github.com/golang/glog"
-	"github.com/google/go-containerregistry/pkg/authn"
-	"github.com/google/go-containerregistry/pkg/name"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/daemon"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 	"k8s.io/minikube/pkg/minikube/assets"
@@ -47,13 +35,13 @@ import (
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/cruntime"
+	"k8s.io/minikube/pkg/minikube/image"
+	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/minikube/vmpath"
 )
 
 // loadRoot is where images should be loaded from within the guest VM
 var loadRoot = path.Join(vmpath.GuestPersistentDir, "images")
-
-var getWindowsVolumeName = getWindowsVolumeNameCmd
 
 // loadImageLock is used to serialize image loads to avoid overloading the guest VM
 var loadImageLock sync.Mutex
@@ -65,37 +53,10 @@ func CacheImagesForBootstrapper(imageRepository string, version string, clusterB
 		return errors.Wrap(err, "cached images list")
 	}
 
-	if err := CacheImagesToTar(images, constants.ImageCacheDir); err != nil {
+	if err := image.CacheImagesToTar(images, constants.ImageCacheDir); err != nil {
 		return errors.Wrapf(err, "Caching images for %s", clusterBootstrapper)
 	}
 
-	return nil
-}
-
-// CacheImagesToTar will cache images on the host
-//
-// The cache directory currently caches images using the imagename_tag
-// For example, k8s.gcr.io/kube-addon-manager:v6.5 would be
-// stored at $CACHE_DIR/k8s.gcr.io/kube-addon-manager_v6.5
-func CacheImagesToTar(images []string, cacheDir string) error {
-	var g errgroup.Group
-	for _, image := range images {
-		image := image
-		g.Go(func() error {
-			dst := filepath.Join(cacheDir, image)
-			dst = sanitizeCacheDir(dst)
-			if err := cacheImageToTarFile(image, dst); err != nil {
-				glog.Errorf("CacheImage %s -> %s failed: %v", image, dst, err)
-				return errors.Wrapf(err, "caching image %q", dst)
-			}
-			glog.Infof("CacheImage %s -> %s succeeded", image, dst)
-			return nil
-		})
-	}
-	if err := g.Wait(); err != nil {
-		return errors.Wrap(err, "caching images")
-	}
-	glog.Infoln("Successfully cached all images.")
 	return nil
 }
 
@@ -135,62 +96,30 @@ func LoadImages(cc *config.MachineConfig, runner command.Runner, images []string
 
 // needsTransfer returns an error if an image needs to be retransfered
 func needsTransfer(imgClient *client.Client, imgName string, cr cruntime.Manager) error {
-	imgHex := ""
+	imgDgst := ""         // for instance sha256:7c92a2c6bbcb6b6beff92d0a940779769c2477b807c202954c537e2e0deb9bed
 	if imgClient != nil { // if possible try to get img digest from Client lib which is 4s faster.
-		imgHex = imgDigestByDaemonClient(imgClient, imgName)
-		if imgHex != "" {
-			if !cr.ImageExists(imgName, imgHex) {
-				return fmt.Errorf("%q does not exist at hash %q in container runtime", imgName, imgHex)
+		imgDgst = image.DigestByLocalDaemon(imgClient, imgName)
+		if imgDgst != "" {
+			if !cr.ImageExists(imgName, imgDgst) {
+				return fmt.Errorf("%q does not exist at hash %q in container runtime", imgName, imgDgst)
 			}
 			return nil
 		}
 	}
 	// if not found with method above try go-container lib (which is 4s slower)
-	imgHex = imgDigestByLib(imgName)
-	if imgHex == "" {
-		return fmt.Errorf("got empty img digest %q for %s", imgHex, imgName)
+	imgDgst = image.DigestByRetrieve(imgName)
+	if imgDgst == "" {
+		return fmt.Errorf("got empty img digest %q for %s", imgDgst, imgName)
 	}
-	if !cr.ImageExists(imgName, imgHex) {
-		return fmt.Errorf("%q does not exist at hash %q in container runtime", imgName, imgHex)
+	if !cr.ImageExists(imgName, imgDgst) {
+		return fmt.Errorf("%q does not exist at hash %q in container runtime", imgName, imgDgst)
 	}
 	return nil
 }
 
-// uses client by docker lib
-func imgDigestByDaemonClient(imgClient *client.Client, imgName string) string {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-	defer cancel()
-	img, _, err := imgClient.ImageInspectWithRaw(ctx, imgName)
-	if err != nil && !client.IsErrImageNotFound(err) {
-		glog.Infof("couldn't find image digest %s from local daemon: %v ", imgName, err)
-		return ""
-	}
-	return img.ID
-}
-
-// gets image digest sha256: uses go-containerregistry lib which is 4s slower per lookup https://github.com/google/go-containerregistry/issues/627
-func imgDigestByLib(imgName string) string {
-	ref, err := name.ParseReference(imgName, name.WeakValidation)
-	if err != nil {
-		glog.Infof("error parsing image name %s ref %v ", imgName, err)
-	}
-
-	img, err := retrieveImage(ref)
-	if err != nil {
-		glog.Infof("error retrieve Image %s ref %v ", imgName, err)
-	}
-
-	cf, err := img.ConfigName()
-	if err != nil {
-		glog.Infof("error getting Image config name %s %v ", imgName, err)
-		return cf.Hex
-	}
-	return cf.Hex
-}
-
 // CacheAndLoadImages caches and loads images to all profiles
 func CacheAndLoadImages(images []string) error {
-	if err := CacheImagesToTar(images, constants.ImageCacheDir); err != nil {
+	if err := image.CacheImagesToTar(images, constants.ImageCacheDir); err != nil {
 		return err
 	}
 	api, err := NewAPIClient()
@@ -232,69 +161,6 @@ func CacheAndLoadImages(images []string) error {
 	return err
 }
 
-// # ParseReference cannot have a : in the directory path
-func sanitizeCacheDir(image string) string {
-	if runtime.GOOS == "windows" && hasWindowsDriveLetter(image) {
-		// not sanitize Windows drive letter.
-		s := image[:2] + strings.Replace(image[2:], ":", "_", -1)
-		glog.Infof("windows sanitize: %s -> %s", image, s)
-		return s
-	}
-	return strings.Replace(image, ":", "_", -1)
-}
-
-func hasWindowsDriveLetter(s string) bool {
-	if len(s) < 3 {
-		return false
-	}
-
-	drive := s[:3]
-	for _, b := range "CDEFGHIJKLMNOPQRSTUVWXYZABcdefghijklmnopqrstuvwxyzab" {
-		if d := string(b) + ":"; drive == d+`\` || drive == d+`/` {
-			return true
-		}
-	}
-
-	return false
-}
-
-// Replace a drive letter to a volume name.
-func replaceWinDriveLetterToVolumeName(s string) (string, error) {
-	vname, err := getWindowsVolumeName(s[:1])
-	if err != nil {
-		return "", err
-	}
-	path := vname + s[3:]
-
-	return path, nil
-}
-
-func getWindowsVolumeNameCmd(d string) (string, error) {
-	cmd := exec.Command("wmic", "volume", "where", "DriveLetter = '"+d+":'", "get", "DeviceID")
-
-	stdout, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-
-	outs := strings.Split(strings.Replace(string(stdout), "\r", "", -1), "\n")
-
-	var vname string
-	for _, l := range outs {
-		s := strings.TrimSpace(l)
-		if strings.HasPrefix(s, `\\?\Volume{`) && strings.HasSuffix(s, `}\`) {
-			vname = s
-			break
-		}
-	}
-
-	if vname == "" {
-		return "", errors.New("failed to get a volume GUID")
-	}
-
-	return vname, nil
-}
-
 // transferAndLoadImage transfers and loads a single image from the cache
 func transferAndLoadImage(cr command.Runner, k8s config.KubernetesConfig, imgName string, cacheDir string) error {
 	r, err := cruntime.New(cruntime.Config{Type: k8s.ContainerRuntime, Runner: cr})
@@ -302,7 +168,7 @@ func transferAndLoadImage(cr command.Runner, k8s config.KubernetesConfig, imgNam
 		return errors.Wrap(err, "runtime")
 	}
 	src := filepath.Join(cacheDir, imgName)
-	src = sanitizeCacheDir(src)
+	src = localpath.SanitizeCacheDir(src)
 	glog.Infof("Loading image from cache: %s", src)
 	filename := filepath.Base(src)
 	if _, err := os.Stat(src); err != nil {
@@ -327,144 +193,4 @@ func transferAndLoadImage(cr command.Runner, k8s config.KubernetesConfig, imgNam
 
 	glog.Infof("Transferred and loaded %s from cache", src)
 	return nil
-}
-
-// DeleteFromImageCacheDir deletes images from the cache
-func DeleteFromImageCacheDir(images []string) error {
-	for _, image := range images {
-		path := filepath.Join(constants.ImageCacheDir, image)
-		path = sanitizeCacheDir(path)
-		glog.Infoln("Deleting image in cache at ", path)
-		if err := os.Remove(path); err != nil {
-			return err
-		}
-	}
-	return cleanImageCacheDir()
-}
-
-func cleanImageCacheDir() error {
-	err := filepath.Walk(constants.ImageCacheDir, func(path string, info os.FileInfo, err error) error {
-		// If error is not nil, it's because the path was already deleted and doesn't exist
-		// Move on to next path
-		if err != nil {
-			return nil
-		}
-		// Check if path is directory
-		if !info.IsDir() {
-			return nil
-		}
-		// If directory is empty, delete it
-		entries, err := ioutil.ReadDir(path)
-		if err != nil {
-			return err
-		}
-		if len(entries) == 0 {
-			if err = os.Remove(path); err != nil {
-				return err
-			}
-		}
-		return nil
-	})
-	return err
-}
-
-func getDstPath(dst string) (string, error) {
-	if runtime.GOOS == "windows" && hasWindowsDriveLetter(dst) {
-		// ParseReference does not support a Windows drive letter.
-		// Therefore, will replace the drive letter to a volume name.
-		var err error
-		if dst, err = replaceWinDriveLetterToVolumeName(dst); err != nil {
-			return "", errors.Wrap(err, "parsing docker archive dst ref: replace a Win drive letter to a volume name")
-		}
-	}
-
-	return dst, nil
-}
-
-// cacheImageToTarFile caches an image
-func cacheImageToTarFile(image, dst string) error {
-	start := time.Now()
-	glog.Infof("CacheImage: %s -> %s", image, dst)
-	defer func() {
-		glog.Infof("CacheImage: %s -> %s completed in %s", image, dst, time.Since(start))
-	}()
-
-	if _, err := os.Stat(dst); err == nil {
-		glog.Infof("%s exists", dst)
-		return nil
-	}
-
-	dstPath, err := getDstPath(dst)
-	if err != nil {
-		return errors.Wrap(err, "getting destination path")
-	}
-
-	if err := os.MkdirAll(filepath.Dir(dstPath), 0777); err != nil {
-		return errors.Wrapf(err, "making cache image directory: %s", dst)
-	}
-
-	ref, err := name.ParseReference(image, name.WeakValidation)
-	if err != nil {
-		return errors.Wrapf(err, "parsing image ref name for %s", image)
-	}
-
-	img, err := retrieveImage(ref)
-	if err != nil {
-		glog.Warningf("unable to retrieve image: %v", err)
-	}
-	glog.Infoln("OPENING: ", dstPath)
-	f, err := ioutil.TempFile(filepath.Dir(dstPath), filepath.Base(dstPath)+".*.tmp")
-	if err != nil {
-		return err
-	}
-	defer func() {
-		// If we left behind a temp file, remove it.
-		_, err := os.Stat(f.Name())
-		if err == nil {
-			os.Remove(f.Name())
-			if err != nil {
-				glog.Warningf("Failed to clean up the temp file %s: %v", f.Name(), err)
-			}
-		}
-	}()
-	tag, err := name.NewTag(image, name.WeakValidation)
-	if err != nil {
-		return errors.Wrap(err, "newtag")
-	}
-	err = tarball.Write(tag, img, &tarball.WriteOptions{}, f)
-	if err != nil {
-		return errors.Wrap(err, "write")
-	}
-	err = f.Close()
-	if err != nil {
-		return errors.Wrap(err, "close")
-	}
-	err = os.Rename(f.Name(), dstPath)
-	if err != nil {
-		return errors.Wrap(err, "rename")
-	}
-	glog.Infof("%s exists", dst)
-	return nil
-}
-
-func retrieveImage(ref name.Reference) (v1.Image, error) {
-	glog.Infof("retrieving image: %+v", ref)
-	img, err := daemon.Image(ref)
-	if err == nil {
-		glog.Infof("found %s locally: %+v", ref.Name(), img)
-		return img, nil
-	}
-	// reference does not exist in the local daemon
-	if err != nil {
-		glog.Infof("daemon lookup for %+v: %v", ref, err)
-	}
-
-	img, err = remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
-	if err == nil {
-		return img, nil
-	}
-
-	glog.Warningf("authn lookup for %+v (trying anon): %+v", ref, err)
-	img, err = remote.Image(ref)
-	return img, err
 }

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -84,7 +84,7 @@ func CacheImagesToTar(images []string, cacheDir string) error {
 			dst = sanitizeCacheDir(dst)
 			if err := cacheImageToTarFile(image, dst); err != nil {
 				glog.Errorf("CacheImage %s -> %s failed: %v", image, dst, err)
-				return errors.Wrapf(err, "caching image %s", dst)
+				return errors.Wrapf(err, "caching image %q", dst)
 			}
 			glog.Infof("CacheImage %s -> %s succeeded", image, dst)
 			return nil
@@ -365,14 +365,13 @@ func cacheImageToTarFile(image, dst string) error {
 
 	ref, err := name.ParseReference(image, name.WeakValidation)
 	if err != nil {
-		return errors.Wrap(err, "creating docker image name")
+		return errors.Wrapf(err, "parsing image ref name for %s", image)
 	}
 
 	img, err := retrieveImage(ref)
 	if err != nil {
 		glog.Warningf("unable to retrieve image: %v", err)
 	}
-
 	glog.Infoln("OPENING: ", dstPath)
 	f, err := ioutil.TempFile(filepath.Dir(dstPath), filepath.Base(dstPath)+".*.tmp")
 	if err != nil {

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -107,21 +107,6 @@ func LoadImages(cc *config.MachineConfig, runner command.Runner, images []string
 		return errors.Wrap(err, "runtime")
 	}
 
-<<<<<<< HEAD
-||||||| constructed merge base
-	cli, err := client.NewEnvClient()
-	if err != nil {
-		glog.Infof("error retrieving oci daemon client %v", err)
-		return err
-	}
-
-=======
-	cli, err := client.NewEnvClient()
-	if err != nil {
-		return errors.Wrap(err, "getting image daemon NewEnvClient")
-	}
-
->>>>>>> resolve code reviews
 	for _, image := range images {
 		image := image
 		g.Go(func() error {

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -53,7 +53,7 @@ func CacheImagesForBootstrapper(imageRepository string, version string, clusterB
 		return errors.Wrap(err, "cached images list")
 	}
 
-	if err := image.CacheImagesToTar(images, constants.ImageCacheDir); err != nil {
+	if err := image.SaveToDir(images, constants.ImageCacheDir); err != nil {
 		return errors.Wrapf(err, "Caching images for %s", clusterBootstrapper)
 	}
 
@@ -119,7 +119,7 @@ func needsTransfer(imgClient *client.Client, imgName string, cr cruntime.Manager
 
 // CacheAndLoadImages caches and loads images to all profiles
 func CacheAndLoadImages(images []string) error {
-	if err := image.CacheImagesToTar(images, constants.ImageCacheDir); err != nil {
+	if err := image.SaveToDir(images, constants.ImageCacheDir); err != nil {
 		return err
 	}
 	api, err := NewAPIClient()

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -107,6 +107,21 @@ func LoadImages(cc *config.MachineConfig, runner command.Runner, images []string
 		return errors.Wrap(err, "runtime")
 	}
 
+<<<<<<< HEAD
+||||||| constructed merge base
+	cli, err := client.NewEnvClient()
+	if err != nil {
+		glog.Infof("error retrieving oci daemon client %v", err)
+		return err
+	}
+
+=======
+	cli, err := client.NewEnvClient()
+	if err != nil {
+		return errors.Wrap(err, "getting image daemon NewEnvClient")
+	}
+
+>>>>>>> resolve code reviews
 	for _, image := range images {
 		image := image
 		g.Go(func() error {

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -412,20 +412,12 @@ func retrieveImage(ref name.Reference) (v1.Image, error) {
 	glog.Infof("retrieving image: %+v", ref)
 	img, err := daemon.Image(ref)
 	if err == nil {
-<<<<<<< HEAD
 		glog.Infof("found %s locally: %+v", ref.Name(), img)
 		return img, nil
 	}
 	// reference does not exist in the local daemon
 	if err != nil {
 		glog.Infof("daemon lookup for %+v: %v", ref, err)
-||||||| constructed merge base
-		glog.Infof("found %s locally; caching", ref.Name())
-		return img, err
-=======
-		glog.Infof("found image %s locally;", ref.Name())
-		return img, err
->>>>>>> improve logging
 	}
 
 	img, err = remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -98,7 +98,7 @@ func LoadImages(cc *config.MachineConfig, runner command.Runner, images []string
 func needsTransfer(imgClient *client.Client, imgName string, cr cruntime.Manager) error {
 	imgDgst := ""         // for instance sha256:7c92a2c6bbcb6b6beff92d0a940779769c2477b807c202954c537e2e0deb9bed
 	if imgClient != nil { // if possible try to get img digest from Client lib which is 4s faster.
-		imgDgst = image.DigestByLocalDaemon(imgClient, imgName)
+		imgDgst = image.DigestByDockerLib(imgClient, imgName)
 		if imgDgst != "" {
 			if !cr.ImageExists(imgName, imgDgst) {
 				return fmt.Errorf("%q does not exist at hash %q in container runtime", imgName, imgDgst)
@@ -107,7 +107,7 @@ func needsTransfer(imgClient *client.Client, imgName string, cr cruntime.Manager
 		}
 	}
 	// if not found with method above try go-container lib (which is 4s slower)
-	imgDgst = image.DigestByRetrieve(imgName)
+	imgDgst = image.DigestByGoLib(imgName)
 	if imgDgst == "" {
 		return fmt.Errorf("got empty img digest %q for %s", imgDgst, imgName)
 	}

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -82,7 +82,7 @@ func CacheImagesToHostDisk(images []string, cacheDir string) error {
 		g.Go(func() error {
 			dst := filepath.Join(cacheDir, image)
 			dst = sanitizeCacheDir(dst)
-			if err := cacheImage(image, dst); err != nil {
+			if err := cacheImageToTarFile(image, dst); err != nil {
 				glog.Errorf("CacheImage %s -> %s failed: %v", image, dst, err)
 				return errors.Wrapf(err, "caching image %s", dst)
 			}
@@ -162,7 +162,7 @@ func CacheAndLoadImages(images []string) error {
 	if err != nil {
 		return errors.Wrap(err, "list profiles")
 	}
-	for _, p := range profiles { // adding images to all the profiles
+	for _, p := range profiles { // loading images to all running profiles
 		pName := p.Name // capture the loop variable
 		status, err := cluster.GetHostStatus(api, pName)
 		if err != nil {
@@ -341,8 +341,8 @@ func getDstPath(dst string) (string, error) {
 	return dst, nil
 }
 
-// cacheImage caches an image
-func cacheImage(image, dst string) error {
+// cacheImageToTarFile caches an image
+func cacheImageToTarFile(image, dst string) error {
 	start := time.Now()
 	glog.Infof("CacheImage: %s -> %s", image, dst)
 	defer func() {

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -63,19 +63,19 @@ func CacheImagesForBootstrapper(imageRepository string, version string, clusterB
 		return errors.Wrap(err, "cached images list")
 	}
 
-	if err := CacheImagesToHostDisk(images, constants.ImageCacheDir); err != nil {
+	if err := CacheImagesToTar(images, constants.ImageCacheDir); err != nil {
 		return errors.Wrapf(err, "Caching images for %s", clusterBootstrapper)
 	}
 
 	return nil
 }
 
-// CacheImagesToHostDisk will cache images on the host
+// CacheImagesToTar will cache images on the host
 //
 // The cache directory currently caches images using the imagename_tag
 // For example, k8s.gcr.io/kube-addon-manager:v6.5 would be
 // stored at $CACHE_DIR/k8s.gcr.io/kube-addon-manager_v6.5
-func CacheImagesToHostDisk(images []string, cacheDir string) error {
+func CacheImagesToTar(images []string, cacheDir string) error {
 	var g errgroup.Group
 	for _, image := range images {
 		image := image
@@ -150,7 +150,7 @@ func needsTransfer(image string, cr cruntime.Manager) error {
 
 // CacheAndLoadImages caches and loads images to all profiles
 func CacheAndLoadImages(images []string) error {
-	if err := CacheImagesToHostDisk(images, constants.ImageCacheDir); err != nil {
+	if err := CacheImagesToTar(images, constants.ImageCacheDir); err != nil {
 		return err
 	}
 	api, err := NewAPIClient()

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -412,12 +412,20 @@ func retrieveImage(ref name.Reference) (v1.Image, error) {
 	glog.Infof("retrieving image: %+v", ref)
 	img, err := daemon.Image(ref)
 	if err == nil {
+<<<<<<< HEAD
 		glog.Infof("found %s locally: %+v", ref.Name(), img)
 		return img, nil
 	}
 	// reference does not exist in the local daemon
 	if err != nil {
 		glog.Infof("daemon lookup for %+v: %v", ref, err)
+||||||| constructed merge base
+		glog.Infof("found %s locally; caching", ref.Name())
+		return img, err
+=======
+		glog.Infof("found image %s locally;", ref.Name())
+		return img, err
+>>>>>>> improve logging
 	}
 
 	img, err = remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -323,7 +323,7 @@ func validateCacheCmd(ctx context.Context, t *testing.T, profile string) {
 				}
 			}
 		})
-		t.Run("delete", func(t *testing.T) {
+		t.Run("delete busybox:1.28.4-glibc", func(t *testing.T) {
 			_, err := Run(t, exec.CommandContext(ctx, Target(), "cache", "delete", "busybox:1.28.4-glibc"))
 			if err != nil {
 				t.Errorf("failed to delete image busybox:1.28.4-glibc from cache: %v", err)
@@ -346,13 +346,38 @@ func validateCacheCmd(ctx context.Context, t *testing.T, profile string) {
 		t.Run("verify cache inside node", func(t *testing.T) {
 			rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "sudo", "crictl", "images"))
 			if err != nil {
-				t.Errorf("failed to get docker images through ssh %v", err)
+				t.Errorf("failed to get images by %q ssh %v", rr.Command(), err)
 			}
 			if !strings.Contains(rr.Output(), "1.28.4-glibc") {
 				t.Errorf("expected '1.28.4-glibc' to be in the output: %s", rr.Output())
 			}
 
 		})
+
+		t.Run("reload", func(t *testing.T) { // deleting image inside minikube node manually and expecting reload to bring it back
+			img := "busybox:latest"
+			// deleting image inside minikube node manually
+			rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "sudo", "crictl", "rmi", img))
+			if err != nil {
+				t.Errorf("failed to delete inside the node %q : %v", rr.Command(), err)
+			}
+			// make sure the image is deleted.
+			rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "sudo", "crictl", "inspecti", img))
+			if err == nil {
+				t.Errorf("expected the image be deleted and get  error but got nil error ! cmd: %q", rr.Command())
+			}
+
+			// minikube cache reload
+			rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "cache", "reload"))
+			if err != nil {
+				t.Errorf("failed to cache reload %v", rr.Command(), err)
+			}
+			rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "sudo", "crictl", "inspecti", img))
+			if err != nil {
+				t.Errorf("expected to get no error for %q but got %v", rr.Command(), err)
+			}
+		})
+
 	})
 }
 

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -357,7 +357,7 @@ func validateCacheCmd(ctx context.Context, t *testing.T, profile string) {
 		t.Run("cache reload", func(t *testing.T) { // deleting image inside minikube node manually and expecting reload to bring it back
 			img := "busybox:latest"
 			// deleting image inside minikube node manually
-			rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "sudo", "crictl", "rmi", img))
+			rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "sudo", "docker", "rmi", img)) // for some reason crictl rmi doesn't work
 			if err != nil {
 				t.Errorf("failed to delete inside the node %q : %v", rr.Command(), err)
 			}

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -366,11 +366,10 @@ func validateCacheCmd(ctx context.Context, t *testing.T, profile string) {
 			if err == nil {
 				t.Errorf("expected the image be deleted and get  error but got nil error ! cmd: %q", rr.Command())
 			}
-
 			// minikube cache reload.
 			rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "cache", "reload"))
 			if err != nil {
-				t.Errorf("failed to cache reload %v", rr.Command(), err)
+				t.Errorf("expected %q to run successfully but got error %v", rr.Command(), err)
 			}
 			// make sure 'cache reload' brought back the manually deleted image.
 			rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "sudo", "crictl", "inspecti", img))

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -354,7 +354,7 @@ func validateCacheCmd(ctx context.Context, t *testing.T, profile string) {
 
 		})
 
-		t.Run("reload", func(t *testing.T) { // deleting image inside minikube node manually and expecting reload to bring it back
+		t.Run("cache reload", func(t *testing.T) { // deleting image inside minikube node manually and expecting reload to bring it back
 			img := "busybox:latest"
 			// deleting image inside minikube node manually
 			rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "sudo", "crictl", "rmi", img))
@@ -367,11 +367,12 @@ func validateCacheCmd(ctx context.Context, t *testing.T, profile string) {
 				t.Errorf("expected the image be deleted and get  error but got nil error ! cmd: %q", rr.Command())
 			}
 
-			// minikube cache reload
+			// minikube cache reload.
 			rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "cache", "reload"))
 			if err != nil {
 				t.Errorf("failed to cache reload %v", rr.Command(), err)
 			}
+			// make sure 'cache reload' brought back the manually deleted image.
 			rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "sudo", "crictl", "inspecti", img))
 			if err != nil {
 				t.Errorf("expected to get no error for %q but got %v", rr.Command(), err)


### PR DESCRIPTION
this pr:
- add a new command `minikube cache reload` which will reload all the images specified in the config file without having to start-stop
- save 3 seconds on each image ID look up. by using `github.com/docker/docker` ID instead of go-containerregistry .
(worth noting go-containerregistry  uses github.com/docker/docker to load the image id.
https://github.com/google/go-containerregistry/issues/627)

- rename funcs for more clarity and unexport funcs

- added an integration test that does the following :
-- manually delete the image inside the node 
-- verify it doesn't exist anymore.
-- minikube cache reload, should bring the image back.

- refactor image related funcs to its own package