### PR TITLE
Added deprecation warning for --network-plugin=cni

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -276,6 +276,11 @@ func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k
 			glog.Errorf("Found deprecated --enable-default-cni flag, setting --cni=bridge")
 			chosenCNI = "bridge"
 		}
+		// networkPlugin cni deprecation warning
+		chosenNetworkPlugin := viper.GetString(networkPlugin)
+		if chosenNetworkPlugin == "cni" {
+			out.WarningT("With --network-plugin=cni, you will need to provide your own CNI. See --cni flag as a user-friendly alternative")
+		}
 
 		cc = config.ClusterConfig{
 			Name:                    ClusterFlagValue(),
@@ -321,7 +326,7 @@ func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k
 				FeatureGates:           viper.GetString(featureGates),
 				ContainerRuntime:       viper.GetString(containerRuntime),
 				CRISocket:              viper.GetString(criSocket),
-				NetworkPlugin:          viper.GetString(networkPlugin),
+				NetworkPlugin:          chosenNetworkPlugin,
 				ServiceCIDR:            viper.GetString(serviceCIDR),
 				ImageRepository:        repository,
 				ExtraOptions:           config.ExtraOptions,


### PR DESCRIPTION
Signed-off-by: Pablo Caderno <kaderno@gmail.com>
Fixes #8445 

@tstromberg please have a look and let me know if the message is OK.


<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->


Before start message:
```
./out/minikube start -p test --network-plugin=cni 
😄  [test] minikube v1.13.1 on Ubuntu 20.04
    ▪ MINIKUBE_ACTIVE_DOCKERD=minikube
✨  Automatically selected the docker driver. Other choices: kvm2, virtualbox
👍  Starting control plane node test in cluster test
🔥  Creating docker container (CPUs=2, Memory=3900MB) ...
🐳  Preparing Kubernetes v1.19.2 on Docker 19.03.8 ...
🔎  Verifying Kubernetes components...
🌟  Enabled addons: storage-provisioner, default-storageclass

❗  /usr/local/bin/kubectl is version 1.17.2, which may have incompatibilites with Kubernetes 1.19.2.
💡  Want kubectl v1.19.2? Try 'minikube kubectl -- get pods -A'
🏄  Done! kubectl is now configured to use "test" by default


```

After start message:
```
 ./out/minikube start -p test --network-plugin=cni 
😄  [test] minikube v1.13.1 on Ubuntu 20.04
    ▪ MINIKUBE_ACTIVE_DOCKERD=minikube
✨  Automatically selected the docker driver. Other choices: kvm2, virtualbox
❗  Found deprecated --network-plugin=cni flag (new flag: --cni), setting --cni=auto if not already set
👍  Starting control plane node test in cluster test
🔥  Creating docker container (CPUs=2, Memory=3900MB) ...
🐳  Preparing Kubernetes v1.19.2 on Docker 19.03.8 ...
🔎  Verifying Kubernetes components...
🌟  Enabled addons: storage-provisioner, default-storageclass

❗  /usr/local/bin/kubectl is version 1.17.2, which may have incompatibilites with Kubernetes 1.19.2.
💡  Want kubectl v1.19.2? Try 'minikube kubectl -- get pods -A'
🏄  Done! kubectl is now configured to use "test" by default

```