### PR TITLE
Add 'stable' and 'latest' as valid kubernetes-version values

### DIFF
--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/constants"
 )
 
-func TestGetKuberneterVersion(t *testing.T) {
+func TestGetKubernetesVersion(t *testing.T) {
 	var tests = []struct {
 		description     string
 		expectedVersion string
@@ -54,6 +54,16 @@ func TestGetKuberneterVersion(t *testing.T) {
 			expectedVersion: "v1.16.0",
 			paramVersion:    "v1.16.0",
 			cfg:             &cfg.ClusterConfig{KubernetesConfig: cfg.KubernetesConfig{KubernetesVersion: "v1.15.0"}},
+		},
+		{
+			description:     "kubernetes-version given as 'stable', no config",
+			expectedVersion: constants.DefaultKubernetesVersion,
+			paramVersion:    "stable",
+		},
+		{
+			description:     "kubernetes-version given as 'latest', no config",
+			expectedVersion: constants.NewestKubernetesVersion,
+			paramVersion:    "latest",
 		},
 	}
 


### PR DESCRIPTION
Fixes #6126 

Hi,

mini PR, this was done with quite a lot of other changes in https://github.com/kubernetes/minikube/pull/6142 already but the user deleted his account.

I added the tags to the CLI help output, used a case insensitive comparison and really basic tests which are longer then the actual code but I think they still make sense e.g. to catch errors during refactorings or such.

CLI Output:
```
 $ out/minikube start --help | grep kubernetes-version
      --kubernetes-version='': The kubernetes version that the minikube VM will use (ex: v1.2.3 or latest/stable for supported versions)
```

**Edit**: I could adjust the CLI help output to contain the mapping from latest/stable to the appropriate version, it could look like:
```
 $ out/minikube start --help | grep kubernetes-version
      --kubernetes-version='': The kubernetes version that the minikube VM will use (ex: v1.2.3, 'stable' for v1.18.0-rc.1, 'latest' for v1.18.0-rc.1)
```

BR, Vincent
