### PR TITLE
point to newest gcp-auth-webhook version

### DIFF
--- a/deploy/addons/gcp-auth/gcp-auth-webhook.yaml
+++ b/deploy/addons/gcp-auth/gcp-auth-webhook.yaml
@@ -80,7 +80,7 @@ spec:
     spec:
       containers:
         - name: gcp-auth
-          image: gcr.io/k8s-minikube/gcp-auth-webhook:v0.0.2
+          image: gcr.io/k8s-minikube/gcp-auth-webhook:v0.0.3
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443


### PR DESCRIPTION
Despite our best efforts with labels, the gcp-auth addons still occasionally tries to patch kube-system pods, which is never a good idea, and usually not even allowed. The newest version of the webhook explicitly ignores kube-system in safe way. 

Fixes #9371