### PR TITLE
Return ExHostPermission for insufficient config file permissions

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -161,7 +161,7 @@ func runStart(cmd *cobra.Command, args []string) {
 	if err != nil && !config.IsNotExist(err) {
 		kind := reason.HostConfigLoad
 		if config.IsPermissionDenied(err) {
-			kind = reason.HostPermissionDenied
+			kind = reason.HostHomePermission
 		}
 		exit.Message(kind, "Unable to load config: {{.error}}", out.V{"error": err})
 	}

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -156,9 +156,14 @@ func runStart(cmd *cobra.Command, args []string) {
 		out.WarningT("Profile name '{{.name}}' is not valid", out.V{"name": ClusterFlagValue()})
 		exit.Message(reason.Usage, "Only alphanumeric and dashes '-' are permitted. Minimum 1 character, starting with alphanumeric.")
 	}
+
 	existing, err := config.Load(ClusterFlagValue())
 	if err != nil && !config.IsNotExist(err) {
-		exit.Message(reason.HostConfigLoad, "Unable to load config: {{.error}}", out.V{"error": err})
+		kind := reason.HostConfigLoad
+		if config.IsPermissionDenied(err) {
+			kind = reason.HostPermissionDenied
+		}
+		exit.Message(kind, "Unable to load config: {{.error}}", out.V{"error": err})
 	}
 
 	if existing != nil {

--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -80,6 +80,24 @@ func IsNotExist(err error) bool {
 	return false
 }
 
+// ErrPermissionDenied is the error returned when the config cannot be read
+// due to insufficient permissions
+type ErrPermissionDenied struct {
+	s string
+}
+
+func (e *ErrPermissionDenied) Error() string {
+	return e.s
+}
+
+// IsPermissionDenied returns whether the error is a ErrPermissionDenied instance
+func IsPermissionDenied(err error) bool {
+	if _, ok := err.(*ErrPermissionDenied); ok {
+		return true
+	}
+	return false
+}
+
 // MinikubeConfig represents minikube config
 type MinikubeConfig map[string]interface{}
 
@@ -184,6 +202,9 @@ func (c *simpleConfigLoader) LoadConfigFromFile(profileName string, miniHome ...
 
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
+		if os.IsPermission(err) {
+			return nil, &ErrPermissionDenied{err.Error()}
+		}
 		return nil, errors.Wrap(err, "read")
 	}
 

--- a/pkg/minikube/reason/known_issues.go
+++ b/pkg/minikube/reason/known_issues.go
@@ -202,12 +202,7 @@ var hostIssues = []match{
 		GOOS:   []string{"linux"},
 	},
 	{
-		Kind: Kind{
-			ID:       "HOST_HOME_PERMISSION",
-			ExitCode: ExGuestPermission,
-			Advice:   "Your user lacks permissions to the minikube profile directory. Run: 'sudo chown -R $USER $HOME/.minikube; chmod -R u+wrx $HOME/.minikube' to fix",
-			Issues:   []int{9165},
-		},
+		Kind:   HostHomePermission,
 		Regexp: re(`/.minikube/.*: permission denied`),
 	},
 }

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -192,6 +192,7 @@ var (
 	HostHomeChown        = Kind{ID: "HOST_HOME_CHOWN", ExitCode: ExHostPermission}
 	HostBrowser          = Kind{ID: "HOST_BROWSER", ExitCode: ExHostError}
 	HostConfigLoad       = Kind{ID: "HOST_CONFIG_LOAD", ExitCode: ExHostConfig}
+	HostPermissionDenied = Kind{ID: "HOST_PERMISSION_DENIED", ExitCode: ExHostPermission}
 	HostCurrentUser      = Kind{ID: "HOST_CURRENT_USER", ExitCode: ExHostConfig}
 	HostDelCache         = Kind{ID: "HOST_DEL_CACHE", ExitCode: ExHostError}
 	HostKillMountProc    = Kind{ID: "HOST_KILL_MOUNT_PROC", ExitCode: ExHostError}

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -188,11 +188,17 @@ var (
 
 	RsrcInsufficientStorage = Kind{ID: "RSRC_INSUFFICIENT_STORAGE", ExitCode: ExInsufficientStorage, Style: style.UnmetRequirement}
 
-	HostHomeMkdir        = Kind{ID: "HOST_HOME_MKDIR", ExitCode: ExHostPermission}
-	HostHomeChown        = Kind{ID: "HOST_HOME_CHOWN", ExitCode: ExHostPermission}
-	HostBrowser          = Kind{ID: "HOST_BROWSER", ExitCode: ExHostError}
-	HostConfigLoad       = Kind{ID: "HOST_CONFIG_LOAD", ExitCode: ExHostConfig}
-	HostPermissionDenied = Kind{ID: "HOST_PERMISSION_DENIED", ExitCode: ExHostPermission}
+	HostHomeMkdir      = Kind{ID: "HOST_HOME_MKDIR", ExitCode: ExHostPermission}
+	HostHomeChown      = Kind{ID: "HOST_HOME_CHOWN", ExitCode: ExHostPermission}
+	HostBrowser        = Kind{ID: "HOST_BROWSER", ExitCode: ExHostError}
+	HostConfigLoad     = Kind{ID: "HOST_CONFIG_LOAD", ExitCode: ExHostConfig}
+	HostHomePermission = Kind{
+		ID:       "HOST_HOME_PERMISSION",
+		ExitCode: ExHostPermission,
+		Advice:   "Your user lacks permissions to the minikube profile directory. Run: 'sudo chown -R $USER $HOME/.minikube; chmod -R u+wrx $HOME/.minikube' to fix",
+		Issues:   []int{9165},
+	}
+
 	HostCurrentUser      = Kind{ID: "HOST_CURRENT_USER", ExitCode: ExHostConfig}
 	HostDelCache         = Kind{ID: "HOST_DEL_CACHE", ExitCode: ExHostError}
 	HostKillMountProc    = Kind{ID: "HOST_KILL_MOUNT_PROC", ExitCode: ExHostError}


### PR DESCRIPTION
Fixes #9297.

Insufficient permissions for reading the config will now result in a `HOST_PERMISSION_DENIED` instead of `HOST_CONFIG_LOAD`, which uses `ExHostPermission` as exit code. I'm yet not sure if this is an appropriate `reason.Kind` instance - the alternative could be to just stick with `HOST_CONFIG_LOAD` and change its `ErrorCode` manually.