### PR TITLE
docker on Linux: Add "Permission Denied" advice 

### DIFF
--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -97,6 +97,10 @@ func status() registry.State {
 		stderr := strings.TrimSpace(string(exitErr.Stderr))
 		newErr := fmt.Errorf(`%q %v: %s`, strings.Join(cmd.Args, " "), exitErr, stderr)
 
+		if strings.Contains(stderr, "permission denied") && runtime.GOOS == "linux" {
+			return registry.State{Error: newErr, Installed: true, Healthy: false, Fix: "Add your user to the 'docker' group, then re-login to your system", Doc: "https://docs.docker.com/engine/install/linux-postinstall/"}
+		}
+
 		if strings.Contains(stderr, "Cannot connect") || strings.Contains(stderr, "refused") || strings.Contains(stderr, "Is the docker daemon running") {
 			return registry.State{Error: newErr, Installed: true, Healthy: false, Fix: "Start the Docker service", Doc: docURL}
 		}

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -98,7 +98,7 @@ func status() registry.State {
 		newErr := fmt.Errorf(`%q %v: %s`, strings.Join(cmd.Args, " "), exitErr, stderr)
 
 		if strings.Contains(stderr, "permission denied") && runtime.GOOS == "linux" {
-			return registry.State{Error: newErr, Installed: true, Healthy: false, Fix: "Add your user to the 'docker' group, then re-login to your system", Doc: "https://docs.docker.com/engine/install/linux-postinstall/"}
+			return registry.State{Error: newErr, Installed: true, Healthy: false, Fix: "Add your user to the 'docker' group: 'sudo usermod -aG docker $USER && newgrp docker'", Doc: "https://docs.docker.com/engine/install/linux-postinstall/"}
 		}
 
 		if strings.Contains(stderr, "Cannot connect") || strings.Contains(stderr, "refused") || strings.Contains(stderr, "Is the docker daemon running") {


### PR DESCRIPTION
Improve advice shown when the user is not in the Docker group. Fixes #7605

## Before

```
❗  'docker' driver reported an issue: "docker version --format {{.Server.Version}}" exit status 1: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get http://%2Fvar%2Frun%2Fdocker.sock/v1.40/version: dial unix /var/run/docker.sock: connect: permission denied
💡  Suggestion: 
📘  Documentation: https://minikube.sigs.k8s.io/docs/drivers/docker/

💣  Failed to validate 'docker' driver
```

## After

```
❗  'docker' driver reported an issue: "docker version --format {{.Server.Version}}" exit status 1: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get http://%2Fvar%2Frun%2Fdocker.sock/v1.40/version: dial unix /var/run/docker.sock: connect: permission denied
💡  Suggestion: Add your user to the 'docker' group: 'sudo usermod -aG docker $USER && newgrp docker'
📘  Documentation: https://docs.docker.com/engine/install/linux-postinstall/

💣  Failed to validate 'docker' driver
```

I've tested the instructions.
