### PR TITLE
experiment: add a single quote for docker/podman inspect formats

### DIFF
--- a/pkg/drivers/kic/oci/network.go
+++ b/pkg/drivers/kic/oci/network.go
@@ -61,7 +61,7 @@ func digDNS(ociBin, containerName, dns string) (net.IP, error) {
 // dockerGatewayIP gets the default gateway ip for the docker bridge on the user's host machine
 // gets the ip from user's host docker
 func dockerGatewayIP() (net.IP, error) {
-	rr, err := runCmd(exec.Command(Docker, "network", "ls", "--filter", "name=bridge", "--format", "{{.ID}}"))
+	rr, err := runCmd(exec.Command(Docker, "network", "ls", "--filter", "name=bridge", "--format", "'{{.ID}}'"))
 	if err != nil {
 		return nil, errors.Wrapf(err, "get network bridge")
 	}
@@ -80,7 +80,7 @@ func dockerGatewayIP() (net.IP, error) {
 
 // containerGatewayIP gets the default gateway ip for the container
 func containerGatewayIP(ociBin, containerName string) (net.IP, error) {
-	rr, err := runCmd(exec.Command(ociBin, "inspect", "--format", "{{.NetworkSettings.Gateway}}", containerName))
+	rr, err := runCmd(exec.Command(ociBin, "inspect", "--format", "'{{.NetworkSettings.Gateway}}'", containerName))
 	if err != nil {
 		return nil, errors.Wrapf(err, "inspect gateway")
 	}
@@ -99,7 +99,7 @@ func ForwardedPort(ociBin string, ociID string, contPort int) (int, error) {
 
 	if ociBin == Podman {
 		//podman inspect -f "{{range .NetworkSettings.Ports}}{{if eq .ContainerPort "80"}}{{.HostPort}}{{end}}{{end}}"
-		rr, err = runCmd(exec.Command(ociBin, "inspect", "-f", fmt.Sprintf("{{range .NetworkSettings.Ports}}{{if eq .ContainerPort %s}}{{.HostPort}}{{end}}{{end}}", fmt.Sprint(contPort)), ociID))
+		rr, err = runCmd(exec.Command(ociBin, "inspect", "-f", fmt.Sprintf("'{{range .NetworkSettings.Ports}}{{if eq .ContainerPort %s}}{{.HostPort}}{{end}}{{end}}'", fmt.Sprint(contPort)), ociID))
 		if err != nil {
 			return 0, errors.Wrapf(err, "get port %d for %q", contPort, ociID)
 		}
@@ -132,7 +132,7 @@ func ContainerIPs(ociBin string, name string) (string, string, error) {
 // podmanConttainerIP returns ipv4, ipv6 of container or error
 func podmanConttainerIP(name string) (string, string, error) {
 	rr, err := runCmd(exec.Command(Podman, "inspect",
-		"-f", "{{.NetworkSettings.IPAddress}}",
+		"-f", "'{{.NetworkSettings.IPAddress}}'",
 		name))
 	if err != nil {
 		return "", "", errors.Wrapf(err, "podman inspect ip %s", name)
@@ -147,7 +147,7 @@ func podmanConttainerIP(name string) (string, string, error) {
 // dockerContainerIP returns ipv4, ipv6 of container or error
 func dockerContainerIP(name string) (string, string, error) {
 	// retrieve the IP address of the node using docker inspect
-	lines, err := inspect(Docker, name, "{{range .NetworkSettings.Networks}}{{.IPAddress}},{{.GlobalIPv6Address}}{{end}}")
+	lines, err := inspect(Docker, name, "'{{range .NetworkSettings.Networks}}{{.IPAddress}},{{.GlobalIPv6Address}}{{end}}'")
 	if err != nil {
 		return "", "", errors.Wrap(err, "inspecting NetworkSettings.Networks")
 	}

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -277,7 +277,7 @@ func StartContainer(ociBin string, container string) error {
 
 // ContainerID returns id of a container name
 func ContainerID(ociBin string, nameOrID string) (string, error) {
-	rr, err := runCmd(exec.Command(ociBin, "inspect", "-f", "{{.Id}}", nameOrID))
+	rr, err := runCmd(exec.Command(ociBin, "inspect", "-f", "'{{.Id}}'", nameOrID))
 	if err != nil { // don't return error if not found, only return empty string
 		if strings.Contains(rr.Stdout.String(), "Error: No such object:") || strings.Contains(rr.Stdout.String(), "unable to find") {
 			err = nil
@@ -289,7 +289,7 @@ func ContainerID(ociBin string, nameOrID string) (string, error) {
 
 // ContainerExists checks if container name exists (either running or exited)
 func ContainerExists(ociBin string, name string, warnSlow ...bool) (bool, error) {
-	rr, err := runCmd(exec.Command(ociBin, "ps", "-a", "--format", "{{.Names}}"), warnSlow...)
+	rr, err := runCmd(exec.Command(ociBin, "ps", "-a", "--format", "'{{.Names}}'"), warnSlow...)
 	if err != nil {
 		return false, err
 	}
@@ -307,7 +307,7 @@ func ContainerExists(ociBin string, name string, warnSlow ...bool) (bool, error)
 // IsCreatedByMinikube returns true if the container was created by minikube
 // with default assumption that it is not created by minikube when we don't know for sure
 func IsCreatedByMinikube(ociBin string, nameOrID string) bool {
-	rr, err := runCmd(exec.Command(ociBin, "inspect", nameOrID, "--format", "{{.Config.Labels}}"))
+	rr, err := runCmd(exec.Command(ociBin, "inspect", nameOrID, "--format", "'{{.Config.Labels}}'"))
 	if err != nil {
 		return false
 	}
@@ -452,7 +452,7 @@ func withPortMappings(portMappings []PortMapping) createOpt {
 
 // ListContainersByLabel returns all the container names with a specified label
 func ListContainersByLabel(ociBin string, label string, warnSlow ...bool) ([]string, error) {
-	rr, err := runCmd(exec.Command(ociBin, "ps", "-a", "--filter", fmt.Sprintf("label=%s", label), "--format", "{{.Names}}"), warnSlow...)
+	rr, err := runCmd(exec.Command(ociBin, "ps", "-a", "--filter", fmt.Sprintf("label=%s", label), "--format", "'{{.Names}}'"), warnSlow...)
 	if err != nil {
 		return nil, err
 	}
@@ -506,7 +506,7 @@ func PointToHostPodman() error {
 
 // ContainerRunning returns running state of a container
 func ContainerRunning(ociBin string, name string, warnSlow ...bool) (bool, error) {
-	rr, err := runCmd(exec.Command(ociBin, "inspect", name, "--format={{.State.Running}}"), warnSlow...)
+	rr, err := runCmd(exec.Command(ociBin, "inspect", name, "--format='{{.State.Running}}'"), warnSlow...)
 	if err != nil {
 		return false, err
 	}
@@ -515,7 +515,7 @@ func ContainerRunning(ociBin string, name string, warnSlow ...bool) (bool, error
 
 // ContainerStatus returns status of a container running,exited,...
 func ContainerStatus(ociBin string, name string, warnSlow ...bool) (state.State, error) {
-	cmd := exec.Command(ociBin, "inspect", name, "--format={{.State.Status}}")
+	cmd := exec.Command(ociBin, "inspect", name, "--format='{{.State.Status}}'")
 	rr, err := runCmd(cmd, warnSlow...)
 	o := strings.TrimSpace(rr.Stdout.String())
 	switch o {

--- a/pkg/drivers/kic/oci/volumes.go
+++ b/pkg/drivers/kic/oci/volumes.go
@@ -66,7 +66,7 @@ func PruneAllVolumesByLabel(ociBin string, label string, warnSlow ...bool) []err
 // allVolumesByLabel returns name of all docker volumes by a specific label
 // will not return error if there is no volume found.
 func allVolumesByLabel(ociBin string, label string) ([]string, error) {
-	rr, err := runCmd(exec.Command(ociBin, "volume", "ls", "--filter", "label="+label, "--format", "{{.Name}}"))
+	rr, err := runCmd(exec.Command(ociBin, "volume", "ls", "--filter", "label="+label, "--format", "'{{.Name}}'"))
 	s := bufio.NewScanner(bytes.NewReader(rr.Stdout.Bytes()))
 	var vols []string
 	for s.Scan() {


### PR DESCRIPTION
when trying to add windows to azure, I saw this be a source of problem where minikube created docker container but after when it was trying to inspect it couldnt work. manually I had to add a single quote. hopefully this doesn't break podman and others