### PR TITLE
Add github actions integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,10 +12,11 @@ jobs:
       run : |
         make minikube-linux-amd64
         make e2e-linux-amd64
+        mkdir -p report
     - name: run integration test
       run: |
         echo running docker driver intergration test on ubuntu
-        ./out/e2e-linux-amd64 -test.run TestDownloadOnly -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64 2>&1 | tee testout.txt
+        ./out/e2e-linux-amd64 -test.run TestDownloadOnly -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64 2>&1 | tee ./report/testout.txt
     - name: install gopogh
       run: |
         cd /tmp
@@ -24,24 +25,45 @@ jobs:
     - name: generate report
       run: |
         export PATH=${PATH}:`go env GOPATH`/bin
-        go tool test2json -t < testout.txt > testout.json || true
-        gopogh -in testout.json -out testout.html -name "docker ubuntu" -repo github.com/kubernetes/minikube/  || true
+        go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
+        gopogh -in ./report/testout.json -out ./report/testout.html -name "docker ubuntu" -repo github.com/kubernetes/minikube/  || true
     - uses: actions/upload-artifact@v1
       with:
-        name: html_report_ubuntu
-        path: testout.html
-    - uses: actions/upload-artifact@v1
-      with:
-        name: txt_report_ubuntu
-        path: testout.txt
-    - uses: actions/upload-artifact@v1
-      with:
-        name: json_report_ubuntu
-        path: testout.json
+        name: docker_on_ubuntu_report
+        path: report
 
   docker_macos:
+
     runs-on: macos-latest
 
+    steps:
+    - uses: actions/checkout@v2
+    - name: build binaries
+      run : |
+        make minikube-darwin-amd64
+        make e2e-darwin-amd64
+        mkdir -p report
+    - name: run integration test
+      run: |
+        echo running docker driver intergration test on ubuntu
+        ./out/e2e-darwin-amd64 -test.run TestDownloadOnly -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-darwin-amd64 2>&1 | tee ./report/testout.txt
+    - name: install gopogh
+      run: |
+        cd /tmp
+        GO111MODULE="on" go get github.com/medyagh/gopogh@v0.0.17 || true
+        cd -
+    - name: generate report
+      run: |
+        export PATH=${PATH}:`go env GOPATH`/bin
+        go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
+        gopogh -in ./report/testout.json -out ./report/testout.html -name "docker macos" -repo github.com/kubernetes/minikube/  || true
+    - uses: actions/upload-artifact@v1
+      with:
+        name: docker_on_macos_report
+        path: ./report
+
+  docker_macos:
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
     - name: build binaries
@@ -64,13 +86,5 @@ jobs:
         gopogh -in testout.json -out testout.html -name "docker macos" -repo github.com/kubernetes/minikube/  || true
     - uses: actions/upload-artifact@v1
       with:
-        name: html_report_macos
-        path: testout.html
-    - uses: actions/upload-artifact@v1
-      with:
-        name: txt_report_macos
-        path: testout.txt
-    - uses: actions/upload-artifact@v1
-      with:
-        name: json_report_macos
-        path: testout.json
+        name: docker_on_macos_report
+        path: ./report

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,30 +61,3 @@ jobs:
       with:
         name: docker_on_macos_report
         path: ./report
-
-  docker_macos:
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: build binaries
-      run : |
-        make minikube-darwin-amd64
-        make e2e-darwin-amd64
-    - name: run integration test
-      run: |
-        echo running docker driver intergration test on ubuntu
-        ./out/e2e-darwin-amd64 -test.run TestDownloadOnly -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-darwin-amd64 2>&1 | tee testout.txt
-    - name: install gopogh
-      run: |
-        cd /tmp
-        GO111MODULE="on" go get github.com/medyagh/gopogh@v0.0.17 || true
-        cd -
-    - name: generate report
-      run: |
-        export PATH=${PATH}:`go env GOPATH`/bin
-        go tool test2json -t < testout.txt > testout.json || true
-        gopogh -in testout.json -out testout.html -name "docker macos" -repo github.com/kubernetes/minikube/  || true
-    - uses: actions/upload-artifact@v1
-      with:
-        name: docker_on_macos_report
-        path: ./report

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         cd /tmp
         GO111MODULE="on" go get github.com/medyagh/gopogh@v0.0.17 || true
         cd -
-    - name: generate report
+    - name: generate gopogh report
       run: |
         export PATH=${PATH}:`go env GOPATH`/bin
         go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
@@ -52,7 +52,7 @@ jobs:
         cd /tmp
         GO111MODULE="on" go get github.com/medyagh/gopogh@v0.0.17 || true
         cd -
-    - name: generate report
+    - name: generate gopogh report
       run: |
         export PATH=${PATH}:`go env GOPATH`/bin
         go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
@@ -61,3 +61,61 @@ jobs:
       with:
         name: docker_on_macos_report
         path: ./report
+
+  none_ubuntu:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: build binaries
+      run : |
+        make minikube-linux-amd64
+        make e2e-linux-amd64
+        mkdir -p report
+    - name: run integration test
+      run: |
+        echo running docker driver intergration test on ubuntu
+        ./out/e2e-linux-amd64 -test.run TestDownloadOnly -minikube-start-args=--vm-driver=none -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+    - name: install gopogh
+      run: |
+        cd /tmp
+        GO111MODULE="on" go get github.com/medyagh/gopogh@v0.0.17 || true
+        cd -
+    - name: generate gopogh report
+      run: |
+        export PATH=${PATH}:`go env GOPATH`/bin
+        go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
+        gopogh -in ./report/testout.json -out ./report/testout.html -name "docker ubuntu" -repo github.com/kubernetes/minikube/  || true
+    - uses: actions/upload-artifact@v1
+      with:
+        name: none_on_ubuntu_latest_report
+        path: report
+
+  none_ubuntu16_04:
+    runs-on: ubuntu-16.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: build binaries
+      run : |
+        make minikube-linux-amd64
+        make e2e-linux-amd64
+        mkdir -p report
+    - name: run integration test
+      run: |
+        echo running docker driver intergration test on ubuntu
+        ./out/e2e-linux-amd64 -test.run TestDownloadOnly -minikube-start-args=--vm-driver=none -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+    - name: install gopogh
+      run: |
+        cd /tmp
+        GO111MODULE="on" go get github.com/medyagh/gopogh@v0.0.17 || true
+        cd -
+    - name: generate gopogh report
+      run: |
+        export PATH=${PATH}:`go env GOPATH`/bin
+        go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
+        gopogh -in ./report/testout.json -out ./report/testout.html -name "docker ubuntu" -repo github.com/kubernetes/minikube/  || true
+    - uses: actions/upload-artifact@v1
+      with:
+        name: none_on_ubuntu_16_04
+        path: report

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     - name: run integration test
       run: |
         echo running docker driver intergration test on ubuntu
-        ./out/e2e-linux-amd64 -test.run TestDownloadOnly -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        ./out/e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64 2>&1 | tee ./report/testout.txt
     - name: install gopogh
       run: |
         cd /tmp
@@ -46,7 +46,7 @@ jobs:
     - name: run integration test
       run: |
         echo running docker driver intergration test on ubuntu
-        ./out/e2e-darwin-amd64 -test.run TestDownloadOnly -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-darwin-amd64 2>&1 | tee ./report/testout.txt
+        ./out/e2e-darwin-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-darwin-amd64 2>&1 | tee ./report/testout.txt
     - name: install gopogh
       run: |
         cd /tmp
@@ -75,7 +75,7 @@ jobs:
     - name: run integration test
       run: |
         echo running docker driver intergration test on ubuntu
-        ./out/e2e-linux-amd64 -test.run TestDownloadOnly -minikube-start-args=--vm-driver=none -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        ./out/e2e-linux-amd64 -minikube-start-args=--vm-driver=none -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64 2>&1 | tee ./report/testout.txt
     - name: install gopogh
       run: |
         cd /tmp
@@ -104,7 +104,7 @@ jobs:
     - name: run integration test
       run: |
         echo running docker driver intergration test on ubuntu
-        ./out/e2e-linux-amd64 -test.run TestDownloadOnly -minikube-start-args=--vm-driver=none -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        ./out/e2e-linux-amd64 -minikube-start-args=--vm-driver=none -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64 2>&1 | tee ./report/testout.txt
     - name: install gopogh
       run: |
         cd /tmp

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,13 +28,49 @@ jobs:
         gopogh -in testout.json -out testout.html -name "docker ubuntu" -repo github.com/kubernetes/minikube/  || true
     - uses: actions/upload-artifact@v1
       with:
-        name: html_report
+        name: html_report_ubuntu
         path: testout.html
     - uses: actions/upload-artifact@v1
       with:
-        name: txt_report
+        name: txt_report_ubuntu
         path: testout.txt
     - uses: actions/upload-artifact@v1
       with:
-        name: json_report
+        name: json_report_ubuntu
+        path: testout.json
+
+  docker_macos:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: build binaries
+      run : |
+        make minikube-darwin-amd64
+        make e2e-darwin-amd64
+    - name: run integration test
+      run: |
+        echo running docker driver intergration test on ubuntu
+        ./out/e2e-darwin-amd64 -test.run TestDownloadOnly -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-darwin-amd64 2>&1 | tee testout.txt
+    - name: install gopogh
+      run: |
+        cd /tmp
+        GO111MODULE="on" go get github.com/medyagh/gopogh@v0.0.17 || true
+        cd -
+    - name: generate report
+      run: |
+        export PATH=${PATH}:`go env GOPATH`/bin
+        go tool test2json -t < testout.txt > testout.json || true
+        gopogh -in testout.json -out testout.html -name "docker macos" -repo github.com/kubernetes/minikube/  || true
+    - uses: actions/upload-artifact@v1
+      with:
+        name: html_report_macos
+        path: testout.html
+    - uses: actions/upload-artifact@v1
+      with:
+        name: txt_report_macos
+        path: testout.txt
+    - uses: actions/upload-artifact@v1
+      with:
+        name: json_report_macos
         path: testout.json


### PR DESCRIPTION
This PR:
add integration tests using github actions and generate reports using [gopogh](https://github.com/medyagh/gopogh)
- docker driver on ubuntu 18 04
- docker driver on mac os 
- none on ubuntu 18 04
- none on ubuntu 16 04

as seen in screenshot it generates reports that can be downloaded
<img width="353" alt="Screen Shot 2020-01-29 at 12 25 38 AM" src="https://user-images.githubusercontent.com/4564227/73339591-f0d9f980-422d-11ea-8894-1d5045f5f765.png">

later we could add uploading reports to GCS bucket using github secrets for consistantcy with jenkins


github actions has windows machines too. would accept any PR that adds windows tests to github actions as well.

