### PR TITLE
explicitly skip gcp-auth webhook for internally maintained addons

### DIFF
--- a/deploy/addons/dashboard/dashboard-dp.yaml
+++ b/deploy/addons/dashboard/dashboard-dp.yaml
@@ -86,6 +86,7 @@ spec:
     metadata:
       labels:
         k8s-app: kubernetes-dashboard
+        gcp-auth-skip-secret: "true"
     spec:
       containers:
         - name: kubernetes-dashboard

--- a/deploy/addons/gcp-auth/gcp-auth-webhook.yaml
+++ b/deploy/addons/gcp-auth/gcp-auth-webhook.yaml
@@ -137,6 +137,12 @@ webhooks:
     matchExpressions:
       - key: gcp-auth-skip-secret
         operator: DoesNotExist
+  namespaceSelector:
+    matchExpressions:
+      - key: name
+        operator: NotIn
+        values:
+        - kube-system
   sideEffects: None
   admissionReviewVersions: ["v1","v1beta1"]
   clientConfig:

--- a/deploy/addons/gcp-auth/gcp-auth-webhook.yaml
+++ b/deploy/addons/gcp-auth/gcp-auth-webhook.yaml
@@ -77,6 +77,7 @@ spec:
       labels:
         app: gcp-auth
         kubernetes.io/minikube-addons: gcp-auth
+        gcp-auth-skip-secret: "true"
     spec:
       containers:
         - name: gcp-auth
@@ -136,12 +137,6 @@ webhooks:
     matchExpressions:
       - key: gcp-auth-skip-secret
         operator: DoesNotExist
-  namespaceSelector:
-    matchExpressions:
-      - key: name
-        operator: NotIn
-        values:
-        - kube-system
   sideEffects: None
   admissionReviewVersions: ["v1","v1beta1"]
   clientConfig:

--- a/deploy/addons/gvisor/gvisor-pod.yaml.tmpl
+++ b/deploy/addons/gvisor/gvisor-pod.yaml.tmpl
@@ -20,6 +20,7 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
     kubernetes.io/minikube-addons: gvisor
+    gcp-auth-skip-secret: "true"
 spec:
   hostPID: true
   containers:

--- a/deploy/addons/ingress-dns/ingress-dns-pod.yaml
+++ b/deploy/addons/ingress-dns/ingress-dns-pod.yaml
@@ -34,6 +34,7 @@ metadata:
     kubernetes.io/bootstrapping: rbac-defaults
     app.kubernetes.io/part-of: kube-system
     addonmanager.kubernetes.io/mode: Reconcile
+    gcp-auth-skip-secret: "true"
 rules:
   - apiGroups:
       - ""

--- a/deploy/addons/ingress/ingress-dp.yaml.tmpl
+++ b/deploy/addons/ingress/ingress-dp.yaml.tmpl
@@ -44,6 +44,7 @@ spec:
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/component: controller
         addonmanager.kubernetes.io/mode: Reconcile
+        gcp-auth-skip-secret: "true"
     spec:
       serviceAccountName: ingress-nginx
       containers:

--- a/deploy/addons/storage-provisioner/storage-provisioner.yaml.tmpl
+++ b/deploy/addons/storage-provisioner/storage-provisioner.yaml.tmpl
@@ -95,6 +95,7 @@ metadata:
   labels:
     integration-test: storage-provisioner
     addonmanager.kubernetes.io/mode: Reconcile
+    gcp-auth-skip-secret: "true"
 spec:
   serviceAccountName: storage-provisioner
   hostNetwork: true

--- a/site/content/en/docs/contrib/addons.en.md
+++ b/site/content/en/docs/contrib/addons.en.md
@@ -23,6 +23,10 @@ Add your manifest YAML's to the directory you have created:
 
 `cp *.yaml deploy/addons/<addon name>`
 
+Note: If the addon never needs authentication to GCP, then consider adding the following label to the pod's yaml:
+
+`gcp-auth-skip-secret: "true"`
+
 To make the addon appear in `minikube addons list`, add it to `pkg/addons/config.go`. Here is the entry used by the `registry` addon, which will work for any addon which does not require custom code:
 
 ```go


### PR DESCRIPTION
Since filtering out kube-system entirely doesn't work (namespaceSelector doesn't filter on name for whatever reason), let's just add the special label to skip the webhook to some of the special addons. So far this is:
- storage-provisioner
- gvisor
- ingress
- dashboard
- gcp-auth itself

This should prevent any weirdness related to race-conditions on minikube start.

Should fix #9392