### PR TITLE
Improve documentation for minikube installation via brew using cask

### DIFF
--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -84,7 +84,7 @@ brew install minikube
 If `which minikube` fails after installation via brew, you may have to remove the minikube cask and link the binary:
 
 ```shell
-brew cask remove minikube
+brew uninstall --cask minikube
 brew link minikube
 ```
 


### PR DESCRIPTION
continue to #8196

when I install minikube using brew, i found deprecated command `brew cask`.

```bash
Warning: Calling brew cask uninstall is deprecated! Use brew uninstall [--cask] instead.
```

- brew cask depreacted at 2.5.0 : https://brew.sh/2020/09/08/homebrew-2.5.0/

