### PR TITLE
start: fixed the type value for kubectl version mismatch to warning

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -421,7 +421,7 @@ func showKubectlInfo(kcs *kubeconfig.Settings, k8sVersion string, machineName st
 		out.Ln("")
 		out.WarningT("{{.path}} is version {{.client_version}}, which may be incompatible with Kubernetes {{.cluster_version}}.",
 			out.V{"path": path, "client_version": client, "cluster_version": cluster})
-		out.ErrT(style.Tip, "You can also use 'minikube kubectl -- get pods' to invoke a matching version",
+		out.WarningT("You can also use 'minikube kubectl -- get pods' to invoke a matching version",
 			out.V{"path": path, "client_version": client})
 	}
 	return nil


### PR DESCRIPTION
This PR addresses code changes that fix the value for type from "type":"io.k8s.sigs.minikube.error" to "type":"io.k8s.sigs.minikube.warning" for the kubectl version mismatch.

Before:
```
{"data":{"message":"/home/vinu/go_workspace/bin/kubectl is version 1.20.0-alpha.0.188+65a1f24b205ece-dirty, which may be incompatible with Kubernetes 1.19.0."},"datacontenttype":"application/json","id":"aa1a2e48-2cd6-4c31-818e-d408cd16894e","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.warning"}
{"data":{"message":"You can also use 'minikube kubectl -- get pods' to invoke a matching version"},"datacontenttype":"application/json","id":"9ee30007-ce04-4140-ad2f-7c0b65e4dab3","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.error"}

```

After:
```
{"data":{"message":"/home/vinu/go_workspace/bin/kubectl is version 1.20.0-alpha.0.188+65a1f24b205ece-dirty, which may be incompatible with Kubernetes 1.19.0."},"datacontenttype":"application/json","id":"fa37ebd3-f512-49e3-91b7-b68d7752847e","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.warning"}
{"data":{"message":"You can also use 'minikube kubectl -- get pods' to invoke a matching version"},"datacontenttype":"application/json","id":"a1ce4f17-7980-4cdd-84b7-00de4993110c","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.warning"}
```