### PR TITLE
Fix none-test integration test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,6 +88,11 @@ jobs:
         docker info || true
         docker version || true
         docker ps || true
+    - name: install lz4
+      shell: bash
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get -qq -y install liblz4-tool
     - name: Install gopogh
       shell: bash
       run: |
@@ -150,6 +155,11 @@ jobs:
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
     needs: [build_minikube]
     steps:
+    - name: install lz4
+      shell: bash
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get -qq -y install liblz4-tool
     - name: Docker Info
       shell: bash
       run: |
@@ -218,6 +228,11 @@ jobs:
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
     runs-on: ubuntu-16.04
     steps:
+    - name: install lz4
+      shell: bash
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get -qq -y install liblz4-tool
     - name: Install gopogh
       shell: bash
       run: |
@@ -280,6 +295,11 @@ jobs:
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
     runs-on: ubuntu-18.04
     steps:
+    - name: install lz4
+      shell: bash
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get -qq -y install liblz4-tool
     - name: Install gopogh
       shell: bash
       run: |
@@ -342,6 +362,11 @@ jobs:
         SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
       runs-on: ubuntu-18.04
       steps:
+      - name: install lz4
+        shell: bash
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get -qq -y install liblz4-tool
       - name: install podman
         shell: bash
         run: |

--- a/test/integration/none_test.go
+++ b/test/integration/none_test.go
@@ -77,7 +77,13 @@ func TestChangeNoneUser(t *testing.T) {
 		t.Errorf("Failed to convert uid to int: %v", err)
 	}
 
-	for _, p := range []string{localpath.MiniPath(), filepath.Join(u.HomeDir, ".kube/config")} {
+	// Retrieve the kube config from env
+	kubeConfig := os.Getenv("KUBECONFIG")
+	if kubeConfig == "" {
+		kubeConfig = filepath.Join(u.HomeDir, ".kube/config")
+	}
+
+	for _, p := range []string{localpath.MiniPath(), kubeConfig} {
 		info, err := os.Stat(p)
 		if err != nil {
 			t.Errorf("stat(%s): %v", p, err)


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

Fix TestChangeNoneUser for non driver integration test.

As per https://github.com/sayboras/minikube/pull/190/checks?check_run_id=494463943, this test was failing.

The test was expecting KUBECONFIG from default directory, but not from environment variable.

Due to recent changes in docker overlap, lz4 is required in host system, hence I added the steps to install this before running integration test. It might be not required for podman for now. 
