### PR TITLE
kic: fix delete -p not cleaning up & add integration test

### DIFF
--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -43,7 +43,7 @@ import (
 func DeleteContainersByLabel(ociBin string, label string) []error {
 	var deleteErrs []error
 
-	cs, err := listContainersByLabel(ociBin, label)
+	cs, err := ListContainersByLabel(ociBin, label)
 	if err != nil {
 		return []error{fmt.Errorf("listing containers by label %q", label)}
 	}
@@ -322,7 +322,7 @@ func IsCreatedByMinikube(ociBinary string, nameOrID string) bool {
 
 // ListOwnedContainers lists all the containres that kic driver created on user's machine using a label
 func ListOwnedContainers(ociBinary string) ([]string, error) {
-	return listContainersByLabel(ociBinary, ProfileLabelKey)
+	return ListContainersByLabel(ociBinary, ProfileLabelKey)
 }
 
 // inspect return low-level information on containers
@@ -452,8 +452,8 @@ func withPortMappings(portMappings []PortMapping) createOpt {
 	}
 }
 
-// listContainersByLabel returns all the container names with a specified label
-func listContainersByLabel(ociBinary string, label string) ([]string, error) {
+// ListContainersByLabel returns all the container names with a specified label
+func ListContainersByLabel(ociBinary string, label string) ([]string, error) {
 	stdout, err := WarnIfSlow(ociBinary, "ps", "-a", "--filter", fmt.Sprintf("label=%s", label), "--format", "{{.Names}}")
 	if err != nil {
 		return nil, err

--- a/test/integration/main.go
+++ b/test/integration/main.go
@@ -69,9 +69,19 @@ func HyperVDriver() bool {
 	return strings.Contains(*startArgs, "--driver=hyperv") || strings.Contains(*startArgs, "--vm-driver=hyperv")
 }
 
+// DockerDriver returns whether or not this test is using the docker or podman driver
+func DockerDriver() bool {
+	return strings.Contains(*startArgs, "--driver=docker") || strings.Contains(*startArgs, "--vm-driver=docker")
+}
+
+// PodmanDriver returns whether or not this test is using the docker or podman driver
+func PodmanDriver() bool {
+	return strings.Contains(*startArgs, "--vm-driver=podman") || strings.Contains(*startArgs, "driver=podman")
+}
+
 // KicDriver returns whether or not this test is using the docker or podman driver
 func KicDriver() bool {
-	return strings.Contains(*startArgs, "--driver=docker") || strings.Contains(*startArgs, "--vm-driver=docker") || strings.Contains(*startArgs, "--vm-driver=podman") || strings.Contains(*startArgs, "driver=podman")
+	return DockerDriver() || PodmanDriver()
 }
 
 // NeedsPortForward returns access to endpoints with this driver needs port forwarding

--- a/test/integration/pause_test.go
+++ b/test/integration/pause_test.go
@@ -98,7 +98,6 @@ func validateUnpause(ctx context.Context, t *testing.T, profile string) {
 }
 
 func validateDelete(ctx context.Context, t *testing.T, profile string) {
-	// vervose logging because this might go wrong, if container get stuck
 	args := []string{"delete", "-p", profile, "--alsologtostderr", "-v=5"}
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
@@ -106,6 +105,7 @@ func validateDelete(ctx context.Context, t *testing.T, profile string) {
 	}
 }
 
+// make sure no left over left after deleting a profile such as containers or volumes
 func validateVerifyDeleted(ctx context.Context, t *testing.T, profile string) {
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), "profile", "list", "--output", "json"))
 	if err != nil {


### PR DESCRIPTION
while debugging prelaod putting extra binaries in the tar file, I found out since my kic delete refactor, minikube delete -p doesnt clean up after itself

https://github.com/kubernetes/minikube/issues/7814

but delerte --all works.
added integeration test for it, so it never happens again
