### PR TITLE
Update go-containerregistry to the rebased commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/google/go-cmp v0.4.0
-	github.com/google/go-containerregistry v0.0.0-20200131185320-aec8da010de2
+	github.com/google/go-containerregistry v0.0.0-20200601195303-96cf69f03a3c
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/martian v2.1.1-0.20190517191504-25dcb96d9e51+incompatible // indirect
 	github.com/google/slowjam v0.0.0-20200530021616-df27e642fe7b
@@ -105,7 +105,7 @@ replace (
 	git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
 	github.com/docker/docker => github.com/docker/docker v1.4.2-0.20190924003213-a8608b5b67c7
 	github.com/docker/machine => github.com/machine-drivers/machine v0.7.1-0.20200323212942-41eb826190d8
-	github.com/google/go-containerregistry => github.com/afbjorklund/go-containerregistry v0.0.0-20200329163843-4f5ebd05922c
+	github.com/google/go-containerregistry => github.com/afbjorklund/go-containerregistry v0.0.0-20200602203322-347d93793dc9
 	github.com/hashicorp/go-getter => github.com/afbjorklund/go-getter v1.4.1-0.20190910175809-eb9f6c26742c
 	github.com/samalba/dockerclient => github.com/sayboras/dockerclient v0.0.0-20191231050035-015626177a97
 	k8s.io/api => k8s.io/api v0.17.3

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUW
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdcM=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
-github.com/afbjorklund/go-containerregistry v0.0.0-20200329163843-4f5ebd05922c h1:6fbgFHLPMCieDysTguJY03Zer8hNr8+GbvpD291DOXA=
-github.com/afbjorklund/go-containerregistry v0.0.0-20200329163843-4f5ebd05922c/go.mod h1:pD1UFYs7MCAx+ZLShBdttcaOSbyc8F9Na/9IZLNwJeA=
+github.com/afbjorklund/go-containerregistry v0.0.0-20200602203322-347d93793dc9 h1:EMF82QM65iOfQTQefF5d5SCsSsXsh6aSdcq9U1KC3Lc=
+github.com/afbjorklund/go-containerregistry v0.0.0-20200602203322-347d93793dc9/go.mod h1:npTSyywOeILcgWqd+rvtzGWflIPPcBQhYoOONaY4ltM=
 github.com/afbjorklund/go-getter v1.4.1-0.20190910175809-eb9f6c26742c h1:18gEt7qzn7CW7qMkfPTFyyotlPbvPQo9o4IDV8jZqP4=
 github.com/afbjorklund/go-getter v1.4.1-0.20190910175809-eb9f6c26742c/go.mod h1:7qxyCd8rBfcShwsvxgIguu4KbS3l8bUCwg2Umn7RjeY=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=


### PR DESCRIPTION
Also forgot to update upstream _last_ time (05459a2e4)
(it was updated to v0.0.0-20200320200342-35f57d7d4930)

https://github.com/google/go-containerregistry/compare/master...afbjorklund:daemon-refwrite

Put the old code on daemon-rewrite.old branch instead,
in case someone wants to build the interim baselines?

https://github.com/google/go-containerregistry/compare/master...afbjorklund:daemon-refwrite.old

----

Fixes build error on master:

`go: github.com/afbjorklund/go-containerregistry@v0.0.0-20200329163843-4f5ebd05922c: invalid version: unknown revision 4f5ebd05922c`

I hate the go versioning.

And don't really like forks.