### PR TITLE
Fix 404 site documentation link to docker_registry.md

### DIFF
--- a/site/content/en/docs/Tasks/docker_daemon.md
+++ b/site/content/en/docs/Tasks/docker_daemon.md
@@ -76,4 +76,4 @@ docker ps
 
 ##  Related Documentation
 
--  [Using the Docker registry](docker_registry.md)
+-  [Using the Docker registry]({{< ref "/docs/tasks/docker_registry" >}})


### PR DESCRIPTION
### What type of PR is this?
/kind bug

### What this PR does / why we need it:

This PR fixes the 404 error link to `docker_registry.md`.
There is a 404 link to `Using the Docker registry` in `Using the Docker daemon` page bottom.

### Which issue(s) this PR fixes:

Fixes #6733 

### Does this PR introduce a user-facing change?

No.

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```