### PR TITLE
ISO: persistently mount /var/lib/containerd

### DIFF
--- a/deploy/iso/minikube-iso/package/automount/minikube-automount
+++ b/deploy/iso/minikube-iso/package/automount/minikube-automount
@@ -101,6 +101,10 @@ if [ -n "$BOOT2DOCKER_DATA" ]; then
     mkdir -p /var/lib/docker
     mount --bind /mnt/$PARTNAME/var/lib/docker /var/lib/docker
 
+    mkdir -p /mnt/$PARTNAME/var/lib/containerd
+    mkdir -p /var/lib/containerd
+    mount --bind /mnt/$PARTNAME/var/lib/containerd /var/lib/containerd
+
     mkdir -p /mnt/$PARTNAME/var/lib/containers
     mkdir -p /var/lib/containers
     mount --bind /mnt/$PARTNAME/var/lib/containers /var/lib/containers
@@ -117,9 +121,14 @@ if [ -n "$BOOT2DOCKER_DATA" ]; then
     mkdir /var/lib/kubelet
     mount --bind /mnt/$PARTNAME/var/lib/kubelet /var/lib/kubelet
 
+    mkdir -p /mnt/$PARTNAME/var/lib/kubelet/pods
+    mkdir /var/lib/kubelet/pods
+    mount --bind /mnt/$PARTNAME/var/lib/kubelet /var/lib/kubelet/pods
+
     mkdir -p /mnt/$PARTNAME/var/lib/cni
     mkdir /var/lib/cni
     mount --bind /mnt/$PARTNAME/var/lib/cni /var/lib/cni
+
 
     mkdir -p /mnt/$PARTNAME/data
     mkdir /data

--- a/deploy/iso/minikube-iso/package/automount/minikube-automount
+++ b/deploy/iso/minikube-iso/package/automount/minikube-automount
@@ -129,7 +129,6 @@ if [ -n "$BOOT2DOCKER_DATA" ]; then
     mkdir /var/lib/cni
     mount --bind /mnt/$PARTNAME/var/lib/cni /var/lib/cni
 
-
     mkdir -p /mnt/$PARTNAME/data
     mkdir /data
     mount --bind /mnt/$PARTNAME/data /data

--- a/deploy/iso/minikube-iso/package/automount/minikube-automount
+++ b/deploy/iso/minikube-iso/package/automount/minikube-automount
@@ -121,10 +121,6 @@ if [ -n "$BOOT2DOCKER_DATA" ]; then
     mkdir /var/lib/kubelet
     mount --bind /mnt/$PARTNAME/var/lib/kubelet /var/lib/kubelet
 
-    mkdir -p /mnt/$PARTNAME/var/lib/kubelet/pods
-    mkdir /var/lib/kubelet/pods
-    mount --bind /mnt/$PARTNAME/var/lib/kubelet /var/lib/kubelet/pods
-
     mkdir -p /mnt/$PARTNAME/var/lib/cni
     mkdir /var/lib/cni
     mount --bind /mnt/$PARTNAME/var/lib/cni /var/lib/cni


### PR DESCRIPTION
before this PR:
/var/lib/containerd was stored in tmpfs

```
$  grep /var /proc/mounts | egrep -v "^(overlay|shm)"
/dev/vda1 /var/lib/boot2docker ext4 rw,relatime 0 0
/dev/vda1 /var/lib/docker ext4 rw,relatime 0 0
/dev/vda1 /var/lib/containers ext4 rw,relatime 0 0
/dev/vda1 /var/log ext4 rw,relatime 0 0
/dev/vda1 /var/lib/kubelet ext4 rw,relatime 0 0
/dev/vda1 /var/lib/cni ext4 rw,relatime 0 0
/dev/vda1 /var/lib/minikube ext4 rw,relatime 0 0
/dev/vda1 /var/lib/toolbox ext4 rw,relatime 0 0
/dev/vda1 /var/lib/minishift ext4 rw,relatime 0 0
tmpfs /var/lib/kubelet/pods/6a9c4fa6-7027-48db-8f80-1ecb3c6e568b/volumes/kubernetes.io~secret/storage-provisioner-token-th5bp tmpfs rw,relatime 0 0
tmpfs /mnt/vda1/var/lib/kubelet/pods/6a9c4fa6-7027-48db-8f80-1ecb3c6e568b/volumes/kubernetes.io~secret/storage-provisioner-token-th5bp tmpfs rw,relatime 0 0
tmpfs /var/lib/kubelet/pods/615c7df5-e19c-440c-8688-000febf34ade/volumes/kubernetes.io~secret/kube-proxy-token-gscfv tmpfs rw,relatime 0 0
tmpfs /mnt/vda1/var/lib/kubelet/pods/615c7df5-e19c-440c-8688-000febf34ade/volumes/kubernetes.io~secret/kube-proxy-token-gscfv tmpfs rw,relatime 0 0
tmpfs /var/lib/kubelet/pods/1bc7a49f-4420-4e8e-a9d1-f2d100558136/volumes/kubernetes.io~secret/coredns-token-mbzzs tmpfs rw,relatime 0 0
tmpfs /mnt/vda1/var/lib/kubelet/pods/1bc7a49f-4420-4e8e-a9d1-f2d100558136/volumes/kubernetes.io~secret/coredns-token-mbzzs tmpfs rw,relatime 0 0
tmpfs /var/lib/kubelet/pods/b96c5a5a-5e2c-4373-a481-2a4a571a936e/volumes/kubernetes.io~secret/coredns-token-mbzzs tmpfs rw,relatime 0 0
tmpfs /mnt/vda1/var/lib/kubelet/pods/b96c5a5a-5e2c-4373-a481-2a4a571a936e/volumes/kubernetes.io~secret/coredns-token-mbzzs tmpfs rw,relatime 0 0
```

## After this PR
```
$ grep /var /proc/mounts | egrep -v "^(overlay|shm)"
/dev/vda1 /var/lib/boot2docker ext4 rw,relatime 0 0
/dev/vda1 /var/lib/docker ext4 rw,relatime 0 0
/dev/vda1 /var/lib/containerd ext4 rw,relatime 0 0
/dev/vda1 /var/lib/containers ext4 rw,relatime 0 0
/dev/vda1 /var/log ext4 rw,relatime 0 0
/dev/vda1 /var/tmp ext4 rw,relatime 0 0
/dev/vda1 /var/lib/kubelet ext4 rw,relatime 0 0
/dev/vda1 /var/lib/kubelet/pods ext4 rw,relatime 0 0
/dev/vda1 /mnt/vda1/var/lib/kubelet/pods ext4 rw,relatime 0 0
/dev/vda1 /var/lib/cni ext4 rw,relatime 0 0
/dev/vda1 /var/lib/minikube ext4 rw,relatime 0 0
/dev/vda1 /var/lib/toolbox ext4 rw,relatime 0 0
/dev/vda1 /var/lib/minishift ext4 rw,relatime 0 0
tmpfs /var/lib/kubelet/pods/e498f978-13ca-4561-bd82-f729a79e0b22/volumes/kubernetes.io~secret/kube-proxy-token-5fb45 tmpfs rw,relatime 0 0
tmpfs /mnt/vda1/var/lib/kubelet/e498f978-13ca-4561-bd82-f729a79e0b22/volumes/kubernetes.io~secret/kube-proxy-token-5fb45 tmpfs rw,relatime 0 0
tmpfs /var/lib/kubelet/e498f978-13ca-4561-bd82-f729a79e0b22/volumes/kubernetes.io~secret/kube-proxy-token-5fb45 tmpfs rw,relatime 0 0
tmpfs /mnt/vda1/var/lib/kubelet/pods/e498f978-13ca-4561-bd82-f729a79e0b22/volumes/kubernetes.io~secret/kube-proxy-token-5fb45 tmpfs rw,relatime 0 0
tmpfs /var/lib/kubelet/pods/76633a80-973a-4b68-9f5e-f39d4c781709/volumes/kubernetes.io~secret/coredns-token-qcxrj tmpfs rw,relatime 0 0
tmpfs /mnt/vda1/var/lib/kubelet/76633a80-973a-4b68-9f5e-f39d4c781709/volumes/kubernetes.io~secret/coredns-token-qcxrj tmpfs rw,relatime 0 0
tmpfs /var/lib/kubelet/76633a80-973a-4b68-9f5e-f39d4c781709/volumes/kubernetes.io~secret/coredns-token-qcxrj tmpfs rw,relatime 0 0
tmpfs /mnt/vda1/var/lib/kubelet/pods/76633a80-973a-4b68-9f5e-f39d4c781709/volumes/kubernetes.io~secret/coredns-token-qcxrj tmpfs rw,relatime 0 0
tmpfs /var/lib/kubelet/pods/ce976354-8acc-4f4c-b63a-9c7bef5ad986/volumes/kubernetes.io~secret/coredns-token-qcxrj tmpfs rw,relatime 0 0
tmpfs /mnt/vda1/var/lib/kubelet/ce976354-8acc-4f4c-b63a-9c7bef5ad986/volumes/kubernetes.io~secret/coredns-token-qcxrj tmpfs rw,relatime 0 0
tmpfs /var/lib/kubelet/ce976354-8acc-4f4c-b63a-9c7bef5ad986/volumes/kubernetes.io~secret/coredns-token-qcxrj tmpfs rw,relatime 0 0
tmpfs /mnt/vda1/var/lib/kubelet/pods/ce976354-8acc-4f4c-b63a-9c7bef5ad986/volumes/kubernetes.io~secret/coredns-token-qcxrj tmpfs rw,relatime 0 0
tmpfs /var/lib/kubelet/pods/bfd58ce3-5687-4b13-bd10-ece1ff1d9dcb/volumes/kubernetes.io~secret/storage-provisioner-token-zzsbh tmpfs rw,relatime 0 0
tmpfs /mnt/vda1/var/lib/kubelet/bfd58ce3-5687-4b13-bd10-ece1ff1d9dcb/volumes/kubernetes.io~secret/storage-provisioner-token-zzsbh tmpfs rw,relatime 0 0
tmpfs /var/lib/kubelet/bfd58ce3-5687-4b13-bd10-ece1ff1d9dcb/volumes/kubernetes.io~secret/storage-provisioner-token-zzsbh tmpfs rw,relatime 0 0
tmpfs /mnt/vda1/var/lib/kubelet/pods/bfd58ce3-5687-4b13-bd10-ece1ff1d9dcb/volumes/kubernetes.io~secret/storage-provisioner-token-zzsbh tmpfs rw,relatime 0 0
```
this PR will add /var/lib/containerd to disk instead of tmpfs that caused preload containerd to fail
and possible source of other mysterious containerd test failures.  

also put /kubelet/pods there too since that was only folder on tempfs before this PR. leaving the rest of /var to be presitant in following up PRs