### PR TITLE
Update translations files by running extract

### DIFF
--- a/translations/de.json
+++ b/translations/de.json
@@ -43,7 +43,6 @@
 	"Basic Commands:": "",
 	"Because you are using docker driver on Mac, the terminal needs to be open to run it.": "",
 	"Bind Address: {{.Address}}": "",
-	"Block until the apiserver is servicing API requests": "",
 	"Both driver={{.driver}} and vm-driver={{.vmd}} have been set.\n\n    Since vm-driver is deprecated, minikube will default to driver={{.driver}}.\n\n    If vm-driver is set in the global config, please run \"minikube config unset vm-driver\" to resolve this warning.": "",
 	"Cannot find directory {{.path}} for mount": "",
 	"Cannot use both --output and --format options": "",

--- a/translations/es.json
+++ b/translations/es.json
@@ -44,7 +44,6 @@
 	"Basic Commands:": "",
 	"Because you are using docker driver on Mac, the terminal needs to be open to run it.": "",
 	"Bind Address: {{.Address}}": "",
-	"Block until the apiserver is servicing API requests": "",
 	"Both driver={{.driver}} and vm-driver={{.vmd}} have been set.\n\n    Since vm-driver is deprecated, minikube will default to driver={{.driver}}.\n\n    If vm-driver is set in the global config, please run \"minikube config unset vm-driver\" to resolve this warning.": "",
 	"Cannot find directory {{.path}} for mount": "",
 	"Cannot use both --output and --format options": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -43,7 +43,6 @@
 	"Basic Commands:": "",
 	"Because you are using docker driver on Mac, the terminal needs to be open to run it.": "",
 	"Bind Address: {{.Address}}": "",
-	"Block until the apiserver is servicing API requests": "",
 	"Both driver={{.driver}} and vm-driver={{.vmd}} have been set.\n\n    Since vm-driver is deprecated, minikube will default to driver={{.driver}}.\n\n    If vm-driver is set in the global config, please run \"minikube config unset vm-driver\" to resolve this warning.": "",
 	"Cannot find directory {{.path}} for mount": "",
 	"Cannot use both --output and --format options": "",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -50,7 +50,6 @@
 	"Basic Commands:": "基本的なコマンド",
 	"Because you are using docker driver on Mac, the terminal needs to be open to run it.": "",
 	"Bind Address: {{.Address}}": "アドレスをバインドします: {{.Address}}",
-	"Block until the apiserver is servicing API requests": "",
 	"Both driver={{.driver}} and vm-driver={{.vmd}} have been set.\n\n    Since vm-driver is deprecated, minikube will default to driver={{.driver}}.\n\n    If vm-driver is set in the global config, please run \"minikube config unset vm-driver\" to resolve this warning.": "",
 	"Cannot find directory {{.path}} for mount": "",
 	"Cannot use both --output and --format options": "",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -46,7 +46,6 @@
 	"Basic Commands:": "Podstawowe polecenia",
 	"Because you are using docker driver on Mac, the terminal needs to be open to run it.": "",
 	"Bind Address: {{.Address}}": "",
-	"Block until the apiserver is servicing API requests": "",
 	"Both driver={{.driver}} and vm-driver={{.vmd}} have been set.\n\n    Since vm-driver is deprecated, minikube will default to driver={{.driver}}.\n\n    If vm-driver is set in the global config, please run \"minikube config unset vm-driver\" to resolve this warning.": "",
 	"Cannot find directory {{.path}} for mount": "Nie można odnoleść folderu {{.path}} do zamontowania",
 	"Cannot use both --output and --format options": "",


### PR DESCRIPTION
This should probably be part of the release procedure ?

`make extract`

----

I'm also missing some gettext maintenance commands...
* show summary per language
* creating new language (`msginit`)
* remove old unused strings (`msgmerge`)

For reference see https://www.gnu.org/software/gettext/manual/html_node/index.html

Maybe some utility functions could be provided for the Minikube Translations System ?