### PR TITLE
Replace fixed time wait with wait function for docker-env cmd

### DIFF
--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -201,8 +201,10 @@ func mustRestartDockerd(name string, runner command.Runner) {
 		// verifying apisever using kverify would add code complexity for a rare case.
 		klog.Warningf("waiting to ensure apisever container is up...")
 		startTime := time.Now()
-		//time.Sleep(time.Second * 5)
-		WaitForAPIServerProcess(runner, startTime, time.Second*5)
+
+		if err = WaitForAPIServerProcess(runner, startTime, time.Second*5); err != nil {
+			exit.Message(reason.RuntimeRestart, `The api server within '{{.name}}' is not up`, out.V{"name": name})
+		}
 	}
 }
 

--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -201,13 +201,13 @@ func mustRestartDockerd(name string, runner command.Runner) {
 		// verifying apisever using kverify would add code complexity for a rare case.
 		klog.Warningf("waiting to ensure apisever container is up...")
 		startTime := time.Now()
-		if err = WaitForAPIServerProcess(runner, startTime, time.Second*30); err != nil {
-			exit.Message(reason.RuntimeRestart, `The api server within '{{.name}}' is not up`, out.V{"name": name})
+		if err = waitForAPIServerProcess(runner, startTime, time.Second*30); err != nil {
+			klog.Warningf("apiserver container isn't up, error: %v", err)
 		}
 	}
 }
 
-func WaitForAPIServerProcess(cr command.Runner, start time.Time, timeout time.Duration) error {
+func waitForAPIServerProcess(cr command.Runner, start time.Time, timeout time.Duration) error {
 	klog.Infof("waiting for apiserver process to appear ...")
 	err := apiWait.PollImmediate(time.Millisecond*500, timeout, func() (bool, error) {
 		if time.Since(start) > timeout {

--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -218,7 +218,7 @@ func WaitForAPIServerProcess(cr command.Runner, start time.Time, timeout time.Du
 			time.Sleep(kconst.APICallRetryInterval * 5)
 		}
 
-		if _, ierr := kverify.ApiServerPID(cr); ierr != nil {
+		if _, ierr := kverify.APIServerPID(cr); ierr != nil {
 			return false, nil
 		}
 

--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -201,8 +201,7 @@ func mustRestartDockerd(name string, runner command.Runner) {
 		// verifying apisever using kverify would add code complexity for a rare case.
 		klog.Warningf("waiting to ensure apisever container is up...")
 		startTime := time.Now()
-
-		if err = WaitForAPIServerProcess(runner, startTime, time.Second*5); err != nil {
+		if err = WaitForAPIServerProcess(runner, startTime, time.Second*30); err != nil {
 			exit.Message(reason.RuntimeRestart, `The api server within '{{.name}}' is not up`, out.V{"name": name})
 		}
 	}

--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -29,10 +29,14 @@ import (
 	"strings"
 	"time"
 
+	apiWait "k8s.io/apimachinery/pkg/util/wait"
+
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 
+	kconst "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
+	"k8s.io/minikube/pkg/minikube/bootstrapper/bsutil/kverify"
 	"k8s.io/minikube/pkg/minikube/command"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/driver"
@@ -44,6 +48,8 @@ import (
 	"k8s.io/minikube/pkg/minikube/shell"
 	"k8s.io/minikube/pkg/minikube/sysinit"
 )
+
+const minLogCheckTime = 60 * time.Second
 
 var dockerEnvTCPTmpl = fmt.Sprintf(
 	"{{ .Prefix }}%s{{ .Delimiter }}{{ .DockerTLSVerify }}{{ .Suffix }}"+
@@ -193,9 +199,36 @@ func mustRestartDockerd(name string, runner command.Runner) {
 		// if we get to the point that we have to restart docker (instead of reload)
 		// will need to wait for apisever container to come up, this usually takes 5 seconds
 		// verifying apisever using kverify would add code complexity for a rare case.
-		klog.Warningf("waiting 5 seconds to ensure apisever container is up...")
-		time.Sleep(time.Second * 5)
+		klog.Warningf("waiting to ensure apisever container is up...")
+		startTime := time.Now()
+		//time.Sleep(time.Second * 5)
+		WaitForAPIServerProcess(runner, startTime, time.Second*5)
 	}
+}
+
+func WaitForAPIServerProcess(cr command.Runner, start time.Time, timeout time.Duration) error {
+	klog.Infof("waiting for apiserver process to appear ...")
+	err := apiWait.PollImmediate(time.Millisecond*500, timeout, func() (bool, error) {
+		if time.Since(start) > timeout {
+			return false, fmt.Errorf("cluster wait timed out during process check")
+		}
+
+		if time.Since(start) > minLogCheckTime {
+			klog.Infof("waiting for apiserver process to appear ...")
+			time.Sleep(kconst.APICallRetryInterval * 5)
+		}
+
+		if _, ierr := kverify.ApiServerPID(cr); ierr != nil {
+			return false, nil
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("apiserver process never appeared")
+	}
+	klog.Infof("duration metric: took %s to wait for apiserver process to appear ...", time.Since(start))
+	return nil
 }
 
 // dockerEnvCmd represents the docker-env command

--- a/pkg/minikube/bootstrapper/bsutil/kverify/api_server.go
+++ b/pkg/minikube/bootstrapper/bsutil/kverify/api_server.go
@@ -56,7 +56,7 @@ func WaitForAPIServerProcess(r cruntime.Manager, bs bootstrapper.Bootstrapper, c
 			time.Sleep(kconst.APICallRetryInterval * 5)
 		}
 
-		if _, ierr := ApiServerPID(cr); ierr != nil {
+		if _, ierr := APIServerPID(cr); ierr != nil {
 			return false, nil
 		}
 
@@ -69,8 +69,8 @@ func WaitForAPIServerProcess(r cruntime.Manager, bs bootstrapper.Bootstrapper, c
 	return nil
 }
 
-// ApiServerPID returns our best guess to the apiserver pid
-func ApiServerPID(cr command.Runner) (int, error) {
+// APIServerPID returns our best guess to the apiserver pid
+func APIServerPID(cr command.Runner) (int, error) {
 	rr, err := cr.RunCmd(exec.Command("sudo", "pgrep", "-xnf", "kube-apiserver.*minikube.*"))
 	if err != nil {
 		return 0, err
@@ -145,7 +145,7 @@ func APIServerVersionMatch(client *kubernetes.Clientset, expected string) error 
 func APIServerStatus(cr command.Runner, hostname string, port int) (state.State, error) {
 	klog.Infof("Checking apiserver status ...")
 
-	pid, err := ApiServerPID(cr)
+	pid, err := APIServerPID(cr)
 	if err != nil {
 		klog.Warningf("stopped: unable to get apiserver pid: %v", err)
 		return state.Stopped, nil

--- a/pkg/minikube/bootstrapper/bsutil/kverify/api_server.go
+++ b/pkg/minikube/bootstrapper/bsutil/kverify/api_server.go
@@ -56,7 +56,7 @@ func WaitForAPIServerProcess(r cruntime.Manager, bs bootstrapper.Bootstrapper, c
 			time.Sleep(kconst.APICallRetryInterval * 5)
 		}
 
-		if _, ierr := apiServerPID(cr); ierr != nil {
+		if _, ierr := ApiServerPID(cr); ierr != nil {
 			return false, nil
 		}
 
@@ -69,8 +69,8 @@ func WaitForAPIServerProcess(r cruntime.Manager, bs bootstrapper.Bootstrapper, c
 	return nil
 }
 
-// apiServerPID returns our best guess to the apiserver pid
-func apiServerPID(cr command.Runner) (int, error) {
+// ApiServerPID returns our best guess to the apiserver pid
+func ApiServerPID(cr command.Runner) (int, error) {
 	rr, err := cr.RunCmd(exec.Command("sudo", "pgrep", "-xnf", "kube-apiserver.*minikube.*"))
 	if err != nil {
 		return 0, err
@@ -145,7 +145,7 @@ func APIServerVersionMatch(client *kubernetes.Clientset, expected string) error 
 func APIServerStatus(cr command.Runner, hostname string, port int) (state.State, error) {
 	klog.Infof("Checking apiserver status ...")
 
-	pid, err := apiServerPID(cr)
+	pid, err := ApiServerPID(cr)
 	if err != nil {
 		klog.Warningf("stopped: unable to get apiserver pid: %v", err)
 		return state.Stopped, nil


### PR DESCRIPTION
fixes #9938

In docker-env, instead of waiting for 5s for api server to be up, wait for api server pid to show up.

Start minikube:
zyanshu@zyanshukvm:~/minikube$ ./out/minikube start -p p1
😄 [p1] minikube v1.16.0-beta.0 on Debian rodete
▪ MINIKUBE_ACTIVE_DOCKERD=p1
✨ Automatically selected the docker driver
👍 Starting control plane node p1 in cluster p1
🚜 Pulling base image ...
💾 Downloading Kubernetes v1.20.0 preload ...
> preloaded-images-k8s-v7-v1....: 490.47 MiB / 490.47 MiB 100.00% 36.11 Mi
🔥 Creating docker container (CPUs=2, Memory=26100MB) ...
🐳 Preparing Kubernetes v1.20.0 on Docker 20.10.0 ...
🔎 Verifying Kubernetes components...
🌟 Enabled addons: storage-provisioner, default-storageclass
🏄 Done! kubectl is now configured to use "p1" cluster and "default" namespace by default

Run docker-env cmd:
zyanshu@zyanshukvm:~/minikube$ ./out/minikube docker-env -p p1 --alsologtostderr
I1216 09:02:56.000487 2711966 out.go:221] Setting OutFile to fd 1 ...
I1216 09:02:56.000826 2711966 out.go:273] isatty.IsTerminal(1) = true
I1216 09:02:56.000848 2711966 out.go:234] Setting ErrFile to fd 2...
I1216 09:02:56.000898 2711966 out.go:273] isatty.IsTerminal(2) = true
I1216 09:02:56.001040 2711966 root.go:279] Updating PATH: /usr/local/google/home/zyanshu/.minikube/bin
I1216 09:02:56.001095 2711966 oci.go:526] shell is pointing to dockerd inside minikube. will unset to use host
I1216 09:02:56.001425 2711966 mustload.go:66] Loading cluster: p1
I1216 09:02:56.002362 2711966 cli_runner.go:111] Run: docker container inspect p1 --format={{.State.Status}}
I1216 09:02:56.063844 2711966 host.go:66] Checking if "p1" exists ...
W1216 09:02:56.064205 2711966 docker-env.go:193] dockerd is not active will try to reload it...
I1216 09:02:56.064821 2711966 ssh_runner.go:148] Run: systemctl --version
I1216 09:02:56.064922 2711966 cli_runner.go:111] Run: docker container inspect -f "'{{(index (index .NetworkSettings.Ports "22/tcp") 0).HostPort}}'" p1
I1216 09:02:56.123186 2711966 sshutil.go:45] new ssh client: &{IP:127.0.0.1 Port:33563 SSHKeyPath:/usr/local/google/home/zyanshu/.minikube/machines/p1/id_rsa Username:docker}
I1216 09:02:56.225523 2711966 ssh_runner.go:148] Run: sudo systemctl daemon-reload
I1216 09:02:56.399247 2711966 ssh_runner.go:148] Run: sudo systemctl reload docker
W1216 09:02:56.419070 2711966 docker-env.go:195] will try to restart dockerd because reload failed: sudo systemctl reload docker: Process exited with status 1
stdout:

stderr:
Job for docker.service failed.
See "systemctl status docker.service" and "journalctl -xe" for details.
I1216 09:02:56.419193 2711966 ssh_runner.go:148] Run: sudo systemctl daemon-reload
I1216 09:02:56.565812 2711966 ssh_runner.go:148] Run: sudo systemctl restart docker
I1216 09:02:57.949276 2711966 ssh_runner.go:188] Completed: sudo systemctl restart docker: (1.383387846s)
W1216 09:02:57.949350 2711966 docker-env.go:202] waiting to ensure apisever container is up...
I1216 09:02:57.949366 2711966 docker-env.go:209] waiting for apiserver process to appear ...
I1216 09:02:57.949446 2711966 ssh_runner.go:148] Run: sudo pgrep -xnf kube-apiserver.minikube.
I1216 09:02:58.467167 2711966 ssh_runner.go:148] Run: sudo pgrep -xnf kube-apiserver.minikube.
I1216 09:02:58.967199 2711966 ssh_runner.go:148] Run: sudo pgrep -xnf kube-apiserver.minikube.
I1216 09:02:59.467186 2711966 ssh_runner.go:148] Run: sudo pgrep -xnf kube-apiserver.minikube.
I1216 09:02:59.967177 2711966 ssh_runner.go:148] Run: sudo pgrep -xnf kube-apiserver.minikube.
I1216 09:03:00.467170 2711966 ssh_runner.go:148] Run: sudo pgrep -xnf kube-apiserver.minikube.
I1216 09:03:00.967182 2711966 ssh_runner.go:148] Run: sudo pgrep -xnf kube-apiserver.minikube.
I1216 09:03:01.039794 2711966 docker-env.go:229] duration metric: took 3.090415908s to wait for apiserver process to appear ...
I1216 09:03:01.039925 2711966 cli_runner.go:111] Run: docker container inspect -f "'{{(index (index .NetworkSettings.Ports "22/tcp") 0).HostPort}}'" p1
I1216 09:03:01.097569 2711966 docker-env.go:459] Testing Docker connectivity with: /usr/bin/docker version --format={{.Server}}
export DOCKER_TLS_VERIFY="1"
export DOCKER_HOST="tcp://192.168.49.2:2376"
export DOCKER_CERT_PATH="/usr/local/google/home/zyanshu/.minikube/certs"
export MINIKUBE_ACTIVE_DOCKERD="p1"

To point your shell to minikube's docker-daemon, run:
eval $(minikube -p p1 docker-env)