### PR TITLE
none_test: Fix nil pointer dereference on stat error

### DIFF
--- a/test/integration/none_test.go
+++ b/test/integration/none_test.go
@@ -83,7 +83,7 @@ func TestChangeNoneUser(t *testing.T) {
 			t.Errorf("stat(%s): %v", p, err)
 			continue
 		}
-		if info == nil && info.Sys() == nil {
+		if info == nil || info.Sys() == nil {
 			t.Errorf("nil info for %s", p)
 			continue
 		}

--- a/test/integration/none_test.go
+++ b/test/integration/none_test.go
@@ -81,6 +81,11 @@ func TestChangeNoneUser(t *testing.T) {
 		info, err := os.Stat(p)
 		if err != nil {
 			t.Errorf("stat(%s): %v", p, err)
+			continue
+		}
+		if info == nil && info.Sys() == nil {
+			t.Errorf("nil info for %s", p)
+			continue
 		}
 		got := info.Sys().(*syscall.Stat_t).Uid
 		if got != uint32(uid) {


### PR DESCRIPTION
Seen while investigating failures in https://github.com/kubernetes/minikube/runs/491029693