### PR TITLE
Add HostIP implementation for parallels driver

### DIFF
--- a/pkg/minikube/cluster/ip.go
+++ b/pkg/minikube/cluster/ip.go
@@ -72,6 +72,25 @@ func HostIP(host *host.Host) (net.IP, error) {
 		re = regexp.MustCompile(`(?s)Name:\s*` + iface + `.+IPAddress:\s*(\S+)`)
 		ip := re.FindStringSubmatch(string(ipList))[1]
 		return net.ParseIP(ip), nil
+	case driver.Parallels:
+		cmd := "prlsrvctl"
+		var cmdPath string
+		if fullPath, err := exec.LookPath(cmd); err != nil {
+			cmdPath = fullPath
+		} else {
+			cmdPath = cmd
+		}
+		out, err := exec.Command(cmdPath, "net", "info", "Shared").Output()
+		if err != nil {
+			return []byte{}, errors.Wrap(err, "Error reading the info of Parallels Shared network interface")
+		}
+		re := regexp.MustCompile(`IPv4 address: (.*)`)
+		ipMatch := re.FindStringSubmatch(string(out))
+		if len(ipMatch) < 2 {
+			return []byte{}, errors.Wrap(err, "Error getting the IP address of Parallels Shared network interface")
+		}
+		ip := ipMatch[1]
+		return net.ParseIP(ip), nil
 	case driver.HyperKit:
 		return net.ParseIP("192.168.64.1"), nil
 	case driver.VMware:

--- a/pkg/minikube/cluster/ip.go
+++ b/pkg/minikube/cluster/ip.go
@@ -73,14 +73,14 @@ func HostIP(host *host.Host) (net.IP, error) {
 		ip := re.FindStringSubmatch(string(ipList))[1]
 		return net.ParseIP(ip), nil
 	case driver.Parallels:
-		cmd := "prlsrvctl"
-		var cmdPath string
-		if fullPath, err := exec.LookPath(cmd); err != nil {
-			cmdPath = fullPath
+		bin := "prlsrvctl"
+		var binPath string
+		if fullPath, err := exec.LookPath(bin); err != nil {
+			binPath = fullPath
 		} else {
-			cmdPath = cmd
+			binPath = bin
 		}
-		out, err := exec.Command(cmdPath, "net", "info", "Shared").Output()
+		out, err := exec.Command(binPath, "net", "info", "Shared").Output()
 		if err != nil {
 			return []byte{}, errors.Wrap(err, "Error reading the info of Parallels Shared network interface")
 		}

--- a/pkg/minikube/driver/driver_linux.go
+++ b/pkg/minikube/driver/driver_linux.go
@@ -23,7 +23,6 @@ import (
 // supportedDrivers is a list of supported drivers on Linux.
 var supportedDrivers = []string{
 	VirtualBox,
-	Parallels,
 	VMwareFusion,
 	KVM2,
 	VMware,


### PR DESCRIPTION
Fixes https://github.com/Parallels/docker-machine-parallels/issues/90
Fixes https://github.com/kubernetes/minikube/issues/4862

This PR does the following:
- adds the support of Parallels driver into `HostIP` function, which actually fixes the entire compatibility of minikube with this driver. 
- removes the support of Parallels driver for Mac, because the driver and Parallels Desktop itself support only macOS. 

Tested on macOS 10.15.4 with `docker-machine-driver-parallels` [v1.4.0](https://github.com/Parallels/docker-machine-parallels/releases/tag/v1.4.0) and Parallels Desktop for Mac 15.1.4.

### Before this PR

```
$ ./out/minikube start --driver parallels
😄  minikube v1.10.1 on Darwin 10.15.4
    ▪ KUBECONFIG=/Users/legal/.kube/config
✨  Using the parallels driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🔥  Creating parallels VM (CPUs=2, Memory=4000MB, Disk=20000MB) ...
🐳  Preparing Kubernetes v1.18.2 on Docker 19.03.8 ...
E0523 23:12:39.024819   54085 start.go:95] Unable to get host IP: HostIP not yet implemented for "parallels" driver

💣  failed to start node: startup failed: Failed to setup kubeconfig: HostIP not yet implemented for "parallels" driver

😿  minikube is exiting due to an error. If the above message is not useful, open an issue:
👉  https://github.com/kubernetes/minikube/issues/new/choose
```

### After this PR
```
$ ./out/minikube start
😄  minikube v1.10.1 on Darwin 10.15.4
    ▪ KUBECONFIG=/Users/legal/.kube/config
✨  Automatically selected the parallels driver
👍  Starting control plane node minikube in cluster minikube
🔥  Creating parallels VM (CPUs=2, Memory=4000MB, Disk=20000MB) ...
🐳  Preparing Kubernetes v1.18.2 on Docker 19.03.8 ...
🔎  Verifying Kubernetes components...
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube"

❗  /usr/local/bin/kubectl is version 1.15.3, which may be incompatible with Kubernetes 1.18.2.
💡  You can also use 'minikube kubectl -- get pods' to invoke a matching version
```

## Implementation details
Just for the reviewer's information:
The function is supposed to run the command `prlsrvctl net info Shared`. Here is the full output example:
```
Network ID: Shared
Type: shared
Bound To: vnic0
Parallels adapter:
	IPv4 address: 10.211.55.2
	IPv4 subnet mask: 255.255.255.0
	Host assign IP v6: off
	IPv6 address: fdb2:2c26:f4e4::1
	IPv6 subnet mask: ffff:ffff:ffff:ffff::
DHCPv4 server:
	Server address: 10.211.55.1
	IP scope start address: 10.211.55.1
	IP scope end address: 10.211.55.254
DHCPv6 server:
	Server address: fdb2:2c26:f4e4::
	IP scope start address: fdb2:2c26:f4e4::
	IP scope end address: fdb2:2c26:f4e4:0:ffff:ffff:ffff:ffff

NAT server:
```
Here we just parse this output to get the value of `IPv4 address` field, which is `10.211.55.2`. The VM created by parallels driver is connected to the same virtual network and can access the host using this IP.