### PR TITLE
Improve "Deploying apps" section of "Getting Started" guide

### DIFF
--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -115,7 +115,7 @@ kubectl create deployment hello-minikube --image=k8s.gcr.io/echoserver:1.4
 kubectl expose deployment hello-minikube --type=NodePort --port=8080
 ```
 
-It may take a second, but your deployment will soon show up if you run:
+It may take a second, but your deployment will soon show up when you run:
 
 ```shell
 kubectl get services hello-minikube
@@ -127,21 +127,21 @@ The easiest way to access this service is to let minikube launch a web browser f
 minikube service hello-minikube
 ```
 
-Alternatively, you can find the cluster IP as seen by your host:
+Alternatively, use kubectl to forward the port:
 
 ```shell
-minikube ip
+kubectl port-forward service/hello-minikube 8780:8080
 ```
 
-Then navigate to &lt;your ip&gt;:8080 in your web browser
+Tada! Your application is now available at http://localhost:7080/
 
-## What about LoadBalanced apps?
+## LoadBalancer deployments
 
-To access a LoadBalancer application, use the "minikube tunnel" feature. Here is an example deployment:
+To access a LoadBalancer deployment, use the "minikube tunnel" command. Here is an example deployment:
 
 ```shell
 kubectl create deployment balanced --image=k8s.gcr.io/echoserver:1.4  
-kubectl expose deployment balanced --type=LoadBalancer --port=8081
+kubectl expose deployment balanced --type=LoadBalancer --port=8080
 ```
 
 In another window, start the tunnel. The tunnel creates routable IP's for LoadBalancer apps:
@@ -150,13 +150,11 @@ In another window, start the tunnel. The tunnel creates routable IP's for LoadBa
 minikube tunnel
 ```
 
-Find the external IP assigned to your LoadBalancer app:
+It may take a second, but your LoadBalancer app will soon have an external IP associated to it:
 
 `kubectl get services balanced`
 
-Access the application using `http://&lt;EXTERNAL-IP&gt;:8081`
-
-TIP: If you are using macOS, minikube will also forward DNS for you: [http://balanced.default.svc.cluster.local:8081/](http://balanced.default.svc.cluster.local:8081/)
+Tada! Your LoadBalancer application is now available at `http://&lt;EXTERNAL-IP&gt;:8080/`
 
 <h2 class="step"><span class="fa-stack fa-1x"><i class="fa fa-circle fa-stack-2x"></i><strong class="fa-stack-1x text-primary">5</strong></span>Manage your cluster</h2>
 

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -115,7 +115,7 @@ kubectl create deployment hello-minikube --image=k8s.gcr.io/echoserver:1.4
 kubectl expose deployment hello-minikube --type=NodePort --port=8080
 ```
 
-It may take a second, but your deployment will soon show up when you run:
+It may take a moment, but your deployment will soon show up when you run:
 
 ```shell
 kubectl get services hello-minikube
@@ -133,7 +133,7 @@ Alternatively, use kubectl to forward the port:
 kubectl port-forward service/hello-minikube 8780:8080
 ```
 
-Tada! Your application is now available at http://localhost:7080/
+Tada! Your application is now available at [http://localhost:7080/](http://localhost:7080/)
 
 ## LoadBalancer deployments
 
@@ -141,7 +141,7 @@ To access a LoadBalancer deployment, use the "minikube tunnel" command. Here is 
 
 ```shell
 kubectl create deployment balanced --image=k8s.gcr.io/echoserver:1.4  
-kubectl expose deployment balanced --type=LoadBalancer --port=8080
+kubectl expose deployment balanced --type=LoadBalancer --port=8000
 ```
 
 In another window, start the tunnel to create a routable IP for the 'balanced' deployment:
@@ -150,11 +150,11 @@ In another window, start the tunnel to create a routable IP for the 'balanced' d
 minikube tunnel
 ```
 
-It may take a second, but the 'balanced' deployment will soon have an external IP listed:
+To find the routable IP, run this command and examine the `EXTERNAL-IP` column:
 
 `kubectl get services balanced`
 
-Tada! Your LoadBalancer deployment is now available at `http://&lt;EXTERNAL-IP&gt;:8080/`
+Your deployment is now available at <EXTERNAL-IP>:8000
 
 <h2 class="step"><span class="fa-stack fa-1x"><i class="fa fa-circle fa-stack-2x"></i><strong class="fa-stack-1x text-primary">5</strong></span>Manage your cluster</h2>
 

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -144,17 +144,17 @@ kubectl create deployment balanced --image=k8s.gcr.io/echoserver:1.4
 kubectl expose deployment balanced --type=LoadBalancer --port=8080
 ```
 
-In another window, start the tunnel. The tunnel creates routable IP's for LoadBalancer apps:
+In another window, start the tunnel to create a routable IP for the 'balanced' deployment:
 
 ```shell
 minikube tunnel
 ```
 
-It may take a second, but your LoadBalancer app will soon have an external IP associated to it:
+It may take a second, but the 'balanced' deployment will soon have an external IP listed:
 
 `kubectl get services balanced`
 
-Tada! Your LoadBalancer application is now available at `http://&lt;EXTERNAL-IP&gt;:8080/`
+Tada! Your LoadBalancer deployment is now available at `http://&lt;EXTERNAL-IP&gt;:8080/`
 
 <h2 class="step"><span class="fa-stack fa-1x"><i class="fa fa-circle fa-stack-2x"></i><strong class="fa-stack-1x text-primary">5</strong></span>Manage your cluster</h2>
 

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -135,7 +135,7 @@ kubectl port-forward service/hello-minikube 8780:8080
 
 Tada! Your application is now available at [http://localhost:7080/](http://localhost:7080/)
 
-## LoadBalancer deployments
+### LoadBalancer deployments
 
 To access a LoadBalancer deployment, use the "minikube tunnel" command. Here is an example deployment:
 
@@ -154,7 +154,7 @@ To find the routable IP, run this command and examine the `EXTERNAL-IP` column:
 
 `kubectl get services balanced`
 
-Your deployment is now available at <EXTERNAL-IP>:8000
+Your deployment is now available at &lt;EXTERNAL-IP&gt;:8000
 
 <h2 class="step"><span class="fa-stack fa-1x"><i class="fa fa-circle fa-stack-2x"></i><strong class="fa-stack-1x text-primary">5</strong></span>Manage your cluster</h2>
 

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -115,17 +115,27 @@ kubectl create deployment hello-minikube --image=k8s.gcr.io/echoserver:1.4
 kubectl expose deployment hello-minikube --type=NodePort --port=8080
 ```
 
-Find your cluster IP:
+It may take a second, but your deployment will soon show up if you run:
+
+```shell
+kubectl get services hello-minikube
+```
+
+The easiest way to access this service is to let minikube launch a web browser for you:
+
+```shell
+minikube service hello-minikube
+```
+
+Alternatively, you can find the cluster IP as seen by your host:
 
 ```shell
 minikube ip
 ```
 
-Either navigate to &lt;your ip&gt;:8080 in your web browser, or let minikube do it for you:
+Then navigate to &lt;your ip&gt;:8080 in your web browser
 
-```shell
-minikube service hello-minikube
-```
+## What about LoadBalanced apps?
 
 To access a LoadBalancer application, use the "minikube tunnel" feature. Here is an example deployment:
 
@@ -134,13 +144,19 @@ kubectl create deployment balanced --image=k8s.gcr.io/echoserver:1.4
 kubectl expose deployment balanced --type=LoadBalancer --port=8081
 ```
 
-In another window, start the tunnel to create a routable IP for the deployment:
+In another window, start the tunnel. The tunnel creates routable IP's for LoadBalancer apps:
 
 ```shell
 minikube tunnel
 ```
 
-Access the application using the "service" command, or your web browser. If you are using macOS, minikube will also forward DNS requests for you: [http://balanced.default.svc.cluster.local:8081/](http://balanced.default.svc.cluster.local:8081/)
+Find the external IP assigned to your LoadBalancer app:
+
+`kubectl get services balanced`
+
+Access the application using `http://&lt;EXTERNAL-IP&gt;:8081`
+
+TIP: If you are using macOS, minikube will also forward DNS for you: [http://balanced.default.svc.cluster.local:8081/](http://balanced.default.svc.cluster.local:8081/)
 
 <h2 class="step"><span class="fa-stack fa-1x"><i class="fa fa-circle fa-stack-2x"></i><strong class="fa-stack-1x text-primary">5</strong></span>Manage your cluster</h2>
 


### PR DESCRIPTION
Preview: https://deploy-preview-7748--kubernetes-sigs-minikube.netlify.app/docs/start/

## NodePorts:
* Recommend using `kubectl get services` to poke around
* Recommend `kubectl port-forward` alternative instead of `minikube ip` (the latter won't work in D4D)

## LoadBalancer:
* Recommend `kubectl get services` to see the IP
* Remove mention of DNS forwarding as it is macOS only, and broken (#7753)