### PR TITLE
Use the correct binary for unpacking the preload

### DIFF
--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -132,7 +132,7 @@ func (d *Driver) Create() error {
 		t := time.Now()
 		glog.Infof("Starting extracting preloaded images to volume ...")
 		// Extract preloaded images to container
-		if err := oci.ExtractTarballToVolume(download.TarballPath(d.NodeConfig.KubernetesVersion, d.NodeConfig.ContainerRuntime), params.Name, BaseImage); err != nil {
+		if err := oci.ExtractTarballToVolume(d.NodeConfig.OCIBinary, download.TarballPath(d.NodeConfig.KubernetesVersion, d.NodeConfig.ContainerRuntime), params.Name, BaseImage); err != nil {
 			glog.Infof("Unable to extract preloaded tarball to volume: %v", err)
 		} else {
 			glog.Infof("duration metric: took %f seconds to extract preloaded images to volume", time.Since(t).Seconds())

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -90,15 +90,12 @@ func DeleteContainer(ociBin string, name string) error {
 }
 
 // PrepareContainerNode sets up the container node before CreateContainerNode is called.
-// For the docker runtime, it creates a docker volume which will be mounted into kic
+// For the container runtime, it creates a volume which will be mounted into kic
 func PrepareContainerNode(p CreateParams) error {
-	if p.OCIBinary != Docker {
-		return nil
-	}
-	if err := createDockerVolume(p.Name, p.Name); err != nil {
+	if err := createVolume(p.OCIBinary, p.Name, p.Name); err != nil {
 		return errors.Wrapf(err, "creating volume for %s container", p.Name)
 	}
-	glog.Infof("Successfully created a docker volume %s", p.Name)
+	glog.Infof("Successfully created a %s volume %s", p.OCIBinary, p.Name)
 	return nil
 }
 

--- a/pkg/drivers/kic/oci/volumes.go
+++ b/pkg/drivers/kic/oci/volumes.go
@@ -79,19 +79,19 @@ func allVolumesByLabel(ociBin string, label string) ([]string, error) {
 
 // ExtractTarballToVolume runs a docker image imageName which extracts the tarball at tarballPath
 // to the volume named volumeName
-func ExtractTarballToVolume(tarballPath, volumeName, imageName string) error {
-	cmd := exec.Command(Docker, "run", "--rm", "--entrypoint", "/usr/bin/tar", "-v", fmt.Sprintf("%s:/preloaded.tar:ro", tarballPath), "-v", fmt.Sprintf("%s:/extractDir", volumeName), imageName, "-I", "lz4", "-xvf", "/preloaded.tar", "-C", "/extractDir")
+func ExtractTarballToVolume(ociBin string, tarballPath, volumeName, imageName string) error {
+	cmd := exec.Command(ociBin, "run", "--rm", "--entrypoint", "/usr/bin/tar", "-v", fmt.Sprintf("%s:/preloaded.tar:ro", tarballPath), "-v", fmt.Sprintf("%s:/extractDir", volumeName), imageName, "-I", "lz4", "-xvf", "/preloaded.tar", "-C", "/extractDir")
 	if _, err := runCmd(cmd); err != nil {
 		return err
 	}
 	return nil
 }
 
-// createDockerVolume creates a docker volume to be attached to the container with correct labels and prefixes based on profile name
+// createVolume creates a volume to be attached to the container with correct labels and prefixes based on profile name
 // Caution ! if volume already exists does NOT return an error and will not apply the minikube labels on it.
 // TODO: this should be fixed as a part of https://github.com/kubernetes/minikube/issues/6530
-func createDockerVolume(profile string, nodeName string) error {
-	if _, err := runCmd(exec.Command(Docker, "volume", "create", nodeName, "--label", fmt.Sprintf("%s=%s", ProfileLabelKey, profile), "--label", fmt.Sprintf("%s=%s", CreatedByLabelKey, "true"))); err != nil {
+func createVolume(ociBin string, profile string, nodeName string) error {
+	if _, err := runCmd(exec.Command(ociBin, "volume", "create", nodeName, "--label", fmt.Sprintf("%s=%s", ProfileLabelKey, profile), "--label", fmt.Sprintf("%s=%s", CreatedByLabelKey, "true"))); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Previously hardcoded to *always* use a Docker volume,
even if using a different container driver (podman).