### PR TITLE
Remove hard-coded list of valid cgroupfs mountpoints to bind mount

### DIFF
--- a/deploy/kicbase/entrypoint
+++ b/deploy/kicbase/entrypoint
@@ -80,9 +80,17 @@ fix_cgroup_mounts() {
   # environment by doing another bind mount for each subsystem.
   local cgroup_mounts
 
-  # NOTE: This extracts fields 4 and on
+  # This regexp finds all /sys/fs/cgroup mounts that are cgroupfs and mounted somewhere other than / - extracting fields 4+
   # See https://man7.org/linux/man-pages/man5/proc.5.html for field names
-  cgroup_mounts=$(egrep -o '(/docker|libpod_parent|/kubepods).*/sys/fs/cgroup.*' /proc/self/mountinfo || true)
+
+  # Example inputs:
+  #
+  # Docker:               /docker/562a56986a84b3cd38d6a32ac43fdfcc8ad4d2473acf2839cbf549273f35c206 /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:143 master:23 - cgroup devices rw,devices
+  # podman:               /libpod_parent/libpod-73a4fb9769188ae5dc51cb7e24b9f2752a4af7b802a8949f06a7b2f2363ab0e9 ...
+  # Cloud Shell:          /kubepods/besteffort/pod3d6beaa3004913efb68ce073d73494b0/accdf94879f0a494f317e9a0517f23cdd18b35ff9439efd0175f17bbc56877c4 /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime master:19 - cgroup cgroup rw,memory
+  # GitHub actions #9304: /actions_job/0924fbbcf7b18d2a00c171482b4600747afc367a9dfbeac9d6b14b35cda80399 /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:263 master:24 - cgroup cgroup rw,memory
+
+  cgroup_mounts=$(grep -E -o '/[[:alnum:]].* /sys/fs/cgroup.*.*cgroup' /proc/self/mountinfo || true)
 
   if [[ -n "${cgroup_mounts}" ]]; then
     local mount_root


### PR DESCRIPTION
Likely fixes #9304 

The TL;DR is that I had previously created an overly strict list of expected mountpaths. As we found more and more corner cases, the regexp got more convoluted. With this GitHub Actions environment, an additional new possibility was found, so this PR generalizes the regexp.

Tested using:

`docker build -t kicbase:experiment deploy/kicbase; minikube delete; minikube start --base-image=kicbase:experiment --driver=docker`

## Docker Desktop

```
+ cgroup_mounts='/docker/b92002beeaf5d283c2bbbba725d66982f145ba98d08fe33a84936d5255c4404d /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:138 master:18 - cgroup
/docker/b92002beeaf5d283c2bbbba725d66982f145ba98d08fe33a84936d5255c4404d /sys/fs/cgroup/cpu rw,nosuid,nodev,noexec,relatime shared:139 master:19 - cgroup
/docker/b92002beeaf5d283c2bbbba725d66982f145ba98d08fe33a84936d5255c4404d /sys/fs/cgroup/cpuacct rw,nosuid,nodev,noexec,relatime shared:140 master:20 - cgroup
/docker/b92002beeaf5d283c2bbbba725d66982f145ba98d08fe33a84936d5255c4404d /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:141 master:21 - cgroup
/docker/b92002beeaf5d283c2bbbba725d66982f145ba98d08fe33a84936d5255c4404d /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:142 master:22 - cgroup
/docker/b92002beeaf5d283c2bbbba725d66982f145ba98d08fe33a84936d5255c4404d /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:143 master:23 - cgroup
/docker/b92002beeaf5d283c2bbbba725d66982f145ba98d08fe33a84936d5255c4404d /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:144 master:24 - cgroup
/docker/b92002beeaf5d283c2bbbba725d66982f145ba98d08fe33a84936d5255c4404d /sys/fs/cgroup/net_cls rw,nosuid,nodev,noexec,relatime shared:145 master:25 - cgroup
/docker/b92002beeaf5d283c2bbbba725d66982f145ba98d08fe33a84936d5255c4404d /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime shared:146 master:26 - cgroup
/docker/b92002beeaf5d283c2bbbba725d66982f145ba98d08fe33a84936d5255c4404d /sys/fs/cgroup/net_prio rw,nosuid,nodev,noexec,relatime shared:147 master:27 - cgroup
/docker/b92002beeaf5d283c2bbbba725d66982f145ba98d08fe33a84936d5255c4404d /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:148 master:28 - cgroup
/docker/b92002beeaf5d283c2bbbba725d66982f145ba98d08fe33a84936d5255c4404d /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:149 master:29 - cgroup
/docker/b92002beeaf5d283c2bbbba725d66982f145ba98d08fe33a84936d5255c4404d /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:151 master:31 - cgroup cgroup'
```

## Cloud Shell

```
+ cgroup_mounts='/kubepods/besteffort/pod3d6beaa3004913efb68ce073d73494b0/accdf94879f0a494f317e9a0517f23cdd18b35ff9439efd0175f17bbc56877c4/docker/9e
0c041b0884d0ba46a3114480e03b7df4ff3cd56e1b9f80305f0744a1855f1d /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:279 master:9 - cgroup c
group
/kubepods/besteffort/pod3d6beaa3004913efb68ce073d73494b0/accdf94879f0a494f317e9a0517f23cdd18b35ff9439efd0175f17bbc56877c4/docker/9e0c041b0884d0ba46a
3114480e03b7df4ff3cd56e1b9f80305f0744a1855f1d /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:283 master:14 - cgroup cgroup
/kubepods/besteffort/pod3d6beaa3004913efb68ce073d73494b0/accdf94879f0a494f317e9a0517f23cdd18b35ff9439efd0175f17bbc56877c4/docker/9e0c041b0884d0ba46a
3114480e03b7df4ff3cd56e1b9f80305f0744a1855f1d /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:288 master:15 - cgroup cgroup
/kubepods/besteffort/pod3d6beaa3004913efb68ce073d73494b0/accdf94879f0a494f317e9a0517f23cdd18b35ff9439efd0175f17bbc56877c4/docker/9e0c041b0884d0ba46a
3114480e03b7df4ff3cd56e1b9f80305f0744a1855f1d /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:292 master:16 - cgroup cgroup
/kubepods/besteffort/pod3d6beaa3004913efb68ce073d73494b0/accdf94879f0a494f317e9a0517f23cdd18b35ff9439efd0175f17bbc56877c4/docker/9e0c041b0884d0ba46a
3114480e03b7df4ff3cd56e1b9f80305f0744a1855f1d /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:296 master:17 - cgroup cgroup
/kubepods/besteffort/pod3d6beaa3004913efb68ce073d73494b0/accdf94879f0a494f317e9a0517f23cdd18b35ff9439efd0175f17bbc56877c4/docker/9e0c041b0884d0ba46a
3114480e03b7df4ff3cd56e1b9f80305f0744a1855f1d /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:298 master:19 - cgroup cgroup
/kubepods/besteffort/pod3d6beaa3004913efb68ce073d73494b0/accdf94879f0a494f317e9a0517f23cdd18b35ff9439efd0175f17bbc56877c4/docker/9e0c041b0884d0ba46a
3114480e03b7df4ff3cd56e1b9f80305f0744a1855f1d /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime shared:299 master:20 - cgroup cgroup
/kubepods/besteffort/pod3d6beaa3004913efb68ce073d73494b0/accdf94879f0a494f317e9a0517f23cdd18b35ff9439efd0175f17bbc56877c4/docker/9e0c041b0884d0ba46a
3114480e03b7df4ff3cd56e1b9f80305f0744a1855f1d /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:300 master:21 - cgroup cgroup
/kubepods/besteffort/pod3d6beaa3004913efb68ce073d73494b0/accdf94879f0a494f317e9a0517f23cdd18b35ff9439efd0175f17bbc56877c4/docker/9e0c041b0884d0ba46a
3114480e03b7df4ff3cd56e1b9f80305f0744a1855f1d /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:301 master:22 - cgroup cgroup
/kubepods/besteffort/pod3d6beaa3004913efb68ce073d73494b0/accdf94879f0a494f317e9a0517f23cdd18b35ff9439efd0175f17bbc56877c4/docker/9e0c041b0884d0ba46a
3114480e03b7df4ff3cd56e1b9f80305f0744a1855f1d /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime shared:302 master:23 - cgroup cgroup
/kubepods/besteffort/pod3d6beaa3004913efb68ce073d73494b0/accdf94879f0a494f317e9a0517f23cdd18b35ff9439efd0175f17bbc56877c4/docker/9e0c041b0884d0ba46a
3114480e03b7df4ff3cd56e1b9f80305f0744a1855f1d /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:303 master:24 - cgroup cgroup'
```
