### PR TITLE
wip: Improve kic start/stop and handle apparmor sec opt

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,7 +129,7 @@ jobs:
         chmod a+x e2e-*
         chmod a+x minikube-*
         START_TIME=$(date -u +%s)
-        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -test.timeout=80m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -test.parallel=2 -test.timeout=80m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
         TIME_ELAPSED=$(($END_TIME-$START_TIME))
         min=$((${TIME_ELAPSED}/60))
@@ -218,7 +218,7 @@ jobs:
         chmod a+x e2e-*
         chmod a+x minikube-*
         START_TIME=$(date -u +%s)
-        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--driver=docker -test.timeout=80m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--driver=docker -test.parallel=2 -test.timeout=80m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
         TIME_ELAPSED=$(($END_TIME-$START_TIME))
         min=$((${TIME_ELAPSED}/60))
@@ -283,7 +283,7 @@ jobs:
         mkdir -p report
         mkdir -p testhome
         START_TIME=$(date -u +%s)
-        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome minikube_binaries/e2e-windows-amd64.exe -minikube-start-args=--vm-driver=docker -binary=minikube_binaries/minikube-windows-amd64.exe -test.v -test.timeout=65m 2>&1 | tee ./report/testout.txt
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome minikube_binaries/e2e-windows-amd64.exe -minikube-start-args=--vm-driver=docker -test.parallel=2 -binary=minikube_binaries/minikube-windows-amd64.exe -test.v -test.timeout=65m 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
         TIME_ELAPSED=$(($END_TIME-$START_TIME)) 
         min=$((${TIME_ELAPSED}/60))
@@ -525,7 +525,7 @@ jobs:
           chmod a+x e2e-*
           chmod a+x minikube-*
           START_TIME=$(date -u +%s)
-          KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome sudo -E ./e2e-linux-amd64 -minikube-start-args=--driver=podman -test.timeout=30m -test.v -timeout-multiplier=1 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+          KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome sudo -E ./e2e-linux-amd64 -minikube-start-args=--driver=podman -test.parallel=1 -test.timeout=30m -test.v -timeout-multiplier=1 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
           END_TIME=$(date -u +%s)
           TIME_ELAPSED=$(($END_TIME-$START_TIME))
           min=$((${TIME_ELAPSED}/60))

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,7 +129,7 @@ jobs:
         chmod a+x e2e-*
         chmod a+x minikube-*
         START_TIME=$(date -u +%s)
-        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -test.parallel=1 -test.timeout=80m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -test.parallel=2 -test.run TestFunctional -test.timeout=30m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
         TIME_ELAPSED=$(($END_TIME-$START_TIME))
         min=$((${TIME_ELAPSED}/60))
@@ -218,7 +218,7 @@ jobs:
         chmod a+x e2e-*
         chmod a+x minikube-*
         START_TIME=$(date -u +%s)
-        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--driver=docker -test.parallel=1 -test.timeout=80m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--driver=docker -test.parallel=2 -test.run TestFunctional -test.timeout=30m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
         TIME_ELAPSED=$(($END_TIME-$START_TIME))
         min=$((${TIME_ELAPSED}/60))
@@ -283,7 +283,7 @@ jobs:
         mkdir -p report
         mkdir -p testhome
         START_TIME=$(date -u +%s)
-        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome minikube_binaries/e2e-windows-amd64.exe -minikube-start-args=--vm-driver=docker -test.parallel=1 -binary=minikube_binaries/minikube-windows-amd64.exe -test.v -test.timeout=30m 2>&1 | tee ./report/testout.txt
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome minikube_binaries/e2e-windows-amd64.exe -minikube-start-args=--vm-driver=docker -test.parallel=2 -test.run TestFunctional -test.timeout=30m -binary=minikube_binaries/minikube-windows-amd64.exe -test.v -test.timeout=65m 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
         TIME_ELAPSED=$(($END_TIME-$START_TIME)) 
         min=$((${TIME_ELAPSED}/60))
@@ -525,7 +525,7 @@ jobs:
           chmod a+x e2e-*
           chmod a+x minikube-*
           START_TIME=$(date -u +%s)
-          KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome sudo -E ./e2e-linux-amd64 -minikube-start-args=--driver=podman -test.parallel=1 -test.timeout=30m -test.v -timeout-multiplier=1 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+          KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome sudo -E ./e2e-linux-amd64 -minikube-start-args=--driver=podman -test.timeout=30m -test.v -timeout-multiplier=1 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
           END_TIME=$(date -u +%s)
           TIME_ELAPSED=$(($END_TIME-$START_TIME))
           min=$((${TIME_ELAPSED}/60))

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -241,70 +241,6 @@ jobs:
         numPass=$(echo $STAT | jq '.NumberOfPass')
         echo "*** $numPass Passed ***"
         if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
-  functional_test_docker_windows:
-    needs: [build_minikube]
-    env:
-      TIME_ELAPSED: time
-      JOB_NAME: "Docker_on_windows"
-      COMMIT_STATUS: ""
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Docker Info
-      shell: bash
-      run: |
-        docker info || true
-        docker version || true
-        docker ps || true
-    - name: Download gopogh
-      run: |
-        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.16/gopogh.exe
-      shell: bash
-    - name: Download binaries
-      uses: actions/download-artifact@v1
-      with:
-        name: minikube_binaries
-    - name: run integration test
-      continue-on-error: true
-      run: |
-        set +euo pipefail
-        mkdir -p report
-        mkdir -p testhome
-        START_TIME=$(date -u +%s)
-        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome minikube_binaries/e2e-windows-amd64.exe -minikube-start-args=--vm-driver=docker -test.parallel=1 -test.run TestFunctional -test.timeout=30m -binary=minikube_binaries/minikube-windows-amd64.exe -test.v -test.timeout=65m 2>&1 | tee ./report/testout.txt
-        END_TIME=$(date -u +%s)
-        TIME_ELAPSED=$(($END_TIME-$START_TIME)) 
-        min=$((${TIME_ELAPSED}/60))
-        sec=$((${TIME_ELAPSED}%60))
-        TIME_ELAPSED="${min} min $sec seconds"
-        echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
-      shell: bash
-    - name: Generate html report
-      run: |
-        go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
-        STAT=$(${GITHUB_WORKSPACE}/gopogh.exe -in ./report/testout.json -out ./report/testout.html -name " $GITHUB_REF" -repo "${JOB_NAME} ${GITHUB_REF} ${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
-        echo status: ${STAT}
-        FailNum=$(echo $STAT | jq '.NumberOfFail')
-        TestsNum=$(echo $STAT | jq '.NumberOfTests')       
-        GOPOGH_RESULT="${JOB_NAME} : completed with ${FailNum} / ${TestsNum} failures in ${TIME_ELAPSED}"
-        echo ::set-env name=GOPOGH_RESULT::${GOPOGH_RESULT}
-        echo ::set-env name=STAT::${STAT}
-      shell: bash
-    - uses: actions/upload-artifact@v1
-      with:
-        name: docker_on_windows
-        path: report
-    - name: The End Result
-      run: |
-        echo ${GOPOGH_RESULT}
-        numFail=$(echo $STAT | jq '.NumberOfFail')
-        echo "----------------${numFail} Failures----------------------------"
-        echo $STAT | jq '.FailedTests' || true
-        echo "--------------------------------------------"
-        numPass=$(echo $STAT | jq '.NumberOfPass')
-        echo "*** $numPass Passed ***"
-        if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
-      shell: bash
   baremetal_ubuntu16_04:
     needs: [build_minikube]
     env:
@@ -552,7 +488,7 @@ jobs:
   # collect all the reports and upload
   upload_all_reports:
     if: always()
-    needs: [functional_test_docker_ubuntu_16_04, functional_test_docker_ubuntu_18_04, functional_test_docker_windows, baremetal_ubuntu16_04, baremetal_ubuntu18_04, functional_test_podman_experimental]
+    needs: [functional_test_docker_ubuntu_16_04, functional_test_docker_ubuntu_18_04,baremetal_ubuntu16_04, baremetal_ubuntu18_04, functional_test_podman_experimental]
     runs-on: ubuntu-18.04
     steps:
     - name: Download Results docker_ubuntu_16_04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,7 +129,7 @@ jobs:
         chmod a+x e2e-*
         chmod a+x minikube-*
         START_TIME=$(date -u +%s)
-        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -test.parallel=2 -test.timeout=80m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -test.parallel=1 -test.timeout=80m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
         TIME_ELAPSED=$(($END_TIME-$START_TIME))
         min=$((${TIME_ELAPSED}/60))
@@ -218,7 +218,7 @@ jobs:
         chmod a+x e2e-*
         chmod a+x minikube-*
         START_TIME=$(date -u +%s)
-        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--driver=docker -test.parallel=2 -test.timeout=80m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--driver=docker -test.parallel=1 -test.timeout=80m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
         TIME_ELAPSED=$(($END_TIME-$START_TIME))
         min=$((${TIME_ELAPSED}/60))
@@ -283,7 +283,7 @@ jobs:
         mkdir -p report
         mkdir -p testhome
         START_TIME=$(date -u +%s)
-        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome minikube_binaries/e2e-windows-amd64.exe -minikube-start-args=--vm-driver=docker -test.parallel=2 -binary=minikube_binaries/minikube-windows-amd64.exe -test.v -test.timeout=65m 2>&1 | tee ./report/testout.txt
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome minikube_binaries/e2e-windows-amd64.exe -minikube-start-args=--vm-driver=docker -test.parallel=1 -binary=minikube_binaries/minikube-windows-amd64.exe -test.v -test.timeout=30m 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
         TIME_ELAPSED=$(($END_TIME-$START_TIME)) 
         min=$((${TIME_ELAPSED}/60))

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,10 +6,6 @@ jobs:
   # Runs before all other jobs
   # builds the minikube binaries
   build_minikube:
-    env:
-      TIME_ELAPSED: time
-      JOB_NAME: "Docker_Ubuntu_16_04"
-      GOPOGH_RESULT: ""
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
@@ -35,10 +31,6 @@ jobs:
         name: minikube_binaries
         path: out
   lint:
-    env:
-      TIME_ELAPSED: time
-      JOB_NAME: "lint"
-      GOPOGH_RESULT: ""
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
@@ -54,10 +46,6 @@ jobs:
       run : make test
       continue-on-error: false
   unit_test:
-    env:
-      TIME_ELAPSED: time
-      JOB_NAME: "unit_test"
-      GOPOGH_RESULT: ""
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
@@ -75,7 +63,7 @@ jobs:
       continue-on-error: false
   # Run the following integration tests after the build_minikube
   # They will run in parallel and use the binaries in previous step
-  docker_ubuntu_16_04:
+  functional_test_docker_ubuntu_16_04:
     needs: [build_minikube]
     env:
       TIME_ELAPSED: time
@@ -129,7 +117,7 @@ jobs:
         chmod a+x e2e-*
         chmod a+x minikube-*
         START_TIME=$(date -u +%s)
-        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -test.parallel=2 -test.run TestFunctional -test.timeout=30m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -test.parallel=1 -test.run TestFunctional -test.timeout=30m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
         TIME_ELAPSED=$(($END_TIME-$START_TIME))
         min=$((${TIME_ELAPSED}/60))
@@ -164,7 +152,7 @@ jobs:
         numPass=$(echo $STAT | jq '.NumberOfPass')
         echo "*** $numPass Passed ***"
         if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
-  docker_ubuntu_18_04:
+  functional_test_docker_ubuntu_18_04:
     runs-on: ubuntu-18.04
     env:
       TIME_ELAPSED: time
@@ -218,7 +206,7 @@ jobs:
         chmod a+x e2e-*
         chmod a+x minikube-*
         START_TIME=$(date -u +%s)
-        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--driver=docker -test.parallel=2 -test.run TestFunctional -test.timeout=30m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--driver=docker -test.parallel=1 -test.run TestFunctional -test.timeout=30m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
         TIME_ELAPSED=$(($END_TIME-$START_TIME))
         min=$((${TIME_ELAPSED}/60))
@@ -253,7 +241,7 @@ jobs:
         numPass=$(echo $STAT | jq '.NumberOfPass')
         echo "*** $numPass Passed ***"
         if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
-  docker_on_windows:
+  functional_test_docker_windows:
     needs: [build_minikube]
     env:
       TIME_ELAPSED: time
@@ -283,7 +271,7 @@ jobs:
         mkdir -p report
         mkdir -p testhome
         START_TIME=$(date -u +%s)
-        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome minikube_binaries/e2e-windows-amd64.exe -minikube-start-args=--vm-driver=docker -test.parallel=2 -test.run TestFunctional -test.timeout=30m -binary=minikube_binaries/minikube-windows-amd64.exe -test.v -test.timeout=65m 2>&1 | tee ./report/testout.txt
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome minikube_binaries/e2e-windows-amd64.exe -minikube-start-args=--vm-driver=docker -test.parallel=1 -test.run TestFunctional -test.timeout=30m -binary=minikube_binaries/minikube-windows-amd64.exe -test.v -test.timeout=65m 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
         TIME_ELAPSED=$(($END_TIME-$START_TIME)) 
         min=$((${TIME_ELAPSED}/60))
@@ -317,7 +305,7 @@ jobs:
         echo "*** $numPass Passed ***"
         if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
       shell: bash
-  none_ubuntu16_04:
+  baremetal_ubuntu16_04:
     needs: [build_minikube]
     env:
       TIME_ELAPSED: time
@@ -398,7 +386,7 @@ jobs:
         numPass=$(echo $STAT | jq '.NumberOfPass')
         echo "*** $numPass Passed ***"
         if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
-  none_ubuntu18_04:
+  baremetal_ubuntu18_04:
     needs: [build_minikube]
     env:
       TIME_ELAPSED: time
@@ -479,7 +467,7 @@ jobs:
         numPass=$(echo $STAT | jq '.NumberOfPass')
         echo "*** $numPass Passed ***"
         if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
-  podman_ubuntu_18_04_experimental:
+  functional_test_podman_experimental:
       needs: [build_minikube]
       env:
         TIME_ELAPSED: time
@@ -525,7 +513,7 @@ jobs:
           chmod a+x e2e-*
           chmod a+x minikube-*
           START_TIME=$(date -u +%s)
-          KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome sudo -E ./e2e-linux-amd64 -minikube-start-args=--driver=podman -test.timeout=30m -test.v -timeout-multiplier=1 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+          KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome sudo -E ./e2e-linux-amd64 -minikube-start-args=--driver=podman -test.parallel=1 -test.run TestFunctional -test.timeout=30m -test.v -timeout-multiplier=1 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
           END_TIME=$(date -u +%s)
           TIME_ELAPSED=$(($END_TIME-$START_TIME))
           min=$((${TIME_ELAPSED}/60))
@@ -564,7 +552,7 @@ jobs:
   # collect all the reports and upload
   upload_all_reports:
     if: always()
-    needs: [docker_ubuntu_16_04,docker_ubuntu_18_04,none_ubuntu16_04,none_ubuntu18_04,podman_ubuntu_18_04_experimental]
+    needs: [functional_test_docker_ubuntu_16_04, functional_test_docker_ubuntu_18_04, functional_test_docker_windows, none_ubuntu16_04, baremetal_ubuntu16_04, baremetal_ubuntu18_04, functional_test_podman_experimental]
     runs-on: ubuntu-18.04
     steps:
     - name: Download Results docker_ubuntu_16_04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -552,7 +552,7 @@ jobs:
   # collect all the reports and upload
   upload_all_reports:
     if: always()
-    needs: [functional_test_docker_ubuntu_16_04, functional_test_docker_ubuntu_18_04, functional_test_docker_windows, none_ubuntu16_04, baremetal_ubuntu16_04, baremetal_ubuntu18_04, functional_test_podman_experimental]
+    needs: [functional_test_docker_ubuntu_16_04, functional_test_docker_ubuntu_18_04, functional_test_docker_windows, baremetal_ubuntu16_04, baremetal_ubuntu18_04, functional_test_podman_experimental]
     runs-on: ubuntu-18.04
     steps:
     - name: Download Results docker_ubuntu_16_04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,7 +117,7 @@ jobs:
         chmod a+x e2e-*
         chmod a+x minikube-*
         START_TIME=$(date -u +%s)
-        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker -test.parallel=1 -test.run TestFunctional -test.timeout=30m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker  -test.run TestFunctional -test.timeout=30m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
         TIME_ELAPSED=$(($END_TIME-$START_TIME))
         min=$((${TIME_ELAPSED}/60))
@@ -206,7 +206,7 @@ jobs:
         chmod a+x e2e-*
         chmod a+x minikube-*
         START_TIME=$(date -u +%s)
-        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--driver=docker -test.parallel=1 -test.run TestFunctional -test.timeout=30m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--driver=docker  -test.run TestFunctional -test.timeout=30m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
         TIME_ELAPSED=$(($END_TIME-$START_TIME))
         min=$((${TIME_ELAPSED}/60))
@@ -403,92 +403,11 @@ jobs:
         numPass=$(echo $STAT | jq '.NumberOfPass')
         echo "*** $numPass Passed ***"
         if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
-  functional_test_podman_experimental:
-      needs: [build_minikube]
-      env:
-        TIME_ELAPSED: time
-        JOB_NAME: "Podman_Ubuntu_18_04"
-        GOPOGH_RESULT: ""
-        SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
-      runs-on: ubuntu-18.04
-      steps:
-      - name: Install kubectl
-        shell: bash
-        run: |
-          curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
-          sudo install kubectl /usr/local/bin/kubectl
-          kubectl version --client=true
-      - name: Install podman
-        shell: bash
-        run: |
-          . /etc/os-release
-          sudo sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
-          wget -q https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_${VERSION_ID}/Release.key -O- | sudo apt-key add -
-          sudo apt-key add - < Release.key || true
-          sudo apt-get update -qq
-          sudo apt-get -qq -y install podman
-          sudo podman version || true
-          sudo podman info || true
-      - name: Install gopogh
-        shell: bash
-        run: |
-          curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.18/gopogh-linux-amd64
-          sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
-      - name: Download binaries
-        uses: actions/download-artifact@v1
-        with:
-          name: minikube_binaries
-      - name: Run Integration Test
-        continue-on-error: true
-        # bash {0} to allow test to continue to next step. in case of
-        shell: bash {0}
-        run: |
-          cd minikube_binaries
-          mkdir -p report
-          mkdir -p testhome
-          chmod a+x e2e-*
-          chmod a+x minikube-*
-          START_TIME=$(date -u +%s)
-          KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome sudo -E ./e2e-linux-amd64 -minikube-start-args=--driver=podman -test.parallel=1 -test.run TestFunctional -test.timeout=30m -test.v -timeout-multiplier=1 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
-          END_TIME=$(date -u +%s)
-          TIME_ELAPSED=$(($END_TIME-$START_TIME))
-          min=$((${TIME_ELAPSED}/60))
-          sec=$((${TIME_ELAPSED}%60))
-          TIME_ELAPSED="${min} min $sec seconds "
-          echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
-      - name: Generate HTML Report
-        shell: bash
-        run: |
-          cd minikube_binaries
-          export PATH=${PATH}:`go env GOPATH`/bin
-          go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
-          STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name "${JOB_NAME} ${GITHUB_REF}" -repo "${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
-          echo status: ${STAT}
-          FailNum=$(echo $STAT | jq '.NumberOfFail')
-          TestsNum=$(echo $STAT | jq '.NumberOfTests')
-          GOPOGH_RESULT="${JOB_NAME} : completed with ${FailNum} / ${TestsNum} failures in ${TIME_ELAPSED}"
-          echo ::set-env name=GOPOGH_RESULT::${GOPOGH_RESULT}
-          echo ::set-env name=STAT::${STAT}
-      - uses: actions/upload-artifact@v1
-        with:
-          name: podman_ubuntu_18_04
-          path: minikube_binaries/report
-      - name: The End Result - Podman On Ubuntu 18:04
-        shell: bash
-        run: |
-          echo ${GOPOGH_RESULT}
-          numFail=$(echo $STAT | jq '.NumberOfFail')
-          echo "----------------${numFail} Failures----------------------------"
-          echo $STAT | jq '.FailedTests' || true
-          echo "-------------------------------------------------------"
-          numPass=$(echo $STAT | jq '.NumberOfPass')
-          echo "*** $numPass Passed ***"
-          if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
   # After all 4 integration tests finished
   # collect all the reports and upload
   upload_all_reports:
     if: always()
-    needs: [functional_test_docker_ubuntu_16_04, functional_test_docker_ubuntu_18_04,baremetal_ubuntu16_04, baremetal_ubuntu18_04, functional_test_podman_experimental]
+    needs: [functional_test_docker_ubuntu_16_04, functional_test_docker_ubuntu_18_04,baremetal_ubuntu16_04, baremetal_ubuntu18_04]
     runs-on: ubuntu-18.04
     steps:
     - name: Download Results docker_ubuntu_16_04
@@ -511,15 +430,6 @@ jobs:
       run: |
         mkdir -p all_reports
         cp -r docker_ubuntu_18_04 ./all_reports/
-    - name: download results docker_on_windows
-      uses: actions/download-artifact@v1
-      with:
-        name: docker_on_windows
-    - name: cp to all_report
-      shell: bash
-      run: |
-        mkdir -p all_reports
-        cp -r docker_on_windows ./all_reports/
     - name: Download Results none_ubuntu16_04
       uses: actions/download-artifact@v1
       with:
@@ -540,16 +450,6 @@ jobs:
       run: |
         mkdir -p all_reports
         cp -r none_ubuntu18_04 ./all_reports/
-    - name: Download Results podman_ubuntu_18_04
-      uses: actions/download-artifact@v1
-      with:
-        name: podman_ubuntu_18_04
-    - name: Copy podman_ubuntu_18_04 to all_report
-      continue-on-error: true
-      shell: bash {0}
-      run: |
-        mkdir -p all_reports
-        cp -r podman_ubuntu_18_04 ./all_reports/
     - uses: actions/upload-artifact@v1
       with:
         name: all_reports

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -222,12 +222,12 @@ func (d *Driver) GetSSHPort() (int, error) {
 	findForward := func() error {
 		p, perr = oci.ForwardedPort(d.OCIBinary, d.MachineName, constants.SSHPort)
 		if perr != nil {
-			glog.Errorf("error getting foraded port: %v", perr)
+			glog.Errorf("(medya dbg) error getting forwaded port: %v", perr)
 			// for debugging
 			cmd := exec.Command(d.NodeConfig.OCIBinary, "ps", "-a")
 			b, err := cmd.CombinedOutput()
+			glog.Errorf("(medya dbg) docker ps -a debug: err: %v output : %q", err, string(b))
 			if err != nil {
-				glog.Errorf("error running debugging command ps -a: %v output %q", err, string(b))
 				return err
 			}
 			return perr

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -212,7 +212,7 @@ func (d *Driver) GetSSHPort() (int, error) {
 		return err
 	}
 
-	if err := retry.Expo(waitRunning, 500*time.Microsecond, time.Second); err != nil {
+	if err := retry.Expo(waitRunning, 500*time.Microsecond, time.Minute); err != nil {
 		// let it try anyways one last time. maybe by now it got there.
 		glog.Errorf("container is not running, might not be able to get SSH port: %v", err)
 	}

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -347,6 +347,7 @@ func (d *Driver) Restart() error {
 // not meant to be used for Create().
 func (d *Driver) Start() error {
 	s, err := d.GetState()
+	glog.Infof("(medya dbg) Inside Kic Start, GetState state: %s err: %v",s,err)
 	if err != nil {
 		return errors.Wrap(err, "get kic state")
 	}

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -223,7 +223,15 @@ func (d *Driver) GetSSHPort() (int, error) {
 	kicRunner := command.NewKICRunner(d.MachineName, d.OCIBinary)
 	waitSSHDSvc := func() error {
 		if s := kverify.SSHDStatus(kicRunner); s != state.Running {
-			glog.Info("SSHD service is not running: %q will retry.", s)
+			glog.Info("(medya dbg) SSHD service is not running: %q will retry but will run a debug first ", s)
+
+			cmd := exec.Command(d.NodeConfig.OCIBinary, "logs", d.MachineName)
+			b, err := cmd.CombinedOutput()
+			glog.Errorf("(medya dbg) docker logs debug: err: %v output : %q", err, string(b))
+
+			cmd = exec.Command(d.NodeConfig.OCIBinary, "ps", "-a")
+			b, err = cmd.CombinedOutput()
+			glog.Errorf("(medya dbg) running docker ps -a debugiing command caused error: %v", err, string(b))
 			return fmt.Errorf("SSHD service not up")
 		}
 		glog.Infof("(medya dbg) SSHD service is running")

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -389,6 +389,8 @@ func killAPIServerProc(runner command.Runner) error {
 }
 
 // killETCDProc will kill an etc proc if it exists
+// this only needs to be done for kic drivers, since the base image has an entrypoint that modfies the SIGs
+// other drivers respect STOP and KILL signals. https://github.com/kubernetes/minikube/issues/7521
 func killETCDProc(runner command.Runner) error {
 	if _, err := runner.RunCmd(exec.Command("pkill", "-xnf", "etcd.*minikube.*")); err != nil {
 		return errors.Wrap(err, "kill etcd")

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -292,26 +292,11 @@ func (d *Driver) GetURL() (string, error) {
 
 // GetState returns the state that the host is in (running, stopped, etc)
 func (d *Driver) GetState() (state.State, error) {
-	out, err := oci.WarnIfSlow(d.NodeConfig.OCIBinary, "inspect", "-f", "{{.State.Status}}", d.MachineName)
+	s, err := oci.ContainerStatus(d.NodeConfig.OCIBinary, d.MachineName)
 	if err != nil {
-		return state.Error, err
+		return s, errors.Wrap(err, "GetState")
 	}
-
-	o := strings.TrimSpace(string(out))
-	switch o {
-	case "running":
-		return state.Running, nil
-	case "exited":
-		return state.Stopped, nil
-	case "paused":
-		return state.Paused, nil
-	case "restarting":
-		return state.Starting, nil
-	case "dead":
-		return state.Error, nil
-	default:
-		return state.None, fmt.Errorf("unknown state")
-	}
+	return s, err
 }
 
 // Kill stops a host forcefully, including any containers that we are managing.
@@ -367,23 +352,28 @@ func (d *Driver) Restart() error {
 	return fmt.Errorf("restarted not implemented for kic state %s yet", s)
 }
 
-// Start a _stopped_ kic container
-// not meant to be used for Create().
+// Start an already created kic container
 func (d *Driver) Start() error {
-	s, err := d.GetState()
-	glog.Infof("(medya dbg) Inside Kic Start, GetState state: %s err: %v", s, err)
-	if err != nil {
-		return errors.Wrap(err, "get kic state")
+	cr := command.NewExecRunner() // using exec runner for interacting with
+	if _, err := cr.RunCmd(exec.Command(d.NodeConfig.OCIBinary, "start", d.MachineName)); err != nil {
+		return err
 	}
-	if s == state.Stopped {
-		cmd := exec.Command(d.NodeConfig.OCIBinary, "start", d.MachineName)
-		if err := cmd.Run(); err != nil {
-			return errors.Wrapf(err, "starting a stopped kic node %s", d.MachineName)
+	checkRunning := func() error {
+		s, err := oci.ContainerStatus(d.NodeConfig.OCIBinary, d.MachineName)
+		if err != nil {
+			return err
 		}
+		if s != state.Running {
+			return fmt.Errorf("expected container state be running but got %q", s)
+		}
+		glog.Infof("container %q state is running.", d.MachineName)
 		return nil
 	}
-	// TODO:medyagh maybe make it idempotent
-	return fmt.Errorf("cant start a not-stopped (%s) kic node", s)
+
+	if err := retry.Expo(checkRunning, 500*time.Microsecond, time.Second*30); err != nil {
+		return err
+	}
+	return nil
 }
 
 // Stop a host gracefully, including any containers that we are managing.

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -206,15 +206,15 @@ func (d *Driver) GetSSHPort() (int, error) {
 			return errors.Wrap(err, "GetState")
 		}
 		if s != state.Running {
-			glog.Warningf("container is not running, will retry: %v", err)
+			glog.Warningf("container %q is in %q state, will retry till it is running: %v", d.MachineName, s, err)
 			return errors.Wrap(err, "not-running")
 		}
-		return err
+		return nil
 	}
 
-	if err := retry.Expo(waitRunning, 500*time.Microsecond, time.Minute); err != nil {
+	if err := retry.Expo(waitRunning, 500*time.Microsecond, 2*time.Minute); err != nil {
 		// let it try anyways one last time. maybe by now it got there.
-		glog.Errorf("container is not running, might not be able to get SSH port: %v", err)
+		return 0, errors.Wrap(err, "not running")
 	}
 
 	p, err := oci.ForwardedPort(d.OCIBinary, d.MachineName, constants.SSHPort)

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -202,21 +202,14 @@ func (d *Driver) GetSSHPort() (int, error) {
 	findForward := func() error {
 		p, perr = oci.ForwardedPort(d.OCIBinary, d.MachineName, constants.SSHPort)
 		if perr != nil {
-			glog.Errorf("(medya dbg) error getting forwaded port: %v", perr)
-			// for debugging
-			cmd := exec.Command(d.NodeConfig.OCIBinary, "ps", "-a")
-			b, err := cmd.CombinedOutput()
-			glog.Errorf("(medya dbg) docker ps -a debug: err: %v output : %q", err, string(b))
-			if err != nil {
-				return err
-			}
 			return perr
 		}
 		return nil
 	}
 
-	if err := retry.Expo(findForward, 500*time.Microsecond, 1*time.Minute); err != nil {
-		return p, errors.Wrap(err, "find forward")
+	// try up to 3 times
+	if err := retry.Expo(findForward, 500*time.Microsecond, 13*time.Second, 3); err != nil {
+		return p, errors.Wrap(err, "forwarded ssh port")
 	}
 	return p, nil
 }

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -197,21 +197,7 @@ func (d *Driver) GetSSHHostname() (string, error) {
 
 // GetSSHPort returns port for use with ssh
 func (d *Driver) GetSSHPort() (int, error) {
-	var perr error
-	var p int
-	findForward := func() error {
-		p, perr = oci.ForwardedPort(d.OCIBinary, d.MachineName, constants.SSHPort)
-		if perr != nil {
-			return perr
-		}
-		return nil
-	}
-
-	// try up to 3 times
-	if err := retry.Expo(findForward, 500*time.Microsecond, 13*time.Second, 3); err != nil {
-		return p, errors.Wrap(err, "forwarded ssh port")
-	}
-	return p, nil
+	return oci.ForwardedPort(d.OCIBinary, d.MachineName, constants.SSHPort)
 }
 
 // GetSSHUsername returns the ssh username

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -207,7 +207,7 @@ func (d *Driver) GetSSHPort() (int, error) {
 		}
 		if s != state.Running {
 			glog.Warningf("container %q is in %q state, will retry till it is running: %v", d.MachineName, s, err)
-			return errors.Wrap(err, "not-running")
+			return fmt.Errorf("expected running but got s", s)
 		}
 		return nil
 	}

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -109,7 +109,9 @@ func CreateContainerNode(p CreateParams) error {
 		// including some ones docker would otherwise do by default.
 		// for now this is what we want. in the future we may revisit this.
 		"--privileged",
-		"--security-opt", "seccomp=unconfined", // also ignore seccomp
+		"--security-opt", "seccomp=unconfined", //  ignore seccomp
+		// for github actions: https://github.com/kubernetes/minikube/issues/7624
+		"--security-opt", "apparmor=unconfined", // ignore apparmor
 		"--tmpfs", "/tmp", // various things depend on working /tmp
 		"--tmpfs", "/run", // systemd wants a writable /run
 		// logs,pods be stroed on  filesystem vs inside container,

--- a/pkg/minikube/bootstrapper/bsutil/kverify/system_pods.go
+++ b/pkg/minikube/bootstrapper/bsutil/kverify/system_pods.go
@@ -164,3 +164,14 @@ func KubeletStatus(cr command.Runner) state.State {
 	}
 	return state.Stopped
 }
+
+// SSHDStatus checks the sshd service status
+func SSHDStatus(cr command.Runner) state.State {
+	active := sysinit.New(cr).Active("sshd")
+	if active {
+		glog.Infof("sshd service is active.")
+		return state.Running
+	}
+	glog.Infof("sshd service is not active.")
+	return state.Stopped
+}

--- a/pkg/minikube/machine/client.go
+++ b/pkg/minikube/machine/client.go
@@ -158,6 +158,7 @@ func CommandRunner(h *host.Host) (command.Runner, error) {
 	if driver.IsKIC(h.Driver.DriverName()) {
 		start := time.Now()
 		// using a temproary kic runner to ensure the SSHD service is up
+		// and then in the end return ssh runner which is faster.
 		kr := command.NewKICRunner(h.Name, h.Driver.DriverName())
 		sshReady := func() error {
 			if s := kverify.SSHDStatus(kr); s != state.Running {

--- a/pkg/minikube/machine/client.go
+++ b/pkg/minikube/machine/client.go
@@ -42,12 +42,14 @@ import (
 	"github.com/docker/machine/libmachine/version"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"k8s.io/minikube/pkg/minikube/bootstrapper/bsutil/kverify"
 	"k8s.io/minikube/pkg/minikube/command"
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/registry"
+	"k8s.io/minikube/pkg/util/retry"
 )
 
 // NewRPCClient gets a new client.
@@ -152,8 +154,25 @@ func CommandRunner(h *host.Host) (command.Runner, error) {
 	if driver.BareMetal(h.Driver.DriverName()) {
 		return command.NewExecRunner(), nil
 	}
+	sshRunner := command.NewSSHRunner(h.Driver)
+	if driver.IsKIC(h.Driver.DriverName()) {
+		start := time.Now()
+		// using a temproary kic runner to ensure the SSHD service is up
+		kr := command.NewKICRunner(h.Name, h.Driver.DriverName())
+		sshReady := func() error {
+			if s := kverify.SSHDStatus(kr); s != state.Running {
+				return fmt.Errorf("sshd service not ready")
+			}
+			glog.Infof("durationg metric: took %s for SSHD service to be up", time.Since(start))
+			return nil
 
-	return command.NewSSHRunner(h.Driver), nil
+		}
+		if err := retry.Expo(sshReady, 250*time.Millisecond, 13*time.Second); err != nil {
+			glog.Infof("SSHD service was not up by 13 seconds, will fall back to KicRunner: %v", err)
+			return kr, nil // if SSHD service is not up by then fall back to kic runner
+		}
+	}
+	return sshRunner, nil
 }
 
 // Create creates the host

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -47,7 +47,7 @@ func beginCacheKubernetesImages(g *errgroup.Group, imageRepository string, k8sVe
 		glog.Info("Caching tarball of preloaded images")
 		err := download.Preload(k8sVersion, cRuntime)
 		if err == nil {
-			glog.Infof("Finished verifying existance of preloaded tar for %s on %s", k8sVersion, cRuntime)
+			glog.Infof("Finished verifying existence of preloaded tar for %s on %s", k8sVersion, cRuntime)
 			return // don't cache individual images if preload is successful.
 		}
 		glog.Warningf("Error downloading preloaded artifacts will continue without preload: %v", err)

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -47,7 +47,7 @@ func beginCacheKubernetesImages(g *errgroup.Group, imageRepository string, k8sVe
 		glog.Info("Caching tarball of preloaded images")
 		err := download.Preload(k8sVersion, cRuntime)
 		if err == nil {
-			glog.Infof("Finished downloading the preloaded tar for %s on %s", k8sVersion, cRuntime)
+			glog.Infof("Finished verifying existance of preloaded tar for %s on %s", k8sVersion, cRuntime)
 			return // don't cache individual images if preload is successful.
 		}
 		glog.Warningf("Error downloading preloaded artifacts will continue without preload: %v", err)

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -773,7 +773,7 @@ func validateMySQL(ctx context.Context, t *testing.T, profile string) {
 		rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "exec", names[0], "--", "mysql", "-ppassword", "-e", "show databases;"))
 		return err
 	}
-	if err = retry.Expo(mysql, 1*time.Second, Minutes(5)); err != nil {
+	if err = retry.Expo(mysql, 1*time.Second, Minutes(7)); err != nil {
 		t.Errorf("failed to exec 'mysql -ppassword -e show databases;': %v", err)
 	}
 }

--- a/test/integration/util.go
+++ b/test/integration/util.go
@@ -56,5 +56,5 @@ func UniqueProfileName(prefix string) string {
 	if NoneDriver() {
 		return "minikube"
 	}
-	return fmt.Sprintf("%s-%s-%d", prefix, time.Now().Format("20060102T150405.999999999"), os.Getpid())
+	return fmt.Sprintf("%s-%s-%d", prefix, time.Now().Format("20060102T150405-9999"), os.Getpid())
 }


### PR DESCRIPTION
hopefully this will solve most of the github action test failures
https://github.com/kubernetes/minikube/issues/7624

## notable changes
1-  add ignore for apparmor  and other local kubernetes experineces in docker also ignore it. this will help running minikube docker driver in github actions.
2- ensure start and ensure stopped by waiting for container status. 
3- make github actions run only functional tests for docker
4- make UniqueProfileName Container Friendly (remove Dot in the name and make it shorter)
5- kill APIServerID and ETCD on stop
6- Ensure SSHD service is up before returning SSHrunner for Kic drivers


## observations,
while debugging, I found out github actions does run out disk space and gets the DiskPressure when we run the full tests in parallel.
once we have Auto- Image Prune on start we could retry to run all tests in github actions again.