### PR TITLE
make deleting orphaned kics optional

### DIFF
--- a/pkg/minikube/machine/cluster_test.go
+++ b/pkg/minikube/machine/cluster_test.go
@@ -339,7 +339,7 @@ func TestDeleteHost(t *testing.T) {
 	cc := defaultClusterConfig
 	cc.Name = viper.GetString("profile")
 
-	if err := DeleteHost(api, driver.MachineName(cc, config.Node{Name: "minikube"})); err != nil {
+	if err := DeleteHost(api, driver.MachineName(cc, config.Node{Name: "minikube"}), false); err != nil {
 		t.Fatalf("Unexpected error deleting host: %v", err)
 	}
 }
@@ -355,7 +355,7 @@ func TestDeleteHostErrorDeletingVM(t *testing.T) {
 	d := &tests.MockDriver{RemoveError: true, T: t}
 	h.Driver = d
 
-	if err := DeleteHost(api, driver.MachineName(defaultClusterConfig, config.Node{Name: "minikube"})); err == nil {
+	if err := DeleteHost(api, driver.MachineName(defaultClusterConfig, config.Node{Name: "minikube"}), false); err == nil {
 		t.Fatal("Expected error deleting host.")
 	}
 }
@@ -368,7 +368,7 @@ func TestDeleteHostErrorDeletingFiles(t *testing.T) {
 		t.Errorf("createHost failed: %v", err)
 	}
 
-	if err := DeleteHost(api, driver.MachineName(defaultClusterConfig, config.Node{Name: "minikube"})); err == nil {
+	if err := DeleteHost(api, driver.MachineName(defaultClusterConfig, config.Node{Name: "minikube"}), false); err == nil {
 		t.Fatal("Expected error deleting host.")
 	}
 }
@@ -383,7 +383,7 @@ func TestDeleteHostErrMachineNotExist(t *testing.T) {
 		t.Errorf("createHost failed: %v", err)
 	}
 
-	if err := DeleteHost(api, driver.MachineName(defaultClusterConfig, config.Node{Name: "minikube"})); err == nil {
+	if err := DeleteHost(api, driver.MachineName(defaultClusterConfig, config.Node{Name: "minikube"}), false); err == nil {
 		t.Fatal("Expected error deleting host.")
 	}
 }

--- a/pkg/minikube/machine/delete.go
+++ b/pkg/minikube/machine/delete.go
@@ -60,9 +60,15 @@ func deleteOrphanedKIC(ociBin string, name string) {
 }
 
 // DeleteHost deletes the host VM.
-func DeleteHost(api libmachine.API, machineName string) error {
+// deleteAbandoned will will try to delete the machine even if there is no minikube config for it.
+func DeleteHost(api libmachine.API, machineName string, deleteAbandoned ...bool) error {
+	delAbandoned := true
+	if len(deleteAbandoned) > 0 {
+		delAbandoned = deleteAbandoned[0]
+	}
+
 	host, err := api.Load(machineName)
-	if err != nil && host == nil {
+	if err != nil && host == nil && delAbandoned {
 		deleteOrphanedKIC(oci.Docker, machineName)
 		deleteOrphanedKIC(oci.Podman, machineName)
 		// Keep going even if minikube does not know about the host


### PR DESCRIPTION
we try to delete abanoned kics, this was making our uni tests slow and flaky because we invoked docker and podman delete on them

closes 
https://github.com/kubernetes/minikube/issues/8069