### PR TITLE
Gracefully exit if container runtime is misspelled

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -857,8 +857,12 @@ func validateFlags(cmd *cobra.Command, drvName string) {
 	if cmd.Flags().Changed(containerRuntime) {
 		runtime := strings.ToLower(viper.GetString(containerRuntime))
 
+		validOptions := cruntime.ValidRuntimes()
+		// `crio` is accepted as an alternative spelling to `cri-o`
+		validOptions = append(validOptions, "crio")
+
 		var validRuntime bool
-		for _, option := range cruntime.ValidRuntimes() {
+		for _, option := range validOptions {
 			if runtime == option {
 				validRuntime = true
 			}

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -859,12 +859,17 @@ func validateFlags(cmd *cobra.Command, drvName string) {
 
 		validOptions := cruntime.ValidRuntimes()
 		// `crio` is accepted as an alternative spelling to `cri-o`
-		validOptions = append(validOptions, "crio")
+		validOptions = append(validOptions, constants.CRIO)
 
 		var validRuntime bool
 		for _, option := range validOptions {
 			if runtime == option {
 				validRuntime = true
+			}
+
+			// Convert `cri-o` to `crio` as the K8s config uses the `crio` spelling
+			if runtime == "cri-o" {
+				viper.Set(containerRuntime, constants.CRIO)
 			}
 		}
 

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/bootstrapper/images"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/cruntime"
 	"k8s.io/minikube/pkg/minikube/download"
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/exit"
@@ -850,6 +851,21 @@ func validateFlags(cmd *cobra.Command, drvName string) {
 		validateMemorySize()
 		if !driver.HasResourceLimits(drvName) {
 			out.WarningT("The '{{.name}}' driver does not respect the --memory flag", out.V{"name": drvName})
+		}
+	}
+
+	if cmd.Flags().Changed(containerRuntime) {
+		runtime := strings.ToLower(viper.GetString(containerRuntime))
+
+		var validRuntime bool
+		for _, option := range cruntime.ValidRuntimes() {
+			if runtime == option {
+				validRuntime = true
+			}
+		}
+
+		if !validRuntime {
+			exit.UsageT(`Invalid Container Runtime: "{{.runtime}}". Valid runtimes are: {{.validOptions}}`, out.V{"runtime": runtime, "validOptions": strings.Join(cruntime.ValidRuntimes(), ", ")})
 		}
 	}
 

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -127,7 +127,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().String(kicBaseImage, kic.BaseImage, "The base image to use for docker/podman drivers. Intended for local development.")
 	startCmd.Flags().Bool(keepContext, false, "This will keep the existing kubectl context and will create a minikube context.")
 	startCmd.Flags().Bool(embedCerts, false, "if true, will embed the certs in kubeconfig.")
-	startCmd.Flags().String(containerRuntime, "docker", fmt.Sprintf("The container runtime to be used (%s) (default: docker).", strings.Join(cruntime.ValidRuntimes(), ", ")))
+	startCmd.Flags().String(containerRuntime, "docker", fmt.Sprintf("The container runtime to be used (%s).", strings.Join(cruntime.ValidRuntimes(), ", ")))
 	startCmd.Flags().Bool(createMount, false, "This will start the mount daemon and automatically mount files into minikube.")
 	startCmd.Flags().String(mountString, constants.DefaultMountDir+":/minikube-host", "The argument to pass the minikube mount command on start.")
 	startCmd.Flags().StringArrayVar(&config.AddonList, "addons", nil, "Enable addons. see `minikube addons list` for a list of valid addon names.")

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -127,7 +127,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().String(kicBaseImage, kic.BaseImage, "The base image to use for docker/podman drivers. Intended for local development.")
 	startCmd.Flags().Bool(keepContext, false, "This will keep the existing kubectl context and will create a minikube context.")
 	startCmd.Flags().Bool(embedCerts, false, "if true, will embed the certs in kubeconfig.")
-	startCmd.Flags().String(containerRuntime, "docker", "The container runtime to be used (docker, crio, containerd).")
+	startCmd.Flags().String(containerRuntime, "docker", fmt.Sprintf("The container runtime to be used (%s) (default: docker).", strings.Join(cruntime.ValidRuntimes(), ", ")))
 	startCmd.Flags().Bool(createMount, false, "This will start the mount daemon and automatically mount files into minikube.")
 	startCmd.Flags().String(mountString, constants.DefaultMountDir+":/minikube-host", "The argument to pass the minikube mount command on start.")
 	startCmd.Flags().StringArrayVar(&config.AddonList, "addons", nil, "Enable addons. see `minikube addons list` for a list of valid addon names.")

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -281,7 +281,7 @@ func (k *Bootstrapper) applyCNI(cfg config.ClusterConfig) error {
 		return errors.Wrap(err, "cni apply")
 	}
 
-	if cfg.KubernetesConfig.ContainerRuntime == "crio" {
+	if cfg.KubernetesConfig.ContainerRuntime == constants.CRIO {
 		if err := cruntime.UpdateCRIONet(k.c, cnm.CIDR()); err != nil {
 			return errors.Wrap(err, "update crio")
 		}

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -42,6 +42,8 @@ const (
 	SSHPort = 22
 	// RegistryAddonPort os the default registry addon port
 	RegistryAddonPort = 5000
+	// CRIO is the default name and spelling for the cri-o container runtime
+	CRIO = "crio"
 
 	// APIServerName is the default API server name
 	APIServerName = "minikubeCA"

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -49,7 +49,7 @@ func (cs ContainerState) String() string {
 
 // ValidRuntimes lists the supported container runtimes
 func ValidRuntimes() []string {
-	return []string{"docker", "crio", "containerd"}
+	return []string{"docker", "cri-o", "containerd"}
 }
 
 // CommandRunner is the subset of command.Runner this package consumes

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -47,6 +47,11 @@ func (cs ContainerState) String() string {
 	return [...]string{"all", "running", "paused"}[cs]
 }
 
+// ValidRuntimes lists the supported container runtimes
+func ValidRuntimes() []string {
+	return []string{"docker", "crio", "containerd"}
+}
+
 // CommandRunner is the subset of command.Runner this package consumes
 type CommandRunner interface {
 	RunCmd(cmd *exec.Cmd) (*command.RunResult, error)

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -30,7 +30,7 @@ minikube start [flags]
       --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase:v0.0.10@sha256:f58e0c4662bac8a9b5dda7984b185bad8502ade5d9fa364bf2755d636ab51438")
       --cache-images                      If true, cache docker images for the current bootstrapper and load them into the machine. Always false with --driver=none. (default true)
       --cni string                        CNI plug-in to use. Valid options: auto, bridge, flannel, kindnet, or path to a CNI manifest (default: auto)
-      --container-runtime string          The container runtime to be used (docker, crio, containerd). (default "docker")
+      --container-runtime string          The container runtime to be used (docker, cri-o, containerd). (default "docker")
       --cpus int                          Number of CPUs allocated to Kubernetes. (default 2)
       --cri-socket string                 The cri socket path to be used.
       --delete-on-failure                 If set, delete the current cluster if start fails and try again. Defaults to false.


### PR DESCRIPTION
This fixes #7426 by creating a simple lookup for valid container runtimes `(docker crio containerd)` and adding it in the `validateFlags` check.

Before:
```bash
$ ./out/minikube-darwin-amd64 start --driver=docker --container-runtime=conatinerd                                                                                                                 
😄  minikube v1.12.0-beta.0 on Darwin 10.14.6
✨  Using the docker driver based on existing profile
🆕  Kubernetes 1.18.3 is now available. If you would like to upgrade, specify: --kubernetes-version=v1.18.3

💣  error provisioning host: Failed to generate config: new runtime manager: unknown runtime type: "conatinerd"

😿  minikube is exiting due to an error. If the above message is not useful, open an issue:
👉  https://github.com/kubernetes/minikube/issues/new/choose
```

After:
```bash
$ ./out/minikube-darwin-amd64 start --driver=docker --container-runtime=conatinerd                                                         
😄  minikube v1.12.0-beta.0 on Darwin 10.14.6
✨  Using the docker driver based on existing profile
💡  Invalid Container Runtime: "conatinerd". Valid runtimes are: docker, crio, containerd
```
