### PR TITLE
testing: Remove use of deprecated ComponentStatusList API

### DIFF
--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -311,26 +311,40 @@ func validateMinikubeKubectl(ctx context.Context, t *testing.T, profile string) 
 func validateComponentHealth(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 
-	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "get", "cs", "-o=json"))
+	// The ComponentStatus API is deprecated in v1.19, so do the next closest thing.
+	found := map[string]bool{
+		"etcd":                    false,
+		"kube-apiserver":          false,
+		"kube-controller-manager": false,
+		"kube-scheduler":          false,
+	}
+
+	rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "get", "po", "-l", "tier=control-plane", "-n", "kube-system", "-o=json"))
 	if err != nil {
 		t.Fatalf("failed to get components. args %q: %v", rr.Command(), err)
 	}
-	cs := api.ComponentStatusList{}
+	cs := api.PodList{}
 	d := json.NewDecoder(bytes.NewReader(rr.Stdout.Bytes()))
 	if err := d.Decode(&cs); err != nil {
 		t.Fatalf("failed to decode kubectl json output: args %q : %v", rr.Command(), err)
 	}
 
 	for _, i := range cs.Items {
-		status := api.ConditionFalse
-		for _, c := range i.Conditions {
-			if c.Type != api.ComponentHealthy {
-				continue
+		for _, l := range i.Labels {
+			t.Logf("%s phase: %s", l, i.Status.Phase)
+			_, ok := found[l]
+			if ok {
+				found[l] = true
+				if i.Status.Phase != "Running" {
+					t.Errorf("%s is not Running: %+v", l, i.Status)
+				}
 			}
-			status = c.Status
 		}
-		if status != api.ConditionTrue {
-			t.Errorf("unexpected status: %v - item: %+v", status, i)
+	}
+
+	for k, v := range found {
+		if !v {
+			t.Errorf("expected component %q was not found", k)
 		}
 	}
 }


### PR DESCRIPTION
Fixes issues with the deprecated usage of ComponentStatusList seen in #9050

For more context, see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md

Sample output:

```
=== CONT  TestFunctional/parallel/ComponentHealth
    functional_test.go:322: (dbg) Run:  kubectl --context minikube get po -l tier=control-plane -n kube-system -o=json
    functional_test.go:334: etcd phase: Running
    functional_test.go:334: control-plane phase: Running
    functional_test.go:334: kube-apiserver phase: Running
    functional_test.go:334: control-plane phase: Running
    functional_test.go:334: kube-controller-manager phase: Running
    functional_test.go:334: control-plane phase: Running
    functional_test.go:334: kube-scheduler phase: Running
    functional_test.go:334: control-plane phase: Running
--- PASS: TestFunctional (0.12s)
```

