### PR TITLE
change loglevel for api freezer if not found

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/kverify/api_server.go
+++ b/pkg/minikube/bootstrapper/bsutil/kverify/api_server.go
@@ -166,7 +166,15 @@ func APIServerStatus(cr command.Runner, hostname string, port int) (state.State,
 
 	rr, err = cr.RunCmd(exec.Command("sudo", "cat", path.Join("/sys/fs/cgroup/freezer", fparts[2], "freezer.state")))
 	if err != nil {
-		glog.Errorf("unable to get freezer state: %s", rr.Stderr.String())
+		// example error from github action:
+		// cat: /sys/fs/cgroup/freezer/actions_job/e62ef4349cc5a70f4b49f8a150ace391da6ad6df27073c83ecc03dbf81fde1ce/kubepods/burstable/poda1de58db0ce81d19df7999f6808def1b/5df53230fe3483fd65f341923f18a477fda92ae9cd71061168130ef164fe479c/freezer.state: No such file or directory\n"*
+		// TODO: #7770 investigate how to handle this error better.
+		if strings.Contains(rr.Stderr.String(), "freezer.state: No such file or directory\n") {
+			glog.Infof("unable to get freezer state (might be okay and be related to #770): \n ", rr.Stderr.String())
+		} else {
+			glog.Warningf("unable to get freezer state : %s", rr.Stderr.String())
+		}
+
 		return apiServerHealthz(hostname, port)
 	}
 

--- a/pkg/minikube/bootstrapper/bsutil/kverify/api_server.go
+++ b/pkg/minikube/bootstrapper/bsutil/kverify/api_server.go
@@ -170,7 +170,7 @@ func APIServerStatus(cr command.Runner, hostname string, port int) (state.State,
 		// cat: /sys/fs/cgroup/freezer/actions_job/e62ef4349cc5a70f4b49f8a150ace391da6ad6df27073c83ecc03dbf81fde1ce/kubepods/burstable/poda1de58db0ce81d19df7999f6808def1b/5df53230fe3483fd65f341923f18a477fda92ae9cd71061168130ef164fe479c/freezer.state: No such file or directory\n"*
 		// TODO: #7770 investigate how to handle this error better.
 		if strings.Contains(rr.Stderr.String(), "freezer.state: No such file or directory\n") {
-			glog.Infof("unable to get freezer state (might be okay and be related to #770): \n ", rr.Stderr.String())
+			glog.Infof("unable to get freezer state (might be okay and be related to #770): %s", rr.Stderr.String())
 		} else {
 			glog.Warningf("unable to get freezer state : %s", rr.Stderr.String())
 		}

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -670,7 +670,7 @@ func validateServiceCmd(ctx context.Context, t *testing.T, profile string) {
 		t.Fatalf("failed to get service url. args %q : %v", rr.Command(), err)
 	}
 	if rr.Stderr.String() != "" {
-		t.Logf("expected stderr to be empty but got *%q*", rr.Stderr)
+		t.Errorf("expected stderr to be empty but got *%q* . args %q", rr.Stderr, rr.Command())
 	}
 
 	endpoint := strings.TrimSpace(rr.Stdout.String())


### PR DESCRIPTION
a follow up PR for the great investigative work by @govargo https://github.com/kubernetes/minikube/pull/7769 

my bad I merged a PR too soon by mistake. before @govargo have time to see my review comment.

this will does not close https://github.com/kubernetes/minikube/issues/7770
but it will help to still test for stderr to be empty without failing on Not-critical.


so this will help us not flood the stderr for the user, if that does not affect the functionality of minikube. (and in this case we the test passes)