### PR TITLE
wip: Use regex anchors to be sure we get `bridge` from the docker network inspect command

### DIFF
--- a/pkg/drivers/kic/oci/network.go
+++ b/pkg/drivers/kic/oci/network.go
@@ -61,7 +61,7 @@ func digDNS(ociBin, containerName, dns string) (net.IP, error) {
 // dockerGatewayIP gets the default gateway ip for the docker bridge on the user's host machine
 // gets the ip from user's host docker
 func dockerGatewayIP() (net.IP, error) {
-	rr, err := runCmd(exec.Command(Docker, "network", "ls", "--filter", "name=bridge", "--format", "{{.ID}}"))
+	rr, err := runCmd(exec.Command(Docker, "network", "ls", "--filter", "name=^bridge$", "--format", "{{.ID}}"))
 	if err != nil {
 		return nil, errors.Wrapf(err, "get network bridge")
 	}


### PR DESCRIPTION
For whatever reason, my docker networks contain multiple bridges, two of them containing the text `bridge`. This change uses regex anchors to be sure we only get one.

```
./out/minikube-linux-amd64 version
minikube version: v1.10.0-beta.2
commit: 3a025104bda8f24025a162432afdce894d463f55
```

```
$ docker network ls
NETWORK ID          NAME                DRIVER              SCOPE
1f6a7ff7d8de        bridge              bridge              local
02b1e0157e69        docker_gwbridge     bridge              local
$ ./out/minikube-linux-amd64 mount -v 10 --alsologtostderr ./data:/data
I0507 08:54:05.927929   25256 mustload.go:64] Loading cluster: minikube
I0507 08:54:05.929063   25256 cli_runner.go:108] Run: docker inspect minikube --format={{.State.Status}}
I0507 08:54:06.017624   25256 host.go:65] Checking if "minikube" exists ...
I0507 08:54:06.018099   25256 cli_runner.go:108] Run: docker network ls --filter name=bridge --format {{.ID}}
I0507 08:54:06.103844   25256 cli_runner.go:108] Run: docker inspect --format "{{(index .IPAM.Config 0).Gateway}}" 1f6a7ff7d8de
02b1e0157e69
I0507 08:54:06.206810   25256 exit.go:58] WithError(Error getting the host IP address to use from within the VM)=inspect IP bridge network "1f6a7ff7d8de\n02b1e0157e69".: docker inspect --format "{{(index .IPAM.Config 0).Gateway}}" 1f6a7ff7d8de
02b1e0157e69: exit status 1
stdout:


stderr:
Error: No such object: 1f6a7ff7d8de
02b1e0157e69
 called from:
goroutine 1 [running]:
runtime/debug.Stack(0x0, 0x6, 0x0)
	/usr/local/go/src/runtime/debug/stack.go:24 +0x9d
k8s.io/minikube/pkg/minikube/exit.WithError(0x1b2a115, 0x3b, 0x1d99280, 0xc0000cd140)
	/home/alexh/repos/kubernetes/minikube/pkg/minikube/exit/exit.go:58 +0x34
k8s.io/minikube/cmd/minikube/cmd.glob..func12(0x2ae7120, 0xc000259fc0, 0x1, 0x4)
	/home/alexh/repos/kubernetes/minikube/cmd/minikube/cmd/mount.go:111 +0x18e8
github.com/spf13/cobra.(*Command).execute(0x2ae7120, 0xc000259f80, 0x4, 0x4, 0x2ae7120, 0xc000259f80)
	/home/alexh/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:846 +0x2aa
github.com/spf13/cobra.(*Command).ExecuteC(0x2ae8b60, 0x0, 0x1, 0xc0001ac640)
	/home/alexh/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950 +0x349
github.com/spf13/cobra.(*Command).Execute(...)
	/home/alexh/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
k8s.io/minikube/cmd/minikube/cmd.Execute()
	/home/alexh/repos/kubernetes/minikube/cmd/minikube/cmd/root.go:108 +0x6a4
main.main()
	/home/alexh/repos/kubernetes/minikube/cmd/minikube/main.go:66 +0xea
W0507 08:54:06.207173   25256 out.go:201] Error getting the host IP address to use from within the VM: inspect IP bridge network "1f6a7ff7d8de\n02b1e0157e69".: docker inspect --format "{{(index .IPAM.Config 0).Gateway}}" 1f6a7ff7d8de
02b1e0157e69: exit status 1
stdout:


stderr:
Error: No such object: 1f6a7ff7d8de
02b1e0157e69

💣  Error getting the host IP address to use from within the VM: inspect IP bridge network "1f6a7ff7d8de\n02b1e0157e69".: docker inspect --format "{{(index .IPAM.Config 0).Gateway}}" 1f6a7ff7d8de
02b1e0157e69: exit status 1
stdout:


stderr:
Error: No such object: 1f6a7ff7d8de
02b1e0157e69


😿  minikube is exiting due to an error. If the above message is not useful, open an issue:
👉  https://github.com/kubernetes/minikube/issues/new/choose
```

After the change:

```
± ./out/minikube-linux-amd64 mount -v 10 --alsologtostderr out/:/data
I0507 08:57:33.171841   32013 mustload.go:64] Loading cluster: minikube
I0507 08:57:33.173373   32013 cli_runner.go:108] Run: docker inspect minikube --format={{.State.Status}}
I0507 08:57:33.260045   32013 host.go:65] Checking if "minikube" exists ...
I0507 08:57:33.260567   32013 cli_runner.go:108] Run: docker network ls --filter name=^bridge$ --format {{.ID}}
I0507 08:57:33.347642   32013 cli_runner.go:108] Run: docker inspect --format "{{(index .IPAM.Config 0).Gateway}}" 1f6a7ff7d8de
I0507 08:57:33.431061   32013 network.go:77] got host ip for mount in container by inspect docker network: 172.17.0.1
📁  Mounting host path out/ into VM as /data ...
    ▪ Mount type:   <no value>
    ▪ User ID:      docker
    ▪ Group ID:     docker
    ▪ Version:      9p2000.L
    ▪ Message Size: 262144
    ▪ Permissions:  755 (-rwxr-xr-x)
    ▪ Options:      map[]
    ▪ Bind Address: 172.17.0.1:40709
I0507 08:57:33.434277   32013 ssh_runner.go:148] Run: /bin/bash -c "[ "x$(findmnt -T /data | grep /data)" != "x" ] && sudo umount -f /data || echo "
🚀  Userspace file server: ufs starting
I0507 08:57:33.434729   32013 cli_runner.go:108] Run: docker inspect -f "'{{(index (index .NetworkSettings.Ports "22/tcp") 0).HostPort}}'" minikube
I0507 08:57:33.518944   32013 sshutil.go:44] new ssh client: &{IP:127.0.0.1 Port:32770 SSHKeyPath:/home/alexh/.minikube/machines/minikube/id_rsa Username:docker}
I0507 08:57:33.627018   32013 mount.go:147] unmount for /data ran successfully
I0507 08:57:33.627069   32013 ssh_runner.go:148] Run: /bin/bash -c "sudo mkdir -m 755 -p /data"
I0507 08:57:33.642723   32013 ssh_runner.go:148] Run: /bin/bash -c "sudo mount -t 9p -o dfltgid=$(grep ^docker: /etc/group | cut -d: -f3),dfltuid=$(id -u docker),msize=262144,port=40709,trans=tcp,version=9p2000.L 172.17.0.1 /data"
I0507 08:57:33.661978   32013 main.go:96] stdlog: ufs.go:141 connected
I0507 08:57:33.663962   32013 main.go:96] stdlog: srv_conn.go:133 >>> 172.17.0.3:53484 Tversion tag 65535 msize 65536 version '9P2000.L'
I0507 08:57:33.664047   32013 main.go:96] stdlog: srv_conn.go:190 <<< 172.17.0.3:53484 Rversion tag 65535 msize 65536 version '9P2000'
I0507 08:57:33.664347   32013 main.go:96] stdlog: srv_conn.go:133 >>> 172.17.0.3:53484 Tattach tag 1 fid 0 afid 4294967295 uname 'nobody' nuname 0 aname ''
I0507 08:57:33.664436   32013 main.go:96] stdlog: srv_conn.go:190 <<< 172.17.0.3:53484 Rattach tag 1 aqid (1420245 efda93af 'd')
I0507 08:57:33.666136   32013 main.go:96] stdlog: srv_conn.go:133 >>> 172.17.0.3:53484 Tstat tag 1 fid 0
I0507 08:57:33.666230   32013 main.go:96] stdlog: srv_conn.go:190 <<< 172.17.0.3:53484 Rstat tag 1 st ('out' 'alexh' 'alexh' '' q (1420245 efda93af 'd') m d775 at 0 mt 1588867011 l 4096 t 0 d 0 ext )
I0507 08:57:33.669040   32013 mount.go:72] mount successful: ""
✅  Successfully mounted out/ to /data

📌  NOTE: This process must stay alive for the mount to be accessible ...
```