### PR TITLE
docker: When creating networks, use MTU of built-in bridge network

### DIFF
--- a/pkg/drivers/kic/oci/network.go
+++ b/pkg/drivers/kic/oci/network.go
@@ -35,16 +35,16 @@ import (
 func RoutableHostIPFromInside(ociBin string, clusterName string, containerName string) (net.IP, error) {
 	if ociBin == Docker {
 		if runtime.GOOS == "linux" {
-			_, gateway, _, err := dockerNetworkInspect(clusterName)
+			info, err := dockerNetworkInspect(clusterName)
 			if err != nil {
 				if errors.Is(err, ErrNetworkNotFound) {
 					klog.Infof("The container %s is not attached to a network, this could be because the cluster was created by minikube <v1.14, will try to get the IP using container gatway", containerName)
 
 					return containerGatewayIP(Docker, containerName)
 				}
-				return gateway, errors.Wrap(err, "network inspect")
+				return info.gateway, errors.Wrap(err, "network inspect")
 			}
-			return gateway, nil
+			return info.gateway, nil
 		}
 		// for windows and mac, the gateway ip is not routable so we use dns trick.
 		return digDNS(ociBin, containerName, "host.docker.internal")

--- a/pkg/drivers/kic/oci/network.go
+++ b/pkg/drivers/kic/oci/network.go
@@ -35,7 +35,7 @@ import (
 func RoutableHostIPFromInside(ociBin string, clusterName string, containerName string) (net.IP, error) {
 	if ociBin == Docker {
 		if runtime.GOOS == "linux" {
-			_, gateway, err := dockerNetworkInspect(clusterName)
+			_, gateway, _, err := dockerNetworkInspect(clusterName)
 			if err != nil {
 				if errors.Is(err, ErrNetworkNotFound) {
 					klog.Infof("The container %s is not attached to a network, this could be because the cluster was created by minikube <v1.14, will try to get the IP using container gatway", containerName)

--- a/pkg/drivers/kic/oci/network_create.go
+++ b/pkg/drivers/kic/oci/network_create.go
@@ -85,7 +85,7 @@ func tryCreateDockerNetwork(subnetAddr string, subnetMask int, name string) (net
 	gateway.To4()[3]++ // first ip for gateway
 	klog.Infof("attempt to create network %s/%d with subnet: %s and gateway %s...", subnetAddr, subnetMask, name, gateway)
 	// options documentation https://docs.docker.com/engine/reference/commandline/network_create/#bridge-driver-options
-	rr, err := runCmd(exec.Command(Docker, "network", "create", "--driver=bridge", fmt.Sprintf("--subnet=%s", fmt.Sprintf("%s/%d", subnetAddr, subnetMask)), fmt.Sprintf("--gateway=%s", gateway), "-o", "--ip-masq", "-o", "--icc", fmt.Sprintf("--label=%s=%s", CreatedByLabelKey, "true"), "--mtu=1400", name))
+	rr, err := runCmd(exec.Command(Docker, "network", "create", "--driver=bridge", fmt.Sprintf("--subnet=%s", fmt.Sprintf("%s/%d", subnetAddr, subnetMask)), fmt.Sprintf("--gateway=%s", gateway), "-o", "--ip-masq", "-o", "--mtu=1400", "-o", "--icc", fmt.Sprintf("--label=%s=%s", CreatedByLabelKey, "true"), name))
 	if err != nil {
 		// Pool overlaps with other one on this address space
 		if strings.Contains(rr.Output(), "Pool overlaps") {

--- a/pkg/drivers/kic/oci/network_create.go
+++ b/pkg/drivers/kic/oci/network_create.go
@@ -122,7 +122,7 @@ type netInfo struct {
 // if exists returns subnet, gateway and mtu
 func dockerNetworkInspect(name string) (netInfo, error) {
 	var info = netInfo{name: name}
-	info.mtu = defaultMTU
+	inf.mtu = defaultMTU
 	cmd := exec.Command(Docker, "network", "inspect", name, "--format", `{{(index .IPAM.Config 0).Subnet}},{{(index .IPAM.Config 0).Gateway}},{{(index .Options "com.docker.network.driver.mtu")}}`)
 	rr, err := runCmd(cmd)
 	if err != nil {
@@ -144,7 +144,7 @@ func dockerNetworkInspect(name string) (netInfo, error) {
 		info.gateway = net.ParseIP(vals[1])
 		mtu, err := strconv.Atoi(vals[2])
 		if err != nil {
-			klog.Warningf("failed to parse docker network %s mtu, will use the default %d : %v", name, defaultMTU, err)
+			klog.Warningf("couldn't parse mtu for docker network %q wil use default MTU %s : %v", name, defaultMTU, err)
 		} else {
 			info.mtu = mtu
 		}

--- a/pkg/drivers/kic/oci/network_create.go
+++ b/pkg/drivers/kic/oci/network_create.go
@@ -111,7 +111,7 @@ func tryCreateDockerNetwork(subnetAddr string, subnetMask int, mtu int, name str
 	return gateway, nil
 }
 
-// netInfo holds part of a docker or podman network information relevent to kic drivers
+// netInfo holds part of a docker or podman network information relevant to kic drivers
 type netInfo struct {
 	name    string
 	subnet  *net.IPNet
@@ -123,7 +123,7 @@ type netInfo struct {
 func dockerNetworkInspect(name string) (netInfo, error) {
 	var info = netInfo{name: name}
 	info.mtu = defaultMTU
-	cmd := exec.Command(Docker, "network", "inspect", name, "--format", `{{(index .IPAM.Config 0).Subnet}},{{(index .IPAM.Config 0).Gateway}},(index .Options "com.docker.network.driver.mtu")`)
+	cmd := exec.Command(Docker, "network", "inspect", name, "--format", `{{(index .IPAM.Config 0).Subnet}},{{(index .IPAM.Config 0).Gateway}},{{(index .Options "com.docker.network.driver.mtu")}}`)
 	rr, err := runCmd(cmd)
 	if err != nil {
 		logDockerNetworkInspect(name)

--- a/pkg/drivers/kic/oci/network_create.go
+++ b/pkg/drivers/kic/oci/network_create.go
@@ -125,9 +125,9 @@ func dockerNetworkInspect(name string) (*net.IPNet, net.IP, int, error) {
 	mtu := defaultNetworkMTU
 	if len(vals) > 0 {
 		gateway = net.ParseIP(vals[1])
-		mtu, err := strconv.Atoi(vals[2])
+		mtu, err = strconv.Atoi(vals[2])
 		if err != nil {
-			klog.Warning("failed to parse docker network %s mtu, will use the default %d : %v", name, defaultNetworkMTU, err)
+			klog.Warningf("failed to parse docker network %s mtu, will use the default %d : %v", name, defaultNetworkMTU, err)
 			mtu = defaultNetworkMTU
 		}
 	}

--- a/pkg/drivers/kic/oci/network_create.go
+++ b/pkg/drivers/kic/oci/network_create.go
@@ -37,8 +37,8 @@ const firstSubnetAddr = "192.168.49.0"
 // big enough for a cluster of 254 nodes
 const defaultSubnetMask = 24
 
-// name of the bridge network that docker creates by default to be used to get the MTU. ( related issue #9528)
-const dockerDefaultBridgeName = "bridge"
+// name of the default Docker bridge network, used to lookup the MTU (see #9528)
+const dockerDefaultBridge = "bridge"
 
 // CreateNetwork creates a network returns gateway and error, minikube creates one network per cluster
 func CreateNetwork(ociBin string, name string) (net.IP, error) {
@@ -58,9 +58,9 @@ func createDockerNetwork(clusterName string) (net.IP, error) {
 
 	// will try to get MTU from the docker network to avoid issue with systems with exotic MTU settings.
 	// related issue #9528
-	info, err = dockerNetworkInspect(dockerDefaultBridgeName)
+	info, err = dockerNetworkInspect(dockerDefaultBridge)
 	if err != nil {
-		klog.Warningf("failed to get mtu information from the docker's default network %q: %v", dockerDefaultBridgeName, err)
+		klog.Warningf("failed to get mtu information from the docker's default network %q: %v", dockerDefaultBridge, err)
 	}
 	attempts := 0
 	subnetAddr := firstSubnetAddr
@@ -108,7 +108,7 @@ func tryCreateDockerNetwork(subnetAddr string, subnetMask int, mtu int, name str
 	}
 
 	// adding MTU option because #9528
-	if mtu != 0 {
+	if mtu > 0 {
 		args = append(args, "-o")
 		args = append(args, fmt.Sprintf("com.docker.network.driver.mtu=%d", mtu))
 	}

--- a/pkg/drivers/kic/oci/network_create.go
+++ b/pkg/drivers/kic/oci/network_create.go
@@ -85,7 +85,7 @@ func tryCreateDockerNetwork(subnetAddr string, subnetMask int, name string) (net
 	gateway.To4()[3]++ // first ip for gateway
 	klog.Infof("attempt to create network %s/%d with subnet: %s and gateway %s...", subnetAddr, subnetMask, name, gateway)
 	// options documentation https://docs.docker.com/engine/reference/commandline/network_create/#bridge-driver-options
-	rr, err := runCmd(exec.Command(Docker, "network", "create", "--driver=bridge", fmt.Sprintf("--subnet=%s", fmt.Sprintf("%s/%d", subnetAddr, subnetMask)), fmt.Sprintf("--gateway=%s", gateway), "-o", "--ip-masq", "-o", "--mtu=1400", "-o", "--icc", fmt.Sprintf("--label=%s=%s", CreatedByLabelKey, "true"), name))
+	rr, err := runCmd(exec.Command(Docker, "network", "create", "--driver=bridge", fmt.Sprintf("--subnet=%s", fmt.Sprintf("%s/%d", subnetAddr, subnetMask)), fmt.Sprintf("--gateway=%s", gateway), "-o", "--ip-masq", "-o", "com.docker.network.driver.mtu=1460", "-o", "--icc", fmt.Sprintf("--label=%s=%s", CreatedByLabelKey, "true"), name))
 	if err != nil {
 		// Pool overlaps with other one on this address space
 		if strings.Contains(rr.Output(), "Pool overlaps") {

--- a/pkg/drivers/kic/oci/network_create.go
+++ b/pkg/drivers/kic/oci/network_create.go
@@ -85,7 +85,7 @@ func tryCreateDockerNetwork(subnetAddr string, subnetMask int, name string) (net
 	gateway.To4()[3]++ // first ip for gateway
 	klog.Infof("attempt to create network %s/%d with subnet: %s and gateway %s...", subnetAddr, subnetMask, name, gateway)
 	// options documentation https://docs.docker.com/engine/reference/commandline/network_create/#bridge-driver-options
-	rr, err := runCmd(exec.Command(Docker, "network", "create", "--driver=bridge", fmt.Sprintf("--subnet=%s", fmt.Sprintf("%s/%d", subnetAddr, subnetMask)), fmt.Sprintf("--gateway=%s", gateway), "-o", "--ip-masq", "-o", "--icc", fmt.Sprintf("--label=%s=%s", CreatedByLabelKey, "true"), name))
+	rr, err := runCmd(exec.Command(Docker, "network", "create", "--driver=bridge", fmt.Sprintf("--subnet=%s", fmt.Sprintf("%s/%d", subnetAddr, subnetMask)), fmt.Sprintf("--gateway=%s", gateway), "-o", "--ip-masq", "-o", "--icc", fmt.Sprintf("--label=%s=%s", CreatedByLabelKey, "true"), "--mtu=1400", name))
 	if err != nil {
 		// Pool overlaps with other one on this address space
 		if strings.Contains(rr.Output(), "Pool overlaps") {


### PR DESCRIPTION
closes https://github.com/kubernetes/minikube/issues/9528

### After this PR
```
medya@cloudshell:~$ ./minikube-linux-amd64 ssh
docker@minikube:~$ docker pull golang:1.15
1.15: Pulling from library/golang
e4c3d3e4f7b0: Pull complete
101c41d0463b: Pull complete
8275efcd805f: Pull complete
751620502a7a: Pull complete
aaabf962c4fc: Pull complete
7883babec904: Pull complete
1791d366c848: Pull complete
Digest: sha256:1ba0da74b20aad52b091877b0e0ece503c563f39e37aa6b0e46777c4d820a2ae
Status: Downloaded newer image for golang:1.15
docker.io/library/golang:1.15
docker@minikube:~$ 
docker@minikube:~$
docker@minikube:~$
docker@minikube:~$
docker@minikube:~$ exit
logout
```


```
gout
medya@cloudshell:~$ docker network inspect minikube
[
    {
        "Name": "minikube",
        "Id": "1d1e52f41e1b8a9ca89c3aba16a9d318251199f57a4b8d15769e1d0673685223",
        "Created": "2020-10-23T21:19:26.083577921Z",
        "Scope": "local",
        "Driver": "bridge",
        "EnableIPv6": false,
        "IPAM": {
            "Driver": "default",
            "Options": {},
            "Config": [
                {
                    "Subnet": "192.168.49.0/24",
                    "Gateway": "192.168.49.1"
                }
            ]
        },
        "Internal": false,
        "Attachable": false,
        "Ingress": false,
        "ConfigFrom": {
            "Network": ""
        },
        "ConfigOnly": false,
        "Containers": {
            "8d3585732ce0878bf5c85fabb3be2e0b72ea181baa7fc3f0299c0188c2ff9d1f": {
                "Name": "minikube",
                "EndpointID": "5810c510b63c76af8d8759e92d72624dc008f06b7eadb2f5aadae43b6bfea146",
                "MacAddress": "02:42:c0:a8:31:02",
                "IPv4Address": "192.168.49.2/24",
                "IPv6Address": ""
            }
        },
        "Options": {
            "--icc": "",
            "--ip-masq": "",
            "com.docker.network.driver.mtu": "1460"
        },
        "Labels": {
            "created_by.minikube.sigs.k8s.io": "true"
        }
    }
]
```