### PR TITLE
Validate profile name characters

### DIFF
--- a/cmd/minikube/cmd/config/profile.go
+++ b/cmd/minikube/cmd/config/profile.go
@@ -44,6 +44,11 @@ var ProfileCmd = &cobra.Command{
 		}
 
 		profile := args[0]
+		// Check whether the profile name is container friendly
+		if !config.ProfileNameValid(profile) {
+			out.WarningT("Profile name '{{.profilename}}' is not valid", out.V{"profilename": profile})
+			exit.UsageT("Only alphanumeric, dots, underscores and dashes '-' are permitted. Minimum 2 characters, starting by alphanumeric.")
+		}
 		/**
 		we need to add code over here to check whether the profile
 		name is in the list of reserved keywords

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -144,6 +144,10 @@ func runStart(cmd *cobra.Command, args []string) {
 		registryMirror = viper.GetStringSlice("registry_mirror")
 	}
 
+	if !config.ProfileNameValid(ClusterFlagValue()) {
+		out.WarningT("Profile name '{{.name}}' is not valid", out.V{"name": ClusterFlagValue()})
+		exit.UsageT("Only alphanumeric, dots, underscores and dashes '-' are permitted. Minimum 2 characters, starting by alphanumeric.")
+	}
 	existing, err := config.Load(ClusterFlagValue())
 	if err != nil && !config.IsNotExist(err) {
 		exit.WithCodeT(exit.Data, "Unable to load config: {{.error}}", out.V{"error": err})

--- a/pkg/minikube/config/profile.go
+++ b/pkg/minikube/config/profile.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/golang/glog"
@@ -81,6 +82,16 @@ func PrimaryControlPlane(cc *ClusterConfig) (Node, error) {
 	}
 
 	return cp, nil
+}
+
+// ProfileNameValid checks if the profile name is container name friendly
+func ProfileNameValid(name string) bool {
+
+	// RestrictedNameChars collects the characters allowed to represent a name
+	const RestrictedNameChars = `[a-zA-Z0-9][a-zA-Z0-9_.-]`
+
+	var validName = regexp.MustCompile(`^` + RestrictedNameChars + `+$`)
+	return validName.MatchString(name)
 }
 
 // ProfileNameInReservedKeywords checks if the profile is an internal keywords

--- a/pkg/minikube/config/profile_test.go
+++ b/pkg/minikube/config/profile_test.go
@@ -72,6 +72,27 @@ func TestListProfiles(t *testing.T) {
 	}
 }
 
+func TestProfileNameValid(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		expected bool
+	}{
+		{"meaningful_name", true},
+		{"meaningful_name@", false},
+		{"n_a_m_e_2", true},
+		{"n", false},
+		{"_name", false},
+		{"N__a.M--E12567", true},
+	}
+	for _, tt := range testCases {
+		got := ProfileNameValid(tt.name)
+		if got != tt.expected {
+			t.Errorf("expected ProfileNameValid(%s)=%t but got %t ", tt.name, tt.expected, got)
+		}
+	}
+
+}
+
 func TestProfileNameInReservedKeywords(t *testing.T) {
 	var testCases = []struct {
 		name     string


### PR DESCRIPTION
It must be container friendly (only `[a-zA-Z0-9][a-zA-Z0-9_.-]` are allowed).

Fixes #7627 

Before:
```
minikube start -p 2myprofile --driver=docker
😄  [2myprofile] minikube v1.9.2 on Ubuntu 20.04
✨  Using the docker driver based on user configuration
👍  Starting control plane node 2myprofile in cluster 2myprofile
🚜  Pulling base image ...
💾  Downloading Kubernetes v1.18.0 preload ...
    > preloaded-images-k8s-v2-v1.18.0-docker-overlay2-amd64.tar.lz4: 542.91 MiB
🔥  Creating docker container (CPUs=2, Memory=3900MB) ...
🐳  Preparing Kubernetes v1.18.0 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16
🌟  Enabling addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "2myprofile"
```
```
minikube start -p -myprofile --driver=docker
😄  [-myprofile] minikube v1.9.2 on Ubuntu 20.04
✨  Using the docker driver based on user configuration
👍  Starting control plane node -myprofile in cluster -myprofile
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=3900MB) ...
🤦  StartHost failed, but will try again: creating host: create: creating: setting up container node: creating volume for -myprofile container: output unknown shorthand flag: 'm' in -myprofile
See 'docker volume create --help'.
: exit status 125
🤷  docker "-myprofile" container is missing, will recreate.
🔥  Creating docker container (CPUs=2, Memory=3900MB) ...
😿  Failed to start docker container. "minikube start -p -myprofile" may fix it: recreate: creating host: create: creating: setting up container node: creating volume for -myprofile container: output unknown shorthand flag: 'm' in -myprofile
See 'docker volume create --help'.
: exit status 125

💣  error provisioning host: Failed to start host: recreate: creating host: create: creating: setting up container node: creating volume for -myprofile container: output unknown shorthand flag: 'm' in -myprofile
See 'docker volume create --help'.
: exit status 125

😿  minikube is exiting due to an error. If the above message is not useful, open an issue:
👉  https://github.com/kubernetes/minikube/issues/new/choose
```
```
minikube start -p 2 --driver=docker
😄  [2] minikube v1.9.2 on Ubuntu 20.04
✨  Using the docker driver based on existing profile
👍  Starting control plane node 2 in cluster 2
🚜  Pulling base image ...
🤷  docker "2" container is missing, will recreate.
🔥  Creating docker container (CPUs=2, Memory=3900MB) ...
🤦  StartHost failed, but will try again: recreate: creating host: create: creating: setting up container node: creating volume for 2 container: output Error response from daemon: create 2: volume name is too short, names should be at least two alphanumeric characters
: exit status 1
🤷  docker "2" container is missing, will recreate.
🔥  Creating docker container (CPUs=2, Memory=3900MB) ...
😿  Failed to start docker container. "minikube start -p 2" may fix it: recreate: creating host: create: creating: setting up container node: creating volume for 2 container: output Error response from daemon: create 2: volume name is too short, names should be at least two alphanumeric characters
: exit status 1

💣  error provisioning host: Failed to start host: recreate: creating host: create: creating: setting up container node: creating volume for 2 container: output Error response from daemon: create 2: volume name is too short, names should be at least two alphanumeric characters
: exit status 1

😿  minikube is exiting due to an error. If the above message is not useful, open an issue:
👉  https://github.com/kubernetes/minikube/issues/new/choose
```
```
minikube start -p -aaa --driver=docker
😄  [-aaa] minikube v1.9.2 on Ubuntu 20.04
✨  Using the docker driver based on existing profile
👍  Starting control plane node -aaa in cluster -aaa
🚜  Pulling base image ...
🤷  docker "-aaa" container is missing, will recreate.
🔥  Creating docker container (CPUs=2, Memory=3900MB) ...
🤦  StartHost failed, but will try again: recreate: creating host: create: creating: setting up container node: creating volume for -aaa container: output unknown shorthand flag: 'a' in -aaa
See 'docker volume create --help'.
: exit status 125
🤷  docker "-aaa" container is missing, will recreate.
🔥  Creating docker container (CPUs=2, Memory=3900MB) ...
😿  Failed to start docker container. "minikube start -p -aaa" may fix it: recreate: creating host: create: creating: setting up container node: creating volume for -aaa container: output unknown shorthand flag: 'a' in -aaa
See 'docker volume create --help'.
: exit status 125

💣  error provisioning host: Failed to start host: recreate: creating host: create: creating: setting up container node: creating volume for -aaa container: output unknown shorthand flag: 'a' in -aaa
See 'docker volume create --help'.
: exit status 125

😿  minikube is exiting due to an error. If the above message is not useful, open an issue:
👉  https://github.com/kubernetes/minikube/issues/new/choose
```
```
minikube start -p aa@a --driver=docker
😄  [aa@a] minikube v1.9.2 on Ubuntu 20.04
✨  Using the docker driver based on user configuration
👍  Starting control plane node aa@a in cluster aa@a
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=3900MB) ...
🤦  StartHost failed, but will try again: creating host: create: creating: setting up container node: creating volume for aa@a container: output Error response from daemon: create aa@a: "aa@a" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path
: exit status 1
🤷  docker "aa@a" container is missing, will recreate.
🔥  Creating docker container (CPUs=2, Memory=3900MB) ...
😿  Failed to start docker container. "minikube start -p aa@a" may fix it: recreate: creating host: create: creating: setting up container node: creating volume for aa@a container: output Error response from daemon: create aa@a: "aa@a" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path
: exit status 1

💣  error provisioning host: Failed to start host: recreate: creating host: create: creating: setting up container node: creating volume for aa@a container: output Error response from daemon: create aa@a: "aa@a" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path
: exit status 1

😿  minikube is exiting due to an error. If the above message is not useful, open an issue:
👉  https://github.com/kubernetes/minikube/issues/new/choose


```

After:

```
minikube start -p 2myprofile --driver=docker
😄  [2myprofile] minikube v1.9.2 on Ubuntu 20.04
✨  Using the docker driver based on existing profile
👍  Starting control plane node 2myprofile in cluster 2myprofile
🚜  Pulling base image ...
🔄  Restarting existing docker container for "2myprofile" ...
🐳  Preparing Kubernetes v1.18.0 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16
🤦  Unable to restart cluster, will reset it: getting k8s client: client config: client config: context "2myprofile" does not exist
🌟  Enabling addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "2myprofile"

```

```
minikube start -p -myprofile --driver=docker
😄  [-myprofile] minikube v1.9.2 on Ubuntu 20.04
❗  Profile name '-myprofile' is not valid
💡  Only alphanumeric, dots, underscores and dashes '-' are permitted. Minimum 2 characters, starting by alphanumeric.
```
```
minikube start -p 2 --driver=docker
😄  [2] minikube v1.9.2 on Ubuntu 20.04
❗  Profile name '2' is not valid
💡  Only alphanumeric, dots, underscores and dashes '-' are permitted. Minimum 2 characters, starting by alphanumeric.
```
```
minikube start -p -aaa --driver=docker
😄  [-aaa] minikube v1.9.2 on Ubuntu 20.04
❗  Profile name '-aaa' is not valid
💡  Only alphanumeric, dots, underscores and dashes '-' are permitted. Minimum 2 characters, starting by alphanumeric.
```
```
minikube start -p aa@a --driver=docker
😄  [aa@a] minikube v1.9.2 on Ubuntu 20.04
❗  Profile name 'aa@a' is not valid
💡  Only alphanumeric, dots, underscores and dashes '-' are permitted. Minimum 2 characters, starting by alphanumeric.

```

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
