### PR TITLE
Fix cache functional test

### DIFF
--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -497,7 +497,7 @@ func validateCacheCmd(ctx context.Context, t *testing.T, profile string) {
 
 	t.Run("cache", func(t *testing.T) {
 		t.Run("add_remote", func(t *testing.T) {
-			for _, img := range []string{"k8s.gcr.io/pause:3.0", "k8s.gcr.io/pause:3.3", "k8s.gcr.io/pause:latest"} {
+			for _, img := range []string{"k8s.gcr.io/pause:3.1", "k8s.gcr.io/pause:3.3", "k8s.gcr.io/pause:latest"} {
 				rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "cache", "add", img))
 				if err != nil {
 					t.Errorf("failed to 'cache add' remote image %q. args %q err %v", img, rr.Command(), err)

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -587,7 +587,7 @@ func validateCacheCmd(ctx context.Context, t *testing.T, profile string) {
 
 		// delete will clean up the cached images since they are global and all other tests will load it for no reason
 		t.Run("delete", func(t *testing.T) {
-			for _, img := range []string{"k8s.gcr.io/pause:3.0", "k8s.gcr.io/pause:latest"} {
+			for _, img := range []string{"k8s.gcr.io/pause:3.1", "k8s.gcr.io/pause:latest"} {
 				rr, err := Run(t, exec.CommandContext(ctx, Target(), "cache", "delete", img))
 				if err != nil {
 					t.Errorf("failed to delete %s from cache. args %q: %v", img, rr.Command(), err)


### PR DESCRIPTION
Trying to cache `k8s.gcr.io/pause:3.0` is suddenly causing strange errors that are clearly not our fault: 
```
X Exiting due to MK_CACHE_LOAD: save to dir: caching images: caching image
"/home/runner/work/minikube/minikube/minikube_binaries/testhome/.minikube/cache/images/k8s.gcr.io/pause_3.0": nil image
for k8s.gcr.io/pause:3.0: unsupported MediaType: "application/vnd.docker.distribution.manifest.v1+prettyjws", see
https://github.com/google/go-containerregistry/issues/377
```

So I'm changing the image to cache to make functional tests pass again.