### PR TITLE
docker-env: Add semicolons back for fish, required for fish 2.x users

### DIFF
--- a/cmd/minikube/cmd/docker-env_test.go
+++ b/cmd/minikube/cmd/docker-env_test.go
@@ -89,18 +89,18 @@ export MINIKUBE_ACTIVE_DOCKERD="ipv6"
 			"fish",
 			DockerEnvConfig{profile: "fish", driver: "kvm2", hostIP: "127.0.0.1", port: 2376, certsDir: "/certs"},
 			nil,
-			`set -gx DOCKER_TLS_VERIFY "1"
-set -gx DOCKER_HOST "tcp://127.0.0.1:2376"
-set -gx DOCKER_CERT_PATH "/certs"
-set -gx MINIKUBE_ACTIVE_DOCKERD "fish"
+			`set -gx DOCKER_TLS_VERIFY "1";
+set -gx DOCKER_HOST "tcp://127.0.0.1:2376";
+set -gx DOCKER_CERT_PATH "/certs";
+set -gx MINIKUBE_ACTIVE_DOCKERD "fish";
 
 # To point your shell to minikube's docker-daemon, run:
 # minikube -p fish docker-env | source
 `,
-			`set -e DOCKER_TLS_VERIFY
-set -e DOCKER_HOST
-set -e DOCKER_CERT_PATH
-set -e MINIKUBE_ACTIVE_DOCKERD
+			`set -e DOCKER_TLS_VERIFY;
+set -e DOCKER_HOST;
+set -e DOCKER_CERT_PATH;
+set -e MINIKUBE_ACTIVE_DOCKERD;
 `,
 		},
 		{

--- a/pkg/minikube/shell/shell.go
+++ b/pkg/minikube/shell/shell.go
@@ -30,11 +30,11 @@ import (
 
 const (
 	fishSetPfx   = "set -gx "
-	fishSetSfx   = "\"\n"
+	fishSetSfx   = "\";\n" // semi-colon required for fish 2.7
 	fishSetDelim = " \""
 
 	fishUnsetPfx = "set -e "
-	fishUnsetSfx = "\n"
+	fishUnsetSfx = ";\n"
 
 	psSetPfx   = "$Env:"
 	psSetSfx   = "\"\n"


### PR DESCRIPTION
While testing v1.8.0 today, i noticed that fish 2.7.1 was concatenating everything badly, creating the following environment variable:

`DOCKER_TLS_VERIFY=1set-gxDOCKER_HOSTtcp://127.0.0.1:32778set-gxDOCKER_CERT_PATH/Users/tstromberg/.minikube/certsset-gxMINIKUBE_ACTIVE_DOCKERDminikube`
