### PR TITLE
get greatest instead of just latest Kubernetes version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,7 @@ require (
 	golang.org/x/build v0.0.0-20190927031335-2835ba2e683f
 	golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37
 	golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6
+	golang.org/x/mod v0.3.0
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 	golang.org/x/sys v0.0.0-20200523222454-059865788121

--- a/hack/kubernetes_version/update_kubernetes_version.go
+++ b/hack/kubernetes_version/update_kubernetes_version.go
@@ -127,9 +127,10 @@ func (p *Patch) apply(data interface{}) (changed bool, err error) {
 }
 
 func main() {
+	klog.InitFlags(nil)
 	// write log statements to stderr instead of to files
 	if err := flag.Set("logtostderr", "true"); err != nil {
-		fmt.Printf("Error setting 'logtostderr' klog flag: %v", err)
+		fmt.Printf("Error setting 'logtostderr' klog flag: %v\n", err)
 	}
 	flag.Parse()
 	defer klog.Flush()

--- a/hack/kubernetes_version/update_kubernetes_version.go
+++ b/hack/kubernetes_version/update_kubernetes_version.go
@@ -40,6 +40,7 @@ import (
 	"text/template"
 	"time"
 
+	"golang.org/x/mod/semver"
 	"golang.org/x/oauth2"
 
 	"github.com/google/go-github/v32/github"
@@ -399,26 +400,19 @@ func ghReleases(ctx context.Context, owner, repo, token string) (stable, latest 
 		}
 		for _, rl := range rls {
 			ver := rl.GetName()
-			if ver == "" {
+			if !semver.IsValid(ver) {
 				continue
 			}
-			// check if ver version is a release (ie, 'v1.19.2') or a
-			// pre-release (ie, 'v1.19.3-rc.0' or 'v1.19.0-beta.2') channel ch
-			// note: github.RepositoryRelease GetPrerelease() bool would be useful for all pre-rels
-			ch := strings.Split(ver, "-")
-			if len(ch) == 1 && stable == "" {
-				stable = ver
-			} else if len(ch) > 1 && latest == "" {
-				if strings.HasPrefix(ch[1], "rc") || strings.HasPrefix(ch[1], "beta") {
-					latest = ver
-				}
+			// check if ver version is release (ie, 'v1.19.2') or pre-release (ie, 'v1.19.3-rc.0' or 'v1.19.0-beta.2')
+			prerls := semver.Prerelease(ver)
+			if prerls == "" {
+				stable = semver.Max(ver, stable)
+			} else if strings.HasPrefix(prerls, "-rc") || strings.HasPrefix(prerls, "-beta") {
+				latest = semver.Max(ver, latest)
 			}
-			if stable != "" && latest != "" {
-				// make sure that v.Latest >= stable
-				if latest < stable {
-					latest = stable
-				}
-				return stable, latest, nil
+			// make sure that latest >= stable
+			if semver.Compare(latest, stable) == -1 {
+				latest = stable
 			}
 		}
 		if resp.NextPage == 0 {


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
fixes #4392 (iteration 1 & 2)

fixing two mistakes i've previously made:
1. returning latest, but not necessarily also the greatest version (eg, Kubernetes released v1.18.10 after v1.19.3 but we need the latter)
2. comparing versions as strings, now using semver to check version validity, check if it's prerelease, and compare versions

and also fixed klog `no such flag -logtostderr` error