### PR TITLE
Upgrade go version 1.13.6 -> 1.13.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 os: linux
 language: go
 go:
-  - 1.13.6
+  - 1.13.8
 env:
   global:
     - GOPROXY=https://proxy.golang.org
@@ -11,7 +11,7 @@ matrix:
   include:
     - language: go
       name: Code Lint
-      go: 1.13.6
+      go: 1.13.8
       env:
         - TESTSUITE=lintall
       before_install:
@@ -20,7 +20,7 @@ matrix:
 
     - language: go
       name: Unit Test
-      go: 1.13.6
+      go: 1.13.8
       env:
         - TESTSUITE=unittest
       before_install:
@@ -29,7 +29,7 @@ matrix:
 
     - language: go
       name: Build
-      go: 1.13.6
+      go: 1.13.8
       script: make
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
 COMMIT ?= $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}")
 
 HYPERKIT_BUILD_IMAGE 	?= karalabe/xgo-1.12.x
-# NOTE: "latest" as of 2019-08-15. kube-cross images aren't updated as often as Kubernetes
-BUILD_IMAGE 	?= k8s.gcr.io/kube-cross:v$(GO_VERSION)-1
+# NOTE: "latest" as of 2020-02-26. kube-cross images aren't updated as often as Kubernetes
+BUILD_IMAGE 	?= us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:v$(GO_VERSION)-1
 ISO_BUILD_IMAGE ?= $(REGISTRY)/buildroot-image
 KVM_BUILD_IMAGE ?= $(REGISTRY)/kvm-build-image:$(GO_VERSION)
 

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ DEB_VERSION ?= $(subst -,~,$(RAW_VERSION))
 RPM_VERSION ?= $(DEB_VERSION)
 
 # used by hack/jenkins/release_build_and_upload.sh and KVM_BUILD_IMAGE, see also BUILD_IMAGE below
-GO_VERSION ?= 1.13.6
+GO_VERSION ?= 1.13.8
 
 INSTALL_SIZE ?= $(shell du out/minikube-windows-amd64.exe | cut -f1)
 BUILDROOT_BRANCH ?= 2019.02.9

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -31,7 +31,7 @@ export KUBECONFIG="${TEST_HOME}/kubeconfig"
 export PATH=$PATH:"/usr/local/bin/:/usr/local/go/bin/:$GOPATH/bin"
 
 # installing golang so we could do go get for gopogh
-sudo ./installers/check_install_golang.sh "1.13.6" "/usr/local" || true
+sudo ./installers/check_install_golang.sh "1.13.8" "/usr/local" || true
 
 docker rm -f -v $(docker ps -aq) >/dev/null 2>&1 || true
 docker volume prune -f || true


### PR DESCRIPTION
It is "soon" available for `kube-cross`

See: https://github.com/kubernetes/release/issues/1134

Similar to #6730

Need to wait on Kubernetes, for 1.14

See: https://github.com/kubernetes/kubernetes/pull/88638