### PR TITLE
Remove controllerManager from the kubeadm v1beta2 template

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta2.go
+++ b/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta2.go
@@ -58,7 +58,6 @@ kind: ClusterConfiguration
 certificatesDir: {{.CertDir}}
 clusterName: kubernetes
 controlPlaneEndpoint: {{.ControlPlaneAddress}}:{{.APIServerPort}}
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-api-port.yaml
@@ -26,7 +26,6 @@ apiServer:
 certificatesDir: /var/lib/minikube/certs
 clusterName: kubernetes
 controlPlaneEndpoint: localhost:12345
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-pod-network-cidr.yaml
@@ -26,7 +26,6 @@ apiServer:
 certificatesDir: /var/lib/minikube/certs
 clusterName: kubernetes
 controlPlaneEndpoint: localhost:8443
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd.yaml
@@ -26,7 +26,6 @@ apiServer:
 certificatesDir: /var/lib/minikube/certs
 clusterName: kubernetes
 controlPlaneEndpoint: localhost:8443
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio-options-gates.yaml
@@ -36,7 +36,6 @@ scheduler:
 certificatesDir: /var/lib/minikube/certs
 clusterName: kubernetes
 controlPlaneEndpoint: localhost:8443
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio.yaml
@@ -26,7 +26,6 @@ apiServer:
 certificatesDir: /var/lib/minikube/certs
 clusterName: kubernetes
 controlPlaneEndpoint: localhost:8443
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/default.yaml
@@ -26,7 +26,6 @@ apiServer:
 certificatesDir: /var/lib/minikube/certs
 clusterName: kubernetes
 controlPlaneEndpoint: localhost:8443
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/dns.yaml
@@ -26,7 +26,6 @@ apiServer:
 certificatesDir: /var/lib/minikube/certs
 clusterName: kubernetes
 controlPlaneEndpoint: localhost:8443
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/image-repository.yaml
@@ -27,7 +27,6 @@ apiServer:
 certificatesDir: /var/lib/minikube/certs
 clusterName: kubernetes
 controlPlaneEndpoint: localhost:8443
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/options.yaml
@@ -33,7 +33,6 @@ scheduler:
 certificatesDir: /var/lib/minikube/certs
 clusterName: kubernetes
 controlPlaneEndpoint: localhost:8443
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd-api-port.yaml
@@ -26,7 +26,6 @@ apiServer:
 certificatesDir: /var/lib/minikube/certs
 clusterName: kubernetes
 controlPlaneEndpoint: localhost:12345
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd-pod-network-cidr.yaml
@@ -26,7 +26,6 @@ apiServer:
 certificatesDir: /var/lib/minikube/certs
 clusterName: kubernetes
 controlPlaneEndpoint: localhost:8443
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd.yaml
@@ -26,7 +26,6 @@ apiServer:
 certificatesDir: /var/lib/minikube/certs
 clusterName: kubernetes
 controlPlaneEndpoint: localhost:8443
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/crio-options-gates.yaml
@@ -36,7 +36,6 @@ scheduler:
 certificatesDir: /var/lib/minikube/certs
 clusterName: kubernetes
 controlPlaneEndpoint: localhost:8443
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/crio.yaml
@@ -26,7 +26,6 @@ apiServer:
 certificatesDir: /var/lib/minikube/certs
 clusterName: kubernetes
 controlPlaneEndpoint: localhost:8443
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/default.yaml
@@ -26,7 +26,6 @@ apiServer:
 certificatesDir: /var/lib/minikube/certs
 clusterName: kubernetes
 controlPlaneEndpoint: localhost:8443
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/dns.yaml
@@ -26,7 +26,6 @@ apiServer:
 certificatesDir: /var/lib/minikube/certs
 clusterName: kubernetes
 controlPlaneEndpoint: localhost:8443
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/image-repository.yaml
@@ -27,7 +27,6 @@ apiServer:
 certificatesDir: /var/lib/minikube/certs
 clusterName: kubernetes
 controlPlaneEndpoint: localhost:8443
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/options.yaml
@@ -33,7 +33,6 @@ scheduler:
 certificatesDir: /var/lib/minikube/certs
 clusterName: kubernetes
 controlPlaneEndpoint: localhost:8443
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd-api-port.yaml
@@ -26,7 +26,6 @@ apiServer:
 certificatesDir: /var/lib/minikube/certs
 clusterName: kubernetes
 controlPlaneEndpoint: localhost:12345
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd-pod-network-cidr.yaml
@@ -26,7 +26,6 @@ apiServer:
 certificatesDir: /var/lib/minikube/certs
 clusterName: kubernetes
 controlPlaneEndpoint: localhost:8443
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd.yaml
@@ -26,7 +26,6 @@ apiServer:
 certificatesDir: /var/lib/minikube/certs
 clusterName: kubernetes
 controlPlaneEndpoint: localhost:8443
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/crio-options-gates.yaml
@@ -36,7 +36,6 @@ scheduler:
 certificatesDir: /var/lib/minikube/certs
 clusterName: kubernetes
 controlPlaneEndpoint: localhost:8443
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/crio.yaml
@@ -26,7 +26,6 @@ apiServer:
 certificatesDir: /var/lib/minikube/certs
 clusterName: kubernetes
 controlPlaneEndpoint: localhost:8443
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/default.yaml
@@ -26,7 +26,6 @@ apiServer:
 certificatesDir: /var/lib/minikube/certs
 clusterName: kubernetes
 controlPlaneEndpoint: localhost:8443
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/dns.yaml
@@ -26,7 +26,6 @@ apiServer:
 certificatesDir: /var/lib/minikube/certs
 clusterName: kubernetes
 controlPlaneEndpoint: localhost:8443
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/image-repository.yaml
@@ -27,7 +27,6 @@ apiServer:
 certificatesDir: /var/lib/minikube/certs
 clusterName: kubernetes
 controlPlaneEndpoint: localhost:8443
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/options.yaml
@@ -33,7 +33,6 @@ scheduler:
 certificatesDir: /var/lib/minikube/certs
 clusterName: kubernetes
 controlPlaneEndpoint: localhost:8443
-controllerManager: {}
 dns:
   type: CoreDNS
 etcd:


### PR DESCRIPTION
Signed-off-by: Richard Wall <richard.wall@jetstack.io>

Fixes: https://github.com/kubernetes/minikube/issues/7028