### PR TITLE
docker/podman: add advice for cpu count error 

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1051,7 +1051,7 @@ func maybeExitWithAdvice(err error) {
 		out.ErrLn("")
 		out.ErrT(out.Conflict, "{{.name}} doesn't have enough CPUs. ", out.V{"name": viper.GetString("driver")})
 		if runtime.GOOS != "linux" && viper.GetString("driver") == "docker" {
-			out.T(out.Warning, "Please consider changing your Docker desktop's resources.")
+			out.T(out.Warning, "Please consider changing your Docker Desktop's resources.")
 			out.T(out.Documentation, "https://docs.docker.com/config/containers/resource_constraints/")
 		} else {
 			cpuCount := viper.GetInt(cpus)

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1062,7 +1062,7 @@ func maybeExitWithAdvice(err error) {
 			}
 		}
 
-		exit.UsageT("Ensure your system has enough CPUs")
+		exit.UsageT("Ensure your {{.driver_name}} system has enough CPUs. The minimum allowed is 2 CPUs.", out.V{"driver_name": viper.GetString("driver")})
 	}
 
 }

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1039,7 +1039,7 @@ func getKubernetesVersion(old *config.ClusterConfig) string {
 func maybeExitWithAdvice(err error) {
 	if errors.Is(err, oci.ErrWindowsContainers) {
 		out.ErrLn("")
-		out.ErrT(out.Conflict, "Your Docker Desktop container os type is Windows but Linux is required.")
+		out.ErrT(out.Conflict, "Your Docker Desktop container OS type is Windows but Linux is required.")
 		out.T(out.Warning, "Please change Docker settings to use Linux containers instead of Windows containers.")
 		out.T(out.Documentation, "https://minikube.sigs.k8s.io/docs/drivers/docker/#verify-docker-container-type-is-linux")
 		exit.UsageT(`You can verify your Docker container type by running:
@@ -1049,15 +1049,20 @@ func maybeExitWithAdvice(err error) {
 
 	if errors.Is(err, oci.ErrCPUCountLimit) {
 		out.ErrLn("")
-		out.ErrT(out.Conflict, "Your {{.name}} doesn't have enough CPUs. ", out.V{"name": viper.GetString("driver")})
+		out.ErrT(out.Conflict, "{{.name}} doesn't have enough CPUs. ", out.V{"name": viper.GetString("driver")})
 		if runtime.GOOS != "linux" && viper.GetString("driver") == "docker" {
 			out.T(out.Warning, "Please consider changing your Docker desktop's resources.")
 			out.T(out.Documentation, "https://docs.docker.com/config/containers/resource_constraints/")
 		} else {
-			out.T(out.Warning, "Please ensure your system has at least {{.cpu_counts}} CPU cores", out.V{"cpu_counts": viper.GetInt(cpus)})
+			cpuCount := viper.GetInt(cpus)
+			if cpuCount == 2 {
+				out.T(out.Tip, "Please ensure your system has {{.cpu_counts}} CPU cores.", out.V{"cpu_counts": viper.GetInt(cpus)})
+			} else {
+				out.T(out.Tip, "Please ensure your {{.driver_name}} system has access to {{.cpu_counts}} CPU cores or reduce the number of the specified CPUs", out.V{"driver_name": viper.GetString("driver"), "cpu_counts": viper.GetInt(cpus)})
+			}
 		}
 
-		exit.UsageT("Esnure your system has enough CPUs")
+		exit.UsageT("Ensure your system has enough CPUs")
 	}
 
 }

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -155,15 +155,7 @@ func runStart(cmd *cobra.Command, args []string) {
 	ds, alts, specified := selectDriver(existing)
 	starter, err := provisionWithDriver(cmd, ds, existing)
 	if err != nil {
-		if errors.Is(err, oci.ErrWindowsContainers) {
-			out.ErrLn("")
-			out.ErrT(out.Conflict, "Your Docker Desktop container os type is Windows but Linux is required.")
-			out.T(out.Warning, "Please change Docker settings to use Linux containers instead of Windows containers.")
-			out.T(out.Documentation, "https://minikube.sigs.k8s.io/docs/drivers/docker/#verify-docker-container-type-is-linux")
-			exit.UsageT(`You can verify your Docker container type by running:
-	{{.command}}
-		`, out.V{"command": "docker info --format '{{.OSType}}'"})
-		}
+		maybeExitWithAdvice(err)
 		if specified {
 			// If the user specified a driver, don't fallback to anything else
 			exit.WithError("error provisioning host", err)
@@ -1041,4 +1033,31 @@ func getKubernetesVersion(old *config.ClusterConfig) string {
 		out.T(out.New, "Kubernetes {{.new}} is now available. If you would like to upgrade, specify: --kubernetes-version={{.prefix}}{{.new}}", out.V{"prefix": version.VersionPrefix, "new": defaultVersion})
 	}
 	return nv
+}
+
+// maybeExitWithAdvice before exiting will try to check for different error types and provide advice
+func maybeExitWithAdvice(err error) {
+	if errors.Is(err, oci.ErrWindowsContainers) {
+		out.ErrLn("")
+		out.ErrT(out.Conflict, "Your Docker Desktop container os type is Windows but Linux is required.")
+		out.T(out.Warning, "Please change Docker settings to use Linux containers instead of Windows containers.")
+		out.T(out.Documentation, "https://minikube.sigs.k8s.io/docs/drivers/docker/#verify-docker-container-type-is-linux")
+		exit.UsageT(`You can verify your Docker container type by running:
+{{.command}}
+	`, out.V{"command": "docker info --format '{{.OSType}}'"})
+	}
+
+	if errors.Is(err, oci.ErrCPUCountLimit) {
+		out.ErrLn("")
+		out.ErrT(out.Conflict, "Your {{.name}} doesn't have enough CPUs. ", out.V{"name": viper.GetString("driver")})
+		if runtime.GOOS != "linux" && viper.GetString("driver") == "docker" {
+			out.T(out.Warning, "Please consider changing your Docker desktop's resources.")
+			out.T(out.Documentation, "https://docs.docker.com/config/containers/resource_constraints/")
+		} else {
+			out.T(out.Warning, "Please ensure your system has at least {{.cpu_counts}} CPU cores", out.V{"cpu_counts": viper.GetInt(cpus)})
+		}
+
+		exit.UsageT("Esnure your system has enough CPUs")
+	}
+
 }

--- a/pkg/drivers/kic/oci/errors.go
+++ b/pkg/drivers/kic/oci/errors.go
@@ -18,8 +18,11 @@ package oci
 
 import "errors"
 
+// FailFastError type is an error that could not be solved by trying again
+type FailFastError error
+
 // ErrWindowsContainers is thrown when docker been configured to run windows containers instead of Linux
-var ErrWindowsContainers = errors.New("docker container type is windows")
+var ErrWindowsContainers = FailFastError(errors.New("docker container type is windows"))
 
 // ErrCPUCountLimit is thrown when docker daemon doesn't have enough CPUs for the requested container
-var ErrCPUCountLimit = errors.New("not enough CPUs is available for container")
+var ErrCPUCountLimit = FailFastError(errors.New("not enough CPUs is available for container"))

--- a/pkg/drivers/kic/oci/errors.go
+++ b/pkg/drivers/kic/oci/errors.go
@@ -20,3 +20,6 @@ import "errors"
 
 // ErrWindowsContainers is thrown when docker been configured to run windows containers instead of Linux
 var ErrWindowsContainers = errors.New("docker container type is windows")
+
+// ErrCPUCountLimit is thrown when docker daemon doesn't have enough CPUs for the requested container
+var ErrCPUCountLimit = errors.New("not enough CPUs is available for container")

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -251,7 +251,11 @@ func createContainer(ociBin string, image string, opts ...createOpt) error {
 	args = append(args, image)
 	args = append(args, o.ContainerArgs...)
 
-	if _, err := runCmd(exec.Command(ociBin, args...)); err != nil {
+	if rr, err := runCmd(exec.Command(ociBin, args...)); err != nil {
+		// full error: docker: Error response from daemon: Range of CPUs is from 0.01 to 8.00, as there are only 8 CPUs available.
+		if strings.Contains(rr.Output(), "Range of CPUs is from") && strings.Contains(rr.Output(), "CPUs available") { // CPUs available
+			return ErrCPUCountLimit
+		}
 		return err
 	}
 

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -366,6 +366,12 @@ func startHost(api libmachine.API, cc *config.ClusterConfig, n *config.Node) (*h
 		return host, exists, err
 	}
 
+	// don't try to re-create if cpu count is not enough
+	if errors.Is(err, oci.ErrCPUCountLimit) {
+		glog.Infof("will skip retrying to create machine because error is not retriable: %v", err)
+		return host, exists, err
+	}
+
 	out.ErrT(out.Embarrassed, "StartHost failed, but will try again: {{.error}}", out.V{"error": err})
 	// Try again, but just once to avoid making the logs overly confusing
 	time.Sleep(5 * time.Second)

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -360,14 +360,7 @@ func startHost(api libmachine.API, cc *config.ClusterConfig, n *config.Node) (*h
 		}
 	}
 
-	// don't try to re-create if container type is windows.
-	if errors.Is(err, oci.ErrWindowsContainers) {
-		glog.Infof("will skip retrying to create machine because error is not retriable: %v", err)
-		return host, exists, err
-	}
-
-	// don't try to re-create if cpu count is not enough
-	if errors.Is(err, oci.ErrCPUCountLimit) {
+	if _, ff := err.(oci.FailFastError); ff {
 		glog.Infof("will skip retrying to create machine because error is not retriable: %v", err)
 		return host, exists, err
 	}


### PR DESCRIPTION
closes https://github.com/kubernetes/minikube/issues/8497

### Before this PR

```
medya@~/workspace/minikube (sol_msg_cpucount) $ minikube start --driver=docker --cpus 12
😄  minikube v1.11.0 on Darwin 10.15.5
✨  Using the docker driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🔥  Creating docker container (CPUs=12, Memory=4000MB) ...
🤦  StartHost failed, but will try again: creating host: create: creating: create kic node: create container: docker run -d -t --privileged --security-opt seccomp=unconfined --security-opt apparmor=unconfined --tmpfs /tmp --tmpfs /run -v /lib/modules:/lib/modules:ro --hostname minikube --name minikube --label created_by.minikube.sigs.k8s.io=true --label name.minikube.sigs.k8s.io=minikube --label role.minikube.sigs.k8s.io= --label mode.minikube.sigs.k8s.io=minikube --volume minikube:/var --cpus=12 --memory=4000mb -e container=docker --expose 8443 --publish=127.0.0.1::8443 --publish=127.0.0.1::22 --publish=127.0.0.1::2376 --publish=127.0.0.1::5000 gcr.io/k8s-minikube/kicbase:v0.0.10@sha256:f58e0c4662bac8a9b5dda7984b185bad8502ade5d9fa364bf2755d636ab51438: exit status 125
stdout:

stderr:
docker: Error response from daemon: Range of CPUs is from 0.01 to 8.00, as there are only 8 CPUs available.
See 'docker run --help'.

🤷  docker "minikube" container is missing, will recreate.
E0616 12:57:26.340125   11245 oci.go:79] docker daemon seems to be stuck. Please try restarting your docker. Will try to delete anyways: unknown state "minikube": docker container inspect minikube --format={{.State.Status}}: exit status 1
stdout:


stderr:
Error: No such container: minikube
🔥  Creating docker container (CPUs=12, Memory=4000MB) ...
😿  Failed to start docker container. "minikube start" may fix it: recreate: creating host: create: creating: create kic node: create container: docker run -d -t --privileged --security-opt seccomp=unconfined --security-opt apparmor=unconfined --tmpfs /tmp --tmpfs /run -v /lib/modules:/lib/modules:ro --hostname minikube --name minikube --label created_by.minikube.sigs.k8s.io=true --label name.minikube.sigs.k8s.io=minikube --label role.minikube.sigs.k8s.io= --label mode.minikube.sigs.k8s.io=minikube --volume minikube:/var --cpus=12 --memory=4000mb -e container=docker --expose 8443 --publish=127.0.0.1::8443 --publish=127.0.0.1::22 --publish=127.0.0.1::2376 --publish=127.0.0.1::5000 gcr.io/k8s-minikube/kicbase:v0.0.10@sha256:f58e0c4662bac8a9b5dda7984b185bad8502ade5d9fa364bf2755d636ab51438: exit status 125
stdout:

stderr:
docker: Error response from daemon: Range of CPUs is from 0.01 to 8.00, as there are only 8 CPUs available.
See 'docker run --help'.


💣  error provisioning host: Failed to start host: recreate: creating host: create: creating: create kic node: create container: docker run -d -t --privileged --security-opt seccomp=unconfined --security-opt apparmor=unconfined --tmpfs /tmp --tmpfs /run -v /lib/modules:/lib/modules:ro --hostname minikube --name minikube --label created_by.minikube.sigs.k8s.io=true --label name.minikube.sigs.k8s.io=minikube --label role.minikube.sigs.k8s.io= --label mode.minikube.sigs.k8s.io=minikube --volume minikube:/var --cpus=12 --memory=4000mb -e container=docker --expose 8443 --publish=127.0.0.1::8443 --publish=127.0.0.1::22 --publish=127.0.0.1::2376 --publish=127.0.0.1::5000 gcr.io/k8s-minikube/kicbase:v0.0.10@sha256:f58e0c4662bac8a9b5dda7984b185bad8502ade5d9fa364bf2755d636ab51438: exit status 125
stdout:

stderr:
docker: Error response from daemon: Range of CPUs is from 0.01 to 8.00, as there are only 8 CPUs available.
See 'docker run --help'.


😿  minikube is exiting due to an error. If the above message is not useful, open an issue:
👉  https://github.com/kubernetes/minikube/issues/new/choose
```


### After this PR

```
😄  minikube v1.11.0 on Darwin 10.15.5
✨  Using the docker driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🔥  Creating docker container (CPUs=11, Memory=4000MB) ...

💥  docker doesn't have enough CPUs. 
❗  Please consider changing your Docker desktop's resources.
📘  https://docs.docker.com/config/containers/resource_constraints/
💡  Ensure your docker system has enough CPUs. The minimum allowed is 2 CPUs.
```