### PR TITLE
Do not use an arch suffix for the coredns name

### DIFF
--- a/pkg/minikube/bootstrapper/images/images.go
+++ b/pkg/minikube/bootstrapper/images/images.go
@@ -74,7 +74,7 @@ func coreDNS(v semver.Version, mirror string) string {
 	case 11:
 		cv = "1.1.3"
 	}
-	return path.Join(kubernetesRepo(mirror), "coredns"+archTag(false)+cv)
+	return path.Join(kubernetesRepo(mirror), "coredns"+":"+cv)
 }
 
 // etcd returns the image used for etcd


### PR DESCRIPTION
They are using multi-arch images instead...
So don't append something like -arm64 to it.

Just use e.g. "k8s.gcr.io/coredns:1.6.5",
and Docker will pull the right platform image.

See https://hub.docker.com/r/coredns/coredns

As seen in #6007 et al