### PR TITLE
Fix testing regression which broke stdout reads

### DIFF
--- a/test/integration/helpers.go
+++ b/test/integration/helpers.go
@@ -64,8 +64,8 @@ func (rr RunResult) Command() string {
 }
 
 // indentLines indents every line in a bytes.Buffer and returns it as string
-func indentLines(b *bytes.Buffer) string {
-	scanner := bufio.NewScanner(b)
+func indentLines(b []byte) string {
+	scanner := bufio.NewScanner(bytes.NewReader(b))
 	var lines string
 	for scanner.Scan() {
 		lines = lines + "\t" + scanner.Text() + "\n"
@@ -77,10 +77,10 @@ func indentLines(b *bytes.Buffer) string {
 func (rr RunResult) Output() string {
 	var sb strings.Builder
 	if rr.Stdout.Len() > 0 {
-		sb.WriteString(fmt.Sprintf("\n-- stdout --\n%s\n-- /stdout --", indentLines(rr.Stdout)))
+		sb.WriteString(fmt.Sprintf("\n-- stdout --\n%s\n-- /stdout --", indentLines(rr.Stdout.Bytes())))
 	}
 	if rr.Stderr.Len() > 0 {
-		sb.WriteString(fmt.Sprintf("\n** stderr ** \n%s\n** /stderr **", indentLines(rr.Stderr)))
+		sb.WriteString(fmt.Sprintf("\n** stderr ** \n%s\n** /stderr **", indentLines(rr.Stderr.Bytes())))
 	}
 	return sb.String()
 }


### PR DESCRIPTION
TestVersionUpgrade began failing because it could not parse the output of `minikube status`. The indenter  was reading off of stdout without re-seeking to zero. Switched it  to  use `.Bytes()` again.

Regression from #7249