### PR TITLE
Fix --extra-config when starting an existing cluster

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -613,6 +613,10 @@ func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterC
 		cc.KubernetesConfig.ImageRepository = viper.GetString(imageRepository)
 	}
 
+	if cmd.Flags().Changed("extra-config") {
+		cc.KubernetesConfig.ExtraOptions = config.ExtraOptions
+	}
+
 	if cmd.Flags().Changed(enableDefaultCNI) && !cmd.Flags().Changed(cniFlag) {
 		if viper.GetBool(enableDefaultCNI) {
 			klog.Errorf("Found deprecated --enable-default-cni flag, setting --cni=bridge")


### PR DESCRIPTION
Fixes #8242

Creating a minikube cluster with `minikube start` no arguments results in null value for ExtraOptions in `.minikube/profiles/minikube/config.json`:

```
        "ExtraOptions": null,
```

If we then stop and start minikube a second time with `minikube start --extra-config=apiserver.enable-admission-plugins=NamespaceAutoProvision` the ExtraOptions in the config file stays the same and in the cluster the apiserver config also doesn't change:

```
$ ps auxwf | grep -v grep | grep -o -- '--enable-admission[^ ]*'
--enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota
```

Doing the same thing with my patch the ExtraOptions in the profile will change to:

```
                "ExtraOptions": [
                        {
                                "Component": "apiserver",
                                "Key": "enable-admission-plugins",
                                "Value": "NamespaceAutoProvision"
                        }
                ],
```

And if we look in the cluster we see the config has been applied this time:

```
$ ps auxwf | grep -v grep | grep -o -- '--enable-admission[^ ]*'
--enable-admission-plugins=NamespaceAutoProvision
```

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
