### PR TITLE
Allow 'profiles list' to work even if a profile has no control plane

### DIFF
--- a/cmd/minikube/cmd/config/profile_list.go
+++ b/cmd/minikube/cmd/config/profile_list.go
@@ -71,14 +71,14 @@ var printProfilesTable = func() {
 	}
 	api, err := machine.NewAPIClient()
 	if err != nil {
-		glog.Infof("failed to get machine api client %v", err)
+		glog.Errorf("failed to get machine api client %v", err)
 	}
 	defer api.Close()
 
 	for _, p := range validProfiles {
 		p.Status, err = cluster.GetHostStatus(api, p.Name)
 		if err != nil {
-			glog.Infof("error getting host status for %s: %v", p.Name, err)
+			glog.Warningf("error getting host status for %s: %v", p.Name, err)
 		}
 		cp, err := config.PrimaryControlPlane(*p.Config)
 		if err != nil {
@@ -112,7 +112,7 @@ var printProfilesTable = func() {
 var printProfilesJSON = func() {
 	api, err := machine.NewAPIClient()
 	if err != nil {
-		glog.Infof("failed to get machine api client %v", err)
+		glog.Errorf("failed to get machine api client %v", err)
 	}
 	defer api.Close()
 
@@ -120,7 +120,7 @@ var printProfilesJSON = func() {
 	for _, v := range validProfiles {
 		status, err := cluster.GetHostStatus(api, v.Name)
 		if err != nil {
-			glog.Infof("error getting host status for %s: %v", v.Name, err)
+			glog.Warningf("error getting host status for %s: %v", v.Name, err)
 		}
 		v.Status = status
 	}

--- a/cmd/minikube/cmd/config/profile_list.go
+++ b/cmd/minikube/cmd/config/profile_list.go
@@ -78,11 +78,12 @@ var printProfilesTable = func() {
 	for _, p := range validProfiles {
 		p.Status, err = cluster.GetHostStatus(api, p.Name)
 		if err != nil {
-			glog.Infof("error getting host status for %v", err)
+			glog.Infof("error getting host status for %s: %v", p.Name, err)
 		}
 		cp, err := config.PrimaryControlPlane(*p.Config)
 		if err != nil {
-			exit.WithError("profile has no control plane", err)
+			glog.Errorf("%q has no control plane: %v", p.Name, err)
+			// Print the data we know about anyways
 		}
 		validData = append(validData, []string{p.Name, p.Config.VMDriver, cp.IP, strconv.Itoa(cp.Port), p.Config.KubernetesConfig.KubernetesVersion, p.Status})
 	}
@@ -119,7 +120,7 @@ var printProfilesJSON = func() {
 	for _, v := range validProfiles {
 		status, err := cluster.GetHostStatus(api, v.Name)
 		if err != nil {
-			glog.Infof("error getting host status for  %v", err)
+			glog.Infof("error getting host status for %s: %v", v.Name, err)
 		}
 		v.Status = status
 	}


### PR DESCRIPTION
Fixes bug seen in #6409 integration test.

Libraries should never cause fatal exits.
