### PR TITLE
Add spinner stop in err messages

### DIFF
--- a/pkg/minikube/out/out.go
+++ b/pkg/minikube/out/out.go
@@ -180,6 +180,10 @@ func Err(format string, a ...interface{}) {
 
 	klog.Warningf(format, a...)
 
+	// if spin is active from a previous step, it will stop spinner displaying
+	if spin.Active() {
+		spin.Stop()
+	}
 	_, err := fmt.Fprintf(errFile, format, a...)
 	if err != nil {
 		klog.Errorf("Fprint failed: %v", err)


### PR DESCRIPTION
This PR fixes #10125

![image](https://user-images.githubusercontent.com/13793894/104327293-9b3b4300-54b8-11eb-87c6-79ffe16c3423.png)

The problem was that the error message (fmt.Fprintf) was printed after `out.Step ()`, and there was never any way to stop the spiner, so the spinner never stops and spinner has no break line so err message continued in the same line.

In this err message it looks like this:
![image](https://user-images.githubusercontent.com/13793894/104329575-0ede4f80-54bb-11eb-9670-e3a4ff3d1cb6.png)


<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
