### PR TITLE
exit with usage when need login to image registry

### DIFF
--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -34,7 +34,7 @@ const (
 
 var (
 	// BaseImage is the base image is used to spin up kic containers. it uses same base-image as kind.
-	BaseImage = fmt.Sprintf("gcr.io/k8s-minikube/kicbase:%s@sha256:%s", Version, baseImageSHA)
+	BaseImage = fmt.Sprintf("gcr.io/k8s-minikube/kicbase1:%s@sha256:%s", Version, baseImageSHA)
 	// BaseImageFallBack the fall back of BaseImage in case gcr.io is not available. stored in github packages https://github.com/kubernetes/minikube/packages/206071
 	// github packages docker does _NOT_ support pulling by sha as mentioned in the docs:
 	// https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -34,7 +34,7 @@ const (
 
 var (
 	// BaseImage is the base image is used to spin up kic containers. it uses same base-image as kind.
-	BaseImage = fmt.Sprintf("gcr.io/k8s-minikube/kicbase1:%s@sha256:%s", Version, baseImageSHA)
+	BaseImage = fmt.Sprintf("gcr.io/k8s-minikube/kicbase:%s@sha256:%s", Version, baseImageSHA)
 	// BaseImageFallBack the fall back of BaseImage in case gcr.io is not available. stored in github packages https://github.com/kubernetes/minikube/packages/206071
 	// github packages docker does _NOT_ support pulling by sha as mentioned in the docs:
 	// https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages

--- a/pkg/minikube/image/image.go
+++ b/pkg/minikube/image/image.go
@@ -18,7 +18,6 @@ package image
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -129,13 +128,11 @@ func WriteImageToDaemon(img string) error {
 	//
 	// https://github.com/google/go-containerregistry/pull/702
 
-	fmt.Println("---------------pulling image----------------")
 	glog.V(3).Infof("Pulling image %v", ref)
 
 	// Pull digest
 	cmd := exec.Command("docker", "pull", "--quiet", img)
 	if _, err := cmd.Output(); err != nil {
-		fmt.Printf("---------------ERROR pulling image----------------: %v", err)
 		return errors.Wrap(err, "pulling remote image")
 	}
 

--- a/pkg/minikube/image/types.go
+++ b/pkg/minikube/image/types.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package image
 
-// ErrNeedsLogin is thrown when regsitery needs login (a general)
+// ErrNeedsLogin is thrown when regsitry needs login (a general)
 var ErrNeedsLogin error
 
 // ErrGithubNeedsLogin is thrown when user needs to login to github to use the fall back image

--- a/pkg/minikube/image/types.go
+++ b/pkg/minikube/image/types.go
@@ -16,8 +16,8 @@ limitations under the License.
 
 package image
 
-// ErrNeedsLogin is thrown when regsitry needs login (a general)
+// ErrNeedsLogin is thrown when registry needs login (a general error)
 var ErrNeedsLogin error
 
-// ErrGithubNeedsLogin is thrown when user needs to login to github to use the fall back image
+// ErrGithubNeedsLogin is thrown when user needs to login specifically to github packages)
 var ErrGithubNeedsLogin error

--- a/pkg/minikube/image/types.go
+++ b/pkg/minikube/image/types.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2020 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package image
+
+// ErrNeedsLogin is thrown when regsitery needs login (a general)
+var ErrNeedsLogin error
+
+// ErrGithubNeedsLogin is thrown when user needs to login to github to use the fall back image
+var ErrGithubNeedsLogin error

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -130,12 +130,14 @@ func waitDownloadKicArtifacts(g *errgroup.Group) {
 		if err != nil {
 			if errors.Is(err, image.ErrGithubNeedsLogin) {
 				glog.Warningf("Error downloading kic artifacts: %v", err)
-				out.T(out.Connectivity, "Unfortunately, could not download the base image {{.image_name}} ", out.V{"image_name": strings.Split(kic.BaseImage, "@")[0]})
-				out.WarningT("In order to use the fall back image, you need to log into to the github packages registry")
-				out.T(out.Documentation, "https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages#authenticating-to-github-packages")
+				out.ErrT(out.Connectivity, "Unfortunately, could not download the base image {{.image_name}} ", out.V{"image_name": strings.Split(kic.BaseImage, "@")[0]})
+				out.WarningT("In order to use the fall back image, you need to log in to the github packages registry")
+				out.T(out.Documentation, `Please visit the following link for documentation around this: 
+	https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages#authenticating-to-github-packages
+`)
 			}
 			if errors.Is(err, image.ErrGithubNeedsLogin) || errors.Is(err, image.ErrNeedsLogin) {
-				exit.UsageT(`Please either authenticate the registry or use --base-image option to use a different registry.`)
+				exit.UsageT(`Please either authenticate to the registry or use --base-image flag to use a different registry.`)
 			} else {
 				glog.Errorln("Error downloading kic artifacts: ", err)
 			}

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -19,6 +19,7 @@ package node
 import (
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
@@ -126,8 +127,21 @@ func beginDownloadKicArtifacts(g *errgroup.Group, cc *config.ClusterConfig) {
 // WaitDownloadKicArtifacts blocks until the required artifacts for KIC are downloaded.
 func waitDownloadKicArtifacts(g *errgroup.Group) {
 	if err := g.Wait(); err != nil {
-		glog.Errorln("Error downloading kic artifacts: ", err)
-		return
+		if err != nil {
+			if errors.Is(err, image.ErrGithubNeedsLogin) {
+				glog.Warningf("Error downloading kic artifacts: %v", err)
+				out.T(out.Connectivity, "Unfortunately, could not download the base image {{.image_name}} ", out.V{"image_name": strings.Split(kic.BaseImage, "@")[0]})
+				out.WarningT("In order to use the fall back image, you need to log into to the github packages registry")
+				out.T(out.Documentation, "https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages#authenticating-to-github-packages")
+			}
+			if errors.Is(err, image.ErrGithubNeedsLogin) || errors.Is(err, image.ErrNeedsLogin) {
+				exit.UsageT(`Please either authenticate the registry or use --base-image option to use a different registry.`)
+			} else {
+				glog.Errorln("Error downloading kic artifacts: ", err)
+			}
+
+		}
+
 	}
 	glog.Info("Successfully downloaded all kic artifacts")
 }


### PR DESCRIPTION
closes https://github.com/kubernetes/minikube/issues/8124

### before this PR
 if user needed logging into the regsitry, (in this case github packages) there would be 
long error lines and crash 

```
😄  minikube v1.10.1 on Ubuntu 20.04
✨  Using the docker driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
E0520 12:59:32.299496  159997 cache.go:129] Error downloading kic artifacts:  getting remote image: GET https://docker.pkg.github.com/v2/kubernetes/minikube/kicbase/manifests/v0.0.10: UNAUTHORIZED: GitHub Docker Registry needs login
🤷  docker "minikube" container is missing, will recreate.
E0520 12:59:32.526096  159997 oci.go:79] docker daemon seems to be stuck. Please try restarting your docker. Will try to delete anyways: unknown state "minikube": docker inspect minikube --format={{.State.Status}}: exit status 1
stdout:


stderr:
Template parsing error: template: :1:8: executing "" at <.State.Status>: map has no entry for key "State"
🔥  Creating docker container (CPUs=2, Memory=3900MB) ...
🤦  StartHost failed, but will try again: recreate: creating host: create: creating: create kic node: create container: docker run -d -t --privileged --security-opt seccomp=unconfined --security-opt apparmor=unconfined --tmpfs /tmp --tmpfs /run -v /lib/modules:/lib/modules:ro --hostname minikube --name minikube --label created_by.minikube.sigs.k8s.io=true --label name.minikube.sigs.k8s.io=minikube --label role.minikube.sigs.k8s.io= --label mode.minikube.sigs.k8s.io=minikube --volume minikube:/var --cpus=2 --memory=3900mb -e container=docker --expose 8443 --publish=127.0.0.1::8443 --publish=127.0.0.1::22 --publish=127.0.0.1::2376 --publish=127.0.0.1::5000 docker.pkg.github.com/kubernetes/minikube/kicbase:v0.0.10: exit status 125
stdout:

stderr:
Unable to find image 'docker.pkg.github.com/kubernetes/minikube/kicbase:v0.0.10' locally
docker: Error response from daemon: Get https://docker.pkg.github.com/v2/kubernetes/minikube/kicbase/manifests/v0.0.10: no basic auth credentials.
See 'docker run --help'.

🤷  docker "minikube" container is missing, will recreate.
E0520 13:00:02.871907  159997 oci.go:79] docker daemon seems to be stuck. Please try restarting your docker. Will try to delete anyways: unknown state "minikube": docker inspect minikube --format={{.State.Status}}: exit status 1
stdout:


stderr:
Template parsing error: template: :1:8: executing "" at <.State.Status>: map has no entry for key "State"
...
...
...

```

After this PR: exit short and sweet and provide link to how to login to the fall back image repos

## After this PR:

```
😄  minikube v1.10.1 on Ubuntu 20.04
✨  Using the docker driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
📶  Unfortunately, could not download the base image gcr.io/k8s-minikube/kicbase1:v0.0.10 
❗  In order to use the fall back image, you need to log in to the github packages registry
📘  Please visit the following link for documentation around this: 
        https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages#authenticating-to-github-packages

💡  Please either authenticate the registry or use --base-image option to use a different registry.

```