### PR TITLE
site: fix display method for tabs if jQuery fails to load

### DIFF
--- a/site/static/css/tabs.css
+++ b/site/static/css/tabs.css
@@ -77,3 +77,8 @@ div.code-tabs h2 {
 div.code-tabs h3 {
     font-size: 1.1rem !important;
 }
+div.code-tabs h3.backup-tab-title {
+    font-size: 1.7rem !important;
+    font-weight: 600;
+    margin-top: 1.3rem;
+}

--- a/site/static/js/tabs.js
+++ b/site/static/js/tabs.js
@@ -1,5 +1,6 @@
 /* Tabs JS implementation. Borrowed from Skaffold */
 function initTabs() {
+  try{
     $('.tab-content').find('.tab-pane').each(function(idx, item) {
       var navTabs = $(this).closest('.code-tabs').find('.nav-tabs'),
           title = $(this).attr('title'),
@@ -27,7 +28,17 @@ function initTabs() {
       tab.addClass('active');
       tabPane.addClass('active');
     });
+  } catch(e) {
+    const elements = document.getElementsByClassName("tab-pane");
+    for (let element of elements) {
+      element.style.display = "block";
+      const title = document.createElement("h3");
+      title.innerText = element.title;
+      title.classList.add("backup-tab-title");
+      element.prepend(title);
+    }
   }
+}
 
 const getTabSelector = currElement => {
     let osSelector = '.'+getUserOS();


### PR DESCRIPTION
Fixes #9956 & #9835 

If jQuery fails to load, displays tabbed content in an alternative method.

**Before:**
<img width="1196" alt="Screen Shot 2020-12-17 at 4 39 52 PM" src="https://user-images.githubusercontent.com/44844360/102556599-84a2f700-4086-11eb-942a-51a6c473ecda.png">

**After:**
<img width="1196" alt="Screen Shot 2020-12-17 at 4 29 03 PM" src="https://user-images.githubusercontent.com/44844360/102556613-8bca0500-4086-11eb-858c-6e19fa9221c3.png">

