### PR TITLE
Change metrics-server pull policy to IfNotPresent

### DIFF
--- a/deploy/addons/metrics-server/metrics-server-deployment.yaml.tmpl
+++ b/deploy/addons/metrics-server/metrics-server-deployment.yaml.tmpl
@@ -20,7 +20,7 @@ spec:
       containers:
       - name: metrics-server
         image: {{default "k8s.gcr.io" .ImageRepository}}/metrics-server-{{.Arch}}:v0.2.1
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command:
         - /metrics-server
         - --source=kubernetes.summary_api:https://kubernetes.default?kubeletHttps=true&kubeletPort=10250&insecure=true


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
In metrics-server addon deployment spec imagePullPolicy is set to Always. This means Kubernetes will never cache this image

Fixes  #10064