### PR TITLE
wip: Fix stop containers for containerd.

### DIFF
--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -320,7 +320,7 @@ func (d *Driver) Stop() error {
 	runtime, err := cruntime.New(cruntime.Config{Type: d.NodeConfig.ContainerRuntime, Runner: d.exec})
 	if err != nil { // won't return error because:
 		// even though we can't stop the cotainers inside, we still wanna stop the minikube container itself
-		glog.Errorf("unable to get container runtime: %v", err)
+		glog.Infof("unable to get container runtime: %v", err)
 	}
 
 	containers, err := runtime.ListContainers(cruntime.ListOptions{Namespaces: constants.DefaultNamespaces})
@@ -329,9 +329,9 @@ func (d *Driver) Stop() error {
 	}
 	if len(containers) > 0 {
 		if err := runtime.StopContainers(containers); err != nil {
-			glog.Errorf("unable to stop containers will try killing  : %v", err)
+			glog.Infof("unable to stop containers will try killing  : %v", err)
 			if err := runtime.KillContainers(containers); err != nil {
-				glog.Errorf("unable to kill containers : %v", err)
+				glog.Infof("unable to kill containers : %v", err)
 			}
 		}
 	}
@@ -339,7 +339,7 @@ func (d *Driver) Stop() error {
 	// docker does not send right SIG for systemd to know to stop the systemd.
 	// to avoid bind address be taken on an upgrade. more info https://github.com/kubernetes/minikube/issues/7171
 	if err := kubelet.Stop(d.exec); err != nil {
-		glog.Warningf("couldn't stop kubelet. will continue with stop anyways: %v", err)
+		glog.Infof("couldn't stop kubelet. will continue with stop anyways: %v", err)
 		if err := kubelet.ForceStop(d.exec); err != nil {
 			glog.Warningf("couldn't force stop kubelet. will continue with stop anyways: %v", err)
 		}

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -330,9 +330,9 @@ func (d *Driver) Stop() error {
 	if len(containers) > 0 {
 		if err := runtime.StopContainers(containers); err != nil {
 			glog.Infof("unable to stop containers will try killing  : %v", err)
-			if err := runtime.KillContainers(containers); err != nil {
-				glog.Infof("unable to kill containers : %v", err)
-			}
+		}
+		if err := runtime.KillContainers(containers); err != nil {
+			glog.Infof("unable to kill containers : %v", err)
 		}
 	}
 
@@ -343,6 +343,10 @@ func (d *Driver) Stop() error {
 		if err := kubelet.ForceStop(d.exec); err != nil {
 			glog.Warningf("couldn't force stop kubelet. will continue with stop anyways: %v", err)
 		}
+	}
+	// to avoid https://github.com/kubernetes/minikube/issues/7521
+	if _, err := d.exec.RunCmd(exec.Command("sudo", "/bin/bash", "-c", "kill -9 $(pgrep kube-apiserver)")); err != nil {
+		glog.Infof("failed to kill kube-apiserver! : %v", err)
 	}
 
 	glog.Infof("successfully stopped kubernetes!")

--- a/pkg/minikube/cruntime/cri.go
+++ b/pkg/minikube/cruntime/cri.go
@@ -195,7 +195,7 @@ func stopCRIContainers(cr CommandRunner, ids []string) error {
 	glog.Infof("Stopping containers: %s", ids)
 
 	crictl := getCrictlPath(cr)
-	args := append([]string{crictl, "rm"}, ids...)
+	args := append([]string{crictl, "stop", "--timeout=2"}, ids...)
 	c := exec.Command("sudo", args...)
 	if _, err := cr.RunCmd(c); err != nil {
 		return errors.Wrap(err, "crictl")

--- a/pkg/minikube/cruntime/cruntime_test.go
+++ b/pkg/minikube/cruntime/cruntime_test.go
@@ -246,6 +246,9 @@ func (f *FakeRunner) dockerStop(args []string) (string, error) {
 	ids := strings.Split(args[1], " ")
 	for _, id := range ids {
 		f.t.Logf("fake docker: Stopping id %q", id)
+		if id == "--timeout=2" { // don't interpret this as an id
+			continue
+		}
 		if f.containers[id] == "" {
 			return "", fmt.Errorf("no such container")
 		}
@@ -257,6 +260,10 @@ func (f *FakeRunner) dockerStop(args []string) (string, error) {
 func (f *FakeRunner) dockerRm(args []string) (string, error) {
 	// Skip "-f" argument
 	for _, id := range args[2:] {
+		if id == "--timeout=2" { // don't interpret this as an id
+			continue
+		}
+
 		f.t.Logf("fake docker: Removing id %q", id)
 		if f.containers[id] == "" {
 			return "", fmt.Errorf("no such container")
@@ -384,6 +391,9 @@ func (f *FakeRunner) crictl(args []string, _ bool) (string, error) {
 		}
 	case "stop":
 		for _, id := range args[1:] {
+			if id == "--timeout=2" {
+				continue
+			}
 			f.t.Logf("fake crictl: Stopping id %q", id)
 			if f.containers[id] == "" {
 				return "", fmt.Errorf("no such container")
@@ -392,6 +402,9 @@ func (f *FakeRunner) crictl(args []string, _ bool) (string, error) {
 		}
 	case "rm":
 		for _, id := range args[1:] {
+			if id == "--timeout=2" {
+				continue
+			}
 			f.t.Logf("fake crictl: Removing id %q", id)
 			if f.containers[id] == "" {
 				return "", fmt.Errorf("no such container")


### PR DESCRIPTION
hopefully closes https://github.com/kubernetes/minikube/issues/7521
which after miniube was stopped for containerd, on the start you would sometimes see this in the logs:

```
	  - Error: failed to create listener: failed to listen on 0.0.0.0:8444: listen tcp 0.0.0.0:8444: bind: address already in use
```


the problem was in kic we were trying to stop containers before kic stop to avoid
bind address problem


but the command stop container was wrong in the lib, it was rm
and even if the lib writer meant remove, u can not remove a not stopped container. so I changed to stop, we _might_ need to do both stop and rm but I dont think rm is needed.

this doesnt work in crictl:

```
docker@minikube:~$ sudo crictl rm 5c3039d13ecadafdd46c1cabe936f4cc48114f1596c60c86e2ca7d33b7358be5
ERRO[0000] container "5c3039d13ecadafdd46c1cabe936f4cc48114f1596c60c86e2ca7d33b7358be5" is running, please stop it first 
FATA[0000] unable to remove container(s)

```

but this works:

```

docker@minikube:~$ sudo crictl stop 5c3039d13ecadafdd46c1cabe936f4cc48114f1596c60c86e2ca7d33b7358be5
5c3039d13ecadafdd46c1cabe936f4cc48114f1596c60c86e2ca7d33b7358be5
```