### PR TITLE
The logging of the kubectl path was broken

### DIFF
--- a/cmd/minikube/cmd/kubectl.go
+++ b/cmd/minikube/cmd/kubectl.go
@@ -48,7 +48,7 @@ minikube kubectl -- get pods --namespace kube-system`,
 			out.ErrLn("Error caching kubectl: %v", err)
 		}
 
-		glog.Infof("Running %s %v", path, args)
+		glog.Infof("Running %s %v", c.Path, args)
 		c.Stdin = os.Stdin
 		c.Stdout = os.Stdout
 		c.Stderr = os.Stderr


### PR DESCRIPTION
After introducing the exec.Cmd parameter previously

Just logging empty string:

`Running  [version]`

Supposed to be the path.