### PR TITLE
respect native-ssh param properly

### DIFF
--- a/cmd/minikube/cmd/ssh.go
+++ b/cmd/minikube/cmd/ssh.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"os"
 
-	"github.com/docker/machine/libmachine/ssh"
 	"github.com/spf13/cobra"
 
 	"k8s.io/minikube/pkg/minikube/config"
@@ -58,13 +57,7 @@ var sshCmd = &cobra.Command{
 			}
 		}
 
-		if nativeSSHClient {
-			ssh.SetDefaultClient(ssh.Native)
-		} else {
-			ssh.SetDefaultClient(ssh.External)
-		}
-
-		err = machine.CreateSSHShell(co.API, *co.Config, *n, args)
+		err = machine.CreateSSHShell(co.API, *co.Config, *n, args, nativeSSHClient)
 		if err != nil {
 			// This is typically due to a non-zero exit code, so no need for flourish.
 			out.ErrLn("ssh: %v", err)

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -246,12 +246,6 @@ func provisionWithDriver(cmd *cobra.Command, ds registry.DriverState, existing *
 		cc.MinikubeISO = url
 	}
 
-	if viper.GetBool(nativeSSH) {
-		ssh.SetDefaultClient(ssh.Native)
-	} else {
-		ssh.SetDefaultClient(ssh.External)
-	}
-
 	var existingAddons map[string]bool
 	if viper.GetBool(installAddons) {
 		existingAddons = map[string]bool{}
@@ -263,6 +257,12 @@ func provisionWithDriver(cmd *cobra.Command, ds registry.DriverState, existing *
 	mRunner, preExists, mAPI, host, err := node.Provision(&cc, &n, true)
 	if err != nil {
 		return node.Starter{}, err
+	}
+
+	if viper.GetBool(nativeSSH) {
+		ssh.SetDefaultClient(ssh.Native)
+	} else {
+		ssh.SetDefaultClient(ssh.External)
 	}
 
 	return node.Starter{

--- a/pkg/minikube/machine/cluster_test.go
+++ b/pkg/minikube/machine/cluster_test.go
@@ -454,7 +454,7 @@ func TestCreateSSHShell(t *testing.T) {
 	cc.Name = viper.GetString("profile")
 
 	cliArgs := []string{"exit"}
-	if err := CreateSSHShell(api, cc, config.Node{Name: "minikube"}, cliArgs); err != nil {
+	if err := CreateSSHShell(api, cc, config.Node{Name: "minikube"}, cliArgs, true); err != nil {
 		t.Fatalf("Error running ssh command: %v", err)
 	}
 

--- a/pkg/minikube/machine/ssh.go
+++ b/pkg/minikube/machine/ssh.go
@@ -18,6 +18,7 @@ package machine
 
 import (
 	"github.com/docker/machine/libmachine"
+	"github.com/docker/machine/libmachine/ssh"
 	"github.com/docker/machine/libmachine/state"
 	"github.com/pkg/errors"
 	"k8s.io/minikube/pkg/minikube/config"
@@ -25,7 +26,7 @@ import (
 )
 
 // CreateSSHShell creates a new SSH shell / client
-func CreateSSHShell(api libmachine.API, cc config.ClusterConfig, n config.Node, args []string) error {
+func CreateSSHShell(api libmachine.API, cc config.ClusterConfig, n config.Node, args []string, native bool) error {
 	machineName := driver.MachineName(cc, n)
 	host, err := LoadHost(api, machineName)
 	if err != nil {
@@ -42,6 +43,13 @@ func CreateSSHShell(api libmachine.API, cc config.ClusterConfig, n config.Node, 
 	}
 
 	client, err := host.CreateSSHClient()
+
+	if native {
+		ssh.SetDefaultClient(ssh.Native)
+	} else {
+		ssh.SetDefaultClient(ssh.External)
+	}
+
 	if err != nil {
 		return errors.Wrap(err, "Creating ssh client")
 	}

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -847,7 +847,7 @@ func validateSSHCmd(ctx context.Context, t *testing.T, profile string) {
 		t.Errorf("failed to run an ssh command. args %q : %v", rr.Command(), err)
 	}
 	// trailing whitespace differs between native and external SSH clients, so let's trim it and call it a day
-	if rr.Stdout.String() != want {
+	if strings.TrimSpace(rr.Stdout.String()) != want {
 		t.Errorf("expected minikube ssh command output to be -%q- but got *%q*. args %q", want, rr.Stdout.String(), rr.Command())
 	}
 

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -821,6 +821,7 @@ func validateSSHCmd(ctx context.Context, t *testing.T, profile string) {
 	if err != nil {
 		t.Errorf("failed to run an ssh command. args %q : %v", rr.Command(), err)
 	}
+	// trailing whitespace differs between native and external SSH clients, so let's trim it and call it a day
 	if strings.TrimSpace(rr.Stdout.String()) != want {
 		t.Errorf("expected minikube ssh command output to be -%q- but got *%q*. args %q", want, rr.Stdout.String(), rr.Command())
 	}

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -816,12 +816,12 @@ func validateSSHCmd(ctx context.Context, t *testing.T, profile string) {
 	if NoneDriver() {
 		t.Skipf("skipping: ssh unsupported by none")
 	}
-	want := "hello\n"
+	want := "hello"
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", fmt.Sprintf("echo hello")))
 	if err != nil {
 		t.Errorf("failed to run an ssh command. args %q : %v", rr.Command(), err)
 	}
-	if rr.Stdout.String() != want {
+	if strings.TrimSpace(rr.Stdout.String()) != want {
 		t.Errorf("expected minikube ssh command output to be -%q- but got *%q*. args %q", want, rr.Stdout.String(), rr.Command())
 	}
 }


### PR DESCRIPTION
We were calling ssh.SetDefaultClient too early, so CreateSSHShell was overriding the property back to external no matter what was passed in.
