### PR TITLE
Fix incorrect node name of `minikube status`

### DIFF
--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -153,9 +153,10 @@ func exitCode(st *Status) int {
 func status(api libmachine.API, cc config.ClusterConfig, n config.Node) (*Status, error) {
 
 	controlPlane := n.ControlPlane
+	name := driver.MachineName(cc, n)
 
 	st := &Status{
-		Name:       n.Name,
+		Name:       name,
 		Host:       Nonexistent,
 		APIServer:  Nonexistent,
 		Kubelet:    Nonexistent,
@@ -163,7 +164,6 @@ func status(api libmachine.API, cc config.ClusterConfig, n config.Node) (*Status
 		Worker:     !controlPlane,
 	}
 
-	name := driver.MachineName(cc, n)
 	hs, err := machine.Status(api, name)
 	glog.Infof("%s host status = %q (err=%v)", name, hs, err)
 	if err != nil {


### PR DESCRIPTION
### What type of PR is this?
/kind bug

### What this PR does / why we need it:
When user executes `minikube status` command, the command outputs "m01" hostname.
However actual node name is `minikube`(if node is 1).
This PR fix the `minikube status` node name.

### Which issue(s) this PR fixes:
Fixes #7452 

### Does this PR introduce a user-facing change?
Yes. 
This PR fixes the `minikube status` command output.
**Before this PR**
```
$ minikube status
m01
host: Running
kubelet: Running
apiserver: Running
kubeconfig: Configured
```
**After this PR**
```
$ minikube status
minikube
host: Running
kubelet: Running
apiserver: Running
kubeconfig: Configured
```
Fixed hostname section.

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```
