### PR TITLE
Add Docker for Windows to pending job list

### DIFF
--- a/hack/jenkins/minikube_set_pending.sh
+++ b/hack/jenkins/minikube_set_pending.sh
@@ -42,6 +42,7 @@ jobs=(
      'none_Linux'
      'Docker_Linux'
      'Docker_macOS'
+     'Docker_Windows'
      'Podman_Linux'
 )
 


### PR DESCRIPTION
Enables the Docker for Windows job on Jenkins.