### PR TITLE
fail if kic container is not running after create

### DIFF
--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -156,6 +156,10 @@ func CreateContainerNode(p CreateParams) error {
 		if s != "running" {
 			return fmt.Errorf("temporary error created container %q is not running yet", p.Name)
 		}
+		if s == "running" {
+			glog.Infof("the created container %q has a running status.", p.Name)
+			return nil
+		}
 		return nil
 	}
 

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -163,8 +163,8 @@ func CreateContainerNode(p CreateParams) error {
 		return nil
 	}
 
-	// retry up to up 5 seconds to make sure the created container status is running.
-	if err := retry.Expo(checkRunning, 13*time.Millisecond, time.Second*10); err != nil {
+	// retry up to up 13 seconds to make sure the created container status is running.
+	if err := retry.Expo(checkRunning, 13*time.Millisecond, time.Second*13); err != nil {
 		return errors.Wrapf(err, "check container %q running", p.Name)
 	}
 

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -164,8 +164,8 @@ func CreateContainerNode(p CreateParams) error {
 	}
 
 	// retry up to up 5 seconds to make sure the created container status is running.
-	if err := retry.Expo(checkRunning, 13*time.Millisecond, time.Second*5); err != nil {
-		glog.Warningf("The created container %q failed to report to be running in 5 seconds.", p.Name)
+	if err := retry.Expo(checkRunning, 13*time.Millisecond, time.Second*10); err != nil {
+		return errors.Wrapf(err, "check container %q running", p.Name)
 	}
 
 	return nil

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -156,10 +156,7 @@ func CreateContainerNode(p CreateParams) error {
 		if s != "running" {
 			return fmt.Errorf("temporary error created container %q is not running yet", p.Name)
 		}
-		if s == "running" {
-			glog.Infof("the created container %q has a running status.", p.Name)
-			return nil
-		}
+		glog.Infof("the created container %q has a running status.", p.Name)
 		return nil
 	}
 


### PR DESCRIPTION
When investigating a failed test I saw

```
I0324 11:58:50.291882   91200 fix.go:62] fixHost completed within 3m0.658676636s
I0324 11:58:50.291887   91200 start.go:77] releasing machines lock for "vupgrade-20200324T115254.289551245-10040", held for 3m0.658733038s
W0324 11:58:50.292059   91200 exit.go:101] Unable to start VM. Please investigate and run 'minikube delete' if possible: provision: get ssh host-port: get host-bind port 22 for "vupgrade-20200324T115254.289551245-10040", output 
Template parsing error: template: :1:4: executing "" at <index (index .NetworkSettings.Ports "22/tcp") 0>: error calling index: index of untyped nil
: exit status 1
* 
```

that got me thinking... is the container in running status ? so lets log it and then to make minikube more reliable, we will wait longer for container status to be running. and fail if it doesn't become running.