### PR TITLE
Make config_test and cluster_test hermetic

### DIFF
--- a/cmd/minikube/cmd/config/set_test.go
+++ b/cmd/minikube/cmd/config/set_test.go
@@ -45,7 +45,12 @@ func TestSetNotAllowed(t *testing.T) {
 func TestSetOK(t *testing.T) {
 	createTestProfile(t)
 	err := Set("vm-driver", "virtualbox")
-	defer Unset("vm-driver")
+	defer func() {
+		err = Unset("vm-driver")
+		if err != nil {
+			t.Errorf("failed to unset vm-driver")
+		}
+	}()
 	if err != nil {
 		t.Fatalf("Set returned error for valid property value")
 	}
@@ -58,7 +63,7 @@ func TestSetOK(t *testing.T) {
 	}
 }
 
-func createTestProfile(t *testing.T) string {
+func createTestProfile(t *testing.T) {
 	t.Helper()
 	td, err := ioutil.TempDir("", "profile")
 	if err != nil {
@@ -78,5 +83,4 @@ func createTestProfile(t *testing.T) string {
 	if err := config.DefaultLoader.WriteConfigToFile(name, &config.MachineConfig{}); err != nil {
 		t.Fatalf("error creating temporary profile config: %v", err)
 	}
-	return name
 }

--- a/pkg/minikube/cluster/fix.go
+++ b/pkg/minikube/cluster/fix.go
@@ -30,6 +30,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/util/retry"
 )
@@ -88,6 +89,10 @@ func fixHost(api libmachine.API, mc config.MachineConfig) (*host.Host, error) {
 		if err := provisioner.Provision(*h.HostOptions.SwarmOptions, *h.HostOptions.AuthOptions, *h.HostOptions.EngineOptions); err != nil {
 			return h, errors.Wrap(err, "provision")
 		}
+	}
+
+	if h.DriverName == driver.Mock {
+		return h, nil
 	}
 
 	if err := postStartSetup(h, mc); err != nil {


### PR DESCRIPTION
1. Fixes #6482 by explicitly setting config file in a temp directory.
2. Speeds up the cluster tests by not worrying about syncing guest clocks with the mock driver
