### PR TITLE
Don't allow profile names that conflict with a multi-node name

### DIFF
--- a/pkg/minikube/config/profile.go
+++ b/pkg/minikube/config/profile.go
@@ -223,7 +223,25 @@ func ListProfiles(miniHome ...string) (validPs []*Profile, inValidPs []*Profile,
 	return validPs, inValidPs, nil
 }
 
-// removeDupes removes duplicates
+// ListValidProfiles returns profiles in minikube home dir
+// Unlike `ListProfiles` this function doens't try to get profile from container
+func ListValidProfiles(miniHome ...string) (ps []*Profile, err error) {
+	// try to get profiles list based on left over evidences such as directory
+	pDirs, err := profileDirs(miniHome...)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, n := range pDirs {
+		p, err := LoadProfile(n, miniHome...)
+		if err == nil && p.IsValid() {
+			ps = append(ps, p)
+		}
+	}
+	return ps, nil
+}
+
+// removeDupes removes duplipcates
 func removeDupes(profiles []string) []string {
 	// Use map to record duplicates as we find them.
 	seen := map[string]bool{}
@@ -291,7 +309,7 @@ func ProfileFolderPath(profile string, miniHome ...string) string {
 // MachineName returns the name of the machine, as seen by the hypervisor given the cluster and node names
 func MachineName(cc ClusterConfig, n Node) string {
 	// For single node cluster, default to back to old naming
-	if len(cc.Nodes) == 1 || n.ControlPlane {
+	if (len(cc.Nodes) == 1 && cc.Nodes[0].Name == n.Name) || n.ControlPlane {
 		return cc.Name
 	}
 	return fmt.Sprintf("%s-%s", cc.Name, n.Name)

--- a/pkg/minikube/machine/cluster_test.go
+++ b/pkg/minikube/machine/cluster_test.go
@@ -146,10 +146,8 @@ func TestStartHostExists(t *testing.T) {
 	mc := defaultClusterConfig
 	mc.Name = ih.Name
 
-	n := config.Node{Name: ih.Name}
-
 	// This should pass without calling Create because the host exists already.
-	h, _, err := StartHost(api, &mc, &n)
+	h, _, err := StartHost(api, &mc, &(mc.Nodes[0]))
 	if err != nil {
 		t.Fatalf("Error starting host: %v", err)
 	}

--- a/pkg/minikube/node/node.go
+++ b/pkg/minikube/node/node.go
@@ -38,6 +38,24 @@ const (
 
 // Add adds a new node config to an existing cluster.
 func Add(cc *config.ClusterConfig, n config.Node, delOnFail bool) error {
+	profiles, err := config.ListValidProfiles()
+	if err != nil {
+		return err
+	}
+
+	machineName := config.MachineName(*cc, n)
+	for _, p := range profiles {
+		if p.Config.Name == cc.Name {
+			continue
+		}
+
+		for _, existNode := range p.Config.Nodes {
+			if machineName == config.MachineName(*p.Config, existNode) {
+				return errors.Errorf("Node %s already exists in %s profile", machineName, p.Name)
+			}
+		}
+	}
+
 	if err := config.SaveNode(cc, &n); err != nil {
 		return errors.Wrap(err, "save node")
 	}


### PR DESCRIPTION
Check profile and node name before add to prevent conflict with
machine name on multinode cluster.

Fixes #10061
