### PR TITLE
wip: same version of tools in kic base image and VM ISO

### DIFF
--- a/hack/images/kicbase.Dockerfile
+++ b/hack/images/kicbase.Dockerfile
@@ -14,12 +14,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     openssh-server=1:8.0p1-6build1 \
     dnsutils=1:9.11.5.P4+dfsg-5.1ubuntu2.1 \
     && rm /etc/crictl.yaml
-# remove crictl in the base image
 # install crictl same version as VM ISO https://github.com/kubernetes/minikube/blob/master/deploy/iso/minikube-iso/package/crictl-bin/crictl-bin.mk#L7
 RUN curl -LO https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.17.0/crictl-v1.17.0-linux-amd64.tar.gz && \
     tar zxvf crictl-v1.17.0-linux-amd64.tar.gz -C /usr/local/bin && \
     rm -f crictl-v1.17.0-linux-amd64.tar.gz
-# remove containerd in the base image
 # install containerd same version as VM ISO https://github.com/kubernetes/minikube/blob/master/deploy/iso/minikube-iso/package/containerd-bin/containerd-bin.mk#L6
 RUN apt-get remove -y containerd && rm /etc/containerd/config.toml && \ 
     curl -LO https://download.docker.com/linux/ubuntu/dists/eoan/pool/stable/amd64/containerd.io_1.2.13-1_amd64.deb && \
@@ -40,7 +38,7 @@ RUN sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/lib
 # install podman same version as VM ISO https://github.com/kubernetes/minikube/blob/master/deploy/iso/minikube-iso/package/podman/podman.mk#L1
 RUN apt-get install -y --no-install-recommends podman=1.8.2~1
 # disable non-docker runtimes by default
-RUN systemctl disable containerd && systemctl disable crio
+RUN systemctl disable containerd && systemctl disable crio && rm /etc/crictl.yaml
 # enable docker which is default
 RUN systemctl enable docker
 # making SSH work for docker container 

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -32,7 +32,7 @@ const (
 	// Version is the current version of kic
 	Version = "v0.0.9"
 	// SHA of the kic base image
-	baseImageSHA = "0f44fcc781bf84b1b6a2ea6f8d347990db28e375206794cb290e4824302a905f"
+	baseImageSHA = "9860c1e0dd883bf67bfdb2aeb984a97fddb7cee9d8fc4bc74a83f41a0056c535"
 
 	// OverlayImage is the cni plugin used for overlay image, created by kind.
 	// CNI plugin image used for kic drivers created by kind.

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -30,9 +30,9 @@ const (
 	DefaultPodCIDR = "10.244.0.0/16"
 
 	// Version is the current version of kic
-	Version = "v0.0.8"
+	Version = "v0.0.9"
 	// SHA of the kic base image
-	baseImageSHA = "2f3380ebf1bb0c75b0b47160fd4e61b7b8fef0f1f32f9def108d3eada50a7a81"
+	baseImageSHA = "0f44fcc781bf84b1b6a2ea6f8d347990db28e375206794cb290e4824302a905f"
 
 	// OverlayImage is the cni plugin used for overlay image, created by kind.
 	// CNI plugin image used for kic drivers created by kind.


### PR DESCRIPTION
### This PR:
- update docker version to latest (and to match VM ISO) 19.03.8
- install same version of docker, crictl , containerd, crio, docker and podman 
- Added comments for the link to get version for opportunity to enforce automation in the future.

### future PRs
investigate if  the rest of things in the VM is needed for KIC as well. (such as falco,...)