### PR TITLE
Remove kubeadm pull images

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1204,6 +1204,50 @@ func getKubernetesVersion(old *config.MachineConfig) string {
 		exit.WithCodeT(exit.Data, `Unable to parse "{{.kubernetes_version}}": {{.error}}`, out.V{"kubernetes_version": paramVersion, "error": err})
 	}
 	nv := version.VersionPrefix + nvs.String()
+
+	if old == nil || old.KubernetesConfig.KubernetesVersion == "" {
+		return nv
+	}
+
+	oldestVersion, err := semver.Make(strings.TrimPrefix(constants.OldestKubernetesVersion, version.VersionPrefix))
+	if err != nil {
+		exit.WithCodeT(exit.Data, "Unable to parse oldest Kubernetes version from constants: {{.error}}", out.V{"error": err})
+	}
+	defaultVersion, err := semver.Make(strings.TrimPrefix(constants.DefaultKubernetesVersion, version.VersionPrefix))
+	if err != nil {
+		exit.WithCodeT(exit.Data, "Unable to parse default Kubernetes version from constants: {{.error}}", out.V{"error": err})
+	}
+
+	if nvs.LT(oldestVersion) {
+		out.WarningT("Specified Kubernetes version {{.specified}} is less than the oldest supported version: {{.oldest}}", out.V{"specified": nvs, "oldest": constants.OldestKubernetesVersion})
+		if viper.GetBool(force) {
+			out.WarningT("Kubernetes {{.version}} is not supported by this release of minikube", out.V{"version": nvs})
+		} else {
+			exit.WithCodeT(exit.Data, "Sorry, Kubernetes {{.version}} is not supported by this release of minikube", out.V{"version": nvs})
+		}
+	}
+
+	ovs, err := semver.Make(strings.TrimPrefix(old.KubernetesConfig.KubernetesVersion, version.VersionPrefix))
+	if err != nil {
+		glog.Errorf("Error parsing old version %q: %v", old.KubernetesConfig.KubernetesVersion, err)
+	}
+
+	if nvs.LT(ovs) {
+		nv = version.VersionPrefix + ovs.String()
+		profileArg := ""
+		if old.Name != constants.DefaultMachineName {
+			profileArg = fmt.Sprintf("-p %s", old.Name)
+		}
+		exit.WithCodeT(exit.Config, `Error: You have selected Kubernetes v{{.new}}, but the existing cluster for your profile is running Kubernetes v{{.old}}. Non-destructive downgrades are not supported, but you can proceed by performing one of the following options:
+
+* Recreate the cluster using Kubernetes v{{.new}}: Run "minikube delete {{.profile}}", then "minikube start {{.profile}} --kubernetes-version={{.new}}"
+* Create a second cluster with Kubernetes v{{.new}}: Run "minikube start -p <new name> --kubernetes-version={{.new}}"
+* Reuse the existing cluster with Kubernetes v{{.old}} or newer: Run "minikube start {{.profile}} --kubernetes-version={{.old}}"`, out.V{"new": nvs, "old": ovs, "profile": profileArg})
+
+	}
+	if defaultVersion.GT(nvs) {
+		out.T(out.ThumbsUp, "Kubernetes {{.new}} is now available. If you would like to upgrade, specify: --kubernetes-version={{.new}}", out.V{"new": defaultVersion})
+	}
 	return nv
 }
 

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1297,13 +1297,6 @@ func configureRuntimes(runner cruntime.CommandRunner, drvName string, k8s config
 
 // bootstrapCluster starts Kubernetes using the chosen bootstrapper
 func bootstrapCluster(bs bootstrapper.Bootstrapper, r cruntime.Manager, runner command.Runner, mc config.MachineConfig, preexisting bool, isUpgrade bool) {
-	if isUpgrade || !preexisting {
-		out.T(out.Pulling, "Pulling images ...")
-		if err := bs.PullImages(mc.KubernetesConfig); err != nil {
-			out.T(out.FailureType, "Unable to pull images, which may be OK: {{.error}}", out.V{"error": err})
-		}
-	}
-
 	out.T(out.Launch, "Launching Kubernetes ... ")
 	if err := bs.StartCluster(mc); err != nil {
 		exit.WithLogEntries("Error starting cluster", err, logs.FindProblems(r, bs, runner))

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -31,33 +31,28 @@ func TestGetKuberneterVersion(t *testing.T) {
 		description     string
 		expectedVersion string
 		paramVersion    string
-		upgrade         bool
 		cfg             *cfg.MachineConfig
 	}{
 		{
 			description:     "kubernetes-version not given, no config",
 			expectedVersion: constants.DefaultKubernetesVersion,
 			paramVersion:    "",
-			upgrade:         false,
 		},
 		{
 			description:     "kubernetes-version not given, config available",
 			expectedVersion: "v1.15.0",
 			paramVersion:    "",
-			upgrade:         false,
 			cfg:             &cfg.MachineConfig{KubernetesConfig: cfg.KubernetesConfig{KubernetesVersion: "v1.15.0"}},
 		},
 		{
 			description:     "kubernetes-version given, no config",
 			expectedVersion: "v1.15.0",
 			paramVersion:    "v1.15.0",
-			upgrade:         false,
 		},
 		{
 			description:     "kubernetes-version given, config available",
 			expectedVersion: "v1.16.0",
 			paramVersion:    "v1.16.0",
-			upgrade:         true,
 			cfg:             &cfg.MachineConfig{KubernetesConfig: cfg.KubernetesConfig{KubernetesVersion: "v1.15.0"}},
 		},
 	}
@@ -65,16 +60,11 @@ func TestGetKuberneterVersion(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			viper.SetDefault(kubernetesVersion, test.paramVersion)
-			version, upgrade := getKubernetesVersion(test.cfg)
+			version := getKubernetesVersion(test.cfg)
 
 			// check whether we are getting the expected version
 			if version != test.expectedVersion {
 				t.Fatalf("test failed because the expected version %s is not returned", test.expectedVersion)
-			}
-
-			// check whether the upgrade flag is correct
-			if test.upgrade != upgrade {
-				t.Fatalf("test failed expected upgrade is %t", test.upgrade)
 			}
 		})
 	}

--- a/pkg/minikube/bootstrapper/bootstrapper.go
+++ b/pkg/minikube/bootstrapper/bootstrapper.go
@@ -35,8 +35,6 @@ type LogOptions struct {
 
 // Bootstrapper contains all the methods needed to bootstrap a kubernetes cluster
 type Bootstrapper interface {
-	// PullImages pulls images necessary for a cluster. Success should not be required.
-	PullImages(config.KubernetesConfig) error
 	StartCluster(config.MachineConfig) error
 	UpdateCluster(config.MachineConfig) error
 	DeleteCluster(config.KubernetesConfig) error

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -390,23 +390,6 @@ func (k *Bootstrapper) DeleteCluster(k8s config.KubernetesConfig) error {
 	return nil
 }
 
-// PullImages downloads images that will be used by Kubernetes
-func (k *Bootstrapper) PullImages(k8s config.KubernetesConfig) error {
-	version, err := bsutil.ParseKubernetesVersion(k8s.KubernetesVersion)
-	if err != nil {
-		return errors.Wrap(err, "parsing kubernetes version")
-	}
-	if version.LT(semver.MustParse("1.11.0")) {
-		return fmt.Errorf("pull command is not supported by kubeadm v%s", version)
-	}
-
-	rr, err := k.c.RunCmd(exec.Command("/bin/bash", "-c", fmt.Sprintf("%s config images pull --config %s", bsutil.InvokeKubeadm(k8s.KubernetesVersion), bsutil.KubeadmYamlPath)))
-	if err != nil {
-		return errors.Wrapf(err, "running cmd: %q", rr.Command())
-	}
-	return nil
-}
-
 // SetupCerts sets up certificates within the cluster.
 func (k *Bootstrapper) SetupCerts(k8s config.KubernetesConfig, n config.Node) error {
 	return bootstrapper.SetupCerts(k.c, k8s, n)


### PR DESCRIPTION
Since we pull and load all of these images already, we shouldn't need to do it again.