### PR TITLE
Update generate-docs test to include --help flag

### DIFF
--- a/cmd/minikube/cmd/generate-docs_test.go
+++ b/cmd/minikube/cmd/generate-docs_test.go
@@ -23,10 +23,12 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/spf13/pflag"
 	"k8s.io/minikube/pkg/generate"
 )
 
 func TestGenerateDocs(t *testing.T) {
+	pflag.BoolP("help", "h", false, "")
 	dir := "../../../site/content/en/docs/commands/"
 
 	for _, sc := range RootCmd.Commands() {

--- a/cmd/minikube/cmd/generate-docs_test.go
+++ b/cmd/minikube/cmd/generate-docs_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestGenerateDocs(t *testing.T) {
-	pflag.BoolP("help", "h", false, "")
+	pflag.BoolP("help", "h", false, "") // avoid 'Docs are not updated. Please run `make generate-docs` to update commands documentation' error
 	dir := "../../../site/content/en/docs/commands/"
 
 	for _, sc := range RootCmd.Commands() {


### PR DESCRIPTION
fixes: #9631 

updates generate-docs test to reflect #9622 and #9614

### before
currently, ci TestGenerateDocs (generate-docs) unit test fails for not including --help flag:
>❯ make clean && make && make test

result:
<details>
<pre>
rm -rf ./out
rm -f pkg/minikube/assets/assets.go
rm -f pkg/minikube/translate/translations.go
rm -rf ./vendor
PATH="/home/prezha/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/go/bin:/usr/local/rar:/home/prezha/bin/rar:/home/prezha/bin/ffmpeg:/home/prezha/dev/go/bin:/home/prezha/dev/protoc/bin:/home/prezha/bin/node/v14/bin:/home/prezha/dev/dotnet/v3:/home/prezha/bin/wkhtmltox/bin:/home/prezha/bin/mongodb:/home/prezha/bin/azure:/home/prezha/bin/k8s:/home/prezha/dev/go/bin" go-bindata -nomemcopy -o pkg/minikube/assets/assets.go -pkg assets deploy/addons/...
gofmt -s -w pkg/minikube/assets/assets.go
PATH="/home/prezha/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/go/bin:/usr/local/rar:/home/prezha/bin/rar:/home/prezha/bin/ffmpeg:/home/prezha/dev/go/bin:/home/prezha/dev/protoc/bin:/home/prezha/bin/node/v14/bin:/home/prezha/dev/dotnet/v3:/home/prezha/bin/wkhtmltox/bin:/home/prezha/bin/mongodb:/home/prezha/bin/azure:/home/prezha/bin/k8s:/home/prezha/dev/go/bin" go-bindata -nomemcopy -o pkg/minikube/translate/translations.go -pkg translate translations/...
gofmt -s -w pkg/minikube/translate/translations.go
go build  -tags "go_getter_nos3 go_getter_nogcs" -ldflags="-X k8s.io/minikube/pkg/version.version=v1.14.2 -X k8s.io/minikube/pkg/version.isoVersion=v1.14.0 -X k8s.io/minikube/pkg/version.isoPath=minikube/iso -X k8s.io/minikube/pkg/version.gitCommitID="18b0c00698dc593b78d677686205e35c3ebb7942" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v3" -o out/minikube k8s.io/minikube/cmd/minikube
MINIKUBE_LDFLAGS="-X k8s.io/minikube/pkg/version.version=v1.14.2 -X k8s.io/minikube/pkg/version.isoVersion=v1.14.0 -X k8s.io/minikube/pkg/version.isoPath=minikube/iso -X k8s.io/minikube/pkg/version.gitCommitID="18b0c00698dc593b78d677686205e35c3ebb7942" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v3" ./test.sh
= make lint =============================================================
golangci/golangci-lint info checking GitHub for tag 'v1.30.0'
golangci/golangci-lint info found version: 1.30.0 for v1.30.0/linux/amd64
golangci/golangci-lint info installed out/linters/golangci-lint
ok
= go mod ================================================================
ok
= boilerplate ===========================================================
ok
= schema_check ==========================================================
ok
= go test ===============================================================
--- FAIL: TestGenerateDocs (0.02s)
    --- FAIL: TestGenerateDocs/addons (0.00s)
        generate-docs_test.go:47: Docs are not updated. Please run `make generate-docs` to update commands documentation:   (
                """
                ... // 17 identical lines
                ```
              
            -   ### Options
            +   ### Options inherited from parent commands
              
                ```
            -     -h, --help   help for addons
            -   ```
            - 
            -   ### Options inherited from parent commands
            - 
            -   ```
                      --add_dir_header                   If true, adds the file directory to the header of the log messages
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 22 identical lines
                ```
              
            -   ### Options
            +   ### Options inherited from parent commands
              
                ```
            -     -h, --help   help for configure
            -   ```
            - 
            -   ### Options inherited from parent commands
            - 
            -   ```
                      --add_dir_header                   If true, adds the file directory to the header of the log messages
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 22 identical lines
                ```
              
            -   ### Options
            +   ### Options inherited from parent commands
              
                ```
            -     -h, --help   help for disable
            -   ```
            - 
            -   ### Options inherited from parent commands
            - 
            -   ```
                      --add_dir_header                   If true, adds the file directory to the header of the log messages
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 9 identical lines
                      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
                ```
            - 
            -   ## minikube addons enable
            - 
            -   Enables the addon w/ADDON_NAME within minikube (example: minikube addons enable dashboard). For a list of available addons use: minikube addons list 
              
            -   ### Synopsis
            +   ## minikube addons enable
                ... // 136 identical, 19 removed, and 13 inserted lines
                """
              )
    --- FAIL: TestGenerateDocs/cache (0.00s)
        generate-docs_test.go:47: Docs are not updated. Please run `make generate-docs` to update commands documentation:   (
                """
                ... // 13 identical lines
                Add, delete, or push a local image into minikube
              
            -   ### Options
            +   ### Options inherited from parent commands
              
                ```
            -     -h, --help   help for cache
            -   ```
            - 
            -   ### Options inherited from parent commands
            - 
            -   ```
                      --add_dir_header                   If true, adds the file directory to the header of the log messages
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 22 identical lines
                ```
              
            -   ### Options
            +   ### Options inherited from parent commands
              
                ```
            -     -h, --help   help for add
            -   ```
            - 
            -   ### Options inherited from parent commands
            - 
            -   ```
                      --add_dir_header                   If true, adds the file directory to the header of the log messages
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 22 identical lines
                ```
              
            -   ### Options
            +   ### Options inherited from parent commands
              
                ```
            -     -h, --help   help for delete
            -   ```
            - 
            -   ### Options inherited from parent commands
            - 
            -   ```
                      --add_dir_header                   If true, adds the file directory to the header of the log messages
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 9 identical lines
                      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
                ```
            - 
            -   ## minikube cache help
            - 
            -   Help about any command
              
            -   ### Synopsis
            +   ## minikube cache help
                ... // 94 identical, 19 removed, and 13 inserted lines
                """
              )
    --- FAIL: TestGenerateDocs/completion (0.00s)
        generate-docs_test.go:47: Docs are not updated. Please run `make generate-docs` to update commands documentation:   (
                """
                ... // 36 identical lines
                ```
                minikube completion SHELL [flags]
            -   ```
            - 
            -   ### Options
            - 
            -   ```
            -     -h, --help   help for completion
                ```
              
                ... // 4 identical lines
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 13 identical lines
                """
              )
    --- FAIL: TestGenerateDocs/config (0.00s)
        generate-docs_test.go:47: Docs are not updated. Please run `make generate-docs` to update commands documentation:   (
                """
                ... // 47 identical lines
                ```
              
            -   ### Options
            +   ### Options inherited from parent commands
              
                ```
            -     -h, --help   help for config
            -   ```
            - 
            -   ### Options inherited from parent commands
            - 
            -   ```
                      --add_dir_header                   If true, adds the file directory to the header of the log messages
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 28 identical lines
              
                ```
            -     -h, --help            help for defaults
                      --output string   Output format. Accepted values: [json]
                ```
                ... // 5 identical lines
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 22 identical lines
                ```
              
            -   ### Options
            +   ### Options inherited from parent commands
              
                ```
            -     -h, --help   help for get
            -   ```
            - 
            -   ### Options inherited from parent commands
            - 
            -   ```
                      --add_dir_header                   If true, adds the file directory to the header of the log messages
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 23 identical lines
                ```
              
            -   ### Options
            +   ### Options inherited from parent commands
              
                ```
            -     -h, --help   help for help
            -   ```
            - 
            -   ### Options inherited from parent commands
            - 
            -   ```
                      --add_dir_header                   If true, adds the file directory to the header of the log messages
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 9 identical lines
                      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
                ```
            - 
            -   ## minikube config set
            - 
            -   Sets an individual value in a minikube config file
                ... // 95 identical, 20 removed, and 14 inserted lines
                """
              )
    --- FAIL: TestGenerateDocs/dashboard (0.00s)
        generate-docs_test.go:47: Docs are not updated. Please run `make generate-docs` to update commands documentation:   strings.Join({
                ... // 20 identical lines
                "",
                "```",
            -   "  -h, --help   help for dashboard",
            -   "      --url    Display dashboard URL instead of opening a browser",
            +   "      --url   Display dashboard URL instead of opening a browser",
                "```",
                "",
                ... // 4 identical lines
                "      --alsologtostderr                  log to standard error as well as files",
                `  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")`,
            +   "  -h, --help                             ",
                "      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)",
                "      --log_dir string                   If non-empty, write log files in this directory",
                ... // 13 identical lines
              }, "\n")
    --- FAIL: TestGenerateDocs/delete (0.00s)
        generate-docs_test.go:47: Docs are not updated. Please run `make generate-docs` to update commands documentation:   (
                """
                ... // 22 identical lines
                ```
                      --all     Set flag to delete all profiles
            -     -h, --help    help for delete
                      --purge   Set this flag to delete the '.minikube' folder from your user directory.
                ```
                ... // 5 identical lines
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 13 identical lines
                """
              )
    --- FAIL: TestGenerateDocs/docker-env (0.00s)
        generate-docs_test.go:47: Docs are not updated. Please run `make generate-docs` to update commands documentation:   (
                """
                ... // 20 identical lines
              
                ```
            -     -h, --help           help for docker-env
                      --no-proxy       Add machine IP to NO_PROXY environment variable
                      --shell string   Force environment to be configured for a specified shell: [fish, cmd, powershell, tcsh, bash, zsh], default is auto-detect
                ... // 7 identical lines
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 13 identical lines
                """
              )
    --- FAIL: TestGenerateDocs/ip (0.00s)
        generate-docs_test.go:47: Docs are not updated. Please run `make generate-docs` to update commands documentation:   (
                """
                ... // 15 identical lines
                ```
                minikube ip [flags]
            -   ```
            - 
            -   ### Options
            - 
            -   ```
            -     -h, --help   help for ip
                ```
              
                ... // 4 identical lines
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 13 identical lines
                """
              )
    --- FAIL: TestGenerateDocs/kubectl (0.00s)
        generate-docs_test.go:47: Docs are not updated. Please run `make generate-docs` to update commands documentation:   (
                """
                ... // 19 identical lines
                ```
                minikube kubectl [flags]
            -   ```
            - 
            -   ### Options
            - 
            -   ```
            -     -h, --help   help for kubectl
                ```
              
                ... // 4 identical lines
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 13 identical lines
                """
              )
    --- FAIL: TestGenerateDocs/logs (0.00s)
        generate-docs_test.go:47: Docs are not updated. Please run `make generate-docs` to update commands documentation:   (
                """
                ... // 21 identical lines
                ```
                  -f, --follow        Show only the most recent journal entries, and continuously print new entries as they are appended to the journal.
            -     -h, --help          help for logs
                  -n, --length int    Number of lines back to go within the log (default 60)
                      --node string   The node to get logs from. Defaults to the primary control plane.
                ... // 7 identical lines
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 13 identical lines
                """
              )
    --- FAIL: TestGenerateDocs/mount (0.00s)
        generate-docs_test.go:47: Docs are not updated. Please run `make generate-docs` to update commands documentation:   (
                """
                ... // 22 identical lines
                      --9p-version string   Specify the 9p version that the mount should use (default "9p2000.L")
                      --gid string          Default group id used for the mount (default "docker")
            -     -h, --help                help for mount
                      --ip string           Specify the ip that the mount should be setup on
                      --kill                Kill the mount process spawned by minikube start
                ... // 11 identical lines
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 13 identical lines
                """
              )
    --- FAIL: TestGenerateDocs/node (0.00s)
        generate-docs_test.go:47: Docs are not updated. Please run `make generate-docs` to update commands documentation:   (
                """
                ... // 17 identical lines
                ```
              
            -   ### Options
            +   ### Options inherited from parent commands
              
                ```
            -     -h, --help   help for node
            -   ```
            - 
            -   ### Options inherited from parent commands
            - 
            -   ```
                      --add_dir_header                   If true, adds the file directory to the header of the log messages
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 27 identical lines
                      --control-plane       If true, the node added will also be a control plane in addition to a worker.
                      --delete-on-failure   If set, delete the current cluster if start fails and try again. Defaults to false.
            -     -h, --help                help for add
                      --worker              If true, the added node will be marked for work. Defaults to true. (default true)
                ```
                ... // 5 identical lines
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 22 identical lines
                ```
              
            -   ### Options
            +   ### Options inherited from parent commands
              
                ```
            -     -h, --help   help for delete
            -   ```
            - 
            -   ### Options inherited from parent commands
            - 
            -   ```
                      --add_dir_header                   If true, adds the file directory to the header of the log messages
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 23 identical lines
                ```
              
            -   ### Options
            +   ### Options inherited from parent commands
              
                ```
            -     -h, --help   help for help
            -   ```
            - 
            -   ### Options inherited from parent commands
            - 
            -   ```
                      --add_dir_header                   If true, adds the file directory to the header of the log messages
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 9 identical lines
                      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
                ```
            - 
            -   ## minikube node list
            - 
            -   List nodes.
                ... // 95 identical, 18 removed, and 12 inserted lines
                """
              )
    --- FAIL: TestGenerateDocs/pause (0.00s)
        generate-docs_test.go:47: Docs are not updated. Please run `make generate-docs` to update commands documentation:   (
                """
                ... // 22 identical lines
                  -n, ----namespaces strings   namespaces to pause (default [kube-system,kubernetes-dashboard,storage-gluster,istio-operator])
                  -A, --all-namespaces         If set, pause all namespaces
            -     -h, --help                   help for pause
                  -o, --output string          Format to print stdout in. Options include: [text,json] (default "text")
                ```
                ... // 5 identical lines
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 13 identical lines
                """
              )
    --- FAIL: TestGenerateDocs/podman-env (0.00s)
        generate-docs_test.go:47: Docs are not updated. Please run `make generate-docs` to update commands documentation:   (
                """
                ... // 20 identical lines
              
                ```
            -     -h, --help           help for podman-env
                      --shell string   Force environment to be configured for a specified shell: [fish, cmd, powershell, tcsh, bash, zsh], default is auto-detect
                  -u, --unset          Unset variables instead of setting them
                ... // 6 identical lines
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 13 identical lines
                """
              )
    --- FAIL: TestGenerateDocs/profile (0.00s)
        generate-docs_test.go:47: Docs are not updated. Please run `make generate-docs` to update commands documentation:   (
                """
                ... // 17 identical lines
                ```
              
            -   ### Options
            +   ### Options inherited from parent commands
              
                ```
            -     -h, --help   help for profile
            -   ```
            - 
            -   ### Options inherited from parent commands
            - 
            -   ```
                      --add_dir_header                   If true, adds the file directory to the header of the log messages
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 13 identical lines
              
                Help about any command
            - 
            -   ### Synopsis
            - 
            -   Help provides help for any command in the application.
            -   Simply type profile help [path to command] for full details.
              
            -   ```
            -   minikube profile help [command] [flags]
            -   ```
            +   ### Synopsis
              
            -   ### Options
            +   Help provides help for any command in the application.
            +   Simply type profile help [path to command] for full details.
              
                ```
            -     -h, --help   help for help
            +   minikube profile help [command] [flags]
                ```
              
                ... // 4 identical lines
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 25 identical lines
              
                ```
            -     -h, --help            help for list
                  -o, --output string   The output format. One of 'json', 'table' (default "table")
                ```
                ... // 5 identical lines
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 13 identical lines
                """
              )
    --- FAIL: TestGenerateDocs/service (0.00s)
        generate-docs_test.go:47: Docs are not updated. Please run `make generate-docs` to update commands documentation:   (
                """
                ... // 21 identical lines
                ```
                      --format string      Format to output service URL in. This format will be applied to each url individually and they will be printed one at a time. (default "http://{{.IP}}:{{.Port}}")
            -     -h, --help               help for service
                      --https              Open the service URL with https instead of http (defaults to "false")
                      --interval int       The initial time interval for each check that wait performs in seconds (default 1)
                ... // 9 identical lines
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 18 identical lines
                Help provides help for any command in the application.
                Simply type service help [path to command] for full details.
            - 
            -   ```
            -   minikube service help [command] [flags]
            -   ```
            - 
            -   ### Options
              
                ```
            -     -h, --help   help for help
            +   minikube service help [command] [flags]
                ```
              
                ... // 5 identical lines
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
                      --format string                    Format to output service URL in. This format will be applied to each url individually and they will be printed one at a time. (default "http://{{.IP}}:{{.Port}}")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 25 identical lines
              
                ```
            -     -h, --help               help for list
                  -n, --namespace string   The services namespace
                ```
                ... // 6 identical lines
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
                      --format string                    Format to output service URL in. This format will be applied to each url individually and they will be printed one at a time. (default "http://{{.IP}}:{{.Port}}")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 13 identical lines
                """
              )
    --- FAIL: TestGenerateDocs/ssh (0.00s)
        generate-docs_test.go:47: Docs are not updated. Please run `make generate-docs` to update commands documentation:   (
                """
                ... // 20 identical lines
              
                ```
            -     -h, --help          help for ssh
                      --native-ssh    Use native Golang SSH client (default true). Set to 'false' to use the command line 'ssh' command when accessing the docker machine. Useful for the machine drivers when they will not start with 'Waiting for SSH'. (default true)
                  -n, --node string   The node to ssh into. Defaults to the primary control plane.
                ... // 6 identical lines
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 13 identical lines
                """
              )
    --- FAIL: TestGenerateDocs/ssh-key (0.00s)
        generate-docs_test.go:47: Docs are not updated. Please run `make generate-docs` to update commands documentation:   (
                """
                ... // 15 identical lines
                ```
                minikube ssh-key [flags]
            -   ```
            - 
            -   ### Options
            - 
            -   ```
            -     -h, --help   help for ssh-key
                ```
              
                ... // 4 identical lines
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 13 identical lines
                """
              )
    --- FAIL: TestGenerateDocs/start (0.00s)
        generate-docs_test.go:47: Docs are not updated. Please run `make generate-docs` to update commands documentation:   (
                """
                ... // 51 identical lines
                      --force                             Force minikube to perform possibly dangerous operations
                      --force-systemd                     If set, force the container runtime to use sytemd as cgroup manager. Currently available for docker and crio. Defaults to false.
            -     -h, --help                              help for start
                      --host-dns-resolver                 Enable host resolver for NAT DNS requests (virtualbox driver only) (default true)
                      --host-only-cidr string             The CIDR to be used for the minikube VM (virtualbox driver only) (default "192.168.99.1/24")
                ... // 45 identical lines
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 13 identical lines
                """
              )
    --- FAIL: TestGenerateDocs/status (0.00s)
        generate-docs_test.go:47: Docs are not updated. Please run `make generate-docs` to update commands documentation:   (
                """
                ... // 24 identical lines
                  -f, --format string   Go template format string for the status output.  The format for Go templates can be found here: https://golang.org/pkg/text/template/
                                        For the list accessible variables for the template, see the struct values here: https://godoc.org/k8s.io/minikube/cmd/minikube/cmd#Status (default "{{.Name}}\ntype: Control Plane\nhost: {{.Host}}\nkubelet: {{.Kubelet}}\napiserver: {{.APIServer}}\nkubeconfig: {{.Kubeconfig}}\n\n")
            -     -h, --help            help for status
                  -l, --layout string   output layout (EXPERIMENTAL, JSON only): 'nodes' or 'cluster' (default "nodes")
                  -n, --node string     The node to check status for. Defaults to control plane. Leave blank with default format for status on all nodes.
                ... // 7 identical lines
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 13 identical lines
                """
              )
    --- FAIL: TestGenerateDocs/stop (0.00s)
        generate-docs_test.go:47: Docs are not updated. Please run `make generate-docs` to update commands documentation:   (
                """
                ... // 21 identical lines
                ```
                      --all                   Set flag to stop all profiles (clusters)
            -     -h, --help                  help for stop
                      --keep-context-active   keep the kube-context active after cluster is stopped. Defaults to false.
                  -o, --output string         Format to print stdout in. Options include: [text,json] (default "text")
                ... // 6 identical lines
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 13 identical lines
                """
              )
    --- FAIL: TestGenerateDocs/tunnel (0.00s)
        generate-docs_test.go:47: Docs are not updated. Please run `make generate-docs` to update commands documentation:   (
                """
                ... // 21 identical lines
                ```
                  -c, --cleanup   call with cleanup=true to remove old tunnels (default true)
            -     -h, --help      help for tunnel
                ```
              
                ... // 4 identical lines
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 13 identical lines
                """
              )
    --- FAIL: TestGenerateDocs/unpause (0.00s)
        generate-docs_test.go:47: Docs are not updated. Please run `make generate-docs` to update commands documentation:   (
                """
                ... // 22 identical lines
                  -n, ----namespaces strings   namespaces to unpause (default [kube-system,kubernetes-dashboard,storage-gluster,istio-operator])
                  -A, --all-namespaces         If set, unpause all namespaces
            -     -h, --help                   help for unpause
                  -o, --output string          Format to print stdout in. Options include: [text,json] (default "text")
                ```
                ... // 5 identical lines
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 13 identical lines
                """
              )
    --- FAIL: TestGenerateDocs/update-check (0.00s)
        generate-docs_test.go:47: Docs are not updated. Please run `make generate-docs` to update commands documentation:   (
                """
                ... // 15 identical lines
                ```
                minikube update-check [flags]
            -   ```
            - 
            -   ### Options
            - 
            -   ```
            -     -h, --help   help for update-check
                ```
              
                ... // 4 identical lines
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 13 identical lines
                """
              )
    --- FAIL: TestGenerateDocs/update-context (0.00s)
        generate-docs_test.go:47: Docs are not updated. Please run `make generate-docs` to update commands documentation:   (
                """
                ... // 16 identical lines
                ```
                minikube update-context [flags]
            -   ```
            - 
            -   ### Options
            - 
            -   ```
            -     -h, --help   help for update-context
                ```
              
                ... // 4 identical lines
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 13 identical lines
                """
              )
    --- FAIL: TestGenerateDocs/version (0.00s)
        generate-docs_test.go:47: Docs are not updated. Please run `make generate-docs` to update commands documentation:   (
                """
                ... // 20 identical lines
              
                ```
            -     -h, --help            help for version
                  -o, --output string   One of 'yaml' or 'json'.
                      --short           Print just the version number.
                ... // 6 identical lines
                      --alsologtostderr                  log to standard error as well as files
                  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
            +     -h, --help                             
                      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
                      --log_dir string                   If non-empty, write log files in this directory
                ... // 13 identical lines
                """
              )
E1107 22:52:08.358608   15860 out.go:142] [unset errFile]: ! Local proxy ignored: not passing HTTP_PROXY=127.0.0.1:3128 to docker env.
E1107 22:52:08.359116   15860 out.go:142] [unset errFile]: ! Local proxy ignored: not passing HTTP_PROXY=127.0.0.1:3128 to docker env.
E1107 22:52:08.359243   15860 out.go:142] [unset errFile]: ! Local proxy ignored: not passing HTTP_PROXY=localhost:3128 to docker env.
E1107 22:52:08.359446   15860 out.go:142] [unset errFile]: ! Local proxy ignored: not passing HTTP_PROXY=localhost:3128 to docker env.
E1107 22:52:08.359574   15860 out.go:142] [unset errFile]: ! Local proxy ignored: not passing HTTP_PROXY=http://localhost:3128 to docker env.
E1107 22:52:08.359770   15860 out.go:142] [unset errFile]: ! Local proxy ignored: not passing HTTP_PROXY=http://localhost:3128 to docker env.
E1107 22:52:08.359932   15860 out.go:142] [unset errFile]: ! Local proxy ignored: not passing HTTP_PROXY=http://127.0.0.1:3128 to docker env.
E1107 22:52:08.360104   15860 out.go:142] [unset errFile]: ! Local proxy ignored: not passing HTTP_PROXY=http://127.0.0.1:3128 to docker env.
FAIL
coverage: 18.5% of statements
FAIL    k8s.io/minikube/cmd/minikube/cmd        4.535s
ok      k8s.io/minikube/cmd/minikube/cmd/config 0.107s  coverage: 21.0% of statements
ok      k8s.io/minikube/pkg/addons      0.080s  coverage: 50.9% of statements
ok      k8s.io/minikube/pkg/drivers     0.019s  coverage: 19.6% of statements
ok      k8s.io/minikube/pkg/drivers/hyperkit    0.028s  coverage: 77.3% of statements
ok      k8s.io/minikube/pkg/drivers/kic/oci     0.036s  coverage: 6.4% of statements
ok      k8s.io/minikube/pkg/drivers/kvm 0.023s  coverage: 2.3% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper       2.034s  coverage: 55.7% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper/bsutil        0.100s  coverage: 62.4% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper/bsutil/ktmpl  0.033s  coverage: 100.0% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper/images        0.038s  coverage: 82.0% of statements
ok      k8s.io/minikube/pkg/minikube/cluster    0.080s  coverage: 14.5% of statements
ok      k8s.io/minikube/pkg/minikube/command    0.030s  coverage: 4.2% of statements
ok      k8s.io/minikube/pkg/minikube/config     0.132s  coverage: 71.6% of statements
ok      k8s.io/minikube/pkg/minikube/cruntime   0.094s  coverage: 36.7% of statements
ok      k8s.io/minikube/pkg/minikube/docker     0.088s  coverage: 20.8% of statements
ok      k8s.io/minikube/pkg/minikube/driver     0.030s  coverage: 40.1% of statements
ok      k8s.io/minikube/pkg/minikube/extract    0.008s  coverage: 58.6% of statements
ok      k8s.io/minikube/pkg/minikube/image      0.052s  coverage: 3.0% of statements
ok      k8s.io/minikube/pkg/minikube/kubeconfig 0.035s  coverage: 81.3% of statements
ok      k8s.io/minikube/pkg/minikube/localpath  0.046s  coverage: 49.3% of statements
ok      k8s.io/minikube/pkg/minikube/logs       0.087s  coverage: 1.3% of statements
ok      k8s.io/minikube/pkg/minikube/machine    1.137s  coverage: 35.8% of statements
ok      k8s.io/minikube/pkg/minikube/mustload   0.024s  coverage: 10.5% of statements
ok      k8s.io/minikube/pkg/minikube/notify     0.049s  coverage: 92.9% of statements
ok      k8s.io/minikube/pkg/minikube/out        0.025s  coverage: 66.7% of statements
ok      k8s.io/minikube/pkg/minikube/out/register       0.028s  coverage: 54.5% of statements
ok      k8s.io/minikube/pkg/minikube/perf       4.015s  coverage: 21.1% of statements
ok      k8s.io/minikube/pkg/minikube/proxy      0.009s  coverage: 68.7% of statements
ok      k8s.io/minikube/pkg/minikube/reason     0.009s  coverage: 80.0% of statements
ok      k8s.io/minikube/pkg/minikube/registry   0.006s  coverage: 75.5% of statements
ok      k8s.io/minikube/pkg/minikube/service    0.024s  coverage: 84.2% of statements
ok      k8s.io/minikube/pkg/minikube/shell      0.044s  coverage: 97.1% of statements
ok      k8s.io/minikube/pkg/minikube/storageclass       0.012s  coverage: 100.0% of statements
ok      k8s.io/minikube/pkg/minikube/style      0.049s  coverage: 100.0% of statements
ok      k8s.io/minikube/pkg/minikube/sysinit    0.015s  coverage: 6.5% of statements
ok      k8s.io/minikube/pkg/minikube/translate  0.003s  coverage: 10.5% of statements
ok      k8s.io/minikube/pkg/minikube/tunnel     1.467s  coverage: 64.2% of statements
ok      k8s.io/minikube/pkg/util        0.655s  coverage: 75.7% of statements
ok      k8s.io/minikube/pkg/util/lock   0.003s  coverage: 22.2% of statements
ok      k8s.io/minikube/pkg/util/retry  0.004s  coverage: 0.0% of statements
FAIL
make: *** [Makefile:315: test] Error 32
</pre>
</details>

manually generating docs does not change anything (ie, all doc files are rightfully reported as currently up-to-date):
>❯ make generate-docs
```
out/minikube generate-docs --path ./site/content/en/docs/commands/
📘  Docs have been saved at - ./site/content/en/docs/commands/
```
so, rerunning `make test`:
>❯ make clean && make && make test

result: _same errors as above_ (under details)

### after
>❯ make clean && make && make test
```
rm -rf ./out
rm -f pkg/minikube/assets/assets.go
rm -f pkg/minikube/translate/translations.go
rm -rf ./vendor
PATH="/home/prezha/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/go/bin:/usr/local/rar:/home/prezha/bin/rar:/home/prezha/bin/ffmpeg:/home/prezha/dev/go/bin:/home/prezha/dev/protoc/bin:/home/prezha/bin/node/v14/bin:/home/prezha/dev/dotnet/v3:/home/prezha/bin/wkhtmltox/bin:/home/prezha/bin/mongodb:/home/prezha/bin/azure:/home/prezha/bin/k8s:/home/prezha/dev/go/bin" go-bindata -nomemcopy -o pkg/minikube/assets/assets.go -pkg assets deploy/addons/...
gofmt -s -w pkg/minikube/assets/assets.go
PATH="/home/prezha/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/go/bin:/usr/local/rar:/home/prezha/bin/rar:/home/prezha/bin/ffmpeg:/home/prezha/dev/go/bin:/home/prezha/dev/protoc/bin:/home/prezha/bin/node/v14/bin:/home/prezha/dev/dotnet/v3:/home/prezha/bin/wkhtmltox/bin:/home/prezha/bin/mongodb:/home/prezha/bin/azure:/home/prezha/bin/k8s:/home/prezha/dev/go/bin" go-bindata -nomemcopy -o pkg/minikube/translate/translations.go -pkg translate translations/...
gofmt -s -w pkg/minikube/translate/translations.go
go build  -tags "go_getter_nos3 go_getter_nogcs" -ldflags="-X k8s.io/minikube/pkg/version.version=v1.14.2 -X k8s.io/minikube/pkg/version.isoVersion=v1.14.0 -X k8s.io/minikube/pkg/version.isoPath=minikube/iso -X k8s.io/minikube/pkg/version.gitCommitID="18b0c00698dc593b78d677686205e35c3ebb7942-dirty" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v3" -o out/minikube k8s.io/minikube/cmd/minikube
MINIKUBE_LDFLAGS="-X k8s.io/minikube/pkg/version.version=v1.14.2 -X k8s.io/minikube/pkg/version.isoVersion=v1.14.0 -X k8s.io/minikube/pkg/version.isoPath=minikube/iso -X k8s.io/minikube/pkg/version.gitCommitID="18b0c00698dc593b78d677686205e35c3ebb7942-dirty" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v3" ./test.sh
= make lint =============================================================
golangci/golangci-lint info checking GitHub for tag 'v1.30.0'
golangci/golangci-lint info found version: 1.30.0 for v1.30.0/linux/amd64
golangci/golangci-lint info installed out/linters/golangci-lint
ok
= go mod ================================================================
ok
= boilerplate ===========================================================
ok
= schema_check ==========================================================
ok
= go test ===============================================================
ok      k8s.io/minikube/cmd/minikube/cmd        3.623s  coverage: 18.5% of statements
ok      k8s.io/minikube/cmd/minikube/cmd/config 0.138s  coverage: 21.0% of statements
ok      k8s.io/minikube/pkg/addons      0.074s  coverage: 50.9% of statements
ok      k8s.io/minikube/pkg/drivers     0.101s  coverage: 19.6% of statements
ok      k8s.io/minikube/pkg/drivers/hyperkit    0.015s  coverage: 77.3% of statements
ok      k8s.io/minikube/pkg/drivers/kic/oci     0.064s  coverage: 6.4% of statements
ok      k8s.io/minikube/pkg/drivers/kvm 0.033s  coverage: 2.3% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper       1.093s  coverage: 55.7% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper/bsutil        0.130s  coverage: 62.4% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper/bsutil/ktmpl  0.038s  coverage: 100.0% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper/images        0.025s  coverage: 82.0% of statements
ok      k8s.io/minikube/pkg/minikube/cluster    0.086s  coverage: 14.5% of statements
ok      k8s.io/minikube/pkg/minikube/command    0.097s  coverage: 4.2% of statements
ok      k8s.io/minikube/pkg/minikube/config     0.167s  coverage: 71.6% of statements
ok      k8s.io/minikube/pkg/minikube/cruntime   0.102s  coverage: 36.7% of statements
ok      k8s.io/minikube/pkg/minikube/docker     0.077s  coverage: 20.8% of statements
ok      k8s.io/minikube/pkg/minikube/driver     0.068s  coverage: 40.1% of statements
ok      k8s.io/minikube/pkg/minikube/extract    0.004s  coverage: 58.6% of statements
ok      k8s.io/minikube/pkg/minikube/image      0.049s  coverage: 3.0% of statements
ok      k8s.io/minikube/pkg/minikube/kubeconfig 0.039s  coverage: 81.3% of statements
ok      k8s.io/minikube/pkg/minikube/localpath  0.031s  coverage: 49.3% of statements
ok      k8s.io/minikube/pkg/minikube/logs       0.042s  coverage: 1.3% of statements
ok      k8s.io/minikube/pkg/minikube/machine    1.086s  coverage: 35.8% of statements
ok      k8s.io/minikube/pkg/minikube/mustload   0.037s  coverage: 10.5% of statements
ok      k8s.io/minikube/pkg/minikube/notify     0.040s  coverage: 92.9% of statements
ok      k8s.io/minikube/pkg/minikube/out        0.020s  coverage: 66.7% of statements
ok      k8s.io/minikube/pkg/minikube/out/register       0.026s  coverage: 54.5% of statements
ok      k8s.io/minikube/pkg/minikube/perf       4.018s  coverage: 21.1% of statements
ok      k8s.io/minikube/pkg/minikube/proxy      0.015s  coverage: 68.7% of statements
ok      k8s.io/minikube/pkg/minikube/reason     0.038s  coverage: 80.0% of statements
ok      k8s.io/minikube/pkg/minikube/registry   0.010s  coverage: 75.5% of statements
ok      k8s.io/minikube/pkg/minikube/service    0.027s  coverage: 84.2% of statements
ok      k8s.io/minikube/pkg/minikube/shell      0.031s  coverage: 97.1% of statements
ok      k8s.io/minikube/pkg/minikube/storageclass       0.013s  coverage: 100.0% of statements
ok      k8s.io/minikube/pkg/minikube/style      0.059s  coverage: 100.0% of statements
ok      k8s.io/minikube/pkg/minikube/sysinit    0.025s  coverage: 6.5% of statements
ok      k8s.io/minikube/pkg/minikube/translate  0.004s  coverage: 10.5% of statements
ok      k8s.io/minikube/pkg/minikube/tunnel     1.792s  coverage: 64.2% of statements
ok      k8s.io/minikube/pkg/util        0.560s  coverage: 75.7% of statements
ok      k8s.io/minikube/pkg/util/lock   0.006s  coverage: 22.2% of statements
ok      k8s.io/minikube/pkg/util/retry  0.003s  coverage: 0.0% of statements
ok
```