### PR TITLE
Add docker.io repo prefix to the dashboard images

### DIFF
--- a/pkg/minikube/bootstrapper/images/images.go
+++ b/pkg/minikube/bootstrapper/images/images.go
@@ -145,7 +145,7 @@ func storageProvisioner(mirror string) string {
 // dashboardFrontend returns the image used for the dashboard frontend
 func dashboardFrontend(repo string) string {
 	if repo == "" {
-		repo = "kubernetesui"
+		repo = "docker.io/kubernetesui"
 	}
 	// See 'kubernetes-dashboard' in deploy/addons/dashboard/dashboard-dp.yaml
 	return path.Join(repo, "dashboard:v2.0.3")
@@ -154,7 +154,7 @@ func dashboardFrontend(repo string) string {
 // dashboardMetrics returns the image used for the dashboard metrics scraper
 func dashboardMetrics(repo string) string {
 	if repo == "" {
-		repo = "kubernetesui"
+		repo = "docker.io/kubernetesui"
 	}
 	// See 'dashboard-metrics-scraper' in deploy/addons/dashboard/dashboard-dp.yaml
 	return path.Join(repo, "metrics-scraper:v1.0.4")

--- a/pkg/minikube/bootstrapper/images/images_test.go
+++ b/pkg/minikube/bootstrapper/images/images_test.go
@@ -25,8 +25,8 @@ import (
 func TestAuxiliary(t *testing.T) {
 	want := []string{
 		"gcr.io/k8s-minikube/storage-provisioner:v3",
-		"kubernetesui/dashboard:v2.0.3",
-		"kubernetesui/metrics-scraper:v1.0.4",
+		"docker.io/kubernetesui/dashboard:v2.0.3",
+		"docker.io/kubernetesui/metrics-scraper:v1.0.4",
 	}
 	got := auxiliary("")
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/pkg/minikube/bootstrapper/images/kubeadm_test.go
+++ b/pkg/minikube/bootstrapper/images/kubeadm_test.go
@@ -38,8 +38,8 @@ func TestKubeadmImages(t *testing.T) {
 			"k8s.gcr.io/etcd:3.4.3-0",
 			"k8s.gcr.io/pause:3.1",
 			"gcr.io/k8s-minikube/storage-provisioner:v3",
-			"kubernetesui/dashboard:v2.0.3",
-			"kubernetesui/metrics-scraper:v1.0.4",
+			"docker.io/kubernetesui/dashboard:v2.0.3",
+			"docker.io/kubernetesui/metrics-scraper:v1.0.4",
 		}},
 		{"v1.16.1", "mirror.k8s.io", []string{
 			"mirror.k8s.io/kube-proxy:v1.16.1",
@@ -62,8 +62,8 @@ func TestKubeadmImages(t *testing.T) {
 			"k8s.gcr.io/etcd:3.3.10",
 			"k8s.gcr.io/pause:3.1",
 			"gcr.io/k8s-minikube/storage-provisioner:v3",
-			"kubernetesui/dashboard:v2.0.3",
-			"kubernetesui/metrics-scraper:v1.0.4",
+			"docker.io/kubernetesui/dashboard:v2.0.3",
+			"docker.io/kubernetesui/metrics-scraper:v1.0.4",
 		}},
 		{"v1.14.0", "", []string{
 			"k8s.gcr.io/kube-proxy:v1.14.0",
@@ -74,8 +74,8 @@ func TestKubeadmImages(t *testing.T) {
 			"k8s.gcr.io/etcd:3.3.10",
 			"k8s.gcr.io/pause:3.1",
 			"gcr.io/k8s-minikube/storage-provisioner:v3",
-			"kubernetesui/dashboard:v2.0.3",
-			"kubernetesui/metrics-scraper:v1.0.4",
+			"docker.io/kubernetesui/dashboard:v2.0.3",
+			"docker.io/kubernetesui/metrics-scraper:v1.0.4",
 		}},
 		{"v1.13.0", "", []string{
 			"k8s.gcr.io/kube-proxy:v1.13.0",
@@ -86,8 +86,8 @@ func TestKubeadmImages(t *testing.T) {
 			"k8s.gcr.io/etcd:3.2.24",
 			"k8s.gcr.io/pause:3.1",
 			"gcr.io/k8s-minikube/storage-provisioner:v3",
-			"kubernetesui/dashboard:v2.0.3",
-			"kubernetesui/metrics-scraper:v1.0.4",
+			"docker.io/kubernetesui/dashboard:v2.0.3",
+			"docker.io/kubernetesui/metrics-scraper:v1.0.4",
 		}},
 		{"v1.12.0", "", []string{
 			"k8s.gcr.io/kube-proxy:v1.12.0",
@@ -98,8 +98,8 @@ func TestKubeadmImages(t *testing.T) {
 			"k8s.gcr.io/etcd:3.2.24",
 			"k8s.gcr.io/pause:3.1",
 			"gcr.io/k8s-minikube/storage-provisioner:v3",
-			"kubernetesui/dashboard:v2.0.3",
-			"kubernetesui/metrics-scraper:v1.0.4",
+			"docker.io/kubernetesui/dashboard:v2.0.3",
+			"docker.io/kubernetesui/metrics-scraper:v1.0.4",
 		}},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
Other CRI might have other registries as default

So explicitly show that they are from Docker Hub

Closes #9131

Closes #8554
