### PR TITLE
Generate cri-o container runtime preload tarball

### DIFF
--- a/hack/preload-images/generate.go
+++ b/hack/preload-images/generate.go
@@ -137,6 +137,10 @@ func imagePullCommand(containerRuntime, img string) *exec.Cmd {
 	if containerRuntime == "containerd" {
 		return exec.Command("docker", "exec", profile, "sudo", "crictl", "pull", img)
 	}
+
+	if containerRuntime == "cri-o" {
+		return exec.Command("docker", "exec", profile, "sudo", "crictl", "pull", img)
+	}
 	return nil
 }
 
@@ -152,6 +156,10 @@ func createImageTarball(tarballFilename, containerRuntime string) error {
 
 	if containerRuntime == "containerd" {
 		dirs = append(dirs, fmt.Sprintf("./lib/containerd"))
+	}
+
+	if containerRuntime == "cri-o" {
+		dirs = append(dirs, fmt.Sprintf("./lib/containers"))
 	}
 
 	args := []string{"exec", profile, "sudo", "tar", "-I", "lz4", "-C", "/var", "-cvf", tarballFilename}

--- a/hack/preload-images/preload_images.go
+++ b/hack/preload-images/preload_images.go
@@ -64,12 +64,6 @@ func main() {
 		fmt.Printf("error cleaning up minikube at start up: %v \n", err)
 	}
 
-	if err := verifyDockerStorage(); err != nil {
-		exit("Docker storage type is incompatible: %v \n", err)
-	}
-	if err := verifyPodmanStorage(); err != nil {
-		exit("Podman storage type is incompatible: %v \n", err)
-	}
 	if k8sVersions == nil {
 		var err error
 		k8sVersions, err = RecentK8sVersions()
@@ -104,7 +98,7 @@ func main() {
 }
 
 func verifyDockerStorage() error {
-	cmd := exec.Command("docker", "info", "-f", "{{.Info.Driver}}")
+	cmd := exec.Command("docker", "exec", profile, "docker", "info", "-f", "{{.Info.Driver}}")
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	output, err := cmd.Output()
@@ -119,7 +113,7 @@ func verifyDockerStorage() error {
 }
 
 func verifyPodmanStorage() error {
-	cmd := exec.Command("sudo", "podman", "info", "-f", "json")
+	cmd := exec.Command("docker", "exec", profile, "sudo", "podman", "info", "-f", "json")
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	output, err := cmd.Output()

--- a/hack/preload-images/preload_images.go
+++ b/hack/preload-images/preload_images.go
@@ -37,7 +37,7 @@ const (
 
 var (
 	dockerStorageDriver = "overlay2"
-	containerRuntimes   = []string{"docker", "containerd"}
+	containerRuntimes   = []string{"docker", "containerd", "cri-o"}
 	k8sVersion          string
 	k8sVersions         []string
 )

--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -370,7 +370,7 @@ func containerdImagesPreloaded(runner command.Runner, images []string) bool {
 	if err != nil {
 		return false
 	}
-	type containerdImages struct {
+	type criImages struct {
 		Images []struct {
 			ID          string      `json:"id"`
 			RepoTags    []string    `json:"repoTags"`
@@ -381,7 +381,7 @@ func containerdImagesPreloaded(runner command.Runner, images []string) bool {
 		} `json:"images"`
 	}
 
-	var jsonImages containerdImages
+	var jsonImages criImages
 	err = json.Unmarshal(rr.Stdout.Bytes(), &jsonImages)
 	if err != nil {
 		glog.Errorf("failed to unmarshal images, will assume images are not preloaded")
@@ -411,16 +411,4 @@ func containerdImagesPreloaded(runner command.Runner, images []string) bool {
 	}
 	glog.Infof("all images are preloaded for containerd runtime.")
 	return true
-}
-
-// addRepoTagToImageName makes sure the image name has a repo tag in it.
-// in crictl images list have the repo tag prepended to them
-// for example "kubernetesui/dashboard:v2.0.0 will show up as "docker.io/kubernetesui/dashboard:v2.0.0"
-// warning this is only meant for kuberentes images where we know the GCR addreses have .io in them
-// not mean to be used for public images
-func addRepoTagToImageName(imgName string) string {
-	if !strings.Contains(imgName, ".io/") {
-		return "docker.io/" + imgName
-	} // else it already has repo name dont add anything
-	return imgName
 }

--- a/pkg/minikube/cruntime/cri.go
+++ b/pkg/minikube/cruntime/cri.go
@@ -259,3 +259,15 @@ func criContainerLogCmd(cr CommandRunner, id string, len int, follow bool) strin
 	cmd.WriteString(id)
 	return cmd.String()
 }
+
+// addRepoTagToImageName makes sure the image name has a repo tag in it.
+// in crictl images list have the repo tag prepended to them
+// for example "kubernetesui/dashboard:v2.0.0 will show up as "docker.io/kubernetesui/dashboard:v2.0.0"
+// warning this is only meant for kuberentes images where we know the GCR addreses have .io in them
+// not mean to be used for public images
+func addRepoTagToImageName(imgName string) string {
+        if !strings.Contains(imgName, ".io/") {
+                return "docker.io/" + imgName
+        } // else it already has repo name dont add anything
+        return imgName
+}

--- a/pkg/minikube/cruntime/cri.go
+++ b/pkg/minikube/cruntime/cri.go
@@ -266,8 +266,8 @@ func criContainerLogCmd(cr CommandRunner, id string, len int, follow bool) strin
 // warning this is only meant for kuberentes images where we know the GCR addreses have .io in them
 // not mean to be used for public images
 func addRepoTagToImageName(imgName string) string {
-        if !strings.Contains(imgName, ".io/") {
-                return "docker.io/" + imgName
-        } // else it already has repo name dont add anything
-        return imgName
+	if !strings.Contains(imgName, ".io/") {
+		return "docker.io/" + imgName
+	} // else it already has repo name dont add anything
+	return imgName
 }

--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -17,14 +17,19 @@ limitations under the License.
 package cruntime
 
 import (
+	"encoding/json"
 	"fmt"
 	"os/exec"
+	"path"
 	"strings"
+	"time"
 
 	"github.com/blang/semver"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/bootstrapper/images"
+	"k8s.io/minikube/pkg/minikube/command"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/download"
 	"k8s.io/minikube/pkg/minikube/out"
@@ -222,5 +227,101 @@ func (r *CRIO) Preload(cfg config.KubernetesConfig) error {
 	if !download.PreloadExists(cfg.KubernetesVersion, cfg.ContainerRuntime) {
 		return nil
 	}
-	return fmt.Errorf("not yet implemented for %s", r.Name())
+
+	k8sVersion := cfg.KubernetesVersion
+	cRuntime := cfg.ContainerRuntime
+
+	// If images already exist, return
+	images, err := images.Kubeadm(cfg.ImageRepository, k8sVersion)
+	if err != nil {
+		return errors.Wrap(err, "getting images")
+	}
+	if crioImagesPreloaded(r.Runner, images) {
+		glog.Info("Images already preloaded, skipping extraction")
+		return nil
+	}
+
+	tarballPath := download.TarballPath(k8sVersion, cRuntime)
+	targetDir := "/"
+	targetName := "preloaded.tar.lz4"
+	dest := path.Join(targetDir, targetName)
+
+	c := exec.Command("which", "lz4")
+	if _, err := r.Runner.RunCmd(c); err != nil {
+		return NewErrISOFeature("lz4")
+	}
+
+	// Copy over tarball into host
+	fa, err := assets.NewFileAsset(tarballPath, targetDir, targetName, "0644")
+	if err != nil {
+		return errors.Wrap(err, "getting file asset")
+	}
+	t := time.Now()
+	if err := r.Runner.Copy(fa); err != nil {
+		return errors.Wrap(err, "copying file")
+	}
+	glog.Infof("Took %f seconds to copy over tarball", time.Since(t).Seconds())
+
+	t = time.Now()
+	// extract the tarball to /var in the VM
+	if rr, err := r.Runner.RunCmd(exec.Command("sudo", "tar", "-I", "lz4", "-C", "/var", "-xvf", dest)); err != nil {
+		return errors.Wrapf(err, "extracting tarball: %s", rr.Output())
+	}
+	glog.Infof("Took %f seconds t extract the tarball", time.Since(t).Seconds())
+
+	//  remove the tarball in the VM
+	if err := r.Runner.Remove(fa); err != nil {
+		glog.Infof("error removing tarball: %v", err)
+	}
+
+	return nil
+}
+
+// crioImagesPreloaded returns true if all images have been preloaded
+func crioImagesPreloaded(runner command.Runner, images []string) bool {
+	rr, err := runner.RunCmd(exec.Command("sudo", "crictl", "images", "--output", "json"))
+	if err != nil {
+		return false
+	}
+	type criImages struct {
+		Images []struct {
+			ID          string      `json:"id"`
+			RepoTags    []string    `json:"repoTags"`
+			RepoDigests []string    `json:"repoDigests"`
+			Size        string      `json:"size"`
+			UID         interface{} `json:"uid"`
+			Username    string      `json:"username"`
+		} `json:"images"`
+	}
+
+	var jsonImages criImages
+	err = json.Unmarshal(rr.Stdout.Bytes(), &jsonImages)
+	if err != nil {
+		glog.Errorf("failed to unmarshal images, will assume images are not preloaded")
+		return false
+	}
+
+	// Make sure images == imgs
+	for _, i := range images {
+		found := false
+		for _, ji := range jsonImages.Images {
+			for _, rt := range ji.RepoTags {
+				i = addRepoTagToImageName(i)
+				if i == rt {
+					found = true
+					break
+				}
+			}
+			if found {
+				break
+			}
+
+		}
+		if !found {
+			glog.Infof("couldn't find preloaded image for %q. assuming images are not preloaded.", i)
+			return false
+		}
+	}
+	glog.Infof("all images are preloaded for crio runtime.")
+	return true
 }

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -87,13 +87,6 @@ func remoteTarballURL(k8sVersion, containerRuntime string) string {
 // PreloadExists returns true if there is a preloaded tarball that can be used
 func PreloadExists(k8sVersion, containerRuntime string, forcePreload ...bool) bool {
 
-	// and https://github.com/kubernetes/minikube/issues/6934
-	// to track status of adding crio
-	if containerRuntime == "crio" {
-		glog.Info("crio is not supported yet, skipping preload")
-		return false
-	}
-
 	// TODO (#8166): Get rid of the need for this and viper at all
 	force := false
 	if len(forcePreload) > 0 {

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -47,6 +47,9 @@ const (
 
 // TarballName returns name of the tarball
 func TarballName(k8sVersion, containerRuntime string) string {
+	if containerRuntime == "crio" {
+		containerRuntime = "cri-o"
+	}
 	var storageDriver string
 	if containerRuntime == "cri-o" {
 		storageDriver = "overlay"

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -47,7 +47,13 @@ const (
 
 // TarballName returns name of the tarball
 func TarballName(k8sVersion, containerRuntime string) string {
-	return fmt.Sprintf("preloaded-images-k8s-%s-%s-%s-overlay2-%s.tar.lz4", PreloadVersion, k8sVersion, containerRuntime, runtime.GOARCH)
+	var storageDriver string
+	if containerRuntime == "cri-o" {
+		storageDriver = "overlay"
+	} else {
+		storageDriver = "overlay2"
+	}
+	return fmt.Sprintf("preloaded-images-k8s-%s-%s-%s-%s-%s.tar.lz4", PreloadVersion, k8sVersion, containerRuntime, storageDriver, runtime.GOARCH)
 }
 
 // returns the name of the checksum file


### PR DESCRIPTION
Added cri-o, to the list of preloaded tarballs:

```
A preloaded tarball for k8s version v1.18.3 - runtime "docker" already exists, skipping generation.
A preloaded tarball for k8s version v1.18.3 - runtime "containerd" already exists, skipping generation.
A preloaded tarball for k8s version v1.18.3 - runtime "cri-o" doesn't exist, generating now...
Image is up to date for k8s.gcr.io/kube-proxy@sha256:6a093c22e305039b7bd6c3f8eab8f202ad8238066ed210857b25524443aa8aff
Image is up to date for k8s.gcr.io/kube-scheduler@sha256:5381cd9680bf5fb16a5c8ac60141eaab242c1c4960f1c32a21807efcca3e765b
Image is up to date for k8s.gcr.io/kube-controller-manager@sha256:168e8f9276e5f947d68f93a9463243f6a525227d15f55fb40b427c8d6caa55c2
Image is up to date for k8s.gcr.io/kube-apiserver@sha256:b5bf4650d7f084d0c9f89ecae50c00ebf5b44edcdd487636d8c7fd400d27cd05
Image is up to date for k8s.gcr.io/coredns@sha256:2c8d61c46f484d881db43b34d13ca47a269336e576c81cf007ca740fa9ec0800
Image is up to date for k8s.gcr.io/etcd@sha256:4198ba6f82f642dfd18ecf840ee37afb9df4b596f06eef20e44d0aec4ea27216
Image is up to date for k8s.gcr.io/pause@sha256:4a1c4b21597c1b4415bdbecb28a3296c6b5e23ca4f9feeb599860a1dac6a0108
Image is up to date for gcr.io/k8s-minikube/storage-provisioner@sha256:088daa9fcbccf04c3f415d77d5a6360d2803922190b675cb7fc88a9d2d91985a
Image is up to date for docker.io/kubernetesui/dashboard@sha256:19207cca570f61bce2294595a767b51b4d7e1f223a003c7972c350cf8689f49e
Image is up to date for docker.io/kubernetesui/metrics-scraper@sha256:555981a24f184420f3be0c79d4efb6c948a85cfce84034f85a563f4151a81cbf
Image is up to date for docker.io/kindest/kindnetd@sha256:46e34ccb3e08557767b7c80e957741d9f2590968ff32646875632d40cf62adad
```

For #6934