### PR TITLE
contrib docs: Mention Github's markdown editor

### DIFF
--- a/site/content/en/docs/contrib/documentation.en.md
+++ b/site/content/en/docs/contrib/documentation.en.md
@@ -12,6 +12,10 @@ minikube's documentation is in [Markdown](https://www.markdownguide.org/cheat-sh
 
 In production, the minikube website is served using [Netlify](https://netlify.com/)
 
+## Small or cosmetic contributions
+
+Use Github's repositories and markdown editor as described by [Kubernetes's general guideline for documentation contributing](https://kubernetes.io/docs/contribute/start/#submit-a-pull-request)
+
 ## Local documentation website
 
 To serve documentation pages locally, clone the `minikube` repository and run:


### PR DESCRIPTION
Refers to Github's repositories and integrated markdown editor that already exists in Kubernetes's general guidelines.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
I didn't find out how to rebase from github's gui so I recreate another PR.
