### PR TITLE
Set 'currentstep' for PullingBaseImage json event

### DIFF
--- a/pkg/minikube/out/register/register.go
+++ b/pkg/minikube/out/register/register.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// If you add a new step here, please also add it to register.Reg registry inside the init() function
 const (
 	InitialSetup         RegStep = "Initial Minikube Setup"
 	SelectingDriver      RegStep = "Selecting Driver"

--- a/pkg/minikube/out/register/register.go
+++ b/pkg/minikube/out/register/register.go
@@ -69,6 +69,7 @@ func init() {
 				SelectingDriver,
 				DownloadingArtifacts,
 				StartingNode,
+				PullingBaseImage,
 				RunningLocalhost,
 				LocalOSRelease,
 				CreatingContainer,

--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -70,20 +70,22 @@ func TestDownloadOnly(t *testing.T) {
 					if err != nil {
 						t.Errorf("failed to download only. args: %q %v", args, err)
 					}
-					s := bufio.NewScanner(bytes.NewReader(rt.Stdout.Bytes()))
-					for s.Scan() {
-						var rtObj map[string]interface{}
-						err = json.Unmarshal(s.Bytes(), &rtObj)
-						if err != nil {
-							t.Errorf("failed to parse output: %v", err)
-						} else if step, ok := rtObj["data"]; ok {
-							if stepMap, ok := step.(map[string]interface{}); ok {
-								if stepMap["currentstep"] == "" {
-									t.Errorf("Empty step number for %v", stepMap["name"])
+					t.Run("check json events", func(t *testing.T) {
+						s := bufio.NewScanner(bytes.NewReader(rt.Stdout.Bytes()))
+						for s.Scan() {
+							var rtObj map[string]interface{}
+							err = json.Unmarshal(s.Bytes(), &rtObj)
+							if err != nil {
+								t.Errorf("failed to parse output: %v", err)
+							} else if step, ok := rtObj["data"]; ok {
+								if stepMap, ok := step.(map[string]interface{}); ok {
+									if stepMap["currentstep"] == "" {
+										t.Errorf("Empty step number for %v", stepMap["name"])
+									}
 								}
 							}
 						}
-					}
+					})
 
 					// skip for none, as none driver does not have preload feature.
 					if !NoneDriver() {

--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -76,12 +76,10 @@ func TestDownloadOnly(t *testing.T) {
 						err = json.Unmarshal(s.Bytes(), &rtObj)
 						if err != nil {
 							t.Errorf("failed to parse output: %v", err)
-						} else {
-							if step, ok := rtObj["data"]; ok {
-								if stepMap, ok := step.(map[string]interface{}); ok {
-									if stepMap["currentstep"] == "" {
-										t.Errorf("Empty step number for %v", stepMap["name"])
-									}
+						} else if step, ok := rtObj["data"]; ok {
+							if stepMap, ok := step.(map[string]interface{}); ok {
+								if stepMap["currentstep"] == "" {
+									t.Errorf("Empty step number for %v", stepMap["name"])
 								}
 							}
 						}

--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -19,8 +19,11 @@ limitations under the License.
 package integration
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"crypto/md5"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -41,7 +44,6 @@ func TestDownloadOnly(t *testing.T) {
 		t.Run(r, func(t *testing.T) {
 			// Stores the startup run result for later error messages
 			var rrr *RunResult
-			var err error
 
 			profile := UniqueProfileName(r)
 			ctx, cancel := context.WithTimeout(context.Background(), Minutes(30))
@@ -58,17 +60,31 @@ func TestDownloadOnly(t *testing.T) {
 					defer PostMortemLogs(t, profile)
 
 					// --force to avoid uid check
-					args := append([]string{"start", "--download-only", "-p", profile, "--force", "--alsologtostderr", fmt.Sprintf("--kubernetes-version=%s", v), fmt.Sprintf("--container-runtime=%s", r)}, StartArgs()...)
+					args := append([]string{"start", "-o=json", "--download-only", "-p", profile, "--force", "--alsologtostderr", fmt.Sprintf("--kubernetes-version=%s", v), fmt.Sprintf("--container-runtime=%s", r)}, StartArgs()...)
 
-					// Preserve the initial run-result for debugging
+					rt, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 					if rrr == nil {
-						rrr, err = Run(t, exec.CommandContext(ctx, Target(), args...))
-					} else {
-						_, err = Run(t, exec.CommandContext(ctx, Target(), args...))
+						// Preserve the initial run-result for debugging
+						rrr = rt
 					}
-
 					if err != nil {
 						t.Errorf("failed to download only. args: %q %v", args, err)
+					}
+					s := bufio.NewScanner(bytes.NewReader(rt.Stdout.Bytes()))
+					for s.Scan() {
+						var rtObj map[string]interface{}
+						err = json.Unmarshal(s.Bytes(), &rtObj)
+						if err != nil {
+							t.Errorf("failed to parse output: %v", err)
+						} else {
+							if step, ok := rtObj["data"]; ok {
+								if stepMap, ok := step.(map[string]interface{}); ok {
+									if stepMap["currentstep"] == "" {
+										t.Errorf("Empty step number for %v", stepMap["name"])
+									}
+								}
+							}
+						}
 					}
 
 					// skip for none, as none driver does not have preload feature.


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/9754

Before:
```
izuyev@izuyev-macbookpro --- z/minikube ‹gh_9754_downloadprogress_currentstep* M?› » out/minikube start --driver=docker -o=json -v=8 | tee start.log
{"data":{"currentstep":"0","message":"minikube v1.15.1 on Darwin 10.15.7","name":"Initial Minikube Setup","totalsteps":"12"},"datacontenttype":"application/json","id":"aa727e4d-a5df-48d8-8a7d-7563a33d2e01","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.step"}
{"data":{"currentstep":"1","message":"Using the docker driver based on user configuration","name":"Selecting Driver","totalsteps":"12"},"datacontenttype":"application/json","id":"5893b876-f201-40b1-9169-b00888677fa3","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.step"}
{"data":{"currentstep":"3","message":"Starting control plane node minikube in cluster minikube","name":"Starting Node","totalsteps":"12"},"datacontenttype":"application/json","id":"a5d9eaa4-73f8-4bd1-8eef-395a3f68c1e3","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.step"}
{"data":{.     "currentstep":"",     "message":"Pulling base image ...","name":"Pulling Base Image","totalsteps":"12"},"datacontenttype":"application/json","id":"1143f123-0f34-4e7b-8e0a-7527c65eb38e","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.step"}
```

After:
```
izuyev@izuyev-macbookpro --- z/minikube ‹gh_9754_downloadprogress_currentstep* M?› » out/minikube start --driver=docker -o=json -v=8 | tee start.log
{"data":{"currentstep":"0","message":"minikube v1.15.1 on Darwin 10.15.7","name":"Initial Minikube Setup","totalsteps":"13"},"datacontenttype":"application/json","id":"f6b4ea90-0704-419e-a108-bc1c657e6942","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.step"}
{"data":{"currentstep":"1","message":"Using the docker driver based on existing profile","name":"Selecting Driver","totalsteps":"13"},"datacontenttype":"application/json","id":"e93110b7-1d22-45a4-ae26-24413593f499","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.step"}
{"data":{"currentstep":"3","message":"Starting control plane node minikube in cluster minikube","name":"Starting Node","totalsteps":"13"},"datacontenttype":"application/json","id":"c83a685a-07b6-4673-83bd-af367a8ff021","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.step"}
{"data":{.   "currentstep":"4",    "message":"Pulling base image ...","name":"Pulling Base Image","totalsteps":"13"},"datacontenttype":"application/json","id":"8e392ad7-808c-4c37-83b4-19f4e3807894","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.step"}
```