### PR TITLE
contained cni: rename default cni file to have higher priority

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/files.go
+++ b/pkg/minikube/bootstrapper/bsutil/files.go
@@ -28,7 +28,7 @@ var KubeadmYamlPath = path.Join(vmpath.GuestEphemeralDir, "kubeadm.yaml")
 
 const (
 	//DefaultCNIConfigPath is the configuration file for CNI networks
-	DefaultCNIConfigPath = "/etc/cni/net.d/k8s.conf"
+	DefaultCNIConfigPath = "/etc/cni/net.d/1-k8s.conf"
 	// KubeletServiceFile is the file for the systemd kubelet.service
 	KubeletServiceFile = "/lib/systemd/system/kubelet.service"
 	// KubeletSystemdConfFile is config for the systemd kubelet.service


### PR DESCRIPTION
fixes https://github.com/kubernetes/minikube/issues/7874

on old ISO :
```
$ ls /etc/cni/net.d/
k8s.conf
```
but on the new ISO we have
```
$ ls /etc/cni/net.d/
87-podman-bridge.conflist  k8s.conf
```

related to the podman cni ISO change https://github.com/kubernetes/minikube/commit/4803589dee1677ef3bea3ef10123f1bf177eacf1
what was happening, is because the podman cni was alphabetically higher importance for containerd and was picked up by it