### PR TITLE
UI: suggest to enable `metric-server` for full feature dashboard addon.

### DIFF
--- a/cmd/minikube/cmd/config/enable.go
+++ b/cmd/minikube/cmd/config/enable.go
@@ -42,12 +42,8 @@ var addonsEnableCmd = &cobra.Command{
 			exit.WithError("enable failed", err)
 		}
 		if addon == "dashboard" {
-			out.T(out.Waiting, "Some dashboard features require the 'metrics-server' add-on")
-			err = addons.SetAndSave(ClusterFlagValue(), "metrics-server", "true")
-			if err != nil {
-				exit.WithError("enable failed", err)
-			}
-			out.T(out.AddonEnable, "The 'metrics-server' add-on was enabled automatically")
+			out.T(out.Tip, "Some dashboard features require the 'metrics-server' add-on. For full features consider enabling metrics-server addon.")
+
 		}
 
 		out.T(out.AddonEnable, "The '{{.addonName}}' addon is enabled", out.V{"addonName": addon})

--- a/cmd/minikube/cmd/config/enable.go
+++ b/cmd/minikube/cmd/config/enable.go
@@ -17,8 +17,11 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"k8s.io/minikube/pkg/addons"
+	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/out"
 )
@@ -42,7 +45,15 @@ var addonsEnableCmd = &cobra.Command{
 			exit.WithError("enable failed", err)
 		}
 		if addon == "dashboard" {
-			out.T(out.Tip, "Some dashboard features require the 'metrics-server' add-on. For full features consider enabling metrics-server addon.")
+			tipProfileArg := ""
+			if ClusterFlagValue() != constants.DefaultClusterName {
+				tipProfileArg = fmt.Sprintf(" -p %s", ClusterFlagValue())
+			}
+			out.T(out.Tip, `Some dashboard features require the metrics-server addon. To enable all features please run:
+
+	minikube{{.profileArg}} addons enable metrics-server	
+
+`, out.V{"profileArg": tipProfileArg})
 
 		}
 


### PR DESCRIPTION
fixing the PR I merged without running full tests on it, https://github.com/kubernetes/minikube/pull/8842


fixes https://github.com/kubernetes/minikube/issues/8859

### after this PR 

```
$ make && ./out/minikube addons -p p1 enable dashboard
💡  Some dashboard features require the metrics-server addon. To enable all features please run:

        minikube -p p1 addons enable metrics-server


🌟  The 'dashboard' addon is enabled
```

for default profile

```
💡  Some dashboard features require the metrics-server addon. To enable all features please run:

        minikube addons enable metrics-server


🌟  The 'dashboard' addon is enabled
```