### PR TITLE
Add KicBaseImage to existing config if missing (fixes v1.9.x upgrade)

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -553,7 +553,8 @@ func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterC
 		cc.VerifyComponents = interpretWaitFlag(*cmd)
 	}
 
-	if cmd.Flags().Changed(kicBaseImage) {
+	// Handle flags and legacy configuration upgrades that do not contain KicBaseImage
+	if cmd.Flags().Changed(kicBaseImage) || cc.KicBaseImage == "" {
 		cc.KicBaseImage = viper.GetString(kicBaseImage)
 	}
 

--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -134,8 +134,8 @@ func TestVersionUpgrade(t *testing.T) {
 	}
 }
 
-// TestMissingUpgrade tests a Docker upgrade where the underlying container is missing
-func TestMissingUpgrade(t *testing.T) {
+// TestMissingContainerUpgrade tests a Docker upgrade where the underlying container is missing
+func TestMissingContainerUpgrade(t *testing.T) {
 	if !DockerDriver() {
 		t.Skipf("This test is only for Docker")
 	}
@@ -190,6 +190,6 @@ func TestMissingUpgrade(t *testing.T) {
 	args = append([]string{"start", "-p", profile, "--memory=2200", "--alsologtostderr", "-v=1"}, StartArgs()...)
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
-		t.Errorf("failed to start minikube HEAD with newest k8s version. args: %s : %v", rr.Command(), err)
+		t.Errorf("failed missing container upgrade from %s. args: %s : %v", legacyVersion, rr.Command(), err)
 	}
 }

--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -133,3 +133,63 @@ func TestVersionUpgrade(t *testing.T) {
 		t.Errorf("start after failed upgrade: %v", err)
 	}
 }
+
+// TestMissingUpgrade tests a Docker upgrade where the underlying container is missing
+func TestMissingUpgrade(t *testing.T) {
+	if !DockerDriver() {
+		t.Skipf("This test is only for Docker")
+	}
+
+	MaybeParallel(t)
+	profile := UniqueProfileName("missing-upgrade")
+	ctx, cancel := context.WithTimeout(context.Background(), Minutes(55))
+
+	defer CleanupWithLogs(t, profile, cancel)
+
+	legacyVersion := "v1.9.1"
+	tf, err := ioutil.TempFile("", fmt.Sprintf("minikube-%s.*.exe", legacyVersion))
+	if err != nil {
+		t.Fatalf("tempfile: %v", err)
+	}
+	defer os.Remove(tf.Name())
+	tf.Close()
+
+	url := pkgutil.GetBinaryDownloadURL(legacyVersion, runtime.GOOS)
+	if err := retry.Expo(func() error { return getter.GetFile(tf.Name(), url) }, 3*time.Second, Minutes(3)); err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(tf.Name(), 0700); err != nil {
+			t.Errorf("chmod: %v", err)
+		}
+	}
+
+	args := append([]string{"start", "-p", profile, "--memory=2200"}, StartArgs()...)
+	rr := &RunResult{}
+	r := func() error {
+		rr, err = Run(t, exec.CommandContext(ctx, tf.Name(), args...))
+		return err
+	}
+
+	// Retry up to two times, to allow flakiness for the previous release
+	if err := retry.Expo(r, 1*time.Second, Minutes(30), 2); err != nil {
+		t.Fatalf("release start failed: %v", err)
+	}
+
+	rr, err = Run(t, exec.CommandContext(ctx, "docker", "stop", profile))
+	if err != nil {
+		t.Fatalf("%s failed: %v", rr.Command(), err)
+	}
+
+	rr, err = Run(t, exec.CommandContext(ctx, "docker", "rm", profile))
+	if err != nil {
+		t.Fatalf("%s failed: %v", rr.Command(), err)
+	}
+
+	args = append([]string{"start", "-p", profile, "--memory=2200", "--alsologtostderr", "-v=1"}, StartArgs()...)
+	rr, err = Run(t, exec.CommandContext(ctx, Target(), args...))
+	if err != nil {
+		t.Errorf("failed to start minikube HEAD with newest k8s version. args: %s : %v", rr.Command(), err)
+	}
+}


### PR DESCRIPTION
Fixes `docker: invalid reference format.` which occurs in the following reproduction case:

```
minikube-1.9.2 start --driver=docker
docker stop minikube
docker rm minikube
minikube-1.12.0 start --driver=docker
```

For upgrades which require a container reset, we were inadvertently passing an empty cc.KicBaseImage to the resulting docker command-line.

