### PR TITLE
allow setting api-server port for docker/podman drivers

### DIFF
--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -81,7 +81,7 @@ func (d *Driver) Create() error {
 	// control plane specific options
 	params.PortMappings = append(params.PortMappings, oci.PortMapping{
 		ListenAddress: oci.DefaultBindIPV4,
-		ContainerPort: constants.APIServerPort,
+		ContainerPort: int32(params.APIServerPort),
 	},
 		oci.PortMapping{
 			ListenAddress: oci.DefaultBindIPV4,
@@ -202,7 +202,7 @@ func (d *Driver) GetSSHKeyPath() string {
 
 // GetURL returns ip of the container running kic control-panel
 func (d *Driver) GetURL() (string, error) {
-	p, err := oci.HostPortBinding(d.NodeConfig.OCIBinary, d.MachineName, d.NodeConfig.APIServerPort)
+	p, err := oci.HostPortBinding(d.NodeConfig.OCIBinary, d.MachineName, int(d.NodeConfig.APIServerPort))
 	url := fmt.Sprintf("https://%s", net.JoinHostPort("127.0.0.1", fmt.Sprint(p)))
 	if err != nil {
 		return url, errors.Wrap(err, "api host port binding")

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -202,7 +202,7 @@ func (d *Driver) GetSSHKeyPath() string {
 
 // GetURL returns ip of the container running kic control-panel
 func (d *Driver) GetURL() (string, error) {
-	p, err := oci.HostPortBinding(d.NodeConfig.OCIBinary, d.MachineName, int(d.NodeConfig.APIServerPort))
+	p, err := oci.HostPortBinding(d.NodeConfig.OCIBinary, d.MachineName, d.NodeConfig.APIServerPort)
 	url := fmt.Sprintf("https://%s", net.JoinHostPort("127.0.0.1", fmt.Sprint(p)))
 	if err != nil {
 		return url, errors.Wrap(err, "api host port binding")

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -62,8 +62,6 @@ func TestStartStop(t *testing.T) {
 			}},
 			{"containerd", constants.DefaultKubernetesVersion, []string{
 				"--container-runtime=containerd",
-				"--docker-opt",
-				"containerd=/var/run/containerd/containerd.sock",
 				"--apiserver-port=8444",
 			}},
 			{"crio", "v1.15.7", []string{

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -62,6 +62,8 @@ func TestStartStop(t *testing.T) {
 			}},
 			{"containerd", constants.DefaultKubernetesVersion, []string{
 				"--container-runtime=containerd",
+				"--docker-opt",
+				"containerd=/var/run/containerd/containerd.sock",
 				"--apiserver-port=8444",
 			}},
 			{"crio", "v1.15.7", []string{


### PR DESCRIPTION
Thank you for whomever who wrote the integeration test for setting Api Server port in the TestStartStop !
because of you I was able to find an imperfection in KIC drivers.


Fixes https://github.com/kubernetes/minikube/issues/6923