### PR TITLE
Add addon enablement to start

### DIFF
--- a/cmd/minikube/cmd/config/addons_list.go
+++ b/cmd/minikube/cmd/config/addons_list.go
@@ -104,7 +104,7 @@ var printAddonsList = func() {
 		addonBundle := assets.Addons[addonName]
 		addonStatus, err := addonBundle.IsEnabled()
 		if err != nil {
-			exit.WithError("Error getting addons status", err)
+			out.WarningT("Unable to get addon status for {{.name}}: {{.error}}", out.V{"name": addonName, "error": err})
 		}
 		tData = append(tData, []string{addonName, pName, fmt.Sprintf("%s %s", stringFromStatus(addonStatus), iconFromStatus(addonStatus))})
 	}
@@ -114,12 +114,11 @@ var printAddonsList = func() {
 
 	v, _, err := config.ListProfiles()
 	if err != nil {
-		glog.Infof("error getting list of porfiles: %v", err)
+		glog.Errorf("list profiles returned error: %v", err)
 	}
 	if len(v) > 1 {
 		out.T(out.Tip, "To see addons list for other profiles use: `minikube addons -p name list`")
 	}
-
 }
 
 var printAddonsJSON = func() {
@@ -137,7 +136,8 @@ var printAddonsJSON = func() {
 
 		addonStatus, err := addonBundle.IsEnabled()
 		if err != nil {
-			exit.WithError("Error getting addons status", err)
+			glog.Errorf("Unable to get addon status for {{.name}}: {{.error}}", err)
+			continue
 		}
 
 		addonsMap[addonName] = map[string]interface{}{

--- a/cmd/minikube/cmd/config/addons_list.go
+++ b/cmd/minikube/cmd/config/addons_list.go
@@ -136,7 +136,7 @@ var printAddonsJSON = func() {
 
 		addonStatus, err := addonBundle.IsEnabled()
 		if err != nil {
-			glog.Errorf("Unable to get addon status for {{.name}}: {{.error}}", err)
+			glog.Errorf("Unable to get addon status for %s: %v", addonName, err)
 			continue
 		}
 

--- a/cmd/minikube/cmd/config/addons_list.go
+++ b/cmd/minikube/cmd/config/addons_list.go
@@ -102,7 +102,7 @@ var printAddonsList = func() {
 
 	for _, addonName := range addonNames {
 		addonBundle := assets.Addons[addonName]
-		addonStatus, err := addonBundle.IsEnabled()
+		addonStatus, err := addonBundle.IsEnabled(pName)
 		if err != nil {
 			out.WarningT("Unable to get addon status for {{.name}}: {{.error}}", out.V{"name": addonName, "error": err})
 		}
@@ -134,7 +134,7 @@ var printAddonsJSON = func() {
 	for _, addonName := range addonNames {
 		addonBundle := assets.Addons[addonName]
 
-		addonStatus, err := addonBundle.IsEnabled()
+		addonStatus, err := addonBundle.IsEnabled(pName)
 		if err != nil {
 			glog.Errorf("Unable to get addon status for %s: %v", addonName, err)
 			continue

--- a/cmd/minikube/cmd/config/disable.go
+++ b/cmd/minikube/cmd/config/disable.go
@@ -39,7 +39,7 @@ var addonsDisableCmd = &cobra.Command{
 		if err != nil {
 			exit.WithError("disable failed", err)
 		}
-		out.SuccessT(`"{{.minikube_addon}}" was successfully disabled`, out.V{"minikube_addon": addon})
+		out.T(out.AddonDisable, `"The '{{.minikube_addon}}' addon is disabled`, out.V{"minikube_addon": addon})
 	},
 }
 

--- a/cmd/minikube/cmd/config/enable.go
+++ b/cmd/minikube/cmd/config/enable.go
@@ -33,13 +33,12 @@ var addonsEnableCmd = &cobra.Command{
 		if len(args) != 1 {
 			exit.UsageT("usage: minikube addons enable ADDON_NAME")
 		}
-
 		addon := args[0]
 		err := addons.Set(addon, "true", viper.GetString(config.MachineProfile))
 		if err != nil {
 			exit.WithError("enable failed", err)
 		}
-		out.SuccessT("{{.addonName}} was successfully enabled", out.V{"addonName": addon})
+		out.T(out.AddonEnable, "The '{{.addonName}}' addon is enabled", out.V{"addonName": addon})
 	},
 }
 

--- a/cmd/minikube/cmd/config/open.go
+++ b/cmd/minikube/cmd/config/open.go
@@ -27,11 +27,11 @@ import (
 	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/cluster"
+	pkg_config "k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/machine"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/service"
-	pkg_config "k8s.io/minikube/pkg/minikube/config"
 )
 
 var (

--- a/cmd/minikube/cmd/config/open.go
+++ b/cmd/minikube/cmd/config/open.go
@@ -24,12 +24,14 @@ import (
 	"github.com/pkg/browser"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/cluster"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/machine"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/service"
+	pkg_config "k8s.io/minikube/pkg/minikube/config"
 )
 
 var (
@@ -66,7 +68,8 @@ var addonsOpenCmd = &cobra.Command{
 		}
 		defer api.Close()
 
-		if !cluster.IsMinikubeRunning(api) {
+		profileName := viper.GetString(pkg_config.MachineProfile)
+		if !cluster.IsHostRunning(api, profileName) {
 			os.Exit(1)
 		}
 		addon, ok := assets.Addons[addonName] // validate addon input
@@ -75,7 +78,7 @@ var addonsOpenCmd = &cobra.Command{
 To see the list of available addons run:
 minikube addons list`, out.V{"name": addonName})
 		}
-		ok, err = addon.IsEnabled()
+		ok, err = addon.IsEnabled(profileName)
 		if err != nil {
 			exit.WithError("IsEnabled failed", err)
 		}

--- a/cmd/minikube/cmd/config/profile.go
+++ b/cmd/minikube/cmd/config/profile.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	pkgConfig "k8s.io/minikube/pkg/minikube/config"
+	pkg_config "k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/kubeconfig"
@@ -78,7 +79,7 @@ var ProfileCmd = &cobra.Command{
 		}
 		cc, err := pkgConfig.Load(profile)
 		// might err when loading older version of cfg file that doesn't have KeepContext field
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !pkg_config.IsNotExist(err) {
 			out.ErrT(out.Sad, `Error loading profile config: {{.error}}`, out.V{"error": err})
 		}
 		if err == nil {

--- a/cmd/minikube/cmd/config/profile_list.go
+++ b/cmd/minikube/cmd/config/profile_list.go
@@ -141,7 +141,7 @@ var printProfilesJSON = func() {
 
 	var body = map[string]interface{}{}
 
-	if err == nil || os.IsNotExist(err) {
+	if err == nil || config.IsNotExist(err) {
 		body["valid"] = valid
 		body["invalid"] = invalid
 		jsonString, _ := json.Marshal(body)

--- a/cmd/minikube/cmd/dashboard.go
+++ b/cmd/minikube/cmd/dashboard.go
@@ -36,7 +36,6 @@ import (
 	pkgaddons "k8s.io/minikube/pkg/addons"
 	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/cluster"
-	"k8s.io/minikube/pkg/minikube/config"
 	pkg_config "k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/machine"
@@ -103,18 +102,18 @@ var dashboardCmd = &cobra.Command{
 			exit.WithCodeT(exit.NoInput, "kubectl not found in PATH, but is required for the dashboard. Installation guide: https://kubernetes.io/docs/tasks/tools/install-kubectl/")
 		}
 
-		if !cluster.IsMinikubeRunning(api) {
+		if !cluster.IsHostRunning(api, profileName) {
 			os.Exit(1)
 		}
 
 		// Check dashboard status before enabling it
 		dashboardAddon := assets.Addons["dashboard"]
-		dashboardStatus, _ := dashboardAddon.IsEnabled()
+		dashboardStatus, _ := dashboardAddon.IsEnabled(profileName)
 		if !dashboardStatus {
 			// Send status messages to stderr for folks re-using this output.
 			out.ErrT(out.Enabling, "Enabling dashboard ...")
 			// Enable the dashboard add-on
-			err = pkgaddons.Set("dashboard", "true", viper.GetString(config.MachineProfile))
+			err = pkgaddons.Set("dashboard", "true", profileName)
 			if err != nil {
 				exit.WithError("Unable to enable dashboard", err)
 			}

--- a/cmd/minikube/cmd/dashboard.go
+++ b/cmd/minikube/cmd/dashboard.go
@@ -60,7 +60,7 @@ var dashboardCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		profileName := viper.GetString(pkg_config.MachineProfile)
 		cc, err := pkg_config.Load(profileName)
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !pkg_config.IsNotExist(err) {
 			exit.WithError("Error loading profile config", err)
 		}
 

--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -188,7 +188,7 @@ func deleteProfile(profile *pkg_config.Profile) error {
 	}
 	defer api.Close()
 	cc, err := pkg_config.Load(profile.Name)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !pkg_config.IsNotExist(err) {
 		delErr := profileDeletionErr(profile.Name, fmt.Sprintf("error loading profile config: %v", err))
 		return DeletionError{Err: delErr, Errtype: MissingProfile}
 	}
@@ -223,7 +223,7 @@ func deleteProfile(profile *pkg_config.Profile) error {
 	deleteProfileDirectory(profile.Name)
 
 	if err := pkg_config.DeleteProfile(profile.Name); err != nil {
-		if os.IsNotExist(err) {
+		if pkg_config.IsNotExist(err) {
 			delErr := profileDeletionErr(profile.Name, fmt.Sprintf("\"%s\" profile does not exist", profile.Name))
 			return DeletionError{Err: delErr, Errtype: MissingProfile}
 		}

--- a/cmd/minikube/cmd/kubectl.go
+++ b/cmd/minikube/cmd/kubectl.go
@@ -27,7 +27,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/config"
-	pkg_config "k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/machine"
@@ -51,8 +50,8 @@ minikube kubectl -- get pods --namespace kube-system`,
 		}
 		defer api.Close()
 
-		cc, err := pkg_config.Load(viper.GetString(config.MachineProfile))
-		if err != nil && !os.IsNotExist(err) {
+		cc, err := config.Load(viper.GetString(config.MachineProfile))
+		if err != nil && !config.IsNotExist(err) {
 			out.ErrLn("Error loading profile config: %v", err)
 		}
 

--- a/cmd/minikube/cmd/pause.go
+++ b/cmd/minikube/cmd/pause.go
@@ -53,7 +53,7 @@ func runPause(cmd *cobra.Command, args []string) {
 	defer api.Close()
 	cc, err := config.Load(cname)
 
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !config.IsNotExist(err) {
 		exit.WithError("Error loading profile config", err)
 	}
 

--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -25,8 +25,10 @@ import (
 	"github.com/golang/glog"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"k8s.io/minikube/pkg/minikube/cluster"
+	pkg_config "k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/machine"
 	"k8s.io/minikube/pkg/minikube/out"
@@ -71,7 +73,8 @@ var serviceCmd = &cobra.Command{
 		}
 		defer api.Close()
 
-		if !cluster.IsMinikubeRunning(api) {
+		profileName := viper.GetString(pkg_config.MachineProfile)
+		if !cluster.IsHostRunning(api, profileName) {
 			os.Exit(1)
 		}
 

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -46,6 +46,7 @@ import (
 	"github.com/spf13/viper"
 	"golang.org/x/sync/errgroup"
 	cmdcfg "k8s.io/minikube/cmd/minikube/cmd/config"
+	"k8s.io/minikube/pkg/addons"
 	"k8s.io/minikube/pkg/minikube/bootstrapper"
 	"k8s.io/minikube/pkg/minikube/bootstrapper/bsutil"
 	"k8s.io/minikube/pkg/minikube/bootstrapper/images"
@@ -56,7 +57,6 @@ import (
 	"k8s.io/minikube/pkg/minikube/cruntime"
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/exit"
-	"k8s.io/minikube/pkg/addons"
 	"k8s.io/minikube/pkg/minikube/kubeconfig"
 	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/minikube/logs"
@@ -171,7 +171,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().String(containerRuntime, "docker", "The container runtime to be used (docker, crio, containerd).")
 	startCmd.Flags().Bool(createMount, false, "This will start the mount daemon and automatically mount files into minikube.")
 	startCmd.Flags().String(mountString, constants.DefaultMountDir+":/minikube-host", "The argument to pass the minikube mount command on start.")
-	startCmd.Flags().StringArrayVar(&addonList,"addons", nil, "Enable addons. see `minikube addons list` for a list of valid addon names.")
+	startCmd.Flags().StringArrayVar(&addonList, "addons", nil, "Enable addons. see `minikube addons list` for a list of valid addon names.")
 	startCmd.Flags().String(criSocket, "", "The cri socket path to be used.")
 	startCmd.Flags().String(networkPlugin, "", "The name of the network plugin.")
 	startCmd.Flags().Bool(enableDefaultCNI, false, "Enable the default CNI plugin (/etc/cni/net.d/k8s.conf). Used in conjunction with \"--network-plugin=cni\".")

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -295,7 +295,7 @@ func runStart(cmd *cobra.Command, args []string) {
 	}
 
 	existing, err := config.Load(viper.GetString(config.MachineProfile))
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !config.IsNotExist(err) {
 		exit.WithCodeT(exit.Data, "Unable to load config: {{.error}}", out.V{"error": err})
 	}
 
@@ -751,7 +751,7 @@ func validateUser(drvName string) {
 		os.Exit(exit.Permissions)
 	}
 	_, err = config.Load(viper.GetString(config.MachineProfile))
-	if err == nil || !os.IsNotExist(err) {
+	if err == nil || !config.IsNotExist(err) {
 		out.T(out.Tip, "Tip: To remove this root owned cluster, run: sudo {{.cmd}} delete", out.V{"cmd": minikubeCmd()})
 	}
 	if !useForce {

--- a/cmd/minikube/cmd/unpause.go
+++ b/cmd/minikube/cmd/unpause.go
@@ -45,7 +45,7 @@ var unpauseCmd = &cobra.Command{
 		defer api.Close()
 		cc, err := config.Load(cname)
 
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !config.IsNotExist(err) {
 			exit.WithError("Error loading profile config", err)
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,6 @@ require (
 	golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456
 	golang.org/x/text v0.3.2
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 // indirect
-	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.2
 	k8s.io/client-go v11.0.0+incompatible

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -18,7 +18,6 @@ package addons
 
 import (
 	"fmt"
-	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -140,7 +139,7 @@ func enableOrDisableAddon(name, val, profile string) error {
 	defer api.Close()
 
 	cfg, err := config.Load(profile)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !config.IsNotExist(err) {
 		exit.WithCodeT(exit.Data, "Unable to load config: {{.error}}", out.V{"error": err})
 	}
 

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -146,7 +146,7 @@ func enableOrDisableAddon(name, val, profile string) error {
 
 	host, err := cluster.CheckIfHostExistsAndLoad(api, profile)
 	if err != nil || !cluster.IsHostRunning(api, profile) {
-		glog.Warningf("%q is not running, writing to %s=%v disk and skipping the rest (err=%v)", profile, addon.Name(), enable, err)
+		glog.Warningf("%q is not running, writing %s=%v to disk and skipping enablement (err=%v)", profile, addon.Name(), enable, err)
 		return nil
 	}
 
@@ -242,7 +242,7 @@ func enableOrDisableStorageClasses(name, val, profile string) error {
 	defer api.Close()
 
 	if !cluster.IsHostRunning(api, profile) {
-		glog.Warningf("%q is not running, writing to %s=%v disk and skipping enablement", profile, name, val)
+		glog.Warningf("%q is not running, writing %s=%v to disk and skipping enablement", profile, name, val)
 		return enableOrDisableAddon(name, val, profile)
 	}
 

--- a/pkg/addons/addons_test.go
+++ b/pkg/addons/addons_test.go
@@ -17,93 +17,115 @@ limitations under the License.
 package addons
 
 import (
-	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
-	"gotest.tools/assert"
 	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/localpath"
 )
 
+func createTestProfile(t *testing.T) string {
+	t.Helper()
+	td, err := ioutil.TempDir("", "profile")
+	if err != nil {
+		t.Fatalf("tempdir: %v", err)
+	}
+
+	err = os.Setenv(localpath.MinikubeHome, td)
+	if err != nil {
+		t.Errorf("error setting up test environment. could not set %s", localpath.MinikubeHome)
+	}
+
+	// Not necessary, but it is a handy random alphanumeric
+	name := filepath.Base(td)
+	if err := os.MkdirAll(config.ProfileFolderPath(name), 0777); err != nil {
+		t.Fatalf("error creating temporary directory")
+	}
+	if err := config.DefaultLoader.WriteConfigToFile(name, &config.MachineConfig{}); err != nil {
+		t.Fatalf("error creating temporary profile config: %v", err)
+	}
+	return name
+}
+
 func TestIsAddonAlreadySet(t *testing.T) {
-	testCases := []struct {
-		addonName string
-	}{
-		{
-			addonName: "ingress",
-		},
-
-		{
-			addonName: "registry",
-		},
+	profile := createTestProfile(t)
+	if err := Set("registry", "true", profile); err != nil {
+		t.Errorf("unable to set registry true: %v", err)
+	}
+	enabled, err := assets.Addons["registry"].IsEnabled(profile)
+	if err != nil {
+		t.Errorf("registry: %v", err)
+	}
+	if !enabled {
+		t.Errorf("expected registry to be enabled")
 	}
 
-	for _, test := range testCases {
-		addon := assets.Addons[test.addonName]
-		addonStatus, _ := addon.IsEnabled()
-
-		alreadySet, err := isAddonAlreadySet(addon, addonStatus)
-		if !alreadySet {
-			if addonStatus {
-				t.Errorf("Did not get expected status, \n\n expected %+v already enabled", test.addonName)
-			} else {
-				t.Errorf("Did not get expected status, \n\n expected %+v already disabled", test.addonName)
-			}
-		}
-		if err != nil {
-			t.Errorf("Got unexpected error: %+v", err)
-		}
+	enabled, err = assets.Addons["ingress"].IsEnabled(profile)
+	if err != nil {
+		t.Errorf("ingress: %v", err)
 	}
+	if enabled {
+		t.Errorf("expected ingress to not be enabled")
+	}
+
 }
 
 func TestDisableUnknownAddon(t *testing.T) {
-	tmpProfile := "temp-minikube-profile"
-	if err := Set("InvalidAddon", "false", tmpProfile); err == nil {
+	profile := createTestProfile(t)
+	if err := Set("InvalidAddon", "false", profile); err == nil {
 		t.Fatalf("Disable did not return error for unknown addon")
 	}
 }
 
 func TestEnableUnknownAddon(t *testing.T) {
-	tmpProfile := "temp-minikube-profile"
-	if err := Set("InvalidAddon", "true", tmpProfile); err == nil {
+	profile := createTestProfile(t)
+	if err := Set("InvalidAddon", "true", profile); err == nil {
 		t.Fatalf("Enable did not return error for unknown addon")
 	}
 }
 
 func TestEnableAndDisableAddon(t *testing.T) {
-	tests := []struct {
-		name   string
-		enable bool
-	}{
-		{
-			name:   "test enable",
-			enable: true,
-		}, {
-			name:   "test disable",
-			enable: false,
-		},
+	profile := createTestProfile(t)
+
+	// enable
+	if err := Set("dashboard", "true", profile); err != nil {
+		t.Errorf("Disable returned unexpected error: " + err.Error())
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			tmpProfile := "temp-minikube-profile"
-			if err := os.MkdirAll(config.ProfileFolderPath(tmpProfile), 0777); err != nil {
-				t.Fatalf("error creating temporary directory")
-			}
-			defer os.RemoveAll(config.ProfileFolderPath(tmpProfile))
+	c, err := config.DefaultLoader.LoadConfigFromFile(profile)
+	if err != nil {
+		t.Errorf("unable to load profile: %v", err)
+	}
+	if c.Addons["dashboard"] != true {
+		t.Errorf("expected dashboard to be enabled")
+	}
 
-			if err := config.DefaultLoader.WriteConfigToFile(tmpProfile, &config.MachineConfig{}); err != nil {
-				t.Fatalf("error creating temporary profile config: %v", err)
-			}
-			if err := Set("dashboard", fmt.Sprintf("%t", test.enable), tmpProfile); err != nil {
-				t.Fatalf("Disable returned unexpected error: " + err.Error())
-			}
-			c, err := config.DefaultLoader.LoadConfigFromFile(tmpProfile)
-			if err != nil {
-				t.Fatalf("error loading config: %v", err)
-			}
-			assert.Equal(t, c.Addons["dashboard"], test.enable)
-		})
+	// disable
+	if err := Set("dashboard", "false", profile); err != nil {
+		t.Errorf("Disable returned unexpected error: " + err.Error())
+	}
+
+	c, err = config.DefaultLoader.LoadConfigFromFile(profile)
+	if err != nil {
+		t.Errorf("unable to load profile: %v", err)
+	}
+	if c.Addons["dashboard"] != false {
+		t.Errorf("expected dashboard to be enabled")
+	}
+}
+
+func TestStart(t *testing.T) {
+	profile := createTestProfile(t)
+	Start(profile, []string{"dashboard"})
+
+	enabled, err := assets.Addons["dashboard"].IsEnabled(profile)
+	if err != nil {
+		t.Errorf("dashboard: %v", err)
+	}
+	if !enabled {
+		t.Errorf("expected dashboard to be enabled")
 	}
 }

--- a/pkg/addons/kubectl.go
+++ b/pkg/addons/kubectl.go
@@ -17,7 +17,6 @@ limitations under the License.
 package addons
 
 import (
-	"os"
 	"os/exec"
 	"path"
 
@@ -53,7 +52,7 @@ func kubectlCommand(profile string, files []string, enable bool) (*exec.Cmd, err
 
 func kubernetesVersion(profile string) (string, error) {
 	cc, err := config.Load(profile)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !config.IsNotExist(err) {
 		return "", err
 	}
 	version := constants.DefaultKubernetesVersion

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/config"
@@ -57,11 +58,18 @@ func (a *Addon) Name() string {
 // IsEnabled checks if an Addon is enabled for the current profile
 func (a *Addon) IsEnabled() (bool, error) {
 	c, err := config.Load(viper.GetString(config.MachineProfile))
-	if err == nil {
-		if status, ok := c.Addons[a.Name()]; ok {
-			return status, nil
-		}
+	if err != nil {
+		return false, err
 	}
+
+	// Is this addon explicitly listed in their configuration?
+	status, ok := c.Addons[a.Name()]
+	glog.Infof("IsEnabled %q = %v (listed in config=%v)", a.Name(), status, ok)
+	if ok {
+		return status, nil
+	}
+
+	// Return the default unconfigured state of the addon
 	return a.enabled, nil
 }
 

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
-	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/localpath"
@@ -55,16 +54,16 @@ func (a *Addon) Name() string {
 	return a.addonName
 }
 
-// IsEnabled checks if an Addon is enabled for the current profile
-func (a *Addon) IsEnabled() (bool, error) {
-	c, err := config.Load(viper.GetString(config.MachineProfile))
+// IsEnabled checks if an Addon is enabled for the given profile
+func (a *Addon) IsEnabled(profile string) (bool, error) {
+	c, err := config.Load(profile)
 	if err != nil {
 		return false, errors.Wrap(err, "load")
 	}
 
 	// Is this addon explicitly listed in their configuration?
 	status, ok := c.Addons[a.Name()]
-	glog.Infof("IsEnabled %q = %v (listed in config=%v)", a.Name(), status, ok)
+	glog.V(1).Infof("IsEnabled %q = %v (listed in config=%v)", a.Name(), status, ok)
 	if ok {
 		return status, nil
 	}

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -59,7 +59,7 @@ func (a *Addon) Name() string {
 func (a *Addon) IsEnabled() (bool, error) {
 	c, err := config.Load(viper.GetString(config.MachineProfile))
 	if err != nil {
-		return false, err
+		return false, errors.Wrap(err, "load")
 	}
 
 	// Is this addon explicitly listed in their configuration?

--- a/pkg/minikube/bootstrapper/bsutil/files.go
+++ b/pkg/minikube/bootstrapper/bsutil/files.go
@@ -20,7 +20,6 @@ package bsutil
 import (
 	"path"
 
-	"github.com/pkg/errors"
 	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/vmpath"
@@ -51,34 +50,4 @@ func ConfigFileAssets(cfg config.KubernetesConfig, kubeadm []byte, kubelet []byt
 		fs = append(fs, assets.NewMemoryAssetTarget(defaultCNIConfig, DefaultCNIConfigPath, "0644"))
 	}
 	return fs
-}
-
-// AddAddons adds addons to list of files
-func AddAddons(files *[]assets.CopyableFile, data interface{}) error {
-	// add addons to file list
-	// custom addons
-	if err := assets.AddMinikubeDirAssets(files); err != nil {
-		return errors.Wrap(err, "adding minikube dir assets")
-	}
-	// bundled addons
-	for _, addonBundle := range assets.Addons {
-		if isEnabled, err := addonBundle.IsEnabled(); err == nil && isEnabled {
-			for _, addon := range addonBundle.Assets {
-				if addon.IsTemplate() {
-					addonFile, err := addon.Evaluate(data)
-					if err != nil {
-						return errors.Wrapf(err, "evaluate bundled addon %s asset", addon.GetAssetName())
-					}
-
-					*files = append(*files, addonFile)
-				} else {
-					*files = append(*files, addon)
-				}
-			}
-		} else if err != nil {
-			return nil
-		}
-	}
-
-	return nil
 }

--- a/pkg/minikube/bootstrapper/bsutil/kubeadm_test.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubeadm_test.go
@@ -120,7 +120,7 @@ func TestGenerateKubeadmYAMLDNS(t *testing.T) {
 			t.Run(tname, func(t *testing.T) {
 				cfg := tc.cfg
 				cfg.Nodes = []config.Node{
-					config.Node{
+					{
 						IP:           "1.1.1.1",
 						Name:         "mk",
 						ControlPlane: true,
@@ -179,7 +179,7 @@ func TestGenerateKubeadmYAML(t *testing.T) {
 		{"options", "docker", false, config.MachineConfig{KubernetesConfig: config.KubernetesConfig{ExtraOptions: extraOpts}}},
 		{"crio-options-gates", "crio", false, config.MachineConfig{KubernetesConfig: config.KubernetesConfig{ExtraOptions: extraOpts, FeatureGates: "a=b"}}},
 		{"unknown-component", "docker", true, config.MachineConfig{KubernetesConfig: config.KubernetesConfig{ExtraOptions: config.ExtraOptionSlice{config.ExtraOption{Component: "not-a-real-component", Key: "killswitch", Value: "true"}}}}},
-		{"containerd-api-port", "containerd", false, config.MachineConfig{Nodes: []config.Node{config.Node{Port: 12345}}}},
+		{"containerd-api-port", "containerd", false, config.MachineConfig{Nodes: []config.Node{{Port: 12345}}}},
 		{"containerd-pod-network-cidr", "containerd", false, config.MachineConfig{KubernetesConfig: config.KubernetesConfig{ExtraOptions: extraOptsPodCidr}}},
 		{"image-repository", "docker", false, config.MachineConfig{KubernetesConfig: config.KubernetesConfig{ImageRepository: "test/repo"}}},
 	}
@@ -199,7 +199,7 @@ func TestGenerateKubeadmYAML(t *testing.T) {
 					cfg.Nodes[0].ControlPlane = true
 				} else {
 					cfg.Nodes = []config.Node{
-						config.Node{
+						{
 							IP:           "1.1.1.1",
 							Name:         "mk",
 							ControlPlane: true,

--- a/pkg/minikube/bootstrapper/bsutil/kubelet_test.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubelet_test.go
@@ -42,7 +42,7 @@ func TestGenerateKubeletConfig(t *testing.T) {
 					ContainerRuntime:  "docker",
 				},
 				Nodes: []config.Node{
-					config.Node{
+					{
 						IP:           "192.168.1.100",
 						Name:         "minikube",
 						ControlPlane: true,
@@ -67,7 +67,7 @@ ExecStart=/var/lib/minikube/binaries/v1.11.10/kubelet --allow-privileged=true --
 					ContainerRuntime:  "cri-o",
 				},
 				Nodes: []config.Node{
-					config.Node{
+					{
 						IP:           "192.168.1.100",
 						Name:         "minikube",
 						ControlPlane: true,
@@ -92,7 +92,7 @@ ExecStart=/var/lib/minikube/binaries/v1.17.2/kubelet --authorization-mode=Webhoo
 					ContainerRuntime:  "containerd",
 				},
 				Nodes: []config.Node{
-					config.Node{
+					{
 						IP:           "192.168.1.100",
 						Name:         "minikube",
 						ControlPlane: true,
@@ -124,7 +124,7 @@ ExecStart=/var/lib/minikube/binaries/v1.17.2/kubelet --authorization-mode=Webhoo
 					},
 				},
 				Nodes: []config.Node{
-					config.Node{
+					{
 						IP:           "192.168.1.100",
 						Name:         "minikube",
 						ControlPlane: true,
@@ -150,7 +150,7 @@ ExecStart=/var/lib/minikube/binaries/v1.17.2/kubelet --authorization-mode=Webhoo
 					ImageRepository:   "docker-proxy-image.io/google_containers",
 				},
 				Nodes: []config.Node{
-					config.Node{
+					{
 						IP:           "192.168.1.100",
 						Name:         "minikube",
 						ControlPlane: true,

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -41,7 +41,6 @@ import (
 	"k8s.io/minikube/pkg/drivers/kic"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/kapi"
-	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/bootstrapper"
 	"k8s.io/minikube/pkg/minikube/bootstrapper/bsutil"
 	"k8s.io/minikube/pkg/minikube/bootstrapper/bsutil/kverify"
@@ -483,10 +482,6 @@ func (k *Bootstrapper) UpdateCluster(cfg config.MachineConfig) error {
 		cniFile = []byte(defaultCNIConfig)
 	}
 	files := bsutil.ConfigFileAssets(cfg.KubernetesConfig, kubeadmCfg, kubeletCfg, kubeletService, cniFile)
-
-	if err := bsutil.AddAddons(&files, assets.GenerateTemplateData(cfg.KubernetesConfig)); err != nil {
-		return errors.Wrap(err, "adding addons")
-	}
 
 	// Combine mkdir request into a single call to reduce load
 	dirs := []string{}

--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -19,10 +19,11 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
 	"io/ioutil"
 	"os"
+
+	"github.com/pkg/errors"
 
 	"k8s.io/minikube/pkg/minikube/localpath"
 )

--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -54,6 +54,23 @@ var (
 	ErrKeyNotFound = errors.New("specified key could not be found in config")
 )
 
+type ErrNotExist struct {
+	s string
+}
+
+func (e *ErrNotExist) Error() string {
+	return e.s
+}
+
+// IsNotExist returns whether the error means a nonexistent configuration
+func IsNotExist(err error) bool {
+	switch err.(type) {
+	case *ErrNotExist:
+		return true
+	}
+	return false
+}
+
 // MinikubeConfig represents minikube config
 type MinikubeConfig map[string]interface{}
 
@@ -151,7 +168,7 @@ func (c *simpleConfigLoader) LoadConfigFromFile(profileName string, miniHome ...
 
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("cluster %q does not exist", profileName)
+			return nil, &ErrNotExist{fmt.Sprintf("cluster %q does not exist", profileName)}
 		}
 		return nil, errors.Wrap(err, "stat")
 	}

--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -64,8 +64,7 @@ func (e *ErrNotExist) Error() string {
 
 // IsNotExist returns whether the error means a nonexistent configuration
 func IsNotExist(err error) bool {
-	switch err.(type) {
-	case *ErrNotExist:
+	if _, ok := err.(*ErrNotExist); ok {
 		return true
 	}
 	return false

--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -18,8 +18,8 @@ package config
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
+	"github.com/pkg/errors"
 	"io"
 	"io/ioutil"
 	"os"
@@ -148,17 +148,20 @@ func (c *simpleConfigLoader) LoadConfigFromFile(profileName string, miniHome ...
 	// Move to profile package
 	path := profileFilePath(profileName, miniHome...)
 
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return nil, err
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("cluster %q does not exist", profileName)
+		}
+		return nil, errors.Wrap(err, "stat")
 	}
 
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "read")
 	}
 
 	if err := json.Unmarshal(data, &cc); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "unmarshal")
 	}
 	return &cc, nil
 }

--- a/pkg/minikube/out/style.go
+++ b/pkg/minikube/out/style.go
@@ -116,6 +116,8 @@ var styles = map[StyleEnum]style{
 	MountOptions:     {Prefix: "💾  "},
 	Fileserver:       {Prefix: "🚀  ", OmitNewline: true},
 	DryRun:           {Prefix: "🏜️   "},
+	AddonEnable:      {Prefix: "🌟  "},
+	AddonDisable:     {Prefix: "🌑  "},
 }
 
 // Add a prefix to a string

--- a/pkg/minikube/out/style_enum.go
+++ b/pkg/minikube/out/style_enum.go
@@ -87,4 +87,6 @@ const (
 	Pause
 	Unpause
 	DryRun
+	AddonEnable
+	AddonDisable
 )

--- a/pkg/minikube/tunnel/cluster_inspector_test.go
+++ b/pkg/minikube/tunnel/cluster_inspector_test.go
@@ -40,10 +40,14 @@ func TestAPIError(t *testing.T) {
 		machineAPI, configLoader, machineName,
 	}
 
-	s, r, err := inspector.getStateAndRoute()
+	_, _, err := inspector.getStateAndRoute()
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	}
 
-	if err == nil || !strings.Contains(err.Error(), "Machine does not exist") {
-		t.Errorf("cluster inspector should propagate errors from API, getStateAndRoute() returned \"%v, %v\", %v", s, r, err)
+	// Make sure we properly propagate errors upward
+	if !strings.Contains(err.Error(), "exist") {
+		t.Errorf("getStateAndRoute error=%q, expected *exist*", err)
 	}
 }
 


### PR DESCRIPTION
This PR explicitly enables addons on startup, in lieu of there being an addon-manager to do so.

There is a new line emitted during startup:

```
🚀  Launching Kubernetes ... 
🌟  Enabling addons: storage-provisioner, default-storageclass
⌛  Waiting for cluster to come online ...
```

## Behavior changes

There is also a behavioral change: if an addon is enabled/disabled, and you attempt to enable it again, it will run the underlying kubectl command. It should still be idempotent. 

I expect this will add ~1 second to our start time, but it does restore the previous behavior.

## API changes

The addons package has a new function to handle startup logic: `addons.Start()`. This obsoletes what was in `start.go:enableAddons()` and `files.go:AddAddons()`

To improve testing, the following public functions now take a profile name:

* `addon.IsEnabled()`
* `cluster.IsHostRunning()`


Fixes #6363