### PR TITLE
kic base image: install stable containerd and clean up packages

### DIFF
--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -4,39 +4,54 @@ ARG COMMIT_SHA
 # could be changed to any debian that can run systemd
 FROM kindest/base:v20200430-2c0eee40 as base
 USER root
-# specify version of everything explicitly using 'apt-cache policy'
-RUN apt-get update && apt-get install -y --no-install-recommends \
+
+# remove files that were installed by kind, replaced by packages
+RUN rm \
+    /etc/crictl.yaml \
+    /etc/systemd/system/multi-user.target.wants/containerd.service \
+    /opt/cni/bin/host-local \
+    /opt/cni/bin/loopback \
+    /opt/cni/bin/portmap \
+    /opt/cni/bin/ptp \
+    /usr/local/bin/containerd \
+    /usr/local/bin/containerd-shim \
+    /usr/local/bin/containerd-shim-runc-v2 \
+    /usr/local/bin/crictl \
+    /usr/local/bin/ctr \
+    /usr/local/sbin/runc
+
+# install system requirements from the regular distro repositories
+RUN clean-install \
     lz4 \
     gnupg \ 
     sudo \
     docker.io \
+    containerd \
     openssh-server \
     dnsutils \
     runc \
     # libglib2.0-0 is required for conmon, which is required for podman
-    libglib2.0-0 \
-    # removing kind's crictl config
-    && rm /etc/crictl.yaml
+    libglib2.0-0
 
 # Install cri-o/podman dependencies:
 RUN sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list" && \ 
     curl -LO https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_20.04/Release.key && \
-    apt-key add - < Release.key && apt-get update && \
-    apt-get install -y --no-install-recommends containers-common catatonit conmon containernetworking-plugins podman-plugins varlink
+    apt-key add - < Release.key && \
+    clean-install containers-common catatonit conmon containernetworking-plugins cri-tools podman-plugins varlink
 
 # install cri-o based on https://github.com/cri-o/cri-o/commit/96b0c34b31a9fc181e46d7d8e34fb8ee6c4dc4e1#diff-04c6e90faac2675aa89e2176d2eec7d8R128
 RUN sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.18:/1.18.3/xUbuntu_20.04/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list" && \
     curl -LO https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.18:/1.18.3/xUbuntu_20.04/Release.key && \
-    apt-key add - < Release.key && apt-get update && \
-    apt-get install -y --no-install-recommends cri-o=1.18.3~3
+    apt-key add - < Release.key && \
+    clean-install cri-o=1.18.3~3
 
 # install podman
 RUN sh -c "echo 'deb https://dl.bintray.com/afbjorklund/podman focal main' > /etc/apt/sources.list.d/podman.list" && \
     curl -L https://bintray.com/user/downloadSubjectPublicKey?username=afbjorklund -o afbjorklund-public.key.asc && \
-    apt-key add - < afbjorklund-public.key.asc && apt-get update && \
-    apt-get install -y --no-install-recommends podman=1.9.3~1
+    apt-key add - < afbjorklund-public.key.asc && \
+    clean-install podman=1.9.3~1
 
-RUN mkdir -p /usr/lib/cri-o-runc/sbin && cp /usr/local/sbin/runc /usr/lib/cri-o-runc/sbin/runc
+RUN mkdir -p /usr/lib/cri-o-runc/sbin && cp /usr/sbin/runc /usr/lib/cri-o-runc/sbin/runc
 
 COPY entrypoint /usr/local/bin/entrypoint
 # automount service
@@ -71,12 +86,7 @@ USER root
 # https://github.com/kubernetes-sigs/kind/blob/master/images/base/files/usr/local/bin/entrypoint
 RUN mkdir -p /kind
 # Deleting leftovers
-RUN apt-get clean -y && rm -rf \
-  /var/cache/debconf/* \
-  /var/lib/apt/lists/* \
-  /var/log/* \
-  /tmp/* \
-  /var/tmp/* \
+RUN rm -rf \
   /usr/share/doc/* \
   /usr/share/man/* \
   /usr/share/local/* \

--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -8,6 +8,7 @@ USER root
 # remove files that were installed by kind, replaced by packages
 RUN rm \
     /etc/crictl.yaml \
+    /etc/systemd/system/containerd.service \
     /etc/systemd/system/multi-user.target.wants/containerd.service \
     /opt/cni/bin/host-local \
     /opt/cni/bin/loopback \


### PR DESCRIPTION
Remove local things from kind, replace with packages.

Use the "clean-install" script for a nicer Dockerfile.

Fixes #8767

----

Here is the diff, from `container-diff`:

```
-----File-----

These entries have been added to gcr.io/k8s-minikube/kicbase:v0.0.12-snapshot3:
FILE                                        SIZE
/usr/bin/crictl                             20.8M
/var/lib/dpkg/info/cri-tools.list           263B
/var/lib/dpkg/info/cri-tools.md5sums        325B

These entries have been deleted from gcr.io/k8s-minikube/kicbase:v0.0.12-snapshot3:
FILE                                          SIZE
/usr/local/bin/containerd                     52.8M
/usr/local/bin/containerd-shim                7.1M
/usr/local/bin/containerd-shim-runc-v2        8.7M
/usr/local/bin/crictl                         27.1M
/usr/local/bin/ctr                            26.3M
/usr/local/sbin/runc                          9.4M

These entries have been changed between gcr.io/k8s-minikube/kicbase:v0.0.12-snapshot3 and local/kicbase:v0.0.12-snapshot3-snapshot:
FILE                                                          SIZE1        SIZE2
/usr/lib/cri-o-runc/sbin/runc                                 9.4M         7.1M
/opt/cni/bin/dhcp                                             8.6M         8.9M
/opt/cni/bin/firewall                                         4.2M         4.2M
/opt/cni/bin/bridge                                           3.2M         3.2M
/opt/cni/bin/ptp                                              3.2M         3.2M
/opt/cni/bin/macvlan                                          3M           3.1M
/opt/cni/bin/ipvlan                                           3M           3M
/opt/cni/bin/vlan                                             3M           3M
/opt/cni/bin/bandwidth                                        2.9M         2.9M
/opt/cni/bin/host-device                                      2.9M         2.9M
/opt/cni/bin/portmap                                          2.7M         2.7M
/opt/cni/bin/host-local                                       2.5M         2.5M
/opt/cni/bin/sbr                                              2.3M         2.5M
/opt/cni/bin/tuning                                           2.3M         2.5M
/opt/cni/bin/loopback                                         2.2M         2.4M
/opt/cni/bin/flannel                                          2.1M         2.4M
/opt/cni/bin/static                                           2M           2.2M
/var/lib/dpkg/status                                          187K         187.3K
/var/lib/dpkg/status-old                                      187K         187.3K
/usr/share/containers/containers.conf                         12.7K        12.7K
/var/cache/ldconfig/aux-cache                                 9.8K         9.8K
/var/lib/apt/extended_states                                  4.8K         4.8K
/etc/ssh/ssh_host_rsa_key                                     2.5K         2.5K
/var/lib/dpkg/info/containernetworking-plugins.md5sums        1K           1K
/etc/shadow-                                                  772B         772B
/etc/shadow                                                   772B         772B
/etc/ssh/ssh_host_rsa_key.pub                                 571B         571B
/etc/ssh/ssh_host_ecdsa_key                                   513B         513B
/etc/ssh/ssh_host_ed25519_key                                 411B         411B
/var/lib/dpkg/info/containers-common.md5sums                  300B         300B
/etc/ssh/ssh_host_ecdsa_key.pub                               179B         179B
/etc/ssh/ssh_host_ed25519_key.pub                             99B          99B

```