### PR TITLE
Use mebibytes instead of megabytes

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 
 	"github.com/blang/semver"
+	"github.com/docker/go-units"
 	"github.com/docker/machine/libmachine/ssh"
 	"github.com/golang/glog"
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -793,7 +794,7 @@ func memoryLimits(drvName string) (int, int, error) {
 		if err != nil {
 			return -1, -1, err
 		}
-		containerLimit = int(s.TotalMemory / 1024 / 1024)
+		containerLimit = int(s.TotalMemory / units.MiB)
 	}
 
 	return sysLimit, containerLimit, nil

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -29,7 +29,6 @@ import (
 	"strings"
 
 	"github.com/blang/semver"
-	"github.com/docker/go-units"
 	"github.com/docker/machine/libmachine/ssh"
 	"github.com/golang/glog"
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -794,7 +793,7 @@ func memoryLimits(drvName string) (int, int, error) {
 		if err != nil {
 			return -1, -1, err
 		}
-		containerLimit = int(s.TotalMemory / units.MiB)
+		containerLimit = util.ConvertBytesToMB(s.TotalMemory)
 	}
 
 	return sysLimit, containerLimit, nil

--- a/pkg/drivers/common.go
+++ b/pkg/drivers/common.go
@@ -23,13 +23,13 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"github.com/docker/go-units"
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/mcnflag"
 	"github.com/docker/machine/libmachine/mcnutils"
 	"github.com/docker/machine/libmachine/ssh"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"k8s.io/minikube/pkg/util"
 )
 
 // This file is for common code shared among internal machine drivers
@@ -51,12 +51,6 @@ func (d *CommonDriver) GetCreateFlags() []mcnflag.Flag {
 // SetConfigFromFlags is not implemented yet
 func (d *CommonDriver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	return nil
-}
-
-func diskSizeInMiB(diskSizeMB int) int64 {
-	result := int64(diskSizeMB)
-	result *= units.MiB
-	return result
 }
 
 func createRawDiskImage(sshKeyPath, diskPath string, diskSizeMb int) error {
@@ -81,7 +75,7 @@ func createRawDiskImage(sshKeyPath, diskPath string, diskSizeMb int) error {
 		return errors.Wrapf(err, "closing file %s", diskPath)
 	}
 
-	if err := os.Truncate(diskPath, diskSizeInMiB(diskSizeMb)); err != nil {
+	if err := os.Truncate(diskPath, util.ConvertMBToBytes(diskSizeMb)); err != nil {
 		return errors.Wrap(err, "truncate")
 	}
 	return nil

--- a/pkg/drivers/common.go
+++ b/pkg/drivers/common.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"github.com/docker/go-units"
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/mcnflag"
 	"github.com/docker/machine/libmachine/mcnutils"
@@ -52,6 +53,12 @@ func (d *CommonDriver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	return nil
 }
 
+func diskSizeInMiB(diskSizeMB int) int64 {
+	result := int64(diskSizeMB)
+	result *= units.MiB
+	return result
+}
+
 func createRawDiskImage(sshKeyPath, diskPath string, diskSizeMb int) error {
 	tarBuf, err := mcnutils.MakeDiskImage(sshKeyPath)
 	if err != nil {
@@ -74,7 +81,7 @@ func createRawDiskImage(sshKeyPath, diskPath string, diskSizeMb int) error {
 		return errors.Wrapf(err, "closing file %s", diskPath)
 	}
 
-	if err := os.Truncate(diskPath, int64(diskSizeMb*1000000)); err != nil {
+	if err := os.Truncate(diskPath, diskSizeInMiB(diskSizeMb)); err != nil {
 		return errors.Wrap(err, "truncate")
 	}
 	return nil

--- a/pkg/drivers/common_test.go
+++ b/pkg/drivers/common_test.go
@@ -36,7 +36,7 @@ func Test_createDiskImage(t *testing.T) {
 	diskPath := filepath.Join(tmpdir, "disk")
 
 	sizeInMb := 100
-	sizeInBytes := int64(sizeInMb) * 1000000
+	sizeInBytes := int64(104857600)
 	if err := createRawDiskImage(sshPath, diskPath, sizeInMb); err != nil {
 		t.Errorf("createDiskImage() error = %v", err)
 	}

--- a/pkg/drivers/kvm/domain.go
+++ b/pkg/drivers/kvm/domain.go
@@ -31,8 +31,8 @@ import (
 
 const domainTmpl = `
 <domain type='kvm'>
-  <name>{{.MachineName}}</name> 
-  <memory unit='MB'>{{.Memory}}</memory>
+  <name>{{.MachineName}}</name>
+  <memory unit='MiB'>{{.Memory}}</memory>
   <vcpu>{{.CPU}}</vcpu>
   <features>
     <acpi/>

--- a/pkg/minikube/machine/info.go
+++ b/pkg/minikube/machine/info.go
@@ -20,7 +20,6 @@ import (
 	"io/ioutil"
 	"os/exec"
 
-	"github.com/docker/go-units"
 	"github.com/docker/machine/libmachine/provision"
 	"github.com/golang/glog"
 	"github.com/shirou/gopsutil/cpu"
@@ -30,6 +29,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/out/register"
 	"k8s.io/minikube/pkg/minikube/style"
+	"k8s.io/minikube/pkg/util"
 )
 
 // HostInfo holds information on the user's machine
@@ -37,10 +37,6 @@ type HostInfo struct {
 	Memory   int64
 	CPUs     int
 	DiskSize int64
-}
-
-func megs(bytes uint64) int64 {
-	return int64(bytes / units.MiB)
 }
 
 // CachedHostInfo returns system information such as memory,CPU, DiskSize
@@ -62,8 +58,8 @@ func CachedHostInfo() (*HostInfo, error, error, error) {
 
 	var info HostInfo
 	info.CPUs = len(i)
-	info.Memory = megs(v.Total)
-	info.DiskSize = megs(d.Total)
+	info.Memory = util.ConvertUnsignedBytesToMB(v.Total)
+	info.DiskSize = util.ConvertUnsignedBytesToMB(d.Total)
 	return &info, cpuErr, memErr, diskErr
 }
 

--- a/pkg/minikube/machine/info.go
+++ b/pkg/minikube/machine/info.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os/exec"
 
+	"github.com/docker/go-units"
 	"github.com/docker/machine/libmachine/provision"
 	"github.com/golang/glog"
 	"github.com/shirou/gopsutil/cpu"
@@ -39,7 +40,7 @@ type HostInfo struct {
 }
 
 func megs(bytes uint64) int64 {
-	return int64(bytes / 1024 / 1024)
+	return int64(bytes / units.MiB)
 }
 
 // CachedHostInfo returns system information such as memory,CPU, DiskSize

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -24,7 +24,7 @@ import (
 	"strconv"
 
 	"github.com/blang/semver"
-	"github.com/docker/go-units"
+	units "github.com/docker/go-units"
 	"github.com/pkg/errors"
 )
 
@@ -45,6 +45,18 @@ func CalculateSizeInMB(humanReadableSize string) (int, error) {
 	}
 
 	return int(size / units.MiB), nil
+}
+
+func ConvertMBToBytes(mbSize int) int64 {
+	return int64(mbSize) * units.MiB
+}
+
+func ConvertBytesToMB(byteSize int64) int {
+	return int(ConvertUnsignedBytesToMB(uint64(byteSize)))
+}
+
+func ConvertUnsignedBytesToMB(byteSize uint64) int64 {
+	return int64(byteSize / units.MiB)
 }
 
 // GetBinaryDownloadURL returns a suitable URL for the platform


### PR DESCRIPTION
It's a minor nitpick but I believe that the hard drive and memory assigned while using KVM and platforms using raw disks was meant to be MiB based on [this](https://github.com/kubernetes/minikube/blob/294a5c3e7b363a999bdb5f73ef6e1b2b8b275193/pkg/util/utils.go#L35-L48). This patch simply calculates disk size in MiB and assigns the correct unit in the domain configruation for libvirt.