### PR TITLE
Address one simple linter error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ MINIKUBE_RELEASES_URL=https://github.com/kubernetes/minikube/releases/download
 
 KERNEL_VERSION ?= 4.19.94
 # latest from https://github.com/golangci/golangci-lint/releases
-GOLINT_VERSION ?= v1.23.2
+GOLINT_VERSION ?= v1.23.6
 # Limit number of default jobs, to avoid the CI builds running out of memory
 GOLINT_JOBS ?= 4
 # see https://github.com/golangci/golangci-lint#memory-usage-of-golangci-lint

--- a/pkg/drivers/kic/oci/network.go
+++ b/pkg/drivers/kic/oci/network.go
@@ -49,7 +49,7 @@ func digDNS(ociBin, containerName, dns string) (net.IP, error) {
 	out, err := cmd.CombinedOutput()
 	ip := net.ParseIP(strings.TrimSpace(string(out)))
 	if err != nil {
-		return ip, errors.Wrapf(err, "resolve dns to ip", string(out))
+		return ip, errors.Wrapf(err, "resolve dns to ip: %s", string(out))
 	}
 	glog.Infof("got host ip for mount in container by digging dns: %s", ip.String())
 	return ip, nil


### PR DESCRIPTION
Address the below linter error:

```bash
pkg/drivers/kic/oci/network.go:52:26: printf: Wrapf call has arguments but no formatting directives (govet)
                return ip, errors.Wrapf(err, "resolve dns to ip", string(out))
```

PS: I found out that there is existing issue https://github.com/kubernetes/minikube/issues/6714, which is about some detection missing. Will investigate further with different OS/env. Currently, I am developing with macOS.