### PR TITLE
Add fallback command when nslookup is missing

### DIFF
--- a/pkg/minikube/node/machine.go
+++ b/pkg/minikube/node/machine.go
@@ -154,12 +154,15 @@ func trySSH(h *host.Host, ip string) {
 
 func tryLookup(r command.Runner) {
 	// DNS check
-	if rr, err := r.RunCmd(exec.Command("nslookup", "kubernetes.io", "-type=ns")); err != nil {
+	if rr, err := r.RunCmd(exec.Command("nslookup", "-type=ns", "kubernetes.io")); err != nil {
 		glog.Infof("%s failed: %v which might be okay will retry nslookup without query type", rr.Args, err)
 		// will try with without query type for ISOs with different busybox versions.
 		if _, err = r.RunCmd(exec.Command("nslookup", "kubernetes.io")); err != nil {
 			glog.Warningf("nslookup failed: %v", err)
-			out.WarningT("Node may be unable to resolve external DNS records")
+			// try with the older "host" command, instead of the newer "nslookup"
+			if _, err = r.RunCmd(exec.Command("host", "kubernetes.io")); err != nil {
+				out.WarningT("Node may be unable to resolve external DNS records")
+			}
 		}
 	}
 }


### PR DESCRIPTION
The "dnsutils" package with nslookup is not installed in all
installations, but the node can still resolve DNS lookups...

Also restore the correct order of the type parameter, that
was lost in a previous commit (when changing from querytype).

Closes #6840 

The parameter was lost in #6481