### PR TITLE
Implement scheduled stop

### DIFF
--- a/cmd/minikube/cmd/stop.go
+++ b/cmd/minikube/cmd/stop.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/docker/machine/libmachine"
@@ -45,7 +44,6 @@ var (
 	stopAll       bool
 	keepActive    bool
 	scheduledStop string
-	waitTime      int
 )
 
 // stopCmd represents the stop command
@@ -61,7 +59,6 @@ func init() {
 	stopCmd.Flags().BoolVar(&stopAll, "all", false, "Set flag to stop all profiles (clusters)")
 	stopCmd.Flags().BoolVar(&keepActive, "keep-context-active", false, "keep the kube-context active after cluster is stopped. Defaults to false.")
 	stopCmd.Flags().StringVar(&scheduledStop, "schedule", "", "Schedule stop for this cluster (e.g. --schedule=5m) ")
-	// stopCmd.Flags().IntVar(&wait, "wait", 0, "wait number of seconds before stopping")
 
 	if err := viper.GetViper().BindPFlags(stopCmd.Flags()); err != nil {
 		exit.Error(reason.InternalFlagsBind, "unable to bind flags", err)
@@ -74,11 +71,6 @@ func init() {
 func runStop(cmd *cobra.Command, args []string) {
 	register.SetEventLogPath(localpath.EventLog(ClusterFlagValue()))
 	register.Reg.SetStep(register.Stopping)
-
-	if waitTime > 0 && scheduledStop == "" {
-		glog.Infof("--wait was passed in, sleeping %v seconds", waitTime)
-		time.Sleep(time.Duration(waitTime) * time.Second)
-	}
 
 	// new code
 	var profilesToStop []string
@@ -95,29 +87,24 @@ func runStop(cmd *cobra.Command, args []string) {
 		profilesToStop = append(profilesToStop, cname)
 	}
 
-	stoppedNodes := 0
 	if scheduledStop != "" {
 		duration, err := time.ParseDuration(scheduledStop)
 		if err != nil {
 			exit.Message(reason.Usage, "provided value {{.schedule}} to --schedule is not a valid Golang time.Duration", out.V{"schedule": scheduledStop})
 		}
-		fmt.Println("starting to daemonize")
-		if err := schedule.Daemonize(profilesToStop[0], duration); err != nil {
-			fmt.Println("error with daemonizing", err)
+		if err := schedule.Daemonize(profilesToStop, duration); err != nil {
+			exit.Message(reason.DaemonizeError, "unable to daemonize: {{.err}}", out.V{"err": err.Error})
 		}
-		fmt.Println("finished daemonizing, returning")
-		time.Sleep(time.Minute)
-		return
+		glog.Infof("sleeping %s before completing stop...", duration.String())
+		time.Sleep(duration)
 	}
+
+	stoppedNodes := 0
 	for _, profile := range profilesToStop {
 		stoppedNodes = stopProfile(profile)
 	}
 
 	register.Reg.SetStep(register.Done)
-	if scheduledStop != "" {
-		out.T(style.Stopped, `{{.count}} nodes have scheduled stopped for {{.schedule}} from now`, out.V{"count": stoppedNodes, "schedule": scheduledStop})
-		return
-	}
 	if stoppedNodes > 0 {
 		out.T(style.Stopped, `{{.count}} nodes stopped.`, out.V{"count": stoppedNodes})
 	}
@@ -178,12 +165,4 @@ func stop(api libmachine.API, machineName string) bool {
 	}
 
 	return nonexistent
-}
-
-func scheduleStopProfile(profile string) error {
-	duration, err := time.ParseDuration(scheduledStop)
-	if err != nil {
-		exit.Message(reason.Usage, "provided value {{.schedule}} to --schedule is not a valid Golang time.Duration", out.V{"schedule": scheduledStop})
-	}
-	return schedule.Stop(profile, duration)
 }

--- a/cmd/minikube/cmd/stop.go
+++ b/cmd/minikube/cmd/stop.go
@@ -58,7 +58,7 @@ itself, leaving all files intact. The cluster can be started again with the "sta
 func init() {
 	stopCmd.Flags().BoolVar(&stopAll, "all", false, "Set flag to stop all profiles (clusters)")
 	stopCmd.Flags().BoolVar(&keepActive, "keep-context-active", false, "keep the kube-context active after cluster is stopped. Defaults to false.")
-	stopCmd.Flags().StringVar(&scheduledStop, "schedule", "", "Schedule stop for this cluster (e.g. --schedule=5m) ")
+	stopCmd.Flags().StringVar(&scheduledStop, "schedule", "", "Set flag to stop cluster after a set amount of time (e.g. --schedule=5m)")
 
 	if err := viper.GetViper().BindPFlags(stopCmd.Flags()); err != nil {
 		exit.Error(reason.InternalFlagsBind, "unable to bind flags", err)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5 // indirect
 	github.com/Parallels/docker-machine-parallels v1.3.0
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
+	github.com/VividCortex/godaemon v0.0.0-20200629145737-581b70a8a603
 	github.com/blang/semver v3.5.0+incompatible
 	github.com/c4milo/gotoolkit v0.0.0-20170318115440-bcc06269efa9 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible
@@ -45,6 +46,7 @@ require (
 	github.com/juju/testing v0.0.0-20190723135506-ce30eb24acd2 // indirect
 	github.com/juju/utils v0.0.0-20180820210520-bf9cc5bdd62d // indirect
 	github.com/juju/version v0.0.0-20180108022336-b64dbd566305 // indirect
+	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/libvirt/libvirt-go v3.4.0+incompatible
 	github.com/machine-drivers/docker-machine-driver-vmware v0.1.1
@@ -62,10 +64,12 @@ require (
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/russross/blackfriday v1.5.3-0.20200218234912-41c5fccfd6f6 // indirect
 	github.com/samalba/dockerclient v0.0.0-20160414174713-91d7393ff859 // indirect
+	github.com/sevlyar/go-daemon v0.1.5
 	github.com/shirou/gopsutil v2.18.12+incompatible
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0
+	github.com/takama/daemon v1.0.0
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f
@@ -75,7 +79,7 @@ require (
 	golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
-	golang.org/x/sys v0.0.0-20200523222454-059865788121
+	golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6
 	golang.org/x/text v0.3.2
 	google.golang.org/api v0.25.0
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 // indirect

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,6 @@ require (
 	github.com/juju/testing v0.0.0-20190723135506-ce30eb24acd2 // indirect
 	github.com/juju/utils v0.0.0-20180820210520-bf9cc5bdd62d // indirect
 	github.com/juju/version v0.0.0-20180108022336-b64dbd566305 // indirect
-	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/libvirt/libvirt-go v3.4.0+incompatible
 	github.com/machine-drivers/docker-machine-driver-vmware v0.1.1
@@ -64,19 +63,16 @@ require (
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/russross/blackfriday v1.5.3-0.20200218234912-41c5fccfd6f6 // indirect
 	github.com/samalba/dockerclient v0.0.0-20160414174713-91d7393ff859 // indirect
-	github.com/sevlyar/go-daemon v0.1.5
 	github.com/shirou/gopsutil v2.18.12+incompatible
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0
-	github.com/takama/daemon v1.0.0
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f
 	github.com/zchee/go-vmnet v0.0.0-20161021174912-97ebf9174097
 	golang.org/x/build v0.0.0-20190927031335-2835ba2e683f
 	golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37
-	golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 	golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUW
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdcM=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
+github.com/VividCortex/godaemon v0.0.0-20200629145737-581b70a8a603 h1:ZqOqBuBJ9QfCo2ErNFCVh5UXWtwXu01xb/WX1ND0rPM=
+github.com/VividCortex/godaemon v0.0.0-20200629145737-581b70a8a603/go.mod h1:Y8CJ3IwPIAkMhv/rRUWIlczaeqd9ty9yrl+nc2AbaL4=
 github.com/afbjorklund/go-containerregistry v0.0.0-20200602203322-347d93793dc9 h1:EMF82QM65iOfQTQefF5d5SCsSsXsh6aSdcq9U1KC3Lc=
 github.com/afbjorklund/go-containerregistry v0.0.0-20200602203322-347d93793dc9/go.mod h1:npTSyywOeILcgWqd+rvtzGWflIPPcBQhYoOONaY4ltM=
 github.com/afbjorklund/go-containerregistry v0.0.0-20200902152226-fbad78ec2813 h1:0tskN1ipU/BBrpoEIy0rdZS9jf5+wdP6IMRak8Iu/YE=
@@ -700,6 +702,8 @@ github.com/juju/version v0.0.0-20180108022336-b64dbd566305 h1:lQxPJ1URr2fjsKnJRt
 github.com/juju/version v0.0.0-20180108022336-b64dbd566305/go.mod h1:kE8gK5X0CImdr7qpSKl3xB2PmpySSmfj7zVbkZFs81U=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
+github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uiaSepXwyf3o52HaUYcV+Tu66S3F5GA=
+github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/karrick/godirwalk v1.7.5/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
@@ -967,6 +971,7 @@ github.com/quasilyte/go-ruleguard v0.1.2-0.20200318202121-b00d7a75d3d8/go.mod h1
 github.com/quobyte/api v0.1.2/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/robfig/cron v1.1.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
+github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.1.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
@@ -998,6 +1003,8 @@ github.com/securego/gosec v0.0.0-20200401082031-e946c8c39989/go.mod h1:i9l/TNj+y
 github.com/securego/gosec/v2 v2.3.0/go.mod h1:UzeVyUXbxukhLeHKV3VVqo7HdoQR9MrRfFmZYotn8ME=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/sevlyar/go-daemon v0.1.5 h1:Zy/6jLbM8CfqJ4x4RPr7MJlSKt90f00kNM1D401C+Qk=
+github.com/sevlyar/go-daemon v0.1.5/go.mod h1:6dJpPatBT9eUwM5VCw9Bt6CdX9Tk6UWvhW3MebLDRKE=
 github.com/shirou/gopsutil v0.0.0-20180427012116-c95755e4bcd7/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/gopsutil v0.0.0-20190901111213-e4ec7b275ada/go.mod h1:WWnYX4lzhCH5h/3YBfyVA3VbLYjlMZZAQcW9ojMexNc=
 github.com/shirou/gopsutil v2.18.12+incompatible h1:1eaJvGomDnH74/5cF4CTmTbLHAriGFsTZppLXDX93OM=
@@ -1081,6 +1088,8 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0TYG7HtkIgExQo+2RdLuwRft63jn2HWj8=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
+github.com/takama/daemon v1.0.0 h1:XS3VLnFKmqw2Z7fQ/dHRarrVjdir9G3z7BEP8osjizQ=
+github.com/takama/daemon v1.0.0/go.mod h1:gKlhcjbqtBODg5v9H1nj5dU1a2j2GemtuWSNLD5rxOE=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/tdakkota/asciicheck v0.0.0-20200416190851-d7f85be797a2/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
 github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
@@ -1359,6 +1368,8 @@ golang.org/x/sys v0.0.0-20200501052902-10377860bb8e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200523222454-059865788121 h1:rITEj+UZHYC927n8GT97eC3zrpzXdb/voyeOuVKS46o=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6 h1:X9xIZ1YU8bLZA3l6gqDUHSFiD0GFI9S548h6C8nDtOY=
+golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915090833-1cbadb444a80/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,6 @@ github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdc
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/VividCortex/godaemon v0.0.0-20200629145737-581b70a8a603 h1:ZqOqBuBJ9QfCo2ErNFCVh5UXWtwXu01xb/WX1ND0rPM=
 github.com/VividCortex/godaemon v0.0.0-20200629145737-581b70a8a603/go.mod h1:Y8CJ3IwPIAkMhv/rRUWIlczaeqd9ty9yrl+nc2AbaL4=
-github.com/afbjorklund/go-containerregistry v0.0.0-20200602203322-347d93793dc9 h1:EMF82QM65iOfQTQefF5d5SCsSsXsh6aSdcq9U1KC3Lc=
-github.com/afbjorklund/go-containerregistry v0.0.0-20200602203322-347d93793dc9/go.mod h1:npTSyywOeILcgWqd+rvtzGWflIPPcBQhYoOONaY4ltM=
 github.com/afbjorklund/go-containerregistry v0.0.0-20200902152226-fbad78ec2813 h1:0tskN1ipU/BBrpoEIy0rdZS9jf5+wdP6IMRak8Iu/YE=
 github.com/afbjorklund/go-containerregistry v0.0.0-20200902152226-fbad78ec2813/go.mod h1:npTSyywOeILcgWqd+rvtzGWflIPPcBQhYoOONaY4ltM=
 github.com/afbjorklund/go-getter v1.4.1-0.20190910175809-eb9f6c26742c h1:18gEt7qzn7CW7qMkfPTFyyotlPbvPQo9o4IDV8jZqP4=
@@ -702,8 +700,6 @@ github.com/juju/version v0.0.0-20180108022336-b64dbd566305 h1:lQxPJ1URr2fjsKnJRt
 github.com/juju/version v0.0.0-20180108022336-b64dbd566305/go.mod h1:kE8gK5X0CImdr7qpSKl3xB2PmpySSmfj7zVbkZFs81U=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
-github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uiaSepXwyf3o52HaUYcV+Tu66S3F5GA=
-github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/karrick/godirwalk v1.7.5/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
@@ -971,7 +967,6 @@ github.com/quasilyte/go-ruleguard v0.1.2-0.20200318202121-b00d7a75d3d8/go.mod h1
 github.com/quobyte/api v0.1.2/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/robfig/cron v1.1.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
-github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.1.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
@@ -1003,8 +998,6 @@ github.com/securego/gosec v0.0.0-20200401082031-e946c8c39989/go.mod h1:i9l/TNj+y
 github.com/securego/gosec/v2 v2.3.0/go.mod h1:UzeVyUXbxukhLeHKV3VVqo7HdoQR9MrRfFmZYotn8ME=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
-github.com/sevlyar/go-daemon v0.1.5 h1:Zy/6jLbM8CfqJ4x4RPr7MJlSKt90f00kNM1D401C+Qk=
-github.com/sevlyar/go-daemon v0.1.5/go.mod h1:6dJpPatBT9eUwM5VCw9Bt6CdX9Tk6UWvhW3MebLDRKE=
 github.com/shirou/gopsutil v0.0.0-20180427012116-c95755e4bcd7/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/gopsutil v0.0.0-20190901111213-e4ec7b275ada/go.mod h1:WWnYX4lzhCH5h/3YBfyVA3VbLYjlMZZAQcW9ojMexNc=
 github.com/shirou/gopsutil v2.18.12+incompatible h1:1eaJvGomDnH74/5cF4CTmTbLHAriGFsTZppLXDX93OM=
@@ -1088,8 +1081,6 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0TYG7HtkIgExQo+2RdLuwRft63jn2HWj8=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
-github.com/takama/daemon v1.0.0 h1:XS3VLnFKmqw2Z7fQ/dHRarrVjdir9G3z7BEP8osjizQ=
-github.com/takama/daemon v1.0.0/go.mod h1:gKlhcjbqtBODg5v9H1nj5dU1a2j2GemtuWSNLD5rxOE=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/tdakkota/asciicheck v0.0.0-20200416190851-d7f85be797a2/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
 github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -140,6 +140,6 @@ type VersionedExtraOption struct {
 
 // ScheduledStopConfig contains information around scheduled stop
 type ScheduledStopConfig struct {
-	InitiationTime time.Time
+	InitiationTime int64
 	Duration       time.Duration
 }

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -71,6 +71,7 @@ type ClusterConfig struct {
 	Addons                  map[string]bool
 	VerifyComponents        map[string]bool // map of components to verify and wait for after start.
 	StartHostTimeout        time.Duration
+	ScheduledStop           *ScheduledStopConfig
 }
 
 // KubernetesConfig contains the parameters used to configure the VM Kubernetes.
@@ -135,4 +136,10 @@ type VersionedExtraOption struct {
 	// If it is the default value, it will have no lower bound on versions the
 	// flag is applied to
 	GreaterThanOrEqual semver.Version
+}
+
+// ScheduledStopConfig contains information around scheduled stop
+type ScheduledStopConfig struct {
+	InitiationTime time.Time
+	Duration       time.Duration
 }

--- a/pkg/minikube/localpath/localpath.go
+++ b/pkg/minikube/localpath/localpath.go
@@ -19,6 +19,7 @@ package localpath
 import (
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -59,6 +60,10 @@ func MakeMiniPath(fileName ...string) string {
 // Profile returns the path to a profile
 func Profile(name string) string {
 	return filepath.Join(MiniPath(), "profiles", name)
+}
+
+func Scheduled(profile string) string {
+	return path.Join(Profile(profile), "scheduled")
 }
 
 // EventLog returns the path to a CloudEvents log

--- a/pkg/minikube/localpath/localpath.go
+++ b/pkg/minikube/localpath/localpath.go
@@ -19,7 +19,6 @@ package localpath
 import (
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -60,10 +59,6 @@ func MakeMiniPath(fileName ...string) string {
 // Profile returns the path to a profile
 func Profile(name string) string {
 	return filepath.Join(MiniPath(), "profiles", name)
-}
-
-func Scheduled(profile string) string {
-	return path.Join(Profile(profile), "scheduled")
 }
 
 // EventLog returns the path to a CloudEvents log

--- a/pkg/minikube/localpath/localpath.go
+++ b/pkg/minikube/localpath/localpath.go
@@ -19,6 +19,7 @@ package localpath
 import (
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -84,6 +85,11 @@ func ClientCert(name string) string {
 	}
 
 	return new
+}
+
+// PID returns the path to the pid file used by profile for scheduled stop
+func PID(profile string) string {
+	return path.Join(Profile(profile), "pid")
 }
 
 // ClientKey returns client certificate path, used by kubeconfig

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -113,6 +113,7 @@ var (
 	InternalYamlMarshal      = Kind{ID: "MK_YAML_MARSHAL", ExitCode: ExProgramError}
 	InternalCredsNotFound    = Kind{ID: "MK_CREDENTIALS_NOT_FOUND", ExitCode: ExProgramNotFound, Style: style.Shrug}
 	InternalSemverParse      = Kind{ID: "MK_SEMVER_PARSE", ExitCode: ExProgramError}
+	DaemonizeError           = Kind{ID: "MK_DAEMONIZE", ExitCode: ExProgramError}
 
 	RsrcInsufficientCores             = Kind{ID: "RSRC_INSUFFICIENT_CORES", ExitCode: ExInsufficientCores, Style: style.UnmetRequirement}
 	RsrcInsufficientDarwinDockerCores = Kind{

--- a/pkg/minikube/schedule/schedule.go
+++ b/pkg/minikube/schedule/schedule.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2020 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schedule
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/VividCortex/godaemon"
+	"github.com/pkg/errors"
+	"k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/localpath"
+	"k8s.io/minikube/pkg/minikube/mustload"
+)
+
+// Daemonize daemonizes minikube so that scheduled stop happens as expected
+func Daemonize(profile string, duration time.Duration) error {
+	// save current time and expected duration in config
+	api, cc := mustload.Partial(profile)
+	defer api.Close()
+
+	cc.ScheduledStop = &config.ScheduledStopConfig{
+		InitiationTime: time.Now(),
+		Duration:       duration,
+	}
+
+	if err := config.SaveProfile(profile, cc); err != nil {
+		return errors.Wrap(err, "saving profile")
+	}
+
+	_, _, err := godaemon.MakeDaemon(&godaemon.DaemonAttr{})
+	if err != nil {
+		return err
+	}
+	// now that this process has daemonized, it has a new PID
+	// store this PID in MINIKUBE_HOME/profiles/<profile>/pid
+	pid := os.Getpid()
+	pidFile := path.Join(localpath.Profile(profile), "pid")
+	if err := ioutil.WriteFile(pidFile, []byte(fmt.Sprintf("%v", pid)), 0644); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Stop schedules a stop for this profile which happens in 'duration' time
+func Stop(profile string, duration time.Duration) error {
+	sc, err := sleepCommand(profile, duration)
+	if err != nil {
+		return errors.Wrap(err, "sleep command")
+	}
+	if err := sc.Start(); err != nil {
+		return errors.Wrap(err, "starting command")
+	}
+	fmt.Println("PID:", sc.Process.Pid)
+
+	godaemon.MakeDaemon(&godaemon.DaemonAttr{})
+
+	// store the time when the command started, the PID, and
+	return nil
+}
+
+func sleepCommand(profile string, duration time.Duration) (*exec.Cmd, error) {
+	// returns the path to the minikube binary being run
+	// so that it can be called again later to stop
+	currentBinary, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	if err != nil {
+		return nil, errors.Wrap(err, "getting path to current binary")
+	}
+	if runtime.GOOS == "windows" {
+		// TODO: priyawadhwa@
+		return nil, nil
+	}
+	cmd := fmt.Sprintf("%s stop -p %s --wait %v", currentBinary, profile, duration.Seconds())
+	return exec.Command("sh", "-c", cmd), nil
+	// return exec.Command("sh", "-c", "sleep", fmt.Sprintf("%v", duration.Seconds()), "&&", currentBinary, "stop", "-p", profile), nil
+}

--- a/site/content/en/docs/commands/stop.md
+++ b/site/content/en/docs/commands/stop.md
@@ -24,6 +24,7 @@ minikube stop [flags]
       --all                   Set flag to stop all profiles (clusters)
   -h, --help                  help for stop
       --keep-context-active   keep the kube-context active after cluster is stopped. Defaults to false.
+      --schedule string       Schedule stop for this cluster (e.g. --schedule=5m) 
 ```
 
 ### Options inherited from parent commands

--- a/site/content/en/docs/commands/stop.md
+++ b/site/content/en/docs/commands/stop.md
@@ -24,7 +24,7 @@ minikube stop [flags]
       --all                   Set flag to stop all profiles (clusters)
   -h, --help                  help for stop
       --keep-context-active   keep the kube-context active after cluster is stopped. Defaults to false.
-      --schedule string       Schedule stop for this cluster (e.g. --schedule=5m) 
+      --schedule string       Set flag to stop cluster after a set amount of time (e.g. --schedule=5m)
 ```
 
 ### Options inherited from parent commands

--- a/test/integration/scheduled_stop_test.go
+++ b/test/integration/scheduled_stop_test.go
@@ -36,8 +36,8 @@ import (
 
 func TestScheduledStop(t *testing.T) {
 	profile := UniqueProfileName("scheduled-stop")
-	ctx, _ := context.WithTimeout(context.Background(), Minutes(5))
-	// defer CleanupWithLogs(t, profile, cancel)
+	ctx, cancel := context.WithTimeout(context.Background(), Minutes(5))
+	defer CleanupWithLogs(t, profile, cancel)
 	startMinikube(ctx, t, profile)
 
 	// schedule a stop for 5 min from now and make sure PID is created
@@ -53,7 +53,7 @@ func TestScheduledStop(t *testing.T) {
 		t.Fatalf("process %v running but should have been killed on reschedule of stop", pid)
 	}
 	checkPID(t, profile)
-	// wait alotted time to make sure minikube status is "Stopped"
+	// wait allotted time to make sure minikube status is "Stopped"
 	time.Sleep(15 * time.Second)
 	checkStatus := func() error {
 		got := Status(ctx, t, Target(), profile, "Host", profile)

--- a/test/integration/scheduled_stop_test.go
+++ b/test/integration/scheduled_stop_test.go
@@ -1,0 +1,114 @@
+// +build integration
+
+/*
+Copyright 2020 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/docker/machine/libmachine/state"
+	"k8s.io/minikube/pkg/minikube/localpath"
+	"k8s.io/minikube/pkg/util/retry"
+)
+
+func TestScheduledStop(t *testing.T) {
+	profile := UniqueProfileName("scheduled-stop")
+	ctx, _ := context.WithTimeout(context.Background(), Minutes(5))
+	// defer CleanupWithLogs(t, profile, cancel)
+	startMinikube(ctx, t, profile)
+
+	// schedule a stop for 5 min from now and make sure PID is created
+	scheduledStopMinikube(ctx, t, profile, "5m")
+	pid := checkPID(t, profile)
+	if !processRunning(t, pid) {
+		t.Fatalf("process %v is not running", pid)
+	}
+
+	// redo scheduled stop to be 3 min
+	scheduledStopMinikube(ctx, t, profile, "10s")
+	if processRunning(t, pid) {
+		t.Fatalf("process %v running but should have been killed on reschedule of stop", pid)
+	}
+	checkPID(t, profile)
+	// wait alotted time to make sure minikube status is "Stopped"
+	time.Sleep(15 * time.Second)
+	checkStatus := func() error {
+		got := Status(ctx, t, Target(), profile, "Host", profile)
+		if got != state.Stopped.String() {
+			return fmt.Errorf("expected post-stop host status to be -%q- but got *%q*", state.Stopped, got)
+		}
+		return nil
+	}
+	if err := retry.Expo(checkStatus, 100*time.Microsecond, 5*time.Second); err != nil {
+		t.Fatalf("error %v", err)
+	}
+}
+
+func startMinikube(ctx context.Context, t *testing.T, profile string) {
+	args := append([]string{"start", "-p", profile}, StartArgs()...)
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
+	if err != nil {
+		t.Fatalf("starting minikube: %v\n%s", err, rr.Output())
+	}
+}
+
+func scheduledStopMinikube(ctx context.Context, t *testing.T, profile string, stop string) {
+	args := []string{"stop", "-p", profile, "--schedule", stop}
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
+	if err != nil {
+		t.Fatalf("starting minikube: %v\n%s", err, rr.Output())
+	}
+}
+
+func checkPID(t *testing.T, profile string) string {
+	file := localpath.PID(profile)
+	var contents []byte
+	getContents := func() error {
+		var err error
+		contents, err = ioutil.ReadFile(file)
+		return err
+	}
+	// first, make sure the PID file exists
+	if err := retry.Expo(getContents, 100*time.Microsecond, time.Minute*1); err != nil {
+		t.Fatalf("error reading %s: %v", file, err)
+	}
+	return string(contents)
+}
+
+func processRunning(t *testing.T, pid string) bool {
+	// make sure PID file contains a running process
+	p, err := strconv.Atoi(pid)
+	if err != nil {
+		return false
+	}
+	process, err := os.FindProcess(p)
+	if err != nil {
+		return false
+	}
+	err = process.Signal(syscall.Signal(0))
+	t.Log("signal error was: ", err)
+	return err == nil
+}


### PR DESCRIPTION
This commit implements scheduled stop by using a daemonize golang package. The flow is as follows:

1. User runs `minikube stop --schedule 1m` to schedule a stop 1m from now
1. Check if a previous scheduled stop is running, kill the process if it is
1. We daemonize the current command, store the new PID of that command in minikube home dir, and update the cluster config
1. Sleep for 1m, then execute stop as usual

Coming in next PRs:
1. Use the info in the cluster config to make sure `minikube status` shows that a stop has been scheduled
1. Add some easy way to cancel any scheduled stops

Note: I've tested that this works on mac and linux, but need to check windows still