### PR TITLE
Fixes busybox nslookup does not support query type

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1115,7 +1115,7 @@ Suggested workarounds:
 
 func tryLookup(r command.Runner) {
 	// DNS check
-	if rr, err := r.RunCmd(exec.Command("nslookup", "-querytype=ns", "kubernetes.io")); err != nil {
+	if rr, err := r.RunCmd(exec.Command("nslookup", "kubernetes.io")); err != nil {
 		glog.Warningf("%s failed: %v", rr.Args, err)
 		out.WarningT("VM may be unable to resolve external DNS records")
 	}


### PR DESCRIPTION
tryLookup runs in the VM busybox.
nslookup binary on the guest OS does not support query type.