### PR TITLE
Fix gofmt and golint on master, after merges

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/kverify/kverify.go
+++ b/pkg/minikube/bootstrapper/bsutil/kverify/kverify.go
@@ -231,6 +231,7 @@ func WaitForHealthyAPIServer(r cruntime.Manager, bs bootstrapper.Bootstrapper, c
 	return nil
 }
 
+// APIServerVersionMatch checks if the server version matches the expected
 func APIServerVersionMatch(client *kubernetes.Clientset, expected string) error {
 	vi, err := client.ServerVersion()
 	if err != nil {

--- a/pkg/minikube/bootstrapper/certs.go
+++ b/pkg/minikube/bootstrapper/certs.go
@@ -129,6 +129,7 @@ func SetupCerts(cmd command.Runner, k8s config.KubernetesConfig, n config.Node) 
 	return copyableFiles, nil
 }
 
+// CACerts has cert and key for CA (and Proxy)
 type CACerts struct {
 	caCert    string
 	caKey     string

--- a/pkg/minikube/mustload/mustload.go
+++ b/pkg/minikube/mustload/mustload.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// mustload loads minikube clusters, exiting with user-friendly messages
+// Package mustload loads minikube clusters, exiting with user-friendly messages
 package mustload
 
 import (
@@ -37,6 +37,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/out"
 )
 
+// ClusterController holds all the needed information for a minikube cluster
 type ClusterController struct {
 	Config   *config.ClusterConfig
 	API      libmachine.API

--- a/pkg/minikube/tunnel/route_freebsd.go
+++ b/pkg/minikube/tunnel/route_freebsd.go
@@ -164,5 +164,3 @@ func (router *osRouter) Cleanup(route *Route) error {
 	}
 	return nil
 }
-
-


### PR DESCRIPTION
gofmt:
```
pkg/minikube/tunnel/route_freebsd.go
```

golint:
```
pkg/minikube/bootstrapper/certs.go:132:6: exported type CACerts should have comment or be unexported
pkg/minikube/bootstrapper/bsutil/kverify/kverify.go:234:1: exported function APIServerVersionMatch should have comment or be unexported
pkg/minikube/mustload/mustload.go:17:1: package comment should be of the form "Package mustload ..."
pkg/minikube/mustload/mustload.go:40:6: exported type ClusterController should have comment or be unexported
```
