### PR TITLE
Fix docker inspect network go template for network which doesn't have MTU

### DIFF
--- a/pkg/drivers/kic/oci/network_create.go
+++ b/pkg/drivers/kic/oci/network_create.go
@@ -176,7 +176,7 @@ func dockerNetworkInspect(name string) (netInfo, error) {
 	var vals networkInspect
 	var info = netInfo{name: name}
 
-	cmd := exec.Command(Docker, "network", "inspect", name, "--format", `{"Name": "{{.Name}}","Driver": "{{.Driver}}","Subnet": "{{range .IPAM.Config}}{{.Subnet}}{{end}}","Gateway": "{{range .IPAM.Config}}{{.Gateway}}{{end}}","MTU": {{(index .Options "com.docker.network.driver.mtu")}},{{$first := true}} "ContainerIPs": [{{range $k,$v := .Containers }}{{if $first}}{{$first = false}}{{else}}, {{end}}"{{$v.IPv4Address}}"{{end}}]}`)
+	cmd := exec.Command(Docker, "network", "inspect", name, "--format", `{"Name": "{{.Name}}","Driver": "{{.Driver}}","Subnet": "{{range .IPAM.Config}}{{.Subnet}}{{end}}","Gateway": "{{range .IPAM.Config}}{{.Gateway}}{{end}}","MTU": {{if (index .Options "com.docker.network.driver.mtu")}}{{(index .Options "com.docker.network.driver.mtu")}}{{else}}0{{end}},{{$first := true}} "ContainerIPs": [{{range $k,$v := .Containers }}{{if $first}}{{$first = false}}{{else}}, {{end}}"{{$v.IPv4Address}}"{{end}}]}`)
 	rr, err := runCmd(cmd)
 	if err != nil {
 		logDockerNetworkInspect(Docker, name)

--- a/pkg/drivers/kic/oci/network_create_test.go
+++ b/pkg/drivers/kic/oci/network_create_test.go
@@ -31,7 +31,7 @@ var dockerInspectGetterMock = func(name string) (*RunResult, error) {
 	return response, nil
 }
 
-func TestDockerInspectWithMTU(t *testing.T) {
+func TestDockerInspect(t *testing.T) {
 	var tests = []struct {
 		name                  string
 		dockerInspectResponse string

--- a/pkg/drivers/kic/oci/network_create_test.go
+++ b/pkg/drivers/kic/oci/network_create_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oci
+
+import (
+	"bytes"
+	"net"
+	"testing"
+)
+
+var dockerResponse string
+var dockerInspectGetterMock = func(name string) (*RunResult, error) {
+	var responseInBytes bytes.Buffer
+	responseInBytes.WriteString(dockerResponse)
+	response := &RunResult{Stdout: responseInBytes}
+
+	return response, nil
+}
+
+func TestDockerInspectWithMTU(t *testing.T) {
+	dockerInspectResponseWithMtu := `{"Name": "m2","Driver": "bridge","Subnet": "172.19.0.0/16","Gateway": "172.19.0.1","MTU": 9216, "ContainerIPs": []}`
+
+	// setting up mock funcs
+	dockerResponse = dockerInspectResponseWithMtu
+	dockerInsepctGetter = dockerInspectGetterMock
+
+	netInfo, err := dockerNetworkInspect("m2")
+
+	if err != nil {
+		t.Errorf("Expected not to have error but got %v", err)
+	}
+
+	if netInfo.mtu != 9216 {
+		t.Errorf("Expected not to have MTU as 9216 but got %v", netInfo.mtu)
+	}
+
+	if !netInfo.gateway.Equal(net.ParseIP("172.19.0.1")) {
+		t.Errorf("Expected not to have gateway as 172.19.0.1 but got %v", netInfo.gateway)
+	}
+
+	if !netInfo.subnet.IP.Equal(net.ParseIP("172.19.0.0")) {
+		t.Errorf("Expected not to have subnet as 172.19.0.0 but got %v", netInfo.gateway)
+	}
+}
+
+func TestDockerInspectWithoutMTU(t *testing.T) {
+	dockerInspectResponseWithMtu := `{"Name": "m2","Driver": "bridge","Subnet": "172.19.0.0/16","Gateway": "172.19.0.1","MTU": 0, "ContainerIPs": []}`
+
+	// setting up mock funcs
+	dockerResponse = dockerInspectResponseWithMtu
+	dockerInsepctGetter = dockerInspectGetterMock
+
+	netInfo, err := dockerNetworkInspect("m2")
+
+	if err != nil {
+		t.Errorf("Expected not to have error but got %v", err)
+	}
+
+	if netInfo.mtu != 0 {
+		t.Errorf("Expected not to have MTU as 0 but got %v", netInfo.mtu)
+	}
+
+	if !netInfo.gateway.Equal(net.ParseIP("172.19.0.1")) {
+		t.Errorf("Expected not to have gateway as 172.19.0.1 but got %v", netInfo.gateway)
+	}
+
+	if !netInfo.subnet.IP.Equal(net.ParseIP("172.19.0.0")) {
+		t.Errorf("Expected not to have subnet as 172.19.0.0 but got %v", netInfo.gateway)
+	}
+}


### PR DESCRIPTION
First create network  without MTU

```
docker@p1:~$ docker network create m1
c3d778d8147416d2dd0d466e77c845191b26915614c3de3e4b7aacad08fd63f9
docker@p1:~$ docker network inspect m1 --format '{"Name": "{{.Name}}","Driver": "{{.Driver}}","Subnet": "{{range .IPAM.Config}}{{.Subnet}}{{end}}","Gateway": "{{range .IPAM.Config}}{{.Gateway}}{{e
nd}}","MTU": {{if (index .Options "com.docker.network.driver.mtu")}}{{(index .Options "com.docker.network.driver.mtu")}}{{else}}0{{end}},{{$first := true}} "ContainerIPs": [{{range $k,$v := .Conta
iners }}{{if $first}}{{$first = false}}{{else}}, {{end}}"{{$v.IPv4Address}}"{{end}}]}'
{"Name": "m1","Driver": "bridge","Subnet": "172.18.0.0/16","Gateway": "172.18.0.1","MTU": 0, "ContainerIPs": []}
```
Create network with MTU

```
docker@p1:~$ docker network create m2 --opt com.docker.network.driver.mtu=9216
1b07fe461e1682b8010951bd17617f1c620144a8d34e22cd4e844860db2c3ee4
docker@p1:~$ docker network inspect m2 --format '{"Name": "{{.Name}}","Driver": "{{.Driver}}","Subnet": "{{range .IPAM.Config}}{{.Subnet}}{{end}}","Gateway": "{{range .IPAM.Config}}{{.Gateway}}{{e
nd}}","MTU": {{if (index .Options "com.docker.network.driver.mtu")}}{{(index .Options "com.docker.network.driver.mtu")}}{{else}}0{{end}},{{$first := true}} "ContainerIPs": [{{range $k,$v := .Conta
iners }}{{if $first}}{{$first = false}}{{else}}, {{end}}"{{$v.IPv4Address}}"{{end}}]}'
{"Name": "m2","Driver": "bridge","Subnet": "172.19.0.0/16","Gateway": "172.19.0.1","MTU": 9216, "ContainerIPs": []}
```

So this go template will work in both scenarios.
