### PR TITLE
Remove warning for using podman v2 with driver

### DIFF
--- a/pkg/minikube/registry/drvs/podman/podman.go
+++ b/pkg/minikube/registry/drvs/podman/podman.go
@@ -41,9 +41,6 @@ import (
 // minReqPodmanVer is required the minimum version of podman to be installed for podman driver.
 var minReqPodmanVer = semver.Version{Major: 1, Minor: 7, Patch: 0}
 
-// podmanVerTwo is required to exit with an error when podman v2 driver is currently installed because it is not supported yet.
-var podmanVerTwo = semver.Version{Major: 2, Minor: 0, Patch: 0}
-
 func init() {
 	priority := registry.Experimental
 	// Staged rollout for default:
@@ -128,9 +125,6 @@ func status() registry.State {
 		if v.LT(minReqPodmanVer) {
 			out.WarningT(`The minimum required version for podman is "{{.minVersion}}". your version is "{{.currentVersion}}". minikube might not work. use at your own risk. To install latest version please see https://podman.io/getting-started/installation.html`,
 				out.V{"minVersion": minReqPodmanVer.String(), "currentVersion": v.String()})
-		} else if v.GTE(podmanVerTwo) {
-			out.WarningT(`Using podman 2 is not supported yet. your version is "{{.currentVersion}}". minikube might not work. use at your own risk.`,
-				out.V{"currentVersion": v.String()})
 		}
 
 		return registry.State{Installed: true, Healthy: true}


### PR DESCRIPTION
Being experimental is probably warning enough

Podman 2.1 should be similar to 1.9 in support

---

This removes the extra line when using podman:
`❗  Using podman 2 is not supported yet. your version is "2.2.1". minikube might not work. use at your own risk.`

They are all equally supported (=experimental)
It probably won't be fully house-broken until v3...