### PR TITLE
none: Skip driver preload and image caching

### DIFF
--- a/pkg/minikube/node/config.go
+++ b/pkg/minikube/node/config.go
@@ -66,7 +66,9 @@ func configureRuntimes(runner cruntime.CommandRunner, drvName string, k8s config
 	if driver.BareMetal(drvName) {
 		disableOthers = false
 	}
-	if !driver.IsKIC(drvName) {
+
+	// Preload is overly invasive for VM's, and caching is not meaningful.
+	if driver.IsVM(drvName) {
 		if err := cr.Preload(k8s.KubernetesVersion); err != nil {
 			switch err.(type) {
 			case *cruntime.ErrISOFeature:

--- a/pkg/minikube/node/config.go
+++ b/pkg/minikube/node/config.go
@@ -67,7 +67,7 @@ func configureRuntimes(runner cruntime.CommandRunner, drvName string, k8s config
 		disableOthers = false
 	}
 
-	// Preload is overly invasive for VM's, and caching is not meaningful.
+	// Preload is overly invasive for bare metal, and caching is not meaningful.
 	if driver.IsVM(drvName) {
 		if err := cr.Preload(k8s.KubernetesVersion); err != nil {
 			switch err.(type) {

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -44,7 +44,10 @@ func Start(mc config.ClusterConfig, n config.Node, primary bool, existingAddons 
 	}
 
 	var cacheGroup errgroup.Group
-	beginCacheKubernetesImages(&cacheGroup, mc.KubernetesConfig.ImageRepository, k8sVersion, mc.KubernetesConfig.ContainerRuntime)
+	// Adding a second layer of cache does not make sense for the none driver
+	if !driver.BareMetal(driverName) {
+		beginCacheKubernetesImages(&cacheGroup, mc.KubernetesConfig.ImageRepository, k8sVersion, mc.KubernetesConfig.ContainerRuntime)
+	}
 
 	// Abstraction leakage alert: startHost requires the config to be saved, to satistfy pkg/provision/buildroot.
 	// Hence, saveConfig must be called before startHost, and again afterwards when we know the IP.


### PR DESCRIPTION
This fixes this error I noticed with the none driver in our integration tests:

```
ℹ️   OS release is Debian GNU/Linux rodete
💡  Existing disk is missing new features (lz4). To upgrade, run 'minikube delete'
🐳  Preparing Kubernetes v1.17.3 on Docker 19.03.5 ...
🚀  Launching Kubernetes ... 
```

Historically, we avoided adding a second level of image caching for the none driver, as Docker does a fine job already. Also, none driver hosts are unlikely to have lz4, and this message does not make any sense.