### PR TITLE
parallelize updating cluster and setting up certs

### DIFF
--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -23,6 +23,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/blang/semver"
@@ -239,12 +240,24 @@ func setupKubeAdm(mAPI libmachine.API, cfg config.ClusterConfig, n config.Node) 
 		out.T(out.Option, "{{.extra_option_component_name}}.{{.key}}={{.value}}", out.V{"extra_option_component_name": eo.Component, "key": eo.Key, "value": eo.Value})
 	}
 	// Loads cached images, generates config files, download binaries
-	if err := bs.UpdateCluster(cfg); err != nil {
-		exit.WithError("Failed to update cluster", err)
-	}
-	if err := bs.SetupCerts(cfg.KubernetesConfig, n); err != nil {
-		exit.WithError("Failed to setup certs", err)
-	}
+	// update cluster and set up certs in parallel
+	var parallel sync.WaitGroup
+	parallel.Add(2)
+	go func() {
+		if err := bs.UpdateCluster(cfg); err != nil {
+			exit.WithError("Failed to update cluster", err)
+		}
+		parallel.Done()
+	}()
+
+	go func() {
+		if err := bs.SetupCerts(cfg.KubernetesConfig, n); err != nil {
+			exit.WithError("Failed to setup certs", err)
+		}
+		parallel.Done()
+	}()
+
+	parallel.Wait()
 	return bs
 }
 


### PR DESCRIPTION
Reduces time in setupKubeadm function from 4.6s to 3.2s

slowjam before change: http://104.197.255.167:8000

slowjam after change: http://34.67.230.103:8000