### PR TITLE
fix proxy env not being passed to docker engine

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -56,7 +56,6 @@ import (
 	"k8s.io/minikube/pkg/minikube/node"
 	"k8s.io/minikube/pkg/minikube/notify"
 	"k8s.io/minikube/pkg/minikube/out"
-	"k8s.io/minikube/pkg/minikube/proxy"
 	"k8s.io/minikube/pkg/minikube/registry"
 	"k8s.io/minikube/pkg/minikube/translate"
 	"k8s.io/minikube/pkg/util"
@@ -907,24 +906,6 @@ func createNode(cc config.ClusterConfig, kubeNodeName string, existing *config.C
 	}
 	cc.Nodes = []config.Node{cp}
 	return cc, cp, nil
-}
-
-// setDockerProxy sets the proxy environment variables in the docker environment.
-func setDockerProxy() {
-	for _, k := range proxy.EnvVars {
-		if v := os.Getenv(k); v != "" {
-			// convert https_proxy to HTTPS_PROXY for linux
-			// TODO (@medyagh): if user has both http_proxy & HTTPS_PROXY set merge them.
-			k = strings.ToUpper(k)
-			if k == "HTTP_PROXY" || k == "HTTPS_PROXY" {
-				if strings.HasPrefix(v, "localhost") || strings.HasPrefix(v, "127.0") {
-					out.WarningT("Not passing {{.name}}={{.value}} to docker env.", out.V{"name": k, "value": v})
-					continue
-				}
-			}
-			config.DockerEnv = append(config.DockerEnv, fmt.Sprintf("%s=%s", k, v))
-		}
-	}
 }
 
 // autoSetDriverOptions sets the options needed for specific driver automatically.

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -341,7 +341,7 @@ func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k
 
 	// Feed Docker our host proxy environment by default, so that it can pull images
 	// doing this for both new config and existing, in case proxy changed since previous start
-	if _, ok := r.(*cruntime.Docker); ok && !cmd.Flags().Changed("docker-env") {
+	if _, ok := r.(*cruntime.Docker); ok {
 		proxy.SetDockerEnv()
 	}
 

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/out"
+	"k8s.io/minikube/pkg/minikube/proxy"
 	pkgutil "k8s.io/minikube/pkg/util"
 	"k8s.io/minikube/pkg/version"
 )
@@ -341,7 +342,7 @@ func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k
 	// Feed Docker our host proxy environment by default, so that it can pull images
 	// doing this for both new config and existing, in case proxy changed since previous start
 	if _, ok := r.(*cruntime.Docker); ok && !cmd.Flags().Changed("docker-env") {
-		setDockerProxy()
+		proxy.SetDockerEnv()
 	}
 
 	var kubeNodeName string

--- a/pkg/minikube/machine/cluster_test.go
+++ b/pkg/minikube/machine/cluster_test.go
@@ -290,7 +290,7 @@ func TestStartHostConfig(t *testing.T) {
 
 	for i := range h.HostOptions.EngineOptions.Env {
 		if h.HostOptions.EngineOptions.Env[i] != cfg.DockerEnv[i] {
-			t.Fatalf("Docker env variables were not set! got %+v but want %+v",h.HostOptions.EngineOptions.Env,cfg.DockerEnv)
+			t.Fatalf("Docker env variables were not set! got %+v but want %+v", h.HostOptions.EngineOptions.Env, cfg.DockerEnv)
 		}
 	}
 

--- a/pkg/minikube/machine/cluster_test.go
+++ b/pkg/minikube/machine/cluster_test.go
@@ -290,7 +290,7 @@ func TestStartHostConfig(t *testing.T) {
 
 	for i := range h.HostOptions.EngineOptions.Env {
 		if h.HostOptions.EngineOptions.Env[i] != cfg.DockerEnv[i] {
-			t.Fatal("Docker env variables were not set!")
+			t.Fatalf("Docker env variables were not set! got %+v but want %+v",h.HostOptions.EngineOptions.Env,cfg.DockerEnv)
 		}
 	}
 

--- a/pkg/minikube/machine/start.go
+++ b/pkg/minikube/machine/start.go
@@ -107,9 +107,6 @@ func engineOptions(cfg config.ClusterConfig) *engine.Options {
 		}
 	}
 
-	// config.DockerEnv is a global so we update that one too
-	config.DockerEnv = uniqueEnvs
-
 	o := engine.Options{
 		Env:              uniqueEnvs,
 		InsecureRegistry: append([]string{constants.DefaultServiceCIDR}, cfg.InsecureRegistry...),

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -410,7 +410,8 @@ func validateNetwork(h *host.Host, r command.Runner, imageRepository string) (st
 			ipExcluded := proxy.IsIPExcluded(ip) // Skip warning if minikube ip is already in NO_PROXY
 			k = strings.ToUpper(k)               // for http_proxy & https_proxy
 			if (k == "HTTP_PROXY" || k == "HTTPS_PROXY") && !ipExcluded && !warnedOnce {
-				out.WarningT("You appear to be using a proxy, but your NO_PROXY environment does not include the minikube IP ({{.ip_address}}). Please see {{.documentation_url}} for more details", out.V{"ip_address": ip, "documentation_url": "https://minikube.sigs.k8s.io/docs/handbook/vpn_and_proxy/"})
+				out.WarningT("You appear to be using a proxy, but your NO_PROXY environment does not include the minikube IP ({{.ip_address}}).", out.V{"ip_address": ip})
+				out.T(out.Documentation, "Please see {{.documentation_url}} for more details", out.V{"documentation_url": "https://minikube.sigs.k8s.io/docs/handbook/vpn_and_proxy/"})
 				warnedOnce = true
 			}
 		}

--- a/pkg/minikube/proxy/proxy.go
+++ b/pkg/minikube/proxy/proxy.go
@@ -168,5 +168,17 @@ func SetDockerEnv() []string {
 			config.DockerEnv = append(config.DockerEnv, fmt.Sprintf("%s=%s", k, v))
 		}
 	}
+
+	// remove duplicates
+	seen := map[string]bool{}
+	uniqueEnvs := []string{}
+	for e := range config.DockerEnv {
+		if !seen[config.DockerEnv[e]] {
+			seen[config.DockerEnv[e]] = true
+			uniqueEnvs = append(uniqueEnvs, config.DockerEnv[e])
+		}
+	}
+	config.DockerEnv = uniqueEnvs
+
 	return config.DockerEnv
 }


### PR DESCRIPTION
closes a regression fixes  https://github.com/kubernetes/minikube/issues/8120

## before this PR
```
make && HTTP_PROXY=192.167.1.113:1313 ./out/minikube start --driver=hyperkit
minikube ssh
$ cat /lib/systemd/system/docker.service | grep Env
(empty)
```
## after this PR

```
make && HTTP_PROXY=192.167.1.113:1313 ./out/minikube start --driver=hyperkit
minikube ssh
$ cat /lib/systemd/system/docker.service | grep Env
Environment=HTTP_PROXY=192.167.1.113:1313
```


### also improve the icon for proxy

### before
```
😄  minikube v1.10.1 on Darwin 10.13.6
✨  Using the docker driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🔥  Creating docker container (CPUs=2, Memory=4000MB) ...
🌐  Found network options:
    ▪ HTTP_PROXY=192.167.1.113:1313
❗  You appear to be using a proxy, but your NO_PROXY environment does not include the minikube IP (172.17.0.3). Please see https://minikube.sigs.k8s.io/docs/handbook/vpn_and_proxy/ for more details
```

### after
```
😄  minikube v1.10.1 on Darwin 10.13.6
✨  Using the docker driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🔥  Creating docker container (CPUs=2, Memory=4000MB) ...
🌐  Found network options:
    ▪ HTTP_PROXY=192.167.1.113:1313
❗  You appear to be using a proxy, but your NO_PROXY environment does not include the minikube IP (172.17.0.3).
📘  Please see https://minikube.sigs.k8s.io/docs/handbook/vpn_and_proxy/ for more details
🐳  Preparing Kubernetes v1.18.2 on Docker 19.03.2 ...
```