### PR TITLE
add --watch flag for minikube status with optional interval duration

### DIFF
--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -217,7 +217,11 @@ var statusCmd = &cobra.Command{
 }
 
 // writeStatusesAtInterval writes statuses in a given output format - at intervals defined by duration
+<<<<<<< HEAD
 func writeStatusesAtInterval(duration time.Duration, api libmachine.API, cc *config.ClusterConfig) {
+=======
+func writeStatusesAtInterval(duration time.Duration, api libmachine.API, cc *config.ClusterConfig) int {
+>>>>>>> ab981fe40 (move write statuses logic to a separate func)
 	for {
 		var statuses []*Status
 

--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -217,11 +217,7 @@ var statusCmd = &cobra.Command{
 }
 
 // writeStatusesAtInterval writes statuses in a given output format - at intervals defined by duration
-<<<<<<< HEAD
 func writeStatusesAtInterval(duration time.Duration, api libmachine.API, cc *config.ClusterConfig) {
-=======
-func writeStatusesAtInterval(duration time.Duration, api libmachine.API, cc *config.ClusterConfig) int {
->>>>>>> ab981fe40 (move write statuses logic to a separate func)
 	for {
 		var statuses []*Status
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/blang/semver v3.5.0+incompatible
 	github.com/c4milo/gotoolkit v0.0.0-20170318115440-bcc06269efa9 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/cenkalti/backoff/v4 v4.1.0
 	github.com/cheggaaa/pb/v3 v3.0.1
 	github.com/cloudevents/sdk-go/v2 v2.1.0
 	github.com/cloudfoundry-attic/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21
@@ -75,6 +76,7 @@ require (
 	golang.org/x/build v0.0.0-20190927031335-2835ba2e683f
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
 	golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6
+	golang.org/x/mod v0.3.0
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 	golang.org/x/sys v0.0.0-20200523222454-059865788121

--- a/go.sum
+++ b/go.sum
@@ -197,6 +197,8 @@ github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oD
 github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/cenkalti/backoff/v4 v4.1.0 h1:c8LkOFQTzuO0WBM/ae5HdGQuZPfPxp7lqBRwQRm4fSc=
+github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/prettybench v0.0.0-20150116022406-03b8cfe5406c/go.mod h1:Xe6ZsFhtM8HrDku0pxJ3/Lr51rwykrzgFwpmTzleatY=
@@ -602,7 +604,6 @@ github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6K
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
-github.com/hashicorp/go-getter v1.4.2/go.mod h1:3Ao9Hol5VJsmwJV5BF1GUrONbaOUmA+m1Nj2+0LuMAY=
 github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=

--- a/site/content/en/docs/commands/status.md
+++ b/site/content/en/docs/commands/status.md
@@ -22,11 +22,12 @@ minikube status [flags]
 ### Options
 
 ```
-  -f, --format string   Go template format string for the status output.  The format for Go templates can be found here: https://golang.org/pkg/text/template/
-                        For the list accessible variables for the template, see the struct values here: https://godoc.org/k8s.io/minikube/cmd/minikube/cmd#Status (default "{{.Name}}\ntype: Control Plane\nhost: {{.Host}}\nkubelet: {{.Kubelet}}\napiserver: {{.APIServer}}\nkubeconfig: {{.Kubeconfig}}\n\n")
-  -l, --layout string   output layout (EXPERIMENTAL, JSON only): 'nodes' or 'cluster' (default "nodes")
-  -n, --node string     The node to check status for. Defaults to control plane. Leave blank with default format for status on all nodes.
-  -o, --output string   minikube status --output OUTPUT. json, text (default "text")
+  -f, --format string         Go template format string for the status output.  The format for Go templates can be found here: https://golang.org/pkg/text/template/
+                              For the list accessible variables for the template, see the struct values here: https://godoc.org/k8s.io/minikube/cmd/minikube/cmd#Status (default "{{.Name}}\ntype: Control Plane\nhost: {{.Host}}\nkubelet: {{.Kubelet}}\napiserver: {{.APIServer}}\nkubeconfig: {{.Kubeconfig}}\n\n")
+  -l, --layout string         output layout (EXPERIMENTAL, JSON only): 'nodes' or 'cluster' (default "nodes")
+  -n, --node string           The node to check status for. Defaults to control plane. Leave blank with default format for status on all nodes.
+  -o, --output string         minikube status --output OUTPUT. json, text (default "text")
+  -w, --watch duration[=1s]   Continuously listing/getting the status with optional interval duration. (default 1s)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
fixes: #9468 

add `minikube status --watch[=duration]` (`-w`) flag that will produce continuous output waiting for a specified duration (defaulting to 1 sec) between each poll

### example output
```
❯ minikube status --output json -l=cluster --watch 2>/dev/null | jq .StatusName 
"Stopped"
"Stopped"
"Stopped"
...
"Starting"
"Starting"
"Starting"
...
"OK"
"OK"
"OK"
...
"Stopping"
"Stopping"
"Unknown"
"Stopped"
"Stopped"
"Stopped"
```