### PR TITLE
Set minLogCheckTime to 60 until we can  cut down on spam

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/kverify/kverify.go
+++ b/pkg/minikube/bootstrapper/bsutil/kverify/kverify.go
@@ -45,7 +45,7 @@ import (
 )
 
 // minLogCheckTime how long to wait before spamming error logs to console
-const minLogCheckTime = 30 * time.Second
+const minLogCheckTime = 60 * time.Second
 
 // WaitForAPIServerProcess waits for api server to be healthy returns error if it doesn't
 func WaitForAPIServerProcess(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.ClusterConfig, cr command.Runner, start time.Time, timeout time.Duration) error {


### PR DESCRIPTION
Some upgrades show scary messages:

```
❌  Problems detected in kube-apiserver [bcd0d01596cf]:
    Error: failed to create listener: failed to listen on 0.0.0.0:8443: listen tcp 0.0.0.0:8443: bind: address already in use
    error: failed to create listener: failed to listen on 0.0.0.0:8443: listen tcp 0.0.0.0:8443: bind: address already in use
❌  Problems detected in kubelet:
    Mar 26 21:15:41 minikube kubelet[1852]: E0326 21:15:41.028575    1852 reflector.go:134] object-"kube-system"/"kube-proxy-token-jllfp": Failed to list *v1.Secret: secrets "kube-proxy-token-jllfp" is forbidden: User "system:node:minikube" cannot list resource "secrets" in API group "" in the namespace "kube-system"
    Mar 26 21:15:41 minikube kubelet[1852]: E0326 21:15:41.098638    1852 reflector.go:134] object-"kube-system"/"kindnet-token-6l455": Failed to list *v1.Secret: secrets "kindnet-token-6l455" is forbidden: User "system:node:minikube" cannot list resource "secrets" in API group "" in the namespace "kube-system"
    Mar 26 21:15:41 minikube kubelet[1852]: E0326 21:15:41.109212    1852 reflector.go:134] object-"kube-system"/"kube-proxy": Failed to list *v1.ConfigMap: configmaps "kube-proxy" is forbidden: User "system:node:minikube" cannot list resource "configmaps" in API group "" in the namespace "kube-system"
    Mar 26 21:15:41 minikube kubelet[1852]: E0326 21:15:41.117874    1852 reflector.go:134] object-"kube-system"/"coredns-token-nj65b": Failed to list *v1.Secret: secrets "coredns-token-nj65b" is forbidden: User "system:node:minikube" cannot list resource "secrets" in API group "" in the namespace "kube-system"
    Mar 26 21:15:41 minikube kubelet[1852]: E0326 21:15:41.118731    1852 reflector.go:134] object-"kube-system"/"coredns": Failed to list *v1.ConfigMap: configmaps "coredns" is forbidden: User "system:node:minikube" cannot list resource "configmaps" in API group "" in the namespace "kube-system"
```