### PR TITLE
bump helm-tiller addon to v2.16.12

### DIFF
--- a/deploy/addons/helm-tiller/helm-tiller-dp.tmpl
+++ b/deploy/addons/helm-tiller/helm-tiller-dp.tmpl
@@ -46,7 +46,7 @@ spec:
               value: kube-system
             - name: TILLER_HISTORY_MAX
               value: "0"
-          image: gcr.io/kubernetes-helm/tiller:v2.16.8
+          image: gcr.io/kubernetes-helm/tiller:v2.16.12
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3


### PR DESCRIPTION
### What type of PR is this?
/area addons

### What this PR does / why we need it:

This PR bump up helm-tiller addon's image v2.16.8 to v2.16.12.
This version has security improvement and fixed issues of helm-tiller.

### Which issue(s) this PR fixes:

Fixes #9443 

### Does this PR introduce a user-facing change?

Yes.
This image bumpup includes helm2 fixed issues.
https://github.com/helm/helm/releases/tag/v2.16.12

**Before**
```
image: gcr.io/kubernetes-helm/tiller:v2.16.8
```

**After**
```
image: gcr.io/kubernetes-helm/tiller:v2.16.12
```

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```