### PR TITLE
docs: Update hugo version used by netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ publish = "site/public/"
 command = "pwd && cd themes/docsy && git submodule update -f --init && cd ../.. && hugo"
 
 [build.environment]
-HUGO_VERSION = "0.59.0"
+HUGO_VERSION = "0.68.3"
 
 [context.production.environment]
 HUGO_ENV = "production"

--- a/site/config.toml
+++ b/site/config.toml
@@ -29,43 +29,27 @@ pygmentsStyle = "tango"
  # First one is picked as the Twitter card image if not set on page.
  #images = ["images/project-illustration.png"]
 
+# Auto-generate the menu
+# sectionPagesMenu = "main"
+
 # Configure how URLs look like per section.
 [permalinks]
 blog = "/:section/:year/:month/:day/:slug/"
 
-[module]
-  [[module.mounts]]
-    source = "../deploy/addons/gvisor/"
-    target = "content/gvisor/"
-  [[module.mounts]]
-    source = "../deploy/addons/helm-tiller/"
-    target = "content/helm-tiller/"
-  [[module.mounts]]
-    source = "../deploy/addons/istio/"
-    target = "content/istio/"
-  [[module.mounts]]
-    source = "../deploy/addons/ingress-dns/"
-    target = "content/ingress-dns/"
-  [[module.mounts]]
-    source = "../deploy/addons/storage-provisioner-gluster/"
-    target = "content/storage-provisioner-gluster/"
-  [[module.mounts]]
-    source = "../deploy/addons/layouts/"
-    target = "layouts"
+[markup]
+  [markup.highlight]
+    codeFences = true
+    hl_Lines = ""
+    lineNoStart = 1
+    lineNos = false
+    lineNumbersInTable = true
+    noClasses = true
+    style = "vs"
+    tabWidth = 4
 
-  [[module.mounts]]
-    source = "content/en"
-    target = "content"
-  [[module.mounts]]
-    source = "layouts"
-    target = "layouts"
-
-## Configuration for BlackFriday markdown parser: https://github.com/russross/blackfriday
-[blackfriday]
-plainIDAnchors = true
-hrefTargetBlank = true
-angledQuotes = false
-latexDashes = true
+# allow html in markdown
+[markup.goldmark.renderer]
+  unsafe=true
 
 # Image processing configuration.
 [imaging]

--- a/site/config.toml
+++ b/site/config.toml
@@ -29,9 +29,6 @@ pygmentsStyle = "tango"
  # First one is picked as the Twitter card image if not set on page.
  #images = ["images/project-illustration.png"]
 
-# Auto-generate the menu
-# sectionPagesMenu = "main"
-
 # Configure how URLs look like per section.
 [permalinks]
 blog = "/:section/:year/:month/:day/:slug/"

--- a/site/layouts/partials/sidebar-tree.html
+++ b/site/layouts/partials/sidebar-tree.html
@@ -1,5 +1,7 @@
-{{/* minikube hack: temporarily forked from docsy/layouts/partials/sidebar-tree.html due to hugo v0.69 compatibility issues */}}
+{{/* minikube hack: temporarily forked from docsy/layouts/partials/sidebar-tree.html for hugo v0.69 compatibility */}}
 
+{{/* We cache this partial for bigger sites and set the active class client side. */}}
+{{ $shouldDelayActive := ge (len .Site.Pages) 2000 }}
 <div id="td-sidebar-menu" class="td-sidebar__inner{{ if $shouldDelayActive }} d-none{{ end }}">
   {{ if not .Site.Params.ui.sidebar_search_disable }}
   <form class="td-sidebar__search d-flex align-items-center">

--- a/site/layouts/partials/sidebar-tree.html
+++ b/site/layouts/partials/sidebar-tree.html
@@ -1,0 +1,57 @@
+{{/* We cache this partial for bigger sites and set the active class client side. */}}
+{{ $shouldDelayActive := ge (len .Site.Pages) 2000 }}
+<div id="td-sidebar-menu" class="td-sidebar__inner{{ if $shouldDelayActive }} d-none{{ end }}">
+  {{ if not .Site.Params.ui.sidebar_search_disable }}
+  <form class="td-sidebar__search d-flex align-items-center">
+    {{ partial "search-input.html" . }}
+    <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="Toggle section navigation">
+    </button>
+  </form>
+  {{ end }}
+  <nav class="collapse td-sidebar-nav pt-2 pl-4" id="td-section-nav">
+    {{ if  (gt (len .Site.Home.Translations) 0) }}
+    <div class="nav-item dropdown d-block d-lg-none">
+      {{ partial "navbar-lang-selector.html" . }}
+    </div>
+    {{ end }}
+    {{ template "section-tree-nav-section" (dict "page" . "section" .FirstSection "delayActive" $shouldDelayActive)  }}
+  </nav>
+</div>
+{{ define "section-tree-nav-section" }}
+{{ $s := .section }}
+{{ $p := .page }}
+{{ $shouldDelayActive := .delayActive }}
+{{ $active := eq $p.CurrentSection $s }}
+{{ $show := or (and (not $p.Site.Params.ui.sidebar_menu_compact) ($p.IsAncestor $s)) ($p.IsDescendant $s) }}
+
+{{/* minikube hack: Override $show due to a Hugo upgrade bug */}}
+{{ $show = true }}
+{{/* end minikube hack */}}
+
+{{ $sid := $s.RelPermalink | anchorize }}
+<ul class="td-sidebar-nav__section pr-md-3">
+  <li class="td-sidebar-nav__section-title">
+    <a href="{{ $s.RelPermalink }}" class="align-left pl-0 pr-2{{ if not $show }} collapsed{{ end }}{{ if $active}} active{{ end }} td-sidebar-link td-sidebar-link__section">{{ $s.LinkTitle }}</a>
+  </li>
+  <ul>
+    <li class="collapse {{ if $show }}show{{ end }}" id="{{ $sid }}">
+      {{ $pages := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true }}
+      {{ $pages := $pages | first 50 }}
+      {{ range $pages }}
+      {{ if .IsPage }}
+        {{ $mid := printf "m-%s" (.RelPermalink | anchorize) }}
+
+        {{/* minikube hack: Override $active due to a Hugo upgrade bug */}}
+        {{ if $active }}
+            {{ $activePage := eq . $p }}
+            <a class="td-sidebar-link td-sidebar-link__page {{ if $activePage }} active{{ end }}" id="{{ $mid }}" href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+        {{ end }}
+        {{/* end minikube hack */}}
+      {{ else }}
+          {{ template "section-tree-nav-section" (dict "page" $p "section" .) }}
+      {{ end }}
+      {{ end }}
+    </li>
+  </ul>
+</ul>
+{{ end }}

--- a/site/layouts/partials/sidebar-tree.html
+++ b/site/layouts/partials/sidebar-tree.html
@@ -1,5 +1,5 @@
-{{/* We cache this partial for bigger sites and set the active class client side. */}}
-{{ $shouldDelayActive := ge (len .Site.Pages) 2000 }}
+{{/* minikube hack: temporarily forked from docsy/layouts/partials/sidebar-tree.html due to hugo v0.69 compatibility issues */}}
+
 <div id="td-sidebar-menu" class="td-sidebar__inner{{ if $shouldDelayActive }} d-none{{ end }}">
   {{ if not .Site.Params.ui.sidebar_search_disable }}
   <form class="td-sidebar__search d-flex align-items-center">


### PR DESCRIPTION
We haven't updated in 9 months. 

NOTE: `make site` uses the latest version of hugo, which could lead to confusion.

