### PR TITLE
Don't have to copy environment for podman build

### DIFF
--- a/site/content/en/docs/handbook/pushing.md
+++ b/site/content/en/docs/handbook/pushing.md
@@ -218,7 +218,7 @@ For more information on the `docker build` command, read the [Docker documentati
 For Podman, use:
 
 ```shell
-sudo -E podman build
+sudo podman build
 ```
 
 For more information on the `podman build` command, read the [Podman documentation](https://github.com/containers/libpod/blob/master/docs/source/markdown/podman-build.1.md) (podman.io).


### PR DESCRIPTION
We did that in order to include BUILDAH_NOPIVOT (fb0a6f4)

But we don't need it anymore, since we moved to using tmpfs
instead of rootfs. So now `pivot_root(8)` is available to us.

So we removed that podman environment variable (ae8894c)
