### PR TITLE
Enable Ingress Addon for Docker Windows

### DIFF
--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -145,14 +145,18 @@ func enableOrDisableAddon(cc *config.ClusterConfig, name string, val string) err
 
 	// to match both ingress and ingress-dns addons
 	if strings.HasPrefix(name, "ingress") && enable {
-		if driver.IsKIC(cc.Driver) && runtime.GOOS != "linux" {
-			exit.Message(reason.Usage, `Due to networking limitations of driver {{.driver_name}} on {{.os_name}}, {{.addon_name}} addon is not supported.
+		if driver.IsKIC(cc.Driver) {
+			if runtime.GOOS == "windows" {
+				out.Step(style.Tip,`After the addon is enabled, please run "minikube tunnel" and your ingress resources would be available at "127.0.0.1"`)
+			} else if runtime.GOOS != "linux" {
+				exit.Message(reason.Usage, `Due to networking limitations of driver {{.driver_name}} on {{.os_name}}, {{.addon_name}} addon is not supported.
 Alternatively to use this addon you can use a vm-based driver:
 
 	'minikube start --vm=true'
 
 To track the update on this work in progress feature please check:
 https://github.com/kubernetes/minikube/issues/7332`, out.V{"driver_name": cc.Driver, "os_name": runtime.GOOS, "addon_name": name})
+			}
 		} else if driver.BareMetal(cc.Driver) {
 			exit.Message(reason.Usage, `Due to networking limitations of driver {{.driver_name}}, {{.addon_name}} addon is not supported. Try using a different driver.`,
 				out.V{"driver_name": cc.Driver, "addon_name": name})

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -147,7 +147,7 @@ func enableOrDisableAddon(cc *config.ClusterConfig, name string, val string) err
 	if strings.HasPrefix(name, "ingress") && enable {
 		if driver.IsKIC(cc.Driver) {
 			if runtime.GOOS == "windows" {
-				out.Step(style.Tip,`After the addon is enabled, please run "minikube tunnel" and your ingress resources would be available at "127.0.0.1"`)
+				out.Step(style.Tip, `After the addon is enabled, please run "minikube tunnel" and your ingress resources would be available at "127.0.0.1"`)
 			} else if runtime.GOOS != "linux" {
 				exit.Message(reason.Usage, `Due to networking limitations of driver {{.driver_name}} on {{.os_name}}, {{.addon_name}} addon is not supported.
 Alternatively to use this addon you can use a vm-based driver:


### PR DESCRIPTION
Related bug - #7332 but just for Docker on Windows.

Before merging this PR, ensure that this PR is merged - https://github.com/kubernetes/minikube/pull/9753


With this PR,
1. Enable the Ingress addon for minikube for Docker on Windows.
2. Add a notice in the output which tells to run `minikube tunnel` to access the ingress resources.

Output -
```
PS C:\utilities> .\minikube-windows-amd64.exe addons enable ingress                                                                                           I1121 00:59:39.443965    3000 translate.go:89] Failed to load translation file for en: Asset translations/en.json not found
* After the addon is enabled, please run "minikube tunnel" and your ingress resources would be available at "127.0.0.1"
* Verifying ingress addon...
* The 'ingress' addon is enabled
```
