### PR TITLE
Stop kube-system containers before applying configuration updates

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -554,6 +554,9 @@ func (k *Bootstrapper) restartControlPlane(cfg config.ClusterConfig) error {
 		return nil
 	}
 
+	if err := k.stopKubeSystem(cfg); err != nil {
+		glog.Warningf("failed to stop kube system container before reconfiguring kubeadm, this might cause port conflicts sometimes : %v", err)
+	}
 	if err := k.clearStaleConfigs(cfg); err != nil {
 		return errors.Wrap(err, "clearing stale configs")
 	}
@@ -900,6 +903,27 @@ func (k *Bootstrapper) elevateKubeSystemPrivileges(cfg config.ClusterConfig) err
 		// retry up to make sure SA is created
 		if err := wait.PollImmediate(kconst.APICallRetryInterval, time.Minute, checkSA); err != nil {
 			return errors.Wrap(err, "ensure sa was created")
+		}
+	}
+	return nil
+}
+
+// stopKubeSystem stops all the containers in the kube-system to prevent #8740 when doing hot upgrade
+func (k *Bootstrapper) stopKubeSystem(cfg config.ClusterConfig) error {
+	glog.Info("stopping kube-system containers ...")
+	cr, err := cruntime.New(cruntime.Config{Type: cfg.KubernetesConfig.ContainerRuntime, Runner: k.c})
+	if err != nil {
+		return errors.Wrap(err, "new cruntime")
+	}
+
+	ids, err := cr.ListContainers(cruntime.ListOptions{Namespaces: []string{"kube-system"}})
+	if err != nil {
+		return errors.Wrap(err, "list")
+	}
+
+	if len(ids) > 0 {
+		if err := cr.StopContainers(ids); err != nil {
+			return errors.Wrap(err, "stop")
 		}
 	}
 	return nil

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -555,7 +555,7 @@ func (k *Bootstrapper) restartControlPlane(cfg config.ClusterConfig) error {
 	}
 
 	if err := k.stopKubeSystem(cfg); err != nil {
-		glog.Warningf("failed to stop kube system container before reconfiguring kubeadm, this might cause port conflicts sometimes : %v", err)
+		glog.Warningf("Failed to stop kube-system containers: port conflicts may arise: %v %v", err)
 	}
 	if err := k.clearStaleConfigs(cfg); err != nil {
 		return errors.Wrap(err, "clearing stale configs")

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -555,7 +555,7 @@ func (k *Bootstrapper) restartControlPlane(cfg config.ClusterConfig) error {
 	}
 
 	if err := k.stopKubeSystem(cfg); err != nil {
-		glog.Warningf("Failed to stop kube-system containers: port conflicts may arise: %v %v", err)
+		glog.Warningf("Failed to stop kube-system containers: port conflicts may arise: %v", err)
 	}
 	if err := k.clearStaleConfigs(cfg); err != nil {
 		return errors.Wrap(err, "clearing stale configs")


### PR DESCRIPTION
might close https://github.com/kubernetes/minikube/issues/8740
while couldn't replicate the race condition but i confirm it doesnt hurt it
```
make: 'out/minikube' is up to date.
med@xmac:~/workspace/minikube (hot_upgrade_fix)$ minikube1.9.2 start --driver=docker
😄  minikube v1.9.2 on Ubuntu 20.04
✨  Using the docker driver based on user configuration
👍  Starting control plane node m01 in cluster minikube
🚜  Pulling base image ...
🔥  Creating Kubernetes in docker container with (CPUs=2) (8 available), Memory=3900MB (15990MB available) ...
🐳  Preparing Kubernetes v1.18.0 on Docker 19.03.2 ...
    ▪ kubeadm.pod-network-cidr=10.244.0.0/16
🌟  Enabling addons: default-storageclass, storage-provisioner

🏄  Done! kubectl is now configured to use "minikube"
med@xmac:~/workspace/minikube (hot_upgrade_fix)$ 
med@xmac:~/workspace/minikube (hot_upgrade_fix)$ 
med@xmac:~/workspace/minikube (hot_upgrade_fix)$ 
med@xmac:~/workspace/minikube (hot_upgrade_fix)$ make && ./out/minikube start --driver=docker --alsologtostderr
make: 'out/minikube' is up to date.
I0722 15:12:20.035658  125103 out.go:174] Setting JSON to false
I0722 15:12:20.055113  125103 start.go:101] hostinfo: {"hostname":"xmac","uptime":179860,"bootTime":1595276080,"procs":669,"os":"linux","platform":"ubuntu","platformFamily":"debian","platformVersion":"20.04","kernelVersion":"5.4.0-40-generic","virtualizationSystem":"kvm","virtualizationRole":"host","hostid":"b9a7bacc-2cc3-44bd-bb2c-7e78c04be6e0"}
I0722 15:12:20.056001  125103 start.go:111] virtualization: kvm host
😄  minikube v1.12.1 on Ubuntu 20.04
I0722 15:12:20.062302  125103 start_flags.go:384] config upgrade: KicBaseImage=gcr.io/k8s-minikube/kicbase:v0.0.10@sha256:f58e0c4662bac8a9b5dda7984b185bad8502ade5d9fa364bf2755d636ab51438
🆕  Kubernetes 1.18.3 is now available. If you would like to upgrade, specify: --kubernetes-version=v1.18.3
I0722 15:12:20.069990  125103 driver.go:287] Setting default libvirt URI to qemu:///system
I0722 15:12:20.130076  125103 docker.go:87] docker version: linux-19.03.8
✨  Using the docker driver based on existing profile
I0722 15:12:20.144477  125103 start.go:217] selected driver: docker
I0722 15:12:20.144502  125103 start.go:623] validating driver "docker" against &{Name:minikube KeepContext:false EmbedCerts:false MinikubeISO: KicBaseImage:gcr.io/k8s-minikube/kicbase:v0.0.10@sha256:f58e0c4662bac8a9b5dda7984b185bad8502ade5d9fa364bf2755d636ab51438 Memory:3900 CPUs:2 DiskSize:20000 VMDriver: Driver:docker HyperkitVpnKitSock: HyperkitVSockPorts:[] DockerEnv:[] InsecureRegistry:[] RegistryMirror:[] HostOnlyCIDR:192.168.99.1/24 HypervVirtualSwitch: HypervUseExternalSwitch:false HypervExternalAdapter: KVMNetwork:default KVMQemuURI:qemu:///system KVMGPU:false KVMHidden:false DockerOpt:[] DisableDriverMounts:false NFSShare:[] NFSSharesRoot:/nfsshares UUID: NoVTXCheck:false DNSProxy:false HostDNSResolver:true HostOnlyNicType:virtio NatNicType:virtio KubernetesConfig:{KubernetesVersion:v1.18.0 ClusterName:minikube APIServerName:minikubeCA APIServerNames:[] APIServerIPs:[] DNSDomain:cluster.local ContainerRuntime:docker CRISocket: NetworkPlugin: FeatureGates: ServiceCIDR:10.96.0.0/12 ImageRepository: LoadBalancerStartIP: LoadBalancerEndIP: ExtraOptions:[{Component:kubeadm Key:pod-network-cidr Value:10.244.0.0/16}] ShouldLoadCachedImages:true EnableDefaultCNI:false CNI: NodeIP: NodePort:0 NodeName:} Nodes:[{Name:m01 IP:172.17.0.2 Port:8443 KubernetesVersion:v1.18.0 ControlPlane:true Worker:true}] Addons:map[default-storageclass:true storage-provisioner:true] VerifyComponents:map[apiserver:true system_pods:true]}
I0722 15:12:20.145568  125103 start.go:634] status for docker: {Installed:true Healthy:true NeedsImprovement:false Error:<nil> Fix: Doc:}
I0722 15:12:20.145800  125103 cli_runner.go:109] Run: docker system info --format "{{json .}}"
I0722 15:12:20.199407  125103 start_flags.go:345] config:
{Name:minikube KeepContext:false EmbedCerts:false MinikubeISO: KicBaseImage:gcr.io/k8s-minikube/kicbase:v0.0.10@sha256:f58e0c4662bac8a9b5dda7984b185bad8502ade5d9fa364bf2755d636ab51438 Memory:3900 CPUs:2 DiskSize:20000 VMDriver: Driver:docker HyperkitVpnKitSock: HyperkitVSockPorts:[] DockerEnv:[] InsecureRegistry:[] RegistryMirror:[] HostOnlyCIDR:192.168.99.1/24 HypervVirtualSwitch: HypervUseExternalSwitch:false HypervExternalAdapter: KVMNetwork:default KVMQemuURI:qemu:///system KVMGPU:false KVMHidden:false DockerOpt:[] DisableDriverMounts:false NFSShare:[] NFSSharesRoot:/nfsshares UUID: NoVTXCheck:false DNSProxy:false HostDNSResolver:true HostOnlyNicType:virtio NatNicType:virtio KubernetesConfig:{KubernetesVersion:v1.18.0 ClusterName:minikube APIServerName:minikubeCA APIServerNames:[] APIServerIPs:[] DNSDomain:cluster.local ContainerRuntime:docker CRISocket: NetworkPlugin: FeatureGates: ServiceCIDR:10.96.0.0/12 ImageRepository: LoadBalancerStartIP: LoadBalancerEndIP: ExtraOptions:[{Component:kubeadm Key:pod-network-cidr Value:10.244.0.0/16}] ShouldLoadCachedImages:true EnableDefaultCNI:false CNI: NodeIP: NodePort:8443 NodeName:} Nodes:[{Name:m01 IP:172.17.0.2 Port:8443 KubernetesVersion:v1.18.0 ControlPlane:true Worker:true}] Addons:map[default-storageclass:true storage-provisioner:true] VerifyComponents:map[apiserver:true system_pods:true]}
👍  Starting control plane node minikube in cluster minikube
I0722 15:12:20.285167  125103 image.go:92] Found gcr.io/k8s-minikube/kicbase:v0.0.10@sha256:f58e0c4662bac8a9b5dda7984b185bad8502ade5d9fa364bf2755d636ab51438 in local docker daemon, skipping pull
I0722 15:12:20.285255  125103 cache.go:113] gcr.io/k8s-minikube/kicbase:v0.0.10@sha256:f58e0c4662bac8a9b5dda7984b185bad8502ade5d9fa364bf2755d636ab51438 exists in daemon, skipping pull
I0722 15:12:20.285293  125103 preload.go:97] Checking if preload exists for k8s version v1.18.0 and runtime docker
I0722 15:12:20.285401  125103 preload.go:105] Found local preload: /home/med/.minikube/cache/preloaded-tarball/preloaded-images-k8s-v4-v1.18.0-docker-overlay2-amd64.tar.lz4
I0722 15:12:20.285423  125103 cache.go:51] Caching tarball of preloaded images
I0722 15:12:20.285447  125103 preload.go:131] Found /home/med/.minikube/cache/preloaded-tarball/preloaded-images-k8s-v4-v1.18.0-docker-overlay2-amd64.tar.lz4 in cache, skipping download
I0722 15:12:20.285461  125103 cache.go:54] Finished verifying existence of preloaded tar for  v1.18.0 on docker
I0722 15:12:20.285696  125103 profile.go:150] Saving config to /home/med/.minikube/profiles/minikube/config.json ...
I0722 15:12:20.286069  125103 cache.go:178] Successfully downloaded all kic artifacts
I0722 15:12:20.286117  125103 start.go:241] acquiring machines lock for minikube: {Name:mk6a500be5d8da551e6c866918d2ce848b848c96 Clock:{} Delay:500ms Timeout:15m0s Cancel:<nil>}
I0722 15:12:20.286296  125103 start.go:245] acquired machines lock for "minikube" in 147.472µs
I0722 15:12:20.286321  125103 start.go:89] Skipping create...Using existing machine configuration
I0722 15:12:20.286333  125103 fix.go:53] fixHost starting: m01
I0722 15:12:20.286669  125103 cli_runner.go:109] Run: docker container inspect minikube --format={{.State.Status}}
I0722 15:12:20.325680  125103 fix.go:105] recreateIfNeeded on minikube: state=Running err=<nil>
W0722 15:12:20.325706  125103 fix.go:131] unexpected machine state, will restart: <nil>
🏃  Updating the running docker "minikube" container ...
I0722 15:12:20.334164  125103 machine.go:88] provisioning docker machine ...
I0722 15:12:20.334254  125103 ubuntu.go:166] provisioning hostname "minikube"
I0722 15:12:20.334381  125103 cli_runner.go:109] Run: docker container inspect -f "'{{(index (index .NetworkSettings.Ports "22/tcp") 0).HostPort}}'" minikube
I0722 15:12:20.380867  125103 main.go:115] libmachine: Using SSH client type: native
I0722 15:12:20.381049  125103 main.go:115] libmachine: &{{{<nil> 0 [] [] []} docker [0x7bfc80] 0x7bfc50 <nil>  [] 0s} 127.0.0.1 32776 <nil> <nil>}
I0722 15:12:20.381069  125103 main.go:115] libmachine: About to run SSH command:
sudo hostname minikube && echo "minikube" | sudo tee /etc/hostname
I0722 15:12:20.516843  125103 main.go:115] libmachine: SSH cmd err, output: <nil>: minikube

I0722 15:12:20.517003  125103 cli_runner.go:109] Run: docker container inspect -f "'{{(index (index .NetworkSettings.Ports "22/tcp") 0).HostPort}}'" minikube
I0722 15:12:20.565962  125103 main.go:115] libmachine: Using SSH client type: native
I0722 15:12:20.566197  125103 main.go:115] libmachine: &{{{<nil> 0 [] [] []} docker [0x7bfc80] 0x7bfc50 <nil>  [] 0s} 127.0.0.1 32776 <nil> <nil>}
I0722 15:12:20.566231  125103 main.go:115] libmachine: About to run SSH command:

                if ! grep -xq '.*\sminikube' /etc/hosts; then
                        if grep -xq '127.0.1.1\s.*' /etc/hosts; then
                                sudo sed -i 's/^127.0.1.1\s.*/127.0.1.1 minikube/g' /etc/hosts;
                        else 
                                echo '127.0.1.1 minikube' | sudo tee -a /etc/hosts; 
                        fi
                fi
I0722 15:12:20.690374  125103 main.go:115] libmachine: SSH cmd err, output: <nil>: 
I0722 15:12:20.690430  125103 ubuntu.go:172] set auth options {CertDir:/home/med/.minikube CaCertPath:/home/med/.minikube/certs/ca.pem CaPrivateKeyPath:/home/med/.minikube/certs/ca-key.pem CaCertRemotePath:/etc/docker/ca.pem ServerCertPath:/home/med/.minikube/machines/server.pem ServerKeyPath:/home/med/.minikube/machines/server-key.pem ClientKeyPath:/home/med/.minikube/certs/key.pem ServerCertRemotePath:/etc/docker/server.pem ServerKeyRemotePath:/etc/docker/server-key.pem ClientCertPath:/home/med/.minikube/certs/cert.pem ServerCertSANs:[] StorePath:/home/med/.minikube}
I0722 15:12:20.690488  125103 ubuntu.go:174] setting up certificates
I0722 15:12:20.690532  125103 provision.go:82] configureAuth start
I0722 15:12:20.690645  125103 cli_runner.go:109] Run: docker container inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}},{{.GlobalIPv6Address}}{{end}}" minikube
I0722 15:12:20.742458  125103 provision.go:131] copyHostCerts
I0722 15:12:20.742588  125103 exec_runner.go:91] found /home/med/.minikube/cert.pem, removing ...
I0722 15:12:20.742724  125103 exec_runner.go:98] cp: /home/med/.minikube/certs/cert.pem --> /home/med/.minikube/cert.pem (1066 bytes)
I0722 15:12:20.742913  125103 exec_runner.go:91] found /home/med/.minikube/key.pem, removing ...
I0722 15:12:20.742983  125103 exec_runner.go:98] cp: /home/med/.minikube/certs/key.pem --> /home/med/.minikube/key.pem (1679 bytes)
I0722 15:12:20.743120  125103 exec_runner.go:91] found /home/med/.minikube/ca.pem, removing ...
I0722 15:12:20.743181  125103 exec_runner.go:98] cp: /home/med/.minikube/certs/ca.pem --> /home/med/.minikube/ca.pem (1029 bytes)
I0722 15:12:20.743389  125103 provision.go:105] generating server cert: /home/med/.minikube/machines/server.pem ca-key=/home/med/.minikube/certs/ca.pem private-key=/home/med/.minikube/certs/ca-key.pem org=med.minikube san=[172.17.0.2 localhost 127.0.0.1]
I0722 15:12:21.150320  125103 provision.go:159] copyRemoteCerts
I0722 15:12:21.150440  125103 ssh_runner.go:148] Run: sudo mkdir -p /etc/docker /etc/docker /etc/docker
I0722 15:12:21.150480  125103 cli_runner.go:109] Run: docker container inspect -f "'{{(index (index .NetworkSettings.Ports "22/tcp") 0).HostPort}}'" minikube
I0722 15:12:21.200892  125103 sshutil.go:44] new ssh client: &{IP:127.0.0.1 Port:32776 SSHKeyPath:/home/med/.minikube/machines/minikube/id_rsa Username:docker}
I0722 15:12:21.289759  125103 ssh_runner.go:215] scp /home/med/.minikube/certs/ca.pem --> /etc/docker/ca.pem (1029 bytes)
I0722 15:12:21.312740  125103 ssh_runner.go:215] scp /home/med/.minikube/machines/server.pem --> /etc/docker/server.pem (1111 bytes)
I0722 15:12:21.330050  125103 ssh_runner.go:215] scp /home/med/.minikube/machines/server-key.pem --> /etc/docker/server-key.pem (1679 bytes)
I0722 15:12:21.384860  125103 provision.go:85] duration metric: configureAuth took 694.293234ms
I0722 15:12:21.384891  125103 ubuntu.go:190] setting minikube options for container-runtime
I0722 15:12:21.385073  125103 cli_runner.go:109] Run: docker container inspect -f "'{{(index (index .NetworkSettings.Ports "22/tcp") 0).HostPort}}'" minikube
I0722 15:12:21.440071  125103 main.go:115] libmachine: Using SSH client type: native
I0722 15:12:21.440259  125103 main.go:115] libmachine: &{{{<nil> 0 [] [] []} docker [0x7bfc80] 0x7bfc50 <nil>  [] 0s} 127.0.0.1 32776 <nil> <nil>}
I0722 15:12:21.440284  125103 main.go:115] libmachine: About to run SSH command:
df --output=fstype / | tail -n 1
I0722 15:12:21.552411  125103 main.go:115] libmachine: SSH cmd err, output: <nil>: overlay

I0722 15:12:21.552450  125103 ubuntu.go:71] root file system type: overlay
I0722 15:12:21.552612  125103 provision.go:290] Updating docker unit: /lib/systemd/system/docker.service ...
I0722 15:12:21.552700  125103 cli_runner.go:109] Run: docker container inspect -f "'{{(index (index .NetworkSettings.Ports "22/tcp") 0).HostPort}}'" minikube
I0722 15:12:21.606971  125103 main.go:115] libmachine: Using SSH client type: native
I0722 15:12:21.607245  125103 main.go:115] libmachine: &{{{<nil> 0 [] [] []} docker [0x7bfc80] 0x7bfc50 <nil>  [] 0s} 127.0.0.1 32776 <nil> <nil>}
I0722 15:12:21.607397  125103 main.go:115] libmachine: About to run SSH command:
sudo mkdir -p /lib/systemd/system && printf %s "[Unit]
Description=Docker Application Container Engine
Documentation=https://docs.docker.com
BindsTo=containerd.service
After=network-online.target firewalld.service containerd.service
Wants=network-online.target
Requires=docker.socket

[Service]
Type=notify



# This file is a systemd drop-in unit that inherits from the base dockerd configuration.
# The base configuration already specifies an 'ExecStart=...' command. The first directive
# here is to clear out that command inherited from the base configuration. Without this,
# the command from the base configuration and the command specified here are treated as
# a sequence of commands, which is not the desired behavior, nor is it valid -- systemd
# will catch this invalid input and refuse to start the service with an error like:
#  Service has more than one ExecStart= setting, which is only allowed for Type=oneshot services.

# NOTE: default-ulimit=nofile is set to an arbitrary number for consistency with other
# container runtimes. If left unlimited, it may result in OOM issues with MySQL.
ExecStart=
ExecStart=/usr/bin/dockerd -H tcp://0.0.0.0:2376 -H unix:///var/run/docker.sock --default-ulimit=nofile=1048576:1048576 --tlsverify --tlscacert /etc/docker/ca.pem --tlscert /etc/docker/server.pem --tlskey /etc/docker/server-key.pem --label provider=docker --insecure-registry 10.96.0.0/12 
ExecReload=/bin/kill -s HUP $MAINPID

# Having non-zero Limit*s causes performance problems due to accounting overhead
# in the kernel. We recommend using cgroups to do container-local accounting.
LimitNOFILE=infinity
LimitNPROC=infinity
LimitCORE=infinity

# Uncomment TasksMax if your systemd version supports it.
# Only systemd 226 and above support this version.
TasksMax=infinity
TimeoutStartSec=0

# set delegate yes so that systemd does not reset the cgroups of docker containers
Delegate=yes

# kill only the docker process, not all processes in the cgroup
KillMode=process

[Install]
WantedBy=multi-user.target
" | sudo tee /lib/systemd/system/docker.service.new
I0722 15:12:21.741561  125103 main.go:115] libmachine: SSH cmd err, output: <nil>: [Unit]
Description=Docker Application Container Engine
Documentation=https://docs.docker.com
BindsTo=containerd.service
After=network-online.target firewalld.service containerd.service
Wants=network-online.target
Requires=docker.socket

[Service]
Type=notify



# This file is a systemd drop-in unit that inherits from the base dockerd configuration.
# The base configuration already specifies an 'ExecStart=...' command. The first directive
# here is to clear out that command inherited from the base configuration. Without this,
# the command from the base configuration and the command specified here are treated as
# a sequence of commands, which is not the desired behavior, nor is it valid -- systemd
# will catch this invalid input and refuse to start the service with an error like:
#  Service has more than one ExecStart= setting, which is only allowed for Type=oneshot services.

# NOTE: default-ulimit=nofile is set to an arbitrary number for consistency with other
# container runtimes. If left unlimited, it may result in OOM issues with MySQL.
ExecStart=
ExecStart=/usr/bin/dockerd -H tcp://0.0.0.0:2376 -H unix:///var/run/docker.sock --default-ulimit=nofile=1048576:1048576 --tlsverify --tlscacert /etc/docker/ca.pem --tlscert /etc/docker/server.pem --tlskey /etc/docker/server-key.pem --label provider=docker --insecure-registry 10.96.0.0/12 
ExecReload=/bin/kill -s HUP 

# Having non-zero Limit*s causes performance problems due to accounting overhead
# in the kernel. We recommend using cgroups to do container-local accounting.
LimitNOFILE=infinity
LimitNPROC=infinity
LimitCORE=infinity

# Uncomment TasksMax if your systemd version supports it.
# Only systemd 226 and above support this version.
TasksMax=infinity
TimeoutStartSec=0

# set delegate yes so that systemd does not reset the cgroups of docker containers
Delegate=yes

# kill only the docker process, not all processes in the cgroup
KillMode=process

[Install]
WantedBy=multi-user.target

I0722 15:12:21.741666  125103 cli_runner.go:109] Run: docker container inspect -f "'{{(index (index .NetworkSettings.Ports "22/tcp") 0).HostPort}}'" minikube
I0722 15:12:21.787016  125103 main.go:115] libmachine: Using SSH client type: native
I0722 15:12:21.787364  125103 main.go:115] libmachine: &{{{<nil> 0 [] [] []} docker [0x7bfc80] 0x7bfc50 <nil>  [] 0s} 127.0.0.1 32776 <nil> <nil>}
I0722 15:12:21.787408  125103 main.go:115] libmachine: About to run SSH command:
sudo diff -u /lib/systemd/system/docker.service /lib/systemd/system/docker.service.new || { sudo mv /lib/systemd/system/docker.service.new /lib/systemd/system/docker.service; sudo systemctl -f daemon-reload && sudo systemctl -f enable docker && sudo systemctl -f restart docker; }
I0722 15:12:21.931878  125103 main.go:115] libmachine: SSH cmd err, output: <nil>: 
I0722 15:12:21.931912  125103 machine.go:91] provisioned docker machine in 1.597724999s
I0722 15:12:21.931929  125103 start.go:204] post-start starting for "minikube" (driver="docker")
I0722 15:12:21.931943  125103 start.go:214] creating required directories: [/etc/kubernetes/addons /etc/kubernetes/manifests /var/tmp/minikube /var/lib/minikube /var/lib/minikube/certs /var/lib/minikube/images /var/lib/minikube/binaries /tmp/gvisor /usr/share/ca-certificates /etc/ssl/certs]
I0722 15:12:21.932000  125103 ssh_runner.go:148] Run: sudo mkdir -p /etc/kubernetes/addons /etc/kubernetes/manifests /var/tmp/minikube /var/lib/minikube /var/lib/minikube/certs /var/lib/minikube/images /var/lib/minikube/binaries /tmp/gvisor /usr/share/ca-certificates /etc/ssl/certs
I0722 15:12:21.932046  125103 cli_runner.go:109] Run: docker container inspect -f "'{{(index (index .NetworkSettings.Ports "22/tcp") 0).HostPort}}'" minikube
I0722 15:12:21.982494  125103 sshutil.go:44] new ssh client: &{IP:127.0.0.1 Port:32776 SSHKeyPath:/home/med/.minikube/machines/minikube/id_rsa Username:docker}
I0722 15:12:22.067441  125103 ssh_runner.go:148] Run: cat /etc/os-release
I0722 15:12:22.070685  125103 main.go:115] libmachine: Couldn't set key PRIVACY_POLICY_URL, no corresponding struct field found
I0722 15:12:22.070741  125103 main.go:115] libmachine: Couldn't set key VERSION_CODENAME, no corresponding struct field found
I0722 15:12:22.070775  125103 main.go:115] libmachine: Couldn't set key UBUNTU_CODENAME, no corresponding struct field found
I0722 15:12:22.070795  125103 info.go:96] Remote host: Ubuntu 19.10
I0722 15:12:22.070825  125103 filesync.go:118] Scanning /home/med/.minikube/addons for local assets ...
I0722 15:12:22.070925  125103 filesync.go:118] Scanning /home/med/.minikube/files for local assets ...
I0722 15:12:22.070980  125103 start.go:207] post-start completed in 139.035068ms
I0722 15:12:22.071010  125103 fix.go:55] fixHost completed within 1.784674123s
I0722 15:12:22.071030  125103 start.go:76] releasing machines lock for "minikube", held for 1.784715928s
I0722 15:12:22.071138  125103 cli_runner.go:109] Run: docker container inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}},{{.GlobalIPv6Address}}{{end}}" minikube
I0722 15:12:22.117856  125103 ssh_runner.go:148] Run: systemctl --version
I0722 15:12:22.117890  125103 ssh_runner.go:148] Run: curl -sS -m 2 https://k8s.gcr.io/
I0722 15:12:22.117914  125103 cli_runner.go:109] Run: docker container inspect -f "'{{(index (index .NetworkSettings.Ports "22/tcp") 0).HostPort}}'" minikube
I0722 15:12:22.117945  125103 cli_runner.go:109] Run: docker container inspect -f "'{{(index (index .NetworkSettings.Ports "22/tcp") 0).HostPort}}'" minikube
I0722 15:12:22.170000  125103 sshutil.go:44] new ssh client: &{IP:127.0.0.1 Port:32776 SSHKeyPath:/home/med/.minikube/machines/minikube/id_rsa Username:docker}
I0722 15:12:22.170142  125103 sshutil.go:44] new ssh client: &{IP:127.0.0.1 Port:32776 SSHKeyPath:/home/med/.minikube/machines/minikube/id_rsa Username:docker}
I0722 15:12:22.252695  125103 ssh_runner.go:148] Run: sudo systemctl is-active --quiet service containerd
I0722 15:12:22.469449  125103 ssh_runner.go:148] Run: sudo systemctl cat docker.service
I0722 15:12:22.483535  125103 cruntime.go:192] skipping containerd shutdown because we are bound to it
I0722 15:12:22.483602  125103 ssh_runner.go:148] Run: sudo systemctl is-active --quiet service crio
I0722 15:12:22.492516  125103 ssh_runner.go:148] Run: sudo systemctl cat docker.service
I0722 15:12:22.501852  125103 ssh_runner.go:148] Run: sudo systemctl daemon-reload
I0722 15:12:22.648762  125103 ssh_runner.go:148] Run: sudo systemctl start docker
I0722 15:12:22.660429  125103 ssh_runner.go:148] Run: docker version --format {{.Server.Version}}
🐳  Preparing Kubernetes v1.18.0 on Docker 19.03.2 ...
I0722 15:12:22.803873  125103 cli_runner.go:109] Run: docker network ls --filter name=bridge --format {{.ID}}
I0722 15:12:22.854536  125103 cli_runner.go:109] Run: docker network inspect --format "{{(index .IPAM.Config 0).Gateway}}" 5556d7d3c222
I0722 15:12:22.898896  125103 network.go:77] got host ip for mount in container by inspect docker network: 172.17.0.1
I0722 15:12:22.898963  125103 ssh_runner.go:148] Run: grep 172.17.0.1   host.minikube.internal$ /etc/hosts
I0722 15:12:22.901599  125103 ssh_runner.go:148] Run: /bin/bash -c "{ grep -v '\thost.minikube.internal$' /etc/hosts; echo "172.17.0.1  host.minikube.internal"; } > /tmp/h.$$; sudo cp /tmp/h.$$ /etc/hosts"
I0722 15:12:22.930282  125103 preload.go:97] Checking if preload exists for k8s version v1.18.0 and runtime docker
I0722 15:12:22.930318  125103 preload.go:105] Found local preload: /home/med/.minikube/cache/preloaded-tarball/preloaded-images-k8s-v4-v1.18.0-docker-overlay2-amd64.tar.lz4
I0722 15:12:22.930367  125103 ssh_runner.go:148] Run: docker images --format {{.Repository}}:{{.Tag}}
I0722 15:12:22.988000  125103 docker.go:381] Got preloaded images: -- stdout --
k8s.gcr.io/kube-proxy:v1.18.0
k8s.gcr.io/kube-scheduler:v1.18.0
k8s.gcr.io/kube-apiserver:v1.18.0
k8s.gcr.io/kube-controller-manager:v1.18.0
kubernetesui/dashboard:v2.0.0-rc6
k8s.gcr.io/pause:3.2
k8s.gcr.io/coredns:1.6.7
kindest/kindnetd:0.5.3
k8s.gcr.io/etcd:3.4.3-0
kubernetesui/metrics-scraper:v1.0.2
gcr.io/k8s-minikube/storage-provisioner:v1.8.1

-- /stdout --
I0722 15:12:22.988030  125103 docker.go:386] kubernetesui/dashboard:v2.0.1 wasn't preloaded
I0722 15:12:22.988102  125103 ssh_runner.go:148] Run: sudo cat /var/lib/docker/image/overlay2/repositories.json
I0722 15:12:23.000828  125103 ssh_runner.go:148] Run: which lz4
I0722 15:12:23.005524  125103 ssh_runner.go:148] Run: stat -c "%s %y" /preloaded.tar.lz4
I0722 15:12:23.008125  125103 ssh_runner.go:205] existence check for /preloaded.tar.lz4: stat -c "%s %y" /preloaded.tar.lz4: Process exited with status 1
stdout:

stderr:
stat: cannot stat '/preloaded.tar.lz4': No such file or directory
I0722 15:12:23.008152  125103 ssh_runner.go:215] scp /home/med/.minikube/cache/preloaded-tarball/preloaded-images-k8s-v4-v1.18.0-docker-overlay2-amd64.tar.lz4 --> /preloaded.tar.lz4 (551216175 bytes)
I0722 15:12:24.663377  125103 docker.go:347] Took 1.657884 seconds to copy over tarball
I0722 15:12:24.663456  125103 ssh_runner.go:148] Run: sudo tar -I lz4 -C /var -xvf /preloaded.tar.lz4
I0722 15:12:27.870903  125103 ssh_runner.go:188] Completed: sudo tar -I lz4 -C /var -xvf /preloaded.tar.lz4: (3.207388289s)
I0722 15:12:27.870959  125103 ssh_runner.go:99] rm: /preloaded.tar.lz4
I0722 15:12:29.686532  125103 ssh_runner.go:148] Run: sudo cat /var/lib/docker/image/overlay2/repositories.json
I0722 15:12:29.952338  125103 ssh_runner.go:215] scp memory --> /var/lib/docker/image/overlay2/repositories.json (3413 bytes)
I0722 15:12:30.187035  125103 ssh_runner.go:148] Run: sudo systemctl daemon-reload
I0722 15:12:30.291726  125103 ssh_runner.go:148] Run: sudo systemctl restart docker
I0722 15:12:54.078804  125103 ssh_runner.go:188] Completed: sudo systemctl restart docker: (23.787035154s)
I0722 15:12:54.078948  125103 ssh_runner.go:148] Run: docker images --format {{.Repository}}:{{.Tag}}
I0722 15:12:54.140021  125103 docker.go:381] Got preloaded images: -- stdout --
kubernetesui/dashboard:v2.0.1
kubernetesui/metrics-scraper:v1.0.4
k8s.gcr.io/kube-proxy:v1.18.0
k8s.gcr.io/kube-apiserver:v1.18.0
k8s.gcr.io/kube-controller-manager:v1.18.0
k8s.gcr.io/kube-scheduler:v1.18.0
<none>:<none>
k8s.gcr.io/pause:3.2
k8s.gcr.io/coredns:1.6.7
kindest/kindnetd:0.5.3
k8s.gcr.io/etcd:3.4.3-0
<none>:<none>
gcr.io/k8s-minikube/storage-provisioner:v1.8.1

-- /stdout --
I0722 15:12:54.140054  125103 cache_images.go:69] Images are preloaded, skipping loading
I0722 15:12:54.140126  125103 ssh_runner.go:148] Run: docker info --format {{.CgroupDriver}}
I0722 15:12:54.202973  125103 cni.go:74] Creating CNI manager for ""
I0722 15:12:54.202998  125103 cni.go:117] CNI unnecessary in this configuration, recommending no CNI
I0722 15:12:54.203011  125103 kubeadm.go:84] Using pod CIDR: 10.244.0.0/16
I0722 15:12:54.203031  125103 kubeadm.go:150] kubeadm options: {CertDir:/var/lib/minikube/certs ServiceCIDR:10.96.0.0/12 PodSubnet:10.244.0.0/16 AdvertiseAddress:172.17.0.2 APIServerPort:8443 KubernetesVersion:v1.18.0 EtcdDataDir:/var/lib/minikube/etcd EtcdExtraArgs:map[] ClusterName:minikube NodeName:minikube DNSDomain:cluster.local CRISocket: ImageRepository: ComponentOptions:[{Component:apiServer ExtraArgs:map[enable-admission-plugins:NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota] Pairs:map[certSANs:["127.0.0.1", "localhost", "172.17.0.2"]]}] FeatureArgs:map[] NoTaintMaster:true NodeIP:172.17.0.2 CgroupDriver:cgroupfs ClientCAFile:/var/lib/minikube/certs/ca.crt StaticPodPath:/etc/kubernetes/manifests ControlPlaneAddress:control-plane.minikube.internal KubeProxyOptions:map[]}
I0722 15:12:54.203154  125103 kubeadm.go:154] kubeadm config:
apiVersion: kubeadm.k8s.io/v1beta2
kind: InitConfiguration
localAPIEndpoint:
  advertiseAddress: 172.17.0.2
  bindPort: 8443
bootstrapTokens:
  - groups:
      - system:bootstrappers:kubeadm:default-node-token
    ttl: 24h0m0s
    usages:
      - signing
      - authentication
nodeRegistration:
  criSocket: /var/run/dockershim.sock
  name: "minikube"
  kubeletExtraArgs:
    node-ip: 172.17.0.2
  taints: []
---
apiVersion: kubeadm.k8s.io/v1beta2
kind: ClusterConfiguration
apiServer:
  certSANs: ["127.0.0.1", "localhost", "172.17.0.2"]
  extraArgs:
    enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
certificatesDir: /var/lib/minikube/certs
clusterName: mk
controlPlaneEndpoint: control-plane.minikube.internal:8443
dns:
  type: CoreDNS
etcd:
  local:
    dataDir: /var/lib/minikube/etcd
controllerManager:
  extraArgs:
    "leader-elect": "false"
scheduler:
  extraArgs:
    "leader-elect": "false"
kubernetesVersion: v1.18.0
networking:
  dnsDomain: cluster.local
  podSubnet: "10.244.0.0/16"
  serviceSubnet: 10.96.0.0/12
---
apiVersion: kubelet.config.k8s.io/v1beta1
kind: KubeletConfiguration
authentication:
  x509:
    clientCAFile: /var/lib/minikube/certs/ca.crt
cgroupDriver: cgroupfs
clusterDomain: "cluster.local"
# disable disk resource management by default
imageGCHighThresholdPercent: 100
evictionHard:
  nodefs.available: "0%"
  nodefs.inodesFree: "0%"
  imagefs.available: "0%"
failSwapOn: false
staticPodPath: /etc/kubernetes/manifests
---
apiVersion: kubeproxy.config.k8s.io/v1alpha1
kind: KubeProxyConfiguration
clusterCIDR: "10.244.0.0/16"
metricsBindAddress: 172.17.0.2:10249

I0722 15:12:54.203255  125103 kubeadm.go:790] kubelet [Unit]
Wants=docker.socket

[Service]
ExecStart=
ExecStart=/var/lib/minikube/binaries/v1.18.0/kubelet --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --config=/var/lib/kubelet/config.yaml --container-runtime=docker --hostname-override=minikube --kubeconfig=/etc/kubernetes/kubelet.conf --node-ip=172.17.0.2

[Install]
 config:
{KubernetesVersion:v1.18.0 ClusterName:minikube APIServerName:minikubeCA APIServerNames:[] APIServerIPs:[] DNSDomain:cluster.local ContainerRuntime:docker CRISocket: NetworkPlugin: FeatureGates: ServiceCIDR:10.96.0.0/12 ImageRepository: LoadBalancerStartIP: LoadBalancerEndIP: ExtraOptions:[{Component:kubeadm Key:pod-network-cidr Value:10.244.0.0/16}] ShouldLoadCachedImages:true EnableDefaultCNI:false CNI: NodeIP: NodePort:8443 NodeName:}
I0722 15:12:54.203325  125103 ssh_runner.go:148] Run: sudo ls /var/lib/minikube/binaries/v1.18.0
I0722 15:12:54.209433  125103 binaries.go:43] Found k8s binaries, skipping transfer
I0722 15:12:54.209506  125103 ssh_runner.go:148] Run: sudo mkdir -p /etc/systemd/system/kubelet.service.d /lib/systemd/system /var/tmp/minikube
I0722 15:12:54.217005  125103 ssh_runner.go:215] scp memory --> /etc/systemd/system/kubelet.service.d/10-kubeadm.conf (332 bytes)
I0722 15:12:54.236241  125103 ssh_runner.go:215] scp memory --> /lib/systemd/system/kubelet.service (349 bytes)
I0722 15:12:54.261120  125103 ssh_runner.go:215] scp memory --> /var/tmp/minikube/kubeadm.yaml.new (1756 bytes)
I0722 15:12:54.280185  125103 ssh_runner.go:148] Run: grep 172.17.0.2   control-plane.minikube.internal$ /etc/hosts
I0722 15:12:54.285004  125103 ssh_runner.go:148] Run: /bin/bash -c "{ grep -v '\tcontrol-plane.minikube.internal$' /etc/hosts; echo "172.17.0.2 control-plane.minikube.internal"; } > /tmp/h.$$; sudo cp /tmp/h.$$ /etc/hosts"
I0722 15:12:54.300202  125103 ssh_runner.go:148] Run: sudo systemctl daemon-reload
I0722 15:12:54.374501  125103 ssh_runner.go:148] Run: sudo systemctl start kubelet
I0722 15:12:54.388126  125103 certs.go:52] Setting up /home/med/.minikube/profiles/minikube for IP: 172.17.0.2
I0722 15:12:54.388183  125103 certs.go:169] skipping minikubeCA CA generation: /home/med/.minikube/ca.key
I0722 15:12:54.388208  125103 certs.go:169] skipping proxyClientCA CA generation: /home/med/.minikube/proxy-client-ca.key
I0722 15:12:54.388268  125103 certs.go:269] skipping minikube-user signed cert generation: /home/med/.minikube/profiles/minikube/client.key
I0722 15:12:54.388292  125103 certs.go:273] generating minikube signed cert: /home/med/.minikube/profiles/minikube/apiserver.key.7b749c5f
I0722 15:12:54.388304  125103 crypto.go:69] Generating cert /home/med/.minikube/profiles/minikube/apiserver.crt.7b749c5f with IP's: [172.17.0.2 10.96.0.1 127.0.0.1 10.0.0.1]
I0722 15:12:54.566904  125103 crypto.go:157] Writing cert to /home/med/.minikube/profiles/minikube/apiserver.crt.7b749c5f ...
I0722 15:12:54.566932  125103 lock.go:35] WriteFile acquiring /home/med/.minikube/profiles/minikube/apiserver.crt.7b749c5f: {Name:mk21bf082ac03a9cde140e630ecb41c4c124efd7 Clock:{} Delay:500ms Timeout:1m0s Cancel:<nil>}
I0722 15:12:54.567106  125103 crypto.go:165] Writing key to /home/med/.minikube/profiles/minikube/apiserver.key.7b749c5f ...
I0722 15:12:54.567120  125103 lock.go:35] WriteFile acquiring /home/med/.minikube/profiles/minikube/apiserver.key.7b749c5f: {Name:mk70d0e6febd3f98e041397de6b5b60ab6bd6a0e Clock:{} Delay:500ms Timeout:1m0s Cancel:<nil>}
I0722 15:12:54.567206  125103 certs.go:284] copying /home/med/.minikube/profiles/minikube/apiserver.crt.7b749c5f -> /home/med/.minikube/profiles/minikube/apiserver.crt
I0722 15:12:54.568226  125103 certs.go:288] copying /home/med/.minikube/profiles/minikube/apiserver.key.7b749c5f -> /home/med/.minikube/profiles/minikube/apiserver.key
I0722 15:12:54.568323  125103 certs.go:269] skipping aggregator signed cert generation: /home/med/.minikube/profiles/minikube/proxy-client.key
I0722 15:12:54.568450  125103 certs.go:348] found cert: /home/med/.minikube/certs/home/med/.minikube/certs/ca-key.pem (1675 bytes)
I0722 15:12:54.568499  125103 certs.go:348] found cert: /home/med/.minikube/certs/home/med/.minikube/certs/ca.pem (1029 bytes)
I0722 15:12:54.568536  125103 certs.go:348] found cert: /home/med/.minikube/certs/home/med/.minikube/certs/cert.pem (1066 bytes)
I0722 15:12:54.568566  125103 certs.go:348] found cert: /home/med/.minikube/certs/home/med/.minikube/certs/key.pem (1679 bytes)
I0722 15:12:54.569402  125103 ssh_runner.go:215] scp /home/med/.minikube/profiles/minikube/apiserver.crt --> /var/lib/minikube/certs/apiserver.crt (1350 bytes)
I0722 15:12:54.592000  125103 ssh_runner.go:215] scp /home/med/.minikube/profiles/minikube/apiserver.key --> /var/lib/minikube/certs/apiserver.key (1679 bytes)
I0722 15:12:54.608408  125103 ssh_runner.go:215] scp /home/med/.minikube/profiles/minikube/proxy-client.crt --> /var/lib/minikube/certs/proxy-client.crt (1103 bytes)
I0722 15:12:54.627434  125103 ssh_runner.go:215] scp /home/med/.minikube/profiles/minikube/proxy-client.key --> /var/lib/minikube/certs/proxy-client.key (1679 bytes)
I0722 15:12:54.644318  125103 ssh_runner.go:215] scp /home/med/.minikube/ca.crt --> /var/lib/minikube/certs/ca.crt (1066 bytes)
I0722 15:12:54.665554  125103 ssh_runner.go:215] scp /home/med/.minikube/ca.key --> /var/lib/minikube/certs/ca.key (1679 bytes)
I0722 15:12:54.681384  125103 ssh_runner.go:215] scp /home/med/.minikube/proxy-client-ca.crt --> /var/lib/minikube/certs/proxy-client-ca.crt (1074 bytes)
I0722 15:12:54.698131  125103 ssh_runner.go:215] scp /home/med/.minikube/proxy-client-ca.key --> /var/lib/minikube/certs/proxy-client-ca.key (1679 bytes)
I0722 15:12:54.723622  125103 ssh_runner.go:215] scp /home/med/.minikube/ca.crt --> /usr/share/ca-certificates/minikubeCA.pem (1066 bytes)
I0722 15:12:54.740244  125103 ssh_runner.go:215] scp memory --> /var/lib/minikube/kubeconfig (398 bytes)
I0722 15:12:54.763379  125103 ssh_runner.go:148] Run: openssl version
I0722 15:12:54.775169  125103 ssh_runner.go:148] Run: sudo /bin/bash -c "test -s /usr/share/ca-certificates/minikubeCA.pem && ln -fs /usr/share/ca-certificates/minikubeCA.pem /etc/ssl/certs/minikubeCA.pem"
I0722 15:12:54.782250  125103 ssh_runner.go:148] Run: ls -la /usr/share/ca-certificates/minikubeCA.pem
I0722 15:12:54.784743  125103 certs.go:389] hashing: -rw-r--r-- 1 root root 1066 Jul 22 21:32 /usr/share/ca-certificates/minikubeCA.pem
I0722 15:12:54.784798  125103 ssh_runner.go:148] Run: openssl x509 -hash -noout -in /usr/share/ca-certificates/minikubeCA.pem
I0722 15:12:54.788738  125103 ssh_runner.go:148] Run: sudo /bin/bash -c "test -L /etc/ssl/certs/b5213941.0 || ln -fs /etc/ssl/certs/minikubeCA.pem /etc/ssl/certs/b5213941.0"
I0722 15:12:54.795872  125103 kubeadm.go:327] StartCluster: {Name:minikube KeepContext:false EmbedCerts:false MinikubeISO: KicBaseImage:gcr.io/k8s-minikube/kicbase:v0.0.10@sha256:f58e0c4662bac8a9b5dda7984b185bad8502ade5d9fa364bf2755d636ab51438 Memory:3900 CPUs:2 DiskSize:20000 VMDriver: Driver:docker HyperkitVpnKitSock: HyperkitVSockPorts:[] DockerEnv:[] InsecureRegistry:[] RegistryMirror:[] HostOnlyCIDR:192.168.99.1/24 HypervVirtualSwitch: HypervUseExternalSwitch:false HypervExternalAdapter: KVMNetwork:default KVMQemuURI:qemu:///system KVMGPU:false KVMHidden:false DockerOpt:[] DisableDriverMounts:false NFSShare:[] NFSSharesRoot:/nfsshares UUID: NoVTXCheck:false DNSProxy:false HostDNSResolver:true HostOnlyNicType:virtio NatNicType:virtio KubernetesConfig:{KubernetesVersion:v1.18.0 ClusterName:minikube APIServerName:minikubeCA APIServerNames:[] APIServerIPs:[] DNSDomain:cluster.local ContainerRuntime:docker CRISocket: NetworkPlugin: FeatureGates: ServiceCIDR:10.96.0.0/12 ImageRepository: LoadBalancerStartIP: LoadBalancerEndIP: ExtraOptions:[{Component:kubeadm Key:pod-network-cidr Value:10.244.0.0/16}] ShouldLoadCachedImages:true EnableDefaultCNI:false CNI: NodeIP: NodePort:8443 NodeName:} Nodes:[{Name:m01 IP:172.17.0.2 Port:8443 KubernetesVersion:v1.18.0 ControlPlane:true Worker:true}] Addons:map[default-storageclass:true storage-provisioner:true] VerifyComponents:map[apiserver:true system_pods:true]}
I0722 15:12:54.796027  125103 ssh_runner.go:148] Run: docker ps --filter status=paused --filter=name=k8s_.*_(kube-system)_ --format={{.ID}}
I0722 15:12:54.844909  125103 ssh_runner.go:148] Run: sudo ls /var/lib/kubelet/kubeadm-flags.env /var/lib/kubelet/config.yaml /var/lib/minikube/etcd
I0722 15:12:54.850963  125103 kubeadm.go:338] found existing configuration files, will attempt cluster restart
I0722 15:12:54.850989  125103 kubeadm.go:512] restartCluster start
I0722 15:12:54.851038  125103 ssh_runner.go:148] Run: sudo test -d /data/minikube
I0722 15:12:54.858144  125103 kubeadm.go:122] /data/minikube skipping compat symlinks: sudo test -d /data/minikube: Process exited with status 1
stdout:

stderr:
I0722 15:12:54.861916  125103 ssh_runner.go:148] Run: sudo diff -u /var/tmp/minikube/kubeadm.yaml /var/tmp/minikube/kubeadm.yaml.new
I0722 15:12:54.888276  125103 kubeadm.go:480] needs reconfigure: configs differ:
-- stdout --
--- /var/tmp/minikube/kubeadm.yaml      2020-07-22 22:11:44.482886918 +0000
+++ /var/tmp/minikube/kubeadm.yaml.new  1901-12-13 20:45:52.000000000 +0000
@@ -25,12 +25,18 @@
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 certificatesDir: /var/lib/minikube/certs
 clusterName: mk
-controlPlaneEndpoint: 172.17.0.2:8443
+controlPlaneEndpoint: control-plane.minikube.internal:8443
 dns:
   type: CoreDNS
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
+controllerManager:
+  extraArgs:
+    "leader-elect": "false"
+scheduler:
+  extraArgs:
+    "leader-elect": "false"
 kubernetesVersion: v1.18.0
 networking:
   dnsDomain: cluster.local
@@ -39,13 +45,21 @@
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+authentication:
+  x509:
+    clientCAFile: /var/lib/minikube/certs/ca.crt
+cgroupDriver: cgroupfs
+clusterDomain: "cluster.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
 evictionHard:
   nodefs.available: "0%"
   nodefs.inodesFree: "0%"
   imagefs.available: "0%"
+failSwapOn: false
+staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
+clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 172.17.0.2:10249

-- /stdout --
I0722 15:12:54.888326  125103 kubeadm.go:913] stopping kube-system containers ...
I0722 15:12:54.888403  125103 ssh_runner.go:148] Run: docker ps -a --filter=name=k8s_.*_(kube-system)_ --format={{.ID}}
I0722 15:12:55.000328  125103 docker.go:229] Stopping containers: [6c448a3cc199 4aeaeabe697d e8fbab89d757 94294aa41d9a ca2219ab8b72 270f3384a538 2723ec339229 a542a3901063 b0c318926faa 5ac3499cb7ec c17ef41a0cc5 06ce1a0b5421 20a2a6bfbc21 cc81128ef9b7 f241ca31d80b 23e9e9873d2b ed148eb16b76 0adcc0aec565]
I0722 15:12:55.000446  125103 ssh_runner.go:148] Run: docker stop 6c448a3cc199 4aeaeabe697d e8fbab89d757 94294aa41d9a ca2219ab8b72 270f3384a538 2723ec339229 a542a3901063 b0c318926faa 5ac3499cb7ec c17ef41a0cc5 06ce1a0b5421 20a2a6bfbc21 cc81128ef9b7 f241ca31d80b 23e9e9873d2b ed148eb16b76 0adcc0aec565
I0722 15:12:55.681799  125103 ssh_runner.go:148] Run: sudo ls -la /etc/kubernetes/admin.conf /etc/kubernetes/kubelet.conf /etc/kubernetes/controller-manager.conf /etc/kubernetes/scheduler.conf
I0722 15:12:55.692773  125103 kubeadm.go:150] found existing configuration files:
-rw------- 1 root root 5474 Jul 22 22:11 /etc/kubernetes/admin.conf
-rw------- 1 root root 5506 Jul 22 22:11 /etc/kubernetes/controller-manager.conf
-rw------- 1 root root 1890 Jul 22 22:12 /etc/kubernetes/kubelet.conf
-rw------- 1 root root 5458 Jul 22 22:11 /etc/kubernetes/scheduler.conf

I0722 15:12:55.692854  125103 ssh_runner.go:148] Run: sudo grep https://control-plane.minikube.internal:8443 /etc/kubernetes/admin.conf
I0722 15:12:55.700529  125103 kubeadm.go:161] "https://control-plane.minikube.internal:8443" may not be in /etc/kubernetes/admin.conf - will remove: sudo grep https://control-plane.minikube.internal:8443 /etc/kubernetes/admin.conf: Process exited with status 1
stdout:

stderr:
I0722 15:12:55.700610  125103 ssh_runner.go:148] Run: sudo rm -f /etc/kubernetes/admin.conf
I0722 15:12:55.707611  125103 ssh_runner.go:148] Run: sudo grep https://control-plane.minikube.internal:8443 /etc/kubernetes/kubelet.conf
I0722 15:12:55.716302  125103 kubeadm.go:161] "https://control-plane.minikube.internal:8443" may not be in /etc/kubernetes/kubelet.conf - will remove: sudo grep https://control-plane.minikube.internal:8443 /etc/kubernetes/kubelet.conf: Process exited with status 1
stdout:

stderr:
I0722 15:12:55.716431  125103 ssh_runner.go:148] Run: sudo rm -f /etc/kubernetes/kubelet.conf
I0722 15:12:55.727349  125103 ssh_runner.go:148] Run: sudo grep https://control-plane.minikube.internal:8443 /etc/kubernetes/controller-manager.conf
I0722 15:12:55.733672  125103 kubeadm.go:161] "https://control-plane.minikube.internal:8443" may not be in /etc/kubernetes/controller-manager.conf - will remove: sudo grep https://control-plane.minikube.internal:8443 /etc/kubernetes/controller-manager.conf: Process exited with status 1
stdout:

stderr:
I0722 15:12:55.733753  125103 ssh_runner.go:148] Run: sudo rm -f /etc/kubernetes/controller-manager.conf
I0722 15:12:55.742726  125103 ssh_runner.go:148] Run: sudo grep https://control-plane.minikube.internal:8443 /etc/kubernetes/scheduler.conf
I0722 15:12:55.748959  125103 kubeadm.go:161] "https://control-plane.minikube.internal:8443" may not be in /etc/kubernetes/scheduler.conf - will remove: sudo grep https://control-plane.minikube.internal:8443 /etc/kubernetes/scheduler.conf: Process exited with status 1
stdout:

stderr:
I0722 15:12:55.749026  125103 ssh_runner.go:148] Run: sudo rm -f /etc/kubernetes/scheduler.conf
I0722 15:12:55.760422  125103 ssh_runner.go:148] Run: sudo cp /var/tmp/minikube/kubeadm.yaml.new /var/tmp/minikube/kubeadm.yaml
I0722 15:12:55.771530  125103 kubeadm.go:576] reconfiguring cluster from /var/tmp/minikube/kubeadm.yaml
I0722 15:12:55.771565  125103 ssh_runner.go:148] Run: /bin/bash -c "sudo env PATH=/var/lib/minikube/binaries/v1.18.0:$PATH kubeadm init phase certs all --config /var/tmp/minikube/kubeadm.yaml"
I0722 15:12:55.836528  125103 ssh_runner.go:148] Run: /bin/bash -c "sudo env PATH=/var/lib/minikube/binaries/v1.18.0:$PATH kubeadm init phase kubeconfig all --config /var/tmp/minikube/kubeadm.yaml"
I0722 15:12:56.820480  125103 ssh_runner.go:148] Run: /bin/bash -c "sudo env PATH=/var/lib/minikube/binaries/v1.18.0:$PATH kubeadm init phase control-plane all --config /var/tmp/minikube/kubeadm.yaml"
I0722 15:12:56.884222  125103 ssh_runner.go:148] Run: /bin/bash -c "sudo env PATH=/var/lib/minikube/binaries/v1.18.0:$PATH kubeadm init phase etcd local --config /var/tmp/minikube/kubeadm.yaml"
I0722 15:12:56.944709  125103 api_server.go:48] waiting for apiserver process to appear ...
I0722 15:12:56.944767  125103 ssh_runner.go:148] Run: sudo pgrep -xnf kube-apiserver.*minikube.*
I0722 15:12:57.454804  125103 ssh_runner.go:148] Run: sudo pgrep -xnf kube-apiserver.*minikube.*
I0722 15:12:57.954761  125103 ssh_runner.go:148] Run: sudo pgrep -xnf kube-apiserver.*minikube.*
I0722 15:12:58.454785  125103 ssh_runner.go:148] Run: sudo pgrep -xnf kube-apiserver.*minikube.*
I0722 15:12:58.954799  125103 ssh_runner.go:148] Run: sudo pgrep -xnf kube-apiserver.*minikube.*
I0722 15:12:59.454814  125103 ssh_runner.go:148] Run: sudo pgrep -xnf kube-apiserver.*minikube.*
I0722 15:12:59.954719  125103 ssh_runner.go:148] Run: sudo pgrep -xnf kube-apiserver.*minikube.*
I0722 15:13:00.454912  125103 ssh_runner.go:148] Run: sudo pgrep -xnf kube-apiserver.*minikube.*
I0722 15:13:00.955376  125103 ssh_runner.go:148] Run: sudo pgrep -xnf kube-apiserver.*minikube.*
I0722 15:13:01.454773  125103 ssh_runner.go:148] Run: sudo pgrep -xnf kube-apiserver.*minikube.*
I0722 15:13:01.514355  125103 api_server.go:68] duration metric: took 4.569643545s to wait for apiserver process to appear ...
I0722 15:13:01.514392  125103 api_server.go:84] waiting for apiserver healthz status ...
I0722 15:13:01.514407  125103 api_server.go:221] Checking apiserver healthz at https://172.17.0.2:8443/healthz ...
I0722 15:13:06.211202  125103 api_server.go:241] https://172.17.0.2:8443/healthz returned 403:
{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"forbidden: User \"system:anonymous\" cannot get path \"/healthz\"","reason":"Forbidden","details":{},"code":403}
W0722 15:13:06.211236  125103 api_server.go:99] status: https://172.17.0.2:8443/healthz returned error 403:
{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"forbidden: User \"system:anonymous\" cannot get path \"/healthz\"","reason":"Forbidden","details":{},"code":403}
I0722 15:13:06.711428  125103 api_server.go:221] Checking apiserver healthz at https://172.17.0.2:8443/healthz ...
I0722 15:13:06.721757  125103 api_server.go:241] https://172.17.0.2:8443/healthz returned 500:
[+]ping ok
[+]log ok
[+]etcd ok
[+]poststarthook/start-kube-apiserver-admission-initializer ok
[+]poststarthook/generic-apiserver-start-informers ok
[+]poststarthook/start-apiextensions-informers ok
[+]poststarthook/start-apiextensions-controllers ok
[+]poststarthook/crd-informer-synced ok
[+]poststarthook/bootstrap-controller ok
[-]poststarthook/rbac/bootstrap-roles failed: reason withheld
[-]poststarthook/scheduling/bootstrap-system-priority-classes failed: reason withheld
[+]poststarthook/start-cluster-authentication-info-controller ok
[+]poststarthook/start-kube-aggregator-informers ok
[+]poststarthook/apiservice-registration-controller ok
[+]poststarthook/apiservice-status-available-controller ok
[+]poststarthook/kube-apiserver-autoregistration ok
[+]autoregister-completion ok
[+]poststarthook/apiservice-openapi-controller ok
healthz check failed
W0722 15:13:06.721847  125103 api_server.go:99] status: https://172.17.0.2:8443/healthz returned error 500:
[+]ping ok
[+]log ok
[+]etcd ok
[+]poststarthook/start-kube-apiserver-admission-initializer ok
[+]poststarthook/generic-apiserver-start-informers ok
[+]poststarthook/start-apiextensions-informers ok
[+]poststarthook/start-apiextensions-controllers ok
[+]poststarthook/crd-informer-synced ok
[+]poststarthook/bootstrap-controller ok
[-]poststarthook/rbac/bootstrap-roles failed: reason withheld
[-]poststarthook/scheduling/bootstrap-system-priority-classes failed: reason withheld
[+]poststarthook/start-cluster-authentication-info-controller ok
[+]poststarthook/start-kube-aggregator-informers ok
[+]poststarthook/apiservice-registration-controller ok
[+]poststarthook/apiservice-status-available-controller ok
[+]poststarthook/kube-apiserver-autoregistration ok
[+]autoregister-completion ok
[+]poststarthook/apiservice-openapi-controller ok
healthz check failed
I0722 15:13:07.211407  125103 api_server.go:221] Checking apiserver healthz at https://172.17.0.2:8443/healthz ...
I0722 15:13:07.220056  125103 api_server.go:241] https://172.17.0.2:8443/healthz returned 500:
[+]ping ok
[+]log ok
[+]etcd ok
[+]poststarthook/start-kube-apiserver-admission-initializer ok
[+]poststarthook/generic-apiserver-start-informers ok
[+]poststarthook/start-apiextensions-informers ok
[+]poststarthook/start-apiextensions-controllers ok
[+]poststarthook/crd-informer-synced ok
[+]poststarthook/bootstrap-controller ok
[-]poststarthook/rbac/bootstrap-roles failed: reason withheld
[+]poststarthook/scheduling/bootstrap-system-priority-classes ok
[+]poststarthook/start-cluster-authentication-info-controller ok
[+]poststarthook/start-kube-aggregator-informers ok
[+]poststarthook/apiservice-registration-controller ok
[+]poststarthook/apiservice-status-available-controller ok
[+]poststarthook/kube-apiserver-autoregistration ok
[+]autoregister-completion ok
[+]poststarthook/apiservice-openapi-controller ok
healthz check failed
W0722 15:13:07.220117  125103 api_server.go:99] status: https://172.17.0.2:8443/healthz returned error 500:
[+]ping ok
[+]log ok
[+]etcd ok
[+]poststarthook/start-kube-apiserver-admission-initializer ok
[+]poststarthook/generic-apiserver-start-informers ok
[+]poststarthook/start-apiextensions-informers ok
[+]poststarthook/start-apiextensions-controllers ok
[+]poststarthook/crd-informer-synced ok
[+]poststarthook/bootstrap-controller ok
[-]poststarthook/rbac/bootstrap-roles failed: reason withheld
[+]poststarthook/scheduling/bootstrap-system-priority-classes ok
[+]poststarthook/start-cluster-authentication-info-controller ok
[+]poststarthook/start-kube-aggregator-informers ok
[+]poststarthook/apiservice-registration-controller ok
[+]poststarthook/apiservice-status-available-controller ok
[+]poststarthook/kube-apiserver-autoregistration ok
[+]autoregister-completion ok
[+]poststarthook/apiservice-openapi-controller ok
healthz check failed
I0722 15:13:07.711438  125103 api_server.go:221] Checking apiserver healthz at https://172.17.0.2:8443/healthz ...
I0722 15:13:07.721360  125103 api_server.go:241] https://172.17.0.2:8443/healthz returned 200:
ok
I0722 15:13:07.731266  125103 api_server.go:137] control plane version: v1.18.0
I0722 15:13:07.731298  125103 api_server.go:127] duration metric: took 6.216897417s to wait for apiserver health ...
I0722 15:13:07.731311  125103 cni.go:74] Creating CNI manager for ""
I0722 15:13:07.731321  125103 cni.go:117] CNI unnecessary in this configuration, recommending no CNI
I0722 15:13:07.731331  125103 system_pods.go:43] waiting for kube-system pods to appear ...
I0722 15:13:07.743361  125103 system_pods.go:59] 9 kube-system pods found
I0722 15:13:07.743418  125103 system_pods.go:61] "coredns-66bff467f8-9979q" [bbc31012-f468-4f3c-a3a1-024e7b8b9750] Running / Ready:ContainersNotReady (containers with unready status: [coredns]) / ContainersReady:ContainersNotReady (containers with unready status: [coredns])
I0722 15:13:07.743438  125103 system_pods.go:61] "coredns-66bff467f8-l47j8" [52a5292c-be76-4752-b751-5c3908eba5c1] Pending / Ready:ContainersNotReady (containers with unready status: [coredns]) / ContainersReady:ContainersNotReady (containers with unready status: [coredns])
I0722 15:13:07.743454  125103 system_pods.go:61] "etcd-minikube" [7faaefab-a8fd-40c4-8a8a-0f5af60dee77] Running
I0722 15:13:07.743465  125103 system_pods.go:61] "kindnet-fgjdh" [6c6eb851-e835-4246-9d5d-f90a07df2405] Running
I0722 15:13:07.743475  125103 system_pods.go:61] "kube-apiserver-minikube" [c8d1bb73-eb0f-4ff6-98d7-9bf4acec0e85] Running
I0722 15:13:07.743485  125103 system_pods.go:61] "kube-controller-manager-minikube" [ec80ebf0-71ed-44dd-b708-d85b6a7d1b9d] Pending
I0722 15:13:07.743496  125103 system_pods.go:61] "kube-proxy-tpv47" [b7739d89-a27d-46cb-bd75-248a2e71d627] Running
I0722 15:13:07.743505  125103 system_pods.go:61] "kube-scheduler-minikube" [f9211934-eba3-45c8-a7d2-ad532af1272d] Pending
I0722 15:13:07.743516  125103 system_pods.go:61] "storage-provisioner" [c2f27454-43f9-47fe-b356-4901fb3e8748] Pending / Ready:ContainersNotReady (containers with unready status: [storage-provisioner]) / ContainersReady:ContainersNotReady (containers with unready status: [storage-provisioner])
I0722 15:13:07.743527  125103 system_pods.go:74] duration metric: took 12.186841ms to wait for pod list to return data ...
I0722 15:13:07.743539  125103 node_conditions.go:101] verifying NodePressure condition ...
I0722 15:13:07.748984  125103 node_conditions.go:121] node storage ephemeral capacity is 66008536Ki
I0722 15:13:07.749022  125103 node_conditions.go:122] node cpu capacity is 8
I0722 15:13:07.749044  125103 node_conditions.go:104] duration metric: took 5.495398ms to run NodePressure ...
I0722 15:13:07.749061  125103 ssh_runner.go:148] Run: /bin/bash -c "sudo env PATH=/var/lib/minikube/binaries/v1.18.0:$PATH kubeadm init phase addon all --config /var/tmp/minikube/kubeadm.yaml"
I0722 15:13:07.997011  125103 ssh_runner.go:148] Run: /bin/bash -c "cat /proc/$(pgrep kube-apiserver)/oom_adj"
I0722 15:13:08.007131  125103 ops.go:35] apiserver oom_adj: -16
I0722 15:13:08.007173  125103 kubeadm.go:516] restartCluster took 13.156168808s
I0722 15:13:08.007199  125103 kubeadm.go:329] StartCluster complete in 13.211335336s
I0722 15:13:08.007252  125103 settings.go:123] acquiring lock: {Name:mk8321abeaf7ec6cc5a76d059c99b841d83ce6ba Clock:{} Delay:500ms Timeout:1m0s Cancel:<nil>}
I0722 15:13:08.007434  125103 settings.go:131] Updating kubeconfig:  /home/med/.kube/config
I0722 15:13:08.008410  125103 lock.go:35] WriteFile acquiring /home/med/.kube/config: {Name:mk2fdd0980d1ed5b01817e272c37508fe5f5a37a Clock:{} Delay:500ms Timeout:1m0s Cancel:<nil>}
I0722 15:13:08.008791  125103 start.go:195] Will wait wait-timeout for node ...
🔎  Verifying Kubernetes components...
I0722 15:13:08.008828  125103 addons.go:353] enableAddons start: toEnable=map[default-storageclass:true storage-provisioner:true], additional=[]
I0722 15:13:08.017301  125103 api_server.go:48] waiting for apiserver process to appear ...
I0722 15:13:08.008953  125103 ssh_runner.go:148] Run: sudo KUBECONFIG=/var/lib/minikube/kubeconfig /var/lib/minikube/binaries/v1.18.0/kubectl scale deployment --replicas=1 coredns -n=kube-system
I0722 15:13:08.017336  125103 addons.go:53] Setting storage-provisioner=true in profile "minikube"
I0722 15:13:08.017366  125103 addons.go:53] Setting default-storageclass=true in profile "minikube"
I0722 15:13:08.017386  125103 addons.go:267] enableOrDisableStorageClasses default-storageclass=true on "minikube"
I0722 15:13:08.017368  125103 addons.go:129] Setting addon storage-provisioner=true in "minikube"
W0722 15:13:08.017443  125103 addons.go:138] addon storage-provisioner should already be in state true
I0722 15:13:08.017482  125103 host.go:65] Checking if "minikube" exists ...
I0722 15:13:08.017351  125103 ssh_runner.go:148] Run: sudo pgrep -xnf kube-apiserver.*minikube.*
I0722 15:13:08.017697  125103 cli_runner.go:109] Run: docker container inspect minikube --format={{.State.Status}}
I0722 15:13:08.017914  125103 cli_runner.go:109] Run: docker container inspect minikube --format={{.State.Status}}
I0722 15:13:08.028534  125103 api_server.go:68] duration metric: took 19.513459ms to wait for apiserver process to appear ...
I0722 15:13:08.028568  125103 api_server.go:84] waiting for apiserver healthz status ...
I0722 15:13:08.028581  125103 api_server.go:221] Checking apiserver healthz at https://172.17.0.2:8443/healthz ...
I0722 15:13:08.034007  125103 api_server.go:241] https://172.17.0.2:8443/healthz returned 200:
ok
I0722 15:13:08.034673  125103 api_server.go:137] control plane version: v1.18.0
I0722 15:13:08.034692  125103 api_server.go:127] duration metric: took 6.115037ms to wait for apiserver health ...
I0722 15:13:08.034705  125103 system_pods.go:43] waiting for kube-system pods to appear ...
I0722 15:13:08.039511  125103 system_pods.go:59] 9 kube-system pods found
I0722 15:13:08.039541  125103 system_pods.go:61] "coredns-66bff467f8-9979q" [bbc31012-f468-4f3c-a3a1-024e7b8b9750] Running / Ready:ContainersNotReady (containers with unready status: [coredns]) / ContainersReady:ContainersNotReady (containers with unready status: [coredns])
I0722 15:13:08.039552  125103 system_pods.go:61] "coredns-66bff467f8-l47j8" [52a5292c-be76-4752-b751-5c3908eba5c1] Pending / Ready:ContainersNotReady (containers with unready status: [coredns]) / ContainersReady:ContainersNotReady (containers with unready status: [coredns])
I0722 15:13:08.039559  125103 system_pods.go:61] "etcd-minikube" [7faaefab-a8fd-40c4-8a8a-0f5af60dee77] Running
I0722 15:13:08.039566  125103 system_pods.go:61] "kindnet-fgjdh" [6c6eb851-e835-4246-9d5d-f90a07df2405] Running
I0722 15:13:08.039572  125103 system_pods.go:61] "kube-apiserver-minikube" [c8d1bb73-eb0f-4ff6-98d7-9bf4acec0e85] Running
I0722 15:13:08.039578  125103 system_pods.go:61] "kube-controller-manager-minikube" [ec80ebf0-71ed-44dd-b708-d85b6a7d1b9d] Pending
I0722 15:13:08.039585  125103 system_pods.go:61] "kube-proxy-tpv47" [b7739d89-a27d-46cb-bd75-248a2e71d627] Running
I0722 15:13:08.039595  125103 system_pods.go:61] "kube-scheduler-minikube" [f9211934-eba3-45c8-a7d2-ad532af1272d] Pending
I0722 15:13:08.039606  125103 system_pods.go:61] "storage-provisioner" [c2f27454-43f9-47fe-b356-4901fb3e8748] Pending / Ready:ContainersNotReady (containers with unready status: [storage-provisioner]) / ContainersReady:ContainersNotReady (containers with unready status: [storage-provisioner])
I0722 15:13:08.039616  125103 system_pods.go:74] duration metric: took 4.902646ms to wait for pod list to return data ...
I0722 15:13:08.039628  125103 kubeadm.go:468] duration metric: took 30.615033ms to wait for : map[apiserver:true system_pods:true] ...
I0722 15:13:08.039645  125103 node_conditions.go:101] verifying NodePressure condition ...
I0722 15:13:08.042076  125103 node_conditions.go:121] node storage ephemeral capacity is 66008536Ki
I0722 15:13:08.042105  125103 node_conditions.go:122] node cpu capacity is 8
I0722 15:13:08.042124  125103 node_conditions.go:104] duration metric: took 2.471396ms to run NodePressure ...
I0722 15:13:08.042137  125103 start.go:200] waiting for startup goroutines ...
I0722 15:13:08.078663  125103 addons.go:236] installing /etc/kubernetes/addons/storage-provisioner.yaml
I0722 15:13:08.078693  125103 ssh_runner.go:215] scp memory --> /etc/kubernetes/addons/storage-provisioner.yaml (2668 bytes)
I0722 15:13:08.078773  125103 cli_runner.go:109] Run: docker container inspect -f "'{{(index (index .NetworkSettings.Ports "22/tcp") 0).HostPort}}'" minikube
I0722 15:13:08.094656  125103 addons.go:129] Setting addon default-storageclass=true in "minikube"
W0722 15:13:08.094690  125103 addons.go:138] addon default-storageclass should already be in state true
I0722 15:13:08.094717  125103 host.go:65] Checking if "minikube" exists ...
I0722 15:13:08.095322  125103 cli_runner.go:109] Run: docker container inspect minikube --format={{.State.Status}}
I0722 15:13:08.127395  125103 start.go:548] successfully scaled coredns replicas to 1
I0722 15:13:08.137672  125103 sshutil.go:44] new ssh client: &{IP:127.0.0.1 Port:32776 SSHKeyPath:/home/med/.minikube/machines/minikube/id_rsa Username:docker}
I0722 15:13:08.154521  125103 addons.go:236] installing /etc/kubernetes/addons/storageclass.yaml
I0722 15:13:08.154550  125103 ssh_runner.go:215] scp deploy/addons/storageclass/storageclass.yaml.tmpl --> /etc/kubernetes/addons/storageclass.yaml (271 bytes)
I0722 15:13:08.154609  125103 cli_runner.go:109] Run: docker container inspect -f "'{{(index (index .NetworkSettings.Ports "22/tcp") 0).HostPort}}'" minikube
I0722 15:13:08.197608  125103 sshutil.go:44] new ssh client: &{IP:127.0.0.1 Port:32776 SSHKeyPath:/home/med/.minikube/machines/minikube/id_rsa Username:docker}
I0722 15:13:08.251410  125103 ssh_runner.go:148] Run: sudo KUBECONFIG=/var/lib/minikube/kubeconfig /var/lib/minikube/binaries/v1.18.0/kubectl apply -f /etc/kubernetes/addons/storage-provisioner.yaml
I0722 15:13:08.298132  125103 ssh_runner.go:148] Run: sudo KUBECONFIG=/var/lib/minikube/kubeconfig /var/lib/minikube/binaries/v1.18.0/kubectl apply -f /etc/kubernetes/addons/storageclass.yaml
🌟  Enabled addons: default-storageclass, storage-provisioner
I0722 15:13:09.136287  125103 addons.go:355] enableAddons completed in 1.127464107s
🏄  Done! kubectl is now configured to use "minikube"
I0722 15:13:09.233215  125103 start.go:402] kubectl: 1.18.6, cluster: 1.18.0 (minor skew: 0)
```