### PR TITLE
Added option --all to stop all clusters

### DIFF
--- a/site/content/en/docs/commands/stop.md
+++ b/site/content/en/docs/commands/stop.md
@@ -22,6 +22,7 @@ minikube stop [flags]
 ### Options
 
 ```
+      --all    Set flag to stop all profiles (clusters)
   -h, --help   help for stop
 ```
 


### PR DESCRIPTION
Resolves #8237

Signed-off-by: kadern0 <kaderno@gmail.com>

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

Example of the PR working:

```
./out/minikube start --profile=cluster1
😄  [cluster1] minikube v1.10.1 on Ubuntu 20.04
✨  Using the docker driver based on existing profile
👍  Starting control plane node cluster1 in cluster cluster1
🔄  Restarting existing docker container for "cluster1" ...
🐳  Preparing Kubernetes v1.18.2 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16
🔎  Verifying Kubernetes components...
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "cluster1"

 ./out/minikube start --profile=cluster2
😄  [cluster2] minikube v1.10.1 on Ubuntu 20.04
✨  Automatically selected the docker driver
👍  Starting control plane node cluster2 in cluster cluster2
🔥  Creating docker container (CPUs=2, Memory=3900MB) ...
🐳  Preparing Kubernetes v1.18.2 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16
🔎  Verifying Kubernetes components...
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "cluster2"

 ./out/minikube stop --all
✋  Stopping "cluster1" in docker ...
🛑  Powering off "cluster1" via SSH ...
🛑  Node "cluster1" stopped.
✋  Stopping "cluster2" in docker ...
🛑  Powering off "cluster2" via SSH ...
🛑  Node "cluster2" stopped.

```

