### PR TITLE
Fix TestDownloadOnly integration test

### DIFF
--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -54,7 +54,7 @@ func TestDownloadOnly(t *testing.T) {
 			t.Run(v, func(t *testing.T) {
 				// Explicitly does not pass StartArgs() to test driver default
 				// --force to avoid uid check
-				args := []string{"start", "--download-only", "-p", profile, "--force", "--alsologtostderr", fmt.Sprintf("--kubernetes-version=%s", v)}
+				args := append([]string{"start", "--download-only", "-p", profile, "--force", "--alsologtostderr", fmt.Sprintf("--kubernetes-version=%s", v)}, StartArgs()...)
 
 				// Preserve the initial run-result for debugging
 				if rrr == nil {
@@ -69,7 +69,7 @@ func TestDownloadOnly(t *testing.T) {
 
 				imgs, err := images.Kubeadm("", v)
 				if err != nil {
-					t.Errorf("kubeadm images: %v", v)
+					t.Errorf("kubeadm images: %v %+v", v, err)
 				}
 
 				for _, img := range imgs {


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

Addresses https://github.com/kubernetes/minikube/issues/6742

`StartArgs` was not passed to command.

TestDownloadOnly failed for all driver as per https://github.com/kubernetes/minikube/issues/6742.