### PR TITLE
Generate fish compatible docker-env hint

### DIFF
--- a/cmd/minikube/cmd/docker-env_test.go
+++ b/cmd/minikube/cmd/docker-env_test.go
@@ -95,7 +95,7 @@ set -gx DOCKER_CERT_PATH "/certs"
 set -gx MINIKUBE_ACTIVE_DOCKERD "fish"
 
 # To point your shell to minikube's docker-daemon, run:
-# eval (minikube -p fish docker-env)
+# minikube -p fish docker-env | source
 `,
 			`set -e DOCKER_TLS_VERIFY
 set -e DOCKER_HOST

--- a/pkg/minikube/shell/shell.go
+++ b/pkg/minikube/shell/shell.go
@@ -97,7 +97,7 @@ func generateUsageHint(sh, usgPlz, usgCmd string) string {
 `, usgPlz, usgCmd),
 		"fish": fmt.Sprintf(`
 # %s
-# eval (%s)
+# %s | source
 `, usgPlz, usgCmd),
 		"powershell": fmt.Sprintf(`# %s
 # & %s | Invoke-Expression


### PR DESCRIPTION
`fish`'s eval handling does not handle multiple lines (https://github.com/fish-shell/fish-shell/issues/3993).

Instead the recommendation is to pipe the output to `source`.

This PR updates the usage hint of the `docker-env` command
when running on `fish`:

`eval (minikube -p fish docker-env)` => `minikube -p fish docker-env | source`

fixes #6155

Signed-off-by: Kevin Pullin <kevin.pullin@gmail.com>

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
