### PR TITLE
Change tunnel cleanup flag default to true for auto tunnel cleanup

### DIFF
--- a/cmd/minikube/cmd/tunnel.go
+++ b/cmd/minikube/cmd/tunnel.go
@@ -57,7 +57,6 @@ var tunnelCmd = &cobra.Command{
 			if err := manager.CleanupNotRunningTunnels(); err != nil {
 				glog.Errorf("error cleaning up: %s", err)
 			}
-			return
 		}
 
 		// Tunnel uses the k8s clientset to query the API server for services in the LoadBalancerEmulator.
@@ -104,5 +103,5 @@ var tunnelCmd = &cobra.Command{
 }
 
 func init() {
-	tunnelCmd.Flags().BoolVarP(&cleanup, "cleanup", "c", false, "call with cleanup=true to remove old tunnels")
+	tunnelCmd.Flags().BoolVarP(&cleanup, "cleanup", "c", true, "call with cleanup=true to remove old tunnels")
 }

--- a/site/content/en/docs/commands/tunnel.md
+++ b/site/content/en/docs/commands/tunnel.md
@@ -21,7 +21,7 @@ minikube tunnel [flags]
 ### Options
 
 ```
-  -c, --cleanup   call with cleanup=true to remove old tunnels
+  -c, --cleanup   call with cleanup=true to remove old tunnels (default true)
   -h, --help      help for tunnel
 ```
 

--- a/site/content/en/docs/handbook/accessing.md
+++ b/site/content/en/docs/handbook/accessing.md
@@ -131,6 +131,8 @@ If the `minikube tunnel` shuts down in an abrupt manner, it may leave orphaned n
 minikube tunnel --cleanup
 ````
 
+NOTE: `--cleanup` flag's default value is `true`.
+
 ### Avoiding password prompts
 
 Adding a route requires root privileges for the user, and thus there are differences in how to run `minikube tunnel` depending on the OS. If you want to avoid entering the root password, consider setting NOPASSWD for "ip" and "route" commands:


### PR DESCRIPTION
### What type of PR is this?
/kind feature

### What this PR does / why we need it:

This PR change `minikube tunnel`'s `cleanup` flag default to true.
Before this PR, if users have problem(like conflict) with `minikube tunnel`, users had to execute `minikube tunnel --cleanup` manually.
After this PR, `minikube tunnel` auto cleanup those error something.

### Which issue(s) this PR fixes:
Fix #7900

### Does this PR introduce a user-facing change?

Yes. This PR change `minikube tunnel` default behavior.

**Before this PR**

2 step is needed.

```
# 1. minikube tunnel has an error
$ minikube tunnel
Status:	
	machine: minikube
	pid: 764782
	route: 10.96.0.0/12 -> 172.17.0.2
	minikube: Running
	services: []
    errors: 
		minikube: no errors
		router: conflicting route: 10.96.0.0/12 via 172.17.0.3 dev docker0 
		loadbalancer emulator: no errors

# 2. cleanup manually
$ minikube tunnel --cleanup
```

**After this PR**

```
# 1. minikube tunnel clenup automatically
$ minikube tunnel
Status:	
	machine: minikube
	pid: 764782
	route: 10.96.0.0/12 -> 172.17.0.2
	minikube: Running
	services: []
    errors: 
		minikube: no errors
		router: no errors
		loadbalancer emulator: no errors
```

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```