### PR TITLE
wip: Reduce flake for integration test TestStartStop

### DIFF
--- a/test/integration/fn_mount_cmd.go
+++ b/test/integration/fn_mount_cmd.go
@@ -106,7 +106,7 @@ func validateMountCmd(ctx context.Context, t *testing.T, profile string) {
 	}
 
 	start := time.Now()
-	if err := retry.Expo(checkMount, time.Second, 15*time.Second); err != nil {
+	if err := retry.Expo(checkMount, time.Second, Seconds(15)); err != nil {
 		// For local testing, allow macOS users to click prompt. If they don't, skip the test.
 		if runtime.GOOS == "darwin" {
 			t.Skip("skipping: mount did not appear, likely because macOS requires prompt to allow non-codesigned binaries to listen on non-localhost port")

--- a/test/integration/fn_pvc.go
+++ b/test/integration/fn_pvc.go
@@ -57,7 +57,7 @@ func validatePersistentVolumeClaim(ctx context.Context, t *testing.T, profile st
 	}
 
 	// Ensure the addon-manager has created the StorageClass before creating a claim, otherwise it won't be bound
-	if err := retry.Expo(checkStorageClass, time.Second, 90*time.Second); err != nil {
+	if err := retry.Expo(checkStorageClass, time.Second, Seconds(90)); err != nil {
 		t.Errorf("no default storage class after retry: %v", err)
 	}
 

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -598,7 +598,7 @@ func validateServiceCmd(ctx context.Context, t *testing.T, profile string) {
 	// to avoid https://github.com/kubernetes/minikube/issues/6997
 	// adding this logic to minikube start is not necessary but useful for rare test flakes
 	saReady := func() error { // check if default service account is created.
-		if _, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "serviceaccount", "default")); err != nil {
+		if _, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "get", "serviceaccount", "default")); err != nil {
 			t.Logf("temporary error waiting for default service account: %v", err)
 			return fmt.Errorf("Error waiting for default service account %v", err)
 		}
@@ -727,7 +727,7 @@ func validateMySQL(ctx context.Context, t *testing.T, profile string) {
 	// to avoid https://github.com/kubernetes/minikube/issues/6997
 	// adding this logic to minikube start is not necessary but useful for rare test flakes
 	saReady := func() error { // check if default service account is created.
-		if _, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "serviceaccount", "default")); err != nil {
+		if _, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "get", "serviceaccount", "default")); err != nil {
 			t.Logf("temporary error waiting for default service account: %v", err)
 			return fmt.Errorf("Error waiting for default service account %v", err)
 		}

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -174,7 +174,7 @@ func testPodScheduling(ctx context.Context, t *testing.T, profile string) {
 	// to avoid https://github.com/kubernetes/minikube/issues/6997
 	// adding this logic to minikube start is not necessary but useful for rare test flakes
 	saReady := func() error { // check if default service account is created.
-		if _, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "serviceaccount", "default")); err != nil {
+		if _, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "get", "serviceaccount", "default")); err != nil {
 			t.Logf("temporary error waiting for default service account: %v", err)
 			return fmt.Errorf("Error waiting for default service account %v", err)
 		}


### PR DESCRIPTION
in first verison of this PR, I tried adding checking for service account being ready to minikube wait, but that adds 13seconds of waiting, for almost very small amount of use cases 
Fixes https://github.com/kubernetes/minikube/issues/6997