### PR TITLE
kic driver: add multiple profiles and ssh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -485,8 +485,8 @@ endif
 
 .PHONY: kic-base-image
 kic-base-image: ## builds the base image used for kic.
-	docker rmi -f $(REGISTRY)/kicbase:v0.0.1-snapshot || true
-	docker build -f ./hack/images/kicbase.Dockerfile -t $(REGISTRY)/kicbase:v0.0.1-snapshot  --build-arg COMMIT_SHA=${VERSION}-$(COMMIT)  .
+	docker rmi -f $(REGISTRY)/kicbase:v0.0.2-snapshot || true
+	docker build -f ./hack/images/kicbase.Dockerfile -t $(REGISTRY)/kicbase:v0.0.2-snapshot  --build-arg COMMIT_SHA=${VERSION}-$(COMMIT)  .
 
 
 

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -445,15 +445,11 @@ func displayEnviron(env []string) {
 }
 
 func setupKubeconfig(h *host.Host, c *cfg.MachineConfig, clusterName string) (*kubeconfig.Settings, error) {
-	addr := ""
-	var err error
-	if driver.IsKIC(h.DriverName) {
-		addr = fmt.Sprintf("https://%s", net.JoinHostPort("127.0.0.1", fmt.Sprint(c.KubernetesConfig.NodePort)))
-	} else {
-		addr, err = h.Driver.GetURL()
-		if err != nil {
-			exit.WithError("Failed to get driver URL", err)
-		}
+	addr, err := h.Driver.GetURL()
+	if err != nil {
+		exit.WithError("Failed to get driver URL", err)
+	}
+	if !driver.IsKIC(h.DriverName) {
 		addr = strings.Replace(addr, "tcp://", "https://", -1)
 		addr = strings.Replace(addr, ":2376", ":"+strconv.Itoa(c.KubernetesConfig.NodePort), -1)
 	}

--- a/hack/images/kicbase.Dockerfile
+++ b/hack/images/kicbase.Dockerfile
@@ -1,10 +1,13 @@
 ARG COMMIT_SHA
+# using node image created by kind https://github.com/kubernetes-sigs/kind
+# could be changed to ubuntu.
 FROM kindest/node:v1.16.2
 USER root
 RUN apt-get update && apt-get install -y \
   sudo \
   dnsutils \
   && apt-get clean -y 
+# Deleting all kind related stuff from the image.
 RUN rm -rf \
     /var/cache/debconf/* \
     /var/lib/apt/lists/* \
@@ -16,3 +19,8 @@ RUN rm -rf \
     /usr/share/local/* \
     /kind/bin/kubeadm /kind/bin/kubelet /kind/systemd /kind/images /kind/manifests
 RUN echo "kic! Build: ${COMMIT_SHA} Time :$(date)" > "/kic.txt"
+# for minikube ssh. to match VM using docker username
+RUN useradd -ms /bin/bash docker 
+USER docker
+RUN mkdir /home/docker/.ssh
+

--- a/hack/images/kicbase.Dockerfile
+++ b/hack/images/kicbase.Dockerfile
@@ -1,13 +1,21 @@
 ARG COMMIT_SHA
-# using node image created by kind https://github.com/kubernetes-sigs/kind
-# could be changed to ubuntu.
+# for now using node image created by kind https://github.com/kubernetes-sigs/kind
+# could be changed to slim ubuntu with systemd. 
 FROM kindest/node:v1.16.2
 USER root
 RUN apt-get update && apt-get install -y \
   sudo \
   dnsutils \
+  openssh-server \
   && apt-get clean -y 
-# Deleting all kind related stuff from the image.
+# based on https://github.com/rastasheep/ubuntu-sshd/blob/master/18.04/Dockerfile
+# making SSH work for docker container 
+RUN mkdir /var/run/sshd
+RUN echo 'root:root' |chpasswd
+RUN sed -ri 's/^#?PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+RUN sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
+EXPOSE 22
+# Deleting all "kind" related stuff from the image.
 RUN rm -rf \
     /var/cache/debconf/* \
     /var/lib/apt/lists/* \
@@ -20,7 +28,9 @@ RUN rm -rf \
     /kind/bin/kubeadm /kind/bin/kubelet /kind/systemd /kind/images /kind/manifests
 RUN echo "kic! Build: ${COMMIT_SHA} Time :$(date)" > "/kic.txt"
 # for minikube ssh. to match VM using docker username
-RUN useradd -ms /bin/bash docker 
+RUN adduser --disabled-password --gecos '' docker
+RUN adduser docker sudo
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER docker
 RUN mkdir /home/docker/.ssh
-
+USER root

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -27,11 +27,13 @@ import (
 	"github.com/docker/machine/libmachine/state"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"github.com/spf13/viper"
 	pkgdrivers "k8s.io/minikube/pkg/drivers"
 	"k8s.io/minikube/pkg/drivers/kic/node"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/command"
+	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 )
 
@@ -172,7 +174,12 @@ func (d *Driver) GetSSHHostname() (string, error) {
 
 // GetSSHPort returns port for use with ssh
 func (d *Driver) GetSSHPort() (int, error) {
-	return d.NodeConfig.SSHHostBindPort, nil
+	cc, err := config.Load(viper.GetString(config.MachineProfile))
+	if err != nil {
+		glog.Infof("error loading config file which may be okay on first run : %v ", err)
+		return 22, nil
+	}
+	return int(cc.SSHBindPort), nil
 }
 
 // GetURL returns ip of the container running kic control-panel

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -41,7 +41,7 @@ const DefaultBindIPV4 = "127.0.0.1"
 // BaseImage is the base image is used to spin up kic containers created by kind.
 // const BaseImage = "gcr.io/k8s-minikube/kicbase:v0.0.1@sha256:c4ad2938877d2ae0d5b7248a5e7182ff58c0603165c3bedfe9d503e2d380a0db"
 // BaseImage is the base image is used to spin up kic containers created by kind.
-const BaseImage = "gcr.io/k8s-minikube/kicbase:v0.0.2-snapshot"
+const BaseImage = "kicbase:local"
 
 // OverlayImage is the cni plugin used for overlay image, created by kind.
 const OverlayImage = "kindest/kindnetd:0.5.3"

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -43,9 +43,7 @@ const DefaultPodCIDR = "10.244.0.0/16"
 const DefaultBindIPV4 = "127.0.0.1"
 
 // BaseImage is the base image is used to spin up kic containers created by kind.
-// const BaseImage = "gcr.io/k8s-minikube/kicbase:v0.0.1@sha256:c4ad2938877d2ae0d5b7248a5e7182ff58c0603165c3bedfe9d503e2d380a0db"
-// BaseImage is the base image is used to spin up kic containers created by kind.
-const BaseImage = "kicbase:local"
+const BaseImage = "gcr.io/k8s-minikube/kicbase:v0.0.2@sha256:8f531b90901721a7bd4e67ceffbbc7ee6c4292b0e6d1a9d6eb59f117d57bc4e9"
 
 // OverlayImage is the cni plugin used for overlay image, created by kind.
 const OverlayImage = "kindest/kindnetd:0.5.3"

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -58,16 +58,17 @@ type Driver struct {
 
 // Config is configuration for the kic driver used by registry
 type Config struct {
-	MachineName  string            // maps to the container name being created
-	CPU          int               // Number of CPU cores assigned to the container
-	Memory       int               // max memory in MB
-	StorePath    string            // libmachine store path
-	OCIBinary    string            // oci tool to use (docker, podman,...)
-	ImageDigest  string            // image name with sha to use for the node
-	HostBindPort int               // port to connect to forward from container to user's machine
-	Mounts       []oci.Mount       // mounts
-	PortMappings []oci.PortMapping // container port mappings
-	Envs         map[string]string // key,value of environment variables passed to the node
+	MachineName     string            // maps to the container name being created
+	CPU             int               // Number of CPU cores assigned to the container
+	Memory          int               // max memory in MB
+	StorePath       string            // libmachine store path
+	OCIBinary       string            // oci tool to use (docker, podman,...)
+	ImageDigest     string            // image name with sha to use for the node
+	APIHostBindPort int               // bind port for api server
+	SSHHostBindPort int               // bind port for ssh server
+	Mounts          []oci.Mount       // mounts
+	PortMappings    []oci.PortMapping // container port mappings
+	Envs            map[string]string // key,value of environment variables passed to the node
 }
 
 // NewDriver returns a fully configured Kic driver
@@ -137,12 +138,12 @@ func (d *Driver) GetIP() (string, error) {
 
 // GetSSHHostname returns hostname for use with ssh
 func (d *Driver) GetSSHHostname() (string, error) {
-	return "", fmt.Errorf("driver does not have SSHHostName")
+	return DefaultBindIPV4, nil
 }
 
 // GetSSHPort returns port for use with ssh
 func (d *Driver) GetSSHPort() (int, error) {
-	return 0, fmt.Errorf("driver does not support GetSSHPort")
+	return d.NodeConfig.SSHHostBindPort, nil
 }
 
 // GetURL returns ip of the container running kic control-panel

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -176,6 +176,11 @@ func (d *Driver) GetSSHPort() (int, error) {
 	return p, nil
 }
 
+// GetSSHUsername returns the ssh username
+func (d *Driver) GetSSHUsername() string {
+	return "docker"
+}
+
 // GetSSHKeyPath returns the ssh key path
 func (d *Driver) GetSSHKeyPath() string {
 	if d.SSHKeyPath == "" {

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -97,7 +97,7 @@ func (d *Driver) Create() error {
 
 	// control plane specific options
 	params.PortMappings = append(params.PortMappings, oci.PortMapping{
-		ListenAddress: "127.0.0.1",
+		ListenAddress: DefaultBindIPV4,
 		HostPort:      int32(d.NodeConfig.HostBindPort),
 		ContainerPort: constants.APIServerPort,
 	})

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -39,7 +39,9 @@ const DefaultPodCIDR = "10.244.0.0/16"
 const DefaultBindIPV4 = "127.0.0.1"
 
 // BaseImage is the base image is used to spin up kic containers created by kind.
-const BaseImage = "gcr.io/k8s-minikube/kicbase:v0.0.1@sha256:c4ad2938877d2ae0d5b7248a5e7182ff58c0603165c3bedfe9d503e2d380a0db"
+// const BaseImage = "gcr.io/k8s-minikube/kicbase:v0.0.1@sha256:c4ad2938877d2ae0d5b7248a5e7182ff58c0603165c3bedfe9d503e2d380a0db"
+// BaseImage is the base image is used to spin up kic containers created by kind.
+const BaseImage = "gcr.io/k8s-minikube/kicbase:v0.0.2-snapshot"
 
 // OverlayImage is the cni plugin used for overlay image, created by kind.
 const OverlayImage = "kindest/kindnetd:0.5.3"
@@ -100,7 +102,13 @@ func (d *Driver) Create() error {
 		ListenAddress: DefaultBindIPV4,
 		HostPort:      int32(d.NodeConfig.HostBindPort),
 		ContainerPort: constants.APIServerPort,
-	})
+	},
+		oci.PortMapping{
+			ListenAddress: DefaultBindIPV4,
+			HostPort:      int32(d.NodeConfig.HostBindPort) + constants.SSHPort, // TODO: @medyagh: use github.com/phayes/freeport instead.
+			ContainerPort: constants.SSHPort,
+		},
+	)
 
 	_, err := node.CreateNode(params)
 	if err != nil {

--- a/pkg/drivers/kic/node/node.go
+++ b/pkg/drivers/kic/node/node.go
@@ -46,17 +46,18 @@ type Node struct {
 }
 
 type CreateConfig struct {
-	Name         string            // used for container name and hostname
-	Image        string            // container image to use to create the node.
-	ClusterLabel string            // label the containers we create using minikube so we can clean up
-	Role         string            // currently only role supported is control-plane
-	Mounts       []oci.Mount       // volume mounts
-	PortMappings []oci.PortMapping // ports to map to container from host
-	CPUs         string            // number of cpu cores assign to container
-	Memory       string            // memory (mbs) to assign to the container
-	Envs         map[string]string // environment variables to pass to the container
-	ExtraArgs    []string          // a list of any extra option to pass to oci binary during creation time, for example --expose 8080...
-	OCIBinary    string            // docker or podman
+	Name          string            // used for container name and hostname
+	Image         string            // container image to use to create the node.
+	ClusterLabel  string            // label the containers we create using minikube so we can clean up
+	Role          string            // currently only role supported is control-plane
+	Mounts        []oci.Mount       // volume mounts
+	APIServerPort int               // kubernetes api server port
+	PortMappings  []oci.PortMapping // ports to map to container from host
+	CPUs          string            // number of cpu cores assign to container
+	Memory        string            // memory (mbs) to assign to the container
+	Envs          map[string]string // environment variables to pass to the container
+	ExtraArgs     []string          // a list of any extra option to pass to oci binary during creation time, for example --expose 8080...
+	OCIBinary     string            // docker or podman
 }
 
 // CreateNode creates a new container node

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -468,7 +468,7 @@ func (k *Bootstrapper) clientEndpointAddr(cfg config.MachineConfig) (string, int
 	if driver.IsKIC(cfg.VMDriver) { // for kic we ask docker/podman what port it assigned to node port
 		p, err := oci.HostPortBinding(cfg.VMDriver, cfg.Name, cfg.KubernetesConfig.NodePort)
 		if err != nil {
-			glog.Warningf("Error getting host bind port %s for api server for %s driver: %v ", p, cfg.VMDriver, err)
+			glog.Warningf("Error getting host bind port %q for api server for %q driver: %v ", p, cfg.VMDriver, err)
 		}
 		return kic.DefaultBindIPV4, p
 	}

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -65,15 +65,13 @@ type MachineConfig struct {
 	HostOnlyNicType     string // Only used by virtualbox
 	NatNicType          string // Only used by virtualbox
 	Addons              map[string]bool
-	APIBindPort         int32 // the host port to bind to apiserver inside the container only used by kic
-	SSHBindPort         int32 // the host port to bind to ssh service inside the container only used by kic
 }
 
 // KubernetesConfig contains the parameters used to configure the VM Kubernetes.
 type KubernetesConfig struct {
 	KubernetesVersion string
 	NodeIP            string
-	NodePort          int
+	NodePort          int // kubernetes api server port
 	NodeName          string
 	APIServerName     string
 	APIServerNames    []string

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -65,7 +65,8 @@ type MachineConfig struct {
 	HostOnlyNicType     string // Only used by virtualbox
 	NatNicType          string // Only used by virtualbox
 	Addons              map[string]bool
-	NodeBindPort        int32 // Only used by kic
+	APIBindPort         int32 // the host port to bind to apiserver inside the container only used by kic
+	SSHBindPort         int32 // the host port to bind to ssh service inside the container only used by kic
 }
 
 // KubernetesConfig contains the parameters used to configure the VM Kubernetes.

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -27,6 +27,8 @@ import (
 )
 
 const (
+	// SSHPort is the SSH serviceport on the node vm and container
+	SSHPort = 22
 	// APIServerPort is the default API server port
 	APIServerPort = 8443
 	// APIServerName is the default API server name

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -43,13 +43,13 @@ func init() {
 
 func configure(mc config.MachineConfig) interface{} {
 	return kic.NewDriver(kic.Config{
-		MachineName:  mc.Name,
-		StorePath:    localpath.MiniPath(),
-		ImageDigest:  kic.BaseImage,
-		CPU:          mc.CPUs,
-		Memory:       mc.Memory,
-		HostBindPort: mc.KubernetesConfig.NodePort,
-		OCIBinary:    oci.Docker,
+		MachineName:     mc.Name,
+		StorePath:       localpath.MiniPath(),
+		ImageDigest:     kic.BaseImage,
+		CPU:             mc.CPUs,
+		Memory:          mc.Memory,
+		APIHostBindPort: mc.KubernetesConfig.NodePort,
+		OCIBinary:       oci.Docker,
 	})
 
 }

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -43,13 +43,13 @@ func init() {
 
 func configure(mc config.MachineConfig) interface{} {
 	return kic.NewDriver(kic.Config{
-		MachineName:     mc.Name,
-		StorePath:       localpath.MiniPath(),
-		ImageDigest:     kic.BaseImage,
-		CPU:             mc.CPUs,
-		Memory:          mc.Memory,
-		APIHostBindPort: mc.KubernetesConfig.NodePort,
-		OCIBinary:       oci.Docker,
+		MachineName:   mc.Name,
+		StorePath:     localpath.MiniPath(),
+		ImageDigest:   kic.BaseImage,
+		CPU:           mc.CPUs,
+		Memory:        mc.Memory,
+		APIServerPort: mc.KubernetesConfig.NodePort,
+		OCIBinary:     oci.Docker,
 	})
 
 }


### PR DESCRIPTION
This PR:
- enables "minikube ssh" functionality for kic drivers
- enables multiple profiles for kic
- new kic base image with openssh installed in it


closes https://github.com/kubernetes/minikube/issues/6304 and https://github.com/kubernetes/minikube/issues/6388