### PR TITLE
Ability to use a custom TLS certificate with the Ingress

### DIFF
--- a/cmd/minikube/cmd/config/configure.go
+++ b/cmd/minikube/cmd/config/configure.go
@@ -19,6 +19,7 @@ package config
 import (
 	"io/ioutil"
 	"net"
+	"regexp"
 
 	"github.com/spf13/cobra"
 	"k8s.io/minikube/pkg/minikube/config"
@@ -202,6 +203,22 @@ var addonsConfigureCmd = &cobra.Command{
 
 			if cfg.KubernetesConfig.LoadBalancerEndIP == "" {
 				cfg.KubernetesConfig.LoadBalancerEndIP = AskForStaticValidatedValue("-- Enter Load Balancer End IP: ", validator)
+			}
+
+			if err := config.SaveProfile(profile, cfg); err != nil {
+				out.ErrT(style.Fatal, "Failed to save config {{.profile}}", out.V{"profile": profile})
+			}
+		case "ingress":
+			profile := ClusterFlagValue()
+			_, cfg := mustload.Partial(profile)
+
+			validator := func(s string) bool {
+				format := regexp.MustCompile("^.+/.+$")
+				return format.MatchString(s)
+			}
+
+			if cfg.KubernetesConfig.CustomIngressCert == "" {
+				cfg.KubernetesConfig.CustomIngressCert = AskForStaticValidatedValue("-- Enter custom cert(format is \"namespace/secret\"): ", validator)
 			}
 
 			if err := config.SaveProfile(profile, cfg); err != nil {

--- a/deploy/addons/ingress/ingress-dp.yaml.tmpl
+++ b/deploy/addons/ingress/ingress-dp.yaml.tmpl
@@ -65,6 +65,9 @@ spec:
             - --validating-webhook=:8443
             - --validating-webhook-certificate=/usr/local/certificates/cert
             - --validating-webhook-key=/usr/local/certificates/key
+            {{if .CustomIngressCert}}
+            - --default-ssl-certificate={{ .CustomIngressCert }} 
+           {{end}}
           securityContext:
             capabilities:
               drop:

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -489,6 +489,7 @@ func GenerateTemplateData(cfg config.KubernetesConfig) interface{} {
 		ImageRepository           string
 		LoadBalancerStartIP       string
 		LoadBalancerEndIP         string
+		CustomIngressCert         string
 		StorageProvisionerVersion string
 	}{
 		Arch:                      a,
@@ -496,6 +497,7 @@ func GenerateTemplateData(cfg config.KubernetesConfig) interface{} {
 		ImageRepository:           cfg.ImageRepository,
 		LoadBalancerStartIP:       cfg.LoadBalancerStartIP,
 		LoadBalancerEndIP:         cfg.LoadBalancerEndIP,
+		CustomIngressCert:         cfg.CustomIngressCert,
 		StorageProvisionerVersion: version.GetStorageProvisionerVersion(),
 	}
 

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -92,6 +92,7 @@ type KubernetesConfig struct {
 	ImageRepository     string
 	LoadBalancerStartIP string // currently only used by MetalLB addon
 	LoadBalancerEndIP   string // currently only used by MetalLB addon
+	CustomIngressCert   string // used by Ingress addon
 	ExtraOptions        ExtraOptionSlice
 
 	ShouldLoadCachedImages bool

--- a/site/content/en/docs/tutorials/custom_cert_ingress.md
+++ b/site/content/en/docs/tutorials/custom_cert_ingress.md
@@ -1,0 +1,44 @@
+---
+title: "How to use custom TLS certificate with ingress addon"
+linkTitle: "Using custom TLS certificate with ingress addon"
+weight: 1
+date: 2020-11-30
+---
+
+## Overview
+
+- This tutorial will show you how to configure custom TLS certificatate for ingress addon.
+
+## Tutorial
+
+- Start minikube
+```
+$ minikube start
+```
+
+- Create TLS secret which contains custom certificate and private key
+```
+$ kubectl -n kube-system create secret tls mkcert --key key.pem --cert cert.pem
+```
+
+- Configure ingress addon
+```
+$ minikube addons configure ingress
+-- Enter custom cert(format is "namespace/secret"): kube-system/mkcert
+✅  ingress was successfully configured
+```
+
+- Enable ingress addon (disable first when already enabled)
+```
+$ minikube addons disable ingress
+🌑  "The 'ingress' addon is disabled
+
+$ minikube addons enable ingress
+🔎  Verifying ingress addon...
+🌟  The 'ingress' addon is enabled
+```
+- Verify if custom certificate was enabled
+```
+$ kubectl -n kube-system get deployment ingress-nginx-controller -o yaml | grep "kube-system"
+- --default-ssl-certificate=kube-system/mkcert
+```


### PR DESCRIPTION
Description of functionality can be found here: #9335

**How to use it**
$ minikube addons configure ingress
-- Enter custom cert(format is "namespace/secret"): kube-system/mkcert
✅  ingress was successfully configured

Enable addons plugin (or disable and then enable if already enabled):
$ minikube addons disable ingress
$ minikube addons enable ingress

**Expected result**
After running:
$ kubectl  -n kube-system get deployment ingress-nginx-controller -o yaml

There will be one extra parameter added to nginx (the last one):
spec:
      containers:
      - args:
        - /nginx-ingress-controller
        - --configmap=$(POD_NAMESPACE)/nginx-load-balancer-conf
        - --report-node-internal-ip-address
        - --tcp-services-configmap=$(POD_NAMESPACE)/tcp-services
        - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
        - --validating-webhook=:8443
        - --validating-webhook-certificate=/usr/local/certificates/cert
        - --validating-webhook-key=/usr/local/certificates/key
        **- --default-ssl-certificate=kube-system/mkcert**

