### PR TITLE
podman: Wrap the start command with cgroup manager too

### DIFF
--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -299,8 +299,7 @@ func (d *Driver) Restart() error {
 
 // Start an already created kic container
 func (d *Driver) Start() error {
-	cr := command.NewExecRunner() // using exec runner for interacting with docker/podman daemon
-	if _, err := cr.RunCmd(oci.PrefixCmd(exec.Command(d.NodeConfig.OCIBinary, "start", d.MachineName))); err != nil {
+	if err := oci.StartContainer(d.NodeConfig.OCIBinary, d.MachineName); err != nil {
 		return errors.Wrap(err, "start")
 	}
 	checkRunning := func() error {

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -239,7 +239,7 @@ func createContainer(ociBin string, image string, opts ...createOpt) error {
 	args := []string{"run"}
 
 	// to run nested container from privileged container in podman https://bugzilla.redhat.com/show_bug.cgi?id=1687713
-	if ociBin == Podman {
+	if ociBin == Podman && runtime.GOOS == "linux" {
 		args = append(args, "--cgroup-manager", "cgroupfs")
 	}
 
@@ -260,7 +260,7 @@ func StartContainer(ociBin string, container string) error {
 	args := []string{"start"}
 
 	// to run nested container from privileged container in podman https://bugzilla.redhat.com/show_bug.cgi?id=1687713
-	if ociBin == Podman {
+	if ociBin == Podman && runtime.GOOS == "linux" {
 		args = append(args, "--cgroup-manager", "cgroupfs")
 	}
 

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -268,7 +268,7 @@ func StartContainer(ociBin string, container string) error {
 
 	args = append(args, container)
 
-	if err := PrefixCmd(exec.Command(ociBin, args...)).Run(); err != nil {
+	if _, err := runCmd(exec.Command(ociBin, args...)); err != nil {
 		return err
 	}
 

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -239,6 +239,7 @@ func createContainer(ociBin string, image string, opts ...createOpt) error {
 	args := []string{"run"}
 
 	// to run nested container from privileged container in podman https://bugzilla.redhat.com/show_bug.cgi?id=1687713
+	// only add when running locally (linux), when running remotely it needs to be configured on server in libpod.conf
 	if ociBin == Podman && runtime.GOOS == "linux" {
 		args = append(args, "--cgroup-manager", "cgroupfs")
 	}
@@ -260,6 +261,7 @@ func StartContainer(ociBin string, container string) error {
 	args := []string{"start"}
 
 	// to run nested container from privileged container in podman https://bugzilla.redhat.com/show_bug.cgi?id=1687713
+	// only add when running locally (linux), when running remotely it needs to be configured on server in libpod.conf
 	if ociBin == Podman && runtime.GOOS == "linux" {
 		args = append(args, "--cgroup-manager", "cgroupfs")
 	}

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -254,6 +254,25 @@ func createContainer(ociBin string, image string, opts ...createOpt) error {
 	return nil
 }
 
+// StartContainer starts a container with "docker/podman start"
+func StartContainer(ociBin string, container string) error {
+	// construct the actual docker start argv
+	args := []string{"start"}
+
+	// to run nested container from privileged container in podman https://bugzilla.redhat.com/show_bug.cgi?id=1687713
+	if ociBin == Podman {
+		args = append(args, "--cgroup-manager", "cgroupfs")
+	}
+
+	args = append(args, container)
+
+	if err := PrefixCmd(exec.Command(ociBin, args...)).Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // ContainerID returns id of a container name
 func ContainerID(ociBin string, nameOrID string) (string, error) {
 	rr, err := runCmd(exec.Command(ociBin, "inspect", "-f", "{{.Id}}", nameOrID))


### PR DESCRIPTION
When running with podman, to match the run cmd

```
Version:            1.8.2
RemoteAPI Version:  1
Go Version:         go1.13.8
Git Commit:         028e3317eb1494b9b2acba4a0a295df80fae66cc
Built:              Mon Apr 27 11:07:45 2020
OS/Arch:            linux/amd64
```

Closes #7996