### PR TITLE
The kubeadm bootstrapper now requires 1700M mem

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -94,8 +94,8 @@ const (
 	interactive             = "interactive"
 	waitTimeout             = "wait-timeout"
 	nativeSSH               = "native-ssh"
-	minUsableMem            = 953  // 1GB In MiB: Kubernetes will not start with less
-	minRecommendedMem       = 1907 // 2GB In MiB: Warn at no lower than existing configurations
+	minUsableMem            = 1700 // Kubernetes (kubeadm) will not start with less
+	minRecommendedMem       = 1900 // Warn at no lower than existing configurations
 	minimumCPUS             = 2
 	minimumDiskSize         = 2000
 	autoUpdate              = "auto-update-drivers"

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -194,6 +194,11 @@ func (k *Bootstrapper) init(cfg config.ClusterConfig) error {
 		"Port-10250", // For "none" users who already have a kubelet online
 		"Swap",       // For "none" users who have swap configured
 	}
+	if version.GE(semver.MustParse("1.20.0")) {
+		ignore = append(ignore,
+			"Mem", // For "none" users who have too little memory
+		)
+	}
 	ignore = append(ignore, bsutil.SkipAdditionalPreflights[r.Name()]...)
 
 	skipSystemVerification := false


### PR DESCRIPTION
The node requirement is 2 vCPU and 2.0 GiB RAM

You can use --force to bypass the requirement

Closes #10016