### PR TITLE
Fix dockerd internal port changing on restart

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 replace (
 	git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
 	github.com/docker/docker => github.com/docker/docker v1.4.2-0.20190924003213-a8608b5b67c7
-	github.com/docker/machine => github.com/medyagh/machine v0.16.3
+	github.com/docker/machine => github.com/medyagh/machine v0.16.4
 	github.com/hashicorp/go-getter => github.com/afbjorklund/go-getter v1.4.1-0.20190910175809-eb9f6c26742c
 	github.com/samalba/dockerclient => github.com/sayboras/dockerclient v0.0.0-20191231050035-015626177a97
 	k8s.io/api => k8s.io/api v0.17.3

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	cloud.google.com/go v0.45.1
 	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5 // indirect
 	github.com/Parallels/docker-machine-parallels v1.3.0
-	github.com/RaveNoX/go-jsonmerge v1.0.0 // indirect
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/blang/semver v3.5.0+incompatible
 	github.com/c4milo/gotoolkit v0.0.0-20170318115440-bcc06269efa9 // indirect
@@ -21,7 +20,7 @@ require (
 	github.com/docker/machine v0.7.1-0.20190718054102-a555e4f7a8f5 // version is 0.7.1 to pin to a555e4f7a8f5
 	github.com/elazarl/goproxy v0.0.0-20190421051319-9d40249d3c2f
 	github.com/elazarl/goproxy/ext v0.0.0-20190421051319-9d40249d3c2f // indirect
-	github.com/evanphx/json-patch v4.5.0+incompatible
+	github.com/evanphx/json-patch v4.5.0+incompatible // indirect
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
@@ -47,7 +46,6 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/libvirt/libvirt-go v3.4.0+incompatible
 	github.com/machine-drivers/docker-machine-driver-vmware v0.1.1
-	github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a
 	github.com/mattn/go-isatty v0.0.9
 	github.com/mitchellh/go-ps v0.0.0-20170309133038-4fdf99ab2936
 	github.com/moby/hyperkit v0.0.0-20171020124204-a12cd7250bcd
@@ -96,7 +94,7 @@ require (
 replace (
 	git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
 	github.com/docker/docker => github.com/docker/docker v1.4.2-0.20190924003213-a8608b5b67c7
-	github.com/docker/machine => github.com/machine-drivers/machine v0.7.1-0.20191109154235-b39d5b50de51
+	github.com/docker/machine => github.com/medyagh/machine v0.16.2
 	github.com/hashicorp/go-getter => github.com/afbjorklund/go-getter v1.4.1-0.20190910175809-eb9f6c26742c
 	github.com/samalba/dockerclient => github.com/sayboras/dockerclient v0.0.0-20191231050035-015626177a97
 	k8s.io/api => k8s.io/api v0.17.3

--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 replace (
 	git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
 	github.com/docker/docker => github.com/docker/docker v1.4.2-0.20190924003213-a8608b5b67c7
-	github.com/docker/machine => github.com/medyagh/machine v0.16.2
+	github.com/docker/machine => github.com/medyagh/machine v0.16.3
 	github.com/hashicorp/go-getter => github.com/afbjorklund/go-getter v1.4.1-0.20190910175809-eb9f6c26742c
 	github.com/samalba/dockerclient => github.com/sayboras/dockerclient v0.0.0-20191231050035-015626177a97
 	k8s.io/api => k8s.io/api v0.17.3

--- a/go.sum
+++ b/go.sum
@@ -510,8 +510,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0j
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2 h1:g+4J5sZg6osfvEfkRZxJ1em0VT95/UOZgi/l7zi1/oE=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
-github.com/medyagh/machine v0.16.3 h1:lHf1CVMoHs+BTcbTl4712zxF0paT9BbD4c6zffT6dqE=
-github.com/medyagh/machine v0.16.3/go.mod h1:/HegrAvHvD0AGQYQaLfrmUqxQTQF3Ks9qkj34p/ZH40=
+github.com/medyagh/machine v0.16.4 h1:oEsH3C1TYzs5axakAI/K1yc5O3r6de0+mCGumX4aHwM=
+github.com/medyagh/machine v0.16.4/go.mod h1:/HegrAvHvD0AGQYQaLfrmUqxQTQF3Ks9qkj34p/ZH40=
 github.com/mesos/mesos-go v0.0.9/go.mod h1:kPYCMQ9gsOXVAle1OsoY4I1+9kPu8GHkf88aV59fDr4=
 github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2/go.mod h1:g4cOPxcjV0oFq3qwpjSA30LReKD8AoIfwAY9VvG35NY=
 github.com/miekg/dns v1.1.3/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=

--- a/go.sum
+++ b/go.sum
@@ -510,8 +510,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0j
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2 h1:g+4J5sZg6osfvEfkRZxJ1em0VT95/UOZgi/l7zi1/oE=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
-github.com/medyagh/machine v0.16.2 h1:rJF0mYTZ73m1GjTJ0m+mom8c+ku2xyJFxwbGs0fCSG4=
-github.com/medyagh/machine v0.16.2/go.mod h1:/HegrAvHvD0AGQYQaLfrmUqxQTQF3Ks9qkj34p/ZH40=
+github.com/medyagh/machine v0.16.3 h1:lHf1CVMoHs+BTcbTl4712zxF0paT9BbD4c6zffT6dqE=
+github.com/medyagh/machine v0.16.3/go.mod h1:/HegrAvHvD0AGQYQaLfrmUqxQTQF3Ks9qkj34p/ZH40=
 github.com/mesos/mesos-go v0.0.9/go.mod h1:kPYCMQ9gsOXVAle1OsoY4I1+9kPu8GHkf88aV59fDr4=
 github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2/go.mod h1:g4cOPxcjV0oFq3qwpjSA30LReKD8AoIfwAY9VvG35NY=
 github.com/miekg/dns v1.1.3/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=

--- a/go.sum
+++ b/go.sum
@@ -52,9 +52,6 @@ github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
-github.com/RaveNoX/go-jsonmerge v1.0.0 h1:2e0nqnadoGUP8rAvcA0hkQelZreVO5X3BHomT2XMrAk=
-github.com/RaveNoX/go-jsonmerge v1.0.0/go.mod h1:qYM/NA77LhO4h51JJM7Z+xBU3ovqrNIACZe+SkSNVFo=
 github.com/Rican7/retry v0.1.0/go.mod h1:FgOROf8P5bebcC1DS0PdOQiqGUridaZvikzUmkFW6gg=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
@@ -96,7 +93,6 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115/go.mod h1:zVt7zX3K/aDCk9Tj+VM7YymsX66ERvzCJzw8rFCX2JU=
 github.com/blang/semver v3.5.0+incompatible h1:CGxCgetQ64DKk7rdZ++Vfnb1+ogGNnB17OJKJXD2Cfs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/c4milo/gotoolkit v0.0.0-20170318115440-bcc06269efa9 h1:+ziP/wVJWuAORkjv7386TRidVKY57X0bXBZFMeFlW+U=
@@ -433,7 +429,6 @@ github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c h1:3UvYABOQRhJAApj9MdCN
 github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c/go.mod h1:nD0vlnrUjcjJhqN5WuCWZyzfd5AHZAC9/ajvbSx69xA=
 github.com/juju/errors v0.0.0-20190806202954-0232dcc7464d h1:hJXjZMxj0SWlMoQkzeZDLi2cmeiWKa7y1B8Rg+qaoEc=
 github.com/juju/errors v0.0.0-20190806202954-0232dcc7464d/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
-github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
 github.com/juju/loggo v0.0.0-20190526231331-6e530bcce5d8 h1:UUHMLvzt/31azWTN/ifGWef4WUqvXk0iRqdhdy/2uzI=
 github.com/juju/loggo v0.0.0-20190526231331-6e530bcce5d8/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/mutex v0.0.0-20180619145857-d21b13acf4bf h1:2d3cilQly1OpAfZcn4QRuwDOdVoHsM4cDTkcKbmO760=
@@ -484,8 +479,6 @@ github.com/lucas-clemente/quic-go v0.10.2/go.mod h1:hvaRS9IHjFLMq76puFJeWNfmn+H7
 github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced/go.mod h1:NCcRLrOTZbzhZvixZLlERbJtDtYsmMw8Jc4vS8Z0g58=
 github.com/machine-drivers/docker-machine-driver-vmware v0.1.1 h1:+E1IKKk+6kaQrCPg6edJZ/zISZijuZTPnzy6RE4C/Ho=
 github.com/machine-drivers/docker-machine-driver-vmware v0.1.1/go.mod h1:ej014C83EmSnxJeJ8PtVb8OLJ91PJKO1Q8Y7sM5CK0o=
-github.com/machine-drivers/machine v0.7.1-0.20191109154235-b39d5b50de51 h1:ra4e+hU8Ca02yNyF8WM89aOShgXEPWRqerGpsmfqgTA=
-github.com/machine-drivers/machine v0.7.1-0.20191109154235-b39d5b50de51/go.mod h1:79Uwa2hGd5S39LDJt58s8JZcIhGEK6pkq9bsuTbFWbk=
 github.com/magiconair/properties v1.7.6/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -498,8 +491,6 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/marten-seemann/qtls v0.2.3/go.mod h1:xzjG7avBwGGbdZ8dTGxlBnLArsVKLvwmjgmPuiQEcYk=
-github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a h1:+J2gw7Bw77w/fbK7wnNJJDKmw1IbWft2Ul5BzrG1Qm8=
-github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a/go.mod h1:M1qoD/MqPgTZIk0EWKB38wE28ACRfVcn+cU08jyArI0=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
@@ -519,6 +510,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0j
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2 h1:g+4J5sZg6osfvEfkRZxJ1em0VT95/UOZgi/l7zi1/oE=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
+github.com/medyagh/machine v0.16.2 h1:rJF0mYTZ73m1GjTJ0m+mom8c+ku2xyJFxwbGs0fCSG4=
+github.com/medyagh/machine v0.16.2/go.mod h1:/HegrAvHvD0AGQYQaLfrmUqxQTQF3Ks9qkj34p/ZH40=
 github.com/mesos/mesos-go v0.0.9/go.mod h1:kPYCMQ9gsOXVAle1OsoY4I1+9kPu8GHkf88aV59fDr4=
 github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2/go.mod h1:g4cOPxcjV0oFq3qwpjSA30LReKD8AoIfwAY9VvG35NY=
 github.com/miekg/dns v1.1.3/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -705,7 +698,6 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.0.2/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
 github.com/spf13/viper v1.3.2 h1:VUFqw5KcqRf7i70GOzW7N+Q7+gxVBkSSqiXB12+JQ4M=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
-github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
 github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc/go.mod h1:ZrLn+e0ZuF3Y65PNF6dIwbJPZqfmtCXxFm9ckv0agOY=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/pkg/drivers/hyperkit/driver.go
+++ b/pkg/drivers/hyperkit/driver.go
@@ -125,8 +125,9 @@ func (d *Driver) GetSSHHostname() (string, error) {
 	return d.IPAddress, nil
 }
 
-// GetURL returns a Docker compatible host URL for connecting to this host
+// GetURL returns a Docker URL inside this host
 // e.g. tcp://1.2.3.4:2376
+// more info https://github.com/docker/machine/blob/b170508bf44c3405e079e26d5fdffe35a64c6972/libmachine/provision/utils.go#L159_L175
 func (d *Driver) GetURL() (string, error) {
 	ip, err := d.GetIP()
 	if err != nil {

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -200,14 +200,14 @@ func (d *Driver) GetSSHKeyPath() string {
 	return d.SSHKeyPath
 }
 
-// GetURL returns ip of the container running kic control-panel
+// GetURL returns a Docker URL inside this host
+// e.g. tcp://1.2.3.4:2376
+// more info https://github.com/docker/machine/blob/b170508bf44c3405e079e26d5fdffe35a64c6972/libmachine/provision/utils.go#L159_L175
 func (d *Driver) GetURL() (string, error) {
 	ip, err := d.GetIP()
 	if err != nil {
 		return "", err
 	}
-	// because of libmachine problem with detecting docker port https://github.com/kubernetes/minikube/issues/7017
-	// we have to do this hack https://github.com/docker/machine/blob/master/libmachine/provision/utils.go#L159_L175
 	url := fmt.Sprintf("tcp://%s", net.JoinHostPort(ip, "2376"))
 	return url, nil
 }

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -202,9 +202,13 @@ func (d *Driver) GetSSHKeyPath() string {
 
 // GetURL returns ip of the container running kic control-panel
 func (d *Driver) GetURL() (string, error) {
+	ip, err := d.GetIP()
+	if err != nil {
+		return "", err
+	}
 	// because of libmachine problem with detecting docker port https://github.com/kubernetes/minikube/issues/7017
 	// we have to do this hack https://github.com/docker/machine/blob/master/libmachine/provision/utils.go#L159_L175
-	url := fmt.Sprintf("https://%s", net.JoinHostPort("127.0.0.1", "2376"))
+	url := fmt.Sprintf("tcp://%s", net.JoinHostPort(ip, "2376"))
 	return url, nil
 }
 

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -202,11 +202,9 @@ func (d *Driver) GetSSHKeyPath() string {
 
 // GetURL returns ip of the container running kic control-panel
 func (d *Driver) GetURL() (string, error) {
-	p, err := oci.HostPortBinding(d.NodeConfig.OCIBinary, d.MachineName, d.NodeConfig.APIServerPort)
-	url := fmt.Sprintf("https://%s", net.JoinHostPort("127.0.0.1", fmt.Sprint(p)))
-	if err != nil {
-		return url, errors.Wrap(err, "api host port binding")
-	}
+	// because of libmachine problem with detecting docker port https://github.com/kubernetes/minikube/issues/7017
+	// we have to do this hack https://github.com/docker/machine/blob/master/libmachine/provision/utils.go#L159_L175
+	url := fmt.Sprintf("https://%s", net.JoinHostPort("127.0.0.1", "2376"))
 	return url, nil
 }
 

--- a/pkg/drivers/kvm/kvm.go
+++ b/pkg/drivers/kvm/kvm.go
@@ -119,7 +119,9 @@ func (d *Driver) PreCommandCheck() error {
 	return nil
 }
 
-// GetURL returns a Docker compatible host URL for connecting to this host
+// GetURL returns a Docker URL inside this host
+// e.g. tcp://1.2.3.4:2376
+// more info https://github.com/docker/machine/blob/b170508bf44c3405e079e26d5fdffe35a64c6972/libmachine/provision/utils.go#L159_L175
 func (d *Driver) GetURL() (string, error) {
 	if err := d.PreCommandCheck(); err != nil {
 		return "", errors.Wrap(err, "getting URL, precheck failed")

--- a/pkg/drivers/none/none.go
+++ b/pkg/drivers/none/none.go
@@ -115,8 +115,9 @@ func (d *Driver) GetSSHPort() (int, error) {
 	return 0, fmt.Errorf("driver does not support ssh commands")
 }
 
-// GetURL returns a Docker compatible host URL for connecting to this host
+// GetURL returns a Docker URL inside this host
 // e.g. tcp://1.2.3.4:2376
+// more info https://github.com/docker/machine/blob/b170508bf44c3405e079e26d5fdffe35a64c6972/libmachine/provision/utils.go#L159_L175
 func (d *Driver) GetURL() (string, error) {
 	ip, err := d.GetIP()
 	if err != nil {

--- a/pkg/minikube/machine/client.go
+++ b/pkg/minikube/machine/client.go
@@ -113,7 +113,7 @@ func (api *LocalClient) NewHost(drvName string, rawDriver []byte) (*host.Host, e
 			},
 			EngineOptions: &engine.Options{
 				StorageDriver: "overlay2",
-				TLSVerify:     true,
+				TLSVerify:     false,
 			},
 			SwarmOptions: &swarm.Options{},
 		},

--- a/pkg/minikube/machine/client.go
+++ b/pkg/minikube/machine/client.go
@@ -113,7 +113,7 @@ func (api *LocalClient) NewHost(drvName string, rawDriver []byte) (*host.Host, e
 			},
 			EngineOptions: &engine.Options{
 				StorageDriver: "overlay2",
-				TLSVerify:     false,
+				TLSVerify:     true,
 			},
 			SwarmOptions: &swarm.Options{},
 		},

--- a/pkg/minikube/node/config.go
+++ b/pkg/minikube/node/config.go
@@ -132,7 +132,7 @@ func setupKubeAdm(mAPI libmachine.API, cfg config.ClusterConfig, node config.Nod
 func setupKubeconfig(h *host.Host, cc *config.ClusterConfig, n *config.Node, clusterName string) (*kubeconfig.Settings, error) {
 	addr, err := apiServerURL(*h, *n)
 	if err != nil {
-		exit.WithError("Failed to api server URL", err)
+		exit.WithError("Failed to get api server URL", err)
 	}
 	if cc.KubernetesConfig.APIServerName != constants.APIServerName {
 		addr = strings.Replace(addr, n.IP, cc.KubernetesConfig.APIServerName, -1)

--- a/pkg/minikube/node/config.go
+++ b/pkg/minikube/node/config.go
@@ -138,10 +138,12 @@ func setupKubeconfig(h *host.Host, c *config.ClusterConfig, n *config.Node, clus
 		if err != nil {
 			exit.WithError("Failed to get host binding port for api port", err)
 		}
-
 	}
 
 	addr = strings.Replace(addr, "tcp://", "https://", -1)
+	// because of libmachine problem with detecting docker port https://github.com/kubernetes/minikube/issues/7017
+	// we have to do this hack https://github.com/docker/machine/blob/master/libmachine/provision/utils.go#L159_L175
+	// @
 	addr = strings.Replace(addr, ":2376", ":"+strconv.Itoa(p), -1)
 
 	if c.KubernetesConfig.APIServerName != constants.APIServerName {

--- a/pkg/minikube/node/config.go
+++ b/pkg/minikube/node/config.go
@@ -164,20 +164,17 @@ func apiServerURL(h host.Host, cc config.ClusterConfig, n config.Node) (string, 
 		if err != nil {
 			return "", errors.Wrap(err, "host port binding")
 		}
-		if cc.KubernetesConfig.APIServerName != constants.APIServerName {
-			hostname = cc.KubernetesConfig.APIServerName
+	} else {
+		hostname, err = h.Driver.GetIP()
+		if err != nil {
+			return "", errors.Wrap(err, "get ip")
 		}
-		return fmt.Sprintf("https://" + net.JoinHostPort(hostname, strconv.Itoa(port))), nil
 	}
 
-	hostname, err = h.Driver.GetIP()
-	if err != nil {
-		return "", errors.Wrap(err, "get ip")
-	}
 	if cc.KubernetesConfig.APIServerName != constants.APIServerName {
 		hostname = cc.KubernetesConfig.APIServerName
 	}
-	return fmt.Sprintf("https://" + net.JoinHostPort(hostname, strconv.Itoa(n.Port))), nil
+	return fmt.Sprintf("https://" + net.JoinHostPort(hostname, strconv.Itoa(port))), nil
 }
 
 // configureMounts configures any requested filesystem mounts

--- a/pkg/minikube/node/config.go
+++ b/pkg/minikube/node/config.go
@@ -130,7 +130,7 @@ func setupKubeAdm(mAPI libmachine.API, cfg config.ClusterConfig, node config.Nod
 
 func setupKubeconfig(h *host.Host, c *config.ClusterConfig, n *config.Node, clusterName string) (*kubeconfig.Settings, error) {
 	addr := ""
-	var err
+	var err error
 	if driver.IsKIC(h.DriverName) {
 		p, err := oci.HostPortBinding(h.DriverName, h.Name, n.Port)
 		if err != nil {

--- a/pkg/provision/buildroot.go
+++ b/pkg/provision/buildroot.go
@@ -155,7 +155,7 @@ WantedBy=multi-user.target
 		return nil, err
 	}
 
-	if err := p.Service("", serviceaction.Enable); err != nil {
+	if err := p.Service("docker", serviceaction.Enable); err != nil {
 		return nil, err
 	}
 

--- a/pkg/provision/buildroot.go
+++ b/pkg/provision/buildroot.go
@@ -151,6 +151,11 @@ WantedBy=multi-user.target
 		return nil, err
 	}
 
+	// To make sure if there is a already-installed docker on the ISO to pick up the new systemd file
+	if err := p.Service("", serviceaction.DaemonReload); err != nil {
+		return nil, err
+	}
+
 	if err := p.Service("docker", serviceaction.Enable); err != nil {
 		return nil, err
 	}

--- a/pkg/provision/buildroot.go
+++ b/pkg/provision/buildroot.go
@@ -151,6 +151,7 @@ WantedBy=multi-user.target
 		return nil, err
 	}
 
+	// because currently we install docker differently in kic, it is harmless to do this step for VM too so the code by the same
 	if err := p.Service("", serviceaction.DaemonReload); err != nil {
 		return nil, err
 	}

--- a/pkg/provision/buildroot.go
+++ b/pkg/provision/buildroot.go
@@ -151,11 +151,6 @@ WantedBy=multi-user.target
 		return nil, err
 	}
 
-	// because currently we install docker differently in kic, it is harmless to do this step for VM too so the code by the same
-	if err := p.Service("", serviceaction.DaemonReload); err != nil {
-		return nil, err
-	}
-
 	if err := p.Service("docker", serviceaction.Enable); err != nil {
 		return nil, err
 	}

--- a/pkg/provision/buildroot.go
+++ b/pkg/provision/buildroot.go
@@ -100,7 +100,7 @@ Environment=DOCKER_RAMDISK=yes
 # NOTE: default-ulimit=nofile is set to an arbitrary number for consistency with other
 # container runtimes. If left unlimited, it may result in OOM issues with MySQL.
 ExecStart=
-ExecStart=/usr/bin/dockerd -H tcp://0.0.0.0:{{.DockerPort}} -H unix:///var/run/docker.sock --default-ulimit=nofile=1048576:1048576 --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}} {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
+ExecStart=/usr/bin/dockerd -H tcp://0.0.0.0:2376 -H unix:///var/run/docker.sock --default-ulimit=nofile=1048576:1048576 --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}} {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
 ExecReload=/bin/kill -s HUP $MAINPID
 
 # Having non-zero Limit*s causes performance problems due to accounting overhead

--- a/pkg/provision/buildroot.go
+++ b/pkg/provision/buildroot.go
@@ -151,11 +151,11 @@ WantedBy=multi-user.target
 		return nil, err
 	}
 
-	if err := p.Service("docker", serviceaction.DaemonReload); err != nil {
+	if err := p.Service("", serviceaction.DaemonReload); err != nil {
 		return nil, err
 	}
 
-	if err := p.Service("docker", serviceaction.Enable); err != nil {
+	if err := p.Service("", serviceaction.Enable); err != nil {
 		return nil, err
 	}
 

--- a/pkg/provision/buildroot.go
+++ b/pkg/provision/buildroot.go
@@ -151,6 +151,10 @@ WantedBy=multi-user.target
 		return nil, err
 	}
 
+	if err := p.Service("docker", serviceaction.DaemonReload); err != nil {
+		return nil, err
+	}
+
 	if err := p.Service("docker", serviceaction.Enable); err != nil {
 		return nil, err
 	}

--- a/pkg/provision/ubuntu.go
+++ b/pkg/provision/ubuntu.go
@@ -155,11 +155,11 @@ WantedBy=multi-user.target
 		return nil, err
 	}
 
-	if err := p.Service("docker", serviceaction.DaemonReload); err != nil {
+	if err := p.Service("", serviceaction.DaemonReload); err != nil {
 		return nil, err
 	}
 
-	if err := p.Service("docker", serviceaction.Enable); err != nil {
+	if err := p.Service("", serviceaction.Enable); err != nil {
 		return nil, err
 	}
 

--- a/pkg/provision/ubuntu.go
+++ b/pkg/provision/ubuntu.go
@@ -159,7 +159,7 @@ WantedBy=multi-user.target
 		return nil, err
 	}
 
-	if err := p.Service("", serviceaction.Enable); err != nil {
+	if err := p.Service("docker", serviceaction.Enable); err != nil {
 		return nil, err
 	}
 

--- a/pkg/provision/ubuntu.go
+++ b/pkg/provision/ubuntu.go
@@ -104,7 +104,7 @@ Environment=DOCKER_RAMDISK=yes
 # NOTE: default-ulimit=nofile is set to an arbitrary number for consistency with other
 # container runtimes. If left unlimited, it may result in OOM issues with MySQL.
 ExecStart=
-ExecStart=/usr/bin/dockerd -H tcp://0.0.0.0:{{.DockerPort}} -H unix:///var/run/docker.sock --default-ulimit=nofile=1048576:1048576 --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}} {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
+ExecStart=/usr/bin/dockerd -H tcp://0.0.0.0:2376 -H unix:///var/run/docker.sock --default-ulimit=nofile=1048576:1048576 --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}} {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
 ExecReload=/bin/kill -s HUP $MAINPID
 
 # Having non-zero Limit*s causes performance problems due to accounting overhead

--- a/pkg/provision/ubuntu.go
+++ b/pkg/provision/ubuntu.go
@@ -155,7 +155,7 @@ WantedBy=multi-user.target
 		return nil, err
 	}
 
-	// because in kic base image we pre-install docker it already has a service file, it is harmless to double check with this step
+	// because in kic base image we pre-install docker it already has a service file. we need to daemon-reload for the new systemd file
 	if err := p.Service("", serviceaction.DaemonReload); err != nil {
 		return nil, err
 	}

--- a/pkg/provision/ubuntu.go
+++ b/pkg/provision/ubuntu.go
@@ -155,6 +155,10 @@ WantedBy=multi-user.target
 		return nil, err
 	}
 
+	if err := p.Service("docker", serviceaction.DaemonReload); err != nil {
+		return nil, err
+	}
+
 	if err := p.Service("docker", serviceaction.Enable); err != nil {
 		return nil, err
 	}

--- a/pkg/provision/ubuntu.go
+++ b/pkg/provision/ubuntu.go
@@ -155,6 +155,7 @@ WantedBy=multi-user.target
 		return nil, err
 	}
 
+	// because in kic base image we pre-install docker it already has a service file, it is harmless to double check with this step
 	if err := p.Service("", serviceaction.DaemonReload); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
closes https://github.com/kubernetes/minikube/issues/7017
### Gotcha 0 : driver.GetURL() is a big Lie !
GetURL in our driver is a very dirty hack, and has nothing to do with our Machine's URL it is just something to satify libmachine that wants to find out the insalled docker inside the node. 
so I had to make kic driver follow hyperkit driver and make GetURL to return a BIG fat lie !
and later replace it in setupKubeConfig function in start ...very hacky and dirty
but till we come up with a solution for machine driver. that is the solution.

related: https://github.com/docker/machine/blob/master/libmachine/provision/utils.go#L159_L175

### Gotcha 1 : Daemon reload

That was the ps aux params for docker in kic driver:
```
root@minikube:/home/docker# ps aux | grep dockerd
root     42776  2.3  1.2 2118696 98856 ?       Ssl  20:48   0:21 /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
```

and this was for VM
```
root      2097  1.1  1.6 632732 65972 ?        Ssl  20:35   0:20 /usr/bin/dockerd -H tcp://0.0.0.0:2376 -H unix:///var/run/docker.sock --default-ulimit=nofile=1048576:1048576 --tlsverify --tlscacert /etc/docker/ca.pem --tlscert /etc/docker/server.pem --tlskey /etc/docker/server-key.pem --label provider=hyperkit --insecure-registry 10.96.0.0/12
```

after doing daemon-reload the KIC one also picked up the right settings.


### Gotcha 2: Cert pining was missing 127.0.01
when dockerd for kic has the right parameters (same as vm) it compains about cert not having the same IP
but the cert is generated by libmachine. so I had to turn of the tls verify for docker inside minikube
```
Error during connect: Get https://127.0.0.1:32799/v1.40/containers/json: x509: certificate is valid for 172.17.0.2, not 127.0.0.1
```

for that I had to Fork libmachine and add 127.0.0.1 in addition to "localhost" to the certs 
I created a PR in libmachine, till that PR gets merged, we are gonna use my fork because we need to release https://github.com/machine-drivers/machine/pull/28/files

@afbjorklund might be able to help


### Gotcha 3: Libmachuine expects Docker Port to be 2376
it is poiintless to have dockerport in a variable, because of libmachine it always has to be "2376" 
so I hard coded it for less confusing debugging for next person. to save some of their hair on their head.
