### PR TITLE
fix unable to set memory in config

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -92,8 +92,8 @@ var settings = []Setting{
 	},
 	{
 		name:        "memory",
-		set:         SetInt,
-		validations: []setFn{IsPositive},
+		set:         SetString,
+		validations: []setFn{IsValidDiskSize},
 		callbacks:   []setFn{RequiresRestartMsg},
 	},
 	{

--- a/cmd/minikube/cmd/config/set_test.go
+++ b/cmd/minikube/cmd/config/set_test.go
@@ -38,6 +38,10 @@ func TestSetNotAllowed(t *testing.T) {
 	if err == nil || err.Error() != "run validations for \"driver\" with value of \"123456\": [driver \"123456\" is not supported]" {
 		t.Fatalf("Set did not return error for unallowed value: %+v", err)
 	}
+	err = Set("memory", "10a")
+	if err == nil || err.Error() != "run validations for \"memory\" with value of \"10a\": [invalid disk size: invalid size: '10a']" {
+		t.Fatalf("Set did not return error for unallowed value: %+v", err)
+	}
 }
 
 func TestSetOK(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Tharun <rajendrantharun@live.com>

This PR fixes the `config set memory` command which has invalid `Validation` and `Set` function which not allowed to set a valid memory value. 

Fixes #9769 