### PR TITLE
Make none driver work as regular user (use sudo on demand)

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -786,10 +786,6 @@ func validateUser(drvName string) {
 
 	useForce := viper.GetBool(force)
 
-	if driver.NeedsRoot(drvName) && u.Uid != "0" && !useForce {
-		exit.Message(reason.DrvNeedsRoot, `The "{{.driver_name}}" driver requires root privileges. Please run minikube using 'sudo -E minikube start --driver={{.driver_name}}'.`, out.V{"driver_name": drvName})
-	}
-
 	// None driver works with root and without root on Linux
 	if runtime.GOOS == "linux" && drvName == driver.None {
 		if !viper.GetBool(interactive) {
@@ -801,8 +797,8 @@ func validateUser(drvName string) {
 		return
 	}
 
-	// If root is required, or we are not root, exit early
-	if driver.NeedsRoot(drvName) || u.Uid != "0" {
+	// If we are not root, exit early
+	if u.Uid != "0" {
 		return
 	}
 

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -143,7 +143,7 @@ func BareMetal(name string) bool {
 
 // NeedsRoot returns true if driver needs to run with root privileges
 func NeedsRoot(name string) bool {
-	return name == None
+	return false
 }
 
 // NeedsPortForward returns true if driver is unable provide direct IP connectivity

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -141,11 +141,6 @@ func BareMetal(name string) bool {
 	return name == None || name == Mock
 }
 
-// NeedsRoot returns true if driver needs to run with root privileges
-func NeedsRoot(name string) bool {
-	return false
-}
-
 // NeedsPortForward returns true if driver is unable provide direct IP connectivity
 func NeedsPortForward(name string) bool {
 	// Docker for Desktop

--- a/pkg/minikube/registry/drvs/none/none.go
+++ b/pkg/minikube/registry/drvs/none/none.go
@@ -61,13 +61,9 @@ func status() registry.State {
 		return registry.State{Running: true, Error: err, Installed: false, Fix: "Install docker", Doc: "https://minikube.sigs.k8s.io/docs/reference/drivers/none/"}
 	}
 
-	u, err := user.Current()
+	_, err = user.Current()
 	if err != nil {
 		return registry.State{Running: true, Error: err, Healthy: false, Doc: "https://minikube.sigs.k8s.io/docs/reference/drivers/none/"}
-	}
-
-	if u.Uid != "0" {
-		return registry.State{Error: fmt.Errorf("the 'none' driver must be run as the root user"), Healthy: false, Fix: "For non-root usage, try the newer 'docker' driver", Installed: true}
 	}
 
 	return registry.State{Installed: true, Healthy: true}

--- a/pkg/minikube/registry/drvs/none/none.go
+++ b/pkg/minikube/registry/drvs/none/none.go
@@ -61,10 +61,16 @@ func status() registry.State {
 		return registry.State{Running: true, Error: err, Installed: false, Fix: "Install docker", Doc: "https://minikube.sigs.k8s.io/docs/reference/drivers/none/"}
 	}
 
-	_, err = user.Current()
+	u, err := user.Current()
 	if err != nil {
 		return registry.State{Running: true, Error: err, Healthy: false, Doc: "https://minikube.sigs.k8s.io/docs/reference/drivers/none/"}
 	}
 
+	if u.Uid != "0" {
+		test := exec.Command("sudo", "-n", "echo", "-n")
+		if err := test.Run(); err != nil {
+			return registry.State{Error: fmt.Errorf("running the 'none' driver as a regular user requires sudo permissions"), Healthy: false}
+		}
+	}
 	return registry.State{Installed: true, Healthy: true}
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
Ref https://github.com/kubernetes/minikube/issues/3760

This almost works:
`minikube start --vm-driver=none --kubernetes-version=1.17.0`

>
> * minikube v1.13.1 on Ubuntu 18.04
> * Using the none driver based on user configuration
> * Starting control plane node minikube in cluster minikube
> * Running on localhost (CPUs=4, Memory=7449MB, Disk=38545MB) ...
> * OS release is Ubuntu 18.04.5 LTS
> * Preparing Kubernetes v1.17.0 on Docker 19.03.13 ...
>   - kubelet.resolv-conf=/run/systemd/resolve/resolv.conf
> ! initialization failed, will try again: run: /bin/bash -c "sudo env PATH=/var/lib/minikube/binaries/v1.17.0:$PATH kubeadminit > --config /var/tmp/minikube/kubeadm.yaml  --ignore-preflight-errors=DirAvailable--etc-kubernetes-manifests,DirAvailable--var-lib-minikube,DirAvailable--var-lib-minikube-etcd,FileAvailable--etc- kubernetes-manifests-kube-scheduler.yaml,FileAvailable--etc-kubernetes-manifests-kube-ap
iserver.yaml,FileAvailable--etc-kubernetes-manifests-kube-controller-manager.yaml,FileAvailable--etc-kubernetes-manifests-etcd.yaml,Port-10250,Swap": exit status 126
stdout:
> 
> stderr:
> env: ‘kubeadm’: Permission denied`

`sudo chmod 711 /var/lib/minikube/binaries/v1.17.0/*`
`minikube start --vm-driver=none --kubernetes-version=1.17.0`
`minikube kubectl -- get pods -A`

So the only open issue is how to properly set those permissions on /var/lib/minikube/binaries/v1.17.0/* 