### PR TITLE
Update min*Mem constants to use MiB instead of MB

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -94,8 +94,8 @@ const (
 	interactive             = "interactive"
 	waitTimeout             = "wait-timeout"
 	nativeSSH               = "native-ssh"
-	minUsableMem            = 1024 // In MiB: Kubernetes will not start with less than 1GiB
-	minRecommendedMem       = 2000 // In MiB: Warn at no lower than existing configurations
+	minUsableMem            = 953  // 1GB In MiB: Kubernetes will not start with less
+	minRecommendedMem       = 1907 // 2GB In MiB: Warn at no lower than existing configurations
 	minimumCPUS             = 2
 	minimumDiskSize         = 2000
 	autoUpdate              = "auto-update-drivers"


### PR DESCRIPTION
At some point, minikube changed from MB to MiB internally, but the constants were never updated.

This fixes the confusing behavior when a user sets Docker to 2GB (1907MiB), but we still warn because it is less than 2000.

This also fixes it so that minikube does not force exit if Docker is set to 1GB of RAM (953MiB), which is acceptable enough for Kubernetes, leaving 200MiB to spare.