### PR TITLE
Handle podman installations without default bridge

### DIFF
--- a/pkg/drivers/kic/oci/network_create.go
+++ b/pkg/drivers/kic/oci/network_create.go
@@ -221,8 +221,13 @@ func podmanNetworkInspect(name string) (netInfo, error) {
 		return info, err
 	}
 
+	output := rr.Stdout.String()
+	if output == "" {
+		return info, fmt.Errorf("no bridge network found for %s", name)
+	}
+
 	// results looks like 172.17.0.0/16,172.17.0.1,1500
-	vals := strings.Split(strings.TrimSpace(rr.Stdout.String()), ",")
+	vals := strings.Split(strings.TrimSpace(output), ",")
 	if len(vals) == 0 {
 		return info, fmt.Errorf("empty list network inspect: %q", rr.Output())
 	}


### PR DESCRIPTION
Closes #10088

😄  minikube v1.16.0 on Debian bullseye/sid
✨  Using the podman (experimental) driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
💾  Downloading Kubernetes v1.20.0 preload ...
    > preloaded-images-k8s-v8-v1....: 491.00 MiB / 491.00 MiB  100.00% 26.42 Mi
🔥  Creating podman container (CPUs=2, Memory=2200MB) ...
🐳  Preparing Kubernetes v1.20.0 on Docker 20.10.0 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
🌟  Enabled addons: storage-provisioner, default-storageclass
💡  kubectl not found. If you need it, try: 'minikube kubectl -- get pods -A'
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
