### PR TITLE
status: error properly if cluster does not exist

### DIFF
--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -98,6 +98,9 @@ var statusCmd = &cobra.Command{
 
 		cc, err := config.Load(viper.GetString(config.ProfileName))
 		if err != nil {
+			if config.IsNotExist(err) {
+				exit.WithCodeT(exitCode(&Status{}), `The "{{.name}}" cluster does not exist!`, out.V{"name": config.ProfileName})
+			}
 			exit.WithError("getting config", err)
 		}
 

--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -99,7 +99,7 @@ var statusCmd = &cobra.Command{
 		cc, err := config.Load(viper.GetString(config.ProfileName))
 		if err != nil {
 			if config.IsNotExist(err) {
-				exit.WithCodeT(exitCode(&Status{}), `The "{{.name}}" cluster does not exist!`, out.V{"name": config.ProfileName})
+				exit.WithCodeT(exitCode(&Status{}), `The "{{.name}}" cluster does not exist!`, out.V{"name": viper.GetString(config.ProfileName)})
 			}
 			exit.WithError("getting config", err)
 		}


### PR DESCRIPTION
Old UI, with exit code 70:

```
$ minikube status
💣  getting config: cluster "minikube" does not exist

😿  minikube is exiting due to an error. If the above message 
👉  https://github.com/kubernetes/minikube/issues/new/choose
```

New UI, with exit code 7 as per documentation:

```
💣  The "minikube" cluster does not exist!
```

