### PR TITLE
gomod: Use tag version for dockerclient

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ replace (
 	github.com/docker/machine => github.com/machine-drivers/machine v0.7.1-0.20200323212942-41eb826190d8
 	github.com/google/go-containerregistry => github.com/afbjorklund/go-containerregistry v0.0.0-20200602203322-347d93793dc9
 	github.com/hashicorp/go-getter => github.com/afbjorklund/go-getter v1.4.1-0.20190910175809-eb9f6c26742c
-	github.com/samalba/dockerclient => github.com/sayboras/dockerclient v0.0.0-20191231050035-015626177a97
+	github.com/samalba/dockerclient => github.com/sayboras/dockerclient v1.0.0
 	k8s.io/api => k8s.io/api v0.17.3
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.17.3
 	k8s.io/apimachinery => k8s.io/apimachinery v0.17.3

--- a/go.sum
+++ b/go.sum
@@ -966,8 +966,8 @@ github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb
 github.com/ryanuber/go-glob v0.0.0-20170128012129-256dc444b735/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/sassoftware/go-rpmutils v0.0.0-20190420191620-a8f1baeba37b/go.mod h1:am+Fp8Bt506lA3Rk3QCmSqmYmLMnPDhdDUcosQCAx+I=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
-github.com/sayboras/dockerclient v0.0.0-20191231050035-015626177a97 h1:DWY4yZN6w+FSKMeqBBXaalT8zmCn4DVwBGopShnlwFE=
-github.com/sayboras/dockerclient v0.0.0-20191231050035-015626177a97/go.mod h1:mUmEoqt0b+uQg57s006FsvL4mybi+N5wINLDBGtaPTY=
+github.com/sayboras/dockerclient v1.0.0 h1:awHcxOzTP07Gl1SJAhkTCTagyJwgA6f/Az/Z4xMP2yg=
+github.com/sayboras/dockerclient v1.0.0/go.mod h1:mUmEoqt0b+uQg57s006FsvL4mybi+N5wINLDBGtaPTY=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/seccomp/libseccomp-golang v0.9.1 h1:NJjM5DNFOs0s3kYE1WUOr6G8V97sdt46rlXTMfXGWBo=


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/8726

I removed the branch containing the commit hash mentioned in go.mod, which causes the build failed.

So update it to tag version v1.0.0

```shell script
$ make      
which go-bindata || GO111MODULE=off GOBIN="/home/tammach/go/bin" go get github.com/jteeuwen/go-bindata/...
PATH="/snap/go/current/bin:/home/tammach/go/bin:/usr/local/opt/coreutils/libexec/gnubin:/usr/local/opt/icu4c/sbin:/usr/local/opt/icu4c/bin:/home/tammach/.local/bin:/home/tammach/go/bin:/home/tammach/.local/bin:/home/tammach/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/home/tammach/.fzf/bin:/home/tammach/go/bin" go-bindata -nomemcopy -o pkg/minikube/assets/assets.go -pkg assets deploy/addons/...
gofmt -s -w pkg/minikube/assets/assets.go
which go-bindata || GO111MODULE=off GOBIN="/home/tammach/go/bin" go get github.com/jteeuwen/go-bindata/...
/home/tammach/go/bin/go-bindata
PATH="/snap/go/current/bin:/home/tammach/go/bin:/usr/local/opt/coreutils/libexec/gnubin:/usr/local/opt/icu4c/sbin:/usr/local/opt/icu4c/bin:/home/tammach/.local/bin:/home/tammach/go/bin:/home/tammach/.local/bin:/home/tammach/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/home/tammach/.fzf/bin:/home/tammach/go/bin" go-bindata -nomemcopy -o pkg/minikube/translate/translations.go -pkg translate translations/...
gofmt -s -w pkg/minikube/translate/translations.go
go build  -tags "container_image_ostree_stub containers_image_openpgp go_getter_nos3 go_getter_nogcs" -ldflags="-X k8s.io/minikube/pkg/version.version=v1.12.0-beta.0 -X k8s.io/minikube/pkg/version.isoVersion=v1.11.0 -X k8s.io/minikube/pkg/version.isoPath=minikube/iso -X k8s.io/minikube/pkg/version.gitCommitID="275d827088c304049eb0b042c00fde5706520fec-dirty"" -o out/minikube k8s.io/minikube/cmd/minikube
```