### PR TITLE
bumpup istio & istio-provisoner addon 1.4.0 → 1.5.0

### DIFF
--- a/deploy/addons/istio-provisioner/istio-operator.yaml.tmpl
+++ b/deploy/addons/istio-provisioner/istio-operator.yaml.tmpl
@@ -11,49 +11,24 @@ metadata:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: istiocontrolplanes.install.istio.io
+  name: istiooperators.install.istio.io
   labels:
     kubernetes.io/minikube-addons: istio
-    addonmanager.kubernetes.io/mode: EnsureExists 
+    addonmanager.kubernetes.io/mode: EnsureExists
 spec:
   group: install.istio.io
   names:
-    kind: IstioControlPlane
-    listKind: IstioControlPlaneList
-    plural: istiocontrolplanes
-    singular: istiocontrolplane
+    kind: IstioOperator
+    listKind: IstioOperatorList
+    plural: istiooperators
+    singular: istiooperator
     shortNames:
-    - icp
+    - iop
   scope: Namespaced
   subresources:
     status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values.
-            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase.
-            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        spec:
-          description: 'Specification of the desired state of the istio control plane resource.
-            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
-          type: object
-        status:
-          description: 'Status describes each of istio control plane component status at the current time.
-            0 means NONE, 1 means UPDATING, 2 means HEALTHY, 3 means ERROR, 4 means RECONCILING.
-            More info: https://github.com/istio/operator/blob/master/pkg/apis/istio/v1alpha2/v1alpha2.pb.html &
-            https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
-          type: object
   versions:
-  - name: v1alpha2
+  - name: v1alpha1
     served: true
     storage: true
 ...
@@ -243,9 +218,9 @@ spec:
       serviceAccountName: istio-operator
       containers:
         - name: istio-operator
-          image: docker.io/istio/operator:1.4.0
+          image: docker.io/istio/operator:1.5.0
           command:
-          - istio-operator
+          - operator
           - server
           imagePullPolicy: Always
           resources:
@@ -257,7 +232,7 @@ spec:
               memory: 128Mi
           env:
             - name: WATCH_NAMESPACE
-              value: ""
+              value: "istio-system"
             - name: LEADER_ELECTION_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/deploy/addons/istio/README.md
+++ b/deploy/addons/istio/README.md
@@ -3,9 +3,10 @@
 
 ### Enable istio on minikube
 Make sure to start minikube with at least 8192 MB of memory and 4 CPUs.
+See official [Platform Setup](https://istio.io/docs/setup/platform-setup/) documentation.
 
 ```shell script
-minikube start --memory=8000mb --cpus=4 
+minikube start --memory=8192mb --cpus=4
 ```
 
 To enable this addon, simply run:

--- a/deploy/addons/istio/istio-default-profile.yaml.tmpl
+++ b/deploy/addons/istio/istio-default-profile.yaml.tmpl
@@ -1,10 +1,19 @@
-apiVersion: install.istio.io/v1alpha2
-kind: IstioControlPlane
+apiVersion: v1
+kind: Namespace
 metadata:
-  namespace: istio-operator
+  name: istio-system
+  labels:
+    kubernetes.io/minikube-addons: istio
+    addonmanager.kubernetes.io/mode: EnsureExists
+
+---
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  namespace: istio-system
   name: example-istiocontrolplane
   labels:
     kubernetes.io/minikube-addons: istio
-    addonmanager.kubernetes.io/mode: Reconcile 
+    addonmanager.kubernetes.io/mode: Reconcile
 spec:
   profile: default


### PR DESCRIPTION
### What type of PR is this?
/kind cleanup

### What this PR does / why we need it:

This PR bump up istio & istio-operator addon's image v1.4.0 to v1.5.0

### Which issue(s) this PR fixes:

Fixes #7118 

### Does this PR introduce a user-facing change?

Yes.
This image bumpup includes istio's bug fix & features.
https://github.com/istio/istio/releases/tag/1.5.0
https://istio.io/news/releases/1.5.x/announcing-1.5/

**Before**
```
$ minikube start --memory=8192mb --cpus=4
$ minikube addons enable istio-provisioner
$ minikube addons enable istio-provisioner

$ kubectl get pods -n istio-system -w
NAME                                      READY   STATUS             RESTARTS   AGE
istio-citadel-68bf6b66c-r7trn             1/1     Running            0          6m55s
istio-galley-6999d4d659-lzlj5             2/2     Running            0          6m55s
istio-ingressgateway-5fc59bb7fb-d878d     1/1     Running            0          6m53s
istio-pilot-578475b5bc-lxrtb              2/2     Running            0          6m53s
istio-policy-6df5d666d5-2vwf4             2/2     Running            5          6m54s
istio-sidecar-injector-6b4d8cdfb5-xk8dm   1/1     Running            0          6m53s
istio-telemetry-7487f698db-khrxh          1/2     Running            5          6m52s
prometheus-946f9f9d8-279pt                1/1     Running            0          6m56s
```

**After**
```
$ minikube start --memory=8192mb --cpus=4
$ minikube addons enable istio-provisioner
$ minikube addons enable istio-provisioner

$ kubectl get pods -n istio-system
NAME                                    READY   STATUS    RESTARTS   AGE
istio-ingressgateway-59d85f84c7-vq4rq   1/1     Running   0          3m40s
istiod-b8ffd7d4d-2j9ck                  1/1     Running   0          3m40s
prometheus-d78dbcffd-24j58              2/2     Running   0          3m42s

$ istioctl version
client version: 1.5.0
control plane version: 1.5.0
data plane version: 1.5.0 (2 proxies)
```

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```