### PR TITLE
Add KubeVirt addon

### DIFF
--- a/deploy/addons/kubevirt/README.md
+++ b/deploy/addons/kubevirt/README.md
@@ -1,0 +1,4 @@
+## kubevirt Addon
+[kubevirt](https://kubevirt.io/) - KubeVirt technology addresses the needs of development teams that have adopted or want to adopt Kubernetes but possess existing Virtual Machine-based workloads that cannot be easily containerized.
+
+More info can be found by reading the tutorial ["How to use KubeVirt with minikube"](https://minikube.sigs.k8s.io/docs/tutorials/kubevirt/)

--- a/deploy/addons/kubevirt/pod.yaml.tmpl
+++ b/deploy/addons/kubevirt/pod.yaml.tmpl
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: kube-system
+  name: kubevirt-scripts
+  labels:
+    kubernetes.io/minikube-addons: kubevirt
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  uninstall.sh: |
+    #!/bin/bash
+
+    kubectl delete -f /manifests/kubevirt.yaml
+
+    kubectl delete -f /manifests/kubevirt-base.yaml
+
+  install.sh: |
+    #!/bin/bash
+
+    export KUBEVIRT_VERSION=$(curl -s https://api.github.com/repos/kubevirt/kubevirt/releases | grep tag_name | grep -v -- - | sort -V | tail -1 | awk -F':' '{print $2}' | sed 's/,//' | xargs)
+    echo $KUBEVIRT_VERSION
+
+    curl -Ls "https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml" -o /manifests/kubevirt-base.yaml
+
+    kubectl create -f /manifests/kubevirt-base.yaml
+
+    EMULATION=$(egrep 'svm|vmx' /proc/cpuinfo)
+    if [ -z "$EMULATION" ]; then
+      echo "use emulation"
+      kubectl create configmap kubevirt-config -n kubevirt --from-literal debug.useEmulation=true
+    fi;
+
+    curl -sL "https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml" -o /manifests/kubevirt.yaml
+
+    kubectl create -f /manifests/kubevirt.yaml
+
+    sleep infinity
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    kubernetes.io/minikube-addons: kubevirt
+    addonmanager.kubernetes.io/mode: Reconcile
+  name: kubevirt-install-manager
+  namespace: kube-system
+spec:
+  containers:
+  - command:
+    - /bin/bash
+    - -c
+    - /kubevirt-scripts/install.sh
+    image: bitnami/kubectl:1.17
+    imagePullPolicy: IfNotPresent
+    name: kubevirt-provisioner
+    lifecycle:
+      preStop:
+        exec:
+          command:
+          - /bin/bash
+          - -c
+          - /kubevirt-scripts/uninstall.sh
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    volumeMounts:
+    - mountPath: /manifests
+      name: tmp
+    - mountPath: /kubevirt-scripts
+      name: kubevirt-scripts
+  terminationGracePeriodSeconds: 60
+  volumes:
+  - name: tmp
+    emptyDir: {}
+  - name: kubevirt-scripts
+    configMap:
+      defaultMode: 0777
+      name: kubevirt-scripts

--- a/pkg/addons/config.go
+++ b/pkg/addons/config.go
@@ -83,6 +83,11 @@ var Addons = []*Addon{
 		callbacks: []setFn{enableOrDisableAddon},
 	},
 	{
+		name:      "kubevirt",
+		set:       SetBool,
+		callbacks: []setFn{enableOrDisableAddon},
+	},
+	{
 		name: "logviewer",
 		set:  SetBool,
 	},

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -189,6 +189,14 @@ var Addons = map[string]*Addon{
 			"0640",
 			false),
 	}, false, "istio"),
+	"kubevirt": NewAddon([]*BinAsset{
+		MustBinAsset(
+			"deploy/addons/kubevirt/pod.yaml.tmpl",
+			vmpath.GuestAddonsDir,
+			"pod.yaml",
+			"0640",
+			false),
+	}, false, "kubevirt"),
 	"metrics-server": NewAddon([]*BinAsset{
 		MustBinAsset(
 			"deploy/addons/metrics-server/metrics-apiservice.yaml.tmpl",

--- a/site/content/en/docs/tutorials/kubevirt.md
+++ b/site/content/en/docs/tutorials/kubevirt.md
@@ -1,0 +1,42 @@
+---
+title: "How to use KubeVirt with minikube"
+linkTitle: "KubeVirt support"
+weight: 1
+date: 2020-05-26
+description: >
+  Using KubeVirt with minikube
+---
+
+## Prerequisites
+
+- kvm2 driver
+
+### Enable KubeVirt on minikube
+Minikube can be started with default values and those will be enough to run a quick example, that being said, if you can spare a few more GiBs of RAM (by default it uses 2GiB), it’ll allow you to experiment further.
+
+We’ll create a profile for KubeVirt so it gets its own settings without interfering what any configuration you might have already, let’s start by increasing the default memory to 4GiB:
+
+```shell script
+minikube config -p kubevirt set memory 4096
+minikube config -p kubevirt set vm-driver kvm2
+minikube start -p kubevirt
+```
+
+To enable this addon, simply run:
+```shell script
+minikube addons enable kubevirt
+```
+
+In a minute or so kubevirt's default components will be installed into your cluster.
+You can run `kubectl get pods -n kubevirt` to see the progress of the kubevirt installation.
+
+
+### Disable KubeVirt
+To disable this addon, simply run:
+```shell script
+minikube addons disable kubevirt
+```
+
+### More Information
+
+See official [Minikube Quickstart](https://kubevirt.io/quickstart_minikube/) documentation for more information and to install KubeVirt without using the addon.


### PR DESCRIPTION
### Description 

This PR fixes #2178 

It adds the KubeVirt operator as an addon that can be enabled, as well as allowing users to separately create an instance of the KubeVirt custom resource to deploy the full environment. 