### PR TITLE
Disable default hypervisors mounts + fix 9P path on Darwin 

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -190,7 +190,7 @@ func initKubernetesFlags() {
 // initDriverFlags inits the commandline flags for vm drivers
 func initDriverFlags() {
 	startCmd.Flags().String("vm-driver", "", fmt.Sprintf("Driver is one of: %v (defaults to auto-detect)", driver.DisplaySupportedDrivers()))
-	startCmd.Flags().Bool(disableDriverMounts, false, "Disables the filesystem mounts provided by the hypervisors")
+	startCmd.Flags().Bool(disableDriverMounts, true, "Disables the filesystem mounts provided by the hypervisors")
 
 	// kvm2
 	startCmd.Flags().String(kvmNetwork, "default", "The KVM network name. (kvm2 driver only)")

--- a/pkg/minikube/constants/constants_darwin.go
+++ b/pkg/minikube/constants/constants_darwin.go
@@ -22,5 +22,5 @@ import (
 	"k8s.io/client-go/util/homedir"
 )
 
-// DefaultMountDir is the default mount directory for Darwin
+// DefaultMountDir is the default mount directory
 var DefaultMountDir = homedir.HomeDir()

--- a/pkg/minikube/constants/constants_darwin.go
+++ b/pkg/minikube/constants/constants_darwin.go
@@ -18,5 +18,9 @@ limitations under the License.
 
 package constants
 
-// DefaultMountDir is the default mounting directory for Darwin
-var DefaultMountDir = "/Users"
+import (
+	"k8s.io/client-go/util/homedir"
+)
+
+// DefaultMountDir is the default mount directory for Darwin
+var DefaultMountDir = homedir.HomeDir()

--- a/pkg/minikube/constants/constants_gendocs.go
+++ b/pkg/minikube/constants/constants_gendocs.go
@@ -18,4 +18,9 @@ limitations under the License.
 
 package constants
 
-var DefaultMountDir = "$HOME"
+import (
+	"k8s.io/client-go/util/homedir"
+)
+
+// DefaultMountDir is the default mount dir
+var DefaultMountDir = homedir.HomeDir()

--- a/site/content/en/docs/Reference/Commands/start.md
+++ b/site/content/en/docs/Reference/Commands/start.md
@@ -66,7 +66,7 @@ minikube start [flags]
       --kvm-qemu-uri string               The KVM QEMU connection URI. (kvm2 driver only) (default "qemu:///system")
       --memory string                     Amount of RAM allocated to the minikube VM (format: <number>[<unit>], where unit = b, k, m or g). (default "2000mb")
       --mount                             This will start the mount daemon and automatically mount files into minikube.
-      --mount-string string               The argument to pass the minikube mount command on start. (default "/Users:/minikube-host")
+      --mount-string string               The argument to pass the minikube mount command on start. (default "<home directory>:/minikube-host")
       --nat-nic-type string               NIC Type used for host only network. One of Am79C970A, Am79C973, 82540EM, 82543GC, 82545EM, or virtio (virtualbox driver only) (default "virtio")
       --native-ssh                        Use native Golang SSH client (default true). Set to 'false' to use the command line 'ssh' command when accessing the docker machine. Useful for the machine drivers when they will not start with 'Waiting for SSH'. (default true)
       --network-plugin string             The name of the network plugin.

--- a/site/content/en/docs/Tasks/mount.md
+++ b/site/content/en/docs/Tasks/mount.md
@@ -71,10 +71,17 @@ Some hypervisors, have built-in host folder sharing. Driver mounts are reliable 
 | VirtualBox | macOS | /Users | /Users |
 | VirtualBox | Windows | C://Users | /c/Users |
 | VMware Fusion | macOS | /Users | /Users |
+| Xhyve | macOS | /Users | /Users |
 | KVM | Linux | Unsupported | | 
 | HyperKit | Linux | Unsupported (see NFS mounts) | | 
 
-These mounts can be disabled by passing `--disable-driver-mounts` to `minikube start`.
+Host folder sharing is disabled by default, it can be enabled by passing `--disable-driver-mounts=false` to `minikube start`.
+
+For Example
+
+```
+minikube start --disable-driver-mounts=false --vm-driver='virtualbox'
+```
 
 ## File Sync
 


### PR DESCRIPTION
Hello,

this PR : 

- Fix default 9P mount path on Darwin ($HOME instead of /Users, same path on all OS) 
- Add the default 9P mount path for Xhyve Hypervisor (doc) 
- Disable default mounts provided by the hypervisors (lax behavior, can lead to data loss on the host machine)

check 
fixes #6788

Regards,