### PR TITLE
wip: github actions build once

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         pwd
         ls -lah
         cp -r test/integration/testdata ./out
-        ls -lah/out
+        ls -lah /out
         whoami
         echo github ref $GITHUB_REF
         echo workflow $GITHUB_WORKFLOW

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,6 @@ jobs:
       run : |
         make minikube-linux-amd64
         make e2e-linux-amd64
-        mkdir -p report
-        mkdir -p testhome
         pwd
         ls -lah
         cp -r test/integration/testdata ./out
@@ -70,6 +68,8 @@ jobs:
       shell: bash
       run: |
         mkdir -p report
+        mkdir -p testhome
+        ls -lah
         chmod a+x e2e-*
         chmod a+x minikube-*
         ls -lah
@@ -123,6 +123,8 @@ jobs:
       shell: bash
       run: |
         mkdir -p report
+        mkdir -p testhome
+        ls -lah
         chmod a+x e2e-*
         chmod a+x minikube-*
         ls -lah
@@ -176,6 +178,8 @@ jobs:
       shell: bash
       run: |
         mkdir -p report
+        mkdir -p testhome
+        ls -lah
         chmod a+x e2e-*
         chmod a+x minikube-*
         ls -lah        
@@ -239,6 +243,8 @@ jobs:
         shell: bash
         run: |
           mkdir -p report
+          mkdir -p testhome
+          ls -lah
           chmod a+x e2e-*
           chmod a+x minikube-*
           ls -lah

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,9 +57,8 @@ jobs:
     steps:
     - name: install gopogh
       run: |
-        cd /tmp
-        GO111MODULE="on" go get github.com/medyagh/gopogh@v0.0.17 || true
-        cd -
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.18/gopogh-linux-amd64
+        sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
     - name: download binaries
       uses: actions/download-artifact@v1
       with:
@@ -111,9 +110,8 @@ jobs:
     steps:
     - name: install gopogh
       run: |
-        cd /tmp
-        GO111MODULE="on" go get github.com/medyagh/gopogh@v0.0.17 || true
-        cd -
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.18/gopogh-linux-amd64
+        sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
     - name: download binaries
       uses: actions/download-artifact@v1
       with:
@@ -165,9 +163,8 @@ jobs:
     steps:
     - name: install gopogh
       run: |
-        cd /tmp
-        GO111MODULE="on" go get github.com/medyagh/gopogh@v0.0.17 || true
-        cd -
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.18/gopogh-linux-amd64
+        sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
     - name: download binaries
       uses: actions/download-artifact@v1
       with:
@@ -219,10 +216,8 @@ jobs:
     steps:
     - name: install gopogh
       run: |
-        cd /tmp
-        GO111MODULE="on" go get github.com/medyagh/gopogh@v0.0.17 || true
-        cd -
-    - name: download binaries
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.18/gopogh-linux-amd64
+        sudo install gopogh-linux-amd64 /usr/local/bin/gopogh    - name: download binaries
       uses: actions/download-artifact@v1
       with:
         name: minikube_binaries
@@ -283,11 +278,8 @@ jobs:
           sudo podman info || true 
       - name: install gopogh
         run: |
-          curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.18/gopogh-linux-amd64 
-          ls -lah
-          sudo install gopogh-linux-amd64 gopogh-linux-amd64
-          which gopogh
-          echo $PATH
+          curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.18/gopogh-linux-amd64
+          sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
       - name: download binaries
         uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,16 @@ jobs:
       with:
         name: minikube_binaries
         path: out
+  unit_test:
+    env:
+      TIME_ELAPSED: time
+      JOB_NAME: "unit_test"
+      COMMIT_STATUS: ""
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: unit test
+      run : make test
   # Run the following integration tests after the build_minikube
   # They will run in parallel and use the binaries in previous step
   docker_ubuntu_16_04:
@@ -60,6 +70,9 @@ jobs:
       shell: bash
       run: |
         mkdir -p report
+        chmod a+x e2e-*
+        chmod a+x minikube-*
+        ls -lah
         START_TIME=$(date -u +%s)
         KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
@@ -110,6 +123,9 @@ jobs:
       shell: bash
       run: |
         mkdir -p report
+        chmod a+x e2e-*
+        chmod a+x minikube-*
+        ls -lah
         START_TIME=$(date -u +%s)
         KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
@@ -160,6 +176,9 @@ jobs:
       shell: bash
       run: |
         mkdir -p report
+        chmod a+x e2e-*
+        chmod a+x minikube-*
+        ls -lah        
         START_TIME=$(date -u +%s)
         KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
@@ -220,6 +239,9 @@ jobs:
         shell: bash
         run: |
           mkdir -p report
+          chmod a+x e2e-*
+          chmod a+x minikube-*
+          ls -lah
           START_TIME=$(date -u +%s)
           KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
           END_TIME=$(date -u +%s)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,7 @@ jobs:
         name: minikube_binaries
         path: out
   # Run the following integration tests after the build_minikube
+  # They will run in parallel and use the binaries in previous step
   docker_ubuntu_16_04:
     needs: [build_minikube]
     env:
@@ -58,7 +59,6 @@ jobs:
     - name: run integration test
       shell: bash
       run: |
-        cd minikube_binaries/out
         mkdir -p report
         START_TIME=$(date -u +%s)
         KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
@@ -70,7 +70,6 @@ jobs:
         echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
     - name: generate gopogh report
       run: |
-        cd minikube_binaries/out
         export PATH=${PATH}:`go env GOPATH`/bin
         go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
         STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name " $GITHUB_REF" -repo "${JOB_NAME} ${GITHUB_REF} ${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
@@ -84,7 +83,7 @@ jobs:
     - uses: actions/upload-artifact@v1
       with:
         name: docker_ubuntu_16_04
-        path: minikube_binaries/out/report
+        path: report
   docker_ubuntu_18_04:
     runs-on: ubuntu-18.04
     env:
@@ -110,7 +109,6 @@ jobs:
     - name: run integration test
       shell: bash
       run: |
-        cd minikube_binaries/out
         mkdir -p report
         START_TIME=$(date -u +%s)
         KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
@@ -122,7 +120,6 @@ jobs:
         echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
     - name: generate gopogh report
       run: |
-        cd minikube_binaries/out
         export PATH=${PATH}:`go env GOPATH`/bin
         go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
         STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name " $GITHUB_REF" -repo "${JOB_NAME} ${GITHUB_REF} ${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
@@ -136,7 +133,7 @@ jobs:
     - uses: actions/upload-artifact@v1
       with:
         name: docker_ubuntu_18_04
-        path: minikube_binaries/out/report
+        path: report
   none_ubuntu16_04:
     needs: [build_minikube]
     env:
@@ -162,7 +159,6 @@ jobs:
     - name: run integration test
       shell: bash
       run: |
-        cd minikube_binaries/out
         mkdir -p report
         START_TIME=$(date -u +%s)
         KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
@@ -174,7 +170,6 @@ jobs:
         echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
     - name: generate gopogh report
       run: |
-        cd minikube_binaries/out
         export PATH=${PATH}:`go env GOPATH`/bin
         go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
         STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name " $GITHUB_REF" -repo "${JOB_NAME} ${GITHUB_REF} ${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
@@ -188,7 +183,7 @@ jobs:
     - uses: actions/upload-artifact@v1
       with:
         name: none_ubuntu16_04
-        path: minikube_binaries/out/report
+        path: report
   podman_ubuntu_18_04:
       needs: [build_minikube]
       env:
@@ -205,6 +200,8 @@ jobs:
           sudo apt-key add - < Release.key || true
           sudo apt-get update -qq
           sudo apt-get -qq -y install podman
+          sudo podman version || true 
+          sudo podman info || true 
       - name: install gopogh
         run: |
           cd /tmp
@@ -222,7 +219,6 @@ jobs:
       - name: run integration test
         shell: bash
         run: |
-          cd minikube_binaries/out
           mkdir -p report
           START_TIME=$(date -u +%s)
           KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
@@ -234,7 +230,6 @@ jobs:
           echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
       - name: generate gopogh report
         run: |
-          cd minikube_binaries/out
           export PATH=${PATH}:`go env GOPATH`/bin
           go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
           STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name " $GITHUB_REF" -repo "${JOB_NAME} ${GITHUB_REF} ${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
@@ -248,7 +243,7 @@ jobs:
       - uses: actions/upload-artifact@v1
         with:
           name: podman_ubuntu_18_04
-          path: minikube_binaries/out/report  
+          path: report  
   # After all 4 integration tests finished 
   # collect all the reports and upload
   upload_all_reports:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,8 +38,13 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
+    - name: install libvirt
+      run : | 
+        sudo apt-get update
+        sudo apt-get install -y libvirt-dev
     - name: unit test
       run : make test
+      continue-on-error: false
   # Run the following integration tests after the build_minikube
   # They will run in parallel and use the binaries in previous step
   docker_ubuntu_16_04:
@@ -60,6 +65,7 @@ jobs:
       with:
         name: minikube_binaries
     - name: run integration test
+      continue-on-error: true
       shell: bash
       run: |
         cd minikube_binaries
@@ -113,6 +119,7 @@ jobs:
       with:
         name: minikube_binaries
     - name: run integration test
+      continue-on-error: true
       shell: bash
       run: |
         pwd
@@ -166,6 +173,61 @@ jobs:
       with:
         name: minikube_binaries
     - name: run integration test
+      continue-on-error: true
+      shell: bash
+      run: |
+        pwd
+        cd minikube_binaries
+        mkdir -p report
+        mkdir -p testhome
+        ls -lah
+        chmod a+x e2e-*
+        chmod a+x minikube-*
+        ls -lah        
+        START_TIME=$(date -u +%s)
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        END_TIME=$(date -u +%s)
+        TIME_ELAPSED=$(($END_TIME-$START_TIME)) 
+        min=$((${TIME_ELAPSED}/60))
+        sec=$((${TIME_ELAPSED}%60))
+        TIME_ELAPSED="${min} min $sec seconds "
+        echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
+    - name: generate gopogh report
+      run: |
+        cd minikube_binaries
+        export PATH=${PATH}:`go env GOPATH`/bin
+        go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
+        STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name " $GITHUB_REF" -repo "${JOB_NAME} ${GITHUB_REF} ${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
+        echo status: ${STAT}
+        COMMIT_STATUS="${JOB_NAME} : Completed with ${STAT} in ${TIME_ELAPSED}"
+        echo ::set-env name=COMMIT_STATUS::${COMMIT_STATUS}
+    - name: The End Result
+      run: |
+        echo time elapsed is ${TIME_ELAPSED}
+        echo END RESULT IS ${COMMIT_STATUS}
+    - uses: actions/upload-artifact@v1
+      with:
+        name: none_ubuntu16_04
+        path: report
+  none_ubuntu18_04:
+    needs: [build_minikube]
+    env:
+      TIME_ELAPSED: time
+      JOB_NAME: "None_Ubuntu_18_04"
+      COMMIT_STATUS: ""
+    runs-on: ubuntu-18.04
+    steps:
+    - name: install gopogh
+      run: |
+        cd /tmp
+        GO111MODULE="on" go get github.com/medyagh/gopogh@v0.0.17 || true
+        cd -
+    - name: download binaries
+      uses: actions/download-artifact@v1
+      with:
+        name: minikube_binaries
+    - name: run integration test
+      continue-on-error: true
       shell: bash
       run: |
         pwd
@@ -221,14 +283,17 @@ jobs:
           sudo podman info || true 
       - name: install gopogh
         run: |
-          cd /tmp
-          GO111MODULE="on" go get github.com/medyagh/gopogh@v0.0.17 || true
-          cd -
+          curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.18/gopogh-linux-amd64 
+          ls -lah
+          sudo install gopogh-linux-amd64 gopogh-linux-amd64
+          which gopogh
+          echo $PATH
       - name: download binaries
         uses: actions/download-artifact@v1
         with:
           name: minikube_binaries
       - name: run integration test
+        continue-on-error: true
         shell: bash
         run: |
           cd minikube_binaries
@@ -246,7 +311,7 @@ jobs:
           sec=$((${TIME_ELAPSED}%60))
           TIME_ELAPSED="${min} min $sec seconds "
           echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
-      - name: generate gopogh report
+      - name: generate html report
         run: |
           pwd
           cd minikube_binaries
@@ -267,14 +332,14 @@ jobs:
   # After all 4 integration tests finished 
   # collect all the reports and upload
   upload_all_reports:
-    needs: [docker_ubuntu_16_04,docker_ubuntu_18_04,none_ubuntu16_04,podman_ubuntu_18_04]
+    needs: [docker_ubuntu_16_04,docker_ubuntu_18_04,none_ubuntu16_04,none_ubuntu18_04,podman_ubuntu_18_04]
     runs-on: ubuntu-18.04
     steps:
     - name: download results docker_ubuntu_16_04
       uses: actions/download-artifact@v1
       with:
         name: docker_ubuntu_16_04
-    - name: see if report is there
+    - name: cp to all_report
       shell: bash
       run: |
         pwd
@@ -286,7 +351,7 @@ jobs:
       uses: actions/download-artifact@v1
       with:
         name: docker_ubuntu_18_04
-    - name: see if report is there
+    - name: cp to all_report
       shell: bash
       run: |
         pwd
@@ -298,7 +363,7 @@ jobs:
       uses: actions/download-artifact@v1
       with:
         name: none_ubuntu16_04
-    - name: see if report is there
+    - name: cp to all_report
       shell: bash
       run: |
         pwd
@@ -306,12 +371,23 @@ jobs:
         ls -lah none_ubuntu16_04
         mkdir -p all_reports
         cp -r none_ubuntu16_04 ./all_reports/
-
+    - name: download results none_ubuntu18_04
+      uses: actions/download-artifact@v1
+      with:
+        name: none_ubuntu18_04
+    - name: cp to all_report
+      shell: bash
+      run: |
+        pwd
+        ls -lah
+        ls -lah none_ubuntu18_04
+        mkdir -p all_reports
+        cp -r none_ubuntu18_04 ./all_reports/
     - name: download results podman_ubuntu_18_04
       uses: actions/download-artifact@v1
       with:
         name: podman_ubuntu_18_04
-    - name: see if report is there
+    - name: cp to all_report
       shell: bash
       run: |
         pwd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,14 +59,10 @@ jobs:
       uses: actions/download-artifact@v1
       with:
         name: minikube_binaries
-    - name: see if report is there
-      shell: bash
-      run: |
-        pwd
-        ls -lah minikube_binaries
     - name: run integration test
       shell: bash
       run: |
+        cd minikube_binaries
         mkdir -p report
         mkdir -p testhome
         ls -lah
@@ -83,6 +79,8 @@ jobs:
         echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
     - name: generate gopogh report
       run: |
+        pwd
+        cd minikube_binaries
         export PATH=${PATH}:`go env GOPATH`/bin
         go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
         STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name " $GITHUB_REF" -repo "${JOB_NAME} ${GITHUB_REF} ${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
@@ -114,14 +112,11 @@ jobs:
       uses: actions/download-artifact@v1
       with:
         name: minikube_binaries
-    - name: see if report is there
-      shell: bash
-      run: |
-        pwd
-        ls -lah minikube_binaries
     - name: run integration test
       shell: bash
       run: |
+        pwd
+        cd minikube_binaries
         mkdir -p report
         mkdir -p testhome
         ls -lah
@@ -138,6 +133,7 @@ jobs:
         echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
     - name: generate gopogh report
       run: |
+        cd minikube_binaries
         export PATH=${PATH}:`go env GOPATH`/bin
         go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
         STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name " $GITHUB_REF" -repo "${JOB_NAME} ${GITHUB_REF} ${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
@@ -169,14 +165,11 @@ jobs:
       uses: actions/download-artifact@v1
       with:
         name: minikube_binaries
-    - name: see if report is there
-      shell: bash
-      run: |
-        pwd
-        ls -lah minikube_binaries
     - name: run integration test
       shell: bash
       run: |
+        pwd
+        cd minikube_binaries
         mkdir -p report
         mkdir -p testhome
         ls -lah
@@ -193,6 +186,7 @@ jobs:
         echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
     - name: generate gopogh report
       run: |
+        cd minikube_binaries
         export PATH=${PATH}:`go env GOPATH`/bin
         go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
         STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name " $GITHUB_REF" -repo "${JOB_NAME} ${GITHUB_REF} ${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
@@ -234,14 +228,10 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: minikube_binaries
-      - name: see if report is there
-        shell: bash
-        run: |
-          pwd
-          ls -lah minikube_binaries
       - name: run integration test
         shell: bash
         run: |
+          cd minikube_binaries
           mkdir -p report
           mkdir -p testhome
           ls -lah
@@ -258,6 +248,8 @@ jobs:
           echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
       - name: generate gopogh report
         run: |
+          pwd
+          cd minikube_binaries
           export PATH=${PATH}:`go env GOPATH`/bin
           go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
           STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name " $GITHUB_REF" -repo "${JOB_NAME} ${GITHUB_REF} ${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,12 +1,14 @@
 name: CI
 on: [pull_request]
 jobs:
-  docker_ubuntu_16_04:
+  # Runs before all other jobs
+  # builds the minikube binaries 
+  build_minikube:
     env:
       TIME_ELAPSED: time
       JOB_NAME: "Docker_Ubuntu_16_04"
       COMMIT_STATUS: ""
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - name: build binaries
@@ -17,8 +19,8 @@ jobs:
         mkdir -p testhome
         pwd
         ls -lah
-        cp -r test/integration/testdata ./
-        ls -lah
+        cp -r test/integration/testdata ./out
+        ls -lah/out
         whoami
         echo github ref $GITHUB_REF
         echo workflow $GITHUB_WORKFLOW
@@ -26,16 +28,40 @@ jobs:
         echo event name $GITHUB_EVENT_NAME
         echo workspace $GITHUB_WORKSPACE
         echo "end of debug stuff"
-        
+    - uses: actions/upload-artifact@v1
+      with:
+        name: minikube_binaries
+        path: out
+  # Run the following integration tests after the build_minikube
+  docker_ubuntu_16_04:
+    needs: [build_minikube]
+    env:
+      TIME_ELAPSED: time
+      JOB_NAME: "Docker_Ubuntu_16_04"
+      COMMIT_STATUS: ""
+    runs-on: ubuntu-16.04
+    steps:
     - name: install gopogh
       run: |
         cd /tmp
         GO111MODULE="on" go get github.com/medyagh/gopogh@v0.0.17 || true
         cd -
-    - name: run integration test
+    - name: download binaries
+      uses: actions/download-artifact@v1
+      with:
+        name: minikube_binaries
+    - name: see if report is there
+      shell: bash
       run: |
+        pwd
+        ls -lah minikube_binaries
+    - name: run integration test
+      shell: bash
+      run: |
+        cd minikube_binaries/out
+        mkdir -p report
         START_TIME=$(date -u +%s)
-        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./out/e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
         TIME_ELAPSED=$(($END_TIME-$START_TIME)) 
         min=$((${TIME_ELAPSED}/60))
@@ -44,6 +70,7 @@ jobs:
         echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
     - name: generate gopogh report
       run: |
+        cd minikube_binaries/out
         export PATH=${PATH}:`go env GOPATH`/bin
         go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
         STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name " $GITHUB_REF" -repo "${JOB_NAME} ${GITHUB_REF} ${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
@@ -57,43 +84,45 @@ jobs:
     - uses: actions/upload-artifact@v1
       with:
         name: docker_ubuntu_16_04
-        path: report
+        path: minikube_binaries/out/report
   docker_ubuntu_18_04:
+    runs-on: ubuntu-18.04
     env:
       TIME_ELAPSED: time
       JOB_NAME: "Docker_Ubuntu_18_04"
       COMMIT_STATUS: ""
-    runs-on: ubuntu-18.04
+    needs: [build_minikube]
     steps:
-    - uses: actions/checkout@v2
-    - name: build binaries
-      run : |
-        make minikube-linux-amd64
-        make e2e-linux-amd64
-        mkdir -p report
-        mkdir -p testhome
-        pwd
-        ls -lah
-        cp -r test/integration/testdata ./
-        ls -lah
-        whoami
     - name: install gopogh
       run: |
         cd /tmp
         GO111MODULE="on" go get github.com/medyagh/gopogh@v0.0.17 || true
         cd -
-    - name: run integration test
+    - name: download binaries
+      uses: actions/download-artifact@v1
+      with:
+        name: minikube_binaries
+    - name: see if report is there
+      shell: bash
       run: |
+        pwd
+        ls -lah minikube_binaries
+    - name: run integration test
+      shell: bash
+      run: |
+        cd minikube_binaries/out
+        mkdir -p report
         START_TIME=$(date -u +%s)
-        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./out/e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
         TIME_ELAPSED=$(($END_TIME-$START_TIME)) 
         min=$((${TIME_ELAPSED}/60))
         sec=$((${TIME_ELAPSED}%60))
-        TIME_ELAPSED="${min} min $sec seconds"
+        TIME_ELAPSED="${min} min $sec seconds "
         echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
     - name: generate gopogh report
       run: |
+        cd minikube_binaries/out
         export PATH=${PATH}:`go env GOPATH`/bin
         go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
         STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name " $GITHUB_REF" -repo "${JOB_NAME} ${GITHUB_REF} ${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
@@ -107,43 +136,45 @@ jobs:
     - uses: actions/upload-artifact@v1
       with:
         name: docker_ubuntu_18_04
-        path: report
+        path: minikube_binaries/out/report
   none_ubuntu16_04:
+    needs: [build_minikube]
     env:
       TIME_ELAPSED: time
       JOB_NAME: "None_Ubuntu_16_04"
       COMMIT_STATUS: ""
     runs-on: ubuntu-16.04
     steps:
-    - uses: actions/checkout@v2
-    - name: build binaries
-      run : |
-        make minikube-linux-amd64
-        make e2e-linux-amd64
-        mkdir -p report
-        mkdir -p testhome
-        pwd
-        ls -lah
-        cp -r test/integration/testdata ./
-        ls -lah
-        whoami
     - name: install gopogh
       run: |
         cd /tmp
         GO111MODULE="on" go get github.com/medyagh/gopogh@v0.0.17 || true
         cd -
-    - name: run integration test
+    - name: download binaries
+      uses: actions/download-artifact@v1
+      with:
+        name: minikube_binaries
+    - name: see if report is there
+      shell: bash
       run: |
+        pwd
+        ls -lah minikube_binaries
+    - name: run integration test
+      shell: bash
+      run: |
+        cd minikube_binaries/out
+        mkdir -p report
         START_TIME=$(date -u +%s)
-        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome sudo -E ./out/e2e-linux-amd64 -minikube-start-args=--vm-driver=none -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
         TIME_ELAPSED=$(($END_TIME-$START_TIME)) 
         min=$((${TIME_ELAPSED}/60))
         sec=$((${TIME_ELAPSED}%60))
-        TIME_ELAPSED="${min} min $sec seconds"
+        TIME_ELAPSED="${min} min $sec seconds "
         echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
     - name: generate gopogh report
       run: |
+        cd minikube_binaries/out
         export PATH=${PATH}:`go env GOPATH`/bin
         go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
         STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name " $GITHUB_REF" -repo "${JOB_NAME} ${GITHUB_REF} ${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
@@ -157,15 +188,15 @@ jobs:
     - uses: actions/upload-artifact@v1
       with:
         name: none_ubuntu16_04
-        path: report
+        path: minikube_binaries/out/report
   podman_ubuntu_18_04:
+      needs: [build_minikube]
       env:
         TIME_ELAPSED: time
         JOB_NAME: "Podman_Ubuntu_18_04"
         COMMIT_STATUS: ""
       runs-on: ubuntu-18.04
       steps:
-      - uses: actions/checkout@v2
       - name: install podman
         run: |
           . /etc/os-release
@@ -174,35 +205,36 @@ jobs:
           sudo apt-key add - < Release.key || true
           sudo apt-get update -qq
           sudo apt-get -qq -y install podman
-      - name: build binaries
-        run : |
-          make minikube-linux-amd64
-          make e2e-linux-amd64
-          mkdir -p report
-          mkdir -p testhome
-          pwd
-          ls -lah
-          cp -r test/integration/testdata ./
-          cp -r test/integration/testdata ./
-          ls -lah
-          whoami
       - name: install gopogh
         run: |
           cd /tmp
           GO111MODULE="on" go get github.com/medyagh/gopogh@v0.0.17 || true
           cd -
-      - name: run integration test
+      - name: download binaries
+        uses: actions/download-artifact@v1
+        with:
+          name: minikube_binaries
+      - name: see if report is there
+        shell: bash
         run: |
+          pwd
+          ls -lah minikube_binaries
+      - name: run integration test
+        shell: bash
+        run: |
+          cd minikube_binaries/out
+          mkdir -p report
           START_TIME=$(date -u +%s)
-          KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome sudo -E ./out/e2e-linux-amd64 -minikube-start-args=--vm-driver=podman -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+          KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
           END_TIME=$(date -u +%s)
           TIME_ELAPSED=$(($END_TIME-$START_TIME)) 
           min=$((${TIME_ELAPSED}/60))
           sec=$((${TIME_ELAPSED}%60))
-          TIME_ELAPSED="${min} min $sec seconds"
+          TIME_ELAPSED="${min} min $sec seconds "
           echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
       - name: generate gopogh report
         run: |
+          cd minikube_binaries/out
           export PATH=${PATH}:`go env GOPATH`/bin
           go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
           STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name " $GITHUB_REF" -repo "${JOB_NAME} ${GITHUB_REF} ${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
@@ -216,7 +248,9 @@ jobs:
       - uses: actions/upload-artifact@v1
         with:
           name: podman_ubuntu_18_04
-          path: report
+          path: minikube_binaries/out/report  
+  # After all 4 integration tests finished 
+  # collect all the reports and upload
   upload_all_reports:
     needs: [docker_ubuntu_16_04,docker_ubuntu_18_04,none_ubuntu16_04,podman_ubuntu_18_04]
     runs-on: ubuntu-18.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         pwd
         ls -lah
         cp -r test/integration/testdata ./out
-        ls -lah /out
+        ls -lah ./out
         whoami
         echo github ref $GITHUB_REF
         echo workflow $GITHUB_WORKFLOW


### PR DESCRIPTION
After this PR:
- you can download minikube binaries (minikube & e2e) for each commit as part of the test.
- build binaries once and share among different github action jobs
- add unit tests to github actions so one page has most information.
