### PR TITLE
fix error usage for the WaitGroup in the pkg addons

### DIFF
--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -340,7 +340,6 @@ func verifyAddonStatus(cc *config.ClusterConfig, name string, val string) error 
 
 // Start enables the default addons for a profile, plus any additional
 func Start(wg *sync.WaitGroup, cc *config.ClusterConfig, toEnable map[string]bool, additional []string) {
-	wg.Add(1)
 	defer wg.Done()
 
 	start := time.Now()

--- a/pkg/addons/addons_test.go
+++ b/pkg/addons/addons_test.go
@@ -130,7 +130,8 @@ func TestStart(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	Start(&wg, cc, map[string]bool{}, []string{"dashboard"})
+	wg.Add(1)
+	go Start(&wg, cc, map[string]bool{}, []string{"dashboard"})
 	wg.Wait()
 
 	if !assets.Addons["dashboard"].IsEnabled(cc) {

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -146,6 +146,7 @@ func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 
 	// enable addons, both old and new!
 	if starter.ExistingAddons != nil {
+		wg.Add(1)
 		go addons.Start(&wg, starter.Cfg, starter.ExistingAddons, config.AddonList)
 	}
 


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

The method `Add` should out in the goroutine, because the `Wait` maybe exec before the goroutine. 