### PR TITLE
add tag to nvidia-driver-installer addon docker image

### DIFF
--- a/deploy/addons/gpu/nvidia-driver-installer.yaml.tmpl
+++ b/deploy/addons/gpu/nvidia-driver-installer.yaml.tmpl
@@ -50,7 +50,7 @@ spec:
         hostPath:
           path: /
       initContainers:
-      - image: {{default "k8s.gcr.io" .ImageRepository}}/minikube-nvidia-driver-installer
+      - image: {{default "k8s.gcr.io" .ImageRepository}}/minikube-nvidia-driver-installer:e2d9b43228decf5d6f7dce3f0a85d390f138fa01
         name: nvidia-driver-installer
         resources:
           requests:


### PR DESCRIPTION
fixes #9727 
Steps to reproduce the issue:

minikube start
minikube addons enable nvidia-driver-installer
kubectl get pod -A | grep nvidia-driver-installer
kube-system nvidia-driver-installer-v9fxt 0/1 Init:ImagePullBackOff

added the image tag from [gcr.io](https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/minikube-nvidia-driver-installer@sha256:492d46f2bc768d6610ec5940b6c3c33c75e03e201cc8786e04cc488659fd6342/details?tab=info)