### PR TITLE
Example how to enable multiple addons on start command

### DIFF
--- a/site/content/en/docs/handbook/deploying.md
+++ b/site/content/en/docs/handbook/deploying.md
@@ -29,10 +29,10 @@ To enable an add-on, see:
 minikube addons enable <name>
 ```
 
-To enable an addon at start-up:
+To enable an addon at start-up, where *--addons* option can be specified multiple times:
 
 ```shell
-minikube start --addons <name>
+minikube start --addons <name1> --addons <name2>
 ```
 
 For addons that expose a browser endpoint, you can quickly open them with:


### PR DESCRIPTION
Example how to enable multiple addons on start command

Multiple addons have been added here: https://github.com/kubernetes/minikube/pull/5543
there is a short spec which explains how does it work.

fixes #7920 
