### PR TITLE
Don't return error when SHELL has not been set

### DIFF
--- a/pkg/minikube/shell/shell.go
+++ b/pkg/minikube/shell/shell.go
@@ -21,6 +21,8 @@ package shell
 import (
 	"fmt"
 	"io"
+	"os"
+	"runtime"
 	"strings"
 	"text/template"
 
@@ -139,13 +141,12 @@ var (
 
 // Detect detects user's current shell.
 func Detect() (string, error) {
-	sh, err := shell.Detect()
+	sh := os.Getenv("SHELL")
 	// Don't error out when $SHELL has not been set
-	// Note: ErrUnknownShell is not used on windows
-	if sh == "" {
+	if sh == "" && runtime.GOOS != "windows" {
 		return defaultSh, nil
 	}
-	return sh, err
+	return shell.Detect()
 }
 
 func (c EnvConfig) getShell() shellData {

--- a/pkg/minikube/shell/shell.go
+++ b/pkg/minikube/shell/shell.go
@@ -1,6 +1,5 @@
 /*
 Copyright 2020 The Kubernetes Authors All rights reserved.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -130,7 +129,8 @@ REM @FOR /f "tokens=*" %%i IN ('%s') DO @%%i
 	},
 }
 
-var defaultShell shellData = shellConfigMap["bash"]
+var defaultSh = "bash"
+var defaultShell shellData = shellConfigMap[defaultSh]
 
 var (
 	// ForceShell forces a shell name
@@ -139,7 +139,13 @@ var (
 
 // Detect detects user's current shell.
 func Detect() (string, error) {
-	return shell.Detect()
+	sh, err := shell.Detect()
+	// Don't error out when $SHELL has not been set
+	// Note: ErrUnknownShell is not used on windows
+	if sh == "" {
+		return defaultSh, nil
+	}
+	return sh, err
 }
 
 func (c EnvConfig) getShell() shellData {

--- a/pkg/minikube/shell/shell.go
+++ b/pkg/minikube/shell/shell.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2020 The Kubernetes Authors All rights reserved.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/minikube/shell/shell_test.go
+++ b/pkg/minikube/shell/shell_test.go
@@ -117,11 +117,23 @@ set -e bar;`},
 	}
 }
 
-func TestDetect(t *testing.T) {
+func TestDetectSet(t *testing.T) {
 	orgShellEnv := os.Getenv("SHELL")
 	defer os.Setenv("SHELL", orgShellEnv)
 
-	os.Setenv("SHELL", "bash")
+	os.Setenv("SHELL", "/bin/bash")
+	if s, err := Detect(); err != nil {
+		t.Fatalf("unexpected error: '%v' during shell detection. Returned shell: %s", err, s)
+	} else if s == "" {
+		t.Fatalf("Detected shell expected to be non empty string")
+	}
+}
+
+func TestDetectUnset(t *testing.T) {
+	orgShellEnv := os.Getenv("SHELL")
+	defer os.Setenv("SHELL", orgShellEnv)
+
+	os.Unsetenv("SHELL")
 	if s, err := Detect(); err != nil {
 		t.Fatalf("unexpected error: '%v' during shell detection. Returned shell: %s", err, s)
 	} else if s == "" {


### PR DESCRIPTION
We can't check the error type, since it is not defined on Windows. So just check for empty shell.
Don't need to bother logging, because it prints on stdout anyway (!) and only happens on GHA.

So we just return the default shell syntax, when the standard $SHELL variable has not been set.
Also add some unit tests (and fix the existing one, with a path), to make sure it works properly.


```
=== RUN   TestDetectSet
--- PASS: TestDetectSet (0.00s)
=== RUN   TestDetectUnset
The default lines below are for a sh/bash shell, you can specify the shell you're using, with the --shell flag.

--- PASS: TestDetectUnset (0.00s)
```

Closes #7886
