### PR TITLE
Check for iptables file before determining container is running

### DIFF
--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -582,11 +582,8 @@ func ShutDown(ociBin string, name string) error {
 
 // iptablesFileExists checks if /var/lib/dpkg/alternatives/iptables exists in minikube
 // this file is necessary for the entrypoint script to pass
-// see: https://github.com/kubernetes/minikube/issues/8179
+// TODO: https://github.com/kubernetes/minikube/issues/8179
 func iptablesFileExists(ociBin string, nameOrID string) bool {
-	if ociBin != Docker {
-		return true
-	}
 	file := "/var/lib/dpkg/alternatives/iptables"
 	_, err := runCmd(exec.Command(ociBin, "exec", nameOrID, "stat", file), false)
 	if err != nil {

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -212,6 +212,9 @@ func CreateContainerNode(p CreateParams) error {
 		if s != state.Running {
 			return fmt.Errorf("temporary error created container %q is not running yet", p.Name)
 		}
+		if !iptablesFileExists(p.OCIBinary, p.Name) {
+			return fmt.Errorf("iptables file doesn't exist, see #8179")
+		}
 		glog.Infof("the created container %q has a running status.", p.Name)
 		return nil
 	}
@@ -575,4 +578,20 @@ func ShutDown(ociBin string, name string) error {
 	}
 	glog.Infof("Successfully shutdown container %s", name)
 	return nil
+}
+
+// iptablesFileExists checks if /var/lib/dpkg/alternatives/iptables exists in minikube
+// this file is necessary for the entrypoint script to pass
+// see: https://github.com/kubernetes/minikube/issues/8179
+func iptablesFileExists(ociBin string, nameOrID string) bool {
+	if ociBin != Docker {
+		return true
+	}
+	file := "/var/lib/dpkg/alternatives/iptables"
+	_, err := runCmd(exec.Command(ociBin, "exec", nameOrID, "stat", file), false)
+	if err != nil {
+		glog.Warningf("error checking if %s exists: %v", file, err)
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
Both https://github.com/kubernetes/minikube/issues/8179 and https://github.com/kubernetes/minikube/issues/8163 are happening because `/var/lib/dpkg/alternatives/iptables` does not exist in the container -- the kic entrypoint.sh file tries to access it & exits with exit code 2 when it isn't there. This is likely caused by a race condition between mounting the minikube volume to /var & the entrypoint file trying to access the iptables file

The correct fix for this problem is to address the race condition, but that will be a bigger task (as described here by @afbjorklund: https://github.com/kubernetes/minikube/pull/8509#issuecomment-646135543)

Until we fix the main issue, I think it would be nice to just check for the file so that we can quickly determine if the container will fail because the file doesn't exist and automatically restart the container (that seems to fix the issue every time I've experienced it in Cloud Shell)

I'm very open to suggestions if someone can think of a better idea for this :) 