### PR TITLE
Warn user for podman2 version

### DIFF
--- a/pkg/minikube/registry/drvs/podman/podman.go
+++ b/pkg/minikube/registry/drvs/podman/podman.go
@@ -108,10 +108,10 @@ func status() registry.State {
 		}
 
 		if v.LT(minReqPodmanVer) {
-			out.WarningT("Warning ! minimum required version for podman is {{.minVersion}}. your version is {{.currentVersion}}. minikube might not work. use at your own risk. To install latest version please see https://podman.io/getting-started/installation.html",
+			out.WarningT("Warning ! minimum required version for podman is '{{.minVersion}}'. your version is '{{.currentVersion}}'. minikube might not work. use at your own risk. To install latest version please see https://podman.io/getting-started/installation.html",
 				out.V{"minVersion": minReqPodmanVer.String(), "currentVersion": v.String()})
 		} else if v.GTE(podmanVerTwo) {
-			out.WarningT("Warning ! podman 2 is not supported yet. your version is {{.currentVersion}}. minikube might not work. use at your own risk.",
+			out.WarningT("Warning ! podman 2 is not supported yet. your version is '{{.currentVersion}}'. minikube might not work. use at your own risk.",
 				out.V{"currentVersion": v.String()})
 		}
 

--- a/pkg/minikube/registry/drvs/podman/podman.go
+++ b/pkg/minikube/registry/drvs/podman/podman.go
@@ -115,7 +115,7 @@ func status() registry.State {
 				Error:     fmt.Errorf("Podman2 is not supported yet"),
 				Installed: true,
 				Healthy:   false,
-				Fix:       "Install a compatable Podman driver",
+				Fix:       "Install a compatible Podman driver",
 				Doc:       "https://github.com/containers/podman/releases/v1.9.3",
 			}
 		}

--- a/pkg/minikube/registry/drvs/podman/podman.go
+++ b/pkg/minikube/registry/drvs/podman/podman.go
@@ -115,7 +115,7 @@ func status() registry.State {
 				Error:     fmt.Errorf("podman v2 is not supported yet"),
 				Installed: true,
 				Healthy:   false,
-				Fix:       "Install a compatible Podman driver",
+				Fix:       fmt.Sprintf("Install a compatible Podman version. %q+", minReqPodmanVer.String()),
 				Doc:       "https://github.com/containers/podman/releases/v1.9.3",
 			}
 		}

--- a/pkg/minikube/registry/drvs/podman/podman.go
+++ b/pkg/minikube/registry/drvs/podman/podman.go
@@ -112,7 +112,7 @@ func status() registry.State {
 
 		if v.GTE(podmanVerTwo) {
 			return registry.State{
-				Error:     fmt.Errorf("Podman2 is not supported yet"),
+				Error:     fmt.Errorf("podman2 is not supported yet"),
 				Installed: true,
 				Healthy:   false,
 				Fix:       "Install a compatible Podman driver",

--- a/pkg/minikube/registry/drvs/podman/podman.go
+++ b/pkg/minikube/registry/drvs/podman/podman.go
@@ -40,7 +40,7 @@ import (
 // minReqPodmanVer is required the minimum version of podman to be installed for podman driver.
 var minReqPodmanVer = semver.Version{Major: 1, Minor: 7, Patch: 0}
 
-// podmanVerTwo is required to exit with an error when podman2 driver is currently installed because it is not supported yet.
+// podmanVerTwo is required to exit with an error when podman v2 driver is currently installed because it is not supported yet.
 var podmanVerTwo = semver.Version{Major: 2, Minor: 0, Patch: 0}
 
 func init() {
@@ -112,7 +112,7 @@ func status() registry.State {
 
 		if v.GTE(podmanVerTwo) {
 			return registry.State{
-				Error:     fmt.Errorf("podman2 is not supported yet"),
+				Error:     fmt.Errorf("podman v2 is not supported yet"),
 				Installed: true,
 				Healthy:   false,
 				Fix:       "Install a compatible Podman driver",

--- a/pkg/minikube/registry/drvs/podman/podman.go
+++ b/pkg/minikube/registry/drvs/podman/podman.go
@@ -107,17 +107,9 @@ func status() registry.State {
 		}
 
 		if v.LT(minReqPodmanVer) {
-			glog.Warningf("Warning ! minimum required version for podman is %s. your version is %q. minikube might not work. use at your own risk. To install latest version please see https://podman.io/getting-started/installation.html ", minReqPodmanVer.String(), v.String())
-		}
-
-		if v.GTE(podmanVerTwo) {
-			return registry.State{
-				Error:     fmt.Errorf("podman v2 is not supported yet"),
-				Installed: true,
-				Healthy:   false,
-				Fix:       fmt.Sprintf("Install a compatible Podman version. %q+", minReqPodmanVer.String()),
-				Doc:       "https://github.com/containers/podman/releases/v1.9.3",
-			}
+			glog.Warningf("Warning ! minimum required version for podman is %s. your version is %q. minikube might not work. use at your own risk. To install latest version please see https://podman.io/getting-started/installation.html", minReqPodmanVer.String(), v.String())
+		} else if v.GTE(podmanVerTwo) {
+			glog.Warningf("Warning ! podman 2 is not supported yet. your version is %q. minikube might not work. use at your own risk.", v.String())
 		}
 
 		return registry.State{Installed: true, Healthy: true}

--- a/pkg/minikube/registry/drvs/podman/podman.go
+++ b/pkg/minikube/registry/drvs/podman/podman.go
@@ -108,10 +108,10 @@ func status() registry.State {
 		}
 
 		if v.LT(minReqPodmanVer) {
-			out.WarningT("Warning ! minimum required version for podman is '{{.minVersion}}'. your version is '{{.currentVersion}}'. minikube might not work. use at your own risk. To install latest version please see https://podman.io/getting-started/installation.html",
+			out.WarningT(`The minimum required version for podman is "{{.minVersion}}". your version is "{{.currentVersion}}". minikube might not work. use at your own risk. To install latest version please see https://podman.io/getting-started/installation.html`,
 				out.V{"minVersion": minReqPodmanVer.String(), "currentVersion": v.String()})
 		} else if v.GTE(podmanVerTwo) {
-			out.WarningT("Warning ! podman 2 is not supported yet. your version is '{{.currentVersion}}'. minikube might not work. use at your own risk.",
+			out.WarningT(`Using podman 2 is not supported yet. your version is "{{.currentVersion}}". minikube might not work. use at your own risk.`,
 				out.V{"currentVersion": v.String()})
 		}
 

--- a/pkg/minikube/registry/drvs/podman/podman.go
+++ b/pkg/minikube/registry/drvs/podman/podman.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/localpath"
+	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/registry"
 )
 
@@ -107,9 +108,11 @@ func status() registry.State {
 		}
 
 		if v.LT(minReqPodmanVer) {
-			glog.Warningf("Warning ! minimum required version for podman is %s. your version is %q. minikube might not work. use at your own risk. To install latest version please see https://podman.io/getting-started/installation.html", minReqPodmanVer.String(), v.String())
+			out.WarningT("Warning ! minimum required version for podman is {{.minVersion}}. your version is {{.currentVersion}}. minikube might not work. use at your own risk. To install latest version please see https://podman.io/getting-started/installation.html",
+				out.V{"minVersion": minReqPodmanVer.String(), "currentVersion": v.String()})
 		} else if v.GTE(podmanVerTwo) {
-			glog.Warningf("Warning ! podman 2 is not supported yet. your version is %q. minikube might not work. use at your own risk.", v.String())
+			out.WarningT("Warning ! podman 2 is not supported yet. your version is {{.currentVersion}}. minikube might not work. use at your own risk.",
+				out.V{"currentVersion": v.String()})
 		}
 
 		return registry.State{Installed: true, Healthy: true}

--- a/pkg/minikube/registry/drvs/podman/podman.go
+++ b/pkg/minikube/registry/drvs/podman/podman.go
@@ -37,8 +37,11 @@ import (
 	"k8s.io/minikube/pkg/minikube/registry"
 )
 
-// minReqPodmanVer is required the mininum version of podman to be installed for podman driver.
+// minReqPodmanVer is required the minimum version of podman to be installed for podman driver.
 var minReqPodmanVer = semver.Version{Major: 1, Minor: 7, Patch: 0}
+
+// podmanVerTwo is required to exit with an error when podman2 driver is currently installed because it is not supported yet.
+var podmanVerTwo = semver.Version{Major: 2, Minor: 0, Patch: 0}
 
 func init() {
 	priority := registry.Experimental
@@ -105,6 +108,16 @@ func status() registry.State {
 
 		if v.LT(minReqPodmanVer) {
 			glog.Warningf("Warning ! minimum required version for podman is %s. your version is %q. minikube might not work. use at your own risk. To install latest version please see https://podman.io/getting-started/installation.html ", minReqPodmanVer.String(), v.String())
+		}
+
+		if v.GTE(podmanVerTwo) {
+			return registry.State{
+				Error:     fmt.Errorf("Podman2 is not supported yet"),
+				Installed: true,
+				Healthy:   false,
+				Fix:       "Install a compatable Podman driver",
+				Doc:       "https://github.com/containers/podman/releases/v1.9.3",
+			}
 		}
 
 		return registry.State{Installed: true, Healthy: true}

--- a/site/content/en/docs/drivers/podman.md
+++ b/site/content/en/docs/drivers/podman.md
@@ -24,7 +24,7 @@ The podman driver is an alternative container runtime to the [Docker]({{< ref "/
 ## Known Issues
 
 - Podman driver is not supported on non-amd64 architectures such as arm yet. For non-amd64 archs please use [other drivers]({{< ref "/docs/drivers/_index.md" >}}) 
-- Podman2 driver is not supported yet.
+- Podman v2 driver is not supported yet.
 - Podman requirements passwordless running of sudo. If you run into an error about sudo, do the following: 
 
 ```shell

--- a/site/content/en/docs/drivers/podman.md
+++ b/site/content/en/docs/drivers/podman.md
@@ -24,6 +24,7 @@ The podman driver is an alternative container runtime to the [Docker]({{< ref "/
 ## Known Issues
 
 - Podman driver is not supported on non-amd64 architectures such as arm yet. For non-amd64 archs please use [other drivers]({{< ref "/docs/drivers/_index.md" >}}) 
+- Podman2 driver is not supported yet.
 - Podman requirements passwordless running of sudo. If you run into an error about sudo, do the following: 
 
 ```shell


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/minikube/issues/8783

* Exit with error when podman2 driver is used as it is not currently supported.
* Add doc entry about known limitation.

## Testing
* Fedora 32
* podman 2.0.2

### Problem(`master`):
```
./out/minikube-linux-amd64 start --driver=podman
😄  minikube v1.12.1 on Fedora 32 (xen/amd64)
✨  Using the podman (experimental) driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
💾  Downloading Kubernetes v1.18.3 preload ...
    > preloaded-images-k8s-v4-v1.18.3-docker-overlay2-amd64.tar.lz4: 526.27 MiB
🔥  Creating podman container (CPUs=2, Memory=2200MB) ...
✋  Stopping "minikube" in podman ...
🛑  Powering off "minikube" via SSH ...
🔥  Deleting "minikube" in podman ...
🤦  StartHost failed, but will try again: creating host: create: provisioning: get ssh host-port: convert host-port '\x00' to number: strconv.Atoi: parsing "": invalid syntax
🔥  Creating podman container (CPUs=2, Memory=2200MB) ...
😿  Failed to start podman container. "minikube start" may fix it: creating host: create: creating: setting up container node: creating volume for minikube container: sudo -n podman volume create minikube --label name.minikube.sigs.k8s.io=minikube --label created_by.minikube.sigs.k8s.io=true: exit status 125
stdout:

stderr:
Error: volume with name minikube already exists: volume already exists


💣  error provisioning host: Failed to start host: creating host: create: creating: setting up container node: creating volume for minikube container: sudo -n podman volume create minikube --label name.minikube.sigs.k8s.io=minikube --label created_by.minikube.sigs.k8s.io=true: exit status 125
stdout:

stderr:
Error: volume with name minikube already exists: volume already exists


😿  minikube is exiting due to an error. If the above message is not useful, open an issue:
👉  https://github.com/kubernetes/minikube/issues/new/choose
```

### Proposed fix(`Dean-Coakley:disable-podman2`):
```
./out/minikube-linux-amd64 start --driver=podman
😄  minikube v1.12.1 on Fedora 32 (xen/amd64)
✨  Using the podman (experimental) driver based on user configuration

❗  'podman' driver reported an issue: podman v2 is not supported yet
💡  Suggestion: Install a compatible Podman version. "1.7.0"+
📘  Documentation: https://github.com/containers/podman/releases/v1.9.3

💣  Failed to validate 'podman' driver
```