### PR TITLE
kic: fix service list for docker on osx

### DIFF
--- a/cmd/minikube/cmd/service_list.go
+++ b/cmd/minikube/cmd/service_list.go
@@ -66,17 +66,18 @@ var serviceListCmd = &cobra.Command{
 			if len(serviceURL.URLs) == 0 {
 				data = append(data, []string{serviceURL.Namespace, serviceURL.Name, "No node port"})
 			} else {
-				data = append(data, []string{serviceURL.Namespace, serviceURL.Name, "", strings.Join(serviceURL.URLs, "\n")})
+				serviceURLs := strings.Join(serviceURL.URLs, "\n")
 
+				// if we are running Docker on OSX we empty the internal service URLs
+				if runtime.GOOS == "darwin" && cfg.Driver == oci.Docker {
+					serviceURLs = ""
+				}
+
+				data = append(data, []string{serviceURL.Namespace, serviceURL.Name, "", serviceURLs})
 			}
-
 		}
+
 		service.PrintServiceList(os.Stdout, data)
-		if runtime.GOOS == "darwin" && cfg.Driver == oci.Docker {
-			out.FailureT("Accessing service is not implemented yet for docker driver on Mac.\nThe following issue is tracking the in progress work::\nhttps://github.com/kubernetes/minikube/issues/6778")
-			exit.WithCodeT(exit.Failure, "Not yet implemented for docker driver on MacOS.")
-		}
-
 	},
 }
 


### PR DESCRIPTION
Fix for https://github.com/kubernetes/minikube/issues/6829

```
./out/minikube service list
|-------------|-----------------|--------------|-----|
|  NAMESPACE  |      NAME       | TARGET PORT  | URL |
|-------------|-----------------|--------------|-----|
| default     | hello-minikube1 |              |     |
| default     | kubernetes      | No node port |
| kube-system | kube-dns        | No node port |
|-------------|-----------------|--------------|-----|
```