### PR TITLE
Fix bugs that prevented previously-enabled addons from starting up

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -367,8 +367,12 @@ func runStart(cmd *cobra.Command, args []string) {
 	bootstrapCluster(bs, cr, mRunner, mc, preExists, isUpgrade)
 	configureMounts()
 
-	// enable addons
-	addons.Start(viper.GetString(config.MachineProfile), addonList)
+	// enable addons, both old and new!
+	existingAddons := map[string]bool{}
+	if existing != nil && existing.Addons != nil {
+		existingAddons = existing.Addons
+	}
+	addons.Start(viper.GetString(config.MachineProfile), existingAddons, addonList)
 
 	if err = cacheAndLoadImagesInConfig(); err != nil {
 		out.T(out.FailureType, "Unable to load cached images from config file.")

--- a/pkg/addons/addons_test.go
+++ b/pkg/addons/addons_test.go
@@ -119,7 +119,7 @@ func TestEnableAndDisableAddon(t *testing.T) {
 
 func TestStart(t *testing.T) {
 	profile := createTestProfile(t)
-	Start(profile, []string{"dashboard"})
+	Start(profile, map[string]bool{}, []string{"dashboard"})
 
 	enabled, err := assets.Addons["dashboard"].IsEnabled(profile)
 	if err != nil {

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -538,7 +538,7 @@ func createHost(api libmachine.API, cfg config.MachineConfig) (*host.Host, error
 	}
 
 	if err := createRequiredDirectories(h); err != nil {
-		errors.Wrap(err, "required directories")
+		return h, errors.Wrap(err, "required directories")
 	}
 
 	if driver.BareMetal(cfg.VMDriver) {

--- a/pkg/minikube/cluster/cluster.go
+++ b/pkg/minikube/cluster/cluster.go
@@ -192,7 +192,7 @@ func configureHost(h *host.Host, e *engine.Options) error {
 	}()
 
 	if err := createRequiredDirectories(h); err != nil {
-		errors.Wrap(err, "required directories")
+		return errors.Wrap(err, "required directories")
 	}
 
 	if len(e.Env) > 0 {

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -105,9 +105,18 @@ func TestStartStop(t *testing.T) {
 					t.Errorf("%s failed: %v", rr.Args, err)
 				}
 
-				got := Status(ctx, t, Target(), profile, "Host")
-				if got != state.Stopped.String() {
-					t.Errorf("status = %q; want = %q", got, state.Stopped)
+				// The none driver never really stops
+				if !NoneDriver() {
+					got := Status(ctx, t, Target(), profile, "Host")
+					if got != state.Stopped.String() {
+						t.Errorf("post-stop host status = %q; want = %q", got, state.Stopped)
+					}
+				}
+
+				// Enable an addon to assert it comes up afterwards
+				rr, err = Run(t, exec.CommandContext(ctx, Target(), "addons", "enable", "dashboard", "-p", profile))
+				if err != nil {
+					t.Errorf("%s failed: %v", rr.Args, err)
 				}
 
 				rr, err = Run(t, exec.CommandContext(ctx, Target(), startArgs...))
@@ -118,13 +127,18 @@ func TestStartStop(t *testing.T) {
 
 				if strings.Contains(tc.name, "cni") {
 					t.Logf("WARNING: cni mode requires additional setup before pods can schedule :(")
-				} else if _, err := PodWait(ctx, t, profile, "default", "integration-test=busybox", 4*time.Minute); err != nil {
-					t.Fatalf("wait: %v", err)
+				} else {
+					if _, err := PodWait(ctx, t, profile, "default", "integration-test=busybox", 4*time.Minute); err != nil {
+						t.Fatalf("post-stop-start pod wait: %v", err)
+					}
+					if _, err := PodWait(ctx, t, profile, "kubernetes-dashboard", "k8s-app=kubernetes-dashboard", 4*time.Minute); err != nil {
+						t.Fatalf("post-stop-start addon wait: %v", err)
+					}
 				}
 
-				got = Status(ctx, t, Target(), profile, "Host")
+				got := Status(ctx, t, Target(), profile, "Host")
 				if got != state.Running.String() {
-					t.Errorf("host status = %q; want = %q", got, state.Running)
+					t.Errorf("post-start host status = %q; want = %q", got, state.Running)
 				}
 
 				if !NoneDriver() {
@@ -227,12 +241,12 @@ func testPause(ctx context.Context, t *testing.T, profile string) {
 
 	got := Status(ctx, t, Target(), profile, "APIServer")
 	if got != state.Paused.String() {
-		t.Errorf("apiserver status = %q; want = %q", got, state.Paused)
+		t.Errorf("post-pause apiserver status = %q; want = %q", got, state.Paused)
 	}
 
 	got = Status(ctx, t, Target(), profile, "Kubelet")
 	if got != state.Stopped.String() {
-		t.Errorf("kubelet status = %q; want = %q", got, state.Stopped)
+		t.Errorf("post-pause kubelet status = %q; want = %q", got, state.Stopped)
 	}
 
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "unpause", "-p", profile, "--alsologtostderr", "-v=1"))
@@ -242,12 +256,12 @@ func testPause(ctx context.Context, t *testing.T, profile string) {
 
 	got = Status(ctx, t, Target(), profile, "APIServer")
 	if got != state.Running.String() {
-		t.Errorf("apiserver status = %q; want = %q", got, state.Running)
+		t.Errorf("post-unpause apiserver status = %q; want = %q", got, state.Running)
 	}
 
 	got = Status(ctx, t, Target(), profile, "Kubelet")
 	if got != state.Running.String() {
-		t.Errorf("kubelet status = %q; want = %q", got, state.Running)
+		t.Errorf("post-unpause kubelet status = %q; want = %q", got, state.Running)
 	}
 
 }


### PR DESCRIPTION
If a cluster is stopped, and then started, we were not enabling previously enabled addons due to two bugs:

- We were not reading the existing addons config
- Even if we were, the necessary directory (`/etc/kubernetes/addons`) was not being recreated at startup.

Fixes #6456