### PR TITLE
Upgrade Docker driver to preferred (Linux), default on other platforms

### DIFF
--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"runtime"
 	"time"
 
 	"github.com/docker/machine/libmachine/drivers"
@@ -32,12 +33,21 @@ import (
 )
 
 func init() {
+	priority := registry.Default
+	// Staged rollout for preferred:
+	// - Linux
+	// - Windows (once "service" command works)
+	// - macOS
+	if runtime.GOOS == "linux" {
+		priority = registry.Preferred
+	}
+
 	if err := registry.Register(registry.DriverDef{
 		Name:     driver.Docker,
 		Config:   configure,
 		Init:     func() drivers.Driver { return kic.NewDriver(kic.Config{OCIBinary: oci.Docker}) },
 		Status:   status,
-		Priority: registry.Fallback,
+		Priority: priority,
 	}); err != nil {
 		panic(fmt.Sprintf("register failed: %v", err))
 	}


### PR DESCRIPTION
Docker driver seems pretty stable and usable now.

Still have some quirks to work out around disk space management and the service command.