### PR TITLE
Fixed error parsing old version "latest" or "stable"

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -479,7 +479,14 @@ func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterC
 	}
 
 	if cmd.Flags().Changed(kubernetesVersion) {
-		cc.KubernetesConfig.KubernetesVersion = viper.GetString(kubernetesVersion)
+		switch viper.GetString(kubernetesVersion) {
+		case "latest":
+			existing.KubernetesConfig.KubernetesVersion = constants.NewestKubernetesVersion
+		case "stable":
+			existing.KubernetesConfig.KubernetesVersion = constants.DefaultKubernetesVersion
+		default:
+			existing.KubernetesConfig.KubernetesVersion = viper.GetString(kubernetesVersion)
+		}
 	}
 
 	if cmd.Flags().Changed(apiServerName) {


### PR DESCRIPTION
Fixes #8210

Signed-off-by: kadern0 <kaderno@gmail.com>

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

Original issue output (consecutive runs):
```
./out/minikube start --kubernetes-version=v1.17.0
😄  minikube v1.9.2 on Ubuntu 20.04
✨  Automatically selected the docker driver

👍  Kubernetes 1.18.0 is now available. If you would like to upgrade, specify: --kubernetes-version=1.18.0
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=3900MB) ...
🐳  Preparing Kubernetes v1.17.0 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16
🌟  Enabling addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube"

 ./out/minikube start --kubernetes-version=stable
😄  minikube v1.9.2 on Ubuntu 20.04
✨  Using the docker driver based on existing profile
E0521 19:56:07.749663  209818 start.go:966] Error parsing old version "stable": No Major.Minor.Patch elements found
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🏃  Updating the running docker "minikube" container ...
🐳  Preparing Kubernetes v1.18.0 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16

❌  [INVALID_KUBERNETES_VERSION] Failed to update cluster kubeadm images: semver: No Major.Minor.Patch elements found
💡  Suggestion: Specify --kubernetes-version in v<major>.<minor.<build> form. example: 'v1.1.14'

 ./out/minikube start --kubernetes-version=stable
😄  minikube v1.9.2 on Ubuntu 20.04
✨  Using the docker driver based on existing profile
E0521 19:56:12.539298  210499 start.go:966] Error parsing old version "stable": No Major.Minor.Patch elements found
E0521 19:56:12.539835  210499 start.go:966] Error parsing old version "stable": No Major.Minor.Patch elements found
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🏃  Updating the running docker "minikube" container ...
🐳  Preparing Kubernetes v1.18.0 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16

❌  [INVALID_KUBERNETES_VERSION] Failed to update cluster kubeadm images: semver: No Major.Minor.Patch elements found
💡  Suggestion: Specify --kubernetes-version in v<major>.<minor.<build> form. example: 'v1.1.14'

./out/minikube start --kubernetes-version=latest
😄  minikube v1.9.2 on Ubuntu 20.04
✨  Using the docker driver based on existing profile
E0521 19:56:19.721802  211046 start.go:966] Error parsing old version "stable": No Major.Minor.Patch elements found
E0521 19:56:19.722759  211046 start.go:966] Error parsing old version "latest": No Major.Minor.Patch elements found
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🏃  Updating the running docker "minikube" container ...
🐳  Preparing Kubernetes v1.18.0 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16

❌  [INVALID_KUBERNETES_VERSION] Failed to update cluster kubeadm images: semver: No Major.Minor.Patch elements found
💡  Suggestion: Specify --kubernetes-version in v<major>.<minor.<build> form. example: 'v1.1.14'

 ./out/minikube start --kubernetes-version=latest
😄  minikube v1.9.2 on Ubuntu 20.04
✨  Using the docker driver based on existing profile
E0521 19:56:24.988163  211418 start.go:966] Error parsing old version "latest": No Major.Minor.Patch elements found
E0521 19:56:24.988886  211418 start.go:966] Error parsing old version "latest": No Major.Minor.Patch elements found
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🏃  Updating the running docker "minikube" container ...
🐳  Preparing Kubernetes v1.18.0 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16

❌  [INVALID_KUBERNETES_VERSION] Failed to update cluster kubeadm images: semver: No Major.Minor.Patch elements found
💡  Suggestion: Specify --kubernetes-version in v<major>.<minor.<build> form. example: 'v1.1.14'


```



Fixed code output:

```
./out/minikube start --kubernetes-version=v1.17.0
😄  minikube v1.9.2 on Ubuntu 20.04
✨  Automatically selected the docker driver
👍  Kubernetes 1.18.0 is now available. If you would like to upgrade, specify: --kubernetes-version=1.18.0
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=3900MB) ...
🐳  Preparing Kubernetes v1.17.0 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16
🌟  Enabling addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube"

 ./out/minikube start --kubernetes-version=stable
😄  minikube v1.9.2 on Ubuntu 20.04
✨  Using the docker driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🏃  Updating the running docker "minikube" container ...
🐳  Preparing Kubernetes v1.18.0 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16
🌟  Enabling addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube"

 ./out/minikube start --kubernetes-version=latest
😄  minikube v1.9.2 on Ubuntu 20.04
✨  Using the docker driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🏃  Updating the running docker "minikube" container ...
🐳  Preparing Kubernetes v1.18.0 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16
🌟  Enabling addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube"

 ./out/minikube start --kubernetes-version=latest
😄  minikube v1.9.2 on Ubuntu 20.04
✨  Using the docker driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🏃  Updating the running docker "minikube" container ...
🐳  Preparing Kubernetes v1.18.0 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16
🌟  Enabling addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube"

```

