### PR TITLE
Add missing source directory for podman cni config

### DIFF
--- a/deploy/iso/minikube-iso/package/podman/podman.mk
+++ b/deploy/iso/minikube-iso/package/podman/podman.mk
@@ -30,7 +30,7 @@ endef
 define PODMAN_INSTALL_TARGET_CMDS
 	$(INSTALL) -Dm755 $(@D)/bin/podman $(TARGET_DIR)/usr/bin/podman
 	$(INSTALL) -d -m 755 $(TARGET_DIR)/etc/cni/net.d/
-	$(INSTALL) -m 644 cni/87-podman-bridge.conflist $(TARGET_DIR)/etc/cni/net.d/87-podman-bridge.conflist
+	$(INSTALL) -m 644 $(@D)/cni/87-podman-bridge.conflist $(TARGET_DIR)/etc/cni/net.d/87-podman-bridge.conflist
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
For some reason this got lost with previous commit 46df921da7e2434d2abb45f4f172abcb49a8d1ef

Fixes #7840