### PR TITLE
Update ebpf documentation

### DIFF
--- a/site/content/en/docs/tutorials/ebpf_tools_in_minikube.md
+++ b/site/content/en/docs/tutorials/ebpf_tools_in_minikube.md
@@ -22,40 +22,50 @@ This tutorial will cover how to set up your minikube cluster so that you can run
 First, start minikube:
 
 ```
-$ minikube start --iso-url https://storage.googleapis.com/minikube-performance/minikube.iso
-```
-
-You will need to download and extract necessary kernel headers within minikube:
-
-```shell
-minikube ssh -- curl -Lo /tmp/kernel-headers-linux-4.19.94.tar.lz4 https://storage.googleapis.com/minikube-kernel-headers/kernel-headers-linux-4.19.94.tar.lz4 
-
-minikube ssh -- sudo mkdir -p /lib/modules/4.19.94/build
-
-minikube ssh -- sudo tar -I lz4 -C /lib/modules/4.19.94/build -xvf /tmp/kernel-headers-linux-4.19.94.tar.lz4
-
-minikube ssh -- rm /tmp/kernel-headers-linux-4.19.94.tar.lz4
+# FIXME: what is the new URL for minikube.iso that includes https://github.com/kubernetes/minikube/pull/8582?
+$ ./out/minikube start --iso-url file://$(pwd)/out/minikube.iso --driver=kvm2
 ```
 
 You can now run [BCC tools](https://github.com/iovisor/bcc) as a Docker container in minikube:
 
 ```shell
-$ minikube ssh -- docker run --rm   --privileged   -v /lib/modules:/lib/modules:ro   -v /usr/src:/usr/src:ro   -v /etc/localtime:/etc/localtime:ro   --workdir /usr/share/bcc/tools   zlim/bcc ./execsnoop
-
-
-Unable to find image 'zlim/bcc:latest' locally
-latest: Pulling from zlim/bcc
-6cf436f81810: Pull complete 
-987088a85b96: Pull complete 
-b4624b3efe06: Pull complete 
-d42beb8ded59: Pull complete 
-90970d1ebfd9: Pull complete 
-29c3815350eb: Pull complete 
-e21dfbd8fcfc: Pull complete 
-Digest: sha256:914bea8970535cd6b0d5dee13f99569c5f0d597942c8333c0aa92443473aff27
-Status: Downloaded newer image for zlim/bcc:latest
+$ minikube ssh -- docker run --rm --privileged -ti --workdir /usr/share/bcc/tools kinvolk/bcc ./execsnoop
+Unable to find image 'kinvolk/bcc:latest' locally
+latest: Pulling from kinvolk/bcc
+23884877105a: Pull complete 
+bc38caa0f5b9: Pull complete 
+2910811b6c42: Pull complete 
+36505266dcc6: Pull complete 
+7cce3becaab1: Pull complete 
+900cb26d625f: Pull complete 
+Digest: sha256:f49695286ac5e896e98d9e9165e062e62212b6e2fa0195f577aa2409eb40a6cd
+Status: Downloaded newer image for kinvolk/bcc:latest
 PCOMM            PID    PPID   RET ARGS
-runc             5059   2011     0 /usr/bin/runc --version
-docker-init      5065   2011     0 /usr/bin/docker-init --version
-nice             5066   4012     0 /usr/bin/nice -n 19 du -x -s -B 1 /var/lib/kubelet/pods/1cf22976-f3e0-498b-bc04-8c7068e6e545/volumes/kubernetes.io~secret/storage-provisioner-token-cvk4x
+runc             3321   869      0 /usr/bin/runc --version
+docker-init      3327   869      0 /usr/bin/docker-init --version
+^C
+```
+
+You can also run [Inspektor Gadget](https://github.com/kinvolk/inspektor-gadget) in minikube:
+
+```shell
+$ kubectl krew install gadget
+$ kubectl gadget deploy | kubectl apply -f -
+```
+
+When the gadget deployment is ready, you can run the execsnoop gadget in two terminals:
+
+```shell
+$ kubectl gadget execsnoop -n default -l run=shell
+Node numbers: 0 = minikube
+NODE PCOMM            PID    PPID   RET ARGS
+[ 0] date             4799   4783     0 /bin/date
+[ 0] sleep            4800   4783     0 /bin/sleep 1
+[ 0] date             4801   4783     0 /bin/date
+[ 0] sleep            4802   4783     0 /bin/sleep 1
+^C
+```
+
+```shell
+$ kubectl run --image=busybox shell -- sh -c 'while sleep 1 ; do date ; done'
 ```


### PR DESCRIPTION
Following https://github.com/kubernetes/minikube/pull/8582, the documentation about ebpf tools should be updated:
https://minikube.sigs.k8s.io/docs/tutorials/ebpf_tools_in_minikube/

I am also adding an example with [Inspektor Gadget](https://github.com/kinvolk/inspektor-gadget).

TODO:
- [ ] Get the proper URL for minikube.iso. According to @afbjorklund, there is some CI issues to generate a new one.
- [ ] We need a new release of Inspektor Gadget first, and the doc should say which version is required.
- [ ] Specify which release of minikube is required for this?

/cc @mauriciovasquezbernal @marga-kinvolk 