### PR TITLE
Add master node/worker node type to `minikube status`

### DIFF
--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -72,14 +72,14 @@ const (
 	minikubeNotRunningStatusFlag = 1 << 0
 	clusterNotRunningStatusFlag  = 1 << 1
 	k8sNotRunningStatusFlag      = 1 << 2
-	defaultStatusFormat          = `{{.Name}}
+	defaultStatusFormat          = `master node: {{.Name}}
 host: {{.Host}}
 kubelet: {{.Kubelet}}
 apiserver: {{.APIServer}}
 kubeconfig: {{.Kubeconfig}}
 
 `
-	workerStatusFormat = `{{.Name}}
+	workerStatusFormat = `worker node: {{.Name}}
 host: {{.Host}}
 kubelet: {{.Kubelet}}
 

--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -72,14 +72,16 @@ const (
 	minikubeNotRunningStatusFlag = 1 << 0
 	clusterNotRunningStatusFlag  = 1 << 1
 	k8sNotRunningStatusFlag      = 1 << 2
-	defaultStatusFormat          = `master node: {{.Name}}
+	defaultStatusFormat          = `{{.Name}}
+type: Control Plane
 host: {{.Host}}
 kubelet: {{.Kubelet}}
 apiserver: {{.APIServer}}
 kubeconfig: {{.Kubeconfig}}
 
 `
-	workerStatusFormat = `worker node: {{.Name}}
+	workerStatusFormat = `{{.Name}}
+type: Worker
 host: {{.Host}}
 kubelet: {{.Kubelet}}
 

--- a/cmd/minikube/cmd/status_test.go
+++ b/cmd/minikube/cmd/status_test.go
@@ -52,17 +52,17 @@ func TestStatusText(t *testing.T) {
 		{
 			name:  "ok",
 			state: &Status{Name: "minikube", Host: "Running", Kubelet: "Running", APIServer: "Running", Kubeconfig: Configured},
-			want:  "minikube\nhost: Running\nkubelet: Running\napiserver: Running\nkubeconfig: Configured\n\n",
+			want:  "master node: minikube\nhost: Running\nkubelet: Running\napiserver: Running\nkubeconfig: Configured\n\n",
 		},
 		{
 			name:  "paused",
 			state: &Status{Name: "minikube", Host: "Running", Kubelet: "Stopped", APIServer: "Paused", Kubeconfig: Configured},
-			want:  "minikube\nhost: Running\nkubelet: Stopped\napiserver: Paused\nkubeconfig: Configured\n\n",
+			want:  "master node: minikube\nhost: Running\nkubelet: Stopped\napiserver: Paused\nkubeconfig: Configured\n\n",
 		},
 		{
 			name:  "down",
 			state: &Status{Name: "minikube", Host: "Stopped", Kubelet: "Stopped", APIServer: "Stopped", Kubeconfig: Misconfigured},
-			want:  "minikube\nhost: Stopped\nkubelet: Stopped\napiserver: Stopped\nkubeconfig: Misconfigured\n\n\nWARNING: Your kubectl is pointing to stale minikube-vm.\nTo fix the kubectl context, run `minikube update-context`\n",
+			want:  "master node: minikube\nhost: Stopped\nkubelet: Stopped\napiserver: Stopped\nkubeconfig: Misconfigured\n\n\nWARNING: Your kubectl is pointing to stale minikube-vm.\nTo fix the kubectl context, run `minikube update-context`\n",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/minikube/cmd/status_test.go
+++ b/cmd/minikube/cmd/status_test.go
@@ -52,17 +52,17 @@ func TestStatusText(t *testing.T) {
 		{
 			name:  "ok",
 			state: &Status{Name: "minikube", Host: "Running", Kubelet: "Running", APIServer: "Running", Kubeconfig: Configured},
-			want:  "master node: minikube\nhost: Running\nkubelet: Running\napiserver: Running\nkubeconfig: Configured\n\n",
+			want:  "minikube\ntype: Control Plane\nhost: Running\nkubelet: Running\napiserver: Running\nkubeconfig: Configured\n\n",
 		},
 		{
 			name:  "paused",
 			state: &Status{Name: "minikube", Host: "Running", Kubelet: "Stopped", APIServer: "Paused", Kubeconfig: Configured},
-			want:  "master node: minikube\nhost: Running\nkubelet: Stopped\napiserver: Paused\nkubeconfig: Configured\n\n",
+			want:  "minikube\ntype: Control Plane\nhost: Running\nkubelet: Stopped\napiserver: Paused\nkubeconfig: Configured\n\n",
 		},
 		{
 			name:  "down",
 			state: &Status{Name: "minikube", Host: "Stopped", Kubelet: "Stopped", APIServer: "Stopped", Kubeconfig: Misconfigured},
-			want:  "master node: minikube\nhost: Stopped\nkubelet: Stopped\napiserver: Stopped\nkubeconfig: Misconfigured\n\n\nWARNING: Your kubectl is pointing to stale minikube-vm.\nTo fix the kubectl context, run `minikube update-context`\n",
+			want:  "minikube\ntype: Control Plane\nhost: Stopped\nkubelet: Stopped\napiserver: Stopped\nkubeconfig: Misconfigured\n\n\nWARNING: Your kubectl is pointing to stale minikube-vm.\nTo fix the kubectl context, run `minikube update-context`\n",
 		},
 	}
 	for _, tc := range tests {

--- a/site/content/en/docs/commands/status.md
+++ b/site/content/en/docs/commands/status.md
@@ -24,7 +24,7 @@ minikube status [flags]
 
 ```
   -f, --format string   Go template format string for the status output.  The format for Go templates can be found here: https://golang.org/pkg/text/template/
-                        For the list accessible variables for the template, see the struct values here: https://godoc.org/k8s.io/minikube/cmd/minikube/cmd#Status (default "{{.Name}}\nhost: {{.Host}}\nkubelet: {{.Kubelet}}\napiserver: {{.APIServer}}\nkubeconfig: {{.Kubeconfig}}\n\n")
+                        For the list accessible variables for the template, see the struct values here: https://godoc.org/k8s.io/minikube/cmd/minikube/cmd#Status (default "master node: {{.Name}}\nhost: {{.Host}}\nkubelet: {{.Kubelet}}\napiserver: {{.APIServer}}\nkubeconfig: {{.Kubeconfig}}\n\n")
   -h, --help            help for status
   -o, --output string   minikube status --output OUTPUT. json, text (default "text")
 ```

--- a/site/content/en/docs/commands/status.md
+++ b/site/content/en/docs/commands/status.md
@@ -24,7 +24,7 @@ minikube status [flags]
 
 ```
   -f, --format string   Go template format string for the status output.  The format for Go templates can be found here: https://golang.org/pkg/text/template/
-                        For the list accessible variables for the template, see the struct values here: https://godoc.org/k8s.io/minikube/cmd/minikube/cmd#Status (default "master node: {{.Name}}\nhost: {{.Host}}\nkubelet: {{.Kubelet}}\napiserver: {{.APIServer}}\nkubeconfig: {{.Kubeconfig}}\n\n")
+                        For the list accessible variables for the template, see the struct values here: https://godoc.org/k8s.io/minikube/cmd/minikube/cmd#Status (default "{{.Name}}\ntype: Control Plane\nhost: {{.Host}}\nkubelet: {{.Kubelet}}\napiserver: {{.APIServer}}\nkubeconfig: {{.Kubeconfig}}\n\n")
   -h, --help            help for status
   -o, --output string   minikube status --output OUTPUT. json, text (default "text")
 ```

--- a/site/content/en/docs/tutorials/multi_node.md
+++ b/site/content/en/docs/tutorials/multi_node.md
@@ -43,6 +43,7 @@ multinode-demo       Ready    master   9m58s   v1.18.0
 multinode-demo-m02   Ready    <none>   9m5s    v1.18.0
 ```
 
+NOTE: You can also check the status of your nodes:
 ```
 $ minikube status
 multinode-demo

--- a/site/content/en/docs/tutorials/multi_node.md
+++ b/site/content/en/docs/tutorials/multi_node.md
@@ -21,12 +21,13 @@ date: 2019-11-24
 minikube start --nodes 2 -p multinode-demo --network-plugin=cni --extra-config=kubeadm.pod-network-cidr=10.244.0.0/16
 😄  [multinode-demo] minikube v1.9.2 on Darwin 10.14.6
 ✨  Automatically selected the hyperkit driver
-👍  Starting control plane node m01 in cluster multinode-demo
+👍  Starting control plane node multinode-demo in cluster multinode-demo
 🔥  Creating hyperkit VM (CPUs=2, Memory=4000MB, Disk=20000MB) ...
 🐳  Preparing Kubernetes v1.18.0 on Docker 19.03.8 ...
+    ▪ kubeadm.pod-network-cidr=10.244.0.0/16
 🌟  Enabling addons: default-storageclass, storage-provisioner
 
-👍  Starting node m02 in cluster multinode-demo
+👍  Starting node multinode-demo-m02 in cluster multinode-demo
 🔥  Creating hyperkit VM (CPUs=2, Memory=4000MB, Disk=20000MB) ...
 🌐  Found network options:
     ▪ NO_PROXY=192.168.64.213
@@ -40,6 +41,21 @@ kubectl get nodes
 NAME                 STATUS   ROLES    AGE     VERSION
 multinode-demo       Ready    master   9m58s   v1.18.0
 multinode-demo-m02   Ready    <none>   9m5s    v1.18.0
+```
+
+```
+$ minikube status
+multinode-demo
+type: Control Plane
+host: Running
+kubelet: Running
+apiserver: Running
+kubeconfig: Configured
+
+multinode-demo-m02
+type: Worker
+host: Running
+kubelet: Running
 ```
 
 - Install a CNI (e.g. flannel):


### PR DESCRIPTION
### What type of PR is this?
/kind ux

### What this PR does / why we need it:

When `minikube status` is executed, the node name & component status are printed.
It don't have node type like master or worker.

This PR add node type(master/worker) to `minikube status` for user to know node clearly. 

### Which issue(s) this PR fixes:
Fixes #7475 

### Does this PR introduce a user-facing change?
Yes. 
This PR fixes the `minikube status` command output(node type).

**Before this PR**

```
$ out/minikube status
minikube
host: Running
kubelet: Running
apiserver: Running
kubeconfig: Configured

minikube-m02
host: Running
kubelet: Running
```
**After this PR**

```
$ out/minikube status
master node: minikube
host: Running
kubelet: Running
apiserver: Running
kubeconfig: Configured

worker node: minikube-m02
host: Running
kubelet: Running
```

Added node type `master node` and `worker node`.

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```