### PR TITLE
make http error test fatal to avoid nil pointer

### DIFF
--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -335,7 +335,7 @@ func validateDashboardCmd(ctx context.Context, t *testing.T, profile string) {
 
 	resp, err := retryablehttp.Get(u.String())
 	if err != nil {
-		t.Errorf("failed to http get %q : %v", u.String(), err)
+		t.Fatalf("failed to http get %q : %v", u.String(), err)
 	}
 	if resp.StatusCode != http.StatusOK {
 		body, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
I just want to be able to run the full docker/podman tests so I can see the full extent of the failures