### PR TITLE
Avoid warning about the suggested memory size

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -95,7 +95,7 @@ const (
 	waitTimeout             = "wait-timeout"
 	nativeSSH               = "native-ssh"
 	minUsableMem            = 1800 // Kubernetes (kubeadm) will not start with less
-	minRecommendedMem       = 2000 // Warn at no lower than existing configurations
+	minRecommendedMem       = 1900 // Warn at no lower than existing configurations
 	minimumCPUS             = 2
 	minimumDiskSize         = 2000
 	autoUpdate              = "auto-update-drivers"


### PR DESCRIPTION
The recommendation is to use (at least) 2048 MB *for the VM*,
which means that you will end up something like 1992 MB total.
We should not issue warnings when using the recommended size,
so lower the limit to 1900 MB (kubeadm will validate 1700 MB).

The reason it is broken is because it uses different values
for different drivers, if running a VM or on Bare Metal...
There is also no difference anymore between the "usable"
and the "recommended", so this will need revisiting later.
