### PR TITLE
Fixed LoadBalancer deployments example in "Get Started" section.

### DIFF
--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -149,7 +149,7 @@ To access a LoadBalancer deployment, use the "minikube tunnel" command. Here is 
 
 ```shell
 kubectl create deployment balanced --image=k8s.gcr.io/echoserver:1.4  
-kubectl expose deployment balanced --type=LoadBalancer --port=8000
+kubectl expose deployment balanced --type=LoadBalancer --port=8080
 ```
 
 In another window, start the tunnel to create a routable IP for the 'balanced' deployment:
@@ -162,7 +162,7 @@ To find the routable IP, run this command and examine the `EXTERNAL-IP` column:
 
 `kubectl get services balanced`
 
-Your deployment is now available at &lt;EXTERNAL-IP&gt;:8000
+Your deployment is now available at &lt;EXTERNAL-IP&gt;:8080
 
 <h2 class="step"><span class="fa-stack fa-1x"><i class="fa fa-circle fa-stack-2x"></i><strong class="fa-stack-1x text-primary">5</strong></span>Manage your cluster</h2>
 


### PR DESCRIPTION
The Load balancer deployment section mentions --port=8000 but that's not the correct port for the container. 
Using curl to <EXTERNAL IP>:8000/ gives an "Empty reply from server" error.
The parameter should be 8080 (--port=8080). Also, the reference to EXTERNAL-IP:8000 should be changed to EXTERNAL-IP:8080

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
