### PR TITLE
fix test err spam skip logic

### DIFF
--- a/test/integration/error_spam_test.go
+++ b/test/integration/error_spam_test.go
@@ -65,12 +65,11 @@ func TestErrorSpam(t *testing.T) {
 
 	for _, line := range strings.Split(stderr, "\n") {
 		if strings.HasPrefix(line, "E") {
+			if stderrAllowRe.MatchString(line) {
+				t.Logf("acceptable stderr: %q", line)
+				continue
+			}
 			t.Errorf("unexpected error log: %q", line)
-			continue
-		}
-
-		if stderrAllowRe.MatchString(line) {
-			t.Logf("acceptable stderr: %q", line)
 			continue
 		}
 


### PR DESCRIPTION
the skip logic was not being effective since it was after t.Errorf
closes https://github.com/kubernetes/minikube/issues/8500