### PR TITLE
Avoid image builders to hang on registry port 443

### DIFF
--- a/deploy/addons/registry/registry-svc.yaml.tmpl
+++ b/deploy/addons/registry/registry-svc.yaml.tmpl
@@ -10,7 +10,11 @@ spec:
   type: ClusterIP
   ports:
   - port: 80
+    name: http
     targetPort: 5000
+  - port: 443
+    name: https
+    targetPort: 443
   selector:
     actual-registry: "true"
     kubernetes.io/minikube-addons: registry


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

This adds a mapping for the 443 port on the registry, because image publishers, in case of insecure registries, first try to contact port 443, then fallback on port 80.

But if port 443 is not mapped to the container (even on a closed port of the container, as in this case), then the application remains stuck until a timeout occurs. This in the end leads to really slow times for publishing an image.

This is happening e.g. in https://github.com/GoogleContainerTools/kaniko/issues/1013
