### PR TITLE
Add 'docker status' check, improve deadline-exceeded error message

### DIFF
--- a/pkg/drivers/kic/oci/cli_runner.go
+++ b/pkg/drivers/kic/oci/cli_runner.go
@@ -145,7 +145,7 @@ func runCmd(cmd *exec.Cmd, warnSlow ...bool) (*RunResult, error) {
 	}
 
 	if ex, ok := err.(*exec.ExitError); ok {
-		glog.Warningf("%s returned with exit code %s", rr.Command(), ex.ExitCode())
+		glog.Warningf("%s returned with exit code %d", rr.Command(), ex.ExitCode())
 		rr.ExitCode = ex.ExitCode()
 	}
 

--- a/pkg/drivers/kic/oci/cli_runner.go
+++ b/pkg/drivers/kic/oci/cli_runner.go
@@ -144,9 +144,11 @@ func runCmd(cmd *exec.Cmd, warnSlow ...bool) (*RunResult, error) {
 		}
 	}
 
-	if exitError, ok := err.(*exec.ExitError); ok {
-		rr.ExitCode = exitError.ExitCode()
+	if ex, ok := err.(*exec.ExitError); ok {
+		glog.Warningf("%s returned with exit code %s", rr.Command(), ex.ExitCode())
+		rr.ExitCode = ex.ExitCode()
 	}
+
 	// Decrease log spam
 	if elapsed > (1 * time.Second) {
 		glog.Infof("Completed: %s: (%s)", rr.Command(), elapsed)

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -128,6 +128,7 @@ func status() registry.State {
 			stderr := strings.TrimSpace(string(exitErr.Stderr))
 			newErr := fmt.Errorf(`%q %v: %s`, strings.Join(cmd.Args, " "), exitErr, stderr)
 
+			// Oddly enough, the underlying connection error is in stdout rather than stderr
 			if strings.Contains(stderr, "errors pretty printing info") || dockerNotRunning(string(o)) {
 				return registry.State{Error: err, Installed: true, Running: false, Healthy: false, Fix: "Start the Docker service", Doc: docURL}
 			}


### PR DESCRIPTION
Fixes #9325 

This adds a second command to the Docker health check: `docker status`. This is helpful for Docker Desktop versions which exit 0 even when docker is nut running:

```
docker version; echo $status                                                                                                                                                   Mon Sep 28 09:36:29 2020
Client: Docker Engine - Community
 Azure integration  0.1.15
 Version:           19.03.12
 API version:       1.40
 Go version:        go1.13.10
 Git commit:        48a66213fe
 Built:             Mon Jun 22 15:41:33 2020
 OS/Arch:           darwin/amd64
 Experimental:      false
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
0
```

This additional command adds ~120ms of runtime if Docker is healthy, but I think the extra clarity & debug information is worth it. While testing this PR for side effects, I noticed that we don't communicate a useful message for context timeouts, so I've updated that error message as well.

## Docker v19.0.3.2 not running:

### Old Behavior

```
⛔  Exiting due to RSRC_DOCKER_CORES: Docker Desktop has less than 2 CPUs configured, but Kubernetes requires at least 2 to be available
💡  Suggestion: 

    1. Click on "Docker for Desktop" menu icon
    2. Click "Preferences"
    3. Click "Resources"
    4. Increase "CPUs" slider bar to 2 or higher
    5. Click "Apply & Restart"
📘  Documentation: https://docs.docker.com/docker-for-mac/#resources
```

### New Behavior

```
💣  Exiting due to PROVIDER_DOCKER_NOT_RUNNING: docker info error: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
💡  Suggestion: Start the Docker service
📘  Documentation: https://minikube.sigs.k8s.io/docs/drivers/docker/
```

## Docker running slowly (6s fault injection)

### Old Behavior

```
💣  Exiting due to PROVIDER_DOCKER_NOT_RUNNING: signal: killed
💡  Suggestion: Restart the Docker service
📘  Documentation: https://minikube.sigs.k8s.io/docs/drivers/docker/
```

### New Behavior

```
💣  Exiting due to PROVIDER_DOCKER_NOT_RUNNING: deadline exceeded running "docker version --format -": signal: killed
💡  Suggestion: Restart the Docker service
📘  Documentation: https://minikube.sigs.k8s.io/docs/drivers/docker/
```
