### PR TITLE
fix TestStartStop crio VerifyKubernetesImages serial test

### DIFF
--- a/pkg/minikube/bootstrapper/images/images.go
+++ b/pkg/minikube/bootstrapper/images/images.go
@@ -29,7 +29,7 @@ import (
 // Pause returns the image name to pull for a given Kubernetes version
 func Pause(v semver.Version, mirror string) string {
 	// Should match `PauseVersion` in:
-	// https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/constants/constants.go
+	// https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/constants/constants_unix.go
 	pv := "3.2"
 	if semver.MustParseRange("<1.18.0-alpha.0")(v) {
 		pv = "3.1"
@@ -37,7 +37,7 @@ func Pause(v semver.Version, mirror string) string {
 	return path.Join(kubernetesRepo(mirror), "pause"+archTag(false)+pv)
 }
 
-// essentials returns images needed too bootstrap a kubenretes
+// essentials returns images needed too bootstrap a Kubernetes
 func essentials(mirror string, v semver.Version) []string {
 	imgs := []string{
 		componentImage("kube-proxy", v, mirror),


### PR DESCRIPTION
fixes #9700

as discussed in the original issue, VerifyKubernetesImages test occasionally 'fails' because of the unexpected images found in the cache (other tests added)

the test changed so that it now only checks if all mandatory images exist, ignoring any other extraneous images in the cache

other minor changes are related to correct reference to current `PauseVersion` image in k8s and typos related to this test