### PR TITLE
WIP: Add new external-dns addon for exposing ingress & LoadBalancer external IPs to the host

### DIFF
--- a/deploy/addons/external-dns/extdns-coredns-configmap.yaml
+++ b/deploy/addons/external-dns/extdns-coredns-configmap.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: extdns-coredns
+  namespace: kube-system
+  labels:
+    app: extdns-coredns
+data:
+  Corefile: |-
+    .:53 {
+        errors
+        health {
+            lameduck 5s
+        }
+        ready
+        etcd test {
+            stubzones
+            path /skydns
+            endpoint http://extdns-etcd:2379
+        }
+        prometheus 0.0.0.0:9153
+        forward . /etc/resolv.conf {
+          except cluster.local
+        }
+        cache 30
+        loop
+        reload
+        loadbalance
+    }

--- a/deploy/addons/external-dns/extdns-coredns-deploy.yaml
+++ b/deploy/addons/external-dns/extdns-coredns-deploy.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: extdns-coredns
+  namespace: kube-system
+  labels:
+    app: extdns-coredns
+spec:
+  selector:
+    matchLabels:
+      app: extdns-coredns
+  template:
+    metadata:
+      labels:
+        app: extdns-coredns
+    spec:
+      containers:
+      - name: coredns
+        image: k8s.gcr.io/coredns:1.6.7
+        args:
+        - -conf
+        - /etc/coredns/Corefile
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: config-volume
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+          # hostIP: {{.NodeIP}} ???
+          # hostPort: 53
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+          # hostIP: {{.NodeIP}} ???
+          # hostPort: 53
+        - containerPort: 9153
+          name: metrics
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          failureThreshold: 5
+          successThreshold: 1
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8181
+            scheme: HTTP
+          periodSeconds: 10
+          failureThreshold: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+      volumes:
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: Corefile
+            path: Corefile
+          name: extdns-coredns
+        name: config-volume

--- a/deploy/addons/external-dns/extdns-etcd-statefulset.yaml
+++ b/deploy/addons/external-dns/extdns-etcd-statefulset.yaml
@@ -1,0 +1,93 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: extdns-etcd
+  namespace: kube-system
+  labels:
+    app: extdns-etcd
+spec:
+  selector:
+    app: extdns-etcd
+  clusterIP: None
+  ports:
+  - name: etcd-client
+    port: 2379
+  - name: etcd-server
+    port: 2380
+  publishNotReadyAddresses: true
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: extdns-etcd
+  namespace: kube-system
+  labels:
+    app: extdns-etcd
+spec:
+  selector:
+    matchLabels:
+      app: extdns-etcd
+  serviceName: extdns-etcd
+  template:
+    metadata:
+      labels:
+        app: extdns-etcd
+    spec:
+      containers:
+      - name: etcd
+        image: k8s.gcr.io/etcd:3.4.3-0
+        command:
+        - etcd
+        - --data-dir=/etcd-data
+        - --name=$(HOSTNAME)
+        - --initial-advertise-peer-urls=http://$(HOSTNAME).extdns-etcd:2380
+        - --listen-peer-urls=http://0.0.0.0:2380
+        - --advertise-client-urls=http://$(HOSTNAME).extdns-etcd:2379
+        - --listen-client-urls=http://0.0.0.0:2379
+        - --initial-cluster=$(HOSTNAME)=http://$(HOSTNAME).extdns-etcd:2380
+        env:
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        volumeMounts:
+        - name: extdns-etcd
+          mountPath: /etcd-data
+        ports:
+        - name: etcd-client
+          containerPort: 2379
+        - name: etcd-server
+          containerPort: 2380
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -ec
+            - ETCDCTL_API=3 etcdctl endpoint health
+          failureThreshold: 3
+          initialDelaySeconds: 10
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -ec
+            - ETCDCTL_API=3 etcdctl endpoint health
+          failureThreshold: 3
+          initialDelaySeconds: 1
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 5
+  volumeClaimTemplates:
+  - metadata:
+      name: extdns-etcd
+      labels:
+        app: extdns-etcd
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi

--- a/deploy/addons/external-dns/external-dns.yaml
+++ b/deploy/addons/external-dns/external-dns.yaml
@@ -1,0 +1,61 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups: [""]
+  resources: ["services","endpoints","pods"]
+  verbs: ["get","watch","list"]
+- apiGroups: ["extensions","networking.k8s.io"]
+  resources: ["ingresses"]
+  verbs: ["get","watch","list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+  namespace: kube-system
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: external-dns
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      serviceAccountName: external-dns
+      containers:
+      - name: external-dns
+        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        args:
+        - --source=service
+        - --source=ingress
+        - --provider=coredns
+        env:
+        - name: ETCD_URLS
+          value: http://extdns-etcd:2379

--- a/pkg/addons/config.go
+++ b/pkg/addons/config.go
@@ -182,4 +182,9 @@ var Addons = []*Addon{
 		validations: []setFn{IsVolumesnapshotsEnabled},
 		callbacks:   []setFn{enableOrDisableAddon, verifyAddonStatus},
 	},
+	{
+		name:      "external-dns",
+		set:       SetBool,
+		callbacks: []setFn{enableOrDisableAddon},
+	},
 }

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -540,6 +540,32 @@ var Addons = map[string]*Addon{
 			"0640",
 			false),
 	}, false, "csi-hostpath-driver"),
+	"external-dns": NewAddon([]*BinAsset{
+		MustBinAsset(
+			"deploy/addons/external-dns/extdns-etcd-statefulset.yaml",
+			vmpath.GuestAddonsDir,
+			"extdns-etcd-statefulset.yaml",
+			"0640",
+			false),
+		MustBinAsset(
+			"deploy/addons/external-dns/extdns-coredns-deploy.yaml",
+			vmpath.GuestAddonsDir,
+			"extdns-coredns-deploy.yaml",
+			"0640",
+			false),
+		MustBinAsset(
+			"deploy/addons/external-dns/extdns-coredns-configmap.yaml",
+			vmpath.GuestAddonsDir,
+			"extdns-coredns-configmap.yaml",
+			"0640",
+			false),
+		MustBinAsset(
+			"deploy/addons/external-dns/external-dns.yaml",
+			vmpath.GuestAddonsDir,
+			"external-dns.yaml",
+			"0640",
+			false),
+	}, false, "external-dns"),
 }
 
 // GenerateTemplateData generates template data for template assets


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

An initial version of an addon for
[external-dns](https://github.com/kubernetes-sigs/external-dns). Based on [ExternalDNS for CoreDNS with minikube](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/coredns.md). Cobbled together from that tutorial, upstream helm charts, and the way minikube/kubeadm deploy etcd & CoreDNS. Those manifests probably
need some reviewing and tweaking (See TODO below)

Add an addon for installing external DNS. See https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/coredns.md which uses CoreDNS as the DNS server.

Unlike ingress-dns, which is minikube specific:
1. This is sometimes used in production, so will give similar behavior in development to production.
2. Will support LoadBalancer services.

Some notes about configuring the host that also apply for ingress-dns:
1. For Linux distros using `systemd-resolved`, you can use [`systemd.network` units](https://www.freedesktop.org/software/systemd/man/systemd.network.html) for configuring DNS domain specific DNS servers. Using the `Domains` & `DNS` keys in a new network unit matching the required interface. I used it before, but don't remember the details.
2. For Windows, there is NRPT which should allow setting this.

At this point it is still WIP/incomplete, I will need some help from someone to finish this according to the TODO list below and any other feedback.

### TODO
- [ ] Which images to use for etcd and CoreDNS? The k8s.io ones minikube uses? or upstream ones (From docs or helm charts)? Using minikube's images means it can use the preloaded ones as long as it is kept up to date, at least for the latest Kubernetes version, though updating those is likely to be forgotten...
- [ ] `readinessProbe`/`livenessProbe`, what times, thresholds should be used, are the scripts, endpoints correct, etc. (I kinda copied them from somewhere and they are not necessarily optimal)
  - [ ] The `readinessProbe` for etcd breaks it because the headless service doesn't register it until it is ready but it queries for it to become ready, At first I tried just disabling it, but that also didn't always work, not sure why, so I added `publishNotReadyAddresses` to the service, which might be correct anyhow, though not sure if I should then add a separate service that does not publish unready addresses, though it is a single node deployment so might not matter much either way.
- [ ] Do any pods here need a `priorityClass`?
- [ ] Do any pods here need `tolerations`?
- [ ] Set `resources` correctly.
- [ ] Use `hostPath` instead of PVC for etcd? or maybe make it ephemeral and not use a volume at all?
- [ ] labels for the objects, etc. Are there any labels add-ons normally use? Any label schema this should use instead of just `app`?
- [ ] I used the headless service to access etcd, not sure that's the best/correct way, some etcd deployments seem to also add `ClusterIP` service and use that instead, might not matter much for a single node.
- [ ] The CoreDNS server currently forwards DNS to the in cluster DNS which will also answer for `cluster.local`, which is not desired on the host, had to explicitly `except` it. Not sure if that's the best config. I can't just `dnsPolicy: Default` like the in-cluster CoreDNS because the CoreDNS server needs to resolve the etcd server address.
- [ ] The CoreDNS server is not currently exposed to the host. I think we should use `hostPort` to expose it. This also requires `hostIP` due to having another DNS server listening on localhost on the `minikube` VM, this needs to be set automatically but I'm not sure how to add such a template parameter, as in: where to extract it from inside minikube. Just using `hostNetwork` will be problematic with accessing etcd.
- [ ] Add `README.md` explaining how to configure host, etc. Like `ingress-dns` has. Maybe also an example, though upstream examples using the appropriate domain should work too.
- [ ] The domain is currently hard-coded to `test`, we might want to make that configurable.
- [ ] Will likely be effected by whatever issue plagues `ingress` & `ingress-dns` on Docker driver, so might need the same provisions and documentation as them.

fixes #8980
