### PR TITLE
WIP: generate join token on control plane

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -281,22 +281,22 @@ func startWithDriver(starter node.Starter, existing *config.ClusterConfig) (*kub
 	if numNodes > 1 {
 		if driver.BareMetal(starter.Cfg.Driver) {
 			exit.WithCodeT(exit.Config, "The none driver is not compatible with multi-node clusters.")
-		} else {
-			for i := 1; i < numNodes; i++ {
-				nodeName := node.Name(i + 1)
-				n := config.Node{
-					Name:              nodeName,
-					Worker:            true,
-					ControlPlane:      false,
-					KubernetesVersion: starter.Cfg.KubernetesConfig.KubernetesVersion,
-				}
-				out.Ln("") // extra newline for clarity on the command line
-				err := node.Add(starter.Cfg, n)
-				if err != nil {
-					return nil, errors.Wrap(err, "adding node")
-				}
+		}
+		for i := 1; i < numNodes; i++ {
+			nodeName := node.Name(i + 1)
+			n := config.Node{
+				Name:              nodeName,
+				Worker:            true,
+				ControlPlane:      false,
+				KubernetesVersion: starter.Cfg.KubernetesConfig.KubernetesVersion,
+			}
+			out.Ln("") // extra newline for clarity on the command line
+			err := node.Add(starter.Cfg, n)
+			if err != nil {
+				return nil, errors.Wrap(err, "adding node")
 			}
 		}
+
 	}
 
 	return kubeconfig, nil

--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -217,7 +217,7 @@ func status(api libmachine.API, cc config.ClusterConfig, n config.Node) (*Status
 		return st, nil
 	}
 
-	hostname, _, port, err := driver.ControlPaneEndpoint(&cc, &n, host.DriverName)
+	hostname, _, port, err := driver.ControlPlaneEndpoint(&cc, &n, host.DriverName)
 	if err != nil {
 		glog.Errorf("forwarded endpoint: %v", err)
 		st.Kubeconfig = Misconfigured

--- a/hack/images/kicbase.Dockerfile
+++ b/hack/images/kicbase.Dockerfile
@@ -52,5 +52,5 @@ RUN apt-get clean -y && rm -rf \
   /var/tmp/* \
   /usr/share/doc/* \
   /usr/share/man/* \
-  /usr/share/local/* \
-  RUN echo "kic! Build: ${COMMIT_SHA} Time :$(date)" > "/kic.txt"
+  /usr/share/local/*
+RUN echo "kic! Build: ${COMMIT_SHA} Time :$(date)" > "/kic.txt"

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -150,6 +150,7 @@ func (d *Driver) Create() error {
 // prepareSSH will generate keys and copy to the container so minikube ssh works
 func (d *Driver) prepareSSH() error {
 	keyPath := d.GetSSHKeyPath()
+
 	glog.Infof("Creating ssh key for kic: %s...", keyPath)
 	if err := ssh.GenerateSSHKey(keyPath); err != nil {
 		return errors.Wrap(err, "generate ssh key")
@@ -160,9 +161,11 @@ func (d *Driver) prepareSSH() error {
 	if err != nil {
 		return errors.Wrap(err, "create pubkey assetfile ")
 	}
+
 	if err := cmder.Copy(f); err != nil {
 		return errors.Wrap(err, "copying pub key")
 	}
+
 	if rr, err := cmder.RunCmd(exec.Command("chown", "docker:docker", "/home/docker/.ssh/authorized_keys")); err != nil {
 		return errors.Wrapf(err, "apply authorized_keys file ownership, output %s", rr.Output())
 	}

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -148,7 +148,7 @@ func CreateContainerNode(p CreateParams) error {
 	// adds node specific args
 	runArgs = append(runArgs, p.ExtraArgs...)
 
-	if enabled := isUsernsRemapEnabled(p.OCIBinary); enabled {
+	if isUsernsRemapEnabled(p.OCIBinary) {
 		// We need this argument in order to make this command work
 		// in systems that have userns-remap enabled on the docker daemon
 		runArgs = append(runArgs, "--userns=host")

--- a/pkg/minikube/driver/endpoint.go
+++ b/pkg/minikube/driver/endpoint.go
@@ -24,8 +24,8 @@ import (
 	"k8s.io/minikube/pkg/minikube/constants"
 )
 
-// ControlPaneEndpoint returns the location where callers can reach this cluster
-func ControlPaneEndpoint(cc *config.ClusterConfig, cp *config.Node, driverName string) (string, net.IP, int, error) {
+// ControlPlaneEndpoint returns the location where callers can reach this cluster
+func ControlPlaneEndpoint(cc *config.ClusterConfig, cp *config.Node, driverName string) (string, net.IP, int, error) {
 	if NeedsPortForward(driverName) {
 		port, err := oci.ForwardedPort(cc.Driver, cc.Name, cp.Port)
 		hostname := oci.DefaultBindIPV4

--- a/pkg/minikube/mustload/mustload.go
+++ b/pkg/minikube/mustload/mustload.go
@@ -119,7 +119,7 @@ func Running(name string) ClusterController {
 		exit.WithError("Unable to get command runner", err)
 	}
 
-	hostname, ip, port, err := driver.ControlPaneEndpoint(cc, &cp, host.DriverName)
+	hostname, ip, port, err := driver.ControlPlaneEndpoint(cc, &cp, host.DriverName)
 	if err != nil {
 		exit.WithError("Unable to get forwarded endpoint", err)
 	}

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -157,20 +157,9 @@ func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 		}
 
 		// Load the control plane host
-		cp, err := config.PrimaryControlPlane(starter.Cfg)
-		if err != nil {
-			return nil, errors.Wrap(err, "Getting primary control plane")
-		}
-		cpHost, err := machine.LoadHost(starter.MachineAPI, driver.MachineName(*starter.Cfg, cp))
-		if err != nil {
-			return nil, errors.Wrap(err, "Loading control plane host")
-		}
-		r, err := machine.CommandRunner(cpHost)
-		if err != nil {
-			return nil, errors.Wrap(err, "Getting cp command runner")
-		}
+		c := mustload.Running(starter.Cfg.Name)
 
-		cpBs, err := cluster.Bootstrapper(starter.MachineAPI, viper.GetString(cmdcfg.Bootstrapper), *starter.Cfg, r)
+		cpBs, err := cluster.Bootstrapper(starter.MachineAPI, viper.GetString(cmdcfg.Bootstrapper), *starter.Cfg, c.CP.Runner)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to get control plane bootstrapper")
 		}

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -308,7 +308,7 @@ func setupKubeconfig(h *host.Host, cc *config.ClusterConfig, n *config.Node, clu
 }
 
 func apiServerURL(h host.Host, cc config.ClusterConfig, n config.Node) (string, error) {
-	hostname, _, port, err := driver.ControlPaneEndpoint(&cc, &n, h.DriverName)
+	hostname, _, port, err := driver.ControlPlaneEndpoint(&cc, &n, h.DriverName)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -161,7 +161,7 @@ func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 
 		cpBs, err := cluster.Bootstrapper(starter.MachineAPI, viper.GetString(cmdcfg.Bootstrapper), *starter.Cfg, c.CP.Runner)
 		if err != nil {
-			return nil, errors.Wrap(err, "Failed to get control plane bootstrapper")
+			return nil, errors.Wrap(err, "getting bootstrapper for control plane")
 		}
 		joinCmd, err := cpBs.GenerateToken(*starter.Cfg)
 		if err != nil {


### PR DESCRIPTION
A refactor resulted in trying to generate the join token on the worker node, rather than the control plane, this restores the old behavior and should fix multi-node.

Fixes #7620 