### PR TITLE
Generate prettier logs for integration tests

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -312,21 +312,19 @@ rm "${JSON_OUT}" || true # clean up build-reruns
 touch "${JSON_OUT}"
 
 # Generate JSON output
-go tool test2json -t < "${TEST_OUT}" > "${JSON_OUT}"
-RESULT=$?
-if [ $RESULT -eq 0 ]; then
-        # Generate HTML human readable test output
-      echo ">> Running gopogh"
-      rm "${HTML_OUT}" || true # clean up build-reruns
-      touch "${HTML_OUT}"
-      gopogh -in "${JSON_OUT}" -out "${HTML_OUT}" -name "${JOB_NAME}" -pr "${MINIKUBE_LOCATION}" -repo github.com/kubernetes/minikube/  -details "${COMMIT}" || true
-      echo ">> Copying ${HTML_OUT} to ${JOB_GS_BUCKET}.html"
-      gsutil -qm cp "${JSON_OUT}" "gs://${JOB_GS_BUCKET}.json"
-      gsutil -qm cp "${HTML_OUT}" "gs://${JOB_GS_BUCKET}.html"
-else
-  echo "failed to go tool test2json. Skpping HTML report output."
-fi
-                
+echo ">> Runnin go test2json"
+go tool test2json -t < "${TEST_OUT}" > "${JSON_OUT}" || true
+echo ">> Installing gopogh"
+go get -u github.com/medyagh/gopogh@v0.0.15 || true
+echo ">> Running gopogh"
+rm "${HTML_OUT}" || true # clean up build-reruns
+touch "${HTML_OUT}"
+gopogh -in "${JSON_OUT}" -out "${HTML_OUT}" -name "${JOB_NAME}" -pr "${MINIKUBE_LOCATION}" -repo github.com/kubernetes/minikube/  -details "${COMMIT}" || true
+echo ">> Copying ${JSON_OUT} to ${JOB_GS_BUCKET}.json"
+gsutil -qm cp "${JSON_OUT}" "gs://${JOB_GS_BUCKET}.json"
+echo ">> Copying ${HTML_OUT} to ${JOB_GS_BUCKET}.html"
+gsutil -qm cp "${HTML_OUT}" "gs://${JOB_GS_BUCKET}.html"
+
 
 echo ">> Cleaning up after ourselves ..."
 ${SUDO_PREFIX}${MINIKUBE_BIN} tunnel --cleanup || true

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -295,6 +295,7 @@ elapsed=$min.$sec
 description="completed with ${status} in ${elapsed} minute(s)."
 echo $description
 echo ">> Copying ${TEST_OUT} to gs://minikube-builds/logs/${MINIKUBE_LOCATION}/${JOB_NAME}.out"
+gsutil -qm cp "${TEST_OUT}" "gs://minikube-builds/logs/${MINIKUBE_LOCATION}/${JOB_NAME}.out"
 echo ">> Copying html formatted logs ..."
 # Generate JSON format from test output 
 echo ">> Running go tool test2json"

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -325,7 +325,7 @@ gsutil -qm cp "${JSON_OUT}" "gs://minikube-builds/logs/${MINIKUBE_LOCATION}/${JO
 gsutil -qm cp "${HTML_OUT}" "gs://minikube-builds/logs/${MINIKUBE_LOCATION}/${JOB_NAME}.html"
 
 public_log_url="https://storage.googleapis.com/minikube-builds/logs/${MINIKUBE_LOCATION}/${JOB_NAME}.txt"
-if [[ $(wc -l <${HTML_OUT}) -ge 3 ]] # if HTML generation was succesfull (would fail if docker is not installed)
+if [[ $(wc -l <${HTML_OUT}) -ge 3 ]]; then # if HTML generation was succesfull (would fail if docker is not installed)
   public_log_url="https://storage.googleapis.com/minikube-builds/logs/${MINIKUBE_LOCATION}/${JOB_NAME}.html"
 fi
 

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -45,6 +45,12 @@ echo "kubectl:   $(env KUBECONFIG=${TEST_HOME} kubectl version --client --short=
 echo "docker:    $(docker version --format '{{ .Client.Version }}')"
 
 
+# Make sure the right golang version is installed based on Makefile
+
+./hack/jenkins/installers/check_install_golang.sh 1.13.4 /usr/local
+declare -rx GOPATH=/var/lib/jenkins/go
+
+
 case "${VM_DRIVER}" in
   kvm2)
     echo "virsh:     $(virsh --version)"

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -271,7 +271,7 @@ ${SUDO_PREFIX}${E2E_BIN} \
   -expected-default-driver="${EXPECTED_DEFAULT_DRIVER}" \
   -test.timeout=70m \
   ${EXTRA_TEST_ARGS} \
-  -binary="${MINIKUBE_BIN}" | tee "${TEST_OUT}"
+  -binary="${MINIKUBE_BIN}" 2>&1 | tee "${TEST_OUT}"
 
 result=${PIPESTATUS[0]} # capture the exit code of the first cmd in pipe.
 set +x
@@ -298,10 +298,12 @@ echo $description
 
 echo ">> Copying html formatted logs ..."
 # Generate JSON format from test output 
-echo ">> Running go tool test2json"
-echo ">> contents of ${TEST_OUT} ..."
+echo ">> Contents of ${TEST_OUT}:"
+echo $(cat ${TEST_OUT})
+echo ">> Contents of ${TEST_OUT} again:"
 cat ${TEST_OUT} || true
-docker run --mount type=bind,source=${TEST_OUT},target=/tmp/log.txt -it medyagh/gopogh:v0.0.8 sh -c "go tool test2json -t < /tmp/log.txt" > ${JSON_OUT}
+echo ">> Running go tool test2json"
+docker run --mount type=bind,source="${TEST_OUT}",target=/tmp/log.txt -it medyagh/gopogh:v0.0.8 sh -c "go tool test2json -t < /tmp/log.txt" > "${JSON_OUT}"
 # Generate HTML human readable test output
 echo ">> Running gopogh"
 docker run --mount type=bind,source=${JSON_OUT},target=/tmp/log.json -it medyagh/gopogh:v0.0.8 sh -c "/gopogh -in /tmp/log.json -out /tmp/log.html; cat /tmp/log.html" > ${HTML_OUT}

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -383,5 +383,5 @@ function retry_github_status() {
 
 
 
-retry_github_status "${COMMIT}" "${JOB_NAME}" "${status}" "${access_token}" ${pubilc_log_url} "${description}"
+retry_github_status "${COMMIT}" "${JOB_NAME}" "${status}" "${access_token}" "${public_log_url}" "${description}"
 exit $result

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -296,7 +296,7 @@ echo $description
 
 
 # Generate well-formed test output
-"${GO_BIN}" tool test2json < "${TEST_OUT}" > "${JSON_OUT}"
+go tool test2json < "${TEST_OUT}" > "${JSON_OUT}"
 go get -u github.com/medyagh/goprettyorgohome
 goprettyorgohome -in "${JSON_OUT}" -out "${HTML_OUT}"
 gsutil -qm cp "${JSON_OUT}" "gs://minikube-builds/${MINIKUBE_LOCATION}/${JOB_NAME}.json"

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -294,13 +294,20 @@ description="completed with ${status} in ${elapsed} minute(s)."
 echo $description
 
 
+echo ">> Copying html formatted logs ..."
 # Generate JSON format from test output 
+echo ">> Running go tool test2json"
 docker run --mount type=bind,source=${TEST_OUT},target=/tmp/log.txt -it medyagh/gopogh:v0.0.8 sh -c "go tool test2json -t < /tmp/log.txt" > ${JSON_OUT}
 # Generate HTML human readable test output
+echo ">> Running gopogh"
 docker run --mount type=bind,source=${JSON_OUT},target=/tmp/log.json -it medyagh/gopogh:v0.0.8 sh -c "/gopogh -in /tmp/log.json -out /tmp/log.html; cat /tmp/log.html" > ${HTML_OUT}
+gsutil -qm cp "${JSON_OUT}" "gs://minikube-builds/logs/${MINIKUBE_LOCATION}/${JOB_NAME}.json"
+gsutil -qm cp "${HTML_OUT}" "gs://minikube-builds/logs/${MINIKUBE_LOCATION}/${JOB_NAME}.html"
+echo ">> contents of ${HTML_OUT} ..."
+cat ${HTML_OUT} || true
+echo ">> contents of ${JSON_OUT} ..."
+cat ${JSON_OUT} || true
 
-gsutil -qm cp "${JSON_OUT}" "gs://minikube-builds/${MINIKUBE_LOCATION}/${JOB_NAME}.json"
-gsutil -qm cp "${HTML_OUT}" "gs://minikube-builds/${MINIKUBE_LOCATION}/${JOB_NAME}.html"
 
 
 echo ">> Cleaning up after ourselves ..."

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -312,18 +312,18 @@ rm "${JSON_OUT}" || true # clean up build-reruns
 touch "${JSON_OUT}"
 
 # Generate JSON output
-echo ">> Runnin go test2json"
+echo ">> Running go test2json"
 go tool test2json -t < "${TEST_OUT}" > "${JSON_OUT}" || true
 echo ">> Installing gopogh"
-go get -u github.com/medyagh/gopogh@v0.0.15 || true
+GO111MODULE="on" go get -u github.com/medyagh/gopogh@v0.0.15 || true
 echo ">> Running gopogh"
 rm "${HTML_OUT}" || true # clean up build-reruns
 touch "${HTML_OUT}"
 gopogh -in "${JSON_OUT}" -out "${HTML_OUT}" -name "${JOB_NAME}" -pr "${MINIKUBE_LOCATION}" -repo github.com/kubernetes/minikube/  -details "${COMMIT}" || true
-echo ">> Copying ${JSON_OUT} to ${JOB_GS_BUCKET}.json"
-gsutil -qm cp "${JSON_OUT}" "gs://${JOB_GS_BUCKET}.json"
-echo ">> Copying ${HTML_OUT} to ${JOB_GS_BUCKET}.html"
-gsutil -qm cp "${HTML_OUT}" "gs://${JOB_GS_BUCKET}.html"
+echo ">> uploading ${JSON_OUT} to ${JOB_GCS_BUCKET}.json"
+gsutil -qm cp "${JSON_OUT}" "gs://${JOB_GCS_BUCKET}.json" || true
+echo ">> uploading ${HTML_OUT} to ${JOB_GCS_BUCKET}.html"
+gsutil -qm cp "${HTML_OUT}" "gs://${JOB_GCS_BUCKET}.html" || true
 
 
 echo ">> Cleaning up after ourselves ..."

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -317,13 +317,7 @@ if [ $RESULT -eq 0 ]; then
       echo ">> Running gopogh"
       rm ${HTML_OUT} || true # clean up build-reruns
       touch ${HTML_OUT}
-
-
-      
-      ${DOCKER_BIN} run --rm --mount type=bind,source=${JSON_OUT},target=/tmp/log.json \
-                      --mount type=bind,source="${HTML_OUT}",target=/tmp/log.html \
-                      -i medyagh/gopogh:v0.0.13 sh -c \
-                      "/gopogh -in /tmp/log.json -out /tmp/log.html -name ${JOB_NAME} -pr ${MINIKUBE_LOCATION} -repo github.com/kubernetes/minikube/  -details ${COMMIT}" || true
+      gopogh -in ${JSON_OUT} -out ${HTML_OUT} -name ${JOB_NAME} -pr ${MINIKUBE_LOCATION} -repo github.com/kubernetes/minikube/  -details ${COMMIT} || true
       echo ">> Copying ${HTML_OUT} to gs://minikube-builds/logs/${MINIKUBE_LOCATION}/${JOB_NAME}.html"
       gsutil -qm cp "${JSON_OUT}" "gs://minikube-builds/logs/${MINIKUBE_LOCATION}/${JOB_NAME}.json"
       gsutil -qm cp "${HTML_OUT}" "gs://minikube-builds/logs/${MINIKUBE_LOCATION}/${JOB_NAME}.html"
@@ -333,7 +327,7 @@ fi
                 
 
 public_log_url="https://storage.googleapis.com/minikube-builds/logs/${MINIKUBE_LOCATION}/${JOB_NAME}.txt"
-if [[ $(wc -l <${HTML_OUT}) -ge 1 ]]; then # if HTML generation was succesfull (would fail if docker is not installed)
+if [[ $(wc -l <${HTML_OUT}) -ge 1 ]]; then # if HTML generation was succesfull (would fail if gopogh is not installed)
   public_log_url="https://storage.googleapis.com/minikube-builds/logs/${MINIKUBE_LOCATION}/${JOB_NAME}.html"
 fi
 

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -45,9 +45,9 @@ echo "kubectl:   $(env KUBECONFIG=${TEST_HOME} kubectl version --client --short=
 echo "docker:    $(docker version --format '{{ .Client.Version }}')"
 
 
-# Make sure the right golang version is installed based on Makefile
-
-./installers/check_install_golang.sh 1.13.4 /usr/local
+# we need golang for test html binary
+# this script is copied by jenkins job config
+./check_install_golang.sh 1.13.4 /usr/local
 
 
 case "${VM_DRIVER}" in

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -316,7 +316,7 @@ ${DOCKER_BIN} run --rm --mount type=bind,source=${JSON_OUT},target=/tmp/log.json
                 -i medyagh/gopogh:v0.0.12 sh -c \
                 "/gopogh -in /tmp/log.json -out /tmp/log.html \ 
                 -name ${JOB_NAME} -pr ${6096}
-                --repo github.com/kubernetes/minikube/   -details ${COMMIT}"
+                -repo github.com/kubernetes/minikube/  -details ${COMMIT}"
                 || true
 echo ">> Copying ${HTML_OUT} to gs://minikube-builds/logs/${MINIKUBE_LOCATION}/${JOB_NAME}.html"
 gsutil -qm cp "${JSON_OUT}" "gs://minikube-builds/logs/${MINIKUBE_LOCATION}/${JOB_NAME}.json"

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -47,7 +47,8 @@ echo "docker:    $(docker version --format '{{ .Client.Version }}')"
 
 # we need golang for test html binary
 # this script is copied by jenkins job config
-./check_install_golang.sh 1.13.4 /usr/local
+sudo chmod +x ./check_install_golang.sh
+sudo ./check_install_golang.sh 1.13.4 /usr/local
 
 
 case "${VM_DRIVER}" in

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -47,8 +47,7 @@ echo "docker:    $(docker version --format '{{ .Client.Version }}')"
 
 # Make sure the right golang version is installed based on Makefile
 
-./hack/jenkins/installers/check_install_golang.sh 1.13.4 /usr/local
-declare -rx GOPATH=/var/lib/jenkins/go
+./installers/check_install_golang.sh 1.13.4 /usr/local
 
 
 case "${VM_DRIVER}" in

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -298,15 +298,7 @@ echo ">> Copying ${TEST_OUT} to gs://minikube-builds/logs/${MINIKUBE_LOCATION}/$
 gsutil -qm cp "${TEST_OUT}" "gs://minikube-builds/logs/${MINIKUBE_LOCATION}/${JOB_NAME}out.txt"
 echo ">> Copying html formatted logs ..."
 # Generate JSON format from test output 
-case "${OS_ARCHR}" in
-  darwin-amd64)
-    DOCKER_BIN="/usr/local/bin/docker"
-  ;;
-  linux-amd64)
-    DOCKER_BIN="docker"
-  ;;
-esac
-
+DOCKER_BIN="docker"
 echo ">> Running go tool test2json"
 touch ${JSON_OUT}
 ${DOCKER_BIN} run --mount type=bind,source="${JSON_OUT}",target=/tmp/out.json \

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -321,7 +321,7 @@ touch "${JSON_OUT}"
 echo ">> Running go test2json"
 go tool test2json -t < "${TEST_OUT}" > "${JSON_OUT}" || true
 echo ">> Installing gopogh"
-GO111MODULE="on" go get -u github.com/medyagh/gopogh@v0.0.15 || true
+GO111MODULE="on" go get -u github.com/medyagh/gopogh@v0.0.16 || true
 echo ">> Running gopogh"
 if test -f "${HTML_OUT}"; then
     rm "${HTML_OUT}" || true # clean up previous runs of same build

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -29,6 +29,7 @@ readonly TEST_HOME="${TEST_ROOT}/${OS_ARCH}-${VM_DRIVER}-${MINIKUBE_LOCATION}-$$
 readonly TEST_OUT="${TEST_HOME}/testout.txt"
 readonly JSON_OUT="${TEST_HOME}/test.json"
 readonly HTML_OUT="${TEST_HOME}/test.html"
+export PATH=$PATH:"/usr/local/bin/"
 
 echo ">> Starting at $(date)"
 echo ""
@@ -309,9 +310,14 @@ ${DOCKER_BIN} run --mount type=bind,source="${JSON_OUT}",target=/tmp/out.json \
 # Generate HTML human readable test output
 echo ">> Running gopogh"
 touch ${HTML_OUT}
+
 ${DOCKER_BIN} run --rm --mount type=bind,source=${JSON_OUT},target=/tmp/log.json \
                 --mount type=bind,source="${HTML_OUT}",target=/tmp/log.html \
-                -i medyagh/gopogh:v0.0.8 sh -c "/gopogh -in /tmp/log.json -out /tmp/log.html" || true
+                -i medyagh/gopogh:v0.0.12 sh -c \
+                "/gopogh -in /tmp/log.json -out /tmp/log.html \ 
+                -name ${JOB_NAME} -pr ${6096}
+                --repo github.com/kubernetes/minikube/   -details ${COMMIT}"
+                || true
 echo ">> Copying ${HTML_OUT} to gs://minikube-builds/logs/${MINIKUBE_LOCATION}/${JOB_NAME}.html"
 gsutil -qm cp "${JSON_OUT}" "gs://minikube-builds/logs/${MINIKUBE_LOCATION}/${JOB_NAME}.json"
 gsutil -qm cp "${HTML_OUT}" "gs://minikube-builds/logs/${MINIKUBE_LOCATION}/${JOB_NAME}.html"

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -305,7 +305,7 @@ echo ">> Running go tool test2json"
 touch ${JSON_OUT}
 ${DOCKER_BIN} run --mount type=bind,source="${JSON_OUT}",target=/tmp/out.json \
            --mount type=bind,source="${TEST_OUT}",target=/tmp/log.txt \
-           -i medyagh/gopogh:v0.0.12 \
+           -i medyagh/gopogh:v0.0.13 \
            sh -c "go tool test2json -t < /tmp/log.txt > /tmp/out.json" || true
 
 # Generate HTML human readable test output
@@ -314,7 +314,7 @@ touch ${HTML_OUT}
 
 ${DOCKER_BIN} run --rm --mount type=bind,source=${JSON_OUT},target=/tmp/log.json \
                 --mount type=bind,source="${HTML_OUT}",target=/tmp/log.html \
-                -i medyagh/gopogh:v0.0.12 sh -c \
+                -i medyagh/gopogh:v0.0.13 sh -c \
                 "/gopogh -in /tmp/log.json -out /tmp/log.html \ 
                 -name ${JOB_NAME} -pr ${MINIKUBE_LOCATION} \
                 -repo github.com/kubernetes/minikube/  -details ${COMMIT}" || true

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -303,7 +303,7 @@ case "${OS_ARCHR}" in
     DOCKER_BIN="/usr/local/bin/docker"
   ;;
   linux-amd64)
-    DOCKER_BIN="/usr/bin/docker"
+    DOCKER_BIN="docker"
   ;;
 esac
 

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -334,6 +334,10 @@ gsutil -qm cp "${JSON_OUT}" "gs://${JOB_GCS_BUCKET}.json" || true
 echo ">> uploading ${HTML_OUT}"
 gsutil -qm cp "${HTML_OUT}" "gs://${JOB_GCS_BUCKET}.html" || true
 
+public_log_url="https://storage.googleapis.com/${JOB_GCS_BUCKET}.txt"
+if grep -q html "$HTML_OUT"; then
+  public_log_url="https://storage.googleapis.com/${JOB_GCS_BUCKET}.html"
+fi
 
 echo ">> Cleaning up after ourselves ..."
 ${SUDO_PREFIX}${MINIKUBE_BIN} tunnel --cleanup || true
@@ -388,10 +392,6 @@ function retry_github_status() {
 }
 
 
-public_log_url="https://storage.googleapis.com/${JOB_GCS_BUCKET}.txt"
-if grep -q html "$HTML_OUT"; then
-  public_log_url="https://storage.googleapis.com/${JOB_GCS_BUCKET}.html"
-fi
 
 retry_github_status "${COMMIT}" "${JOB_NAME}" "${status}" "${access_token}" "${public_log_url}" "${description}"
 exit $result

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -271,7 +271,9 @@ ${SUDO_PREFIX}${E2E_BIN} \
   -expected-default-driver="${EXPECTED_DEFAULT_DRIVER}" \
   -test.timeout=70m \
   ${EXTRA_TEST_ARGS} \
-  -binary="${MINIKUBE_BIN}" | tee "${TEST_OUT}" && result=$? || result=$?
+  -binary="${MINIKUBE_BIN}" | tee "${TEST_OUT}"
+
+result=${PIPESTATUS[0]} # capture the exit code of the first cmd in pipe.
 set +x
 echo ">> ${E2E_BIN} exited with ${result} at $(date)"
 echo ""
@@ -297,6 +299,8 @@ echo $description
 echo ">> Copying html formatted logs ..."
 # Generate JSON format from test output 
 echo ">> Running go tool test2json"
+echo ">> contents of ${TEST_OUT} ..."
+cat ${TEST_OUT} || true
 docker run --mount type=bind,source=${TEST_OUT},target=/tmp/log.txt -it medyagh/gopogh:v0.0.8 sh -c "go tool test2json -t < /tmp/log.txt" > ${JSON_OUT}
 # Generate HTML human readable test output
 echo ">> Running gopogh"

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -276,7 +276,7 @@ touch "${TEST_OUT}"
 ${SUDO_PREFIX}${E2E_BIN} \
   -minikube-start-args="--vm-driver=${VM_DRIVER} ${EXTRA_START_ARGS}" \
   -expected-default-driver="${EXPECTED_DEFAULT_DRIVER}" \
-  -test.timeout=70m \
+  -test.timeout=70m -test.v \
   ${EXTRA_TEST_ARGS} \
   -binary="${MINIKUBE_BIN}" 2>&1 | tee "${TEST_OUT}"
 

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -26,7 +26,8 @@
 
 readonly TEST_ROOT="${HOME}/minikube-integration"
 readonly TEST_HOME="${TEST_ROOT}/${OS_ARCH}-${VM_DRIVER}-${MINIKUBE_LOCATION}-$$-${COMMIT}"
-export PATH=$PATH:"/usr/local/bin/:/usr/local/go/bin/"
+export GOPATH="$HOME/go"
+export PATH=$PATH:"/usr/local/bin/:/usr/local/go/bin/:$GOPATH/bin"
 
 echo ">> Starting at $(date)"
 echo ""

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -298,15 +298,12 @@ echo $description
 
 echo ">> Copying html formatted logs ..."
 # Generate JSON format from test output 
-echo ">> Contents of ${TEST_OUT}:"
-echo $(cat ${TEST_OUT})
-echo ">> Contents of ${TEST_OUT} again:"
-cat ${TEST_OUT} || true
 echo ">> Running go tool test2json"
-docker run --mount type=bind,source="${TEST_OUT}",target=/tmp/log.txt -it medyagh/gopogh:v0.0.8 sh -c "go tool test2json -t < /tmp/log.txt" > "${JSON_OUT}"
+docker run --mount type=bind,source="${TEST_OUT}",target=/tmp/log.txt -i medyagh/gopogh:v0.0.8 sh -c "go tool test2json -t < /tmp/log.txt" > "${JSON_OUT}"
 # Generate HTML human readable test output
 echo ">> Running gopogh"
-docker run --mount type=bind,source=${JSON_OUT},target=/tmp/log.json -it medyagh/gopogh:v0.0.8 sh -c "/gopogh -in /tmp/log.json -out /tmp/log.html; cat /tmp/log.html" > ${HTML_OUT}
+docker run --rm --mount type=bind,source=${JSON_OUT},target=/tmp/log.json -i medyagh/gopogh:v0.0.8 sh -c "/gopogh -in /tmp/log.json -out /tmp/log.html; cat /tmp/log.html" > ${HTML_OUT}
+echo ">> Copying ${HTML_OUT} to gs://minikube-builds/logs/${MINIKUBE_LOCATION}/${JOB_NAME}.html"
 gsutil -qm cp "${JSON_OUT}" "gs://minikube-builds/logs/${MINIKUBE_LOCATION}/${JOB_NAME}.json"
 gsutil -qm cp "${HTML_OUT}" "gs://minikube-builds/logs/${MINIKUBE_LOCATION}/${JOB_NAME}.html"
 echo ">> contents of ${HTML_OUT} ..."

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -379,8 +379,8 @@ function retry_github_status() {
 }
 
 
-public_log_url="https://storage.googleapis.com/${JOB_GCS_BUCKET}.txt"
-if [[ $(wc -l <"${HTML_OUT}") -ge 1 ]]; then # if HTML generation was succesfull (would fail if gopogh is not installed)
+public_log_url="https://storage.googleapis.com/${JOB_GCS_BUCKET}out.txt"
+if [ `wc -l ${HTML_OUT} | awk '{print $1}'` -ge "2" ]; then  # if HTML generation was succesfull (would fail if gopogh is not installed)
   public_log_url="https://storage.googleapis.com/${JOB_GCS_BUCKET}.html"
 fi
 

--- a/hack/jenkins/linux_integration_tests_kvm.sh
+++ b/hack/jenkins/linux_integration_tests_kvm.sh
@@ -38,7 +38,7 @@ sudo install cron/cleanup_and_reboot_Linux.sh /etc/cron.hourly/cleanup_and_reboo
 
 ## download and install gopogh
 wget -O gopogh https://github.com/medyagh/gopogh/releases/download/v0.0.14/gopogh-linux-amd64 || echo "Failed to download gopogh"
-sudo install gopogh /usr/loca/bin/ || echo "Failed to install Gopogh"
+sudo install gopogh /usr/local/bin/ || echo "Failed to install Gopogh"
 
 
 # Download files and set permissions

--- a/hack/jenkins/linux_integration_tests_kvm.sh
+++ b/hack/jenkins/linux_integration_tests_kvm.sh
@@ -36,5 +36,10 @@ EXTRA_TEST_ARGS="-gvisor"
 mkdir -p cron && gsutil -qm rsync "gs://minikube-builds/${MINIKUBE_LOCATION}/cron" cron || echo "FAILED TO GET CRON FILES"
 sudo install cron/cleanup_and_reboot_Linux.sh /etc/cron.hourly/cleanup_and_reboot || echo "FAILED TO INSTALL CLEANUP"
 
+## download and install gopogh
+wget -O gopogh https://github.com/medyagh/gopogh/releases/download/v0.0.14/gopogh-linux-amd64 || echo "Failed to download gopogh"
+sudo install gopogh /usr/loca/bin/ || echo "Failed to install Gopogh"
+
+
 # Download files and set permissions
 source ./common.sh

--- a/hack/jenkins/linux_integration_tests_kvm.sh
+++ b/hack/jenkins/linux_integration_tests_kvm.sh
@@ -36,10 +36,4 @@ EXTRA_TEST_ARGS="-gvisor"
 mkdir -p cron && gsutil -qm rsync "gs://minikube-builds/${MINIKUBE_LOCATION}/cron" cron || echo "FAILED TO GET CRON FILES"
 sudo install cron/cleanup_and_reboot_Linux.sh /etc/cron.hourly/cleanup_and_reboot || echo "FAILED TO INSTALL CLEANUP"
 
-## download and install gopogh
-wget -O gopogh https://github.com/medyagh/gopogh/releases/download/v0.0.14/gopogh-linux-amd64 || echo "Failed to download gopogh"
-sudo install gopogh /usr/local/bin/ || echo "Failed to install Gopogh"
-
-
-# Download files and set permissions
 source ./common.sh

--- a/hack/jenkins/linux_integration_tests_none.sh
+++ b/hack/jenkins/linux_integration_tests_none.sh
@@ -54,10 +54,4 @@ systemctl is-active --quiet kubelet \
 mkdir -p cron && gsutil -m rsync "gs://minikube-builds/${MINIKUBE_LOCATION}/cron" cron || echo "FAILED TO GET CRON FILES"
 sudo install cron/cleanup_and_reboot_Linux.sh /etc/cron.hourly/cleanup_and_reboot || echo "FAILED TO INSTALL CLEANUP"
 
-## download and install gopogh
-wget -O gopogh https://github.com/medyagh/gopogh/releases/download/v0.0.14/gopogh-linux-amd64 || echo "Failed to download gopogh"
-sudo install gopogh /usr/local/bin/ || echo "Failed to install Gopogh"
-
-
-# Download files and set permissions
 source ./common.sh

--- a/hack/jenkins/linux_integration_tests_none.sh
+++ b/hack/jenkins/linux_integration_tests_none.sh
@@ -56,7 +56,7 @@ sudo install cron/cleanup_and_reboot_Linux.sh /etc/cron.hourly/cleanup_and_reboo
 
 ## download and install gopogh
 wget -O gopogh https://github.com/medyagh/gopogh/releases/download/v0.0.14/gopogh-linux-amd64 || echo "Failed to download gopogh"
-sudo install gopogh /usr/loca/bin/ || echo "Failed to install Gopogh"
+sudo install gopogh /usr/local/bin/ || echo "Failed to install Gopogh"
 
 
 # Download files and set permissions

--- a/hack/jenkins/linux_integration_tests_none.sh
+++ b/hack/jenkins/linux_integration_tests_none.sh
@@ -54,5 +54,10 @@ systemctl is-active --quiet kubelet \
 mkdir -p cron && gsutil -m rsync "gs://minikube-builds/${MINIKUBE_LOCATION}/cron" cron || echo "FAILED TO GET CRON FILES"
 sudo install cron/cleanup_and_reboot_Linux.sh /etc/cron.hourly/cleanup_and_reboot || echo "FAILED TO INSTALL CLEANUP"
 
+## download and install gopogh
+wget -O gopogh https://github.com/medyagh/gopogh/releases/download/v0.0.14/gopogh-linux-amd64 || echo "Failed to download gopogh"
+sudo install gopogh /usr/loca/bin/ || echo "Failed to install Gopogh"
+
+
 # Download files and set permissions
 source ./common.sh

--- a/hack/jenkins/linux_integration_tests_virtualbox.sh
+++ b/hack/jenkins/linux_integration_tests_virtualbox.sh
@@ -33,10 +33,4 @@ EXPECTED_DEFAULT_DRIVER="kvm2"
 mkdir -p cron && gsutil -qm rsync "gs://minikube-builds/${MINIKUBE_LOCATION}/cron" cron || echo "FAILED TO GET CRON FILES"
 sudo install cron/cleanup_and_reboot_Linux.sh /etc/cron.hourly/cleanup_and_reboot || echo "FAILED TO INSTALL CLEANUP"
 
-## download and install gopogh
-wget -O gopogh https://github.com/medyagh/gopogh/releases/download/v0.0.14/gopogh-linux-amd64 || echo "Failed to download gopogh"
-sudo install gopogh /usr/local/bin/ || echo "Failed to install Gopogh"
-
-
-# Download files and set permissions
 source ./common.sh

--- a/hack/jenkins/linux_integration_tests_virtualbox.sh
+++ b/hack/jenkins/linux_integration_tests_virtualbox.sh
@@ -33,6 +33,10 @@ EXPECTED_DEFAULT_DRIVER="kvm2"
 mkdir -p cron && gsutil -qm rsync "gs://minikube-builds/${MINIKUBE_LOCATION}/cron" cron || echo "FAILED TO GET CRON FILES"
 sudo install cron/cleanup_and_reboot_Linux.sh /etc/cron.hourly/cleanup_and_reboot || echo "FAILED TO INSTALL CLEANUP"
 
+## download and install gopogh
+wget -O gopogh https://github.com/medyagh/gopogh/releases/download/v0.0.14/gopogh-linux-amd64 || echo "Failed to download gopogh"
+sudo install gopogh /usr/loca/bin/ || echo "Failed to install Gopogh"
+
 
 # Download files and set permissions
 source ./common.sh

--- a/hack/jenkins/linux_integration_tests_virtualbox.sh
+++ b/hack/jenkins/linux_integration_tests_virtualbox.sh
@@ -35,7 +35,7 @@ sudo install cron/cleanup_and_reboot_Linux.sh /etc/cron.hourly/cleanup_and_reboo
 
 ## download and install gopogh
 wget -O gopogh https://github.com/medyagh/gopogh/releases/download/v0.0.14/gopogh-linux-amd64 || echo "Failed to download gopogh"
-sudo install gopogh /usr/loca/bin/ || echo "Failed to install Gopogh"
+sudo install gopogh /usr/local/bin/ || echo "Failed to install Gopogh"
 
 
 # Download files and set permissions

--- a/hack/jenkins/minikube_set_pending.sh
+++ b/hack/jenkins/minikube_set_pending.sh
@@ -78,6 +78,6 @@ function retry_github_status() {
 
 for j in ${jobs[@]}; do
   retry_github_status "${ghprbActualCommit}" "${j}" "pending" "${access_token}" \
-    "https://storage.googleapis.com/minikube-builds/logs/${ghprbPullId}/${j}.txt"
+    "https://storage.googleapis.com/minikube-builds/logs/${ghprbPullId}/${j}.html"
 done
 

--- a/hack/jenkins/minikube_set_pending.sh
+++ b/hack/jenkins/minikube_set_pending.sh
@@ -78,6 +78,6 @@ function retry_github_status() {
 
 for j in ${jobs[@]}; do
   retry_github_status "${ghprbActualCommit}" "${j}" "pending" "${access_token}" \
-    "https://storage.googleapis.com/minikube-builds/logs/${ghprbPullId}/${j}.html"
+    "https://storage.googleapis.com/minikube-builds/logs/${ghprbPullId}/${j}.pending"
 done
 

--- a/hack/jenkins/osx_integration_tests_hyperkit.sh
+++ b/hack/jenkins/osx_integration_tests_hyperkit.sh
@@ -39,10 +39,4 @@ install cron/cleanup_and_reboot_Darwin.sh $HOME/cleanup_and_reboot.sh || echo "F
 echo "*/30 * * * * $HOME/cleanup_and_reboot.sh" | crontab
 crontab -l
 
-## download and install gopogh
-wget -O gopogh https://github.com/medyagh/gopogh/releases/download/v0.0.14/gopogh-linux-amd64 || echo "Failed to download gopogh"
-sudo install gopogh /usr/local/bin/ || echo "Failed to install Gopogh"
-
-
-# Download files and set permissions
 source common.sh

--- a/hack/jenkins/osx_integration_tests_hyperkit.sh
+++ b/hack/jenkins/osx_integration_tests_hyperkit.sh
@@ -41,7 +41,7 @@ crontab -l
 
 ## download and install gopogh
 wget -O gopogh https://github.com/medyagh/gopogh/releases/download/v0.0.14/gopogh-linux-amd64 || echo "Failed to download gopogh"
-sudo install gopogh /usr/loca/bin/ || echo "Failed to install Gopogh"
+sudo install gopogh /usr/local/bin/ || echo "Failed to install Gopogh"
 
 
 # Download files and set permissions

--- a/hack/jenkins/osx_integration_tests_hyperkit.sh
+++ b/hack/jenkins/osx_integration_tests_hyperkit.sh
@@ -39,5 +39,10 @@ install cron/cleanup_and_reboot_Darwin.sh $HOME/cleanup_and_reboot.sh || echo "F
 echo "*/30 * * * * $HOME/cleanup_and_reboot.sh" | crontab
 crontab -l
 
+## download and install gopogh
+wget -O gopogh https://github.com/medyagh/gopogh/releases/download/v0.0.14/gopogh-linux-amd64 || echo "Failed to download gopogh"
+sudo install gopogh /usr/loca/bin/ || echo "Failed to install Gopogh"
+
+
 # Download files and set permissions
 source common.sh

--- a/hack/jenkins/osx_integration_tests_virtualbox.sh
+++ b/hack/jenkins/osx_integration_tests_virtualbox.sh
@@ -39,9 +39,4 @@ install cron/cleanup_and_reboot_Darwin.sh $HOME/cleanup_and_reboot.sh  || echo "
 echo "*/30 * * * * $HOME/cleanup_and_reboot.sh" | crontab
 crontab -l
 
-## download and install gopogh
-wget -O gopogh https://github.com/medyagh/gopogh/releases/download/v0.0.14/gopogh-linux-amd64 || echo "Failed to download gopogh"
-sudo install gopogh /usr/local/bin/ || echo "Failed to install Gopogh"
-
-# Download files and set permissions
 source common.sh

--- a/hack/jenkins/osx_integration_tests_virtualbox.sh
+++ b/hack/jenkins/osx_integration_tests_virtualbox.sh
@@ -39,5 +39,9 @@ install cron/cleanup_and_reboot_Darwin.sh $HOME/cleanup_and_reboot.sh  || echo "
 echo "*/30 * * * * $HOME/cleanup_and_reboot.sh" | crontab
 crontab -l
 
+## download and install gopogh
+wget -O gopogh https://github.com/medyagh/gopogh/releases/download/v0.0.14/gopogh-linux-amd64 || echo "Failed to download gopogh"
+sudo install gopogh /usr/loca/bin/ || echo "Failed to install Gopogh"
+
 # Download files and set permissions
 source common.sh

--- a/hack/jenkins/osx_integration_tests_virtualbox.sh
+++ b/hack/jenkins/osx_integration_tests_virtualbox.sh
@@ -41,7 +41,7 @@ crontab -l
 
 ## download and install gopogh
 wget -O gopogh https://github.com/medyagh/gopogh/releases/download/v0.0.14/gopogh-linux-amd64 || echo "Failed to download gopogh"
-sudo install gopogh /usr/loca/bin/ || echo "Failed to install Gopogh"
+sudo install gopogh /usr/local/bin/ || echo "Failed to install Gopogh"
 
 # Download files and set permissions
 source common.sh

--- a/hack/jenkins/windows_integration_test_hyperv.ps1
+++ b/hack/jenkins/windows_integration_test_hyperv.ps1
@@ -17,26 +17,24 @@ gsutil.cmd -m cp gs://minikube-builds/$env:MINIKUBE_LOCATION/minikube-windows-am
 gsutil.cmd -m cp gs://minikube-builds/$env:MINIKUBE_LOCATION/e2e-windows-amd64.exe out/
 gsutil.cmd -m cp -r gs://minikube-builds/$env:MINIKUBE_LOCATION/testdata .
 
-./out/minikube-windows-amd64.exe delete
+./out/minikube-windows-amd64.exe delete --all --purge
 out/e2e-windows-amd64.exe --expected-default-driver=hyperv -minikube-start-args="--vm-driver=hyperv --hyperv-virtual-switch=primary-virtual-switch" -binary=out/minikube-windows-amd64.exe -test.v -test.timeout=65m  > ./out/test.out 2>&1
 $env:result=$lastexitcode
 # If the last exit code was 0->success, x>0->error
 If($env:result -eq 0){$env:status="success"}
 Else {$env:status="failure"}
 
-type nul > out/test.json
 # generate json output using go tool test2json
-go tool test2json -t < ./out/test.out > ./out/test.json
-GO111MODULE="on" go get -u "github.com/medyagh/gopogh@v0.0.15"
-
-type nul > out/test.html # touch 
+cmd /c 'go tool test2json -t < ./out/test.out > ./out/test.json'
+$env:GO111MODULE='on'
+go get -u "github.com/medyagh/gopogh@v0.0.16"
 # Generate html report 
 gopogh -in ./out/test.json  -out ./out/test.html -name $env:JOB_NAME -pr $env:MINIKUBE_LOCATION -repo github.com/kubernetes/minikube/  -details $env:COMMIT
 gsutil -qm cp ./out/test.json "gs://minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:JOB_NAME.json"
 gsutil -qm cp ./out/test.html "gs://minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:JOB_NAME.html"
                 
 
-$env:target_url="https://storage.googleapis.com/minikube-builds/logs/$env:MINIKUBE_LOCATION/Hyper-V_Windows.txt"
+$env:target_url="https://storage.googleapis.com/minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:JOB_NAME.html"
 $json = "{`"state`": `"$env:status`", `"description`": `"Jenkins`", `"target_url`": `"$env:target_url`", `"context`": `"Hyper-V_Windows`"}"
 Invoke-WebRequest -Uri "https://api.github.com/repos/kubernetes/minikube/statuses/$env:COMMIT`?access_token=$env:access_token" -Body $json -ContentType "application/json" -Method Post -usebasicparsing
 

--- a/hack/jenkins/windows_integration_test_hyperv.ps1
+++ b/hack/jenkins/windows_integration_test_hyperv.ps1
@@ -27,7 +27,7 @@ Else {$env:status="failure"}
 type nul > out/test.json
 # generate json output using go tool test2json
 go tool test2json -t < ./out/test.out > ./out/test.json || VER>NUL
-go get -u "github.com/medyagh/gopogh@v0.0.15"
+GO111MODULE="on" go get -u "github.com/medyagh/gopogh@v0.0.15"
 
 type nul > out/test.html # touch 
 # Generate html report 

--- a/hack/jenkins/windows_integration_test_hyperv.ps1
+++ b/hack/jenkins/windows_integration_test_hyperv.ps1
@@ -18,7 +18,7 @@ gsutil.cmd -m cp gs://minikube-builds/$env:MINIKUBE_LOCATION/e2e-windows-amd64.e
 gsutil.cmd -m cp -r gs://minikube-builds/$env:MINIKUBE_LOCATION/testdata .
 
 ./out/minikube-windows-amd64.exe delete
-out/e2e-windows-amd64.exe --expected-default-driver=hyperv -minikube-start-args="--vm-driver=hyperv --hyperv-virtual-switch=primary-virtual-switch" -binary=out/minikube-windows-amd64.exe -test.v -test.timeout=65m  > /out/test.out 2>&1
+out/e2e-windows-amd64.exe --expected-default-driver=hyperv -minikube-start-args="--vm-driver=hyperv --hyperv-virtual-switch=primary-virtual-switch" -binary=out/minikube-windows-amd64.exe -test.v -test.timeout=65m  > ./out/test.out 2>&1
 $env:result=$lastexitcode
 # If the last exit code was 0->success, x>0->error
 If($env:result -eq 0){$env:status="success"}
@@ -26,16 +26,14 @@ Else {$env:status="failure"}
 
 type nul > out/test.json
 # generate json output using go tool test2json
-docker run --mount type=bind,source=out/test.json,target=/tmp/out.json --mount type=bind,source=out/test.out,target=/tmp/log.txt -i medyagh/gopogh:v0.0.13 sh -c "go tool test2json -t < /tmp/log.txt > /tmp/out.json" || VER>NUL
+go tool test2json -t < ./out/test.out > ./out/test.json || VER>NUL
 
 type nul > out/test.html # touch 
 # genearte html report
-docker run --rm --mount type=bind,source=test.json,target=/tmp/log.json --mount type=bind,source="out/test.html",target=/tmp/log.html -i medyagh/gopogh:v0.0.13 sh -c "/gopogh -in /tmp/log.json -out /tmp/log.html -name $env:JOB_NAME -pr $env:MINIKUBE_LOCATION -repo github.com/kubernetes/minikube/  -details $env:COMMIT" || VER>NUL
-
+gopogh -in ./out/test.json  -out ./out/test.html -name $env:JOB_NAME -pr $env:MINIKUBE_LOCATION -repo github.com/kubernetes/minikube/  -details $env:COMMIT || VER>NUL
 gsutil -qm cp ./out/test.json "gs://minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:JOB_NAME.json" || VER>NUL
 gsutil -qm cp ./out/test.html "gs://minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:JOB_NAME.html" || VER>NUL
                 
-
 
 $env:target_url="https://storage.googleapis.com/minikube-builds/logs/$env:MINIKUBE_LOCATION/Hyper-V_Windows.txt"
 $json = "{`"state`": `"$env:status`", `"description`": `"Jenkins`", `"target_url`": `"$env:target_url`", `"context`": `"Hyper-V_Windows`"}"

--- a/hack/jenkins/windows_integration_test_hyperv.ps1
+++ b/hack/jenkins/windows_integration_test_hyperv.ps1
@@ -29,7 +29,7 @@ type nul > out/test.json
 go tool test2json -t < ./out/test.out > ./out/test.json || VER>NUL
 
 type nul > out/test.html # touch 
-# genearte html report
+# Generate html report 
 gopogh -in ./out/test.json  -out ./out/test.html -name $env:JOB_NAME -pr $env:MINIKUBE_LOCATION -repo github.com/kubernetes/minikube/  -details $env:COMMIT || VER>NUL
 gsutil -qm cp ./out/test.json "gs://minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:JOB_NAME.json" || VER>NUL
 gsutil -qm cp ./out/test.html "gs://minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:JOB_NAME.html" || VER>NUL

--- a/hack/jenkins/windows_integration_test_hyperv.ps1
+++ b/hack/jenkins/windows_integration_test_hyperv.ps1
@@ -17,24 +17,15 @@ gsutil.cmd -m cp gs://minikube-builds/$env:MINIKUBE_LOCATION/minikube-windows-am
 gsutil.cmd -m cp gs://minikube-builds/$env:MINIKUBE_LOCATION/e2e-windows-amd64.exe out/
 gsutil.cmd -m cp -r gs://minikube-builds/$env:MINIKUBE_LOCATION/testdata .
 
-./out/minikube-windows-amd64.exe delete --all --purge
-out/e2e-windows-amd64.exe --expected-default-driver=hyperv -minikube-start-args="--vm-driver=hyperv --hyperv-virtual-switch=primary-virtual-switch" -binary=out/minikube-windows-amd64.exe -test.v -test.timeout=65m  > ./out/test.out 2>&1
+./out/minikube-windows-amd64.exe delete
+
+out/e2e-windows-amd64.exe --expected-default-driver=hyperv -minikube-start-args="--vm-driver=hyperv --hyperv-virtual-switch=primary-virtual-switch" -binary=out/minikube-windows-amd64.exe -test.v -test.timeout=65m
 $env:result=$lastexitcode
 # If the last exit code was 0->success, x>0->error
 If($env:result -eq 0){$env:status="success"}
 Else {$env:status="failure"}
 
-# generate json output using go tool test2json
-cmd /c 'go tool test2json -t < ./out/test.out > ./out/test.json'
-$env:GO111MODULE='on'
-go get -u "github.com/medyagh/gopogh@v0.0.16"
-# Generate html report 
-gopogh -in ./out/test.json  -out ./out/test.html -name $env:JOB_NAME -pr $env:MINIKUBE_LOCATION -repo github.com/kubernetes/minikube/  -details $env:COMMIT
-gsutil -qm cp ./out/test.json "gs://minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:JOB_NAME.json"
-gsutil -qm cp ./out/test.html "gs://minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:JOB_NAME.html"
-                
-
-$env:target_url="https://storage.googleapis.com/minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:JOB_NAME.html"
+$env:target_url="https://storage.googleapis.com/minikube-builds/logs/$env:MINIKUBE_LOCATION/Hyper-V_Windows.txt"
 $json = "{`"state`": `"$env:status`", `"description`": `"Jenkins`", `"target_url`": `"$env:target_url`", `"context`": `"Hyper-V_Windows`"}"
 Invoke-WebRequest -Uri "https://api.github.com/repos/kubernetes/minikube/statuses/$env:COMMIT`?access_token=$env:access_token" -Body $json -ContentType "application/json" -Method Post -usebasicparsing
 

--- a/hack/jenkins/windows_integration_test_hyperv.ps1
+++ b/hack/jenkins/windows_integration_test_hyperv.ps1
@@ -27,6 +27,7 @@ Else {$env:status="failure"}
 type nul > out/test.json
 # generate json output using go tool test2json
 go tool test2json -t < ./out/test.out > ./out/test.json || VER>NUL
+go get -u "github.com/medyagh/gopogh@v0.0.15"
 
 type nul > out/test.html # touch 
 # Generate html report 

--- a/hack/jenkins/windows_integration_test_hyperv.ps1
+++ b/hack/jenkins/windows_integration_test_hyperv.ps1
@@ -26,14 +26,14 @@ Else {$env:status="failure"}
 
 type nul > out/test.json
 # generate json output using go tool test2json
-go tool test2json -t < ./out/test.out > ./out/test.json || VER>NUL
+go tool test2json -t < ./out/test.out > ./out/test.json
 GO111MODULE="on" go get -u "github.com/medyagh/gopogh@v0.0.15"
 
 type nul > out/test.html # touch 
 # Generate html report 
-gopogh -in ./out/test.json  -out ./out/test.html -name $env:JOB_NAME -pr $env:MINIKUBE_LOCATION -repo github.com/kubernetes/minikube/  -details $env:COMMIT || VER>NUL
-gsutil -qm cp ./out/test.json "gs://minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:JOB_NAME.json" || VER>NUL
-gsutil -qm cp ./out/test.html "gs://minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:JOB_NAME.html" || VER>NUL
+gopogh -in ./out/test.json  -out ./out/test.html -name $env:JOB_NAME -pr $env:MINIKUBE_LOCATION -repo github.com/kubernetes/minikube/  -details $env:COMMIT
+gsutil -qm cp ./out/test.json "gs://minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:JOB_NAME.json"
+gsutil -qm cp ./out/test.html "gs://minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:JOB_NAME.html"
                 
 
 $env:target_url="https://storage.googleapis.com/minikube-builds/logs/$env:MINIKUBE_LOCATION/Hyper-V_Windows.txt"

--- a/hack/jenkins/windows_integration_test_hyperv.ps1
+++ b/hack/jenkins/windows_integration_test_hyperv.ps1
@@ -26,19 +26,11 @@ Else {$env:status="failure"}
 
 type nul > out/test.json
 # generate json output using go tool test2json
-docker run --mount type=bind,source=out/test.json,target=/tmp/out.json \
-           --mount type=bind,source=out/test.out,target=/tmp/log.txt \
-           -i medyagh/gopogh:v0.0.13 \
-           sh -c "go tool test2json -t < /tmp/log.txt > /tmp/out.json" || VER>NUL
+docker run --mount type=bind,source=out/test.json,target=/tmp/out.json --mount type=bind,source=out/test.out,target=/tmp/log.txt -i medyagh/gopogh:v0.0.13 sh -c "go tool test2json -t < /tmp/log.txt > /tmp/out.json" || VER>NUL
 
 type nul > out/test.html # touch 
 # genearte html report
-docker run --rm --mount type=bind,source=test.json,target=/tmp/log.json \
-                --mount type=bind,source="out/test.html",target=/tmp/log.html \
-                -i medyagh/gopogh:v0.0.13 sh -c \
-                "/gopogh -in /tmp/log.json -out /tmp/log.html \ 
-                -name $env:JOB_NAME -pr $env:MINIKUBE_LOCATION \
-                -repo github.com/kubernetes/minikube/  -details $env:COMMIT" || VER>NUL
+docker run --rm --mount type=bind,source=test.json,target=/tmp/log.json --mount type=bind,source="out/test.html",target=/tmp/log.html -i medyagh/gopogh:v0.0.13 sh -c "/gopogh -in /tmp/log.json -out /tmp/log.html -name $env:JOB_NAME -pr $env:MINIKUBE_LOCATION -repo github.com/kubernetes/minikube/  -details $env:COMMIT" || VER>NUL
 
 gsutil -qm cp ./out/test.json "gs://minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:JOB_NAME.json" || VER>NUL
 gsutil -qm cp ./out/test.html "gs://minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:JOB_NAME.html" || VER>NUL

--- a/hack/jenkins/windows_integration_test_virtualbox.ps1
+++ b/hack/jenkins/windows_integration_test_virtualbox.ps1
@@ -17,15 +17,24 @@ gsutil.cmd -m cp gs://minikube-builds/$env:MINIKUBE_LOCATION/minikube-windows-am
 gsutil.cmd -m cp gs://minikube-builds/$env:MINIKUBE_LOCATION/e2e-windows-amd64.exe out/
 gsutil.cmd -m cp -r gs://minikube-builds/$env:MINIKUBE_LOCATION/testdata .
 
-./out/minikube-windows-amd64.exe delete
-
-out/e2e-windows-amd64.exe -minikube-start-args="--vm-driver=virtualbox" -expected-default-driver=hyperv -binary=out/minikube-windows-amd64.exe -test.v -test.timeout=30m
+./out/minikube-windows-amd64.exe delete --all --purge
+out/e2e-windows-amd64.exe -minikube-start-args="--vm-driver=virtualbox" -expected-default-driver=hyperv -binary=out/minikube-windows-amd64.exe -test.v -test.timeout=60m > ./out/test.out 2>&1
 $env:result=$lastexitcode
 # If the last exit code was 0->success, x>0->error
 If($env:result -eq 0){$env:status="success"}
 Else {$env:status="failure"}
 
-$env:target_url="https://storage.googleapis.com/minikube-builds/logs/$env:MINIKUBE_LOCATION/VirtualBox_Windows.txt"
+# generate json output using go tool test2json
+cmd /c 'go tool test2json -t < ./out/test.out > ./out/test.json'
+$env:GO111MODULE='on'
+go get -u "github.com/medyagh/gopogh@v0.0.16"
+# Generate html report 
+gopogh -in ./out/test.json  -out ./out/test.html -name $env:JOB_NAME -pr $env:MINIKUBE_LOCATION -repo github.com/kubernetes/minikube/  -details $env:COMMIT
+gsutil -qm cp ./out/test.json "gs://minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:JOB_NAME.json"
+gsutil -qm cp ./out/test.html "gs://minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:JOB_NAME.html"
+
+
+$env:target_url="https://storage.googleapis.com/minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:JOB_NAME.html"
 $json = "{`"state`": `"$env:status`", `"description`": `"Jenkins`", `"target_url`": `"$env:target_url`", `"context`": `"VirtualBox_Windows`"}"
 Invoke-WebRequest -Uri "https://api.github.com/repos/kubernetes/minikube/statuses/$env:COMMIT`?access_token=$env:access_token" -Body $json -ContentType "application/json" -Method Post -usebasicparsing
 

--- a/hack/jenkins/windows_integration_test_virtualbox.ps1
+++ b/hack/jenkins/windows_integration_test_virtualbox.ps1
@@ -17,24 +17,15 @@ gsutil.cmd -m cp gs://minikube-builds/$env:MINIKUBE_LOCATION/minikube-windows-am
 gsutil.cmd -m cp gs://minikube-builds/$env:MINIKUBE_LOCATION/e2e-windows-amd64.exe out/
 gsutil.cmd -m cp -r gs://minikube-builds/$env:MINIKUBE_LOCATION/testdata .
 
-./out/minikube-windows-amd64.exe delete --all --purge
-out/e2e-windows-amd64.exe -minikube-start-args="--vm-driver=virtualbox" -expected-default-driver=hyperv -binary=out/minikube-windows-amd64.exe -test.v -test.timeout=60m > ./out/test.out 2>&1
+./out/minikube-windows-amd64.exe delete
+
+out/e2e-windows-amd64.exe -minikube-start-args="--vm-driver=virtualbox" -expected-default-driver=hyperv -binary=out/minikube-windows-amd64.exe -test.v -test.timeout=30m
 $env:result=$lastexitcode
 # If the last exit code was 0->success, x>0->error
 If($env:result -eq 0){$env:status="success"}
 Else {$env:status="failure"}
 
-# generate json output using go tool test2json
-cmd /c 'go tool test2json -t < ./out/test.out > ./out/test.json'
-$env:GO111MODULE='on'
-go get -u "github.com/medyagh/gopogh@v0.0.16"
-# Generate html report 
-gopogh -in ./out/test.json  -out ./out/test.html -name $env:JOB_NAME -pr $env:MINIKUBE_LOCATION -repo github.com/kubernetes/minikube/  -details $env:COMMIT
-gsutil -qm cp ./out/test.json "gs://minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:JOB_NAME.json"
-gsutil -qm cp ./out/test.html "gs://minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:JOB_NAME.html"
-
-
-$env:target_url="https://storage.googleapis.com/minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:JOB_NAME.html"
+$env:target_url="https://storage.googleapis.com/minikube-builds/logs/$env:MINIKUBE_LOCATION/VirtualBox_Windows.txt"
 $json = "{`"state`": `"$env:status`", `"description`": `"Jenkins`", `"target_url`": `"$env:target_url`", `"context`": `"VirtualBox_Windows`"}"
 Invoke-WebRequest -Uri "https://api.github.com/repos/kubernetes/minikube/statuses/$env:COMMIT`?access_token=$env:access_token" -Body $json -ContentType "application/json" -Method Post -usebasicparsing
 


### PR DESCRIPTION
## This PR
###  Generates prettier logs using [gopogh](https://github.com/medyagh/gopogh)
- Converts TXT logs to HTML
- Foldable Tests Results
-  Altenrating background color (white/black for every other test)
- Search for a specific word in each different test separately. (high light)
- Table of contents per @tstromberg's request

- Runs go tool test2json and (gopogh)[https://github.com/medyagh/gopogh] inside docker ( if docker doesnt exist on the intgraiton test machine it will revert back to uploading the .txt logs)

Based @tstromberg PR 
https://github.com/kubernetes/minikube/pull/5225


## also 

- Set pending used to set .txt file for the jobs that made it confusing when a job was re-running. it would show the test result of previous text. changed that from .txt to .pending
so if user wants to quickly see older runs results rename to .txt but also dont be mislead