### PR TITLE
wip: docker: fix network static

### DIFF
--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -119,6 +119,11 @@ func deleteContainersAndVolumes(ociBin string) {
 	if len(errs) > 0 { // it will not error if there is nothing to delete
 		glog.Warningf("error pruning volumes by label %q (might be okay): %+v", delLabel, errs)
 	}
+
+	errs = oci.DeleteAllNetworksByKIC()
+	if errs != nil {
+		glog.Warningf("error deleting left over networks (might be okay).\nTo see the list of netowrks: 'docker network ls'\n:%v", errs)
+	}
 }
 
 // runDelete handles the executes the flow of "minikube delete"
@@ -256,6 +261,11 @@ func deletePossibleKicLeftOver(cname string, driverName string) {
 	errs := oci.DeleteAllVolumesByLabel(bin, delLabel)
 	if errs != nil { // it will not error if there is nothing to delete
 		glog.Warningf("error deleting volumes (might be okay).\nTo see the list of volumes run: 'docker volume ls'\n:%v", errs)
+	}
+
+	errs = oci.DeleteAllNetworksByKIC()
+	if errs != nil {
+		glog.Warningf("error deleting left over networks (might be okay).\nTo see the list of netowrks: 'docker network ls'\n:%v", errs)
 	}
 
 	if bin == oci.Podman {

--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -117,7 +117,6 @@ var mountCmd = &cobra.Command{
 			}
 		}
 		port, err := getPort()
-		fmt.Println("port is ", ip)
 		if err != nil {
 			exit.WithError("Error finding port for mount", err)
 		}
@@ -148,7 +147,6 @@ var mountCmd = &cobra.Command{
 		}
 
 		bindIP := ip.String() // the ip to listen on the user's host machine
-		fmt.Println("bind ip is", bindIP)
 		if driver.IsKIC(co.CP.Host.Driver.DriverName()) && runtime.GOOS != "linux" {
 			bindIP = "127.0.0.1"
 		}

--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -106,7 +106,7 @@ var mountCmd = &cobra.Command{
 		var ip net.IP
 		var err error
 		if mountIP == "" {
-			ip, err = cluster.HostIP(co.CP.Host)
+			ip, err = cluster.HostIP(co.CP.Host, co.Config.Name)
 			if err != nil {
 				exit.WithError("Error getting the host IP address to use from within the VM", err)
 			}

--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -117,6 +117,7 @@ var mountCmd = &cobra.Command{
 			}
 		}
 		port, err := getPort()
+		fmt.Println("port is ", ip)
 		if err != nil {
 			exit.WithError("Error finding port for mount", err)
 		}
@@ -147,6 +148,7 @@ var mountCmd = &cobra.Command{
 		}
 
 		bindIP := ip.String() // the ip to listen on the user's host machine
+		fmt.Println("bind ip is", bindIP)
 		if driver.IsKIC(co.CP.Host.Driver.DriverName()) && runtime.GOOS != "linux" {
 			bindIP = "127.0.0.1"
 		}

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -35,7 +35,10 @@ sudo ./installers/check_install_golang.sh "1.14.6" "/usr/local" || true
 
 docker rm -f -v $(docker ps -aq) >/dev/null 2>&1 || true
 docker volume prune -f || true
+docker network prune -f || true
+docker system prune -f || true
 docker system df || true
+
 
 echo ">> Starting at $(date)"
 echo ""

--- a/hack/jenkins/cron/cleanup_and_reboot_Darwin.sh
+++ b/hack/jenkins/cron/cleanup_and_reboot_Darwin.sh
@@ -44,6 +44,8 @@ killall java
 # clean docker left overs
 docker rm -f -v $(docker ps -aq) >/dev/null 2>&1 || true
 docker volume prune -f || true
+docker system prune -f || true
+docker network prune -f || true
 docker volume ls || true
 docker system df || true
 

--- a/hack/jenkins/cron/cleanup_and_reboot_Linux.sh
+++ b/hack/jenkins/cron/cleanup_and_reboot_Linux.sh
@@ -39,6 +39,8 @@ killall java
 # clean docker left overs
 docker rm -f -v $(docker ps -aq) >/dev/null 2>&1 || true
 docker volume prune -f || true
+docker system prune -f || true
+docker network prune -f || true
 docker volume ls || true
 docker system df || true
 

--- a/hack/preload-images/generate.go
+++ b/hack/preload-images/generate.go
@@ -39,6 +39,7 @@ import (
 
 func generateTarball(kubernetesVersion, containerRuntime, tarballFilename string) error {
 	driver := kic.NewDriver(kic.Config{
+		ClusterName:       profile,
 		KubernetesVersion: kubernetesVersion,
 		ContainerRuntime:  containerRuntime,
 		OCIBinary:         oci.Docker,

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -81,11 +81,19 @@ func (d *Driver) Create() error {
 	}
 
 	defaultNetwork := d.MachineName
-	if err := oci.CreateNetwork(defaultNetwork, oci.DefaultIPRange, oci.DefaultGateway); err != nil {
-		glog.Warningf("unable to create docker network; node ip may not be stable: %v", err)
+	if subnet, err := oci.CreateNetwork(defaultNetwork); err != nil {
+		glog.Errorf("unable to create docker network; node ip may not be stable: %v", err)
 	} else {
 		params.Network = defaultNetwork
-		params.IP = oci.DefaultIP
+		fmt.Println("subnet is", subnet)
+		ip := net.ParseIP(strings.Split(subnet, "/")[0])
+		fmt.Println("the ip is", ip)
+		// make sure it's only 4 bytes
+		ip = ip.To4()
+		// check ip != nil
+		ip[3]++
+		ip[3]++
+		params.IP = ip.String()
 	}
 
 	// control plane specific options

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -85,14 +85,10 @@ func (d *Driver) Create() error {
 		glog.Errorf("unable to create docker network; node ip may not be stable: %v", err)
 	} else {
 		params.Network = defaultNetwork
-		fmt.Println("subnet is", subnet)
-		ip := net.ParseIP(strings.Split(subnet, "/")[0])
-		fmt.Println("the ip is", ip)
-		// make sure it's only 4 bytes
-		ip = ip.To4()
-		// check ip != nil
-		ip[3]++
-		ip[3]++
+		ip := subnet.IP.To4()
+		if ip != nil {
+			ip[3]++
+		}
 		params.IP = ip.String()
 	}
 

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -101,8 +101,8 @@ func (d *Driver) Create() error {
 	} else {
 		params.Network = defaultNetwork
 		ip := gateway.To4()
-		i := machineOrder(d.NodeConfig.MachineName)
-		ip[3] = ip[3] + byte(i)
+		// calculate the container IP based on its machine order
+		ip[3] = ip[3] + byte(machineOrder(d.NodeConfig.MachineName))
 		glog.Infof("calculated static IP %q for the %q container ", ip.String(), d.NodeConfig.MachineName)
 		params.IP = ip.String()
 	}

--- a/pkg/drivers/kic/kic_test.go
+++ b/pkg/drivers/kic/kic_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kic
+
+import (
+	"testing"
+)
+
+func TestMachineOrder(t *testing.T) {
+	testCases := []struct {
+		Name        string
+		MachineName string
+		Want        int
+	}{
+		{
+			Name:        "default",
+			MachineName: "minikube",
+			Want:        1},
+		{
+			Name:        "second-node",
+			MachineName: "minikube-m02",
+			Want:        2},
+		{
+			Name:        "dash-profile",
+			MachineName: "my-dashy-minikube",
+			Want:        1},
+
+		{
+			Name:        "dash-profile-second-node",
+			MachineName: "my-dashy-minikube-m02",
+			Want:        2},
+		{
+			Name:        "michivious-user",
+			MachineName: "michivious-user-m02-m03",
+			Want:        3},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			got := machineOrder(tc.MachineName)
+			if got != tc.Want {
+				t.Errorf("want order %q but got %q", tc.Want, got)
+
+			}
+		})
+
+	}
+}

--- a/pkg/drivers/kic/oci/errors.go
+++ b/pkg/drivers/kic/oci/errors.go
@@ -39,6 +39,9 @@ var ErrWindowsContainers = &FailFastError{errors.New("docker container type is w
 // ErrCPUCountLimit is thrown when docker daemon doesn't have enough CPUs for the requested container
 var ErrCPUCountLimit = &FailFastError{errors.New("not enough CPUs is available for container")}
 
+// ErrIPinUse is thrown when the container been given an IP used by another container
+var ErrIPinUse = &FailFastError{errors.New("can't create with that IP, address already in use")}
+
 // ErrExitedUnexpectedly is thrown when container is created/started without error but later it exists and it's status is not running anymore.
 var ErrExitedUnexpectedly = errors.New("container exited unexpectedly")
 

--- a/pkg/drivers/kic/oci/errors.go
+++ b/pkg/drivers/kic/oci/errors.go
@@ -45,6 +45,9 @@ var ErrExitedUnexpectedly = errors.New("container exited unexpectedly")
 // ErrDaemonInfo is thrown when docker/podman info is failing or not responding
 var ErrDaemonInfo = errors.New("daemon info not responding")
 
+// ErrNetworkSubnetTaken is thrown when a subnet is taken by another network
+var ErrNetworkSubnetTaken = errors.New("subnet is taken")
+
 // LogContainerDebug will print relevant docker/podman infos after a container fails
 func LogContainerDebug(ociBin string, name string) string {
 	rr, err := containerInspect(ociBin, name)

--- a/pkg/drivers/kic/oci/errors.go
+++ b/pkg/drivers/kic/oci/errors.go
@@ -48,6 +48,15 @@ var ErrDaemonInfo = errors.New("daemon info not responding")
 // ErrNetworkSubnetTaken is thrown when a subnet is taken by another network
 var ErrNetworkSubnetTaken = errors.New("subnet is taken")
 
+// ErrNetworkNotFound is when given network was not found
+var ErrNetworkNotFound = errors.New("kic network not found")
+
+// ErrNetworkGatewayTaken is when given network gatway is taken
+var ErrNetworkGatewayTaken = errors.New("network gateway is taken")
+
+// ErrNetworkInUse is when trying to delete a network which is attached to another container
+var ErrNetworkInUse = errors.New("can't delete network attached to a running container")
+
 // LogContainerDebug will print relevant docker/podman infos after a container fails
 func LogContainerDebug(ociBin string, name string) string {
 	rr, err := containerInspect(ociBin, name)

--- a/pkg/drivers/kic/oci/network.go
+++ b/pkg/drivers/kic/oci/network.go
@@ -198,7 +198,7 @@ func attemptCreateNework(subnet *net.IPNet, name string) error {
 	gateway[3]++ // first ip for gateway
 	glog.Infof("attempt to create network %q with subnet: %s and gateway %s...", subnet, name, gateway)
 	// options documenation https://docs.docker.com/engine/reference/commandline/network_create/#bridge-driver-options
-	rr, err := runCmd(exec.Command(Docker, "network", "create", "--driver=bridge", fmt.Sprintf("--subnet=%s", subnet), fmt.Sprintf("--gateway=%s", gateway), "-o", "com.docker.network.bridge.enable_ip_masquerade=true", "-o", "com.docker.network.bridge.enable_icc", fmt.Sprintf("--label=%s=%s", CreatedByLabelKey, "true"), name))
+	rr, err := runCmd(exec.Command(Docker, "network", "create", "--driver=bridge", fmt.Sprintf("--subnet=%s", subnet), fmt.Sprintf("--gateway=%s", gateway), "-o", "--ip-masq", "-o", "--icc", fmt.Sprintf("--label=%s=%s", CreatedByLabelKey, "true"), name))
 	if err != nil {
 		if strings.Contains(rr.Output(), "Pool overlaps with other one on this address space") {
 			return ErrNetworkSubnetTaken

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -276,6 +276,10 @@ func createContainer(ociBin string, image string, opts ...createOpt) error {
 		if strings.Contains(rr.Output(), "Range of CPUs is from") && strings.Contains(rr.Output(), "CPUs available") { // CPUs available
 			return ErrCPUCountLimit
 		}
+		// example: docker: Error response from daemon: Address already in use.
+		if strings.Contains(rr.Output(), "Address already in use") {
+			return ErrIPinUse
+		}
 		return err
 	}
 

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -88,7 +88,7 @@ func DeleteContainer(ociBin string, name string) error {
 	if _, err := runCmd(exec.Command(ociBin, "rm", "-f", "-v", name)); err != nil {
 		return errors.Wrapf(err, "delete %s", name)
 	}
-	if err := removeNetwork(name); err != nil {
+	if err := RemoveNetwork(name); err != nil {
 		return errors.Wrap(err, "removing network")
 	}
 	return nil
@@ -153,8 +153,10 @@ func CreateContainerNode(p CreateParams) error {
 		runArgs = append(runArgs, "--volume", fmt.Sprintf("%s:/var:exec", p.Name))
 	}
 	if p.OCIBinary == Docker {
-		if p.Network != "" {
+		// to provide a static IP for docker
+		if p.Network != "" && p.IP != "" {
 			runArgs = append(runArgs, "--network", p.Network)
+			runArgs = append(runArgs, "--ip", p.IP)
 		}
 
 		runArgs = append(runArgs, "--volume", fmt.Sprintf("%s:/var", p.Name))

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -153,10 +153,8 @@ func CreateContainerNode(p CreateParams) error {
 		runArgs = append(runArgs, "--volume", fmt.Sprintf("%s:/var:exec", p.Name))
 	}
 	if p.OCIBinary == Docker {
-		// on linux, we can provide a static IP for docker
-		if runtime.GOOS == "linux" && p.Network != "" && p.IP != "" {
+		if p.Network != "" {
 			runArgs = append(runArgs, "--network", p.Network)
-			runArgs = append(runArgs, "--ip", p.IP)
 		}
 
 		runArgs = append(runArgs, "--volume", fmt.Sprintf("%s:/var", p.Name))

--- a/pkg/drivers/kic/oci/types.go
+++ b/pkg/drivers/kic/oci/types.go
@@ -31,6 +31,8 @@ const (
 	nodeRoleLabelKey = "role.minikube.sigs.k8s.io"
 	// CreatedByLabelKey is applied to any container/volume that is created by minikube created_by.minikube.sigs.k8s.io=true
 	CreatedByLabelKey = "created_by.minikube.sigs.k8s.io"
+	// DefaultSubnet subnet to be used on first cluster
+	defaultSubnet = "192.168.39.0/24"
 )
 
 // CreateParams are parameters needed to create a container

--- a/pkg/drivers/kic/oci/types.go
+++ b/pkg/drivers/kic/oci/types.go
@@ -31,12 +31,6 @@ const (
 	nodeRoleLabelKey = "role.minikube.sigs.k8s.io"
 	// CreatedByLabelKey is applied to any container/volume that is created by minikube created_by.minikube.sigs.k8s.io=true
 	CreatedByLabelKey = "created_by.minikube.sigs.k8s.io"
-	// DefaultGateway is the default gateway for the docker network created by the kic driver on linux
-	DefaultGateway = "192.168.39.1"
-	// DefaultIPRange is the default IP range for the docker network created by the kic driver on linux
-	DefaultIPRange = "192.168.39.0/24"
-	// DefaultIP is the default IP for the docker network created by the kic driver on linux
-	DefaultIP = "192.168.39.2"
 )
 
 // CreateParams are parameters needed to create a container

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -48,6 +48,7 @@ var (
 
 // Config is configuration for the kic driver used by registry
 type Config struct {
+	ClusterName       string            // profile name or cluster name
 	MachineName       string            // maps to the container name being created
 	CPU               int               // Number of CPU cores assigned to the container
 	Memory            int               // max memory in MB

--- a/pkg/minikube/cluster/ip.go
+++ b/pkg/minikube/cluster/ip.go
@@ -34,12 +34,12 @@ import (
 )
 
 // HostIP gets the ip address to be used for mapping host -> VM and VM -> host
-func HostIP(host *host.Host) (net.IP, error) {
+func HostIP(host *host.Host, clusterName string) (net.IP, error) {
 	switch host.DriverName {
 	case driver.Docker:
-		return oci.RoutableHostIPFromInside(oci.Docker, host.Name)
+		return oci.RoutableHostIPFromInside(oci.Docker, clusterName, host.Name)
 	case driver.Podman:
-		return oci.RoutableHostIPFromInside(oci.Podman, host.Name)
+		return oci.RoutableHostIPFromInside(oci.Podman, clusterName, host.Name)
 	case driver.KVM2:
 		return net.ParseIP("192.168.39.1"), nil
 	case driver.HyperV:

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -92,7 +92,7 @@ func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 	showVersionInfo(starter.Node.KubernetesVersion, cr)
 
 	// Add "host.minikube.internal" DNS alias (intentionally non-fatal)
-	hostIP, err := cluster.HostIP(starter.Host)
+	hostIP, err := cluster.HostIP(starter.Host, starter.Cfg.Name)
 	if err != nil {
 		glog.Errorf("Unable to get host IP: %v", err)
 	} else if err := machine.AddHostAlias(starter.Runner, constants.HostAlias, hostIP); err != nil {

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -50,6 +50,7 @@ func init() {
 
 func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 	return kic.NewDriver(kic.Config{
+		ClusterName:       cc.Name,
 		MachineName:       driver.MachineName(cc, n),
 		StorePath:         localpath.MiniPath(),
 		ImageDigest:       cc.KicBaseImage,

--- a/pkg/minikube/registry/drvs/podman/podman.go
+++ b/pkg/minikube/registry/drvs/podman/podman.go
@@ -64,6 +64,7 @@ func init() {
 
 func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 	return kic.NewDriver(kic.Config{
+		ClusterName:       cc.Name,
 		MachineName:       driver.MachineName(cc, n),
 		StorePath:         localpath.MiniPath(),
 		ImageDigest:       strings.Split(cc.KicBaseImage, "@")[0], // for podman does not support docker images references with both a tag and digest.


### PR DESCRIPTION
### After this PR
- Create one network per Cluster
- Assign Static IP based on the machine order (offset from gateway)
- if can't create network becaue subnet is taken, bump the subnet 3rd digit by 10, and try again.
- fix left over docker networks not being deleted with minikube delete --all
- add more error types
- add failfast error type for not trying again with same IP, when error is IP is in use.
- add created_by_minikube=true label to the networks we create for better clean up. and avoid deleting user's networks.


closes https://github.com/kubernetes/minikube/issues/9087 
closes https://github.com/kubernetes/minikube/issues/9069
closes https://github.com/kubernetes/minikube/issues/8936


### TODO: fix upgrading existing cluster
```
medya@medya:~/workspace/minikube$ ./out/minikube start 
😄  minikube v1.12.3 on Debian rodete
✨  Using the docker driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
🏃  Updating the running docker "minikube" container ...
🐳  Preparing Kubernetes v1.18.3 on Docker 19.03.8 ...
E0826 11:57:18.506400 2936672 start.go:97] Unable to get host IP: network inspect: kic network not found

💣  failed to start node: startup failed: Failed to setup kubeconfig: network inspect: kic network not found

😿  minikube is exiting due to an error. If the above message is not useful, open an issue:
👉  https://github.com/kubernetes/minikube/issues/new/choose
```