### PR TITLE
If user doesn't specify driver, don't validate against existing cluster

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -496,6 +496,10 @@ func validateSpecifiedDriver(existing *config.ClusterConfig) {
 	} else if d := viper.GetString("vm-driver"); d != "" {
 		requested = d
 	}
+	// Neither --vm-driver or --driver was specified
+	if requested == "" {
+		return
+	}
 	if old == requested {
 		return
 	}


### PR DESCRIPTION
```
$ minikube start --driver docker
😄  minikube v1.9.0-beta.1 on Darwin 10.14.6
✨  Using the docker driver based on user configuration
🔥  Creating Kubernetes in docker container with (CPUs=2) (8 available), Memory=1988MB (1988MB available) ...
🐳  Preparing Kubernetes v1.18.0-rc.1 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16
    > kubectl.sha256: 65 B / 65 B [--------------------------] 100.00% ? p/s 0s
    > kubeadm.sha256: 65 B / 65 B [--------------------------] 100.00% ? p/s 0s
    > kubelet.sha256: 65 B / 65 B [--------------------------] 100.00% ? p/s 0s
    > kubectl: 41.99 MiB / 41.99 MiB [---------------] 100.00% 1.72 MiB p/s 25s
    > kubeadm: 37.97 MiB / 37.97 MiB [---------------] 100.00% 1.50 MiB p/s 26s
    > kubelet: 108.02 MiB / 108.02 MiB [-------------] 100.00% 1.99 MiB p/s 55s
🚀  Launching Kubernetes ... 
🌟  Enabling addons: default-storageclass, storage-provisioner
⌛  Waiting for cluster to come online ...
🏄  Done! kubectl is now configured to use "minikube"

❗  /usr/local/bin/kubectl is v1.16.1, which may be incompatible with Kubernetes v1.18.0-rc.1.
💡  You can also use 'minikube kubectl -- get pods' to invoke a matching version

$ minikube start 
😄  minikube v1.9.0-beta.1 on Darwin 10.14.6
✨  Using the docker driver based on existing profile
⌛  Reconfiguring existing host ...
🏃  Using the running docker "minikube" container ...
🐳  Preparing Kubernetes v1.18.0-rc.1 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16
🚀  Launching Kubernetes ... 
🌟  Enabling addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube"

❗  /usr/local/bin/kubectl is v1.16.1, which may be incompatible with Kubernetes v1.18.0-rc.1.
💡  You can also use 'minikube kubectl -- get pods' to invoke a matching version
```



Should fix #7095