### PR TITLE
mustload: Replace DriverIP with Forwarded(IP|Port)

### DIFF
--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -161,7 +161,7 @@ var dockerEnvCmd = &cobra.Command{
 			EnvConfig: sh,
 			profile:   cname,
 			driver:    driverName,
-			hostIP:    co.DriverIP.String(),
+			hostIP:    co.CP.ForwardedIP.String(),
 			port:      port,
 			certsDir:  localpath.MakeMiniPath("certs"),
 			noProxy:   noProxy,

--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -129,7 +129,7 @@ var dockerEnvCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cname := ClusterFlagValue()
 		co := mustload.Running(cname)
-		driverName := co.CPHost.DriverName
+		driverName := co.CP.Host.DriverName
 
 		if driverName == driver.None {
 			exit.UsageT(`'none' driver does not support 'minikube docker-env' command`)
@@ -140,7 +140,7 @@ var dockerEnvCmd = &cobra.Command{
 				out.V{"runtime": co.Config.KubernetesConfig.ContainerRuntime})
 		}
 
-		if ok := isDockerActive(co.CPRunner); !ok {
+		if ok := isDockerActive(co.CP.Runner); !ok {
 			exit.WithCodeT(exit.Unavailable, `The docker service within '{{.name}}' is not active`, out.V{"name": cname})
 		}
 

--- a/cmd/minikube/cmd/ip.go
+++ b/cmd/minikube/cmd/ip.go
@@ -29,6 +29,6 @@ var ipCmd = &cobra.Command{
 	Long:  `Retrieves the IP address of the running cluster, and writes it to STDOUT.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		co := mustload.Running(ClusterFlagValue())
-		out.Ln(co.DriverIP.String())
+		out.Ln(co.CP.ForwardedIP.String())
 	},
 }

--- a/cmd/minikube/cmd/logs.go
+++ b/cmd/minikube/cmd/logs.go
@@ -53,28 +53,28 @@ var logsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		co := mustload.Running(ClusterFlagValue())
 
-		bs, err := cluster.Bootstrapper(co.API, viper.GetString(cmdcfg.Bootstrapper), *co.Config, *co.CPNode)
+		bs, err := cluster.Bootstrapper(co.API, viper.GetString(cmdcfg.Bootstrapper), *co.Config, *co.CP.Node)
 		if err != nil {
 			exit.WithError("Error getting cluster bootstrapper", err)
 		}
 
-		cr, err := cruntime.New(cruntime.Config{Type: co.Config.KubernetesConfig.ContainerRuntime, Runner: co.CPRunner})
+		cr, err := cruntime.New(cruntime.Config{Type: co.Config.KubernetesConfig.ContainerRuntime, Runner: co.CP.Runner})
 		if err != nil {
 			exit.WithError("Unable to get runtime", err)
 		}
 		if followLogs {
-			err := logs.Follow(cr, bs, *co.Config, co.CPRunner)
+			err := logs.Follow(cr, bs, *co.Config, co.CP.Runner)
 			if err != nil {
 				exit.WithError("Follow", err)
 			}
 			return
 		}
 		if showProblems {
-			problems := logs.FindProblems(cr, bs, *co.Config, co.CPRunner)
+			problems := logs.FindProblems(cr, bs, *co.Config, co.CP.Runner)
 			logs.OutputProblems(problems, numberOfProblems)
 			return
 		}
-		err = logs.Output(cr, bs, *co.Config, co.CPRunner, numberOfLines)
+		err = logs.Output(cr, bs, *co.Config, co.CP.Runner, numberOfLines)
 		if err != nil {
 			out.Ln("")
 			// Avoid exit.WithError, since it outputs the issue URL

--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -99,14 +99,14 @@ var mountCmd = &cobra.Command{
 		}
 
 		co := mustload.Running(ClusterFlagValue())
-		if co.CPHost.Driver.DriverName() == driver.None {
+		if co.CP.Host.Driver.DriverName() == driver.None {
 			exit.UsageT(`'none' driver does not support 'minikube mount' command`)
 		}
 
 		var ip net.IP
 		var err error
 		if mountIP == "" {
-			ip, err = cluster.GetVMHostIP(co.CPHost)
+			ip, err = cluster.GetVMHostIP(co.CP.Host)
 			if err != nil {
 				exit.WithError("Error getting the host IP address to use from within the VM", err)
 			}
@@ -147,7 +147,7 @@ var mountCmd = &cobra.Command{
 		}
 
 		bindIP := ip.String() // the ip to listen on the user's host machine
-		if driver.IsKIC(co.CPHost.Driver.DriverName()) && runtime.GOOS != "linux" {
+		if driver.IsKIC(co.CP.Host.Driver.DriverName()) && runtime.GOOS != "linux" {
 			bindIP = "127.0.0.1"
 		}
 		out.T(out.Mounting, "Mounting host path {{.sourcePath}} into VM as {{.destinationPath}} ...", out.V{"sourcePath": hostPath, "destinationPath": vmPath})
@@ -177,7 +177,7 @@ var mountCmd = &cobra.Command{
 		go func() {
 			for sig := range c {
 				out.T(out.Unmount, "Unmounting {{.path}} ...", out.V{"path": vmPath})
-				err := cluster.Unmount(co.CPRunner, vmPath)
+				err := cluster.Unmount(co.CP.Runner, vmPath)
 				if err != nil {
 					out.ErrT(out.FailureType, "Failed unmount: {{.error}}", out.V{"error": err})
 				}
@@ -185,7 +185,7 @@ var mountCmd = &cobra.Command{
 			}
 		}()
 
-		err = cluster.Mount(co.CPRunner, ip.String(), vmPath, cfg)
+		err = cluster.Mount(co.CP.Runner, ip.String(), vmPath, cfg)
 		if err != nil {
 			exit.WithError("mount failed", err)
 		}

--- a/cmd/minikube/cmd/podman-env.go
+++ b/cmd/minikube/cmd/podman-env.go
@@ -108,17 +108,17 @@ var podmanEnvCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cname := ClusterFlagValue()
 		co := mustload.Running(cname)
-		driverName := co.CPHost.DriverName
+		driverName := co.CP.Host.DriverName
 
 		if driverName == driver.None {
 			exit.UsageT(`'none' driver does not support 'minikube podman-env' command`)
 		}
 
-		if ok := isPodmanAvailable(co.CPRunner); !ok {
+		if ok := isPodmanAvailable(co.CP.Runner); !ok {
 			exit.WithCodeT(exit.Unavailable, `The podman service within '{{.cluster}}' is not active`, out.V{"cluster": cname})
 		}
 
-		client, err := createExternalSSHClient(co.CPHost.Driver)
+		client, err := createExternalSSHClient(co.CP.Host.Driver)
 		if err != nil {
 			exit.WithError("Error getting ssh client", err)
 		}

--- a/cmd/minikube/cmd/ssh.go
+++ b/cmd/minikube/cmd/ssh.go
@@ -43,14 +43,14 @@ var sshCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cname := ClusterFlagValue()
 		co := mustload.Running(cname)
-		if co.CPHost.DriverName == driver.None {
+		if co.CP.Host.DriverName == driver.None {
 			exit.UsageT("'none' driver does not support 'minikube ssh' command")
 		}
 
 		var err error
 		var n *config.Node
 		if nodeName == "" {
-			n = co.CPNode
+			n = co.CP.Node
 		} else {
 			n, _, err = node.Retrieve(co.Config, nodeName)
 			if err != nil {

--- a/cmd/minikube/cmd/update-context.go
+++ b/cmd/minikube/cmd/update-context.go
@@ -33,14 +33,17 @@ var updateContextCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cname := ClusterFlagValue()
 		co := mustload.Running(cname)
-		updated, err := kubeconfig.UpdateIP(co.DriverIP, cname, kubeconfig.PathFromEnv())
+		ip := co.CP.ForwardedIP
+
+		// ??? For KIC, should we also update the port ???
+		updated, err := kubeconfig.UpdateIP(ip, cname, kubeconfig.PathFromEnv())
 		if err != nil {
 			exit.WithError("update config", err)
 		}
 		if updated {
-			out.T(out.Celebrate, "{{.cluster}} IP has been updated to point at {{.ip}}", out.V{"cluster": cname, "ip": co.DriverIP})
+			out.T(out.Celebrate, "{{.cluster}} IP has been updated to point at {{.ip}}", out.V{"cluster": cname, "ip": ip})
 		} else {
-			out.T(out.Meh, "{{.cluster}} IP was already correctly configured for {{.ip}}", out.V{"cluster": cname, "ip": co.DriverIP})
+			out.T(out.Meh, "{{.cluster}} IP was already correctly configured for {{.ip}}", out.V{"cluster": cname, "ip": ip})
 		}
 
 	},

--- a/pkg/minikube/mustload/mustload.go
+++ b/pkg/minikube/mustload/mustload.go
@@ -41,10 +41,16 @@ import (
 type ClusterController struct {
 	Config   *config.ClusterConfig
 	API      libmachine.API
-	CPHost   *host.Host
-	CPNode   *config.Node
-	CPRunner command.Runner
 	DriverIP net.IP
+	CP       ControlPlane
+}
+
+type ControlPlane struct {
+	Host          *host.Host
+	Node          *config.Node
+	Runner        command.Runner
+	ForwardedIP   net.IP
+	ForwardedPort int
 }
 
 // Partial is a cmd-friendly way to load a cluster which may or may not be running
@@ -107,26 +113,36 @@ func Running(name string) ClusterController {
 		exit.WithError("Unable to get command runner", err)
 	}
 
-	ips, err := host.Driver.GetIP()
+	ipStr, err := host.Driver.GetIP()
 	if err != nil {
 		exit.WithError("Unable to get driver IP", err)
 	}
 
-	if driver.IsKIC(host.DriverName) {
-		ips = oci.DefaultBindIPV4
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		exit.WithCodeT(exit.Software, fmt.Sprintf("Unable to parse driver IP: %q", ipStr))
 	}
 
-	ip := net.ParseIP(ips)
-	if ip == nil {
-		exit.WithCodeT(exit.Software, fmt.Sprintf("Unable to parse driver IP: %q", ips))
+	cpIP := cp.IP
+	cpPort := cp.Port
+	if driver.IsKIC(host.DriverName) {
+		cpIP = oci.DefaultBindIPV4
+		cpPort, err = oci.ForwardedPort(cc.Driver, cc.Name, cp.Port)
+		if err != nil {
+			exit.WithError("Unable to get forwarded port", err)
+		}
 	}
 
 	return ClusterController{
-		API:      api,
-		Config:   cc,
-		CPRunner: cr,
-		CPHost:   host,
-		CPNode:   &cp,
+		API:    api,
+		Config: cc,
+		CP: ControlPlane{
+			Runner:        cr,
+			Host:          host,
+			Node:          &cp,
+			ForwardedIP:   net.ParseIP(cpIP),
+			ForwardedPort: cpPort,
+		},
 		DriverIP: ip,
 	}
 }
@@ -135,7 +151,7 @@ func Running(name string) ClusterController {
 func Healthy(name string) ClusterController {
 	co := Running(name)
 
-	as, err := kverify.APIServerStatus(co.CPRunner, net.ParseIP(co.CPNode.IP), co.CPNode.Port)
+	as, err := kverify.APIServerStatus(co.CP.Runner, co.CP.ForwardedIP, co.CP.ForwardedPort)
 	if err != nil {
 		out.T(out.FailureType, `Unable to get control plane status: {{.error}}`, out.V{"error": err})
 		exitTip("delete", name, exit.Unavailable)
@@ -165,6 +181,6 @@ func ExampleCmd(cname string, action string) string {
 // exitTip returns an action tip and exits
 func exitTip(action string, profile string, code int) {
 	command := ExampleCmd(profile, action)
-	out.T(out.Workaround, "To fix this, run: {{.command}}", out.V{"command": command})
+	out.T(out.Workaround, `To fix this, run: "{{.command}}"`, out.V{"command": command})
 	os.Exit(code)
 }

--- a/pkg/minikube/mustload/mustload.go
+++ b/pkg/minikube/mustload/mustload.go
@@ -39,10 +39,9 @@ import (
 
 // ClusterController holds all the needed information for a minikube cluster
 type ClusterController struct {
-	Config   *config.ClusterConfig
-	API      libmachine.API
-	DriverIP net.IP
-	CP       ControlPlane
+	Config *config.ClusterConfig
+	API    libmachine.API
+	CP     ControlPlane
 }
 
 type ControlPlane struct {
@@ -143,7 +142,6 @@ func Running(name string) ClusterController {
 			ForwardedIP:   net.ParseIP(cpIP),
 			ForwardedPort: cpPort,
 		},
-		DriverIP: ip,
 	}
 }
 


### PR DESCRIPTION
Fixes #7296 - a serious regression for supporting Docker on macOS.

I'm not sure how I missed this.

This PR obsoletes #7267