### PR TITLE
Fix spacing in vm driver selection log

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -594,7 +594,7 @@ func selectDriver(existing *config.MachineConfig) string {
 	if existing != nil {
 		pick, alts := driver.Choose(existing.VMDriver, options)
 		if pick.Priority == registry.Experimental {
-			exp = "experimental"
+			exp = "experimental "
 		}
 		out.T(out.Sparkle, `Selecting {{.experimental}}'{{.driver}}' driver from existing profile (alternates: {{.alternates}})`, out.V{"experimental": exp, "driver": existing.VMDriver, "alternates": alts})
 		return pick.Name

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -596,14 +596,14 @@ func selectDriver(existing *config.MachineConfig) string {
 		if pick.Priority == registry.Experimental {
 			exp = "experimental"
 		}
-		out.T(out.Sparkle, `Selecting {{.experimental}} '{{.driver}}' driver from existing profile (alternates: {{.alternates}})`, out.V{"experimental": exp, "driver": existing.VMDriver, "alternates": alts})
+		out.T(out.Sparkle, `Selecting {{.experimental}}'{{.driver}}' driver from existing profile (alternates: {{.alternates}})`, out.V{"experimental": exp, "driver": existing.VMDriver, "alternates": alts})
 		return pick.Name
 	}
 
 	if len(options) > 1 {
-		out.T(out.Sparkle, `Automatically selected the {{.experimental}} '{{.driver}}' driver (alternates: {{.alternates}})`, out.V{"experimental": exp, "driver": pick.Name, "alternates": alts})
+		out.T(out.Sparkle, `Automatically selected the {{.experimental}}'{{.driver}}' driver (alternates: {{.alternates}})`, out.V{"experimental": exp, "driver": pick.Name, "alternates": alts})
 	} else {
-		out.T(out.Sparkle, `Automatically selected the {{.experimental}} '{{.driver}}' driver`, out.V{"experimental": exp, "driver": pick.Name})
+		out.T(out.Sparkle, `Automatically selected the {{.experimental}}'{{.driver}}' driver`, out.V{"experimental": exp, "driver": pick.Name})
 	}
 
 	if pick.Name == "" {

--- a/pkg/provision/buildroot.go
+++ b/pkg/provision/buildroot.go
@@ -19,6 +19,7 @@ package provision
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
@@ -186,9 +187,29 @@ WantedBy=multi-user.target
 		return nil, err
 	}
 
-	if err := p.Service("docker", serviceaction.Restart); err != nil {
+	log.Info("Moving folder...")
+	if _, err = p.SSHCommand("sudo mv /var/lib/all_of_docker/docker.tar /docker.tar"); err != nil {
 		return nil, err
 	}
+
+	log.Info("Extracting docker images...")
+	if _, err = p.SSHCommand("sudo tar xvf /docker.tar"); err != nil {
+		return nil, err
+	}
+
+	if _, err = p.SSHCommand("sudo systemctl stop docker"); err != nil {
+		return nil, err
+	}
+
+	if _, err = p.SSHCommand("sudo systemctl start docker"); err != nil {
+		return nil, err
+	}
+
+	// if err := p.Service("docker", serviceaction.Start); err != nil {
+	// 	return nil, err
+	// }
+
+	os.Exit(1)
 	return dockerCfg, nil
 }
 

--- a/pkg/provision/buildroot.go
+++ b/pkg/provision/buildroot.go
@@ -19,7 +19,6 @@ package provision
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
@@ -187,29 +186,9 @@ WantedBy=multi-user.target
 		return nil, err
 	}
 
-	log.Info("Moving folder...")
-	if _, err = p.SSHCommand("sudo mv /var/lib/all_of_docker/docker.tar /docker.tar"); err != nil {
+	if err := p.Service("docker", serviceaction.Restart); err != nil {
 		return nil, err
 	}
-
-	log.Info("Extracting docker images...")
-	if _, err = p.SSHCommand("sudo tar xvf /docker.tar"); err != nil {
-		return nil, err
-	}
-
-	if _, err = p.SSHCommand("sudo systemctl stop docker"); err != nil {
-		return nil, err
-	}
-
-	if _, err = p.SSHCommand("sudo systemctl start docker"); err != nil {
-		return nil, err
-	}
-
-	// if err := p.Service("docker", serviceaction.Start); err != nil {
-	// 	return nil, err
-	// }
-
-	os.Exit(1)
 	return dockerCfg, nil
 }
 


### PR DESCRIPTION
Fixes #6439 

Output is now:

```
$ minikube start
😄  minikube v1.7.0-beta.1 on Debian rodete
✨  Automatically selected the 'kvm2' driver (alternates: [none docker])
```