### PR TITLE
Add /kubepods to cgroup mounting regex in entrypoint

### DIFF
--- a/deploy/kicbase/entrypoint
+++ b/deploy/kicbase/entrypoint
@@ -82,7 +82,7 @@ fix_cgroup_mounts() {
 
   # NOTE: This extracts fields 4 and on
   # See https://man7.org/linux/man-pages/man5/proc.5.html for field names
-  cgroup_mounts=$(egrep -o '(/docker|libpod_parent).*/sys/fs/cgroup.*' /proc/self/mountinfo || true)
+  cgroup_mounts=$(egrep -o '(/docker|libpod_parent|/kubepods).*/sys/fs/cgroup.*' /proc/self/mountinfo || true)
 
   if [[ -n "${cgroup_mounts}" ]]; then
     local mount_root

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -24,9 +24,9 @@ import (
 
 const (
 	// Version is the current version of kic
-	Version = "v0.0.12-snapshot2"
+	Version = "v0.0.12-snapshot3"
 	// SHA of the kic base image
-	baseImageSHA = "2e78dd54231714527631b27e9d6674549d9114d7be1ff55ed417d2bc514a63f4"
+	baseImageSHA = "1d687ba53e19dbe5fafe4cc18aa07f269ecc4b7b622f2251b5bf569ddb474e9b"
 )
 
 var (

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -27,7 +27,7 @@ minikube start [flags]
       --apiserver-names stringArray       A set of apiserver names which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine
       --apiserver-port int                The apiserver listening port (default 8443)
       --auto-update-drivers               If set, automatically updates drivers to the latest version. Defaults to true. (default true)
-      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase:v0.0.12-snapshot2@sha256:2e78dd54231714527631b27e9d6674549d9114d7be1ff55ed417d2bc514a63f4")
+      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase:v0.0.12-snapshot3@sha256:1d687ba53e19dbe5fafe4cc18aa07f269ecc4b7b622f2251b5bf569ddb474e9b")
       --cache-images                      If true, cache docker images for the current bootstrapper and load them into the machine. Always false with --driver=none. (default true)
       --cni string                        CNI plug-in to use. Valid options: auto, bridge, calico, cilium, flannel, kindnet, or path to a CNI manifest (default: auto)
       --container-runtime string          The container runtime to be used (docker, cri-o, containerd). (default "docker")


### PR DESCRIPTION
This will ensure that the kubepods cgroup is correctly mounted, which
kubeadm uses. Without it, `kubeadm init` fails in Cloud Shell.

According to this [article](https://medium.com/appvia/prevent-resource-starvation-of-critical-system-and-kubernetes-services-83cfeaa6ac96)

>Kubelet by default will always create the root /kubepods cgroup, which all Kubernetes pods are started within.

Also update kic to incorporate this change

fixes https://github.com/kubernetes/minikube/issues/9082