### PR TITLE
feat: add use-local-cached-images option.

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -105,6 +105,7 @@ const (
 	disableDriverMounts   = "disable-driver-mounts"
 	addons                = "addons"
 	cacheImages           = "cache-images"
+	useLocalCachedImages  = "use-local-cached-images"
 	uuid                  = "uuid"
 	vpnkitSock            = "hyperkit-vpnkit-sock"
 	vsockPorts            = "hyperkit-vsock-ports"
@@ -163,6 +164,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().String(humanReadableDiskSize, defaultDiskSize, "Disk size allocated to the minikube VM (format: <number>[<unit>], where unit = b, k, m or g).")
 	startCmd.Flags().Bool(downloadOnly, false, "If true, only download and cache files for later use - don't install or start anything.")
 	startCmd.Flags().Bool(cacheImages, true, "If true, cache docker images for the current bootstrapper and load them into the machine. Always false with --vm-driver=none.")
+	startCmd.Flags().Bool(useLocalCachedImages, false, "If true, use local cached docker images without pulling them from remote. Always false with --vm-driver=none.")
 	startCmd.Flags().String(isoURL, constants.DefaultISOURL, "Location of the minikube iso.")
 	startCmd.Flags().Bool(keepContext, false, "This will keep the existing kubectl context and will create a minikube context.")
 	startCmd.Flags().Bool(embedCerts, false, "if true, will embed the certs in kubeconfig.")
@@ -935,6 +937,7 @@ func generateCfgFromFlags(cmd *cobra.Command, k8sVersion string, drvName string)
 			ImageRepository:        repository,
 			ExtraOptions:           extraOptions,
 			ShouldLoadCachedImages: viper.GetBool(cacheImages),
+			UseLocalCachedImages:   viper.GetBool(useLocalCachedImages),
 			EnableDefaultCNI:       selectedEnableDefaultCNI,
 		},
 	}
@@ -969,6 +972,11 @@ func autoSetDriverOptions(cmd *cobra.Command, drvName string) error {
 	if !cmd.Flags().Changed(cacheImages) {
 		viper.Set(cacheImages, hints.CacheImages)
 	}
+
+	if !cmd.Flags().Changed(useLocalCachedImages) {
+		viper.Set(useLocalCachedImages, hints.UseLocalCachedImages)
+	}
+
 	return nil
 }
 

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -85,6 +85,7 @@ type KubernetesConfig struct {
 	ExtraOptions      ExtraOptionSlice
 
 	ShouldLoadCachedImages bool
+	UseLocalCachedImages   bool
 	EnableDefaultCNI       bool
 }
 

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -73,14 +73,15 @@ func BareMetal(name string) bool {
 
 // FlagHints are hints for what default options should be used for this driver
 type FlagHints struct {
-	ExtraOptions string
-	CacheImages  bool
+	ExtraOptions         string
+	CacheImages          bool
+	UseLocalCachedImages bool
 }
 
 // FlagDefaults returns suggested defaults based on a driver
 func FlagDefaults(name string) FlagHints {
 	if name != None {
-		return FlagHints{CacheImages: true}
+		return FlagHints{CacheImages: true, UseLocalCachedImages: false}
 	}
 
 	extraOpts := ""
@@ -88,8 +89,9 @@ func FlagDefaults(name string) FlagHints {
 		extraOpts = fmt.Sprintf("kubelet.resolv-conf=%s", systemdResolvConf)
 	}
 	return FlagHints{
-		ExtraOptions: extraOpts,
-		CacheImages:  false,
+		ExtraOptions:         extraOpts,
+		CacheImages:          false,
+		UseLocalCachedImages: false,
 	}
 }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

This PR is going to fixes #6103 by introducing a new config option `use-local-cached-images`, it will load local cached images without fetching images, and make minikube works well inside no-public-network-access environment.
