### PR TITLE
Add new flag "--ports" to expose ports for docker & podman drivers

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -107,6 +107,7 @@ const (
 	forceSystemd            = "force-systemd"
 	kicBaseImage            = "base-image"
 	startOutput             = "output"
+	dockerPorts             = "docker-ports"
 )
 
 // initMinikubeFlags includes commandline flags for minikube.
@@ -197,6 +198,9 @@ func initDriverFlags() {
 	startCmd.Flags().String(hypervVirtualSwitch, "", "The hyperv virtual switch name. Defaults to first found. (hyperv driver only)")
 	startCmd.Flags().Bool(hypervUseExternalSwitch, false, "Whether to use external switch over Default Switch if virtual switch not explicitly specified. (hyperv driver only)")
 	startCmd.Flags().String(hypervExternalAdapter, "", "External Adapter on which external switch will be created if no external switch is found. (hyperv driver only)")
+
+	// docker
+	startCmd.Flags().StringSlice(dockerPorts, []string{}, "List of ports that should be exposed (docker driver only)")
 }
 
 // initNetworkingFlags inits the commandline flags for connectivity related flags for start
@@ -311,6 +315,7 @@ func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k
 			HostOnlyNicType:         viper.GetString(hostOnlyNicType),
 			NatNicType:              viper.GetString(natNicType),
 			StartHostTimeout:        viper.GetDuration(waitTimeout),
+			DockerPorts:             viper.GetStringSlice(dockerPorts),
 			KubernetesConfig: config.KubernetesConfig{
 				KubernetesVersion:      k8sVersion,
 				ClusterName:            ClusterFlagValue(),
@@ -545,6 +550,10 @@ func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterC
 
 	if cmd.Flags().Changed(apiServerPort) {
 		cc.KubernetesConfig.NodePort = viper.GetInt(apiServerPort)
+	}
+
+	if cmd.Flags().Changed(vsockPorts) {
+		cc.DockerPorts = viper.GetStringSlice(dockerPorts)
 	}
 
 	// pre minikube 1.9.2 cc.KubernetesConfig.NodePort was not populated.

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -107,7 +107,7 @@ const (
 	forceSystemd            = "force-systemd"
 	kicBaseImage            = "base-image"
 	startOutput             = "output"
-	dockerPorts             = "docker-ports"
+	ports                   = "ports"
 )
 
 // initMinikubeFlags includes commandline flags for minikube.
@@ -199,8 +199,8 @@ func initDriverFlags() {
 	startCmd.Flags().Bool(hypervUseExternalSwitch, false, "Whether to use external switch over Default Switch if virtual switch not explicitly specified. (hyperv driver only)")
 	startCmd.Flags().String(hypervExternalAdapter, "", "External Adapter on which external switch will be created if no external switch is found. (hyperv driver only)")
 
-	// docker
-	startCmd.Flags().StringSlice(dockerPorts, []string{}, "List of ports that should be exposed (docker driver only)")
+	// docker & podman
+	startCmd.Flags().StringSlice(ports, []string{}, "List of ports that should be exposed (docker and podman driver only)")
 }
 
 // initNetworkingFlags inits the commandline flags for connectivity related flags for start
@@ -315,7 +315,7 @@ func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k
 			HostOnlyNicType:         viper.GetString(hostOnlyNicType),
 			NatNicType:              viper.GetString(natNicType),
 			StartHostTimeout:        viper.GetDuration(waitTimeout),
-			DockerPorts:             viper.GetStringSlice(dockerPorts),
+			ExposedPorts:             viper.GetStringSlice(ports),
 			KubernetesConfig: config.KubernetesConfig{
 				KubernetesVersion:      k8sVersion,
 				ClusterName:            ClusterFlagValue(),
@@ -553,7 +553,7 @@ func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterC
 	}
 
 	if cmd.Flags().Changed(vsockPorts) {
-		cc.DockerPorts = viper.GetStringSlice(dockerPorts)
+		cc.ExposedPorts = viper.GetStringSlice(ports)
 	}
 
 	// pre minikube 1.9.2 cc.KubernetesConfig.NodePort was not populated.

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -315,7 +315,7 @@ func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k
 			HostOnlyNicType:         viper.GetString(hostOnlyNicType),
 			NatNicType:              viper.GetString(natNicType),
 			StartHostTimeout:        viper.GetDuration(waitTimeout),
-			ExposedPorts:             viper.GetStringSlice(ports),
+			ExposedPorts:            viper.GetStringSlice(ports),
 			KubernetesConfig: config.KubernetesConfig{
 				KubernetesVersion:      k8sVersion,
 				ClusterName:            ClusterFlagValue(),

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -78,7 +78,7 @@ func (d *Driver) Create() error {
 		CPUs:          strconv.Itoa(d.NodeConfig.CPU),
 		Memory:        strconv.Itoa(d.NodeConfig.Memory) + "mb",
 		Envs:          d.NodeConfig.Envs,
-		ExtraArgs:     []string{"--expose", fmt.Sprintf("%d", d.NodeConfig.APIServerPort)},
+		ExtraArgs:     append([]string{"--expose", fmt.Sprintf("%d", d.NodeConfig.APIServerPort)}, d.NodeConfig.ExtraArgs...),
 		OCIBinary:     d.NodeConfig.OCIBinary,
 		APIServerPort: d.NodeConfig.APIServerPort,
 	}

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -60,5 +60,6 @@ type Config struct {
 	PortMappings      []oci.PortMapping // container port mappings
 	Envs              map[string]string // key,value of environment variables passed to the node
 	KubernetesVersion string            // Kubernetes version to install
-	ContainerRuntime  string            // container runtime kic is running
+	ContainerRuntime  string            // container runtime kic is running,
+	ExtraArgs         []string          // a list of any extra option to pass to oci binary during creation time, for example --expose 8080...
 }

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -60,6 +60,6 @@ type Config struct {
 	PortMappings      []oci.PortMapping // container port mappings
 	Envs              map[string]string // key,value of environment variables passed to the node
 	KubernetesVersion string            // Kubernetes version to install
-	ContainerRuntime  string            // container runtime kic is running,
+	ContainerRuntime  string            // container runtime kic is running
 	ExtraArgs         []string          // a list of any extra option to pass to oci binary during creation time, for example --expose 8080...
 }

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -71,6 +71,7 @@ type ClusterConfig struct {
 	Addons                  map[string]bool
 	VerifyComponents        map[string]bool // map of components to verify and wait for after start.
 	StartHostTimeout        time.Duration
+	DockerPorts             []string // Only used by the docker driver
 }
 
 // KubernetesConfig contains the parameters used to configure the VM Kubernetes.

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -71,7 +71,7 @@ type ClusterConfig struct {
 	Addons                  map[string]bool
 	VerifyComponents        map[string]bool // map of components to verify and wait for after start.
 	StartHostTimeout        time.Duration
-	DockerPorts             []string // Only used by the docker driver
+	ExposedPorts             []string // Only used by the docker and podman driver
 }
 
 // KubernetesConfig contains the parameters used to configure the VM Kubernetes.

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -71,7 +71,7 @@ type ClusterConfig struct {
 	Addons                  map[string]bool
 	VerifyComponents        map[string]bool // map of components to verify and wait for after start.
 	StartHostTimeout        time.Duration
-	ExposedPorts             []string // Only used by the docker and podman driver
+	ExposedPorts            []string // Only used by the docker and podman driver
 }
 
 // KubernetesConfig contains the parameters used to configure the VM Kubernetes.

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -62,7 +62,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 
 	extraArgs := []string{}
 
-	for _, port := range cc.DockerPorts {
+	for _, port := range cc.ExposedPorts {
 		extraArgs = append(extraArgs, "-p", port)
 	}
 

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -60,6 +60,12 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		}
 	}
 
+	extraArgs := []string{}
+
+	for _, port := range cc.DockerPorts {
+		extraArgs = append(extraArgs, "-p", port)
+	}
+
 	return kic.NewDriver(kic.Config{
 		ClusterName:       cc.Name,
 		MachineName:       driver.MachineName(cc, n),
@@ -72,6 +78,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		APIServerPort:     cc.Nodes[0].Port,
 		KubernetesVersion: cc.KubernetesConfig.KubernetesVersion,
 		ContainerRuntime:  cc.KubernetesConfig.ContainerRuntime,
+		ExtraArgs:         extraArgs,
 	}), nil
 }
 

--- a/pkg/minikube/registry/drvs/podman/podman.go
+++ b/pkg/minikube/registry/drvs/podman/podman.go
@@ -72,6 +72,12 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		}
 	}
 
+	extraArgs := []string{}
+
+	for _, port := range cc.ExposedPorts {
+		extraArgs = append(extraArgs, "-p", port)
+	}
+
 	return kic.NewDriver(kic.Config{
 		ClusterName:       cc.Name,
 		MachineName:       driver.MachineName(cc, n),
@@ -84,6 +90,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		APIServerPort:     cc.Nodes[0].Port,
 		KubernetesVersion: cc.KubernetesConfig.KubernetesVersion,
 		ContainerRuntime:  cc.KubernetesConfig.ContainerRuntime,
+		ExtraArgs:         extraArgs,
 	}), nil
 }
 

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -39,6 +39,7 @@ minikube start [flags]
       --dns-proxy                         Enable proxy for NAT DNS requests (virtualbox driver only)
       --docker-env stringArray            Environment variables to pass to the Docker daemon. (format: key=value)
       --docker-opt stringArray            Specify arbitrary flags to pass to the Docker daemon. (format: key=value)
+      --docker-ports strings              List of ports that should be exposed (docker driver only)
       --download-only                     If true, only download and cache files for later use - don't install or start anything.
       --driver string                     Used to specify the driver to run Kubernetes in. The list of available drivers depends on operating system.
       --dry-run                           dry-run mode. Validates configuration, but does not mutate system state

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -39,7 +39,6 @@ minikube start [flags]
       --dns-proxy                         Enable proxy for NAT DNS requests (virtualbox driver only)
       --docker-env stringArray            Environment variables to pass to the Docker daemon. (format: key=value)
       --docker-opt stringArray            Specify arbitrary flags to pass to the Docker daemon. (format: key=value)
-      --docker-ports strings              List of ports that should be exposed (docker driver only)
       --download-only                     If true, only download and cache files for later use - don't install or start anything.
       --driver string                     Used to specify the driver to run Kubernetes in. The list of available drivers depends on operating system.
       --dry-run                           dry-run mode. Validates configuration, but does not mutate system state
@@ -84,6 +83,7 @@ minikube start [flags]
       --no-vtx-check                      Disable checking for the availability of hardware virtualization before the vm is started (virtualbox driver only)
   -n, --nodes int                         The number of nodes to spin up. Defaults to 1. (default 1)
   -o, --output string                     Format to print stdout in. Options include: [text,json] (default "text")
+      --ports strings                     List of ports that should be exposed (docker and podman driver only)
       --preload                           If set, download tarball of preloaded images if available to improve start time. Defaults to true. (default true)
       --registry-mirror strings           Registry mirrors to pass to the Docker daemon
       --service-cluster-ip-range string   The CIDR to be used for service cluster IPs. (default "10.96.0.0/12")


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

expose extra ports when using docker driver. This fixes issue: #8008 #8398 #9198 

Usage:
```
minikube start --driver=docker \
--ports=8080:30000 \
--ports=8443:30001 \
--ports=15021:30002 
```

Please let me know if changes are necessary 😃 