### PR TITLE
bumpup helm-tiller v2.16.1 → v2.16.3

### DIFF
--- a/deploy/addons/helm-tiller/helm-tiller-dp.tmpl
+++ b/deploy/addons/helm-tiller/helm-tiller-dp.tmpl
@@ -46,7 +46,7 @@ spec:
               value: kube-system
             - name: TILLER_HISTORY_MAX
               value: "0"
-          image: gcr.io/kubernetes-helm/tiller:v2.16.1
+          image: gcr.io/kubernetes-helm/tiller:v2.16.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3


### PR DESCRIPTION
### What type of PR is this?
/area addons

### What this PR does / why we need it:

This PR bump up helm-tiller addon's image v2.16.1 to v2.16.3

And I added integration test for helm-tiller to gurantee our change stability.

### Which issue(s) this PR fixes:

Fixes #7129

### Does this PR introduce a user-facing change?

Yes.
This image bumpup includes security patch for [CVE-2019-1551](https://nvd.nist.gov/vuln/detail/CVE-2019-1551).
https://github.com/helm/helm/releases/tag/v2.16.3

**Before**
```
image: gcr.io/kubernetes-helm/tiller:v2.16.1
```

**After**
```
image: gcr.io/kubernetes-helm/tiller:v2.16.3
```

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```