### PR TITLE
Add --node option for command `ip` and `ssh-key`

### DIFF
--- a/cmd/minikube/cmd/ip.go
+++ b/cmd/minikube/cmd/ip.go
@@ -18,17 +18,29 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/mustload"
+	"k8s.io/minikube/pkg/minikube/node"
 	"k8s.io/minikube/pkg/minikube/out"
+	"k8s.io/minikube/pkg/minikube/reason"
 )
 
 // ipCmd represents the ip command
 var ipCmd = &cobra.Command{
 	Use:   "ip",
-	Short: "Retrieves the IP address of the running cluster",
-	Long:  `Retrieves the IP address of the running cluster, and writes it to STDOUT.`,
+	Short: "Retrieves the IP address of the specified node",
+	Long:  `Retrieves the IP address of the specified node, and writes it to STDOUT.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		co := mustload.Running(ClusterFlagValue())
-		out.Ln(co.CP.IP.String())
+		n, _, err := node.Retrieve(*co.Config, nodeName)
+		if err != nil {
+			exit.Error(reason.GuestNodeRetrieve, "retrieving node", err)
+		}
+
+		out.Ln(n.IP)
 	},
+}
+
+func init() {
+	ipCmd.Flags().StringVarP(&nodeName, "node", "n", "", "The node to get IP. Defaults to the primary control plane.")
 }

--- a/cmd/minikube/cmd/ssh-key.go
+++ b/cmd/minikube/cmd/ssh-key.go
@@ -20,18 +20,31 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+	"k8s.io/minikube/pkg/minikube/driver"
+	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/minikube/mustload"
+	"k8s.io/minikube/pkg/minikube/node"
 	"k8s.io/minikube/pkg/minikube/out"
+	"k8s.io/minikube/pkg/minikube/reason"
 )
 
 // sshKeyCmd represents the sshKey command
 var sshKeyCmd = &cobra.Command{
 	Use:   "ssh-key",
-	Short: "Retrieve the ssh identity key path of the specified cluster",
-	Long:  "Retrieve the ssh identity key path of the specified cluster.",
+	Short: "Retrieve the ssh identity key path of the specified node",
+	Long:  "Retrieve the ssh identity key path of the specified node, and writes it to STDOUT.",
 	Run: func(cmd *cobra.Command, args []string) {
 		_, cc := mustload.Partial(ClusterFlagValue())
-		out.Ln(filepath.Join(localpath.MiniPath(), "machines", cc.Name, "id_rsa"))
+		n, _, err := node.Retrieve(*cc, nodeName)
+		if err != nil {
+			exit.Error(reason.GuestNodeRetrieve, "retrieving node", err)
+		}
+
+		out.Ln(filepath.Join(localpath.MiniPath(), "machines", driver.MachineName(*cc, *n), "id_rsa"))
 	},
+}
+
+func init() {
+	sshKeyCmd.Flags().StringVarP(&nodeName, "node", "n", "", "The node to get ssh-key path. Defaults to the primary control plane.")
 }

--- a/site/content/en/docs/commands/ip.md
+++ b/site/content/en/docs/commands/ip.md
@@ -1,20 +1,26 @@
 ---
 title: "ip"
 description: >
-  Retrieves the IP address of the running cluster
+  Retrieves the IP address of the specified node
 ---
 
 
 ## minikube ip
 
-Retrieves the IP address of the running cluster
+Retrieves the IP address of the specified node
 
 ### Synopsis
 
-Retrieves the IP address of the running cluster, and writes it to STDOUT.
+Retrieves the IP address of the specified node, and writes it to STDOUT.
 
 ```shell
 minikube ip [flags]
+```
+
+### Options
+
+```
+  -n, --node string   The node to get IP. Defaults to the primary control plane.
 ```
 
 ### Options inherited from parent commands

--- a/site/content/en/docs/commands/ssh-key.md
+++ b/site/content/en/docs/commands/ssh-key.md
@@ -1,20 +1,26 @@
 ---
 title: "ssh-key"
 description: >
-  Retrieve the ssh identity key path of the specified cluster
+  Retrieve the ssh identity key path of the specified node
 ---
 
 
 ## minikube ssh-key
 
-Retrieve the ssh identity key path of the specified cluster
+Retrieve the ssh identity key path of the specified node
 
 ### Synopsis
 
-Retrieve the ssh identity key path of the specified cluster.
+Retrieve the ssh identity key path of the specified node, and writes it to STDOUT.
 
 ```shell
 minikube ssh-key [flags]
+```
+
+### Options
+
+```
+  -n, --node string   The node to get ssh-key path. Defaults to the primary control plane.
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Provides options `-n, --node` for command `ip` and `ssh-key` while minikube now support multi-node.

Example:
```bash
$ minikube ip -n m03
192.168.39.112
$ minikube ip -n m02
192.168.39.195
$ minikube ip -n m05

❌  Exiting due to GUEST_NODE_RETRIEVE: Could not find node m05

😿  If the above advice does not help, please let us know: 
👉  https://github.com/kubernetes/minikube/issues/new/choose

$ minikube ssh-key -n m05

❌  Exiting due to GUEST_NODE_RETRIEVE: Could not find node m05

😿  If the above advice does not help, please let us know: 
👉  https://github.com/kubernetes/minikube/issues/new/choose

$ minikube ssh-key -n m03
/home/lingsamuel/.minikube/machines/minikube-m03/id_rsa
$ minikube ip
192.168.39.13
$ minikube ssh-key
/home/lingsamuel/.minikube/machines/minikube/id_rsa
```