### PR TITLE
Add a 2-second timeout to driver detection commands

### DIFF
--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -17,8 +17,10 @@ limitations under the License.
 package docker
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
+	"time"
 
 	"github.com/docker/machine/libmachine/drivers"
 	"k8s.io/minikube/pkg/drivers/kic"
@@ -59,8 +61,11 @@ func status() registry.State {
 	if err != nil {
 		return registry.State{Error: err, Installed: false, Healthy: false, Fix: "Docker is required.", Doc: "https://minikube.sigs.k8s.io/docs/reference/drivers/kic/"}
 	}
+	// Allow no more than 2 seconds for querying state
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
 
-	err = exec.Command("docker", "info").Run()
+	err = exec.CommandContext(ctx, "docker", "info").Run()
 	if err != nil {
 		return registry.State{Error: err, Installed: true, Healthy: false, Fix: "Docker is not running. Try: restarting docker desktop."}
 	}

--- a/pkg/minikube/registry/drvs/hyperkit/hyperkit.go
+++ b/pkg/minikube/registry/drvs/hyperkit/hyperkit.go
@@ -19,6 +19,7 @@ limitations under the License.
 package hyperkit
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -87,7 +88,11 @@ func status() registry.State {
 		return registry.State{Error: err, Fix: "Run 'brew install hyperkit'", Doc: docURL}
 	}
 
-	cmd := exec.Command(path, "-v")
+	// Allow no more than 2 seconds for querying state
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, path, "-v")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return registry.State{Installed: true, Error: fmt.Errorf("%s failed:\n%s", strings.Join(cmd.Args, " "), out), Fix: "Run 'brew install hyperkit'", Doc: docURL}

--- a/pkg/minikube/registry/drvs/hyperv/hyperv.go
+++ b/pkg/minikube/registry/drvs/hyperv/hyperv.go
@@ -19,9 +19,11 @@ limitations under the License.
 package hyperv
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/docker/machine/drivers/hyperv"
 	"github.com/docker/machine/libmachine/drivers"
@@ -66,7 +68,11 @@ func status() registry.State {
 		return registry.State{Error: err}
 	}
 
-	cmd := exec.Command(path, "Get-WindowsOptionalFeature", "-FeatureName", "Microsoft-Hyper-V-All", "-Online")
+	// Allow no more than 2 seconds for querying state
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, path, "Get-WindowsOptionalFeature", "-FeatureName", "Microsoft-Hyper-V-All", "-Online")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return registry.State{Installed: false, Error: fmt.Errorf("%s failed:\n%s", strings.Join(cmd.Args, " "), out), Fix: "Start PowerShell as Administrator, and run: 'Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All'", Doc: docURL}

--- a/pkg/minikube/registry/drvs/virtualbox/virtualbox.go
+++ b/pkg/minikube/registry/drvs/virtualbox/virtualbox.go
@@ -17,9 +17,11 @@ limitations under the License.
 package virtualbox
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/docker/machine/drivers/virtualbox"
 	"github.com/docker/machine/libmachine/drivers"
@@ -75,7 +77,11 @@ func status() registry.State {
 		}
 	}
 
-	cmd := exec.Command(path, "list", "hostinfo")
+	// Allow no more than 2 seconds for querying state
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, path, "list", "hostinfo")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return registry.State{


### PR DESCRIPTION
Confirmed locally. Fixes #6228

Logs will show:

`I0129 10:59:07.582677    9816 driver.go:154] not recommending "docker" due to health: signal: killed`
