### PR TITLE
exit earlier if the driver is invalid

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -465,13 +465,19 @@ func selectDriver(existing *config.ClusterConfig) registry.DriverState {
 			out.T(out.Warning, warning, out.V{"driver": d, "vmd": vmd})
 		}
 		ds := driver.Status(d)
+		if ds.Name == "" {
+			exit.WithCodeT(exit.Unavailable, "The driver '{{.driver}}' is not supported on {{.os}}", out.V{"driver": d, "os": runtime.GOOS})
+		}
 		out.T(out.Sparkle, `Using the {{.driver}} driver based on user configuration`, out.V{"driver": ds.String()})
 		return ds
 	}
 
 	// Fallback to old driver parameter
-	if viper.GetString("vm-driver") != "" {
+	if d := viper.GetString("vm-driver"); d != "" {
 		ds := driver.Status(viper.GetString("vm-driver"))
+		if ds.Name == "" {
+			exit.WithCodeT(exit.Unavailable, "The driver '{{.driver}}' is not supported on {{.os}}", out.V{"driver": d, "os": runtime.GOOS})
+		}
 		out.T(out.Sparkle, `Using the {{.driver}} driver based on user configuration`, out.V{"driver": ds.String()})
 		return ds
 	}
@@ -551,7 +557,7 @@ func validateDriver(ds registry.DriverState, existing *config.ClusterConfig) {
 	name := ds.Name
 	glog.Infof("validating driver %q against %+v", name, existing)
 	if !driver.Supported(name) {
-		exit.WithCodeT(exit.Unavailable, "The driver {{.experimental}} '{{.driver}}' is not supported on {{.os}}", out.V{"driver": name, "os": runtime.GOOS})
+		exit.WithCodeT(exit.Unavailable, "The driver '{{.driver}}' is not supported on {{.os}}", out.V{"driver": name, "os": runtime.GOOS})
 	}
 
 	st := ds.State

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -19,12 +19,15 @@ package driver
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"sort"
 	"strings"
 
 	"github.com/golang/glog"
 	"k8s.io/minikube/pkg/drivers/kic"
 	"k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/exit"
+	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/registry"
 )
 
@@ -214,6 +217,9 @@ func Suggest(options []registry.DriverState) (registry.DriverState, []registry.D
 // Status returns the status of a driver
 func Status(name string) registry.DriverState {
 	d := registry.Driver(name)
+	if d.Empty() {
+		exit.WithCodeT(exit.Unavailable, "The driver '{{.driver}}' is not supported on {{.os}}", out.V{"driver": name, "os": runtime.GOOS})
+	}
 	return registry.DriverState{
 		Name:     d.Name,
 		Priority: d.Priority,

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -19,15 +19,12 @@ package driver
 import (
 	"fmt"
 	"os"
-	"runtime"
 	"sort"
 	"strings"
 
 	"github.com/golang/glog"
 	"k8s.io/minikube/pkg/drivers/kic"
 	"k8s.io/minikube/pkg/minikube/config"
-	"k8s.io/minikube/pkg/minikube/exit"
-	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/registry"
 )
 
@@ -217,9 +214,6 @@ func Suggest(options []registry.DriverState) (registry.DriverState, []registry.D
 // Status returns the status of a driver
 func Status(name string) registry.DriverState {
 	d := registry.Driver(name)
-	if d.Empty() {
-		exit.WithCodeT(exit.Unavailable, "The driver '{{.driver}}' is not supported on {{.os}}", out.V{"driver": name, "os": runtime.GOOS})
-	}
 	return registry.DriverState{
 		Name:     d.Name,
 		Priority: d.Priority,


### PR DESCRIPTION
Before:
```
sudo out/minikube start --driver=none
😄  minikube v1.9.0-beta.1 on Darwin 10.14.6
✨  Using the  driver based on user configuration
💣  The driver <no value> '' is not supported on darwin
```

After:
```
sudo out/minikube start --driver=none
😄  minikube v1.9.0-beta.1 on Darwin 10.14.6
💣  The driver 'none' is not supported on darwin
```