### PR TITLE
local search for the site

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -625,7 +625,7 @@ release-kvm-driver: install-kvm-driver checksum  ## Release KVM Driver
 	gsutil cp $(GOBIN)/docker-machine-driver-kvm2 gs://minikube/drivers/kvm/$(VERSION)/
 	gsutil cp $(GOBIN)/docker-machine-driver-kvm2.sha256 gs://minikube/drivers/kvm/$(VERSION)/
 
-site/themes/docsy/assets/vendor/bootstrap/package.js:
+site/themes/docsy/assets/vendor/bootstrap/package.js: ## update the website docsy theme git submodule 
 	git submodule update -f --init --recursive
 
 out/hugo/hugo:

--- a/site/config.toml
+++ b/site/config.toml
@@ -112,7 +112,10 @@ github_project_repo = ""
 github_subdir = "site"
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
-gcs_engine_id = "005331096405080631692:s7c4yfpw9sy"
+# gcs_engine_id = "005331096405080631692:s7c4yfpw9sy"
+
+# enabling local search https://www.docsy.dev/docs/adding-content/navigation/#configure-local-search-with-lunr
+offlineSearch = true
 
 # User interface configuration
 [params.ui]


### PR DESCRIPTION
the current website search is not ideal, because it shows results outside the minikube website which is annoying.

with this PR, it will do a static search using javascript. also this PR updates the theme git submodule. 



## Before this PR:

you would see some annoying ads not related to your search. 
also the format of results is not helpful 
(showing date and url) I rather see the words I looked for not a full search engine result in my doc site.

![Screen Shot 2020-03-26 at 2 48 52 AM](https://user-images.githubusercontent.com/4564227/77633237-67ccff00-6f0c-11ea-9947-2d923f0dd0ca.png)

## After this PR: 
try it for yourself  https://deploy-preview-7253--kubernetes-sigs-minikube.netlify.com/
- the title of result is the mark down page title 
- contains the words u searched for

### local search from right search bar

![Screen Shot 2020-03-26 at 2 50 15 AM](https://user-images.githubusercontent.com/4564227/77633360-96e37080-6f0c-11ea-9768-86d0a7a510d9.png)


### from left search bar

![Screen Shot 2020-03-26 at 2 51 17 AM](https://user-images.githubusercontent.com/4564227/77633435-b37fa880-6f0c-11ea-8d6f-593329913364.png)


# What I dont love about local search

the box is too small on the left or right.
if there is a way to make it bigger in the config I would like it