### PR TITLE
warn about "stuck docker"  in minikube delete

### DIFF
--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -116,7 +116,7 @@ func runDelete(cmd *cobra.Command, args []string) {
 			exit.UsageT("usage: minikube delete --all")
 		}
 		delLabel := fmt.Sprintf("%s=%s", oci.CreatedByLabelKey, "true")
-		errs := oci.DeleteAllContainersByLabel(oci.Docker, delLabel)
+		errs := oci.DeleteContainersByLabel(oci.Docker, delLabel)
 		if len(errs) > 0 { // it will error if there is no container to delete
 			glog.Infof("error delete containers by label %q (might be okay): %+v", delLabel, err)
 		}
@@ -194,7 +194,7 @@ func deleteProfile(profile *pkg_config.Profile) error {
 	viper.Set(pkg_config.MachineProfile, profile.Name)
 
 	delLabel := fmt.Sprintf("%s=%s", oci.ProfileLabelKey, profile.Name)
-	errs := oci.DeleteAllContainersByLabel(oci.Docker, delLabel)
+	errs := oci.DeleteContainersByLabel(oci.Docker, delLabel)
 	if errs != nil { // it will error if there is no container to delete
 		glog.Infof("error deleting containers for %s (might be okay):\n%v", profile.Name, errs)
 	}
@@ -207,7 +207,6 @@ func deleteProfile(profile *pkg_config.Profile) error {
 	if len(errs) > 0 { // it will not error if there is nothing to delete
 		glog.Warningf("error pruning volume (might be okay):\n%v", errs)
 	}
-
 	api, err := machine.NewAPIClient()
 	if err != nil {
 		delErr := profileDeletionErr(profile.Name, fmt.Sprintf("error getting client %v", err))

--- a/pkg/drivers/kic/oci/network.go
+++ b/pkg/drivers/kic/oci/network.go
@@ -43,7 +43,7 @@ func RoutableHostIPFromInside(ociBin string, containerName string) (net.IP, erro
 // digDNS will get the IP record for a dns
 func digDNS(ociBin, containerName, dns string) (net.IP, error) {
 	if err := PointToHostDockerDaemon(); err != nil {
-		return nil, errors.Wrap(err, "point host docker-daemon")
+		return nil, errors.Wrap(err, "point host docker daemon")
 	}
 	cmd := exec.Command(ociBin, "exec", "-t", containerName, "dig", "+short", dns)
 	out, err := cmd.CombinedOutput()
@@ -59,7 +59,7 @@ func digDNS(ociBin, containerName, dns string) (net.IP, error) {
 // gets the ip from user's host docker
 func dockerGatewayIP() (net.IP, error) {
 	if err := PointToHostDockerDaemon(); err != nil {
-		return nil, errors.Wrap(err, "point host docker-daemon")
+		return nil, errors.Wrap(err, "point host docker daemon")
 	}
 	cmd := exec.Command(Docker, "network", "ls", "--filter", "name=bridge", "--format", "{{.ID}}")
 	out, err := cmd.CombinedOutput()

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -59,13 +59,13 @@ func DeleteContainersByLabel(ociBin string, label string) []error {
 		if err != nil {
 			deleteErrs = append(deleteErrs, errors.Wrapf(err, "delete container %s: %s daemon is stuck. please try again!", c, ociBin))
 			glog.Errorf("%s daemon seems to be stuck. Please try restarting your %s.", ociBin, ociBin)
-		} else {
-			cmd := exec.Command(ociBin, "rm", "-f", "-v", c)
-			if out, err := cmd.CombinedOutput(); err != nil {
-				deleteErrs = append(deleteErrs, errors.Wrapf(err, "delete container %s: output %s", c, out))
-			}
-
+			continue
 		}
+		cmd := exec.Command(ociBin, "rm", "-f", "-v", c)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			deleteErrs = append(deleteErrs, errors.Wrapf(err, "delete container %s: output %s", c, out))
+		}
+
 	}
 	return deleteErrs
 }

--- a/pkg/minikube/machine/delete.go
+++ b/pkg/minikube/machine/delete.go
@@ -17,7 +17,9 @@ limitations under the License.
 package machine
 
 import (
+	"context"
 	"os/exec"
+	"time"
 
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/mcnerror"
@@ -29,10 +31,30 @@ import (
 	"k8s.io/minikube/pkg/minikube/out"
 )
 
-// deleteOrphanedKIC attempts to delete an orphaned docker instance
-func deleteOrphanedKIC(name string) {
-	cmd := exec.Command(oci.Docker, "rm", "-f", "-v", name)
-	err := cmd.Run()
+// deleteOrphanedKIC attempts to delete an orphaned docker instance for machines without a config file
+// used as last effort clean up not returning errors, wont warn user.
+func deleteOrphanedKIC(ociBin string, name string) {
+	if !(ociBin == oci.Podman || ociBin == oci.Docker) {
+		return
+	}
+	if ociBin == oci.Docker {
+		if err := oci.PointToHostDockerDaemon(); err != nil {
+			glog.Infof("Failed to point to host docker-damon: %v", err)
+			return
+		}
+	}
+
+	_, err := oci.ContainerStatus(ociBin, name)
+	if err != nil {
+		glog.Infof("couldn't inspect container %q before deleting, %s-daemon might needs a restart!: %v", name, ociBin, err)
+		return
+	}
+	// allow no more than 5 seconds for delting the container
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, ociBin, "rm", "-f", "-v", name)
+	err = cmd.Run()
 	if err == nil {
 		glog.Infof("Found stale kic container and successfully cleaned it up!")
 	}
@@ -42,7 +64,8 @@ func deleteOrphanedKIC(name string) {
 func DeleteHost(api libmachine.API, machineName string) error {
 	host, err := api.Load(machineName)
 	if err != nil && host == nil {
-		deleteOrphanedKIC(machineName)
+		deleteOrphanedKIC(oci.Docker, machineName)
+		deleteOrphanedKIC(oci.Podman, machineName)
 		// Keep going even if minikube does not know about the host
 	}
 


### PR DESCRIPTION
### Before PR:
delete would hang forever...

because docker container was stuck (however docker itself is healthy and no signs of docker problem but in reality docker needs restart, only way to identify this issue is to do docker inspect on the container and it would hang forever ... (no error) and other docker commands like info or system info were just acting normal)

### after this PR:
Fail Fast. Warn User to restart docker.
nothing should hang forever.
```
🙄  "minikube" profile does not exist, trying anyways.
E0226 12:34:52.650785   31788 oci.go:61] docker daemon seems to be stuck. Please try restarting your docker.
💀  Removed all traces of the "minikube" cluster.```