### PR TITLE
Upgrade dashboard to v2.0.0-rc6

### DIFF
--- a/deploy/addons/dashboard/dashboard-dp.yaml
+++ b/deploy/addons/dashboard/dashboard-dp.yaml
@@ -90,7 +90,7 @@ spec:
       containers:
         - name: kubernetes-dashboard
           # WARNING: This must match pkg/minikube/bootstrapper/images/images.go
-          image: kubernetesui/dashboard:v2.0.0-beta8
+          image: kubernetesui/dashboard:v2.0.0-rc6
           ports:
             - containerPort: 9090
               protocol: TCP

--- a/pkg/minikube/bootstrapper/images/images.go
+++ b/pkg/minikube/bootstrapper/images/images.go
@@ -135,7 +135,7 @@ func dashboardFrontend(repo string) string {
 		repo = "kubernetesui"
 	}
 	// See 'kubernetes-dashboard' in deploy/addons/dashboard/dashboard-dp.yaml
-	return path.Join(repo, "dashboard:v2.0.0-beta8")
+	return path.Join(repo, "dashboard:v2.0.0-rc6")
 }
 
 // dashboardMetrics returns the image used for the dashboard metrics scraper

--- a/pkg/minikube/bootstrapper/images/images_test.go
+++ b/pkg/minikube/bootstrapper/images/images_test.go
@@ -25,7 +25,7 @@ import (
 func TestAuxiliary(t *testing.T) {
 	want := []string{
 		"gcr.io/k8s-minikube/storage-provisioner:v1.8.1",
-		"kubernetesui/dashboard:v2.0.0-beta8",
+		"kubernetesui/dashboard:v2.0.0-rc6",
 		"kubernetesui/metrics-scraper:v1.0.2",
 	}
 	got := auxiliary("")
@@ -37,7 +37,7 @@ func TestAuxiliary(t *testing.T) {
 func TestAuxiliaryMirror(t *testing.T) {
 	want := []string{
 		"test.mirror/storage-provisioner:v1.8.1",
-		"test.mirror/dashboard:v2.0.0-beta8",
+		"test.mirror/dashboard:v2.0.0-rc6",
 		"test.mirror/metrics-scraper:v1.0.2",
 	}
 	got := auxiliary("test.mirror")

--- a/pkg/minikube/bootstrapper/images/kubeadm_test.go
+++ b/pkg/minikube/bootstrapper/images/kubeadm_test.go
@@ -38,7 +38,7 @@ func TestKubeadmImages(t *testing.T) {
 			"k8s.gcr.io/etcd:3.4.3-0",
 			"k8s.gcr.io/pause:3.1",
 			"gcr.io/k8s-minikube/storage-provisioner:v1.8.1",
-			"kubernetesui/dashboard:v2.0.0-beta8",
+			"kubernetesui/dashboard:v2.0.0-rc6",
 			"kubernetesui/metrics-scraper:v1.0.2",
 		}},
 		{"v1.16.1", "mirror.k8s.io", []string{
@@ -50,7 +50,7 @@ func TestKubeadmImages(t *testing.T) {
 			"mirror.k8s.io/etcd:3.3.15-0",
 			"mirror.k8s.io/pause:3.1",
 			"mirror.k8s.io/storage-provisioner:v1.8.1",
-			"mirror.k8s.io/dashboard:v2.0.0-beta8",
+			"mirror.k8s.io/dashboard:v2.0.0-rc6",
 			"mirror.k8s.io/metrics-scraper:v1.0.2",
 		}},
 		{"v1.15.0", "", []string{
@@ -62,7 +62,7 @@ func TestKubeadmImages(t *testing.T) {
 			"k8s.gcr.io/etcd:3.3.10",
 			"k8s.gcr.io/pause:3.1",
 			"gcr.io/k8s-minikube/storage-provisioner:v1.8.1",
-			"kubernetesui/dashboard:v2.0.0-beta8",
+			"kubernetesui/dashboard:v2.0.0-rc6",
 			"kubernetesui/metrics-scraper:v1.0.2",
 		}},
 		{"v1.14.0", "", []string{
@@ -74,7 +74,7 @@ func TestKubeadmImages(t *testing.T) {
 			"k8s.gcr.io/etcd:3.3.10",
 			"k8s.gcr.io/pause:3.1",
 			"gcr.io/k8s-minikube/storage-provisioner:v1.8.1",
-			"kubernetesui/dashboard:v2.0.0-beta8",
+			"kubernetesui/dashboard:v2.0.0-rc6",
 			"kubernetesui/metrics-scraper:v1.0.2",
 		}},
 		{"v1.13.0", "", []string{
@@ -86,7 +86,7 @@ func TestKubeadmImages(t *testing.T) {
 			"k8s.gcr.io/etcd:3.2.24",
 			"k8s.gcr.io/pause:3.1",
 			"gcr.io/k8s-minikube/storage-provisioner:v1.8.1",
-			"kubernetesui/dashboard:v2.0.0-beta8",
+			"kubernetesui/dashboard:v2.0.0-rc6",
 			"kubernetesui/metrics-scraper:v1.0.2",
 		}},
 		{"v1.12.0", "", []string{
@@ -98,7 +98,7 @@ func TestKubeadmImages(t *testing.T) {
 			"k8s.gcr.io/etcd:3.2.24",
 			"k8s.gcr.io/pause:3.1",
 			"gcr.io/k8s-minikube/storage-provisioner:v1.8.1",
-			"kubernetesui/dashboard:v2.0.0-beta8",
+			"kubernetesui/dashboard:v2.0.0-rc6",
 			"kubernetesui/metrics-scraper:v1.0.2",
 		}},
 		{"v1.11.10", "", []string{
@@ -110,7 +110,7 @@ func TestKubeadmImages(t *testing.T) {
 			"k8s.gcr.io/etcd-amd64:3.2.18",
 			"k8s.gcr.io/pause:3.1",
 			"gcr.io/k8s-minikube/storage-provisioner:v1.8.1",
-			"kubernetesui/dashboard:v2.0.0-beta8",
+			"kubernetesui/dashboard:v2.0.0-rc6",
 			"kubernetesui/metrics-scraper:v1.0.2",
 		}},
 	}

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -37,7 +37,9 @@ import (
 
 const (
 	// PreloadVersion is the current version of the preloaded tarball
-	PreloadVersion = "v1"
+	//
+	// NOTE: You may need to bump this version up when upgrading auxiliary docker images
+	PreloadVersion = "v2"
 	// PreloadBucket is the name of the GCS bucket where preloaded volume tarballs exist
 	PreloadBucket = "minikube-preloaded-volume-tarballs"
 )


### PR DESCRIPTION
Also updates PreloadVersion to avoid version mismatches with older minikube releases.