### PR TITLE
Fix TestScheduledStop flake on KVM

### DIFF
--- a/test/integration/scheduled_stop_test.go
+++ b/test/integration/scheduled_stop_test.go
@@ -58,6 +58,8 @@ func TestScheduledStop(t *testing.T) {
 	checkPID(t, profile)
 	// wait allotted time to make sure minikube status is "Stopped"
 	checkStatus := func() error {
+		ctx, cancel := context.WithDeadline(ctx, time.Now().Add(10*time.Second))
+		defer cancel()
 		got := Status(ctx, t, Target(), profile, "Host", profile)
 		if got != state.Stopped.String() {
 			return fmt.Errorf("expected post-stop host status to be -%q- but got *%q*", state.Stopped, got)

--- a/test/integration/scheduled_stop_test.go
+++ b/test/integration/scheduled_stop_test.go
@@ -66,7 +66,7 @@ func TestScheduledStop(t *testing.T) {
 		}
 		return nil
 	}
-	if err := retry.Expo(checkStatus, time.Second, 30*time.Second); err != nil {
+	if err := retry.Expo(checkStatus, time.Second, time.Minute); err != nil {
 		t.Fatalf("error %v", err)
 	}
 }


### PR DESCRIPTION
This test was flaky because we gave `minikube status` 30 seconds to return a `Stopped` state, but the call to `status` was timing out if it was made while minikube was still stopping.

Force a 10 second limit on calls to `minikube status`, to ensure at least a couple calls are made before the timeout is hit.

Tested on our KVM machine, passed 10x in a row.


fixes https://github.com/kubernetes/minikube/issues/9695