### PR TITLE
Add HostIP support for Parallels driver

### DIFF
--- a/pkg/minikube/cluster/ip.go
+++ b/pkg/minikube/cluster/ip.go
@@ -86,6 +86,8 @@ func HostIP(host *host.Host) (net.IP, error) {
 		return net.IPv4(vmIP[0], vmIP[1], vmIP[2], byte(1)), nil
 	case driver.None:
 		return net.ParseIP("127.0.0.1"), nil
+	case driver.Parallels:
+		return net.ParseIP("10.211.55.2"), nil
 	default:
 		return []byte{}, fmt.Errorf("HostIP not yet implemented for %q driver", host.DriverName)
 	}


### PR DESCRIPTION
Fixes #8315

Example:

```
😄  minikube v1.10.1 on Darwin 10.15.4
✨  Using the parallels driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
🏃  Updating the running parallels "minikube" VM ...
🐳  Preparing Kubernetes v1.18.2 on Docker 19.03.8 ...
🔎  Verifying Kubernetes components...
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube"
```
