### PR TITLE
Add "minikube" and machineName to docker certificate SANs

### DIFF
--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -101,7 +101,7 @@ func configureAuth(p miniProvisioner) error {
 	}
 
 	// The Host IP is always added to the certificate's SANs list
-	hosts := append(authOptions.ServerCertSANs, ip, "localhost", "127.0.0.1")
+	hosts := append(authOptions.ServerCertSANs, ip, "localhost", "127.0.0.1", "minikube", machineName)
 	glog.Infof("generating server cert: %s ca-key=%s private-key=%s org=%s san=%s",
 		authOptions.ServerCertPath,
 		authOptions.CaCertPath,


### PR DESCRIPTION
Fixes #6367

The solution does not take the `--apiserver-name` parameter into consideration as proposed but instead some sane defaults which also make sense for the docker daemon certificate.

Before:
```
$ openssl s_client -showcerts -connect DOCKER_HOST_WITH_PORT < /dev/null | openssl x509 -text | grep Alternative -A1
...
            X509v3 Subject Alternative Name:
                DNS:localhost, IP Address:172.17.0.3, IP Address:127.0.0.1
```

After with profile specified:
```
            X509v3 Subject Alternative Name:
                DNS:localhost, DNS:minikube, DNS:after, IP Address:192.168.64.93, IP Address:127.0.0.1
```

After with no profile specified:
```
            X509v3 Subject Alternative Name:
                DNS:localhost, DNS:minikube, DNS:minikube, IP Address:172.17.0.4, IP Address:127.0.0.1
```
Includes minikube twice as this is the default `machineName` as it seems but it shouldn't hurt.