### PR TITLE
fix bsutil (kubeadm) unit tests (testdata)

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/files.go
+++ b/pkg/minikube/bootstrapper/bsutil/files.go
@@ -18,8 +18,11 @@ limitations under the License.
 package bsutil
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os/exec"
 	"path"
+	"sort"
 
 	"github.com/pkg/errors"
 	"k8s.io/minikube/pkg/minikube/assets"
@@ -58,4 +61,24 @@ func CopyFiles(runner command.Runner, files []assets.CopyableFile) error {
 		}
 	}
 	return nil
+}
+
+// ReverseDirList returns a list of subdirectories under the given path, sorted in reverse order, and any error.
+// If n > 0, ReverseDirList returns at most n subdirectories.
+// If n <= 0, ReverseDirList returns all the subdirectories from the directory.
+func ReverseDirList(path string, n int) (list []string, err error) {
+	files, err := ioutil.ReadDir(path)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to list directory %s: %w", path, err)
+	}
+	for _, file := range files {
+		if file.IsDir() {
+			list = append(list, file.Name())
+		}
+	}
+	sort.Slice(list, func(i, j int) bool { return list[i] > list[j] })
+	if n <= 0 || n > len(list) {
+		n = len(list)
+	}
+	return list[0:n], nil
 }

--- a/pkg/minikube/bootstrapper/bsutil/files.go
+++ b/pkg/minikube/bootstrapper/bsutil/files.go
@@ -69,7 +69,7 @@ func CopyFiles(runner command.Runner, files []assets.CopyableFile) error {
 func ReverseDirList(path string, n int) (list []string, err error) {
 	files, err := ioutil.ReadDir(path)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to list directory %s: %w", path, err)
+		return nil, fmt.Errorf("unable to list directory %s: %w", path, err)
 	}
 	for _, file := range files {
 		if file.IsDir() {

--- a/pkg/minikube/bootstrapper/bsutil/files.go
+++ b/pkg/minikube/bootstrapper/bsutil/files.go
@@ -18,11 +18,8 @@ limitations under the License.
 package bsutil
 
 import (
-	"fmt"
-	"io/ioutil"
 	"os/exec"
 	"path"
-	"sort"
 
 	"github.com/pkg/errors"
 	"k8s.io/minikube/pkg/minikube/assets"
@@ -61,24 +58,4 @@ func CopyFiles(runner command.Runner, files []assets.CopyableFile) error {
 		}
 	}
 	return nil
-}
-
-// ReverseDirList returns a list of subdirectories under the given path, sorted in reverse order, and any error.
-// If n > 0, ReverseDirList returns at most n subdirectories.
-// If n <= 0, ReverseDirList returns all the subdirectories from the directory.
-func ReverseDirList(path string, n int) (list []string, err error) {
-	files, err := ioutil.ReadDir(path)
-	if err != nil {
-		return nil, fmt.Errorf("unable to list directory %s: %w", path, err)
-	}
-	for _, file := range files {
-		if file.IsDir() {
-			list = append(list, file.Name())
-		}
-	}
-	sort.Slice(list, func(i, j int) bool { return list[i] > list[j] })
-	if n <= 0 || n > len(list) {
-		n = len(list)
-	}
-	return list[0:n], nil
 }

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd-api-port.yaml
@@ -39,7 +39,7 @@ etcd:
     dataDir: /var/lib/minikube/etcd
     extraArgs:
       proxy-refresh-interval: "70000"
-kubernetesVersion: v1.20.0-beta.1.0
+kubernetesVersion: v1.20.0-beta.1
 networking:
   dnsDomain: cluster.local
   podSubnet: "10.244.0.0/16"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd-pod-network-cidr.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/crio/crio.sock
+  criSocket: /run/containerd/containerd.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1
@@ -39,10 +39,10 @@ etcd:
     dataDir: /var/lib/minikube/etcd
     extraArgs:
       proxy-refresh-interval: "70000"
-kubernetesVersion: v1.20.0-beta.1.0
+kubernetesVersion: v1.20.0-beta.1
 networking:
   dnsDomain: cluster.local
-  podSubnet: "10.244.0.0/16"
+  podSubnet: "192.168.32.0/20"
   serviceSubnet: 10.96.0.0/12
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
@@ -63,5 +63,5 @@ staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
-clusterCIDR: "10.244.0.0/16"
+clusterCIDR: "192.168.32.0/20"
 metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/dockershim.sock
+  criSocket: /run/containerd/containerd.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1
@@ -19,7 +19,6 @@ nodeRegistration:
 ---
 apiVersion: kubeadm.k8s.io/v1beta2
 kind: ClusterConfiguration
-imageRepository: test/repo
 apiServer:
   certSANs: ["127.0.0.1", "localhost", "1.1.1.1"]
   extraArgs:
@@ -40,7 +39,7 @@ etcd:
     dataDir: /var/lib/minikube/etcd
     extraArgs:
       proxy-refresh-interval: "70000"
-kubernetesVersion: v1.20.0-beta.1.0
+kubernetesVersion: v1.20.0-beta.1
 networking:
   dnsDomain: cluster.local
   podSubnet: "10.244.0.0/16"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/crio-options-gates.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/dockershim.sock
+  criSocket: /var/run/crio/crio.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1
@@ -24,12 +24,15 @@ apiServer:
   extraArgs:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
     fail-no-swap: "true"
+    feature-gates: "a=b"
 controllerManager:
   extraArgs:
+    feature-gates: "a=b"
     kube-api-burst: "32"
     leader-elect: "false"
 scheduler:
   extraArgs:
+    feature-gates: "a=b"
     leader-elect: "false"
     scheduler-name: "mini-scheduler"
 certificatesDir: /var/lib/minikube/certs
@@ -42,7 +45,7 @@ etcd:
     dataDir: /var/lib/minikube/etcd
     extraArgs:
       proxy-refresh-interval: "70000"
-kubernetesVersion: v1.20.0-beta.1.0
+kubernetesVersion: v1.20.0-beta.1
 networking:
   dnsDomain: cluster.local
   podSubnet: "10.244.0.0/16"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/crio.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/dockershim.sock
+  criSocket: /var/run/crio/crio.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1
@@ -39,7 +39,7 @@ etcd:
     dataDir: /var/lib/minikube/etcd
     extraArgs:
       proxy-refresh-interval: "70000"
-kubernetesVersion: v1.20.0-beta.1.0
+kubernetesVersion: v1.20.0-beta.1
 networking:
   dnsDomain: cluster.local
   podSubnet: "10.244.0.0/16"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/default.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/crio/crio.sock
+  criSocket: /var/run/dockershim.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1
@@ -23,18 +23,12 @@ apiServer:
   certSANs: ["127.0.0.1", "localhost", "1.1.1.1"]
   extraArgs:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
-    fail-no-swap: "true"
-    feature-gates: "a=b"
 controllerManager:
   extraArgs:
-    feature-gates: "a=b"
-    kube-api-burst: "32"
     leader-elect: "false"
 scheduler:
   extraArgs:
-    feature-gates: "a=b"
     leader-elect: "false"
-    scheduler-name: "mini-scheduler"
 certificatesDir: /var/lib/minikube/certs
 clusterName: mk
 controlPlaneEndpoint: control-plane.minikube.internal:8443
@@ -45,7 +39,7 @@ etcd:
     dataDir: /var/lib/minikube/etcd
     extraArgs:
       proxy-refresh-interval: "70000"
-kubernetesVersion: v1.20.0-beta.1.0
+kubernetesVersion: v1.20.0-beta.1
 networking:
   dnsDomain: cluster.local
   podSubnet: "10.244.0.0/16"
@@ -71,4 +65,3 @@ apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 1.1.1.1:10249
-mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/dns.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /run/containerd/containerd.sock
+  criSocket: /var/run/dockershim.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1
@@ -39,9 +39,9 @@ etcd:
     dataDir: /var/lib/minikube/etcd
     extraArgs:
       proxy-refresh-interval: "70000"
-kubernetesVersion: v1.20.0-beta.1.0
+kubernetesVersion: v1.20.0-beta.1
 networking:
-  dnsDomain: cluster.local
+  dnsDomain: 1.1.1.1
   podSubnet: "10.244.0.0/16"
   serviceSubnet: 10.96.0.0/12
 ---

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/image-repository.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /run/containerd/containerd.sock
+  criSocket: /var/run/dockershim.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1
@@ -19,6 +19,7 @@ nodeRegistration:
 ---
 apiVersion: kubeadm.k8s.io/v1beta2
 kind: ClusterConfiguration
+imageRepository: test/repo
 apiServer:
   certSANs: ["127.0.0.1", "localhost", "1.1.1.1"]
   extraArgs:
@@ -39,10 +40,10 @@ etcd:
     dataDir: /var/lib/minikube/etcd
     extraArgs:
       proxy-refresh-interval: "70000"
-kubernetesVersion: v1.20.0-beta.1.0
+kubernetesVersion: v1.20.0-beta.1
 networking:
   dnsDomain: cluster.local
-  podSubnet: "192.168.32.0/20"
+  podSubnet: "10.244.0.0/16"
   serviceSubnet: 10.96.0.0/12
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
@@ -63,5 +64,5 @@ staticPodPath: /etc/kubernetes/manifests
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
-clusterCIDR: "192.168.32.0/20"
+clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 1.1.1.1:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/options.yaml
@@ -23,12 +23,15 @@ apiServer:
   certSANs: ["127.0.0.1", "localhost", "1.1.1.1"]
   extraArgs:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
+    fail-no-swap: "true"
 controllerManager:
   extraArgs:
+    kube-api-burst: "32"
     leader-elect: "false"
 scheduler:
   extraArgs:
     leader-elect: "false"
+    scheduler-name: "mini-scheduler"
 certificatesDir: /var/lib/minikube/certs
 clusterName: mk
 controlPlaneEndpoint: control-plane.minikube.internal:8443
@@ -39,9 +42,9 @@ etcd:
     dataDir: /var/lib/minikube/etcd
     extraArgs:
       proxy-refresh-interval: "70000"
-kubernetesVersion: v1.20.0-beta.1.0
+kubernetesVersion: v1.20.0-beta.1
 networking:
-  dnsDomain: 1.1.1.1
+  dnsDomain: cluster.local
   podSubnet: "10.244.0.0/16"
   serviceSubnet: 10.96.0.0/12
 ---
@@ -65,3 +68,4 @@ apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 1.1.1.1:10249
+mode: "iptables"


### PR DESCRIPTION
fixes: #9707

this pr replaces the hard-coded list of k8s versions to test and builds it dynamically from the existing testdata versions subdirectories, and also handles the case when `<major>.<minor>.0` stable version is not yet released (eg, as with 'v1.20.0-beta.1') by using the latest k8s pre-release version available until stable version gets out, so to have only one set (subdirectory) with test data for each `<major>.<minor>` k8s version under `pkg/minikube/bootstrapper/bsutil/testdata/`