### PR TITLE
Add support for docker driver to mkcmp

### DIFF
--- a/pkg/minikube/perf/result_manager.go
+++ b/pkg/minikube/perf/result_manager.go
@@ -64,8 +64,10 @@ func (rm *resultManager) averageTime(binary *Binary) float64 {
 	return average(times)
 }
 
-func (rm *resultManager) summarizeResults(binaries []*Binary) {
+func (rm *resultManager) summarizeResults(binaries []*Binary, driver string) {
 	// print total and average times
+	fmt.Printf("**%s Driver**\n", driver)
+
 	for _, b := range binaries {
 		fmt.Printf("Times for %s: %v\n", b.Name(), rm.totalTimes(b))
 		fmt.Printf("Average time for %s: %v\n\n", b.Name(), rm.averageTime(b))


### PR DESCRIPTION
The output is now as follows (ran on my mac so kvm2 gave an error, but this is how we would comment errors on PRs now)

**kvm2 Driver**
error collecting results for kvm2 driver: timing run 0 with minikube: timing cmd: [./out/minikube start --driver=kvm2]: waiting for minikube: exit status 69
**docker Driver**
Times for minikube: 30.8s 30.6s 
Average time for minikube: 30.7s

Times for minikube: 30.1s 30.2s 
Average time for minikube: 30.2s

Averages Time Per Log
<details>


```
+----------------------------------------+----------+----------+
|                  LOG                   | MINIKUBE | MINIKUBE |
+----------------------------------------+----------+----------+
| 😄  minikube v1.10.1 on Darwin         | 0.1s     | 0.1s     |
| 10.14.6                                |          |          |
| ✨  Using the docker driver            | 0.2s     | 0.1s     |
| based on user configuration            |          |          |
| 👍  Starting control plane             | 0.1s     | 0.1s     |
| node minikube in cluster               |          |          |
| minikube                               |          |          |
| 🔥  Creating docker container          | 8.6s     | 8.8s     |
| (CPUs=2, Memory=1988MB) ...            |          |          |
| 🐳  Preparing Kubernetes               | 0.2s     | 0.3s     |
| v1.18.2 on Docker 19.03.2 ...          |          |          |
|     ▪                                  | 20.1s    | 19.8s    |
| kubeadm.pod-network-cidr=10.244.0.0/16 |          |          |
| 🔎  Verifying Kubernetes               | 1.4s     | 0.9s     |
| components...                          |          |          |
| 🌟  Enabled addons:                    | 0.0s     | 0.1s     |
| default-storageclass,                  |          |          |
| storage-provisioner                    |          |          |
| 🏄  Done! kubectl is now               | 0.1s     | 0.1s     |
| configured to use "minikube"           |          |          |
+----------------------------------------+----------+----------+
```
</details>
