### PR TITLE
advice user when allocate more than 80% of their memory

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -37,7 +37,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/shirou/gopsutil/cpu"
 	gopshost "github.com/shirou/gopsutil/host"
-	"github.com/shirou/gopsutil/mem"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	cmdcfg "k8s.io/minikube/cmd/minikube/cmd/config"
@@ -764,13 +763,13 @@ func validateUser(drvName string) {
 	}
 }
 
-// memoryLimits returns the amount of memory allocated to the system and hypervisor
+// memoryLimits returns the amount of memory allocated to the system and hypervisor , the return value is in MB
 func memoryLimits(drvName string) (int, int, error) {
-	v, err := mem.VirtualMemory()
+	info, err := machine.CachedHostInfo()
 	if err != nil {
 		return -1, -1, err
 	}
-	sysLimit := int(v.Total / 1024 / 1024)
+	sysLimit := int(info.Memory)
 	containerLimit := 0
 
 	if driver.IsKIC(drvName) {
@@ -822,6 +821,29 @@ func suggestMemoryAllocation(sysLimit int, containerLimit int, nodes int) int {
 	return suggested
 }
 
+// validateMemoryHardLimit checks if the user system has enough memory at all !
+func validateMemoryHardLimit(drvName string) {
+	s, c, err := memoryLimits(drvName)
+	if err != nil {
+		glog.Warningf("Unable to query memory limits: %v", err)
+		out.T(out.Conflict, "Failed to verify system memory limits.")
+	}
+	if s < 2200 {
+		out.WarningT("Your system has only {{.memory_amount}}MB memory. This might not work minimum required is 2000MB.", out.V{"memory_amount": s})
+	}
+	if driver.IsDockerDesktop(drvName) {
+		// in Docker Desktop if you allocate 2 GB the docker info shows:  Total Memory: 1.945GiB which becomes 1991 when we calculate the MBs
+		// thats why it is not same number as other drivers which is 2 GB
+		if c < 1991 {
+			out.WarningT(`Increase Docker for Desktop memory to at least 2.5GB or more:
+			
+	Docker for Desktop > Settings > Resources > Memory
+
+`)
+		}
+	}
+}
+
 // validateMemorySize validates the memory size matches the minimum recommended
 func validateMemorySize(req int, drvName string) {
 	sysLimit, containerLimit, err := memoryLimits(drvName)
@@ -843,22 +865,12 @@ func validateMemorySize(req int, drvName string) {
 			out.V{"requested": req, "recommended": minRecommendedMem})
 	}
 
-	if driver.IsDockerDesktop(drvName) {
-		// in Docker Desktop if you allocate 2 GB the docker info shows:  Total Memory: 1.945GiB which becomes 1991 when we calculate the MBs
-		// thats why it is not same number as other drivers which is 2 GB
-		if containerLimit < 1991 {
-			out.WarningT(`Increase Docker for Desktop memory to at least 2.5GB or more:
-			
-	Docker for Desktop > Settings > Resources > Memory
-
-`)
-		} else if containerLimit < 2997 && sysLimit > 8000 { // for users with more than 8 GB advice 3 GB
-			out.WarningT(`Your system has {{.system_limit}}MB memory but Docker has only {{.container_limit}}MB. For a better performance increase to at least 3GB.
+	if driver.IsDockerDesktop(drvName) && containerLimit < 2997 && sysLimit > 8000 { // for users with more than 8 GB advice 3 GB
+		out.WarningT(`Your system has {{.system_limit}}MB memory but Docker has only {{.container_limit}}MB. For a better performance increase to at least 3GB.
 
 	Docker for Desktop  > Settings > Resources > Memory
 
 `, out.V{"container_limit": containerLimit, "system_limit": sysLimit})
-		}
 	}
 
 	if req > sysLimit && !viper.GetBool(force) {
@@ -945,6 +957,7 @@ func validateFlags(cmd *cobra.Command, drvName string) {
 		}
 	}
 	validateCPUCount(drvName)
+	validateMemoryHardLimit(drvName)
 
 	if cmd.Flags().Changed(memory) {
 		if !driver.HasResourceLimits(drvName) {

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -826,7 +826,7 @@ func validateMemoryHardLimit(drvName string) {
 	s, c, err := memoryLimits(drvName)
 	if err != nil {
 		glog.Warningf("Unable to query memory limits: %v", err)
-		out.T(out.Conflict, "Failed to verify system memory limits.")
+		out.WarningT("Failed to verify system memory limits.")
 	}
 	if s < 2200 {
 		out.WarningT("Your system has only {{.memory_amount}}MB memory. This might not work minimum required is 2000MB.", out.V{"memory_amount": s})

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -950,6 +950,11 @@ func validateFlags(cmd *cobra.Command, drvName string) {
 		if !driver.HasResourceLimits(drvName) {
 			out.WarningT("The '{{.name}}' driver does not respect the --memory flag", out.V{"name": drvName})
 		}
+		req, err := util.CalculateSizeInMB(viper.GetString(memory))
+		if err != nil {
+			exit.WithCodeT(exit.Config, "Unable to parse memory '{{.memory}}': {{.error}}", out.V{"memory": viper.GetString(memory), "error": err})
+		}
+		validateMemorySize(req, drvName)
 	}
 
 	if cmd.Flags().Changed(containerRuntime) {

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -829,8 +829,9 @@ func validateMemorySize(req int, drvName string) {
 		glog.Warningf("Unable to query memory limits: %v", err)
 	}
 
-	// maximm ram they should allocate to minikube to prevent #8708
+	// maximm percent of their ram they could allocate to minikube to prevent #8708
 	maxAdvised := 0.79 * float64(sysLimit)
+	// a more sane alternative to their high memory 80%
 	minAdvised := 0.50 * float64(sysLimit)
 
 	if req < minUsableMem && !viper.GetBool(force) {

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -393,6 +393,9 @@ func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterC
 
 	cc := *existing
 
+	// validate the memory size in case user changed their system memory limits (example change docker desktop or upgraded memory.)
+	validateMemorySize(cc.Memory, cc.Driver)
+
 	if cmd.Flags().Changed(containerRuntime) {
 		cc.KubernetesConfig.ContainerRuntime = viper.GetString(containerRuntime)
 	}

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -236,9 +236,8 @@ func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k
 				exit.UsageT("{{.driver_name}} has only {{.container_limit}}MB memory but you specified {{.specified_memory}}MB", out.V{"container_limit": containerLimit, "specified_memory": mem, "driver_name": driver.FullName(drvName)})
 			}
 
-			validateMemorySize(mem, drvName)
-
 		} else {
+			validateMemorySize(mem, drvName)
 			glog.Infof("Using suggested %dMB memory alloc based on sys=%dMB, container=%dMB", mem, sysLimit, containerLimit)
 		}
 

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -236,11 +236,11 @@ func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k
 				exit.UsageT("{{.driver_name}} has only {{.container_limit}}MB memory but you specified {{.specified_memory}}MB", out.V{"container_limit": containerLimit, "specified_memory": mem, "driver_name": driver.FullName(drvName)})
 			}
 
+			validateMemorySize(mem, drvName)
+
 		} else {
 			glog.Infof("Using suggested %dMB memory alloc based on sys=%dMB, container=%dMB", mem, sysLimit, containerLimit)
 		}
-
-		validateMemorySize(mem, drvName)
 
 		diskSize, err := pkgutil.CalculateSizeInMB(viper.GetString(humanReadableDiskSize))
 		if err != nil {

--- a/pkg/minikube/machine/info.go
+++ b/pkg/minikube/machine/info.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/out/register"
 )
 
+// HostInfo holds information on the user's machine
 type HostInfo struct {
 	Memory   int64
 	CPUs     int
@@ -103,7 +104,7 @@ func logRemoteOsRelease(r command.Runner) {
 var cachedSystemMemoryLimit *mem.VirtualMemoryStat
 var cachedSystemMemoryErr *error
 
-//  cachedSysMemLimit will return a chaced limit for the system's virtual memory.
+//  cachedSysMemLimit will return a cached limit for the system's virtual memory.
 func cachedSysMemLimit() (*mem.VirtualMemoryStat, error) {
 	if cachedSystemMemoryLimit == nil {
 		v, err := mem.VirtualMemory()
@@ -116,7 +117,7 @@ func cachedSysMemLimit() (*mem.VirtualMemoryStat, error) {
 var cachedDiskInfo *disk.UsageStat
 var cachedDiskInfoeErr *error
 
-//  cachedSysMemLimit will return a cached disk usage info
+// cachedDisInfo will return a cached disk usage info
 func cachedDisInfo() (disk.UsageStat, error) {
 	if cachedDiskInfo == nil {
 		d, err := disk.Usage("/")

--- a/pkg/minikube/machine/info.go
+++ b/pkg/minikube/machine/info.go
@@ -54,7 +54,7 @@ func CachedHostInfo() (*HostInfo, error) {
 		return nil, err
 	}
 
-	d, err := cachedDisInfo()
+	d, err := cachedDiskInfo()
 	if err != nil {
 		glog.Warningf("Unable to get disk info: %v", err)
 		return nil, err
@@ -114,17 +114,17 @@ func cachedSysMemLimit() (*mem.VirtualMemoryStat, error) {
 	return cachedSystemMemoryLimit, *cachedSystemMemoryErr
 }
 
-var cachedDiskInfo *disk.UsageStat
+var cachedDisk *disk.UsageStat
 var cachedDiskInfoeErr *error
 
-// cachedDisInfo will return a cached disk usage info
-func cachedDisInfo() (disk.UsageStat, error) {
-	if cachedDiskInfo == nil {
+// cachedDiskInfo will return a cached disk usage info
+func cachedDiskInfo() (disk.UsageStat, error) {
+	if cachedDisk == nil {
 		d, err := disk.Usage("/")
-		cachedDiskInfo = d
+		cachedDisk = d
 		cachedDiskInfoeErr = &err
 	}
-	return *cachedDiskInfo, *cachedDiskInfoeErr
+	return *cachedDisk, *cachedDiskInfoeErr
 }
 
 var cachedCPU *[]cpu.InfoStat

--- a/pkg/minikube/machine/start.go
+++ b/pkg/minikube/machine/start.go
@@ -251,7 +251,7 @@ func acquireMachinesLock(name string) (mutex.Releaser, error) {
 func showHostInfo(cfg config.ClusterConfig) {
 	machineType := driver.MachineType(cfg.Driver)
 	if driver.BareMetal(cfg.Driver) {
-		info, err := getHostInfo()
+		info, err := CachedHostInfo()
 		if err == nil {
 			register.Reg.SetStep(register.RunningLocalhost)
 			out.T(out.StartingNone, "Running on localhost (CPUs={{.number_of_cpus}}, Memory={{.memory_size}}MB, Disk={{.disk_size}}MB) ...", out.V{"number_of_cpus": info.CPUs, "memory_size": info.Memory, "disk_size": info.DiskSize})


### PR DESCRIPTION
closes this https://github.com/kubernetes/minikube/issues/8708
also fixed a bug that the advice was showing twice.
and also fixed the bug that we were not checking for allowing max
also moves all the calls to getting CPU/memory info into a cached func for less overhead

## before this PR

allowing more than max memory was allowed.

## after this PR on a macbook with 16 GB ram

#### Don't allow 17GB
```
medya@~/workspace/minikube (max_memory) $ make && ./out/minikube start --driver=hyperkit --memory=17gb

😄  minikube v1.12.1 on Darwin 10.15.6
✨  Using the hyperkit driver based on user configuration
💡  To suppress memory validations you can use --force flag.
💣  Requested memory allocation 17408MB is more than your system limit 16384MB. Try specifying a lower memory:

        miniube start --memory=8192mb
```


#### Advice more than 80% allocation.
```

medya@~/workspace/minikube (max_memory) $ make && ./out/minikube start --driver=hyperkit --memory=15gb
make: `out/minikube' is up to date.
😄  minikube v1.12.1 on Darwin 10.15.6
✨  Using the hyperkit driver based on user configuration
❗  You are allocating 15360MB to memory and your system only has 16384MB. You might face issues. try specifying a lower memory:

                miniube start --memory=8192mb


💡  To suppress and ignore this warning you can use --force flag.
👍  Starting control plane node minikube in cluster minikube
🔥  Creating hyperkit VM (CPUs=2, Memory=15360MB, Disk=20000MB) ...
```