### PR TITLE
Fix update-context in order to recover kubeconfig even if it's missing

### DIFF
--- a/pkg/minikube/kubeconfig/kubeconfig.go
+++ b/pkg/minikube/kubeconfig/kubeconfig.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 
@@ -30,6 +31,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/tools/clientcmd/api/latest"
 	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/localpath"
 	pkgutil "k8s.io/minikube/pkg/util"
 	"k8s.io/minikube/pkg/util/lock"
 )
@@ -103,24 +105,43 @@ func Endpoint(contextName string, configPath ...string) (string, int, error) {
 }
 
 // UpdateEndpoint overwrites the IP stored in kubeconfig with the provided IP.
-func UpdateEndpoint(contextName string, hostname string, port int, path string) (bool, error) {
+func UpdateEndpoint(contextName string, hostname string, port int, confpath string) (bool, error) {
 	if hostname == "" {
 		return false, fmt.Errorf("empty ip")
 	}
 
-	err := VerifyEndpoint(contextName, hostname, port, path)
+	err := VerifyEndpoint(contextName, hostname, port, confpath)
 	if err == nil {
 		return false, nil
 	}
 	glog.Infof("verify returned: %v", err)
 
-	cfg, err := readOrNew(path)
+	cfg, err := readOrNew(confpath)
 	if err != nil {
 		return false, errors.Wrap(err, "read")
 	}
 
-	cfg.Clusters[contextName].Server = "https://" + hostname + ":" + strconv.Itoa(port)
-	err = writeToFile(cfg, path)
+	address := "https://" + hostname + ":" + strconv.Itoa(port)
+
+	// if the kubeconfig is missed, create new one
+	if len(cfg.Clusters) == 0 {
+		lp := localpath.Profile(contextName)
+		gp := localpath.MiniPath()
+		kcs := &Settings{
+			ClusterName:          contextName,
+			ClusterServerAddress: address,
+			ClientCertificate:    path.Join(lp, "client.crt"),
+			ClientKey:            path.Join(lp, "client.key"),
+			CertificateAuthority: path.Join(gp, "ca.crt"),
+			KeepContext:          false,
+		}
+		err = PopulateFromSettings(kcs, cfg)
+		if err != nil {
+			return false, errors.Wrap(err, "populating kubeconfig")
+		}
+	}
+	cfg.Clusters[contextName].Server = address
+	err = writeToFile(cfg, confpath)
 	if err != nil {
 		return false, errors.Wrap(err, "write")
 	}


### PR DESCRIPTION
### What type of PR is this?
/kind bug

### What this PR does / why we need it:

Without kubeconfig, when user executes `minikue update-context`, SIGSEV occurs because config struct is nil.

This PR fix to recreate new kubeconfig even if it's missing.

### Which issue(s) this PR fixes:
Fixes #7437

### Does this PR introduce a user-facing change?
Yes. 
This PR fixes the `minikube update-context` behavior.

**Before this PR**

```
## delete kubeconfig
$ rm ~/.kube/config

$ out/minikube update-context
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x5176f10]

goroutine 1 [running]:
k8s.io/minikube/pkg/minikube/kubeconfig.UpdateEndpoint(0x56d831e, 0x8, 0x56d8cd6, 0x9, 0x8000, 0xc00003f2a0, 0x19, 0x59e6d00, 0xc000124620, 0x56d8cd6)
        /Users/k-iso/go/src/k8s.io/minikube/pkg/minikube/kubeconfig/kubeconfig.go:122 +0x290
k8s.io/minikube/cmd/minikube/cmd.glob..func30(0x670c320, 0x6743478, 0x0, 0x0)
        /Users/k-iso/go/src/k8s.io/minikube/cmd/minikube/cmd/update-context.go:37 +0x10a
github.com/spf13/cobra.(*Command).execute(0x670c320, 0x6743478, 0x0, 0x0, 0x670c320, 0x6743478)
        /Users/k-iso/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:830 +0x2aa
github.com/spf13/cobra.(*Command).ExecuteC(0x670a520, 0x0, 0x1, 0xc0002f2660)
        /Users/k-iso/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x2fb
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/k-iso/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
k8s.io/minikube/cmd/minikube/cmd.Execute()
        /Users/k-iso/go/src/k8s.io/minikube/cmd/minikube/cmd/root.go:108 +0x6a4
main.main()
        /Users/k-iso/go/src/k8s.io/minikube/cmd/minikube/main.go:66 +0xea
```
**After this PR**

```
## delete kubeconfig
$ rm ~/.kube/config

## recreate new kubeconfig & success
$ out/minikube update-context
🎉  "minikube" context has been updated to point to 192.168.64.66:8443
```

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```