### PR TITLE
Improve "addon list" by viewing as a table 

### DIFF
--- a/cmd/minikube/cmd/config/addons_list.go
+++ b/cmd/minikube/cmd/config/addons_list.go
@@ -22,17 +22,17 @@ import (
 	"os"
 	"sort"
 	"strings"
-	"text/template"
 
+	"github.com/golang/glog"
+	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/assets"
+	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/out"
 )
 
-const defaultAddonListFormat = "- {{.AddonName}}: {{.AddonStatus}}\n"
-
-var addonListFormat string
 var addonListOutput string
 
 // AddonListTemplate represents the addon list template
@@ -50,10 +50,6 @@ var addonsListCmd = &cobra.Command{
 			exit.UsageT("usage: minikube addons list")
 		}
 
-		if addonListOutput != "list" && addonListFormat != defaultAddonListFormat {
-			exit.UsageT("Cannot use both --output and --format options")
-		}
-
 		switch strings.ToLower(addonListOutput) {
 		case "list":
 			printAddonsList()
@@ -67,14 +63,6 @@ var addonsListCmd = &cobra.Command{
 
 func init() {
 	addonsListCmd.Flags().StringVarP(
-		&addonListFormat,
-		"format",
-		"f",
-		defaultAddonListFormat,
-		`Go template format string for the addon list output.  The format for Go templates can be found here: https://golang.org/pkg/text/template/
-For the list of accessible variables for the template, see the struct values here: https://godoc.org/k8s.io/minikube/cmd/minikube/cmd/config#AddonListTemplate`)
-
-	addonsListCmd.Flags().StringVarP(
 		&addonListOutput,
 		"output",
 		"o",
@@ -82,6 +70,13 @@ For the list of accessible variables for the template, see the struct values her
 		`minikube addons list --output OUTPUT. json, list`)
 
 	AddonsCmd.AddCommand(addonsListCmd)
+}
+
+var iconFromStatus = func(addonStatus bool) string {
+	if addonStatus {
+		return "✅"
+	}
+	return "   " // because emoji indentation is different
 }
 
 var stringFromStatus = func(addonStatus bool) string {
@@ -97,6 +92,13 @@ var printAddonsList = func() {
 		addonNames = append(addonNames, addonName)
 	}
 	sort.Strings(addonNames)
+	var tData [][]string
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"Addon Name", "Profile", "Status"})
+	table.SetAutoFormatHeaders(true)
+	table.SetBorders(tablewriter.Border{Left: true, Top: true, Right: true, Bottom: true})
+	table.SetCenterSeparator("|")
+	pName := viper.GetString(config.MachineProfile)
 
 	for _, addonName := range addonNames {
 		addonBundle := assets.Addons[addonName]
@@ -104,20 +106,25 @@ var printAddonsList = func() {
 		if err != nil {
 			exit.WithError("Error getting addons status", err)
 		}
-		tmpl, err := template.New("list").Parse(addonListFormat)
-		if err != nil {
-			exit.WithError("Error creating list template", err)
-		}
-		listTmplt := AddonListTemplate{addonName, stringFromStatus(addonStatus)}
-		err = tmpl.Execute(os.Stdout, listTmplt)
-		if err != nil {
-			exit.WithError("Error executing list template", err)
-		}
+		tData = append(tData, []string{addonName, pName, fmt.Sprintf("%s %s", stringFromStatus(addonStatus), iconFromStatus(addonStatus))})
 	}
+
+	table.AppendBulk(tData)
+	table.Render()
+
+	v, _, err := config.ListProfiles()
+	if err != nil {
+		glog.Infof("error getting list of porfiles: %v", err)
+	}
+	if len(v) > 1 {
+		out.T(out.Tip, "To see addons list for other profiles use: `minikube addons -p name list`")
+	}
+
 }
 
 var printAddonsJSON = func() {
 	addonNames := make([]string, 0, len(assets.Addons))
+	pName := viper.GetString(config.MachineProfile)
 	for addonName := range assets.Addons {
 		addonNames = append(addonNames, addonName)
 	}
@@ -134,7 +141,8 @@ var printAddonsJSON = func() {
 		}
 
 		addonsMap[addonName] = map[string]interface{}{
-			"Status": stringFromStatus(addonStatus),
+			"Status":  stringFromStatus(addonStatus),
+			"Profile": pName,
 		}
 	}
 	jsonString, _ := json.Marshal(addonsMap)

--- a/cmd/minikube/cmd/config/profile_list.go
+++ b/cmd/minikube/cmd/config/profile_list.go
@@ -59,7 +59,6 @@ var profileListCmd = &cobra.Command{
 var printProfilesTable = func() {
 
 	var validData [][]string
-
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"Profile", "VM Driver", "NodeIP", "Node Port", "Kubernetes Version", "Status"})
 	table.SetAutoFormatHeaders(false)

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -548,23 +548,8 @@ func validateServiceCmd(ctx context.Context, t *testing.T, profile string) {
 
 // validateAddonsCmd asserts basic "addon" command functionality
 func validateAddonsCmd(ctx context.Context, t *testing.T, profile string) {
-
-	// Default output
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "addons", "list"))
-	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
-	}
-	listLines := strings.Split(strings.TrimSpace(rr.Stdout.String()), "\n")
-	r := regexp.MustCompile(`-\s[a-z|-]+:\s(enabled|disabled)`)
-	for _, line := range listLines {
-		match := r.MatchString(line)
-		if !match {
-			t.Errorf("Plugin output did not match expected format. Got: %s", line)
-		}
-	}
-
 	// Table output
-	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "addons", "list"))
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "addons", "list"))
 	if err != nil {
 		t.Errorf("%s failed: %v", rr.Args, err)
 	}

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -563,31 +563,14 @@ func validateAddonsCmd(ctx context.Context, t *testing.T, profile string) {
 		}
 	}
 
-	// Custom format
-	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "addons", "list", "--format", `"{{.AddonName}}":"{{.AddonStatus}}"`))
+	// Table output
+	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "addons", "list"))
 	if err != nil {
 		t.Errorf("%s failed: %v", rr.Args, err)
 	}
-	listLines = strings.Split(strings.TrimSpace(rr.Stdout.String()), "\n")
-	r = regexp.MustCompile(`"[a-z|-]+":"(enabled|disabled)"`)
-	for _, line := range listLines {
-		match := r.MatchString(line)
-		if !match {
-			t.Errorf("Plugin output did not match expected custom format. Got: %s", line)
-		}
-	}
-
-	// Custom format shorthand
-	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "addons", "list", "-f", `"{{.AddonName}}":"{{.AddonStatus}}"`))
-	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
-	}
-	listLines = strings.Split(strings.TrimSpace(rr.Stdout.String()), "\n")
-	r = regexp.MustCompile(`"[a-z|-]+":"(enabled|disabled)"`)
-	for _, line := range listLines {
-		match := r.MatchString(line)
-		if !match {
-			t.Errorf("Plugin output did not match expected custom format. Got: %s", line)
+	for _, a := range []string{"dashboard", "ingress", "ingress-dns"} {
+		if !strings.Contains(rr.Output(), a) {
+			t.Errorf("addon list expected to include %q but didn't output: %q", a, rr.Output())
 		}
 	}
 

--- a/test/integration/guest_env_test.go
+++ b/test/integration/guest_env_test.go
@@ -29,7 +29,6 @@ import (
 func TestGuestEnvironment(t *testing.T) {
 	MaybeParallel(t)
 
-
 	profile := UniqueProfileName("guest")
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer CleanupWithLogs(t, profile, cancel)


### PR DESCRIPTION
- display addon list as a table (consistent with profile list and service list)
- also if user has more than one profile, it will hint them to specify the profile
- add a field to json (profile)
- remove the --format option for addon list

### Before this PR:
```
- addon-manager: enabled
- dashboard: disabled
- default-storageclass: enabled
- efk: disabled
- freshpod: disabled
- gvisor: disabled
- heapster: disabled
- helm-tiller: disabled
- ingress: disabled
- ingress-dns: disabled
- logviewer: disabled
- metrics-server: disabled
- nvidia-driver-installer: disabled
- nvidia-gpu-device-plugin: disabled
- registry: disabled
- registry-creds: disabled
- storage-provisioner: enabled
- storage-provisioner-gluster: disabled

```

### After this PR
```
|-----------------------------|----------|--------------|
|         ADDON NAME          | PROFILE  |    STATUS    |
|-----------------------------|----------|--------------|
| addon-manager               | minikube | enabled ✅   |
| dashboard                   | minikube | disabled     |
| default-storageclass        | minikube | enabled ✅   |
| efk                         | minikube | disabled     |
| freshpod                    | minikube | disabled     |
| gvisor                      | minikube | disabled     |
| helm-tiller                 | minikube | disabled     |
| ingress                     | minikube | disabled     |
| ingress-dns                 | minikube | disabled     |
| istio                       | minikube | disabled     |
| istio-provisioner           | minikube | enabled ✅   |
| logviewer                   | minikube | disabled     |
| metrics-server              | minikube | disabled     |
| nvidia-driver-installer     | minikube | disabled     |
| nvidia-gpu-device-plugin    | minikube | disabled     |
| registry                    | minikube | disabled     |
| registry-creds              | minikube | disabled     |
| storage-provisioner         | minikube | enabled ✅   |
| storage-provisioner-gluster | minikube | disabled     |
|-----------------------------|----------|--------------|
```

### if more user has more than 1 profile 
```
$ ./out/minikube addons list
|-----------------------------|----------|--------------|
|         ADDON NAME          | PROFILE  |    STATUS    |
|-----------------------------|----------|--------------|
| addon-manager               | minikube | enabled ✅   |
| dashboard                   | minikube | disabled     |
| default-storageclass        | minikube | enabled ✅   |
| efk                         | minikube | disabled     |
| freshpod                    | minikube | disabled     |
| gvisor                      | minikube | disabled     |
| helm-tiller                 | minikube | disabled     |
| ingress                     | minikube | disabled     |
| ingress-dns                 | minikube | disabled     |
| istio                       | minikube | disabled     |
| istio-provisioner           | minikube | enabled ✅   |
| logviewer                   | minikube | disabled     |
| metrics-server              | minikube | disabled     |
| nvidia-driver-installer     | minikube | disabled     |
| nvidia-gpu-device-plugin    | minikube | disabled     |
| registry                    | minikube | disabled     |
| registry-creds              | minikube | disabled     |
| storage-provisioner         | minikube | enabled ✅   |
| storage-provisioner-gluster | minikube | disabled     |
|-----------------------------|----------|--------------|
💡  To see addons list for other profiles use: `minikube addons -p name list`
```


## JSON output:

```
{"addon-manager":{"Profile":"minikube","Status":"enabled"},"dashboard":{"Profile":"minikube","Status":"disabled"},"default-storageclass":{"Profile":"minikube","Status":"enabled"},"efk":{"Profile":"minikube","Status":"disabled"},"freshpod":{"Profile":"minikube","Status":"disabled"},"gvisor":{"Profile":"minikube","Status":"disabled"},"helm-tiller":{"Profile":"minikube","Status":"disabled"},"ingress":{"Profile":"minikube","Status":"disabled"},"ingress-dns":{"Profile":"minikube","Status":"disabled"},"istio":{"Profile":"minikube","Status":"disabled"},"istio-provisioner":{"Profile":"minikube","Status":"enabled"},"logviewer":{"Profile":"minikube","Status":"disabled"},"metrics-server":{"Profile":"minikube","Status":"disabled"},"nvidia-driver-installer":{"Profile":"minikube","Status":"disabled"},"nvidia-gpu-device-plugin":{"Profile":"minikube","Status":"disabled"},"registry":{"Profile":"minikube","Status":"disabled"},"registry-creds":{"Profile":"minikube","Status":"disabled"},"storage-provisioner":{"Profile":"minikube","Status":"enabled"},"storage-provisioner-gluster":{"Profile":"minikube","Status":"disabled"}
```