### PR TITLE
promote docker driver priority from "experimental" to "fallback"

### DIFF
--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -37,7 +37,7 @@ func init() {
 		Config:   configure,
 		Init:     func() drivers.Driver { return kic.NewDriver(kic.Config{OCIBinary: oci.Docker}) },
 		Status:   status,
-		Priority: registry.Experimental,
+		Priority: registry.Fallback,
 	}); err != nil {
 		panic(fmt.Sprintf("register failed: %v", err))
 	}


### PR DESCRIPTION
This PR should be merged. as last PR before releasing 1.8.0 
If tests on this PR look good at that time, we can announce docker driver GA.

it will still not be the prefered as "hyperkit" on mac or "hyperv" on window but it will be higher priority

closes https://github.com/kubernetes/minikube/pull/6791