### PR TITLE
skip olm addon

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -630,7 +630,7 @@ jobs:
           echo "*** $numPass Passed ***"
           if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
           if [ "$numPass" -eq 0 ];then echo "*** 0 Passed! ***";exit 2;fi
-          if [ "$numPass" -lt 6 ];then echo "*** Failed to pass at least 6 ! ***";exit 2;fi
+          if [ "$numPass" -lt 5 ];then echo "*** Failed to pass at least 5 ! ***";exit 2;fi
           if [ "$numPass" -eq 0 ];then echo "*** Passed! ***";exit 0;fi
   multinode_pause_docker_ubuntu:
     runs-on: ubuntu-18.04

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -628,7 +628,7 @@ jobs:
           echo "*** $numPass Passed ***"
           if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
           if [ "$numPass" -eq 0 ];then echo "*** 0 Passed! ***";exit 2;fi
-          if [ "$numPass" -lt 6 ];then echo "*** Failed to pass at least 6 ! ***";exit 2;fi
+          if [ "$numPass" -lt 5 ];then echo "*** Failed to pass at least 5 ! ***";exit 2;fi
           if [ "$numPass" -eq 0 ];then echo "*** Passed! ***";exit 0;fi
   multinode_pause_docker_ubuntu:
     runs-on: ubuntu-18.04

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -331,9 +331,7 @@ func validateHelmTillerAddon(ctx context.Context, t *testing.T, profile string) 
 }
 
 func validateOlmAddon(ctx context.Context, t *testing.T, profile string) {
-	if NoneDriver() {
-		t.Skipf("Skipping none driver, olm addon is not supported on none driver")
-	}
+	t.Skipf("Skipping olm test till this timeout issue is solved https://github.com/operator-framework/operator-lifecycle-manager/issues/1534#issuecomment-632342257")
 	defer PostMortemLogs(t, profile)
 
 	client, err := kapi.Client(profile)


### PR DESCRIPTION
till this issue is fixed and I am convinced that this test can run on our github action test infra without adding extra memory.

https://github.com/operator-framework/operator-lifecycle-manager/issues/1534#issuecomment-632342257