### PR TITLE
Create explicit var to avoid incorrect loop iterator reference

### DIFF
--- a/test/integration/aab_offline_test.go
+++ b/test/integration/aab_offline_test.go
@@ -30,6 +30,7 @@ import (
 func TestOffline(t *testing.T) {
 	t.Run("group", func(t *testing.T) {
 		for _, runtime := range []string{"docker", "crio", "containerd"} {
+			runtime := runtime
 			t.Run(runtime, func(t *testing.T) {
 				MaybeParallel(t)
 				WaitForStartSlot(t)


### PR DESCRIPTION
I was investigating flaky tests and noticed when that all of the subprocesses invoked by this test used containerd as the runtime. Oops!
