### PR TITLE
Profile command should not create non existent profiles

### DIFF
--- a/cmd/minikube/cmd/config/profile.go
+++ b/cmd/minikube/cmd/config/profile.go
@@ -65,11 +65,7 @@ var ProfileCmd = &cobra.Command{
 		}
 
 		if !pkgConfig.ProfileExists(profile) {
-			err := pkgConfig.CreateEmptyProfile(profile)
-			if err != nil {
-				exit.WithError("Creating a new profile failed", err)
-			}
-			out.SuccessT("Created a new profile : {{.profile_name}}", out.V{"profile_name": profile})
+			out.FailureT("if you want to create a profile you can by this command: minikube start -p {{.profile_name}}", out.V{"profile_name": profile})
 		}
 
 		err := Set(pkgConfig.MachineProfile, profile)
@@ -91,7 +87,7 @@ var ProfileCmd = &cobra.Command{
 					out.ErrT(out.Sad, `Error while setting kubectl current context :  {{.error}}`, out.V{"error": err})
 				}
 			}
+			out.SuccessT("minikube profile was successfully set to {{.profile_name}}", out.V{"profile_name": profile})
 		}
-		out.SuccessT("minikube profile was successfully set to {{.profile_name}}", out.V{"profile_name": profile})
 	},
 }

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -494,7 +494,25 @@ func validateLogsCmd(ctx context.Context, t *testing.T, profile string) {
 
 // validateProfileCmd asserts "profile" command functionality
 func validateProfileCmd(ctx context.Context, t *testing.T, profile string) {
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), "profile", "list"))
+	// Profile command should not create a nonexistent profile
+	nonexistentProfile := "lis"
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), "profile", nonexistentProfile))
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Args, err)
+	}
+	for _, word := range []string{fmt.Sprintf("Created a new profile : %s", nonexistentProfile), fmt.Sprintf("minikube profile was successfully set to %s", nonexistentProfile)} {
+		if strings.Contains(rr.Stdout.String(), word) {
+			t.Errorf("minikube profile should not create a nonexistent profile")
+		}
+	}
+	for _, word := range []string{fmt.Sprintf("profile \"%s\" not found", nonexistentProfile), fmt.Sprintf("if you want to create a profile you can by this command: minikube start -p %s", nonexistentProfile)} {
+		if !strings.Contains(rr.Stderr.String(), word) {
+			t.Errorf("minikube profile should provide guidance on how to create a nonexistent profile")
+		}
+	}
+
+	// List profiles
+	rr, err = Run(t, exec.CommandContext(ctx, Target(), "profile", "list"))
 	if err != nil {
 		t.Errorf("%s failed: %v", rr.Args, err)
 	}

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -500,13 +500,13 @@ func validateProfileCmd(ctx context.Context, t *testing.T, profile string) {
 	if err != nil {
 		t.Errorf("%s failed: %v", rr.Args, err)
 	}
-	for _, word := range []string{fmt.Sprintf("Created a new profile : %s", nonexistentProfile), fmt.Sprintf("minikube profile was successfully set to %s", nonexistentProfile)} {
-		if strings.Contains(rr.Stdout.String(), word) {
+	for _, line := range []string{fmt.Sprintf("Created a new profile : %s", nonexistentProfile), fmt.Sprintf("minikube profile was successfully set to %s", nonexistentProfile)} {
+		if strings.Contains(rr.Stdout.String(), line) {
 			t.Errorf("minikube profile should not create a nonexistent profile")
 		}
 	}
-	for _, word := range []string{fmt.Sprintf("profile \"%s\" not found", nonexistentProfile), fmt.Sprintf("if you want to create a profile you can by this command: minikube start -p %s", nonexistentProfile)} {
-		if !strings.Contains(rr.Stderr.String(), word) {
+	for _, line := range []string{fmt.Sprintf("profile \"%s\" not found", nonexistentProfile), fmt.Sprintf("if you want to create a profile you can by this command: minikube start -p %s", nonexistentProfile)} {
+		if !strings.Contains(rr.Stderr.String(), line) {
 			t.Errorf("minikube profile should provide guidance on how to create a nonexistent profile")
 		}
 	}


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
### The Change Set
Fixes #6647

This updates `profile` to no longer create profiles that do not exist and provides feedback to user on how to create the non-existent profile.

### Just One Snag...

One thing brought up in the issue that doesn't appear to be true is...

> however, 'minikube profile pname'
> should still change the profile to 'pname' if it exists. but should not create a new one.

However; **`minikube profile pname` does not change `profile` to `pname` before this change set**. This seems like it would be **new functionality**

``` bash
$ minikube create -p profile
$ minikube profile pname
```

Instead of _renaming `profile` to `pname`_, it instead creates a `pname` profile that needs to be deleted.

TLDR; This aspect of issue #6647 may be a new feature request because this behavior does not exist today.

See below screenshots.

<img width="717" alt="Screenshot 2020-02-17 18 53 24" src="https://user-images.githubusercontent.com/3106250/74693191-a1e20d00-51b8-11ea-9271-627d8704bdc9.png">
<img width="718" alt="Screenshot 2020-02-17 18 53 33" src="https://user-images.githubusercontent.com/3106250/74693193-a4446700-51b8-11ea-96ee-567be90ba271.png">
<img width="717" alt="Screenshot 2020-02-17 18 53 43" src="https://user-images.githubusercontent.com/3106250/74693195-a6a6c100-51b8-11ea-94ce-51624b9b0422.png">
<img width="718" alt="Screenshot 2020-02-17 18 53 54" src="https://user-images.githubusercontent.com/3106250/74693198-a8708480-51b8-11ea-8bee-7922182ce941.png">
<img width="717" alt="Screenshot 2020-02-17 18 54 01" src="https://user-images.githubusercontent.com/3106250/74693203-aa3a4800-51b8-11ea-8d8f-dbe7c603872a.png">
<img width="720" alt="Screenshot 2020-02-17 19 04 47" src="https://user-images.githubusercontent.com/3106250/74693206-ac040b80-51b8-11ea-9f85-b01dc4913e85.png">
