### PR TITLE
Increase preload version to v6

### DIFF
--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -41,7 +41,7 @@ const (
 	// PreloadVersion is the current version of the preloaded tarball
 	//
 	// NOTE: You may need to bump this version up when upgrading auxiliary docker images
-	PreloadVersion = "v5"
+	PreloadVersion = "v6"
 	// PreloadBucket is the name of the GCS bucket where preloaded volume tarballs exist
 	PreloadBucket = "minikube-preloaded-volume-tarballs"
 )


### PR DESCRIPTION
We upgraded the dashboard image in #9129, this will rebuild tarballs to include the latest version.

This should also fix a small performance regression, where start time was increased by 25% on kvm2, probably because preload failed and we were waiting for the new dashboard image to download. [PR bot comment](https://github.com/kubernetes/minikube/pull/9129#issuecomment-684035146)

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
