### PR TITLE
Round suggested memory alloc by 100MB for VM's

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -868,7 +868,7 @@ func generateCfgFromFlags(cmd *cobra.Command, k8sVersion string, drvName string)
 	}
 
 	mem := suggestMemoryAllocation(sysLimit, containerLimit)
-	if viper.GetString(memory) != "" {
+	if cmd.Flags().Changed(memory) {
 		mem = pkgutil.CalculateSizeInMB(viper.GetString(memory))
 	} else {
 		glog.Infof("Using suggested %dMB memory alloc based on sys=%dMB, container=%dMB", mem, sysLimit, containerLimit)

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -71,6 +71,9 @@ func TestGetKuberneterVersion(t *testing.T) {
 }
 
 func TestGenerateCfgFromFlagsHTTPProxyHandling(t *testing.T) {
+	// Set default disk size value in lieu of flag init
+	viper.SetDefault(humanReadableDiskSize, defaultDiskSize)
+
 	originalEnv := os.Getenv("HTTP_PROXY")
 	defer func() {
 		err := os.Setenv("HTTP_PROXY", originalEnv)
@@ -104,8 +107,6 @@ func TestGenerateCfgFromFlagsHTTPProxyHandling(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		// Set default disk size value in lieu of flag init
-		viper.SetDefault(humanReadableDiskSize, defaultDiskSize)
 		t.Run(test.description, func(t *testing.T) {
 			cmd := &cobra.Command{}
 			if err := os.Setenv("HTTP_PROXY", test.proxy); err != nil {

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -104,6 +104,8 @@ func TestGenerateCfgFromFlagsHTTPProxyHandling(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
+		// Set default disk size value in lieu of flag init
+		viper.SetDefault(humanReadableDiskSize, defaultDiskSize)
 		t.Run(test.description, func(t *testing.T) {
 			cmd := &cobra.Command{}
 			if err := os.Setenv("HTTP_PROXY", test.proxy); err != nil {

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -127,7 +127,10 @@ func enableOrDisableAddon(name, val, profile string) error {
 	if name == "istio" && enable {
 		minMem := 8192
 		minCpus := 4
-		memorySizeMB := pkgutil.CalculateSizeInMB(viper.GetString("memory"))
+		memorySizeMB, err := pkgutil.CalculateSizeInMB(viper.GetString("memory"))
+		if err != nil {
+			return errors.Wrap(err, "calculate memory")
+		}
 		cpuCount := viper.GetInt("cpus")
 		if memorySizeMB < minMem || cpuCount < minCpus {
 			out.WarningT("Enable istio needs {{.minMem}} MB of memory and {{.minCpus}} CPUs.", out.V{"minMem": minMem, "minCpus": minCpus})

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -25,8 +25,6 @@ import (
 
 	units "github.com/docker/go-units"
 	"github.com/pkg/errors"
-	"k8s.io/minikube/pkg/minikube/exit"
-	"k8s.io/minikube/pkg/minikube/out"
 )
 
 const (
@@ -34,17 +32,17 @@ const (
 )
 
 // CalculateSizeInMB returns the number of MB in the human readable string
-func CalculateSizeInMB(humanReadableSize string) int {
+func CalculateSizeInMB(humanReadableSize string) (int, error) {
 	_, err := strconv.ParseInt(humanReadableSize, 10, 64)
 	if err == nil {
 		humanReadableSize += "mb"
 	}
 	size, err := units.FromHumanSize(humanReadableSize)
 	if err != nil {
-		exit.WithCodeT(exit.Config, "Invalid size passed in argument: {{.error}}", out.V{"error": err})
+		return 0, fmt.Errorf("FromHumanSize: %v", err)
 	}
 
-	return int(size / units.MB)
+	return int(size / units.MB), nil
 }
 
 // GetBinaryDownloadURL returns a suitable URL for the platform

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -52,7 +52,10 @@ func TestCalculateSizeInMB(t *testing.T) {
 	}
 
 	for _, tt := range testData {
-		number := CalculateSizeInMB(tt.size)
+		number, err := CalculateSizeInMB(tt.size)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
 		if number != tt.expectedNumber {
 			t.Fatalf("Expected '%d'' but got '%d'", tt.expectedNumber, number)
 		}


### PR DESCRIPTION
Fixes #6964

There are now loads of tests, but here is a log from an example run:

`I0310 16:00:45.581333   12309 start.go:870] Using suggested 6000MB memory alloc based on sys=32768MB, container=0MB`

