### PR TITLE
Fix TestCreateSSHShell failulre

### DIFF
--- a/pkg/minikube/machine/cluster_test.go
+++ b/pkg/minikube/machine/cluster_test.go
@@ -413,7 +413,7 @@ func TestGetHostStatus(t *testing.T) {
 
 func TestCreateSSHShell(t *testing.T) {
 	api := tests.NewMockAPI(t)
-	// Setting the default client to native gives much better performance.
+	// Setting the default ssh client to native for test stability.
 	ssh.SetDefaultClient(ssh.Native)
 
 	s, _ := tests.NewSSHServer(t)

--- a/pkg/minikube/machine/cluster_test.go
+++ b/pkg/minikube/machine/cluster_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/provision"
+	"github.com/docker/machine/libmachine/ssh"
 	"github.com/docker/machine/libmachine/state"
 	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/config"
@@ -412,6 +413,8 @@ func TestGetHostStatus(t *testing.T) {
 
 func TestCreateSSHShell(t *testing.T) {
 	api := tests.NewMockAPI(t)
+	// Setting the default client to native gives much better performance.
+	ssh.SetDefaultClient(ssh.Native)
 
 	s, _ := tests.NewSSHServer(t)
 	port, err := s.Start()


### PR DESCRIPTION
### What type of PR is this?
/kind failing-test

### What this PR does / why we need it:

This PR fix unit test case TestCreateSSHShell failulre.

### Which issue(s) this PR fixes:

Fixes #6947

### Does this PR introduce a user-facing change?

No. This PR changes test case only.

In minikube v1.7.2, this test file was in `pkg/minikube/cluster`.
In `pkg/minikube/cluster`, the `cluster.go`'s `init()` func sets native ssh client via `ssh.SetDefaultClient(ssh.Native)`.
SSH client have two types(Native & External): https://github.com/docker/machine/blob/b170508bf44c3405e079e26d5fdffe35a64c6972/libmachine/ssh/client.go#L84-L94

But from minikube v1.7.3, this test case has moved to `pkg/minikube/machine`.
Thus, the previously working `cluster.go`'s `init()` func doesn't work to this test case.
Finally, this set SSH client to External(not Native).

This PR add `ssh.SetDefaultClient(ssh.Native)` to use native ssh client.

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```