### PR TITLE
unconfine apparmor for kic

### DIFF
--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -108,7 +108,9 @@ func CreateContainerNode(p CreateParams) error {
 		// including some ones docker would otherwise do by default.
 		// for now this is what we want. in the future we may revisit this.
 		"--privileged",
-		"--security-opt", "seccomp=unconfined", // also ignore seccomp
+		"--security-opt", "seccomp=unconfined", //  ignore seccomp
+		// ignore apparmore github actions docker: https://github.com/kubernetes/minikube/issues/7624
+		"--security-opt", "apparmor=unconfined",
 		"--tmpfs", "/tmp", // various things depend on working /tmp
 		"--tmpfs", "/run", // systemd wants a writable /run
 		// logs,pods be stroed on  filesystem vs inside container,


### PR DESCRIPTION
as suggested by @tstromberg :
I am splitting this PR https://github.com/kubernetes/minikube/pull/7608 into smaller PRs :

### unconfine apparmor 
-- for dockers that have it enabled such as github actions docker