### PR TITLE
Enable docker and kubelet units after adding them

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -786,7 +786,9 @@ func startKubeletIfRequired(runner command.Runner, sm sysinit.Manager) error {
 		return errors.Wrap(err, "starting kubelet")
 	}
 
-	sm.Enable("kubelet")
+	if err := sm.Enable("kubelet"); err != nil {
+		return err
+	}
 	return sm.Start("kubelet")
 }
 

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -786,6 +786,7 @@ func startKubeletIfRequired(runner command.Runner, sm sysinit.Manager) error {
 		return errors.Wrap(err, "starting kubelet")
 	}
 
+	sm.Enable("kubelet")
 	return sm.Start("kubelet")
 }
 

--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -292,7 +292,7 @@ func updateUnit(p provision.SSHCommander, name string, content string, dst strin
 	if _, err := p.SSHCommand(fmt.Sprintf("sudo mkdir -p %s && printf %%s \"%s\" | sudo tee %s.new", path.Dir(dst), content, dst)); err != nil {
 		return err
 	}
-	if _, err := p.SSHCommand(fmt.Sprintf("sudo diff -u %s %s.new || { sudo mv %s.new %s; sudo systemctl -f daemon-reload && sudo sudo systemctl -f restart %s; }", dst, dst, dst, dst, name)); err != nil {
+	if _, err := p.SSHCommand(fmt.Sprintf("sudo diff -u %s %s.new || { sudo mv %s.new %s; sudo systemctl -f daemon-reload && sudo systemctl -f enable %s && sudo systemctl -f restart %s; }", dst, dst, dst, dst, name, name)); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
This avoids warnings from `kubeadm init` later:

`! 	[WARNING Service-Docker]`: docker service is not enabled, please run 'systemctl enable docker.service'
`! 	[WARNING Service-Kubelet]`: kubelet service is not enabled, please run 'systemctl enable kubelet.service'

For #7368