### PR TITLE
Ignore non-socks5 ALL_PROXY env var when checking docker status

### DIFF
--- a/cmd/minikube/cmd/docker-env_test.go
+++ b/cmd/minikube/cmd/docker-env_test.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -304,5 +305,39 @@ MINIKUBE_ACTIVE_DOCKERD
 			}
 
 		})
+	}
+}
+
+func TestValidDockerProxy(t *testing.T) {
+	var tests = []struct {
+		proxy   string
+		isValid bool
+	}{
+		{
+			proxy:   "socks5://192.168.0.1:1080",
+			isValid: true,
+		},
+		{
+			proxy:   "",
+			isValid: true,
+		},
+		{
+			proxy:   "socks://192.168.0.1:1080",
+			isValid: false,
+		},
+		{
+			proxy:   "http://192.168.0.1:1080",
+			isValid: false,
+		},
+	}
+
+	for _, tc := range tests {
+		os.Setenv("ALL_PROXY", tc.proxy)
+		valid := isValidDockerProxy("ALL_PROXY")
+		if tc.isValid && valid != tc.isValid {
+			t.Errorf("Expect %#v to be valid docker proxy", tc.proxy)
+		} else if !tc.isValid && valid != tc.isValid {
+			t.Errorf("Expect %#v to be invalid docker proxy", tc.proxy)
+		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Ling Samuel <lingsamuelgrace@gmail.com>

Fixes #10098

Env:
```bash
$ env | grep -i all_proxy
all_proxy=socks://127.0.0.1:1080/
ALL_PROXY=socks://127.0.0.1:1080/
```

Before:
![image](https://user-images.githubusercontent.com/14567045/103973421-59ee1f00-51aa-11eb-9647-c6a72d44b1d7.png)

After:
![image](https://user-images.githubusercontent.com/14567045/103973479-78ecb100-51aa-11eb-8ac7-0d6bf66f3c8a.png)
