### PR TITLE
Don't show any podman hint about restarting sudo

### DIFF
--- a/pkg/drivers/kic/oci/cli_runner.go
+++ b/pkg/drivers/kic/oci/cli_runner.go
@@ -131,7 +131,10 @@ func runCmd(cmd *exec.Cmd, warnSlow ...bool) (*RunResult, error) {
 	if warn {
 		if elapsed > warnTime {
 			out.WarningT(`Executing "{{.command}}" took an unusually long time: {{.duration}}`, out.V{"command": rr.Command(), "duration": elapsed})
-			out.ErrT(out.Tip, `Restarting the {{.name}} service may improve performance.`, out.V{"name": cmd.Args[0]})
+			// Don't show any restarting hint, when running podman locally (on linux, with sudo). Only when having a service.
+			if cmd.Args[0] != "sudo" {
+				out.ErrT(out.Tip, `Restarting the {{.name}} service may improve performance.`, out.V{"name": cmd.Args[0]})
+			}
 		}
 
 		if ctx.Err() == context.DeadlineExceeded {


### PR DESCRIPTION
Basically it only applies to the docker daemon, but _could_ also apply to an external podman socket.

Closes #7966