### PR TITLE
add verification for enabling ingress, registry and gvisor addons

### DIFF
--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -141,7 +141,7 @@ func enableOrDisableAddon(cc *config.ClusterConfig, name string, val string) err
 	}
 
 	// to match both ingress and ingress-dns adons
-	if strings.HasPrefix(name, "ingress") && enable && driver.IsKIC(cc.Driver) && runtime.GOOS == "linux" {
+	if strings.HasPrefix(name, "ingress") && enable && driver.IsKIC(cc.Driver) && runtime.GOOS != "linux" {
 		exit.UsageT(`Due to {{.driver_name}} networking limitations on {{.os_name}}, {{.addon_name}} addon is not supported for this driver.
 Alternatively to use this addon you can use a vm-based driver:
 

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -313,24 +313,20 @@ func enableOrDisableStorageClasses(cc *config.ClusterConfig, name string, val st
 }
 
 func validateIngress(cc *config.ClusterConfig, name string, val string) error {
-	fmt.Println("inside validatr inresssss")
 	glog.Infof("Setting addon %s=%s in %q", name, val, cc.Name)
 	enable, err := strconv.ParseBool(val)
 	if err != nil {
 		return errors.Wrapf(err, "parsing bool: %s", name)
 	}
 	if name == "ingress" && enable {
-		fmt.Println("validating client")
 		client, err := kapi.Client(viper.GetString(config.ProfileName))
 		if err != nil {
 			return errors.Wrapf(err, "get kube-client to validate ingress addon: %s", name)
 		} else {
-			fmt.Println("validating deployment.....")
 			err = kapi.WaitForDeploymentToStabilize(client, "kube-system", "ingress-nginx-controller", time.Minute*3)
 			if err != nil {
-				return errors.Wrapf(err, "Failed verifying ingress addon: %s", name)
+				return errors.Wrapf(err, "Failed verifying ingress addon deployment: %s", name)
 			}
-			fmt.Println("SCUCESSSFULLY validated deployment.....")
 		}
 	}
 	return nil

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -140,15 +140,15 @@ func enableOrDisableAddon(cc *config.ClusterConfig, name string, val string) err
 		}
 	}
 
-	//	to match both ingress and ingress-dns adons
+	// to match both ingress and ingress-dns adons
 	if strings.HasPrefix(name, "ingress") && enable && driver.IsKIC(cc.Driver) && runtime.GOOS != "linux" {
 		exit.UsageT(`Due to {{.driver_name}} networking limitations on {{.os_name}}, {{.addon_name}} addon is not supported for this driver.
-	Alternatively to use this addon you can use a vm-based driver:
+Alternatively to use this addon you can use a vm-based driver:
 
-		'minikube start --vm=true'
+	'minikube start --vm=true'
 
-	To track the update on this work in progress feature please check:
-	https://github.com/kubernetes/minikube/issues/7332`, out.V{"driver_name": cc.Driver, "os_name": runtime.GOOS, "addon_name": name})
+To track the update on this work in progress feature please check:
+https://github.com/kubernetes/minikube/issues/7332`, out.V{"driver_name": cc.Driver, "os_name": runtime.GOOS, "addon_name": name})
 	}
 
 	if strings.HasPrefix(name, "istio") && enable {

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -323,11 +323,10 @@ func validateIngress(cc *config.ClusterConfig, name string, val string) error {
 		client, err := kapi.Client(viper.GetString(config.ProfileName))
 		if err != nil {
 			return errors.Wrapf(err, "get kube-client to validate ingress addon: %s", name)
-		} else {
-			err = kapi.WaitForDeploymentToStabilize(client, "kube-system", "ingress-nginx-controller", time.Minute*3)
-			if err != nil {
-				return errors.Wrapf(err, "Failed verifying ingress addon deployment: %s", name)
-			}
+		}
+		err = kapi.WaitForDeploymentToStabilize(client, "kube-system", "ingress-nginx-controller", time.Minute*3)
+		if err != nil {
+			return errors.Wrapf(err, "Failed verifying ingress addon deployment: %s", name)
 		}
 	}
 	return nil

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -19,6 +19,7 @@ package addons
 import (
 	"fmt"
 	"path"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -139,16 +140,16 @@ func enableOrDisableAddon(cc *config.ClusterConfig, name string, val string) err
 		}
 	}
 
-	// to match both ingress and ingress-dns adons
-	// 	if strings.HasPrefix(name, "ingress") && enable && driver.IsKIC(cc.Driver) && runtime.GOOS != "linux" {
-	// 		exit.UsageT(`Due to {{.driver_name}} networking limitations on {{.os_name}}, {{.addon_name}} addon is not supported for this driver.
-	// Alternatively to use this addon you can use a vm-based driver:
+	//	to match both ingress and ingress-dns adons
+	if strings.HasPrefix(name, "ingress") && enable && driver.IsKIC(cc.Driver) && runtime.GOOS != "linux" {
+		exit.UsageT(`Due to {{.driver_name}} networking limitations on {{.os_name}}, {{.addon_name}} addon is not supported for this driver.
+	Alternatively to use this addon you can use a vm-based driver:
 
-	// 	'minikube start --vm=true'
+		'minikube start --vm=true'
 
-	// To track the update on this work in progress feature please check:
-	// https://github.com/kubernetes/minikube/issues/7332`, out.V{"driver_name": cc.Driver, "os_name": runtime.GOOS, "addon_name": name})
-	// 	}
+	To track the update on this work in progress feature please check:
+	https://github.com/kubernetes/minikube/issues/7332`, out.V{"driver_name": cc.Driver, "os_name": runtime.GOOS, "addon_name": name})
+	}
 
 	if strings.HasPrefix(name, "istio") && enable {
 		minMem := 8192

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -314,7 +314,7 @@ func enableOrDisableStorageClasses(cc *config.ClusterConfig, name string, val st
 }
 
 func verifyAddonStatus(cc *config.ClusterConfig, name string, val string) error {
-	glog.Infof("Setting addon %s=%s in %q", name, val, cc.Name)
+	glog.Infof("Verifying addon %s=%s in %q", name, val, cc.Name)
 	enable, err := strconv.ParseBool(val)
 	if err != nil {
 		return errors.Wrapf(err, "parsing bool: %s", name)

--- a/pkg/addons/config.go
+++ b/pkg/addons/config.go
@@ -65,7 +65,7 @@ var Addons = []*Addon{
 	{
 		name:      "ingress",
 		set:       SetBool,
-		callbacks: []setFn{enableOrDisableAddon},
+		callbacks: []setFn{enableOrDisableAddon, validateIngress},
 	},
 	{
 		name:      "ingress-dns",

--- a/pkg/addons/config.go
+++ b/pkg/addons/config.go
@@ -28,6 +28,13 @@ type Addon struct {
 	callbacks   []setFn
 }
 
+// addonPodLabels holds the pod label that will be used to verify if the addon is enabled
+var addonPodLabels = map[string]string{
+	"ingress":  "app.kubernetes.io/name=ingress-nginx",
+	"registry": "kubernetes.io/minikube-addons=registry",
+	"gvisor":   "kubernetes.io/minikube-addons=gvisor",
+}
+
 // Addons is a list of all addons
 var Addons = []*Addon{
 	{
@@ -55,7 +62,7 @@ var Addons = []*Addon{
 		name:        "gvisor",
 		set:         SetBool,
 		validations: []setFn{IsRuntimeContainerd},
-		callbacks:   []setFn{enableOrDisableAddon},
+		callbacks:   []setFn{enableOrDisableAddon, verifyAddonStatus},
 	},
 	{
 		name:      "helm-tiller",
@@ -65,7 +72,7 @@ var Addons = []*Addon{
 	{
 		name:      "ingress",
 		set:       SetBool,
-		callbacks: []setFn{enableOrDisableAddon, validateIngress},
+		callbacks: []setFn{enableOrDisableAddon, verifyAddonStatus},
 	},
 	{
 		name:      "ingress-dns",
@@ -115,7 +122,7 @@ var Addons = []*Addon{
 	{
 		name:      "registry",
 		set:       SetBool,
-		callbacks: []setFn{enableOrDisableAddon},
+		callbacks: []setFn{enableOrDisableAddon, verifyAddonStatus},
 	},
 	{
 		name:      "registry-creds",

--- a/pkg/kapi/kapi.go
+++ b/pkg/kapi/kapi.go
@@ -28,7 +28,6 @@ import (
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
@@ -70,21 +69,21 @@ func Client(context string) (*kubernetes.Clientset, error) {
 	return kubernetes.NewForConfig(c)
 }
 
-// WaitForPodsWithLabelRunning waits for all matching pods to become Running and at least one matching pod exists.
-func WaitForPodsWithLabelRunning(c kubernetes.Interface, ns string, label labels.Selector, timeOut ...time.Duration) error {
+// WaitForPods waits for all matching pods to become Running or finish successfully and at least one matching pod exists.
+func WaitForPods(c kubernetes.Interface, ns string, selector string, timeOut ...time.Duration) error {
 	start := time.Now()
-	glog.Infof("Waiting for pod with label %q in ns %q ...", ns, label)
+	glog.Infof("Waiting for pod with label %q in ns %q ...", ns, selector)
 	lastKnownPodNumber := -1
 	f := func() (bool, error) {
-		listOpts := meta.ListOptions{LabelSelector: label.String()}
+		listOpts := meta.ListOptions{LabelSelector: selector}
 		pods, err := c.CoreV1().Pods(ns).List(listOpts)
 		if err != nil {
-			glog.Infof("temporary error: getting Pods with label selector %q : [%v]\n", label.String(), err)
+			glog.Infof("temporary error: getting Pods with label selector %q : [%v]\n", selector, err)
 			return false, nil
 		}
 
 		if lastKnownPodNumber != len(pods.Items) {
-			glog.Infof("Found %d Pods for label selector %s\n", len(pods.Items), label.String())
+			glog.Infof("Found %d Pods for label selector %s\n", len(pods.Items), selector)
 			lastKnownPodNumber = len(pods.Items)
 		}
 
@@ -93,8 +92,8 @@ func WaitForPodsWithLabelRunning(c kubernetes.Interface, ns string, label labels
 		}
 
 		for _, pod := range pods.Items {
-			if pod.Status.Phase != core.PodRunning {
-				glog.Infof("waiting for pod %q, current state: %s: [%v]\n", label.String(), pod.Status.Phase, err)
+			if pod.Status.Phase != core.PodRunning && pod.Status.Phase != core.PodSucceeded {
+				glog.Infof("waiting for pod %q, current state: %s: [%v]\n", selector, pod.Status.Phase, err)
 				return false, nil
 			}
 		}
@@ -106,7 +105,7 @@ func WaitForPodsWithLabelRunning(c kubernetes.Interface, ns string, label labels
 		t = timeOut[0]
 	}
 	err := wait.PollImmediate(kconst.APICallRetryInterval, t, f)
-	glog.Infof("duration metric: took %s to wait for %s ...", time.Since(start), label)
+	glog.Infof("duration metric: took %s to wait for %s ...", time.Since(start), selector)
 	return err
 }
 


### PR DESCRIPTION

### After this PR:
Added the Pod Label Verification for 3 popular addon

will wait for the addon pod to be running, before exiting, this will eleminate a lot of integration test and docs needing waiting for pod to be running
as seen in kuberentes docs https://kubernetes.io/docs/tasks/access-application-cluster/ingress-minikube/


```
$minikube addons enable gvisor
🔎  Verifying gvisor addon...
🌟  The 'gvisor' addon is enabled
```

