### PR TITLE
Stop creating .minikube directory when the base of MINIKUBE_HOME is minikube

### DIFF
--- a/pkg/minikube/localpath/localpath.go
+++ b/pkg/minikube/localpath/localpath.go
@@ -42,7 +42,8 @@ func MiniPath() string {
 	if minikubeHomeEnv == "" {
 		return filepath.Join(homedir.HomeDir(), ".minikube")
 	}
-	if filepath.Base(minikubeHomeEnv) == ".minikube" {
+	switch filepath.Base(minikubeHomeEnv) {
+	case ".minikube", "minikube":
 		return minikubeHomeEnv
 	}
 	return filepath.Join(minikubeHomeEnv, ".minikube")

--- a/pkg/minikube/localpath/localpath_test.go
+++ b/pkg/minikube/localpath/localpath_test.go
@@ -74,11 +74,12 @@ func TestHasWindowsDriveLetter(t *testing.T) {
 
 func TestMiniPath(t *testing.T) {
 	var testCases = []struct {
-		env, basePath string
+		env, expected string
 	}{
-		{"/tmp/.minikube", "/tmp/"},
-		{"/tmp/", "/tmp"},
-		{"", homedir.HomeDir()},
+		{"/tmp/.minikube", "/tmp/.minikube"},
+		{"/tmp/minikube", "/tmp/minikube"},
+		{"/tmp/", "/tmp/.minikube"},
+		{"", filepath.Join(homedir.HomeDir(), ".minikube")},
 	}
 	originalEnv := os.Getenv(MinikubeHome)
 	defer func() { // revert to pre-test env var
@@ -89,11 +90,10 @@ func TestMiniPath(t *testing.T) {
 	}()
 	for _, tc := range testCases {
 		t.Run(tc.env, func(t *testing.T) {
-			expectedPath := filepath.Join(tc.basePath, ".minikube")
 			os.Setenv(MinikubeHome, tc.env)
 			path := MiniPath()
-			if path != expectedPath {
-				t.Errorf("MiniPath expected to return '%s', but got '%s'", expectedPath, path)
+			if path != tc.expected {
+				t.Errorf("MiniPath expected to return '%s', but got '%s'", tc.expected, path)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

## Problem
When the user configures as `export MINIKUBE_HOME=~/.local/share/minikube`, minikube creates `~/.local/share/minikube/.minikube` directory. This is not what the user would expect, minikube uses the directory they specify by `MINIKUBE_HOME`

## Solution
When the base of `MINIKUBE_HOME` is equal to `minikube`, use it for the root directory.

## Comparison to other tools
`GEM_HOME`, `CARGO_HOME`, `GRADLE_USER_HOME` are considered as the root directory for storing their data, defaults to `$HOME/.gem`, `$HOME/.cargo`, `$HOME/.gradle`. So I think `MINIKUBE_HOME` should be considered as the value which defaults to `~/.minikube`, not the env for configuring `$HOME`. But considering the compatibility, this pr suggests with minimal impact.

Ref: #1104