### PR TITLE
Upgrade to v1.9.0 and add release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ New features & improvements
 * gpu addon: privileged mode no longer required [#7149](https://github.com/kubernetes/minikube/pull/7149)
 * Add sch_tbf and extend filter ipset kernel module for bandwidth shaping [#7255](https://github.com/kubernetes/minikube/pull/7255)
 * Parse --disk-size and --memory sizes with binary suffixes [#7206](https://github.com/kubernetes/minikube/pull/7206)
-* local search for the site [#7253](https://github.com/kubernetes/minikube/pull/7253)
 
 
 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Release Notes
 
+## Version 1.9.0- 2020-03-26
+
+New features & improvements
+
+* Update DefaultKubernetesVersion to v1.18.0 [#7235](https://github.com/kubernetes/minikube/pull/7235)
+* Add --vm flag for users who want to autoselect only VM's [#7068](https://github.com/kubernetes/minikube/pull/7068)
+* Add 'stable' and 'latest' as valid kubernetes-version values [#7212](https://github.com/kubernetes/minikube/pull/7212)
+
+* gpu addon: privileged mode no longer required [#7149](https://github.com/kubernetes/minikube/pull/7149)
+* Add sch_tbf and extend filter ipset kernel module for bandwidth shaping [#7255](https://github.com/kubernetes/minikube/pull/7255)
+* Parse --disk-size and --memory sizes with binary suffixes [#7206](https://github.com/kubernetes/minikube/pull/7206)
+* local search for the site [#7253](https://github.com/kubernetes/minikube/pull/7253)
+
+
+Bug Fixes
+
+* Re-initalize failed Kubernetes clusters [#7234](https://github.com/kubernetes/minikube/pull/7234)
+* do not override hostname if extraConfig is specified [#7238](https://github.com/kubernetes/minikube/pull/7238)
+* Enable HW_RANDOM_VIRTIO to fix sshd startup delays [#7208](https://github.com/kubernetes/minikube/pull/7208)
+* hyperv Delete: call StopHost before removing VM [#7160](https://github.com/kubernetes/minikube/pull/7160)
+
+Huge thank you for this release towards our contributors: 
+
+- Anders F Björklund
+- Medya Ghazizadeh
+- Priya Wadhwa
+- Sharif Elgamal
+- Thomas Strömberg
+- Tom
+- Vincent Link
+- Yang Keao
+- Zhongcheng Lao
+- vikkyomkar
+
+
 ## Version 1.9.0-beta.2 - 2020-03-21
 
 New features & improvements

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 # Bump these on release - and please check ISO_VERSION for correctness.
 VERSION_MAJOR ?= 1
 VERSION_MINOR ?= 9
-VERSION_BUILD ?= 0-beta.2
+VERSION_BUILD ?= 0
 RAW_VERSION=$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_BUILD)
 VERSION ?= v$(RAW_VERSION)
 


### PR DESCRIPTION
Waiting for v1.9.0 ISO to [finish building](https://a646c87040050000000000000000001.proxy.googleprod.com/job/ISO/90/) before running integration tests: