### PR TITLE
regenerate config on retry

### DIFF
--- a/cmd/minikube/cmd/node_add.go
+++ b/cmd/minikube/cmd/node_add.go
@@ -64,7 +64,7 @@ var nodeAddCmd = &cobra.Command{
 		}
 
 		if err := node.Add(cc, n, false); err != nil {
-			_, err := maybeDeleteAndRetry(cc, n, nil, err)
+			_, err := maybeDeleteAndRetry(cmd, *cc, n, nil, err)
 			if err != nil {
 				exit.WithError("failed to add node", err)
 			}

--- a/cmd/minikube/cmd/node_add.go
+++ b/cmd/minikube/cmd/node_add.go
@@ -64,7 +64,7 @@ var nodeAddCmd = &cobra.Command{
 		}
 
 		if err := node.Add(cc, n, false); err != nil {
-			_, err := maybeDeleteAndRetry(*cc, n, nil, err)
+			_, err := maybeDeleteAndRetry(cc, n, nil, err)
 			if err != nil {
 				exit.WithError("failed to add node", err)
 			}

--- a/cmd/minikube/cmd/node_start.go
+++ b/cmd/minikube/cmd/node_start.go
@@ -69,7 +69,7 @@ var nodeStartCmd = &cobra.Command{
 
 		_, err = node.Start(s, false)
 		if err != nil {
-			_, err := maybeDeleteAndRetry(cc, *n, nil, err)
+			_, err := maybeDeleteAndRetry(cmd, *cc, *n, nil, err)
 			if err != nil {
 				node.MaybeExitWithAdvice(err)
 				exit.WithError("failed to start node", err)

--- a/cmd/minikube/cmd/node_start.go
+++ b/cmd/minikube/cmd/node_start.go
@@ -69,7 +69,7 @@ var nodeStartCmd = &cobra.Command{
 
 		_, err = node.Start(s, false)
 		if err != nil {
-			_, err := maybeDeleteAndRetry(*cc, *n, nil, err)
+			_, err := maybeDeleteAndRetry(cc, *n, nil, err)
 			if err != nil {
 				node.MaybeExitWithAdvice(err)
 				exit.WithError("failed to start node", err)

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -200,7 +200,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	kubeconfig, err := startWithDriver(starter, existing)
+	kubeconfig, err := startWithDriver(cmd, starter, existing)
 	if err != nil {
 		node.MaybeExitWithAdvice(err)
 		exit.WithError("failed to start node", err)
@@ -279,10 +279,10 @@ func provisionWithDriver(cmd *cobra.Command, ds registry.DriverState, existing *
 	}, nil
 }
 
-func startWithDriver(starter node.Starter, existing *config.ClusterConfig) (*kubeconfig.Settings, error) {
+func startWithDriver(cmd *cobra.Command, starter node.Starter, existing *config.ClusterConfig) (*kubeconfig.Settings, error) {
 	kubeconfig, err := node.Start(starter, true)
 	if err != nil {
-		kubeconfig, err = maybeDeleteAndRetry(starter.Cfg, *starter.Node, starter.ExistingAddons, err)
+		kubeconfig, err = maybeDeleteAndRetry(cmd, *starter.Cfg, *starter.Node, starter.ExistingAddons, err)
 		if err != nil {
 			return nil, err
 		}
@@ -411,31 +411,31 @@ func showKubectlInfo(kcs *kubeconfig.Settings, k8sVersion string, machineName st
 	return nil
 }
 
-func maybeDeleteAndRetry(cc *config.ClusterConfig, n config.Node, existingAddons map[string]bool, originalErr error) (*kubeconfig.Settings, error) {
+func maybeDeleteAndRetry(cmd *cobra.Command, existing config.ClusterConfig, n config.Node, existingAddons map[string]bool, originalErr error) (*kubeconfig.Settings, error) {
 	if viper.GetBool(deleteOnFailure) {
 		out.WarningT("Node {{.name}} failed to start, deleting and trying again.", out.V{"name": n.Name})
 		// Start failed, delete the cluster and try again
-		profile, err := config.LoadProfile(cc.Name)
+		profile, err := config.LoadProfile(existing.Name)
 		if err != nil {
-			out.ErrT(out.Meh, `"{{.name}}" profile does not exist, trying anyways.`, out.V{"name": cc.Name})
+			out.ErrT(out.Meh, `"{{.name}}" profile does not exist, trying anyways.`, out.V{"name": existing.Name})
 		}
 
 		err = deleteProfile(profile)
 		if err != nil {
-			out.WarningT("Failed to delete cluster {{.name}}, proceeding with retry anyway.", out.V{"name": cc.Name})
+			out.WarningT("Failed to delete cluster {{.name}}, proceeding with retry anyway.", out.V{"name": existing.Name})
 		}
 
 		// Re-generate the cluster config, just in case the failure was related to an old config format
-		upgradeExistingConfig(cc)
+		cc := updateExistingConfigFromFlags(cmd, &existing)
 		var kubeconfig *kubeconfig.Settings
 		for _, n := range cc.Nodes {
-			r, p, m, h, err := node.Provision(cc, &n, n.ControlPlane, false)
+			r, p, m, h, err := node.Provision(&cc, &n, n.ControlPlane, false)
 			s := node.Starter{
 				Runner:         r,
 				PreExists:      p,
 				MachineAPI:     m,
 				Host:           h,
-				Cfg:            cc,
+				Cfg:            &cc,
 				Node:           &n,
 				ExistingAddons: existingAddons,
 			}

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -217,7 +217,7 @@ func ClusterFlagValue() string {
 // generateClusterConfig generate a config.ClusterConfig based on flags or existing cluster config
 func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k8sVersion string, drvName string) (config.ClusterConfig, config.Node, error) {
 	var cc config.ClusterConfig
-	if existing != nil { // create profile config first time
+	if existing != nil {
 		cc = updateExistingConfigFromFlags(cmd, existing)
 	} else {
 		glog.Info("no existing cluster config was found, will generate one from the flags ")


### PR DESCRIPTION
Fixes #8736

Example of 1.9 config:
```
 cat ~/.minikube/profiles/minikube/config.json 
{
        "Name": "minikube",
        "KeepContext": false,
        "EmbedCerts": false,
        "MinikubeISO": "",
        "Memory": 3892,
        "CPUs": 2,
        "DiskSize": 20000,
        "Driver": "docker",
        "HyperkitVpnKitSock": "",
        "HyperkitVSockPorts": [],
        "DockerEnv": null,
        "InsecureRegistry": null,
        "RegistryMirror": null,
        "HostOnlyCIDR": "192.168.99.1/24",
        "HypervVirtualSwitch": "",
        "HypervUseExternalSwitch": false,
        "HypervExternalAdapter": "",
        "KVMNetwork": "default",
        "KVMQemuURI": "qemu:///system",
        "KVMGPU": false,
        "KVMHidden": false,
        "DockerOpt": null,
        "DisableDriverMounts": false,
        "NFSShare": [],
        "NFSSharesRoot": "/nfsshares",
        "UUID": "",
        "NoVTXCheck": false,
        "DNSProxy": false,
        "HostDNSResolver": true,
        "HostOnlyNicType": "virtio",
        "NatNicType": "virtio",
        "KubernetesConfig": {
                "KubernetesVersion": "v1.18.0",
                "ClusterName": "minikube",
                "APIServerName": "minikubeCA",
                "APIServerNames": null,
                "APIServerIPs": null,
                "DNSDomain": "cluster.local",
                "ContainerRuntime": "docker",
                "CRISocket": "",
                "NetworkPlugin": "",
                "FeatureGates": "",
                "ServiceCIDR": "10.96.0.0/12",
                "ImageRepository": "",
                "ExtraOptions": [
                        {
                                "Component": "kubeadm",
                                "Key": "pod-network-cidr",
                                "Value": "10.244.0.0/16"
                        }
                ],
                "ShouldLoadCachedImages": true,
                "EnableDefaultCNI": false,
                "NodeIP": "",
                "NodePort": 0,
                "NodeName": ""
        },
        "Nodes": [
                {
                        "Name": "m01",
                        "IP": "172.17.0.2",
                        "Port": 8443,
                        "KubernetesVersion": "v1.18.0",
                        "ControlPlane": true,
                        "Worker": true
                }
        ],
        "Addons": {
                "default-storageclass": true,
                "storage-provisioner": true
        },
        "VerifyComponents": {
                "apiserver": true,
                "system_pods": true
        }
```

What a start with retry on failure now looks like:
```
minikube start --delete-on-failure=true
😄  minikube v1.12.1 on Darwin 10.15.5
🆕  Kubernetes 1.18.3 is now available. If you would like to upgrade, specify: --kubernetes-version=v1.18.3
✨  Using the docker driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
🏃  Updating the running docker "minikube" container ...
❗  Node m01 failed to start, deleting and trying again.
🔥  Deleting "minikube" in docker ...
🔥  Deleting container "minikube" ...
🔥  Removing /Users/selgamal/.minikube/machines/minikube ...
💀  Removed all traces of the "minikube" cluster.
👍  Starting control plane node minikube in cluster minikube
🔥  Creating docker container (CPUs=2, Memory=3892MB) ...
🌐  Found network options:
    ▪ NO_PROXY=172.17.0.2
🐳  Preparing Kubernetes v1.18.0 on Docker 19.03.2 ...
    ▪ env NO_PROXY=172.17.0.2
🔎  Verifying Kubernetes components...
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube"
```

And the config file after the retry:
```
cat ~/.minikube/profiles/minikube/config.json 
{
        "Name": "minikube",
        "KeepContext": false,
        "EmbedCerts": false,
        "MinikubeISO": "",
        "KicBaseImage": "gcr.io/k8s-minikube/kicbase:v0.0.10@sha256:f58e0c4662bac8a9b5dda7984b185bad8502ade5d9fa364bf2755d636ab51438",
        "Memory": 3892,
        "CPUs": 2,
        "DiskSize": 20000,
        "VMDriver": "",
        "Driver": "docker",
        "HyperkitVpnKitSock": "",
        "HyperkitVSockPorts": [],
        "DockerEnv": null,
        "InsecureRegistry": null,
        "RegistryMirror": null,
        "HostOnlyCIDR": "192.168.99.1/24",
        "HypervVirtualSwitch": "",
        "HypervUseExternalSwitch": false,
        "HypervExternalAdapter": "",
        "KVMNetwork": "default",
        "KVMQemuURI": "qemu:///system",
        "KVMGPU": false,
        "KVMHidden": false,
        "DockerOpt": null,
        "DisableDriverMounts": false,
        "NFSShare": [],
        "NFSSharesRoot": "/nfsshares",
        "UUID": "",
        "NoVTXCheck": false,
        "DNSProxy": false,
        "HostDNSResolver": true,
        "HostOnlyNicType": "virtio",
        "NatNicType": "virtio",
        "KubernetesConfig": {
                "KubernetesVersion": "v1.18.0",
                "ClusterName": "minikube",
                "APIServerName": "minikubeCA",
                "APIServerNames": null,
                "APIServerIPs": null,
                "DNSDomain": "cluster.local",
                "ContainerRuntime": "docker",
                "CRISocket": "",
                "NetworkPlugin": "",
                "FeatureGates": "",
                "ServiceCIDR": "10.96.0.0/12",
                "ImageRepository": "",
                "LoadBalancerStartIP": "",
                "LoadBalancerEndIP": "",
                "ExtraOptions": [
                        {
                                "Component": "kubeadm",
                                "Key": "pod-network-cidr",
                                "Value": "10.244.0.0/16"
                        }
                ],
                "ShouldLoadCachedImages": true,
                "EnableDefaultCNI": false,
                "CNI": "",
                "NodeIP": "",
                "NodePort": 8443,
                "NodeName": ""
        },
        "Nodes": [
                {
                        "Name": "m01",
                        "IP": "172.17.0.3",
                        "Port": 8443,
                        "KubernetesVersion": "v1.18.0",
                        "ControlPlane": true,
                        "Worker": true
                }
        ],
        "Addons": {
                "ambassador": false,
                "dashboard": false,
                "default-storageclass": true,
                "efk": false,
                "freshpod": false,
                "gvisor": false,
                "helm-tiller": false,
                "ingress": false,
                "ingress-dns": false,
                "istio": false,
                "istio-provisioner": false,
                "kubevirt": false,
                "logviewer": false,
                "metallb": false,
                "metrics-server": false,
                "nvidia-driver-installer": false,
                "nvidia-gpu-device-plugin": false,
                "olm": false,
                "pod-security-policy": false,
                "registry": false,
                "registry-aliases": false,
                "registry-creds": false,
                "storage-provisioner": true,
                "storage-provisioner-gluster": false
        },
        "VerifyComponents": {
                "apiserver": true,
                "system_pods": true
        }
```