### PR TITLE
Debian installer: only recommend virtualbox when running on amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -462,6 +462,11 @@ out/minikube_$(DEB_VERSION)-0_%.deb: out/minikube-linux-%
 	chmod 0755 out/minikube_$(DEB_VERSION)/DEBIAN
 	sed -E -i 's/--VERSION--/'$(DEB_VERSION)'/g' out/minikube_$(DEB_VERSION)/DEBIAN/control
 	sed -E -i 's/--ARCH--/'$*'/g' out/minikube_$(DEB_VERSION)/DEBIAN/control
+	if [ "$*" = "amd64" ]; then \
+	    sed -E -i 's/--RECOMMENDS--/virtualbox/' out/minikube_$(DEB_VERSION)/DEBIAN/control; \
+	else \
+	    sed -E -i '/Recommends: --RECOMMENDS--/d' out/minikube_$(DEB_VERSION)/DEBIAN/control; \
+	fi
 	mkdir -p out/minikube_$(DEB_VERSION)/usr/bin
 	cp $< out/minikube_$(DEB_VERSION)/usr/bin/minikube
 	fakeroot dpkg-deb --build out/minikube_$(DEB_VERSION) $@

--- a/installers/linux/deb/minikube_deb_template/DEBIAN/control
+++ b/installers/linux/deb/minikube_deb_template/DEBIAN/control
@@ -3,7 +3,7 @@ Version: --VERSION--
 Section: base
 Priority: optional
 Architecture: --ARCH--
-Recommends: virtualbox
+Recommends: --RECOMMENDS--
 Maintainer: Thomas Strömberg <t+minikube@stromberg.org>
 Description: Minikube
  minikube is a tool that makes it easy to run Kubernetes locally.


### PR DESCRIPTION
Remove the "recommendation" from the arm64 deb
