### PR TITLE
improve integration test for delete kubeconfig context

### DIFF
--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -154,12 +154,12 @@ func TestStartStop(t *testing.T) {
 						t.Errorf("%s failed: %v", rr.Args, err)
 					}
 
-					rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "config", "get-contexts"))
+					rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "config", "get-contexts", profile))
 					if err != nil {
-						t.Fatalf("%s failed: %v", rr.Args, err)
+						t.Logf("config context error: %v (may be ok)", err)
 					}
-					if notDeleted := strings.Contains(rr.Output(), profile); notDeleted {
-						t.Errorf(" kubeconfig of %s is not deleted = %t; want = %t", profile, notDeleted, false)
+					if rr.ExitCode != 1 {
+						t.Errorf("wanted exit code 1, got %d. output: %s", rr.ExitCode, rr.Output())
 					}
 				}
 			})


### PR DESCRIPTION
update the test to use exitcode as as assertion
and to print stdout for debugging easily in error
case

applying review in #6541 from @tstromberg 

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
