### PR TITLE
Reduce coredns replicas from 2 to 1

### DIFF
--- a/pkg/addons/kubectl.go
+++ b/pkg/addons/kubectl.go
@@ -32,7 +32,7 @@ func kubectlCommand(cc *config.ClusterConfig, files []string, enable bool) *exec
 		v = cc.KubernetesConfig.KubernetesVersion
 	}
 
-	kubectlBinary := kubectlBinaryPath(v)
+	kubectlBinary := KubectlBinaryPath(v)
 
 	kubectlAction := "apply"
 	if !enable {
@@ -47,6 +47,7 @@ func kubectlCommand(cc *config.ClusterConfig, files []string, enable bool) *exec
 	return exec.Command("sudo", args...)
 }
 
-func kubectlBinaryPath(version string) string {
+// KubectlBinaryPath returns the path to kubectl on the node
+func KubectlBinaryPath(version string) string {
 	return path.Join(vmpath.GuestPersistentDir, "binaries", version, "kubectl")
 }

--- a/pkg/addons/kubectl.go
+++ b/pkg/addons/kubectl.go
@@ -21,6 +21,7 @@ import (
 	"os/exec"
 	"path"
 
+	"k8s.io/minikube/pkg/kapi"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/vmpath"
@@ -32,7 +33,7 @@ func kubectlCommand(cc *config.ClusterConfig, files []string, enable bool) *exec
 		v = cc.KubernetesConfig.KubernetesVersion
 	}
 
-	kubectlBinary := KubectlBinaryPath(v)
+	kubectlBinary := kapi.KubectlBinaryPath(v)
 
 	kubectlAction := "apply"
 	if !enable {
@@ -45,9 +46,4 @@ func kubectlCommand(cc *config.ClusterConfig, files []string, enable bool) *exec
 	}
 
 	return exec.Command("sudo", args...)
-}
-
-// KubectlBinaryPath returns the path to kubectl on the node
-func KubectlBinaryPath(version string) string {
-	return path.Join(vmpath.GuestPersistentDir, "binaries", version, "kubectl")
 }

--- a/pkg/kapi/kapi.go
+++ b/pkg/kapi/kapi.go
@@ -19,6 +19,7 @@ package kapi
 import (
 	"context"
 	"fmt"
+	"path"
 	"time"
 
 	"github.com/golang/glog"
@@ -37,6 +38,7 @@ import (
 	watchtools "k8s.io/client-go/tools/watch"
 	kconst "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/minikube/pkg/minikube/proxy"
+	"k8s.io/minikube/pkg/minikube/vmpath"
 )
 
 var (
@@ -204,4 +206,9 @@ func WaitForService(c kubernetes.Interface, namespace, name string, exist bool, 
 // IsRetryableAPIError returns if this error is retryable or not
 func IsRetryableAPIError(err error) bool {
 	return apierr.IsTimeout(err) || apierr.IsServerTimeout(err) || apierr.IsTooManyRequests(err) || apierr.IsInternalError(err)
+}
+
+// KubectlBinaryPath returns the path to kubectl on the node
+func KubectlBinaryPath(version string) string {
+	return path.Join(vmpath.GuestPersistentDir, "binaries", version, "kubectl")
 }

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -146,6 +146,12 @@ func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 		go addons.Start(&wg, starter.Cfg, starter.ExistingAddons, config.AddonList)
 	}
 
+	wg.Add(1)
+	go func() {
+		rescaleCoreDNS(starter.Cfg, starter.Runner)
+		wg.Done()
+	}()
+
 	if apiServer {
 		// special ops for none , like change minikube directory.
 		// multinode super doesn't work on the none driver
@@ -505,5 +511,17 @@ func prepareNone() {
 
 	if err := util.MaybeChownDirRecursiveToMinikubeUser(localpath.MiniPath()); err != nil {
 		exit.WithCodeT(exit.Permissions, "Failed to change permissions for {{.minikube_dir_path}}: {{.error}}", out.V{"minikube_dir_path": localpath.MiniPath(), "error": err})
+	}
+}
+
+// rescaleCoreDNS attempts to reduce coredns replicas from 2 to 1 to improve CPU overhead
+// no worries if this doesn't work
+func rescaleCoreDNS(cc *config.ClusterConfig, runner command.Runner) {
+	kubectl := addons.KubectlBinaryPath(cc.KubernetesConfig.KubernetesVersion)
+	cmd := exec.Command("sudo", "KUBECONFIG=/var/lib/minikube/kubeconfig", kubectl, "scale", "deployment", "--replicas=1", "coredns", "-n=kube-system")
+	if _, err := runner.RunCmd(cmd); err != nil {
+		glog.Infof("unable to scale coredns replicas to 1: %v", err)
+	} else {
+		glog.Infof("successfully scaled coredns replicas to 1")
 	}
 }

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -521,7 +521,7 @@ func rescaleCoreDNS(cc *config.ClusterConfig, runner command.Runner) {
 	kubectl := kapi.KubectlBinaryPath(cc.KubernetesConfig.KubernetesVersion)
 	cmd := exec.Command("sudo", "KUBECONFIG=/var/lib/minikube/kubeconfig", kubectl, "scale", "deployment", "--replicas=1", "coredns", "-n=kube-system")
 	if _, err := runner.RunCmd(cmd); err != nil {
-		glog.Infof("unable to scale coredns replicas to 1: %v", err)
+		glog.Warningf("unable to scale coredns replicas to 1: %v", err)
 	} else {
 		glog.Infof("successfully scaled coredns replicas to 1")
 	}

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -36,6 +36,7 @@ import (
 	cmdcfg "k8s.io/minikube/cmd/minikube/cmd/config"
 	"k8s.io/minikube/pkg/addons"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
+	"k8s.io/minikube/pkg/kapi"
 	"k8s.io/minikube/pkg/minikube/bootstrapper"
 	"k8s.io/minikube/pkg/minikube/bootstrapper/images"
 	"k8s.io/minikube/pkg/minikube/cluster"
@@ -517,7 +518,7 @@ func prepareNone() {
 // rescaleCoreDNS attempts to reduce coredns replicas from 2 to 1 to improve CPU overhead
 // no worries if this doesn't work
 func rescaleCoreDNS(cc *config.ClusterConfig, runner command.Runner) {
-	kubectl := addons.KubectlBinaryPath(cc.KubernetesConfig.KubernetesVersion)
+	kubectl := kapi.KubectlBinaryPath(cc.KubernetesConfig.KubernetesVersion)
 	cmd := exec.Command("sudo", "KUBECONFIG=/var/lib/minikube/kubeconfig", kubectl, "scale", "deployment", "--replicas=1", "coredns", "-n=kube-system")
 	if _, err := runner.RunCmd(cmd); err != nil {
 		glog.Infof("unable to scale coredns replicas to 1: %v", err)


### PR DESCRIPTION
This is an easy way to improve overhead -- we don't need 2 coredns pods running by default. If a user wants more, they can easily scale the deployment up with `kubectl`


it won't make a huge difference alone, but in combination with some other PRs I'll be opening it should get us to our goal of 20% reduction

#5682 