### PR TITLE
Allow backwards compatibility with 1.6 and earlier configs

### DIFF
--- a/cmd/minikube/cmd/config/open.go
+++ b/cmd/minikube/cmd/config/open.go
@@ -74,7 +74,7 @@ var addonsOpenCmd = &cobra.Command{
 		if err != nil {
 			exit.WithError("Error getting cluster", err)
 		}
-		cp, err := config.PrimaryControlPlane(*cc)
+		cp, err := config.PrimaryControlPlane(cc)
 		if err != nil {
 			exit.WithError("Error getting control plane", err)
 		}

--- a/cmd/minikube/cmd/config/profile_list.go
+++ b/cmd/minikube/cmd/config/profile_list.go
@@ -76,7 +76,7 @@ var printProfilesTable = func() {
 	defer api.Close()
 
 	for _, p := range validProfiles {
-		cp, err := config.PrimaryControlPlane(*p.Config)
+		cp, err := config.PrimaryControlPlane(p.Config)
 		if err != nil {
 			exit.WithError("error getting primary control plane", err)
 		}
@@ -117,7 +117,7 @@ var printProfilesJSON = func() {
 
 	validProfiles, invalidProfiles, err := config.ListProfiles()
 	for _, v := range validProfiles {
-		cp, err := config.PrimaryControlPlane(*v.Config)
+		cp, err := config.PrimaryControlPlane(v.Config)
 		if err != nil {
 			exit.WithError("error getting primary control plane", err)
 		}

--- a/cmd/minikube/cmd/dashboard.go
+++ b/cmd/minikube/cmd/dashboard.go
@@ -82,7 +82,7 @@ var dashboardCmd = &cobra.Command{
 			exit.WithError("Error getting client", err)
 		}
 
-		cp, err := config.PrimaryControlPlane(*cc)
+		cp, err := config.PrimaryControlPlane(cc)
 		if err != nil {
 			exit.WithError("Error getting primary control plane", err)
 		}

--- a/cmd/minikube/cmd/logs.go
+++ b/cmd/minikube/cmd/logs.go
@@ -57,7 +57,7 @@ var logsCmd = &cobra.Command{
 		}
 
 		if nodeName == "" {
-			cp, err := config.PrimaryControlPlane(*cfg)
+			cp, err := config.PrimaryControlPlane(cfg)
 			if err != nil {
 				exit.WithError("Error getting primary control plane", err)
 			}

--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -109,7 +109,7 @@ var mountCmd = &cobra.Command{
 			exit.WithError("Error getting config", err)
 		}
 
-		cp, err := config.PrimaryControlPlane(*cc)
+		cp, err := config.PrimaryControlPlane(cc)
 		if err != nil {
 			exit.WithError("Error getting primary cp", err)
 		}

--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -88,7 +88,7 @@ var serviceCmd = &cobra.Command{
 		if err != nil {
 			exit.WithError("Error getting config", err)
 		}
-		cp, err := config.PrimaryControlPlane(*cfg)
+		cp, err := config.PrimaryControlPlane(cfg)
 		if err != nil {
 			exit.WithError("Error getting control plane", err)
 		}

--- a/cmd/minikube/cmd/service_list.go
+++ b/cmd/minikube/cmd/service_list.go
@@ -52,7 +52,7 @@ var serviceListCmd = &cobra.Command{
 		if err != nil {
 			exit.WithError("Error getting config", err)
 		}
-		cp, err := config.PrimaryControlPlane(*cfg)
+		cp, err := config.PrimaryControlPlane(cfg)
 		if err != nil {
 			exit.WithError("Error getting primary control plane", err)
 		}

--- a/cmd/minikube/cmd/ssh.go
+++ b/cmd/minikube/cmd/ssh.go
@@ -50,7 +50,7 @@ var sshCmd = &cobra.Command{
 			exit.WithError("Error getting config", err)
 		}
 		// TODO: allow choice of node to ssh into
-		cp, err := config.PrimaryControlPlane(*cc)
+		cp, err := config.PrimaryControlPlane(cc)
 		if err != nil {
 			exit.WithError("Error getting primary control plane", err)
 		}

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -514,7 +514,7 @@ func validateDriver(ds registry.DriverState, existing *config.ClusterConfig) {
 		return
 	}
 
-	cp, err := config.PrimaryControlPlane(*existing)
+	cp, err := config.PrimaryControlPlane(existing)
 	if err != nil {
 		exit.WithError("Error getting primary cp", err)
 	}

--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -101,7 +101,7 @@ var statusCmd = &cobra.Command{
 			exit.WithError("getting config", err)
 		}
 
-		cp, err := config.PrimaryControlPlane(*cc)
+		cp, err := config.PrimaryControlPlane(cc)
 		if err != nil {
 			exit.WithError("getting primary control plane", err)
 		}

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -252,7 +252,7 @@ func enableOrDisableStorageClasses(name, val, profile string) error {
 		return errors.Wrap(err, "getting cluster")
 	}
 
-	cp, err := config.PrimaryControlPlane(*cc)
+	cp, err := config.PrimaryControlPlane(cc)
 	if err != nil {
 		return errors.Wrap(err, "getting control plane")
 	}

--- a/pkg/minikube/bootstrapper/bsutil/kubeadm.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubeadm.go
@@ -50,7 +50,7 @@ func GenerateKubeadmYAML(mc config.ClusterConfig, r cruntime.Manager, n config.N
 	}
 
 	// In case of no port assigned, use default
-	cp, err := config.PrimaryControlPlane(mc)
+	cp, err := config.PrimaryControlPlane(&mc)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting control plane")
 	}

--- a/pkg/minikube/bootstrapper/bsutil/kubelet.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubelet.go
@@ -53,7 +53,7 @@ func NewKubeletConfig(mc config.ClusterConfig, nc config.Node, r cruntime.Manage
 	if k8s.NetworkPlugin != "" {
 		extraOpts["network-plugin"] = k8s.NetworkPlugin
 	}
-	cp, err := config.PrimaryControlPlane(mc)
+	cp, err := config.PrimaryControlPlane(&mc)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting master node")
 	}

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -254,7 +254,7 @@ func (k *Bootstrapper) client(ip string, port int) (*kubernetes.Clientset, error
 func (k *Bootstrapper) WaitForCluster(cfg config.ClusterConfig, timeout time.Duration) error {
 	start := time.Now()
 	out.T(out.Waiting, "Waiting for cluster to come online ...")
-	cp, err := config.PrimaryControlPlane(cfg)
+	cp, err := config.PrimaryControlPlane(&cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/minikube/config/profile.go
+++ b/pkg/minikube/config/profile.go
@@ -18,13 +18,13 @@ package config
 
 import (
 	"encoding/json"
-	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/golang/glog"
+	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/util/lock"
@@ -52,14 +52,35 @@ func (p *Profile) IsValid() bool {
 }
 
 // PrimaryControlPlane gets the node specific config for the first created control plane
-func PrimaryControlPlane(cc ClusterConfig) (Node, error) {
+func PrimaryControlPlane(cc *ClusterConfig) (Node, error) {
 	for _, n := range cc.Nodes {
 		if n.ControlPlane {
 			return n, nil
 		}
 	}
 
-	return Node{}, errors.New("could not find master node")
+	// This config is probably from 1.6 or earlier, let's convert it.
+	cp := Node{
+		Name:              cc.KubernetesConfig.NodeName,
+		IP:                cc.KubernetesConfig.NodeIP,
+		Port:              cc.KubernetesConfig.NodePort,
+		KubernetesVersion: cc.KubernetesConfig.KubernetesVersion,
+		ControlPlane:      true,
+		Worker:            true,
+	}
+
+	cc.Nodes = []Node{cp}
+
+	// Remove old style attribute to avoid confusion
+	cc.KubernetesConfig.NodeName = ""
+	cc.KubernetesConfig.NodeIP = ""
+
+	err := SaveProfile(viper.GetString(ProfileName), cc)
+	if err != nil {
+		return Node{}, err
+	}
+
+	return cp, nil
 }
 
 // ProfileNameInReservedKeywords checks if the profile is an internal keywords

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -85,6 +85,11 @@ type KubernetesConfig struct {
 
 	ShouldLoadCachedImages bool
 	EnableDefaultCNI       bool
+
+	// We need to keep these in the short term for backwards compatibility
+	NodeIP   string
+	NodePort int
+	NodeName string
 }
 
 // Node contains information about specific nodes in a cluster


### PR DESCRIPTION
Fixes #6943 

Now minikube will be able to retrieve older style configs and translate them to newer style. 