### PR TITLE
bump lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,8 @@ DEB_VERSION ?= $(subst -,~,$(RAW_VERSION))
 RPM_VERSION ?= $(DEB_VERSION)
 
 # used by hack/jenkins/release_build_and_upload.sh and KVM_BUILD_IMAGE, see also BUILD_IMAGE below
-GO_VERSION ?= 1.13.8
+# latest available image from kuberentes https://github.com/kubernetes/kubernetes/blob/master/build/build-image/cross/VERSION
+GO_VERSION ?= v1.13.9
 
 INSTALL_SIZE ?= $(shell du out/minikube-windows-amd64.exe | cut -f1)
 BUILDROOT_BRANCH ?= 2019.02.10
@@ -54,7 +55,7 @@ MINIKUBE_RELEASES_URL=https://github.com/kubernetes/minikube/releases/download
 
 KERNEL_VERSION ?= 4.19.107
 # latest from https://github.com/golangci/golangci-lint/releases
-GOLINT_VERSION ?= v1.23.6
+GOLINT_VERSION ?= v1.24.0
 # Limit number of default jobs, to avoid the CI builds running out of memory
 GOLINT_JOBS ?= 4
 # see https://github.com/golangci/golangci-lint#memory-usage-of-golangci-lint

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -60,7 +60,6 @@ import (
 	"k8s.io/minikube/pkg/minikube/registry"
 	"k8s.io/minikube/pkg/minikube/translate"
 	"k8s.io/minikube/pkg/util"
-	pkgutil "k8s.io/minikube/pkg/util"
 	"k8s.io/minikube/pkg/version"
 )
 
@@ -747,7 +746,7 @@ func suggestMemoryAllocation(sysLimit int, containerLimit int) int {
 
 // validateMemorySize validates the memory size matches the minimum recommended
 func validateMemorySize() {
-	req, err := pkgutil.CalculateSizeInMB(viper.GetString(memory))
+	req, err := util.CalculateSizeInMB(viper.GetString(memory))
 	if err != nil {
 		exit.WithCodeT(exit.Config, "Unable to parse memory '{{.memory}}': {{.error}}", out.V{"memory": viper.GetString(memory), "error": err})
 	}
@@ -783,7 +782,7 @@ func validateCPUCount(local bool) {
 // validateFlags validates the supplied flags against known bad combinations
 func validateFlags(cmd *cobra.Command, drvName string) {
 	if cmd.Flags().Changed(humanReadableDiskSize) {
-		diskSizeMB, err := pkgutil.CalculateSizeInMB(viper.GetString(humanReadableDiskSize))
+		diskSizeMB, err := util.CalculateSizeInMB(viper.GetString(humanReadableDiskSize))
 		if err != nil {
 			exit.WithCodeT(exit.Config, "Validation unable to parse disk size '{{.diskSize}}': {{.error}}", out.V{"diskSize": viper.GetString(humanReadableDiskSize), "error": err})
 		}
@@ -967,14 +966,13 @@ func getKubernetesVersion(old *config.ClusterConfig) string {
 	}
 
 	if nvs.LT(ovs) {
-		nv = version.VersionPrefix + ovs.String()
 		profileArg := ""
 		if old.Name != constants.DefaultClusterName {
 			profileArg = fmt.Sprintf(" -p %s", old.Name)
 		}
 
 		suggestedName := old.Name + "2"
-		out.T(out.Conflict, "You have selected Kubernetes v{{.new}}, but the existing cluster is running Kubernetes v{{.old}}", out.V{"new": nvs, "old": ovs, "profile": profileArg})
+		out.T(out.Conflict, "You have selected Kubernetes v{{.new}}, but the existing cluster is running Kubernetes v{{.old}}", out.V{"new": nvs, "old": ovs})
 		exit.WithCodeT(exit.Config, `Non-destructive downgrades are not supported, but you can proceed with one of the following options:
 
   1) Recreate the cluster with Kubernetes v{{.new}}, by running:

--- a/go.mod
+++ b/go.mod
@@ -126,8 +126,5 @@ replace (
 	k8s.io/kubelet => k8s.io/kubelet v0.17.3
 	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.17.3
 	k8s.io/metrics => k8s.io/metrics v0.17.3
-	k8s.io/node-api => k8s.io/node-api v0.17.3
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.17.3
-	k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.17.3
-	k8s.io/sample-controller => k8s.io/sample-controller v0.17.3
 )

--- a/pkg/drivers/hyperkit/driver.go
+++ b/pkg/drivers/hyperkit/driver.go
@@ -397,7 +397,7 @@ func (d *Driver) Stop() error {
 	d.cleanupNfsExports()
 	err := d.sendSignal(syscall.SIGTERM)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("hyperkit sigterm failed"))
+		return errors.Wrap(err, "hyperkit sigterm failed")
 	}
 
 	// wait 5s for graceful shutdown
@@ -406,7 +406,7 @@ func (d *Driver) Stop() error {
 		time.Sleep(time.Second * 1)
 		s, err := d.GetState()
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("hyperkit waiting graceful shutdown failed"))
+			return errors.Wrap(err, "hyperkit graceful shutdown")
 		}
 		if s == state.Stopped {
 			return nil
@@ -468,7 +468,7 @@ func (d *Driver) setupNFSShare() error {
 		return err
 	}
 
-	mountCommands := fmt.Sprintf("#/bin/bash\\n")
+	mountCommands := "#/bin/bash\\n"
 	log.Info(d.IPAddress)
 
 	for _, share := range d.NFSShares {

--- a/pkg/minikube/bootstrapper/bsutil/ops.go
+++ b/pkg/minikube/bootstrapper/bsutil/ops.go
@@ -17,7 +17,6 @@ limitations under the License.
 package bsutil
 
 import (
-	"fmt"
 	"os/exec"
 	"strings"
 
@@ -42,7 +41,7 @@ func AdjustResourceLimits(c command.Runner) error {
 	// Prevent the apiserver from OOM'ing before other pods, as it is our gateway into the cluster.
 	// It'd be preferable to do this via Kubernetes, but kubeadm doesn't have a way to set pod QoS.
 	if _, err = c.RunCmd(exec.Command("/bin/bash", "-c", "echo -10 | sudo tee /proc/$(pgrep kube-apiserver)/oom_adj")); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("oom_adj adjust"))
+		return errors.Wrap(err, "oom_adj adjust")
 	}
 	return nil
 }

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -765,7 +765,7 @@ func (k *Bootstrapper) applyKICOverlay(cfg config.ClusterConfig) error {
 		return err
 	}
 
-	ko := path.Join(vmpath.GuestEphemeralDir, fmt.Sprintf("kic_overlay.yaml"))
+	ko := path.Join(vmpath.GuestEphemeralDir, "kic_overlay.yaml")
 	f := assets.NewMemoryAssetTarget(b.Bytes(), ko, "0644")
 
 	if err := k.c.Copy(f); err != nil {
@@ -831,7 +831,7 @@ func (k *Bootstrapper) elevateKubeSystemPrivileges(cfg config.ClusterConfig) err
 	rr, err := k.c.RunCmd(cmd)
 	if err != nil {
 		// Error from server (AlreadyExists): clusterrolebindings.rbac.authorization.k8s.io "minikube-rbac" already exists
-		if strings.Contains(rr.Output(), fmt.Sprintf("Error from server (AlreadyExists)")) {
+		if strings.Contains(rr.Output(), "Error from server (AlreadyExists)") {
 			glog.Infof("rbac %q already exists not need to re-create.", rbacName)
 			return nil
 		}

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -116,7 +116,7 @@ func validateIngressAddon(ctx context.Context, t *testing.T, profile string) {
 
 	want := "Welcome to nginx!"
 	checkIngress := func() error {
-		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", fmt.Sprintf("curl http://127.0.0.1:80 -H 'Host: nginx.example.com'")))
+		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "curl http://127.0.0.1:80 -H 'Host: nginx.example.com'"))
 		if err != nil {
 			return err
 		}

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -747,7 +747,7 @@ func validateSSHCmd(ctx context.Context, t *testing.T, profile string) {
 		t.Skipf("skipping: ssh unsupported by none")
 	}
 	want := "hello\n"
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", fmt.Sprintf("echo hello")))
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "echo hello"))
 	if err != nil {
 		t.Errorf("failed to run an ssh command. args %q : %v", rr.Command(), err)
 	}


### PR DESCRIPTION
### bumped lint version :)

- bump golang-ci version
- bump go version to latest available
- putting a comment to specify where we can find latest available golang for kuberentes project
- remove un-needed replaces 

### didn't bump kubernetes version :(
tried to bump kubernetes version but I faced this issue https://github.com/kubernetes/minikube/issues/7638 till that is solved will not bump kubernets version which has nice nice new features such as passing context to client-go calls
 
