### PR TITLE
Fix syntax of minikube kubectl example command

### DIFF
--- a/cmd/minikube/cmd/kubectl.go
+++ b/cmd/minikube/cmd/kubectl.go
@@ -41,7 +41,7 @@ var kubectlCmd = &cobra.Command{
 	Long: `Run the kubernetes client, download it if necessary.
 Examples:
 minikube kubectl -- --help
-kubectl get pods --namespace kube-system`,
+minikube kubectl -- get pods --namespace kube-system`,
 	Run: func(cmd *cobra.Command, args []string) {
 		api, err := machine.NewAPIClient()
 		if err != nil {

--- a/cmd/minikube/cmd/kubectl.go
+++ b/cmd/minikube/cmd/kubectl.go
@@ -38,7 +38,8 @@ import (
 var kubectlCmd = &cobra.Command{
 	Use:   "kubectl",
 	Short: "Run kubectl",
-	Long: `Run the kubernetes client, download it if necessary.
+	Long: `Run the kubernetes client, download it if necessary. Remember -- after kubectl!
+
 Examples:
 minikube kubectl -- --help
 minikube kubectl -- get pods --namespace kube-system`,

--- a/site/content/en/docs/Reference/Commands/kubectl.md
+++ b/site/content/en/docs/Reference/Commands/kubectl.md
@@ -11,6 +11,7 @@ description: >
 ### Overview
 
 Run the Kubernetes client, download it if necessary.
+Remember `--` after kubectl!
 
 ### Usage
 

--- a/site/content/en/docs/Reference/Commands/kubectl.md
+++ b/site/content/en/docs/Reference/Commands/kubectl.md
@@ -22,7 +22,7 @@ minikube kubectl [flags]
 
 ```
 minikube kubectl -- --help
-kubectl get pods --namespace kube-system
+minikube kubectl -- get pods --namespace kube-system
 ```
 
 

--- a/translations/de.json
+++ b/translations/de.json
@@ -290,7 +290,7 @@
 	"Run 'minikube delete' to delete the stale VM": "",
 	"Run kubectl": "",
 	"Run minikube from the C: drive.": "",
-	"Run the kubernetes client, download it if necessary.\nExamples:\nminikube kubectl -- --help\nkubectl get pods --namespace kube-system": "",
+	"Run the kubernetes client, download it if necessary.\nExamples:\nminikube kubectl -- --help\nminikube kubectl -- get pods --namespace kube-system": "",
 	"Run the minikube command as an Administrator": "",
 	"Running on localhost (CPUs={{.number_of_cpus}}, Memory={{.memory_size}}MB, Disk={{.disk_size}}MB) ...": "",
 	"Set failed": "",

--- a/translations/de.json
+++ b/translations/de.json
@@ -290,7 +290,7 @@
 	"Run 'minikube delete' to delete the stale VM": "",
 	"Run kubectl": "",
 	"Run minikube from the C: drive.": "",
-	"Run the kubernetes client, download it if necessary.\nExamples:\nminikube kubectl -- --help\nminikube kubectl -- get pods --namespace kube-system": "",
+	"Run the kubernetes client, download it if necessary. Remember -- after kubectl!\n\nExamples:\nminikube kubectl -- --help\nminikube kubectl -- get pods --namespace kube-system": "",
 	"Run the minikube command as an Administrator": "",
 	"Running on localhost (CPUs={{.number_of_cpus}}, Memory={{.memory_size}}MB, Disk={{.disk_size}}MB) ...": "",
 	"Set failed": "",

--- a/translations/es.json
+++ b/translations/es.json
@@ -290,7 +290,7 @@
 	"Run 'minikube delete' to delete the stale VM": "",
 	"Run kubectl": "",
 	"Run minikube from the C: drive.": "",
-	"Run the kubernetes client, download it if necessary.\nExamples:\nminikube kubectl -- --help\nkubectl get pods --namespace kube-system": "",
+	"Run the kubernetes client, download it if necessary.\nExamples:\nminikube kubectl -- --help\nminikube kubectl -- get pods --namespace kube-system": "",
 	"Run the minikube command as an Administrator": "",
 	"Running on localhost (CPUs={{.number_of_cpus}}, Memory={{.memory_size}}MB, Disk={{.disk_size}}MB) ...": "",
 	"Set failed": "",

--- a/translations/es.json
+++ b/translations/es.json
@@ -290,7 +290,7 @@
 	"Run 'minikube delete' to delete the stale VM": "",
 	"Run kubectl": "",
 	"Run minikube from the C: drive.": "",
-	"Run the kubernetes client, download it if necessary.\nExamples:\nminikube kubectl -- --help\nminikube kubectl -- get pods --namespace kube-system": "",
+	"Run the kubernetes client, download it if necessary. Remember -- after kubectl!\n\nExamples:\nminikube kubectl -- --help\nminikube kubectl -- get pods --namespace kube-system": "",
 	"Run the minikube command as an Administrator": "",
 	"Running on localhost (CPUs={{.number_of_cpus}}, Memory={{.memory_size}}MB, Disk={{.disk_size}}MB) ...": "",
 	"Set failed": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -291,7 +291,7 @@
 	"Run 'minikube delete' to delete the stale VM": "",
 	"Run kubectl": "",
 	"Run minikube from the C: drive.": "",
-	"Run the kubernetes client, download it if necessary.\nExamples:\nminikube kubectl -- --help\nminikube kubectl -- get pods --namespace kube-system": "",
+	"Run the kubernetes client, download it if necessary. Remember -- after kubectl!\n\nExamples:\nminikube kubectl -- --help\nminikube kubectl -- get pods --namespace kube-system": "",
 	"Run the minikube command as an Administrator": "",
 	"Running on localhost (CPUs={{.number_of_cpus}}, Memory={{.memory_size}}MB, Disk={{.disk_size}}MB) ...": "",
 	"Set failed": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -291,7 +291,7 @@
 	"Run 'minikube delete' to delete the stale VM": "",
 	"Run kubectl": "",
 	"Run minikube from the C: drive.": "",
-	"Run the kubernetes client, download it if necessary.\nExamples:\nminikube kubectl -- --help\nkubectl get pods --namespace kube-system": "",
+	"Run the kubernetes client, download it if necessary.\nExamples:\nminikube kubectl -- --help\nminikube kubectl -- get pods --namespace kube-system": "",
 	"Run the minikube command as an Administrator": "",
 	"Running on localhost (CPUs={{.number_of_cpus}}, Memory={{.memory_size}}MB, Disk={{.disk_size}}MB) ...": "",
 	"Set failed": "",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -290,7 +290,7 @@
 	"Run 'minikube delete' to delete the stale VM": "",
 	"Run kubectl": "",
 	"Run minikube from the C: drive.": "",
-	"Run the kubernetes client, download it if necessary.\nExamples:\nminikube kubectl -- --help\nkubectl get pods --namespace kube-system": "",
+	"Run the kubernetes client, download it if necessary.\nExamples:\nminikube kubectl -- --help\nminikube kubectl -- get pods --namespace kube-system": "",
 	"Run the minikube command as an Administrator": "",
 	"Running on localhost (CPUs={{.number_of_cpus}}, Memory={{.memory_size}}MB, Disk={{.disk_size}}MB) ...": "",
 	"Set failed": "",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -290,7 +290,7 @@
 	"Run 'minikube delete' to delete the stale VM": "",
 	"Run kubectl": "",
 	"Run minikube from the C: drive.": "",
-	"Run the kubernetes client, download it if necessary.\nExamples:\nminikube kubectl -- --help\nminikube kubectl -- get pods --namespace kube-system": "",
+	"Run the kubernetes client, download it if necessary. Remember -- after kubectl!\n\nExamples:\nminikube kubectl -- --help\nminikube kubectl -- get pods --namespace kube-system": "",
 	"Run the minikube command as an Administrator": "",
 	"Running on localhost (CPUs={{.number_of_cpus}}, Memory={{.memory_size}}MB, Disk={{.disk_size}}MB) ...": "",
 	"Set failed": "",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -290,7 +290,7 @@
 	"Run 'minikube delete' to delete the stale VM": "",
 	"Run kubectl": "Uruchamia kubectl",
 	"Run minikube from the C: drive.": "",
-	"Run the kubernetes client, download it if necessary.\nExamples:\nminikube kubectl -- --help\nkubectl get pods --namespace kube-system": "",
+	"Run the kubernetes client, download it if necessary.\nExamples:\nminikube kubectl -- --help\nminikube kubectl -- get pods --namespace kube-system": "",
 	"Run the minikube command as an Administrator": "",
 	"Running on localhost (CPUs={{.number_of_cpus}}, Memory={{.memory_size}}MB, Disk={{.disk_size}}MB) ...": "",
 	"Set failed": "",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -290,7 +290,7 @@
 	"Run 'minikube delete' to delete the stale VM": "",
 	"Run kubectl": "Uruchamia kubectl",
 	"Run minikube from the C: drive.": "",
-	"Run the kubernetes client, download it if necessary.\nExamples:\nminikube kubectl -- --help\nminikube kubectl -- get pods --namespace kube-system": "",
+	"Run the kubernetes client, download it if necessary. Remember -- after kubectl!\n\nExamples:\nminikube kubectl -- --help\nminikube kubectl -- get pods --namespace kube-system": "",
 	"Run the minikube command as an Administrator": "",
 	"Running on localhost (CPUs={{.number_of_cpus}}, Memory={{.memory_size}}MB, Disk={{.disk_size}}MB) ...": "",
 	"Set failed": "",

--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -327,7 +327,7 @@
 	"Run 'kubectl describe pod coredns -n kube-system' and check for a firewall or DNS conflict": "",
 	"Run 'minikube delete' to delete the stale VM, or and ensure that minikube is running as the same user you are issuing this command with": "执行 'minikube delete' 以删除过时的虚拟机，或者确保 minikube 以与您发出此命令的用户相同的用户身份运行",
 	"Run minikube from the C: drive.": "",
-	"Run the kubernetes client, download it if necessary.\nExamples:\nminikube kubectl -- --help\nminikube kubectl -- get pods --namespace kube-system": "",
+	"Run the kubernetes client, download it if necessary. Remember -- after kubectl!\n\nExamples:\nminikube kubectl -- --help\nminikube kubectl -- get pods --namespace kube-system": "",
 	"Run the minikube command as an Administrator": "",
 	"Run: 'chmod 600 $HOME/.kube/config'": "执行 'chmod 600 $HOME/.kube/config'",
 	"Running on localhost (CPUs={{.number_of_cpus}}, Memory={{.memory_size}}MB, Disk={{.disk_size}}MB) ...": "",

--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -327,7 +327,7 @@
 	"Run 'kubectl describe pod coredns -n kube-system' and check for a firewall or DNS conflict": "",
 	"Run 'minikube delete' to delete the stale VM, or and ensure that minikube is running as the same user you are issuing this command with": "执行 'minikube delete' 以删除过时的虚拟机，或者确保 minikube 以与您发出此命令的用户相同的用户身份运行",
 	"Run minikube from the C: drive.": "",
-	"Run the kubernetes client, download it if necessary.\nExamples:\nminikube kubectl -- --help\nkubectl get pods --namespace kube-system": "",
+	"Run the kubernetes client, download it if necessary.\nExamples:\nminikube kubectl -- --help\nminikube kubectl -- get pods --namespace kube-system": "",
 	"Run the minikube command as an Administrator": "",
 	"Run: 'chmod 600 $HOME/.kube/config'": "执行 'chmod 600 $HOME/.kube/config'",
 	"Running on localhost (CPUs={{.number_of_cpus}}, Memory={{.memory_size}}MB, Disk={{.disk_size}}MB) ...": "",


### PR DESCRIPTION
Need to terminate the minikube flags with --,
before starting with the kubectl command flags.

Fixes #6238
