### PR TITLE
Remove conflicting & inaccurate Docker Desktop memory warning

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -868,15 +868,6 @@ func validateRequestedMemorySize(req int, drvName string) {
 		out.WarnReason(reason.RsrcInsufficientReqMemory, "Requested memory allocation ({{.requested}}MB) is less than the recommended minimum {{.recommend}}MB. Deployments may fail.", out.V{"requested": req, "recommend": minRecommendedMem})
 	}
 
-	if driver.IsDockerDesktop(drvName) && containerLimit < 2997 && sysLimit > 8000 { // for users with more than 8 GB advice 3 GB
-		r := reason.RsrcInsufficientDarwinDockerMemory
-		if runtime.GOOS == "Windows" {
-			r = reason.RsrcInsufficientWindowsDockerMemory
-		}
-		r.Style = style.Improvement
-		out.WarnReason(r, "Docker Desktop has access to only {{.size}}MiB of the {{.sys}}MiB in available system memory. Consider increasing this for improved performance.", out.V{"size": containerLimit, "sys": sysLimit, "recommend": "3 GB"})
-	}
-
 	advised := suggestMemoryAllocation(sysLimit, containerLimit, viper.GetInt(nodes))
 	if req > sysLimit {
 		exitIfNotForced(reason.Kind{ID: "RSRC_OVER_ALLOC_MEM", Advice: "Start minikube with less memory allocated: 'minikube start --memory={{.advised}}mb'"},


### PR DESCRIPTION
I propose we remove this warning for a couple of reasons:

* The 3GB recommendation here conflicts with the 2.25 GB recommendation we make 18 lines above it.

* This puts us in an awkward position of providing conflicting advice: we first ask the user to increase to 2.25GB, then we warn that they haven't increased it to 3GB

* I have observed no performance degradation with 2GB of memory. Intuitively, with the exception of OOM pressure, the amount of memory has little measurable effect on Kubernetes performance. I would be willing to accept measurements that disprove this assertion, however.

* If there was a warning to be made here, there is nothing that should make it a Docker Desktop specific warning

* For people who intentionally allocate only 2GB of memory, the warning is noisy and there is no way to turn it off.

Fixes #8892