### PR TITLE
Fix embed certs by updating kubeconfig after certs are populated

### DIFF
--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -71,6 +71,9 @@ func TestStartStop(t *testing.T) {
 				"--disable-driver-mounts",
 				"--extra-config=kubeadm.ignore-preflight-errors=SystemVerification",
 			}},
+			{"embed-certs", constants.DefaultKubernetesVersion, []string{
+				"--embed-certs",
+			}},
 		}
 
 		for _, tc := range tests {


### PR DESCRIPTION
Fixes #7293 

The content of the kubeconfig is defined before certs are generated by
the bootstrapper. When certs are embedded via --embed-certs writing the
kubeconfig fails if the certificates are not generated so it must run
after the bootstrap process which generates them.

Not a nice solution but I think it is the easiest without major refactorings.


```
 $ rm -f ~/.kube/config && make && rm -rf ~/.minikube && out/minikube start --embed-certs
make: `out/minikube' is up to date.
😄  minikube v1.9.0 auf Darwin 10.15.3
✨  Automatically selected the hyperkit driver. Other choices: docker, virtualbox
💾  Downloading driver docker-machine-driver-hyperkit:
    > docker-machine-driver-hyperkit.sha256: 65 B / 65 B [---] 100.00% ? p/s 0s
    > docker-machine-driver-hyperkit: 10.90 MiB / 10.90 MiB  100.00% 3.11 MiB p
🔑  The 'hyperkit' driver requires elevated permissions. The following commands will be executed:

    $ sudo chown root:wheel /Users/vincent/.minikube/bin/docker-machine-driver-hyperkit
    $ sudo chmod u+s /Users/vincent/.minikube/bin/docker-machine-driver-hyperkit


💿  Downloading VM boot image ...
    > minikube-v1.9.0.iso.sha256: 65 B / 65 B [--------------] 100.00% ? p/s 0s
    > minikube-v1.9.0.iso: 174.93 MiB / 174.93 MiB [-] 100.00% 9.34 MiB p/s 19s
💾  Downloading Kubernetes v1.18.0 preload ...
    > preloaded-images-k8s-v2-v1.18.0-docker-overlay2-amd64.tar.lz4: 542.91 MiB
🔥  Creating hyperkit VM (CPUs=2, Memory=4000MB, Disk=20000MB) ...
🐳  Vorbereiten von Kubernetes v1.18.0 auf Docker 19.03.8...
🌟  Enabling addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube"
```

I found out why it worked after starting a minikube cluster initially without `--embed-certs` as it is already broken since a few versions with a fresh setup: The private keys were the same across multiple machines, they were reloaded in https://github.com/kubernetes/minikube/blob/eb13446e786c9ef70cb0a9f85a633194e62396a1/pkg/util/crypto.go#L112
With the change now for putting them into the profiles dir this didn't work anymore.