### PR TITLE
Extend maximum stop retry from 30s to 120s

### DIFF
--- a/cmd/minikube/cmd/stop.go
+++ b/cmd/minikube/cmd/stop.go
@@ -88,7 +88,7 @@ func stop(api libmachine.API, cluster config.ClusterConfig, n config.Node) bool 
 		}
 	}
 
-	if err := retry.Expo(tryStop, 1*time.Second, 30*time.Second, 3); err != nil {
+	if err := retry.Expo(tryStop, 1*time.Second, 120*time.Second, 5); err != nil {
 		exit.WithError("Unable to stop VM", err)
 	}
 


### PR DESCRIPTION
To address some KVM2 stop failures in https://storage.googleapis.com/minikube-builds/logs/7279/f7f9498/KVM_Linux.html#fail_TestGvisorAddon
