### PR TITLE
Remove trailing spaces after leader-elect: false

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/ktmpl/v1alpha3.go
+++ b/pkg/minikube/bootstrapper/bsutil/ktmpl/v1alpha3.go
@@ -59,7 +59,7 @@ etcd:
 controllerManagerExtraArgs:
   leader-elect: "false"
 schedulerExtraArgs:
-  leader-elect: "false"  
+  leader-elect: "false"
 kubernetesVersion: {{.KubernetesVersion}}
 networking:
   dnsDomain: {{if .DNSDomain}}{{.DNSDomain}}{{else}}cluster.local{{end}}

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.11/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.11/containerd-api-port.yaml
@@ -14,7 +14,7 @@ etcd:
 controllerManagerExtraArgs:
   leader-elect: "false"
 schedulerExtraArgs:
-  leader-elect: "false"  
+  leader-elect: "false"
 nodeName: "mk"
 apiServerCertSANs: ["127.0.0.1", "localhost", "1.1.1.1"]
 criSocket: /run/containerd/containerd.sock

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.11/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.11/containerd-pod-network-cidr.yaml
@@ -14,7 +14,7 @@ etcd:
 controllerManagerExtraArgs:
   leader-elect: "false"
 schedulerExtraArgs:
-  leader-elect: "false"  
+  leader-elect: "false"
 nodeName: "mk"
 apiServerCertSANs: ["127.0.0.1", "localhost", "1.1.1.1"]
 criSocket: /run/containerd/containerd.sock

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.11/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.11/containerd.yaml
@@ -14,7 +14,7 @@ etcd:
 controllerManagerExtraArgs:
   leader-elect: "false"
 schedulerExtraArgs:
-  leader-elect: "false"  
+  leader-elect: "false"
 nodeName: "mk"
 apiServerCertSANs: ["127.0.0.1", "localhost", "1.1.1.1"]
 criSocket: /run/containerd/containerd.sock

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.11/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.11/crio-options-gates.yaml
@@ -14,7 +14,7 @@ etcd:
 controllerManagerExtraArgs:
   leader-elect: "false"
 schedulerExtraArgs:
-  leader-elect: "false"  
+  leader-elect: "false"
 nodeName: "mk"
 apiServerCertSANs: ["127.0.0.1", "localhost", "1.1.1.1"]
 criSocket: /var/run/crio/crio.sock

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.11/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.11/crio.yaml
@@ -14,7 +14,7 @@ etcd:
 controllerManagerExtraArgs:
   leader-elect: "false"
 schedulerExtraArgs:
-  leader-elect: "false"  
+  leader-elect: "false"
 nodeName: "mk"
 apiServerCertSANs: ["127.0.0.1", "localhost", "1.1.1.1"]
 criSocket: /var/run/crio/crio.sock

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.11/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.11/default.yaml
@@ -14,7 +14,7 @@ etcd:
 controllerManagerExtraArgs:
   leader-elect: "false"
 schedulerExtraArgs:
-  leader-elect: "false"  
+  leader-elect: "false"
 nodeName: "mk"
 apiServerCertSANs: ["127.0.0.1", "localhost", "1.1.1.1"]
 apiServerExtraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.11/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.11/image-repository.yaml
@@ -14,7 +14,7 @@ etcd:
 controllerManagerExtraArgs:
   leader-elect: "false"
 schedulerExtraArgs:
-  leader-elect: "false"  
+  leader-elect: "false"
 nodeName: "mk"
 apiServerCertSANs: ["127.0.0.1", "localhost", "1.1.1.1"]
 imageRepository: test/repo

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.11/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.11/options.yaml
@@ -14,7 +14,7 @@ etcd:
 controllerManagerExtraArgs:
   leader-elect: "false"
 schedulerExtraArgs:
-  leader-elect: "false"  
+  leader-elect: "false"
 nodeName: "mk"
 apiServerCertSANs: ["127.0.0.1", "localhost", "1.1.1.1"]
 apiServerExtraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/containerd-api-port.yaml
@@ -31,7 +31,7 @@ etcd:
 controllerManagerExtraArgs:
   leader-elect: "false"
 schedulerExtraArgs:
-  leader-elect: "false"  
+  leader-elect: "false"
 kubernetesVersion: v1.12.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/containerd-pod-network-cidr.yaml
@@ -31,7 +31,7 @@ etcd:
 controllerManagerExtraArgs:
   leader-elect: "false"
 schedulerExtraArgs:
-  leader-elect: "false"  
+  leader-elect: "false"
 kubernetesVersion: v1.12.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/containerd.yaml
@@ -31,7 +31,7 @@ etcd:
 controllerManagerExtraArgs:
   leader-elect: "false"
 schedulerExtraArgs:
-  leader-elect: "false"  
+  leader-elect: "false"
 kubernetesVersion: v1.12.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/crio-options-gates.yaml
@@ -39,7 +39,7 @@ etcd:
 controllerManagerExtraArgs:
   leader-elect: "false"
 schedulerExtraArgs:
-  leader-elect: "false"  
+  leader-elect: "false"
 kubernetesVersion: v1.12.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/crio.yaml
@@ -31,7 +31,7 @@ etcd:
 controllerManagerExtraArgs:
   leader-elect: "false"
 schedulerExtraArgs:
-  leader-elect: "false"  
+  leader-elect: "false"
 kubernetesVersion: v1.12.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/default.yaml
@@ -31,7 +31,7 @@ etcd:
 controllerManagerExtraArgs:
   leader-elect: "false"
 schedulerExtraArgs:
-  leader-elect: "false"  
+  leader-elect: "false"
 kubernetesVersion: v1.12.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/dns.yaml
@@ -31,7 +31,7 @@ etcd:
 controllerManagerExtraArgs:
   leader-elect: "false"
 schedulerExtraArgs:
-  leader-elect: "false"  
+  leader-elect: "false"
 kubernetesVersion: v1.12.0
 networking:
   dnsDomain: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/image-repository.yaml
@@ -32,7 +32,7 @@ etcd:
 controllerManagerExtraArgs:
   leader-elect: "false"
 schedulerExtraArgs:
-  leader-elect: "false"  
+  leader-elect: "false"
 kubernetesVersion: v1.12.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/options.yaml
@@ -36,7 +36,7 @@ etcd:
 controllerManagerExtraArgs:
   leader-elect: "false"
 schedulerExtraArgs:
-  leader-elect: "false"  
+  leader-elect: "false"
 kubernetesVersion: v1.12.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/containerd-api-port.yaml
@@ -31,7 +31,7 @@ etcd:
 controllerManagerExtraArgs:
   leader-elect: "false"
 schedulerExtraArgs:
-  leader-elect: "false"  
+  leader-elect: "false"
 kubernetesVersion: v1.13.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/containerd-pod-network-cidr.yaml
@@ -31,7 +31,7 @@ etcd:
 controllerManagerExtraArgs:
   leader-elect: "false"
 schedulerExtraArgs:
-  leader-elect: "false"  
+  leader-elect: "false"
 kubernetesVersion: v1.13.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/containerd.yaml
@@ -31,7 +31,7 @@ etcd:
 controllerManagerExtraArgs:
   leader-elect: "false"
 schedulerExtraArgs:
-  leader-elect: "false"  
+  leader-elect: "false"
 kubernetesVersion: v1.13.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/crio-options-gates.yaml
@@ -39,7 +39,7 @@ etcd:
 controllerManagerExtraArgs:
   leader-elect: "false"
 schedulerExtraArgs:
-  leader-elect: "false"  
+  leader-elect: "false"
 kubernetesVersion: v1.13.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/crio.yaml
@@ -31,7 +31,7 @@ etcd:
 controllerManagerExtraArgs:
   leader-elect: "false"
 schedulerExtraArgs:
-  leader-elect: "false"  
+  leader-elect: "false"
 kubernetesVersion: v1.13.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/default.yaml
@@ -31,7 +31,7 @@ etcd:
 controllerManagerExtraArgs:
   leader-elect: "false"
 schedulerExtraArgs:
-  leader-elect: "false"  
+  leader-elect: "false"
 kubernetesVersion: v1.13.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/dns.yaml
@@ -31,7 +31,7 @@ etcd:
 controllerManagerExtraArgs:
   leader-elect: "false"
 schedulerExtraArgs:
-  leader-elect: "false"  
+  leader-elect: "false"
 kubernetesVersion: v1.13.0
 networking:
   dnsDomain: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/image-repository.yaml
@@ -32,7 +32,7 @@ etcd:
 controllerManagerExtraArgs:
   leader-elect: "false"
 schedulerExtraArgs:
-  leader-elect: "false"  
+  leader-elect: "false"
 kubernetesVersion: v1.13.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/options.yaml
@@ -36,7 +36,7 @@ etcd:
 controllerManagerExtraArgs:
   leader-elect: "false"
 schedulerExtraArgs:
-  leader-elect: "false"  
+  leader-elect: "false"
 kubernetesVersion: v1.13.0
 networking:
   dnsDomain: cluster.local


### PR DESCRIPTION
VS Code kept stripping the trailing spaces off, which was making my CNI PR confusing to look at.