### PR TITLE
Fix profile list when there are multi node clusters 

### DIFF
--- a/pkg/minikube/config/profile.go
+++ b/pkg/minikube/config/profile.go
@@ -207,8 +207,9 @@ func ListProfiles(miniHome ...string) (validPs []*Profile, inValidPs []*Profile,
 	if err == nil {
 		pDirs = append(pDirs, cs...)
 	}
-	pDirs = removeDupes(pDirs)
-	for _, n := range pDirs {
+
+	nodeNames := map[string]bool{}
+	for _, n := range removeDupes(pDirs) {
 		p, err := LoadProfile(n, miniHome...)
 		if err != nil {
 			inValidPs = append(inValidPs, p)
@@ -219,7 +220,13 @@ func ListProfiles(miniHome ...string) (validPs []*Profile, inValidPs []*Profile,
 			continue
 		}
 		validPs = append(validPs, p)
+
+		for _, child := range p.Config.Nodes {
+			nodeNames[MachineName(*p.Config, child)] = true
+		}
 	}
+
+	inValidPs = removeChildNodes(inValidPs, nodeNames)
 	return validPs, inValidPs, nil
 }
 
@@ -241,6 +248,18 @@ func removeDupes(profiles []string) []string {
 	}
 	// Return the new slice.
 	return result
+}
+
+// removeChildNodes remove invalid profiles which have a same name with any sub-node's machine name
+// it will return nil if invalid profiles are not exists.
+func removeChildNodes(inValidPs []*Profile, nodeNames map[string]bool) (ps []*Profile) {
+	for _, p := range inValidPs {
+		if _, ok := nodeNames[p.Name]; !ok {
+			ps = append(ps, p)
+		}
+	}
+
+	return ps
 }
 
 // LoadProfile loads type Profile based on its name

--- a/test/integration/multinode_test.go
+++ b/test/integration/multinode_test.go
@@ -20,10 +20,13 @@ package integration
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os/exec"
 	"strings"
 	"testing"
+
+	"k8s.io/minikube/pkg/minikube/config"
 )
 
 func TestMultiNode(t *testing.T) {
@@ -43,6 +46,7 @@ func TestMultiNode(t *testing.T) {
 		}{
 			{"FreshStart2Nodes", validateMultiNodeStart},
 			{"AddNode", validateAddNodeToMultiNode},
+			{"ProfileList", validateProfileListWithMultiNode},
 			{"StopNode", validateStopRunningNode},
 			{"StartAfterStop", validateStartNodeAfterStop},
 			{"DeleteNode", validateDeleteNodeFromMultiNode},
@@ -107,6 +111,44 @@ func validateAddNodeToMultiNode(ctx context.Context, t *testing.T, profile strin
 	if strings.Count(rr.Stdout.String(), "kubelet: Running") != 3 {
 		t.Errorf("status says all kubelets are not running: args %q: %v", rr.Command(), rr.Stdout.String())
 	}
+}
+
+func validateProfileListWithMultiNode(ctx context.Context, t *testing.T, profile string) {
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), "profile", "list", "--output", "json"))
+	if err != nil {
+		t.Errorf("failed to list profiles with json format. args %q: %v", rr.Command(), err)
+	}
+
+	var jsonObject map[string][]config.Profile
+	err = json.Unmarshal(rr.Stdout.Bytes(), &jsonObject)
+	if err != nil {
+		t.Errorf("failed to decode json from profile list: args %q: %v", rr.Command(), err)
+	}
+
+	validProfiles := jsonObject["valid"]
+	var profileObject *config.Profile
+	for _, obj := range validProfiles {
+		if obj.Name == profile {
+			profileObject = &obj
+			break
+		}
+	}
+
+	if profileObject == nil {
+		t.Errorf("expected the json of 'profile list' to include %q but got *%q*. args: %q", profile, rr.Stdout.String(), rr.Command())
+	} else if expected, numNodes := 3, len(profileObject.Config.Nodes); expected != numNodes {
+		t.Errorf("expected profile %q in json of 'profile list' include %d nodes but have %d nodes. got *%q*. args: %q", profile, expected, numNodes, rr.Stdout.String(), rr.Command())
+	}
+
+	if invalidPs, ok := jsonObject["invalid"]; ok {
+		for _, ps := range invalidPs {
+			if strings.Contains(ps.Name, profile) {
+				t.Errorf("expected the json of 'profile list' to not include profile or node in invalid profile but got *%q*. args: %q", rr.Stdout.String(), rr.Command())
+			}
+		}
+
+	}
+
 }
 
 func validateStopRunningNode(ctx context.Context, t *testing.T, profile string) {


### PR DESCRIPTION
Fix problem which ListProfiles return sub-nodes in Mult-Node clusters as
a part of inValidPs.

fixes #9772
 
before
```
❯ minikube profile list
|----------|-----------|---------|--------------|------|---------|---------|-------|
| Profile  | VM Driver | Runtime |      IP      | Port | Version | Status  | Nodes |
|----------|-----------|---------|--------------|------|---------|---------|-------|
| minikube | docker    | docker  | 192.168.49.2 | 8443 | v1.20.0 | Running |     2 |
|----------|-----------|---------|--------------|------|---------|---------|-------|
❗  Found 1 invalid profile(s) !
	 minikube-m02
💡  You can delete them using the following command(s):
	 $ minikube delete -p minikube-m02
```
after
```
❯ minikube profile list
|----------|-----------|---------|--------------|------|---------|---------|-------|
| Profile  | VM Driver | Runtime |      IP      | Port | Version | Status  | Nodes |
|----------|-----------|---------|--------------|------|---------|---------|-------|
| minikube | docker    | docker  | 192.168.49.2 | 8443 | v1.20.0 | Running |     2 |
|----------|-----------|---------|--------------|------|---------|---------|-------|
❗  Found 0 invalid profile(s) !
💡  You can delete them using the following command(s):
```
