### PR TITLE
[BumpUp]update registry 2.6.1 → 2.7.1

### DIFF
--- a/deploy/addons/registry/registry-rc.yaml.tmpl
+++ b/deploy/addons/registry/registry-rc.yaml.tmpl
@@ -18,7 +18,7 @@ spec:
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:
-      - image: registry.hub.docker.com/library/registry:2.6.1
+      - image: registry.hub.docker.com/library/registry:2.7.1
         imagePullPolicy: IfNotPresent
         name: registry
         ports:

--- a/site/content/en/docs/Tasks/docker_daemon.md
+++ b/site/content/en/docs/Tasks/docker_daemon.md
@@ -76,4 +76,4 @@ docker ps
 
 ##  Related Documentation
 
-- [docker_registry.md](Using the Docker registry)
+-  [Using the Docker registry](docker_registry.md)


### PR DESCRIPTION
### What type of PR is this?
/kind cleanup

### What this PR does / why we need it:

This PR bump up registry addon's image v2.16.1 to v2.17.1

### Which issue(s) this PR fixes:

Fixes #6706

### Does this PR introduce a user-facing change?

No.

**Before**
```
image: registry.hub.docker.com/library/registry:v2.16.1
```

**After**
```
image: registry.hub.docker.com/library/registry:v2.17.1
```

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```

