### PR TITLE
add not implemented messages for docker on mac service

### DIFF
--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"runtime"
 	"text/template"
 
 	"github.com/golang/glog"
@@ -27,6 +28,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"k8s.io/minikube/pkg/drivers/kic/oci"
+	"k8s.io/minikube/pkg/minikube/config"
 	pkg_config "k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/machine"
@@ -77,9 +80,19 @@ var serviceCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		cfg, err := config.Load(profileName)
+		if err != nil {
+			exit.WithError("Error getting config", err)
+		}
+
 		urls, err := service.WaitForService(api, namespace, svc, serviceURLTemplate, serviceURLMode, https, wait, interval)
 		if err != nil {
 			exit.WithError("Error opening service", err)
+		}
+
+		if runtime.GOOS == "darwin" && cfg.Driver == oci.Docker {
+			out.T(out.Sad, "openning service in browser is not yet implemented in docker driver on mac.\nPlease track the URL bellow to see updates for in progress work.\nhttps://github.com/kubernetes/minikube/issues/6778")
+			exit.WithCodeT(exit.Unavailable, "not implemented for docker driver on MacOs yet")
 		}
 
 		for _, u := range urls {
@@ -94,6 +107,7 @@ var serviceCmd = &cobra.Command{
 				out.String(fmt.Sprintf("%s\n", u))
 				continue
 			}
+
 			out.T(out.Celebrate, "Opening service {{.namespace_name}}/{{.service_name}} in default browser...", out.V{"namespace_name": namespace, "service_name": svc})
 			if err := browser.OpenURL(u); err != nil {
 				exit.WithError(fmt.Sprintf("open url failed: %s", u), err)

--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -91,8 +91,8 @@ var serviceCmd = &cobra.Command{
 		}
 
 		if runtime.GOOS == "darwin" && cfg.Driver == oci.Docker {
-			out.FailureT("openning service in browser is not implemented yet for \"docker driver on mac\".\nPlease track the URL bellow to see updates for in progress work:\nhttps://github.com/kubernetes/minikube/issues/6778")
-			exit.WithCodeT(exit.Unavailable, "not implemented for docker driver on MacOs yet")
+			out.FailureT("Opening service in browser is not implemented yet for docker driver on Mac.\nThe following issue is tracking the in progress work:\nhttps://github.com/kubernetes/minikube/issues/6778")
+			exit.WithCodeT(exit.Unavailable, "Not yet implemented for docker driver on MacOS.")
 		}
 
 		for _, u := range urls {

--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -91,7 +91,7 @@ var serviceCmd = &cobra.Command{
 		}
 
 		if runtime.GOOS == "darwin" && cfg.Driver == oci.Docker {
-			out.T(out.Sad, "openning service in browser is not yet implemented in docker driver on mac.\nPlease track the URL bellow to see updates for in progress work.\nhttps://github.com/kubernetes/minikube/issues/6778")
+			out.FailureT("openning service in browser is not implemented yet for \"docker driver on mac\".\nPlease track the URL bellow to see updates for in progress work:\nhttps://github.com/kubernetes/minikube/issues/6778")
 			exit.WithCodeT(exit.Unavailable, "not implemented for docker driver on MacOs yet")
 		}
 

--- a/cmd/minikube/cmd/service_list.go
+++ b/cmd/minikube/cmd/service_list.go
@@ -48,7 +48,7 @@ var serviceListCmd = &cobra.Command{
 		defer api.Close()
 		profileName := viper.GetString(pkg_config.MachineProfile)
 		if !machine.IsHostRunning(api, profileName) {
-			exit.WithCodeT(exit.Unavailable, "profile {{.name}} is not running. ", out.V{"name": profileName})
+			exit.WithCodeT(exit.Unavailable, "profile {{.name}} is not running.", out.V{"name": profileName})
 		}
 		serviceURLs, err := service.GetServiceURLs(api, serviceListNamespace, serviceURLTemplate)
 		if err != nil {
@@ -73,8 +73,8 @@ var serviceListCmd = &cobra.Command{
 		}
 		service.PrintServiceList(os.Stdout, data)
 		if runtime.GOOS == "darwin" && cfg.Driver == oci.Docker {
-			out.FailureT("Accessing service on docker driver for mac is not fully implemented yet.\nTo read about workarroudns on mac and update on the work in progress, please reffer to this link:\nhttps://github.com/kubernetes/minikube/issues/6778")
-			exit.WithCodeT(exit.Failure, "not implemented for docker on mac driver yet.")
+			out.FailureT("Accessing service is not implemented yet for docker driver on Mac.\nThe following issue is tracking the in progress work::\nhttps://github.com/kubernetes/minikube/issues/6778")
+			exit.WithCodeT(exit.Failure, "Not yet implemented for docker driver on MacOS.")
 		}
 
 	},

--- a/cmd/minikube/cmd/service_list.go
+++ b/cmd/minikube/cmd/service_list.go
@@ -18,10 +18,15 @@ package cmd
 
 import (
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	core "k8s.io/api/core/v1"
+	"k8s.io/minikube/pkg/drivers/kic/oci"
+	"k8s.io/minikube/pkg/minikube/config"
+	pkg_config "k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/machine"
 	"k8s.io/minikube/pkg/minikube/out"
@@ -41,11 +46,19 @@ var serviceListCmd = &cobra.Command{
 			exit.WithError("Error getting client", err)
 		}
 		defer api.Close()
+		profileName := viper.GetString(pkg_config.MachineProfile)
+		if !machine.IsHostRunning(api, profileName) {
+			exit.WithCodeT(exit.Unavailable, "profile {{.name}} is not running. ", out.V{"name": profileName})
+		}
 		serviceURLs, err := service.GetServiceURLs(api, serviceListNamespace, serviceURLTemplate)
 		if err != nil {
 			out.FatalT("Failed to get service URL: {{.error}}", out.V{"error": err})
 			out.ErrT(out.Notice, "Check that minikube is running and that you have specified the correct namespace (-n flag) if required.")
 			os.Exit(exit.Unavailable)
+		}
+		cfg, err := config.Load(viper.GetString(config.MachineProfile))
+		if err != nil {
+			exit.WithError("Error getting config", err)
 		}
 
 		var data [][]string
@@ -53,12 +66,17 @@ var serviceListCmd = &cobra.Command{
 			if len(serviceURL.URLs) == 0 {
 				data = append(data, []string{serviceURL.Namespace, serviceURL.Name, "No node port"})
 			} else {
-				data = append(data, []string{serviceURL.Namespace, serviceURL.Name, strings.Join(serviceURL.URLs, "\n")})
+				data = append(data, []string{serviceURL.Namespace, serviceURL.Name, "", strings.Join(serviceURL.URLs, "\n")})
+
 			}
 
 		}
-
 		service.PrintServiceList(os.Stdout, data)
+		if runtime.GOOS == "darwin" && cfg.Driver == oci.Docker {
+			out.FailureT("Accessing service on docker driver for mac is not implemented yet.Please follow the work in progress and the workarround to solve this issue:\n\thttps://github.com/kubernetes/minikube/issues/6778")
+			exit.WithCodeT(exit.Failure, "not implemented for docker on mac driver yet.")
+		}
+
 	},
 }
 

--- a/cmd/minikube/cmd/service_list.go
+++ b/cmd/minikube/cmd/service_list.go
@@ -73,7 +73,7 @@ var serviceListCmd = &cobra.Command{
 		}
 		service.PrintServiceList(os.Stdout, data)
 		if runtime.GOOS == "darwin" && cfg.Driver == oci.Docker {
-			out.FailureT("Accessing service on docker driver for mac is not implemented yet.Please follow the work in progress and the workarround to solve this issue:\n\thttps://github.com/kubernetes/minikube/issues/6778")
+			out.FailureT("Accessing service on docker driver for mac is not fully implemented yet.\nTo read about workarroudns on mac and update on the work in progress, please reffer to this link:\nhttps://github.com/kubernetes/minikube/issues/6778")
 			exit.WithCodeT(exit.Failure, "not implemented for docker on mac driver yet.")
 		}
 


### PR DESCRIPTION
This PR will point the users using docker driver on Mac about service command not being implemented fully yet.

```
|-------------|-----------------|--------------|-------------------------|
|  NAMESPACE  |      NAME       | TARGET PORT  |           URL           |
|-------------|-----------------|--------------|-------------------------|
| default     | hello-minikube  |              | http://172.17.0.2:32150 |
| default     | hello-minikube1 |              | http://172.17.0.2:32172 |
| default     | hello-minikube2 |              | http://172.17.0.2:30582 |
| default     | kubernetes      | No node port |
| kube-system | kube-dns        | No node port |
|-------------|-----------------|--------------|-------------------------|
❌  Accessing service on docker driver for mac is not implemented yet.Please follow the work in progress and the workarround to solve this issue:
        https://github.com/kubernetes/minikube/issues/6778
💣  not implemented for docker on mac driver yet.
```

also

```
 $ make && ./out/minikube service hello-minikube
|-----------|----------------|-------------|-------------------------|
| NAMESPACE |      NAME      | TARGET PORT |           URL           |
|-----------|----------------|-------------|-------------------------|
| default   | hello-minikube |             | http://172.17.0.2:32150 |
|-----------|----------------|-------------|-------------------------|
❌  openning service in browser is not implemented yet for "docker driver on mac".
Please track the URL bellow to see updates for in progress work:
https://github.com/kubernetes/minikube/issues/6778
💣  not implemented for docker driver on MacOs yet
```


### also
fixes the URL being printed in the 3rd column (a missing "")