### PR TITLE
Fix a small markdown syntax error on minikube.sigs.k8s.io/docs/faq/

### DIFF
--- a/site/content/en/docs/faq/_index.md
+++ b/site/content/en/docs/faq/_index.md
@@ -20,6 +20,6 @@ Alternatively, configure `sudo` to never prompt for the commands issued by minik
 
 ## How to ignore system verification?
 
-minikube's bootstrapper, [Kubeadm] (https://github.com/kubernetes/kubeadm) verifies a list of features on the host system before installing Kubernetes. in case you get this error, and you still want to try minikube anyways despite your system's limitation you can skip the verification by starting minikube with this extra option:
+minikube's bootstrapper, [Kubeadm](https://github.com/kubernetes/kubeadm) verifies a list of features on the host system before installing Kubernetes. in case you get this error, and you still want to try minikube anyways despite your system's limitation you can skip the verification by starting minikube with this extra option:
 
 `minikube start --extra-config kubeadm.ignore-preflight-errors=SystemVerification`


### PR DESCRIPTION
Hello, I found there is a small error on [FAQ page](https://minikube.sigs.k8s.io/docs/faq/#how-to-ignore-system-verification) of the documentation as shown in the following screenshot:

![Screenshot from 2020-08-08 13-49-19](https://user-images.githubusercontent.com/1425259/89702618-fef79800-d97d-11ea-9bf4-91a5869850b0.png)

This PR removes an extra space from the Markdown file.

Thank you.