### PR TITLE
Running internal kubectl command when minikube is called as 'kubectl'

### DIFF
--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	goflag "flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -73,6 +74,10 @@ var RootCmd = &cobra.Command{
 // Execute adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	_, callingCmd := filepath.Split(os.Args[0])
+	if callingCmd == "kubectl" {
+		os.Args = append([]string{"minikube", callingCmd}, os.Args[1:]...)
+	}
 	for _, c := range RootCmd.Commands() {
 		c.Short = translate.T(c.Short)
 		c.Long = translate.T(c.Long)

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -75,8 +75,9 @@ var RootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	_, callingCmd := filepath.Split(os.Args[0])
+
 	if callingCmd == "kubectl" {
-		os.Args = append([]string{"minikube", callingCmd}, os.Args[1:]...)
+		os.Args = append([]string{RootCmd.Use, callingCmd}, os.Args[1:]...)
 	}
 	for _, c := range RootCmd.Commands() {
 		c.Short = translate.T(c.Short)

--- a/site/content/en/docs/faq/_index.md
+++ b/site/content/en/docs/faq/_index.md
@@ -32,5 +32,5 @@ Please allocate sufficient resources for Knative setup using minikube, especiall
 
 ## Do I need to install kubectl locally?
 
-No, minikube comes with built-in kubectl [see minikube's kubectl documentation]({{< ref "docs/handbook/kubectl.md"}}). 
+No, minikube comes with built-in kubectl [see minikube's kubectl documentation]({{< ref "docs/handbook/kubectl.md" >}}). 
 

--- a/site/content/en/docs/faq/_index.md
+++ b/site/content/en/docs/faq/_index.md
@@ -29,3 +29,8 @@ minikube's bootstrapper, [Kubeadm](https://github.com/kubernetes/kubeadm) verifi
 Please allocate sufficient resources for Knative setup using minikube, especially when you run a minikube cluster on your local machine. We recommend allocating at least 6 CPUs and 8G memory.
 
 `minikube start --cpus 6 --memory 8000`
+
+## Do I need to install kubectl locally?
+
+No, minikube comes with built-in kubectl [see minikube's kubectl documentation]({{< ref "docs/handbook/kubectl.md"}}). 
+

--- a/site/content/en/docs/handbook/kubectl.md
+++ b/site/content/en/docs/handbook/kubectl.md
@@ -17,6 +17,10 @@ as well.
 
 You can also `alias kubectl="minikube kubectl --"` for easier usage.
 
+Alternatively, you can create a symbolic link to minikube's binary named 'kubectl'.
+
+`ln -s $(which minikube) /usr/local/bin/kubectl`
+
 Get pods
 
 `minikube kubectl -- get pods`

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -320,7 +320,7 @@ func validateMinikubeKubectlDirectCall(ctx context.Context, t *testing.T, profil
 	}
 	defer os.Remove(dstfn) // clean up
 
-	kubectlArgs := []string{"-p", profile, "--", "--context", profile, "get", "pods"}
+	kubectlArgs := []string{"get", "pods"}
 	rr, err := Run(t, exec.CommandContext(ctx, dstfn, kubectlArgs...))
 	if err != nil {
 		t.Fatalf("failed to run kubectl directl. args %q: %v", rr.Command(), err)

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	//	"io"
 	"net/http"
 	"net/url"
 	"os"

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -87,7 +87,7 @@ func TestFunctional(t *testing.T) {
 			{"KubectlGetPods", validateKubectlGetPods},      // Make sure apiserver is up
 			{"CacheCmd", validateCacheCmd},                  // Caches images needed for subsequent tests because of proxy
 			{"MinikubeKubectlCmd", validateMinikubeKubectl}, // Make sure `minikube kubectl` works
-			{"MinikubeKubectlCmdDirectly",validateMinikubeKubectlDirectCall},
+			{"MinikubeKubectlCmdDirectly", validateMinikubeKubectlDirectCall},
 		}
 		for _, tc := range tests {
 			tc := tc


### PR DESCRIPTION
Fixes issue #8857

Signed-off-by: Pablo Caderno <kaderno@gmail.com>

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

```
./out/minikube version
minikube version: v1.12.1
commit: f8406b6f02d65c1cf8d42219c30d24acedc9e8c3-dirty
```
```
 ./out/minikube kubectl version
Client Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.3", GitCommit:"06ad960bfd03b39c8310aaf92d1e7c12ce618213", GitTreeState:"clean", BuildDate:"2020-02-11T18:14:22Z", GoVersion:"go1.13.6", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.3", GitCommit:"06ad960bfd03b39c8310aaf92d1e7c12ce618213", GitTreeState:"clean", BuildDate:"2020-02-11T18:07:13Z", GoVersion:"go1.13.6", Compiler:"gc", Platform:"linux/amd64"}
```
```
 ./kubectl version
Client Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.3", GitCommit:"06ad960bfd03b39c8310aaf92d1e7c12ce618213", GitTreeState:"clean", BuildDate:"2020-02-11T18:14:22Z", GoVersion:"go1.13.6", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.3", GitCommit:"06ad960bfd03b39c8310aaf92d1e7c12ce618213", GitTreeState:"clean", BuildDate:"2020-02-11T18:07:13Z", GoVersion:"go1.13.6", Compiler:"gc", Platform:"linux/amd64"}
```
