### PR TITLE
retrieve virtual switch name from driver object directly

### DIFF
--- a/pkg/minikube/cluster/ip.go
+++ b/pkg/minikube/cluster/ip.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"os/exec"
+	"reflect"
 	"regexp"
 
 	"github.com/docker/machine/libmachine"
@@ -40,9 +41,18 @@ func HostIP(host *host.Host) (net.IP, error) {
 	case driver.KVM2:
 		return net.ParseIP("192.168.39.1"), nil
 	case driver.HyperV:
-		re := regexp.MustCompile(`"VSwitch": "(.*?)",`)
-		// TODO(aprindle) Change this to deserialize the driver instead
-		hypervVirtualSwitch := re.FindStringSubmatch(string(host.RawDriver))[1]
+		v := reflect.ValueOf(host.Driver).Elem()
+		var hypervVirtualSwitch string
+		// We don't have direct access to hyperv.Driver so use reflection to retrieve the virtual switch name
+		for i := 0; i < v.NumField(); i++ {
+			if v.Type().Field(i).Name == "VSwitch" {
+				hypervVirtualSwitch = v.Field(i).Interface().(string)
+				break
+			}
+		}
+		if hypervVirtualSwitch == "" {
+			return nil, errors.New("No virtual switch found")
+		}
 		ip, err := getIPForInterface(fmt.Sprintf("vEthernet (%s)", hypervVirtualSwitch))
 		if err != nil {
 			return []byte{}, errors.Wrap(err, fmt.Sprintf("ip for interface (%s)", hypervVirtualSwitch))


### PR DESCRIPTION
RawDriver is never being populated anymore by non-legacy drivers, and we never noticed because this code was not called by anything but mount. This is fixed by addressing a long-standing TODO and just grab the wanted value directly from the object instead of counting on RawDriver.

Before
```
* minikube v1.10.0 on Microsoft Windows 10 Pro 10.0.18363 Build 18363
* Automatically selected the hyperv driver. Other choices: docker, virtualbox
* Starting control plane node minikube in cluster minikube
* Creating hyperv VM (CPUs=2, Memory=6000MB, Disk=20000MB) ...
* Preparing Kubernetes v1.18.1 on Docker 19.03.8 ...
panic: runtime error: index out of range [1] with length 0

goroutine 1 [running]:
k8s.io/minikube/pkg/minikube/cluster.HostIP(0xc000a0c240, 0x7, 0x1df4d40, 0xc0004cfcb0, 0x0, 0xc000782690)
        C:/Users/shari/Documents/minikube/pkg/minikube/cluster/ip.go:46 +0xcd5
k8s.io/minikube/pkg/minikube/node.Start(0x1dc3d20, 0xc00059a0a0, 0x0, 0x1de35a0, 0xc0005aa380, 0xc000a0c240, 0xc0003e6e00, 0xc0005aa280, 0xc000535aa0, 0x4e01, ...)
        C:/Users/shari/Documents/minikube/pkg/minikube/node/start.go:93 +0x201
k8s.io/minikube/cmd/minikube/cmd.startWithDriver(0x1dc3d20, 0xc00059a0a0, 0x0, 0x1de35a0, 0xc0005aa380, 0xc000a0c240, 0xc0003e6e00, 0xc0005aa280, 0xc000535aa0, 0x0, ...)
        C:/Users/shari/Documents/minikube/cmd/minikube/cmd/start.go:281 +0x83
k8s.io/minikube/cmd/minikube/cmd.runStart(0x2ac7c40, 0x2b13d10, 0x0, 0x0)
        C:/Users/shari/Documents/minikube/cmd/minikube/cmd/start.go:202 +0x6f3
github.com/spf13/cobra.(*Command).execute(0x2ac7c40, 0x2b13d10, 0x0, 0x0, 0x2ac7c40, 0x2b13d10)
        C:/Users/shari/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:846 +0x2a4
github.com/spf13/cobra.(*Command).ExecuteC(0x2ac6c80, 0x0, 0x0, 0xc00059a201)
        C:/Users/shari/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950 +0x350
github.com/spf13/cobra.(*Command).Execute(...)
        C:/Users/shari/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
k8s.io/minikube/cmd/minikube/cmd.Execute()
        C:/Users/shari/Documents/minikube/cmd/minikube/cmd/root.go:112 +0x6ba
main.main()
        C:/Users/shari/Documents/minikube/cmd/minikube/main.go:66 +0xed
```

After
```
* minikube v1.10.0 on Microsoft Windows 10 Pro 10.0.18363 Build 18363
* Automatically selected the hyperv driver. Other choices: docker, virtualbox
* Starting control plane node minikube in cluster minikube
* Creating hyperv VM (CPUs=2, Memory=6000MB, Disk=20000MB) ...
* Preparing Kubernetes v1.18.1 on Docker 19.03.8 ...
* Verifying Kubernetes components...
* Enabled addons: default-storageclass, storage-provisioner
* Done! kubectl is now configured to use "minikube"
```