### PR TITLE
Add unversioned package paths to avoid updating upstream docs each release

### DIFF
--- a/hack/jenkins/release_build_and_upload.sh
+++ b/hack/jenkins/release_build_and_upload.sh
@@ -54,6 +54,10 @@ env BUILD_IN_DOCKER=y \
 
 make checksum
 
+# unversioned names to avoid updating upstream Kubernetes documentation each release
+cp "out/minikube_${DEB_VERSION}-0_amd64.deb" out/minikube_latest_amd64.deb
+cp "out/minikube-${RPM_VERSION}-0.x86_64.rpm" out/minikube_latest.x86_64.rpm
+
 gsutil -m cp out/* "gs://$BUCKET/releases/$TAGNAME/"
 
 # Update "latest" release for non-beta/non-alpha builds


### PR DESCRIPTION
Allows us to have these instructions upstream:

For Linux users, there are 3 easy download options:


```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
 sudo install minikube-linux-amd64 /usr/local/bin/minikube
```

### Debian package

```shell
curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_latest_amd64.deb
sudo dpkg -i minikube_latest_amd64.deb
```

### RPM package

```shell
curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest.x86_64.rpm
sudo rpm -ivh minikube-latest.x86_64.rpm
```

Related to #5686

Tested with gLinux and CentOS.