### PR TITLE
Add build tags so that the test only runs on Darwin

### DIFF
--- a/pkg/minikube/registry/drvs/hyperkit/hyperkit_test.go
+++ b/pkg/minikube/registry/drvs/hyperkit/hyperkit_test.go
@@ -1,3 +1,5 @@
+// +build darwin
+
 /*
 Copyright 2019 The Kubernetes Authors All rights reserved.
 


### PR DESCRIPTION
Fixes Linux / Travis build issue caused as a side-effect of me force-merging #5833:

```
# k8s.io/minikube/pkg/minikube/registry/drvs/hyperkit [k8s.io/minikube/pkg/minikube/registry/drvs/hyperkit.test]
pkg/minikube/registry/drvs/hyperkit/hyperkit_test.go:55:15: undefined: splitHyperKitVersion
pkg/minikube/registry/drvs/hyperkit/hyperkit_test.go:85:15: undefined: convertVersionToDate
pkg/minikube/registry/drvs/hyperkit/hyperkit_test.go:119:18: undefined: isNewerVersion
```