### PR TITLE
Remove CrashLoopBackOff from root causes

### DIFF
--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -51,7 +51,6 @@ var rootCauses = []string{
 	`unable to evict any pods`,
 	`eviction manager: unexpected error`,
 	`Resetting AnonymousAuth to false`,
-	`CrashLoopBackOff`,
 	`Unable to register node.*forbidden`,
 	`Failed to initialize CSINodeInfo.*forbidden`,
 	`Failed to admit pod`,


### PR DESCRIPTION
It isn't really a root cause, and generates a lot of noise during a cluster upgrade.