### PR TITLE
Remove pod list stability double check

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/kverify/kverify.go
+++ b/pkg/minikube/bootstrapper/bsutil/kverify/kverify.go
@@ -91,11 +91,7 @@ func SystemPods(client *kubernetes.Clientset, start time.Time, timeout time.Dura
 		}
 
 		glog.Infof("%d kube-system pods found since %s", len(pods.Items), podStart)
-		if time.Since(podStart) > 2*kconst.APICallRetryInterval {
-			glog.Infof("stability requirement met, returning")
-			return true, nil
-		}
-		return false, nil
+		return true, nil
 	}
 	if err := wait.PollImmediate(kconst.APICallRetryInterval, kconst.DefaultControlPlaneTimeout, podList); err != nil {
 		return fmt.Errorf("apiserver never returned a pod list")


### PR DESCRIPTION
I added this to be overly cautious, but in reality, I don't think that double-checking the results after 1 second has much value.

Saves 1 second off of start time.