### PR TITLE
status: Explicitly state that the cluster does not exist

### DIFF
--- a/cmd/minikube/cmd/status_test.go
+++ b/cmd/minikube/cmd/status_test.go
@@ -31,6 +31,7 @@ func TestExitCode(t *testing.T) {
 		{"ok", 0, &Status{Host: "Running", Kubelet: "Running", APIServer: "Running", Kubeconfig: Configured}},
 		{"paused", 2, &Status{Host: "Running", Kubelet: "Stopped", APIServer: "Paused", Kubeconfig: Configured}},
 		{"down", 7, &Status{Host: "Stopped", Kubelet: "Stopped", APIServer: "Stopped", Kubeconfig: Misconfigured}},
+		{"missing", 7, &Status{Host: "Nonexistent", Kubelet: "Nonexistent", APIServer: "Nonexistent", Kubeconfig: "Nonexistent"}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
While debugging a local integration test failure that said the cluster status was "", I dug in and noticed that "minikube status" on a nonexistent cluster emits no error:

```
host: 
kubelet: 
apiserver: 
kubeconfig: 
```

This PR changes the behavior to emit an error to stderr, and populate the fields with "Nonexistent":

```
E0130 14:43:04.992476    7478 status.go:98] The "minikube" cluster does not exist!
host: Nonexistent
kubelet: Nonexistent
apiserver: Nonexistent
kubeconfig: Nonexistent
```

With `-o json`, it emits:

```
E0130 14:43:07.520741    7534 status.go:98] The "minikube" cluster does not exist!
{"Host":"Nonexistent","Kubelet":"Nonexistent","APIServer":"Nonexistent","Kubeconfig":"Nonexistent"} 
```
