### PR TITLE
Don't show download message until downloading

### DIFF
--- a/pkg/minikube/download/iso.go
+++ b/pkg/minikube/download/iso.go
@@ -79,7 +79,6 @@ func localISOPath(u *url.URL) string {
 
 // ISO downloads and returns the path to the downloaded ISO
 func ISO(urls []string, skipChecksum bool) (string, error) {
-	out.T(out.ISODownload, "Downloading VM boot image ...")
 	errs := map[string]string{}
 
 	for _, url := range urls {
@@ -127,6 +126,8 @@ func downloadISO(isoURL string, skipChecksum bool) error {
 	if _, err := os.Stat(dst); err == nil {
 		return nil
 	}
+
+	out.T(out.ISODownload, "Downloading VM boot image ...")
 
 	urlWithChecksum := isoURL + "?checksum=file:" + isoURL + ".sha256"
 	if skipChecksum {


### PR DESCRIPTION
For instance if the boot image already exists

Closes #6950