### PR TITLE
TestNetworkPlugins/DNS: Wait longer for DNS to become available

### DIFF
--- a/test/integration/net_test.go
+++ b/test/integration/net_test.go
@@ -157,7 +157,7 @@ func TestNetworkPlugins(t *testing.T) {
 						}
 
 						// If the coredns process was stable, this retry wouldn't be necessary.
-						if err := retry.Expo(nslookup, 1*time.Second, Minutes(2)); err != nil {
+						if err := retry.Expo(nslookup, 1*time.Second, Minutes(6)); err != nil {
 							t.Errorf("failed to do nslookup on kubernetes.default: %v", err)
 						}
 


### PR DESCRIPTION
May fix #8713 #8666 #8665

Hoping this will reduce flakiness for cases such as https://storage.googleapis.com/minikube-builds/logs/8738/VirtualBox_Linux.txt

```
        	* ==> coredns [36d66ddd176e] <==
        	* [INFO] plugin/ready: Still waiting on: "kubernetes"
        	* [INFO] plugin/ready: Still waiting on: "kubernetes"
        	* [INFO] plugin/ready: Still waiting on: "kubernetes"
        	* E0717 01:45:25.075303       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Namespace: Unauthorized
        	* E0717 01:45:26.074768       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Service: Unauthorized
        	* E0717 01:45:26.075965       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Endpoints: Unauthorized
        	* E0717 01:45:26.077055       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Namespace: Unauthorized
        	* E0717 01:45:27.076914       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Service: Unauthorized
        	* E0717 01:45:27.077789       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Endpoints: Unauthorized
        	* E0717 01:45:27.078513       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Namespace: Unauthorized
        	* E0717 01:45:28.080121       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Service: Unauthorized
        	* E0717 01:45:28.080659       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Endpoints: Unauthorized
        	* E0717 01:45:28.081113       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Namespace: Unauthorized
        	* E0717 01:45:29.082929       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Service: Unauthorized
        	* E0717 01:45:29.084065       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Endpoints: Unauthorized
        	* E0717 01:45:29.084839       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Namespace: Unauthorized
        	* E0717 01:45:30.088184       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Service: Unauthorized
        	* E0717 01:45:30.088456       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Endpoints: Unauthorized
        	* E0717 01:45:30.088710       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Namespace: Unauthorized
        	* E0717 01:45:31.092623       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Service: Unauthorized
        	* E0717 01:45:31.094645       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Namespace: Unauthorized
        	* E0717 01:45:31.094833       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Endpoints: Unauthorized
        	* E0717 01:45:32.094474       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Service: Unauthorized
        	* E0717 01:45:32.096852       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Namespace: Unauthorized
        	* E0717 01:45:32.097893       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1.Endpoints: Unauthorized
```

resulting in:

```
      	;; connection timed out; no servers could be reached
        	
```


