### PR TITLE
update_kubernetes_version: automate the update of DefaultKubernetesVersion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/google/go-cmp v0.4.1
 	github.com/google/go-containerregistry v0.0.0-20200601195303-96cf69f03a3c
 	github.com/google/go-github v17.0.0+incompatible
+	github.com/google/go-github/v32 v32.1.0
 	github.com/google/slowjam v0.0.0-20200530021616-df27e642fe7b
 	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -517,6 +517,8 @@ github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-github/v28 v28.1.1/go.mod h1:bsqJWQX05omyWVmc00nEUql9mhQyv38lDZ8kPZcQVoM=
+github.com/google/go-github/v32 v32.1.0 h1:GWkQOdXqviCPx7Q7Fj+KyPoGm4SwHRh8rheoPhd27II=
+github.com/google/go-github/v32 v32.1.0/go.mod h1:rIEpZD9CTDQwDK9GDrtMTycQNA4JU3qBsCizh3q2WCI=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-replayers/grpcreplay v0.1.0/go.mod h1:8Ig2Idjpr6gifRd6pNVggX6TC1Zw6Jx74AKp7QNH2QE=

--- a/hack/kubernetes_version/update_kubernetes_version.go
+++ b/hack/kubernetes_version/update_kubernetes_version.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -25,17 +26,65 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
+
+	"github.com/google/go-github/v32/github"
 )
 
 func main() {
-	if len(os.Args) == 1 {
-		fmt.Println("Usage: go run update_kubernetes_version.go <kubernetes_version>")
-		os.Exit(1)
+	vDefault := ""
+	vNewest := ""
+
+	client := github.NewClient(nil)
+
+	// walk through the paginated list of all 'kubernetes/kubernetes' repo releases
+	// from latest to older releases, until latest release and pre-release are found
+	// use max value (100) for PerPage to avoid hitting the rate limits (60 per hour, 10 per minute)
+	// see https://godoc.org/github.com/google/go-github/github#hdr-Rate_Limiting
+	opt := &github.ListOptions{PerPage: 100}
+out:
+	for {
+		rels, resp, err := client.Repositories.ListReleases(context.Background(), "kubernetes", "kubernetes", opt)
+		if err != nil {
+			glog.Errorf("GitHub ListReleases failed: %v", err)
+			break
+		}
+
+		for _, r := range rels {
+			// GetName returns the Name field if it's non-nil, zero value otherwise.
+			ver := r.GetName()
+			if ver == "" {
+				continue
+			}
+
+			rel := strings.Split(ver, "-")
+			// check if it is a release channel (ie, 'v1.19.2') or a
+			// pre-release channel (ie, 'v1.19.3-rc.0' or 'v1.19.0-beta.2')
+			if len(rel) == 1 && vDefault == "" {
+				vDefault = ver
+			} else if len(rel) > 1 && vNewest == "" {
+				if strings.HasPrefix(rel[1], "rc") || strings.HasPrefix(rel[1], "beta") {
+					vNewest = ver
+				}
+			}
+
+			if vDefault != "" && vNewest != "" {
+				// make sure that vNewest >= vDefault
+				if vNewest < vDefault {
+					vNewest = vDefault
+				}
+				break out
+			}
+		}
+
+		if resp.NextPage == 0 {
+			break
+		}
+		opt.Page = resp.NextPage
 	}
 
-	v := os.Args[1]
-	if !strings.HasPrefix(v, "v") {
-		v = "v" + v
+	if vDefault == "" || vNewest == "" {
+		glog.Errorf("Cannot determine DefaultKubernetesVersion or NewestKubernetesVersion")
+		os.Exit(1)
 	}
 
 	constantsFile := "../../pkg/minikube/constants/constants.go"
@@ -53,17 +102,19 @@ func main() {
 	mode := info.Mode()
 
 	re := regexp.MustCompile(`DefaultKubernetesVersion = \".*`)
-	f := re.ReplaceAllString(string(cf), "DefaultKubernetesVersion = \""+v+"\"")
+	f := re.ReplaceAllString(string(cf), "DefaultKubernetesVersion = \""+vDefault+"\"")
 
 	re = regexp.MustCompile(`NewestKubernetesVersion = \".*`)
-	f = re.ReplaceAllString(f, "NewestKubernetesVersion = \""+v+"\"")
+	f = re.ReplaceAllString(f, "NewestKubernetesVersion = \""+vNewest+"\"")
 
 	if err := ioutil.WriteFile(constantsFile, []byte(f), mode); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
-	testData := "../../pkg/minikube/bootstrapper/bsutil/testdata"
+	// update testData just for the latest 'v<MAJOR>.<MINOR>' from vDefault
+	vDefaultMM := vDefault[:strings.LastIndex(vDefault, ".")]
+	testData := "../../pkg/minikube/bootstrapper/bsutil/testdata/" + vDefaultMM
 
 	err = filepath.Walk(testData, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -77,7 +128,7 @@ func main() {
 			return err
 		}
 		re = regexp.MustCompile(`kubernetesVersion: .*`)
-		cf = []byte(re.ReplaceAllString(string(cf), "kubernetesVersion: "+v))
+		cf = []byte(re.ReplaceAllString(string(cf), "kubernetesVersion: "+vDefaultMM+".0")) // TODO: let <PATCH> version to be the latest one instead of "0"
 		return ioutil.WriteFile(path, cf, info.Mode())
 	})
 	if err != nil {


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
fixes #4392 (iteration 0)

### description:

existing `hack/kubernetes_version/update_kubernetes_version.go` script was modified to automate the update of `DefaultKubernetesVersion` and `NewestKubernetesVersion` - it now polls GitHub Releases (using `github.com/google/go-github`) for the latest Kubernetes [pre-]releases and updates the `pkg/minikube/constants/constants.go` accordingly, whereas:

- `DefaultKubernetesVersion` is updated to the latest release version 
- `NewestKubernetesVersion` is updated to the latest `-rc` or `-beta` pre-release version
- if such `NewestKubernetesVersion` is less than `DefaultKubernetesVersion`, then `DefaultKubernetesVersion` would be used for both
- `make test` passes (~~**note**: `make generate-docs` must be run before `make test`, or `TestGenerateDocs` test will fail~~ - _this dependency/requirement was removed in [commit 1444ce3](https://github.com/prezha/minikube/commit/1444ce37d7aadb3796c9b94345c21b6edfc9d49b)_)