### PR TITLE
Remove kubelet options for k8s version < 1.12

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/versions.go
+++ b/pkg/minikube/bootstrapper/bsutil/versions.go
@@ -50,14 +50,6 @@ var versionSpecificOpts = []config.VersionedExtraOption{
 	// Kubeconfig args
 	config.NewUnversionedOption(Kubelet, "kubeconfig", "/etc/kubernetes/kubelet.conf"),
 	config.NewUnversionedOption(Kubelet, "bootstrap-kubeconfig", "/etc/kubernetes/bootstrap-kubelet.conf"),
-	{
-		Option: config.ExtraOption{
-			Component: Kubelet,
-			Key:       "require-kubeconfig",
-			Value:     "true",
-		},
-		LessThanOrEqual: semver.MustParse("1.9.10"),
-	},
 
 	// System pods args
 	config.NewUnversionedOption(Kubelet, "pod-manifest-path", vmpath.GuestManifestsDir),
@@ -98,14 +90,5 @@ var versionSpecificOpts = []config.VersionedExtraOption{
 			Value:     strings.Join(util.DefaultV114AdmissionControllers, ","),
 		},
 		GreaterThanOrEqual: semver.MustParse("1.14.0-alpha.0"),
-	},
-
-	{
-		Option: config.ExtraOption{
-			Component: Kubelet,
-			Key:       "cadvisor-port",
-			Value:     "0",
-		},
-		LessThanOrEqual: semver.MustParse("1.11.1000"),
 	},
 }


### PR DESCRIPTION
This does some cleanup, now that the minimum k8s version is bumped up to 1.13

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
