### PR TITLE
Fix some minor gofmt and golint issues

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -353,7 +353,7 @@ func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k
 
 // updateExistingConfigFromFlags will update the existing config from the flags - used on a second start
 // skipping updating existing docker env , docker opt, InsecureRegistry, registryMirror, extra-config, apiserver-ips
-func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterConfig) config.ClusterConfig { //nolint to supress cyclomatic complexity 45 of func `updateExistingConfigFromFlags` is high (> 30)
+func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterConfig) config.ClusterConfig { //nolint to suppress cyclomatic complexity 45 of func `updateExistingConfigFromFlags` is high (> 30)
 	validateFlags(cmd, existing.Driver)
 
 	if cmd.Flags().Changed(containerRuntime) {

--- a/pkg/generate/rewrite.go
+++ b/pkg/generate/rewrite.go
@@ -33,7 +33,7 @@ type rewrite struct {
 // outputs possible drivers for the operating system
 func rewriteFlags(command *cobra.Command) error {
 	rewrites := map[string][]rewrite{
-		"start": []rewrite{{
+		"start": {{
 			flag:  "driver",
 			usage: "Used to specify the driver to run Kubernetes in. The list of available drivers depends on operating system.",
 		}, {

--- a/pkg/minikube/bootstrapper/bsutil/kverify/kverify.go
+++ b/pkg/minikube/bootstrapper/bsutil/kverify/kverify.go
@@ -31,7 +31,7 @@ const (
 	SystemPodsWaitKey = "system_pods"
 	// DefaultSAWaitKey is the name used in the flags for default service account
 	DefaultSAWaitKey = "default_sa"
-	// AppsRunning is the name used in the flags for waiting for k8s-apps to be running
+	// AppsRunningKey is the name used in the flags for waiting for k8s-apps to be running
 	AppsRunningKey = "apps_running"
 	// NodeReadyKey is the name used in the flags for waiting for the node status to be ready
 	NodeReadyKey = "node_ready"

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -51,7 +51,7 @@ const (
 	DefaultServiceCIDR = "10.96.0.0/12"
 	// HostAlias is a DNS alias to the the container/VM host IP
 	HostAlias = "host.minikube.internal"
-	// ControlPaneAlias is a DNS alias pointing to the apiserver frontend
+	// ControlPlaneAlias is a DNS alias pointing to the apiserver frontend
 	ControlPlaneAlias = "control-plane.minikube.internal"
 
 	// DockerHostEnv is used for docker daemon settings

--- a/pkg/minikube/perf/binary.go
+++ b/pkg/minikube/perf/binary.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/constants"
 )
 
+// Binary holds a minikube binary
 type Binary struct {
 	path string
 	pr   int


### PR DESCRIPTION
So that "make gofmt" and "make golint" go green again

See https://goreportcard.com/report/github.com/kubernetes/minikube