### PR TITLE
Fix docker reload issue in docker-env cmd

### DIFF
--- a/pkg/provision/buildroot.go
+++ b/pkg/provision/buildroot.go
@@ -106,7 +106,7 @@ Environment=DOCKER_RAMDISK=yes
 # container runtimes. If left unlimited, it may result in OOM issues with MySQL.
 ExecStart=
 ExecStart=/usr/bin/dockerd -H tcp://0.0.0.0:2376 -H unix:///var/run/docker.sock --default-ulimit=nofile=1048576:1048576 --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}} {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
-ExecReload=/bin/kill -s HUP $MAINPID
+ExecReload=/bin/kill -s HUP \$MAINPID
 
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.

--- a/pkg/provision/ubuntu.go
+++ b/pkg/provision/ubuntu.go
@@ -109,7 +109,7 @@ Environment=DOCKER_RAMDISK=yes
 # container runtimes. If left unlimited, it may result in OOM issues with MySQL.
 ExecStart=
 ExecStart=/usr/bin/dockerd -H tcp://0.0.0.0:2376 -H unix:///var/run/docker.sock --default-ulimit=nofile=1048576:1048576 --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}} {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
-ExecReload=/bin/kill -s HUP $MAINPID
+ExecReload=/bin/kill -s HUP \$MAINPID
 
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.


### PR DESCRIPTION
```
zyanshu@zyanshukvm:~/minikube$ ./out/minikube start -p p1
😄  [p1] minikube v1.16.0 on Debian rodete
✨  Automatically selected the docker driver
👍  Starting control plane node p1 in cluster p1
🔥  Creating docker container (CPUs=2, Memory=26100MB) ...
🐳  Preparing Kubernetes v1.20.0 on Docker 20.10.0 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "p1" cluster and "default" namespace by default
zyanshu@zyanshukvm:~/minikube$ ./out/minikube ssh -p p1
docker@p1:~$ cat /lib/systemd/system/docker.service
[Unit]
Description=Docker Application Container Engine
Documentation=https://docs.docker.com
BindsTo=containerd.service
After=network-online.target firewalld.service containerd.service
Wants=network-online.target
Requires=docker.socket

[Service]
Type=notify
Restart=on-failure
StartLimitBurst=3
StartLimitIntervalSec=60



# This file is a systemd drop-in unit that inherits from the base dockerd configuration.
# The base configuration already specifies an 'ExecStart=...' command. The first directive
# here is to clear out that command inherited from the base configuration. Without this,
# the command from the base configuration and the command specified here are treated as
# a sequence of commands, which is not the desired behavior, nor is it valid -- systemd
# will catch this invalid input and refuse to start the service with an error like:
#  Service has more than one ExecStart= setting, which is only allowed for Type=oneshot services.

# NOTE: default-ulimit=nofile is set to an arbitrary number for consistency with other
# container runtimes. If left unlimited, it may result in OOM issues with MySQL.
ExecStart=
ExecStart=/usr/bin/dockerd -H tcp://0.0.0.0:2376 -H unix:///var/run/docker.sock --default-ulimit=nofile=1048576:1048576 --tlsverify --tlscacert /etc/docker/ca.pem --tlscert /etc/docker/server.pem
--tlskey /etc/docker/server-key.pem --label provider=docker --insecure-registry 10.96.0.0/12
ExecReload=/bin/kill -s HUP $MAINPID

# Having non-zero Limit*s causes performance problems due to accounting overhead
# in the kernel. We recommend using cgroups to do container-local accounting.
.....

docker@p1:~$ sudo systemctl reload docker
docker@p1:~$ docker ps
CONTAINER ID   IMAGE                  COMMAND                  CREATED              STATUS              PORTS     NAMES
05d0d07135a0   85069258b98a           "/storage-provisioner"   49 seconds ago       Up 48 seconds                 k8s_storage-provisioner_storage-provisioner_kube-system_1f5f1824-a7f5-444e-bab3-a3
b9d0635456_1
9507d432e824   bfe3a36ebd25           "/coredns -conf /etc…"   About a minute ago   Up About a minute             k8s_coredns_coredns-74ff55c5b-hmbn7_kube-system_945b813a-ca8b-4811-80fa-7891f209cd
f0_0
744a252e879f   10cc881966cf           "/usr/local/bin/kube…"   About a minute ago   Up About a minute             k8s_kube-proxy_kube-proxy-46grz_kube-system_8efca21b-2e9b-4828-b523-e28621a048df_0
fb7f52703b06   k8s.gcr.io/pause:3.2   "/pause"                 About a minute ago   Up About a minute             k8s_POD_coredns-74ff55c5b-hmbn7_kube-system_945b813a-ca8b-4811-80fa-7891f209cdf0_0
a9af4d429ffc   k8s.gcr.io/pause:3.2   "/pause"                 About a minute ago   Up About a minute             k8s_POD_kube-proxy-46grz_kube-system_8efca21b-2e9b-4828-b523-e28621a048df_0
45cbbef7b365   k8s.gcr.io/pause:3.2   "/pause"                 About a minute ago   Up About a minute             k8s_POD_storage-provisioner_kube-system_1f5f1824-a7f5-444e-bab3-a3b9d0635456_0
9e65fc1a0373   3138b6e3d471           "kube-scheduler --au…"   About a minute ago   Up About a minute             k8s_kube-scheduler_kube-scheduler-p1_kube-system_3478da2c440ba32fb6c087b3f3b99813_
0
4d95b42fe8a0   ca9843d3b545           "kube-apiserver --ad…"   About a minute ago   Up About a minute             k8s_kube-apiserver_kube-apiserver-p1_kube-system_524cecac593a7ad14f29307cb61f56b8_
0
5499344bc5b2   b9fa1895dcaa           "kube-controller-man…"   About a minute ago   Up About a minute             k8s_kube-controller-manager_kube-controller-manager-p1_kube-system_a3e7be694ef7cf9
52503c5d331abc0ac_0
9c112272eac0   0369cf4303ff           "etcd --advertise-cl…"   About a minute ago   Up About a minute             k8s_etcd_etcd-p1_kube-system_b428d92493177474d4f20b2e4a888f6f_0
559ceb493135   k8s.gcr.io/pause:3.2   "/pause"                 About a minute ago   Up About a minute             k8s_POD_kube-scheduler-p1_kube-system_3478da2c440ba32fb6c087b3f3b99813_0
d0fc3258463f   k8s.gcr.io/pause:3.2   "/pause"                 About a minute ago   Up About a minute             k8s_POD_kube-controller-manager-p1_kube-system_a3e7be694ef7cf952503c5d331abc0ac_0
63ce8571eae2   k8s.gcr.io/pause:3.2   "/pause"                 About a minute ago   Up About a minute             k8s_POD_kube-apiserver-p1_kube-system_524cecac593a7ad14f29307cb61f56b8_0
ad96084bfdd6   k8s.gcr.io/pause:3.2   "/pause"                 About a minute ago   Up About a minute             k8s_POD_etcd-p1_kube-system_b428d92493177474d4f20b2e4a888f6f_0
```