### PR TITLE
improve error handling for validating memory limits

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -497,7 +497,7 @@ jobs:
           $env:KUBECONFIG="${pwd}\testhome\kubeconfig"
           $env:MINIKUBE_HOME="${pwd}\testhome"
           $ErrorActionPreference = "SilentlyContinue"
-          .\e2e-windows-amd64.exe --minikube-start-args="--driver=hyperv" --test.timeout=15m --timeout-multiplier=1.5 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Tee-Object -FilePath ".\report\testout.txt"
+          .\e2e-windows-amd64.exe --minikube-start-args="--driver=hyperv" --test.timeout=20m --timeout-multiplier=1.5 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Tee-Object -FilePath ".\report\testout.txt"
           $END_TIME=(GET-DATE)
           echo $END_TIME
           $DURATION=(NEW-TIMESPAN -Start $START_TIME -End $END_TIME)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -495,7 +495,7 @@ jobs:
           $env:KUBECONFIG="${pwd}\testhome\kubeconfig"
           $env:MINIKUBE_HOME="${pwd}\testhome"
           $ErrorActionPreference = "SilentlyContinue"
-          .\e2e-windows-amd64.exe --minikube-start-args="--driver=hyperv" --test.timeout=15m --timeout-multiplier=1.5 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Tee-Object -FilePath ".\report\testout.txt"
+          .\e2e-windows-amd64.exe --minikube-start-args="--driver=hyperv" --test.timeout=20m --timeout-multiplier=1.5 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Tee-Object -FilePath ".\report\testout.txt"
           $END_TIME=(GET-DATE)
           echo $END_TIME
           $DURATION=(NEW-TIMESPAN -Start $START_TIME -End $END_TIME)

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -827,9 +827,11 @@ func validateMemoryHardLimit(drvName string) {
 	if err != nil {
 		glog.Warningf("Unable to query memory limits: %v", err)
 		out.WarningT("Failed to verify system memory limits.")
+		return
 	}
 	if s < 2200 {
 		out.WarningT("Your system has only {{.memory_amount}}MB memory. This might not work minimum required is 2000MB.", out.V{"memory_amount": s})
+		return
 	}
 	if driver.IsDockerDesktop(drvName) {
 		// in Docker Desktop if you allocate 2 GB the docker info shows:  Total Memory: 1.945GiB which becomes 1991 when we calculate the MBs

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -764,7 +764,7 @@ func validateUser(drvName string) {
 }
 
 // memoryLimits returns the amount of memory allocated to the system and hypervisor , the return value is in MB
-func memoryLimits(drvName string) (int, int, error) {
+func memoryLimits(drvName string) (int, int, []error) {
 	info, err := machine.CachedHostInfo()
 	if err != nil {
 		return -1, -1, err
@@ -775,7 +775,7 @@ func memoryLimits(drvName string) (int, int, error) {
 	if driver.IsKIC(drvName) {
 		s, err := oci.CachedDaemonInfo(drvName)
 		if err != nil {
-			return -1, -1, err
+			return -1, -1, []error{err}
 		}
 		containerLimit = int(s.TotalMemory / 1024 / 1024)
 	}

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -220,14 +220,14 @@ func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k
 		cc = updateExistingConfigFromFlags(cmd, existing)
 	} else {
 		glog.Info("no existing cluster config was found, will generate one from the flags ")
-		sysLimit, containerLimit, err := memoryLimits(drvName)
-		if err != nil {
-			glog.Warningf("Unable to query memory limits: %v", err)
+		sysLimit, containerLimit, errs := memoryLimits(drvName)
+		if errs != nil {
+			glog.Warningf("Unable to query memory limits: %+v", errs)
 		}
 
 		mem := suggestMemoryAllocation(sysLimit, containerLimit, viper.GetInt(nodes))
 		if cmd.Flags().Changed(memory) {
-			mem, err = pkgutil.CalculateSizeInMB(viper.GetString(memory))
+			mem, err := pkgutil.CalculateSizeInMB(viper.GetString(memory))
 			if err != nil {
 				exit.WithCodeT(exit.Config, "Generate unable to parse memory '{{.memory}}': {{.error}}", out.V{"memory": viper.GetString(memory), "error": err})
 			}

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -220,9 +220,9 @@ func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k
 		cc = updateExistingConfigFromFlags(cmd, existing)
 	} else {
 		glog.Info("no existing cluster config was found, will generate one from the flags ")
-		sysLimit, containerLimit, errs := memoryLimits(drvName)
-		if errs != nil {
-			glog.Warningf("Unable to query memory limits: %+v", errs)
+		sysLimit, containerLimit, err := memoryLimits(drvName)
+		if err != nil {
+			glog.Warningf("Unable to query memory limits: %+v", err)
 		}
 
 		mem := suggestMemoryAllocation(sysLimit, containerLimit, viper.GetInt(nodes))

--- a/pkg/drivers/kic/oci/info.go
+++ b/pkg/drivers/kic/oci/info.go
@@ -37,7 +37,7 @@ var cachedSysInfoErr *error
 
 // CachedDaemonInfo will run and return a docker/podman info only once per minikube run time. to avoid performance
 func CachedDaemonInfo(ociBin string) (SysInfo, error) {
-	if cachedSysInfo == nil { // if cached daemon info has error, try to get a new one
+	if cachedSysInfo == nil {
 		si, err := DaemonInfo(ociBin)
 		cachedSysInfo = &si
 		cachedSysInfoErr = &err

--- a/pkg/drivers/kic/oci/info.go
+++ b/pkg/drivers/kic/oci/info.go
@@ -37,10 +37,13 @@ var cachedSysInfoErr *error
 
 // CachedDaemonInfo will run and return a docker/podman info only once per minikube run time. to avoid performance
 func CachedDaemonInfo(ociBin string) (SysInfo, error) {
-	if cachedSysInfo == nil || cachedSysInfoErr != nil { // if cached daemon info has error, try to get a new one
+	if cachedSysInfo == nil { // if cached daemon info has error, try to get a new one
 		si, err := DaemonInfo(ociBin)
 		cachedSysInfo = &si
 		cachedSysInfoErr = &err
+	}
+	if cachedSysInfoErr == nil {
+		return *cachedSysInfo, nil
 	}
 	return *cachedSysInfo, *cachedSysInfoErr
 }

--- a/pkg/drivers/kic/oci/info.go
+++ b/pkg/drivers/kic/oci/info.go
@@ -37,7 +37,7 @@ var cachedSysInfoErr *error
 
 // CachedDaemonInfo will run and return a docker/podman info only once per minikube run time. to avoid performance
 func CachedDaemonInfo(ociBin string) (SysInfo, error) {
-	if cachedSysInfo == nil {
+	if cachedSysInfo == nil || cachedSysInfoErr != nil { // if cached daemon info has error, try to get a new one
 		si, err := DaemonInfo(ociBin)
 		cachedSysInfo = &si
 		cachedSysInfoErr = &err

--- a/pkg/minikube/machine/info.go
+++ b/pkg/minikube/machine/info.go
@@ -42,28 +42,32 @@ func megs(bytes uint64) int64 {
 }
 
 // CachedHostInfo returns system information such as memory,CPU, DiskSize
-func CachedHostInfo() (*HostInfo, error) {
+func CachedHostInfo() (*HostInfo, []error) {
+	var hostInfoErrs []error
 	i, err := cachedCPUInfo()
 	if err != nil {
 		glog.Warningf("Unable to get CPU info: %v", err)
-		return nil, err
+		hostInfoErrs = append(hostInfoErrs, err)
 	}
 	v, err := cachedSysMemLimit()
 	if err != nil {
 		glog.Warningf("Unable to get mem info: %v", err)
-		return nil, err
+		hostInfoErrs = append(hostInfoErrs, err)
 	}
 
 	d, err := cachedDiskInfo()
 	if err != nil {
 		glog.Warningf("Unable to get disk info: %v", err)
-		return nil, err
+		hostInfoErrs = append(hostInfoErrs, err)
 	}
 
 	var info HostInfo
 	info.CPUs = len(i)
 	info.Memory = megs(v.Total)
 	info.DiskSize = megs(d.Total)
+	if len(hostInfoErrs) > 0 {
+		return &info, hostInfoErrs
+	}
 	return &info, nil
 }
 

--- a/pkg/minikube/machine/info.go
+++ b/pkg/minikube/machine/info.go
@@ -111,10 +111,13 @@ var cachedSystemMemoryErr *error
 
 //  cachedSysMemLimit will return a cached limit for the system's virtual memory.
 func cachedSysMemLimit() (*mem.VirtualMemoryStat, error) {
-	if cachedSystemMemoryLimit == nil || cachedSystemMemoryErr != nil {
+	if cachedSystemMemoryLimit == nil {
 		v, err := mem.VirtualMemory()
 		cachedSystemMemoryLimit = v
 		cachedSystemMemoryErr = &err
+	}
+	if cachedSystemMemoryErr == nil {
+		return cachedSystemMemoryLimit, nil
 	}
 	return cachedSystemMemoryLimit, *cachedSystemMemoryErr
 }
@@ -124,10 +127,13 @@ var cachedDiskInfoeErr *error
 
 // cachedDiskInfo will return a cached disk usage info
 func cachedDiskInfo() (disk.UsageStat, error) {
-	if cachedDisk == nil || cachedDiskInfoeErr != nil {
+	if cachedDisk == nil {
 		d, err := disk.Usage("/")
 		cachedDisk = d
 		cachedDiskInfoeErr = &err
+	}
+	if cachedDiskInfoeErr == nil {
+		return *cachedDisk, nil
 	}
 	return *cachedDisk, *cachedDiskInfoeErr
 }
@@ -137,13 +143,13 @@ var cachedCPUErr *error
 
 //  cachedCPUInfo will return a cached cpu info
 func cachedCPUInfo() ([]cpu.InfoStat, error) {
-	if cachedCPU == nil || cachedCPUErr != nil {
+	if cachedCPU == nil {
 		i, err := cpu.Info()
 		cachedCPU = &i
 		cachedCPUErr = &err
-		if err != nil {
-			return nil, *cachedCPUErr
-		}
+	}
+	if cachedCPUErr == nil {
+		return *cachedCPU, nil
 	}
 	return *cachedCPU, *cachedCPUErr
 }

--- a/pkg/minikube/machine/info.go
+++ b/pkg/minikube/machine/info.go
@@ -110,7 +110,7 @@ var cachedSystemMemoryErr *error
 
 //  cachedSysMemLimit will return a cached limit for the system's virtual memory.
 func cachedSysMemLimit() (*mem.VirtualMemoryStat, error) {
-	if cachedSystemMemoryLimit == nil {
+	if cachedSystemMemoryLimit == nil || cachedSystemMemoryErr != nil {
 		v, err := mem.VirtualMemory()
 		cachedSystemMemoryLimit = v
 		cachedSystemMemoryErr = &err
@@ -123,7 +123,7 @@ var cachedDiskInfoeErr *error
 
 // cachedDiskInfo will return a cached disk usage info
 func cachedDiskInfo() (disk.UsageStat, error) {
-	if cachedDisk == nil {
+	if cachedDisk == nil || cachedDiskInfoeErr != nil {
 		d, err := disk.Usage("/")
 		cachedDisk = d
 		cachedDiskInfoeErr = &err
@@ -136,7 +136,7 @@ var cachedCPUErr *error
 
 //  cachedCPUInfo will return a cached cpu info
 func cachedCPUInfo() ([]cpu.InfoStat, error) {
-	if cachedCPU == nil {
+	if cachedCPU == nil || cachedCPUErr != nil {
 		i, err := cpu.Info()
 		cachedCPU = &i
 		cachedCPUErr = &err

--- a/pkg/minikube/machine/info.go
+++ b/pkg/minikube/machine/info.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/docker/machine/libmachine/provision"
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/disk"
 	"github.com/shirou/gopsutil/mem"
@@ -47,18 +48,18 @@ func CachedHostInfo() (*HostInfo, []error) {
 	i, err := cachedCPUInfo()
 	if err != nil {
 		glog.Warningf("Unable to get CPU info: %v", err)
-		hostInfoErrs = append(hostInfoErrs, err)
+		hostInfoErrs = append(hostInfoErrs, errors.Wrap(err, "cpuInfo"))
 	}
 	v, err := cachedSysMemLimit()
 	if err != nil {
 		glog.Warningf("Unable to get mem info: %v", err)
-		hostInfoErrs = append(hostInfoErrs, err)
+		hostInfoErrs = append(hostInfoErrs, errors.Wrap(err, "memInfo"))
 	}
 
 	d, err := cachedDiskInfo()
 	if err != nil {
 		glog.Warningf("Unable to get disk info: %v", err)
-		hostInfoErrs = append(hostInfoErrs, err)
+		hostInfoErrs = append(hostInfoErrs, errors.Wrap(err, "diskInfo"))
 	}
 
 	var info HostInfo

--- a/pkg/minikube/machine/start.go
+++ b/pkg/minikube/machine/start.go
@@ -254,8 +254,8 @@ func acquireMachinesLock(name string) (mutex.Releaser, error) {
 func showHostInfo(cfg config.ClusterConfig) {
 	machineType := driver.MachineType(cfg.Driver)
 	if driver.BareMetal(cfg.Driver) {
-		info, err := machine.CachedHostInfo()
-		if err == nil {
+		info, cpuErr, memErr, DiskErr := CachedHostInfo()
+		if cpuErr == nil && memErr == nil && DiskErr == nil {
 			register.Reg.SetStep(register.RunningLocalhost)
 			out.T(out.StartingNone, "Running on localhost (CPUs={{.number_of_cpus}}, Memory={{.memory_size}}MB, Disk={{.disk_size}}MB) ...", out.V{"number_of_cpus": info.CPUs, "memory_size": info.Memory, "disk_size": info.DiskSize})
 		}

--- a/pkg/minikube/machine/start.go
+++ b/pkg/minikube/machine/start.go
@@ -254,7 +254,7 @@ func acquireMachinesLock(name string) (mutex.Releaser, error) {
 func showHostInfo(cfg config.ClusterConfig) {
 	machineType := driver.MachineType(cfg.Driver)
 	if driver.BareMetal(cfg.Driver) {
-		info, err := CachedHostInfo()
+		info, err := machine.CachedHostInfo()
 		if err == nil {
 			register.Reg.SetStep(register.RunningLocalhost)
 			out.T(out.StartingNone, "Running on localhost (CPUs={{.number_of_cpus}}, Memory={{.memory_size}}MB, Disk={{.disk_size}}MB) ...", out.V{"number_of_cpus": info.CPUs, "memory_size": info.Memory, "disk_size": info.DiskSize})


### PR DESCRIPTION
side effect of this https://github.com/kubernetes/minikube/pull/8877

might help with weird flakes like this https://github.com/kubernetes/minikube/issues/8958

```

\minikube-windows-amd64 start --driver=hyperv --memory=4000MB

! Failed to verify system memory limits.                                                                                                                                            
! Your system has only -1MB memory. This might not work minimum required is 2000MB.                                                                                                 
X Requested memory allocation 4000MB is more than your system limit -1MB. Try specifying a lower memory:
        miniube start --memory=-0.5mb

```
most notably, do NOT return -1 if there is CPU or Disk Info Error.