### PR TITLE
Remove obsolete 'vmwarefusion' driver, add friendly message

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -705,6 +705,16 @@ func validateDriver(ds registry.DriverState, existing *config.ClusterConfig) {
 		out.Step(style.Improvement, `For improved {{.driver}} performance, {{.fix}}`, out.V{"driver": driver.FullName(ds.Name), "fix": translate.T(st.Fix)})
 	}
 
+	if ds.Priority == registry.Obsolete {
+		exit.Message(reason.Kind{
+			ID:       fmt.Sprintf("PROVIDER_%s_OBSOLETE", strings.ToUpper(name)),
+			Advice:   translate.T(st.Fix),
+			ExitCode: reason.ExProviderUnsupported,
+			URL:      st.Doc,
+			Style:    style.Shrug,
+		}, st.Error.Error())
+	}
+
 	if st.Error == nil {
 		return
 	}

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -47,7 +47,7 @@ const (
 	HyperKit = "hyperkit"
 	// VMware driver
 	VMware = "vmware"
-	// VMwareFusion driver (deprecated)
+	// VMwareFusion driver (obsolete)
 	VMwareFusion = "vmwarefusion"
 	// HyperV driver
 	HyperV = "hyperv"

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -47,7 +47,7 @@ const (
 	HyperKit = "hyperkit"
 	// VMware driver
 	VMware = "vmware"
-	// VMwareFusion driver
+	// VMwareFusion driver (deprecated)
 	VMwareFusion = "vmwarefusion"
 	// HyperV driver
 	HyperV = "hyperv"

--- a/pkg/minikube/machine/start.go
+++ b/pkg/minikube/machine/start.go
@@ -34,7 +34,6 @@ import (
 	"github.com/docker/machine/libmachine/host"
 	"github.com/juju/mutex"
 	"github.com/pkg/errors"
-	"github.com/spf13/viper"
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/command"
@@ -130,12 +129,6 @@ func createHost(api libmachine.API, cfg *config.ClusterConfig, n *config.Node) (
 		klog.Infof("duration metric: createHost completed in %s", time.Since(start))
 	}()
 
-	if cfg.Driver == driver.VMwareFusion && viper.GetBool(config.ShowDriverDeprecationNotification) {
-		out.WarningT(`The vmwarefusion driver is deprecated and support for it will be removed in a future release.
-			Please consider switching to the new vmware unified driver, which is intended to replace the vmwarefusion driver.
-			See https://minikube.sigs.k8s.io/docs/reference/drivers/vmware/ for more information.
-			To disable this message, run [minikube config set ShowDriverDeprecationNotification false]`)
-	}
 	showHostInfo(*cfg)
 	def := registry.Driver(cfg.Driver)
 	if def.Empty() {

--- a/pkg/minikube/registry/drvs/vmwarefusion/vmwarefusion.go
+++ b/pkg/minikube/registry/drvs/vmwarefusion/vmwarefusion.go
@@ -16,52 +16,30 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// vmwarefusion contains a shell of the deprecated vmware vdriver
 package vmwarefusion
 
 import (
 	"fmt"
-	"os/exec"
 
-	"github.com/docker/machine/drivers/vmwarefusion"
-	"github.com/docker/machine/libmachine/drivers"
-	"github.com/pkg/errors"
-
-	"k8s.io/minikube/pkg/minikube/config"
-	"k8s.io/minikube/pkg/minikube/download"
 	"k8s.io/minikube/pkg/minikube/driver"
-	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/minikube/registry"
 )
 
 func init() {
 	if err := registry.Register(registry.DriverDef{
 		Name:     driver.VMwareFusion,
-		Config:   configure,
 		Status:   status,
-		Init:     func() drivers.Driver { return vmwarefusion.NewDriver("", "") },
-		Priority: registry.Deprecated,
+		Priority: registry.Obsolete,
 	}); err != nil {
 		panic(fmt.Sprintf("register: %v", err))
 	}
 }
 
-func configure(cfg config.ClusterConfig, n config.Node) (interface{}, error) {
-	d := vmwarefusion.NewDriver(driver.MachineName(cfg, n), localpath.MiniPath()).(*vmwarefusion.Driver)
-	d.Boot2DockerURL = download.LocalISOResource(cfg.MinikubeISO)
-	d.Memory = cfg.Memory
-	d.CPU = cfg.CPUs
-	d.DiskSize = cfg.DiskSize
-
-	// TODO(philips): push these defaults upstream to fixup this driver
-	d.SSHPort = 22
-	d.ISO = d.ResolveStorePath("boot2docker.iso")
-	return d, nil
-}
-
 func status() registry.State {
-	_, err := exec.LookPath("vmrun")
-	if err != nil {
-		return registry.State{Error: errors.Wrap(err, "vmrun path check"), Fix: "Install VMWare Fusion", Doc: "https://minikube.sigs.k8s.io/docs/reference/drivers/vmwarefusion/"}
+	return registry.State{
+		Error: fmt.Errorf("The 'vmwarefusion' driver is no longer available"),
+		Fix:   "Switch to the newer 'vmware' driver by using '--driver=vmware'. This may require first deleting your existing cluster",
+		Doc:   "https://minikube.sigs.k8s.io/docs/drivers/vmware/",
 	}
-	return registry.State{Installed: true, Healthy: true}
 }

--- a/pkg/minikube/registry/registry.go
+++ b/pkg/minikube/registry/registry.go
@@ -31,6 +31,8 @@ type Priority int
 const (
 	// Unknown is when there is no status check available
 	Unknown Priority = iota
+	// Obsolete is when a driver has been removed
+	Obsolete
 	// Unhealthy is when a driver does not pass health checks
 	Unhealthy
 	// Experimental is when a driver is not officially supported because it's still experimental


### PR DESCRIPTION
The vmwarefusion driver has been broken for 6+ months.  Fixes #8374

With this PR, this is the behavior when `--driver=vmwarefusion` is provided:

```
😄  minikube v1.15.1 on Darwin 10.15.7
✨  Using the vmwarefusion driver based on user configuration

🤷  Exiting due to PROVIDER_VMWAREFUSION_OBSOLETE: The 'vmwarefusion' driver is no longer available
💡  Suggestion: Switch to the newer 'vmware' driver by using '--driver=vmware'. This may require first deleting your existing cluster
📘  Documentation: https://minikube.sigs.k8s.io/docs/drivers/vmware/
```
