### PR TITLE
docker driver on linux: Give warning if overlay module is not enabled

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -616,6 +616,13 @@ func validateDriver(ds registry.DriverState, existing *config.ClusterConfig) {
 	st := ds.State
 	glog.Infof("status for %s: %+v", name, st)
 
+	if st.NeedsImprovement { // warn but don't exit
+		out.ErrLn("")
+		out.WarningT("'{{.driver}}' driver reported a issue that could affect the performance.", out.V{"driver": name})
+		out.ErrT(out.Tip, "Suggestion: {{.fix}}", out.V{"fix": translate.T(st.Fix)})
+		out.ErrLn("")
+	}
+
 	if st.Error != nil {
 		out.ErrLn("")
 

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -94,7 +94,7 @@ func status() registry.State {
 	}
 	if err == nil {
 		glog.Infof("docker version: %s", output)
-		return checkOverlayMod()
+		return checkNeedsImprovement()
 	}
 
 	glog.Warningf("docker returned error: %v", err)
@@ -114,17 +114,44 @@ func status() registry.State {
 	return registry.State{Error: err, Installed: true, Healthy: false, Doc: docURL}
 }
 
-// checkOverlayMod checks if overlay mod is installed on a system
+// checkNeedsImprovement if overlay mod is installed on a system
+func checkNeedsImprovement() registry.State {
+	if runtime.GOOS == "linux" {
+		return checkOverlayMod()
+	} // TODO #8540: on non-linux check if docker desktop has enough CPU/memory
+	return registry.State{Installed: true, Healthy: true}
+}
+
+// checkOverlayMod checks if
 func checkOverlayMod() registry.State {
 	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "mod", "probe", "overlay")
+	cmd := exec.CommandContext(ctx, "modprobe", "overlay")
 	_, err := cmd.Output()
 	if err != nil {
 		// try a different way
-		cmd := exec.CommandContext(ctx, "mod", "probe", "overlay")
-
-		return registry.State{Error: err, Installed: true, Healthy: false, Fix: "Add your user to the 'docker' group: 'sudo usermod -aG docker $USER && newgrp docker'", Doc: "https://docs.docker.com/engine/install/linux-postinstall/"}
+		cmd = exec.CommandContext(ctx, "uname", "-r")
+		out, err := cmd.Output()
+		if ctx.Err() == context.DeadlineExceeded {
+			glog.Warningf("%q timed out checking for ", strings.Join(cmd.Args, " "))
+			return registry.State{NeedsImprovement: true, Installed: true, Healthy: true, Fix: "enable overlayfs kernel module on your Linux"}
+		}
+		if err != nil {
+			glog.Warningf("couldn't verify the linux distro's uname : %s", err)
+			return registry.State{NeedsImprovement: true, Installed: true, Healthy: true, Fix: "enable overlayfs kernel module on your Linux"}
+		}
+		path := fmt.Sprintf("/lib/modules/%s/modules.builtin", string(out))
+		cmd = exec.CommandContext(ctx, "cat", path)
+		out, err = cmd.Output()
+		if err != nil {
+			glog.Warningf("overlay module was not found in %q", path)
+			return registry.State{NeedsImprovement: true, Installed: true, Healthy: true, Fix: "enable overlayfs kernel module on your Linux"}
+		}
+		if strings.Contains(string(out), "overlay") { // success
+			return registry.State{NeedsImprovement: false, Installed: true, Healthy: true}
+		}
+		glog.Warningf("overlay module was not found")
+		return registry.State{NeedsImprovement: true, Installed: true, Healthy: true}
 	}
 	return registry.State{Installed: true, Healthy: true}
 }

--- a/pkg/minikube/registry/registry.go
+++ b/pkg/minikube/registry/registry.go
@@ -70,11 +70,12 @@ type StatusChecker func() State
 
 // State is the current state of the driver and its dependencies
 type State struct {
-	Installed bool
-	Healthy   bool
-	Error     error
-	Fix       string
-	Doc       string
+	Installed          bool
+	Healthy            bool
+	RoomForImprovement bool
+	Error              error
+	Fix                string
+	Doc                string
 }
 
 // DriverDef defines how to initialize and load a machine driver

--- a/pkg/minikube/registry/registry.go
+++ b/pkg/minikube/registry/registry.go
@@ -70,12 +70,12 @@ type StatusChecker func() State
 
 // State is the current state of the driver and its dependencies
 type State struct {
-	Installed          bool
-	Healthy            bool
-	RoomForImprovement bool
-	Error              error
-	Fix                string
-	Doc                string
+	Installed        bool
+	Healthy          bool
+	NeedsImprovement bool // driver is healthy but could be improved
+	Error            error
+	Fix              string
+	Doc              string
 }
 
 // DriverDef defines how to initialize and load a machine driver


### PR DESCRIPTION
Currently we install the docker inside minikube with overlayfs storage driver.
and it is not currently on our roadmap to support others, and and if you are on linux and your linux kernel does not have overlayfs then it will have significant  slow performances 
### after this PR:
(ignore that it is running on darwin I fliped the If statement to make error in darwin)
this should only add warnning for linux, since docker-machine comes with overlayfs on mac and windows
```
😄  minikube v1.12.0-beta.0 on Darwin 10.15.5
✨  Using the docker driver based on user configuration

❗  'docker' driver reported a issue that could affect the performance.
💡  Suggestion: enable overlayfs kernel module on your Linux

👍  Starting control plane node minikube in cluster minikube
🔥  Creating docker container (CPUs=2, Memory=4000MB) ...
🐳  Preparing Kubernetes v1.18.3 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16
🔎  Verifying Kubernetes components...
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube"
```