### PR TITLE
Disable swap in Docker & podman containers

### DIFF
--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -177,9 +177,14 @@ func CreateContainerNode(p CreateParams) error {
 
 	if p.OCIBinary == Podman && memcgSwap { // swap is required for memory
 		runArgs = append(runArgs, fmt.Sprintf("--memory=%s", p.Memory))
+		// Disable swap by setting the value to match
+		runArgs = append(runArgs, fmt.Sprintf("--memory-swap=%s", p.Memory))
 	}
-	if p.OCIBinary == Docker { // swap is only required for --memory-swap
+
+	if p.OCIBinary == Docker {
 		runArgs = append(runArgs, fmt.Sprintf("--memory=%s", p.Memory))
+		// Disable swap by setting the value to match
+		runArgs = append(runArgs, fmt.Sprintf("--memory-swap=%s", p.Memory))
 	}
 
 	// https://www.freedesktop.org/wiki/Software/systemd/ContainerInterface/


### PR DESCRIPTION
This fixes the performance degradation issues seen when Docker is used with limited RAM.

For example, with 1GB allocated to Docker Desktop, minikube suffers a ~28% performance hit without this PR. With this PR, it performs the same as if there was 4GB of memory.

NOTE: The Docker kernel will still swap, and swap will still show up in `free`, as it is not cgroups aware. This merely keeps processes launched within minikube container from swapping.

Related PR: #9144

Fixes: #8892 by ensuring that Docker has the same performance characteristics as our ISO -- less RAM does not make it slower.