### PR TITLE
Add docker run-time for kic driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -485,8 +485,8 @@ endif
 
 .PHONY: kic-base-image
 kic-base-image: ## builds the base image used for kic.
-	docker rmi -f $(REGISTRY)/kicbase:v0.0.2-snapshot || true
-	docker build -f ./hack/images/kicbase.Dockerfile -t $(REGISTRY)/kicbase:v0.0.2-snapshot  --build-arg COMMIT_SHA=${VERSION}-$(COMMIT)  .
+	docker rmi -f $(REGISTRY)/kicbase:v0.0.3-snapshot || true
+	docker build -f ./hack/images/kicbase.Dockerfile -t $(REGISTRY)/kicbase:v0.0.3-snapshot  --build-arg COMMIT_SHA=${VERSION}-$(COMMIT)  .
 
 
 

--- a/hack/images/kicbase.Dockerfile
+++ b/hack/images/kicbase.Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y \
   sudo \
   dnsutils \
   openssh-server \
+  docker.io \
   && apt-get clean -y 
 # based on https://github.com/rastasheep/ubuntu-sshd/blob/master/18.04/Dockerfile
 # making SSH work for docker container 
@@ -28,7 +29,7 @@ RUN rm -rf \
     /kind/bin/kubeadm /kind/bin/kubelet /kind/systemd /kind/images /kind/manifests
 RUN echo "kic! Build: ${COMMIT_SHA} Time :$(date)" > "/kic.txt"
 # for minikube ssh. to match VM using docker username
-RUN adduser --disabled-password --gecos '' docker
+RUN adduser --ingroup docker --disabled-password --gecos '' docker 
 RUN adduser docker sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER docker

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -43,7 +43,7 @@ const DefaultPodCIDR = "10.244.0.0/16"
 const DefaultBindIPV4 = "127.0.0.1"
 
 // BaseImage is the base image is used to spin up kic containers created by kind.
-const BaseImage = "gcr.io/k8s-minikube/kicbase:v0.0.2@sha256:8f531b90901721a7bd4e67ceffbbc7ee6c4292b0e6d1a9d6eb59f117d57bc4e9"
+const BaseImage = "gcr.io/k8s-minikube/kicbase:v0.0.3@sha256:34db5e30f8830c0d5e49b62f3ea6b2844f805980592fe0084cbea799bfb12664"
 
 // OverlayImage is the cni plugin used for overlay image, created by kind.
 const OverlayImage = "kindest/kindnetd:0.5.3"
@@ -108,6 +108,10 @@ func (d *Driver) Create() error {
 		oci.PortMapping{
 			ListenAddress: DefaultBindIPV4,
 			ContainerPort: constants.SSHPort,
+		},
+		oci.PortMapping{
+			ListenAddress: DefaultBindIPV4,
+			ContainerPort: constants.DockerDaemonPort,
 		},
 	)
 	_, err := node.CreateNode(params)

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -543,7 +543,7 @@ func GetHostDockerEnv(api libmachine.API) (map[string]string, error) {
 	}
 
 	ip := kic.DefaultBindIPV4
-	if !driver.IsKIC(host.Driver.DriverName()) { // unlike VM drivers, kic externaly accessible ip is different that node ip
+	if !driver.IsKIC(host.Driver.DriverName()) { // unlike VM drivers, kic externally accessible ip is different that node ip
 		ip, err = host.Driver.GetIP()
 		if err != nil {
 			return nil, errors.Wrap(err, "Error getting ip from host")
@@ -553,7 +553,7 @@ func GetHostDockerEnv(api libmachine.API) (map[string]string, error) {
 
 	tcpPrefix := "tcp://"
 	port := constants.DockerDaemonPort
-	if driver.IsKIC(host.Driver.DriverName()) {
+	if driver.IsKIC(host.Driver.DriverName()) { // for kic we need to find out what port docker allocated during creation
 		port, err = oci.HostPortBinding(host.Driver.DriverName(), pName, constants.DockerDaemonPort)
 		if err != nil {
 			return nil, errors.Wrapf(err, "get hostbind port for %d", constants.DockerDaemonPort)

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -543,7 +543,7 @@ func GetHostDockerEnv(api libmachine.API) (map[string]string, error) {
 	}
 
 	ip := kic.DefaultBindIPV4
-	if !driver.IsKIC(host.Driver.DriverName()) { // unlike VM drivers, kic externally accessible ip is different that node ip
+	if !driver.IsKIC(host.Driver.DriverName()) { // kic externally accessible ip is different that node ip
 		ip, err = host.Driver.GetIP()
 		if err != nil {
 			return nil, errors.Wrap(err, "Error getting ip from host")

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -47,6 +47,8 @@ import (
 	"github.com/shirou/gopsutil/mem"
 	"github.com/spf13/viper"
 
+	"k8s.io/minikube/pkg/drivers/kic"
+	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/command"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
@@ -534,21 +536,33 @@ func createHost(api libmachine.API, cfg config.MachineConfig) (*host.Host, error
 
 // GetHostDockerEnv gets the necessary docker env variables to allow the use of docker through minikube's vm
 func GetHostDockerEnv(api libmachine.API) (map[string]string, error) {
-	host, err := CheckIfHostExistsAndLoad(api, viper.GetString(config.MachineProfile))
+	pName := viper.GetString(config.MachineProfile)
+	host, err := CheckIfHostExistsAndLoad(api, pName)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error checking that api exists and loading it")
 	}
-	ip, err := host.Driver.GetIP()
-	if err != nil {
-		return nil, errors.Wrap(err, "Error getting ip from host")
+
+	ip := kic.DefaultBindIPV4
+	if !driver.IsKIC(host.Driver.DriverName()) { // unlike VM drivers, kic externaly accessible ip is different that node ip
+		ip, err = host.Driver.GetIP()
+		if err != nil {
+			return nil, errors.Wrap(err, "Error getting ip from host")
+		}
+
 	}
 
 	tcpPrefix := "tcp://"
-	port := "2376"
+	port := constants.DockerDaemonPort
+	if driver.IsKIC(host.Driver.DriverName()) {
+		port, err = oci.HostPortBinding(host.Driver.DriverName(), pName, constants.DockerDaemonPort)
+		if err != nil {
+			return nil, errors.Wrapf(err, "get hostbind port for %d", constants.DockerDaemonPort)
+		}
+	}
 
 	envMap := map[string]string{
 		"DOCKER_TLS_VERIFY": "1",
-		"DOCKER_HOST":       tcpPrefix + net.JoinHostPort(ip, port),
+		"DOCKER_HOST":       tcpPrefix + net.JoinHostPort(ip, fmt.Sprint(port)),
 		"DOCKER_CERT_PATH":  localpath.MakeMiniPath("certs"),
 	}
 	return envMap, nil

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -27,6 +27,8 @@ import (
 )
 
 const (
+	// DockerDaemonPort is the port Docker daemon listening inside a minikube node (vm or container).
+	DockerDaemonPort = 2376
 	// SSHPort is the SSH serviceport on the node vm and container
 	SSHPort = 22
 	// APIServerPort is the default API server port

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -108,7 +108,6 @@ func FlagDefaults(name string) FlagHints {
 		fh.CacheImages = true
 		// only for kic, till other run-times are available we auto-set containerd.
 		if name == Docker {
-			fh.ContainerRuntime = "containerd"
 			fh.ExtraOptions = append(fh.ExtraOptions, fmt.Sprintf("kubeadm.pod-network-cidr=%s", kic.DefaultPodCIDR))
 		}
 		return fh


### PR DESCRIPTION
Before this PR:
- only containerd runtime was supported by kic drivers (docker driver)

After this PR:
- Add Docker container run time options to Kic Drivers (docker)
- Remove Auto-setting container runtime to containerd for kic drivers (the default is back to docker)
- Enable using minikube docker-env

closes https://github.com/kubernetes/minikube/issues/6433
