### PR TITLE
kic: fix unprivileged port bind tunnel docker for mac

### DIFF
--- a/pkg/minikube/tunnel/kic/ssh_conn.go
+++ b/pkg/minikube/tunnel/kic/ssh_conn.go
@@ -36,6 +36,7 @@ func createSSHConn(name, sshPort, sshKey string, svc *v1.Service) *sshConn {
 	// extract sshArgs
 	sshArgs := []string{
 		// TODO: document the options here
+		"ssh",
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-o", "StrictHostKeyChecking no",
 		"-N",
@@ -55,7 +56,7 @@ func createSSHConn(name, sshPort, sshKey string, svc *v1.Service) *sshConn {
 		sshArgs = append(sshArgs, arg)
 	}
 
-	cmd := exec.Command("ssh", sshArgs...)
+	cmd := exec.Command("sudo", sshArgs...)
 
 	return &sshConn{
 		name:    name,


### PR DESCRIPTION
Fix for https://github.com/kubernetes/minikube/issues/6832

If any service exposes privileged ports, we print a message informing the user which service/port and ask sudo permission.

```
minikube tunnel
The service nginx-svc requires priviledged ports to be exposed: [80]
sudo permission will be asked for it.
```

This PR also fixes the functional test for tunnel, it now passes for docker on osx too. https://github.com/kubernetes/minikube/blob/master/test/integration/fn_tunnel_cmd.go