### PR TITLE
preload_images: Fix unnecessary conversion (unconvert)

### DIFF
--- a/hack/preload-images/preload_images.go
+++ b/hack/preload-images/preload_images.go
@@ -89,7 +89,7 @@ func copyTarballToHost() error {
 	}
 
 	dest := filepath.Join("out/", tarballFilename)
-	args := []string{"scp", "-o", "StrictHostKeyChecking=no", "-i", string(sshKey), fmt.Sprintf("docker@%s:/home/docker/%s", ip, tarballFilename), dest}
+	args := []string{"scp", "-o", "StrictHostKeyChecking=no", "-i", sshKey, fmt.Sprintf("docker@%s:/home/docker/%s", ip, tarballFilename), dest}
 	_, err = runCmd(args)
 	return err
 }


### PR DESCRIPTION
Fixes lint error:

```
hack/preload-images/preload_images.go:92:72: unnecessary conversion (unconvert)
	args := []string{"scp", "-o", "StrictHostKeyChecking=no", "-i", string(sshKey), 
```