### PR TITLE
Use stable networking api in ingress-dns example

### DIFF
--- a/deploy/addons/ingress-dns/README.md
+++ b/deploy/addons/ingress-dns/README.md
@@ -107,7 +107,7 @@ TODO
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/minikube/master/deploy/addons/ingress-dns/example/example.yaml
 ```
-Note: Minimum Kubernetes version for example ingress is 1.14.7
+Note: Minimum Kubernetes version for example ingress is 1.19
 
 ### Validate DNS queries are returning A records
 ```bash

--- a/deploy/addons/ingress-dns/example/example.yaml
+++ b/deploy/addons/ingress-dns/example/example.yaml
@@ -33,7 +33,7 @@ spec:
           ports:
             - containerPort: 8080
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: example-ingress
@@ -44,16 +44,22 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: hello-world-app
-              servicePort: 80
+              service:
+                name: hello-world-app
+                port:
+                  number: 80
     - host: hello-jane.test
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: hello-world-app
-              servicePort: 80
+              service:
+                name: hello-world-app
+                port:
+                  number: 80
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Since the `Ingress` resource became stable in the kubernetes API, I upgraded the example to this new stable API.