### PR TITLE
add mount feature to kic drivers

### DIFF
--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -170,7 +171,11 @@ var mountCmd = &cobra.Command{
 			wg.Add(1)
 			go func() {
 				out.T(out.Fileserver, "Userspace file server: ")
-				ufs.StartServer(net.JoinHostPort(ip.String(), strconv.Itoa(port)), debugVal, hostPath)
+				bindIP := ip.String() // the ip to listen on the user's host machine
+				if driver.IsKIC(Driver.DriverName()) && runtime.GOOS != "linux" {
+					bindIP = "127.0.0.1"
+				}
+				ufs.StartServer(net.JoinHostPort(bindIP, strconv.Itoa(port)), debugVal, hostPath)
 				out.T(out.Stopped, "Userspace file server is shutdown")
 				wg.Done()
 			}()

--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -172,7 +172,7 @@ var mountCmd = &cobra.Command{
 			go func() {
 				out.T(out.Fileserver, "Userspace file server: ")
 				bindIP := ip.String() // the ip to listen on the user's host machine
-				if driver.IsKIC(Driver.DriverName()) && runtime.GOOS != "linux" {
+				if driver.IsKIC(host.Driver.DriverName()) && runtime.GOOS != "linux" {
 					bindIP = "127.0.0.1"
 				}
 				ufs.StartServer(net.JoinHostPort(bindIP, strconv.Itoa(port)), debugVal, hostPath)

--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -152,6 +152,15 @@ var mountCmd = &cobra.Command{
 			cfg.Options[parts[0]] = parts[1]
 		}
 
+		// An escape valve to allow future hackers to try NFS, VirtFS, or other FS types.
+		if !supportedFilesystems[cfg.Type] {
+			out.T(out.WarningType, "{{.type}} is not yet a supported filesystem. We will try anyways!", out.V{"type": cfg.Type})
+		}
+
+		bindIP := ip.String() // the ip to listen on the user's host machine
+		if driver.IsKIC(host.Driver.DriverName()) && runtime.GOOS != "linux" {
+			bindIP = "127.0.0.1"
+		}
 		out.T(out.Mounting, "Mounting host path {{.sourcePath}} into VM as {{.destinationPath}} ...", out.V{"sourcePath": hostPath, "destinationPath": vmPath})
 		out.T(out.Option, "Mount type:   {{.name}}", out.V{"type": cfg.Type})
 		out.T(out.Option, "User ID:      {{.userID}}", out.V{"userID": cfg.UID})
@@ -160,21 +169,13 @@ var mountCmd = &cobra.Command{
 		out.T(out.Option, "Message Size: {{.size}}", out.V{"size": cfg.MSize})
 		out.T(out.Option, "Permissions:  {{.octalMode}} ({{.writtenMode}})", out.V{"octalMode": fmt.Sprintf("%o", cfg.Mode), "writtenMode": cfg.Mode})
 		out.T(out.Option, "Options:      {{.options}}", out.V{"options": cfg.Options})
-
-		// An escape valve to allow future hackers to try NFS, VirtFS, or other FS types.
-		if !supportedFilesystems[cfg.Type] {
-			out.T(out.WarningType, "{{.type}} is not yet a supported filesystem. We will try anyways!", out.V{"type": cfg.Type})
-		}
+		out.T(out.Option, "Bind Address: {{.Address}}", out.V{"Address": net.JoinHostPort(bindIP, fmt.Sprint(port))})
 
 		var wg sync.WaitGroup
 		if cfg.Type == nineP {
 			wg.Add(1)
 			go func() {
 				out.T(out.Fileserver, "Userspace file server: ")
-				bindIP := ip.String() // the ip to listen on the user's host machine
-				if driver.IsKIC(host.Driver.DriverName()) && runtime.GOOS != "linux" {
-					bindIP = "127.0.0.1"
-				}
 				ufs.StartServer(net.JoinHostPort(bindIP, strconv.Itoa(port)), debugVal, hostPath)
 				out.T(out.Stopped, "Userspace file server is shutdown")
 				wg.Done()

--- a/pkg/drivers/kic/oci/network.go
+++ b/pkg/drivers/kic/oci/network.go
@@ -23,6 +23,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/pkg/errors"
 )
 
@@ -48,6 +49,7 @@ func digDNS(ociBin, containerName, dns string) (net.IP, error) {
 	if err != nil {
 		return ip, errors.Wrapf(err, "resolve dns to ip", string(out))
 	}
+	glog.Infof("got host ip for mount in container by digging dns: %s", ip.String())
 	return ip, nil
 }
 
@@ -67,6 +69,7 @@ func dockerGatewayIP() (net.IP, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "inspect IP gatway for bridge network: %q. output: %s", string(out), bridgeID)
 	}
-	return net.ParseIP(strings.TrimSpace(string(out))), nil
-
+	ip := net.ParseIP(strings.TrimSpace(string(out)))
+	glog.Infof("got host ip for mount in container by inspect docker network: %s", ip.String())
+	return ip, nil
 }

--- a/pkg/drivers/kic/oci/network.go
+++ b/pkg/drivers/kic/oci/network.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oci
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// RoutableHostIPFromInside returns the ip/dns of the host that container lives on
+// is routable from inside the container
+func RoutableHostIPFromInside(ociBin string, containerName string) (string, error) {
+	if ociBin != Docker {
+		return "", fmt.Errorf("RoutableHostIPFromInside is currently only implemented for docker https://github.com/containers/libpod/issues/5205")
+	}
+	if runtime.GOOS == "linux" {
+		return dockerGatewayBridgeIP()
+	}
+	// for winows and mac, the gateway ip is not routable so we use dns trick.
+	return "host.docker.internal", nil
+}
+
+// dockerGatewayBridgeIP gets the default gateway ip for the docker bridge on the user's host machine
+func dockerGatewayBridgeIP() (string, error) {
+	cmd := exec.Command(Docker, "network", "ls", "--filter", "name=bridge", "--format", "{{.ID}}")
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", errors.Wrapf(err, "get network bridge. output: %s", string(out))
+	}
+
+	bridgeID := strings.TrimSpace(string(out))
+	cmd = exec.Command(Docker, "inspect",
+		"--format", "{{(index .IPAM.Config 0).Gateway}}", bridgeID)
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		return "", errors.Wrapf(err, "inspect IP gatway for bridge network: %q. output: %s", string(out), bridgeID)
+	}
+	return strings.TrimSpace(string(out)), nil
+
+}

--- a/pkg/drivers/kic/oci/network.go
+++ b/pkg/drivers/kic/oci/network.go
@@ -42,7 +42,9 @@ func RoutableHostIPFromInside(ociBin string, containerName string) (net.IP, erro
 
 // digDNS will get the IP record for a dns
 func digDNS(ociBin, containerName, dns string) (net.IP, error) {
-	PointToHostDockerDaemon()
+	if err := PointToHostDockerDaemon(); err != nil {
+		return nil, errors.Wrap(err, "point host docker-daemon")
+	}
 	cmd := exec.Command(ociBin, "exec", "-t", containerName, "dig", "+short", dns)
 	out, err := cmd.CombinedOutput()
 	ip := net.ParseIP(strings.TrimSpace(string(out)))
@@ -56,7 +58,9 @@ func digDNS(ociBin, containerName, dns string) (net.IP, error) {
 // dockerGatewayIP gets the default gateway ip for the docker bridge on the user's host machine
 // gets the ip from user's host docker
 func dockerGatewayIP() (net.IP, error) {
-	PointToHostDockerDaemon()
+	if err := PointToHostDockerDaemon(); err != nil {
+		return nil, errors.Wrap(err, "point host docker-daemon")
+	}
 	cmd := exec.Command(Docker, "network", "ls", "--filter", "name=bridge", "--format", "{{.ID}}")
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/pkg/minikube/cluster/ip.go
+++ b/pkg/minikube/cluster/ip.go
@@ -33,6 +33,10 @@ import (
 // GetVMHostIP gets the ip address to be used for mapping host -> VM and VM -> host
 func GetVMHostIP(host *host.Host) (net.IP, error) {
 	switch host.DriverName {
+	case driver.Docker:
+		return oci.RoutableHostIPFromInside(oci.Docker, host.Name)
+	case driver.Podman:
+		return oci.RoutableHostIPFromInside(oci.Podman, host.Name)
 	case driver.KVM2:
 		return net.ParseIP("192.168.39.1"), nil
 	case driver.HyperV:

--- a/pkg/minikube/cluster/mount.go
+++ b/pkg/minikube/cluster/mount.go
@@ -60,7 +60,7 @@ func Mount(r mountRunner, source string, target string, c *MountConfig) error {
 		return errors.Wrap(err, "umount")
 	}
 
-	if _, err := r.RunCmd(exec.Command("/bin/bash", "-c", fmt.Sprintf("sudo mkdir -m %o -p %s && %s", c.Mode, target, mntCmd(source, target, c)))); err != nil {
+	if _, err := r.RunCmd(exec.Command("/bin/bash", "-c", fmt.Sprintf("sudo mkdir -m %o -p %s", c.Mode, target))); err != nil {
 		return errors.Wrap(err, "create folder pre-mount")
 	}
 


### PR DESCRIPTION
This PR enables mount on docker driver for mac 
also adds a new line to the output to display the bind address

```
📁  Mounting host path /tmp/med1/ into VM as /med1 ...
    ▪ Mount type:   <no value>
    ▪ User ID:      docker
    ▪ Group ID:     docker
    ▪ Version:      9p2000.L
    ▪ Message Size: 262144
    ▪ Permissions:  755 (-rwxr-xr-x)
    ▪ Options:      map[]
    ▪ Bind Address: 127.0.0.1:56215
🚀  Userspace file server: ufs starting
✅  Successfully mounted /tmp/med1/ to /med1

📌  NOTE: This process must stay alive for the mount to be accessible 
```


closes https://github.com/kubernetes/minikube/issues/6628