### PR TITLE
Removed verbosity level from SSH commands to increase log visibility

### DIFF
--- a/pkg/minikube/command/ssh_runner.go
+++ b/pkg/minikube/command/ssh_runner.go
@@ -122,13 +122,13 @@ func teeSSH(s *ssh.Session, cmd string, outB io.Writer, errB io.Writer) error {
 	wg.Add(2)
 
 	go func() {
-		if err := teePrefix(ErrPrefix, errPipe, errB, klog.V(8).Infof); err != nil {
+		if err := teePrefix(ErrPrefix, errPipe, errB, klog.Infof); err != nil {
 			klog.Errorf("tee stderr: %v", err)
 		}
 		wg.Done()
 	}()
 	go func() {
-		if err := teePrefix(OutPrefix, outPipe, outB, klog.V(8).Infof); err != nil {
+		if err := teePrefix(OutPrefix, outPipe, outB, klog.Infof); err != nil {
 			klog.Errorf("tee stdout: %v", err)
 		}
 		wg.Done()


### PR DESCRIPTION
This PR is to help fix part of issue #9779, the tldr of that issue is that the logging of SSH commands wasn't being output to the logs when running the command `minikube start --alsologtostderr` so some commands were running for 20+ seconds without feedback. The verbosity level on the SSH logging was preventing it from making it's way to the logs.

**Command: `minikube start --alsologtostderr`**
Before:
```
I1202 15:57:29.712096    2917 ssh_runner.go:148] Run: /bin/bash -c "sudo env PATH=/var/lib/minikube/binaries/v1.19.4:$PATH kubeadm init --config /var/tmp/minikube/kubeadm.yaml  --ignore-preflight-errors=DirAvailable--etc-kubernetes-manifests,DirAvailable--var-lib-minikube,DirAvailable--var-lib-minikube-etcd,FileAvailable--etc-kubernetes-manifests-kube-scheduler.yaml,FileAvailable--etc-kubernetes-manifests-kube-apiserver.yaml,FileAvailable--etc-kubernetes-manifests-kube-controller-manager.yaml,FileAvailable--etc-kubernetes-manifests-etcd.yaml,Port-10250,Swap,SystemVerification,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables"
I1202 15:57:51.076393    2917 ssh_runner.go:188] Completed: /bin/bash -c "sudo env PATH=/var/lib/minikube/binaries/v1.19.4:$PATH kubeadm init --config /var/tmp/minikube/kubeadm.yaml  --ignore-preflight-errors=DirAvailable--etc-kubernetes-manifests,DirAvailable--var-lib-minikube,DirAvailable--var-lib-minikube-etcd,FileAvailable--etc-kubernetes-manifests-kube-scheduler.yaml,FileAvailable--etc-kubernetes-manifests-kube-apiserver.yaml,FileAvailable--etc-kubernetes-manifests-kube-controller-manager.yaml,FileAvailable--etc-kubernetes-manifests-etcd.yaml,Port-10250,Swap,SystemVerification,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables": (21.364140109s)
```

After:
```
I1202 14:56:28.108127   95594 ssh_runner.go:150] Run: /bin/bash -c "sudo env PATH=/var/lib/minikube/binaries/v1.19.4:$PATH kubeadm init --config /var/tmp/minikube/kubeadm.yaml  --ignore-preflight-errors=DirAvailable--etc-kubernetes-manifests,DirAvailable--var-lib-minikube,DirAvailable--var-lib-minikube-etcd,FileAvailable--etc-kubernetes-manifests-kube-scheduler.yaml,FileAvailable--etc-kubernetes-manifests-kube-apiserver.yaml,FileAvailable--etc-kubernetes-manifests-kube-controller-manager.yaml,FileAvailable--etc-kubernetes-manifests-etcd.yaml,Port-10250,Swap,SystemVerification,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables"
I1202 14:56:28.331835   95594 command_runner.go:109] > [init] Using Kubernetes version: v1.19.4
I1202 14:56:28.331878   95594 command_runner.go:109] > [preflight] Running pre-flight checks
I1202 14:56:28.893032   95594 command_runner.go:109] > [preflight] Pulling images required for setting up a Kubernetes cluster
I1202 14:56:28.893074   95594 command_runner.go:109] > [preflight] This might take a minute or two, depending on the speed of your internet connection
I1202 14:56:28.893086   95594 command_runner.go:109] > [preflight] You can also perform this action in beforehand using 'kubeadm config images pull'
I1202 14:56:29.297307   95594 command_runner.go:109] > [certs] Using certificateDir folder "/var/lib/minikube/certs"
I1202 14:56:29.298054   95594 command_runner.go:109] > [certs] Using existing ca certificate authority
I1202 14:56:29.299443   95594 command_runner.go:109] > [certs] Using existing apiserver certificate and key on disk
I1202 14:56:29.369683   95594 command_runner.go:109] > [certs] Generating "apiserver-kubelet-client" certificate and key
I1202 14:56:29.602507   95594 command_runner.go:109] > [certs] Generating "front-proxy-ca" certificate and key
I1202 14:56:29.762999   95594 command_runner.go:109] > [certs] Generating "front-proxy-client" certificate and key
I1202 14:56:30.431189   95594 command_runner.go:109] > [certs] Generating "etcd/ca" certificate and key
I1202 14:56:30.596962   95594 command_runner.go:109] > [certs] Generating "etcd/server" certificate and key
I1202 14:56:30.596994   95594 command_runner.go:109] > [certs] etcd/server serving cert is signed for DNS names [localhost minikube] and IPs [192.168.49.2 127.0.0.1 ::1]
I1202 14:56:30.861383   95594 command_runner.go:109] > [certs] Generating "etcd/peer" certificate and key
I1202 14:56:30.861428   95594 command_runner.go:109] > [certs] etcd/peer serving cert is signed for DNS names [localhost minikube] and IPs [192.168.49.2 127.0.0.1 ::1]
I1202 14:56:31.270539   95594 command_runner.go:109] > [certs] Generating "etcd/healthcheck-client" certificate and key
I1202 14:56:31.496451   95594 command_runner.go:109] > [certs] Generating "apiserver-etcd-client" cer
...
I1202 14:56:54.860877   95594 ssh_runner.go:190] Completed: /bin/bash -c "sudo env PATH=/var/lib/minikube/binaries/v1.19.4:$PATH kubeadm init --config /var/tmp/minikube/kubeadm.yaml  --ignore-preflight-errors=DirAvailable--etc-kubernetes-manifests,DirAvailable--var-lib-minikube,DirAvailable--var-lib-minikube-etcd,FileAvailable--etc-kubernetes-manifests-kube-scheduler.yaml,FileAvailable--etc-kubernetes-manifests-kube-apiserver.yaml,FileAvailable--etc-kubernetes-manifests-kube-controller-manager.yaml,FileAvailable--etc-kubernetes-manifests-etcd.yaml,Port-10250,Swap,SystemVerification,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables": (26.751018914s)
```