### PR TITLE
ci: docker check github action continue-on-err

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -309,6 +309,7 @@ jobs:
           name: minikube_binaries
       - name: Start Docker Desktop
         shell: powershell
+        continue-on-error: true
         run: |
           docker ps 2>&1 | Out-Null
           $docker_running = $?
@@ -442,6 +443,7 @@ jobs:
           name: minikube_binaries
       - name: Start Docker Desktop
         shell: powershell
+        continue-on-error: true
         run: |
           docker ps 2>&1 | Out-Null
           $docker_running = $?

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -307,6 +307,7 @@ jobs:
           name: minikube_binaries
       - name: Start Docker Desktop
         shell: powershell
+        continue-on-error: true
         run: |
           docker ps 2>&1 | Out-Null
           $docker_running = $?
@@ -440,6 +441,7 @@ jobs:
           name: minikube_binaries
       - name: Start Docker Desktop
         shell: powershell
+        continue-on-error: true
         run: |
           docker ps 2>&1 | Out-Null
           $docker_running = $?


### PR DESCRIPTION
to avoid this:
```
docker : error during connect: Get http://%2F%2F.%2Fpipe%2Fdocker_engine/v1.40/containers/json: open //./pipe/docker_engine: The system cannot find the file specified. In the default daemon configuration on Windows, the docker client must be run elevated to connect. This error may also indicate that the docker daemon is not running. At C:\Users\jenkins\actions-runner\_work\_temp\ee30c2a6-2221-4fec-a330-8bbd5545e6a8.ps1:2 char:1 + docker ps 2>&1 | Out-Null + ~~~~~~~~~~~~~~ + CategoryInfo          : NotSpecified: (error during co...is not running.:String) [], RemoteException + FullyQualifiedErrorId : NativeCommandError
```
we should not check while we are verifying the docker 