### PR TITLE
docs: Use "_latest" package filenames instead of < latest > tag

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -71,8 +71,6 @@ weight = 1
 
 [params]
 copyright = "The Kubernetes Authors -- "
-# The latest release of minikube
-latest_release = "1.9.2"
 
 privacy_policy = ""
 

--- a/site/content/en/docs/contrib/releasing/binaries.md
+++ b/site/content/en/docs/contrib/releasing/binaries.md
@@ -82,12 +82,6 @@ This file is used for auto-update notifications, but is not active until release
 
 minikube-bot will send out a PR to update the release checksums at the top of `deploy/minikube/releases.json`. You should merge this PR.
 
-## Update documentation link
-
-Update `latest_release` in `site/config.toml`
-
-example: https://github.com/kubernetes/minikube/pull/5413
-
 ## Package managers which include minikube
 
 These are downstream packages that are being maintained by others and how to upgrade them to make sure they have the latest versions

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -36,15 +36,15 @@ For Linux users, we provide 3 easy download options:
 ### Debian package
 
 ```shell
-curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_{{< latest >}}-0_amd64.deb
-sudo dpkg -i minikube_{{< latest >}}-0_amd64.deb
+curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_latest_amd64.deb
+sudo dpkg -i minikube_latest_amd64.deb
 ```
 
 ### RPM package
 
 ```shell
-curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-{{< latest >}}-0.x86_64.rpm
-sudo rpm -ivh minikube-{{< latest >}}-0.x86_64.rpm
+curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest.x86_64.rpm
+sudo rpm -ivh minikube-latest.x86_64.rpm
 ```
 
 {{% /tab %}}

--- a/site/layouts/shortcodes/latest.html
+++ b/site/layouts/shortcodes/latest.html
@@ -1,1 +1,0 @@
-{{ $.Site.Params.latest_release }}


### PR DESCRIPTION
This removes the manual "update the docs version" step from our release process.
