### PR TITLE
reword error message when cluster state exit code is not found

### DIFF
--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/machine"
 	"k8s.io/minikube/pkg/minikube/mustload"
 	"k8s.io/minikube/pkg/minikube/node"
+	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/out/register"
 	"k8s.io/minikube/pkg/minikube/reason"
 	"k8s.io/minikube/pkg/version"
@@ -196,9 +197,11 @@ var statusCmd = &cobra.Command{
 	Exit status contains the status of minikube's VM, cluster and Kubernetes encoded on it's bits in this order from right to left.
 	Eg: 7 meaning: 1 (for minikube NOK) + 2 (for cluster NOK) + 4 (for Kubernetes NOK)`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if output != "text" && statusFormat != defaultStatusFormat {
+		if strings.ToLower(output) != "text" && statusFormat != defaultStatusFormat {
 			exit.Message(reason.Usage, "Cannot use both --output and --format options")
 		}
+
+		out.SetJSON(strings.ToLower(output) == "json")
 
 		cname := ClusterFlagValue()
 		api, cc := mustload.Partial(cname)
@@ -544,7 +547,7 @@ func clusterState(sts []*Status) ClusterState {
 			}
 			exitCode, err := strconv.Atoi(data["exitcode"])
 			if err != nil {
-				klog.Errorf("unable to convert exit code to int: %v", err)
+				klog.Warningf("exit code not found: %v", err)
 				continue
 			}
 			if val, ok := exitCodeToHTTPCode[exitCode]; ok {

--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -547,7 +547,7 @@ func clusterState(sts []*Status) ClusterState {
 			}
 			exitCode, err := strconv.Atoi(data["exitcode"])
 			if err != nil {
-				klog.Warningf("exit code not found: %v", err)
+				klog.Errorf("exit code not found: %v", err)
 				continue
 			}
 			if val, ok := exitCodeToHTTPCode[exitCode]; ok {

--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -197,11 +197,12 @@ var statusCmd = &cobra.Command{
 	Exit status contains the status of minikube's VM, cluster and Kubernetes encoded on it's bits in this order from right to left.
 	Eg: 7 meaning: 1 (for minikube NOK) + 2 (for cluster NOK) + 4 (for Kubernetes NOK)`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if strings.ToLower(output) != "text" && statusFormat != defaultStatusFormat {
+		output = strings.ToLower(output)
+		if output != "text" && statusFormat != defaultStatusFormat {
 			exit.Message(reason.Usage, "Cannot use both --output and --format options")
 		}
 
-		out.SetJSON(strings.ToLower(output) == "json")
+		out.SetJSON(output == "json")
 
 		cname := ClusterFlagValue()
 		api, cc := mustload.Partial(cname)
@@ -236,7 +237,7 @@ var statusCmd = &cobra.Command{
 			}
 		}
 
-		switch strings.ToLower(output) {
+		switch output {
 		case "text":
 			for _, st := range statuses {
 				if err := statusText(st, os.Stdout); err != nil {

--- a/pkg/minikube/out/out.go
+++ b/pkg/minikube/out/out.go
@@ -19,7 +19,6 @@ package out
 
 import (
 	"bytes"
-	"flag"
 	"fmt"
 	"html"
 	"html/template"
@@ -29,6 +28,7 @@ import (
 	"strings"
 
 	isatty "github.com/mattn/go-isatty"
+
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/minikube/out/register"
 	"k8s.io/minikube/pkg/minikube/style"
@@ -191,17 +191,6 @@ func SetOutFile(w fdWriter) {
 func SetJSON(j bool) {
 	klog.Infof("Setting JSON to %v", j)
 	JSON = j
-	if JSON {
-		if err := flag.Set("logtostderr", "false"); err != nil {
-			klog.Warningf("Unable to set 'logtostderr' default flag value: %v", err)
-		}
-		if err := flag.Set("alsologtostderr", "false"); err != nil {
-			klog.Warningf("Unable to set 'alsologtostderr' default flag value: %v", err)
-		}
-		if err := flag.Set("stderrthreshold", "FATAL"); err != nil {
-			klog.Warningf("Unable to set 'stderrthreshold' default flag value: %v", err)
-		}
-	}
 }
 
 // SetErrFile configures which writer error output goes to.

--- a/pkg/minikube/out/out.go
+++ b/pkg/minikube/out/out.go
@@ -19,6 +19,7 @@ package out
 
 import (
 	"bytes"
+	"flag"
 	"fmt"
 	"html"
 	"html/template"
@@ -28,7 +29,6 @@ import (
 	"strings"
 
 	isatty "github.com/mattn/go-isatty"
-
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/minikube/out/register"
 	"k8s.io/minikube/pkg/minikube/style"
@@ -191,6 +191,17 @@ func SetOutFile(w fdWriter) {
 func SetJSON(j bool) {
 	klog.Infof("Setting JSON to %v", j)
 	JSON = j
+	if JSON {
+		if err := flag.Set("logtostderr", "false"); err != nil {
+			klog.Warningf("Unable to set 'logtostderr' default flag value: %v", err)
+		}
+		if err := flag.Set("alsologtostderr", "false"); err != nil {
+			klog.Warningf("Unable to set 'alsologtostderr' default flag value: %v", err)
+		}
+		if err := flag.Set("stderrthreshold", "FATAL"); err != nil {
+			klog.Warningf("Unable to set 'stderrthreshold' default flag value: %v", err)
+		}
+	}
 }
 
 // SetErrFile configures which writer error output goes to.


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
fixes: #9374 
fixes https://github.com/kubernetes/minikube/issues/8933

as described by @medyagh in issue #9374, json output contains `unable to convert exit code to int: strconv.Atoi: parsing "": invalid syntax` error messages while the container is starting, and they should be treated as non-errors (consequentially not showing in json output)

**original output (before pr)** - example:
```
medya@cloudshell:~/campwiz2$ minikube status -o=json -l=cluster | jq .StatusName
E1001 22:38:25.301197  184671 status.go:533] unable to convert exit code to int: strconv.Atoi: parsing "": invalid syntax
E1001 22:38:25.302112  184671 status.go:533] unable to convert exit code to int: strconv.Atoi: parsing "": invalid syntax
E1001 22:38:25.302145  184671 status.go:533] unable to convert exit code to int: strconv.Atoi: parsing "": invalid syntax
```
**new output (after pr)**:
- `minikube status -o=json -l=cluster | jq .StatusName` does not contain this error
- `minikube status -o=json -l=cluster --alsologtostderr` would log it as message from data map ~(`transient code 100 ("Starting"): Waiting for container(s) to start (exitcode="")`)~

edit: i wasn't able to replicate case when `data["exitcode"]` was _set_ to `""`, just the complete absence of `data["exitcode"]` (that manifests the same like `""` value in maps) - eg:
```
data[message:❗  docker is currently using the btrfs storage driver, consider switching to overlay2 for better performance]
data[message:❗  Multi-node clusters are currently experimental and might exhibit unintended behavior.]
```
therefore i've amended pr to, in case that `data["exitcode"]` is set to `""` or is _unset_ (which boils down again to be "", just being explicit), print warning entry with the data map instead of the specific message (and potentially wrong/misleading message i've initially mentioned above - ie, _waiting for container to start..._)

 - example outputs:

-- with default (docker) driver:
```
I1005 03:18:10.947344  387936 system_pods.go:161] Checking kubelet status ...
I1005 03:18:10.947464  387936 ssh_runner.go:148] Run: sudo systemctl is-active --quiet service kubelet
I1005 03:18:10.964020  387936 status.go:338] minikube-m03 kubelet status = Running
I1005 03:18:10.964046  387936 status.go:213] minikube-m03 status: &{Name:minikube-m03 Host:Running Kubelet:Running APIServer:Irrelevant Kubeconfig:Irrelevant Worker:true}
I1005 03:18:10.964918  387936 status.go:522] transient code 100 ("Starting") for step: map[currentstep:0 message:😄  minikube v1.13.1 on "Opensuse-Tumbleweed" name:Initial Minikube Setup totalsteps:12]
I1005 03:18:10.964964  387936 status.go:522] transient code 100 ("Starting") for step: map[currentstep:1 message:✨  Automatically selected the docker driver name:Selecting Driver totalsteps:12]
W1005 03:18:10.964983  387936 status.go:532] transient code 100 ("Starting"): map[message:❗  docker is currently using the btrfs storage driver, consider switching to overlay2 for better performance]
I1005 03:18:10.965007  387936 status.go:522] transient code 100 ("Starting") for step: map[currentstep:3 message:👍  Starting control plane node minikube in cluster minikube name:Starting Node totalsteps:12]
I1005 03:18:10.965031  387936 status.go:522] transient code 100 ("Starting") for step: map[currentstep:6 message:🔥  Creating docker container (CPUs=8, Memory=16384MB) ... name:Creating Container totalsteps:12]
I1005 03:18:10.965061  387936 status.go:522] transient code 100 ("Starting") for step: map[currentstep:8 message:🐳  Preparing Kubernetes v1.19.2 on Docker 19.03.8 ... name:Preparing Kubernetes totalsteps:12]
I1005 03:18:10.965090  387936 status.go:522] transient code 100 ("Starting") for step: map[currentstep:10 message:🔎  Verifying Kubernetes components... name:Verifying Kubernetes totalsteps:12]
I1005 03:18:10.965114  387936 status.go:522] transient code 100 ("Starting") for step: map[currentstep:11 message:🌟  Enabled addons: storage-provisioner, default-storageclass name:Enabling Addons totalsteps:12]
W1005 03:18:10.965131  387936 status.go:532] transient code 100 ("Starting"): map[message:❗  Multi-node clusters are currently experimental and might exhibit unintended behavior.]
I1005 03:18:10.965152  387936 status.go:522] transient code 100 ("Starting") for step: map[currentstep:11 message:📘  To track progress on multi-node clusters, see https://github.com/kubernetes/minikube/issues/7538. name:Enabling Addons totalsteps:12]
I1005 03:18:10.965175  387936 status.go:522] transient code 100 ("Starting") for step: map[currentstep:3 message:👍  Starting node minikube-m02 in cluster minikube name:Starting Node totalsteps:12]
I1005 03:18:10.965199  387936 status.go:522] transient code 100 ("Starting") for step: map[currentstep:6 message:🔥  Creating docker container (CPUs=8, Memory=16384MB) ... name:Creating Container totalsteps:12]
I1005 03:18:10.965223  387936 status.go:522] transient code 100 ("Starting") for step: map[currentstep:6 message:🌐  Found network options: name:Creating Container totalsteps:12]
I1005 03:18:10.965247  387936 status.go:522] transient code 100 ("Starting") for step: map[currentstep:8 message:🐳  Preparing Kubernetes v1.19.2 on Docker 19.03.8 ... name:Preparing Kubernetes totalsteps:12]
I1005 03:18:10.965271  387936 status.go:522] transient code 100 ("Starting") for step: map[currentstep:10 message:🔎  Verifying Kubernetes components... name:Verifying Kubernetes totalsteps:12]
I1005 03:18:10.965295  387936 status.go:522] transient code 100 ("Starting") for step: map[currentstep:3 message:👍  Starting node minikube-m03 in cluster minikube name:Starting Node totalsteps:12]
I1005 03:18:10.965319  387936 status.go:522] transient code 100 ("Starting") for step: map[currentstep:6 message:🔥  Creating docker container (CPUs=8, Memory=16384MB) ... name:Creating Container totalsteps:12]
I1005 03:18:10.965342  387936 status.go:522] transient code 100 ("Starting") for step: map[currentstep:6 message:🌐  Found network options: name:Creating Container totalsteps:12]
I1005 03:18:10.965365  387936 status.go:522] transient code 100 ("Starting") for step: map[currentstep:8 message:🐳  Preparing Kubernetes v1.19.2 on Docker 19.03.8 ... name:Preparing Kubernetes totalsteps:12]
I1005 03:18:10.965391  387936 status.go:522] transient code 100 ("Starting") for step: map[currentstep:10 message:🔎  Verifying Kubernetes components... name:Verifying Kubernetes totalsteps:12]
I1005 03:18:10.965416  387936 status.go:522] transient code 0 ("") for step: map[currentstep:12 message:🏄  Done! kubectl is now configured to use "minikube" by default name:Done totalsteps:12]
{"Name":"minikube","StatusCode":200,"StatusName":"OK","Step":"Done","StepDetail":"🏄  Done! kubectl is now configured to use \"minikube\" by default","BinaryVersion":"v1.13.1","Components":{"kubeconfig":{"Name":"kubeconfig","StatusCode":200,"StatusName":""}},"Nodes":[{"Name":"minikube","StatusCode":200,"StatusName":"OK","Components":{"apiserver":{"Name":"apiserver","StatusCode":200,"StatusName":"OK"},"kubelet":{"Name":"kubelet","StatusCode":200,"StatusName":"OK"}}},{"Name":"minikube-m02","StatusCode":200,"StatusName":"OK","Components":{"kubelet":{"Name":"kubelet","StatusCode":200,"StatusName":"OK"}}},{"Name":"minikube-m03","StatusCode":200,"StatusName":"OK","Components":{"kubelet":{"Name":"kubelet","StatusCode":200,"StatusName":"OK"}}}]}
```
-- with kvm2 driver:
```
1005 03:14:16.542353  356179 system_pods.go:161] Checking kubelet status ...
I1005 03:14:16.542420  356179 ssh_runner.go:148] Run: sudo systemctl is-active --quiet service kubelet
I1005 03:14:16.557881  356179 status.go:338] minikube-m03 kubelet status = Running
I1005 03:14:16.557919  356179 status.go:213] minikube-m03 status: &{Name:minikube-m03 Host:Running Kubelet:Running APIServer:Irrelevant Kubeconfig:Irrelevant Worker:true}
I1005 03:14:16.559581  356179 status.go:522] transient code 100 ("Starting") for step: map[currentstep:0 message:😄  minikube v1.13.1 on "Opensuse-Tumbleweed" name:Initial Minikube Setup totalsteps:12]
I1005 03:14:16.559684  356179 status.go:522] transient code 100 ("Starting") for step: map[currentstep:1 message:✨  Using the kvm2 driver based on user configuration name:Selecting Driver totalsteps:12]
I1005 03:14:16.559759  356179 status.go:522] transient code 100 ("Starting") for step: map[currentstep:1 message:💿  Downloading VM boot image ... name:Selecting Driver totalsteps:12]
I1005 03:14:16.559826  356179 status.go:522] transient code 100 ("Starting") for step: map[currentstep:3 message:👍  Starting control plane node minikube in cluster minikube name:Starting Node totalsteps:12]
I1005 03:14:16.559892  356179 status.go:522] transient code 100 ("Starting") for step: map[currentstep:3 message:💾  Downloading Kubernetes v1.19.2 preload ... name:Starting Node totalsteps:12]
I1005 03:14:16.559956  356179 status.go:522] transient code 100 ("Starting") for step: map[currentstep:7 message:🔥  Creating kvm2 VM (CPUs=8, Memory=16384MB, Disk=32768MB) ... name:Creating VM totalsteps:12]
I1005 03:14:16.560020  356179 status.go:522] transient code 100 ("Starting") for step: map[currentstep:8 message:🐳  Preparing Kubernetes v1.19.2 on Docker 19.03.12 ... name:Preparing Kubernetes totalsteps:12]
I1005 03:14:16.560083  356179 status.go:522] transient code 100 ("Starting") for step: map[currentstep:10 message:🔎  Verifying Kubernetes components... name:Verifying Kubernetes totalsteps:12]
I1005 03:14:16.560153  356179 status.go:522] transient code 100 ("Starting") for step: map[currentstep:11 message:🌟  Enabled addons: storage-provisioner, default-storageclass name:Enabling Addons totalsteps:12]
W1005 03:14:16.560207  356179 status.go:532] transient code 100 ("Starting"): map[message:❗  Multi-node clusters are currently experimental and might exhibit unintended behavior.]
I1005 03:14:16.560269  356179 status.go:522] transient code 100 ("Starting") for step: map[currentstep:11 message:📘  To track progress on multi-node clusters, see https://github.com/kubernetes/minikube/issues/7538. name:Enabling Addons totalsteps:12]
I1005 03:14:16.560332  356179 status.go:522] transient code 100 ("Starting") for step: map[currentstep:3 message:👍  Starting node minikube-m02 in cluster minikube name:Starting Node totalsteps:12]
I1005 03:14:16.560400  356179 status.go:522] transient code 100 ("Starting") for step: map[currentstep:7 message:🔥  Creating kvm2 VM (CPUs=8, Memory=16384MB, Disk=32768MB) ... name:Creating VM totalsteps:12]
I1005 03:14:16.560464  356179 status.go:522] transient code 100 ("Starting") for step: map[currentstep:7 message:🌐  Found network options: name:Creating VM totalsteps:12]
I1005 03:14:16.560528  356179 status.go:522] transient code 100 ("Starting") for step: map[currentstep:8 message:🐳  Preparing Kubernetes v1.19.2 on Docker 19.03.12 ... name:Preparing Kubernetes totalsteps:12]
I1005 03:14:16.560592  356179 status.go:522] transient code 100 ("Starting") for step: map[currentstep:10 message:🔎  Verifying Kubernetes components... name:Verifying Kubernetes totalsteps:12]
I1005 03:14:16.560659  356179 status.go:522] transient code 100 ("Starting") for step: map[currentstep:3 message:👍  Starting node minikube-m03 in cluster minikube name:Starting Node totalsteps:12]
I1005 03:14:16.560723  356179 status.go:522] transient code 100 ("Starting") for step: map[currentstep:7 message:🔥  Creating kvm2 VM (CPUs=8, Memory=16384MB, Disk=32768MB) ... name:Creating VM totalsteps:12]
I1005 03:14:16.560786  356179 status.go:522] transient code 100 ("Starting") for step: map[currentstep:7 message:🌐  Found network options: name:Creating VM totalsteps:12]
I1005 03:14:16.560850  356179 status.go:522] transient code 100 ("Starting") for step: map[currentstep:8 message:🐳  Preparing Kubernetes v1.19.2 on Docker 19.03.12 ... name:Preparing Kubernetes totalsteps:12]
I1005 03:14:16.560913  356179 status.go:522] transient code 100 ("Starting") for step: map[currentstep:10 message:🔎  Verifying Kubernetes components... name:Verifying Kubernetes totalsteps:12]
I1005 03:14:16.560980  356179 status.go:522] transient code 0 ("") for step: map[currentstep:12 message:🏄  Done! kubectl is now configured to use "minikube" by default name:Done totalsteps:12]
W1005 03:14:16.561017  356179 status.go:552] event stream is too old (2020-10-05 03:02:27.515235027 +0100 BST) to be considered a transient state
{"Name":"minikube","StatusCode":200,"StatusName":"OK","BinaryVersion":"v1.13.1","Components":{"kubeconfig":{"Name":"kubeconfig","StatusCode":200,"StatusName":""}},"Nodes":[{"Name":"minikube","StatusCode":200,"StatusName":"OK","Components":{"apiserver":{"Name":"apiserver","StatusCode":200,"StatusName":"OK"},"kubelet":{"Name":"kubelet","StatusCode":200,"StatusName":"OK"}}},{"Name":"minikube-m02","StatusCode":200,"StatusName":"OK","Components":{"kubelet":{"Name":"kubelet","StatusCode":200,"StatusName":"OK"}}},{"Name":"minikube-m03","StatusCode":200,"StatusName":"OK","Components":{"kubelet":{"Name":"kubelet","StatusCode":200,"StatusName":"OK"}}}]}
```