### PR TITLE
Negotiate Docker API Version before image query

### DIFF
--- a/pkg/minikube/image/image.go
+++ b/pkg/minikube/image/image.go
@@ -44,6 +44,7 @@ var defaultPlatform = v1.Platform{
 func DigestByDockerLib(imgClient *client.Client, imgName string) string {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
+	imgClient.NegotiateAPIVersion(ctx)
 	img, _, err := imgClient.ImageInspectWithRaw(ctx, imgName)
 	if err != nil && !client.IsErrNotFound(err) {
 		glog.Infof("couldn't find image digest %s from local daemon: %v ", imgName, err)


### PR DESCRIPTION
Avoids error working with older Docker daemons
    Error response from daemon:
        client version 1.41 is too new.
        Maximum supported API version is 1.39
