### PR TITLE
added warning for changing mount configuration with KiC driver on exsting cluster

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -210,7 +210,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		if viper.GetBool(createMount) {
 			mount := viper.GetString(mountString)
 			if len(existing.ContainerVolumeMounts) != 1 || existing.ContainerVolumeMounts[0] != mount {
-				out.WarningT("Due to the limitations of {{.driver}}, it's not possible to change mount configuration of an existing cluster.", out.V{"driver": existing.Driver})
+				out.WarningT("Due to the limitations of {{.driver}}, it's not possible to the change mount configuration of an existing cluster.", out.V{"driver": existing.Driver})
 				out.WarningT("If necessary delete and recreate the cluster, proceeding with old mount configuration")
 			}
 		}

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -206,14 +206,24 @@ func runStart(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	if existing != nil && existing.KubernetesConfig.ContainerRuntime == "crio" && driver.IsKIC(existing.Driver) {
-		// Stop and start again if it's crio because it's broken above v1.17.3
-		out.WarningT("Due to issues with CRI-O post v1.17.3, we need to restart your cluster.")
-		out.WarningT("See details at https://github.com/kubernetes/minikube/issues/8861")
-		stopProfile(existing.Name)
-		starter, err = provisionWithDriver(cmd, ds, existing)
-		if err != nil {
-			exit.Error(reason.GuestProvision, "error provisioning host", err)
+	if existing != nil && driver.IsKIC(existing.Driver) {
+		if viper.GetBool(createMount) {
+			mount := viper.GetString(mountString)
+			if len(existing.ContainerVolumeMounts) != 1 || existing.ContainerVolumeMounts[0] != mount {
+				out.WarningT("Due to the limitations of %s, it's not possible to change mount configuration of an existing cluster.", out.V{"driver": existing.Driver})
+				out.WarningT("If necessary delete and recreate the cluster, proceeding with old mount configuration")
+			}
+		}
+
+		if existing.KubernetesConfig.ContainerRuntime == "crio" {
+			// Stop and start again if it's crio because it's broken above v1.17.3
+			out.WarningT("Due to issues with CRI-O post v1.17.3, we need to restart your cluster.")
+			out.WarningT("See details at https://github.com/kubernetes/minikube/issues/8861")
+			stopProfile(existing.Name)
+			starter, err = provisionWithDriver(cmd, ds, existing)
+			if err != nil {
+				exit.Error(reason.GuestProvision, "error provisioning host", err)
+			}
 		}
 	}
 

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -210,7 +210,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		if viper.GetBool(createMount) {
 			mount := viper.GetString(mountString)
 			if len(existing.ContainerVolumeMounts) != 1 || existing.ContainerVolumeMounts[0] != mount {
-				out.WarningT("Due to the limitations of %s, it's not possible to change mount configuration of an existing cluster.", out.V{"driver": existing.Driver})
+				out.WarningT("Due to the limitations of {{.driver}}, it's not possible to change mount configuration of an existing cluster.", out.V{"driver": existing.Driver})
 				out.WarningT("If necessary delete and recreate the cluster, proceeding with old mount configuration")
 			}
 		}


### PR DESCRIPTION
This PR prints a warning when changing the mount configuration on an existing cluster when using either Docker or podman.

As discussed in https://github.com/kubernetes/minikube/pull/8159#issuecomment-666996559