### PR TITLE
fix: use release tags and add make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -808,5 +808,5 @@ update-kubernetes-version:
 .PHONY: update-kubernetes-version-pr
 update-kubernetes-version-pr:
 	(cd hack/update/kubernetes_version && \
-	 export UPDATE_TARGET="gh" && \
+	 export UPDATE_TARGET="all" && \
 	 go run update_kubernetes_version.go)

--- a/Makefile
+++ b/Makefile
@@ -807,6 +807,11 @@ update-kubernetes-version:
 
 .PHONY: update-kubernetes-version-pr
 update-kubernetes-version-pr:
+ifndef GITHUB_TOKEN
+	@echo "⚠️ please set GITHUB_TOKEN environment variable with your GitHub token"
+	@echo "you can use https://github.com/settings/tokens/new to create new one"
+else
 	(cd hack/update/kubernetes_version && \
 	 export UPDATE_TARGET="all" && \
 	 go run update_kubernetes_version.go)
+endif

--- a/Makefile
+++ b/Makefile
@@ -798,3 +798,15 @@ help:
 	@printf "\033[1mAvailable targets for minikube ${VERSION}\033[21m\n"
 	@printf "\033[1m--------------------------------------\033[21m\n"
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+
+.PHONY: update-kubernetes-version
+update-kubernetes-version:
+	(cd hack/update/kubernetes_version && \
+	 go run update_kubernetes_version.go)
+
+.PHONY: update-kubernetes-version-pr
+update-kubernetes-version-pr:
+	(cd hack/update/kubernetes_version && \
+	 export UPDATE_TARGET="gh" && \
+	 go run update_kubernetes_version.go)

--- a/Makefile
+++ b/Makefile
@@ -809,7 +809,7 @@ update-kubernetes-version:
 update-kubernetes-version-pr:
 ifndef GITHUB_TOKEN
 	@echo "⚠️ please set GITHUB_TOKEN environment variable with your GitHub token"
-	@echo "you can use https://github.com/settings/tokens/new to create new one"
+	@echo "you can use https://github.com/settings/tokens/new?scopes=repo,write:packages to create new one"
 else
 	(cd hack/update/kubernetes_version && \
 	 export UPDATE_TARGET="all" && \

--- a/hack/update/github.go
+++ b/hack/update/github.go
@@ -216,12 +216,12 @@ func GHReleases(ctx context.Context, owner, repo string) (stable, latest string,
 	// walk through the paginated list of up to ghSearchLimit newest releases
 	opts := &github.ListOptions{PerPage: ghListPerPage}
 	for (opts.Page+1)*ghListPerPage <= ghSearchLimit {
-		rls, resp, err := ghc.Repositories.ListReleases(ctx, owner, repo, opts)
+		rls, resp, err := ghc.Repositories.ListTags(ctx, owner, repo, opts)
 		if err != nil {
 			return "", "", err
 		}
 		for _, rl := range rls {
-			ver := rl.GetTagName()
+			ver := *rl.Name
 			if !semver.IsValid(ver) {
 				continue
 			}


### PR DESCRIPTION
fixes: #9898 

the update script now correctly picks up github releases' tags

also, added make targets as:
`make update-kubernetes-version`
to automatically update local repo with newest k8s versions (stable and latest), and:
`make update-kubernetes-version-pr`
to additionally automatically create pr

### example output:

```
❯ make update-kubernetes-version 
(cd hack/update/kubernetes_version && \
 go run update_kubernetes_version.go)
I1210 01:24:49.534560    5453 update_kubernetes_version.go:140] Kubernetes versions: 'stable' is v1.20.0 and 'latest' is v1.20.1-rc.0
I1210 01:24:49.536565    5453 update.go:111] The Plan:
{
  "pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd-api-port.yaml": {
    "replace": {
      "kubernetesVersion:.*": "kubernetesVersion: v1.20.0"
    }
  },
  "pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd-pod-network-cidr.yaml": {
    "replace": {
      "kubernetesVersion:.*": "kubernetesVersion: v1.20.0"
    }
  },
  "pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd.yaml": {
    "replace": {
      "kubernetesVersion:.*": "kubernetesVersion: v1.20.0"
    }
  },
  "pkg/minikube/bootstrapper/bsutil/testdata/v1.20/crio-options-gates.yaml": {
    "replace": {
      "kubernetesVersion:.*": "kubernetesVersion: v1.20.0"
    }
  },
  "pkg/minikube/bootstrapper/bsutil/testdata/v1.20/crio.yaml": {
    "replace": {
      "kubernetesVersion:.*": "kubernetesVersion: v1.20.0"
    }
  },
  "pkg/minikube/bootstrapper/bsutil/testdata/v1.20/default.yaml": {
    "replace": {
      "kubernetesVersion:.*": "kubernetesVersion: v1.20.0"
    }
  },
  "pkg/minikube/bootstrapper/bsutil/testdata/v1.20/dns.yaml": {
    "replace": {
      "kubernetesVersion:.*": "kubernetesVersion: v1.20.0"
    }
  },
  "pkg/minikube/bootstrapper/bsutil/testdata/v1.20/image-repository.yaml": {
    "replace": {
      "kubernetesVersion:.*": "kubernetesVersion: v1.20.0"
    }
  },
  "pkg/minikube/bootstrapper/bsutil/testdata/v1.20/options.yaml": {
    "replace": {
      "kubernetesVersion:.*": "kubernetesVersion: v1.20.0"
    }
  },
  "pkg/minikube/constants/constants.go": {
    "replace": {
      "DefaultKubernetesVersion = \".*": "DefaultKubernetesVersion = \"v1.20.0\"",
      "NewestKubernetesVersion = \".*": "NewestKubernetesVersion = \"v1.20.1-rc.0\""
    }
  },
  "site/content/en/docs/commands/start.md": {
    "replace": {
      "'latest' for .*\\)": "'latest' for v1.20.1-rc.0)",
      "'stable' for .*,": "'stable' for v1.20.0,"
    }
  }
}
I1210 01:24:49.541219    5453 update.go:120] Local repo successfully updated
```

note that the script already updates `site/content/en/docs/commands/start.md`, so we do not need to run `make generate-docs` additionally