### PR TITLE
try nslookup both ways

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1149,7 +1149,7 @@ func tryLookup(r command.Runner) {
 		// will try with different command format for ISOs with diffrent busybox versions.
 		if rr, err = r.RunCmd(exec.Command("nslookup", "kubernetes.io")); err != nil {
 			glog.Warningf("nslookup failed: %v", rr.Args, err)
-			out.WarningT("VM may be unable to resolve external DNS records")
+			out.WarningT("Node may be unable to resolve external DNS records")
 		}
 	}
 }

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1145,15 +1145,14 @@ Suggested workarounds:
 func tryLookup(r command.Runner) {
 	// DNS check
 	if rr, err := r.RunCmd(exec.Command("nslookup", "kubernetes.io", "-type=ns")); err != nil {
-		glog.Infof("%s failed: %v which might be okay will retry nslookup with query type", rr.Args, err)
-		// will try with different command format for ISOs with diffrent busybox versions.
-		if rr, err = r.RunCmd(exec.Command("nslookup", "kubernetes.io")); err != nil {
-			glog.Warningf("nslookup failed: %v", rr.Args, err)
+		glog.Infof("%s failed: %v which might be okay will retry nslookup without query type", rr.Args, err)
+		// will try with without query type for ISOs with different busybox versions.
+		if _, err = r.RunCmd(exec.Command("nslookup", "kubernetes.io")); err != nil {
+			glog.Warningf("nslookup failed: %v", err)
 			out.WarningT("Node may be unable to resolve external DNS records")
 		}
 	}
 }
-
 func tryRegistry(r command.Runner) {
 	// Try an HTTPS connection to the image repository
 	proxy := os.Getenv("HTTPS_PROXY")

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1144,9 +1144,13 @@ Suggested workarounds:
 
 func tryLookup(r command.Runner) {
 	// DNS check
-	if rr, err := r.RunCmd(exec.Command("nslookup", "kubernetes.io")); err != nil {
-		glog.Warningf("%s failed: %v", rr.Args, err)
-		out.WarningT("VM may be unable to resolve external DNS records")
+	if rr, err := r.RunCmd(exec.Command("nslookup", "kubernetes.io", "-type=ns")); err != nil {
+		glog.Infof("%s failed: %v which might be okay will retry nslookup with query type", rr.Args, err)
+		// will try with different command format for ISOs with diffrent busybox versions.
+		if rr, err = r.RunCmd(exec.Command("nslookup", "kubernetes.io")); err != nil {
+			glog.Warningf("nslookup failed: %v", rr.Args, err)
+			out.WarningT("VM may be unable to resolve external DNS records")
+		}
 	}
 }
 


### PR DESCRIPTION
- will try nslookup one way and if it doesnt will try another way
( a user who was using different ISO for VM had reverted passing the -query-type so I thought lets have both ways)

- changed wording from VM to node.
'Node may be unable to resolve external DNS records'
closes https://github.com/kubernetes/minikube/issues/6475