### PR TITLE
wip: improve kic start restart and stop

### DIFF
--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -346,7 +346,7 @@ func (d *Driver) Stop() error {
 
 	}
 
-	// this is needed only by kic drivers becasue of the entry-point of the base image overrides the STOP and KILL SIGs
+	// this is needed only by kic drivers because of the entry-point of the base image overrides the STOP and KILL SIGs
 	// other drivers dont need this
 	if err := killAPIServerProc(d.exec); err != nil {
 		glog.Warningf("kill kube-apiserver proc: %v", err)

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -273,7 +273,7 @@ func (d *Driver) Remove() error {
 func (d *Driver) Restart() error {
 	s, err := d.GetState()
 	if err != nil {
-		glog.Warningf("get state : %v", err)
+		glog.Warningf("get state during restart: %v", err)
 	}
 	if s == state.Stopped { // don't stop if already stopped
 		return d.Start()

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -346,16 +346,6 @@ func (d *Driver) Stop() error {
 
 	}
 
-	// this is needed only by kic drivers because of the entry-point of the base image overrides the STOP and KILL SIGs
-	// other drivers dont need this
-	if err := killAPIServerProc(d.exec); err != nil {
-		glog.Warningf("kill kube-apiserver proc: %v", err)
-	}
-
-	if err := killETCDProc(d.exec); err != nil {
-		glog.Infof("kill etcd proc: %v", err)
-	}
-
 	cmd := exec.Command(d.NodeConfig.OCIBinary, "stop", d.MachineName)
 	if err := cmd.Run(); err != nil {
 		return errors.Wrapf(err, "stopping %s", d.MachineName)
@@ -368,21 +358,3 @@ func (d *Driver) RunSSHCommandFromDriver() error {
 	return fmt.Errorf("driver does not support RunSSHCommandFromDriver commands")
 }
 
-// killAPIServerProc will kill an api server proc if it exists
-// to ensure this never happens https://github.com/kubernetes/minikube/issues/7521
-func killAPIServerProc(runner command.Runner) error {
-	if _, err := runner.RunCmd(exec.Command("pkill", "-xnf", "kube-apiserver.*minikube.*")); err != nil {
-		return errors.Wrap(err, "kill apiserver")
-	}
-	return nil
-}
-
-// killETCDProc will kill an etc proc if it exists
-// this only needs to be done for kic drivers, since the base image has an entrypoint that modfies the SIGs
-// other drivers respect STOP and KILL signals. https://github.com/kubernetes/minikube/issues/7521
-func killETCDProc(runner command.Runner) error {
-	if _, err := runner.RunCmd(exec.Command("pkill", "-xnf", "etcd.*minikube.*")); err != nil {
-		return errors.Wrap(err, "kill etcd")
-	}
-	return nil
-}


### PR DESCRIPTION
as suggested by @tstromberg :
I am splitting this PR https://github.com/kubernetes/minikube/pull/7608 into smaller PRs :

### improve kic start and stop and restart by:
- allow restart proceed even if can't get state.
- container status to return state.State type.
- check container is running status after start.