### PR TITLE
The kubernetes memory requirement is for the total

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -94,8 +94,8 @@ const (
 	interactive             = "interactive"
 	waitTimeout             = "wait-timeout"
 	nativeSSH               = "native-ssh"
-	minUsableMem            = 1700 // Kubernetes (kubeadm) will not start with less
-	minRecommendedMem       = 1900 // Warn at no lower than existing configurations
+	minUsableMem            = 1800 // Kubernetes (kubeadm) will not start with less
+	minRecommendedMem       = 2000 // Warn at no lower than existing configurations
 	minimumCPUS             = 2
 	minimumDiskSize         = 2000
 	autoUpdate              = "auto-update-drivers"


### PR DESCRIPTION
The kernel will reserve some memory for itself, so if you want
1700 MB free you need to allocate 1800 MB for the VM hardware.

The recommendation is still 2048 (or 2000), with an even 2.0 GiB.
So let's increase the old values with +100, for ~60 overhead.

See ~~#10018~~
Closes #10016