### PR TITLE
Fix to delete context when delete minikube

### DIFF
--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -238,7 +238,7 @@ func deleteProfile(profile *pkg_config.Profile) error {
 }
 
 func deleteContext(machineName string) error {
-	if err := kubeconfig.DeleteContext(constants.KubeconfigPath, machineName); err != nil {
+	if err := kubeconfig.DeleteContext(machineName, constants.KubeconfigPath); err != nil {
 		return DeletionError{Err: fmt.Errorf("update config: %v", err), Errtype: Fatal}
 	}
 

--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -238,7 +238,7 @@ func deleteProfile(profile *pkg_config.Profile) error {
 }
 
 func deleteContext(machineName string) error {
-	if err := kubeconfig.DeleteContext(machineName, constants.KubeconfigPath); err != nil {
+	if err := kubeconfig.DeleteContext(machineName); err != nil {
 		return DeletionError{Err: fmt.Errorf("update config: %v", err), Errtype: Fatal}
 	}
 

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -153,6 +153,14 @@ func TestStartStop(t *testing.T) {
 					if err != nil {
 						t.Errorf("%s failed: %v", rr.Args, err)
 					}
+
+					rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "config", "get-contexts"))
+					if err != nil {
+						t.Fatalf("%s failed: %v", rr.Args, err)
+					}
+					if notDeleted := strings.Contains(rr.Output(), profile); notDeleted {
+						t.Errorf(" kubeconfig of %s is not deleted = %t; want = %t", profile, notDeleted, false)
+					}
 				}
 			})
 		}


### PR DESCRIPTION
- When `minikube delete`, minikube must delete its contexts which are set when `minikube start`.
- But, there was some mistakes in the function that does this logic.
- `DeleteContext(machineName string, configPath ...string)` in `pkg/minikube/kubeconfig/context.go` was not matching with usage in `deleteContext`.
    - it calls the function in the wrong order of parameter :
    - `kubeconfig.DeleteContext(constants.KubeconfigPath, machineName)`

Fixes #6538 

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
