### PR TITLE
fixes(#8301): --help: bool flags which default to 'false' yield confusing output

### DIFF
--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -104,7 +104,7 @@ You may select another namespace by using 'minikube service {{.service}} -n <nam
 func init() {
 	serviceCmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "The service namespace")
 	serviceCmd.Flags().BoolVar(&serviceURLMode, "url", false, "Display the Kubernetes service URL in the CLI instead of opening it in the default browser")
-	serviceCmd.Flags().BoolVar(&https, "https", false, "Open the service URL with https instead of http")
+	serviceCmd.Flags().BoolVar(&https, "https", false, "Open the service URL with https instead of http (defaults to \"false\")")
 	serviceCmd.Flags().IntVar(&wait, "wait", service.DefaultWait, "Amount of time to wait for a service in seconds")
 	serviceCmd.Flags().IntVar(&interval, "interval", service.DefaultInterval, "The initial time interval for each check that wait performs in seconds")
 

--- a/site/content/en/docs/commands/service.md
+++ b/site/content/en/docs/commands/service.md
@@ -22,7 +22,7 @@ minikube service [flags] SERVICE
 ```
       --format string      Format to output service URL in. This format will be applied to each url individually and they will be printed one at a time. (default "http://{{.IP}}:{{.Port}}")
   -h, --help               help for service
-      --https              Open the service URL with https instead of http
+      --https              Open the service URL with https instead of http (defaults to "false")
       --interval int       The initial time interval for each check that wait performs in seconds (default 1)
   -n, --namespace string   The service namespace (default "default")
       --url                Display the Kubernetes service URL in the CLI instead of opening it in the default browser


### PR DESCRIPTION
Adds the help-text mentioned in [#8301 (comment)](https://github.com/kubernetes/minikube/issues/8301#issuecomment-635582825)