### PR TITLE
Add support for podman v2 to podman-env command

### DIFF
--- a/cmd/minikube/cmd/podman-env.go
+++ b/cmd/minikube/cmd/podman-env.go
@@ -208,34 +208,7 @@ func podmanSetScript(ec PodmanEnvConfig, w io.Writer) error {
 
 // podmanUnsetScript writes out a shell-compatible 'podman-env unset' script
 func podmanUnsetScript(ec PodmanEnvConfig, w io.Writer) error {
-	// podman v1
-	vars1 := []string{
-		constants.PodmanVarlinkBridgeEnv,
-	}
-	// podman v2
-	vars2 := []string{
-		constants.PodmanContainerHostEnv,
-		constants.PodmanContainerSSHKeyEnv,
-	}
-	// common
-	vars0 := []string{
-		constants.MinikubeActivePodmanEnv,
-	}
-
-	var vars []string
-	if ec.client != nil || ec.hostname != "" {
-		// getting ec.varlink needs a running machine
-		if ec.varlink {
-			vars = vars1
-		} else {
-			vars = vars2
-		}
-	} else {
-		// just unset *all* of the variables instead
-		vars = vars1
-		vars = append(vars, vars2...)
-	}
-	vars = append(vars, vars0...)
+	vars := podmanEnvNames(ec)
 	return shell.UnsetScript(ec.EnvConfig, w, vars)
 }
 
@@ -279,6 +252,39 @@ func podmanEnvVars(ec PodmanEnvConfig) map[string]string {
 		env[k] = v
 	}
 	return env
+}
+
+// podmanEnvNames gets the necessary podman env variables to reset after using minikube's podman service
+func podmanEnvNames(ec PodmanEnvConfig) []string {
+	// podman v1
+	vars1 := []string{
+		constants.PodmanVarlinkBridgeEnv,
+	}
+	// podman v2
+	vars2 := []string{
+		constants.PodmanContainerHostEnv,
+		constants.PodmanContainerSSHKeyEnv,
+	}
+	// common
+	vars0 := []string{
+		constants.MinikubeActivePodmanEnv,
+	}
+
+	var vars []string
+	if ec.client != nil || ec.hostname != "" {
+		// getting ec.varlink needs a running machine
+		if ec.varlink {
+			vars = vars1
+		} else {
+			vars = vars2
+		}
+	} else {
+		// just unset *all* of the variables instead
+		vars = vars1
+		vars = append(vars, vars2...)
+	}
+	vars = append(vars, vars0...)
+	return vars
 }
 
 func init() {

--- a/cmd/minikube/cmd/podman-env.go
+++ b/cmd/minikube/cmd/podman-env.go
@@ -39,7 +39,9 @@ import (
 	"k8s.io/minikube/pkg/minikube/shell"
 )
 
-var podmanEnvTmpl = fmt.Sprintf("{{ if .VarlinkBridge }}{{ .Prefix }}%s{{ .Delimiter }}{{ .VarlinkBridge }}{{ .Suffix }}{{end}}{{ if .ContainerHost }}{{ .Prefix }}%s{{ .Delimiter }}{{ .ContainerHost }}{{ .Suffix }}{{end}}{{ if .ContainerSSHKey }}{{ .Prefix }}%s{{ .Delimiter }}{{ .ContainerSSHKey}}{{ .Suffix }}{{ end }}{{ .Prefix }}%s{{ .Delimiter }}{{ .MinikubePodmanProfile }}{{ .Suffix }}{{ .UsageHint }}", constants.PodmanVarlinkBridgeEnv, constants.PodmanContainerHostEnv, constants.PodmanContainerSSHKeyEnv, constants.MinikubeActivePodmanEnv)
+var podmanEnv1Tmpl = fmt.Sprintf("{{ .Prefix }}%s{{ .Delimiter }}{{ .VarlinkBridge }}{{ .Suffix }}{{ .Prefix }}%s{{ .Delimiter }}{{ .MinikubePodmanProfile }}{{ .Suffix }}{{ .UsageHint }}", constants.PodmanVarlinkBridgeEnv, constants.MinikubeActivePodmanEnv)
+
+var podmanEnv2Tmpl = fmt.Sprintf("{{ .Prefix }}%s{{ .Delimiter }}{{ .ContainerHost }}{{ .Suffix }}{{ if .ContainerSSHKey }}{{ .Prefix }}%s{{ .Delimiter }}{{ .ContainerSSHKey}}{{ .Suffix }}{{ end }}{{ .Prefix }}%s{{ .Delimiter }}{{ .MinikubePodmanProfile }}{{ .Suffix }}{{ .UsageHint }}", constants.PodmanContainerHostEnv, constants.PodmanContainerSSHKeyEnv, constants.MinikubeActivePodmanEnv)
 
 // PodmanShellConfig represents the shell config for Podman
 type PodmanShellConfig struct {
@@ -202,6 +204,12 @@ type PodmanEnvConfig struct {
 
 // podmanSetScript writes out a shell-compatible 'podman-env' script
 func podmanSetScript(ec PodmanEnvConfig, w io.Writer) error {
+	var podmanEnvTmpl string
+	if ec.varlink {
+		podmanEnvTmpl = podmanEnv1Tmpl
+	} else {
+		podmanEnvTmpl = podmanEnv2Tmpl
+	}
 	envVars := podmanEnvVars(ec)
 	return shell.SetScript(ec.EnvConfig, w, podmanEnvTmpl, podmanShellCfgSet(ec, envVars))
 }

--- a/cmd/minikube/cmd/podman-env_test.go
+++ b/cmd/minikube/cmd/podman-env_test.go
@@ -41,7 +41,7 @@ func TestGeneratePodmanScripts(t *testing.T) {
 	}{
 		{
 			"bash",
-			PodmanEnvConfig{profile: "bash", driver: "kvm2", client: newFakeClient()},
+			PodmanEnvConfig{profile: "bash", driver: "kvm2", varlink: true, client: newFakeClient()},
 			nil,
 			`export PODMAN_VARLINK_BRIDGE="/usr/bin/ssh root@host -- sudo varlink -A \'podman varlink \\\$VARLINK_ADDRESS\' bridge"
 export MINIKUBE_ACTIVE_PODMAN="bash"
@@ -50,6 +50,19 @@ export MINIKUBE_ACTIVE_PODMAN="bash"
 # eval $(minikube -p bash podman-env)
 `,
 			`unset PODMAN_VARLINK_BRIDGE MINIKUBE_ACTIVE_PODMAN
+`,
+		},
+		{
+			"bash",
+			PodmanEnvConfig{profile: "bash", driver: "kvm2", client: newFakeClient(), username: "root", hostname: "host", port: 22},
+			nil,
+			`export CONTAINER_HOST="ssh://root@host:22/run/podman/podman.sock"
+export MINIKUBE_ACTIVE_PODMAN="bash"
+
+# To point your shell to minikube's podman service, run:
+# eval $(minikube -p bash podman-env)
+`,
+			`unset CONTAINER_HOST CONTAINER_SSHKEY MINIKUBE_ACTIVE_PODMAN
 `,
 		},
 	}

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -68,6 +68,10 @@ const (
 	MinikubeActiveDockerdEnv = "MINIKUBE_ACTIVE_DOCKERD"
 	// PodmanVarlinkBridgeEnv is used for podman settings
 	PodmanVarlinkBridgeEnv = "PODMAN_VARLINK_BRIDGE"
+	// PodmanContainerHostEnv is used for podman settings
+	PodmanContainerHostEnv = "CONTAINER_HOST"
+	// PodmanContainerSSHKeyEnv is used for podman settings
+	PodmanContainerSSHKeyEnv = "CONTAINER_SSHKEY"
 	// MinikubeActivePodmanEnv holds the podman service that the user's shell is pointing at
 	// value would be profile or empty if pointing to the user's host.
 	MinikubeActivePodmanEnv = "MINIKUBE_ACTIVE_PODMAN"


### PR DESCRIPTION
Podman v1 (like 1.9.3) uses the varlink bridge,
while podman v2 (like 2.1.x) uses a REST API.

Both are using ssh for their transport, but the
environment variables exported are different.


Not using `sudo` anymore, so user needs root access.

See #8596 for how to set that up for the "docker" user

Tested OK with 1.9.3 and 2.1.1 minikube profiles.

But don't recommend using podman 2.0.x (at all)