### PR TITLE
Fixed output on back to back spinner steps

### DIFF
--- a/pkg/minikube/out/out.go
+++ b/pkg/minikube/out/out.go
@@ -138,6 +138,10 @@ func spinnerString(format string, a ...interface{}) {
 	}
 
 	klog.Infof(format, a...)
+	// if spin is active from a previous step, it will stop spinner displaying
+	if spin.Active() {
+		spin.Stop()
+	}
 	_, err := fmt.Fprintf(outFile, format, a...)
 	if err != nil {
 		klog.Errorf("Fprintf failed: %v", err)


### PR DESCRIPTION
Fixed bug in #9855 where back to back spinner steps produced malformed output.

Before:
```
🐳  Preparing Kubernetes v1.20.0 on Docker 20.10.0 ...|     ▪ Generating certificates and keys .|     ▪ Booting up control plane .|     ▪ Configuring RBAC rules .
```

After:
```
🐳  Preparing Kubernetes v1.20.0 on Docker 20.10.0 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
```
