### PR TITLE
Make the image load lock configurable per runtime

### DIFF
--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -233,6 +233,12 @@ func (r *Containerd) ImageExists(name string, sha string) bool {
 	return true
 }
 
+// WantSingleLoadImage returns if LoadImage show load just one image
+func (r *Containerd) WantSingleLoadImage() bool {
+	// daemon will serialize as needed
+	return false
+}
+
 // LoadImage loads an image into this runtime
 func (r *Containerd) LoadImage(path string) error {
 	glog.Infof("Loading image: %s", path)

--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -153,6 +153,12 @@ func (r *CRIO) ImageExists(name string, sha string) bool {
 	return true
 }
 
+// WantSingleLoadImage returns if LoadImage show load just one image
+func (r *CRIO) WantSingleLoadImage() bool {
+	// no daemon to coordinate load
+	return true
+}
+
 // LoadImage loads an image into this runtime
 func (r *CRIO) LoadImage(path string) error {
 	glog.Infof("Loading image: %s", path)

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -81,6 +81,8 @@ type Manager interface {
 	// DefaultCNI returns whether to use CNI networking by default
 	DefaultCNI() bool
 
+	// WantSingleLoadImage returns if LoadImage show load just one image
+	WantSingleLoadImage() bool
 	// Load an image idempotently into the runtime on a host
 	LoadImage(string) error
 

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -148,6 +148,12 @@ func (r *Docker) ImageExists(name string, sha string) bool {
 	return true
 }
 
+// WantSingleLoadImage returns if LoadImage show load just one image
+func (r *Docker) WantSingleLoadImage() bool {
+	// daemon will serialize as needed
+	return false
+}
+
 // LoadImage loads an image into this runtime
 func (r *Docker) LoadImage(path string) error {
 	glog.Infof("Loading image: %s", path)

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -199,8 +199,10 @@ func transferAndLoadImage(cr command.Runner, k8s config.KubernetesConfig, imgNam
 		return errors.Wrap(err, "transferring cached image")
 	}
 
-	loadImageLock.Lock()
-	defer loadImageLock.Unlock()
+	if r.WantSingleLoadImage() {
+		loadImageLock.Lock()
+		defer loadImageLock.Unlock()
+	}
 
 	err = r.LoadImage(dst)
 	if err != nil {


### PR DESCRIPTION
The container runtimes that have a central server daemon to
coordinate loads, don't need to lock image load at each client.

We still need to limit the number of simultaneous loads for
runtimes that load directly, in order to not run of resources.

Closes #6992