### PR TITLE
Fix --memory flag parsing in minikube start

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -227,14 +227,14 @@ func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k
 
 		mem := suggestMemoryAllocation(sysLimit, containerLimit, viper.GetInt(nodes))
 		if cmd.Flags().Changed(memory) {
-			mem, err := pkgutil.CalculateSizeInMB(viper.GetString(memory))
+			var err error
+			mem, err = pkgutil.CalculateSizeInMB(viper.GetString(memory))
 			if err != nil {
 				exit.WithCodeT(exit.Config, "Generate unable to parse memory '{{.memory}}': {{.error}}", out.V{"memory": viper.GetString(memory), "error": err})
 			}
 			if driver.IsKIC(drvName) && mem > containerLimit {
 				exit.UsageT("{{.driver_name}} has only {{.container_limit}}MB memory but you specified {{.specified_memory}}MB", out.V{"container_limit": containerLimit, "specified_memory": mem, "driver_name": driver.FullName(drvName)})
 			}
-
 		} else {
 			validateMemorySize(mem, drvName)
 			glog.Infof("Using suggested %dMB memory alloc based on sys=%dMB, container=%dMB", mem, sysLimit, containerLimit)


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

Fixes #9017. Due to the way Go handles variable scope, `mem` was being redeclared inside the conditional. Outside, we were stuck with the value provided by `suggestMemoryAllocation`, therefore ignoring the value passed through the `--memory` flag.

Output of `minikube start` with the fix:
```
# minikube start --memory=2g --driver=kvm2
😄  minikube v1.12.3 on Ubuntu 18.04
✨  Using the kvm2 driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🔥  Creating kvm2 VM (CPUs=2, Memory=2048MB, Disk=20000MB) ...

# minikube start --memory=8g --driver=kvm2
😄  minikube v1.12.3 on Ubuntu 18.04
✨  Using the kvm2 driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🔥  Creating kvm2 VM (CPUs=2, Memory=8192MB, Disk=20000MB) ...
```
