### PR TITLE
possible typo ? Flush defer

### DIFF
--- a/cmd/minikube/main.go
+++ b/cmd/minikube/main.go
@@ -53,7 +53,7 @@ var (
 
 func main() {
 	bridgeLogMessages()
-	defer glog.Flush()
+	defer func() { glog.Flush() }()
 
 	if os.Getenv(minikubeEnableProfile) == "1" {
 		defer profile.Start(profile.TraceProfile).Stop()

--- a/cmd/minikube/main.go
+++ b/cmd/minikube/main.go
@@ -56,7 +56,7 @@ func main() {
 	defer func() { glog.Flush() }()
 
 	if os.Getenv(minikubeEnableProfile) == "1" {
-		defer profile.Start(profile.TraceProfile).Stop()
+		defer func() { profile.Start(profile.TraceProfile).Stop() }()
 	}
 	if os.Getenv(constants.IsMinikubeChildProcess) == "" {
 		machine.StartDriver()


### PR DESCRIPTION
while I was doing a PR I noticed this code was wrong:
```
	start := time.Now()
	glog.Infof("duration metric: took %s to wait for elevateKubeSystemPrivileges.", time.Since(start))
```
and the correct was
```
	start := time.Now()
	defer func() {
		glog.Infof("duration metric: took %s to wait for elevateKubeSystemPrivileges.", time.Since(start))
	}()
```
I saw this in the code, not sure if this is also a mistake or am I reading it wrong.

