### PR TITLE
provisioner: only reload docker if necessary, don't install curl

### DIFF
--- a/pkg/minikube/machine/client.go
+++ b/pkg/minikube/machine/client.go
@@ -172,6 +172,7 @@ func (api *LocalClient) Create(h *host.Host) error {
 		return fmt.Errorf("driver %q does not exist", h.DriverName)
 	}
 	if def.Init == nil {
+		// NOTE: This will call provision.DetectProvisioner
 		return api.legacyClient.Create(h)
 	}
 

--- a/pkg/provision/buildroot.go
+++ b/pkg/provision/buildroot.go
@@ -19,18 +19,16 @@ package provision
 import (
 	"bytes"
 	"fmt"
-	"path"
 	"text/template"
 	"time"
 
 	"github.com/docker/machine/libmachine/auth"
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/engine"
-	"github.com/docker/machine/libmachine/log"
 	"github.com/docker/machine/libmachine/provision"
 	"github.com/docker/machine/libmachine/provision/pkgaction"
-	"github.com/docker/machine/libmachine/provision/serviceaction"
 	"github.com/docker/machine/libmachine/swarm"
+	"github.com/golang/glog"
 	"k8s.io/minikube/pkg/util/retry"
 )
 
@@ -42,7 +40,7 @@ type BuildrootProvisioner struct {
 // NewBuildrootProvisioner creates a new BuildrootProvisioner
 func NewBuildrootProvisioner(d drivers.Driver) provision.Provisioner {
 	return &BuildrootProvisioner{
-		provision.NewSystemdProvisioner("buildroot", d),
+		NewSystemdProvisioner("buildroot", d),
 	}
 }
 
@@ -65,7 +63,7 @@ func (p *BuildrootProvisioner) GenerateDockerOptions(dockerPort int) (*provision
 	noPivot := true
 	// Using pivot_root is not supported on fstype rootfs
 	if fstype, err := rootFileSystemType(p); err == nil {
-		log.Debugf("root file system type: %s", fstype)
+		glog.Infof("root file system type: %s", fstype)
 		noPivot = fstype == "rootfs"
 	}
 
@@ -79,7 +77,7 @@ Requires= minikube-automount.service docker.socket
 Type=notify
 `
 	if noPivot {
-		log.Warn("Using fundamentally insecure --no-pivot option")
+		glog.Warning("Using fundamentally insecure --no-pivot option")
 		engineConfigTmpl += `
 # DOCKER_RAMDISK disables pivot_root in Docker, using MS_MOVE instead.
 Environment=DOCKER_RAMDISK=yes
@@ -140,30 +138,11 @@ WantedBy=multi-user.target
 		return nil, err
 	}
 
-	dockerCfg := &provision.DockerOptions{
+	do := &provision.DockerOptions{
 		EngineOptions:     engineCfg.String(),
 		EngineOptionsPath: "/lib/systemd/system/docker.service",
 	}
-
-	log.Info("Setting Docker configuration on the remote daemon...")
-
-	if _, err = p.SSHCommand(fmt.Sprintf("sudo mkdir -p %s && printf %%s \"%s\" | sudo tee %s", path.Dir(dockerCfg.EngineOptionsPath), dockerCfg.EngineOptions, dockerCfg.EngineOptionsPath)); err != nil {
-		return nil, err
-	}
-
-	// To make sure if there is a already-installed docker on the ISO to pick up the new systemd file
-	if err := p.Service("", serviceaction.DaemonReload); err != nil {
-		return nil, err
-	}
-
-	if err := p.Service("docker", serviceaction.Enable); err != nil {
-		return nil, err
-	}
-
-	if err := p.Service("docker", serviceaction.Restart); err != nil {
-		return nil, err
-	}
-	return dockerCfg, nil
+	return do, updateUnit(p, "docker", do.EngineOptions, do.EngineOptionsPath)
 }
 
 // Package installs a package
@@ -177,18 +156,18 @@ func (p *BuildrootProvisioner) Provision(swarmOptions swarm.Options, authOptions
 	p.AuthOptions = authOptions
 	p.EngineOptions = engineOptions
 
-	log.Infof("provisioning hostname %q", p.Driver.GetMachineName())
+	glog.Infof("provisioning hostname %q", p.Driver.GetMachineName())
 	if err := p.SetHostname(p.Driver.GetMachineName()); err != nil {
 		return err
 	}
 
 	p.AuthOptions = setRemoteAuthOptions(p)
-	log.Debugf("set auth options %+v", p.AuthOptions)
+	glog.Infof("set auth options %+v", p.AuthOptions)
 
-	log.Debugf("setting up certificates")
+	glog.Infof("setting up certificates")
 	configAuth := func() error {
 		if err := configureAuth(p); err != nil {
-			log.Warnf("configureAuth failed: %v", err)
+			glog.Warningf("configureAuth failed: %v", err)
 			return &retry.RetriableError{Err: err}
 		}
 		return nil
@@ -196,13 +175,13 @@ func (p *BuildrootProvisioner) Provision(swarmOptions swarm.Options, authOptions
 
 	err := retry.Expo(configAuth, time.Second, 2*time.Minute)
 	if err != nil {
-		log.Debugf("Error configuring auth during provisioning %v", err)
+		glog.Infof("Error configuring auth during provisioning %v", err)
 		return err
 	}
 
-	log.Debugf("setting minikube options for container-runtime")
+	glog.Infof("setting minikube options for container-runtime")
 	if err := setContainerRuntimeOptions(p.Driver.GetMachineName(), p); err != nil {
-		log.Debugf("Error setting container-runtime options during provisioning %v", err)
+		glog.Infof("Error setting container-runtime options during provisioning %v", err)
 		return err
 	}
 

--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -31,10 +31,10 @@ import (
 	"github.com/docker/machine/libmachine/cert"
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/engine"
-	"github.com/docker/machine/libmachine/log"
 	"github.com/docker/machine/libmachine/mcnutils"
 	"github.com/docker/machine/libmachine/provision"
 	"github.com/docker/machine/libmachine/swarm"
+	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/command"
@@ -66,11 +66,24 @@ func init() {
 
 }
 
+// NewSystemdProvisioner is our fork of the same name in the upstream provision library, without the packages
+func NewSystemdProvisioner(osReleaseID string, d drivers.Driver) provision.SystemdProvisioner {
+	return provision.SystemdProvisioner{
+		provision.GenericProvisioner{
+			SSHCommander:      provision.GenericSSHCommander{Driver: d},
+			DockerOptionsDir:  "/etc/docker",
+			DaemonOptionsFile: "/etc/systemd/system/docker.service.d/10-machine.conf",
+			OsReleaseID:       osReleaseID,
+			Driver:            d,
+		},
+	}
+}
+
 func configureAuth(p miniProvisioner) error {
-	log.Infof("configureAuth start")
+	glog.Infof("configureAuth start")
 	start := time.Now()
 	defer func() {
-		log.Infof("configureAuth took %s", time.Since(start))
+		glog.Infof("configureAuth took %s", time.Since(start))
 	}()
 
 	driver := p.GetDriver()
@@ -90,7 +103,7 @@ func configureAuth(p miniProvisioner) error {
 
 	// The Host IP is always added to the certificate's SANs list
 	hosts := append(authOptions.ServerCertSANs, ip, "localhost", "127.0.0.1")
-	log.Debugf("generating server cert: %s ca-key=%s private-key=%s org=%s san=%s",
+	glog.Infof("generating server cert: %s ca-key=%s private-key=%s org=%s san=%s",
 		authOptions.ServerCertPath,
 		authOptions.CaCertPath,
 		authOptions.CaPrivateKeyPath,
@@ -116,11 +129,11 @@ func configureAuth(p miniProvisioner) error {
 }
 
 func copyHostCerts(authOptions auth.Options) error {
-	log.Infof("copyHostCerts")
+	glog.Infof("copyHostCerts")
 
 	err := os.MkdirAll(authOptions.StorePath, 0700)
 	if err != nil {
-		log.Errorf("mkdir failed: %v", err)
+		glog.Errorf("mkdir failed: %v", err)
 	}
 
 	hostCerts := map[string]string{
@@ -144,7 +157,7 @@ func copyHostCerts(authOptions auth.Options) error {
 }
 
 func copyRemoteCerts(authOptions auth.Options, driver drivers.Driver) error {
-	log.Infof("copyRemoteCerts")
+	glog.Infof("copyRemoteCerts")
 
 	remoteCerts := map[string]string{
 		authOptions.CaCertPath:     authOptions.CaCertRemotePath,
@@ -275,4 +288,17 @@ func concatStrings(src []string, prefix string, postfix string) []string {
 		buf.Reset()
 	}
 	return ret
+}
+
+// updateUnit efficiently updates a systemd unit file
+func updateUnit(p provision.SSHCommander, name string, content string, dst string) error {
+	glog.Infof("Updating %s ...", dst)
+
+	if _, err := p.SSHCommand(fmt.Sprintf("sudo mkdir -p %s && printf %%s \"%s\" | sudo tee %s.new", path.Dir(dst), content, dst)); err != nil {
+		return err
+	}
+	if _, err := p.SSHCommand(fmt.Sprintf("sudo diff -u %s %s.new || { sudo mv %s.new %s; sudo systemctl -f daemon-reload && sudo sudo systemctl -f restart docker; }", dst, dst, dst, dst)); err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -69,7 +69,7 @@ func init() {
 // NewSystemdProvisioner is our fork of the same name in the upstream provision library, without the packages
 func NewSystemdProvisioner(osReleaseID string, d drivers.Driver) provision.SystemdProvisioner {
 	return provision.SystemdProvisioner{
-		provision.GenericProvisioner{
+		GenericProvisioner: provision.GenericProvisioner{
 			SSHCommander:      provision.GenericSSHCommander{Driver: d},
 			DockerOptionsDir:  "/etc/docker",
 			DaemonOptionsFile: "/etc/systemd/system/docker.service.d/10-machine.conf",
@@ -292,12 +292,12 @@ func concatStrings(src []string, prefix string, postfix string) []string {
 
 // updateUnit efficiently updates a systemd unit file
 func updateUnit(p provision.SSHCommander, name string, content string, dst string) error {
-	glog.Infof("Updating %s ...", dst)
+	glog.Infof("Updating %s unit: %s ...", name, dst)
 
 	if _, err := p.SSHCommand(fmt.Sprintf("sudo mkdir -p %s && printf %%s \"%s\" | sudo tee %s.new", path.Dir(dst), content, dst)); err != nil {
 		return err
 	}
-	if _, err := p.SSHCommand(fmt.Sprintf("sudo diff -u %s %s.new || { sudo mv %s.new %s; sudo systemctl -f daemon-reload && sudo sudo systemctl -f restart docker; }", dst, dst, dst, dst)); err != nil {
+	if _, err := p.SSHCommand(fmt.Sprintf("sudo diff -u %s %s.new || { sudo mv %s.new %s; sudo systemctl -f daemon-reload && sudo sudo systemctl -f restart %s; }", dst, dst, dst, dst, name)); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/provision/ubuntu.go
+++ b/pkg/provision/ubuntu.go
@@ -19,18 +19,16 @@ package provision
 import (
 	"bytes"
 	"fmt"
-	"path"
 	"text/template"
 	"time"
 
 	"github.com/docker/machine/libmachine/auth"
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/engine"
-	"github.com/docker/machine/libmachine/log"
 	"github.com/docker/machine/libmachine/provision"
 	"github.com/docker/machine/libmachine/provision/pkgaction"
-	"github.com/docker/machine/libmachine/provision/serviceaction"
 	"github.com/docker/machine/libmachine/swarm"
+	"github.com/golang/glog"
 	"k8s.io/minikube/pkg/util/retry"
 )
 
@@ -43,7 +41,7 @@ type UbuntuProvisioner struct {
 func NewUbuntuProvisioner(d drivers.Driver) provision.Provisioner {
 	return &UbuntuProvisioner{
 		BuildrootProvisioner{
-			provision.NewSystemdProvisioner("ubuntu", d),
+			NewSystemdProvisioner("ubuntu", d),
 		},
 	}
 }
@@ -67,7 +65,7 @@ func (p *UbuntuProvisioner) GenerateDockerOptions(dockerPort int) (*provision.Do
 	noPivot := true
 	// Using pivot_root is not supported on fstype rootfs
 	if fstype, err := rootFileSystemType(p); err == nil {
-		log.Debugf("root file system type: %s", fstype)
+		glog.Infof("root file system type: %s", fstype)
 		noPivot = fstype == "rootfs"
 	}
 
@@ -83,7 +81,7 @@ Requires=docker.socket
 Type=notify
 `
 	if noPivot {
-		log.Warn("Using fundamentally insecure --no-pivot option")
+		glog.Warning("Using fundamentally insecure --no-pivot option")
 		engineConfigTmpl += `
 # DOCKER_RAMDISK disables pivot_root in Docker, using MS_MOVE instead.
 Environment=DOCKER_RAMDISK=yes
@@ -144,30 +142,11 @@ WantedBy=multi-user.target
 		return nil, err
 	}
 
-	dockerCfg := &provision.DockerOptions{
+	do := &provision.DockerOptions{
 		EngineOptions:     engineCfg.String(),
 		EngineOptionsPath: "/lib/systemd/system/docker.service",
 	}
-
-	log.Info("Setting Docker configuration on the remote daemon...")
-
-	if _, err = p.SSHCommand(fmt.Sprintf("sudo mkdir -p %s && printf %%s \"%s\" | sudo tee %s", path.Dir(dockerCfg.EngineOptionsPath), dockerCfg.EngineOptions, dockerCfg.EngineOptionsPath)); err != nil {
-		return nil, err
-	}
-
-	// because in kic base image we pre-install docker it already has a service file. we need to daemon-reload for the new systemd file
-	if err := p.Service("", serviceaction.DaemonReload); err != nil {
-		return nil, err
-	}
-
-	if err := p.Service("docker", serviceaction.Enable); err != nil {
-		return nil, err
-	}
-
-	if err := p.Service("docker", serviceaction.Restart); err != nil {
-		return nil, err
-	}
-	return dockerCfg, nil
+	return do, updateUnit(p, "docker", do.EngineOptions, do.EngineOptionsPath)
 }
 
 // Package installs a package
@@ -181,32 +160,33 @@ func (p *UbuntuProvisioner) Provision(swarmOptions swarm.Options, authOptions au
 	p.AuthOptions = authOptions
 	p.EngineOptions = engineOptions
 
-	log.Infof("provisioning hostname %q", p.Driver.GetMachineName())
+	glog.Infof("provisioning hostname %q", p.Driver.GetMachineName())
 	if err := p.SetHostname(p.Driver.GetMachineName()); err != nil {
 		return err
 	}
 
 	p.AuthOptions = setRemoteAuthOptions(p)
-	log.Debugf("set auth options %+v", p.AuthOptions)
+	glog.Infof("set auth options %+v", p.AuthOptions)
 
-	log.Debugf("setting up certificates")
+	glog.Infof("setting up certificates")
 	configAuth := func() error {
 		if err := configureAuth(p); err != nil {
-			log.Warnf("configureAuth failed: %v", err)
+			glog.Warningf("configureAuth failed: %v", err)
 			return &retry.RetriableError{Err: err}
 		}
 		return nil
 	}
 
 	err := retry.Expo(configAuth, time.Second, 2*time.Minute)
+
 	if err != nil {
-		log.Debugf("Error configuring auth during provisioning %v", err)
+		glog.Infof("Error configuring auth during provisioning %v", err)
 		return err
 	}
 
-	log.Debugf("setting minikube options for container-runtime")
+	glog.Infof("setting minikube options for container-runtime")
 	if err := setContainerRuntimeOptions(p.Driver.GetMachineName(), p); err != nil {
-		log.Debugf("Error setting container-runtime options during provisioning %v", err)
+		glog.Infof("Error setting container-runtime options during provisioning %v", err)
 		return err
 	}
 


### PR DESCRIPTION
This modernizes the provisioner in three important ways:

* Only calls systemctl reload/restart if docker file has been updated - fixes #7103
* Adds it's own `NewSystemdProvisioner` to avoid unnecessary `apt-get` commands to install curl.
* Uses `glog` for consistency with rest of minikube codebase

This PR improves "minikube start" performance on an already running cluster by a second or so.