### PR TITLE
Adds support for unsetting of env vars

### DIFF
--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -133,6 +133,17 @@ var dockerEnvCmd = &cobra.Command{
 	Short: "Configure environment to use minikube's Docker daemon",
 	Long:  `Sets up docker env variables; similar to '$(docker-machine env)'.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		sh := shell.EnvConfig{
+			Shell: shell.ForceShell,
+		}
+
+		if dockerUnset {
+			if err := dockerUnsetScript(DockerEnvConfig{EnvConfig: sh}, os.Stdout); err != nil {
+				exit.WithError("Error generating unset output", err)
+			}
+			return
+		}
+
 		cname := ClusterFlagValue()
 		co := mustload.Running(cname)
 		driverName := co.CP.Host.DriverName
@@ -144,10 +155,6 @@ var dockerEnvCmd = &cobra.Command{
 		if co.Config.KubernetesConfig.ContainerRuntime != "docker" {
 			exit.WithCodeT(exit.BadUsage, `The docker-env command is only compatible with the "docker" runtime, but this cluster was configured to use the "{{.runtime}}" runtime.`,
 				out.V{"runtime": co.Config.KubernetesConfig.ContainerRuntime})
-		}
-
-		sh := shell.EnvConfig{
-			Shell: shell.ForceShell,
 		}
 
 		if ok := isDockerActive(co.CP.Runner); !ok {
@@ -186,13 +193,6 @@ var dockerEnvCmd = &cobra.Command{
 			// to fix issues like this #8185
 			glog.Warningf("couldn't connect to docker inside minikube. will try to restart dockerd service... output: %s error: %v", string(out), err)
 			mustRestartDocker(cname, co.CP.Runner)
-		}
-
-		if dockerUnset {
-			if err := dockerUnsetScript(ec, os.Stdout); err != nil {
-				exit.WithError("Error generating unset output", err)
-			}
-			return
 		}
 
 		if err := dockerSetScript(ec, os.Stdout); err != nil {

--- a/cmd/minikube/cmd/podman-env.go
+++ b/cmd/minikube/cmd/podman-env.go
@@ -108,6 +108,17 @@ var podmanEnvCmd = &cobra.Command{
 	Short: "Configure environment to use minikube's Podman service",
 	Long:  `Sets up podman env variables; similar to '$(podman-machine env)'.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		sh := shell.EnvConfig{
+			Shell: shell.ForceShell,
+		}
+
+		if podmanUnset {
+			if err := podmanUnsetScript(PodmanEnvConfig{EnvConfig: sh}, os.Stdout); err != nil {
+				exit.WithError("Error generating unset output", err)
+			}
+			return
+		}
+
 		cname := ClusterFlagValue()
 		co := mustload.Running(cname)
 		driverName := co.CP.Host.DriverName
@@ -125,9 +136,6 @@ var podmanEnvCmd = &cobra.Command{
 			exit.WithError("Error getting ssh client", err)
 		}
 
-		sh := shell.EnvConfig{
-			Shell: shell.ForceShell,
-		}
 		ec := PodmanEnvConfig{
 			EnvConfig: sh,
 			profile:   cname,
@@ -140,13 +148,6 @@ var podmanEnvCmd = &cobra.Command{
 			if err != nil {
 				exit.WithError("Error detecting shell", err)
 			}
-		}
-
-		if podmanUnset {
-			if err := podmanUnsetScript(ec, os.Stdout); err != nil {
-				exit.WithError("Error generating unset output", err)
-			}
-			return
 		}
 
 		if err := podmanSetScript(ec, os.Stdout); err != nil {


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
Fixes: #8476 

#### Behaviour before this PR
```
[hsingh@localhost out]$ ./minikube docker-env --unset
🤷  The control plane node must be running for this command
👉  To fix this, run: "minikube start"
```

#### Behaviour after this PR
```
[hsingh@localhost out]$ ./minikube docker-env --unset
unset DOCKER_TLS_VERIFY DOCKER_HOST DOCKER_CERT_PATH MINIKUBE_ACTIVE_DOCKERD
```
Reference: https://github.com/kubernetes/minikube/issues/8476#issuecomment-644652128

**Explanation:**
The unsettling of env-vars in docker should be independent of whether the docker-machine is running or not. This is minikube specific issue and was occurring due `co := mustload.Running(cname)`. Moving the unset statements up, before the running-checks solves the issue. Similar is the situation for podman.
