### PR TITLE
fix inverted logic for resource logic

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -665,7 +665,7 @@ func validateFlags(cmd *cobra.Command, drvName string) {
 	validateDiskSize()
 	validateMemorySize()
 
-	if !driver.HasResourceLimits(drvName) { // both podman and none need root and they both cant specify resources
+	if !driver.HasResourceLimits(drvName) {
 		if cmd.Flags().Changed(cpus) {
 			out.WarningT("The '{{.name}}' driver does not respect the --cpus flag", out.V{"name": drvName})
 		}

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -115,7 +115,7 @@ func NeedsRoot(name string) bool {
 
 // HasResourceLimits returns true if driver can set resource limits such as memory size or CPU count.
 func HasResourceLimits(name string) bool {
-	return name == None || name == Podman
+	return !(name == None || name == Podman)
 }
 
 // FlagHints are hints for what default options should be used for this driver

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -522,7 +522,7 @@ func validateProfileCmd(ctx context.Context, t *testing.T, profile string) {
 
 	t.Run("profile_list", func(t *testing.T) {
 		// List profiles
-		rr, err = Run(t, exec.CommandContext(ctx, Target(), "profile", "list"))
+		rr, err := Run(t, exec.CommandContext(ctx, Target(), "profile", "list"))
 		if err != nil {
 			t.Errorf("%s failed: %v", rr.Args, err)
 		}
@@ -545,7 +545,7 @@ func validateProfileCmd(ctx context.Context, t *testing.T, profile string) {
 
 	t.Run("profile_json_output", func(t *testing.T) {
 		// Json output
-		rr, err = Run(t, exec.CommandContext(ctx, Target(), "profile", "list", "--output", "json"))
+		rr, err := Run(t, exec.CommandContext(ctx, Target(), "profile", "list", "--output", "json"))
 		if err != nil {
 			t.Errorf("%s failed: %v", rr.Args, err)
 		}
@@ -555,7 +555,7 @@ func validateProfileCmd(ctx context.Context, t *testing.T, profile string) {
 			t.Errorf("%s failed: %v", rr.Args, err)
 		}
 		validProfiles := jsonObject["valid"]
-		profileExists = false
+		profileExists := false
 		for _, profileObject := range validProfiles {
 			if profileObject["Name"] == profile {
 				profileExists = true

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -494,68 +494,79 @@ func validateLogsCmd(ctx context.Context, t *testing.T, profile string) {
 
 // validateProfileCmd asserts "profile" command functionality
 func validateProfileCmd(ctx context.Context, t *testing.T, profile string) {
-	// Profile command should not create a nonexistent profile
-	nonexistentProfile := "lis"
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), "profile", nonexistentProfile))
-	rr, err = Run(t, exec.CommandContext(ctx, Target(), "profile", "list", "--output", "json"))
-	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
-	}
-	var profileJson map[string][]map[string]interface{}
-	err = json.Unmarshal(rr.Stdout.Bytes(), &profileJson)
-	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
-	}
-	for profileK := range profileJson {
-		for _, p := range profileJson[profileK] {
-			var name = p["Name"]
-			if name == nonexistentProfile {
-				t.Errorf("minikube profile %s should not exist", nonexistentProfile)
+	t.Run("profile_not_create", func(t *testing.T) {
+		// Profile command should not create a nonexistent profile
+		nonexistentProfile := "lis"
+		rr, err := Run(t, exec.CommandContext(ctx, Target(), "profile", nonexistentProfile))
+		if err != nil {
+			t.Errorf("%s failed: %v", rr.Args, err)
+		}
+		rr, err = Run(t, exec.CommandContext(ctx, Target(), "profile", "list", "--output", "json"))
+		if err != nil {
+			t.Errorf("%s failed: %v", rr.Args, err)
+		}
+		var profileJSON map[string][]map[string]interface{}
+		err = json.Unmarshal(rr.Stdout.Bytes(), &profileJSON)
+		if err != nil {
+			t.Errorf("%s failed: %v", rr.Args, err)
+		}
+		for profileK := range profileJSON {
+			for _, p := range profileJSON[profileK] {
+				var name = p["Name"]
+				if name == nonexistentProfile {
+					t.Errorf("minikube profile %s should not exist", nonexistentProfile)
+				}
 			}
 		}
-	}
+	})
 
-	// List profiles
-	rr, err = Run(t, exec.CommandContext(ctx, Target(), "profile", "list"))
-	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
-	}
-
-	// Table output
-	listLines := strings.Split(strings.TrimSpace(rr.Stdout.String()), "\n")
-	profileExists := false
-	for i := 3; i < (len(listLines) - 1); i++ {
-		profileLine := listLines[i]
-		if strings.Contains(profileLine, profile) {
-			profileExists = true
-			break
+	t.Run("profile_list", func(t *testing.T) {
+		// List profiles
+		rr, err = Run(t, exec.CommandContext(ctx, Target(), "profile", "list"))
+		if err != nil {
+			t.Errorf("%s failed: %v", rr.Args, err)
 		}
-	}
-	if !profileExists {
-		t.Errorf("%s failed: Missing profile '%s'. Got '\n%s\n'", rr.Args, profile, rr.Stdout.String())
-	}
 
-	// Json output
-	rr, err = Run(t, exec.CommandContext(ctx, Target(), "profile", "list", "--output", "json"))
-	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
-	}
-	var jsonObject map[string][]map[string]interface{}
-	err = json.Unmarshal(rr.Stdout.Bytes(), &jsonObject)
-	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
-	}
-	validProfiles := jsonObject["valid"]
-	profileExists = false
-	for _, profileObject := range validProfiles {
-		if profileObject["Name"] == profile {
-			profileExists = true
-			break
+		// Table output
+		listLines := strings.Split(strings.TrimSpace(rr.Stdout.String()), "\n")
+		profileExists := false
+		for i := 3; i < (len(listLines) - 1); i++ {
+			profileLine := listLines[i]
+			if strings.Contains(profileLine, profile) {
+				profileExists = true
+				break
+			}
 		}
-	}
-	if !profileExists {
-		t.Errorf("%s failed: Missing profile '%s'. Got '\n%s\n'", rr.Args, profile, rr.Stdout.String())
-	}
+		if !profileExists {
+			t.Errorf("%s failed: Missing profile '%s'. Got '\n%s\n'", rr.Args, profile, rr.Stdout.String())
+		}
+
+	})
+
+	t.Run("profile_json_output", func(t *testing.T) {
+		// Json output
+		rr, err = Run(t, exec.CommandContext(ctx, Target(), "profile", "list", "--output", "json"))
+		if err != nil {
+			t.Errorf("%s failed: %v", rr.Args, err)
+		}
+		var jsonObject map[string][]map[string]interface{}
+		err = json.Unmarshal(rr.Stdout.Bytes(), &jsonObject)
+		if err != nil {
+			t.Errorf("%s failed: %v", rr.Args, err)
+		}
+		validProfiles := jsonObject["valid"]
+		profileExists = false
+		for _, profileObject := range validProfiles {
+			if profileObject["Name"] == profile {
+				profileExists = true
+				break
+			}
+		}
+		if !profileExists {
+			t.Errorf("%s failed: Missing profile '%s'. Got '\n%s\n'", rr.Args, profile, rr.Stdout.String())
+		}
+
+	})
 }
 
 // validateServiceCmd asserts basic "service" command functionality

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -509,7 +509,7 @@ func validateProfileCmd(ctx context.Context, t *testing.T, profile string) {
 	for profileK := range profileJson {
 		for _, p := range profileJson[profileK] {
 			var name = p["Name"]
-			if (name == nonexistentProfile) {
+			if name == nonexistentProfile {
 				t.Errorf("minikube profile %s should not exist", nonexistentProfile)
 			}
 		}


### PR DESCRIPTION
medmac@~/minikube (mount_kic) $ ./out/minikube start --vm-driver=docker -p p2 --memory=2500mb
😄  [p2] minikube v1.7.2 on Darwin 10.13.6
✨  Using the docker (experimental) driver based on user configuration
⚠️  The 'docker' driver does not respect the --memory flag

also the lint issue on master, which travis didnt show on the PR