### PR TITLE
Double addon pod wait time to avoid errors on slow pulls

### DIFF
--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -353,9 +353,10 @@ func verifyAddonStatusInternal(cc *config.ClusterConfig, name string, val string
 			return errors.Wrapf(err, "get kube-client to validate %s addon: %v", name, err)
 		}
 
-		err = kapi.WaitForPods(client, ns, label, time.Minute*3)
+		// This timeout includes image pull time, which can take a few minutes. 3 is not enough.
+		err = kapi.WaitForPods(client, ns, label, time.Minute*5)
 		if err != nil {
-			return errors.Wrapf(err, "verifying %s addon pods : %v", name, err)
+			return errors.Wrapf(err, "waiting for %s pods", label)
 		}
 
 	}

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -354,7 +354,7 @@ func verifyAddonStatusInternal(cc *config.ClusterConfig, name string, val string
 		}
 
 		// This timeout includes image pull time, which can take a few minutes. 3 is not enough.
-		err = kapi.WaitForPods(client, ns, label, time.Minute*5)
+		err = kapi.WaitForPods(client, ns, label, time.Minute*6)
 		if err != nil {
 			return errors.Wrapf(err, "waiting for %s pods", label)
 		}


### PR DESCRIPTION
Fixes #9514

"If a unit seems too weak, don’t lower its cost by 5%; instead, double its strength. If players feel overwhelmed by too many upgrades, try removing half of them. In the original Civilization, the gameplay kept slowing down to a painful crawl, which Sid solved by shrinking the map in half. The point is not that the new values are likely to be correct; the goal is to stake out more design territory with each successive iteration."

— Analysis: Sid Meier's Key Design Lessons

## Old behavior

If an addon takes >3 minutes to pull and start, emit error:

`❌ Exiting due to MK_ENABLE: run callbacks: running callbacks: [verifying registry addon pods : timed out waiting for the condition: timed out waiting for the condition]`

## New behavior

If an addon takes >6 minutes to pull and start, emit error:

`❌ Exiting due to MK_ENABLE: run callbacks: running callbacks: [waiting for kubernetes.io/minikube-addons=registry pods: timed out waiting for the condition: timed out]`

