### PR TITLE
don't set event log on deletion

### DIFF
--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -126,7 +126,7 @@ func runDelete(cmd *cobra.Command, args []string) {
 	if len(args) > 0 {
 		exit.UsageT("Usage: minikube delete")
 	}
-	register.SetEventLogPath(localpath.EventLog(ClusterFlagValue()))
+	//register.SetEventLogPath(localpath.EventLog(ClusterFlagValue()))
 	register.Reg.SetStep(register.Deleting)
 
 	validProfiles, invalidProfiles, err := config.ListProfiles()


### PR DESCRIPTION
This breaks `minikube delete` for windows since it can't delete the event log as it uses separate processes to run the delete and to write to the file.

There isn't a real need to write to a file that's about to be deleted anyway.

Before:
```
$ minikube delete
* Stopping node "minikube"  ...
* Powering off "minikube" via SSH ...
* Deleting "minikube" in hyperv ...
* Trying to delete invalid profile minikube
X remove C:\Users\sharif\.minikube\profiles\minikube\events.json: The process cannot access the file because it is being used by another process.
```

After:
```
$ minikube delete
* Stopping node "minikube"  ...
* Powering off "minikube" via SSH ...
* Deleting "minikube" in hyperv ...
* Removed all traces of the "minikube" cluster.
```