### PR TITLE
Fix minikube-net network failures for KVM driver

### DIFF
--- a/pkg/drivers/kvm/kvm.go
+++ b/pkg/drivers/kvm/kvm.go
@@ -240,14 +240,6 @@ func (d *Driver) Restart() error {
 
 // Start a host
 func (d *Driver) Start() (err error) {
-	// if somebody/something deleted the network in the meantime,
-	// we might need to recreate it. It's (nearly) a noop if the network exists.
-	log.Info("Creating network...")
-	err = d.createNetwork()
-	if err != nil {
-		return errors.Wrap(err, "creating network")
-	}
-
 	// this call ensures that all networks are active
 	log.Info("Ensuring networks are active...")
 	err = d.ensureNetwork()

--- a/pkg/drivers/kvm/kvm.go
+++ b/pkg/drivers/kvm/kvm.go
@@ -110,6 +110,8 @@ func (d *Driver) PreCommandCheck() error {
 	if err != nil {
 		return errors.Wrap(err, "error connecting to libvirt socket. Have you added yourself to the libvirtd group?")
 	}
+	defer conn.Close()
+
 	libVersion, err := conn.GetLibVersion()
 	if err != nil {
 		return errors.Wrap(err, "getting libvirt version")
@@ -481,4 +483,15 @@ func (d *Driver) undefineDomain(conn *libvirt.Connect, dom *libvirt.Domain) erro
 	}
 
 	return dom.Undefine()
+}
+
+// lvErr will return libvirt Error struct containing specific libvirt error code, domain, message and level
+func lvErr(err error) libvirt.Error {
+	if err != nil {
+		if lverr, ok := err.(libvirt.Error); ok {
+			return lverr
+		}
+		return libvirt.Error{Code: libvirt.ERR_INTERNAL_ERROR, Message: "internal error"}
+	}
+	return libvirt.Error{Code: libvirt.ERR_OK, Message: ""}
 }


### PR DESCRIPTION
fixes: #9610
fixes: #9049
fixes: #8952

as explained in original issues, cluster with minikube-net network for kvm driver might fail because eg, the network is inactive or already in use, and this pr tries to handle those situations by either trying to avoid race conditions between ops in the first place, then fix the issue, or recreate the network as the last resort

### example for safely recreating minikube-net network (if all else fails)

step 1 - create cluster with kvm2 driver:
>$ minikube start --driver=kvm2

step 2 - stop the cluster:
>$ minikube stop
```
✋  Stopping node "minikube"  ...
🛑  1 nodes stopped.
```
step 3 - check networks:
```
# virsh net-list --all
 Name           State    Autostart   Persistent
-------------------------------------------------
 default        active   yes         yes
 minikube-net   active   yes         yes
```
step 4 - 'break'  minikube-net network:
```
# virsh net-destroy minikube-net 
Network minikube-net destroyed
```
step 5 - check networks:
```
# virsh net-list --all
 Name           State      Autostart   Persistent
---------------------------------------------------
 default        active     yes         yes
 minikube-net   inactive   yes         yes
```
step 6 - disable 'easy fix' (reactivate inactive network) in kvm.setupNetwork()

step 7 - start the cluster (and see the network being safely recreated, and cluster brought up successfully):
>$ minikube start --alsologtostderr -v=99

relevant output sections:
```
...
I1109 02:14:34.527197  733246 fix.go:107] recreateIfNeeded on minikube: state=Stopped err=<nil>
I1109 02:14:34.527215  733246 main.go:119] libmachine: (minikube) Calling .DriverName
W1109 02:14:34.527311  733246 fix.go:133] unexpected machine state, will restart: <nil>
I1109 02:14:34.535671  733246 out.go:110] 🔄  Restarting existing kvm2 VM for "minikube" ...
🔄  Restarting existing kvm2 VM for "minikube" ...
I1109 02:14:34.535689  733246 main.go:119] libmachine: (minikube) Calling .Start
I1109 02:14:34.535795  733246 main.go:119] libmachine: (minikube) Ensuring networks are active...
I1109 02:14:34.537807  733246 main.go:119] libmachine: (minikube) Ensuring network default is active
I1109 02:14:34.538136  733246 main.go:119] libmachine: (minikube) Ensuring network minikube-net is active
I1109 02:14:34.538402  733246 main.go:119] libmachine: (minikube) DBG | Network minikube-net is inoperable, will try to recreate it: network minikube-net inactive
I1109 02:14:34.539801  733246 main.go:119] libmachine: (minikube) DBG | Checking if network minikube-net exists...
I1109 02:14:34.539815  733246 main.go:119] libmachine: (minikube) DBG | Network minikube-net exists
I1109 02:14:34.539827  733246 main.go:119] libmachine: (minikube) DBG | Trying to list all domains...
I1109 02:14:34.539904  733246 main.go:119] libmachine: (minikube) DBG | Listed all domains: total of 6 domains
I1109 02:14:34.539920  733246 main.go:119] libmachine: (minikube) DBG | Trying to get name of domain...
I1109 02:14:34.539932  733246 main.go:119] libmachine: (minikube) DBG | Got domain name: minikube
I1109 02:14:34.539941  733246 main.go:119] libmachine: (minikube) DBG | Skipping domain as it is us...
I1109 02:14:34.539951  733246 main.go:119] libmachine: (minikube) DBG | Trying to get name of domain...
I1109 02:14:34.539960  733246 main.go:119] libmachine: (minikube) DBG | Got domain name: Dom1
I1109 02:14:34.539973  733246 main.go:119] libmachine: (minikube) DBG | Getting XML for domain Dom1...
I1109 02:14:34.540178  733246 main.go:119] libmachine: (minikube) DBG | Got XML for domain Dom1
I1109 02:14:34.540724  733246 main.go:119] libmachine: (minikube) DBG | Unmarshaled XML for domain Dom1: kvm.result{Name:"Dom1", Interfaces:[]kvm.iface{kvm.iface{Source:kvm.source{Network:"default"}}}}
I1109 02:14:34.540736  733246 main.go:119] libmachine: (minikube) DBG | domain Dom1 does not use network minikube-net
I1109 02:14:34.540749  733246 main.go:119] libmachine: (minikube) DBG | Trying to get name of domain...
I1109 02:14:34.540757  733246 main.go:119] libmachine: (minikube) DBG | Got domain name: opensuse15.2
I1109 02:14:34.540768  733246 main.go:119] libmachine: (minikube) DBG | Getting XML for domain opensuse15.2...
I1109 02:14:34.540873  733246 main.go:119] libmachine: (minikube) DBG | Got XML for domain opensuse15.2
I1109 02:14:34.541428  733246 main.go:119] libmachine: (minikube) DBG | Unmarshaled XML for domain opensuse15.2: kvm.result{Name:"opensuse15.2", Interfaces:[]kvm.iface{kvm.iface{Source:kvm.source{Network:"default"}}}}
I1109 02:14:34.541444  733246 main.go:119] libmachine: (minikube) DBG | domain opensuse15.2 does not use network minikube-net
I1109 02:14:34.541456  733246 main.go:119] libmachine: (minikube) DBG | Trying to get name of domain...
I1109 02:14:34.541464  733246 main.go:119] libmachine: (minikube) DBG | Got domain name: opensuse15.2-clone
I1109 02:14:34.541476  733246 main.go:119] libmachine: (minikube) DBG | Getting XML for domain opensuse15.2-clone...
I1109 02:14:34.541564  733246 main.go:119] libmachine: (minikube) DBG | Got XML for domain opensuse15.2-clone
I1109 02:14:34.542111  733246 main.go:119] libmachine: (minikube) DBG | Unmarshaled XML for domain opensuse15.2-clone: kvm.result{Name:"opensuse15.2-clone", Interfaces:[]kvm.iface{kvm.iface{Source:kvm.source{Network:"default"}}}}
I1109 02:14:34.542130  733246 main.go:119] libmachine: (minikube) DBG | domain opensuse15.2-clone does not use network minikube-net
I1109 02:14:34.542142  733246 main.go:119] libmachine: (minikube) DBG | Trying to get name of domain...
I1109 02:14:34.542149  733246 main.go:119] libmachine: (minikube) DBG | Got domain name: Dom2
I1109 02:14:34.542161  733246 main.go:119] libmachine: (minikube) DBG | Getting XML for domain Dom2...
I1109 02:14:34.542272  733246 main.go:119] libmachine: (minikube) DBG | Got XML for domain Dom2
I1109 02:14:34.542775  733246 main.go:119] libmachine: (minikube) DBG | Unmarshaled XML for domain Dom2: kvm.result{Name:"Dom2", Interfaces:[]kvm.iface{kvm.iface{Source:kvm.source{Network:"default"}}}}
I1109 02:14:34.542792  733246 main.go:119] libmachine: (minikube) DBG | domain Dom2 does not use network minikube-net
I1109 02:14:34.542805  733246 main.go:119] libmachine: (minikube) DBG | Trying to get name of domain...
I1109 02:14:34.542815  733246 main.go:119] libmachine: (minikube) DBG | Got domain name: Dom3
I1109 02:14:34.542826  733246 main.go:119] libmachine: (minikube) DBG | Getting XML for domain Dom3...
I1109 02:14:34.542926  733246 main.go:119] libmachine: (minikube) DBG | Got XML for domain Dom3
I1109 02:14:34.543397  733246 main.go:119] libmachine: (minikube) DBG | Unmarshaled XML for domain Dom3: kvm.result{Name:"Dom3", Interfaces:[]kvm.iface{kvm.iface{Source:kvm.source{Network:"default"}}}}
I1109 02:14:34.543412  733246 main.go:119] libmachine: (minikube) DBG | domain Dom3 does not use network minikube-net
I1109 02:14:34.543424  733246 main.go:119] libmachine: (minikube) DBG | Trying to destroy network minikube-net...
I1109 02:14:34.543507  733246 main.go:119] libmachine: (minikube) DBG | Trying to reactivate network minikube-net first...
I1109 02:14:34.778054  733246 main.go:119] libmachine: (minikube) DBG | Trying to undefine network minikube-net...
I1109 02:14:34.779608  733246 main.go:119] libmachine: (minikube) DBG | Successfully deleted minikube-net network
I1109 02:14:34.900222  733246 main.go:119] libmachine: (minikube) DBG | Successfully recreated minikube-net network
I1109 02:14:34.900776  733246 main.go:119] libmachine: (minikube) DBG | Successfully activated minikube-net network
I1109 02:14:34.900955  733246 main.go:119] libmachine: (minikube) Getting domain xml...
I1109 02:14:34.903049  733246 main.go:119] libmachine: (minikube) Creating domain...
I1109 02:14:35.202168  733246 main.go:119] libmachine: (minikube) Waiting to get IP...
I1109 02:14:35.206868  733246 main.go:119] libmachine: (minikube) DBG | Waiting for machine to come up 0/40
I1109 02:14:38.211570  733246 main.go:119] libmachine: (minikube) DBG | Waiting for machine to come up 1/40
I1109 02:14:41.226804  733246 main.go:119] libmachine: (minikube) DBG | Waiting for machine to come up 2/40
I1109 02:14:44.242477  733246 main.go:119] libmachine: (minikube) DBG | Waiting for machine to come up 3/40
I1109 02:14:47.248240  733246 main.go:119] libmachine: (minikube) DBG | Getting to WaitForSSH function...
I1109 02:14:47.248289  733246 main.go:119] libmachine: (minikube) Found IP for machine: 192.168.39.42
I1109 02:14:47.248347  733246 main.go:119] libmachine: (minikube) Waiting for SSH to be available...
I1109 02:14:47.253140  733246 main.go:119] libmachine: (minikube) DBG | Using SSH client type: external
I1109 02:14:47.253172  733246 main.go:119] libmachine: (minikube) DBG | Using SSH private key: /home/prezha/.minikube/machines/minikube/id_rsa (-rw-------)
I1109 02:14:47.253229  733246 main.go:119] libmachine: (minikube) DBG | &{[-F /dev/null -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=no -o ControlPath=none -o LogLevel=quiet -o PasswordAuthentication=no -o ServerAliveInterval=60 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null docker@192.168.39.42 -o IdentitiesOnly=yes -i /home/prezha/.minikube/machines/minikube/id_rsa -p 22] /usr/bin/ssh <nil>}
I1109 02:14:47.253252  733246 main.go:119] libmachine: (minikube) DBG | About to run SSH command:
I1109 02:14:47.253269  733246 main.go:119] libmachine: (minikube) DBG | exit 0
I1109 02:14:47.375267  733246 main.go:119] libmachine: (minikube) DBG | SSH cmd err, output: <nil>: 
I1109 02:14:47.375481  733246 main.go:119] libmachine: (minikube) Calling .GetConfigRaw
I1109 02:14:47.375947  733246 main.go:119] libmachine: (minikube) Calling .GetIP
...
I1109 02:15:22.129948  733246 out.go:110] 🌟  Enabled addons: storage-provisioner, default-storageclass
🌟  Enabled addons: storage-provisioner, default-storageclass
I1109 02:15:22.129969  733246 addons.go:373] enableAddons completed in 593.04175ms
I1109 02:15:22.160877  733246 start.go:461] kubectl: 1.19.3, cluster: 1.19.2 (minor skew: 0)
I1109 02:15:22.165854  733246 out.go:110] 🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```
step 8 - finally, check networks again:
```
# virsh net-list --all
 Name           State    Autostart   Persistent
-------------------------------------------------
 default        active   yes         yes
 minikube-net   active   yes         yes
```