### PR TITLE
Remove Init function from the parallels driver definition

### DIFF
--- a/pkg/minikube/registry/drvs/parallels/parallels.go
+++ b/pkg/minikube/registry/drvs/parallels/parallels.go
@@ -23,7 +23,6 @@ import (
 	"os/exec"
 
 	parallels "github.com/Parallels/docker-machine-parallels"
-	"github.com/docker/machine/libmachine/drivers"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/download"
 	"k8s.io/minikube/pkg/minikube/driver"
@@ -37,7 +36,6 @@ func init() {
 		Config:   configure,
 		Status:   status,
 		Priority: registry.Default,
-		Init:     func() drivers.Driver { return parallels.NewDriver("", "") },
 	})
 	if err != nil {
 		panic(fmt.Sprintf("unable to register: %v", err))


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/9493

That's needed for `minikube` to stop treating `parallels` as a built-in driver and use RPC calls for calling its functionality.
