### PR TITLE
TestServiceCmd: use echoserver image instead of hello-node

### DIFF
--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -639,7 +639,7 @@ func validateProfileCmd(ctx context.Context, t *testing.T, profile string) {
 
 // validateServiceCmd asserts basic "service" command functionality
 func validateServiceCmd(ctx context.Context, t *testing.T, profile string) {
-	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "create", "deployment", "hello-node", "--image=gcr.io/hello-minikube-zero-install/hello-node"))
+	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "create", "deployment", "hello-node", "--image=k8s.gcr.io/echoserver:1.4"))
 	if err != nil {
 		t.Logf("%q failed: %v (may not be an error).", rr.Command(), err)
 	}


### PR DESCRIPTION
Should fix #7868
