### PR TITLE
Rename `out.T` to `out.Step`

### DIFF
--- a/cmd/minikube/cmd/config/addons_list.go
+++ b/cmd/minikube/cmd/config/addons_list.go
@@ -117,7 +117,7 @@ var printAddonsList = func(cc *config.ClusterConfig) {
 		klog.Errorf("list profiles returned error: %v", err)
 	}
 	if len(v) > 1 {
-		out.T(style.Tip, "To see addons list for other profiles use: `minikube addons -p name list`")
+		out.Step(style.Tip, "To see addons list for other profiles use: `minikube addons -p name list`")
 	}
 }
 

--- a/cmd/minikube/cmd/config/disable.go
+++ b/cmd/minikube/cmd/config/disable.go
@@ -42,7 +42,7 @@ var addonsDisableCmd = &cobra.Command{
 		if err != nil {
 			exit.Error(reason.InternalDisable, "disable failed", err)
 		}
-		out.T(style.AddonDisable, `"The '{{.minikube_addon}}' addon is disabled`, out.V{"minikube_addon": addon})
+		out.Step(style.AddonDisable, `"The '{{.minikube_addon}}' addon is disabled`, out.V{"minikube_addon": addon})
 	},
 }
 

--- a/cmd/minikube/cmd/config/enable.go
+++ b/cmd/minikube/cmd/config/enable.go
@@ -39,7 +39,7 @@ var addonsEnableCmd = &cobra.Command{
 		addon := args[0]
 		// replace heapster as metrics-server because heapster is deprecated
 		if addon == "heapster" {
-			out.T(style.Waiting, "enable metrics-server addon instead of heapster addon because heapster is deprecated")
+			out.Step(style.Waiting, "enable metrics-server addon instead of heapster addon because heapster is deprecated")
 			addon = "metrics-server"
 		}
 		err := addons.SetAndSave(ClusterFlagValue(), addon, "true")
@@ -51,7 +51,7 @@ var addonsEnableCmd = &cobra.Command{
 			if ClusterFlagValue() != constants.DefaultClusterName {
 				tipProfileArg = fmt.Sprintf(" -p %s", ClusterFlagValue())
 			}
-			out.T(style.Tip, `Some dashboard features require the metrics-server addon. To enable all features please run:
+			out.Step(style.Tip, `Some dashboard features require the metrics-server addon. To enable all features please run:
 
 	minikube{{.profileArg}} addons enable metrics-server	
 
@@ -59,7 +59,7 @@ var addonsEnableCmd = &cobra.Command{
 
 		}
 
-		out.T(style.AddonEnable, "The '{{.addonName}}' addon is enabled", out.V{"addonName": addon})
+		out.Step(style.AddonEnable, "The '{{.addonName}}' addon is enabled", out.V{"addonName": addon})
 	},
 }
 

--- a/cmd/minikube/cmd/config/open.go
+++ b/cmd/minikube/cmd/config/open.go
@@ -96,7 +96,7 @@ You can add one by annotating a service with the label {{.labelName}}:{{.addonNa
 			}
 
 			if len(urlString) != 0 {
-				out.T(style.Celebrate, "Opening Kubernetes service  {{.namespace_name}}/{{.service_name}} in default browser...", out.V{"namespace_name": namespace, "service_name": svc})
+				out.Step(style.Celebrate, "Opening Kubernetes service  {{.namespace_name}}/{{.service_name}} in default browser...", out.V{"namespace_name": namespace, "service_name": svc})
 				for _, url := range urlString {
 					if err := browser.OpenURL(url); err != nil {
 						exit.Error(reason.HostBrowser, fmt.Sprintf("browser failed to open url %s", url), err)

--- a/cmd/minikube/cmd/config/profile.go
+++ b/cmd/minikube/cmd/config/profile.go
@@ -37,7 +37,7 @@ var ProfileCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			profile := ClusterFlagValue()
-			out.T(style.Empty, profile)
+			out.Step(style.Empty, profile)
 			os.Exit(0)
 		}
 

--- a/cmd/minikube/cmd/dashboard.go
+++ b/cmd/minikube/cmd/dashboard.go
@@ -112,7 +112,7 @@ var dashboardCmd = &cobra.Command{
 		if dashboardURLMode || user.Uid == "0" {
 			out.Ln(url)
 		} else {
-			out.T(style.Celebrate, "Opening {{.url}} in your default browser...", out.V{"url": url})
+			out.Step(style.Celebrate, "Opening {{.url}} in your default browser...", out.V{"url": url})
 			if err = browser.OpenURL(url); err != nil {
 				exit.Message(reason.HostBrowser, "failed to open browser: {{.error}}", out.V{"error": err})
 			}

--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -142,7 +142,7 @@ func runDelete(cmd *cobra.Command, args []string) {
 	if purge && len(profilesToDelete) > 1 && !deleteAll {
 		out.ErrT(style.Notice, "Multiple minikube profiles were found - ")
 		for _, p := range profilesToDelete {
-			out.T(style.Notice, "    - {{.profile}}", out.V{"profile": p.Name})
+			out.Step(style.Notice, "    - {{.profile}}", out.V{"profile": p.Name})
 		}
 		exit.Message(reason.Usage, "Usage: minikube delete --all --purge")
 	}
@@ -157,7 +157,7 @@ func runDelete(cmd *cobra.Command, args []string) {
 		if len(errs) > 0 {
 			HandleDeletionErrors(errs)
 		} else {
-			out.T(style.DeletingHost, "Successfully deleted all profiles")
+			out.Step(style.DeletingHost, "Successfully deleted all profiles")
 		}
 	} else {
 		if len(args) > 0 {
@@ -198,7 +198,7 @@ func purgeMinikubeDirectory() {
 	if err := os.RemoveAll(localpath.MiniPath()); err != nil {
 		exit.Error(reason.HostPurge, "unable to delete minikube config folder", err)
 	}
-	out.T(style.Deleted, "Successfully purged minikube directory located at - [{{.minikubeDirectory}}]", out.V{"minikubeDirectory": localpath.MiniPath()})
+	out.Step(style.Deleted, "Successfully purged minikube directory located at - [{{.minikubeDirectory}}]", out.V{"minikubeDirectory": localpath.MiniPath()})
 }
 
 // DeleteProfiles deletes one or more profiles
@@ -246,7 +246,7 @@ func deletePossibleKicLeftOver(cname string, driverName string) {
 	cs, err := oci.ListContainersByLabel(bin, delLabel)
 	if err == nil && len(cs) > 0 {
 		for _, c := range cs {
-			out.T(style.DeletingHost, `Deleting container "{{.name}}" ...`, out.V{"name": cname})
+			out.Step(style.DeletingHost, `Deleting container "{{.name}}" ...`, out.V{"name": cname})
 			err := oci.DeleteContainer(bin, c)
 			if err != nil { // it will error if there is no container to delete
 				klog.Errorf("error deleting container %q. You may want to delete it manually :\n%v", cname, err)
@@ -286,7 +286,7 @@ func deleteProfile(profile *config.Profile) error {
 
 		// if driver is oci driver, delete containers and volumes
 		if driver.IsKIC(profile.Config.Driver) {
-			out.T(style.DeletingHost, `Deleting "{{.profile_name}}" in {{.driver_name}} ...`, out.V{"profile_name": profile.Name, "driver_name": profile.Config.Driver})
+			out.Step(style.DeletingHost, `Deleting "{{.profile_name}}" in {{.driver_name}} ...`, out.V{"profile_name": profile.Name, "driver_name": profile.Config.Driver})
 			for _, n := range profile.Config.Nodes {
 				machineName := driver.MachineName(*profile.Config, n)
 				deletePossibleKicLeftOver(machineName, profile.Config.Driver)
@@ -337,7 +337,7 @@ func deleteProfile(profile *config.Profile) error {
 	if err := deleteContext(profile.Name); err != nil {
 		return err
 	}
-	out.T(style.Deleted, `Removed all traces of the "{{.name}}" cluster.`, out.V{"name": profile.Name})
+	out.Step(style.Deleted, `Removed all traces of the "{{.name}}" cluster.`, out.V{"name": profile.Name})
 	return nil
 }
 
@@ -353,7 +353,7 @@ func deleteHosts(api libmachine.API, cc *config.ClusterConfig) {
 					klog.Infof("Host %s does not exist. Proceeding ahead with cleanup.", machineName)
 				default:
 					out.FailureT("Failed to delete cluster: {{.error}}", out.V{"error": err})
-					out.T(style.Notice, `You may need to manually remove the "{{.name}}" VM from your hypervisor`, out.V{"name": machineName})
+					out.Step(style.Notice, `You may need to manually remove the "{{.name}}" VM from your hypervisor`, out.V{"name": machineName})
 				}
 			}
 		}
@@ -384,7 +384,7 @@ func deleteContext(machineName string) error {
 }
 
 func deleteInvalidProfile(profile *config.Profile) []error {
-	out.T(style.DeletingHost, "Trying to delete invalid profile {{.profile}}", out.V{"profile": profile.Name})
+	out.Step(style.DeletingHost, "Trying to delete invalid profile {{.profile}}", out.V{"profile": profile.Name})
 
 	var errs []error
 	pathToProfile := config.ProfileFolderPath(profile.Name, localpath.MiniPath())
@@ -410,7 +410,7 @@ func profileDeletionErr(cname string, additionalInfo string) error {
 }
 
 func uninstallKubernetes(api libmachine.API, cc config.ClusterConfig, n config.Node, bsName string) error {
-	out.T(style.Resetting, "Uninstalling Kubernetes {{.kubernetes_version}} using {{.bootstrapper_name}} ...", out.V{"kubernetes_version": cc.KubernetesConfig.KubernetesVersion, "bootstrapper_name": bsName})
+	out.Step(style.Resetting, "Uninstalling Kubernetes {{.kubernetes_version}} using {{.bootstrapper_name}} ...", out.V{"kubernetes_version": cc.KubernetesConfig.KubernetesVersion, "bootstrapper_name": bsName})
 	host, err := machine.LoadHost(api, driver.MachineName(cc, n))
 	if err != nil {
 		return DeletionError{Err: fmt.Errorf("unable to load host: %v", err), Errtype: MissingCluster}
@@ -488,7 +488,7 @@ func handleMultipleDeletionErrors(errors []error) {
 func deleteProfileDirectory(profile string) {
 	machineDir := filepath.Join(localpath.MiniPath(), "machines", profile)
 	if _, err := os.Stat(machineDir); err == nil {
-		out.T(style.DeletingHost, `Removing {{.directory}} ...`, out.V{"directory": machineDir})
+		out.Step(style.DeletingHost, `Removing {{.directory}} ...`, out.V{"directory": machineDir})
 		err := os.RemoveAll(machineDir)
 		if err != nil {
 			exit.Error(reason.GuestProfileDeletion, "Unable to remove machine directory", err)

--- a/cmd/minikube/cmd/generate-docs.go
+++ b/cmd/minikube/cmd/generate-docs.go
@@ -47,7 +47,7 @@ var generateDocs = &cobra.Command{
 		if err := generate.Docs(RootCmd, path); err != nil {
 			exit.Error(reason.InternalGenerateDocs, "Unable to generate docs", err)
 		}
-		out.T(style.Documentation, "Docs have been saved at - {{.path}}", out.V{"path": path})
+		out.Step(style.Documentation, "Docs have been saved at - {{.path}}", out.V{"path": path})
 	},
 }
 

--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -154,7 +154,7 @@ var mountCmd = &cobra.Command{
 		if driver.IsKIC(co.CP.Host.Driver.DriverName()) && runtime.GOOS != "linux" {
 			bindIP = "127.0.0.1"
 		}
-		out.T(style.Mounting, "Mounting host path {{.sourcePath}} into VM as {{.destinationPath}} ...", out.V{"sourcePath": hostPath, "destinationPath": vmPath})
+		out.Step(style.Mounting, "Mounting host path {{.sourcePath}} into VM as {{.destinationPath}} ...", out.V{"sourcePath": hostPath, "destinationPath": vmPath})
 		out.Infof("Mount type:   {{.name}}", out.V{"type": cfg.Type})
 		out.Infof("User ID:      {{.userID}}", out.V{"userID": cfg.UID})
 		out.Infof("Group ID:     {{.groupID}}", out.V{"groupID": cfg.GID})
@@ -168,9 +168,9 @@ var mountCmd = &cobra.Command{
 		if cfg.Type == nineP {
 			wg.Add(1)
 			go func() {
-				out.T(style.Fileserver, "Userspace file server: ")
+				out.Step(style.Fileserver, "Userspace file server: ")
 				ufs.StartServer(net.JoinHostPort(bindIP, strconv.Itoa(port)), debugVal, hostPath)
-				out.T(style.Stopped, "Userspace file server is shutdown")
+				out.Step(style.Stopped, "Userspace file server is shutdown")
 				wg.Done()
 			}()
 		}
@@ -180,7 +180,7 @@ var mountCmd = &cobra.Command{
 		signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 		go func() {
 			for sig := range c {
-				out.T(style.Unmount, "Unmounting {{.path}} ...", out.V{"path": vmPath})
+				out.Step(style.Unmount, "Unmounting {{.path}} ...", out.V{"path": vmPath})
 				err := cluster.Unmount(co.CP.Runner, vmPath)
 				if err != nil {
 					out.FailureT("Failed unmount: {{.error}}", out.V{"error": err})
@@ -193,9 +193,9 @@ var mountCmd = &cobra.Command{
 		if err != nil {
 			exit.Error(reason.GuestMount, "mount failed", err)
 		}
-		out.T(style.Success, "Successfully mounted {{.sourcePath}} to {{.destinationPath}}", out.V{"sourcePath": hostPath, "destinationPath": vmPath})
+		out.Step(style.Success, "Successfully mounted {{.sourcePath}} to {{.destinationPath}}", out.V{"sourcePath": hostPath, "destinationPath": vmPath})
 		out.Ln("")
-		out.T(style.Notice, "NOTE: This process must stay alive for the mount to be accessible ...")
+		out.Step(style.Notice, "NOTE: This process must stay alive for the mount to be accessible ...")
 		wg.Wait()
 	},
 }

--- a/cmd/minikube/cmd/node_add.go
+++ b/cmd/minikube/cmd/node_add.go
@@ -48,7 +48,7 @@ var nodeAddCmd = &cobra.Command{
 
 		name := node.Name(len(cc.Nodes) + 1)
 
-		out.T(style.Happy, "Adding node {{.name}} to cluster {{.cluster}}", out.V{"name": name, "cluster": cc.Name})
+		out.Step(style.Happy, "Adding node {{.name}} to cluster {{.cluster}}", out.V{"name": name, "cluster": cc.Name})
 
 		// TODO: Deal with parameters better. Ideally we should be able to acceot any node-specific minikube start params here.
 		n := config.Node{
@@ -77,7 +77,7 @@ var nodeAddCmd = &cobra.Command{
 			exit.Error(reason.HostSaveProfile, "failed to save config", err)
 		}
 
-		out.T(style.Ready, "Successfully added {{.name}} to {{.cluster}}!", out.V{"name": name, "cluster": cc.Name})
+		out.Step(style.Ready, "Successfully added {{.name}} to {{.cluster}}!", out.V{"name": name, "cluster": cc.Name})
 	},
 }
 

--- a/cmd/minikube/cmd/node_delete.go
+++ b/cmd/minikube/cmd/node_delete.go
@@ -38,7 +38,7 @@ var nodeDeleteCmd = &cobra.Command{
 		name := args[0]
 
 		co := mustload.Healthy(ClusterFlagValue())
-		out.T(style.DeletingHost, "Deleting node {{.name}} from cluster {{.cluster}}", out.V{"name": name, "cluster": co.Config.Name})
+		out.Step(style.DeletingHost, "Deleting node {{.name}} from cluster {{.cluster}}", out.V{"name": name, "cluster": co.Config.Name})
 
 		n, err := node.Delete(*co.Config, name)
 		if err != nil {
@@ -50,7 +50,7 @@ var nodeDeleteCmd = &cobra.Command{
 			deletePossibleKicLeftOver(machineName, co.Config.Driver)
 		}
 
-		out.T(style.Deleted, "Node {{.name}} was successfully deleted.", out.V{"name": name})
+		out.Step(style.Deleted, "Node {{.name}} was successfully deleted.", out.V{"name": name})
 	},
 }
 

--- a/cmd/minikube/cmd/node_start.go
+++ b/cmd/minikube/cmd/node_start.go
@@ -50,7 +50,7 @@ var nodeStartCmd = &cobra.Command{
 
 		machineName := driver.MachineName(*cc, *n)
 		if machine.IsRunning(api, machineName) {
-			out.T(style.Check, "{{.name}} is already running", out.V{"name": name})
+			out.Step(style.Check, "{{.name}} is already running", out.V{"name": name})
 			os.Exit(0)
 		}
 
@@ -77,7 +77,7 @@ var nodeStartCmd = &cobra.Command{
 				exit.Error(reason.GuestNodeStart, "failed to start node", err)
 			}
 		}
-		out.T(style.Happy, "Successfully started node {{.name}}!", out.V{"name": machineName})
+		out.Step(style.Happy, "Successfully started node {{.name}}!", out.V{"name": machineName})
 	},
 }
 

--- a/cmd/minikube/cmd/node_stop.go
+++ b/cmd/minikube/cmd/node_stop.go
@@ -51,7 +51,7 @@ var nodeStopCmd = &cobra.Command{
 		if err != nil {
 			out.FatalT("Failed to stop node {{.name}}", out.V{"name": name})
 		}
-		out.T(style.Stopped, "Successfully stopped node {{.name}}", out.V{"name": machineName})
+		out.Step(style.Stopped, "Successfully stopped node {{.name}}", out.V{"name": machineName})
 	},
 }
 

--- a/cmd/minikube/cmd/pause.go
+++ b/cmd/minikube/cmd/pause.go
@@ -71,7 +71,7 @@ func runPause(cmd *cobra.Command, args []string) {
 			name = co.Config.Name
 		}
 
-		out.T(style.Pause, "Pausing node {{.name}} ... ", out.V{"name": name})
+		out.Step(style.Pause, "Pausing node {{.name}} ... ", out.V{"name": name})
 
 		host, err := machine.LoadHost(co.API, driver.MachineName(*co.Config, n))
 		if err != nil {
@@ -97,9 +97,9 @@ func runPause(cmd *cobra.Command, args []string) {
 
 	register.Reg.SetStep(register.Done)
 	if namespaces == nil {
-		out.T(style.Unpause, "Paused {{.count}} containers", out.V{"count": len(ids)})
+		out.Step(style.Unpause, "Paused {{.count}} containers", out.V{"count": len(ids)})
 	} else {
-		out.T(style.Unpause, "Paused {{.count}} containers in: {{.namespaces}}", out.V{"count": len(ids), "namespaces": strings.Join(namespaces, ", ")})
+		out.Step(style.Unpause, "Paused {{.count}} containers in: {{.namespaces}}", out.V{"count": len(ids), "namespaces": strings.Join(namespaces, ", ")})
 	}
 }
 

--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -164,7 +164,7 @@ func openURLs(svc string, urls []string) {
 			continue
 		}
 
-		out.T(style.Celebrate, "Opening service {{.namespace_name}}/{{.service_name}} in default browser...", out.V{"namespace_name": namespace, "service_name": svc})
+		out.Step(style.Celebrate, "Opening service {{.namespace_name}}/{{.service_name}} in default browser...", out.V{"namespace_name": namespace, "service_name": svc})
 		if err := browser.OpenURL(u); err != nil {
 			exit.Error(reason.HostBrowser, fmt.Sprintf("open url failed: %s", u), err)
 		}

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -295,7 +295,7 @@ func provisionWithDriver(cmd *cobra.Command, ds registry.DriverState, existing *
 
 	// This is about as far as we can go without overwriting config files
 	if viper.GetBool(dryRun) {
-		out.T(style.DryRun, `dry-run validation complete!`)
+		out.Step(style.DryRun, `dry-run validation complete!`)
 		os.Exit(0)
 	}
 
@@ -395,7 +395,7 @@ func startWithDriver(cmd *cobra.Command, starter node.Starter, existing *config.
 
 func warnAboutMultiNode() {
 	out.WarningT("Multi-node clusters are currently experimental and might exhibit unintended behavior.")
-	out.T(style.Documentation, "To track progress on multi-node clusters, see https://github.com/kubernetes/minikube/issues/7538.")
+	out.Step(style.Documentation, "To track progress on multi-node clusters, see https://github.com/kubernetes/minikube/issues/7538.")
 }
 
 func updateDriver(driverName string) {
@@ -414,7 +414,7 @@ func displayVersion(version string) {
 	}
 
 	register.Reg.SetStep(register.InitialSetup)
-	out.T(style.Happy, "{{.prefix}}minikube {{.version}} on {{.platform}}", out.V{"prefix": prefix, "version": version, "platform": platform()})
+	out.Step(style.Happy, "{{.prefix}}minikube {{.version}} on {{.platform}}", out.V{"prefix": prefix, "version": version, "platform": platform()})
 }
 
 // displayEnviron makes the user aware of environment variables that will affect how minikube operates
@@ -434,15 +434,15 @@ func showKubectlInfo(kcs *kubeconfig.Settings, k8sVersion string, machineName st
 	defer func() {
 		register.Reg.SetStep(register.Done)
 		if kcs.KeepContext {
-			out.T(style.Kubectl, "To connect to this cluster, use:  --context={{.name}}", out.V{"name": kcs.ClusterName})
+			out.Step(style.Kubectl, "To connect to this cluster, use:  --context={{.name}}", out.V{"name": kcs.ClusterName})
 		} else {
-			out.T(style.Ready, `Done! kubectl is now configured to use "{{.name}}" cluster and "{{.ns}}" namespace by default`, out.V{"name": machineName, "ns": kcs.Namespace})
+			out.Step(style.Ready, `Done! kubectl is now configured to use "{{.name}}" cluster and "{{.ns}}" namespace by default`, out.V{"name": machineName, "ns": kcs.Namespace})
 		}
 	}()
 
 	path, err := exec.LookPath("kubectl")
 	if err != nil {
-		out.T(style.Tip, "kubectl not found. If you need it, try: 'minikube kubectl -- get pods -A'")
+		out.Step(style.Tip, "kubectl not found. If you need it, try: 'minikube kubectl -- get pods -A'")
 		return nil
 	}
 
@@ -464,7 +464,7 @@ func showKubectlInfo(kcs *kubeconfig.Settings, k8sVersion string, machineName st
 		out.Ln("")
 		out.WarningT("{{.path}} is version {{.client_version}}, which may have incompatibilites with Kubernetes {{.cluster_version}}.",
 			out.V{"path": path, "client_version": client, "cluster_version": cluster})
-		out.T(style.Tip, "Want kubectl {{.version}}? Try 'minikube kubectl -- get pods -A'", out.V{"version": k8sVersion})
+		out.Step(style.Tip, "Want kubectl {{.version}}? Try 'minikube kubectl -- get pods -A'", out.V{"version": k8sVersion})
 	}
 	return nil
 }
@@ -551,7 +551,7 @@ func selectDriver(existing *config.ClusterConfig) (registry.DriverState, []regis
 	if existing != nil {
 		old := hostDriver(existing)
 		ds := driver.Status(old)
-		out.T(style.Sparkle, `Using the {{.driver}} driver based on existing profile`, out.V{"driver": ds.String()})
+		out.Step(style.Sparkle, `Using the {{.driver}} driver based on existing profile`, out.V{"driver": ds.String()})
 		return ds, nil, true
 	}
 
@@ -571,7 +571,7 @@ func selectDriver(existing *config.ClusterConfig) (registry.DriverState, []regis
 		if ds.Name == "" {
 			exit.Message(reason.DrvUnsupportedOS, "The driver '{{.driver}}' is not supported on {{.os}}", out.V{"driver": d, "os": runtime.GOOS})
 		}
-		out.T(style.Sparkle, `Using the {{.driver}} driver based on user configuration`, out.V{"driver": ds.String()})
+		out.Step(style.Sparkle, `Using the {{.driver}} driver based on user configuration`, out.V{"driver": ds.String()})
 		return ds, nil, true
 	}
 
@@ -581,14 +581,14 @@ func selectDriver(existing *config.ClusterConfig) (registry.DriverState, []regis
 		if ds.Name == "" {
 			exit.Message(reason.DrvUnsupportedOS, "The driver '{{.driver}}' is not supported on {{.os}}", out.V{"driver": d, "os": runtime.GOOS})
 		}
-		out.T(style.Sparkle, `Using the {{.driver}} driver based on user configuration`, out.V{"driver": ds.String()})
+		out.Step(style.Sparkle, `Using the {{.driver}} driver based on user configuration`, out.V{"driver": ds.String()})
 		return ds, nil, true
 	}
 
 	choices := driver.Choices(viper.GetBool("vm"))
 	pick, alts, rejects := driver.Suggest(choices)
 	if pick.Name == "" {
-		out.T(style.ThumbsDown, "Unable to pick a default driver. Here is what was considered, in preference order:")
+		out.Step(style.ThumbsDown, "Unable to pick a default driver. Here is what was considered, in preference order:")
 		for _, r := range rejects {
 			out.Infof("{{ .name }}: {{ .rejection }}", out.V{"name": r.Name, "rejection": r.Rejection})
 		}
@@ -600,9 +600,9 @@ func selectDriver(existing *config.ClusterConfig) (registry.DriverState, []regis
 		for _, a := range alts {
 			altNames = append(altNames, a.String())
 		}
-		out.T(style.Sparkle, `Automatically selected the {{.driver}} driver. Other choices: {{.alternates}}`, out.V{"driver": pick.Name, "alternates": strings.Join(altNames, ", ")})
+		out.Step(style.Sparkle, `Automatically selected the {{.driver}} driver. Other choices: {{.alternates}}`, out.V{"driver": pick.Name, "alternates": strings.Join(altNames, ", ")})
 	} else {
-		out.T(style.Sparkle, `Automatically selected the {{.driver}} driver`, out.V{"driver": pick.String()})
+		out.Step(style.Sparkle, `Automatically selected the {{.driver}} driver`, out.V{"driver": pick.String()})
 	}
 	return pick, alts, false
 }
@@ -691,7 +691,7 @@ func validateDriver(ds registry.DriverState, existing *config.ClusterConfig) {
 	klog.Infof("status for %s: %+v", name, st)
 
 	if st.NeedsImprovement {
-		out.T(style.Improvement, `For improved {{.driver}} performance, {{.fix}}`, out.V{"driver": driver.FullName(ds.Name), "fix": translate.T(st.Fix)})
+		out.Step(style.Improvement, `For improved {{.driver}} performance, {{.fix}}`, out.V{"driver": driver.FullName(ds.Name), "fix": translate.T(st.Fix)})
 	}
 
 	if st.Error == nil {
@@ -956,7 +956,7 @@ func validateCPUCount(drvName string) {
 
 	si, err := oci.CachedDaemonInfo(drvName)
 	if err != nil {
-		out.T(style.Confused, "Failed to verify '{{.driver_name}} info' will try again ...", out.V{"driver_name": drvName})
+		out.Step(style.Confused, "Failed to verify '{{.driver_name}} info' will try again ...", out.V{"driver_name": drvName})
 		si, err = oci.DaemonInfo(drvName)
 		if err != nil {
 			exit.Message(reason.Usage, "Ensure your {{.driver_name}} is running and is healthy.", out.V{"driver_name": driver.FullName(drvName)})
@@ -1208,7 +1208,7 @@ func validateKubernetesVersion(old *config.ClusterConfig) {
 
 	}
 	if defaultVersion.GT(nvs) {
-		out.T(style.New, "Kubernetes {{.new}} is now available. If you would like to upgrade, specify: --kubernetes-version={{.prefix}}{{.new}}", out.V{"prefix": version.VersionPrefix, "new": defaultVersion})
+		out.Step(style.New, "Kubernetes {{.new}} is now available. If you would like to upgrade, specify: --kubernetes-version={{.prefix}}{{.new}}", out.V{"prefix": version.VersionPrefix, "new": defaultVersion})
 	}
 }
 

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -276,7 +276,7 @@ func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k
 		}
 
 		if cmd.Flags().Changed(imageRepository) || cmd.Flags().Changed(imageMirrorCountry) {
-			out.T(style.Success, "Using image repository {{.name}}", out.V{"name": repository})
+			out.Step(style.Success, "Using image repository {{.name}}", out.V{"name": repository})
 		}
 
 		// Backwards compatibility with --enable-default-cni

--- a/cmd/minikube/cmd/stop.go
+++ b/cmd/minikube/cmd/stop.go
@@ -95,7 +95,7 @@ func runStop(cmd *cobra.Command, args []string) {
 
 	register.Reg.SetStep(register.Done)
 	if stoppedNodes > 0 {
-		out.T(style.Stopped, `{{.count}} nodes stopped.`, out.V{"count": stoppedNodes})
+		out.Step(style.Stopped, `{{.count}} nodes stopped.`, out.V{"count": stoppedNodes})
 	}
 }
 
@@ -141,7 +141,7 @@ func stop(api libmachine.API, machineName string) bool {
 
 		switch err := errors.Cause(err).(type) {
 		case mcnerror.ErrHostDoesNotExist:
-			out.T(style.Meh, `"{{.machineName}}" does not exist, nothing to stop`, out.V{"machineName": machineName})
+			out.Step(style.Meh, `"{{.machineName}}" does not exist, nothing to stop`, out.V{"machineName": machineName})
 			nonexistent = true
 			return nil
 		default:

--- a/cmd/minikube/cmd/unpause.go
+++ b/cmd/minikube/cmd/unpause.go
@@ -69,7 +69,7 @@ var unpauseCmd = &cobra.Command{
 				name = co.Config.Name
 			}
 
-			out.T(style.Pause, "Unpausing node {{.name}} ... ", out.V{"name": name})
+			out.Step(style.Pause, "Unpausing node {{.name}} ... ", out.V{"name": name})
 
 			machineName := driver.MachineName(*co.Config, n)
 			host, err := machine.LoadHost(co.API, machineName)
@@ -97,9 +97,9 @@ var unpauseCmd = &cobra.Command{
 		register.Reg.SetStep(register.Done)
 
 		if namespaces == nil {
-			out.T(style.Pause, "Unpaused {{.count}} containers", out.V{"count": len(ids)})
+			out.Step(style.Pause, "Unpaused {{.count}} containers", out.V{"count": len(ids)})
 		} else {
-			out.T(style.Pause, "Unpaused {{.count}} containers in: {{.namespaces}}", out.V{"count": len(ids), "namespaces": strings.Join(namespaces, ", ")})
+			out.Step(style.Pause, "Unpaused {{.count}} containers in: {{.namespaces}}", out.V{"count": len(ids), "namespaces": strings.Join(namespaces, ", ")})
 		}
 	},
 }

--- a/cmd/minikube/cmd/update-context.go
+++ b/cmd/minikube/cmd/update-context.go
@@ -41,15 +41,15 @@ var updateContextCmd = &cobra.Command{
 			exit.Error(reason.HostKubeconfigUpdate, "update config", err)
 		}
 		if updated {
-			out.T(style.Celebrate, `"{{.context}}" context has been updated to point to {{.hostname}}:{{.port}}`, out.V{"context": cname, "hostname": co.CP.Hostname, "port": co.CP.Port})
+			out.Step(style.Celebrate, `"{{.context}}" context has been updated to point to {{.hostname}}:{{.port}}`, out.V{"context": cname, "hostname": co.CP.Hostname, "port": co.CP.Port})
 		} else {
-			out.T(style.Meh, `No changes required for the "{{.context}}" context`, out.V{"context": cname})
+			out.Step(style.Meh, `No changes required for the "{{.context}}" context`, out.V{"context": cname})
 		}
 
 		if err := kubeconfig.SetCurrentContext(cname, kubeconfig.PathFromEnv()); err != nil {
 			out.ErrT(style.Sad, `Error while setting kubectl current context:  {{.error}}`, out.V{"error": err})
 		} else {
-			out.T(style.Kubectl, `Current context is "{{.context}}"`, out.V{"context": cname})
+			out.Step(style.Kubectl, `Current context is "{{.context}}"`, out.V{"context": cname})
 		}
 	},
 }

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -195,8 +195,8 @@ https://github.com/kubernetes/minikube/issues/7332`, out.V{"driver_name": cc.Dri
 			if err != nil {
 				return errors.Wrap(err, "registry port")
 			}
-			out.T(style.Tip, `Registry addon on with {{.driver}} uses {{.port}} please use that instead of default 5000`, out.V{"driver": cc.Driver, "port": port})
-			out.T(style.Documentation, `For more information see: https://minikube.sigs.k8s.io/docs/drivers/{{.driver}}`, out.V{"driver": cc.Driver})
+			out.Step(style.Tip, `Registry addon on with {{.driver}} uses {{.port}} please use that instead of default 5000`, out.V{"driver": cc.Driver, "port": port})
+			out.Step(style.Documentation, `For more information see: https://minikube.sigs.k8s.io/docs/drivers/{{.driver}}`, out.V{"driver": cc.Driver})
 		}
 	}
 
@@ -331,8 +331,8 @@ func verifyGCPAuthAddon(cc *config.ClusterConfig, name string, val string) error
 	err = verifyAddonStatusInternal(cc, name, val, "gcp-auth")
 
 	if enable && err == nil {
-		out.T(style.Notice, "Your GCP credentials will now be mounted into every pod created in the {{.name}} cluster.", out.V{"name": cc.Name})
-		out.T(style.Notice, "If you don't want your credentials mounted into a specific pod, add a label with the `gcp-auth-skip-secret` key to your pod configuration.")
+		out.Step(style.Notice, "Your GCP credentials will now be mounted into every pod created in the {{.name}} cluster.", out.V{"name": cc.Name})
+		out.Step(style.Notice, "If you don't want your credentials mounted into a specific pod, add a label with the `gcp-auth-skip-secret` key to your pod configuration.")
 	}
 
 	return err
@@ -347,7 +347,7 @@ func verifyAddonStatusInternal(cc *config.ClusterConfig, name string, val string
 
 	label, ok := addonPodLabels[name]
 	if ok && enable {
-		out.T(style.HealthCheck, "Verifying {{.addon_name}} addon...", out.V{"addon_name": name})
+		out.Step(style.HealthCheck, "Verifying {{.addon_name}} addon...", out.V{"addon_name": name})
 		client, err := kapi.Client(viper.GetString(config.ProfileName))
 		if err != nil {
 			return errors.Wrapf(err, "get kube-client to validate %s addon: %v", name, err)
@@ -410,7 +410,7 @@ func Start(wg *sync.WaitGroup, cc *config.ClusterConfig, toEnable map[string]boo
 
 	defer func() { // making it show after verifications (see #7613)
 		register.Reg.SetStep(register.EnablingAddons)
-		out.T(style.AddonEnable, "Enabled addons: {{.addons}}", out.V{"addons": strings.Join(enabledAddons, ", ")})
+		out.Step(style.AddonEnable, "Enabled addons: {{.addons}}", out.V{"addons": strings.Join(enabledAddons, ", ")})
 	}()
 	for _, a := range toEnableList {
 		awg.Add(1)

--- a/pkg/addons/gcpauth/enable.go
+++ b/pkg/addons/gcpauth/enable.go
@@ -85,7 +85,7 @@ func enableAddon(cfg *config.ClusterConfig) error {
 	}
 
 	out.WarningT("Could not determine a Google Cloud project, which might be ok.")
-	out.T(style.Tip, `To set your Google Cloud project,  run: 
+	out.Step(style.Tip, `To set your Google Cloud project,  run: 
 
 		gcloud config set project <project name>
 

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -283,7 +283,7 @@ func (k *Bootstrapper) applyCNI(cfg config.ClusterConfig) error {
 		return nil
 	}
 
-	out.T(style.CNI, "Configuring {{.name}} (Container Networking Interface) ...", out.V{"name": cnm.String()})
+	out.Step(style.CNI, "Configuring {{.name}} (Container Networking Interface) ...", out.V{"name": cnm.String()})
 
 	if err := cnm.Apply(k.c); err != nil {
 		return errors.Wrap(err, "cni apply")
@@ -393,7 +393,7 @@ func (k *Bootstrapper) client(ip string, port int) (*kubernetes.Clientset, error
 func (k *Bootstrapper) WaitForNode(cfg config.ClusterConfig, n config.Node, timeout time.Duration) error {
 	start := time.Now()
 	register.Reg.SetStep(register.VerifyingKubernetes)
-	out.T(style.HealthCheck, "Verifying Kubernetes components...")
+	out.Step(style.HealthCheck, "Verifying Kubernetes components...")
 	// regardless if waiting is set or not, we will make sure kubelet is not stopped
 	// to solve corner cases when a container is hibernated and once coming back kubelet not running.
 	if err := k.ensureServiceStarted("kubelet"); err != nil {
@@ -968,16 +968,16 @@ func adviseNodePressure(err error, name string, drv string) {
 		klog.Warning(diskErr)
 		out.WarningT("The node {{.name}} has ran out of disk space.", out.V{"name": name})
 		// generic advice for all drivers
-		out.T(style.Tip, "Please free up disk or prune images.")
+		out.Step(style.Tip, "Please free up disk or prune images.")
 		if driver.IsVM(drv) {
-			out.T(style.Stopped, "Please create a cluster with bigger disk size: `minikube start --disk SIZE_MB` ")
+			out.Step(style.Stopped, "Please create a cluster with bigger disk size: `minikube start --disk SIZE_MB` ")
 		} else if drv == oci.Docker && runtime.GOOS != "linux" {
-			out.T(style.Stopped, "Please increse Desktop's disk size.")
+			out.Step(style.Stopped, "Please increse Desktop's disk size.")
 			if runtime.GOOS == "darwin" {
-				out.T(style.Documentation, "Documentation: {{.url}}", out.V{"url": "https://docs.docker.com/docker-for-mac/space/"})
+				out.Step(style.Documentation, "Documentation: {{.url}}", out.V{"url": "https://docs.docker.com/docker-for-mac/space/"})
 			}
 			if runtime.GOOS == "windows" {
-				out.T(style.Documentation, "Documentation: {{.url}}", out.V{"url": "https://docs.docker.com/docker-for-windows/"})
+				out.Step(style.Documentation, "Documentation: {{.url}}", out.V{"url": "https://docs.docker.com/docker-for-windows/"})
 			}
 		}
 		out.ErrLn("")
@@ -988,16 +988,16 @@ func adviseNodePressure(err error, name string, drv string) {
 		out.ErrLn("")
 		klog.Warning(memErr)
 		out.WarningT("The node {{.name}} has ran out of memory.", out.V{"name": name})
-		out.T(style.Tip, "Check if you have unnecessary pods running by running 'kubectl get po -A")
+		out.Step(style.Tip, "Check if you have unnecessary pods running by running 'kubectl get po -A")
 		if driver.IsVM(drv) {
-			out.T(style.Stopped, "Consider creating a cluster with larger memory size using `minikube start --memory SIZE_MB` ")
+			out.Step(style.Stopped, "Consider creating a cluster with larger memory size using `minikube start --memory SIZE_MB` ")
 		} else if drv == oci.Docker && runtime.GOOS != "linux" {
-			out.T(style.Stopped, "Consider increasing Docker Desktop's memory size.")
+			out.Step(style.Stopped, "Consider increasing Docker Desktop's memory size.")
 			if runtime.GOOS == "darwin" {
-				out.T(style.Documentation, "Documentation: {{.url}}", out.V{"url": "https://docs.docker.com/docker-for-mac/space/"})
+				out.Step(style.Documentation, "Documentation: {{.url}}", out.V{"url": "https://docs.docker.com/docker-for-mac/space/"})
 			}
 			if runtime.GOOS == "windows" {
-				out.T(style.Documentation, "Documentation: {{.url}}", out.V{"url": "https://docs.docker.com/docker-for-windows/"})
+				out.Step(style.Documentation, "Documentation: {{.url}}", out.V{"url": "https://docs.docker.com/docker-for-windows/"})
 			}
 		}
 		out.ErrLn("")

--- a/pkg/minikube/browser/browser.go
+++ b/pkg/minikube/browser/browser.go
@@ -30,7 +30,7 @@ func OpenURL(url string) error {
 	if runtime.GOOS == "linux" {
 		_, err := exec.LookPath("xdg-open")
 		if err != nil {
-			out.T(style.URL, url)
+			out.Step(style.URL, url)
 			return nil
 		}
 	}

--- a/pkg/minikube/download/driver.go
+++ b/pkg/minikube/download/driver.go
@@ -33,7 +33,7 @@ func driverWithChecksumURL(name string, v semver.Version) string {
 
 // Driver downloads an arbitrary driver
 func Driver(name string, destination string, v semver.Version) error {
-	out.T(style.FileDownload, "Downloading driver {{.driver}}:", out.V{"driver": name})
+	out.Step(style.FileDownload, "Downloading driver {{.driver}}:", out.V{"driver": name})
 	if err := download(driverWithChecksumURL(name, v), destination); err != nil {
 		return errors.Wrap(err, "download")
 	}

--- a/pkg/minikube/download/iso.go
+++ b/pkg/minikube/download/iso.go
@@ -127,7 +127,7 @@ func downloadISO(isoURL string, skipChecksum bool) error {
 		return nil
 	}
 
-	out.T(style.ISODownload, "Downloading VM boot image ...")
+	out.Step(style.ISODownload, "Downloading VM boot image ...")
 
 	urlWithChecksum := isoURL + "?checksum=file:" + isoURL + ".sha256"
 	if skipChecksum {

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -138,7 +138,7 @@ func Preload(k8sVersion, containerRuntime string) error {
 		return nil
 	}
 
-	out.T(style.FileDownload, "Downloading Kubernetes {{.version}} preload ...", out.V{"version": k8sVersion})
+	out.Step(style.FileDownload, "Downloading Kubernetes {{.version}} preload ...", out.V{"version": k8sVersion})
 	url := remoteTarballURL(k8sVersion, containerRuntime)
 
 	if err := download(url, targetPath); err != nil {

--- a/pkg/minikube/driver/install.go
+++ b/pkg/minikube/driver/install.go
@@ -91,7 +91,7 @@ func fixDriverPermissions(name string, path string, interactive bool) error {
 		example.WriteString(fmt.Sprintf("    $ %s \n", strings.Join(c.Args, " ")))
 	}
 
-	out.T(style.Permissions, "The '{{.driver}}' driver requires elevated permissions. The following commands will be executed:\n\n{{ .example }}\n", out.V{"driver": name, "example": example.String()})
+	out.Step(style.Permissions, "The '{{.driver}}' driver requires elevated permissions. The following commands will be executed:\n\n{{ .example }}\n", out.V{"driver": name, "example": example.String()})
 	for _, c := range cmds {
 		testArgs := append([]string{"-n"}, c.Args[1:]...)
 		test := exec.Command("sudo", testArgs...)

--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -151,7 +151,7 @@ func OutputProblems(problems map[string][]string, maxLines int) {
 			lines = lines[len(lines)-maxLines:]
 		}
 		for _, l := range lines {
-			out.T(style.LogEntry, l)
+			out.Step(style.LogEntry, l)
 		}
 	}
 }
@@ -170,9 +170,9 @@ func Output(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.Cluster
 	failed := []string{}
 	for i, name := range names {
 		if i > 0 {
-			out.T(style.Empty, "")
+			out.Step(style.Empty, "")
 		}
-		out.T(style.Empty, "==> {{.name}} <==", out.V{"name": name})
+		out.Step(style.Empty, "==> {{.name}} <==", out.V{"name": name})
 		var b bytes.Buffer
 		c := exec.Command("/bin/bash", "-c", cmds[name])
 		c.Stdout = &b
@@ -184,7 +184,7 @@ func Output(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.Cluster
 		}
 		scanner := bufio.NewScanner(&b)
 		for scanner.Scan() {
-			out.T(style.Empty, scanner.Text())
+			out.Step(style.Empty, scanner.Text())
 		}
 	}
 

--- a/pkg/minikube/machine/advice.go
+++ b/pkg/minikube/machine/advice.go
@@ -38,29 +38,29 @@ func MaybeDisplayAdvice(err error, driver string) {
 	}
 
 	if errors.Is(err, oci.ErrExitedUnexpectedly) || errors.Is(err, oci.ErrDaemonInfo) {
-		out.T(style.Tip, "If you are still interested to make {{.driver_name}} driver work. The following suggestions might help you get passed this issue:", out.V{"driver_name": driver})
+		out.Step(style.Tip, "If you are still interested to make {{.driver_name}} driver work. The following suggestions might help you get passed this issue:", out.V{"driver_name": driver})
 		if driver == oci.Docker || driver == oci.Podman {
 			out.String("\n\t")
-			out.T(style.Empty, `- Prune unused {{.driver_name}} images, volumes, networks and abandoned containers.
+			out.Step(style.Empty, `- Prune unused {{.driver_name}} images, volumes, networks and abandoned containers.
 
 				{{.driver_name}} system prune --volumes`, out.V{"driver_name": driver})
 		}
 		out.String("\n\t")
-		out.T(style.Empty, `- Restart your {{.driver_name}} service`, out.V{"driver_name": driver})
+		out.Step(style.Empty, `- Restart your {{.driver_name}} service`, out.V{"driver_name": driver})
 		if runtime.GOOS != "linux" {
 			out.String("\n\t")
-			out.T(style.Empty, `- Ensure your {{.driver_name}} daemon has access to enough CPU/memory resources.`, out.V{"driver_name": driver})
+			out.Step(style.Empty, `- Ensure your {{.driver_name}} daemon has access to enough CPU/memory resources.`, out.V{"driver_name": driver})
 			if runtime.GOOS == "darwin" && driver == oci.Docker {
 				out.String("\n\t")
-				out.T(style.Empty, `- Docs https://docs.docker.com/docker-for-mac/#resources`, out.V{"driver_name": driver})
+				out.Step(style.Empty, `- Docs https://docs.docker.com/docker-for-mac/#resources`, out.V{"driver_name": driver})
 			}
 			if runtime.GOOS == "windows" && driver == oci.Docker {
 				out.String("\n\t")
-				out.T(style.Empty, `- Docs https://docs.docker.com/docker-for-windows/#resources`, out.V{"driver_name": driver})
+				out.Step(style.Empty, `- Docs https://docs.docker.com/docker-for-windows/#resources`, out.V{"driver_name": driver})
 			}
 		}
 		out.String("\n\t")
-		out.T(style.Empty, `- Delete and recreate minikube cluster
+		out.Step(style.Empty, `- Delete and recreate minikube cluster
 		minikube delete
 		minikube start --driver={{.driver_name}}`, out.V{"driver_name": driver})
 		// TODO #8348: maybe advice user if to set the --force-systemd https://github.com/kubernetes/minikube/issues/8348

--- a/pkg/minikube/machine/delete.go
+++ b/pkg/minikube/machine/delete.go
@@ -96,7 +96,7 @@ func DeleteHost(api libmachine.API, machineName string, deleteAbandoned ...bool)
 		time.Sleep(1 * time.Second)
 	}
 
-	out.T(style.DeletingHost, `Deleting "{{.profile_name}}" in {{.driver_name}} ...`, out.V{"profile_name": machineName, "driver_name": host.DriverName})
+	out.Step(style.DeletingHost, `Deleting "{{.profile_name}}" in {{.driver_name}} ...`, out.V{"profile_name": machineName, "driver_name": host.DriverName})
 	return delete(api, host, machineName)
 }
 

--- a/pkg/minikube/machine/fix.go
+++ b/pkg/minikube/machine/fix.go
@@ -113,7 +113,7 @@ func recreateIfNeeded(api libmachine.API, cc *config.ClusterConfig, n *config.No
 		}
 
 		if !me || err == constants.ErrMachineMissing {
-			out.T(style.Shrug, `{{.driver_name}} "{{.cluster}}" {{.machine_type}} is missing, will recreate.`, out.V{"driver_name": cc.Driver, "cluster": machineName, "machine_type": machineType})
+			out.Step(style.Shrug, `{{.driver_name}} "{{.cluster}}" {{.machine_type}} is missing, will recreate.`, out.V{"driver_name": cc.Driver, "cluster": machineName, "machine_type": machineType})
 			demolish(api, *cc, *n, h)
 
 			klog.Infof("Sleeping 1 second for extra luck!")
@@ -135,13 +135,13 @@ func recreateIfNeeded(api libmachine.API, cc *config.ClusterConfig, n *config.No
 
 	if s == state.Running {
 		if !recreated {
-			out.T(style.Running, `Updating the running {{.driver_name}} "{{.cluster}}" {{.machine_type}} ...`, out.V{"driver_name": cc.Driver, "cluster": machineName, "machine_type": machineType})
+			out.Step(style.Running, `Updating the running {{.driver_name}} "{{.cluster}}" {{.machine_type}} ...`, out.V{"driver_name": cc.Driver, "cluster": machineName, "machine_type": machineType})
 		}
 		return h, nil
 	}
 
 	if !recreated {
-		out.T(style.Restarting, `Restarting existing {{.driver_name}} {{.machine_type}} for "{{.cluster}}" ...`, out.V{"driver_name": cc.Driver, "cluster": machineName, "machine_type": machineType})
+		out.Step(style.Restarting, `Restarting existing {{.driver_name}} {{.machine_type}} for "{{.cluster}}" ...`, out.V{"driver_name": cc.Driver, "cluster": machineName, "machine_type": machineType})
 	}
 	if err := h.Driver.Start(); err != nil {
 		MaybeDisplayAdvice(err, h.DriverName)
@@ -161,7 +161,7 @@ func maybeWarnAboutEvalEnv(drver string, name string) {
 		return
 	}
 	if os.Getenv(constants.MinikubeActiveDockerdEnv) != "" {
-		out.T(style.Notice, "Noticed you have an activated docker-env on {{.driver_name}} driver in this terminal:", out.V{"driver_name": drver})
+		out.Step(style.Notice, "Noticed you have an activated docker-env on {{.driver_name}} driver in this terminal:", out.V{"driver_name": drver})
 		// TODO: refactor docker-env package to generate only eval command per shell. https://github.com/kubernetes/minikube/issues/6887
 		out.WarningT(`Please re-eval your docker-env, To ensure your environment variables have updated ports:
 
@@ -170,7 +170,7 @@ func maybeWarnAboutEvalEnv(drver string, name string) {
 	`, out.V{"profile_name": name})
 	}
 	if os.Getenv(constants.MinikubeActivePodmanEnv) != "" {
-		out.T(style.Notice, "Noticed you have an activated podman-env on {{.driver_name}} driver in this terminal:", out.V{"driver_name": drver})
+		out.Step(style.Notice, "Noticed you have an activated podman-env on {{.driver_name}} driver in this terminal:", out.V{"driver_name": drver})
 		// TODO: refactor podman-env package to generate only eval command per shell. https://github.com/kubernetes/minikube/issues/6887
 		out.WarningT(`Please re-eval your podman-env, To ensure your environment variables have updated ports:
 

--- a/pkg/minikube/machine/info.go
+++ b/pkg/minikube/machine/info.go
@@ -78,7 +78,7 @@ func showLocalOsRelease() {
 	}
 
 	register.Reg.SetStep(register.LocalOSRelease)
-	out.T(style.Provisioner, "OS release is {{.pretty_name}}", out.V{"pretty_name": osReleaseInfo.PrettyName})
+	out.Step(style.Provisioner, "OS release is {{.pretty_name}}", out.V{"pretty_name": osReleaseInfo.PrettyName})
 }
 
 // logRemoteOsRelease shows systemd information about the current linux distribution, on the remote VM

--- a/pkg/minikube/machine/start.go
+++ b/pkg/minikube/machine/start.go
@@ -327,17 +327,17 @@ func showHostInfo(cfg config.ClusterConfig) {
 		info, cpuErr, memErr, DiskErr := CachedHostInfo()
 		if cpuErr == nil && memErr == nil && DiskErr == nil {
 			register.Reg.SetStep(register.RunningLocalhost)
-			out.T(style.StartingNone, "Running on localhost (CPUs={{.number_of_cpus}}, Memory={{.memory_size}}MB, Disk={{.disk_size}}MB) ...", out.V{"number_of_cpus": info.CPUs, "memory_size": info.Memory, "disk_size": info.DiskSize})
+			out.Step(style.StartingNone, "Running on localhost (CPUs={{.number_of_cpus}}, Memory={{.memory_size}}MB, Disk={{.disk_size}}MB) ...", out.V{"number_of_cpus": info.CPUs, "memory_size": info.Memory, "disk_size": info.DiskSize})
 		}
 		return
 	}
 	if driver.IsKIC(cfg.Driver) { // TODO:medyagh add free disk space on docker machine
 		register.Reg.SetStep(register.CreatingContainer)
-		out.T(style.StartingVM, "Creating {{.driver_name}} {{.machine_type}} (CPUs={{.number_of_cpus}}, Memory={{.memory_size}}MB) ...", out.V{"driver_name": cfg.Driver, "number_of_cpus": cfg.CPUs, "memory_size": cfg.Memory, "machine_type": machineType})
+		out.Step(style.StartingVM, "Creating {{.driver_name}} {{.machine_type}} (CPUs={{.number_of_cpus}}, Memory={{.memory_size}}MB) ...", out.V{"driver_name": cfg.Driver, "number_of_cpus": cfg.CPUs, "memory_size": cfg.Memory, "machine_type": machineType})
 		return
 	}
 	register.Reg.SetStep(register.CreatingVM)
-	out.T(style.StartingVM, "Creating {{.driver_name}} {{.machine_type}} (CPUs={{.number_of_cpus}}, Memory={{.memory_size}}MB, Disk={{.disk_size}}MB) ...", out.V{"driver_name": cfg.Driver, "number_of_cpus": cfg.CPUs, "memory_size": cfg.Memory, "disk_size": cfg.DiskSize, "machine_type": machineType})
+	out.Step(style.StartingVM, "Creating {{.driver_name}} {{.machine_type}} (CPUs={{.number_of_cpus}}, Memory={{.memory_size}}MB, Disk={{.disk_size}}MB) ...", out.V{"driver_name": cfg.Driver, "number_of_cpus": cfg.CPUs, "memory_size": cfg.Memory, "disk_size": cfg.DiskSize, "machine_type": machineType})
 }
 
 // AddHostAlias makes fine adjustments to pod resources that aren't possible via kubeadm config.

--- a/pkg/minikube/machine/stop.go
+++ b/pkg/minikube/machine/stop.go
@@ -42,7 +42,7 @@ func StopHost(api libmachine.API, machineName string) error {
 		return errors.Wrapf(err, "load")
 	}
 
-	out.T(style.Stopping, `Stopping node "{{.name}}"  ...`, out.V{"name": machineName})
+	out.Step(style.Stopping, `Stopping node "{{.name}}"  ...`, out.V{"name": machineName})
 	return stop(h)
 }
 
@@ -81,7 +81,7 @@ func trySSHPowerOff(h *host.Host) error {
 	}
 
 	register.Reg.SetStep(register.PowerOff)
-	out.T(style.Shutdown, `Powering off "{{.profile_name}}" via SSH ...`, out.V{"profile_name": h.Name})
+	out.Step(style.Shutdown, `Powering off "{{.profile_name}}" via SSH ...`, out.V{"profile_name": h.Name})
 	// differnet for kic because RunSSHCommand is not implemented by kic
 	if driver.IsKIC(h.DriverName) {
 		err := oci.ShutDown(h.DriverName, h.Name)

--- a/pkg/minikube/mustload/mustload.go
+++ b/pkg/minikube/mustload/mustload.go
@@ -72,7 +72,7 @@ func Partial(name string, miniHome ...string) (libmachine.API, *config.ClusterCo
 	cc, err := config.Load(name, miniHome...)
 	if err != nil {
 		if config.IsNotExist(err) {
-			out.T(style.Shrug, `Profile "{{.cluster}}" not found. Run "minikube profile list" to view all profiles.`, out.V{"cluster": name})
+			out.Step(style.Shrug, `Profile "{{.cluster}}" not found. Run "minikube profile list" to view all profiles.`, out.V{"cluster": name})
 			exitTip("start", name, reason.ExGuestNotFound)
 		}
 		exit.Error(reason.HostConfigLoad, "Error getting cluster config", err)
@@ -97,17 +97,17 @@ func Running(name string) ClusterController {
 	}
 
 	if hs == state.None.String() {
-		out.T(style.Shrug, `The control plane node "{{.name}}" does not exist.`, out.V{"name": cp.Name})
+		out.Step(style.Shrug, `The control plane node "{{.name}}" does not exist.`, out.V{"name": cp.Name})
 		exitTip("start", name, reason.ExGuestNotFound)
 	}
 
 	if hs == state.Stopped.String() {
-		out.T(style.Shrug, `The control plane node must be running for this command`)
+		out.Step(style.Shrug, `The control plane node must be running for this command`)
 		exitTip("start", name, reason.ExGuestUnavailable)
 	}
 
 	if hs != state.Running.String() {
-		out.T(style.Shrug, `The control plane node is not running (state={{.state}})`, out.V{"name": cp.Name, "state": hs})
+		out.Step(style.Shrug, `The control plane node is not running (state={{.state}})`, out.V{"name": cp.Name, "state": hs})
 		exitTip("start", name, reason.ExSvcUnavailable)
 	}
 
@@ -151,12 +151,12 @@ func Healthy(name string) ClusterController {
 	}
 
 	if as == state.Paused {
-		out.T(style.Shrug, `The control plane for "{{.name}}" is paused!`, out.V{"name": name})
+		out.Step(style.Shrug, `The control plane for "{{.name}}" is paused!`, out.V{"name": name})
 		exitTip("unpause", name, reason.ExSvcConfig)
 	}
 
 	if as != state.Running {
-		out.T(style.Shrug, `This control plane is not running! (state={{.state}})`, out.V{"state": as.String()})
+		out.Step(style.Shrug, `This control plane is not running! (state={{.state}})`, out.V{"state": as.String()})
 		out.WarningT(`This is unusual - you may want to investigate using "{{.command}}"`, out.V{"command": ExampleCmd(name, "logs")})
 		exitTip("start", name, reason.ExSvcUnavailable)
 	}
@@ -174,6 +174,6 @@ func ExampleCmd(cname string, action string) string {
 // exitTip returns an action tip and exits
 func exitTip(action string, profile string, code int) {
 	command := ExampleCmd(profile, action)
-	out.T(style.Workaround, `To start a cluster, run: "{{.command}}"`, out.V{"command": command})
+	out.Step(style.Workaround, `To start a cluster, run: "{{.command}}"`, out.V{"command": command})
 	os.Exit(code)
 }

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -119,7 +119,7 @@ func beginDownloadKicBaseImage(g *errgroup.Group, cc *config.ClusterConfig, down
 
 	klog.Infof("Beginning downloading kic base image for %s with %s", cc.Driver, cc.KubernetesConfig.ContainerRuntime)
 	register.Reg.SetStep(register.PullingBaseImage)
-	out.StepT(style.Pulling, "Pulling base image ...")
+	out.Step(style.Pulling, "Pulling base image ...")
 	g.Go(func() error {
 		baseImg := cc.KicBaseImage
 		if baseImg == kic.BaseImage && len(cc.KubernetesConfig.ImageRepository) != 0 {

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -85,7 +85,7 @@ func handleDownloadOnly(cacheGroup, kicGroup *errgroup.Group, k8sVersion string)
 	if err := saveImagesToTarFromConfig(); err != nil {
 		exit.Error(reason.InetCacheTar, "Failed to cache images to tar", err)
 	}
-	out.T(style.Check, "Download complete!")
+	out.Step(style.Check, "Download complete!")
 	os.Exit(0)
 }
 
@@ -117,7 +117,7 @@ func beginDownloadKicBaseImage(g *errgroup.Group, cc *config.ClusterConfig, down
 	}
 
 	klog.Infof("Beginning downloading kic base image for %s with %s", cc.Driver, cc.KubernetesConfig.ContainerRuntime)
-	out.T(style.Pulling, "Pulling base image ...")
+	out.Step(style.Pulling, "Pulling base image ...")
 	g.Go(func() error {
 		baseImg := cc.KicBaseImage
 		if baseImg == kic.BaseImage && len(cc.KubernetesConfig.ImageRepository) != 0 {
@@ -167,7 +167,7 @@ func waitDownloadKicBaseImage(g *errgroup.Group) {
 				klog.Warningf("Error downloading kic artifacts: %v", err)
 				out.ErrT(style.Connectivity, "Unfortunately, could not download the base image {{.image_name}} ", out.V{"image_name": strings.Split(kic.BaseImage, "@")[0]})
 				out.WarningT("In order to use the fall back image, you need to log in to the github packages registry")
-				out.T(style.Documentation, `Please visit the following link for documentation around this: 
+				out.Step(style.Documentation, `Please visit the following link for documentation around this: 
 	https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages#authenticating-to-github-packages
 `)
 			}

--- a/pkg/minikube/node/config.go
+++ b/pkg/minikube/node/config.go
@@ -41,7 +41,7 @@ import (
 func showVersionInfo(k8sVersion string, cr cruntime.Manager) {
 	version, _ := cr.Version()
 	register.Reg.SetStep(register.PreparingKubernetes)
-	out.T(cr.Style(), "Preparing Kubernetes {{.k8sVersion}} on {{.runtime}} {{.runtimeVersion}} ...", out.V{"k8sVersion": k8sVersion, "runtime": cr.Name(), "runtimeVersion": version})
+	out.Step(cr.Style(), "Preparing Kubernetes {{.k8sVersion}} on {{.runtime}} {{.runtimeVersion}} ...", out.V{"k8sVersion": k8sVersion, "runtime": cr.Name(), "runtimeVersion": version})
 	for _, v := range config.DockerOpt {
 		out.Infof("opt {{.docker_option}}", out.V{"docker_option": v})
 	}
@@ -59,7 +59,7 @@ func configureMounts(wg *sync.WaitGroup) {
 		return
 	}
 
-	out.T(style.Mounting, "Creating mount {{.name}} ...", out.V{"name": viper.GetString(mountString)})
+	out.Step(style.Mounting, "Creating mount {{.name}} ...", out.V{"name": viper.GetString(mountString)})
 	path := os.Args[0]
 	mountDebugVal := 0
 	if klog.V(8).Enabled() {

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -212,9 +212,9 @@ func Provision(cc *config.ClusterConfig, n *config.Node, apiServer bool, delOnFa
 	register.Reg.SetStep(register.StartingNode)
 	name := driver.MachineName(*cc, *n)
 	if apiServer {
-		out.T(style.ThumbsUp, "Starting control plane node {{.name}} in cluster {{.cluster}}", out.V{"name": name, "cluster": cc.Name})
+		out.Step(style.ThumbsUp, "Starting control plane node {{.name}} in cluster {{.cluster}}", out.V{"name": name, "cluster": cc.Name})
 	} else {
-		out.T(style.ThumbsUp, "Starting node {{.name}} in cluster {{.cluster}}", out.V{"name": name, "cluster": cc.Name})
+		out.Step(style.ThumbsUp, "Starting node {{.name}} in cluster {{.cluster}}", out.V{"name": name, "cluster": cc.Name})
 	}
 
 	if driver.IsKIC(cc.Driver) {
@@ -425,7 +425,7 @@ func validateNetwork(h *host.Host, r command.Runner, imageRepository string) (st
 	for _, k := range proxy.EnvVars {
 		if v := os.Getenv(k); v != "" {
 			if !optSeen {
-				out.T(style.Internet, "Found network options:")
+				out.Step(style.Internet, "Found network options:")
 				optSeen = true
 			}
 			out.Infof("{{.key}}={{.value}}", out.V{"key": k, "value": v})
@@ -433,7 +433,7 @@ func validateNetwork(h *host.Host, r command.Runner, imageRepository string) (st
 			k = strings.ToUpper(k)               // for http_proxy & https_proxy
 			if (k == "HTTP_PROXY" || k == "HTTPS_PROXY") && !ipExcluded && !warnedOnce {
 				out.WarningT("You appear to be using a proxy, but your NO_PROXY environment does not include the minikube IP ({{.ip_address}}).", out.V{"ip_address": ip})
-				out.T(style.Documentation, "Please see {{.documentation_url}} for more details", out.V{"documentation_url": "https://minikube.sigs.k8s.io/docs/handbook/vpn_and_proxy/"})
+				out.Step(style.Documentation, "Please see {{.documentation_url}} for more details", out.V{"documentation_url": "https://minikube.sigs.k8s.io/docs/handbook/vpn_and_proxy/"})
 				warnedOnce = true
 			}
 		}
@@ -515,7 +515,7 @@ func tryRegistry(r command.Runner, driverName string, imageRepository string) {
 // prepareNone prepares the user and host for the joy of the "none" driver
 func prepareNone() {
 	register.Reg.SetStep(register.ConfiguringLHEnv)
-	out.T(style.StartingNone, "Configuring local host environment ...")
+	out.Step(style.StartingNone, "Configuring local host environment ...")
 	if viper.GetBool(config.WantNoneDriverWarning) {
 		out.ErrT(style.Empty, "")
 		out.WarningT("The 'none' driver is designed for experts who need to integrate with an existing VM")

--- a/pkg/minikube/notify/notify.go
+++ b/pkg/minikube/notify/notify.go
@@ -67,8 +67,8 @@ func MaybePrintUpdateText(url string, lastUpdatePath string) bool {
 			klog.Errorf("write time failed: %v", err)
 		}
 		url := "https://github.com/kubernetes/minikube/releases/tag/v" + latestVersion.String()
-		out.T(style.Celebrate, `minikube {{.version}} is available! Download it: {{.url}}`, out.V{"version": latestVersion, "url": url})
-		out.T(style.Tip, "To disable this notice, run: 'minikube config set WantUpdateNotification false'\n")
+		out.Step(style.Celebrate, `minikube {{.version}} is available! Download it: {{.url}}`, out.V{"version": latestVersion, "url": url})
+		out.Step(style.Tip, "To disable this notice, run: 'minikube config set WantUpdateNotification false'\n")
 		return true
 	}
 	return false

--- a/pkg/minikube/out/out.go
+++ b/pkg/minikube/out/out.go
@@ -40,7 +40,7 @@ import (
 //
 // out.SetOutFile(os.Stdout)
 // out.String("Starting up!")
-// out.T(style.StatusChange, "Configuring things")
+// out.Step(style.StatusChange, "Configuring things")
 
 // out.SetErrFile(os.Stderr)
 // out.Fatal("Oh no, everything failed.")

--- a/pkg/minikube/out/out.go
+++ b/pkg/minikube/out/out.go
@@ -72,8 +72,8 @@ type fdWriter interface {
 // V is a convenience wrapper for templating, it represents the variable key/value pair.
 type V map[string]interface{}
 
-// T writes a stylized and templated message to stdout
-func T(st style.Enum, format string, a ...V) {
+// Step writes a stylized and templated message to stdout
+func Step(st style.Enum, format string, a ...V) {
 	if st == style.Option {
 		Infof(format, a...)
 		return
@@ -158,7 +158,7 @@ func ErrLn(format string, a ...interface{}) {
 
 // SuccessT is a shortcut for writing a templated success message to stdout
 func SuccessT(format string, a ...V) {
-	T(style.Success, format, a...)
+	Step(style.Success, format, a...)
 }
 
 // FatalT is a shortcut for writing a templated fatal message to stderr
@@ -243,12 +243,12 @@ func LogEntries(msg string, err error, entries map[string][]string) {
 	DisplayError(msg, err)
 
 	for name, lines := range entries {
-		T(style.Failure, "Problems detected in {{.entry}}:", V{"entry": name})
+		Step(style.Failure, "Problems detected in {{.entry}}:", V{"entry": name})
 		if len(lines) > MaxLogEntries {
 			lines = lines[:MaxLogEntries]
 		}
 		for _, l := range lines {
-			T(style.LogEntry, l)
+			Step(style.LogEntry, l)
 		}
 	}
 }

--- a/pkg/minikube/out/out_test.go
+++ b/pkg/minikube/out/out_test.go
@@ -58,7 +58,7 @@ func TestOutT(t *testing.T) {
 				os.Setenv(OverrideEnv, strconv.FormatBool(override))
 				f := tests.NewFakeFile()
 				SetOutFile(f)
-				T(tc.style, tc.message, tc.params)
+				Step(tc.style, tc.message, tc.params)
 				got := f.String()
 				want := tc.wantASCII
 				if override {

--- a/pkg/minikube/service/service.go
+++ b/pkg/minikube/service/service.go
@@ -287,7 +287,7 @@ func WaitForService(api libmachine.API, cname string, namespace string, service 
 	}
 
 	if len(serviceURL.URLs) == 0 {
-		out.T(style.Sad, "service {{.namespace_name}}/{{.service_name}} has no node port", out.V{"namespace_name": namespace, "service_name": service})
+		out.Step(style.Sad, "service {{.namespace_name}}/{{.service_name}} has no node port", out.V{"namespace_name": namespace, "service_name": service})
 		return urlList, nil
 	}
 

--- a/pkg/minikube/tunnel/kic/ssh_conn.go
+++ b/pkg/minikube/tunnel/kic/ssh_conn.go
@@ -68,13 +68,13 @@ func createSSHConn(name, sshPort, sshKey string, svc *v1.Service) *sshConn {
 	command := "ssh"
 
 	if askForSudo {
-		out.T(
+		out.Step(
 			style.Warning,
 			"The service {{.service}} requires privileged ports to be exposed: {{.ports}}",
 			out.V{"service": svc.Name, "ports": fmt.Sprintf("%v", privilegedPorts)},
 		)
 
-		out.T(style.Permissions, "sudo permission will be asked for it.")
+		out.Step(style.Permissions, "sudo permission will be asked for it.")
 
 		command = "sudo"
 		sshArgs = append([]string{"ssh"}, sshArgs...)
@@ -131,7 +131,7 @@ func createSSHConnWithRandomPorts(name, sshPort, sshKey string, svc *v1.Service)
 }
 
 func (c *sshConn) startAndWait() error {
-	out.T(style.Running, "Starting tunnel for service {{.service}}.", out.V{"service": c.service})
+	out.Step(style.Running, "Starting tunnel for service {{.service}}.", out.V{"service": c.service})
 
 	err := c.cmd.Start()
 	if err != nil {
@@ -145,7 +145,7 @@ func (c *sshConn) startAndWait() error {
 }
 
 func (c *sshConn) stop() error {
-	out.T(style.Stopping, "Stopping tunnel for service {{.service}}.", out.V{"service": c.service})
+	out.Step(style.Stopping, "Stopping tunnel for service {{.service}}.", out.V{"service": c.service})
 
 	return c.cmd.Process.Kill()
 }

--- a/site/content/en/docs/contrib/json_output.en.md
+++ b/site/content/en/docs/contrib/json_output.en.md
@@ -69,5 +69,5 @@ You can see an example of setting the registry step in the code in [config.go](h
 
 ```go
 	register.Reg.SetStep(register.PreparingKubernetes)
-	out.T(cr.Style(), "Preparing Kubernetes {{.k8sVersion}} on {{.runtime}} {{.runtimeVersion}} ...", out.V{"k8sVersion": k8sVersion, "runtime": cr.Name(), "runtimeVersion": version})
+	out.Step(cr.Style(), "Preparing Kubernetes {{.k8sVersion}} on {{.runtime}} {{.runtimeVersion}} ...", out.V{"k8sVersion": k8sVersion, "runtime": cr.Name(), "runtimeVersion": version})
 ```


### PR DESCRIPTION
### PR Summary:
- Renames `out.T` to `out.Step`
- Fixes #9664 

### Comments for a reviewer:
I can see that there are still number of functions in out.go with T in the names:
`out.ErrT`, `out.SuccessT`, `out.FatalT`, `out.WarningT`, `out.FailureT`
should we rename them as well? WDYT @priyawadhwa  ? 