### PR TITLE
update-context: Automatically set the context as current/active in ku…

### DIFF
--- a/cmd/minikube/cmd/update-context.go
+++ b/cmd/minikube/cmd/update-context.go
@@ -45,5 +45,11 @@ var updateContextCmd = &cobra.Command{
 		} else {
 			out.T(style.Meh, `No changes required for the "{{.context}}" context`, out.V{"context": cname})
 		}
+
+		if err := kubeconfig.SetCurrentContext(cname, kubeconfig.PathFromEnv()); err != nil {
+			out.ErrT(style.Sad, `Error while setting kubectl current context:  {{.error}}`, out.V{"error": err})
+		} else {
+			out.T(style.Kubectl, `Current context is "{{.context}}"`, out.V{"context": cname})
+		}
 	},
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
fixes #9246 

### example scenario:

**common starting point:**
```
❯ minikube profile list
|---------------------------------|-----------|---------|------------|------|---------|---------|
|             Profile             | VM Driver | Runtime |     IP     | Port | Version | Status  |
|---------------------------------|-----------|---------|------------|------|---------|---------|
| functional-20200910153511-83042 | docker    | docker  | 172.17.0.3 | 8443 | v1.19.2 | Running |
|---------------------------------|-----------|---------|------------|------|---------|---------|

❯ kubectl get pods -A
The connection to the server localhost:8080 was refused - did you specify the right host or port?

❯ kubectl config get-contexts
CURRENT   NAME                              CLUSTER                           AUTHINFO                                                       NAMESPACE
          functional-20200910153511-83042   functional-20200910153511-83042   functional-20200910153511-83042
```

**before PR:**
```
❯ minikube update-context -p functional-20200910153511-83042
🙄  No changes required for the "functional-20200910153511-83042" context

❯ kubectl get pods -A
The connection to the server localhost:8080 was refused - did you specify the right host or port?

❯ kubectl config get-contexts
CURRENT   NAME                              CLUSTER                           AUTHINFO                                                       NAMESPACE
          functional-20200910153511-83042   functional-20200910153511-83042   functional-20200910153511-83042
```

**after PR:**
```
❯ minikube update-context -p functional-20200910153511-83042
🙄  No changes required for the "functional-20200910153511-83042" context
💗  Current context is "functional-20200910153511-83042"

❯ kubectl get pods -A
NAMESPACE     NAME                                                      READY   STATUS    RESTARTS   AGE
kube-system   coredns-f9fd979d6-gqgcm                                   1/1     Running   0          8m35s
kube-system   etcd-functional-20200910153511-83042                      1/1     Running   0          8m32s
kube-system   kube-apiserver-functional-20200910153511-83042            1/1     Running   0          8m32s
kube-system   kube-controller-manager-functional-20200910153511-83042   1/1     Running   0          8m32s
kube-system   kube-proxy-8vnrd                                          1/1     Running   0          8m34s
kube-system   kube-scheduler-functional-20200910153511-83042            1/1     Running   0          8m32s
kube-system   storage-provisioner                                       1/1     Running   1          8m38s

❯ kubectl config get-contexts
CURRENT   NAME                              CLUSTER                           AUTHINFO                                                       NAMESPACE
*         functional-20200910153511-83042   functional-20200910153511-83042   functional-20200910153511-83042
```