### PR TITLE
Fix to kubeConfigPath could be set from env

### DIFF
--- a/cmd/minikube/cmd/config/profile.go
+++ b/cmd/minikube/cmd/config/profile.go
@@ -23,7 +23,6 @@ import (
 	"github.com/spf13/viper"
 	pkgConfig "k8s.io/minikube/pkg/minikube/config"
 	pkg_config "k8s.io/minikube/pkg/minikube/config"
-	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/kubeconfig"
 	"k8s.io/minikube/pkg/minikube/out"
@@ -87,7 +86,7 @@ var ProfileCmd = &cobra.Command{
 				out.SuccessT("Skipped switching kubectl context for {{.profile_name}} because --keep-context was set.", out.V{"profile_name": profile})
 				out.SuccessT("To connect to this cluster, use: kubectl --context={{.profile_name}}", out.V{"profile_name": profile})
 			} else {
-				err := kubeconfig.SetCurrentContext(profile, constants.KubeconfigPath)
+				err := kubeconfig.SetCurrentContext(profile, kubeconfig.PathFromEnv())
 				if err != nil {
 					out.ErrT(out.Sad, `Error while setting kubectl current context :  {{.error}}`, out.V{"error": err})
 				}

--- a/cmd/minikube/cmd/stop.go
+++ b/cmd/minikube/cmd/stop.go
@@ -26,7 +26,6 @@ import (
 	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/cluster"
 	pkg_config "k8s.io/minikube/pkg/minikube/config"
-	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/kubeconfig"
 	"k8s.io/minikube/pkg/minikube/machine"
@@ -82,7 +81,7 @@ func runStop(cmd *cobra.Command, args []string) {
 		out.T(out.WarningType, "Unable to kill mount process: {{.error}}", out.V{"error": err})
 	}
 
-	err = kubeconfig.UnsetCurrentContext(profile, constants.KubeconfigPath)
+	err = kubeconfig.UnsetCurrentContext(profile, kubeconfig.PathFromEnv())
 	if err != nil {
 		exit.WithError("update config", err)
 	}

--- a/cmd/minikube/cmd/update-context.go
+++ b/cmd/minikube/cmd/update-context.go
@@ -17,13 +17,10 @@ limitations under the License.
 package cmd
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/cluster"
 	"k8s.io/minikube/pkg/minikube/config"
-	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/kubeconfig"
 	"k8s.io/minikube/pkg/minikube/machine"
@@ -47,13 +44,7 @@ var updateContextCmd = &cobra.Command{
 		if err != nil {
 			exit.WithError("Error host driver ip status", err)
 		}
-		var updated bool
-		kubeConfigPath := os.Getenv("KUBECONFIG")
-		if kubeConfigPath == "" {
-			updated, err = kubeconfig.UpdateIP(ip, machineName, constants.KubeconfigPath)
-		} else {
-			updated, err = kubeconfig.UpdateIP(ip, machineName, kubeConfigPath)
-		}
+		updated, err := kubeconfig.UpdateIP(ip, machineName, kubeconfig.PathFromEnv())
 		if err != nil {
 			exit.WithError("update config", err)
 		}


### PR DESCRIPTION
Some codes used kubeConfigPath just as $HOME/.kube/config,
but it may be different if KUBECONFIG env was set.
Thus, modify those codes to use kubeConfigPath by
using kubeconfig.PathFromEnv function.

- applying review from #6541 

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
