### PR TITLE
Repair kubecontext before checking cluster health

### DIFF
--- a/pkg/minikube/kubeconfig/kubeconfig.go
+++ b/pkg/minikube/kubeconfig/kubeconfig.go
@@ -125,6 +125,7 @@ func UpdateEndpoint(contextName string, hostname string, port int, confpath stri
 
 	// if the cluster setting is missed in the kubeconfig, create new one
 	if _, ok := cfg.Clusters[contextName]; !ok {
+		glog.Infof("%q context is missing from %s - will repair!", contextName, confpath)
 		lp := localpath.Profile(contextName)
 		gp := localpath.MiniPath()
 		kcs := &Settings{


### PR DESCRIPTION
This fixes this ugly error noticed by @marlongamez and myself:

`🤦  Unable to restart cluster, will reset it: getting k8s client: client config: client config: context "minikube" does not exist`

With this PR, we no longer unnecessarily call `kubeadm reset` if the only thing wrong with the cluster is a missing kube config entry. This reduces restart time from 73.83s to 5.4s in this particular scenario:

`minikube start && sleep 30 && rm $HOME/.kube/config && minikube start` 