### PR TITLE
Add platform option when downloading images

### DIFF
--- a/pkg/minikube/image/image.go
+++ b/pkg/minikube/image/image.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	"github.com/docker/docker/client"
@@ -32,6 +33,11 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"k8s.io/minikube/pkg/minikube/constants"
 )
+
+var defaultPlatform = v1.Platform{
+	Architecture: runtime.GOARCH,
+	OS:           "linux",
+}
 
 // DigestByDockerLib uses client by docker lib to return image digest
 // img.ID in as same as image digest
@@ -81,7 +87,8 @@ func retrieveImage(ref name.Reference) (v1.Image, error) {
 		glog.Infof("daemon lookup for %+v: %v", ref, err)
 	}
 
-	img, err = remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	platform := defaultPlatform
+	img, err = remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithPlatform(platform))
 	if err == nil {
 		return img, nil
 	}


### PR DESCRIPTION
This is for #6252, and should make the dashboard work again on non-amd64 platforms
Before it would download the `amd64` version of the dashboard, when running on `arm64`:

```
kubernetesui/dashboard                          v2.0.0-beta8        f76aaff1043f
<none>                                          <none>              eb51a3597525
kubernetesui/metrics-scraper                    v1.0.2              9437feda71d2
<none>                                          <none>              3b08661dc379
```

Left to do is to clean up the image list, it should **not** append the arch for some k8s images.

```
k8s.gcr.io/kube-proxy-arm64                     v1.17.0             ac19e9cffff5
k8s.gcr.io/kube-proxy                           v1.17.0             ac19e9cffff5
k8s.gcr.io/kube-apiserver-arm64                 v1.17.0             aca151bf3e90
k8s.gcr.io/kube-apiserver                       v1.17.0             aca151bf3e90
k8s.gcr.io/kube-controller-manager-arm64        v1.17.0             7045158f92f8
k8s.gcr.io/kube-controller-manager              v1.17.0             7045158f92f8
k8s.gcr.io/kube-scheduler-arm64                 v1.17.0             0d5c120f87f3
k8s.gcr.io/kube-scheduler                       v1.17.0             0d5c120f87f3
k8s.gcr.io/etcd-arm64                           3.4.3-0             ab707b0a0ea3
k8s.gcr.io/etcd                                 3.4.3-0             ab707b0a0ea3
k8s.gcr.io/pause                                3.1                 6cf7c80fe444
k8s.gcr.io/pause-arm64                          3.1                 6cf7c80fe444
```
The coredns image was actually _missing_ as -arm64 suffix, so it had to be fixed first (#6243)

```
k8s.gcr.io/coredns                              1.6.5               f96217e2532b
<none>                                          <none>              70f311871ae1
```

> Error response from daemon: manifest for k8s.gcr.io/coredns-arm64:1.6.5 not found: manifest unknown: Failed to fetch "1.6.5" from request "/v2/coredns-arm64/manifests/1.6.5".


But for other images, it still _needs_ to add the arch (until they can be rebuilt with "[manifest](https://docs.docker.com/engine/reference/commandline/manifest/)")

```
gcr.io/k8s-minikube/storage-provisioner-arm64   v1.8.1              59d85f778be4
k8s.gcr.io/kube-addon-manager-arm64             v9.0.2              9eec193e9ae4
```

So it gets confusing, and the logic in the images code is a bit convoluted (with amd64) as well :
(It's even worse that some of the older versions only had the renamed images, before multi-arch)

https://github.com/kubernetes/minikube/blob/master/pkg/minikube/bootstrapper/images/images.go


----
Here is the default list of images: (for **all** supported architectures)

```console
$ kubeadm config images list
k8s.gcr.io/kube-apiserver:v1.17.0
k8s.gcr.io/kube-controller-manager:v1.17.0
k8s.gcr.io/kube-scheduler:v1.17.0
k8s.gcr.io/kube-proxy:v1.17.0
k8s.gcr.io/pause:3.1
k8s.gcr.io/etcd:3.4.3-0
k8s.gcr.io/coredns:1.6.5
```
