### PR TITLE
Doc fix: use LC_ALL which has priority for system locale instead of LANG

### DIFF
--- a/site/content/en/docs/contrib/translations.md
+++ b/site/content/en/docs/contrib/translations.md
@@ -79,11 +79,12 @@ All translations are stored in the top-level `translations` directory.
 
 * You now have a fresh minikube binary in the `out` directory. If your system locale is that of the language you added translations for, a simple `out/minikube start` will work as a test, assuming you translated phrases from `minikube start`. You can use whatever command you'd like in that way. 
 
-* If you have a different system locale, you can override the printed language using the LANG environment variable:
+* If you have a different system locale, you can override the printed language using the LC_ALL environment variable:
 	```
-	~/minikube$ LANG=fr out/minikube start
-	😄  minikube v1.9.0-beta.2 sur Darwin 10.14.6
-	✨  Choix automatique du driver hyperkit
+	~/minikube$ LC_ALL=fr out/minikube start
+	😄  minikube v1.9.2 sur Darwin 10.14.5
+	✨  Choix automatique du driver hyperkit. Autres choix: <no value>
+	👍  Starting control plane node minikube in cluster minikube
 	🔥  Création de VM hyperkit (CPUs=2, Mémoire=4000MB, Disque=20000MB)...
 	🐳  Préparation de Kubernetes v1.18.0 sur Docker 19.03.8...
 	🌟  Installation des addons: default-storageclass, storage-provisioner


### PR DESCRIPTION
### What type of PR is this?
/kind documentation

### What this PR does / why we need it:

The doc for translation says `use LANG environment variable`. But It doesn't work.
https://minikube.sigs.k8s.io/docs/contrib/translations/

```
LANG=en out/minikube start
😄  Darwin 10.14.5 上の minikube v1.9.2
```

This PR will fix the doc to use `LC_ALL` instead of `LANG`.

https://kubernetes.slack.com/archives/C1F5CT6Q1/p1586365055370200

### Does this PR introduce a user-facing change?

Yes. 

**Before this PR**
```
$ LANG=fr out/minikube start
😄  Darwin 10.14.5 上の minikube v1.9.2
```

**After this PR**
```
$ LC_ALL=fr out/minikube start
😄  minikube v1.9.2 sur Darwin 10.14.5
✨  Choix automatique du driver hyperkit. Autres choix: <no value>
👍  Starting control plane node minikube in cluster minikube
```

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```