### PR TITLE
doc: minikube tunnel command runs as a process in the same terminal

### DIFF
--- a/site/content/en/docs/Tasks/loadbalancer.md
+++ b/site/content/en/docs/Tasks/loadbalancer.md
@@ -14,7 +14,7 @@ A LoadBalancer service is the standard way to expose a service to the internet. 
 
 ## Using `minikube tunnel`
 
-Services of type `LoadBalancer` can be exposed via the `minikube tunnel` command. It will run in a separate terminal until Ctrl-C is hit.
+Services of type `LoadBalancer` can be exposed via the `minikube tunnel` command. It will run in the terminal until Ctrl-C is hit.
 
 ## Example
 
@@ -25,7 +25,7 @@ it will ask for password.
 minikube tunnel
 ```
 
-`minikube tunnel` runs as a separate daemon, creating a network route on the host to the service CIDR of the cluster using the cluster's IP address as a gateway.  The tunnel command exposes the external IP directly to any program running on the host operating system.
+`minikube tunnel` runs as a process, creating a network route on the host to the service CIDR of the cluster using the cluster's IP address as a gateway.  The tunnel command exposes the external IP directly to any program running on the host operating system.
 
 
 <details>

--- a/site/content/en/docs/Tasks/loadbalancer.md
+++ b/site/content/en/docs/Tasks/loadbalancer.md
@@ -14,7 +14,7 @@ A LoadBalancer service is the standard way to expose a service to the internet. 
 
 ## Using `minikube tunnel`
 
-Services of type `LoadBalancer` can be exposed via the `minikube tunnel` command. It must be continuously run in a terminal to keep the `LoadBalancer` running.  Ctrl-C in the terminal can be used to terminate the process at which time the network routes will be cleaned up.
+Services of type `LoadBalancer` can be exposed via the `minikube tunnel` command. It must be run in a separate terminal window to keep the `LoadBalancer` running.  Ctrl-C in the terminal can be used to terminate the process at which time the network routes will be cleaned up.
 
 ## Example
 

--- a/site/content/en/docs/Tasks/loadbalancer.md
+++ b/site/content/en/docs/Tasks/loadbalancer.md
@@ -14,7 +14,7 @@ A LoadBalancer service is the standard way to expose a service to the internet. 
 
 ## Using `minikube tunnel`
 
-Services of type `LoadBalancer` can be exposed via the `minikube tunnel` command. It will run in the terminal until Ctrl-C is hit.
+Services of type `LoadBalancer` can be exposed via the `minikube tunnel` command. It must be continuously run in a terminal to keep the `LoadBalancer` running.  Ctrl-C in the terminal can be used to terminate the process at which time the network routes will be cleaned up.
 
 ## Example
 


### PR DESCRIPTION
The documentation suggests that minikube tunnel runs in a separate terminal window and as a daemon, but actually it is just a process that requires root and runs until terminated.