### PR TITLE
Added sub-step logging to adm init step on start

### DIFF
--- a/pkg/minikube/command/command_runner.go
+++ b/pkg/minikube/command/command_runner.go
@@ -51,11 +51,25 @@ type RunResult struct {
 	Args     []string // the args that was passed to Runner
 }
 
+// StartedCmd holds the contents of a started command
+type StartedCmd struct {
+	cmd *exec.Cmd
+	rr  *RunResult
+}
+
 // Runner represents an interface to run commands.
 type Runner interface {
 	// RunCmd runs a cmd of exec.Cmd type. allowing user to set cmd.Stdin, cmd.Stdout,...
 	// not all implementors are guaranteed to handle all the properties of cmd.
 	RunCmd(cmd *exec.Cmd) (*RunResult, error)
+
+	// StartCmd starts a cmd of exec.Cmd type.
+	// This func in non-blocking, use WaitCmd to block until complete.
+	// Not all implementors are guaranteed to handle all the properties of cmd.
+	StartCmd(cmd *exec.Cmd) (*StartedCmd, error)
+
+	// WaitCmd will prevent further execution until the started command has completed.
+	WaitCmd(startedCmd *StartedCmd) (*RunResult, error)
 
 	// Copy is a convenience method that runs a command to copy a file
 	Copy(assets.CopyableFile) error

--- a/pkg/minikube/command/fake_runner_test.go
+++ b/pkg/minikube/command/fake_runner_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package command
+
+import (
+	"os/exec"
+	"testing"
+
+	"k8s.io/minikube/pkg/minikube/assets"
+)
+
+func TestFakeRunnerFile(t *testing.T) {
+	fakeCommandRunner := NewFakeCommandRunner()
+	cmdArg := "test"
+	cmdToOutput := make(map[string]string)
+	cmdToOutput[cmdArg] = "123"
+	fakeCommandRunner.SetCommandToOutput(cmdToOutput)
+
+	t.Run("SetGetFileContents", func(t *testing.T) {
+		fileToContentsMap := make(map[string]string)
+		fileName := "fileName"
+		expectedFileContents := "fileContents"
+		fileToContentsMap[fileName] = expectedFileContents
+
+		fakeCommandRunner.SetFileToContents(fileToContentsMap)
+
+		retrievedFileContents, err := fakeCommandRunner.GetFileToContents(fileName)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if expectedFileContents != retrievedFileContents {
+			t.Errorf("expected %q, retrieved %q", expectedFileContents, retrievedFileContents)
+		}
+	})
+
+	t.Run("CopyRemoveFile", func(t *testing.T) {
+		expectedFileContents := "test contents"
+		fileName := "memory"
+		file := assets.NewMemoryAssetTarget([]byte(expectedFileContents), "", "")
+
+		if err := fakeCommandRunner.Copy(file); err != nil {
+			t.Fatal(err)
+		}
+
+		retrievedFileContents, err := fakeCommandRunner.GetFileToContents(fileName)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if expectedFileContents != retrievedFileContents {
+			t.Errorf("expected %q, retrieved %q", expectedFileContents, retrievedFileContents)
+		}
+
+		if err := fakeCommandRunner.Remove(file); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := fakeCommandRunner.GetFileToContents(fileName); err == nil {
+			t.Errorf("file was not removed")
+		}
+	})
+
+	t.Run("RunCmd", func(t *testing.T) {
+		expectedOutput := "123"
+		command := &exec.Cmd{Args: []string{cmdArg}}
+
+		rr, err := fakeCommandRunner.RunCmd(command)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		retrievedOutput := rr.Stdout.String()
+		if expectedOutput != retrievedOutput {
+			t.Errorf("expected %q, retrieved %q", expectedOutput, retrievedOutput)
+		}
+	})
+
+	t.Run("StartWaitCmd", func(t *testing.T) {
+		expectedOutput := "123"
+		command := &exec.Cmd{Args: []string{cmdArg}}
+
+		sc, err := fakeCommandRunner.StartCmd(command)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		retrievedOutput := sc.rr.Stdout.String()
+		if expectedOutput != retrievedOutput {
+			t.Errorf("expected %q, retrieved %q", expectedOutput, retrievedOutput)
+		}
+
+		rr, err := fakeCommandRunner.WaitCmd(sc)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		retrievedOutput = rr.Stdout.String()
+		if expectedOutput != retrievedOutput {
+			t.Errorf("expected %q, retrieved %q", expectedOutput, retrievedOutput)
+		}
+
+	})
+}

--- a/pkg/minikube/command/kic_runner.go
+++ b/pkg/minikube/command/kic_runner.go
@@ -131,6 +131,14 @@ func (k *kicRunner) RunCmd(cmd *exec.Cmd) (*RunResult, error) {
 
 }
 
+func (k *kicRunner) StartCmd(cmd *exec.Cmd) (*StartedCmd, error) {
+	return nil, fmt.Errorf("kicRunner does not support StartCmd - you could be the first to add it")
+}
+
+func (k *kicRunner) WaitCmd(sc *StartedCmd) (*RunResult, error) {
+	return nil, fmt.Errorf("kicRunner does not support WaitCmd - you could be the first to add it")
+}
+
 // Copy copies a file and its permissions
 func (k *kicRunner) Copy(f assets.CopyableFile) error {
 	dst := path.Join(path.Join(f.GetTargetDir(), f.GetTargetName()))

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -53,7 +53,15 @@ func ValidRuntimes() []string {
 
 // CommandRunner is the subset of command.Runner this package consumes
 type CommandRunner interface {
+	// RunCmd is a blocking method that runs a command
+	// Use this if you don't need to stream stdout and stderr in real-time
 	RunCmd(cmd *exec.Cmd) (*command.RunResult, error)
+	// StartCmd is a non-blocking method that starts a command
+	// Use WaitCmd to block until the command is complete
+	// Use this if you need to stream stdout and/or stderr in real-time
+	StartCmd(cmd *exec.Cmd) (*command.StartedCmd, error)
+	// WaitCmd blocks until the started command completes
+	WaitCmd(sc *command.StartedCmd) (*command.RunResult, error)
 	// Copy is a convenience method that runs a command to copy a file
 	Copy(assets.CopyableFile) error
 	// Remove is a convenience method that runs a command to remove a file

--- a/pkg/minikube/cruntime/cruntime_test.go
+++ b/pkg/minikube/cruntime/cruntime_test.go
@@ -217,6 +217,14 @@ func (f *FakeRunner) RunCmd(cmd *exec.Cmd) (*command.RunResult, error) {
 	}
 }
 
+func (f *FakeRunner) StartCmd(cmd *exec.Cmd) (*command.StartedCmd, error) {
+	return &command.StartedCmd{}, nil
+}
+
+func (f *FakeRunner) WaitCmd(sc *command.StartedCmd) (*command.RunResult, error) {
+	return &command.RunResult{}, nil
+}
+
 func (f *FakeRunner) Copy(assets.CopyableFile) error {
 	return nil
 }

--- a/pkg/minikube/out/register/register.go
+++ b/pkg/minikube/out/register/register.go
@@ -26,20 +26,23 @@ import (
 
 // If you add a new step here, please also add it to register.Reg registry inside the init() function
 const (
-	InitialSetup         RegStep = "Initial Minikube Setup"
-	SelectingDriver      RegStep = "Selecting Driver"
-	DownloadingArtifacts RegStep = "Downloading Artifacts"
-	StartingNode         RegStep = "Starting Node"
-	PullingBaseImage     RegStep = "Pulling Base Image"
-	RunningLocalhost     RegStep = "Running on Localhost"
-	LocalOSRelease       RegStep = "Local OS Release"
-	CreatingContainer    RegStep = "Creating Container"
-	CreatingVM           RegStep = "Creating VM"
-	ConfiguringLHEnv     RegStep = "Configuring Localhost Environment"
-	PreparingKubernetes  RegStep = "Preparing Kubernetes"
-	VerifyingKubernetes  RegStep = "Verifying Kubernetes"
-	EnablingAddons       RegStep = "Enabling Addons"
-	Done                 RegStep = "Done"
+	InitialSetup                      RegStep = "Initial Minikube Setup"
+	SelectingDriver                   RegStep = "Selecting Driver"
+	DownloadingArtifacts              RegStep = "Downloading Artifacts"
+	StartingNode                      RegStep = "Starting Node"
+	PullingBaseImage                  RegStep = "Pulling Base Image"
+	RunningLocalhost                  RegStep = "Running on Localhost"
+	LocalOSRelease                    RegStep = "Local OS Release"
+	CreatingContainer                 RegStep = "Creating Container"
+	CreatingVM                        RegStep = "Creating VM"
+	ConfiguringLHEnv                  RegStep = "Configuring Localhost Environment"
+	PreparingKubernetes               RegStep = "Preparing Kubernetes"
+	PreparingKubernetesCerts          RegStep = "Generating certificates"
+	PreparingKubernetesControlPlane   RegStep = "Booting control plane"
+	PreparingKubernetesBootstrapToken RegStep = "Configuring RBAC rules"
+	VerifyingKubernetes               RegStep = "Verifying Kubernetes"
+	EnablingAddons                    RegStep = "Enabling Addons"
+	Done                              RegStep = "Done"
 
 	Stopping  RegStep = "Stopping"
 	PowerOff  RegStep = "PowerOff"
@@ -77,6 +80,9 @@ func init() {
 				CreatingContainer,
 				CreatingVM,
 				PreparingKubernetes,
+				PreparingKubernetesCerts,
+				PreparingKubernetesControlPlane,
+				PreparingKubernetesBootstrapToken,
 				ConfiguringLHEnv,
 				VerifyingKubernetes,
 				EnablingAddons,

--- a/pkg/minikube/style/style.go
+++ b/pkg/minikube/style/style.go
@@ -127,6 +127,7 @@ var Config = map[Enum]Options{
 	Shutdown:         {Prefix: "🛑  "},
 	StartingNone:     {Prefix: "🤹  "},
 	StartingVM:       {Prefix: "🔥  "},
+	SubStep:          {Prefix: "    ▪ ", LowPrefix: LowIndent, OmitNewline: true, Spinner: true}, // Indented bullet
 	Tip:              {Prefix: "💡  "},
 	Unmount:          {Prefix: "🔥  "},
 	VerifyingNoLine:  {Prefix: "🤔  ", OmitNewline: true},

--- a/pkg/minikube/style/style_enum.go
+++ b/pkg/minikube/style/style_enum.go
@@ -84,6 +84,7 @@ const (
 	StartingVM
 	Stopped
 	Stopping
+	SubStep
 	Success
 	ThumbsDown
 	ThumbsUp

--- a/test/integration/error_spam_test.go
+++ b/test/integration/error_spam_test.go
@@ -91,4 +91,17 @@ func TestErrorSpam(t *testing.T) {
 		t.Logf("minikube stdout:\n%s", stdout)
 		t.Logf("minikube stderr:\n%s", stderr)
 	}
+
+	t.Run("KubeadmSteps", func(t *testing.T) {
+		steps := []string{
+			"Generating certificates and keys ...",
+			"Booting up control plane ...",
+			"Configuring RBAC rules ...",
+		}
+		for _, step := range steps {
+			if !strings.Contains(stdout, step) {
+				t.Errorf("missing kubeadm init sub-step %q", step)
+			}
+		}
+	})
 }


### PR DESCRIPTION
Fixes: #9779 

Added StartCmd and WaitCmd to CommandRunner interface to allow real-time streaming of logs.
Used these two new methods to add sub-step logging to adm init on start, these steps also output to JSON.

```
😄  minikube v1.15.1 on Darwin 10.15.7
✨  Automatically selected the docker driver. Other choices: hyperkit, virtualbox
👍  Starting control plane node minikube in cluster minikube
🔥  Creating docker container (CPUs=2, Memory=4000MB) ...
🐳  Preparing Kubernetes v1.19.4 on Docker 19.03.13 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```