### PR TITLE
site: simplify instructions to find service external IP

### DIFF
--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -150,9 +150,11 @@ In another window, start the tunnel to create a routable IP for the 'balanced' d
 minikube tunnel
 ```
 
-To find the routable IP, run this command and examine the `EXTERNAL-IP` column:
+To find the routable external IP, run this command:
 
-`kubectl get services balanced`
+```shell
+kubectl get services balanced --output=jsonpath='{.spec.clusterIP}'
+```
 
 Your deployment is now available at &lt;EXTERNAL-IP&gt;:8000
 

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -153,7 +153,7 @@ minikube tunnel
 To find the routable external IP, run this command:
 
 ```shell
-kubectl get services balanced --output=jsonpath='{.spec.clusterIP}'
+kubectl get services balanced --output=jsonpath='{.status.loadBalancer.ingress[0].ip}''
 ```
 
 Your deployment is now available at &lt;EXTERNAL-IP&gt;:8000


### PR DESCRIPTION
instead of telling the user to examine output of a command for external IP, use a better command:
tested locally
```
$ curl $(kubectl get services discover2 --output=jsonpath='{.status.loadBalancer.ingress[0].ip}'):8080/version
version: 0.0.1

```