### PR TITLE
Use 'k8s.gcr.io' instead of 'gcr.io/google-containers'

### DIFF
--- a/deploy/addons/gpu/nvidia-driver-installer.yaml.tmpl
+++ b/deploy/addons/gpu/nvidia-driver-installer.yaml.tmpl
@@ -72,5 +72,5 @@ spec:
         - name: root-mount
           mountPath: /root
       containers:
-      - image: "{{default "gcr.io/google-containers" .ImageRepository}}/pause:2.0"
+      - image: "{{default "k8s.gcr.io" .ImageRepository}}/pause:2.0"
         name: pause


### PR DESCRIPTION
Ref: kubernetes/kubeadm/issues/2051

See: [k8s.gcr.io moving from gcr.io/google-containers to gcr.io/k8s-artifacts-prod in early April](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/kubernetes-sig-release/ew-k9PEBckQ/T7dFepHdCAAJ)

Signed-off-by: Nguyen Hai Truong <truongnh@vn.fujitsu.com>

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
