### PR TITLE
Use noninteractive sudo when running podman

### DIFF
--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -168,6 +168,7 @@ func runDelete(cmd *cobra.Command, args []string) {
 		if orphan {
 			// TODO: generalize for non-KIC drivers: #8040
 			deletePossibleKicLeftOver(cname, driver.Docker)
+			deletePossibleKicLeftOver(cname, driver.Podman)
 		}
 	}
 
@@ -210,8 +211,6 @@ func DeleteProfiles(profiles []*config.Profile) []error {
 
 // TODO: remove and/or move to delete package: #8040
 func deletePossibleKicLeftOver(cname string, driverName string) {
-	glog.Infof("deleting possible KIC leftovers for %s (driver=%s) ...", cname, driverName)
-
 	bin := ""
 	switch driverName {
 	case driver.Docker:
@@ -221,6 +220,13 @@ func deletePossibleKicLeftOver(cname string, driverName string) {
 	default:
 		return
 	}
+
+	if _, err := exec.LookPath(bin); err != nil {
+		glog.Infof("skipping deletePossibleKicLeftOver for %s: %v", bin, err)
+		return
+	}
+
+	glog.Infof("deleting possible KIC leftovers for %s (driver=%s) ...", cname, driverName)
 
 	delLabel := fmt.Sprintf("%s=%s", oci.ProfileLabelKey, cname)
 	cs, err := oci.ListContainersByLabel(bin, delLabel)

--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -109,6 +109,11 @@ func deleteContainersAndVolumes(ociBin string) {
 		glog.Warningf("error delete volumes by label %q (might be okay): %+v", delLabel, errs)
 	}
 
+	if ociBin == oci.Podman {
+		// podman prune does not support --filter
+		return
+	}
+
 	errs = oci.PruneAllVolumesByLabel(ociBin, delLabel)
 	if len(errs) > 0 { // it will not error if there is nothing to delete
 		glog.Warningf("error pruning volumes by label %q (might be okay): %+v", delLabel, errs)
@@ -244,6 +249,11 @@ func deletePossibleKicLeftOver(cname string, driverName string) {
 	errs := oci.DeleteAllVolumesByLabel(bin, delLabel)
 	if errs != nil { // it will not error if there is nothing to delete
 		glog.Warningf("error deleting volumes (might be okay).\nTo see the list of volumes run: 'docker volume ls'\n:%v", errs)
+	}
+
+	if bin == oci.Podman {
+		// podman prune does not support --filter
+		return
 	}
 
 	errs = oci.PruneAllVolumesByLabel(bin, delLabel)

--- a/pkg/drivers/kic/oci/cli_runner.go
+++ b/pkg/drivers/kic/oci/cli_runner.go
@@ -67,7 +67,7 @@ func (rr RunResult) Output() string {
 // PrefixCmd adds any needed prefix (such as sudo) to the command
 func PrefixCmd(cmd *exec.Cmd) *exec.Cmd {
 	if cmd.Args[0] == Podman && runtime.GOOS == "linux" { // want sudo when not running podman-remote
-		cmdWithSudo := exec.Command("sudo", cmd.Args...)
+		cmdWithSudo := exec.Command("sudo", append([]string{"-n"}, cmd.Args...)...)
 		cmdWithSudo.Env = cmd.Env
 		cmdWithSudo.Dir = cmd.Dir
 		cmdWithSudo.Stdin = cmd.Stdin

--- a/pkg/minikube/registry/drvs/podman/podman.go
+++ b/pkg/minikube/registry/drvs/podman/podman.go
@@ -86,7 +86,7 @@ func status() registry.State {
 	cmd := exec.CommandContext(ctx, oci.Podman, "version", "--format", "{{.Server.Version}}")
 	// Run with sudo on linux (local), otherwise podman-remote (as podman)
 	if runtime.GOOS == "linux" {
-		cmd = exec.CommandContext(ctx, "sudo", "-n", oci.Podman, "version", "--format", "{{.Version}}")
+		cmd = exec.CommandContext(ctx, "sudo", "-k", "-n", oci.Podman, "version", "--format", "{{.Version}}")
 		cmd.Env = append(os.Environ(), "LANG=C", "LC_ALL=C") // sudo is localized
 	}
 	o, err := cmd.Output()


### PR DESCRIPTION
To avoid asking for a password in the middle of minikube commands.

The setup process is supposed to involve adding podman to sudoers...

Fixes #7958

Related to #7960 in that it runs podman, no matter what driver is used.