### PR TITLE
Use SSH runner once SSH is set up in kic

### DIFF
--- a/pkg/minikube/machine/client.go
+++ b/pkg/minikube/machine/client.go
@@ -157,6 +157,11 @@ func CommandRunner(h *host.Host) (command.Runner, error) {
 	if driver.IsKIC(h.Driver.DriverName()) {
 		return command.NewKICRunner(h.Name, h.Driver.DriverName()), nil
 	}
+	return SSHRunner(h)
+}
+
+// SSHRunner returns an SSH runner for the host
+func SSHRunner(h *host.Host) (command.Runner, error) {
 	client, err := sshutil.NewSSHClient(h.Driver)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting ssh client for bootstrapper")

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -106,6 +106,17 @@ func Start(cc config.ClusterConfig, n config.Node, existingAddons map[string]boo
 	cr := configureRuntimes(mRunner, cc.Driver, cc.KubernetesConfig, sv)
 	showVersionInfo(n.KubernetesVersion, cr)
 
+	// ssh should be set up by now
+	// switch to using ssh runner since it is faster
+	if driver.IsKIC(cc.Driver) {
+		sshRunner, err := machine.SSHRunner(host)
+		if err != nil {
+			glog.Infof("error getting ssh runner, will use slower command runner: %v", err)
+		} else {
+			mRunner = sshRunner
+		}
+	}
+
 	var bs bootstrapper.Bootstrapper
 	var kcs *kubeconfig.Settings
 	if apiServer {

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -111,8 +111,9 @@ func Start(cc config.ClusterConfig, n config.Node, existingAddons map[string]boo
 	if driver.IsKIC(cc.Driver) {
 		sshRunner, err := machine.SSHRunner(host)
 		if err != nil {
-			glog.Infof("error getting ssh runner, will use slower command runner: %v", err)
+			glog.Infof("error getting ssh runner: %v", err)
 		} else {
+			glog.Infof("Using ssh runner for kic...")
 			mRunner = sshRunner
 		}
 	}


### PR DESCRIPTION
This change shaves off 1.1 seconds on setupKubeadm


Slowjam at HEAD: http://104.197.255.167:8000 
Slowjam with this PR: http://35.193.233.143:8000