### PR TITLE
Add mention of the Windows Package Manager

### DIFF
--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -98,12 +98,22 @@ sudo install minikube-darwin-amd64 /usr/local/bin/minikube
 {{% /mactab %}}
 {{% windowstab %}}
 
-If the [Chocolatey Package Manager](https://chocolatey.org/) is installed, use it to install minikube:
+### Windows Package Manager
+
+If the [Windows Package Manager](https://docs.microsoft.com/en-us/windows/package-manager/) is installed, use the following command to install minikube:
+
+```shell
+winget install minikube
+```
+
+### Chocolatey
+If the [Chocolatey Package Manager](https://chocolatey.org/) is installed, use the following command:
 
 ```shell
 choco install minikube
 ```
 
+### Stand-alone Windows Installer
 Otherwise, download and run the [Windows installer](https://storage.googleapis.com/minikube/releases/latest/minikube-installer.exe)
 
 {{% /windowstab %}}


### PR DESCRIPTION
Update the installation guide to mention winget, the Windows Package Manager.

Minikube is in the repository, and the command I listed works correctly:
andre@IRIDIUM-MMXX  C:\Windows\System32                                                                      [16:11]
❯ winget search minikube
Name     Id                  Version
------------------------------------
minikube Kubernetes.minikube 1.15.1
andre@IRIDIUM-MMXX  C:\Windows\System32                                                                      [16:12]
❯ winget install minikube
Found minikube [Kubernetes.minikube]
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licences to, third-party packages.
Downloading https://storage.googleapis.com/minikube/releases/latest/minikube-installer.exe
  ██████████████████████████████  23.7 MB / 23.7 MB
Successfully verified installer hash
Starting package install...
Successfully installed

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
