### PR TITLE
Document that minikube with kubeadm needs 2 CPUs

### DIFF
--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -13,6 +13,7 @@ All you need is Docker (or similarly compatible) container or a Virtual Machine 
 
 ## What you’ll need
 
+* 2 CPUs or more
 * 2GB of free memory
 * 20GB of free disk space
 * Internet connection


### PR DESCRIPTION
Eventually this also needs better validation, both for none and for docker driver.

This is supposed to be synced with the information https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#before-you-begin

> 2 GB or more of RAM per machine (any less will leave little room for your apps)
> 2 CPUs or more

The memory size is a little misleading (since it uses 2200M, not 2048M) but is not about cpus.
And we accept both 1GB (with a warning, and probably swap) and 2000 without any complaint.

For #6961 #7445 #7782 #7907 #7850 #8045