### PR TITLE
fix wording for docker/podman drivers to "container"

### DIFF
--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -86,6 +86,20 @@ func Supported(name string) bool {
 	return false
 }
 
+// MachineType returns appropriate machine name for the driver
+func MachineType(name string) string {
+	if IsKIC(name) {
+		return "container"
+	}
+
+	if IsVM(name) {
+		return "VM"
+	}
+
+	// none or mock
+	return "bare metal machine"
+}
+
 // IsKIC checks if the driver is a kubernetes in container
 func IsKIC(name string) bool {
 	return name == Docker || name == Podman

--- a/pkg/minikube/driver/driver_test.go
+++ b/pkg/minikube/driver/driver_test.go
@@ -58,6 +58,31 @@ func TestBareMetal(t *testing.T) {
 	}
 }
 
+func TestMachineType(t *testing.T) {
+	types := map[string]string{
+		Podman:       "container",
+		Docker:       "container",
+		Mock:         "bare metal machine",
+		None:         "bare metal machine",
+		KVM2:         "VM",
+		VirtualBox:   "VM",
+		HyperKit:     "VM",
+		VMware:       "VM",
+		VMwareFusion: "VM",
+		HyperV:       "VM",
+		Parallels:    "VM",
+	}
+
+	drivers := SupportedDrivers()
+	for _, driver := range drivers {
+		want := types[driver]
+		got := MachineType(driver)
+		if want != got {
+			t.Errorf("mismatched machine type for driver %s: want = %s got = %s", driver, want, got)
+		}
+	}
+}
+
 func TestFlagDefaults(t *testing.T) {
 	expected := FlagHints{CacheImages: true}
 	if diff := cmp.Diff(FlagDefaults(VirtualBox), expected); diff != "" {

--- a/pkg/minikube/machine/fix.go
+++ b/pkg/minikube/machine/fix.go
@@ -105,10 +105,11 @@ func fixHost(api libmachine.API, cc config.ClusterConfig, n config.Node) (*host.
 		}
 	}
 
+	machineType := driver.MachineType(cc.Driver)
 	if s == state.Running {
-		out.T(out.Running, `Using the running {{.driver_name}} "{{.profile_name}}" VM ...`, out.V{"driver_name": cc.Driver, "profile_name": cc.Name})
+		out.T(out.Running, `Using the running {{.driver_name}} "{{.profile_name}}" {{.machine_type}} ...`, out.V{"driver_name": cc.Driver, "profile_name": cc.Name, "machine_type": machineType})
 	} else {
-		out.T(out.Restarting, `Starting existing {{.driver_name}} VM for "{{.profile_name}}" ...`, out.V{"driver_name": cc.Driver, "profile_name": cc.Name})
+		out.T(out.Restarting, `Starting existing {{.driver_name}} {{.machine_type}} for "{{.profile_name}}" ...`, out.V{"driver_name": cc.Driver, "profile_name": cc.Name, "machine_type": machineType})
 		if err := h.Driver.Start(); err != nil {
 			return h, errors.Wrap(err, "driver start")
 		}

--- a/pkg/minikube/machine/start.go
+++ b/pkg/minikube/machine/start.go
@@ -253,6 +253,7 @@ func acquireMachinesLock(name string) (mutex.Releaser, error) {
 
 // showHostInfo shows host information
 func showHostInfo(cfg config.ClusterConfig) {
+	machineType := driver.MachineType(cfg.Driver)
 	if driver.BareMetal(cfg.Driver) {
 		info, err := getHostInfo()
 		if err == nil {
@@ -266,9 +267,9 @@ func showHostInfo(cfg config.ClusterConfig) {
 			var info hostInfo
 			info.CPUs = s.CPUs
 			info.Memory = megs(uint64(s.TotalMemory))
-			out.T(out.StartingVM, "Creating Kubernetes in {{.driver_name}} container with (CPUs={{.number_of_cpus}}) ({{.number_of_host_cpus}} available), Memory={{.memory_size}}MB ({{.host_memory_size}}MB available) ...", out.V{"driver_name": cfg.Driver, "number_of_cpus": cfg.CPUs, "number_of_host_cpus": info.CPUs, "memory_size": cfg.Memory, "host_memory_size": info.Memory})
+			out.T(out.StartingVM, "Creating Kubernetes in {{.driver_name}} {{.machine_type}} with (CPUs={{.number_of_cpus}}) ({{.number_of_host_cpus}} available), Memory={{.memory_size}}MB ({{.host_memory_size}}MB available) ...", out.V{"driver_name": cfg.Driver, "number_of_cpus": cfg.CPUs, "number_of_host_cpus": info.CPUs, "memory_size": cfg.Memory, "host_memory_size": info.Memory, "machine_type": machineType})
 		}
 		return
 	}
-	out.T(out.StartingVM, "Creating {{.driver_name}} VM (CPUs={{.number_of_cpus}}, Memory={{.memory_size}}MB, Disk={{.disk_size}}MB) ...", out.V{"driver_name": cfg.Driver, "number_of_cpus": cfg.CPUs, "memory_size": cfg.Memory, "disk_size": cfg.DiskSize})
+	out.T(out.StartingVM, "Creating {{.driver_name}} {{.machine_type}} (CPUs={{.number_of_cpus}}, Memory={{.memory_size}}MB, Disk={{.disk_size}}MB) ...", out.V{"driver_name": cfg.Driver, "number_of_cpus": cfg.CPUs, "memory_size": cfg.Memory, "disk_size": cfg.DiskSize, "machine_type": machineType})
 }


### PR DESCRIPTION
fixes #6859

before:
```
$ minikube start
Using the running docker "minikube" VM ...
```
```
$ minikube start
Starting existing docker VM for "minikube"...
```

after:
```bash
$ minikube start
Using the running docker "minikube" container ...
```
```
$ minikube start
Starting existing docker container for "minikube"...
```

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
