### PR TITLE
install conntrack for github action integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,7 +155,7 @@ jobs:
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
     needs: [build_minikube]
     steps:
-    - name: install lz4
+    - name: Install lz4
       shell: bash
       run: |
         sudo apt-get update -qq
@@ -362,12 +362,12 @@ jobs:
         SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
       runs-on: ubuntu-18.04
       steps:
-      - name: install lz4
+      - name: Install lz4
         shell: bash
         run: |
           sudo apt-get update -qq
           sudo apt-get -qq -y install liblz4-tool
-      - name: install podman
+      - name: Install podman
         shell: bash
         run: |
           . /etc/os-release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,10 +93,6 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt-get -qq -y install liblz4-tool
-    - name: Install conntrack
-      shell: bash
-      run: |
-        sudo apt-get -qq -y install conntrack
     - name: Install gopogh
       shell: bash
       run: |
@@ -164,10 +160,6 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt-get -qq -y install liblz4-tool
-    - name: Install conntrack
-      shell: bash
-      run: |
-        sudo apt-get -qq -y install conntrack
     - name: Docker Info
       shell: bash
       run: |
@@ -236,6 +228,7 @@ jobs:
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
     runs-on: ubuntu-16.04
     steps:
+    # conntrack is required for kubernetes 1.18 and highter
     - name: Install conntrack
       shell: bash
       run: |
@@ -303,6 +296,7 @@ jobs:
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
     runs-on: ubuntu-18.04
     steps:
+    # conntrack is required for kubernetes 1.18 and highter
     - name: Install conntrack
       shell: bash
       run: |
@@ -375,10 +369,6 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get -qq -y install liblz4-tool
-      - name: Install conntrack
-        shell: bash
-        run: |
-          sudo apt-get -qq -y install conntrack
       - name: Install podman
         shell: bash
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
         docker info || true
         docker version || true
         docker ps || true
-    - name: install lz4
+    - name: Install lz4
       shell: bash
       run: |
         sudo apt-get update -qq
@@ -228,11 +228,11 @@ jobs:
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
     runs-on: ubuntu-16.04
     steps:
-    - name: install lz4
+    - name: Install conntrack
       shell: bash
       run: |
         sudo apt-get update -qq
-        sudo apt-get -qq -y install liblz4-tool
+        sudo apt-get -qq -y install conntrack
     - name: Install gopogh
       shell: bash
       run: |
@@ -295,11 +295,11 @@ jobs:
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
     runs-on: ubuntu-18.04
     steps:
-    - name: install lz4
+    - name: Install conntrack
       shell: bash
       run: |
         sudo apt-get update -qq
-        sudo apt-get -qq -y install liblz4-tool
+        sudo apt-get -qq -y install conntrack
     - name: Install gopogh
       shell: bash
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -228,10 +228,14 @@ jobs:
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
     runs-on: ubuntu-16.04
     steps:
-    - name: Install conntrack
+    - name: Install lz4
       shell: bash
       run: |
         sudo apt-get update -qq
+        sudo apt-get -qq -y install liblz4-tool
+    - name: Install conntrack
+      shell: bash
+      run: |
         sudo apt-get -qq -y install conntrack
     - name: Install gopogh
       shell: bash
@@ -295,10 +299,14 @@ jobs:
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
     runs-on: ubuntu-18.04
     steps:
-    - name: Install conntrack
+    - name: Install lz4
       shell: bash
       run: |
         sudo apt-get update -qq
+        sudo apt-get -qq -y install liblz4-tool
+    - name: Install conntrack
+      shell: bash
+      run: |
         sudo apt-get -qq -y install conntrack
     - name: Install gopogh
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -228,7 +228,7 @@ jobs:
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
     runs-on: ubuntu-16.04
     steps:
-    # conntrack is required for kubernetes 1.18 and highter
+    # conntrack is required for kubernetes 1.18 and higher
     - name: Install conntrack
       shell: bash
       run: |
@@ -296,7 +296,7 @@ jobs:
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
     runs-on: ubuntu-18.04
     steps:
-    # conntrack is required for kubernetes 1.18 and highter
+    # conntrack is required for kubernetes 1.18 and higher
     - name: Install conntrack
       shell: bash
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,6 +93,10 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt-get -qq -y install liblz4-tool
+    - name: Install conntrack
+      shell: bash
+      run: |
+        sudo apt-get -qq -y install conntrack
     - name: Install gopogh
       shell: bash
       run: |
@@ -160,6 +164,10 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt-get -qq -y install liblz4-tool
+    - name: Install conntrack
+      shell: bash
+      run: |
+        sudo apt-get -qq -y install conntrack
     - name: Docker Info
       shell: bash
       run: |
@@ -228,14 +236,10 @@ jobs:
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
     runs-on: ubuntu-16.04
     steps:
-    - name: Install lz4
-      shell: bash
-      run: |
-        sudo apt-get update -qq
-        sudo apt-get -qq -y install liblz4-tool
     - name: Install conntrack
       shell: bash
       run: |
+        sudo apt-get update -qq
         sudo apt-get -qq -y install conntrack
     - name: Install gopogh
       shell: bash
@@ -299,14 +303,10 @@ jobs:
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
     runs-on: ubuntu-18.04
     steps:
-    - name: Install lz4
-      shell: bash
-      run: |
-        sudo apt-get update -qq
-        sudo apt-get -qq -y install liblz4-tool
     - name: Install conntrack
       shell: bash
       run: |
+        sudo apt-get update -qq
         sudo apt-get -qq -y install conntrack
     - name: Install gopogh
       shell: bash
@@ -375,6 +375,10 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get -qq -y install liblz4-tool
+      - name: Install conntrack
+        shell: bash
+        run: |
+          sudo apt-get -qq -y install conntrack
       - name: Install podman
         shell: bash
         run: |

--- a/test/integration/main.go
+++ b/test/integration/main.go
@@ -60,12 +60,12 @@ func Target() string {
 
 // NoneDriver returns whether or not this test is using the none driver
 func NoneDriver() bool {
-	return strings.Contains(*startArgs, "--driver=none")
+	return strings.Contains(*startArgs, "--driver=none") || strings.Contains(*startArgs, "--vm-driver=none")
 }
 
 // HyperVDriver returns whether or not this test is using the Hyper-V driver
 func HyperVDriver() bool {
-	return strings.Contains(*startArgs, "--driver=hyperv")
+	return strings.Contains(*startArgs, "--driver=hyperv") || strings.Contains(*startArgs, "--vm-driver=hyperv")
 }
 
 // CanCleanup returns if cleanup is allowed


### PR DESCRIPTION
Kubernetes 1.18 needs conntrack to run, so let's install it before running none tests

Fixes #7179 