### PR TITLE
do not delete generated certs for functional test

### DIFF
--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -69,14 +69,6 @@ func TestFunctional(t *testing.T) {
 		if err := os.Remove(p); err != nil {
 			t.Logf("unable to remove %q: %v", p, err)
 		}
-		p = localTestCertPath()
-		if err := os.Remove(p); err != nil {
-			t.Logf("unable to remove %q: %v", p, err)
-		}
-		p = localEmptyCertPath()
-		if err := os.Remove(p); err != nil {
-			t.Logf("unable to remove %q: %v", p, err)
-		}
 
 		Cleanup(t, profile, cancel)
 	}()


### PR DESCRIPTION
Other tests can pick up these certs then will randomly fail if they are deleted in parallel.

Fixes #8141