### PR TITLE
Update OIDC documentation.

### DIFF
--- a/site/content/en/docs/tutorials/openid_connect_auth.md
+++ b/site/content/en/docs/tutorials/openid_connect_auth.md
@@ -25,6 +25,8 @@ minikube start \
   --extra-config=apiserver.oidc-client-id=kubernetes-local
 ```
 
+Note that as stated in the Kubernetes [documentation](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#configuring-the-api-server), for `--extra-config=apiserver.oidc-issuer-url` flag, only URLs which use the `https://` scheme are accepted. Otherwise `kube-apiserver` will not start.
+
 ## Configuring kubectl
 
 You can use the kubectl `oidc` authenticator to create a kubeconfig as shown in the Kubernetes docs: <https://kubernetes.io/docs/reference/access-authn-authz/authentication/#option-1-oidc-authenticator>


### PR DESCRIPTION
Update OIDC documentation to include extra information about `--oidc-issuer-url` flag.

I just wanted to make it more visible after losing some hours debugging it. Unforunately, in case `http` is passed, `kube-apiserver` does not produce any helpful log.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
