### PR TITLE
Do not output usage hint when shell=none.

### DIFF
--- a/pkg/minikube/shell/shell.go
+++ b/pkg/minikube/shell/shell.go
@@ -124,10 +124,7 @@ REM @FOR /f "tokens=*" %%i IN ('%s') DO @%%i
 		unsetSuffix:    "\n",
 		unsetDelimiter: "",
 		usageHint: func(s ...interface{}) string {
-			return fmt.Sprintf(`
-# %s
-# eval $(%s)
-`, s...)
+			return  ""
 		},
 	},
 }

--- a/pkg/minikube/shell/shell.go
+++ b/pkg/minikube/shell/shell.go
@@ -124,7 +124,7 @@ REM @FOR /f "tokens=*" %%i IN ('%s') DO @%%i
 		unsetSuffix:    "\n",
 		unsetDelimiter: "",
 		usageHint: func(s ...interface{}) string {
-			return  ""
+			return ""
 		},
 	},
 }

--- a/pkg/minikube/shell/shell_test.go
+++ b/pkg/minikube/shell/shell_test.go
@@ -40,8 +40,7 @@ func TestGenerateUsageHint(t *testing.T) {
 ;; (with-temp-buffer (shell-command "bar" (current-buffer)) (eval-buffer))`},
 		{EnvConfig{"fish"}, `# foo
 # bar | source`},
-		{EnvConfig{"none"}, `# foo
-# eval $(bar)`},
+		{EnvConfig{"none"}, ``},
 	}
 	for _, tc := range testCases {
 		tc := tc


### PR DESCRIPTION
Since there is no shell, there is no clear way to expect how a usage hint will be interpretted.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
