### PR TITLE
wsl2: log warning if br_netfilter cannot be enabled rather than fatally exit

### DIFF
--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -22,7 +22,6 @@ import (
 	"os/exec"
 
 	"github.com/blang/semver"
-	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/command"
@@ -207,24 +206,6 @@ func disableOthers(me Manager, cr CommandRunner) error {
 		if r.Active() {
 			return fmt.Errorf("%s is still active", r.Name())
 		}
-	}
-	return nil
-}
-
-// enableIPForwarding configures IP forwarding, which is handled normally by Docker
-// Context: https://github.com/kubernetes/kubeadm/issues/1062
-func enableIPForwarding(cr CommandRunner) error {
-	c := exec.Command("sudo", "sysctl", "net.bridge.bridge-nf-call-iptables")
-	if rr, err := cr.RunCmd(c); err != nil {
-		klog.Infof("couldn't verify netfilter by %q which might be okay. error: %v", rr.Command(), err)
-		c = exec.Command("sudo", "modprobe", "br_netfilter")
-		if _, err := cr.RunCmd(c); err != nil {
-			return errors.Wrapf(err, "br_netfilter")
-		}
-	}
-	c = exec.Command("sudo", "sh", "-c", "echo 1 > /proc/sys/net/ipv4/ip_forward")
-	if _, err := cr.RunCmd(c); err != nil {
-		return errors.Wrapf(err, "ip_forward")
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #9837

Also moved `enableIPForwarding` function to `crio.go`, as CRIO is the only runtime we do this with. 

Confirmed by testing locally using Docker & WSL2.
