### PR TITLE
Disable base image flag for vm drivers

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1193,14 +1193,14 @@ func validateKubernetesVersion(old *config.ClusterConfig) {
 
 // validateBaseImage checks that --base-image is not passed if the drive being in use is KIC (docker/podman)
 // if so, the function exits the process
-func validateBaseImage(imageFlag *pflag.Flag, driver string) {
-	if !validBaseImageFlag(imageFlag.Changed, driver) {
+func validateBaseImage(imageFlag *pflag.Flag, drv string) {
+	if !validBaseImageFlag(imageFlag.Changed, drv) {
 		exit.Message(reason.Usage,
 			"flag --{{.imgFlag}} is not available for driver '{{.driver}}'. Did you mean to use '{{.docker}}' or '{{.podman}}' driver instead?\n"+
 				"Please use --{{.isoFlag}} flag to configure VM based drivers",
 			out.V{
 				"imgFlag": imageFlag.Name,
-				"driver":  driver,
+				"driver":  drv,
 				"image":   imageFlag.Value,
 				"docker":  registry.Docker,
 				"podman":  registry.Podman,

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1193,12 +1193,18 @@ func validateKubernetesVersion(old *config.ClusterConfig) {
 
 // validateBaseImage checks that --base-image is not passed if the drive being in use is KIC (docker/podman)
 // if so, the function exits the process
-func validateBaseImage(baseImage *pflag.Flag, driver string) {
-	if !validBaseImageFlag(baseImage.Changed, driver) {
-		exit.Message(reason.Usage, "TODO:  image {{.image}} with driver {{.driver}}",
+func validateBaseImage(imageFlag *pflag.Flag, driver string) {
+	if !validBaseImageFlag(imageFlag.Changed, driver) {
+		exit.Message(reason.Usage,
+			"flag --{{.imgFlag}} is not available for driver '{{.driver}}'. Did you mean to use '{{.docker}}' or '{{.podman}}' driver instead?\n"+
+				"Please use --{{.isoFlag}} flag to configure VM based drivers",
 			out.V{
-				"driver": driver,
-				"image":  baseImage.Value,
+				"imgFlag": imageFlag.Name,
+				"driver":  driver,
+				"image":   imageFlag.Value,
+				"docker":  registry.Docker,
+				"podman":  registry.Podman,
+				"isoFlag": isoURL,
 			},
 		)
 	}

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -296,6 +296,8 @@ func TestBaseImageFlagDriverCombo(t *testing.T) {
 		{driver.VMwareFusion, false},
 		{driver.HyperV, false},
 		{driver.Parallels, false},
+		{"something_invalid", false},
+		{"", false},
 	}
 
 	for _, test := range tests {

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -23,8 +23,10 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
 	cfg "k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/proxy"
 )
 
@@ -274,6 +276,53 @@ func TestSuggestMemoryAllocation(t *testing.T) {
 			got := suggestMemoryAllocation(test.sysLimit, test.containerLimit, test.nodes)
 			if got != test.want {
 				t.Errorf("defaultMemorySize(sys=%d, container=%d) = %d, want: %d", test.sysLimit, test.containerLimit, got, test.want)
+			}
+		})
+	}
+}
+
+func TestBaseImageFlagDriverCombo(t *testing.T) {
+	type testStruct struct {
+		description string
+		imageSet    bool
+		driver      string
+	}
+	invalidCombos := []testStruct{
+		{"KVM2 with flag", true, driver.KVM2},
+		{"VirtualBox with flag", true, driver.VirtualBox},
+		{"HyperKit with flag", true, driver.HyperKit},
+		{"VMware with flag", true, driver.VMware},
+		{"VMwareFusion with flag", true, driver.VMwareFusion},
+		{"HyperV with flag", true, driver.HyperV},
+		{"Parallels with flag", true, driver.Parallels},
+	}
+	validCombos := []testStruct{
+		{"Docker with flag", true, driver.Docker},
+		{"Podman with flag", true, driver.Podman},
+		{"Docker w/o flag", false, driver.Docker},
+		{"Podman w/o flag", false, driver.Podman},
+		{"KVM2 w/o flag", false, driver.KVM2},
+		{"VirtualBox w/o flag", false, driver.VirtualBox},
+		{"HyperKit w/o flag", false, driver.HyperKit},
+		{"VMware w/o flag", false, driver.VMware},
+		{"VMwareFusion w/o flag", false, driver.VMwareFusion},
+		{"HyperV w/o flag", false, driver.HyperV},
+		{"Parallels w/o flag", false, driver.Parallels},
+	}
+
+	for _, test := range validCombos {
+		t.Run(test.description, func(t *testing.T) {
+			if !validBaseImageFlag(test.imageSet, test.driver) {
+				t.Errorf("invalidBaseImageFlag(base-image-set=%v, driver=%v): got false, expected true",
+					test.imageSet, test.driver)
+			}
+		})
+	}
+	for _, test := range invalidCombos {
+		t.Run(test.description, func(t *testing.T) {
+			if validBaseImageFlag(test.imageSet, test.driver) {
+				t.Errorf("invalidBaseImageFlag(base-image-set=%v, driver=%v): got true, expected false",
+					test.imageSet, test.driver)
 			}
 		})
 	}

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -282,47 +282,28 @@ func TestSuggestMemoryAllocation(t *testing.T) {
 }
 
 func TestBaseImageFlagDriverCombo(t *testing.T) {
-	type testStruct struct {
-		description string
-		imageSet    bool
-		driver      string
-	}
-	invalidCombos := []testStruct{
-		{"KVM2 with flag", true, driver.KVM2},
-		{"VirtualBox with flag", true, driver.VirtualBox},
-		{"HyperKit with flag", true, driver.HyperKit},
-		{"VMware with flag", true, driver.VMware},
-		{"VMwareFusion with flag", true, driver.VMwareFusion},
-		{"HyperV with flag", true, driver.HyperV},
-		{"Parallels with flag", true, driver.Parallels},
-	}
-	validCombos := []testStruct{
-		{"Docker with flag", true, driver.Docker},
-		{"Podman with flag", true, driver.Podman},
-		{"Docker w/o flag", false, driver.Docker},
-		{"Podman w/o flag", false, driver.Podman},
-		{"KVM2 w/o flag", false, driver.KVM2},
-		{"VirtualBox w/o flag", false, driver.VirtualBox},
-		{"HyperKit w/o flag", false, driver.HyperKit},
-		{"VMware w/o flag", false, driver.VMware},
-		{"VMwareFusion w/o flag", false, driver.VMwareFusion},
-		{"HyperV w/o flag", false, driver.HyperV},
-		{"Parallels w/o flag", false, driver.Parallels},
+	tests := []struct {
+		driver        string
+		canUseBaseImg bool
+	}{
+		{driver.Docker, true},
+		{driver.Podman, true},
+		{driver.None, false},
+		{driver.KVM2, false},
+		{driver.VirtualBox, false},
+		{driver.HyperKit, false},
+		{driver.VMware, false},
+		{driver.VMwareFusion, false},
+		{driver.HyperV, false},
+		{driver.Parallels, false},
 	}
 
-	for _, test := range validCombos {
-		t.Run(test.description, func(t *testing.T) {
-			if !validBaseImageFlag(test.imageSet, test.driver) {
-				t.Errorf("invalidBaseImageFlag(base-image-set=%v, driver=%v): got false, expected true",
-					test.imageSet, test.driver)
-			}
-		})
-	}
-	for _, test := range invalidCombos {
-		t.Run(test.description, func(t *testing.T) {
-			if validBaseImageFlag(test.imageSet, test.driver) {
-				t.Errorf("invalidBaseImageFlag(base-image-set=%v, driver=%v): got true, expected false",
-					test.imageSet, test.driver)
+	for _, test := range tests {
+		t.Run(test.driver, func(t *testing.T) {
+			got := isBaseImageApplicable(test.driver)
+			if got != test.canUseBaseImg {
+				t.Errorf("isBaseImageApplicable(driver=%v): got %v, expected %v",
+					test.driver, got, test.canUseBaseImg)
 			}
 		})
 	}


### PR DESCRIPTION
## Disallow `--base-image` flag when a KIC driver is used

This PR fixes https://github.com/kubernetes/minikube/issues/8891.

If `--base-image` flag is passed for the `start` command and the active driver, passed through command line args or minikube config file is KIC, i.e. 'docker' or 'podman'  an error message is displayed and minikube exits

```shell
izuyev@izuyev-macbookpro --- z/minikube ‹gh8891_forbid_base_image_for_vm_drivers› » minikube start --base-image=local/kicbase:v0.0.10-snapshot --driver hyperkit                                                                                          1 ↵
* minikube v1.13.1 on Darwin 10.15.6
* Using the hyperkit driver based on user configuration

X Exiting due to MK_USAGE: flag --base-image is not available for driver 'hyperkit'. Did you mean to use 'docker' or 'podman' driver instead?
Please use --iso-url flag to configure VM based drivers
```


<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
