### PR TITLE
Update latest release in docs to 1.9.2

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -72,7 +72,7 @@ weight = 1
 [params]
 copyright = "The Kubernetes Authors -- "
 # The latest release of minikube
-latest_release = "1.9.1"
+latest_release = "1.9.2"
 
 privacy_policy = ""
 


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

The docs at https://minikube.sigs.k8s.io/docs/start/ still state 1.9.1 as the latest version, e.g. for the deb packages. Bump the version in `site/config.toml` to the recently released version 1.9.2.
