### PR TITLE
Update Nvidia GPU plugin

### DIFF
--- a/deploy/addons/gpu/nvidia-gpu-device-plugin.yaml
+++ b/deploy/addons/gpu/nvidia-gpu-device-plugin.yaml
@@ -46,21 +46,18 @@ spec:
         hostPath:
           path: /dev
       containers:
-      - image: "{{default "k8s.gcr.io" .ImageRepository}}/nvidia-gpu-device-plugin@sha256:0842734032018be107fa2490c98156992911e3e1f2a21e059ff0105b07dd8e9e"
-        command: ["/usr/bin/nvidia-gpu-device-plugin", "-logtostderr"]
+      - image: "nvidia/k8s-device-plugin:1.0.0-beta4"
+        command: ["/usr/bin/nvidia-device-plugin", "-logtostderr"]
         name: nvidia-gpu-device-plugin
         resources:
           requests:
-            cpu: 50m
-            memory: 10Mi
-          limits:
             cpu: 50m
             memory: 10Mi
         securityContext:
           privileged: true
         volumeMounts:
         - name: device-plugin
-          mountPath: /device-plugin
+          mountPath: /var/lib/kubelet/device-plugins
         - name: dev
           mountPath: /dev
   updateStrategy:

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -296,11 +296,11 @@ var Addons = map[string]*Addon{
 	}, false, "nvidia-driver-installer"),
 	"nvidia-gpu-device-plugin": NewAddon([]*BinAsset{
 		MustBinAsset(
-			"deploy/addons/gpu/nvidia-gpu-device-plugin.yaml.tmpl",
+			"deploy/addons/gpu/nvidia-gpu-device-plugin.yaml",
 			vmpath.GuestAddonsDir,
 			"nvidia-gpu-device-plugin.yaml",
 			"0640",
-			true),
+			false),
 	}, false, "nvidia-gpu-device-plugin"),
 	"logviewer": NewAddon([]*BinAsset{
 		MustBinAsset(


### PR DESCRIPTION
The current plugin used by minikube is too old without properly setting up NVIDIA_VISIBLE_DEVICES for GPU isolation.
Update Nvidia device plugin to latest release to resolve this issue.
