### PR TITLE
service list: populate target port

### DIFF
--- a/cmd/minikube/cmd/service_list.go
+++ b/cmd/minikube/cmd/service_list.go
@@ -66,6 +66,7 @@ var serviceListCmd = &cobra.Command{
 			if len(serviceURL.URLs) == 0 {
 				data = append(data, []string{serviceURL.Namespace, serviceURL.Name, "No node port"})
 			} else {
+				servicePortNames := strings.Join(serviceURL.PortNames, "\n")
 				serviceURLs := strings.Join(serviceURL.URLs, "\n")
 
 				// if we are running Docker on OSX we empty the internal service URLs
@@ -73,7 +74,7 @@ var serviceListCmd = &cobra.Command{
 					serviceURLs = ""
 				}
 
-				data = append(data, []string{serviceURL.Namespace, serviceURL.Name, "", serviceURLs})
+				data = append(data, []string{serviceURL.Namespace, serviceURL.Name, servicePortNames, serviceURLs})
 			}
 		}
 

--- a/pkg/minikube/service/service.go
+++ b/pkg/minikube/service/service.go
@@ -199,7 +199,7 @@ func printURLsForService(c typed_core.CoreV1Interface, ip, service, namespace st
 	for _, port := range svc.Spec.Ports {
 
 		if port.Name != "" {
-			m[port.TargetPort.IntVal] = port.Name
+			m[port.TargetPort.IntVal] = fmt.Sprintf("%s/%d", port.Name, port.Port)
 		} else {
 			m[port.TargetPort.IntVal] = strconv.Itoa(int(port.Port))
 		}

--- a/pkg/minikube/service/service.go
+++ b/pkg/minikube/service/service.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -196,6 +197,13 @@ func printURLsForService(c typed_core.CoreV1Interface, ip, service, namespace st
 	urls := []string{}
 	portNames := []string{}
 	for _, port := range svc.Spec.Ports {
+
+		if port.Name != "" {
+			m[port.TargetPort.IntVal] = port.Name
+		} else {
+			m[port.TargetPort.IntVal] = strconv.Itoa(int(port.Port))
+		}
+
 		if port.NodePort > 0 {
 			var doc bytes.Buffer
 			err = t.Execute(&doc, struct {

--- a/pkg/minikube/service/service_test.go
+++ b/pkg/minikube/service/service_test.go
@@ -134,13 +134,17 @@ var defaultNamespaceServiceInterface = &MockServiceInterface{
 				Spec: core.ServiceSpec{
 					Ports: []core.ServicePort{
 						{
+							Name:     "port1",
 							NodePort: int32(1111),
+							Port:     int32(11111),
 							TargetPort: intstr.IntOrString{
 								IntVal: int32(11111),
 							},
 						},
 						{
+							Name:     "port2",
 							NodePort: int32(2222),
+							Port:     int32(22222),
 							TargetPort: intstr.IntOrString{
 								IntVal: int32(22222),
 							},
@@ -324,7 +328,7 @@ func TestPrintURLsForService(t *testing.T) {
 			serviceName:    "mock-dashboard",
 			namespace:      "default",
 			tmpl:           template.Must(template.New("svc-arbitrary-template").Parse("{{.Name}}={{.IP}}:{{.Port}}")),
-			expectedOutput: []string{"port1=127.0.0.1:1111", "port2=127.0.0.1:2222"},
+			expectedOutput: []string{"port1/11111=127.0.0.1:1111", "port2/22222=127.0.0.1:2222"},
 		},
 		{
 			description:    "empty slice for no node ports",
@@ -452,7 +456,7 @@ func TestGetServiceURLs(t *testing.T) {
 					Namespace: "default",
 					Name:      "mock-dashboard",
 					URLs:      []string{"http://127.0.0.1:1111", "http://127.0.0.1:2222"},
-					PortNames: []string{"port1", "port2"},
+					PortNames: []string{"port1/11111", "port2/22222"},
 				},
 				{
 					Namespace: "default",


### PR DESCRIPTION
Populate the target port in `service list`

fixes: #6860 

Use port name for target port if provided. If not, use 'port'.
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#serviceport-v1-core

This is my first contribution to minikube. I am also fairly new to kubernetes. So please go easy on me. :)

### Before
![image](https://user-images.githubusercontent.com/7345249/75926336-38e8cf00-5e1f-11ea-92c5-e308e3859dda.png)

### After
![image](https://user-images.githubusercontent.com/7345249/75926375-4bfb9f00-5e1f-11ea-889c-12ce4791733b.png)
