### PR TITLE
Make sure gcp-auth addon can be enabled on startup

### DIFF
--- a/deploy/addons/gcp-auth/gcp-auth-webhook.yaml
+++ b/deploy/addons/gcp-auth/gcp-auth-webhook.yaml
@@ -135,6 +135,12 @@ webhooks:
     matchExpressions:
       - key: gcp-auth-skip-secret
         operator: DoesNotExist
+  namespaceSelector:
+    matchExpressions:
+      - key: name
+        operator: NotIn
+        values:
+        - kube-system
   sideEffects: None
   admissionReviewVersions: ["v1","v1beta1"]
   clientConfig:

--- a/deploy/addons/gcp-auth/gcp-auth-webhook.yaml
+++ b/deploy/addons/gcp-auth/gcp-auth-webhook.yaml
@@ -131,6 +131,7 @@ metadata:
     app: gcp-auth
 webhooks:
 - name: gcp-auth-mutate.k8s.io
+  failurePolicy: Fail
   objectSelector:
     matchExpressions:
       - key: gcp-auth-skip-secret

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -405,7 +405,7 @@ func Start(wg *sync.WaitGroup, cc *config.ClusterConfig, toEnable map[string]boo
 
 	var awg sync.WaitGroup
 
-	deferredAddons := []string{}
+	deferredAddons := []string{"gcp-auth"}
 	enabledAddons := []string{}
 
 	defer func() { // making it show after verifications (see #7613)
@@ -414,11 +414,12 @@ func Start(wg *sync.WaitGroup, cc *config.ClusterConfig, toEnable map[string]boo
 	}()
 	var addonErr error
 	for _, a := range toEnableList {
-		// Run the gcp-auth addon last to give everything else extra time to come up
-		if a == "gcp-auth" {
-			deferredAddons = append(deferredAddons, a)
-			continue
+		for _, da := range deferredAddons {
+			if a == da {
+				continue
+			}
 		}
+
 		awg.Add(1)
 		err := func(name string) error {
 			err := RunCallbacks(cc, name, "true")

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -324,11 +324,12 @@ func verifyAddonStatus(cc *config.ClusterConfig, name string, val string) error 
 }
 
 func verifyGCPAuthAddon(cc *config.ClusterConfig, name string, val string) error {
-	err := verifyAddonStatusInternal(cc, name, val, "gcp-auth")
 	enable, err := strconv.ParseBool(val)
 	if err != nil {
 		return errors.Wrapf(err, "parsing bool: %s", name)
 	}
+	err = verifyAddonStatusInternal(cc, name, val, "gcp-auth")
+
 	if enable && err == nil {
 		out.T(style.Notice, "Your GCP credentials will now be mounted into every pod created in the {{.name}} cluster.", out.V{"name": cc.Name})
 		out.T(style.Notice, "If you don't want your credentials mounted into a specific pod, add a label with the `gcp-auth-skip-secret` key to your pod configuration.")

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -414,7 +414,7 @@ func Start(wg *sync.WaitGroup, cc *config.ClusterConfig, toEnable map[string]boo
 	}()
 	var addonErr error
 	for _, a := range toEnableList {
-		// Run the gcp-auth addon last to make sure everything else is up
+		// Run the gcp-auth addon last to give everything else extra time to come up
 		if a == "gcp-auth" {
 			deferredAddons = append(deferredAddons, a)
 			continue

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -324,7 +324,17 @@ func verifyAddonStatus(cc *config.ClusterConfig, name string, val string) error 
 }
 
 func verifyGCPAuthAddon(cc *config.ClusterConfig, name string, val string) error {
-	return verifyAddonStatusInternal(cc, name, val, "gcp-auth")
+	err := verifyAddonStatusInternal(cc, name, val, "gcp-auth")
+	enable, err := strconv.ParseBool(val)
+	if err != nil {
+		return errors.Wrapf(err, "parsing bool: %s", name)
+	}
+	if enable && err == nil {
+		out.T(style.Notice, "Your GCP credentials will now be mounted into every pod created in the {{.name}} cluster.", out.V{"name": cc.Name})
+		out.T(style.Notice, "If you don't want your credentials mounted into a specific pod, add a label with the `gcp-auth-skip-secret` key to your pod configuration.")
+	}
+
+	return err
 }
 
 func verifyAddonStatusInternal(cc *config.ClusterConfig, name string, val string, ns string) error {
@@ -394,24 +404,53 @@ func Start(wg *sync.WaitGroup, cc *config.ClusterConfig, toEnable map[string]boo
 
 	var awg sync.WaitGroup
 
-	defer func() { // making it show after verifications( not perfect till #7613 is closed)
+	deferredAddons := []string{}
+	enabledAddons := []string{}
+
+	defer func() { // making it show after verifications (see #7613)
 		register.Reg.SetStep(register.EnablingAddons)
-		out.T(style.AddonEnable, "Enabled addons: {{.addons}}", out.V{"addons": strings.Join(toEnableList, ", ")})
+		out.T(style.AddonEnable, "Enabled addons: {{.addons}}", out.V{"addons": enabledAddons})
 	}()
+	var addonErr error
 	for _, a := range toEnableList {
+		// Run the gcp-auth addon last to make sure everything else is up
+		if a == "gcp-auth" {
+			deferredAddons = append(deferredAddons, a)
+			continue
+		}
 		awg.Add(1)
-		go func(name string) {
+		err := func(name string) error {
 			err := RunCallbacks(cc, name, "true")
 			if err != nil {
 				out.WarningT("Enabling '{{.name}}' returned an error: {{.error}}", out.V{"name": name, "error": err})
 			}
 			awg.Done()
+			return err
 		}(a)
+
+		if err != nil {
+			addonErr = err
+		} else {
+			enabledAddons = append(enabledAddons, a)
+		}
 	}
 
 	// Wait until all of the addons are enabled before updating the config (not thread safe)
 	awg.Wait()
-	for _, a := range toEnableList {
+
+	// Don't bother trying more addons if one of the default ones failed
+	if addonErr == nil {
+		for _, a := range deferredAddons {
+			err := RunCallbacks(cc, a, "true")
+			if err != nil {
+				out.WarningT("Enabling '{{.name}}' returned an error: {{.error}}", out.V{"name": a, "error": err})
+			} else {
+				enabledAddons = append(enabledAddons, a)
+			}
+		}
+	}
+
+	for _, a := range enabledAddons {
 		if err := Set(cc, a, "true"); err != nil {
 			glog.Errorf("store failed: %v", err)
 		}

--- a/pkg/addons/config.go
+++ b/pkg/addons/config.go
@@ -169,7 +169,7 @@ var Addons = []*Addon{
 	{
 		name:      "gcp-auth",
 		set:       SetBool,
-		callbacks: []setFn{gcpauth.EnableOrDisable, enableOrDisableAddon, verifyGCPAuthAddon, gcpauth.DisplayAddonMessage},
+		callbacks: []setFn{gcpauth.EnableOrDisable, enableOrDisableAddon, verifyGCPAuthAddon},
 	},
 	{
 		name:      "volumesnapshots",

--- a/pkg/addons/gcpauth/enable.go
+++ b/pkg/addons/gcpauth/enable.go
@@ -60,7 +60,7 @@ func enableAddon(cfg *config.ClusterConfig) error {
 	ctx := context.Background()
 	creds, err := google.FindDefaultCredentials(ctx)
 	if err != nil {
-		exit.Message(reason.InternalCredsNotFound, "Could not find any GCP credentials. Either run `gcloud auth login` or set the GOOGLE_APPLICATION_CREDENTIALS environment variable to the path of your credentials file.")
+		exit.Message(reason.InternalCredsNotFound, "Could not find any GCP credentials. Either run `gcloud auth application-default login` or set the GOOGLE_APPLICATION_CREDENTIALS environment variable to the path of your credentials file.")
 	}
 
 	f := assets.NewMemoryAssetTarget(creds.JSON, credentialsPath, "0444")

--- a/pkg/addons/gcpauth/enable.go
+++ b/pkg/addons/gcpauth/enable.go
@@ -116,16 +116,3 @@ func disableAddon(cfg *config.ClusterConfig) error {
 
 	return nil
 }
-
-// DisplayAddonMessage display an gcp auth addon specific message to the user
-func DisplayAddonMessage(cfg *config.ClusterConfig, name string, val string) error {
-	enable, err := strconv.ParseBool(val)
-	if err != nil {
-		return errors.Wrapf(err, "parsing bool: %s", name)
-	}
-	if enable {
-		out.T(style.Notice, "Your GCP credentials will now be mounted into every pod created in the {{.name}} cluster.", out.V{"name": cfg.Name})
-		out.T(style.Notice, "If you don't want your credentials mounted into a specific pod, add a label with the `gcp-auth-skip-secret` key to your pod configuration.")
-	}
-	return nil
-}

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -149,10 +149,8 @@ func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 	}()
 
 	// enable addons, both old and new!
-	if starter.ExistingAddons != nil {
-		wg.Add(1)
-		go addons.Start(&wg, starter.Cfg, starter.ExistingAddons, config.AddonList)
-	}
+	wg.Add(1)
+	go addons.Start(&wg, starter.Cfg, starter.ExistingAddons, config.AddonList)
 
 	wg.Add(1)
 	go func() {

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -149,8 +149,10 @@ func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 	}()
 
 	// enable addons, both old and new!
-	wg.Add(1)
-	go addons.Start(&wg, starter.Cfg, starter.ExistingAddons, config.AddonList)
+	if starter.ExistingAddons != nil {
+		wg.Add(1)
+		go addons.Start(&wg, starter.Cfg, starter.ExistingAddons, config.AddonList)
+	}
 
 	wg.Add(1)
 	go func() {

--- a/site/content/en/docs/handbook/addons/gcp-auth.md
+++ b/site/content/en/docs/handbook/addons/gcp-auth.md
@@ -5,7 +5,7 @@ weight: 1
 date: 2020-07-15
 ---
 
-If you have a containerized GCP app with a Kubernetes yaml, you can automatically add your credentials to all your deployed pods dynamically with this minikube addon. You just need to have a credentials file, which can be generated with `gcloud auth login`. If you already have a json credentials file you want specify, use the GOOGLE_APPLICATION_CREDENTIALS environment variable.
+If you have a containerized GCP app with a Kubernetes yaml, you can automatically add your credentials to all your deployed pods dynamically with this minikube addon. You just need to have a credentials file, which can be generated with `gcloud auth application-default login`. If you already have a json credentials file you want specify, use the GOOGLE_APPLICATION_CREDENTIALS environment variable.
 
 - Start a cluster:
 ```


### PR DESCRIPTION
This PR makes sure the gcp-auth addons can be enabled on startup safely by making it the last addon enabled. It also fixes a documentation issue in an error message and makes sure we never apply the webhook to the internal kube-system pods.

Fixes #9208
Fixes #9215 