### PR TITLE
TestFunctional/parallel/ServiceCmd: Add logging

### DIFF
--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -639,6 +639,30 @@ func validateProfileCmd(ctx context.Context, t *testing.T, profile string) {
 
 // validateServiceCmd asserts basic "service" command functionality
 func validateServiceCmd(ctx context.Context, t *testing.T, profile string) {
+	defer func() {
+		if t.Failed() {
+			t.Logf("service test failed - dumping debug information")
+
+			rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "describe", "po", "hello-node"))
+			if err != nil {
+				t.Logf("%q failed: %v", rr.Command(), err)
+			}
+			t.Logf("hello-node pod describe:\n%s", rr.Stdout)
+
+			rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "logs", "-l", "app=hello-node"))
+			if err != nil {
+				t.Logf("%q failed: %v", rr.Command(), err)
+			}
+			t.Logf("hello-node logs:\n%s", rr.Stdout)
+
+			rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "describe", "svc", "hello-node"))
+			if err != nil {
+				t.Logf("%q failed: %v", rr.Command(), err)
+			}
+			t.Logf("hello-node svc describe:\n%s", rr.Stdout)
+		}
+	}()
+
 	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "create", "deployment", "hello-node", "--image=k8s.gcr.io/echoserver:1.4"))
 	if err != nil {
 		t.Logf("%q failed: %v (may not be an error).", rr.Command(), err)
@@ -658,6 +682,11 @@ func validateServiceCmd(ctx context.Context, t *testing.T, profile string) {
 	}
 	if !strings.Contains(rr.Stdout.String(), "hello-node") {
 		t.Errorf("expected 'service list' to contain *hello-node* but got -%q-", rr.Stdout.String())
+	}
+
+	rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "get", "po", "hello-node"))
+	if err != nil {
+		t.Logf("%q failed: %v (may not be an error)", rr.Command(), err)
 	}
 
 	if NeedsPortForward() {
@@ -691,29 +720,59 @@ func validateServiceCmd(ctx context.Context, t *testing.T, profile string) {
 		t.Errorf("expected 'service --format={{.IP}}' output to be -%q- but got *%q* . args %q.", u.Hostname(), rr.Stdout.String(), rr.Command())
 	}
 
-	// Test a regular URLminikube
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "service", "hello-node", "--url"))
 	if err != nil {
 		t.Errorf("failed to get service url. args: %q: %v", rr.Command(), err)
 	}
 
 	endpoint = strings.TrimSpace(rr.Stdout.String())
+	t.Logf("found endpoint for hello-node: %s", endpoint)
+
 	u, err = url.Parse(endpoint)
 	if err != nil {
 		t.Fatalf("failed to parse %q: %v", endpoint, err)
 	}
+
 	if u.Scheme != "http" {
 		t.Fatalf("expected scheme to be -%q- got scheme: *%q*", "http", u.Scheme)
 	}
 
-	t.Logf("url: %s", endpoint)
-	resp, err := retryablehttp.Get(endpoint)
-	if err != nil {
-		t.Fatalf("get failed: %v\nresp: %v", err, resp)
+	c := retryablehttp.NewClient()
+	c.Logger = &logAdapter{t: t}
+
+	t.Logf("Attempting to fetch %s ...", endpoint)
+
+	fetch := func() error {
+		resp, err := http.Get(endpoint)
+		if err != nil {
+			t.Logf("error fetching %s: %v", endpoint, err)
+			return err
+		}
+
+		defer resp.Body.Close()
+
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Logf("error reading body from %s: %v", endpoint, err)
+			return err
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Logf("%s: unexpected status code %d - body:\n%s", endpoint, resp.StatusCode, body)
+		} else {
+			t.Logf("%s: success! body:\n%s", endpoint, body)
+		}
+		return nil
 	}
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected status code for %q to be -%q- but got *%q*", endpoint, http.StatusOK, resp.StatusCode)
+
+	if err = retry.Expo(fetch, 1*time.Second, Seconds(30)); err != nil {
+		t.Errorf("failed to fetch %s: %v", endpoint, err)
 	}
+}
+
+type logAdapter struct{ t *testing.T }
+
+func (l *logAdapter) Printf(s string, args ...interface{}) {
+	l.t.Logf(s, args...)
 }
 
 // validateAddonsCmd asserts basic "addon" command functionality


### PR DESCRIPTION
While I have not been able to duplicate #8013 across 100 runs, I've at least make it easier to debug when it fails:

- Replace retryablehttp with something that logs the underlying error message
- Dump pod/svc/logs information if it fails

Example output with a forced error:

```
    TestFunctional/parallel/ServiceCmd: functional_test.go:698: (dbg) Run:  out/minikube -p minikube service --namespace=default --https --url hello-node
    TestFunctional/parallel/ServiceCmd: functional_test.go:716: (dbg) Run:  out/minikube -p minikube service hello-node --url --format={{.IP}}
    TestFunctional/parallel/ServiceCmd: functional_test.go:724: (dbg) Run:  out/minikube -p minikube service hello-node --url
    TestFunctional/parallel/ServiceCmd: functional_test.go:730: found endpoint for hello-node: http://192.168.64.2:30720
    TestFunctional/parallel/ServiceCmd: functional_test.go:744: Attempting to fetch http://192.168.64.2:30720 ...
    TestFunctional/parallel/ServiceCmd: functional_test.go:763: http://192.168.64.2:30720: success! body:
        CLIENT VALUES:
        client_address=172.17.0.1
        command=GET
        real path=/
        query=nil
        request_version=1.1
        request_uri=http://192.168.64.2:8080/
        
        SERVER VALUES:
        server_version=nginx: 1.10.0 - lua: 10001
        
        HEADERS RECEIVED:
        accept-encoding=gzip
        host=192.168.64.2:30720
        user-agent=Go-http-client/1.1
        BODY:
        -no body in request-
    TestFunctional/parallel/ServiceCmd: functional_test.go:644: service test failed - dumping debug information
    TestFunctional/parallel/ServiceCmd: functional_test.go:646: (dbg) Run:  kubectl --context minikube describe po hello-node
    TestFunctional/parallel/ServiceCmd: functional_test.go:650: hello-node pod describe:
        Name:         hello-node-7bf657c596-vj8bl
        Namespace:    default
        Priority:     0
        Node:         minikube/192.168.64.2
        Start Time:   Thu, 07 May 2020 16:22:35 -0700
        Labels:       app=hello-node
                      pod-template-hash=7bf657c596
        Annotations:  <none>
        Status:       Running
        IP:           172.17.0.4
        IPs:
          IP:           172.17.0.4
        Controlled By:  ReplicaSet/hello-node-7bf657c596
        Containers:
          echoserver:
            Container ID:   docker://2bc8c88d8a1020d3f6184dec8ecf2053856c8ced93709d04626ad54988a56b75
            Image:          k8s.gcr.io/echoserver:1.4
            Image ID:       docker-pullable://k8s.gcr.io/echoserver@sha256:5d99aa1120524c801bc8c1a7077e8f5ec122ba16b6dda1a5d3826057f67b9bcb
            Port:           <none>
            Host Port:      <none>
            State:          Running
              Started:      Thu, 07 May 2020 16:22:53 -0700
            Ready:          True
            Restart Count:  0
            Environment:    <none>
            Mounts:
              /var/run/secrets/kubernetes.io/serviceaccount from default-token-sxrxl (ro)
        Conditions:
          Type              Status
          Initialized       True 
          Ready             True 
          ContainersReady   True 
          PodScheduled      True 
        Volumes:
          default-token-sxrxl:
            Type:        Secret (a volume populated by a Secret)
            SecretName:  default-token-sxrxl
            Optional:    false
        QoS Class:       BestEffort
        Node-Selectors:  <none>
        Tolerations:     node.kubernetes.io/not-ready:NoExecute for 300s
                         node.kubernetes.io/unreachable:NoExecute for 300s
        Events:
          Type    Reason     Age   From               Message
          ----    ------     ----  ----               -------
          Normal  Scheduled  21m   default-scheduler  Successfully assigned default/hello-node-7bf657c596-vj8bl to minikube
          Normal  Pulling    21m   kubelet, minikube  Pulling image "k8s.gcr.io/echoserver:1.4"
          Normal  Pulled     20m   kubelet, minikube  Successfully pulled image "k8s.gcr.io/echoserver:1.4"
          Normal  Created    20m   kubelet, minikube  Created container echoserver
          Normal  Started    20m   kubelet, minikube  Started container echoserver
        
    TestFunctional/parallel/ServiceCmd: functional_test.go:652: (dbg) Run:  kubectl --context minikube logs -l app=hello-node
    TestFunctional/parallel/ServiceCmd: functional_test.go:656: hello-node logs:
        172.17.0.1 - - [07/May/2020:23:23:02 +0000] "GET / HTTP/1.1" 200 433 "-" "Go-http-client/1.1"
        172.17.0.1 - - [07/May/2020:23:31:08 +0000] "GET / HTTP/1.1" 200 433 "-" "Go-http-client/1.1"
        172.17.0.1 - - [07/May/2020:23:32:34 +0000] "GET / HTTP/1.1" 200 433 "-" "Go-http-client/1.1"
        172.17.0.1 - - [07/May/2020:23:41:21 +0000] "GET / HTTP/1.1" 200 410 "-" "Go-http-client/1.1"
        172.17.0.1 - - [07/May/2020:23:41:51 +0000] "GET / HTTP/1.1" 200 410 "-" "Go-http-client/1.1"
        172.17.0.1 - - [07/May/2020:23:43:42 +0000] "GET / HTTP/1.1" 200 410 "-" "Go-http-client/1.1"
    TestFunctional/parallel/ServiceCmd: functional_test.go:658: (dbg) Run:  kubectl --context minikube describe svc hello-node
    TestFunctional/parallel/ServiceCmd: functional_test.go:662: hello-node svc describe:
        Name:                     hello-node
        Namespace:                default
        Labels:                   app=hello-node
        Annotations:              <none>
        Selector:                 app=hello-node
        Type:                     NodePort
        IP:                       10.103.214.205
        Port:                     <unset>  8080/TCP
        TargetPort:               8080/TCP
        NodePort:                 <unset>  30720/TCP
        Endpoints:                172.17.0.4:8080
        Session Affinity:         None
        External Traffic Policy:  Cluster
        Events:                   <none>
--- FAIL: TestFunctional (6.17s)
    --- FAIL: TestFunctional/parallel (0.00s)
        --- FAIL: TestFunctional/parallel/ServiceCmd (6.17s)
FAIL
FAIL	k8s.io/minikube/test/integration	7.284s
FAIL
make: *** [integration] Error 1
```