### PR TITLE
change registries title from "docker on macOS" to "docker on Linux/ma…

### DIFF
--- a/site/content/en/docs/handbook/registry.md
+++ b/site/content/en/docs/handbook/registry.md
@@ -44,9 +44,9 @@ One nifty hack is to allow the kubelet running in minikube to talk to registries
 with TLS certificates. Because the default service cluster IP is known to be available at 10.0.0.1, users can pull images from registries
 deployed inside the cluster by creating the cluster with `minikube start --insecure-registry "10.0.0.0/24"`.
 
-### docker on macOS
+### docker on Linux/macOS
 
-Quick guide for configuring minikube and docker on macOS, enabling docker to push images to minikube's registry.
+Quick guide for configuring minikube and docker on Linux/macOS, enabling docker to push images to minikube's registry.
 
 The first step is to enable the registry addon:
 
@@ -56,7 +56,7 @@ minikube addons enable registry
 
 When enabled, the registry addon exposes its port 5000 on the minikube's virtual machine.
 
-In order to make docker accept pushing images to this registry, we have to redirect port 5000 on the docker virtual machine over to port 5000 on the minikube machine. We can (ab)use docker's network configuration to instantiate a container on the docker's host, and run socat there:
+In order to make docker accept pushing images to this registry on macOS, we have to redirect port 5000 on the docker virtual machine over to port 5000 on the minikube machine. We can (ab)use docker's network configuration to instantiate a container on the docker's host, and run socat there:
 
 ```
 docker run --rm -it --network=host alpine ash -c "apk add socat && socat TCP-LISTEN:5000,reuseaddr,fork TCP:$(minikube ip):5000"


### PR DESCRIPTION
PR Summary:
- Changes registries title from "docker on macOS" to "docker on Linux/macOS"
- Fixes https://github.com/kubernetes/minikube/issues/8925
