### PR TITLE
Warn if /var disk space is full and add a solution message

### DIFF
--- a/pkg/minikube/exit/exit.go
+++ b/pkg/minikube/exit/exit.go
@@ -73,7 +73,6 @@ func WithError(msg string, err error) {
 // WithProblem outputs info related to a known problem and exits.
 func WithProblem(msg string, err error, p *problem.Problem) {
 	out.ErrT(out.Empty, "")
-	glog.Errorf("%+v\n", p)
 	out.FailureT("[{{.id}}] {{.msg}} {{.error}}", out.V{"msg": msg, "id": p.ID, "error": p.Err})
 	p.Display()
 	if p.ShowIssueLink {

--- a/pkg/minikube/machine/fix.go
+++ b/pkg/minikube/machine/fix.go
@@ -59,6 +59,7 @@ func fixHost(api libmachine.API, cc *config.ClusterConfig, n *config.Node) (*hos
 	if err != nil {
 		return h, errors.Wrap(err, "Error loading existing host. Please try running [minikube delete], then run [minikube start] again.")
 	}
+	defer postStartValidations(h, cc.Driver)
 
 	driverName := h.Driver.DriverName()
 

--- a/pkg/minikube/machine/start.go
+++ b/pkg/minikube/machine/start.go
@@ -207,6 +207,7 @@ func timedCreateHost(h *host.Host, api libmachine.API, t time.Duration) error {
 }
 
 // postStartValidations are validations against the host after it is created
+// TODO: Add validations for VM drivers as well, see issue #9035
 func postStartValidations(h *host.Host, drvName string) {
 	if !driver.IsKIC(drvName) {
 		return

--- a/pkg/minikube/problem/err_map.go
+++ b/pkg/minikube/problem/err_map.go
@@ -582,7 +582,7 @@ var stateProblems = map[string]match{
 // dockerProblems are issues relating to issues with the docker driver
 var dockerProblems = map[string]match{
 	"NO_SPACE_ON_DEVICE": {
-		Regexp: re(`No space left on device`),
+		Regexp: re(`.*docker.*No space left on device.*`),
 		Advice: `Run 'docker system prune' to free up space on the device, or increase amount of memory allocated to Docker for Desktop via
 		
 	Docker icon > Settings > Resources > Disk Image Size

--- a/pkg/minikube/problem/err_map.go
+++ b/pkg/minikube/problem/err_map.go
@@ -583,9 +583,12 @@ var stateProblems = map[string]match{
 var dockerProblems = map[string]match{
 	"NO_SPACE_ON_DEVICE": {
 		Regexp: re(`.*docker.*No space left on device.*`),
-		Advice: `Run 'docker system prune' to free up space on the device, or increase amount of memory allocated to Docker for Desktop via
-		
-	Docker icon > Settings > Resources > Disk Image Size
+		Advice: `Try at least one of the following to free up space on the device:
+
+	1. Run "docker system prune" to remove unused docker data
+	2. Increase the amount of memory allocated to Docker for Desktop via 
+		Docker icon > Preferences > Resources > Disk Image Size
+	3. Run "minikube ssh -- docker system prune" if using the docker container runtime
 `,
 		Issues: []int{9024},
 	},

--- a/pkg/minikube/problem/err_map.go
+++ b/pkg/minikube/problem/err_map.go
@@ -578,3 +578,12 @@ var stateProblems = map[string]match{
 		Issues: []int{7256},
 	},
 }
+
+// dockerProblems are issues relating to issues with the docker driver
+var dockerProblems = map[string]match{
+	"NO_SPACE_ON_DEVICE": {
+		Regexp: re(`No space left on device`),
+		Advice: "Run 'docker system prune' to delete unused data and free up space on the device",
+		Issues: []int{9024},
+	},
+}

--- a/pkg/minikube/problem/err_map.go
+++ b/pkg/minikube/problem/err_map.go
@@ -583,7 +583,10 @@ var stateProblems = map[string]match{
 var dockerProblems = map[string]match{
 	"NO_SPACE_ON_DEVICE": {
 		Regexp: re(`No space left on device`),
-		Advice: "Run 'docker system prune' to delete unused data and free up space on the device",
+		Advice: `Run 'docker system prune' to free up space on the device, or increase amount of memory allocated to Docker for Desktop via
+		
+	Docker icon > Settings > Resources > Disk Image Size
+`,
 		Issues: []int{9024},
 	},
 }

--- a/pkg/minikube/problem/problem.go
+++ b/pkg/minikube/problem/problem.go
@@ -104,6 +104,7 @@ func FromError(err error, goos string) *Problem {
 		netProblems,
 		deployProblems,
 		stateProblems,
+		dockerProblems,
 	}
 
 	var osMatch *Problem


### PR DESCRIPTION
closes #9024


Current output on my machine for failure looks like this:

```
$ minikube start --driver docker
$ minikube start --driver docker
😄  minikube v1.12.3 on Darwin 10.15.6
✨  Using the docker driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=4893MB) ...

❌  [NO_SPACE_ON_DEVICE]  docker daemon out of memory. No space left on device
💡  Suggestion: Try at least one of the following to free up space on the device:

	1. Run "docker system prune"
	2. Increase the amount of memory allocated to Docker for Desktop via 
		Docker icon > Preferences > Resources > Disk Image Size
	3. Run "minikube ssh -- docker system prune" if using the docker container runtime

⁉️   Related issue: https://github.com/kubernetes/minikube/issues/9024
```
