### PR TITLE
wip: minikube docker driver should surive Docker Daemon  Stop/Start

### DIFF
--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -182,7 +182,8 @@ func CreateContainerNode(p CreateParams) error {
 		runArgs = append(runArgs, fmt.Sprintf("--memory=%s", p.Memory))
 		// Disable swap by setting the value to match
 		runArgs = append(runArgs, fmt.Sprintf("--memory-swap=%s", p.Memory))
-
+		// reboot docker container after Docker daemon or docker Desktop was rebooted.
+		runArgs = append(runArgs, "--restart=on-failure:1")
 		virtualization = "docker" // VIRTUALIZATION_DOCKER
 	}
 


### PR DESCRIPTION
### Before this PR 
After we stop Docker Desktop and then Start it agian, the minikube HOST status shows stopped


```
medya@~/workspace/minikube (docker_retry) $ minikube-v1.13.2 start
```
then
```
medya@~/workspace/minikube (docker_retry) $ ECHO "STOPPING Docker Desktop" 
STOPPING Docker Desktop

medya@~/workspace/minikube (docker_retry) $ minikube-v1.13.2 status
...

host: Nonexistent
...
```

then start docker
```
medya@~/workspace/minikube (docker_retry) $ ECHO "STARTING Docker Desktop" 
STARTING Docker Desktop


medya@~/workspace/minikube (docker_retry) $ minikube-v1.13.2 status
minikube

host: Stopped
kubelet: Stopped
apiserver: Stopped
kubeconfig: Stopped

````

## After this PR
The Host shows running after we stop Docker Deskopt and then start it again

(the kublet and apiserver still need to fixed to show running too)

```
medya@~/workspace/minikube (docker_retry) $ make && ./out/minikube start
medya@~/workspace/minikube (docker_retry) $ ECHO "STOPPING docker destkop with this PR"
STOPPING docker destkop with this PR

medya@~/workspace/minikube (docker_retry) $ make && ./out/minikube status
make: `out/minikube' is up to date.
E1001 16:10:26.824781   43732 status.go:216] status error: host: state: unknown state "minikube": docker container inspect minikube --format={{.State.Status}}: exit status 1
stdout:


stderr:
Error response from daemon: dial unix docker.raw.sock: connect: connection refused
E1001 16:10:26.825389   43732 status.go:219] The "minikube" host does not exist!
minikube
type: Control Plane
host: Nonexistent
kubelet: Nonexistent
apiserver: Nonexistent
kubeconfig: Nonexistent




medya@~/workspace/minikube (docker_retry) $ ECHO "STARTING DOCKER DESKTOP"
STARTING DOCKER DESKTOP
medya@~/workspace/minikube (docker_retry) $ make && ./out/minikube status
make: `out/minikube' is up to date.
minikube
type: Control Plane
host: Running
kubelet: Stopped
apiserver: Stopped
kubeconfig: Configured
```


closes https://github.com/kubernetes/minikube/issues/9376