### PR TITLE
indent CI test outputs for better readability

### DIFF
--- a/test/integration/helpers.go
+++ b/test/integration/helpers.go
@@ -76,11 +76,9 @@ func indentLines(b *bytes.Buffer) string {
 // Output returns human-readable output for an execution result
 func (rr RunResult) Output() string {
 	var sb strings.Builder
-
 	if rr.Stdout.Len() > 0 {
-		sb.WriteString(fmt.Sprintf("-- stdout --\n%s\n-- /stdout --", indentLines(rr.Stdout)))
+		sb.WriteString(fmt.Sprintf("\n-- stdout --\n%s\n-- /stdout --", indentLines(rr.Stdout)))
 	}
-
 	if rr.Stderr.Len() > 0 {
 		sb.WriteString(fmt.Sprintf("\n** stderr ** \n%s\n** /stderr **", indentLines(rr.Stderr)))
 	}

--- a/test/integration/helpers.go
+++ b/test/integration/helpers.go
@@ -63,14 +63,26 @@ func (rr RunResult) Command() string {
 	return sb.String()
 }
 
+// indentLines indents every line in a bytes.Buffer and returns it as string
+func indentLines(b *bytes.Buffer) string {
+	scanner := bufio.NewScanner(b)
+	var lines string
+	for scanner.Scan() {
+		lines = lines + "\t" + scanner.Text() + "\n"
+	}
+	return lines
+}
+
 // Output returns human-readable output for an execution result
 func (rr RunResult) Output() string {
 	var sb strings.Builder
+
 	if rr.Stdout.Len() > 0 {
-		sb.WriteString(fmt.Sprintf("-- stdout --\n%s\n-- /stdout --", rr.Stdout.Bytes()))
+		sb.WriteString(fmt.Sprintf("-- stdout --\n%s\n-- /stdout --", indentLines(rr.Stdout)))
 	}
+
 	if rr.Stderr.Len() > 0 {
-		sb.WriteString(fmt.Sprintf("\n** stderr ** \n%s\n** /stderr **", rr.Stderr.Bytes()))
+		sb.WriteString(fmt.Sprintf("\n** stderr ** \n%s\n** /stderr **", indentLines(rr.Stderr)))
 	}
 	return sb.String()
 }


### PR DESCRIPTION
### Before this PR:
```
--- FAIL: TestFunctional/parallel/DryRun (1.54s)
functional_test.go:385: (dbg) Run:  out/minikube-linux-amd64 start -p minikube --dry-run --memory 250MB --alsologtostderr -v=1 --driver=none 
functional_test.go:385: (dbg) Non-zero exit: out/minikube-linux-amd64 start -p minikube --dry-run --memory 250MB --alsologtostderr -v=1 --driver=none : exit status 78 (1.36949181s)
-- stdout --
* minikube v1.9.0-beta.2 on Debian 9.12
- KUBECONFIG=/home/jenkins/minikube-integration/linux-amd64-none-7244-8067-dc3b842d4164dd96d4c9192833c22b769bd3f2f8/kubeconfig
- MINIKUBE_BIN=out/minikube-linux-amd64
- MINIKUBE_HOME=/home/jenkins/minikube-integration/linux-amd64-none-7244-8067-dc3b842d4164dd96d4c9192833c22b769bd3f2f8/.minikube
- MINIKUBE_LOCATION=7244
* Using the none driver based on existing profile
-- /stdout --
** stderr ** 
I0325 17:33:27.275891   25181 notify.go:125] Checking for updates...
I0325 17:33:27.396718   25181 start.go:259] hostinfo: {"hostname":"kvm-integration-slave4","uptime":4562,"bootTime":1585178245,"procs":251,"os":"linux","platform":"debian","platformFamily":"debian","platformVersion":"9.12","kernelVersion":"4.9.0-12-amd64","virtualizationSystem":"kvm","virtualizationRole":"host","hostid":"ecd1c669-ba24-1b1d-e04e-2bc385d19e9b"}
I0325 17:33:27.397357   25181 start.go:269] virtualization: kvm host
I0325 17:33:28.605739   25181 driver.go:226] Setting default libvirt URI to qemu:///system
I0325 17:33:28.608365   25181 start.go:307] selected driver: none
I0325 17:33:28.608374   25181 start.go:596] validating driver "none" against &{Name:minikube KeepContext:false EmbedCerts:false MinikubeISO: Memory:2500 CPUs:2 DiskSize:20000 Driver:none HyperkitVpnKitSock: HyperkitVSockPorts:[] DockerEnv:[] InsecureRegistry:[] RegistryMirror:[] HostOnlyCIDR:192.168.99.1/24 HypervVirtualSwitch: HypervUseExternalSwitch:false HypervExternalAdapter: KVMNetwork:default KVMQemuURI:qemu:///system KVMGPU:false KVMHidden:false DockerOpt:[] DisableDriverMounts:false NFSShare:[] NFSSharesRoot:/nfsshares UUID: NoVTXCheck:false DNSProxy:false HostDNSResolver:true HostOnlyNicType:virtio NatNicType:virtio KubernetesConfig:{KubernetesVersion:v1.18.0-rc.1 ClusterName:minikube APIServerName:minikubeCA APIServerNames:[] APIServerIPs:[] DNSDomain:cluster.local ContainerRuntime:docker CRISocket: NetworkPlugin: FeatureGates: ServiceCIDR:10.96.0.0/12 ImageRepository: ExtraOptions:[] ShouldLoadCachedImages:false EnableDefaultCNI:false NodeIP: NodePort:0 NodeName:} Nodes:[{Name: IP:1
0.138.0.6 Port:8443 KubernetesVersion:v1.18.0-rc.1 ControlPlane:true Worker:true}] Addons:map[dashboard:true default-storageclass:true storage-provisioner:true]}
I0325 17:33:28.608430   25181 start.go:602] status for none: {Installed:true Healthy:true Error:<nil> Fix: Doc:}
X Requested memory allocation 250MB is less than the usable minimum of <no value>MB
** /stderr **
```

# After this PR expecting:

```

-- stdout --
    * minikube v1.9.0-beta.2 on Debian 9.12
    - KUBECONFIG=/home/jenkins/minikube-integration/linux-amd64-none-7244-8067-dc3b842d4164dd96d4c9192833c22b769bd3f2f8/kubeconfig
    - MINIKUBE_BIN=out/minikube-linux-amd64
    - MINIKUBE_HOME=/home/jenkins/minikube-integration/linux-amd64-none-7244-8067-dc3b842d4164dd96d4c9192833c22b769bd3f2f8/.minikube
    - MINIKUBE_LOCATION=7244
    * Using the none driver based on existing profile
-- /stdout --
** stderr ** 
    I0325 17:33:27.275891   25181 notify.go:125] Checking for updates...
    I0325 17:33:27.396718   25181 start.go:259] hostinfo: {"hostname":"kvm-integration-slave4","uptime":4562,"bootTime":1585178245,"procs":251,"os":"linux","platform":"debian","platformFamily":"debian","platformVersion":"9.12","kernelVersion":"4.9.0-12-amd64","virtualizationSystem":"kvm","virtualizationRole":"host","hostid":"ecd1c669-ba24-1b1d-e04e-2bc385d19e9b"}
    I0325 17:33:27.397357   25181 start.go:269] virtualization: kvm host
    I0325 17:33:28.605739   25181 driver.go:226] Setting default libvirt URI to qemu:///system
    I0325 17:33:28.608365   25181 start.go:307] selected driver: none
    I0325 17:33:28.608374   25181 start.go:596] validating driver "none" against &{Name:minikube KeepContext:false EmbedCerts:false MinikubeISO: Memory:2500 CPUs:2 DiskSize:20000 Driver:none HyperkitVpnKitSock: HyperkitVSockPorts:[] DockerEnv:[] InsecureRegistry:[] RegistryMirror:[] HostOnlyCIDR:192.168.99.1/24 HypervVirtualSwitch: HypervUseExternalSwitch:false HypervExternalAdapter: KVMNetwork:default KVMQemuURI:qemu:///system KVMGPU:false KVMHidden:false DockerOpt:[] DisableDriverMounts:false NFSShare:[] NFSSharesRoot:/nfsshares UUID: NoVTXCheck:false DNSProxy:false HostDNSResolver:true HostOnlyNicType:virtio NatNicType:virtio KubernetesConfig:{KubernetesVersion:v1.18.0-rc.1 ClusterName:minikube APIServerName:minikubeCA APIServerNames:[] APIServerIPs:[] DNSDomain:cluster.local ContainerRuntime:docker CRISocket: NetworkPlugin: FeatureGates: ServiceCIDR:10.96.0.0/12 ImageRepository: ExtraOptions:[] ShouldLoadCachedImages:false EnableDefaultCNI:false NodeIP: NodePort:0 NodeName:} Nodes:[{Name: IP:1
    0.138.0.6 Port:8443 KubernetesVersion:v1.18.0-rc.1 ControlPlane:true Worker:true}] Addons:map[dashboard:true default-storageclass:true storage-provisioner:true]}
    I0325 17:33:28.608430   25181 start.go:602] status for none: {Installed:true Healthy:true Error:<nil> Fix: Doc:}
    X Requested memory allocation 250MB is less than the usable minimum of <no value>MB
** /stderr **
```
