### PR TITLE
label minikube nodes

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -490,7 +490,7 @@ func (k *Bootstrapper) applyKicOverlay(cfg config.MachineConfig) error {
 
 // applyNodeLabels applies minikube labels to all the nodes
 func (k *Bootstrapper) applyNodeLabels(cfg config.MachineConfig) error {
-	// timne cluster was created. time format is based on ISO 8601 (RFC 3339)
+	// time cluster was created. time format is based on ISO 8601 (RFC 3339)
 	// converting - and : to _ because of kubernetes label restriction
 	createdAtLbl := "minikube.k8s.io/updated_at=" + time.Now().Format("2006_01_02T15_04_05_0700")
 	verLbl := "minikube.k8s.io/version=" + version.GetVersion()

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -231,7 +231,6 @@ func (k *Bootstrapper) StartCluster(cfg config.MachineConfig) error {
 			return errors.Wrap(err, "timed out waiting to elevate kube-system RBAC privileges")
 		}
 	}
-	fmt.Println("about to apply node labels")
 	if err := k.applyNodeLabels(cfg); err != nil {
 		glog.Warningf("unable to apply node labels: %v", err)
 	}

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -126,30 +126,14 @@ func TestFunctional(t *testing.T) {
 
 // validateNodeLabels checks if minikube cluster is created with correct kubernetes's node label
 func validateNodeLabels(ctx context.Context, t *testing.T, profile string) {
-	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "get", "nodes", "--output", "jsonpath={.items[0].metadata.labels}"))
+	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "get", "nodes", "--output=go-template", "--template='{{range $k, $v := (index .items 0).metadata.labels}}{{$k}} {{end}}'"))
 	if err != nil {
 		t.Errorf("%s failed: %v", rr.Args, err)
 	}
-
-	var labels []string
-	// json output:
-	// [beta.kubernetes.io/arch:amd64 beta.kubernetes.io/os:linux minikube.k8s.io/commit:aa91f39ffbcf27dcbb93c4ff3f457c54e585cf4a-dirty minikube.k8s.io/name:p1 minikube.k8s.io/updated_at:2020_02_20T12_05_35_0700 minikube.k8s.io/version:v1.7.3 kubernetes.io/arch:amd64 kubernetes.io/hostname:p1 kubernetes.io/os:linux node-role.kubernetes.io/master:]
-	err = json.Unmarshal(rr.Stdout.Bytes(), &labels)
-	if err != nil {
-		t.Errorf("%s umarshaling node label from json failed: %v", rr.Args, err)
-	}
-
 	expectedLabels := []string{"minikube.k8s.io/commit", "minikube.k8s.io/version", "minikube.k8s.io/updated_at", "minikube.k8s.io/name"}
 	for _, el := range expectedLabels {
-		found := false
-		for _, l := range labels {
-			if strings.Contains(l, el) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("Failed to have label %q in node labels %+v", expectedLabels, labels)
+		if !strings.Contains(rr.Output(), el) {
+			t.Errorf("expected to have label %q in node labels: %q", expectedLabels, rr.Output())
 		}
 	}
 }

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -126,16 +126,14 @@ func TestFunctional(t *testing.T) {
 
 // validateNodeLabels checks if minikube cluster is created with correct kubernetes's node label
 func validateNodeLabels(ctx context.Context, t *testing.T, profile string) {
-	defer cancel()
 	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "get", "nodes", "--output", "jsonpath={.items[0].metadata.labels}"))
 	if err != nil {
 		t.Errorf("%s failed: %v", rr.Args, err)
 	}
 
-	// json output would look like this
-	// [beta.kubernetes.io/arch:amd64 beta.kubernetes.io/os:linux minikube.k8s.io/commit:aa91f39ffbcf27dcbb93c4ff3f457c54e585cf4a-dirty minikube.k8s.io/name:p1 minikube.k8s.io/updated_at:2020_02_20T12_05_35_0700 minikube.k8s.io/version:v1.7.3 kubernetes.io/arch:amd64 kubernetes.io/hostname:p1 kubernetes.io/os:linux node-role.kubernetes.io/master:]
-
 	var labels []string
+	// json output:
+	// [beta.kubernetes.io/arch:amd64 beta.kubernetes.io/os:linux minikube.k8s.io/commit:aa91f39ffbcf27dcbb93c4ff3f457c54e585cf4a-dirty minikube.k8s.io/name:p1 minikube.k8s.io/updated_at:2020_02_20T12_05_35_0700 minikube.k8s.io/version:v1.7.3 kubernetes.io/arch:amd64 kubernetes.io/hostname:p1 kubernetes.io/os:linux node-role.kubernetes.io/master:]
 	err = json.Unmarshal(rr.Stdout.Bytes(), &labels)
 	if err != nil {
 		t.Errorf("%s umarshaling node label from json failed: %v", rr.Args, err)

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -126,7 +126,6 @@ func TestFunctional(t *testing.T) {
 
 // validateNodeLabels checks if minikube cluster is created with correct kubernetes's node label
 func validateNodeLabels(ctx context.Context, t *testing.T, profile string) {
-	mctx, cancel := context.WithTimeout(ctx, 13*time.Second)
 	defer cancel()
 	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "get", "nodes", "--output", "jsonpath={.items[0].metadata.labels}"))
 	if err != nil {


### PR DESCRIPTION
After this PR minikube nodes will be annonated with a label, 
would help to identify this was created by minikube 
here are the labels after this PR:

```
medya@medya:~/workspace/minikube (annotate_node)$ kubectl get nodes --show-labels 
NAME   STATUS   ROLES    AGE     VERSION   LABELS
p1     Ready    master   4m53s   v1.17.3   

beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,
k8s.minikube.io/commit=aa91f39ffbcf27dcbb93c4ff3f457c54e585cf4a-dirty,
k8s.minikube.io/name=p1,
k8s.minikube.io/updated_at=2020_02_20T12_05_35_0700,
k8s.minikube.io/version=v1.7.3,
kubernetes.io/arch=amd64,
kubernetes.io/hostname=p1,
kubernetes.io/os=linux,
node-role.kubernetes.io/master=
```


minikube added labels are : 

```
k8s.minikube.io/commit=aa91f39ffbcf27dcbb93c4ff3f457c54e585cf4a-dirty,
k8s.minikube.io/name=p1,
k8s.minikube.io/updated_at=2020_02_20T12_05_35_0700,
k8s.minikube.io/version=v1.7.3,


```
