### PR TITLE
Update golangci-lint from v1.21 to v1.23.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ MINIKUBE_RELEASES_URL=https://github.com/kubernetes/minikube/releases/download
 
 KERNEL_VERSION ?= 4.19.88
 # latest from https://github.com/golangci/golangci-lint/releases
-GOLINT_VERSION ?= v1.21.0
+GOLINT_VERSION ?= v1.23.2
 # Limit number of default jobs, to avoid the CI builds running out of memory
 GOLINT_JOBS ?= 4
 # see https://github.com/golangci/golangci-lint#memory-usage-of-golangci-lint


### PR DESCRIPTION
I was hoping this would solve some linter issues with running ~go1.14 on my workstation.

It didn't fix the issues, but felt it was a useful PR to propose anyways. 
