### PR TITLE
wip: Fix to not create unused file from broken test

### DIFF
--- a/pkg/minikube/config/profile.go
+++ b/pkg/minikube/config/profile.go
@@ -53,7 +53,12 @@ func (p *Profile) IsValid() bool {
 }
 
 // PrimaryControlPlane gets the node specific config for the first created control plane
-func PrimaryControlPlane(cc *ClusterConfig) (Node, error) {
+func PrimaryControlPlane(cc *ClusterConfig, miniHome ...string) (Node, error) {
+	miniPath := localpath.MiniPath()
+	if len(miniHome) > 0 {
+		miniPath = miniHome[0]
+	}
+
 	for _, n := range cc.Nodes {
 		if n.ControlPlane {
 			return n, nil
@@ -76,7 +81,7 @@ func PrimaryControlPlane(cc *ClusterConfig) (Node, error) {
 	cc.KubernetesConfig.NodeName = ""
 	cc.KubernetesConfig.NodeIP = ""
 
-	err := SaveProfile(viper.GetString(ProfileName), cc)
+	err := SaveProfile(viper.GetString(ProfileName), cc, miniPath)
 	if err != nil {
 		return Node{}, err
 	}

--- a/pkg/minikube/config/profile_test.go
+++ b/pkg/minikube/config/profile_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"github.com/spf13/viper"
+
 	"path/filepath"
 	"testing"
 )
@@ -136,7 +138,7 @@ func TestProfileNameInReservedKeywords(t *testing.T) {
 func TestProfileExists(t *testing.T) {
 	miniDir, err := filepath.Abs("./testdata/.minikube2")
 	if err != nil {
-		t.Errorf("error getting dir path for ./testdata/.minikube : %v", err)
+		t.Errorf("error getting dir path for ./testdata/.minikube2 : %v", err)
 	}
 
 	var testCases = []struct {
@@ -163,7 +165,7 @@ func TestProfileExists(t *testing.T) {
 func TestCreateEmptyProfile(t *testing.T) {
 	miniDir, err := filepath.Abs("./testdata/.minikube2")
 	if err != nil {
-		t.Errorf("error getting dir path for ./testdata/.minikube : %v", err)
+		t.Errorf("error getting dir path for ./testdata/.minikube2 : %v", err)
 	}
 
 	var testCases = []struct {
@@ -194,7 +196,7 @@ func TestCreateEmptyProfile(t *testing.T) {
 func TestCreateProfile(t *testing.T) {
 	miniDir, err := filepath.Abs("./testdata/.minikube2")
 	if err != nil {
-		t.Errorf("error getting dir path for ./testdata/.minikube : %v", err)
+		t.Errorf("error getting dir path for ./testdata/.minikube2 : %v", err)
 	}
 
 	var testCases = []struct {
@@ -230,7 +232,7 @@ func TestCreateProfile(t *testing.T) {
 func TestDeleteProfile(t *testing.T) {
 	miniDir, err := filepath.Abs("./testdata/.minikube2")
 	if err != nil {
-		t.Errorf("error getting dir path for ./testdata/.minikube : %v", err)
+		t.Errorf("error getting dir path for ./testdata/.minikube2 : %v", err)
 	}
 
 	err = CreateEmptyProfile("existing_prof", miniDir)
@@ -257,7 +259,7 @@ func TestDeleteProfile(t *testing.T) {
 func TestGetPrimaryControlPlane(t *testing.T) {
 	miniDir, err := filepath.Abs("./testdata/.minikube2")
 	if err != nil {
-		t.Errorf("error getting dir path for ./testdata/.minikube : %v", err)
+		t.Errorf("error getting dir path for ./testdata/.minikube2 : %v", err)
 	}
 
 	var tests = []struct {
@@ -277,7 +279,11 @@ func TestGetPrimaryControlPlane(t *testing.T) {
 			t.Fatalf("Failed to load config for %s", tc.description)
 		}
 
-		n, err := PrimaryControlPlane(cc)
+		if tc.description == "old style" {
+			viper.Set(ProfileName, tc.profile+"_converted")
+		}
+
+		n, err := PrimaryControlPlane(cc, miniDir)
 		if err != nil {
 			t.Fatalf("Unexpexted error getting primary control plane: %v", err)
 		}
@@ -294,6 +300,11 @@ func TestGetPrimaryControlPlane(t *testing.T) {
 			t.Errorf("Unexpected name. expected: %d, got: %d", tc.expectedPort, n.Port)
 		}
 
+		if tc.description == "old style" {
+			err = DeleteProfile(viper.GetString(ProfileName), miniDir)
+			if err != nil {
+				t.Errorf("error test tear down %v", err)
+			}
+		}
 	}
-
 }


### PR DESCRIPTION
- Fix broken test to not create unused config file anymore

Signed-off-by: anencore94 <anencore94@kaist.ac.kr>

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

fixes #8614
