### PR TITLE
[WIP] Fix ValidateTunnelCmd test

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -437,7 +437,9 @@ jobs:
           $env:MINIKUBE_HOME="${pwd}\testhome"
           .\minikube-windows-amd64.exe delete --all --purge
           Get-VM | Where-Object {$_.Name -ne "DockerDesktopVM"} | Foreach {
-            Stop-VM -Name $_.Name -Force
+            .\minikube-windows-amd64.exe delete -p $_.Name
+            Suspend-VM $_.Name
+            Stop-VM $_.Name -Force
             Remove-VM $_.Name -Force
           }
           cd ..

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -435,7 +435,9 @@ jobs:
           $env:MINIKUBE_HOME="${pwd}\testhome"
           .\minikube-windows-amd64.exe delete --all --purge
           Get-VM | Where-Object {$_.Name -ne "DockerDesktopVM"} | Foreach {
-            Stop-VM -Name $_.Name -Force
+            .\minikube-windows-amd64.exe delete -p $_.Name
+            Suspend-VM $_.Name
+            Stop-VM $_.Name -Force
             Remove-VM $_.Name -Force
           }
           cd ..

--- a/test/integration/fn_tunnel_cmd_test.go
+++ b/test/integration/fn_tunnel_cmd_test.go
@@ -165,9 +165,6 @@ func validateServiceStable(ctx context.Context, t *testing.T, profile string) {
 	}
 
 	t.Run("IngressIP", func(t *testing.T) {
-		if HyperVDriver() {
-			t.Skip("The test WaitService/IngressIP is broken on hyperv https://github.com/kubernetes/minikube/issues/8381")
-		}
 		// Wait until the nginx-svc has a loadbalancer ingress IP
 		err = wait.PollImmediate(5*time.Second, Minutes(3), func() (bool, error) {
 			rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "get", "svc", "nginx-svc", "-o", "jsonpath={.status.loadBalancer.ingress[0].ip}"))

--- a/test/integration/fn_tunnel_cmd_test.go
+++ b/test/integration/fn_tunnel_cmd_test.go
@@ -126,7 +126,7 @@ func validateTunnelStart(ctx context.Context, t *testing.T, profile string) {
 
 	if runtime.GOOS == "windows" {
 		cmd = "powershell"
-		args = []string{fmt.Sprintf("Start-Process %v -ArgumentList \"-p %v tunnel --alsologtostderr\" -Verb RunAs -WindowStyle Hidden", Target(), profile)}
+		args = []string{"Start-Process " + Target() + " -ArgumentList \"-p " + profile + " tunnel --alsologtostderr\" -Verb RunAs -WindowStyle Hidden"}
 	} else {
 		cmd = Target()
 		args = []string{"-p", profile, "tunnel", "--alsologtostderr"}
@@ -165,6 +165,9 @@ func validateServiceStable(ctx context.Context, t *testing.T, profile string) {
 	}
 
 	t.Run("IngressIP", func(t *testing.T) {
+		if HyperVDriver() {
+			t.Skip("The test WaitService/IngressIP is broken on hyperv https://github.com/kubernetes/minikube/issues/8381")
+		}
 		// Wait until the nginx-svc has a loadbalancer ingress IP
 		err = wait.PollImmediate(5*time.Second, Minutes(3), func() (bool, error) {
 			rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "get", "svc", "nginx-svc", "-o", "jsonpath={.status.loadBalancer.ingress[0].ip}"))


### PR DESCRIPTION
Fixes #8304 

On windows, when tests run `minikube tunnel`, it does not inherit the elevated privileges of the parent process - it needs to be set explicitly during the invocation. The chosen approach is using powershell and Start-Process because (almost) no additional code changes are required (especially for termination). Other possible approach would be through lower level win specific API, but the required code changes would be much larger.