### PR TITLE
Upgrade golang version from 1.13.8 to 1.13.9

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -17,6 +17,10 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.13.9'
+          stable: true
       - name: Download Dependencies
         run: go mod download
       - name: Build Binaries
@@ -40,6 +44,10 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.13.9'
+          stable: true
       - name: Install libvirt
         run: |
           sudo apt-get update
@@ -55,6 +63,10 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.13.9'
+          stable: true
       - name: Install libvirt
         run: |
           sudo apt-get update

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,6 +15,10 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.13.9'
+          stable: true
       - name: Download Dependencies
         run: go mod download
       - name: Build Binaries
@@ -38,6 +42,10 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.13.9'
+          stable: true
       - name: Install libvirt
         run: |
           sudo apt-get update
@@ -53,6 +61,10 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.13.9'
+          stable: true
       - name: Install libvirt
         run: |
           sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 os: linux
 language: go
 go:
-  - 1.13.8
+  - 1.13.9
 env:
   global:
     - GOPROXY=https://proxy.golang.org
@@ -11,7 +11,7 @@ matrix:
   include:
     - language: go
       name: Code Lint
-      go: 1.13.8
+      go: 1.13.9
       env:
         - TESTSUITE=lintall
       before_install:
@@ -20,7 +20,7 @@ matrix:
 
     - language: go
       name: Unit Test
-      go: 1.13.8
+      go: 1.13.9
       env:
         - TESTSUITE=unittest
       before_install:
@@ -29,7 +29,7 @@ matrix:
 
     - language: go
       name: Build
-      go: 1.13.8
+      go: 1.13.9
       script: make
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ DEB_VERSION ?= $(subst -,~,$(RAW_VERSION))
 RPM_VERSION ?= $(DEB_VERSION)
 
 # used by hack/jenkins/release_build_and_upload.sh and KVM_BUILD_IMAGE, see also BUILD_IMAGE below
-GO_VERSION ?= 1.13.8
+GO_VERSION ?= 1.13.9
 
 INSTALL_SIZE ?= $(shell du out/minikube-windows-amd64.exe | cut -f1)
 BUILDROOT_BRANCH ?= 2020.02.2
@@ -40,8 +40,9 @@ COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
 COMMIT ?= $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}")
 
 HYPERKIT_BUILD_IMAGE 	?= karalabe/xgo-1.12.x
-# NOTE: "latest" as of 2020-02-26. kube-cross images aren't updated as often as Kubernetes
-BUILD_IMAGE 	?= us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:v$(GO_VERSION)-1
+# NOTE: "latest" as of 2020-05-13. kube-cross images aren't updated as often as Kubernetes
+# https://github.com/kubernetes/kubernetes/blob/release-1.18/build/build-image/cross/VERSION
+BUILD_IMAGE 	?= us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:v$(GO_VERSION)-5
 ISO_BUILD_IMAGE ?= $(REGISTRY)/buildroot-image
 KVM_BUILD_IMAGE ?= $(REGISTRY)/kvm-build-image:$(GO_VERSION)
 

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -31,7 +31,7 @@ export KUBECONFIG="${TEST_HOME}/kubeconfig"
 export PATH=$PATH:"/usr/local/bin/:/usr/local/go/bin/:$GOPATH/bin"
 
 # installing golang so we could do go get for gopogh
-sudo ./installers/check_install_golang.sh "1.13.8" "/usr/local" || true
+sudo ./installers/check_install_golang.sh "1.13.9" "/usr/local" || true
 
 docker rm -f -v $(docker ps -aq) >/dev/null 2>&1 || true
 docker volume prune -f || true


### PR DESCRIPTION
Updated upstream in March and then again in May

```
commit cbba10741ee0fbb7f419177a4cb2955fc5103b72
Author: Stephen Augustus <saugustus@vmware.com>
Date:   Sun May 10 23:34:06 2020 -0400

    base-images: Update to kube-cross:v1.13.9-5
    
    Signed-off-by: Stephen Augustus <saugustus@vmware.com>

diff --git a/build/build-image/cross/VERSION b/build/build-image/cross/VERSION
index 83b672bbe4d..7c4f2e37647 100644
--- a/build/build-image/cross/VERSION
+++ b/build/build-image/cross/VERSION
@@ -1 +1 @@
-v1.13.9-2
+v1.13.9-5

commit 374e61893b9be5beecd25285e63bc46c0d46aa98
Author: Stephen Augustus <saugustus@vmware.com>
Date:   Thu Mar 19 20:15:24 2020 -0400

    deps: Update to Golang 1.13.9
    
    Signed-off-by: Stephen Augustus <saugustus@vmware.com>
    Co-authored-by: Jeff Grafton <jgrafton@google.com>

diff --git a/build/build-image/cross/VERSION b/build/build-image/cross/VERSION
index d1d10070e0e..83b672bbe4d 100644
--- a/build/build-image/cross/VERSION
+++ b/build/build-image/cross/VERSION
@@ -1 +1 @@
-v1.13.8-1
+v1.13.9-2
```

Apparently the GitHub actions was using latest go