### PR TITLE
Fix the version number output of runc

### DIFF
--- a/deploy/iso/minikube-iso/package/runc-master/runc-master.mk
+++ b/deploy/iso/minikube-iso/package/runc-master/runc-master.mk
@@ -13,15 +13,15 @@ RUNC_MASTER_LICENSE_FILES = LICENSE
 
 RUNC_MASTER_DEPENDENCIES = host-go
 
-RUNC_MASTER_GOPATH = "$(@D)/Godeps/_workspace"
+RUNC_MASTER_GOPATH = $(@D)/_output
 RUNC_MASTER_MAKE_ENV = $(HOST_GO_TARGET_ENV) \
 	CGO_ENABLED=1 \
-	GOBIN="$(@D)/bin" \
+	GO111MODULE=off \
 	GOPATH="$(RUNC_MASTER_GOPATH)" \
-	PATH=$(BR_PATH)
+	GOBIN="$(RUNC_MASTER_GOPATH)/bin" \
+	PATH=$(RUNC_MASTER_GOPATH)/bin:$(BR_PATH)
 
-RUNC_MASTER_GLDFLAGS = \
-	-buildmode=pie -X main.gitCommit=$(RUNC_MASTER_VERSION)
+RUNC_MASTER_COMPILE_SRC = $(RUNC_MASTER_GOPATH)/src/github.com/opencontainers/runc
 
 ifeq ($(BR2_PACKAGE_LIBSECCOMP),y)
 RUNC_MASTER_GOTAGS += seccomp
@@ -34,13 +34,11 @@ define RUNC_MASTER_CONFIGURE_CMDS
 endef
 
 define RUNC_MASTER_BUILD_CMDS
-	cd $(@D) && $(RUNC_MASTER_MAKE_ENV) $(HOST_DIR)/usr/bin/go \
-		build -v -o $(@D)/bin/runc \
-		-tags "$(RUNC_MASTER_GOTAGS)" -ldflags "$(RUNC_MASTER_GLDFLAGS)" github.com/opencontainers/runc
+	PWD=$(RUNC_MASTER_COMPILE_SRC) $(RUNC_MASTER_MAKE_ENV) $(MAKE) $(TARGET_CONFIGURE_OPTS) -C $(@D) BUILDTAGS="$(RUNC_MASTER_GOTAGS)" COMMIT_NO=$(RUNC_MASTER_VERSION) PREFIX=/usr
 endef
 
 define RUNC_MASTER_INSTALL_TARGET_CMDS
-	$(INSTALL) -D -m 0755 $(@D)/bin/runc $(TARGET_DIR)/usr/bin/runc
+	$(INSTALL) -D -m 0755 $(@D)/runc $(TARGET_DIR)/usr/bin/runc
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
Current output:

```
runc version commit: d736ef14f0288d6993a1845745d6756cfc9ddd5a
spec: 1.0.1-dev
```

Expected output:

```
runc version 1.0.0-rc9
commit: d736ef14f0288d6993a1845745d6756cfc9ddd5a
spec: 1.0.1-dev
```

First noted in #5823


This makes for instance `docker info` miss the commit information: 

```
 Runtimes: runc
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: b34a5c8af56e510852c35414db4c1f4fa6172339
 runc version: 
 init version: fec3683
```
And it makes it harder to tell which version that the commit refers to.

----

In general we should prefer using provided build script, rather than reinventing them.

So call `make` instead of `go build`, avoids having to duplicate linker flags and such...