### PR TITLE
Improved file-filter for github-release-assets

### DIFF
--- a/hack/jenkins/release_github_page.sh
+++ b/hack/jenkins/release_github_page.sh
@@ -81,7 +81,7 @@ for path in $(gsutil ls "gs://${ISO_BUCKET}/minikube-v${VERSION}*" || true); do
 done
  
 # Upload all end-user assets other than preload files, as they are release independent
-for file in out/minikube[_-]* out/docker-machine-*; do
+for file in $( find out \( -name "minikube[_-]*" -or -name "docker-machine-*"  \) -and ! -name "*latest*"); do
     n=0
     until [ $n -ge 5 ]
     do


### PR DESCRIPTION
Fixes #9341 

Excludes `*latest*` files from github release assets, as they should be downloaded from google, not github.
For "advanced" filtering a move to `find` was necessary.
