### PR TITLE
Only print the virtualization system if it exists

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -268,7 +268,11 @@ func platform() string {
 
 	// This environment is exotic, let's output a bit more.
 	if vrole == "guest" || runtime.GOARCH != "amd64" {
-		s.WriteString(fmt.Sprintf(" (%s/%s)", vsys, runtime.GOARCH))
+		if vsys != "" {
+			s.WriteString(fmt.Sprintf(" (%s/%s)", vsys, runtime.GOARCH))
+		} else {
+			s.WriteString(fmt.Sprintf(" (%s)", runtime.GOARCH))
+		}
 	}
 	return s.String()
 }


### PR DESCRIPTION
Avoids output like (/arm64), with an extra slash