### PR TITLE
Add digest to image in daemon after pulling it

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -104,6 +104,7 @@ replace (
 	git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
 	github.com/docker/docker => github.com/docker/docker v1.4.2-0.20190924003213-a8608b5b67c7
 	github.com/docker/machine => github.com/machine-drivers/machine v0.7.1-0.20200323212942-41eb826190d8
+	github.com/google/go-containerregistry => github.com/afbjorklund/go-containerregistry v0.0.0-20200329163843-4f5ebd05922c
 	github.com/hashicorp/go-getter => github.com/afbjorklund/go-getter v1.4.1-0.20190910175809-eb9f6c26742c
 	github.com/samalba/dockerclient => github.com/sayboras/dockerclient v0.0.0-20191231050035-015626177a97
 	k8s.io/api => k8s.io/api v0.17.3

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUW
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdcM=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
+github.com/afbjorklund/go-containerregistry v0.0.0-20200329163843-4f5ebd05922c h1:6fbgFHLPMCieDysTguJY03Zer8hNr8+GbvpD291DOXA=
+github.com/afbjorklund/go-containerregistry v0.0.0-20200329163843-4f5ebd05922c/go.mod h1:pD1UFYs7MCAx+ZLShBdttcaOSbyc8F9Na/9IZLNwJeA=
 github.com/afbjorklund/go-getter v1.4.1-0.20190910175809-eb9f6c26742c h1:18gEt7qzn7CW7qMkfPTFyyotlPbvPQo9o4IDV8jZqP4=
 github.com/afbjorklund/go-getter v1.4.1-0.20190910175809-eb9f6c26742c/go.mod h1:7qxyCd8rBfcShwsvxgIguu4KbS3l8bUCwg2Umn7RjeY=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=

--- a/pkg/minikube/image/cache.go
+++ b/pkg/minikube/image/cache.go
@@ -121,11 +121,7 @@ func saveToTarFile(iname, rawDest string) error {
 		return errors.Wrapf(err, "nil image for %s", iname)
 	}
 
-	tag, err := name.NewTag(iname, name.WeakValidation)
-	if err != nil {
-		return errors.Wrap(err, "newtag")
-	}
-	err = writeImage(img, dst, tag)
+	err = writeImage(img, dst, ref)
 	if err != nil {
 		return err
 	}
@@ -134,7 +130,7 @@ func saveToTarFile(iname, rawDest string) error {
 	return nil
 }
 
-func writeImage(img v1.Image, dst string, tag name.Tag) error {
+func writeImage(img v1.Image, dst string, ref name.Reference) error {
 	glog.Infoln("opening: ", dst)
 	f, err := ioutil.TempFile(filepath.Dir(dst), filepath.Base(dst)+".*.tmp")
 	if err != nil {
@@ -151,7 +147,7 @@ func writeImage(img v1.Image, dst string, tag name.Tag) error {
 		}
 	}()
 
-	err = tarball.Write(tag, img, f)
+	err = tarball.Write(ref, img, f)
 	if err != nil {
 		return errors.Wrap(err, "write")
 	}

--- a/pkg/minikube/image/image.go
+++ b/pkg/minikube/image/image.go
@@ -113,27 +113,10 @@ func WriteImageToDaemon(img string) error {
 
 		return errors.Wrap(err, "getting remote image")
 	}
-	tag, err := name.NewTag(strings.Split(img, "@")[0])
+	glog.V(3).Infof("Writing image %v", ref)
+	_, err = daemon.Write(ref, i)
 	if err != nil {
-		return errors.Wrap(err, "getting tag")
-	}
-	glog.V(3).Infof("Writing image %v", tag)
-	_, err = daemon.Write(tag, i)
-	if err != nil {
-		return errors.Wrap(err, "writing image")
-	}
-
-	//TODO: Make pkg/v1/daemon accept Ref too
-	//      Only added it to pkg/v1/tarball
-	//
-	// https://github.com/google/go-containerregistry/pull/702
-
-	glog.V(3).Infof("Pulling image %v", ref)
-
-	// Pull digest
-	cmd := exec.Command("docker", "pull", "--quiet", img)
-	if _, err := cmd.Output(); err != nil {
-		return errors.Wrap(err, "pulling remote image")
+		return errors.Wrap(err, "writing daemon image")
 	}
 
 	return nil


### PR DESCRIPTION
The image was added with digest "none", which caused it to be
written to daemon again next time since reference didn't match.

This avoids having to do the "docker pull" workaround.

commit e054d7583677ba6c7e9a6d40b8fed7105062ead2

Seems like PR is **not** merged upstream yet, though ?

See ~#7242~