### PR TITLE
testing: Remove flaky TestCreateSSHShell

### DIFF
--- a/pkg/minikube/machine/cluster_test.go
+++ b/pkg/minikube/machine/cluster_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/provision"
-	"github.com/docker/machine/libmachine/ssh"
 	"github.com/docker/machine/libmachine/state"
 	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/config"
@@ -423,44 +422,6 @@ func TestStatus(t *testing.T) {
 		t.Errorf("StopHost failed: %v", err)
 	}
 	checkState(state.Stopped.String(), m)
-}
-
-func TestCreateSSHShell(t *testing.T) {
-	api := tests.NewMockAPI(t)
-	// Setting the default ssh client to native for test stability.
-	ssh.SetDefaultClient(ssh.Native)
-
-	s, _ := tests.NewSSHServer(t)
-	port, err := s.Start()
-	if err != nil {
-		t.Fatalf("Error starting ssh server: %v", err)
-	}
-
-	m := viper.GetString("profile")
-
-	d := &tests.MockDriver{
-		Port:         port,
-		CurrentState: state.Running,
-		BaseDriver: drivers.BaseDriver{
-			IPAddress:   "127.0.0.1",
-			SSHKeyPath:  "",
-			MachineName: m,
-		},
-		T: t,
-	}
-	api.Hosts[m] = &host.Host{Driver: d}
-
-	cc := defaultClusterConfig
-	cc.Name = viper.GetString("profile")
-
-	cliArgs := []string{"exit"}
-	if err := CreateSSHShell(api, cc, config.Node{Name: "minikube"}, cliArgs, true); err != nil {
-		t.Fatalf("Error running ssh command: %v", err)
-	}
-
-	if !s.IsSessionRequested() {
-		t.Fatalf("Expected ssh session to be run")
-	}
 }
 
 func TestGuestClockDelta(t *testing.T) {


### PR DESCRIPTION
I finally concede defeat.

I've tried to fix this test by refactoring it and the underlying code 3-4 times over the years. It continues to flake as it did on the first day I joined the project. I've never seen it create value for minikube. Here is the latest:

```
-- FAIL: TestCreateSSHShell (0.21s)
    ssh_mock.go:193: Listening on 127.0.0.1:45951
    ssh_mock.go:83: Serving ...
    ssh_mock.go:87: [loop 1] Accepting for &{0xc000963860 map[] false  0 {map[]} false 0xc00090b440 0xc000964120}...
    api_mock.go:62: MockAPI.Load: &{ConfigVersion:0 Driver:0xc00091b130 DriverName: HostOptions:<nil> Name: RawDriver:[]} - <nil>
    driver_mock.go:49: MockDriver.GetState called from /home/travis/gopath/src/github.com/kubernetes/minikube/pkg/minikube/machine/cluster_test.go#457: returning "Running"
    ssh_mock.go:87: [loop 2] Accepting for &{0xc000963860 map[] false  0 {map[]} false 0xc00090b440 0xc000964120}...
    ssh_mock.go:175: pty request received: &{Type:pty-req WantReply:true Payload:[0 0 0 5 120 116 101 114 109 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 6 53 0 0 0 1 0] ch:0xc00091c6c0 mux:<nil>}
    ssh_mock.go:149: exec request received: &{Type:exec WantReply:true Payload:[0 0 0 4 101 120 105 116] ch:0xc00091c6c0 mux:<nil>}
    ssh_mock.go:161: returning output for exit ...
    ssh_mock.go:169: setting exit-status for exit ...
    ssh_mock.go:171: SendRequest failed: EOF
```

Related: #6947