### PR TITLE
Revert role change from cluster-admin->system:persistent-volume-provisioner

### DIFF
--- a/deploy/addons/storage-provisioner/storage-provisioner.yaml.tmpl
+++ b/deploy/addons/storage-provisioner/storage-provisioner.yaml.tmpl
@@ -31,7 +31,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: system:persistent-volume-provisioner
 subjects:
   - kind: ServiceAccount
     name: storage-provisioner


### PR DESCRIPTION
This reverts part of #6156 that caused a warning to be output when upgrading an old cluster.

Fixes #6510 

/cc @nanikjava 