### PR TITLE
fix Error getting VM/Host IP address on clean install

### DIFF
--- a/pkg/minikube/cluster/ip.go
+++ b/pkg/minikube/cluster/ip.go
@@ -61,7 +61,7 @@ func HostIP(host *host.Host) (net.IP, error) {
 		}
 		ipRe := regexp.MustCompile(`(?s)Name:\s*` + iface + `.+?IPAddress:\s*(\S+)`)
 		ip := ipRe.FindStringSubmatch(string(ipOut))[1]
-		return ip, nil
+		return net.ParseIP(ip), nil
 	case driver.HyperKit:
 		return net.ParseIP("192.168.64.1"), nil
 	case driver.VMware:

--- a/pkg/minikube/cluster/ip.go
+++ b/pkg/minikube/cluster/ip.go
@@ -55,10 +55,12 @@ func HostIP(host *host.Host) (net.IP, error) {
 		}
 		re := regexp.MustCompile(`hostonlyadapter2="(.*?)"`)
 		iface := re.FindStringSubmatch(string(out))[1]
-		ip, err := getIPForInterface(iface)
-		if err != nil {
+		ipOut, ipErr := exec.Command(driver.VBoxManagePath(), "list", "hostonlyifs").Output()
+		if ipErr != nil {
 			return []byte{}, errors.Wrap(err, "Error getting VM/Host IP address")
 		}
+		ipRe := regexp.MustCompile(`(?s)Name:\s*` + iface + `.+?IPAddress:\s*(\S+)`)
+		ip := ipRe.FindStringSubmatch(string(ipOut))[1]
 		return ip, nil
 	case driver.HyperKit:
 		return net.ParseIP("192.168.64.1"), nil


### PR DESCRIPTION
- replace getIPForInterface with VBoxManage equivalent
- network created by VirtualBox 6.1.6 is named differently then the adapter on Windows 10
- minikube v1.10.0 was failing to start due to net.InterfaceByName is failing inside getIPForInterface

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

### Reproduce the error:

On a clean Windows 10 install with VirtualBox 6.1.6 the Host only adapter name is not matching the network name so `net.InterfaceByName` will fail due to the passed name is not an interface name.

### Error screenshot on clean start

![Screenshot_7](https://user-images.githubusercontent.com/11232402/81714826-2a064480-9480-11ea-9cdb-086635586544.png)
