### PR TITLE
Add proxy cidr check in order not to access nil address

### DIFF
--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -398,7 +398,7 @@ func validateNetwork(h *host.Host, r command.Runner, imageRepository string) (st
 			ipExcluded := proxy.IsIPExcluded(ip) // Skip warning if minikube ip is already in NO_PROXY
 			k = strings.ToUpper(k)               // for http_proxy & https_proxy
 			if (k == "HTTP_PROXY" || k == "HTTPS_PROXY") && !ipExcluded && !warnedOnce {
-				out.WarningT("You appear to be using a proxy, but your NO_PROXY environment does not include the minikube IP ({{.ip_address}}). Please see {{.documentation_url}} for more details", out.V{"ip_address": ip, "documentation_url": "https://minikube.sigs.k8s.io/docs/reference/networking/proxy/"})
+				out.WarningT("You appear to be using a proxy, but your NO_PROXY environment does not include the minikube IP ({{.ip_address}}). Please see {{.documentation_url}} for more details", out.V{"ip_address": ip, "documentation_url": "https://minikube.sigs.k8s.io/docs/handbook/vpn_and_proxy/"})
 				warnedOnce = true
 			}
 		}

--- a/pkg/minikube/proxy/proxy.go
+++ b/pkg/minikube/proxy/proxy.go
@@ -112,7 +112,7 @@ func checkEnv(ip string, env string) bool {
 	for _, b := range noProxyBlocks {
 		yes, err := isInBlock(ip, b)
 		if err != nil {
-			glog.Errorf("fail to check proxy env: %v", err)
+			glog.Warningf("fail to check proxy env: %v", err)
 		}
 		if yes {
 			return true

--- a/pkg/minikube/proxy/proxy.go
+++ b/pkg/minikube/proxy/proxy.go
@@ -44,6 +44,9 @@ func isInBlock(ip string, block string) (bool, error) {
 	if i == nil {
 		return false, fmt.Errorf("parsed IP is nil")
 	}
+	if !strings.Contains(block, "/") {
+		return false, nil
+	}
 	_, b, err := net.ParseCIDR(block)
 	if err != nil {
 		return false, errors.Wrapf(err, "Error Parsing block %s", b)
@@ -101,7 +104,11 @@ func checkEnv(ip string, env string) bool {
 	// Checks if included in IP ranges, i.e., 192.168.39.13/24
 	noProxyBlocks := strings.Split(v, ",")
 	for _, b := range noProxyBlocks {
-		if yes, _ := isInBlock(ip, b); yes {
+		yes, err := isInBlock(ip, b)
+		if err != nil {
+			glog.Errorf("fail to check proxy env: %v", err)
+		}
+		if yes {
 			return true
 		}
 	}

--- a/pkg/minikube/proxy/proxy.go
+++ b/pkg/minikube/proxy/proxy.go
@@ -40,22 +40,28 @@ func isInBlock(ip string, block string) (bool, error) {
 		return false, fmt.Errorf("CIDR is nil")
 	}
 
+	if ip == block {
+		return true, nil
+	}
+
 	i := net.ParseIP(ip)
 	if i == nil {
 		return false, fmt.Errorf("parsed IP is nil")
 	}
-	if !strings.Contains(block, "/") {
-		return false, nil
-	}
-	_, b, err := net.ParseCIDR(block)
-	if err != nil {
-		return false, errors.Wrapf(err, "Error Parsing block %s", b)
+
+	// check the block if it's CIDR
+	if strings.Contains(block, "/") {
+		_, b, err := net.ParseCIDR(block)
+		if err != nil {
+			return false, errors.Wrapf(err, "Error Parsing block %s", b)
+		}
+
+		if b.Contains(i) {
+			return true, nil
+		}
 	}
 
-	if b.Contains(i) {
-		return true, nil
-	}
-	return false, errors.Wrapf(err, "Error ip not in block")
+	return false, errors.New("Error ip not in block")
 }
 
 // ExcludeIP takes ip or CIDR as string and excludes it from the http(s)_proxy

--- a/pkg/minikube/proxy/proxy_test.go
+++ b/pkg/minikube/proxy/proxy_test.go
@@ -53,11 +53,13 @@ func TestIsInBlock(t *testing.T) {
 		wanntAErr bool
 	}{
 		{"", "192.168.0.1/32", false, true},
+		{"192.168.0.1", "", false, true},
+		{"192.168.0.1", "192.168.0.1", true, false},
 		{"192.168.0.1", "192.168.0.1/32", true, false},
-		{"192.168.0.2", "192.168.0.1/32", false, false},
+		{"192.168.0.2", "192.168.0.1/32", false, true},
 		{"192.168.0.1", "192.168.0.1/18", true, false},
 		{"abcd", "192.168.0.1/18", false, true},
-		{"192.168.0.1", "foo", false, false},
+		{"192.168.0.1", "foo", false, true},
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%s in %s Want: %t WantAErr: %t", tc.ip, tc.block, tc.want, tc.wanntAErr), func(t *testing.T) {
@@ -122,6 +124,7 @@ func TestCheckEnv(t *testing.T) {
 		{"192.168.0.13", "NO_PROXY", false, ""},
 		{"192.168.0.13", "NO_PROXY", false, ","},
 		{"192.168.0.13", "NO_PROXY", true, "192.168.0.13"},
+		{"192.168.0.13", "NO_PROXY", false, "192.168.0.14"},
 		{"192.168.0.13", "NO_PROXY", true, ",192.168.0.13"},
 		{"192.168.0.13", "NO_PROXY", true, "10.10.0.13,192.168.0.13"},
 		{"192.168.0.13", "NO_PROXY", true, "192.168.0.13/22"},

--- a/pkg/minikube/proxy/proxy_test.go
+++ b/pkg/minikube/proxy/proxy_test.go
@@ -57,7 +57,7 @@ func TestIsInBlock(t *testing.T) {
 		{"192.168.0.2", "192.168.0.1/32", false, false},
 		{"192.168.0.1", "192.168.0.1/18", true, false},
 		{"abcd", "192.168.0.1/18", false, true},
-		{"192.168.0.1", "foo", false, true},
+		{"192.168.0.1", "foo", false, false},
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%s in %s Want: %t WantAErr: %t", tc.ip, tc.block, tc.want, tc.wanntAErr), func(t *testing.T) {


### PR DESCRIPTION
### What type of PR is this?
/kind bug
/kind cleanup

### What this PR does / why we need it:

Now the proxy CIDR is not checked, when invalid CIDR is set(e.g. `10.0.0.0` missing `/XX`).
This PR add the check if the proxy CIDR is valid before `net.ParseCIDR`.
This prevents the minikube from accessing nil address(SIGSEV).
I described the detail of this in #7618.

### Which issue(s) this PR fixes:
Fixes #7618 

### Does this PR introduce a user-facing change?
Yes. the broken url for proxy is fixed.

The CIDR check in proxy.go is performed inside the process. Users doesn't face.

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```
