### PR TITLE
Use appropriate ClusterDomain value in kubeadm KubeletConfiguration

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/ktmpl/v1alpha3.go
+++ b/pkg/minikube/bootstrapper/bsutil/ktmpl/v1alpha3.go
@@ -70,7 +70,7 @@ networking:
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 cgroupDriver: {{.CgroupDriver}}
-clusterDomain: "cluster.local"
+clusterDomain: "{{if .DNSDomain}}{{.DNSDomain}}{{else}}cluster.local{{end}}"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
 evictionHard:

--- a/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta1.go
+++ b/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta1.go
@@ -77,7 +77,7 @@ authentication:
   x509:
     clientCAFile: {{.ClientCAFile}}
 cgroupDriver: {{.CgroupDriver}}
-clusterDomain: "cluster.local"
+clusterDomain: "{{if .DNSDomain}}{{.DNSDomain}}{{else}}cluster.local{{end}}"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
 evictionHard:

--- a/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta2.go
+++ b/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta2.go
@@ -80,7 +80,7 @@ authentication:
   x509:
     clientCAFile: {{.ClientCAFile}}
 cgroupDriver: {{.CgroupDriver}}
-clusterDomain: "cluster.local"
+clusterDomain: "{{if .DNSDomain}}{{.DNSDomain}}{{else}}cluster.local{{end}}"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
 evictionHard:

--- a/pkg/minikube/bootstrapper/bsutil/kubeadm_test.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubeadm_test.go
@@ -126,7 +126,7 @@ func recentReleases(n int) ([]string, error) {
 Need a separate test function to test the DNS server IP
 as v1.11 yaml file is very different compared to v1.12+.
 This test case has only 1 thing to test and that is the
-nnetworking/dnsDomain value
+networking/dnsDomain value
 */
 func TestGenerateKubeadmYAMLDNS(t *testing.T) {
 	// test all testdata releases greater than v1.11
@@ -150,7 +150,7 @@ func TestGenerateKubeadmYAMLDNS(t *testing.T) {
 		shouldErr bool
 		cfg       config.ClusterConfig
 	}{
-		{"dns", "docker", false, config.ClusterConfig{Name: "mk", KubernetesConfig: config.KubernetesConfig{DNSDomain: "1.1.1.1"}}},
+		{"dns", "docker", false, config.ClusterConfig{Name: "mk", KubernetesConfig: config.KubernetesConfig{DNSDomain: "minikube.local"}}},
 	}
 	for _, version := range versions {
 		for _, tc := range tests {

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.12/dns.yaml
@@ -35,14 +35,14 @@ schedulerExtraArgs:
   leader-elect: "false"
 kubernetesVersion: v1.12.0
 networking:
-  dnsDomain: 1.1.1.1
+  dnsDomain: minikube.local
   podSubnet: "10.244.0.0/16"
   serviceSubnet: 10.96.0.0/12
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 cgroupDriver: systemd
-clusterDomain: "cluster.local"
+clusterDomain: "minikube.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
 evictionHard:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.13/dns.yaml
@@ -35,14 +35,14 @@ schedulerExtraArgs:
   leader-elect: "false"
 kubernetesVersion: v1.13.0
 networking:
-  dnsDomain: 1.1.1.1
+  dnsDomain: minikube.local
   podSubnet: "10.244.0.0/16"
   serviceSubnet: 10.96.0.0/12
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 cgroupDriver: systemd
-clusterDomain: "cluster.local"
+clusterDomain: "minikube.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
 evictionHard:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/dns.yaml
@@ -42,7 +42,7 @@ etcd:
       listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.14.0
 networking:
-  dnsDomain: 1.1.1.1
+  dnsDomain: minikube.local
   podSubnet: "10.244.0.0/16"
   serviceSubnet: 10.96.0.0/12
 ---
@@ -52,7 +52,7 @@ authentication:
   x509:
     clientCAFile: /var/lib/minikube/certs/ca.crt
 cgroupDriver: systemd
-clusterDomain: "cluster.local"
+clusterDomain: "minikube.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
 evictionHard:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/dns.yaml
@@ -42,7 +42,7 @@ etcd:
       listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.15.0
 networking:
-  dnsDomain: 1.1.1.1
+  dnsDomain: minikube.local
   podSubnet: "10.244.0.0/16"
   serviceSubnet: 10.96.0.0/12
 ---
@@ -52,7 +52,7 @@ authentication:
   x509:
     clientCAFile: /var/lib/minikube/certs/ca.crt
 cgroupDriver: systemd
-clusterDomain: "cluster.local"
+clusterDomain: "minikube.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
 evictionHard:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/dns.yaml
@@ -42,7 +42,7 @@ etcd:
       listen-metrics-urls: http://127.0.0.1:2381,http://1.1.1.1:2381
 kubernetesVersion: v1.16.0
 networking:
-  dnsDomain: 1.1.1.1
+  dnsDomain: minikube.local
   podSubnet: "10.244.0.0/16"
   serviceSubnet: 10.96.0.0/12
 ---
@@ -52,7 +52,7 @@ authentication:
   x509:
     clientCAFile: /var/lib/minikube/certs/ca.crt
 cgroupDriver: systemd
-clusterDomain: "cluster.local"
+clusterDomain: "minikube.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
 evictionHard:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/dns.yaml
@@ -42,7 +42,7 @@ etcd:
       proxy-refresh-interval: "70000"
 kubernetesVersion: v1.17.0
 networking:
-  dnsDomain: 1.1.1.1
+  dnsDomain: minikube.local
   podSubnet: "10.244.0.0/16"
   serviceSubnet: 10.96.0.0/12
 ---
@@ -52,7 +52,7 @@ authentication:
   x509:
     clientCAFile: /var/lib/minikube/certs/ca.crt
 cgroupDriver: systemd
-clusterDomain: "cluster.local"
+clusterDomain: "minikube.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
 evictionHard:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/dns.yaml
@@ -42,7 +42,7 @@ etcd:
       proxy-refresh-interval: "70000"
 kubernetesVersion: v1.18.0
 networking:
-  dnsDomain: 1.1.1.1
+  dnsDomain: minikube.local
   podSubnet: "10.244.0.0/16"
   serviceSubnet: 10.96.0.0/12
 ---
@@ -52,7 +52,7 @@ authentication:
   x509:
     clientCAFile: /var/lib/minikube/certs/ca.crt
 cgroupDriver: systemd
-clusterDomain: "cluster.local"
+clusterDomain: "minikube.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
 evictionHard:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/dns.yaml
@@ -42,7 +42,7 @@ etcd:
       proxy-refresh-interval: "70000"
 kubernetesVersion: v1.19.0
 networking:
-  dnsDomain: 1.1.1.1
+  dnsDomain: minikube.local
   podSubnet: "10.244.0.0/16"
   serviceSubnet: 10.96.0.0/12
 ---
@@ -52,7 +52,7 @@ authentication:
   x509:
     clientCAFile: /var/lib/minikube/certs/ca.crt
 cgroupDriver: systemd
-clusterDomain: "cluster.local"
+clusterDomain: "minikube.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
 evictionHard:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/dns.yaml
@@ -42,7 +42,7 @@ etcd:
       proxy-refresh-interval: "70000"
 kubernetesVersion: v1.20.0
 networking:
-  dnsDomain: 1.1.1.1
+  dnsDomain: minikube.local
   podSubnet: "10.244.0.0/16"
   serviceSubnet: 10.96.0.0/12
 ---
@@ -52,7 +52,7 @@ authentication:
   x509:
     clientCAFile: /var/lib/minikube/certs/ca.crt
 cgroupDriver: systemd
-clusterDomain: "cluster.local"
+clusterDomain: "minikube.local"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100
 evictionHard:

--- a/pkg/minikube/registry/drvs/vmwarefusion/vmwarefusion.go
+++ b/pkg/minikube/registry/drvs/vmwarefusion/vmwarefusion.go
@@ -38,7 +38,7 @@ func init() {
 
 func status() registry.State {
 	return registry.State{
-		Error: fmt.Errorf("The 'vmwarefusion' driver is no longer available"),
+		Error: fmt.Errorf("the 'vmwarefusion' driver is no longer available"),
 		Fix:   "Switch to the newer 'vmware' driver by using '--driver=vmware'. This may require first deleting your existing cluster",
 		Doc:   "https://minikube.sigs.k8s.io/docs/drivers/vmware/",
 	}


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
Fixes #9881 

User provided flag `--dns-domain` is only used in kubeadm network configurations. Kubelet clusterDomian is always set to cluster.local and that results in broken dns resolving for service names like `kube-dns.kube-system`. This PR uses the value of the flag for clusterDomain if provided or else defaults to cluster.local.
According to https://github.com/kubernetes/kubernetes/blob/cea1d4e20b4a7886d8ff65f34c6d4f95efcb4742/pkg/kubelet/apis/config/types.go#L164 ClusterDomain should be same as DNSDomain for the cluster. 

