### PR TITLE
fixing the controller name in ingress-nginx-controller patch

### DIFF
--- a/site/content/en/docs/tutorials/nginx_tcp_udp_ingress.md
+++ b/site/content/en/docs/tutorials/nginx_tcp_udp_ingress.md
@@ -172,7 +172,7 @@ spec:
   template:
     spec:
       containers:
-      - name: ingress-nginx-controller
+      - name: controller
         ports:
          - containerPort: 6379
            hostPort: 6379


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:



1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
# Description

fixes #9354

fixing the container name in  ingress-nginx-controller-patch.yaml ( Ref : [ingress-dp.yaml](https://github.com/kubernetes/minikube/blob/master/deploy/addons/ingress/ingress-dp.yaml.tmpl#L51) )

## How Has This Been Tested?

### Issue Reproduced

```
> minikube addons enable ingress
🔎  Verifying ingress addon...
🌟  The 'ingress' addon is enabled
```

```
>cat ingress-nginx-controller-patch.yaml
spec:
  template:
    spec:
      containers:
      - name: ingress-nginx-controller
        ports:
         - containerPort: 6379
           hostPort: 6379
```
```

>kubectl patch deployment ingress-nginx-controller --patch "$(cat ingress-nginx-controller-patch.yaml)" -n kube-system
**The Deployment "ingress-nginx-controller" is invalid: spec.template.spec.containers[0].image: Required value**
```


### after applying the fix

```
>cat ingress-nginx-controller-patch.yaml
spec:
  template:
    spec:
      containers:
      - name: controller
        ports:
         - containerPort: 6379
           hostPort: 6379
```

```
>kubectl patch deployment ingress-nginx-controller --patch "$(cat ingress-nginx-controller-patch.yaml)" -n kube-system
**deployment.apps/ingress-nginx-controller patched**
```
