### PR TITLE
Make it possible to translate (experimental)

### DIFF
--- a/pkg/minikube/registry/global.go
+++ b/pkg/minikube/registry/global.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 
 	"github.com/golang/glog"
+	"k8s.io/minikube/pkg/minikube/translate"
 )
 
 const (
@@ -74,7 +75,8 @@ type DriverState struct {
 
 func (d DriverState) String() string {
 	if d.Priority == Experimental {
-		return fmt.Sprintf("%s (experimental)", d.Name)
+		experimental := translate.T("experimental")
+		return fmt.Sprintf("%s (%s)", d.Name, experimental)
 	}
 	return d.Name
 }


### PR DESCRIPTION
The string "experimental" was not extracted/translated