### PR TITLE
Use the appropriate OCI for deletePossibleKicLeftOver when known

### DIFF
--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -165,7 +165,7 @@ func runDelete(cmd *cobra.Command, args []string) {
 		}
 
 		if orphan {
-			// TODO: generalize for non-KIC drivers
+			// TODO: generalize for non-KIC drivers: #8040
 			deletePossibleKicLeftOver(cname, driver.Docker)
 		}
 	}
@@ -207,7 +207,7 @@ func DeleteProfiles(profiles []*config.Profile) []error {
 	return errs
 }
 
-// TODO: remove and/or move to delete package.
+// TODO: remove and/or move to delete package: #8040
 func deletePossibleKicLeftOver(cname string, driverName string) {
 	glog.Infof("deleting possible KIC leftovers for %s (driver=%s) ...", cname, driverName)
 

--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 
@@ -88,7 +89,15 @@ func init() {
 	RootCmd.AddCommand(deleteCmd)
 }
 
+// shotgun cleanup to delete orphaned docker container data
 func deleteContainersAndVolumes() {
+	if _, err := exec.LookPath(oci.Docker); err != nil {
+		glog.Infof("skipping deleteContainersAndVolumes for %s: %v", oci.Docker, err)
+		return
+	}
+
+	glog.Infof("deleting containers and volumes ...")
+
 	delLabel := fmt.Sprintf("%s=%s", oci.CreatedByLabelKey, "true")
 	errs := oci.DeleteContainersByLabel(oci.Docker, delLabel)
 	if len(errs) > 0 { // it will error if there is no container to delete
@@ -143,15 +152,21 @@ func runDelete(cmd *cobra.Command, args []string) {
 
 		cname := ClusterFlagValue()
 		profile, err := config.LoadProfile(cname)
+		orphan := false
+
 		if err != nil {
 			out.ErrT(out.Meh, `"{{.name}}" profile does not exist, trying anyways.`, out.V{"name": cname})
+			orphan = true
 		}
-
-		deletePossibleKicLeftOver(cname)
 
 		errs := DeleteProfiles([]*config.Profile{profile})
 		if len(errs) > 0 {
 			HandleDeletionErrors(errs)
+		}
+
+		if orphan {
+			// TODO: generalize for non-KIC drivers
+			deletePossibleKicLeftOver(cname, driver.Docker)
 		}
 	}
 
@@ -171,6 +186,7 @@ func purgeMinikubeDirectory() {
 
 // DeleteProfiles deletes one or more profiles
 func DeleteProfiles(profiles []*config.Profile) []error {
+	glog.Infof("DeleteProfiles")
 	var errs []error
 	for _, profile := range profiles {
 		err := deleteProfile(profile)
@@ -191,41 +207,57 @@ func DeleteProfiles(profiles []*config.Profile) []error {
 	return errs
 }
 
-func deletePossibleKicLeftOver(name string) {
-	delLabel := fmt.Sprintf("%s=%s", oci.ProfileLabelKey, name)
-	for _, bin := range []string{oci.Docker, oci.Podman} {
-		cs, err := oci.ListContainersByLabel(bin, delLabel)
-		if err == nil && len(cs) > 0 {
-			for _, c := range cs {
-				out.T(out.DeletingHost, `Deleting container "{{.name}}" ...`, out.V{"name": name})
-				err := oci.DeleteContainer(bin, c)
-				if err != nil { // it will error if there is no container to delete
-					glog.Errorf("error deleting container %q. you might want to delete that manually :\n%v", name, err)
-				}
+// TODO: remove and/or move to delete package.
+func deletePossibleKicLeftOver(cname string, driverName string) {
+	glog.Infof("deleting possible KIC leftovers for %s (driver=%s) ...", cname, driverName)
 
+	bin := ""
+	switch driverName {
+	case driver.Docker:
+		bin = oci.Docker
+	case driver.Podman:
+		bin = oci.Podman
+	default:
+		return
+	}
+
+	delLabel := fmt.Sprintf("%s=%s", oci.ProfileLabelKey, cname)
+	cs, err := oci.ListContainersByLabel(bin, delLabel)
+	if err == nil && len(cs) > 0 {
+		for _, c := range cs {
+			out.T(out.DeletingHost, `Deleting container "{{.name}}" ...`, out.V{"name": cname})
+			err := oci.DeleteContainer(bin, c)
+			if err != nil { // it will error if there is no container to delete
+				glog.Errorf("error deleting container %q. You may want to delete it manually :\n%v", cname, err)
 			}
-		}
 
-		errs := oci.DeleteAllVolumesByLabel(bin, delLabel)
-		if errs != nil { // it will not error if there is nothing to delete
-			glog.Warningf("error deleting volumes (might be okay).\nTo see the list of volumes run: 'docker volume ls'\n:%v", errs)
 		}
+	}
 
-		errs = oci.PruneAllVolumesByLabel(bin, delLabel)
-		if len(errs) > 0 { // it will not error if there is nothing to delete
-			glog.Warningf("error pruning volume (might be okay):\n%v", errs)
-		}
+	errs := oci.DeleteAllVolumesByLabel(bin, delLabel)
+	if errs != nil { // it will not error if there is nothing to delete
+		glog.Warningf("error deleting volumes (might be okay).\nTo see the list of volumes run: 'docker volume ls'\n:%v", errs)
+	}
+
+	errs = oci.PruneAllVolumesByLabel(bin, delLabel)
+	if len(errs) > 0 { // it will not error if there is nothing to delete
+		glog.Warningf("error pruning volume (might be okay):\n%v", errs)
 	}
 }
 
 func deleteProfile(profile *config.Profile) error {
+	glog.Infof("Deleting %s", profile.Name)
 	viper.Set(config.ProfileName, profile.Name)
 	if profile.Config != nil {
+		glog.Infof("%s configuration: %+v", profile.Name, profile.Config)
+
 		// if driver is oci driver, delete containers and volumes
 		if driver.IsKIC(profile.Config.Driver) {
 			out.T(out.DeletingHost, `Deleting "{{.profile_name}}" in {{.driver_name}} ...`, out.V{"profile_name": profile.Name, "driver_name": profile.Config.Driver})
-			deletePossibleKicLeftOver(profile.Name)
+			deletePossibleKicLeftOver(profile.Name, profile.Config.Driver)
 		}
+	} else {
+		glog.Infof("%s has no configuration, will try to make it work anyways", profile.Name)
 	}
 
 	api, err := machine.NewAPIClient()


### PR DESCRIPTION
Partially resolves #7958

Important changes:

- deletePossibleKicLeftOver is now only called once
- deletePossibleKicLeftOver is now called inside DeleteProfiles if a profile is known, and after DeleteProfiles if it's orphaned
- deletePossibleKicLeftOver now takes a driver name. If unknown, Docker is passed in.
 
Other changes:

- deleteContainersAndVolumes only runs docker commands if docker is found
- extra logging added

## Old Behavior

Deleting a known Docker profile:

```
I0507 15:27:06.349053   24786 cli_runner.go:108] Run: docker ps -a --filter label=name.minikube.sigs.k8s.io --format {{.Names}}
I0507 15:27:06.416720   24786 cli_runner.go:108] Run: docker ps -a --filter label=name.minikube.sigs.k8s.io=minikube --format {{.Names}}
🔥  Deleting container "minikube" ...
I0507 15:27:06.461363   24786 cli_runner.go:108] Run: docker inspect minikube --format={{.State.Status}}
I0507 15:27:06.503719   24786 cli_runner.go:108] Run: docker exec --privileged -t minikube /bin/bash -c "sudo init 0"
I0507 15:27:07.800099   24786 cli_runner.go:108] Run: docker inspect minikube --format={{.State.Status}}
I0507 15:27:07.838059   24786 oci.go:519] temporary error: container minikube status is Running but expect it to be exited
I0507 15:27:07.838109   24786 oci.go:525] Successfully shutdown container minikube
I0507 15:27:07.838230   24786 cli_runner.go:108] Run: docker rm -f -v minikube
I0507 15:27:08.213716   24786 volumes.go:34] trying to delete all docker volumes with label name.minikube.sigs.k8s.io=minikube
I0507 15:27:08.213876   24786 cli_runner.go:108] Run: docker volume ls --filter label=name.minikube.sigs.k8s.io=minikube --format {{.Name}}
I0507 15:27:08.247632   24786 cli_runner.go:108] Run: docker volume rm --force minikube
I0507 15:27:08.655286   24786 volumes.go:56] trying to prune all docker volumes with label name.minikube.sigs.k8s.io=minikube
I0507 15:27:08.655443   24786 cli_runner.go:108] Run: docker volume prune -f --filter label=name.minikube.sigs.k8s.io=minikube
I0507 15:27:08.688318   24786 cli_runner.go:108] Run: podman ps -a --filter label=name.minikube.sigs.k8s.io=minikube --format {{.Names}}
I0507 15:27:08.688363   24786 volumes.go:34] trying to delete all podman volumes with label name.minikube.sigs.k8s.io=minikube
I0507 15:27:08.688439   24786 cli_runner.go:108] Run: podman volume ls --filter label=name.minikube.sigs.k8s.io=minikube --format {{.Name}}
W0507 15:27:08.688457   24786 delete.go:211] error deleting volumes (might be okay).
To see the list of volumes run: 'docker volume ls'
:[listing volumes by label "name.minikube.sigs.k8s.io=minikube": podman volume ls --filter label=name.minikube.sigs.k8s.io=minikube --format {{.Name}}: exec: "podman": executable file not found in $PATH
stdout:

stderr:
]
I0507 15:27:08.689139   24786 volumes.go:56] trying to prune all podman volumes with label name.minikube.sigs.k8s.io=minikube
I0507 15:27:08.689249   24786 cli_runner.go:108] Run: podman volume prune -f --filter label=name.minikube.sigs.k8s.io=minikube
W0507 15:27:08.689277   24786 delete.go:216] error pruning volume (might be okay):
[prune volume by label name.minikube.sigs.k8s.io=minikube: podman volume prune -f --filter label=name.minikube.sigs.k8s.io=minikube: exec: "podman": executable file not found in $PATH
stdout:

stderr:
]
🔥  Deleting "minikube" in docker ...
I0507 15:27:08.712940   24786 cli_runner.go:108] Run: docker ps -a --filter label=name.minikube.sigs.k8s.io=minikube --format {{.Names}}
I0507 15:27:08.749170   24786 volumes.go:34] trying to delete all docker volumes with label name.minikube.sigs.k8s.io=minikube
I0507 15:27:08.749329   24786 cli_runner.go:108] Run: docker volume ls --filter label=name.minikube.sigs.k8s.io=minikube --format {{.Name}}
I0507 15:27:08.781812   24786 volumes.go:56] trying to prune all docker volumes with label name.minikube.sigs.k8s.io=minikube
I0507 15:27:08.781945   24786 cli_runner.go:108] Run: docker volume prune -f --filter label=name.minikube.sigs.k8s.io=minikube
I0507 15:27:08.815468   24786 cli_runner.go:108] Run: podman ps -a --filter label=name.minikube.sigs.k8s.io=minikube --format {{.Names}}
I0507 15:27:08.815497   24786 volumes.go:34] trying to delete all podman volumes with label name.minikube.sigs.k8s.io=minikube
I0507 15:27:08.815562   24786 cli_runner.go:108] Run: podman volume ls --filter label=name.minikube.sigs.k8s.io=minikube --format {{.Name}}
W0507 15:27:08.815581   24786 delete.go:211] error deleting volumes (might be okay).
To see the list of volumes run: 'docker volume ls'
:[listing volumes by label "name.minikube.sigs.k8s.io=minikube": podman volume ls --filter label=name.minikube.sigs.k8s.io=minikube --format {{.Name}}: exec: "podman": executable file not found in $PATH
stdout:

stderr:
]
I0507 15:27:08.815593   24786 volumes.go:56] trying to prune all podman volumes with label name.minikube.sigs.k8s.io=minikube
I0507 15:27:08.815663   24786 cli_runner.go:108] Run: podman volume prune -f --filter label=name.minikube.sigs.k8s.io=minikube
W0507 15:27:08.815682   24786 delete.go:216] error pruning volume (might be okay):
[prune volume by label name.minikube.sigs.k8s.io=minikube: podman volume prune -f --filter label=name.minikube.sigs.k8s.io=minikube: exec: "podman": executable file not found in $PATH
stdout:

stderr:
]
I0507 15:27:08.816516   24786 cli_runner.go:108] Run: docker inspect minikube --format={{.State.Status}}
I0507 15:27:08.869693   24786 delete.go:75] Unable to get host status for minikube, assuming it has already been deleted: state: unknown state "minikube": docker inspect minikube --format={{.State.Status}}: exit status 1
stdout:


stderr:
Error: No such object: minikube
🔥  Removing /Users/tstromberg/.minikube/machines/minikube ...
I0507 15:27:08.891006   24786 lock.go:35] WriteFile acquiring /Users/tstromberg/.kube/config: {Name:mke11dbcd579c84d4d098461d9cff60a03fa7a38 Clock:{} Delay:500ms Timeout:1m0s Cancel:<nil>}
💀  Removed all traces of the "minikube" cluster.
```

Deleting a non-existent profile:

```
I0507 15:27:28.695001   24859 cli_runner.go:108] Run: docker ps -a --filter label=name.minikube.sigs.k8s.io --format {{.Names}}
🙄  "minikube" profile does not exist, trying anyways.
I0507 15:27:28.727648   24859 cli_runner.go:108] Run: docker ps -a --filter label=name.minikube.sigs.k8s.io=minikube --format {{.Names}}
I0507 15:27:28.758055   24859 volumes.go:34] trying to delete all docker volumes with label name.minikube.sigs.k8s.io=minikube
I0507 15:27:28.758224   24859 cli_runner.go:108] Run: docker volume ls --filter label=name.minikube.sigs.k8s.io=minikube --format {{.Name}}
I0507 15:27:28.790737   24859 volumes.go:56] trying to prune all docker volumes with label name.minikube.sigs.k8s.io=minikube
I0507 15:27:28.790897   24859 cli_runner.go:108] Run: docker volume prune -f --filter label=name.minikube.sigs.k8s.io=minikube
I0507 15:27:28.823814   24859 cli_runner.go:108] Run: podman ps -a --filter label=name.minikube.sigs.k8s.io=minikube --format {{.Names}}
I0507 15:27:28.824224   24859 volumes.go:34] trying to delete all podman volumes with label name.minikube.sigs.k8s.io=minikube
I0507 15:27:28.824348   24859 cli_runner.go:108] Run: podman volume ls --filter label=name.minikube.sigs.k8s.io=minikube --format {{.Name}}
W0507 15:27:28.824371   24859 delete.go:211] error deleting volumes (might be okay).
To see the list of volumes run: 'docker volume ls'
:[listing volumes by label "name.minikube.sigs.k8s.io=minikube": podman volume ls --filter label=name.minikube.sigs.k8s.io=minikube --format {{.Name}}: exec: "podman": executable file not found in $PATH
stdout:

stderr:
]
I0507 15:27:28.825341   24859 volumes.go:56] trying to prune all podman volumes with label name.minikube.sigs.k8s.io=minikube
I0507 15:27:28.825490   24859 cli_runner.go:108] Run: podman volume prune -f --filter label=name.minikube.sigs.k8s.io=minikube
W0507 15:27:28.825518   24859 delete.go:216] error pruning volume (might be okay):
[prune volume by label name.minikube.sigs.k8s.io=minikube: podman volume prune -f --filter label=name.minikube.sigs.k8s.io=minikube: exec: "podman": executable file not found in $PATH
stdout:

stderr:
]
I0507 15:27:28.827318   24859 lock.go:35] WriteFile acquiring /Users/tstromberg/.kube/config: {Name:mke11dbcd579c84d4d098461d9cff60a03fa7a38 Clock:{} Delay:500ms Timeout:1m0s Cancel:<nil>}
💀  Removed all traces of the "minikube" cluster.
```

## New Behavior

Deleting a known Docker profile:

```
I0507 15:25:17.974658   24496 cli_runner.go:108] Run: docker ps -a --filter label=name.minikube.sigs.k8s.io --format {{.Names}}
I0507 15:25:18.049231   24496 delete.go:189] DeleteProfiles
I0507 15:25:18.049256   24496 delete.go:249] Deleting minikube
I0507 15:25:18.049267   24496 delete.go:252] minikube configuration: &{Name:minikube KeepContext:false EmbedCerts:false MinikubeISO: KicBaseImage:gcr.io/k8s-minikube/kicbase:v0.0.10@sha256:f58e0c4662bac8a9b5dda7984b185bad8502ade5d9fa364bf2755d636ab51438 Memory:982 CPUs:2 DiskSize:20000 Driver:docker HyperkitVpnKitSock: HyperkitVSockPorts:[] DockerEnv:[] InsecureRegistry:[] RegistryMirror:[] HostOnlyCIDR:192.168.99.1/24 HypervVirtualSwitch: HypervUseExternalSwitch:false HypervExternalAdapter: KVMNetwork:default KVMQemuURI:qemu:///system KVMGPU:false KVMHidden:false DockerOpt:[] DisableDriverMounts:false NFSShare:[] NFSSharesRoot:/nfsshares UUID: NoVTXCheck:false DNSProxy:false HostDNSResolver:true HostOnlyNicType:virtio NatNicType:virtio KubernetesConfig:{KubernetesVersion:v1.18.1 ClusterName:minikube APIServerName:minikubeCA APIServerNames:[] APIServerIPs:[] DNSDomain:cluster.local ContainerRuntime:docker CRISocket: NetworkPlugin: FeatureGates: ServiceCIDR:10.96.0.0/12 ImageRepository: LoadBalancerStartIP: LoadBalancerEndIP: ExtraOptions:[{Component:kubeadm Key:pod-network-cidr Value:10.244.0.0/16}] ShouldLoadCachedImages:true EnableDefaultCNI:false NodeIP: NodePort:8443 NodeName:} Nodes:[{Name: IP:172.17.0.3 Port:8443 KubernetesVersion:v1.18.1 ControlPlane:true Worker:true}] Addons:map[default-storageclass:true storage-provisioner:true] VerifyComponents:map[apiserver:true system_pods:true]}
🔥  Deleting "minikube" in docker ...
I0507 15:25:18.062225   24496 delete.go:212] deleting possible KIC leftovers for minikube (driver=docker) ...
I0507 15:25:18.062419   24496 cli_runner.go:108] Run: docker ps -a --filter label=name.minikube.sigs.k8s.io=minikube --format {{.Names}}
🔥  Deleting container "minikube" ...
I0507 15:25:18.107310   24496 cli_runner.go:108] Run: docker inspect minikube --format={{.State.Status}}
I0507 15:25:18.153675   24496 cli_runner.go:108] Run: docker exec --privileged -t minikube /bin/bash -c "sudo init 0"
I0507 15:25:19.449497   24496 cli_runner.go:108] Run: docker inspect minikube --format={{.State.Status}}
I0507 15:25:19.505777   24496 oci.go:519] temporary error: container minikube status is Running but expect it to be exited
I0507 15:25:19.505816   24496 oci.go:525] Successfully shutdown container minikube
I0507 15:25:19.505940   24496 cli_runner.go:108] Run: docker rm -f -v minikube
I0507 15:25:19.953547   24496 volumes.go:34] trying to delete all docker volumes with label name.minikube.sigs.k8s.io=minikube
I0507 15:25:19.953700   24496 cli_runner.go:108] Run: docker volume ls --filter label=name.minikube.sigs.k8s.io=minikube --format {{.Name}}
I0507 15:25:19.989498   24496 cli_runner.go:108] Run: docker volume rm --force minikube
I0507 15:25:20.422175   24496 volumes.go:56] trying to prune all docker volumes with label name.minikube.sigs.k8s.io=minikube
I0507 15:25:20.422329   24496 cli_runner.go:108] Run: docker volume prune -f --filter label=name.minikube.sigs.k8s.io=minikube
I0507 15:25:20.457190   24496 cli_runner.go:108] Run: docker inspect minikube --format={{.State.Status}}
I0507 15:25:20.513857   24496 delete.go:75] Unable to get host status for minikube, assuming it has already been deleted: state: unknown state "minikube": docker inspect minikube --format={{.State.Status}}: exit status 1
stdout:


stderr:
Error: No such object: minikube
🔥  Removing /Users/tstromberg/.minikube/machines/minikube ...
I0507 15:25:20.526813   24496 lock.go:35] WriteFile acquiring /Users/tstromberg/.kube/config: {Name:mke11dbcd579c84d4d098461d9cff60a03fa7a38 Clock:{} Delay:500ms Timeout:1m0s Cancel:<nil>}
💀  Removed all traces of the "minikube" cluster.
```

Deleting a non-existent profile:

```
I0507 15:25:40.120023   24583 cli_runner.go:108] Run: docker ps -a --filter label=name.minikube.sigs.k8s.io --format {{.Names}}
🙄  "minikube" profile does not exist, trying anyways.
I0507 15:25:40.156649   24583 delete.go:189] DeleteProfiles
I0507 15:25:40.156661   24583 delete.go:249] Deleting minikube
I0507 15:25:40.156673   24583 delete.go:260] minikube has no configuration, will try to make it work anyways
I0507 15:25:40.158487   24583 lock.go:35] WriteFile acquiring /Users/tstromberg/.kube/config: {Name:mke11dbcd579c84d4d098461d9cff60a03fa7a38 Clock:{} Delay:500ms Timeout:1m0s Cancel:<nil>}
💀  Removed all traces of the "minikube" cluster.
I0507 15:25:40.174158   24583 delete.go:212] deleting possible KIC leftovers for minikube (driver=docker) ...
I0507 15:25:40.174329   24583 cli_runner.go:108] Run: docker ps -a --filter label=name.minikube.sigs.k8s.io=minikube --format {{.Names}}
I0507 15:25:40.214958   24583 volumes.go:34] trying to delete all docker volumes with label name.minikube.sigs.k8s.io=minikube
I0507 15:25:40.215113   24583 cli_runner.go:108] Run: docker volume ls --filter label=name.minikube.sigs.k8s.io=minikube --format {{.Name}}
I0507 15:25:40.247956   24583 volumes.go:56] trying to prune all docker volumes with label name.minikube.sigs.k8s.io=minikube
I0507 15:25:40.248109   24583 cli_runner.go:108] Run: docker volume prune -f --filter label=name.minikube.sigs.k8s.io=minikube
```


