### PR TITLE
Add ImagesPreloaded to cruntime Manager interface

### DIFF
--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -412,3 +412,7 @@ func containerdImagesPreloaded(runner command.Runner, images []string) bool {
 	glog.Infof("all images are preloaded for containerd runtime.")
 	return true
 }
+
+func (r *Containerd) ImagesPreloaded(images []string) bool {
+	return containerdImagesPreloaded(r.Runner, images)
+}

--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -326,6 +326,10 @@ func crioImagesPreloaded(runner command.Runner, images []string) bool {
 	return true
 }
 
+func (r *CRIO) ImagesPreloaded(images []string) bool {
+	return crioImagesPreloaded(r.Runner, images)
+}
+
 // UpdateCRIONet updates CRIO CNI network configuration and restarts it
 func UpdateCRIONet(r CommandRunner, cidr string) error {
 	glog.Infof("Updating CRIO to use CIDR: %q", cidr)

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -107,6 +107,8 @@ type Manager interface {
 	SystemLogCmd(int) string
 	// Preload preloads the container runtime with k8s images
 	Preload(config.KubernetesConfig) error
+	// ImagesPreloaded returns true if all images have been preloaded
+	ImagesPreloaded([]string) bool
 }
 
 // Config is runtime configuration
@@ -226,15 +228,4 @@ func enableIPForwarding(cr CommandRunner) error {
 		return errors.Wrapf(err, "ip_forward")
 	}
 	return nil
-}
-
-// ImagesPreloaded returns true if all images have been preloaded
-func ImagesPreloaded(containerRuntime string, runner command.Runner, images []string) bool {
-	if containerRuntime == "docker" {
-		return dockerImagesPreloaded(runner, images)
-	}
-	if containerRuntime == "containerd" {
-		return containerdImagesPreloaded(runner, images)
-	}
-	return false
 }

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -404,3 +404,7 @@ func dockerBoundToContainerd(runner command.Runner) bool {
 
 	return false
 }
+
+func (r *Docker) ImagesPreloaded(images []string) bool {
+	return dockerImagesPreloaded(r.Runner, images)
+}


### PR DESCRIPTION
To make sure that it is actually called for all container runtimes,
including CRIO which was missing (only had Docker and Containerd)

Closes #8919