### PR TITLE
docker-env: "reload" dockerd service first before "restart" to avoid restarting apiserver container

### DIFF
--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -159,10 +159,10 @@ func ensureDockerd(name string, runner command.Runner) {
 	}
 
 	// Docker Docs: https://docs.docker.com/config/containers/live-restore
-	//   On Linux, you can avoid a restart (and avoid any downtime for your containers) by reloading the Docker daemon.
+	//  On Linux, you can avoid a restart (and avoid any downtime for your containers) by reloading the Docker daemon.
 	klog.Warningf("dockerd is not active will try to reload it...")
 	if err := sysinit.New(runner).Reload("docker"); err != nil {
-		klog.Warningf("will try to restar docker because reload failed: %v", err)
+		klog.Warningf("will try to restart dockerd because reload failed: %v", err)
 		if err := sysinit.New(runner).Restart("docker"); err != nil {
 			exit.Message(reason.RuntimeRestart, `The Docker service within '{{.name}}' is not active`, out.V{"name": name})
 		}
@@ -253,7 +253,7 @@ var dockerEnvCmd = &cobra.Command{
 			if err != nil { // docker might be up but been loaded with wrong certs/config
 				// to fix issues like this #8185
 				klog.Warningf("couldn't connect to docker inside minikube. will try to restart dockerd service... output: %s error: %v", string(out), err)
-				esnureDockerd(cname, co.CP.Runner)
+				ensureDockerd(cname, co.CP.Runner)
 			}
 		}
 

--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -165,10 +165,10 @@ func isDockerActive(r command.Runner) bool {
 	return sysinit.New(r).Active("docker")
 }
 
-// mustRestartDockerd will attemp to reload dockerd if fails, will try restart and exit if fails again
+// mustRestartDockerd will attempt to reload dockerd if fails, will try restart and exit if fails again
 func mustRestartDockerd(name string, runner command.Runner) {
 	// Docker Docs: https://docs.docker.com/config/containers/live-restore
-	//  On Linux, you can avoid a restart (and avoid any downtime for your containers) by reloading the Docker daemon.
+	// On Linux, you can avoid a restart (and avoid any downtime for your containers) by reloading the Docker daemon.
 	klog.Warningf("dockerd is not active will try to reload it...")
 	if err := sysinit.New(runner).Reload("docker"); err != nil {
 		klog.Warningf("will try to restart dockerd because reload failed: %v", err)
@@ -256,6 +256,7 @@ var dockerEnvCmd = &cobra.Command{
 			out, err := tryDockerConnectivity("docker", ec)
 			if err != nil { // docker might be up but been loaded with wrong certs/config
 				// to fix issues like this #8185
+				// even though docker maybe running just fine it could be holding on to old certs and needs a refresh
 				klog.Warningf("couldn't connect to docker inside minikube.  output: %s error: %v", string(out), err)
 				mustRestartDockerd(cname, co.CP.Runner)
 			}

--- a/pkg/minikube/sysinit/openrc.go
+++ b/pkg/minikube/sysinit/openrc.go
@@ -20,6 +20,7 @@ package sysinit
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"html/template"
 	"os/exec"
 	"path"
@@ -126,6 +127,12 @@ func (s *OpenRC) Restart(svc string) error {
 	rr, err := s.r.RunCmd(exec.Command("sudo", "service", svc, "restart"))
 	klog.Infof("restart output: %s", rr.Output())
 	return err
+}
+
+// Reload reloads a service
+// currently only used by our docker-env that doesn't need openrc implementation
+func (s *OpenRC) Reload(svc string) error {
+	return fmt.Errorf("reload is not implemented for OpenRC yet ! Please implement if needed")
 }
 
 // Stop stops a service

--- a/pkg/minikube/sysinit/sysinit.go
+++ b/pkg/minikube/sysinit/sysinit.go
@@ -50,6 +50,9 @@ type Manager interface {
 	// Restart restarts a service
 	Restart(string) error
 
+	// Reload restarts a service
+	Reload(string) error
+
 	// Stop stops a service
 	Stop(string) error
 

--- a/pkg/minikube/sysinit/systemd.go
+++ b/pkg/minikube/sysinit/systemd.go
@@ -34,8 +34,8 @@ func (s *Systemd) Name() string {
 	return "systemd"
 }
 
-// reload reloads systemd configuration
-func (s *Systemd) reload() error {
+// daemonReload reloads systemd configuration
+func (s *Systemd) daemonReload() error {
 	_, err := s.r.RunCmd(exec.Command("sudo", "systemctl", "daemon-reload"))
 	return err
 }
@@ -63,7 +63,7 @@ func (s *Systemd) Enable(svc string) error {
 
 // Start starts a service
 func (s *Systemd) Start(svc string) error {
-	if err := s.reload(); err != nil {
+	if err := s.daemonReload(); err != nil {
 		return err
 	}
 	_, err := s.r.RunCmd(exec.Command("sudo", "systemctl", "start", svc))
@@ -72,10 +72,19 @@ func (s *Systemd) Start(svc string) error {
 
 // Restart restarts a service
 func (s *Systemd) Restart(svc string) error {
-	if err := s.reload(); err != nil {
+	if err := s.daemonReload(); err != nil {
 		return err
 	}
 	_, err := s.r.RunCmd(exec.Command("sudo", "systemctl", "restart", svc))
+	return err
+}
+
+// Reload reloads a service
+func (s *Systemd) Reload(svc string) error {
+	if err := s.daemonReload(); err != nil {
+		return err
+	}
+	_, err := s.r.RunCmd(exec.Command("sudo", "systemctl", "reload", svc))
 	return err
 }
 


### PR DESCRIPTION
will attempt to fix this 
https://github.com/kubernetes/minikube/issues/9691