### PR TITLE
Upgrade buildroot minor version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ KIC_VERSION ?= 0.0.5
 GO_VERSION ?= 1.13.4
 
 INSTALL_SIZE ?= $(shell du out/minikube-windows-amd64.exe | cut -f1)
-BUILDROOT_BRANCH ?= 2019.02.8
+BUILDROOT_BRANCH ?= 2019.02.9
 REGISTRY?=gcr.io/k8s-minikube
 
 # Get git commit id
@@ -52,7 +52,7 @@ MINIKUBE_BUCKET ?= minikube/releases
 MINIKUBE_UPLOAD_LOCATION := gs://${MINIKUBE_BUCKET}
 MINIKUBE_RELEASES_URL=https://github.com/kubernetes/minikube/releases/download
 
-KERNEL_VERSION ?= 4.19.88
+KERNEL_VERSION ?= 4.19.94
 # latest from https://github.com/golangci/golangci-lint/releases
 GOLINT_VERSION ?= v1.23.2
 # Limit number of default jobs, to avoid the CI builds running out of memory

--- a/deploy/iso/minikube-iso/package/hyperv-daemons/hyperv-daemons.mk
+++ b/deploy/iso/minikube-iso/package/hyperv-daemons/hyperv-daemons.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-HYPERV_DAEMONS_VERSION = 4.19.88
+HYPERV_DAEMONS_VERSION = $(call qstrip,$(BR2_LINUX_KERNEL_VERSION))
 HYPERV_DAEMONS_SITE = https://www.kernel.org/pub/linux/kernel/v4.x
 HYPERV_DAEMONS_SOURCE = linux-$(HYPERV_DAEMONS_VERSION).tar.xz
 


### PR DESCRIPTION
Buildroot 2019.02.9

http://lists.busybox.net/pipermail/buildroot/2020-January/271410.html
