### PR TITLE
Make storage-provisioner available for all arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,12 +94,8 @@ GVISOR_TAG ?= latest
 # storage provisioner tag to push changes to
 STORAGE_PROVISIONER_TAG ?= v3
 
-# TODO: multi-arch manifest
-ifeq ($(GOARCH),amd64)
-STORAGE_PROVISIONER_IMAGE ?= $(REGISTRY)/storage-provisioner:$(STORAGE_PROVISIONER_TAG)
-else
+STORAGE_PROVISIONER_MANIFEST ?= $(REGISTRY)/storage-provisioner:$(STORAGE_PROVISIONER_TAG)
 STORAGE_PROVISIONER_IMAGE ?= $(REGISTRY)/storage-provisioner-$(GOARCH):$(STORAGE_PROVISIONER_TAG)
-endif
 
 # Set the version information for the Kubernetes servers
 MINIKUBE_LDFLAGS := -X k8s.io/minikube/pkg/version.version=$(VERSION) -X k8s.io/minikube/pkg/version.isoVersion=$(ISO_VERSION) -X k8s.io/minikube/pkg/version.isoPath=$(ISO_BUCKET) -X k8s.io/minikube/pkg/version.gitCommitID=$(COMMIT) -X k8s.io/minikube/pkg/version.storageProvisionerVersion=$(STORAGE_PROVISIONER_TAG)
@@ -573,8 +569,11 @@ else
 endif
 
 .PHONY: storage-provisioner-image
-storage-provisioner-image: out/storage-provisioner-$(GOARCH) ## Build storage-provisioner docker image
-	docker build -t $(STORAGE_PROVISIONER_IMAGE) -f deploy/storage-provisioner/Dockerfile  --build-arg arch=$(GOARCH) .
+storage-provisioner-image: storage-provisioner-image-$(GOARCH) ## Build storage-provisioner docker image
+	docker tag $(REGISTRY)/storage-provisioner-$(GOARCH):$(STORAGE_PROVISIONER_TAG) $(REGISTRY)/storage-provisioner:$(STORAGE_PROVISIONER_TAG)
+
+storage-provisioner-image-%: out/storage-provisioner-%
+	docker build -t $(REGISTRY)/storage-provisioner-$*:$(STORAGE_PROVISIONER_TAG) -f deploy/storage-provisioner/Dockerfile  --build-arg arch=$* .
 
 .PHONY: kic-base-image
 kic-base-image: ## builds the base image used for kic.
@@ -594,6 +593,18 @@ upload-preloaded-images-tar: out/minikube # Upload the preloaded images for olde
 push-storage-provisioner-image: storage-provisioner-image ## Push storage-provisioner docker image using gcloud
 	docker login gcr.io/k8s-minikube
 	$(MAKE) push-docker IMAGE=$(STORAGE_PROVISIONER_IMAGE)
+
+ALL_ARCH = amd64 arm arm64 ppc64le s390x
+IMAGE = $(REGISTRY)/storage-provisioner
+TAG = $(STORAGE_PROVISIONER_TAG)
+
+.PHONY: push-storage-provisioner-manifest
+push-storage-provisioner-manifest: $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~storage\-provisioner\-image\-&~g")
+	docker login gcr.io/k8s-minikube
+	set -x; for arch in $(ALL_ARCH); do docker push ${IMAGE}-$${arch}:${TAG}; done
+	docker manifest create --amend $(IMAGE):$(TAG) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(IMAGE)\-&:$(TAG)~g")
+	set -x; for arch in $(ALL_ARCH); do docker manifest annotate --arch $${arch} ${IMAGE}:${TAG} ${IMAGE}-$${arch}:${TAG}; done
+	docker manifest push $(STORAGE_PROVISIONER_MANIFEST)
 
 .PHONY: push-docker
 push-docker: # Push docker image base on to IMAGE variable

--- a/deploy/addons/storage-provisioner/storage-provisioner.yaml.tmpl
+++ b/deploy/addons/storage-provisioner/storage-provisioner.yaml.tmpl
@@ -100,7 +100,7 @@ spec:
   hostNetwork: true
   containers:
   - name: storage-provisioner
-    image: {{default "gcr.io/k8s-minikube" .ImageRepository}}/storage-provisioner{{.ExoticArch}}:{{.StorageProvisionerVersion}}
+    image: {{default "gcr.io/k8s-minikube" .ImageRepository}}/storage-provisioner:{{.StorageProvisionerVersion}}
     command: ["/storage-provisioner"]
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/hack/jenkins/release_build_and_upload.sh
+++ b/hack/jenkins/release_build_and_upload.sh
@@ -67,7 +67,7 @@ if ! [[ ${VERSION_BUILD} =~ ^[0-9]+$ ]]; then
 fi
 
 #echo "Updating Docker images ..."
-#make push-gvisor-addon-image push-storage-provisioner-image
+#make push-gvisor-addon-image push-storage-provisioner-manifest
 
 echo "Updating latest bucket for ${VERSION} release ..."
 gsutil cp -r "gs://${BUCKET}/releases/${TAGNAME}/*" "gs://${BUCKET}/releases/latest/"


### PR DESCRIPTION
Always use architecture when building the image.

When developing locally, tag the image with version
(this tag now refers to the local host architecture)

When making a release, make a manifest with version
(this manifest now lists all supported architectures)

Don't use architecture, when specifying "image:".

Closes #9061
