### PR TITLE
skip two always failing test on windows and create issue

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -242,7 +242,6 @@ jobs:
       - name: The End Result functional_test_docker_windows
         shell: powershell
         run: |
-          $ErrorActionPreference = "SilentlyContinue"
           $numFail=(echo $Env:STAT | jq '.NumberOfFail')
           $failedTests=( echo $Env:STAT | jq '.FailedTests')
           echo "----------------${numFail} Failures----------------------------"
@@ -250,7 +249,7 @@ jobs:
           echo "-------------------------------------------------------"
           $numPass=$(echo $Env:STAT | jq '.NumberOfPass')
           echo "*** $numPass Passed ***"
-          If ($numFail -ge 0){ exit 2 } 
+          If ($numFail -gt 0){ exit 2 } 
           If ($numPass -eq 0){ exit 2 }
           If ($numFail -eq 0){ exit 0 }
   functional_test_hyperv_windows:
@@ -330,7 +329,6 @@ jobs:
       - name: The End Result functional_test_hyperv_windows
         shell: powershell
         run: |
-          $ErrorActionPreference = "SilentlyContinue"
           $numFail=(echo $Env:STAT | jq '.NumberOfFail')
           $failedTests=( echo $Env:STAT | jq '.FailedTests')
           echo "----------------${numFail} Failures----------------------------"
@@ -338,7 +336,7 @@ jobs:
           echo "-------------------------------------------------------"
           $numPass=$(echo $Env:STAT | jq '.NumberOfPass')
           echo "*** $numPass Passed ***"
-          If ($numFail -ge 0){ exit 2 } 
+          If ($numFail -gt 0){ exit 2 } 
           If ($numPass -eq 0){ exit 2 }
           If ($numFail -eq 0){ exit 0 }
   addons_certs_tests_docker_ubuntu:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -289,7 +289,7 @@ jobs:
           $env:KUBECONFIG="${pwd}\testhome\kubeconfig"
           $env:MINIKUBE_HOME="${pwd}\testhome"
           $ErrorActionPreference = "SilentlyContinue"
-          ./e2e-windows-amd64.exe --minikube-start-args="--driver=hyperv" --test.timeout=13m --test.v --test.run=TestFunctional --binary="./minikube-windows-amd64.exe" | Out-File -FilePath .\report\testout.txt -Encoding ASCII
+          ./e2e-windows-amd64.exe --minikube-start-args="--driver=hyperv" --test.timeout=13m -timeout-multiplier=1.5 --test.v --test.run=TestFunctional --binary="./minikube-windows-amd64.exe" | Out-File -FilePath .\report\testout.txt -Encoding ASCII
           $END_TIME=(GET-DATE)
           echo $END_TIME
           $DURATION=(NEW-TIMESPAN -Start $START_TIME -End $END_TIME)

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -249,8 +249,9 @@ jobs:
           echo "-------------------------------------------------------"
           $numPass=$(echo $Env:STAT | jq '.NumberOfPass')
           echo "*** $numPass Passed ***"
-          If ($numFail -ge 0){ exit 2 } else { echo "goodjob" }
+          If ($numFail -ge 0){ exit 2 } 
           If ($numPass -eq 0){ exit 2 }
+          If ($numFail -eq 0){ exit 0 }
   functional_test_hyperv_windows:
     needs: [build_minikube]
     env:
@@ -335,8 +336,9 @@ jobs:
           echo "-------------------------------------------------------"
           $numPass=$(echo $Env:STAT | jq '.NumberOfPass')
           echo "*** $numPass Passed ***"
-          If ($numFail -ge 0){ exit 2 } else { echo "goodjob" }
+          If ($numFail -ge 0){ exit 2 } 
           If ($numPass -eq 0){ exit 2 }
+          If ($numFail -eq 0){ exit 0 }
   addons_certs_tests_docker_ubuntu:
     runs-on: ubuntu-18.04
     env:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -242,6 +242,7 @@ jobs:
       - name: The End Result functional_test_docker_windows
         shell: powershell
         run: |
+          $ErrorActionPreference = "SilentlyContinue"
           $numFail=(echo $Env:STAT | jq '.NumberOfFail')
           $failedTests=( echo $Env:STAT | jq '.FailedTests')
           echo "----------------${numFail} Failures----------------------------"
@@ -329,6 +330,7 @@ jobs:
       - name: The End Result functional_test_hyperv_windows
         shell: powershell
         run: |
+          $ErrorActionPreference = "SilentlyContinue"
           $numFail=(echo $Env:STAT | jq '.NumberOfFail')
           $failedTests=( echo $Env:STAT | jq '.FailedTests')
           echo "----------------${numFail} Failures----------------------------"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -287,7 +287,7 @@ jobs:
           $env:KUBECONFIG="${pwd}\testhome\kubeconfig"
           $env:MINIKUBE_HOME="${pwd}\testhome"
           $ErrorActionPreference = "SilentlyContinue"
-          ./e2e-windows-amd64.exe --minikube-start-args="--driver=hyperv" --test.timeout=13m --test.v --test.run=TestFunctional --binary="./minikube-windows-amd64.exe" | Out-File -FilePath .\report\testout.txt -Encoding ASCII
+          ./e2e-windows-amd64.exe --minikube-start-args="--driver=hyperv" --test.timeout=13m -timeout-multiplier=1.5 --test.v --test.run=TestFunctional --binary="./minikube-windows-amd64.exe" | Out-File -FilePath .\report\testout.txt -Encoding ASCII
           $END_TIME=(GET-DATE)
           echo $END_TIME
           $DURATION=(NEW-TIMESPAN -Start $START_TIME -End $END_TIME)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -240,6 +240,7 @@ jobs:
       - name: The End Result functional_test_docker_windows
         shell: powershell
         run: |
+          $ErrorActionPreference = "SilentlyContinue"
           $numFail=(echo $Env:STAT | jq '.NumberOfFail')
           $failedTests=( echo $Env:STAT | jq '.FailedTests')
           echo "----------------${numFail} Failures----------------------------"
@@ -327,6 +328,7 @@ jobs:
       - name: The End Result functional_test_hyperv_windows
         shell: powershell
         run: |
+          $ErrorActionPreference = "SilentlyContinue"
           $numFail=(echo $Env:STAT | jq '.NumberOfFail')
           $failedTests=( echo $Env:STAT | jq '.FailedTests')
           echo "----------------${numFail} Failures----------------------------"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -240,7 +240,6 @@ jobs:
       - name: The End Result functional_test_docker_windows
         shell: powershell
         run: |
-          $ErrorActionPreference = "SilentlyContinue"
           $numFail=(echo $Env:STAT | jq '.NumberOfFail')
           $failedTests=( echo $Env:STAT | jq '.FailedTests')
           echo "----------------${numFail} Failures----------------------------"
@@ -248,7 +247,7 @@ jobs:
           echo "-------------------------------------------------------"
           $numPass=$(echo $Env:STAT | jq '.NumberOfPass')
           echo "*** $numPass Passed ***"
-          If ($numFail -ge 0){ exit 2 } 
+          If ($numFail -gt 0){ exit 2 } 
           If ($numPass -eq 0){ exit 2 }
           If ($numFail -eq 0){ exit 0 }
   functional_test_hyperv_windows:
@@ -328,7 +327,6 @@ jobs:
       - name: The End Result functional_test_hyperv_windows
         shell: powershell
         run: |
-          $ErrorActionPreference = "SilentlyContinue"
           $numFail=(echo $Env:STAT | jq '.NumberOfFail')
           $failedTests=( echo $Env:STAT | jq '.FailedTests')
           echo "----------------${numFail} Failures----------------------------"
@@ -336,7 +334,7 @@ jobs:
           echo "-------------------------------------------------------"
           $numPass=$(echo $Env:STAT | jq '.NumberOfPass')
           echo "*** $numPass Passed ***"
-          If ($numFail -ge 0){ exit 2 } 
+          If ($numFail -gt 0){ exit 2 } 
           If ($numPass -eq 0){ exit 2 }
           If ($numFail -eq 0){ exit 0 }
   addons_certs_tests_docker_ubuntu:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -247,8 +247,9 @@ jobs:
           echo "-------------------------------------------------------"
           $numPass=$(echo $Env:STAT | jq '.NumberOfPass')
           echo "*** $numPass Passed ***"
-          If ($numFail -ge 0){ exit 2 } else { echo "goodjob" }
+          If ($numFail -ge 0){ exit 2 } 
           If ($numPass -eq 0){ exit 2 }
+          If ($numFail -eq 0){ exit 0 }
   functional_test_hyperv_windows:
     needs: [build_minikube]
     env:
@@ -333,8 +334,9 @@ jobs:
           echo "-------------------------------------------------------"
           $numPass=$(echo $Env:STAT | jq '.NumberOfPass')
           echo "*** $numPass Passed ***"
-          If ($numFail -ge 0){ exit 2 } else { echo "goodjob" }
+          If ($numFail -ge 0){ exit 2 } 
           If ($numPass -eq 0){ exit 2 }
+          If ($numFail -eq 0){ exit 0 }
   addons_certs_tests_docker_ubuntu:
     runs-on: ubuntu-18.04
     env:

--- a/test/integration/fn_mount_cmd.go
+++ b/test/integration/fn_mount_cmd.go
@@ -43,12 +43,16 @@ const (
 	createdByPodRemovedByTest = "created-by-pod-removed-by-test"
 )
 
-func validateMountCmd(ctx context.Context, t *testing.T, profile string) {
+func validateMountCmd(ctx context.Context, t *testing.T, profile string) { // nolint: cyclomatic complexity 31
 	if NoneDriver() {
 		t.Skip("skipping: none driver does not support mount")
 	}
 	if HyperVDriver() {
 		t.Skip("skipping: mount broken on hyperv: https://github.com/kubernetes/minikube/issues/5029")
+	}
+
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping: mount broken on windows: https://github.com/kubernetes/minikube/issues/8303")
 	}
 
 	tempDir, err := ioutil.TempDir("", "mounttest")

--- a/test/integration/fn_tunnel_cmd.go
+++ b/test/integration/fn_tunnel_cmd.go
@@ -173,6 +173,10 @@ func validateServiceStable(ctx context.Context, t *testing.T, profile string) {
 
 // validateAccessDirect validates if the test service can be accessed with LoadBalancer IP from host
 func validateAccessDirect(ctx context.Context, t *testing.T, profile string) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping: mount broken on windows: https://github.com/kubernetes/minikube/issues/8304")
+	}
+
 	checkRoutePassword(t)
 
 	got := []byte{}

--- a/test/integration/fn_tunnel_cmd.go
+++ b/test/integration/fn_tunnel_cmd.go
@@ -174,7 +174,7 @@ func validateServiceStable(ctx context.Context, t *testing.T, profile string) {
 // validateAccessDirect validates if the test service can be accessed with LoadBalancer IP from host
 func validateAccessDirect(ctx context.Context, t *testing.T, profile string) {
 	if runtime.GOOS == "windows" {
-		t.Skip("skipping: mount broken on windows: https://github.com/kubernetes/minikube/issues/8304")
+		t.Skip("skipping: access direct test is broken on windows: https://github.com/kubernetes/minikube/issues/8304")
 	}
 
 	checkRoutePassword(t)


### PR DESCRIPTION
github actions always fails with these two tests
```
----------------2 Failures----------------------------
[
  "TestFunctional/parallel/MountCmd",
  "TestFunctional/parallel/TunnelCmd/serial/AccessDirect"
]
-------------------------------------------------------
```
in the spirit of not getting used to see Always Red, and make red a solid warning sign 
and make the github actions red always, we skip the test, and will create issues for them so we fix them.

