### PR TITLE
Allow setting custom images for addons

### DIFF
--- a/cmd/minikube/cmd/config/enable.go
+++ b/cmd/minikube/cmd/config/enable.go
@@ -31,9 +31,10 @@ import (
 )
 
 var addonsEnableCmd = &cobra.Command{
-	Use:   "enable ADDON_NAME",
-	Short: "Enables the addon w/ADDON_NAME within minikube (example: minikube addons enable dashboard). For a list of available addons use: minikube addons list ",
-	Long:  "Enables the addon w/ADDON_NAME within minikube (example: minikube addons enable dashboard). For a list of available addons use: minikube addons list ",
+	Use:     "enable ADDON_NAME",
+	Short:   "Enables the addon w/ADDON_NAME within minikube. For a list of available addons use: minikube addons list ",
+	Long:    "Enables the addon w/ADDON_NAME within minikube. For a list of available addons use: minikube addons list ",
+	Example: "minikube addons enable dashboard",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 1 {
 			exit.Message(reason.Usage, "usage: minikube addons enable ADDON_NAME")
@@ -45,6 +46,7 @@ var addonsEnableCmd = &cobra.Command{
 			addon = "metrics-server"
 		}
 		viper.Set(config.AddonImages, images)
+		viper.Set(config.AddonRegistries, registries)
 		err := addons.SetAndSave(ClusterFlagValue(), addon, "true")
 		if err != nil {
 			exit.Error(reason.InternalEnable, "enable failed", err)
@@ -67,10 +69,12 @@ var addonsEnableCmd = &cobra.Command{
 }
 
 var (
-	images string
+	images     string
+	registries string
 )
 
 func init() {
-	addonsEnableCmd.Flags().StringVar(&images, "images", "", "Alpha feature. Image names used by this addon. Divided by comma.")
+	addonsEnableCmd.Flags().StringVar(&images, "images", "", "Images used by this addon. Divided by comma.")
+	addonsEnableCmd.Flags().StringVar(&registries, "registries", "", "Registries used by this addon. Divided by comma.")
 	AddonsCmd.AddCommand(addonsEnableCmd)
 }

--- a/cmd/minikube/cmd/config/enable.go
+++ b/cmd/minikube/cmd/config/enable.go
@@ -74,7 +74,7 @@ var (
 )
 
 func init() {
-	addonsEnableCmd.Flags().StringVar(&images, "images", "", "Images used by this addon. Divided by comma.")
-	addonsEnableCmd.Flags().StringVar(&registries, "registries", "", "Registries used by this addon. Divided by comma.")
+	addonsEnableCmd.Flags().StringVar(&images, "images", "", "Images used by this addon. Separated by commas.")
+	addonsEnableCmd.Flags().StringVar(&registries, "registries", "", "Registries used by this addon. Separated by commas.")
 	AddonsCmd.AddCommand(addonsEnableCmd)
 }

--- a/cmd/minikube/cmd/config/enable.go
+++ b/cmd/minikube/cmd/config/enable.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/addons"
+	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/out"
@@ -42,6 +44,7 @@ var addonsEnableCmd = &cobra.Command{
 			out.Step(style.Waiting, "enable metrics-server addon instead of heapster addon because heapster is deprecated")
 			addon = "metrics-server"
 		}
+		viper.Set(config.AddonImages, images)
 		err := addons.SetAndSave(ClusterFlagValue(), addon, "true")
 		if err != nil {
 			exit.Error(reason.InternalEnable, "enable failed", err)
@@ -63,6 +66,11 @@ var addonsEnableCmd = &cobra.Command{
 	},
 }
 
+var (
+	images string
+)
+
 func init() {
+	addonsEnableCmd.Flags().StringVar(&images, "images", "", "Alpha feature. Image names used by this addon. Divided by comma.")
 	AddonsCmd.AddCommand(addonsEnableCmd)
 }

--- a/cmd/minikube/cmd/config/images.go
+++ b/cmd/minikube/cmd/config/images.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"os"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+	"k8s.io/minikube/pkg/minikube/assets"
+	"k8s.io/minikube/pkg/minikube/exit"
+	"k8s.io/minikube/pkg/minikube/out"
+	"k8s.io/minikube/pkg/minikube/reason"
+)
+
+var addonsImagesCmd = &cobra.Command{
+	Use:   "images ADDON_NAME",
+	Short: "Alpha feature. List image names the addon w/ADDON_NAME used (example: minikube addons images ingress). For a list of available addons use: minikube addons list",
+	Long:  "Alpha feature. List image names the addon w/ADDON_NAME used (example: minikube addons images ingress). For a list of available addons use: minikube addons list",
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) != 1 {
+			exit.Message(reason.Usage, "usage: minikube addons configure ADDON_NAME")
+		}
+
+		addon := args[0]
+		// allows for additional prompting of information when enabling addons
+		if conf, ok := assets.Addons[addon]; ok {
+			if conf.Images != nil {
+				out.Infof("{{.name}} has following images:", out.V{"name": addon})
+
+				var tData [][]string
+				table := tablewriter.NewWriter(os.Stdout)
+				table.SetHeader([]string{"Image Name", "Default"})
+				table.SetAutoFormatHeaders(true)
+				table.SetBorders(tablewriter.Border{Left: true, Top: true, Right: true, Bottom: true})
+				table.SetCenterSeparator("|")
+
+				for imageName, defaultImage := range conf.Images {
+					tData = append(tData, []string{imageName, defaultImage})
+				}
+
+				table.AppendBulk(tData)
+				table.Render()
+			} else {
+				out.Infof("{{.name}} has not been implemented yet", out.V{"name": addon})
+			}
+		} else {
+			out.FailureT("No such addon {{.name}}", out.V{"name": addon})
+		}
+	},
+}
+
+func init() {
+	AddonsCmd.AddCommand(addonsImagesCmd)
+}

--- a/cmd/minikube/cmd/config/images.go
+++ b/cmd/minikube/cmd/config/images.go
@@ -28,12 +28,13 @@ import (
 )
 
 var addonsImagesCmd = &cobra.Command{
-	Use:   "images ADDON_NAME",
-	Short: "Alpha feature. List image names the addon w/ADDON_NAME used (example: minikube addons images ingress). For a list of available addons use: minikube addons list",
-	Long:  "Alpha feature. List image names the addon w/ADDON_NAME used (example: minikube addons images ingress). For a list of available addons use: minikube addons list",
+	Use:     "images ADDON_NAME",
+	Short:   "List image names the addon w/ADDON_NAME used. For a list of available addons use: minikube addons list",
+	Long:    "List image names the addon w/ADDON_NAME used. For a list of available addons use: minikube addons list",
+	Example: "minikube addons images ingress",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 1 {
-			exit.Message(reason.Usage, "usage: minikube addons configure ADDON_NAME")
+			exit.Message(reason.Usage, "usage: minikube addons images ADDON_NAME")
 		}
 
 		addon := args[0]
@@ -44,19 +45,19 @@ var addonsImagesCmd = &cobra.Command{
 
 				var tData [][]string
 				table := tablewriter.NewWriter(os.Stdout)
-				table.SetHeader([]string{"Image Name", "Default"})
+				table.SetHeader([]string{"Image Name", "Default Image", "Default Registry"})
 				table.SetAutoFormatHeaders(true)
 				table.SetBorders(tablewriter.Border{Left: true, Top: true, Right: true, Bottom: true})
 				table.SetCenterSeparator("|")
 
 				for imageName, defaultImage := range conf.Images {
-					tData = append(tData, []string{imageName, defaultImage})
+					tData = append(tData, []string{imageName, defaultImage, conf.Registries[imageName]})
 				}
 
 				table.AppendBulk(tData)
 				table.Render()
 			} else {
-				out.Infof("{{.name}} has not been implemented yet", out.V{"name": addon})
+				out.Infof("{{.name}} doesn't have images.", out.V{"name": addon})
 			}
 		} else {
 			out.FailureT("No such addon {{.name}}", out.V{"name": addon})

--- a/deploy/addons/ambassador/ambassador-operator.yaml.tmpl
+++ b/deploy/addons/ambassador/ambassador-operator.yaml.tmpl
@@ -180,7 +180,7 @@ spec:
       containers:
         - name: ambassador-operator
           # Replace this with the built image name
-          image: {{default .Registries.AmbassadorOperator .ImageRepository}}/{{.Images.AmbassadorOperator}}
+          image: {{default .Registries.AmbassadorOperator .ImageRepository}}{{.Images.AmbassadorOperator}}
           command:
           - ambassador-operator
           imagePullPolicy: Always

--- a/deploy/addons/ambassador/ambassador-operator.yaml.tmpl
+++ b/deploy/addons/ambassador/ambassador-operator.yaml.tmpl
@@ -180,7 +180,7 @@ spec:
       containers:
         - name: ambassador-operator
           # Replace this with the built image name
-          image: {{default "quay.io/datawire" .ImageRepository}}/ambassador-operator:v1.2.3
+          image: {{default "quay.io/" .ImageRepository}}/{{.Images.AmbassadorOperator}}
           command:
           - ambassador-operator
           imagePullPolicy: Always

--- a/deploy/addons/ambassador/ambassador-operator.yaml.tmpl
+++ b/deploy/addons/ambassador/ambassador-operator.yaml.tmpl
@@ -180,7 +180,7 @@ spec:
       containers:
         - name: ambassador-operator
           # Replace this with the built image name
-          image: {{default "quay.io/" .ImageRepository}}/{{.Images.AmbassadorOperator}}
+          image: {{default .Registries.AmbassadorOperator .ImageRepository}}/{{.Images.AmbassadorOperator}}
           command:
           - ambassador-operator
           imagePullPolicy: Always

--- a/deploy/addons/ambassador/ambassador-operator.yaml.tmpl
+++ b/deploy/addons/ambassador/ambassador-operator.yaml.tmpl
@@ -180,10 +180,10 @@ spec:
       containers:
         - name: ambassador-operator
           # Replace this with the built image name
-          image: {{default .Registries.AmbassadorOperator .ImageRepository}}{{.Images.AmbassadorOperator}}
+          image: {{.CustomRegistries.AmbassadorOperator  | default .ImageRepository | default .Registries.AmbassadorOperator }}{{.Images.AmbassadorOperator}}
           command:
           - ambassador-operator
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE
               valueFrom:

--- a/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-attacher.yaml.tmpl
+++ b/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-attacher.yaml.tmpl
@@ -57,7 +57,7 @@ spec:
       serviceAccountName: csi-attacher
       containers:
         - name: csi-attacher
-          image: {{default .Registries.Attacher .ImageRepository}}/{{.Images.Attacher}}
+          image: {{default .Registries.Attacher .ImageRepository}}{{.Images.Attacher}}
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-attacher.yaml.tmpl
+++ b/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-attacher.yaml.tmpl
@@ -57,7 +57,7 @@ spec:
       serviceAccountName: csi-attacher
       containers:
         - name: csi-attacher
-          image: {{default "quay.io/k8scsi" .ImageRepository}}/csi-attacher:v3.0.0-rc1
+          image: {{default "quay.io" .ImageRepository}}/{{.Images.Attacher}}
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-attacher.yaml.tmpl
+++ b/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-attacher.yaml.tmpl
@@ -57,7 +57,7 @@ spec:
       serviceAccountName: csi-attacher
       containers:
         - name: csi-attacher
-          image: {{default "quay.io" .ImageRepository}}/{{.Images.Attacher}}
+          image: {{default .Registries.Attacher .ImageRepository}}/{{.Images.Attacher}}
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-attacher.yaml.tmpl
+++ b/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-attacher.yaml.tmpl
@@ -57,7 +57,7 @@ spec:
       serviceAccountName: csi-attacher
       containers:
         - name: csi-attacher
-          image: {{default .Registries.Attacher .ImageRepository}}{{.Images.Attacher}}
+          image: {{.CustomRegistries.Attacher  | default .ImageRepository | default .Registries.Attacher }}{{.Images.Attacher}}
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-plugin.yaml.tmpl
+++ b/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-plugin.yaml.tmpl
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
         - name: node-driver-registrar
-          image: {{default .Registries.NodeDriverRegistrar .ImageRepository}}{{.Images.NodeDriverRegistrar}}
+          image: {{.CustomRegistries.NodeDriverRegistrar  | default .ImageRepository | default .Registries.NodeDriverRegistrar }}{{.Images.NodeDriverRegistrar}}
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -78,7 +78,7 @@ spec:
             name: csi-data-dir
 
         - name: hostpath
-          image: {{default .Registries.HostPathPlugin .ImageRepository}}{{.Images.HostPathPlugin}}
+          image: {{.CustomRegistries.HostPathPlugin  | default .ImageRepository | default .Registries.HostPathPlugin }}{{.Images.HostPathPlugin}}
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"
@@ -123,7 +123,7 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          image: {{default .Registries.LivenessProbe .ImageRepository}}{{.Images.LivenessProbe}}
+          image: {{.CustomRegistries.LivenessProbe  | default .ImageRepository | default .Registries.LivenessProbe }}{{.Images.LivenessProbe}}
           args:
           - --csi-address=/csi/csi.sock
           - --health-port=9898

--- a/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-plugin.yaml.tmpl
+++ b/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-plugin.yaml.tmpl
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
         - name: node-driver-registrar
-          image: {{default "quay.io/k8scsi" .ImageRepository}}/csi-node-driver-registrar:v1.3.0
+          image: {{default "quay.io" .ImageRepository}}/{{.Images.NodeDriverRegistrar}}
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -78,7 +78,7 @@ spec:
             name: csi-data-dir
 
         - name: hostpath
-          image: {{default "quay.io/k8scsi" .ImageRepository}}/hostpathplugin:v1.4.0-rc2
+          image: {{default "quay.io" .ImageRepository}}/{{.Images.HostPathPlugin}}
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"
@@ -123,7 +123,7 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          image: {{default "quay.io/k8scsi" .ImageRepository}}/livenessprobe:v1.1.0
+          image: {{default "quay.io" .ImageRepository}}/{{.Images.LivenessProbe}}
           args:
           - --csi-address=/csi/csi.sock
           - --health-port=9898

--- a/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-plugin.yaml.tmpl
+++ b/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-plugin.yaml.tmpl
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
         - name: node-driver-registrar
-          image: {{default "quay.io" .ImageRepository}}/{{.Images.NodeDriverRegistrar}}
+          image: {{default .Registries.NodeDriverRegistrar .ImageRepository}}/{{.Images.NodeDriverRegistrar}}
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -78,7 +78,7 @@ spec:
             name: csi-data-dir
 
         - name: hostpath
-          image: {{default "quay.io" .ImageRepository}}/{{.Images.HostPathPlugin}}
+          image: {{default .Registries.HostPathPlugin .ImageRepository}}/{{.Images.HostPathPlugin}}
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"
@@ -123,7 +123,7 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          image: {{default "quay.io" .ImageRepository}}/{{.Images.LivenessProbe}}
+          image: {{default .Registries.LivenessProbe .ImageRepository}}/{{.Images.LivenessProbe}}
           args:
           - --csi-address=/csi/csi.sock
           - --health-port=9898

--- a/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-plugin.yaml.tmpl
+++ b/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-plugin.yaml.tmpl
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
         - name: node-driver-registrar
-          image: {{default .Registries.NodeDriverRegistrar .ImageRepository}}/{{.Images.NodeDriverRegistrar}}
+          image: {{default .Registries.NodeDriverRegistrar .ImageRepository}}{{.Images.NodeDriverRegistrar}}
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -78,7 +78,7 @@ spec:
             name: csi-data-dir
 
         - name: hostpath
-          image: {{default .Registries.HostPathPlugin .ImageRepository}}/{{.Images.HostPathPlugin}}
+          image: {{default .Registries.HostPathPlugin .ImageRepository}}{{.Images.HostPathPlugin}}
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"
@@ -123,7 +123,7 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          image: {{default .Registries.LivenessProbe .ImageRepository}}/{{.Images.LivenessProbe}}
+          image: {{default .Registries.LivenessProbe .ImageRepository}}{{.Images.LivenessProbe}}
           args:
           - --csi-address=/csi/csi.sock
           - --health-port=9898

--- a/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-provisioner.yaml.tmpl
+++ b/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-provisioner.yaml.tmpl
@@ -57,7 +57,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: {{default "gcr.io" .ImageRepository}}/{{.Images.Provisioner}}
+          image: {{default .Registries.Provisioner .ImageRepository}}/{{.Images.Provisioner}}
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-provisioner.yaml.tmpl
+++ b/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-provisioner.yaml.tmpl
@@ -57,7 +57,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: {{default "gcr.io/k8s-staging-sig-storage" .ImageRepository}}/csi-provisioner:v2.0.0-rc2
+          image: {{default "gcr.io" .ImageRepository}}/{{.Images.Provisioner}}
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-provisioner.yaml.tmpl
+++ b/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-provisioner.yaml.tmpl
@@ -57,7 +57,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: {{default .Registries.Provisioner .ImageRepository}}/{{.Images.Provisioner}}
+          image: {{default .Registries.Provisioner .ImageRepository}}{{.Images.Provisioner}}
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-provisioner.yaml.tmpl
+++ b/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-provisioner.yaml.tmpl
@@ -57,7 +57,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: {{default .Registries.Provisioner .ImageRepository}}{{.Images.Provisioner}}
+          image: {{.CustomRegistries.Provisioner  | default .ImageRepository | default .Registries.Provisioner }}{{.Images.Provisioner}}
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-resizer.yaml.tmpl
+++ b/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-resizer.yaml.tmpl
@@ -57,7 +57,7 @@ spec:
       serviceAccountName: csi-resizer
       containers:
         - name: csi-resizer
-          image: {{default .Registries.Resizer .ImageRepository}}/{{.Images.Resizer}}
+          image: {{default .Registries.Resizer .ImageRepository}}{{.Images.Resizer}}
           args:
             - -v=5
             - -csi-address=/csi/csi.sock

--- a/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-resizer.yaml.tmpl
+++ b/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-resizer.yaml.tmpl
@@ -57,7 +57,7 @@ spec:
       serviceAccountName: csi-resizer
       containers:
         - name: csi-resizer
-          image: {{default "quay.io/k8scsi" .ImageRepository}}/csi-resizer:v0.6.0-rc1
+          image: {{default "quay.io" .ImageRepository}}/{{.Images.Resizer}}
           args:
             - -v=5
             - -csi-address=/csi/csi.sock

--- a/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-resizer.yaml.tmpl
+++ b/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-resizer.yaml.tmpl
@@ -57,7 +57,7 @@ spec:
       serviceAccountName: csi-resizer
       containers:
         - name: csi-resizer
-          image: {{default "quay.io" .ImageRepository}}/{{.Images.Resizer}}
+          image: {{default .Registries.Resizer .ImageRepository}}/{{.Images.Resizer}}
           args:
             - -v=5
             - -csi-address=/csi/csi.sock

--- a/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-resizer.yaml.tmpl
+++ b/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-resizer.yaml.tmpl
@@ -57,7 +57,7 @@ spec:
       serviceAccountName: csi-resizer
       containers:
         - name: csi-resizer
-          image: {{default .Registries.Resizer .ImageRepository}}{{.Images.Resizer}}
+          image: {{.CustomRegistries.Resizer  | default .ImageRepository | default .Registries.Resizer }}{{.Images.Resizer}}
           args:
             - -v=5
             - -csi-address=/csi/csi.sock

--- a/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-snapshotter.yaml.tmpl
+++ b/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-snapshotter.yaml.tmpl
@@ -57,7 +57,7 @@ spec:
       serviceAccount: csi-snapshotter
       containers:
         - name: csi-snapshotter
-          image: {{default "quay.io/k8scsi" .ImageRepository}}/csi-snapshotter:v2.1.0
+          image: {{default "quay.io" .ImageRepository}}/{{.Images.Snapshotter}}
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-snapshotter.yaml.tmpl
+++ b/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-snapshotter.yaml.tmpl
@@ -57,7 +57,7 @@ spec:
       serviceAccount: csi-snapshotter
       containers:
         - name: csi-snapshotter
-          image: {{default .Registries.Snapshotter .ImageRepository}}/{{.Images.Snapshotter}}
+          image: {{default .Registries.Snapshotter .ImageRepository}}{{.Images.Snapshotter}}
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-snapshotter.yaml.tmpl
+++ b/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-snapshotter.yaml.tmpl
@@ -57,7 +57,7 @@ spec:
       serviceAccount: csi-snapshotter
       containers:
         - name: csi-snapshotter
-          image: {{default .Registries.Snapshotter .ImageRepository}}{{.Images.Snapshotter}}
+          image: {{.CustomRegistries.Snapshotter  | default .ImageRepository | default .Registries.Snapshotter }}{{.Images.Snapshotter}}
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-snapshotter.yaml.tmpl
+++ b/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-snapshotter.yaml.tmpl
@@ -57,7 +57,7 @@ spec:
       serviceAccount: csi-snapshotter
       containers:
         - name: csi-snapshotter
-          image: {{default "quay.io" .ImageRepository}}/{{.Images.Snapshotter}}
+          image: {{default .Registries.Snapshotter .ImageRepository}}/{{.Images.Snapshotter}}
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/addons/dashboard/dashboard-dp.yaml.tmpl
+++ b/deploy/addons/dashboard/dashboard-dp.yaml.tmpl
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
         - name: dashboard-metrics-scraper
-          image: {{default "docker.io" .ImageRepository}}/{{.Images.MetricsScraper}}
+          image: {{default .Registries.MetricsScraper .ImageRepository}}/{{.Images.MetricsScraper}}
           ports:
             - containerPort: 8000
               protocol: TCP
@@ -91,7 +91,7 @@ spec:
       containers:
         - name: kubernetes-dashboard
           # WARNING: This must match pkg/minikube/bootstrapper/images/images.go
-          image: {{default "docker.io" .ImageRepository}}/{{.Images.Dashboard}}
+          image: {{default .Registries.Dashboard .ImageRepository}}/{{.Images.Dashboard}}
           ports:
             - containerPort: 9090
               protocol: TCP

--- a/deploy/addons/dashboard/dashboard-dp.yaml.tmpl
+++ b/deploy/addons/dashboard/dashboard-dp.yaml.tmpl
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
         - name: dashboard-metrics-scraper
-          image: {{default .Registries.MetricsScraper .ImageRepository}}{{.Images.MetricsScraper}}
+          image: {{.CustomRegistries.MetricsScraper  | default .ImageRepository | default .Registries.MetricsScraper }}{{.Images.MetricsScraper}}
           ports:
             - containerPort: 8000
               protocol: TCP
@@ -91,7 +91,7 @@ spec:
       containers:
         - name: kubernetes-dashboard
           # WARNING: This must match pkg/minikube/bootstrapper/images/images.go
-          image: {{default .Registries.Dashboard .ImageRepository}}{{.Images.Dashboard}}
+          image: {{.CustomRegistries.Dashboard  | default .ImageRepository | default .Registries.Dashboard }}{{.Images.Dashboard}}
           ports:
             - containerPort: 9090
               protocol: TCP

--- a/deploy/addons/dashboard/dashboard-dp.yaml.tmpl
+++ b/deploy/addons/dashboard/dashboard-dp.yaml.tmpl
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
         - name: dashboard-metrics-scraper
-          image: {{default "kubernetesui" .ImageRepository}}/metrics-scraper:v1.0.4
+          image: {{default "docker.io" .ImageRepository}}/{{.Images.MetricsScraper}}
           ports:
             - containerPort: 8000
               protocol: TCP
@@ -91,7 +91,7 @@ spec:
       containers:
         - name: kubernetes-dashboard
           # WARNING: This must match pkg/minikube/bootstrapper/images/images.go
-          image: {{default "kubernetesui" .ImageRepository}}/dashboard:v2.1.0
+          image: {{default "docker.io" .ImageRepository}}/{{.Images.Dashboard}}
           ports:
             - containerPort: 9090
               protocol: TCP

--- a/deploy/addons/dashboard/dashboard-dp.yaml.tmpl
+++ b/deploy/addons/dashboard/dashboard-dp.yaml.tmpl
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
         - name: dashboard-metrics-scraper
-          image: {{default .Registries.MetricsScraper .ImageRepository}}/{{.Images.MetricsScraper}}
+          image: {{default .Registries.MetricsScraper .ImageRepository}}{{.Images.MetricsScraper}}
           ports:
             - containerPort: 8000
               protocol: TCP
@@ -91,7 +91,7 @@ spec:
       containers:
         - name: kubernetes-dashboard
           # WARNING: This must match pkg/minikube/bootstrapper/images/images.go
-          image: {{default .Registries.Dashboard .ImageRepository}}/{{.Images.Dashboard}}
+          image: {{default .Registries.Dashboard .ImageRepository}}{{.Images.Dashboard}}
           ports:
             - containerPort: 9090
               protocol: TCP

--- a/deploy/addons/efk/elasticsearch-rc.yaml.tmpl
+++ b/deploy/addons/efk/elasticsearch-rc.yaml.tmpl
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: elasticsearch-logging
-        image: {{default "k8s.gcr.io" .ImageRepository}}/elasticsearch:v5.6.2
+        image: {{default "k8s.gcr.io" .ImageRepository}}/{{.Images.Elasticsearch}}
         resources:
           limits:
             cpu: 500m
@@ -62,7 +62,7 @@ spec:
         - name: ES_JAVA_OPTS
           value: "-Xms1024m -Xmx1024m"
       initContainers:
-      - image: {{default "registry.hub.docker.com/library" .ImageRepository}}/alpine:3.6
+      - image: {{default "docker.io" .ImageRepository}}/{{.Images.Alpine}}
         command: ["/sbin/sysctl", "-w", "vm.max_map_count=262144"]
         name: elasticsearch-logging-init
         securityContext:

--- a/deploy/addons/efk/elasticsearch-rc.yaml.tmpl
+++ b/deploy/addons/efk/elasticsearch-rc.yaml.tmpl
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: elasticsearch-logging
-        image: {{default .Registries.Elasticsearch .ImageRepository}}{{.Images.Elasticsearch}}
+        image: {{.CustomRegistries.Elasticsearch  | default .ImageRepository | default .Registries.Elasticsearch }}{{.Images.Elasticsearch}}
         resources:
           limits:
             cpu: 500m
@@ -62,7 +62,7 @@ spec:
         - name: ES_JAVA_OPTS
           value: "-Xms1024m -Xmx1024m"
       initContainers:
-      - image: {{default .Registries.Alpine .ImageRepository}}{{.Images.Alpine}}
+      - image: {{.CustomRegistries.Alpine  | default .ImageRepository | default .Registries.Alpine }}{{.Images.Alpine}}
         command: ["/sbin/sysctl", "-w", "vm.max_map_count=262144"]
         name: elasticsearch-logging-init
         securityContext:

--- a/deploy/addons/efk/elasticsearch-rc.yaml.tmpl
+++ b/deploy/addons/efk/elasticsearch-rc.yaml.tmpl
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: elasticsearch-logging
-        image: {{default "k8s.gcr.io" .ImageRepository}}/{{.Images.Elasticsearch}}
+        image: {{default .Registries.Elasticsearch .ImageRepository}}/{{.Images.Elasticsearch}}
         resources:
           limits:
             cpu: 500m
@@ -62,7 +62,7 @@ spec:
         - name: ES_JAVA_OPTS
           value: "-Xms1024m -Xmx1024m"
       initContainers:
-      - image: {{default "docker.io" .ImageRepository}}/{{.Images.Alpine}}
+      - image: {{default .Registries.Alpine .ImageRepository}}/{{.Images.Alpine}}
         command: ["/sbin/sysctl", "-w", "vm.max_map_count=262144"]
         name: elasticsearch-logging-init
         securityContext:

--- a/deploy/addons/efk/elasticsearch-rc.yaml.tmpl
+++ b/deploy/addons/efk/elasticsearch-rc.yaml.tmpl
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: elasticsearch-logging
-        image: {{default .Registries.Elasticsearch .ImageRepository}}/{{.Images.Elasticsearch}}
+        image: {{default .Registries.Elasticsearch .ImageRepository}}{{.Images.Elasticsearch}}
         resources:
           limits:
             cpu: 500m
@@ -62,7 +62,7 @@ spec:
         - name: ES_JAVA_OPTS
           value: "-Xms1024m -Xmx1024m"
       initContainers:
-      - image: {{default .Registries.Alpine .ImageRepository}}/{{.Images.Alpine}}
+      - image: {{default .Registries.Alpine .ImageRepository}}{{.Images.Alpine}}
         command: ["/sbin/sysctl", "-w", "vm.max_map_count=262144"]
         name: elasticsearch-logging-init
         securityContext:

--- a/deploy/addons/efk/fluentd-es-rc.yaml.tmpl
+++ b/deploy/addons/efk/fluentd-es-rc.yaml.tmpl
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: fluentd-es
-        image: {{default "k8s.gcr.io" .ImageRepository}}/fluentd-elasticsearch:v2.0.2
+        image: {{default "k8s.gcr.io" .ImageRepository}}/{{.Images.FluentdElasticsearch}}
         env:
         - name: FLUENTD_ARGS
           value: --no-supervisor -q

--- a/deploy/addons/efk/fluentd-es-rc.yaml.tmpl
+++ b/deploy/addons/efk/fluentd-es-rc.yaml.tmpl
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: fluentd-es
-        image: {{default "k8s.gcr.io" .ImageRepository}}/{{.Images.FluentdElasticsearch}}
+        image: {{default .Registries.FluentdElasticsearch .ImageRepository}}/{{.Images.FluentdElasticsearch}}
         env:
         - name: FLUENTD_ARGS
           value: --no-supervisor -q

--- a/deploy/addons/efk/fluentd-es-rc.yaml.tmpl
+++ b/deploy/addons/efk/fluentd-es-rc.yaml.tmpl
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: fluentd-es
-        image: {{default .Registries.FluentdElasticsearch .ImageRepository}}/{{.Images.FluentdElasticsearch}}
+        image: {{default .Registries.FluentdElasticsearch .ImageRepository}}{{.Images.FluentdElasticsearch}}
         env:
         - name: FLUENTD_ARGS
           value: --no-supervisor -q

--- a/deploy/addons/efk/fluentd-es-rc.yaml.tmpl
+++ b/deploy/addons/efk/fluentd-es-rc.yaml.tmpl
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: fluentd-es
-        image: {{default .Registries.FluentdElasticsearch .ImageRepository}}{{.Images.FluentdElasticsearch}}
+        image: {{.CustomRegistries.FluentdElasticsearch  | default .ImageRepository | default .Registries.FluentdElasticsearch }}{{.Images.FluentdElasticsearch}}
         env:
         - name: FLUENTD_ARGS
           value: --no-supervisor -q

--- a/deploy/addons/efk/kibana-rc.yaml.tmpl
+++ b/deploy/addons/efk/kibana-rc.yaml.tmpl
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: kibana-logging
-        image: {{default "docker.elastic.co" .ImageRepository}}/{{.Images.Kibana}}
+        image: {{default .Registries.Kibana .ImageRepository}}/{{.Images.Kibana}}
         resources:
           limits:
             cpu: 500m

--- a/deploy/addons/efk/kibana-rc.yaml.tmpl
+++ b/deploy/addons/efk/kibana-rc.yaml.tmpl
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: kibana-logging
-        image: {{default "docker.elastic.co/kibana" .ImageRepository}}/kibana:5.6.2
+        image: {{default "docker.elastic.co" .ImageRepository}}/{{.Images.Kibana}}
         resources:
           limits:
             cpu: 500m

--- a/deploy/addons/efk/kibana-rc.yaml.tmpl
+++ b/deploy/addons/efk/kibana-rc.yaml.tmpl
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: kibana-logging
-        image: {{default .Registries.Kibana .ImageRepository}}{{.Images.Kibana}}
+        image: {{.CustomRegistries.Kibana  | default .ImageRepository | default .Registries.Kibana }}{{.Images.Kibana}}
         resources:
           limits:
             cpu: 500m

--- a/deploy/addons/efk/kibana-rc.yaml.tmpl
+++ b/deploy/addons/efk/kibana-rc.yaml.tmpl
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: kibana-logging
-        image: {{default .Registries.Kibana .ImageRepository}}/{{.Images.Kibana}}
+        image: {{default .Registries.Kibana .ImageRepository}}{{.Images.Kibana}}
         resources:
           limits:
             cpu: 500m

--- a/deploy/addons/freshpod/freshpod-rc.yaml.tmpl
+++ b/deploy/addons/freshpod/freshpod-rc.yaml.tmpl
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: freshpod
-        image: {{default "gcr.io" .ImageRepository}}/{{.Images.FreshPod}}
+        image: {{default .Registries.FreshPod .ImageRepository}}/{{.Images.FreshPod}}
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: docker

--- a/deploy/addons/freshpod/freshpod-rc.yaml.tmpl
+++ b/deploy/addons/freshpod/freshpod-rc.yaml.tmpl
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: freshpod
-        image: {{default .Registries.FreshPod .ImageRepository}}/{{.Images.FreshPod}}
+        image: {{default .Registries.FreshPod .ImageRepository}}{{.Images.FreshPod}}
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: docker

--- a/deploy/addons/freshpod/freshpod-rc.yaml.tmpl
+++ b/deploy/addons/freshpod/freshpod-rc.yaml.tmpl
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: freshpod
-        image: {{default "gcr.io/google-samples" .ImageRepository}}/freshpod:v0.0.1
+        image: {{default "gcr.io" .ImageRepository}}/{{.Images.FreshPod}}
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: docker

--- a/deploy/addons/freshpod/freshpod-rc.yaml.tmpl
+++ b/deploy/addons/freshpod/freshpod-rc.yaml.tmpl
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: freshpod
-        image: {{default .Registries.FreshPod .ImageRepository}}{{.Images.FreshPod}}
+        image: {{.CustomRegistries.FreshPod  | default .ImageRepository | default .Registries.FreshPod }}{{.Images.FreshPod}}
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: docker

--- a/deploy/addons/gcp-auth/gcp-auth-webhook.yaml.tmpl.tmpl
+++ b/deploy/addons/gcp-auth/gcp-auth-webhook.yaml.tmpl.tmpl
@@ -68,7 +68,7 @@ spec:
       serviceAccountName: minikube-gcp-auth-certs
       containers:
         - name: create
-          image: {{default .Registries.KubeWebhookCertgen .ImageRepository}}{{.Images.KubeWebhookCertgen}}
+          image: {{.CustomRegistries.KubeWebhookCertgen  | default .ImageRepository | default .Registries.KubeWebhookCertgen }}{{.Images.KubeWebhookCertgen}}
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -94,7 +94,7 @@ spec:
     spec:
       containers:
         - name: gcp-auth
-          image: {{default .Registries.GCPAuthWebhook .ImageRepository}}{{.Images.GCPAuthWebhook}}
+          image: {{.CustomRegistries.GCPAuthWebhook  | default .ImageRepository | default .Registries.GCPAuthWebhook }}{{.Images.GCPAuthWebhook}}
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
@@ -127,7 +127,7 @@ spec:
       serviceAccountName: minikube-gcp-auth-certs
       containers:
         - name: patch
-          image: {{default .Registries.KubeWebhookCertgen .ImageRepository}}{{.Images.KubeWebhookCertgen}}
+          image: {{.CustomRegistries.KubeWebhookCertgen  | default .ImageRepository | default .Registries.KubeWebhookCertgen }}{{.Images.KubeWebhookCertgen}}
           imagePullPolicy: IfNotPresent
           args:
             - patch

--- a/deploy/addons/gcp-auth/gcp-auth-webhook.yaml.tmpl.tmpl
+++ b/deploy/addons/gcp-auth/gcp-auth-webhook.yaml.tmpl.tmpl
@@ -68,7 +68,7 @@ spec:
       serviceAccountName: minikube-gcp-auth-certs
       containers:
         - name: create
-          image: {{default "jettech" .ImageRepository}}/kube-webhook-certgen:v1.3.0
+          image: {{default "docker.io" .ImageRepository}}/{{.Images.KubeWebhookCertgen}}
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -94,7 +94,7 @@ spec:
     spec:
       containers:
         - name: gcp-auth
-          image: {{default "gcr.io/k8s-minikube" .ImageRepository}}/gcp-auth-webhook:v0.0.3
+          image: {{default "gcr.io" .ImageRepository}}/{{.Images.GCPAuthWebhook}}
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
@@ -127,7 +127,7 @@ spec:
       serviceAccountName: minikube-gcp-auth-certs
       containers:
         - name: patch
-          image: {{default "jettech" .ImageRepository}}/kube-webhook-certgen:v1.3.0
+          image: {{default "docker.io" .ImageRepository}}/{{.Images.KubeWebhookCertgen}}
           imagePullPolicy: IfNotPresent
           args:
             - patch

--- a/deploy/addons/gcp-auth/gcp-auth-webhook.yaml.tmpl.tmpl
+++ b/deploy/addons/gcp-auth/gcp-auth-webhook.yaml.tmpl.tmpl
@@ -68,7 +68,7 @@ spec:
       serviceAccountName: minikube-gcp-auth-certs
       containers:
         - name: create
-          image: {{default .Registries.KubeWebhookCertgen .ImageRepository}}/{{.Images.KubeWebhookCertgen}}
+          image: {{default .Registries.KubeWebhookCertgen .ImageRepository}}{{.Images.KubeWebhookCertgen}}
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -94,7 +94,7 @@ spec:
     spec:
       containers:
         - name: gcp-auth
-          image: {{default .Registries.GCPAuthWebhook .ImageRepository}}/{{.Images.GCPAuthWebhook}}
+          image: {{default .Registries.GCPAuthWebhook .ImageRepository}}{{.Images.GCPAuthWebhook}}
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
@@ -127,7 +127,7 @@ spec:
       serviceAccountName: minikube-gcp-auth-certs
       containers:
         - name: patch
-          image: {{default .Registries.KubeWebhookCertgen .ImageRepository}}/{{.Images.KubeWebhookCertgen}}
+          image: {{default .Registries.KubeWebhookCertgen .ImageRepository}}{{.Images.KubeWebhookCertgen}}
           imagePullPolicy: IfNotPresent
           args:
             - patch

--- a/deploy/addons/gcp-auth/gcp-auth-webhook.yaml.tmpl.tmpl
+++ b/deploy/addons/gcp-auth/gcp-auth-webhook.yaml.tmpl.tmpl
@@ -68,7 +68,7 @@ spec:
       serviceAccountName: minikube-gcp-auth-certs
       containers:
         - name: create
-          image: {{default "docker.io" .ImageRepository}}/{{.Images.KubeWebhookCertgen}}
+          image: {{default .Registries.KubeWebhookCertgen .ImageRepository}}/{{.Images.KubeWebhookCertgen}}
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -94,7 +94,7 @@ spec:
     spec:
       containers:
         - name: gcp-auth
-          image: {{default "gcr.io" .ImageRepository}}/{{.Images.GCPAuthWebhook}}
+          image: {{default .Registries.GCPAuthWebhook .ImageRepository}}/{{.Images.GCPAuthWebhook}}
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
@@ -127,7 +127,7 @@ spec:
       serviceAccountName: minikube-gcp-auth-certs
       containers:
         - name: patch
-          image: {{default "docker.io" .ImageRepository}}/{{.Images.KubeWebhookCertgen}}
+          image: {{default .Registries.KubeWebhookCertgen .ImageRepository}}/{{.Images.KubeWebhookCertgen}}
           imagePullPolicy: IfNotPresent
           args:
             - patch

--- a/deploy/addons/gpu/nvidia-driver-installer.yaml.tmpl
+++ b/deploy/addons/gpu/nvidia-driver-installer.yaml.tmpl
@@ -50,7 +50,7 @@ spec:
         hostPath:
           path: /
       initContainers:
-      - image: {{default .Registries.NvidiaDriverInstaller .ImageRepository}}{{.Images.NvidiaDriverInstaller}}
+      - image: {{.CustomRegistries.NvidiaDriverInstaller  | default .ImageRepository | default .Registries.NvidiaDriverInstaller }}{{.Images.NvidiaDriverInstaller}}
         name: nvidia-driver-installer
         resources:
           requests:

--- a/deploy/addons/gpu/nvidia-driver-installer.yaml.tmpl
+++ b/deploy/addons/gpu/nvidia-driver-installer.yaml.tmpl
@@ -50,7 +50,7 @@ spec:
         hostPath:
           path: /
       initContainers:
-      - image: {{default "k8s.gcr.io" .ImageRepository}}/minikube-nvidia-driver-installer:e2d9b43228decf5d6f7dce3f0a85d390f138fa01
+      - image: {{default "k8s.gcr.io" .ImageRepository}}/{{.Images.NvidiaDriverInstaller}}
         name: nvidia-driver-installer
         resources:
           requests:
@@ -72,5 +72,5 @@ spec:
         - name: root-mount
           mountPath: /root
       containers:
-      - image: "{{default "k8s.gcr.io" .ImageRepository}}/pause:2.0"
+      - image: "{{default "k8s.gcr.io" .ImageRepository}}/{{.Images.Pause}}"
         name: pause

--- a/deploy/addons/gpu/nvidia-driver-installer.yaml.tmpl
+++ b/deploy/addons/gpu/nvidia-driver-installer.yaml.tmpl
@@ -50,7 +50,7 @@ spec:
         hostPath:
           path: /
       initContainers:
-      - image: {{default .Registries.NvidiaDriverInstaller .ImageRepository}}/{{.Images.NvidiaDriverInstaller}}
+      - image: {{default .Registries.NvidiaDriverInstaller .ImageRepository}}{{.Images.NvidiaDriverInstaller}}
         name: nvidia-driver-installer
         resources:
           requests:

--- a/deploy/addons/gpu/nvidia-driver-installer.yaml.tmpl
+++ b/deploy/addons/gpu/nvidia-driver-installer.yaml.tmpl
@@ -50,7 +50,7 @@ spec:
         hostPath:
           path: /
       initContainers:
-      - image: {{default "k8s.gcr.io" .ImageRepository}}/{{.Images.NvidiaDriverInstaller}}
+      - image: {{default .Registries.NvidiaDriverInstaller .ImageRepository}}/{{.Images.NvidiaDriverInstaller}}
         name: nvidia-driver-installer
         resources:
           requests:

--- a/deploy/addons/gpu/nvidia-gpu-device-plugin.yaml.tmpl
+++ b/deploy/addons/gpu/nvidia-gpu-device-plugin.yaml.tmpl
@@ -43,7 +43,7 @@ spec:
         hostPath:
           path: /var/lib/kubelet/device-plugins
       containers:
-      - image: {{default "docker.io" .ImageRepository}}/{{.Images.NvidiaDevicePlugin}}
+      - image: {{default .Registries.NvidiaDevicePlugin .ImageRepository}}/{{.Images.NvidiaDevicePlugin}}
         command: ["/usr/bin/nvidia-device-plugin", "-logtostderr"]
         name: nvidia-gpu-device-plugin
         resources:

--- a/deploy/addons/gpu/nvidia-gpu-device-plugin.yaml.tmpl
+++ b/deploy/addons/gpu/nvidia-gpu-device-plugin.yaml.tmpl
@@ -43,7 +43,7 @@ spec:
         hostPath:
           path: /var/lib/kubelet/device-plugins
       containers:
-      - image: {{default "nvidia" .ImageRepository}}/k8s-device-plugin:1.0.0-beta4
+      - image: {{default "docker.io" .ImageRepository}}/{{.Images.NvidiaDevicePlugin}}
         command: ["/usr/bin/nvidia-device-plugin", "-logtostderr"]
         name: nvidia-gpu-device-plugin
         resources:

--- a/deploy/addons/gpu/nvidia-gpu-device-plugin.yaml.tmpl
+++ b/deploy/addons/gpu/nvidia-gpu-device-plugin.yaml.tmpl
@@ -43,7 +43,7 @@ spec:
         hostPath:
           path: /var/lib/kubelet/device-plugins
       containers:
-      - image: {{default .Registries.NvidiaDevicePlugin .ImageRepository}}{{.Images.NvidiaDevicePlugin}}
+      - image: {{.CustomRegistries.NvidiaDevicePlugin  | default .ImageRepository | default .Registries.NvidiaDevicePlugin }}{{.Images.NvidiaDevicePlugin}}
         command: ["/usr/bin/nvidia-device-plugin", "-logtostderr"]
         name: nvidia-gpu-device-plugin
         resources:

--- a/deploy/addons/gpu/nvidia-gpu-device-plugin.yaml.tmpl
+++ b/deploy/addons/gpu/nvidia-gpu-device-plugin.yaml.tmpl
@@ -43,7 +43,7 @@ spec:
         hostPath:
           path: /var/lib/kubelet/device-plugins
       containers:
-      - image: {{default .Registries.NvidiaDevicePlugin .ImageRepository}}/{{.Images.NvidiaDevicePlugin}}
+      - image: {{default .Registries.NvidiaDevicePlugin .ImageRepository}}{{.Images.NvidiaDevicePlugin}}
         command: ["/usr/bin/nvidia-device-plugin", "-logtostderr"]
         name: nvidia-gpu-device-plugin
         resources:

--- a/deploy/addons/gvisor/gvisor-pod.yaml.tmpl
+++ b/deploy/addons/gvisor/gvisor-pod.yaml.tmpl
@@ -25,7 +25,7 @@ spec:
   hostPID: true
   containers:
     - name: gvisor
-      image: {{default .Registries.GvisorAddon .ImageRepository}}/{{.Images.GvisorAddon}}
+      image: {{default .Registries.GvisorAddon .ImageRepository}}{{.Images.GvisorAddon}}
       securityContext:
         privileged: true
       volumeMounts:

--- a/deploy/addons/gvisor/gvisor-pod.yaml.tmpl
+++ b/deploy/addons/gvisor/gvisor-pod.yaml.tmpl
@@ -25,7 +25,7 @@ spec:
   hostPID: true
   containers:
     - name: gvisor
-      image: {{default .Registries.GvisorAddon .ImageRepository}}{{.Images.GvisorAddon}}
+      image: {{.CustomRegistries.GvisorAddon  | default .ImageRepository | default .Registries.GvisorAddon }}{{.Images.GvisorAddon}}
       securityContext:
         privileged: true
       volumeMounts:

--- a/deploy/addons/gvisor/gvisor-pod.yaml.tmpl
+++ b/deploy/addons/gvisor/gvisor-pod.yaml.tmpl
@@ -25,7 +25,7 @@ spec:
   hostPID: true
   containers:
     - name: gvisor
-      image: {{default "gcr.io/k8s-minikube" .ImageRepository}}/gvisor-addon:3
+      image: {{default "gcr.io" .ImageRepository}}/{{.Images.GvisorAddon}}
       securityContext:
         privileged: true
       volumeMounts:

--- a/deploy/addons/gvisor/gvisor-pod.yaml.tmpl
+++ b/deploy/addons/gvisor/gvisor-pod.yaml.tmpl
@@ -25,7 +25,7 @@ spec:
   hostPID: true
   containers:
     - name: gvisor
-      image: {{default "gcr.io" .ImageRepository}}/{{.Images.GvisorAddon}}
+      image: {{default .Registries.GvisorAddon .ImageRepository}}/{{.Images.GvisorAddon}}
       securityContext:
         privileged: true
       volumeMounts:

--- a/deploy/addons/helm-tiller/helm-tiller-dp.tmpl
+++ b/deploy/addons/helm-tiller/helm-tiller-dp.tmpl
@@ -46,7 +46,7 @@ spec:
               value: kube-system
             - name: TILLER_HISTORY_MAX
               value: "0"
-          image: {{default "gcr.io" .ImageRepository}}/{{.Images.Tiller}}
+          image: {{default .Registries.Tiller .ImageRepository}}/{{.Images.Tiller}}
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3

--- a/deploy/addons/helm-tiller/helm-tiller-dp.tmpl
+++ b/deploy/addons/helm-tiller/helm-tiller-dp.tmpl
@@ -46,7 +46,7 @@ spec:
               value: kube-system
             - name: TILLER_HISTORY_MAX
               value: "0"
-          image: {{default .Registries.Tiller .ImageRepository}}/{{.Images.Tiller}}
+          image: {{default .Registries.Tiller .ImageRepository}}{{.Images.Tiller}}
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3

--- a/deploy/addons/helm-tiller/helm-tiller-dp.tmpl
+++ b/deploy/addons/helm-tiller/helm-tiller-dp.tmpl
@@ -46,7 +46,7 @@ spec:
               value: kube-system
             - name: TILLER_HISTORY_MAX
               value: "0"
-          image: {{default .Registries.Tiller .ImageRepository}}{{.Images.Tiller}}
+          image: {{.CustomRegistries.Tiller  | default .ImageRepository | default .Registries.Tiller }}{{.Images.Tiller}}
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3

--- a/deploy/addons/helm-tiller/helm-tiller-dp.tmpl
+++ b/deploy/addons/helm-tiller/helm-tiller-dp.tmpl
@@ -46,7 +46,7 @@ spec:
               value: kube-system
             - name: TILLER_HISTORY_MAX
               value: "0"
-          image: {{default "gcr.io/kubernetes-helm" .ImageRepository}}/tiller:v2.16.12
+          image: {{default "gcr.io" .ImageRepository}}/{{.Images.Tiller}}
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3

--- a/deploy/addons/ingress-dns/ingress-dns-pod.yaml.tmpl
+++ b/deploy/addons/ingress-dns/ingress-dns-pod.yaml.tmpl
@@ -80,7 +80,7 @@ spec:
   hostNetwork: true
   containers:
     - name: minikube-ingress-dns
-      image: {{default "cryptexlabs" .ImageRepository}}/minikube-ingress-dns:0.3.0
+      image: {{default "docker.io" .ImageRepository}}/{{.Images.IngressDNS}}
       imagePullPolicy: IfNotPresent
       ports:
         - containerPort: 53

--- a/deploy/addons/ingress-dns/ingress-dns-pod.yaml.tmpl
+++ b/deploy/addons/ingress-dns/ingress-dns-pod.yaml.tmpl
@@ -80,7 +80,7 @@ spec:
   hostNetwork: true
   containers:
     - name: minikube-ingress-dns
-      image: {{default .Registries.IngressDNS .ImageRepository}}{{.Images.IngressDNS}}
+      image: {{.CustomRegistries.IngressDNS  | default .ImageRepository | default .Registries.IngressDNS }}{{.Images.IngressDNS}}
       imagePullPolicy: IfNotPresent
       ports:
         - containerPort: 53

--- a/deploy/addons/ingress-dns/ingress-dns-pod.yaml.tmpl
+++ b/deploy/addons/ingress-dns/ingress-dns-pod.yaml.tmpl
@@ -80,7 +80,7 @@ spec:
   hostNetwork: true
   containers:
     - name: minikube-ingress-dns
-      image: {{default "docker.io" .ImageRepository}}/{{.Images.IngressDNS}}
+      image: {{default .Registries.IngressDNS .ImageRepository}}/{{.Images.IngressDNS}}
       imagePullPolicy: IfNotPresent
       ports:
         - containerPort: 53

--- a/deploy/addons/ingress-dns/ingress-dns-pod.yaml.tmpl
+++ b/deploy/addons/ingress-dns/ingress-dns-pod.yaml.tmpl
@@ -80,7 +80,7 @@ spec:
   hostNetwork: true
   containers:
     - name: minikube-ingress-dns
-      image: {{default .Registries.IngressDNS .ImageRepository}}/{{.Images.IngressDNS}}
+      image: {{default .Registries.IngressDNS .ImageRepository}}{{.Images.IngressDNS}}
       imagePullPolicy: IfNotPresent
       ports:
         - containerPort: 53

--- a/deploy/addons/ingress/ingress-dp.yaml.tmpl
+++ b/deploy/addons/ingress/ingress-dp.yaml.tmpl
@@ -49,7 +49,7 @@ spec:
       serviceAccountName: ingress-nginx
       containers:
         - name: controller
-          image: {{default .Registries.IngressController .ImageRepository}}{{.Images.IngressController}}
+          image: {{.CustomRegistries.IngressController  | default .ImageRepository | default .Registries.IngressController }}{{.Images.IngressController}}
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:
@@ -220,7 +220,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: {{default .Registries.KubeWebhookCertgenCreate .ImageRepository}}{{.Images.KubeWebhookCertgenCreate}}
+          image: {{.CustomRegistries.KubeWebhookCertgenCreate  | default .ImageRepository | default .Registries.KubeWebhookCertgenCreate }}{{.Images.KubeWebhookCertgenCreate}}
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -255,7 +255,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: {{default .Registries.KubeWebhookCertgenPatch .ImageRepository}}{{.Images.KubeWebhookCertgenPatch}}
+          image: {{.CustomRegistries.KubeWebhookCertgenPatch  | default .ImageRepository | default .Registries.KubeWebhookCertgenPatch }}{{.Images.KubeWebhookCertgenPatch}}
           imagePullPolicy:
           args:
             - patch

--- a/deploy/addons/ingress/ingress-dp.yaml.tmpl
+++ b/deploy/addons/ingress/ingress-dp.yaml.tmpl
@@ -49,7 +49,7 @@ spec:
       serviceAccountName: ingress-nginx
       containers:
         - name: controller
-          image: {{default .Registries.IngressController .ImageRepository}}/{{.Images.IngressController}}
+          image: {{default .Registries.IngressController .ImageRepository}}{{.Images.IngressController}}
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:
@@ -220,7 +220,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: {{default .Registries.KubeWebhookCertgenCreate .ImageRepository}}/{{.Images.KubeWebhookCertgenCreate}}
+          image: {{default .Registries.KubeWebhookCertgenCreate .ImageRepository}}{{.Images.KubeWebhookCertgenCreate}}
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -255,7 +255,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: {{default .Registries.KubeWebhookCertgenPatch .ImageRepository}}/{{.Images.KubeWebhookCertgenPatch}}
+          image: {{default .Registries.KubeWebhookCertgenPatch .ImageRepository}}{{.Images.KubeWebhookCertgenPatch}}
           imagePullPolicy:
           args:
             - patch

--- a/deploy/addons/ingress/ingress-dp.yaml.tmpl
+++ b/deploy/addons/ingress/ingress-dp.yaml.tmpl
@@ -49,7 +49,7 @@ spec:
       serviceAccountName: ingress-nginx
       containers:
         - name: controller
-          image: {{default "us.gcr.io/k8s-artifacts-prod" .ImageRepository}}/{{default "ingress-nginx/controller:v0.40.2" .Images.IngressController}}
+          image: {{default "us.gcr.io/k8s-artifacts-prod" .ImageRepository}}/{{.Images.IngressController}}
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:
@@ -220,7 +220,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: {{default "jettech" .ImageRepository}}/{{default "kube-webhook-certgen:v1.2.2" .Images.KubeWebhookCertgenCreate}}
+          image: {{default "jettech" .ImageRepository}}/{{.Images.KubeWebhookCertgenCreate}}
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -255,7 +255,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: {{default "jettech" .ImageRepository}}/{{default "kube-webhook-certgen:v1.3.0" .Images.KubeWebhookCertgenPatch}}
+          image: {{default "jettech" .ImageRepository}}/{{.Images.KubeWebhookCertgenPatch}}
           imagePullPolicy:
           args:
             - patch

--- a/deploy/addons/ingress/ingress-dp.yaml.tmpl
+++ b/deploy/addons/ingress/ingress-dp.yaml.tmpl
@@ -220,7 +220,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: {{default "jettech" .ImageRepository}}/{{.Images.KubeWebhookCertgenCreate}}
+          image: {{default "docker.io" .ImageRepository}}/{{.Images.KubeWebhookCertgenCreate}}
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -255,7 +255,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: {{default "jettech" .ImageRepository}}/{{.Images.KubeWebhookCertgenPatch}}
+          image: {{default "docker.io" .ImageRepository}}/{{.Images.KubeWebhookCertgenPatch}}
           imagePullPolicy:
           args:
             - patch

--- a/deploy/addons/ingress/ingress-dp.yaml.tmpl
+++ b/deploy/addons/ingress/ingress-dp.yaml.tmpl
@@ -49,7 +49,7 @@ spec:
       serviceAccountName: ingress-nginx
       containers:
         - name: controller
-          image: {{default "us.gcr.io/k8s-artifacts-prod" .ImageRepository}}/{{.Images.IngressController}}
+          image: {{default .Registries.IngressController .ImageRepository}}/{{.Images.IngressController}}
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:
@@ -220,7 +220,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: {{default "docker.io" .ImageRepository}}/{{.Images.KubeWebhookCertgenCreate}}
+          image: {{default .Registries.KubeWebhookCertgenCreate .ImageRepository}}/{{.Images.KubeWebhookCertgenCreate}}
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -255,7 +255,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: {{default "docker.io" .ImageRepository}}/{{.Images.KubeWebhookCertgenPatch}}
+          image: {{default .Registries.KubeWebhookCertgenPatch .ImageRepository}}/{{.Images.KubeWebhookCertgenPatch}}
           imagePullPolicy:
           args:
             - patch

--- a/deploy/addons/ingress/ingress-dp.yaml.tmpl
+++ b/deploy/addons/ingress/ingress-dp.yaml.tmpl
@@ -49,7 +49,7 @@ spec:
       serviceAccountName: ingress-nginx
       containers:
         - name: controller
-          image: {{default "us.gcr.io/k8s-artifacts-prod/ingress-nginx" .ImageRepository}}/controller:v0.40.2
+          image: {{default "us.gcr.io/k8s-artifacts-prod" .ImageRepository}}/{{default "ingress-nginx/controller:v0.40.2" .Images.IngressController}}
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:
@@ -220,7 +220,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: {{default "jettech" .ImageRepository}}/kube-webhook-certgen:v1.2.2
+          image: {{default "jettech" .ImageRepository}}/{{default "kube-webhook-certgen:v1.2.2" .Images.KubeWebhookCertgenCreate}}
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -255,7 +255,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: {{default "jettech" .ImageRepository}}/kube-webhook-certgen:v1.3.0
+          image: {{default "jettech" .ImageRepository}}/{{default "kube-webhook-certgen:v1.3.0" .Images.KubeWebhookCertgenPatch}}
           imagePullPolicy:
           args:
             - patch

--- a/deploy/addons/istio-provisioner/istio-operator.yaml.tmpl
+++ b/deploy/addons/istio-provisioner/istio-operator.yaml.tmpl
@@ -218,7 +218,7 @@ spec:
       serviceAccountName: istio-operator
       containers:
         - name: istio-operator
-          image: docker.io/istio/operator:1.5.0
+          image: {{default "docker.io" .ImageRepository}}/{{.Images.IstioOperator}}
           command:
           - operator
           - server

--- a/deploy/addons/istio-provisioner/istio-operator.yaml.tmpl
+++ b/deploy/addons/istio-provisioner/istio-operator.yaml.tmpl
@@ -218,11 +218,11 @@ spec:
       serviceAccountName: istio-operator
       containers:
         - name: istio-operator
-          image: {{default .Registries.IstioOperator .ImageRepository}}{{.Images.IstioOperator}}
+          image: {{.CustomRegistries.IstioOperator  | default .ImageRepository | default .Registries.IstioOperator }}{{.Images.IstioOperator}}
           command:
           - operator
           - server
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           resources:
             limits:
               cpu: 200m

--- a/deploy/addons/istio-provisioner/istio-operator.yaml.tmpl
+++ b/deploy/addons/istio-provisioner/istio-operator.yaml.tmpl
@@ -218,7 +218,7 @@ spec:
       serviceAccountName: istio-operator
       containers:
         - name: istio-operator
-          image: {{default "docker.io" .ImageRepository}}/{{.Images.IstioOperator}}
+          image: {{default .Registries.IstioOperator .ImageRepository}}/{{.Images.IstioOperator}}
           command:
           - operator
           - server

--- a/deploy/addons/istio-provisioner/istio-operator.yaml.tmpl
+++ b/deploy/addons/istio-provisioner/istio-operator.yaml.tmpl
@@ -218,7 +218,7 @@ spec:
       serviceAccountName: istio-operator
       containers:
         - name: istio-operator
-          image: {{default .Registries.IstioOperator .ImageRepository}}/{{.Images.IstioOperator}}
+          image: {{default .Registries.IstioOperator .ImageRepository}}{{.Images.IstioOperator}}
           command:
           - operator
           - server

--- a/deploy/addons/kubevirt/pod.yaml.tmpl
+++ b/deploy/addons/kubevirt/pod.yaml.tmpl
@@ -50,7 +50,7 @@ spec:
     - /bin/bash
     - -c
     - /kubevirt-scripts/install.sh
-    image: {{default .Registries.Kubectl .ImageRepository}}{{.Images.Kubectl}}
+    image: {{.CustomRegistries.Kubectl  | default .ImageRepository | default .Registries.Kubectl }}{{.Images.Kubectl}}
     imagePullPolicy: IfNotPresent
     name: kubevirt-provisioner
     lifecycle:

--- a/deploy/addons/kubevirt/pod.yaml.tmpl
+++ b/deploy/addons/kubevirt/pod.yaml.tmpl
@@ -50,7 +50,7 @@ spec:
     - /bin/bash
     - -c
     - /kubevirt-scripts/install.sh
-    image: {{default "docker.io" .ImageRepository}}/{{.Images.Kubectl}}
+    image: {{default .Registries.Kubectl .ImageRepository}}/{{.Images.Kubectl}}
     imagePullPolicy: IfNotPresent
     name: kubevirt-provisioner
     lifecycle:

--- a/deploy/addons/kubevirt/pod.yaml.tmpl
+++ b/deploy/addons/kubevirt/pod.yaml.tmpl
@@ -50,7 +50,7 @@ spec:
     - /bin/bash
     - -c
     - /kubevirt-scripts/install.sh
-    image: {{default .Registries.Kubectl .ImageRepository}}/{{.Images.Kubectl}}
+    image: {{default .Registries.Kubectl .ImageRepository}}{{.Images.Kubectl}}
     imagePullPolicy: IfNotPresent
     name: kubevirt-provisioner
     lifecycle:

--- a/deploy/addons/kubevirt/pod.yaml.tmpl
+++ b/deploy/addons/kubevirt/pod.yaml.tmpl
@@ -50,7 +50,7 @@ spec:
     - /bin/bash
     - -c
     - /kubevirt-scripts/install.sh
-    image: bitnami/kubectl:1.17
+    image: {{default "docker.io" .ImageRepository}}/{{.Images.Kubectl}}
     imagePullPolicy: IfNotPresent
     name: kubevirt-provisioner
     lifecycle:

--- a/deploy/addons/logviewer/logviewer-dp-and-svc.yaml.tmpl
+++ b/deploy/addons/logviewer/logviewer-dp-and-svc.yaml.tmpl
@@ -41,8 +41,8 @@ spec:
       serviceAccountName: sa-logviewer
       containers:
       - name: logviewer
-        imagePullPolicy: Always
-        image: {{default .Registries.LogViewer .ImageRepository}}{{.Images.LogViewer}}
+        imagePullPolicy: IfNotPresent
+        image: {{.CustomRegistries.LogViewer  | default .ImageRepository | default .Registries.LogViewer }}{{.Images.LogViewer}}
         volumeMounts:
          - name: logs
            mountPath: /var/log/containers/

--- a/deploy/addons/logviewer/logviewer-dp-and-svc.yaml.tmpl
+++ b/deploy/addons/logviewer/logviewer-dp-and-svc.yaml.tmpl
@@ -42,7 +42,7 @@ spec:
       containers:
       - name: logviewer
         imagePullPolicy: Always
-        image: {{default "docker.io/ivans3" .ImageRepository}}/minikube-log-viewer:latest
+        image: {{default "docker.io" .ImageRepository}}/{{.Images.LogViewer}}
         volumeMounts:
          - name: logs
            mountPath: /var/log/containers/

--- a/deploy/addons/logviewer/logviewer-dp-and-svc.yaml.tmpl
+++ b/deploy/addons/logviewer/logviewer-dp-and-svc.yaml.tmpl
@@ -42,7 +42,7 @@ spec:
       containers:
       - name: logviewer
         imagePullPolicy: Always
-        image: {{default .Registries.LogViewer .ImageRepository}}/{{.Images.LogViewer}}
+        image: {{default .Registries.LogViewer .ImageRepository}}{{.Images.LogViewer}}
         volumeMounts:
          - name: logs
            mountPath: /var/log/containers/

--- a/deploy/addons/logviewer/logviewer-dp-and-svc.yaml.tmpl
+++ b/deploy/addons/logviewer/logviewer-dp-and-svc.yaml.tmpl
@@ -42,7 +42,7 @@ spec:
       containers:
       - name: logviewer
         imagePullPolicy: Always
-        image: {{default "docker.io" .ImageRepository}}/{{.Images.LogViewer}}
+        image: {{default .Registries.LogViewer .ImageRepository}}/{{.Images.LogViewer}}
         volumeMounts:
          - name: logs
            mountPath: /var/log/containers/

--- a/deploy/addons/metallb/metallb.yaml.tmpl
+++ b/deploy/addons/metallb/metallb.yaml.tmpl
@@ -212,7 +212,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: {{default "metallb" .ImageRepository}}/speaker:v0.8.2
+        image: {{default "docker.io" .ImageRepository}}/{{.Images.Speaker}}
         imagePullPolicy: IfNotPresent
         name: speaker
         ports:
@@ -268,7 +268,7 @@ spec:
       - args:
         - --port=7472
         - --config=config
-        image: {{default "metallb" .ImageRepository}}/controller:v0.8.2
+        image: {{default "docker.io" .ImageRepository}}/{{.Images.Controller}}
         imagePullPolicy: IfNotPresent
         name: controller
         ports:

--- a/deploy/addons/metallb/metallb.yaml.tmpl
+++ b/deploy/addons/metallb/metallb.yaml.tmpl
@@ -212,7 +212,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: {{default .Registries.Speaker .ImageRepository}}/{{.Images.Speaker}}
+        image: {{default .Registries.Speaker .ImageRepository}}{{.Images.Speaker}}
         imagePullPolicy: IfNotPresent
         name: speaker
         ports:
@@ -268,7 +268,7 @@ spec:
       - args:
         - --port=7472
         - --config=config
-        image: {{default .Registries.Controller .ImageRepository}}/{{.Images.Controller}}
+        image: {{default .Registries.Controller .ImageRepository}}{{.Images.Controller}}
         imagePullPolicy: IfNotPresent
         name: controller
         ports:

--- a/deploy/addons/metallb/metallb.yaml.tmpl
+++ b/deploy/addons/metallb/metallb.yaml.tmpl
@@ -212,7 +212,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: {{default "docker.io" .ImageRepository}}/{{.Images.Speaker}}
+        image: {{default .Registries.Speaker .ImageRepository}}/{{.Images.Speaker}}
         imagePullPolicy: IfNotPresent
         name: speaker
         ports:
@@ -268,7 +268,7 @@ spec:
       - args:
         - --port=7472
         - --config=config
-        image: {{default "docker.io" .ImageRepository}}/{{.Images.Controller}}
+        image: {{default .Registries.Controller .ImageRepository}}/{{.Images.Controller}}
         imagePullPolicy: IfNotPresent
         name: controller
         ports:

--- a/deploy/addons/metallb/metallb.yaml.tmpl
+++ b/deploy/addons/metallb/metallb.yaml.tmpl
@@ -212,7 +212,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: {{default .Registries.Speaker .ImageRepository}}{{.Images.Speaker}}
+        image: {{.CustomRegistries.Speaker  | default .ImageRepository | default .Registries.Speaker }}{{.Images.Speaker}}
         imagePullPolicy: IfNotPresent
         name: speaker
         ports:
@@ -268,7 +268,7 @@ spec:
       - args:
         - --port=7472
         - --config=config
-        image: {{default .Registries.Controller .ImageRepository}}{{.Images.Controller}}
+        image: {{.CustomRegistries.Controller  | default .ImageRepository | default .Registries.Controller }}{{.Images.Controller}}
         imagePullPolicy: IfNotPresent
         name: controller
         ports:

--- a/deploy/addons/metrics-server/metrics-server-deployment.yaml.tmpl
+++ b/deploy/addons/metrics-server/metrics-server-deployment.yaml.tmpl
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: metrics-server
-        image: {{default "k8s.gcr.io" .ImageRepository}}/metrics-server-{{.Arch}}:v0.2.1
+        image: {{default "k8s.gcr.io" .ImageRepository}}/{{.Images.MetricsServer}}
         imagePullPolicy: IfNotPresent
         command:
         - /metrics-server

--- a/deploy/addons/metrics-server/metrics-server-deployment.yaml.tmpl
+++ b/deploy/addons/metrics-server/metrics-server-deployment.yaml.tmpl
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: metrics-server
-        image: {{default .Registries.MetricsServer .ImageRepository}}/{{.Images.MetricsServer}}
+        image: {{default .Registries.MetricsServer .ImageRepository}}{{.Images.MetricsServer}}
         imagePullPolicy: IfNotPresent
         command:
         - /metrics-server

--- a/deploy/addons/metrics-server/metrics-server-deployment.yaml.tmpl
+++ b/deploy/addons/metrics-server/metrics-server-deployment.yaml.tmpl
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: metrics-server
-        image: {{default .Registries.MetricsServer .ImageRepository}}{{.Images.MetricsServer}}
+        image: {{.CustomRegistries.MetricsServer  | default .ImageRepository | default .Registries.MetricsServer }}{{.Images.MetricsServer}}
         imagePullPolicy: IfNotPresent
         command:
         - /metrics-server

--- a/deploy/addons/metrics-server/metrics-server-deployment.yaml.tmpl
+++ b/deploy/addons/metrics-server/metrics-server-deployment.yaml.tmpl
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: metrics-server
-        image: {{default "k8s.gcr.io" .ImageRepository}}/{{.Images.MetricsServer}}
+        image: {{default .Registries.MetricsServer .ImageRepository}}/{{.Images.MetricsServer}}
         imagePullPolicy: IfNotPresent
         command:
         - /metrics-server

--- a/deploy/addons/olm/olm.yaml.tmpl
+++ b/deploy/addons/olm/olm.yaml.tmpl
@@ -82,7 +82,7 @@ spec:
           - $(OPERATOR_NAMESPACE)
           - -writeStatusName
           - ""
-          image: {{default .Registries.OLM .ImageRepository}}{{.Images.OLM}}
+          image: {{.CustomRegistries.OLM  | default .ImageRepository | default .Registries.OLM }}{{.Images.OLM}}
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -143,7 +143,7 @@ spec:
           - '-namespace'
           - olm
           - -configmapServerImage=quay.io/operator-framework/configmap-operator-registry:latest
-          image: {{default .Registries.OLM .ImageRepository}}{{.Images.OLM}}
+          image: {{.CustomRegistries.OLM  | default .ImageRepository | default .Registries.OLM }}{{.Images.OLM}}
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -307,8 +307,8 @@ spec:
                 - "5443"
                 - --global-namespace
                 - olm
-                image: {{default .Registries.OLM .ImageRepository}}{{.Images.OLM}}
-                imagePullPolicy: Always
+                image: {{.CustomRegistries.OLM  | default .ImageRepository | default .Registries.OLM }}{{.Images.OLM}}
+                imagePullPolicy: IfNotPresent
                 ports:
                 - containerPort: 5443
                 livenessProbe:
@@ -346,6 +346,6 @@ metadata:
   namespace: olm
 spec:
   sourceType: grpc
-  image: {{default .Registries.UpstreamCommunityOperators .ImageRepository}}{{.Images.UpstreamCommunityOperators}}
+  image: {{.CustomRegistries.UpstreamCommunityOperators  | default .ImageRepository | default .Registries.UpstreamCommunityOperators }}{{.Images.UpstreamCommunityOperators}}
   displayName: Community Operators
   publisher: OperatorHub.io

--- a/deploy/addons/olm/olm.yaml.tmpl
+++ b/deploy/addons/olm/olm.yaml.tmpl
@@ -82,7 +82,7 @@ spec:
           - $(OPERATOR_NAMESPACE)
           - -writeStatusName
           - ""
-          image: quay.io/operator-framework/olm@sha256:0d15ffb5d10a176ef6e831d7865f98d51255ea5b0d16403618c94a004d049373
+          image: {{default "quay.io" .ImageRepository}}/{{.Images.OLM}}
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -143,7 +143,7 @@ spec:
           - '-namespace'
           - olm
           - -configmapServerImage=quay.io/operator-framework/configmap-operator-registry:latest
-          image: quay.io/operator-framework/olm@sha256:0d15ffb5d10a176ef6e831d7865f98d51255ea5b0d16403618c94a004d049373
+          image: {{default "quay.io" .ImageRepository}}/{{.Images.OLM}}
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -307,7 +307,7 @@ spec:
                 - "5443"
                 - --global-namespace
                 - olm
-                image: quay.io/operator-framework/olm@sha256:0d15ffb5d10a176ef6e831d7865f98d51255ea5b0d16403618c94a004d049373
+                image: {{default "quay.io" .ImageRepository}}/{{.Images.OLM}}
                 imagePullPolicy: Always
                 ports:
                 - containerPort: 5443
@@ -346,6 +346,6 @@ metadata:
   namespace: olm
 spec:
   sourceType: grpc
-  image: quay.io/operator-framework/upstream-community-operators:latest
+  image: {{default "quay.io" .ImageRepository}}/{{.Images.UpstreamCommunityOperators}}
   displayName: Community Operators
   publisher: OperatorHub.io

--- a/deploy/addons/olm/olm.yaml.tmpl
+++ b/deploy/addons/olm/olm.yaml.tmpl
@@ -82,7 +82,7 @@ spec:
           - $(OPERATOR_NAMESPACE)
           - -writeStatusName
           - ""
-          image: {{default "quay.io" .ImageRepository}}/{{.Images.OLM}}
+          image: {{default .Registries.OLM .ImageRepository}}/{{.Images.OLM}}
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -143,7 +143,7 @@ spec:
           - '-namespace'
           - olm
           - -configmapServerImage=quay.io/operator-framework/configmap-operator-registry:latest
-          image: {{default "quay.io" .ImageRepository}}/{{.Images.OLM}}
+          image: {{default .Registries.OLM .ImageRepository}}/{{.Images.OLM}}
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -307,7 +307,7 @@ spec:
                 - "5443"
                 - --global-namespace
                 - olm
-                image: {{default "quay.io" .ImageRepository}}/{{.Images.OLM}}
+                image: {{default .Registries.OLM .ImageRepository}}/{{.Images.OLM}}
                 imagePullPolicy: Always
                 ports:
                 - containerPort: 5443
@@ -346,6 +346,6 @@ metadata:
   namespace: olm
 spec:
   sourceType: grpc
-  image: {{default "quay.io" .ImageRepository}}/{{.Images.UpstreamCommunityOperators}}
+  image: {{default .Registries.UpstreamCommunityOperators .ImageRepository}}/{{.Images.UpstreamCommunityOperators}}
   displayName: Community Operators
   publisher: OperatorHub.io

--- a/deploy/addons/olm/olm.yaml.tmpl
+++ b/deploy/addons/olm/olm.yaml.tmpl
@@ -82,7 +82,7 @@ spec:
           - $(OPERATOR_NAMESPACE)
           - -writeStatusName
           - ""
-          image: {{default .Registries.OLM .ImageRepository}}/{{.Images.OLM}}
+          image: {{default .Registries.OLM .ImageRepository}}{{.Images.OLM}}
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -143,7 +143,7 @@ spec:
           - '-namespace'
           - olm
           - -configmapServerImage=quay.io/operator-framework/configmap-operator-registry:latest
-          image: {{default .Registries.OLM .ImageRepository}}/{{.Images.OLM}}
+          image: {{default .Registries.OLM .ImageRepository}}{{.Images.OLM}}
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -307,7 +307,7 @@ spec:
                 - "5443"
                 - --global-namespace
                 - olm
-                image: {{default .Registries.OLM .ImageRepository}}/{{.Images.OLM}}
+                image: {{default .Registries.OLM .ImageRepository}}{{.Images.OLM}}
                 imagePullPolicy: Always
                 ports:
                 - containerPort: 5443
@@ -346,6 +346,6 @@ metadata:
   namespace: olm
 spec:
   sourceType: grpc
-  image: {{default .Registries.UpstreamCommunityOperators .ImageRepository}}/{{.Images.UpstreamCommunityOperators}}
+  image: {{default .Registries.UpstreamCommunityOperators .ImageRepository}}{{.Images.UpstreamCommunityOperators}}
   displayName: Community Operators
   publisher: OperatorHub.io

--- a/deploy/addons/registry-aliases/node-etc-hosts-update.tmpl
+++ b/deploy/addons/registry-aliases/node-etc-hosts-update.tmpl
@@ -17,7 +17,7 @@ spec:
     spec:
       initContainers:
         - name: update
-          image: {{default .Registries.Alpine .ImageRepository}}/{{.Images.Alpine}}
+          image: {{default .Registries.Alpine .ImageRepository}}{{.Images.Alpine}}
           volumeMounts:
             - name: etchosts
               mountPath: /host-etc/hosts
@@ -43,7 +43,7 @@ spec:
               echo "Done."
       containers:
         - name: pause-for-update
-          image: {{default .Registries.Pause .ImageRepository}}/{{.Images.Pause}}
+          image: {{default .Registries.Pause .ImageRepository}}{{.Images.Pause}}
       terminationGracePeriodSeconds: 30
       volumes:
         - name: etchosts

--- a/deploy/addons/registry-aliases/node-etc-hosts-update.tmpl
+++ b/deploy/addons/registry-aliases/node-etc-hosts-update.tmpl
@@ -17,7 +17,7 @@ spec:
     spec:
       initContainers:
         - name: update
-          image: {{default "docker.io" .ImageRepository}}/{{.Images.Alpine}}
+          image: {{default .Registries.Alpine .ImageRepository}}/{{.Images.Alpine}}
           volumeMounts:
             - name: etchosts
               mountPath: /host-etc/hosts
@@ -43,7 +43,7 @@ spec:
               echo "Done."
       containers:
         - name: pause-for-update
-          image: {{default "gcr.io" .ImageRepository}}/{{.Images.Pause}}
+          image: {{default .Registries.Pause .ImageRepository}}/{{.Images.Pause}}
       terminationGracePeriodSeconds: 30
       volumes:
         - name: etchosts

--- a/deploy/addons/registry-aliases/node-etc-hosts-update.tmpl
+++ b/deploy/addons/registry-aliases/node-etc-hosts-update.tmpl
@@ -17,7 +17,7 @@ spec:
     spec:
       initContainers:
         - name: update
-          image: {{default .Registries.Alpine .ImageRepository}}{{.Images.Alpine}}
+          image: {{.CustomRegistries.Alpine  | default .ImageRepository | default .Registries.Alpine }}{{.Images.Alpine}}
           volumeMounts:
             - name: etchosts
               mountPath: /host-etc/hosts
@@ -43,7 +43,7 @@ spec:
               echo "Done."
       containers:
         - name: pause-for-update
-          image: {{default .Registries.Pause .ImageRepository}}{{.Images.Pause}}
+          image: {{.CustomRegistries.Pause  | default .ImageRepository | default .Registries.Pause }}{{.Images.Pause}}
       terminationGracePeriodSeconds: 30
       volumes:
         - name: etchosts

--- a/deploy/addons/registry-aliases/node-etc-hosts-update.tmpl
+++ b/deploy/addons/registry-aliases/node-etc-hosts-update.tmpl
@@ -17,7 +17,7 @@ spec:
     spec:
       initContainers:
         - name: update
-          image: {{default "registry.hub.docker.com/library" .ImageRepository}}/alpine:3.11
+          image: {{default "docker.io" .ImageRepository}}/{{.Images.Alpine}}
           volumeMounts:
             - name: etchosts
               mountPath: /host-etc/hosts
@@ -43,7 +43,7 @@ spec:
               echo "Done."
       containers:
         - name: pause-for-update
-          image: {{default "gcr.io/google_containers" .ImageRepository}}/pause-amd64:3.1
+          image: {{default "gcr.io" .ImageRepository}}/{{.Images.Pause}}
       terminationGracePeriodSeconds: 30
       volumes:
         - name: etchosts

--- a/deploy/addons/registry-aliases/patch-coredns-job.tmpl
+++ b/deploy/addons/registry-aliases/patch-coredns-job.tmpl
@@ -15,7 +15,7 @@ spec:
            path: /var/lib/minikube/binaries
       containers:
        - name: core-dns-patcher
-         image:  {{default "quay.io/rhdevelopers" .ImageRepository}}/core-dns-patcher
+         image:  {{default "quay.io" .ImageRepository}}/{{.Images.CoreDNSPatcher}}
          imagePullPolicy: IfNotPresent
          # using the kubectl from the minikube instance
          volumeMounts:

--- a/deploy/addons/registry-creds/registry-creds-rc.yaml.tmpl
+++ b/deploy/addons/registry-creds/registry-creds-rc.yaml.tmpl
@@ -18,9 +18,9 @@ spec:
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:
-      - image: {{default .Registries.RegistryCreds .ImageRepository}}{{.Images.RegistryCreds}}
+      - image: {{.CustomRegistries.RegistryCreds  | default .ImageRepository | default .Registries.RegistryCreds }}{{.Images.RegistryCreds}}
         name: registry-creds
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         env:
           - name: AWS_ACCESS_KEY_ID
             valueFrom:

--- a/deploy/addons/registry-creds/registry-creds-rc.yaml.tmpl
+++ b/deploy/addons/registry-creds/registry-creds-rc.yaml.tmpl
@@ -18,7 +18,7 @@ spec:
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:
-      - image: {{default "upmcenterprises" .ImageRepository}}/registry-creds:1.10
+      - image: {{default "docker.io" .ImageRepository}}/{{.Images.RegistryCreds}}
         name: registry-creds
         imagePullPolicy: Always
         env:

--- a/deploy/addons/registry-creds/registry-creds-rc.yaml.tmpl
+++ b/deploy/addons/registry-creds/registry-creds-rc.yaml.tmpl
@@ -18,7 +18,7 @@ spec:
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:
-      - image: {{default .Registries.RegistryCreds .ImageRepository}}/{{.Images.RegistryCreds}}
+      - image: {{default .Registries.RegistryCreds .ImageRepository}}{{.Images.RegistryCreds}}
         name: registry-creds
         imagePullPolicy: Always
         env:

--- a/deploy/addons/registry-creds/registry-creds-rc.yaml.tmpl
+++ b/deploy/addons/registry-creds/registry-creds-rc.yaml.tmpl
@@ -18,7 +18,7 @@ spec:
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:
-      - image: {{default "docker.io" .ImageRepository}}/{{.Images.RegistryCreds}}
+      - image: {{default .Registries.RegistryCreds .ImageRepository}}/{{.Images.RegistryCreds}}
         name: registry-creds
         imagePullPolicy: Always
         env:

--- a/deploy/addons/registry/registry-proxy.yaml.tmpl
+++ b/deploy/addons/registry/registry-proxy.yaml.tmpl
@@ -19,7 +19,7 @@ spec:
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:
-      - image: {{default .Registries.KubeRegistryProxy .ImageRepository}}{{.Images.KubeRegistryProxy}}
+      - image: {{.CustomRegistries.KubeRegistryProxy  | default .ImageRepository | default .Registries.KubeRegistryProxy }}{{.Images.KubeRegistryProxy}}
         imagePullPolicy: IfNotPresent
         name: registry-proxy
         ports:

--- a/deploy/addons/registry/registry-proxy.yaml.tmpl
+++ b/deploy/addons/registry/registry-proxy.yaml.tmpl
@@ -19,7 +19,7 @@ spec:
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:
-      - image: {{default .Registries.KubeRegistryProxy .ImageRepository}}/{{.Images.KubeRegistryProxy}}
+      - image: {{default .Registries.KubeRegistryProxy .ImageRepository}}{{.Images.KubeRegistryProxy}}
         imagePullPolicy: IfNotPresent
         name: registry-proxy
         ports:

--- a/deploy/addons/registry/registry-proxy.yaml.tmpl
+++ b/deploy/addons/registry/registry-proxy.yaml.tmpl
@@ -19,7 +19,7 @@ spec:
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:
-      - image: {{default "gcr.io/google_containers" .ImageRepository}}/kube-registry-proxy:0.4
+      - image: {{default "gcr.io" .ImageRepository}}/{{.Images.KubeRegistryProxy}}
         imagePullPolicy: IfNotPresent
         name: registry-proxy
         ports:

--- a/deploy/addons/registry/registry-proxy.yaml.tmpl
+++ b/deploy/addons/registry/registry-proxy.yaml.tmpl
@@ -19,7 +19,7 @@ spec:
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:
-      - image: {{default "gcr.io" .ImageRepository}}/{{.Images.KubeRegistryProxy}}
+      - image: {{default .Registries.KubeRegistryProxy .ImageRepository}}/{{.Images.KubeRegistryProxy}}
         imagePullPolicy: IfNotPresent
         name: registry-proxy
         ports:

--- a/deploy/addons/registry/registry-rc.yaml.tmpl
+++ b/deploy/addons/registry/registry-rc.yaml.tmpl
@@ -18,7 +18,7 @@ spec:
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:
-      - image: {{default .Registries.Registry .ImageRepository}}/{{.Images.Registry}}
+      - image: {{default .Registries.Registry .ImageRepository}}{{.Images.Registry}}
         imagePullPolicy: IfNotPresent
         name: registry
         ports:

--- a/deploy/addons/registry/registry-rc.yaml.tmpl
+++ b/deploy/addons/registry/registry-rc.yaml.tmpl
@@ -18,7 +18,7 @@ spec:
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:
-      - image: {{default "docker.io" .ImageRepository}}/{{.Images.Registry}}
+      - image: {{default .Registries.Registry .ImageRepository}}/{{.Images.Registry}}
         imagePullPolicy: IfNotPresent
         name: registry
         ports:

--- a/deploy/addons/registry/registry-rc.yaml.tmpl
+++ b/deploy/addons/registry/registry-rc.yaml.tmpl
@@ -18,7 +18,7 @@ spec:
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:
-      - image: {{default .Registries.Registry .ImageRepository}}{{.Images.Registry}}
+      - image: {{.CustomRegistries.Registry  | default .ImageRepository | default .Registries.Registry }}{{.Images.Registry}}
         imagePullPolicy: IfNotPresent
         name: registry
         ports:

--- a/deploy/addons/registry/registry-rc.yaml.tmpl
+++ b/deploy/addons/registry/registry-rc.yaml.tmpl
@@ -18,7 +18,7 @@ spec:
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:
-      - image: {{default "registry.hub.docker.com/library" .ImageRepository}}/registry:2.7.1
+      - image: {{default "docker.io" .ImageRepository}}/{{.Images.Registry}}
         imagePullPolicy: IfNotPresent
         name: registry
         ports:

--- a/deploy/addons/storage-provisioner-gluster/glusterfs-daemonset.yaml.tmpl
+++ b/deploy/addons/storage-provisioner-gluster/glusterfs-daemonset.yaml.tmpl
@@ -31,7 +31,7 @@ spec:
       #  kubernetes.io/hostname: minikube
       hostNetwork: true
       containers:
-      - image: {{default .Registries.GlusterfsServer .ImageRepository}}{{.Images.GlusterfsServer}}
+      - image: {{.CustomRegistries.GlusterfsServer  | default .ImageRepository | default .Registries.GlusterfsServer }}{{.Images.GlusterfsServer}}
         imagePullPolicy: IfNotPresent
         name: glusterfs
         env:

--- a/deploy/addons/storage-provisioner-gluster/glusterfs-daemonset.yaml.tmpl
+++ b/deploy/addons/storage-provisioner-gluster/glusterfs-daemonset.yaml.tmpl
@@ -31,7 +31,7 @@ spec:
       #  kubernetes.io/hostname: minikube
       hostNetwork: true
       containers:
-      - image: {{default "quay.io" .ImageRepository}}/{{.Images.GlusterfsServer}}
+      - image: {{default .Registries.GlusterfsServer .ImageRepository}}/{{.Images.GlusterfsServer}}
         imagePullPolicy: IfNotPresent
         name: glusterfs
         env:

--- a/deploy/addons/storage-provisioner-gluster/glusterfs-daemonset.yaml.tmpl
+++ b/deploy/addons/storage-provisioner-gluster/glusterfs-daemonset.yaml.tmpl
@@ -31,7 +31,7 @@ spec:
       #  kubernetes.io/hostname: minikube
       hostNetwork: true
       containers:
-      - image: {{default .Registries.GlusterfsServer .ImageRepository}}/{{.Images.GlusterfsServer}}
+      - image: {{default .Registries.GlusterfsServer .ImageRepository}}{{.Images.GlusterfsServer}}
         imagePullPolicy: IfNotPresent
         name: glusterfs
         env:

--- a/deploy/addons/storage-provisioner-gluster/glusterfs-daemonset.yaml.tmpl
+++ b/deploy/addons/storage-provisioner-gluster/glusterfs-daemonset.yaml.tmpl
@@ -31,7 +31,7 @@ spec:
       #  kubernetes.io/hostname: minikube
       hostNetwork: true
       containers:
-      - image: {{default "quay.io/nixpanic" .ImageRepository}}/glusterfs-server:pr_fake-disk
+      - image: {{default "quay.io" .ImageRepository}}/{{.Images.GlusterfsServer}}
         imagePullPolicy: IfNotPresent
         name: glusterfs
         env:

--- a/deploy/addons/storage-provisioner-gluster/heketi-deployment.yaml.tmpl
+++ b/deploy/addons/storage-provisioner-gluster/heketi-deployment.yaml.tmpl
@@ -116,7 +116,7 @@ spec:
     spec:
       serviceAccountName: heketi-service-account
       containers:
-      - image: {{default .Registries.Heketi .ImageRepository}}{{.Images.Heketi}}
+      - image: {{.CustomRegistries.Heketi  | default .ImageRepository | default .Registries.Heketi }}{{.Images.Heketi}}
         imagePullPolicy: IfNotPresent
         name: heketi
         env:

--- a/deploy/addons/storage-provisioner-gluster/heketi-deployment.yaml.tmpl
+++ b/deploy/addons/storage-provisioner-gluster/heketi-deployment.yaml.tmpl
@@ -116,7 +116,7 @@ spec:
     spec:
       serviceAccountName: heketi-service-account
       containers:
-      - image: {{default "docker.io" .ImageRepository}}/{{.Images.Heketi}}
+      - image: {{default .Registries.Heketi .ImageRepository}}/{{.Images.Heketi}}
         imagePullPolicy: IfNotPresent
         name: heketi
         env:

--- a/deploy/addons/storage-provisioner-gluster/heketi-deployment.yaml.tmpl
+++ b/deploy/addons/storage-provisioner-gluster/heketi-deployment.yaml.tmpl
@@ -116,7 +116,7 @@ spec:
     spec:
       serviceAccountName: heketi-service-account
       containers:
-      - image: {{default .Registries.Heketi .ImageRepository}}/{{.Images.Heketi}}
+      - image: {{default .Registries.Heketi .ImageRepository}}{{.Images.Heketi}}
         imagePullPolicy: IfNotPresent
         name: heketi
         env:

--- a/deploy/addons/storage-provisioner-gluster/heketi-deployment.yaml.tmpl
+++ b/deploy/addons/storage-provisioner-gluster/heketi-deployment.yaml.tmpl
@@ -116,7 +116,7 @@ spec:
     spec:
       serviceAccountName: heketi-service-account
       containers:
-      - image: {{default "heketi" .ImageRepository}}/heketi:latest
+      - image: {{default "docker.io" .ImageRepository}}/{{.Images.Heketi}}
         imagePullPolicy: IfNotPresent
         name: heketi
         env:

--- a/deploy/addons/storage-provisioner-gluster/storage-provisioner-glusterfile.yaml.tmpl
+++ b/deploy/addons/storage-provisioner-gluster/storage-provisioner-glusterfile.yaml.tmpl
@@ -106,7 +106,7 @@ spec:
       serviceAccountName: glusterfile-provisioner
       containers:
       - name: glusterfile-provisioner
-        image: {{default "docker.io" .ImageRepository}}/{{.Images.GlusterfileProvisioner}}
+        image: {{default .Registries.GlusterfileProvisioner .ImageRepository}}/{{.Images.GlusterfileProvisioner}}
         imagePullPolicy: Always
         env:
         - name: PROVISIONER_NAME

--- a/deploy/addons/storage-provisioner-gluster/storage-provisioner-glusterfile.yaml.tmpl
+++ b/deploy/addons/storage-provisioner-gluster/storage-provisioner-glusterfile.yaml.tmpl
@@ -106,8 +106,8 @@ spec:
       serviceAccountName: glusterfile-provisioner
       containers:
       - name: glusterfile-provisioner
-        image: {{default .Registries.GlusterfileProvisioner .ImageRepository}}{{.Images.GlusterfileProvisioner}}
-        imagePullPolicy: Always
+        image: {{.CustomRegistries.GlusterfileProvisioner  | default .ImageRepository | default .Registries.GlusterfileProvisioner }}{{.Images.GlusterfileProvisioner}}
+        imagePullPolicy: IfNotPresent
         env:
         - name: PROVISIONER_NAME
           value: gluster.org/glusterfile

--- a/deploy/addons/storage-provisioner-gluster/storage-provisioner-glusterfile.yaml.tmpl
+++ b/deploy/addons/storage-provisioner-gluster/storage-provisioner-glusterfile.yaml.tmpl
@@ -106,7 +106,7 @@ spec:
       serviceAccountName: glusterfile-provisioner
       containers:
       - name: glusterfile-provisioner
-        image: {{default .Registries.GlusterfileProvisioner .ImageRepository}}/{{.Images.GlusterfileProvisioner}}
+        image: {{default .Registries.GlusterfileProvisioner .ImageRepository}}{{.Images.GlusterfileProvisioner}}
         imagePullPolicy: Always
         env:
         - name: PROVISIONER_NAME

--- a/deploy/addons/storage-provisioner-gluster/storage-provisioner-glusterfile.yaml.tmpl
+++ b/deploy/addons/storage-provisioner-gluster/storage-provisioner-glusterfile.yaml.tmpl
@@ -106,7 +106,7 @@ spec:
       serviceAccountName: glusterfile-provisioner
       containers:
       - name: glusterfile-provisioner
-        image: {{default "gluster" .ImageRepository}}/glusterfile-provisioner:latest
+        image: {{default "docker.io" .ImageRepository}}/{{.Images.GlusterfileProvisioner}}
         imagePullPolicy: Always
         env:
         - name: PROVISIONER_NAME

--- a/deploy/addons/storage-provisioner/storage-provisioner.yaml.tmpl
+++ b/deploy/addons/storage-provisioner/storage-provisioner.yaml.tmpl
@@ -100,7 +100,7 @@ spec:
   hostNetwork: true
   containers:
   - name: storage-provisioner
-    image: {{default .Registries.StorageProvisioner .ImageRepository}}{{.Images.StorageProvisioner}}
+    image: {{.CustomRegistries.StorageProvisioner  | default .ImageRepository | default .Registries.StorageProvisioner }}{{.Images.StorageProvisioner}}
     command: ["/storage-provisioner"]
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/deploy/addons/storage-provisioner/storage-provisioner.yaml.tmpl
+++ b/deploy/addons/storage-provisioner/storage-provisioner.yaml.tmpl
@@ -100,7 +100,7 @@ spec:
   hostNetwork: true
   containers:
   - name: storage-provisioner
-    image: {{default .Registries.StorageProvisioner .ImageRepository}}/{{.Images.StorageProvisioner}}
+    image: {{default .Registries.StorageProvisioner .ImageRepository}}{{.Images.StorageProvisioner}}
     command: ["/storage-provisioner"]
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/deploy/addons/storage-provisioner/storage-provisioner.yaml.tmpl
+++ b/deploy/addons/storage-provisioner/storage-provisioner.yaml.tmpl
@@ -100,7 +100,7 @@ spec:
   hostNetwork: true
   containers:
   - name: storage-provisioner
-    image: {{default "gcr.io/k8s-minikube" .ImageRepository}}/storage-provisioner:{{.StorageProvisionerVersion}}
+    image: {{default "gcr.io" .ImageRepository}}/{{.Images.StorageProvisioner}}
     command: ["/storage-provisioner"]
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/deploy/addons/storage-provisioner/storage-provisioner.yaml.tmpl
+++ b/deploy/addons/storage-provisioner/storage-provisioner.yaml.tmpl
@@ -100,7 +100,7 @@ spec:
   hostNetwork: true
   containers:
   - name: storage-provisioner
-    image: {{default "gcr.io" .ImageRepository}}/{{.Images.StorageProvisioner}}
+    image: {{default .Registries.StorageProvisioner .ImageRepository}}/{{.Images.StorageProvisioner}}
     command: ["/storage-provisioner"]
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/deploy/addons/volumesnapshots/volume-snapshot-controller-deployment.yaml.tmpl
+++ b/deploy/addons/volumesnapshots/volume-snapshot-controller-deployment.yaml.tmpl
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: volume-snapshot-controller
           # TODO(xyang): Replace with an official image when it is released
-          image: {{default .Registries.SnapshotController .ImageRepository}}{{.Images.SnapshotController}}
+          image: {{.CustomRegistries.SnapshotController  | default .ImageRepository | default .Registries.SnapshotController }}{{.Images.SnapshotController}}
           args:
             - "--v=5"
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent

--- a/deploy/addons/volumesnapshots/volume-snapshot-controller-deployment.yaml.tmpl
+++ b/deploy/addons/volumesnapshots/volume-snapshot-controller-deployment.yaml.tmpl
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: volume-snapshot-controller
           # TODO(xyang): Replace with an official image when it is released
-          image: {{default "gcr.io/k8s-staging-csi" .ImageRepository}}/snapshot-controller:v2.0.0-rc2
+          image: {{default "gcr.io" .ImageRepository}}/{{.Images.SnapshotController}}
           args:
             - "--v=5"
           imagePullPolicy: Always

--- a/deploy/addons/volumesnapshots/volume-snapshot-controller-deployment.yaml.tmpl
+++ b/deploy/addons/volumesnapshots/volume-snapshot-controller-deployment.yaml.tmpl
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: volume-snapshot-controller
           # TODO(xyang): Replace with an official image when it is released
-          image: {{default "gcr.io" .ImageRepository}}/{{.Images.SnapshotController}}
+          image: {{default .Registries.SnapshotController .ImageRepository}}/{{.Images.SnapshotController}}
           args:
             - "--v=5"
           imagePullPolicy: Always

--- a/deploy/addons/volumesnapshots/volume-snapshot-controller-deployment.yaml.tmpl
+++ b/deploy/addons/volumesnapshots/volume-snapshot-controller-deployment.yaml.tmpl
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: volume-snapshot-controller
           # TODO(xyang): Replace with an official image when it is released
-          image: {{default .Registries.SnapshotController .ImageRepository}}/{{.Images.SnapshotController}}
+          image: {{default .Registries.SnapshotController .ImageRepository}}{{.Images.SnapshotController}}
           args:
             - "--v=5"
           imagePullPolicy: Always

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -209,7 +209,7 @@ https://github.com/kubernetes/minikube/issues/7332`, out.V{"driver_name": cc.Dri
 		return errors.Wrap(err, "command runner")
 	}
 
-	data := assets.GenerateTemplateData(cc.KubernetesConfig)
+	data := assets.GenerateTemplateData(addon, cc.KubernetesConfig)
 	return enableOrDisableAddonInternal(cc, addon, cmd, data, enable)
 }
 

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -634,7 +634,7 @@ func GenerateTemplateData(addon *Addon, cfg config.KubernetesConfig) interface{}
 	if images != "" {
 		for _, image := range strings.Split(images, ",") {
 			vals := strings.Split(image, "=")
-			if len(vals) != 2 {
+			if len(vals) != 2 || vals[1] == "" {
 				out.WarningT("Ignoring invalid custom image {{.conf}}", out.V{"conf": image})
 				continue
 			}
@@ -654,7 +654,7 @@ func GenerateTemplateData(addon *Addon, cfg config.KubernetesConfig) interface{}
 	if registries != "" {
 		for _, registry := range strings.Split(registries, ",") {
 			vals := strings.Split(registry, "=")
-			if len(vals) != 2 {
+			if len(vals) != 2 || vals[1] == "" {
 				out.WarningT("Ignoring invalid custom registry {{.conf}}", out.V{"conf": registry})
 				continue
 			}
@@ -668,7 +668,7 @@ func GenerateTemplateData(addon *Addon, cfg config.KubernetesConfig) interface{}
 
 	// Append postfix "/" to registries
 	for k, v := range opts.Registries {
-		if !strings.HasSuffix(opts.Registries[k], "/") {
+		if opts.Registries[k] != "" && !strings.HasSuffix(opts.Registries[k], "/") {
 			opts.Registries[k] = v + "/"
 		}
 	}

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -654,7 +654,7 @@ func GenerateTemplateData(addon *Addon, cfg config.KubernetesConfig) interface{}
 	if registries != "" {
 		for _, registry := range strings.Split(registries, ",") {
 			vals := strings.Split(registry, "=")
-			if len(vals) != 2 || vals[1] == "" {
+			if len(vals) != 2 {
 				out.WarningT("Ignoring invalid custom registry {{.conf}}", out.V{"conf": registry})
 				continue
 			}

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -521,16 +521,18 @@ func GenerateTemplateData(addon *Addon, cfg config.KubernetesConfig) interface{}
 	}
 
 	images := viper.GetString(config.AddonImages)
-	for _, image := range strings.Split(images, ",") {
-		vals := strings.Split(image, "=")
-		if len(vals) != 2 {
-			out.WarningT("Ignoring invalid custom image {{.conf}}", out.V{"conf": image})
-			continue
+	if images != "" {
+		for _, image := range strings.Split(images, ",") {
+			vals := strings.Split(image, "=")
+			if len(vals) != 2 {
+				out.WarningT("Ignoring invalid custom image {{.conf}}", out.V{"conf": image})
+				continue
+			}
+			if defaultImage, ok := opts.Images[vals[0]]; ok {
+				out.Infof("Using {{.image}} instead default image {{.default}}", out.V{"image": vals[1], "name": defaultImage})
+			}
+			opts.Images[vals[0]] = vals[1]
 		}
-		if defaultImage, ok := opts.Images[vals[0]]; ok {
-			out.Infof("Using {{.image}} instead default image {{.default}}", out.V{"image": vals[1], "name": defaultImage})
-		}
-		opts.Images[vals[0]] = vals[1]
 	}
 
 	return opts

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/out"
+	"k8s.io/minikube/pkg/minikube/style"
 	"k8s.io/minikube/pkg/minikube/vmpath"
 	"k8s.io/minikube/pkg/version"
 )
@@ -86,10 +87,7 @@ var Addons = map[string]*Addon{
 	}, false, "dashboard", map[string]string{
 		"Dashboard":      "kubernetesui/dashboard:v2.1.0",
 		"MetricsScraper": "kubernetesui/metrics-scraper:v1.0.4",
-	}, map[string]string{
-		"Dashboard":      "docker.io",
-		"MetricsScraper": "docker.io",
-	}),
+	}, nil),
 	"default-storageclass": NewAddon([]*BinAsset{
 		MustBinAsset(
 			"deploy/addons/storageclass/storageclass.yaml.tmpl",
@@ -141,9 +139,7 @@ var Addons = map[string]*Addon{
 		"GlusterfileProvisioner": "gluster/glusterfile-provisioner:latest",
 		"GlusterfsServer":        "nixpanic/glusterfs-server:pr_fake-disk",
 	}, map[string]string{
-		"Heketi":                 "docker.io",
-		"GlusterfileProvisioner": "docker.io",
-		"GlusterfsServer":        "quay.io",
+		"GlusterfsServer": "quay.io",
 	}),
 	"efk": NewAddon([]*BinAsset{
 		MustBinAsset(
@@ -184,7 +180,6 @@ var Addons = map[string]*Addon{
 	}, map[string]string{
 		"Elasticsearch":        "k8s.gcr.io",
 		"FluentdElasticsearch": "k8s.gcr.io",
-		"Alpine":               "docker.io",
 		"Kibana":               "docker.elastic.co",
 	}),
 	"ingress": NewAddon([]*BinAsset{
@@ -208,9 +203,7 @@ var Addons = map[string]*Addon{
 		"KubeWebhookCertgenCreate": "jettech/kube-webhook-certgen:v1.2.2",
 		"KubeWebhookCertgenPatch":  "jettech/kube-webhook-certgen:v1.3.0",
 	}, map[string]string{
-		"IngressController":        "us.gcr.io",
-		"KubeWebhookCertgenCreate": "docker.io",
-		"KubeWebhookCertgenPatch":  "docker.io",
+		"IngressController": "us.gcr.io",
 	}),
 	"istio-provisioner": NewAddon([]*BinAsset{
 		MustBinAsset(
@@ -220,9 +213,7 @@ var Addons = map[string]*Addon{
 			"0640"),
 	}, false, "istio-provisioner", map[string]string{
 		"IstioOperator": "istio/operator:1.5.0",
-	}, map[string]string{
-		"IstioOperator": "docker.io",
-	}),
+	}, nil),
 	"istio": NewAddon([]*BinAsset{
 		MustBinAsset(
 			"deploy/addons/istio/istio-default-profile.yaml.tmpl",
@@ -238,9 +229,7 @@ var Addons = map[string]*Addon{
 			"0640"),
 	}, false, "kubevirt", map[string]string{
 		"Kubectl": "bitnami/kubectl:1.17",
-	}, map[string]string{
-		"Kubectl": "docker.io",
-	}),
+	}, nil),
 	"metrics-server": NewAddon([]*BinAsset{
 		MustBinAsset(
 			"deploy/addons/metrics-server/metrics-apiservice.yaml.tmpl",
@@ -300,7 +289,6 @@ var Addons = map[string]*Addon{
 		"Registry":          "registry:2.7.1",
 		"KubeRegistryProxy": "google_containers/kube-registry-proxy:0.4",
 	}, map[string]string{
-		"Registry":          "docker.io",
 		"KubeRegistryProxy": "gcr.io",
 	}),
 	"registry-creds": NewAddon([]*BinAsset{
@@ -311,9 +299,7 @@ var Addons = map[string]*Addon{
 			"0640"),
 	}, false, "registry-creds", map[string]string{
 		"RegistryCreds": "upmcenterprises/registry-creds:1.10",
-	}, map[string]string{
-		"RegistryCreds": "docker.io",
-	}),
+	}, nil),
 	"registry-aliases": NewAddon([]*BinAsset{
 		MustBinAsset(
 			"deploy/addons/registry-aliases/registry-aliases-sa.tmpl",
@@ -346,7 +332,6 @@ var Addons = map[string]*Addon{
 		"Pause":          "google_containers/pause-amd64:3.1",
 	}, map[string]string{
 		"CoreDNSPatcher": "quay.io",
-		"Alpine":         "docker.io",
 		"Pause":          "gcr.io",
 	}),
 	"freshpod": NewAddon([]*BinAsset{
@@ -381,9 +366,7 @@ var Addons = map[string]*Addon{
 			"0640"),
 	}, false, "nvidia-gpu-device-plugin", map[string]string{
 		"NvidiaDevicePlugin": "nvidia/k8s-device-plugin:1.0.0-beta4",
-	}, map[string]string{
-		"NvidiaDevicePlugin": "docker.io",
-	}),
+	}, nil),
 	"logviewer": NewAddon([]*BinAsset{
 		MustBinAsset(
 			"deploy/addons/logviewer/logviewer-dp-and-svc.yaml.tmpl",
@@ -397,9 +380,7 @@ var Addons = map[string]*Addon{
 			"0640"),
 	}, false, "logviewer", map[string]string{
 		"LogViewer": "ivans3/minikube-log-viewer:latest",
-	}, map[string]string{
-		"LogViewer": "docker.io",
-	}),
+	}, nil),
 	"gvisor": NewAddon([]*BinAsset{
 		MustBinAsset(
 			"deploy/addons/gvisor/gvisor-pod.yaml.tmpl",
@@ -450,9 +431,7 @@ var Addons = map[string]*Addon{
 			"0640"),
 	}, false, "ingress-dns", map[string]string{
 		"IngressDNS": "cryptexlabs/minikube-ingress-dns:0.3.0",
-	}, map[string]string{
-		"IngressDNS": "docker.io",
-	}),
+	}, nil),
 	"metallb": NewAddon([]*BinAsset{
 		MustBinAsset(
 			"deploy/addons/metallb/metallb.yaml.tmpl",
@@ -467,10 +446,7 @@ var Addons = map[string]*Addon{
 	}, false, "metallb", map[string]string{
 		"Speaker":    "metallb/speaker:v0.8.2",
 		"Controller": "metallb/controller:v0.8.2",
-	}, map[string]string{
-		"Speaker":    "docker.io",
-		"Controller": "docker.io",
-	}),
+	}, nil),
 	"ambassador": NewAddon([]*BinAsset{
 		MustBinAsset(
 			"deploy/addons/ambassador/ambassador-operator-crds.yaml.tmpl",
@@ -512,8 +488,7 @@ var Addons = map[string]*Addon{
 		"KubeWebhookCertgen": "jettech/kube-webhook-certgen:v1.3.0",
 		"GCPAuthWebhook":     "k8s-minikube/gcp-auth-webhook:v0.0.3",
 	}, map[string]string{
-		"KubeWebhookCertgen": "docker.io",
-		"GCPAuthWebhook":     "gcr.io",
+		"GCPAuthWebhook": "gcr.io",
 	}),
 	"volumesnapshots": NewAddon([]*BinAsset{
 		MustBinAsset(
@@ -663,12 +638,47 @@ func GenerateTemplateData(addon *Addon, cfg config.KubernetesConfig) interface{}
 				out.WarningT("Ignoring invalid custom image {{.conf}}", out.V{"conf": image})
 				continue
 			}
-			if defaultImage, ok := opts.Images[vals[0]]; ok {
-				out.Infof("Using {{.image}} instead default image {{.default}}", out.V{"image": vals[1], "name": defaultImage})
+			if _, ok := opts.Images[vals[0]]; ok {
+				opts.Images[vals[0]] = vals[1]
+			} else {
+				out.WarningT("Ignoring unknown custom image {{.name}}", out.V{"name": vals[0]})
 			}
-			opts.Images[vals[0]] = vals[1]
 		}
 	}
 
+	if opts.Registries == nil {
+		opts.Registries = make(map[string]string)
+	}
+
+	registries := viper.GetString(config.AddonRegistries)
+	if registries != "" {
+		for _, registry := range strings.Split(registries, ",") {
+			vals := strings.Split(registry, "=")
+			if len(vals) != 2 {
+				out.WarningT("Ignoring invalid custom registry {{.conf}}", out.V{"conf": registry})
+				continue
+			}
+			if _, ok := opts.Registries[vals[0]]; ok {
+				opts.Registries[vals[0]] = vals[1]
+			} else {
+				out.WarningT("Ignoring unknown custom registry {{.name}}", out.V{"name": vals[0]})
+			}
+		}
+	}
+
+	// Append postfix "/" to registries
+	for k, v := range opts.Registries {
+		if !strings.HasSuffix(opts.Registries[k], "/") {
+			opts.Registries[k] = v + "/"
+		}
+	}
+
+	for name, image := range opts.Images {
+		if _, ok := opts.Registries[name]; !ok {
+			opts.Registries[name] = "" // Avoid nil access when rendering
+		}
+		// Send messages to stderr due to some tests rely on stdout
+		out.ErrT(style.Option, "Using image {{.registry}}{{.image}}", out.V{"registry": opts.Registries[name], "image": image})
+	}
 	return opts
 }

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -639,6 +639,7 @@ func GenerateTemplateData(addon *Addon, cfg config.KubernetesConfig) interface{}
 		LoadBalancerEndIP   string
 		CustomIngressCert   string
 		Images              map[string]string
+		Registries          map[string]string
 	}{
 		Arch:                a,
 		ExoticArch:          ea,
@@ -647,6 +648,7 @@ func GenerateTemplateData(addon *Addon, cfg config.KubernetesConfig) interface{}
 		LoadBalancerEndIP:   cfg.LoadBalancerEndIP,
 		CustomIngressCert:   cfg.CustomIngressCert,
 		Images:              addon.Images,
+		Registries:          addon.Registries,
 	}
 
 	if opts.Images == nil {

--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -52,6 +52,8 @@ const (
 	UserFlag = "user"
 	// AddonImages stores custom addon images config
 	AddonImages = "addon-images"
+	// AddonRegistries stores custom addon images config
+	AddonRegistries = "addon-registries"
 )
 
 var (

--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -50,6 +50,8 @@ const (
 	ShowBootstrapperDeprecationNotification = "ShowBootstrapperDeprecationNotification"
 	// UserFlag is the key for the global user flag (ex. --user=user1)
 	UserFlag = "user"
+	// AddonImages stores custom addon images config
+	AddonImages = "addon-images"
 )
 
 var (

--- a/site/content/en/docs/commands/addons.md
+++ b/site/content/en/docs/commands/addons.md
@@ -109,20 +109,27 @@ minikube addons disable ADDON_NAME [flags]
 
 ## minikube addons enable
 
-Enables the addon w/ADDON_NAME within minikube (example: minikube addons enable dashboard). For a list of available addons use: minikube addons list 
+Enables the addon w/ADDON_NAME within minikube. For a list of available addons use: minikube addons list 
 
 ### Synopsis
 
-Enables the addon w/ADDON_NAME within minikube (example: minikube addons enable dashboard). For a list of available addons use: minikube addons list 
+Enables the addon w/ADDON_NAME within minikube. For a list of available addons use: minikube addons list 
 
 ```shell
 minikube addons enable ADDON_NAME [flags]
 ```
 
+### Examples
+
+```
+minikube addons enable dashboard
+```
+
 ### Options
 
 ```
-      --images string   Alpha feature. Image names used by this addon. Divided by comma.
+      --images string       Images used by this addon. Divided by comma.
+      --registries string   Registries used by this addon. Divided by comma.
 ```
 
 ### Options inherited from parent commands

--- a/site/content/en/docs/commands/addons.md
+++ b/site/content/en/docs/commands/addons.md
@@ -128,8 +128,8 @@ minikube addons enable dashboard
 ### Options
 
 ```
-      --images string       Images used by this addon. Divided by comma.
-      --registries string   Registries used by this addon. Divided by comma.
+      --images string       Images used by this addon. Separated by commas.
+      --registries string   Registries used by this addon. Separated by commas.
 ```
 
 ### Options inherited from parent commands

--- a/site/content/en/docs/commands/addons.md
+++ b/site/content/en/docs/commands/addons.md
@@ -119,6 +119,12 @@ Enables the addon w/ADDON_NAME within minikube (example: minikube addons enable 
 minikube addons enable ADDON_NAME [flags]
 ```
 
+### Options
+
+```
+      --images string   Alpha feature. Image names used by this addon. Divided by comma.
+```
+
 ### Options inherited from parent commands
 
 ```
@@ -172,6 +178,39 @@ minikube addons help [command] [flags]
       --skip_log_headers                 If true, avoid headers when opening log files
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
       --user string                      Specifies the user executing the operation. Useful for auditing operations executed by 3rd party tools. Defaults to the operating system username.
+  -v, --v Level                          number for the log level verbosity
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+```
+
+## minikube addons images
+
+Alpha feature. List image names the addon w/ADDON_NAME used (example: minikube addons images ingress). For a list of available addons use: minikube addons list
+
+### Synopsis
+
+Alpha feature. List image names the addon w/ADDON_NAME used (example: minikube addons images ingress). For a list of available addons use: minikube addons list
+
+```shell
+minikube addons images ADDON_NAME [flags]
+```
+
+### Options inherited from parent commands
+
+```
+      --add_dir_header                   If true, adds the file directory to the header of the log messages
+      --alsologtostderr                  log to standard error as well as files
+  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
+  -h, --help                             
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --log_file string                  If non-empty, use this log file
+      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+      --logtostderr                      log to standard error instead of files
+      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level
+  -p, --profile string                   The name of the minikube VM being used. This can be set to allow having multiple instances of minikube independently. (default "minikube")
+      --skip_headers                     If true, avoid header prefixes in the log messages
+      --skip_log_headers                 If true, avoid headers when opening log files
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          number for the log level verbosity
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/site/content/en/docs/commands/addons.md
+++ b/site/content/en/docs/commands/addons.md
@@ -184,14 +184,20 @@ minikube addons help [command] [flags]
 
 ## minikube addons images
 
-Alpha feature. List image names the addon w/ADDON_NAME used (example: minikube addons images ingress). For a list of available addons use: minikube addons list
+List image names the addon w/ADDON_NAME used. For a list of available addons use: minikube addons list
 
 ### Synopsis
 
-Alpha feature. List image names the addon w/ADDON_NAME used (example: minikube addons images ingress). For a list of available addons use: minikube addons list
+List image names the addon w/ADDON_NAME used. For a list of available addons use: minikube addons list
 
 ```shell
 minikube addons images ADDON_NAME [flags]
+```
+
+### Examples
+
+```
+minikube addons images ingress
 ```
 
 ### Options inherited from parent commands

--- a/site/content/en/docs/commands/addons.md
+++ b/site/content/en/docs/commands/addons.md
@@ -224,6 +224,7 @@ minikube addons images ingress
       --skip_headers                     If true, avoid header prefixes in the log messages
       --skip_log_headers                 If true, avoid headers when opening log files
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+      --user string                      Specifies the user executing the operation. Useful for auditing operations executed by 3rd party tools. Defaults to the operating system username.
   -v, --v Level                          number for the log level verbosity
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/site/content/en/docs/handbook/addons/custom-images.md
+++ b/site/content/en/docs/handbook/addons/custom-images.md
@@ -1,0 +1,57 @@
+---
+title: "Config the Addon to Use Custom Registries and Images"
+linkTitle: "Custom Images"
+weight: 2
+date: 2021-01-13
+---
+
+If you have trouble to access default images, or want to use images from a private registry or local version, you could achieve
+this by flag `--images` and `--registries`.
+
+We defined and named all images used by an addon, you could view them by command `addons images`:
+
+```shell
+minikube addons images efk
+```
+
+```
+    ▪ efk has following images:
+|----------------------|------------------------------|-------------------|
+|      IMAGE NAME      |        DEFAULT IMAGE         | DEFAULT REGISTRY  |
+|----------------------|------------------------------|-------------------|
+| Elasticsearch        | elasticsearch:v5.6.2         | k8s.gcr.io        |
+| FluentdElasticsearch | fluentd-elasticsearch:v2.0.2 | k8s.gcr.io        |
+| Alpine               | alpine:3.6                   |                   |
+| Kibana               | kibana/kibana:5.6.2          | docker.elastic.co |
+|----------------------|------------------------------|-------------------|
+```
+
+The `DEFAULT IMAGE` and `DEFAULT REGISTRY` columns indicate which images are used by default.
+An empty registry means the image is stored locally or default registry `docker.io`.
+
+The `IMAGE NAME` column is used to customize the corresponding image and registry.
+
+Assume we have a private registry at `localhost:5555` to replace `k8s.gcr.io` and a locally built Kibana called `kibana/kibana:5.6.2-custom`.
+
+We could load local images to minikube by:
+
+```shell
+minikube cache add kibana/kibana:5.6.2-custom
+```
+
+Then we can start `efk` addon with flags `--images` and `--registries`.
+The format is `IMAGE_NAME=CUSTOM_VALUE`, separated by commas, where the `IMAGE_NAME` is the value of `IMAGE NAME` column in the table above.
+
+```shell
+minikube addons enable efk --images="Kibana=kibana/kibana:5.6.2-custom" --registries="Kibana=,Elasticsearch=localhost:5555,FluentdElasticsearch=localhost:5555"
+```
+
+```
+    ▪ Using image localhost:5555/elasticsearch:v5.6.2
+    ▪ Using image localhost:5555/fluentd-elasticsearch:v2.0.2
+    ▪ Using image alpine:3.6
+    ▪ Using image kibana/kibana:5.6.2-custom
+🌟  The 'efk' addon is enabled
+```
+
+Now the `efk` addon is using the custom registry and images.

--- a/site/content/en/docs/handbook/addons/custom-images.md
+++ b/site/content/en/docs/handbook/addons/custom-images.md
@@ -31,7 +31,7 @@ An empty registry means the image is stored locally or default registry `docker.
 
 The `IMAGE NAME` column is used to customize the corresponding image and registry.
 
-Assume we have a private registry at `localhost:5555` to replace `k8s.gcr.io` and a locally built Kibana called `kibana/kibana:5.6.2-custom`.
+Assume we have a private registry at `192.168.10.2:5555` to replace `k8s.gcr.io` and a locally built Kibana called `kibana/kibana:5.6.2-custom`.
 
 We could load local images to minikube by:
 
@@ -43,12 +43,12 @@ Then we can start `efk` addon with flags `--images` and `--registries`.
 The format is `IMAGE_NAME=CUSTOM_VALUE`, separated by commas, where the `IMAGE_NAME` is the value of `IMAGE NAME` column in the table above.
 
 ```shell
-minikube addons enable efk --images="Kibana=kibana/kibana:5.6.2-custom" --registries="Kibana=,Elasticsearch=localhost:5555,FluentdElasticsearch=localhost:5555"
+minikube addons enable efk --images="Kibana=kibana/kibana:5.6.2-custom" --registries="Kibana=,Elasticsearch=192.168.10.2:5555,FluentdElasticsearch=192.168.10.2:5555"
 ```
 
 ```
-    ▪ Using image localhost:5555/elasticsearch:v5.6.2
-    ▪ Using image localhost:5555/fluentd-elasticsearch:v2.0.2
+    ▪ Using image 192.168.10.2:5555/elasticsearch:v5.6.2
+    ▪ Using image 192.168.10.2:5555/fluentd-elasticsearch:v2.0.2
     ▪ Using image alpine:3.6
     ▪ Using image kibana/kibana:5.6.2-custom
 🌟  The 'efk' addon is enabled


### PR DESCRIPTION
Signed-off-by: Ling Samuel <lingsamuelgrace@gmail.com>

Currently addon image names are hardcoded, see #10063.

This PR move images to golang instead of yaml (currently migrated: ingress). To fully support #10063, we need to migrate all yaml template to the format this PR used.

Fixes #10063

Changes:
- name all images in yaml, store them in `Addon` struct
- add param `--images` for `addons enable`, format is: `ImageName=Image,ImageName2=Image2`
- add param `--registries` for `addons enable`, format is: `ImageName=Registry,ImageName2=Registry2`. Empty is okay (will use docker.io).
- add command `addon images` to view how many images the addon requires, and images name used above
- fix several `ImageRepository` mistakes in yaml template

Examples:
Custom 1 image (newest `images` output see below):
![image](https://user-images.githubusercontent.com/14567045/103981813-89f2ed80-51bd-11eb-949c-d1ef4f2f77f2.png)

Custom 2 images:
![image](https://user-images.githubusercontent.com/14567045/104158623-b199be00-5428-11eb-9c03-346ef822be0b.png)

Custom image and registry:
![image](https://user-images.githubusercontent.com/14567045/104210066-65bd3800-546d-11eb-9401-8e5faabe17e1.png)

`addons images ingress`:
![image](https://user-images.githubusercontent.com/14567045/104210313-addc5a80-546d-11eb-8447-1d891ebf3905.png)


Note:
- ingress yaml using different version `kube-webhook-certgen`, I am not sure if it's by design, so I keep this as is.
- OLM image `quay.io/operator-framework/olm@sha256:0d15ffb5d10a176ef6e831d7865f98d51255ea5b0d16403618c94a004d049373` is `0.14.1`:
![image](https://user-images.githubusercontent.com/14567045/104189734-0acc1680-5456-11eb-9f59-04f1726e3817.png)