### PR TITLE
clean up logs

### DIFF
--- a/pkg/minikube/machine/fix.go
+++ b/pkg/minikube/machine/fix.go
@@ -106,8 +106,9 @@ func recreateIfNeeded(api libmachine.API, cc config.ClusterConfig, n config.Node
 	if serr != nil || s == state.Stopped || s == state.None {
 		// If virtual machine does not exist due to user interrupt cancel(i.e. Ctrl + C), recreate virtual machine
 		me, err := machineExists(h.Driver.DriverName(), s, serr)
-		glog.Infof("exists: %v err=%v", me, err)
-		glog.Infof("%q vs %q", err, constants.ErrMachineMissing)
+		if err != nil {
+			glog.Infof("machineExists: %t. err=%v", me, err)
+		}
 
 		if !me || err == constants.ErrMachineMissing {
 			out.T(out.Shrug, `{{.driver_name}} "{{.cluster}}" {{.machine_type}} is missing, will recreate.`, out.V{"driver_name": cc.Driver, "cluster": cc.Name, "machine_type": machineType})

--- a/pkg/minikube/machine/start.go
+++ b/pkg/minikube/machine/start.go
@@ -102,7 +102,7 @@ func createHost(api libmachine.API, cfg config.ClusterConfig, n config.Node) (*h
 	glog.Infof("createHost starting for %q (driver=%q)", n.Name, cfg.Driver)
 	start := time.Now()
 	defer func() {
-		glog.Infof("createHost completed in %s", time.Since(start))
+		glog.Infof("duration metric: createHost completed in %s", time.Since(start))
 	}()
 
 	if cfg.Driver == driver.VMwareFusion && viper.GetBool(config.ShowDriverDeprecationNotification) {
@@ -140,7 +140,7 @@ func createHost(api libmachine.API, cfg config.ClusterConfig, n config.Node) (*h
 	if err := timedCreateHost(h, api, 2*time.Minute); err != nil {
 		return nil, errors.Wrap(err, "creating host")
 	}
-	glog.Infof("libmachine.API.Create for %q took %s", cfg.Name, time.Since(cstart))
+	glog.Infof("duration metric: libmachine.API.Create for %q took %s", cfg.Name, time.Since(cstart))
 
 	if err := postStartSetup(h, cfg); err != nil {
 		return h, errors.Wrap(err, "post-start")

--- a/pkg/minikube/machine/stop.go
+++ b/pkg/minikube/machine/stop.go
@@ -61,7 +61,7 @@ func stop(h *host.Host) error {
 		}
 		return &retry.RetriableError{Err: errors.Wrap(err, "stop")}
 	}
-	glog.Infof("stop complete within %s", time.Since(start))
+	glog.Infof("duration metric: stop complete within %s", time.Since(start))
 	return nil
 }
 

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -47,7 +47,7 @@ func beginCacheKubernetesImages(g *errgroup.Group, imageRepository string, k8sVe
 		glog.Info("Caching tarball of preloaded images")
 		err := download.Preload(k8sVersion, cRuntime)
 		if err == nil {
-			glog.Infof("Finished downloading the preloaded tar for %s on %s", k8sVersion, cRuntime)
+			glog.Infof("Finished verifying existence of preloaded tar for  %s on %s", k8sVersion, cRuntime)
 			return // don't cache individual images if preload is successful.
 		}
 		glog.Warningf("Error downloading preloaded artifacts will continue without preload: %v", err)

--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -82,7 +82,7 @@ func configureAuth(p miniProvisioner) error {
 	glog.Infof("configureAuth start")
 	start := time.Now()
 	defer func() {
-		glog.Infof("configureAuth took %s", time.Since(start))
+		glog.Infof("duration metric: configureAuth took %s", time.Since(start))
 	}()
 
 	driver := p.GetDriver()


### PR DESCRIPTION
as suggested by @tstromberg :
I am splitting this PR https://github.com/kubernetes/minikube/pull/7608 into smaller PRs :

### cleaning up logs
- more acurate
- same format of duration metric wording