### PR TITLE
fix GHReleases() to use rls tag name instead of rls name for rls version

### DIFF
--- a/hack/update/github.go
+++ b/hack/update/github.go
@@ -221,7 +221,7 @@ func GHReleases(ctx context.Context, owner, repo string) (stable, latest string,
 			return "", "", err
 		}
 		for _, rl := range rls {
-			ver := rl.GetName()
+			ver := rl.GetTagName()
 			if !semver.IsValid(ver) {
 				continue
 			}

--- a/hack/update/update.go
+++ b/hack/update/update.go
@@ -88,8 +88,7 @@ func (i *Item) apply(data interface{}) error {
 	if i.Content == nil {
 		return fmt.Errorf("unable to update content: nothing to update")
 	}
-	org := string(i.Content)
-	str := org
+	str := string(i.Content)
 	for src, dst := range i.Replace {
 		out, err := ParseTmpl(dst, data, "")
 		if err != nil {


### PR DESCRIPTION
fixes #9851 

as described in the original issue, currently we will miss out any non-semver-compliant _release names_, whereas we should use respective _release tags_ instead

eg, https://github.com/kubernetes/kubernetes/releases for the first time now used `Kubernetes v1.20.0-rc.0` as a release name, while all previous ones were in semver format (ie, w/o any prefix such as `Kubernetes` in this specific case)

### examples running the kubernetes update script (notice the difference in 'latest' version)
'before' the pr:
```
❯ go run update_kubernetes_version.go
I1204 19:07:39.296409    9943 update_kubernetes_version.go:140] Kubernetes versions: 'stable' is v1.19.4 and 'latest' is v1.20.0-beta.2
I1204 19:07:39.298731    9943 update.go:111] The Plan:
{
  "pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd-api-port.yaml": {
    "replace": {
      "kubernetesVersion:.*": "kubernetesVersion: v1.20.0-beta.2"
    }
  },
  "pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd-pod-network-cidr.yaml": {
    "replace": {
      "kubernetesVersion:.*": "kubernetesVersion: v1.20.0-beta.2"
    }
  },
  "pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd.yaml": {
    "replace": {
      "kubernetesVersion:.*": "kubernetesVersion: v1.20.0-beta.2"
    }
  },
  "pkg/minikube/bootstrapper/bsutil/testdata/v1.20/crio-options-gates.yaml": {
    "replace": {
      "kubernetesVersion:.*": "kubernetesVersion: v1.20.0-beta.2"
    }
  },
  "pkg/minikube/bootstrapper/bsutil/testdata/v1.20/crio.yaml": {
    "replace": {
      "kubernetesVersion:.*": "kubernetesVersion: v1.20.0-beta.2"
    }
  },
  "pkg/minikube/bootstrapper/bsutil/testdata/v1.20/default.yaml": {
    "replace": {
      "kubernetesVersion:.*": "kubernetesVersion: v1.20.0-beta.2"
    }
  },
  "pkg/minikube/bootstrapper/bsutil/testdata/v1.20/dns.yaml": {
    "replace": {
      "kubernetesVersion:.*": "kubernetesVersion: v1.20.0-beta.2"
    }
  },
  "pkg/minikube/bootstrapper/bsutil/testdata/v1.20/image-repository.yaml": {
    "replace": {
      "kubernetesVersion:.*": "kubernetesVersion: v1.20.0-beta.2"
    }
  },
  "pkg/minikube/bootstrapper/bsutil/testdata/v1.20/options.yaml": {
    "replace": {
      "kubernetesVersion:.*": "kubernetesVersion: v1.20.0-beta.2"
    }
  },
  "pkg/minikube/constants/constants.go": {
    "replace": {
      "DefaultKubernetesVersion = \".*": "DefaultKubernetesVersion = \"v1.19.4\"",
      "NewestKubernetesVersion = \".*": "NewestKubernetesVersion = \"v1.20.0-beta.2\""
    }
  },
  "site/content/en/docs/commands/start.md": {
    "replace": {
      "'latest' for .*\\)": "'latest' for v1.20.0-beta.2)",
      "'stable' for .*,": "'stable' for v1.19.4,"
    }
  }
}
I1204 19:07:39.302119    9943 update.go:120] Local repo successfully updated
```

'after' the pr:
```
❯ go run update_kubernetes_version.go
I1204 19:12:03.899309   11907 update_kubernetes_version.go:140] Kubernetes versions: 'stable' is v1.19.4 and 'latest' is v1.20.0-rc.0
I1204 19:12:03.900094   11907 update.go:111] The Plan:
{
  "pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd-api-port.yaml": {
    "replace": {
      "kubernetesVersion:.*": "kubernetesVersion: v1.20.0-rc.0"
    }
  },
  "pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd-pod-network-cidr.yaml": {
    "replace": {
      "kubernetesVersion:.*": "kubernetesVersion: v1.20.0-rc.0"
    }
  },
  "pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd.yaml": {
    "replace": {
      "kubernetesVersion:.*": "kubernetesVersion: v1.20.0-rc.0"
    }
  },
  "pkg/minikube/bootstrapper/bsutil/testdata/v1.20/crio-options-gates.yaml": {
    "replace": {
      "kubernetesVersion:.*": "kubernetesVersion: v1.20.0-rc.0"
    }
  },
  "pkg/minikube/bootstrapper/bsutil/testdata/v1.20/crio.yaml": {
    "replace": {
      "kubernetesVersion:.*": "kubernetesVersion: v1.20.0-rc.0"
    }
  },
  "pkg/minikube/bootstrapper/bsutil/testdata/v1.20/default.yaml": {
    "replace": {
      "kubernetesVersion:.*": "kubernetesVersion: v1.20.0-rc.0"
    }
  },
  "pkg/minikube/bootstrapper/bsutil/testdata/v1.20/dns.yaml": {
    "replace": {
      "kubernetesVersion:.*": "kubernetesVersion: v1.20.0-rc.0"
    }
  },
  "pkg/minikube/bootstrapper/bsutil/testdata/v1.20/image-repository.yaml": {
    "replace": {
      "kubernetesVersion:.*": "kubernetesVersion: v1.20.0-rc.0"
    }
  },
  "pkg/minikube/bootstrapper/bsutil/testdata/v1.20/options.yaml": {
    "replace": {
      "kubernetesVersion:.*": "kubernetesVersion: v1.20.0-rc.0"
    }
  },
  "pkg/minikube/constants/constants.go": {
    "replace": {
      "DefaultKubernetesVersion = \".*": "DefaultKubernetesVersion = \"v1.19.4\"",
      "NewestKubernetesVersion = \".*": "NewestKubernetesVersion = \"v1.20.0-rc.0\""
    }
  },
  "site/content/en/docs/commands/start.md": {
    "replace": {
      "'latest' for .*\\)": "'latest' for v1.20.0-rc.0)",
      "'stable' for .*,": "'stable' for v1.19.4,"
    }
  }
}
I1204 19:12:03.901250   11907 update.go:120] Local repo successfully updated
```