### PR TITLE
Disable update check for (--interactive|--dry-run), make non-blocking

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -286,6 +286,13 @@ func platform() string {
 // runStart handles the executes the flow of "minikube start"
 func runStart(cmd *cobra.Command, args []string) {
 	displayVersion(version.GetVersion())
+
+	// No need to do the update check if no one is going to see it
+	if !viper.GetBool(interactive) || !viper.GetBool(dryRun) {
+		// Avoid blocking execution on optional HTTP fetches
+		go notify.MaybePrintUpdateTextFromGithub()
+	}
+
 	displayEnviron(os.Environ())
 
 	// if --registry-mirror specified when run minikube start,
@@ -406,12 +413,7 @@ func displayVersion(version string) {
 		prefix = fmt.Sprintf("[%s] ", ClusterFlagValue())
 	}
 
-	versionState := out.Happy
-	if notify.MaybePrintUpdateTextFromGithub() {
-		versionState = out.Meh
-	}
-
-	out.T(versionState, "{{.prefix}}minikube {{.version}} on {{.platform}}", out.V{"prefix": prefix, "version": version, "platform": platform()})
+	out.T(out.Happy, "{{.prefix}}minikube {{.version}} on {{.platform}}", out.V{"prefix": prefix, "version": version, "platform": platform()})
 }
 
 // displayEnviron makes the user aware of environment variables that will affect how minikube operates


### PR DESCRIPTION
Fixes #6364 
Pseudo-fixes: #7181

NOTE: This does make startup faster, but does make output order less predictable. For example:

```
😄  minikube v1.9.0 on Darwin 10.15.4
✨  Using the hyperkit driver based on existing profile
👍  Starting control plane node m01 in cluster minikube
🔄  Restarting existing hyperkit VM for "minikube" ...
🎉  minikube 1.9.2 is available! Download it: https://github.com/kubernetes/minikube/releases/tag/v1.9.2
💡  To disable this notice, run: 'minikube config set WantUpdateNotification false'
```