### PR TITLE
Fix navbar logo font to match headings

### DIFF
--- a/site/assets/scss/_variables_project.scss
+++ b/site/assets/scss/_variables_project.scss
@@ -40,7 +40,7 @@ body, p {
 }
 
 
-h1,h2,h3,h4,h5 {
+h1,h2,h3,h4,h5,.navbar-brand {
     font-family: 'Open Sans', sans-serif !important;
 }
 


### PR DESCRIPTION
This was a regression from the recent UI overhaul.