### PR TITLE
Show all global flags in options command

### DIFF
--- a/cmd/minikube/cmd/options.go
+++ b/cmd/minikube/cmd/options.go
@@ -37,10 +37,9 @@ var optionsCmd = &cobra.Command{
 // runOptions handles the executes the flow of "minikube options"
 func runOptions(cmd *cobra.Command, args []string) {
 	out.String("The following options can be passed to any command:\n\n")
-	for _, flagName := range viperWhiteList {
-		f := pflag.Lookup(flagName)
-		out.String(flagUsage(f))
-	}
+	cmd.Root().PersistentFlags().VisitAll(func(flag *pflag.Flag) {
+		out.String(flagUsage(flag))
+	})
 }
 
 func flagUsage(flag *pflag.Flag) string {


### PR DESCRIPTION
Fixes #5117
Before this fix the flags shown in `minikube options` were taken from a list of options (`viperWhiteList`) which seems a bit arbitrary to me with no background.
I still don't know for sure why this is done but taking all PersistentFlags (persistent=apply to all sub commands) from the root command seems like the correct way.

This doesn't fix the problem as described in the issue but keeps it consistent with e.g. kubectl, which also shows global flags only with the `options` command.

### Before
```
 $ minikube version && minikube options
minikube version: v1.9.0
commit: 48fefd43444d2f8852f527c78f0141b377b1e42a
The following options can be passed to any command:

      --alsologtostderr=false: log to standard error as well as files
      --log_dir='': If non-empty, write log files in this directory
  -v, --v=0: log level for V logs
```
### After
```
 $ make && out/minikube version && out/minikube options
make: `out/minikube' is up to date.
minikube version: v1.9.0
commit: b47e8d502fb62ec0a968c47e75414aeadf125b4d
The following options can be passed to any command:

      --alsologtostderr=false: log to standard error as well as files
  -b, --bootstrapper='kubeadm': The name of the cluster bootstrapper that will set up the kubernetes cluster.
      --log_backtrace_at=:0: when logging hits line file:N, emit a stack trace
      --log_dir='': If non-empty, write log files in this directory
      --logtostderr=false: log to standard error instead of files
  -p, --profile='minikube': The name of the minikube VM being used. This can be set to allow having multiple instances of minikube independently.
      --stderrthreshold=2: logs at or above this threshold go to stderr
  -v, --v=0: log level for V logs
      --vmodule=: comma-separated list of pattern=N settings for file-filtered logging
```