### PR TITLE
Wait 30 seconds before spamming console with error logs

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/kverify/kverify.go
+++ b/pkg/minikube/bootstrapper/bsutil/kverify/kverify.go
@@ -40,17 +40,18 @@ import (
 	"k8s.io/minikube/pkg/minikube/logs"
 )
 
+// minLogCheckTime how long to wait before spamming error logs to console
+const minLogCheckTime = 30 * time.Second
+
 // WaitForAPIServerProcess waits for api server to be healthy returns error if it doesn't
 func WaitForAPIServerProcess(r cruntime.Manager, bs bootstrapper.Bootstrapper, cr command.Runner, start time.Time, timeout time.Duration) error {
 	glog.Infof("waiting for apiserver process to appear ...")
-	minLogTime := kconst.APICallRetryInterval * 10
-
 	err := wait.PollImmediate(time.Millisecond*500, timeout, func() (bool, error) {
 		if time.Since(start) > timeout {
 			return false, fmt.Errorf("cluster wait timed out during process check")
 		}
 
-		if time.Since(start) > minLogTime {
+		if time.Since(start) > minLogCheckTime {
 			announceProblems(r, bs, cr)
 			time.Sleep(kconst.APICallRetryInterval * 5)
 		}
@@ -81,13 +82,12 @@ func apiServerPID(cr command.Runner) (int, error) {
 func WaitForSystemPods(r cruntime.Manager, bs bootstrapper.Bootstrapper, cr command.Runner, client *kubernetes.Clientset, start time.Time, timeout time.Duration) error {
 	glog.Info("waiting for kube-system pods to appear ...")
 	pStart := time.Now()
-	minLogTime := kconst.APICallRetryInterval * 10
 
 	podList := func() (bool, error) {
 		if time.Since(start) > timeout {
 			return false, fmt.Errorf("cluster wait timed out during pod check")
 		}
-		if time.Since(start) > minLogTime {
+		if time.Since(start) > minLogCheckTime {
 			announceProblems(r, bs, cr)
 			time.Sleep(kconst.APICallRetryInterval * 5)
 		}
@@ -116,13 +116,12 @@ func WaitForHealthyAPIServer(r cruntime.Manager, bs bootstrapper.Bootstrapper, c
 	glog.Infof("waiting for apiserver healthz status ...")
 	hStart := time.Now()
 
-	minLogTime := kconst.APICallRetryInterval * 10
 	healthz := func() (bool, error) {
 		if time.Since(start) > timeout {
 			return false, fmt.Errorf("cluster wait timed out during healthz check")
 		}
 
-		if time.Since(start) > minLogTime {
+		if time.Since(start) > minLogCheckTime {
 			announceProblems(r, bs, cr)
 			time.Sleep(kconst.APICallRetryInterval * 5)
 		}


### PR DESCRIPTION
While working on #7102 - I noticed that sometimes we were spamming console with errors that Kubernetes was able to recover from. Let's wait a little longer.
