### PR TITLE
bump helm-tiller addon to v2.16.8

### DIFF
--- a/deploy/addons/helm-tiller/helm-tiller-dp.tmpl
+++ b/deploy/addons/helm-tiller/helm-tiller-dp.tmpl
@@ -46,7 +46,7 @@ spec:
               value: kube-system
             - name: TILLER_HISTORY_MAX
               value: "0"
-          image: gcr.io/kubernetes-helm/tiller:v2.16.7
+          image: gcr.io/kubernetes-helm/tiller:v2.16.8
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3


### PR DESCRIPTION
### What type of PR is this?
/area addons

### What this PR does / why we need it:

This PR bump up helm-tiller addon's image v2.16.7 to v2.16.8.
This fix high-severity security vulnerability in helm2(tiller) addons.

### Which issue(s) this PR fixes:

Fixes #8470  

### Does this PR introduce a user-facing change?

Yes.
This image bumpup includes helm2 security patch.
https://github.com/helm/helm/releases/tag/v2.16.8

**Before**
```
image: gcr.io/kubernetes-helm/tiller:v2.16.7
```

**After**
```
image: gcr.io/kubernetes-helm/tiller:v2.16.8
```

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```