### PR TITLE
docker/podman: graceful shutdown to avoid stuck containers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,7 +152,7 @@ jobs:
         numPass=$(echo $STAT | jq '.NumberOfPass')
         echo "*** $numPass Passed ***"
         if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
-  functional_test_docker_ubuntu_18_04:
+  pause_test_docker_ubuntu_18_04:
     runs-on: ubuntu-18.04
     env:
       TIME_ELAPSED: time
@@ -206,7 +206,7 @@ jobs:
         chmod a+x e2e-*
         chmod a+x minikube-*
         START_TIME=$(date -u +%s)
-        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--driver=docker  -test.run TestFunctional -test.timeout=30m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--driver=docker  -test.run TestPause -test.timeout=30m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
         TIME_ELAPSED=$(($END_TIME-$START_TIME))
         min=$((${TIME_ELAPSED}/60))
@@ -407,7 +407,7 @@ jobs:
   # collect all the reports and upload
   upload_all_reports:
     if: always()
-    needs: [functional_test_docker_ubuntu_16_04, functional_test_docker_ubuntu_18_04,baremetal_ubuntu16_04, baremetal_ubuntu18_04]
+    needs: [functional_test_docker_ubuntu_16_04, pause_test_docker_ubuntu_18_04,baremetal_ubuntu16_04, baremetal_ubuntu18_04]
     runs-on: ubuntu-18.04
     steps:
     - name: Download Results docker_ubuntu_16_04

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -282,6 +282,10 @@ func (d *Driver) Remove() error {
 		}
 
 	}
+
+	if id, err := oci.ContainerID(d.OCIBinary, d.MachineName); err == nil && id != "" {
+		return fmt.Errorf("expected no container ID be found for %q after delete. but got %q", d.MachineName, id)
+	}
 	return nil
 }
 
@@ -368,6 +372,11 @@ func (d *Driver) Stop() error {
 		return errors.Wrapf(err, "stopping %s", d.MachineName)
 	}
 	return nil
+}
+
+// RunSSHCommandFromDriver implements direct ssh control to the driver
+func (d *Driver) RunSSHCommandFromDriver() error {
+	return fmt.Errorf("driver does not support RunSSHCommandFromDriver commands")
 }
 
 // killAPIServerProc will kill an api server proc if it exists

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -268,7 +268,7 @@ func (d *Driver) Kill() error {
 // Remove will delete the Kic Node Container
 func (d *Driver) Remove() error {
 	if _, err := oci.ContainerID(d.OCIBinary, d.MachineName); err != nil {
-		glog.Info("could not find the container %s to remove it. will try anyways", d.MachineName)
+		glog.Infof("could not find the container %s to remove it. will try anyways", d.MachineName)
 	}
 
 	if err := oci.DeleteContainer(d.NodeConfig.OCIBinary, d.MachineName); err != nil {
@@ -277,7 +277,7 @@ func (d *Driver) Remove() error {
 			return err
 		}
 		if strings.Contains(err.Error(), "No such container:") {
-			glog.Info("no container name %q found to delete", d.MachineName)
+			glog.Infof("no container name %q found to delete", d.MachineName)
 			return nil
 		}
 

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -273,16 +273,15 @@ func (d *Driver) Remove() error {
 
 	if err := oci.DeleteContainer(d.NodeConfig.OCIBinary, d.MachineName); err != nil {
 		if strings.Contains(err.Error(), "is already in progress") {
-			glog.Warningf("Docker engine is stuck. please restart docker daemon on your computer.")
-			return err
+			return errors.Wrap(err, "stuck delete")
 		}
 		if strings.Contains(err.Error(), "No such container:") {
-			glog.Infof("no container name %q found to delete", d.MachineName)
-			return nil
+			return nil // nothing was found to delete.
 		}
 
 	}
 
+	// check there be no container left after delete
 	if id, err := oci.ContainerID(d.OCIBinary, d.MachineName); err == nil && id != "" {
 		return fmt.Errorf("expected no container ID be found for %q after delete. but got %q", d.MachineName, id)
 	}

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -368,11 +368,6 @@ func (d *Driver) Stop() error {
 	return nil
 }
 
-// RunSSHCommandFromDriver implements direct ssh control to the driver
-func (d *Driver) RunSSHCommandFromDriver() error {
-	return fmt.Errorf("driver does not support RunSSHCommandFromDriver commands")
-}
-
 // killAPIServerProc will kill an api server proc if it exists
 // to ensure this never happens https://github.com/kubernetes/minikube/issues/7521
 func killAPIServerProc(runner command.Runner) error {

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -273,7 +273,7 @@ func (d *Driver) Remove() error {
 
 	if err := oci.DeleteContainer(d.NodeConfig.OCIBinary, d.MachineName); err != nil {
 		if strings.Contains(err.Error(), "is already in progress") {
-			glog.Warningf("Docker engine is stuck. please restart docker daemon on your computer.", d.MachineName)
+			glog.Warningf("Docker engine is stuck. please restart docker daemon on your computer.")
 			return err
 		}
 		if strings.Contains(err.Error(), "No such container:") {

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/docker/machine/libmachine/drivers"
-	"github.com/docker/machine/libmachine/log"
 	"github.com/docker/machine/libmachine/ssh"
 	"github.com/docker/machine/libmachine/state"
 	"github.com/golang/glog"
@@ -269,16 +268,19 @@ func (d *Driver) Kill() error {
 // Remove will delete the Kic Node Container
 func (d *Driver) Remove() error {
 	if _, err := oci.ContainerID(d.OCIBinary, d.MachineName); err != nil {
-		log.Warnf("could not find the container %s to remove it.", d.MachineName)
+		glog.Info("could not find the container %s to remove it. will try anyways", d.MachineName)
 	}
-	cmd := exec.Command(d.NodeConfig.OCIBinary, "rm", "-f", "-v", d.MachineName)
-	o, err := cmd.CombinedOutput()
-	out := strings.TrimSpace(string(o))
-	if err != nil {
-		if strings.Contains(out, "is already in progress") {
-			log.Warnf("Docker engine is stuck. please restart docker daemon on your computer.", d.MachineName)
+
+	if err := oci.DeleteContainer(d.NodeConfig.OCIBinary, d.MachineName); err != nil {
+		if strings.Contains(err.Error(), "is already in progress") {
+			glog.Warningf("Docker engine is stuck. please restart docker daemon on your computer.", d.MachineName)
+			return err
 		}
-		return errors.Wrapf(err, "removing container %s, output %s", d.MachineName, out)
+		if strings.Contains(err.Error(), "No such container:") {
+			glog.Info("no container name %q found to delete", d.MachineName)
+			return nil
+		}
+
 	}
 	return nil
 }

--- a/pkg/drivers/kic/oci/types.go
+++ b/pkg/drivers/kic/oci/types.go
@@ -31,8 +31,8 @@ const (
 	nodeRoleLabelKey = "role.minikube.sigs.k8s.io"
 	// CreatedByLabelKey is applied to any container/volume that is created by minikube created_by.minikube.sigs.k8s.io=true
 	CreatedByLabelKey = "created_by.minikube.sigs.k8s.io"
-	// ShutDownCmd is the command halt and stop the container
-	ShutDownCmd = "sudo init 0"
+	// ShutownCmd is the command halt and stop the container
+	ShutownCmd = "sudo init 0"
 )
 
 // CreateParams are parameters needed to create a container

--- a/pkg/drivers/kic/oci/types.go
+++ b/pkg/drivers/kic/oci/types.go
@@ -31,6 +31,8 @@ const (
 	nodeRoleLabelKey = "role.minikube.sigs.k8s.io"
 	// CreatedByLabelKey is applied to any container/volume that is created by minikube created_by.minikube.sigs.k8s.io=true
 	CreatedByLabelKey = "created_by.minikube.sigs.k8s.io"
+	// ShutDownCmd is the command halt and stop the container
+	ShutDownCmd = "sudo init 0"
 )
 
 // CreateParams are parameters needed to create a container

--- a/pkg/drivers/kic/oci/types.go
+++ b/pkg/drivers/kic/oci/types.go
@@ -31,8 +31,6 @@ const (
 	nodeRoleLabelKey = "role.minikube.sigs.k8s.io"
 	// CreatedByLabelKey is applied to any container/volume that is created by minikube created_by.minikube.sigs.k8s.io=true
 	CreatedByLabelKey = "created_by.minikube.sigs.k8s.io"
-	// ShutownCmd is the command halt and stop the container
-	ShutownCmd = "sudo init 0"
 )
 
 // CreateParams are parameters needed to create a container

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -140,6 +140,16 @@ func HasResourceLimits(name string) bool {
 	return !(name == None || name == Podman)
 }
 
+// NeedsShutdown returns true if driver needs manual shutdown command before stopping.
+// Hyper-V requires special care to avoid ACPI and file locking issues
+// KIC also needs shutdown to avoid container getting stuck, https://github.com/kubernetes/minikube/issues/7657
+func NeedsShutdown(name string) bool {
+	if name == HyperV || IsKIC(name) {
+		return true
+	}
+	return false
+}
+
 // FlagHints are hints for what default options should be used for this driver
 type FlagHints struct {
 	ExtraOptions     []string

--- a/pkg/minikube/machine/delete.go
+++ b/pkg/minikube/machine/delete.go
@@ -49,6 +49,9 @@ func deleteOrphanedKIC(ociBin string, name string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
+	if err := oci.ShutDown(ociBin, name); err != nil {
+		glog.Info("couldn't shut down %s (might be okay): %v ", name, err)
+	}
 	cmd := exec.CommandContext(ctx, ociBin, "rm", "-f", "-v", name)
 	err = cmd.Run()
 	if err == nil {

--- a/pkg/minikube/machine/delete.go
+++ b/pkg/minikube/machine/delete.go
@@ -77,8 +77,8 @@ func DeleteHost(api libmachine.API, machineName string) error {
 		return mcnerror.ErrHostDoesNotExist{Name: machineName}
 	}
 
-	// Hyper-V requires special care to avoid ACPI and file locking issues
-	if host.Driver.DriverName() == driver.HyperV {
+	// some drivers need manual shut down before delete to avoid getting stuck.
+	if driver.NeedsShutdown(host.Driver.DriverName()) {
 		if err := StopHost(api, machineName); err != nil {
 			glog.Warningf("stop host: %v", err)
 		}

--- a/pkg/minikube/machine/delete.go
+++ b/pkg/minikube/machine/delete.go
@@ -50,7 +50,7 @@ func deleteOrphanedKIC(ociBin string, name string) {
 	defer cancel()
 
 	if err := oci.ShutDown(ociBin, name); err != nil {
-		glog.Info("couldn't shut down %s (might be okay): %v ", name, err)
+		glog.Infof("couldn't shut down %s (might be okay): %v ", name, err)
 	}
 	cmd := exec.CommandContext(ctx, ociBin, "rm", "-f", "-v", name)
 	err = cmd.Run()

--- a/pkg/minikube/machine/stop.go
+++ b/pkg/minikube/machine/stop.go
@@ -46,7 +46,7 @@ func StopHost(api libmachine.API, machineName string) error {
 // stop forcibly stops a host without needing to load
 func stop(h *host.Host) error {
 	start := time.Now()
-	if h.DriverName == driver.HyperV {
+	if driver.NeedsShutdown(h.DriverName) {
 		glog.Infof("As there are issues with stopping Hyper-V VMs using API, trying to shut down using SSH")
 		if err := trySSHPowerOff(h); err != nil {
 			return errors.Wrap(err, "ssh power off")
@@ -80,8 +80,8 @@ func trySSHPowerOff(h *host.Host) error {
 
 	out.T(out.Shutdown, `Powering off "{{.profile_name}}" via SSH ...`, out.V{"profile_name": h.Name})
 	if driver.IsKIC(h.DriverName) {
-		out, err := h.RunSSHCommand(oci.ShutDownCmd)
-		glog.Infof("shutdown cmd %q result: out=%s, err=%v", oci.ShutDownCmd, out, err)
+		out, err := h.RunSSHCommand(oci.ShutownCmd)
+		glog.Infof("shutdown cmd %q result: out=%s, err=%v", oci.ShutownCmd, out, err)
 	} else {
 		out, err := h.RunSSHCommand("sudo poweroff")
 		// poweroff always results in an error, since the host disconnects.

--- a/pkg/minikube/machine/stop.go
+++ b/pkg/minikube/machine/stop.go
@@ -25,6 +25,7 @@ import (
 	"github.com/docker/machine/libmachine/state"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/util/retry"
@@ -78,8 +79,13 @@ func trySSHPowerOff(h *host.Host) error {
 	}
 
 	out.T(out.Shutdown, `Powering off "{{.profile_name}}" via SSH ...`, out.V{"profile_name": h.Name})
-	out, err := h.RunSSHCommand("sudo poweroff")
-	// poweroff always results in an error, since the host disconnects.
-	glog.Infof("poweroff result: out=%s, err=%v", out, err)
+	if driver.IsKIC(h.DriverName) {
+		out, err := h.RunSSHCommand(oci.ShutDownCmd)
+		glog.Infof("shutdown cmd %q result: out=%s, err=%v", oci.ShutDownCmd, out, err)
+	} else {
+		out, err := h.RunSSHCommand("sudo poweroff")
+		// poweroff always results in an error, since the host disconnects.
+		glog.Infof("poweroff result: out=%s, err=%v", out, err)
+	}
 	return nil
 }

--- a/pkg/minikube/machine/stop.go
+++ b/pkg/minikube/machine/stop.go
@@ -47,7 +47,6 @@ func StopHost(api libmachine.API, machineName string) error {
 func stop(h *host.Host) error {
 	start := time.Now()
 	if driver.NeedsShutdown(h.DriverName) {
-		glog.Infof("As there are issues with stopping Hyper-V VMs using API, trying to shut down using SSH")
 		if err := trySSHPowerOff(h); err != nil {
 			return errors.Wrap(err, "ssh power off")
 		}
@@ -79,6 +78,7 @@ func trySSHPowerOff(h *host.Host) error {
 	}
 
 	out.T(out.Shutdown, `Powering off "{{.profile_name}}" via SSH ...`, out.V{"profile_name": h.Name})
+	// differnet for kic because RunSSHCommand is not implemented by kic
 	if driver.IsKIC(h.DriverName) {
 		err := oci.ShutDown(h.DriverName, h.Name)
 		glog.Infof("shutdown container: err=%v", err)

--- a/pkg/minikube/machine/stop.go
+++ b/pkg/minikube/machine/stop.go
@@ -80,8 +80,8 @@ func trySSHPowerOff(h *host.Host) error {
 
 	out.T(out.Shutdown, `Powering off "{{.profile_name}}" via SSH ...`, out.V{"profile_name": h.Name})
 	if driver.IsKIC(h.DriverName) {
-		out, err := h.RunSSHCommand(oci.ShutownCmd)
-		glog.Infof("shutdown cmd %q result: out=%s, err=%v", oci.ShutownCmd, out, err)
+		err := oci.ShutDown(h.DriverName, h.Name)
+		glog.Infof("shutdown container: err=%v", err)
 	} else {
 		out, err := h.RunSSHCommand("sudo poweroff")
 		// poweroff always results in an error, since the host disconnects.

--- a/test/integration/pause_test.go
+++ b/test/integration/pause_test.go
@@ -1,0 +1,88 @@
+// +build integration
+
+/*
+Copyright 2020 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+)
+
+func TestPause(t *testing.T) {
+	MaybeParallel(t)
+
+	type validateFunc func(context.Context, *testing.T, string)
+	profile := UniqueProfileName("pause")
+	ctx, cancel := context.WithTimeout(context.Background(), Minutes(30))
+	defer CleanupWithLogs(t, profile, cancel)
+
+	// Serial tests
+	t.Run("serial", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			validator validateFunc
+		}{
+			{"Start", validateFreshStart},
+			{"Pause", validatePause},
+			{"Unpause", validateUnpause},
+			{"Pause Again", validatePause},
+			{"delete", validateDelete},
+		}
+		for _, tc := range tests {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				tc.validator(ctx, t, profile)
+			})
+		}
+	})
+}
+
+// validateFreshStart
+func validateFreshStart(ctx context.Context, t *testing.T, profile string) {
+	args := append([]string{"start", "-p", profile, "--memory=1800", "--install-addons=false", "--wait=false"}, StartArgs()...)
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
+	if err != nil {
+		t.Fatalf("failed to start minikube with args: %q : %v", rr.Command(), err)
+	}
+}
+
+func validatePause(ctx context.Context, t *testing.T, profile string) {
+	args := append([]string{"pause", "-p", profile, "--alsologtostderr", "-v=5"}, StartArgs()...)
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
+	if err != nil {
+		t.Errorf("failed to pause minikube with args: %q : %v", rr.Command(), err)
+	}
+}
+
+func validateUnpause(ctx context.Context, t *testing.T, profile string) {
+	args := append([]string{"unpause", "-p", profile, "--alsologtostderr", "-v=5"}, StartArgs()...)
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
+	if err != nil {
+		t.Errorf("failed to unpause minikube with args: %q : %v", rr.Command(), err)
+	}
+}
+
+func validateDelete(ctx context.Context, t *testing.T, profile string) {
+	// vervose logging because this might go wrong, if container get stuck
+	args := append([]string{"delete", "-p", profile, "--alsologtostderr", "-v=5"}, StartArgs()...)
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
+	if err != nil {
+		t.Errorf("failed to delete minikube with args: %q : %v", rr.Command(), err)
+	}
+}

--- a/test/integration/pause_test.go
+++ b/test/integration/pause_test.go
@@ -41,8 +41,8 @@ func TestPause(t *testing.T) {
 			{"Start", validateFreshStart},
 			{"Pause", validatePause},
 			{"Unpause", validateUnpause},
-			{"Pause Again", validatePause},
-			{"delete", validateDelete},
+			{"PauseAgain", validatePause},
+			{"DeletePaused", validateDelete},
 		}
 		for _, tc := range tests {
 			tc := tc
@@ -63,7 +63,7 @@ func validateFreshStart(ctx context.Context, t *testing.T, profile string) {
 }
 
 func validatePause(ctx context.Context, t *testing.T, profile string) {
-	args := append([]string{"pause", "-p", profile, "--alsologtostderr", "-v=5"}, StartArgs()...)
+	args := []string{"pause", "-p", profile, "--alsologtostderr", "-v=5"}
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
 		t.Errorf("failed to pause minikube with args: %q : %v", rr.Command(), err)
@@ -71,7 +71,7 @@ func validatePause(ctx context.Context, t *testing.T, profile string) {
 }
 
 func validateUnpause(ctx context.Context, t *testing.T, profile string) {
-	args := append([]string{"unpause", "-p", profile, "--alsologtostderr", "-v=5"}, StartArgs()...)
+	args := []string{"unpause", "-p", profile, "--alsologtostderr", "-v=5"}
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
 		t.Errorf("failed to unpause minikube with args: %q : %v", rr.Command(), err)
@@ -80,7 +80,7 @@ func validateUnpause(ctx context.Context, t *testing.T, profile string) {
 
 func validateDelete(ctx context.Context, t *testing.T, profile string) {
 	// vervose logging because this might go wrong, if container get stuck
-	args := append([]string{"delete", "-p", profile, "--alsologtostderr", "-v=5"}, StartArgs()...)
+	args := []string{"delete", "-p", profile, "--alsologtostderr", "-v=5"}
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
 		t.Errorf("failed to delete minikube with args: %q : %v", rr.Command(), err)

--- a/test/integration/pause_test.go
+++ b/test/integration/pause_test.go
@@ -53,7 +53,6 @@ func TestPause(t *testing.T) {
 	})
 }
 
-// validateFreshStart
 func validateFreshStart(ctx context.Context, t *testing.T, profile string) {
 	args := append([]string{"start", "-p", profile, "--memory=1800", "--install-addons=false", "--wait=false"}, StartArgs()...)
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))


### PR DESCRIPTION
redoing this PR from sctratch after getting lost in the woods !
 https://github.com/kubernetes/minikube/pull/7660

### After this PR no more container get stuck:

```
medmac@~/workspace/minikube (kic_stuck_redo1) $ ./out/minikube start --driver=docker
😄  minikube v1.9.2 on Darwin 10.13.6
✨  Using the docker driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=4000MB) ...
🐳  Preparing Kubernetes v1.18.0 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16
🌟  Enabling addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube"
medmac@~/workspace/minikube (kic_stuck_redo1) $ ./out/minikube pause
⏯️  Paused kubelet and 8 containers in: kube-system, kubernetes-dashboard, storage-gluster, istio-operator
medmac@~/workspace/minikube (kic_stuck_redo1) $ ./out/minikube delete --all
🔥  Deleting "minikube" in docker ...
🔥  Removing /Users/medmac/.minikube/machines/minikube ...
💀  Removed all traces of the "minikube" cluster.
🔥  Successfully deleted all profiles
medmac@~/workspace/minikube (kic_stuck_redo1) $ docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
```

Also added integration tests, so this might never happen again !