### PR TITLE
Fix typo detected by linter

### DIFF
--- a/pkg/minikube/tunnel/kic/ssh_conn.go
+++ b/pkg/minikube/tunnel/kic/ssh_conn.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kic
 
 import (

--- a/pkg/minikube/tunnel/kic/ssh_tunnel.go
+++ b/pkg/minikube/tunnel/kic/ssh_tunnel.go
@@ -118,7 +118,7 @@ func (t *SSHTunnel) stopMarkedConnections() {
 
 // sshConnName creates a uniq name for the tunnel, using its name/clusterIP/ports.
 // This allows a new process to be created if an existing service was changed,
-// the new process will support the IP/Ports change ocurred.
+// the new process will support the IP/Ports change occurred.
 func sshConnUniqName(service v1.Service) string {
 	n := []string{
 		service.Name,

--- a/pkg/minikube/tunnel/kic/ssh_tunnel.go
+++ b/pkg/minikube/tunnel/kic/ssh_tunnel.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kic
 
 import (


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

Fixes typo caused travis and gh action failed.

@medyagh I feel like we should enable the `required` check  for at least (build and lint gh action) to avoid such occurrence later. There might be the case that golangci-lint misses some rule, however, it still helps.