### PR TITLE
clean up minikube start output

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -371,6 +371,7 @@ func runStart(cmd *cobra.Command, args []string) {
 					ControlPlane:      false,
 					KubernetesVersion: cc.KubernetesConfig.KubernetesVersion,
 				}
+				out.Ln("") // extra newline for clarity on the command line
 				err := node.Add(&cc, n)
 				if err != nil {
 					exit.WithError("adding node", err)

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -66,7 +66,6 @@ const (
 
 // Start spins up a guest and starts the kubernetes node.
 func Start(cc config.ClusterConfig, n config.Node, existingAddons map[string]bool, apiServer bool) *kubeconfig.Settings {
-
 	cp := ""
 	if apiServer {
 		cp = "control plane "

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -66,6 +66,14 @@ const (
 
 // Start spins up a guest and starts the kubernetes node.
 func Start(cc config.ClusterConfig, n config.Node, existingAddons map[string]bool, apiServer bool) *kubeconfig.Settings {
+
+	cp := ""
+	if apiServer {
+		cp = "control plane "
+	}
+
+	out.T(out.ThumbsUp, "Starting {{.controlPlane}}node {{.name}} in cluster {{.cluster}}", out.V{"controlPlane": cp, "name": n.Name, "cluster": cc.Name})
+
 	var kicGroup errgroup.Group
 	if driver.IsKIC(cc.Driver) {
 		beginDownloadKicArtifacts(&kicGroup)


### PR DESCRIPTION
I was aiming to make starting multiple nodes more clear on the command line, I am open to suggestions here as well.

Before
```
minikube start -n 2
😄  minikube v1.9.0 on Darwin 10.14.6
✨  Automatically selected the hyperkit driver
🔥  Creating hyperkit VM (CPUs=2, Memory=4000MB, Disk=20000MB) ...
🐳  Preparing Kubernetes v1.18.0 on Docker 19.03.8 ...
🌟  Enabling addons: default-storageclass, storage-provisioner
🔥  Creating hyperkit VM (CPUs=2, Memory=4000MB, Disk=20000MB) ...
🌐  Found network options:
    ▪ NO_PROXY=192.168.64.184
🐳  Preparing Kubernetes v1.18.0 on Docker 19.03.8 ...
🏄  Done! kubectl is now configured to use "minikube"
```

After
```
minikube start -n 2
😄  minikube v1.9.0 on Darwin 10.14.6
✨  Automatically selected the hyperkit driver
👍  Starting control plane node m01 in cluster minikube
🔥  Creating hyperkit VM (CPUs=2, Memory=4000MB, Disk=20000MB) ...
🐳  Preparing Kubernetes v1.18.0 on Docker 19.03.8 ...
🌟  Enabling addons: default-storageclass, storage-provisioner

👍  Starting node m02 in cluster minikube
🔥  Creating hyperkit VM (CPUs=2, Memory=4000MB, Disk=20000MB) ...
🌐  Found network options:
    ▪ NO_PROXY=192.168.64.192
🐳  Preparing Kubernetes v1.18.0 on Docker 19.03.8 ...
🏄  Done! kubectl is now configured to use "minikube"
```