### PR TITLE
Adding warning for docker windows tunnel

### DIFF
--- a/pkg/minikube/tunnel/kic/ssh_conn.go
+++ b/pkg/minikube/tunnel/kic/ssh_conn.go
@@ -79,6 +79,11 @@ func createSSHConn(name, sshPort, sshKey string, svc *v1.Service) *sshConn {
 		command = "sudo"
 		sshArgs = append([]string{"ssh"}, sshArgs...)
 	}
+
+	if askForSudo && runtime.GOOS == "windows" {
+		out.Step(style.Warning, "Access to ports <1024 may not work with some SSH clients. Kindly refer to the docs over here - https://minikube.sigs.k8s.io/docs/handbook/accessing/#access-to-ports-1024-on-windows-requires-root-permission")
+	}
+
 	cmd := exec.Command(command, sshArgs...)
 
 	return &sshConn{

--- a/pkg/minikube/tunnel/kic/ssh_conn.go
+++ b/pkg/minikube/tunnel/kic/ssh_conn.go
@@ -81,7 +81,7 @@ func createSSHConn(name, sshPort, sshKey string, svc *v1.Service) *sshConn {
 	}
 
 	if askForSudo && runtime.GOOS == "windows" {
-		out.Step(style.Warning, "Access to ports <1024 may not work with some SSH clients. Kindly refer to the docs over here - https://minikube.sigs.k8s.io/docs/handbook/accessing/#access-to-ports-1024-on-windows-requires-root-permission")
+		out.WarningT("Access to ports below 1024 may fail on Windows with OpenSSH clients older than v8.1. For more information, see: https://minikube.sigs.k8s.io/docs/handbook/accessing/#access-to-ports-1024-on-windows-requires-root-permission")
 	}
 
 	cmd := exec.Command(command, sshArgs...)

--- a/site/content/en/docs/handbook/accessing.md
+++ b/site/content/en/docs/handbook/accessing.md
@@ -154,7 +154,7 @@ Adding a route requires root privileges for the user, and thus there are differe
 ### Access to ports <1024 on Windows requires root permission
 If you are using Docker driver on Windows, there is a chance that you have an old version of SSH client you might get an error like - `Privileged ports can only be forwarded by root.` or you might not be able to access the service even after `minikube tunnel` if the access port is less than 1024 but for ports greater than 1024 works fine.
 
-In order to resolve this, ensure that you are running the latest version of SSH client. You can install the latest version of the SSH client on Windows by running the following in a Command Prompt with an Administrator Privileges
+In order to resolve this, ensure that you are running the latest version of SSH client. You can install the latest version of the SSH client on Windows by running the following in a Command Prompt with an Administrator Privileges (Requires [chocolatey package manager](https://chocolatey.org/install))
 ```
 choco install openssh
 ```

--- a/site/content/en/docs/handbook/accessing.md
+++ b/site/content/en/docs/handbook/accessing.md
@@ -149,3 +149,13 @@ NOTE: `--cleanup` flag's default value is `true`.
 Adding a route requires root privileges for the user, and thus there are differences in how to run `minikube tunnel` depending on the OS. If you want to avoid entering the root password, consider setting NOPASSWD for "ip" and "route" commands:
 
 <https://superuser.com/questions/1328452/sudoers-nopasswd-for-single-executable-but-allowing-others>
+
+
+### Access to ports <1024 on Windows requires root permission
+If you are using Docker driver on Windows, there is a chance that you have an old version of SSH client you might get an error like - `Privileged ports can only be forwarded by root.` or you might not be able to access the service even after `minikube tunnel` if the access port is less than 1024 but for ports greater than 1024 works fine.
+
+In order to resolve this, ensure that you are running the latest version of SSH client. You can install the latest version of the SSH client on Windows by running the following in a Command Prompt with an Administrator Privileges
+```
+choco install openssh
+```
+The latest version (`OpenSSH_for_Windows_7.7p1, LibreSSL 2.6.5`) which is available on Windows 10 by default doesn't work. You can track the issue with this over here - https://github.com/PowerShell/Win32-OpenSSH/issues/1693


### PR DESCRIPTION
Adds a warning for users using minikube with Docker on Windows to upgrade to latest version of SSH.