### PR TITLE
integration testing: Fail fast if the context timer has run out

### DIFF
--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -63,6 +63,9 @@ func TestAddons(t *testing.T) {
 		}
 		for _, tc := range tests {
 			tc := tc
+			if ctx.Err() == context.DeadlineExceeded {
+				t.Fatalf("Unable to run more tests (deadline exceeded)")
+			}
 			t.Run(tc.name, func(t *testing.T) {
 				MaybeParallel(t)
 				tc.validator(ctx, t, profile)

--- a/test/integration/fn_tunnel_cmd_test.go
+++ b/test/integration/fn_tunnel_cmd_test.go
@@ -69,6 +69,9 @@ func validateTunnelCmd(ctx context.Context, t *testing.T, profile string) {
 		}
 		for _, tc := range tests {
 			tc := tc
+			if ctx.Err() == context.DeadlineExceeded {
+				t.Fatalf("Unable to run more tests (deadline exceeded)")
+			}
 			t.Run(tc.name, func(t *testing.T) {
 				tc.validator(ctx, t, profile)
 			})

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -89,6 +89,9 @@ func TestFunctional(t *testing.T) {
 		}
 		for _, tc := range tests {
 			tc := tc
+			if ctx.Err() == context.DeadlineExceeded {
+				t.Fatalf("Unable to run more tests (deadline exceeded)")
+			}
 			t.Run(tc.name, func(t *testing.T) {
 				tc.validator(ctx, t, profile)
 			})
@@ -126,6 +129,10 @@ func TestFunctional(t *testing.T) {
 		}
 		for _, tc := range tests {
 			tc := tc
+			if ctx.Err() == context.DeadlineExceeded {
+				t.Fatalf("Unable to run more tests (deadline exceeded)")
+			}
+
 			t.Run(tc.name, func(t *testing.T) {
 				MaybeParallel(t)
 				tc.validator(ctx, t, profile)
@@ -1072,6 +1079,11 @@ users:
 
 	for _, tc := range tests {
 		tc := tc
+
+		if ctx.Err() == context.DeadlineExceeded {
+			t.Fatalf("Unable to run more tests (deadline exceeded)")
+		}
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			c := exec.CommandContext(ctx, Target(), "-p", profile, "update-context", "--alsologtostderr", "-v=2")

--- a/test/integration/multinode_test.go
+++ b/test/integration/multinode_test.go
@@ -52,6 +52,9 @@ func TestMultiNode(t *testing.T) {
 		}
 		for _, tc := range tests {
 			tc := tc
+			if ctx.Err() == context.DeadlineExceeded {
+				t.Fatalf("Unable to run more tests (deadline exceeded)")
+			}
 			t.Run(tc.name, func(t *testing.T) {
 				defer PostMortemLogs(t, profile)
 				tc.validator(ctx, t, profile)

--- a/test/integration/pause_test.go
+++ b/test/integration/pause_test.go
@@ -50,6 +50,11 @@ func TestPause(t *testing.T) {
 		}
 		for _, tc := range tests {
 			tc := tc
+
+			if ctx.Err() == context.DeadlineExceeded {
+				t.Fatalf("Unable to run more tests (deadline exceeded)")
+			}
+
 			t.Run(tc.name, func(t *testing.T) {
 				tc.validator(ctx, t, profile)
 				if t.Failed() && *postMortemLogs {

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -78,7 +78,6 @@ func TestStartStop(t *testing.T) {
 
 		for _, tc := range tests {
 			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				MaybeParallel(t)
 				profile := UniqueProfileName(tc.name)
@@ -114,12 +113,13 @@ func TestStartStop(t *testing.T) {
 						{"Pause", validatePauseAfterSart},
 					}
 					for _, stc := range serialTests {
-						tcName := tc.name
-						tcVersion := tc.version
-						stc := stc
 						if ctx.Err() == context.DeadlineExceeded {
 							t.Fatalf("Unable to run more tests (deadline exceeded)")
 						}
+
+						tcName := tc.name
+						tcVersion := tc.version
+						stc := stc
 
 						t.Run(stc.name, func(t *testing.T) {
 							stc.validator(ctx, t, profile, tcName, tcVersion, startArgs)

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -78,6 +78,7 @@ func TestStartStop(t *testing.T) {
 
 		for _, tc := range tests {
 			tc := tc
+
 			t.Run(tc.name, func(t *testing.T) {
 				MaybeParallel(t)
 				profile := UniqueProfileName(tc.name)
@@ -116,6 +117,10 @@ func TestStartStop(t *testing.T) {
 						tcName := tc.name
 						tcVersion := tc.version
 						stc := stc
+						if ctx.Err() == context.DeadlineExceeded {
+							t.Fatalf("Unable to run more tests (deadline exceeded)")
+						}
+
 						t.Run(stc.name, func(t *testing.T) {
 							stc.validator(ctx, t, profile, tcName, tcVersion, startArgs)
 						})


### PR DESCRIPTION
When looking at integration test failures that incur a timeout, it can be difficult to see the specific failing test because all further tests fail with giant post-mortem logs. 

This PR causes the parent test to fail when the context has run out, preventing subsequent sub-tests from starting up.

