### PR TITLE
Fix multi node two pods getting same IP and nodespec not having PodCIDR

### DIFF
--- a/cmd/minikube/cmd/node_add.go
+++ b/cmd/minikube/cmd/node_add.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"k8s.io/minikube/pkg/minikube/cni"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/exit"
@@ -63,6 +64,10 @@ var nodeAddCmd = &cobra.Command{
 			warnAboutMultiNode()
 			if viper.GetString(memory) == "" {
 				cc.Memory = 2200
+			}
+
+			if !cc.MultiNodeRequested || cni.IsDisabled(*cc) {
+				warnAboutMultiNodeCNI()
 			}
 		}
 

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -403,6 +403,10 @@ func warnAboutMultiNode() {
 	out.Step(style.Documentation, "To track progress on multi-node clusters, see https://github.com/kubernetes/minikube/issues/7538.")
 }
 
+func warnAboutMultiNodeCNI() {
+	out.WarningT("Cluster was created without any CNI, adding node to it might cause broken network.")
+}
+
 func updateDriver(driverName string) {
 	v, err := version.GetSemverVersion()
 	if err != nil {

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -347,6 +347,7 @@ func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k
 				CNI:                    chosenCNI,
 				NodePort:               viper.GetInt(apiServerPort),
 			},
+			MultiNodeRequested: viper.GetInt(nodes) > 1,
 		}
 		cc.VerifyComponents = interpretWaitFlag(*cmd)
 		if viper.GetBool(createMount) && driver.IsKIC(drvName) {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	cloud.google.com/go/storage v1.10.0
+	contrib.go.opencensus.io/exporter/stackdriver v0.12.1
 	github.com/Azure/azure-sdk-for-go v42.3.0+incompatible
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v0.13.0
 	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5 // indirect
@@ -75,6 +76,7 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f
 	github.com/zchee/go-vmnet v0.0.0-20161021174912-97ebf9174097
+	go.opencensus.io v0.22.4
 	go.opentelemetry.io/otel v0.13.0
 	go.opentelemetry.io/otel/sdk v0.13.0
 	golang.org/x/build v0.0.0-20190927031335-2835ba2e683f

--- a/pkg/minikube/bootstrapper/bsutil/ktmpl/v1alpha3.go
+++ b/pkg/minikube/bootstrapper/bsutil/ktmpl/v1alpha3.go
@@ -57,6 +57,7 @@ etcd:
   local:
     dataDir: {{.EtcdDataDir}}
 controllerManagerExtraArgs:
+  allocate-node-cidrs: "true"
   leader-elect: "false"
 schedulerExtraArgs:
   leader-elect: "false"

--- a/pkg/minikube/bootstrapper/bsutil/kubeadm.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubeadm.go
@@ -116,7 +116,7 @@ func GenerateKubeadmYAML(cc config.ClusterConfig, n config.Node, r cruntime.Mana
 		EtcdDataDir:       EtcdDataDir(),
 		EtcdExtraArgs:     etcdExtraArgs(k8s.ExtraOptions),
 		ClusterName:       cc.Name,
-		//kubeadm uses NodeName as the --hostname-override parameter, so this needs to be the name of the machine
+		// kubeadm uses NodeName as the --hostname-override parameter, so this needs to be the name of the machine
 		NodeName:            KubeNodeName(cc, n),
 		CRISocket:           r.SocketPath(),
 		ImageRepository:     k8s.ImageRepository,

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/dns.yaml
@@ -29,6 +29,7 @@ etcd:
   local:
     dataDir: /var/lib/minikube/etcd
 controllerManagerExtraArgs:
+  allocate-node-cidrs: "true"
   leader-elect: "false"
 schedulerExtraArgs:
   leader-elect: "false"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/dns.yaml
@@ -29,6 +29,7 @@ etcd:
   local:
     dataDir: /var/lib/minikube/etcd
 controllerManagerExtraArgs:
+  allocate-node-cidrs: "true"
   leader-elect: "false"
 schedulerExtraArgs:
   leader-elect: "false"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd-api-port.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd-pod-network-cidr.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/crio-options-gates.yaml
@@ -27,6 +27,7 @@ apiServer:
     feature-gates: "a=b"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     feature-gates: "a=b"
     kube-api-burst: "32"
     leader-elect: "false"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/crio.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/default.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/dns.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/image-repository.yaml
@@ -26,6 +26,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/options.yaml
@@ -26,6 +26,7 @@ apiServer:
     fail-no-swap: "true"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     kube-api-burst: "32"
     leader-elect: "false"
 scheduler:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd-api-port.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd-pod-network-cidr.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/crio-options-gates.yaml
@@ -27,6 +27,7 @@ apiServer:
     feature-gates: "a=b"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     feature-gates: "a=b"
     kube-api-burst: "32"
     leader-elect: "false"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/crio.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/default.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/dns.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/image-repository.yaml
@@ -26,6 +26,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/options.yaml
@@ -26,6 +26,7 @@ apiServer:
     fail-no-swap: "true"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     kube-api-burst: "32"
     leader-elect: "false"
 scheduler:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd-api-port.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd-pod-network-cidr.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/crio-options-gates.yaml
@@ -27,6 +27,7 @@ apiServer:
     feature-gates: "a=b"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     feature-gates: "a=b"
     kube-api-burst: "32"
     leader-elect: "false"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/crio.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/default.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/dns.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/image-repository.yaml
@@ -26,6 +26,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/options.yaml
@@ -26,6 +26,7 @@ apiServer:
     fail-no-swap: "true"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     kube-api-burst: "32"
     leader-elect: "false"
 scheduler:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-api-port.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-pod-network-cidr.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio-options-gates.yaml
@@ -27,6 +27,7 @@ apiServer:
     feature-gates: "a=b"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     feature-gates: "a=b"
     kube-api-burst: "32"
     leader-elect: "false"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/default.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/dns.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/image-repository.yaml
@@ -26,6 +26,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/options.yaml
@@ -26,6 +26,7 @@ apiServer:
     fail-no-swap: "true"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     kube-api-burst: "32"
     leader-elect: "false"
 scheduler:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd-api-port.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd-pod-network-cidr.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/crio-options-gates.yaml
@@ -27,6 +27,7 @@ apiServer:
     feature-gates: "a=b"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     feature-gates: "a=b"
     kube-api-burst: "32"
     leader-elect: "false"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/crio.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/default.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/dns.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/image-repository.yaml
@@ -26,6 +26,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/options.yaml
@@ -26,6 +26,7 @@ apiServer:
     fail-no-swap: "true"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     kube-api-burst: "32"
     leader-elect: "false"
 scheduler:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd-api-port.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd-pod-network-cidr.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/crio-options-gates.yaml
@@ -27,6 +27,7 @@ apiServer:
     feature-gates: "a=b"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     feature-gates: "a=b"
     kube-api-burst: "32"
     leader-elect: "false"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/crio.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/default.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/dns.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/image-repository.yaml
@@ -26,6 +26,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/options.yaml
@@ -26,6 +26,7 @@ apiServer:
     fail-no-swap: "true"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     kube-api-burst: "32"
     leader-elect: "false"
 scheduler:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd-api-port.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd-pod-network-cidr.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/crio-options-gates.yaml
@@ -27,6 +27,7 @@ apiServer:
     feature-gates: "a=b"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     feature-gates: "a=b"
     kube-api-burst: "32"
     leader-elect: "false"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/crio.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/default.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/dns.yaml
@@ -25,6 +25,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/image-repository.yaml
@@ -26,6 +26,7 @@ apiServer:
     enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     leader-elect: "false"
 scheduler:
   extraArgs:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/options.yaml
@@ -26,6 +26,7 @@ apiServer:
     fail-no-swap: "true"
 controllerManager:
   extraArgs:
+    allocate-node-cidrs: "true"
     kube-api-burst: "32"
     leader-elect: "false"
 scheduler:

--- a/pkg/minikube/bootstrapper/bsutil/versions.go
+++ b/pkg/minikube/bootstrapper/bsutil/versions.go
@@ -39,7 +39,6 @@ func versionIsBetween(version, gte, lte semver.Version) bool {
 }
 
 var versionSpecificOpts = []config.VersionedExtraOption{
-
 	config.NewUnversionedOption(Kubelet, "bootstrap-kubeconfig", "/etc/kubernetes/bootstrap-kubelet.conf"),
 	config.NewUnversionedOption(Kubelet, "config", "/var/lib/kubelet/config.yaml"),
 	config.NewUnversionedOption(Kubelet, "kubeconfig", "/etc/kubernetes/kubelet.conf"),
@@ -96,6 +95,14 @@ var versionSpecificOpts = []config.VersionedExtraOption{
 			Value:     "0",
 		},
 		LessThanOrEqual: semver.MustParse("1.11.1000"),
+	},
+	{
+		Option: config.ExtraOption{
+			Component: ControllerManager,
+			Key:       "allocate-node-cidrs",
+			Value:     "true",
+		},
+		GreaterThanOrEqual: semver.MustParse("1.14.0"),
 	},
 	{
 		Option: config.ExtraOption{

--- a/pkg/minikube/cni/disabled.go
+++ b/pkg/minikube/cni/disabled.go
@@ -47,5 +47,6 @@ func (c Disabled) Apply(r Runner) error {
 
 // CIDR returns the default CIDR used by this CNI
 func (c Disabled) CIDR() string {
-	return ""
+	// Even without any CNI we want our nodes to have spec.PodCIDR set.
+	return DefaultPodCIDR
 }

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -73,6 +73,7 @@ type ClusterConfig struct {
 	StartHostTimeout        time.Duration
 	ScheduledStop           *ScheduledStopConfig
 	ExposedPorts            []string // Only used by the docker and podman driver
+	MultiNodeRequested      bool
 }
 
 // KubernetesConfig contains the parameters used to configure the VM Kubernetes.


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

Fixes https://github.com/kubernetes/minikube/issues/9838
Ref https://github.com/kubernetes/minikube/issues/7538

With this fixes enabled In multi node mode nodes gets the podCIDR set
```
$ kubectl get nodes -o custom-columns=NAME:.metadata.name,SPEC:.spec
NAME           SPEC
minikube       map[podCIDR:10.244.0.0/24 podCIDRs:[10.244.0.0/24]]
minikube-m02   map[podCIDR:10.244.1.0/24 podCIDRs:[10.244.1.0/24]]
minikube-m03   map[podCIDR:10.244.2.0/24 podCIDRs:[10.244.2.0/24]]
```

Pods running in a node gets IP from the node CIDR as intended. And No reuse of same IP.
```
$ kubectl get pods --all-namespaces -o wide
NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE     IP             NODE           NOMINATED NODE   READINESS GATES
default       my-nginx-5b56ccd65f-dghzv          1/1     Running   0          43s     10.244.1.2     minikube-m02   <none>           <none>
default       my-nginx-5b56ccd65f-l5f2k          1/1     Running   0          43s     10.244.2.2     minikube-m03   <none>           <none>
default       my-nginx-5b56ccd65f-tlwx5          1/1     Running   0          43s     10.244.0.3     minikube       <none>           <none>
default       my-nginx-5b56ccd65f-xfhmp          1/1     Running   0          43s     10.244.1.4     minikube-m02   <none>           <none>
default       net-test-c4f9cfdd4-4w95m           1/1     Running   0          43s     10.244.1.3     minikube-m02   <none>           <none>
default       net-test-c4f9cfdd4-9bsks           1/1     Running   0          43s     10.244.2.3     minikube-m03   <none>           <none>
default       net-test-c4f9cfdd4-jxqt8           1/1     Running   0          43s     10.244.0.4     minikube       <none>           <none>
default       net-test-c4f9cfdd4-wkfrg           1/1     Running   0          43s     10.244.2.4     minikube-m03   <none>           <none>
kube-system   coredns-f9fd979d6-wcdm8            1/1     Running   0          3m1s    10.244.0.2     minikube       <none>           <none>
```

Pods running in worker nodes are able to resolve dns and connect.
```
kubectl exec -it net-test-c4f9cfdd4-9bsks -- /bin/bash
bash-5.0# curl google.com
<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>301 Moved</TITLE></HEAD><BODY>
<H1>301 Moved</H1>
The document has moved
<A HREF="http://www.google.com/">here</A>.
</BODY></HTML>
bash-5.0# curl my-nginx.default
<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
<style>
    body {
        width: 35em;
        margin: 0 auto;
        font-family: Tahoma, Verdana, Arial, sans-serif;
    }
</style>
</head>
<body>
<h1>Welcome to nginx!</h1>
<p>If you see this page, the nginx web server is successfully installed and
working. Further configuration is required.</p>

<p>For online documentation and support please refer to
<a href="http://nginx.org/">nginx.org</a>.<br/>
Commercial support is available at
<a href="http://nginx.com/">nginx.com</a>.</p>

<p><em>Thank you for using nginx.</em></p>
</body>
</html>
```

Running with only single node also have the kindnet enabled as CNI and getting ips from the podCIDR. 
```
$ kubectl get pods --all-namespaces -o wide
NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE    IP             NODE       NOMINATED NODE   READINESS GATES
default       my-nginx-5b56ccd65f-56gnr          1/1     Running   0          38s    10.244.0.10    minikube   <none>           <none>
default       my-nginx-5b56ccd65f-8ntxh          1/1     Running   0          38s    10.244.0.7     minikube   <none>           <none>
default       my-nginx-5b56ccd65f-msxws          1/1     Running   0          38s    10.244.0.3     minikube   <none>           <none>
default       my-nginx-5b56ccd65f-sdm7v          1/1     Running   0          38s    10.244.0.8     minikube   <none>           <none>
default       net-test-c4f9cfdd4-8wbp8           1/1     Running   0          37s    10.244.0.9     minikube   <none>           <none>
default       net-test-c4f9cfdd4-d9hr9           1/1     Running   0          37s    10.244.0.6     minikube   <none>           <none>
default       net-test-c4f9cfdd4-klmdg           1/1     Running   0          38s    10.244.0.4     minikube   <none>           <none>
default       net-test-c4f9cfdd4-vrb2l           1/1     Running   0          37s    10.244.0.5     minikube   <none>           <none>
kube-system   coredns-f9fd979d6-25pwj            1/1     Running   0          106s   10.244.0.2     minikube   <none>           <none>
kube-system   etcd-minikube                      1/1     Running   0          119s   192.168.49.2   minikube   <none>           <none>
kube-system   kindnet-2klfc                      1/1     Running   0          106s   192.168.49.2   minikube   <none>           <none>
kube-system   kube-apiserver-minikube            1/1     Running   0          119s   192.168.49.2   minikube   <none>           <none>
kube-system   kube-controller-manager-minikube   1/1     Running   0          119s   192.168.49.2   minikube   <none>           <none>
kube-system   kube-proxy-txqpb                   1/1     Running   0          106s   192.168.49.2   minikube   <none>           <none>
kube-system   kube-scheduler-minikube            1/1     Running   0          119s   192.168.49.2   minikube   <none>           <none>
kube-system   storage-provisioner                1/1     Running   0          118s   192.168.49.2   minikube   <none>           <none>
```

