### PR TITLE
Add minimal minikube-automount to the kic image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -532,7 +532,7 @@ storage-provisioner-image: out/storage-provisioner-$(GOARCH) ## Build storage-pr
 .PHONY: kic-base-image
 kic-base-image: ## builds the base image used for kic.
 	docker rmi -f $(REGISTRY)/kicbase:$(KIC_VERSION)-snapshot || true
-	docker build -f ./hack/images/kicbase.Dockerfile -t $(REGISTRY)/kicbase:$(KIC_VERSION)-snapshot  --build-arg COMMIT_SHA=${VERSION}-$(COMMIT) --cache-from $(REGISTRY)/kicbase:$(KIC_VERSION) --target base .
+	docker build -f ./hack/images/kicbase.Dockerfile -t $(REGISTRY)/kicbase:$(KIC_VERSION)-snapshot  --build-arg COMMIT_SHA=${VERSION}-$(COMMIT) --cache-from $(REGISTRY)/kicbase:$(KIC_VERSION) --target base ./hack/images
 
 .PHONY: upload-preloaded-images-tar
 upload-preloaded-images-tar: out/minikube # Upload the preloaded images for oldest supported, newest supported, and default kubernetes versions to GCS.

--- a/hack/images/automount/minikube-automount
+++ b/hack/images/automount/minikube-automount
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -x
+
+echo "automount ...";
+
+if [ -d /var ]; then
+    mkdir -p /var/data
+    mkdir /data
+    mount --bind /var/data /data
+
+    mkdir -p /var/hostpath_pv
+    mkdir /tmp/hostpath_pv
+    mount --bind /var/hostpath_pv /tmp/hostpath_pv
+
+    mkdir -p /var/hostpath-provisioner
+    mkdir /tmp/hostpath-provisioner
+    mount --bind /var/hostpath-provisioner /tmp/hostpath-provisioner
+fi

--- a/hack/images/automount/minikube-automount.service
+++ b/hack/images/automount/minikube-automount.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=minikube automount
+Requires=local-fs.target
+Before=docker.service
+After=local-fs.target
+
+[Service]
+ExecStart=/usr/sbin/minikube-automount
+Type=oneshot
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target

--- a/hack/images/kicbase.Dockerfile
+++ b/hack/images/kicbase.Dockerfile
@@ -28,6 +28,11 @@ RUN apt-get install -y --no-install-recommends podman
 # install varlink
 RUN apt-get install -y --no-install-recommends varlink
 
+# automount service
+COPY automount/minikube-automount /usr/sbin/minikube-automount
+COPY automount/minikube-automount.service /usr/lib/systemd/system/minikube-automount.service
+RUN ln -fs /usr/lib/systemd/system/minikube-automount.service \
+    /etc/systemd/system/multi-user.target.wants/minikube-automount.service
 
 # disable non-docker runtimes by default
 RUN systemctl disable containerd && systemctl disable crio && rm /etc/crictl.yaml

--- a/hack/images/kicbase.Dockerfile
+++ b/hack/images/kicbase.Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     sudo=1.8.27-1ubuntu4.1 \
     docker.io=19.03.2-0ubuntu1 \
     openssh-server=1:8.0p1-6build1 \
-    dnsutils=1:9.11.5.P4+dfsg-5.1ubuntu2.1 \
+    dnsutils=1:9.11.5.P4+dfsg-5.1ubuntu2.2 \
     # libglib2.0-0 is required for conmon, which is required for podman
     libglib2.0-0=2.62.1-1 \
     && rm /etc/crictl.yaml


### PR DESCRIPTION
Make sure to mount required paths for storage provisioning:
/tmp/hostpath_pv
/tmp/hostpath-provisioner
/data

Closes #8151 #8458

Also includes some required build fixes, taken from PR #8774 
(hopefully those can be rebased away later on, but are needed)