### PR TITLE
Don't check for docker.io prefix in docker preload

### DIFF
--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -375,6 +375,7 @@ func dockerImagesPreloaded(runner command.Runner, images []string) bool {
 	}
 	preloadedImages := map[string]struct{}{}
 	for _, i := range strings.Split(rr.Stdout.String(), "\n") {
+		i = trimDockerIO(i)
 		preloadedImages[i] = struct{}{}
 	}
 
@@ -382,12 +383,20 @@ func dockerImagesPreloaded(runner command.Runner, images []string) bool {
 
 	// Make sure images == imgs
 	for _, i := range images {
+		i = trimDockerIO(i)
 		if _, ok := preloadedImages[i]; !ok {
 			klog.Infof("%s wasn't preloaded", i)
 			return false
 		}
 	}
 	return true
+}
+
+// Remove docker.io prefix since it won't be included in images names
+// when we call 'docker images'
+func trimDockerIO(name string) string {
+	name = strings.TrimPrefix(name, "docker.io/")
+	return name
 }
 
 func dockerBoundToContainerd(runner command.Runner) bool {

--- a/test/integration/pause_test.go
+++ b/test/integration/pause_test.go
@@ -83,6 +83,7 @@ func validateStartNoReconfigure(ctx context.Context, t *testing.T, profile strin
 	defer PostMortemLogs(t, profile)
 
 	args := []string{"start", "-p", profile, "--alsologtostderr", "-v=1"}
+	args = append(args, StartArgs()...)
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
 		t.Fatalf("failed to second start a running minikube with args: %q : %v", rr.Command(), err)


### PR DESCRIPTION
Right now, preload isn't working because it thinks that the
kubernetes/dashboard images don't exist. This is because they now have a
docker.io prefix introduced by 4c54e7868179471b9531e21b4d29472600860cbc

Since `docker images` won't return image names with that prefix, we want
to strip the images of `docker.io` before checking if they exists in the
docker daemon.

This also fixes the TestPause/serial/SecondStartNoReconfiguration
failing integration test.

fixes https://github.com/kubernetes/minikube/issues/9668

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
