### PR TITLE
none CNI: error if portmap plug-in is required but unavailable

### DIFF
--- a/pkg/minikube/cni/flannel.go
+++ b/pkg/minikube/cni/flannel.go
@@ -17,6 +17,9 @@ limitations under the License.
 package cni
 
 import (
+	"os/exec"
+
+	"github.com/pkg/errors"
 	"k8s.io/minikube/pkg/minikube/config"
 )
 
@@ -637,6 +640,12 @@ func (c Flannel) String() string {
 
 // Apply enables the CNI
 func (c Flannel) Apply(r Runner) error {
+	// Mostly applicable to the 'none' driver
+	_, err := r.RunCmd(exec.Command("stat", "/opt/cni/bin/portmap"))
+	if err != nil {
+		return errors.Wrap(err, "required 'portmap' CNI plug-in not found")
+	}
+
 	return applyManifest(c.cc, r, manifestAsset([]byte(flannelTmpl)))
 }
 

--- a/pkg/minikube/cni/kindnet.go
+++ b/pkg/minikube/cni/kindnet.go
@@ -18,6 +18,7 @@ package cni
 
 import (
 	"bytes"
+	"os/exec"
 	"text/template"
 
 	"github.com/pkg/errors"
@@ -168,6 +169,12 @@ func (c KindNet) manifest() (assets.CopyableFile, error) {
 
 // Apply enables the CNI
 func (c KindNet) Apply(r Runner) error {
+	// This is mostly applicable to the 'none' driver
+	_, err := r.RunCmd(exec.Command("stat", "/opt/cni/bin/portmap"))
+	if err != nil {
+		return errors.Wrap(err, "required 'portmap' CNI plug-in not found")
+	}
+
 	m, err := c.manifest()
 	if err != nil {
 		return errors.Wrap(err, "manifest")

--- a/test/integration/net_test.go
+++ b/test/integration/net_test.go
@@ -90,7 +90,16 @@ func TestNetworkPlugins(t *testing.T) {
 				}
 				if !t.Failed() {
 					t.Run("KubeletFlags", func(t *testing.T) {
-						rr, err := Run(t, exec.CommandContext(ctx, Target(), "ssh", "-p", profile, "pgrep -a kubelet"))
+						var rr *RunResult
+						var err error
+
+						// none does not support 'minikube ssh'
+						if NoneDriver() {
+							rr, err = Run(t, exec.CommandContext(ctx, "pgrep", "-a", "kubelet"))
+						} else {
+							rr, err = Run(t, exec.CommandContext(ctx, Target(), "ssh", "-p", profile, "pgrep -a kubelet"))
+						}
+
 						if err != nil {
 							t.Fatalf("ssh failed: %v", err)
 						}


### PR DESCRIPTION
`flannel` and `kindnet` both require that the `portmap` CNI plug-in to be installed.

Our VM and Docker image includes it, but it's presence cannot be assumed for the `none` driver, resulting in a very confusing error message. This makes PR makes the omission very apparent. 

It also fixes an integration test assumption that did not work for `none`, but does not endeavor to enable CNI tests for `none` yet.

