### PR TITLE
Fix failing TestJSONOutput/start test

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -464,7 +464,7 @@ func showKubectlInfo(kcs *kubeconfig.Settings, k8sVersion string, machineName st
 		out.Ln("")
 		out.WarningT("{{.path}} is version {{.client_version}}, which may have incompatibilites with Kubernetes {{.cluster_version}}.",
 			out.V{"path": path, "client_version": client, "cluster_version": cluster})
-		out.T(style.Tip, "Want kubectl {{.version}}? Try 'minikube kubectl -- get pods -A'", out.V{"version": k8sVersion})
+		out.Infof("Want kubectl {{.version}}? Try 'minikube kubectl -- get pods -A'", out.V{"version": k8sVersion})
 	}
 	return nil
 }

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -117,6 +117,7 @@ func beginDownloadKicBaseImage(g *errgroup.Group, cc *config.ClusterConfig, down
 	}
 
 	klog.Infof("Beginning downloading kic base image for %s with %s", cc.Driver, cc.KubernetesConfig.ContainerRuntime)
+	register.Reg.SetStep(register.PullingBaseImage)
 	out.T(style.Pulling, "Pulling base image ...")
 	g.Go(func() error {
 		baseImg := cc.KicBaseImage

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/minikube/machine"
 	"k8s.io/minikube/pkg/minikube/out"
+	"k8s.io/minikube/pkg/minikube/out/register"
 	"k8s.io/minikube/pkg/minikube/reason"
 	"k8s.io/minikube/pkg/minikube/style"
 )

--- a/pkg/minikube/out/register/register.go
+++ b/pkg/minikube/out/register/register.go
@@ -28,6 +28,7 @@ const (
 	SelectingDriver      RegStep = "Selecting Driver"
 	DownloadingArtifacts RegStep = "Downloading Artifacts"
 	StartingNode         RegStep = "Starting Node"
+	PullingBaseImage     RegStep = "Pulling Base Image"
 	RunningLocalhost     RegStep = "Running on Localhost"
 	LocalOSRelease       RegStep = "Local OS Release"
 	CreatingContainer    RegStep = "Creating Container"


### PR DESCRIPTION
Should fix https://github.com/kubernetes/minikube/issues/9620


This test is likely failing because we don't have a separate step for pulling base image.

I also changed `out.T` to `out.Infof` for the suggestion to upgrade kubectl, which was failing locally for me and makes more sense since this is an informational message rather than a distinct step in the minikube process.