### PR TITLE
Separate cached kubernetes binaries by OS on host machine

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -484,6 +484,9 @@ func handleDownloadOnly(cacheGroup *errgroup.Group, k8sVersion string) {
 	if err := doCacheBinaries(k8sVersion); err != nil {
 		exit.WithError("Failed to cache binaries", err)
 	}
+	if _, err := cacheKubectlBinary(k8sVersion); err != nil {
+		exit.WithError("Failed to cache kubectl", err)
+	}
 	waitCacheRequiredImages(cacheGroup)
 	if err := saveImagesToTarFromConfig(); err != nil {
 		exit.WithError("Failed to cache images to tar", err)

--- a/pkg/minikube/machine/cache_binaries.go
+++ b/pkg/minikube/machine/cache_binaries.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"runtime"
 
 	"github.com/golang/glog"
@@ -63,7 +64,7 @@ func KubernetesReleaseURLSHA1(binaryName, version, osName, archName string) stri
 
 // CacheBinary will cache a binary on the host
 func CacheBinary(binary, version, osName, archName string) (string, error) {
-	targetDir := localpath.MakeMiniPath("cache", version)
+	targetDir := localpath.MakeMiniPath(filepath.Join("cache", osName), version)
 	targetFilepath := path.Join(targetDir, binary)
 
 	url := KubernetesReleaseURL(binary, version, osName, archName)

--- a/pkg/minikube/machine/cache_binaries.go
+++ b/pkg/minikube/machine/cache_binaries.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"path/filepath"
 	"runtime"
 
 	"github.com/golang/glog"
@@ -64,7 +63,7 @@ func KubernetesReleaseURLSHA1(binaryName, version, osName, archName string) stri
 
 // CacheBinary will cache a binary on the host
 func CacheBinary(binary, version, osName, archName string) (string, error) {
-	targetDir := localpath.MakeMiniPath(filepath.Join("cache", osName), version)
+	targetDir := localpath.MakeMiniPath("cache", osName, version)
 	targetFilepath := path.Join(targetDir, binary)
 
 	url := KubernetesReleaseURL(binary, version, osName, archName)

--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -83,7 +84,7 @@ func TestDownloadOnly(t *testing.T) {
 
 				// checking binaries downloaded (kubelet,kubeadm)
 				for _, bin := range constants.KubernetesReleaseBinaries {
-					fp := filepath.Join(localpath.MiniPath(), "cache", v, bin)
+					fp := filepath.Join(localpath.MiniPath(), "cache", runtime.GOOS, v, bin)
 					_, err := os.Stat(fp)
 					if err != nil {
 						t.Errorf("expected the file for binary exist at %q but got error %v", fp, err)

--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -84,11 +84,25 @@ func TestDownloadOnly(t *testing.T) {
 
 				// checking binaries downloaded (kubelet,kubeadm)
 				for _, bin := range constants.KubernetesReleaseBinaries {
-					fp := filepath.Join(localpath.MiniPath(), "cache", runtime.GOOS, v, bin)
+					fp := filepath.Join(localpath.MiniPath(), "cache", "linux", v, bin)
 					_, err := os.Stat(fp)
 					if err != nil {
 						t.Errorf("expected the file for binary exist at %q but got error %v", fp, err)
 					}
+				}
+
+				// If we are on darwin/windows, check to make sure OS specific kubectl has been downloaded
+				// as well for the `minikube kubectl` command
+				if runtime.GOOS == "linux" {
+					return
+				}
+				binary := "kubectl"
+				if runtime.GOOS == "windows" {
+					binary = "kubectl.exe"
+				}
+				fp := filepath.Join(localpath.MiniPath(), "cache", runtime.GOOS, v, binary)
+				if _, err := os.Stat(fp); err != nil {
+					t.Errorf("expected the file for binary exist at %q but got error %v", fp, err)
 				}
 			})
 		}


### PR DESCRIPTION
This way, all kubernetes binaries stored in ~/.minikube/cache/linux will be copied over to the VM and used for `minikube kubectl` on linux machines. kubectl will be stored in `~/.minikube/cache/{windows or darwin}` on windows/darwin so that `minikube kubectl` still works.

Should fix #6559