### PR TITLE
CNI: Update CRIO netconfig with matching subnet

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -282,8 +282,8 @@ func (k *Bootstrapper) applyCNI(cfg config.ClusterConfig) error {
 	}
 
 	if cfg.KubernetesConfig.ContainerRuntime == "crio" {
-		if err := sysinit.New(k.c).Restart("crio"); err != nil {
-			glog.Errorf("failed to restart CRI: %v", err)
+		if err := cruntime.UpdateCRIONet(k.c, cnm.CIDR()); err != nil {
+			return errors.Wrap(err, "update crio")
 		}
 	}
 

--- a/pkg/minikube/cni/bridge.go
+++ b/pkg/minikube/cni/bridge.go
@@ -82,6 +82,7 @@ func (c Bridge) Apply(r Runner) error {
 	if err := r.Copy(f); err != nil {
 		return errors.Wrapf(err, "copy")
 	}
+
 	return nil
 }
 

--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -18,6 +18,7 @@ package cruntime
 
 import (
 	"fmt"
+	"net"
 	"os/exec"
 	"strings"
 
@@ -96,7 +97,6 @@ func (r *CRIO) Available() error {
 		return errors.Wrapf(err, "check crio available.")
 	}
 	return nil
-
 }
 
 // Active returns if CRIO is active on the host
@@ -223,4 +223,31 @@ func (r *CRIO) Preload(cfg config.KubernetesConfig) error {
 		return nil
 	}
 	return fmt.Errorf("not yet implemented for %s", r.Name())
+}
+
+// UpdateCRIONet updates CRIO CNI network configuration and restarts it
+func UpdateCRIONet(r CommandRunner, cidr string) error {
+	glog.Infof("Updating CRIO to use CIDR: %q", cidr)
+	ip, net, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return errors.Wrap(err, "parse cidr")
+	}
+
+	oldNet := "10.88.0.0/16"
+	oldGw := "10.88.0.1"
+
+	newNet := cidr
+
+	// Assume gateway is first IP in netmask (10.244.0.1, for instance)
+	newGw := ip.Mask(net.Mask)
+	newGw[3]++
+
+	// Update subnets used by 100-crio-bridge.conf & 87-podman-bridge.conflist
+	// avoids: "Error adding network: failed to set bridge addr: could not add IP address to \"cni0\": permission denied"
+	sed := fmt.Sprintf("sed -i -e s#%s#%s# -e s#%s#%s# /etc/cni/net.d/*bridge*", oldNet, newNet, oldGw, newGw)
+	if _, err := r.RunCmd(exec.Command("sudo", "/bin/bash", "-c", sed)); err != nil {
+		glog.Errorf("netconf update failed: %v", err)
+	}
+
+	return sysinit.New(r).Restart("crio")
 }


### PR DESCRIPTION
In hopes of avoiding `failed to set bridge addr: could not add IP address to \"cni0\": permission denied"` race condition seen at: https://storage.googleapis.com/minikube-builds/logs/8545/03ec6f9/Docker_Linux.html#fail_TestOffline%2fgroup%2fcrio

as a bonus, this PR also skips more weavenet CNI tests to avoid `TestNetworkPlugins/group/custom-weave/DNS` test flake:

https://storage.googleapis.com/minikube-builds/logs/8545/03ec6f9/VirtualBox_Linux.html#fail_TestNetworkPlugins%2fgroup%2fcustom-weave%2fDNS