### PR TITLE
Remove old unused build tags from localkube

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,8 +114,7 @@ MARKDOWNLINT ?= markdownlint
 
 MINIKUBE_MARKDOWN_FILES := README.md CONTRIBUTING.md CHANGELOG.md
 
-MINIKUBE_BUILD_TAGS := container_image_ostree_stub containers_image_openpgp
-MINIKUBE_BUILD_TAGS += go_getter_nos3 go_getter_nogcs
+MINIKUBE_BUILD_TAGS := go_getter_nos3 go_getter_nogcs
 MINIKUBE_INTEGRATION_BUILD_TAGS := integration $(MINIKUBE_BUILD_TAGS)
 
 CMD_SOURCE_DIRS = cmd pkg


### PR DESCRIPTION
These are being used by github.com/containers/image:

* containers_image_ostree_stub
* containers_image_openpgp

It is not used by minikube anymore, since localkube:

* 5e34247db Use containers/image build tags everywhere
* 57aa3e61a Use the build tags for containers/image everywhere

* 55b41415e Cache images for localkube
* 201e5f9ef Vendor changes

Note that the minikube build tag actually had a typo.

Said "container_image" rather than "containers_image".

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
