### PR TITLE
Skip irrelevent upgrade-tests when --base-image is passed

### DIFF
--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -65,6 +65,11 @@ func legacyStartArgs() []string {
 
 // TestRunningBinaryUpgrade does an upgrade test on a running cluster
 func TestRunningBinaryUpgrade(t *testing.T) {
+	// not supported till v1.10, and passing new images to old releases isn't supported anyways
+	if strings.Contains(*startArgs, "base-image") {
+		t.Skipf("Skipping, test does not make sense with --base-image")
+	}
+
 	MaybeParallel(t)
 	profile := UniqueProfileName("running-upgrade")
 	ctx, cancel := context.WithTimeout(context.Background(), Minutes(55))
@@ -105,6 +110,10 @@ func TestRunningBinaryUpgrade(t *testing.T) {
 
 // TestStoppedBinaryUpgrade does an upgrade test on a stopped cluster
 func TestStoppedBinaryUpgrade(t *testing.T) {
+	// not supported till v1.10, and passing new images to old releases isn't supported anyways
+	if strings.Contains(*startArgs, "base-image") {
+		t.Skipf("Skipping, test does not make sense with --base-image")
+	}
 
 	MaybeParallel(t)
 	profile := UniqueProfileName("stopped-upgrade")
@@ -223,6 +232,11 @@ func TestKubernetesUpgrade(t *testing.T) {
 func TestMissingContainerUpgrade(t *testing.T) {
 	if !DockerDriver() {
 		t.Skipf("This test is only for Docker")
+	}
+
+	// not supported till v1.10, and passing new images to old releases isn't supported anyways
+	if strings.Contains(*startArgs, "base-image") {
+		t.Skipf("Skipping, test does not make sense with --base-image")
 	}
 
 	MaybeParallel(t)


### PR DESCRIPTION
Should fix failures when testing upgraded base images, such as:

```
se:experiment
    TestMissingContainerUpgrade: version_upgrade_test.go:245: (dbg) Non-zero exit: /var/folders/n1/qxvd9kc11w15mc4qv6g43x80000kt3/T/minikube-v1.9.1.390243971.exe start -p missing-upgrade-20200727133242-27041 --memory=2200 --vm-driver=docker --base-image=kicbase:experiment: exit status 64 (91.093951ms)
        
        ** stderr ** 
        	Error: unknown flag: --base-image
        	See 'minikube start --help' for usage.        
```

These failures occur because this flag was not supported until v1.10.0. It also doesn't make sense to test new base images with older binaries.