### PR TITLE
Remove reference to Virtualbox in "stop" help

### DIFF
--- a/cmd/minikube/cmd/stop.go
+++ b/cmd/minikube/cmd/stop.go
@@ -48,9 +48,8 @@ var (
 var stopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stops a running local Kubernetes cluster",
-	Long: `Stops a local Kubernetes cluster running in Virtualbox. This command stops the VM
-itself, leaving all files intact. The cluster can be started again with the "start" command.`,
-	Run: runStop,
+	Long:  `Stops a local Kubernetes cluster. This command stops the underlying VM or container, but keeps user data intact. The cluster can be started again with the "start" command.`,
+	Run:   runStop,
 }
 
 func init() {

--- a/site/content/en/docs/commands/stop.md
+++ b/site/content/en/docs/commands/stop.md
@@ -11,8 +11,7 @@ Stops a running local Kubernetes cluster
 
 ### Synopsis
 
-Stops a local Kubernetes cluster running in Virtualbox. This command stops the VM
-itself, leaving all files intact. The cluster can be started again with the "start" command.
+Stops a local Kubernetes cluster. This command stops the underlying VM or container, but keeps user data intact. The cluster can be started again with the "start" command.
 
 ```
 minikube stop [flags]


### PR DESCRIPTION
## Old

`Stops a local Kubernetes cluster running in Virtualbox. This command stops the VM itself, leaving all files intact. The cluster can be started again with the "start" command.`

## New

`Stops a local Kubernetes cluster. This command stops the underlying VM or container, but keeps user data intact. The cluster can be started again with the "start" command.`
