### PR TITLE
Plumb config.ClusterConfig throughout addon validation code

### DIFF
--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
-	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/command"
 	"k8s.io/minikube/pkg/minikube/config"
@@ -35,7 +34,6 @@ import (
 	"k8s.io/minikube/pkg/minikube/machine"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/storageclass"
-	pkgutil "k8s.io/minikube/pkg/util"
 )
 
 // defaultStorageClassProvisioner is the name of the default storage class provisioner
@@ -49,35 +47,34 @@ func Set(name, value, profile string) error {
 		return errors.Errorf("%s is not a valid addon", name)
 	}
 
-	// Run any additional validations for this property
-	if err := run(name, value, profile, a.validations); err != nil {
-		return errors.Wrap(err, "running validations")
-	}
-
-	// Set the value
-	c, err := config.Load(profile)
+	cc, err := config.Load(profile)
 	if err != nil {
 		return errors.Wrap(err, "loading profile")
 	}
 
-	if err := a.set(c, name, value); err != nil {
+	// Run any additional validations for this property
+	if err := run(cc, name, value, a.validations); err != nil {
+		return errors.Wrap(err, "running validations")
+	}
+
+	if err := a.set(cc, name, value); err != nil {
 		return errors.Wrap(err, "setting new value of addon")
 	}
 
 	// Run any callbacks for this property
-	if err := run(name, value, profile, a.callbacks); err != nil {
+	if err := run(cc, name, value, a.callbacks); err != nil {
 		return errors.Wrap(err, "running callbacks")
 	}
 
 	glog.Infof("Writing out %q config to set %s=%v...", profile, name, value)
-	return config.Write(profile, c)
+	return config.Write(profile, cc)
 }
 
 // Runs all the validation or callback functions and collects errors
-func run(name, value, profile string, fns []setFn) error {
+func run(cc *config.ClusterConfig, name string, value string, fns []setFn) error {
 	var errors []error
 	for _, fn := range fns {
-		err := fn(name, value, profile)
+		err := fn(cc, name, value)
 		if err != nil {
 			errors = append(errors, err)
 		}
@@ -89,21 +86,21 @@ func run(name, value, profile string, fns []setFn) error {
 }
 
 // SetBool sets a bool value
-func SetBool(m *config.ClusterConfig, name string, val string) error {
+func SetBool(cc *config.ClusterConfig, name string, val string) error {
 	b, err := strconv.ParseBool(val)
 	if err != nil {
 		return err
 	}
-	if m.Addons == nil {
-		m.Addons = map[string]bool{}
+	if cc.Addons == nil {
+		cc.Addons = map[string]bool{}
 	}
-	m.Addons[name] = b
+	cc.Addons[name] = b
 	return nil
 }
 
 // enableOrDisableAddon updates addon status executing any commands necessary
-func enableOrDisableAddon(name, val, profile string) error {
-	glog.Infof("Setting addon %s=%s in %q", name, val, profile)
+func enableOrDisableAddon(cc *config.ClusterConfig, name string, val string) error {
+	glog.Infof("Setting addon %s=%s in %q", name, val, cc.Name)
 	enable, err := strconv.ParseBool(val)
 	if err != nil {
 		return errors.Wrapf(err, "parsing bool: %s", name)
@@ -111,7 +108,7 @@ func enableOrDisableAddon(name, val, profile string) error {
 	addon := assets.Addons[name]
 
 	// check addon status before enabling/disabling it
-	alreadySet, err := isAddonAlreadySet(addon, enable, profile)
+	alreadySet, err := isAddonAlreadySet(addon, enable, cc.Name)
 	if err != nil {
 		out.ErrT(out.Conflict, "{{.error}}", out.V{"error": err})
 		return err
@@ -124,13 +121,14 @@ func enableOrDisableAddon(name, val, profile string) error {
 		}
 	}
 
-	if name == "istio" && enable {
+	if strings.HasPrefix(name, "istio") && enable {
 		minMem := 8192
-		minCpus := 4
-		memorySizeMB := pkgutil.CalculateSizeInMB(viper.GetString("memory"))
-		cpuCount := viper.GetInt("cpus")
-		if memorySizeMB < minMem || cpuCount < minCpus {
-			out.WarningT("Enable istio needs {{.minMem}} MB of memory and {{.minCpus}} CPUs.", out.V{"minMem": minMem, "minCpus": minCpus})
+		minCPUs := 4
+		if cc.Memory < minMem {
+			out.WarningT("Istio needs {{.minMem}}MB of memory -- your configuration only allocates {{.memory}}MB", out.V{"minMem": minMem, "memory": cc.Memory})
+		}
+		if cc.CPUs < minCPUs {
+			out.WarningT("Istio needs {{.minCPUs}} CPUs -- your configuration only allocates {{.cpus}} CPUs", out.V{"minCPUs": minCPUs, "cpus": cc.CPUs})
 		}
 	}
 
@@ -141,14 +139,15 @@ func enableOrDisableAddon(name, val, profile string) error {
 	}
 	defer api.Close()
 
-	cfg, err := config.Load(profile)
-	if err != nil && !config.IsNotExist(err) {
-		exit.WithCodeT(exit.Data, "Unable to load config: {{.error}}", out.V{"error": err})
+	cp, err := config.PrimaryControlPlane(cc)
+	if err != nil {
+		exit.WithError("Error getting primary control plane", err)
 	}
 
-	host, err := machine.CheckIfHostExistsAndLoad(api, profile)
-	if err != nil || !machine.IsHostRunning(api, profile) {
-		glog.Warningf("%q is not running, writing %s=%v to disk and skipping enablement (err=%v)", profile, addon.Name(), enable, err)
+	mName := driver.MachineName(*cc, cp)
+	host, err := machine.CheckIfHostExistsAndLoad(api, mName)
+	if err != nil || !machine.IsHostRunning(api, mName) {
+		glog.Warningf("%q is not running, writing %s=%v to disk and skipping enablement (err=%v)", mName, addon.Name(), enable, err)
 		return nil
 	}
 
@@ -157,8 +156,8 @@ func enableOrDisableAddon(name, val, profile string) error {
 		return errors.Wrap(err, "command runner")
 	}
 
-	data := assets.GenerateTemplateData(cfg.KubernetesConfig)
-	return enableOrDisableAddonInternal(addon, cmd, data, enable, profile)
+	data := assets.GenerateTemplateData(cc.KubernetesConfig)
+	return enableOrDisableAddonInternal(cc, addon, cmd, data, enable)
 }
 
 func isAddonAlreadySet(addon *assets.Addon, enable bool, profile string) (bool, error) {
@@ -176,7 +175,7 @@ func isAddonAlreadySet(addon *assets.Addon, enable bool, profile string) (bool, 
 	return false, nil
 }
 
-func enableOrDisableAddonInternal(addon *assets.Addon, cmd command.Runner, data interface{}, enable bool, profile string) error {
+func enableOrDisableAddonInternal(cc *config.ClusterConfig, addon *assets.Addon, cmd command.Runner, data interface{}, enable bool) error {
 	deployFiles := []string{}
 
 	for _, addon := range addon.Assets {
@@ -211,10 +210,7 @@ func enableOrDisableAddonInternal(addon *assets.Addon, cmd command.Runner, data 
 		}
 	}
 
-	command, err := kubectlCommand(profile, deployFiles, enable)
-	if err != nil {
-		return err
-	}
+	command := kubectlCommand(cc, deployFiles, enable)
 	glog.Infof("Running: %v", command)
 	rr, err := cmd.RunCmd(command)
 	if err != nil {
@@ -225,8 +221,8 @@ func enableOrDisableAddonInternal(addon *assets.Addon, cmd command.Runner, data 
 }
 
 // enableOrDisableStorageClasses enables or disables storage classes
-func enableOrDisableStorageClasses(name, val, profile string) error {
-	glog.Infof("enableOrDisableStorageClasses %s=%v on %q", name, val, profile)
+func enableOrDisableStorageClasses(cc *config.ClusterConfig, name string, val string) error {
+	glog.Infof("enableOrDisableStorageClasses %s=%v on %q", name, val, cc.Name)
 	enable, err := strconv.ParseBool(val)
 	if err != nil {
 		return errors.Wrap(err, "Error parsing boolean")
@@ -247,18 +243,13 @@ func enableOrDisableStorageClasses(name, val, profile string) error {
 	}
 	defer api.Close()
 
-	cc, err := config.Load(profile)
-	if err != nil {
-		return errors.Wrap(err, "getting cluster")
-	}
-
 	cp, err := config.PrimaryControlPlane(cc)
 	if err != nil {
 		return errors.Wrap(err, "getting control plane")
 	}
 	if !machine.IsHostRunning(api, driver.MachineName(*cc, cp)) {
-		glog.Warningf("%q is not running, writing %s=%v to disk and skipping enablement", profile, name, val)
-		return enableOrDisableAddon(name, val, profile)
+		glog.Warningf("%q is not running, writing %s=%v to disk and skipping enablement", driver.MachineName(*cc, cp), name, val)
+		return enableOrDisableAddon(cc, name, val)
 	}
 
 	if enable {
@@ -275,7 +266,7 @@ func enableOrDisableStorageClasses(name, val, profile string) error {
 		}
 	}
 
-	return enableOrDisableAddon(name, val, profile)
+	return enableOrDisableAddon(cc, name, val)
 }
 
 // Start enables the default addons for a profile, plus any additional

--- a/pkg/addons/addons_test.go
+++ b/pkg/addons/addons_test.go
@@ -44,7 +44,15 @@ func createTestProfile(t *testing.T) string {
 	if err := os.MkdirAll(config.ProfileFolderPath(name), 0777); err != nil {
 		t.Fatalf("error creating temporary directory")
 	}
-	if err := config.DefaultLoader.WriteConfigToFile(name, &config.ClusterConfig{}); err != nil {
+
+	cc := &config.ClusterConfig{
+		Name:             name,
+		CPUs:             2,
+		Memory:           2500,
+		KubernetesConfig: config.KubernetesConfig{},
+	}
+
+	if err := config.DefaultLoader.WriteConfigToFile(name, cc); err != nil {
 		t.Fatalf("error creating temporary profile config: %v", err)
 	}
 	return name

--- a/pkg/addons/config.go
+++ b/pkg/addons/config.go
@@ -18,7 +18,7 @@ package addons
 
 import "k8s.io/minikube/pkg/minikube/config"
 
-type setFn func(string, string, string) error
+type setFn func(*config.ClusterConfig, string, string) error
 
 // Addon represents an addon
 type Addon struct {

--- a/pkg/addons/config.go
+++ b/pkg/addons/config.go
@@ -54,7 +54,7 @@ var Addons = []*Addon{
 	{
 		name:        "gvisor",
 		set:         SetBool,
-		validations: []setFn{IsContainerdRuntime},
+		validations: []setFn{UsingContainerd},
 		callbacks:   []setFn{enableOrDisableAddon},
 	},
 	{

--- a/pkg/addons/config.go
+++ b/pkg/addons/config.go
@@ -54,7 +54,7 @@ var Addons = []*Addon{
 	{
 		name:        "gvisor",
 		set:         SetBool,
-		validations: []setFn{UsingContainerd},
+		validations: []setFn{IsRuntimeContainerd},
 		callbacks:   []setFn{enableOrDisableAddon},
 	},
 	{

--- a/pkg/addons/kubectl.go
+++ b/pkg/addons/kubectl.go
@@ -26,16 +26,12 @@ import (
 	"k8s.io/minikube/pkg/minikube/vmpath"
 )
 
-var (
-	// For testing
-	k8sVersion = kubernetesVersion
-)
-
-func kubectlCommand(profile string, files []string, enable bool) (*exec.Cmd, error) {
-	v, err := k8sVersion(profile)
-	if err != nil {
-		return nil, err
+func kubectlCommand(cc *config.ClusterConfig, files []string, enable bool) *exec.Cmd {
+	v := constants.DefaultKubernetesVersion
+	if cc != nil {
+		v = cc.KubernetesConfig.KubernetesVersion
 	}
+
 	kubectlBinary := kubectlBinaryPath(v)
 
 	kubectlAction := "apply"
@@ -48,20 +44,7 @@ func kubectlCommand(profile string, files []string, enable bool) (*exec.Cmd, err
 		args = append(args, []string{"-f", f}...)
 	}
 
-	cmd := exec.Command("sudo", args...)
-	return cmd, nil
-}
-
-func kubernetesVersion(profile string) (string, error) {
-	cc, err := config.Load(profile)
-	if err != nil && !config.IsNotExist(err) {
-		return "", err
-	}
-	version := constants.DefaultKubernetesVersion
-	if cc != nil {
-		version = cc.KubernetesConfig.KubernetesVersion
-	}
-	return version, nil
+	return exec.Command("sudo", args...)
 }
 
 func kubectlBinaryPath(version string) string {

--- a/pkg/addons/kubectl_test.go
+++ b/pkg/addons/kubectl_test.go
@@ -19,6 +19,8 @@ package addons
 import (
 	"strings"
 	"testing"
+
+	"k8s.io/minikube/pkg/minikube/config"
 )
 
 func TestKubectlCommand(t *testing.T) {
@@ -41,18 +43,15 @@ func TestKubectlCommand(t *testing.T) {
 		},
 	}
 
+	cc := &config.ClusterConfig{
+		KubernetesConfig: config.KubernetesConfig{
+			KubernetesVersion: "v1.17.0",
+		},
+	}
+
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			originalK8sVersion := k8sVersion
-			defer func() { k8sVersion = originalK8sVersion }()
-			k8sVersion = func(_ string) (string, error) {
-				return "v1.17.0", nil
-			}
-
-			command, err := kubectlCommand("", test.files, test.enable)
-			if err != nil {
-				t.Fatalf("error getting kubectl command: %v", err)
-			}
+			command := kubectlCommand(cc, test.files, test.enable)
 			actual := strings.Join(command.Args, " ")
 
 			if actual != test.expected {

--- a/pkg/addons/validations.go
+++ b/pkg/addons/validations.go
@@ -33,8 +33,8 @@ and then start minikube again with the following flags:
 
 minikube start --container-runtime=containerd --docker-opt containerd=/var/run/containerd/containerd.sock`
 
-// IsContainerdRuntime is a validator which returns an error if the current runtime is not containerd
-func IsContainerdRuntime(cc *config.ClusterConfig, _, _ string) error {
+// IsRuntimeContainerd is a validator which returns an error if the current runtime is not containerd
+func IsRuntimeContainerd(cc *config.ClusterConfig, _, _ string) error {
 	r, err := cruntime.New(cruntime.Config{Type: cc.KubernetesConfig.ContainerRuntime})
 	if err != nil {
 		return err

--- a/pkg/addons/validations.go
+++ b/pkg/addons/validations.go
@@ -34,12 +34,8 @@ and then start minikube again with the following flags:
 minikube start --container-runtime=containerd --docker-opt containerd=/var/run/containerd/containerd.sock`
 
 // IsContainerdRuntime is a validator which returns an error if the current runtime is not containerd
-func IsContainerdRuntime(_, _, profile string) error {
-	config, err := config.Load(profile)
-	if err != nil {
-		return fmt.Errorf("config.Load: %v", err)
-	}
-	r, err := cruntime.New(cruntime.Config{Type: config.KubernetesConfig.ContainerRuntime})
+func IsContainerdRuntime(cc *config.ClusterConfig, _, _ string) error {
+	r, err := cruntime.New(cruntime.Config{Type: cc.KubernetesConfig.ContainerRuntime})
 	if err != nil {
 		return err
 	}

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -47,7 +47,7 @@ func Start(mc config.ClusterConfig, n config.Node, primary bool, existingAddons 
 	beginCacheKubernetesImages(&cacheGroup, mc.KubernetesConfig.ImageRepository, k8sVersion, mc.KubernetesConfig.ContainerRuntime)
 
 	// Abstraction leakage alert: startHost requires the config to be saved, to satistfy pkg/provision/buildroot.
-	// Hence, saveConfig must be called before startHost, and again afterwards when we know the IP.
+	// Hence, saveProfile must be called before startHost, and again afterwards when we know the IP.
 	if err := config.SaveProfile(viper.GetString(config.ProfileName), &mc); err != nil {
 		exit.WithError("Failed to save config", err)
 	}


### PR DESCRIPTION
This passes config objects around addons code rather than doing global lookups (flags & config.Load).

This also provides warnings for the "istio-provisioner" addon rather than just the "istio" addon.

Example output:

```
$ ./out/minikube addons enable istio-provisioner
❗  Istio needs 8192MB of memory -- your configuration only allocates 6000MB
❗  Istio needs 4 CPUs -- your configuration only allocates 2 CPUs
🌟  The 'istio-provisioner' addon is enabled
```

Fixes #6989 