### PR TITLE
Fix host network interface for VBox

### DIFF
--- a/pkg/minikube/cluster/ip.go
+++ b/pkg/minikube/cluster/ip.go
@@ -59,17 +59,18 @@ func HostIP(host *host.Host) (net.IP, error) {
 		}
 		return ip, nil
 	case driver.VirtualBox:
-		out, err := exec.Command(driver.VBoxManagePath(), "showvminfo", host.Name, "--machinereadable").Output()
+		vBoxManageCmd := driver.VBoxManagePath()
+		out, err := exec.Command(vBoxManageCmd, "showvminfo", host.Name, "--machinereadable").Output()
 		if err != nil {
 			return []byte{}, errors.Wrap(err, "vboxmanage")
 		}
 		re := regexp.MustCompile(`hostonlyadapter2="(.*?)"`)
 		iface := re.FindStringSubmatch(string(out))[1]
-		ipList, err := exec.Command(driver.VBoxManagePath(), "list", "hostonlyifs").Output()
+		ipList, err := exec.Command(vBoxManageCmd, "list", "hostonlyifs").Output()
 		if err != nil {
 			return []byte{}, errors.Wrap(err, "Error getting VM/Host IP address")
 		}
-		re = regexp.MustCompile(`(?s)Name:\s*` + iface + `.+IPAddress:\s*(\S+)`)
+		re = regexp.MustCompile(`(?sm)Name:\s*` + iface + `\s*$.+?IPAddress:\s*(\S+)`)
 		ip := re.FindStringSubmatch(string(ipList))[1]
 		return net.ParseIP(ip), nil
 	case driver.Parallels:


### PR DESCRIPTION
Fixes #8456 

The regex selecting the interface was greedy - if another interface was printed after the one we're looking for, it would skip everything up to the `IPAddress` of the last interface in the list.
Also made more robust for matching the interface names (to prevent mismatches when multiple interfaces are named `some_if`, `some_if #2`, `some_if #3` etc.)