### PR TITLE
docker/podman: add alternative image repo for base image to fallback

### DIFF
--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -35,6 +35,10 @@ const (
 var (
 	// BaseImage is the base image is used to spin up kic containers. it uses same base-image as kind.
 	BaseImage = fmt.Sprintf("gcr.io/k8s-minikube/kicbase:%s@sha256:%s", Version, baseImageSHA)
+	// BaseImageFallBack the fall back of BaseImage in case gcr.io is not available. stored in github packages https://github.com/kubernetes/minikube/packages/206071
+	// github packages docker does _NOT_ support pulling by sha as mentioned in the docs:
+	// https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages
+	BaseImageFallBack = fmt.Sprintf("docker.pkg.github.com/kubernetes/minikube/kicbase:%s", Version)
 )
 
 // Config is configuration for the kic driver used by registry

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -109,9 +109,8 @@ func beginDownloadKicArtifacts(g *errgroup.Group, cc *config.ClusterConfig) {
 				glog.Infof("Downloading %s to local daemon", cc.KicBaseImage)
 				err := image.WriteImageToDaemon(cc.KicBaseImage)
 				if err != nil {
-					origImage := cc.KicBaseImage
+					glog.Infof("failed to download base-image %q will try to download the fallback base-image %q instead.", cc.KicBaseImage, kic.BaseImageFallBack)
 					cc.KicBaseImage = kic.BaseImageFallBack
-					glog.Infof("failed to download base image %q will try to download the fallback image %q instead.", origImage, kic.BaseImageFallBack)
 					return image.WriteImageToDaemon(kic.BaseImageFallBack)
 				}
 				return nil

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -106,6 +106,7 @@ func beginDownloadKicArtifacts(g *errgroup.Group, cc *config.ClusterConfig) {
 		if !image.ExistsImageInDaemon(cc.KicBaseImage) {
 			out.T(out.Pulling, "Pulling base image ...")
 			g.Go(func() error {
+				// TODO #8004 : make base-image respect --image-repository
 				glog.Infof("Downloading %s to local daemon", cc.KicBaseImage)
 				err := image.WriteImageToDaemon(cc.KicBaseImage)
 				if err != nil {

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -109,7 +109,8 @@ func beginDownloadKicArtifacts(g *errgroup.Group, driver string, cRuntime string
 				glog.Infof("Downloading %s to local daemon", baseImage)
 				err := image.WriteImageToDaemon(baseImage)
 				if err != nil {
-					// registry/driver package uses viper.Set
+					// TODO : remove this global set when this issue is closed
+					// https://github.com/kubernetes/minikube/issues/7944
 					viper.Set("base-image", kic.BaseImageFallBack)
 					glog.Infof("failed to download %s will try to download the fallback image from %s", baseImage, kic.BaseImageFallBack)
 					return image.WriteImageToDaemon(kic.BaseImageFallBack)

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -197,7 +197,7 @@ func Provision(cc *config.ClusterConfig, n *config.Node, apiServer bool) (comman
 	}
 
 	if driver.IsKIC(cc.Driver) {
-		beginDownloadKicArtifacts(&kicGroup, cc.Driver, cc.KubernetesConfig.ContainerRuntime, cc.KicBaseImage)
+		beginDownloadKicArtifacts(&kicGroup, cc)
 	}
 
 	if !driver.BareMetal(cc.Driver) {


### PR DESCRIPTION
This PR adds an alternative image-repo in https://github.com/kubernetes/minikube/packages
 for kic base image. instead of gcr.io
fixes: https://github.com/kubernetes/minikube/issues/7472

## First: Emulating not having access to GCR:
```
$ cat /etc/hosts | grep gcr.io
127.0.0.1       gcr.io

$ docker rmi gcr.io/k8s-minikube/kicbase:v0.0.10
```
### Before this PR: time out with ugly error when image not avialble
```
 $ minikube start --driver=docker
😄  minikube v1.10.0-beta.2 on Darwin 10.15.4
✨  Using the docker driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
E0429 22:29:51.276201   86892 cache.go:122] Error downloading kic artifacts:  getting remote image: Get https://gcr.io/v2/: dial tcp 127.0.0.2:443: i/o timeout
🔥  Creating docker container (CPUs=2, Memory=4000MB) ...
🤦  StartHost failed, but will try again: creating host: create: creating: create kic node: create container: docker run -d -t --privileged --security-opt seccomp=unconfined --security-opt apparmor=unconfined --tmpfs /tmp --tmpfs /run -v /lib/modules:/lib/modules:ro --hostname minikube --name minikube --label created_by.minikube.sigs.k8s.io=true --label name.minikube.sigs.k8s.io=minikube --label role.minikube.sigs.k8s.io= --label mode.minikube.sigs.k8s.io=minikube --volume minikube:/var --cpus=2 --memory=4000mb -e container=docker --expose 8443 --publish=127.0.0.1::8443 --publish=127.0.0.1::22 --publish=127.0.0.1::2376 --publish=127.0.0.1::5000 gcr.io/k8s-minikube/kicbase:v0.0.10@sha256:f58e0c4662bac8a9b5dda7984b185bad8502ade5d9fa364bf2755d636ab51438: exit status 125
stdout:

stderr:
Unable to find image 'gcr.io/k8s-minikube/kicbase:v0.0.10@sha256:f58e0c4662bac8a9b5dda7984b185bad8502ade5d9fa364bf2755d636ab51438' locally
docker: Error response from daemon: Get http://gcr.io/v2/: net/http: request canceled (Client.Timeout exceeded while awaiting headers).
See 'docker run --help'.

🤷  docker "minikube" container is missing, will recreate.
E0429 22:30:30.176700   86892 oci.go:79] docker daemon seems to be stuck. Please try restarting your docker. Will try to delete anyways: unknown state "minikube": docker inspect minikube --format={{.State.Status}}: exit status 1
stdout:


stderr:
Template parsing error: template: :1:8: executing "" at <.State.Status>: map has no entry for key "State"
🔥  Creating docker container (CPUs=2, Memory=4000MB) ...
😿  Failed to start docker container. "minikube start" may fix it: recreate: creating host: create: creating: create kic node: create container: docker run -d -t --privileged --security-opt seccomp=unconfined --security-opt apparmor=unconfined --tmpfs /tmp --tmpfs /run -v /lib/modules:/lib/modules:ro --hostname minikube --name minikube --label created_by.minikube.sigs.k8s.io=true --label name.minikube.sigs.k8s.io=minikube --label role.minikube.sigs.k8s.io= --label mode.minikube.sigs.k8s.io=minikube --volume minikube:/var --cpus=2 --memory=4000mb -e container=docker --expose 8443 --publish=127.0.0.1::8443 --publish=127.0.0.1::22 --publish=127.0.0.1::2376 --publish=127.0.0.1::5000 gcr.io/k8s-minikube/kicbase:v0.0.10@sha256:f58e0c4662bac8a9b5dda7984b185bad8502ade5d9fa364bf2755d636ab51438: exit status 125
stdout:

stderr:
Unable to find image 'gcr.io/k8s-minikube/kicbase:v0.0.10@sha256:f58e0c4662bac8a9b5dda7984b185bad8502ade5d9fa364bf2755d636ab51438' locally
docker: Error response from daemon: Get http://gcr.io/v2/: net/http: request canceled (Client.Timeout exceeded while awaiting headers).
See 'docker run --help'.


💣  error provisioning host: Failed to start host: recreate: creating host: create: creating: create kic node: create container: docker run -d -t --privileged --security-opt seccomp=unconfined --security-opt apparmor=unconfined --tmpfs /tmp --tmpfs /run -v /lib/modules:/lib/modules:ro --hostname minikube --name minikube --label created_by.minikube.sigs.k8s.io=true --label name.minikube.sigs.k8s.io=minikube --label role.minikube.sigs.k8s.io= --label mode.minikube.sigs.k8s.io=minikube --volume minikube:/var --cpus=2 --memory=4000mb -e container=docker --expose 8443 --publish=127.0.0.1::8443 --publish=127.0.0.1::22 --publish=127.0.0.1::2376 --publish=127.0.0.1::5000 gcr.io/k8s-minikube/kicbase:v0.0.10@sha256:f58e0c4662bac8a9b5dda7984b185bad8502ade5d9fa364bf2755d636ab51438: exit status 125
stdout:

stderr:
Unable to find image 'gcr.io/k8s-minikube/kicbase:v0.0.10@sha256:f58e0c4662bac8a9b5dda7984b185bad8502ade5d9fa364bf2755d636ab51438' locally
docker: Error response from daemon: Get http://gcr.io/v2/: net/http: request canceled (Client.Timeout exceeded while awaiting headers).
See 'docker run --help'.


😿  minikube is exiting due to an error. If the above message is not useful, open an issue:
👉  https://github.com/kubernetes/minikube/issues/new/choose
```

### After this PR
```
$ make && ./out/minikube start --driver=docker
make: `out/minikube' is up to date.
😄  minikube v1.10.0-beta.2 on Darwin 10.15.4
✨  Using the docker driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
E0429 23:07:03.587714   94304 cache.go:130] Error downloading kic artifacts:  getting remote image: GET https://docker.pkg.github.com/v2/kubernetes/minikube/kicbase/manifests/v0.0.10: UNAUTHORIZED: GitHub Docker Registry needs login
🔥  Creating docker container (CPUs=2, Memory=4000MB) ...
🐳  Preparing Kubernetes v1.18.1 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16
🔎  Verifying Kubernetes components...
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube"
```
#### verifying image with docker ps
```
medya@~/workspace/minikube (kicbase_gh_package) $ docker ps
CONTAINER ID        IMAGE                                                       COMMAND                  CREATED             STATUS              PORTS                                                                                                      NAMES
0e0a63c61b83        docker.pkg.github.com/kubernetes/minikube/kicbase:v0.0.10   "/usr/local/bin/entr…"   46 seconds ago      Up 44 seconds       127.0.0.1:32787->22/tcp, 127.0.0.1:32786->2376/tcp, 127.0.0.1:32785->5000/tcp, 127.0.0.1:32784->8443/tcp   minikube
```

### footnotes and not in the scope of this PR

1- github docker packages does NOT support pulling with SHA, which we consider it Acceptable but not ideal for our fallback image. ( see the note in this doc https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages)

2- our go-containerregstiry lib is producing some errors about github needs login, that seems to be harmless error. (a spam error) but wont affect the functionality of using fallback. however that will be another PR to refactor our image.WriteToDaemon to not produce that error or handle it carefuly. so I will not consider to do that in this PR.

3- created another issue that we should detect early which image repo is best instead of failing one after time out and trying another one. that is also NOT in the scope of this PR.
 https://github.com/kubernetes/minikube/issues/7942

