### PR TITLE
Disable AppArmor for TestFunctional/parallel/MySQL fail(CrashLoopBackOff)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,6 +116,8 @@ jobs:
         mkdir -p testhome
         chmod a+x e2e-*
         chmod a+x minikube-*
+        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         START_TIME=$(date -u +%s)
         KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker  -test.run TestFunctional -test.timeout=30m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -207,6 +207,8 @@ jobs:
         mkdir -p testhome
         chmod a+x e2e-*
         chmod a+x minikube-*
+        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         START_TIME=$(date -u +%s)
         KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--driver=docker  -test.run TestPause -test.timeout=30m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)

--- a/site/content/en/docs/drivers/docker.md
+++ b/site/content/en/docs/drivers/docker.md
@@ -40,6 +40,4 @@ The Docker driver allows you to install Kubernetes into an existing Docker insta
    If you machine enables AppArmor, you need to disable AppArmor for the mysql profile.
    To disable apparmor for mysql, run the following command on host machine.
 
-    `sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-    sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
-    `
+    `sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/ && sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld`

--- a/site/content/en/docs/drivers/docker.md
+++ b/site/content/en/docs/drivers/docker.md
@@ -36,8 +36,5 @@ The Docker driver allows you to install Kubernetes into an existing Docker insta
 
 - On Linux, if you want to run MySQL pod, you need to disable AppArmor for mysql profile
 
-   AppArmor is access control security system for Linux. This is enabled on Ubuntu by default.
-   If you machine enables AppArmor, you need to disable AppArmor for the mysql profile.
-   To disable apparmor for mysql, run the following command on host machine.
-
-    `sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/ && sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld`
+   If your docker has [AppArmor](https://wiki.ubuntu.com/AppArmor) enabled, running mysql in privileged mode with docker driver will have the issue [#7401](https://github.com/kubernetes/minikube/issues/7401).
+   There is a workaround - see [moby/moby#7512](https://github.com/moby/moby/issues/7512#issuecomment-61787845).

--- a/site/content/en/docs/drivers/docker.md
+++ b/site/content/en/docs/drivers/docker.md
@@ -33,3 +33,13 @@ The Docker driver allows you to install Kubernetes into an existing Docker insta
 - On macOS or Windows, you may need to restart Docker for Desktop if a command gets hung
 
 - Run `--alsologtostderr -v=1` for extra debugging information
+
+- On Linux, if you want to run MySQL pod, you need to disable AppArmor for mysql profile
+
+   AppArmor is access control security system for Linux. This is enabled on Ubuntu by default.
+   If you machine enables AppArmor, you need to disable AppArmor for the mysql profile.
+   To disable apparmor for mysql, run the following command on host machine.
+
+    `sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
+    sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+    `

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -774,8 +774,6 @@ func validateMySQL(ctx context.Context, t *testing.T, profile string) {
 		return err
 	}
 	if err = retry.Expo(mysql, 1*time.Second, Minutes(5)); err != nil {
-		// show mysql pod logs to isolate what is happening: https://github.com/kubernetes/minikube/issues/7401
-		showPodLogs(ctx, t, profile, "default", names)
 		t.Errorf("failed to exec 'mysql -ppassword -e show databases;': %v", err)
 	}
 }

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -774,6 +774,8 @@ func validateMySQL(ctx context.Context, t *testing.T, profile string) {
 		return err
 	}
 	if err = retry.Expo(mysql, 1*time.Second, Minutes(5)); err != nil {
+		// show mysql pod logs to isolate what is happening: https://github.com/kubernetes/minikube/issues/7401
+		showPodLogs(ctx, t, profile, "default", names)
 		t.Errorf("failed to exec 'mysql -ppassword -e show databases;': %v", err)
 	}
 }


### PR DESCRIPTION
### What type of PR is this?
/kind flake
/area testing

### What this PR does / why we need it:

<del>In e2e test TestFunctional/parallel/MySQL, the mysql pod often comes to be CrashLoopBackOff.</del>
<del>This PR add pod's log when retry is over.</del>
(Added) I deleted logs func because cause had come to be clear.

This PR disable apparmor for e2e test docker_ubuntu.
Because ubuntu has apparmor security, it restricts docker mysql privileage. 

### Which issue(s) this PR fixes:
Fixes #7401 

### Does this PR introduce a user-facing change?

No.

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```
