### PR TITLE
Skip ISO checksum validation if custom URL is specified

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -322,7 +322,7 @@ func runStart(cmd *cobra.Command, args []string) {
 	}
 
 	if !driver.BareMetal(driverName) && !driver.IsKIC(driverName) {
-		url, err := download.ISO(viper.GetStringSlice(isoURL))
+		url, err := download.ISO(viper.GetStringSlice(isoURL), cmd.Flags().Changed(isoURL))
 		if err != nil {
 			exit.WithError("Failed to cache ISO", err)
 		}

--- a/pkg/minikube/download/iso.go
+++ b/pkg/minikube/download/iso.go
@@ -78,12 +78,12 @@ func localISOPath(u *url.URL) string {
 }
 
 // ISO downloads and returns the path to the downloaded ISO
-func ISO(urls []string) (string, error) {
+func ISO(urls []string, skipChecksum bool) (string, error) {
 	out.T(out.ISODownload, "Downloading VM boot image ...")
 	errs := map[string]string{}
 
 	for _, url := range urls {
-		err := downloadISO(url)
+		err := downloadISO(url, skipChecksum)
 		if err != nil {
 			glog.Errorf("Unable to download %s: %v", url, err)
 			errs[url] = err.Error()
@@ -102,7 +102,7 @@ func ISO(urls []string) (string, error) {
 }
 
 // downloadISO downloads an ISO URL
-func downloadISO(isoURL string) error {
+func downloadISO(isoURL string, skipChecksum bool) error {
 	u, err := url.Parse(isoURL)
 	if err != nil {
 		return errors.Wrapf(err, "url.parse %q", isoURL)
@@ -129,6 +129,9 @@ func downloadISO(isoURL string) error {
 	}
 
 	urlWithChecksum := isoURL + "?checksum=file:" + isoURL + ".sha256"
+	if skipChecksum {
+		urlWithChecksum = isoURL
+	}
 
 	// Predictable temp destination so that resume can function
 	tmpDst := dst + ".download"

--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -67,7 +67,7 @@ func TestVersionUpgrade(t *testing.T) {
 
 	// Assert that --iso-url works without a sha checksum, and that we can upgrade from old ISO's
 	// Some day, this will break an implicit assumption that a tool is available in the ISO :)
-	oldISO := "https://storage.googleapis.com/minikube/iso/integration-test-v1.7.0.iso"
+	oldISO := "https://storage.googleapis.com/minikube/iso/integration-test.iso"
 	args := append([]string{"start", "-p", profile, fmt.Sprintf("--iso-url=%s", oldISO), fmt.Sprintf("--kubernetes-version=%s", constants.OldestKubernetesVersion), "--alsologtostderr", "-v=1"}, StartArgs()...)
 	rr := &RunResult{}
 	r := func() error {

--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -65,7 +65,10 @@ func TestVersionUpgrade(t *testing.T) {
 		}
 	}
 
-	args := append([]string{"start", "-p", profile, fmt.Sprintf("--kubernetes-version=%s", constants.OldestKubernetesVersion), "--alsologtostderr", "-v=1"}, StartArgs()...)
+	// Assert that --iso-url works without a sha checksum, and that we can upgrade from old ISO's
+	// Some day, this will break an implicit assumption that a tool is available in the ISO :)
+	oldISO := "https://storage.googleapis.com/minikube/iso/integration-test-v1.7.0.iso"
+	args := append([]string{"start", "-p", profile, fmt.Sprintf("--iso-url=%s", oldISO), fmt.Sprintf("--kubernetes-version=%s", constants.OldestKubernetesVersion), "--alsologtostderr", "-v=1"}, StartArgs()...)
 	rr := &RunResult{}
 	r := func() error {
 		rr, err = Run(t, exec.CommandContext(ctx, tf.Name(), args...))


### PR DESCRIPTION
Allows users of `--iso-url` to not generate checksum files. This returns to the behavior before the ISO fallback refactor.