### PR TITLE
Configure etcd and kube-proxy metrics to listen on minikube node IP

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta1.go
+++ b/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta1.go
@@ -60,6 +60,8 @@ dns:
 etcd:
   local:
     dataDir: {{.EtcdDataDir}}
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://{{.AdvertiseAddress}}:2381
 kubernetesVersion: {{.KubernetesVersion}}
 networking:
   dnsDomain: {{if .DNSDomain}}{{.DNSDomain}}{{else}}cluster.local{{end}}
@@ -73,4 +75,8 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: {{.AdvertiseAddress}}:10249
 `))

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd-api-port.yaml
@@ -30,6 +30,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.14.0
 networking:
   dnsDomain: cluster.local
@@ -43,3 +45,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd-pod-network-cidr.yaml
@@ -30,6 +30,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.14.0
 networking:
   dnsDomain: cluster.local
@@ -43,3 +45,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd.yaml
@@ -30,6 +30,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.14.0
 networking:
   dnsDomain: cluster.local
@@ -43,3 +45,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/crio-options-gates.yaml
@@ -40,6 +40,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.14.0
 networking:
   dnsDomain: cluster.local
@@ -53,3 +55,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/crio.yaml
@@ -30,6 +30,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.14.0
 networking:
   dnsDomain: cluster.local
@@ -43,3 +45,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/default.yaml
@@ -30,6 +30,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.14.0
 networking:
   dnsDomain: cluster.local
@@ -43,3 +45,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/dns.yaml
@@ -30,6 +30,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.14.0
 networking:
   dnsDomain: 1.1.1.1
@@ -43,3 +45,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/image-repository.yaml
@@ -31,6 +31,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.14.0
 networking:
   dnsDomain: cluster.local
@@ -44,3 +46,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/options.yaml
@@ -37,6 +37,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.14.0
 networking:
   dnsDomain: cluster.local
@@ -50,3 +52,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd-api-port.yaml
@@ -30,6 +30,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.15.0
 networking:
   dnsDomain: cluster.local
@@ -43,3 +45,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd-pod-network-cidr.yaml
@@ -30,6 +30,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.15.0
 networking:
   dnsDomain: cluster.local
@@ -43,3 +45,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd.yaml
@@ -30,6 +30,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.15.0
 networking:
   dnsDomain: cluster.local
@@ -43,3 +45,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/crio-options-gates.yaml
@@ -40,6 +40,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.15.0
 networking:
   dnsDomain: cluster.local
@@ -53,3 +55,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/crio.yaml
@@ -30,6 +30,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.15.0
 networking:
   dnsDomain: cluster.local
@@ -43,3 +45,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/default.yaml
@@ -30,6 +30,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.15.0
 networking:
   dnsDomain: cluster.local
@@ -43,3 +45,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/dns.yaml
@@ -30,6 +30,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.15.0
 networking:
   dnsDomain: 1.1.1.1
@@ -43,3 +45,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/image-repository.yaml
@@ -31,6 +31,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.15.0
 networking:
   dnsDomain: cluster.local
@@ -44,3 +46,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/options.yaml
@@ -37,6 +37,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.15.0
 networking:
   dnsDomain: cluster.local
@@ -50,3 +52,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd-api-port.yaml
@@ -30,6 +30,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.16.0
 networking:
   dnsDomain: cluster.local
@@ -43,3 +45,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd-pod-network-cidr.yaml
@@ -30,6 +30,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.16.0
 networking:
   dnsDomain: cluster.local
@@ -43,3 +45,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd.yaml
@@ -30,6 +30,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.16.0
 networking:
   dnsDomain: cluster.local
@@ -43,3 +45,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/crio-options-gates.yaml
@@ -40,6 +40,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.16.0
 networking:
   dnsDomain: cluster.local
@@ -53,3 +55,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/crio.yaml
@@ -30,6 +30,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.16.0
 networking:
   dnsDomain: cluster.local
@@ -43,3 +45,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/default.yaml
@@ -30,6 +30,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.16.0
 networking:
   dnsDomain: cluster.local
@@ -43,3 +45,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/dns.yaml
@@ -30,6 +30,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.16.0
 networking:
   dnsDomain: 1.1.1.1
@@ -43,3 +45,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/image-repository.yaml
@@ -31,6 +31,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.16.0
 networking:
   dnsDomain: cluster.local
@@ -44,3 +46,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/options.yaml
@@ -37,6 +37,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.16.0
 networking:
   dnsDomain: cluster.local
@@ -50,3 +52,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-api-port.yaml
@@ -30,6 +30,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.17.0
 networking:
   dnsDomain: cluster.local
@@ -43,3 +45,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-pod-network-cidr.yaml
@@ -30,6 +30,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.17.0
 networking:
   dnsDomain: cluster.local
@@ -43,3 +45,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd.yaml
@@ -30,6 +30,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.17.0
 networking:
   dnsDomain: cluster.local
@@ -43,3 +45,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio-options-gates.yaml
@@ -40,6 +40,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.17.0
 networking:
   dnsDomain: cluster.local
@@ -53,3 +55,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio.yaml
@@ -30,6 +30,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.17.0
 networking:
   dnsDomain: cluster.local
@@ -43,3 +45,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/default.yaml
@@ -30,6 +30,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.17.0
 networking:
   dnsDomain: cluster.local
@@ -43,3 +45,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/dns.yaml
@@ -30,6 +30,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.17.0
 networking:
   dnsDomain: 1.1.1.1
@@ -43,3 +45,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/image-repository.yaml
@@ -31,6 +31,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.17.0
 networking:
   dnsDomain: cluster.local
@@ -44,3 +46,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/options.yaml
@@ -37,6 +37,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+    extraArgs:
+      listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.17.0
 networking:
   dnsDomain: cluster.local
@@ -50,3 +52,7 @@ evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 1.1.1.1:10249


### PR DESCRIPTION
Configures etcd and kube-proxy to expose their metrics on the minikube node IP
instead of localhost so that their metrics can be scraped by Prometheus.

Metrics are already exposed for other control plane services such as kube
apiserver, controller-manager, and scheduler, this simply updates etcd and
kube-proxy to match.

This is desirable so that Prometheus monitoring works within minikube.