### PR TITLE
Reduce complexity in the integration tests

### DIFF
--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -516,8 +516,7 @@ func validateLogsCmd(ctx context.Context, t *testing.T, profile string) {
 	}
 }
 
-// validateProfileCmd asserts "profile" command functionality
-func validateProfileCmd(ctx context.Context, t *testing.T, profile string) {
+func profileNotCreate(ctx context.Context, t *testing.T) {
 	t.Run("profile_not_create", func(t *testing.T) {
 		// Profile command should not create a nonexistent profile
 		nonexistentProfile := "lis"
@@ -543,7 +542,9 @@ func validateProfileCmd(ctx context.Context, t *testing.T, profile string) {
 			}
 		}
 	})
+}
 
+func profileList(ctx context.Context, t *testing.T, profile string) {
 	t.Run("profile_list", func(t *testing.T) {
 		// List profiles
 		rr, err := Run(t, exec.CommandContext(ctx, Target(), "profile", "list"))
@@ -566,7 +567,9 @@ func validateProfileCmd(ctx context.Context, t *testing.T, profile string) {
 		}
 
 	})
+}
 
+func profileJSONOutput(ctx context.Context, t *testing.T, profile string) {
 	t.Run("profile_json_output", func(t *testing.T) {
 		// Json output
 		rr, err := Run(t, exec.CommandContext(ctx, Target(), "profile", "list", "--output", "json"))
@@ -593,8 +596,14 @@ func validateProfileCmd(ctx context.Context, t *testing.T, profile string) {
 	})
 }
 
-// validateServiceCmd asserts basic "service" command functionality
-func validateServiceCmd(ctx context.Context, t *testing.T, profile string) {
+// validateProfileCmd asserts "profile" command functionality
+func validateProfileCmd(ctx context.Context, t *testing.T, profile string) {
+	profileNotCreate(ctx, t)
+	profileList(ctx, t, profile)
+	profileJSONOutput(ctx, t, profile)
+}
+
+func createHelloNodePods(ctx context.Context, t *testing.T, profile string) {
 	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "create", "deployment", "hello-node", "--image=gcr.io/hello-minikube-zero-install/hello-node"))
 	if err != nil {
 		t.Logf("%s failed: %v (may not be an error)", rr.Args, err)
@@ -607,8 +616,13 @@ func validateServiceCmd(ctx context.Context, t *testing.T, profile string) {
 	if _, err := PodWait(ctx, t, profile, "default", "app=hello-node", Minutes(10)); err != nil {
 		t.Fatalf("wait: %v", err)
 	}
+}
 
-	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "service", "list"))
+// validateServiceCmd asserts basic "service" command functionality
+func validateServiceCmd(ctx context.Context, t *testing.T, profile string) {
+	createHelloNodePods(ctx, t, profile)
+
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "service", "list"))
 	if err != nil {
 		t.Errorf("%s failed: %v", rr.Args, err)
 	}

--- a/test/integration/gvisor_addon_test.go
+++ b/test/integration/gvisor_addon_test.go
@@ -92,7 +92,11 @@ func TestGvisorAddon(t *testing.T) {
 		t.Fatalf("%s failed: %v", rr.Args, err)
 	}
 
-	rr, err = Run(t, exec.CommandContext(ctx, Target(), startArgs...))
+	runGvisorAddonTest(ctx, t, profile, startArgs)
+}
+
+func runGvisorAddonTest(ctx context.Context, t *testing.T, profile string, startArgs []string) {
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), startArgs...))
 	if err != nil {
 		t.Fatalf("%s failed: %v", rr.Args, err)
 	}


### PR DESCRIPTION
Split too large functions into smaller ones:

```
29 integration validateMountCmd test/integration/fn_mount_cmd.go:46:1
23 integration TestDownloadOnly test/integration/aaa_download_only_test.go:45:1
20 integration TestStartStop test/integration/start_stop_delete_test.go:38:1
18 integration validateTunnelCmd test/integration/fn_tunnel_cmd.go:40:1
18 integration TestGvisorAddon test/integration/gvisor_addon_test.go:28:1
17 integration validateServiceCmd test/integration/functional_test.go:597:1
16 integration validateProfileCmd test/integration/functional_test.go:520:1
```

This completes the go reportcard again:

Grade: A+ (100.0%)
Files: 4118
Issues: 0
gofmt: 100%
go_vet: 100%
golint: 100%
gocyclo: 100%
license: 100%
ineffassign: 100%
misspell: 100%

---

Hopefully I didn't break anything, haven't run the tests.

Use "ignore whitespace" (indent) when reviewing this...