### PR TITLE
add timeout for kubeadm init

### DIFF
--- a/pkg/drivers/hyperkit/network_test.go
+++ b/pkg/drivers/hyperkit/network_test.go
@@ -20,7 +20,6 @@ package hyperkit
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 

--- a/pkg/minikube/bootstrapper/kubeadm/errors.go
+++ b/pkg/minikube/bootstrapper/kubeadm/errors.go
@@ -23,7 +23,7 @@ import (
 
 // max minutes wait for kubeadm init. usually finishes in less than 1 minute.
 // giving it a generous timeout for possible super slow machines.
-const initTimeOutMinutes = 10
+const initTimeoutMinutes = 10
 
 // max seconds to wait for running kubectl apply manifests to the cluster to exit
 const applyTimeoutSeconds = 10
@@ -42,4 +42,4 @@ func (f *FailFastError) Error() string {
 var ErrNoExecLinux = &FailFastError{errors.New("mounted kubeadm binary is not executable")}
 
 // ErrInitTimedout is thrown if kubeadm init takes longer than max time allowed
-var ErrInitTimedout = fmt.Errorf("kubeadm init timed out in %d minutes", initTimeOutMinutes)
+var ErrInitTimedout = fmt.Errorf("kubeadm init timed out in %d minutes", initTimeoutMinutes)

--- a/pkg/minikube/bootstrapper/kubeadm/errors.go
+++ b/pkg/minikube/bootstrapper/kubeadm/errors.go
@@ -25,7 +25,7 @@ import (
 // giving it a generous timeout for possible super slow machines.
 const initTimeOutMinutes = 10
 
-// max seconds to wait for running kbuectl apply manfiests to the cluster to exit
+// max seconds to wait for running kubectl apply manifests to the cluster to exit
 const applyTimeoutSeconds = 10
 
 // FailFastError type is an error that could not be solved by trying again

--- a/pkg/minikube/bootstrapper/kubeadm/errors.go
+++ b/pkg/minikube/bootstrapper/kubeadm/errors.go
@@ -23,7 +23,7 @@ import (
 
 // max minutes wait for kubeadm init. usually finishes in less than 1 minute.
 // giving it a generous timeout for possible super slow machines.
-const initTimeOutMinutes = 13
+const initTimeOutMinutes = 10
 
 // FailFastError type is an error that could not be solved by trying again
 type FailFastError struct {

--- a/pkg/minikube/bootstrapper/kubeadm/errors.go
+++ b/pkg/minikube/bootstrapper/kubeadm/errors.go
@@ -21,8 +21,9 @@ import (
 	"fmt"
 )
 
-// max minutes wait for kubeadm init
-const initTimeOutMinutes = 1
+// max minutes wait for kubeadm init. usually finishes in less than 1 minute.
+// giving it a generous timeout for possible super slow machines.
+const initTimeOutMinutes = 13
 
 // FailFastError type is an error that could not be solved by trying again
 type FailFastError struct {

--- a/pkg/minikube/bootstrapper/kubeadm/errors.go
+++ b/pkg/minikube/bootstrapper/kubeadm/errors.go
@@ -16,7 +16,13 @@ limitations under the License.
 
 package kubeadm
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
+
+// max minutes wait for kubeadm init
+const initTimeOutMinutes = 1
 
 // FailFastError type is an error that could not be solved by trying again
 type FailFastError struct {
@@ -30,3 +36,6 @@ func (f *FailFastError) Error() string {
 // ErrNoExecLinux is thrown on linux when the kubeadm binaries are mounted in a noexec volume on Linux as seen in https://github.com/kubernetes/minikube/issues/8327#issuecomment-651288459
 // this error could be seen on docker/podman or none driver.
 var ErrNoExecLinux = &FailFastError{errors.New("mounted kubeadm binary is not executable")}
+
+// ErrInitTimedout is thrown if kubeadm init takes longer than max time allowed
+var ErrInitTimedout = fmt.Errorf("kubeadm init timed out in %d minutes", initTimeOutMinutes)

--- a/pkg/minikube/bootstrapper/kubeadm/errors.go
+++ b/pkg/minikube/bootstrapper/kubeadm/errors.go
@@ -25,6 +25,9 @@ import (
 // giving it a generous timeout for possible super slow machines.
 const initTimeOutMinutes = 10
 
+// max seconds to wait for running kbuectl apply manfiests to the cluster to exit
+const applyTimeoutSeconds = 10
+
 // FailFastError type is an error that could not be solved by trying again
 type FailFastError struct {
 	Err error

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -224,7 +224,7 @@ func (k *Bootstrapper) init(cfg config.ClusterConfig) error {
 	}
 
 	conf := bsutil.KubeadmYamlPath
-	ctx, cancel := context.WithTimeout(context.Background(), initTimeOutMinutes*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), initTimeoutMinutes*time.Minute)
 	defer cancel()
 	c := exec.CommandContext(ctx, "/bin/bash", "-c", fmt.Sprintf("%s init --config %s %s --ignore-preflight-errors=%s",
 		bsutil.InvokeKubeadm(cfg.KubernetesConfig.KubernetesVersion), conf, extraFlags, strings.Join(ignore, ",")))

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -224,7 +224,7 @@ func (k *Bootstrapper) init(cfg config.ClusterConfig) error {
 	}
 
 	conf := bsutil.KubeadmYamlPath
-	ctx, cancel := context.WithTimeout(context.Background(), initTimeOutMinutes*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), initTimeOutMinutes*time.Minute)
 	defer cancel()
 	c := exec.CommandContext(ctx, "/bin/bash", "-c", fmt.Sprintf("%s init --config %s %s --ignore-preflight-errors=%s",
 		bsutil.InvokeKubeadm(cfg.KubernetesConfig.KubernetesVersion), conf, extraFlags, strings.Join(ignore, ",")))

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -844,7 +844,7 @@ func (k *Bootstrapper) applyNodeLabels(cfg config.ClusterConfig) error {
 
 	if _, err := k.c.RunCmd(cmd); err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
-			return errors.Wrapf(err, "timeout apply node labels")
+			return errors.Wrapf(err, "timeout apply labels")
 		}
 		return errors.Wrapf(err, "applying node labels")
 	}

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -843,6 +843,9 @@ func (k *Bootstrapper) applyNodeLabels(cfg config.ClusterConfig) error {
 		fmt.Sprintf("--kubeconfig=%s", path.Join(vmpath.GuestPersistentDir, "kubeconfig")))
 
 	if _, err := k.c.RunCmd(cmd); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return errors.Wrapf(err, "timeout apply node labels")
+		}
 		return errors.Wrapf(err, "applying node labels")
 	}
 	return nil

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -833,8 +833,7 @@ func (k *Bootstrapper) applyNodeLabels(cfg config.ClusterConfig) error {
 	commitLbl := "minikube.k8s.io/commit=" + version.GetGitCommitID()
 	nameLbl := "minikube.k8s.io/name=" + cfg.Name
 
-	// Allow no more than 5 seconds for applying labels
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), applyTimeoutSeconds*time.Second)
 	defer cancel()
 	// example:
 	// sudo /var/lib/minikube/binaries/<version>/kubectl label nodes minikube.k8s.io/version=<version> minikube.k8s.io/commit=aa91f39ffbcf27dcbb93c4ff3f457c54e585cf4a-dirty minikube.k8s.io/name=p1 minikube.k8s.io/updated_at=2020_02_20T12_05_35_0700 --all --overwrite --kubeconfig=/var/lib/minikube/kubeconfig


### PR DESCRIPTION
### before this PR when there is a kubedm stuck issue (artifically made error)

```
😄  minikube v1.12.0 on Darwin 10.15.5
✨  Using the docker driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🔥  Creating docker container (CPUs=2, Memory=4000MB) ...
🐳  Preparing Kubernetes v1.18.3 on Docker 19.03.2 ...
    ▪ etcd.client-cert-auth=false
..
.. (stuck forever no exit till ctrl+c)

```


###After this PR

```
😄  minikube v1.12.0 on Darwin 10.15.5
✨  Using the docker driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🔥  Creating docker container (CPUs=2, Memory=4000MB) ...
🐳  Preparing Kubernetes v1.18.3 on Docker 19.03.2 ...
    ▪ etcd.client-cert-auth=false
💥  initialization failed, will try again: kubeadm init timed out in 10 minutes

💣  Error starting cluster: kubeadm init timed out in 10 minutes

😿  minikube is exiting due to an error. If the above message is not useful, open an issue:
👉  https://github.com/kubernetes/minikube/issues/new/choose
❌  Problems detected in kubelet:
    Jul 10 19:46:36 minikube kubelet[2090]: E0710 19:46:36.920108    2090 reflector.go:178] object-"kube-system"/"kube-proxy-token-2vhs7": Failed to list *v1.Secret: secrets "kube-proxy-token-2vhs7" is forbidden: User "system:node:minikube" cannot list resource "secrets" in API group "" in the namespace "kube-system": no relationship found between node "minikube" and this object

💣  failed to start node: startup failed: kubeadm init timed out in 10 minutes

😿  minikube is exiting due to an error. If the above message is not useful, open an issue:
👉  https://github.com/kubernetes/minikube/issues/new/choose
```

closes https://github.com/kubernetes/minikube/issues/8693