### PR TITLE
add ImageRepository to addons templates

### DIFF
--- a/deploy/addons/dashboard/dashboard-dp.yaml.tmpl
+++ b/deploy/addons/dashboard/dashboard-dp.yaml.tmpl
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
         - name: dashboard-metrics-scraper
-          image: kubernetesui/metrics-scraper:v1.0.4
+          image: {{default "kubernetesui" .ImageRepository}}/metrics-scraper:v1.0.4
           ports:
             - containerPort: 8000
               protocol: TCP
@@ -91,7 +91,7 @@ spec:
       containers:
         - name: kubernetes-dashboard
           # WARNING: This must match pkg/minikube/bootstrapper/images/images.go
-          image: kubernetesui/dashboard:v2.0.3
+          image: {{default "kubernetesui" .ImageRepository}}/dashboard:v2.0.3
           ports:
             - containerPort: 9090
               protocol: TCP

--- a/deploy/addons/efk/elasticsearch-rc.yaml.tmpl
+++ b/deploy/addons/efk/elasticsearch-rc.yaml.tmpl
@@ -62,7 +62,7 @@ spec:
         - name: ES_JAVA_OPTS
           value: "-Xms1024m -Xmx1024m"
       initContainers:
-      - image: registry.hub.docker.com/library/alpine:3.6
+      - image: {{default "registry.hub.docker.com/library" .ImageRepository}}/alpine:3.6
         command: ["/sbin/sysctl", "-w", "vm.max_map_count=262144"]
         name: elasticsearch-logging-init
         securityContext:

--- a/deploy/addons/efk/kibana-rc.yaml.tmpl
+++ b/deploy/addons/efk/kibana-rc.yaml.tmpl
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: kibana-logging
-        image: docker.elastic.co/kibana/kibana:5.6.2
+        image: {{default "docker.elastic.co/kibana" .ImageRepository}}/kibana:5.6.2
         resources:
           limits:
             cpu: 500m

--- a/deploy/addons/gcp-auth/gcp-auth-webhook.yaml.tmpl
+++ b/deploy/addons/gcp-auth/gcp-auth-webhook.yaml.tmpl
@@ -54,7 +54,7 @@ spec:
       serviceAccountName: minikube-gcp-auth-certs
       containers:
         - name: create
-          image: jettech/kube-webhook-certgen:v1.3.0
+          image: {{default "jettech" .ImageRepository}}/kube-webhook-certgen:v1.3.0
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -80,7 +80,7 @@ spec:
     spec:
       containers:
         - name: gcp-auth
-          image: gcr.io/k8s-minikube/gcp-auth-webhook:v0.0.3
+          image: {{default "gcr.io/k8s-minikube" .ImageRepository}}/gcp-auth-webhook:v0.0.3
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
@@ -113,7 +113,7 @@ spec:
       serviceAccountName: minikube-gcp-auth-certs
       containers:
         - name: patch
-          image: jettech/kube-webhook-certgen:v1.3.0
+          image: {{default "jettech" .ImageRepository}}/kube-webhook-certgen:v1.3.0
           imagePullPolicy: IfNotPresent
           args:
             - patch

--- a/deploy/addons/gpu/nvidia-driver-installer.yaml.tmpl
+++ b/deploy/addons/gpu/nvidia-driver-installer.yaml.tmpl
@@ -50,7 +50,7 @@ spec:
         hostPath:
           path: /
       initContainers:
-      - image: {{default "k8s.gcr.io" .ImageRepository}}/minikube-nvidia-driver-installer@sha256:492d46f2bc768d6610ec5940b6c3c33c75e03e201cc8786e04cc488659fd6342
+      - image: {{default "k8s.gcr.io" .ImageRepository}}/minikube-nvidia-driver-installer
         name: nvidia-driver-installer
         resources:
           requests:

--- a/deploy/addons/gpu/nvidia-gpu-device-plugin.yaml.tmpl
+++ b/deploy/addons/gpu/nvidia-gpu-device-plugin.yaml.tmpl
@@ -43,7 +43,7 @@ spec:
         hostPath:
           path: /var/lib/kubelet/device-plugins
       containers:
-      - image: "nvidia/k8s-device-plugin:1.0.0-beta4"
+      - image: {{default "nvidia" .ImageRepository}}/k8s-device-plugin:1.0.0-beta4
         command: ["/usr/bin/nvidia-device-plugin", "-logtostderr"]
         name: nvidia-gpu-device-plugin
         resources:

--- a/deploy/addons/helm-tiller/helm-tiller-dp.tmpl
+++ b/deploy/addons/helm-tiller/helm-tiller-dp.tmpl
@@ -46,7 +46,7 @@ spec:
               value: kube-system
             - name: TILLER_HISTORY_MAX
               value: "0"
-          image: gcr.io/kubernetes-helm/tiller:v2.16.12
+          image: {{default "gcr.io/kubernetes-helm" .ImageRepository}}/tiller:v2.16.12
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3

--- a/deploy/addons/ingress-dns/ingress-dns-pod.yaml.tmpl
+++ b/deploy/addons/ingress-dns/ingress-dns-pod.yaml.tmpl
@@ -80,7 +80,7 @@ spec:
   hostNetwork: true
   containers:
     - name: minikube-ingress-dns
-      image: "cryptexlabs/minikube-ingress-dns:0.3.0"
+      image: {{default "cryptexlabs" .ImageRepository}}/minikube-ingress-dns:0.3.0
       imagePullPolicy: IfNotPresent
       ports:
         - containerPort: 53

--- a/deploy/addons/ingress/ingress-dp.yaml.tmpl
+++ b/deploy/addons/ingress/ingress-dp.yaml.tmpl
@@ -49,7 +49,7 @@ spec:
       serviceAccountName: ingress-nginx
       containers:
         - name: controller
-          image: k8s.gcr.io/ingress-nginx/controller:v0.40.2@sha256:46ba23c3fbaafd9e5bd01ea85b2f921d9f2217be082580edc22e6c704a83f02f
+          image: {{default "us.gcr.io/k8s-artifacts-prod/ingress-nginx" .ImageRepository}}/controller:v0.40.2
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:
@@ -217,7 +217,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: jettech/kube-webhook-certgen:v1.2.2
+          image: {{default "jettech" .ImageRepository}}/kube-webhook-certgen:v1.2.2
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -252,7 +252,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: docker.io/jettech/kube-webhook-certgen:v1.3.0
+          image: {{default "jettech" .ImageRepository}}/kube-webhook-certgen:v1.3.0
           imagePullPolicy:
           args:
             - patch

--- a/deploy/addons/logviewer/logviewer-dp-and-svc.yaml.tmpl
+++ b/deploy/addons/logviewer/logviewer-dp-and-svc.yaml.tmpl
@@ -42,7 +42,7 @@ spec:
       containers:
       - name: logviewer
         imagePullPolicy: Always
-        image: docker.io/ivans3/minikube-log-viewer:latest
+        image: {{default "docker.io/ivans3" .ImageRepository}}/minikube-log-viewer:latest
         volumeMounts:
          - name: logs
            mountPath: /var/log/containers/

--- a/deploy/addons/metallb/metallb.yaml.tmpl
+++ b/deploy/addons/metallb/metallb.yaml.tmpl
@@ -212,7 +212,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: metallb/speaker:v0.8.2
+        image: {{default "metallb" .ImageRepository}}/speaker:v0.8.2
         imagePullPolicy: IfNotPresent
         name: speaker
         ports:
@@ -268,7 +268,7 @@ spec:
       - args:
         - --port=7472
         - --config=config
-        image: metallb/controller:v0.8.2
+        image: {{default "metallb" .ImageRepository}}/controller:v0.8.2
         imagePullPolicy: IfNotPresent
         name: controller
         ports:

--- a/deploy/addons/registry-aliases/node-etc-hosts-update.tmpl
+++ b/deploy/addons/registry-aliases/node-etc-hosts-update.tmpl
@@ -17,7 +17,7 @@ spec:
     spec:
       initContainers:
         - name: update
-          image: alpine:3.11
+          image: {{default "registry.hub.docker.com/library" .ImageRepository}}/alpine:3.11
           volumeMounts:
             - name: etchosts
               mountPath: /host-etc/hosts
@@ -43,7 +43,7 @@ spec:
               echo "Done."
       containers:
         - name: pause-for-update
-          image: gcr.io/google_containers/pause-amd64:3.1
+          image: {{default "gcr.io/google_containers" .ImageRepository}}/pause-amd64:3.1
       terminationGracePeriodSeconds: 30
       volumes:
         - name: etchosts

--- a/deploy/addons/registry-aliases/patch-coredns-job.tmpl
+++ b/deploy/addons/registry-aliases/patch-coredns-job.tmpl
@@ -15,7 +15,7 @@ spec:
            path: /var/lib/minikube/binaries
       containers:
        - name: core-dns-patcher
-         image:  quay.io/rhdevelopers/core-dns-patcher
+         image:  {{default "quay.io/rhdevelopers" .ImageRepository}}/core-dns-patcher
          imagePullPolicy: IfNotPresent
          # using the kubectl from the minikube instance
          volumeMounts:

--- a/deploy/addons/registry-aliases/registry-aliases-config.tmpl
+++ b/deploy/addons/registry-aliases/registry-aliases-config.tmpl
@@ -13,6 +13,7 @@ data:
     example.com
     test.com
     test.org
+    registry.minikube
   # default registry address in minikube when enabled via minikube addons enable registry
   registrySvc: registry.kube-system.svc.cluster.local
 

--- a/deploy/addons/registry-creds/registry-creds-rc.yaml.tmpl
+++ b/deploy/addons/registry-creds/registry-creds-rc.yaml.tmpl
@@ -18,7 +18,7 @@ spec:
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:
-      - image: upmcenterprises/registry-creds:1.10
+      - image: {{default "upmcenterprises" .ImageRepository}}/registry-creds:1.10
         name: registry-creds
         imagePullPolicy: Always
         env:

--- a/deploy/addons/registry/registry-proxy.yaml.tmpl
+++ b/deploy/addons/registry/registry-proxy.yaml.tmpl
@@ -19,7 +19,7 @@ spec:
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:
-      - image: gcr.io/google_containers/kube-registry-proxy:0.4
+      - image: {{default "gcr.io/google_containers" .ImageRepository}}/kube-registry-proxy:0.4
         imagePullPolicy: IfNotPresent
         name: registry-proxy
         ports:

--- a/deploy/addons/registry/registry-rc.yaml.tmpl
+++ b/deploy/addons/registry/registry-rc.yaml.tmpl
@@ -18,7 +18,7 @@ spec:
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:
-      - image: registry.hub.docker.com/library/registry:2.7.1
+      - image: {{default "registry.hub.docker.com/library" .ImageRepository}}/registry:2.7.1
         imagePullPolicy: IfNotPresent
         name: registry
         ports:

--- a/deploy/addons/storage-provisioner-gluster/glusterfs-daemonset.yaml.tmpl
+++ b/deploy/addons/storage-provisioner-gluster/glusterfs-daemonset.yaml.tmpl
@@ -31,7 +31,7 @@ spec:
       #  kubernetes.io/hostname: minikube
       hostNetwork: true
       containers:
-      - image: quay.io/nixpanic/glusterfs-server:pr_fake-disk
+      - image: {{default "quay.io/nixpanic" .ImageRepository}}/glusterfs-server:pr_fake-disk
         imagePullPolicy: IfNotPresent
         name: glusterfs
         env:

--- a/deploy/addons/storage-provisioner-gluster/heketi-deployment.yaml.tmpl
+++ b/deploy/addons/storage-provisioner-gluster/heketi-deployment.yaml.tmpl
@@ -116,7 +116,7 @@ spec:
     spec:
       serviceAccountName: heketi-service-account
       containers:
-      - image: heketi/heketi:latest
+      - image: {{default "heketi" .ImageRepository}}/heketi:latest
         imagePullPolicy: IfNotPresent
         name: heketi
         env:

--- a/deploy/addons/volumesnapshots/volume-snapshot-controller-deployment.yaml.tmpl
+++ b/deploy/addons/volumesnapshots/volume-snapshot-controller-deployment.yaml.tmpl
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: volume-snapshot-controller
           # TODO(xyang): Replace with an official image when it is released
-          image: gcr.io/k8s-staging-csi/snapshot-controller:v2.0.0-rc2
+          image: {{default "gcr.io/k8s-staging-csi" .ImageRepository}}/snapshot-controller:v2.0.0-rc2
           args:
             - "--v=5"
           imagePullPolicy: Always

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -67,7 +67,7 @@ var Addons = map[string]*Addon{
 		MustBinAsset("deploy/addons/dashboard/dashboard-clusterrole.yaml", vmpath.GuestAddonsDir, "dashboard-clusterrole.yaml", "0640", false),
 		MustBinAsset("deploy/addons/dashboard/dashboard-clusterrolebinding.yaml", vmpath.GuestAddonsDir, "dashboard-clusterrolebinding.yaml", "0640", false),
 		MustBinAsset("deploy/addons/dashboard/dashboard-configmap.yaml", vmpath.GuestAddonsDir, "dashboard-configmap.yaml", "0640", false),
-		MustBinAsset("deploy/addons/dashboard/dashboard-dp.yaml", vmpath.GuestAddonsDir, "dashboard-dp.yaml", "0640", false),
+		MustBinAsset("deploy/addons/dashboard/dashboard-dp.yaml.tmpl", vmpath.GuestAddonsDir, "dashboard-dp.yaml", "0640", true),
 		MustBinAsset("deploy/addons/dashboard/dashboard-role.yaml", vmpath.GuestAddonsDir, "dashboard-role.yaml", "0640", false),
 		MustBinAsset("deploy/addons/dashboard/dashboard-rolebinding.yaml", vmpath.GuestAddonsDir, "dashboard-rolebinding.yaml", "0640", false),
 		MustBinAsset("deploy/addons/dashboard/dashboard-sa.yaml", vmpath.GuestAddonsDir, "dashboard-sa.yaml", "0640", false),
@@ -110,13 +110,13 @@ var Addons = map[string]*Addon{
 			vmpath.GuestAddonsDir,
 			"glusterfs-daemonset.yaml",
 			"0640",
-			false),
+			true),
 		MustBinAsset(
 			"deploy/addons/storage-provisioner-gluster/heketi-deployment.yaml.tmpl",
 			vmpath.GuestAddonsDir,
 			"heketi-deployment.yaml",
 			"0640",
-			false),
+			true),
 		MustBinAsset(
 			"deploy/addons/storage-provisioner-gluster/storage-provisioner-glusterfile.yaml.tmpl",
 			vmpath.GuestAddonsDir,
@@ -154,7 +154,7 @@ var Addons = map[string]*Addon{
 			vmpath.GuestAddonsDir,
 			"kibana-rc.yaml",
 			"0640",
-			false),
+			true),
 		MustBinAsset(
 			"deploy/addons/efk/kibana-svc.yaml.tmpl",
 			vmpath.GuestAddonsDir,
@@ -246,7 +246,7 @@ var Addons = map[string]*Addon{
 			vmpath.GuestAddonsDir,
 			"registry-rc.yaml",
 			"0640",
-			false),
+			true),
 		MustBinAsset(
 			"deploy/addons/registry/registry-svc.yaml.tmpl",
 			vmpath.GuestAddonsDir,
@@ -258,7 +258,7 @@ var Addons = map[string]*Addon{
 			vmpath.GuestAddonsDir,
 			"registry-proxy.yaml",
 			"0640",
-			false),
+			true),
 	}, false, "registry"),
 	"registry-creds": NewAddon([]*BinAsset{
 		MustBinAsset(
@@ -292,13 +292,13 @@ var Addons = map[string]*Addon{
 			vmpath.GuestAddonsDir,
 			"node-etc-hosts-update.yaml",
 			"0640",
-			false),
+			true),
 		MustBinAsset(
 			"deploy/addons/registry-aliases/patch-coredns-job.tmpl",
 			vmpath.GuestAddonsDir,
 			"patch-coredns-job.yaml",
 			"0640",
-			false),
+			true),
 	}, false, "registry-aliases"),
 	"freshpod": NewAddon([]*BinAsset{
 		MustBinAsset(
@@ -318,11 +318,11 @@ var Addons = map[string]*Addon{
 	}, false, "nvidia-driver-installer"),
 	"nvidia-gpu-device-plugin": NewAddon([]*BinAsset{
 		MustBinAsset(
-			"deploy/addons/gpu/nvidia-gpu-device-plugin.yaml",
+			"deploy/addons/gpu/nvidia-gpu-device-plugin.yaml.tmpl",
 			vmpath.GuestAddonsDir,
 			"nvidia-gpu-device-plugin.yaml",
 			"0640",
-			false),
+			true),
 	}, false, "nvidia-gpu-device-plugin"),
 	"logviewer": NewAddon([]*BinAsset{
 		MustBinAsset(
@@ -380,19 +380,19 @@ var Addons = map[string]*Addon{
 	}, false, "helm-tiller"),
 	"ingress-dns": NewAddon([]*BinAsset{
 		MustBinAsset(
-			"deploy/addons/ingress-dns/ingress-dns-pod.yaml",
+			"deploy/addons/ingress-dns/ingress-dns-pod.yaml.tmpl",
 			vmpath.GuestAddonsDir,
 			"ingress-dns-pod.yaml",
 			"0640",
-			false),
+			true),
 	}, false, "ingress-dns"),
 	"metallb": NewAddon([]*BinAsset{
 		MustBinAsset(
-			"deploy/addons/metallb/metallb.yaml",
+			"deploy/addons/metallb/metallb.yaml.tmpl",
 			vmpath.GuestAddonsDir,
 			"metallb.yaml",
 			"0640",
-			false),
+			true),
 		MustBinAsset(
 			"deploy/addons/metallb/metallb-config.yaml.tmpl",
 			vmpath.GuestAddonsDir,
@@ -434,11 +434,11 @@ var Addons = map[string]*Addon{
 			"0640",
 			false),
 		MustBinAsset(
-			"deploy/addons/gcp-auth/gcp-auth-webhook.yaml",
+			"deploy/addons/gcp-auth/gcp-auth-webhook.yaml.tmpl",
 			vmpath.GuestAddonsDir,
 			"gcp-auth-webhook.yaml",
 			"0640",
-			false),
+			true),
 	}, false, "gcp-auth"),
 	"volumesnapshots": NewAddon([]*BinAsset{
 		MustBinAsset(
@@ -466,11 +466,11 @@ var Addons = map[string]*Addon{
 			"0640",
 			false),
 		MustBinAsset(
-			"deploy/addons/volumesnapshots/volume-snapshot-controller-deployment.yaml",
+			"deploy/addons/volumesnapshots/volume-snapshot-controller-deployment.yaml.tmpl",
 			vmpath.GuestAddonsDir,
 			"volume-snapshot-controller-deployment.yaml",
 			"0640",
-			false),
+			true),
 	}, false, "volumesnapshots"),
 	"csi-hostpath-driver": NewAddon([]*BinAsset{
 		MustBinAsset(


### PR DESCRIPTION
fixes #8298 

minikube start has a flag `--image-repository` that can be used to specify a private docker registry for pulling minikube images.
The imageRepository is used for some of the built in addons, but not for all of them.

For example, the ingress addon doesn't currently use the imageRepository

**Before:**
```
minikube start --image-repository some.docker.registry --addons ingress
kubectl get deploy -n kube-system ingress-nginx-controller -o jsonpath='{.spec.template.spec.containers[0].image}'
```
image is `us.gcr.io/k8s-artifacts-prod/ingress-nginx/controller:v0.34.1@sha256...`

**After:**
```
minikube start --image-repository some.docker.registry --addons ingress
kubectl get deploy -n kube-system ingress-nginx-controller -o jsonpath='{.spec.template.spec.containers[0].image}'
```
image is `some.docker.registry/controller:v0.34.1`


 