### PR TITLE
fix validateDriver() to exit() when it detects an error.

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -679,6 +679,10 @@ func validateDriver(ds registry.DriverState, existing *config.ClusterConfig) {
 			}
 			exit.WithCodeT(exit.Unavailable, "{{.driver}} does not appear to be installed", out.V{"driver": name})
 		}
+
+		if !viper.GetBool(force) {
+			exit.WithCodeT(exit.Unavailable, "Failed to validate '{{.driver}}' driver", out.V{"driver": name})
+		}
 	}
 }
 

--- a/translations/de.json
+++ b/translations/de.json
@@ -184,6 +184,7 @@
 	"Failed to stop node {{.name}}": "",
 	"Failed to update cluster": "",
 	"Failed to update config": "",
+	"Failed to validate '{{.driver}}' driver": "",
 	"Failed unmount: {{.error}}": "",
 	"File permissions used for the mount": "",
 	"Filter to use only VM Drivers": "",

--- a/translations/es.json
+++ b/translations/es.json
@@ -185,6 +185,7 @@
 	"Failed to stop node {{.name}}": "",
 	"Failed to update cluster": "",
 	"Failed to update config": "",
+	"Failed to validate '{{.driver}}' driver": "",
 	"Failed unmount: {{.error}}": "",
 	"File permissions used for the mount": "",
 	"Filter to use only VM Drivers": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -182,6 +182,7 @@
 	"Failed to stop node {{.name}}": "",
 	"Failed to update cluster": "",
 	"Failed to update config": "",
+	"Failed to validate '{{.driver}}' driver": "",
 	"Failed unmount: {{.error}}": "",
 	"File permissions used for the mount": "",
 	"Filter to use only VM Drivers": "",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -193,6 +193,7 @@
 	"Failed to stop node {{.name}}": "",
 	"Failed to update cluster": "",
 	"Failed to update config": "",
+	"Failed to validate '{{.driver}}' driver": "",
 	"Failed unmount: {{.error}}": "",
 	"File permissions used for the mount": "",
 	"Filter to use only VM Drivers": "",

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -197,6 +197,7 @@
 	"Failed to stop node {{.name}}": "노드 {{.name}} 중지에 실패하였습니다",
 	"Failed to update cluster": "클러스터를 수정하는 데 실패하였습니다",
 	"Failed to update config": "컨피그를 수정하는 데 실패하였습니다",
+	"Failed to validate '{{.driver}}' driver": "",
 	"Failed unmount: {{.error}}": "마운트 해제에 실패하였습니다: {{.error}}",
 	"File permissions used for the mount": "",
 	"Filter to use only VM Drivers": "",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -190,6 +190,7 @@
 	"Failed to setup kubeconfig": "Konfiguracja kubeconfig nie powiodła się",
 	"Failed to stop node {{.name}}": "",
 	"Failed to update cluster": "Aktualizacja klastra nie powiodła się",
+	"Failed to validate '{{.driver}}' driver": "",
 	"Failed to update config": "Aktualizacja konfiguracji nie powiodła się",
 	"Failed unmount: {{.error}}": "",
 	"File permissions used for the mount": "",

--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -240,6 +240,7 @@
 	"Failed to stop node {{.name}}": "",
 	"Failed to update cluster": "更新 cluster 失败",
 	"Failed to update config": "更新 config 失败",
+	"Failed to validate '{{.driver}}' driver": "",
 	"Failed unmount: {{.error}}": "unmount 失败：{{.error}}",
 	"File permissions used for the mount": "用于 mount 的文件权限",
 	"Filter to use only VM Drivers": "",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Minikube creates VM even if validateDriver() fails.
This PR fixes validateDriver() to exit() when it detects an error.

**Which issue(s) this PR fixes**:
NONE

**Does this PR introduce a user-facing change?**:
Yes. this PR fixes the behavior of the `minikube start` command.

before : minikube creates VM even if validateDriver() fails.

```sh
# destroy virtualbox executable file to reproduce. 
$ sudo vim /usr/bin/virtualbox

# start
$ out/minikube start --vm-driver virtualbox
😄  minikube v1.9.2 on Ubuntu 18.04
✨  Using the virtualbox driver based on user configuration

❗  'virtualbox' driver reported an issue: /usr/bin/VBoxManage list hostinfo failed:

💡  Suggestion: Install the latest version of VirtualBox
📘  Documentation: https://minikube.sigs.k8s.io/docs/reference/drivers/virtualbox/

👍  Starting control plane node m01 in cluster minikube
🔥  Creating virtualbox VM (CPUs=2, Memory=40960MB, Disk=20000MB) ...
🤦  StartHost failed, but will try again: creating host: create: precreate: fork/exec /usr/bin/VBoxManage: exec format error
🔥  Creating virtualbox VM (CPUs=2, Memory=40960MB, Disk=20000MB) ...

💣  Failed to start virtualbox VM. "minikube start" may fix it.: creating host: create: precreate: fork/exec /usr/bin/VBoxManage: exec format error

😿  minikube is exiting due to an error. If the above message is not useful, open an issue:
👉  https://github.com/kubernetes/minikube/issues/new/choose
$
```

after : minikube doesn't creates VM, and exits with the message "Failed to validate '{{.driver}}' driver".

```sh
# destroy virtualbox executable file to reproduce. 
$ sudo vim /usr/bin/virtualbox

# start
$ out/minikube start --vm-driver virtualbox
😄  minikube v1.9.2 on Ubuntu 18.04
✨  Using the virtualbox driver based on user configuration

❗  'virtualbox' driver reported an issue: /usr/bin/VBoxManage list hostinfo failed:

💡  Suggestion: Install the latest version of VirtualBox
📘  Documentation: https://minikube.sigs.k8s.io/docs/reference/drivers/virtualbox/

💣  Failed to validate 'virtualbox' driver
$
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
NONE
```