### PR TITLE
Update documentation to show docker as a preferred driver

### DIFF
--- a/site/content/en/docs/drivers/_index.md
+++ b/site/content/en/docs/drivers/_index.md
@@ -22,8 +22,8 @@ To do so, we use the [Docker Machine](https://github.com/docker/machine) library
 
 ## macOS
 
-* [Hyperkit]({{<ref "hyperkit.md">}}) - VM (preferred)
-* [Docker]({{<ref "docker.md">}}) - VM + Container
+* [Docker]({{<ref "docker.md">}}) - VM + Container (preferred)
+* [Hyperkit]({{<ref "hyperkit.md">}}) - VM
 * [VirtualBox]({{<ref "virtualbox.md">}}) - FVM
 * [Parallels]({{<ref "parallels.md">}}) - VM
 * [VMware]({{<ref "vmware.md">}}) - VM


### PR DESCRIPTION
PR Summary:
- Updates documentation to show docker as a preferred driver

@priyawadhwa I've removed "preferred" from HyperKit driver. I hope it's OK

closes #8757