### PR TITLE
Improve test logs formatting

### DIFF
--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -156,9 +156,9 @@ func TestDownloadOnlyKic(t *testing.T) {
 
 	args := []string{"start", "--download-only", "-p", profile, "--force", "--alsologtostderr"}
 	args = append(args, StartArgs()...)
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
-	if err != nil {
-		t.Errorf("start with download only failed %q : %v:\n%s", args, err)
+
+	if _, err := Run(t, exec.CommandContext(ctx, Target(), args...)); err != nil {
+		t.Errorf("start with download only failed %q : %v", args, err)
 	}
 
 	// Make sure the downloaded image tarball exists

--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -129,7 +129,7 @@ func TestDownloadOnly(t *testing.T) {
 				}
 				rr, err := Run(t, exec.CommandContext(ctx, Target(), "delete", "--all"))
 				if err != nil {
-					t.Errorf("failed to delete all. args: %q : %v", rr.Args, err)
+					t.Errorf("failed to delete all. args: %q : %v", rr.Command(), err)
 				}
 			})
 			// Delete should always succeed, even if previously partially or fully deleted.
@@ -139,7 +139,7 @@ func TestDownloadOnly(t *testing.T) {
 				}
 				rr, err := Run(t, exec.CommandContext(ctx, Target(), "delete", "-p", profile))
 				if err != nil {
-					t.Errorf("failed to delete. args: %q: %v", rr.Args, err)
+					t.Errorf("failed to delete. args: %q: %v", rr.Command(), err)
 				}
 			})
 		})

--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -67,7 +67,7 @@ func TestDownloadOnly(t *testing.T) {
 					}
 
 					if err != nil {
-						t.Errorf("%s failed: %v", args, err)
+						t.Errorf("failed to download only. args: %q %v", args, err)
 					}
 
 					// skip for none, as none driver does not have preload feature.
@@ -75,14 +75,14 @@ func TestDownloadOnly(t *testing.T) {
 						if download.PreloadExists(v, r) {
 							// Just make sure the tarball path exists
 							if _, err := os.Stat(download.TarballPath(v)); err != nil {
-								t.Errorf("preloaded tarball path doesn't exist: %v", err)
+								t.Errorf("failed to verify preloaded tarball file exists: %v", err)
 							}
 							return
 						}
 					}
 					imgs, err := images.Kubeadm("", v)
 					if err != nil {
-						t.Errorf("kubeadm images: %v %+v", v, err)
+						t.Errorf("failed to get kubeadm images for %v: %+v", v, err)
 					}
 
 					// skip verify for cache images if --driver=none
@@ -129,7 +129,7 @@ func TestDownloadOnly(t *testing.T) {
 				}
 				rr, err := Run(t, exec.CommandContext(ctx, Target(), "delete", "--all"))
 				if err != nil {
-					t.Errorf("%s failed: %v", rr.Args, err)
+					t.Errorf("failed to delete all. args: %q : %v", rr.Args, err)
 				}
 			})
 			// Delete should always succeed, even if previously partially or fully deleted.
@@ -139,7 +139,7 @@ func TestDownloadOnly(t *testing.T) {
 				}
 				rr, err := Run(t, exec.CommandContext(ctx, Target(), "delete", "-p", profile))
 				if err != nil {
-					t.Errorf("%s failed: %v", rr.Args, err)
+					t.Errorf("failed to delete. args: %q: %v", rr.Args, err)
 				}
 			})
 		})
@@ -158,22 +158,22 @@ func TestDownloadOnlyKic(t *testing.T) {
 	args = append(args, StartArgs()...)
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
-		t.Errorf("%s failed: %v:\n%s", args, err, rr.Output())
+		t.Errorf("start with download only failed %q : %v:\n%s", args, err)
 	}
 
 	// Make sure the downloaded image tarball exists
 	tarball := download.TarballPath(constants.DefaultKubernetesVersion)
 	contents, err := ioutil.ReadFile(tarball)
 	if err != nil {
-		t.Errorf("reading tarball: %v", err)
+		t.Errorf("failed to read tarball file %q: %v", tarball, err)
 	}
 	// Make sure it has the correct checksum
 	checksum := md5.Sum(contents)
 	remoteChecksum, err := ioutil.ReadFile(download.PreloadChecksumPath(constants.DefaultKubernetesVersion))
 	if err != nil {
-		t.Errorf("reading checksum file: %v", err)
+		t.Errorf("failed to read checksum file %q : %v", download.PreloadChecksumPath(constants.DefaultKubernetesVersion), err)
 	}
 	if string(remoteChecksum) != string(checksum[:]) {
-		t.Errorf("checksum of %s does not match remote checksum (%s != %s)", tarball, string(remoteChecksum), string(checksum[:]))
+		t.Errorf("failed to verify checksum. checksum of %q does not match remote checksum (%q != %q)", tarball, string(remoteChecksum), string(checksum[:]))
 	}
 }

--- a/test/integration/aab_offline_test.go
+++ b/test/integration/aab_offline_test.go
@@ -53,7 +53,7 @@ func TestOffline(t *testing.T) {
 				rr, err := Run(t, c)
 				if err != nil {
 					// Fatal so that we may collect logs before stop/delete steps
-					t.Fatalf("%s failed: %v", rr.Args, err)
+					t.Fatalf("%s failed: %v", rr.Command(), err)
 				}
 			})
 		}

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -69,15 +69,15 @@ func TestAddons(t *testing.T) {
 	// Assert that disable/enable works offline
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "stop", "-p", profile))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed to stop minikube. args %q : %v", rr.Args, err)
 	}
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "addons", "enable", "dashboard", "-p", profile))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed to enable dashboard addon: args %q : %v", rr.Args, err)
 	}
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "addons", "disable", "dashboard", "-p", profile))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed to disable dashboard addon: args %q : %v", rr.Args, err)
 	}
 }
 
@@ -88,30 +88,30 @@ func validateIngressAddon(ctx context.Context, t *testing.T, profile string) {
 
 	client, err := kapi.Client(profile)
 	if err != nil {
-		t.Fatalf("kubernetes client: %v", client)
+		t.Fatalf("failed to get kubernetes client: %v", client)
 	}
 
 	if err := kapi.WaitForDeploymentToStabilize(client, "kube-system", "nginx-ingress-controller", Minutes(6)); err != nil {
-		t.Errorf("waiting for ingress-controller deployment to stabilize: %v", err)
+		t.Errorf("failed waiting for ingress-controller deployment to stabilize: %v", err)
 	}
 	if _, err := PodWait(ctx, t, profile, "kube-system", "app.kubernetes.io/name=nginx-ingress-controller", Minutes(12)); err != nil {
-		t.Fatalf("wait: %v", err)
+		t.Fatalf("failed waititing for nginx-ingress-controller : %v", err)
 	}
 
 	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "replace", "--force", "-f", filepath.Join(*testdataDir, "nginx-ing.yaml")))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed to kubectl replace nginx-ing. args %q. %v", rr.Args, err)
 	}
 	rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "replace", "--force", "-f", filepath.Join(*testdataDir, "nginx-pod-svc.yaml")))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed to kubectl replace nginx-pod-svc. args %q. %v", rr.Args, err)
 	}
 
 	if _, err := PodWait(ctx, t, profile, "default", "run=nginx", Minutes(4)); err != nil {
-		t.Fatalf("wait: %v", err)
+		t.Fatalf("failed waiting for ngnix pod: %v", err)
 	}
 	if err := kapi.WaitForService(client, "default", "nginx", true, time.Millisecond*500, Minutes(10)); err != nil {
-		t.Errorf("Error waiting for nginx service to be up")
+		t.Errorf("failed waiting for nginx service to be up: %v", err)
 	}
 
 	want := "Welcome to nginx!"
@@ -121,7 +121,7 @@ func validateIngressAddon(ctx context.Context, t *testing.T, profile string) {
 			return err
 		}
 		if rr.Stderr.String() != "" {
-			t.Logf("%v: unexpected stderr: %s", rr.Args, rr.Stderr)
+			t.Logf("%v: unexpected stderr: %s (may be temproary)", rr.Args, rr.Stderr)
 		}
 		if !strings.Contains(rr.Stdout.String(), want) {
 			return fmt.Errorf("%v stdout = %q, want %q", rr.Args, rr.Stdout, want)
@@ -130,32 +130,32 @@ func validateIngressAddon(ctx context.Context, t *testing.T, profile string) {
 	}
 
 	if err := retry.Expo(checkIngress, 500*time.Millisecond, Seconds(90)); err != nil {
-		t.Errorf("ingress never responded as expected on 127.0.0.1:80: %v", err)
+		t.Errorf("failed to get response from ngninx ingress on 127.0.0.1:80: %v", err)
 	}
 
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "addons", "disable", "ingress", "--alsologtostderr", "-v=1"))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed to disable ingress addon. args %q : %v", rr.Args, err)
 	}
 }
 
 func validateRegistryAddon(ctx context.Context, t *testing.T, profile string) {
 	client, err := kapi.Client(profile)
 	if err != nil {
-		t.Fatalf("kubernetes client: %v", client)
+		t.Fatalf("failed to get kubernetes client for %s : %v", profile, err)
 	}
 
 	start := time.Now()
 	if err := kapi.WaitForRCToStabilize(client, "kube-system", "registry", Minutes(6)); err != nil {
-		t.Errorf("waiting for registry replicacontroller to stabilize: %v", err)
+		t.Errorf("failed waiting for registry replicacontroller to stabilize: %v", err)
 	}
 	t.Logf("registry stabilized in %s", time.Since(start))
 
 	if _, err := PodWait(ctx, t, profile, "kube-system", "actual-registry=true", Minutes(6)); err != nil {
-		t.Fatalf("wait: %v", err)
+		t.Fatalf("failed waiting for pod actual-registry: %v", err)
 	}
 	if _, err := PodWait(ctx, t, profile, "kube-system", "registry-proxy=true", Minutes(10)); err != nil {
-		t.Fatalf("wait: %v", err)
+		t.Fatalf("failed waiting for pod registry-proxy: %v", err)
 	}
 
 	// Test from inside the cluster (no curl available on busybox)
@@ -166,20 +166,20 @@ func validateRegistryAddon(ctx context.Context, t *testing.T, profile string) {
 
 	rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "run", "--rm", "registry-test", "--restart=Never", "--image=busybox", "-it", "--", "sh", "-c", "wget --spider -S http://registry.kube-system.svc.cluster.local"))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed to hit registry.kube-system.svc.cluster.local. args %q failed: %v", rr.Args, err)
 	}
 	want := "HTTP/1.1 200"
 	if !strings.Contains(rr.Stdout.String(), want) {
-		t.Errorf("curl = %q, want *%s*", rr.Stdout.String(), want)
+		t.Errorf("expected curl response be %q, but got *%s*", want, rr.Stdout.String())
 	}
 
 	// Test from outside the cluster
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ip"))
 	if err != nil {
-		t.Fatalf("%s failed: %v", rr.Args, err)
+		t.Fatalf("failed run minikube ip. args %q : %v", rr.Args, err)
 	}
 	if rr.Stderr.String() != "" {
-		t.Errorf("%s: unexpected stderr: %s", rr.Args, rr.Stderr)
+		t.Errorf("expected stderr to be -empty- but got: *%q*", rr.Args, rr.Stderr)
 	}
 
 	endpoint := fmt.Sprintf("http://%s:%d", strings.TrimSpace(rr.Stdout.String()), 5000)
@@ -199,30 +199,30 @@ func validateRegistryAddon(ctx context.Context, t *testing.T, profile string) {
 		return nil
 	}
 
-	if err := retry.Expo(checkExternalAccess, 500*time.Millisecond, Minutes(2)); err != nil {
-		t.Errorf(err.Error())
+	if err := retry.Expo(checkExternalAccess, 500*time.Millisecond, Seconds(150)); err != nil {
+		t.Errorf("failed to check external access to %s: %v", u.String(), err.Error())
 	}
 
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "addons", "disable", "registry", "--alsologtostderr", "-v=1"))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed to disable registry addon. args %q: %v", rr.Args, err)
 	}
 }
 
 func validateMetricsServerAddon(ctx context.Context, t *testing.T, profile string) {
 	client, err := kapi.Client(profile)
 	if err != nil {
-		t.Fatalf("kubernetes client: %v", client)
+		t.Fatalf("failed to get kubernetes client for %s: %v", profile, err)
 	}
 
 	start := time.Now()
 	if err := kapi.WaitForDeploymentToStabilize(client, "kube-system", "metrics-server", Minutes(6)); err != nil {
-		t.Errorf("waiting for metrics-server deployment to stabilize: %v", err)
+		t.Errorf("failed waiting for metrics-server deployment to stabilize: %v", err)
 	}
 	t.Logf("metrics-server stabilized in %s", time.Since(start))
 
 	if _, err := PodWait(ctx, t, profile, "kube-system", "k8s-app=metrics-server", Minutes(6)); err != nil {
-		t.Fatalf("wait: %v", err)
+		t.Fatalf("failed waiting for k8s-app=metrics-server pod: %v", err)
 	}
 
 	want := "CPU(cores)"
@@ -242,29 +242,29 @@ func validateMetricsServerAddon(ctx context.Context, t *testing.T, profile strin
 
 	// metrics-server takes some time to be able to collect metrics
 	if err := retry.Expo(checkMetricsServer, time.Second*3, Minutes(6)); err != nil {
-		t.Errorf(err.Error())
+		t.Errorf("failed checking metric server: %v", err.Error())
 	}
 
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "addons", "disable", "metrics-server", "--alsologtostderr", "-v=1"))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed to disable metrics-server addon: args %q: %v", rr.Args, err)
 	}
 }
 
 func validateHelmTillerAddon(ctx context.Context, t *testing.T, profile string) {
 	client, err := kapi.Client(profile)
 	if err != nil {
-		t.Fatalf("kubernetes client: %v", client)
+		t.Fatalf("failed to get kubernetes client for %s: %v", profile, err)
 	}
 
 	start := time.Now()
 	if err := kapi.WaitForDeploymentToStabilize(client, "kube-system", "tiller-deploy", Minutes(6)); err != nil {
-		t.Errorf("waiting for tiller-deploy deployment to stabilize: %v", err)
+		t.Errorf("failed waiting for tiller-deploy deployment to stabilize: %v", err)
 	}
 	t.Logf("tiller-deploy stabilized in %s", time.Since(start))
 
 	if _, err := PodWait(ctx, t, profile, "kube-system", "app=helm", Minutes(6)); err != nil {
-		t.Fatalf("wait: %v", err)
+		t.Fatalf("failed waiting for helm pod: %v", err)
 	}
 
 	if NoneDriver() {
@@ -292,11 +292,11 @@ func validateHelmTillerAddon(ctx context.Context, t *testing.T, profile string) 
 	}
 
 	if err := retry.Expo(checkHelmTiller, 500*time.Millisecond, Minutes(2)); err != nil {
-		t.Errorf(err.Error())
+		t.Errorf("failed checking helm tiller: %v", err.Error())
 	}
 
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "addons", "disable", "helm-tiller", "--alsologtostderr", "-v=1"))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed disabling helm-tiller addon. arg %q.s %v", rr.Args, err)
 	}
 }

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -179,7 +179,7 @@ func validateRegistryAddon(ctx context.Context, t *testing.T, profile string) {
 		t.Fatalf("failed run minikube ip. args %q : %v", rr.Args, err)
 	}
 	if rr.Stderr.String() != "" {
-		t.Errorf("expected stderr to be -empty- but got: *%q*", rr.Args, rr.Stderr)
+		t.Errorf("expected stderr to be -empty- but got: *%q* .  args %q", rr.Stderr, rr.Args)
 	}
 
 	endpoint := fmt.Sprintf("http://%s:%d", strings.TrimSpace(rr.Stdout.String()), 5000)

--- a/test/integration/docker_test.go
+++ b/test/integration/docker_test.go
@@ -39,27 +39,27 @@ func TestDockerFlags(t *testing.T) {
 	args := append([]string{"start", "-p", profile, "--cache-images=false", "--memory=1800", "--install-addons=false", "--wait=false", "--docker-env=FOO=BAR", "--docker-env=BAZ=BAT", "--docker-opt=debug", "--docker-opt=icc=true", "--alsologtostderr", "-v=5"}, StartArgs()...)
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed to start minikube with args: %q : %v", rr.Args, err)
 	}
 
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "sudo systemctl show docker --property=Environment --no-pager"))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed to 'systemctl show docker' inside minikube. args %q: %v", rr.Args, err)
 	}
 
 	for _, envVar := range []string{"FOO=BAR", "BAZ=BAT"} {
 		if !strings.Contains(rr.Stdout.String(), envVar) {
-			t.Errorf("env var %s missing: %s.", envVar, rr.Stdout)
+			t.Errorf("expected env key/value %q to be passed to minikube's docker and be included in: *%q*.", envVar, rr.Stdout)
 		}
 	}
 
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "sudo systemctl show docker --property=ExecStart --no-pager"))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed on the second 'systemctl show docker' inside minikube. args %q: %v", rr.Args, err)
 	}
 	for _, opt := range []string{"--debug", "--icc=true"} {
 		if !strings.Contains(rr.Stdout.String(), opt) {
-			t.Fatalf("%s = %q, want *%s*", rr.Command(), rr.Stdout, opt)
+			t.Fatalf("expected %q output to have include *%s* . output: %q", rr.Command(), opt, rr.Stdout)
 		}
 	}
 }

--- a/test/integration/docker_test.go
+++ b/test/integration/docker_test.go
@@ -39,12 +39,12 @@ func TestDockerFlags(t *testing.T) {
 	args := append([]string{"start", "-p", profile, "--cache-images=false", "--memory=1800", "--install-addons=false", "--wait=false", "--docker-env=FOO=BAR", "--docker-env=BAZ=BAT", "--docker-opt=debug", "--docker-opt=icc=true", "--alsologtostderr", "-v=5"}, StartArgs()...)
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
-		t.Errorf("failed to start minikube with args: %q : %v", rr.Args, err)
+		t.Errorf("failed to start minikube with args: %q : %v", rr.Command(), err)
 	}
 
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "sudo systemctl show docker --property=Environment --no-pager"))
 	if err != nil {
-		t.Errorf("failed to 'systemctl show docker' inside minikube. args %q: %v", rr.Args, err)
+		t.Errorf("failed to 'systemctl show docker' inside minikube. args %q: %v", rr.Command(), err)
 	}
 
 	for _, envVar := range []string{"FOO=BAR", "BAZ=BAT"} {
@@ -55,7 +55,7 @@ func TestDockerFlags(t *testing.T) {
 
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "sudo systemctl show docker --property=ExecStart --no-pager"))
 	if err != nil {
-		t.Errorf("failed on the second 'systemctl show docker' inside minikube. args %q: %v", rr.Args, err)
+		t.Errorf("failed on the second 'systemctl show docker' inside minikube. args %q: %v", rr.Command(), err)
 	}
 	for _, opt := range []string{"--debug", "--icc=true"} {
 		if !strings.Contains(rr.Stdout.String(), opt) {

--- a/test/integration/fn_mount_cmd.go
+++ b/test/integration/fn_mount_cmd.go
@@ -117,7 +117,7 @@ func validateMountCmd(ctx context.Context, t *testing.T, profile string) {
 	// Assert that we can access the mount without an error. Display for debugging.
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "--", "ls", "-la", guestMount))
 	if err != nil {
-		t.Fatalf("failed verifying accessing to the mount. args %q : %v", rr.Args, err)
+		t.Fatalf("failed verifying accessing to the mount. args %q : %v", rr.Command(), err)
 	}
 	t.Logf("guest mount directory contents\n%s", rr.Stdout)
 
@@ -125,7 +125,7 @@ func validateMountCmd(ctx context.Context, t *testing.T, profile string) {
 	tp := filepath.Join("/mount-9p", testMarker)
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "cat", tp))
 	if err != nil {
-		t.Fatalf("failed to verify the mount contains unique test marked: args %q: %v", rr.Args, err)
+		t.Fatalf("failed to verify the mount contains unique test marked: args %q: %v", rr.Command(), err)
 	}
 
 	if !bytes.Equal(rr.Stdout.Bytes(), wantFromTest) {
@@ -136,7 +136,7 @@ func validateMountCmd(ctx context.Context, t *testing.T, profile string) {
 	// Start the "busybox-mount" pod.
 	rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "replace", "--force", "-f", filepath.Join(*testdataDir, "busybox-mount-test.yaml")))
 	if err != nil {
-		t.Fatalf("failed to 'kubectl replace' for busybox-mount-test. args %q : %v", rr.Args, err)
+		t.Fatalf("failed to 'kubectl replace' for busybox-mount-test. args %q : %v", rr.Command(), err)
 	}
 
 	if _, err := PodWait(ctx, t, profile, "default", "integration-test=busybox-mount", Minutes(4)); err != nil {
@@ -157,7 +157,7 @@ func validateMountCmd(ctx context.Context, t *testing.T, profile string) {
 	// test that file written from host was read in by the pod via cat /mount-9p/written-by-host;
 	rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "logs", "busybox-mount"))
 	if err != nil {
-		t.Errorf("failed to get kubectl logs for busybox-mount. args %q : %v", rr.Args, err)
+		t.Errorf("failed to get kubectl logs for busybox-mount. args %q : %v", rr.Command(), err)
 	}
 	if !bytes.Equal(rr.Stdout.Bytes(), wantFromTest) {
 		t.Errorf("busybox-mount logs = %q, want %q", rr.Stdout.Bytes(), wantFromTest)
@@ -169,7 +169,7 @@ func validateMountCmd(ctx context.Context, t *testing.T, profile string) {
 		// test that file written from host was read in by the pod via cat /mount-9p/fromhost;
 		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "stat", gp))
 		if err != nil {
-			t.Errorf("failed to stat the file %q iniside minikube : args %q: %v", gp, rr.Args, err)
+			t.Errorf("failed to stat the file %q iniside minikube : args %q: %v", gp, rr.Command(), err)
 		}
 
 		if runtime.GOOS == "windows" {

--- a/test/integration/fn_mount_cmd.go
+++ b/test/integration/fn_mount_cmd.go
@@ -66,10 +66,10 @@ func validateMountCmd(ctx context.Context, t *testing.T, profile string) {
 
 	defer func() {
 		if t.Failed() {
-			t.Logf("%s failed, getting debug info...", t.Name())
+			t.Logf("%q failed, getting debug info...", t.Name())
 			rr, err := Run(t, exec.Command(Target(), "-p", profile, "ssh", "mount | grep 9p; ls -la /mount-9p; cat /mount-9p/pod-dates"))
 			if err != nil {
-				t.Logf("%s: %v", rr.Command(), err)
+				t.Logf("debugging command %q failed : %v", rr.Command(), err)
 			} else {
 				t.Logf("(debug) %s:\n%s", rr.Command(), rr.Stdout)
 			}
@@ -78,7 +78,7 @@ func validateMountCmd(ctx context.Context, t *testing.T, profile string) {
 		// Cleanup in advance of future tests
 		rr, err := Run(t, exec.Command(Target(), "-p", profile, "ssh", "sudo umount -f /mount-9p"))
 		if err != nil {
-			t.Logf("%s: %v", rr.Command(), err)
+			t.Logf("%q: %v", rr.Command(), err)
 		}
 		ss.Stop(t)
 		cancel()
@@ -117,7 +117,7 @@ func validateMountCmd(ctx context.Context, t *testing.T, profile string) {
 	// Assert that we can access the mount without an error. Display for debugging.
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "--", "ls", "-la", guestMount))
 	if err != nil {
-		t.Fatalf("%s failed: %v", rr.Args, err)
+		t.Fatalf("failed verifying accessing to the mount. args %q : %v", rr.Args, err)
 	}
 	t.Logf("guest mount directory contents\n%s", rr.Stdout)
 
@@ -125,7 +125,7 @@ func validateMountCmd(ctx context.Context, t *testing.T, profile string) {
 	tp := filepath.Join("/mount-9p", testMarker)
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "cat", tp))
 	if err != nil {
-		t.Fatalf("%s failed: %v", rr.Args, err)
+		t.Fatalf("failed to verify the mount contains unique test marked: args %q: %v", rr.Args, err)
 	}
 
 	if !bytes.Equal(rr.Stdout.Bytes(), wantFromTest) {
@@ -136,28 +136,28 @@ func validateMountCmd(ctx context.Context, t *testing.T, profile string) {
 	// Start the "busybox-mount" pod.
 	rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "replace", "--force", "-f", filepath.Join(*testdataDir, "busybox-mount-test.yaml")))
 	if err != nil {
-		t.Fatalf("%s failed: %v", rr.Args, err)
+		t.Fatalf("failed to 'kubectl replace' for busybox-mount-test. args %q : %v", rr.Args, err)
 	}
 
 	if _, err := PodWait(ctx, t, profile, "default", "integration-test=busybox-mount", Minutes(4)); err != nil {
-		t.Fatalf("wait: %v", err)
+		t.Fatalf("failed waiting for busybox-mount pod: %v", err)
 	}
 
 	// Read the file written by pod startup
 	p := filepath.Join(tempDir, createdByPod)
 	got, err := ioutil.ReadFile(p)
 	if err != nil {
-		t.Errorf("readfile %s: %v", p, err)
+		t.Errorf("failed to read file created by pod %q: %v", p, err)
 	}
 	wantFromPod := []byte("test\n")
 	if !bytes.Equal(got, wantFromPod) {
-		t.Errorf("%s = %q, want %q", p, got, wantFromPod)
+		t.Errorf("the content of the file %q is %q, but want it to be: *%q*", p, got, wantFromPod)
 	}
 
 	// test that file written from host was read in by the pod via cat /mount-9p/written-by-host;
 	rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "logs", "busybox-mount"))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed to get kubectl logs for busybox-mount. args %q : %v", rr.Args, err)
 	}
 	if !bytes.Equal(rr.Stdout.Bytes(), wantFromTest) {
 		t.Errorf("busybox-mount logs = %q, want %q", rr.Stdout.Bytes(), wantFromTest)
@@ -169,27 +169,27 @@ func validateMountCmd(ctx context.Context, t *testing.T, profile string) {
 		// test that file written from host was read in by the pod via cat /mount-9p/fromhost;
 		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "stat", gp))
 		if err != nil {
-			t.Errorf("%s failed: %v", rr.Args, err)
+			t.Errorf("failed to stat the file %q iniside minikube : args %q: %v", gp, rr.Args, err)
 		}
 
 		if runtime.GOOS == "windows" {
 			if strings.Contains(rr.Stdout.String(), "Access: 1970-01-01") {
-				t.Errorf("invalid access time: %v", rr.Stdout)
+				t.Errorf("expected to get valid access time but got: %q", rr.Stdout)
 			}
 		}
 
 		if strings.Contains(rr.Stdout.String(), "Modify: 1970-01-01") {
-			t.Errorf("invalid modify time: %v", rr.Stdout)
+			t.Errorf("expected to get valid modify time but got: %q", rr.Stdout)
 		}
 	}
 
 	p = filepath.Join(tempDir, createdByTestRemovedByPod)
 	if _, err := os.Stat(p); err == nil {
-		t.Errorf("expected file %s to be removed", p)
+		t.Errorf("expected file %q to be removed but exists !", p)
 	}
 
 	p = filepath.Join(tempDir, createdByPodRemovedByTest)
 	if err := os.Remove(p); err != nil {
-		t.Errorf("unexpected error removing file %s: %v", p, err)
+		t.Errorf("failed to remove file %q: %v", p, err)
 	}
 }

--- a/test/integration/fn_pvc.go
+++ b/test/integration/fn_pvc.go
@@ -64,7 +64,7 @@ func validatePersistentVolumeClaim(ctx context.Context, t *testing.T, profile st
 	// Now create a testpvc
 	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "apply", "-f", filepath.Join(*testdataDir, "pvc.yaml")))
 	if err != nil {
-		t.Fatalf("kubectl apply pvc.yaml failed: args %q: %v", rr.Args, err)
+		t.Fatalf("kubectl apply pvc.yaml failed: args %q: %v", rr.Command(), err)
 	}
 
 	checkStoragePhase := func() error {

--- a/test/integration/fn_pvc.go
+++ b/test/integration/fn_pvc.go
@@ -38,7 +38,7 @@ func validatePersistentVolumeClaim(ctx context.Context, t *testing.T, profile st
 	defer cancel()
 
 	if _, err := PodWait(ctx, t, profile, "kube-system", "integration-test=storage-provisioner", Minutes(4)); err != nil {
-		t.Fatalf("wait: %v", err)
+		t.Fatalf("failed waiting for storage-provisioner: %v", err)
 	}
 
 	checkStorageClass := func() error {
@@ -58,13 +58,13 @@ func validatePersistentVolumeClaim(ctx context.Context, t *testing.T, profile st
 
 	// Ensure the addon-manager has created the StorageClass before creating a claim, otherwise it won't be bound
 	if err := retry.Expo(checkStorageClass, time.Millisecond*500, Seconds(100)); err != nil {
-		t.Errorf("no default storage class after retry: %v", err)
+		t.Errorf("failed to check for storage class: %v", err)
 	}
 
 	// Now create a testpvc
 	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "apply", "-f", filepath.Join(*testdataDir, "pvc.yaml")))
 	if err != nil {
-		t.Fatalf("%s failed: %v", rr.Args, err)
+		t.Fatalf("kubectl apply pvc.yaml failed: args %q: %v", rr.Args, err)
 	}
 
 	checkStoragePhase := func() error {
@@ -84,6 +84,6 @@ func validatePersistentVolumeClaim(ctx context.Context, t *testing.T, profile st
 	}
 
 	if err := retry.Expo(checkStoragePhase, 2*time.Second, Minutes(4)); err != nil {
-		t.Fatalf("PV Creation failed with error: %v", err)
+		t.Fatalf("failed to check storage phase: %v", err)
 	}
 }

--- a/test/integration/fn_tunnel_cmd.go
+++ b/test/integration/fn_tunnel_cmd.go
@@ -69,7 +69,7 @@ func validateTunnelCmd(ctx context.Context, t *testing.T, profile string) {
 	// Start the "nginx" pod.
 	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "apply", "-f", filepath.Join(*testdataDir, "testsvc.yaml")))
 	if err != nil {
-		t.Fatalf("%s failed: %v", rr.Args, err)
+		t.Fatalf("%s failed: %v", rr.Command(), err)
 	}
 	if _, err := PodWait(ctx, t, profile, "default", "run=nginx-svc", Minutes(4)); err != nil {
 		t.Fatalf("wait: %v", err)
@@ -97,7 +97,7 @@ func validateTunnelCmd(ctx context.Context, t *testing.T, profile string) {
 
 		rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "get", "svc", "nginx-svc"))
 		if err != nil {
-			t.Errorf("%s failed: %v", rr.Args, err)
+			t.Errorf("%s failed: %v", rr.Command(), err)
 		}
 		t.Logf("failed to kubectl get svc nginx-svc:\n%s", rr.Stdout)
 	}

--- a/test/integration/fn_tunnel_cmd.go
+++ b/test/integration/fn_tunnel_cmd.go
@@ -50,7 +50,7 @@ func validateTunnelCmd(ctx context.Context, t *testing.T, profile string) {
 
 	client, err := kapi.Client(profile)
 	if err != nil {
-		t.Fatalf("client: %v", err)
+		t.Fatalf("failed to get kubernetes client for %q: %v", profile, err)
 	}
 
 	// Pre-Cleanup
@@ -62,7 +62,7 @@ func validateTunnelCmd(ctx context.Context, t *testing.T, profile string) {
 	args := []string{"-p", profile, "tunnel", "--alsologtostderr", "-v=1"}
 	ss, err := Start(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
-		t.Errorf("%s failed: %v", args, err)
+		t.Errorf("failed to start a tunnel: args %q: %v", args, err)
 	}
 	defer ss.Stop(t)
 
@@ -99,7 +99,7 @@ func validateTunnelCmd(ctx context.Context, t *testing.T, profile string) {
 		if err != nil {
 			t.Errorf("%s failed: %v", rr.Args, err)
 		}
-		t.Logf("kubectl get svc nginx-svc:\n%s", rr.Stdout)
+		t.Logf("failed to kubectl get svc nginx-svc:\n%s", rr.Stdout)
 	}
 
 	got := []byte{}
@@ -120,11 +120,11 @@ func validateTunnelCmd(ctx context.Context, t *testing.T, profile string) {
 		return nil
 	}
 	if err = retry.Expo(fetch, time.Millisecond*500, Minutes(2), 13); err != nil {
-		t.Errorf("failed to contact nginx at %s: %v", nginxIP, err)
+		t.Errorf("failed to hit nginx at %q: %v", nginxIP, err)
 	}
 
 	want := "Welcome to nginx!"
 	if !strings.Contains(string(got), want) {
-		t.Errorf("body = %q, want *%s*", got, want)
+		t.Errorf("expected body to contain %q, but got *%q*", want, got)
 	}
 }

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -598,11 +598,11 @@ func validateProfileCmd(ctx context.Context, t *testing.T, profile string) {
 func validateServiceCmd(ctx context.Context, t *testing.T, profile string) {
 	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "create", "deployment", "hello-node", "--image=gcr.io/hello-minikube-zero-install/hello-node"))
 	if err != nil {
-		t.Logf("% failed: %v (may not be an error)", rr.Args, err)
+		t.Logf("%q failed: %v (may not be an error).", rr.Args, err)
 	}
 	rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "expose", "deployment", "hello-node", "--type=NodePort", "--port=8080"))
 	if err != nil {
-		t.Logf("%s failed: %v (may not be an error)", rr.Args, err)
+		t.Logf("%q failed: %v (may not be an error)", rr.Args, err)
 	}
 
 	if _, err := PodWait(ctx, t, profile, "default", "app=hello-node", Minutes(10)); err != nil {
@@ -656,7 +656,7 @@ func validateServiceCmd(ctx context.Context, t *testing.T, profile string) {
 		t.Fatalf("failed to parse %q: %v", endpoint, err)
 	}
 	if u.Scheme != "http" {
-		t.Fatalf("expected scheme to be -'http'- got scheme: *%q*", "http", u.Scheme)
+		t.Fatalf("expected scheme to be -%q- got scheme: *%q*", "http", u.Scheme)
 	}
 
 	t.Logf("url: %s", endpoint)
@@ -665,7 +665,7 @@ func validateServiceCmd(ctx context.Context, t *testing.T, profile string) {
 		t.Fatalf("get failed: %v\nresp: %v", err, resp)
 	}
 	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expeced status code for %q to be -%q- but got *%q*", endpoint, http.StatusOK, resp.StatusCode)
+		t.Fatalf("expected status code for %q to be -%q- but got *%q*", endpoint, http.StatusOK, resp.StatusCode)
 	}
 }
 
@@ -813,7 +813,7 @@ func validateCertSync(ctx context.Context, t *testing.T, profile string) {
 		t.Logf("Checking for existence of %s within VM", vp)
 		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", fmt.Sprintf("cat %s", vp)))
 		if err != nil {
-			t.Errorf("failed to check existance of %q inside minikube. args %q: %v", vp, rr.Args, err)
+			t.Errorf("failed to check existence of %q inside minikube. args %q: %v", vp, rr.Args, err)
 		}
 
 		// Strip carriage returned by ssh

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -63,11 +63,11 @@ func TestFunctional(t *testing.T) {
 		}
 		p := localSyncTestPath()
 		if err := os.Remove(p); err != nil {
-			t.Logf("unable to remove %s: %v", p, err)
+			t.Logf("unable to remove %q: %v", p, err)
 		}
 		p = localTestCertPath()
 		if err := os.Remove(p); err != nil {
-			t.Logf("unable to remove %s: %v", p, err)
+			t.Logf("unable to remove %q: %v", p, err)
 		}
 		CleanupWithLogs(t, profile, cancel)
 	}()
@@ -137,7 +137,7 @@ func TestFunctional(t *testing.T) {
 func validateNodeLabels(ctx context.Context, t *testing.T, profile string) {
 	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "get", "nodes", "--output=go-template", "--template='{{range $k, $v := (index .items 0).metadata.labels}}{{$k}} {{end}}'"))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed to 'kubectl get nodes' with args %q: %v", rr.Args, err)
 	}
 	expectedLabels := []string{"minikube.k8s.io/commit", "minikube.k8s.io/version", "minikube.k8s.io/updated_at", "minikube.k8s.io/name"}
 	for _, el := range expectedLabels {
@@ -155,10 +155,10 @@ func validateDockerEnv(ctx context.Context, t *testing.T, profile string) {
 	c := exec.CommandContext(mctx, "/bin/bash", "-c", "eval $("+Target()+" -p "+profile+" docker-env) && "+Target()+" status -p "+profile)
 	rr, err := Run(t, c)
 	if err != nil {
-		t.Fatalf("Failed to do minikube status after eval-ing docker-env %s", err)
+		t.Fatalf("failed to do minikube status after eval-ing docker-env %s", err)
 	}
 	if !strings.Contains(rr.Output(), "Running") {
-		t.Fatalf("Expected status output to include 'Running' after eval docker-env but got \n%s", rr.Output())
+		t.Fatalf("expected status output to include 'Running' after eval docker-env but got: *%q*", rr.Output())
 	}
 
 	mctx, cancel = context.WithTimeout(ctx, Seconds(13))
@@ -167,12 +167,12 @@ func validateDockerEnv(ctx context.Context, t *testing.T, profile string) {
 	c = exec.CommandContext(mctx, "/bin/bash", "-c", "eval $("+Target()+" -p "+profile+" docker-env) && docker images")
 	rr, err = Run(t, c)
 	if err != nil {
-		t.Fatalf("Failed to test eval docker-evn %s", err)
+		t.Fatalf("failed to run minikube docker-env. args %q : %v ", rr.Args, err)
 	}
 
 	expectedImgInside := "gcr.io/k8s-minikube/storage-provisioner"
 	if !strings.Contains(rr.Output(), expectedImgInside) {
-		t.Fatalf("Expected 'docker ps' to have %q from docker-daemon inside minikube. the docker ps output is:\n%q\n", expectedImgInside, rr.Output())
+		t.Fatalf("expected 'docker images' to have %q inside minikube. but the output is: *%q*", expectedImgInside, rr.Output())
 	}
 
 }
@@ -180,11 +180,11 @@ func validateDockerEnv(ctx context.Context, t *testing.T, profile string) {
 func validateStartWithProxy(ctx context.Context, t *testing.T, profile string) {
 	srv, err := startHTTPProxy(t)
 	if err != nil {
-		t.Fatalf("Failed to set up the test proxy: %s", err)
+		t.Fatalf("failed to set up the test proxy: %s", err)
 	}
 
 	// Use more memory so that we may reliably fit MySQL and nginx
-	startArgs := append([]string{"start", "-p", profile, "--wait=true", "--memory", "2500MB"}, StartArgs()...)
+	startArgs := append([]string{"start", "-p", profile, "--wait=true"}, StartArgs()...)
 	c := exec.CommandContext(ctx, Target(), startArgs...)
 	env := os.Environ()
 	env = append(env, fmt.Sprintf("HTTP_PROXY=%s", srv.Addr))
@@ -192,7 +192,7 @@ func validateStartWithProxy(ctx context.Context, t *testing.T, profile string) {
 	c.Env = env
 	rr, err := Run(t, c)
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed minikube start. args %q: %v", rr.Args, err)
 	}
 
 	want := "Found network options:"
@@ -210,10 +210,10 @@ func validateStartWithProxy(ctx context.Context, t *testing.T, profile string) {
 func validateKubeContext(ctx context.Context, t *testing.T, profile string) {
 	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "config", "current-context"))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed to get current-context. args %q : %v", rr.Args, err)
 	}
 	if !strings.Contains(rr.Stdout.String(), profile) {
-		t.Errorf("current-context = %q, want %q", rr.Stdout.String(), profile)
+		t.Errorf("expected current-context = %q, but got *%q*", profile, rr.Stdout.String())
 	}
 }
 
@@ -221,13 +221,13 @@ func validateKubeContext(ctx context.Context, t *testing.T, profile string) {
 func validateKubectlGetPods(ctx context.Context, t *testing.T, profile string) {
 	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "get", "po", "-A"))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed to get kubectl pods: args %q : %v", rr.Args, err)
 	}
 	if rr.Stderr.String() != "" {
-		t.Errorf("%s: got unexpected stderr: %s", rr.Command(), rr.Stderr)
+		t.Errorf("expected stderr to be empty but got *%q*: args %q", rr.Stderr, rr.Command())
 	}
 	if !strings.Contains(rr.Stdout.String(), "kube-system") {
-		t.Errorf("%s = %q, want *kube-system*", rr.Command(), rr.Stdout)
+		t.Errorf("expected stdout to include *kube-system* but got *%q*. args: %q", rr.Stdout, rr.Command())
 	}
 }
 
@@ -237,7 +237,7 @@ func validateMinikubeKubectl(ctx context.Context, t *testing.T, profile string) 
 	kubectlArgs := []string{"-p", profile, "kubectl", "--", "--context", profile, "get", "pods"}
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), kubectlArgs...))
 	if err != nil {
-		t.Fatalf("%s failed: %v", rr.Args, err)
+		t.Fatalf("failed to get pods. args %q: %v", rr.Args, err)
 	}
 }
 
@@ -245,12 +245,12 @@ func validateMinikubeKubectl(ctx context.Context, t *testing.T, profile string) 
 func validateComponentHealth(ctx context.Context, t *testing.T, profile string) {
 	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "get", "cs", "-o=json"))
 	if err != nil {
-		t.Fatalf("%s failed: %v", rr.Args, err)
+		t.Fatalf("failed to get components. args %q: %v", rr.Args, err)
 	}
 	cs := api.ComponentStatusList{}
 	d := json.NewDecoder(bytes.NewReader(rr.Stdout.Bytes()))
 	if err := d.Decode(&cs); err != nil {
-		t.Fatalf("decode: %v", err)
+		t.Fatalf("failed to decode kubectl json output: args %q : %v", rr.Args, err)
 	}
 
 	for _, i := range cs.Items {
@@ -270,28 +270,29 @@ func validateComponentHealth(ctx context.Context, t *testing.T, profile string) 
 func validateStatusCmd(ctx context.Context, t *testing.T, profile string) {
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "status"))
 	if err != nil {
-		t.Errorf("%q failed: %v", rr.Args, err)
+		t.Errorf("failed to run minikube status. args %q : %v", rr.Args, err)
 	}
 
 	// Custom format
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "status", "-f", "host:{{.Host}},kublet:{{.Kubelet}},apiserver:{{.APIServer}},kubeconfig:{{.Kubeconfig}}"))
 	if err != nil {
-		t.Errorf("%q failed: %v", rr.Args, err)
+		t.Errorf("failed to run minikube status with custom format: args %q: %v", rr.Args, err)
 	}
-	match, _ := regexp.MatchString(`host:([A-z]+),kublet:([A-z]+),apiserver:([A-z]+),kubeconfig:([A-z]+)`, rr.Stdout.String())
+	re := `host:([A-z]+),kublet:([A-z]+),apiserver:([A-z]+),kubeconfig:([A-z]+)`
+	match, _ := regexp.MatchString(re, rr.Stdout.String())
 	if !match {
-		t.Errorf("%q failed: %v. Output for custom format did not match", rr.Args, err)
+		t.Errorf("failed to match regex %q for minikube status with custom format. args %q. output %q", re, rr.Args, rr.Output())
 	}
 
 	// Json output
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "status", "-o", "json"))
 	if err != nil {
-		t.Errorf("%q failed: %v", rr.Args, err)
+		t.Errorf("failed to run minikube status with json output. args %q : %v", rr.Args, err)
 	}
 	var jsonObject map[string]interface{}
 	err = json.Unmarshal(rr.Stdout.Bytes(), &jsonObject)
 	if err != nil {
-		t.Errorf("%q failed: %v", rr.Args, err)
+		t.Errorf("failed to decode json from minikube status. args %q. %v", rr.Args, err)
 	}
 	if _, ok := jsonObject["Host"]; !ok {
 		t.Errorf("%q failed: %v. Missing key %s in json object", rr.Args, err, "Host")
@@ -312,7 +313,7 @@ func validateDashboardCmd(ctx context.Context, t *testing.T, profile string) {
 	args := []string{"dashboard", "--url", "-p", profile, "--alsologtostderr", "-v=1"}
 	ss, err := Start(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
-		t.Errorf("%q failed: %v", args, err)
+		t.Errorf("failed to run minikube dashboard. args %q : %v", args, err)
 	}
 	defer func() {
 		ss.Stop(t)
@@ -339,7 +340,7 @@ func validateDashboardCmd(ctx context.Context, t *testing.T, profile string) {
 	if resp.StatusCode != http.StatusOK {
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			t.Errorf("Unable to read http response body: %v", err)
+			t.Errorf("failed to read http response body from dashboard %q: %v", u.String(), err)
 		}
 		t.Errorf("%s returned status code %d, expected %d.\nbody:\n%s", u, resp.StatusCode, http.StatusOK, body)
 	}
@@ -349,7 +350,7 @@ func validateDashboardCmd(ctx context.Context, t *testing.T, profile string) {
 func validateDNS(ctx context.Context, t *testing.T, profile string) {
 	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "replace", "--force", "-f", filepath.Join(*testdataDir, "busybox.yaml")))
 	if err != nil {
-		t.Fatalf("%q failed: %v", rr.Args, err)
+		t.Fatalf("failed to kubectl replace busybox : args %q: %v", rr.Args, err)
 	}
 
 	names, err := PodWait(ctx, t, profile, "default", "integration-test=busybox", Minutes(4))
@@ -407,29 +408,29 @@ func validateCacheCmd(ctx context.Context, t *testing.T, profile string) {
 	t.Run("cache", func(t *testing.T) {
 		t.Run("add", func(t *testing.T) {
 			for _, img := range []string{"busybox:latest", "busybox:1.28.4-glibc", "k8s.gcr.io/pause:latest"} {
-				_, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "cache", "add", img))
+				rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "cache", "add", img))
 				if err != nil {
-					t.Errorf("Failed to cache image %q", img)
+					t.Errorf("failed to cache add image %q. args %q err %v", img, rr.Args, err)
 				}
 			}
 		})
 		t.Run("delete_busybox:1.28.4-glibc", func(t *testing.T) {
-			_, err := Run(t, exec.CommandContext(ctx, Target(), "cache", "delete", "busybox:1.28.4-glibc"))
+			rr, err := Run(t, exec.CommandContext(ctx, Target(), "cache", "delete", "busybox:1.28.4-glibc"))
 			if err != nil {
-				t.Errorf("failed to delete image busybox:1.28.4-glibc from cache: %v", err)
+				t.Errorf("failed to delete image busybox:1.28.4-glibc from cache. args %q: %v", rr.Args, err)
 			}
 		})
 
 		t.Run("list", func(t *testing.T) {
 			rr, err := Run(t, exec.CommandContext(ctx, Target(), "cache", "list"))
 			if err != nil {
-				t.Errorf("cache list failed: %v", err)
+				t.Errorf("failed to do cache list. args %q: %v", rr.Args, err)
 			}
 			if !strings.Contains(rr.Output(), "k8s.gcr.io/pause") {
-				t.Errorf("cache list did not include k8s.gcr.io/pause")
+				t.Errorf("expected 'cache list' output to include 'k8s.gcr.io/pause' but got:\n ***%q***", rr.Output())
 			}
 			if strings.Contains(rr.Output(), "busybox:1.28.4-glibc") {
-				t.Errorf("cache list should not include busybox:1.28.4-glibc")
+				t.Errorf("expected 'cache list' output not to include busybox:1.28.4-glibc but got:\n ***%q***", rr.Output())
 			}
 		})
 
@@ -439,7 +440,7 @@ func validateCacheCmd(ctx context.Context, t *testing.T, profile string) {
 				t.Errorf("failed to get images by %q ssh %v", rr.Command(), err)
 			}
 			if !strings.Contains(rr.Output(), "1.28.4-glibc") {
-				t.Errorf("expected '1.28.4-glibc' to be in the output: %s", rr.Output())
+				t.Errorf("expected '1.28.4-glibc' to be in the output but got %q", rr.Output())
 			}
 
 		})
@@ -490,16 +491,16 @@ func validateConfigCmd(ctx context.Context, t *testing.T, profile string) {
 		args := append([]string{"-p", profile, "config"}, tc.args...)
 		rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 		if err != nil && tc.wantErr == "" {
-			t.Errorf("unexpected failure: %s failed: %v", rr.Args, err)
+			t.Errorf("failed to config minikube. args %q : %v", rr.Args, err)
 		}
 
 		got := strings.TrimSpace(rr.Stdout.String())
 		if got != tc.wantOut {
-			t.Errorf("%s stdout got: %q, want: %q", rr.Command(), got, tc.wantOut)
+			t.Errorf("expected config output for %q to be -%q- but got *%q*", rr.Command(), tc.wantOut, got)
 		}
 		got = strings.TrimSpace(rr.Stderr.String())
 		if got != tc.wantErr {
-			t.Errorf("%s stderr got: %q, want: %q", rr.Command(), got, tc.wantErr)
+			t.Errorf("expected config error for %q to be -%q- but got *%q*", rr.Command(), tc.wantErr, got)
 		}
 	}
 }
@@ -512,7 +513,7 @@ func validateLogsCmd(ctx context.Context, t *testing.T, profile string) {
 	}
 	for _, word := range []string{"Docker", "apiserver", "Linux", "kubelet"} {
 		if !strings.Contains(rr.Stdout.String(), word) {
-			t.Errorf("minikube logs missing expected word: %q", word)
+			t.Errorf("excpeted minikube logs to include word: -%q- but got \n***%q***\n", word, rr.Output())
 		}
 	}
 }
@@ -549,7 +550,7 @@ func validateProfileCmd(ctx context.Context, t *testing.T, profile string) {
 		// List profiles
 		rr, err := Run(t, exec.CommandContext(ctx, Target(), "profile", "list"))
 		if err != nil {
-			t.Errorf("%s failed: %v", rr.Args, err)
+			t.Errorf("failed to list profiles: args %q : %v", rr.Args, err)
 		}
 
 		// Table output
@@ -563,21 +564,20 @@ func validateProfileCmd(ctx context.Context, t *testing.T, profile string) {
 			}
 		}
 		if !profileExists {
-			t.Errorf("%s failed: Missing profile '%s'. Got '\n%s\n'", rr.Args, profile, rr.Stdout.String())
+			t.Errorf("expected 'profile list' output to include %q but got *%q*. args: %q", profile, rr.Stdout.String(), rr.Args)
 		}
-
 	})
 
 	t.Run("profile_json_output", func(t *testing.T) {
 		// Json output
 		rr, err := Run(t, exec.CommandContext(ctx, Target(), "profile", "list", "--output", "json"))
 		if err != nil {
-			t.Errorf("%s failed: %v", rr.Args, err)
+			t.Errorf("failed to list profiles with json format. args %q: %v", rr.Args, err)
 		}
 		var jsonObject map[string][]map[string]interface{}
 		err = json.Unmarshal(rr.Stdout.Bytes(), &jsonObject)
 		if err != nil {
-			t.Errorf("%s failed: %v", rr.Args, err)
+			t.Errorf("failed to decode json from profile list: args %q: %v", rr.Args, err)
 		}
 		validProfiles := jsonObject["valid"]
 		profileExists := false
@@ -588,7 +588,7 @@ func validateProfileCmd(ctx context.Context, t *testing.T, profile string) {
 			}
 		}
 		if !profileExists {
-			t.Errorf("%s failed: Missing profile '%s'. Got '\n%s\n'", rr.Args, profile, rr.Stdout.String())
+			t.Errorf("expected the json of 'profile list' to include %q but got *%q*. args: %q", profile, rr.Stdout.String(), rr.Args)
 		}
 
 	})
@@ -598,7 +598,7 @@ func validateProfileCmd(ctx context.Context, t *testing.T, profile string) {
 func validateServiceCmd(ctx context.Context, t *testing.T, profile string) {
 	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "create", "deployment", "hello-node", "--image=gcr.io/hello-minikube-zero-install/hello-node"))
 	if err != nil {
-		t.Logf("%s failed: %v (may not be an error)", rr.Args, err)
+		t.Logf("% failed: %v (may not be an error)", rr.Args, err)
 	}
 	rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "expose", "deployment", "hello-node", "--type=NodePort", "--port=8080"))
 	if err != nil {
@@ -606,48 +606,48 @@ func validateServiceCmd(ctx context.Context, t *testing.T, profile string) {
 	}
 
 	if _, err := PodWait(ctx, t, profile, "default", "app=hello-node", Minutes(10)); err != nil {
-		t.Fatalf("wait: %v", err)
+		t.Fatalf("failed waiting for hello-node pod: %v", err)
 	}
 
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "service", "list"))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed to do service list. args %q : %v", rr.Args, err)
 	}
 	if !strings.Contains(rr.Stdout.String(), "hello-node") {
-		t.Errorf("service list got %q, wanted *hello-node*", rr.Stdout.String())
+		t.Errorf("expected 'service list' to contain *hello-node* but got -%q-", rr.Stdout.String())
 	}
 
 	// Test --https --url mode
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "service", "--namespace=default", "--https", "--url", "hello-node"))
 	if err != nil {
-		t.Fatalf("%s failed: %v", rr.Args, err)
+		t.Fatalf("failed to get service url. args %q : %v", rr.Args, err)
 	}
 	if rr.Stderr.String() != "" {
-		t.Errorf("unexpected stderr output: %s", rr.Stderr)
+		t.Errorf("expected stderr to be empty but got *%q*", rr.Stderr)
 	}
 
 	endpoint := strings.TrimSpace(rr.Stdout.String())
 	u, err := url.Parse(endpoint)
 	if err != nil {
-		t.Fatalf("failed to parse %q: %v", endpoint, err)
+		t.Fatalf("failed to parse service url endpoint %q: %v", endpoint, err)
 	}
 	if u.Scheme != "https" {
-		t.Errorf("got scheme: %q, expected: %q", u.Scheme, "https")
+		t.Errorf("expected scheme to be 'https' but got %q", u.Scheme)
 	}
 
 	// Test --format=IP
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "service", "hello-node", "--url", "--format={{.IP}}"))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed to get service url with custom format. args %q: %v", rr.Args, err)
 	}
 	if strings.TrimSpace(rr.Stdout.String()) != u.Hostname() {
-		t.Errorf("%s = %q, wanted %q", rr.Args, rr.Stdout.String(), u.Hostname())
+		t.Errorf("expected 'service --format={{.IP}}' output to be -%q- but got *%q* . args %q.", u.Hostname(), rr.Stdout.String(), rr.Args)
 	}
 
 	// Test a regular URLminikube
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "service", "hello-node", "--url"))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed to get service url. args: %q: %v", rr.Args, err)
 	}
 
 	endpoint = strings.TrimSpace(rr.Stdout.String())
@@ -656,7 +656,7 @@ func validateServiceCmd(ctx context.Context, t *testing.T, profile string) {
 		t.Fatalf("failed to parse %q: %v", endpoint, err)
 	}
 	if u.Scheme != "http" {
-		t.Fatalf("got scheme: %q, expected: %q", u.Scheme, "http")
+		t.Fatalf("expected scheme to be -'http'- got scheme: *%q*", "http", u.Scheme)
 	}
 
 	t.Logf("url: %s", endpoint)
@@ -665,7 +665,7 @@ func validateServiceCmd(ctx context.Context, t *testing.T, profile string) {
 		t.Fatalf("get failed: %v\nresp: %v", err, resp)
 	}
 	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("%s = status code %d, want %d", u, resp.StatusCode, http.StatusOK)
+		t.Fatalf("expeced status code for %q to be -%q- but got *%q*", endpoint, http.StatusOK, resp.StatusCode)
 	}
 }
 
@@ -674,23 +674,23 @@ func validateAddonsCmd(ctx context.Context, t *testing.T, profile string) {
 	// Table output
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "addons", "list"))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed to do addon list: args %q : %v", rr.Args, err)
 	}
 	for _, a := range []string{"dashboard", "ingress", "ingress-dns"} {
 		if !strings.Contains(rr.Output(), a) {
-			t.Errorf("addon list expected to include %q but didn't output: %q", a, rr.Output())
+			t.Errorf("expected 'addon list' output to include -%q- but got *%q*", a, rr.Output())
 		}
 	}
 
 	// Json output
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "addons", "list", "-o", "json"))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed to do addon list with json output. args %q: %v", rr.Args, err)
 	}
 	var jsonObject map[string]interface{}
 	err = json.Unmarshal(rr.Stdout.Bytes(), &jsonObject)
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed to decode addon list json output : %v", err)
 	}
 }
 
@@ -702,10 +702,10 @@ func validateSSHCmd(ctx context.Context, t *testing.T, profile string) {
 	want := "hello\n"
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", fmt.Sprintf("echo hello")))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed to run an ssh command. args %q : %v", rr.Args, err)
 	}
 	if rr.Stdout.String() != want {
-		t.Errorf("%v = %q, want = %q", rr.Args, rr.Stdout.String(), want)
+		t.Errorf("expected minikube ssh command output to be -%q- but got *%q*. args %q", want, rr.Stdout.String(), rr.Args)
 	}
 }
 
@@ -713,12 +713,12 @@ func validateSSHCmd(ctx context.Context, t *testing.T, profile string) {
 func validateMySQL(ctx context.Context, t *testing.T, profile string) {
 	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "replace", "--force", "-f", filepath.Join(*testdataDir, "mysql.yaml")))
 	if err != nil {
-		t.Fatalf("%s failed: %v", rr.Args, err)
+		t.Fatalf("failed to kubectl replace mysql: args %q failed: %v", rr.Args, err)
 	}
 
 	names, err := PodWait(ctx, t, profile, "default", "app=mysql", Minutes(10))
 	if err != nil {
-		t.Fatalf("podwait: %v", err)
+		t.Fatalf("failed waiting for mysql pod: %v", err)
 	}
 
 	// Retry, as mysqld first comes up without users configured. Scan for names in case of a reschedule.
@@ -726,8 +726,8 @@ func validateMySQL(ctx context.Context, t *testing.T, profile string) {
 		rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "exec", names[0], "--", "mysql", "-ppassword", "-e", "show databases;"))
 		return err
 	}
-	if err = retry.Expo(mysql, 2*time.Second, Seconds(180)); err != nil {
-		t.Errorf("mysql failing: %v", err)
+	if err = retry.Expo(mysql, 1*time.Second, Seconds(200)); err != nil {
+		t.Errorf("failed to exec 'mysql -ppassword -e show databases;': %v", err)
 	}
 }
 
@@ -757,12 +757,12 @@ func setupFileSync(ctx context.Context, t *testing.T, profile string) {
 	t.Logf("local sync path: %s", p)
 	err := copy.Copy("./testdata/sync.test", p)
 	if err != nil {
-		t.Fatalf("copy: %v", err)
+		t.Fatalf("failed to copy ./testdata/sync.test : %v", err)
 	}
 
 	err = copy.Copy("./testdata/minikube_test.pem", localTestCertPath())
 	if err != nil {
-		t.Fatalf("copy: %v", err)
+		t.Fatalf("failed to copy ./testdata/minikube_test.pem : %v", err)
 	}
 }
 
@@ -783,7 +783,7 @@ func validateFileSync(ctx context.Context, t *testing.T, profile string) {
 
 	expected, err := ioutil.ReadFile("./testdata/sync.test")
 	if err != nil {
-		t.Errorf("test file not found: %v", err)
+		t.Errorf("failed to read test file '/testdata/sync.test' : %v", err)
 	}
 
 	if diff := cmp.Diff(string(expected), got); diff != "" {
@@ -813,13 +813,13 @@ func validateCertSync(ctx context.Context, t *testing.T, profile string) {
 		t.Logf("Checking for existence of %s within VM", vp)
 		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", fmt.Sprintf("cat %s", vp)))
 		if err != nil {
-			t.Errorf("%s failed: %v", rr.Args, err)
+			t.Errorf("failed to check existance of %q inside minikube. args %q: %v", vp, rr.Args, err)
 		}
 
 		// Strip carriage returned by ssh
 		got := strings.Replace(rr.Stdout.String(), "\r", "", -1)
 		if diff := cmp.Diff(string(want), got); diff != "" {
-			t.Errorf("minikube_test.pem -> %s mismatch (-want +got):\n%s", vp, diff)
+			t.Errorf("failed verify pem file. minikube_test.pem -> %s mismatch (-want +got):\n%s", vp, diff)
 		}
 	}
 }
@@ -828,7 +828,7 @@ func validateCertSync(ctx context.Context, t *testing.T, profile string) {
 func validateUpdateContextCmd(ctx context.Context, t *testing.T, profile string) {
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "update-context", "--alsologtostderr", "-v=2"))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed to run minikube update-context: args %q: %v", rr.Args, err)
 	}
 
 	want := []byte("IP was already correctly configured")

--- a/test/integration/guest_env_test.go
+++ b/test/integration/guest_env_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/vmpath"
 )
 
+// TestGuestEnvironment verifies files and packges installed inside minikube ISO/Base image
 func TestGuestEnvironment(t *testing.T) {
 	MaybeParallel(t)
 
@@ -37,18 +38,18 @@ func TestGuestEnvironment(t *testing.T) {
 	args := append([]string{"start", "-p", profile, "--install-addons=false", "--memory=1800", "--wait=false"}, StartArgs()...)
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed to start minikube: args %q: %v", rr.Args, err)
 	}
 
 	// Run as a group so that our defer doesn't happen as tests are runnings
 	t.Run("Binaries", func(t *testing.T) {
-		for _, pkg := range []string{"git", "rsync", "curl", "wget", "socat", "iptables", "VBoxControl", "VBoxService"} {
+		for _, pkg := range []string{"git", "rsync", "curl", "wget", "socat", "iptables", "VBoxControl", "VBoxService", "crictl", "podman", "docker"} {
 			pkg := pkg
 			t.Run(pkg, func(t *testing.T) {
 				t.Parallel()
 				rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", fmt.Sprintf("which %s", pkg)))
 				if err != nil {
-					t.Errorf("%s failed: %v", rr.Args, err)
+					t.Errorf("failed to verify existance of %q binary : args %q: %v", pkg, rr.Args, err)
 				}
 			})
 		}
@@ -67,9 +68,9 @@ func TestGuestEnvironment(t *testing.T) {
 			mount := mount
 			t.Run(mount, func(t *testing.T) {
 				t.Parallel()
-				rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", fmt.Sprintf("df -t ext4 %s | grep %s", mount, mount)))
+				rr, err := Run(t, exec.CommandContext(ctx, Targt(), "-p", profile, "ssh", fmt.Sprintf("df -t ext4 %s | grep %s", mount, mount)))
 				if err != nil {
-					t.Errorf("%s failed: %v", rr.Args, err)
+					t.Errorf("failed to verify existance of %q mount. args %q: %v", mount, rr.Args, err)
 				}
 			})
 		}

--- a/test/integration/guest_env_test.go
+++ b/test/integration/guest_env_test.go
@@ -38,7 +38,7 @@ func TestGuestEnvironment(t *testing.T) {
 	args := append([]string{"start", "-p", profile, "--install-addons=false", "--memory=1800", "--wait=false"}, StartArgs()...)
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
-		t.Errorf("failed to start minikube: args %q: %v", rr.Args, err)
+		t.Errorf("failed to start minikube: args %q: %v", rr.Command(), err)
 	}
 
 	// Run as a group so that our defer doesn't happen as tests are runnings
@@ -49,7 +49,7 @@ func TestGuestEnvironment(t *testing.T) {
 				t.Parallel()
 				rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", fmt.Sprintf("which %s", pkg)))
 				if err != nil {
-					t.Errorf("failed to verify existance of %q binary : args %q: %v", pkg, rr.Args, err)
+					t.Errorf("failed to verify existance of %q binary : args %q: %v", pkg, rr.Command(), err)
 				}
 			})
 		}
@@ -70,7 +70,7 @@ func TestGuestEnvironment(t *testing.T) {
 				t.Parallel()
 				rr, err := Run(t, exec.CommandContext(ctx, Targt(), "-p", profile, "ssh", fmt.Sprintf("df -t ext4 %s | grep %s", mount, mount)))
 				if err != nil {
-					t.Errorf("failed to verify existance of %q mount. args %q: %v", mount, rr.Args, err)
+					t.Errorf("failed to verify existance of %q mount. args %q: %v", mount, rr.Command(), err)
 				}
 			})
 		}

--- a/test/integration/gvisor_addon_test.go
+++ b/test/integration/gvisor_addon_test.go
@@ -50,18 +50,18 @@ func TestGvisorAddon(t *testing.T) {
 	startArgs := append([]string{"start", "-p", profile, "--memory=2200", "--container-runtime=containerd", "--docker-opt", "containerd=/var/run/containerd/containerd.sock"}, StartArgs()...)
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), startArgs...))
 	if err != nil {
-		t.Fatalf("failed to start minikube: args %q: %v", rr.Args, err)
+		t.Fatalf("failed to start minikube: args %q: %v", rr.Command(), err)
 	}
 
 	// If it exists, include a locally built gvisor image
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "cache", "add", "gcr.io/k8s-minikube/gvisor-addon:2"))
 	if err != nil {
-		t.Logf("%s failed: %v (won't test local image)", rr.Args, err)
+		t.Logf("%s failed: %v (won't test local image)", rr.Command(), err)
 	}
 
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "addons", "enable", "gvisor"))
 	if err != nil {
-		t.Fatalf("%s failed: %v", rr.Args, err)
+		t.Fatalf("%s failed: %v", rr.Command(), err)
 	}
 
 	if _, err := PodWait(ctx, t, profile, "kube-system", "kubernetes.io/minikube-addons=gvisor", Minutes(4)); err != nil {
@@ -71,12 +71,12 @@ func TestGvisorAddon(t *testing.T) {
 	// Create an untrusted workload
 	rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "replace", "--force", "-f", filepath.Join(*testdataDir, "nginx-untrusted.yaml")))
 	if err != nil {
-		t.Fatalf("%s failed: %v", rr.Args, err)
+		t.Fatalf("%s failed: %v", rr.Command(), err)
 	}
 	// Create gvisor workload
 	rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "replace", "--force", "-f", filepath.Join(*testdataDir, "nginx-gvisor.yaml")))
 	if err != nil {
-		t.Fatalf("%s failed: %v", rr.Args, err)
+		t.Fatalf("%s failed: %v", rr.Command(), err)
 	}
 
 	if _, err := PodWait(ctx, t, profile, "default", "run=nginx,untrusted=true", Minutes(4)); err != nil {
@@ -89,12 +89,12 @@ func TestGvisorAddon(t *testing.T) {
 	// Ensure that workloads survive a restart
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "stop", "-p", profile))
 	if err != nil {
-		t.Fatalf("faild stopping minikube. args %q : %v", rr.Args, err)
+		t.Fatalf("faild stopping minikube. args %q : %v", rr.Command(), err)
 	}
 
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), startArgs...))
 	if err != nil {
-		t.Fatalf("failed starting minikube after a stop. args %q, %v", rr.Args, err)
+		t.Fatalf("failed starting minikube after a stop. args %q, %v", rr.Command(), err)
 	}
 	if _, err := PodWait(ctx, t, profile, "kube-system", "kubernetes.io/minikube-addons=gvisor", Minutes(4)); err != nil {
 		t.Errorf("failed waiting for 'gvisor controller' pod : %v", err)

--- a/test/integration/gvisor_addon_test.go
+++ b/test/integration/gvisor_addon_test.go
@@ -50,7 +50,7 @@ func TestGvisorAddon(t *testing.T) {
 	startArgs := append([]string{"start", "-p", profile, "--memory=2200", "--container-runtime=containerd", "--docker-opt", "containerd=/var/run/containerd/containerd.sock"}, StartArgs()...)
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), startArgs...))
 	if err != nil {
-		t.Fatalf("%s failed: %v", rr.Args, err)
+		t.Fatalf("failed to start minikube: args %q: %v", rr.Args, err)
 	}
 
 	// If it exists, include a locally built gvisor image
@@ -65,7 +65,7 @@ func TestGvisorAddon(t *testing.T) {
 	}
 
 	if _, err := PodWait(ctx, t, profile, "kube-system", "kubernetes.io/minikube-addons=gvisor", Minutes(4)); err != nil {
-		t.Fatalf("waiting for gvisor controller to be up: %v", err)
+		t.Fatalf("failed waiting for 'gvisor controller' pod: %v", err)
 	}
 
 	// Create an untrusted workload
@@ -80,29 +80,29 @@ func TestGvisorAddon(t *testing.T) {
 	}
 
 	if _, err := PodWait(ctx, t, profile, "default", "run=nginx,untrusted=true", Minutes(4)); err != nil {
-		t.Errorf("nginx: %v", err)
+		t.Errorf("failed waiting for nginx pod: %v", err)
 	}
 	if _, err := PodWait(ctx, t, profile, "default", "run=nginx,runtime=gvisor", Minutes(4)); err != nil {
-		t.Errorf("nginx: %v", err)
+		t.Errorf("failed waitinf for gvisor pod: %v", err)
 	}
 
 	// Ensure that workloads survive a restart
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "stop", "-p", profile))
 	if err != nil {
-		t.Fatalf("%s failed: %v", rr.Args, err)
+		t.Fatalf("faild stopping minikube. args %q : %v", rr.Args, err)
 	}
 
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), startArgs...))
 	if err != nil {
-		t.Fatalf("%s failed: %v", rr.Args, err)
+		t.Fatalf("failed starting minikube after a stop. args %q, %v", rr.Args, err)
 	}
 	if _, err := PodWait(ctx, t, profile, "kube-system", "kubernetes.io/minikube-addons=gvisor", Minutes(4)); err != nil {
-		t.Errorf("waiting for gvisor controller to be up: %v", err)
+		t.Errorf("failed waiting for 'gvisor controller' pod : %v", err)
 	}
 	if _, err := PodWait(ctx, t, profile, "default", "run=nginx,untrusted=true", Minutes(4)); err != nil {
-		t.Errorf("nginx: %v", err)
+		t.Errorf("failed waiting for 'nginx' pod : %v", err)
 	}
 	if _, err := PodWait(ctx, t, profile, "default", "run=nginx,runtime=gvisor", Minutes(4)); err != nil {
-		t.Errorf("nginx: %v", err)
+		t.Errorf("failed waiting for 'gvisor' pod : %v", err)
 	}
 }

--- a/test/integration/none_test.go
+++ b/test/integration/none_test.go
@@ -46,22 +46,22 @@ func TestChangeNoneUser(t *testing.T) {
 	startArgs := append([]string{"CHANGE_MINIKUBE_NONE_USER=true", Target(), "start", "--wait=false"}, StartArgs()...)
 	rr, err := Run(t, exec.CommandContext(ctx, "/usr/bin/env", startArgs...))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("%s failed: %v", rr.Command(), err)
 	}
 
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "delete"))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("%s failed: %v", rr.Command(), err)
 	}
 
 	rr, err = Run(t, exec.CommandContext(ctx, "/usr/bin/env", startArgs...))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("%s failed: %v", rr.Command(), err)
 	}
 
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "status"))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("%s failed: %v", rr.Command(), err)
 	}
 
 	username := os.Getenv("SUDO_USER")

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -115,13 +115,13 @@ func TestStartStop(t *testing.T) {
 				// Enable an addon to assert it comes up afterwards
 				rr, err = Run(t, exec.CommandContext(ctx, Target(), "addons", "enable", "dashboard", "-p", profile))
 				if err != nil {
-					t.Errorf("failed to enable an addon while minikube is stopped. args %q:  ", rr.Args, err)
+					t.Errorf("failed to enable an addon post-stop. args %q: %v", rr.Args, err)
 				}
 
 				rr, err = Run(t, exec.CommandContext(ctx, Target(), startArgs...))
 				if err != nil {
 					// Explicit fatal so that failures don't move directly to deletion
-					t.Fatalf("Failed to start minikube after stop -Second Start-. args %q: %v", rr.Args, err)
+					t.Fatalf("failed to start minikube post-stop. args %q: %v", rr.Args, err)
 				}
 
 				if strings.Contains(tc.name, "cni") {

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -92,7 +92,7 @@ func TestStartStop(t *testing.T) {
 
 				rr, err := Run(t, exec.CommandContext(ctx, Target(), startArgs...))
 				if err != nil {
-					t.Fatalf("failed starting minikube -first start-. args %q: %v", rr.Args, err)
+					t.Fatalf("failed starting minikube -first start-. args %q: %v", rr.Command(), err)
 				}
 
 				if !strings.Contains(tc.name, "cni") {
@@ -101,7 +101,7 @@ func TestStartStop(t *testing.T) {
 
 				rr, err = Run(t, exec.CommandContext(ctx, Target(), "stop", "-p", profile, "--alsologtostderr", "-v=3"))
 				if err != nil {
-					t.Errorf("failed stopping minikube - first stop-. args %q : %v", rr.Args, err)
+					t.Errorf("failed stopping minikube - first stop-. args %q : %v", rr.Command(), err)
 				}
 
 				// The none driver never really stops
@@ -115,13 +115,13 @@ func TestStartStop(t *testing.T) {
 				// Enable an addon to assert it comes up afterwards
 				rr, err = Run(t, exec.CommandContext(ctx, Target(), "addons", "enable", "dashboard", "-p", profile))
 				if err != nil {
-					t.Errorf("failed to enable an addon post-stop. args %q: %v", rr.Args, err)
+					t.Errorf("failed to enable an addon post-stop. args %q: %v", rr.Command(), err)
 				}
 
 				rr, err = Run(t, exec.CommandContext(ctx, Target(), startArgs...))
 				if err != nil {
 					// Explicit fatal so that failures don't move directly to deletion
-					t.Fatalf("failed to start minikube post-stop. args %q: %v", rr.Args, err)
+					t.Fatalf("failed to start minikube post-stop. args %q: %v", rr.Command(), err)
 				}
 
 				if strings.Contains(tc.name, "cni") {
@@ -150,7 +150,7 @@ func TestStartStop(t *testing.T) {
 					// Normally handled by cleanuprofile, but not fatal there
 					rr, err = Run(t, exec.CommandContext(ctx, Target(), "delete", "-p", profile))
 					if err != nil {
-						t.Errorf("failed to clean up: args %q: %v", rr.Args, err)
+						t.Errorf("failed to clean up: args %q: %v", rr.Command(), err)
 					}
 
 					rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "config", "get-contexts", profile))
@@ -182,14 +182,14 @@ func TestStartStopWithPreload(t *testing.T) {
 
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), startArgs...))
 	if err != nil {
-		t.Fatalf("%s failed: %v", rr.Args, err)
+		t.Fatalf("%s failed: %v", rr.Command(), err)
 	}
 
 	// Now, pull the busybox image into the VMs docker daemon
 	image := "busybox"
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "ssh", "-p", profile, "--", "docker", "pull", image))
 	if err != nil {
-		t.Fatalf("%s failed: %v", rr.Args, err)
+		t.Fatalf("%s failed: %v", rr.Command(), err)
 	}
 
 	// Restart minikube with v1.17.3, which has a preloaded tarball
@@ -199,11 +199,11 @@ func TestStartStopWithPreload(t *testing.T) {
 	startArgs = append(startArgs, fmt.Sprintf("--kubernetes-version=%s", k8sVersion))
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), startArgs...))
 	if err != nil {
-		t.Fatalf("%s failed: %v", rr.Args, err)
+		t.Fatalf("%s failed: %v", rr.Command(), err)
 	}
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "ssh", "-p", profile, "--", "docker", "images"))
 	if err != nil {
-		t.Fatalf("%s failed: %v", rr.Args, err)
+		t.Fatalf("%s failed: %v", rr.Command(), err)
 	}
 	if !strings.Contains(rr.Output(), image) {
 		t.Fatalf("Expected to find %s in output of `docker images`, instead got %s", image, rr.Output())
@@ -217,7 +217,7 @@ func testPodScheduling(ctx context.Context, t *testing.T, profile string) {
 	// schedule a pod to assert persistence
 	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "create", "-f", filepath.Join(*testdataDir, "busybox.yaml")))
 	if err != nil {
-		t.Fatalf("%s failed: %v", rr.Args, err)
+		t.Fatalf("%s failed: %v", rr.Command(), err)
 	}
 
 	// 8 minutes, because 4 is not enough for images to pull in all cases.
@@ -250,7 +250,7 @@ func testPulledImages(ctx context.Context, t *testing.T, profile string, version
 
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), "ssh", "-p", profile, "sudo crictl images -o json"))
 	if err != nil {
-		t.Errorf("failed tp get images inside minikube. args %q: %v", rr.Args, err)
+		t.Errorf("failed tp get images inside minikube. args %q: %v", rr.Command(), err)
 	}
 	jv := map[string][]struct {
 		Tags []string `json:"repoTags"`
@@ -293,7 +293,7 @@ func testPause(ctx context.Context, t *testing.T, profile string) {
 
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), "pause", "-p", profile, "--alsologtostderr", "-v=1"))
 	if err != nil {
-		t.Fatalf("%s failed: %v", rr.Args, err)
+		t.Fatalf("%s failed: %v", rr.Command(), err)
 	}
 
 	got := Status(ctx, t, Target(), profile, "APIServer")
@@ -308,7 +308,7 @@ func testPause(ctx context.Context, t *testing.T, profile string) {
 
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "unpause", "-p", profile, "--alsologtostderr", "-v=1"))
 	if err != nil {
-		t.Fatalf("%s failed: %v", rr.Args, err)
+		t.Fatalf("%s failed: %v", rr.Command(), err)
 	}
 
 	got = Status(ctx, t, Target(), profile, "APIServer")

--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -97,7 +97,7 @@ func TestVersionUpgrade(t *testing.T) {
 	args = append([]string{"start", "-p", profile, fmt.Sprintf("--kubernetes-version=%s", constants.NewestKubernetesVersion), "--alsologtostderr", "-v=1"}, StartArgs()...)
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("failed to start minikube HEAD with newest k8s version. args: %s : %v", rr.Args, err)
 	}
 
 	s, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "version", "--output=json"))
@@ -127,6 +127,6 @@ func TestVersionUpgrade(t *testing.T) {
 	args = append([]string{"start", "-p", profile, fmt.Sprintf("--kubernetes-version=%s", constants.NewestKubernetesVersion), "--alsologtostderr", "-v=1"}, StartArgs()...)
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
-		t.Errorf("%s failed: %v", rr.Args, err)
+		t.Errorf("start and already started minikube failed. args: %q : %v", rr.Args, err)
 	}
 }

--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -82,7 +82,7 @@ func TestVersionUpgrade(t *testing.T) {
 
 	rr, err = Run(t, exec.CommandContext(ctx, tf.Name(), "stop", "-p", profile))
 	if err != nil {
-		t.Fatalf("%s failed: %v", rr.Args, err)
+		t.Fatalf("%s failed: %v", rr.Command(), err)
 	}
 
 	rr, err = Run(t, exec.CommandContext(ctx, tf.Name(), "-p", profile, "status", "--format={{.Host}}"))
@@ -97,7 +97,7 @@ func TestVersionUpgrade(t *testing.T) {
 	args = append([]string{"start", "-p", profile, fmt.Sprintf("--kubernetes-version=%s", constants.NewestKubernetesVersion), "--alsologtostderr", "-v=1"}, StartArgs()...)
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
-		t.Errorf("failed to start minikube HEAD with newest k8s version. args: %s : %v", rr.Args, err)
+		t.Errorf("failed to start minikube HEAD with newest k8s version. args: %s : %v", rr.Command(), err)
 	}
 
 	s, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "version", "--output=json"))
@@ -121,12 +121,12 @@ func TestVersionUpgrade(t *testing.T) {
 
 	args = append([]string{"start", "-p", profile, fmt.Sprintf("--kubernetes-version=%s", constants.OldestKubernetesVersion), "--alsologtostderr", "-v=1"}, StartArgs()...)
 	if rr, err := Run(t, exec.CommandContext(ctx, tf.Name(), args...)); err == nil {
-		t.Fatalf("downgrading kubernetes should not be allowed. expected to see error but got %v for %q", err, rr.Args)
+		t.Fatalf("downgrading kubernetes should not be allowed. expected to see error but got %v for %q", err, rr.Command())
 	}
 
 	args = append([]string{"start", "-p", profile, fmt.Sprintf("--kubernetes-version=%s", constants.NewestKubernetesVersion), "--alsologtostderr", "-v=1"}, StartArgs()...)
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
-		t.Errorf("start and already started minikube failed. args: %q : %v", rr.Args, err)
+		t.Errorf("start and already started minikube failed. args: %q : %v", rr.Command(), err)
 	}
 }


### PR DESCRIPTION
- make it easier for humans to read and find the test failures without having to find the test args and figure out what they meant.
- fixed a few wrong formatting where we logged vars instead of err.
- "quote" all the args.
- a bit more consistent formatting  `failed to...` and `expected -%q-  *%q*`
- in complicated tests such as test version upgrade or test start stop... make it clear which start and stop failed.

this PR hopes me and people like me have easier time reading the logs.