### PR TITLE
The ISO build doesn't need Go installed on host

### DIFF
--- a/.github/workflows/iso.yml
+++ b/.github/workflows/iso.yml
@@ -64,11 +64,6 @@ jobs:
           echo workspace $GITHUB_WORKSPACE
           echo "end of debug stuff"
           echo $(which jq)
-      # iso needs golang 1.11.3 
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '1.11.13'
-          stable: true
       - name: Build ISO
         run: |
           whoami


### PR DESCRIPTION
Buildroot will bootstrap the Go compiler anyway...

Updated after comments by @prezha in #9280 

The previous commit message was a bit useless:

* a029474f1 rebase