### PR TITLE
kic: Show log excerpt for ErrExitedUnexpectedly, check state within prepareSSH

### DIFF
--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -225,12 +225,13 @@ func CreateContainerNode(p CreateParams) error {
 
 	// retry up to up 13 seconds to make sure the created container status is running.
 	if err := retry.Expo(checkRunning, 13*time.Millisecond, time.Second*13); err != nil {
-		LogContainerDebug(p.OCIBinary, p.Name)
+		excerpt := LogContainerDebug(p.OCIBinary, p.Name)
 		_, err := DaemonInfo(p.OCIBinary)
 		if err != nil {
 			return errors.Wrapf(ErrDaemonInfo, "container name %q", p.Name)
 		}
-		return errors.Wrapf(ErrExitedUnexpectedly, "container name %q", p.Name)
+
+		return errors.Wrapf(ErrExitedUnexpectedly, "container name %q: log: %s", p.Name, excerpt)
 	}
 
 	return nil


### PR DESCRIPTION
This is to make Docker bug reports better and easier to debug:

* Before setting up SSH, double-check that the container is running
* Add 4 lines of logging output to ErrExitedUnexpectedly errors:

Old output with an entrypoint that is designed to fail:

```
🤦  StartHost failed, but will try again: creating host: create: creating: prepare kic ssh: apply authorized_keys file ownership, output 
** stderr ** 
Error response from daemon: Container 5b830c371c4f57d02d1c0e1f2470dbc66393c67dfef7d967b126c31a14ee5093 is not running

** /stderr **: chown docker:docker /home/docker/.ssh/authorized_keys: exit status 1
stdout:

stderr:
Error response from daemon: Container 5b830c371c4f57d02d1c0e1f2470dbc66393c67dfef7d967b126c31a14ee5093 is not running

```

New output:

```
🤦  StartHost failed, but will try again: creating host: create: creating: prepare kic ssh: container name "minikube" state Stopped: log: 2020-07-24T16:07:16.195204100Z  ++ date
2020-07-24T16:07:16.196371400Z  + echo 'entrypoint 1 exit test at Fri Jul 24 16:07:16 UTC 2020'
2020-07-24T16:07:16.196600900Z  entrypoint 1 exit test at Fri Jul 24 16:07:16 UTC 2020
2020-07-24T16:07:16.196756500Z  + exit 99: container exited unexpectedly
```