### PR TITLE
delete: Remove confusing output when deleting a nonexistent cluster

### DIFF
--- a/pkg/minikube/out/style.go
+++ b/pkg/minikube/out/style.go
@@ -72,7 +72,7 @@ var styles = map[StyleEnum]style{
 	Option:        {Prefix: "    ▪ ", LowPrefix: lowIndent}, // Indented bullet
 	Command:       {Prefix: "    ▪ ", LowPrefix: lowIndent}, // Indented bullet
 	LogEntry:      {Prefix: "    "},                         // Indent
-	Crushed:       {Prefix: "💔  "},
+	Deleted:       {Prefix: "💀  "},
 	URL:           {Prefix: "👉  ", LowPrefix: lowIndent},
 	Documentation: {Prefix: "📘  "},
 	Issues:        {Prefix: "⁉️   "},

--- a/pkg/minikube/out/style_enum.go
+++ b/pkg/minikube/out/style_enum.go
@@ -45,7 +45,7 @@ const (
 	Option
 	Command
 	LogEntry
-	Crushed
+	Deleted
 	URL
 	Documentation
 	Issues


### PR DESCRIPTION
Since 80b4121c0652a3aa9f7fe901d2304747a7526942 - if you run "minikube delete" on a cluster that does not exist, we output a confusing error message:

```
🙄  "minikube" profile does not exist
❌  Failed to delete cluster: load: exit status 1
📌  You may need to manually remove the "minikube" VM from your hypervisor
💔  The "minikube" cluster has been deleted.
🔥  Successfully deleted profile "minikube"
```

This removes the confusing error message and outputs a terser deletion message when deleting a profile that does not exist:

```
🙄  "minikube" profile does not exist, trying anyways.
💀  Removed all traces of the "minikube" cluster.
```

Here is the behavior when the cluster does exist:

```
🔥  Deleting "minikube" in hyperkit ...
💀  Removed all traces of the "minikube" cluster.
```