### PR TITLE
Add linker flags to go test, for docs test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,7 @@ generate-docs: out/minikube ## Automatically generate commands documentation.
 
 .PHONY: gotest
 gotest: $(SOURCE_GENERATED) ## Trigger minikube test
-	go test -tags "$(MINIKUBE_BUILD_TAGS)" $(MINIKUBE_TEST_FILES)
+	go test -tags "$(MINIKUBE_BUILD_TAGS)" -ldflags="$(MINIKUBE_LDFLAGS)" $(MINIKUBE_TEST_FILES)
 
 .PHONY: extract
 extract: ## Compile extract tool


### PR DESCRIPTION
TestGenerateDocs uses the minikube version

```
--- FAIL: TestGenerateDocs (0.02s)
    --- FAIL: TestGenerateDocs/start (0.00s)
        generate-docs_test.go:47: Docs are not updated. Please run `make generate-docs` to update commands documentation:   strings.Join({
              	... // 6268 identical bytes
              	"ngs                   Locations to fetch the minikube ISO from. ",
              	"(default [https://storage.googleapis.com/minikube/iso/minikube-v",
            - 	"0.0.0-unset.iso,https",
            + 	"1.9.0.iso,https",
              	"://github.com/kubernetes/minikube/releases/download/v",
            - 	"0.0.0-unset/minikube-v0.0.0-unset",
            + 	"1.9.0/minikube-v1.9.0",
              	".iso,https://kubernetes.oss-cn-hangzhou.aliyuncs.com/minikube/is",
              	"o/minikube-v",
            - 	"0.0.0-unset",
            + 	"1.9.0",
              	".iso])\n      --keep-context                      This will keep ",
              	"the existing kubectl context and will create a minikube context.",
              	... // 4085 identical bytes
              }, "")

```