### PR TITLE
Need to use python3 from the path for varlink

### DIFF
--- a/deploy/iso/minikube-iso/package/varlink/varlink.mk
+++ b/deploy/iso/minikube-iso/package/varlink/varlink.mk
@@ -4,4 +4,12 @@ VARLINK_SOURCE = $(VARLINK_VERSION).tar.gz
 VARLINK_LICENSE = Apache-2.0
 VARLINK_LICENSE_FILES = LICENSE
 
+VARLINK_NEEDS_HOST_PYTHON = python3
+
+define VARLINK_ENV_PYTHON3
+    sed -e 's|/usr/bin/python3|/usr/bin/env python3|' -i $(@D)/varlink-wrapper.py
+endef
+
+VARLINK_POST_EXTRACT_HOOKS += VARLINK_ENV_PYTHON3
+
 $(eval $(meson-package))


### PR DESCRIPTION
Replaces #6671 

Varlink hardcodes `/usr/bin/python3`, but _should_ use `/usr/bin/env python3` and the $PATH.

We have a python3 version in `out/buildroot/output/host/bin/python3`, so don't need it installed...