### PR TITLE
fix ip node retrieve for none driver

### DIFF
--- a/pkg/minikube/node/node.go
+++ b/pkg/minikube/node/node.go
@@ -115,6 +115,10 @@ func Delete(cc config.ClusterConfig, name string) (*config.Node, error) {
 
 // Retrieve finds the node by name in the given cluster
 func Retrieve(cc config.ClusterConfig, name string) (*config.Node, int, error) {
+	if driver.BareMetal(cc.Driver) {
+		name = "m01"
+	}
+
 	for i, n := range cc.Nodes {
 		if n.Name == name {
 			return &n, i, nil


### PR DESCRIPTION
We hardcode a node name for the none driver, which broke minikube ip when we added the `node.Retrieve` call to it.