### PR TITLE
Remove obsolete mention of kvm driver, fixes generate-docs issue

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -181,7 +181,7 @@ var settings = []Setting{
 var ConfigCmd = &cobra.Command{
 	Use:   "config SUBCOMMAND [flags]",
 	Short: "Modify persistent configuration values",
-	Long: `config modifies minikube config files using subcommands like "minikube config set driver kvm"
+	Long: `config modifies minikube config files using subcommands like "minikube config set driver kvm2"
 Configurable fields: ` + "\n\n" + configurableFields(),
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := cmd.Help(); err != nil {


### PR DESCRIPTION
Someone updated the autogenerated doc file to say `kvm2` instead of `kvm` without fixing the generator of it.