### PR TITLE
addon registry-alias: change hosts update container image

### DIFF
--- a/deploy/addons/registry-aliases/node-etc-hosts-update.tmpl
+++ b/deploy/addons/registry-aliases/node-etc-hosts-update.tmpl
@@ -17,7 +17,7 @@ spec:
     spec:
       initContainers:
         - name: update
-          image: ubuntu:bionic
+          image: alpine:3.11
           volumeMounts:
             - name: etchosts
               mountPath: /host-etc/hosts
@@ -39,7 +39,7 @@ spec:
               for H in $REGISTRY_ALIASES; do                
                 echo "$HOSTS" | grep "$H"  || HOSTS="$HOSTS$NL$REGISTRY_SERVICE_HOST$TAB$H";
               done;
-              echo "$HOSTS" | diff -u /host-etc/hosts - || echo "$HOSTS" > /host-etc/hosts
+              echo "$HOSTS" | diff -U 3 /host-etc/hosts - || echo "$HOSTS" > /host-etc/hosts
               echo "Done."
       containers:
         - name: pause-for-update

--- a/deploy/addons/registry-aliases/node-etc-hosts-update.tmpl
+++ b/deploy/addons/registry-aliases/node-etc-hosts-update.tmpl
@@ -17,7 +17,7 @@ spec:
     spec:
       initContainers:
         - name: update
-          image: registry.fedoraproject.org/fedora
+          image: ubuntu:bionic
           volumeMounts:
             - name: etchosts
               mountPath: /host-etc/hosts


### PR DESCRIPTION
The most recent Fedora image doesn't include a `diff` binary. This changes the container image to use Ubuntu Bionic instead, which _does_ provide a diff binary.

Fixes #7715.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
