### PR TITLE
Unify Kubernetes client creation around kapi.Client

### DIFF
--- a/cmd/minikube/cmd/config/configure.go
+++ b/cmd/minikube/cmd/config/configure.go
@@ -100,8 +100,11 @@ var addonsConfigureCmd = &cobra.Command{
 				acrPassword = AskForPasswordValue("-- Enter service principal password to access Azure Container Registry: ")
 			}
 
+			cname := ClusterFlagValue()
+
 			// Create ECR Secret
 			err := service.CreateSecret(
+				cname,
 				"kube-system",
 				"registry-creds-ecr",
 				map[string]string{
@@ -124,6 +127,7 @@ var addonsConfigureCmd = &cobra.Command{
 
 			// Create GCR Secret
 			err = service.CreateSecret(
+				cname,
 				"kube-system",
 				"registry-creds-gcr",
 				map[string]string{
@@ -142,6 +146,7 @@ var addonsConfigureCmd = &cobra.Command{
 
 			// Create Docker Secret
 			err = service.CreateSecret(
+				cname,
 				"kube-system",
 				"registry-creds-dpr",
 				map[string]string{
@@ -161,6 +166,7 @@ var addonsConfigureCmd = &cobra.Command{
 
 			// Create Azure Container Registry Secret
 			err = service.CreateSecret(
+				cname,
 				"kube-system",
 				"registry-creds-acr",
 				map[string]string{

--- a/cmd/minikube/cmd/config/open.go
+++ b/cmd/minikube/cmd/config/open.go
@@ -77,7 +77,7 @@ minikube addons enable {{.name}}`, out.V{"name": addonName})
 		namespace := "kube-system"
 		key := "kubernetes.io/minikube-addons-endpoint"
 
-		serviceList, err := service.GetServiceListByLabel(namespace, key, addonName)
+		serviceList, err := service.GetServiceListByLabel(cname, namespace, key, addonName)
 		if err != nil {
 			exit.WithCodeT(exit.Unavailable, "Error getting service with namespace: {{.namespace}} and labels {{.labelName}}:{{.addonName}}: {{.error}}", out.V{"namespace": namespace, "labelName": key, "addonName": addonName, "error": err})
 		}
@@ -89,7 +89,7 @@ You can add one by annotating a service with the label {{.labelName}}:{{.addonNa
 			svc := serviceList.Items[i].ObjectMeta.Name
 			var urlString []string
 
-			if urlString, err = service.WaitForService(co.API, namespace, svc, addonsURLTemplate, addonsURLMode, https, wait, interval); err != nil {
+			if urlString, err = service.WaitForService(co.API, co.Config.Name, namespace, svc, addonsURLTemplate, addonsURLMode, https, wait, interval); err != nil {
 				exit.WithCodeT(exit.Unavailable, "Wait failed: {{.error}}", out.V{"error": err})
 			}
 

--- a/cmd/minikube/cmd/dashboard.go
+++ b/cmd/minikube/cmd/dashboard.go
@@ -83,7 +83,7 @@ var dashboardCmd = &cobra.Command{
 		ns := "kubernetes-dashboard"
 		svc := "kubernetes-dashboard"
 		out.ErrT(out.Verifying, "Verifying dashboard health ...")
-		checkSVC := func() error { return service.CheckService(ns, svc) }
+		checkSVC := func() error { return service.CheckService(cname, ns, svc) }
 		// for slow machines or parallels in CI to avoid #7503
 		if err = retry.Expo(checkSVC, 100*time.Microsecond, time.Minute*10); err != nil {
 			exit.WithCodeT(exit.Unavailable, "dashboard service is not running: {{.error}}", out.V{"error": err})

--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -84,7 +84,7 @@ var serviceCmd = &cobra.Command{
 			return
 		}
 
-		urls, err := service.WaitForService(co.API, namespace, svc, serviceURLTemplate, serviceURLMode, https, wait, interval)
+		urls, err := service.WaitForService(co.API, co.Config.Name, namespace, svc, serviceURLTemplate, serviceURLMode, https, wait, interval)
 		if err != nil {
 			var s *service.SVCNotFoundError
 			if errors.As(err, &s) {

--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -33,6 +33,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/minikube/pkg/drivers/kic/oci"
+	"k8s.io/minikube/pkg/kapi"
 	"k8s.io/minikube/pkg/minikube/browser"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/localpath"
@@ -112,7 +113,7 @@ func startKicServiceTunnel(svc, configName string) {
 	ctrlC := make(chan os.Signal, 1)
 	signal.Notify(ctrlC, os.Interrupt)
 
-	clientset, err := service.K8s.GetClientset(1 * time.Second)
+	clientset, err := kapi.Client(configName)
 	if err != nil {
 		exit.WithError("error creating clientset", err)
 	}

--- a/cmd/minikube/cmd/service_list.go
+++ b/cmd/minikube/cmd/service_list.go
@@ -40,7 +40,7 @@ var serviceListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		co := mustload.Healthy(ClusterFlagValue())
 
-		serviceURLs, err := service.GetServiceURLs(co.API, serviceListNamespace, serviceURLTemplate)
+		serviceURLs, err := service.GetServiceURLs(co.API, co.Config.Name, serviceListNamespace, serviceURLTemplate)
 		if err != nil {
 			out.FatalT("Failed to get service URL: {{.error}}", out.V{"error": err})
 			out.ErrT(out.Notice, "Check that minikube is running and that you have specified the correct namespace (-n flag) if required.")

--- a/cmd/minikube/cmd/tunnel.go
+++ b/cmd/minikube/cmd/tunnel.go
@@ -23,17 +23,16 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
-	"time"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
 	"k8s.io/minikube/pkg/drivers/kic/oci"
+	"k8s.io/minikube/pkg/kapi"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/minikube/mustload"
-	"k8s.io/minikube/pkg/minikube/service"
 	"k8s.io/minikube/pkg/minikube/tunnel"
 	"k8s.io/minikube/pkg/minikube/tunnel/kic"
 )
@@ -65,7 +64,7 @@ var tunnelCmd = &cobra.Command{
 		// We define the tunnel and minikube error free if the API server responds within a second.
 		// This also contributes to better UX, the tunnel status check can happen every second and
 		// doesn't hang on the API server call during startup and shutdown time or if there is a temporary error.
-		clientset, err := service.K8s.GetClientset(1 * time.Second)
+		clientset, err := kapi.Client(cname)
 		if err != nil {
 			exit.WithError("error creating clientset", err)
 		}

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -259,10 +259,6 @@ func enableOrDisableStorageClasses(cc *config.ClusterConfig, name string, val st
 	if name == "storage-provisioner-gluster" {
 		class = "glusterfile"
 	}
-	storagev1, err := storageclass.GetStoragev1()
-	if err != nil {
-		return errors.Wrapf(err, "Error getting storagev1 interface %v ", err)
-	}
 
 	api, err := machine.NewAPIClient()
 	if err != nil {
@@ -277,6 +273,11 @@ func enableOrDisableStorageClasses(cc *config.ClusterConfig, name string, val st
 	if !machine.IsRunning(api, driver.MachineName(*cc, cp)) {
 		glog.Warningf("%q is not running, writing %s=%v to disk and skipping enablement", driver.MachineName(*cc, cp), name, val)
 		return enableOrDisableAddon(cc, name, val)
+	}
+
+	storagev1, err := storageclass.GetStoragev1(cc.Name)
+	if err != nil {
+		return errors.Wrapf(err, "Error getting storagev1 interface %v ", err)
 	}
 
 	if enable {

--- a/pkg/minikube/service/service.go
+++ b/pkg/minikube/service/service.go
@@ -44,7 +44,6 @@ import (
 )
 
 const (
-	defaultK8sClientTimeout = 60 * time.Second
 	// DefaultWait is the default wait time, in seconds
 	DefaultWait = 2
 	// DefaultInterval is the default interval, in seconds

--- a/pkg/minikube/service/service_test.go
+++ b/pkg/minikube/service/service_test.go
@@ -469,7 +469,7 @@ func TestGetServiceURLs(t *testing.T) {
 				servicesMap:  serviceNamespaces,
 				endpointsMap: endpointNamespaces,
 			}
-			urls, err := GetServiceURLs(test.api, test.namespace, defaultTemplate)
+			urls, err := GetServiceURLs(test.api, "minikube", test.namespace, defaultTemplate)
 			if err != nil && !test.err {
 				t.Errorf("Error GetServiceURLs %v", err)
 			}
@@ -537,7 +537,7 @@ func TestGetServiceURLsForService(t *testing.T) {
 				servicesMap:  serviceNamespaces,
 				endpointsMap: endpointNamespaces,
 			}
-			svcURL, err := GetServiceURLsForService(test.api, test.namespace, test.service, defaultTemplate)
+			svcURL, err := GetServiceURLsForService(test.api, "minikube", test.namespace, test.service, defaultTemplate)
 			if err != nil && !test.err {
 				t.Errorf("Error GetServiceURLsForService %v", err)
 			}
@@ -684,7 +684,7 @@ func TestGetServiceListByLabel(t *testing.T) {
 				secretsMap:   secretsNamespaces,
 			}
 			getCoreClientFail = test.failedGetClient
-			svcs, err := GetServiceListByLabel(test.ns, test.name, test.label)
+			svcs, err := GetServiceListByLabel("minikube", test.ns, test.name, test.label)
 			if err != nil && !test.err {
 				t.Fatalf("Test %v got unexpected error: %v", test.description, err)
 			}
@@ -734,7 +734,7 @@ func TestCheckService(t *testing.T) {
 				secretsMap:   secretsNamespaces,
 			}
 			getCoreClientFail = test.failedGetClient
-			err := CheckService(test.ns, test.name)
+			err := CheckService("minikube", test.ns, test.name)
 			if err == nil && test.err {
 				t.Fatalf("Test %v expected error but got nil", test.description)
 			}
@@ -773,7 +773,7 @@ func TestDeleteSecret(t *testing.T) {
 				secretsMap:   secretsNamespaces,
 			}
 			getCoreClientFail = test.failedGetClient
-			err := DeleteSecret(test.ns, test.name)
+			err := DeleteSecret("minikube", test.ns, test.name)
 			if err == nil && test.err {
 				t.Fatalf("Test %v expected error but got nil", test.description)
 			}
@@ -812,7 +812,7 @@ func TestCreateSecret(t *testing.T) {
 				secretsMap:   secretsNamespaces,
 			}
 			getCoreClientFail = test.failedGetClient
-			err := CreateSecret(test.ns, test.name, map[string]string{"ns": "secret"}, map[string]string{"ns": "baz"})
+			err := CreateSecret("minikube", test.ns, test.name, map[string]string{"ns": "secret"}, map[string]string{"ns": "baz"})
 			if err == nil && test.err {
 				t.Fatalf("Test %v expected error but got nil", test.description)
 			}
@@ -914,7 +914,7 @@ func TestWaitAndMaybeOpenService(t *testing.T) {
 			}
 
 			var urlList []string
-			urlList, err := WaitForService(test.api, test.namespace, test.service, defaultTemplate, test.urlMode, test.https, 1, 0)
+			urlList, err := WaitForService(test.api, "minikube", test.namespace, test.service, defaultTemplate, test.urlMode, test.https, 1, 0)
 			if test.err && err == nil {
 				t.Fatalf("WaitForService expected to fail for test: %v", test)
 			}
@@ -979,7 +979,7 @@ func TestWaitAndMaybeOpenServiceForNotDefaultNamspace(t *testing.T) {
 				servicesMap:  serviceNamespaceOther,
 				endpointsMap: endpointNamespaces,
 			}
-			_, err := WaitForService(test.api, test.namespace, test.service, defaultTemplate, test.urlMode, test.https, 1, 0)
+			_, err := WaitForService(test.api, "minikube", test.namespace, test.service, defaultTemplate, test.urlMode, test.https, 1, 0)
 			if test.err && err == nil {
 				t.Fatalf("WaitForService expected to fail for test: %v", test)
 			}

--- a/pkg/minikube/service/service_test.go
+++ b/pkg/minikube/service/service_test.go
@@ -26,8 +26,6 @@ import (
 	"testing"
 	"text/template"
 
-	"time"
-
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/pkg/errors"
@@ -35,7 +33,6 @@ import (
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/client-go/kubernetes"
 	typed_core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/kubernetes/typed/core/v1/fake"
 	testing_fake "k8s.io/client-go/testing"
@@ -63,10 +60,6 @@ func (m *MockClientGetter) GetCoreClient() (typed_core.CoreV1Interface, error) {
 		servicesMap:  m.servicesMap,
 		endpointsMap: m.endpointsMap,
 		secretsMap:   m.secretsMap}, nil
-}
-
-func (m *MockClientGetter) GetClientset(timeout time.Duration) (*kubernetes.Clientset, error) {
-	return nil, nil
 }
 
 func (m *MockCoreClient) Secrets(ns string) typed_core.SecretInterface {

--- a/pkg/minikube/service/service_test.go
+++ b/pkg/minikube/service/service_test.go
@@ -52,7 +52,7 @@ type MockClientGetter struct {
 // Force GetCoreClient to fail
 var getCoreClientFail bool
 
-func (m *MockClientGetter) GetCoreClient() (typed_core.CoreV1Interface, error) {
+func (m *MockClientGetter) GetCoreClient(string) (typed_core.CoreV1Interface, error) {
 	if getCoreClientFail {
 		return nil, fmt.Errorf("test Error - Mocked Get")
 	}
@@ -619,7 +619,7 @@ users:
 			os.Setenv("KUBECONFIG", mockK8sConfigPath)
 
 			k8s := K8sClientGetter{}
-			_, err = k8s.GetCoreClient()
+			_, err = k8s.GetCoreClient("minikube")
 			if err != nil && !test.err {
 				t.Fatalf("GetCoreClient returned unexpected error: %v", err)
 			}

--- a/pkg/minikube/storageclass/storageclass.go
+++ b/pkg/minikube/storageclass/storageclass.go
@@ -22,9 +22,8 @@ import (
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	storagev1 "k8s.io/client-go/kubernetes/typed/storage/v1"
-	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/minikube/pkg/kapi"
 )
 
 func annotateDefaultStorageClass(storage storagev1.StorageV1Interface, class *v1.StorageClass, enable bool) error {
@@ -71,25 +70,11 @@ func SetDefaultStorageClass(storage storagev1.StorageV1Interface, name string) e
 }
 
 // GetStoragev1 return storage v1 interface for client
-func GetStoragev1() (storagev1.StorageV1Interface, error) {
-	client, err := getClient()
+func GetStoragev1(context string) (storagev1.StorageV1Interface, error) {
+	client, err := kapi.Client(context)
 	if err != nil {
 		return nil, err
 	}
 	sv1 := client.StorageV1()
 	return sv1, nil
-}
-
-func getClient() (*kubernetes.Clientset, error) {
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
-	config, err := kubeConfig.ClientConfig()
-	if err != nil {
-		return nil, errors.Wrap(err, "Error creating kubeConfig")
-	}
-	client, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, errors.Wrap(err, "Error creating new client from kubeConfig.ClientConfig()")
-	}
-	return client, nil
 }

--- a/pkg/minikube/storageclass/storageclass_test.go
+++ b/pkg/minikube/storageclass/storageclass_test.go
@@ -239,7 +239,8 @@ func TestGetStoragev1(t *testing.T) {
 				t.Fatalf(err.Error())
 			}
 
-			_, err = GetStoragev1(configfile.Name())
+			// context name is hardcoded by mockK8sConfig
+			_, err = GetStoragev1("minikube")
 			if err != nil && !test.err {
 				t.Fatalf("Unexpected err: %v for test: %v", err, test.description)
 			}

--- a/pkg/minikube/storageclass/storageclass_test.go
+++ b/pkg/minikube/storageclass/storageclass_test.go
@@ -212,45 +212,6 @@ users:
 - name: minikube
 `
 
-func TestGetClient(t *testing.T) {
-	var tests = []struct {
-		description string
-		config      string
-		err         bool
-	}{
-		{
-			description: "ok",
-			config:      mockK8sConfig,
-		},
-		{
-			description: "no valid config",
-			config:      "this is not valid config",
-			err:         true,
-		},
-	}
-	configFile, err := ioutil.TempFile("/tmp", "")
-	if err != nil {
-		t.Fatalf(err.Error())
-	}
-	defer os.Remove(configFile.Name())
-	for _, test := range tests {
-		t.Run(test.description, func(t *testing.T) {
-
-			if err := setK8SConfig(test.config, configFile.Name()); err != nil {
-				t.Fatalf(err.Error())
-			}
-
-			_, err = getClient()
-			if err != nil && !test.err {
-				t.Fatalf("Unexpected err: %v for test: %v", err, test.description)
-			}
-			if err == nil && test.err {
-				t.Fatalf("Expected err for test: %v", test.description)
-			}
-		})
-	}
-}
-
 func TestGetStoragev1(t *testing.T) {
 	var tests = []struct {
 		description string
@@ -278,7 +239,7 @@ func TestGetStoragev1(t *testing.T) {
 				t.Fatalf(err.Error())
 			}
 
-			_, err = GetStoragev1()
+			_, err = GetStoragev1(configfile.Name())
 			if err != nil && !test.err {
 				t.Fatalf("Unexpected err: %v for test: %v", err, test.description)
 			}


### PR DESCRIPTION
Fixes race condition where minikube may try to apply the default storage-class to the current Kubernetes context rather than to the minikube context. 

Fixes #7745

