### PR TITLE
Add Support for driver name alias

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -660,6 +660,12 @@ func validateSpecifiedDriver(existing *config.ClusterConfig) {
 		return
 	}
 
+	// hostDriver always returns original driver name even if an alias is used to start minikube.
+	// For all next start with alias needs to be check against the host driver aliases.
+	if driver.IsAlias(old, requested) {
+		return
+	}
+
 	exit.Advice(
 		reason.GuestDrvMismatch,
 		`The existing "{{.name}}" cluster was created using the "{{.old}}" driver, which is incompatible with requested "{{.new}}" driver.`,

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -53,6 +53,9 @@ const (
 	HyperV = "hyperv"
 	// Parallels driver
 	Parallels = "parallels"
+
+	// AliasKVM is driver name alias for kvm2
+	AliasKVM = "kvm"
 )
 
 var (
@@ -281,6 +284,17 @@ func Status(name string) registry.DriverState {
 		Priority: d.Priority,
 		State:    registry.Status(name),
 	}
+}
+
+// IsAlias checks if an alias belongs to provided driver by name.
+func IsAlias(name, alias string) bool {
+	d := registry.Driver(name)
+	for _, da := range d.Alias {
+		if da == alias {
+			return true
+		}
+	}
+	return false
 }
 
 // SetLibvirtURI sets the URI to perform libvirt health checks against

--- a/pkg/minikube/registry/drvs/kvm2/kvm2.go
+++ b/pkg/minikube/registry/drvs/kvm2/kvm2.go
@@ -43,6 +43,7 @@ const (
 func init() {
 	if err := registry.Register(registry.DriverDef{
 		Name:     driver.KVM2,
+		Alias:    []string{driver.AliasKVM},
 		Config:   configure,
 		Status:   status,
 		Priority: registry.Preferred,

--- a/pkg/minikube/registry/registry_test.go
+++ b/pkg/minikube/registry/registry_test.go
@@ -63,3 +63,31 @@ func TestList(t *testing.T) {
 		t.Errorf("list mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestDriverAlias(t *testing.T) {
+	foo := DriverDef{Name: "foo", Alias: []string{"foo-alias"}}
+	r := newRegistry()
+
+	if err := r.Register(foo); err != nil {
+		t.Errorf("Register = %v, expected nil", err)
+	}
+
+	d := r.Driver("foo")
+	if d.Empty() {
+		t.Errorf("driver.Empty = true, expected false")
+	}
+
+	d = r.Driver("foo-alias")
+	if d.Empty() {
+		t.Errorf("driver.Empty = true, expected false")
+	}
+
+	if diff := cmp.Diff(r.List(), []DriverDef{foo}); diff != "" {
+		t.Errorf("list mismatch (-want +got):\n%s", diff)
+	}
+
+	d = r.Driver("bar")
+	if !d.Empty() {
+		t.Errorf("driver.Empty = false, expected true")
+	}
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

This PR introduces support for driver name aliases. Currently it introduces only one alias for driver kvm2 to kvm. The changes also includes support for alternating between aliases and name when starting minikube. 


Fixes #8822 
Ref #7772 

Example
```
$ minikube start --driver=kvm
$ minikube stop
$ minikube start --driver=kvm2
$ minikube stop
$ minikube start --driver=kvm
```
