### PR TITLE
disable scheduled stop service on minikube start

### DIFF
--- a/pkg/minikube/schedule/daemonize_windows.go
+++ b/pkg/minikube/schedule/daemonize_windows.go
@@ -100,8 +100,12 @@ func startSystemdService(profile string, duration time.Duration) error {
 		return errors.Wrap(err, "copying scheduled stop env file")
 	}
 	// restart scheduled stop service in container
-	sysManger := sysinit.New(runner)
-	return sysManger.Restart(constants.ScheduledStopSystemdService)
+	sysManager := sysinit.New(runner)
+	// enable scheduled stop service
+	if err := sysManager.Enable(constants.ScheduledStopSystemdService); err != nil {
+		return err
+	}
+	return sysManager.Start(constants.ScheduledStopSystemdService)
 }
 
 // return the contents of the environment file for minikube-scheduled-stop systemd service


### PR DESCRIPTION
Signed-off-by: Tharun <rajendrantharun@live.com>

Fixes #9865

@priyawadhwa I am able to do the `enable` the service only when scheduled-stop is initiated. But I went through different docs and references to make `systemd` services to be in an idle state. Need your help on this part. 