### PR TITLE
trim kic base image and disable containerd by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -500,8 +500,8 @@ storage-provisioner-image: out/storage-provisioner-$(GOARCH) ## Build storage-pr
 
 .PHONY: kic-base-image
 kic-base-image: ## builds the base image used for kic.
-	docker rmi -f $(REGISTRY)/kicbase:v0.0.3-snapshot || true
-	docker build -f ./hack/images/kicbase.Dockerfile -t $(REGISTRY)/kicbase:v0.0.3-snapshot  --build-arg COMMIT_SHA=${VERSION}-$(COMMIT)  .
+	docker rmi -f $(REGISTRY)/kicbase:v0.0.4-snapshot || true
+	docker build -f ./hack/images/kicbase.Dockerfile -t $(REGISTRY)/kicbase:v0.0.4-snapshot  --build-arg COMMIT_SHA=${VERSION}-$(COMMIT)  .
 
 
 

--- a/hack/images/kicbase.Dockerfile
+++ b/hack/images/kicbase.Dockerfile
@@ -1,7 +1,8 @@
 ARG COMMIT_SHA
-# for now using node image created by kind https://github.com/kubernetes-sigs/kind
-# could be changed to slim ubuntu with systemd. 
-FROM kindest/node:v1.16.2
+# using base image created by kind https://github.com/kubernetes-sigs/kind
+# which is an ubuntu 19.10 with an entry-point that helps running systemd
+# could be changed to any debian that can run systemd
+FROM kindest/base:v20200122-2dfe64b2
 USER root
 RUN apt-get update && apt-get install -y \
   sudo \
@@ -9,14 +10,28 @@ RUN apt-get update && apt-get install -y \
   openssh-server \
   docker.io \
   && apt-get clean -y 
-# based on https://github.com/rastasheep/ubuntu-sshd/blob/master/18.04/Dockerfile
+# disable containerd by default
+RUN systemctl disable containerd
+# enable docker which is default
+RUN systemctl enable docker
 # making SSH work for docker container 
+# based on https://github.com/rastasheep/ubuntu-sshd/blob/master/18.04/Dockerfile
 RUN mkdir /var/run/sshd
 RUN echo 'root:root' |chpasswd
 RUN sed -ri 's/^#?PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
 RUN sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
 EXPOSE 22
-# Deleting all "kind" related stuff from the image.
+# for minikube ssh. to match VM using "docker" as username
+RUN adduser --ingroup docker --disabled-password --gecos '' docker 
+RUN adduser docker sudo
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+USER docker
+RUN mkdir /home/docker/.ssh
+# Deleting leftovers
+USER root
+# kind base-image entry-point expects a "kind" folder for product_name,product_uuid
+# https://github.com/kubernetes-sigs/kind/blob/master/images/base/files/usr/local/bin/entrypoint
+RUN mkdir -p /kind
 RUN rm -rf \
     /var/cache/debconf/* \
     /var/lib/apt/lists/* \
@@ -26,12 +41,4 @@ RUN rm -rf \
     /usr/share/doc/* \
     /usr/share/man/* \
     /usr/share/local/* \
-    /kind/bin/kubeadm /kind/bin/kubelet /kind/systemd /kind/images /kind/manifests
 RUN echo "kic! Build: ${COMMIT_SHA} Time :$(date)" > "/kic.txt"
-# for minikube ssh. to match VM using docker username
-RUN adduser --ingroup docker --disabled-password --gecos '' docker 
-RUN adduser docker sudo
-RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-USER docker
-RUN mkdir /home/docker/.ssh
-USER root

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -25,8 +25,9 @@ const (
 	DefaultPodCIDR = "10.244.0.0/16"
 	// DefaultBindIPV4 is The default IP the container will bind to.
 	DefaultBindIPV4 = "127.0.0.1"
-	// BaseImage is the base image is used to spin up kic containers created by kind.
-	BaseImage = "gcr.io/k8s-minikube/kicbase:v0.0.3@sha256:34db5e30f8830c0d5e49b62f3ea6b2844f805980592fe0084cbea799bfb12664" // OverlayImage is the cni plugin used for overlay image, created by kind.
+	// BaseImage is the base image is used to spin up kic containers. it uses same base-image as kind.
+	BaseImage = "gcr.io/k8s-minikube/kicbase:v0.0.4@sha256:01552b7ffc7cb0c49c6106796ed73f69647691d8fbae89fed8ee317dc7f1015a"
+	// OverlayImage is the cni plugin used for overlay image, created by kind.
 	// CNI plugin image used for kic drivers created by kind.
 	OverlayImage = "kindest/kindnetd:0.5.3"
 )


### PR DESCRIPTION
This PR:
- Trim the kicimage by 800 mb
```
gcr.io/k8s-minikube/kicbase   <none>               93d2b8cf202a        4 days ago          1.76GB
gcr.io/k8s-minikube/kicbase   v0.0.4               87a690612c07        6 minutes ago       802MB
```
- might help to identify root cause of cache test issue with docker runtime https://github.com/kubernetes/minikube/issues/6445
- Disable containerd by default  fixes https://github.com/kubernetes/minikube/issues/6476