### PR TITLE
Do some simple cleanup of the golint complaints

### DIFF
--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -57,6 +57,7 @@ var (
 
 const (
 	// Additional legacy states:
+
 	// Configured means configured
 	Configured = "Configured" // ~state.Saved
 	// Misconfigured means misconfigured
@@ -67,7 +68,9 @@ const (
 	Irrelevant = "Irrelevant"
 
 	// New status modes, based roughly on HTTP/SMTP standards
+
 	// 1xx signifies a transitional state. If retried, it will soon return a 2xx, 4xx, or 5xx
+
 	Starting  = 100
 	Pausing   = 101
 	Unpausing = 102
@@ -75,15 +78,18 @@ const (
 	Deleting  = 120
 
 	// 2xx signifies that the API Server is able to service requests
+
 	OK      = 200
 	Warning = 203
 
 	// 4xx signifies an error that requires help from the client to resolve
+
 	NotFound = 404
 	Stopped  = 405
 	Paused   = 418 // I'm a teapot!
 
 	// 5xx signifies a server-side error (that may be retryable)
+
 	Error               = 500
 	InsufficientStorage = 507
 	Unknown             = 520

--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -413,6 +413,7 @@ func containerdImagesPreloaded(runner command.Runner, images []string) bool {
 	return true
 }
 
+// ImagesPreloaded returns true if all images have been preloaded
 func (r *Containerd) ImagesPreloaded(images []string) bool {
 	return containerdImagesPreloaded(r.Runner, images)
 }

--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -326,6 +326,7 @@ func crioImagesPreloaded(runner command.Runner, images []string) bool {
 	return true
 }
 
+// ImagesPreloaded returns true if all images have been preloaded
 func (r *CRIO) ImagesPreloaded(images []string) bool {
 	return crioImagesPreloaded(r.Runner, images)
 }

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -405,6 +405,7 @@ func dockerBoundToContainerd(runner command.Runner) bool {
 	return false
 }
 
+// ImagesPreloaded returns true if all images have been preloaded
 func (r *Docker) ImagesPreloaded(images []string) bool {
 	return dockerImagesPreloaded(r.Runner, images)
 }

--- a/pkg/minikube/download/json_output.go
+++ b/pkg/minikube/download/json_output.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/out/register"
 )
 
+// DefaultJSONOutput is a progress tracker with JSON output
 var DefaultJSONOutput getter.ProgressTracker = &jsonOutput{}
 
 type jsonOutput struct {

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -112,7 +112,7 @@ func IsDocker(name string) bool {
 	return name == Docker
 }
 
-// IsKIC checks if the driver is a Docker for Desktop (Docker on windows or MacOs)
+// IsDockerDesktop checks if the driver is a Docker for Desktop (Docker on windows or MacOs)
 // for linux and exotic archs, this will be false
 func IsDockerDesktop(name string) bool {
 	if IsDocker(name) {

--- a/pkg/minikube/out/register/cloud_events.go
+++ b/pkg/minikube/out/register/cloud_events.go
@@ -33,6 +33,8 @@ const (
 
 var (
 	outputFile io.Writer = os.Stdout
+
+	//GetUUID returns the UUID function to use
 	GetUUID              = randomID
 
 	eventFile *os.File

--- a/pkg/minikube/out/register/cloud_events.go
+++ b/pkg/minikube/out/register/cloud_events.go
@@ -35,7 +35,7 @@ var (
 	outputFile io.Writer = os.Stdout
 
 	//GetUUID returns the UUID function to use
-	GetUUID              = randomID
+	GetUUID = randomID
 
 	eventFile *os.File
 )

--- a/pkg/minikube/out/register/log.go
+++ b/pkg/minikube/out/register/log.go
@@ -110,6 +110,7 @@ type Info struct {
 	data map[string]string
 }
 
+// Type returns the cloud events compatible type of this struct
 func (s *Info) Type() string {
 	return "io.k8s.sigs.minikube.info"
 }
@@ -128,6 +129,7 @@ type Error struct {
 	data map[string]string
 }
 
+// NewError returns a new Error type
 func NewError(err string) *Error {
 	return &Error{
 		map[string]string{
@@ -148,6 +150,7 @@ func NewErrorExitCode(err string, exitcode int, additionalData ...map[string]str
 	return e
 }
 
+// Type returns the cloud events compatible type of this struct
 func (s *Error) Type() string {
 	return "io.k8s.sigs.minikube.error"
 }

--- a/pkg/minikube/reason/exitcodes.go
+++ b/pkg/minikube/reason/exitcodes.go
@@ -34,6 +34,7 @@ package reason
 
 const (
 	// Reserved UNIX exit codes
+
 	ExFailure     = 1 // Failure represents a general failure code
 	ExInterrupted = 2 // Ctrl-C (SIGINT)
 
@@ -56,6 +57,7 @@ const (
 	// navailableOff = 9 // (~EX_UNAVAILABLE)
 
 	// Error codes specific to the minikube program
+
 	ExProgramError       = 10 // generic error
 	ExProgramUsage       = 14 // bad command-line options
 	ExProgramConflict    = 11 // can't do what you want because of existing data
@@ -64,6 +66,7 @@ const (
 	ExProgramConfig      = 18 // bad configuration specified
 
 	// Error codes specific to resource limits (exit code layout follows no rules)
+
 	ExResourceError          = 20
 	ExInsufficientMemory     = 23
 	ExInsufficientStorage    = 26
@@ -71,6 +74,7 @@ const (
 	ExInsufficientCores      = 29
 
 	// Error codes specific to the host
+
 	ExHostError       = 30
 	ExHostConflict    = 31
 	ExHostTimeout     = 32
@@ -81,6 +85,7 @@ const (
 	ExHostConfig      = 38
 
 	// Error codes specific to remote networking
+
 	ExInternetError       = 40
 	ExInternetConflict    = 41
 	ExInternetTimeout     = 42
@@ -89,6 +94,7 @@ const (
 	ExInternetUnavailable = 49
 
 	// Error codes specific to the libmachine driver
+
 	ExDriverError       = 50
 	ExDriverConflict    = 51
 	ExDriverTimeout     = 52
@@ -100,11 +106,14 @@ const (
 	ExDriverUnavailable = 59
 
 	// Error codes specific to the driver provider
+
 	ExProviderError      = 60
 	ExProviderConflict   = 61
 	ExProviderTimeout    = 62
 	ExProviderNotRunning = 63
+
 	// Reserve 64 for the moment as it used to be usage
+
 	ExProviderNotFound    = 65
 	ExProviderUnsupported = 66
 	ExProviderPermission  = 67
@@ -112,6 +121,7 @@ const (
 	ExProviderUnavailable = 69 // In common use
 
 	// Error codes specific to local networking
+
 	ExLocalNetworkError       = 70
 	ExLocalNetworkConflict    = 71
 	ExLocalNetworkTimeout     = 72
@@ -121,6 +131,7 @@ const (
 	ExLocalNetworkUnavailable = 79
 
 	// Error codes specific to the guest host
+
 	ExGuestError       = 80
 	ExGuestConflict    = 81
 	ExGuestTimeout     = 82
@@ -132,12 +143,14 @@ const (
 	ExGuestUnavailable = 89
 
 	// Error codes specific to the container runtime
+
 	ExRuntimeError       = 90
 	ExRuntimeNotRunning  = 93
 	ExRuntimeNotFound    = 95
 	ExRuntimeUnavailable = 99
 
 	// Error codes specific to the Kubernetes control plane
+
 	ExControlPlaneError       = 100
 	ExControlPlaneConflict    = 101
 	ExControlPlaneTimeout     = 102
@@ -148,6 +161,7 @@ const (
 	ExControlPlaneUnavailable = 109
 
 	// Error codes specific to a Kubernetes service
+
 	ExSvcError       = 110
 	ExSvcConflict    = 111
 	ExSvcTimeout     = 112

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -61,6 +61,7 @@ type Kind struct {
 	NoMatch bool
 }
 
+// IssueURLs returns URLs for issues
 func (k *Kind) IssueURLs() []string {
 	is := []string{}
 	for _, i := range k.Issues {

--- a/pkg/minikube/tests/dir_utils.go
+++ b/pkg/minikube/tests/dir_utils.go
@@ -45,6 +45,7 @@ func MakeTempDir() string {
 	return localpath.MiniPath()
 }
 
+// RemoveTempDir removes the temp dir
 func RemoveTempDir(tempdir string) {
 	if filepath.Base(tempdir) == ".minikube" {
 		tempdir = filepath.Dir(tempdir)

--- a/pkg/perf/monitor/constants.go
+++ b/pkg/perf/monitor/constants.go
@@ -21,14 +21,14 @@ const (
 	GithubAccessTokenEnvVar = "GITHUB_ACCESS_TOKEN"
 
 	// OkToTestLabel is the github label for ok-to-test
-	OkToTestLabel           = "ok-to-test"
+	OkToTestLabel = "ok-to-test"
 
 	// GithubOwner is the owner of the github repository
-	GithubOwner             = "kubernetes"
+	GithubOwner = "kubernetes"
 
 	// GithubRepo is the name of the github repository
-	GithubRepo              = "minikube"
+	GithubRepo = "minikube"
 
 	// BotName is the name of the minikube Pull Request bot
-	BotName                 = "minikube-pr-bot"
+	BotName = "minikube-pr-bot"
 )

--- a/pkg/perf/monitor/constants.go
+++ b/pkg/perf/monitor/constants.go
@@ -17,9 +17,18 @@ limitations under the License.
 package monitor
 
 const (
+	// GithubAccessTokenEnvVar is the env var name to use
 	GithubAccessTokenEnvVar = "GITHUB_ACCESS_TOKEN"
+
+	// OkToTestLabel is the github label for ok-to-test
 	OkToTestLabel           = "ok-to-test"
+
+	// GithubOwner is the owner of the github repository
 	GithubOwner             = "kubernetes"
+
+	// GithubRepo is the name of the github repository
 	GithubRepo              = "minikube"
+
+	// BotName is the name of the minikube Pull Request bot
 	BotName                 = "minikube-pr-bot"
 )

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -47,14 +47,17 @@ func CalculateSizeInMB(humanReadableSize string) (int, error) {
 	return int(size / units.MiB), nil
 }
 
+// ConvertMBToBytes converts MB to bytes
 func ConvertMBToBytes(mbSize int) int64 {
 	return int64(mbSize) * units.MiB
 }
 
+// ConvertBytesToMB converts bytes to MB
 func ConvertBytesToMB(byteSize int64) int {
 	return int(ConvertUnsignedBytesToMB(uint64(byteSize)))
 }
 
+// ConvertUnsignedBytesToMB converts bytes to MB
 func ConvertUnsignedBytesToMB(byteSize uint64) int64 {
 	return int64(byteSize / units.MiB)
 }


### PR DESCRIPTION
The "magic strings" and enums still needs another approach

Simply echoing everything twice doesn't seem very useful ?