### PR TITLE
Disable containerd from starting up at boot

### DIFF
--- a/deploy/iso/minikube-iso/package/containerd-bin/50-minikube.preset
+++ b/deploy/iso/minikube-iso/package/containerd-bin/50-minikube.preset
@@ -1,0 +1,1 @@
+disable containerd.service

--- a/deploy/iso/minikube-iso/package/containerd-bin/containerd-bin.mk
+++ b/deploy/iso/minikube-iso/package/containerd-bin/containerd-bin.mk
@@ -48,11 +48,12 @@ define CONTAINERD_BIN_INSTALL_TARGET_CMDS
 endef
 
 define CONTAINERD_BIN_INSTALL_INIT_SYSTEMD
-	$(INSTALL) -Dm755 \
+	$(INSTALL) -Dm644 \
 		$(CONTAINERD_BIN_PKGDIR)/containerd.service \
 		$(TARGET_DIR)/usr/lib/systemd/system/containerd.service
-	$(call link-service,containerd.service)
-	$(call link-service,containerd-shutdown.service)
+	$(INSTALL) -Dm644 \
+		$(CONTAINERD_BIN_PKGDIR)/50-minikube.preset \
+		$(TARGET_DIR)/usr/lib/systemd/system-preset/50-minikube.preset
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
Saves us having to restart docker later on (see f2ea21ab23aa49c5e924c5c340a1a6cf5108dd14)

Tested with docker and with containerd runtimes

With the currently generated `minikube.service`, the default is to run with `/run/docker/containerd/containerd.sock`

It is only when containerd is explicitly selected (and **not** docker), that we want to use `/run/containerd/containerd.sock`

Note that it will just disable the containerd.service

There will still be a containerd process running...