### PR TITLE
docs: Add /docs/contributing compatibility alias

### DIFF
--- a/site/content/en/docs/contrib/_index.md
+++ b/site/content/en/docs/contrib/_index.md
@@ -4,4 +4,6 @@ linkTitle: "Contributing"
 weight: 10
 description: >
   How to contribute to minikube
+aliases:
+ - /docs/contributing
 ---


### PR DESCRIPTION
I broke this in the docs refactor.