### PR TITLE
fix "cache add" command error when not specifying :latest tag 

### DIFF
--- a/pkg/minikube/image/cache.go
+++ b/pkg/minikube/image/cache.go
@@ -76,6 +76,7 @@ func SaveToDir(images []string, cacheDir string) error {
 
 // saveToTarFile caches an image
 func saveToTarFile(iname, rawDest string) error {
+	iname = normalizeTagName(iname)
 	start := time.Now()
 	defer func() {
 		klog.Infof("cache image %q -> %q took %s", iname, rawDest, time.Since(start))

--- a/pkg/minikube/image/image.go
+++ b/pkg/minikube/image/image.go
@@ -212,3 +212,22 @@ func cleanImageCacheDir() error {
 	})
 	return err
 }
+
+// normalizeTagName automatically tag latest to image
+// Example:
+//  nginx -> nginx:latest
+//  localhost:5000/nginx -> localhost:5000/nginx:latest
+//  localhost:5000/nginx:latest -> localhost:5000/nginx:latest
+//  docker.io/dotnet/core/sdk -> docker.io/dotnet/core/sdk:latest
+func normalizeTagName(image string) string {
+	base := image
+	tag := "latest"
+
+	// From google/go-containerregistry/pkg/name/tag.go
+	parts := strings.Split(strings.TrimSpace(image), ":")
+	if len(parts) > 1 && !strings.Contains(parts[len(parts)-1], "/") {
+		base = strings.Join(parts[:len(parts)-1], ":")
+		tag = parts[len(parts)-1]
+	}
+	return base + ":" + tag
+}

--- a/pkg/minikube/image/image_test.go
+++ b/pkg/minikube/image/image_test.go
@@ -46,3 +46,48 @@ func TestTag(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeImageName(t *testing.T) {
+	cases := []struct {
+		image    string
+		expected string
+	}{
+		{
+			image:    "nginx",
+			expected: "nginx:latest",
+		},
+		{
+			image:    "localhost:5000/nginx",
+			expected: "localhost:5000/nginx:latest",
+		},
+		{
+			image:    "localhost:5000/nginx:3.0",
+			expected: "localhost:5000/nginx:3.0",
+		},
+		{
+			image:    "localhost:5000/nginx:latest",
+			expected: "localhost:5000/nginx:latest",
+		},
+		{
+			image:    "docker.io/nginx",
+			expected: "docker.io/nginx:latest",
+		},
+		{
+			image:    "nginx:3.0",
+			expected: "nginx:3.0",
+		},
+		{
+			image:    "docker.io/dotnet/core/sdk",
+			expected: "docker.io/dotnet/core/sdk:latest",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.image, func(t *testing.T) {
+			got := normalizeTagName(c.image)
+			if got != c.expected {
+				t.Errorf("Normalize error: expected: %v, got: %v", c.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -218,6 +218,7 @@ func CacheAndLoadImages(images []string) error {
 				if err != nil {
 					failed = append(failed, m)
 					klog.Warningf("Failed to load cached images for profile %s. make sure the profile is running. %v", pName, err)
+					continue
 				}
 				succeeded = append(succeeded, m)
 			}


### PR DESCRIPTION
Signed-off-by: Ling Samuel <lingsamuelgrace@gmail.com>

Fixes #10047, code from https://github.com/google/go-containerregistry/blob/6544cb07415a0b92dcc4079fdb13c4540f651e11/pkg/name/tag.go#L74-L84

/kind bug