### PR TITLE
Fix SVG logo file (white/icon)

### DIFF
--- a/images/logo/logo_white.svg
+++ b/images/logo/logo_white.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg width="702px" height="683px" viewBox="0 0 702 683" version="1.1" xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 39.1 (31720) - https://www.sketchapp.com/ -->
+<svg width="702px" height="683px" viewBox="0 0 702 683" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 39.1 (31720) - http://www.bohemiancoding.com/sketch -->
     <title>minikube</title>
     <desc>Created with Sketch.</desc>
     <defs>


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
The file [`images/logo/logo_white.svg`](https://github.com/kubernetes/minikube/blob/master/images/logo/logo_white.svg) included invalid namespace URLs (`https` instead of `http`) and for this reason could not be displayed by any of the browsers that I tested (Chrome, Safari, Firefox, Opera). It resulted in the following error:

![Screenshot 2020-09-26 at 14 55 09](https://user-images.githubusercontent.com/2396208/94341298-75bd2300-0008-11eb-9332-af6d92048f69.png)


 I fixed the URLs to be analogous to the black version of the logo ([`images/logo/logo.svg`](https://github.com/kubernetes/minikube/blob/master/images/logo/logo.svg)) and now the file can be correctly displayed.

Apparently, this bug has been introduced by #3061 (not sure what the reason for this was).