### PR TITLE
Parse --disk-size and --memory sizes with binary suffixes

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -38,12 +38,13 @@ func CalculateSizeInMB(humanReadableSize string) (int, error) {
 	if err == nil {
 		humanReadableSize += "mb"
 	}
-	size, err := units.FromHumanSize(humanReadableSize)
+	// parse the size suffix binary instead of decimal so that 1G -> 1024MB instead of 1000MB
+	size, err := units.RAMInBytes(humanReadableSize)
 	if err != nil {
 		return 0, fmt.Errorf("FromHumanSize: %v", err)
 	}
 
-	return int(size / units.MB), nil
+	return int(size / units.MiB), nil
 }
 
 // GetBinaryDownloadURL returns a suitable URL for the platform

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -51,6 +51,7 @@ func TestCalculateSizeInMB(t *testing.T) {
 		{"1024KB", 1},
 		{"1024mb", 1024},
 		{"1024b", 0},
+		{"1g", 1024},
 	}
 
 	for _, tt := range testData {
@@ -59,7 +60,7 @@ func TestCalculateSizeInMB(t *testing.T) {
 			t.Fatalf("unexpected err: %v", err)
 		}
 		if number != tt.expectedNumber {
-			t.Fatalf("Expected '%d'' but got '%d'", tt.expectedNumber, number)
+			t.Fatalf("Expected '%d' but got '%d' from size '%s'", tt.expectedNumber, number, tt.size)
 		}
 	}
 }


### PR DESCRIPTION
Hi!

when enabling the istio addon I got the message that I would need more memory in my VM - to my surprise it parsed the `--memory 8g` parameter as `8000MB` and not `8192MB`.
After looking at the rest of the code which uses 1024 in various locations for calculating sizes this seems not intended - I'm of course not sure if this is really the case :).

### Detailed Issue Description
```
 $ minikube addons enable istio
❗  Istio needs 8192MB of memory -- your configuration only allocates 4000MB
...
```

As it said I need to give my VM 8192MB I thought that I can just run it with `--memory 8g` which resulted in 8000MB instead of the expected 8GiB=8192MB:
```
 $ minikube start --memory 8g --cpus 4
😄  minikube v1.8.2 on Darwin 10.15.3
✨  Using the hyperkit driver based on existing profile
⌛  Reconfiguring existing host ...
🏃  Using the running hyperkit "minikube" VM ...
🐳  Preparing Kubernetes v1.17.3 on Docker 19.03.6 ...
🚀  Launching Kubernetes ...
🌟  Enabling addons: dashboard, default-storageclass, efk, ingress, logviewer, registry, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube"
 $ minikube addons enable istio
❗  Istio needs 8192MB of memory -- your configuration only allocates 8000MB
...
```

Thanks!
Vincent
