### PR TITLE
Move kubelet params to config file

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/ktmpl/v1alpha3.go
+++ b/pkg/minikube/bootstrapper/bsutil/ktmpl/v1alpha3.go
@@ -68,7 +68,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: {{.ClientCAFile}}
+cgroupDriver: {{.CgroupDriver}}
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/ktmpl/v1alpha3.go
+++ b/pkg/minikube/bootstrapper/bsutil/ktmpl/v1alpha3.go
@@ -68,6 +68,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: {{.ClientCAFile}}
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -76,4 +77,5 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: {{.StaticPodPath}}
 `))

--- a/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta1.go
+++ b/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta1.go
@@ -79,7 +79,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: {{.ClientCAFile}}
+authentication:
+  x509:
+    clientCAFile: {{.ClientCAFile}}
+cgroupDriver: {{.CgroupDriver}}
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta1.go
+++ b/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta1.go
@@ -79,6 +79,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: {{.ClientCAFile}}
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -87,6 +88,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: {{.StaticPodPath}}
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta2.go
+++ b/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta2.go
@@ -83,7 +83,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: {{.ClientCAFile}}
+authentication:
+  x509:
+    clientCAFile: {{.ClientCAFile}}
+cgroupDriver: {{.CgroupDriver}}
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta2.go
+++ b/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta2.go
@@ -83,6 +83,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: {{.ClientCAFile}}
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -91,6 +92,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: {{.StaticPodPath}}
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/kubeadm.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubeadm.go
@@ -61,6 +61,11 @@ func GenerateKubeadmYAML(cc config.ClusterConfig, n config.Node, r cruntime.Mana
 		nodePort = constants.APIServerPort
 	}
 
+	cgroupDriver, err := r.CGroupDriver()
+	if err != nil {
+		return nil, errors.Wrap(err, "getting cgroup driver")
+	}
+
 	componentOpts, err := createExtraComponentConfig(k8s.ExtraOptions, version, componentFeatureArgs, cp)
 	if err != nil {
 		return nil, errors.Wrap(err, "generating extra component config for kubeadm")
@@ -96,6 +101,7 @@ func GenerateKubeadmYAML(cc config.ClusterConfig, n config.Node, r cruntime.Mana
 		FeatureArgs         map[string]bool
 		NoTaintMaster       bool
 		NodeIP              string
+		CgroupDriver        string
 		ClientCAFile        string
 		StaticPodPath       string
 		ControlPlaneAddress string
@@ -119,6 +125,7 @@ func GenerateKubeadmYAML(cc config.ClusterConfig, n config.Node, r cruntime.Mana
 		NoTaintMaster:       false, // That does not work with k8s 1.12+
 		DNSDomain:           k8s.DNSDomain,
 		NodeIP:              n.IP,
+		CgroupDriver:        cgroupDriver,
 		ClientCAFile:        path.Join(vmpath.GuestKubernetesCertsDir, "ca.crt"),
 		StaticPodPath:       vmpath.GuestManifestsDir,
 		ControlPlaneAddress: constants.ControlPlaneAlias,

--- a/pkg/minikube/bootstrapper/bsutil/kubeadm.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubeadm.go
@@ -96,6 +96,8 @@ func GenerateKubeadmYAML(cc config.ClusterConfig, n config.Node, r cruntime.Mana
 		FeatureArgs         map[string]bool
 		NoTaintMaster       bool
 		NodeIP              string
+		ClientCAFile        string
+		StaticPodPath       string
 		ControlPlaneAddress string
 		KubeProxyOptions    map[string]string
 	}{
@@ -117,6 +119,8 @@ func GenerateKubeadmYAML(cc config.ClusterConfig, n config.Node, r cruntime.Mana
 		NoTaintMaster:       false, // That does not work with k8s 1.12+
 		DNSDomain:           k8s.DNSDomain,
 		NodeIP:              n.IP,
+		ClientCAFile:        path.Join(vmpath.GuestKubernetesCertsDir, "ca.crt"),
+		StaticPodPath:       vmpath.GuestManifestsDir,
 		ControlPlaneAddress: constants.ControlPlaneAlias,
 		KubeProxyOptions:    createKubeProxyOptions(k8s.ExtraOptions),
 	}

--- a/pkg/minikube/bootstrapper/bsutil/kubelet.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubelet.go
@@ -44,11 +44,6 @@ func extraKubeletOpts(mc config.ClusterConfig, nc config.Node, r cruntime.Manage
 		return nil, errors.Wrap(err, "generating extra configuration for kubelet")
 	}
 
-	cgroupDriver, err := r.CGroupDriver()
-	if err == nil {
-		extraOpts["cgroup-driver"] = cgroupDriver
-	}
-
 	for k, v := range r.KubeletOptions() {
 		extraOpts[k] = v
 	}

--- a/pkg/minikube/bootstrapper/bsutil/kubelet_test.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubelet_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/pmezard/go-difflib/difflib"
-	"k8s.io/minikube/pkg/minikube/command"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/cruntime"
@@ -176,8 +175,7 @@ ExecStart=/var/lib/minikube/binaries/v1.18.2/kubelet --authorization-mode=Webhoo
 
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
-			runtime, err := cruntime.New(cruntime.Config{Type: tc.cfg.KubernetesConfig.ContainerRuntime,
-				Runner: command.NewFakeCommandRunner()})
+			runtime, err := cruntime.New(cruntime.Config{Type: tc.cfg.KubernetesConfig.ContainerRuntime})
 			if err != nil {
 				t.Fatalf("runtime: %v", err)
 			}

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/containerd-api-port.yaml
@@ -40,6 +40,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -48,3 +49,4 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/containerd-api-port.yaml
@@ -40,7 +40,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/containerd-pod-network-cidr.yaml
@@ -40,6 +40,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -48,3 +49,4 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/containerd-pod-network-cidr.yaml
@@ -40,7 +40,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/containerd.yaml
@@ -40,6 +40,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -48,3 +49,4 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/containerd.yaml
@@ -40,7 +40,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/crio-options-gates.yaml
@@ -48,7 +48,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/crio-options-gates.yaml
@@ -48,6 +48,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -56,3 +57,4 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/crio.yaml
@@ -40,6 +40,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -48,3 +49,4 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/crio.yaml
@@ -40,7 +40,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/default.yaml
@@ -40,6 +40,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -48,3 +49,4 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/default.yaml
@@ -40,7 +40,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/dns.yaml
@@ -40,6 +40,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -48,3 +49,4 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/dns.yaml
@@ -40,7 +40,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/image-repository.yaml
@@ -41,6 +41,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -49,3 +50,4 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/image-repository.yaml
@@ -41,7 +41,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/options.yaml
@@ -45,6 +45,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -53,3 +54,4 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/options.yaml
@@ -45,7 +45,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/containerd-api-port.yaml
@@ -40,6 +40,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -48,3 +49,4 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/containerd-api-port.yaml
@@ -40,7 +40,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/containerd-pod-network-cidr.yaml
@@ -40,6 +40,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -48,3 +49,4 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/containerd-pod-network-cidr.yaml
@@ -40,7 +40,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/containerd.yaml
@@ -40,6 +40,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -48,3 +49,4 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/containerd.yaml
@@ -40,7 +40,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/crio-options-gates.yaml
@@ -48,7 +48,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/crio-options-gates.yaml
@@ -48,6 +48,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -56,3 +57,4 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/crio.yaml
@@ -40,6 +40,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -48,3 +49,4 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/crio.yaml
@@ -40,7 +40,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/default.yaml
@@ -40,6 +40,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -48,3 +49,4 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/default.yaml
@@ -40,7 +40,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/dns.yaml
@@ -40,6 +40,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -48,3 +49,4 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/dns.yaml
@@ -40,7 +40,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/image-repository.yaml
@@ -41,6 +41,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -49,3 +50,4 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/image-repository.yaml
@@ -41,7 +41,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/options.yaml
@@ -45,6 +45,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -53,3 +54,4 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/options.yaml
@@ -45,7 +45,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd-api-port.yaml
@@ -47,6 +47,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -55,6 +56,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd-api-port.yaml
@@ -47,7 +47,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd-pod-network-cidr.yaml
@@ -47,6 +47,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -55,6 +56,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd-pod-network-cidr.yaml
@@ -47,7 +47,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd.yaml
@@ -47,6 +47,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -55,6 +56,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd.yaml
@@ -47,7 +47,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/crio-options-gates.yaml
@@ -57,6 +57,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -65,6 +66,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/crio-options-gates.yaml
@@ -57,7 +57,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/crio.yaml
@@ -47,6 +47,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -55,6 +56,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/crio.yaml
@@ -47,7 +47,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/default.yaml
@@ -47,6 +47,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -55,6 +56,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/default.yaml
@@ -47,7 +47,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/dns.yaml
@@ -47,6 +47,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -55,6 +56,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/dns.yaml
@@ -47,7 +47,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/image-repository.yaml
@@ -48,7 +48,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/image-repository.yaml
@@ -48,6 +48,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -56,6 +57,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/options.yaml
@@ -54,6 +54,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -62,6 +63,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/options.yaml
@@ -54,7 +54,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd-api-port.yaml
@@ -47,6 +47,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -55,6 +56,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd-api-port.yaml
@@ -47,7 +47,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd-pod-network-cidr.yaml
@@ -47,6 +47,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -55,6 +56,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd-pod-network-cidr.yaml
@@ -47,7 +47,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd.yaml
@@ -47,6 +47,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -55,6 +56,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd.yaml
@@ -47,7 +47,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/crio-options-gates.yaml
@@ -57,6 +57,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -65,6 +66,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/crio-options-gates.yaml
@@ -57,7 +57,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/crio.yaml
@@ -47,6 +47,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -55,6 +56,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/crio.yaml
@@ -47,7 +47,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/default.yaml
@@ -47,6 +47,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -55,6 +56,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/default.yaml
@@ -47,7 +47,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/dns.yaml
@@ -47,6 +47,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -55,6 +56,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/dns.yaml
@@ -47,7 +47,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/image-repository.yaml
@@ -48,7 +48,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/image-repository.yaml
@@ -48,6 +48,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -56,6 +57,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/options.yaml
@@ -54,6 +54,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -62,6 +63,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/options.yaml
@@ -54,7 +54,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd-api-port.yaml
@@ -47,6 +47,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -55,6 +56,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd-api-port.yaml
@@ -47,7 +47,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd-pod-network-cidr.yaml
@@ -47,6 +47,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -55,6 +56,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd-pod-network-cidr.yaml
@@ -47,7 +47,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd.yaml
@@ -47,6 +47,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -55,6 +56,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd.yaml
@@ -47,7 +47,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/crio-options-gates.yaml
@@ -57,6 +57,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -65,6 +66,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/crio-options-gates.yaml
@@ -57,7 +57,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/crio.yaml
@@ -47,6 +47,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -55,6 +56,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/crio.yaml
@@ -47,7 +47,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/default.yaml
@@ -47,6 +47,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -55,6 +56,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/default.yaml
@@ -47,7 +47,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/dns.yaml
@@ -47,6 +47,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -55,6 +56,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/dns.yaml
@@ -47,7 +47,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/image-repository.yaml
@@ -48,7 +48,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/image-repository.yaml
@@ -48,6 +48,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -56,6 +57,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/options.yaml
@@ -54,6 +54,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -62,6 +63,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/options.yaml
@@ -54,7 +54,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-api-port.yaml
@@ -45,7 +45,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-api-port.yaml
@@ -45,6 +45,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -53,6 +54,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-pod-network-cidr.yaml
@@ -45,7 +45,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-pod-network-cidr.yaml
@@ -45,6 +45,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -53,6 +54,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd.yaml
@@ -45,7 +45,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd.yaml
@@ -45,6 +45,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -53,6 +54,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio-options-gates.yaml
@@ -55,6 +55,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -63,6 +64,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio-options-gates.yaml
@@ -55,7 +55,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio.yaml
@@ -45,7 +45,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio.yaml
@@ -45,6 +45,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -53,6 +54,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/default.yaml
@@ -45,7 +45,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/default.yaml
@@ -45,6 +45,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -53,6 +54,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/dns.yaml
@@ -45,7 +45,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/dns.yaml
@@ -45,6 +45,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -53,6 +54,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/image-repository.yaml
@@ -46,6 +46,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -54,6 +55,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/image-repository.yaml
@@ -46,7 +46,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/options.yaml
@@ -52,7 +52,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/options.yaml
@@ -52,6 +52,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -60,6 +61,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd-api-port.yaml
@@ -45,7 +45,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd-api-port.yaml
@@ -45,6 +45,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -53,6 +54,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd-pod-network-cidr.yaml
@@ -45,7 +45,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd-pod-network-cidr.yaml
@@ -45,6 +45,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -53,6 +54,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd.yaml
@@ -45,7 +45,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd.yaml
@@ -45,6 +45,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -53,6 +54,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/crio-options-gates.yaml
@@ -55,6 +55,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -63,6 +64,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/crio-options-gates.yaml
@@ -55,7 +55,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/crio.yaml
@@ -45,7 +45,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/crio.yaml
@@ -45,6 +45,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -53,6 +54,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/default.yaml
@@ -45,7 +45,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/default.yaml
@@ -45,6 +45,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -53,6 +54,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/dns.yaml
@@ -45,7 +45,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/dns.yaml
@@ -45,6 +45,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -53,6 +54,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/image-repository.yaml
@@ -46,6 +46,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -54,6 +55,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/image-repository.yaml
@@ -46,7 +46,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/options.yaml
@@ -52,7 +52,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/options.yaml
@@ -52,6 +52,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -60,6 +61,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd-api-port.yaml
@@ -45,7 +45,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd-api-port.yaml
@@ -45,6 +45,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -53,6 +54,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd-pod-network-cidr.yaml
@@ -45,7 +45,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd-pod-network-cidr.yaml
@@ -45,6 +45,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -53,6 +54,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd.yaml
@@ -45,7 +45,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd.yaml
@@ -45,6 +45,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -53,6 +54,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/crio-options-gates.yaml
@@ -55,6 +55,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -63,6 +64,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/crio-options-gates.yaml
@@ -55,7 +55,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/crio.yaml
@@ -45,7 +45,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/crio.yaml
@@ -45,6 +45,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -53,6 +54,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/default.yaml
@@ -45,7 +45,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/default.yaml
@@ -45,6 +45,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -53,6 +54,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/dns.yaml
@@ -45,7 +45,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/dns.yaml
@@ -45,6 +45,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -53,6 +54,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/image-repository.yaml
@@ -46,6 +46,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -54,6 +55,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/image-repository.yaml
@@ -46,7 +46,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/options.yaml
@@ -52,7 +52,10 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-clientCAFile: /var/lib/minikube/certs/ca.crt
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: systemd
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/options.yaml
@@ -52,6 +52,7 @@ networking:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+clientCAFile: /var/lib/minikube/certs/ca.crt
 clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
@@ -60,6 +61,7 @@ evictionHard:
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
 failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/pkg/minikube/bootstrapper/bsutil/versions.go
+++ b/pkg/minikube/bootstrapper/bsutil/versions.go
@@ -17,12 +17,10 @@ limitations under the License.
 package bsutil
 
 import (
-	"path"
 	"strings"
 
 	"github.com/blang/semver"
 	"k8s.io/minikube/pkg/minikube/config"
-	"k8s.io/minikube/pkg/minikube/vmpath"
 	"k8s.io/minikube/pkg/util"
 )
 
@@ -52,8 +50,6 @@ var versionSpecificOpts = []config.VersionedExtraOption{
 		LessThanOrEqual: semver.MustParse("1.9.10"),
 	},
 
-	// System pods args
-	config.NewUnversionedOption(Kubelet, "pod-manifest-path", vmpath.GuestManifestsDir),
 	{
 		Option: config.ExtraOption{
 			Component: Kubelet,
@@ -66,12 +62,6 @@ var versionSpecificOpts = []config.VersionedExtraOption{
 	// Kubelet config file
 	config.NewUnversionedOption(Kubelet, "config", "/var/lib/kubelet/config.yaml"),
 
-	// Auth args
-	config.NewUnversionedOption(Kubelet, "authorization-mode", "Webhook"),
-	config.NewUnversionedOption(Kubelet, "client-ca-file", path.Join(vmpath.GuestKubernetesCertsDir, "ca.crt")),
-
-	// Cgroup args
-	config.NewUnversionedOption(Kubelet, "cgroup-driver", "cgroupfs"),
 	{
 		Option: config.ExtraOption{
 			Component: Apiserver,


### PR DESCRIPTION
fixes #8380

This is a follow-up to #8342. It takes care of the following parameters which were being passed on the command-line (causing deprecation warnings in kubelet logs) -

1. `--authorization-mode` - removed as it already defaults to Webhook when --config flag is present
1. `--cgroup-driver` - set in the config file instead of cmdline
1. `--client-ca-file` - set in the config file for v1.16+. Before that a kubeadm bug did not allow overriding this via config file. (https://github.com/kubernetes/kubernetes/pull/81903)
1. `--pod-manifest-path` - set in config file instead of cmdline

This takes care of all such warnings in kubelet logs.
>minikube kubelet[3637]: Flag --authorization-mode has been deprecated ...
minikube kubelet[3637]: Flag --cgroup-driver has been deprecated ...
minikube kubelet[3637]: Flag --client-ca-file has been deprecated ...
minikube kubelet[3637]: Flag --pod-manifest-path has been deprecated ...

Tested by running `minikube start` (only for the hyperkit driver) for all minor versions between v1.13 - v1.18