### PR TITLE
kic: Increase inspect timeout to 10s

### DIFF
--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -228,11 +228,11 @@ func (d *Driver) GetState() (state.State, error) {
 	out, err := cmd.CombinedOutput()
 	
 	if time.Since(start) > 2*time.Second {
-		glog.Errorf("%s took an unusually long time. Restarting the %s daemon may improve performance.", cmd, d.OCIBinary)
+		glog.Errorf("%s took an unusually long time. Restarting the %s daemon may improve performance.", strings.Join(cmd.Args, " "), d.OCIBinary)
 	}
 	
 	if ctx.Err() == context.DeadlineExceeded {
-		return state.Error, fmt.Errorf("inspect %s timeout", d.MachineName)
+		return state.Error, fmt.Errorf("timed out: %s", strings.Join(cmd.Args, " "))
 	}
 	
 	o := strings.TrimSpace(string(out))

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -220,8 +220,7 @@ func (d *Driver) GetURL() (string, error) {
 
 // GetState returns the state that the host is in (running, stopped, etc)
 func (d *Driver) GetState() (state.State, error) {
-	// allow no more than 2 seconds for this. when this takes long this means deadline passed
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, d.NodeConfig.OCIBinary, "inspect", "-f", "{{.State.Status}}", d.MachineName)

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -228,7 +228,7 @@ func (d *Driver) GetState() (state.State, error) {
 	out, err := cmd.CombinedOutput()
 	
 	if time.Since(start) > 2*time.Second {
-		glog.Errorf("%s took an unusually long time. Restarting the %s daemon may improve performance.", cmd.Args(), d.OCIBinary)
+		glog.Errorf("%s took an unusually long time. Restarting the %s daemon may improve performance.", cmd, d.OCIBinary)
 	}
 	
 	if ctx.Err() == context.DeadlineExceeded {


### PR DESCRIPTION
Heavy docker loads can sometimes slow this down.

Fixes #7193

