### PR TITLE
Fix: disable a disabled addon cause error

### DIFF
--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -118,6 +118,9 @@ func enableOrDisableAddon(name, val, profile string) error {
 
 	if alreadySet {
 		glog.Warningf("addon %s should already be in state %v", name, val)
+		if !enable {
+			return nil
+		}
 	}
 
 	if name == "istio" && enable {


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
Fixes #6749 
It seems that enabling an enabled addon again is a designed behavior and does not cause error according to #6440.  
But disabling a disabled addon will just cause error.