### PR TITLE
fix virtualbox IP address retrieval

### DIFF
--- a/pkg/minikube/cluster/ip.go
+++ b/pkg/minikube/cluster/ip.go
@@ -65,11 +65,13 @@ func HostIP(host *host.Host) (net.IP, error) {
 		}
 		re := regexp.MustCompile(`hostonlyadapter2="(.*?)"`)
 		iface := re.FindStringSubmatch(string(out))[1]
-		ip, err := getIPForInterface(iface)
+		ipList, err := exec.Command(driver.VBoxManagePath(), "list", "hostonlyifs").Output()
 		if err != nil {
 			return []byte{}, errors.Wrap(err, "Error getting VM/Host IP address")
 		}
-		return ip, nil
+		re = regexp.MustCompile(`(?s)Name:\s*` + iface + `.+IPAddress:\s*(\S+)`)
+		ip := re.FindStringSubmatch(string(ipList))[1]
+		return net.ParseIP(ip), nil
 	case driver.HyperKit:
 		return net.ParseIP("192.168.64.1"), nil
 	case driver.VMware:


### PR DESCRIPTION
Based on #8083 

Thanks to @cprogrammer1994 for finding and fixing the issue initially.

Fixes #7993 

Before
```
* minikube v1.10.0 on Microsoft Windows 10 Pro 10.0.18363 Build 18363
* Using the virtualbox driver based on user configuration
* Starting control plane node minikube in cluster minikube
* Creating virtualbox VM (CPUs=2, Memory=6000MB, Disk=20000MB) ...
* Preparing Kubernetes v1.18.1 on Docker 19.03.8 ...
E0512 16:21:31.787931   15788 start.go:95] Unable to get host IP: Error getting VM/Host IP address: Error finding IPV4 address for VirtualBox Host-Only Ethernet Adapter #2
*
X failed to start node: startup failed: Failed to setup kubeconfig: Error getting VM/Host IP address: Error finding IPV4 address for VirtualBox Host-Only Ethernet Adapter #2
*
* minikube is exiting due to an error. If the above message is not useful, open an issue:
  - https://github.com/kubernetes/minikube/issues/new/choose
```

After
```
* minikube v1.10.0 on Microsoft Windows 10 Pro 10.0.18363 Build 18363
* Using the virtualbox driver based on user configuration
* Starting control plane node minikube in cluster minikube
* Creating virtualbox VM (CPUs=2, Memory=6000MB, Disk=20000MB) ...
* Preparing Kubernetes v1.18.1 on Docker 19.03.8 ...
* Verifying Kubernetes components...
* Enabled addons: default-storageclass, storage-provisioner
* Done! kubectl is now configured to use "minikube"
```