### PR TITLE
fix ci machine for docker on macos

### DIFF
--- a/hack/jenkins/osx_integration_tests_docker.sh
+++ b/hack/jenkins/osx_integration_tests_docker.sh
@@ -33,8 +33,13 @@ EXTRA_START_ARGS=""
 EXPECTED_DEFAULT_DRIVER="hyperkit"
 
 
-# restart docker on mac for a fresh test
-osascript -e 'quit app "Docker"'; open -a Docker ; while [ -z "$(docker info 2> /dev/null )" ]; do printf "."; sleep 1; done; echo "" || true
+# fix mac os as a service on mac os
+# https://github.com/docker/for-mac/issues/882#issuecomment-506372814
+osascript -e 'quit app "Docker"';
+sudo /Applications/Docker.app/Contents/MacOS/Docker --quit-after-install --unattended || true
+# repeating without sudo because  https://github.com/docker/for-mac/issues/882#issuecomment-516946766
+/Applications/Docker.app/Contents/MacOS/Docker --quit-after-install --unattended || true
+osascript -e 'quit app "Docker"'; /Applications/Docker.app/Contents/MacOS/Docker --unattended &; while [ -z "$(docker info 2> /dev/null )" ]; do printf "."; sleep 1; done; echo "" || true
 
 mkdir -p cron && gsutil -qm rsync "gs://minikube-builds/${MINIKUBE_LOCATION}/cron" cron || echo "FAILED TO GET CRON FILES"
 install cron/cleanup_and_reboot_Darwin.sh $HOME/cleanup_and_reboot.sh || echo "FAILED TO INSTALL CLEANUP"


### PR DESCRIPTION
### Update
we cant connect to our mac os machines because of this
https://github.com/kubernetes/minikube/issues/7251

till that ticket is solved we can not verify if this PR works.

Original PR description
------
our docker installation on mac os machine keeps crashing. seems like it is an issue for anyone using docker as in CI on mac os.

while trying to make docker work on travis on mac os I stumpled upon an old code of mine:
https://github.com/medyagh/travis-macos-experiment/blob/8fb615e2803a65e8bcbf4b7ec08ab237f8914adb/install_docker_hyperkit_on_travis.sh#L9
```
sudo /Applications/Docker.app/Contents/MacOS/Docker --unattended &
```

that I noticed other people have seen same issue.
More info

https://github.com/docker/for-mac/issues/882#issuecomment-506372814
https://github.com/docker/for-mac/issues/882#issuecomment-516946766

---

Bottom line: MAYBE be fixes our docker installation on mac os CIs