### PR TITLE
Fix output of ssh command test

### DIFF
--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -698,7 +698,7 @@ func validateSSHCmd(ctx context.Context, t *testing.T, profile string) {
 	if NoneDriver() {
 		t.Skipf("skipping: ssh unsupported by none")
 	}
-	want := "hello\r\n"
+	want := "hello\n"
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", fmt.Sprintf("echo hello")))
 	if err != nil {
 		t.Errorf("%s failed: %v", rr.Args, err)


### PR DESCRIPTION
TestFunctional/parallel/SSHCmd was failing with the error:

```
    --- FAIL: TestFunctional/parallel (0.00s)
        --- FAIL: TestFunctional/parallel/SSHCmd (0.40s)
            functional_test.go:702: (dbg) Run:  out/minikube -p minikube ssh "echo hello"
            functional_test.go:707: [../../out/minikube -p minikube ssh echo hello] = "hello\n", want = "hello\r\n"
```

this fixes it locally on my mac

should fix #7170 