### PR TITLE
Add prune docker images instructions

### DIFF
--- a/pkg/minikube/machine/advice.go
+++ b/pkg/minikube/machine/advice.go
@@ -41,6 +41,7 @@ func MaybeDisplayAdvice(err error, driver string) {
 		out.T(style.Tip, "If you are still interested to make {{.driver_name}} driver work. The following suggestions might help you get passed this issue:", out.V{"driver_name": driver})
 		out.T(style.Empty, `
 	- Prune unused {{.driver_name}} images, volumes, networks and abandoned containers.
+
 		docker system prune --volumes`, out.V{"driver_name": driver})
 		out.T(style.Empty, `
 	- Restart your {{.driver_name}} service`, out.V{"driver_name": driver})

--- a/pkg/minikube/machine/advice.go
+++ b/pkg/minikube/machine/advice.go
@@ -40,7 +40,8 @@ func MaybeDisplayAdvice(err error, driver string) {
 	if errors.Is(err, oci.ErrExitedUnexpectedly) || errors.Is(err, oci.ErrDaemonInfo) {
 		out.T(style.Tip, "If you are still interested to make {{.driver_name}} driver work. The following suggestions might help you get passed this issue:", out.V{"driver_name": driver})
 		out.T(style.Empty, `
-	- Prune unused {{.driver_name}} images, volumes and abandoned containers.`, out.V{"driver_name": driver})
+	- Prune unused {{.driver_name}} images, volumes, networks and abandoned containers.
+		docker system prune --volumes`, out.V{"driver_name": driver})
 		out.T(style.Empty, `
 	- Restart your {{.driver_name}} service`, out.V{"driver_name": driver})
 		if runtime.GOOS != "linux" {

--- a/pkg/minikube/machine/advice.go
+++ b/pkg/minikube/machine/advice.go
@@ -39,10 +39,12 @@ func MaybeDisplayAdvice(err error, driver string) {
 
 	if errors.Is(err, oci.ErrExitedUnexpectedly) || errors.Is(err, oci.ErrDaemonInfo) {
 		out.T(style.Tip, "If you are still interested to make {{.driver_name}} driver work. The following suggestions might help you get passed this issue:", out.V{"driver_name": driver})
-		out.T(style.Empty, `
+		if driver == oci.Docker || driver == oci.Podman {
+			out.T(style.Empty, `
 	- Prune unused {{.driver_name}} images, volumes, networks and abandoned containers.
 
-		docker system prune --volumes`, out.V{"driver_name": driver})
+		{{.driver_name}} system prune --volumes`, out.V{"driver_name": driver})
+		}
 		out.T(style.Empty, `
 	- Restart your {{.driver_name}} service`, out.V{"driver_name": driver})
 		if runtime.GOOS != "linux" {


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/minikube/issues/8894

Add instructions on the docker command required to remove the following:
  - all stopped containers
  - all networks not used by at least one container
  - all volumes not used by at least one container
  - all dangling images
  - all dangling build cache


#### Output:
```
💡  If you are still interested to make docker driver work. The following suggestions might help you get passed this issue:

	- Prune unused docker images, volumes, networks and abandoned containers.
		
		docker system prune --volumes

	- Restart your docker service

	- Delete and recreate minikube cluster
		minikube delete
		minikube start --driver=docker

```