### PR TITLE
wip: Move docker root dir outside of /var and mount preload to that instead

### DIFF
--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -149,7 +149,7 @@ func CreateContainerNode(p CreateParams) error {
 		runArgs = append(runArgs, "--volume", fmt.Sprintf("%s:/var:exec", p.Name))
 	}
 	if p.OCIBinary == Docker {
-		runArgs = append(runArgs, "--volume", fmt.Sprintf("%s:/var", p.Name))
+		runArgs = append(runArgs, "--volume", fmt.Sprintf("%s:/tmp/var", p.Name))
 	}
 
 	runArgs = append(runArgs, fmt.Sprintf("--cpus=%s", p.CPUs))

--- a/pkg/minikube/vmpath/constants.go
+++ b/pkg/minikube/vmpath/constants.go
@@ -24,7 +24,7 @@ const (
 	// GuestEphemeralDir is the path where ephemeral data should be stored within the VM
 	GuestEphemeralDir = "/var/tmp/minikube"
 	// GuestPersistentDir is the path where persistent data should be stored within the VM (not tmpfs)
-	GuestPersistentDir = "/var/lib/minikube"
+	GuestPersistentDir = "/tmp/var/lib/minikube"
 	// GuestKubernetesCertsDir are where Kubernetes certificates are stored
 	GuestKubernetesCertsDir = GuestPersistentDir + "/certs"
 	// GuestCertAuthDir is where system CA certificates are installed to

--- a/pkg/provision/ubuntu.go
+++ b/pkg/provision/ubuntu.go
@@ -105,7 +105,7 @@ Environment=DOCKER_RAMDISK=yes
 # NOTE: default-ulimit=nofile is set to an arbitrary number for consistency with other
 # container runtimes. If left unlimited, it may result in OOM issues with MySQL.
 ExecStart=
-ExecStart=/usr/bin/dockerd -H tcp://0.0.0.0:2376 -H unix:///var/run/docker.sock --default-ulimit=nofile=1048576:1048576 --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}} {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
+ExecStart=/usr/bin/dockerd -g /tmp/var/lib/docker -H tcp://0.0.0.0:2376 -H unix:///var/run/docker.sock --default-ulimit=nofile=1048576:1048576 --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}} {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
 ExecReload=/bin/kill -s HUP $MAINPID
 
 # Having non-zero Limit*s causes performance problems due to accounting overhead


### PR DESCRIPTION
I think this could potentially fix https://github.com/kubernetes/minikube/issues/8179 and https://github.com/kubernetes/minikube/issues/8163

Still looking into it