### PR TITLE
Add podman storage warning to match docker

### DIFF
--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -176,6 +176,15 @@ var (
 			3. Run "minikube ssh -- docker system prune" if using the docker container runtime`,
 		Issues: []int{9024},
 	}
+	RsrcInsufficientPodmanStorage = Kind{
+		ID:       "RSRC_PODMAN_STORAGE",
+		ExitCode: ExInsufficientStorage,
+		Advice: `Try at least one of the following to free up space on the device:
+	
+			1. Run "sudo podman system prune" to remove unused podman data
+			2. Run "minikube ssh -- docker system prune" if using the docker container runtime`,
+		Issues: []int{9024},
+	}
 
 	RsrcInsufficientStorage = Kind{ID: "RSRC_INSUFFICIENT_STORAGE", ExitCode: ExInsufficientStorage, Style: style.UnmetRequirement}
 


### PR DESCRIPTION
```
🔥  Creating podman container (CPUs=2, Memory=7900MB) ...

🧯  Podman is nearly out of disk space, which may cause deployments to fail! (95% of capacity)
💡  Suggestion: 

    Try at least one of the following to free up space on the device:
     
    1. Run "sudo podman system prune" to remove unused podman data
    2. Run "minikube ssh -- docker system prune" if using the docker container runtime
🍿  Related issue: https://github.com/kubernetes/minikube/issues/9024

```

Closes #9238