### PR TITLE
Avoid panic: runtime error: invalid memory address or nil pointer der…

### DIFF
--- a/pkg/minikube/exit/exit.go
+++ b/pkg/minikube/exit/exit.go
@@ -57,10 +57,12 @@ func WithCodeT(code int, format string, a ...out.V) {
 func WithError(msg string, err error) {
 	glog.Infof("WithError(%s)=%v called from:\n%s", msg, err, debug.Stack())
 	p := problem.FromError(err, runtime.GOOS)
-	if p != nil && out.JSON {
-		p.DisplayJSON(Config)
-		os.Exit(Config)
-	} else {
+
+	if p != nil {
+		if out.JSON {
+			p.DisplayJSON(Config)
+			os.Exit(Config)
+		}
 		WithProblem(msg, err, p)
 		os.Exit(Config)
 	}


### PR DESCRIPTION
Fixes nil pointer deref when there is no matching problem:

```
😿  Failed to start docker container. "minikube start" may fix it: creating host: create: creating: prepare kic ssh: apply authorized_keys file ownership, output 
** stderr ** 
Error response from daemon: Container 84bea4de4048e8a3e38bca927cdbe3fe2e2724dff1f1345845daa271da52fbfd is not running

** /stderr **: chown docker:docker /home/docker/.ssh/authorized_keys: exit status 1
stdout:

stderr:
Error response from daemon: Container 84bea4de4048e8a3e38bca927cdbe3fe2e2724dff1f1345845daa271da52fbfd is not running


panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x4ad0240]

goroutine 1 [running]:
k8s.io/minikube/pkg/minikube/exit.WithProblem(0x57cd099, 0x17, 0x5ae5120, 0xc0001be200, 0x0)
	/Users/tstromberg/src/minikube/pkg/minikube/exit/exit.go:74 +0xd0
k8s.io/minikube/pkg/minikube/exit.WithError(0x57cd099, 0x17, 0x5ae5120, 0xc0001be200)
	/Users/tstromberg/src/minikube/pkg/minikube/exit/exit.go:64 +0x1de
k8s.io/minikube/cmd/minikube/cmd.runStart(0x69031e0, 0xc0003d15c0, 0x0, 0x2)
	/Users/tstromberg/src/minikube/cmd/minikube/cmd/start.go:171 +0xbe2
github.com/spf13/cobra.(*Command).execute(0x69031e0, 0xc0003d15a0, 0x2, 0x2, 0x69031e0, 0xc0003d15a0)
	/Users/tstromberg/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:846 +0x29d
github.com/spf13/cobra.(*Command).ExecuteC(0x6902220, 0x0, 0x1, 0xc000147d80)
	/Users/tstromberg/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950 +0x349
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/tstromberg/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
k8s.io/minikube/cmd/minikube/cmd.Execute()
	/Users/tstromberg/src/minikube/cmd/minikube/cmd/root.go:106 +0x72c
main.main()
	/Users/tstromberg/src/minikube/cmd/minikube/main.go:71 +0x11f
```