### PR TITLE
WIP Add dependency for integration test job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
   # Run the following integration tests after the build_minikube
   # They will run in parallel and use the binaries in previous step
   docker_ubuntu_16_04:
-    needs: [build_minikube]
+    needs: [build_minikube, lint, unit_test]
     env:
       TIME_ELAPSED: time
       JOB_NAME: "Docker_Ubuntu_16_04"
@@ -134,7 +134,7 @@ jobs:
       JOB_NAME: "Docker_Ubuntu_18_04"
       GOPOGH_RESULT: ""
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
-    needs: [build_minikube]
+    needs: [build_minikube, lint, unit_test]
     steps:
     - name: Install gopogh
       shell: bash
@@ -190,7 +190,7 @@ jobs:
         echo "-------------------------------------------------------"
         if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
   none_ubuntu16_04:
-    needs: [build_minikube]
+    needs: [build_minikube, lint, unit_test]
     env:
       TIME_ELAPSED: time
       JOB_NAME: "None_Ubuntu_16_04"
@@ -252,7 +252,7 @@ jobs:
         echo "-------------------------------------------------------"
         if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
   none_ubuntu18_04:
-    needs: [build_minikube]
+    needs: [build_minikube, lint, unit_test]
     env:
       TIME_ELAPSED: time
       JOB_NAME: "None_Ubuntu_18_04"
@@ -314,7 +314,7 @@ jobs:
         echo "-------------------------------------------------------"
         if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
   podman_ubuntu_18_04:
-      needs: [build_minikube]
+    needs: [build_minikube, lint, unit_test]
       env:
         TIME_ELAPSED: time
         JOB_NAME: "Podman_Ubuntu_18_04"


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

Integration test jobs are depending on `build` step only. So it's unnecessary to run these job if `lint` or `unit test` failed. Additionally, we didn't save much time for head start as build, lint and unit test are running in parallel.

Making integration tests run only after lint and unit test jobs passed will help contributors to be aware of the issues earlier. 