### PR TITLE
Prevent start cmd from logging multiple k8s upgrade messages

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1053,7 +1053,6 @@ func validateKubernetesVersion(old *config.ClusterConfig) {
 	}
 }
 
-// getKubernetesVersion ensures that the requested version is reasonable
 func getKubernetesVersion(old *config.ClusterConfig) string {
 	paramVersion := viper.GetString(kubernetesVersion)
 

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -216,7 +216,7 @@ func ClusterFlagValue() string {
 func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k8sVersion string, drvName string) (config.ClusterConfig, config.Node, error) {
 	var cc config.ClusterConfig
 	if existing != nil { // create profile config first time
-		cc = updateExistingConfigFromFlags(cmd, existing)
+		cc = updateExistingConfigFromFlags(cmd, existing, k8sVersion)
 	} else {
 		glog.Info("no existing cluster config was found, will generate one from the flags ")
 		sysLimit, containerLimit, err := memoryLimits(drvName)
@@ -350,13 +350,13 @@ func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k
 	if driver.BareMetal(cc.Driver) {
 		kubeNodeName = "m01"
 	}
-	return createNode(cc, kubeNodeName, existing)
+	return createNode(cc, kubeNodeName, existing, k8sVersion)
 }
 
 // updateExistingConfigFromFlags will update the existing config from the flags - used on a second start
 // skipping updating existing docker env , docker opt, InsecureRegistry, registryMirror, extra-config, apiserver-ips
-func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterConfig) config.ClusterConfig { //nolint to suppress cyclomatic complexity 45 of func `updateExistingConfigFromFlags` is high (> 30)
-	validateFlags(cmd, existing.Driver)
+func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterConfig, k8sVersion string) config.ClusterConfig { //nolint to suppress cyclomatic complexity 45 of func `updateExistingConfigFromFlags` is high (> 30)
+	validateFlags(cmd, existing.Driver, k8sVersion)
 
 	cc := *existing
 
@@ -481,7 +481,7 @@ func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterC
 	}
 
 	if cmd.Flags().Changed(kubernetesVersion) {
-		cc.KubernetesConfig.KubernetesVersion = getKubernetesVersion(existing)
+		cc.KubernetesConfig.KubernetesVersion = k8sVersion
 	}
 
 	if cmd.Flags().Changed(apiServerName) {

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -216,7 +216,7 @@ func ClusterFlagValue() string {
 func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k8sVersion string, drvName string) (config.ClusterConfig, config.Node, error) {
 	var cc config.ClusterConfig
 	if existing != nil { // create profile config first time
-		cc = updateExistingConfigFromFlags(cmd, existing, k8sVersion)
+		cc = updateExistingConfigFromFlags(cmd, existing)
 	} else {
 		glog.Info("no existing cluster config was found, will generate one from the flags ")
 		sysLimit, containerLimit, err := memoryLimits(drvName)
@@ -350,13 +350,13 @@ func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k
 	if driver.BareMetal(cc.Driver) {
 		kubeNodeName = "m01"
 	}
-	return createNode(cc, kubeNodeName, existing, k8sVersion)
+	return createNode(cc, kubeNodeName, existing)
 }
 
 // updateExistingConfigFromFlags will update the existing config from the flags - used on a second start
 // skipping updating existing docker env , docker opt, InsecureRegistry, registryMirror, extra-config, apiserver-ips
-func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterConfig, k8sVersion string) config.ClusterConfig { //nolint to suppress cyclomatic complexity 45 of func `updateExistingConfigFromFlags` is high (> 30)
-	validateFlags(cmd, existing.Driver, k8sVersion)
+func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterConfig) config.ClusterConfig { //nolint to suppress cyclomatic complexity 45 of func `updateExistingConfigFromFlags` is high (> 30)
+	validateFlags(cmd, existing.Driver)
 
 	cc := *existing
 
@@ -481,7 +481,7 @@ func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterC
 	}
 
 	if cmd.Flags().Changed(kubernetesVersion) {
-		cc.KubernetesConfig.KubernetesVersion = k8sVersion
+		cc.KubernetesConfig.KubernetesVersion = getKubernetesVersion(existing)
 	}
 
 	if cmd.Flags().Changed(apiServerName) {


### PR DESCRIPTION
This fixes #8418

Currently, the `getKubernetesVersion` method is called upwards of 5 times when the `start` command is run. This leads to to the `Kubernetes 1.18.3 is now available. If you would like to upgrade, specify: --kubernetes-version=v1.18.3` message to get logged multiple times to the console.

One possible way to prevent this from happening is to remove the part of of `getKubernetesVersion` that logs the upgrade message and only have it log once in `runStart`. This would cause the fewest amount of code change.

However, another solution, which this PR uses, is to only call `getKubernetesVersion` once at the beginning of `runStart` and pass the resulting value to the functions that need it as an additional argument. This ensures that the message is only printed once and has the added benefit of slightly optimizing the speed of the `runStart` script.

Though I'm certainly open to suggestions for alternate/better implementations.

I realize there's another PR that is open for this issue (#8433), though that PR hasn't been updated in over 2 weeks. Feel free to close this PR if you don't want multiple PRs open for the same issue. 

Before: 
```bash
$ go run main.go start --kubernetes-version 1.17.4

😄  minikube v0.0.0-unset on Darwin 10.14.6
✨  Automatically selected the hyperkit driver
🆕  Kubernetes 1.18.3 is now available. If you would like to upgrade, specify: --kubernetes-version=v1.18.3
🆕  Kubernetes 1.18.3 is now available. If you would like to upgrade, specify: --kubernetes-version=v1.18.3
🆕  Kubernetes 1.18.3 is now available. If you would like to upgrade, specify: --kubernetes-version=v1.18.3
👍  Starting control plane node minikube in cluster minikube
🔥  Creating docker container (CPUs=2, Memory=1991MB) ...
🐳  Preparing Kubernetes v1.17.4 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16
🔎  Verifying Kubernetes components...
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube"
```

After:
```bash
$ go run main.go start --kubernetes-version 1.17.4

😄  minikube v0.0.0-unset on Darwin 10.14.6
✨  Automatically selected the hyperkit driver
🆕  Kubernetes 1.18.3 is now available. If you would like to upgrade, specify: --kubernetes-version=v1.18.3
👍  Starting control plane node minikube in cluster minikube
🔥  Creating docker container (CPUs=2, Memory=1991MB) ...
🐳  Preparing Kubernetes v1.17.4 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16
🔎  Verifying Kubernetes components...
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube"
```