### PR TITLE
Kic base ubuntu2020

### DIFF
--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -6,27 +6,28 @@ FROM kindest/base:v20200430-2c0eee40 as base
 USER root
 # specify version of everything explicitly using 'apt-cache policy'
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    lz4=1.9.1-1 \
-    gnupg=2.2.12-1ubuntu3 \ 
-    sudo=1.8.27-1ubuntu4.1 \
-    docker.io=19.03.2-0ubuntu1 \
-    openssh-server=1:8.0p1-6build1 \
-    dnsutils=1:9.11.5.P4+dfsg-5.1ubuntu2.2 \
+    lz4 \
+    gnupg \ 
+    sudo \
+    docker.io \
+    openssh-server \
+    dnsutils \
     # libglib2.0-0 is required for conmon, which is required for podman
-    libglib2.0-0=2.62.1-1 \
+    libglib2.0-0 \
+    # removing kind's crictl config
     && rm /etc/crictl.yaml
 
 # install cri-o based on https://github.com/cri-o/cri-o/commit/96b0c34b31a9fc181e46d7d8e34fb8ee6c4dc4e1#diff-04c6e90faac2675aa89e2176d2eec7d8R128
-RUN sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_19.10/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list" && \    
-    curl -LO https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_19.10/Release.key && \
+RUN sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list" && \
+    curl -LO https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_20.04/Release.key && \
     apt-key add - < Release.key && apt-get update && \
     apt-get install -y --no-install-recommends cri-o-1.17
 
 # install podman
-RUN sh -c "echo 'deb https://dl.bintray.com/afbjorklund/podman eoan main' > /etc/apt/sources.list.d/podman.list" && \
+RUN sh -c "echo 'deb https://dl.bintray.com/afbjorklund/podman focal main' > /etc/apt/sources.list.d/podman.list" && \
     curl -L https://bintray.com/user/downloadSubjectPublicKey?username=afbjorklund -o afbjorklund-public.key.asc && \
     apt-key add - < afbjorklund-public.key.asc && apt-get update && \
-    apt-get install -y --no-install-recommends podman=1.9.3~1
+    apt-get install -y --no-install-recommends podman=1.8.2~2
 
 # install varlink
 RUN apt-get install -y --no-install-recommends varlink

--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -1,8 +1,8 @@
 ARG COMMIT_SHA
-# using base image created by kind https://github.com/kubernetes-sigs/kind/blob/master/images/base/Dockerfile
-# which is an ubuntu 19.10 with an entry-point that helps running systemd
+# using base image created by kind https://github.com/kubernetes-sigs/kind/blob/v0.8.1/images/base/Dockerfile
+# which is an ubuntu 20.04 with an entry-point that helps running systemd
 # could be changed to any debian that can run systemd
-FROM kindest/base:v20200317-92225082 as base
+FROM kindest/base:v20200430-2c0eee40 as base
 USER root
 # specify version of everything explicitly using 'apt-cache policy'
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Closes #8250 #8766 #8767

re-doing @afbjorklund 's PR https://github.com/kubernetes/minikube/pull/8251

the only failures are 

```

---------------- 5 Failures :( ----------------------------
[
  "TestStartStop/group/crio/serial/SecondStart",
  "TestNetworkPlugins/group/auto/DNS",
  "TestStartStop/group/crio/serial/UserAppExistsAfterStop",
  "TestStartStop/group/crio/serial/AddonExistsAfterStop",
  "TestStartStop/group/crio/serial/Pause"
]
```
the crio failures are because of crio package, https://github.com/kubernetes/minikube/issues/8861