### PR TITLE
Add kic base image to the cluster config

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -283,6 +283,7 @@ func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k
 			KeepContext:             viper.GetBool(keepContext),
 			EmbedCerts:              viper.GetBool(embedCerts),
 			MinikubeISO:             viper.GetString(isoURL),
+			KicBaseImage:            viper.GetString(kicBaseImage),
 			Memory:                  mem,
 			CPUs:                    viper.GetInt(cpus),
 			DiskSize:                diskSize,
@@ -541,6 +542,10 @@ func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterC
 
 	if cmd.Flags().Changed(waitComponents) {
 		existing.VerifyComponents = interpretWaitFlag(*cmd)
+	}
+
+	if cmd.Flags().Changed(kicBaseImage) {
+		existing.KicBaseImage = viper.GetString(kicBaseImage)
 	}
 
 	return *existing

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -42,8 +42,8 @@ type ClusterConfig struct {
 	Name                    string
 	KeepContext             bool   // used by start and profile command to or not to switch kubectl's current context
 	EmbedCerts              bool   // used by kubeconfig.Setup
-	MinikubeISO             string // ISO used for VM-drivers
-	KicBaseImage            string // bage image used for docker/podman drivers
+	MinikubeISO             string // ISO used for VM-drivers.
+	KicBaseImage            string // base-image used for docker/podman drivers.
 	Memory                  int
 	CPUs                    int
 	DiskSize                int

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -40,9 +40,10 @@ type Profile struct {
 // ClusterConfig contains the parameters used to start a cluster.
 type ClusterConfig struct {
 	Name                    string
-	KeepContext             bool // used by start and profile command to or not to switch kubectl's current context
-	EmbedCerts              bool // used by kubeconfig.Setup
-	MinikubeISO             string
+	KeepContext             bool   // used by start and profile command to or not to switch kubectl's current context
+	EmbedCerts              bool   // used by kubeconfig.Setup
+	MinikubeISO             string // ISO used for VM-drivers
+	KicBaseImage            string // bage image used for docker/podman drivers
 	Memory                  int
 	CPUs                    int
 	DiskSize                int

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -99,9 +99,8 @@ func doCacheBinaries(k8sVersion string) error {
 }
 
 // BeginDownloadKicArtifacts downloads the kic image + preload tarball, returns true if preload is available
-func beginDownloadKicArtifacts(g *errgroup.Group, driver string, cRuntime string) {
+func beginDownloadKicArtifacts(g *errgroup.Group, driver string, cRuntime string, baseImage string) {
 	glog.Infof("Beginning downloading kic artifacts for %s with %s", driver, cRuntime)
-	baseImage := viper.GetString("base-image")
 	if driver == "docker" {
 		if !image.ExistsImageInDaemon(baseImage) {
 			out.T(out.Pulling, "Pulling base image ...")

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -196,7 +196,7 @@ func Provision(cc *config.ClusterConfig, n *config.Node, apiServer bool) (comman
 	}
 
 	if driver.IsKIC(cc.Driver) {
-		beginDownloadKicArtifacts(&kicGroup, cc.Driver, cc.KubernetesConfig.ContainerRuntime)
+		beginDownloadKicArtifacts(&kicGroup, cc.Driver, cc.KubernetesConfig.ContainerRuntime, cc.KicBaseImage)
 	}
 
 	if !driver.BareMetal(cc.Driver) {

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/golang/glog"
-	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/drivers/kic"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/config"
@@ -60,7 +59,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 	return kic.NewDriver(kic.Config{
 		MachineName:       driver.MachineName(cc, n),
 		StorePath:         localpath.MiniPath(),
-		ImageDigest:       viper.GetString("base-image"),
+		ImageDigest:       cc.KicBaseImage,
 		CPU:               cc.CPUs,
 		Memory:            cc.Memory,
 		OCIBinary:         oci.Docker,

--- a/pkg/minikube/registry/drvs/podman/podman.go
+++ b/pkg/minikube/registry/drvs/podman/podman.go
@@ -29,7 +29,6 @@ import (
 	"github.com/blang/semver"
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/golang/glog"
-	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/drivers/kic"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/config"
@@ -60,11 +59,10 @@ func init() {
 }
 
 func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
-	baseImage := viper.GetString("base-image")
 	return kic.NewDriver(kic.Config{
 		MachineName:       driver.MachineName(cc, n),
 		StorePath:         localpath.MiniPath(),
-		ImageDigest:       strings.Split(baseImage, "@")[0], // for podman does not support docker images references with both a tag and digest.
+		ImageDigest:       strings.Split(cc.KicBaseImage, "@")[0], // for podman does not support docker images references with both a tag and digest.
 		CPU:               cc.CPUs,
 		Memory:            cc.Memory,
 		OCIBinary:         oci.Podman,


### PR DESCRIPTION
this PR will get rid of global viper.GetString("base-image")
this PR is a prerequisite for this PR:
https://github.com/kubernetes/minikube/pull/7943#discussion_r418271378 