### PR TITLE
exit on existing cluster start with KiC driver mount configuration change

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -210,8 +210,11 @@ func runStart(cmd *cobra.Command, args []string) {
 		if viper.GetBool(createMount) {
 			mount := viper.GetString(mountString)
 			if len(existing.ContainerVolumeMounts) != 1 || existing.ContainerVolumeMounts[0] != mount {
-				out.WarningT("Due to the limitations of {{.driver}}, it's not possible to the change mount configuration of an existing cluster.", out.V{"driver": existing.Driver})
-				out.WarningT("If necessary delete and recreate the cluster, proceeding with old mount configuration")
+				exit.Message(reason.GuestMountConflict, "Sorry, {{.driver}} does not allow mounts to be changed after container creation (previous mount: {{.old}}, new mount: {{.new}})", out.V{
+					"driver": existing.Driver,
+					"new":    mount,
+					"old":    existing.ContainerVolumeMounts[0],
+				})
 			}
 		}
 

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -210,7 +210,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		if viper.GetBool(createMount) {
 			mount := viper.GetString(mountString)
 			if len(existing.ContainerVolumeMounts) != 1 || existing.ContainerVolumeMounts[0] != mount {
-				exit.Message(reason.GuestMountConflict, "Sorry, {{.driver}} does not allow mounts to be changed after container creation (previous mount: {{.old}}, new mount: {{.new}})", out.V{
+				exit.Message(reason.GuestMountConflict, "Sorry, {{.driver}} does not allow mounts to be changed after container creation (previous mount: '{{.old}}', new mount: '{{.new}})'", out.V{
 					"driver": existing.Driver,
 					"new":    mount,
 					"old":    existing.ContainerVolumeMounts[0],

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -214,7 +214,7 @@ var (
 	GuestDeletion         = Kind{ID: "GUEST_DELETION", ExitCode: ExGuestError}
 	GuestLoadHost         = Kind{ID: "GUEST_LOAD_HOST", ExitCode: ExGuestError}
 	GuestMount            = Kind{ID: "GUEST_MOUNT", ExitCode: ExGuestError}
-	GuestMountConflict    = Kind{ID: "GUEST_MOUNT_CONFLICT", ExitCode: ExGuestError}
+	GuestMountConflict    = Kind{ID: "GUEST_MOUNT_CONFLICT", ExitCode: ExGuestConflict}
 	GuestNodeAdd          = Kind{ID: "GUEST_NODE_ADD", ExitCode: ExGuestError}
 	GuestNodeDelete       = Kind{ID: "GUEST_NODE_DELETE", ExitCode: ExGuestError}
 	GuestNodeProvision    = Kind{ID: "GUEST_NODE_PROVISION", ExitCode: ExGuestError}

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -214,6 +214,7 @@ var (
 	GuestDeletion         = Kind{ID: "GUEST_DELETION", ExitCode: ExGuestError}
 	GuestLoadHost         = Kind{ID: "GUEST_LOAD_HOST", ExitCode: ExGuestError}
 	GuestMount            = Kind{ID: "GUEST_MOUNT", ExitCode: ExGuestError}
+	GuestMountConflict    = Kind{ID: "GUEST_MOUNT_CONFLICT", ExitCode: ExGuestError}
 	GuestNodeAdd          = Kind{ID: "GUEST_NODE_ADD", ExitCode: ExGuestError}
 	GuestNodeDelete       = Kind{ID: "GUEST_NODE_DELETE", ExitCode: ExGuestError}
 	GuestNodeProvision    = Kind{ID: "GUEST_NODE_PROVISION", ExitCode: ExGuestError}


### PR DESCRIPTION
when changing the mount configuration on a kic cluster exit instead showing a warning. as discussed in: https://github.com/kubernetes/minikube/pull/9172