### PR TITLE
WIP: start: fix to delete existing cluster when 'delete-on-failure' is set

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -170,7 +170,6 @@ func runStart(cmd *cobra.Command, args []string) {
 		upgradeExistingConfig(existing)
 	}
 
-	//validateSpecifiedDriver(existing)
 	validateKubernetesVersion(existing)
 
 	ds, alts, specified, _ := selectDriver(existing)
@@ -753,44 +752,6 @@ func hostDriver(existing *config.ClusterConfig) string {
 	}
 
 	return h.Driver.DriverName()
-}
-
-// validateSpecifiedDriver makes sure that if a user has passed in a driver
-// it matches the existing cluster if there is one
-func validateSpecifiedDriver(existing *config.ClusterConfig) {
-	if existing == nil {
-		return
-	}
-
-	var requested string
-	if d := viper.GetString("driver"); d != "" {
-		requested = d
-	} else if d := viper.GetString("vm-driver"); d != "" {
-		requested = d
-	}
-
-	// Neither --vm-driver or --driver was specified
-	if requested == "" {
-		return
-	}
-
-	old := hostDriver(existing)
-	if requested == old {
-		return
-	}
-
-	exit.Advice(
-		reason.GuestDrvMismatch,
-		`The existing "{{.name}}" cluster was created using the "{{.old}}" driver, which is incompatible with requested "{{.new}}" driver.`,
-		"Delete the existing '{{.name}}' cluster using: '{{.delcommand}}', or start the existing '{{.name}}' cluster using: '{{.command}} --driver={{.old}}'",
-		out.V{
-			"name":       existing.Name,
-			"new":        requested,
-			"old":        old,
-			"command":    mustload.ExampleCmd(existing.Name, "start"),
-			"delcommand": mustload.ExampleCmd(existing.Name, "delete"),
-		},
-	)
 }
 
 // validateDriver validates that the selected driver appears sane, exits if not

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -220,9 +220,9 @@ func ClusterFlagValue() string {
 }
 
 // generateClusterConfig generate a config.ClusterConfig based on flags or existing cluster config
-func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k8sVersion string, drvName string) (config.ClusterConfig, config.Node, error) {
+func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k8sVersion string, drvName string, deleteExistingCluster bool) (config.ClusterConfig, config.Node, error) {
 	var cc config.ClusterConfig
-	if existing != nil {
+	if existing != nil && !deleteExistingCluster {
 		cc = updateExistingConfigFromFlags(cmd, existing)
 	} else {
 		klog.Info("no existing cluster config was found, will generate one from the flags ")

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -133,7 +133,7 @@ func TestMirrorCountry(t *testing.T) {
 			cmd := &cobra.Command{}
 			viper.SetDefault(imageRepository, test.imageRepository)
 			viper.SetDefault(imageMirrorCountry, test.mirrorCountry)
-			config, _, err := generateClusterConfig(cmd, nil, k8sVersion, "none")
+			config, _, err := generateClusterConfig(cmd, nil, k8sVersion, "none", false)
 			if err != nil {
 				t.Fatalf("Got unexpected error %v during config generation", err)
 			}
@@ -202,7 +202,7 @@ func TestGenerateCfgFromFlagsHTTPProxyHandling(t *testing.T) {
 
 			cfg.DockerEnv = []string{} // clear docker env to avoid pollution
 			proxy.SetDockerEnv()
-			config, _, err := generateClusterConfig(cmd, nil, k8sVersion, "none")
+			config, _, err := generateClusterConfig(cmd, nil, k8sVersion, "none", false)
 			if err != nil {
 				t.Fatalf("Got unexpected error %v during config generation", err)
 			}

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -628,3 +628,13 @@ func iptablesFileExists(ociBin string, nameOrID string) bool {
 	}
 	return true
 }
+
+func RenameProfile(oldName, newName string) error {
+	_, err := runCmd(exec.Command(Docker, "rename", oldName, newName), false)
+	if err != nil {
+		klog.Errorf("Error in renaming profile : %s", err.Error())
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
**What**
The PR address changes required to forcefully delete cluster when there exists another cluster with same profile making decision based on the user specified driver validations.

**Why**
fixes: #9399
