### PR TITLE
wip: Fix StartStopTest/group/containerd flake …

### DIFF
--- a/cmd/minikube/cmd/config/disable.go
+++ b/cmd/minikube/cmd/config/disable.go
@@ -39,7 +39,7 @@ var addonsDisableCmd = &cobra.Command{
 
 		// check addon status before enabling/disabling it
 		if addons.AlreadySet(addon, profile, false) {
-			out.T(out.AddonEnable, "The '{{.addonName}}' addon is already enabled", out.V{"addonName": addon})
+			out.T(out.AddonEnable, "The '{{.addonName}}' addon is already disabled", out.V{"addonName": addon})
 		}
 		err := addons.SetAndSave(ClusterFlagValue(), addon, "false")
 		if err != nil {

--- a/cmd/minikube/cmd/config/disable.go
+++ b/cmd/minikube/cmd/config/disable.go
@@ -18,7 +18,9 @@ package config
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/addons"
+	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/out"
 )
@@ -33,6 +35,12 @@ var addonsDisableCmd = &cobra.Command{
 		}
 
 		addon := args[0]
+		profile := viper.GetString(config.ProfileName)
+
+		// check addon status before enabling/disabling it
+		if addons.AlreadySet(addon, profile, false) {
+			out.T(out.AddonEnable, "The '{{.addonName}}' addon is already enabled", out.V{"addonName": addon})
+		}
 		err := addons.SetAndSave(ClusterFlagValue(), addon, "false")
 		if err != nil {
 			exit.WithError("disable failed", err)

--- a/cmd/minikube/cmd/config/enable.go
+++ b/cmd/minikube/cmd/config/enable.go
@@ -18,7 +18,9 @@ package config
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/addons"
+	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/out"
 )
@@ -32,6 +34,11 @@ var addonsEnableCmd = &cobra.Command{
 			exit.UsageT("usage: minikube addons enable ADDON_NAME")
 		}
 		addon := args[0]
+		profile := viper.GetString(config.ProfileName)
+		// check addon status before enabling/disabling it
+		if addons.AlreadySet(addon, profile, true) {
+			out.T(out.AddonEnable, "The '{{.addonName}}' addon is already enabled", out.V{"addonName": addon})
+		}
 		err := addons.SetAndSave(ClusterFlagValue(), addon, "true")
 		if err != nil {
 			exit.WithError("enable failed", err)

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -135,10 +135,8 @@ func TestStartStop(t *testing.T) {
 
 				if strings.Contains(tc.name, "cni") {
 					t.Logf("WARNING: cni mode requires additional setup before pods can schedule :(")
-				} else {
-					if _, err := PodWait(ctx, t, profile, "kubernetes-dashboard", "k8s-app=kubernetes-dashboard", Minutes(9)); err != nil {
-						t.Fatalf("failed waiting for 'addon dashboard' pod post-stop-start: %v", err)
-					}
+				} else if _, err := PodWait(ctx, t, profile, "kubernetes-dashboard", "k8s-app=kubernetes-dashboard", Minutes(9)); err != nil {
+					t.Fatalf("failed waiting for 'addon dashboard' pod post-stop-start: %v", err)
 				}
 
 				got := Status(ctx, t, Target(), profile, "Host")

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -65,6 +65,7 @@ func TestStartStop(t *testing.T) {
 				"--apiserver-port=8444",
 				"--network-plugin=cni",
 				"--enable-default-cni",
+				"--extra-config=kubeadm.pod-network-cidr=10.244.0.0/16",
 			}},
 			{"crio", "v1.15.7", []string{
 				"--container-runtime=crio",

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -62,9 +62,9 @@ func TestStartStop(t *testing.T) {
 			}},
 			{"containerd", constants.DefaultKubernetesVersion, []string{
 				"--container-runtime=containerd",
-				"--docker-opt",
-				"containerd=/var/run/containerd/containerd.sock",
 				"--apiserver-port=8444",
+				"--network-plugin=cni",
+				"--enable-default-cni",
 			}},
 			{"crio", "v1.15.7", []string{
 				"--container-runtime=crio",
@@ -135,9 +135,6 @@ func TestStartStop(t *testing.T) {
 				if strings.Contains(tc.name, "cni") {
 					t.Logf("WARNING: cni mode requires additional setup before pods can schedule :(")
 				} else {
-					if _, err := PodWait(ctx, t, profile, "default", "integration-test=busybox", Minutes(7)); err != nil {
-						t.Fatalf("failed waiting for pod 'busybox' post-stop-start: %v", err)
-					}
 					if _, err := PodWait(ctx, t, profile, "kubernetes-dashboard", "k8s-app=kubernetes-dashboard", Minutes(9)); err != nil {
 						t.Fatalf("failed waiting for 'addon dashboard' pod post-stop-start: %v", err)
 					}
@@ -179,7 +176,7 @@ func testPodScheduling(ctx context.Context, t *testing.T, profile string) {
 	t.Helper()
 
 	// schedule a pod to assert persistence
-	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "create", "-f", filepath.Join(*testdataDir, "busybox.yaml")))
+	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "apply", "-f", filepath.Join(*testdataDir, "busybox.yaml")))
 	if err != nil {
 		t.Fatalf("%s failed: %v", rr.Command(), err)
 	}


### PR DESCRIPTION
This test was failing regularly with the following error showing up on all pods:

```
FailedCreatePodSandbox
```

after doing some digging, it seems that this error is always CNI related. I found these docs on the k8s website about running containerd in minikube:

https://kubernetes.io/docs/setup/learning-environment/minikube/

which says the flags `--network-plugin=cni` and `--enable-default-cni` should be set with running containerd. I tried passing those flags in, and a flag for pod subnet.

This test was then failing because the kubernetes dashboard addon would never come up. 

The dashboard addon wasn't being enabled because of this flow:

```
minikube stop
minikube addons enable dashboard
minikube start
```

but on start, dashboard was skipped because it seemed like it had already been enabled.

I refactored addons code to always enable addons on `minikube start`, and to only check if they've already been enabled on `minikube addons enable/disable xxx`

Should fix #7704 