### PR TITLE
docker-env: restart dockerd inside minikube on failure

### DIFF
--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -184,9 +184,8 @@ var dockerEnvCmd = &cobra.Command{
 
 		out, err := tryDockerConnectivity("docker", ec)
 		if err != nil { // docker might be up but been loaded with wrong certs/config
-			glog.Warningf("couldn't connect to docker inside minikube. output: %s error: %v", string(out), err)
 			// to fix issues like this #8185
-			glog.Infof("will try to restart dockerd service...")
+			glog.Warningf("couldn't connect to docker inside minikube. will try to restart dockerd service... output: %s error: %v", string(out), err)
 			mustRestartDocker(cname, co.CP.Runner)
 			// TODO #8241: use kverify to wait for apisefver instead
 			// waiting for the basics like api-server to come up

--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -27,7 +27,6 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
@@ -187,9 +186,6 @@ var dockerEnvCmd = &cobra.Command{
 			// to fix issues like this #8185
 			glog.Warningf("couldn't connect to docker inside minikube. will try to restart dockerd service... output: %s error: %v", string(out), err)
 			mustRestartDocker(cname, co.CP.Runner)
-			// TODO #8241: use kverify to wait for apisefver instead
-			// waiting for the basics like api-server to come up
-			time.Sleep(time.Second * 3)
 		}
 
 		if dockerUnset {

--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -122,9 +122,9 @@ func isDockerActive(r command.Runner) bool {
 	return sysinit.New(r).Active("docker")
 }
 
-func mustRestartDaemon(bin string, name string, runner command.Runner) {
-	if err := sysinit.New(runner).Restart(bin); err != nil {
-		exit.WithCodeT(exit.Unavailable, `The {{.service_name}} service within '{{.name}}' is not active`, out.V{"name": name, "service_name": bin})
+func mustRestartDocker(name string, runner command.Runner) {
+	if err := sysinit.New(runner).Restart("docker"); err != nil {
+		exit.WithCodeT(exit.Unavailable, `The Docker service within '{{.name}}' is not active`, out.V{"name": name})
 	}
 }
 
@@ -153,7 +153,7 @@ var dockerEnvCmd = &cobra.Command{
 
 		if ok := isDockerActive(co.CP.Runner); !ok {
 			glog.Warningf("dockerd is not active will try to restart it...")
-			mustRestartDaemon("docker", cname, co.CP.Runner)
+			mustRestartDocker(cname, co.CP.Runner)
 		}
 
 		var err error
@@ -187,7 +187,7 @@ var dockerEnvCmd = &cobra.Command{
 			glog.Warningf("couldn't connect to docker inside minikube. output: %s error: %v", string(out), err)
 			// to fix issues like this #8185
 			glog.Infof("will try to restart dockerd service...")
-			mustRestartDaemon("docker", cname, co.CP.Runner)
+			mustRestartDocker(cname, co.CP.Runner)
 			// TODO #8241: use kverify to wait for apisefver instead
 			// waiting for the basics like api-server to come up
 			time.Sleep(time.Second * 3)

--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/command"
@@ -136,6 +137,12 @@ var dockerEnvCmd = &cobra.Command{
 		if co.Config.KubernetesConfig.ContainerRuntime != "docker" {
 			exit.WithCodeT(exit.BadUsage, `The docker-env command is only compatible with the "docker" runtime, but this cluster was configured to use the "{{.runtime}}" runtime.`,
 				out.V{"runtime": co.Config.KubernetesConfig.ContainerRuntime})
+		}
+
+		// on minikube stop, or computer restart the IP might change.
+		// reloads the certs to prevent #8185
+		if err := sysinit.New(co.CP.Runner).Restart("docker"); err != nil {
+			glog.Warningf("failed to start the dockerd withhin %q minikube node: %v", cname, err)
 		}
 
 		if ok := isDockerActive(co.CP.Runner); !ok {

--- a/cmd/minikube/cmd/podman-env.go
+++ b/cmd/minikube/cmd/podman-env.go
@@ -25,11 +25,9 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"time"
 
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/ssh"
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"k8s.io/minikube/pkg/minikube/command"
 	"k8s.io/minikube/pkg/minikube/constants"
@@ -117,11 +115,6 @@ var podmanEnvCmd = &cobra.Command{
 			exit.UsageT(`'none' driver does not support 'minikube podman-env' command`)
 		}
 
-		if ok := isPodmanAvailable(co.CP.Runner); !ok {
-			glog.Warningf("podman service inside minikube is not active will try to restart it...")
-			restartOrExitDaemon("podman", cname, co.CP.Runner)
-		}
-
 		client, err := createExternalSSHClient(co.CP.Host.Driver)
 		if err != nil {
 			exit.WithError("Error getting ssh client", err)
@@ -142,22 +135,6 @@ var podmanEnvCmd = &cobra.Command{
 			if err != nil {
 				exit.WithError("Error detecting shell", err)
 			}
-		}
-
-		out, err := tryPodmanConnectivity(ec)
-		if err != nil { // docker might be up but been loaded with wrong certs/config
-			if strings.Contains(err.Error(), "x509: certificate is valid") {
-				glog.Infof("dockerd inside minkube is loaded with old certs with wrong IP. output: %s error: %v", string(out), err)
-			} else {
-				glog.Warningf("couldn't connect to docker inside minikube. output: %s error: %v", string(out), err)
-			}
-			// on minikube stop, or computer restart the IP might change.
-			// reloads the certs to prevent #8185
-			glog.Infof("will try to restart dockerd service...")
-			restartOrExitDaemon("docker", cname, co.CP.Runner)
-			// temp fix we add Wait for apiserver
-			// TODO: use kverify to wait for apisefver instead #8241
-			time.Sleep(time.Second * 3)
 		}
 
 		if podmanUnset {
@@ -216,19 +193,4 @@ func podmanEnvVars(ec PodmanEnvConfig) map[string]string {
 func init() {
 	podmanEnvCmd.Flags().StringVar(&shell.ForceShell, "shell", "", "Force environment to be configured for a specified shell: [fish, cmd, powershell, tcsh, bash, zsh], default is auto-detect")
 	podmanEnvCmd.Flags().BoolVarP(&podmanUnset, "unset", "u", false, "Unset variables instead of setting them")
-}
-
-// dpodmanEnvVarsList gets the necessary env variables to allow the use of minikube's podman daemon to be used in a exec.Command
-func podmanEnvVarsList(ec PodmanEnvConfig) []string {
-	return []string{
-		fmt.Sprintf("%s=%s", constants.PodmanVarlinkBridgeEnv, podmanBridge(ec.client)),
-		fmt.Sprintf("%s=%s", constants.MinikubeActivePodmanEnv, ec.profile),
-	}
-}
-
-// tryPodmanConnectivity will try to connect to podman-env from user's POV to detect the problem if it needs reset or not
-func tryPodmanConnectivity(ec PodmanEnvConfig) ([]byte, error) {
-	c := exec.Command("podman", "version", "--format={{.Server}}")
-	c.Env = append(os.Environ(), podmanEnvVarsList(ec)...)
-	return c.CombinedOutput()
 }

--- a/cmd/minikube/cmd/podman-env.go
+++ b/cmd/minikube/cmd/podman-env.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/mustload"
+	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/shell"
 )
 
@@ -113,6 +114,10 @@ var podmanEnvCmd = &cobra.Command{
 
 		if driverName == driver.None {
 			exit.UsageT(`'none' driver does not support 'minikube podman-env' command`)
+		}
+
+		if ok := isPodmanAvailable(co.CP.Runner); !ok {
+			exit.WithCodeT(exit.Unavailable, `The podman service within '{{.cluster}}' is not active`, out.V{"cluster": cname})
 		}
 
 		client, err := createExternalSSHClient(co.CP.Host.Driver)


### PR DESCRIPTION
Before this PR when running docker-env, if docker service is not running we exit with error, 
for example if minikube IP changes, the docker inside minikube needs to be restart to pick up the certs that have the new IP added to them.

closes https://github.com/kubernetes/minikube/issues/8185

This PR is meant for the last effort, when user reaches out to docker-env, the root cause can be fixed by a different PR. that will be for another release.

### Before this PR: docker env when IP changed after minikube start
```
$ eval $(minikube -p p1 docker-env)

$ docker ps
error during connect: Get https://172.17.0.2:2376/v1.40/containers/json: x509: certificate is valid for 172.17.0.3, 127.0.0.1, not 172.17.0.2

```
### After this PR: docker env when IP changed after minikube start

```
$ eval $(./out/minikube -p p1 docker-env)
$ docker ps
CONTAINER ID        IMAGE                  COMMAND                  CREATED             STATUS                  PORTS               NAMES
e81df52d2ad1        303ce5db0e90           "etcd --advertise-cl…"   1 second ago        Up Less than a second                       k8s_etcd_etcd-p1_kube-system_ce05cdf6ecce4bf90b96c7f248feb6a3_1
2f979b669a97        k8s.gcr.io/pause:3.2   "/pause"                 2 seconds ago       Up Less than a second                       k8s_POD_coredns-66bff467f8-2zfbs_kube-system_493e5a5f-fd51-424a-83b2-f515607de399_7
bec03d29f012        k8s.gcr.io/pause:3.2   "/pause"                 2 seconds ago       Up Less than a second                       k8s_POD_kube-scheduler-p1_kube-system_155707e0c19147c8dc5e997f089c0ad1_7
86a7cda645da        k8s.gcr.io/pause:3.2   "/pause"                 2 seconds ago       Up Less than a second                       k8s_POD_kube-proxy-nv2gh_kube-system_9dd0c993-ccc8-4f6e-9b69-673a53ed3572_7
e23ba5d4b230        k8s.gcr.io/pause:3.2   "/pause"                 2 seconds ago       Up Less than a second                       k8s_POD_kube-controller-manager-p1_kube-system_7f415a35d57cff5428871c5a51313bd5_7
cd8534425555        k8s.gcr.io/pause:3.2   "/pause"                 2 seconds ago       Up Less than a second                       k8s_POD_etcd-p1_kube-system_ce05cdf6ecce4bf90b96c7f248feb6a3_4
```
