### PR TITLE
Make recreateIfNeeded more robust, improve UX

### DIFF
--- a/cmd/minikube/cmd/stop.go
+++ b/cmd/minikube/cmd/stop.go
@@ -69,8 +69,9 @@ func runStop(cmd *cobra.Command, args []string) {
 
 func stop(api libmachine.API, cluster config.ClusterConfig, n config.Node) bool {
 	nonexistent := false
-	stop := func() (err error) {
-		machineName := driver.MachineName(cluster, n)
+	machineName := driver.MachineName(cluster, n)
+
+	tryStop := func() (err error) {
 		err = machine.StopHost(api, machineName)
 		if err == nil {
 			return nil
@@ -87,7 +88,7 @@ func stop(api libmachine.API, cluster config.ClusterConfig, n config.Node) bool 
 		}
 	}
 
-	if err := retry.Expo(stop, 5*time.Second, 3*time.Minute, 5); err != nil {
+	if err := retry.Expo(tryStop, 1*time.Second, 30*time.Second, 3); err != nil {
 		exit.WithError("Unable to stop VM", err)
 	}
 

--- a/go.sum
+++ b/go.sum
@@ -421,8 +421,6 @@ github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
-github.com/johanneswuerbach/nfsexports v0.0.0-20181204082207-1aa528dcb345 h1:XP1VL9iOZu4yz/rq8zj+yvB23XEY5erXRzp8JYmkWu0=
-github.com/johanneswuerbach/nfsexports v0.0.0-20181204082207-1aa528dcb345/go.mod h1:+c1/kUpg2zlkoWqTOvzDs36Wpbm3Gd1nlmtXAEB0WGU=
 github.com/johanneswuerbach/nfsexports v0.0.0-20200318065542-c48c3734757f h1:tL0xH80QVHQOde6Qqdohv6PewABH8l8N9pywZtuojJ0=
 github.com/johanneswuerbach/nfsexports v0.0.0-20200318065542-c48c3734757f/go.mod h1:+c1/kUpg2zlkoWqTOvzDs36Wpbm3Gd1nlmtXAEB0WGU=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -17,6 +17,7 @@ limitations under the License.
 package constants
 
 import (
+	"errors"
 	"path/filepath"
 
 	"k8s.io/client-go/tools/clientcmd"
@@ -100,4 +101,7 @@ var (
 		"storage-gluster",
 		"istio-operator",
 	}
+
+	// ErrMachineMissing is returned when virtual machine does not exist due to user interrupt cancel(i.e. Ctrl + C)
+	ErrMachineMissing = errors.New("machine does not exist")
 )

--- a/pkg/minikube/machine/cluster_test.go
+++ b/pkg/minikube/machine/cluster_test.go
@@ -44,7 +44,9 @@ func createMockDriverHost(c config.ClusterConfig, n config.Node) (interface{}, e
 
 func RegisterMockDriver(t *testing.T) {
 	// Debugging this test is a nightmare.
-	flag.Lookup("logtostderr").Value.Set("true")
+	if err := flag.Lookup("logtostderr").Value.Set("true"); err != nil {
+		t.Logf("unable to set logtostderr: %v", err)
+	}
 
 	t.Helper()
 	if !registry.Driver(driver.Mock).Empty() {

--- a/pkg/minikube/machine/cluster_test.go
+++ b/pkg/minikube/machine/cluster_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package machine
 
 import (
+	"flag"
 	"fmt"
 	"testing"
 	"time"
 
 	// Driver used by testdata
+	"k8s.io/minikube/pkg/minikube/constants"
 	_ "k8s.io/minikube/pkg/minikube/registry/drvs/virtualbox"
 
 	"github.com/docker/machine/libmachine/drivers"
@@ -41,6 +43,9 @@ func createMockDriverHost(c config.ClusterConfig, n config.Node) (interface{}, e
 }
 
 func RegisterMockDriver(t *testing.T) {
+	// Debugging this test is a nightmare.
+	flag.Lookup("logtostderr").Value.Set("true")
+
 	t.Helper()
 	if !registry.Driver(driver.Mock).Empty() {
 		return
@@ -163,7 +168,7 @@ func TestStartHostErrMachineNotExist(t *testing.T) {
 	// This should pass with creating host, while machine does not exist.
 	h, _, err = StartHost(api, mc, n)
 	if err != nil {
-		if err != ErrorMachineNotExist {
+		if err != constants.ErrMachineMissing {
 			t.Fatalf("Error starting host: %v", err)
 		}
 	}

--- a/pkg/minikube/machine/delete.go
+++ b/pkg/minikube/machine/delete.go
@@ -94,7 +94,7 @@ func DeleteHost(api libmachine.API, machineName string) error {
 func delete(api libmachine.API, h *host.Host, machineName string) error {
 	if err := h.Driver.Remove(); err != nil {
 		glog.Warningf("remove failed, will retry: %v", err)
-		time.Sleep(2 * time.Second)
+		time.Sleep(1 * time.Second)
 
 		nerr := h.Driver.Remove()
 		if nerr != nil {
@@ -111,9 +111,7 @@ func delete(api libmachine.API, h *host.Host, machineName string) error {
 // demolish destroys a host by any means necessary - use only if state is inconsistent
 func demolish(api libmachine.API, cc config.ClusterConfig, n config.Node, h *host.Host) {
 	machineName := driver.MachineName(cc, n)
-	glog.Infof("destroying %s ...", machineName)
-
-	// First try using the friendly API's.
+	glog.Infof("DEMOLISHING %s ...", machineName)
 
 	// This will probably fail
 	err := stop(h)

--- a/pkg/minikube/out/style.go
+++ b/pkg/minikube/out/style.go
@@ -60,7 +60,6 @@ var styles = map[StyleEnum]style{
 	Running:       {Prefix: "🏃  "},
 	Provisioning:  {Prefix: "🌱  "},
 	Restarting:    {Prefix: "🔄  "},
-	Reconfiguring: {Prefix: "📯  "},
 	Stopping:      {Prefix: "✋  "},
 	Stopped:       {Prefix: "🛑  "},
 	Warning:       {Prefix: "❗  ", LowPrefix: lowWarning},

--- a/pkg/minikube/out/style_enum.go
+++ b/pkg/minikube/out/style_enum.go
@@ -32,7 +32,6 @@ const (
 	Running
 	Provisioning
 	Restarting
-	Reconfiguring
 	Stopping
 	Stopped
 	Warning


### PR DESCRIPTION
Makes recreateIfNeeded more resilient to unexpected machine state failures, such as #7204

Also improves the UX. Here's an example where I've removed the VM of an active minikube cluster from VirtualBox:

## Before

```
⌛  Reconfiguring existing host ...
🙄  machine 'minikube' does not exist. Proceeding ahead with recreating VM.
🔥  Creating virtualbox VM (CPUs=2, Memory=6000MB, Disk=20000MB) ...
🤦  StartHost failed, but will try again: machine does not exist
⌛  Reconfiguring existing host ...
🏃  Using the running virtualbox "minikube" VM ...
```

## After

```
🤷  virtualbox "minikube" VM is missing, will recreate.
🔥  Creating virtualbox VM (CPUs=2, Memory=6000MB, Disk=20000MB) ...
```
