### PR TITLE
Fix error in unittest, as pointed out by warning

### DIFF
--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -403,7 +403,7 @@ func killAPIServerProc(runner command.Runner) error {
 		pid, err := strconv.Atoi(rr.Stdout.String())
 		if err == nil { // this means we have a valid pid
 			glog.Warningf("Found a kube-apiserver running with pid %d, will try to kill the proc", pid)
-			if _, err = runner.RunCmd(exec.Command("pkill", "-9", string(pid))); err != nil {
+			if _, err = runner.RunCmd(exec.Command("pkill", "-9", fmt.Sprint(pid))); err != nil {
 				return errors.Wrap(err, "kill")
 			}
 		}


### PR DESCRIPTION
"conversion from int to string yields a string of one rune,
not a string of digits (did you mean fmt.Sprint(x)?)"

I think this warning might be new in go 1.15 or something ?
