### PR TITLE
increase number of docker tests on gtihub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -507,7 +507,7 @@ jobs:
         echo "*** $numPass Passed ***"
         if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
   # After all integration tests finished
-  # collect all the reports and upload
+  # collect all the reports and upload them
   upload_all_reports:
     if: always()
     needs: [functional_test_docker_ubuntu, addons_certs_tests_docker_ubuntu, multinode_pause_tests_docker_ubuntu, preload_docker_flags_tests_docker_ubuntu, baremetal_ubuntu18_04]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
       continue-on-error: false
   # Run the following integration tests after the build_minikube
   # They will run in parallel and use the binaries in previous step
-  functional_preload_test_docker_ubuntu:
+  functional_test_docker_ubuntu:
     needs: [build_minikube]
     env:
       TIME_ELAPSED: time
@@ -506,53 +506,28 @@ jobs:
         numPass=$(echo $STAT | jq '.NumberOfPass')
         echo "*** $numPass Passed ***"
         if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
-  # After all 4 integration tests finished
+  # After all integration tests finished
   # collect all the reports and upload
   upload_all_reports:
     if: always()
-    needs: [functional_preload_test_docker_ubuntu, addons_certs_tests_docker_ubuntu, multinode_pause_tests_docker_ubuntu, preload_docker_flags_tests_docker_ubuntu, baremetal_ubuntu18_04]
+    needs: [functional_test_docker_ubuntu, addons_certs_tests_docker_ubuntu, multinode_pause_tests_docker_ubuntu, preload_docker_flags_tests_docker_ubuntu, baremetal_ubuntu18_04]
     runs-on: ubuntu-18.04
     steps:
-    - name: Download Results functional_test_docker_ubuntu
-      uses: actions/download-artifact@v1
-      with:
-        name: functional_test_docker_ubuntu
-    - name:  functional_test_docker_ubuntu to all_report
+    - name: upload all results
       continue-on-error: true
+      # using preview version to allow download all https://github.com/actions/download-artifact/tree/v2-preview#download-all-artifacts
+      # skiping uploading baremetal_ubuntu18_04 since that finishes too late
+      uses: actions/download-artifact@v2-preview
       shell: bash {0}
       run: |
         mkdir -p all_reports
-        cp -r functional_test_docker_ubuntu ./all_reports/
-    - name: Download Results multinode_pause_tests_docker_ubuntu
-      uses: actions/download-artifact@v1
-      with:
-        name: multinode_pause_tests_docker_ubuntu
-    - name: Copy multinode_pause_tests_docker_ubuntu to all_report
-      continue-on-error: true
-      shell: bash {0}
-      run: |
-        mkdir -p all_reports
-        cp -r multinode_pause_tests_docker_ubuntu ./all_reports/
-    - name: Download Results preload_docker_flags_tests_docker_ubuntu
-      uses: actions/download-artifact@v1
-      with:
-        name: preload_docker_flags_tests_docker_ubuntu
-    - name: Copy preload_docker_flags_tests_docker_ubuntu to all_report
-      continue-on-error: true
-      shell: bash {0}
-      run: |
-        mkdir -p all_reports
-        cp -r none_ubuntu16_04 ./all_reports/
-    - name: Download Results none_ubuntu18_04
-      uses: actions/download-artifact@v1
-      with:
-        name: none_ubuntu18_04
-    - name: Copy none_ubuntu18_04 to all_report
-      continue-on-error: true
-      shell: bash {0}
-      run: |
-        mkdir -p all_reports
-        cp -r none_ubuntu18_04 ./all_reports/
+        ls -lah
+        ls -lah minikube_binaries
+        ls -lah minikube_binaries/report
+        cp -r ./minikube_binaries/report/functional_test_docker_ubuntu ./all_reports/
+        cp -r ./minikube_binaries/report/addons_certs_tests_docker_ubuntu ./all_reports/
+        cp -r ./minikube_binaries/report/multinode_pause_tests_docker_ubuntu ./all_reports/
+        cp -r ./minikube_binaries/report/preload_docker_flags_tests_docker_ubuntu        
     - uses: actions/upload-artifact@v1
       with:
         name: all_reports

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 name: CI
-on: [pull_request]
+on: 
+  - pull_request
+  - push
 env:
   GOPROXY: https://proxy.golang.org
 jobs:
@@ -60,7 +62,7 @@ jobs:
         make test
       continue-on-error: false
   # Run the following integration tests after the build_minikube
-  # They will run in parallel and use the binaries in previous step
+  # They will run in parallel and use the binaries in previous step 
   functional_test_docker_ubuntu:
     needs: [build_minikube]
     env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -515,12 +515,11 @@ jobs:
     needs: [functional_test_docker_ubuntu, addons_certs_tests_docker_ubuntu, multinode_pause_tests_docker_ubuntu, preload_docker_flags_tests_docker_ubuntu, baremetal_ubuntu18_04]
     runs-on: ubuntu-18.04
     steps:
-    - name: upload all results
-      continue-on-error: true
-      # using preview version to allow download all https://github.com/actions/download-artifact/tree/v2-preview#download-all-artifacts
-      # skiping uploading baremetal_ubuntu18_04 since that finishes too late
+    - name: download all reports
       uses: actions/download-artifact@v2-preview
+    - name: upload all reports
       shell: bash {0}
+      continue-on-error: true
       run: |
         mkdir -p all_reports
         ls -lah

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,14 +63,14 @@ jobs:
       continue-on-error: false
   # Run the following integration tests after the build_minikube
   # They will run in parallel and use the binaries in previous step
-  functional_test_docker_ubuntu_16_04:
+  functional_preload_test_docker_ubuntu:
     needs: [build_minikube]
     env:
       TIME_ELAPSED: time
-      JOB_NAME: "Docker_Ubuntu_16_04"
+      JOB_NAME: "functional_test_docker_ubuntu"
       GOPOGH_RESULT: ""
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:    
     - name: Install kubectl
       shell: bash
@@ -141,9 +141,9 @@ jobs:
         echo ::set-env name=STAT::${STAT}
     - uses: actions/upload-artifact@v1
       with:
-        name: docker_ubuntu_16_04
+        name: functional_test_docker_ubuntu
         path: minikube_binaries/report
-    - name: The End Result Docker on ubuntu 16:04
+    - name: The End Result functional_test_docker_ubuntu
       shell: bash
       run: |
         echo ${GOPOGH_RESULT}
@@ -154,11 +154,11 @@ jobs:
         numPass=$(echo $STAT | jq '.NumberOfPass')
         echo "*** $numPass Passed ***"
         if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
-  pause_test_docker_ubuntu_18_04:
+  addons_certs_tests_docker_ubuntu:
     runs-on: ubuntu-18.04
     env:
       TIME_ELAPSED: time
-      JOB_NAME: "Docker_Ubuntu_18_04"
+      JOB_NAME: "addons_certs_tests_docker_ubuntu"
       GOPOGH_RESULT: ""
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
     needs: [build_minikube]
@@ -210,7 +210,7 @@ jobs:
         sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         START_TIME=$(date -u +%s)
-        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--driver=docker  -test.run TestPause -test.timeout=30m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--driver=docker  -test.run "(TestAddons|TestCertOptions)" -test.timeout=30m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
         TIME_ELAPSED=$(($END_TIME-$START_TIME))
         min=$((${TIME_ELAPSED}/60))
@@ -232,9 +232,9 @@ jobs:
         echo ::set-env name=STAT::${STAT}
     - uses: actions/upload-artifact@v1
       with:
-        name: docker_ubuntu_18_04
+        name: addons_certs_tests_docker_ubuntu
         path: minikube_binaries/report
-    - name: The End Result - Docker On Ubuntu 18:04
+    - name: The End Result - addons_certs_tests_docker_ubuntu
       shell: bash
       run: |
         echo ${GOPOGH_RESULT}
@@ -245,14 +245,14 @@ jobs:
         numPass=$(echo $STAT | jq '.NumberOfPass')
         echo "*** $numPass Passed ***"
         if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
-  baremetal_ubuntu16_04:
-    needs: [build_minikube]
+  multinode_pause_tests_docker_ubuntu:
+    runs-on: ubuntu-18.04
     env:
       TIME_ELAPSED: time
-      JOB_NAME: "None_Ubuntu_16_04"
+      JOB_NAME: "multinode_pause_tests_docker_ubuntu"
       GOPOGH_RESULT: ""
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
-    runs-on: ubuntu-16.04
+    needs: [build_minikube]
     steps:
     - name: Install kubectl
       shell: bash
@@ -260,17 +260,25 @@ jobs:
         curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
         sudo install kubectl /usr/local/bin/kubectl
         kubectl version --client=true
-    # conntrack is required for kubernetes 1.18 and higher
-    # socat is required for kubectl port forward which is used in some tests such as validateHelmTillerAddon
-    - name: Install tools for none
+    - name: Install lz4
       shell: bash
       run: |
         sudo apt-get update -qq
-        sudo apt-get -qq -y install conntrack
-        sudo apt-get -qq -y install socat
-        VERSION="v1.17.0"
-        curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-${VERSION}-linux-amd64.tar.gz --output crictl-${VERSION}-linux-amd64.tar.gz
-        sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
+        sudo apt-get -qq -y install liblz4-tool
+    - name: Docker Info
+      shell: bash
+      run: |
+        echo "--------------------------"
+        docker version || true
+        echo "--------------------------"
+        docker info || true
+        echo "--------------------------"
+        docker system df || true
+        echo "--------------------------"
+        docker system info || true
+        echo "--------------------------"
+        docker ps || true
+        echo "--------------------------"
     - name: Install gopogh
       shell: bash
       run: |
@@ -290,8 +298,10 @@ jobs:
         mkdir -p testhome
         chmod a+x e2e-*
         chmod a+x minikube-*
+        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         START_TIME=$(date -u +%s)
-        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome sudo -E ./e2e-linux-amd64 -minikube-start-args=--driver=none -test.timeout=35m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--driver=docker  -test.run "(TestPause|TestMultiNode)" -test.timeout=30m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
         TIME_ELAPSED=$(($END_TIME-$START_TIME))
         min=$((${TIME_ELAPSED}/60))
@@ -313,9 +323,100 @@ jobs:
         echo ::set-env name=STAT::${STAT}
     - uses: actions/upload-artifact@v1
       with:
-        name: none_ubuntu16_04
+        name: multinode_pause_tests_docker_ubuntu
         path: minikube_binaries/report
-    - name: The End Result - None On Ubuntu 16:04
+    - name: The End Result - multinode_pause_tests_docker_ubuntu
+      shell: bash
+      run: |
+        echo ${GOPOGH_RESULT}
+        numFail=$(echo $STAT | jq '.NumberOfFail')
+        echo "----------------${numFail} Failures----------------------------"
+        echo $STAT | jq '.FailedTests' || true
+        echo "-------------------------------------------------------"
+        numPass=$(echo $STAT | jq '.NumberOfPass')
+        echo "*** $numPass Passed ***"
+        if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
+  preload_docker_flags_tests_docker_ubuntu:
+    runs-on: ubuntu-18.04
+    env:
+      TIME_ELAPSED: time
+      JOB_NAME: "preload_docker_flags_tests_docker_ubuntu"
+      GOPOGH_RESULT: ""
+      SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
+    needs: [build_minikube]
+    steps:
+    - name: Install kubectl
+      shell: bash
+      run: |
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
+        sudo install kubectl /usr/local/bin/kubectl
+        kubectl version --client=true
+    - name: Install lz4
+      shell: bash
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get -qq -y install liblz4-tool
+    - name: Docker Info
+      shell: bash
+      run: |
+        echo "--------------------------"
+        docker version || true
+        echo "--------------------------"
+        docker info || true
+        echo "--------------------------"
+        docker system df || true
+        echo "--------------------------"
+        docker system info || true
+        echo "--------------------------"
+        docker ps || true
+        echo "--------------------------"
+    - name: Install gopogh
+      shell: bash
+      run: |
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.19/gopogh-linux-amd64
+        sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
+    - name: Download Binaries
+      uses: actions/download-artifact@v1
+      with:
+        name: minikube_binaries
+    - name: Run Integration Test
+      continue-on-error: true
+      # bash {0} to allow test to continue to next step. in case of
+      shell: bash {0}
+      run: |
+        cd minikube_binaries
+        mkdir -p report
+        mkdir -p testhome
+        chmod a+x e2e-*
+        chmod a+x minikube-*
+        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+        START_TIME=$(date -u +%s)
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--driver=docker  -test.run "(TestPreload|TestDockerFlags)" -test.timeout=30m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        END_TIME=$(date -u +%s)
+        TIME_ELAPSED=$(($END_TIME-$START_TIME))
+        min=$((${TIME_ELAPSED}/60))
+        sec=$((${TIME_ELAPSED}%60))
+        TIME_ELAPSED="${min} min $sec seconds "
+        echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
+    - name: Generate HTML Report
+      shell: bash
+      run: |
+        cd minikube_binaries
+        export PATH=${PATH}:`go env GOPATH`/bin
+        go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
+        STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name "${JOB_NAME} ${GITHUB_REF}" -repo "${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
+        echo status: ${STAT}
+        FailNum=$(echo $STAT | jq '.NumberOfFail')
+        TestsNum=$(echo $STAT | jq '.NumberOfTests')
+        GOPOGH_RESULT="${JOB_NAME} : completed with ${FailNum} / ${TestsNum} failures in ${TIME_ELAPSED}"
+        echo ::set-env name=GOPOGH_RESULT::${GOPOGH_RESULT}
+        echo ::set-env name=STAT::${STAT}
+    - uses: actions/upload-artifact@v1
+      with:
+        name: preload_docker_flags_tests_docker_ubuntu
+        path: minikube_binaries/report
+    - name: The End Result - preload_docker_flags_tests_docker_ubuntu
       shell: bash
       run: |
         echo ${GOPOGH_RESULT}
@@ -411,34 +512,34 @@ jobs:
   # collect all the reports and upload
   upload_all_reports:
     if: always()
-    needs: [functional_test_docker_ubuntu_16_04, pause_test_docker_ubuntu_18_04,baremetal_ubuntu16_04, baremetal_ubuntu18_04]
+    needs: [functional_preload_test_docker_ubuntu, addons_certs_tests_docker_ubuntu, multinode_pause_tests_docker_ubuntu, preload_docker_flags_tests_docker_ubuntu, baremetal_ubuntu18_04]
     runs-on: ubuntu-18.04
     steps:
-    - name: Download Results docker_ubuntu_16_04
+    - name: Download Results functional_test_docker_ubuntu
       uses: actions/download-artifact@v1
       with:
-        name: docker_ubuntu_16_04
-    - name: cp docker_ubuntu_16_04 to all_report
+        name: functional_test_docker_ubuntu
+    - name:  functional_test_docker_ubuntu to all_report
       continue-on-error: true
       shell: bash {0}
       run: |
         mkdir -p all_reports
-        cp -r docker_ubuntu_16_04 ./all_reports/
-    - name: Download Results docker_ubuntu_18_04
+        cp -r functional_test_docker_ubuntu ./all_reports/
+    - name: Download Results multinode_pause_tests_docker_ubuntu
       uses: actions/download-artifact@v1
       with:
-        name: docker_ubuntu_18_04
-    - name: cp docker_ubuntu_18_04 to all_report
+        name: multinode_pause_tests_docker_ubuntu
+    - name: Copy multinode_pause_tests_docker_ubuntu to all_report
       continue-on-error: true
       shell: bash {0}
       run: |
         mkdir -p all_reports
-        cp -r docker_ubuntu_18_04 ./all_reports/
-    - name: Download Results none_ubuntu16_04
+        cp -r multinode_pause_tests_docker_ubuntu ./all_reports/
+    - name: Download Results preload_docker_flags_tests_docker_ubuntu
       uses: actions/download-artifact@v1
       with:
-        name: none_ubuntu16_04
-    - name: cp none_ubuntu16_04 to all_report
+        name: preload_docker_flags_tests_docker_ubuntu
+    - name: Copy preload_docker_flags_tests_docker_ubuntu to all_report
       continue-on-error: true
       shell: bash {0}
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,6 @@ jobs:
       run : |
         make minikube-linux-amd64
         make e2e-linux-amd64
-        make minikube-windows-amd64.exe
-        make e2e-windows-amd64.exe
         cp -r test/integration/testdata ./out
         whoami
         echo github ref $GITHUB_REF

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -476,7 +476,7 @@ jobs:
         chmod a+x e2e-*
         chmod a+x minikube-*
         START_TIME=$(date -u +%s)
-        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome sudo -E ./e2e-linux-amd64 -minikube-start-args=--driver=none -test.timeout=35m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome sudo -E ./e2e-linux-amd64 -minikube-start-args=--driver=none -test.timeout=35m -test.run TestFunctional -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
         TIME_ELAPSED=$(($END_TIME-$START_TIME))
         min=$((${TIME_ELAPSED}/60))

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,7 +1,10 @@
-name: CI
+name: master
 on: 
-  - pull_request
-  - push
+  push:
+    path:
+      - '**.go'
+    branches:    
+      - master         # Push events on master branch  paths:
 env:
   GOPROXY: https://proxy.golang.org
 jobs:
@@ -427,92 +430,10 @@ jobs:
         numPass=$(echo $STAT | jq '.NumberOfPass')
         echo "*** $numPass Passed ***"
         if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
-  baremetal_ubuntu18_04:
-    needs: [build_minikube]
-    env:
-      TIME_ELAPSED: time
-      JOB_NAME: "None_Ubuntu_18_04"
-      GOPOGH_RESULT: ""
-      SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
-    runs-on: ubuntu-18.04
-    steps:
-    - name: Install kubectl
-      shell: bash
-      run: |
-        curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
-        sudo install kubectl /usr/local/bin/kubectl
-        kubectl version --client=true
-    # conntrack is required for kubernetes 1.18 and higher
-    # socat is required for kubectl port forward which is used in some tests such as validateHelmTillerAddon
-    - name: Install tools for none
-      shell: bash
-      run: |
-        sudo apt-get update -qq
-        sudo apt-get -qq -y install conntrack
-        sudo apt-get -qq -y install socat
-        VERSION="v1.17.0"
-        curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-${VERSION}-linux-amd64.tar.gz --output crictl-${VERSION}-linux-amd64.tar.gz
-        sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
-    - name: Install gopogh
-      shell: bash
-      run: |
-        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.19/gopogh-linux-amd64
-        sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
-    - name: Download Binaries
-      uses: actions/download-artifact@v1
-      with:
-        name: minikube_binaries
-    - name: Run Integration Test
-      continue-on-error: true
-      # bash {0} to allow test to continue to next step. in case of
-      shell: bash {0}
-      run: |
-        cd minikube_binaries
-        mkdir -p report
-        mkdir -p testhome
-        chmod a+x e2e-*
-        chmod a+x minikube-*
-        START_TIME=$(date -u +%s)
-        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome sudo -E ./e2e-linux-amd64 -minikube-start-args=--driver=none -test.timeout=35m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
-        END_TIME=$(date -u +%s)
-        TIME_ELAPSED=$(($END_TIME-$START_TIME))
-        min=$((${TIME_ELAPSED}/60))
-        sec=$((${TIME_ELAPSED}%60))
-        TIME_ELAPSED="${min} min $sec seconds "
-        echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
-    - name: Generate HTML Report
-      shell: bash
-      run: |
-        cd minikube_binaries
-        export PATH=${PATH}:`go env GOPATH`/bin
-        go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
-        STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name "${JOB_NAME} ${GITHUB_REF}" -repo "${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
-        echo status: ${STAT}
-        FailNum=$(echo $STAT | jq '.NumberOfFail')
-        TestsNum=$(echo $STAT | jq '.NumberOfTests')
-        GOPOGH_RESULT="${JOB_NAME} : completed with ${FailNum} / ${TestsNum} failures in ${TIME_ELAPSED}"
-        echo ::set-env name=GOPOGH_RESULT::${GOPOGH_RESULT}
-        echo ::set-env name=STAT::${STAT}
-    - uses: actions/upload-artifact@v1
-      with:
-        name: none_ubuntu18_04
-        path: minikube_binaries/report
-    - name: The End Result - None on Ubuntu 18:04
-      shell: bash
-      run: |
-        echo ${GOPOGH_RESULT}
-        numFail=$(echo $STAT | jq '.NumberOfFail')
-        echo "----------------${numFail} Failures----------------------------"
-        echo $STAT | jq '.FailedTests' || true
-        echo "-------------------------------------------------------"
-        numPass=$(echo $STAT | jq '.NumberOfPass')
-        echo "*** $numPass Passed ***"
-        if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
-  # After all integration tests finished
   # collect all the reports and upload them
   upload_all_reports:
     if: always()
-    needs: [functional_test_docker_ubuntu, addons_certs_tests_docker_ubuntu, multinode_pause_tests_docker_ubuntu, preload_docker_flags_tests_docker_ubuntu, baremetal_ubuntu18_04]
+    needs: [functional_test_docker_ubuntu, addons_certs_tests_docker_ubuntu, multinode_pause_tests_docker_ubuntu, preload_docker_flags_tests_docker_ubuntu]
     runs-on: ubuntu-18.04
     steps:
     - name: download all reports

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -430,10 +430,92 @@ jobs:
         numPass=$(echo $STAT | jq '.NumberOfPass')
         echo "*** $numPass Passed ***"
         if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
+  functional_baremetal_ubuntu18_04:
+    needs: [build_minikube]
+    env:
+      TIME_ELAPSED: time
+      JOB_NAME: "functional_baremetal_ubuntu18_04"
+      GOPOGH_RESULT: ""
+      SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Install kubectl
+      shell: bash
+      run: |
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
+        sudo install kubectl /usr/local/bin/kubectl
+        kubectl version --client=true
+    # conntrack is required for kubernetes 1.18 and higher
+    # socat is required for kubectl port forward which is used in some tests such as validateHelmTillerAddon
+    - name: Install tools for none
+      shell: bash
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get -qq -y install conntrack
+        sudo apt-get -qq -y install socat
+        VERSION="v1.17.0"
+        curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-${VERSION}-linux-amd64.tar.gz --output crictl-${VERSION}-linux-amd64.tar.gz
+        sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
+    - name: Install gopogh
+      shell: bash
+      run: |
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.19/gopogh-linux-amd64
+        sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
+    - name: Download Binaries
+      uses: actions/download-artifact@v1
+      with:
+        name: minikube_binaries
+    - name: Run Integration Test
+      continue-on-error: true
+      # bash {0} to allow test to continue to next step. in case of
+      shell: bash {0}
+      run: |
+        cd minikube_binaries
+        mkdir -p report
+        mkdir -p testhome
+        chmod a+x e2e-*
+        chmod a+x minikube-*
+        START_TIME=$(date -u +%s)
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome sudo -E ./e2e-linux-amd64 -minikube-start-args=--driver=none -test.timeout=35m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        END_TIME=$(date -u +%s)
+        TIME_ELAPSED=$(($END_TIME-$START_TIME))
+        min=$((${TIME_ELAPSED}/60))
+        sec=$((${TIME_ELAPSED}%60))
+        TIME_ELAPSED="${min} min $sec seconds "
+        echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
+    - name: Generate HTML Report
+      shell: bash
+      run: |
+        cd minikube_binaries
+        export PATH=${PATH}:`go env GOPATH`/bin
+        go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
+        STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name "${JOB_NAME} ${GITHUB_REF}" -repo "${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
+        echo status: ${STAT}
+        FailNum=$(echo $STAT | jq '.NumberOfFail')
+        TestsNum=$(echo $STAT | jq '.NumberOfTests')
+        GOPOGH_RESULT="${JOB_NAME} : completed with ${FailNum} / ${TestsNum} failures in ${TIME_ELAPSED}"
+        echo ::set-env name=GOPOGH_RESULT::${GOPOGH_RESULT}
+        echo ::set-env name=STAT::${STAT}
+    - uses: actions/upload-artifact@v1
+      with:
+        name: none_ubuntu18_04
+        path: minikube_binaries/report
+    - name: The End Result - None on Ubuntu 18:04
+      shell: bash
+      run: |
+        echo ${GOPOGH_RESULT}
+        numFail=$(echo $STAT | jq '.NumberOfFail')
+        echo "----------------${numFail} Failures----------------------------"
+        echo $STAT | jq '.FailedTests' || true
+        echo "-------------------------------------------------------"
+        numPass=$(echo $STAT | jq '.NumberOfPass')
+        echo "*** $numPass Passed ***"
+        if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
+  # After all integration tests finished
   # collect all the reports and upload them
   upload_all_reports:
     if: always()
-    needs: [functional_test_docker_ubuntu, addons_certs_tests_docker_ubuntu, multinode_pause_tests_docker_ubuntu, preload_docker_flags_tests_docker_ubuntu]
+    needs: [functional_test_docker_ubuntu, addons_certs_tests_docker_ubuntu, multinode_pause_tests_docker_ubuntu, preload_docker_flags_tests_docker_ubuntu, functional_baremetal_ubuntu18_04]
     runs-on: ubuntu-18.04
     steps:
     - name: download all reports
@@ -448,7 +530,7 @@ jobs:
         cp -r ./addons_certs_tests_docker_ubuntu ./all_reports/
         cp -r ./multinode_pause_tests_docker_ubuntu ./all_reports/
         cp -r ./preload_docker_flags_tests_docker_ubuntu ./all_reports/
-        cp -r ./minikube_binaries ./all_reports/
+        cp -r ./functional_baremetal_ubuntu18_04 ./all_reports/
     - uses: actions/upload-artifact@v1
       with:
         name: all_reports

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,10 +1,10 @@
-name: master
-on: 
+name: MasterCI
+on:
   push:
-    path:
-      - '**.go'
-    branches:    
-      - master         # Push events on master branch  paths:
+    branches:
+    - master
+    paths:
+    - '**.go'
 env:
   GOPROXY: https://proxy.golang.org
 jobs:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -444,12 +444,11 @@ jobs:
       run: |
         mkdir -p all_reports
         ls -lah
-        ls -lah minikube_binaries
-        ls -lah minikube_binaries/report
-        cp -r ./minikube_binaries/report/functional_test_docker_ubuntu ./all_reports/
-        cp -r ./minikube_binaries/report/addons_certs_tests_docker_ubuntu ./all_reports/
-        cp -r ./minikube_binaries/report/multinode_pause_tests_docker_ubuntu ./all_reports/
-        cp -r ./minikube_binaries/report/preload_docker_flags_tests_docker_ubuntu        
+        cp -r ./functional_test_docker_ubuntu ./all_reports/
+        cp -r ./addons_certs_tests_docker_ubuntu ./all_reports/
+        cp -r ./multinode_pause_tests_docker_ubuntu ./all_reports/
+        cp -r ./preload_docker_flags_tests_docker_ubuntu ./all_reports/
+        cp -r ./minikube_binaries ./all_reports/
     - uses: actions/upload-artifact@v1
       with:
         name: all_reports

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -524,12 +524,11 @@ jobs:
       run: |
         mkdir -p all_reports
         ls -lah
-        ls -lah minikube_binaries
-        ls -lah minikube_binaries/report
-        cp -r ./minikube_binaries/report/functional_test_docker_ubuntu ./all_reports/
-        cp -r ./minikube_binaries/report/addons_certs_tests_docker_ubuntu ./all_reports/
-        cp -r ./minikube_binaries/report/multinode_pause_tests_docker_ubuntu ./all_reports/
-        cp -r ./minikube_binaries/report/preload_docker_flags_tests_docker_ubuntu        
+        cp -r ./functional_test_docker_ubuntu ./all_reports/
+        cp -r ./addons_certs_tests_docker_ubuntu ./all_reports/
+        cp -r ./multinode_pause_tests_docker_ubuntu ./all_reports/
+        cp -r ./preload_docker_flags_tests_docker_ubuntu ./all_reports/
+        cp -r ./minikube_binaries ./all_reports/
     - uses: actions/upload-artifact@v1
       with:
         name: all_reports

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,8 +1,8 @@
 name: CI
-on: 
-  - pull_request
-  paths:
-  - '**.go'
+on:
+  pull_request:
+    paths:
+    - '**.go'
 env:
   GOPROXY: https://proxy.golang.org
 jobs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -474,7 +474,7 @@ jobs:
         chmod a+x e2e-*
         chmod a+x minikube-*
         START_TIME=$(date -u +%s)
-        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome sudo -E ./e2e-linux-amd64 -minikube-start-args=--driver=none -test.timeout=35m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome sudo -E ./e2e-linux-amd64 -minikube-start-args=--driver=none -test.timeout=35m -test.v -timeout-multiplier=1.5 -test.run TestFunctional -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
         END_TIME=$(date -u +%s)
         TIME_ELAPSED=$(($END_TIME-$START_TIME))
         min=$((${TIME_ELAPSED}/60))

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,536 @@
+name: CI
+on: 
+  - pull_request
+  paths:
+  - '**.go'
+env:
+  GOPROXY: https://proxy.golang.org
+jobs:
+  # Runs before all other jobs
+  # builds the minikube binaries
+  build_minikube:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download Dependencies
+      run : go mod download
+    - name: Build Binaries
+      run : |
+        make minikube-linux-amd64
+        make e2e-linux-amd64
+        cp -r test/integration/testdata ./out
+        whoami
+        echo github ref $GITHUB_REF
+        echo workflow $GITHUB_WORKFLOW
+        echo home $HOME
+        echo event name $GITHUB_EVENT_NAME
+        echo workspace $GITHUB_WORKSPACE
+        echo "end of debug stuff"
+        echo $(which jq)
+    - uses: actions/upload-artifact@v1
+      with:
+        name: minikube_binaries
+        path: out
+  lint:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install libvirt
+      run : |
+        sudo apt-get update
+        sudo apt-get install -y libvirt-dev
+    - name: Download Dependencies
+      run : go mod download
+    - name: Lint
+      env:
+        TESTSUITE: lintall
+      run : make test
+      continue-on-error: false
+  unit_test:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install libvirt
+      run : |
+        sudo apt-get update
+        sudo apt-get install -y libvirt-dev
+    - name: Download Dependencies
+      run : go mod download
+    - name: Unit Test
+      env:
+        TESTSUITE: unittest
+      run :
+        make test
+      continue-on-error: false
+  # Run the following integration tests after the build_minikube
+  # They will run in parallel and use the binaries in previous step 
+  functional_test_docker_ubuntu:
+    needs: [build_minikube]
+    env:
+      TIME_ELAPSED: time
+      JOB_NAME: "functional_test_docker_ubuntu"
+      GOPOGH_RESULT: ""
+      SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
+    runs-on: ubuntu-18.04
+    steps:    
+    - name: Install kubectl
+      shell: bash
+      run: |
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
+        sudo install kubectl /usr/local/bin/kubectl
+        kubectl version --client=true
+    - name: Docker Info
+      shell: bash
+      run: |
+        echo "--------------------------"
+        docker version || true
+        echo "--------------------------"
+        docker info || true
+        echo "--------------------------"
+        docker system df || true
+        echo "--------------------------"
+        docker system info || true
+        echo "--------------------------"
+        docker ps || true
+        echo "--------------------------"
+    - name: Install lz4
+      shell: bash
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get -qq -y install liblz4-tool
+    - name: Install gopogh
+      shell: bash
+      run: |
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.19/gopogh-linux-amd64
+        sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
+    - name: Download Binaries
+      uses: actions/download-artifact@v1
+      with:
+        name: minikube_binaries
+    - name: Run Integration Test
+      continue-on-error: false
+      # bash {0} to allow test to continue to next step. in case of
+      shell: bash {0}
+      run: |
+        cd minikube_binaries
+        mkdir -p report
+        mkdir -p testhome
+        chmod a+x e2e-*
+        chmod a+x minikube-*
+        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+        START_TIME=$(date -u +%s)
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--vm-driver=docker  -test.run TestFunctional -test.timeout=30m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        END_TIME=$(date -u +%s)
+        TIME_ELAPSED=$(($END_TIME-$START_TIME))
+        min=$((${TIME_ELAPSED}/60))
+        sec=$((${TIME_ELAPSED}%60))
+        TIME_ELAPSED="${min} min $sec seconds "
+        echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
+    - name: Generate HTML Report
+      shell: bash
+      run: |
+        cd minikube_binaries
+        export PATH=${PATH}:`go env GOPATH`/bin
+        go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
+        STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name "${JOB_NAME} ${GITHUB_REF}" -repo "${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
+        echo status: ${STAT}
+        FailNum=$(echo $STAT | jq '.NumberOfFail')
+        TestsNum=$(echo $STAT | jq '.NumberOfTests')
+        GOPOGH_RESULT="${JOB_NAME} : completed with ${FailNum} / ${TestsNum} failures in ${TIME_ELAPSED}"
+        echo ::set-env name=GOPOGH_RESULT::${GOPOGH_RESULT}
+        echo ::set-env name=STAT::${STAT}
+    - uses: actions/upload-artifact@v1
+      with:
+        name: functional_test_docker_ubuntu
+        path: minikube_binaries/report
+    - name: The End Result functional_test_docker_ubuntu
+      shell: bash
+      run: |
+        echo ${GOPOGH_RESULT}
+        numFail=$(echo $STAT | jq '.NumberOfFail')
+        echo "----------------${numFail} Failures----------------------------"
+        echo $STAT | jq '.FailedTests' || true
+        echo "-------------------------------------------------------"
+        numPass=$(echo $STAT | jq '.NumberOfPass')
+        echo "*** $numPass Passed ***"
+        if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
+  addons_certs_tests_docker_ubuntu:
+    runs-on: ubuntu-18.04
+    env:
+      TIME_ELAPSED: time
+      JOB_NAME: "addons_certs_tests_docker_ubuntu"
+      GOPOGH_RESULT: ""
+      SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
+    needs: [build_minikube]
+    steps:
+    - name: Install kubectl
+      shell: bash
+      run: |
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
+        sudo install kubectl /usr/local/bin/kubectl
+        kubectl version --client=true
+    - name: Install lz4
+      shell: bash
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get -qq -y install liblz4-tool
+    - name: Docker Info
+      shell: bash
+      run: |
+        echo "--------------------------"
+        docker version || true
+        echo "--------------------------"
+        docker info || true
+        echo "--------------------------"
+        docker system df || true
+        echo "--------------------------"
+        docker system info || true
+        echo "--------------------------"
+        docker ps || true
+        echo "--------------------------"
+    - name: Install gopogh
+      shell: bash
+      run: |
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.19/gopogh-linux-amd64
+        sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
+    - name: Download Binaries
+      uses: actions/download-artifact@v1
+      with:
+        name: minikube_binaries
+    - name: Run Integration Test
+      continue-on-error: true
+      # bash {0} to allow test to continue to next step. in case of
+      shell: bash {0}
+      run: |
+        cd minikube_binaries
+        mkdir -p report
+        mkdir -p testhome
+        chmod a+x e2e-*
+        chmod a+x minikube-*
+        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+        START_TIME=$(date -u +%s)
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--driver=docker  -test.run "(TestAddons|TestCertOptions)" -test.timeout=30m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        END_TIME=$(date -u +%s)
+        TIME_ELAPSED=$(($END_TIME-$START_TIME))
+        min=$((${TIME_ELAPSED}/60))
+        sec=$((${TIME_ELAPSED}%60))
+        TIME_ELAPSED="${min} min $sec seconds "
+        echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
+    - name: Generate HTML Report
+      shell: bash
+      run: |
+        cd minikube_binaries
+        export PATH=${PATH}:`go env GOPATH`/bin
+        go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
+        STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name "${JOB_NAME} ${GITHUB_REF}" -repo "${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
+        echo status: ${STAT}
+        FailNum=$(echo $STAT | jq '.NumberOfFail')
+        TestsNum=$(echo $STAT | jq '.NumberOfTests')
+        GOPOGH_RESULT="${JOB_NAME} : completed with ${FailNum} / ${TestsNum} failures in ${TIME_ELAPSED}"
+        echo ::set-env name=GOPOGH_RESULT::${GOPOGH_RESULT}
+        echo ::set-env name=STAT::${STAT}
+    - uses: actions/upload-artifact@v1
+      with:
+        name: addons_certs_tests_docker_ubuntu
+        path: minikube_binaries/report
+    - name: The End Result - addons_certs_tests_docker_ubuntu
+      shell: bash
+      run: |
+        echo ${GOPOGH_RESULT}
+        numFail=$(echo $STAT | jq '.NumberOfFail')
+        echo "----------------${numFail} Failures----------------------------"
+        echo $STAT | jq '.FailedTests' || true
+        echo "-------------------------------------------------------"
+        numPass=$(echo $STAT | jq '.NumberOfPass')
+        echo "*** $numPass Passed ***"
+        if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
+  multinode_pause_tests_docker_ubuntu:
+    runs-on: ubuntu-18.04
+    env:
+      TIME_ELAPSED: time
+      JOB_NAME: "multinode_pause_tests_docker_ubuntu"
+      GOPOGH_RESULT: ""
+      SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
+    needs: [build_minikube]
+    steps:
+    - name: Install kubectl
+      shell: bash
+      run: |
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
+        sudo install kubectl /usr/local/bin/kubectl
+        kubectl version --client=true
+    - name: Install lz4
+      shell: bash
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get -qq -y install liblz4-tool
+    - name: Docker Info
+      shell: bash
+      run: |
+        echo "--------------------------"
+        docker version || true
+        echo "--------------------------"
+        docker info || true
+        echo "--------------------------"
+        docker system df || true
+        echo "--------------------------"
+        docker system info || true
+        echo "--------------------------"
+        docker ps || true
+        echo "--------------------------"
+    - name: Install gopogh
+      shell: bash
+      run: |
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.19/gopogh-linux-amd64
+        sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
+    - name: Download Binaries
+      uses: actions/download-artifact@v1
+      with:
+        name: minikube_binaries
+    - name: Run Integration Test
+      continue-on-error: true
+      # bash {0} to allow test to continue to next step. in case of
+      shell: bash {0}
+      run: |
+        cd minikube_binaries
+        mkdir -p report
+        mkdir -p testhome
+        chmod a+x e2e-*
+        chmod a+x minikube-*
+        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+        START_TIME=$(date -u +%s)
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--driver=docker  -test.run "(TestPause|TestMultiNode)" -test.timeout=30m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        END_TIME=$(date -u +%s)
+        TIME_ELAPSED=$(($END_TIME-$START_TIME))
+        min=$((${TIME_ELAPSED}/60))
+        sec=$((${TIME_ELAPSED}%60))
+        TIME_ELAPSED="${min} min $sec seconds "
+        echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
+    - name: Generate HTML Report
+      shell: bash
+      run: |
+        cd minikube_binaries
+        export PATH=${PATH}:`go env GOPATH`/bin
+        go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
+        STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name "${JOB_NAME} ${GITHUB_REF}" -repo "${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
+        echo status: ${STAT}
+        FailNum=$(echo $STAT | jq '.NumberOfFail')
+        TestsNum=$(echo $STAT | jq '.NumberOfTests')
+        GOPOGH_RESULT="${JOB_NAME} : completed with ${FailNum} / ${TestsNum} failures in ${TIME_ELAPSED}"
+        echo ::set-env name=GOPOGH_RESULT::${GOPOGH_RESULT}
+        echo ::set-env name=STAT::${STAT}
+    - uses: actions/upload-artifact@v1
+      with:
+        name: multinode_pause_tests_docker_ubuntu
+        path: minikube_binaries/report
+    - name: The End Result - multinode_pause_tests_docker_ubuntu
+      shell: bash
+      run: |
+        echo ${GOPOGH_RESULT}
+        numFail=$(echo $STAT | jq '.NumberOfFail')
+        echo "----------------${numFail} Failures----------------------------"
+        echo $STAT | jq '.FailedTests' || true
+        echo "-------------------------------------------------------"
+        numPass=$(echo $STAT | jq '.NumberOfPass')
+        echo "*** $numPass Passed ***"
+        if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
+  preload_docker_flags_tests_docker_ubuntu:
+    runs-on: ubuntu-18.04
+    env:
+      TIME_ELAPSED: time
+      JOB_NAME: "preload_docker_flags_tests_docker_ubuntu"
+      GOPOGH_RESULT: ""
+      SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
+    needs: [build_minikube]
+    steps:
+    - name: Install kubectl
+      shell: bash
+      run: |
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
+        sudo install kubectl /usr/local/bin/kubectl
+        kubectl version --client=true
+    - name: Install lz4
+      shell: bash
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get -qq -y install liblz4-tool
+    - name: Docker Info
+      shell: bash
+      run: |
+        echo "--------------------------"
+        docker version || true
+        echo "--------------------------"
+        docker info || true
+        echo "--------------------------"
+        docker system df || true
+        echo "--------------------------"
+        docker system info || true
+        echo "--------------------------"
+        docker ps || true
+        echo "--------------------------"
+    - name: Install gopogh
+      shell: bash
+      run: |
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.19/gopogh-linux-amd64
+        sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
+    - name: Download Binaries
+      uses: actions/download-artifact@v1
+      with:
+        name: minikube_binaries
+    - name: Run Integration Test
+      continue-on-error: true
+      # bash {0} to allow test to continue to next step. in case of
+      shell: bash {0}
+      run: |
+        cd minikube_binaries
+        mkdir -p report
+        mkdir -p testhome
+        chmod a+x e2e-*
+        chmod a+x minikube-*
+        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+        START_TIME=$(date -u +%s)
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--driver=docker  -test.run "(TestPreload|TestDockerFlags)" -test.timeout=30m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        END_TIME=$(date -u +%s)
+        TIME_ELAPSED=$(($END_TIME-$START_TIME))
+        min=$((${TIME_ELAPSED}/60))
+        sec=$((${TIME_ELAPSED}%60))
+        TIME_ELAPSED="${min} min $sec seconds "
+        echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
+    - name: Generate HTML Report
+      shell: bash
+      run: |
+        cd minikube_binaries
+        export PATH=${PATH}:`go env GOPATH`/bin
+        go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
+        STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name "${JOB_NAME} ${GITHUB_REF}" -repo "${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
+        echo status: ${STAT}
+        FailNum=$(echo $STAT | jq '.NumberOfFail')
+        TestsNum=$(echo $STAT | jq '.NumberOfTests')
+        GOPOGH_RESULT="${JOB_NAME} : completed with ${FailNum} / ${TestsNum} failures in ${TIME_ELAPSED}"
+        echo ::set-env name=GOPOGH_RESULT::${GOPOGH_RESULT}
+        echo ::set-env name=STAT::${STAT}
+    - uses: actions/upload-artifact@v1
+      with:
+        name: preload_docker_flags_tests_docker_ubuntu
+        path: minikube_binaries/report
+    - name: The End Result - preload_docker_flags_tests_docker_ubuntu
+      shell: bash
+      run: |
+        echo ${GOPOGH_RESULT}
+        numFail=$(echo $STAT | jq '.NumberOfFail')
+        echo "----------------${numFail} Failures----------------------------"
+        echo $STAT | jq '.FailedTests' || true
+        echo "-------------------------------------------------------"
+        numPass=$(echo $STAT | jq '.NumberOfPass')
+        echo "*** $numPass Passed ***"
+        if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
+  baremetal_ubuntu18_04:
+    needs: [build_minikube]
+    env:
+      TIME_ELAPSED: time
+      JOB_NAME: "None_Ubuntu_18_04"
+      GOPOGH_RESULT: ""
+      SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Install kubectl
+      shell: bash
+      run: |
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
+        sudo install kubectl /usr/local/bin/kubectl
+        kubectl version --client=true
+    # conntrack is required for kubernetes 1.18 and higher
+    # socat is required for kubectl port forward which is used in some tests such as validateHelmTillerAddon
+    - name: Install tools for none
+      shell: bash
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get -qq -y install conntrack
+        sudo apt-get -qq -y install socat
+        VERSION="v1.17.0"
+        curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-${VERSION}-linux-amd64.tar.gz --output crictl-${VERSION}-linux-amd64.tar.gz
+        sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
+    - name: Install gopogh
+      shell: bash
+      run: |
+        curl -LO https://github.com/medyagh/gopogh/releases/download/v0.1.19/gopogh-linux-amd64
+        sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
+    - name: Download Binaries
+      uses: actions/download-artifact@v1
+      with:
+        name: minikube_binaries
+    - name: Run Integration Test
+      continue-on-error: true
+      # bash {0} to allow test to continue to next step. in case of
+      shell: bash {0}
+      run: |
+        cd minikube_binaries
+        mkdir -p report
+        mkdir -p testhome
+        chmod a+x e2e-*
+        chmod a+x minikube-*
+        START_TIME=$(date -u +%s)
+        KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome sudo -E ./e2e-linux-amd64 -minikube-start-args=--driver=none -test.timeout=35m -test.v -timeout-multiplier=1.5 -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+        END_TIME=$(date -u +%s)
+        TIME_ELAPSED=$(($END_TIME-$START_TIME))
+        min=$((${TIME_ELAPSED}/60))
+        sec=$((${TIME_ELAPSED}%60))
+        TIME_ELAPSED="${min} min $sec seconds "
+        echo ::set-env name=TIME_ELAPSED::${TIME_ELAPSED}
+    - name: Generate HTML Report
+      shell: bash
+      run: |
+        cd minikube_binaries
+        export PATH=${PATH}:`go env GOPATH`/bin
+        go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
+        STAT=$(gopogh -in ./report/testout.json -out ./report/testout.html -name "${JOB_NAME} ${GITHUB_REF}" -repo "${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
+        echo status: ${STAT}
+        FailNum=$(echo $STAT | jq '.NumberOfFail')
+        TestsNum=$(echo $STAT | jq '.NumberOfTests')
+        GOPOGH_RESULT="${JOB_NAME} : completed with ${FailNum} / ${TestsNum} failures in ${TIME_ELAPSED}"
+        echo ::set-env name=GOPOGH_RESULT::${GOPOGH_RESULT}
+        echo ::set-env name=STAT::${STAT}
+    - uses: actions/upload-artifact@v1
+      with:
+        name: none_ubuntu18_04
+        path: minikube_binaries/report
+    - name: The End Result - None on Ubuntu 18:04
+      shell: bash
+      run: |
+        echo ${GOPOGH_RESULT}
+        numFail=$(echo $STAT | jq '.NumberOfFail')
+        echo "----------------${numFail} Failures----------------------------"
+        echo $STAT | jq '.FailedTests' || true
+        echo "-------------------------------------------------------"
+        numPass=$(echo $STAT | jq '.NumberOfPass')
+        echo "*** $numPass Passed ***"
+        if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
+  # After all integration tests finished
+  # collect all the reports and upload them
+  upload_all_reports:
+    if: always()
+    needs: [functional_test_docker_ubuntu, addons_certs_tests_docker_ubuntu, multinode_pause_tests_docker_ubuntu, preload_docker_flags_tests_docker_ubuntu]
+    runs-on: ubuntu-18.04
+    steps:
+    - name: download all reports
+      uses: actions/download-artifact@v2-preview
+    - name: upload all reports
+      shell: bash {0}
+      continue-on-error: true
+      run: |
+        mkdir -p all_reports
+        ls -lah
+        ls -lah minikube_binaries
+        ls -lah minikube_binaries/report
+        cp -r ./minikube_binaries/report/functional_test_docker_ubuntu ./all_reports/
+        cp -r ./minikube_binaries/report/addons_certs_tests_docker_ubuntu ./all_reports/
+        cp -r ./minikube_binaries/report/multinode_pause_tests_docker_ubuntu ./all_reports/
+        cp -r ./minikube_binaries/report/preload_docker_flags_tests_docker_ubuntu        
+    - uses: actions/upload-artifact@v1
+      with:
+        name: all_reports
+        path: all_reports

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -428,11 +428,11 @@ jobs:
         numPass=$(echo $STAT | jq '.NumberOfPass')
         echo "*** $numPass Passed ***"
         if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
-  baremetal_ubuntu18_04:
+  functional_baremetal_ubuntu18_04:
     needs: [build_minikube]
     env:
       TIME_ELAPSED: time
-      JOB_NAME: "None_Ubuntu_18_04"
+      JOB_NAME: "functional_baremetal_ubuntu18_04"
       GOPOGH_RESULT: ""
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
     runs-on: ubuntu-18.04
@@ -513,7 +513,7 @@ jobs:
   # collect all the reports and upload them
   upload_all_reports:
     if: always()
-    needs: [functional_test_docker_ubuntu, addons_certs_tests_docker_ubuntu, multinode_pause_tests_docker_ubuntu, preload_docker_flags_tests_docker_ubuntu]
+    needs: [functional_test_docker_ubuntu, addons_certs_tests_docker_ubuntu, multinode_pause_tests_docker_ubuntu, preload_docker_flags_tests_docker_ubuntu, functional_baremetal_ubuntu18_04]
     runs-on: ubuntu-18.04
     steps:
     - name: download all reports
@@ -528,7 +528,7 @@ jobs:
         cp -r ./addons_certs_tests_docker_ubuntu ./all_reports/
         cp -r ./multinode_pause_tests_docker_ubuntu ./all_reports/
         cp -r ./preload_docker_flags_tests_docker_ubuntu ./all_reports/
-        cp -r ./minikube_binaries ./all_reports/
+        cp -r ./functional_baremetal_ubuntu18_04 ./all_reports/
     - uses: actions/upload-artifact@v1
       with:
         name: all_reports

--- a/test/integration/multinode_test.go
+++ b/test/integration/multinode_test.go
@@ -30,11 +30,6 @@ func TestMultiNode(t *testing.T) {
 		t.Skip("none driver does not support multinode")
 	}
 
-	// TODO: remove this skip once docker multinode is fixed
-	if KicDriver() {
-		t.Skip("docker driver multinode is currently broken :(")
-	}
-
 	profile := UniqueProfileName("multinode")
 	ctx, cancel := context.WithTimeout(context.Background(), Minutes(30))
 	defer CleanupWithLogs(t, profile, cancel)


### PR DESCRIPTION
### more tests 
- functional_preload_test_docker_ubuntu
- addons_certs_tests_docker_ubuntu
- multinode_pause_tests_docker_ubuntu
- preload_docker_flags_tests_docker_ubuntu
- baremetal_ubuntu18_04

### upgrade to v2-preview 
which allows downloading multiple things at once, so we wont have 10 silly blocks to download something

### dont trigger test on .MD files
being mindful to github and earth

### run on push to master
test each push to master


### foot notes:
1- in the future we should break down the none tests as well. 
2- github actions have limitted voluem space and when a lot of tests run in a one VM they get super slow.
so breaking down the tests to different VMs makes them finish MUCH faster and also have more visibility what test exactly failed
github has limit of 20 VMs running at the same time, this should not affect since, most of the integration VMs will end in 2-3 minutes. and free up the quota for other PRs.
