### PR TITLE
Only run deleteHosts if running a VM

### DIFF
--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -239,9 +239,7 @@ func deleteProfile(profile *config.Profile) error {
 		out.T(out.FailureType, "Failed to kill mount process: {{.error}}", out.V{"error": err})
 	}
 
-	if driver.IsVM(cc.Driver) {
-		deleteHosts(api, cc)
-	}
+	deleteHosts(api, cc)
 
 	// In case DeleteHost didn't complete the job.
 	deleteProfileDirectory(profile.Name)

--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -239,7 +239,9 @@ func deleteProfile(profile *config.Profile) error {
 		out.T(out.FailureType, "Failed to kill mount process: {{.error}}", out.V{"error": err})
 	}
 
-	deleteHosts(api, cc)
+	if driver.IsVM(cc.Driver) {
+		deleteHosts(api, cc)
+	}
 
 	// In case DeleteHost didn't complete the job.
 	deleteProfileDirectory(profile.Name)

--- a/pkg/minikube/machine/delete.go
+++ b/pkg/minikube/machine/delete.go
@@ -66,8 +66,9 @@ func DeleteHost(api libmachine.API, machineName string) error {
 	// Get the status of the host. Ensure that it exists before proceeding ahead.
 	status, err := Status(api, machineName)
 	if err != nil {
-		// Warn, but proceed
-		out.WarningT(`Unable to get host status for "{{.name}}": {{.error}}`, out.V{"name": machineName, "error": err})
+		// Assume that the host has already been deleted, log and return
+		glog.Infof("Unable to get host status for %s, assuming it has already been deleted: %v", machineName, err)
+		return nil
 	}
 
 	if status == state.None.String() {


### PR DESCRIPTION
If minikube is started with the docker driver, all containers and volumes will be deleted in the call to `deleteProfileContainersAndVolumes`. If we then try to call `deleteHosts` on it, we get this warning:

```
❗  Unable to get host status for "minikube": state: docker inspect -f {{.State.Status}} minikube: Error: No such object: minikube: exit status 1
```

which will always happen because we've already deleted the container.

cc @medyagh does this seem reasonable to you?

Should fix #7097