### PR TITLE
start: Parallelize mount, cache push, and addon enablement

### DIFF
--- a/cmd/minikube/cmd/config/disable.go
+++ b/cmd/minikube/cmd/config/disable.go
@@ -33,7 +33,7 @@ var addonsDisableCmd = &cobra.Command{
 		}
 
 		addon := args[0]
-		err := addons.Set(addon, "false", ClusterFlagValue())
+		err := addons.SetAndSave(ClusterFlagValue(), addon, "false")
 		if err != nil {
 			exit.WithError("disable failed", err)
 		}

--- a/cmd/minikube/cmd/config/enable.go
+++ b/cmd/minikube/cmd/config/enable.go
@@ -32,7 +32,7 @@ var addonsEnableCmd = &cobra.Command{
 			exit.UsageT("usage: minikube addons enable ADDON_NAME")
 		}
 		addon := args[0]
-		err := addons.Set(addon, "true", ClusterFlagValue())
+		err := addons.SetAndSave(ClusterFlagValue(), addon, "true")
 		if err != nil {
 			exit.WithError("enable failed", err)
 		}

--- a/cmd/minikube/cmd/config/open.go
+++ b/cmd/minikube/cmd/config/open.go
@@ -66,11 +66,9 @@ var addonsOpenCmd = &cobra.Command{
 To see the list of available addons run:
 minikube addons list`, out.V{"name": addonName})
 		}
-		ok, err := addon.IsEnabled(cname)
-		if err != nil {
-			exit.WithError("IsEnabled failed", err)
-		}
-		if !ok {
+
+		enabled := addon.IsEnabled(co.Config)
+		if !enabled {
 			exit.WithCodeT(exit.Unavailable, `addon '{{.name}}' is currently not enabled.
 To enable this addon run:
 minikube addons enable {{.name}}`, out.V{"name": addonName})

--- a/cmd/minikube/cmd/dashboard.go
+++ b/cmd/minikube/cmd/dashboard.go
@@ -67,13 +67,14 @@ var dashboardCmd = &cobra.Command{
 		var err error
 
 		// Check dashboard status before enabling it
-		dashboardAddon := assets.Addons["dashboard"]
-		dashboardStatus, _ := dashboardAddon.IsEnabled(cname)
-		if !dashboardStatus {
+		addon := assets.Addons["dashboard"]
+		enabled := addon.IsEnabled(co.Config)
+
+		if !enabled {
 			// Send status messages to stderr for folks re-using this output.
 			out.ErrT(out.Enabling, "Enabling dashboard ...")
 			// Enable the dashboard add-on
-			err = addons.Set("dashboard", "true", cname)
+			err = addons.SetAndSave(cname, "dashboard", "true")
 			if err != nil {
 				exit.WithError("Unable to enable dashboard", err)
 			}

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -290,9 +290,7 @@ func enableOrDisableStorageClasses(cc *config.ClusterConfig, name string, val st
 // Start enables the default addons for a profile, plus any additional
 func Start(wg sync.WaitGroup, profile string, toEnable map[string]bool, additional []string) {
 	wg.Add(1)
-	defer func() {
-		wg.Done()
-	}()
+	defer wg.Done()
 
 	start := time.Now()
 	glog.Infof("enableAddons start: toEnable=%v, additional=%s", toEnable, additional)
@@ -329,12 +327,12 @@ func Start(wg sync.WaitGroup, profile string, toEnable map[string]bool, addition
 
 	out.T(out.AddonEnable, "Enabling addons: {{.addons}}", out.V{"addons": strings.Join(toEnableList, ", ")})
 	for _, a := range toEnableList {
-		go func() {
-			wg.Add(1)
-			err := Set(a, "true", profile)
+		wg.Add(1)
+		go func(name) {
+			err := Set(name, "true", profile)
 			if err != nil {
 				// Intentionally non-fatal
-				out.WarningT("Enabling '{{.name}}' returned an error: {{.error}}", out.V{"name": a, "error": err})
+				out.WarningT("Enabling '{{.name}}' returned an error: {{.error}}", out.V{"name": name, "error": err})
 			}
 			wg.Done()
 		}()

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -328,13 +328,13 @@ func Start(wg sync.WaitGroup, profile string, toEnable map[string]bool, addition
 	out.T(out.AddonEnable, "Enabling addons: {{.addons}}", out.V{"addons": strings.Join(toEnableList, ", ")})
 	for _, a := range toEnableList {
 		wg.Add(1)
-		go func(name) {
+		go func(name string) {
 			err := Set(name, "true", profile)
 			if err != nil {
 				// Intentionally non-fatal
 				out.WarningT("Enabling '{{.name}}' returned an error: {{.error}}", out.V{"name": name, "error": err})
 			}
 			wg.Done()
-		}()
+		}(a)
 	}
 }

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -42,17 +42,12 @@ import (
 // defaultStorageClassProvisioner is the name of the default storage class provisioner
 const defaultStorageClassProvisioner = "standard"
 
-// Set sets a value
-func Set(name, value, profile string) error {
-	glog.Infof("Setting %s=%s in profile %q", name, value, profile)
+// RunCallbacks runs all actions associated to an addon, but does not set it (thread-safe)
+func RunCallbacks(cc *config.ClusterConfig, name string, value string) error {
+	glog.Infof("Setting %s=%s in profile %q", name, value, cc.Name)
 	a, valid := isAddonValid(name)
 	if !valid {
 		return errors.Errorf("%s is not a valid addon", name)
-	}
-
-	cc, err := config.Load(profile)
-	if err != nil {
-		return errors.Wrap(err, "loading profile")
 	}
 
 	// Run any additional validations for this property
@@ -60,13 +55,35 @@ func Set(name, value, profile string) error {
 		return errors.Wrap(err, "running validations")
 	}
 
-	if err := a.set(cc, name, value); err != nil {
-		return errors.Wrap(err, "setting new value of addon")
-	}
-
 	// Run any callbacks for this property
 	if err := run(cc, name, value, a.callbacks); err != nil {
 		return errors.Wrap(err, "running callbacks")
+	}
+	return nil
+}
+
+// Set sets a value in the config (not threadsafe)
+func Set(cc *config.ClusterConfig, name string, value string) error {
+	a, valid := isAddonValid(name)
+	if !valid {
+		return errors.Errorf("%s is not a valid addon", name)
+	}
+	return a.set(cc, name, value)
+}
+
+// SetAndSave sets a value and saves the config
+func SetAndSave(profile string, name string, value string) error {
+	cc, err := config.Load(profile)
+	if err != nil {
+		return errors.Wrap(err, "loading profile")
+	}
+
+	if err := RunCallbacks(cc, name, value); err != nil {
+		return errors.Wrap(err, "run callbacks")
+	}
+
+	if err := Set(cc, name, value); err != nil {
+		return errors.Wrap(err, "set")
 	}
 
 	glog.Infof("Writing out %q config to set %s=%v...", profile, name, value)
@@ -88,7 +105,7 @@ func run(cc *config.ClusterConfig, name string, value string, fns []setFn) error
 	return nil
 }
 
-// SetBool sets a bool value
+// SetBool sets a bool value in the config (not threadsafe)
 func SetBool(cc *config.ClusterConfig, name string, val string) error {
 	b, err := strconv.ParseBool(val)
 	if err != nil {
@@ -111,13 +128,7 @@ func enableOrDisableAddon(cc *config.ClusterConfig, name string, val string) err
 	addon := assets.Addons[name]
 
 	// check addon status before enabling/disabling it
-	alreadySet, err := isAddonAlreadySet(addon, enable, cc.Name)
-	if err != nil {
-		out.ErrT(out.Conflict, "{{.error}}", out.V{"error": err})
-		return err
-	}
-
-	if alreadySet {
+	if isAddonAlreadySet(cc, addon, enable) {
 		glog.Warningf("addon %s should already be in state %v", name, val)
 		if !enable {
 			return nil
@@ -161,7 +172,7 @@ https://github.com/kubernetes/minikube/issues/7332`, out.V{"driver_name": cc.Dri
 	mName := driver.MachineName(*cc, cp)
 	host, err := machine.LoadHost(api, mName)
 	if err != nil || !machine.IsRunning(api, mName) {
-		glog.Warningf("%q is not running, writing %s=%v to disk and skipping enablement (err=%v)", mName, addon.Name(), enable, err)
+		glog.Warningf("%q is not running, setting %s=%v and skipping enablement (err=%v)", mName, addon.Name(), enable, err)
 		return nil
 	}
 
@@ -174,19 +185,17 @@ https://github.com/kubernetes/minikube/issues/7332`, out.V{"driver_name": cc.Dri
 	return enableOrDisableAddonInternal(cc, addon, cmd, data, enable)
 }
 
-func isAddonAlreadySet(addon *assets.Addon, enable bool, profile string) (bool, error) {
-	addonStatus, err := addon.IsEnabled(profile)
-	if err != nil {
-		return false, errors.Wrap(err, "is enabled")
+func isAddonAlreadySet(cc *config.ClusterConfig, addon *assets.Addon, enable bool) bool {
+	enabled := addon.IsEnabled(cc)
+	if enabled && enable {
+		return true
 	}
 
-	if addonStatus && enable {
-		return true, nil
-	} else if !addonStatus && !enable {
-		return true, nil
+	if !enabled && !enable {
+		return true
 	}
 
-	return false, nil
+	return false
 }
 
 func enableOrDisableAddonInternal(cc *config.ClusterConfig, addon *assets.Addon, cmd command.Runner, data interface{}, enable bool) error {
@@ -288,7 +297,7 @@ func enableOrDisableStorageClasses(cc *config.ClusterConfig, name string, val st
 }
 
 // Start enables the default addons for a profile, plus any additional
-func Start(wg sync.WaitGroup, profile string, toEnable map[string]bool, additional []string) {
+func Start(wg *sync.WaitGroup, cc *config.ClusterConfig, toEnable map[string]bool, additional []string) {
 	wg.Add(1)
 	defer wg.Done()
 
@@ -300,11 +309,7 @@ func Start(wg sync.WaitGroup, profile string, toEnable map[string]bool, addition
 
 	// Get the default values of any addons not saved to our config
 	for name, a := range assets.Addons {
-		defaultVal, err := a.IsEnabled(profile)
-		if err != nil {
-			glog.Errorf("is-enabled failed for %q: %v", a.Name(), err)
-			continue
-		}
+		defaultVal := a.IsEnabled(cc)
 
 		_, exists := toEnable[name]
 		if !exists {
@@ -325,16 +330,25 @@ func Start(wg sync.WaitGroup, profile string, toEnable map[string]bool, addition
 	}
 	sort.Strings(toEnableList)
 
+	var awg sync.WaitGroup
+
 	out.T(out.AddonEnable, "Enabling addons: {{.addons}}", out.V{"addons": strings.Join(toEnableList, ", ")})
 	for _, a := range toEnableList {
-		wg.Add(1)
+		awg.Add(1)
 		go func(name string) {
-			err := Set(name, "true", profile)
+			err := RunCallbacks(cc, name, "true")
 			if err != nil {
-				// Intentionally non-fatal
 				out.WarningT("Enabling '{{.name}}' returned an error: {{.error}}", out.V{"name": name, "error": err})
 			}
-			wg.Done()
+			awg.Done()
 		}(a)
+	}
+
+	// Wait until all of the addons are enabled before updating the config (not thread safe)
+	awg.Wait()
+	for _, a := range toEnableList {
+		if err := Set(cc, a, "true"); err != nil {
+			glog.Errorf("store failed: %v", err)
+		}
 	}
 }

--- a/pkg/addons/addons_test.go
+++ b/pkg/addons/addons_test.go
@@ -95,7 +95,7 @@ func TestSetAndSave(t *testing.T) {
 	profile := createTestProfile(t)
 
 	// enable
-	if err := SetAndSave("dashboard", "true", profile); err != nil {
+	if err := SetAndSave(profile, "dashboard", "true"); err != nil {
 		t.Errorf("Disable returned unexpected error: " + err.Error())
 	}
 
@@ -108,7 +108,7 @@ func TestSetAndSave(t *testing.T) {
 	}
 
 	// disable
-	if err := SetAndSave("dashboard", "false", profile); err != nil {
+	if err := SetAndSave(profile, "dashboard", "false"); err != nil {
 		t.Errorf("Disable returned unexpected error: " + err.Error())
 	}
 

--- a/pkg/addons/addons_test.go
+++ b/pkg/addons/addons_test.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"k8s.io/minikube/pkg/minikube/assets"
@@ -59,47 +60,42 @@ func createTestProfile(t *testing.T) string {
 }
 
 func TestIsAddonAlreadySet(t *testing.T) {
-	profile := createTestProfile(t)
-	if err := Set("registry", "true", profile); err != nil {
+	cc := &config.ClusterConfig{Name: "test"}
+
+	if err := Set(cc, "registry", "true"); err != nil {
 		t.Errorf("unable to set registry true: %v", err)
 	}
-	enabled, err := assets.Addons["registry"].IsEnabled(profile)
-	if err != nil {
-		t.Errorf("registry: %v", err)
-	}
-	if !enabled {
+	if !assets.Addons["registry"].IsEnabled(cc) {
 		t.Errorf("expected registry to be enabled")
 	}
 
-	enabled, err = assets.Addons["ingress"].IsEnabled(profile)
-	if err != nil {
-		t.Errorf("ingress: %v", err)
-	}
-	if enabled {
+	if assets.Addons["ingress"].IsEnabled(cc) {
 		t.Errorf("expected ingress to not be enabled")
 	}
 
 }
 
 func TestDisableUnknownAddon(t *testing.T) {
-	profile := createTestProfile(t)
-	if err := Set("InvalidAddon", "false", profile); err == nil {
+	cc := &config.ClusterConfig{Name: "test"}
+
+	if err := Set(cc, "InvalidAddon", "false"); err == nil {
 		t.Fatalf("Disable did not return error for unknown addon")
 	}
 }
 
 func TestEnableUnknownAddon(t *testing.T) {
-	profile := createTestProfile(t)
-	if err := Set("InvalidAddon", "true", profile); err == nil {
+	cc := &config.ClusterConfig{Name: "test"}
+
+	if err := Set(cc, "InvalidAddon", "true"); err == nil {
 		t.Fatalf("Enable did not return error for unknown addon")
 	}
 }
 
-func TestEnableAndDisableAddon(t *testing.T) {
+func TestSetAndSave(t *testing.T) {
 	profile := createTestProfile(t)
 
 	// enable
-	if err := Set("dashboard", "true", profile); err != nil {
+	if err := SetAndSave("dashboard", "true", profile); err != nil {
 		t.Errorf("Disable returned unexpected error: " + err.Error())
 	}
 
@@ -112,7 +108,7 @@ func TestEnableAndDisableAddon(t *testing.T) {
 	}
 
 	// disable
-	if err := Set("dashboard", "false", profile); err != nil {
+	if err := SetAndSave("dashboard", "false", profile); err != nil {
 		t.Errorf("Disable returned unexpected error: " + err.Error())
 	}
 
@@ -126,14 +122,18 @@ func TestEnableAndDisableAddon(t *testing.T) {
 }
 
 func TestStart(t *testing.T) {
-	profile := createTestProfile(t)
-	Start(profile, map[string]bool{}, []string{"dashboard"})
-
-	enabled, err := assets.Addons["dashboard"].IsEnabled(profile)
-	if err != nil {
-		t.Errorf("dashboard: %v", err)
+	cc := &config.ClusterConfig{
+		Name:             "start",
+		CPUs:             2,
+		Memory:           2500,
+		KubernetesConfig: config.KubernetesConfig{},
 	}
-	if !enabled {
+
+	var wg sync.WaitGroup
+	Start(&wg, cc, map[string]bool{}, []string{"dashboard"})
+	wg.Wait()
+
+	if !assets.Addons["dashboard"].IsEnabled(cc) {
 		t.Errorf("expected dashboard to be enabled")
 	}
 }

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -19,8 +19,6 @@ package assets
 import (
 	"runtime"
 
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/vmpath"
@@ -49,21 +47,14 @@ func (a *Addon) Name() string {
 }
 
 // IsEnabled checks if an Addon is enabled for the given profile
-func (a *Addon) IsEnabled(profile string) (bool, error) {
-	c, err := config.Load(profile)
-	if err != nil {
-		return false, errors.Wrap(err, "load")
-	}
-
-	// Is this addon explicitly listed in their configuration?
-	status, ok := c.Addons[a.Name()]
-	glog.V(1).Infof("IsEnabled %q = %v (listed in config=%v)", a.Name(), status, ok)
+func (a *Addon) IsEnabled(cc *config.ClusterConfig) bool {
+	status, ok := cc.Addons[a.Name()]
 	if ok {
-		return status, nil
+		return status
 	}
 
 	// Return the default unconfigured state of the addon
-	return a.enabled, nil
+	return a.enabled
 }
 
 // Addons is the list of addons

--- a/pkg/minikube/exit/exit.go
+++ b/pkg/minikube/exit/exit.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"runtime/debug"
 
 	"github.com/golang/glog"
 	"k8s.io/minikube/pkg/minikube/out"
@@ -59,6 +60,7 @@ func WithCodeT(code int, format string, a ...out.V) {
 
 // WithError outputs an error and exits.
 func WithError(msg string, err error) {
+	glog.Infof("WithError(%s)=%v called from:\n%s", msg, err, debug.Stack())
 	p := problem.FromError(err, runtime.GOOS)
 	if p != nil {
 		WithProblem(msg, err, p)

--- a/pkg/minikube/node/config.go
+++ b/pkg/minikube/node/config.go
@@ -49,9 +49,7 @@ func showVersionInfo(k8sVersion string, cr cruntime.Manager) {
 // configureMounts configures any requested filesystem mounts
 func configureMounts(wg sync.WaitGroup) {
 	wg.Add(1)
-	defer func() {
-		wg.Done()
-	}()
+	defer wg.Done()
 
 	if !viper.GetBool(createMount) {
 		return

--- a/pkg/minikube/node/config.go
+++ b/pkg/minikube/node/config.go
@@ -47,7 +47,7 @@ func showVersionInfo(k8sVersion string, cr cruntime.Manager) {
 }
 
 // configureMounts configures any requested filesystem mounts
-func configureMounts(wg sync.WaitGroup) {
+func configureMounts(wg *sync.WaitGroup) {
 	wg.Add(1)
 	defer wg.Done()
 

--- a/pkg/minikube/node/config.go
+++ b/pkg/minikube/node/config.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"sync"
 
 	"github.com/golang/glog"
 	"github.com/spf13/viper"
@@ -46,7 +47,12 @@ func showVersionInfo(k8sVersion string, cr cruntime.Manager) {
 }
 
 // configureMounts configures any requested filesystem mounts
-func configureMounts() {
+func configureMounts(wg sync.WaitGroup) {
+	wg.Add(1)
+	defer func() {
+		wg.Done()
+	}()
+
 	if !viper.GetBool(createMount) {
 		return
 	}


### PR DESCRIPTION
Pushes 3 steps to run in parallel:

- Mount setup
- Pushing cached images from config
- Addon enablement (each addon gets run in parallel)

Shaves ~1.3s off of `minikube start --driver=docker` on macOS (average across 5 runs)

To make this race-safe, it required a small refactor of the addons package, as `addons.Set()` is not thread-safe. On the plus side, we no longer load & store the profile repeatedly.