### PR TITLE
Fixed IPv6 format for SSH

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1061,7 +1061,7 @@ func validateNetwork(h *host.Host, r command.Runner) string {
 }
 
 func trySSH(h *host.Host, ip string) {
-	sshAddr := fmt.Sprintf("%s:22", ip)
+	sshAddr := net.JoinHostPort(ip, "22")
 
 	dial := func() (err error) {
 		d := net.Dialer{Timeout: 3 * time.Second}


### PR DESCRIPTION
Not very familiar with go, so I have yet to be able to test this, but it appears to be similar to the issue in #576 . I made a similar fix to #625 and I'm working on setting up golang so I can test it.