### PR TITLE
Improve the go reportcard for minikube

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -337,14 +337,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		ssh.SetDefaultClient(ssh.External)
 	}
 
-	var existingAddons map[string]bool
-	if viper.GetBool(installAddons) {
-		existingAddons = map[string]bool{}
-		if existing != nil && existing.Addons != nil {
-			existingAddons = existing.Addons
-		}
-	}
-	kubeconfig, err := node.Start(mc, n, true, existingAddons)
+	kubeconfig, err := startNode(existing, mc, n)
 	if err != nil {
 		exit.WithError("Starting node", err)
 	}
@@ -387,6 +380,17 @@ func displayEnviron(env []string) {
 			out.T(out.Option, "{{.key}}={{.value}}", out.V{"key": k, "value": v})
 		}
 	}
+}
+
+func startNode(existing *config.ClusterConfig, mc config.ClusterConfig, n config.Node) (*kubeconfig.Settings, error) {
+	var existingAddons map[string]bool
+	if viper.GetBool(installAddons) {
+		existingAddons = map[string]bool{}
+		if existing != nil && existing.Addons != nil {
+			existingAddons = existing.Addons
+		}
+	}
+	return node.Start(mc, n, true, existingAddons)
 }
 
 func showKubectlInfo(kcs *kubeconfig.Settings, k8sVersion string, machineName string) error {

--- a/pkg/minikube/bootstrapper/bsutil/kubelet.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubelet.go
@@ -28,9 +28,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/cruntime"
 )
 
-// NewKubeletConfig generates a new systemd unit containing a configured kubelet
-// based on the options present in the KubernetesConfig.
-func NewKubeletConfig(mc config.ClusterConfig, nc config.Node, r cruntime.Manager) ([]byte, error) {
+func extraKubeletOpts(mc config.ClusterConfig, nc config.Node, r cruntime.Manager) (map[string]string, error) {
 	k8s := mc.KubernetesConfig
 	version, err := ParseKubernetesVersion(k8s.KubernetesVersion)
 	if err != nil {
@@ -79,7 +77,18 @@ func NewKubeletConfig(mc config.ClusterConfig, nc config.Node, r cruntime.Manage
 		extraOpts["feature-gates"] = kubeletFeatureArgs
 	}
 
+	return extraOpts, nil
+}
+
+// NewKubeletConfig generates a new systemd unit containing a configured kubelet
+// based on the options present in the KubernetesConfig.
+func NewKubeletConfig(mc config.ClusterConfig, nc config.Node, r cruntime.Manager) ([]byte, error) {
 	b := bytes.Buffer{}
+	extraOpts, err := extraKubeletOpts(mc, nc, r)
+	if err != nil {
+		return nil, err
+	}
+	k8s := mc.KubernetesConfig
 	opts := struct {
 		ExtraOptions     string
 		ContainerRuntime string

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/minikube/pkg/drivers/kic"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/kapi"
+	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/bootstrapper"
 	"k8s.io/minikube/pkg/minikube/bootstrapper/bsutil"
 	"k8s.io/minikube/pkg/minikube/bootstrapper/bsutil/kverify"
@@ -421,10 +422,9 @@ func (k *Bootstrapper) UpdateCluster(cfg config.ClusterConfig) error {
 
 	glog.Infof("kubelet %s config:\n%+v", kubeletCfg, cfg.KubernetesConfig)
 
-	stopCmd := exec.Command("/bin/bash", "-c", "pgrep kubelet && sudo systemctl stop kubelet")
 	// stop kubelet to avoid "Text File Busy" error
-	if rr, err := k.c.RunCmd(stopCmd); err != nil {
-		glog.Warningf("unable to stop kubelet: %s command: %q output: %q", err, rr.Command(), rr.Output())
+	if err := stopKubelet(k.c); err != nil {
+		glog.Warningf("unable to stop kubelet: %s", err)
 	}
 
 	if err := bsutil.TransferBinaries(cfg.KubernetesConfig, k.c); err != nil {
@@ -436,24 +436,46 @@ func (k *Bootstrapper) UpdateCluster(cfg config.ClusterConfig) error {
 		cniFile = []byte(defaultCNIConfig)
 	}
 	files := bsutil.ConfigFileAssets(cfg.KubernetesConfig, kubeadmCfg, kubeletCfg, kubeletService, cniFile)
+	if err := copyFiles(k.c, files); err != nil {
+		return err
+	}
 
+	if err := startKubelet(k.c); err != nil {
+		return err
+	}
+	return nil
+}
+
+func stopKubelet(runner command.Runner) error {
+	stopCmd := exec.Command("/bin/bash", "-c", "pgrep kubelet && sudo systemctl stop kubelet")
+	if rr, err := runner.RunCmd(stopCmd); err != nil {
+		return errors.Wrapf(err, "command: %q output: %q", rr.Command(), rr.Output())
+	}
+	return nil
+}
+
+func copyFiles(runner command.Runner, files []assets.CopyableFile) error {
 	// Combine mkdir request into a single call to reduce load
 	dirs := []string{}
 	for _, f := range files {
 		dirs = append(dirs, f.GetTargetDir())
 	}
 	args := append([]string{"mkdir", "-p"}, dirs...)
-	if _, err := k.c.RunCmd(exec.Command("sudo", args...)); err != nil {
+	if _, err := runner.RunCmd(exec.Command("sudo", args...)); err != nil {
 		return errors.Wrap(err, "mkdir")
 	}
 
 	for _, f := range files {
-		if err := k.c.Copy(f); err != nil {
+		if err := runner.Copy(f); err != nil {
 			return errors.Wrapf(err, "copy")
 		}
 	}
+	return nil
+}
 
-	if _, err := k.c.RunCmd(exec.Command("/bin/bash", "-c", "sudo systemctl daemon-reload && sudo systemctl start kubelet")); err != nil {
+func startKubelet(runner command.Runner) error {
+	startCmd := exec.Command("/bin/bash", "-c", "sudo systemctl daemon-reload && sudo systemctl start kubelet")
+	if _, err := runner.RunCmd(startCmd); err != nil {
 		return errors.Wrap(err, "starting kubelet")
 	}
 	return nil

--- a/pkg/minikube/cruntime/cruntime_test.go
+++ b/pkg/minikube/cruntime/cruntime_test.go
@@ -224,43 +224,60 @@ func (f *FakeRunner) Remove(assets.CopyableFile) error {
 	return nil
 }
 
+func (f *FakeRunner) dockerPs(args []string) (string, error) {
+	// ps -a --filter="name=apiserver" --format="{{.ID}}"
+	if args[1] == "-a" && strings.HasPrefix(args[2], "--filter") {
+		filter := strings.Split(args[2], `r=`)[1]
+		fname := strings.Split(filter, "=")[1]
+		ids := []string{}
+		f.t.Logf("fake docker: Looking for containers matching %q", fname)
+		for id, cname := range f.containers {
+			if strings.Contains(cname, fname) {
+				ids = append(ids, id)
+			}
+		}
+		f.t.Logf("fake docker: Found containers: %v", ids)
+		return strings.Join(ids, "\n"), nil
+	}
+	return "", nil
+}
+
+func (f *FakeRunner) dockerStop(args []string) (string, error) {
+	ids := strings.Split(args[1], " ")
+	for _, id := range ids {
+		f.t.Logf("fake docker: Stopping id %q", id)
+		if f.containers[id] == "" {
+			return "", fmt.Errorf("no such container")
+		}
+		delete(f.containers, id)
+	}
+	return "", nil
+}
+
+func (f *FakeRunner) dockerRm(args []string) (string, error) {
+	// Skip "-f" argument
+	for _, id := range args[2:] {
+		f.t.Logf("fake docker: Removing id %q", id)
+		if f.containers[id] == "" {
+			return "", fmt.Errorf("no such container")
+		}
+		delete(f.containers, id)
+	}
+	return "", nil
+}
+
 // docker is a fake implementation of docker
 func (f *FakeRunner) docker(args []string, _ bool) (string, error) {
 	switch cmd := args[0]; cmd {
 	case "ps":
-		// ps -a --filter="name=apiserver" --format="{{.ID}}"
-		if args[1] == "-a" && strings.HasPrefix(args[2], "--filter") {
-			filter := strings.Split(args[2], `r=`)[1]
-			fname := strings.Split(filter, "=")[1]
-			ids := []string{}
-			f.t.Logf("fake docker: Looking for containers matching %q", fname)
-			for id, cname := range f.containers {
-				if strings.Contains(cname, fname) {
-					ids = append(ids, id)
-				}
-			}
-			f.t.Logf("fake docker: Found containers: %v", ids)
-			return strings.Join(ids, "\n"), nil
-		}
-	case "stop":
-		ids := strings.Split(args[1], " ")
-		for _, id := range ids {
-			f.t.Logf("fake docker: Stopping id %q", id)
-			if f.containers[id] == "" {
-				return "", fmt.Errorf("no such container")
-			}
-			delete(f.containers, id)
-		}
-	case "rm":
-		// Skip "-f" argument
-		for _, id := range args[2:] {
-			f.t.Logf("fake docker: Removing id %q", id)
-			if f.containers[id] == "" {
-				return "", fmt.Errorf("no such container")
-			}
-			delete(f.containers, id)
+		return f.dockerPs(args)
 
-		}
+	case "stop":
+		return f.dockerStop(args)
+
+	case "rm":
+		return f.dockerRm(args)
+
 	case "version":
 
 		if args[1] == "--format" && args[2] == "{{.Server.Version}}" {

--- a/pkg/minikube/machine/cluster_test.go
+++ b/pkg/minikube/machine/cluster_test.go
@@ -58,7 +58,7 @@ var defaultClusterConfig = config.ClusterConfig{
 	Name:      viper.GetString("profile"),
 	Driver:    driver.Mock,
 	DockerEnv: []string{"MOCK_MAKE_IT_PROVISION=true"},
-	Nodes:     []config.Node{config.Node{Name: "minikube"}},
+	Nodes:     []config.Node{{Name: "minikube"}},
 }
 
 func TestCreateHost(t *testing.T) {

--- a/pkg/minikube/machine/fix.go
+++ b/pkg/minikube/machine/fix.go
@@ -73,6 +73,45 @@ func fixHost(api libmachine.API, cc config.ClusterConfig, n config.Node) (*host.
 	// check if need to re-run docker-env
 	maybeWarnAboutEvalEnv(cc.Driver, cc.Name)
 
+	h, err = recreateIfNeeded(api, cc, n, h)
+	if err != nil {
+		return h, err
+	}
+
+	e := engineOptions(cc)
+	if len(e.Env) > 0 {
+		h.HostOptions.EngineOptions.Env = e.Env
+		glog.Infof("Detecting provisioner ...")
+		provisioner, err := provision.DetectProvisioner(h.Driver)
+		if err != nil {
+			return h, errors.Wrap(err, "detecting provisioner")
+		}
+		if err := provisioner.Provision(*h.HostOptions.SwarmOptions, *h.HostOptions.AuthOptions, *h.HostOptions.EngineOptions); err != nil {
+			return h, errors.Wrap(err, "provision")
+		}
+	}
+
+	if driver.IsMock(h.DriverName) {
+		return h, nil
+	}
+
+	if err := postStartSetup(h, cc); err != nil {
+		return h, errors.Wrap(err, "post-start")
+	}
+
+	if driver.BareMetal(h.Driver.DriverName()) {
+		glog.Infof("%s is local, skipping auth/time setup (requires ssh)", h.Driver.DriverName())
+		return h, nil
+	}
+
+	glog.Infof("Configuring auth for driver %s ...", h.Driver.DriverName())
+	if err := h.ConfigureAuth(); err != nil {
+		return h, &retry.RetriableError{Err: errors.Wrap(err, "Error configuring auth on host")}
+	}
+	return h, ensureSyncedGuestClock(h, cc.Driver)
+}
+
+func recreateIfNeeded(api libmachine.API, cc config.ClusterConfig, n config.Node, h *host.Host) (*host.Host, error) {
 	s, err := h.Driver.GetState()
 	if err != nil || s == state.Stopped || s == state.None {
 		// If virtual machine does not exist due to user interrupt cancel(i.e. Ctrl + C), recreate virtual machine
@@ -118,37 +157,7 @@ func fixHost(api libmachine.API, cc config.ClusterConfig, n config.Node) (*host.
 		}
 	}
 
-	e := engineOptions(cc)
-	if len(e.Env) > 0 {
-		h.HostOptions.EngineOptions.Env = e.Env
-		glog.Infof("Detecting provisioner ...")
-		provisioner, err := provision.DetectProvisioner(h.Driver)
-		if err != nil {
-			return h, errors.Wrap(err, "detecting provisioner")
-		}
-		if err := provisioner.Provision(*h.HostOptions.SwarmOptions, *h.HostOptions.AuthOptions, *h.HostOptions.EngineOptions); err != nil {
-			return h, errors.Wrap(err, "provision")
-		}
-	}
-
-	if driver.IsMock(h.DriverName) {
-		return h, nil
-	}
-
-	if err := postStartSetup(h, cc); err != nil {
-		return h, errors.Wrap(err, "post-start")
-	}
-
-	if driver.BareMetal(h.Driver.DriverName()) {
-		glog.Infof("%s is local, skipping auth/time setup (requires ssh)", h.Driver.DriverName())
-		return h, nil
-	}
-
-	glog.Infof("Configuring auth for driver %s ...", h.Driver.DriverName())
-	if err := h.ConfigureAuth(); err != nil {
-		return h, &retry.RetriableError{Err: errors.Wrap(err, "Error configuring auth on host")}
-	}
-	return h, ensureSyncedGuestClock(h, cc.Driver)
+	return h, nil
 }
 
 // maybeWarnAboutEvalEnv wil warn user if they need to re-eval their docker-env, podman-env
@@ -222,6 +231,41 @@ func adjustGuestClock(h hostRunner, t time.Time) error {
 	return err
 }
 
+func machineExistsState(s state.State, err error) (bool, error) {
+	if s == state.None {
+		return false, ErrorMachineNotExist
+	}
+	return true, err
+}
+
+func machineExistsError(s state.State, err error, drverr error) (bool, error) {
+	_ = s // not used
+	if err == drverr {
+		// if the error matches driver error
+		return false, ErrorMachineNotExist
+	}
+	return true, err
+}
+
+func machineExistsMessage(s state.State, err error, msg string) (bool, error) {
+	if s == state.None || (err != nil && err.Error() == msg) {
+		// if the error contains the message
+		return false, ErrorMachineNotExist
+	}
+	return true, err
+}
+
+func machineExistsDocker(s state.State, err error) (bool, error) {
+	if s == state.Error {
+		// if the kic image is not present on the host machine, when user cancel `minikube start`, state.Error will be return
+		return false, ErrorMachineNotExist
+	} else if s == state.None {
+		// if the kic image is present on the host machine, when user cancel `minikube start`, state.None will be return
+		return false, ErrorMachineNotExist
+	}
+	return true, err
+}
+
 // machineExists checks if virtual machine does not exist
 // if the virtual machine exists, return true
 func machineExists(d string, s state.State, err error) (bool, error) {
@@ -230,54 +274,23 @@ func machineExists(d string, s state.State, err error) (bool, error) {
 	}
 	switch d {
 	case driver.HyperKit:
-		if s == state.None || (err != nil && err.Error() == "connection is shut down") {
-			return false, ErrorMachineNotExist
-		}
-		return true, err
+		return machineExistsMessage(s, err, "connection is shut down")
 	case driver.HyperV:
-		if s == state.None {
-			return false, ErrorMachineNotExist
-		}
-		return true, err
+		return machineExistsState(s, err)
 	case driver.KVM2:
-		if s == state.None {
-			return false, ErrorMachineNotExist
-		}
-		return true, err
+		return machineExistsState(s, err)
 	case driver.None:
-		if s == state.None {
-			return false, ErrorMachineNotExist
-		}
-		return true, err
+		return machineExistsState(s, err)
 	case driver.Parallels:
-		if err != nil && err.Error() == "machine does not exist" {
-			return false, ErrorMachineNotExist
-		}
-		return true, err
+		return machineExistsMessage(s, err, "connection is shut down")
 	case driver.VirtualBox:
-		if err == virtualbox.ErrMachineNotExist {
-			return false, ErrorMachineNotExist
-		}
-		return true, err
+		return machineExistsError(s, err, virtualbox.ErrMachineNotExist)
 	case driver.VMware:
-		if s == state.None {
-			return false, ErrorMachineNotExist
-		}
-		return true, err
+		return machineExistsState(s, err)
 	case driver.VMwareFusion:
-		if s == state.None {
-			return false, ErrorMachineNotExist
-		}
-		return true, err
+		return machineExistsState(s, err)
 	case driver.Docker:
-		if s == state.Error {
-			// if the kic image is not present on the host machine, when user cancel `minikube start`, state.Error will be return
-			return false, ErrorMachineNotExist
-		} else if s == state.None {
-			// if the kic image is present on the host machine, when user cancel `minikube start`, state.None will be return
-			return false, ErrorMachineNotExist
-		}
-		return true, err
+		return machineExistsDocker(s, err)
 	case driver.Mock:
 		if s == state.Error {
 			return false, ErrorMachineNotExist

--- a/pkg/minikube/tunnel/loadbalancer_patcher.go
+++ b/pkg/minikube/tunnel/loadbalancer_patcher.go
@@ -44,16 +44,19 @@ type LoadBalancerEmulator struct {
 	patchConverter patchConverter
 }
 
+// PatchServices will update all load balancer services
 func (l *LoadBalancerEmulator) PatchServices() ([]string, error) {
 	return l.applyOnLBServices(l.updateService)
 }
 
+// PatchServiceIP will patch the given service and ip
 func (l *LoadBalancerEmulator) PatchServiceIP(restClient rest.Interface, svc core.Service, ip string) error {
 	// TODO: do not ignore result
 	_, err := l.updateServiceIP(restClient, svc, ip)
 	return err
 }
 
+// Cleanup will clean up all load balancer services
 func (l *LoadBalancerEmulator) Cleanup() ([]string, error) {
 	return l.applyOnLBServices(l.cleanupService)
 }
@@ -143,6 +146,7 @@ func (l *LoadBalancerEmulator) cleanupService(restClient rest.Interface, svc cor
 
 }
 
+// NewLoadBalancerEmulator creates a new LoadBalancerEmulator
 func NewLoadBalancerEmulator(corev1Client typed_core.CoreV1Interface) LoadBalancerEmulator {
 	return LoadBalancerEmulator{
 		coreV1Client:   corev1Client,


### PR DESCRIPTION
Fix gofmt, golint, and most of gocyclo
(but not the integration tests just yet)

```
gofmt: 99%
	pkg/minikube/machine/cluster_test.go
		Line 1: warning: file is not gofmted with -s (gofmt)
golint: 99%
	pkg/minikube/tunnel/loadbalancer_patcher.go
		Line 47: warning: exported method LoadBalancerEmulator.PatchServices should have comment or be unexported (golint)
		Line 51: warning: exported method LoadBalancerEmulator.PatchServiceIP should have comment or be unexported (golint)
		Line 57: warning: exported method LoadBalancerEmulator.Cleanup should have comment or be unexported (golint)
		Line 146: warning: exported function NewLoadBalancerEmulator should have comment or be unexported (golint)
gocyclo: 99%
	cmd/minikube/cmd/delete.go
		Line 188: warning: cyclomatic complexity 20 of function deleteProfile() is high (> 15) (gocyclo)
		Line 92: warning: cyclomatic complexity 16 of function runDelete() is high (> 15) (gocyclo)
	pkg/minikube/cruntime/cruntime_test.go
		Line 228: warning: cyclomatic complexity 22 of function (*FakeRunner).docker() is high (> 15) (gocyclo)
	cmd/minikube/cmd/start.go
		Line 277: warning: cyclomatic complexity 17 of function runStart() is high (> 15) (gocyclo)
	pkg/minikube/bootstrapper/kubeadm/kubeadm.go
		Line 388: warning: cyclomatic complexity 16 of function (*Bootstrapper).UpdateCluster() is high (> 15) (gocyclo)
	pkg/minikube/image/cache.go
		Line 77: warning: cyclomatic complexity 16 of function saveToTarFile() is high (> 15) (gocyclo)
	pkg/minikube/bootstrapper/bsutil/kubelet.go
		Line 33: warning: cyclomatic complexity 16 of function NewKubeletConfig() is high (> 15) (gocyclo)
	pkg/minikube/machine/fix.go
		Line 227: warning: cyclomatic complexity 28 of function machineExists() is high (> 15) (gocyclo)
		Line 59: warning: cyclomatic complexity 21 of function fixHost() is high (> 15) (gocyclo)
```