### PR TITLE
De-parallelize GetServiceURL unit tests: the mocks are not thread safe

### DIFF
--- a/pkg/minikube/service/service_test.go
+++ b/pkg/minikube/service/service_test.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/tests"
 )
 
+// Mock Kubernetes client getter - NOT THREAD SAFE
 type MockClientGetter struct {
 	servicesMap  map[string]typed_core.ServiceInterface
 	endpointsMap map[string]typed_core.EndpointsInterface
@@ -76,6 +77,7 @@ func (m *MockCoreClient) Services(namespace string) typed_core.ServiceInterface 
 	return m.servicesMap[namespace]
 }
 
+// Mock Kubernetes client - NOT THREAD SAFE
 type MockCoreClient struct {
 	fake.FakeCoreV1
 	servicesMap  map[string]typed_core.ServiceInterface
@@ -466,8 +468,6 @@ func TestGetServiceURLs(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.description, func(t *testing.T) {
-			t.Parallel()
-
 			K8s = &MockClientGetter{
 				servicesMap:  serviceNamespaces,
 				endpointsMap: endpointNamespaces,
@@ -536,7 +536,6 @@ func TestGetServiceURLsForService(t *testing.T) {
 	defer revertK8sClient(K8s)
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			t.Parallel()
 			K8s = &MockClientGetter{
 				servicesMap:  serviceNamespaces,
 				endpointsMap: endpointNamespaces,


### PR DESCRIPTION
Fixes race found using:

`go test -race k8s.io/minikube/pkg/minikube/service`

Also mentioned in #4768 

Details:

```
==================
WARNING: DATA RACE
Write at 0x000006f43ff0 by goroutine 60:
  k8s.io/minikube/pkg/minikube/service.TestGetServiceURLs.func1()
      /Users/tstromberg/src/minikube/pkg/minikube/service/service_test.go:471 +0x174
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Previous write at 0x000006f43ff0 by goroutine 61:
  k8s.io/minikube/pkg/minikube/service.TestGetServiceURLs.func1()
      /Users/tstromberg/src/minikube/pkg/minikube/service/service_test.go:471 +0x174
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Goroutine 60 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:960 +0x651
  k8s.io/minikube/pkg/minikube/service.TestGetServiceURLs()
      /Users/tstromberg/src/minikube/pkg/minikube/service/service_test.go:468 +0x8b0
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Goroutine 61 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:960 +0x651
  k8s.io/minikube/pkg/minikube/service.TestGetServiceURLs()
      /Users/tstromberg/src/minikube/pkg/minikube/service/service_test.go:468 +0x8b0
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199
==================
==================
WARNING: DATA RACE
Read at 0x00c000158400 by goroutine 61:
  k8s.io/minikube/pkg/minikube/service.(*MockClientGetter).GetCoreClient()
      /Users/tstromberg/src/minikube/pkg/minikube/service/service_test.go:62 +0xd2
  k8s.io/minikube/pkg/minikube/service.GetServiceURLs()
      /Users/tstromberg/src/minikube/pkg/minikube/service/service.go:132 +0x147
  k8s.io/minikube/pkg/minikube/service.TestGetServiceURLs.func1()
      /Users/tstromberg/src/minikube/pkg/minikube/service/service_test.go:475 +0x1d8
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Previous write at 0x00c000158400 by goroutine 60:
  k8s.io/minikube/pkg/minikube/service.TestGetServiceURLs.func1()
      /Users/tstromberg/src/minikube/pkg/minikube/service/service_test.go:473 +0x98
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Goroutine 61 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:960 +0x651
  k8s.io/minikube/pkg/minikube/service.TestGetServiceURLs()
      /Users/tstromberg/src/minikube/pkg/minikube/service/service_test.go:468 +0x8b0
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Goroutine 60 (finished) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:960 +0x651
  k8s.io/minikube/pkg/minikube/service.TestGetServiceURLs()
      /Users/tstromberg/src/minikube/pkg/minikube/service/service_test.go:468 +0x8b0
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199
==================
==================
WARNING: DATA RACE
Read at 0x00c000158408 by goroutine 61:
  k8s.io/minikube/pkg/minikube/service.(*MockClientGetter).GetCoreClient()
      /Users/tstromberg/src/minikube/pkg/minikube/service/service_test.go:63 +0x120
  k8s.io/minikube/pkg/minikube/service.GetServiceURLs()
      /Users/tstromberg/src/minikube/pkg/minikube/service/service.go:132 +0x147
  k8s.io/minikube/pkg/minikube/service.TestGetServiceURLs.func1()
      /Users/tstromberg/src/minikube/pkg/minikube/service/service_test.go:475 +0x1d8
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Previous write at 0x00c000158408 by goroutine 60:
  k8s.io/minikube/pkg/minikube/service.TestGetServiceURLs.func1()
      /Users/tstromberg/src/minikube/pkg/minikube/service/service_test.go:473 +0x98
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Goroutine 61 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:960 +0x651
  k8s.io/minikube/pkg/minikube/service.TestGetServiceURLs()
      /Users/tstromberg/src/minikube/pkg/minikube/service/service_test.go:468 +0x8b0
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Goroutine 60 (finished) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:960 +0x651
  k8s.io/minikube/pkg/minikube/service.TestGetServiceURLs()
      /Users/tstromberg/src/minikube/pkg/minikube/service/service_test.go:468 +0x8b0
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199
==================
==================
WARNING: DATA RACE
Read at 0x00c000158410 by goroutine 61:
  k8s.io/minikube/pkg/minikube/service.(*MockClientGetter).GetCoreClient()
      /Users/tstromberg/src/minikube/pkg/minikube/service/service_test.go:64 +0x16f
  k8s.io/minikube/pkg/minikube/service.GetServiceURLs()
      /Users/tstromberg/src/minikube/pkg/minikube/service/service.go:132 +0x147
  k8s.io/minikube/pkg/minikube/service.TestGetServiceURLs.func1()
      /Users/tstromberg/src/minikube/pkg/minikube/service/service_test.go:475 +0x1d8
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Previous write at 0x00c000158410 by goroutine 60:
  k8s.io/minikube/pkg/minikube/service.TestGetServiceURLs.func1()
      /Users/tstromberg/src/minikube/pkg/minikube/service/service_test.go:473 +0x98
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Goroutine 61 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:960 +0x651
  k8s.io/minikube/pkg/minikube/service.TestGetServiceURLs()
      /Users/tstromberg/src/minikube/pkg/minikube/service/service_test.go:468 +0x8b0
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Goroutine 60 (finished) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:960 +0x651
  k8s.io/minikube/pkg/minikube/service.TestGetServiceURLs()
      /Users/tstromberg/src/minikube/pkg/minikube/service/service_test.go:468 +0x8b0
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199
==================
--- FAIL: TestGetServiceURLs (0.00s)
    --- FAIL: TestGetServiceURLs/no_host (0.00s)
        testing.go:853: race detected during execution of test
    --- FAIL: TestGetServiceURLs/correctly_return_serviceURLs (0.00s)
        testing.go:853: race detected during execution of test
```
