### PR TITLE
give the logs test a little wiggle room

### DIFF
--- a/pkg/minikube/perf/logs_test.go
+++ b/pkg/minikube/perf/logs_test.go
@@ -38,7 +38,8 @@ func TestTimeCommandLogs(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected log %s but didn't find it", log)
 		}
-		if actualTime < time {
+		// Let's give a little wiggle room so we don't fail if time is 3 and actualTime is 2.999
+		if actualTime < time && time-actualTime > 0.001 {
 			t.Fatalf("expected log \"%s\" to take more time than it actually did. got %v, expected > %v", log, actualTime, time)
 		}
 	}


### PR DESCRIPTION
Every so often during the unit tests, TestTimeCommandLogs will fail like this:
```
--- FAIL: TestTimeCommandLogs (4.00s)
    logs_test.go:42: expected log "hi" to take more time than it actually did. got 2.999284149, expected > 3
FAIL
```
which is just silly. So let's just give the test a little leeway so we pass this scenario without compromising the point of the test.
