### PR TITLE
Fix registry-creds addon failure with ImageRepository

### DIFF
--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -266,7 +266,7 @@ var Addons = map[string]*Addon{
 			vmpath.GuestAddonsDir,
 			"registry-creds-rc.yaml",
 			"0640",
-			false),
+			true),
 	}, false, "registry-creds"),
 	"registry-aliases": NewAddon([]*BinAsset{
 		MustBinAsset(


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->


This PR fixes #9722 

It's not necessary make a reverse (#9725).

Problem was that addon was not loading data in this func to deployment file.
`func (m *BinAsset) loadData(isTemplate bool) error`
because isTemplate was always in false.

This PR only change a cred bool var to true in addon class (`pkg/minikube/assets/addons.go`)

In this PR #9551 this value should also have been changed.

Note: Since if you are going to use data load with jinja template as `{{.ImageRepository}}` in yaml file, you have to set the `isTemplate` variable into `true`, in case you are going to set it manually like "`repository/nameImagev1.0`", you can set `isTemplate` into `false`.  All this is done in [addons.go](https://github.com/kubernetes/minikube/blob/master/pkg/minikube/assets/addons.go)

Now it's working

![image](https://user-images.githubusercontent.com/13793894/99541913-6bbbfe80-297f-11eb-8f2c-d58767a972a1.png)

