### PR TITLE
add HTML report to Makefile and funtional only test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,7 +300,7 @@ integration-versioned: out/minikube ## Trigger minikube integration testing
 integration-functional-only: out/minikube$(IS_EXE) ## Trigger only functioanl tests in integration test 
 	go test -ldflags="${MINIKUBE_LDFLAGS}" -v -test.timeout=20m ./test/integration --tags="$(MINIKUBE_INTEGRATION_BUILD_TAGS)" $(TEST_ARGS) -test.run TestFunctional/serial/StartWithProxy 2>&1 | tee "./out/testout_$(COMMIT_SHORT).txt"
 
-
+.PHONY: html_report
 html_report: ## generate HTML gopogh report out of the last integration test logs (haave to run after integration test targets)
 	@go tool test2json -t < "./out/testout_$(COMMIT_SHORT).txt" > "./out/testout_$(COMMIT_SHORT).json"
 	@gopogh -in "./out/testout_$(COMMIT_SHORT).json" -out ./out/testout_$(COMMIT_SHORT).html -name "$(shell git rev-parse --abbrev-ref HEAD)" -pr "" -repo github.com/kubernetes/minikube/  -details "${COMMIT_SHORT}"

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ REGISTRY_GH?=docker.pkg.github.com/kubernetes/minikube
 # Get git commit id
 COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
 COMMIT ?= $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}")
-
+COMMIT_SHORT = $(shell git rev-parse --short HEAD 2> /dev/null || true)
 HYPERKIT_BUILD_IMAGE 	?= karalabe/xgo-1.12.x
 # NOTE: "latest" as of 2020-05-13. kube-cross images aren't updated as often as Kubernetes
 # https://github.com/kubernetes/kubernetes/blob/master/build/build-image/cross/VERSION
@@ -286,16 +286,28 @@ docker-machine-driver-kvm2: out/docker-machine-driver-kvm2 ## Build KVM2 driver
 
 .PHONY: integration
 integration: out/minikube$(IS_EXE) ## Trigger minikube integration test
-	go test -ldflags="${MINIKUBE_LDFLAGS}" -v -test.timeout=90m ./test/integration --tags="$(MINIKUBE_INTEGRATION_BUILD_TAGS)" $(TEST_ARGS)
+	go test -ldflags="${MINIKUBE_LDFLAGS}" -v -test.timeout=90m ./test/integration --tags="$(MINIKUBE_INTEGRATION_BUILD_TAGS)" $(TEST_ARGS) 2>&1 | tee "./out/testout_$(COMMIT_SHORT).txt"
 
 .PHONY: integration-none-driver
 integration-none-driver: e2e-linux-$(GOARCH) out/minikube-linux-$(GOARCH)  ## Trigger minikube none driver test
-	sudo -E out/e2e-linux-$(GOARCH) -testdata-dir "test/integration/testdata" -minikube-start-args="--driver=none" -test.v -test.timeout=60m -binary=out/minikube-linux-amd64 $(TEST_ARGS)
+	sudo -E out/e2e-linux-$(GOARCH) -testdata-dir "test/integration/testdata" -minikube-start-args="--driver=none" -test.v -test.timeout=60m -binary=out/minikube-linux-amd64 $(TEST_ARGS) 2>&1 | tee "./out/testout_$(COMMIT_SHORT).txt"
 
 .PHONY: integration-versioned
 integration-versioned: out/minikube ## Trigger minikube integration testing
-	go test -ldflags="${MINIKUBE_LDFLAGS}" -v -test.timeout=90m ./test/integration --tags="$(MINIKUBE_INTEGRATION_BUILD_TAGS) versioned" $(TEST_ARGS)
+	go test -ldflags="${MINIKUBE_LDFLAGS}" -v -test.timeout=90m ./test/integration --tags="$(MINIKUBE_INTEGRATION_BUILD_TAGS) versioned" $(TEST_ARGS) 2>&1 | tee "./out/testout_$(COMMIT_SHORT).txt"
 
+.PHONY: integration-functional-only
+integration-functional-only: out/minikube$(IS_EXE) ## Trigger only functioanl tests in integration test 
+	go test -ldflags="${MINIKUBE_LDFLAGS}" -v -test.timeout=20m ./test/integration --tags="$(MINIKUBE_INTEGRATION_BUILD_TAGS)" $(TEST_ARGS) -test.run TestFunctional 2>&1 | tee "./out/testout_$(COMMIT_SHORT).txt"
+
+
+html_report: ## generate HTML gopogh report out of the last test run 
+	go tool test2json -t < "./out/testout_$(COMMIT_SHORT).txt" > "./out/testout_$(COMMIT_SHORT).json"
+	gopogh -in "./out/testout_$(COMMIT_SHORT).json" -out ./out/testout_$(COMMIT_SHORT).html -name "$(shell git rev-parse --abbrev-ref HEAD)" -pr "" -repo github.com/kubernetes/minikube/  -details "${COMMIT_SHORT}"
+	@echo "-------------------------- Open HTML Report in Browser: --------------------------"
+	@echo open $(CURDIR)/out/testout_$(COMMIT_SHORT).html
+	@echo "-----------------------------------------------------------------------------------"
+	open $(CURDIR)/out/testout_$(COMMIT_SHORT).html || true
 .PHONY: test
 test: pkg/minikube/assets/assets.go pkg/minikube/translate/translations.go ## Trigger minikube test
 	MINIKUBE_LDFLAGS="${MINIKUBE_LDFLAGS}" ./test.sh

--- a/Makefile
+++ b/Makefile
@@ -298,16 +298,17 @@ integration-versioned: out/minikube ## Trigger minikube integration testing
 
 .PHONY: integration-functional-only
 integration-functional-only: out/minikube$(IS_EXE) ## Trigger only functioanl tests in integration test 
-	go test -ldflags="${MINIKUBE_LDFLAGS}" -v -test.timeout=20m ./test/integration --tags="$(MINIKUBE_INTEGRATION_BUILD_TAGS)" $(TEST_ARGS) -test.run TestFunctional 2>&1 | tee "./out/testout_$(COMMIT_SHORT).txt"
+	go test -ldflags="${MINIKUBE_LDFLAGS}" -v -test.timeout=20m ./test/integration --tags="$(MINIKUBE_INTEGRATION_BUILD_TAGS)" $(TEST_ARGS) -test.run TestFunctional/serial/StartWithProxy 2>&1 | tee "./out/testout_$(COMMIT_SHORT).txt"
 
 
-html_report: ## generate HTML gopogh report out of the last test run 
-	go tool test2json -t < "./out/testout_$(COMMIT_SHORT).txt" > "./out/testout_$(COMMIT_SHORT).json"
-	gopogh -in "./out/testout_$(COMMIT_SHORT).json" -out ./out/testout_$(COMMIT_SHORT).html -name "$(shell git rev-parse --abbrev-ref HEAD)" -pr "" -repo github.com/kubernetes/minikube/  -details "${COMMIT_SHORT}"
-	@echo "-------------------------- Open HTML Report in Browser: --------------------------"
+html_report: ## generate HTML gopogh report out of the last integration test logs (haave to run after integration test targets)
+	@go tool test2json -t < "./out/testout_$(COMMIT_SHORT).txt" > "./out/testout_$(COMMIT_SHORT).json"
+	@gopogh -in "./out/testout_$(COMMIT_SHORT).json" -out ./out/testout_$(COMMIT_SHORT).html -name "$(shell git rev-parse --abbrev-ref HEAD)" -pr "" -repo github.com/kubernetes/minikube/  -details "${COMMIT_SHORT}"
+	@echo "-------------------------- Open HTML Report in Browser: ---------------------------"
 	@echo open $(CURDIR)/out/testout_$(COMMIT_SHORT).html
 	@echo "-----------------------------------------------------------------------------------"
 	open $(CURDIR)/out/testout_$(COMMIT_SHORT).html || true
+
 .PHONY: test
 test: pkg/minikube/assets/assets.go pkg/minikube/translate/translations.go ## Trigger minikube test
 	MINIKUBE_LDFLAGS="${MINIKUBE_LDFLAGS}" ./test.sh

--- a/Makefile
+++ b/Makefile
@@ -298,7 +298,7 @@ integration-versioned: out/minikube ## Trigger minikube integration testing
 
 .PHONY: integration-functional-only
 integration-functional-only: out/minikube$(IS_EXE) ## Trigger only functioanl tests in integration test 
-	go test -ldflags="${MINIKUBE_LDFLAGS}" -v -test.timeout=20m ./test/integration --tags="$(MINIKUBE_INTEGRATION_BUILD_TAGS)" $(TEST_ARGS) -test.run TestFunctional/serial/StartWithProxy 2>&1 | tee "./out/testout_$(COMMIT_SHORT).txt"
+	go test -ldflags="${MINIKUBE_LDFLAGS}" -v -test.timeout=20m ./test/integration --tags="$(MINIKUBE_INTEGRATION_BUILD_TAGS)" $(TEST_ARGS) -test.run TestFunctional 2>&1 | tee "./out/testout_$(COMMIT_SHORT).txt"
 
 .PHONY: html_report
 html_report: ## generate HTML gopogh report out of the last integration test logs (haave to run after integration test targets)
@@ -307,7 +307,7 @@ html_report: ## generate HTML gopogh report out of the last integration test log
 	@echo "-------------------------- Open HTML Report in Browser: ---------------------------"
 	@echo open $(CURDIR)/out/testout_$(COMMIT_SHORT).html
 	@echo "-----------------------------------------------------------------------------------"
-	open $(CURDIR)/out/testout_$(COMMIT_SHORT).html || true
+	@open $(CURDIR)/out/testout_$(COMMIT_SHORT).html || true
 
 .PHONY: test
 test: pkg/minikube/assets/assets.go pkg/minikube/translate/translations.go ## Trigger minikube test

--- a/Makefile
+++ b/Makefile
@@ -285,23 +285,23 @@ docker-machine-driver-hyperkit: out/docker-machine-driver-hyperkit ## Build Hype
 docker-machine-driver-kvm2: out/docker-machine-driver-kvm2 ## Build KVM2 driver
 
 .PHONY: integration
-integration: out/minikube$(IS_EXE) ## Trigger minikube integration test
+integration: out/minikube$(IS_EXE) ## Trigger minikube integration test, logs to ./out/testout_COMMIT.txt
 	go test -ldflags="${MINIKUBE_LDFLAGS}" -v -test.timeout=90m ./test/integration --tags="$(MINIKUBE_INTEGRATION_BUILD_TAGS)" $(TEST_ARGS) 2>&1 | tee "./out/testout_$(COMMIT_SHORT).txt"
 
 .PHONY: integration-none-driver
-integration-none-driver: e2e-linux-$(GOARCH) out/minikube-linux-$(GOARCH)  ## Trigger minikube none driver test
+integration-none-driver: e2e-linux-$(GOARCH) out/minikube-linux-$(GOARCH)  ## Trigger minikube none driver test, logs to ./out/testout_COMMIT.txt
 	sudo -E out/e2e-linux-$(GOARCH) -testdata-dir "test/integration/testdata" -minikube-start-args="--driver=none" -test.v -test.timeout=60m -binary=out/minikube-linux-amd64 $(TEST_ARGS) 2>&1 | tee "./out/testout_$(COMMIT_SHORT).txt"
 
 .PHONY: integration-versioned
-integration-versioned: out/minikube ## Trigger minikube integration testing
+integration-versioned: out/minikube ## Trigger minikube integration testing, logs to ./out/testout_COMMIT.txt
 	go test -ldflags="${MINIKUBE_LDFLAGS}" -v -test.timeout=90m ./test/integration --tags="$(MINIKUBE_INTEGRATION_BUILD_TAGS) versioned" $(TEST_ARGS) 2>&1 | tee "./out/testout_$(COMMIT_SHORT).txt"
 
 .PHONY: integration-functional-only
-integration-functional-only: out/minikube$(IS_EXE) ## Trigger only functioanl tests in integration test 
+integration-functional-only: out/minikube$(IS_EXE) ## Trigger only functioanl tests in integration test, logs to ./out/testout_COMMIT.txt
 	go test -ldflags="${MINIKUBE_LDFLAGS}" -v -test.timeout=20m ./test/integration --tags="$(MINIKUBE_INTEGRATION_BUILD_TAGS)" $(TEST_ARGS) -test.run TestFunctional 2>&1 | tee "./out/testout_$(COMMIT_SHORT).txt"
 
 .PHONY: html_report
-html_report: ## generate HTML gopogh report out of the last integration test logs (haave to run after integration test targets)
+html_report: ## Generate HTML  report out of the last ran integration test logs.
 	@go tool test2json -t < "./out/testout_$(COMMIT_SHORT).txt" > "./out/testout_$(COMMIT_SHORT).json"
 	@gopogh -in "./out/testout_$(COMMIT_SHORT).json" -out ./out/testout_$(COMMIT_SHORT).html -name "$(shell git rev-parse --abbrev-ref HEAD)" -pr "" -repo github.com/kubernetes/minikube/  -details "${COMMIT_SHORT}"
 	@echo "-------------------------- Open HTML Report in Browser: ---------------------------"


### PR DESCRIPTION
After this PR

- All the Makefile integration tests will output their test logs to `./out/testout_COMMITSHA.txt`
- There is new make target called "integration-functional-only" that only runs functional tests
- `make html_report`  will convert the last test logs in `./out/testout_COMMITSHA.txt` to HTML in `./out/testout_COMMITSHA.html` on MacOs it will use open command to also automatically open the report in browser.

###  make html_report 
```

github.com/kubernetes/minikube/  -details "3e5d0abba"
{
    "NumberOfTests": 1,
    "NumberOfFail": 0,
    "NumberOfPass": 1,
    "NumberOfSkip": 0,
    "FailedTests": null,
    "PassedTests": [
        "TestFunctional/serial/StartWithProxy"
    ],
    "GopoghVersion": "v0.1.21",
    "GopoghBuild": "a81078f701f45acf523f7e1162606405e1767e99",
    "Detail": {
        "Name": "makefile_functional",
        "Details": "3e5d0abba",
        "PR": "",
        "RepoName": "github.com/kubernetes/minikube/"
    }
}
-------------------------- Open HTML Report in Browser: ---------------------------
open /Users/medya/workspace/minikube/out/testout_3e5d0abba.html
-----------------------------------------------------------------------------------
open /Users/medya/workspace/minikube/out/testout_3e5d0abba.html || true
```

closes https://github.com/kubernetes/minikube/issues/9212