### PR TITLE
lock names: Remove uid suffix & hash entire path

### DIFF
--- a/pkg/minikube/bootstrapper/certs.go
+++ b/pkg/minikube/bootstrapper/certs.go
@@ -70,7 +70,7 @@ func SetupCerts(cmd command.Runner, k8s config.KubernetesConfig) error {
 	//
 	// If another process updates the shared certificate, it's invalid.
 	// TODO: Instead of racey manipulation of a shared certificate, use per-profile certs
-	spec := lock.UserMutexSpec(filepath.Join(localPath, "certs"))
+	spec := lock.PathMutexSpec(filepath.Join(localPath, "certs"))
 	glog.Infof("acquiring lock: %+v", spec)
 	releaser, err := mutex.Acquire(spec)
 	if err != nil {

--- a/pkg/minikube/kubeconfig/settings.go
+++ b/pkg/minikube/kubeconfig/settings.go
@@ -119,7 +119,7 @@ func PopulateFromSettings(cfg *Settings, apiCfg *api.Config) error {
 // activeContext is true when minikube is the CurrentContext
 // If no CurrentContext is set, the given name will be used.
 func Update(kcs *Settings) error {
-	spec := lock.UserMutexSpec(filepath.Join(kcs.filePath(), "settings.Update"))
+	spec := lock.PathMutexSpec(filepath.Join(kcs.filePath(), "settings.Update"))
 	glog.Infof("acquiring lock: %+v", spec)
 	releaser, err := mutex.Acquire(spec)
 	if err != nil {

--- a/pkg/util/lock/lock.go
+++ b/pkg/util/lock/lock.go
@@ -38,16 +38,16 @@ var (
 // WriteFile decorates ioutil.WriteFile with a file lock and retry
 func WriteFile(filename string, data []byte, perm os.FileMode) error {
 	spec := UserMutexSpec(filename)
-	glog.Infof("acquiring lock for %s: %+v", filename, spec)
+	glog.Infof("WriteFile acquiring %s: %+v", filename, spec)
 	releaser, err := mutex.Acquire(spec)
 	if err != nil {
-		return errors.Wrapf(err, "error acquiring lock for %s", filename)
+		return errors.Wrapf(err, "failed to acquire lock for %s: %+v", filename, spec)
 	}
 
 	defer releaser.Release()
 
 	if err = ioutil.WriteFile(filename, data, perm); err != nil {
-		return errors.Wrapf(err, "error writing file %s", filename)
+		return errors.Wrapf(err, "writefile failed for %s", filename)
 	}
 	return err
 }
@@ -62,7 +62,6 @@ func UserMutexSpec(path string) mutex.Spec {
 		}
 	}
 	name := getMutexNameForPath(fmt.Sprintf("%s-%s", path, id))
-	glog.Infof("mutex name for %s: %s", path, name)
 	s := mutex.Spec{
 		Name:  name,
 		Clock: clock.WallClock,

--- a/pkg/util/lock/lock.go
+++ b/pkg/util/lock/lock.go
@@ -29,11 +29,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-var (
-	// forceID is a user id for consistent testing
-	forceID = ""
-)
-
 // WriteFile decorates ioutil.WriteFile with a file lock and retry
 func WriteFile(filename string, data []byte, perm os.FileMode) error {
 	spec := PathMutexSpec(filename)

--- a/pkg/util/lock/lock.go
+++ b/pkg/util/lock/lock.go
@@ -36,7 +36,7 @@ var (
 
 // WriteFile decorates ioutil.WriteFile with a file lock and retry
 func WriteFile(filename string, data []byte, perm os.FileMode) error {
-	spec := pathSpec(filename)
+	spec := PathMutexSpec(filename)
 	glog.Infof("WriteFile acquiring %s: %+v", filename, spec)
 	releaser, err := mutex.Acquire(spec)
 	if err != nil {
@@ -51,8 +51,8 @@ func WriteFile(filename string, data []byte, perm os.FileMode) error {
 	return err
 }
 
-// pathSpec returns a mutex spec for a path
-func pathSpec(path string) mutex.Spec {
+// PathMutexSpec returns a mutex spec for a path
+func PathMutexSpec(path string) mutex.Spec {
 	s := mutex.Spec{
 		Name:  fmt.Sprintf("mk%x", sha1.Sum([]byte(path)))[0:40],
 		Clock: clock.WallClock,

--- a/pkg/util/lock/lock.go
+++ b/pkg/util/lock/lock.go
@@ -17,12 +17,12 @@ limitations under the License.
 package lock
 
 import (
+	"crypto/md5"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"os/user"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -78,13 +78,5 @@ func UserMutexSpec(path string) mutex.Spec {
 
 func getMutexNameForPath(path string) string {
 	// juju requires that names match ^[a-zA-Z][a-zA-Z0-9-]*$", and be under 40 chars long.
-	n := strings.Trim(nonString.ReplaceAllString(path, "-"), "-")
-	// we need to always guarantee an alphanumeric prefix
-	prefix := "m"
-
-	// Prefer the last 40 chars, as paths tend get more specific toward the end
-	if len(n) >= 40 {
-		return prefix + n[len(n)-39:]
-	}
-	return prefix + n
+	return fmt.Sprintf("m%x", md5.Sum([]byte(path)))
 }

--- a/pkg/util/lock/lock_test.go
+++ b/pkg/util/lock/lock_test.go
@@ -66,7 +66,7 @@ func TestUserMutexSpec(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
-			got := pathSpec(tc.path)
+			got := PathMutexSpec(tc.path)
 			if len(got.Name) != 40 {
 				t.Errorf("%s is not 40 chars long", got.Name)
 			}

--- a/pkg/util/lock/lock_test.go
+++ b/pkg/util/lock/lock_test.go
@@ -62,8 +62,8 @@ func TestUserMutexSpec(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			got := UserMutexSpec(tc.path)
-			if len(got.Name) > 40 {
-				t.Errorf("%s mutex name is too long", got.Name)
+			if len(got.Name) != 40 {
+				t.Errorf("%s is not 40 chars long", got.Name)
 			}
 		})
 	}

--- a/pkg/util/lock/lock_test.go
+++ b/pkg/util/lock/lock_test.go
@@ -24,45 +24,46 @@ func TestUserMutexSpec(t *testing.T) {
 	var tests = []struct {
 		description string
 		path        string
-		expected    string
 	}{
 		{
 			description: "standard",
 			path:        "/foo/bar",
-			expected:    "mfoo-bar-test",
 		},
 		{
 			description: "deep directory",
 			path:        "/foo/bar/baz/bat",
-			expected:    "mfoo-bar-baz-bat-test",
 		},
 		{
 			description: "underscores",
 			path:        "/foo_bar/baz",
-			expected:    "mfoo-bar-baz-test",
 		},
 		{
 			description: "starts with number",
 			path:        "/foo/2bar/baz",
-			expected:    "mfoo-2bar-baz-test",
 		},
 		{
 			description: "starts with punctuation",
 			path:        "/.foo/bar",
-			expected:    "mfoo-bar-test",
 		},
 		{
 			description: "long filename",
 			path:        "/very-very-very-very-very-very-very-very-long/bar",
-			expected:    "m-very-very-very-very-very-long-bar-test",
+		},
+		{
+			description: "Windows kubeconfig",
+			path:        `C:\Users\admin/.kube/config`,
+		},
+		{
+			description: "Windows json",
+			path:        `C:\Users\admin\.minikube\profiles\containerd-20191210T212325.7356633-8584\config.json`,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			got := UserMutexSpec(tc.path)
-			if got.Name != tc.expected {
-				t.Errorf("%s mutex name = %q, expected %q", tc.path, got.Name, tc.expected)
+			if len(got.Name) > 40 {
+				t.Errorf("%s mutex name is too long", got.Name)
 			}
 		})
 	}


### PR DESCRIPTION
This PR makes lock names unique again for Windows users.

Currently, we generate lock names by taking the last 39 characters of:

`fmt.Sprintf("%s-%s", path, uid))`

On most platforms, uid's are 0-6 characters long. However, on Windows, a SID is returned, which looks like:

`S-1-5-21-1180699209-877415012-3182924384-1004`

That's 46 characters long. Effectively, on Windows, all of our locks shared the same name:

`m21-1180699209-877415012-3182924384`

Why was the UID added anyways? Because we used to assign lock names based on a descripter, like "kubeConfig", and we wanted multiple users to be able to run minikube simultaneously. Now that we only generate locks on a path name, this is no longer necessary, as we actually do want to lock a file if multiple users try to update it.

Fixes #6058