### PR TITLE
Bump version for ingress dns addon

### DIFF
--- a/deploy/addons/ingress-dns/ingress-dns-pod.yaml
+++ b/deploy/addons/ingress-dns/ingress-dns-pod.yaml
@@ -80,7 +80,7 @@ spec:
   hostNetwork: true
   containers:
     - name: minikube-ingress-dns
-      image: "cryptexlabs/minikube-ingress-dns:0.2.1"
+      image: "cryptexlabs/minikube-ingress-dns:0.3.0"
       imagePullPolicy: IfNotPresent
       ports:
         - containerPort: 53


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/9022

New image version removes additionals from dns response. See https://gitlab.com/cryptexlabs/public/development/minikube-ingress-dns/-/merge_requests/2 for more info