### PR TITLE
implemented options command, fixes #5036

### DIFF
--- a/cmd/minikube/cmd/options.go
+++ b/cmd/minikube/cmd/options.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"k8s.io/minikube/pkg/minikube/out"
+)
+
+// optionsCmd represents the options command
+var optionsCmd = &cobra.Command{
+	Use:   "options",
+	Short: "Show a list of global command-line options (applies to all commands).",
+	Long:  "Show a list of global command-line options (applies to all commands).",
+	Run:   runOptions,
+}
+
+// runOptions handles the executes the flow of "minikube stop"
+func runOptions(cmd *cobra.Command, args []string) {
+	out.String("The following options can be passed to any command:\n\n")
+	for _, flagName := range viperWhiteList {
+		f := pflag.Lookup(flagName)
+		out.String(flagUsage(f))
+	}
+}
+
+func flagUsage(flag *pflag.Flag) string {
+	x := new(bytes.Buffer)
+
+	if flag.Hidden {
+		return ""
+	}
+
+	format := "--%s=%s: %s\n"
+
+	if flag.Value.Type() == "string" {
+		format = "--%s='%s': %s\n"
+	}
+
+	if len(flag.Shorthand) > 0 {
+		format = "  -%s, " + format
+	} else {
+		format = "   %s   " + format
+	}
+
+	fmt.Fprintf(x, format, flag.Shorthand, flag.Name, flag.DefValue, flag.Usage)
+
+	return x.String()
+}

--- a/cmd/minikube/cmd/options.go
+++ b/cmd/minikube/cmd/options.go
@@ -34,7 +34,7 @@ var optionsCmd = &cobra.Command{
 	Run:   runOptions,
 }
 
-// runOptions handles the executes the flow of "minikube stop"
+// runOptions handles the executes the flow of "minikube options"
 func runOptions(cmd *cobra.Command, args []string) {
 	out.String("The following options can be passed to any command:\n\n")
 	for _, flagName := range viperWhiteList {

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -54,9 +54,9 @@ var dirs = [...]string{
 }
 
 var viperWhiteList = []string{
-	"v",
 	"alsologtostderr",
 	"log_dir",
+	"v",
 }
 
 // RootCmd represents the base command when called without any subcommands
@@ -214,6 +214,7 @@ func init() {
 				logsCmd,
 				updateCheckCmd,
 				versionCmd,
+				optionsCmd,
 			},
 		},
 	}


### PR DESCRIPTION
This is to fix the `help` command showing invalid `minikube <command> options`. It happened because minikube reuses kubectl templates which expects options cmd to be there.

**Before:**

```
$ minikube profile --help
... (skipped)
...
Use "minikube profile options" for a list of global command-line options (applies to all commands).
```
minikube profile options is an invalid suggestion.

**After:**
```
$ ./out/minikube profile --help
... (skipped)
...
Use "minikube options" for a list of global command-line options (applies to all commands).

$ ./out/minikube options

The following options can be passed to any command:

      --alsologtostderr=false: log to standard error as well as files
      --log_dir='': If non-empty, write log files in this directory
  -v, --v=0: log level for V logs

```

It uses the same style as `kubectl options`:

```
$ kubectl options
The following options can be passed to any command:

      --alsologtostderr=false: log to standard error as well as files
      --as='': Username to impersonate for the operation
      --as-group=[]: Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
      --cache-dir='/home/andy/.kube/http-cache': Default HTTP cache directory
      --certificate-authority='': Path to a cert file for the certificate authority
... (skipped)
...
  -v, --v=0: number for the log level verbosity
```

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
