### PR TITLE
Disable IPv6 in the minikube VM until it can be properly supported

### DIFF
--- a/deploy/iso/minikube-iso/board/coreos/minikube/rootfs-overlay/etc/sysctl.d/disable-ipv6.conf
+++ b/deploy/iso/minikube-iso/board/coreos/minikube/rootfs-overlay/etc/sysctl.d/disable-ipv6.conf
@@ -1,0 +1,2 @@
+net.ipv6.conf.all.disable_ipv6=1
+net.ipv6.conf.default.disable_ipv6=1


### PR DESCRIPTION
Fixes #3963

With this change, the VM will no longer attempt to configure interfaces for IPv6 if the DHCP server provides one.
