### PR TITLE
Kic: make sure NO_PROXY contains api endpoint

### DIFF
--- a/deploy/kicbase/entrypoint
+++ b/deploy/kicbase/entrypoint
@@ -23,9 +23,12 @@ configure_proxy() {
   # ensure all processes receive the proxy settings by default
   # https://www.freedesktop.org/software/systemd/man/systemd-system.conf.html
   mkdir -p /etc/systemd/system.conf.d/
+  if [[ ! -z "${NO_PROXY-}" ]]; then
+    NO_PROXY="${NO_PROXY},control-plane.minikube.internal"
+  fi
   cat <<EOF >/etc/systemd/system.conf.d/proxy-default-environment.conf
 [Manager]
-DefaultEnvironment="HTTP_PROXY=${HTTP_PROXY:-}" "HTTPS_PROXY=${HTTPS_PROXY:-}" "NO_PROXY=${NO_PROXY:-}"
+DefaultEnvironment="HTTP_PROXY=${HTTP_PROXY:-}" "HTTPS_PROXY=${HTTPS_PROXY:-}" "NO_PROXY=${NO_PROXY:-"control-plane.minikube.internal"}"
 EOF
 }
 


### PR DESCRIPTION
Signed-off-by: Ling Samuel <lingsamuelgrace@gmail.com>

We should make sure api endpoint exists in NO_PROXY.

With noProxy in .docker/config.json:
![image](https://user-images.githubusercontent.com/14567045/103326574-eeaa9b80-4a8b-11eb-8606-a9b73ce641bc.png)


without noProxy in .docker/config.json:
![image](https://user-images.githubusercontent.com/14567045/103326458-61674700-4a8b-11eb-8a95-816c9c736e01.png)

