### PR TITLE
wip: Fixes duplicate messages to upgrade Kubernetes

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -154,7 +154,8 @@ func runStart(cmd *cobra.Command, args []string) {
 
 	validateSpecifiedDriver(existing)
 	ds, alts, specified := selectDriver(existing)
-	starter, err := provisionWithDriver(cmd, ds, existing)
+	var displayKubernetesUpgradeMessage uint32 = 0
+	starter, err := provisionWithDriver(cmd, ds, existing, &displayKubernetesUpgradeMessage)
 	if err != nil {
 		if errors.Is(err, oci.ErrWindowsContainers) {
 			out.ErrLn("")
@@ -184,7 +185,7 @@ func runStart(cmd *cobra.Command, args []string) {
 				if err != nil {
 					out.WarningT("Failed to delete cluster {{.name}}, proceeding with retry anyway.", out.V{"name": ClusterFlagValue()})
 				}
-				starter, err = provisionWithDriver(cmd, ds, existing)
+				starter, err = provisionWithDriver(cmd, ds, existing, &displayKubernetesUpgradeMessage)
 				if err != nil {
 					continue
 				} else {
@@ -219,7 +220,7 @@ func provisionWithDriver(cmd *cobra.Command, ds registry.DriverState, existing *
 		glog.Errorf("Error autoSetOptions : %v", err)
 	}
 
-	validateFlags(cmd, driverName)
+	validateFlags(cmd, driverName, displayKubernetesUpgradeMessage)
 	validateUser(driverName)
 
 	// Download & update the driver, even in --download-only mode

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -345,13 +345,15 @@ func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k
 	if driver.BareMetal(cc.Driver) {
 		kubeNodeName = "m01"
 	}
-	return createNode(cc, kubeNodeName, existing)
+	var displayKubernetesUpgradeMessage uint32 = 1
+	return createNode(cc, kubeNodeName, existing, &displayKubernetesUpgradeMessage)
 }
 
 // updateExistingConfigFromFlags will update the existing config from the flags - used on a second start
 // skipping updating existing docker env , docker opt, InsecureRegistry, registryMirror, extra-config, apiserver-ips
 func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterConfig) config.ClusterConfig { //nolint to suppress cyclomatic complexity 45 of func `updateExistingConfigFromFlags` is high (> 30)
-	validateFlags(cmd, existing.Driver)
+	var displayKubernetesUpgradeMessage uint32 = 1
+	validateFlags(cmd, existing.Driver, &displayKubernetesUpgradeMessage)
 
 	cc := *existing
 	if cmd.Flags().Changed(containerRuntime) {

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -475,7 +475,8 @@ func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterC
 	}
 
 	if cmd.Flags().Changed(kubernetesVersion) {
-		cc.KubernetesConfig.KubernetesVersion = getKubernetesVersion(existing)
+		var displayKubernetesUpgradeMessage uint32 = 1
+		cc.KubernetesConfig.KubernetesVersion = getKubernetesVersion(existing, &displayKubernetesUpgradeMessage)
 	}
 
 	if cmd.Flags().Changed(apiServerName) {

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -70,7 +70,8 @@ func TestGetKubernetesVersion(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			viper.SetDefault(kubernetesVersion, test.paramVersion)
-			version := getKubernetesVersion(test.cfg)
+			var displayKubernetesUpgradeMessage uint32 = 1
+			version := getKubernetesVersion(test.cfg, &displayKubernetesUpgradeMessage)
 
 			// check whether we are getting the expected version
 			if version != test.expectedVersion {


### PR DESCRIPTION
Introduce a parameter displayKubernetesUpgradeMessage in func getKubernetesVersion that disables multiple prints of the upgrade message

Fixes #8418 

Before:
```
😄  minikube v1.11.0 on Darwin 10.14.6
✨  Using the hyperkit driver based on existing profile
🆕  Kubernetes 1.18.3 is now available. If you would like to upgrade, specify: --kubernetes-version=v1.18.3
🆕  Kubernetes 1.18.3 is now available. If you would like to upgrade, specify: --kubernetes-version=v1.18.3
🆕  Kubernetes 1.18.3 is now available. If you would like to upgrade, specify: --kubernetes-version=v1.18.3
👍  Starting control plane node minikube in cluster minikube
🏃  Updating the running hyperkit "minikube" VM ...
❗  This VM is having trouble accessing https://k8s.gcr.io
💡  To pull new external images, you may need to configure a proxy: https://minikube.sigs.k8s.io/docs/reference/networking/proxy/
🐳  Preparing Kubernetes v1.18.3 on Docker 19.03.8 ...
🔎  Verifying Kubernetes components...
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube"

❗  /usr/local/bin/kubectl is version 1.15.5, which may be incompatible with Kubernetes 1.18.3.
💡  You can also use 'minikube kubectl -- get pods' to invoke a matching version
```

After:
```
😄  minikube v1.11.0 on Darwin 10.14.6
✨  Using the hyperkit driver based on existing profile
🆕  Kubernetes 1.18.3 is now available. If you would like to upgrade, specify: --kubernetes-version=v1.18.3
👍  Starting control plane node minikube in cluster minikube
🏃  Updating the running hyperkit "minikube" VM ...
❗  This VM is having trouble accessing https://k8s.gcr.io
💡  To pull new external images, you may need to configure a proxy: https://minikube.sigs.k8s.io/docs/reference/networking/proxy/
🐳  Preparing Kubernetes v1.18.3 on Docker 19.03.8 ...
🔎  Verifying Kubernetes components...
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube"

❗  /usr/local/bin/kubectl is version 1.15.5, which may be incompatible with Kubernetes 1.18.3.
💡  You can also use 'minikube kubectl -- get pods' to invoke a matching version
```
