### PR TITLE
install kubectl on github action machines

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,6 +87,7 @@ jobs:
       run: |
         curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
         sudo install kubectl /usr/local/bin/kubectl
+        kubectl version
     - name: Docker Info
       shell: bash
       run: |
@@ -175,6 +176,7 @@ jobs:
       run: |
         curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
         sudo install kubectl /usr/local/bin/kubectl
+        kubectl version
     - name: Install lz4
       shell: bash
       run: |
@@ -263,6 +265,7 @@ jobs:
       run: |
         curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
         sudo install kubectl /usr/local/bin/kubectl
+        kubectl version
     # conntrack is required for kubernetes 1.18 and higher
     # socat is required for kubectl port forward which is used in some tests such as validateHelmTillerAddon
     - name: Install tools for none
@@ -340,6 +343,7 @@ jobs:
       run: |
         curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
         sudo install kubectl /usr/local/bin/kubectl
+        kubectl version
     # conntrack is required for kubernetes 1.18 and higher
     # socat is required for kubectl port forward which is used in some tests such as validateHelmTillerAddon
     - name: Install tools for none
@@ -417,6 +421,7 @@ jobs:
         run: |
           curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
           sudo install kubectl /usr/local/bin/kubectl
+          kubectl version
       - name: Install podman
         shell: bash
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,13 +81,26 @@ jobs:
       GOPOGH_RESULT: ""
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
     runs-on: ubuntu-16.04
-    steps:
+    steps:    
+    - name: Install kubectl
+      shell: bash
+      run: |
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
+        sudo install kubectl /usr/local/bin/kubectl
     - name: Docker Info
       shell: bash
       run: |
-        docker info || true
+        echo "--------------------------"
         docker version || true
+        echo "--------------------------"
+        docker info || true
+        echo "--------------------------"
+        docker system df || true
+        echo "--------------------------"
+        docker system info || true
+        echo "--------------------------"
         docker ps || true
+        echo "--------------------------"
     - name: Install lz4
       shell: bash
       run: |
@@ -157,6 +170,11 @@ jobs:
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
     needs: [build_minikube]
     steps:
+    - name: Install kubectl
+      shell: bash
+      run: |
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
+        sudo install kubectl /usr/local/bin/kubectl
     - name: Install lz4
       shell: bash
       run: |
@@ -165,9 +183,17 @@ jobs:
     - name: Docker Info
       shell: bash
       run: |
-        docker info || true
+        echo "--------------------------"
         docker version || true
+        echo "--------------------------"
+        docker info || true
+        echo "--------------------------"
+        docker system df || true
+        echo "--------------------------"
+        docker system info || true
+        echo "--------------------------"
         docker ps || true
+        echo "--------------------------"
     - name: Install gopogh
       shell: bash
       run: |
@@ -232,6 +258,11 @@ jobs:
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
     runs-on: ubuntu-16.04
     steps:
+    - name: Install kubectl
+      shell: bash
+      run: |
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
+        sudo install kubectl /usr/local/bin/kubectl
     # conntrack is required for kubernetes 1.18 and higher
     # socat is required for kubectl port forward which is used in some tests such as validateHelmTillerAddon
     - name: Install tools for none
@@ -304,6 +335,11 @@ jobs:
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
     runs-on: ubuntu-18.04
     steps:
+    - name: Install kubectl
+      shell: bash
+      run: |
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
+        sudo install kubectl /usr/local/bin/kubectl
     # conntrack is required for kubernetes 1.18 and higher
     # socat is required for kubectl port forward which is used in some tests such as validateHelmTillerAddon
     - name: Install tools for none
@@ -376,11 +412,11 @@ jobs:
         SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
       runs-on: ubuntu-18.04
       steps:
-      - name: Install lz4
+      - name: Install kubectl
         shell: bash
         run: |
-          sudo apt-get update -qq
-          sudo apt-get -qq -y install liblz4-tool
+          curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
+          sudo install kubectl /usr/local/bin/kubectl
       - name: Install podman
         shell: bash
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
       run: |
         curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
         sudo install kubectl /usr/local/bin/kubectl
-        kubectl version
+        kubectl version --client=true
     - name: Docker Info
       shell: bash
       run: |
@@ -176,7 +176,7 @@ jobs:
       run: |
         curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
         sudo install kubectl /usr/local/bin/kubectl
-        kubectl version
+        kubectl version --client=true
     - name: Install lz4
       shell: bash
       run: |
@@ -265,7 +265,7 @@ jobs:
       run: |
         curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
         sudo install kubectl /usr/local/bin/kubectl
-        kubectl version
+        kubectl version --client=true
     # conntrack is required for kubernetes 1.18 and higher
     # socat is required for kubectl port forward which is used in some tests such as validateHelmTillerAddon
     - name: Install tools for none
@@ -343,7 +343,7 @@ jobs:
       run: |
         curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
         sudo install kubectl /usr/local/bin/kubectl
-        kubectl version
+        kubectl version --client=true
     # conntrack is required for kubernetes 1.18 and higher
     # socat is required for kubectl port forward which is used in some tests such as validateHelmTillerAddon
     - name: Install tools for none
@@ -421,7 +421,7 @@ jobs:
         run: |
           curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
           sudo install kubectl /usr/local/bin/kubectl
-          kubectl version
+          kubectl version --client=true
       - name: Install podman
         shell: bash
         run: |


### PR DESCRIPTION
this will install kubectl on github action CI machines as 
some of our tests depends on having kubectl.

aslo adds more docker info for debuggings