### PR TITLE
fix "profile list" timing out when cluster stopped.

### DIFF
--- a/cmd/minikube/cmd/config/profile_list.go
+++ b/cmd/minikube/cmd/config/profile_list.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/style"
 
 	"github.com/docker/machine/libmachine"
+	"github.com/docker/machine/libmachine/state"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 
@@ -95,6 +96,16 @@ func profileStatus(p *config.Profile, api libmachine.API) string {
 	if err != nil {
 		klog.Warningf("error loading profiles: %v", err)
 		return "Unknown"
+	}
+
+	// The machine isn't running, no need to check inside
+	s, err := host.Driver.GetState()
+	if err != nil {
+		klog.Warningf("error getting host state: %v", err)
+		return "Unknown"
+	}
+	if s != state.Running {
+		return s.String()
 	}
 
 	cr, err := machine.CommandRunner(host)

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/libvirt/libvirt-go v3.4.0+incompatible
 	github.com/machine-drivers/docker-machine-driver-vmware v0.1.1
+	github.com/machine-drivers/machine v0.16.2 // indirect
 	github.com/mattn/go-isatty v0.0.12
 	github.com/mitchellh/go-ps v0.0.0-20190716172923-621e5597135b
 	github.com/moby/hyperkit v0.0.0-20171020124204-a12cd7250bcd

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,6 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/libvirt/libvirt-go v3.4.0+incompatible
 	github.com/machine-drivers/docker-machine-driver-vmware v0.1.1
-	github.com/machine-drivers/machine v0.16.2 // indirect
 	github.com/mattn/go-isatty v0.0.12
 	github.com/mitchellh/go-ps v0.0.0-20190716172923-621e5597135b
 	github.com/moby/hyperkit v0.0.0-20171020124204-a12cd7250bcd

--- a/go.sum
+++ b/go.sum
@@ -597,7 +597,6 @@ github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6K
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
-github.com/hashicorp/go-getter v1.4.2/go.mod h1:3Ao9Hol5VJsmwJV5BF1GUrONbaOUmA+m1Nj2+0LuMAY=
 github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -755,8 +754,6 @@ github.com/machine-drivers/docker-machine-driver-vmware v0.1.1 h1:+E1IKKk+6kaQrC
 github.com/machine-drivers/docker-machine-driver-vmware v0.1.1/go.mod h1:ej014C83EmSnxJeJ8PtVb8OLJ91PJKO1Q8Y7sM5CK0o=
 github.com/machine-drivers/machine v0.7.1-0.20200810185219-7d42fed1b770 h1:jc5SzpD28ZqDb+PoA4FxOwkl+slv593qJjrMVM35JFQ=
 github.com/machine-drivers/machine v0.7.1-0.20200810185219-7d42fed1b770/go.mod h1:79Uwa2hGd5S39LDJt58s8JZcIhGEK6pkq9bsuTbFWbk=
-github.com/machine-drivers/machine v0.16.2 h1:v7+AQ3SdVC5TytHfEf/ivCJbyaxIj+MxNFXFPvqFdc8=
-github.com/machine-drivers/machine v0.16.2/go.mod h1:79Uwa2hGd5S39LDJt58s8JZcIhGEK6pkq9bsuTbFWbk=
 github.com/magiconair/properties v1.7.6/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/go.sum
+++ b/go.sum
@@ -755,6 +755,8 @@ github.com/machine-drivers/docker-machine-driver-vmware v0.1.1 h1:+E1IKKk+6kaQrC
 github.com/machine-drivers/docker-machine-driver-vmware v0.1.1/go.mod h1:ej014C83EmSnxJeJ8PtVb8OLJ91PJKO1Q8Y7sM5CK0o=
 github.com/machine-drivers/machine v0.7.1-0.20200810185219-7d42fed1b770 h1:jc5SzpD28ZqDb+PoA4FxOwkl+slv593qJjrMVM35JFQ=
 github.com/machine-drivers/machine v0.7.1-0.20200810185219-7d42fed1b770/go.mod h1:79Uwa2hGd5S39LDJt58s8JZcIhGEK6pkq9bsuTbFWbk=
+github.com/machine-drivers/machine v0.16.2 h1:v7+AQ3SdVC5TytHfEf/ivCJbyaxIj+MxNFXFPvqFdc8=
+github.com/machine-drivers/machine v0.16.2/go.mod h1:79Uwa2hGd5S39LDJt58s8JZcIhGEK6pkq9bsuTbFWbk=
 github.com/magiconair/properties v1.7.6/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/pkg/minikube/config/profile.go
+++ b/pkg/minikube/config/profile.go
@@ -204,7 +204,7 @@ func ListProfiles(miniHome ...string) (validPs []*Profile, inValidPs []*Profile,
 	if err != nil {
 		return nil, nil, err
 	}
-	// try to get profiles list based on all contrainers created by docker driver
+	// try to get profiles list based on all containers created by docker driver
 	cs, err := oci.ListOwnedContainers(oci.Docker)
 	if err == nil {
 		pDirs = append(pDirs, cs...)

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -26,7 +26,7 @@ import (
 // Profile represents a minikube profile
 type Profile struct {
 	Name   string
-	Status string // running, stopped
+	Status string // running, stopped, paused, unknown
 	Config *ClusterConfig
 }
 


### PR DESCRIPTION
Fixes #9553 

We were trying to ssh into a stopped VM which was causing `minikube profile list` to take over a minute per stopped profile instead of the usual 200 milliseconds