### PR TITLE
Add k8s binaries to preloaded tarball

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/binaries.go
+++ b/pkg/minikube/bootstrapper/bsutil/binaries.go
@@ -18,10 +18,13 @@ limitations under the License.
 package bsutil
 
 import (
+	"fmt"
 	"os/exec"
 	"path"
 	"runtime"
+	"strings"
 
+	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 	"k8s.io/minikube/pkg/minikube/command"
@@ -33,8 +36,15 @@ import (
 
 // TransferBinaries transfers all required Kubernetes binaries
 func TransferBinaries(cfg config.KubernetesConfig, c command.Runner) error {
+	ok, err := binariesExist(cfg, c)
+	if err == nil && ok {
+		glog.Info("Found k8s binaries, skipping transfer")
+		return nil
+	}
+	glog.Infof("Didn't find k8s binaries: %v\nInitiating transfer...", err)
+
 	dir := binRoot(cfg.KubernetesVersion)
-	_, err := c.RunCmd(exec.Command("sudo", "mkdir", "-p", dir))
+	_, err = c.RunCmd(exec.Command("sudo", "mkdir", "-p", dir))
 	if err != nil {
 		return err
 	}
@@ -56,6 +66,26 @@ func TransferBinaries(cfg config.KubernetesConfig, c command.Runner) error {
 		})
 	}
 	return g.Wait()
+}
+
+// binariesExist returns true if the binaries already exist
+func binariesExist(cfg config.KubernetesConfig, c command.Runner) (bool, error) {
+	dir := binRoot(cfg.KubernetesVersion)
+	rr, err := c.RunCmd(exec.Command("sudo", "ls", dir))
+	stdout := rr.Stdout.String()
+	if err != nil {
+		return false, err
+	}
+	foundBinaries := map[string]struct{}{}
+	for _, binary := range strings.Split(stdout, "\n") {
+		foundBinaries[binary] = struct{}{}
+	}
+	for _, name := range constants.KubernetesReleaseBinaries {
+		if _, ok := foundBinaries[name]; !ok {
+			return false, fmt.Errorf("didn't find preexisting %s", name)
+		}
+	}
+	return true, nil
 }
 
 // binRoot returns the persistent path binaries are stored in


### PR DESCRIPTION
Include k8s binaries in preloaded tarball so that we can skip tranferring this over.

This increases the size of the tarball from around 430 MB to 500MB, but saves a couple seconds on start time.

Fixes #6868 