### PR TITLE
Add heapster alias to metrics-server addon

### DIFF
--- a/cmd/minikube/cmd/config/disable.go
+++ b/cmd/minikube/cmd/config/disable.go
@@ -34,7 +34,7 @@ var addonsDisableCmd = &cobra.Command{
 
 		addon := args[0]
 		if addon == "heapster" {
-			exit.WithCodeT(exit.Unavailable, "There is no heapster addon")
+			exit.WithCodeT(exit.Unavailable, "The heapster addon is depreciated. please try to disable metrics-server instead")
 		}
 		err := addons.SetAndSave(ClusterFlagValue(), addon, "false")
 		if err != nil {

--- a/cmd/minikube/cmd/config/disable.go
+++ b/cmd/minikube/cmd/config/disable.go
@@ -33,6 +33,9 @@ var addonsDisableCmd = &cobra.Command{
 		}
 
 		addon := args[0]
+		if addon == "heapster" {
+			exit.WithCodeT(exit.Unavailable, "There is no heapster addon")
+		}
 		err := addons.SetAndSave(ClusterFlagValue(), addon, "false")
 		if err != nil {
 			exit.WithError("disable failed", err)

--- a/cmd/minikube/cmd/config/enable.go
+++ b/cmd/minikube/cmd/config/enable.go
@@ -32,6 +32,11 @@ var addonsEnableCmd = &cobra.Command{
 			exit.UsageT("usage: minikube addons enable ADDON_NAME")
 		}
 		addon := args[0]
+		// replace heapster as metrics-server because heapster is deprecated
+		if addon == "heapster" {
+			out.T(out.Waiting, "enable metrics-server addon instead of heapster addon because heapster is deprecated")
+			addon = "metrics-server"
+		}
 		err := addons.SetAndSave(ClusterFlagValue(), addon, "true")
 		if err != nil {
 			exit.WithError("enable failed", err)

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -334,7 +334,11 @@ func Start(wg *sync.WaitGroup, cc *config.ClusterConfig, toEnable map[string]boo
 
 	// Apply new addons
 	for _, name := range additional {
-		toEnable[name] = true
+		// if the specified addon doesn't exist, skip enabling
+		_, e := isAddonValid(name)
+		if e {
+			toEnable[name] = true
+		}
 	}
 
 	toEnableList := []string{}

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -334,6 +334,10 @@ func Start(wg *sync.WaitGroup, cc *config.ClusterConfig, toEnable map[string]boo
 
 	// Apply new addons
 	for _, name := range additional {
+		// replace heapster as metrics-server because heapster is deprecated
+		if name == "heapster" {
+			name = "metrics-server"
+		}
 		// if the specified addon doesn't exist, skip enabling
 		_, e := isAddonValid(name)
 		if e {

--- a/pkg/addons/config.go
+++ b/pkg/addons/config.go
@@ -149,9 +149,4 @@ var Addons = []*Addon{
 		set:       SetBool,
 		callbacks: []setFn{enableOrDisableAddon},
 	},
-	{
-		name:      "heapster",
-		set:       SetBool,
-		callbacks: []setFn{enableOrDisableAddon},
-	},
 }

--- a/pkg/addons/config.go
+++ b/pkg/addons/config.go
@@ -149,4 +149,9 @@ var Addons = []*Addon{
 		set:       SetBool,
 		callbacks: []setFn{enableOrDisableAddon},
 	},
+	{
+		name:      "heapster",
+		set:       SetBool,
+		callbacks: []setFn{enableOrDisableAddon},
+	},
 }


### PR DESCRIPTION
### What type of PR is this?
/kind bug
/area addons

### What this PR does / why we need it:

This PR add heapster alias to metrics-server addon.
`kubectl top` command needs heapster or metrics-server addon. But heapster is deprecated. 
By this PR, when users enable heapster addon, metrics-server addon will be enabled instead.

### Which issue(s) this PR fixes:
Fix #8360

### Does this PR introduce a user-facing change?

Yes. This PR add heapster addon alias.

**Before this PR**

```
$ kubectl top pods
Error from server (NotFound): the server could not find the requested resource (get services http:heapster:)

$ minikube addons enable heapster
💣  enable failed: run callbacks: heapster is not a valid addon

😿  minikube is exiting due to an error. If the above message is not useful, open an issue:
👉  https://github.com/kubernetes/minikube/issues/new/choose
```

**After this PR**

```
$ kubectl top pods
Error from server (NotFound): the server could not find the requested resource (get services http:heapster:)

$ minikube addons enable heapster
⌛  enable metrics-server addon instead of heapster addon because heapster is deprecated
🌟  The 'metrics-server' addon is enabled

$ kubectl top pods -n kube-system
NAME                               CPU(cores)   MEMORY(bytes)
coredns-66bff467f8-8z27z           3m           6Mi
...
```

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```