### PR TITLE
Delete the existing cluster if guest driver mismatch

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -668,7 +668,7 @@ func validateSpecifiedDriver(existing *config.ClusterConfig) {
 		return
 	}
 
-	out.WarningT("Start deleting cluster {{.name}} with delete-on-failure flag set", out.V{"name": existing.Name})
+	out.WarningT("Deleting existing cluster {{.name}} with different driver {{.driver_name}} due to --delete-on-failure flag set by the user. ", out.V{"name": existing.Name, "driver_name": old})
 	if viper.GetBool(deleteOnFailure) {
 		// Start failed, delete the cluster
 		profile, err := config.LoadProfile(existing.Name)
@@ -684,13 +684,14 @@ func validateSpecifiedDriver(existing *config.ClusterConfig) {
 
 	exit.Advice(
 		reason.GuestDrvMismatch,
-		`The existing "{{.name}}" cluster was created using the "{{.old}}" driver, which is incompatible with requested "{{.new}}" driver. Deleted the existing '{{.name}}' cluster.`,
-		"Start the new '{{.name}}' cluster using: '{{.command}} --driver={{.new}}'",
+		`The existing "{{.name}}" cluster was created using the "{{.old}}" driver, which is incompatible with requested "{{.new}}" driver.`,
+		"Delete the existing '{{.name}}' cluster using: '{{.delcommand}}', or start the existing '{{.name}}' cluster using: '{{.command}} --driver={{.old}}'",
 		out.V{
-			"name":    existing.Name,
-			"new":     requested,
-			"old":     old,
-			"command": mustload.ExampleCmd(existing.Name, "start"),
+			"name":       existing.Name,
+			"new":        requested,
+			"old":        old,
+			"command":    mustload.ExampleCmd(existing.Name, "start"),
+			"delcommand": mustload.ExampleCmd(existing.Name, "delete"),
 		},
 	)
 }


### PR DESCRIPTION
Delete the existing cluster if minikube start failed with  GUEST_DRIVER_MISMATCH
```
zyanshu@zyanshukvm:~/minikube$ ./out/minikube start --driver=docker
😄  minikube v1.16.0 on Debian rodete
    ▪ MINIKUBE_ACTIVE_DOCKERD=p1
✨  Using the docker driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🔥  Creating docker container (CPUs=2, Memory=26100MB) ...
🐳  Preparing Kubernetes v1.20.0 on Docker 20.10.0 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
zyanshu@zyanshukvm:~/minikube$ ./out/minikube start --driver=kvm2 --delete-on-failure
😄  minikube v1.16.0 on Debian rodete
    ▪ MINIKUBE_ACTIVE_DOCKERD=p1
❗  Start deleting cluster minikube with delete-on-failure flag set
🔥  Deleting "minikube" in docker ...
🔥  Deleting container "minikube" ...
🔥  Removing /usr/local/google/home/zyanshu/.minikube/machines/minikube ...
💀  Removed all traces of the "minikube" cluster.

💢  Exiting due to GUEST_DRIVER_MISMATCH: The existing "minikube" cluster was created using the "docker" driver, which is incompatible with requested "kvm2" driver. Deleted the existing 'minikube'
 cluster.
💡  Suggestion: Start the new 'minikube' cluster using: 'minikube start --driver=kvm2'

zyanshu@zyanshukvm:~/minikube$ ./out/minikube profile list

❌  Exiting due to MK_USAGE: No minikube profile was found. You can create one using `minikube start`.

```