### PR TITLE
Add Azure Container Registry support

### DIFF
--- a/deploy/addons/registry-creds/registry-creds-rc.yaml.tmpl
+++ b/deploy/addons/registry-creds/registry-creds-rc.yaml.tmpl
@@ -18,7 +18,7 @@ spec:
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:
-      - image: upmcenterprises/registry-creds:1.9
+      - image: upmcenterprises/registry-creds:1.10
         name: registry-creds
         imagePullPolicy: Always
         env:
@@ -77,6 +77,21 @@ spec:
               secretKeyRef:
                 name: registry-creds-gcr
                 key: gcrurl
+          - name: ACR_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: registry-creds-acr
+                key: ACR_PASSWORD
+          - name: ACR_URL
+            valueFrom:
+              secretKeyRef:
+                name: registry-creds-acr
+                key: ACR_URL
+          - name: ACR_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: registry-creds-acr
+                key: ACR_CLIENT_ID
         volumeMounts:
         - name: gcr-creds
           mountPath: "/root/.config/gcloud"

--- a/site/content/en/docs/Tasks/Registry/private.md
+++ b/site/content/en/docs/Tasks/Registry/private.md
@@ -2,13 +2,13 @@
 title: "Private"
 linkTitle: "Private"
 weight: 6
-date: 2019-08-01
+date: 2020-01-14
 description: >
   How to use a private registry within minikube
 ---
 
 
-**GCR/ECR/Docker**: minikube has an addon, `registry-creds` which maps credentials into minikube to support pulling from Google Container Registry (GCR), Amazon's EC2 Container Registry (ECR), and Private Docker registries.  You will need to run `minikube addons configure registry-creds` and `minikube addons enable registry-creds` to get up and running.  An example of this is below:
+**GCR/ECR/ACR/Docker**: minikube has an addon, `registry-creds` which maps credentials into minikube to support pulling from Google Container Registry (GCR), Amazon's EC2 Container Registry (ECR), Azure Container Registry (ACR), and Private Docker registries.  You will need to run `minikube addons configure registry-creds` and `minikube addons enable registry-creds` to get up and running.  An example of this is below:
 
 ```shell
 $ minikube addons configure registry-creds
@@ -18,6 +18,8 @@ Do you want to enable Google Container Registry? [y/n]: y
 -- Enter path to credentials (e.g. /home/user/.config/gcloud/application_default_credentials.json):/home/user/.config/gcloud/application_default_credentials.json
 
 Do you want to enable Docker Registry? [y/n]: n
+
+Do you want to enable Azure Container Registry? [y/n]: n
 registry-creds was successfully configured
 $ minikube addons enable registry-creds
 ```


### PR DESCRIPTION
This PR adds Azure Container Registry support to minikube (registry-creds add-on).

The registry-creds component, including its public image, has been updated accordingly, see https://github.com/upmc-enterprises/registry-creds/pull/82 for details. 

Hope this helps! 