### PR TITLE
Allow passing in extra args to etcd via command line

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/extraconfig.go
+++ b/pkg/minikube/bootstrapper/bsutil/extraconfig.go
@@ -191,14 +191,14 @@ func createExtraComponentConfig(extraOptions config.ExtraOptionSlice, version se
 	if err != nil {
 		return nil, err
 	}
-	validComponenets := []componentOptions{}
+	validComponents := []componentOptions{}
 	for _, extraArgs := range extraArgsSlice {
 		if extraArgs.Component == Kubeadm || extraArgs.Component == Etcd {
 			continue
 		}
-		validComponenets = append(validComponenets, extraArgs)
+		validComponents = append(validComponents, extraArgs)
 	}
-	return validComponenets, nil
+	return validComponents, nil
 }
 
 // createKubeProxyOptions generates a map of extra config for kube-proxy

--- a/pkg/minikube/bootstrapper/bsutil/extraconfig.go
+++ b/pkg/minikube/bootstrapper/bsutil/extraconfig.go
@@ -184,22 +184,21 @@ func optionPairsForComponent(component string, version semver.Version, cp config
 // kubeadm extra args should not be included in the kubeadm config in the extra args section (instead, they must
 // be inserted explicitly in the appropriate places or supplied from the command line); here we remove all of the
 // kubeadm extra args from the slice
-// etcd must also not be included in that section, as they must exist in the 'etcd' extra args section
-// so, all etcd components are removed as well
+// etcd must also not be included in that section, as those extra args exist in the `etcd` section
 // createExtraComponentConfig generates a map of component to extra args for all of the components except kubeadm
 func createExtraComponentConfig(extraOptions config.ExtraOptionSlice, version semver.Version, componentFeatureArgs string, cp config.Node) ([]componentOptions, error) {
 	extraArgsSlice, err := newComponentOptions(extraOptions, version, componentFeatureArgs, cp)
 	if err != nil {
 		return nil, err
 	}
-
-	for i, extraArgs := range extraArgsSlice {
+	validComponenets := []componentOptions{}
+	for _, extraArgs := range extraArgsSlice {
 		if extraArgs.Component == Kubeadm || extraArgs.Component == Etcd {
-			extraArgsSlice = append(extraArgsSlice[:i], extraArgsSlice[i+1:]...)
-			break
+			continue
 		}
+		validComponenets = append(validComponenets, extraArgs)
 	}
-	return extraArgsSlice, nil
+	return validComponenets, nil
 }
 
 // createKubeProxyOptions generates a map of extra config for kube-proxy

--- a/pkg/minikube/bootstrapper/bsutil/extraconfig.go
+++ b/pkg/minikube/bootstrapper/bsutil/extraconfig.go
@@ -184,6 +184,8 @@ func optionPairsForComponent(component string, version semver.Version, cp config
 // kubeadm extra args should not be included in the kubeadm config in the extra args section (instead, they must
 // be inserted explicitly in the appropriate places or supplied from the command line); here we remove all of the
 // kubeadm extra args from the slice
+// etcd must also not be included in that section, as they must exist in the 'etcd' extra args section
+// so, all etcd components are removed as well
 // createExtraComponentConfig generates a map of component to extra args for all of the components except kubeadm
 func createExtraComponentConfig(extraOptions config.ExtraOptionSlice, version semver.Version, componentFeatureArgs string, cp config.Node) ([]componentOptions, error) {
 	extraArgsSlice, err := newComponentOptions(extraOptions, version, componentFeatureArgs, cp)

--- a/pkg/minikube/bootstrapper/bsutil/extraconfig.go
+++ b/pkg/minikube/bootstrapper/bsutil/extraconfig.go
@@ -49,6 +49,7 @@ var componentToKubeadmConfigKey = map[string]string{
 	Apiserver:         "apiServer",
 	ControllerManager: "controllerManager",
 	Scheduler:         "scheduler",
+	Etcd:              "etcd",
 	Kubeadm:           "kubeadm",
 	// The KubeProxy is handled in different config block
 	Kubeproxy: "",
@@ -191,7 +192,7 @@ func createExtraComponentConfig(extraOptions config.ExtraOptionSlice, version se
 	}
 
 	for i, extraArgs := range extraArgsSlice {
-		if extraArgs.Component == Kubeadm {
+		if extraArgs.Component == Kubeadm || extraArgs.Component == Etcd {
 			extraArgsSlice = append(extraArgsSlice[:i], extraArgsSlice[i+1:]...)
 			break
 		}

--- a/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta2.go
+++ b/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta2.go
@@ -63,6 +63,10 @@ dns:
 etcd:
   local:
     dataDir: {{.EtcdDataDir}}
+    extraArgs:
+{{- range $i, $val := printMapInOrder .EtcdExtraArgs ": " }}
+      {{$val}}
+{{- end}}   
 controllerManager:
   extraArgs:
     "leader-elect": "false"

--- a/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta2.go
+++ b/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta2.go
@@ -63,10 +63,12 @@ dns:
 etcd:
   local:
     dataDir: {{.EtcdDataDir}}
+{{- if .EtcdExtraArgs}}
     extraArgs:
 {{- range $i, $val := printMapInOrder .EtcdExtraArgs ": " }}
       {{$val}}
-{{- end}}   
+{{- end}}
+{{- end }} 
 controllerManager:
   extraArgs:
     "leader-elect": "false"

--- a/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta2.go
+++ b/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta2.go
@@ -68,7 +68,7 @@ etcd:
 {{- range $i, $val := printMapInOrder .EtcdExtraArgs ": " }}
       {{$val}}
 {{- end}}
-{{- end }} 
+{{- end}}
 controllerManager:
   extraArgs:
     "leader-elect": "false"

--- a/pkg/minikube/bootstrapper/bsutil/kubeadm.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubeadm.go
@@ -43,14 +43,12 @@ func GenerateKubeadmYAML(cc config.ClusterConfig, n config.Node, r cruntime.Mana
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing Kubernetes version")
 	}
-	fmt.Println(k8s.ExtraOptions)
 
 	// parses a map of the feature gates for kubeadm and component
 	kubeadmFeatureArgs, componentFeatureArgs, err := parseFeatureArgs(k8s.FeatureGates)
 	if err != nil {
 		return nil, errors.Wrap(err, "parses feature gate config for kubeadm and component")
 	}
-	fmt.Println(k8s.ExtraOptions)
 
 	// In case of no port assigned, use default
 	cp, err := config.PrimaryControlPlane(&cc)
@@ -62,12 +60,10 @@ func GenerateKubeadmYAML(cc config.ClusterConfig, n config.Node, r cruntime.Mana
 		nodePort = constants.APIServerPort
 	}
 
-	fmt.Println(k8s.ExtraOptions)
 	componentOpts, err := createExtraComponentConfig(k8s.ExtraOptions, version, componentFeatureArgs, cp)
 	if err != nil {
 		return nil, errors.Wrap(err, "generating extra component config for kubeadm")
 	}
-	fmt.Println(k8s.ExtraOptions)
 
 	opts := struct {
 		CertDir             string
@@ -131,7 +127,7 @@ func GenerateKubeadmYAML(cc config.ClusterConfig, n config.Node, r cruntime.Mana
 	if err := configTmpl.Execute(&b, opts); err != nil {
 		return nil, err
 	}
-	fmt.Printf("kubeadm config:\n%s\n", b.String())
+	glog.Infof("kubeadm config:\n%s\n", b.String())
 	return b.Bytes(), nil
 }
 
@@ -165,6 +161,5 @@ func etcdExtraArgs(extraOpts config.ExtraOptionSlice) map[string]string {
 		}
 		args[eo.Key] = eo.Value
 	}
-	fmt.Println("etcd extra args:", args)
 	return args
 }

--- a/pkg/minikube/bootstrapper/bsutil/kubeadm_test.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubeadm_test.go
@@ -241,7 +241,7 @@ func TestGenerateKubeadmYAML(t *testing.T) {
 					t.Fatalf("diff error: %v", err)
 				}
 				if diff != "" {
-					t.Errorf("unexpected diff:\n%s\n===== [RAW OUTPUT] =====\n%s", diff, got)
+					t.Errorf("unexpected diff:\n%s\n", diff)
 				}
 			})
 		}
@@ -249,49 +249,16 @@ func TestGenerateKubeadmYAML(t *testing.T) {
 }
 
 func TestEtcdExtraArgs(t *testing.T) {
-	tcs := []struct {
-		description string
-		extraOpts   config.ExtraOptionSlice
-		expected    map[string]string
-	}{
-		{
-			description: "includes an etcd option",
-			extraOpts: config.ExtraOptionSlice{
-				config.ExtraOption{
-					Component: "kubeadm",
-					Key:       "key",
-					Value:     "value",
-				}, config.ExtraOption{
-					Component: "etcd",
-					Key:       "key1",
-					Value:     "value1",
-				},
-			},
-			expected: map[string]string{
-				"key1": "value1",
-			},
-		}, {
-			description: "no etcd option",
-			extraOpts: config.ExtraOptionSlice{
-				config.ExtraOption{
-					Component: "kubeadm",
-					Key:       "key",
-					Value:     "value",
-				}, config.ExtraOption{
-					Component: "apiserver",
-					Key:       "key1",
-					Value:     "value1",
-				},
-			},
-			expected: map[string]string{},
-		},
+	expected := map[string]string{
+		"key": "value",
 	}
-	for _, tc := range tcs {
-		t.Run(tc.description, func(t *testing.T) {
-			actual := etcdExtraArgs(tc.extraOpts)
-			if diff := cmp.Diff(tc.expected, actual); diff != "" {
-				t.Errorf("machines mismatch (-want +got):\n%s", diff)
-			}
-		})
+	extraOpts := append(getExtraOpts(), config.ExtraOption{
+		Component: Etcd,
+		Key:       "key",
+		Value:     "value",
+	})
+	actual := etcdExtraArgs(extraOpts)
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Errorf("machines mismatch (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
I'm working on tuning some etcd flags to improve overhead, and will set those numbers as defaults in a follow-up PR. I want to give users the ability to change those numbers back should they require it