### PR TITLE
Remove duplicate command additions

### DIFF
--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -91,7 +91,6 @@ func init() {
 	if err := viper.BindPFlags(deleteCmd.Flags()); err != nil {
 		exit.Error(reason.InternalBindFlags, "unable to bind flags", err)
 	}
-	RootCmd.AddCommand(deleteCmd)
 }
 
 // shotgun cleanup to delete orphaned docker container data

--- a/cmd/minikube/cmd/stop.go
+++ b/cmd/minikube/cmd/stop.go
@@ -60,8 +60,6 @@ func init() {
 	if err := viper.GetViper().BindPFlags(stopCmd.Flags()); err != nil {
 		exit.Error(reason.InternalFlagsBind, "unable to bind flags", err)
 	}
-
-	RootCmd.AddCommand(stopCmd)
 }
 
 // runStop handles the executes the flow of "minikube stop"


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->


**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The process of adding commands to `RootCmd` is in `cmd/root.go#init`, so the following processes are duplicated.

- `RootCmd.AddCommand(deleteCmd)`
  - at `cmd/delete.go#init`
- `RootCmd.AddCommand(stopCmd)`
  - at `cmd/stop.go#init`

**Which issue(s) this PR fixes**:
fixes #9293

**Does this PR introduce a user-facing change?**:
Yes. this PR fixes the behavior of the suggestions for misspellings of `minikube delete` and `minikube stop`.

before :  the suggestions for misspellings are displayed twice.

```sh
$ out/minikube dele
Error: unknown command "dele" for "minikube"

Did you mean this?
        delete
        delete

Run 'minikube --help' for usage.
$ out/minikube sto
Error: unknown command "sto" for "minikube"

Did you mean this?
        ssh
        stop
        stop

Run 'minikube --help' for usage.
$ 
```

after : the suggestions for misspellings are displayed once.

```sh
$ out/minikube dele
Error: unknown command "dele" for "minikube"

Did you mean this?
        delete

Run 'minikube --help' for usage.
$ out/minikube sto
Error: unknown command "sto" for "minikube"

Did you mean this?
        ssh
        stop

Run 'minikube --help' for usage.
$ 
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
NONE
```