### PR TITLE
Add a clear example of minikube tunnel to the docs

### DIFF
--- a/cmd/minikube/cmd/tunnel.go
+++ b/cmd/minikube/cmd/tunnel.go
@@ -38,7 +38,7 @@ var cleanup bool
 var tunnelCmd = &cobra.Command{
 	Use:   "tunnel",
 	Short: "tunnel makes services of type LoadBalancer accessible on localhost",
-	Long:  `tunnel creates a route to services deployed with type LoadBalancer and sets their Ingress to their ClusterIP`,
+	Long:  `tunnel creates a route to services deployed with type LoadBalancer and sets their Ingress to their ClusterIP. for a detailed example see https://minikube.sigs.k8s.io/docs/tasks/loadbalancer`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		RootCmd.PersistentPreRun(cmd, args)
 	},

--- a/site/content/en/docs/Tasks/loadbalancer.md
+++ b/site/content/en/docs/Tasks/loadbalancer.md
@@ -67,7 +67,7 @@ kubectl get svc
 <pre>
  $ kc get svc
 NAME             TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)          AGE
-hello-minikube   LoadBalancer   10.96.184.178   10.96.184.178   8080:30791/TCP   40s
+hello-minikube1   LoadBalancer   10.96.184.178   10.96.184.178   8080:30791/TCP   40s
 </pre>
 
 note that without minikube tunnel, it would kubernetes would be showing external IP as <pending>.

--- a/site/content/en/docs/Tasks/loadbalancer.md
+++ b/site/content/en/docs/Tasks/loadbalancer.md
@@ -14,7 +14,7 @@ A LoadBalancer service is the standard way to expose a service to the internet. 
 
 ## Using `minikube tunnel`
 
-Services of type `LoadBalancer` can be exposed via the `minikube tunnel` command. It will run until Ctrl-C is hit.
+Services of type `LoadBalancer` can be exposed via the `minikube tunnel` command. It will run in a separate terminal until Ctrl-C is hit.
 
 ## Example
 
@@ -70,7 +70,8 @@ NAME             TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)         
 hello-minikube1   LoadBalancer   10.96.184.178   10.96.184.178   8080:30791/TCP   40s
 </pre>
 
-note that without minikube tunnel, it would kubernetes would be showing external IP as <pending>.
+
+note that without minikube tunnel, it would kubernetes would be showing external IP as "pending".
 
 ### Try in your browser
 open in your browser (make sure there is no proxy set)
@@ -79,7 +80,7 @@ http://REPLACE_WITH_EXTERNAL_IP:8080
 ```
 
 
-Each service will get it is own external ip.
+Each service will get it's own external ip.
 
 ----
 ### DNS resolution (experimental)

--- a/site/content/en/docs/Tasks/loadbalancer.md
+++ b/site/content/en/docs/Tasks/loadbalancer.md
@@ -16,29 +16,72 @@ A LoadBalancer service is the standard way to expose a service to the internet. 
 
 Services of type `LoadBalancer` can be exposed via the `minikube tunnel` command. It will run until Ctrl-C is hit.
 
-````shell
-minikube tunnel
-````
-Example output:
+## Example
 
-```text
-out/minikube tunnel
-Password: *****
-Status:
-        machine: minikube
-        pid: 59088
-        route: 10.96.0.0/12 -> 192.168.99.101
-        minikube: Running
-        services: []
-    errors:
-                minikube: no errors
-                router: no errors
-                loadbalancer emulator: no errors
+#### Run tunnel in a separate terminal
+it will ask for password.
+
 ```
-
+minikube tunnel
+```
 
 `minikube tunnel` runs as a separate daemon, creating a network route on the host to the service CIDR of the cluster using the cluster's IP address as a gateway.  The tunnel command exposes the external IP directly to any program running on the host operating system.
 
+
+<details>
+<summary>
+tunnel output example
+</summary>
+<pre>
+Password: 
+Status:	
+	machine: minikube
+	pid: 39087
+	route: 10.96.0.0/12 -> 192.168.64.194
+	minikube: Running
+	services: [hello-minikube]
+    errors: 
+		minikube: no errors
+		router: no errors
+		loadbalancer emulator: no errors
+...
+...
+...
+</pre>
+</details>
+
+
+#### Create a kubernetes deployment 
+```
+  kubectl create deployment hello-minikube1 --image=k8s.gcr.io/echoserver:1.4
+```
+#### Create a kubernetes service type LoadBalancer
+```
+  kubectl expose deployment hello-minikube1 --type=LoadBalancer --port=8080
+```
+
+### Check external IP 
+```
+kubectl get svc
+```
+<pre>
+ $ kc get svc
+NAME             TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)          AGE
+hello-minikube   LoadBalancer   10.96.184.178   10.96.184.178   8080:30791/TCP   40s
+</pre>
+
+note that without minikube tunnel, it would kubernetes would be showing external IP as <pending>.
+
+### Try in your browser
+open in your browser (make sure there is no proxy set)
+```
+http://REPLACE_WITH_EXTERNAL_IP:8080
+```
+
+
+Each service will get it is own external ip.
+
+----
 ### DNS resolution (experimental)
 
 If you are on macOS, the tunnel command also allows DNS resolution for Kubernetes services from the host.


### PR DESCRIPTION
I am not sure on the cmd description that we have in minikube but I left it untouched it says

```
tunnel creates a route to services deployed with type LoadBalancer and sets their Ingress to their ClusterIP.
```
I think it would be better to say it sets external ip for the service type 

but for this PR I added a clear example of using tunnel