### PR TITLE
Don't skip the check for too old versions for new

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1000,10 +1000,6 @@ func getKubernetesVersion(old *config.ClusterConfig) string {
 	}
 	nv := version.VersionPrefix + nvs.String()
 
-	if old == nil || old.KubernetesConfig.KubernetesVersion == "" {
-		return nv
-	}
-
 	oldestVersion, err := semver.Make(strings.TrimPrefix(constants.OldestKubernetesVersion, version.VersionPrefix))
 	if err != nil {
 		exit.WithCodeT(exit.Data, "Unable to parse oldest Kubernetes version from constants: {{.error}}", out.V{"error": err})
@@ -1020,6 +1016,10 @@ func getKubernetesVersion(old *config.ClusterConfig) string {
 		} else {
 			exit.WithCodeT(exit.Data, "Sorry, Kubernetes {{.version}} is not supported by this release of minikube", out.V{"version": nvs})
 		}
+	}
+
+	if old == nil || old.KubernetesConfig.KubernetesVersion == "" {
+		return nv
 	}
 
 	ovs, err := semver.Make(strings.TrimPrefix(old.KubernetesConfig.KubernetesVersion, version.VersionPrefix))


### PR DESCRIPTION
Even when starting a new profile, we still need to check the
k8s version parameter against the oldest supported version...

This helps guard against accidental errors like confusing the
kubernetes version (v1.17.3) with the minikube version (v1.8.1)

Closes #7018