### PR TITLE
Make test.sh output non-verbose again

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -60,7 +60,7 @@ then
     echo "mode: count" >"${COVERAGE_PATH}"
     pkgs=$(go list -f '{{ if .TestGoFiles }}{{.ImportPath}}{{end}}' ./cmd/... ./pkg/... | xargs)
     go test \
-        -v -ldflags="$MINIKUBE_LDFLAGS" \
+        -ldflags="$MINIKUBE_LDFLAGS" \
         -tags "container_image_ostree_stub containers_image_openpgp" \
         -covermode=count \
         -coverprofile="${cov_tmp}" \


### PR DESCRIPTION
Fixes a regression from https://github.com/kubernetes/minikube/commit/6fdecf2ebf86d1261449905f095c84447533cd0a#diff-1b531c5e405e0bc95890d52cf2f2f5b5 and makes `test.sh` usable by mere mortals again.
