### PR TITLE
Fix copy & paste errors in Podman driver setup docs

### DIFF
--- a/site/content/en/docs/Reference/Drivers/includes/podman_usage.inc
+++ b/site/content/en/docs/Reference/Drivers/includes/podman_usage.inc
@@ -9,12 +9,12 @@ for a better kubernetes in container experience, use docker [driver](https://min
 
 ## Usage
 
-Start a cluster using the docker driver:
+Start a cluster using the podman driver:
 
 ```shell
 minikube start --driver=podman
 ```
-To make docker the default driver:
+To make podman the default driver:
 
 ```shell
 minikube config set driver podman


### PR DESCRIPTION
Docs referred to docker while they should have referred to podman