### PR TITLE
make docker driver highly preferred

### DIFF
--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -37,21 +37,12 @@ import (
 var docURL = "https://minikube.sigs.k8s.io/docs/drivers/docker/"
 
 func init() {
-	priority := registry.Default
-	// Staged rollout for preferred:
-	// - Linux
-	// - Windows (once "service" command works)
-	// - macOS
-	if runtime.GOOS == "linux" {
-		priority = registry.Preferred
-	}
-
 	if err := registry.Register(registry.DriverDef{
 		Name:     driver.Docker,
 		Config:   configure,
 		Init:     func() drivers.Driver { return kic.NewDriver(kic.Config{OCIBinary: oci.Docker}) },
 		Status:   status,
-		Priority: priority,
+		Priority: registry.HighlyPreferred,
 	}); err != nil {
 		panic(fmt.Sprintf("register failed: %v", err))
 	}

--- a/pkg/minikube/registry/registry.go
+++ b/pkg/minikube/registry/registry.go
@@ -45,6 +45,8 @@ const (
 	Default
 	// Preferred is for drivers that use a native hypervisor interface
 	Preferred
+	// HighlyPreferred is the ultimate driver preferences
+	HighlyPreferred
 )
 
 // Registry contains all the supported driver definitions on the host


### PR DESCRIPTION
# after this PR 

on mac 

```
medya@~/workspace/minikube (docker_prefered) $ make && ./out/minikube start
make: `out/minikube' is up to date.
😄  minikube v1.12.0-beta.0 on Darwin 10.15.5
✨  Automatically selected the docker driver
👍  Starting control plane node minikube in cluster minikube
💾  Downloading Kubernetes v1.18.3 preload ...
    > preloaded-images-k8s-v4-v1.18.3-docker-overlay2-amd64.tar.lz4: 526.27 MiB
🔥  Creating docker container (CPUs=2, Memory=4000MB) ...
🐳  Preparing Kubernetes v1.18.3 on Docker 19.03.2 ...
🔎  Verifying Kubernetes components...
🌟  Enabled addons: default-storageclass, storage-provisi
```