### PR TITLE
Require minikube-automount for /run/minikube/env

### DIFF
--- a/deploy/iso/minikube-iso/package/crio-bin/crio-wipe.service
+++ b/deploy/iso/minikube-iso/package/crio-bin/crio-wipe.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=CRI-O Auto Update Script
 Before=crio.service
+After=minikube-automount.service
+Requires=minikube-automount.service
 RequiresMountsFor=/var/lib/containers
 
 [Service]


### PR DESCRIPTION
systemd gets sad if environment files are missing

For #8466