### PR TITLE
Fix bug in FailFastError and add unit test

### DIFF
--- a/pkg/drivers/kic/oci/errors.go
+++ b/pkg/drivers/kic/oci/errors.go
@@ -24,13 +24,19 @@ import (
 )
 
 // FailFastError type is an error that could not be solved by trying again
-type FailFastError error
+type FailFastError struct {
+	Err error
+}
+
+func (f *FailFastError) Error() string {
+	return f.Err.Error()
+}
 
 // ErrWindowsContainers is thrown when docker been configured to run windows containers instead of Linux
-var ErrWindowsContainers = FailFastError(errors.New("docker container type is windows"))
+var ErrWindowsContainers = &FailFastError{errors.New("docker container type is windows")}
 
 // ErrCPUCountLimit is thrown when docker daemon doesn't have enough CPUs for the requested container
-var ErrCPUCountLimit = FailFastError(errors.New("not enough CPUs is available for container"))
+var ErrCPUCountLimit = &FailFastError{errors.New("not enough CPUs is available for container")}
 
 // ErrExitedUnexpectedly is thrown when container is created/started without error but later it exists and it's status is not running anymore.
 var ErrExitedUnexpectedly = errors.New("container exited unexpectedly")

--- a/pkg/drivers/kic/oci/errors_test.go
+++ b/pkg/drivers/kic/oci/errors_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2020 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oci
+
+import "testing"
+
+func TestFailFastError(t *testing.T) {
+	tcs := []struct {
+		description      string
+		err              error
+		shouldBeFailFast bool
+	}{
+		{
+			description:      "fail fast error",
+			err:              ErrWindowsContainers,
+			shouldBeFailFast: true,
+		}, {
+			description: "not a fail fast error",
+			err:         ErrExitedUnexpectedly,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.description, func(t *testing.T) {
+			_, ff := tc.err.(*FailFastError)
+			if ff != tc.shouldBeFailFast {
+				t.Fatalf("expected fail fast to be %v, was %v", tc.shouldBeFailFast, ff)
+			}
+		})
+	}
+}

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -379,7 +379,7 @@ func startHost(api libmachine.API, cc *config.ClusterConfig, n *config.Node) (*h
 		}
 	}
 
-	if _, ff := err.(oci.FailFastError); ff {
+	if _, ff := err.(*oci.FailFastError); ff {
 		glog.Infof("will skip retrying to create machine because error is not retriable: %v", err)
 		return host, exists, err
 	}


### PR DESCRIPTION
I noticed this small bug which was preventing recreation of containers on `minikube start` if the container exited randomly. Previously, FailFastError was just type `error`, so all errors were technically of type `FailFastError`.

This code makes `FailFastError` a struct which implements the error interface, so that now errors can be distinctly identified as `FailFastError`'

Also added a unit test to prove that this works now.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
