### PR TITLE
Add persistent storage for /var/lib/buildkit

### DIFF
--- a/deploy/iso/minikube-iso/package/automount/minikube-automount
+++ b/deploy/iso/minikube-iso/package/automount/minikube-automount
@@ -105,6 +105,10 @@ if [ -n "$BOOT2DOCKER_DATA" ]; then
     mkdir -p /var/lib/containerd
     mount --bind /mnt/$PARTNAME/var/lib/containerd /var/lib/containerd
 
+    mkdir -p /mnt/$PARTNAME/var/lib/buildkit
+    mkdir -p /var/lib/buildkit
+    mount --bind /mnt/$PARTNAME/var/lib/buildkit /var/lib/buildkit
+
     mkdir -p /mnt/$PARTNAME/var/lib/containers
     mkdir -p /var/lib/containers
     mount --bind /mnt/$PARTNAME/var/lib/containers /var/lib/containers

--- a/site/content/en/docs/handbook/persistent_volumes.md
+++ b/site/content/en/docs/handbook/persistent_volumes.md
@@ -18,6 +18,9 @@ minikube is configured to persist files stored under the following directories, 
 * `/data`
 * `/var/lib/minikube`
 * `/var/lib/docker`
+* `/var/lib/containerd`
+* `/var/lib/buildkit`
+* `/var/lib/containers`
 * `/tmp/hostpath_pv`
 * `/tmp/hostpath-provisioner`
 


### PR DESCRIPTION
Mostly to not fill up the tmpfs (RAM), most of the contents
are expendable (although the cache can of course be useful)

This is for the ISO, alreading doing the entire `/var` for KIC
Updated the documenation as well, since it was out-of-sync

Improves #9640