### PR TITLE
implement remove file for kic runner

### DIFF
--- a/pkg/minikube/command/kic_runner.go
+++ b/pkg/minikube/command/kic_runner.go
@@ -169,7 +169,11 @@ func (k *kicRunner) Copy(f assets.CopyableFile) error {
 
 // Remove removes a file
 func (k *kicRunner) Remove(f assets.CopyableFile) error {
-	return fmt.Errorf("not implemented yet for kic runner")
+	fp := path.Join(f.GetTargetDir(), f.GetTargetName())
+	if rr, err := k.RunCmd(exec.Command("sudo", "rm", fp)); err != nil {
+		return errors.Wrapf(err, "removing file %q output: %s", fp, rr.Output())
+	}
+	return nil
 }
 
 // isTerminal returns true if the writer w is a terminal


### PR DESCRIPTION
- Implement remove file for kic runner. (last un-implemented feature)
- after this PR minikube addon disable will work for kic as well.

closes https://github.com/kubernetes/minikube/issues/6297