### PR TITLE
downloadable reports and one line result summary

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,9 +42,11 @@ jobs:
       run : | 
         sudo apt-get update
         sudo apt-get install -y libvirt-dev
+    # does not include lint, because lint times out in github actions
+    # lint is done in travis
     - name: only unit test
       run : |
-        export TESTSUITE" = "unittest"
+        export TESTSUITE = "unittest"
         make test
         continue-on-error: false
   # Run the following integration tests after the build_minikube
@@ -85,7 +87,7 @@ jobs:
         sec=$((${TIME_ELAPSED}%60))
         TIME_ELAPSED="${min} min $sec seconds "
         echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
-    - name: generate gopogh report
+    - name: Generate html report
       run: |
         pwd
         cd minikube_binaries
@@ -102,7 +104,7 @@ jobs:
     - uses: actions/upload-artifact@v1
       with:
         name: docker_ubuntu_16_04
-        path: report
+        path: minikube_binaries/report
   docker_ubuntu_18_04:
     runs-on: ubuntu-18.04
     env:
@@ -140,7 +142,7 @@ jobs:
         sec=$((${TIME_ELAPSED}%60))
         TIME_ELAPSED="${min} min $sec seconds "
         echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
-    - name: generate gopogh report
+    - name: Generate html report
       run: |
         cd minikube_binaries
         export PATH=${PATH}:`go env GOPATH`/bin
@@ -156,7 +158,7 @@ jobs:
     - uses: actions/upload-artifact@v1
       with:
         name: docker_ubuntu_18_04
-        path: report
+        path: minikube_binaries/report
   none_ubuntu16_04:
     needs: [build_minikube]
     env:
@@ -194,7 +196,7 @@ jobs:
         sec=$((${TIME_ELAPSED}%60))
         TIME_ELAPSED="${min} min $sec seconds "
         echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
-    - name: generate gopogh report
+    - name: Generate html report
       run: |
         cd minikube_binaries
         export PATH=${PATH}:`go env GOPATH`/bin
@@ -210,7 +212,7 @@ jobs:
     - uses: actions/upload-artifact@v1
       with:
         name: none_ubuntu16_04
-        path: report
+        path: minikube_binaries/report
   none_ubuntu18_04:
     needs: [build_minikube]
     env:
@@ -248,7 +250,7 @@ jobs:
         sec=$((${TIME_ELAPSED}%60))
         TIME_ELAPSED="${min} min $sec seconds "
         echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
-    - name: generate gopogh report
+    - name: Generate html report
       run: |
         cd minikube_binaries
         export PATH=${PATH}:`go env GOPATH`/bin
@@ -264,7 +266,7 @@ jobs:
     - uses: actions/upload-artifact@v1
       with:
         name: none_ubuntu16_04
-        path: report
+        path: minikube_binaries/report
   podman_ubuntu_18_04:
       needs: [build_minikube]
       env:
@@ -328,7 +330,7 @@ jobs:
       - uses: actions/upload-artifact@v1
         with:
           name: podman_ubuntu_18_04
-          path: report  
+          path: minikube_binaries/report
   # After all 4 integration tests finished 
   # collect all the reports and upload
   upload_all_reports:
@@ -397,5 +399,5 @@ jobs:
         cp -r podman_ubuntu_18_04 ./all_reports/
     - uses: actions/upload-artifact@v1
       with:
-        name: all_reports
+        name: all_reports_${GITHUB_REF}
         path: all_reports

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,24 +1,24 @@
 name: CI
 on: [pull_request]
 jobs:
-  docker_ubuntu_16_04:
+  # Runs before all other jobs
+  # builds the minikube binaries 
+  build_minikube:
     env:
       TIME_ELAPSED: time
       JOB_NAME: "Docker_Ubuntu_16_04"
       COMMIT_STATUS: ""
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - name: build binaries
       run : |
         make minikube-linux-amd64
         make e2e-linux-amd64
-        mkdir -p report
-        mkdir -p testhome
         pwd
         ls -lah
-        cp -r test/integration/testdata ./
-        ls -lah
+        cp -r test/integration/testdata ./out
+        ls -lah ./out
         whoami
         echo github ref $GITHUB_REF
         echo workflow $GITHUB_WORKFLOW
@@ -26,16 +26,56 @@ jobs:
         echo event name $GITHUB_EVENT_NAME
         echo workspace $GITHUB_WORKSPACE
         echo "end of debug stuff"
-        
+    - uses: actions/upload-artifact@v1
+      with:
+        name: minikube_binaries
+        path: out
+  unit_test:
+    env:
+      TIME_ELAPSED: time
+      JOB_NAME: "unit_test"
+      COMMIT_STATUS: ""
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: install libvirt
+      run : | 
+        sudo apt-get update
+        sudo apt-get install -y libvirt-dev
+    - name: unit test
+      run : make test
+      continue-on-error: false
+  # Run the following integration tests after the build_minikube
+  # They will run in parallel and use the binaries in previous step
+  docker_ubuntu_16_04:
+    needs: [build_minikube]
+    env:
+      TIME_ELAPSED: time
+      JOB_NAME: "Docker_Ubuntu_16_04"
+      COMMIT_STATUS: ""
+    runs-on: ubuntu-16.04
+    steps:
     - name: install gopogh
       run: |
-        cd /tmp
-        GO111MODULE="on" go get github.com/medyagh/gopogh@v0.0.17 || true
-        cd -
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.18/gopogh-linux-amd64
+        sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
+    - name: download binaries
+      uses: actions/download-artifact@v1
+      with:
+        name: minikube_binaries
     - name: run integration test
+      continue-on-error: true
+      shell: bash
       run: |
+        cd minikube_binaries
+        mkdir -p report
+        mkdir -p testhome
+        ls -lah
+        chmod a+x e2e-*
+        chmod a+x minikube-*
+        ls -lah
         START_TIME=$(date -u +%s)
-        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./out/e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
         TIME_ELAPSED=$(($END_TIME-$START_TIME)) 
         min=$((${TIME_ELAPSED}/60))
@@ -44,6 +84,8 @@ jobs:
         echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
     - name: generate gopogh report
       run: |
+        pwd
+        cd minikube_binaries
         export PATH=${PATH}:`go env GOPATH`/bin
         go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
         STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name " $GITHUB_REF" -repo "${JOB_NAME} ${GITHUB_REF} ${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
@@ -59,41 +101,44 @@ jobs:
         name: docker_ubuntu_16_04
         path: report
   docker_ubuntu_18_04:
+    runs-on: ubuntu-18.04
     env:
       TIME_ELAPSED: time
       JOB_NAME: "Docker_Ubuntu_18_04"
       COMMIT_STATUS: ""
-    runs-on: ubuntu-18.04
+    needs: [build_minikube]
     steps:
-    - uses: actions/checkout@v2
-    - name: build binaries
-      run : |
-        make minikube-linux-amd64
-        make e2e-linux-amd64
-        mkdir -p report
-        mkdir -p testhome
-        pwd
-        ls -lah
-        cp -r test/integration/testdata ./
-        ls -lah
-        whoami
     - name: install gopogh
       run: |
-        cd /tmp
-        GO111MODULE="on" go get github.com/medyagh/gopogh@v0.0.17 || true
-        cd -
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.18/gopogh-linux-amd64
+        sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
+    - name: download binaries
+      uses: actions/download-artifact@v1
+      with:
+        name: minikube_binaries
     - name: run integration test
+      continue-on-error: true
+      shell: bash
       run: |
+        pwd
+        cd minikube_binaries
+        mkdir -p report
+        mkdir -p testhome
+        ls -lah
+        chmod a+x e2e-*
+        chmod a+x minikube-*
+        ls -lah
         START_TIME=$(date -u +%s)
-        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./out/e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
         TIME_ELAPSED=$(($END_TIME-$START_TIME)) 
         min=$((${TIME_ELAPSED}/60))
         sec=$((${TIME_ELAPSED}%60))
-        TIME_ELAPSED="${min} min $sec seconds"
+        TIME_ELAPSED="${min} min $sec seconds "
         echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
     - name: generate gopogh report
       run: |
+        cd minikube_binaries
         export PATH=${PATH}:`go env GOPATH`/bin
         go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
         STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name " $GITHUB_REF" -repo "${JOB_NAME} ${GITHUB_REF} ${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
@@ -109,41 +154,97 @@ jobs:
         name: docker_ubuntu_18_04
         path: report
   none_ubuntu16_04:
+    needs: [build_minikube]
     env:
       TIME_ELAPSED: time
       JOB_NAME: "None_Ubuntu_16_04"
       COMMIT_STATUS: ""
     runs-on: ubuntu-16.04
     steps:
-    - uses: actions/checkout@v2
-    - name: build binaries
-      run : |
-        make minikube-linux-amd64
-        make e2e-linux-amd64
-        mkdir -p report
-        mkdir -p testhome
-        pwd
-        ls -lah
-        cp -r test/integration/testdata ./
-        ls -lah
-        whoami
     - name: install gopogh
       run: |
-        cd /tmp
-        GO111MODULE="on" go get github.com/medyagh/gopogh@v0.0.17 || true
-        cd -
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.18/gopogh-linux-amd64
+        sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
+    - name: download binaries
+      uses: actions/download-artifact@v1
+      with:
+        name: minikube_binaries
     - name: run integration test
+      continue-on-error: true
+      shell: bash
       run: |
+        pwd
+        cd minikube_binaries
+        mkdir -p report
+        mkdir -p testhome
+        ls -lah
+        chmod a+x e2e-*
+        chmod a+x minikube-*
+        ls -lah        
         START_TIME=$(date -u +%s)
-        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome sudo -E ./out/e2e-linux-amd64 -minikube-start-args=--vm-driver=none -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
         TIME_ELAPSED=$(($END_TIME-$START_TIME)) 
         min=$((${TIME_ELAPSED}/60))
         sec=$((${TIME_ELAPSED}%60))
-        TIME_ELAPSED="${min} min $sec seconds"
+        TIME_ELAPSED="${min} min $sec seconds "
         echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
     - name: generate gopogh report
       run: |
+        cd minikube_binaries
+        export PATH=${PATH}:`go env GOPATH`/bin
+        go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
+        STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name " $GITHUB_REF" -repo "${JOB_NAME} ${GITHUB_REF} ${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
+        echo status: ${STAT}
+        COMMIT_STATUS="${JOB_NAME} : Completed with ${STAT} in ${TIME_ELAPSED}"
+        echo ::set-env name=COMMIT_STATUS::${COMMIT_STATUS}
+    - name: The End Result
+      run: |
+        echo time elapsed is ${TIME_ELAPSED}
+        echo END RESULT IS ${COMMIT_STATUS}
+    - uses: actions/upload-artifact@v1
+      with:
+        name: none_ubuntu16_04
+        path: report
+  none_ubuntu18_04:
+    needs: [build_minikube]
+    env:
+      TIME_ELAPSED: time
+      JOB_NAME: "None_Ubuntu_18_04"
+      COMMIT_STATUS: ""
+    runs-on: ubuntu-18.04
+    steps:
+    - name: install gopogh
+      run: |
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.18/gopogh-linux-amd64
+        sudo install gopogh-linux-amd64 /usr/local/bin/gopogh    
+    - name: download binaries
+      uses: actions/download-artifact@v1
+      with:
+        name: minikube_binaries
+    - name: run integration test
+      continue-on-error: true
+      shell: bash
+      run: |
+        pwd
+        cd minikube_binaries
+        mkdir -p report
+        mkdir -p testhome
+        ls -lah
+        chmod a+x e2e-*
+        chmod a+x minikube-*
+        ls -lah        
+        START_TIME=$(date -u +%s)
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        END_TIME=$(date -u +%s)
+        TIME_ELAPSED=$(($END_TIME-$START_TIME)) 
+        min=$((${TIME_ELAPSED}/60))
+        sec=$((${TIME_ELAPSED}%60))
+        TIME_ELAPSED="${min} min $sec seconds "
+        echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
+    - name: generate gopogh report
+      run: |
+        cd minikube_binaries
         export PATH=${PATH}:`go env GOPATH`/bin
         go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
         STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name " $GITHUB_REF" -repo "${JOB_NAME} ${GITHUB_REF} ${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
@@ -159,13 +260,13 @@ jobs:
         name: none_ubuntu16_04
         path: report
   podman_ubuntu_18_04:
+      needs: [build_minikube]
       env:
         TIME_ELAPSED: time
         JOB_NAME: "Podman_Ubuntu_18_04"
         COMMIT_STATUS: ""
       runs-on: ubuntu-18.04
       steps:
-      - uses: actions/checkout@v2
       - name: install podman
         run: |
           . /etc/os-release
@@ -174,35 +275,39 @@ jobs:
           sudo apt-key add - < Release.key || true
           sudo apt-get update -qq
           sudo apt-get -qq -y install podman
-      - name: build binaries
-        run : |
-          make minikube-linux-amd64
-          make e2e-linux-amd64
-          mkdir -p report
-          mkdir -p testhome
-          pwd
-          ls -lah
-          cp -r test/integration/testdata ./
-          cp -r test/integration/testdata ./
-          ls -lah
-          whoami
+          sudo podman version || true 
+          sudo podman info || true 
       - name: install gopogh
         run: |
-          cd /tmp
-          GO111MODULE="on" go get github.com/medyagh/gopogh@v0.0.17 || true
-          cd -
+          curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.18/gopogh-linux-amd64
+          sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
+      - name: download binaries
+        uses: actions/download-artifact@v1
+        with:
+          name: minikube_binaries
       - name: run integration test
+        continue-on-error: true
+        shell: bash
         run: |
+          cd minikube_binaries
+          mkdir -p report
+          mkdir -p testhome
+          ls -lah
+          chmod a+x e2e-*
+          chmod a+x minikube-*
+          ls -lah
           START_TIME=$(date -u +%s)
-          KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome sudo -E ./out/e2e-linux-amd64 -minikube-start-args=--vm-driver=podman -expected-default-driver= -test.timeout=70m -test.v -binary=out/minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+          KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
           END_TIME=$(date -u +%s)
           TIME_ELAPSED=$(($END_TIME-$START_TIME)) 
           min=$((${TIME_ELAPSED}/60))
           sec=$((${TIME_ELAPSED}%60))
-          TIME_ELAPSED="${min} min $sec seconds"
+          TIME_ELAPSED="${min} min $sec seconds "
           echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
-      - name: generate gopogh report
+      - name: generate html report
         run: |
+          pwd
+          cd minikube_binaries
           export PATH=${PATH}:`go env GOPATH`/bin
           go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
           STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name " $GITHUB_REF" -repo "${JOB_NAME} ${GITHUB_REF} ${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
@@ -216,16 +321,18 @@ jobs:
       - uses: actions/upload-artifact@v1
         with:
           name: podman_ubuntu_18_04
-          path: report
+          path: report  
+  # After all 4 integration tests finished 
+  # collect all the reports and upload
   upload_all_reports:
-    needs: [docker_ubuntu_16_04,docker_ubuntu_18_04,none_ubuntu16_04,podman_ubuntu_18_04]
+    needs: [docker_ubuntu_16_04,docker_ubuntu_18_04,none_ubuntu16_04,none_ubuntu18_04,podman_ubuntu_18_04]
     runs-on: ubuntu-18.04
     steps:
     - name: download results docker_ubuntu_16_04
       uses: actions/download-artifact@v1
       with:
         name: docker_ubuntu_16_04
-    - name: see if report is there
+    - name: cp to all_report
       shell: bash
       run: |
         pwd
@@ -237,7 +344,7 @@ jobs:
       uses: actions/download-artifact@v1
       with:
         name: docker_ubuntu_18_04
-    - name: see if report is there
+    - name: cp to all_report
       shell: bash
       run: |
         pwd
@@ -249,7 +356,7 @@ jobs:
       uses: actions/download-artifact@v1
       with:
         name: none_ubuntu16_04
-    - name: see if report is there
+    - name: cp to all_report
       shell: bash
       run: |
         pwd
@@ -257,12 +364,23 @@ jobs:
         ls -lah none_ubuntu16_04
         mkdir -p all_reports
         cp -r none_ubuntu16_04 ./all_reports/
-
+    - name: download results none_ubuntu18_04
+      uses: actions/download-artifact@v1
+      with:
+        name: none_ubuntu18_04
+    - name: cp to all_report
+      shell: bash
+      run: |
+        pwd
+        ls -lah
+        ls -lah none_ubuntu18_04
+        mkdir -p all_reports
+        cp -r none_ubuntu18_04 ./all_reports/
     - name: download results podman_ubuntu_18_04
       uses: actions/download-artifact@v1
       with:
         name: podman_ubuntu_18_04
-    - name: see if report is there
+    - name: cp to all_report
       shell: bash
       run: |
         pwd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -391,5 +391,5 @@ jobs:
         cp -r podman_ubuntu_18_04 ./all_reports/
     - uses: actions/upload-artifact@v1
       with:
-        name: all_reports_${{ GITHUB_REF }}
+        name: all_reports
         path: all_reports

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     env:
       TIME_ELAPSED: time
       JOB_NAME: "Docker_Ubuntu_16_04"
-      COMMIT_STATUS: ""
+      GOPOGH_RESULT: ""
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
     env:
       TIME_ELAPSED: time
       JOB_NAME: "unit_test"
-      COMMIT_STATUS: ""
+      GOPOGH_RESULT: ""
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
@@ -58,12 +58,12 @@ jobs:
     env:
       TIME_ELAPSED: time
       JOB_NAME: "Docker_Ubuntu_16_04"
-      COMMIT_STATUS: ""
+      GOPOGH_RESULT: ""
     runs-on: ubuntu-16.04
     steps:
     - name: Install gopogh
       run: |
-        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.14/gopogh-linux-amd64
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.16/gopogh-linux-amd64
         sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
     - name: Download binaries
       uses: actions/download-artifact@v1
@@ -94,12 +94,16 @@ jobs:
         go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
         STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name " $GITHUB_REF" -repo "${JOB_NAME} ${GITHUB_REF} ${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
         echo status: ${STAT}
-        COMMIT_STATUS="${JOB_NAME} : Completed with ${STAT} in ${TIME_ELAPSED}"
-        echo ::set-env name=COMMIT_STATUS::${COMMIT_STATUS}
+        FailNum=$(echo $STAT | jq '.NumberOfFail')
+        TestsNum=$(echo $STAT | jq '.NumberOfTests')       
+        GOPOGH_RESULT="${JOB_NAME} : completed with ${FailNum} / ${TestsNum} failures in ${TIME_ELAPSED}"
+        echo ::set-env name=GOPOGH_RESULT::${GOPOGH_RESULT}
+        echo ::set-env name=STAT::${STAT}
     - name: The End Result
       run: |
-        echo time elapsed is ${TIME_ELAPSED}
-        echo END RESULT IS ${COMMIT_STATUS}
+        echo ${GOPOGH_RESULT}
+        echo ""
+        echo $STAT | jq '.FailedTests' || true
     - uses: actions/upload-artifact@v1
       with:
         name: docker_ubuntu_16_04
@@ -109,12 +113,12 @@ jobs:
     env:
       TIME_ELAPSED: time
       JOB_NAME: "Docker_Ubuntu_18_04"
-      COMMIT_STATUS: ""
+      GOPOGH_RESULT: ""
     needs: [build_minikube]
     steps:
     - name: Install gopogh
       run: |
-        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.14/gopogh-linux-amd64
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.16/gopogh-linux-amd64
         sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
     - name: Download binaries
       uses: actions/download-artifact@v1
@@ -145,12 +149,16 @@ jobs:
         go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
         STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name " $GITHUB_REF" -repo "${JOB_NAME} ${GITHUB_REF} ${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
         echo status: ${STAT}
-        COMMIT_STATUS="${JOB_NAME} : Completed with ${STAT} in ${TIME_ELAPSED}"
-        echo ::set-env name=COMMIT_STATUS::${COMMIT_STATUS}
+        FailNum=$(echo $STAT | jq '.NumberOfFail')
+        TestsNum=$(echo $STAT | jq '.NumberOfTests')       
+        GOPOGH_RESULT="${JOB_NAME} : completed with ${FailNum} / ${TestsNum} failures in ${TIME_ELAPSED}"
+        echo ::set-env name=GOPOGH_RESULT::${GOPOGH_RESULT}
+        echo ::set-env name=STAT::${STAT}
     - name: The End Result
       run: |
-        echo time elapsed is ${TIME_ELAPSED}
-        echo END RESULT IS ${COMMIT_STATUS}
+        echo ${GOPOGH_RESULT}
+        echo ""
+        echo $STAT | jq '.FailedTests' || true
     - uses: actions/upload-artifact@v1
       with:
         name: docker_ubuntu_18_04
@@ -160,12 +168,12 @@ jobs:
     env:
       TIME_ELAPSED: time
       JOB_NAME: "None_Ubuntu_16_04"
-      COMMIT_STATUS: ""
+      GOPOGH_RESULT: ""
     runs-on: ubuntu-16.04
     steps:
     - name: Install gopogh
       run: |
-        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.14/gopogh-linux-amd64
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.16/gopogh-linux-amd64
         sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
     - name: Download binaries
       uses: actions/download-artifact@v1
@@ -196,12 +204,16 @@ jobs:
         go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
         STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name " $GITHUB_REF" -repo "${JOB_NAME} ${GITHUB_REF} ${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
         echo status: ${STAT}
-        COMMIT_STATUS="${JOB_NAME} : Completed with ${STAT} in ${TIME_ELAPSED}"
-        echo ::set-env name=COMMIT_STATUS::${COMMIT_STATUS}
+        FailNum=$(echo $STAT | jq '.NumberOfFail')
+        TestsNum=$(echo $STAT | jq '.NumberOfTests')       
+        GOPOGH_RESULT="${JOB_NAME} : completed with ${FailNum} / ${TestsNum} failures in ${TIME_ELAPSED}"
+        echo ::set-env name=GOPOGH_RESULT::${GOPOGH_RESULT}
+        echo ::set-env name=STAT::${STAT}
     - name: The End Result
       run: |
-        echo time elapsed is ${TIME_ELAPSED}
-        echo END RESULT IS ${COMMIT_STATUS}
+        echo ${GOPOGH_RESULT}
+        echo ""
+        echo $STAT | jq '.FailedTests' || true
     - uses: actions/upload-artifact@v1
       with:
         name: none_ubuntu16_04
@@ -211,12 +223,12 @@ jobs:
     env:
       TIME_ELAPSED: time
       JOB_NAME: "None_Ubuntu_18_04"
-      COMMIT_STATUS: ""
+      GOPOGH_RESULT: ""
     runs-on: ubuntu-18.04
     steps:
     - name: Install gopogh
       run: |
-        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.14/gopogh-linux-amd64
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.16/gopogh-linux-amd64
         sudo install gopogh-linux-amd64 /usr/local/bin/gopogh    
     - name: Download binaries
       uses: actions/download-artifact@v1
@@ -247,12 +259,16 @@ jobs:
         go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
         STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name " $GITHUB_REF" -repo "${JOB_NAME} ${GITHUB_REF} ${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
         echo status: ${STAT}
-        COMMIT_STATUS="${JOB_NAME} : Completed with ${STAT} in ${TIME_ELAPSED}"
-        echo ::set-env name=COMMIT_STATUS::${COMMIT_STATUS}
+        FailNum=$(echo $STAT | jq '.NumberOfFail')
+        TestsNum=$(echo $STAT | jq '.NumberOfTests')       
+        GOPOGH_RESULT="${JOB_NAME} : completed with ${FailNum} / ${TestsNum} failures in ${TIME_ELAPSED}"
+        echo ::set-env name=GOPOGH_RESULT::${GOPOGH_RESULT}
+        echo ::set-env name=STAT::${STAT}
     - name: The End Result
       run: |
-        echo time elapsed is ${TIME_ELAPSED}
-        echo END RESULT IS ${COMMIT_STATUS}
+        echo ${GOPOGH_RESULT}
+        echo ""
+        echo $STAT | jq '.FailedTests' || true
     - uses: actions/upload-artifact@v1
       with:
         name: none_ubuntu18_04
@@ -262,7 +278,7 @@ jobs:
       env:
         TIME_ELAPSED: time
         JOB_NAME: "Podman_Ubuntu_18_04"
-        COMMIT_STATUS: ""
+        GOPOGH_RESULT: ""
       runs-on: ubuntu-18.04
       steps:
       - name: install podman
@@ -277,7 +293,7 @@ jobs:
           sudo podman info || true 
       - name: Install gopogh
         run: |
-          curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.14/gopogh-linux-amd64
+          curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.16/gopogh-linux-amd64
           sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
       - name: Download binaries
         uses: actions/download-artifact@v1
@@ -306,14 +322,18 @@ jobs:
           cd minikube_binaries
           export PATH=${PATH}:`go env GOPATH`/bin
           go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
-          STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name " $GITHUB_REF" -repo "${JOB_NAME} ${GITHUB_REF} ${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
           echo status: ${STAT}
-          COMMIT_STATUS="${JOB_NAME} : Completed with ${STAT} in ${TIME_ELAPSED}"
-          echo ::set-env name=COMMIT_STATUS::${COMMIT_STATUS}
+          FailNum=$(echo $STAT | jq '.NumberOfFail')
+          TestsNum=$(echo $STAT | jq '.NumberOfTests')       
+          GOPOGH_RESULT="${JOB_NAME} : completed with ${FailNum} / ${TestsNum} failures in ${TIME_ELAPSED}"
+          echo ::set-env name=GOPOGH_RESULT::${GOPOGH_RESULT}
+          echo ::set-env name=STAT::${STAT}
       - name: The End Result
         run: |
-          echo time elapsed is ${TIME_ELAPSED}
-          echo ${COMMIT_STATUS}
+          echo ${GOPOGH_RESULT}
+          echo ""
+          echo $STAT | jq '.FailedTests' || true
+
       - uses: actions/upload-artifact@v1
         with:
           name: podman_ubuntu_18_04
@@ -371,5 +391,5 @@ jobs:
         cp -r podman_ubuntu_18_04 ./all_reports/
     - uses: actions/upload-artifact@v1
       with:
-        name: all_reports_${GITHUB_REF}
+        name: all_reports_${{ GITHUB_REF }}
         path: all_reports

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,15 +63,15 @@ jobs:
       COMMIT_STATUS: ""
     runs-on: ubuntu-16.04
     steps:
-    - name: install gopogh
+    - name: Install gopogh
       run: |
         curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.22/gopogh-linux-amd64
-        sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
+        sudo Install gopogh-linux-amd64 /usr/local/bin/gopogh
     - name: download binaries
       uses: actions/download-artifact@v1
       with:
         name: minikube_binaries
-    - name: run integration test
+    - name: Run integration test
       continue-on-error: true
       # bash {0} to allow test to continue to next step. in case of
       shell: bash {0}
@@ -117,15 +117,15 @@ jobs:
       COMMIT_STATUS: ""
     needs: [build_minikube]
     steps:
-    - name: install gopogh
+    - name: Install gopogh
       run: |
         curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.22/gopogh-linux-amd64
-        sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
+        sudo Install gopogh-linux-amd64 /usr/local/bin/gopogh
     - name: download binaries
       uses: actions/download-artifact@v1
       with:
         name: minikube_binaries
-    - name: run integration test
+    - name: Run integration test
       continue-on-error: true
       # bash {0} to allow test to continue to next step. in case of
       shell: bash {0}
@@ -171,15 +171,15 @@ jobs:
       COMMIT_STATUS: ""
     runs-on: ubuntu-16.04
     steps:
-    - name: install gopogh
+    - name: Install gopogh
       run: |
         curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.22/gopogh-linux-amd64
-        sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
+        sudo Install gopogh-linux-amd64 /usr/local/bin/gopogh
     - name: download binaries
       uses: actions/download-artifact@v1
       with:
         name: minikube_binaries
-    - name: run integration test
+    - name: Run integration test
       continue-on-error: true
       # bash {0} to allow test to continue to next step. in case of
       shell: bash {0}
@@ -225,15 +225,15 @@ jobs:
       COMMIT_STATUS: ""
     runs-on: ubuntu-18.04
     steps:
-    - name: install gopogh
+    - name: Install gopogh
       run: |
         curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.22/gopogh-linux-amd64
-        sudo install gopogh-linux-amd64 /usr/local/bin/gopogh    
+        sudo Install gopogh-linux-amd64 /usr/local/bin/gopogh    
     - name: download binaries
       uses: actions/download-artifact@v1
       with:
         name: minikube_binaries
-    - name: run integration test
+    - name: Run integration test
       continue-on-error: true
       # bash {0} to allow test to continue to next step. in case of
       shell: bash {0}
@@ -269,7 +269,7 @@ jobs:
         echo END RESULT IS ${COMMIT_STATUS}
     - uses: actions/upload-artifact@v1
       with:
-        name: none_ubuntu16_04
+        name: none_ubuntu18_04
         path: minikube_binaries/report
   podman_ubuntu_18_04:
       needs: [build_minikube]
@@ -289,15 +289,15 @@ jobs:
           sudo apt-get -qq -y install podman
           sudo podman version || true 
           sudo podman info || true 
-      - name: install gopogh
+      - name: Install gopogh
         run: |
           curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.22/gopogh-linux-amd64
-          sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
+          sudo Install gopogh-linux-amd64 /usr/local/bin/gopogh
       - name: download binaries
         uses: actions/download-artifact@v1
         with:
           name: minikube_binaries
-      - name: run integration test
+      - name: Run integration test
         continue-on-error: true
         # bash {0} to allow test to continue to next step. in case of
         shell: bash {0}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -322,6 +322,7 @@ jobs:
           cd minikube_binaries
           export PATH=${PATH}:`go env GOPATH`/bin
           go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
+          STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name " $GITHUB_REF" -repo "${JOB_NAME} ${GITHUB_REF} ${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
           echo status: ${STAT}
           FailNum=$(echo $STAT | jq '.NumberOfFail')
           TestsNum=$(echo $STAT | jq '.NumberOfTests')       

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,9 +42,11 @@ jobs:
       run : | 
         sudo apt-get update
         sudo apt-get install -y libvirt-dev
-    - name: unit test
-      run : make test
-      continue-on-error: false
+    - name: only unit test
+      run : |
+        export TESTSUITE" = "unittest"
+        make test
+        continue-on-error: false
   # Run the following integration tests after the build_minikube
   # They will run in parallel and use the binaries in previous step
   docker_ubuntu_16_04:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,8 +65,8 @@ jobs:
     steps:
     - name: Install gopogh
       run: |
-        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.22/gopogh-linux-amd64
-        sudo Install gopogh-linux-amd64 /usr/local/bin/gopogh
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.3/gopogh-linux-amd64
+        sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
     - name: download binaries
       uses: actions/download-artifact@v1
       with:
@@ -119,8 +119,8 @@ jobs:
     steps:
     - name: Install gopogh
       run: |
-        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.22/gopogh-linux-amd64
-        sudo Install gopogh-linux-amd64 /usr/local/bin/gopogh
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.3/gopogh-linux-amd64
+        sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
     - name: download binaries
       uses: actions/download-artifact@v1
       with:
@@ -173,8 +173,8 @@ jobs:
     steps:
     - name: Install gopogh
       run: |
-        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.22/gopogh-linux-amd64
-        sudo Install gopogh-linux-amd64 /usr/local/bin/gopogh
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.3/gopogh-linux-amd64
+        sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
     - name: download binaries
       uses: actions/download-artifact@v1
       with:
@@ -227,8 +227,8 @@ jobs:
     steps:
     - name: Install gopogh
       run: |
-        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.22/gopogh-linux-amd64
-        sudo Install gopogh-linux-amd64 /usr/local/bin/gopogh    
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.3/gopogh-linux-amd64
+        sudo install gopogh-linux-amd64 /usr/local/bin/gopogh    
     - name: download binaries
       uses: actions/download-artifact@v1
       with:
@@ -291,8 +291,8 @@ jobs:
           sudo podman info || true 
       - name: Install gopogh
         run: |
-          curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.22/gopogh-linux-amd64
-          sudo Install gopogh-linux-amd64 /usr/local/bin/gopogh
+          curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.3/gopogh-linux-amd64
+          sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
       - name: download binaries
         uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
     - name: install gopogh
       run: |
-        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.18/gopogh-linux-amd64
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.22/gopogh-linux-amd64
         sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
     - name: download binaries
       uses: actions/download-artifact@v1
@@ -110,7 +110,7 @@ jobs:
     steps:
     - name: install gopogh
       run: |
-        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.18/gopogh-linux-amd64
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.22/gopogh-linux-amd64
         sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
     - name: download binaries
       uses: actions/download-artifact@v1
@@ -163,7 +163,7 @@ jobs:
     steps:
     - name: install gopogh
       run: |
-        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.18/gopogh-linux-amd64
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.22/gopogh-linux-amd64
         sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
     - name: download binaries
       uses: actions/download-artifact@v1
@@ -216,7 +216,7 @@ jobs:
     steps:
     - name: install gopogh
       run: |
-        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.18/gopogh-linux-amd64
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.22/gopogh-linux-amd64
         sudo install gopogh-linux-amd64 /usr/local/bin/gopogh    
     - name: download binaries
       uses: actions/download-artifact@v1
@@ -279,7 +279,7 @@ jobs:
           sudo podman info || true 
       - name: install gopogh
         run: |
-          curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.18/gopogh-linux-amd64
+          curl -LO https://github.com/medyagh/gopogh/releases/download/v0.0.22/gopogh-linux-amd64
           sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
       - name: download binaries
         uses: actions/download-artifact@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,8 @@ jobs:
         name: minikube_binaries
     - name: run integration test
       continue-on-error: true
-      shell: bash
+      # bash {0} to allow test to continue to next step. in case of
+      shell: bash {0}
       run: |
         cd minikube_binaries
         mkdir -p report
@@ -120,7 +121,8 @@ jobs:
         name: minikube_binaries
     - name: run integration test
       continue-on-error: true
-      shell: bash
+      # bash {0} to allow test to continue to next step. in case of
+      shell: bash {0}
       run: |
         pwd
         cd minikube_binaries
@@ -173,7 +175,8 @@ jobs:
         name: minikube_binaries
     - name: run integration test
       continue-on-error: true
-      shell: bash
+      # bash {0} to allow test to continue to next step. in case of
+      shell: bash {0}
       run: |
         pwd
         cd minikube_binaries
@@ -226,7 +229,8 @@ jobs:
         name: minikube_binaries
     - name: run integration test
       continue-on-error: true
-      shell: bash
+      # bash {0} to allow test to continue to next step. in case of
+      shell: bash {0}
       run: |
         pwd
         cd minikube_binaries
@@ -289,7 +293,8 @@ jobs:
           name: minikube_binaries
       - name: run integration test
         continue-on-error: true
-        shell: bash
+        # bash {0} to allow test to continue to next step. in case of
+        shell: bash {0}
         run: |
           cd minikube_binaries
           mkdir -p report

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,13 +42,17 @@ jobs:
       run : | 
         sudo apt-get update
         sudo apt-get install -y libvirt-dev
-    # does not include lint, because lint times out in github actions
-    # lint is done in travis
-    - name: only unit test
-      run : |
-        export TESTSUITE = "unittest"
+    - name: lint
+      env:
+        TESTSUITE: lintall
+      run : make test
+      continue-on-error: false
+    - name: unit test
+      env:
+        TESTSUITE: unittest
+      run :
         make test
-        continue-on-error: false
+      continue-on-error: false
   # Run the following integration tests after the build_minikube
   # They will run in parallel and use the binaries in previous step
   docker_ubuntu_16_04:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,10 +15,7 @@ jobs:
       run : |
         make minikube-linux-amd64
         make e2e-linux-amd64
-        pwd
-        ls -lah
         cp -r test/integration/testdata ./out
-        ls -lah ./out
         whoami
         echo github ref $GITHUB_REF
         echo workflow $GITHUB_WORKFLOW
@@ -26,6 +23,7 @@ jobs:
         echo event name $GITHUB_EVENT_NAME
         echo workspace $GITHUB_WORKSPACE
         echo "end of debug stuff"
+        echo $(which jq)
     - uses: actions/upload-artifact@v1
       with:
         name: minikube_binaries
@@ -65,9 +63,9 @@ jobs:
     steps:
     - name: Install gopogh
       run: |
-        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.3/gopogh-linux-amd64
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.14/gopogh-linux-amd64
         sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
-    - name: download binaries
+    - name: Download binaries
       uses: actions/download-artifact@v1
       with:
         name: minikube_binaries
@@ -79,10 +77,8 @@ jobs:
         cd minikube_binaries
         mkdir -p report
         mkdir -p testhome
-        ls -lah
         chmod a+x e2e-*
         chmod a+x minikube-*
-        ls -lah
         START_TIME=$(date -u +%s)
         KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
@@ -93,7 +89,6 @@ jobs:
         echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
     - name: Generate html report
       run: |
-        pwd
         cd minikube_binaries
         export PATH=${PATH}:`go env GOPATH`/bin
         go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
@@ -119,9 +114,9 @@ jobs:
     steps:
     - name: Install gopogh
       run: |
-        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.3/gopogh-linux-amd64
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.14/gopogh-linux-amd64
         sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
-    - name: download binaries
+    - name: Download binaries
       uses: actions/download-artifact@v1
       with:
         name: minikube_binaries
@@ -130,14 +125,11 @@ jobs:
       # bash {0} to allow test to continue to next step. in case of
       shell: bash {0}
       run: |
-        pwd
         cd minikube_binaries
         mkdir -p report
         mkdir -p testhome
-        ls -lah
         chmod a+x e2e-*
         chmod a+x minikube-*
-        ls -lah
         START_TIME=$(date -u +%s)
         KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
@@ -173,9 +165,9 @@ jobs:
     steps:
     - name: Install gopogh
       run: |
-        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.3/gopogh-linux-amd64
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.14/gopogh-linux-amd64
         sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
-    - name: download binaries
+    - name: Download binaries
       uses: actions/download-artifact@v1
       with:
         name: minikube_binaries
@@ -184,14 +176,11 @@ jobs:
       # bash {0} to allow test to continue to next step. in case of
       shell: bash {0}
       run: |
-        pwd
         cd minikube_binaries
         mkdir -p report
         mkdir -p testhome
-        ls -lah
         chmod a+x e2e-*
         chmod a+x minikube-*
-        ls -lah        
         START_TIME=$(date -u +%s)
         KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
@@ -227,9 +216,9 @@ jobs:
     steps:
     - name: Install gopogh
       run: |
-        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.3/gopogh-linux-amd64
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.14/gopogh-linux-amd64
         sudo install gopogh-linux-amd64 /usr/local/bin/gopogh    
-    - name: download binaries
+    - name: Download binaries
       uses: actions/download-artifact@v1
       with:
         name: minikube_binaries
@@ -238,14 +227,11 @@ jobs:
       # bash {0} to allow test to continue to next step. in case of
       shell: bash {0}
       run: |
-        pwd
         cd minikube_binaries
         mkdir -p report
         mkdir -p testhome
-        ls -lah
         chmod a+x e2e-*
         chmod a+x minikube-*
-        ls -lah        
         START_TIME=$(date -u +%s)
         KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
@@ -291,9 +277,9 @@ jobs:
           sudo podman info || true 
       - name: Install gopogh
         run: |
-          curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.3/gopogh-linux-amd64
+          curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.14/gopogh-linux-amd64
           sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
-      - name: download binaries
+      - name: Download binaries
         uses: actions/download-artifact@v1
         with:
           name: minikube_binaries
@@ -305,10 +291,8 @@ jobs:
           cd minikube_binaries
           mkdir -p report
           mkdir -p testhome
-          ls -lah
           chmod a+x e2e-*
           chmod a+x minikube-*
-          ls -lah
           START_TIME=$(date -u +%s)
           KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -expected-default-driver= -test.timeout=70m -test.v -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
           END_TIME=$(date -u +%s)
@@ -317,9 +301,8 @@ jobs:
           sec=$((${TIME_ELAPSED}%60))
           TIME_ELAPSED="${min} min $sec seconds "
           echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
-      - name: generate html report
+      - name: Generate html report
         run: |
-          pwd
           cd minikube_binaries
           export PATH=${PATH}:`go env GOPATH`/bin
           go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
@@ -330,7 +313,7 @@ jobs:
       - name: The End Result
         run: |
           echo time elapsed is ${TIME_ELAPSED}
-          echo END RESULT IS ${COMMIT_STATUS}
+          echo ${COMMIT_STATUS}
       - uses: actions/upload-artifact@v1
         with:
           name: podman_ubuntu_18_04
@@ -348,9 +331,6 @@ jobs:
     - name: cp to all_report
       shell: bash
       run: |
-        pwd
-        ls -lah
-        ls -lah docker_ubuntu_16_04
         mkdir -p all_reports
         cp -r docker_ubuntu_16_04 ./all_reports/
     - name: download results docker_ubuntu_18_04
@@ -360,9 +340,6 @@ jobs:
     - name: cp to all_report
       shell: bash
       run: |
-        pwd
-        ls -lah
-        ls -lah docker_ubuntu_18_04
         mkdir -p all_reports
         cp -r docker_ubuntu_18_04 ./all_reports/
     - name: download results none_ubuntu16_04
@@ -372,9 +349,6 @@ jobs:
     - name: cp to all_report
       shell: bash
       run: |
-        pwd
-        ls -lah
-        ls -lah none_ubuntu16_04
         mkdir -p all_reports
         cp -r none_ubuntu16_04 ./all_reports/
     - name: download results none_ubuntu18_04
@@ -384,9 +358,6 @@ jobs:
     - name: cp to all_report
       shell: bash
       run: |
-        pwd
-        ls -lah
-        ls -lah none_ubuntu18_04
         mkdir -p all_reports
         cp -r none_ubuntu18_04 ./all_reports/
     - name: download results podman_ubuntu_18_04
@@ -396,9 +367,6 @@ jobs:
     - name: cp to all_report
       shell: bash
       run: |
-        pwd
-        ls -lah
-        ls -lah podman_ubuntu_18_04
         mkdir -p all_reports
         cp -r podman_ubuntu_18_04 ./all_reports/
     - uses: actions/upload-artifact@v1

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ GOLINT_JOBS ?= 4
 # see https://github.com/golangci/golangci-lint#memory-usage-of-golangci-lint
 GOLINT_GOGC ?= 100
 # options for lint (golangci-lint)
-GOLINT_OPTIONS = --timeout 4m \
+GOLINT_OPTIONS = --timeout 7m \
 	  --build-tags "${MINIKUBE_INTEGRATION_BUILD_TAGS}" \
 	  --enable goimports,gocritic,golint,gocyclo,misspell,nakedret,stylecheck,unconvert,unparam,dogsled \
 	  --exclude 'variable on range scope.*in function literal|ifElseChain' \


### PR DESCRIPTION
After this PR:

- you can download minikube binaries (minikube & e2e) for each commit as part of the test.
- build binaries once and share among different github action jobs
- add unit tests to github actions so one page has most information.
- add a block called The End Result to see summary of what tests and how many tests failed.

```
 The End Result
Docker_Ubuntu_18_04 : completed with 16 / 48 failures in 30 min 26 seconds

[
  "TestDownloadOnly/group/v1.11.10",
  "TestDownloadOnly/group/v1.17.2",
  "TestDownloadOnly/group/v1.17.2#01",
  "TestDownloadOnly/group/DeleteAll",
  "TestOffline/group/docker",
  "TestOffline/group/crio",
  "TestOffline/group/containerd",
  "TestAddons/parallel/MetricsServer",
  "TestVersionUpgrade",
  "TestFunctional/parallel/MountCmd",
  "TestFunctional/parallel/MySQL",
  "TestFunctional/parallel/DockerEnv",
  "TestStartStop/group/old-docker",
  "TestStartStop/group/newest-cni",
  "TestStartStop/group/containerd",
  "TestStartStop/group/crio"

```

- link to download either all test reports or built binaries for this PR or individual test report

![Screen Shot 2020-02-14 at 6 54 12 PM](https://user-images.githubusercontent.com/4564227/74580668-79110c00-4f5b-11ea-990f-73aa4c365ddb.png)
