### PR TITLE
Fix typo in the csi-hostpath-driver addon name

### DIFF
--- a/site/content/en/docs/tutorials/volume_snapshots_and_csi.md
+++ b/site/content/en/docs/tutorials/volume_snapshots_and_csi.md
@@ -28,7 +28,7 @@ by default as well.
 Thus, to utilize the volume snapshots functionality, you must:
 
 1\) enable the `volumesnapshots` addon AND\
-2a\) either enable the `csi-hostpth-driver` addon OR\
+2a\) either enable the `csi-hostpath-driver` addon OR\
 2b\) deploy your own CSI driver
 
 You can enable/disable either of the above-mentioned addons using


### PR DESCRIPTION
Hey 👋

A very small PR to fix a typo in the `csi-hostpath-driver` addon name (the `a` was missing).

Happy holidays to all 🎉 🎄 