### PR TITLE
Update docs VMware Fusion mount location.

### DIFF
--- a/site/content/en/docs/handbook/mount.md
+++ b/site/content/en/docs/handbook/mount.md
@@ -72,7 +72,7 @@ Some hypervisors, have built-in host folder sharing. Driver mounts are reliable 
 | VirtualBox | Linux | /home | /hosthome |
 | VirtualBox | macOS | /Users | /Users |
 | VirtualBox | Windows | C://Users | /c/Users |
-| VMware Fusion | macOS | /Users | /Users |
+| VMware Fusion | macOS | /Users | /mnt/hgfs/Users |
 | KVM | Linux | Unsupported | |
 | HyperKit | Linux | Unsupported (see NFS mounts) | |
 


### PR DESCRIPTION
I noticed the mount does not end up in `/Users`, but in `/mnt/hgfs/Users` using the following start command:

```
minikube start --vm-driver=vmware --mount-string=/Users:/Users
```

Source: https://github.com/kubernetes/website/pull/18674/files

