### PR TITLE
increase memory for functional test

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -336,6 +336,8 @@ jobs:
           echo "------------------------"
           docker volume ls
           echo "------------------------"
+          docker system info --format {{json .}}
+          echo "------------------------"
       - uses: actions/setup-go@v2
         with:
           go-version: '1.14.6'

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -359,7 +359,7 @@ jobs:
           $env:KUBECONFIG="${pwd}\testhome\kubeconfig"
           $env:MINIKUBE_HOME="${pwd}\testhome"
           $ErrorActionPreference = "SilentlyContinue"
-          .\e2e-windows-amd64.exe --minikube-start-args="--driver=docker" --test.timeout=10m --timeout-multiplier=1 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Tee-Object -FilePath ".\report\testout.txt"
+          .\e2e-windows-amd64.exe --minikube-start-args="--driver=docker" --test.timeout=15m --timeout-multiplier=1 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Tee-Object -FilePath ".\report\testout.txt"
           $END_TIME=(GET-DATE)
           echo $END_TIME
           $DURATION=(NEW-TIMESPAN -Start $START_TIME -End $END_TIME)
@@ -495,7 +495,7 @@ jobs:
           $env:KUBECONFIG="${pwd}\testhome\kubeconfig"
           $env:MINIKUBE_HOME="${pwd}\testhome"
           $ErrorActionPreference = "SilentlyContinue"
-          .\e2e-windows-amd64.exe --minikube-start-args="--driver=hyperv" --test.timeout=13m --timeout-multiplier=1.5 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Tee-Object -FilePath ".\report\testout.txt"
+          .\e2e-windows-amd64.exe --minikube-start-args="--driver=hyperv" --test.timeout=15m --timeout-multiplier=1.5 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Tee-Object -FilePath ".\report\testout.txt"
           $END_TIME=(GET-DATE)
           echo $END_TIME
           $DURATION=(NEW-TIMESPAN -Start $START_TIME -End $END_TIME)

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -336,7 +336,7 @@ jobs:
           echo "------------------------"
           docker volume ls
           echo "------------------------"
-          docker system info --format {{json .}}
+          docker system info --format '{{json .}}'
           echo "------------------------"
       - uses: actions/setup-go@v2
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -357,7 +357,7 @@ jobs:
           $env:KUBECONFIG="${pwd}\testhome\kubeconfig"
           $env:MINIKUBE_HOME="${pwd}\testhome"
           $ErrorActionPreference = "SilentlyContinue"
-          .\e2e-windows-amd64.exe --minikube-start-args="--driver=docker" --test.timeout=10m --timeout-multiplier=1 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Tee-Object -FilePath ".\report\testout.txt"
+          .\e2e-windows-amd64.exe --minikube-start-args="--driver=docker" --test.timeout=15m --timeout-multiplier=1 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Tee-Object -FilePath ".\report\testout.txt"
           $END_TIME=(GET-DATE)
           echo $END_TIME
           $DURATION=(NEW-TIMESPAN -Start $START_TIME -End $END_TIME)
@@ -493,7 +493,7 @@ jobs:
           $env:KUBECONFIG="${pwd}\testhome\kubeconfig"
           $env:MINIKUBE_HOME="${pwd}\testhome"
           $ErrorActionPreference = "SilentlyContinue"
-          .\e2e-windows-amd64.exe --minikube-start-args="--driver=hyperv" --test.timeout=13m --timeout-multiplier=1.5 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Tee-Object -FilePath ".\report\testout.txt"
+          .\e2e-windows-amd64.exe --minikube-start-args="--driver=hyperv" --test.timeout=15m --timeout-multiplier=1.5 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Tee-Object -FilePath ".\report\testout.txt"
           $END_TIME=(GET-DATE)
           echo $END_TIME
           $DURATION=(NEW-TIMESPAN -Start $START_TIME -End $END_TIME)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -334,7 +334,7 @@ jobs:
           echo "------------------------"
           docker volume ls
           echo "------------------------"
-          docker system info --format {{json .}}
+          docker system info --format '{{json .}}'
           echo "------------------------"
       - uses: actions/setup-go@v2
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -334,6 +334,8 @@ jobs:
           echo "------------------------"
           docker volume ls
           echo "------------------------"
+          docker system info --format {{json .}}
+          echo "------------------------"
       - uses: actions/setup-go@v2
         with:
           go-version: '1.14.6'

--- a/test/integration/fn_pvc_test.go
+++ b/test/integration/fn_pvc_test.go
@@ -126,7 +126,7 @@ func createPVTestPod(ctx context.Context, t *testing.T, profile string) {
 		t.Fatalf("kubectl apply pvc.yaml failed: args %q: %v", rr.Command(), err)
 	}
 	// wait for pod to be running
-	if _, err := PodWait(ctx, t, profile, "default", "test=storage-provisioner", Minutes(1)); err != nil {
+	if _, err := PodWait(ctx, t, profile, "default", "test=storage-provisioner", Minutes(3)); err != nil {
 		t.Fatalf("failed waiting for pod: %v", err)
 	}
 }

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -211,7 +211,7 @@ func validateStartWithProxy(ctx context.Context, t *testing.T, profile string) {
 
 	// Use more memory so that we may reliably fit MySQL and nginx
 	// changing api server so later in soft start we verify it didn't change
-	startArgs := append([]string{"start", "-p", profile, "--memory=2800", fmt.Sprintf("--apiserver-port=%d", apiPortTest), "--wait=true"}, StartArgs()...)
+	startArgs := append([]string{"start", "-p", profile, "--memory=4000", fmt.Sprintf("--apiserver-port=%d", apiPortTest), "--wait=true"}, StartArgs()...)
 	c := exec.CommandContext(ctx, Target(), startArgs...)
 	env := os.Environ()
 	env = append(env, fmt.Sprintf("HTTP_PROXY=%s", srv.Addr))

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -247,7 +247,7 @@ func validateSoftStart(ctx context.Context, t *testing.T, profile string) {
 		t.Errorf("expected cluster config node port before soft start to be %d but got %d", apiPortTest, beforeCfg.Config.KubernetesConfig.NodePort)
 	}
 
-	softStartArgs := []string{"start", "-p", profile}
+	softStartArgs := []string{"start", "-p", profile, "--alsologtstderr", "-v=8"}
 	c := exec.CommandContext(ctx, Target(), softStartArgs...)
 	rr, err := Run(t, c)
 	if err != nil {

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -247,7 +247,7 @@ func validateSoftStart(ctx context.Context, t *testing.T, profile string) {
 		t.Errorf("expected cluster config node port before soft start to be %d but got %d", apiPortTest, beforeCfg.Config.KubernetesConfig.NodePort)
 	}
 
-	softStartArgs := []string{"start", "-p", profile, "--alsologtstderr", "-v=8"}
+	softStartArgs := []string{"start", "-p", profile, "--alsologtostderr", "-v=8"}
 	c := exec.CommandContext(ctx, Target(), softStartArgs...)
 	rr, err := Run(t, c)
 	if err != nil {


### PR DESCRIPTION
redoing this PR with a better method
https://github.com/kubernetes/minikube/pull/8916


also increasing the timeout for windows test to reduce flakes

also adjusting waiting for PVC as seen in gh action

```
2020-08-10T19:53:24.7790500Z     fn_pvc_test.go:129: ***** TestFunctional/parallel/PersistentVolumeClaim: pod "test=storage-provisioner" failed to start within 1m0s: timed out waiting for the condition ****
2020-08-10T19:53:24.7793070Z     fn_pvc_test.go:129: (dbg) Run:  ./minikube-darwin-amd64 status --format={{.APIServer}} -p functional-20200810194816-1038 -n functional-20200810194816-1038
2020-08-10T19:53:27.2193820Z     fn_pvc_test.go:129: (dbg) Done: ./minikube-darwin-amd64 status --format={{.APIServer}} -p functional-20200810194816-1038 -n functional-20200810194816-1038: (2.441760342s)
2020-08-10T19:53:27.2196090Z     fn_pvc_test.go:129: TestFunctional/parallel/PersistentVolumeClaim: showing logs for failed pods as of 2020-08-10 19:53:27.218965 +0000 UTC m=+310.950083066
```