### PR TITLE
wip:Support multi control plane

### DIFF
--- a/cmd/minikube/cmd/node_add.go
+++ b/cmd/minikube/cmd/node_add.go
@@ -21,7 +21,6 @@ import (
 	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/cni"
 	"k8s.io/minikube/pkg/minikube/config"
-	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/mustload"
@@ -68,7 +67,7 @@ var nodeAddCmd = &cobra.Command{
 		}
 
 		if n.ControlPlane {
-			n.Port = constants.APIServerPort
+			n.Port = cc.KubernetesConfig.NodePort
 		}
 
 		// Make sure to decrease the default amount of memory we use per VM if this is the first worker node

--- a/cmd/minikube/cmd/node_add.go
+++ b/cmd/minikube/cmd/node_add.go
@@ -44,6 +44,7 @@ var nodeAddCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		co := mustload.Healthy(ClusterFlagValue())
 		cc := co.Config
+		config.TagPrimaryControlPlane(cc)
 
 		if driver.BareMetal(cc.Driver) {
 			out.FailureT("none driver does not support multi-node clusters")
@@ -59,11 +60,11 @@ var nodeAddCmd = &cobra.Command{
 
 		// TODO: Deal with parameters better. Ideally we should be able to acceot any node-specific minikube start params here.
 		n := config.Node{
-			Name:              name,
-			Worker:            worker,
-			ControlPlane:      cp,
-			APIEndpointServer: false,
-			KubernetesVersion: cc.KubernetesConfig.KubernetesVersion,
+			Name:                name,
+			Worker:              worker,
+			ControlPlane:        cp,
+			PrimaryControlPlane: false,
+			KubernetesVersion:   cc.KubernetesConfig.KubernetesVersion,
 		}
 
 		if n.ControlPlane {

--- a/cmd/minikube/cmd/node_add.go
+++ b/cmd/minikube/cmd/node_add.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/out/register"
 	"k8s.io/minikube/pkg/minikube/reason"
 	"k8s.io/minikube/pkg/minikube/style"
+	"k8s.io/minikube/pkg/util"
 )
 
 var (
@@ -67,6 +68,10 @@ var nodeAddCmd = &cobra.Command{
 		}
 
 		if n.ControlPlane {
+			err := util.CheckMultiControlPlaneVersion(cc.KubernetesConfig.KubernetesVersion)
+			if err != nil {
+				exit.Error(reason.KubernetesTooOld, "target kubernetes version too old", err)
+			}
 			n.Port = cc.KubernetesConfig.NodePort
 		}
 

--- a/cmd/minikube/cmd/node_start.go
+++ b/cmd/minikube/cmd/node_start.go
@@ -56,7 +56,7 @@ var nodeStartCmd = &cobra.Command{
 		}
 
 		register.Reg.SetStep(register.InitialSetup)
-		r, p, m, h, err := node.Provision(cc, n, n.ControlPlane, viper.GetBool(deleteOnFailure))
+		r, p, m, h, err := node.Provision(cc, n, viper.GetBool(deleteOnFailure))
 		if err != nil {
 			exit.Error(reason.GuestNodeProvision, "provisioning host for node", err)
 		}
@@ -71,7 +71,7 @@ var nodeStartCmd = &cobra.Command{
 			ExistingAddons: nil,
 		}
 
-		_, err = node.Start(s, n.ControlPlane)
+		_, err = node.Start(s)
 		if err != nil {
 			_, err := maybeDeleteAndRetry(cmd, *cc, *n, nil, err)
 			if err != nil {

--- a/cmd/minikube/cmd/node_stop.go
+++ b/cmd/minikube/cmd/node_stop.go
@@ -46,7 +46,7 @@ var nodeStopCmd = &cobra.Command{
 		}
 
 		machineName := config.MachineName(*cc, *n)
-
+		node.MustReset(*cc, *n, api, machineName)
 		err = machine.StopHost(api, machineName)
 		if err != nil {
 			out.FatalT("Failed to stop node {{.name}}", out.V{"name": name})

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -375,11 +375,11 @@ func startWithDriver(cmd *cobra.Command, starter node.Starter, existing *config.
 				for i := 1; i < numNodes; i++ {
 					nodeName := node.Name(i + 1)
 					n := config.Node{
-						Name:              nodeName,
-						Worker:            true,
-						ControlPlane:      false,
-						APIEndpointServer: false,
-						KubernetesVersion: starter.Cfg.KubernetesConfig.KubernetesVersion,
+						Name:                nodeName,
+						Worker:              true,
+						ControlPlane:        false,
+						PrimaryControlPlane: false,
+						KubernetesVersion:   starter.Cfg.KubernetesConfig.KubernetesVersion,
 					}
 					out.Ln("") // extra newline for clarity on the command line
 					err := node.Add(starter.Cfg, n, viper.GetBool(deleteOnFailure))
@@ -389,7 +389,7 @@ func startWithDriver(cmd *cobra.Command, starter node.Starter, existing *config.
 				}
 			} else {
 				for _, n := range existing.Nodes {
-					if !n.APIEndpointServer {
+					if !n.PrimaryControlPlane {
 						err := node.Add(starter.Cfg, n, viper.GetBool(deleteOnFailure))
 						if err != nil {
 							return nil, errors.Wrap(err, "adding node")
@@ -1197,12 +1197,12 @@ func createNode(cc config.ClusterConfig, kubeNodeName string, existing *config.C
 	}
 
 	cp := config.Node{
-		Port:              cc.KubernetesConfig.NodePort,
-		KubernetesVersion: getKubernetesVersion(&cc),
-		Name:              kubeNodeName,
-		ControlPlane:      true,
-		APIEndpointServer: true,
-		Worker:            true,
+		Port:                cc.KubernetesConfig.NodePort,
+		KubernetesVersion:   getKubernetesVersion(&cc),
+		Name:                kubeNodeName,
+		ControlPlane:        true,
+		PrimaryControlPlane: true,
+		Worker:              true,
 	}
 	cc.Nodes = []config.Node{cp}
 	return cc, cp, nil

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -137,6 +137,13 @@ func runStart(cmd *cobra.Command, args []string) {
 		out.WarningT(fmt.Sprintf("control planes number %v larger than nodes number %v, enlarge nodes to %v.", controlPlanesNum, nodesNum, controlPlanesNum))
 		viper.Set(nodes, controlPlanesNum)
 	}
+	k8sVersion := viper.GetString(kubernetesVersion)
+	if controlPlanesNum > 1 {
+		err := util.CheckMultiControlPlaneVersion(k8sVersion)
+		if err != nil {
+			exit.Error(reason.KubernetesTooOld, "target kubernetes version too old", err)
+		}
+	}
 
 	out.SetJSON(outputFormat == "json")
 	if err := pkgtrace.Initialize(viper.GetString(trace)); err != nil {

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -102,6 +102,7 @@ const (
 	hostOnlyNicType         = "host-only-nic-type"
 	natNicType              = "nat-nic-type"
 	nodes                   = "nodes"
+	controlPlanes           = "control-planes"
 	preload                 = "preload"
 	deleteOnFailure         = "delete-on-failure"
 	forceSystemd            = "force-systemd"
@@ -150,6 +151,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().Bool(autoUpdate, true, "If set, automatically updates drivers to the latest version. Defaults to true.")
 	startCmd.Flags().Bool(installAddons, true, "If set, install addons. Defaults to true.")
 	startCmd.Flags().IntP(nodes, "n", 1, "The number of nodes to spin up. Defaults to 1.")
+	startCmd.Flags().Int(controlPlanes, 1, "The number of control planes to spin up. Defaults to 1.")
 	startCmd.Flags().Bool(preload, true, "If set, download tarball of preloaded images if available to improve start time. Defaults to true.")
 	startCmd.Flags().Bool(deleteOnFailure, false, "If set, delete the current cluster if start fails and try again. Defaults to false.")
 	startCmd.Flags().Bool(forceSystemd, false, "If set, force the container runtime to use sytemd as cgroup manager. Defaults to false.")

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -412,6 +412,22 @@ func upgradeExistingConfig(cc *config.ClusterConfig) {
 		cc.KicBaseImage = viper.GetString(kicBaseImage)
 		klog.Infof("config upgrade: KicBaseImage=%s", cc.KicBaseImage)
 	}
+
+	needTagAPIEndpointServer := true
+	for i := range cc.Nodes {
+		if cc.Nodes[i].APIEndpointServer {
+			needTagAPIEndpointServer = false
+			break
+		}
+	}
+	if needTagAPIEndpointServer {
+		for i := range cc.Nodes {
+			if cc.Nodes[i].ControlPlane {
+				cc.Nodes[i].APIEndpointServer = true
+				break
+			}
+		}
+	}
 }
 
 // updateExistingConfigFromFlags will update the existing config from the flags - used on a second start

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -413,21 +413,7 @@ func upgradeExistingConfig(cc *config.ClusterConfig) {
 		klog.Infof("config upgrade: KicBaseImage=%s", cc.KicBaseImage)
 	}
 
-	needTagAPIEndpointServer := true
-	for i := range cc.Nodes {
-		if cc.Nodes[i].APIEndpointServer {
-			needTagAPIEndpointServer = false
-			break
-		}
-	}
-	if needTagAPIEndpointServer {
-		for i := range cc.Nodes {
-			if cc.Nodes[i].ControlPlane {
-				cc.Nodes[i].APIEndpointServer = true
-				break
-			}
-		}
-	}
+	config.TagPrimaryControlPlane(cc)
 }
 
 // updateExistingConfigFromFlags will update the existing config from the flags - used on a second start
@@ -660,6 +646,8 @@ func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterC
 	if cmd.Flags().Changed(kicBaseImage) || cc.KicBaseImage == "" {
 		cc.KicBaseImage = viper.GetString(kicBaseImage)
 	}
+
+	config.TagPrimaryControlPlane(&cc)
 
 	return cc
 }

--- a/cmd/minikube/cmd/status_test.go
+++ b/cmd/minikube/cmd/status_test.go
@@ -51,18 +51,18 @@ func TestStatusText(t *testing.T) {
 	}{
 		{
 			name:  "ok",
-			state: &Status{Name: "minikube", Host: "Running", Kubelet: "Running", APIServer: "Running", Kubeconfig: Configured, TimeToStop: "10m"},
-			want:  "minikube\ntype: Control Plane\nhost: Running\nkubelet: Running\napiserver: Running\nkubeconfig: Configured\ntimeToStop: 10m\n\n",
+			state: &Status{Name: "minikube", Host: "Running", Kubelet: "Running", APIServer: "Running", Kubeconfig: Configured, TimeToStop: "10m", IP: "192.168.39.10"},
+			want:  "minikube\ntype: Control Plane\nhost: Running\nkubelet: Running\napiserver: Running\nkubeconfig: Configured\ntimeToStop: 10m\nIP: 192.168.39.10\n\n",
 		},
 		{
 			name:  "paused",
-			state: &Status{Name: "minikube", Host: "Running", Kubelet: "Stopped", APIServer: "Paused", Kubeconfig: Configured, TimeToStop: Nonexistent},
-			want:  "minikube\ntype: Control Plane\nhost: Running\nkubelet: Stopped\napiserver: Paused\nkubeconfig: Configured\ntimeToStop: Nonexistent\n\n",
+			state: &Status{Name: "minikube", Host: "Running", Kubelet: "Stopped", APIServer: "Paused", Kubeconfig: Configured, TimeToStop: Nonexistent, IP: "192.168.39.10"},
+			want:  "minikube\ntype: Control Plane\nhost: Running\nkubelet: Stopped\napiserver: Paused\nkubeconfig: Configured\ntimeToStop: Nonexistent\nIP: 192.168.39.10\n\n",
 		},
 		{
 			name:  "down",
-			state: &Status{Name: "minikube", Host: "Stopped", Kubelet: "Stopped", APIServer: "Stopped", Kubeconfig: Misconfigured, TimeToStop: Nonexistent},
-			want:  "minikube\ntype: Control Plane\nhost: Stopped\nkubelet: Stopped\napiserver: Stopped\nkubeconfig: Misconfigured\ntimeToStop: Nonexistent\n\n\nWARNING: Your kubectl is pointing to stale minikube-vm.\nTo fix the kubectl context, run `minikube update-context`\n",
+			state: &Status{Name: "minikube", Host: "Stopped", Kubelet: "Stopped", APIServer: "Stopped", Kubeconfig: Misconfigured, TimeToStop: Nonexistent, IP: "192.168.39.10"},
+			want:  "minikube\ntype: Control Plane\nhost: Stopped\nkubelet: Stopped\napiserver: Stopped\nkubeconfig: Misconfigured\ntimeToStop: Nonexistent\nIP: 192.168.39.10\n\n\nWARNING: Your kubectl is pointing to stale minikube-vm.\nTo fix the kubectl context, run `minikube update-context`\n",
 		},
 	}
 	for _, tc := range tests {
@@ -75,7 +75,7 @@ func TestStatusText(t *testing.T) {
 
 			got := b.String()
 			if got != tc.want {
-				t.Errorf("text(%+v) = %q, want: %q", tc.state, got, tc.want)
+				t.Errorf("text(%+v)\n got: %q\nwant: %q", tc.state, got, tc.want)
 			}
 		})
 	}

--- a/cmd/minikube/cmd/stop.go
+++ b/cmd/minikube/cmd/stop.go
@@ -135,13 +135,17 @@ func stopProfile(profile string) int {
 
 	// end new code
 	api, cc := mustload.Partial(profile)
+
+	// ensure tag primary control plane properly
+	config.TagPrimaryControlPlane(cc)
+
 	defer api.Close()
 
 	primaryMachineName := ""
 	for _, n := range cc.Nodes {
 		machineName := config.MachineName(*cc, n)
 
-		if n.APIEndpointServer {
+		if n.PrimaryControlPlane {
 			// Skip because we need to update etcd members
 			primaryMachineName = machineName
 			continue

--- a/pkg/minikube/bootstrapper/bootstrapper.go
+++ b/pkg/minikube/bootstrapper/bootstrapper.go
@@ -41,7 +41,7 @@ type Bootstrapper interface {
 	WaitForNode(config.ClusterConfig, config.Node, time.Duration) error
 	JoinCluster(config.ClusterConfig, config.Node, string) error
 	UpdateNode(config.ClusterConfig, config.Node, cruntime.Manager) error
-	GenerateToken(config.ClusterConfig) (string, error)
+	GenerateToken(config.ClusterConfig, bool) (string, error)
 	// LogCommands returns a map of log type to a command which will display that log.
 	LogCommands(config.ClusterConfig, LogOptions) map[string]string
 	SetupCerts(config.KubernetesConfig, config.Node) error

--- a/pkg/minikube/bootstrapper/bsutil/extraconfig.go
+++ b/pkg/minikube/bootstrapper/bsutil/extraconfig.go
@@ -70,7 +70,7 @@ var KubeadmExtraArgsAllowed = map[int][]string{
 		"kubeconfig-dir",
 		"node-name",
 		"cri-socket",
-		"experimental-upload-certs",
+		"upload-certs",
 		"certificate-key",
 		"rootfs",
 		"skip-phases",

--- a/pkg/minikube/bootstrapper/bsutil/kubeadm.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubeadm.go
@@ -128,7 +128,7 @@ func GenerateKubeadmYAML(cc config.ClusterConfig, n config.Node, r cruntime.Mana
 		CgroupDriver:        cgroupDriver,
 		ClientCAFile:        path.Join(vmpath.GuestKubernetesCertsDir, "ca.crt"),
 		StaticPodPath:       vmpath.GuestManifestsDir,
-		ControlPlaneAddress: constants.ControlPlaneAlias,
+		ControlPlaneAddress: constants.APIEndpointAlias,
 		KubeProxyOptions:    createKubeProxyOptions(k8s.ExtraOptions),
 	}
 

--- a/pkg/minikube/bootstrapper/certs.go
+++ b/pkg/minikube/bootstrapper/certs.go
@@ -94,7 +94,7 @@ func SetupCerts(cmd command.Runner, k8s config.KubernetesConfig, n config.Node) 
 	}
 
 	endpoint := net.JoinHostPort(constants.APIEndpointAlias, fmt.Sprint(k8s.NodePort))
-	if n.APIEndpointServer {
+	if n.PrimaryControlPlane {
 		endpoint = net.JoinHostPort("localhost", fmt.Sprint(n.Port))
 	}
 	kcs := &kubeconfig.Settings{
@@ -186,7 +186,7 @@ func generateSharedCACerts() (CACerts, error) {
 func generateProfileCerts(k8s config.KubernetesConfig, n config.Node, ccs CACerts) ([]string, error) {
 
 	// Only generate these certs for the api server
-	if !n.APIEndpointServer {
+	if !n.PrimaryControlPlane {
 		return []string{}, nil
 	}
 

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -236,7 +236,7 @@ func (k *Bootstrapper) init(cfg config.ClusterConfig) error {
 	ctx, cancel := context.WithTimeout(context.Background(), initTimeoutMinutes*time.Minute)
 	defer cancel()
 	kr, kw := io.Pipe()
-	c := exec.CommandContext(ctx, "/bin/bash", "-c", fmt.Sprintf("%s init --config %s %s --ignore-preflight-errors=%s --upload-certs",
+	c := exec.CommandContext(ctx, "/bin/bash", "-c", fmt.Sprintf("%s init --config %s %s --ignore-preflight-errors=%s",
 		bsutil.InvokeKubeadm(cfg.KubernetesConfig.KubernetesVersion), conf, extraFlags, strings.Join(ignore, ",")))
 	c.Stdout = kw
 	c.Stderr = kw

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -784,7 +784,6 @@ func (k *Bootstrapper) GenerateToken(cc config.ClusterConfig, genCertKey bool) (
 		}
 
 		certCmd := fmt.Sprintf("%s init phase upload-certs --upload-certs --config %s", ka, confPath)
-		out.Step(style.Tip, certCmd)
 		certKeyCmd := exec.Command("/bin/bash", "-c", certCmd)
 		certKeyResult, err := k.c.RunCmd(certKeyCmd)
 		if err != nil {

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -790,7 +790,6 @@ func (k *Bootstrapper) GenerateToken(cc config.ClusterConfig, genCertKey bool) (
 		if err != nil {
 			return "", errors.Wrap(err, "generating join command")
 		}
-		out.Step(style.Tip, certKeyResult.Stdout.String())
 		// Currently we have to parse stdout manually to get certificate key
 		outputs := strings.Split(certKeyResult.Stdout.String(), "\n")
 

--- a/pkg/minikube/cni/kindnet.go
+++ b/pkg/minikube/cni/kindnet.go
@@ -149,7 +149,7 @@ type KindNet struct {
 
 // String returns a string representation of this CNI
 func (c KindNet) String() string {
-	return "CNI"
+	return "KindNet"
 }
 
 // manifest returns a Kubernetes manifest for a CNI

--- a/pkg/minikube/config/profile.go
+++ b/pkg/minikube/config/profile.go
@@ -53,7 +53,12 @@ func (p *Profile) IsValid() bool {
 // PrimaryControlPlane gets the node specific config for the first created control plane
 func PrimaryControlPlane(cc *ClusterConfig) (Node, error) {
 	for _, n := range cc.Nodes {
-		if n.ControlPlane {
+		if n.APIEndpointServer {
+			return n, nil
+		}
+	}
+	for _, n := range cc.Nodes {
+		if n.ControlPlane { // keep n.ControlPlane for backward compatibility
 			return n, nil
 		}
 	}
@@ -65,6 +70,7 @@ func PrimaryControlPlane(cc *ClusterConfig) (Node, error) {
 		Port:              cc.KubernetesConfig.NodePort,
 		KubernetesVersion: cc.KubernetesConfig.KubernetesVersion,
 		ControlPlane:      true,
+		APIEndpointServer: true,
 		Worker:            true,
 	}
 
@@ -291,7 +297,7 @@ func ProfileFolderPath(profile string, miniHome ...string) string {
 // MachineName returns the name of the machine, as seen by the hypervisor given the cluster and node names
 func MachineName(cc ClusterConfig, n Node) string {
 	// For single node cluster, default to back to old naming
-	if len(cc.Nodes) == 1 || n.ControlPlane {
+	if len(cc.Nodes) == 1 || n.APIEndpointServer || (n.ControlPlane && n.Name == "") {
 		return cc.Name
 	}
 	return fmt.Sprintf("%s-%s", cc.Name, n.Name)

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -110,13 +110,13 @@ type KubernetesConfig struct {
 
 // Node contains information about specific nodes in a cluster
 type Node struct {
-	Name              string
-	IP                string
-	Port              int
-	KubernetesVersion string
-	APIEndpointServer bool
-	ControlPlane      bool
-	Worker            bool
+	Name                string
+	IP                  string
+	Port                int
+	KubernetesVersion   string
+	PrimaryControlPlane bool
+	ControlPlane        bool
+	Worker              bool
 }
 
 // VersionedExtraOption holds information on flags to apply to a specific range

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -114,6 +114,7 @@ type Node struct {
 	IP                string
 	Port              int
 	KubernetesVersion string
+	APIEndpointServer bool
 	ControlPlane      bool
 	Worker            bool
 }

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -54,8 +54,8 @@ const (
 	DefaultServiceCIDR = "10.96.0.0/12"
 	// HostAlias is a DNS alias to the the container/VM host IP
 	HostAlias = "host.minikube.internal"
-	// ControlPlaneAlias is a DNS alias pointing to the apiserver frontend
-	ControlPlaneAlias = "control-plane.minikube.internal"
+	// APIEndpointAlias is a DNS alias pointing to the apiserver frontend
+	APIEndpointAlias = "control-plane.minikube.internal"
 
 	// DockerHostEnv is used for docker daemon settings
 	DockerHostEnv = "DOCKER_HOST"

--- a/pkg/minikube/node/node.go
+++ b/pkg/minikube/node/node.go
@@ -89,6 +89,16 @@ func Delete(cc config.ClusterConfig, name string) (*config.Node, error) {
 
 	// leave master
 	if n.ControlPlane {
+		host, err := machine.LoadHost(api, m)
+		if err != nil {
+			return n, err
+		}
+
+		runner, err := machine.CommandRunner(host)
+		if err != nil {
+			return n, err
+		}
+
 		resetCmd := fmt.Sprintf("%s reset -f", bsutil.InvokeKubeadm(cc.KubernetesConfig.KubernetesVersion))
 		rc := exec.Command("/bin/bash", "-c", resetCmd)
 		_, err = runner.RunCmd(rc)

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -81,7 +81,7 @@ type Starter struct {
 
 // Start spins up a guest and starts the Kubernetes node.
 func Start(starter Starter) (*kubeconfig.Settings, error) {
-	apiEndpointServer := starter.Node.APIEndpointServer // TODO backward compatibility
+	apiEndpointServer := starter.Node.PrimaryControlPlane // TODO backward compatibility
 	// wait for preloaded tarball to finish downloading before configuring runtimes
 	waitCacheRequiredImages(&cacheGroup)
 

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -81,7 +81,7 @@ type Starter struct {
 
 // Start spins up a guest and starts the Kubernetes node.
 func Start(starter Starter) (*kubeconfig.Settings, error) {
-	apiEndpointServer := starter.Node.PrimaryControlPlane // TODO backward compatibility
+	apiEndpointServer := starter.Node.PrimaryControlPlane
 	// wait for preloaded tarball to finish downloading before configuring runtimes
 	waitCacheRequiredImages(&cacheGroup)
 

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -242,6 +242,7 @@ var (
 	GuestMount            = Kind{ID: "GUEST_MOUNT", ExitCode: ExGuestError}
 	GuestMountConflict    = Kind{ID: "GUEST_MOUNT_CONFLICT", ExitCode: ExGuestConflict}
 	GuestNodeAdd          = Kind{ID: "GUEST_NODE_ADD", ExitCode: ExGuestError}
+	GuestNodeReset        = Kind{ID: "GUEST_NODE_RESET", ExitCode: ExGuestError}
 	GuestNodeDelete       = Kind{ID: "GUEST_NODE_DELETE", ExitCode: ExGuestError}
 	GuestNodeProvision    = Kind{ID: "GUEST_NODE_PROVISION", ExitCode: ExGuestError}
 	GuestNodeRetrieve     = Kind{ID: "GUEST_NODE_RETRIEVE", ExitCode: ExGuestNotFound}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -109,3 +109,14 @@ func MaybeChownDirRecursiveToMinikubeUser(dir string) error {
 func ParseKubernetesVersion(version string) (semver.Version, error) {
 	return semver.Make(version[1:])
 }
+
+func CheckMultiControlPlaneVersion(version string) error {
+	ver, err := ParseKubernetesVersion(version)
+	if err != nil {
+		return err
+	}
+	if ver.Minor < 15 {
+		return errors.Errorf("Multi control plane requires Kubernetes 1.15+, current version %s is not supported.", version)
+	}
+	return nil
+}

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -30,6 +30,7 @@ minikube start [flags]
       --cache-images                      If true, cache docker images for the current bootstrapper and load them into the machine. Always false with --driver=none. (default true)
       --cni string                        CNI plug-in to use. Valid options: auto, bridge, calico, cilium, flannel, kindnet, or path to a CNI manifest (default: auto)
       --container-runtime string          The container runtime to be used (docker, cri-o, containerd). (default "docker")
+      --control-planes int                The number of control planes to spin up. Defaults to 1. (default 1)
       --cpus int                          Number of CPUs allocated to Kubernetes. (default 2)
       --cri-socket string                 The cri socket path to be used.
       --delete-on-failure                 If set, delete the current cluster if start fails and try again. Defaults to false.

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -47,7 +47,7 @@ minikube start [flags]
       --extra-config ExtraOption          A set of key=value pairs that describe configuration that may be passed to different components.
                                           		The key should be '.' separated, and the first part before the dot is the component to apply the configuration to.
                                           		Valid components are: kubelet, kubeadm, apiserver, controller-manager, etcd, proxy, scheduler
-                                          		Valid kubeadm parameters: ignore-preflight-errors, dry-run, kubeconfig, kubeconfig-dir, node-name, cri-socket, experimental-upload-certs, certificate-key, rootfs, skip-phases, pod-network-cidr
+                                          		Valid kubeadm parameters: ignore-preflight-errors, dry-run, kubeconfig, kubeconfig-dir, node-name, cri-socket, upload-certs, certificate-key, rootfs, skip-phases, pod-network-cidr
       --feature-gates string              A set of key=value pairs that describe feature gates for alpha/experimental features.
       --force                             Force minikube to perform possibly dangerous operations
       --force-systemd                     If set, force the container runtime to use sytemd as cgroup manager. Defaults to false.

--- a/site/content/en/docs/commands/status.md
+++ b/site/content/en/docs/commands/status.md
@@ -22,12 +22,13 @@ minikube status [flags]
 ### Options
 
 ```
-  -f, --format string         Go template format string for the status output.  The format for Go templates can be found here: https://golang.org/pkg/text/template/
-                              For the list accessible variables for the template, see the struct values here: https://godoc.org/k8s.io/minikube/cmd/minikube/cmd#Status (default "{{.Name}}\ntype: Control Plane{{if .IsAPIEndpoint}} (Primary){{end}}\nhost: {{.Host}}\nkubelet: {{.Kubelet}}\napiserver: {{.APIServer}}\nkubeconfig: {{.Kubeconfig}}\ntimeToStop: {{.TimeToStop}}\nIP: {{.IP}}\n\n")
-  -l, --layout string         output layout (EXPERIMENTAL, JSON only): 'nodes' or 'cluster' (default "nodes")
-  -n, --node string           The node to check status for. Defaults to control plane. Leave blank with default format for status on all nodes.
-  -o, --output string         minikube status --output OUTPUT. json, text (default "text")
-  -w, --watch duration[=1s]   Continuously listing/getting the status with optional interval duration. (default 1s)
+  -f, --format string                      Go template format string for the status output.  The format for Go templates can be found here: https://golang.org/pkg/text/template/
+                                           For the list accessible variables for the template, see the struct values here: https://godoc.org/k8s.io/minikube/cmd/minikube/cmd#Status (default "{{.Name}}\ntype: Control Plane{{if .IsAPIEndpoint}} (Primary){{end}}\nhost: {{.Host}}\nkubelet: {{.Kubelet}}\napiserver: {{.APIServer}}\nkubeconfig: {{.Kubeconfig}}\ntimeToStop: {{.TimeToStop}}\nIP: {{.IP}}\n\n")
+  -l, --layout string                      output layout (EXPERIMENTAL, JSON only): 'nodes' or 'cluster' (default "nodes")
+  -n, --node string                        The node to check status for. Defaults to control plane. Leave blank with default format for status on all nodes.
+  -o, --output string                      minikube status --output OUTPUT. json, text (default "text")
+      --update-primary-control-plane-tag   Update primary control plane tag if there is no control plane marked as API endpoint.
+  -w, --watch duration[=1s]                Continuously listing/getting the status with optional interval duration. (default 1s)
 ```
 
 ### Options inherited from parent commands

--- a/site/content/en/docs/commands/status.md
+++ b/site/content/en/docs/commands/status.md
@@ -23,7 +23,7 @@ minikube status [flags]
 
 ```
   -f, --format string         Go template format string for the status output.  The format for Go templates can be found here: https://golang.org/pkg/text/template/
-                              For the list accessible variables for the template, see the struct values here: https://godoc.org/k8s.io/minikube/cmd/minikube/cmd#Status (default "{{.Name}}\ntype: Control Plane\nhost: {{.Host}}\nkubelet: {{.Kubelet}}\napiserver: {{.APIServer}}\nkubeconfig: {{.Kubeconfig}}\ntimeToStop: {{.TimeToStop}}\n\n")
+                              For the list accessible variables for the template, see the struct values here: https://godoc.org/k8s.io/minikube/cmd/minikube/cmd#Status (default "{{.Name}}\ntype: Control Plane{{if .IsAPIEndpoint}} (Primary){{end}}\nhost: {{.Host}}\nkubelet: {{.Kubelet}}\napiserver: {{.APIServer}}\nkubeconfig: {{.Kubeconfig}}\ntimeToStop: {{.TimeToStop}}\nIP: {{.IP}}\n\n")
   -l, --layout string         output layout (EXPERIMENTAL, JSON only): 'nodes' or 'cluster' (default "nodes")
   -n, --node string           The node to check status for. Defaults to control plane. Leave blank with default format for status on all nodes.
   -o, --output string         minikube status --output OUTPUT. json, text (default "text")

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -48,6 +48,7 @@ var testdataDir = flag.String("testdata-dir", "testdata", "the directory relativ
 const (
 	SecondNodeName = "m02"
 	ThirdNodeName  = "m03"
+	FourthNodeName = "m04"
 )
 
 // TestMain is the test main

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -48,7 +48,6 @@ var testdataDir = flag.String("testdata-dir", "testdata", "the directory relativ
 const (
 	SecondNodeName = "m02"
 	ThirdNodeName  = "m03"
-	FourthNodeName = "m04"
 )
 
 // TestMain is the test main

--- a/test/integration/multinode_test.go
+++ b/test/integration/multinode_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 /*
 Copyright 2020 The Kubernetes Authors All rights reserved.
 
@@ -26,14 +24,22 @@ import (
 	"testing"
 )
 
+type clusterStatus struct {
+	running          bool
+	totalNodes       int
+	wantRunningNodes int
+	wantStoppedNodes int
+}
+
+type validatorFunc func(context.Context, *testing.T, string, *clusterStatus)
+
 func TestMultiNode(t *testing.T) {
 	if NoneDriver() {
 		t.Skip("none driver does not support multinode")
 	}
 
-	type validatorFunc func(context.Context, *testing.T, string)
 	profile := UniqueProfileName("multinode")
-	ctx, cancel := context.WithTimeout(context.Background(), Minutes(30))
+	ctx, cancel := context.WithTimeout(context.Background(), Minutes(45))
 	defer CleanupWithLogs(t, profile, cancel)
 
 	t.Run("serial", func(t *testing.T) {
@@ -43,12 +49,18 @@ func TestMultiNode(t *testing.T) {
 		}{
 			{"FreshStart2Nodes", validateMultiNodeStart},
 			{"AddNode", validateAddNodeToMultiNode},
-			{"StopNode", validateStopRunningNode},
-			{"StartAfterStop", validateStartNodeAfterStop},
-			{"DeleteNode", validateDeleteNodeFromMultiNode},
+			{"StopNode", validateStopRunningNode(ThirdNodeName)},
+			{"AddControlPlaneNode", validateAddControlPlaneNodeToMultiNode},
+			{"StopControlPlaneNode", validateStopRunningNode(FourthNodeName)},
+			{"StartAfterStop", validateStartNodeAfterStop(ThirdNodeName)},
+			{"StartControlPlaneAfterStop", validateStartNodeAfterStop(FourthNodeName)},
+			{"DeleteNode", validateDeleteNodeFromMultiNode(ThirdNodeName, true)},
+			{"DeleteControlPlaneNode", validateDeleteNodeFromMultiNode(FourthNodeName, true)},
 			{"StopMultiNode", validateStopMultiNodeCluster},
 			{"RestartMultiNode", validateRestartMultiNodeCluster},
 		}
+
+		s := &clusterStatus{}
 		for _, tc := range tests {
 			tc := tc
 			if ctx.Err() == context.DeadlineExceeded {
@@ -56,13 +68,13 @@ func TestMultiNode(t *testing.T) {
 			}
 			t.Run(tc.name, func(t *testing.T) {
 				defer PostMortemLogs(t, profile)
-				tc.validator(ctx, t, profile)
+				tc.validator(ctx, t, profile, s)
 			})
 		}
 	})
 }
 
-func validateMultiNodeStart(ctx context.Context, t *testing.T, profile string) {
+func validateMultiNodeStart(ctx context.Context, t *testing.T, profile string, s *clusterStatus) {
 	// Start a 2 node cluster with the --nodes param
 	startArgs := append([]string{"start", "-p", profile, "--wait=true", "--memory=2200", "--nodes=2", "-v=8", "--alsologtostderr"}, StartArgs()...)
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), startArgs...))
@@ -70,147 +82,84 @@ func validateMultiNodeStart(ctx context.Context, t *testing.T, profile string) {
 		t.Fatalf("failed to start cluster. args %q : %v", rr.Command(), err)
 	}
 
-	// Make sure minikube status shows 2 nodes
-	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "status", "--alsologtostderr"))
-	if err != nil {
-		t.Fatalf("failed to run minikube status. args %q : %v", rr.Command(), err)
-	}
-
-	if strings.Count(rr.Stdout.String(), "host: Running") != 2 {
-		t.Errorf("status says both hosts are not running: args %q: %v", rr.Command(), rr.Stdout.String())
-	}
-
-	if strings.Count(rr.Stdout.String(), "kubelet: Running") != 2 {
-		t.Errorf("status says both kubelets are not running: args %q: %v", rr.Command(), rr.Stdout.String())
-	}
-
+	s.startCluster()
+	s.addNode(2)
+	validateClusterStatus(ctx, t, profile, s)
 }
 
-func validateAddNodeToMultiNode(ctx context.Context, t *testing.T, profile string) {
+func validateAddNodeToMultiNode(ctx context.Context, t *testing.T, profile string, s *clusterStatus) {
 	// Add a node to the current cluster
 	addArgs := []string{"node", "add", "-p", profile, "-v", "3", "--alsologtostderr"}
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), addArgs...))
 	if err != nil {
 		t.Fatalf("failed to add node to current cluster. args %q : %v", rr.Command(), err)
 	}
-
-	// Make sure minikube status shows 3 nodes
-	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "status", "--alsologtostderr"))
-	if err != nil {
-		t.Fatalf("failed to run minikube status. args %q : %v", rr.Command(), err)
-	}
-
-	if strings.Count(rr.Stdout.String(), "host: Running") != 3 {
-		t.Errorf("status says all hosts are not running: args %q: %v", rr.Command(), rr.Stdout.String())
-	}
-
-	if strings.Count(rr.Stdout.String(), "kubelet: Running") != 3 {
-		t.Errorf("status says all kubelets are not running: args %q: %v", rr.Command(), rr.Stdout.String())
-	}
+	s.addNode(1)
+	validateClusterStatus(ctx, t, profile, s)
 }
 
-func validateStopRunningNode(ctx context.Context, t *testing.T, profile string) {
-	// Run minikube node stop on that node
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "node", "stop", ThirdNodeName))
+func validateAddControlPlaneNodeToMultiNode(ctx context.Context, t *testing.T, profile string, s *clusterStatus) {
+	// Add a node to the current cluster
+	addArgs := []string{"node", "add", "-p", profile, "-v", "3", "--alsologtostderr", "--control-plane"}
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), addArgs...))
 	if err != nil {
-		t.Errorf("node stop returned an error. args %q: %v", rr.Command(), err)
+		t.Fatalf("failed to add control plane node to current cluster. args %q : %v", rr.Command(), err)
 	}
 
-	// Run status again to see the stopped host
-	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "status"))
-	// Exit code 7 means one host is stopped, which we are expecting
-	if err != nil && rr.ExitCode != 7 {
-		t.Fatalf("failed to run minikube status. args %q : %v", rr.Command(), err)
-	}
-
-	// Make sure minikube status shows 2 running nodes and 1 stopped one
-	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "status", "--alsologtostderr"))
-	if err != nil && rr.ExitCode != 7 {
-		t.Fatalf("failed to run minikube status. args %q : %v", rr.Command(), err)
-	}
-
-	if strings.Count(rr.Stdout.String(), "kubelet: Running") != 2 {
-		t.Errorf("incorrect number of running kubelets: args %q: %v", rr.Command(), rr.Stdout.String())
-	}
-
-	if strings.Count(rr.Stdout.String(), "host: Stopped") != 1 {
-		t.Errorf("incorrect number of stopped hosts: args %q: %v", rr.Command(), rr.Stdout.String())
-	}
-
-	if strings.Count(rr.Stdout.String(), "kubelet: Stopped") != 1 {
-		t.Errorf("incorrect number of stopped kubelets: args %q: %v", rr.Command(), rr.Stdout.String())
-	}
+	s.addNode(1)
+	validateClusterStatus(ctx, t, profile, s)
 }
 
-func validateStartNodeAfterStop(ctx context.Context, t *testing.T, profile string) {
-	if DockerDriver() {
-		rr, err := Run(t, exec.Command("docker", "version", "-f", "{{.Server.Version}}"))
+func validateStopRunningNode(nodeName string) validatorFunc {
+	return func(ctx context.Context, t *testing.T, profile string, s *clusterStatus) {
+		// Run minikube node stop on that node
+		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "node", "stop", nodeName))
 		if err != nil {
-			t.Fatalf("docker is broken: %v", err)
+			t.Errorf("node stop returned an error. args %q: %v", rr.Command(), err)
 		}
-		if strings.Contains(rr.Stdout.String(), "azure") {
-			t.Skip("kic containers are not supported on docker's azure")
-		}
-	}
 
-	// Start the node back up
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "node", "start", ThirdNodeName, "--alsologtostderr"))
-	if err != nil {
-		t.Logf(rr.Stderr.String())
-		t.Errorf("node start returned an error. args %q: %v", rr.Command(), err)
-	}
-
-	// Make sure minikube status shows 3 running hosts
-	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "status"))
-	if err != nil {
-		t.Fatalf("failed to run minikube status. args %q : %v", rr.Command(), err)
-	}
-
-	if strings.Count(rr.Stdout.String(), "host: Running") != 3 {
-		t.Errorf("status says both hosts are not running: args %q: %v", rr.Command(), rr.Stdout.String())
-	}
-
-	if strings.Count(rr.Stdout.String(), "kubelet: Running") != 3 {
-		t.Errorf("status says both kubelets are not running: args %q: %v", rr.Command(), rr.Stdout.String())
-	}
-
-	// Make sure kubectl can connect correctly
-	rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "get", "nodes"))
-	if err != nil {
-		t.Fatalf("failed to kubectl get nodes. args %q : %v", rr.Command(), err)
+		s.stopNode()
+		validateClusterStatus(ctx, t, profile, s)
 	}
 }
 
-func validateStopMultiNodeCluster(ctx context.Context, t *testing.T, profile string) {
+func validateStartNodeAfterStop(nodeName string) validatorFunc {
+	return func(ctx context.Context, t *testing.T, profile string, s *clusterStatus) {
+		if DockerDriver() {
+			rr, err := Run(t, exec.Command("docker", "version", "-f", "{{.Server.Version}}"))
+			if err != nil {
+				t.Fatalf("docker is broken: %v", err)
+			}
+			if strings.Contains(rr.Stdout.String(), "azure") {
+				s.startNode() // Make GitHub test happy
+				t.Skip("kic containers are not supported on docker's azure")
+			}
+		}
+
+		// Start the node back up
+		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "node", "start", nodeName, "--alsologtostderr"))
+		if err != nil {
+			t.Logf(rr.Stderr.String())
+			t.Errorf("node start returned an error. args %q: %v", rr.Command(), err)
+		}
+
+		s.startNode()
+		validateClusterStatus(ctx, t, profile, s)
+	}
+}
+
+func validateStopMultiNodeCluster(ctx context.Context, t *testing.T, profile string, s *clusterStatus) {
 	// Run minikube stop on the cluster
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "stop"))
 	if err != nil {
 		t.Errorf("node stop returned an error. args %q: %v", rr.Command(), err)
 	}
 
-	// Run status to see the stopped hosts
-	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "status"))
-	// Exit code 7 means one host is stopped, which we are expecting
-	if err != nil && rr.ExitCode != 7 {
-		t.Fatalf("failed to run minikube status. args %q : %v", rr.Command(), err)
-	}
-
-	// Make sure minikube status shows 2 stopped nodes
-	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "status", "--alsologtostderr"))
-	if err != nil && rr.ExitCode != 7 {
-		t.Fatalf("failed to run minikube status. args %q : %v", rr.Command(), err)
-	}
-
-	if strings.Count(rr.Stdout.String(), "host: Stopped") != 2 {
-		t.Errorf("incorrect number of stopped hosts: args %q: %v", rr.Command(), rr.Stdout.String())
-	}
-
-	if strings.Count(rr.Stdout.String(), "kubelet: Stopped") != 2 {
-		t.Errorf("incorrect number of stopped kubelets: args %q: %v", rr.Command(), rr.Stdout.String())
-	}
+	s.stopCluster()
+	validateClusterStatus(ctx, t, profile, s)
 }
 
-func validateRestartMultiNodeCluster(ctx context.Context, t *testing.T, profile string) {
+func validateRestartMultiNodeCluster(ctx context.Context, t *testing.T, profile string, s *clusterStatus) {
 	if DockerDriver() {
 		rr, err := Run(t, exec.Command("docker", "version", "-f", "{{.Server.Version}}"))
 		if err != nil {
@@ -227,19 +176,8 @@ func validateRestartMultiNodeCluster(ctx context.Context, t *testing.T, profile 
 		t.Fatalf("failed to start cluster. args %q : %v", rr.Command(), err)
 	}
 
-	// Make sure minikube status shows 2 running nodes
-	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "status", "--alsologtostderr"))
-	if err != nil {
-		t.Fatalf("failed to run minikube status. args %q : %v", rr.Command(), err)
-	}
-
-	if strings.Count(rr.Stdout.String(), "host: Running") != 2 {
-		t.Errorf("status says both hosts are not running: args %q: %v", rr.Command(), rr.Output())
-	}
-
-	if strings.Count(rr.Stdout.String(), "kubelet: Running") != 2 {
-		t.Errorf("status says both kubelets are not running: args %q: %v", rr.Command(), rr.Output())
-	}
+	s.startCluster()
+	validateClusterStatus(ctx, t, profile, s)
 
 	// Make sure kubectl reports that all nodes are ready
 	rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "get", "nodes"))
@@ -247,64 +185,140 @@ func validateRestartMultiNodeCluster(ctx context.Context, t *testing.T, profile 
 		t.Fatalf("failed to run kubectl get nodes. args %q : %v", rr.Command(), err)
 	}
 	if strings.Count(rr.Stdout.String(), "NotReady") > 0 {
-		t.Errorf("expected 2 nodes to be Ready, got %v", rr.Output())
+		t.Errorf("expected %v nodes to be Ready, got %v", s.wantRunningNodes, rr.Output())
 	}
 
 	rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "get", "nodes", "-o", `go-template='{{range .items}}{{range .status.conditions}}{{if eq .type "Ready"}} {{.status}}{{"\n"}}{{end}}{{end}}{{end}}'`))
 	if err != nil {
 		t.Fatalf("failed to run kubectl get nodes. args %q : %v", rr.Command(), err)
 	}
-	if strings.Count(rr.Stdout.String(), "True") != 2 {
-		t.Errorf("expected 2 nodes Ready status to be True, got %v", rr.Output())
+	if strings.Count(rr.Stdout.String(), "True") != s.wantRunningNodes {
+		t.Errorf("expected %v nodes Ready status to be True, got %v", s.wantRunningNodes, rr.Output())
 	}
 }
 
-func validateDeleteNodeFromMultiNode(ctx context.Context, t *testing.T, profile string) {
-
-	// Start the node back up
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "node", "delete", ThirdNodeName))
-	if err != nil {
-		t.Errorf("node stop returned an error. args %q: %v", rr.Command(), err)
-	}
-
-	// Make sure status is back down to 2 hosts
-	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "status", "--alsologtostderr"))
-	if err != nil {
-		t.Fatalf("failed to run minikube status. args %q : %v", rr.Command(), err)
-	}
-
-	if strings.Count(rr.Stdout.String(), "host: Running") != 2 {
-		t.Errorf("status says both hosts are not running: args %q: %v", rr.Command(), rr.Stdout.String())
-	}
-
-	if strings.Count(rr.Stdout.String(), "kubelet: Running") != 2 {
-		t.Errorf("status says both kubelets are not running: args %q: %v", rr.Command(), rr.Stdout.String())
-	}
-
-	if DockerDriver() {
-		rr, err := Run(t, exec.Command("docker", "volume", "ls"))
+func validateDeleteNodeFromMultiNode(nodeName string, running bool) validatorFunc {
+	return func(ctx context.Context, t *testing.T, profile string, s *clusterStatus) {
+		// Start the node back up
+		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "node", "delete", nodeName))
 		if err != nil {
-			t.Errorf("failed to run %q : %v", rr.Command(), err)
+			t.Errorf("node stop returned an error. args %q: %v", rr.Command(), err)
 		}
-		if strings.Contains(rr.Stdout.String(), fmt.Sprintf("%s-%s", profile, ThirdNodeName)) {
-			t.Errorf("docker volume was not properly deleted: %s", rr.Stdout.String())
+
+		if running {
+			s.deleteRunningNode()
+		} else {
+			s.deleteStoppedNode()
 		}
+		validateClusterStatus(ctx, t, profile, s)
+
+		if DockerDriver() {
+			rr, err := Run(t, exec.Command("docker", "volume", "ls"))
+			if err != nil {
+				t.Errorf("failed to run %q : %v", rr.Command(), err)
+			}
+			if strings.Contains(rr.Stdout.String(), fmt.Sprintf("%s-%s", profile, ThirdNodeName)) {
+				t.Errorf("docker volume was not properly deleted: %s", rr.Stdout.String())
+			}
+		}
+
+		// Make sure kubectl knows the node is gone
+		rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "get", "nodes"))
+		if err != nil {
+			t.Fatalf("failed to run kubectl get nodes. args %q : %v", rr.Command(), err)
+		}
+		if strings.Count(rr.Stdout.String(), "NotReady") > 0 {
+			t.Errorf("expected %v nodes to be Ready, got %v", s.wantRunningNodes, rr.Output())
+		}
+
+		rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "get", "nodes", "-o", `go-template='{{range .items}}{{range .status.conditions}}{{if eq .type "Ready"}} {{.status}}{{"\n"}}{{end}}{{end}}{{end}}'`))
+		if err != nil {
+			t.Fatalf("failed to run kubectl get nodes. args %q : %v", rr.Command(), err)
+		}
+		if strings.Count(rr.Stdout.String(), "True") != s.wantRunningNodes {
+			t.Errorf("expected %v nodes Ready status to be True, got %v", s.wantRunningNodes, rr.Output())
+		}
+	}
+}
+
+func (s *clusterStatus) addNode(count int) {
+	s.totalNodes += count
+	s.wantRunningNodes += count
+}
+
+func (s *clusterStatus) stopNode() {
+	s.wantRunningNodes--
+	s.wantStoppedNodes++
+}
+
+func (s *clusterStatus) startNode() {
+	s.wantRunningNodes++
+	s.wantStoppedNodes--
+}
+
+func (s *clusterStatus) deleteRunningNode() {
+	s.totalNodes--
+	s.wantRunningNodes--
+}
+
+func (s *clusterStatus) deleteStoppedNode() {
+	s.totalNodes--
+	s.wantStoppedNodes--
+}
+
+func (s *clusterStatus) stopCluster() {
+	s.running = false
+	s.wantRunningNodes = 0
+	s.wantStoppedNodes = s.totalNodes
+}
+
+func (s *clusterStatus) startCluster() {
+	s.running = true
+	s.wantRunningNodes = s.totalNodes
+	s.wantStoppedNodes = 0
+}
+
+// validateClusterStatus validates running/stopped kubelet/host count, check kubectl config and api serve connection.
+func validateClusterStatus(ctx context.Context, t *testing.T, profile string, s *clusterStatus) {
+	// Make sure minikube status shows expected running nodes and stopped nodes
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "status", "--alsologtostderr"))
+	if err != nil {
+		if s.wantStoppedNodes > 0 {
+			// Exit code 7 means one host is stopped, which we are expecting
+			if rr.ExitCode != 7 {
+				t.Fatalf("failed to run minikube status. args %q : %v", rr.Command(), err)
+			}
+		} else {
+			t.Fatalf("failed to run minikube status. args %q : %v", rr.Command(), err)
+		}
+	}
+	var count int
+
+	count = strings.Count(rr.Stdout.String(), "kubelet: Running")
+	if count != s.wantRunningNodes {
+		t.Errorf("incorrect number of running kubelets (want: %v, got %v): args %q: %v", s.wantRunningNodes, count, rr.Command(), rr.Stdout.String())
 	}
 
-	// Make sure kubectl knows the node is gone
-	rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "get", "nodes"))
-	if err != nil {
-		t.Fatalf("failed to run kubectl get nodes. args %q : %v", rr.Command(), err)
-	}
-	if strings.Count(rr.Stdout.String(), "NotReady") > 0 {
-		t.Errorf("expected 2 nodes to be Ready, got %v", rr.Output())
+	count = strings.Count(rr.Stdout.String(), "kubelet: Stopped")
+	if count != s.wantStoppedNodes {
+		t.Errorf("incorrect number of stopped kubelets (want: %v, got %v): args %q: %v", s.wantStoppedNodes, count, rr.Command(), rr.Stdout.String())
 	}
 
-	rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "get", "nodes", "-o", `go-template='{{range .items}}{{range .status.conditions}}{{if eq .type "Ready"}} {{.status}}{{"\n"}}{{end}}{{end}}{{end}}'`))
-	if err != nil {
-		t.Fatalf("failed to run kubectl get nodes. args %q : %v", rr.Command(), err)
+	count = strings.Count(rr.Stdout.String(), "host: Running")
+	if count != s.wantRunningNodes {
+		t.Errorf("incorrect number of running hosts (want: %v, got %v): args %q: %v", s.wantRunningNodes, count, rr.Command(), rr.Stdout.String())
 	}
-	if strings.Count(rr.Stdout.String(), "True") != 2 {
-		t.Errorf("expected 2 nodes Ready status to be True, got %v", rr.Output())
+
+	count = strings.Count(rr.Stdout.String(), "host: Stopped")
+	if count != s.wantStoppedNodes {
+		t.Errorf("incorrect number of stopped hosts (want: %v, got %v): args %q: %v", s.wantStoppedNodes, count, rr.Command(), rr.Stdout.String())
+	}
+
+	if s.running {
+		// Make sure kubectl can connect correctly
+		rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "get", "nodes"))
+		if err != nil {
+			t.Fatalf("failed to kubectl get nodes. args %q : %v", rr.Command(), err)
+		}
 	}
 }

--- a/test/integration/multinode_test.go
+++ b/test/integration/multinode_test.go
@@ -50,14 +50,17 @@ func TestMultiNode(t *testing.T) {
 			validator validatorFunc
 		}{
 			{"FreshStart2Nodes", validateMultiNodeStart},
+			// Add worker node
 			{"AddNode", validateAddNodeToMultiNode},
 			{"StopNode", validateStopRunningNode(ThirdNodeName)},
-			{"AddControlPlaneNode", validateAddControlPlaneNodeToMultiNode},
-			{"StopControlPlaneNode", validateStopRunningNode(FourthNodeName)},
 			{"StartAfterStop", validateStartNodeAfterStop(ThirdNodeName)},
-			{"StartControlPlaneAfterStop", validateStartNodeAfterStop(FourthNodeName)},
 			{"DeleteNode", validateDeleteNodeFromMultiNode(ThirdNodeName, true)},
-			{"DeleteControlPlaneNode", validateDeleteNodeFromMultiNode(FourthNodeName, true)},
+			// Add control plane node
+			{"AddControlPlaneNode", validateAddControlPlaneNodeToMultiNode},
+			{"StopControlPlaneNode", validateStopRunningNode(ThirdNodeName)},
+			{"StartControlPlaneAfterStop", validateStartNodeAfterStop(ThirdNodeName)},
+			{"DeleteControlPlaneNode", validateDeleteNodeFromMultiNode(ThirdNodeName, true)},
+			// Test cluster stop && start
 			{"StopMultiNode", validateStopMultiNodeCluster},
 			{"RestartMultiNode", validateRestartMultiNodeCluster},
 		}


### PR DESCRIPTION
/kind feature

Changes:
- [x] fix tests - hope finished
- [x] fix missing InitialSetup in `node add`
- [x] fix/implement `node add --control-plane`
- [x] add flag `--control-planes` to config control planes number: `minikube start --control-planes 2`. `--nodes` will automatically enlarge if `nodes < control-planes` and outputs a warning.
- [x] tag primary control plane: add field `PrimaryControlPlane`
- [x] add IP and primary tag in `status`
- [x] reset control plane node before stop it, make sure primary control plane can start without others control planes
- [x] add some step output
- [x] change KindNet.String() from `CNI` to `KindNet`
- [x] `status` command: stacked control plane node `kubeconfig` should be irrelevant. `kubeconfig` still exist in stacked control plane node but configured at `control-plane.minikube.internal:8443` to generate certificate keys.
- [x] backward compatibility
  - [x] `start` from a stopped old cluster config
  - [x] `node add`, `node stop`, `node start`, `stop` a running old cluster
  - [x] `status` warn user outdated config, provides flag `--update-primary-control-plane-tag` to update profile.
- [x] multiple control planes integration tests

Fixes: #7461, part of #7538

Currently finished:

```bash
minikube start
minikube node add --control-plane # Support multi control plane
minikube stop # make sure stop && start works
minikube start
minikube node stop m02 # make sure node stop && node start works
minikube node start m02
```

Some output changes:
```bash
$ minikube status
minikube
type: Control Plane (Primary)
host: Running
kubelet: Running
apiserver: Running
kubeconfig: Configured
timeToStop: Nonexistent
IP: 192.168.39.13

minikube-m02
type: Control Plane
host: Running
kubelet: Running
apiserver: Running
kubeconfig: Irrelevant
timeToStop: Nonexistent
IP: 192.168.39.252
```

Outdated profile and `status` command output:

```js
// ...
"Nodes": [
        {
            "Name": "",
            "IP": "192.168.39.164",
            "Port": 8443,
            "KubernetesVersion": "v1.19.3",
            "PrimaryControlPlane": false, // <- outdated config is false here
            "ControlPlane": true,
            "Worker": true
        }
    ],
// ...
```

```bash
$ minikube status
There is no primary control plane, set --update-primary-control-plane-tag=true to update profile.
minikube
type: Control Plane
host: Running
kubelet: Running
apiserver: Running
kubeconfig: Irrelevant
timeToStop: Nonexistent
IP: 192.168.39.164
```