### PR TITLE
Add Infof function to out package

### DIFF
--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -151,14 +151,14 @@ var mountCmd = &cobra.Command{
 			bindIP = "127.0.0.1"
 		}
 		out.T(out.Mounting, "Mounting host path {{.sourcePath}} into VM as {{.destinationPath}} ...", out.V{"sourcePath": hostPath, "destinationPath": vmPath})
-		out.T(out.Option, "Mount type:   {{.name}}", out.V{"type": cfg.Type})
-		out.T(out.Option, "User ID:      {{.userID}}", out.V{"userID": cfg.UID})
-		out.T(out.Option, "Group ID:     {{.groupID}}", out.V{"groupID": cfg.GID})
-		out.T(out.Option, "Version:      {{.version}}", out.V{"version": cfg.Version})
-		out.T(out.Option, "Message Size: {{.size}}", out.V{"size": cfg.MSize})
-		out.T(out.Option, "Permissions:  {{.octalMode}} ({{.writtenMode}})", out.V{"octalMode": fmt.Sprintf("%o", cfg.Mode), "writtenMode": cfg.Mode})
-		out.T(out.Option, "Options:      {{.options}}", out.V{"options": cfg.Options})
-		out.T(out.Option, "Bind Address: {{.Address}}", out.V{"Address": net.JoinHostPort(bindIP, fmt.Sprint(port))})
+		out.Infof("Mount type:   {{.name}}", out.V{"type": cfg.Type})
+		out.Infof("User ID:      {{.userID}}", out.V{"userID": cfg.UID})
+		out.Infof("Group ID:     {{.groupID}}", out.V{"groupID": cfg.GID})
+		out.Infof("Version:      {{.version}}", out.V{"version": cfg.Version})
+		out.Infof("Message Size: {{.size}}", out.V{"size": cfg.MSize})
+		out.Infof("Permissions:  {{.octalMode}} ({{.writtenMode}})", out.V{"octalMode": fmt.Sprintf("%o", cfg.Mode), "writtenMode": cfg.Mode})
+		out.Infof("Options:      {{.options}}", out.V{"options": cfg.Options})
+		out.Infof("Bind Address: {{.Address}}", out.V{"Address": net.JoinHostPort(bindIP, fmt.Sprint(port))})
 
 		var wg sync.WaitGroup
 		if cfg.Type == nineP {

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -357,7 +357,7 @@ func displayEnviron(env []string) {
 		k := bits[0]
 		v := bits[1]
 		if strings.HasPrefix(k, "MINIKUBE_") || k == constants.KubeconfigEnvVar {
-			out.T(out.Option, "{{.key}}={{.value}}", out.V{"key": k, "value": v})
+			out.Infof("{{.key}}={{.value}}", out.V{"key": k, "value": v})
 		}
 	}
 }
@@ -519,7 +519,7 @@ func selectDriver(existing *config.ClusterConfig) (registry.DriverState, []regis
 	if pick.Name == "" {
 		out.T(out.ThumbsDown, "Unable to pick a default driver. Here is what was considered, in preference order:")
 		for _, r := range rejects {
-			out.T(out.Option, "{{ .name }}: {{ .rejection }}", out.V{"name": r.Name, "rejection": r.Rejection})
+			out.Infof("{{ .name }}: {{ .rejection }}", out.V{"name": r.Name, "rejection": r.Rejection})
 		}
 		out.T(out.Workaround, "Try specifying a --driver, or see https://minikube.sigs.k8s.io/docs/start/")
 		os.Exit(exit.Unavailable)

--- a/pkg/minikube/node/config.go
+++ b/pkg/minikube/node/config.go
@@ -39,10 +39,10 @@ func showVersionInfo(k8sVersion string, cr cruntime.Manager) {
 	version, _ := cr.Version()
 	out.T(cr.Style(), "Preparing Kubernetes {{.k8sVersion}} on {{.runtime}} {{.runtimeVersion}} ...", out.V{"k8sVersion": k8sVersion, "runtime": cr.Name(), "runtimeVersion": version})
 	for _, v := range config.DockerOpt {
-		out.T(out.Option, "opt {{.docker_option}}", out.V{"docker_option": v})
+		out.Infof("opt {{.docker_option}}", out.V{"docker_option": v})
 	}
 	for _, v := range config.DockerEnv {
-		out.T(out.Option, "env {{.docker_env}}", out.V{"docker_env": v})
+		out.Infof("env {{.docker_env}}", out.V{"docker_env": v})
 	}
 }
 

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -288,7 +288,7 @@ func setupKubeAdm(mAPI libmachine.API, cfg config.ClusterConfig, n config.Node, 
 		exit.WithError("Failed to get bootstrapper", err)
 	}
 	for _, eo := range config.ExtraOptions {
-		out.T(out.Option, "{{.extra_option_component_name}}.{{.key}}={{.value}}", out.V{"extra_option_component_name": eo.Component, "key": eo.Key, "value": eo.Value})
+		out.Infof("{{.extra_option_component_name}}.{{.key}}={{.value}}", out.V{"extra_option_component_name": eo.Component, "key": eo.Key, "value": eo.Value})
 	}
 	// Loads cached images, generates config files, download binaries
 	// update cluster and set up certs
@@ -423,7 +423,7 @@ func validateNetwork(h *host.Host, r command.Runner, imageRepository string) (st
 				out.T(out.Internet, "Found network options:")
 				optSeen = true
 			}
-			out.T(out.Option, "{{.key}}={{.value}}", out.V{"key": k, "value": v})
+			out.Infof("{{.key}}={{.value}}", out.V{"key": k, "value": v})
 			ipExcluded := proxy.IsIPExcluded(ip) // Skip warning if minikube ip is already in NO_PROXY
 			k = strings.ToUpper(k)               // for http_proxy & https_proxy
 			if (k == "HTTP_PROXY" || k == "HTTPS_PROXY") && !ipExcluded && !warnedOnce {

--- a/pkg/minikube/out/out.go
+++ b/pkg/minikube/out/out.go
@@ -66,7 +66,16 @@ type V map[string]interface{}
 
 // T writes a stylized and templated message to stdout
 func T(style StyleEnum, format string, a ...V) {
+	if style == Option {
+		Infof(format, a...)
+	}
 	outStyled := ApplyTemplateFormatting(style, useColor, format, a...)
+	String(outStyled)
+}
+
+// Infof is used for informational logs (options, env variables, etc)
+func Infof(format string, a ...V) {
+	outStyled := ApplyTemplateFormatting(Option, useColor, format, a...)
 	String(outStyled)
 }
 

--- a/pkg/minikube/out/out.go
+++ b/pkg/minikube/out/out.go
@@ -68,6 +68,7 @@ type V map[string]interface{}
 func T(style StyleEnum, format string, a ...V) {
 	if style == Option {
 		Infof(format, a...)
+		return
 	}
 	outStyled := ApplyTemplateFormatting(style, useColor, format, a...)
 	String(outStyled)

--- a/pkg/minikube/out/out_test.go
+++ b/pkg/minikube/out/out_test.go
@@ -114,7 +114,3 @@ func TestErr(t *testing.T) {
 		t.Errorf("Err() = %q, want %q", got, want)
 	}
 }
-
-func TestInfof(t *testing.T) {
-
-}

--- a/pkg/minikube/out/out_test.go
+++ b/pkg/minikube/out/out_test.go
@@ -114,3 +114,7 @@ func TestErr(t *testing.T) {
 		t.Errorf("Err() = %q, want %q", got, want)
 	}
 }
+
+func TestInfof(t *testing.T) {
+
+}


### PR DESCRIPTION
This is a refactor for the work around minikube start JSON output #8655 

One of the types of logs we will output in JSON is an `Info` type, which covers things like options, env variables, and other informational logs during `minikube start`

Separating these into its own function will make it easier to identify the informational type and print in JSON in future PRs