### PR TITLE
make CommandRunner.Copy/Remove consistent across runners

### DIFF
--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -197,7 +197,7 @@ func enableOrDisableAddonInternal(cc *config.ClusterConfig, addon *assets.Addon,
 		if addon.IsTemplate() {
 			f, err = addon.Evaluate(data)
 			if err != nil {
-				return errors.Wrapf(err, "evaluate bundled addon %s asset", addon.GetAssetName())
+				return errors.Wrapf(err, "evaluate bundled addon %s asset", addon.GetSourcePath())
 			}
 
 		} else {

--- a/pkg/gvisor/enable.go
+++ b/pkg/gvisor/enable.go
@@ -181,7 +181,7 @@ func copyAssetToDest(targetName, dest string) error {
 	log.Printf("%s asset path: %s", targetName, src)
 	contents, err := ioutil.ReadFile(src)
 	if err != nil {
-		return errors.Wrapf(err, "getting contents of %s", asset.GetAssetName())
+		return errors.Wrapf(err, "getting contents of %s", asset.GetSourcePath())
 	}
 	if _, err := os.Stat(dest); err == nil {
 		if err := os.Remove(dest); err != nil {

--- a/pkg/minikube/bootstrapper/certs.go
+++ b/pkg/minikube/bootstrapper/certs.go
@@ -117,9 +117,8 @@ func SetupCerts(cmd command.Runner, k8s config.KubernetesConfig, n config.Node) 
 	}
 
 	for _, f := range copyableFiles {
-		glog.Infof("copying: %s/%s", f.GetTargetDir(), f.GetTargetName())
 		if err := cmd.Copy(f); err != nil {
-			return nil, errors.Wrapf(err, "Copy %s", f.GetAssetName())
+			return nil, errors.Wrapf(err, "Copy %s", f.GetSourcePath())
 		}
 	}
 

--- a/pkg/minikube/command/command_runner.go
+++ b/pkg/minikube/command/command_runner.go
@@ -17,12 +17,17 @@ limitations under the License.
 package command
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
+	"io"
+	"os"
 	"os/exec"
-	"path"
+	"strconv"
 	"strings"
+	"time"
 
+	"github.com/pkg/errors"
 	"k8s.io/minikube/pkg/minikube/assets"
 )
 
@@ -55,10 +60,6 @@ type Runner interface {
 	Remove(assets.CopyableFile) error
 }
 
-func getDeleteFileCommand(f assets.CopyableFile) string {
-	return fmt.Sprintf("sudo rm %s", path.Join(f.GetTargetDir(), f.GetTargetName()))
-}
-
 // Command returns a human readable command string that does not induce eye fatigue
 func (rr RunResult) Command() string {
 	var sb strings.Builder
@@ -83,4 +84,102 @@ func (rr RunResult) Output() string {
 		sb.WriteString(fmt.Sprintf("\n** stderr ** \n%s\n** /stderr **", rr.Stderr.Bytes()))
 	}
 	return sb.String()
+}
+
+// teePrefix copies bytes from a reader to writer, logging each new line.
+func teePrefix(prefix string, r io.Reader, w io.Writer, logger func(format string, args ...interface{})) error {
+	scanner := bufio.NewScanner(r)
+	scanner.Split(bufio.ScanBytes)
+	var line bytes.Buffer
+
+	for scanner.Scan() {
+		b := scanner.Bytes()
+		if _, err := w.Write(b); err != nil {
+			return err
+		}
+		if bytes.IndexAny(b, "\r\n") == 0 {
+			if line.Len() > 0 {
+				logger("%s%s", prefix, line.String())
+				line.Reset()
+			}
+			continue
+		}
+		line.Write(b)
+	}
+	// Catch trailing output in case stream does not end with a newline
+	if line.Len() > 0 {
+		logger("%s%s", prefix, line.String())
+	}
+	return nil
+}
+
+// fileExists checks that the same file exists on the other end
+func fileExists(r Runner, f assets.CopyableFile, dst string) (bool, error) {
+	// It's too difficult to tell if the file exists with the exact contents
+	if f.GetSourcePath() == assets.MemorySource {
+		return false, nil
+	}
+
+	// get file size and modtime of the source
+	srcSize := f.GetLength()
+	srcModTime, err := f.GetModTime()
+	if err != nil {
+		return false, err
+	}
+	if srcModTime.IsZero() {
+		return false, nil
+	}
+
+	// get file size and modtime of the destination
+	rr, err := r.RunCmd(exec.Command("stat", "-c", "%s %y", dst))
+	if err != nil {
+		if rr.ExitCode == 1 {
+			return false, nil
+		}
+
+		// avoid the noise because ssh doesn't propagate the exit code
+		if strings.HasSuffix(err.Error(), "status 1") {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	stdout := strings.TrimSpace(rr.Stdout.String())
+	outputs := strings.SplitN(stdout, " ", 2)
+	dstSize, err := strconv.Atoi(outputs[0])
+	if err != nil {
+		return false, err
+	}
+
+	dstModTime, err := time.Parse(layout, outputs[1])
+	if err != nil {
+		return false, err
+	}
+
+	if srcSize != dstSize {
+		return false, errors.New("source file and destination file are different sizes")
+	}
+
+	return srcModTime.Equal(dstModTime), nil
+}
+
+// writeFile is like ioutil.WriteFile, but does not require reading file into memory
+func writeFile(dst string, f assets.CopyableFile, perms os.FileMode) error {
+	w, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE, perms)
+	if err != nil {
+		return errors.Wrap(err, "create")
+	}
+	defer w.Close()
+
+	r := f.(io.Reader)
+	n, err := io.Copy(w, r)
+	if err != nil {
+		return errors.Wrap(err, "copy")
+	}
+
+	if n != int64(f.GetLength()) {
+		return fmt.Errorf("%s: expected to write %d bytes, but wrote %d instead", dst, f.GetLength(), n)
+	}
+	return w.Close()
 }

--- a/pkg/minikube/command/fake_runner.go
+++ b/pkg/minikube/command/fake_runner.go
@@ -97,13 +97,13 @@ func (f *FakeCommandRunner) Copy(file assets.CopyableFile) error {
 	if err != nil {
 		return errors.Wrapf(err, "error reading file: %+v", file)
 	}
-	f.fileMap.Store(file.GetAssetName(), b.String())
+	f.fileMap.Store(file.GetSourcePath(), b.String())
 	return nil
 }
 
 // Remove removes the filename, file contents key value pair from the stored map
 func (f *FakeCommandRunner) Remove(file assets.CopyableFile) error {
-	f.fileMap.Delete(file.GetAssetName())
+	f.fileMap.Delete(file.GetSourcePath())
 	return nil
 }
 

--- a/pkg/minikube/machine/filesync_test.go
+++ b/pkg/minikube/machine/filesync_test.go
@@ -149,7 +149,7 @@ func TestAssetsFromDir(t *testing.T) {
 
 			got := make(map[string]string)
 			for _, actualFile := range actualFiles {
-				got[actualFile.GetAssetName()] = actualFile.GetTargetDir()
+				got[actualFile.GetSourcePath()] = actualFile.GetTargetDir()
 			}
 			if diff := cmp.Diff(want, got); diff != "" {
 				t.Errorf("files differ: (-want +got)\n%s", diff)


### PR DESCRIPTION
While investigating #7541 I found some inconsistency between how the 3 runners copied files, so I did some cleanup to help me find the underlying issue, if not fix it entirely:

- `Copy` now consistently logs and warn about 0-byte assets across all runners
- `kiRunner.Copy` now checks for pre-existing files (only over a certain size)
- `kicRunner.Copy` now buffer copies instead of reading the entire file into memory at once
- `Remove` now logs across all runners
-  Moved `teePrefix` from `ssh_runner.go` to `command_runner.go`
- For clarity, `asset.GetAssetName()` was renamed to `asset.GetSourcePath()`

I did some performance testing on macOS (cold and warm start, docker and hyperkit), and found the performance improvements negligible. The only scenario that showed a performance benefit  was docker warm start (9% faster).
 