### PR TITLE
Simplify docs redirect page to avoid content flashing

### DIFF
--- a/site/content/en/_index.html
+++ b/site/content/en/_index.html
@@ -1,21 +1,7 @@
 ---
 title: "minikube"
 ---
-
-
----
-
-# [minikube site](https://minikube.sigs.k8s.io/docs/)
-
-<!-- Sales pitch -->
-{{< blocks/lead >}}
-<h1><a href="https://minikube.sigs.k8s.io/docs/"> minikube docs website </a> </h1>
-
-minikube website has moved to <a href="/docs">/docs</a>
+<a href="/docs">redirecting to /docs</a>
 <script language="javascript">
   window.location.replace("/docs");
 </script>
-
-{{< /blocks/lead >}}
-
-


### PR DESCRIPTION
When users visit https://minikube.sigs.k8s.io/ - they get a flash of content before redirection.

This change makes the redirection much more immediate.