### PR TITLE
start: fixed the type value for latest minikube version availability message

### DIFF
--- a/pkg/minikube/notify/notify.go
+++ b/pkg/minikube/notify/notify.go
@@ -67,8 +67,8 @@ func MaybePrintUpdateText(url string, lastUpdatePath string) bool {
 			glog.Errorf("write time failed: %v", err)
 		}
 		url := "https://github.com/kubernetes/minikube/releases/tag/v" + latestVersion.String()
-		out.ErrT(style.Celebrate, `minikube {{.version}} is available! Download it: {{.url}}`, out.V{"version": latestVersion, "url": url})
-		out.ErrT(style.Tip, "To disable this notice, run: 'minikube config set WantUpdateNotification false'\n")
+		out.T(style.Celebrate, `minikube {{.version}} is available! Download it: {{.url}}`, out.V{"version": latestVersion, "url": url})
+		out.T(style.Tip, "To disable this notice, run: 'minikube config set WantUpdateNotification false'\n")
 		return true
 	}
 	return false

--- a/pkg/minikube/notify/notify_test.go
+++ b/pkg/minikube/notify/notify_test.go
@@ -154,7 +154,7 @@ func TestMaybePrintUpdateText(t *testing.T) {
 	tempDir := tests.MakeTempDir()
 	defer tests.RemoveTempDir(tempDir)
 	outputBuffer := tests.NewFakeFile()
-	out.SetErrFile(outputBuffer)
+	out.SetOutFile(outputBuffer)
 
 	var tc = []struct {
 		len                     int


### PR DESCRIPTION
This PR addresses code changes that fix the value for type from ```"type":"io.k8s.sigs.minikube.error"``` to ```"type":"io.k8s.sigs.minikube.step"``` for the latest minikube version availability message.

Fixes #9108

```
{"data":{"currentstep":"6","message":"minikube 1.12.3 is available! Download it: https://github.com/kubernetes/minikube/releases/tag/v1.12.3\n","name":"Creating Container","totalsteps":"12"},"datacontenttype":"application/json","id":"9afa18a5-bb67-46f9-abd6-3deb86fc65a0","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.step"}
{"data":{"currentstep":"6","message":"To disable this notice, run: 'minikube config set WantUpdateNotification false'\n\n","name":"Creating Container","totalsteps":"12"},"datacontenttype":"application/json","id":"41623db0-83f5-4a58-9d36-c3544760f49f","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.step"}
```
