### PR TITLE
Fix `minikube delete` output nodename missing with KIC driver

### DIFF
--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -208,7 +208,13 @@ func deleteProfileContainersAndVolumes(name string) {
 
 func deleteProfile(profile *config.Profile) error {
 	viper.Set(config.ProfileName, profile.Name)
-	deleteProfileContainersAndVolumes(profile.Name)
+	if profile.Config != nil {
+		// if driver is oci driver, delete containers and volumes
+		if driver.IsKIC(profile.Config.Driver) {
+			out.T(out.DeletingHost, `Deleting "{{.profile_name}}" in {{.driver_name}} ...`, out.V{"profile_name": profile.Name, "driver_name": profile.Config.Driver})
+			deleteProfileContainersAndVolumes(profile.Name)
+		}
+	}
 
 	api, err := machine.NewAPIClient()
 	if err != nil {


### PR DESCRIPTION
### What type of PR is this?
/kind bug
/kind cleanup

### What this PR does / why we need it:

When `minikube delete` with KIC driver is executed, the node name isn't outputed although other driver(virtualbox, hyperkit) does.

This PR fix that behavior. I added the deleted node name information.

### Which issue(s) this PR fixes:
Fixes #7517  

### Does this PR introduce a user-facing change?
Yes. 
This PR fixes the `minikube delete` command output(nodename).

#### Before this PR
**(single node)**
```
$ LC_ALL=en out/minikube start --driver docker
😄  minikube v1.9.2 on Darwin 10.14.5
✨  Using the docker driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating Kubernetes in docker container with (CPUs=2) (4 available), Memory=4000MB (8204MB available) ...
🐳  Preparing Kubernetes v1.18.0 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16
🌟  Enabling addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube"

$ LC_ALL=en out/minikube delete
🔥  Removing /Users/XXX/.minikube/machines/minikube ...
💀  Removed all traces of the "minikube" cluster.
```

**(multi node)**
```
$ LC_ALL=en out/minikube start --driver docker -n 2
😄  minikube v1.9.2 on Darwin 10.14.5
✨  Using the docker driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating Kubernetes in docker container with (CPUs=2) (4 available), Memory=4000MB (8204MB available) ...
🐳  Preparing Kubernetes v1.18.0 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16
🌟  Enabling addons: default-storageclass, storage-provisioner

👍  Starting node minikube-m02 in cluster minikube
🚜  Pulling base image ...
🔥  Creating Kubernetes in docker container with (CPUs=2) (4 available), Memory=4000MB (8204MB available) ...
🌐  Found network options:
    ▪ NO_PROXY=172.17.0.3
🐳  Preparing Kubernetes v1.18.0 on Docker 19.03.2 ...
🏄  Done! kubectl is now configured to use "minikube"

$ LC_ALL=en out/minikube delete
🔥  Deleting "minikube-m02" in docker ...
🔥  Removing /Users/XXX/.minikube/machines/minikube ...
💀  Removed all traces of the "minikube" cluster.
```

#### After this PR
**(single node)**
```
$ LC_ALL=en out/minikube start --driver docker
😄  minikube v1.9.2 on Darwin 10.14.5
✨  Using the docker driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating Kubernetes in docker container with (CPUs=2) (4 available), Memory=4000MB (8204MB available) ...
🐳  Preparing Kubernetes v1.18.0 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16
🌟  Enabling addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube"

$ LC_ALL=en out/minikube delete
🔥  Deleting "minikube" in docker ...
🔥  Removing /Users/XXX/.minikube/machines/minikube ...
💀  Removed all traces of the "minikube" cluster.
```

**(multi node)**
```
$ LC_ALL=en out/minikube start --driver docker -n 2
😄  minikube v1.9.2 on Darwin 10.14.5
✨  Using the docker driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating Kubernetes in docker container with (CPUs=2) (4 available), Memory=4000MB (8204MB available) ...
🐳  Preparing Kubernetes v1.18.0 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16
🌟  Enabling addons: default-storageclass, storage-provisioner

👍  Starting node minikube-m02 in cluster minikube
🚜  Pulling base image ...
🔥  Creating Kubernetes in docker container with (CPUs=2) (4 available), Memory=4000MB (8204MB available) ...
🌐  Found network options:
    ▪ NO_PROXY=172.17.0.3
🐳  Preparing Kubernetes v1.18.0 on Docker 19.03.2 ...
🏄  Done! kubectl is now configured to use "minikube"

$ LC_ALL=en out/minikube delete
🔥  Deleting "minikube" in docker ...
🔥  Deleting "minikube-m02" in docker ...
🔥  Removing /Users/XXX/.minikube/machines/minikube ...
💀  Removed all traces of the "minikube" cluster.
```

Added node name section in `minikube delete`.
`🔥  Deleting "minikube" in docker ...`

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```