### PR TITLE
upload "per commit" logs for integration test 

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -345,9 +345,10 @@ gsutil -qm cp "${JSON_OUT}" "gs://${JOB_GCS_BUCKET}.json" || true
 echo ">> uploading ${HTML_OUT}"
 gsutil -qm cp "${HTML_OUT}" "gs://${JOB_GCS_BUCKET}.html" || true
 
-public_log_url="https://storage.googleapis.com/${JOB_GCS_BUCKET}.txt"
+short_commit=${COMMIT:0:7}
+public_log_url="https://storage.googleapis.com/${short_commit}/${JOB_GCS_BUCKET}.txt"
 if grep -q html "$HTML_OUT"; then
-  public_log_url="https://storage.googleapis.com/${JOB_GCS_BUCKET}.html"
+  public_log_url="https://storage.googleapis.com/${short_commit}/${JOB_GCS_BUCKET}.html"
 fi
 
 echo ">> Cleaning up after ourselves ..."

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -308,7 +308,8 @@ min=$(($elapsed/60))
 sec=$(tail -c 3 <<< $((${elapsed}00/60)))
 elapsed=$min.$sec
 
-JOB_GCS_BUCKET="minikube-builds/logs/${MINIKUBE_LOCATION}/${JOB_NAME}"
+SHORT_COMMIT=${COMMIT:0:7}
+JOB_GCS_BUCKET="minikube-builds/logs/${MINIKUBE_LOCATION}/${SHORT_COMMIT}/${JOB_NAME}/"
 echo ">> Copying ${TEST_OUT} to gs://${JOB_GCS_BUCKET}out.txt"
 gsutil -qm cp "${TEST_OUT}" "gs://${JOB_GCS_BUCKET}out.txt"
 
@@ -345,10 +346,10 @@ gsutil -qm cp "${JSON_OUT}" "gs://${JOB_GCS_BUCKET}.json" || true
 echo ">> uploading ${HTML_OUT}"
 gsutil -qm cp "${HTML_OUT}" "gs://${JOB_GCS_BUCKET}.html" || true
 
-short_commit=${COMMIT:0:7}
-public_log_url="https://storage.googleapis.com/${short_commit}/${JOB_GCS_BUCKET}.txt"
+
+public_log_url="https://storage.googleapis.com/${SHORT_COMMIT}/${JOB_GCS_BUCKET}.txt"
 if grep -q html "$HTML_OUT"; then
-  public_log_url="https://storage.googleapis.com/${short_commit}/${JOB_GCS_BUCKET}.html"
+  public_log_url="https://storage.googleapis.com/${SHORT_COMMIT}/${JOB_GCS_BUCKET}.html"
 fi
 
 echo ">> Cleaning up after ourselves ..."

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -309,7 +309,7 @@ sec=$(tail -c 3 <<< $((${elapsed}00/60)))
 elapsed=$min.$sec
 
 SHORT_COMMIT=${COMMIT:0:7}
-JOB_GCS_BUCKET="minikube-builds/logs/${MINIKUBE_LOCATION}/${SHORT_COMMIT}/${JOB_NAME}/"
+JOB_GCS_BUCKET="minikube-builds/logs/${MINIKUBE_LOCATION}/${SHORT_COMMIT}/${JOB_NAME}"
 echo ">> Copying ${TEST_OUT} to gs://${JOB_GCS_BUCKET}out.txt"
 gsutil -qm cp "${TEST_OUT}" "gs://${JOB_GCS_BUCKET}out.txt"
 
@@ -347,9 +347,9 @@ echo ">> uploading ${HTML_OUT}"
 gsutil -qm cp "${HTML_OUT}" "gs://${JOB_GCS_BUCKET}.html" || true
 
 
-public_log_url="https://storage.googleapis.com/${SHORT_COMMIT}/${JOB_GCS_BUCKET}.txt"
+public_log_url="https://storage.googleapis.com/${JOB_GCS_BUCKET}.txt"
 if grep -q html "$HTML_OUT"; then
-  public_log_url="https://storage.googleapis.com/${SHORT_COMMIT}/${JOB_GCS_BUCKET}.html"
+  public_log_url="https://storage.googleapis.com/${JOB_GCS_BUCKET}.html"
 fi
 
 echo ">> Cleaning up after ourselves ..."

--- a/hack/jenkins/minikube_set_pending.sh
+++ b/hack/jenkins/minikube_set_pending.sh
@@ -78,9 +78,9 @@ function retry_github_status() {
   done
 }
 
-SHORT_COMMIT=${COMMIT:0:7}
+SHORT_COMMIT=${ghprbActualCommit:0:7}
 for j in ${jobs[@]}; do	for j in ${jobs[@]}; do
   retry_github_status "${ghprbActualCommit}" "${j}" "pending" "${access_token}" \	  retry_github_status "${ghprbActualCommit}" "${j}" "pending" "${access_token}" \
-    "https://storage.googleapis.com/minikube-builds/logs/${ghprbPullId}/${j}.pending"	    "https://storage.googleapis.com/minikube-builds/logs/${ghprbPullId}/${SHORT_COMMIT}/${j}.pending"
+  "https://storage.googleapis.com/minikube-builds/logs/${ghprbPullId}/${SHORT_COMMIT}/${j}.pending"
 done	done
 

--- a/hack/jenkins/minikube_set_pending.sh
+++ b/hack/jenkins/minikube_set_pending.sh
@@ -78,8 +78,9 @@ function retry_github_status() {
   done
 }
 
-for j in ${jobs[@]}; do
-  retry_github_status "${ghprbActualCommit}" "${j}" "pending" "${access_token}" \
-    "https://storage.googleapis.com/minikube-builds/logs/${ghprbPullId}/${j}.pending"
-done
+SHORT_COMMIT=${COMMIT:0:7}
+for j in ${jobs[@]}; do	for j in ${jobs[@]}; do
+  retry_github_status "${ghprbActualCommit}" "${j}" "pending" "${access_token}" \	  retry_github_status "${ghprbActualCommit}" "${j}" "pending" "${access_token}" \
+    "https://storage.googleapis.com/minikube-builds/logs/${ghprbPullId}/${j}.pending"	    "https://storage.googleapis.com/minikube-builds/logs/${ghprbPullId}/${SHORT_COMMIT}/${j}.pending"
+done	done
 

--- a/hack/jenkins/minikube_set_pending.sh
+++ b/hack/jenkins/minikube_set_pending.sh
@@ -79,8 +79,8 @@ function retry_github_status() {
 }
 
 SHORT_COMMIT=${ghprbActualCommit:0:7}
-for j in ${jobs[@]}; do	for j in ${jobs[@]}; do
-  retry_github_status "${ghprbActualCommit}" "${j}" "pending" "${access_token}" \	  retry_github_status "${ghprbActualCommit}" "${j}" "pending" "${access_token}" \
+for j in ${jobs[@]}; do
+  retry_github_status "${ghprbActualCommit}" "${j}" "pending" "${access_token}" \
   "https://storage.googleapis.com/minikube-builds/logs/${ghprbPullId}/${SHORT_COMMIT}/${j}.pending"
-done	done
+done
 

--- a/hack/jenkins/windows_integration_test_hyperv.ps1
+++ b/hack/jenkins/windows_integration_test_hyperv.ps1
@@ -25,8 +25,9 @@ $env:result=$lastexitcode
 If($env:result -eq 0){$env:status="success"}
 Else {$env:status="failure"}
 
-$env:SHORT_COMMIT=$env:COMMIT.substring(0, 7)
-$env:target_url="https://storage.googleapis.com/minikube-builds/logs/$env:MINIKUBE_LOCATION$env:SHORT_COMMIT/Hyper-V_Windows.txt"
+# $env:SHORT_COMMIT=$env:COMMIT.substring(0, 7)
+# to be used later to implement https://github.com/kubernetes/minikube/issues/6593
+$env:target_url="https://storage.googleapis.com/minikube-builds/logs/$env:MINIKUBE_LOCATION/Hyper-V_Windows.txt"
 $json = "{`"state`": `"$env:status`", `"description`": `"Jenkins`", `"target_url`": `"$env:target_url`", `"context`": `"Hyper-V_Windows`"}"
 Invoke-WebRequest -Uri "https://api.github.com/repos/kubernetes/minikube/statuses/$env:COMMIT`?access_token=$env:access_token" -Body $json -ContentType "application/json" -Method Post -usebasicparsing
 

--- a/hack/jenkins/windows_integration_test_hyperv.ps1
+++ b/hack/jenkins/windows_integration_test_hyperv.ps1
@@ -25,7 +25,8 @@ $env:result=$lastexitcode
 If($env:result -eq 0){$env:status="success"}
 Else {$env:status="failure"}
 
-$env:target_url="https://storage.googleapis.com/minikube-builds/logs/$env:MINIKUBE_LOCATION/Hyper-V_Windows.txt"
+$env:SHORT_COMMIT=$env:COMMIT.substring(0, 7)
+$env:target_url="https://storage.googleapis.com/minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:SHORT_COMMIT/Hyper-V_Windows.txt"
 $json = "{`"state`": `"$env:status`", `"description`": `"Jenkins`", `"target_url`": `"$env:target_url`", `"context`": `"Hyper-V_Windows`"}"
 Invoke-WebRequest -Uri "https://api.github.com/repos/kubernetes/minikube/statuses/$env:COMMIT`?access_token=$env:access_token" -Body $json -ContentType "application/json" -Method Post -usebasicparsing
 

--- a/hack/jenkins/windows_integration_test_hyperv.ps1
+++ b/hack/jenkins/windows_integration_test_hyperv.ps1
@@ -26,7 +26,7 @@ If($env:result -eq 0){$env:status="success"}
 Else {$env:status="failure"}
 
 $env:SHORT_COMMIT=$env:COMMIT.substring(0, 7)
-$env:target_url="https://storage.googleapis.com/minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:SHORT_COMMIT/Hyper-V_Windows.txt"
+$env:target_url="https://storage.googleapis.com/minikube-builds/logs/$env:MINIKUBE_LOCATION$env:SHORT_COMMIT/Hyper-V_Windows.txt"
 $json = "{`"state`": `"$env:status`", `"description`": `"Jenkins`", `"target_url`": `"$env:target_url`", `"context`": `"Hyper-V_Windows`"}"
 Invoke-WebRequest -Uri "https://api.github.com/repos/kubernetes/minikube/statuses/$env:COMMIT`?access_token=$env:access_token" -Body $json -ContentType "application/json" -Method Post -usebasicparsing
 

--- a/hack/jenkins/windows_integration_test_virtualbox.ps1
+++ b/hack/jenkins/windows_integration_test_virtualbox.ps1
@@ -25,7 +25,8 @@ $env:result=$lastexitcode
 If($env:result -eq 0){$env:status="success"}
 Else {$env:status="failure"}
 
-$env:target_url="https://storage.googleapis.com/minikube-builds/logs/$env:MINIKUBE_LOCATION/VirtualBox_Windows.txt"
+$env:SHORT_COMMIT=$env:COMMIT.substring(0, 7)
+$env:target_url="https://storage.googleapis.com/minikube-builds/logs/$env:MINIKUBE_LOCATION/VirtualBox_Windows.txt"	$env:target_url="https://storage.googleapis.com/minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:SHORT_COMMIT/VirtualBox_Windows.txt"
 $json = "{`"state`": `"$env:status`", `"description`": `"Jenkins`", `"target_url`": `"$env:target_url`", `"context`": `"VirtualBox_Windows`"}"
 Invoke-WebRequest -Uri "https://api.github.com/repos/kubernetes/minikube/statuses/$env:COMMIT`?access_token=$env:access_token" -Body $json -ContentType "application/json" -Method Post -usebasicparsing
 

--- a/hack/jenkins/windows_integration_test_virtualbox.ps1
+++ b/hack/jenkins/windows_integration_test_virtualbox.ps1
@@ -26,7 +26,7 @@ If($env:result -eq 0){$env:status="success"}
 Else {$env:status="failure"}
 
 $env:SHORT_COMMIT=$env:COMMIT.substring(0, 7)
-$env:target_url="https://storage.googleapis.com/minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:SHORT_COMMIT/VirtualBox_Windows.txt"
+$env:target_url="https://storage.googleapis.com/minikube-builds/logs/$env:MINIKUBE_LOCATION$env:SHORT_COMMIT/VirtualBox_Windows.txt"
 $json = "{`"state`": `"$env:status`", `"description`": `"Jenkins`", `"target_url`": `"$env:target_url`", `"context`": `"VirtualBox_Windows`"}"
 Invoke-WebRequest -Uri "https://api.github.com/repos/kubernetes/minikube/statuses/$env:COMMIT`?access_token=$env:access_token" -Body $json -ContentType "application/json" -Method Post -usebasicparsing
 

--- a/hack/jenkins/windows_integration_test_virtualbox.ps1
+++ b/hack/jenkins/windows_integration_test_virtualbox.ps1
@@ -26,7 +26,7 @@ If($env:result -eq 0){$env:status="success"}
 Else {$env:status="failure"}
 
 $env:SHORT_COMMIT=$env:COMMIT.substring(0, 7)
-$env:target_url="https://storage.googleapis.com/minikube-builds/logs/$env:MINIKUBE_LOCATION/VirtualBox_Windows.txt"	$env:target_url="https://storage.googleapis.com/minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:SHORT_COMMIT/VirtualBox_Windows.txt"
+$env:target_url="https://storage.googleapis.com/minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:SHORT_COMMIT/VirtualBox_Windows.txt"
 $json = "{`"state`": `"$env:status`", `"description`": `"Jenkins`", `"target_url`": `"$env:target_url`", `"context`": `"VirtualBox_Windows`"}"
 Invoke-WebRequest -Uri "https://api.github.com/repos/kubernetes/minikube/statuses/$env:COMMIT`?access_token=$env:access_token" -Body $json -ContentType "application/json" -Method Post -usebasicparsing
 

--- a/hack/jenkins/windows_integration_test_virtualbox.ps1
+++ b/hack/jenkins/windows_integration_test_virtualbox.ps1
@@ -25,8 +25,9 @@ $env:result=$lastexitcode
 If($env:result -eq 0){$env:status="success"}
 Else {$env:status="failure"}
 
-$env:SHORT_COMMIT=$env:COMMIT.substring(0, 7)
-$env:target_url="https://storage.googleapis.com/minikube-builds/logs/$env:MINIKUBE_LOCATION$env:SHORT_COMMIT/VirtualBox_Windows.txt"
+# $env:SHORT_COMMIT=$env:COMMIT.substring(0, 7)
+# to be used later 
+$env:target_url="https://storage.googleapis.com/minikube-builds/logs/$env:MINIKUBE_LOCATION/VirtualBox_Windows.txt"
 $json = "{`"state`": `"$env:status`", `"description`": `"Jenkins`", `"target_url`": `"$env:target_url`", `"context`": `"VirtualBox_Windows`"}"
 Invoke-WebRequest -Uri "https://api.github.com/repos/kubernetes/minikube/statuses/$env:COMMIT`?access_token=$env:access_token" -Body $json -ContentType "application/json" -Method Post -usebasicparsing
 


### PR DESCRIPTION
This PR will let every commit have its own Log File attached to it, and fixes and closes https://github.com/kubernetes/minikube/issues/6593

Before this PR:
all the test of different commits of a PR will have the same URL

https://storage.googleapis.com/minikube-builds/logs/6599/Docker_Linux.html

After this PR
each commit will have its own URL and avoids the race condition and possible overwrite of a latest log by a slower older commit

https://storage.googleapis.com/minikube-builds/logs/6599/abcdefg/Docker_Linux.html

abcdefg (would be shortened commit sha)

also fixes the CDN caching issue too (CDN caches an older .txt or .html) and you would have to do some tricks to see real latest logs