### PR TITLE
docker-env: fall back to bash if can not detect shell.

### DIFF
--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -27,6 +27,8 @@ import (
 	"strconv"
 	"strings"
 
+	lib_shell "github.com/docker/machine/libmachine/shell"
+	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/command"
@@ -168,7 +170,14 @@ var dockerEnvCmd = &cobra.Command{
 		if ec.Shell == "" {
 			ec.Shell, err = shell.Detect()
 			if err != nil {
-				exit.WithError("Error detecting shell", err)
+				// if we can't detect it could be bash. for example github actions
+				if err == lib_shell.ErrUnknownShell {
+					ec.Shell = "bash"
+					glog.Warningf("couldn't detect shell type, will default to bash: %v", err)
+				} else {
+					exit.WithError("Error detecting shell", err)
+				}
+
 			}
 		}
 


### PR DESCRIPTION
while making a github action bot for minikube, I was trying to use docker-env functionality,
I realized github action shell is NOT detectable, even though it is bash.
because it doesn't give you SHELL environment variable.

I even set shell: bash expclicitly but still minikube cant detect it
 https://github.com/k8sguard/discover/blob/master/.github/workflows/main.yml#L17

I think it is better for minikube to fall back to bash instead of crashing and not doing anything. and more users will be able to use minikube in github actions and environments like that.

closes  https://github.com/kubernetes/minikube/issues/7886
closes https://github.com/kubernetes/minikube/issues/6766

