### PR TITLE
allow ingress addon for docker/podman drivers only on linux for now

### DIFF
--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -126,7 +126,9 @@ func enableOrDisableAddon(cc *config.ClusterConfig, name string, val string) err
 	// to match both ingress and ingress-dns adons
 	if strings.HasPrefix(name, "ingress") && enable && driver.IsKIC(cc.Driver) && runtime.GOOS != "linux" {
 		exit.UsageT(`Due to {{.driver_name}} networking limitations on {{.os_name}}, {{.addon_name}} addon is not supported for this driver.
-you can use a different driver such as hyperkit or virtualbox or hypev.
+Alternatively to use this addon you can use a vm-based driver:
+
+		'minikube start --vm=true'
 
 To track the update on this work in progress feature please check:
 https://github.com/kubernetes/minikube/issues/7332`, out.V{"driver_name": cc.Driver, "os_name": runtime.GOOS, "addon_name": name})

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -128,7 +128,7 @@ func enableOrDisableAddon(cc *config.ClusterConfig, name string, val string) err
 		exit.UsageT(`Due to {{.driver_name}} networking limitations on {{.os_name}}, {{.addon_name}} addon is not supported for this driver.
 Alternatively to use this addon you can use a vm-based driver:
 
-		'minikube start --vm=true'
+	'minikube start --vm=true'
 
 To track the update on this work in progress feature please check:
 https://github.com/kubernetes/minikube/issues/7332`, out.V{"driver_name": cc.Driver, "os_name": runtime.GOOS, "addon_name": name})

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -19,6 +19,7 @@ package addons
 import (
 	"fmt"
 	"path"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -120,6 +121,11 @@ func enableOrDisableAddon(cc *config.ClusterConfig, name string, val string) err
 		if !enable {
 			return nil
 		}
+	}
+
+	// to match both ingress and ingress-dns adons
+	if strings.HasPrefix(name, "ingress") && enable && driver.IsKIC(cc.Driver) && runtime.GOOS != "linux" {
+		exit.UsageT("Due to {{.driver_name}} networking limitations on {{.os_name}}, {{.addon_name}} addon is not supported for this driver. meanwhile a different driver such as 'hyperkit' or 'virtualbox' or 'hypev'. To track the update on this feature being worked on please check https://github.com/kubernetes/minikube/issues/7332", out.V{"driver_name": cc.Driver, "os_name": runtime.GOOS, "addon_name": name})
 	}
 
 	if strings.HasPrefix(name, "istio") && enable {

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -125,7 +125,11 @@ func enableOrDisableAddon(cc *config.ClusterConfig, name string, val string) err
 
 	// to match both ingress and ingress-dns adons
 	if strings.HasPrefix(name, "ingress") && enable && driver.IsKIC(cc.Driver) && runtime.GOOS != "linux" {
-		exit.UsageT("Due to {{.driver_name}} networking limitations on {{.os_name}}, {{.addon_name}} addon is not supported for this driver. meanwhile a different driver such as 'hyperkit' or 'virtualbox' or 'hypev'. To track the update on this feature being worked on please check https://github.com/kubernetes/minikube/issues/7332", out.V{"driver_name": cc.Driver, "os_name": runtime.GOOS, "addon_name": name})
+		exit.UsageT(`Due to {{.driver_name}} networking limitations on {{.os_name}}, {{.addon_name}} addon is not supported for this driver.
+you can use a different driver such as hyperkit or virtualbox or hypev.
+
+To track the update on this work in progress feature please check:
+https://github.com/kubernetes/minikube/issues/7332`, out.V{"driver_name": cc.Driver, "os_name": runtime.GOOS, "addon_name": name})
 	}
 
 	if strings.HasPrefix(name, "istio") && enable {

--- a/site/content/en/docs/Reference/Drivers/docker.md
+++ b/site/content/en/docs/Reference/Drivers/docker.md
@@ -18,4 +18,8 @@ The Docker driver is the newest minikube driver. which runs kubernetes in contai
 - Cross platform (linux, macos, windows)
 - No hypervisor required when run on Linux.
 
+## Known Issues.
 
+- The 'ingress' and 'ingress-dns' addons is only supported on Linux and they are  not supported in Docker Driver on MacOS and Windows yet. to get updates on the work in progress please check [issue page](https://github.com/kubernetes/minikube/issues/7332)
+
+- a known [docker issue for MacOs](https://github.com/docker/for-mac/issues/1835), a containers on Docker on MacOS might hang and get stuck while other containers can get created. The current workaround is restarting docker.

--- a/site/content/en/docs/Reference/Drivers/docker.md
+++ b/site/content/en/docs/Reference/Drivers/docker.md
@@ -20,6 +20,7 @@ The Docker driver is the newest minikube driver. which runs kubernetes in contai
 
 ## Known Issues.
 
-- The 'ingress' and 'ingress-dns' addons is only supported on Linux and they are  not supported in Docker Driver on MacOS and Windows yet. to get updates on the work in progress please check [issue page](https://github.com/kubernetes/minikube/issues/7332)
+- The 'ingress' and 'ingress-dns' addons are only supported on Linux. 
+these addons are not supported for Docker Driver on MacOS and Windows yet. to get updates on the work in progress please check [issue page](https://github.com/kubernetes/minikube/issues/7332)
 
 - a known [docker issue for MacOs](https://github.com/docker/for-mac/issues/1835), a containers on Docker on MacOS might hang and get stuck while other containers can get created. The current workaround is restarting docker.


### PR DESCRIPTION
does not close https://github.com/kubernetes/minikube/issues/7332 but it will at least provide a better message.

## after this PR:
```
💡  Due to docker networking limitations on darwin, ingress addon is not supported for this driver.
Alternatively to use this addon you can use a vm-based driver:

        'minikube start --vm=true'

To track the update on this work in progress feature please check:
https://github.com/kubernetes/minikube/issues/7332```
```

also add docs to the website

meanwhile we will work on implementing this feature for mac an windows.
