### PR TITLE
Improve reportcard by refactoring and commenting

### DIFF
--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -419,13 +419,8 @@ func showRemoteOsRelease(driver drivers.Driver) {
 	glog.Infof("Provisioned with %s", osReleaseInfo.PrettyName)
 }
 
-func createHost(api libmachine.API, config cfg.MachineConfig) (*host.Host, error) {
-	if config.VMDriver == driver.VMwareFusion && viper.GetBool(cfg.ShowDriverDeprecationNotification) {
-		out.WarningT(`The vmwarefusion driver is deprecated and support for it will be removed in a future release.
-			Please consider switching to the new vmware unified driver, which is intended to replace the vmwarefusion driver.
-			See https://minikube.sigs.k8s.io/docs/reference/drivers/vmware/ for more information.
-			To disable this message, run [minikube config set ShowDriverDeprecationNotification false]`)
-	}
+// showHostInfo shows host information
+func showHostInfo(config cfg.MachineConfig) {
 	if driver.BareMetal(config.VMDriver) {
 		info, err := getHostInfo()
 		if err == nil {
@@ -439,6 +434,16 @@ func createHost(api libmachine.API, config cfg.MachineConfig) (*host.Host, error
 	} else {
 		out.T(out.StartingVM, "Creating {{.driver_name}} VM (CPUs={{.number_of_cpus}}, Memory={{.memory_size}}MB, Disk={{.disk_size}}MB) ...", out.V{"driver_name": config.VMDriver, "number_of_cpus": config.CPUs, "memory_size": config.Memory, "disk_size": config.DiskSize})
 	}
+}
+
+func createHost(api libmachine.API, config cfg.MachineConfig) (*host.Host, error) {
+	if config.VMDriver == driver.VMwareFusion && viper.GetBool(cfg.ShowDriverDeprecationNotification) {
+		out.WarningT(`The vmwarefusion driver is deprecated and support for it will be removed in a future release.
+			Please consider switching to the new vmware unified driver, which is intended to replace the vmwarefusion driver.
+			See https://minikube.sigs.k8s.io/docs/reference/drivers/vmware/ for more information.
+			To disable this message, run [minikube config set ShowDriverDeprecationNotification false]`)
+	}
+	showHostInfo(config)
 	def := registry.Driver(config.VMDriver)
 	if def.Empty() {
 		return nil, fmt.Errorf("unsupported/missing driver: %s", config.VMDriver)

--- a/pkg/minikube/localpath/localpath.go
+++ b/pkg/minikube/localpath/localpath.go
@@ -61,8 +61,7 @@ func MachinePath(machine string, miniHome ...string) string {
 	return filepath.Join(miniPath, "machines", machine)
 }
 
-// SanitizeCacheDir
-// # ParseReference cannot have a : in the directory path
+// SanitizeCacheDir returns a path without special characters
 func SanitizeCacheDir(image string) string {
 	if runtime.GOOS == "windows" && hasWindowsDriveLetter(image) {
 		// not sanitize Windows drive letter.
@@ -70,6 +69,7 @@ func SanitizeCacheDir(image string) string {
 		glog.Infof("windows sanitize: %s -> %s", image, s)
 		return s
 	}
+	// ParseReference cannot have a : in the directory path
 	return strings.Replace(image, ":", "_", -1)
 }
 


### PR DESCRIPTION
Improves the https://goreportcard.com/report/github.com/kubernetes/minikube

```
golint: 99%
	pkg/minikube/localpath/localpath.go
		Line 64: warning: comment on exported function SanitizeCacheDir should be of the form "SanitizeCacheDir ..." (golint)
gocyclo: 99%
	pkg/minikube/cluster/cluster.go
		Line 422: warning: cyclomatic complexity 16 of function createHost() is high (> 15) (gocyclo)
	cmd/minikube/cmd/start.go
		Line 276: warning: cyclomatic complexity 18 of function runStart() is high (> 15) (gocyclo)
		Line 742: warning: cyclomatic complexity 18 of function validateFlags() is high (> 15) (gocyclo)
```
----

Left to do is to clean up the lint introduced with the KIC and Multinode additions:

```
golint: 99%
	pkg/minikube/bootstrapper/bsutil/binaries.go
		Line 17: warning: package comment should be of the form "Package bsutil ..." (golint)
	pkg/minikube/bootstrapper/bsutil/kubeadm.go
		Line 17: warning: package comment should be of the form "Package bsutil ..." (golint)
	pkg/minikube/bootstrapper/bsutil/kubelet.go
		Line 17: warning: package comment should be of the form "Package bsutil ..." (golint)
	pkg/minikube/bootstrapper/bsutil/featuregates.go
		Line 17: warning: package comment should be of the form "Package bsutil ..." (golint)
	pkg/minikube/bootstrapper/bsutil/files.go
		Line 17: warning: package comment should be of the form "Package bsutil ..." (golint)
		Line 32: warning: exported const DefaultCNIConfigPath should have comment (or a comment on this block) or be unexported (golint)
		Line 34: warning: comment on exported const KubeletSystemdConfFile should be of the form "KubeletSystemdConfFile ..." (golint)
	pkg/minikube/bootstrapper/kicbs/cni.go
		Line 17: warning: package comment should be of the form "Package kicbs ..." (golint)
	pkg/minikube/bootstrapper/kicbs/kicbs.go
		Line 17: warning: package comment should be of the form "Package kicbs ..." (golint)
		Line 125: warning: exported method Bootstrapper.PullImages should have comment or be unexported (golint)
		Line 128: warning: exported method Bootstrapper.StartCluster should have comment or be unexported (golint)
		Line 132: warning: exported method Bootstrapper.DeleteCluster should have comment or be unexported (golint)
		Line 135: warning: exported method Bootstrapper.WaitForCluster should have comment or be unexported (golint)
		Line 138: warning: exported method Bootstrapper.LogCommands should have comment or be unexported (golint)
		Line 141: warning: exported method Bootstrapper.SetupCerts should have comment or be unexported (golint)
		Line 144: warning: exported method Bootstrapper.GetKubeletStatus should have comment or be unexported (golint)
		Line 147: warning: exported method Bootstrapper.GetAPIServerStatus should have comment or be unexported (golint)
	pkg/drivers/kic/kic.go
		Line 34: warning: comment on exported type Driver should be of the form "Driver ..." (with optional leading article) (golint)
		Line 254: warning: exported function ImageForVersion should have comment or be unexported (golint)
	pkg/drivers/kic/node/node.go
		Line 33: warning: comment on exported const DefaultNetwork should be of the form "DefaultNetwork ..." (golint)
		Line 35: warning: exported const ClusterLabelKey should have comment (or a comment on this block) or be unexported (golint)
		Line 48: warning: exported type CreateConfig should have comment or be unexported (golint)
	pkg/minikube/bootstrapper/bootstrapper.go
		Line 54: warning: exported const KIC should have comment (or a comment on this block) or be unexported (golint)
	pkg/minikube/bootstrapper/bsutil/extraconfig.go
		Line 17: warning: package comment should be of the form "Package bsutil ..." (golint)
		Line 32: warning: exported const KubeadmCmdParam should have comment (or a comment on this block) or be unexported (golint)
```