### PR TITLE
wip: fix mounting /var/lib/contaired to tmpfs in VM ISO

### DIFF
--- a/deploy/iso/minikube-iso/package/automount/minikube-automount
+++ b/deploy/iso/minikube-iso/package/automount/minikube-automount
@@ -89,37 +89,10 @@ if [ -n "$BOOT2DOCKER_DATA" ]; then
     fi
 
     # Just in case, the links will fail if not
-    umount -f /var/lib/docker || true
-    rm -rf /var/lib/docker /var/lib/boot2docker
-    mkdir -p /var/lib
-
-    mkdir -p /mnt/$PARTNAME/var/lib/boot2docker
-    mkdir /var/lib/boot2docker
-    mount --bind /mnt/$PARTNAME/var/lib/boot2docker /var/lib/boot2docker
-
-    mkdir -p /mnt/$PARTNAME/var/lib/docker
-    mkdir -p /var/lib/docker
-    mount --bind /mnt/$PARTNAME/var/lib/docker /var/lib/docker
-
-    mkdir -p /mnt/$PARTNAME/var/lib/containers
-    mkdir -p /var/lib/containers
-    mount --bind /mnt/$PARTNAME/var/lib/containers /var/lib/containers
-
-    mkdir -p /mnt/$PARTNAME/var/log
-    mkdir /var/log
-    mount --bind /mnt/$PARTNAME/var/log /var/log
-
-    mkdir -p /mnt/$PARTNAME/var/tmp
-    mkdir /var/tmp
-    mount --bind /mnt/$PARTNAME/var/tmp /var/tmp
-
-    mkdir -p /mnt/$PARTNAME/var/lib/kubelet
-    mkdir /var/lib/kubelet
-    mount --bind /mnt/$PARTNAME/var/lib/kubelet /var/lib/kubelet
-
-    mkdir -p /mnt/$PARTNAME/var/lib/cni
-    mkdir /var/lib/cni
-    mount --bind /mnt/$PARTNAME/var/lib/cni /var/lib/cni
+    umount -f /var || true
+    rm -rf /var
+    mkdir -p /var
+    mount --bind /mnt/$PARTNAME/var /var
 
     mkdir -p /mnt/$PARTNAME/data
     mkdir /data
@@ -140,18 +113,6 @@ if [ -n "$BOOT2DOCKER_DATA" ]; then
     tar xf /var/lib/boot2docker/userdata.tar -C /home/docker/
     chown -R docker:docker /home/docker/.ssh
     rm -f '/home/docker/boot2docker, please format-me'
-
-    mkdir -p /mnt/$PARTNAME/var/lib/minikube
-    mkdir /var/lib/minikube
-    mount --bind /mnt/$PARTNAME/var/lib/minikube /var/lib/minikube
-
-    mkdir -p /mnt/$PARTNAME/var/lib/toolbox
-    mkdir /var/lib/toolbox
-    mount --bind /mnt/$PARTNAME/var/lib/toolbox /var/lib/toolbox
-
-    mkdir -p /mnt/$PARTNAME/var/lib/minishift
-    mkdir /var/lib/minishift
-    mount --bind /mnt/$PARTNAME/var/lib/minishift /var/lib/minishift
 
     ## make an env file for other services to discover this PARTNAME easier
     mkdir -p /var/run/minikube

--- a/deploy/iso/minikube-iso/package/automount/minikube-automount
+++ b/deploy/iso/minikube-iso/package/automount/minikube-automount
@@ -92,6 +92,15 @@ if [ -n "$BOOT2DOCKER_DATA" ]; then
     umount -f /var || true
     rm -rf /var
     mkdir -p /var
+    mkdir -p /var/lib/docker
+    mkdir -p /var/lib/containers
+    mkdir /var/log
+    mkdir /var/tmp
+    mkdir /var/lib/kubelet
+    mkdir /var/lib/cni
+    ln -s /var/run /run
+    ## make an env file for other services to discover this PARTNAME easier
+    mkdir -p /var/run/minikube
     mount --bind /mnt/$PARTNAME/var /var
 
     mkdir -p /mnt/$PARTNAME/data
@@ -114,8 +123,7 @@ if [ -n "$BOOT2DOCKER_DATA" ]; then
     chown -R docker:docker /home/docker/.ssh
     rm -f '/home/docker/boot2docker, please format-me'
 
-    ## make an env file for other services to discover this PARTNAME easier
-    mkdir -p /var/run/minikube
+
     echo "PERSISTENT_DIR=\"/mnt/$PARTNAME\"" > /var/run/minikube/env
 fi
 


### PR DESCRIPTION
while debugging preload on containerd, it said there is no diskpace left.
@tstromberg found out that /var/lib/contained is living on tmpfs
```
$ df -h /var
Filesystem      Size  Used Avail Use% Mounted on
tmpfs           5.2G  496M  4.7G  10% /
$ 
```

### Before this PR: 
```
$  grep /var /proc/mounts | egrep -v "^(overlay|shm)"
/dev/vda1 /var/lib/boot2docker ext4 rw,relatime 0 0
/dev/vda1 /var/lib/docker ext4 rw,relatime 0 0
/dev/vda1 /var/lib/containers ext4 rw,relatime 0 0
/dev/vda1 /var/log ext4 rw,relatime 0 0
/dev/vda1 /var/lib/kubelet ext4 rw,relatime 0 0
/dev/vda1 /var/lib/cni ext4 rw,relatime 0 0
/dev/vda1 /var/lib/minikube ext4 rw,relatime 0 0
/dev/vda1 /var/lib/toolbox ext4 rw,relatime 0 0
/dev/vda1 /var/lib/minishift ext4 rw,relatime 0 0
tmpfs /var/lib/kubelet/pods/6a9c4fa6-7027-48db-8f80-1ecb3c6e568b/volumes/kubernetes.io~secret/storage-provisioner-token-th5bp tmpfs rw,relatime 0 0
tmpfs /mnt/vda1/var/lib/kubelet/pods/6a9c4fa6-7027-48db-8f80-1ecb3c6e568b/volumes/kubernetes.io~secret/storage-provisioner-token-th5bp tmpfs rw,relatime 0 0
tmpfs /var/lib/kubelet/pods/615c7df5-e19c-440c-8688-000febf34ade/volumes/kubernetes.io~secret/kube-proxy-token-gscfv tmpfs rw,relatime 0 0
tmpfs /mnt/vda1/var/lib/kubelet/pods/615c7df5-e19c-440c-8688-000febf34ade/volumes/kubernetes.io~secret/kube-proxy-token-gscfv tmpfs rw,relatime 0 0
tmpfs /var/lib/kubelet/pods/1bc7a49f-4420-4e8e-a9d1-f2d100558136/volumes/kubernetes.io~secret/coredns-token-mbzzs tmpfs rw,relatime 0 0
tmpfs /mnt/vda1/var/lib/kubelet/pods/1bc7a49f-4420-4e8e-a9d1-f2d100558136/volumes/kubernetes.io~secret/coredns-token-mbzzs tmpfs rw,relatime 0 0
tmpfs /var/lib/kubelet/pods/b96c5a5a-5e2c-4373-a481-2a4a571a936e/volumes/kubernetes.io~secret/coredns-token-mbzzs tmpfs rw,relatime 0 0
tmpfs /mnt/vda1/var/lib/kubelet/pods/b96c5a5a-5e2c-4373-a481-2a4a571a936e/volumes/kubernetes.io~secret/coredns-token-mbzzs tmpfs rw,relatime 0 0
```