### PR TITLE
Compare fully qualified image names when pulling kic base image

### DIFF
--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -127,7 +127,7 @@ func beginDownloadKicBaseImage(g *errgroup.Group, cc *config.ClusterConfig, down
 		// If we end up using a fallback image, notify the user
 		defer func() {
 			if finalImg != "" && finalImg != baseImg {
-				out.WarningT(fmt.Sprintf("minikube was unable to download %s, but successfully downloaded %s as a fallback image", image.Tag(cc.KicBaseImage), image.Tag(finalImg)))
+				out.WarningT(fmt.Sprintf("minikube was unable to download %s, but successfully downloaded %s as a fallback image", image.Tag(baseImg), image.Tag(finalImg)))
 				cc.KicBaseImage = finalImg
 			}
 		}()
@@ -136,7 +136,7 @@ func beginDownloadKicBaseImage(g *errgroup.Group, cc *config.ClusterConfig, down
 				glog.Infof("successfully loaded %s from cached tarball", img)
 				// strip the digest from the img before saving it in the config
 				// because loading an image from tarball to daemon doesn't load the digest
-				finalImg = image.Tag(img)
+				finalImg = img
 				return nil
 			}
 			glog.Infof("Downloading %s to local daemon", img)


### PR DESCRIPTION
Tested and passes on Cloud Shell.

Fixes a small bug where we were comparing one fully qualified image (tag+digest) to an image that had only tag specified. This resulted in an unnecessary warning, which only showed up when the base image was loaded from a tarball. This happens on Cloud Shell.

fixes https://github.com/kubernetes/minikube/issues/9317

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
