### PR TITLE
skip cni test for none driver

### DIFF
--- a/test/integration/net_test.go
+++ b/test/integration/net_test.go
@@ -34,6 +34,9 @@ import (
 
 func TestNetworkPlugins(t *testing.T) {
 	MaybeParallel(t)
+	if NoneDriver() {
+		t.Skip("skipping since test for none driver")
+	}
 
 	t.Run("group", func(t *testing.T) {
 		tests := []struct {


### PR DESCRIPTION
as explaied in this issue https://github.com/kubernetes/minikube/issues/8601
the CNI pr added tests that times out on none driver. skipping till @tstromberg figures out which one of the CNI tests could be run on none