### PR TITLE
Use -f to remove up to 6s of of delay disabling containerd.

### DIFF
--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -217,7 +217,7 @@ func (r *Containerd) Enable(disOthers bool) error {
 
 // Disable idempotently disables containerd on a host
 func (r *Containerd) Disable() error {
-	c := exec.Command("sudo", "systemctl", "stop", "containerd")
+	c := exec.Command("sudo", "systemctl", "stop", "-f", "containerd")
 	if _, err := r.Runner.RunCmd(c); err != nil {
 		return errors.Wrapf(err, "stop containerd")
 	}

--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -133,7 +133,7 @@ func (r *CRIO) Enable(disOthers bool) error {
 
 // Disable idempotently disables CRIO on a host
 func (r *CRIO) Disable() error {
-	if _, err := r.Runner.RunCmd(exec.Command("sudo", "systemctl", "stop", "crio")); err != nil {
+	if _, err := r.Runner.RunCmd(exec.Command("sudo", "systemctl", "stop", "-f", "crio")); err != nil {
 		return errors.Wrapf(err, "disable crio.")
 	}
 	return nil

--- a/pkg/minikube/cruntime/cruntime_test.go
+++ b/pkg/minikube/cruntime/cruntime_test.go
@@ -408,6 +408,10 @@ func (f *FakeRunner) crictl(args []string, _ bool) (string, error) {
 func (f *FakeRunner) systemctl(args []string, root bool) (string, error) { // nolint result 0 (string) is always ""
 	action := args[0]
 	svcs := args[1:]
+	// force
+	if svcs[0] == "-f" {
+		svcs = svcs[1:]
+	}
 	out := ""
 
 	for i, arg := range args {
@@ -503,9 +507,9 @@ func TestDisable(t *testing.T) {
 		runtime string
 		want    []string
 	}{
-		{"docker", []string{"sudo", "systemctl", "stop", "docker", "docker.socket"}},
-		{"crio", []string{"sudo", "systemctl", "stop", "crio"}},
-		{"containerd", []string{"sudo", "systemctl", "stop", "containerd"}},
+		{"docker", []string{"sudo", "systemctl", "stop", "-f", "docker", "docker.socket"}},
+		{"crio", []string{"sudo", "systemctl", "stop", "-f", "crio"}},
+		{"containerd", []string{"sudo", "systemctl", "stop", "-f", "containerd"}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.runtime, func(t *testing.T) {

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -127,7 +127,7 @@ func (r *Docker) Restart() error {
 
 // Disable idempotently disables Docker on a host
 func (r *Docker) Disable() error {
-	c := exec.Command("sudo", "systemctl", "stop", "docker", "docker.socket")
+	c := exec.Command("sudo", "systemctl", "stop", "-f", "docker", "docker.socket")
 	if _, err := r.Runner.RunCmd(c); err != nil {
 		return errors.Wrap(err, "disable docker")
 	}


### PR DESCRIPTION
Silly quirk I noticed while debugging #7102

Based on my observations, this can improve the performance of KIC startup by up to 6 seconds.