### PR TITLE
kic: improve error message for service not found

### DIFF
--- a/pkg/minikube/tunnel/kic/service_tunnel.go
+++ b/pkg/minikube/tunnel/kic/service_tunnel.go
@@ -47,7 +47,7 @@ func NewServiceTunnel(sshPort, sshKey string, v1Core typed_core.CoreV1Interface)
 func (t *ServiceTunnel) Start(svcName, namespace string) ([]string, error) {
 	svc, err := t.v1Core.Services(namespace).Get(svcName, metav1.GetOptions{})
 	if err != nil {
-		return nil, errors.Wrap(err, "getting service")
+		return nil, errors.Wrapf(err, "Service %s was not found in %q namespace. You may select another namespace by using 'minikube service %s -n <namespace>", svcName, namespace, svcName)
 	}
 
 	t.sshConn, err = createSSHConnWithRandomPorts(svcName, t.sshPort, t.sshKey, svc)


### PR DESCRIPTION
currently: 

```
minikube service test

💣  Error opening service: getting service: services "test" not found

😿  minikube is exiting due to an error. If the above message is not useful, open an issue:
👉  https://github.com/kubernetes/minikube/issues/new/choose
```

with the PR:

```
minikube service test

💣  Error opening service: Service test was not found in "default" namespace. You may select another namespace by using 'minikube service test -n <namespace>: services "test" not found

😿  minikube is exiting due to an error. If the above message is not useful, open an issue:
👉  https://github.com/kubernetes/minikube/issues/new/choose
```