### PR TITLE
Improve reliability of cluster role binding creation for containerd/cri-o

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -835,11 +835,12 @@ func (k *Bootstrapper) elevateKubeSystemPrivileges(cfg config.ClusterConfig) err
 		}
 	}
 
+	// verfy it is created if user specified to wait
 	if cfg.VerifyComponents[kverify.DefaultSAWaitKey] {
 		// double checking defalut sa was created.
 		// good for ensuring using minikube in CI is robust.
 		checkSA := func() error {
-			cmd = exec.CommandContext(ctx, "sudo", kubectlPath(cfg),
+			cmd = exec.Command("sudo", kubectlPath(cfg),
 				"get", "sa", "default", fmt.Sprintf("--kubeconfig=%s", path.Join(vmpath.GuestPersistentDir, "kubeconfig")))
 			rr, err = k.c.RunCmd(cmd)
 			if err != nil {
@@ -853,6 +854,5 @@ func (k *Bootstrapper) elevateKubeSystemPrivileges(cfg config.ClusterConfig) err
 			return errors.Wrap(err, "ensure sa was created")
 		}
 	}
-
 	return nil
 }

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -202,20 +202,15 @@ func (k *Bootstrapper) init(cfg config.ClusterConfig) error {
 	}
 
 	var wg sync.WaitGroup
-	wg.Add(4)
+	wg.Add(3)
 
 	go func() {
+		// we need to have cluster role binding before applying overlay to avoid #7428
+		if err := k.elevateKubeSystemPrivileges(cfg); err != nil {
+			glog.Errorf("unable to create cluster role binding, some addons might not work: %v", err)
+		}
 		// the overlay is required for containerd and cri-o runtime: see #7428
 		if driver.IsKIC(cfg.Driver) && cfg.KubernetesConfig.ContainerRuntime != "docker" {
-			// this is a sepcial wait only for containerd,cri-o on docker
-			// because for containerd and cri-o we need to
-			// to wait for default SA to be up to avoid #7704
-			tmpCFG := cfg // making a temp config to use for this specific wait
-			tmpCFG.VerifyComponents = map[string]bool{kverify.DefaultSAWaitKey: true}
-			glog.Infof("waiting for default sevice account before we apply kic overlay")
-			if err := k.WaitForNode(tmpCFG, tmpCFG.Nodes[0], time.Second*30); err != nil {
-				glog.Warningf("failed to wait for default serive account. This might cause issue #7704 when applying kic overlay.")
-			}
 			if err := k.applyKICOverlay(cfg); err != nil {
 				glog.Errorf("failed to apply kic overlay: %v", err)
 			}
@@ -233,13 +228,6 @@ func (k *Bootstrapper) init(cfg config.ClusterConfig) error {
 	go func() {
 		if err := bsutil.AdjustResourceLimits(k.c); err != nil {
 			glog.Warningf("unable to adjust resource limits: %v", err)
-		}
-		wg.Done()
-	}()
-
-	go func() {
-		if err := k.elevateKubeSystemPrivileges(cfg); err != nil {
-			glog.Warningf("unable to create cluster role binding, some addons might not work: %v", err)
 		}
 		wg.Done()
 	}()
@@ -829,6 +817,7 @@ func (k *Bootstrapper) applyNodeLabels(cfg config.ClusterConfig) error {
 // elevateKubeSystemPrivileges gives the kube-system service account cluster admin privileges to work with RBAC.
 func (k *Bootstrapper) elevateKubeSystemPrivileges(cfg config.ClusterConfig) error {
 	start := time.Now()
+	defer glog.Infof("duration metric: took %s to wait for elevateKubeSystemPrivileges.", time.Since(start))
 	// Allow no more than 5 seconds for creating cluster role bindings
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -845,6 +834,25 @@ func (k *Bootstrapper) elevateKubeSystemPrivileges(cfg config.ClusterConfig) err
 			return nil
 		}
 	}
-	glog.Infof("duration metric: took %s to wait for elevateKubeSystemPrivileges.", time.Since(start))
-	return err
+
+	if cfg.VerifyComponents[kverify.DefaultSAWaitKey] {
+		// double checking defalut sa was created.
+		// good for ensuring using minikube in CI is robust.
+		checkSA := func() error {
+			cmd = exec.CommandContext(ctx, "sudo", kubectlPath(cfg),
+				"get", "sa", "default", fmt.Sprintf("--kubeconfig=%s", path.Join(vmpath.GuestPersistentDir, "kubeconfig")))
+			rr, err = k.c.RunCmd(cmd)
+			if err != nil {
+				return err
+			}
+			return nil
+		}
+
+		// retry up to make sure SA is created
+		if err := retry.Expo(checkSA, 1*time.Millisecond, time.Minute); err != nil {
+			return errors.Wrap(err, "ensure sa was created")
+		}
+	}
+
+	return nil
 }

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -37,6 +37,7 @@ import (
 	"github.com/docker/machine/libmachine/state"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	kconst "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/minikube/pkg/drivers/kic"
@@ -817,7 +818,10 @@ func (k *Bootstrapper) applyNodeLabels(cfg config.ClusterConfig) error {
 // elevateKubeSystemPrivileges gives the kube-system service account cluster admin privileges to work with RBAC.
 func (k *Bootstrapper) elevateKubeSystemPrivileges(cfg config.ClusterConfig) error {
 	start := time.Now()
-	defer glog.Infof("duration metric: took %s to wait for elevateKubeSystemPrivileges.", time.Since(start))
+	defer func() {
+		glog.Infof("duration metric: took %s to wait for elevateKubeSystemPrivileges.", time.Since(start))
+	}()
+
 	// Allow no more than 5 seconds for creating cluster role bindings
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -835,22 +839,21 @@ func (k *Bootstrapper) elevateKubeSystemPrivileges(cfg config.ClusterConfig) err
 		}
 	}
 
-	// verfy it is created if user specified to wait
 	if cfg.VerifyComponents[kverify.DefaultSAWaitKey] {
 		// double checking defalut sa was created.
 		// good for ensuring using minikube in CI is robust.
-		checkSA := func() error {
+		checkSA := func() (bool, error) {
 			cmd = exec.Command("sudo", kubectlPath(cfg),
 				"get", "sa", "default", fmt.Sprintf("--kubeconfig=%s", path.Join(vmpath.GuestPersistentDir, "kubeconfig")))
 			rr, err = k.c.RunCmd(cmd)
 			if err != nil {
-				return err
+				return false, nil
 			}
-			return nil
+			return true, nil
 		}
 
 		// retry up to make sure SA is created
-		if err := retry.Expo(checkSA, 1*time.Millisecond, time.Minute); err != nil {
+		if err := wait.PollImmediate(kconst.APICallRetryInterval, time.Minute, checkSA); err != nil {
 			return errors.Wrap(err, "ensure sa was created")
 		}
 	}

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -324,11 +324,11 @@ func (k *Bootstrapper) client(ip string, port int) (*kubernetes.Clientset, error
 }
 
 // WaitForNode blocks until the node appears to be healthy
-func (k *Bootstrapper) WaitForNode(cfg config.ClusterConfig, myNode config.Node, timeout time.Duration) error {
+func (k *Bootstrapper) WaitForNode(cfg config.ClusterConfig, n config.Node, timeout time.Duration) error {
 	start := time.Now()
 
-	if !myNode.ControlPlane {
-		glog.Infof("%s is not a control plane, nothing to wait for", myNode.Name)
+	if !n.ControlPlane {
+		glog.Infof("%s is not a control plane, nothing to wait for", n.Name)
 		return nil
 	}
 	if !kverify.ShouldWait(cfg.VerifyComponents) {
@@ -341,7 +341,7 @@ func (k *Bootstrapper) WaitForNode(cfg config.ClusterConfig, myNode config.Node,
 		return errors.Wrapf(err, "create runtme-manager %s", cfg.KubernetesConfig.ContainerRuntime)
 	}
 
-	hostname, _, port, err := driver.ControlPaneEndpoint(&cfg, &myNode, cfg.Driver)
+	hostname, _, port, err := driver.ControlPaneEndpoint(&cfg, &n, cfg.Driver)
 	if err != nil {
 		return errors.Wrap(err, "get control plane endpoint")
 	}

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -398,7 +398,7 @@ func validateNetwork(h *host.Host, r command.Runner, imageRepository string) (st
 			ipExcluded := proxy.IsIPExcluded(ip) // Skip warning if minikube ip is already in NO_PROXY
 			k = strings.ToUpper(k)               // for http_proxy & https_proxy
 			if (k == "HTTP_PROXY" || k == "HTTPS_PROXY") && !ipExcluded && !warnedOnce {
-				out.WarningT("You appear to be using a proxy, but your NO_PROXY environment does not include the minikube IP ({{.ip_address}}). Please see {{.documentation_url}} for more details", out.V{"ip_address": ip, "documentation_url": "https://minikube.sigs.k8s.io/docs/reference/networking/proxy/"})
+				out.WarningT("You appear to be using a proxy, but your NO_PROXY environment does not include the minikube IP ({{.ip_address}}). Please see {{.documentation_url}} for more details", out.V{"ip_address": ip, "documentation_url": "https://minikube.sigs.k8s.io/docs/handbook/vpn_and_proxy/"})
 				warnedOnce = true
 			}
 		}

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -133,11 +133,6 @@ func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 		wg.Done()
 	}()
 
-	// enable addons, both old and new!
-	if starter.ExistingAddons != nil {
-		go addons.Start(&wg, starter.Cfg, starter.ExistingAddons, config.AddonList)
-	}
-
 	if apiServer {
 		// special ops for none , like change minikube directory.
 		// multinode super doesn't work on the none driver
@@ -149,6 +144,10 @@ func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 		if kverify.ShouldWait(starter.Cfg.VerifyComponents) && !starter.PreExists {
 			if err := bs.WaitForNode(*starter.Cfg, *starter.Node, viper.GetDuration(waitTimeout)); err != nil {
 				return nil, errors.Wrap(err, "Wait failed")
+			}
+			// enable addons, both old and new!
+			if starter.ExistingAddons != nil {
+				go addons.Start(&wg, starter.Cfg, starter.ExistingAddons, config.AddonList)
 			}
 		}
 	} else {
@@ -168,6 +167,10 @@ func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 
 		if err = bs.JoinCluster(*starter.Cfg, *starter.Node, joinCmd); err != nil {
 			return nil, errors.Wrap(err, "joining cluster")
+		}
+		// enable addons, both old and new!
+		if starter.ExistingAddons != nil {
+			go addons.Start(&wg, starter.Cfg, starter.ExistingAddons, config.AddonList)
 		}
 	}
 


### PR DESCRIPTION
closes https://github.com/kubernetes/minikube/issues/7704


## Why this PR ?
### Integration Test Flake 
To fix flakes like this:
 https://storage.googleapis.com/minikube-builds/logs/7611/d3db795/Docker_Linux.html#fail_TestStartStop%2fgroup%2fcontainerd
```
 cannot list resource "secrets" in API group "" in the namespace "kube-system": no relationship found between node "containerd-20200415t195638-32245" and this object
```

### what was happening ?
we tried to apply kic overlay network and enable addons and Elevate System Permissions in Parallel.  we need default service account before creating things on minikube.

### which drivers are affected by this PR ?
- Expected slower --wait=true for on  only Containerd and CRIO runtimes on docker/podman drivers. 



### Future PRS ?
users reported same error for when they enabled addons on virtualbox 
https://github.com/kubernetes/minikube/issues/7613 
we need to refactor enable addons, in a way that it always ensures the Default SA is created. it could be part of Bootstrapper Interface.