### PR TITLE
warn to update docker-env on restart

### DIFF
--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -228,7 +228,7 @@ func (d *Driver) GetState() (state.State, error) {
 // Kill stops a host forcefully, including any containers that we are managing.
 func (d *Driver) Kill() error {
 	if err := oci.PointToHostDockerDaemon(); err != nil {
-		return state.Error, errors.Wrap(err, "point host docker daemon")
+		return errors.Wrap(err, "point host docker daemon")
 	}
 	cmd := exec.Command(d.NodeConfig.OCIBinary, "kill", d.MachineName)
 	if err := cmd.Run(); err != nil {
@@ -240,7 +240,7 @@ func (d *Driver) Kill() error {
 // Remove will delete the Kic Node Container
 func (d *Driver) Remove() error {
 	if err := oci.PointToHostDockerDaemon(); err != nil {
-		return state.Error, errors.Wrap(err, "point host docker daemon")
+		return errors.Wrap(err, "point host docker daemon")
 	}
 
 	if _, err := oci.ContainerID(d.OCIBinary, d.MachineName); err != nil {
@@ -261,7 +261,7 @@ func (d *Driver) Remove() error {
 // Restart a host
 func (d *Driver) Restart() error {
 	if err := oci.PointToHostDockerDaemon(); err != nil {
-		return state.Error, errors.Wrap(err, "point host docker daemon")
+		return errors.Wrap(err, "point host docker daemon")
 	}
 	s, err := d.GetState()
 	if err != nil {
@@ -287,7 +287,7 @@ func (d *Driver) Restart() error {
 // not meant to be used for Create().
 func (d *Driver) Start() error {
 	if err := oci.PointToHostDockerDaemon(); err != nil {
-		return state.Error, errors.Wrap(err, "point host docker daemon")
+		return errors.Wrap(err, "point host docker daemon")
 	}
 	s, err := d.GetState()
 	if err != nil {
@@ -307,7 +307,7 @@ func (d *Driver) Start() error {
 // Stop a host gracefully, including any containers that we are managing.
 func (d *Driver) Stop() error {
 	if err := oci.PointToHostDockerDaemon(); err != nil {
-		return state.Error, errors.Wrap(err, "point host docker daemon")
+		return errors.Wrap(err, "point host docker daemon")
 	}
 	cmd := exec.Command(d.NodeConfig.OCIBinary, "stop", d.MachineName)
 	if err := cmd.Run(); err != nil {

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -136,10 +136,10 @@ func (d *Driver) prepareSSH() error {
 
 // DriverName returns the name of the driver
 func (d *Driver) DriverName() string {
-	if d.NodeConfig.OCIBinary == "podman" {
-		return "podman"
+	if d.NodeConfig.OCIBinary == oci.Podman {
+		return oci.Podman
 	}
-	return "docker"
+	return oci.Docker
 }
 
 // GetIP returns an IP or hostname that this host is available at
@@ -227,6 +227,9 @@ func (d *Driver) GetState() (state.State, error) {
 
 // Kill stops a host forcefully, including any containers that we are managing.
 func (d *Driver) Kill() error {
+	if err := oci.PointToHostDockerDaemon(); err != nil {
+		return state.Error, errors.Wrap(err, "point host docker daemon")
+	}
 	cmd := exec.Command(d.NodeConfig.OCIBinary, "kill", d.MachineName)
 	if err := cmd.Run(); err != nil {
 		return errors.Wrapf(err, "killing kic node %s", d.MachineName)
@@ -236,6 +239,10 @@ func (d *Driver) Kill() error {
 
 // Remove will delete the Kic Node Container
 func (d *Driver) Remove() error {
+	if err := oci.PointToHostDockerDaemon(); err != nil {
+		return state.Error, errors.Wrap(err, "point host docker daemon")
+	}
+
 	if _, err := oci.ContainerID(d.OCIBinary, d.MachineName); err != nil {
 		log.Warnf("could not find the container %s to remove it.", d.MachineName)
 	}
@@ -253,13 +260,14 @@ func (d *Driver) Remove() error {
 
 // Restart a host
 func (d *Driver) Restart() error {
+	if err := oci.PointToHostDockerDaemon(); err != nil {
+		return state.Error, errors.Wrap(err, "point host docker daemon")
+	}
 	s, err := d.GetState()
 	if err != nil {
 		return errors.Wrap(err, "get kic state")
 	}
 	switch s {
-	case state.Paused:
-		return d.Unpause()
 	case state.Stopped:
 		return d.Start()
 	case state.Running, state.Error:
@@ -275,18 +283,12 @@ func (d *Driver) Restart() error {
 	return fmt.Errorf("restarted not implemented for kic state %s yet", s)
 }
 
-// Unpause a kic container
-func (d *Driver) Unpause() error {
-	cmd := exec.Command(d.NodeConfig.OCIBinary, "unpause", d.MachineName)
-	if err := cmd.Run(); err != nil {
-		return errors.Wrapf(err, "unpausing %s", d.MachineName)
-	}
-	return nil
-}
-
 // Start a _stopped_ kic container
 // not meant to be used for Create().
 func (d *Driver) Start() error {
+	if err := oci.PointToHostDockerDaemon(); err != nil {
+		return state.Error, errors.Wrap(err, "point host docker daemon")
+	}
 	s, err := d.GetState()
 	if err != nil {
 		return errors.Wrap(err, "get kic state")
@@ -304,6 +306,9 @@ func (d *Driver) Start() error {
 
 // Stop a host gracefully, including any containers that we are managing.
 func (d *Driver) Stop() error {
+	if err := oci.PointToHostDockerDaemon(); err != nil {
+		return state.Error, errors.Wrap(err, "point host docker daemon")
+	}
 	cmd := exec.Command(d.NodeConfig.OCIBinary, "stop", d.MachineName)
 	if err := cmd.Run(); err != nil {
 		return errors.Wrapf(err, "stopping %s", d.MachineName)

--- a/pkg/drivers/kic/oci/network.go
+++ b/pkg/drivers/kic/oci/network.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os/exec"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/golang/glog"
@@ -76,4 +77,83 @@ func dockerGatewayIP() (net.IP, error) {
 	ip := net.ParseIP(strings.TrimSpace(string(out)))
 	glog.Infof("got host ip for mount in container by inspect docker network: %s", ip.String())
 	return ip, nil
+}
+
+// HostPortBinding will return port mapping for a container using cli.
+// example : HostPortBinding("docker", "minikube", "22")
+// will return the docker assigned port:
+// 32769, nil
+// only supports TCP ports
+func HostPortBinding(ociBinary string, ociID string, contPort int) (int, error) {
+	if err := PointToHostDockerDaemon(); err != nil {
+		return 0, errors.Wrap(err, "point host docker daemon")
+	}
+	var out []byte
+	var err error
+	if ociBinary == Podman {
+		//podman inspect -f "{{range .NetworkSettings.Ports}}{{if eq .ContainerPort "80"}}{{.HostPort}}{{end}}{{end}}"
+		cmd := exec.Command(ociBinary, "inspect", "-f", fmt.Sprintf("{{range .NetworkSettings.Ports}}{{if eq .ContainerPort %s}}{{.HostPort}}{{end}}{{end}}", fmt.Sprint(contPort)), ociID)
+		out, err = cmd.CombinedOutput()
+		if err != nil {
+			return 0, errors.Wrapf(err, "get host-bind port %d for %q, output %s", contPort, ociID, out)
+		}
+	} else {
+		cmd := exec.Command(ociBinary, "inspect", "-f", fmt.Sprintf("'{{(index (index .NetworkSettings.Ports \"%d/tcp\") 0).HostPort}}'", contPort), ociID)
+		out, err = cmd.CombinedOutput()
+		if err != nil {
+			return 0, errors.Wrapf(err, "get host-bind port %d for %q, output %s", contPort, ociID, out)
+		}
+	}
+
+	o := strings.TrimSpace(string(out))
+	o = strings.Trim(o, "'")
+	p, err := strconv.Atoi(o)
+	if err != nil {
+		return p, errors.Wrapf(err, "convert host-port %q to number", p)
+	}
+	return p, nil
+}
+
+// ContainerIPs returns ipv4,ipv6, error of a container by their name
+func ContainerIPs(ociBinary string, name string) (string, string, error) {
+	if ociBinary == Podman {
+		return podmanConttainerIP(name)
+	}
+	return dockerContainerIP(name)
+}
+
+// podmanConttainerIP returns ipv4, ipv6 of container or error
+func podmanConttainerIP(name string) (string, string, error) {
+	cmd := exec.Command(Podman, "inspect",
+		"-f", "{{.NetworkSettings.IPAddress}}",
+		name)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", "", errors.Wrapf(err, "podman inspect ip %s", name)
+	}
+	output := strings.TrimSpace(string(out))
+	if err == nil && output == "" { // podman returns empty for 127.0.0.1
+		return DefaultBindIPV4, "", nil
+	}
+	return output, "", nil
+}
+
+// dockerContainerIP returns ipv4, ipv6 of container or error
+func dockerContainerIP(name string) (string, string, error) {
+	if err := PointToHostDockerDaemon(); err != nil {
+		return "", "", errors.Wrap(err, "point host docker daemon")
+	}
+	// retrieve the IP address of the node using docker inspect
+	lines, err := inspect(Docker, name, "{{range .NetworkSettings.Networks}}{{.IPAddress}},{{.GlobalIPv6Address}}{{end}}")
+	if err != nil {
+		return "", "", errors.Wrap(err, "inspecting NetworkSettings.Networks")
+	}
+	if len(lines) != 1 {
+		return "", "", errors.Errorf("IPs output should only be one line, got %d lines", len(lines))
+	}
+	ips := strings.Split(lines[0], ",")
+	if len(ips) != 2 {
+		return "", "", errors.Errorf("container addresses should have 2 values, got %d values: %+v", len(ips), ips)
+	}
+	return ips[0], ips[1], nil
 }

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -461,7 +461,7 @@ func listContainersByLabel(ociBinary string, label string) ([]string, error) {
 func PointToHostDockerDaemon() error {
 	p := os.Getenv(constants.MinikubeActiveDockerdEnv)
 	if p != "" {
-		glog.Infof("shell is pointing to docker inside minikube. will unset to use host")
+		glog.Infof("shell is pointing to dockerd inside minikube. will unset to use host")
 	}
 
 	for i := range constants.DockerDaemonEnvs {

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	"bufio"
@@ -208,85 +207,6 @@ func Copy(ociBinary string, ociID string, targetDir string, fName string) error 
 		return errors.Wrapf(err, "error copying %s into node", fName)
 	}
 	return nil
-}
-
-// HostPortBinding will return port mapping for a container using cli.
-// example : HostPortBinding("docker", "minikube", "22")
-// will return the docker assigned port:
-// 32769, nil
-// only supports TCP ports
-func HostPortBinding(ociBinary string, ociID string, contPort int) (int, error) {
-	if err := PointToHostDockerDaemon(); err != nil {
-		return 0, errors.Wrap(err, "point host docker daemon")
-	}
-	var out []byte
-	var err error
-	if ociBinary == Podman {
-		//podman inspect -f "{{range .NetworkSettings.Ports}}{{if eq .ContainerPort "80"}}{{.HostPort}}{{end}}{{end}}"
-		cmd := exec.Command(ociBinary, "inspect", "-f", fmt.Sprintf("{{range .NetworkSettings.Ports}}{{if eq .ContainerPort %s}}{{.HostPort}}{{end}}{{end}}", fmt.Sprint(contPort)), ociID)
-		out, err = cmd.CombinedOutput()
-		if err != nil {
-			return 0, errors.Wrapf(err, "get host-bind port %d for %q, output %s", contPort, ociID, out)
-		}
-	} else {
-		cmd := exec.Command(ociBinary, "inspect", "-f", fmt.Sprintf("'{{(index (index .NetworkSettings.Ports \"%d/tcp\") 0).HostPort}}'", contPort), ociID)
-		out, err = cmd.CombinedOutput()
-		if err != nil {
-			return 0, errors.Wrapf(err, "get host-bind port %d for %q, output %s", contPort, ociID, out)
-		}
-	}
-
-	o := strings.TrimSpace(string(out))
-	o = strings.Trim(o, "'")
-	p, err := strconv.Atoi(o)
-	if err != nil {
-		return p, errors.Wrapf(err, "convert host-port %q to number", p)
-	}
-	return p, nil
-}
-
-// ContainerIPs returns ipv4,ipv6, error of a container by their name
-func ContainerIPs(ociBinary string, name string) (string, string, error) {
-	if ociBinary == Podman {
-		return podmanConttainerIP(name)
-	}
-	return dockerContainerIP(name)
-}
-
-// podmanConttainerIP returns ipv4, ipv6 of container or error
-func podmanConttainerIP(name string) (string, string, error) {
-	cmd := exec.Command(Podman, "inspect",
-		"-f", "{{.NetworkSettings.IPAddress}}",
-		name)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return "", "", errors.Wrapf(err, "podman inspect ip %s", name)
-	}
-	output := strings.TrimSpace(string(out))
-	if err == nil && output == "" { // podman returns empty for 127.0.0.1
-		return DefaultBindIPV4, "", nil
-	}
-	return output, "", nil
-}
-
-// dockerContainerIP returns ipv4, ipv6 of container or error
-func dockerContainerIP(name string) (string, string, error) {
-	if err := PointToHostDockerDaemon(); err != nil {
-		return "", "", errors.Wrap(err, "point host docker daemon")
-	}
-	// retrieve the IP address of the node using docker inspect
-	lines, err := inspect(Docker, name, "{{range .NetworkSettings.Networks}}{{.IPAddress}},{{.GlobalIPv6Address}}{{end}}")
-	if err != nil {
-		return "", "", errors.Wrap(err, "inspecting NetworkSettings.Networks")
-	}
-	if len(lines) != 1 {
-		return "", "", errors.Errorf("IPs output should only be one line, got %d lines", len(lines))
-	}
-	ips := strings.Split(lines[0], ",")
-	if len(ips) != 2 {
-		return "", "", errors.Errorf("container addresses should have 2 values, got %d values: %+v", len(ips), ips)
-	}
-	return ips[0], ips[1], nil
 }
 
 // ContainerID returns id of a container name

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -85,7 +85,7 @@ func Supported(name string) bool {
 	return false
 }
 
-// IsKIC checks if the driver is a kubernetes in continer
+// IsKIC checks if the driver is a kubernetes in container
 func IsKIC(name string) bool {
 	return name == Docker || name == Podman
 }

--- a/pkg/minikube/machine/fix.go
+++ b/pkg/minikube/machine/fix.go
@@ -159,7 +159,6 @@ func warnToReEvalEnv(drver string, name string) {
 		out.T(out.WarningType, `Please run the following command: 
 		'minikube -p {{.profile_name}} docker-env'`, out.V{"profile_name": name})
 	}
-	return
 }
 
 // ensureGuestClockSync ensures that the guest system clock is relatively in-sync

--- a/pkg/minikube/machine/fix.go
+++ b/pkg/minikube/machine/fix.go
@@ -156,7 +156,8 @@ func warnToReEvalEnv(drver string, name string) {
 	p := os.Getenv(constants.MinikubeActiveDockerdEnv)
 	if p != "" {
 		out.T(out.WarningType, "dockerd port changed since restart. minikube's docker-env need to be updated.")
-		out.T(out.WarningType, "Please run the following command: 'minikube -p {{.profile_name}} docker-env'", out.V{"profile_name": name})
+		out.T(out.WarningType, `Please run the following command: 
+		'minikube -p {{.profile_name}} docker-env'`, out.V{"profile_name": name})
 	}
 	return
 }

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -63,7 +63,7 @@ func status() registry.State {
 		return registry.State{Error: err, Installed: false, Healthy: false, Fix: "Docker is required.", Doc: "https://minikube.sigs.k8s.io/docs/reference/drivers/docker/"}
 	}
 
-	if err := PointToHostDockerDaemon(); err != nil {
+	if err := oci.PointToHostDockerDaemon(); err != nil {
 		return registry.State{Error: err, Installed: true, Healthy: false, Fix: "Failed to point to dockerd. Please make sure DOCKER_HOST environment variable is pointing to your installed dockerd."}
 	}
 

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -63,6 +63,10 @@ func status() registry.State {
 		return registry.State{Error: err, Installed: false, Healthy: false, Fix: "Docker is required.", Doc: "https://minikube.sigs.k8s.io/docs/reference/drivers/docker/"}
 	}
 
+	if err := PointToHostDockerDaemon(); err != nil {
+		return registry.State{Error: err, Installed: true, Healthy: false, Fix: "Failed to point to dockerd. Please make sure DOCKER_HOST environment variable is pointing to your installed dockerd."}
+	}
+
 	// Allow no more than 3 seconds for docker info
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()


### PR DESCRIPTION
### Before this PR:
in case of an minikube docker-env in terminal:

docker driver restart was sending wrong warnning because was pointing to wrong docker
```
⚠️  'docker' driver reported an issue: exit status 1
💡  Suggestion: Docker is not running or is responding too slow. Try: restarting docker desktop.
```


### Before this PR Also:

docker-env would break after a restart without any warnning to user

### After this PR when run in a terminal with docker env set:

- No False warrning
- Warn user to Re-eval the docker-env after restarting docker env.
```
😄  minikube v1.7.3 on Darwin 10.14.6
    ▪ MINIKUBE_ACTIVE_DOCKERD=minikube
✨  Using the docker (experimental) driver based on existing profile
⌛  Reconfiguring existing host ...
📌  Noticed that you are using minikube docker-env:
⚠️  After minikube restart the dockerd ports might have changed. To ensure docker-env works properly.
Please re-eval the docker-env command:

        'minikube -p minikube docker-env'


🏃  Using the running docker "minikube" VM ...
```

### after this PR when run in a terminal without docker env set
```
$ ./out/minikube start
😄  minikube v1.7.3 on Darwin 10.14.6
✨  Using the docker (experimental) driver based on existing profile
⌛  Reconfiguring existing host ...
🏃  Using the running docker "minikube" VM ...
```


closes https://github.com/kubernetes/minikube/issues/6824 
but still the user has to do manual step !

