### PR TITLE
release notes: fix whitespace before contributors list

### DIFF
--- a/hack/release_notes.sh
+++ b/hack/release_notes.sh
@@ -39,5 +39,6 @@ recent=$(git describe --abbrev=0)
 
 "${DIR}/release-notes" kubernetes minikube --since $recent
 
-echo "Thank you to our contributors for this release! "
+echo "Thank you to our contributors for this release!"
+echo ""
 git log "$recent".. --format="%aN" --reverse | sort | uniq | awk '{printf "- %s\n", $0 }'


### PR DESCRIPTION
Instead of a space, markdown should have a newline before a list.

This allows generated release notes to pass `mdlint`.