### PR TITLE
feat(minikube) add flag to cancel all exisiting scheduled stops

### DIFF
--- a/site/content/en/docs/commands/stop.md
+++ b/site/content/en/docs/commands/stop.md
@@ -20,9 +20,10 @@ minikube stop [flags]
 ### Options
 
 ```
-      --all                   Set flag to stop all profiles (clusters)
-      --keep-context-active   keep the kube-context active after cluster is stopped. Defaults to false.
-  -o, --output string         Format to print stdout in. Options include: [text,json] (default "text")
+      --all                     Set flag to stop all profiles (clusters)
+      --cancel-scheduled-stop   Set flag to cancel all scheduled stop. Defaults to false.
+      --keep-context-active     keep the kube-context active after cluster is stopped. Defaults to false.
+  -o, --output string           Format to print stdout in. Options include: [text,json] (default "text")
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Signed-off-by: Tharun <rajendrantharun@live.com>

Added a new command line flag `--cancel-scheduled-stop` to cancel all scheduled stops.

@priyawadhwa, I reused the existing `KillExisting` to do this. Is this okay or do you have any other suggestions?

Fixes #9790