### PR TITLE
wip: add broken link check to github lint

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -48,6 +48,8 @@ jobs:
           TESTSUITE: lintall
         run: make test
         continue-on-error: false
+      - name: Broken Link Check
+        uses: technote-space/broken-link-checker-action@v1
   unit_test:
     runs-on: ubuntu-18.04
     steps:


### PR DESCRIPTION
while reading https://minikube.sigs.k8s.io/docs/tutorials/nginx_tcp_udp_ingress/
I saw two broken links,

giving technote-space/broken-link-checker-action@v1 a try to detect all broken links automatically.


