### PR TITLE
Update kube-webhook-certgen image 1.2.0->1.2.2

### DIFF
--- a/deploy/addons/ingress/ingress-dp.yaml.tmpl
+++ b/deploy/addons/ingress/ingress-dp.yaml.tmpl
@@ -212,7 +212,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: jettech/kube-webhook-certgen:v1.2.0
+          image: jettech/kube-webhook-certgen:v1.2.2
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -247,7 +247,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: jettech/kube-webhook-certgen:v1.2.0
+          image: jettech/kube-webhook-certgen:v1.2.2
           imagePullPolicy:
           args:
             - patch


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/minikube/issues/8636

First contribution, there may be additional changes required that I'm unaware of.