### PR TITLE
Change service wait and interval defaults

### DIFF
--- a/pkg/minikube/service/service.go
+++ b/pkg/minikube/service/service.go
@@ -48,9 +48,9 @@ import (
 const (
 	defaultK8sClientTimeout = 60 * time.Second
 	// DefaultWait is the default wait time, in seconds
-	DefaultWait = 20
+	DefaultWait = 2
 	// DefaultInterval is the default interval, in seconds
-	DefaultInterval = 6
+	DefaultInterval = 1
 )
 
 // K8sClient represents a kubernetes client


### PR DESCRIPTION
The wait, and interval flags were added to the service command on the PR: https://github.com/kubernetes/minikube/pull/1651

I understand having those flags for one trying to automate something with minikube. But the default values for basic user are too high, it takes 35s to return a service doesn't exist. 

```
time minikube service non-existing

💣  Error opening service: Service non-existing was not found in "default" namespace. You may select another namespace by using 'minikube service non-existing -n <namespace>: Temporary Error: Error getting service non-existing: services "non-existing" not found

😿  minikube is exiting due to an error. If the above message is not useful, open an issue:
👉  https://github.com/kubernetes/minikube/issues/new/choose

real	0m35,478s
user	0m0,125s
sys	0m0,057s
```

This PR soft the defaults.

```
time minikube service non-existing

💣  Error opening service: Service non-existing was not found in "default" namespace. You may select another namespace by using 'minikube service non-existing -n <namespace>: Temporary Error: Error getting service non-existing: services "non-existing" not found

😿  minikube is exiting due to an error. If the above message is not useful, open an issue:
👉  https://github.com/kubernetes/minikube/issues/new/choose

real	0m3,376s
user	0m0,048s
sys	0m0,068s
```