### PR TITLE
Site: update community page

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -121,12 +121,12 @@ no = 'Sorry to hear that. Please <a href="https://github.com/kubernetes/minikube
 	name = "Slack"
 	url = "https://kubernetes.slack.com/messages/C1F5CT6Q1"
 	icon = "fab fa-slack"
-    desc = "Chat with other minikube users & developers"
+    desc = "Chat with other minikube users and developers"
 [[params.links.user]]
 	name = "minikube-users mailing list"
 	url = "https://groups.google.com/forum/#!forum/minikube-users"
 	icon = "fas fa-envelope"
-	desc = "Interact with the minikube Users here"
+	desc = "Interact with the minikube users here"
 
 # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
 [[params.links.developer]]
@@ -138,7 +138,29 @@ no = 'Sorry to hear that. Please <a href="https://github.com/kubernetes/minikube
 	name = "minikube-dev mailing list"
 	url = "https://groups.google.com/forum/#!forum/minikube-dev"
 	icon = "fa fa-envelope"
-	desc = "Contact the minikube Dev's here"
+	desc = "Contact the minikube developers here"
+[[params.links.developer]]
+	name = "Contributing Guide"
+	url = "https://minikube.sigs.k8s.io/docs/contrib/"
+	icon = "fas fa-external-link-alt"
+	desc = "Check out the contributing guide"
+[[params.links.developer]]
+	name = "Project Roadmap"
+	url = "https://minikube.sigs.k8s.io/docs/contrib/roadmap/"
+	icon = "fas fa-external-link-alt"
+	desc = "Check out the project roadmap"
+
+# minikube meetings
+[[params.links.meetings]]
+	name = "Office hours"
+	url = "https://tinyurl.com/minikube-oh"
+	icon = "fas fa-comments"
+	desc = "Bi-weekly office hours, Mondays @ 11am PST"
+[[params.links.meetings]]
+	name = "Triage Party"
+	url = "https://minikube.sigs.k8s.io/docs/contrib/triage/"
+	icon = "fas fa-comments"
+	desc = "All community members are welcome and encouraged to join and help us triage minikube!"
 
 
 # Related pages - does not appear to work yet
@@ -156,5 +178,3 @@ no = 'Sorry to hear that. Please <a href="https://github.com/kubernetes/minikube
     name  = "keywords"
     weight = 50
     includeNewer = true
-
-    

--- a/site/config.toml
+++ b/site/config.toml
@@ -29,10 +29,6 @@ pygmentsStyle = "tango"
  # First one is picked as the Twitter card image if not set on page.
  #images = ["images/project-illustration.png"]
 
-# Configure how URLs look like per section.
-[permalinks]
-blog = "/:section/:year/:month/:day/:slug/"
-
 [markup]
   [markup.highlight]
     codeFences = true

--- a/site/content/en/community/_index.md
+++ b/site/content/en/community/_index.md
@@ -4,16 +4,3 @@ menu:
   main:
     weight: 40
 ---
-
-minikube is a Kubernetes [#sig-cluster-lifecycle](https://github.com/kubernetes/community/tree/master/sig-cluster-lifecycle)  project.
-
-* [**#minikube on Kubernetes Slack**](https://kubernetes.slack.com) - Live chat with minikube developers!
-* [minikube-users mailing list](https://groups.google.com/forum/#!forum/minikube-users)
-* [minikube-dev mailing list](https://groups.google.com/forum/#!forum/minikube-dev)
-
-* [Contributing](https://minikube.sigs.k8s.io/docs/contrib/)
-* [Development Roadmap](https://minikube.sigs.k8s.io/docs/contrib/roadmap/)
-
-Join our meetings:
-* [Bi-weekly office hours, Mondays @ 11am PST](https://tinyurl.com/minikube-oh)
-* [Triage Party](https://minikube.sigs.k8s.io/docs/contrib/triage/)

--- a/site/content/en/docs/contrib/documentation.en.md
+++ b/site/content/en/docs/contrib/documentation.en.md
@@ -3,6 +3,8 @@ linkTitle: "Documentation"
 title: "Contributing to minikube documentation"
 date: 2019-07-31
 weight: 2
+aliases:
+  - /docs/contribution-guidelines/
 ---
 
 minikube's documentation is in [Markdown](https://www.markdownguide.org/cheat-sheet/), and generated using the following tools:

--- a/site/layouts/community/list.html
+++ b/site/layouts/community/list.html
@@ -1,0 +1,19 @@
+{{ define "main" }}
+
+<a class="td-offset-anchor"></a>
+<section class="row td-box td-box--1 position-relative td-box--gradient td-box--height-auto">
+	<div class="container text-center td-arrow-down">
+		<span class="h4 mb-0">
+<h1>Join the {{ .Site.Title }} community</h1>
+
+<p>{{ .Site.Title }} is an open source project that anyone in the community can use, improve, and enjoy. We'd love you to join us! Here's a few ways to find out what's happening and get involved.
+</span>
+	</div>
+</section>
+{{ partial "community_links.html" . }}
+
+<div class="td-content">
+{{ .Content }}
+</div>
+
+{{ end }}

--- a/site/layouts/partials/community_links.html
+++ b/site/layouts/partials/community_links.html
@@ -10,11 +10,16 @@
 </div>
 <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
 <h2>Develop and Contribute</h2>
+<p>minikube is a Kubernetes <a href="https://github.com/kubernetes/community/tree/master/sig-cluster-lifecycle">#sig-cluster-lifecycle</a> project.</p>
 <p>If you want to get more involved by contributing to {{ .Site.Title }}, join us here:
 {{ with index $links "developer"}}
 {{ template "community-links-list"  . }}
 {{ end }}
-<p>You can find out how to contribute to these docs in our <a href="/contributing/guide">Contributing Guide</a>.
+<p>You can find out how to contribute to these docs in our <a href="/docs/contribution-guidelines/">Contribution Guidelines</a>.
+<h2>Join our meetings</h2>
+{{ with index $links "meetings"}}
+{{ template "community-links-list"  . }}
+{{ end }}
 </div>
 </section>
 


### PR DESCRIPTION
Updated community page. The information about minikube meetings has been added to the "Develop and Contribute" section.

Before: 
https://minikube.sigs.k8s.io/community/

After: 
https://deploy-preview-7799--kubernetes-sigs-minikube.netlify.app/community/


