### PR TITLE
Improve parsing of start flag apiserver-names

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -165,7 +165,7 @@ func initKubernetesFlags() {
 	startCmd.Flags().String(dnsDomain, constants.ClusterDNSDomain, "The cluster dns domain name used in the Kubernetes cluster")
 	startCmd.Flags().Int(apiServerPort, constants.APIServerPort, "The apiserver listening port")
 	startCmd.Flags().String(apiServerName, constants.APIServerName, "The authoritative apiserver hostname for apiserver certificates and connectivity. This can be used if you want to make the apiserver available from outside the machine")
-	startCmd.Flags().StringArrayVar(&apiServerNames, "apiserver-names", nil, "A set of apiserver names which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine")
+	startCmd.Flags().StringSliceVar(&apiServerNames, "apiserver-names", nil, "A set of apiserver names which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine")
 	startCmd.Flags().IPSliceVar(&apiServerIPs, "apiserver-ips", nil, "A set of apiserver IP Addresses which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine")
 }
 

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -23,7 +23,7 @@ minikube start [flags]
       --addons minikube addons list       Enable addons. see minikube addons list for a list of valid addon names.
       --apiserver-ips ipSlice             A set of apiserver IP Addresses which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine (default [])
       --apiserver-name string             The authoritative apiserver hostname for apiserver certificates and connectivity. This can be used if you want to make the apiserver available from outside the machine (default "minikubeCA")
-      --apiserver-names stringArray       A set of apiserver names which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine
+      --apiserver-names strings           A set of apiserver names which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine
       --apiserver-port int                The apiserver listening port (default 8443)
       --auto-update-drivers               If set, automatically updates drivers to the latest version. Defaults to true. (default true)
       --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase:v0.0.13@sha256:4d43acbd0050148d4bc399931f1b15253b5e73815b63a67b8ab4a5c9e523403f")


### PR DESCRIPTION
Fixes #8990 
Uses [StringSliceVar](https://godoc.org/github.com/spf13/pflag#StringSliceVar) instead of [StringArrayVar](https://godoc.org/github.com/spf13/pflag#FlagSet.StringArrayVar) so that comma separated SANs can be processed on first run and then interpreted correctly on subsequent runs. RFC 1035 does not allow for commas in DNS names, so this shouldn't be an issue.


```
[bluestealth@neptune minikube]$ ./out/minikube start -p testing --memory 2048 --apiserver-names=1,2,3 --apiserver-names=4
😄  [testing] minikube v1.13.1 on Fedora 32
✨  Using the kvm2 driver based on user configuration
👍  Starting control plane node testing in cluster testing
🔥  Creating kvm2 VM (CPUs=4, Memory=2048MB, Disk=20000MB) ...
🎁  Preparing Kubernetes v1.19.2 on CRI-O 1.18.3 ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "testing" by default
[bluestealth@neptune minikube]$ cat ~/.minikube/profiles/testing/config.json  | jq .KubernetesConfig.APIServerNames
[
  "1",
  "2",
  "3",
  "4"
]
[bluestealth@neptune minikube]$ ./out/minikube start -p testing --memory 2048 --apiserver-names=1,2,3 --apiserver-names=4
😄  [testing] minikube v1.13.1 on Fedora 32
✨  Using the kvm2 driver based on existing profile
👍  Starting control plane node testing in cluster testing
🏃  Updating the running kvm2 "testing" VM ...
🎁  Preparing Kubernetes v1.19.2 on CRI-O 1.18.3 ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "testing" by default
[bluestealth@neptune minikube]$ cat ~/.minikube/profiles/testing/config.json  | jq .KubernetesConfig.APIServerNames
[
  "1",
  "2",
  "3",
  "4"
]
[bluestealth@neptune minikube]$ ./out/minikube start -p testing --memory 2048 --apiserver-names=1 --apiserver-names=4
😄  [testing] minikube v1.13.1 on Fedora 32
✨  Using the kvm2 driver based on existing profile
👍  Starting control plane node testing in cluster testing
🏃  Updating the running kvm2 "testing" VM ...
🎁  Preparing Kubernetes v1.19.2 on CRI-O 1.18.3 ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "testing" by default
[bluestealth@neptune minikube]$ cat ~/.minikube/profiles/testing/config.json  | jq .KubernetesConfig.APIServerNames
[
  "1",
  "4"
]
[bluestealth@neptune minikube]$ minikube delete -p testing
🔥  Deleting "testing" in kvm2 ...
💀  Removed all traces of the "testing" cluster.
[bluestealth@neptune minikube]$ ./out/minikube start -p testing --memory 2048 --apiserver-names=1 --apiserver-names=4
😄  [testing] minikube v1.13.1 on Fedora 32
✨  Using the kvm2 driver based on user configuration
👍  Starting control plane node testing in cluster testing
🔥  Creating kvm2 VM (CPUs=4, Memory=2048MB, Disk=20000MB) ...
🎁  Preparing Kubernetes v1.19.2 on CRI-O 1.18.3 ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "testing" by default
[bluestealth@neptune minikube]$ cat ~/.minikube/profiles/testing/config.json  | jq .KubernetesConfig.APIServerNames
[
  "1",
  "4"
]
[bluestealth@neptune minikube]$ ./out/minikube start -p testing --memory 2048 --apiserver-names=1 --apiserver-names=4
😄  [testing] minikube v1.13.1 on Fedora 32
✨  Using the kvm2 driver based on existing profile
👍  Starting control plane node testing in cluster testing
🏃  Updating the running kvm2 "testing" VM ...
🎁  Preparing Kubernetes v1.19.2 on CRI-O 1.18.3 ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "testing" by default
[bluestealth@neptune minikube]$ cat ~/.minikube/profiles/testing/config.json  | jq .KubernetesConfig.APIServerNames
[
  "1",
  "4"
]
[bluestealth@neptune minikube]$ openssl x509 -in ~/.minikube/profiles/testing/apiserver.crt -noout -text | grep DNS
                DNS:1, DNS:4, DNS:minikubeCA, DNS:control-plane.minikube.internal, DNS:kubernetes.default.svc.cluster.local, DNS:kubernetes.default.svc, DNS:kubernetes.default, DNS:kubernetes, DNS:localhost, IP Address:192.168.39.49, IP Address:10.96.0.1, IP Address:127.0.0.1, IP Address:10.0.0.1

```