### PR TITLE
added statusName for kubeconfig

### DIFF
--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -499,7 +499,7 @@ func clusterState(sts []*Status) ClusterState {
 		TimeToStop: sts[0].TimeToStop,
 
 		Components: map[string]BaseState{
-			"kubeconfig": {Name: "kubeconfig", StatusCode: statusCode(sts[0].Kubeconfig)},
+			"kubeconfig": {Name: "kubeconfig", StatusCode: statusCode(sts[0].Kubeconfig), StatusName: codeNames[statusCode(sts[0].Kubeconfig)]},
 		},
 	}
 


### PR DESCRIPTION
Added statusName for kubeconfig in status

FYI, `statusName` is not displayed in default minikube status. So, adding output for `--layout=cluster`

Before output of `./minikube-darwin-amd64 status --output json --layout cluster`,
<img width="1680" alt="Screen Shot 2020-12-10 at 11 52 25 AM" src="https://user-images.githubusercontent.com/14926492/101729500-4170e300-3ade-11eb-89e0-fdb06539c4df.png">

After:
<img width="1674" alt="Screen Shot 2020-12-10 at 11 54 04 AM" src="https://user-images.githubusercontent.com/14926492/101729623-8137ca80-3ade-11eb-81d5-865017e860a2.png">


Fixes #8921

Signed-off-by: Tharun <rajendrantharun@live.com>
