### PR TITLE
start: Add -o shorthand option for --output

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -144,7 +144,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().Bool(preload, true, "If set, download tarball of preloaded images if available to improve start time. Defaults to true.")
 	startCmd.Flags().Bool(deleteOnFailure, false, "If set, delete the current cluster if start fails and try again. Defaults to false.")
 	startCmd.Flags().Bool(forceSystemd, false, "If set, force the container runtime to use sytemd as cgroup manager. Currently available for docker and crio. Defaults to false.")
-	startCmd.Flags().String(startOutput, "text", "Format to print stdout in. Options include: [text,json]")
+	startCmd.Flags().StringP(startOutput, "o", "text", "Format to print stdout in. Options include: [text,json]")
 }
 
 // initKubernetesFlags inits the commandline flags for Kubernetes related options

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -83,7 +83,7 @@ minikube start [flags]
       --nfs-shares-root string            Where to root the NFS Shares, defaults to /nfsshares (hyperkit driver only) (default "/nfsshares")
       --no-vtx-check                      Disable checking for the availability of hardware virtualization before the vm is started (virtualbox driver only)
   -n, --nodes int                         The number of nodes to spin up. Defaults to 1. (default 1)
-      --output string                     Format to print stdout in. Options include: [text,json] (default "text")
+  -o, --output string                     Format to print stdout in. Options include: [text,json] (default "text")
       --preload                           If set, download tarball of preloaded images if available to improve start time. Defaults to true. (default true)
       --registry-mirror strings           Registry mirrors to pass to the Docker daemon
       --service-cluster-ip-range string   The CIDR to be used for service cluster IPs. (default "10.96.0.0/12")


### PR DESCRIPTION
##what
This PR addresses code changes that adds shorthand for start command output option.

Fixes #9088

usage: 
before: 
```
vinu@vinu-HP-Spectre-x360-Convertible-13-ae0xx:~/go_workspace/src/minikube$ ./out/minikube start -o text
Error: unknown shorthand flag: 'o' in -o
See 'minikube start --help' for usage.
vinu@vinu-HP-Spectre-x360-Convertible-13-ae0xx:~/go_workspace/src/minikube$ 
```

after: 
```
vinu@vinu-HP-Spectre-x360-Convertible-13-ae0xx:~/go_workspace/src/minikube$ ./out/minikube start -o json
{"data":{"currentstep":"0","message":"minikube v1.12.3 on Ubuntu 20.04\n","name":"Initial Minikube Setup","totalsteps":"12"},"datacontenttype":"application/json","id":"655565a5-37e1-49f9-9098-bb9a0f30fccf","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.step"}
{"data":{"currentstep":"1","message":"Automatically selected the docker driver\n","name":"Selecting Driver","totalsteps":"12"},"datacontenttype":"application/json","id":"1b9a4557-045a-4295-8c7e-d2c498fb3e63","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.step"}
{"data":{"currentstep":"3","message":"Starting control plane node minikube in cluster minikube\n","name":"Starting Node","totalsteps":"12"},"datacontenttype":"application/json","id":"14b33c23-9bba-4d10-9b20-b45812cac7e0","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.step"}
{"data":{"currentstep":"6","message":"Creating docker container (CPUs=2, Memory=3900MB) ...\n","name":"Creating Container","totalsteps":"12"},"datacontenttype":"application/json","id":"76755d77-982b-4fed-9482-2839162202ad","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.step"}
{"data":{"currentstep":"8","message":"Preparing Kubernetes v1.18.3 on Docker 19.03.8 ...\n","name":"Preparing Kubernetes","totalsteps":"12"},"datacontenttype":"application/json","id":"c420f5f6-0dd0-40ad-a499-9e2e5634dd14","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.step"}
{"data":{"currentstep":"10","message":"Verifying Kubernetes components...\n","name":"Verifying Kubernetes","totalsteps":"12"},"datacontenttype":"application/json","id":"05d8091d-79a6-4071-bff4-f896c52e244c","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.step"}
{"data":{"currentstep":"11","message":"Enabled addons: default-storageclass, storage-provisioner\n","name":"Enabling Addons","totalsteps":"12"},"datacontenttype":"application/json","id":"0ef9f1dc-16fe-46ae-9d79-4a40d878a353","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.step"}
{"data":{"currentstep":"12","message":"Done! kubectl is now configured to use \"minikube\"\n","name":"Done","totalsteps":"12"},"datacontenttype":"application/json","id":"fdfd89c8-5974-4fcb-8e69-a8ce5e222ccb","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.step"}
{"data":{"message":"/home/vinu/go_workspace/bin/kubectl is version 1.20.0-alpha.0.188+65a1f24b205ece-dirty, which may be incompatible with Kubernetes 1.18.3.\n"},"datacontenttype":"application/json","id":"52f350a1-6f3a-4631-a52b-856ec66b44d9","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.warning"}
{"data":{"message":"You can also use 'minikube kubectl -- get pods' to invoke a matching version\n"},"datacontenttype":"application/json","id":"959e5207-2389-4520-9892-251d5ee6fbed","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.error"}```