### PR TITLE
Add cri-o runtime to kic drivers and improve kic image

### DIFF
--- a/hack/images/kicbase.Dockerfile
+++ b/hack/images/kicbase.Dockerfile
@@ -4,16 +4,23 @@ ARG COMMIT_SHA
 # could be changed to any debian that can run systemd
 FROM kindest/base:v20200122-2dfe64b2 as base
 USER root
+# specify version of everything explcitly using apt-cache policy
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  sudo \
-  dnsutils \
-  openssh-server \
-  docker.io \
-  lz4 \
-  && apt-get clean -y 
-# disable containerd by default
-RUN systemctl disable containerd
-RUN rm /etc/crictl.yaml
+  lz4=1.9.1-1 \
+  sudo=1.8.27-1ubuntu4.1 \
+  gnupg=2.2.12-1ubuntu3 \ 
+  dnsutils=1:9.11.5.P4+dfsg-5.1ubuntu2.1 \
+  docker.io=19.03.2-0ubuntu1 \
+  openssh-server=1:8.0p1-6build1 \
+  && rm /etc/crictl.yaml
+# install cri-o based on https://github.com/cri-o/cri-o/commit/96b0c34b31a9fc181e46d7d8e34fb8ee6c4dc4e1#diff-04c6e90faac2675aa89e2176d2eec7d8R128
+RUN sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_19.10/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list" && \    
+    curl -LO https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_19.10/Release.key && \
+    apt-key add - < Release.key && apt-get update && apt-get install -y cri-o-1.17=1.17.0-3
+# install podman
+RUN apt-get install -y podman=1.8.0~7
+# disable non-docker runtimes by default
+RUN systemctl disable containerd && systemctl disable crio
 # enable docker which is default
 RUN systemctl enable docker
 # making SSH work for docker container 
@@ -23,18 +30,18 @@ RUN echo 'root:root' |chpasswd
 RUN sed -ri 's/^#?PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
 RUN sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
 EXPOSE 22
-# for minikube ssh. to match VM using "docker" as username
+# create docker user for minikube ssh. to match VM using "docker" as username
 RUN adduser --ingroup docker --disabled-password --gecos '' docker 
 RUN adduser docker sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER docker
 RUN mkdir /home/docker/.ssh
-# Deleting leftovers
 USER root
 # kind base-image entry-point expects a "kind" folder for product_name,product_uuid
 # https://github.com/kubernetes-sigs/kind/blob/master/images/base/files/usr/local/bin/entrypoint
 RUN mkdir -p /kind
-RUN rm -rf \
+# Deleting leftovers
+RUN apt-get clean -y && rm -rf \
   /var/cache/debconf/* \
   /var/lib/apt/lists/* \
   /var/log/* \

--- a/hack/images/kicbase.Dockerfile
+++ b/hack/images/kicbase.Dockerfile
@@ -21,7 +21,7 @@ RUN sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/lib
 # install podman
 RUN apt-get install -y --no-install-recommends podman=1.8.0~7
 # disable non-docker runtimes by default
-RUN systemctl disable containerd && systemctl disable crio
+RUN systemctl disable containerd && systemctl disable crio && rm /etc/crictl.yaml
 # enable docker which is default
 RUN systemctl enable docker
 # making SSH work for docker container 

--- a/hack/images/kicbase.Dockerfile
+++ b/hack/images/kicbase.Dockerfile
@@ -1,18 +1,18 @@
 ARG COMMIT_SHA
-# using base image created by kind https://github.com/kubernetes-sigs/kind
+# using base image created by kind https://github.com/kubernetes-sigs/kind/blob/master/images/base/Dockerfile
 # which is an ubuntu 19.10 with an entry-point that helps running systemd
 # could be changed to any debian that can run systemd
 FROM kindest/base:v20200122-2dfe64b2 as base
 USER root
-# specify version of everything explcitly using apt-cache policy
+# specify version of everything explicitly using 'apt-cache policy'
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  lz4=1.9.1-1 \
-  sudo=1.8.27-1ubuntu4.1 \
-  gnupg=2.2.12-1ubuntu3 \ 
-  dnsutils=1:9.11.5.P4+dfsg-5.1ubuntu2.1 \
-  docker.io=19.03.2-0ubuntu1 \
-  openssh-server=1:8.0p1-6build1 \
-  && rm /etc/crictl.yaml
+    lz4=1.9.1-1 \
+    gnupg=2.2.12-1ubuntu3 \ 
+    sudo=1.8.27-1ubuntu4.1 \
+    docker.io=19.03.2-0ubuntu1 \
+    openssh-server=1:8.0p1-6build1 \
+    dnsutils=1:9.11.5.P4+dfsg-5.1ubuntu2.1 \
+    && rm /etc/crictl.yaml
 # install cri-o based on https://github.com/cri-o/cri-o/commit/96b0c34b31a9fc181e46d7d8e34fb8ee6c4dc4e1#diff-04c6e90faac2675aa89e2176d2eec7d8R128
 RUN sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_19.10/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list" && \    
     curl -LO https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_19.10/Release.key && \

--- a/hack/images/kicbase.Dockerfile
+++ b/hack/images/kicbase.Dockerfile
@@ -16,9 +16,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # install cri-o based on https://github.com/cri-o/cri-o/commit/96b0c34b31a9fc181e46d7d8e34fb8ee6c4dc4e1#diff-04c6e90faac2675aa89e2176d2eec7d8R128
 RUN sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_19.10/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list" && \    
     curl -LO https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_19.10/Release.key && \
-    apt-key add - < Release.key && apt-get update && apt-get install -y cri-o-1.17=1.17.0-3
+    apt-key add - < Release.key && apt-get update && \
+    apt-get install -y --no-install-recommends cri-o-1.17=1.17.0-3
 # install podman
-RUN apt-get install -y podman=1.8.0~7
+RUN apt-get install -y --no-install-recommends podman=1.8.0~7
 # disable non-docker runtimes by default
 RUN systemctl disable containerd && systemctl disable crio
 # enable docker which is default

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -32,7 +32,7 @@ const (
 	// Version is the current version of kic
 	Version = "v0.0.7"
 	// SHA of the kic base image
-	baseImageSHA = "66eab477ec0cf93855d9261ded5851d42ce3688d4ea1a6e9241e860d7c8010a1"
+	baseImageSHA = "a6f288de0e5863cdeab711fa6bafa38ee7d8d285ca14216ecf84fcfb07c7d176"
 
 	// OverlayImage is the cni plugin used for overlay image, created by kind.
 	// CNI plugin image used for kic drivers created by kind.

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -41,7 +41,8 @@ const (
 
 var (
 	// BaseImage is the base image is used to spin up kic containers. it uses same base-image as kind.
-	BaseImage = fmt.Sprintf("gcr.io/k8s-minikube/kicbase:%s@sha256:%s", Version, baseImageSHA)
+	// BaseImage = fmt.Sprintf("gcr.io/k8s-minikube/kicbase:%s@sha256:%s", Version, baseImageSHA)
+	BaseImage = fmt.Sprintf("kicbase:local")
 )
 
 // Config is configuration for the kic driver used by registry

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -30,7 +30,7 @@ const (
 	DefaultPodCIDR = "10.244.0.0/16"
 
 	// Version is the current version of kic
-	Version = "v0.0.6"
+	Version = "v0.0.7"
 	// SHA of the kic base image
 	baseImageSHA = "53725be5106d1d797dff4041d8c297383f32ab2edeff0a69fc3f50263cf17c79"
 

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -32,7 +32,7 @@ const (
 	// Version is the current version of kic
 	Version = "v0.0.7"
 	// SHA of the kic base image
-	baseImageSHA = "53725be5106d1d797dff4041d8c297383f32ab2edeff0a69fc3f50263cf17c79"
+	baseImageSHA = "sha256:66eab477ec0cf93855d9261ded5851d42ce3688d4ea1a6e9241e860d7c8010a1"
 
 	// OverlayImage is the cni plugin used for overlay image, created by kind.
 	// CNI plugin image used for kic drivers created by kind.
@@ -41,8 +41,7 @@ const (
 
 var (
 	// BaseImage is the base image is used to spin up kic containers. it uses same base-image as kind.
-	// BaseImage = fmt.Sprintf("gcr.io/k8s-minikube/kicbase:%s@sha256:%s", Version, baseImageSHA)
-	BaseImage = fmt.Sprintf("kicbase:local")
+	BaseImage = fmt.Sprintf("gcr.io/k8s-minikube/kicbase:%s@sha256:%s", Version, baseImageSHA)
 )
 
 // Config is configuration for the kic driver used by registry

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -32,7 +32,7 @@ const (
 	// Version is the current version of kic
 	Version = "v0.0.7"
 	// SHA of the kic base image
-	baseImageSHA = "sha256:66eab477ec0cf93855d9261ded5851d42ce3688d4ea1a6e9241e860d7c8010a1"
+	baseImageSHA = "66eab477ec0cf93855d9261ded5851d42ce3688d4ea1a6e9241e860d7c8010a1"
 
 	// OverlayImage is the cni plugin used for overlay image, created by kind.
 	// CNI plugin image used for kic drivers created by kind.


### PR DESCRIPTION
- for clarity and prevent issues, explicitly specify version of everything on the image
- install cri-o and podman on the kic base image
- improve comments

After this PR: kic driver will support all the run-times that VM drivers support

```
medmac@~/minikube (crio_kic) $ ./out/minikube profile list
|---------|-----------|------------|------------|------|---------|---------|
| Profile | VM Driver |  Runtime   |     IP     | Port | Version | Status  |
|---------|-----------|------------|------------|------|---------|---------|
| p14     | docker    | docker     | 172.17.0.3 | 8443 | v1.17.3 | Running |
| p15     | docker    | crio       | 172.17.0.4 | 8443 | v1.17.3 | Running |
| p16     | docker    | containerd | 172.17.0.2 | 8443 | v1.17.3 | Running |
|---------|-----------|------------|------------|------|---------|---------|
```

closes https://github.com/kubernetes/minikube/issues/6757