### PR TITLE
Added target for Windows HTML & switched encoding for Windows Report

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -362,7 +362,7 @@ jobs:
           $env:KUBECONFIG="${pwd}\testhome\kubeconfig"
           $env:MINIKUBE_HOME="${pwd}\testhome"
           $ErrorActionPreference = "SilentlyContinue"
-          .\e2e-windows-amd64.exe --minikube-start-args="--driver=docker" --test.timeout=15m --timeout-multiplier=1 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Out-File -Encoding utf8 -FilePath ".\report\testout.txt"
+          .\e2e-windows-amd64.exe --minikube-start-args="--driver=docker" --test.timeout=15m --timeout-multiplier=1 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Tee-Object -FilePath ".\report\testout.txt"
           $END_TIME=(GET-DATE)
           echo $END_TIME
           $DURATION=(NEW-TIMESPAN -Start $START_TIME -End $END_TIME)
@@ -379,7 +379,7 @@ jobs:
         shell: powershell
         run: |
           cd minikube_binaries
-          Get-Content .\report\testout.txt -Encoding UTF8  | go tool test2json -t | Out-File -FilePath .\report\testout.json -Encoding utf8
+          Get-Content .\report\testout.txt -Encoding ASCII  | go tool test2json -t | Out-File -FilePath .\report\testout.json -Encoding ASCII
           $STAT=(gopogh -in .\report\testout.json -out .\report\testout.html -name "${Env:JOB_NAME} ${Env:GITHUB_REF}" -repo "${Env:GITHUB_REPOSITORY}"  -details "${Env:GITHUB_SHA}")
           echo status: ${STAT}
           $FailNum=$(echo $STAT | jq '.NumberOfFail')
@@ -412,7 +412,7 @@ jobs:
           echo "---------------- ${numFail} Failures :( ----------------------------"
           echo $failedTests
           echo "-------------------------------------------------------"
-          If ($numFail -gt 0){ exit 2 } 
+          If ($numFail -gt 0){ exit 2 }
           If ($numPass -eq 0){ exit 2 }
           If ($numPass -lt 33){ exit 2 }
           If ($numFail -eq 0){ exit 0 }
@@ -429,7 +429,7 @@ jobs:
         shell: powershell
         run: |
           echo $env:computerName
-          ls 
+          ls
           $ErrorActionPreference = "SilentlyContinue"
           cd minikube_binaries
           ls
@@ -464,14 +464,14 @@ jobs:
           $docker_running = $?
           }
           Write-Output "Docker is running"
-          docker system prune -f 
+          docker system prune -f
       - name: Info
         continue-on-error: true
         shell: powershell
         run: |
           $ErrorActionPreference = "SilentlyContinue"
           cd minikube_binaries
-          ls 
+          ls
           echo $env:computername
           Get-WmiObject -class Win32_ComputerSystem
       - uses: actions/setup-go@v2
@@ -483,7 +483,7 @@ jobs:
         shell: powershell
         run: |
           $ErrorActionPreference = "SilentlyContinue"
-          (New-Object Net.WebClient).DownloadFile("https://github.com/medyagh/gopogh/releases/download/v0.2.4/gopogh.exe", "C:\ProgramData\chocolatey\bin\gopogh.exe")          
+          (New-Object Net.WebClient).DownloadFile("https://github.com/medyagh/gopogh/releases/download/v0.2.4/gopogh.exe", "C:\ProgramData\chocolatey\bin\gopogh.exe")
           choco install -y kubernetes-cli
           choco install -y jq
           choco install -y caffeine
@@ -499,7 +499,7 @@ jobs:
           $env:KUBECONFIG="${pwd}\testhome\kubeconfig"
           $env:MINIKUBE_HOME="${pwd}\testhome"
           $ErrorActionPreference = "SilentlyContinue"
-          .\e2e-windows-amd64.exe --minikube-start-args="--driver=hyperv" --test.timeout=20m --timeout-multiplier=1.5 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Out-File -Encoding utf8 -FilePath ".\report\testout.txt"
+          .\e2e-windows-amd64.exe --minikube-start-args="--driver=hyperv" --test.timeout=20m --timeout-multiplier=1.5 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Tee-Object -FilePath ".\report\testout.txt"
           $END_TIME=(GET-DATE)
           echo $END_TIME
           $DURATION=(NEW-TIMESPAN -Start $START_TIME -End $END_TIME)
@@ -516,7 +516,7 @@ jobs:
         shell: powershell
         run: |
           cd minikube_binaries
-          Get-Content .\report\testout.txt -Encoding UTF8  | go tool test2json -t | Out-File -FilePath .\report\testout.json -Encoding utf8
+          Get-Content .\report\testout.txt -Encoding ASCII  | go tool test2json -t | Out-File -FilePath .\report\testout.json -Encoding ASCII
           $STAT=(gopogh -in .\report\testout.json -out .\report\testout.html -name "${Env:JOB_NAME} ${Env:GITHUB_REF}" -repo "${Env:GITHUB_REPOSITORY}"  -details "${Env:GITHUB_SHA}")
           echo status: ${STAT}
           $FailNum=$(echo $STAT | jq '.NumberOfFail')
@@ -549,7 +549,7 @@ jobs:
           echo "---------------- ${numFail} Failures :( ----------------------------"
           echo $failedTests
           echo "-------------------------------------------------------"
-          If ($numFail -gt 0){ exit 2 } 
+          If ($numFail -gt 0){ exit 2 }
           If ($numPass -eq 0){ exit 2 }
           If ($numPass -lt 33){ exit 2 }
           If ($numFail -eq 0){ exit 0 }
@@ -775,11 +775,11 @@ jobs:
         run: |
           hostname
           VBoxManage --version
-          sysctl hw.physicalcpu hw.logicalcpu 
+          sysctl hw.physicalcpu hw.logicalcpu
       - name: Disable firewall
         run: |
           sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
-          sudo /usr/libexec/ApplicationFirewall/socketfilterfw -k      
+          sudo /usr/libexec/ApplicationFirewall/socketfilterfw -k
       - name: Download Binaries
         uses: actions/download-artifact@v1
         with:
@@ -966,7 +966,7 @@ jobs:
         run: |
           hostname
           VBoxManage --version
-          sysctl hw.physicalcpu hw.logicalcpu 
+          sysctl hw.physicalcpu hw.logicalcpu
       - name: Disable firewall
         run: |
           sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
@@ -1150,7 +1150,7 @@ jobs:
         run: |
           hostname
           VBoxManage --version
-          sysctl hw.physicalcpu hw.logicalcpu 
+          sysctl hw.physicalcpu hw.logicalcpu
       - name: Disable firewall
         run: |
           sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -362,7 +362,7 @@ jobs:
           $env:KUBECONFIG="${pwd}\testhome\kubeconfig"
           $env:MINIKUBE_HOME="${pwd}\testhome"
           $ErrorActionPreference = "SilentlyContinue"
-          .\e2e-windows-amd64.exe --minikube-start-args="--driver=docker" --test.timeout=15m --timeout-multiplier=1 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Tee-Object -FilePath ".\report\testout.txt"
+          .\e2e-windows-amd64.exe --minikube-start-args="--driver=docker" --test.timeout=15m --timeout-multiplier=1 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Out-File -Encoding utf8 -FilePath ".\report\testout.txt"
           $END_TIME=(GET-DATE)
           echo $END_TIME
           $DURATION=(NEW-TIMESPAN -Start $START_TIME -End $END_TIME)
@@ -379,7 +379,7 @@ jobs:
         shell: powershell
         run: |
           cd minikube_binaries
-          Get-Content .\report\testout.txt -Encoding ASCII  | go tool test2json -t | Out-File -FilePath .\report\testout.json -Encoding ASCII
+          Get-Content .\report\testout.txt -Encoding UTF8  | go tool test2json -t | Out-File -FilePath .\report\testout.json -Encoding utf8
           $STAT=(gopogh -in .\report\testout.json -out .\report\testout.html -name "${Env:JOB_NAME} ${Env:GITHUB_REF}" -repo "${Env:GITHUB_REPOSITORY}"  -details "${Env:GITHUB_SHA}")
           echo status: ${STAT}
           $FailNum=$(echo $STAT | jq '.NumberOfFail')
@@ -499,7 +499,7 @@ jobs:
           $env:KUBECONFIG="${pwd}\testhome\kubeconfig"
           $env:MINIKUBE_HOME="${pwd}\testhome"
           $ErrorActionPreference = "SilentlyContinue"
-          .\e2e-windows-amd64.exe --minikube-start-args="--driver=hyperv" --test.timeout=20m --timeout-multiplier=1.5 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Tee-Object -FilePath ".\report\testout.txt"
+          .\e2e-windows-amd64.exe --minikube-start-args="--driver=hyperv" --test.timeout=20m --timeout-multiplier=1.5 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Out-File -Encoding utf8 -FilePath ".\report\testout.txt"
           $END_TIME=(GET-DATE)
           echo $END_TIME
           $DURATION=(NEW-TIMESPAN -Start $START_TIME -End $END_TIME)
@@ -516,7 +516,7 @@ jobs:
         shell: powershell
         run: |
           cd minikube_binaries
-          Get-Content .\report\testout.txt -Encoding ASCII  | go tool test2json -t | Out-File -FilePath .\report\testout.json -Encoding ASCII
+          Get-Content .\report\testout.txt -Encoding UTF8  | go tool test2json -t | Out-File -FilePath .\report\testout.json -Encoding utf8
           $STAT=(gopogh -in .\report\testout.json -out .\report\testout.html -name "${Env:JOB_NAME} ${Env:GITHUB_REF}" -repo "${Env:GITHUB_REPOSITORY}"  -details "${Env:GITHUB_SHA}")
           echo status: ${STAT}
           $FailNum=$(echo $STAT | jq '.NumberOfFail')

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -360,7 +360,7 @@ jobs:
           $env:KUBECONFIG="${pwd}\testhome\kubeconfig"
           $env:MINIKUBE_HOME="${pwd}\testhome"
           $ErrorActionPreference = "SilentlyContinue"
-          .\e2e-windows-amd64.exe --minikube-start-args="--driver=docker" --test.timeout=15m --timeout-multiplier=1 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Tee-Object -FilePath ".\report\testout.txt"
+          .\e2e-windows-amd64.exe --minikube-start-args="--driver=docker" --test.timeout=15m --timeout-multiplier=1 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Out-File -Encoding utf8 -FilePath ".\report\testout.txt"
           $END_TIME=(GET-DATE)
           echo $END_TIME
           $DURATION=(NEW-TIMESPAN -Start $START_TIME -End $END_TIME)
@@ -377,7 +377,7 @@ jobs:
         shell: powershell
         run: |
           cd minikube_binaries
-          Get-Content .\report\testout.txt -Encoding ASCII  | go tool test2json -t | Out-File -FilePath .\report\testout.json -Encoding ASCII
+          Get-Content .\report\testout.txt -Encoding UTF8  | go tool test2json -t | Out-File -FilePath .\report\testout.json -Encoding utf8
           $STAT=(gopogh -in .\report\testout.json -out .\report\testout.html -name "${Env:JOB_NAME} ${Env:GITHUB_REF}" -repo "${Env:GITHUB_REPOSITORY}"  -details "${Env:GITHUB_SHA}")
           echo status: ${STAT}
           $FailNum=$(echo $STAT | jq '.NumberOfFail')
@@ -497,7 +497,7 @@ jobs:
           $env:KUBECONFIG="${pwd}\testhome\kubeconfig"
           $env:MINIKUBE_HOME="${pwd}\testhome"
           $ErrorActionPreference = "SilentlyContinue"
-          .\e2e-windows-amd64.exe --minikube-start-args="--driver=hyperv" --test.timeout=20m --timeout-multiplier=1.5 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Tee-Object -FilePath ".\report\testout.txt"
+          .\e2e-windows-amd64.exe --minikube-start-args="--driver=hyperv" --test.timeout=20m --timeout-multiplier=1.5 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Out-File -Encoding utf8 -FilePath ".\report\testout.txt"
           $END_TIME=(GET-DATE)
           echo $END_TIME
           $DURATION=(NEW-TIMESPAN -Start $START_TIME -End $END_TIME)
@@ -514,7 +514,7 @@ jobs:
         shell: powershell
         run: |
           cd minikube_binaries
-          Get-Content .\report\testout.txt -Encoding ASCII  | go tool test2json -t | Out-File -FilePath .\report\testout.json -Encoding ASCII
+          Get-Content .\report\testout.txt -Encoding UTF8  | go tool test2json -t | Out-File -FilePath .\report\testout.json -Encoding utf8
           $STAT=(gopogh -in .\report\testout.json -out .\report\testout.html -name "${Env:JOB_NAME} ${Env:GITHUB_REF}" -repo "${Env:GITHUB_REPOSITORY}"  -details "${Env:GITHUB_SHA}")
           echo status: ${STAT}
           $FailNum=$(echo $STAT | jq '.NumberOfFail')

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -360,7 +360,7 @@ jobs:
           $env:KUBECONFIG="${pwd}\testhome\kubeconfig"
           $env:MINIKUBE_HOME="${pwd}\testhome"
           $ErrorActionPreference = "SilentlyContinue"
-          .\e2e-windows-amd64.exe --minikube-start-args="--driver=docker" --test.timeout=15m --timeout-multiplier=1 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Out-File -Encoding utf8 -FilePath ".\report\testout.txt"
+          .\e2e-windows-amd64.exe --minikube-start-args="--driver=docker" --test.timeout=15m --timeout-multiplier=1 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Tee-Object -FilePath ".\report\testout.txt"
           $END_TIME=(GET-DATE)
           echo $END_TIME
           $DURATION=(NEW-TIMESPAN -Start $START_TIME -End $END_TIME)
@@ -377,7 +377,7 @@ jobs:
         shell: powershell
         run: |
           cd minikube_binaries
-          Get-Content .\report\testout.txt -Encoding UTF8  | go tool test2json -t | Out-File -FilePath .\report\testout.json -Encoding utf8
+          Get-Content .\report\testout.txt -Encoding ASCII  | go tool test2json -t | Out-File -FilePath .\report\testout.json -Encoding ASCII
           $STAT=(gopogh -in .\report\testout.json -out .\report\testout.html -name "${Env:JOB_NAME} ${Env:GITHUB_REF}" -repo "${Env:GITHUB_REPOSITORY}"  -details "${Env:GITHUB_SHA}")
           echo status: ${STAT}
           $FailNum=$(echo $STAT | jq '.NumberOfFail')
@@ -410,7 +410,7 @@ jobs:
           echo "---------------- ${numFail} Failures :( ----------------------------"
           echo $failedTests
           echo "-------------------------------------------------------"
-          If ($numFail -gt 0){ exit 2 } 
+          If ($numFail -gt 0){ exit 2 }
           If ($numPass -eq 0){ exit 2 }
           If ($numPass -lt 33){ exit 2 }
           If ($numFail -eq 0){ exit 0 }
@@ -427,7 +427,7 @@ jobs:
         shell: powershell
         run: |
           echo $env:computerName
-          ls 
+          ls
           $ErrorActionPreference = "SilentlyContinue"
           cd minikube_binaries
           ls
@@ -462,14 +462,14 @@ jobs:
           $docker_running = $?
           }
           Write-Output "Docker is running"
-          docker system prune -f 
+          docker system prune -f
       - name: Info
         continue-on-error: true
         shell: powershell
         run: |
           $ErrorActionPreference = "SilentlyContinue"
           cd minikube_binaries
-          ls 
+          ls
           echo $env:computername
           Get-WmiObject -class Win32_ComputerSystem
       - uses: actions/setup-go@v2
@@ -481,7 +481,7 @@ jobs:
         shell: powershell
         run: |
           $ErrorActionPreference = "SilentlyContinue"
-          (New-Object Net.WebClient).DownloadFile("https://github.com/medyagh/gopogh/releases/download/v0.2.4/gopogh.exe", "C:\ProgramData\chocolatey\bin\gopogh.exe")          
+          (New-Object Net.WebClient).DownloadFile("https://github.com/medyagh/gopogh/releases/download/v0.2.4/gopogh.exe", "C:\ProgramData\chocolatey\bin\gopogh.exe")
           choco install -y kubernetes-cli
           choco install -y jq
           choco install -y caffeine
@@ -497,7 +497,7 @@ jobs:
           $env:KUBECONFIG="${pwd}\testhome\kubeconfig"
           $env:MINIKUBE_HOME="${pwd}\testhome"
           $ErrorActionPreference = "SilentlyContinue"
-          .\e2e-windows-amd64.exe --minikube-start-args="--driver=hyperv" --test.timeout=20m --timeout-multiplier=1.5 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Out-File -Encoding utf8 -FilePath ".\report\testout.txt"
+          .\e2e-windows-amd64.exe --minikube-start-args="--driver=hyperv" --test.timeout=20m --timeout-multiplier=1.5 --test.v --test.run=TestFunctional --binary=./minikube-windows-amd64.exe | Tee-Object -FilePath ".\report\testout.txt"
           $END_TIME=(GET-DATE)
           echo $END_TIME
           $DURATION=(NEW-TIMESPAN -Start $START_TIME -End $END_TIME)
@@ -514,7 +514,7 @@ jobs:
         shell: powershell
         run: |
           cd minikube_binaries
-          Get-Content .\report\testout.txt -Encoding UTF8  | go tool test2json -t | Out-File -FilePath .\report\testout.json -Encoding utf8
+          Get-Content .\report\testout.txt -Encoding ASCII  | go tool test2json -t | Out-File -FilePath .\report\testout.json -Encoding ASCII
           $STAT=(gopogh -in .\report\testout.json -out .\report\testout.html -name "${Env:JOB_NAME} ${Env:GITHUB_REF}" -repo "${Env:GITHUB_REPOSITORY}"  -details "${Env:GITHUB_SHA}")
           echo status: ${STAT}
           $FailNum=$(echo $STAT | jq '.NumberOfFail')
@@ -547,7 +547,7 @@ jobs:
           echo "---------------- ${numFail} Failures :( ----------------------------"
           echo $failedTests
           echo "-------------------------------------------------------"
-          If ($numFail -gt 0){ exit 2 } 
+          If ($numFail -gt 0){ exit 2 }
           If ($numPass -eq 0){ exit 2 }
           If ($numPass -lt 33){ exit 2 }
           If ($numFail -eq 0){ exit 0 }
@@ -773,11 +773,11 @@ jobs:
         run: |
           hostname
           VBoxManage --version
-          sysctl hw.physicalcpu hw.logicalcpu 
+          sysctl hw.physicalcpu hw.logicalcpu
       - name: Disable firewall
         run: |
           sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
-          sudo /usr/libexec/ApplicationFirewall/socketfilterfw -k      
+          sudo /usr/libexec/ApplicationFirewall/socketfilterfw -k
       - name: Download Binaries
         uses: actions/download-artifact@v1
         with:
@@ -964,7 +964,7 @@ jobs:
         run: |
           hostname
           VBoxManage --version
-          sysctl hw.physicalcpu hw.logicalcpu 
+          sysctl hw.physicalcpu hw.logicalcpu
       - name: Disable firewall
         run: |
           sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
@@ -1148,7 +1148,7 @@ jobs:
         run: |
           hostname
           VBoxManage --version
-          sysctl hw.physicalcpu hw.logicalcpu 
+          sysctl hw.physicalcpu hw.logicalcpu
       - name: Disable firewall
         run: |
           sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off

--- a/Makefile
+++ b/Makefile
@@ -309,6 +309,15 @@ html_report: ## Generate HTML  report out of the last ran integration test logs.
 	@echo "-----------------------------------------------------------------------------------"
 	@open $(CURDIR)/out/testout_$(COMMIT_SHORT).html || true
 
+.PHONY: html_report_windows
+html_report_windows: ## Generate the HTML Report out of the last ran integration test logs on Windows.
+	@go tool test2json -t < "./out/testout_$(COMMIT_SHORT).txt" > "./out/testout_$(COMMIT_SHORT).json"
+	@gopogh -in "./out/testout_$(COMMIT_SHORT).json" -out ./out/testout_$(COMMIT_SHORT).html -name "$(shell git rev-parse --abbrev-ref HEAD)" -pr "" -repo github.com/kubernetes/minikube/ -details "${COMMIT_SHORT}"
+	@echo "-------------------------- Open HTML Report in Browser: ---------------------------"
+	@echo $(CURDIR)/out/testout_$(COMMIT_SHORT).html
+	@echo "-----------------------------------------------------------------------------------"
+	@start $(CURDIR)/out/testout_$(COMMIT_SHORT).html || true
+
 .PHONY: test
 test: pkg/minikube/assets/assets.go pkg/minikube/translate/translations.go ## Trigger minikube test
 	MINIKUBE_LDFLAGS="${MINIKUBE_LDFLAGS}" ./test.sh

--- a/Makefile
+++ b/Makefile
@@ -305,18 +305,15 @@ html_report: ## Generate HTML  report out of the last ran integration test logs.
 	@go tool test2json -t < "./out/testout_$(COMMIT_SHORT).txt" > "./out/testout_$(COMMIT_SHORT).json"
 	@gopogh -in "./out/testout_$(COMMIT_SHORT).json" -out ./out/testout_$(COMMIT_SHORT).html -name "$(shell git rev-parse --abbrev-ref HEAD)" -pr "" -repo github.com/kubernetes/minikube/  -details "${COMMIT_SHORT}"
 	@echo "-------------------------- Open HTML Report in Browser: ---------------------------"
+ifeq ($(GOOS),windows)
+	@echo start $(CURDIR)/out/testout_$(COMMIT_SHORT).html
+	@echo "-----------------------------------------------------------------------------------"
+	@start $(CURDIR)/out/testout_$(COMMIT_SHORT).html || true
+else
 	@echo open $(CURDIR)/out/testout_$(COMMIT_SHORT).html
 	@echo "-----------------------------------------------------------------------------------"
 	@open $(CURDIR)/out/testout_$(COMMIT_SHORT).html || true
-
-.PHONY: html_report_windows
-html_report_windows: ## Generate the HTML Report out of the last ran integration test logs on Windows.
-	@go tool test2json -t < "./out/testout_$(COMMIT_SHORT).txt" > "./out/testout_$(COMMIT_SHORT).json"
-	@gopogh -in "./out/testout_$(COMMIT_SHORT).json" -out ./out/testout_$(COMMIT_SHORT).html -name "$(shell git rev-parse --abbrev-ref HEAD)" -pr "" -repo github.com/kubernetes/minikube/ -details "${COMMIT_SHORT}"
-	@echo "-------------------------- Open HTML Report in Browser: ---------------------------"
-	@echo $(CURDIR)/out/testout_$(COMMIT_SHORT).html
-	@echo "-----------------------------------------------------------------------------------"
-	@start $(CURDIR)/out/testout_$(COMMIT_SHORT).html || true
+endif
 
 .PHONY: test
 test: pkg/minikube/assets/assets.go pkg/minikube/translate/translations.go ## Trigger minikube test


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

1. Added the make target for Windows HTML Test Report.
2. Switched encoding to UTF8 instead of ASCII which was causing issues while parsing in Git Bash.

@medyagh - I wonder if we require the `open HTML report` command. Cannot we just remove this and just echo that the HTML report is located over there because `open` doesn't exist on Windows and Git Bash? This make target will work in Git Bash. If we need this makefile to work in PowerShell, I would suggest a separate makefile. We can discuss this in today's call.