### PR TITLE
Run generate-docs again for the driver rename

### DIFF
--- a/site/content/en/docs/commands/config.md
+++ b/site/content/en/docs/commands/config.md
@@ -11,7 +11,7 @@ Modify persistent configuration values
 
 ### Synopsis
 
-config modifies minikube config files using subcommands like "minikube config set driver kvm"
+config modifies minikube config files using subcommands like "minikube config set driver kvm2"
 Configurable fields: 
 
  * driver


### PR DESCRIPTION
The iso bump reverted the previous fix again

Was broken in f3be305abb7c609130b6957b2b63ae924113770f