### PR TITLE
gvisor fixes for v1.7.0

### DIFF
--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -174,7 +174,6 @@ func isAddonAlreadySet(addon *assets.Addon, enable bool, profile string) (bool, 
 }
 
 func enableOrDisableAddonInternal(addon *assets.Addon, cmd command.Runner, data interface{}, enable bool, profile string) error {
-	files := []string{}
 	deployFiles := []string{}
 
 	for _, addon := range addon.Assets {
@@ -204,7 +203,6 @@ func enableOrDisableAddonInternal(addon *assets.Addon, cmd command.Runner, data 
 				}
 			}()
 		}
-		files = append(files, fPath)
 		if strings.HasSuffix(fPath, ".yaml") {
 			deployFiles = append(deployFiles, fPath)
 		}

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -175,6 +175,8 @@ func isAddonAlreadySet(addon *assets.Addon, enable bool, profile string) (bool, 
 
 func enableOrDisableAddonInternal(addon *assets.Addon, cmd command.Runner, data interface{}, enable bool, profile string) error {
 	files := []string{}
+	deployFiles := []string{}
+
 	for _, addon := range addon.Assets {
 		var f assets.CopyableFile
 		var err error
@@ -203,8 +205,12 @@ func enableOrDisableAddonInternal(addon *assets.Addon, cmd command.Runner, data 
 			}()
 		}
 		files = append(files, fPath)
+		if strings.HasSuffix(fPath, ".yaml") {
+			deployFiles = append(deployFiles, fPath)
+		}
 	}
-	command, err := kubectlCommand(profile, files, enable)
+
+	command, err := kubectlCommand(profile, deployFiles, enable)
 	if err != nil {
 		return err
 	}

--- a/pkg/minikube/cluster/start.go
+++ b/pkg/minikube/cluster/start.go
@@ -54,6 +54,7 @@ var (
 		vmpath.GuestCertsDir,
 		path.Join(vmpath.GuestPersistentDir, "images"),
 		path.Join(vmpath.GuestPersistentDir, "binaries"),
+		"/tmp/gvisor",
 	}
 )
 


### PR DESCRIPTION
- /tmp/gvisor must exist before we can copy files into it
- Don't attempt to kubectl apply non-YAML files in an addon

Fixes error:

`⚠️  Enabling 'gvisor' returned an error: running callbacks: [sudo test -d /tmp/gvisor && sudo scp -t /tmp/gvisor && sudo touch -d "0001-01-01 00:00:00 +0000" /tmp/gvisor/gvisor-config.toml: Process exited with status 1`

and:

`⚠️  Enabling 'gvisor' returned an error: running callbacks: [addon apply: sudo KUBECONFIG=/var/lib/minikube/kubeconfig /var/lib/minikube/binaries/v1.17.2/kubectl apply -f /etc/kubernetes/addons/gvisor-pod.yaml -f /etc/kubernetes/addons/gvisor-runtimeclass.yaml -f /tmp/gvisor/gvisor-config.toml: Process exited with status 1`