### PR TITLE
Removing stale information from the docker driver docs

### DIFF
--- a/site/content/en/docs/drivers/docker.md
+++ b/site/content/en/docs/drivers/docker.md
@@ -23,7 +23,7 @@ The Docker driver allows you to install Kubernetes into an existing Docker insta
 
 - On macOS, containers might get hung and require a restart of Docker for Desktop. See [docker/for-mac#1835](https://github.com/docker/for-mac/issues/1835)
 
-- The `ingress`, `ingress-dns` and `registry` addons are currently only supported on Linux. See [#7332](https://github.com/kubernetes/minikube/issues/7332) and [#7535](https://github.com/kubernetes/minikube/issues/7535)
+- The `ingress`, and `ingress-dns` addons are currently only supported on Linux. See [#7332](https://github.com/kubernetes/minikube/issues/7332)
 
 - On WSL2 (experimental - see [#5392](https://github.com/kubernetes/minikube/issues/5392)), you may need to run:
 


### PR DESCRIPTION
It looks like there was a fix for the registry addon not working on Mac OS X [here](https://github.com/kubernetes/minikube/issues/7535), so updating the documentation to remove that warning as the warning is no longer correct.