### PR TITLE
Avoid setting time for memory assets

### DIFF
--- a/pkg/minikube/command/ssh_runner.go
+++ b/pkg/minikube/command/ssh_runner.go
@@ -263,7 +263,7 @@ func (s *SSHRunner) Copy(f assets.CopyableFile) error {
 	mtime, err := f.GetModTime()
 	if err != nil {
 		glog.Infof("error getting modtime for %s: %v", dst, err)
-	} else {
+	} else if mtime != (time.Time{}) {
 		scp += fmt.Sprintf(" && sudo touch -d \"%s\" %s", mtime.Format(layout), dst)
 	}
 	out, err := sess.CombinedOutput(scp)


### PR DESCRIPTION
These do not have any file modification time

Previously used '0001-01-01 00:00:00 +0000'

Closes #9252