### PR TITLE
kic tunnel avoid printing exit as error

### DIFF
--- a/pkg/minikube/tunnel/kic/ssh_conn.go
+++ b/pkg/minikube/tunnel/kic/ssh_conn.go
@@ -66,7 +66,7 @@ func (c *sshConn) startAndWait() error {
 	}
 
 	// we ignore wait error because the process will be killed
-	c.cmd.Wait()
+	_ = c.cmd.Wait()
 
 	return nil
 }

--- a/pkg/minikube/tunnel/kic/ssh_conn.go
+++ b/pkg/minikube/tunnel/kic/ssh_conn.go
@@ -24,8 +24,9 @@ import (
 )
 
 type sshConn struct {
-	name string
-	cmd  *exec.Cmd
+	name    string
+	service string
+	cmd     *exec.Cmd
 }
 
 func createSSHConn(name, sshPort, sshKey string, svc v1.Service) *sshConn {
@@ -51,17 +52,26 @@ func createSSHConn(name, sshPort, sshKey string, svc v1.Service) *sshConn {
 	cmd := exec.Command("ssh", sshArgs...)
 
 	return &sshConn{
-		name: name,
-		cmd:  cmd,
+		name:    name,
+		service: svc.Name,
+		cmd:     cmd,
 	}
 }
 
-func (c *sshConn) run() error {
-	fmt.Printf("starting tunnel for %s\n", c.name)
-	return c.cmd.Run()
+func (c *sshConn) startAndWait() error {
+	fmt.Printf("starting tunnel for %s\n", c.service)
+	err := c.cmd.Start()
+	if err != nil {
+		return err
+	}
+
+	// we ignore wait error because the process will be killed
+	c.cmd.Wait()
+
+	return nil
 }
 
 func (c *sshConn) stop() error {
-	fmt.Printf("stopping tunnel for %s\n", c.name)
+	fmt.Printf("stopping tunnel for %s\n", c.service)
 	return c.cmd.Process.Kill()
 }

--- a/pkg/minikube/tunnel/kic/ssh_tunnel.go
+++ b/pkg/minikube/tunnel/kic/ssh_tunnel.go
@@ -108,11 +108,10 @@ func (t *SSHTunnel) startConnection(svc v1.Service) {
 	t.conns[newSSHConn.name] = newSSHConn
 
 	go func() {
-		err := newSSHConn.run()
+		err := newSSHConn.startAndWait()
 		if err != nil {
 			glog.Errorf("error starting ssh tunnel: %v", err)
 		}
-
 	}()
 
 	err := t.LoadBalancerEmulator.PatchServiceIP(t.v1Core.RESTClient(), svc, "127.0.0.1")


### PR DESCRIPTION
The current implementation will print an error when the tunnel is stopped. We should ignore it because the tunnel is stopped, when a changed was done to the service, eg an existing service exposed a new port, this kill the previous tunnel and creates a new one that includes the new port.
