### PR TITLE
add github actions integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run a one-line script
+      run: echo Hello, world!
+    - name: Run a multi-line script
+      run: |
+        echo Add other actions to build,
+        echo test, and deploy your project.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
         cd -
     - name: generate report
       run: |
+        export PATH=${PATH}:`go env GOPATH`/bin
         go tool test2json -t < /report/testout.txt > /report/testout.json || true
         gopogh -in /report/testout.json -out /report/testout.html -name "docker ubuntu" -repo github.com/kubernetes/minikube/  || true
     - uses: actions/upload-artifact@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push]
 
 jobs:
-  build:
+  docker_ubuntu:
     runs-on: ubuntu-latest
 
     steps:
@@ -23,6 +23,7 @@ jobs:
         cd -
     - name: generate report
       run: |
+        export PATH=${PATH}:`go env GOPATH`/bin
         go tool test2json -t < testout.txt > testout.json || true
         gopogh -in testout.json -out testout.html -name "docker ubuntu" -repo github.com/kubernetes/minikube/  || true
     - uses: actions/upload-artifact@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,3 @@ jobs:
       with:
         name: html_report
         path: /testout.html
-        name: json_report
-        path: /testout.json
-        name: text_report
-        path: /testout.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,10 +12,11 @@ jobs:
       run : |
         make minikube-linux-amd64
         make e2e-linux-amd64
+        mkdir -p /report
     - name: run integration test
       run: |
         echo running docker driver intergration test on ubuntu
-        ./out/e2e-linux-amd64 '-test.run TestDownloadOnly -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64' 2>&1 | tee /testout.txt
+        ./out/e2e-linux-amd64 '-test.run TestDownloadOnly -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64' 2>&1 | tee /report/testout.txt
     - name: install gopogh
       run: |
         cd /tmp
@@ -23,9 +24,17 @@ jobs:
         cd -
     - name: generate report
       run: |
-        go tool test2json -t < /testout.txt > /testout.json || true
-        gopogh -in /testout.json -out /testout.html -name "docker ubuntu" -repo github.com/kubernetes/minikube/  || true
+        go tool test2json -t < /report/testout.txt > /report/testout.json || true
+        gopogh -in /report/testout.json -out /report/testout.html -name "docker ubuntu" -repo github.com/kubernetes/minikube/  || true
     - uses: actions/upload-artifact@v1
       with:
         name: html_report
-        path: /testout.html
+        path: /report/testout.html
+    - uses: actions/upload-artifact@v1
+      with:
+        name: txt_report
+        path: /report/testout.txt
+    - uses: actions/upload-artifact@v1
+      with:
+        name: json_report
+        path: /report/testout.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     - name: run integration test
       run: |
         echo running docker driver intergration test on ubuntu
-        ./out/e2e-linux-amd64 '-test.run TestDownloadOnly -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64' 2>&1 | tee /report/testout.txt
+        ./out/e2e-linux-amd64 '-test.run TestDownloadOnly -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64' 2>&1 | tee testout.txt
     - name: install gopogh
       run: |
         cd /tmp
@@ -25,17 +25,17 @@ jobs:
     - name: generate report
       run: |
         export PATH=${PATH}:`go env GOPATH`/bin
-        go tool test2json -t < /report/testout.txt > /report/testout.json || true
-        gopogh -in /report/testout.json -out /report/testout.html -name "docker ubuntu" -repo github.com/kubernetes/minikube/  || true
+        go tool test2json -t < testout.txt > testout.json || true
+        gopogh -in testout.json -out testout.html -name "docker ubuntu" -repo github.com/kubernetes/minikube/  || true
     - uses: actions/upload-artifact@v1
       with:
         name: html_report
-        path: /report/testout.html
+        path: testout.html
     - uses: actions/upload-artifact@v1
       with:
         name: txt_report
-        path: /report/testout.txt
+        path: testout.txt
     - uses: actions/upload-artifact@v1
       with:
         name: json_report
-        path: /report/testout.json
+        path: testout.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,10 @@ jobs:
     - name: run integration test
       run: |
         echo running docker driver intergration test on ubuntu
-        ./out/e2e-linux-amd64 '-test.run TestStartStop TestDownloadOnly -minikube-start-args=--vm-driver=docker ' -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64 2>&1 | tee testout.txt"
+        ./out/e2e-linux-amd64 '-test.run TestStartStop TestDownloadOnly -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64' 2>&1 | tee testout.txt 
         echo converting test output to human readable format
+    - name: generate report
+      run: |
         go tool test2json -t < "testout.txt" > "testout.json" || true
         gopogh -in "testout.json" -out "/tmp/testout.html" -name "docker ubuntu" -repo github.com/kubernetes/minikube/  || true 
     - uses: actions/upload-artifact@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,15 +15,14 @@ jobs:
     - name: run integration test
       run: |
         echo running docker driver intergration test on ubuntu
-        ./out/e2e-linux-amd64 '-test.run TestDownloadOnly -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64' 2>&1 | tee /tmp/testout.txt 
+        ./out/e2e-linux-amd64 '-test.run TestDownloadOnly -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64' 2>&1 | tee /tmp/testout.txt
     - name: generate report
       run: |
-        echo converting test output to human readable format
         cd /tmp
-        GO111MODULE="on" go get -u github.com/medyagh/gopogh@v0.0.17 || true
+        GO111MODULE="on" go get github.com/medyagh/gopogh@v0.0.17 || true
         cd -
         go tool test2json -t < /tmp/testout.txt > /tmp/testout.json || true
-        gopogh -in /tmp/testout.json -out /tmp/testout.html -name "docker ubuntu" -repo github.com/kubernetes/minikube/  || true 
+        gopogh -in /tmp/testout.json -out /tmp/testout.html -name "docker ubuntu" -repo github.com/kubernetes/minikube/  || true
     - uses: actions/upload-artifact@v1
       with:
         name: report

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     - name: run integration test
       run: |
         echo running docker driver intergration test on ubuntu
-        ./out/e2e-linux-amd64 '-test.run TestDownloadOnly -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64' 2>&1 | tee testout.txt
+        ./out/e2e-linux-amd64 -test.run TestDownloadOnly -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64 2>&1 | tee testout.txt
     - name: install gopogh
       run: |
         cd /tmp
@@ -23,7 +23,6 @@ jobs:
         cd -
     - name: generate report
       run: |
-        export PATH=${PATH}:`go env GOPATH`/bin
         go tool test2json -t < testout.txt > testout.json || true
         gopogh -in testout.json -out testout.html -name "docker ubuntu" -repo github.com/kubernetes/minikube/  || true
     - uses: actions/upload-artifact@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,5 +24,5 @@ jobs:
         gopogh -in "testout.json" -out "/tmp/testout.html" -name "docker ubuntu" -repo github.com/kubernetes/minikube/  || true 
     - uses: actions/upload-artifact@v1
       with:
-        name: html report
+        name: report
         path: /tmp/testout.html

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,23 +9,22 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: build binaries
-    - shell: bash
-      run: |
+      run : |
         make minikube-linux-amd64
         make e2e-linux-amd64
     - name: run integration test
-      - shell: bash
-        run: |
-        ./out/e2e-linux-amd64 '-test.run TestDownloadOnly -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64' 2>&1 | tee /tmp/testout.txt
+      run: |
+        echo running docker driver intergration test on ubuntu
+        ./out/e2e-linux-amd64 '-test.run TestStartStop TestDownloadOnly -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64' 2>&1 | tee /tmp/testout.txt 
     - name: generate report
-      - shell: bash
-        run: |
+      run: |
+        echo converting test output to human readable format
         cd /tmp
         GO111MODULE="on" go get -u github.com/medyagh/gopogh@v0.0.17 || true
         cd -
-        go tool test2json -t < "/tmp/testout.txt" > "/tmp/testout.json" || true
-        gopogh -in "/tmp/testout.json" -out "/tmp/testout.html" -name "docker ubuntu" -repo github.com/kubernetes/minikube/  || true 
+        go tool test2json -t < /tmp/testout.txt > /tmp/testout.json || true
+        gopogh -in /tmp/testout.json -out /tmp/testout.html -name "docker ubuntu" -repo github.com/kubernetes/minikube/  || true 
     - uses: actions/upload-artifact@v1
       with:
-        name: html report
+        name: report
         path: /tmp/testout.html

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     - name: run integration test
       run: |
         echo running docker driver intergration test on ubuntu
-        ./out/e2e-linux-amd64 '-test.run TestStartStop TestDownloadOnly -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64' 2>&1 | tee /tmp/testout.txt 
+        ./out/e2e-linux-amd64 '-test.run TestDownloadOnly -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64' 2>&1 | tee /tmp/testout.txt 
     - name: generate report
       run: |
         echo converting test output to human readable format

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,6 @@ jobs:
       run : |
         make minikube-linux-amd64
         make e2e-linux-amd64
-        mkdir -p /report
     - name: run integration test
       run: |
         echo running docker driver intergration test on ubuntu

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,15 +15,21 @@ jobs:
     - name: run integration test
       run: |
         echo running docker driver intergration test on ubuntu
-        ./out/e2e-linux-amd64 '-test.run TestDownloadOnly -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64' 2>&1 | tee /tmp/testout.txt
-    - name: generate report
+        ./out/e2e-linux-amd64 '-test.run TestDownloadOnly -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64' 2>&1 | tee /testout.txt
+    - name: install gopogh
       run: |
         cd /tmp
         GO111MODULE="on" go get github.com/medyagh/gopogh@v0.0.17 || true
         cd -
-        go tool test2json -t < /tmp/testout.txt > /tmp/testout.json || true
-        gopogh -in /tmp/testout.json -out /tmp/testout.html -name "docker ubuntu" -repo github.com/kubernetes/minikube/  || true
+    - name: generate report
+      run: |
+        go tool test2json -t < /testout.txt > /testout.json || true
+        gopogh -in /testout.json -out /testout.html -name "docker ubuntu" -repo github.com/kubernetes/minikube/  || true
     - uses: actions/upload-artifact@v1
       with:
-        name: report
-        path: /tmp/testout.html
+        name: html_report
+        path: /testout.html
+        name: json_report
+        path: /testout.json
+        name: text_report
+        path: /testout.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,14 +4,25 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
-    - name: Run a one-line script
-      run: echo Hello, world!
+    - name: build binaries
+      run : |
+        make minikube-linux-amd64
+        make e2e-linux-amd64
+        cd /tmp
+        GO111MODULE="on" go get -u github.com/medyagh/gopogh@v0.0.17 || true
+        cd -
     - name: run integration test
       run: |
         echo running docker driver intergration test on ubuntu
-        env TEST_ARGS="-minikube-start-args=--vm-driver=docker" make integration
+        ./out/e2e-linux-amd64 '-test.run TestStartStop TestDownloadOnly -minikube-start-args=--vm-driver=docker ' -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64 2>&1 | tee testout.txt"
+        echo converting test output to human readable format
+        go tool test2json -t < "testout.txt" > "testout.json" || true
+        gopogh -in "testout.json" -out "/tmp/testout.html" -name "docker ubuntu" -repo github.com/kubernetes/minikube/  || true 
+    - uses: actions/upload-artifact@v1
+      with:
+        name: html report
+        path: /tmp/testout.html

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run a one-line script
       run: echo Hello, world!
-    - name: Run a multi-line script
+    - name: run integration test
       run: |
-        echo Add other actions to build,
-        echo test, and deploy your project.
+        echo running docker driver intergration test on ubuntu
+        env TEST_ARGS="-minikube-start-args=--vm-driver=docker" make integration

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,20 +9,23 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: build binaries
-      run : |
+    - shell: bash
+      run: |
         make minikube-linux-amd64
         make e2e-linux-amd64
     - name: run integration test
-      run: |
-        echo running docker driver intergration test on ubuntu
-        ./out/e2e-linux-amd64 '-test.run TestStartStop TestDownloadOnly -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64' 2>&1 | tee testout.txt 
+      - shell: bash
+        run: |
+        ./out/e2e-linux-amd64 '-test.run TestDownloadOnly -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64' 2>&1 | tee /tmp/testout.txt
     - name: generate report
-      run: |
-        echo converting test output to human readable format
+      - shell: bash
+        run: |
+        cd /tmp
         GO111MODULE="on" go get -u github.com/medyagh/gopogh@v0.0.17 || true
-        go tool test2json -t < "testout.txt" > "testout.json" || true
-        gopogh -in "testout.json" -out "/tmp/testout.html" -name "docker ubuntu" -repo github.com/kubernetes/minikube/  || true 
+        cd -
+        go tool test2json -t < "/tmp/testout.txt" > "/tmp/testout.json" || true
+        gopogh -in "/tmp/testout.json" -out "/tmp/testout.html" -name "docker ubuntu" -repo github.com/kubernetes/minikube/  || true 
     - uses: actions/upload-artifact@v1
       with:
-        name: report
+        name: html report
         path: /tmp/testout.html

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,16 +12,14 @@ jobs:
       run : |
         make minikube-linux-amd64
         make e2e-linux-amd64
-        cd /tmp
-        GO111MODULE="on" go get -u github.com/medyagh/gopogh@v0.0.17 || true
-        cd -
     - name: run integration test
       run: |
         echo running docker driver intergration test on ubuntu
         ./out/e2e-linux-amd64 '-test.run TestStartStop TestDownloadOnly -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64' 2>&1 | tee testout.txt 
-        echo converting test output to human readable format
     - name: generate report
       run: |
+        echo converting test output to human readable format
+        GO111MODULE="on" go get -u github.com/medyagh/gopogh@v0.0.17 || true
         go tool test2json -t < "testout.txt" > "testout.json" || true
         gopogh -in "testout.json" -out "/tmp/testout.html" -name "docker ubuntu" -repo github.com/kubernetes/minikube/  || true 
     - uses: actions/upload-artifact@v1


### PR DESCRIPTION
This PR:
add integration tests using github actions and generate reports using [gopogh](https://github.com/medyagh/gopogh)
- docker driver on ubuntu 18 04
- docker driver on mac os 
- none on ubuntu 18 04
- none on ubuntu 16 04

as seen in screenshot it generates reports that can be downloaded
<img width="353" alt="Screen Shot 2020-01-29 at 12 25 38 AM" src="https://user-images.githubusercontent.com/4564227/73339591-f0d9f980-422d-11ea-8894-1d5045f5f765.png">

later we could add uploading reports to GCS bucket using github secrets for consistantcy with jenkins


github actions has windows machines too. would accept any PR that adds windows tests to github actions as well.

