### PR TITLE
install socat

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -233,7 +233,8 @@ jobs:
     runs-on: ubuntu-16.04
     steps:
     # conntrack is required for kubernetes 1.18 and higher
-    - name: Install conntrack
+    # socat is required for kubectl port forward which is used in some tests such as validateHelmTillerAddon
+    - name: Install tools for none
       shell: bash
       run: |
         sudo apt-get update -qq
@@ -303,7 +304,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     # conntrack is required for kubernetes 1.18 and higher
-    - name: Install conntrack
+    # socat is required for kubectl port forward which is used in some tests such as validateHelmTillerAddon
+    - name: Install tools for none
       shell: bash
       run: |
         sudo apt-get update -qq

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -239,6 +239,7 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt-get -qq -y install conntrack
+        sudo apt-get -qq -y install socat
     - name: Install gopogh
       shell: bash
       run: |
@@ -310,6 +311,7 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt-get -qq -y install conntrack
+        sudo apt-get -qq -y install socat
     - name: Install gopogh
       shell: bash
       run: |

--- a/hack/jenkins/linux_integration_tests_none.sh
+++ b/hack/jenkins/linux_integration_tests_none.sh
@@ -53,14 +53,14 @@ sudo systemctl is-active --quiet kubelet \
 
  # conntrack is required for kubernetes 1.18 and higher for none driver
 if ! conntrack --version &>/dev/null; then
-  echo "WARNING: No contrack is not installed"
+  echo "WARNING: contrack is not installed. will try to install."
   sudo apt-get update -qq
   sudo apt-get -qq -y install conntrack
 fi
 
  # socat is required for kubectl port forward which is used in some tests such as validateHelmTillerAddon
 if ! which socat &>/dev/null; then
-  echo "WARNING: No socat is not installed"
+  echo "WARNING: socat is not installed. will try to install."
   sudo apt-get update -qq
   sudo apt-get -qq -y install socat
 fi

--- a/hack/jenkins/linux_integration_tests_none.sh
+++ b/hack/jenkins/linux_integration_tests_none.sh
@@ -58,6 +58,12 @@ if ! conntrack --version &>/dev/null; then
   sudo apt-get -qq -y install conntrack
 fi
 
+ # socat is required for kubectl port forward which is used in some tests such as validateHelmTillerAddon
+if ! which socat &>/dev/null; then
+  echo "WARNING: No socat is not installed"
+  sudo apt-get update -qq
+  sudo apt-get -qq -y install socat
+fi
 
 mkdir -p cron && gsutil -m rsync "gs://minikube-builds/${MINIKUBE_LOCATION}/cron" cron || echo "FAILED TO GET CRON FILES"
 sudo install cron/cleanup_and_reboot_Linux.sh /etc/cron.hourly/cleanup_and_reboot || echo "FAILED TO INSTALL CLEANUP"


### PR DESCRIPTION
for none tests we need kubectl portforward to test, as a follow up PR for https://github.com/kubernetes/minikube/pull/7232
to install socat on none machines, so we get higher test coverage.
