### PR TITLE
restart: validate configs with new hostname, add logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,6 @@ require (
 	k8s.io/api v0.17.3
 	k8s.io/apimachinery v0.17.3
 	k8s.io/client-go v0.17.3
-	k8s.io/klog v1.0.0
 	k8s.io/kubectl v0.0.0
 	k8s.io/kubernetes v1.17.3
 	k8s.io/utils v0.0.0-20200229041039-0a110f9eb7ab // indirect

--- a/go.mod
+++ b/go.mod
@@ -94,6 +94,7 @@ require (
 	k8s.io/api v0.17.3
 	k8s.io/apimachinery v0.17.3
 	k8s.io/client-go v0.17.3
+	k8s.io/klog v1.0.0
 	k8s.io/kubectl v0.0.0
 	k8s.io/kubernetes v1.17.3
 	k8s.io/utils v0.0.0-20200229041039-0a110f9eb7ab // indirect

--- a/pkg/minikube/bootstrapper/bsutil/kverify/api_server.go
+++ b/pkg/minikube/bootstrapper/bsutil/kverify/api_server.go
@@ -206,6 +206,9 @@ func apiServerHealthz(hostname string, port int) (state.State, error) {
 
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		glog.Warningf("unable to read response body: %s", err)
+	}
 
 	glog.Infof("%s returned %d:\n%s", url, resp.StatusCode, body)
 	if resp.StatusCode == http.StatusUnauthorized {

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -298,7 +298,6 @@ func (k *Bootstrapper) StartCluster(cfg config.ClusterConfig) error {
 			return nil
 		}
 
-		panic(fmt.Sprintf("FAILED: %v", rerr))
 		out.ErrT(out.Embarrassed, "Unable to restart cluster, will reset it: {{.error}}", out.V{"error": rerr})
 		if err := k.DeleteCluster(cfg.KubernetesConfig); err != nil {
 			glog.Warningf("delete failed: %v", err)

--- a/test/integration/pause_test.go
+++ b/test/integration/pause_test.go
@@ -65,22 +65,22 @@ func validateFreshStart(ctx context.Context, t *testing.T, profile string) {
 	}
 }
 
-// validateStartNoReset validates that starting a running cluster won't invoke a reset
-func validateStartNoReset(ctx context.Context, t *testing.T, profile string) {
+// validateStartNoReconfigure validates that starting a running cluster does not invoke reconfiguration
+func validateStartNoReconfigure(ctx context.Context, t *testing.T, profile string) {
 	args := []string{"start", "-p", profile, "--alsologtostderr", "-v=5"}
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
 		defer clusterLogs(t, profile)
 		t.Fatalf("failed to second start a running minikube with args: %q : %v", rr.Command(), err)
 	}
+
 	if !NoneDriver() {
-		softLog := "The running cluster does not need a reset"
+		softLog := "The running cluster does not require reconfiguration"
 		if !strings.Contains(rr.Output(), softLog) {
 			defer clusterLogs(t, profile)
-			t.Errorf("expected the second start log outputs to include %q but got: %s", softLog, rr.Output())
+			t.Errorf("expected the second start log output to include %q but got: %s", softLog, rr.Output())
 		}
 	}
-
 }
 
 func validatePause(ctx context.Context, t *testing.T, profile string) {

--- a/test/integration/pause_test.go
+++ b/test/integration/pause_test.go
@@ -41,7 +41,7 @@ func TestPause(t *testing.T) {
 			validator validateFunc
 		}{
 			{"Start", validateFreshStart},
-			{"SecondStartNoReset", validateStartNoReset},
+			{"SecondStartNoReconfiguration", validateStartNoReconfigure},
 			{"Pause", validatePause},
 			{"Unpause", validateUnpause},
 			{"PauseAgain", validatePause},


### PR DESCRIPTION
Fixes an important root cause issue:

* The `kubeconfig` endpoint check still referenced IP addresses after we had migrated to using `DNS` names, causing us to unnecessarily remove files out every stop/start cycle.

Fixes issues which made this difficult to debug:

kubeadm:

* replaced mis-use of `reset` terminology with `reconfigure`
* separately log when a file has incorrect endpoint information which needs removal

kverify:

* `apiServerHealthz` now returns errors
* `apiServerHealthz` now logs the response body, and includes it with errors

May fix #7704 #7921

This will also make #7895 much easier to debug, but may not fix the underlying issue.