### PR TITLE
restart inner docker daemon using systemd

### DIFF
--- a/pkg/provision/buildroot.go
+++ b/pkg/provision/buildroot.go
@@ -80,7 +80,7 @@ StartLimitBurst=5
 StartLimitIntervalSec=60
 
 [Service]
-Restart=always
+Restart=on-failure
 RestartSec=1
 Type=notify
 `

--- a/pkg/provision/buildroot.go
+++ b/pkg/provision/buildroot.go
@@ -76,8 +76,12 @@ Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
 After=network.target  minikube-automount.service docker.socket
 Requires= minikube-automount.service docker.socket 
+StartLimitBurst=5
+StartLimitIntervalSec=60
 
 [Service]
+Restart=always
+RestartSec=1
 Type=notify
 `
 	if noPivot {

--- a/pkg/provision/buildroot.go
+++ b/pkg/provision/buildroot.go
@@ -76,13 +76,12 @@ Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
 After=network.target  minikube-automount.service docker.socket
 Requires= minikube-automount.service docker.socket 
-StartLimitBurst=5
-StartLimitIntervalSec=60
 
 [Service]
-Restart=on-failure
-RestartSec=1
 Type=notify
+Restart=on-failure
+StartLimitBurst=3
+StartLimitIntervalSec=60
 `
 	if noPivot {
 		klog.Warning("Using fundamentally insecure --no-pivot option")

--- a/pkg/provision/ubuntu.go
+++ b/pkg/provision/ubuntu.go
@@ -79,8 +79,12 @@ BindsTo=containerd.service
 After=network-online.target firewalld.service containerd.service
 Wants=network-online.target
 Requires=docker.socket
+StartLimitBurst=5
+StartLimitIntervalSec=60
 
 [Service]
+Restart=always
+RestartSec=1
 Type=notify
 `
 	if noPivot {

--- a/pkg/provision/ubuntu.go
+++ b/pkg/provision/ubuntu.go
@@ -83,7 +83,7 @@ StartLimitBurst=5
 StartLimitIntervalSec=60
 
 [Service]
-Restart=always
+Restart=on-failure
 RestartSec=1
 Type=notify
 `

--- a/pkg/provision/ubuntu.go
+++ b/pkg/provision/ubuntu.go
@@ -79,13 +79,12 @@ BindsTo=containerd.service
 After=network-online.target firewalld.service containerd.service
 Wants=network-online.target
 Requires=docker.socket
-StartLimitBurst=5
-StartLimitIntervalSec=60
 
 [Service]
-Restart=on-failure
-RestartSec=1
 Type=notify
+Restart=on-failure
+StartLimitBurst=3
+StartLimitIntervalSec=60
 `
 	if noPivot {
 		klog.Warning("Using fundamentally insecure --no-pivot option")


### PR DESCRIPTION
closes https://github.com/kubernetes/minikube/issues/9691

Fixes the case when docker dies and we never restart it. and then when users run minkube docker-env minikube sees docker sotpped and tries to restart it and that had caused Api server container to be restarting as well. 

it was partially improved by previous PR that changed restart to reload) but still didnt fix actual problem that docker was dying and nobody was birning it back to life

this PR will make Docker service to start after it is failed automatically by Systemd without sending it to an endless loop


in addition to restart always I added `StartLimitIntervalSec=interval` and ,` StartLimitBurst=burst` to the systemd file to avoid infinite restart loops


systemd docs https://www.freedesktop.org/software/systemd/man/systemd.unit.html#StartLimitIntervalSec=

```
StartLimitIntervalSec=interval, StartLimitBurst=burst
Configure unit start rate limiting. Units which are started more than burst times within an interval time interval are not permitted to start any more. Use StartLimitIntervalSec= to configure the checking interval (defaults to DefaultStartLimitIntervalSec= in manager configuration file, set it to 0 to disable any kind of rate limiting). Use StartLimitBurst= to configure how many starts per interval are allowed (defaults to DefaultStartLimitBurst= in manager configuration file). These configuration options are particularly useful in conjunction with the service setting Restart= (see systemd.service(5)); however, they apply to all kinds of starts (including manual), not just those triggered by the Restart= logic. Note that units which are configured for Restart= and which reach the start limit are not attempted to be restarted anymore; however, they may still be restarted manually at a later point, after the interval has passed. From this point on, the restart logic is activated again. Note that systemctl reset-failed will cause the restart rate counter for a service to be flushed, which is useful if the administrator wants to manually start a unit and the start limit interferes with that. Note that this rate-limiting is enforced after any unit condition checks are executed, and hence unit activations with failing conditions do not count towards this rate limit. This setting does not apply to slice, target, device, and scope units, since they are unit types whose activation may either never fail, or may succeed only a single time.

When a unit is unloaded due to the garbage collection logic (see above) its rate limit counters are flushed out too. This means that configuring start rate limiting for a unit that is not referenced continuously has no effect.


```


## link to Docker's recommended setting
https://github.com/moby/moby/blob/e1b15e1e5bf3a512ac7298ed29fcd4126c45c1ae/contrib/init/systemd/docker.service#L29-L31