### PR TITLE
Upgrade buildroot minor version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ RPM_VERSION ?= $(DEB_VERSION)
 GO_VERSION ?= 1.13.4
 
 INSTALL_SIZE ?= $(shell du out/minikube-windows-amd64.exe | cut -f1)
-BUILDROOT_BRANCH ?= 2019.02.7
+BUILDROOT_BRANCH ?= 2019.02.8
 REGISTRY?=gcr.io/k8s-minikube
 
 # Get git commit id
@@ -49,7 +49,7 @@ MINIKUBE_BUCKET ?= minikube/releases
 MINIKUBE_UPLOAD_LOCATION := gs://${MINIKUBE_BUCKET}
 MINIKUBE_RELEASES_URL=https://github.com/kubernetes/minikube/releases/download
 
-KERNEL_VERSION ?= 4.19.81
+KERNEL_VERSION ?= 4.19.88
 # latest from https://github.com/golangci/golangci-lint/releases
 GOLINT_VERSION ?= v1.21.0
 # Limit number of default jobs, to avoid the CI builds running out of memory

--- a/deploy/iso/minikube-iso/package/hyperv-daemons/hyperv-daemons.mk
+++ b/deploy/iso/minikube-iso/package/hyperv-daemons/hyperv-daemons.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-HYPERV_DAEMONS_VERSION = 4.19.81
+HYPERV_DAEMONS_VERSION = 4.19.88
 HYPERV_DAEMONS_SITE = https://www.kernel.org/pub/linux/kernel/v4.x
 HYPERV_DAEMONS_SOURCE = linux-$(HYPERV_DAEMONS_VERSION).tar.xz
 


### PR DESCRIPTION
https://buildroot.org/news.html

> **2019.02.8 released**
> 7 December 2019
> 
> The 2019.02.8 bugfix release is out, fixing a number of important / security related issues discovered since the 2019.02.7 release