### PR TITLE
hyperv Delete: call StopHost before removing VM

### DIFF
--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -402,7 +402,7 @@ func deleteProfileDirectory(profile string) {
 		out.T(out.DeletingHost, `Removing {{.directory}} ...`, out.V{"directory": machineDir})
 		err := os.RemoveAll(machineDir)
 		if err != nil {
-			exit.WithError("Unable to remove machine directory: %v", err)
+			exit.WithError("Unable to remove machine directory", err)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #6804 - a bug I ran into this morning while running "minikube start/minikube delete" in an infinite loop.

Just in case, it also tries driver deletion twice, since it gets messy if we later delete the machine profile but the VM deletion never happened.