### PR TITLE
Improve logging for cloud shell

### DIFF
--- a/pkg/drivers/kic/oci/cli_runner.go
+++ b/pkg/drivers/kic/oci/cli_runner.go
@@ -88,7 +88,7 @@ func runCmd(cmd *exec.Cmd, warnSlow ...bool) (*RunResult, error) {
 	}
 
 	killTime := 19 * time.Second // this will be applied only if warnSlow is true
-	warnTime := 10 * time.Second
+	warnTime := 2 * time.Second
 
 	if cmd.Args[1] == "volume" || cmd.Args[1] == "ps" { // volume and ps requires more time than inspect
 		killTime = 30 * time.Second

--- a/pkg/drivers/kic/oci/cli_runner.go
+++ b/pkg/drivers/kic/oci/cli_runner.go
@@ -88,7 +88,7 @@ func runCmd(cmd *exec.Cmd, warnSlow ...bool) (*RunResult, error) {
 	}
 
 	killTime := 19 * time.Second // this will be applied only if warnSlow is true
-	warnTime := 2 * time.Second
+	warnTime := 10 * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), killTime)
 	defer cancel()
 
@@ -138,7 +138,7 @@ func runCmd(cmd *exec.Cmd, warnSlow ...bool) (*RunResult, error) {
 		}
 
 		if ctx.Err() == context.DeadlineExceeded {
-			return rr, fmt.Errorf("%q timed out after %s", rr.Command(), killTime)
+			return rr, context.DeadlineExceeded
 		}
 	}
 

--- a/pkg/drivers/kic/oci/cli_runner.go
+++ b/pkg/drivers/kic/oci/cli_runner.go
@@ -89,13 +89,14 @@ func runCmd(cmd *exec.Cmd, warnSlow ...bool) (*RunResult, error) {
 
 	killTime := 19 * time.Second // this will be applied only if warnSlow is true
 	warnTime := 10 * time.Second
-	ctx, cancel := context.WithTimeout(context.Background(), killTime)
-	defer cancel()
 
 	if cmd.Args[1] == "volume" || cmd.Args[1] == "ps" { // volume and ps requires more time than inspect
 		killTime = 30 * time.Second
 		warnTime = 3 * time.Second
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), killTime)
+	defer cancel()
 
 	if warn { // convert exec.Command to with context
 		cmdWithCtx := exec.CommandContext(ctx, cmd.Args[0], cmd.Args[1:]...)

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -17,6 +17,7 @@ limitations under the License.
 package oci
 
 import (
+	"context"
 	"os"
 	"time"
 
@@ -27,6 +28,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/util/retry"
 
 	"fmt"
@@ -73,10 +75,11 @@ func DeleteContainersByLabel(ociBin string, label string) []error {
 
 // DeleteContainer deletes a container by ID or Name
 func DeleteContainer(ociBin string, name string) error {
-
 	_, err := ContainerStatus(ociBin, name)
-	if err != nil {
-		glog.Infof("%s daemon seems to be stuck. Will try to delete anyways: %v", ociBin, err)
+	if err == context.DeadlineExceeded {
+		out.WarningT("{{.ocibin}} daemon is taking an unsually long time to respond, consider restarting {{.ocibin}}", out.V{"ociBin": ociBin})
+	} else if err != nil {
+		glog.Warningf("error getting container status, will try to delete anyways: %v", err)
 	}
 	// try to delete anyways
 	if err := ShutDown(ociBin, name); err != nil {

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -77,7 +77,7 @@ func DeleteContainersByLabel(ociBin string, label string) []error {
 func DeleteContainer(ociBin string, name string) error {
 	_, err := ContainerStatus(ociBin, name)
 	if err == context.DeadlineExceeded {
-		out.WarningT("{{.ocibin}} daemon is taking an unsually long time to respond, consider restarting {{.ocibin}}", out.V{"ociBin": ociBin})
+		out.WarningT("{{.ocibin}} is taking an unsually long time to respond, consider restarting {{.ocibin}}", out.V{"ociBin": ociBin})
 	} else if err != nil {
 		glog.Warningf("error getting container status, will try to delete anyways: %v", err)
 	}

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -76,7 +76,7 @@ func DeleteContainer(ociBin string, name string) error {
 
 	_, err := ContainerStatus(ociBin, name)
 	if err != nil {
-		glog.Errorf("%s daemon seems to be stuck. Please try restarting your %s. Will try to delete anyways: %v", ociBin, ociBin, err)
+		glog.Infof("%s daemon seems to be stuck. Will try to delete anyways: %v", ociBin, err)
 	}
 	// try to delete anyways
 	if err := ShutDown(ociBin, name); err != nil {


### PR DESCRIPTION
For cloud shell, on restart the home directory of the VM is preserved. This means that if minikube was running, the minikube profile config is leftover even though minikube has been deleted.

When running `minikube start` on a refreshed Cloud Shell VM, minikube thinks there's an existing cluster because the profile exists, and we get this ugly log to stdout:

```
$ minikube start
* minikube v1.10.1 on Debian 10.4
  - MINIKUBE_FORCE_SYSTEMD=true
* Using the docker driver based on existing profile
* Starting control plane node minikube in cluster minikube
* Pulling base image ...
* minikube 1.11.0 is available! Download it: https://github.com/kubernetes/minikube/releases/tag/v1.11.0
* To disable this notice, run: 'minikube config set WantUpdateNotification false'
* docker "minikube" container is missing, will recreate.
E0611 10:53:46.318887     504 oci.go:79] docker daemon seems to be stuck. Please try restarting your docker. Will try to delete anyways: unknown state "minikube": docker inspect minikube --format={{.State.Status}}: exit status 1
stdout:
stderr:
Error: No such object: minikube

E0611 10:53:46.318887     504 oci.go:79] docker daemon seems to be stuck. Please try restarting your docker. Will try to delete anyways: unknown state "minikube": docker inspect minikube --format={{.State.Status}}: exit status 1
stdout:
stderr:
Error: No such object: minikube

E0611 10:53:46.318887     504 oci.go:79] docker daemon seems to be stuck. Please try restarting your docker. Will try to delete anyways: unknown state "minikube": docker inspect minikube --format={{.State.Status}}: exit status 1
stdout:
stderr:
Error: No such object: minikube
```

I generally think all glog logs should be sent to stderr & if we want an explicit warning message here it should go through the `out` package.

In this case I also think the explicit warning to restart docker is confusing -- it takes a long time to get info on minikube in docker because it doesn't exist, and then we assume the daemon is stuck, which isn't correct.