### PR TITLE
Ability to use a custom TLS certificate with the Ingress addon

### DIFF
--- a/cmd/minikube/cmd/config/configure.go
+++ b/cmd/minikube/cmd/config/configure.go
@@ -19,6 +19,7 @@ package config
 import (
 	"io/ioutil"
 	"net"
+	"regexp"
 
 	"github.com/spf13/cobra"
 	"k8s.io/minikube/pkg/minikube/config"
@@ -202,6 +203,22 @@ var addonsConfigureCmd = &cobra.Command{
 
 			if cfg.KubernetesConfig.LoadBalancerEndIP == "" {
 				cfg.KubernetesConfig.LoadBalancerEndIP = AskForStaticValidatedValue("-- Enter Load Balancer End IP: ", validator)
+			}
+
+			if err := config.SaveProfile(profile, cfg); err != nil {
+				out.ErrT(style.Fatal, "Failed to save config {{.profile}}", out.V{"profile": profile})
+			}
+		case "ingress":
+			profile := ClusterFlagValue()
+			_, cfg := mustload.Partial(profile)
+
+			validator := func(s string) bool {
+				format := regexp.MustCompile("^.+/.+$")
+				return format.MatchString(s)
+			}
+
+			if cfg.KubernetesConfig.CustomIngressCert == "" {
+				cfg.KubernetesConfig.CustomIngressCert = AskForStaticValidatedValue("-- Enter custom cert(format is \"namespace/secret\"): ", validator)
 			}
 
 			if err := config.SaveProfile(profile, cfg); err != nil {

--- a/deploy/addons/ingress/ingress-dp.yaml.tmpl
+++ b/deploy/addons/ingress/ingress-dp.yaml.tmpl
@@ -65,6 +65,9 @@ spec:
             - --validating-webhook=:8443
             - --validating-webhook-certificate=/usr/local/certificates/cert
             - --validating-webhook-key=/usr/local/certificates/key
+            {{if .CustomIngressCert}}
+            - --default-ssl-certificate={{ .CustomIngressCert }} 
+           {{end}}
           securityContext:
             capabilities:
               drop:

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -489,6 +489,7 @@ func GenerateTemplateData(cfg config.KubernetesConfig) interface{} {
 		ImageRepository           string
 		LoadBalancerStartIP       string
 		LoadBalancerEndIP         string
+		CustomIngressCert         string
 		StorageProvisionerVersion string
 	}{
 		Arch:                      a,
@@ -496,6 +497,7 @@ func GenerateTemplateData(cfg config.KubernetesConfig) interface{} {
 		ImageRepository:           cfg.ImageRepository,
 		LoadBalancerStartIP:       cfg.LoadBalancerStartIP,
 		LoadBalancerEndIP:         cfg.LoadBalancerEndIP,
+		CustomIngressCert:         cfg.CustomIngressCert,
 		StorageProvisionerVersion: version.GetStorageProvisionerVersion(),
 	}
 

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -92,6 +92,7 @@ type KubernetesConfig struct {
 	ImageRepository     string
 	LoadBalancerStartIP string // currently only used by MetalLB addon
 	LoadBalancerEndIP   string // currently only used by MetalLB addon
+	CustomIngressCert   string // used by Ingress addon
 	ExtraOptions        ExtraOptionSlice
 
 	ShouldLoadCachedImages bool

--- a/pkg/provision/buildroot.go
+++ b/pkg/provision/buildroot.go
@@ -79,6 +79,9 @@ Requires= minikube-automount.service docker.socket
 
 [Service]
 Type=notify
+Restart=on-failure
+StartLimitBurst=3
+StartLimitIntervalSec=60
 `
 	if noPivot {
 		klog.Warning("Using fundamentally insecure --no-pivot option")

--- a/pkg/provision/ubuntu.go
+++ b/pkg/provision/ubuntu.go
@@ -82,6 +82,9 @@ Requires=docker.socket
 
 [Service]
 Type=notify
+Restart=on-failure
+StartLimitBurst=3
+StartLimitIntervalSec=60
 `
 	if noPivot {
 		klog.Warning("Using fundamentally insecure --no-pivot option")


### PR DESCRIPTION
Description of functionality can be found here: #9335 

This is my first contribution to this repository. I'm sorry for any mistakes.

The change is pretty straightforward, however I have a doubts regarding the tests. I can see that there are no tests for similar pieces of functionality when it comes to addons "registry-creds" and "metallb".

However I found integration tests for ingress addon (test/integration/addons_test.go). Maybe I should extend them to test the new functionality?
