### PR TITLE
Remove stray space from driver selection message

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -586,11 +586,11 @@ func selectDriver(existing *cfg.MachineConfig) string {
 	pick, alts := driver.Choose(name, options)
 	exp := ""
 	if pick.Priority == registry.Experimental {
-		exp = "experimental"
+		exp = "experimental "
 	}
 
 	if name != "" {
-		out.T(out.Sparkle, `Selecting {{.experimental}} '{{.driver}}' driver from user configuration (alternates: {{.alternates}})`, out.V{"experimental": exp, "driver": name, "alternates": alts})
+		out.T(out.Sparkle, `Selecting {{.experimental}}'{{.driver}}' driver from user configuration (alternates: {{.alternates}})`, out.V{"experimental": exp, "driver": name, "alternates": alts})
 		return name
 	}
 


### PR DESCRIPTION
```
✨  Selecting  'virtualbox' driver from user configuration (alternates: [kvm2 none docker])
```

Added in 010d0d4091d777ab88d99ec7d9340750ed3f70b8