### PR TITLE
Run sudo for file display due to umask

### DIFF
--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -774,7 +774,7 @@ func validateFileSync(ctx context.Context, t *testing.T, profile string) {
 
 	vp := vmSyncTestPath()
 	t.Logf("Checking for existence of %s within VM", vp)
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", fmt.Sprintf("cat %s", vp)))
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", fmt.Sprintf("sudo cat %s", vp)))
 	if err != nil {
 		t.Errorf("%s failed: %v", rr.Command(), err)
 	}
@@ -811,7 +811,7 @@ func validateCertSync(ctx context.Context, t *testing.T, profile string) {
 	}
 	for _, vp := range paths {
 		t.Logf("Checking for existence of %s within VM", vp)
-		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", fmt.Sprintf("cat %s", vp)))
+		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", fmt.Sprintf("sudo cat %s", vp)))
 		if err != nil {
 			t.Errorf("failed to check existence of %q inside minikube. args %q: %v", vp, rr.Command(), err)
 		}


### PR DESCRIPTION
Found during local testing on gLinux:

```
        --- FAIL: TestFunctional/parallel/FileSync (1.91s)                                                                                                            
            functional_test.go:776: Checking for existence of /etc/test/nested/copy/211259/hosts within VM                                                            
            functional_test.go:777: (dbg) Run:  out/minikube -p minikube ssh "cat /etc/test/nested/copy/211259/hosts"                                                 
            functional_test.go:777: (dbg) Non-zero exit: out/minikube -p minikube ssh "cat /etc/test/nested/copy/211259/hosts": exit status 1 (1.909581527s)          
                                                                                                                                                                      
                ** stderr **                                                                                                                                          
                        cat: /etc/test/nested/copy/211259/hosts: Permission denied                                                                                    
                        ssh: exit status 1
```

The root cause was that the file locally was created with a 640 umask, which propagated into the VM.