### PR TITLE
integration test: break-down TestStartStop to sub-tests

### DIFF
--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -107,8 +107,8 @@ func TestStartStop(t *testing.T) {
 						{"Stop", validateStop},
 						{"EnableAddonAfterStop", validateEnableAddonAfterStop},
 						{"SecondStart", validateSecondStart},
-						{"AppExistsAfterStop", validateAppExistsAfterStop},
-						{"AddonExistAfterStop", validateAddonAfterStop},
+						{"UserAppExistsAfterStop", validateAppExistsAfterStop},
+						{"AddonExistsAfterStop", validateAddonAfterStop},
 						{"VerifyKubernetesImages", validateKubernetesImages},
 						{"Pause", validatePauseAfterSart},
 					}

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -109,7 +109,6 @@ func TestStartStop(t *testing.T) {
 						{"SecondStart", validateSecondStart},
 						{"AppExistsAfterStop", validateAppExistsAfterStop},
 						{"AddonExistAfterStop", validateAddonAfterStop},
-
 						{"VerifyKubernetesImages", validateKubernetesImages},
 						{"Pause", validatePauseAfterSart},
 					}

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -108,6 +108,8 @@ func TestStartStop(t *testing.T) {
 						{"EnableAddonAfterStop", validateEnableAddonAfterStop},
 						{"SecondStart", validateSecondStart},
 						{"AppExistsAfterStop", validateAppExistsAfterStop},
+						{"AddonExistAfterStop", validateAddonAfterStop},
+
 						{"VerifyKubernetesImages", validateKubernetesImages},
 						{"Pause", validatePauseAfterSart},
 					}
@@ -248,13 +250,22 @@ func validateSecondStart(ctx context.Context, t *testing.T, profile string, tcNa
 
 }
 
+// validateAppExistsAfterStop verifies that a user's app will not vanish after a minikube stop
 func validateAppExistsAfterStop(ctx context.Context, t *testing.T, profile string, tcName string, tcVersion string, startArgs []string) {
 	if strings.Contains(tcName, "cni") {
 		t.Logf("WARNING: cni mode requires additional setup before pods can schedule :(")
 	} else {
-		if _, err := PodWait(ctx, t, profile, "default", "integration-test=busybox", Minutes(7)); err != nil {
-			t.Fatalf("failed waiting for pod 'busybox' post-stop-start: %v", err)
+		if _, err := PodWait(ctx, t, profile, "kubernetes-dashboard", "k8s-app=kubernetes-dashboard", Minutes(9)); err != nil {
+			t.Fatalf("failed waiting for 'addon dashboard' pod post-stop-start: %v", err)
 		}
+	}
+}
+
+// validateAddonAfterStop validates that an addon which was enabled when minikube is stopped will be enabled and working..
+func validateAddonAfterStop(ctx context.Context, t *testing.T, profile string, tcName string, tcVersion string, startArgs []string) {
+	if strings.Contains(tcName, "cni") {
+		t.Logf("WARNING: cni mode requires additional setup before pods can schedule :(")
+	} else {
 		if _, err := PodWait(ctx, t, profile, "kubernetes-dashboard", "k8s-app=kubernetes-dashboard", Minutes(9)); err != nil {
 			t.Fatalf("failed waiting for 'addon dashboard' pod post-stop-start: %v", err)
 		}

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -80,14 +80,13 @@ func TestStartStop(t *testing.T) {
 			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				MaybeParallel(t)
-
-				if !strings.Contains(tc.name, "docker") && NoneDriver() {
-					t.Skipf("skipping %s - incompatible with none driver", t.Name())
-				}
-
 				profile := UniqueProfileName(tc.name)
 				ctx, cancel := context.WithTimeout(context.Background(), Minutes(40))
 				defer CleanupWithLogs(t, profile, cancel)
+				type validateStartStopFunc func(context.Context, *testing.T, string, string, string, []string)
+				if !strings.Contains(tc.name, "docker") && NoneDriver() {
+					t.Skipf("skipping %s - incompatible with none driver", t.Name())
+				}
 
 				waitFlag := "--wait=true"
 				if strings.Contains(tc.name, "cni") { // wait=app_running is broken for CNI https://github.com/kubernetes/minikube/issues/7354
@@ -98,20 +97,60 @@ func TestStartStop(t *testing.T) {
 				startArgs = append(startArgs, StartArgs()...)
 				startArgs = append(startArgs, fmt.Sprintf("--kubernetes-version=%s", tc.version))
 
-				rr, err := Run(t, exec.CommandContext(ctx, Target(), startArgs...))
-				if err != nil {
-					t.Fatalf("failed starting minikube -first start-. args %q: %v", rr.Command(), err)
-				}
+				t.Run("serial", func(t *testing.T) {
+					serialTests := []struct {
+						name      string
+						validator validateStartStopFunc
+					}{
+						{"FirstStart", validateFirstStart},
+						{"DeployApp", validateDeploying},
+						{"Stop", validateStop},
+						{"EnableAddonAfterStop", validateEnableAddonAfterStop},
+						{"SecondStart", validateSecondStart},
+						{"AppExistsAfterStop", validateAppExistsAfterStop},
+						{"VerifyKubernetesImages", validateKubernetesImages},
+						{"Pause", validatePauseAfterSart},
+					}
+					for _, stc := range serialTests {
+						tcName := tc.name
+						tcVersion := tc.version
+						stc := stc
+						t.Run(stc.name, func(t *testing.T) {
+							stc.validator(ctx, t, profile, tcName, tcVersion, startArgs)
+						})
+					}
 
-				if !strings.Contains(tc.name, "cni") {
-					testPodScheduling(ctx, t, profile)
-				}
+					if *cleanup {
+						// Normally handled by cleanuprofile, but not fatal there
+						rr, err := Run(t, exec.CommandContext(ctx, Target(), "delete", "-p", profile))
+						if err != nil {
+							t.Errorf("failed to clean up: args %q: %v", rr.Command(), err)
+						}
 
+						rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "config", "get-contexts", profile))
+						if err != nil {
+							t.Logf("config context error: %v (may be ok)", err)
+						}
+						if rr.ExitCode != 1 {
+							t.Errorf("expected exit code 1, got %d. output: %s", rr.ExitCode, rr.Output())
+						}
+					}
+
+<<<<<<< HEAD
 				rr, err = Run(t, exec.CommandContext(ctx, Target(), "stop", "-p", profile, "--alsologtostderr", "-v=3"))
 				if err != nil {
 					t.Fatalf("failed stopping minikube - first stop-. args %q : %v", rr.Command(), err)
 				}
+||||||| merged common ancestors
+				rr, err = Run(t, exec.CommandContext(ctx, Target(), "stop", "-p", profile, "--alsologtostderr", "-v=3"))
+				if err != nil {
+					t.Errorf("failed stopping minikube - first stop-. args %q : %v", rr.Command(), err)
+				}
+=======
+				})
+>>>>>>> break down test strat stop to sub tests
 
+<<<<<<< HEAD
 				// The none driver never really stops
 				if !NoneDriver() {
 					got := Status(ctx, t, Target(), profile, "Host")
@@ -119,59 +158,117 @@ func TestStartStop(t *testing.T) {
 						t.Fatalf("expected post-stop host status to be -%q- but got *%q*", state.Stopped, got)
 					}
 				}
+||||||| merged common ancestors
+				// The none driver never really stops
+				if !NoneDriver() {
+					got := Status(ctx, t, Target(), profile, "Host")
+					if got != state.Stopped.String() {
+						t.Errorf("expected post-stop host status to be -%q- but got *%q*", state.Stopped, got)
+					}
+				}
+=======
+			})
+		}
+	})
+}
+>>>>>>> break down test strat stop to sub tests
 
+<<<<<<< HEAD
 				// Enable an addon to assert it comes up afterwards
 				rr, err = Run(t, exec.CommandContext(ctx, Target(), "addons", "enable", "dashboard", "-p", profile))
 				if err != nil {
 					t.Fatalf("failed to enable an addon post-stop. args %q: %v", rr.Command(), err)
 				}
-
-				rr, err = Run(t, exec.CommandContext(ctx, Target(), startArgs...))
+||||||| merged common ancestors
+				// Enable an addon to assert it comes up afterwards
+				rr, err = Run(t, exec.CommandContext(ctx, Target(), "addons", "enable", "dashboard", "-p", profile))
 				if err != nil {
-					// Explicit fatal so that failures don't move directly to deletion
-					t.Fatalf("failed to start minikube post-stop. args %q: %v", rr.Command(), err)
+					t.Errorf("failed to enable an addon post-stop. args %q: %v", rr.Command(), err)
 				}
+=======
+func validateFirstStart(ctx context.Context, t *testing.T, profile string, tcName string, tcVersion string, startArgs []string) {
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), startArgs...))
+	if err != nil {
+		t.Fatalf("failed starting minikube -first start-. args %q: %v", rr.Command(), err)
+	}
+}
+>>>>>>> break down test strat stop to sub tests
 
-				if strings.Contains(tc.name, "cni") {
-					t.Logf("WARNING: cni mode requires additional setup before pods can schedule :(")
-				} else {
-					if _, err := PodWait(ctx, t, profile, "default", "integration-test=busybox", Minutes(7)); err != nil {
-						t.Fatalf("failed waiting for pod 'busybox' post-stop-start: %v", err)
-					}
-					if _, err := PodWait(ctx, t, profile, "kubernetes-dashboard", "k8s-app=kubernetes-dashboard", Minutes(9)); err != nil {
-						t.Fatalf("failed waiting for 'addon dashboard' pod post-stop-start: %v", err)
-					}
-				}
+func validateDeploying(ctx context.Context, t *testing.T, profile string, tcName string, tcVersion string, startArgs []string) {
+	testPodScheduling(ctx, t, profile)
+}
 
+func validateStop(ctx context.Context, t *testing.T, profile string, tcName string, tcVersion string, startArgs []string) {
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), "stop", "-p", profile, "--alsologtostderr", "-v=3"))
+	if err != nil {
+		t.Errorf("failed stopping minikube - first stop-. args %q : %v", rr.Command(), err)
+	}
+}
+
+<<<<<<< HEAD
 				got := Status(ctx, t, Target(), profile, "Host")
 				if got != state.Running.String() {
 					t.Fatalf("expected host status after start-stop-start to be -%q- but got *%q*", state.Running, got)
 				}
-
-				if !NoneDriver() {
-					testPulledImages(ctx, t, profile, tc.version)
+||||||| merged common ancestors
+				got := Status(ctx, t, Target(), profile, "Host")
+				if got != state.Running.String() {
+					t.Errorf("expected host status after start-stop-start to be -%q- but got *%q*", state.Running, got)
 				}
-
-				testPause(ctx, t, profile)
-
-				if *cleanup {
-					// Normally handled by cleanuprofile, but not fatal there
-					rr, err = Run(t, exec.CommandContext(ctx, Target(), "delete", "-p", profile))
-					if err != nil {
-						t.Errorf("failed to clean up: args %q: %v", rr.Command(), err)
-					}
-
-					rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "config", "get-contexts", profile))
-					if err != nil {
-						t.Logf("config context error: %v (may be ok)", err)
-					}
-					if rr.ExitCode != 1 {
-						t.Errorf("expected exit code 1, got %d. output: %s", rr.ExitCode, rr.Output())
-					}
-				}
-			})
+=======
+func validateEnableAddonAfterStop(ctx context.Context, t *testing.T, profile string, tcName string, tcVersion string, startArgs []string) {
+	// The none driver never really stops
+	if !NoneDriver() {
+		got := Status(ctx, t, Target(), profile, "Host")
+		if got != state.Stopped.String() {
+			t.Errorf("expected post-stop host status to be -%q- but got *%q*", state.Stopped, got)
 		}
-	})
+	}
+>>>>>>> break down test strat stop to sub tests
+
+	// Enable an addon to assert it comes up afterwards
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), "addons", "enable", "dashboard", "-p", profile))
+	if err != nil {
+		t.Errorf("failed to enable an addon post-stop. args %q: %v", rr.Command(), err)
+	}
+
+}
+
+func validateSecondStart(ctx context.Context, t *testing.T, profile string, tcName string, tcVersion string, startArgs []string) {
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), startArgs...))
+	if err != nil {
+		// Explicit fatal so that failures don't move directly to deletion
+		t.Fatalf("failed to start minikube post-stop. args %q: %v", rr.Command(), err)
+	}
+
+	got := Status(ctx, t, Target(), profile, "Host")
+	if got != state.Running.String() {
+		t.Errorf("expected host status after start-stop-start to be -%q- but got *%q*", state.Running, got)
+	}
+
+}
+
+func validateAppExistsAfterStop(ctx context.Context, t *testing.T, profile string, tcName string, tcVersion string, startArgs []string) {
+	if strings.Contains(tcName, "cni") {
+		t.Logf("WARNING: cni mode requires additional setup before pods can schedule :(")
+	} else {
+		if _, err := PodWait(ctx, t, profile, "default", "integration-test=busybox", Minutes(7)); err != nil {
+			t.Fatalf("failed waiting for pod 'busybox' post-stop-start: %v", err)
+		}
+		if _, err := PodWait(ctx, t, profile, "kubernetes-dashboard", "k8s-app=kubernetes-dashboard", Minutes(9)); err != nil {
+			t.Fatalf("failed waiting for 'addon dashboard' pod post-stop-start: %v", err)
+		}
+	}
+}
+
+func validateKubernetesImages(ctx context.Context, t *testing.T, profile string, tcName string, tcVersion string, startArgs []string) {
+	if !NoneDriver() {
+		testPulledImages(ctx, t, profile, tcVersion)
+	}
+}
+
+func validatePauseAfterSart(ctx context.Context, t *testing.T, profile string, tcName string, tcVersion string, startArgs []string) {
+	testPause(ctx, t, profile)
 }
 
 // testPodScheduling asserts that this configuration can schedule new pods

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -196,7 +196,9 @@ func validateFirstStart(ctx context.Context, t *testing.T, profile string, tcNam
 >>>>>>> break down test strat stop to sub tests
 
 func validateDeploying(ctx context.Context, t *testing.T, profile string, tcName string, tcVersion string, startArgs []string) {
-	testPodScheduling(ctx, t, profile)
+	if !strings.Contains(tcName, "cni") {
+		testPodScheduling(ctx, t, profile)
+	}
 }
 
 func validateStop(ctx context.Context, t *testing.T, profile string, tcName string, tcVersion string, startArgs []string) {

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -254,21 +254,18 @@ func validateSecondStart(ctx context.Context, t *testing.T, profile string, tcNa
 func validateAppExistsAfterStop(ctx context.Context, t *testing.T, profile string, tcName string, tcVersion string, startArgs []string) {
 	if strings.Contains(tcName, "cni") {
 		t.Logf("WARNING: cni mode requires additional setup before pods can schedule :(")
-	} else {
-		if _, err := PodWait(ctx, t, profile, "kubernetes-dashboard", "k8s-app=kubernetes-dashboard", Minutes(9)); err != nil {
-			t.Fatalf("failed waiting for 'addon dashboard' pod post-stop-start: %v", err)
-		}
+	} else if _, err := PodWait(ctx, t, profile, "kubernetes-dashboard", "k8s-app=kubernetes-dashboard", Minutes(9)); err != nil {
+		t.Fatalf("failed waiting for 'addon dashboard' pod post-stop-start: %v", err)
 	}
+
 }
 
 // validateAddonAfterStop validates that an addon which was enabled when minikube is stopped will be enabled and working..
 func validateAddonAfterStop(ctx context.Context, t *testing.T, profile string, tcName string, tcVersion string, startArgs []string) {
 	if strings.Contains(tcName, "cni") {
 		t.Logf("WARNING: cni mode requires additional setup before pods can schedule :(")
-	} else {
-		if _, err := PodWait(ctx, t, profile, "kubernetes-dashboard", "k8s-app=kubernetes-dashboard", Minutes(9)); err != nil {
-			t.Fatalf("failed waiting for 'addon dashboard' pod post-stop-start: %v", err)
-		}
+	} else if _, err := PodWait(ctx, t, profile, "kubernetes-dashboard", "k8s-app=kubernetes-dashboard", Minutes(9)); err != nil {
+		t.Fatalf("failed waiting for 'addon dashboard' pod post-stop-start: %v", err)
 	}
 }
 


### PR DESCRIPTION
break down the giagantic test start stop to 9 sub tests for better clarity what exactly Broke.
I basicly put every logical test to a validaterFunc with a for loop to make sure they run one after the other one (not in parallle)
```
    {"FirstStart", validateFirstStart},
    {"DeployApp", validateDeploying},
    {"Stop", validateStop},
    {"EnableAddonAfterStop", validateEnableAddonAfterStop},
    {"SecondStart", validateSecondStart},
    {"AppExistsAfterStop", validateAppExistsAfterStop},
    {"AddonExistAfterStop", validateAddonAfterStop},
    {"VerifyKubernetesImages", validateKubernetesImages},
    {"Pause", validatePauseAfterSart},
```