### PR TITLE
docker/podman: warn if allocated memory is below limit

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -99,7 +99,7 @@ jobs:
           echo "--------------------------"
           docker version || true
           echo "--------------------------"
-          docker info --format", "{{json .}} || true
+          docker info --format='{{json .}}' || true
           echo "--------------------------"
           docker system df || true
           echo "--------------------------"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -103,7 +103,7 @@ jobs:
           echo "--------------------------"
           docker system df || true
           echo "--------------------------"
-          docker system info || true
+          docker system info --format='{{json .}}'|| true
           echo "--------------------------"
           docker ps || true
           echo "--------------------------"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -99,7 +99,7 @@ jobs:
           echo "--------------------------"
           docker version || true
           echo "--------------------------"
-          docker info || true
+          docker info --format", "{{json .}} || true
           echo "--------------------------"
           docker system df || true
           echo "--------------------------"

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -70,7 +70,6 @@ var (
 	insecureRegistry []string
 	apiServerNames   []string
 	apiServerIPs     []net.IP
-	kicSysInfo       *oci.SysInfo
 )
 
 func init() {
@@ -753,7 +752,7 @@ func memoryLimits(drvName string) (int, int, error) {
 	containerLimit := 0
 
 	if driver.IsKIC(drvName) {
-		s, err := cachedKicSystemInfo(drvName)
+		s, err := oci.CachedDaemonInfo(drvName)
 		if err != nil {
 			return -1, -1, err
 		}
@@ -854,7 +853,7 @@ func validateCPUCount(drvName string) {
 	}
 
 	if driver.IsKIC((drvName)) {
-		si, err := cachedKicSystemInfo(drvName)
+		si, err := oci.CachedDaemonInfo(drvName)
 		if err != nil {
 			out.WarningT("Failed to verify '{{.driver_name}} info', ensure your {{.driver_name}} is running healthy.", out.V{"driver_namee": drvName})
 		}
@@ -1143,15 +1142,4 @@ func getKubernetesVersion(old *config.ClusterConfig) string {
 	}
 
 	return version.VersionPrefix + nvs.String()
-}
-
-// cachedKicSystemInfo will return docker/podman info. it will call docker/podam info only once per minikube start to avoid perforamce side effects
-func cachedKicSystemInfo(ociBin string) (oci.SysInfo, error) {
-	var err error
-	if kicSysInfo == nil {
-		si, err := oci.DaemonInfo(ociBin)
-		kicSysInfo = &si
-		return *kicSysInfo, err
-	}
-	return *kicSysInfo, err
 }

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -763,9 +763,9 @@ func memoryLimits(drvName string) (int, int, error) {
 	return sysLimit, containerLimit, nil
 }
 
-func myabeAdviceDockerResources(containerLimit int, sysLimit int, CPUs int, drvName string) {
+func myabeAdviceDockerResources(containerLimit int, sysLimit int, cpus int, drvName string) {
 	if drvName == oci.Docker && runtime.GOOS != "linux" {
-		if containerLimit < 2492 {
+		if containerLimit < 1991 {
 			out.T(out.Conflict, `Your Docker Desktop has only {{.container_limit}} memory. Increase memory to at least 2.5 GB or more:
 
 	Docker Icon > Settings > Resources > Memory
@@ -779,12 +779,15 @@ func myabeAdviceDockerResources(containerLimit int, sysLimit int, CPUs int, drvN
 
 `, out.V{"container_limit": containerLimit, "system_limit": sysLimit})
 		}
-		if CPUs < 2 {
-			out.T(out.Conflict, `Your Docker Desktop has less than 2 CPUs. Increase CPUs for Docker Desktop:
+		if cpus < 2 {
+			out.T(out.Conflict, `Your Docker Desktop has less than 2 CPUs. Increase CPUs for Docker Desktop. 
 
 	Docker icon > Settings > Resources > CPUs
 
 `, out.V{"container_limit": containerLimit})
+			out.T(out.Documentation, "https://docs.docker.com/config/containers/resource_constraints/")
+			exit.UsageT("Ensure your {{.driver_name}} system has enough CPUs. The minimum allowed is 2 CPUs.", out.V{"driver_name": viper.GetString("driver")})
+
 		}
 	}
 }

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -818,14 +818,16 @@ func validateMemorySize(req int, drvName string) {
 	}
 
 	if driver.IsDockerDesktop(drvName) {
+		// in Docker Desktop if you allocate 2 GB the docker info shows:  Total Memory: 1.945GiB which becomes 1991 when we calculate the MBs
+		// thats why it is not same number as other drivers which is 2 GB
 		if containerLimit < 1991 {
-			out.T(out.Tip, `Increase Docker for Desktop memory to at least 2.5 GB or more:
+			out.T(out.Tip, `Increase Docker for Desktop memory to at least 2.5GB or more:
 			
 	Docker for Desktop > Settings > Resources > Memory
 
 `)
 		} else if containerLimit < 2997 && sysLimit > 8000 { // for users with more than 8 GB advice 3 GB
-			out.T(out.Tip, `Your system has {{.system_limit}}MB memory but Docker has only {{.container_limit}}MB. For a better performance increase to at least 3 GB.
+			out.T(out.Tip, `Your system has {{.system_limit}}MB memory but Docker has only {{.container_limit}}MB. For a better performance increase to at least 3GB.
 
 	Docker for Desktop  > Settings > Resources > Memory
 

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -858,7 +858,7 @@ func validateCPUCount(drvName string) {
 			out.T(out.Confused, "Failed to verify '{{.driver_name}} info' will try again ...", out.V{"driver_name": drvName})
 			si, err = oci.DaemonInfo(drvName)
 			if err != nil {
-				exit.UsageT("Ensure your {{.driver_name}} is running and is healthy.", out.V{"driver_name": driver.NameForHumans(drvName)})
+				exit.UsageT("Ensure your {{.driver_name}} is running and is healthy.", out.V{"driver_name": driver.FullName(drvName)})
 			}
 
 		}
@@ -871,7 +871,7 @@ func validateCPUCount(drvName string) {
 				`)
 			}
 			out.T(out.Documentation, "https://docs.docker.com/config/containers/resource_constraints/")
-			exit.UsageT("Ensure your {{.driver_name}} system has enough CPUs. The minimum allowed is 2 CPUs.", out.V{"driver_name": driver.NameForHumans(viper.GetString("driver"))})
+			exit.UsageT("Ensure your {{.driver_name}} system has enough CPUs. The minimum allowed is 2 CPUs.", out.V{"driver_name": driver.FullName(viper.GetString("driver"))})
 
 		}
 	}

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -855,7 +855,7 @@ func validateCPUCount(drvName string) {
 	if driver.IsKIC((drvName)) {
 		si, err := oci.CachedDaemonInfo(drvName)
 		if err != nil {
-			out.WarningT("Failed to verify '{{.driver_name}} info', ensure your {{.driver_name}} is running healthy.", out.V{"driver_namee": drvName})
+			out.WarningT("Failed to verify '{{.driver_name}} info', ensure your {{.driver_name}} is running healthy.", out.V{"driver_name": drvName})
 		}
 		if si.CPUs < 2 {
 			if drvName == oci.Docker {

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -885,8 +885,8 @@ func validateFlags(cmd *cobra.Command, drvName string) {
 		}
 	}
 
-	validateMemorySize()
 	if cmd.Flags().Changed(memory) {
+		validateMemorySize()
 		if !driver.HasResourceLimits(drvName) {
 			out.WarningT("The '{{.name}}' driver does not respect the --memory flag", out.V{"name": drvName})
 		}

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -855,7 +855,12 @@ func validateCPUCount(drvName string) {
 	if driver.IsKIC((drvName)) {
 		si, err := oci.CachedDaemonInfo(drvName)
 		if err != nil {
-			out.WarningT("Failed to verify '{{.driver_name}} info', ensure your {{.driver_name}} is running healthy.", out.V{"driver_name": drvName})
+			out.T(out.Confused, "Failed to verify '{{.driver_name}} info' will try again ...", out.V{"driver_name": drvName})
+			si, err = oci.DaemonInfo(drvName)
+			if err != nil {
+				exit.UsageT("Ensure your {{.driver_name}} is running and is healthy.", out.V{"driver_name": driver.NameForHumans(drvName)})
+			}
+
 		}
 		if si.CPUs < 2 {
 			if drvName == oci.Docker {

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -233,7 +233,7 @@ func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k
 				exit.WithCodeT(exit.Config, "Generate unable to parse memory '{{.memory}}': {{.error}}", out.V{"memory": viper.GetString(memory), "error": err})
 			}
 			if driver.IsKIC(drvName) && mem > containerLimit {
-				exit.UsageT("{{.driver_name}} has only {{.container_limit}}MB memory but you specified {{.specified_memory}}mb", out.V{"container_limit": containerLimit, "specified_memory": mem, "driver_name": driver.NameForHumans(drvName)})
+				exit.UsageT("{{.driver_name}} has only {{.container_limit}}MB memory but you specified {{.specified_memory}}MB", out.V{"container_limit": containerLimit, "specified_memory": mem, "driver_name": driver.FullName(drvName)})
 			}
 
 		} else {

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -233,12 +233,14 @@ func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k
 				exit.WithCodeT(exit.Config, "Generate unable to parse memory '{{.memory}}': {{.error}}", out.V{"memory": viper.GetString(memory), "error": err})
 			}
 			if driver.IsKIC(drvName) && mem > containerLimit {
-				exit.UsageT("{{.driver_name}} service has only {{.container_limit}}mb memory but you specified {{.specified_memory}}mb", out.V{"container_limit": containerLimit, "specified_memory": mem, "driver_name": drvName})
+				exit.UsageT("{{.driver_name}} has only {{.container_limit}}MB memory but you specified {{.specified_memory}}mb", out.V{"container_limit": containerLimit, "specified_memory": mem, "driver_name": driver.NameForHumans(drvName)})
 			}
 
 		} else {
 			glog.Infof("Using suggested %dMB memory alloc based on sys=%dMB, container=%dMB", mem, sysLimit, containerLimit)
 		}
+
+		validateMemorySize(mem, drvName)
 
 		diskSize, err := pkgutil.CalculateSizeInMB(viper.GetString(humanReadableDiskSize))
 		if err != nil {

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -232,6 +232,9 @@ func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k
 			if err != nil {
 				exit.WithCodeT(exit.Config, "Generate unable to parse memory '{{.memory}}': {{.error}}", out.V{"memory": viper.GetString(memory), "error": err})
 			}
+			if driver.IsKIC(drvName) && mem > containerLimit {
+				exit.UsageT("{{.driver_name}} service has only {{.container_limit}}mb memory but you specified {{.specified_memory}}mb", out.V{"container_limit": containerLimit, "specified_memory": mem, "driver_name": drvName})
+			}
 
 		} else {
 			glog.Infof("Using suggested %dMB memory alloc based on sys=%dMB, container=%dMB", mem, sysLimit, containerLimit)

--- a/pkg/drivers/kic/oci/info.go
+++ b/pkg/drivers/kic/oci/info.go
@@ -49,15 +49,11 @@ func CachedDaemonInfo(ociBin string) (SysInfo, error) {
 func DaemonInfo(ociBin string) (SysInfo, error) {
 	if ociBin == Podman {
 		p, err := podmanSystemInfo()
-		cachedSysInfo.CPUs = p.Host.Cpus
-		cachedSysInfo.TotalMemory = p.Host.MemTotal
-		cachedSysInfo.OSType = p.Host.Os
+		cachedSysInfo = &SysInfo{CPUs: p.Host.Cpus, TotalMemory: p.Host.MemTotal, OSType: p.Host.Os}
 		return *cachedSysInfo, err
 	}
 	d, err := dockerSystemInfo()
-	cachedSysInfo.CPUs = d.NCPU
-	cachedSysInfo.TotalMemory = d.MemTotal
-	cachedSysInfo.OSType = d.OSType
+	cachedSysInfo = &SysInfo{CPUs: d.NCPU, TotalMemory: d.MemTotal, OSType: d.OSType}
 	return *cachedSysInfo, err
 }
 

--- a/pkg/drivers/kic/oci/info.go
+++ b/pkg/drivers/kic/oci/info.go
@@ -37,12 +37,10 @@ var cachedSysInfoErr *error
 
 // CachedDaemonInfo will run and return a docker/podman info only once per minikube run time. to avoid performance
 func CachedDaemonInfo(ociBin string) (SysInfo, error) {
-	var err error
 	if cachedSysInfo == nil {
 		si, err := DaemonInfo(ociBin)
 		cachedSysInfo = &si
 		cachedSysInfoErr = &err
-		return *cachedSysInfo, err
 	}
 	return *cachedSysInfo, *cachedSysInfoErr
 }

--- a/pkg/drivers/kic/oci/info.go
+++ b/pkg/drivers/kic/oci/info.go
@@ -34,7 +34,7 @@ type SysInfo struct {
 
 var cachedSysInfo *SysInfo
 
-// CachedDaemonInfo will run and return a docker/podman info only once per minikube run time. to avoid perfomance
+// CachedDaemonInfo will run and return a docker/podman info only once per minikube run time. to avoid performance
 func CachedDaemonInfo(ociBin string) (SysInfo, error) {
 	var err error
 	if cachedSysInfo == nil {

--- a/pkg/drivers/kic/oci/info.go
+++ b/pkg/drivers/kic/oci/info.go
@@ -33,6 +33,7 @@ type SysInfo struct {
 }
 
 var cachedSysInfo *SysInfo
+var cachedSysInfoErr *error
 
 // CachedDaemonInfo will run and return a docker/podman info only once per minikube run time. to avoid performance
 func CachedDaemonInfo(ociBin string) (SysInfo, error) {
@@ -40,9 +41,10 @@ func CachedDaemonInfo(ociBin string) (SysInfo, error) {
 	if cachedSysInfo == nil {
 		si, err := DaemonInfo(ociBin)
 		cachedSysInfo = &si
+		cachedSysInfoErr = &err
 		return *cachedSysInfo, err
 	}
-	return *cachedSysInfo, err
+	return *cachedSysInfo, *cachedSysInfoErr
 }
 
 // DaemonInfo returns common docker/podman daemon system info that minikube cares about

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -173,7 +173,7 @@ func NeedsShutdown(name string) bool {
 	return false
 }
 
-// FullName will return the human-known and formatted name for the driver
+// FullName will return the human-known and title formatted name for the driver based on platform
 func FullName(name string) string {
 	switch name {
 	case oci.Docker:
@@ -181,9 +181,6 @@ func FullName(name string) string {
 			return "Docker for Desktop"
 		}
 		return "Docker Service"
-
-	case oci.Podman:
-		return "Podman Service"
 	default:
 		return strings.Title(name)
 	}

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -106,10 +106,15 @@ func IsKIC(name string) bool {
 	return name == Docker || name == Podman
 }
 
+// IsDocker checks if the driver docker
+func IsDocker(name string) bool {
+	return name == Docker
+}
+
 // IsKIC checks if the driver is a Docker for Desktop (Docker on windows or MacOs)
 // for linux and exotic archs, this will be false
 func IsDockerDesktop(name string) bool {
-	if IsKIC(name) {
+	if IsDocker(name) {
 		if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
 			return true
 		}
@@ -168,8 +173,8 @@ func NeedsShutdown(name string) bool {
 	return false
 }
 
-// NameForHumans will return the human-known and formatted name for the driver
-func NameForHumans(name string) string {
+// FullName will return the human-known and formatted name for the driver
+func FullName(name string) string {
 	switch name {
 	case oci.Docker:
 		if IsDockerDesktop(name) {

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
+	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/registry"
 )
@@ -105,6 +106,17 @@ func IsKIC(name string) bool {
 	return name == Docker || name == Podman
 }
 
+// IsKIC checks if the driver is a Docker for Desktop (Docker on windows or MacOs)
+// for linux and exotic archs, this will be false
+func IsDockerDesktop(name string) bool {
+	if IsKIC(name) {
+		if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+			return true
+		}
+	}
+	return false
+}
+
 // IsMock checks if the driver is a mock
 func IsMock(name string) bool {
 	return name == Mock
@@ -154,6 +166,22 @@ func NeedsShutdown(name string) bool {
 		return true
 	}
 	return false
+}
+
+// NameForHumans will return the human-known and formatted name for the driver
+func NameForHumans(name string) string {
+	switch name {
+	case oci.Docker:
+		if IsDockerDesktop(name) {
+			return "Docker for Desktop"
+		}
+		return "Docker Service"
+
+	case oci.Podman:
+		return "Podman Service"
+	default:
+		return strings.Title(name)
+	}
 }
 
 // FlagHints are hints for what default options should be used for this driver

--- a/pkg/minikube/node/advice.go
+++ b/pkg/minikube/node/advice.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/bootstrapper/kubeadm"
+	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/out"
 )
@@ -45,7 +46,7 @@ func MaybeExitWithAdvice(err error) {
 
 	if errors.Is(err, oci.ErrCPUCountLimit) {
 		out.ErrLn("")
-		out.ErrT(out.Conflict, "{{.name}} doesn't have enough CPUs. ", out.V{"name": viper.GetString("driver")})
+		out.ErrT(out.Conflict, "{{.name}} doesn't have enough CPUs. ", out.V{"name": driver.NameForHumans(viper.GetString("driver"))})
 		if runtime.GOOS != "linux" && viper.GetString("driver") == "docker" {
 			out.T(out.Warning, "Please consider changing your Docker Desktop's resources.")
 			out.T(out.Documentation, "https://docs.docker.com/config/containers/resource_constraints/")
@@ -54,7 +55,7 @@ func MaybeExitWithAdvice(err error) {
 			if cpuCount == 2 {
 				out.T(out.Tip, "Please ensure your system has {{.cpu_counts}} CPU cores.", out.V{"cpu_counts": viper.GetInt(cpus)})
 			} else {
-				out.T(out.Tip, "Please ensure your {{.driver_name}} system has access to {{.cpu_counts}} CPU cores or reduce the number of the specified CPUs", out.V{"driver_name": viper.GetString("driver"), "cpu_counts": viper.GetInt(cpus)})
+				out.T(out.Tip, "Please ensure your {{.driver_name}} system has access to {{.cpu_counts}} CPU cores or reduce the number of the specified CPUs", out.V{"driver_name": driver.NameForHumans(viper.GetString("driver")), "cpu_counts": viper.GetInt(cpus)})
 			}
 		}
 		exit.UsageT("Ensure your {{.driver_name}} system has enough CPUs. The minimum allowed is 2 CPUs.", out.V{"driver_name": viper.GetString("driver")})

--- a/pkg/minikube/node/advice.go
+++ b/pkg/minikube/node/advice.go
@@ -46,7 +46,7 @@ func MaybeExitWithAdvice(err error) {
 
 	if errors.Is(err, oci.ErrCPUCountLimit) {
 		out.ErrLn("")
-		out.ErrT(out.Conflict, "{{.name}} doesn't have enough CPUs. ", out.V{"name": driver.NameForHumans(viper.GetString("driver"))})
+		out.ErrT(out.Conflict, "{{.name}} doesn't have enough CPUs. ", out.V{"name": driver.FullName(viper.GetString("driver"))})
 		if runtime.GOOS != "linux" && viper.GetString("driver") == "docker" {
 			out.T(out.Warning, "Please consider changing your Docker Desktop's resources.")
 			out.T(out.Documentation, "https://docs.docker.com/config/containers/resource_constraints/")
@@ -55,7 +55,7 @@ func MaybeExitWithAdvice(err error) {
 			if cpuCount == 2 {
 				out.T(out.Tip, "Please ensure your system has {{.cpu_counts}} CPU cores.", out.V{"cpu_counts": viper.GetInt(cpus)})
 			} else {
-				out.T(out.Tip, "Please ensure your {{.driver_name}} system has access to {{.cpu_counts}} CPU cores or reduce the number of the specified CPUs", out.V{"driver_name": driver.NameForHumans(viper.GetString("driver")), "cpu_counts": viper.GetInt(cpus)})
+				out.T(out.Tip, "Please ensure your {{.driver_name}} system has access to {{.cpu_counts}} CPU cores or reduce the number of the specified CPUs", out.V{"driver_name": driver.FullName(viper.GetString("driver")), "cpu_counts": viper.GetInt(cpus)})
 			}
 		}
 		exit.UsageT("Ensure your {{.driver_name}} system has enough CPUs. The minimum allowed is 2 CPUs.", out.V{"driver_name": viper.GetString("driver")})


### PR DESCRIPTION
closes https://github.com/kubernetes/minikube/issues/8540 and https://github.com/kubernetes/minikube/issues/7980
# 1
### Before This PR setting memory Memory=50000000MB
```
$ minikube start --driver=docker --memory=50000000mb
😄  minikube v1.12.0-beta.1 on Darwin 10.15.5
👍  Starting control plane node minikube in cluster minikube
🔥  Creating docker container (CPUs=2, Memory=50000000MB) ...
🐳  Preparing Kubernetes v1.18.3 on Docker 19.03.2 ...
... 
...(continues happily without knowing)
...
```

### After this PR setting memory to higher than what is available:

```
./out/minikube start --driver=docker --memory=50000000mb
make: `out/minikube' is up to date.
medya@~/workspace/minikube (check_docker_deskop) $ ./out/minikube start --driver=docker --memory=50000000mb
😄  minikube v1.12.0 on Darwin 10.15.5
✨  Using the docker driver based on user configuration
💡  Docker for Desktop has only 3436MB memory but you specified 50000000mb

Exits with Usage Error
```

------------------------------

# 2
### Before  this PR with less than 2 GB memory in docker desktop
(goes un-detected) 
```

medya@~/workspace/minikube (check_docker_deskop) $ minikube start --driver=docker 
😄  minikube v1.12.0-beta.1 on Darwin 10.15.5
✨  Using the docker driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🔥  Creating docker container (CPUs=2, Memory=1739MB) ...
🐳  Preparing Kubernetes v1.18.3 on Docker 19.03.2 ...
🔎  Verifying Kubernetes components...
🌟  Enabled addons: default-storageclass, storage-pro
```


### After  this PR with less than 2 GB memory in docker desktop

```
12.0 -X k8s.io/minikube/pkg/version.isoPath=minikube/iso -X k8s.io/minikube/pkg/version.gitCommitID="9acc975e176445267e20b644c0f180b667c05065-dirty"" -o out/minikube k8s.io/minikube/cmd/minikube
😄  minikube v1.12.0 on Darwin 10.15.5
✨  Using the docker driver based on user configuration
📌  Requested memory allocation (1739MB) is less than the recommended minimum 2000MB. Kubernetes may crash unexpectedly.
💡  Increase memory to at least 2.5 GB or more:

        Docker for Desktop > Settings > Resources > Memory


👍  Starting control plane node minikube in cluster minikube
🔥  Creating docker container (CPUs=2, Memory=1739MB) ...
🐳  Preparing Kubernetes v1.18.3 on Docker 19.03.2 ...
🔎  Verifying Kubernetes components...
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube"

```

# 3

 Suggest user to increase docker desktop memory if user has at least 8 GB system memory


### After this PR
```
😄  minikube v1.12.0 on Darwin 10.15.5
✨  Using the docker driver based on user configuration
💡  Your system has 16384MB memory but Docker has only 2745MB. For a better performance increase to at least 3 GB.

        Docker for Desktop  > Settings > Resources > Memory


👍  Starting control plane node minikube in cluster minikube
🔥  Creating docker container (CPUs=2, Memory=2697MB) ...
🐳  Preparing Kubernetes v1.18.3 on Docker 19.03.2 ...
🔎  Verifying Kubernetes components...
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube"````
````
-------------------------------------------------

# 4 CPU 

### Before this PR with 1 CPU in docker

```
😄  minikube v1.12.0 on Darwin 10.15.5
✨  Using the docker driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🔥  Creating docker container (CPUs=2, Memory=2697MB) ...
🤦  StartHost failed, but will try again: creating host: create: creating: create kic node: create container: not enough CPUs is available for container
🤷  docker "minikube" container is missing, will recreate.
🔥  Creating docker container (CPUs=2, Memory=2697MB) ...
😿  Failed to start docker container. "minikube start" may fix it: recreate: creating host: create: creating: create kic node: create container: not enough CPUs is available for container

💥  docker doesn't have enough CPUs. 
❗  Please consider changing your Docker Desktop's resources.
📘  https://docs.docker.com/config/containers/resource_constraints/
💡  Ensure your docker system has enough CPUs. The minimum allowed is 2 CPUs.
```

### After this PR with a docker desktop with only 1 CPUs

```
😄  minikube v1.12.0 on Darwin 10.15.5
✨  Using the docker driver based on user configuration
💥  Your Docker Desktop has less than 2 CPUs. Increase CPUs for Docker Desktop. 

        Docker icon > Settings > Resources > CPUs


📘  https://docs.docker.com/config/containers/resource_constraints/
💡  Ensure your Docker for Desktop system has enough CPUs. The minimum allowed is 2 CPUs
```