### PR TITLE
test: remove dot from profile names

### DIFF
--- a/test/integration/util.go
+++ b/test/integration/util.go
@@ -56,5 +56,6 @@ func UniqueProfileName(prefix string) string {
 	if NoneDriver() {
 		return "minikube"
 	}
-	return fmt.Sprintf("%s-%s-%d", prefix, time.Now().Format("20060102T150405.999999999"), os.Getpid())
+	
+	return fmt.Sprintf("%s-%s-%d", prefix, time.Now().Format("20060102T150405.9999"), os.Getpid())
 }

--- a/test/integration/util.go
+++ b/test/integration/util.go
@@ -56,6 +56,6 @@ func UniqueProfileName(prefix string) string {
 	if NoneDriver() {
 		return "minikube"
 	}
-	
-	return fmt.Sprintf("%s-%s-%d", prefix, time.Now().Format("20060102T150405.9999"), os.Getpid())
+	// example: prefix-20200413T162239-3215
+	return fmt.Sprintf("%s-%s-%d", prefix, time.Now().Format("20060102T150405"), os.Getpid())
 }


### PR DESCRIPTION
as suggested by @tstromberg :
I am splitting this PR https://github.com/kubernetes/minikube/pull/7608 into smaller PRs :

### Remove the dot from the test profile names
while debugging I saw errors 
which causes an error in the test that it can not set the host name.

there is another PR that will prevent this in minikube itself so we dont let users to set the wrong format profile name but thats a different PR: https://github.com/kubernetes/minikube/pull/7635
