### PR TITLE
Add comments to avoid warnings from go lint

### DIFF
--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -44,10 +44,16 @@ var statusFormat string
 var output string
 
 const (
-	// Additional states used by kubeconfig
-	Configured    = "Configured"    // ~state.Saved
+	// # Additional states used by kubeconfig:
+
+	// Configured means configured
+	Configured = "Configured" // ~state.Saved
+	// Misconfigured means misconfigured
 	Misconfigured = "Misconfigured" // ~state.Error
-	// Additional states used for clarity
+
+	// # Additional states used for clarity:
+
+	// Nonexistent means nonexistent
 	Nonexistent = "Nonexistent" // ~state.None
 )
 

--- a/pkg/drivers/kic/oci/types.go
+++ b/pkg/drivers/kic/oci/types.go
@@ -19,8 +19,10 @@ package oci
 const (
 	// DefaultBindIPV4 is The default IP the container will listen on.
 	DefaultBindIPV4 = "127.0.0.1"
-	Docker          = "docker"
-	Podman          = "podman"
+	// Docker is docker
+	Docker = "docker"
+	// Podman is podman
+	Podman = "podman"
 	// ProfileLabelKey is applied to any container or volume created by a specific minikube profile name.minikube.sigs.k8s.io=PROFILE_NAME
 	ProfileLabelKey = "name.minikube.sigs.k8s.io"
 	// NodeRoleKey is used to identify if it is control plane or worker

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -23,7 +23,8 @@ import (
 )
 
 const (
-	// Docker default bridge network is named "bridge" (https://docs.docker.com/network/bridge/#use-the-default-bridge-network)
+	// DefaultNetwork is the Docker default bridge network named "bridge"
+	// (https://docs.docker.com/network/bridge/#use-the-default-bridge-network)
 	DefaultNetwork = "bridge"
 	// DefaultPodCIDR is The CIDR to be used for pods inside the node.
 	DefaultPodCIDR = "10.244.0.0/16"

--- a/pkg/minikube/bootstrapper/bsutil/extraconfig.go
+++ b/pkg/minikube/bootstrapper/bsutil/extraconfig.go
@@ -28,8 +28,12 @@ import (
 	"k8s.io/minikube/pkg/minikube/config"
 )
 
+// enum to differentiate kubeadm command line parameters from kubeadm config file parameters (see the
+// KubeadmExtraArgsWhitelist variable for more info)
 const (
-	KubeadmCmdParam    = iota
+	// KubeadmCmdParam is command parameters for kubeadm
+	KubeadmCmdParam = iota
+	// KubeadmConfigParam is config parameters for kubeadm
 	KubeadmConfigParam = iota
 )
 

--- a/pkg/minikube/bootstrapper/bsutil/files.go
+++ b/pkg/minikube/bootstrapper/bsutil/files.go
@@ -29,10 +29,11 @@ import (
 var KubeadmYamlPath = path.Join(vmpath.GuestEphemeralDir, "kubeadm.yaml")
 
 const (
+	//DefaultCNIConfigPath is the configuration file for CNI networks
 	DefaultCNIConfigPath = "/etc/cni/net.d/k8s.conf"
-	KubeletServiceFile   = "/lib/systemd/system/kubelet.service"
-	// enum to differentiate kubeadm command line parameters from kubeadm config file parameters (see the
-	// KubeadmExtraArgsWhitelist variable for more info)
+	// KubeletServiceFile is the file for the systemd kubelet.service
+	KubeletServiceFile = "/lib/systemd/system/kubelet.service"
+	// KubeletSystemdConfFile is config for the systemd kubelet.service
 	KubeletSystemdConfFile = "/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
 )
 

--- a/pkg/minikube/bootstrapper/bsutil/kverify/kverify.go
+++ b/pkg/minikube/bootstrapper/bsutil/kverify/kverify.go
@@ -182,6 +182,7 @@ func apiServerHealthz(ip net.IP, port int) (state.State, error) {
 	return state.Running, nil
 }
 
+// KubeletStatus checks the kubelet status
 func KubeletStatus(cr command.Runner) (state.State, error) {
 	glog.Infof("Checking kubelet status ...")
 	rr, err := cr.RunCmd(exec.Command("sudo", "systemctl", "is-active", "kubelet"))

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -72,11 +72,8 @@ var (
 	GvisorConfigTomlTargetName = "gvisor-config.toml"
 	// MountProcessFileName is the filename of the mount process
 	MountProcessFileName = ".mount-process"
+
 	// SHASuffix is the suffix of a SHA-256 checksum file
-
-)
-
-var (
 	SHASuffix = ".sha256"
 	// DefaultISOURL is the default location of the minikube.iso file
 	DefaultISOURL = fmt.Sprintf("https://storage.googleapis.com/%s/minikube-%s.iso", minikubeVersion.GetISOPath(), minikubeVersion.GetISOVersion())
@@ -88,13 +85,13 @@ var (
 
 	// DefaultMinipath is the default Minikube path (under the home directory)
 	DefaultMinipath = filepath.Join(homedir.HomeDir(), ".minikube")
-	// KubeconfigEnvVar is the env var to check for the Kubernetes client config
 
+	// KubeconfigEnvVar is the env var to check for the Kubernetes client config
 	KubeconfigEnvVar = clientcmd.RecommendedConfigPathEnvVar
 	// KubeconfigPath is the path to the Kubernetes client config
 	KubeconfigPath = clientcmd.RecommendedHomeFile
-	// ImageRepositories contains all known image repositories
 
+	// ImageRepositories contains all known image repositories
 	ImageRepositories = map[string][]string{
 		"global": {""},
 		"cn":     {"registry.cn-hangzhou.aliyuncs.com/google_containers"},

--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -284,7 +284,7 @@ func (r *Containerd) PauseContainers(ids []string) error {
 	return pauseCRIContainers(r.Runner, containerdNamespaceRoot, ids)
 }
 
-// PauseContainers pauses a running container based on ID
+// UnpauseContainers unpauses a running container based on ID
 func (r *Containerd) UnpauseContainers(ids []string) error {
 	return unpauseCRIContainers(r.Runner, containerdNamespaceRoot, ids)
 }

--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -201,7 +201,7 @@ func (r *CRIO) PauseContainers(ids []string) error {
 	return pauseCRIContainers(r.Runner, "", ids)
 }
 
-// PauseContainers pauses a running container based on ID
+// UnpauseContainers unpauses a running container based on ID
 func (r *CRIO) UnpauseContainers(ids []string) error {
 	return unpauseCRIContainers(r.Runner, "", ids)
 }

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -27,11 +27,15 @@ import (
 	"k8s.io/minikube/pkg/minikube/out"
 )
 
+// ContainerState is the run state of a container
 type ContainerState int
 
 const (
+	// All is all of the states
 	All ContainerState = iota
+	// Running is only running
 	Running
+	// Paused is only paused
 	Paused
 )
 
@@ -106,6 +110,7 @@ type Config struct {
 	KubernetesVersion string
 }
 
+// ListOptions are the options to use for listing containers
 type ListOptions struct {
 	// State is the container state to filter by (All, Running, Paused)
 	State ContainerState

--- a/pkg/minikube/node/config.go
+++ b/pkg/minikube/node/config.go
@@ -43,10 +43,14 @@ import (
 )
 
 var (
-	DockerEnv    []string
-	DockerOpt    []string
+	// DockerEnv contains the environment variables
+	DockerEnv []string
+	// DockerOpt contains the option parameters
+	DockerOpt []string
+	// ExtraOptions contains extra options (if any)
 	ExtraOptions config.ExtraOptionSlice
-	AddonList    []string
+	// AddonList contains the list of addons
+	AddonList []string
 )
 
 // configureRuntimes does what needs to happen to get a runtime going.

--- a/pkg/minikube/vmpath/constants.go
+++ b/pkg/minikube/vmpath/constants.go
@@ -31,6 +31,6 @@ const (
 	GuestCertAuthDir = "/usr/share/ca-certificates"
 	// GuestCertStoreDir is where system SSL certificates are installed
 	GuestCertStoreDir = "/etc/ssl/certs"
-	// Where gvisor bootstraps from
+	// GuestGvisorDir is where gvisor bootstraps from
 	GuestGvisorDir = "/tmp/gvisor"
 )


### PR DESCRIPTION
```
cmd/minikube/cmd/status.go:47:2: comment on exported const Configured should be of the form "Configured ..."
cmd/minikube/cmd/status.go:49:2: exported const Misconfigured should have comment (or a comment on this block) or be unexported
cmd/minikube/cmd/status.go:50:2: comment on exported const Nonexistent should be of the form "Nonexistent ..."
pkg/drivers/kic/types.go:26:2: comment on exported const DefaultNetwork should be of the form "DefaultNetwork ..."
pkg/drivers/kic/oci/types.go:22:2: exported const Docker should have comment (or a comment on this block) or be unexported
pkg/minikube/bootstrapper/bsutil/extraconfig.go:32:2: exported const KubeadmCmdParam should have comment (or a comment on this block) or be unexported
pkg/minikube/bootstrapper/bsutil/files.go:32:2: exported const DefaultCNIConfigPath should have comment (or a comment on this block) or be unexported
pkg/minikube/bootstrapper/bsutil/files.go:34:2: comment on exported const KubeletSystemdConfFile should be of the form "KubeletSystemdConfFile ..."
pkg/minikube/bootstrapper/bsutil/kverify/kverify.go:185:1: exported function KubeletStatus should have comment or be unexported
pkg/minikube/constants/constants.go:80:2: exported var SHASuffix should have comment or be unexported
pkg/minikube/cruntime/containerd.go:287:1: comment on exported method Containerd.UnpauseContainers should be of the form "UnpauseContainers ..."
pkg/minikube/cruntime/crio.go:204:1: comment on exported method CRIO.UnpauseContainers should be of the form "UnpauseContainers ..."
pkg/minikube/cruntime/cruntime.go:30:6: exported type ContainerState should have comment or be unexported
pkg/minikube/cruntime/cruntime.go:33:2: exported const All should have comment (or a comment on this block) or be unexported
pkg/minikube/cruntime/cruntime.go:109:6: exported type ListOptions should have comment or be unexported
pkg/minikube/node/config.go:46:2: exported var DockerEnv should have comment or be unexported
pkg/minikube/vmpath/constants.go:34:2: comment on exported const GuestGvisorDir should be of the form "GuestGvisorDir ..."
Found 17 lint suggestions; failing.
Makefile:350: receptet för målet ”golint” misslyckades

```