### PR TITLE
integration: add delete  to cache test

### DIFF
--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -547,6 +547,15 @@ func validateCacheCmd(ctx context.Context, t *testing.T, profile string) {
 			}
 		})
 
+		// delete will clean up the cached images since they are global and all other tests will load it for no reason
+		t.Run("delete", func(t *testing.T) {
+			for _, img := range []string{"busybox:latest", "k8s.gcr.io/pause:latest"} {
+				rr, err := Run(t, exec.CommandContext(ctx, Target(), "cache", "delete", img))
+				if err != nil {
+					t.Errorf("failed to delete %s from cache. args %q: %v", img, rr.Command(), err)
+				}
+			}
+		})
 	})
 }
 


### PR DESCRIPTION
two reasons for this PR:
- cache is global and once functional test adds something to cache all other tests will want to cache it too, causing slowing down and also error spam 
- also adds a test for just "cache delete"