### PR TITLE
Add rejection reason to 'unable to find driver' error

### DIFF
--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -202,14 +202,14 @@ func Suggest(options []registry.DriverState) (registry.DriverState, []registry.D
 	for _, ds := range options {
 		if ds != pick {
 			glog.Errorf("%s: %s", ds.Name, ds.Rejection)
-			if !ds.State.Healthy {
-				ds.Rejection = fmt.Sprintf("Not healthy: %v", ds.State.Error)
+			if !ds.State.Installed {
+				ds.Rejection = fmt.Sprintf("Not installed: %v", ds.State.Error)
 				rejects = append(rejects, ds)
 				continue
 			}
 
-			if !ds.State.Installed {
-				ds.Rejection = fmt.Sprintf("Not installed: %v", ds.State.Error)
+			if !ds.State.Healthy {
+				ds.Rejection = fmt.Sprintf("Not healthy: %v", ds.State.Error)
 				rejects = append(rejects, ds)
 				continue
 			}

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -174,8 +174,8 @@ func Choices(vm bool) []registry.DriverState {
 	return options
 }
 
-// Suggest returns a suggested driver from a set of options
-func Suggest(options []registry.DriverState) (registry.DriverState, []registry.DriverState) {
+// Suggest returns a suggested driver, alternate drivers, and rejected drivers
+func Suggest(options []registry.DriverState) (registry.DriverState, []registry.DriverState, []registry.DriverState) {
 	pick := registry.DriverState{}
 	for _, ds := range options {
 		if !ds.State.Installed {
@@ -198,17 +198,30 @@ func Suggest(options []registry.DriverState) (registry.DriverState, []registry.D
 	}
 
 	alternates := []registry.DriverState{}
+	rejects := []registry.DriverState{}
 	for _, ds := range options {
 		if ds != pick {
-			if !ds.State.Healthy || !ds.State.Installed {
+			glog.Errorf("%s: %s", ds.Name, ds.Rejection)
+			if !ds.State.Healthy {
+				ds.Rejection = fmt.Sprintf("Not healthy: %v", ds.State.Error)
+				rejects = append(rejects, ds)
 				continue
 			}
+
+			if !ds.State.Installed {
+				ds.Rejection = fmt.Sprintf("Not installed: %v", ds.State.Error)
+				rejects = append(rejects, ds)
+				continue
+			}
+
+			ds.Rejection = fmt.Sprintf("%s is preferred", pick.Name)
 			alternates = append(alternates, ds)
 		}
 	}
 	glog.Infof("Picked: %+v", pick)
 	glog.Infof("Alternatives: %+v", alternates)
-	return pick, alternates
+	glog.Infof("Rejects: %+v", rejects)
+	return pick, alternates, rejects
 }
 
 // Status returns the status of a driver

--- a/pkg/minikube/driver/driver_test.go
+++ b/pkg/minikube/driver/driver_test.go
@@ -112,6 +112,7 @@ func TestSuggest(t *testing.T) {
 		choices []string
 		pick    string
 		alts    []string
+		rejects []string
 	}{
 		{
 			def: registry.DriverDef{
@@ -122,6 +123,7 @@ func TestSuggest(t *testing.T) {
 			choices: []string{"unhealthy"},
 			pick:    "",
 			alts:    []string{},
+			rejects: []string{"unhealthy"},
 		},
 		{
 			def: registry.DriverDef{
@@ -132,6 +134,7 @@ func TestSuggest(t *testing.T) {
 			choices: []string{"discouraged", "unhealthy"},
 			pick:    "",
 			alts:    []string{"discouraged"},
+			rejects: []string{"unhealthy"},
 		},
 		{
 			def: registry.DriverDef{
@@ -142,6 +145,7 @@ func TestSuggest(t *testing.T) {
 			choices: []string{"default", "discouraged", "unhealthy"},
 			pick:    "default",
 			alts:    []string{"discouraged"},
+			rejects: []string{"unhealthy"},
 		},
 		{
 			def: registry.DriverDef{
@@ -152,6 +156,7 @@ func TestSuggest(t *testing.T) {
 			choices: []string{"preferred", "default", "discouraged", "unhealthy"},
 			pick:    "preferred",
 			alts:    []string{"default", "discouraged"},
+			rejects: []string{"unhealthy"},
 		},
 	}
 	for _, tc := range tests {
@@ -172,7 +177,7 @@ func TestSuggest(t *testing.T) {
 				t.Errorf("choices mismatch (-want +got):\n%s", diff)
 			}
 
-			pick, alts := Suggest(got)
+			pick, alts, rejects := Suggest(got)
 			if pick.Name != tc.pick {
 				t.Errorf("pick = %q, expected %q", pick.Name, tc.pick)
 			}
@@ -184,6 +189,15 @@ func TestSuggest(t *testing.T) {
 			if diff := cmp.Diff(gotAlts, tc.alts); diff != "" {
 				t.Errorf("alts mismatch (-want +got):\n%s", diff)
 			}
+
+			gotRejects := []string{}
+			for _, r := range rejects {
+				gotRejects = append(gotRejects, r.Name)
+			}
+			if diff := cmp.Diff(gotRejects, tc.rejects); diff != "" {
+				t.Errorf("rejects mismatch (-want +got):\n%s", diff)
+			}
+
 		})
 	}
 }

--- a/pkg/minikube/out/style.go
+++ b/pkg/minikube/out/style.go
@@ -68,6 +68,7 @@ var styles = map[StyleEnum]style{
 	Launch:        {Prefix: "🚀  "},
 	Sad:           {Prefix: "😿  "},
 	ThumbsUp:      {Prefix: "👍  "},
+	ThumbsDown:    {Prefix: "👎  "},
 	Option:        {Prefix: "    ▪ ", LowPrefix: lowIndent}, // Indented bullet
 	Command:       {Prefix: "    ▪ ", LowPrefix: lowIndent}, // Indented bullet
 	LogEntry:      {Prefix: "    "},                         // Indent

--- a/pkg/minikube/out/style_enum.go
+++ b/pkg/minikube/out/style_enum.go
@@ -41,6 +41,7 @@ const (
 	Launch
 	Sad
 	ThumbsUp
+	ThumbsDown
 	Option
 	Command
 	LogEntry

--- a/pkg/minikube/registry/global.go
+++ b/pkg/minikube/registry/global.go
@@ -68,6 +68,8 @@ type DriverState struct {
 	Name     string
 	Priority Priority
 	State    State
+	// Rejection is why we chose not to use this driver
+	Rejection string
 }
 
 func (d DriverState) String() string {


### PR DESCRIPTION
Our current error message is not as helpful as it could be:

`💣  Unable to determine a default driver to use. Try specifying --driver, or see https://minikube.sigs.k8s.io/docs/start/`

Here is the new error message this PR proposes:

```
👎  Unable to pick a default driver. Here is what was considered, in preference order:
    ▪ parallels: Not installed: exec: "docker-machine-driver-parallels": executable file not found in $PATH
    ▪ podman: Not installed: exec: "podman": executable file not found in $PATH
    ▪ vmware: Not installed: exec: "docker-machine-driver-vmware": executable file not found in $PATH
👉  Try specifying a --driver, or see https://minikube.sigs.k8s.io/docs/start/
```

Solves mysteries such as #7371 