### PR TITLE
make post mortem logs easier on the eye

### DIFF
--- a/test/integration/helpers.go
+++ b/test/integration/helpers.go
@@ -201,9 +201,9 @@ func clusterLogs(t *testing.T, profile string) {
 		return
 	}
 
-	t.Logf("--------------------------post-mortem--------------------------------")
+	t.Logf("-----------------------post-mortem--------------------------------")
 	t.Logf("<<< %s FAILED: start of post-mortem logs <<<", t.Name())
-	t.Logf("----------------------post-mortem minikube logs----------------------")
+	t.Logf("-------------------post-mortem minikube logs----------------------")
 	rr, err := Run(t, exec.Command(Target(), "-p", profile, "logs", "--problems"))
 	if err != nil {
 		t.Logf("failed logs error: %v", err)
@@ -211,20 +211,20 @@ func clusterLogs(t *testing.T, profile string) {
 	}
 	t.Logf("%s logs: %s", t.Name(), rr.Output())
 
-	t.Logf("----------------------post-mortem api server status-------------------")
+	t.Logf("------------------post-mortem api server status-------------------")
 	st = Status(context.Background(), t, Target(), profile, "APIServer")
 	if st != state.Running.String() {
 		t.Logf("%q apiserver is not running, skipping kubectl commands (state=%q)", profile, st)
 		return
 	}
-	t.Logf("---------------------post-mortem get pods------------------------------")
+	t.Logf("--------------------post-mortem get pods--------------------------")
 	rr, rerr := Run(t, exec.Command("kubectl", "--context", profile, "get", "po", "-A", "--show-labels"))
 	if rerr != nil {
 		t.Logf("%s: %v", rr.Command(), rerr)
 		return
 	}
 	t.Logf("(dbg) %s:\n%s", rr.Command(), rr.Output())
-	t.Logf("---------------------post-mortem describe node-------------------------")
+	t.Logf("-------------------post-mortem describe node----------------------")
 	rr, err = Run(t, exec.Command("kubectl", "--context", profile, "describe", "node"))
 	if err != nil {
 		t.Logf("%s: %v", rr.Command(), err)
@@ -233,7 +233,7 @@ func clusterLogs(t *testing.T, profile string) {
 	}
 	t.Logf("------------------------------------------------------------------")
 	t.Logf("<<< %s FAILED: end of post-mortem logs <<<", t.Name())
-	t.Logf("----------------   /post-mortem   ---------------------------")
+	t.Logf("---------------------/post-mortem---------------------------------")
 }
 
 // podStatusMsg returns a human-readable pod status, for generating debug status

--- a/test/integration/helpers.go
+++ b/test/integration/helpers.go
@@ -201,34 +201,39 @@ func clusterLogs(t *testing.T, profile string) {
 		return
 	}
 
+	t.Logf("--------------------------post-mortem--------------------------------")
 	t.Logf("<<< %s FAILED: start of post-mortem logs <<<", t.Name())
+	t.Logf("----------------------post-mortem minikube logs----------------------")
 	rr, err := Run(t, exec.Command(Target(), "-p", profile, "logs", "--problems"))
 	if err != nil {
 		t.Logf("failed logs error: %v", err)
 		return
 	}
-	t.Logf("%s logs: %s", t.Name(), rr.Stdout)
+	t.Logf("%s logs: %s", t.Name(), rr.Output())
 
+	t.Logf("----------------------post-mortem api server status-------------------")
 	st = Status(context.Background(), t, Target(), profile, "APIServer")
 	if st != state.Running.String() {
 		t.Logf("%q apiserver is not running, skipping kubectl commands (state=%q)", profile, st)
 		return
 	}
-
+	t.Logf("---------------------post-mortem get pods------------------------------")
 	rr, rerr := Run(t, exec.Command("kubectl", "--context", profile, "get", "po", "-A", "--show-labels"))
 	if rerr != nil {
 		t.Logf("%s: %v", rr.Command(), rerr)
 		return
 	}
-	t.Logf("(dbg) %s:\n%s", rr.Command(), rr.Stdout)
-
+	t.Logf("(dbg) %s:\n%s", rr.Command(), rr.Output())
+	t.Logf("---------------------post-mortem describe node-------------------------")
 	rr, err = Run(t, exec.Command("kubectl", "--context", profile, "describe", "node"))
 	if err != nil {
 		t.Logf("%s: %v", rr.Command(), err)
 	} else {
-		t.Logf("(dbg) %s:\n%s", rr.Command(), rr.Stdout)
+		t.Logf("(dbg) %s:\n%s", rr.Command(), rr.Output())
 	}
+	t.Logf("------------------------------------------------------------------")
 	t.Logf("<<< %s FAILED: end of post-mortem logs <<<", t.Name())
+	t.Logf("----------------   /post-mortem   ---------------------------")
 }
 
 // podStatusMsg returns a human-readable pod status, for generating debug status


### PR DESCRIPTION
## After this PR : 
- add separator for each post mortem section
- indent stdout 
```
panic.go:563: *** TestOffline/group/crio FAILED at 2020-04-07 11:13:54.729212628 -0700 PDT m=+608.329710256
helpers.go:198: (dbg) Run:  out/minikube-linux-amd64 status --format={{.Host}} -p offline-crio-20200407T110412.001029523-5722
helpers.go:204: -----------------------post-mortem--------------------------------
helpers.go:205: <<< TestOffline/group/crio FAILED: start of post-mortem logs <<<
helpers.go:206: -------------------post-mortem minikube logs----------------------
helpers.go:207: (dbg) Run:  out/minikube-linux-amd64 -p offline-crio-20200407T110412.001029523-5722 logs --problems
helpers.go:207: (dbg) Done: out/minikube-linux-amd64 -p offline-crio-20200407T110412.001029523-5722 logs --problems: (4.278290075s)
helpers.go:212: TestOffline/group/crio logs: 
helpers.go:214: ------------------post-mortem api server status-------------------
helpers.go:215: (dbg) Run:  out/minikube-linux-amd64 status --format={{.APIServer}} -p offline-crio-20200407T110412.001029523-5722
helpers.go:220: --------------------post-mortem get pods--------------------------
helpers.go:221: (dbg) Run:  kubectl --context offline-crio-20200407T110412.001029523-5722 get po -A --show-labels
helpers.go:221: (dbg) Done: kubectl --context offline-crio-20200407T110412.001029523-5722 get po -A --show-labels: (1.210704971s)
helpers.go:226: (dbg) kubectl --context offline-crio-20200407T110412.001029523-5722 get po -A --show-labels:
-- stdout --
	NAMESPACE     NAME                                                                  READY   STATUS              RESTARTS   AGE     LABELS
	kube-system   coredns-66bff467f8-2wlxv                                              0/1     ContainerCreating   0          7m1s    k8s-app=kube-dns,pod-template-hash=66bff467f8
	kube-system   coredns-66bff467f8-b7vrs                                              0/1     ContainerCreating   0          7m1s    k8s-app=kube-dns,pod-template-hash=66bff467f8
	kube-system   etcd-offline-crio-20200407t110412.001029523-5722                      1/1     Running             0          7m16s   component=etcd,tier=control-plane
	kube-system   kindnet-bktzk                                                         1/1     Running             0          7m1s    app=kindnet,controller-revision-hash=5c5d549dd7,k8s-app=kindnet,pod-template-generation=1,tier=node
	kube-system   kube-apiserver-offline-crio-20200407t110412.001029523-5722            1/1     Running             0          7m16s   component=kube-apiserver,tier=control-plane
	kube-system   kube-controller-manager-offline-crio-20200407t110412.001029523-5722   1/1     Running             0          7m16s   component=kube-controller-manager,tier=control-plane
	kube-system   kube-proxy-bcfh9                                                      1/1     Running             0          7m1s    controller-revision-hash=c8bb659c5,k8s-app=kube-proxy,pod-template-generation=1
	kube-system   kube-scheduler-offline-crio-20200407t110412.001029523-5722            1/1     Running             0          7m16s   component=kube-scheduler,tier=control-plane
	kube-system   storage-provisioner                                                   1/1     Running             0          6m45s   addonmanager.kubernetes.io/mode=Reconcile,integration-test=storage-provisioner
-- /stdout --
helpers.go:227: -------------------post-mortem describe node----------------------
helpers.go:228: (dbg) Run:  kubectl --context offline-crio-20200407T110412.001029523-5722 describe node
helpers.go:232: (dbg) kubectl --context offline-crio-20200407T110412.001029523-5722 describe node:
-- stdout --
	Name:               offline-crio-20200407t110412.001029523-5722
	Roles:              master
	Labels:             beta.kubernetes.io/arch=amd64
	                    beta.kubernetes.io/os=linux
	                    kubernetes.io/arch=amd64
	                    kubernetes.io/hostname=offline-crio-20200407t110412.001029523-5722
	                    kubernetes.io/os=linux
	                    minikube.k8s.io/commit=157d7a4e3cde2d8f9765dcf9d2332aeb6863222d
	                    minikube.k8s.io/name=offline-crio-20200407T110412.001029523-5722
	                    minikube.k8s.io/updated_at=2020_04_07T11_06_45_0700
	                    minikube.k8s.io/version=v1.9.2
	                    node-role.kubernetes.io/master=
	Annotations:        kubeadm.alpha.kubernetes.io/cri-socket: /var/run/crio/crio.sock
	                    node.alpha.kubernetes.io/ttl: 0
	                    volumes.kubernetes.io/controller-managed-attach-detach: true
	CreationTimestamp:  Tue, 07 Apr 2020 11:06:41 -0700
	Taints:             <none>
	Unschedulable:      false
	Lease:
	  HolderIdentity:  offline-crio-20200407t110412.001029523-5722
	  AcquireTime:     <unset>
	  RenewTime:       Tue, 07 Apr 2020 11:13:54 -0700
	Conditions:
	  Type             Status  LastHeartbeatTime                 LastTransitionTime                Reason                       Message
	  ----             ------  -----------------                 ------------------                ------                       -------
	  MemoryPressure   False   Tue, 07 Apr 2020 11:12:15 -0700   Tue, 07 Apr 2020 11:06:36 -0700   KubeletHasSufficientMemory   kubelet has sufficient memory available
	  DiskPressure     False   Tue, 07 Apr 2020 11:12:15 -0700   Tue, 07 Apr 2020 11:06:36 -0700   KubeletHasNoDiskPressure     kubelet has no disk pressure
	  PIDPressure      False   Tue, 07 Apr 2020 11:12:15 -0700   Tue, 07 Apr 2020 11:06:36 -0700   KubeletHasSufficientPID      kubelet has sufficient PID available
	  Ready            True    Tue, 07 Apr 2020 11:12:15 -0700   Tue, 07 Apr 2020 11:06:54 -0700   KubeletReady                 kubelet is posting ready status
	Addresses:
	  InternalIP:  172.17.0.2
	  Hostname:    offline-crio-20200407t110412.001029523-5722
	Capacity:
	  cpu:                8
	  ephemeral-storage:  515928484Ki
	  hugepages-1Gi:      0
	  hugepages-2Mi:      0
	  memory:             30887012Ki
	  pods:               110
	Allocatable:
	  cpu:                8
	  ephemeral-storage:  515928484Ki
	  hugepages-1Gi:      0
	  hugepages-2Mi:      0
	  memory:             30887012Ki
	  pods:               110
	System Info:
	  Machine ID:                 56f762c70ad44947aa30f0627fa521fb
	  System UUID:                d20e46c9-43bb-4094-aa5f-ed801a85907e
	  Boot ID:                    2a0a1865-87e6-4121-9ca8-f094b4d5b8f9
	  Kernel Version:             4.9.0-12-amd64
	  OS Image:                   Ubuntu 19.10
	  Operating System:           linux
	  Architecture:               amd64
	  Container Runtime Version:  cri-o://1.17.0
	  Kubelet Version:            v1.18.0
	  Kube-Proxy Version:         v1.18.0
	PodCIDR:                      10.244.0.0/24
	PodCIDRs:                     10.244.0.0/24
	Non-terminated Pods:          (9 in total)
	  Namespace                   Name                                                                   CPU Requests  CPU Limits  Memory Requests  Memory Limits  AGE
	  ---------                   ----                                                                   ------------  ----------  ---------------  -------------  ---
	  kube-system                 coredns-66bff467f8-2wlxv                                               100m (1%)     0 (0%)      70Mi (0%)        170Mi (0%)     7m1s
	  kube-system                 coredns-66bff467f8-b7vrs                                               100m (1%)     0 (0%)      70Mi (0%)        170Mi (0%)     7m1s
	  kube-system                 etcd-offline-crio-20200407t110412.001029523-5722                       0 (0%)        0 (0%)      0 (0%)           0 (0%)         7m16s
	  kube-system                 kindnet-bktzk                                                          100m (1%)     100m (1%)   50Mi (0%)        50Mi (0%)      7m1s
	  kube-system                 kube-apiserver-offline-crio-20200407t110412.001029523-5722             250m (3%)     0 (0%)      0 (0%)           0 (0%)         7m16s
	  kube-system                 kube-controller-manager-offline-crio-20200407t110412.001029523-5722    200m (2%)     0 (0%)      0 (0%)           0 (0%)         7m16s
	  kube-system                 kube-proxy-bcfh9                                                       0 (0%)        0 (0%)      0 (0%)           0 (0%)         7m1s
	  kube-system                 kube-scheduler-offline-crio-20200407t110412.001029523-5722             100m (1%)     0 (0%)      0 (0%)           0 (0%)         7m16s
	  kube-system                 storage-provisioner                                                    0 (0%)        0 (0%)      0 (0%)           0 (0%)         6m45s
	Allocated resources:
	  (Total limits may be over 100 percent, i.e., overcommitted.)
	  Resource           Requests    Limits
	  --------           --------    ------
	  cpu                850m (10%)  100m (1%)
	  memory             190Mi (0%)  390Mi (1%)
	  ephemeral-storage  0 (0%)      0 (0%)
	  hugepages-1Gi      0 (0%)      0 (0%)
	  hugepages-2Mi      0 (0%)      0 (0%)
	Events:
	  Type    Reason                   Age    From                                                     Message
	  ----    ------                   ----   ----                                                     -------
	  Normal  Starting                 7m17s  kubelet, offline-crio-20200407t110412.001029523-5722     Starting kubelet.
	  Normal  NodeHasSufficientMemory  7m17s  kubelet, offline-crio-20200407t110412.001029523-5722     Node offline-crio-20200407t110412.001029523-5722 status is now: NodeHasSufficientMemory
	  Normal  NodeHasNoDiskPressure    7m17s  kubelet, offline-crio-20200407t110412.001029523-5722     Node offline-crio-20200407t110412.001029523-5722 status is now: NodeHasNoDiskPressure
	  Normal  NodeHasSufficientPID     7m17s  kubelet, offline-crio-20200407t110412.001029523-5722     Node offline-crio-20200407t110412.001029523-5722 status is now: NodeHasSufficientPID
	  Normal  NodeNotReady             7m17s  kubelet, offline-crio-20200407t110412.001029523-5722     Node offline-crio-20200407t110412.001029523-5722 status is now: NodeNotReady
	  Normal  NodeAllocatableEnforced  7m17s  kubelet, offline-crio-20200407t110412.001029523-5722     Updated Node Allocatable limit across pods
	  Normal  NodeReady                7m7s   kubelet, offline-crio-20200407t110412.001029523-5722     Node offline-crio-20200407t110412.001029523-5722 status is now: NodeReady
	  Normal  Starting                 7m     kube-proxy, offline-crio-20200407t110412.001029523-5722  Starting kube-proxy.
-- /stdout --
helpers.go:234: ------------------------------------------------------------------
helpers.go:235: <<< TestOffline/group/crio FAILED: end of post-mortem logs <<<
helpers.go:236: ---------------------/post-mortem---------------------------------
helpers.go:170: (dbg) Run:  out/minikube-linux-amd64 delete -p offline-crio-20200407T110412.001029523-5722
helpers.go:170: (dbg) Done: out/minikube-linux-amd64 delete -p offline-crio-20200407T110412.001029523-5722: (1.441482696s)
```