### PR TITLE
stop: removed setEventLogPath for stop process

### DIFF
--- a/cmd/minikube/cmd/stop.go
+++ b/cmd/minikube/cmd/stop.go
@@ -65,7 +65,6 @@ func init() {
 // runStop handles the executes the flow of "minikube stop"
 func runStop(cmd *cobra.Command, args []string) {
 	out.SetJSON(outputFormat == "json")
-	register.SetEventLogPath(localpath.EventLog(ClusterFlagValue()))
 	register.Reg.SetStep(register.Stopping)
 
 	// new code

--- a/cmd/minikube/cmd/stop.go
+++ b/cmd/minikube/cmd/stop.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"os"
 	"time"
 
 	"github.com/docker/machine/libmachine"
@@ -66,6 +67,11 @@ func init() {
 func runStop(cmd *cobra.Command, args []string) {
 	out.SetJSON(outputFormat == "json")
 	register.Reg.SetStep(register.Stopping)
+
+	// check if profile path exists, if no PathError log file exists for valid profile
+	if _, err := os.Stat(localpath.Profile(ClusterFlagValue())); err == nil {
+		register.SetEventLogPath(localpath.EventLog(ClusterFlagValue()))
+	}
 
 	// new code
 	var profilesToStop []string


### PR DESCRIPTION
##what##
This PR address code changes that eliminates the profile folder creation if that profile doesn't exist.
Basically it removes the setEventLogPath function which creates a folder for tracking the transient events. In case of stop function, if the profile is valid the file exists in the profile folder. So it's not required to create new one.

Fixes: #9486 