### PR TITLE
Revert "Add default CNI network for running wth podman"

### DIFF
--- a/deploy/iso/minikube-iso/package/podman/podman.mk
+++ b/deploy/iso/minikube-iso/package/podman/podman.mk
@@ -29,8 +29,6 @@ endef
 
 define PODMAN_INSTALL_TARGET_CMDS
 	$(INSTALL) -Dm755 $(@D)/bin/podman $(TARGET_DIR)/usr/bin/podman
-	$(INSTALL) -d -m 755 $(TARGET_DIR)/etc/cni/net.d/
-	$(INSTALL) -m 644 cni/87-podman-bridge.conflist $(TARGET_DIR)/etc/cni/net.d/87-podman-bridge.conflist
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
Reverts kubernetes/minikube#7754

probable cause of https://github.com/kubernetes/minikube/issues/7840 