### PR TITLE
clarify stopped node output in minikube stop command

### DIFF
--- a/cmd/minikube/cmd/stop.go
+++ b/cmd/minikube/cmd/stop.go
@@ -62,7 +62,7 @@ func runStop(cmd *cobra.Command, args []string) {
 		nonexistent := stop(api, *cc, n)
 
 		if !nonexistent {
-			out.T(out.Stopped, `"{{.node_name}}" stopped.`, out.V{"node_name": n.Name})
+			out.T(out.Stopped, `Node: "{{.node_name}}" stopped.`, out.V{"node_name": n.Name})
 		}
 	}
 


### PR DESCRIPTION
### What type of PR is this?
/kind bug
### What this PR does / why we need it:
When user executes `minikube stop` or `minikube stop -p <profile>` command, the command output says `"m01" stopped.`.
This message is not user friendly because user doesn't know what is "m01".
This PR clarifies the `minikube stop` command output.
```
$ minikube stop -p <profile>
✋  Stopping "<profile>" in hyperkit ...
🛑  "m01" stopped.
```
### Which issue(s) this PR fixes:
Fixes #6955
### Does this PR introduce a user-facing change?
Yes. 
This PR fixes the `minikube stop` command output.
**Before this PR**
```
✋  Stopping "<profile>" in hyperkit ...
🛑  "m01" stopped.
```
**After this PR**
```
✋  Stopping "p01" in hyperkit ...
🛑  Node: "m01" stopped.
```
Added `Node: ` section.

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```