### PR TITLE
arm64: Fix offline start by removing obsolete arch suffix

### DIFF
--- a/pkg/minikube/bootstrapper/images/images.go
+++ b/pkg/minikube/bootstrapper/images/images.go
@@ -20,7 +20,6 @@ package images
 import (
 	"fmt"
 	"path"
-	"runtime"
 
 	"github.com/blang/semver"
 	"k8s.io/minikube/pkg/version"
@@ -34,7 +33,7 @@ func Pause(v semver.Version, mirror string) string {
 	if semver.MustParseRange("<1.18.0-alpha.0")(v) {
 		pv = "3.1"
 	}
-	return path.Join(kubernetesRepo(mirror), "pause"+archTag(false)+pv)
+	return path.Join(kubernetesRepo(mirror), "pause:"+pv)
 }
 
 // essentials returns images needed too bootstrap a Kubernetes
@@ -53,13 +52,7 @@ func essentials(mirror string, v semver.Version) []string {
 
 // componentImage returns a Kubernetes component image to pull
 func componentImage(name string, v semver.Version, mirror string) string {
-	needsArchSuffix := false
-	ancient := semver.MustParseRange("<1.12.0")
-	if ancient(v) {
-		needsArchSuffix = true
-	}
-
-	return fmt.Sprintf("%sv%s", path.Join(kubernetesRepo(mirror), name+archTag(needsArchSuffix)), v)
+	return fmt.Sprintf("%s:v%s", path.Join(kubernetesRepo(mirror), name), v)
 }
 
 // coreDNS returns the images used for CoreDNS
@@ -83,17 +76,11 @@ func coreDNS(v semver.Version, mirror string) string {
 	case 11:
 		cv = "1.1.3"
 	}
-	return path.Join(kubernetesRepo(mirror), "coredns"+":"+cv)
+	return path.Join(kubernetesRepo(mirror), "coredns:"+cv)
 }
 
 // etcd returns the image used for etcd
 func etcd(v semver.Version, mirror string) string {
-	needsArchSuffix := false
-	ancient := semver.MustParseRange("<1.12.0")
-	if ancient(v) {
-		needsArchSuffix = true
-	}
-
 	// Should match `DefaultEtcdVersion` in:
 	// https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/constants/constants.go
 	ev := "3.4.13-0"
@@ -116,15 +103,7 @@ func etcd(v semver.Version, mirror string) string {
 		ev = "3.4.9-1"
 	}
 
-	return path.Join(kubernetesRepo(mirror), "etcd"+archTag(needsArchSuffix)+ev)
-}
-
-// archTag returns a CPU architecture suffix for images
-func archTag(hasTag bool) string {
-	if runtime.GOARCH == "amd64" && !hasTag {
-		return ":"
-	}
-	return "-" + runtime.GOARCH + ":"
+	return path.Join(kubernetesRepo(mirror), "etcd:"+ev)
 }
 
 // auxiliary returns images that are helpful for running minikube
@@ -139,7 +118,7 @@ func auxiliary(mirror string) []string {
 
 // storageProvisioner returns the minikube storage provisioner image
 func storageProvisioner(mirror string) string {
-	return path.Join(minikubeRepo(mirror), "storage-provisioner"+archTag(false)+version.GetStorageProvisionerVersion())
+	return path.Join(minikubeRepo(mirror), "storage-provisioner:"+version.GetStorageProvisionerVersion())
 }
 
 // dashboardFrontend returns the image used for the dashboard frontend


### PR DESCRIPTION
This PR removes the `archTag()` function, which added a  `-<arch>` suffix to image names.

It has behaved incorrectly for non-x86 platforms for at least the last year, as this suffix hasn't been used since Kubernetes v1.12 (no longer supported). This PR fixes the following error message on macOS/arm64:

`E0114 14:24:35.028160   82660 cache.go:63] save image to file "k8s.gcr.io/etcd-arm64:3.4.13-0" -> "/Users/t/.minikube/cache/images/k8s.gcr.io/etcd-arm64_3.4.13-0" failed: nil image for k8s.gcr.io/etcd-arm64:3.4.13-0: GET https://k8s.gcr.io/v2/etcd-arm64/manifests/3.4.13-0: MANIFEST_UNKNOWN: Failed to fetch "3.4.13-0" from request "/v2/etcd-arm64/manifests/3.4.13-0"`

It also happens to mean that `minikube start` now functions in offline-mode on arm64.

Here's a demonstration of the newly error-free output on arm64, with preload disabled (output looks identical either way):

```
😄  minikube v1.16.0 on Darwin 11.1 (arm64)
✨  Automatically selected the docker driver
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=1981MB) ...
🐳  Preparing Kubernetes v1.20.0 on Docker 20.10.2 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```


