### PR TITLE
Point multi-node *-env users to the registry addon

### DIFF
--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -141,6 +141,10 @@ var dockerEnvCmd = &cobra.Command{
 			exit.UsageT(`'none' driver does not support 'minikube docker-env' command`)
 		}
 
+		if len(co.Config.Nodes) > 1 {
+			exit.WithCodeT(exit.BadUsage, `The docker-env command is incompatible with multi-node clusters. Use the 'registry' add-on: https://minikube.sigs.k8s.io/docs/handbook/registry/`)
+		}
+
 		if co.Config.KubernetesConfig.ContainerRuntime != "docker" {
 			exit.WithCodeT(exit.BadUsage, `The docker-env command is only compatible with the "docker" runtime, but this cluster was configured to use the "{{.runtime}}" runtime.`,
 				out.V{"runtime": co.Config.KubernetesConfig.ContainerRuntime})

--- a/cmd/minikube/cmd/podman-env.go
+++ b/cmd/minikube/cmd/podman-env.go
@@ -116,6 +116,10 @@ var podmanEnvCmd = &cobra.Command{
 			exit.UsageT(`'none' driver does not support 'minikube podman-env' command`)
 		}
 
+		if len(co.Config.Nodes) > 1 {
+			exit.WithCodeT(exit.BadUsage, `The podman-env command is incompatible with multi-node clusters. Use the 'registry' add-on: https://minikube.sigs.k8s.io/docs/handbook/registry/`)
+		}
+
 		if ok := isPodmanAvailable(co.CP.Runner); !ok {
 			exit.WithCodeT(exit.Unavailable, `The podman service within '{{.cluster}}' is not active`, out.V{"cluster": cname})
 		}


### PR DESCRIPTION
Fixes #6506

If someone wants to create support for multi-node *-env commands in the future, I'd be happy to review it. It will be a substantial engineering effort, however, and probably not worthwhile versus the registry add-on.