### PR TITLE
additional documentation context for MINIKUBE env vars vs Kubernetes tools

### DIFF
--- a/site/content/en/docs/Reference/environment_variables.md
+++ b/site/content/en/docs/Reference/environment_variables.md
@@ -13,9 +13,9 @@ For example the `minikube start --iso-url="$ISO_URL"` flag can also be set by se
 
 ## Other variables
 
-Some features can only be accessed by environment variables, here is a list of these features:
+Some features can only be accessed by minikube specific environment variables, here is a list of these features:
 
-* **MINIKUBE_HOME** - (string) sets the path for the .minikube directory that minikube uses for state/configuration
+* **MINIKUBE_HOME** - (string) sets the path for the .minikube directory that minikube uses for state/configuration. *Please note: this is used only by minikube and does not affect anything related to Kubernetes tools such as kubectl.*
 
 * **MINIKUBE_IN_STYLE** - (bool) manually sets whether or not emoji and colors should appear in minikube. Set to false or 0 to disable this feature, true or 1 to force it to be turned on.
 


### PR DESCRIPTION
This fixes #7323 by adding extra documentation around how minikube specific environment do not affect Kubernetes tools such as kubectl.