### PR TITLE
wip: Improved message when docker is not installed for none

### DIFF
--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -91,8 +91,10 @@ func (r *Docker) DefaultCNI() bool {
 
 // Available returns an error if it is not possible to use this runtime on a host
 func (r *Docker) Available() error {
-	_, err := exec.LookPath("docker")
-	return err
+	if _, err := exec.LookPath("docker"); err != nil {
+		return errors.New("docker not found in $PATH. please install docker or try adding it to the $PATH")
+	}
+	return nil
 }
 
 // Active returns if docker is active on the host


### PR DESCRIPTION
fixes #7166 

before:
```
medya@none-experiment-instance-1-medya:~$ sudo minikube start --vm-driver=none
😄  minikube v1.8.2 on Ubuntu 18.04
✨  Using the none driver based on user configuration
🤹  Running on localhost (CPUs=2, Memory=7470MB, Disk=9749MB) ...
💣  Unable to start VM. Please investigate and run 'minikube delete' if possible: creating host: create: precreate:
 exec: "docker": executable file not found in $PATH
😿  minikube is exiting due to an error. If the above message is not useful, open an issue:
👉  https://github.com/kubernetes/minikube/issues/new/choose
```  
  
after:  

```
$ sudo ./out/minikube start --driver=none
😄  minikube v1.9.0 on Ubuntu 18.04
✨  Using the none driver based on existing profile
👍  Starting control plane node  in cluster minikube
🤹  Running on localhost (CPUs=8, Memory=15803MB, Disk=149202MB) ...
🤦  StartHost failed, but will try again: creating host: create: precreate: docker not found in $PATH. please install docker or try adding it to the $PATH
🤹  Running on localhost (CPUs=8, Memory=15803MB, Disk=149202MB) ...
❌  StartHost failed again: creating host: create: precreate: docker not found in $PATH. please install docker or try adding it to the $PATH
👉  Run: "minikube delete", then "minikube start --alsologtostderr -v=1" to try again with more logging
💣  Failed to start none bare metal machine. "minikube start" may fix it.: creating host: create: precreate: docker not found in $PATH. please install docker or try adding it to the $PATH
😿  minikube is exiting due to an error. If the above message is not useful, open an issue:
👉  https://github.com/kubernetes/minikube/issues/new/choose
```  

This pull request changes the error message from `exec: "docker": executable file not found in $PATH` to `docker not found in $PATH. please install docker or try adding it to the $PATH`