### PR TITLE
give hint if 'minikube delete' cannot delete the machine directory

### DIFF
--- a/pkg/minikube/problem/err_map.go
+++ b/pkg/minikube/problem/err_map.go
@@ -111,7 +111,7 @@ var vmProblems = map[string]match{
 	},
 	"HYPERV_FILE_DELETE_FAILURE": {
 		Regexp: re(`Unable to remove machine directory`),
-		Advice: "Stop the  Hyper-V Manager and run 'minikube delete'.",
+		Advice: "You may need to stop the  Hyper-V Manager and run `minikube delete` again.",
 		Issues: []int{6804},
 		GOOS:   []string{"windows"},
 	},

--- a/pkg/minikube/problem/err_map.go
+++ b/pkg/minikube/problem/err_map.go
@@ -109,6 +109,12 @@ var vmProblems = map[string]match{
 		Issues: []int{4511},
 		GOOS:   []string{"windows"},
 	},
+	"HYPERV_FILE_DELETE_FAILURE": {
+		Regexp: re(`Unable to remove machine directory`),
+		Advice: "Stop the  Hyper-V Manager and and run 'minikube delete'.",
+		Issues: []int{6804},
+		GOOS:   []string{"windows"},
+	},
 
 	// KVM
 	"KVM2_NOT_FOUND": {

--- a/pkg/minikube/problem/err_map.go
+++ b/pkg/minikube/problem/err_map.go
@@ -111,7 +111,7 @@ var vmProblems = map[string]match{
 	},
 	"HYPERV_FILE_DELETE_FAILURE": {
 		Regexp: re(`Unable to remove machine directory`),
-		Advice: "You may need to stop the  Hyper-V Manager and run `minikube delete` again.",
+		Advice: "You may need to stop the Hyper-V Manager and run `minikube delete` again.",
 		Issues: []int{6804},
 		GOOS:   []string{"windows"},
 	},

--- a/pkg/minikube/problem/err_map.go
+++ b/pkg/minikube/problem/err_map.go
@@ -111,7 +111,7 @@ var vmProblems = map[string]match{
 	},
 	"HYPERV_FILE_DELETE_FAILURE": {
 		Regexp: re(`Unable to remove machine directory`),
-		Advice: "Stop the  Hyper-V Manager and and run 'minikube delete'.",
+		Advice: "Stop the  Hyper-V Manager and run 'minikube delete'.",
 		Issues: []int{6804},
 		GOOS:   []string{"windows"},
 	},


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

In some cases the command `minikube delete` can produce error message like this on Windows:

```
! Unable to get the status of the minikube cluster.
* Removing C:\Users\...\.minikube\machines\minikube ...
*
X Unable to remove machine directory: %v: remove C:\Users\...\.minikube\machines\minikube\disk.vhd: The process cannot access the file because it is being used by another process.
*
* minikube is exiting due to an error. If the above message is not useful, open an issue:
  - https://github.com/kubernetes/minikube/issues/new/choose
```

A possible explanation for this is that the Hyper-V Manager keeps some files locked which prevents the directory from being deleted. 

This Pull Request aims to give a more reasonable explanation if such a situation happens.