### PR TITLE
Bump helm-tiller 2.16.7 and promote tiller ClusterRoleBinding to v1

### DIFF
--- a/deploy/addons/helm-tiller/helm-tiller-dp.tmpl
+++ b/deploy/addons/helm-tiller/helm-tiller-dp.tmpl
@@ -46,7 +46,7 @@ spec:
               value: kube-system
             - name: TILLER_HISTORY_MAX
               value: "0"
-          image: gcr.io/kubernetes-helm/tiller:v2.16.3
+          image: gcr.io/kubernetes-helm/tiller:v2.16.7
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3

--- a/deploy/addons/helm-tiller/helm-tiller-rbac.tmpl
+++ b/deploy/addons/helm-tiller/helm-tiller-rbac.tmpl
@@ -24,7 +24,7 @@ metadata:
     kubernetes.io/minikube-addons: helm
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: tiller-clusterrolebinding
   labels:


### PR DESCRIPTION
### What type of PR is this?
/area addons

### What this PR does / why we need it:

This is small PR.
This bump up helm-tiller addon's image v2.16.3 to v2.16.7 and promote ClusterRoleBinding to v1.

### Which issue(s) this PR fixes:

Fixes #8173 

### Does this PR introduce a user-facing change?

Yes.
This image bumpup includes some helm2 bug fixes.
https://github.com/helm/helm/releases/tag/v2.16.7

**Before**
```
image: gcr.io/kubernetes-helm/tiller:v2.16.3
```

**After**
```
image: gcr.io/kubernetes-helm/tiller:v2.16.7
```

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```