### PR TITLE
Log the remote OS also for the KIC drivers

### DIFF
--- a/pkg/minikube/machine/start.go
+++ b/pkg/minikube/machine/start.go
@@ -206,7 +206,7 @@ func postStartSetup(h *host.Host, mc config.ClusterConfig) error {
 	if driver.BareMetal(mc.Driver) {
 		showLocalOsRelease()
 	}
-	if driver.IsVM(mc.Driver) {
+	if driver.IsVM(mc.Driver) || driver.IsKIC(mc.Driver) {
 		logRemoteOsRelease(r)
 	}
 	return syncLocalAssets(r)


### PR DESCRIPTION
Currently Ubuntu 19.10, from `kindest/base`