### PR TITLE
Download to a temporary files and finalize using os.Rename

### DIFF
--- a/pkg/minikube/download/binary.go
+++ b/pkg/minikube/download/binary.go
@@ -62,9 +62,11 @@ func Binary(binary, version, osName, archName string) (string, error) {
 		return "", errors.Wrapf(err, "mkdir %s", targetDir)
 	}
 
+	tmpDst := targetFilepath + ".download"
+
 	client := &getter.Client{
 		Src:     url,
-		Dst:     targetFilepath,
+		Dst:     tmpDst,
 		Mode:    getter.ClientModeFile,
 		Options: []getter.ClientOption{getter.WithProgress(DefaultProgressBar)},
 	}
@@ -75,9 +77,9 @@ func Binary(binary, version, osName, archName string) (string, error) {
 	}
 
 	if osName == runtime.GOOS && archName == runtime.GOARCH {
-		if err = os.Chmod(targetFilepath, 0755); err != nil {
+		if err = os.Chmod(tmpDst, 0755); err != nil {
 			return "", errors.Wrapf(err, "chmod +x %s", targetFilepath)
 		}
 	}
-	return targetFilepath, nil
+	return targetFilepath, os.Rename(tmpDst, targetFilepath)
 }

--- a/pkg/minikube/download/iso.go
+++ b/pkg/minikube/download/iso.go
@@ -134,7 +134,6 @@ func downloadISO(isoURL string, skipChecksum bool) error {
 		urlWithChecksum = isoURL
 	}
 
-	// Predictable temp destination so that resume can function
 	tmpDst := dst + ".download"
 
 	opts := []getter.ClientOption{getter.WithProgress(DefaultProgressBar)}


### PR DESCRIPTION
Make other downloaders follow the ISO download behavior, where the download is atomic through use of os.Rename as the final step.

This allows us to avoid issues around partial downloads, and skip checksum remote validation if the finalized filename exists.
