### PR TITLE
Add interface for download/Binary package and use it for unittests

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/binaries.go
+++ b/pkg/minikube/bootstrapper/bsutil/binaries.go
@@ -37,6 +37,8 @@ import (
 
 // TransferBinaries transfers all required Kubernetes binaries
 func TransferBinaries(cfg config.KubernetesConfig, c command.Runner) error {
+	binaryIf := download.GetBinaryInterface()
+
 	ok, err := binariesExist(cfg, c)
 	if err == nil && ok {
 		glog.Info("Found k8s binaries, skipping transfer")
@@ -59,7 +61,7 @@ func TransferBinaries(cfg config.KubernetesConfig, c command.Runner) error {
 	for _, name := range constants.KubernetesReleaseBinaries {
 		name := name
 		g.Go(func() error {
-			src, err := download.Binary(name, cfg.KubernetesVersion, "linux", runtime.GOARCH)
+			src, err := binaryIf.Binary(name, cfg.KubernetesVersion, "linux", runtime.GOARCH)
 			if err != nil {
 				return errors.Wrapf(err, "downloading %s", name)
 			}

--- a/pkg/minikube/download/binary.go
+++ b/pkg/minikube/download/binary.go
@@ -26,11 +26,19 @@ import (
 	"github.com/golang/glog"
 	"github.com/hashicorp/go-getter"
 	"github.com/pkg/errors"
+	"k8s.io/minikube/pkg/minikube/download/intf"
 	"k8s.io/minikube/pkg/minikube/localpath"
 )
 
+// GetBinaryInterface ...
+func GetBinaryInterface() intf.BinaryIf {
+	return &binary{}
+}
+
+type binary struct{}
+
 // binaryWithChecksumURL gets the location of a Kubernetes binary
-func binaryWithChecksumURL(binaryName, version, osName, archName string) (string, error) {
+func (b *binary) binaryWithChecksumURL(binaryName, version, osName, archName string) (string, error) {
 	base := fmt.Sprintf("https://storage.googleapis.com/kubernetes-release/release/%s/bin/%s/%s/%s", version, osName, archName, binaryName)
 	v, err := semver.Make(version[1:])
 	if err != nil {
@@ -44,11 +52,11 @@ func binaryWithChecksumURL(binaryName, version, osName, archName string) (string
 }
 
 // Binary will download a binary onto the host
-func Binary(binary, version, osName, archName string) (string, error) {
+func (b *binary) Binary(binary, version, osName, archName string) (string, error) {
 	targetDir := localpath.MakeMiniPath("cache", osName, version)
 	targetFilepath := path.Join(targetDir, binary)
 
-	url, err := binaryWithChecksumURL(binary, version, osName, archName)
+	url, err := b.binaryWithChecksumURL(binary, version, osName, archName)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/minikube/download/binary_test.go
+++ b/pkg/minikube/download/binary_test.go
@@ -24,6 +24,8 @@ import (
 )
 
 func TestCacheBinary(t *testing.T) {
+	binaryIf := GetBinaryInterface()
+
 	oldMinikubeHome := os.Getenv("MINIKUBE_HOME")
 	defer os.Setenv("MINIKUBE_HOME", oldMinikubeHome)
 
@@ -105,7 +107,7 @@ func TestCacheBinary(t *testing.T) {
 	for _, test := range tc {
 		t.Run(test.desc, func(t *testing.T) {
 			os.Setenv("MINIKUBE_HOME", test.minikubeHome)
-			_, err := Binary(test.binary, test.version, test.osName, test.archName)
+			_, err := binaryIf.Binary(test.binary, test.version, test.osName, test.archName)
 			if err != nil && !test.err {
 				t.Fatalf("Got unexpected error %v", err)
 			}

--- a/pkg/minikube/download/intf/if.go
+++ b/pkg/minikube/download/intf/if.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2020 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package intf
+
+// BinaryIf ...
+type BinaryIf interface {
+	Binary(binary, version, osName, archName string) (string, error)
+}

--- a/pkg/minikube/download/intf/mock_if.go
+++ b/pkg/minikube/download/intf/mock_if.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2020 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package intf
+
+import (
+	"github.com/pkg/errors"
+)
+
+// MockBinary ...
+type MockBinary struct {
+	ExpectedError bool
+}
+
+// Binary ...
+func (mb *MockBinary) Binary(binary, version, osName, archName string) (string, error) {
+	if mb.ExpectedError {
+		return "", errors.New("Error")
+	}
+	return "", nil
+}

--- a/pkg/minikube/machine/cache_binaries.go
+++ b/pkg/minikube/machine/cache_binaries.go
@@ -26,17 +26,23 @@ import (
 	"k8s.io/minikube/pkg/minikube/bootstrapper"
 	"k8s.io/minikube/pkg/minikube/command"
 	"k8s.io/minikube/pkg/minikube/download"
+	"k8s.io/minikube/pkg/minikube/download/intf"
 )
 
 // CacheBinariesForBootstrapper will cache binaries for a bootstrapper
 func CacheBinariesForBootstrapper(version string, clusterBootstrapper string) error {
+	binaryIf := download.GetBinaryInterface()
+	return cacheBinariesForBootstrapperHelper(version, clusterBootstrapper, binaryIf)
+}
+
+func cacheBinariesForBootstrapperHelper(version string, clusterBootstrapper string, binaryIf intf.BinaryIf) error {
 	binaries := bootstrapper.GetCachedBinaryList(clusterBootstrapper)
 
 	var g errgroup.Group
 	for _, bin := range binaries {
 		bin := bin // https://golang.org/doc/faq#closures_and_goroutines
 		g.Go(func() error {
-			if _, err := download.Binary(bin, version, "linux", runtime.GOARCH); err != nil {
+			if _, err := binaryIf.Binary(bin, version, "linux", runtime.GOARCH); err != nil {
 				return errors.Wrapf(err, "caching binary %s", bin)
 			}
 			return nil

--- a/pkg/minikube/machine/cache_binaries_test.go
+++ b/pkg/minikube/machine/cache_binaries_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/bootstrapper"
 	"k8s.io/minikube/pkg/minikube/command"
+	"k8s.io/minikube/pkg/minikube/download/intf"
 )
 
 type copyFailRunner struct {
@@ -112,7 +113,9 @@ func TestCacheBinariesForBootstrapper(t *testing.T) {
 	for _, test := range tc {
 		t.Run(test.version, func(t *testing.T) {
 			os.Setenv("MINIKUBE_HOME", test.minikubeHome)
-			err := CacheBinariesForBootstrapper(test.version, test.clusterBootstrapper)
+			mockBinary := &intf.MockBinary{ExpectedError: test.err}
+			err := cacheBinariesForBootstrapperHelper(test.version, test.clusterBootstrapper, mockBinary)
+
 			if err != nil && !test.err {
 				t.Fatalf("Got unexpected error %v", err)
 			}

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -85,12 +85,14 @@ func handleDownloadOnly(cacheGroup, kicGroup *errgroup.Group, k8sVersion string)
 
 // CacheKubectlBinary caches the kubectl binary
 func CacheKubectlBinary(k8sVerison string) (string, error) {
+	binaryIf := download.GetBinaryInterface()
+
 	binary := "kubectl"
 	if runtime.GOOS == "windows" {
 		binary = "kubectl.exe"
 	}
 
-	return download.Binary(binary, k8sVerison, runtime.GOOS, runtime.GOARCH)
+	return binaryIf.Binary(binary, k8sVerison, runtime.GOOS, runtime.GOARCH)
 }
 
 // doCacheBinaries caches Kubernetes binaries in the foreground


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
Currently `TestCacheBinariesForBootstrapper` downloads the v1.16.0 which takes a long time, and wastes space in the minikube cache.

Solution:
==============
- Create an interface for `download/Binary` package, and use the interface to download binaries.
- In the unit-tests, use mocks of the binary interface to manipulate behavior.

Testing:
==============
- Can locally build the project
- All unit-tests pass