### PR TITLE
Update helm-tiller addon image v2.14.3 → v2.16.1

### DIFF
--- a/deploy/addons/helm-tiller/helm-tiller-dp.tmpl
+++ b/deploy/addons/helm-tiller/helm-tiller-dp.tmpl
@@ -46,7 +46,7 @@ spec:
               value: kube-system
             - name: TILLER_HISTORY_MAX
               value: "0"
-          image: gcr.io/kubernetes-helm/tiller:v2.14.3
+          image: gcr.io/kubernetes-helm/tiller:v2.16.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3


### PR DESCRIPTION
### What type of PR is this?
/kind cleanup

### What this PR does / why we need it:

This PR bump up helm-tiller addon's image v2.14.3 to v2.16.1

### Which issue(s) this PR fixes:

Fixes #6574

### Does this PR introduce a user-facing change?

Yes.
This image bumpup includes helm's bug fix & features.
https://github.com/helm/helm/releases 

**Before**
```
image: gcr.io/kubernetes-helm/tiller:v2.14.3
```

**After**
```
image: gcr.io/kubernetes-helm/tiller:v2.16.1
```

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```
