### PR TITLE
update how to add translations page.

### DIFF
--- a/site/content/en/docs/contrib/translations.md
+++ b/site/content/en/docs/contrib/translations.md
@@ -16,7 +16,7 @@ All translations are stored in the top-level `translations` directory.
 	~/minikube$ ls translations/
 	de.json		es.json		fr.json		ja.json		ko.json		pl.json		zh-CN.json
 	```
-* Run `make extract` from root to populate that file with the strings to translate in json
+* Run `make extract` from root directory to populate that file with the strings to translate in json
   form.
 	```
 	~/minikube$ make extract


### PR DESCRIPTION
Run `make extract` from root seems to be ambiguous with root user/directory. This PR make it unambiguous.