### PR TITLE
Display more meaningful system info for kic Drivers

### DIFF
--- a/pkg/drivers/kic/oci/info.go
+++ b/pkg/drivers/kic/oci/info.go
@@ -209,7 +209,7 @@ func DaemonInfo(ociBin string) (SysInfo, error) {
 func dockerSystemInfo() (SysInfo, error) {
 	var ds dockerSysInfo
 	var s SysInfo
-	cmd := exec.Command(Docker, "system", "info", "--format", "'{{json .}}'")
+	cmd := exec.Command(Docker, "system", "info", "--format", "{{json .}}")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return s, errors.Wrap(err, "get docker system info")

--- a/pkg/drivers/kic/oci/info.go
+++ b/pkg/drivers/kic/oci/info.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oci
+
+import (
+	"encoding/json"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// SysInfo Info represents common system Information between docker and podman that minikube cares
+type SysInfo struct {
+	CPUs        int   // CPUs is Number of CPUs
+	TotalMemory int64 // TotalMemory Total available ram
+}
+
+// dockerSysInfo represents the output of docker system info --format '{{json .}}'
+type dockerSysInfo struct {
+	ID                string      `json:"ID"`
+	Containers        int         `json:"Containers"`
+	ContainersRunning int         `json:"ContainersRunning"`
+	ContainersPaused  int         `json:"ContainersPaused"`
+	ContainersStopped int         `json:"ContainersStopped"`
+	Images            int         `json:"Images"`
+	Driver            string      `json:"Driver"`
+	DriverStatus      [][]string  `json:"DriverStatus"`
+	SystemStatus      interface{} `json:"SystemStatus"`
+	Plugins           struct {
+		Volume        []string    `json:"Volume"`
+		Network       []string    `json:"Network"`
+		Authorization interface{} `json:"Authorization"`
+		Log           []string    `json:"Log"`
+	} `json:"Plugins"`
+	MemoryLimit        bool      `json:"MemoryLimit"`
+	SwapLimit          bool      `json:"SwapLimit"`
+	KernelMemory       bool      `json:"KernelMemory"`
+	KernelMemoryTCP    bool      `json:"KernelMemoryTCP"`
+	CPUCfsPeriod       bool      `json:"CpuCfsPeriod"`
+	CPUCfsQuota        bool      `json:"CpuCfsQuota"`
+	CPUShares          bool      `json:"CPUShares"`
+	CPUSet             bool      `json:"CPUSet"`
+	PidsLimit          bool      `json:"PidsLimit"`
+	IPv4Forwarding     bool      `json:"IPv4Forwarding"`
+	BridgeNfIptables   bool      `json:"BridgeNfIptables"`
+	BridgeNfIP6Tables  bool      `json:"BridgeNfIp6tables"`
+	Debug              bool      `json:"Debug"`
+	NFd                int       `json:"NFd"`
+	OomKillDisable     bool      `json:"OomKillDisable"`
+	NGoroutines        int       `json:"NGoroutines"`
+	SystemTime         time.Time `json:"SystemTime"`
+	LoggingDriver      string    `json:"LoggingDriver"`
+	CgroupDriver       string    `json:"CgroupDriver"`
+	NEventsListener    int       `json:"NEventsListener"`
+	KernelVersion      string    `json:"KernelVersion"`
+	OperatingSystem    string    `json:"OperatingSystem"`
+	OSType             string    `json:"OSType"`
+	Architecture       string    `json:"Architecture"`
+	IndexServerAddress string    `json:"IndexServerAddress"`
+	RegistryConfig     struct {
+		AllowNondistributableArtifactsCIDRs     []interface{} `json:"AllowNondistributableArtifactsCIDRs"`
+		AllowNondistributableArtifactsHostnames []interface{} `json:"AllowNondistributableArtifactsHostnames"`
+		InsecureRegistryCIDRs                   []string      `json:"InsecureRegistryCIDRs"`
+		IndexConfigs                            struct {
+			DockerIo struct {
+				Name     string        `json:"Name"`
+				Mirrors  []interface{} `json:"Mirrors"`
+				Secure   bool          `json:"Secure"`
+				Official bool          `json:"Official"`
+			} `json:"docker.io"`
+		} `json:"IndexConfigs"`
+		Mirrors []interface{} `json:"Mirrors"`
+	} `json:"RegistryConfig"`
+	NCPU              int           `json:"NCPU"`
+	MemTotal          int64         `json:"MemTotal"`
+	GenericResources  interface{}   `json:"GenericResources"`
+	DockerRootDir     string        `json:"DockerRootDir"`
+	HTTPProxy         string        `json:"HttpProxy"`
+	HTTPSProxy        string        `json:"HttpsProxy"`
+	NoProxy           string        `json:"NoProxy"`
+	Name              string        `json:"Name"`
+	Labels            []interface{} `json:"Labels"`
+	ExperimentalBuild bool          `json:"ExperimentalBuild"`
+	ServerVersion     string        `json:"ServerVersion"`
+	ClusterStore      string        `json:"ClusterStore"`
+	ClusterAdvertise  string        `json:"ClusterAdvertise"`
+	Runtimes          struct {
+		Runc struct {
+			Path string `json:"path"`
+		} `json:"runc"`
+	} `json:"Runtimes"`
+	DefaultRuntime string `json:"DefaultRuntime"`
+	Swarm          struct {
+		NodeID           string      `json:"NodeID"`
+		NodeAddr         string      `json:"NodeAddr"`
+		LocalNodeState   string      `json:"LocalNodeState"`
+		ControlAvailable bool        `json:"ControlAvailable"`
+		Error            string      `json:"Error"`
+		RemoteManagers   interface{} `json:"RemoteManagers"`
+	} `json:"Swarm"`
+	LiveRestoreEnabled bool   `json:"LiveRestoreEnabled"`
+	Isolation          string `json:"Isolation"`
+	InitBinary         string `json:"InitBinary"`
+	ContainerdCommit   struct {
+		ID       string `json:"ID"`
+		Expected string `json:"Expected"`
+	} `json:"ContainerdCommit"`
+	RuncCommit struct {
+		ID       string `json:"ID"`
+		Expected string `json:"Expected"`
+	} `json:"RuncCommit"`
+	InitCommit struct {
+		ID       string `json:"ID"`
+		Expected string `json:"Expected"`
+	} `json:"InitCommit"`
+	SecurityOptions []string    `json:"SecurityOptions"`
+	ProductLicense  string      `json:"ProductLicense"`
+	Warnings        interface{} `json:"Warnings"`
+	ClientInfo      struct {
+		Debug    bool          `json:"Debug"`
+		Plugins  []interface{} `json:"Plugins"`
+		Warnings interface{}   `json:"Warnings"`
+	} `json:"ClientInfo"`
+}
+
+// podmanSysInfo represents the output of podman system info --format '{{json .}}'
+type podmanSysInfo struct {
+	Host struct {
+		BuildahVersion string `json:"BuildahVersion"`
+		CgroupVersion  string `json:"CgroupVersion"`
+		Conmon         struct {
+			Package string `json:"package"`
+			Path    string `json:"path"`
+			Version string `json:"version"`
+		} `json:"Conmon"`
+		Distribution struct {
+			Distribution string `json:"distribution"`
+			Version      string `json:"version"`
+		} `json:"Distribution"`
+		MemFree    int   `json:"MemFree"`
+		MemTotal   int64 `json:"MemTotal"`
+		OCIRuntime struct {
+			Name    string `json:"name"`
+			Package string `json:"package"`
+			Path    string `json:"path"`
+			Version string `json:"version"`
+		} `json:"OCIRuntime"`
+		SwapFree    int    `json:"SwapFree"`
+		SwapTotal   int    `json:"SwapTotal"`
+		Arch        string `json:"arch"`
+		Cpus        int    `json:"cpus"`
+		Eventlogger string `json:"eventlogger"`
+		Hostname    string `json:"hostname"`
+		Kernel      string `json:"kernel"`
+		Os          string `json:"os"`
+		Rootless    bool   `json:"rootless"`
+		Uptime      string `json:"uptime"`
+	} `json:"host"`
+	Registries struct {
+		Search []string `json:"search"`
+	} `json:"registries"`
+	Store struct {
+		ConfigFile     string `json:"ConfigFile"`
+		ContainerStore struct {
+			Number int `json:"number"`
+		} `json:"ContainerStore"`
+		GraphDriverName string `json:"GraphDriverName"`
+		GraphOptions    struct {
+		} `json:"GraphOptions"`
+		GraphRoot   string `json:"GraphRoot"`
+		GraphStatus struct {
+			BackingFilesystem string `json:"Backing Filesystem"`
+			NativeOverlayDiff string `json:"Native Overlay Diff"`
+			SupportsDType     string `json:"Supports d_type"`
+			UsingMetacopy     string `json:"Using metacopy"`
+		} `json:"GraphStatus"`
+		ImageStore struct {
+			Number int `json:"number"`
+		} `json:"ImageStore"`
+		RunRoot    string `json:"RunRoot"`
+		VolumePath string `json:"VolumePath"`
+	} `json:"store"`
+}
+
+// DaemonInfo returns docker system info
+func DaemonInfo(ociBin string) (SysInfo, error) {
+	if ociBin == Podman {
+		return podmanSystemInfo()
+	}
+	return dockerSystemInfo()
+}
+
+func dockerSystemInfo() (SysInfo, error) {
+	var ds dockerSysInfo
+	var s SysInfo
+	cmd := exec.Command(Docker, "system", "info", "--format", "'{{json .}}'")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return s, errors.Wrap(err, "get docker system info")
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(out))), &ds); err != nil {
+		return s, errors.Wrapf(err, "unmarshal docker system info")
+	}
+	s.CPUs = ds.NCPU
+	s.TotalMemory = ds.MemTotal
+	return s, nil
+}
+
+func podmanSystemInfo() (SysInfo, error) {
+	var ps podmanSysInfo
+	var s SysInfo
+	cmd := exec.Command(Podman, "system", "info", "--format", "'{{json .}}'")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return s, errors.Wrap(err, "get podman system info")
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(out))), &ps); err != nil {
+		return s, errors.Wrapf(err, "unmarshal podman system info")
+	}
+	s.CPUs = ps.Host.Cpus
+	s.TotalMemory = ps.Host.MemTotal
+	return s, nil
+}

--- a/pkg/minikube/machine/info.go
+++ b/pkg/minikube/machine/info.go
@@ -29,13 +29,13 @@ import (
 )
 
 type hostInfo struct {
-	Memory   int
+	Memory   int64
 	CPUs     int
-	DiskSize int
+	DiskSize int64
 }
 
-func megs(bytes uint64) int {
-	return int(bytes / 1024 / 1024)
+func megs(bytes uint64) int64 {
+	return int64(bytes / 1024 / 1024)
 }
 
 func getHostInfo() (*hostInfo, error) {

--- a/pkg/minikube/machine/start.go
+++ b/pkg/minikube/machine/start.go
@@ -260,13 +260,13 @@ func showHostInfo(cfg config.ClusterConfig) {
 		}
 		return
 	}
-	if driver.IsKIC(cfg.Driver) {
+	if driver.IsKIC(cfg.Driver) { // TODO:medyagh add free disk space on docker machine
 		s, err := oci.DaemonInfo(cfg.Driver)
 		if err == nil {
 			var info hostInfo
 			info.CPUs = s.CPUs
-			info.Memory = s.TotalMemory
-			out.T(out.StartingVM, "Creating Kubernetes in {{.driver_name}} container with (CPUs={{.number_of_cpus}}), Memory={{.memory_size}}MB ({{.host_memory_size}}MB available) ...", out.V{"driver_name": cfg.Driver, "number_of_cpus": cfg.CPUs, "number_of_host_cpus": info.CPUs, "memory_size": cfg.Memory, "host_memory_size": info.Memory})
+			info.Memory = megs(uint64(s.TotalMemory))
+			out.T(out.StartingVM, "Creating Kubernetes in {{.driver_name}} container with (CPUs={{.number_of_cpus}}) ({{.number_of_host_cpus}} available), Memory={{.memory_size}}MB ({{.host_memory_size}}MB available) ...", out.V{"driver_name": cfg.Driver, "number_of_cpus": cfg.CPUs, "number_of_host_cpus": info.CPUs, "memory_size": cfg.Memory, "host_memory_size": info.Memory})
 		}
 		return
 	}

--- a/pkg/minikube/machine/start.go
+++ b/pkg/minikube/machine/start.go
@@ -32,6 +32,7 @@ import (
 	"github.com/juju/mutex"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
+	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/command"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
@@ -260,8 +261,11 @@ func showHostInfo(cfg config.ClusterConfig) {
 		return
 	}
 	if driver.IsKIC(cfg.Driver) {
-		info, err := getHostInfo() // TODO medyagh: get docker-machine info for non linux
+		s, err := oci.DaemonInfo(cfg.Driver)
 		if err == nil {
+			var info hostInfo
+			info.CPUs = s.CPUs
+			info.Memory = s.TotalMemory
 			out.T(out.StartingVM, "Creating Kubernetes in {{.driver_name}} container with (CPUs={{.number_of_cpus}}), Memory={{.memory_size}}MB ({{.host_memory_size}}MB available) ...", out.V{"driver_name": cfg.Driver, "number_of_cpus": cfg.CPUs, "number_of_host_cpus": info.CPUs, "memory_size": cfg.Memory, "host_memory_size": info.Memory})
 		}
 		return


### PR DESCRIPTION
## After this PR: 
it will show the actual memory size from the docker-machine (as opposed to the user system) and how much is available to them.
in this case, my docker-machine has less than 2GB but it used to show 16 GB

```
😄  minikube v1.7.3 on Darwin 10.13.6
✨  Using the docker (experimental) driver based on user configuration
🔥  Creating Kubernetes in docker container with (CPUs=2) (4 available), Memory=2000MB (1989MB available) ...
🐳  Preparing Kubernetes v1.17.3 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16
```


## before this PR 
the info before this PR was useless because it was showing ram on the host machine not the docker-machine.that user can decide to allocate limtited resource to it. so their machine might have 16 GB ram but their docker-machine only have 2 GB

```
medmac@~/minikube (d_cpu_ram) $ minikube start --vm-driver=docker
😄  minikube v1.7.3 on Darwin 10.13.6
✨  Using the docker (experimental) driver based on user configuration
🔥  Creating Kubernetes in docker container with (CPUs=2), Memory=2000MB (16384MB available) ...
```

Closes https://github.com/kubernetes/minikube/issues/6801
closes https://github.com/kubernetes/minikube/issues/6801