### PR TITLE
block on preload download

### DIFF
--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -42,6 +42,7 @@ func beginCacheKubernetesImages(g *errgroup.Group, imageRepository string, k8sVe
 			glog.Info("Caching tarball of preloaded images")
 			return download.Preload(k8sVersion, cRuntime)
 		})
+		g.Wait()
 		return
 	}
 

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -42,8 +42,12 @@ func beginCacheKubernetesImages(g *errgroup.Group, imageRepository string, k8sVe
 			glog.Info("Caching tarball of preloaded images")
 			return download.Preload(k8sVersion, cRuntime)
 		})
-		g.Wait()
-		return
+		err := g.Wait()
+		if err == nil {
+			glog.Infof("Finished downloading the preloaded tar for %s on %s", k8sVersion, cRuntime)
+			return // don't cache individual images if preload is successful.
+		}
+		glog.Errorf("Error downloading preloaded artifacts will continue without preload: %v", err)
 	}
 
 	if !viper.GetBool("cache-images") {

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -38,16 +38,13 @@ import (
 // beginCacheKubernetesImages caches images required for kubernetes version in the background
 func beginCacheKubernetesImages(g *errgroup.Group, imageRepository string, k8sVersion, cRuntime string) {
 	if download.PreloadExists(k8sVersion, cRuntime) {
-		g.Go(func() error {
-			glog.Info("Caching tarball of preloaded images")
-			return download.Preload(k8sVersion, cRuntime)
-		})
-		err := g.Wait()
+		glog.Info("Caching tarball of preloaded images")
+		err := download.Preload(k8sVersion, cRuntime)
 		if err == nil {
 			glog.Infof("Finished downloading the preloaded tar for %s on %s", k8sVersion, cRuntime)
 			return // don't cache individual images if preload is successful.
 		}
-		glog.Errorf("Error downloading preloaded artifacts will continue without preload: %v", err)
+		glog.Warningf("Error downloading preloaded artifacts will continue without preload: %v", err)
 	}
 
 	if !viper.GetBool("cache-images") {


### PR DESCRIPTION
### before this PR:

"Creating Kubernetes in docker container"...starts while the preload is in progress
while this might be okay in VM world, because VM takes time to warm up but in docker it causes failures.
```
💾  Downloading preloaded images tarball for k8s v1.17.3 ...
🔥  Creating Kubernetes in docker container with (CPUs=2) (2 available), Memory=4000MB (7964MB available) ...
    > preloaded-images-k8s-v1-v1.17.3-docker-overlay2.tar.lz4: 499.26 MiB / 499
...
...

❌  Unable to load cached images: loading cached images: stat /Users/medmac/.minikube/cache/images/gcr.io/k8s-minikube/storage-provisioner_v1.8.1: no such file or directory
    > kubelet.sha256: 65 B / 65 B [--------------------------] 100.00% ? p/s 0s
    > kubeadm.sha256: 65 B / 65 B [--------------------------] 100.00% ? p/s 0s
    > kubectl.sha256: 65 B / 65 B [--------------------------] 100.00% ? p/s 0s
...
...
...
```




### After this PR: the docker driver will not fail if you purge:

```
medmac@~/workspace/minikube (preload_block) $ ./out/minikube delete --all --purge && ./out/minikube start --vm-driver=docker
🔥  Successfully deleted all profiles
💀  Successfully purged minikube directory located at - [/Users/medmac/.minikube]
😄  minikube v1.8.1 on Darwin 10.13.6
✨  Using the docker driver based on user configuration
💾  Downloading preloaded images tarball for k8s v1.17.3 ...
    > preloaded-images-k8s-v1-v1.17.3-docker-overlay2.tar.lz4: 499.26 MiB / 499
🔥  Creating Kubernetes in docker container with (CPUs=2) (2 available), Memory=4000MB (7964MB available) ...
🐳  Preparing Kubernetes v1.17.3 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16
🚀  Launching Kubernetes ... 
🌟  Enabling addons: default-storageclass, storage-provisioner
⌛  Waiting for cluster to come online ...
🏄  Done! kubectl is now configured to use "minikube"
```

Fixes https://github.com/kubernetes/minikube/issues/7000

