### PR TITLE
add new method to clean

### DIFF
--- a/cmd/minikube/cmd/config/set_test.go
+++ b/cmd/minikube/cmd/config/set_test.go
@@ -81,4 +81,8 @@ func createTestConfig(t *testing.T) {
 	if err = os.MkdirAll(localpath.MakeMiniPath("profiles"), 0777); err != nil {
 		t.Fatalf("error creating temporary profiles directory: %+v", err)
 	}
+
+	t.Cleanup(func() {
+		os.RemoveAll(td)
+	})
 }

--- a/cmd/minikube/cmd/config/set_test.go
+++ b/cmd/minikube/cmd/config/set_test.go
@@ -83,6 +83,9 @@ func createTestConfig(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		os.RemoveAll(td)
+		err := os.RemoveAll(td)
+		if err != nil {
+			t.Errorf("failed to clean up temp folder  %q", td)
+		}
 	})
 }

--- a/cmd/minikube/cmd/delete_test.go
+++ b/cmd/minikube/cmd/delete_test.go
@@ -66,12 +66,12 @@ func TestDeleteProfile(t *testing.T) {
 		t.Fatalf("tempdir: %v", err)
 	}
 
-	defer func() { //clean up tempdir
+	t.Cleanup(func() {
 		err := os.RemoveAll(td)
 		if err != nil {
 			t.Errorf("failed to clean up temp folder  %q", td)
 		}
-	}()
+	})
 
 	err = copy.Copy("../../../pkg/minikube/config/testdata/delete-single", td)
 	if err != nil {


### PR DESCRIPTION
This PR is for #7670

An improvement of #7787

According to what was discussed in the triage, and suggestion of @tstromberg. Cleanup was implemented, which was integrated into Go 1.14 [details](https://github.com/golang/go/commit/1b2ff1013678bca2181d046a91857e78f3981f9c)

Clean up after creating temporary directories in unit tests. With validation for tests that call a single directory multiple times.
