### PR TITLE
Make sure to use internal containerd for docker

### DIFF
--- a/pkg/minikube/cruntime/cruntime_test.go
+++ b/pkg/minikube/cruntime/cruntime_test.go
@@ -572,7 +572,7 @@ func TestEnable(t *testing.T) {
 		want    map[string]serviceState
 	}{
 		{"docker", map[string]serviceState{
-			"docker":        SvcRestarted,
+			"docker":        SvcRunning,
 			"containerd":    SvcExited,
 			"crio":          SvcExited,
 			"crio-shutdown": SvcExited,

--- a/pkg/minikube/cruntime/cruntime_test.go
+++ b/pkg/minikube/cruntime/cruntime_test.go
@@ -478,6 +478,16 @@ func (f *FakeRunner) systemctl(args []string, root bool) (string, error) { // no
 				return out, nil
 			}
 			return out, fmt.Errorf("%s in state: %v", svc, state)
+		case "cat":
+			f.t.Logf("fake systemctl: %s cat: %v", svc, state)
+			if svc == "docker.service" {
+				out += "[Unit]\n"
+				out += "Description=Docker Application Container Engine\n"
+				out += "Documentation=https://docs.docker.com\n"
+				//out += "BindsTo=containerd.service\n"
+				return out, nil
+			}
+			return out, fmt.Errorf("%s cat unimplemented", svc)
 		default:
 			return out, fmt.Errorf("unimplemented fake action: %q", action)
 		}
@@ -562,7 +572,7 @@ func TestEnable(t *testing.T) {
 		want    map[string]serviceState
 	}{
 		{"docker", map[string]serviceState{
-			"docker":        SvcRunning,
+			"docker":        SvcRestarted,
 			"containerd":    SvcExited,
 			"crio":          SvcExited,
 			"crio-shutdown": SvcExited,

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -104,6 +104,8 @@ func (r *Docker) Active() bool {
 
 // Enable idempotently enables Docker on a host
 func (r *Docker) Enable(disOthers, forceSystemd bool) error {
+	containerdWasActive := r.Init.Active("containerd")
+
 	if disOthers {
 		if err := disableOthers(r, r.Runner); err != nil {
 			glog.Warningf("disableOthers: %v", err)
@@ -117,7 +119,7 @@ func (r *Docker) Enable(disOthers, forceSystemd bool) error {
 		return r.Init.Restart("docker")
 	}
 
-	if !dockerBoundToContainerd(r.Runner) {
+	if containerdWasActive && !dockerBoundToContainerd(r.Runner) {
 		// Make sure to use the internal containerd
 		return r.Init.Restart("docker")
 	}

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -117,6 +117,11 @@ func (r *Docker) Enable(disOthers, forceSystemd bool) error {
 		return r.Init.Restart("docker")
 	}
 
+	if !dockerBoundToContainerd(r.Runner) {
+		// Make sure to use the internal containerd
+		return r.Init.Restart("docker")
+	}
+
 	return r.Init.Start("docker")
 }
 


### PR DESCRIPTION
When not using the containerd.service, we should make
sure that dockerd does not use the stopped containerd.

Closes #8203