### PR TITLE
Don't run the extraction tar container for podman

### DIFF
--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -122,22 +122,27 @@ func (d *Driver) Create() error {
 	}
 
 	var waitForPreload sync.WaitGroup
-	waitForPreload.Add(1)
-	go func() {
-		defer waitForPreload.Done()
-		// If preload doesn't exist, don't bother extracting tarball to volume
-		if !download.PreloadExists(d.NodeConfig.KubernetesVersion, d.NodeConfig.ContainerRuntime) {
-			return
-		}
-		t := time.Now()
-		glog.Infof("Starting extracting preloaded images to volume ...")
-		// Extract preloaded images to container
-		if err := oci.ExtractTarballToVolume(d.NodeConfig.OCIBinary, download.TarballPath(d.NodeConfig.KubernetesVersion, d.NodeConfig.ContainerRuntime), params.Name, BaseImage); err != nil {
-			glog.Infof("Unable to extract preloaded tarball to volume: %v", err)
-		} else {
-			glog.Infof("duration metric: took %f seconds to extract preloaded images to volume", time.Since(t).Seconds())
-		}
-	}()
+	if d.NodeConfig.OCIBinary == oci.Docker {
+		waitForPreload.Add(1)
+		go func() {
+			defer waitForPreload.Done()
+			// If preload doesn't exist, don't bother extracting tarball to volume
+			if !download.PreloadExists(d.NodeConfig.KubernetesVersion, d.NodeConfig.ContainerRuntime) {
+				return
+			}
+			t := time.Now()
+			glog.Infof("Starting extracting preloaded images to volume ...")
+			// Extract preloaded images to container
+			if err := oci.ExtractTarballToVolume(d.NodeConfig.OCIBinary, download.TarballPath(d.NodeConfig.KubernetesVersion, d.NodeConfig.ContainerRuntime), params.Name, BaseImage); err != nil {
+				glog.Infof("Unable to extract preloaded tarball to volume: %v", err)
+			} else {
+				glog.Infof("duration metric: took %f seconds to extract preloaded images to volume", time.Since(t).Seconds())
+			}
+		}()
+	} else {
+		// driver == "podman"
+		glog.Info("Driver isn't docker, skipping extracting preloaded images")
+	}
 
 	if err := oci.CreateContainerNode(params); err != nil {
 		return errors.Wrap(err, "create kic node")


### PR DESCRIPTION
The preloaded images will be extracted anyway, using ssh.

But if creating them on the volume before the container is
booted, means that /var will not be fully copied over to it.
And without /var/lib/dpkg and others, kicbase will not boot.
So skip the parallel extraction for podman, do it afterwards.

Probably shouldn't mount all of /var, but just a sub-set...

Closes #8056
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
