### PR TITLE
[don't merge] remove var volume for experiment

### DIFF
--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -53,7 +53,7 @@ func CreateContainerNode(p CreateParams) error {
 		"--tmpfs", "/tmp", // various things depend on working /tmp
 		"--tmpfs", "/run", // systemd wants a writable /run
 		// logs,pods be stroed on  filesystem vs inside container,
-		"--volume", "/var",
+		// "--volume", "/var",
 		// some k8s things want /lib/modules
 		"-v", "/lib/modules:/lib/modules:ro",
 		"--hostname", p.Name, // make hostname match container name


### PR DESCRIPTION
Update:
the result of this invetigation is to DO use volumes but store them in minikube machine folder for better clean up

trying and documenting observations
# Intergration Tests on master minikube 

Failures on Latest minikube on docker driver: 7 Failures - takes 17 minutes
<pre>
TestOffline/group/crio - 40.93
TestAddons/parallel/MetricsServer - 365.7
TestVersionUpgrade - 294.09
TestStartStop/group/newest-cni - 199.23
TestStartStop/group/containerd - 37.42
TestStartStop/group/crio - 47.64
TestFunctional/parallel/MountCmd - 19.56
</pre>

Failures with Var (performance related) [22 Failures](https://storage.googleapis.com/minikube-builds/logs/6591/Docker_Linux.html) takes LONGER (28 mins)
<pre>
TestOffline/group/docker - 380.49
TestOffline/group/crio - 45.16
TestOffline/group/containerd - 384.13
TestAddons - 290.08
TestDockerFlags - 342.32
TestFunctional/serial/StartWithProxy - 285.04
TestFunctional/serial/KubectlGetPods - 7.44
TestVersionUpgrade - 241.77
TestStartStop/group/old-docker - 333.92
TestFunctional/parallel/ComponentHealth - 5.49
TestStartStop/group/newest-cni - 323.55
TestStartStop/group/containerd - 11.95
TestStartStop/group/crio - 60.49
TestFunctional/parallel/DashboardCmd - 5.24
TestFunctional/parallel/DNS - 0.12
TestFunctional/parallel/StatusCmd - 2.11
TestFunctional/parallel/MountCmd - 26.06
TestFunctional/parallel/ProfileCmd - 0.96
TestFunctional/parallel/ServiceCmd - 605.9
TestFunctional/parallel/PersistentVolumeClaim - 250.56
TestFunctional/parallel/TunnelCmd - 8.31
TestFunctional/parallel/MySQL - 2.28
</pre>


# Performance without var volume

------------------------------------------------------------------------
This PR (trying docker without volume) = starting 3 profile starts (start from a purged home)
------------------------------------------------------------------------
```
$ time ./out/minikube start --vm-driver=docker
real	1m31.177s
user	0m9.832s
sys	0m7.846s

$ time ./out/minikube start --vm-driver=docker -p p1
real	1m37.947s
user	0m5.834s
sys	0m5.679s

$ time ./out/minikube start --vm-driver=docker -p p2
real	2m2.906s
user	0m6.028s
sys	0m5.438s
```

------------------------------------------------------------------------
latest minikube (1.7.2):  starting 3 profile starts (start from a purged home)
------------------------------------------------------------------------
```
medya@~/workspace/minikube (no_var) $ time minikube start --vm-driver=docker 
real	1m26.107s
user	0m9.804s
sys	0m7.782s

medya@~/workspace/minikube (no_var) $ time minikube start --vm-driver=docker -p p1
real	1m26.640s
user	0m6.053s
sys	0m5.490s

medya@~/workspace/minikube (no_var) $ time minikube start --vm-driver=docker -p p2
real	1m42.456s
user	0m5.934s
sys	0m5.430s
```