### PR TITLE
Bump default Kubernetes version to v1.17.2, latest to v1.18.0-alpha.2

### DIFF
--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -67,10 +67,10 @@ var DefaultISOURL = fmt.Sprintf("https://storage.googleapis.com/%s/minikube-%s.i
 var DefaultISOSHAURL = DefaultISOURL + SHASuffix
 
 // DefaultKubernetesVersion is the default kubernetes version
-var DefaultKubernetesVersion = "v1.17.0"
+var DefaultKubernetesVersion = "v1.17.2"
 
 // NewestKubernetesVersion is the newest Kubernetes version to test against
-var NewestKubernetesVersion = "v1.17.0"
+var NewestKubernetesVersion = "v1.18.0-alpha.2"
 
 // OldestKubernetesVersion is the oldest Kubernetes version to test against
 var OldestKubernetesVersion = "v1.11.10"


### PR DESCRIPTION
Please carefully look at latest test result to make sure we don't break it.