### PR TITLE
Support more error messages for container inspect

### DIFF
--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -294,7 +294,12 @@ func StartContainer(ociBin string, container string) error {
 func ContainerID(ociBin string, nameOrID string) (string, error) {
 	rr, err := runCmd(exec.Command(ociBin, "container", "inspect", "-f", "{{.Id}}", nameOrID))
 	if err != nil { // don't return error if not found, only return empty string
-		if strings.Contains(rr.Stdout.String(), "Error: No such object:") || strings.Contains(rr.Stdout.String(), "unable to find") {
+		if strings.Contains(rr.Stdout.String(), "Error: No such object:") ||
+			strings.Contains(rr.Stdout.String(), "Error: No such container:") ||
+			strings.Contains(rr.Stdout.String(), "unable to find") ||
+			strings.Contains(rr.Stdout.String(), "Error: error inspecting object") ||
+			strings.Contains(rr.Stdout.String(), "Error: error looking up container") ||
+			strings.Contains(rr.Stdout.String(), "no such container") {
 			err = nil
 		}
 		return "", err


### PR DESCRIPTION
The messages are different between "inspect" and "container inspect",
and also changed a bit in format between Podman v1 and Podman v2.

Support all of them, for compatibility with different versions of
Docker and Podman. Was causing restarts and failures, with KIC.
