### PR TITLE
fix broken link

### DIFF
--- a/site/content/en/docs/handbook/pushing.md
+++ b/site/content/en/docs/handbook/pushing.md
@@ -19,7 +19,7 @@ Here is a comparison table to help you choose:
 |---	|---	|---	|---	|---	|
 |  [docker-env command](/docs/handbook/pushing/#1pushing-directly-to-the-in-cluster-docker-daemon-docker-env)	|   only docker	|  	|  good 	|
 |  [podman-env command](/docs/handbook/pushing/#3-pushing-directly-to-in-cluster-crio-podman-env)	|   only cri-o	|     |  good 	|
-|  [cache add command](/pushing/#push-images-using-cache-command) 	|  all 	|    	|  ok 	|
+|  [cache add command](/pushing/#2-push-images-using-cache-command) 	|  all 	|    	|  ok 	|
 |  [registry addon](/docs/handbook/pushing/#4-pushing-to-an-in-cluster-using-registry-addon)   |   all	|   work in progress for [docker on mac](https://github.com/kubernetes/minikube/issues/7535) |  ok 	|
 |  [minikube ssh](/docs/handbook/pushing/#5-building-images-inside-of-minikube-using-ssh)   |   all	|    |  best 	|
 
@@ -76,7 +76,7 @@ more information on [docker-env](https://minikube.sigs.k8s.io/docs/commands/dock
 
 ---
 
-## 2.Push images using 'cache' command.
+## 2. Push images using 'cache' command.
 
 From your host, you can push a Docker image directly to minikube. This image will be cached and automatically pulled into all future minikube clusters created on the machine
 


### PR DESCRIPTION
Ran into a broken link:

The 3rd row in the table here: https://minikube.sigs.k8s.io/docs/handbook/pushing/#comparison-table-for-different-methods points to https://minikube.sigs.k8s.io/pushing/#push-images-using-cache-command

