### PR TITLE
handle already in use container name

### DIFF
--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -106,8 +106,8 @@ func (d *Driver) Create() error {
 				return errors.Wrapf(err, "deleting already in-use mini-created container %s", params.Name)
 			}
 		} else {
-			// if not the conflicting container name is not created by minikube
-			// that means it is a user has a container that conflicts with minikube profile name
+			// The conflicting container name was not created by minikube
+			// user has a container that conflicts with minikube profile name, will not delete users container.
 			glog.Errorf("You have a container named %s that conflicts with minikube profile name %s, please either remove manually or choose a different minikbue profile name", params.Name, params.Name)
 			return errors.Wrap(err, "conflicting name with user's container")
 		}

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -102,7 +102,7 @@ func (d *Driver) Create() error {
 		if oci.IsCreatedByMinikube(d.OCIBinary, params.Name) {
 			glog.Info("Found already existing abandoned minikube container, will try to delete.")
 			if err := oci.DeleteContainer(d.OCIBinary, params.Name); err != nil {
-				glog.Errorf("Failed to delete a conflicting minikube container %s. You might need to restart your %s daemon and delete it manually and try again.", params.Name)
+				glog.Errorf("Failed to delete a conflicting minikube container %s. You might need to restart your %s daemon and delete it manually and try again.", params.Name, params.OCIBinary)
 				return errors.Wrapf(err, "deleting already in-use mini-created container %s", params.Name)
 			}
 		} else {

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -95,13 +95,13 @@ func (d *Driver) Create() error {
 
 	exists, err := oci.ContainerExists(d.OCIBinary, params.Name)
 	if err != nil {
-		glog.Infof("failed to check if container already exists: %v", err)
+		glog.Warningf("failed to check if container already exists: %v", err)
 	}
 	if exists {
 		// if container was created by minikube it is safe to delete and recreate it.
 		if oci.IsCreatedByMinikube(d.OCIBinary, params.Name) {
 			glog.Info("Found already existing abandoned minikube container, will try to delete.")
-			if err := oci.DeleteContainersByID(d.OCIBinary, params.Name); err != nil {
+			if err := oci.DeleteContainer(d.OCIBinary, params.Name); err != nil {
 				glog.Errorf("Failed to delete a conflicting minikube container %s. You might need to restart your %s daemon and delete it manually and try again.", params.Name)
 				return errors.Wrapf(err, "deleting already in-use mini-created container %s", params.Name)
 			}

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -102,14 +102,12 @@ func (d *Driver) Create() error {
 		if oci.IsCreatedByMinikube(d.OCIBinary, params.Name) {
 			glog.Info("Found already existing abandoned minikube container, will try to delete.")
 			if err := oci.DeleteContainer(d.OCIBinary, params.Name); err != nil {
-				glog.Errorf("Failed to delete a conflicting minikube container %s. You might need to restart your %s daemon and delete it manually and try again.", params.Name, params.OCIBinary)
-				return errors.Wrapf(err, "deleting already in-use mini-created container %s", params.Name)
+				glog.Errorf("Failed to delete a conflicting minikube container %s. You might need to restart your %s daemon and delete it manually and try again: %v", params.Name, params.OCIBinary, err)
 			}
 		} else {
 			// The conflicting container name was not created by minikube
 			// user has a container that conflicts with minikube profile name, will not delete users container.
-			glog.Errorf("You have a container named %s that conflicts with minikube profile name %s, please either remove manually or choose a different minikbue profile name", params.Name, params.Name)
-			return errors.Wrap(err, "conflicting name with user's container")
+			return errors.Wrapf(err, "user has a conflicting container name %q with minikube container. Needs to be deleted by user's consent.", params.Name)
 		}
 	}
 

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -57,7 +57,7 @@ func DeleteContainersByLabel(ociBin string, label string) []error {
 		// if it doesn't it means docker daemon is stuck and needs restart
 		if err != nil {
 			deleteErrs = append(deleteErrs, errors.Wrapf(err, "delete container %s: %s daemon is stuck. please try again!", c, ociBin))
-			glog.Errorf("%s daemon seems to be stuck. Please try restarting your %s.", ociBin, ociBin)
+			glog.Errorf("%s daemon seems to be stuck. Please try restarting your %s. :%v", ociBin, ociBin, err)
 			continue
 		}
 		cmd := exec.Command(ociBin, "rm", "-f", "-v", c)
@@ -75,10 +75,8 @@ func DeleteContainer(ociBin string, name string) error {
 		return errors.Wrap(err, "point host docker daemon")
 	}
 	_, err := ContainerStatus(ociBin, name)
-	// only try to delete if docker/podman inspect returns
-	// if it doesn't it means docker daemon is stuck and needs restart
 	if err != nil {
-		glog.Errorf("%s daemon seems to be stuck. Please try restarting your %s. Will try to delete anyways", ociBin, ociBin)
+		glog.Errorf("%s daemon seems to be stuck. Please try restarting your %s. Will try to delete anyways: %v", ociBin, ociBin, err)
 	}
 	// try to delete anyways
 	cmd := exec.Command(ociBin, "rm", "-f", "-v", name)


### PR DESCRIPTION
closes https://github.com/kubernetes/minikube/issues/6899
closes https://github.com/kubernetes/minikube/issues/6713

## before this PR:

if you delete machine folder and profile folder and kill the minikube container

```
medya@~/workspace/minikube (master) $ docker kill 8f47e4ec187d
medya@~/workspace/minikube (master) $ rm -rf ~/.minikube/profiles/minikube/
medya@~/workspace/minikube (master) $ ./out/minikube start --vm-driver=docker
```
and then start minikube  you would get this error
```
😄  minikube v1.7.3 on Darwin 10.14.6
✨  Using the docker driver based on user configuration
🔥  Creating Kubernetes in docker container with (CPUs=2) (8 available), Memory=4096MB (7963MB available) ...

💣  Unable to start VM. Please investigate and run 'minikube delete' if possible: creating host: create: creating: create kic node: create a kic node: args: [run -d -t --privileged --security-opt seccomp=unconfined --tmpfs /tmp --tmpfs /run -v /lib/modules:/lib/modules:ro --hostname minikube --name minikube --label created_by.minikube.sigs.k8s.io=true --label name.minikube.sigs.k8s.io=minikube --label role.minikube.sigs.k8s.io= --label mode.minikube.sigs.k8s.io=minikube --volume minikube:/var --cpus=2 --memory=4096mb --expose 8443 --publish=127.0.0.1::8443 --publish=127.0.0.1::22 --publish=127.0.0.1::2376 gcr.io/k8s-minikube/kicbase:v0.0.7@sha256:a6f288de0e5863cdeab711fa6bafa38ee7d8d285ca14216ecf84fcfb07c7d176]  output: [docker: Error response from daemon: Conflict. The container name "/minikube" is already in use by container "8f47e4ec187d722bdc748714c29cd7e8ec35a4a4dee5d39c77db050c020eda3f". You have to remove (or rename) that container to be able to reuse that name. See 'docker run --help'.] : exit status 125

😿  minikube is exiting due to an error. If the above message is not useful, open an issue:
```

### After this PR:

- if we find already existing container with same name, we will check if was created by minikube (by inspecting the labels) if yes we will delete it and recreate it.
```
😄  minikube v1.7.3 on Darwin 10.13.6
✨  Using the docker driver based on user configuration
🔥  Creating Kubernetes in docker container with (CPUs=2) (2 available), Memory=4096MB (7964MB available) ...
🐳  Preparing Kubernetes v1.17.3 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16
🚀  Launching Kubernetes ... 
```

in the logs you would be seeing

```
I0305 22:27:02.148397   13158 kic.go:103] Found already existing abandoned minikube container, will try to delete.
```

- if container exists but was not created by minikube (a user's container) will exit with an error to tell user they need to delete the conflicting container name.

