### PR TITLE
Fix update-context to use KUBECONFIG when the env is set

### DIFF
--- a/cmd/minikube/cmd/update-context.go
+++ b/cmd/minikube/cmd/update-context.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/cluster"
@@ -45,7 +47,13 @@ var updateContextCmd = &cobra.Command{
 		if err != nil {
 			exit.WithError("Error host driver ip status", err)
 		}
-		updated, err := kubeconfig.UpdateIP(ip, machineName, constants.KubeconfigPath)
+		updated := false
+		kubeConfigPath := os.Getenv("KUBECONFIG")
+		if kubeConfigPath == "" {
+			updated, err = kubeconfig.UpdateIP(ip, machineName, constants.KubeconfigPath)
+		} else {
+			updated, err = kubeconfig.UpdateIP(ip, machineName, kubeConfigPath)
+		}
 		if err != nil {
 			exit.WithError("update config", err)
 		}

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -103,6 +103,7 @@ func TestFunctional(t *testing.T) {
 			{"SSHCmd", validateSSHCmd},
 			{"MySQL", validateMySQL},
 			{"FileSync", validateFileSync},
+			{"UpdateContextCmd", validateUpdateContextCmd},
 		}
 		for _, tc := range tests {
 			tc := tc
@@ -642,6 +643,19 @@ func validateFileSync(ctx context.Context, t *testing.T, profile string) {
 
 	if diff := cmp.Diff(string(expected), rr.Stdout.String()); diff != "" {
 		t.Errorf("/etc/sync.test content mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// validateUpdateContextCmd asserts basic "update-context" command functionality
+func validateUpdateContextCmd(ctx context.Context, t *testing.T, profile string) {
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "update-context", "--alsologtostderr", "-v=2"))
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Args, err)
+	}
+
+	want := []byte("IP was already correctly configured")
+	if !bytes.Contains(rr.Stdout.Bytes(), want) {
+		t.Errorf("update-context: got=%q, want=*%q*", rr.Stdout.Bytes(), want)
 	}
 }
 


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

When user executes `minikube update-context` with `KUBECONFIG` env, the command fails.

```
KUBECONFIG=/tmp/.somewhereelse/config minikube update-context
💣 update config: Kubeconfig does not have a record of the machine cluster
😿 Sorry that minikube crashed. If this was unexpected, we would love to hear from you:
👉 https://github.com/kubernetes/minikube/issues/new/choose
```

This is because the `update-context` uses only `$HOME/.kube/config`(`KUBECONFIG` env will be ignored).
This PR allows users to use `KUBECONFIG` env when they execute `minikube update-context`
If the `KUBECONFIG` env is not set, `$HOME/.kube/config` filepath will be used.

### Which issue(s) this PR fixes:
Fixes #5944

### Does this PR introduce a user-facing change?

Yes. 
This PR fixes bug when the user executes `KUBECONFIG=xxxx minikube update-context`

**Before this PR, `KUBECONFIG=xxxx minikube update-context` command may fail(update-context uses `$HOME/.kube/config`)**
```
KUBECONFIG=/tmp/.somewhereelse/config minikube update-context
💣 update config: Kubeconfig does not have a record of the machine cluster
😿 Sorry that minikube crashed. If this was unexpected, we would love to hear from you:
👉 https://github.com/kubernetes/minikube/issues/new/choose
```

**After this PR, `KUBECONFIG=xxxx minikube update-context` command successes**
```
KUBECONFIG=/tmp/.somewhereelse/config minikube update-context
minikube IP has been updated to point at xxx.xxx.xxx.xxx
or
minikube IP was already correctly configured for xxx.xxx.xxx.xxx
```

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```