### PR TITLE
Only cache k8s images if necessary

### DIFF
--- a/pkg/minikube/preload/preload.go
+++ b/pkg/minikube/preload/preload.go
@@ -74,7 +74,7 @@ func TarballExists(k8sVersion, containerRuntime string) bool {
 		return false
 	}
 	url := remoteTarballURL(k8sVersion)
-	_, err := http.Get(url)
+	_, err := http.Head(url)
 	return err == nil
 }
 

--- a/pkg/minikube/preload/preload.go
+++ b/pkg/minikube/preload/preload.go
@@ -67,6 +67,17 @@ func remoteTarballURL(k8sVersion string) string {
 	return fmt.Sprintf("https://storage.googleapis.com/%s/%s", constants.PreloadedVolumeTarballsBucket, tarballName(k8sVersion))
 }
 
+// TarballExists returns true if there is a preloaded tarball
+// that can be used
+func TarballExists(k8sVersion, containerRuntime string) bool {
+	if containerRuntime != "docker" {
+		return false
+	}
+	url := remoteTarballURL(k8sVersion)
+	_, err := http.Get(url)
+	return err == nil
+}
+
 // CacheTarball caches the preloaded images tarball on the host machine
 func CacheTarball(k8sVersion, containerRuntime string) error {
 	if containerRuntime != "docker" {
@@ -81,15 +92,14 @@ func CacheTarball(k8sVersion, containerRuntime string) error {
 		}
 	}
 
-	url := remoteTarballURL(k8sVersion)
-
 	// Make sure we support this k8s version
-	if _, err := http.Get(url); err != nil {
-		glog.Infof("Unable to get response from %s, skipping downloading: %v", url, err)
+	if !TarballExists(k8sVersion, containerRuntime) {
+		glog.Infof("Preloaded tarball for k8s version %s does not exist", k8sVersion)
 		return nil
 	}
 
 	out.T(out.FileDownload, "Downloading preloaded images tarball for k8s {{.version}} ...", out.V{"version": k8sVersion})
+	url := remoteTarballURL(k8sVersion)
 	client := &getter.Client{
 		Src:     url,
 		Dst:     targetFilepath,


### PR DESCRIPTION
We can skip caching k8s images if we are using the kic driver and a preloaded tarball for that k8s version exists.

Fixes #6871