### PR TITLE
Change log for flake test: TestFunctional/parallel/TunnelCmd: failed to hit nginx with DNS forwarded

### DIFF
--- a/test/integration/fn_tunnel_cmd.go
+++ b/test/integration/fn_tunnel_cmd.go
@@ -125,10 +125,10 @@ func validateTunnelCmd(ctx context.Context, t *testing.T, profile string) {
 	}
 
 	want := "Welcome to nginx!"
-	if !strings.Contains(string(got), want) {
-		t.Errorf("expected body to contain %q, but got *%q*", want, got)
-	} else {
+	if strings.Contains(string(got), want) {
 		t.Logf("tunnel at %s is working!", url)
+	} else {
+		t.Errorf("expected body to contain %q, but got *%q*", want, got)
 	}
 
 	// Not all platforms support DNS forwarding
@@ -136,16 +136,19 @@ func validateTunnelCmd(ctx context.Context, t *testing.T, profile string) {
 		return
 	}
 
-	url = "http://nginx-svc.default.svc.cluster.local"
+	// use FQDN to avoid extra DNS query lookup
+	url = "http://nginx-svc.default.svc.cluster.local."
 	if err = retry.Expo(fetch, 3*time.Second, Seconds(30), 10); err != nil {
 		t.Errorf("failed to hit nginx with DNS forwarded %q: %v", url, err)
+		// debug more information for: https://github.com/kubernetes/minikube/issues/7809
+		clusterLogs(t, profile)
 	}
 
 	want = "Welcome to nginx!"
-	if !strings.Contains(string(got), want) {
-		t.Errorf("expected body to contain %q, but got *%q*", want, got)
-	} else {
+	if strings.Contains(string(got), want) {
 		t.Logf("tunnel at %s is working!", url)
+	} else {
+		t.Errorf("expected body to contain %q, but got *%q*", want, got)
 	}
 
 }


### PR DESCRIPTION
### What type of PR is this?
/kind flake
/area testing

### What this PR does / why we need it:

Changed following
- Change log conditions for `t.Logf` & `t.Errorf`.  Previously, even if it failed, the log was output as if it had succeeded
- Add `clusterLogs` for debugging root cause

### Which issue(s) this PR fixes:
Fixes #7809

### Does this PR introduce a user-facing change?

No.

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```