### PR TITLE
Podman downgrade to 1.9.3 for the build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -532,7 +532,7 @@ storage-provisioner-image: out/storage-provisioner-$(GOARCH) ## Build storage-pr
 .PHONY: kic-base-image
 kic-base-image: ## builds the base image used for kic.
 	docker rmi -f $(REGISTRY)/kicbase:$(KIC_VERSION)-snapshot || true
-	docker build -f ./hack/images/kicbase.Dockerfile -t $(REGISTRY)/kicbase:$(KIC_VERSION)-snapshot  --build-arg COMMIT_SHA=${VERSION}-$(COMMIT) --cache-from $(REGISTRY)/kicbase:$(KIC_VERSION) --target base .
+	docker build -f ./hack/images/kicbase.Dockerfile -t $(REGISTRY)/kicbase:$(KIC_VERSION)-snapshot  --build-arg COMMIT_SHA=${VERSION}-$(COMMIT) --cache-from $(REGISTRY)/kicbase:$(KIC_VERSION) --target base ./hack/images
 
 .PHONY: upload-preloaded-images-tar
 upload-preloaded-images-tar: out/minikube # Upload the preloaded images for oldest supported, newest supported, and default kubernetes versions to GCS.

--- a/hack/images/kicbase.Dockerfile
+++ b/hack/images/kicbase.Dockerfile
@@ -23,7 +23,10 @@ RUN sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/lib
     apt-get install -y --no-install-recommends cri-o-1.17
 
 # install podman
-RUN apt-get install -y --no-install-recommends podman
+RUN sh -c "echo 'deb https://dl.bintray.com/afbjorklund/podman eoan main' > /etc/apt/sources.list.d/podman.list" && \
+    curl -L https://bintray.com/user/downloadSubjectPublicKey?username=afbjorklund -o afbjorklund-public.key.asc && \
+    apt-key add - < afbjorklund-public.key.asc && apt-get update && \
+    apt-get install -y --no-install-recommends podman=1.9.3~1
 
 # install varlink
 RUN apt-get install -y --no-install-recommends varlink

--- a/hack/images/kicbase.Dockerfile
+++ b/hack/images/kicbase.Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     sudo=1.8.27-1ubuntu4.1 \
     docker.io=19.03.2-0ubuntu1 \
     openssh-server=1:8.0p1-6build1 \
-    dnsutils=1:9.11.5.P4+dfsg-5.1ubuntu2.1 \
+    dnsutils=1:9.11.5.P4+dfsg-5.1ubuntu2.2 \
     # libglib2.0-0 is required for conmon, which is required for podman
     libglib2.0-0=2.62.1-1 \
     && rm /etc/crictl.yaml


### PR DESCRIPTION
There seems to be something wrong with the CNI configuration in the latest minikube, but this PR fixes podman-remote build...

`error configuring network namespace for container 8c6d6bcbfb79ef388b298bb168a9a44f9fdb9100ea07975190c3c48e631c917f: failed to set bridge addr: \"cni-podman0\" already has an IP address different from 10.244.0.1/16"`

Closes #8063