### PR TITLE
Fix handling of parseIP error

### DIFF
--- a/pkg/minikube/driver/endpoint.go
+++ b/pkg/minikube/driver/endpoint.go
@@ -17,6 +17,7 @@ limitations under the License.
 package driver
 
 import (
+	"fmt"
 	"net"
 
 	"k8s.io/minikube/pkg/drivers/kic/oci"
@@ -30,6 +31,9 @@ func ControlPlaneEndpoint(cc *config.ClusterConfig, cp *config.Node, driverName 
 		port, err := oci.ForwardedPort(cc.Driver, cc.Name, cp.Port)
 		hostname := oci.DefaultBindIPV4
 		ip := net.ParseIP(hostname)
+		if ip == nil {
+			return hostname, ip, port, fmt.Errorf("failed to parse ip for %q", hostname)
+		}
 
 		// https://github.com/kubernetes/minikube/issues/3878
 		if cc.KubernetesConfig.APIServerName != constants.APIServerName {
@@ -43,5 +47,9 @@ func ControlPlaneEndpoint(cc *config.ClusterConfig, cp *config.Node, driverName 
 	if cc.KubernetesConfig.APIServerName != constants.APIServerName {
 		hostname = cc.KubernetesConfig.APIServerName
 	}
-	return hostname, net.ParseIP(cp.IP), cp.Port, nil
+	ip := net.ParseIP(cp.IP)
+	if ip == nil {
+		return hostname, ip, cp.Port, fmt.Errorf("failed to parse ip for %q", cp.IP)
+	}
+	return hostname, ip, cp.Port, nil
 }


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/minikube/issues/8646

### Before changes:
```
$ minikube ip delete
$ minikube start
...
🐳  Preparing Kubernetes v1.18.3 on Docker 19.03.8 ...
```
* In a separate terminal session
```
$ minikube ip
<nil>
$ echo $?
0
```


### Fix
* (Same repro steps)
```
$ minikube ip

💣  Unable to get forwarded endpoint: failed to parse ip

😿  minikube is exiting due to an error. If the above message is not useful, open an issue:
👉  https://github.com/kubernetes/minikube/issues/new/choose
➜  minikube git:(fix-minikube-ip-errhandle) echo $?
70
```
