### PR TITLE
CI: add -unattended to docker on mac os machines

### DIFF
--- a/hack/jenkins/osx_integration_tests_docker.sh
+++ b/hack/jenkins/osx_integration_tests_docker.sh
@@ -37,7 +37,7 @@ sudo /Applications/Docker.app/Contents/MacOS/Docker --quit-after-install --unatt
 # repeating above command without sudo because  https://github.com/docker/for-mac/issues/882#issuecomment-516946766
 /Applications/Docker.app/Contents/MacOS/Docker --quit-after-install --unattended || true
 
-# restart docker on mac for a fresh test
+# restart docker on mac
 osascript -e 'quit app "Docker"'; open -a Docker /Applications/Docker.app/Contents/MacOS/Docker --quit-after-install --unattended  ; while [ -z "$(docker info 2> /dev/null )" ]; do printf "."; sleep 1; done; echo "" || true
 
 mkdir -p cron && gsutil -qm rsync "gs://minikube-builds/${MINIKUBE_LOCATION}/cron" cron || echo "FAILED TO GET CRON FILES"

--- a/hack/jenkins/osx_integration_tests_docker.sh
+++ b/hack/jenkins/osx_integration_tests_docker.sh
@@ -32,14 +32,13 @@ JOB_NAME="Docker_macOS"
 EXTRA_START_ARGS=""
 EXPECTED_DEFAULT_DRIVER="hyperkit"
 
-
-# fix mac os as a service on mac os
-# https://github.com/docker/for-mac/issues/882#issuecomment-506372814
-osascript -e 'quit app "Docker"';
+osascript -e 'quit app "Docker"'
 sudo /Applications/Docker.app/Contents/MacOS/Docker --quit-after-install --unattended || true
-# repeating without sudo because  https://github.com/docker/for-mac/issues/882#issuecomment-516946766
+# repeating above command without sudo because  https://github.com/docker/for-mac/issues/882#issuecomment-516946766
 /Applications/Docker.app/Contents/MacOS/Docker --quit-after-install --unattended || true
-osascript -e 'quit app "Docker"'; /Applications/Docker.app/Contents/MacOS/Docker --unattended &; while [ -z "$(docker info 2> /dev/null )" ]; do printf "."; sleep 1; done; echo "" || true
+
+# restart docker on mac for a fresh test
+osascript -e 'quit app "Docker"'; open -a Docker /Applications/Docker.app/Contents/MacOS/Docker --quit-after-install --unattended  ; while [ -z "$(docker info 2> /dev/null )" ]; do printf "."; sleep 1; done; echo "" || true
 
 mkdir -p cron && gsutil -qm rsync "gs://minikube-builds/${MINIKUBE_LOCATION}/cron" cron || echo "FAILED TO GET CRON FILES"
 install cron/cleanup_and_reboot_Darwin.sh $HOME/cleanup_and_reboot.sh || echo "FAILED TO INSTALL CLEANUP"


### PR DESCRIPTION
based on insights in this issue https://github.com/docker/for-mac/issues/882 to make docker run in CI on macOS