### PR TITLE
add new --extra-config option "scheduler"

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -873,7 +873,7 @@ func validateFlags(cmd *cobra.Command, drvName string) {
 	}
 
 	// validate kubeadm extra args
-	if invalidOpts := bsutil.FindInvalidExtraConfigFlags(config.ExtraOptions); invalidOpts != nil {
+	if invalidOpts := bsutil.FindInvalidExtraConfigFlags(config.ExtraOptions); len(invalidOpts) > 0 {
 		out.ErrT(
 			out.Warning,
 			"These --extra-config parameters are invalid: {{.invalid_extra_opts}}",

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -872,6 +872,20 @@ func validateFlags(cmd *cobra.Command, drvName string) {
 		}
 	}
 
+	// validate kubeadm extra args
+	if invalidOpts := bsutil.FindInvalidExtraConfigFlags(config.ExtraOptions); invalidOpts != nil {
+		out.ErrT(
+			out.Warning,
+			"These --extra-config parameters are invalid: {{.invalid_extra_opts}}",
+			out.V{"invalid_extra_opts": invalidOpts},
+		)
+		exit.WithCodeT(
+			exit.Config,
+			"Valid components are: {{.valid_extra_opts}}",
+			out.V{"valid_extra_opts": bsutil.KubeadmExtraConfigOpts},
+		)
+	}
+
 	// check that kubeadm extra args contain only allowed parameters
 	for param := range config.ExtraOptions.AsMap().Get(bsutil.Kubeadm) {
 		if !config.ContainsParam(bsutil.KubeadmExtraArgsAllowed[bsutil.KubeadmCmdParam], param) &&

--- a/pkg/minikube/bootstrapper/bsutil/extraconfig.go
+++ b/pkg/minikube/bootstrapper/bsutil/extraconfig.go
@@ -136,7 +136,7 @@ func newComponentOptions(opts config.ExtraOptionSlice, version semver.Version, f
 	var kubeadmExtraArgs []componentOptions
 	for _, extraOpt := range opts {
 		if _, ok := componentToKubeadmConfigKey[extraOpt.Component]; !ok {
-			return nil, fmt.Errorf("unknown component %q. valid components are: %v", componentToKubeadmConfigKey, componentToKubeadmConfigKey)
+			return nil, fmt.Errorf("unknown component %q. valid components are: %v", extraOpt.Component, componentToKubeadmConfigKey)
 		}
 	}
 

--- a/pkg/minikube/bootstrapper/bsutil/extraconfig.go
+++ b/pkg/minikube/bootstrapper/bsutil/extraconfig.go
@@ -148,7 +148,7 @@ func defaultOptionsForComponentAndVersion(component string, version semver.Versi
 
 // newComponentOptions creates a new componentOptions
 func newComponentOptions(opts config.ExtraOptionSlice, version semver.Version, featureGates string, cp config.Node) ([]componentOptions, error) {
-	if invalidOpts := FindInvalidExtraConfigFlags(opts); invalidOpts != nil {
+	if invalidOpts := FindInvalidExtraConfigFlags(opts); len(invalidOpts) > 0 {
 		return nil, fmt.Errorf("unknown components %v. valid components are: %v", invalidOpts, KubeadmExtraConfigOpts)
 	}
 

--- a/pkg/minikube/bootstrapper/bsutil/extraconfig.go
+++ b/pkg/minikube/bootstrapper/bsutil/extraconfig.go
@@ -134,17 +134,17 @@ func defaultOptionsForComponentAndVersion(component string, version semver.Versi
 // newComponentOptions creates a new componentOptions
 func newComponentOptions(opts config.ExtraOptionSlice, version semver.Version, featureGates string, cp config.Node) ([]componentOptions, error) {
 	var kubeadmExtraArgs []componentOptions
-	for _, extraOpt := range opts {
-		if _, ok := componentToKubeadmConfigKey[extraOpt.Component]; !ok {
-			return nil, fmt.Errorf("unknown component %q. valid components are: %v", extraOpt.Component, componentToKubeadmConfigKey)
-		}
-	}
-
 	keys := []string{}
 	for k := range componentToKubeadmConfigKey {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
+
+	for _, extraOpt := range opts {
+		if _, ok := componentToKubeadmConfigKey[extraOpt.Component]; !ok {
+			return nil, fmt.Errorf("unknown component %q. valid components are: %v", extraOpt.Component, keys)
+		}
+	}
 
 	for _, component := range keys {
 		kubeadmComponentKey := componentToKubeadmConfigKey[component]

--- a/pkg/minikube/bootstrapper/bsutil/extraconfig_test.go
+++ b/pkg/minikube/bootstrapper/bsutil/extraconfig_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package bsutil will eventually be renamed to kubeadm package after getting rid of older one
+package bsutil
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/minikube/pkg/minikube/config"
+)
+
+func TestFindInvalidExtraConfigFlags(t *testing.T) {
+	defaultOpts := getExtraOpts()
+	badOption1 := config.ExtraOption{Component: "bad_option_1"}
+	badOption2 := config.ExtraOption{Component: "bad_option_2"}
+	tests := []struct {
+		name string
+		opts config.ExtraOptionSlice
+		want []string
+	}{
+		{
+			name: "with valid options only",
+			opts: defaultOpts,
+			want: nil,
+		},
+		{
+			name: "with invalid options",
+			opts: append(defaultOpts, badOption1, badOption2),
+			want: []string{"bad_option_1", "bad_option_2"},
+		},
+		{
+			name: "with invalid options and duplicates",
+			opts: append(defaultOpts, badOption2, badOption1, badOption1),
+			want: []string{"bad_option_2", "bad_option_1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FindInvalidExtraConfigFlags(tt.opts); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FindInvalidExtraConfigFlags() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/minikube/bootstrapper/bsutil/kubeadm.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubeadm.go
@@ -147,14 +147,24 @@ func GenerateKubeadmYAML(cc config.ClusterConfig, n config.Node, r cruntime.Mana
 // These are the components that can be configured
 // through the "extra-config"
 const (
-	Kubelet           = "kubelet"
-	Kubeadm           = "kubeadm"
 	Apiserver         = "apiserver"
-	Scheduler         = "scheduler"
 	ControllerManager = "controller-manager"
+	Kubeadm           = "kubeadm"
+	Kubelet           = "kubelet"
 	Kubeproxy         = "kube-proxy"
+	Scheduler         = "scheduler"
 	Etcd              = "etcd"
 )
+
+// KubeadmExtraConfigOpts is a list of allowed "extra-config" components
+var KubeadmExtraConfigOpts = []string{
+	Apiserver,
+	ControllerManager,
+	Kubeadm,
+	Kubelet,
+	Kubeproxy,
+	Scheduler,
+}
 
 // InvokeKubeadm returns the invocation command for Kubeadm
 func InvokeKubeadm(version string) string {

--- a/pkg/minikube/bootstrapper/bsutil/kubeadm.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubeadm.go
@@ -160,10 +160,11 @@ const (
 var KubeadmExtraConfigOpts = []string{
 	Apiserver,
 	ControllerManager,
+	Scheduler,
+	Etcd,
 	Kubeadm,
 	Kubelet,
 	Kubeproxy,
-	Scheduler,
 }
 
 // InvokeKubeadm returns the invocation command for Kubeadm

--- a/pkg/minikube/bootstrapper/bsutil/kubeadm.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubeadm.go
@@ -149,11 +149,11 @@ func GenerateKubeadmYAML(cc config.ClusterConfig, n config.Node, r cruntime.Mana
 const (
 	Apiserver         = "apiserver"
 	ControllerManager = "controller-manager"
-	Kubeadm           = "kubeadm"
-	Kubelet           = "kubelet"
-	Kubeproxy         = "kube-proxy"
 	Scheduler         = "scheduler"
 	Etcd              = "etcd"
+	Kubeadm           = "kubeadm"
+	Kubeproxy         = "kube-proxy"
+	Kubelet           = "kubelet"
 )
 
 // KubeadmExtraConfigOpts is a list of allowed "extra-config" components


### PR DESCRIPTION
This PR fixes the error message for the `--extra-config` option parsing for the `minikube start` command (also mentioned in https://github.com/kubernetes/minikube/issues/6689).
Seems like it was a simple copy-paste issue in the original commit.

Example:

`minikube start --extra-config=kubeProxy.IPTables.SyncPeriod.Duration=5000000000`

Before (failing during the process of setup):

```
X Failed to update cluster: updating node: generating kubeadm cfg: generating extra component config for kubeadm: unknown component map["apiserver":"apiServer" "controller-manager":"controllerManager" "kube-proxy":"" "kubeadm":"kubeadm" "kubelet":"" "scheduler":"scheduler"]. valid components are: map[apiserver:apiServer controller-manager:controllerManager kube-proxy: kubeadm:kubeadm kubelet: scheduler:scheduler]
```

After (validation check during the initialization):

```
❗	These --extra-config parameters are invalid: [kubeProxy]
💣	Valid components are: [apiserver controller-manager kubeadm kubelet kube-proxy scheduler]
```