### PR TITLE
Create reusable SSH session in factory

### DIFF
--- a/pkg/minikube/machine/client.go
+++ b/pkg/minikube/machine/client.go
@@ -157,7 +157,7 @@ func CommandRunner(h *host.Host) (command.Runner, error) {
 		return command.NewExecRunner(), nil
 	}
 
-	return command.NewSSHRunner(h.Driver), nil
+	return command.NewSSHRunner(h.Driver)
 }
 
 // Create creates the host

--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -170,7 +170,10 @@ func copyRemoteCerts(authOptions auth.Options, driver drivers.Driver) error {
 		authOptions.ServerKeyPath:  authOptions.ServerKeyRemotePath,
 	}
 
-	sshRunner := command.NewSSHRunner(driver)
+	sshRunner, err := command.NewSSHRunner(driver)
+	if err != nil {
+		return err
+	}
 
 	dirs := []string{}
 	for _, dst := range remoteCerts {


### PR DESCRIPTION
This change opens the gate to allow log streaming on SSH commands. It will hopefully also result in a speed increase as new sessions won't have to be created on every command.