### PR TITLE
Update commands to consistently detect down & paused clusters

### DIFF
--- a/cmd/minikube/cmd/config/addons_list.go
+++ b/cmd/minikube/cmd/config/addons_list.go
@@ -26,7 +26,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/exit"
@@ -98,7 +97,7 @@ var printAddonsList = func() {
 	table.SetAutoFormatHeaders(true)
 	table.SetBorders(tablewriter.Border{Left: true, Top: true, Right: true, Bottom: true})
 	table.SetCenterSeparator("|")
-	pName := viper.GetString(config.ProfileName)
+	pName := ClusterFlagValue()
 
 	for _, addonName := range addonNames {
 		addonBundle := assets.Addons[addonName]
@@ -123,7 +122,7 @@ var printAddonsList = func() {
 
 var printAddonsJSON = func() {
 	addonNames := make([]string, 0, len(assets.Addons))
-	pName := viper.GetString(config.ProfileName)
+	pName := ClusterFlagValue()
 	for addonName := range assets.Addons {
 		addonNames = append(addonNames, addonName)
 	}

--- a/cmd/minikube/cmd/config/disable.go
+++ b/cmd/minikube/cmd/config/disable.go
@@ -18,9 +18,7 @@ package config
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/addons"
-	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/out"
 )
@@ -35,7 +33,7 @@ var addonsDisableCmd = &cobra.Command{
 		}
 
 		addon := args[0]
-		err := addons.Set(addon, "false", viper.GetString(config.ProfileName))
+		err := addons.Set(addon, "false", ClusterFlagValue())
 		if err != nil {
 			exit.WithError("disable failed", err)
 		}

--- a/cmd/minikube/cmd/config/enable.go
+++ b/cmd/minikube/cmd/config/enable.go
@@ -18,9 +18,7 @@ package config
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/addons"
-	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/out"
 )
@@ -34,7 +32,7 @@ var addonsEnableCmd = &cobra.Command{
 			exit.UsageT("usage: minikube addons enable ADDON_NAME")
 		}
 		addon := args[0]
-		err := addons.Set(addon, "true", viper.GetString(config.ProfileName))
+		err := addons.Set(addon, "true", ClusterFlagValue())
 		if err != nil {
 			exit.WithError("enable failed", err)
 		}

--- a/cmd/minikube/cmd/config/flags.go
+++ b/cmd/minikube/cmd/config/flags.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package config
 
 import (

--- a/cmd/minikube/cmd/config/flags.go
+++ b/cmd/minikube/cmd/config/flags.go
@@ -1,0 +1,11 @@
+package config
+
+import (
+	"github.com/spf13/viper"
+	"k8s.io/minikube/pkg/minikube/config"
+)
+
+// ClusterFlagValue returns the current cluster name based on flags
+func ClusterFlagValue() string {
+	return viper.GetString(config.ProfileName)
+}

--- a/cmd/minikube/cmd/config/get.go
+++ b/cmd/minikube/cmd/config/get.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	pkgConfig "k8s.io/minikube/pkg/minikube/config"
+	config "k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/out"
 )
 
@@ -59,5 +59,5 @@ func init() {
 
 // Get gets a property
 func Get(name string) (string, error) {
-	return pkgConfig.Get(name)
+	return config.Get(name)
 }

--- a/cmd/minikube/cmd/config/open.go
+++ b/cmd/minikube/cmd/config/open.go
@@ -18,19 +18,14 @@ package config
 
 import (
 	"fmt"
-	"os"
 	"text/template"
 
 	"github.com/pkg/browser"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/assets"
-	"k8s.io/minikube/pkg/minikube/config"
-	pkg_config "k8s.io/minikube/pkg/minikube/config"
-	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/exit"
-	"k8s.io/minikube/pkg/minikube/machine"
+	"k8s.io/minikube/pkg/minikube/mustload"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/service"
 )
@@ -62,32 +57,17 @@ var addonsOpenCmd = &cobra.Command{
 			exit.UsageT("usage: minikube addons open ADDON_NAME")
 		}
 		addonName := args[0]
-		// TODO(r2d4): config should not reference API, pull this out
-		api, err := machine.NewAPIClient()
-		if err != nil {
-			exit.WithError("Error getting client", err)
-		}
-		defer api.Close()
 
-		profileName := viper.GetString(pkg_config.ProfileName)
-		cc, err := config.Load(profileName)
-		if err != nil {
-			exit.WithError("Error getting cluster", err)
-		}
-		cp, err := config.PrimaryControlPlane(cc)
-		if err != nil {
-			exit.WithError("Error getting control plane", err)
-		}
-		if !machine.IsRunning(api, driver.MachineName(*cc, cp)) {
-			os.Exit(1)
-		}
+		cname := ClusterFlagValue()
+		co := mustload.Healthy(cname)
+
 		addon, ok := assets.Addons[addonName] // validate addon input
 		if !ok {
 			exit.WithCodeT(exit.Data, `addon '{{.name}}' is not a valid addon packaged with minikube.
 To see the list of available addons run:
 minikube addons list`, out.V{"name": addonName})
 		}
-		ok, err = addon.IsEnabled(profileName)
+		ok, err := addon.IsEnabled(cname)
 		if err != nil {
 			exit.WithError("IsEnabled failed", err)
 		}
@@ -112,7 +92,7 @@ You can add one by annotating a service with the label {{.labelName}}:{{.addonNa
 			svc := serviceList.Items[i].ObjectMeta.Name
 			var urlString []string
 
-			if urlString, err = service.WaitForService(api, namespace, svc, addonsURLTemplate, addonsURLMode, https, wait, interval); err != nil {
+			if urlString, err = service.WaitForService(co.API, namespace, svc, addonsURLTemplate, addonsURLMode, https, wait, interval); err != nil {
 				exit.WithCodeT(exit.Unavailable, "Wait failed: {{.error}}", out.V{"error": err})
 			}
 

--- a/cmd/minikube/cmd/config/profile.go
+++ b/cmd/minikube/cmd/config/profile.go
@@ -20,9 +20,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	pkgConfig "k8s.io/minikube/pkg/minikube/config"
-	pkg_config "k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/kubeconfig"
 	"k8s.io/minikube/pkg/minikube/out"
@@ -35,7 +33,7 @@ var ProfileCmd = &cobra.Command{
 	Long:  "profile sets the current minikube profile, or gets the current profile if no arguments are provided.  This is used to run and manage multiple minikube instance.  You can return to the default minikube profile by running `minikube profile default`",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			profile := viper.GetString(pkgConfig.ProfileName)
+			profile := ClusterFlagValue()
 			out.T(out.Empty, profile)
 			os.Exit(0)
 		}
@@ -49,7 +47,7 @@ var ProfileCmd = &cobra.Command{
 		we need to add code over here to check whether the profile
 		name is in the list of reserved keywords
 		*/
-		if pkgConfig.ProfileNameInReservedKeywords(profile) {
+		if config.ProfileNameInReservedKeywords(profile) {
 			out.ErrT(out.FailureType, `Profile name "{{.profilename}}" is minikube keyword. To delete profile use command minikube delete -p <profile name>  `, out.V{"profilename": profile})
 			os.Exit(0)
 		}
@@ -64,18 +62,18 @@ var ProfileCmd = &cobra.Command{
 			}
 		}
 
-		if !pkgConfig.ProfileExists(profile) {
+		if !config.ProfileExists(profile) {
 			out.ErrT(out.Tip, `if you want to create a profile you can by this command: minikube start -p {{.profile_name}}`, out.V{"profile_name": profile})
 			os.Exit(0)
 		}
 
-		err := Set(pkgConfig.ProfileName, profile)
+		err := Set(config.ProfileName, profile)
 		if err != nil {
 			exit.WithError("Setting profile failed", err)
 		}
-		cc, err := pkgConfig.Load(profile)
+		cc, err := config.Load(profile)
 		// might err when loading older version of cfg file that doesn't have KeepContext field
-		if err != nil && !pkg_config.IsNotExist(err) {
+		if err != nil && !config.IsNotExist(err) {
 			out.ErrT(out.Sad, `Error loading profile config: {{.error}}`, out.V{"error": err})
 		}
 		if err == nil {

--- a/cmd/minikube/cmd/config/set.go
+++ b/cmd/minikube/cmd/config/set.go
@@ -19,7 +19,7 @@ package config
 import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	pkgConfig "k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/minikube/out"
@@ -61,11 +61,11 @@ func Set(name string, value string) error {
 	}
 
 	// Set the value
-	config, err := pkgConfig.ReadConfig(localpath.ConfigFile())
+	cc, err := config.ReadConfig(localpath.ConfigFile())
 	if err != nil {
 		return errors.Wrapf(err, "read config file %q", localpath.ConfigFile())
 	}
-	err = s.set(config, name, value)
+	err = s.set(cc, name, value)
 	if err != nil {
 		return errors.Wrapf(err, "set")
 	}
@@ -77,5 +77,5 @@ func Set(name string, value string) error {
 	}
 
 	// Write the value
-	return pkgConfig.WriteConfig(localpath.ConfigFile(), config)
+	return config.WriteConfig(localpath.ConfigFile(), cc)
 }

--- a/cmd/minikube/cmd/config/unset.go
+++ b/cmd/minikube/cmd/config/unset.go
@@ -18,7 +18,7 @@ package config
 
 import (
 	"github.com/spf13/cobra"
-	pkgConfig "k8s.io/minikube/pkg/minikube/config"
+	config "k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/localpath"
 )
@@ -44,10 +44,10 @@ func init() {
 
 // Unset unsets a property
 func Unset(name string) error {
-	m, err := pkgConfig.ReadConfig(localpath.ConfigFile())
+	m, err := config.ReadConfig(localpath.ConfigFile())
 	if err != nil {
 		return err
 	}
 	delete(m, name)
-	return pkgConfig.WriteConfig(localpath.ConfigFile(), m)
+	return config.WriteConfig(localpath.ConfigFile(), m)
 }

--- a/cmd/minikube/cmd/config/util_test.go
+++ b/cmd/minikube/cmd/config/util_test.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"testing"
 
-	pkgConfig "k8s.io/minikube/pkg/minikube/config"
+	config "k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/driver"
 )
 
-var minikubeConfig = pkgConfig.MinikubeConfig{
+var minikubeConfig = config.MinikubeConfig{
 	"driver":               driver.KVM2,
 	"cpus":                 12,
 	"show-libmachine-logs": true,
@@ -83,21 +83,10 @@ func TestSetBool(t *testing.T) {
 }
 
 func TestValidateProfile(t *testing.T) {
-	testCases := []struct {
-		profileName string
-	}{
-		{
-			profileName: "82374328742_2974224498",
-		},
-		{
-			profileName: "validate_test",
-		},
-	}
-
-	for _, test := range testCases {
-		profileNam := test.profileName
-		expected := fmt.Sprintf("profile %q not found", test.profileName)
-		err, ok := ValidateProfile(profileNam)
+	testCases := []string{"82374328742_2974224498", "validate_test"}
+	for _, name := range testCases {
+		expected := fmt.Sprintf("profile %q not found", name)
+		err, ok := ValidateProfile(name)
 		if !ok && err.Error() != expected {
 			t.Errorf("got error %q, expected %q", err, expected)
 		}

--- a/cmd/minikube/cmd/dashboard.go
+++ b/cmd/minikube/cmd/dashboard.go
@@ -21,25 +21,19 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"os/exec"
 	"os/user"
 	"regexp"
 	"time"
 
-	"github.com/docker/machine/libmachine/mcnerror"
 	"github.com/golang/glog"
 	"github.com/pkg/browser"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	pkgaddons "k8s.io/minikube/pkg/addons"
 	"k8s.io/minikube/pkg/minikube/assets"
-	"k8s.io/minikube/pkg/minikube/config"
-	pkg_config "k8s.io/minikube/pkg/minikube/config"
-	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/exit"
-	"k8s.io/minikube/pkg/minikube/machine"
+	"k8s.io/minikube/pkg/minikube/mustload"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/proxy"
 	"k8s.io/minikube/pkg/minikube/service"
@@ -59,47 +53,11 @@ var dashboardCmd = &cobra.Command{
 	Short: "Access the kubernetes dashboard running within the minikube cluster",
 	Long:  `Access the kubernetes dashboard running within the minikube cluster`,
 	Run: func(cmd *cobra.Command, args []string) {
-		profileName := viper.GetString(pkg_config.ProfileName)
-		cc, err := pkg_config.Load(profileName)
-		if err != nil && !pkg_config.IsNotExist(err) {
-			exit.WithError("Error loading profile config", err)
-		}
+		cname := ClusterFlagValue()
+		co := mustload.Healthy(cname)
 
-		if err != nil {
-			out.ErrT(out.Meh, `"{{.name}}" profile does not exist`, out.V{"name": profileName})
-			os.Exit(1)
-		}
-
-		api, err := machine.NewAPIClient()
-		defer func() {
-			err := api.Close()
-			if err != nil {
-				glog.Warningf("Failed to close API: %v", err)
-			}
-		}()
-
-		if err != nil {
-			exit.WithError("Error getting client", err)
-		}
-
-		cp, err := config.PrimaryControlPlane(cc)
-		if err != nil {
-			exit.WithError("Error getting primary control plane", err)
-		}
-
-		machineName := driver.MachineName(*cc, cp)
-		if _, err = api.Load(machineName); err != nil {
-			switch err := errors.Cause(err).(type) {
-			case mcnerror.ErrHostDoesNotExist:
-				exit.WithCodeT(exit.Unavailable, "{{.name}} cluster does not exist", out.V{"name": cc.Name})
-			default:
-				exit.WithError("Error getting cluster", err)
-			}
-		}
-
-		for _, n := range cc.Nodes {
-			err = proxy.ExcludeIP(n.IP) // to be used for http get calls
-			if err != nil {
+		for _, n := range co.Config.Nodes {
+			if err := proxy.ExcludeIP(n.IP); err != nil {
 				glog.Errorf("Error excluding IP from proxy: %s", err)
 			}
 		}
@@ -109,18 +67,14 @@ var dashboardCmd = &cobra.Command{
 			exit.WithCodeT(exit.NoInput, "kubectl not found in PATH, but is required for the dashboard. Installation guide: https://kubernetes.io/docs/tasks/tools/install-kubectl/")
 		}
 
-		if !machine.IsRunning(api, machineName) {
-			os.Exit(1)
-		}
-
 		// Check dashboard status before enabling it
 		dashboardAddon := assets.Addons["dashboard"]
-		dashboardStatus, _ := dashboardAddon.IsEnabled(profileName)
+		dashboardStatus, _ := dashboardAddon.IsEnabled(cname)
 		if !dashboardStatus {
 			// Send status messages to stderr for folks re-using this output.
 			out.ErrT(out.Enabling, "Enabling dashboard ...")
 			// Enable the dashboard add-on
-			err = pkgaddons.Set("dashboard", "true", profileName)
+			err = pkgaddons.Set("dashboard", "true", cname)
 			if err != nil {
 				exit.WithError("Unable to enable dashboard", err)
 			}
@@ -135,7 +89,7 @@ var dashboardCmd = &cobra.Command{
 		}
 
 		out.ErrT(out.Launch, "Launching proxy ...")
-		p, hostPort, err := kubectlProxy(kubectl, machineName)
+		p, hostPort, err := kubectlProxy(kubectl, cname)
 		if err != nil {
 			exit.WithError("kubectl proxy", err)
 		}
@@ -169,10 +123,10 @@ var dashboardCmd = &cobra.Command{
 }
 
 // kubectlProxy runs "kubectl proxy", returning host:port
-func kubectlProxy(path string, machineName string) (*exec.Cmd, string, error) {
+func kubectlProxy(path string, contextName string) (*exec.Cmd, string, error) {
 	// port=0 picks a random system port
 
-	cmd := exec.Command(path, "--context", machineName, "proxy", "--port=0")
+	cmd := exec.Command(path, "--context", contextName, "proxy", "--port=0")
 
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {

--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -141,10 +141,10 @@ func runDelete(cmd *cobra.Command, args []string) {
 			exit.UsageT("usage: minikube delete")
 		}
 
-		profileName := viper.GetString(config.ProfileName)
-		profile, err := config.LoadProfile(profileName)
+		cname := ClusterFlagValue()
+		profile, err := config.LoadProfile(cname)
 		if err != nil {
-			out.ErrT(out.Meh, `"{{.name}}" profile does not exist, trying anyways.`, out.V{"name": profileName})
+			out.ErrT(out.Meh, `"{{.name}}" profile does not exist, trying anyways.`, out.V{"name": cname})
 		}
 
 		errs := DeleteProfiles([]*config.Profile{profile})
@@ -272,13 +272,13 @@ func deleteHosts(api libmachine.API, cc *config.ClusterConfig) {
 	}
 }
 
-func deleteConfig(profileName string) error {
-	if err := config.DeleteProfile(profileName); err != nil {
+func deleteConfig(cname string) error {
+	if err := config.DeleteProfile(cname); err != nil {
 		if config.IsNotExist(err) {
-			delErr := profileDeletionErr(profileName, fmt.Sprintf("\"%s\" profile does not exist", profileName))
+			delErr := profileDeletionErr(cname, fmt.Sprintf("\"%s\" profile does not exist", cname))
 			return DeletionError{Err: delErr, Errtype: MissingProfile}
 		}
-		delErr := profileDeletionErr(profileName, fmt.Sprintf("failed to remove profile %v", err))
+		delErr := profileDeletionErr(cname, fmt.Sprintf("failed to remove profile %v", err))
 		return DeletionError{Err: delErr, Errtype: Fatal}
 	}
 	return nil
@@ -317,8 +317,8 @@ func deleteInvalidProfile(profile *config.Profile) []error {
 	return errs
 }
 
-func profileDeletionErr(profileName string, additionalInfo string) error {
-	return fmt.Errorf("error deleting profile \"%s\": %s", profileName, additionalInfo)
+func profileDeletionErr(cname string, additionalInfo string) error {
+	return fmt.Errorf("error deleting profile \"%s\": %s", cname, additionalInfo)
 }
 
 func uninstallKubernetes(api libmachine.API, cc config.ClusterConfig, n config.Node, bsName string) error {

--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -24,20 +24,18 @@ import (
 	"io"
 	"net"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 
-	"github.com/docker/machine/libmachine/drivers"
-	"github.com/docker/machine/libmachine/state"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
-	"k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/command"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/localpath"
-	"k8s.io/minikube/pkg/minikube/machine"
+	"k8s.io/minikube/pkg/minikube/mustload"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/shell"
 )
@@ -117,23 +115,10 @@ func (EnvNoProxyGetter) GetNoProxyVar() (string, string) {
 }
 
 // isDockerActive checks if Docker is active
-func isDockerActive(d drivers.Driver) (bool, error) {
-	client, err := drivers.GetSSHClientFromDriver(d)
-	if err != nil {
-		return false, err
-	}
-	cmd := "sudo systemctl is-active docker"
-
-	output, err := client.Output(cmd)
-	s := strings.TrimSpace(output)
-
-	if err != nil {
-		return false, fmt.Errorf("%s failed: %v\noutput: %q", cmd, err, s)
-	}
-	if s != "active" {
-		return false, fmt.Errorf("%s returned %q", cmd, s)
-	}
-	return true, nil
+func isDockerActive(r command.Runner) bool {
+	c := exec.Command("sudo", "systemctl", "is-active", "--quiet", "service", "docker")
+	_, err := r.RunCmd(c)
+	return err == nil
 }
 
 // dockerEnvCmd represents the docker-env command
@@ -142,94 +127,62 @@ var dockerEnvCmd = &cobra.Command{
 	Short: "Sets up docker env variables; similar to '$(docker-machine env)'",
 	Long:  `Sets up docker env variables; similar to '$(docker-machine env)'.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		api, err := machine.NewAPIClient()
-		if err != nil {
-			exit.WithError("Error getting client", err)
+		cname := ClusterFlagValue()
+		co := mustload.Running(cname)
+		driverName := co.CPHost.DriverName
+
+		if driverName == driver.None {
+			exit.UsageT(`'none' driver does not support 'minikube docker-env' command`)
 		}
-		defer api.Close()
 
-		profile := viper.GetString(config.ProfileName)
-		cc, err := config.Load(profile)
-		if err != nil {
-			exit.WithError("Error getting config", err)
+		if co.Config.KubernetesConfig.ContainerRuntime != "docker" {
+			exit.WithCodeT(exit.BadUsage, `The docker-env command is only compatible with the "docker" runtime, but this cluster was configured to use the "{{.runtime}}" runtime.`,
+				out.V{"runtime": co.Config.KubernetesConfig.ContainerRuntime})
 		}
-		for _, n := range cc.Nodes {
-			machineName := driver.MachineName(*cc, n)
-			host, err := machine.LoadHost(api, machineName)
+
+		if ok := isDockerActive(co.CPRunner); !ok {
+			exit.WithCodeT(exit.Unavailable, `The docker service within '{{.name}}' is not active`, out.V{"name": cname})
+		}
+
+		sh := shell.EnvConfig{
+			Shell: shell.ForceShell,
+		}
+
+		var err error
+		port := constants.DockerDaemonPort
+		if driver.IsKIC(driverName) {
+			port, err = oci.ForwardedPort(driverName, cname, port)
 			if err != nil {
-				exit.WithError("Error getting host", err)
+				exit.WithCodeT(exit.Failure, "Error getting port binding for '{{.driver_name}} driver: {{.error}}", out.V{"driver_name": driverName, "error": err})
 			}
-			if host.Driver.DriverName() == driver.None {
-				exit.UsageT(`'none' driver does not support 'minikube docker-env' command`)
-			}
+		}
 
-			hostSt, err := machine.Status(api, machineName)
+		ec := DockerEnvConfig{
+			EnvConfig: sh,
+			profile:   cname,
+			driver:    driverName,
+			hostIP:    co.DriverIP.String(),
+			port:      port,
+			certsDir:  localpath.MakeMiniPath("certs"),
+			noProxy:   noProxy,
+		}
+
+		if ec.Shell == "" {
+			ec.Shell, err = shell.Detect()
 			if err != nil {
-				exit.WithError("Error getting host status", err)
+				exit.WithError("Error detecting shell", err)
 			}
-			if hostSt != state.Running.String() {
-				exit.WithCodeT(exit.Unavailable, `'{{.profile}}' is not running`, out.V{"profile": profile})
-			}
+		}
 
-			if cc.KubernetesConfig.ContainerRuntime != "docker" {
-				exit.WithCodeT(exit.BadUsage, `The docker-env command is only compatible with the "docker" runtime, but this cluster was configured to use the "{{.runtime}}" runtime.`,
-					out.V{"runtime": cc.KubernetesConfig.ContainerRuntime})
+		if dockerUnset {
+			if err := dockerUnsetScript(ec, os.Stdout); err != nil {
+				exit.WithError("Error generating unset output", err)
 			}
+			return
+		}
 
-			ok, err := isDockerActive(host.Driver)
-			if err != nil {
-				exit.WithError("Docker runtime check failed", err)
-			}
-
-			if !ok {
-				exit.WithCodeT(exit.Unavailable, `The docker service within '{{.profile}}' is not active`, out.V{"profile": profile})
-			}
-
-			hostIP, err := host.Driver.GetIP()
-			if err != nil {
-				exit.WithError("Error getting host IP", err)
-			}
-
-			sh := shell.EnvConfig{
-				Shell: shell.ForceShell,
-			}
-
-			port := constants.DockerDaemonPort
-			if driver.IsKIC(host.DriverName) { // for kic we need to find what port docker/podman chose for us
-				hostIP = oci.DefaultBindIPV4
-				port, err = oci.ForwardedPort(host.DriverName, profile, port)
-				if err != nil {
-					exit.WithCodeT(exit.Failure, "Error getting port binding for '{{.driver_name}} driver: {{.error}}", out.V{"driver_name": host.DriverName, "error": err})
-				}
-			}
-
-			ec := DockerEnvConfig{
-				EnvConfig: sh,
-				profile:   profile,
-				driver:    host.DriverName,
-				hostIP:    hostIP,
-				port:      port,
-				certsDir:  localpath.MakeMiniPath("certs"),
-				noProxy:   noProxy,
-			}
-
-			if ec.Shell == "" {
-				ec.Shell, err = shell.Detect()
-				if err != nil {
-					exit.WithError("Error detecting shell", err)
-				}
-			}
-
-			if dockerUnset {
-				if err := dockerUnsetScript(ec, os.Stdout); err != nil {
-					exit.WithError("Error generating unset output", err)
-				}
-				return
-			}
-
-			if err := dockerSetScript(ec, os.Stdout); err != nil {
-				exit.WithError("Error generating set output", err)
-			}
+		if err := dockerSetScript(ec, os.Stdout); err != nil {
+			exit.WithError("Error generating set output", err)
 		}
 	},
 }

--- a/cmd/minikube/cmd/flags.go
+++ b/cmd/minikube/cmd/flags.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cmd
 
 import (

--- a/cmd/minikube/cmd/flags.go
+++ b/cmd/minikube/cmd/flags.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/viper"
+	"k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/constants"
+)
+
+// Return a minikube command containing the current profile name
+func minikubeCmd() string {
+	cname := ClusterFlagValue()
+	if cname != constants.DefaultClusterName {
+		return fmt.Sprintf("minikube -p %s", cname)
+	}
+	return "minikube"
+}
+
+// ClusterFlagValue returns the current cluster name based on flags
+func ClusterFlagValue() string {
+	return viper.GetString(config.ProfileName)
+}

--- a/cmd/minikube/cmd/flags.go
+++ b/cmd/minikube/cmd/flags.go
@@ -17,21 +17,9 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/config"
-	"k8s.io/minikube/pkg/minikube/constants"
 )
-
-// Return a minikube command containing the current profile name
-func minikubeCmd() string {
-	cname := ClusterFlagValue()
-	if cname != constants.DefaultClusterName {
-		return fmt.Sprintf("minikube -p %s", cname)
-	}
-	return "minikube"
-}
 
 // ClusterFlagValue returns the current cluster name based on flags
 func ClusterFlagValue() string {

--- a/cmd/minikube/cmd/ip.go
+++ b/cmd/minikube/cmd/ip.go
@@ -17,14 +17,8 @@ limitations under the License.
 package cmd
 
 import (
-	"github.com/docker/machine/libmachine/mcnerror"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"k8s.io/minikube/pkg/minikube/config"
-	"k8s.io/minikube/pkg/minikube/driver"
-	"k8s.io/minikube/pkg/minikube/exit"
-	"k8s.io/minikube/pkg/minikube/machine"
+	"k8s.io/minikube/pkg/minikube/mustload"
 	"k8s.io/minikube/pkg/minikube/out"
 )
 
@@ -34,32 +28,7 @@ var ipCmd = &cobra.Command{
 	Short: "Retrieves the IP address of the running cluster",
 	Long:  `Retrieves the IP address of the running cluster, and writes it to STDOUT.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		api, err := machine.NewAPIClient()
-		if err != nil {
-			exit.WithError("Error getting client", err)
-		}
-		defer api.Close()
-
-		cc, err := config.Load(viper.GetString(config.ProfileName))
-		if err != nil {
-			exit.WithError("Error getting config", err)
-		}
-		for _, n := range cc.Nodes {
-			machineName := driver.MachineName(*cc, n)
-			host, err := api.Load(machineName)
-			if err != nil {
-				switch err := errors.Cause(err).(type) {
-				case mcnerror.ErrHostDoesNotExist:
-					exit.WithCodeT(exit.NoInput, `"{{.profile_name}}" host does not exist, unable to show an IP`, out.V{"profile_name": cc.Name})
-				default:
-					exit.WithError("Error getting host", err)
-				}
-			}
-			ip, err := host.Driver.GetIP()
-			if err != nil {
-				exit.WithError("Error getting IP", err)
-			}
-			out.Ln(ip)
-		}
+		co := mustload.Running(ClusterFlagValue())
+		out.Ln(co.DriverIP.String())
 	},
 }

--- a/cmd/minikube/cmd/kubectl.go
+++ b/cmd/minikube/cmd/kubectl.go
@@ -24,10 +24,8 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
-	"k8s.io/minikube/pkg/minikube/machine"
+	"k8s.io/minikube/pkg/minikube/mustload"
 	"k8s.io/minikube/pkg/minikube/node"
 	"k8s.io/minikube/pkg/minikube/out"
 )
@@ -42,21 +40,11 @@ Examples:
 minikube kubectl -- --help
 minikube kubectl -- get pods --namespace kube-system`,
 	Run: func(cmd *cobra.Command, args []string) {
-		api, err := machine.NewAPIClient()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error getting client: %v\n", err)
-			os.Exit(1)
-		}
-		defer api.Close()
+		co := mustload.Healthy(ClusterFlagValue())
 
-		cc, err := config.Load(viper.GetString(config.ProfileName))
-		if err != nil && !config.IsNotExist(err) {
-			out.ErrLn("Error loading profile config: %v", err)
-		}
-
-		version := constants.DefaultKubernetesVersion
-		if cc != nil {
-			version = cc.KubernetesConfig.KubernetesVersion
+		version := co.Config.KubernetesConfig.KubernetesVersion
+		if version == "" {
+			version = constants.DefaultKubernetesVersion
 		}
 
 		path, err := node.CacheKubectlBinary(version)

--- a/cmd/minikube/cmd/logs.go
+++ b/cmd/minikube/cmd/logs.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	cmdcfg "k8s.io/minikube/cmd/minikube/cmd/config"
@@ -25,6 +27,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/logs"
 	"k8s.io/minikube/pkg/minikube/mustload"
+	"k8s.io/minikube/pkg/minikube/out"
 )
 
 const (
@@ -73,7 +76,10 @@ var logsCmd = &cobra.Command{
 		}
 		err = logs.Output(cr, bs, *co.Config, co.CPRunner, numberOfLines)
 		if err != nil {
-			exit.WithError("Error getting machine logs", err)
+			out.Ln("")
+			// Avoid exit.WithError, since it outputs the issue URL
+			out.T(out.Warning, "{{.error}}", out.V{"error": err})
+			os.Exit(exit.Unavailable)
 		}
 	},
 }

--- a/cmd/minikube/cmd/node_add.go
+++ b/cmd/minikube/cmd/node_add.go
@@ -19,10 +19,10 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/exit"
+	"k8s.io/minikube/pkg/minikube/mustload"
 	"k8s.io/minikube/pkg/minikube/node"
 	"k8s.io/minikube/pkg/minikube/out"
 )
@@ -36,11 +36,8 @@ var nodeAddCmd = &cobra.Command{
 	Short: "Adds a node to the given cluster.",
 	Long:  "Adds a node to the given cluster config, and starts it.",
 	Run: func(cmd *cobra.Command, args []string) {
-		profile := viper.GetString(config.ProfileName)
-		cc, err := config.Load(profile)
-		if err != nil {
-			exit.WithError("Error getting config", err)
-		}
+		co := mustload.Healthy(ClusterFlagValue())
+		cc := co.Config
 
 		if driver.BareMetal(cc.Driver) {
 			out.ErrT(out.FailureType, "none driver does not support multi-node clusters")
@@ -48,7 +45,7 @@ var nodeAddCmd = &cobra.Command{
 
 		name := node.Name(len(cc.Nodes) + 1)
 
-		out.T(out.Happy, "Adding node {{.name}} to cluster {{.cluster}}", out.V{"name": name, "cluster": profile})
+		out.T(out.Happy, "Adding node {{.name}} to cluster {{.cluster}}", out.V{"name": name, "cluster": cc.Name})
 
 		// TODO: Deal with parameters better. Ideally we should be able to acceot any node-specific minikube start params here.
 		n := config.Node{
@@ -58,12 +55,11 @@ var nodeAddCmd = &cobra.Command{
 			KubernetesVersion: cc.KubernetesConfig.KubernetesVersion,
 		}
 
-		err = node.Add(cc, n)
-		if err != nil {
+		if err := node.Add(cc, n); err != nil {
 			exit.WithError("Error adding node to cluster", err)
 		}
 
-		out.T(out.Ready, "Successfully added {{.name}} to {{.cluster}}!", out.V{"name": name, "cluster": profile})
+		out.T(out.Ready, "Successfully added {{.name}} to {{.cluster}}!", out.V{"name": name, "cluster": cc.Name})
 	},
 }
 

--- a/cmd/minikube/cmd/node_delete.go
+++ b/cmd/minikube/cmd/node_delete.go
@@ -18,9 +18,8 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/exit"
+	"k8s.io/minikube/pkg/minikube/mustload"
 	"k8s.io/minikube/pkg/minikube/node"
 	"k8s.io/minikube/pkg/minikube/out"
 )
@@ -36,16 +35,10 @@ var nodeDeleteCmd = &cobra.Command{
 		}
 		name := args[0]
 
-		profile := viper.GetString(config.ProfileName)
-		out.T(out.DeletingHost, "Deleting node {{.name}} from cluster {{.cluster}}", out.V{"name": name, "cluster": profile})
+		co := mustload.Healthy(ClusterFlagValue())
+		out.T(out.DeletingHost, "Deleting node {{.name}} from cluster {{.cluster}}", out.V{"name": name, "cluster": co.Config.Name})
 
-		cc, err := config.Load(profile)
-		if err != nil {
-			exit.WithError("loading config", err)
-		}
-
-		err = node.Delete(*cc, name)
-		if err != nil {
+		if err := node.Delete(*co.Config, name); err != nil {
 			exit.WithError("deleting node", err)
 		}
 

--- a/cmd/minikube/cmd/node_start.go
+++ b/cmd/minikube/cmd/node_start.go
@@ -20,10 +20,9 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/machine"
+	"k8s.io/minikube/pkg/minikube/mustload"
 	"k8s.io/minikube/pkg/minikube/node"
 	"k8s.io/minikube/pkg/minikube/out"
 )
@@ -37,22 +36,12 @@ var nodeStartCmd = &cobra.Command{
 			exit.UsageT("Usage: minikube node start [name]")
 		}
 
+		api, cc := mustload.Partial(ClusterFlagValue())
 		name := args[0]
-
-		// Make sure it's not running
-		api, err := machine.NewAPIClient()
-		if err != nil {
-			exit.WithError("creating api client", err)
-		}
 
 		if machine.IsRunning(api, name) {
 			out.T(out.Check, "{{.name}} is already running", out.V{"name": name})
 			os.Exit(0)
-		}
-
-		cc, err := config.Load(viper.GetString(config.ProfileName))
-		if err != nil {
-			exit.WithError("loading config", err)
 		}
 
 		n, _, err := node.Retrieve(cc, name)

--- a/cmd/minikube/cmd/node_stop.go
+++ b/cmd/minikube/cmd/node_stop.go
@@ -18,11 +18,10 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/machine"
+	"k8s.io/minikube/pkg/minikube/mustload"
 	"k8s.io/minikube/pkg/minikube/node"
 	"k8s.io/minikube/pkg/minikube/out"
 )
@@ -37,16 +36,7 @@ var nodeStopCmd = &cobra.Command{
 		}
 
 		name := args[0]
-
-		api, err := machine.NewAPIClient()
-		if err != nil {
-			exit.WithError("creating api client", err)
-		}
-
-		cc, err := config.Load(viper.GetString(config.ProfileName))
-		if err != nil {
-			exit.WithError("getting config", err)
-		}
+		api, cc := mustload.Partial(ClusterFlagValue())
 
 		n, _, err := node.Retrieve(cc, name)
 		if err != nil {

--- a/cmd/minikube/cmd/pause.go
+++ b/cmd/minikube/cmd/pause.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"os"
 	"strings"
 
 	"github.com/golang/glog"
@@ -25,11 +24,11 @@ import (
 	"github.com/spf13/viper"
 
 	"k8s.io/minikube/pkg/minikube/cluster"
-	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/cruntime"
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/machine"
+	"k8s.io/minikube/pkg/minikube/mustload"
 	"k8s.io/minikube/pkg/minikube/out"
 )
 
@@ -46,27 +45,10 @@ var pauseCmd = &cobra.Command{
 }
 
 func runPause(cmd *cobra.Command, args []string) {
-	cname := viper.GetString(config.ProfileName)
-	api, err := machine.NewAPIClient()
-	if err != nil {
-		exit.WithError("Error getting client", err)
-	}
-	defer api.Close()
-	cc, err := config.Load(cname)
+	co := mustload.Running(ClusterFlagValue())
 
-	if err != nil && !config.IsNotExist(err) {
-		exit.WithError("Error loading profile config", err)
-	}
-
-	if err != nil {
-		out.ErrT(out.Meh, `"{{.name}}" profile does not exist`, out.V{"name": cname})
-		os.Exit(1)
-	}
-
-	glog.Infof("config: %+v", cc)
-
-	for _, n := range cc.Nodes {
-		host, err := machine.LoadHost(api, driver.MachineName(*cc, n))
+	for _, n := range co.Config.Nodes {
+		host, err := machine.LoadHost(co.API, driver.MachineName(*co.Config, n))
 		if err != nil {
 			exit.WithError("Error getting host", err)
 		}
@@ -76,7 +58,7 @@ func runPause(cmd *cobra.Command, args []string) {
 			exit.WithError("Failed to get command runner", err)
 		}
 
-		cr, err := cruntime.New(cruntime.Config{Type: cc.KubernetesConfig.ContainerRuntime, Runner: r})
+		cr, err := cruntime.New(cruntime.Config{Type: co.Config.KubernetesConfig.ContainerRuntime, Runner: r})
 		if err != nil {
 			exit.WithError("Failed runtime", err)
 		}

--- a/cmd/minikube/cmd/podman-env.go
+++ b/cmd/minikube/cmd/podman-env.go
@@ -27,16 +27,13 @@ import (
 	"strings"
 
 	"github.com/docker/machine/libmachine/drivers"
-	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/ssh"
-	"github.com/docker/machine/libmachine/state"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/command"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/exit"
-	"k8s.io/minikube/pkg/minikube/machine"
+	"k8s.io/minikube/pkg/minikube/mustload"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/shell"
 )
@@ -67,15 +64,16 @@ func podmanShellCfgSet(ec PodmanEnvConfig, envMap map[string]string) *PodmanShel
 }
 
 // isPodmanAvailable checks if Podman is available
-func isPodmanAvailable(host *host.Host) (bool, error) {
-	// we need both "varlink bridge" and "podman varlink"
-	if _, err := host.RunSSHCommand("which varlink"); err != nil {
-		return false, err
+func isPodmanAvailable(r command.Runner) bool {
+	if _, err := r.RunCmd(exec.Command("which", "varlink")); err != nil {
+		return false
 	}
-	if _, err := host.RunSSHCommand("which podman"); err != nil {
-		return false, err
+
+	if _, err := r.RunCmd(exec.Command("which", "podman")); err != nil {
+		return false
 	}
-	return true, nil
+
+	return true
 }
 
 func createExternalSSHClient(d drivers.Driver) (*ssh.ExternalClient, error) {
@@ -108,75 +106,49 @@ var podmanEnvCmd = &cobra.Command{
 	Short: "Sets up podman env variables; similar to '$(podman-machine env)'",
 	Long:  `Sets up podman env variables; similar to '$(podman-machine env)'.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		api, err := machine.NewAPIClient()
-		if err != nil {
-			exit.WithError("Error getting client", err)
+		cname := ClusterFlagValue()
+		co := mustload.Running(cname)
+		driverName := co.CPHost.DriverName
+
+		if driverName == driver.None {
+			exit.UsageT(`'none' driver does not support 'minikube podman-env' command`)
 		}
-		defer api.Close()
 
-		profile := viper.GetString(config.ProfileName)
-		cc, err := config.Load(profile)
-		if err != nil {
-			exit.WithError("Error getting config", err)
+		if ok := isPodmanAvailable(co.CPRunner); !ok {
+			exit.WithCodeT(exit.Unavailable, `The podman service within '{{.cluster}}' is not active`, out.V{"cluster": cname})
 		}
-		for _, n := range cc.Nodes {
-			machineName := driver.MachineName(*cc, n)
-			host, err := machine.LoadHost(api, machineName)
+
+		client, err := createExternalSSHClient(co.CPHost.Driver)
+		if err != nil {
+			exit.WithError("Error getting ssh client", err)
+		}
+
+		sh := shell.EnvConfig{
+			Shell: shell.ForceShell,
+		}
+		ec := PodmanEnvConfig{
+			EnvConfig: sh,
+			profile:   cname,
+			driver:    driverName,
+			client:    client,
+		}
+
+		if ec.Shell == "" {
+			ec.Shell, err = shell.Detect()
 			if err != nil {
-				exit.WithError("Error getting host", err)
+				exit.WithError("Error detecting shell", err)
 			}
-			if host.Driver.DriverName() == driver.None {
-				exit.UsageT(`'none' driver does not support 'minikube podman-env' command`)
-			}
+		}
 
-			hostSt, err := machine.Status(api, machineName)
-			if err != nil {
-				exit.WithError("Error getting host status", err)
+		if podmanUnset {
+			if err := podmanUnsetScript(ec, os.Stdout); err != nil {
+				exit.WithError("Error generating unset output", err)
 			}
-			if hostSt != state.Running.String() {
-				exit.WithCodeT(exit.Unavailable, `'{{.profile}}' is not running`, out.V{"profile": profile})
-			}
-			ok, err := isPodmanAvailable(host)
-			if err != nil {
-				exit.WithError("Error getting service status", err)
-			}
+			return
+		}
 
-			if !ok {
-				exit.WithCodeT(exit.Unavailable, `The podman service within '{{.profile}}' is not active`, out.V{"profile": profile})
-			}
-
-			client, err := createExternalSSHClient(host.Driver)
-			if err != nil {
-				exit.WithError("Error getting ssh client", err)
-			}
-
-			sh := shell.EnvConfig{
-				Shell: shell.ForceShell,
-			}
-			ec := PodmanEnvConfig{
-				EnvConfig: sh,
-				profile:   profile,
-				driver:    host.DriverName,
-				client:    client,
-			}
-
-			if ec.Shell == "" {
-				ec.Shell, err = shell.Detect()
-				if err != nil {
-					exit.WithError("Error detecting shell", err)
-				}
-			}
-
-			if podmanUnset {
-				if err := podmanUnsetScript(ec, os.Stdout); err != nil {
-					exit.WithError("Error generating unset output", err)
-				}
-				return
-			}
-
-			if err := podmanSetScript(ec, os.Stdout); err != nil {
-				exit.WithError("Error generating set output", err)
-			}
+		if err := podmanSetScript(ec, os.Stdout); err != nil {
+			exit.WithError("Error generating set output", err)
 		}
 	},
 }

--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -32,15 +32,11 @@ import (
 	"github.com/golang/glog"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	"k8s.io/minikube/pkg/drivers/kic/oci"
-	"k8s.io/minikube/pkg/minikube/config"
-	pkg_config "k8s.io/minikube/pkg/minikube/config"
-	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/localpath"
-	"k8s.io/minikube/pkg/minikube/machine"
+	"k8s.io/minikube/pkg/minikube/mustload"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/service"
 	"k8s.io/minikube/pkg/minikube/tunnel/kic"
@@ -78,32 +74,16 @@ var serviceCmd = &cobra.Command{
 		}
 
 		svc := args[0]
-		api, err := machine.NewAPIClient()
-		if err != nil {
-			exit.WithError("Error getting client", err)
-		}
-		defer api.Close()
 
-		profileName := viper.GetString(pkg_config.ProfileName)
-		cfg, err := config.Load(profileName)
-		if err != nil {
-			exit.WithError("Error getting config", err)
-		}
-		cp, err := config.PrimaryControlPlane(cfg)
-		if err != nil {
-			exit.WithError("Error getting control plane", err)
-		}
-		machineName := driver.MachineName(*cfg, cp)
-		if !machine.IsRunning(api, machineName) {
-			os.Exit(1)
-		}
+		cname := ClusterFlagValue()
+		co := mustload.Healthy(cname)
 
-		if runtime.GOOS == "darwin" && cfg.Driver == oci.Docker {
-			startKicServiceTunnel(svc, cfg.Name)
+		if runtime.GOOS == "darwin" && co.Config.Driver == oci.Docker {
+			startKicServiceTunnel(svc, cname)
 			return
 		}
 
-		urls, err := service.WaitForService(api, namespace, svc, serviceURLTemplate, serviceURLMode, https, wait, interval)
+		urls, err := service.WaitForService(co.API, namespace, svc, serviceURLTemplate, serviceURLMode, https, wait, interval)
 		if err != nil {
 			var s *service.SVCNotFoundError
 			if errors.As(err, &s) {

--- a/cmd/minikube/cmd/service_list.go
+++ b/cmd/minikube/cmd/service_list.go
@@ -22,14 +22,10 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	core "k8s.io/api/core/v1"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
-	"k8s.io/minikube/pkg/minikube/config"
-	pkg_config "k8s.io/minikube/pkg/minikube/config"
-	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/exit"
-	"k8s.io/minikube/pkg/minikube/machine"
+	"k8s.io/minikube/pkg/minikube/mustload"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/service"
 )
@@ -42,24 +38,9 @@ var serviceListCmd = &cobra.Command{
 	Short: "Lists the URLs for the services in your local cluster",
 	Long:  `Lists the URLs for the services in your local cluster`,
 	Run: func(cmd *cobra.Command, args []string) {
-		api, err := machine.NewAPIClient()
-		if err != nil {
-			exit.WithError("Error getting client", err)
-		}
-		defer api.Close()
-		profileName := viper.GetString(pkg_config.ProfileName)
-		cfg, err := config.Load(profileName)
-		if err != nil {
-			exit.WithError("Error getting config", err)
-		}
-		cp, err := config.PrimaryControlPlane(cfg)
-		if err != nil {
-			exit.WithError("Error getting primary control plane", err)
-		}
-		if !machine.IsRunning(api, driver.MachineName(*cfg, cp)) {
-			exit.WithCodeT(exit.Unavailable, "profile {{.name}} is not running.", out.V{"name": profileName})
-		}
-		serviceURLs, err := service.GetServiceURLs(api, serviceListNamespace, serviceURLTemplate)
+		co := mustload.Healthy(ClusterFlagValue())
+
+		serviceURLs, err := service.GetServiceURLs(co.API, serviceListNamespace, serviceURLTemplate)
 		if err != nil {
 			out.FatalT("Failed to get service URL: {{.error}}", out.V{"error": err})
 			out.ErrT(out.Notice, "Check that minikube is running and that you have specified the correct namespace (-n flag) if required.")
@@ -74,7 +55,7 @@ var serviceListCmd = &cobra.Command{
 				serviceURLs := strings.Join(serviceURL.URLs, "\n")
 
 				// if we are running Docker on OSX we empty the internal service URLs
-				if runtime.GOOS == "darwin" && cfg.Driver == oci.Docker {
+				if runtime.GOOS == "darwin" && co.Config.Driver == oci.Docker {
 					serviceURLs = ""
 				}
 

--- a/cmd/minikube/cmd/ssh-key.go
+++ b/cmd/minikube/cmd/ssh-key.go
@@ -20,10 +20,8 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"k8s.io/minikube/pkg/minikube/config"
-	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/localpath"
+	"k8s.io/minikube/pkg/minikube/mustload"
 	"k8s.io/minikube/pkg/minikube/out"
 )
 
@@ -33,10 +31,7 @@ var sshKeyCmd = &cobra.Command{
 	Short: "Retrieve the ssh identity key path of the specified cluster",
 	Long:  "Retrieve the ssh identity key path of the specified cluster.",
 	Run: func(cmd *cobra.Command, args []string) {
-		cc, err := config.Load(viper.GetString(config.ProfileName))
-		if err != nil {
-			exit.WithError("Getting machine config failed", err)
-		}
+		_, cc := mustload.Partial(ClusterFlagValue())
 		out.Ln(filepath.Join(localpath.MiniPath(), "machines", cc.Name, "id_rsa"))
 	},
 }

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -291,7 +291,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		registryMirror = viper.GetStringSlice("registry_mirror")
 	}
 
-	existing, err := config.Load(viper.GetString(config.ProfileName))
+	existing, err := config.Load(ClusterFlagValue())
 	if err != nil && !config.IsNotExist(err) {
 		exit.WithCodeT(exit.Data, "Unable to load config: {{.error}}", out.V{"error": err})
 	}
@@ -390,8 +390,8 @@ func updateDriver(driverName string) {
 
 func displayVersion(version string) {
 	prefix := ""
-	if viper.GetString(config.ProfileName) != constants.DefaultClusterName {
-		prefix = fmt.Sprintf("[%s] ", viper.GetString(config.ProfileName))
+	if ClusterFlagValue() != constants.DefaultClusterName {
+		prefix = fmt.Sprintf("[%s] ", ClusterFlagValue())
 	}
 
 	versionState := out.Happy
@@ -653,14 +653,6 @@ func selectImageRepository(mirrorCountry string, v semver.Version) (bool, string
 	return false, fallback, nil
 }
 
-// Return a minikube command containing the current profile name
-func minikubeCmd() string {
-	if viper.GetString(config.ProfileName) != constants.DefaultClusterName {
-		return fmt.Sprintf("minikube -p %s", config.ProfileName)
-	}
-	return "minikube"
-}
-
 // validateUser validates minikube is run by the recommended user (privileged or regular)
 func validateUser(drvName string) {
 	u, err := user.Current()
@@ -686,7 +678,7 @@ func validateUser(drvName string) {
 	if !useForce {
 		os.Exit(exit.Permissions)
 	}
-	_, err = config.Load(viper.GetString(config.ProfileName))
+	_, err = config.Load(ClusterFlagValue())
 	if err == nil || !config.IsNotExist(err) {
 		out.T(out.Tip, "Tip: To remove this root owned cluster, run: sudo {{.cmd}} delete", out.V{"cmd": minikubeCmd()})
 	}
@@ -811,7 +803,7 @@ func validateFlags(cmd *cobra.Command, drvName string) {
 	}
 
 	if driver.BareMetal(drvName) {
-		if viper.GetString(config.ProfileName) != constants.DefaultClusterName {
+		if ClusterFlagValue() != constants.DefaultClusterName {
 			exit.WithCodeT(exit.Config, "The '{{.name}} driver does not support multiple profiles: https://minikube.sigs.k8s.io/docs/reference/drivers/none/", out.V{"name": drvName})
 		}
 
@@ -938,7 +930,7 @@ func createNode(cmd *cobra.Command, k8sVersion, kubeNodeName, drvName, repositor
 	}
 
 	cfg := config.ClusterConfig{
-		Name:                    viper.GetString(config.ProfileName),
+		Name:                    ClusterFlagValue(),
 		KeepContext:             viper.GetBool(keepContext),
 		EmbedCerts:              viper.GetBool(embedCerts),
 		MinikubeISO:             viper.GetString(isoURL),
@@ -971,7 +963,7 @@ func createNode(cmd *cobra.Command, k8sVersion, kubeNodeName, drvName, repositor
 		NatNicType:              viper.GetString(natNicType),
 		KubernetesConfig: config.KubernetesConfig{
 			KubernetesVersion:      k8sVersion,
-			ClusterName:            viper.GetString(config.ProfileName),
+			ClusterName:            ClusterFlagValue(),
 			APIServerName:          viper.GetString(apiServerName),
 			APIServerNames:         apiServerNames,
 			APIServerIPs:           apiServerIPs,

--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -29,16 +29,14 @@ import (
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/bootstrapper/bsutil/kverify"
 	"k8s.io/minikube/pkg/minikube/cluster"
-	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/kubeconfig"
 	"k8s.io/minikube/pkg/minikube/machine"
-	"k8s.io/minikube/pkg/minikube/out"
+	"k8s.io/minikube/pkg/minikube/mustload"
 )
 
 var statusFormat string
@@ -101,24 +99,13 @@ var statusCmd = &cobra.Command{
 			exit.UsageT("Cannot use both --output and --format options")
 		}
 
-		api, err := machine.NewAPIClient()
-		if err != nil {
-			exit.WithCodeT(exit.Unavailable, "Error getting client: {{.error}}", out.V{"error": err})
-		}
-		defer api.Close()
-
-		cc, err := config.Load(viper.GetString(config.ProfileName))
-		if err != nil {
-			if config.IsNotExist(err) {
-				exit.WithCodeT(exitCode(&Status{}), `The "{{.name}}" cluster does not exist!`, out.V{"name": viper.GetString(config.ProfileName)})
-			}
-			exit.WithError("getting config", err)
-		}
+		cname := ClusterFlagValue()
+		api, cc := mustload.Partial(cname)
 
 		var st *Status
 		for _, n := range cc.Nodes {
 			machineName := driver.MachineName(*cc, n)
-			st, err = status(api, machineName, n.ControlPlane)
+			st, err := status(api, machineName, n.ControlPlane)
 			if err != nil {
 				glog.Errorf("status error: %v", err)
 			}

--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -103,9 +103,13 @@ var statusCmd = &cobra.Command{
 		api, cc := mustload.Partial(cname)
 
 		var st *Status
+		var err error
 		for _, n := range cc.Nodes {
+			glog.Infof("checking status of %s ...", n.Name)
 			machineName := driver.MachineName(*cc, n)
-			st, err := status(api, machineName, n.ControlPlane)
+			st, err = status(api, machineName, n.ControlPlane)
+			glog.Infof("%s status: %+v", machineName, st)
+
 			if err != nil {
 				glog.Errorf("status error: %v", err)
 			}
@@ -127,6 +131,7 @@ var statusCmd = &cobra.Command{
 			}
 		}
 
+		// TODO: Update for multi-node
 		os.Exit(exitCode(st))
 	},
 }

--- a/cmd/minikube/cmd/unpause.go
+++ b/cmd/minikube/cmd/unpause.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"os"
 	"strings"
 
 	"github.com/golang/glog"
@@ -25,11 +24,11 @@ import (
 	"github.com/spf13/viper"
 
 	"k8s.io/minikube/pkg/minikube/cluster"
-	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/cruntime"
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/machine"
+	"k8s.io/minikube/pkg/minikube/mustload"
 	"k8s.io/minikube/pkg/minikube/out"
 )
 
@@ -38,27 +37,12 @@ var unpauseCmd = &cobra.Command{
 	Use:   "unpause",
 	Short: "unpause Kubernetes",
 	Run: func(cmd *cobra.Command, args []string) {
-		cname := viper.GetString(config.ProfileName)
-		api, err := machine.NewAPIClient()
-		if err != nil {
-			exit.WithError("Error getting client", err)
-		}
-		defer api.Close()
-		cc, err := config.Load(cname)
+		cname := ClusterFlagValue()
+		co := mustload.Running(cname)
 
-		if err != nil && !config.IsNotExist(err) {
-			exit.WithError("Error loading profile config", err)
-		}
-
-		if err != nil {
-			out.ErrT(out.Meh, `"{{.name}}" profile does not exist`, out.V{"name": cname})
-			os.Exit(1)
-		}
-		glog.Infof("config: %+v", cc)
-
-		for _, n := range cc.Nodes {
-			machineName := driver.MachineName(*cc, n)
-			host, err := machine.LoadHost(api, machineName)
+		for _, n := range co.Config.Nodes {
+			machineName := driver.MachineName(*co.Config, n)
+			host, err := machine.LoadHost(co.API, machineName)
 			if err != nil {
 				exit.WithError("Error getting host", err)
 			}
@@ -68,7 +52,7 @@ var unpauseCmd = &cobra.Command{
 				exit.WithError("Failed to get command runner", err)
 			}
 
-			cr, err := cruntime.New(cruntime.Config{Type: cc.KubernetesConfig.ContainerRuntime, Runner: r})
+			cr, err := cruntime.New(cruntime.Config{Type: co.Config.KubernetesConfig.ContainerRuntime, Runner: r})
 			if err != nil {
 				exit.WithError("Failed runtime", err)
 			}

--- a/cmd/minikube/cmd/update-context.go
+++ b/cmd/minikube/cmd/update-context.go
@@ -18,12 +18,9 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"k8s.io/minikube/pkg/minikube/cluster"
-	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/kubeconfig"
-	"k8s.io/minikube/pkg/minikube/machine"
+	"k8s.io/minikube/pkg/minikube/mustload"
 	"k8s.io/minikube/pkg/minikube/out"
 )
 
@@ -34,24 +31,16 @@ var updateContextCmd = &cobra.Command{
 	Long: `Retrieves the IP address of the running cluster, checks it
 			with IP in kubeconfig, and corrects kubeconfig if incorrect.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		api, err := machine.NewAPIClient()
-		if err != nil {
-			exit.WithError("Error getting client", err)
-		}
-		defer api.Close()
-		machineName := viper.GetString(config.ProfileName)
-		ip, err := cluster.GetHostDriverIP(api, machineName)
-		if err != nil {
-			exit.WithError("Error host driver ip status", err)
-		}
-		updated, err := kubeconfig.UpdateIP(ip, machineName, kubeconfig.PathFromEnv())
+		cname := ClusterFlagValue()
+		co := mustload.Running(cname)
+		updated, err := kubeconfig.UpdateIP(co.DriverIP, cname, kubeconfig.PathFromEnv())
 		if err != nil {
 			exit.WithError("update config", err)
 		}
 		if updated {
-			out.T(out.Celebrate, "{{.machine}} IP has been updated to point at {{.ip}}", out.V{"machine": machineName, "ip": ip})
+			out.T(out.Celebrate, "{{.cluster}} IP has been updated to point at {{.ip}}", out.V{"cluster": cname, "ip": co.DriverIP})
 		} else {
-			out.T(out.Meh, "{{.machine}} IP was already correctly configured for {{.ip}}", out.V{"machine": machineName, "ip": ip})
+			out.T(out.Meh, "{{.cluster}} IP was already correctly configured for {{.ip}}", out.V{"cluster": cname, "ip": co.DriverIP})
 		}
 
 	},

--- a/pkg/minikube/mustload/mustload.go
+++ b/pkg/minikube/mustload/mustload.go
@@ -25,6 +25,7 @@ import (
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/state"
+	"github.com/golang/glog"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/bootstrapper/bsutil/kverify"
 	"k8s.io/minikube/pkg/minikube/command"
@@ -47,6 +48,7 @@ type ClusterController struct {
 
 // Partial is a cmd-friendly way to load a cluster which may or may not be running
 func Partial(name string) (libmachine.API, *config.ClusterConfig) {
+	glog.Infof("Loading cluster: %s", name)
 	api, err := machine.NewAPIClient()
 	if err != nil {
 		exit.WithError("libmachine failed", err)

--- a/pkg/minikube/mustload/mustload.go
+++ b/pkg/minikube/mustload/mustload.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2020 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// mustload loads minikube clusters, exiting with user-friendly messages
+package mustload
+
+import (
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/docker/machine/libmachine"
+	"github.com/docker/machine/libmachine/host"
+	"github.com/docker/machine/libmachine/state"
+	"k8s.io/minikube/pkg/drivers/kic/oci"
+	"k8s.io/minikube/pkg/minikube/bootstrapper/bsutil/kverify"
+	"k8s.io/minikube/pkg/minikube/command"
+	"k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/driver"
+	"k8s.io/minikube/pkg/minikube/exit"
+	"k8s.io/minikube/pkg/minikube/machine"
+	"k8s.io/minikube/pkg/minikube/out"
+)
+
+type ClusterController struct {
+	Config   *config.ClusterConfig
+	API      libmachine.API
+	CPHost   *host.Host
+	CPNode   *config.Node
+	CPRunner command.Runner
+	DriverIP net.IP
+}
+
+// Partial is a cmd-friendly way to load a cluster which may or may not be running
+func Partial(name string) (libmachine.API, *config.ClusterConfig) {
+	api, err := machine.NewAPIClient()
+	if err != nil {
+		exit.WithError("libmachine failed", err)
+	}
+
+	cc, err := config.Load(name)
+	if err != nil {
+		if config.IsNotExist(err) {
+			out.T(out.Shrug, `There is no local cluster named "{{.cluster}}"`, out.V{"cluster": name})
+			exitTip("start", name, exit.Data)
+		}
+		exit.WithError("Error getting cluster config", err)
+	}
+
+	return api, cc
+}
+
+// Running is a cmd-friendly way to load a running cluster
+func Running(name string) ClusterController {
+	api, cc := Partial(name)
+
+	cp, err := config.PrimaryControlPlane(cc)
+	if err != nil {
+		exit.WithError("Unable to find control plane", err)
+	}
+
+	hs, err := machine.Status(api, cp.Name)
+	if err != nil {
+		exit.WithError("Unable to get machine status", err)
+	}
+
+	if hs == state.None.String() {
+		out.T(out.Shrug, `The control plane node "{{.name}}" does not exist.`, out.V{"name": cp.Name})
+		exitTip("start", name, exit.Unavailable)
+	}
+
+	if hs == state.Stopped.String() {
+		out.T(out.Shrug, `The control plane node must be running for this command`)
+		exitTip("start", name, exit.Unavailable)
+	}
+
+	if hs != state.Running.String() {
+		out.T(out.Shrug, `The control plane node is not running (state={{.state}})`, out.V{"name": cp.Name, "state": hs})
+		exitTip("start", name, exit.Unavailable)
+	}
+
+	host, err := machine.LoadHost(api, name)
+	if err != nil {
+		exit.WithError("Unable to load host", err)
+	}
+
+	cr, err := machine.CommandRunner(host)
+	if err != nil {
+		exit.WithError("Unable to get command runner", err)
+	}
+
+	ips, err := host.Driver.GetIP()
+	if err != nil {
+		exit.WithError("Unable to get driver IP", err)
+	}
+
+	if driver.IsKIC(host.DriverName) {
+		ips = oci.DefaultBindIPV4
+	}
+
+	ip := net.ParseIP(ips)
+	if ip == nil {
+		exit.WithCodeT(exit.Software, fmt.Sprintf("Unable to parse driver IP: %q", ips))
+	}
+
+	return ClusterController{
+		API:      api,
+		Config:   cc,
+		CPRunner: cr,
+		CPHost:   host,
+		CPNode:   &cp,
+		DriverIP: ip,
+	}
+}
+
+// Healthy is a cmd-friendly way to load a healthy cluster
+func Healthy(name string) ClusterController {
+	co := Running(name)
+
+	as, err := kverify.APIServerStatus(co.CPRunner, net.ParseIP(co.CPNode.IP), co.CPNode.Port)
+	if err != nil {
+		out.T(out.FailureType, `Unable to get control plane status: {{.error}}`, out.V{"error": err})
+		exitTip("delete", name, exit.Unavailable)
+	}
+
+	if as == state.Paused {
+		out.T(out.Shrug, `The control plane for "{{.name}}" is paused!`, out.V{"name": name})
+		exitTip("unpause", name, exit.Unavailable)
+	}
+
+	if as != state.Running {
+		out.T(out.Shrug, `This control plane is not running! (state={{.state}})`, out.V{"state": as.String()})
+		out.T(out.Warning, `This is unusual - you may want to investigate using "{{.command}} logs"`, out.V{"command": minikubeCmd(name)})
+		exitTip("start", name, exit.Unavailable)
+	}
+	return co
+}
+
+// Return a minikube command containing the current profile name
+func minikubeCmd(cname string) string {
+	if cname != constants.DefaultClusterName {
+		return fmt.Sprintf("minikube -p %s", cname)
+	}
+	return "minikube"
+}
+
+// exitTip returns an action tip and exits
+func exitTip(action string, profile string, code int) {
+	command := minikubeCmd(profile) + " " + action
+	out.T(out.Workaround, "To fix this, run: {{.command}}", out.V{"command": command})
+	os.Exit(code)
+}

--- a/pkg/minikube/mustload/mustload.go
+++ b/pkg/minikube/mustload/mustload.go
@@ -153,17 +153,17 @@ func Healthy(name string) ClusterController {
 	return co
 }
 
-// Return a minikube command containing the current profile name
-func minikubeCmd(cname string) string {
+// ExampleCmd Return a minikube command containing the current profile name
+func ExampleCmd(cname string, action string) string {
 	if cname != constants.DefaultClusterName {
-		return fmt.Sprintf("minikube -p %s", cname)
+		return fmt.Sprintf("minikube %s -p %s", action, cname)
 	}
-	return "minikube"
+	return fmt.Sprintf("minikube %s", action)
 }
 
 // exitTip returns an action tip and exits
 func exitTip(action string, profile string, code int) {
-	command := minikubeCmd(profile) + " " + action
+	command := ExampleCmd(profile, action)
 	out.T(out.Workaround, "To fix this, run: {{.command}}", out.V{"command": command})
 	os.Exit(code)
 }

--- a/pkg/minikube/mustload/mustload.go
+++ b/pkg/minikube/mustload/mustload.go
@@ -75,7 +75,8 @@ func Running(name string) ClusterController {
 		exit.WithError("Unable to find control plane", err)
 	}
 
-	hs, err := machine.Status(api, cp.Name)
+	machineName := driver.MachineName(*cc, cp)
+	hs, err := machine.Status(api, machineName)
 	if err != nil {
 		exit.WithError("Unable to get machine status", err)
 	}

--- a/pkg/minikube/out/style.go
+++ b/pkg/minikube/out/style.go
@@ -83,6 +83,8 @@ var styles = map[StyleEnum]style{
 	Sparkle:       {Prefix: "✨  "},
 	Pause:         {Prefix: "⏸️  "},
 	Unpause:       {Prefix: "⏯️  "},
+	Confused:      {Prefix: "😕  "},
+	Shrug:         {Prefix: "🤷  "},
 
 	// Specialized purpose styles
 	ISODownload:      {Prefix: "💿  "},

--- a/pkg/minikube/out/style_enum.go
+++ b/pkg/minikube/out/style_enum.go
@@ -61,6 +61,7 @@ const (
 	DeletingHost
 	Copying
 	Connectivity
+	Confused
 	Internet
 	Mounting
 	Celebrate
@@ -89,4 +90,5 @@ const (
 	DryRun
 	AddonEnable
 	AddonDisable
+	Shrug
 )


### PR DESCRIPTION
This brings all of the commands together to consistently load clusters in a way that we can deliver a friendly message. 

Also fixes minor bits of technical debt:

* consistent naming of imports
* consistent naming of cluster name
* adds `ClusterFlagValue()` function

Fixes #7150 #7128 #7127 #7066 #6814 #5807 

# Examples

## stopping a nonexistent cluster

Was:

```

💣  Error getting cluster config: cluster "minikube" does not exist

😿  minikube is exiting due to an error. If the above message is not useful, open an issue:
👉  https://github.com/kubernetes/minikube/issues/new/choose
```


Now:

```
🤷  There is no local cluster named "minikube"
👉  To fix this, run: minikube start
```

## pausing a stopped cluster

Was:

```

💣  Pause: kubelet disable: disable: sudo systemctl disable kubelet: exit status 1
stdout:

stderr:
Error response from daemon: Container 9946e6e75d6826978a1323785252010ebb8e3cead58b4fec52e813de3398444a is not running


😿  minikube is exiting due to an error. If the above message is not useful, open an issue:
👉  https://github.com/kubernetes/minikube/issues/new/choose
```

Now:

```
🤷  The control plane node must be running for this command
👉  To fix this, run: minikube -p xyzzy start
```

## service on a paused cluster

Was:

```
💣  error starting tunnel: Service hello-node was not found in "default" namespace. You may select another namespace by using 'minikube service hello-node -n <namespace>: Get https://127.0.0.1:32774/api/v1/namespaces/default/services/hello-node?timeout=1s: context deadline exceeded

😿  minikube is exiting due to an error. If the above message is not useful, open an issue:
👉  https://github.com/kubernetes/minikube/issues/new/choose
```

Now:

```
🤷  The control plane for "xyzzy" is paused!
👉  To fix this, run: minikube -p xyzzy unpause
```

## Testing

Tested with:

```
status
./out/minikube stop
dashboard
pause
./out/minikube unpause
docker-env
podman-env
cache add moo
addons
config
profile
update-context
service xxx
tunnel
mount /tmp:/tmp
ssh
kubectl
ssh-key
ip
logs
update-check
version
options
completion
delete
```