### PR TITLE
Revert "docker-env: fall back to bash if can not detect shell."

### DIFF
--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -27,8 +27,6 @@ import (
 	"strconv"
 	"strings"
 
-	lib_shell "github.com/docker/machine/libmachine/shell"
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/command"
@@ -170,14 +168,7 @@ var dockerEnvCmd = &cobra.Command{
 		if ec.Shell == "" {
 			ec.Shell, err = shell.Detect()
 			if err != nil {
-				// if we can't detect it could be bash. for example github actions
-				if err == lib_shell.ErrUnknownShell {
-					ec.Shell = "bash"
-					glog.Warningf("couldn't detect shell type, will default to bash: %v", err)
-				} else {
-					exit.WithError("Error detecting shell", err)
-				}
-
+				exit.WithError("Error detecting shell", err)
 			}
 		}
 


### PR DESCRIPTION
this PR's build fails on windows
```
cmd/minikube/cmd/docker-env.go:174:15: undefined: "github.com/docker/machine/libmachine/shell".ErrUnknownShell
make: *** [Makefile:186: out/minikube-windows-amd64] Error 2
Makefile:184: recipe for target 'out/minikube-windows-amd64' failed
make: *** [out/minikube-windows-amd64] Error 2
make: *** Waiting for unfinished jobs....
+ failed=2
++ go env GOOS

```

Reverts kubernetes/minikube#7887