### PR TITLE
Exits gracefully if container runtime is mispelled

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -322,7 +322,7 @@ func runStart(cmd *cobra.Command, args []string) {
 	k8sVersion := getKubernetesVersion(existing)
 	cc, n, err := generateCfgFromFlags(cmd, k8sVersion, driverName)
 	if err != nil {
-		exit.WithError("Failed to generate config", err)
+		exit.UsageT("Failed to load configration. {{.error}}", out.V{"error": err.Error()})
 	}
 
 	// This is about as far as we can go without overwriting config files

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -20,6 +20,7 @@ package cruntime
 import (
 	"fmt"
 	"os/exec"
+	"strings"
 
 	"github.com/blang/semver"
 	"github.com/golang/glog"
@@ -44,6 +45,10 @@ const (
 
 func (cs ContainerState) String() string {
 	return [...]string{"all", "running", "paused"}[cs]
+}
+
+func supportedContainerRuntimes() []string {
+	return []string{"docker", "crio", "containerd"}
 }
 
 // CommandRunner is the subset of command.Runner this package consumes
@@ -139,7 +144,7 @@ func New(c Config) (Manager, error) {
 	case "containerd":
 		return &Containerd{Socket: c.Socket, Runner: c.Runner, ImageRepository: c.ImageRepository, KubernetesVersion: c.KubernetesVersion}, nil
 	default:
-		return nil, fmt.Errorf("unknown runtime type: %q", c.Type)
+		return nil, fmt.Errorf("Invalid Runtime: %q\n\nThe supported runtimes are: %s", c.Type, strings.Join(supportedContainerRuntimes(), ", "))
 	}
 }
 


### PR DESCRIPTION
fixes #7426 

![image](https://user-images.githubusercontent.com/28949397/79332404-68204f00-7f3a-11ea-8de8-d6129615b8ac.png)
