### PR TITLE
Removed parallel running from test func to prevent ctx timeout

### DIFF
--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -102,9 +102,6 @@ func TestFunctional(t *testing.T) {
 		}
 	})
 
-	// Now that we are out of the woods, lets go.
-	MaybeParallel(t)
-
 	// Parallelized tests
 	t.Run("parallel", func(t *testing.T) {
 		tests := []struct {


### PR DESCRIPTION
Should fix #9905 

Issue is that context timeout was started, but tests were marked to run in parallel with other tests, so if unlucky, tests would run at the end after ctx had already timed out, hence the tests intermittently failing.