### PR TITLE
noop: Run gofumports -w on codebase

### DIFF
--- a/cmd/minikube/cmd/completion.go
+++ b/cmd/minikube/cmd/completion.go
@@ -93,7 +93,6 @@ var completionCmd = &cobra.Command{
 				exit.WithError("fish completion failed", err)
 			}
 		}
-
 	},
 }
 

--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -140,7 +140,7 @@ var settings = []Setting{
 	},
 	{
 		name: Bootstrapper,
-		set:  SetString, //TODO(r2d4): more validation here?
+		set:  SetString, // TODO(r2d4): more validation here?
 	},
 	{
 		name: config.ShowDriverDeprecationNotification,

--- a/cmd/minikube/cmd/config/configure.go
+++ b/cmd/minikube/cmd/config/configure.go
@@ -123,7 +123,6 @@ var addonsConfigureCmd = &cobra.Command{
 					"cloud":                         "ecr",
 					"kubernetes.io/minikube-addons": "registry-creds",
 				})
-
 			if err != nil {
 				out.FailureT("ERROR creating `registry-creds-ecr` secret: {{.error}}", out.V{"error": err})
 			}

--- a/cmd/minikube/cmd/config/profile_list.go
+++ b/cmd/minikube/cmd/config/profile_list.go
@@ -34,16 +34,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	output string
-)
+var output string
 
 var profileListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "Lists all minikube profiles.",
 	Long:  "Lists all valid minikube profiles and detects all possible invalid profiles.",
 	Run: func(cmd *cobra.Command, args []string) {
-
 		switch strings.ToLower(output) {
 		case "json":
 			printProfilesJSON()
@@ -52,12 +49,10 @@ var profileListCmd = &cobra.Command{
 		default:
 			exit.WithCodeT(exit.BadUsage, fmt.Sprintf("invalid output format: %s. Valid values: 'table', 'json'", output))
 		}
-
 	},
 }
 
 var printProfilesTable = func() {
-
 	var validData [][]string
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"Profile", "VM Driver", "Runtime", "IP", "Port", "Version", "Status"})
@@ -105,7 +100,6 @@ var printProfilesTable = func() {
 	if err != nil {
 		glog.Warningf("error loading profiles: %v", err)
 	}
-
 }
 
 var printProfilesJSON = func() {
@@ -143,7 +137,7 @@ var printProfilesJSON = func() {
 		invalid = []*config.Profile{}
 	}
 
-	var body = map[string]interface{}{}
+	body := map[string]interface{}{}
 
 	if err == nil || config.IsNotExist(err) {
 		body["valid"] = valid

--- a/cmd/minikube/cmd/config/prompt.go
+++ b/cmd/minikube/cmd/config/prompt.go
@@ -119,7 +119,6 @@ func concealableAskForStaticValue(readWriter io.ReadWriter, promptString string,
 
 // AskForPasswordValue asks for a password value, while hiding the input
 func AskForPasswordValue(s string) string {
-
 	stdInFd := int(os.Stdin.Fd())
 	oldState, err := terminal.MakeRaw(stdInFd)
 	if err != nil {

--- a/cmd/minikube/cmd/config/set_test.go
+++ b/cmd/minikube/cmd/config/set_test.go
@@ -74,11 +74,11 @@ func createTestConfig(t *testing.T) {
 	}
 
 	// Not necessary, but it is a handy random alphanumeric
-	if err = os.MkdirAll(localpath.MakeMiniPath("config"), 0777); err != nil {
+	if err = os.MkdirAll(localpath.MakeMiniPath("config"), 0o777); err != nil {
 		t.Fatalf("error creating temporary directory: %+v", err)
 	}
 
-	if err = os.MkdirAll(localpath.MakeMiniPath("profiles"), 0777); err != nil {
+	if err = os.MkdirAll(localpath.MakeMiniPath("profiles"), 0o777); err != nil {
 		t.Fatalf("error creating temporary profiles directory: %+v", err)
 	}
 

--- a/cmd/minikube/cmd/config/util.go
+++ b/cmd/minikube/cmd/config/util.go
@@ -106,7 +106,6 @@ func (e ErrValidateProfile) Error() string {
 
 // ValidateProfile checks if the profile user is trying to switch exists, else throws error
 func ValidateProfile(profile string) (*ErrValidateProfile, bool) {
-
 	validProfiles, invalidProfiles, err := config.ListProfiles()
 	if err != nil {
 		out.FailureT(err.Error())

--- a/cmd/minikube/cmd/config/validations_test.go
+++ b/cmd/minikube/cmd/config/validations_test.go
@@ -39,8 +39,7 @@ func runValidations(t *testing.T, tests []validationTest, name string, f func(st
 }
 
 func TestDriver(t *testing.T) {
-
-	var tests = []validationTest{
+	tests := []validationTest{
 		{
 			value:     "vkasdhfasjdf",
 			shouldErr: true,
@@ -52,11 +51,10 @@ func TestDriver(t *testing.T) {
 	}
 
 	runValidations(t, tests, "driver", IsValidDriver)
-
 }
 
 func TestValidCIDR(t *testing.T) {
-	var tests = []validationTest{
+	tests := []validationTest{
 		{
 			value:     "0.0.0.0/0",
 			shouldErr: false,
@@ -99,7 +97,7 @@ func TestValidCIDR(t *testing.T) {
 }
 
 func TestValidRuntime(t *testing.T) {
-	var tests = []validationTest{
+	tests := []validationTest{
 		{
 			value:     "", // default
 			shouldErr: false,
@@ -126,7 +124,6 @@ func TestValidRuntime(t *testing.T) {
 }
 
 func TestIsURLExists(t *testing.T) {
-
 	self, err := os.Executable()
 	if err != nil {
 		t.Error(err)

--- a/cmd/minikube/cmd/dashboard.go
+++ b/cmd/minikube/cmd/dashboard.go
@@ -102,7 +102,7 @@ var dashboardCmd = &cobra.Command{
 			exit.WithCodeT(exit.Unavailable, "{{.url}} is not accessible: {{.error}}", out.V{"url": url, "error": err})
 		}
 
-		//check if current user is root
+		// check if current user is root
 		user, err := user.Current()
 		if err != nil {
 			exit.WithError("Unable to get current user", err)

--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -47,8 +47,10 @@ import (
 	"k8s.io/minikube/pkg/minikube/out/register"
 )
 
-var deleteAll bool
-var purge bool
+var (
+	deleteAll bool
+	purge     bool
+)
 
 // deleteCmd represents the delete command
 var deleteCmd = &cobra.Command{
@@ -126,7 +128,7 @@ func runDelete(cmd *cobra.Command, args []string) {
 	if len(args) > 0 {
 		exit.UsageT("Usage: minikube delete")
 	}
-	//register.SetEventLogPath(localpath.EventLog(ClusterFlagValue()))
+	// register.SetEventLogPath(localpath.EventLog(ClusterFlagValue()))
 	register.Reg.SetStep(register.Deleting)
 
 	validProfiles, invalidProfiles, err := config.ListProfiles()
@@ -204,7 +206,6 @@ func DeleteProfiles(profiles []*config.Profile) []error {
 	var errs []error
 	for _, profile := range profiles {
 		err := deleteProfile(profile)
-
 		if err != nil {
 			mm, loadErr := machine.LoadMachine(profile.Name)
 

--- a/cmd/minikube/cmd/delete_test.go
+++ b/cmd/minikube/cmd/delete_test.go
@@ -159,7 +159,7 @@ func TestDeleteAllProfiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("tempdir: %v", err)
 	}
-	defer func() { //clean up tempdir
+	defer func() { // clean up tempdir
 		err := os.RemoveAll(td)
 		if err != nil {
 			t.Errorf("failed to clean up temp folder  %q", td)

--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -73,7 +73,7 @@ type EnvNoProxyGetter struct{}
 func dockerShellCfgSet(ec DockerEnvConfig, envMap map[string]string) *DockerShellConfig {
 	profile := ec.profile
 	const usgPlz = "To point your shell to minikube's docker-daemon, run:"
-	var usgCmd = fmt.Sprintf("minikube -p %s docker-env", profile)
+	usgCmd := fmt.Sprintf("minikube -p %s docker-env", profile)
 	s := &DockerShellConfig{
 		Config: *shell.CfgSet(ec.EnvConfig, usgPlz, usgCmd),
 	}

--- a/cmd/minikube/cmd/docker-env_test.go
+++ b/cmd/minikube/cmd/docker-env_test.go
@@ -33,7 +33,7 @@ func (f FakeNoProxyGetter) GetNoProxyVar() (string, string) {
 }
 
 func TestGenerateDockerScripts(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		shell         string
 		config        DockerEnvConfig
 		noProxyGetter *FakeNoProxyGetter
@@ -255,7 +255,6 @@ MINIKUBE_ACTIVE_DOCKERD=noneshell
 			if diff := cmp.Diff(tc.wantUnset, got); diff != "" {
 				t.Errorf("unsetScript(%+v) mismatch (-want +got):\n%s\n\nraw output:\n%s\nquoted: %q", tc.config, diff, got, got)
 			}
-
 		})
 	}
 }

--- a/cmd/minikube/cmd/generate-docs.go
+++ b/cmd/minikube/cmd/generate-docs.go
@@ -35,7 +35,6 @@ var generateDocs = &cobra.Command{
 	Example: "minikube generate-docs --path <FOLDER_PATH>",
 	Hidden:  true,
 	Run: func(cmd *cobra.Command, args []string) {
-
 		// if directory does not exist
 		docsPath, err := os.Stat(path)
 		if err != nil || !docsPath.IsDir() {

--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -46,15 +46,17 @@ const (
 )
 
 // placeholders for flag values
-var mountIP string
-var mountVersion string
-var mountType string
-var isKill bool
-var uid string
-var gid string
-var mSize int
-var options []string
-var mode uint
+var (
+	mountIP      string
+	mountVersion string
+	mountType    string
+	isKill       bool
+	uid          string
+	gid          string
+	mSize        int
+	options      []string
+	mode         uint
+)
 
 // supportedFilesystems is a map of filesystem types to not warn against.
 var supportedFilesystems = map[string]bool{nineP: true}
@@ -203,7 +205,7 @@ func init() {
 	mountCmd.Flags().BoolVar(&isKill, "kill", false, "Kill the mount process spawned by minikube start")
 	mountCmd.Flags().StringVar(&uid, "uid", "docker", "Default user id used for the mount")
 	mountCmd.Flags().StringVar(&gid, "gid", "docker", "Default group id used for the mount")
-	mountCmd.Flags().UintVar(&mode, "mode", 0755, "File permissions used for the mount")
+	mountCmd.Flags().UintVar(&mode, "mode", 0o755, "File permissions used for the mount")
 	mountCmd.Flags().StringSliceVar(&options, "options", []string{}, "Additional mount options, such as cache=fscache")
 	mountCmd.Flags().IntVar(&mSize, "msize", defaultMsize, "The number of bytes to use for 9p packet payload")
 }

--- a/cmd/minikube/cmd/node_add.go
+++ b/cmd/minikube/cmd/node_add.go
@@ -31,6 +31,7 @@ var (
 	cp     bool
 	worker bool
 )
+
 var nodeAddCmd = &cobra.Command{
 	Use:   "add",
 	Short: "Adds a node to the given cluster.",

--- a/cmd/minikube/cmd/node_delete.go
+++ b/cmd/minikube/cmd/node_delete.go
@@ -30,7 +30,6 @@ var nodeDeleteCmd = &cobra.Command{
 	Short: "Deletes a node from a cluster.",
 	Long:  "Deletes a node from a cluster.",
 	Run: func(cmd *cobra.Command, args []string) {
-
 		if len(args) == 0 {
 			exit.UsageT("Usage: minikube node delete [name]")
 		}

--- a/cmd/minikube/cmd/pause.go
+++ b/cmd/minikube/cmd/pause.go
@@ -54,7 +54,7 @@ func runPause(cmd *cobra.Command, args []string) {
 
 	glog.Infof("namespaces: %v keys: %v", namespaces, viper.AllSettings())
 	if allNamespaces {
-		namespaces = nil //all
+		namespaces = nil // all
 	} else if len(namespaces) == 0 {
 		exit.WithCodeT(exit.BadUsage, "Use -A to specify all namespaces")
 	}

--- a/cmd/minikube/cmd/podman-env.go
+++ b/cmd/minikube/cmd/podman-env.go
@@ -47,15 +47,13 @@ type PodmanShellConfig struct {
 	MinikubePodmanProfile string
 }
 
-var (
-	podmanUnset bool
-)
+var podmanUnset bool
 
 // podmanShellCfgSet generates context variables for "podman-env"
 func podmanShellCfgSet(ec PodmanEnvConfig, envMap map[string]string) *PodmanShellConfig {
 	profile := ec.profile
 	const usgPlz = "To point your shell to minikube's podman service, run:"
-	var usgCmd = fmt.Sprintf("minikube -p %s podman-env", profile)
+	usgCmd := fmt.Sprintf("minikube -p %s podman-env", profile)
 	s := &PodmanShellConfig{
 		Config: *shell.CfgSet(ec.EnvConfig, usgPlz, usgCmd),
 	}

--- a/cmd/minikube/cmd/podman-env_test.go
+++ b/cmd/minikube/cmd/podman-env_test.go
@@ -32,7 +32,7 @@ func newFakeClient() *ssh.ExternalClient {
 }
 
 func TestGeneratePodmanScripts(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		shell         string
 		config        PodmanEnvConfig
 		noProxyGetter *FakeNoProxyGetter
@@ -75,7 +75,6 @@ export MINIKUBE_ACTIVE_PODMAN="bash"
 			if diff := cmp.Diff(tc.wantUnset, got); diff != "" {
 				t.Errorf("unsetScript(%+v) mismatch (-want +got):\n%s\n\nraw output:\n%s\nquoted: %q", tc.config, diff, got, got)
 			}
-
 		})
 	}
 }

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -56,7 +56,7 @@ var RootCmd = &cobra.Command{
 	Long:  `minikube provisions and manages local Kubernetes clusters optimized for development workflows.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		for _, path := range dirs {
-			if err := os.MkdirAll(path, 0777); err != nil {
+			if err := os.MkdirAll(path, 0o777); err != nil {
 				exit.WithError("Error creating minikube directory", err)
 			}
 		}
@@ -143,7 +143,7 @@ func usageTemplate() string {
 // by setting them directly, using values from viper when not passed in as args
 func setFlagsUsingViper() {
 	for _, config := range []string{"alsologtostderr", "log_dir", "v"} {
-		var a = pflag.Lookup(config)
+		a := pflag.Lookup(config)
 		viper.SetDefault(a.Name, a.DefValue)
 		// If the flag is set, override viper value
 		if a.Changed {
@@ -232,7 +232,6 @@ func init() {
 		exit.WithError("Unable to bind flags", err)
 	}
 	cobra.OnInitialize(initConfig)
-
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -107,7 +107,6 @@ func init() {
 	serviceCmd.Flags().IntVar(&interval, "interval", service.DefaultInterval, "The initial time interval for each check that wait performs in seconds")
 
 	serviceCmd.PersistentFlags().StringVar(&serviceURLFormat, "format", defaultServiceFormatTemplate, "Format to output service URL in. This format will be applied to each url individually and they will be printed one at a time.")
-
 }
 
 func startKicServiceTunnel(svc, configName string) {

--- a/cmd/minikube/cmd/ssh.go
+++ b/cmd/minikube/cmd/ssh.go
@@ -30,9 +30,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/out"
 )
 
-var (
-	nativeSSHClient bool
-)
+var nativeSSHClient bool
 
 // sshCmd represents the docker-ssh command
 var sshCmd = &cobra.Command{

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -224,7 +224,6 @@ func runStart(cmd *cobra.Command, args []string) {
 	if err := showKubectlInfo(kubeconfig, starter.Node.KubernetesVersion, starter.Cfg.Name); err != nil {
 		glog.Errorf("kubectl info: %v", err)
 	}
-
 }
 
 func provisionWithDriver(cmd *cobra.Command, ds registry.DriverState, existing *config.ClusterConfig) (node.Starter, error) {
@@ -898,7 +897,6 @@ func validateMemorySize(req int, drvName string) {
 
 `, out.V{"requested": req, "system_limit": sysLimit, "min_advised": minAdvised})
 	}
-
 }
 
 // validateCPUCount validates the cpu count matches the minimum recommended
@@ -945,7 +943,6 @@ func validateCPUCount(drvName string) {
 
 // validateFlags validates the supplied flags against known bad combinations
 func validateFlags(cmd *cobra.Command, drvName string) {
-
 	if cmd.Flags().Changed(humanReadableDiskSize) {
 		diskSizeMB, err := util.CalculateSizeInMB(viper.GetString(humanReadableDiskSize))
 		if err != nil {
@@ -1051,7 +1048,6 @@ func validateFlags(cmd *cobra.Command, drvName string) {
 // This function validates if the --registry-mirror
 // args match the format of http://localhost
 func validateRegistryMirror() {
-
 	if len(registryMirror) > 0 {
 		for _, loc := range registryMirror {
 			URL, err := url.Parse(loc)

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestGetKubernetesVersion(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		description     string
 		expectedVersion string
 		paramVersion    string
@@ -87,7 +87,7 @@ func TestMirrorCountry(t *testing.T) {
 	viper.SetDefault(humanReadableDiskSize, defaultDiskSize)
 
 	k8sVersion := constants.DefaultKubernetesVersion
-	var tests = []struct {
+	tests := []struct {
 		description     string
 		k8sVersion      string
 		imageRepository string
@@ -153,7 +153,7 @@ func TestGenerateCfgFromFlagsHTTPProxyHandling(t *testing.T) {
 		}
 	}()
 	k8sVersion := constants.NewestKubernetesVersion
-	var tests = []struct {
+	tests := []struct {
 		description  string
 		proxy        string
 		proxyIgnored bool
@@ -240,7 +240,7 @@ func TestGenerateCfgFromFlagsHTTPProxyHandling(t *testing.T) {
 }
 
 func TestSuggestMemoryAllocation(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		description    string
 		sysLimit       int
 		containerLimit int

--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -48,9 +48,11 @@ import (
 	"k8s.io/minikube/pkg/version"
 )
 
-var statusFormat string
-var output string
-var layout string
+var (
+	statusFormat string
+	output       string
+	layout       string
+)
 
 const (
 	// Additional legacy states:
@@ -182,7 +184,6 @@ var statusCmd = &cobra.Command{
 	Exit status contains the status of minikube's VM, cluster and Kubernetes encoded on it's bits in this order from right to left.
 	Eg: 7 meaning: 1 (for minikube NOK) + 2 (for cluster NOK) + 4 (for Kubernetes NOK)`,
 	Run: func(cmd *cobra.Command, args []string) {
-
 		if output != "text" && statusFormat != defaultStatusFormat {
 			exit.UsageT("Cannot use both --output and --format options")
 		}

--- a/cmd/minikube/cmd/status_test.go
+++ b/cmd/minikube/cmd/status_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestExitCode(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name  string
 		want  int
 		state *Status
@@ -44,7 +44,7 @@ func TestExitCode(t *testing.T) {
 }
 
 func TestStatusText(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name  string
 		state *Status
 		want  string
@@ -82,7 +82,7 @@ func TestStatusText(t *testing.T) {
 }
 
 func TestStatusJSON(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name  string
 		state *Status
 	}{

--- a/cmd/minikube/cmd/stop.go
+++ b/cmd/minikube/cmd/stop.go
@@ -37,8 +37,10 @@ import (
 	"k8s.io/minikube/pkg/util/retry"
 )
 
-var stopAll bool
-var keepActive bool
+var (
+	stopAll    bool
+	keepActive bool
+)
 
 // stopCmd represents the stop command
 var stopCmd = &cobra.Command{
@@ -50,7 +52,6 @@ itself, leaving all files intact. The cluster can be started again with the "sta
 }
 
 func init() {
-
 	stopCmd.Flags().BoolVar(&stopAll, "all", false, "Set flag to stop all profiles (clusters)")
 	stopCmd.Flags().BoolVar(&keepActive, "keep-context-active", false, "keep the kube-context active after cluster is stopped. Defaults to false.")
 

--- a/cmd/minikube/cmd/unpause.go
+++ b/cmd/minikube/cmd/unpause.go
@@ -48,7 +48,7 @@ var unpauseCmd = &cobra.Command{
 
 		glog.Infof("namespaces: %v keys: %v", namespaces, viper.AllSettings())
 		if allNamespaces {
-			namespaces = nil //all
+			namespaces = nil // all
 		} else {
 			if len(namespaces) == 0 {
 				exit.WithCodeT(exit.BadUsage, "Use -A to specify all namespaces")

--- a/cmd/minikube/cmd/update-context.go
+++ b/cmd/minikube/cmd/update-context.go
@@ -43,6 +43,5 @@ var updateContextCmd = &cobra.Command{
 		} else {
 			out.T(out.Meh, `No changes required for the "{{.context}}" context`, out.V{"context": cname})
 		}
-
 	},
 }

--- a/cmd/storage-provisioner/main.go
+++ b/cmd/storage-provisioner/main.go
@@ -29,7 +29,7 @@ var pvDir = "/tmp/hostpath-provisioner"
 
 func main() {
 	// Glog requires that /tmp exists.
-	if err := os.MkdirAll("/tmp", 0755); err != nil {
+	if err := os.MkdirAll("/tmp", 0o755); err != nil {
 		fmt.Fprintf(os.Stderr, "Error creating tmpdir: %v\n", err)
 		os.Exit(1)
 	}
@@ -38,5 +38,4 @@ func main() {
 	if err := storage.StartStorageProvisioner(pvDir); err != nil {
 		glog.Exit(err)
 	}
-
 }

--- a/hack/boilerplate/boilerplate.go
+++ b/hack/boilerplate/boilerplate.go
@@ -67,7 +67,6 @@ func main() {
 			fmt.Println(path)
 		}
 	}
-
 }
 
 // extensionToBoilerplate returns a map of file extension to required boilerplate text.

--- a/hack/help_text/gen_help_text.go
+++ b/hack/help_text/gen_help_text.go
@@ -25,7 +25,7 @@ import (
 )
 
 func main() {
-	if err := os.MkdirAll("./out/docs", os.FileMode(0755)); err != nil {
+	if err := os.MkdirAll("./out/docs", os.FileMode(0o755)); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/hack/preload-images/generate.go
+++ b/hack/preload-images/generate.go
@@ -53,7 +53,7 @@ func generateTarball(kubernetesVersion, containerRuntime, tarballFilename string
 	baseDir := filepath.Dir(driver.GetSSHKeyPath())
 	defer os.Remove(baseDir)
 
-	if err := os.MkdirAll(baseDir, 0755); err != nil {
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
 		return errors.Wrap(err, "mkdir")
 	}
 	if err := driver.Create(); err != nil {

--- a/pkg/addons/addons_test.go
+++ b/pkg/addons/addons_test.go
@@ -42,7 +42,7 @@ func createTestProfile(t *testing.T) string {
 
 	// Not necessary, but it is a handy random alphanumeric
 	name := filepath.Base(td)
-	if err := os.MkdirAll(config.ProfileFolderPath(name), 0777); err != nil {
+	if err := os.MkdirAll(config.ProfileFolderPath(name), 0o777); err != nil {
 		t.Fatalf("error creating temporary directory")
 	}
 
@@ -72,7 +72,6 @@ func TestIsAddonAlreadySet(t *testing.T) {
 	if assets.Addons["ingress"].IsEnabled(cc) {
 		t.Errorf("expected ingress to not be enabled")
 	}
-
 }
 
 func TestDisableUnknownAddon(t *testing.T) {

--- a/pkg/addons/config.go
+++ b/pkg/addons/config.go
@@ -137,8 +137,8 @@ var Addons = []*Addon{
 		name:      "registry-aliases",
 		set:       SetBool,
 		callbacks: []setFn{enableOrDisableAddon},
-		//TODO - add other settings
-		//TODO check if registry addon is enabled
+		// TODO - add other settings
+		// TODO check if registry addon is enabled
 	},
 	{
 		name:      "storage-provisioner",

--- a/pkg/addons/gcpauth/enable.go
+++ b/pkg/addons/gcpauth/enable.go
@@ -46,7 +46,6 @@ func EnableOrDisable(cfg *config.ClusterConfig, name string, val string) error {
 		return enableAddon(cfg)
 	}
 	return disableAddon(cfg)
-
 }
 
 func enableAddon(cfg *config.ClusterConfig) error {

--- a/pkg/drivers/common.go
+++ b/pkg/drivers/common.go
@@ -58,7 +58,7 @@ func createRawDiskImage(sshKeyPath, diskPath string, diskSizeMb int) error {
 		return errors.Wrap(err, "make disk image")
 	}
 
-	file, err := os.OpenFile(diskPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	file, err := os.OpenFile(diskPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
 	if err != nil {
 		return errors.Wrap(err, "open")
 	}

--- a/pkg/drivers/common_test.go
+++ b/pkg/drivers/common_test.go
@@ -30,7 +30,7 @@ func Test_createDiskImage(t *testing.T) {
 	defer tests.RemoveTempDir(tmpdir)
 
 	sshPath := filepath.Join(tmpdir, "ssh")
-	if err := ioutil.WriteFile(sshPath, []byte("mysshkey"), 0644); err != nil {
+	if err := ioutil.WriteFile(sshPath, []byte("mysshkey"), 0o644); err != nil {
 		t.Fatalf("writefile: %v", err)
 	}
 	diskPath := filepath.Join(tmpdir, "disk")

--- a/pkg/drivers/hyperkit/driver.go
+++ b/pkg/drivers/hyperkit/driver.go
@@ -343,13 +343,13 @@ func (t tempError) Error() string {
 	return "Temporary error: " + t.Err.Error()
 }
 
-//recoverFromUncleanShutdown searches for an existing hyperkit.pid file in
-//the machine directory. If it can't find it, a clean shutdown is assumed.
-//If it finds the pid file, it checks for a running hyperkit process with that pid
-//as the existence of a file might not indicate an unclean shutdown but an actual running
-//hyperkit server. This is an error situation - we shouldn't start minikube as there is likely
-//an instance running already. If the PID in the pidfile does not belong to a running hyperkit
-//process, we can safely delete it, and there is a good chance the machine will recover when restarted.
+// recoverFromUncleanShutdown searches for an existing hyperkit.pid file in
+// the machine directory. If it can't find it, a clean shutdown is assumed.
+// If it finds the pid file, it checks for a running hyperkit process with that pid
+// as the existence of a file might not indicate an unclean shutdown but an actual running
+// hyperkit server. This is an error situation - we shouldn't start minikube as there is likely
+// an instance running already. If the PID in the pidfile does not belong to a running hyperkit
+// process, we can safely delete it, and there is a good chance the machine will recover when restarted.
 func (d *Driver) recoverFromUncleanShutdown() error {
 	stateDir := filepath.Join(d.StorePath, "machines", d.MachineName)
 	pidFile := filepath.Join(stateDir, pidFileName)

--- a/pkg/drivers/hyperkit/driver_test.go
+++ b/pkg/drivers/hyperkit/driver_test.go
@@ -63,7 +63,6 @@ func Test_portExtraction(t *testing.T) {
 }
 
 func testEq(a, b []int) bool {
-
 	if a == nil && b == nil {
 		return true
 	}

--- a/pkg/drivers/hyperkit/iso_test.go
+++ b/pkg/drivers/hyperkit/iso_test.go
@@ -27,7 +27,7 @@ func TestExtractFile(t *testing.T) {
 	if nil != err {
 		return
 	}
-	defer func() { //clean up tempdir
+	defer func() { // clean up tempdir
 		err := os.RemoveAll(testDir)
 		if err != nil {
 			t.Errorf("failed to clean up temp folder  %q", testDir)

--- a/pkg/drivers/hyperkit/network.go
+++ b/pkg/drivers/hyperkit/network.go
@@ -40,9 +40,7 @@ const (
 	SharedNetAddrKey = "Shared_Net_Address"
 )
 
-var (
-	leadingZeroRegexp = regexp.MustCompile(`0([A-Fa-f0-9](:|$))`)
-)
+var leadingZeroRegexp = regexp.MustCompile(`0([A-Fa-f0-9](:|$))`)
 
 // DHCPEntry holds a parsed DNS entry
 type DHCPEntry struct {

--- a/pkg/drivers/hyperkit/network_test.go
+++ b/pkg/drivers/hyperkit/network_test.go
@@ -53,12 +53,12 @@ func Test_getIpAddressFromFile(t *testing.T) {
 	defer tests.RemoveTempDir(tmpdir)
 
 	dhcpFile := filepath.Join(tmpdir, "dhcp")
-	if err := ioutil.WriteFile(dhcpFile, validLeases, 0644); err != nil {
+	if err := ioutil.WriteFile(dhcpFile, validLeases, 0o644); err != nil {
 		t.Fatalf("writefile: %v", err)
 	}
 
 	invalidFile := filepath.Join(tmpdir, "invalid")
-	if err := ioutil.WriteFile(invalidFile, []byte("foo"), 0644); err != nil {
+	if err := ioutil.WriteFile(invalidFile, []byte("foo"), 0o644); err != nil {
 		t.Fatalf("writefile: %v", err)
 	}
 

--- a/pkg/drivers/kic/oci/cli_runner.go
+++ b/pkg/drivers/kic/oci/cli_runner.go
@@ -100,7 +100,7 @@ func runCmd(cmd *exec.Cmd, warnSlow ...bool) (*RunResult, error) {
 
 	if warn { // convert exec.Command to with context
 		cmdWithCtx := exec.CommandContext(ctx, cmd.Args[0], cmd.Args[1:]...)
-		cmdWithCtx.Stdout = cmd.Stdout //copying the original command
+		cmdWithCtx.Stdout = cmd.Stdout // copying the original command
 		cmdWithCtx.Stderr = cmd.Stderr
 		cmd = cmdWithCtx
 	}

--- a/pkg/drivers/kic/oci/info.go
+++ b/pkg/drivers/kic/oci/info.go
@@ -34,8 +34,10 @@ type SysInfo struct {
 	StorageDriver string // the storage driver for the daemon  (for example overlay2)
 }
 
-var cachedSysInfo *SysInfo
-var cachedSysInfoErr *error
+var (
+	cachedSysInfo    *SysInfo
+	cachedSysInfoErr *error
+)
 
 // CachedDaemonInfo will run and return a docker/podman info only once per minikube run time. to avoid performance
 func CachedDaemonInfo(ociBin string) (SysInfo, error) {

--- a/pkg/drivers/kic/oci/info_test.go
+++ b/pkg/drivers/kic/oci/info_test.go
@@ -20,10 +20,12 @@ import (
 	"testing"
 )
 
-var daemonResponseMock string
-var daemonInfoGetterMock = func() (string, error) {
-	return daemonResponseMock, nil
-}
+var (
+	daemonResponseMock   string
+	daemonInfoGetterMock = func() (string, error) {
+		return daemonResponseMock, nil
+	}
+)
 
 func TestDockerSystemInfo(t *testing.T) {
 	testCases := []struct {
@@ -71,7 +73,8 @@ func TestDockerSystemInfo(t *testing.T) {
 			OS:            "linux",
 			Swarm:         false,
 			StorageDriver: "overlay2",
-		}, {
+		},
+		{
 			Name:   "podman_1.8_linux",
 			OciBin: "podman",
 			RawJSON: `{
@@ -178,8 +181,6 @@ func TestDockerSystemInfo(t *testing.T) {
 			if s.Swarm != tc.Swarm {
 				t.Errorf("Expected Swarm to be %t but got %t", tc.Swarm, s.Swarm)
 			}
-
 		})
-
 	}
 }

--- a/pkg/drivers/kic/oci/network.go
+++ b/pkg/drivers/kic/oci/network.go
@@ -117,7 +117,6 @@ func ForwardedPort(ociBin string, ociID string, contPort int) (int, error) {
 	o := strings.TrimSpace(rr.Stdout.String())
 	o = strings.Trim(o, "'")
 	p, err := strconv.Atoi(o)
-
 	if err != nil {
 		return p, errors.Wrapf(err, "convert host-port %q to number", p)
 	}

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -17,12 +17,16 @@ limitations under the License.
 package oci
 
 import (
-	"context"
-	"os"
-	"time"
-
 	"bufio"
 	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/docker/machine/libmachine/state"
 	"github.com/golang/glog"
@@ -30,12 +34,6 @@ import (
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/util/retry"
-
-	"fmt"
-	"os/exec"
-	"runtime"
-	"strconv"
-	"strings"
 )
 
 // DeleteContainersByLabel deletes all containers that have a specific label

--- a/pkg/drivers/kic/oci/volumes.go
+++ b/pkg/drivers/kic/oci/volumes.go
@@ -35,7 +35,6 @@ func DeleteAllVolumesByLabel(ociBin string, label string, warnSlow ...bool) []er
 	glog.Infof("trying to delete all %s volumes with label %s", ociBin, label)
 
 	vs, err := allVolumesByLabel(ociBin, label)
-
 	if err != nil {
 		return []error{fmt.Errorf("listing volumes by label %q: %v", label, err)}
 	}

--- a/pkg/drivers/kvm/gpu.go
+++ b/pkg/drivers/kvm/gpu.go
@@ -30,8 +30,10 @@ import (
 	"github.com/docker/machine/libmachine/log"
 )
 
-var sysFsPCIDevicesPath = "/sys/bus/pci/devices/"
-var sysKernelIOMMUGroupsPath = "/sys/kernel/iommu_groups/"
+var (
+	sysFsPCIDevicesPath      = "/sys/bus/pci/devices/"
+	sysKernelIOMMUGroupsPath = "/sys/kernel/iommu_groups/"
+)
 
 const nvidiaVendorID = "0x10de"
 
@@ -103,7 +105,6 @@ func getDevicesXML() (string, error) {
 // - host doesn't support pci passthrough (IOMMU).
 // - there are no passthorughable NVIDIA devices on the host.
 func getPassthroughableNVIDIADevices() ([]string, error) {
-
 	// Make sure the host supports IOMMU
 	iommuGroups, err := ioutil.ReadDir(sysKernelIOMMUGroupsPath)
 	if err != nil {

--- a/pkg/drivers/kvm/kvm.go
+++ b/pkg/drivers/kvm/kvm.go
@@ -323,7 +323,7 @@ func (d *Driver) Create() (err error) {
 	store := d.ResolveStorePath(".")
 	log.Infof("Setting up store path in %s ...", store)
 	// 0755 because it must be accessible by libvirt/qemu across a variety of configs
-	if err := os.MkdirAll(store, 0755); err != nil {
+	if err := os.MkdirAll(store, 0o755); err != nil {
 		return errors.Wrap(err, "creating store")
 	}
 
@@ -365,9 +365,9 @@ func ensureDirPermissions(store string) error {
 			continue
 		}
 		mode := s.Mode()
-		if mode&0011 != 1 {
+		if mode&0o011 != 1 {
 			log.Infof("Setting executable bit set on %s (perms=%s)", dir, mode)
-			mode |= 0011
+			mode |= 0o011
 			if err := os.Chmod(dir, mode); err != nil {
 				return err
 			}

--- a/pkg/generate/docs.go
+++ b/pkg/generate/docs.go
@@ -134,5 +134,5 @@ func saveDocForCommand(command *cobra.Command, contents []byte, path string) err
 	if err := os.Remove(fp); err != nil {
 		glog.Warningf("error removing %s", fp)
 	}
-	return ioutil.WriteFile(fp, contents, 0644)
+	return ioutil.WriteFile(fp, contents, 0o644)
 }

--- a/pkg/gvisor/enable.go
+++ b/pkg/gvisor/enable.go
@@ -81,13 +81,13 @@ func Enable() error {
 func makeGvisorDirs() error {
 	// Make /run/containerd/runsc to hold logs
 	fp := filepath.Join(nodeDir, "run/containerd/runsc")
-	if err := os.MkdirAll(fp, 0755); err != nil {
+	if err := os.MkdirAll(fp, 0o755); err != nil {
 		return errors.Wrap(err, "creating runsc dir")
 	}
 
 	// Make /tmp/runsc to also hold logs
 	fp = filepath.Join(nodeDir, "tmp/runsc")
-	if err := os.MkdirAll(fp, 0755); err != nil {
+	if err := os.MkdirAll(fp, 0o755); err != nil {
 		return errors.Wrap(err, "creating runsc logs dir")
 	}
 
@@ -143,7 +143,7 @@ func downloadFileToDest(url, dest string) error {
 	if _, err := io.Copy(fi, resp.Body); err != nil {
 		return errors.Wrap(err, "copying binary")
 	}
-	if err := fi.Chmod(0777); err != nil {
+	if err := fi.Chmod(0o777); err != nil {
 		return errors.Wrap(err, "fixing perms")
 	}
 	return nil

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -444,7 +444,6 @@ var Addons = map[string]*Addon{
 
 // GenerateTemplateData generates template data for template assets
 func GenerateTemplateData(cfg config.KubernetesConfig) interface{} {
-
 	a := runtime.GOARCH
 	// Some legacy docker images still need the -arch suffix
 	// for  less common architectures blank suffix for amd64

--- a/pkg/minikube/assets/vm_assets.go
+++ b/pkg/minikube/assets/vm_assets.go
@@ -264,7 +264,6 @@ func (m *BinAsset) IsTemplate() bool {
 func (m *BinAsset) Evaluate(data interface{}) (*MemoryAsset, error) {
 	if !m.IsTemplate() {
 		return nil, errors.Errorf("the asset %s is not a template", m.SourcePath)
-
 	}
 
 	var buf bytes.Buffer

--- a/pkg/minikube/bootstrapper/bsutil/featuregates_test.go
+++ b/pkg/minikube/bootstrapper/bsutil/featuregates_test.go
@@ -50,7 +50,6 @@ func TestParseFeatureArgs(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			kubeadm, component, err := parseFeatureArgs(test.featureGates)
-
 			if err != nil {
 				t.Fatalf("Error parsing feature args: %v", err)
 			}
@@ -67,7 +66,6 @@ func TestParseFeatureArgs(t *testing.T) {
 }
 
 func TestSupport(t *testing.T) {
-
 	tests := []struct {
 		name     string
 		expected bool
@@ -90,5 +88,4 @@ func TestSupport(t *testing.T) {
 			t.Errorf("expected supportedFG(%s) to be %t ! ", tc.name, tc.expected)
 		}
 	}
-
 }

--- a/pkg/minikube/bootstrapper/bsutil/kubeadm.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubeadm.go
@@ -116,7 +116,7 @@ func GenerateKubeadmYAML(cc config.ClusterConfig, n config.Node, r cruntime.Mana
 		EtcdDataDir:       EtcdDataDir(),
 		EtcdExtraArgs:     etcdExtraArgs(k8s.ExtraOptions),
 		ClusterName:       cc.Name,
-		//kubeadm uses NodeName as the --hostname-override parameter, so this needs to be the name of the machine
+		// kubeadm uses NodeName as the --hostname-override parameter, so this needs to be the name of the machine
 		NodeName:            KubeNodeName(cc, n),
 		CRISocket:           r.SocketPath(),
 		ImageRepository:     k8s.ImageRepository,

--- a/pkg/minikube/bootstrapper/certs.go
+++ b/pkg/minikube/bootstrapper/certs.go
@@ -181,7 +181,6 @@ func generateSharedCACerts() (CACerts, error) {
 
 // generateProfileCerts generates profile certs for a profile
 func generateProfileCerts(k8s config.KubernetesConfig, n config.Node, ccs CACerts) ([]string, error) {
-
 	// Only generate these certs for the api server
 	if !n.ControlPlane {
 		return []string{}, nil

--- a/pkg/minikube/bootstrapper/certs_test.go
+++ b/pkg/minikube/bootstrapper/certs_test.go
@@ -38,7 +38,7 @@ func TestSetupCerts(t *testing.T) {
 		ServiceCIDR:   constants.DefaultServiceCIDR,
 	}
 
-	if err := os.Mkdir(filepath.Join(tempDir, "certs"), 0777); err != nil {
+	if err := os.Mkdir(filepath.Join(tempDir, "certs"), 0o777); err != nil {
 		t.Fatalf("error create certificate directory: %v", err)
 	}
 

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -18,19 +18,17 @@ package kubeadm
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"os/exec"
 	"path"
 	"runtime"
-	"sync"
-
-	"fmt"
-	"net"
-
-	// WARNING: Do not use path/filepath in this package unless you want bizarre Windows paths
-
 	"strconv"
 	"strings"
+	"sync"
 	"time"
+
+	// WARNING: Do not use path/filepath in this package unless you want bizarre Windows paths
 
 	"github.com/blang/semver"
 	"github.com/docker/machine/libmachine"
@@ -217,7 +215,6 @@ func (k *Bootstrapper) init(cfg config.ClusterConfig) error {
 
 	if driver.IsKIC(cfg.Driver) { // to bypass this error: /proc/sys/net/bridge/bridge-nf-call-iptables does not exist
 		ignore = append(ignore, "FileContent--proc-sys-net-bridge-bridge-nf-call-iptables")
-
 	}
 
 	if err := k.clearStaleConfigs(cfg); err != nil {
@@ -275,7 +272,6 @@ func (k *Bootstrapper) init(cfg config.ClusterConfig) error {
 
 // applyCNI applies CNI to a cluster. Needs to be done every time a VM is powered up.
 func (k *Bootstrapper) applyCNI(cfg config.ClusterConfig) error {
-
 	cnm, err := cni.New(cfg)
 	if err != nil {
 		return errors.Wrap(err, "cni config")
@@ -302,7 +298,6 @@ func (k *Bootstrapper) applyCNI(cfg config.ClusterConfig) error {
 
 // unpause unpauses any Kubernetes backplane components
 func (k *Bootstrapper) unpause(cfg config.ClusterConfig) error {
-
 	cr, err := cruntime.New(cruntime.Config{Type: cfg.KubernetesConfig.ContainerRuntime, Runner: k.c})
 	if err != nil {
 		return err
@@ -747,8 +742,10 @@ func (k *Bootstrapper) UpdateCluster(cfg config.ClusterConfig) error {
 		return errors.Wrap(err, "kubeadm images")
 	}
 
-	r, err := cruntime.New(cruntime.Config{Type: cfg.KubernetesConfig.ContainerRuntime,
-		Runner: k.c, Socket: cfg.KubernetesConfig.CRISocket})
+	r, err := cruntime.New(cruntime.Config{
+		Type:   cfg.KubernetesConfig.ContainerRuntime,
+		Runner: k.c, Socket: cfg.KubernetesConfig.CRISocket,
+	})
 	if err != nil {
 		return errors.Wrap(err, "runtime")
 	}

--- a/pkg/minikube/cluster/mount_test.go
+++ b/pkg/minikube/cluster/mount_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestMntCmd(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name   string
 		source string
 		target string
@@ -35,21 +35,21 @@ func TestMntCmd(t *testing.T) {
 			name:   "simple",
 			source: "src",
 			target: "target",
-			cfg:    &MountConfig{Type: "9p", Mode: os.FileMode(0700)},
+			cfg:    &MountConfig{Type: "9p", Mode: os.FileMode(0o700)},
 			want:   "sudo mount -t 9p -o dfltgid=0,dfltuid=0,trans=tcp src target",
 		},
 		{
 			name:   "named uid",
 			source: "src",
 			target: "target",
-			cfg:    &MountConfig{Type: "9p", Mode: os.FileMode(0700), UID: "docker", GID: "docker"},
+			cfg:    &MountConfig{Type: "9p", Mode: os.FileMode(0o700), UID: "docker", GID: "docker"},
 			want:   "sudo mount -t 9p -o dfltgid=$(grep ^docker: /etc/group | cut -d: -f3),dfltuid=$(id -u docker),trans=tcp src target",
 		},
 		{
 			name:   "everything",
 			source: "10.0.0.1",
 			target: "/target",
-			cfg: &MountConfig{Type: "9p", Mode: os.FileMode(0777), UID: "82", GID: "72", Version: "9p2000.u", Options: map[string]string{
+			cfg: &MountConfig{Type: "9p", Mode: os.FileMode(0o777), UID: "82", GID: "72", Version: "9p2000.u", Options: map[string]string{
 				"noextend": "",
 				"cache":    "fscache",
 			}},
@@ -59,7 +59,7 @@ func TestMntCmd(t *testing.T) {
 			name:   "version-conflict",
 			source: "src",
 			target: "tgt",
-			cfg: &MountConfig{Type: "9p", Mode: os.FileMode(0700), Version: "9p2000.u", Options: map[string]string{
+			cfg: &MountConfig{Type: "9p", Mode: os.FileMode(0o700), Version: "9p2000.u", Options: map[string]string{
 				"version": "9p2000.L",
 			}},
 			want: "sudo mount -t 9p -o dfltgid=0,dfltuid=0,trans=tcp,version=9p2000.L src tgt",

--- a/pkg/minikube/command/kic_runner.go
+++ b/pkg/minikube/command/kic_runner.go
@@ -128,7 +128,6 @@ func (k *kicRunner) RunCmd(cmd *exec.Cmd) (*RunResult, error) {
 		rr.ExitCode = exitError.ExitCode()
 	}
 	return rr, fmt.Errorf("%s: %v\nstdout:\n%s\nstderr:\n%s", rr.Command(), err, rr.Stdout.String(), rr.Stderr.String())
-
 }
 
 // Copy copies a file and its permissions

--- a/pkg/minikube/command/ssh_runner.go
+++ b/pkg/minikube/command/ssh_runner.go
@@ -36,9 +36,7 @@ import (
 	"k8s.io/minikube/pkg/util/retry"
 )
 
-var (
-	layout = "2006-01-02 15:04:05.999999999 -0700"
-)
+var layout = "2006-01-02 15:04:05.999999999 -0700"
 
 // SSHRunner runs commands through SSH.
 //

--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -199,7 +199,7 @@ func (c *simpleConfigLoader) WriteConfigToFile(profileName string, cc *ClusterCo
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(path, contents, 0644)
+	return ioutil.WriteFile(path, contents, 0o644)
 }
 
 // MultiNode returns true if the cluster has multiple nodes or if the request is asking for multinode

--- a/pkg/minikube/config/config_test.go
+++ b/pkg/minikube/config/config_test.go
@@ -81,7 +81,7 @@ func Test_get(t *testing.T) {
 		t.Fatalf("Error decoding config : %v", err)
 	}
 
-	var testcases = []struct {
+	testcases := []struct {
 		key string
 		val string
 		err bool

--- a/pkg/minikube/config/profile.go
+++ b/pkg/minikube/config/profile.go
@@ -89,7 +89,7 @@ func ProfileNameValid(name string) bool {
 	// RestrictedNamePattern describes the characters allowed to represent a profile's name
 	const RestrictedNamePattern = `(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])`
 
-	var validName = regexp.MustCompile(`^` + RestrictedNamePattern + `$`)
+	validName := regexp.MustCompile(`^` + RestrictedNamePattern + `$`)
 
 	return validName.MatchString(name)
 }
@@ -148,13 +148,13 @@ func SaveProfile(name string, cfg *ClusterConfig, miniHome ...string) error {
 	}
 	path := profileFilePath(name, miniHome...)
 	glog.Infof("Saving config to %s ...", path)
-	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
 
 	// If no config file exists, don't worry about swapping paths
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		if err := lock.WriteFile(path, data, 0600); err != nil {
+		if err := lock.WriteFile(path, data, 0o600); err != nil {
 			return err
 		}
 		return nil
@@ -166,7 +166,7 @@ func SaveProfile(name string, cfg *ClusterConfig, miniHome ...string) error {
 	}
 	defer os.Remove(tf.Name())
 
-	if err = ioutil.WriteFile(tf.Name(), data, 0600); err != nil {
+	if err = ioutil.WriteFile(tf.Name(), data, 0o600); err != nil {
 		return err
 	}
 
@@ -198,7 +198,6 @@ func DeleteProfile(profile string, miniHome ...string) error {
 // invalidPs are the profiles that have a directory or config file but not usable
 // invalidPs would be suggested to be deleted
 func ListProfiles(miniHome ...string) (validPs []*Profile, inValidPs []*Profile, err error) {
-
 	// try to get profiles list based on left over evidences such as directory
 	pDirs, err := profileDirs(miniHome...)
 	if err != nil {

--- a/pkg/minikube/config/profile_test.go
+++ b/pkg/minikube/config/profile_test.go
@@ -28,7 +28,7 @@ func TestListProfiles(t *testing.T) {
 		t.Errorf("error getting dir path for ./testdata/.minikube : %v", err)
 	}
 	// test cases for valid profiles
-	var testCasesValidProfs = []struct {
+	testCasesValidProfs := []struct {
 		index      int
 		expectName string
 		vmDriver   string
@@ -38,7 +38,7 @@ func TestListProfiles(t *testing.T) {
 	}
 
 	// test cases for invalid profiles
-	var testCasesInValidProfs = []struct {
+	testCasesInValidProfs := []struct {
 		index      int
 		expectName string
 		vmDriver   string
@@ -73,7 +73,7 @@ func TestListProfiles(t *testing.T) {
 }
 
 func TestProfileNameValid(t *testing.T) {
-	var testCases = map[string]bool{
+	testCases := map[string]bool{
 		"profile":             true,
 		"pro-file":            true,
 		"profile1":            true,
@@ -108,7 +108,7 @@ func TestProfileNameValid(t *testing.T) {
 }
 
 func TestProfileNameInReservedKeywords(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		name     string
 		expected bool
 	}{
@@ -139,7 +139,7 @@ func TestProfileExists(t *testing.T) {
 		t.Errorf("error getting dir path for ./testdata/.minikube : %v", err)
 	}
 
-	var testCases = []struct {
+	testCases := []struct {
 		name     string
 		expected bool
 	}{
@@ -157,7 +157,6 @@ func TestProfileExists(t *testing.T) {
 		}
 
 	}
-
 }
 
 func TestCreateEmptyProfile(t *testing.T) {
@@ -166,7 +165,7 @@ func TestCreateEmptyProfile(t *testing.T) {
 		t.Errorf("error getting dir path for ./testdata/.minikube : %v", err)
 	}
 
-	var testCases = []struct {
+	testCases := []struct {
 		name      string
 		expectErr bool
 	}{
@@ -188,7 +187,6 @@ func TestCreateEmptyProfile(t *testing.T) {
 		}()
 
 	}
-
 }
 
 func TestCreateProfile(t *testing.T) {
@@ -197,17 +195,20 @@ func TestCreateProfile(t *testing.T) {
 		t.Errorf("error getting dir path for ./testdata/.minikube : %v", err)
 	}
 
-	var testCases = []struct {
+	testCases := []struct {
 		name      string
 		cfg       *ClusterConfig
 		expectErr bool
 	}{
 		{"p_empty_config", &ClusterConfig{}, false},
 		{"p_partial_config", &ClusterConfig{KubernetesConfig: KubernetesConfig{
-			ShouldLoadCachedImages: false}}, false},
+			ShouldLoadCachedImages: false,
+		}}, false},
 		{"p_partial_config2", &ClusterConfig{
 			KeepContext: false, KubernetesConfig: KubernetesConfig{
-				ShouldLoadCachedImages: false}}, false},
+				ShouldLoadCachedImages: false,
+			},
+		}, false},
 	}
 	for _, tc := range testCases {
 		n := tc.name // capturing  loop variable
@@ -224,7 +225,6 @@ func TestCreateProfile(t *testing.T) {
 			}
 		}()
 	}
-
 }
 
 func TestDeleteProfile(t *testing.T) {
@@ -238,7 +238,7 @@ func TestDeleteProfile(t *testing.T) {
 		t.Errorf("error setting up TestDeleteProfile %v", err)
 	}
 
-	var testCases = []struct {
+	testCases := []struct {
 		name      string
 		expectErr bool
 	}{
@@ -251,7 +251,6 @@ func TestDeleteProfile(t *testing.T) {
 			t.Errorf("expected CreateEmptyProfile not to error but got err=%v", gotErr)
 		}
 	}
-
 }
 
 func TestGetPrimaryControlPlane(t *testing.T) {
@@ -260,7 +259,7 @@ func TestGetPrimaryControlPlane(t *testing.T) {
 		t.Errorf("error getting dir path for ./testdata/.minikube : %v", err)
 	}
 
-	var tests = []struct {
+	tests := []struct {
 		description  string
 		profile      string
 		expectedIP   string
@@ -295,5 +294,4 @@ func TestGetPrimaryControlPlane(t *testing.T) {
 		}
 
 	}
-
 }

--- a/pkg/minikube/cruntime/containerd_test.go
+++ b/pkg/minikube/cruntime/containerd_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestAddRepoTagToImageName(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		imgName string
 		want    string
 	}{

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -175,7 +175,6 @@ func ContainerStatusCommand() string {
 
 // disableOthers disables all other runtimes except for me.
 func disableOthers(me Manager, cr CommandRunner) error {
-
 	// valid values returned by manager.Name()
 	runtimes := []string{"containerd", "crio", "docker"}
 	for _, name := range runtimes {

--- a/pkg/minikube/cruntime/cruntime_test.go
+++ b/pkg/minikube/cruntime/cruntime_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func TestName(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		runtime string
 		want    string
 	}{
@@ -57,7 +57,7 @@ func TestName(t *testing.T) {
 }
 
 func TestImageExists(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		runtime string
 		name    string
 		sha     string
@@ -84,7 +84,7 @@ func TestImageExists(t *testing.T) {
 }
 
 func TestCGroupDriver(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		runtime string
 		want    string
 	}{
@@ -111,7 +111,7 @@ func TestCGroupDriver(t *testing.T) {
 }
 
 func TestKubeletOptions(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		runtime string
 		want    map[string]string
 	}{
@@ -444,7 +444,6 @@ func (f *FakeRunner) systemctl(args []string, root bool) (string, error) { // no
 		if arg == "service" {
 			svcs = args[i+1:]
 		}
-
 	}
 
 	for _, svc := range svcs {
@@ -484,7 +483,7 @@ func (f *FakeRunner) systemctl(args []string, root bool) (string, error) { // no
 				out += "[Unit]\n"
 				out += "Description=Docker Application Container Engine\n"
 				out += "Documentation=https://docs.docker.com\n"
-				//out += "BindsTo=containerd.service\n"
+				// out += "BindsTo=containerd.service\n"
 				return out, nil
 			}
 			return out, fmt.Errorf("%s cat unimplemented", svc)
@@ -503,7 +502,7 @@ func (f *FakeRunner) which(args []string, root bool) (string, error) { // nolint
 }
 
 func TestVersion(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		runtime string
 		want    string
 	}{
@@ -545,7 +544,7 @@ var allServices = map[string]serviceState{
 }
 
 func TestDisable(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		runtime string
 		want    []string
 	}{
@@ -575,39 +574,47 @@ func TestDisable(t *testing.T) {
 }
 
 func TestEnable(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		runtime  string
 		services map[string]serviceState
 		want     map[string]serviceState
 	}{
-		{"docker", defaultServices,
+		{
+			"docker", defaultServices,
 			map[string]serviceState{
 				"docker":        SvcRunning,
 				"containerd":    SvcExited,
 				"crio":          SvcExited,
 				"crio-shutdown": SvcExited,
-			}},
-		{"docker", allServices,
+			},
+		},
+		{
+			"docker", allServices,
 			map[string]serviceState{
 				"docker":        SvcRestarted,
 				"containerd":    SvcExited,
 				"crio":          SvcExited,
 				"crio-shutdown": SvcExited,
-			}},
-		{"containerd", defaultServices,
+			},
+		},
+		{
+			"containerd", defaultServices,
 			map[string]serviceState{
 				"docker":        SvcExited,
 				"containerd":    SvcRestarted,
 				"crio":          SvcExited,
 				"crio-shutdown": SvcExited,
-			}},
-		{"crio", defaultServices,
+			},
+		},
+		{
+			"crio", defaultServices,
 			map[string]serviceState{
 				"docker":        SvcExited,
 				"containerd":    SvcExited,
 				"crio":          SvcRunning,
 				"crio-shutdown": SvcExited,
-			}},
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.runtime, func(t *testing.T) {
@@ -631,7 +638,7 @@ func TestEnable(t *testing.T) {
 }
 
 func TestContainerFunctions(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		runtime string
 	}{
 		{"docker"},

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -49,6 +49,7 @@ func NewErrISOFeature(missing string) *ErrISOFeature {
 		missing: missing,
 	}
 }
+
 func (e *ErrISOFeature) Error() string {
 	return e.missing
 }
@@ -154,7 +155,6 @@ func (r *Docker) LoadImage(path string) error {
 		return errors.Wrap(err, "loadimage docker.")
 	}
 	return nil
-
 }
 
 // CGroupDriver returns cgroup driver ("cgroupfs" or "systemd")

--- a/pkg/minikube/download/binary.go
+++ b/pkg/minikube/download/binary.go
@@ -62,7 +62,7 @@ func Binary(binary, version, osName, archName string) (string, error) {
 	}
 
 	if osName == runtime.GOOS && archName == runtime.GOARCH {
-		if err = os.Chmod(targetFilepath, 0755); err != nil {
+		if err = os.Chmod(targetFilepath, 0o755); err != nil {
 			return "", errors.Wrapf(err, "chmod +x %s", targetFilepath)
 		}
 	}

--- a/pkg/minikube/download/download.go
+++ b/pkg/minikube/download/download.go
@@ -29,9 +29,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/out"
 )
 
-var (
-	mockMode = false
-)
+var mockMode = false
 
 // EnableMock allows tests to selectively enable if downloads are mocked
 func EnableMock(b bool) {
@@ -58,7 +56,7 @@ func download(src string, dst string) error {
 		},
 	}
 
-	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 		return errors.Wrap(err, "mkdir")
 	}
 

--- a/pkg/minikube/download/driver.go
+++ b/pkg/minikube/download/driver.go
@@ -38,5 +38,5 @@ func Driver(name string, destination string, v semver.Version) error {
 	}
 
 	// Give downloaded drivers a baseline decent file permission
-	return os.Chmod(destination, 0755)
+	return os.Chmod(destination, 0o755)
 }

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -86,7 +86,6 @@ func remoteTarballURL(k8sVersion, containerRuntime string) string {
 
 // PreloadExists returns true if there is a preloaded tarball that can be used
 func PreloadExists(k8sVersion, containerRuntime string, forcePreload ...bool) bool {
-
 	// TODO (#8166): Get rid of the need for this and viper at all
 	force := false
 	if len(forcePreload) > 0 {
@@ -168,7 +167,7 @@ func saveChecksumFile(k8sVersion, containerRuntime string) error {
 		return errors.Wrap(err, "getting storage object")
 	}
 	checksum := attrs.MD5
-	return ioutil.WriteFile(PreloadChecksumPath(k8sVersion, containerRuntime), checksum, 0644)
+	return ioutil.WriteFile(PreloadChecksumPath(k8sVersion, containerRuntime), checksum, 0o644)
 }
 
 // verifyChecksum returns true if the checksum of the local binary matches

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -54,10 +54,8 @@ const (
 	Parallels = "parallels"
 )
 
-var (
-	// systemdResolvConf is path to systemd's DNS configuration. https://github.com/kubernetes/minikube/issues/3511
-	systemdResolvConf = "/run/systemd/resolve/resolv.conf"
-)
+// systemdResolvConf is path to systemd's DNS configuration. https://github.com/kubernetes/minikube/issues/3511
+var systemdResolvConf = "/run/systemd/resolve/resolv.conf"
 
 // SupportedDrivers returns a list of supported drivers
 func SupportedDrivers() []string {
@@ -286,7 +284,6 @@ func Status(name string) registry.DriverState {
 func SetLibvirtURI(v string) {
 	glog.Infof("Setting default libvirt URI to %s", v)
 	os.Setenv("LIBVIRT_DEFAULT_URI", v)
-
 }
 
 // MachineName returns the name of the machine, as seen by the hypervisor given the cluster and node names

--- a/pkg/minikube/driver/driver_test.go
+++ b/pkg/minikube/driver/driver_test.go
@@ -106,7 +106,6 @@ func TestFlagDefaults(t *testing.T) {
 }
 
 func TestSuggest(t *testing.T) {
-
 	tests := []struct {
 		def     registry.DriverDef
 		choices []string
@@ -197,7 +196,6 @@ func TestSuggest(t *testing.T) {
 			if diff := cmp.Diff(gotRejects, tc.rejects); diff != "" {
 				t.Errorf("rejects mismatch (-want +got):\n%s", diff)
 			}
-
 		})
 	}
 }

--- a/pkg/minikube/extract/extract.go
+++ b/pkg/minikube/extract/extract.go
@@ -121,7 +121,6 @@ func setParentFunc(e *state, f string) {
 // TranslatableStrings finds all strings to that need to be translated in paths and prints them out to all json files in output
 func TranslatableStrings(paths []string, functions []string, output string) error {
 	e, err := newExtractor(functions)
-
 	if err != nil {
 		return errors.Wrap(err, "Initializing")
 	}
@@ -138,7 +137,6 @@ func TranslatableStrings(paths []string, functions []string, output string) erro
 				}
 				return nil
 			})
-
 			if err != nil {
 				return errors.Wrap(err, "Extracting strings")
 			}
@@ -283,7 +281,6 @@ func checkArguments(s *ast.CallExpr, e *state) {
 	if !matched {
 		addParentFuncToList(e)
 	}
-
 }
 
 // checkIdentForStringValue takes a identifier and sees if it's a variable assigned to a string
@@ -300,7 +297,6 @@ func checkIdentForStringValue(i *ast.Ident) string {
 		if rhs, ok := as.Rhs[0].(*ast.BasicLit); ok {
 			s = rhs.Value
 		}
-
 	}
 
 	// This Identifier is part of the const or var declaration
@@ -320,7 +316,6 @@ func checkIdentForStringValue(i *ast.Ident) string {
 	}
 
 	return checkString(s)
-
 }
 
 // checkString checks if a string is meant to be translated
@@ -420,7 +415,7 @@ func checkBinaryExpression(b *ast.BinaryExpr) string {
 		}
 	}
 
-	//Check the right side
+	// Check the right side
 	if l, ok := b.Y.(*ast.BasicLit); ok {
 		if x := checkString(l.Value); x != "" {
 			s += x
@@ -504,7 +499,6 @@ func writeStringsToFiles(e *state, output string) error {
 		fmt.Printf(" (%d translated, %d untranslated)\n", t, u)
 		return nil
 	})
-
 	if err != nil {
 		return err
 	}
@@ -514,7 +508,7 @@ func writeStringsToFiles(e *state, output string) error {
 		return errors.Wrap(err, "marshalling translations")
 	}
 	path := filepath.Join(output, "strings.txt")
-	err = lock.WriteFile(path, c, 0644)
+	err = lock.WriteFile(path, c, 0o644)
 	if err != nil {
 		return errors.Wrap(err, "writing translation file")
 	}

--- a/pkg/minikube/extract/extract_test.go
+++ b/pkg/minikube/extract/extract_test.go
@@ -36,7 +36,7 @@ func TestExtract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Creating temp dir: %v", err)
 	}
-	defer func() { //clean up tempdir
+	defer func() { // clean up tempdir
 		err := os.RemoveAll(tempdir)
 		if err != nil {
 			t.Errorf("failed to clean up temp folder  %q", tempdir)
@@ -49,7 +49,7 @@ func TestExtract(t *testing.T) {
 	}
 
 	tempfile := filepath.Join(tempdir, "tmpdata.json")
-	err = ioutil.WriteFile(tempfile, src, 0666)
+	err = ioutil.WriteFile(tempfile, src, 0o666)
 	if err != nil {
 		t.Fatalf("Writing temp json file: %v", err)
 	}
@@ -82,5 +82,4 @@ func TestExtract(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Fatalf("Translation JSON not equal: expected %v, got %v", expected, got)
 	}
-
 }

--- a/pkg/minikube/extract/testdata/sample_file.go
+++ b/pkg/minikube/extract/testdata/sample_file.go
@@ -38,7 +38,6 @@ func DoSomeStuff() {
 }
 
 func DoSomeOtherStuff(choice bool, i int, s string) {
-
 	// Let's try an if statement
 	if choice {
 		PrintToScreen("This was a choice: %s", s)
@@ -51,7 +50,6 @@ func DoSomeOtherStuff(choice bool, i int, s string) {
 			i = i + 1
 		}
 	}
-
 }
 
 func PrintToScreenNoInterface(s string) {

--- a/pkg/minikube/image/cache.go
+++ b/pkg/minikube/image/cache.go
@@ -101,7 +101,7 @@ func saveToTarFile(iname, rawDest string) error {
 		return nil
 	}
 
-	if err := os.MkdirAll(filepath.Dir(dst), 0777); err != nil {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o777); err != nil {
 		return errors.Wrapf(err, "making cache image directory: %s", dst)
 	}
 

--- a/pkg/minikube/image/image.go
+++ b/pkg/minikube/image/image.go
@@ -120,7 +120,6 @@ func LoadFromTarball(binary, img string) error {
 		_, err = daemon.Write(tag, i)
 		return err
 	}
-
 }
 
 // Tag returns just the image with the tag

--- a/pkg/minikube/kubeconfig/kubeconfig.go
+++ b/pkg/minikube/kubeconfig/kubeconfig.go
@@ -172,13 +172,13 @@ func writeToFile(config runtime.Object, configPath ...string) error {
 	// create parent dir if doesn't exist
 	dir := filepath.Dir(fPath)
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		if err = os.MkdirAll(dir, 0755); err != nil {
+		if err = os.MkdirAll(dir, 0o755); err != nil {
 			return errors.Wrapf(err, "Error creating directory: %s", dir)
 		}
 	}
 
 	// write with restricted permissions
-	if err := lock.WriteFile(fPath, data, 0600); err != nil {
+	if err := lock.WriteFile(fPath, data, 0o600); err != nil {
 		return errors.Wrapf(err, "Error writing file %s", fPath)
 	}
 

--- a/pkg/minikube/kubeconfig/kubeconfig_test.go
+++ b/pkg/minikube/kubeconfig/kubeconfig_test.go
@@ -193,7 +193,7 @@ func TestUpdate(t *testing.T) {
 		KeepContext:          false,
 	}
 
-	var tests = []struct {
+	tests := []struct {
 		description string
 		cfg         *Settings
 		existingCfg []byte
@@ -233,7 +233,7 @@ func TestUpdate(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Error making temp directory %v", err)
 			}
-			defer func() { //clean up tempdir
+			defer func() { // clean up tempdir
 				err := os.RemoveAll(tmpDir)
 				if err != nil {
 					t.Errorf("failed to clean up temp folder  %q", tmpDir)
@@ -242,7 +242,7 @@ func TestUpdate(t *testing.T) {
 
 			test.cfg.SetPath(filepath.Join(tmpDir, "kubeconfig"))
 			if len(test.existingCfg) != 0 {
-				if err := ioutil.WriteFile(test.cfg.filePath(), test.existingCfg, 0600); err != nil {
+				if err := ioutil.WriteFile(test.cfg.filePath(), test.existingCfg, 0o600); err != nil {
 					t.Fatalf("WriteFile: %v", err)
 				}
 			}
@@ -266,13 +266,11 @@ func TestUpdate(t *testing.T) {
 
 			os.RemoveAll(tmpDir)
 		})
-
 	}
 }
 
 func TestVerifyEndpoint(t *testing.T) {
-
-	var tests = []struct {
+	tests := []struct {
 		description string
 		hostname    string
 		port        int
@@ -343,8 +341,7 @@ func TestVerifyEndpoint(t *testing.T) {
 }
 
 func TestUpdateIP(t *testing.T) {
-
-	var tests = []struct {
+	tests := []struct {
 		description string
 		hostname    string
 		port        int
@@ -493,8 +490,7 @@ func TestNewConfig(t *testing.T) {
 }
 
 func Test_Endpoint(t *testing.T) {
-
-	var tests = []struct {
+	tests := []struct {
 		description string
 		cfg         []byte
 		hostname    string
@@ -704,7 +700,7 @@ func contextEquals(aContext, bContext *api.Context) bool {
 }
 
 func TestGetKubeConfigPath(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		input string
 		want  string
 	}{

--- a/pkg/minikube/localpath/localpath_test.go
+++ b/pkg/minikube/localpath/localpath_test.go
@@ -33,7 +33,7 @@ func TestReplaceWinDriveLetterToVolumeName(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error make tmp directory: %v", err)
 	}
-	defer func() { //clean up tempdir
+	defer func() { // clean up tempdir
 		err := os.RemoveAll(path)
 		if err != nil {
 			t.Errorf("failed to clean up temp folder  %q", path)
@@ -73,7 +73,7 @@ func TestHasWindowsDriveLetter(t *testing.T) {
 }
 
 func TestMiniPath(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		env, basePath string
 	}{
 		{"/tmp/.minikube", "/tmp/"},
@@ -100,7 +100,7 @@ func TestMiniPath(t *testing.T) {
 }
 
 func TestMachinePath(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		miniHome []string
 		contains string
 	}{
@@ -121,7 +121,7 @@ func TestMachinePath(t *testing.T) {
 type propertyFnWithArg func(string) string
 
 func TestPropertyWithNameArg(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		propertyFunc propertyFnWithArg
 		name         string
 	}{
@@ -140,14 +140,13 @@ func TestPropertyWithNameArg(t *testing.T) {
 				t.Errorf("Property %s(%v) doesn't contain passed name %v", tc.name, tc.propertyFunc, mockedName)
 			}
 		})
-
 	}
 }
 
 type propertyFnWithoutArg func() string
 
 func TestPropertyWithoutNameArg(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		propertyFunc propertyFnWithoutArg
 		name         string
 	}{

--- a/pkg/minikube/logs/logs_test.go
+++ b/pkg/minikube/logs/logs_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestIsProblem(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name  string
 		want  bool
 		input string

--- a/pkg/minikube/machine/advice.go
+++ b/pkg/minikube/machine/advice.go
@@ -60,5 +60,4 @@ func MaybeDisplayAdvice(err error, driver string) {
 		minikube start --driver={{.driver_name}}`, out.V{"driver_name": driver})
 		// TODO #8348: maybe advice user if to set the --force-systemd https://github.com/kubernetes/minikube/issues/8348
 	}
-
 }

--- a/pkg/minikube/machine/cache_binaries_test.go
+++ b/pkg/minikube/machine/cache_binaries_test.go
@@ -41,7 +41,7 @@ func newFakeCommandRunnerCopyFail() command.Runner {
 }
 
 func TestCopyBinary(t *testing.T) {
-	var tc = []struct {
+	tc := []struct {
 		lastUpdateCheckFilePath string
 		src, dst, desc          string
 		err                     bool
@@ -93,14 +93,14 @@ func TestCacheBinariesForBootstrapper(t *testing.T) {
 		t.Fatalf("error during creating tmp dir: %v", err)
 	}
 
-	defer func() { //clean up tempdir
+	defer func() { // clean up tempdir
 		err := os.RemoveAll(minikubeHome)
 		if err != nil {
 			t.Errorf("failed to clean up temp folder  %q", minikubeHome)
 		}
 	}()
 
-	var tc = []struct {
+	tc := []struct {
 		version, clusterBootstrapper string
 		minikubeHome                 string
 		err                          bool

--- a/pkg/minikube/machine/client.go
+++ b/pkg/minikube/machine/client.go
@@ -220,7 +220,6 @@ func (api *LocalClient) Create(h *host.Host) error {
 	}
 
 	for _, step := range steps {
-
 		if err := step.f(); err != nil {
 			return errors.Wrap(err, step.name)
 		}

--- a/pkg/minikube/machine/client_test.go
+++ b/pkg/minikube/machine/client_test.go
@@ -67,7 +67,7 @@ func TestLocalClientNewHost(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var tests = []struct {
+	tests := []struct {
 		description string
 		driver      string
 		rawDriver   []byte

--- a/pkg/minikube/machine/cluster_test.go
+++ b/pkg/minikube/machine/cluster_test.go
@@ -234,7 +234,6 @@ func TestStartStoppedHost(t *testing.T) {
 	if !api.SaveCalled {
 		t.Fatalf("Machine must be saved after starting.")
 	}
-
 }
 
 func TestStartHost(t *testing.T) {
@@ -298,7 +297,6 @@ func TestStartHostConfig(t *testing.T) {
 			t.Fatal("Docker flags were not set!")
 		}
 	}
-
 }
 
 func TestStopHostError(t *testing.T) {

--- a/pkg/minikube/machine/filesync_test.go
+++ b/pkg/minikube/machine/filesync_test.go
@@ -85,7 +85,7 @@ func TestAssetsFromDir(t *testing.T) {
 			vmPath: "/",
 		},
 	}
-	var testDirs = make([]string, 0)
+	testDirs := make([]string, 0)
 	defer func() {
 		for _, testDir := range testDirs {
 			err := os.RemoveAll(testDir)
@@ -106,7 +106,7 @@ func TestAssetsFromDir(t *testing.T) {
 			for _, fileDef := range test.files {
 				err := func() error {
 					path := filepath.Join(testFileBaseDir, fileDef.relativePath)
-					err := os.MkdirAll(filepath.Dir(path), 0755)
+					err := os.MkdirAll(filepath.Dir(path), 0o755)
 					want[path] = fileDef.expectedPath
 					if err != nil {
 						return err
@@ -143,7 +143,6 @@ func TestAssetsFromDir(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestSyncDest(t *testing.T) {

--- a/pkg/minikube/machine/fix.go
+++ b/pkg/minikube/machine/fix.go
@@ -177,7 +177,6 @@ func maybeWarnAboutEvalEnv(drver string, name string) {
 
 	`, out.V{"profile_name": name})
 	}
-
 }
 
 // ensureGuestClockSync ensures that the guest system clock is relatively in-sync

--- a/pkg/minikube/machine/info.go
+++ b/pkg/minikube/machine/info.go
@@ -99,8 +99,10 @@ func logRemoteOsRelease(r command.Runner) {
 	glog.Infof("Remote host: %s", osReleaseInfo.PrettyName)
 }
 
-var cachedSystemMemoryLimit *mem.VirtualMemoryStat
-var cachedSystemMemoryErr *error
+var (
+	cachedSystemMemoryLimit *mem.VirtualMemoryStat
+	cachedSystemMemoryErr   *error
+)
 
 //  cachedSysMemLimit will return a cached limit for the system's virtual memory.
 func cachedSysMemLimit() (*mem.VirtualMemoryStat, error) {
@@ -115,8 +117,10 @@ func cachedSysMemLimit() (*mem.VirtualMemoryStat, error) {
 	return cachedSystemMemoryLimit, *cachedSystemMemoryErr
 }
 
-var cachedDisk *disk.UsageStat
-var cachedDiskInfoErr *error
+var (
+	cachedDisk        *disk.UsageStat
+	cachedDiskInfoErr *error
+)
 
 // cachedDiskInfo will return a cached disk usage info
 func cachedDiskInfo() (disk.UsageStat, error) {
@@ -131,8 +135,10 @@ func cachedDiskInfo() (disk.UsageStat, error) {
 	return *cachedDisk, *cachedDiskInfoErr
 }
 
-var cachedCPU *[]cpu.InfoStat
-var cachedCPUErr *error
+var (
+	cachedCPU    *[]cpu.InfoStat
+	cachedCPUErr *error
+)
 
 //  cachedCPUInfo will return a cached cpu info
 func cachedCPUInfo() ([]cpu.InfoStat, error) {

--- a/pkg/minikube/machine/start.go
+++ b/pkg/minikube/machine/start.go
@@ -50,21 +50,19 @@ import (
 	"k8s.io/minikube/pkg/util/lock"
 )
 
-var (
-	// requiredDirectories are directories to create on the host during setup
-	requiredDirectories = []string{
-		vmpath.GuestAddonsDir,
-		vmpath.GuestManifestsDir,
-		vmpath.GuestEphemeralDir,
-		vmpath.GuestPersistentDir,
-		vmpath.GuestKubernetesCertsDir,
-		path.Join(vmpath.GuestPersistentDir, "images"),
-		path.Join(vmpath.GuestPersistentDir, "binaries"),
-		vmpath.GuestGvisorDir,
-		vmpath.GuestCertAuthDir,
-		vmpath.GuestCertStoreDir,
-	}
-)
+// requiredDirectories are directories to create on the host during setup
+var requiredDirectories = []string{
+	vmpath.GuestAddonsDir,
+	vmpath.GuestManifestsDir,
+	vmpath.GuestEphemeralDir,
+	vmpath.GuestPersistentDir,
+	vmpath.GuestKubernetesCertsDir,
+	path.Join(vmpath.GuestPersistentDir, "images"),
+	path.Join(vmpath.GuestPersistentDir, "binaries"),
+	vmpath.GuestGvisorDir,
+	vmpath.GuestCertAuthDir,
+	vmpath.GuestCertStoreDir,
+}
 
 // StartHost starts a host VM.
 func StartHost(api libmachine.API, cfg *config.ClusterConfig, n *config.Node) (*host.Host, bool, error) {
@@ -292,7 +290,6 @@ func acquireMachinesLock(name string, drv string) (mutex.Releaser, error) {
 	spec.Timeout = 13 * time.Minute
 	if driver.IsKIC(drv) {
 		spec.Timeout = 10 * time.Minute
-
 	}
 
 	glog.Infof("acquiring machines lock for %s: %+v", name, spec)

--- a/pkg/minikube/node/advice.go
+++ b/pkg/minikube/node/advice.go
@@ -71,5 +71,4 @@ func MaybeExitWithAdvice(err error) {
 
 `)
 	}
-
 }

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -176,7 +176,6 @@ func waitDownloadKicBaseImage(g *errgroup.Group) {
 			}
 
 		}
-
 	}
 	glog.Info("Successfully downloaded all kic artifacts")
 }

--- a/pkg/minikube/node/config.go
+++ b/pkg/minikube/node/config.go
@@ -72,7 +72,7 @@ func configureMounts(wg *sync.WaitGroup) {
 	if err := mountCmd.Start(); err != nil {
 		exit.WithError("Error starting mount", err)
 	}
-	if err := lock.WriteFile(filepath.Join(localpath.MiniPath(), constants.MountProcessFileName), []byte(strconv.Itoa(mountCmd.Process.Pid)), 0644); err != nil {
+	if err := lock.WriteFile(filepath.Join(localpath.MiniPath(), constants.MountProcessFileName), []byte(strconv.Itoa(mountCmd.Process.Pid)), 0o644); err != nil {
 		exit.WithError("Error writing mount pid", err)
 	}
 }

--- a/pkg/minikube/node/node.go
+++ b/pkg/minikube/node/node.go
@@ -116,7 +116,6 @@ func Delete(cc config.ClusterConfig, name string) (*config.Node, error) {
 
 // Retrieve finds the node by name in the given cluster
 func Retrieve(cc config.ClusterConfig, name string) (*config.Node, int, error) {
-
 	for i, n := range cc.Nodes {
 		if n.Name == name {
 			return &n, i, nil

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -161,7 +161,6 @@ func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 		if starter.Cfg.Driver == driver.None && len(starter.Cfg.Nodes) == 1 {
 			prepareNone()
 		}
-
 	} else {
 		if err := bs.UpdateNode(*starter.Cfg, *starter.Node, cr); err != nil {
 			return nil, errors.Wrap(err, "update node")
@@ -232,7 +231,6 @@ func Provision(cc *config.ClusterConfig, n *config.Node, apiServer bool, delOnFa
 	waitDownloadKicBaseImage(&kicGroup)
 
 	return startMachine(cc, n, delOnFail)
-
 }
 
 // ConfigureRuntimes does what needs to happen to get a runtime going.

--- a/pkg/minikube/notify/notify.go
+++ b/pkg/minikube/notify/notify.go
@@ -133,7 +133,7 @@ func GetAllVersionsFromURL(url string) (Releases, error) {
 }
 
 func writeTimeToFile(path string, inputTime time.Time) error {
-	err := lock.WriteFile(path, []byte(inputTime.Format(timeLayout)), 0644)
+	err := lock.WriteFile(path, []byte(inputTime.Format(timeLayout)), 0o644)
 	if err != nil {
 		return errors.Wrap(err, "Error writing current update time to file: ")
 	}

--- a/pkg/minikube/notify/notify_test.go
+++ b/pkg/minikube/notify/notify_test.go
@@ -62,7 +62,7 @@ func TestShouldCheckURL(t *testing.T) {
 	// test that update notifications get triggered if it has been longer than 24 hours
 	viper.Set(config.ReminderWaitPeriodInHours, 24)
 
-	//time.Time{} returns time -> January 1, year 1, 00:00:00.000000000 UTC.
+	// time.Time{} returns time -> January 1, year 1, 00:00:00.000000000 UTC.
 	if err := writeTimeToFile(lastUpdateCheckFilePath, time.Time{}); err != nil {
 		t.Errorf("write failed: %v", err)
 	}
@@ -77,7 +77,6 @@ func TestShouldCheckURL(t *testing.T) {
 	if shouldCheckURLVersion(lastUpdateCheckFilePath) {
 		t.Fatalf("shouldCheckURLVersion returned true even though less than 24 hours since last update")
 	}
-
 }
 
 type URLHandlerCorrect struct {
@@ -156,7 +155,7 @@ func TestMaybePrintUpdateText(t *testing.T) {
 	outputBuffer := tests.NewFakeFile()
 	out.SetErrFile(outputBuffer)
 
-	var tc = []struct {
+	tc := []struct {
 		len                     int
 		wantUpdateNotification  bool
 		latestVersionFromURL    string

--- a/pkg/minikube/out/out_test.go
+++ b/pkg/minikube/out/out_test.go
@@ -35,7 +35,7 @@ func TestOutT(t *testing.T) {
 		"Installing Kubernetes version {{.version}} ...": "... {{.version}} تثبيت Kubernetes الإصدار",
 	}
 
-	var testCases = []struct {
+	testCases := []struct {
 		style     StyleEnum
 		message   string
 		params    V
@@ -74,7 +74,7 @@ func TestOutT(t *testing.T) {
 func TestOut(t *testing.T) {
 	os.Setenv(OverrideEnv, "")
 
-	var testCases = []struct {
+	testCases := []struct {
 		format string
 		arg    interface{}
 		want   string

--- a/pkg/minikube/out/register/cloud_events.go
+++ b/pkg/minikube/out/register/cloud_events.go
@@ -46,7 +46,7 @@ func SetOutputFile(w io.Writer) {
 // SetEventLogPath sets the path of an event log file
 func SetEventLogPath(path string) {
 	if _, err := os.Stat(filepath.Dir(path)); err != nil {
-		if err := os.MkdirAll(filepath.Dir(path), 0777); err != nil {
+		if err := os.MkdirAll(filepath.Dir(path), 0o777); err != nil {
 			glog.Errorf("Error creating profile directory: %v", err)
 			return
 		}

--- a/pkg/minikube/out/register/json_test.go
+++ b/pkg/minikube/out/register/json_test.go
@@ -104,6 +104,7 @@ func TestErrorExitCode(t *testing.T) {
 		t.Fatalf("expected didn't match actual:\nExpected:\n%v\n\nActual:\n%v", expected, actual)
 	}
 }
+
 func TestWarning(t *testing.T) {
 	expected := `{"data":{"message":"warning"},"datacontenttype":"application/json","id":"random-id","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.warning"}`
 	expected += "\n"

--- a/pkg/minikube/out/style_test.go
+++ b/pkg/minikube/out/style_test.go
@@ -23,8 +23,7 @@ import (
 )
 
 func TestApplyPrefix(t *testing.T) {
-
-	var tests = []struct {
+	tests := []struct {
 		prefix, format, expected, description string
 	}{
 		{
@@ -51,8 +50,7 @@ func TestApplyPrefix(t *testing.T) {
 }
 
 func TestLowPrefix(t *testing.T) {
-
-	var tests = []struct {
+	tests := []struct {
 		expected    string
 		description string
 		style       style
@@ -88,8 +86,7 @@ func TestLowPrefix(t *testing.T) {
 }
 
 func TestApplyStyle(t *testing.T) {
-
-	var tests = []struct {
+	tests := []struct {
 		expected    string
 		description string
 		styleEnum   StyleEnum
@@ -130,8 +127,7 @@ func TestApplyStyle(t *testing.T) {
 }
 
 func TestApplyTemplateFormating(t *testing.T) {
-
-	var tests = []struct {
+	tests := []struct {
 		expected    string
 		description string
 		styleEnum   StyleEnum

--- a/pkg/minikube/perf/binary.go
+++ b/pkg/minikube/perf/binary.go
@@ -94,11 +94,11 @@ func downloadBinary(url, path string) error {
 	}
 	defer resp.Body.Close()
 
-	if err := os.MkdirAll(filepath.Dir(path), 0777); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o777); err != nil {
 		return err
 	}
 
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0777)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o777)
 	if err != nil {
 		return err
 	}

--- a/pkg/minikube/perf/binary_test.go
+++ b/pkg/minikube/perf/binary_test.go
@@ -43,7 +43,6 @@ func TestBinaryName(t *testing.T) {
 				t.Fatalf("Binary name(%v) doesn't match expected name(%v)", name, test.expected)
 			}
 		})
-
 	}
 }
 

--- a/pkg/minikube/problem/err_map.go
+++ b/pkg/minikube/problem/err_map.go
@@ -373,8 +373,10 @@ var vmProblems = map[string]match{
 }
 
 // proxyDoc is the URL to proxy documentation
-const proxyDoc = "https://minikube.sigs.k8s.io/docs/handbook/vpn_and_proxy/"
-const vpnDoc = "https://minikube.sigs.k8s.io/docs/handbook/vpn_and_proxy/"
+const (
+	proxyDoc = "https://minikube.sigs.k8s.io/docs/handbook/vpn_and_proxy/"
+	vpnDoc   = "https://minikube.sigs.k8s.io/docs/handbook/vpn_and_proxy/"
+)
 
 // netProblems are network related problems.
 var netProblems = map[string]match{

--- a/pkg/minikube/problem/problem_test.go
+++ b/pkg/minikube/problem/problem_test.go
@@ -37,7 +37,7 @@ func (b buffFd) Fd() uintptr { return b.uptr }
 func TestDisplay(t *testing.T) {
 	buffErr := buffFd{}
 	out.SetErrFile(&buffErr)
-	var tests = []struct {
+	tests := []struct {
 		description string
 		problem     Problem
 		expected    string
@@ -138,7 +138,7 @@ func TestDisplayJSON(t *testing.T) {
 }
 
 func TestFromError(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		issue int
 		os    string
 		want  string

--- a/pkg/minikube/proxy/proxy_test.go
+++ b/pkg/minikube/proxy/proxy_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestIsValidEnv(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		env  string
 		want bool
 	}{
@@ -42,11 +42,10 @@ func TestIsValidEnv(t *testing.T) {
 			}
 		})
 	}
-
 }
-func TestIsInBlock(t *testing.T) {
 
-	var testCases = []struct {
+func TestIsInBlock(t *testing.T) {
+	testCases := []struct {
 		ip        string
 		block     string
 		want      bool
@@ -75,13 +74,12 @@ func TestIsInBlock(t *testing.T) {
 			if got != tc.want {
 				t.Errorf("isInBlock(%v,%v) got %v; want %v", tc.ip, tc.block, got, tc.want)
 			}
-
 		})
 	}
 }
 
 func TestUpdateEnv(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		ip      string
 		env     string
 		wantErr bool
@@ -107,14 +105,12 @@ func TestUpdateEnv(t *testing.T) {
 			if err != nil && tc.env != "" {
 				t.Errorf("Error reverting the env var (%s) to its original value (%s)", tc.env, origVal)
 			}
-
 		})
 	}
-
 }
 
 func TestCheckEnv(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		ip           string
 		envName      string
 		want         bool
@@ -150,11 +146,10 @@ func TestCheckEnv(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestIsIPExcluded(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		ip, env  string
 		excluded bool
 	}{
@@ -185,7 +180,7 @@ func TestIsIPExcluded(t *testing.T) {
 }
 
 func TestExcludeIP(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		ip, env  string
 		wantAErr bool
 	}{
@@ -247,7 +242,6 @@ func TestUpdateTransport(t *testing.T) {
 		if rt == rc.WrapTransport(transport) {
 			t.Fatalf("Expected to reuse existing RoundTripper(%v) but found %v", rt, transport)
 		}
-
 	})
 	t.Run("nil", func(t *testing.T) {
 		rc := rest.Config{}

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -81,7 +81,6 @@ func status() registry.State {
 	output := string(o)
 	if strings.Contains(output, "windows-") {
 		return registry.State{Error: oci.ErrWindowsContainers, Installed: true, Healthy: false, Fix: "Change container type to \"linux\" in Docker Desktop settings", Doc: docURL + "#verify-docker-container-type-is-linux"}
-
 	}
 	if err == nil {
 		glog.Infof("docker version: %s", output)

--- a/pkg/minikube/registry/drvs/hyperkit/hyperkit.go
+++ b/pkg/minikube/registry/drvs/hyperkit/hyperkit.go
@@ -42,10 +42,8 @@ const (
 	docURL = "https://minikube.sigs.k8s.io/docs/reference/drivers/hyperkit/"
 )
 
-var (
-	// minimumVersion is used by hyperkit versionCheck(whether user's hyperkit is older than this)
-	minimumVersion = "0.20190201"
-)
+// minimumVersion is used by hyperkit versionCheck(whether user's hyperkit is older than this)
+var minimumVersion = "0.20190201"
 
 func init() {
 	if err := registry.Register(registry.DriverDef{

--- a/pkg/minikube/registry/drvs/hyperkit/hyperkit_test.go
+++ b/pkg/minikube/registry/drvs/hyperkit/hyperkit_test.go
@@ -28,7 +28,7 @@ var (
 )
 
 func TestSplitHyperKitVersion(t *testing.T) {
-	var tc = []struct {
+	tc := []struct {
 		desc, version, expect string
 	}{
 		{
@@ -63,7 +63,7 @@ func TestSplitHyperKitVersion(t *testing.T) {
 }
 
 func TestConvertVersionToDate(t *testing.T) {
-	var tc = []struct {
+	tc := []struct {
 		desc, versionOutput, expect string
 	}{
 		{
@@ -93,7 +93,7 @@ func TestConvertVersionToDate(t *testing.T) {
 }
 
 func TestIsNewerVersion(t *testing.T) {
-	var tc = []struct {
+	tc := []struct {
 		desc, currentVersion, specificVersion string
 		isNew                                 bool
 	}{

--- a/pkg/minikube/registry/drvs/hyperv/hyperv.go
+++ b/pkg/minikube/registry/drvs/hyperv/hyperv.go
@@ -91,7 +91,6 @@ func status() registry.State {
 
 	cmd := exec.CommandContext(ctx, path, "@(Get-Wmiobject Win32_ComputerSystem).HypervisorPresent")
 	out, err := cmd.CombinedOutput()
-
 	if err != nil {
 		errorMessage := fmt.Errorf("%s failed:\n%s", strings.Join(cmd.Args, " "), out)
 		fixMessage := "Start PowerShell as an Administrator"

--- a/pkg/minikube/registry/drvs/parallels/parallels.go
+++ b/pkg/minikube/registry/drvs/parallels/parallels.go
@@ -42,7 +42,6 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("unable to register: %v", err))
 	}
-
 }
 
 func configure(cfg config.ClusterConfig, n config.Node) (interface{}, error) {

--- a/pkg/minikube/registry/global.go
+++ b/pkg/minikube/registry/global.go
@@ -59,10 +59,8 @@ func BareMetal(name string) bool {
 	return name == None || name == Mock
 }
 
-var (
-	// globalRegistry is a globally accessible driver registry
-	globalRegistry = newRegistry()
-)
+// globalRegistry is a globally accessible driver registry
+var globalRegistry = newRegistry()
 
 // DriverState is metadata relating to a driver and status
 type DriverState struct {

--- a/pkg/minikube/service/service_test.go
+++ b/pkg/minikube/service/service_test.go
@@ -59,7 +59,8 @@ func (m *MockClientGetter) GetCoreClient(string) (typed_core.CoreV1Interface, er
 	return &MockCoreClient{
 		servicesMap:  m.servicesMap,
 		endpointsMap: m.endpointsMap,
-		secretsMap:   m.secretsMap}, nil
+		secretsMap:   m.secretsMap,
+	}, nil
 }
 
 func (m *MockCoreClient) Secrets(ns string) typed_core.SecretInterface {
@@ -294,7 +295,7 @@ func TestPrintURLsForService(t *testing.T) {
 		servicesMap:  serviceNamespaces,
 		endpointsMap: endpointNamespaces,
 	}
-	var tests = []struct {
+	tests := []struct {
 		description    string
 		serviceName    string
 		namespace      string
@@ -354,8 +355,7 @@ func TestPrintURLsForService(t *testing.T) {
 }
 
 func TestOptionallyHttpsFormattedUrlString(t *testing.T) {
-
-	var tests = []struct {
+	tests := []struct {
 		description                     string
 		bareURLString                   string
 		https                           bool
@@ -424,7 +424,7 @@ func TestGetServiceURLs(t *testing.T) {
 	defaultTemplate := template.Must(template.New("svc-template").Parse("http://{{.IP}}:{{.Port}}"))
 	viper.Set(config.ProfileName, constants.DefaultClusterName)
 
-	var tests = []struct {
+	tests := []struct {
 		description string
 		api         libmachine.API
 		namespace   string
@@ -497,7 +497,7 @@ func TestGetServiceURLsForService(t *testing.T) {
 	defaultTemplate := template.Must(template.New("svc-template").Parse("http://{{.IP}}:{{.Port}}"))
 	viper.Set(config.ProfileName, constants.DefaultClusterName)
 
-	var tests = []struct {
+	tests := []struct {
 		description string
 		api         libmachine.API
 		namespace   string
@@ -581,7 +581,7 @@ preferences: {}
 users:
 - name: minikube
 `
-	var tests = []struct {
+	tests := []struct {
 		description    string
 		kubeconfigPath string
 		config         string
@@ -611,7 +611,7 @@ users:
 		t.Run(test.description, func(t *testing.T) {
 			mockK8sConfigByte := []byte(test.config)
 			mockK8sConfigPath := test.kubeconfigPath
-			err := ioutil.WriteFile(mockK8sConfigPath, mockK8sConfigByte, 0644)
+			err := ioutil.WriteFile(mockK8sConfigPath, mockK8sConfigByte, 0o644)
 			defer os.Remove(mockK8sConfigPath)
 			if err != nil {
 				t.Fatalf("Unexpected error when writing to file %v. Error: %v", test.kubeconfigPath, err)
@@ -648,7 +648,7 @@ func TestPrintServiceList(t *testing.T) {
 }
 
 func TestGetServiceListByLabel(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		description, ns, name, label string
 		items                        int
 		failedGetClient, err         bool
@@ -701,7 +701,7 @@ func TestGetServiceListByLabel(t *testing.T) {
 }
 
 func TestCheckService(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		description, ns, name string
 		failedGetClient, err  bool
 	}{
@@ -746,7 +746,7 @@ func TestCheckService(t *testing.T) {
 }
 
 func TestDeleteSecret(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		description, ns, name string
 		failedGetClient, err  bool
 	}{
@@ -785,7 +785,7 @@ func TestDeleteSecret(t *testing.T) {
 }
 
 func TestCreateSecret(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		description, ns, name string
 		failedGetClient, err  bool
 	}{
@@ -836,7 +836,7 @@ func TestWaitAndMaybeOpenService(t *testing.T) {
 	}
 	defaultTemplate := template.Must(template.New("svc-template").Parse("http://{{.IP}}:{{.Port}}"))
 
-	var tests = []struct {
+	tests := []struct {
 		description string
 		api         libmachine.API
 		namespace   string
@@ -935,7 +935,6 @@ func TestWaitAndMaybeOpenService(t *testing.T) {
 					}
 				}
 			}
-
 		})
 	}
 }
@@ -953,7 +952,7 @@ func TestWaitAndMaybeOpenServiceForNotDefaultNamspace(t *testing.T) {
 	}
 	defaultTemplate := template.Must(template.New("svc-template").Parse("http://{{.IP}}:{{.Port}}"))
 
-	var tests = []struct {
+	tests := []struct {
 		description string
 		api         libmachine.API
 		namespace   string
@@ -986,7 +985,6 @@ func TestWaitAndMaybeOpenServiceForNotDefaultNamspace(t *testing.T) {
 			if !test.err && err != nil {
 				t.Fatalf("WaitForService not expected to fail but got err: %v", err)
 			}
-
 		})
 	}
 }

--- a/pkg/minikube/shell/shell.go
+++ b/pkg/minikube/shell/shell.go
@@ -129,13 +129,13 @@ REM @FOR /f "tokens=*" %%i IN ('%s') DO @%%i
 	},
 }
 
-var defaultSh = "bash"
-var defaultShell shellData = shellConfigMap[defaultSh]
-
 var (
-	// ForceShell forces a shell name
-	ForceShell string
+	defaultSh              = "bash"
+	defaultShell shellData = shellConfigMap[defaultSh]
 )
+
+// ForceShell forces a shell name
+var ForceShell string
 
 // Detect detects user's current shell.
 func Detect() (string, error) {

--- a/pkg/minikube/shell/shell_test.go
+++ b/pkg/minikube/shell/shell_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestGenerateUsageHint(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		ec       EnvConfig
 		expected string
 	}{
@@ -55,7 +55,7 @@ func TestGenerateUsageHint(t *testing.T) {
 }
 
 func TestCfgSet(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		plz, cmd string
 		ec       EnvConfig
 		expected string
@@ -82,7 +82,7 @@ func TestCfgSet(t *testing.T) {
 }
 
 func TestUnsetScript(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		vars     []string
 		ec       EnvConfig
 		expected string

--- a/pkg/minikube/sshutil/sshutil.go
+++ b/pkg/minikube/sshutil/sshutil.go
@@ -34,7 +34,6 @@ func NewSSHClient(d drivers.Driver) (*ssh.Client, error) {
 	h, err := newSSHHost(d)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error creating new ssh host from driver")
-
 	}
 	auth := &machinessh.Auth{}
 	if h.SSHKeyPath != "" {
@@ -72,7 +71,6 @@ type sshHost struct {
 }
 
 func newSSHHost(d drivers.Driver) (*sshHost, error) {
-
 	ip, err := d.GetSSHHostname()
 	if err != nil {
 		return nil, errors.Wrap(err, "Error getting ssh host name for driver")

--- a/pkg/minikube/storageclass/storageclass_test.go
+++ b/pkg/minikube/storageclass/storageclass_test.go
@@ -33,18 +33,23 @@ import (
 type mockStorageV1InterfaceOk struct {
 	storagev1.StorageV1Interface
 }
+
 type mockStorageV1InterfaceListErr struct {
 	storagev1.StorageV1Interface
 }
+
 type mockStorageV1InterfaceWithBadItem struct {
 	storagev1.StorageV1Interface
 }
+
 type mockStorageClassInterfaceOk struct {
 	storagev1.StorageClassInterface
 }
+
 type mockStorageClassInterfaceListErr struct {
 	storagev1.StorageClassInterface
 }
+
 type mockStorageClassInterfaceWithBadItem struct {
 	storagev1.StorageClassInterface
 }
@@ -53,10 +58,12 @@ func testStoragev1Ok() (storagev1.StorageV1Interface, error) {
 	client := fake.Clientset{Fake: testing_client.Fake{}}
 	return mockStorageV1InterfaceOk{client.StorageV1()}, nil
 }
+
 func testStoragev1ListErr() (storagev1.StorageV1Interface, error) {
 	client := fake.Clientset{Fake: testing_client.Fake{}}
 	return mockStorageV1InterfaceListErr{client.StorageV1()}, nil
 }
+
 func testStoragev1WithBadItem() (storagev1.StorageV1Interface, error) {
 	client := fake.Clientset{Fake: testing_client.Fake{}}
 	return mockStorageV1InterfaceWithBadItem{client.StorageV1()}, nil
@@ -95,6 +102,7 @@ func (m mockStorageClassInterfaceWithBadItem) List(opts metav1.ListOptions) (*v1
 	scl.Items = append(scl.Items, sc)
 	return &scl, nil
 }
+
 func (mockStorageClassInterfaceListErr) List(opts metav1.ListOptions) (*v1.StorageClassList, error) {
 	return nil, fmt.Errorf("mocked list error")
 }
@@ -114,7 +122,7 @@ func (mockStorageClassInterfaceWithBadItem) Update(sc *v1.StorageClass) (*v1.Sto
 }
 
 func TestDisableDefaultStorageClass(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		description string
 		class       string
 		err         bool
@@ -154,7 +162,7 @@ func TestDisableDefaultStorageClass(t *testing.T) {
 }
 
 func TestSetDefaultStorageClass(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		description string
 		class       string
 		err         bool
@@ -213,7 +221,7 @@ users:
 `
 
 func TestGetStoragev1(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		description string
 		config      string
 		err         bool
@@ -254,7 +262,7 @@ func TestGetStoragev1(t *testing.T) {
 func setK8SConfig(config, kubeconfigPath string) error {
 	mockK8sConfigByte := []byte(config)
 	mockK8sConfigPath := kubeconfigPath
-	err := ioutil.WriteFile(mockK8sConfigPath, mockK8sConfigByte, 0644)
+	err := ioutil.WriteFile(mockK8sConfigPath, mockK8sConfigByte, 0o644)
 	if err != nil {
 		return fmt.Errorf("Unexpected error when writing to file %v. Error: %v", kubeconfigPath, err)
 	}

--- a/pkg/minikube/sysinit/systemd_test.go
+++ b/pkg/minikube/sysinit/systemd_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 func TestEnable(t *testing.T) {
-
 	tests := []struct {
 		service   string
 		shouldErr bool

--- a/pkg/minikube/tests/dir_utils.go
+++ b/pkg/minikube/tests/dir_utils.go
@@ -33,11 +33,11 @@ func MakeTempDir() string {
 		log.Fatal(err)
 	}
 	tempDir = filepath.Join(tempDir, ".minikube")
-	err = os.MkdirAll(filepath.Join(tempDir, "addons"), 0777)
+	err = os.MkdirAll(filepath.Join(tempDir, "addons"), 0o777)
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = os.MkdirAll(filepath.Join(tempDir, "cache", "iso"), 0777)
+	err = os.MkdirAll(filepath.Join(tempDir, "cache", "iso"), 0o777)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -70,6 +70,7 @@ func (f *FakeFile) Fd() uintptr {
 func (f *FakeFile) Write(p []byte) (int, error) {
 	return f.b.Write(p)
 }
+
 func (f *FakeFile) String() string {
 	return f.b.String()
 }

--- a/pkg/minikube/tests/fake_store.go
+++ b/pkg/minikube/tests/fake_store.go
@@ -51,7 +51,6 @@ func (s *FakeStore) Load(name string) (*host.Host, error) {
 		return nil, mcnerror.ErrHostDoesNotExist{
 			Name: name,
 		}
-
 	}
 	return h, nil
 }
@@ -63,7 +62,6 @@ func (s *FakeStore) Remove(name string) error {
 		return mcnerror.ErrHostDoesNotExist{
 			Name: name,
 		}
-
 	}
 	delete(s.Hosts, name)
 	return nil

--- a/pkg/minikube/translate/translate.go
+++ b/pkg/minikube/translate/translate.go
@@ -98,7 +98,6 @@ func DetermineLocale() {
 	if err != nil {
 		glog.Infof("Failed to populate translation map: %v", err)
 	}
-
 }
 
 // setPreferredLanguageTag configures which language future messages should use.

--- a/pkg/minikube/translate/translate_test.go
+++ b/pkg/minikube/translate/translate_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestSetPreferredLanguage(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		input string
 		want  language.Tag
 	}{
@@ -49,11 +49,10 @@ func TestSetPreferredLanguage(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestT(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		description, input, expected string
 		langDef, langPref            language.Tag
 		translations                 map[string]interface{}

--- a/pkg/minikube/tunnel/cluster_inspector.go
+++ b/pkg/minikube/tunnel/cluster_inspector.go
@@ -36,9 +36,7 @@ type clusterInspector struct {
 }
 
 func (m *clusterInspector) getStateAndHost() (HostState, *host.Host, error) {
-
 	h, err := machine.LoadHost(m.machineAPI, m.machineName)
-
 	if err != nil {
 		err = errors.Wrapf(err, "error loading docker-machine host for: %s", m.machineName)
 		return Unknown, nil, err

--- a/pkg/minikube/tunnel/cluster_inspector_test.go
+++ b/pkg/minikube/tunnel/cluster_inspector_test.go
@@ -17,13 +17,12 @@ limitations under the License.
 package tunnel
 
 import (
-	"testing"
-
-	"k8s.io/minikube/pkg/util"
-
 	"net"
 	"reflect"
 	"strings"
+	"testing"
+
+	"k8s.io/minikube/pkg/util"
 
 	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/state"
@@ -77,7 +76,6 @@ func TestMinikubeCheckReturnsHostInformation(t *testing.T) {
 	}
 
 	s, r, err := inspector.getStateAndRoute()
-
 	if err != nil {
 		t.Errorf("`error` is not nil")
 	}
@@ -107,7 +105,8 @@ func TestUnparseableCIDR(t *testing.T) {
 	cfg := config.ClusterConfig{
 		KubernetesConfig: config.KubernetesConfig{
 			ServiceCIDR: "bad.cidr.0.0/12",
-		}}
+		},
+	}
 	h := &host.Host{
 		Driver: &tests.MockDriver{
 			IP: "192.168.1.1",
@@ -138,7 +137,6 @@ func TestRouteIPDetection(t *testing.T) {
 	}
 
 	routerConfig, err := getRoute(h, cfg)
-
 	if err != nil {
 		t.Errorf("expected no errors but got: %s", err)
 	}
@@ -150,5 +148,4 @@ func TestRouteIPDetection(t *testing.T) {
 	if routerConfig.Gateway.String() != expectedGatewayIP {
 		t.Errorf("add gateway IP doesn't match, expected '%s', got '%s'", expectedGatewayIP, routerConfig.Gateway)
 	}
-
 }

--- a/pkg/minikube/tunnel/loadbalancer_patcher.go
+++ b/pkg/minikube/tunnel/loadbalancer_patcher.go
@@ -143,7 +143,6 @@ func (l *LoadBalancerEmulator) cleanupService(restClient rest.Interface, svc cor
 	result, err := l.requestSender.send(request)
 	glog.Infof("Removed load balancer ingress from %s.", svc.Name)
 	return result, err
-
 }
 
 // NewLoadBalancerEmulator creates a new LoadBalancerEmulator

--- a/pkg/minikube/tunnel/loadbalancer_patcher_test.go
+++ b/pkg/minikube/tunnel/loadbalancer_patcher_test.go
@@ -17,9 +17,8 @@ limitations under the License.
 package tunnel
 
 import (
-	"testing"
-
 	"reflect"
+	"testing"
 
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,7 +56,8 @@ func (s *stubServices) List(opts meta.ListOptions) (*core.ServiceList, error) {
 func newStubCoreClient(servicesList *core.ServiceList) *stubCoreClient {
 	if servicesList == nil {
 		servicesList = &core.ServiceList{
-			Items: []core.Service{}}
+			Items: []core.Service{},
+		}
 	}
 	return &stubCoreClient{
 		servicesList: servicesList,
@@ -85,7 +85,8 @@ func (r *recordingPatchConverter) convert(restClient rest.Interface, patch *Patc
 
 func TestEmptyListOfServicesDoesNothing(t *testing.T) {
 	client := newStubCoreClient(&core.ServiceList{
-		Items: []core.Service{}})
+		Items: []core.Service{},
+	})
 
 	patcher := NewLoadBalancerEmulator(client)
 
@@ -94,7 +95,6 @@ func TestEmptyListOfServicesDoesNothing(t *testing.T) {
 	if len(serviceNames) > 0 || err != nil {
 		t.Errorf("Expected: [], nil\n Got: %v, %s", serviceNames, err)
 	}
-
 }
 
 func TestServicesWithNoLoadbalancerType(t *testing.T) {
@@ -120,7 +120,6 @@ func TestServicesWithNoLoadbalancerType(t *testing.T) {
 	if len(serviceNames) > 0 || err != nil {
 		t.Errorf("Expected: [], nil\n Got: %v, %s", serviceNames, err)
 	}
-
 }
 
 func TestServicesWithLoadbalancerType(t *testing.T) {
@@ -233,7 +232,6 @@ func TestServicesWithLoadbalancerType(t *testing.T) {
 	if requestSender.requests != 2 {
 		t.Errorf("error in number of requests sent.\nExpected: %v, <nil>\nGot: %v", 2, requestSender.requests)
 	}
-
 }
 
 func TestCleanupPatchedIPs(t *testing.T) {

--- a/pkg/minikube/tunnel/process.go
+++ b/pkg/minikube/tunnel/process.go
@@ -23,8 +23,10 @@ import (
 	"syscall"
 )
 
-var checkIfRunning func(pid int) (bool, error)
-var getPid func() int
+var (
+	checkIfRunning func(pid int) (bool, error)
+	getPid         func() int
+)
 
 func init() {
 	checkIfRunning = osCheckIfRunning

--- a/pkg/minikube/tunnel/registry.go
+++ b/pkg/minikube/tunnel/registry.go
@@ -110,7 +110,7 @@ func (r *persistentRegistry) Register(tunnel *ID) (rerr error) {
 
 	glog.V(5).Infof("json marshalled: %v, %s\n", tunnels, bytes)
 
-	f, err := os.OpenFile(r.path, os.O_RDWR|os.O_TRUNC, 0600)
+	f, err := os.OpenFile(r.path, os.O_RDWR|os.O_TRUNC, 0o600)
 	if err != nil {
 		if os.IsNotExist(err) {
 			f, err = os.Create(r.path)
@@ -154,7 +154,7 @@ func (r *persistentRegistry) Remove(route *Route) (rerr error) {
 	}
 	tunnels = append(tunnels[:idx], tunnels[idx+1:]...)
 	glog.V(4).Infof("tunnels after remove: %s", tunnels)
-	f, err := os.OpenFile(r.path, os.O_RDWR|os.O_TRUNC, 0600)
+	f, err := os.OpenFile(r.path, os.O_RDWR|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("error removing tunnel %s", err)
 	}
@@ -177,6 +177,7 @@ func (r *persistentRegistry) Remove(route *Route) (rerr error) {
 
 	return nil
 }
+
 func (r *persistentRegistry) List() ([]*ID, error) {
 	f, err := os.Open(r.path)
 	if err != nil {

--- a/pkg/minikube/tunnel/registry_test.go
+++ b/pkg/minikube/tunnel/registry_test.go
@@ -43,7 +43,6 @@ func TestPersistentRegistryNullableMetadata(t *testing.T) {
 		Route: unsafeParseRoute("1.2.3.4", "10.96.0.0/12"),
 	}
 	err := registry.Register(route)
-
 	if err != nil {
 		t.Errorf("metadata should be nullable, expected no error, got %s", err)
 	}
@@ -143,6 +142,7 @@ func TestListAfterRegister(t *testing.T) {
 		t.Errorf("\nexpected %+v,\ngot      %+v", expectedList, tunnelList)
 	}
 }
+
 func TestRegisterRemoveList(t *testing.T) {
 	file := tmpFile(t)
 	reg := &persistentRegistry{

--- a/pkg/minikube/tunnel/reporter.go
+++ b/pkg/minikube/tunnel/reporter.go
@@ -18,7 +18,6 @@ package tunnel
 
 import (
 	"fmt"
-
 	"io"
 	"strings"
 

--- a/pkg/minikube/tunnel/reporter_test.go
+++ b/pkg/minikube/tunnel/reporter_test.go
@@ -19,7 +19,6 @@ package tunnel
 import (
 	"errors"
 	"fmt"
-
 	"testing"
 )
 

--- a/pkg/minikube/tunnel/route.go
+++ b/pkg/minikube/tunnel/route.go
@@ -76,7 +76,6 @@ func (t *routingTable) Check(route *Route) (exists bool, conflict string, overla
 	exists = false
 	overlaps = []string{}
 	for _, tableLine := range *t {
-
 		if route.Equal(tableLine.route) {
 			exists = true
 		} else if route.DestCIDR.String() == tableLine.route.DestCIDR.String() &&

--- a/pkg/minikube/tunnel/route_darwin.go
+++ b/pkg/minikube/tunnel/route_darwin.go
@@ -200,7 +200,7 @@ func writeResolverFile(route *Route) error {
 		return errors.Wrap(err, "close")
 	}
 
-	if err = os.Chmod(tf.Name(), 0644); err != nil {
+	if err = os.Chmod(tf.Name(), 0o644); err != nil {
 		return errors.Wrap(err, "chmod")
 	}
 

--- a/pkg/minikube/tunnel/route_darwin_test.go
+++ b/pkg/minikube/tunnel/route_darwin_test.go
@@ -19,13 +19,11 @@ limitations under the License.
 package tunnel
 
 import (
+	"fmt"
 	"net"
 	"os/exec"
-	"testing"
-
-	"fmt"
-
 	"reflect"
+	"testing"
 )
 
 func TestDarwinRouteFailsOnConflictIntegrationTest(t *testing.T) {
@@ -75,7 +73,6 @@ func TestDarwinRouteIdempotentIntegrationTest(t *testing.T) {
 }
 
 func TestDarwinRouteCleanupIdempontentIntegrationTest(t *testing.T) {
-
 	cfg := &Route{
 		Gateway: net.IPv4(192, 168, 1, 1),
 		DestCIDR: &net.IPNet{

--- a/pkg/minikube/tunnel/route_linux_test.go
+++ b/pkg/minikube/tunnel/route_linux_test.go
@@ -34,7 +34,8 @@ func TestLinuxRouteFailsOnConflictIntegrationTest(t *testing.T) {
 		DestCIDR: &net.IPNet{
 			IP:   net.IPv4(10, 96, 0, 0),
 			Mask: net.IPv4Mask(255, 240, 0, 0),
-		}})
+		},
+	})
 	if err == nil {
 		t.Errorf("add should have error, but it is nil")
 	}
@@ -66,7 +67,6 @@ func TestLinuxRouteIdempotentIntegrationTest(t *testing.T) {
 }
 
 func TestLinuxRouteCleanupIdempontentIntegrationTest(t *testing.T) {
-
 	r := &osRouter{}
 	route := &Route{
 		Gateway: net.IPv4(127, 0, 0, 1),
@@ -89,7 +89,6 @@ func TestLinuxRouteCleanupIdempontentIntegrationTest(t *testing.T) {
 }
 
 func TestParseTable(t *testing.T) {
-
 	const table = `default via 172.31.126.254 dev eno1 proto dhcp metric 100
 10.96.0.0/12 via 192.168.39.47 dev virbr1
 10.110.0.0/16 via 127.0.0.1 dev lo

--- a/pkg/minikube/tunnel/route_windows_test.go
+++ b/pkg/minikube/tunnel/route_windows_test.go
@@ -21,10 +21,9 @@ package tunnel
 import (
 	"net"
 	"os/exec"
-	"testing"
-
 	"reflect"
 	"strings"
+	"testing"
 )
 
 func TestWindowsRouteFailsOnConflictIntegrationTest(t *testing.T) {
@@ -149,7 +148,6 @@ Persistent Routes:
 	if !reflect.DeepEqual(rt.String(), expectedRt.String()) {
 		t.Errorf("expected:\n %s\ngot\n %s", expectedRt.String(), rt.String())
 	}
-
 }
 
 func addRoute(t *testing.T, dstIP string, dstMask string, gw string) {

--- a/pkg/minikube/tunnel/test_doubles.go
+++ b/pkg/minikube/tunnel/test_doubles.go
@@ -56,6 +56,7 @@ func (r *fakeRouter) EnsureRouteIsAdded(route *Route) error {
 	}
 	return r.errorResponse
 }
+
 func (r *fakeRouter) Cleanup(route *Route) error {
 	glog.V(4).Infof("fake router cleanup: %v\n", route)
 	if r.errorResponse == nil {

--- a/pkg/minikube/tunnel/tunnel.go
+++ b/pkg/minikube/tunnel/tunnel.go
@@ -19,7 +19,6 @@ package tunnel
 import (
 	"fmt"
 	"os"
-
 	"os/exec"
 	"regexp"
 
@@ -51,7 +50,6 @@ func newTunnel(machineName string, machineAPI libmachine.API, configLoader confi
 		configLoader: configLoader,
 	}
 	state, route, err := ci.getStateAndRoute()
-
 	if err != nil {
 		return nil, fmt.Errorf("unable to determine cluster info: %s", err)
 	}
@@ -81,7 +79,6 @@ func newTunnel(machineName string, machineAPI libmachine.API, configLoader confi
 			out: os.Stdout,
 		},
 	}, nil
-
 }
 
 type tunnel struct {
@@ -188,7 +185,6 @@ func setupRoute(t *tunnel, h *host.Host) {
 		t.status.RouteError = errorTunnelAlreadyExists(existingTunnel)
 		return
 	}
-
 }
 
 func setupBridge(t *tunnel) {

--- a/pkg/minikube/tunnel/tunnel_manager.go
+++ b/pkg/minikube/tunnel/tunnel_manager.go
@@ -17,11 +17,10 @@ limitations under the License.
 package tunnel
 
 import (
-	"path/filepath"
-	"time"
-
 	"context"
 	"fmt"
+	"path/filepath"
+	"time"
 
 	"github.com/docker/machine/libmachine"
 	"github.com/golang/glog"
@@ -65,8 +64,8 @@ func (mgr *Manager) StartTunnel(ctx context.Context, machineName string, machine
 		return nil, fmt.Errorf("error creating tunnel: %s", err)
 	}
 	return mgr.startTunnel(ctx, tunnel)
-
 }
+
 func (mgr *Manager) startTunnel(ctx context.Context, tunnel controller) (done chan bool, err error) {
 	glog.Info("Setting up tunnel...")
 

--- a/pkg/minikube/tunnel/tunnel_manager_test.go
+++ b/pkg/minikube/tunnel/tunnel_manager_test.go
@@ -17,10 +17,9 @@ limitations under the License.
 package tunnel
 
 import (
-	"testing"
-
 	"context"
 	"os"
+	"testing"
 	"time"
 
 	"github.com/golang/glog"
@@ -96,7 +95,6 @@ func TestTunnelManagerEventHandling(t *testing.T) {
 					<-ready
 					cancel()
 					check <- true
-
 				}()
 
 				select {
@@ -140,7 +138,6 @@ func TestTunnelManagerEventHandling(t *testing.T) {
 				}
 			}
 		})
-
 	}
 }
 
@@ -220,6 +217,7 @@ func registerNotRunningTunnels(reg *persistentRegistry) (*ID, *ID, error) {
 
 	return notRunningTunnel1, notRunningTunnel2, nil
 }
+
 func TestTunnelManagerCleanup(t *testing.T) {
 	reg, cleanup := createTestRegistry(t)
 	defer cleanup()
@@ -270,7 +268,6 @@ func TestTunnelManagerCleanup(t *testing.T) {
 	}
 
 	tunnels, err := reg.List()
-
 	if err != nil {
 		t.Errorf("expected no error got: %v", err)
 	}
@@ -280,7 +277,6 @@ func TestTunnelManagerCleanup(t *testing.T) {
 		!tunnels[1].Equal(runningTunnel2) {
 		t.Errorf("tunnels are not cleaned up properly, expected only running tunnels to stay, got: %v", tunnels)
 	}
-
 }
 
 type tunnelStub struct {

--- a/pkg/minikube/tunnel/tunnel_test.go
+++ b/pkg/minikube/tunnel/tunnel_test.go
@@ -18,24 +18,25 @@ package tunnel
 
 import (
 	"errors"
-
-	"github.com/docker/machine/libmachine/host"
-	"github.com/docker/machine/libmachine/state"
-	"k8s.io/minikube/pkg/minikube/config"
-	"k8s.io/minikube/pkg/minikube/tests"
-
 	"fmt"
 	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/docker/machine/libmachine/host"
+	"github.com/docker/machine/libmachine/state"
+	"k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/tests"
 )
 
-const RunningPid1 = 1234
-const RunningPid2 = 1235
-const NotRunningPid = 1236
-const NotRunningPid2 = 1237
+const (
+	RunningPid1    = 1234
+	RunningPid2    = 1235
+	NotRunningPid  = 1236
+	NotRunningPid2 = 1237
+)
 
 func mockPidChecker(pid int) (bool, error) {
 	if pid == NotRunningPid || pid == NotRunningPid2 {
@@ -276,7 +277,6 @@ func raceCondition1() tunnelTestCase {
 		machineIP:       "1.2.3.4",
 		mockPidHandling: true,
 		call: func(tunnel *tunnel) (*Status, error) {
-
 			err := tunnel.registry.Register(&ID{
 				Route:       unsafeParseRoute("1.2.3.4", "1.2.3.4/5"),
 				MachineName: "testmachine",
@@ -333,7 +333,6 @@ func raceCondition2() tunnelTestCase {
 		machineIP:       "1.2.3.4",
 		mockPidHandling: true,
 		call: func(tunnel *tunnel) (*Status, error) {
-
 			err := tunnel.registry.Register(&ID{
 				Route:       unsafeParseRoute("1.2.3.4", "1.2.3.4/5"),
 				MachineName: "testmachine",
@@ -426,7 +425,8 @@ func TestTunnel(t *testing.T) {
 				c: &config.ClusterConfig{
 					KubernetesConfig: config.KubernetesConfig{
 						ServiceCIDR: tc.serviceCIDR,
-					}},
+					},
+				},
 				e: tc.configLoaderError,
 			}
 
@@ -456,10 +456,8 @@ func TestTunnel(t *testing.T) {
 				routes = append(routes, r.route)
 			}
 			tc.assertion(t, returnedState, reporter.statesRecorded, routes, tunnels)
-
 		})
 	}
-
 }
 
 func TestErrorCreatingTunnel(t *testing.T) {
@@ -481,7 +479,8 @@ func TestErrorCreatingTunnel(t *testing.T) {
 		c: &config.ClusterConfig{
 			KubernetesConfig: config.KubernetesConfig{
 				ServiceCIDR: "10.96.0.0/12",
-			}},
+			},
+		},
 		e: errors.New("error loading machine"),
 	}
 

--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -62,7 +62,6 @@ func init() {
 	provision.Register("Ubuntu", &provision.RegisteredProvisioner{
 		New: NewUbuntuProvisioner,
 	})
-
 }
 
 // NewSystemdProvisioner is our fork of the same name in the upstream provision library, without the packages
@@ -130,7 +129,7 @@ func configureAuth(p miniProvisioner) error {
 func copyHostCerts(authOptions auth.Options) error {
 	glog.Infof("copyHostCerts")
 
-	err := os.MkdirAll(authOptions.StorePath, 0700)
+	err := os.MkdirAll(authOptions.StorePath, 0o700)
 	if err != nil {
 		glog.Errorf("mkdir failed: %v", err)
 	}

--- a/pkg/provision/ubuntu.go
+++ b/pkg/provision/ubuntu.go
@@ -181,7 +181,6 @@ func (p *UbuntuProvisioner) Provision(swarmOptions swarm.Options, authOptions au
 	}
 
 	err := retry.Expo(configAuth, 100*time.Microsecond, 2*time.Minute)
-
 	if err != nil {
 		glog.Infof("Error configuring auth during provisioning %v", err)
 		return err

--- a/pkg/storage/storage_provisioner.go
+++ b/pkg/storage/storage_provisioner.go
@@ -58,12 +58,12 @@ var _ controller.Provisioner = &hostPathProvisioner{}
 func (p *hostPathProvisioner) Provision(options controller.ProvisionOptions) (*core.PersistentVolume, error) {
 	glog.Infof("Provisioning volume %v", options)
 	path := path.Join(p.pvDir, options.PVC.Name)
-	if err := os.MkdirAll(path, 0777); err != nil {
+	if err := os.MkdirAll(path, 0o777); err != nil {
 		return nil, err
 	}
 
 	// Explicitly chmod created dir, so we know mode is set to 0777 regardless of umask
-	if err := os.Chmod(path, 0777); err != nil {
+	if err := os.Chmod(path, 0o777); err != nil {
 		return nil, err
 	}
 

--- a/pkg/util/crypto.go
+++ b/pkg/util/crypto.go
@@ -151,19 +151,19 @@ func writeCertsAndKeys(template *x509.Certificate, certPath string, signeeKey *r
 		return errors.Wrap(err, "Error encoding key")
 	}
 
-	if err := os.MkdirAll(filepath.Dir(certPath), os.FileMode(0755)); err != nil {
+	if err := os.MkdirAll(filepath.Dir(certPath), os.FileMode(0o755)); err != nil {
 		return errors.Wrap(err, "Error creating certificate directory")
 	}
 	glog.Infof("Writing cert to %s ...", certPath)
-	if err := lock.WriteFile(certPath, certBuffer.Bytes(), os.FileMode(0644)); err != nil {
+	if err := lock.WriteFile(certPath, certBuffer.Bytes(), os.FileMode(0o644)); err != nil {
 		return errors.Wrap(err, "Error writing certificate to cert path")
 	}
 
-	if err := os.MkdirAll(filepath.Dir(keyPath), os.FileMode(0755)); err != nil {
+	if err := os.MkdirAll(filepath.Dir(keyPath), os.FileMode(0o755)); err != nil {
 		return errors.Wrap(err, "Error creating key directory")
 	}
 	glog.Infof("Writing key to %s ...", keyPath)
-	if err := lock.WriteFile(keyPath, keyBuffer.Bytes(), os.FileMode(0600)); err != nil {
+	if err := lock.WriteFile(keyPath, keyBuffer.Bytes(), os.FileMode(0o600)); err != nil {
 		return errors.Wrap(err, "Error writing key file")
 	}
 

--- a/pkg/util/crypto_test.go
+++ b/pkg/util/crypto_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestGenerateCACert(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "")
-	defer func() { //clean up tempdir
+	defer func() { // clean up tempdir
 		err := os.RemoveAll(tmpDir)
 		if err != nil {
 			t.Errorf("failed to clean up temp folder  %q", tmpDir)
@@ -63,7 +63,7 @@ func TestGenerateCACert(t *testing.T) {
 
 func TestGenerateSignedCert(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "")
-	defer func() { //clean up tempdir
+	defer func() { // clean up tempdir
 		err := os.RemoveAll(tmpDir)
 		if err != nil {
 			t.Errorf("failed to clean up temp folder  %q", tmpDir)
@@ -74,7 +74,7 @@ func TestGenerateSignedCert(t *testing.T) {
 	}
 
 	signerTmpDir, err := ioutil.TempDir("", "")
-	defer func() { //clean up tempdir
+	defer func() { // clean up tempdir
 		err := os.RemoveAll(signerTmpDir)
 		if err != nil {
 			t.Errorf("failed to clean up temp folder  %q", signerTmpDir)
@@ -98,7 +98,7 @@ func TestGenerateSignedCert(t *testing.T) {
 	ips := []net.IP{net.ParseIP("192.168.99.100"), net.ParseIP("10.0.0.10")}
 	alternateDNS := []string{"kubernetes.default.svc.cluster.local", "kubernetes.default"}
 
-	var tests = []struct {
+	tests := []struct {
 		description    string
 		signerCertPath string
 		signerKeyPath  string
@@ -159,7 +159,6 @@ func TestGenerateSignedCert(t *testing.T) {
 					t.Errorf("Error parsing certificate: %v", err)
 				}
 			}
-
 		})
 	}
 }

--- a/pkg/util/lock/lock_test.go
+++ b/pkg/util/lock/lock_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestUserMutexSpec(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		description string
 		path        string
 		expected    string

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -43,7 +43,6 @@ func TestGetBinaryDownloadURL(t *testing.T) {
 			t.Fatalf("Expected '%s' but got '%s'", tt.expectedURL, url)
 		}
 	}
-
 }
 
 func TestCalculateSizeInMB(t *testing.T) {
@@ -88,7 +87,7 @@ func TestChownR(t *testing.T) {
 	if nil != err {
 		return
 	}
-	defer func() { //clean up tempdir
+	defer func() { // clean up tempdir
 		err := os.RemoveAll(testDir)
 		if err != nil {
 			t.Errorf("failed to clean up temp folder  %q", testDir)
@@ -142,7 +141,7 @@ func TestMaybeChownDirRecursiveToMinikubeUser(t *testing.T) {
 		return
 	}
 
-	defer func() { //clean up tempdir
+	defer func() { // clean up tempdir
 		err := os.RemoveAll(testDir)
 		if err != nil {
 			t.Errorf("failed to clean up temp folder  %q", testDir)

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -312,7 +312,6 @@ func validateHelmTillerAddon(ctx context.Context, t *testing.T, profile string) 
 	want := "Server: &version.Version"
 	// Test from inside the cluster (`helm version` use pod.list permission. we use tiller serviceaccount in kube-system to list pod)
 	checkHelmTiller := func() error {
-
 		rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "run", "--rm", "helm-test", "--restart=Never", "--image=alpine/helm:2.16.3", "-it", "--namespace=kube-system", "--serviceaccount=tiller", "--", "version"))
 		if err != nil {
 			return err

--- a/test/integration/cert_options_test.go
+++ b/test/integration/cert_options_test.go
@@ -76,5 +76,4 @@ func TestCertOptions(t *testing.T) {
 	if !strings.Contains(rr.Stdout.String(), "8555") {
 		t.Errorf("apiserver server port incorrect. Output of 'kubectl config view' = %q", rr.Output())
 	}
-
 }

--- a/test/integration/driver_install_or_update_test.go
+++ b/test/integration/driver_install_or_update_test.go
@@ -77,7 +77,7 @@ func TestKVMDriverInstallOrUpdate(t *testing.T) {
 		}
 
 		// change permission to allow driver to be executable
-		err = os.Chmod(filepath.Join(path, "docker-machine-driver-kvm2"), 0700)
+		err = os.Chmod(filepath.Join(path, "docker-machine-driver-kvm2"), 0o700)
 		if err != nil {
 			t.Fatalf("Expected not expected when changing driver permission. test: %s, got: %v", tc.name, err)
 		}
@@ -145,7 +145,7 @@ func TestHyperKitDriverInstallOrUpdate(t *testing.T) {
 		}
 
 		// change permission to allow driver to be executable
-		err = os.Chmod(filepath.Join(path, "docker-machine-driver-hyperkit"), 0700)
+		err = os.Chmod(filepath.Join(path, "docker-machine-driver-hyperkit"), 0o700)
 		if err != nil {
 			t.Fatalf("Expected not expected when changing driver permission. test: %s, got: %v", tc.name, err)
 		}

--- a/test/integration/fn_mount_cmd_test.go
+++ b/test/integration/fn_mount_cmd_test.go
@@ -56,7 +56,7 @@ func validateMountCmd(ctx context.Context, t *testing.T, profile string) { // no
 	}
 
 	tempDir, err := ioutil.TempDir("", "mounttest")
-	defer func() { //clean up tempdir
+	defer func() { // clean up tempdir
 		err := os.RemoveAll(tempDir)
 		if err != nil {
 			t.Errorf("failed to clean up %q temp folder.", tempDir)
@@ -102,7 +102,7 @@ func validateMountCmd(ctx context.Context, t *testing.T, profile string) { // no
 	wantFromTest := []byte(testMarker)
 	for _, name := range []string{createdByTest, createdByTestRemovedByPod, testMarker} {
 		p := filepath.Join(tempDir, name)
-		err := ioutil.WriteFile(p, wantFromTest, 0644)
+		err := ioutil.WriteFile(p, wantFromTest, 0o644)
 		t.Logf("wrote %q to %s", wantFromTest, p)
 		if err != nil {
 			t.Errorf("WriteFile %s: %v", p, err)

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -58,7 +58,6 @@ var apiPortTest = 8441
 
 // TestFunctional are functionality tests which can safely share a profile in parallel
 func TestFunctional(t *testing.T) {
-
 	profile := UniqueProfileName("functional")
 	ctx, cancel := context.WithTimeout(context.Background(), Minutes(40))
 	defer func() {
@@ -205,7 +204,6 @@ func validateDockerEnv(ctx context.Context, t *testing.T, profile string) {
 	if !strings.Contains(rr.Output(), expectedImgInside) {
 		t.Fatalf("expected 'docker images' to have %q inside minikube. but the output is: *%s*", expectedImgInside, rr.Output())
 	}
-
 }
 
 func validateStartWithProxy(ctx context.Context, t *testing.T, profile string) {
@@ -270,7 +268,6 @@ func validateSoftStart(ctx context.Context, t *testing.T, profile string) {
 	if afterCfg.Config.KubernetesConfig.NodePort != apiPortTest {
 		t.Errorf("expected node port in the config not change after soft start. exepceted node port to be %d but got %d.", apiPortTest, afterCfg.Config.KubernetesConfig.NodePort)
 	}
-
 }
 
 // validateKubeContext asserts that kubectl is properly configured (race-condition prone!)
@@ -509,14 +506,12 @@ func validateCacheCmd(ctx context.Context, t *testing.T, profile string) {
 			if !strings.Contains(rr.Output(), "1.28.4-glibc") {
 				t.Errorf("expected '1.28.4-glibc' to be in the output but got *%s*", rr.Output())
 			}
-
 		})
 
 		t.Run("cache_reload", func(t *testing.T) { // deleting image inside minikube node manually and expecting reload to bring it back
 			img := "busybox:latest"
 			// deleting image inside minikube node manually
 			rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "sudo", "docker", "rmi", img))
-
 			if err != nil {
 				t.Errorf("failed to delete inside the node %q : %v", rr.Command(), err)
 			}
@@ -615,7 +610,7 @@ func validateProfileCmd(ctx context.Context, t *testing.T, profile string) {
 		}
 		for profileK := range profileJSON {
 			for _, p := range profileJSON[profileK] {
-				var name = p["Name"]
+				name := p["Name"]
 				if name == nonexistentProfile {
 					t.Errorf("minikube profile %s should not exist", nonexistentProfile)
 				}
@@ -667,7 +662,6 @@ func validateProfileCmd(ctx context.Context, t *testing.T, profile string) {
 		if !profileExists {
 			t.Errorf("expected the json of 'profile list' to include %q but got *%q*. args: %q", profile, rr.Stdout.String(), rr.Command())
 		}
-
 	})
 }
 
@@ -1093,7 +1087,7 @@ users:
 					t.Fatal(err)
 				}
 
-				if err := ioutil.WriteFile(tf.Name(), tc.kubeconfig, 0644); err != nil {
+				if err := ioutil.WriteFile(tf.Name(), tc.kubeconfig, 0o644); err != nil {
 					t.Fatal(err)
 				}
 

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -34,15 +34,19 @@ import (
 var startArgs = flag.String("minikube-start-args", "", "Arguments to pass to minikube start")
 
 // Flags for faster local integration testing
-var forceProfile = flag.String("profile", "", "force tests to run against a particular profile")
-var cleanup = flag.Bool("cleanup", true, "cleanup failed test run")
-var enableGvisor = flag.Bool("gvisor", false, "run gvisor integration test (slow)")
-var postMortemLogs = flag.Bool("postmortem-logs", true, "show logs after a failed test run")
-var timeOutMultiplier = flag.Float64("timeout-multiplier", 1, "multiply the timeout for the tests")
+var (
+	forceProfile      = flag.String("profile", "", "force tests to run against a particular profile")
+	cleanup           = flag.Bool("cleanup", true, "cleanup failed test run")
+	enableGvisor      = flag.Bool("gvisor", false, "run gvisor integration test (slow)")
+	postMortemLogs    = flag.Bool("postmortem-logs", true, "show logs after a failed test run")
+	timeOutMultiplier = flag.Float64("timeout-multiplier", 1, "multiply the timeout for the tests")
+)
 
 // Paths to files - normally set for CI
-var binaryPath = flag.String("binary", "../../out/minikube", "path to minikube binary")
-var testdataDir = flag.String("testdata-dir", "testdata", "the directory relative to test/integration where the testdata lives")
+var (
+	binaryPath  = flag.String("binary", "../../out/minikube", "path to minikube binary")
+	testdataDir = flag.String("testdata-dir", "testdata", "the directory relative to test/integration where the testdata lives")
+)
 
 // Node names are consistent, let's store these for easy access later
 const (
@@ -63,7 +67,6 @@ func TestMain(m *testing.M) {
 
 // setMaxParallelism caps the max parallelism. Go assumes 1 core per test, whereas minikube needs 2 cores per test.
 func setMaxParallelism() {
-
 	flagVal := flag.Lookup("test.parallel").Value.String()
 	requested, err := strconv.Atoi(flagVal)
 	if err != nil {

--- a/test/integration/multinode_test.go
+++ b/test/integration/multinode_test.go
@@ -84,7 +84,6 @@ func validateMultiNodeStart(ctx context.Context, t *testing.T, profile string) {
 	if strings.Count(rr.Stdout.String(), "kubelet: Running") != 2 {
 		t.Errorf("status says both kubelets are not running: args %q: %v", rr.Command(), rr.Stdout.String())
 	}
-
 }
 
 func validateAddNodeToMultiNode(ctx context.Context, t *testing.T, profile string) {
@@ -263,7 +262,6 @@ func validateRestartMultiNodeCluster(ctx context.Context, t *testing.T, profile 
 }
 
 func validateDeleteNodeFromMultiNode(ctx context.Context, t *testing.T, profile string) {
-
 	// Start the node back up
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "node", "delete", ThirdNodeName))
 	if err != nil {
@@ -293,5 +291,4 @@ func validateDeleteNodeFromMultiNode(ctx context.Context, t *testing.T, profile 
 			t.Errorf("docker volume was not properly deleted: %s", rr.Stdout.String())
 		}
 	}
-
 }

--- a/test/integration/net_test.go
+++ b/test/integration/net_test.go
@@ -116,7 +116,6 @@ func TestNetworkPlugins(t *testing.T) {
 								t.Errorf("expected --network-plugin=%s, got %s", tc.kubeletPlugin, out)
 							}
 						}
-
 					})
 				}
 
@@ -139,7 +138,6 @@ func TestNetworkPlugins(t *testing.T) {
 						if _, err := PodWait(ctx, t, profile, "default", "app=netcat", Minutes(15)); err != nil {
 							t.Fatalf("failed waiting for netcat pod: %v", err)
 						}
-
 					})
 				}
 

--- a/test/integration/pause_test.go
+++ b/test/integration/pause_test.go
@@ -164,5 +164,4 @@ func validateVerifyDeleted(ctx context.Context, t *testing.T, profile string) {
 		}
 
 	}
-
 }

--- a/test/integration/skaffold_test.go
+++ b/test/integration/skaffold_test.go
@@ -126,7 +126,7 @@ func installSkaffold() (f *os.File, err error) {
 	}
 
 	if runtime.GOOS != "windows" {
-		if err := os.Chmod(tf.Name(), 0700); err != nil {
+		if err := os.Chmod(tf.Name(), 0o700); err != nil {
 			return tf, err
 		}
 	}

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -141,9 +141,7 @@ func TestStartStop(t *testing.T) {
 							t.Errorf("expected exit code 1, got %d. output: %s", rr.ExitCode, rr.Output())
 						}
 					}
-
 				})
-
 			})
 		}
 	})
@@ -187,7 +185,6 @@ func validateEnableAddonAfterStop(ctx context.Context, t *testing.T, profile str
 	if err != nil {
 		t.Errorf("failed to enable an addon post-stop. args %q: %v", rr.Command(), err)
 	}
-
 }
 
 func validateSecondStart(ctx context.Context, t *testing.T, profile string, tcName string, tcVersion string, startArgs []string) {
@@ -202,7 +199,6 @@ func validateSecondStart(ctx context.Context, t *testing.T, profile string, tcNa
 	if got != state.Running.String() {
 		t.Errorf("expected host status after start-stop-start to be -%q- but got *%q*", state.Running, got)
 	}
-
 }
 
 // validateAppExistsAfterStop verifies that a user's app will not vanish after a minikube stop
@@ -213,7 +209,6 @@ func validateAppExistsAfterStop(ctx context.Context, t *testing.T, profile strin
 	} else if _, err := PodWait(ctx, t, profile, "kubernetes-dashboard", "k8s-app=kubernetes-dashboard", Minutes(9)); err != nil {
 		t.Errorf("failed waiting for 'addon dashboard' pod post-stop-start: %v", err)
 	}
-
 }
 
 // validateAddonAfterStop validates that an addon which was enabled when minikube is stopped will be enabled and working..
@@ -352,7 +347,6 @@ func testPause(ctx context.Context, t *testing.T, profile string) {
 	if got != state.Running.String() {
 		t.Errorf("post-unpause kubelet status = %q; want = %q", got, state.Running)
 	}
-
 }
 
 // defaultImage returns true if this image is expected in a default minikube install

--- a/test/integration/testdata/skaffold/leeroy-web/web.go
+++ b/test/integration/testdata/skaffold/leeroy-web/web.go
@@ -2,9 +2,8 @@ package main
 
 import (
 	"io"
-	"net/http"
-
 	"log"
+	"net/http"
 )
 
 func handler(w http.ResponseWriter, r *http.Request) {

--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -50,7 +50,7 @@ func installRelease(version string) (f *os.File, err error) {
 	}
 
 	if runtime.GOOS != "windows" {
-		if err := os.Chmod(tf.Name(), 0700); err != nil {
+		if err := os.Chmod(tf.Name(), 0o700); err != nil {
 			return tf, err
 		}
 	}

--- a/third_party/go9p/clnt_clnt.go
+++ b/third_party/go9p/clnt_clnt.go
@@ -79,9 +79,11 @@ type ClntList struct {
 	clntList, clntLast *Clnt
 }
 
-var clnts *ClntList
-var DefaultDebuglevel int
-var DefaultLogger *Logger
+var (
+	clnts             *ClntList
+	DefaultDebuglevel int
+	DefaultLogger     *Logger
+)
 
 func (clnt *Clnt) Rpcnb(r *Req) error {
 	var tag uint16

--- a/third_party/go9p/fmt.go
+++ b/third_party/go9p/fmt.go
@@ -45,7 +45,7 @@ func permToString(perm uint32) string {
 		ret += "L"
 	}
 
-	ret += fmt.Sprintf("%o", perm&0777)
+	ret += fmt.Sprintf("%o", perm&0o777)
 	return ret
 }
 

--- a/third_party/go9p/p9.go
+++ b/third_party/go9p/p9.go
@@ -486,7 +486,6 @@ func UnpackDir(buf []byte, dotu bool) (d *Dir, b []byte, amt int, err error) {
 	}
 
 	return d, b, len(buf) - len(b), nil
-
 }
 
 // Allocates a new Fcall.

--- a/third_party/go9p/srv_conn.go
+++ b/third_party/go9p/srv_conn.go
@@ -165,7 +165,6 @@ func (conn *Conn) recv() {
 			pos -= fcsize
 		}
 	}
-
 }
 
 func (conn *Conn) send() {

--- a/third_party/go9p/srv_fcall.go
+++ b/third_party/go9p/srv_fcall.go
@@ -84,7 +84,6 @@ func (srv *Srv) auth(req *SrvReq) {
 	} else {
 		req.RespondError(Enoauth)
 	}
-
 }
 
 func (srv *Srv) authPost(req *SrvReq) {

--- a/third_party/go9p/srv_file.go
+++ b/third_party/go9p/srv_file.go
@@ -105,11 +105,13 @@ type Fsrv struct {
 	Root *srvFile
 }
 
-var lock sync.Mutex
-var qnext uint64
-var Eexist = &Error{"file already exists", EEXIST}
-var Enoent = &Error{"file not found", ENOENT}
-var Enotempty = &Error{"directory not empty", EPERM}
+var (
+	lock      sync.Mutex
+	qnext     uint64
+	Eexist    = &Error{"file already exists", EEXIST}
+	Enoent    = &Error{"file not found", ENOENT}
+	Enotempty = &Error{"directory not empty", EPERM}
+)
 
 // Creates a file server with root as root directory
 func NewsrvFileSrv(root *srvFile) *Fsrv {
@@ -123,7 +125,6 @@ func NewsrvFileSrv(root *srvFile) *Fsrv {
 // Initializes the fields of a file and add it to a directory.
 // Returns nil if successful, or an error.
 func (f *srvFile) Add(dir *srvFile, name string, uid User, gid Group, mode uint32, ops interface{}) error {
-
 	lock.Lock()
 	qpath := qnext
 	qnext++
@@ -478,7 +479,6 @@ func (*Fsrv) Write(req *SrvReq) {
 	} else {
 		req.RespondError(Eperm)
 	}
-
 }
 
 func (*Fsrv) Clunk(req *SrvReq) {

--- a/third_party/go9p/srv_pipe.go
+++ b/third_party/go9p/srv_pipe.go
@@ -167,7 +167,7 @@ func (*Pipefs) Create(req *SrvReq) {
 	var file *os.File = nil
 	switch {
 	case tc.Perm&DMDIR != 0:
-		e = os.Mkdir(path, os.FileMode(tc.Perm&0777))
+		e = os.Mkdir(path, os.FileMode(tc.Perm&0o777))
 
 	case tc.Perm&DMSYMLINK != 0:
 		e = os.Symlink(tc.Ext, path)
@@ -193,7 +193,7 @@ func (*Pipefs) Create(req *SrvReq) {
 		return
 
 	default:
-		var mode uint32 = tc.Perm & 0777
+		var mode uint32 = tc.Perm & 0o777
 		if req.Conn.Dotu {
 			if tc.Perm&DMSETUID > 0 {
 				mode |= syscall.S_ISUID

--- a/third_party/go9p/srv_srv.go
+++ b/third_party/go9p/srv_srv.go
@@ -21,18 +21,20 @@ const (
 	reqSaved                             /* no response was produced after the request is worked on */
 )
 
-var Eunknownfid error = &Error{"unknown fid", EINVAL}
-var Enoauth error = &Error{"no authentication required", EINVAL}
-var Einuse error = &Error{"fid already in use", EINVAL}
-var Ebaduse error = &Error{"bad use of fid", EINVAL}
-var Eopen error = &Error{"fid already opened", EINVAL}
-var Enotdir error = &Error{"not a directory", ENOTDIR}
-var Eperm error = &Error{"permission denied", EPERM}
-var Etoolarge error = &Error{"i/o count too large", EINVAL}
-var Ebadoffset error = &Error{"bad offset in directory read", EINVAL}
-var Edirchange error = &Error{"cannot convert between files and directories", EINVAL}
-var Enouser error = &Error{"unknown user", EINVAL}
-var Enotimpl error = &Error{"not implemented", EINVAL}
+var (
+	Eunknownfid error = &Error{"unknown fid", EINVAL}
+	Enoauth     error = &Error{"no authentication required", EINVAL}
+	Einuse      error = &Error{"fid already in use", EINVAL}
+	Ebaduse     error = &Error{"bad use of fid", EINVAL}
+	Eopen       error = &Error{"fid already opened", EINVAL}
+	Enotdir     error = &Error{"not a directory", ENOTDIR}
+	Eperm       error = &Error{"permission denied", EPERM}
+	Etoolarge   error = &Error{"i/o count too large", EINVAL}
+	Ebadoffset  error = &Error{"bad offset in directory read", EINVAL}
+	Edirchange  error = &Error{"cannot convert between files and directories", EINVAL}
+	Enouser     error = &Error{"unknown user", EINVAL}
+	Enotimpl    error = &Error{"not implemented", EINVAL}
+)
 
 // Authentication operations. The file server should implement them if
 // it requires user authentication. The authentication in 9P2000 is

--- a/third_party/go9p/srv_stats_http.go
+++ b/third_party/go9p/srv_stats_http.go
@@ -9,9 +9,11 @@ import (
 	"sync"
 )
 
-var mux sync.RWMutex
-var stat map[string]http.Handler
-var httponce sync.Once
+var (
+	mux      sync.RWMutex
+	stat     map[string]http.Handler
+	httponce sync.Once
+)
 
 func register(s string, h http.Handler) {
 	mux.Lock()
@@ -26,6 +28,7 @@ func register(s string, h http.Handler) {
 	}
 	mux.Unlock()
 }
+
 func (srv *Srv) statsRegister() {
 	httponce.Do(func() {
 		http.HandleFunc("/go9p/", StatsHandler)

--- a/third_party/go9p/ufs.go
+++ b/third_party/go9p/ufs.go
@@ -95,7 +95,7 @@ func dir2QidType(d os.FileInfo) uint8 {
 }
 
 func dir2Npmode(d os.FileInfo, dotu bool) uint32 {
-	ret := uint32(d.Mode() & 0777)
+	ret := uint32(d.Mode() & 0o777)
 	if d.IsDir() {
 		ret |= DMDIR
 	}
@@ -258,7 +258,7 @@ func (*Ufs) Create(req *SrvReq) {
 	var file *os.File = nil
 	switch {
 	case tc.Perm&DMDIR != 0:
-		e = os.Mkdir(path, os.FileMode(tc.Perm&0777))
+		e = os.Mkdir(path, os.FileMode(tc.Perm&0o777))
 
 	case tc.Perm&DMSYMLINK != 0:
 		e = os.Symlink(tc.Ext, path)
@@ -284,7 +284,7 @@ func (*Ufs) Create(req *SrvReq) {
 		return
 
 	default:
-		var mode uint32 = tc.Perm & 0777
+		var mode uint32 = tc.Perm & 0o777
 		if req.Conn.Dotu {
 			if tc.Perm&DMSETUID > 0 {
 				mode |= syscall.S_ISUID

--- a/third_party/go9p/ufs_darwin.go
+++ b/third_party/go9p/ufs_darwin.go
@@ -131,7 +131,7 @@ func (u *Ufs) Wstat(req *SrvReq) {
 
 	dir := &req.Tc.Dir
 	if dir.Mode != 0xFFFFFFFF {
-		mode := dir.Mode & 0777
+		mode := dir.Mode & 0o777
 		if req.Conn.Dotu {
 			if dir.Mode&DMSETUID > 0 {
 				mode |= syscall.S_ISUID

--- a/third_party/go9p/ufs_freebsd.go
+++ b/third_party/go9p/ufs_freebsd.go
@@ -131,7 +131,7 @@ func (u *Ufs) Wstat(req *SrvReq) {
 
 	dir := &req.Tc.Dir
 	if dir.Mode != 0xFFFFFFFF {
-		mode := dir.Mode & 0777
+		mode := dir.Mode & 0o777
 		if req.Conn.Dotu {
 			if dir.Mode&DMSETUID > 0 {
 				mode |= syscall.S_ISUID

--- a/third_party/go9p/ufs_linux.go
+++ b/third_party/go9p/ufs_linux.go
@@ -127,7 +127,7 @@ func (u *Ufs) Wstat(req *SrvReq) {
 
 	dir := &req.Tc.Dir
 	if dir.Mode != 0xFFFFFFFF {
-		mode := dir.Mode & 0777
+		mode := dir.Mode & 0o777
 		if req.Conn.Dotu {
 			if dir.Mode&DMSETUID > 0 {
 				mode |= syscall.S_ISUID

--- a/third_party/go9p/ufs_windows.go
+++ b/third_party/go9p/ufs_windows.go
@@ -143,7 +143,7 @@ func (u *Ufs) Wstat(req *SrvReq) {
 
 	dir := &req.Tc.Dir
 	if dir.Mode != 0xFFFFFFFF {
-		mode := dir.Mode & 0777
+		mode := dir.Mode & 0o777
 		if req.Conn.Dotu {
 			if dir.Mode&DMSETUID > 0 {
 				mode |= syscall.S_ISUID

--- a/third_party/go9p/unpack.go
+++ b/third_party/go9p/unpack.go
@@ -29,9 +29,11 @@ func Unpack(buf []byte, dotu bool) (fc *Fcall, err error, fcsz int) {
 	fc.Tag, p = gint16(p)
 
 	if int(fc.Size) > len(buf) || fc.Size < 7 {
-		return nil, &Error{fmt.Sprintf("buffer too short: %d expected %d",
-				len(buf), fc.Size),
-				EINVAL},
+		return nil, &Error{
+				fmt.Sprintf("buffer too short: %d expected %d",
+					len(buf), fc.Size),
+				EINVAL,
+			},
 			0
 	}
 
@@ -218,7 +220,7 @@ func Unpack(buf []byte, dotu bool) (fc *Fcall, err error, fcsz int) {
 		goto szerror
 	}
 
-	return //NOSONAR
+	return // NOSONAR
 
 szerror:
 	return nil, &Error{"invalid size", EINVAL}, 0


### PR DESCRIPTION
This is a style-only is to prepare for a future refactor of how exit codes are handled:

`find . -name "*.go" | xargs -P30 gofumports -w`
