### PR TITLE
Fix TestDownloadOnly for --vm-driver=none

### DIFF
--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -73,7 +73,7 @@ func TestDownloadOnly(t *testing.T) {
 				}
 
 				// skip verify for cache images if --vm-driver=none
-				if !strings.Contains(strings.Join(StartArgs(), " "), "--vm-driver=none") {
+				if !strings.Contains(strings.Join(rrr.Args, " "), "--vm-driver=none") {
 					for _, img := range imgs {
 						img = strings.Replace(img, ":", "_", 1) // for example kube-scheduler:v1.15.2 --> kube-scheduler_v1.15.2
 						fp := filepath.Join(localpath.MiniPath(), "cache", "images", img)

--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -72,12 +72,15 @@ func TestDownloadOnly(t *testing.T) {
 					t.Errorf("kubeadm images: %v %+v", v, err)
 				}
 
-				for _, img := range imgs {
-					img = strings.Replace(img, ":", "_", 1) // for example kube-scheduler:v1.15.2 --> kube-scheduler_v1.15.2
-					fp := filepath.Join(localpath.MiniPath(), "cache", "images", img)
-					_, err := os.Stat(fp)
-					if err != nil {
-						t.Errorf("expected image file exist at %q but got error: %v", fp, err)
+				// skip verify for cache images if --vm-driver=none
+				if !strings.Contains(strings.Join(StartArgs(), " "), "--vm-driver=none") {
+					for _, img := range imgs {
+						img = strings.Replace(img, ":", "_", 1) // for example kube-scheduler:v1.15.2 --> kube-scheduler_v1.15.2
+						fp := filepath.Join(localpath.MiniPath(), "cache", "images", img)
+						_, err := os.Stat(fp)
+						if err != nil {
+							t.Errorf("expected image file exist at %q but got error: %v", fp, err)
+						}
 					}
 				}
 

--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -73,7 +73,7 @@ func TestDownloadOnly(t *testing.T) {
 				}
 
 				// skip verify for cache images if --vm-driver=none
-				if !strings.Contains(strings.Join(rrr.Args, " "), "--vm-driver=none") {
+				if !NoneDriver() {
 					for _, img := range imgs {
 						img = strings.Replace(img, ":", "_", 1) // for example kube-scheduler:v1.15.2 --> kube-scheduler_v1.15.2
 						fp := filepath.Join(localpath.MiniPath(), "cache", "images", img)


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

Do not verify the cache image (e.g. kube-proxy, kube-scheduler, kube-controller-manager, etc) for vm-driver=none as per existing logic in below files

```go
startCmd.Flags().Bool(cacheImages, true, "If true, cache docker images for the current bootstrapper and load them into the machine. Always false with --vm-driver=none.")
```

https://github.com/kubernetes/minikube/blob/master/pkg/minikube/driver/driver.go#L141
https://github.com/kubernetes/minikube/blob/master/cmd/minikube/cmd/start.go#L156

Related PR https://github.com/kubernetes/minikube/pull/6761
Related Issue https://github.com/kubernetes/minikube/issues/6742
