### PR TITLE
Fix: do not change the profile to a none existing profile

### DIFF
--- a/cmd/minikube/cmd/config/profile.go
+++ b/cmd/minikube/cmd/config/profile.go
@@ -65,7 +65,7 @@ var ProfileCmd = &cobra.Command{
 		}
 
 		if !pkgConfig.ProfileExists(profile) {
-			out.FailureT("if you want to create a profile you can by this command: minikube start -p {{.profile_name}}", out.V{"profile_name": profile})
+			out.ErrT(out.Tip, `if you want to create a profile you can by this command: minikube start -p {{.profile_name}}`, out.V{"profile_name": profile})
 			os.Exit(0)
 		}
 

--- a/cmd/minikube/cmd/config/profile.go
+++ b/cmd/minikube/cmd/config/profile.go
@@ -66,6 +66,7 @@ var ProfileCmd = &cobra.Command{
 
 		if !pkgConfig.ProfileExists(profile) {
 			out.FailureT("if you want to create a profile you can by this command: minikube start -p {{.profile_name}}", out.V{"profile_name": profile})
+			os.Exit(0)
 		}
 
 		err := Set(pkgConfig.MachineProfile, profile)


### PR DESCRIPTION
This PR fixes bug of switching to non existing Minikube profile
Fixes #6767 


(base) vikky$ ./out/minikube profile 
minikube

(base) vikky$ ./out/minikube profile lis
❌  profile "lis" not found
❌  if you want to create a profile you can by this command: minikube start -p lis

(base) vikkyq$ ./out/minikube profile 
minikube

(base) vikky$ ./out/minikube docker-env
export DOCKER_TLS_VERIFY="1"
export DOCKER_HOST="tcp://192.168.99.100:2376"
export DOCKER_CERT_PATH="/Users/vikky/.minikube/certs"
export MINIKUBE_ACTIVE_DOCKERD="minikube"`

 To point your shell to minikube's docker-daemon, run:
 eval $(minikube -p minikube docker-env)
