### PR TITLE
Fix whitespace issues in the site content markdown

### DIFF
--- a/site/content/en/docs/contrib/documentation.en.md
+++ b/site/content/en/docs/contrib/documentation.en.md
@@ -47,7 +47,6 @@ We follow the [Kubernetes Documentation Style Guide](https://kubernetes.io/docs/
 
 For compile-time checking of links, use one of the following forms to link between documentation pages:
 
-
 ```go-html-template
 {{</* ref "document.md" */>}}
 {{</* ref "#anchor" */>}}

--- a/site/content/en/docs/contrib/drivers.en.md
+++ b/site/content/en/docs/contrib/drivers.en.md
@@ -8,7 +8,7 @@ description: >
 
 This document is written for contributors who are familiar with minikube, who would like to add support for a new VM driver.
 
-minikube relies on docker-machine drivers to manage machines. This document discusses how to modify minikube, so that this driver may be used by `minikube start --driver=<new_driver>`. 
+minikube relies on docker-machine drivers to manage machines. This document discusses how to modify minikube, so that this driver may be used by `minikube start --driver=<new_driver>`.
 
 ## Creating a new driver
 
@@ -35,7 +35,7 @@ The integration process is effectively 3 steps.
 
 ### The driver shim
 
-The primary duty of the driver shim is to register a VM driver with minikube, and translate minikube VM hardware configuration into a format that the driver understands. 
+The primary duty of the driver shim is to register a VM driver with minikube, and translate minikube VM hardware configuration into a format that the driver understands.
 
 ### Registering your driver
 
@@ -54,7 +54,6 @@ pretty simple once you understand your driver well:
 on your `$USER/.minikube` directory. Most likely the driver config is the driver itself.
 
 - DriverCreator: Only needed when driver is builtin, to instantiate the driver instance.
-
 
 ## Integration example: vmwarefusion
 
@@ -103,7 +102,4 @@ earlier, it's builtin, so you also need to specify `DriverCreator` to tell minik
 runs on MacOS, so that the releases on Windows and Linux won't have this driver in registry.
 - Last but not least, import the driver in `pkg/minikube/cluster/default_drivers.go` to include it in build.
 
-
-
 Any Questions: please ping your friend [@anfernee](https://github.com/anfernee) or the #minikube Slack channel.
-

--- a/site/content/en/docs/contrib/json_output.en.md
+++ b/site/content/en/docs/contrib/json_output.en.md
@@ -10,6 +10,7 @@ This document is written for minikube contributors who need to add logs to the m
 You may need to add logs to the registry if the `TestJSONOutput` integration test is failing on your PR.
 
 ### Background
+
 minikube provides JSON output for `minikube start`, accesible via the `--output` flag:
 
 ```shell
@@ -39,6 +40,7 @@ $ minikube start --output json
 ```
 
 There are a few key points to note in the above output:
+
 1. Each log of type `io.k8s.sigs.minikube.step` indicates a distinct step in the `minikube start` process
 1. Each step has a `currentstep` field which allows clients to track `minikube start` progress
 1. Each `currentstep` is distinct and increasing in order
@@ -48,12 +50,12 @@ This way, minikube knows how many expected `totalsteps` there are at the beginni
 
 If you change logs, or add a new log, you need to update the minikube registry to pass integration tests.
 
-
 ### Adding a Log to the Registry
 
 There are three steps to adding a log to the registry, which exists in [register.go](https://github.com/kubernetes/minikube/blob/master/pkg/minikube/out/register/register.go).
 
 You will need to add your new log in two places:
+
 1. As a constant of type `RegStep` [here](https://github.com/kubernetes/minikube/blob/master/pkg/minikube/out/register/register.go#L24)
 1. In the register itself in the `init()` function, [here](https://github.com/kubernetes/minikube/blob/master/pkg/minikube/out/register/register.go#L52)
 
@@ -68,6 +70,6 @@ register.Reg.SetStep(register.MyNewStep)
 You can see an example of setting the registry step in the code in [config.go](https://github.com/kubernetes/minikube/blob/master/pkg/minikube/node/config.go):
 
 ```go
-	register.Reg.SetStep(register.PreparingKubernetes)
-	out.Step(cr.Style(), "Preparing Kubernetes {{.k8sVersion}} on {{.runtime}} {{.runtimeVersion}} ...", out.V{"k8sVersion": k8sVersion, "runtime": cr.Name(), "runtimeVersion": version})
+ register.Reg.SetStep(register.PreparingKubernetes)
+ out.Step(cr.Style(), "Preparing Kubernetes {{.k8sVersion}} on {{.runtime}} {{.runtimeVersion}} ...", out.V{"k8sVersion": k8sVersion, "runtime": cr.Name(), "runtimeVersion": version})
 ```

--- a/site/content/en/docs/contrib/principles.en.md
+++ b/site/content/en/docs/contrib/principles.en.md
@@ -6,13 +6,13 @@ aliases:
 
 The primary goal of minikube is to make it simple to run Kubernetes locally, for day-to-day development workflows and learning purposes. Here are the guiding principles for minikube, in rough priority order:
 
-1.  Inclusive and community-driven
-2.  User-friendly
-3.  Support all Kubernetes features
-4.  Cross-platform
-5.  Reliable
-6.  High Performance
-7.  Developer Focused
+1. Inclusive and community-driven
+2. User-friendly
+3. Support all Kubernetes features
+4. Cross-platform
+5. Reliable
+6. High Performance
+7. Developer Focused
 
 Here are some specific minikube features that align with our goal:
 

--- a/site/content/en/docs/contrib/releasing/binaries.md
+++ b/site/content/en/docs/contrib/releasing/binaries.md
@@ -40,7 +40,7 @@ Paste the output into CHANGELOG.md, sorting changes by importance to an end-user
 - The changelog should only contain user facing change. This means removing PR's for:
   - Documentation
   - Low-risk refactors
-  - Test-only changes 
+  - Test-only changes
 - Remove bots from the contributor list
 - Remove duplicated similar names from the contributor list
 

--- a/site/content/en/docs/contrib/roadmap.en.md
+++ b/site/content/en/docs/contrib/roadmap.en.md
@@ -10,7 +10,7 @@ This roadmap is a living document outlining the major technical improvements whi
 
 Please send a PR to suggest any improvements to it.
 
-# 2020 
+# 2020
 
 ## (#1) Inclusive and community-driven
 

--- a/site/content/en/docs/contrib/testing.en.md
+++ b/site/content/en/docs/contrib/testing.en.md
@@ -74,7 +74,7 @@ make integration -e TEST_ARGS="-test.parallel=1"
 - Readers should need to read only the test body to understand the test
 - Top-to-bottom readability is more important than code de-duplication
 
-Tests are typically read with a great air of skepticism, because chances are they are being read only when things are broken. 
+Tests are typically read with a great air of skepticism, because chances are they are being read only when things are broken.
 
 ## Conformance Tests
 

--- a/site/content/en/docs/contrib/translations.md
+++ b/site/content/en/docs/contrib/translations.md
@@ -9,84 +9,96 @@ description: >
 All translations are stored in the top-level `translations` directory.
 
 ### Adding a New Language
+
 * Add a new json file in the translations directory with the locale code of the language you want to add
   translations for, e.g. fr for French.
-	```
-	~/minikube$ touch translations/fr.json
-	~/minikube$ ls translations/
-	de.json		es.json		fr.json		ja.json		ko.json		pl.json		zh-CN.json
-	```
+
+ ```
+ ~/minikube$ touch translations/fr.json
+ ~/minikube$ ls translations/
+ de.json  es.json  fr.json  ja.json  ko.json  pl.json  zh-CN.json
+ ```
+
 * Run `make extract` from root directory to populate that file with the strings to translate in json
   form.
-	```
-	~/minikube$ make extract
-	go run cmd/extract/extract.go
-	Compiling translation strings...
-	Writing to de.json
-	Writing to es.json
-	Writing to fr.json
-	Writing to ja.json
-	Writing to ko.json
-	Writing to pl.json
-	Writing to zh-CN.json
-	Done!
-	```
+
+ ```
+ ~/minikube$ make extract
+ go run cmd/extract/extract.go
+ Compiling translation strings...
+ Writing to de.json
+ Writing to es.json
+ Writing to fr.json
+ Writing to ja.json
+ Writing to ko.json
+ Writing to pl.json
+ Writing to zh-CN.json
+ Done!
+ ```
+
 * Add translated strings to the json file as the value of the map where the English phrase is the key.
-	```
-	~/minikube$ head translations/fr.json 
-	{
-		"\"The '{{.minikube_addon}}' addon is disabled": "",
-		"\"{{.machineName}}\" does not exist, nothing to stop": "",
-		"\"{{.name}}\" profile does not exist, trying anyways.": "",
-		"'none' driver does not support 'minikube docker-env' command": "",
-		"'none' driver does not support 'minikube mount' command": "",
-		"'none' driver does not support 'minikube podman-env' command": "",
-		"'none' driver does not support 'minikube ssh' command": "",
-		"'{{.driver}}' driver reported an issue: {{.error}}": "",
-	```
-	* Add the translations as the values of the map, keeping in mind that anything in double braces `{{}}` are variable names describing what gets injected and should not be translated.
-	```
-	~/minikube$ vi translations/fr.json
-	{
-        	[...]
-        	"Amount of time to wait for a service in seconds": "",
-        	"Amount of time to wait for service in seconds": "",
-        	"Another hypervisor, such as VirtualBox, is conflicting with KVM. Please stop the other hypervisor, or use --driver to switch to it.": "",
-        	"Automatically selected the {{.driver}} driver": "Choix automatique du driver {{.driver}}",
-        	"Automatically selected the {{.driver}} driver. Other choices: {{.alternates}}": "Choix automatique du driver {{.driver}}. Autres choix: {{.alternatives}}",
-        	"Available Commands": "",
-        	"Basic Commands:": "",
-        	"Because you are using docker driver on Mac, the terminal needs to be open to run it.": "",
-        	[...]
-	}
-        ```
-	
+
+ ```
+ ~/minikube$ head translations/fr.json
+ {
+  "\"The '{{.minikube_addon}}' addon is disabled": "",
+  "\"{{.machineName}}\" does not exist, nothing to stop": "",
+  "\"{{.name}}\" profile does not exist, trying anyways.": "",
+  "'none' driver does not support 'minikube docker-env' command": "",
+  "'none' driver does not support 'minikube mount' command": "",
+  "'none' driver does not support 'minikube podman-env' command": "",
+  "'none' driver does not support 'minikube ssh' command": "",
+  "'{{.driver}}' driver reported an issue: {{.error}}": "",
+ ```
+
+* Add the translations as the values of the map, keeping in mind that anything in double braces `{{}}` are variable names describing what gets injected and should not be translated.
+
+ ```
+ ~/minikube$ vi translations/fr.json
+ {
+         [...]
+         "Amount of time to wait for a service in seconds": "",
+         "Amount of time to wait for service in seconds": "",
+         "Another hypervisor, such as VirtualBox, is conflicting with KVM. Please stop the other hypervisor, or use --driver to switch to it.": "",
+         "Automatically selected the {{.driver}} driver": "Choix automatique du driver {{.driver}}",
+         "Automatically selected the {{.driver}} driver. Other choices: {{.alternates}}": "Choix automatique du driver {{.driver}}. Autres choix: {{.alternatives}}",
+         "Available Commands": "",
+         "Basic Commands:": "",
+         "Because you are using docker driver on Mac, the terminal needs to be open to run it.": "",
+         [...]
+ }
+ ```
+
 ### Adding Translations To an Existing Language
+
 * Run `make extract` to make sure all strings are up to date
 * Edit the appropriate json file in the 'translations' directory, in the same way as described above.
 
 ### Testing translations
-* Once you have all the translations you want, save the file and rebuild the minikube from scratch to pick up your new translations:
-	```
-	~/minikube$ make clean
-	rm -rf ./out
-	rm -f pkg/minikube/assets/assets.go
-	rm -f pkg/minikube/translate/translations.go
-	rm -rf ./vendor
-	~/minikube$ make
-	```
-	Note: the clean is required to regenerate the embedded `translations.go` file
 
-* You now have a fresh minikube binary in the `out` directory. If your system locale is that of the language you added translations for, a simple `out/minikube start` will work as a test, assuming you translated phrases from `minikube start`. You can use whatever command you'd like in that way. 
+* Once you have all the translations you want, save the file and rebuild the minikube from scratch to pick up your new translations:
+
+ ```
+ ~/minikube$ make clean
+ rm -rf ./out
+ rm -f pkg/minikube/assets/assets.go
+ rm -f pkg/minikube/translate/translations.go
+ rm -rf ./vendor
+ ~/minikube$ make
+ ```
+ Note: the clean is required to regenerate the embedded `translations.go` file
+
+* You now have a fresh minikube binary in the `out` directory. If your system locale is that of the language you added translations for, a simple `out/minikube start` will work as a test, assuming you translated phrases from `minikube start`. You can use whatever command you'd like in that way.
 
 * If you have a different system locale, you can override the printed language using the LC_ALL environment variable:
-	```
-	~/minikube$ LC_ALL=fr out/minikube start
-	😄  minikube v1.9.2 sur Darwin 10.14.5
-	✨  Choix automatique du driver hyperkit. Autres choix: docker
-	👍  Démarrage du noeud de plan de contrôle minikube dans le cluster minikube
-	🔥  Création de VM hyperkit (CPUs=2, Mémoire=4000MB, Disque=20000MB)...
-	🐳  Préparation de Kubernetes v1.18.0 sur Docker 19.03.8...
-	🌟  Installation des addons: default-storageclass, storage-provisioner
-	🏄  Terminé ! kubectl est maintenant configuré pour utiliser "minikube".
-	```
+
+ ```
+ ~/minikube$ LC_ALL=fr out/minikube start
+ 😄  minikube v1.9.2 sur Darwin 10.14.5
+ ✨  Choix automatique du driver hyperkit. Autres choix: docker
+ 👍  Démarrage du noeud de plan de contrôle minikube dans le cluster minikube
+ 🔥  Création de VM hyperkit (CPUs=2, Mémoire=4000MB, Disque=20000MB)...
+ 🐳  Préparation de Kubernetes v1.18.0 sur Docker 19.03.8...
+ 🌟  Installation des addons: default-storageclass, storage-provisioner
+ 🏄  Terminé ! kubectl est maintenant configuré pour utiliser "minikube".
+ ```

--- a/site/content/en/docs/contrib/triage.md
+++ b/site/content/en/docs/contrib/triage.md
@@ -16,15 +16,17 @@ Triage is an important part of maintaining the health of the minikube repo.
 A well organized repo allows maintainers to prioritize feature requests, fix bugs, and respond to users facing difficulty with the tool as quickly as possible.
 
 Triage includes:
+
 - Labeling issues
 - Responding to issues
 - Closing issues
 
 If you're interested in helping out with minikube triage, this doc covers the basics of doing so.
 
-Additionally, if you'd be interested in participating in our weekly triage meeting, please fill out this [form](https://forms.gle/vNtWZSWXqeYaaNbU9) to express interest. Thank you! 
+Additionally, if you'd be interested in participating in our weekly triage meeting, please fill out this [form](https://forms.gle/vNtWZSWXqeYaaNbU9) to express interest. Thank you!
 
 # Daily Triage
+
 Daily triage has two goals:
 
 1. Responsiveness for new issues
@@ -44,7 +46,8 @@ We typically want at least one of the following labels on every issue, and some 
 - `kind/support`   - The default for most incoming issues
 - `kind/bug` - When it’s a bug or we aren’t delivering the best user experience
 
-Other possibilities: 
+Other possibilities:
+
 - `kind/feature`- Identify new feature requests
 - `kind/flake` - Used for flaky integration or unit tests
 - `kind/cleanup` - Cleaning up/refactoring the codebase
@@ -56,31 +59,30 @@ If the issue is specific to an operating system, hypervisor, container, addon, o
 
 **os/[operating system]** - When the issue appears specific to an operating system
 
-  - `os/linux`
-  - `os/macos`
-  - `os/windows`
+- `os/linux`
+- `os/macos`
+- `os/windows`
 
 **co/[driver]**  - When the issue appears specific to a driver
 
-  - `co/hyperkit`
-  - `co/hyperv`
-  - `co/kvm2`
-  - `co/none-driver`
-  - `co/docker-driver`
-  - `co/podman-driver`
-  - `co/virtualbox`
+- `co/hyperkit`
+- `co/hyperv`
+- `co/kvm2`
+- `co/none-driver`
+- `co/docker-driver`
+- `co/podman-driver`
+- `co/virtualbox`
 
 **co/[kubernetes component]**  - When the issue appears specific to a k8s component
 
-  - `co/apiserver`
-  - `co/etcd`
-  - `co/coredns`
-  - `co/dashboard`
-  - `co/kube-proxy`
-  - `co/kubeadm`
-  - `co/kubelet`
-  - `co/kubeconfig`
- 
+- `co/apiserver`
+- `co/etcd`
+- `co/coredns`
+- `co/dashboard`
+- `co/kube-proxy`
+- `co/kubeadm`
+- `co/kubelet`
+- `co/kubeconfig`
 
 Other useful tags:
 
@@ -102,8 +104,8 @@ Suspected **Root cause**:
 
 `Help wanted` - if the bug could use help from a contributor
 
-
 ## Prioritization
+
 If the issue is not `kind/support`, it needs a [priority label](https://github.com/kubernetes/community/blob/master/contributors/guide/issue-triage.md#define-priority):
 
 `priority/critical-urgent` - someones top priority ASAP, such as security issue, user-visible bug, or build breakage. Rarely used.
@@ -115,7 +117,6 @@ If the issue is not `kind/support`, it needs a [priority label](https://github.c
 `priority/backlog`: agreed that this would be good to have, but no one is available at the moment. Consider tagging as `help wanted`
 
 `priority/awaiting-more-evidence`: may be more useful, but there is not yet enough support.
-
 
 # Weekly Triage
 
@@ -142,10 +143,10 @@ This includes reviewing:
 1. Re-evaluation of long-term issues
 1. Re-evaluation of short-term issues
 
-
 ## Responding to Issues
 
 ### Needs More Information
+
 A sample response to ask for more info:
 
 > I don’t yet have a clear way to replicate this issue. Do you mind adding some additional details. Here is additional information that would be helpful:
@@ -162,16 +163,15 @@ A sample response to ask for more info:
 >
 > Thank you for sharing your experience!
 
-
 Then: Label with `triage/needs-information`.
 
 ### Issue might be resolved
+
 If you think a release may have resolved an issue, ask the author to see if their issue has been resolved:
 
 > Could you please check to see if minikube <x> addresses this issue? We've made some changes with how this is handled, and improved the minikube logs output to help us debug tricky cases like this.
 
 Then: Label with `triage/needs-information`.
-
 
 ## Closing with Care
 
@@ -204,10 +204,11 @@ Then: Close the issue
 Then: Label with `triage/duplicate` and close the issue.
 
 ### Lack of Information
+
 If an issue hasn't been active for more than four weeks, and the author has been pinged at least once, then the issue can be closed.
 
 >Hey @author -- hopefully it's OK if I close this - there wasn't enough information to make it actionable, and some time has already passed. If you are able to provide additional details, you may reopen it at any point by adding /reopen to your comment.
-> 
+>
 >Here is additional information that may be helpful to us:
 >
 >\* Whether the issue occurs with the latest minikube release

--- a/site/content/en/docs/drivers/docker.md
+++ b/site/content/en/docs/drivers/docker.md
@@ -23,7 +23,7 @@ The Docker driver allows you to install Kubernetes into an existing Docker insta
   - [userns-remap](https://docs.docker.com/engine/security/userns-remap/)
   - [rootless](https://docs.docker.com/engine/security/rootless/)
 
-- Docker driver is not supported on non-amd64 architectures such as arm yet. For non-amd64 archs please use [other drivers]({{< ref "/docs/drivers/_index.md" >}}) 
+- Docker driver is not supported on non-amd64 architectures such as arm yet. For non-amd64 archs please use [other drivers]({{< ref "/docs/drivers/_index.md" >}})
 
 - On macOS, containers might get hung and require a restart of Docker for Desktop. See [docker/for-mac#1835](https://github.com/docker/for-mac/issues/1835)
 
@@ -36,9 +36,10 @@ The Docker driver allows you to install Kubernetes into an existing Docker insta
 ## Troubleshooting
 
 [comment]: <> (this title is used in the docs links, don't change)
+
 ### Verify Docker container type is Linux
 
-- On Windows, make sure Docker Desktop's container type setting is Linux and not windows. see docker docs on [switching container type](https://docs.docker.com/docker-for-windows/#switch-between-windows-and-linux-containers). 
+- On Windows, make sure Docker Desktop's container type setting is Linux and not windows. see docker docs on [switching container type](https://docs.docker.com/docker-for-windows/#switch-between-windows-and-linux-containers).
 You can verify your Docker container type by running:
    ```shell
    docker info --format '{{.OSType}}'

--- a/site/content/en/docs/drivers/hyperkit.md
+++ b/site/content/en/docs/drivers/hyperkit.md
@@ -35,11 +35,12 @@ If you are running other DNS servers, shut them off or specify an alternative bi
 
 ## Troubleshooting
 
-
 ### Run with logs
+
 Run `minikube start --alsologtostderr -v=7` to debug crashes
 
 ### Upgrade HyperKit
+
 New updates to macOS often require an updated hyperkit driver. To upgrade:
 
 * If Docker for Desktop is installed, click on icon in your menu bar and select `Check for updates...`
@@ -49,4 +50,5 @@ New updates to macOS often require an updated hyperkit driver. To upgrade:
 * If the version didn't change after upgrading verify the correct HyperKit is in the path. run: `which hyperkit`
 
 ### Check driver version
+
 Run `docker-machine-driver-hyperkit version` to make sure the version matches minikube

--- a/site/content/en/docs/drivers/kvm2.md
+++ b/site/content/en/docs/drivers/kvm2.md
@@ -42,6 +42,7 @@ Also see [co/kvm2 open issues](https://github.com/kubernetes/minikube/labels/co%
 If you are running KVM in a nested virtualization environment ensure your config the kernel modules correctly follow either [this](https://stafwag.github.io/blog/blog/2018/06/04/nested-virtualization-in-kvm/) or [this](https://computingforgeeks.com/how-to-install-kvm-virtualization-on-debian/) tutorial.
 
 ## Troubleshooting
+
 * Run `virt-host-validate` and check for the suggestions.
 * Run `minikube start --alsologtostderr -v=7` to debug crashes
 * Run `docker-machine-driver-kvm2 version` to verify the kvm2 driver executes properly.

--- a/site/content/en/docs/drivers/podman.md
+++ b/site/content/en/docs/drivers/podman.md
@@ -15,17 +15,16 @@ The podman driver is an alternative container runtime to the [Docker]({{< ref "/
 
 ## Requirements
 
-- Linux or macOS operating systems on amd64 architecture 
+- Linux or macOS operating systems on amd64 architecture
 - Install [podman](https://podman.io/getting-started/installation.html)
-
 
 {{% readfile file="/docs/drivers/includes/podman_usage.inc" %}}
 
 ## Known Issues
 
-- Podman driver is not supported on non-amd64 architectures such as arm yet. For non-amd64 archs please use [other drivers]({{< ref "/docs/drivers/_index.md" >}}) 
+- Podman driver is not supported on non-amd64 architectures such as arm yet. For non-amd64 archs please use [other drivers]({{< ref "/docs/drivers/_index.md" >}})
 - Podman v2 driver is not supported yet.
-- Podman requirements passwordless running of sudo. If you run into an error about sudo, do the following: 
+- Podman requirements passwordless running of sudo. If you run into an error about sudo, do the following:
 
 ```shell
 $ sudo visudo
@@ -36,7 +35,7 @@ Then append the following to the section *at the very bottom* of the file where 
 username ALL=(ALL) NOPASSWD: /usr/bin/podman
 ```
 
-Be sure this text is *after* `#includedir /etc/sudoers.d`. To confirm it worked, try: 
+Be sure this text is *after* `#includedir /etc/sudoers.d`. To confirm it worked, try:
 
 ```shell
 sudo -k -n podman version

--- a/site/content/en/docs/faq/_index.md
+++ b/site/content/en/docs/faq/_index.md
@@ -36,4 +36,4 @@ minikube start --cpus 6 --memory 8000
 
 ## Do I need to install kubectl locally?
 
-No, minikube comes with built-in kubectl [see minikube's kubectl documentation]({{< ref "docs/handbook/kubectl.md" >}}). 
+No, minikube comes with built-in kubectl [see minikube's kubectl documentation]({{< ref "docs/handbook/kubectl.md" >}}).

--- a/site/content/en/docs/handbook/accessing.md
+++ b/site/content/en/docs/handbook/accessing.md
@@ -49,10 +49,10 @@ minikube start --extra-config=apiserver.service-node-port-range=1-65535
 This flag also accepts a comma separated list of ports and port ranges.
 
 ----
+
 ## LoadBalancer access
 
 A LoadBalancer service is the standard way to expose a service to the internet. With this method, each service gets its own IP address.
-
 
 ## Using `minikube tunnel`
 
@@ -61,6 +61,7 @@ Services of type `LoadBalancer` can be exposed via the `minikube tunnel` command
 ## Example
 
 #### Run tunnel in a separate terminal
+
 it will ask for password.
 
 ```shell
@@ -69,40 +70,42 @@ minikube tunnel
 
 `minikube tunnel` runs as a process, creating a network route on the host to the service CIDR of the cluster using the cluster's IP address as a gateway.  The tunnel command exposes the external IP directly to any program running on the host operating system.
 
-
 <details>
 <summary>
 tunnel output example
 </summary>
 <pre>
-Password: 
-Status:	
-	machine: minikube
-	pid: 39087
-	route: 10.96.0.0/12 -> 192.168.64.194
-	minikube: Running
-	services: [hello-minikube]
-    errors: 
-		minikube: no errors
-		router: no errors
-		loadbalancer emulator: no errors
+Password:
+Status:
+ machine: minikube
+ pid: 39087
+ route: 10.96.0.0/12 -> 192.168.64.194
+ minikube: Running
+ services: [hello-minikube]
+    errors:
+  minikube: no errors
+  router: no errors
+  loadbalancer emulator: no errors
 ...
 ...
 ...
 </pre>
 </details>
 
+#### Create a kubernetes deployment
 
-#### Create a kubernetes deployment 
 ```shell
 kubectl create deployment hello-minikube1 --image=k8s.gcr.io/echoserver:1.4
 ```
+
 #### Create a kubernetes service type LoadBalancer
+
 ```shell
 kubectl expose deployment hello-minikube1 --type=LoadBalancer --port=8080
 ```
 
-### Check external IP 
+### Check external IP
+
 ```shell
 kubectl get svc
 ```
@@ -112,19 +115,19 @@ NAME              TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)        
 hello-minikube1   LoadBalancer   10.96.184.178   10.96.184.178   8080:30791/TCP   40s
 </pre>
 
-
 note that without minikube tunnel, kubernetes would be showing external IP as "pending".
 
 ### Try in your browser
+
 open in your browser (make sure there is no proxy set)
 ```
 http://REPLACE_WITH_EXTERNAL_IP:8080
 ```
 
-
 Each service will get its own external ip.
 
 ----
+
 ### DNS resolution (experimental)
 
 If you are on macOS, the tunnel command also allows DNS resolution for Kubernetes services from the host.

--- a/site/content/en/docs/handbook/addons/gcp-auth.md
+++ b/site/content/en/docs/handbook/addons/gcp-auth.md
@@ -8,6 +8,7 @@ date: 2020-07-15
 If you have a containerized GCP app with a Kubernetes yaml, you can automatically add your credentials to all your deployed pods dynamically with this minikube addon. You just need to have a credentials file, which can be generated with `gcloud auth application-default login`. If you already have a json credentials file you want specify, use the GOOGLE_APPLICATION_CREDENTIALS environment variable.
 
 - Start a cluster:
+
 ```shell
 minikube start
 ```
@@ -24,6 +25,7 @@ minikube start
 ```
 
 - Enable the `gcp-auth` addon:
+
 ```shell
 minikube addons enable gcp-auth
 ```
@@ -36,12 +38,14 @@ minikube addons enable gcp-auth
 ```
 
 - For credentials in an arbitrary path:
+
 ```shell
-export GOOGLE_APPLICATION_CREDENTIALS=<creds-path>.json 
+export GOOGLE_APPLICATION_CREDENTIALS=<creds-path>.json
 minikube addons enable gcp-auth
 ```
 
 - Deploy your GCP app as normal:
+
 ```shell
 kubectl apply -f test.yaml
 ```

--- a/site/content/en/docs/handbook/controls.md
+++ b/site/content/en/docs/handbook/controls.md
@@ -5,7 +5,9 @@ weight: 2
 description: >
   See minikube in action!
 aliases:
-  - /docs/examples/
+
+- /docs/examples/
+
 ---
 
 Start a cluster by running:

--- a/site/content/en/docs/handbook/dashboard.md
+++ b/site/content/en/docs/handbook/dashboard.md
@@ -13,13 +13,12 @@ minikube has integrated support for the [Kubernetes Dashboard UI](https://github
 
 The Dashboard is a web-based Kubernetes user interface. You can use it to:
 
-
 - deploy containerized applications to a Kubernetes cluster
 - troubleshoot your containerized application
 - manage the cluster resources
 - get an overview of applications running on your cluster
 - creating or modifying individual Kubernetes resources (such as Deployments, Jobs, DaemonSets, etc)
- 
+
 For example, you can scale a Deployment, initiate a rolling update, restart a pod or deploy new applications using a deploy wizard.
 
 ## Basic usage
@@ -30,7 +29,7 @@ To access the dashboard:
 minikube dashboard
 ```
 
-This will enable the dashboard add-on, and open the proxy in the default web browser. 
+This will enable the dashboard add-on, and open the proxy in the default web browser.
 
 It's worth noting that web browsers generally do not run properly as the root user, so if you are
 in an environment where you are running as root, see the URL-only option.

--- a/site/content/en/docs/handbook/deploying.md
+++ b/site/content/en/docs/handbook/deploying.md
@@ -19,7 +19,6 @@ kubectl expose deployment hello-minikube1 --type=LoadBalancer --port=8080
 
 minikube has a built-in list of applications and services that may be easily deployed, such as Istio or Ingress. To list the available addons for your version of minikube:
 
-
 ```shell
 minikube addons list
 ```
@@ -42,7 +41,6 @@ minikube addons open <name>
 ```
 
 To disable an addon:
-
 
 ```shell
 minikube addons disable <name>

--- a/site/content/en/docs/handbook/filesync.md
+++ b/site/content/en/docs/handbook/filesync.md
@@ -30,7 +30,7 @@ minikube start
 
 ## Other approaches
 
-With a bit of work, one could setup [Syncthing](https://syncthing.net) between the host and the guest VM for persistent file synchronization. 
+With a bit of work, one could setup [Syncthing](https://syncthing.net) between the host and the guest VM for persistent file synchronization.
 
 If you are looking for a solution tuned for iterative application development, consider using a Kubernetes tool that is known to work well with minikube:
 

--- a/site/content/en/docs/handbook/host-access.md
+++ b/site/content/en/docs/handbook/host-access.md
@@ -20,14 +20,14 @@ To make it easier to access your host, minikube v1.10 adds a hostname entry `hos
 You can use `minikube ssh` to confirm connectivity:
 
 ```
-                         _             _            
-            _         _ ( )           ( )           
+                         _             _
+            _         _ ( )           ( )
   ___ ___  (_)  ___  (_)| |/')  _   _ | |_      __  
 /' _ ` _ `\| |/' _ `\| || , <  ( ) ( )| '_`\  /'__`\
 | ( ) ( ) || || ( ) || || |\`\ | (_) || |_) )(  ___/
 (_) (_) (_)(_)(_) (_)(_)(_) (_)`\___/'(_,__/'`\____)
 
-$ ping host.minikube.internal 
+$ ping host.minikube.internal
 PING host.minikube.internal (192.168.64.1): 56 data bytes
 64 bytes from 192.168.64.1: seq=0 ttl=64 time=0.225 ms
 ```

--- a/site/content/en/docs/handbook/kubectl.md
+++ b/site/content/en/docs/handbook/kubectl.md
@@ -8,7 +8,7 @@ aliases:
 ---
 
 By default, [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) gets configured to access the kubernetes cluster control plane
-inside minikube when the `minikube start` command is executed. 
+inside minikube when the `minikube start` command is executed.
 
 However if `kubectl` is not installed locally, minikube already includes kubectl which can be used like this:
 
@@ -50,5 +50,5 @@ minikube kubectl -- --help
 
 ### Shell autocompletion
 
-After applying the alias or the symbolic link you can follow https://kubernetes.io/docs/tasks/tools/install-kubectl/#enabling-shell-autocompletion to enable shell-autocompletion. 
+After applying the alias or the symbolic link you can follow https://kubernetes.io/docs/tasks/tools/install-kubectl/#enabling-shell-autocompletion to enable shell-autocompletion.
 When using zsh and the alias approach you also have to execute `setopt complete_aliases`.

--- a/site/content/en/docs/handbook/mount.md
+++ b/site/content/en/docs/handbook/mount.md
@@ -73,8 +73,8 @@ Some hypervisors, have built-in host folder sharing. Driver mounts are reliable 
 | VirtualBox | macOS | /Users | /Users |
 | VirtualBox | Windows | C://Users | /c/Users |
 | VMware Fusion | macOS | /Users | /Users |
-| KVM | Linux | Unsupported | | 
-| HyperKit | Linux | Unsupported (see NFS mounts) | | 
+| KVM | Linux | Unsupported | |
+| HyperKit | Linux | Unsupported (see NFS mounts) | |
 
 These mounts can be disabled by passing `--disable-driver-mounts` to `minikube start`.
 

--- a/site/content/en/docs/handbook/pushing.md
+++ b/site/content/en/docs/handbook/pushing.md
@@ -11,19 +11,18 @@ aliases:
 ---
 
 
-## Comparison table for different methods 
+## Comparison table for different methods
+
 The best method to push your image to minikube depends on the container-runtime you built your cluster with (the default is docker).
 Here is a comparison table to help you choose:
 
-
-| Method   	| Supported Runtimes   	| 	|  Performance 	|
-|---	|---	|---	|---	|---	|
-|  [docker-env command](/docs/handbook/pushing/#1pushing-directly-to-the-in-cluster-docker-daemon-docker-env)	|   only docker	|  good 	|
-|  [podman-env command](/docs/handbook/pushing/#3-pushing-directly-to-in-cluster-crio-podman-env)	|   only cri-o |  good 	|
-|  [cache add command]({{< ref "/docs/commands/cache.md#minikube-cache-add" >}}) 	|  all 	|  ok 	|
-|  [registry addon](/docs/handbook/pushing/#4-pushing-to-an-in-cluster-using-registry-addon)   |   all |  ok 	|
-|  [minikube ssh](/docs/handbook/pushing/#5-building-images-inside-of-minikube-using-ssh)   |   all	| best 	|
-
+| Method    | Supported Runtimes    |  |  Performance  |
+|--- |--- |--- |--- |--- |
+|  [docker-env command](/docs/handbook/pushing/#1pushing-directly-to-the-in-cluster-docker-daemon-docker-env) |   only docker |  good  |
+|  [podman-env command](/docs/handbook/pushing/#3-pushing-directly-to-in-cluster-crio-podman-env) |   only cri-o |  good  |
+|  [cache add command]({{< ref "/docs/commands/cache.md#minikube-cache-add" >}})  |  all  |  ok  |
+|  [registry addon](/docs/handbook/pushing/#4-pushing-to-an-in-cluster-using-registry-addon)   |   all |  ok  |
+|  [minikube ssh](/docs/handbook/pushing/#5-building-images-inside-of-minikube-using-ssh)   |   all | best  |
 
 * note1 : the default container-runtime on minikube is 'docker'.
 * note2 : 'none' driver (bare metal) does not need pushing image to the cluster, as any image on your system is already available to the kuberentes.
@@ -31,6 +30,7 @@ Here is a comparison table to help you choose:
 ---
 
 ## 1. Pushing directly to the in-cluster Docker daemon (docker-env)
+
 When using a container or VM driver (all drivers except none), you can reuse the Docker daemon inside minikube cluster.
 this means you don't have to build on your host machine and push the image into a docker registry. You can just build inside the same docker daemon as minikube which speeds up local experiments.
 
@@ -57,12 +57,12 @@ docker build -t my_image .
 To verify your terminal is using minikuber's docker-env you can check the value of the environment variable MINIKUBE_ACTIVE_DOCKERD to reflect the cluster name.
 
 {{% pageinfo color="info" %}}
-Tip 1: 
+Tip 1:
 Remember to turn off the `imagePullPolicy:Always` (use `imagePullPolicy:IfNotPresent` or `imagePullPolicy:Never`) in your yaml file. Otherwise Kubernetes won't use your locally build image and it will pull from the network.
 {{% /pageinfo %}}
 
 {{% pageinfo color="info" %}}
-Tip 2: 
+Tip 2:
 Evaluating the docker-env is only valid for the current terminal.
 By closing the terminal, you will go back to using your own system's docker daemon.
 {{% /pageinfo %}}
@@ -71,7 +71,6 @@ By closing the terminal, you will go back to using your own system's docker daem
 Tip 3:
 In container-based drivers such as Docker or Podman, you will need to re-do docker-env each time you restart your minikube cluster.
 {{% /pageinfo %}}
-
 
 more information on [docker-env](https://minikube.sigs.k8s.io/docs/commands/docker-env/)
 
@@ -92,7 +91,6 @@ Tip 1 :
 If your image changes after your cached it, you need to do 'cache reload'.
 {{% /pageinfo %}}
 
-
 minikube refreshes the cache images on each start. however to reload all the cached images on demand, run this command :
 ```shell
 minikube cache reload
@@ -103,7 +101,6 @@ Tip 2 :
 if you have multiple clusters, the cache command will load the image for all of them.
 {{% /pageinfo %}}
 
-
 To display images you have added to the cache:
 
 ```shell
@@ -111,8 +108,6 @@ minikube cache list
 ```
 
 This listing will not include the images minikube's built-in system images.
-
-
 
 ```shell
 minikube cache delete <image name>
@@ -170,7 +165,6 @@ Note: On Windows the remote client is called "podman", since there is no local "
 
 {{% /windowstab %}}
 {{% /tabs %}}
-
 
 Remember to turn off the `imagePullPolicy:Always` (use `imagePullPolicy:IfNotPresent` or `imagePullPolicy:Never`), as otherwise Kubernetes won't use images you built locally.
 

--- a/site/content/en/docs/handbook/registry.md
+++ b/site/content/en/docs/handbook/registry.md
@@ -35,7 +35,7 @@ We recommend you use _ImagePullSecrets_, but if you would like to configure acce
 
 ## Enabling Insecure Registries
 
-minikube allows users to configure the docker engine's `--insecure-registry` flag. 
+minikube allows users to configure the docker engine's `--insecure-registry` flag.
 
 You can use the `--insecure-registry` flag on the
 `minikube start` command to enable insecure communication between the docker engine and registries listening to requests from the CIDR range.
@@ -83,7 +83,7 @@ minikube addons enable registry
 
 When enabled, the registry addon exposes its port 5000 on the minikube's virtual machine.
 
-In order to make docker accept pushing images to this registry, we have to redirect port 5000 on the docker virtual machine over to port 5000 on the minikube machine. Unfortunately, the docker vm cannot directly see the IP address of the minikube vm. To fix this, you will have to add one more level of redirection. 
+In order to make docker accept pushing images to this registry, we have to redirect port 5000 on the docker virtual machine over to port 5000 on the minikube machine. Unfortunately, the docker vm cannot directly see the IP address of the minikube vm. To fix this, you will have to add one more level of redirection.
 
 Use kubectl port-forward to map your local workstation to the minikube vm
 ```shell
@@ -107,4 +107,4 @@ docker push localhost:5000/myimage
 
 After the image is pushed, refer to it by `localhost:5000/{name}` in kubectl specs.
 
-## 
+##

--- a/site/content/en/docs/handbook/troubleshooting.md
+++ b/site/content/en/docs/handbook/troubleshooting.md
@@ -19,7 +19,7 @@ Example:
 
 ## Post-mortem minikube debug logs
 
-minikube stores post-mortem INFO logs in the temporary directory of your system. On macOS or Linux, it's easy to get a list of recent INFO logs: 
+minikube stores post-mortem INFO logs in the temporary directory of your system. On macOS or Linux, it's easy to get a list of recent INFO logs:
 
 ```shell
 find $TMPDIR -mtime -1 -type f -name "*minikube*INFO*" -ls  2>/dev/null

--- a/site/content/en/docs/handbook/untrusted_certs.md
+++ b/site/content/en/docs/handbook/untrusted_certs.md
@@ -9,7 +9,7 @@ description: >
 ## Untrusted Root Certificates
 
 Many organizations deploy their own Root Certificate and CA service inside the corporate networks.
-Internal websites, image repositories and other resources may install SSL server certificates issued by this CA service for security and privacy concerns. 
+Internal websites, image repositories and other resources may install SSL server certificates issued by this CA service for security and privacy concerns.
 
 You may install the Root Certificate into the minikube cluster to access these corporate resources within the cluster.
 

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -6,10 +6,9 @@ aliases:
   - /docs/start
 ---
 
-minikube is local Kubernetes, focusing on making it easy to learn and develop for Kubernetes. 
+minikube is local Kubernetes, focusing on making it easy to learn and develop for Kubernetes.
 
 All you need is Docker (or similarly compatible) container or a Virtual Machine environment, and Kubernetes is a single command away: `minikube start`
-
 
 ## What you’ll need
 
@@ -199,7 +198,6 @@ minikube start -p aged --kubernetes-version=v1.16.1
 ```
 
 Delete all of the minikube clusters:
-
 
 ```shell
 minikube delete --all

--- a/site/content/en/docs/tutorials/_index.md
+++ b/site/content/en/docs/tutorials/_index.md
@@ -5,4 +5,4 @@ description: >
   Contributed end-to-end tutorials using minikube
 ---
 
-Tutorials are **complete worked examples** made up of **multiple tasks** that guide the user through a relatively simple but realistic scenario: building an application that uses some of your project’s features, for example. If you have already created some Examples for your project you can base Tutorials on them. 
+Tutorials are **complete worked examples** made up of **multiple tasks** that guide the user through a relatively simple but realistic scenario: building an application that uses some of your project’s features, for example. If you have already created some Examples for your project you can base Tutorials on them.

--- a/site/content/en/docs/tutorials/ambassador_ingress_controller.md
+++ b/site/content/en/docs/tutorials/ambassador_ingress_controller.md
@@ -43,7 +43,7 @@ minikube tunnel
 You can now access Ambassador at the external IP allotted to the `ambassador` service.
 Get the external IP with the following command:
 ```shell script
-kubectl get service ambassador -n ambassador 
+kubectl get service ambassador -n ambassador
 NAME         TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                      AGE
 ambassador   LoadBalancer   10.104.86.124   10.104.86.124   80:31287/TCP,443:31934/TCP   77m
 ```
@@ -84,7 +84,7 @@ spec:
           serviceName: hello-minikube
           servicePort: 8080
 ```
-Run the command: 
+Run the command:
 ```shell
 kubectl apply -f hello-ingress.yaml
 ```
@@ -123,7 +123,7 @@ spec:
   prefix: /hello-mapping/
   service: mapping-minikube.default:8080
 ```
-Run the command: 
+Run the command:
 ```shell
 kubectl apply -f hello-mapping.yaml
 ```

--- a/site/content/en/docs/tutorials/configuring_creds_for_aws_ecr.md
+++ b/site/content/en/docs/tutorials/configuring_creds_for_aws_ecr.md
@@ -13,7 +13,6 @@ The minikube [registry-creds addon](https://github.com/kubernetes/minikube/tree/
 
 The addon automagically refreshes the service account token for the `default` service account in the `default` namespace.
 
-
 ## Prerequisites
 
 - a working minikube cluster
@@ -21,13 +20,11 @@ The addon automagically refreshes the service account token for the `default` se
 - AWS access keys that can be used to pull the above image
 - AWS account number of the account hosting the registry
 
-
 ## Configuring and enabling the registry-creds addon
 
+### Configure the registry-creds addon
 
-### Configure the registry-creds addon 
-
-Configure the minikube registry-creds addon with the following command: 
+Configure the minikube registry-creds addon with the following command:
 
 Note: In this tutorial, we will focus only on the AWS ECR.
 
@@ -56,9 +53,9 @@ Do you want to enable Azure Container Registry? [y/n]: n
 
 ```
 
-### Enable the registry-creds addon 
+### Enable the registry-creds addon
 
-Enable the minikube registry-creds addon with the following command: 
+Enable the minikube registry-creds addon with the following command:
 
 ```shell
 minikube addons enable registry-creds
@@ -116,11 +113,9 @@ Successfully pulled image "<<account_number>>.dkr.ecr.<<aws_region>>.amazonaws.c
 
 If you do not see that event, look at the troubleshooting section.
 
-
 ## Review
 
 In the above tutorial, we configured the `registry-creds` addon to refresh the credentials for AWS ECR so that we could pull private container images onto our minikube cluster. We ultimately created a deployment that used an image in a private AWS ECR repository.
-
 
 ## Troubleshooting
 

--- a/site/content/en/docs/tutorials/ebpf_tools_in_minikube.md
+++ b/site/content/en/docs/tutorials/ebpf_tools_in_minikube.md
@@ -11,7 +11,7 @@ description: >
 
 eBPF tools are performance tools used for observing the Linux kernel.
 These tools can be used to monitor your Kubernetes application in minikube.
-This tutorial will cover how to set up your minikube cluster so that you can run eBPF tools from a Docker container within minikube. 
+This tutorial will cover how to set up your minikube cluster so that you can run eBPF tools from a Docker container within minikube.
 
 ## Prerequisites
 
@@ -28,7 +28,7 @@ $ minikube start --iso-url https://storage.googleapis.com/minikube-performance/m
 You will need to download and extract necessary kernel headers within minikube:
 
 ```shell
-minikube ssh -- curl -Lo /tmp/kernel-headers-linux-4.19.94.tar.lz4 https://storage.googleapis.com/minikube-kernel-headers/kernel-headers-linux-4.19.94.tar.lz4 
+minikube ssh -- curl -Lo /tmp/kernel-headers-linux-4.19.94.tar.lz4 https://storage.googleapis.com/minikube-kernel-headers/kernel-headers-linux-4.19.94.tar.lz4
 
 minikube ssh -- sudo mkdir -p /lib/modules/4.19.94/build
 
@@ -45,13 +45,13 @@ $ minikube ssh -- docker run --rm   --privileged   -v /lib/modules:/lib/modules:
 
 Unable to find image 'zlim/bcc:latest' locally
 latest: Pulling from zlim/bcc
-6cf436f81810: Pull complete 
-987088a85b96: Pull complete 
-b4624b3efe06: Pull complete 
-d42beb8ded59: Pull complete 
-90970d1ebfd9: Pull complete 
-29c3815350eb: Pull complete 
-e21dfbd8fcfc: Pull complete 
+6cf436f81810: Pull complete
+987088a85b96: Pull complete
+b4624b3efe06: Pull complete
+d42beb8ded59: Pull complete
+90970d1ebfd9: Pull complete
+29c3815350eb: Pull complete
+e21dfbd8fcfc: Pull complete
 Digest: sha256:914bea8970535cd6b0d5dee13f99569c5f0d597942c8333c0aa92443473aff27
 Status: Downloaded newer image for zlim/bcc:latest
 PCOMM            PID    PPID   RET ARGS

--- a/site/content/en/docs/tutorials/kubevirt.md
+++ b/site/content/en/docs/tutorials/kubevirt.md
@@ -12,6 +12,7 @@ description: >
 - kvm2 driver
 
 ### Enable KubeVirt on minikube
+
 Minikube can be started with default values and those will be enough to run a quick example, that being said, if you can spare a few more GiBs of RAM (by default it uses 2GiB), it’ll allow you to experiment further.
 
 We’ll create a profile for KubeVirt so it gets its own settings without interfering what any configuration you might have already, let’s start by increasing the default memory to 4GiB:
@@ -30,8 +31,8 @@ minikube addons enable kubevirt
 In a minute or so kubevirt's default components will be installed into your cluster.
 You can run `kubectl get pods -n kubevirt` to see the progress of the kubevirt installation.
 
-
 ### Disable KubeVirt
+
 To disable this addon, simply run:
 ```shell script
 minikube addons disable kubevirt

--- a/site/content/en/docs/tutorials/multi_node.md
+++ b/site/content/en/docs/tutorials/multi_node.md
@@ -17,6 +17,7 @@ date: 2019-11-24
 ## Tutorial
 
 - Start a cluster with 2 nodes in the driver of your choice:
+
 ```shell
 minikube start --nodes 2 -p multinode-demo
 ```
@@ -42,6 +43,7 @@ To track progress on multi-node clusters, see https://github.com/kubernetes/mini
 ```
 
 - Get the list of your nodes:
+
 ```shell
 kubectl get nodes
 ```
@@ -52,9 +54,11 @@ multinode-demo-m02   Ready    <none>   33s   v1.18.2
 ```
 
 - You can also check the status of your nodes:
+
 ```shell
 minikube status -p multinode-demo
 ```
+
 ```
 multinode-demo
 type: Control Plane
@@ -70,6 +74,7 @@ kubelet: Running
 ```
 
 - Deploy our hello world deployment:
+
 ```shell
 kubectl apply -f hello-deployment.yaml
 ```
@@ -83,8 +88,8 @@ kubectl rollout status deployment/hello
 deployment "hello" successfully rolled out
 ```
 
-
 - Deploy our hello world service, which just spits back the IP address the request was served from:
+
 ```shell
 kubectl apply -f hello-svc.yaml
 ```
@@ -92,8 +97,8 @@ kubectl apply -f hello-svc.yaml
 service/hello created
 ```
 
-
 - Check out the IP addresses of our pods, to note for future reference
+
 ```shell
 kubectl get pods -o wide
 ```
@@ -104,6 +109,7 @@ hello-c7b8df44f-xv4v6   1/1     Running   0          31s   10.244.0.2   multinod
 ```
 
 - Look at our service, to know what URL to hit
+
 ```shell
 minikube service list -p multinode-demo
 ```
@@ -118,6 +124,7 @@ minikube service list -p multinode-demo
 ```
 
 - Let's hit the URL a few times and see what comes back
+
 ```shell
 curl  http://192.168.64.226:31000
 ```
@@ -136,10 +143,10 @@ Hello from hello-c7b8df44f-xv4v6 (10.244.0.2)
 
 - Multiple nodes!
 
-
 - Referenced YAML files
 {{% tabs %}}
 {{% tab hello-deployment.yaml %}}
+
 ```
 {{% readfile file="/docs/tutorials/includes/hello-deployment.yaml" %}}
 ```

--- a/site/content/en/docs/tutorials/nginx_tcp_udp_ingress.md
+++ b/site/content/en/docs/tutorials/nginx_tcp_udp_ingress.md
@@ -9,7 +9,7 @@ description: >
 
 ## Overview
 
-The minikube [ingress addon](https://github.com/kubernetes/minikube/tree/master/deploy/addons/ingress) enables developers 
+The minikube [ingress addon](https://github.com/kubernetes/minikube/tree/master/deploy/addons/ingress) enables developers
 to route traffic from their host (Laptop, Desktop, etc) to a Kubernetes service running inside their minikube cluster.
 The ingress addon uses the [ingress nginx](https://github.com/kubernetes/ingress-nginx) controller which by default
 is only configured to listen on ports 80 and 443. TCP and UDP services listening on other ports can be enabled.
@@ -36,7 +36,7 @@ minikube addons enable ingress
 Borrowing from the tutorial on [configuring TCP and UDP services with the ingress nginx controller](https://kubernetes.github.io/ingress-nginx/user-guide/exposing-tcp-udp-services/)
 we will need to edit the configmap which is installed by default when enabling the minikube ingress addon.
 
-There are 2 configmaps, 1 for TCP services and 1 for UDP services. By default they look like this: 
+There are 2 configmaps, 1 for TCP services and 1 for UDP services. By default they look like this:
 
 ```yaml
 apiVersion: v1
@@ -54,7 +54,7 @@ metadata:
   namespace: ingress-nginx
 ```
 
-Since these configmaps are centralized and may contain configurations, it is best if we only patch them rather than completely overwrite them. 
+Since these configmaps are centralized and may contain configurations, it is best if we only patch them rather than completely overwrite them.
 
 Let's use this redis deployment as an example:
 
@@ -130,13 +130,13 @@ Where:
 - `default` : the namespace that your service is installed in
 - `redis-service` : the name of the service
 
-We can verify that our resource was patched with the following command: 
+We can verify that our resource was patched with the following command:
 
 ```shell
 kubectl get configmap tcp-services -n kube-system -o yaml
 ```
 
-We should see something like this: 
+We should see something like this:
 
 ```yaml
 apiVersion: v1
@@ -154,7 +154,7 @@ metadata:
   uid: 4f7fac22-e467-11e9-b543-080027057910
 ```
 
-The only value you need to validate is that there is a value under the `data` property that looks like this: 
+The only value you need to validate is that there is a value under the `data` property that looks like this:
 
 ```yaml
   "6379": default/redis-service:6379
@@ -215,19 +215,18 @@ In the above example we did the following:
 - Patched the `ingress-nginx-controller` deployment in the `kube-system` namespace
 - Connected to our service from the host via port 6379
 
-You can apply the same steps that were applied to `tcp-services` to the `udp-services` configmap as well if you have a 
+You can apply the same steps that were applied to `tcp-services` to the `udp-services` configmap as well if you have a
 service that uses UDP and/or TCP
 
 ## Caveats
 
-With the exception of ports 80 and 443, each minikube instance can only be configured for exactly 1 service to be listening 
-on any particular port. Multiple TCP and/or UDP services listening on the same port in the same minikube instance is not supported 
-and can not be supported until an update of the ingress spec is released. 
-Please see [this document](https://docs.google.com/document/d/1BxYbDovMwnEqe8lj8JwHo8YxHAt3oC7ezhlFsG_tyag/edit#) 
+With the exception of ports 80 and 443, each minikube instance can only be configured for exactly 1 service to be listening
+on any particular port. Multiple TCP and/or UDP services listening on the same port in the same minikube instance is not supported
+and can not be supported until an update of the ingress spec is released.
+Please see [this document](https://docs.google.com/document/d/1BxYbDovMwnEqe8lj8JwHo8YxHAt3oC7ezhlFsG_tyag/edit#)
 for the latest info on these potential changes.
 
 ## Related articles
 
 - [Routing traffic multiple services on ports 80 and 443 in minikube with the Kubernetes Ingress resource](https://kubernetes.io/docs/tasks/access-application-cluster/ingress-minikube/)
 - [Use port forwarding to access applications in a cluster](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/)
-

--- a/site/content/en/docs/tutorials/setup_minikube_in_github_actions.md
+++ b/site/content/en/docs/tutorials/setup_minikube_in_github_actions.md
@@ -9,7 +9,6 @@ description: >
 
 To install and start a minikube cluster, add the following step to your [github action workflow](https://help.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow).
 
-
   ```yaml
       steps:
       - name: start minikube

--- a/site/content/en/docs/tutorials/telemetry.md
+++ b/site/content/en/docs/tutorials/telemetry.md
@@ -10,6 +10,7 @@ date: 2020-11-24
 minikube provides telemetry suppport via [OpenTelemetry tracing](https://opentelemetry.io/about/) to collect trace data for `minikube start`.
 
 Currently, minikube supports the following exporters for tracing data:
+
 - [Stackdriver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/stackdriverexporter)
 
 To collect trace data with minikube and the Stackdriver exporter, run:
@@ -19,6 +20,7 @@ MINIKUBE_GCP_PROJECT_ID=<project ID> minikube start --output json --trace gcp
 ```
 
 ## Contributing
+
 There are many exporters available via [OpenTelemetry community contributions](https://github.com/open-telemetry/opentelemetry-collector-contrib).
 
 If you would like to see additional exporters, please create an [issue](https://github.com/kubernetes/minikube/issues) or refer to our [contribution][https://minikube.sigs.k8s.io/docs/contrib/] guidelines and submit a pull request. Thank you!

--- a/site/content/en/docs/tutorials/volume_snapshots_and_csi.md
+++ b/site/content/en/docs/tutorials/volume_snapshots_and_csi.md
@@ -22,7 +22,7 @@ CRDs and deploys the Volume Snapshot Controller. It is <b>disabled by default</b
 
 Furthermore, the default storage provider in minikube does not implement the CSI interface and thus is NOT capable of creating/handling
 volume snapshots. For that, you must first deploy a CSI driver. To make this step easy, minikube offers the `csi-hostpath-driver` addon,
-which deploys the [CSI Hostpath Driver](https://github.com/kubernetes-csi/csi-driver-host-path). This addon is <b>disabled</b> 
+which deploys the [CSI Hostpath Driver](https://github.com/kubernetes-csi/csi-driver-host-path). This addon is <b>disabled</b>
 by default as well.
 
 Thus, to utilize the volume snapshots functionality, you must:
@@ -37,10 +37,10 @@ minikube addons enable [ADDON_NAME]
 minikube addons disable [ADDON_NAME]
 ```
 
-The `csi-hostpath-driver` addon deploys its required resources into the `kube-system` namespace and sets up a dedicated 
+The `csi-hostpath-driver` addon deploys its required resources into the `kube-system` namespace and sets up a dedicated
 storage class called `csi-hostpath-sc` that you need to reference in your PVCs. The driver itself is created under the
 name `hostpath.csi.k8s.io`. Use this wherever necessary (e.g. snapshot class definitions).
 
 Once both addons are enabled, you can create persistent volumes and snapshots using standard ways (for a quick test of
 volume snapshots, you can find some example yaml files along with a step-by-step [here](https://kubernetes-csi.github.io/docs/snapshot-restore-feature.html)).
-The driver stores all persistent volumes in the `/var/lib/csi-hostpath-data/` directory of minikube's host. 
+The driver stores all persistent volumes in the `/var/lib/csi-hostpath-data/` directory of minikube's host.


### PR DESCRIPTION
Courtesy of `markdownlint`, but nothing to show on:

`git show --ignore-all-space --ignore-blank-lines`

Remaining issues:

`find site/content/en/docs/ -name '*.md' | grep -v commands/ | xargs markdownlint`

```
      1 MD001/heading-increment/header-increment
      1 MD003/heading-style/header-style
      3 MD025/single-title/single-h1
      7 MD034/no-bare-urls
     26 MD040/fenced-code-language
      1 MD041/first-line-heading/first-line-h1
```