### PR TITLE
Feature request #7604: use native docker bind mounts with driver-mounts option

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1045,6 +1045,13 @@ func validateFlags(cmd *cobra.Command, drvName string) {
 		exit.UsageT("Sorry, please set the --output flag to one of the following valid options: [text,json]")
 	}
 
+	if cmd.Flags().Changed(driverMounts) && !driver.IsDocker(drvName) {
+		exit.UsageT(
+			"Sorry, provided flag --{{.flag_name}} doesn't supported by {{.name}} driver, use --mount-string instead",
+			out.V{"flag_name": driverMounts, "name": drvName},
+		)
+	}
+
 	validateRegistryMirror()
 }
 

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -105,6 +105,7 @@ const (
 	forceSystemd            = "force-systemd"
 	kicBaseImage            = "base-image"
 	startOutput             = "output"
+	driverMounts            = "driver-mounts"
 )
 
 // initMinikubeFlags includes commandline flags for minikube.
@@ -195,6 +196,11 @@ func initDriverFlags() {
 	startCmd.Flags().String(hypervVirtualSwitch, "", "The hyperv virtual switch name. Defaults to first found. (hyperv driver only)")
 	startCmd.Flags().Bool(hypervUseExternalSwitch, false, "Whether to use external switch over Default Switch if virtual switch not explicitly specified. (hyperv driver only)")
 	startCmd.Flags().String(hypervExternalAdapter, "", "External Adapter on which external switch will be created if no external switch is found. (hyperv driver only)")
+
+	// Driver specific mounts
+	startCmd.Flags().String(driverMounts, "",
+		`Use native driver mounts. Supported drivers:
+		Docker: -v flag(bind mounts). Has no effect in the existing docker container. Additional options rw and Z supported, for example --driver-mounts="/tmp:/tmp:rwZ"`)
 }
 
 // initNetworkingFlags inits the commandline flags for connectivity related flags for start
@@ -291,6 +297,7 @@ func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k
 			NFSSharesRoot:           viper.GetString(nfsSharesRoot),
 			DockerEnv:               config.DockerEnv,
 			DockerOpt:               config.DockerOpt,
+			DriverMounts:            viper.GetString(driverMounts),
 			InsecureRegistry:        insecureRegistry,
 			RegistryMirror:          registryMirror,
 			HostOnlyCIDR:            viper.GetString(hostOnlyCIDR),

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -78,6 +78,7 @@ func (d *Driver) Create() error {
 		ExtraArgs:     []string{"--expose", fmt.Sprintf("%d", d.NodeConfig.APIServerPort)},
 		OCIBinary:     d.NodeConfig.OCIBinary,
 		APIServerPort: d.NodeConfig.APIServerPort,
+		Mounts:        d.NodeConfig.Mounts,
 	}
 
 	defaultNetwork := d.MachineName

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -609,3 +609,39 @@ func iptablesFileExists(ociBin string, nameOrID string) bool {
 	}
 	return true
 }
+
+// CreateMounts use for init mounts configuration, to use it in oci drivers like docker, podman
+func CreateMounts(mountString string) []Mount {
+	var mounts []Mount
+	isReadOnly := true
+	SelinuxRelabel := false
+
+	if mountString == "" {
+		return mounts
+	}
+
+	splittedMounts := strings.Split(mountString, ",")
+	for _, mountString := range splittedMounts {
+		mountPieces := strings.Split(mountString, ":")
+		if len(mountPieces) == 1 {
+			mountPieces = append(mountPieces, mountPieces[0])
+		}
+
+		if len(mountPieces) == 3 {
+			if strings.Contains(mountPieces[2], "rw") {
+				isReadOnly = false
+			}
+			if strings.Contains(mountPieces[2], "Z") {
+				SelinuxRelabel = true
+			}
+		}
+		mounts = append(mounts, Mount{
+			ContainerPath:  mountPieces[1],
+			HostPath:       mountPieces[0],
+			Readonly:       isReadOnly,
+			SelinuxRelabel: SelinuxRelabel,
+		})
+	}
+
+	return mounts
+}

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -70,6 +70,7 @@ type ClusterConfig struct {
 	Addons                  map[string]bool
 	VerifyComponents        map[string]bool // map of components to verify and wait for after start.
 	StartHostTimeout        time.Duration
+	DriverMounts            string
 }
 
 // KubernetesConfig contains the parameters used to configure the VM Kubernetes.

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -59,6 +59,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		APIServerPort:     cc.Nodes[0].Port,
 		KubernetesVersion: cc.KubernetesConfig.KubernetesVersion,
 		ContainerRuntime:  cc.KubernetesConfig.ContainerRuntime,
+		Mounts:            oci.CreateMounts(cc.DriverMounts),
 	}), nil
 }
 

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -42,6 +42,8 @@ minikube start [flags]
       --docker-opt stringArray            Specify arbitrary flags to pass to the Docker daemon. (format: key=value)
       --download-only                     If true, only download and cache files for later use - don't install or start anything.
       --driver string                     Used to specify the driver to run Kubernetes in. The list of available drivers depends on operating system.
+      --driver-mounts string              Use native driver mounts. Supported drivers:
+                                          		Docker: -v flag(bind mounts). Has no effect in the existing docker container. Additional options rw and Z supported, for example --driver-mounts="/tmp:/tmp:rwZ"
       --dry-run                           dry-run mode. Validates configuration, but does not mutate system state
       --embed-certs                       if true, will embed the certs in kubeconfig.
       --enable-default-cni                DEPRECATED: Replaced by --cni=bridge


### PR DESCRIPTION
Hello everyone! I added new feature for native driver mount **--driver-mounts** by request https://github.com/kubernetes/minikube/issues/7604. 
At this pr, only docker driver supported. Usage example:
`minikube start --driver=docker --driver-mounts=/tmp:/opt/tmp`

Here is test example output:
(⎈ |N/A:default)➜  minikube git:(fix-7604) mkdir /tmp/123
(⎈ |N/A:default)➜  minikube git:(fix-7604) echo "test" > /tmp/123/file.txt
(⎈ |N/A:default)➜  minikube git:(fix-7604) ./out/minikube-linux-amd64 start -p minikube-test --driver=docker --driver-mounts="/tmp/123:/tmp/123:rw"
😄  [minikube-test] minikube v1.12.1 on Arch 20.0.3
    ▪ KUBECONFIG=/home/eth/.kube/config
✨  Using the docker driver based on user configuration
👍  Starting control plane node minikube-test in cluster minikube-test
🚜  Pulling base image ...
💾  Downloading Kubernetes v1.18.3 preload ...
    > preloaded-images-k8s-v4-v1.18.3-docker-overlay2-amd64.tar.lz4: 526.27 MiB
🔥  Creating docker container (CPUs=2, Memory=3900MB) ...
🐳  Preparing Kubernetes v1.18.3 on Docker 19.03.8 ...
🔎  Verifying Kubernetes components...
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube-test"
(⎈ |minikube-test:default)➜  minikube git:(fix-7604) docker inspect -f '{{ .Mounts }}' minikube-test
[{bind  /lib/modules /lib/modules  ro false rprivate} {volume minikube-test /var/lib/docker/volumes/minikube-test/_data /var local z true } {bind  /tmp/123 /tmp/123   true rprivate}]
(⎈ |minikube-test:default)➜  minikube git:(fix-7604) docker exec minikube-test ls /tmp/123
file.txt
(⎈ |minikube-test:default)➜  minikube git:(fix-7604) docker exec minikube-test cat /tmp/123/file.txt                                     
test
(⎈ |minikube-test:default)➜  minikube git:(fix-7604) docker exec minikube-test sh -c "echo 123 > /tmp/123/file.txt"
(⎈ |minikube-test:default)➜  minikube git:(fix-7604) echo /tmp/123/file.txt 
/tmp/123/file.txt
(⎈ |minikube-test:default)➜  minikube git:(fix-7604) 


![Screenshot_20200802_111301](https://user-images.githubusercontent.com/944617/89118801-5646c580-d4b1-11ea-9731-a48600c8dd04.png)

