### PR TITLE
addons: fix initial retry delay, double maximum limit

### DIFF
--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -258,7 +258,7 @@ func enableOrDisableAddonInternal(cc *config.ClusterConfig, addon *assets.Addon,
 		return err
 	}
 
-	return retry.Expo(apply, 100*time.Microsecond, time.Minute)
+	return retry.Expo(apply, 250*time.Millisecond, 2*time.Minute)
 }
 
 // enableOrDisableStorageClasses enables or disables storage classes


### PR DESCRIPTION
* The initial retry delay was accidentally set to microseconds!
* Double the maximum retry limit to 2 minutes to fight test flakes. This helps to ensure that addons are eventually deployed when requirements are met, without needing to understand what is required by each addon. 


Fixes #7719