### PR TITLE
Add minikube cp command as new feature

### DIFF
--- a/cmd/minikube/cmd/cp.go
+++ b/cmd/minikube/cmd/cp.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"k8s.io/minikube/pkg/minikube/assets"
+	"k8s.io/minikube/pkg/minikube/exit"
+	"k8s.io/minikube/pkg/minikube/mustload"
+	"k8s.io/minikube/pkg/minikube/out"
+	"k8s.io/minikube/pkg/minikube/reason"
+)
+
+// placeholders for flag values
+var (
+	srcPath string
+	dstPath string
+)
+
+// cpCmd represents the cp command, similar to docker cp
+var cpCmd = &cobra.Command{
+	Use:   "cp <source file path> <target file path followed by '/home/docker/'>",
+	Short: "Copy the specified file into minikube",
+	Long: "Copy the specified file into minikube, it will be saved at path \"/home/docker/<target file path>\" in your minikube.\n" +
+		"Example Command : \"minikube cp a.txt b.txt\"\n",
+	Run: func(cmd *cobra.Command, args []string) {
+		// validate args
+		if len(args) != 2 {
+			exit.Message(reason.Usage, `Please specify the path to copy: 
+	minikube cp <source file path> <target file path>   (example: "minikube cp a/b/c/d.txt a.txt")`)
+		}
+		srcPath = args[0]
+		dstPath = args[1]
+
+		co := mustload.Running(ClusterFlagValue())
+		fa, err := assets.NewFileAsset(srcPath, "/home/docker/", dstPath, "0644")
+		if err != nil {
+			out.ErrLn("%v", errors.Wrap(err, "getting file asset"))
+			os.Exit(1)
+		}
+		if err = co.CP.Runner.Copy(fa); err != nil {
+			out.ErrLn("%v", errors.Wrap(err, "copying file"))
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+}

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -243,6 +243,7 @@ func init() {
 				sshCmd,
 				kubectlCmd,
 				nodeCmd,
+				cpCmd,
 			},
 		},
 		{

--- a/site/content/en/docs/commands/cp.md
+++ b/site/content/en/docs/commands/cp.md
@@ -11,12 +11,12 @@ Copy the specified file into minikube
 
 ### Synopsis
 
-Copy the specified file into minikube, it will be saved at path "/home/docker/<target file path>" in your minikube.
-Example Command : "minikube cp a.txt b.txt"
+Copy the specified file into minikube, it will be saved at path <target file absolute path> in your minikube.
+Example Command : "minikube cp a.txt /home/docker/b.txt"
 
 
 ```shell
-minikube cp <source file path> <target file path followed by '/home/docker/'> [flags]
+minikube cp <source file path> <target file absolute path> [flags]
 ```
 
 ### Options inherited from parent commands

--- a/site/content/en/docs/commands/cp.md
+++ b/site/content/en/docs/commands/cp.md
@@ -1,0 +1,43 @@
+---
+title: "cp"
+description: >
+  Copy the specified file into minikube
+---
+
+
+## minikube cp
+
+Copy the specified file into minikube
+
+### Synopsis
+
+Copy the specified file into minikube, it will be saved at path "/home/docker/<target file path>" in your minikube.
+Example Command : "minikube cp a.txt b.txt"
+
+
+```shell
+minikube cp <source file path> <target file path followed by '/home/docker/'> [flags]
+```
+
+### Options inherited from parent commands
+
+```
+      --add_dir_header                   If true, adds the file directory to the header of the log messages
+      --alsologtostderr                  log to standard error as well as files
+  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
+  -h, --help                             
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --log_file string                  If non-empty, use this log file
+      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+      --logtostderr                      log to standard error instead of files
+      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level
+  -p, --profile string                   The name of the minikube VM being used. This can be set to allow having multiple instances of minikube independently. (default "minikube")
+      --skip_headers                     If true, avoid header prefixes in the log messages
+      --skip_log_headers                 If true, avoid headers when opening log files
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+      --user string                      Specifies the user executing the operation. Useful for auditing operations executed by 3rd party tools. Defaults to the operating system username.
+  -v, --v Level                          number for the log level verbosity
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+```
+

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -1151,7 +1151,7 @@ func validateCpCmd(ctx context.Context, t *testing.T, profile string) {
 	}
 
 	cpPath := filepath.Join(*testdataDir, "cp-test.txt")
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "cp", cpPath, "hello_cp.txt"))
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "cp", cpPath, "/home/docker/hello_cp.txt"))
 	if ctx.Err() == context.DeadlineExceeded {
 		t.Errorf("failed to run command by deadline. exceeded timeout : %s", rr.Command())
 	}
@@ -1160,7 +1160,7 @@ func validateCpCmd(ctx context.Context, t *testing.T, profile string) {
 	}
 
 	expected := "Test file for checking file cp process"
-	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "cat hello_cp.txt"))
+	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "cat /home/docker/hello_cp.txt"))
 	if ctx.Err() == context.DeadlineExceeded {
 		t.Errorf("failed to run command by deadline. exceeded timeout : %s", rr.Command())
 	}

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -123,6 +123,7 @@ func TestFunctional(t *testing.T) {
 			{"PersistentVolumeClaim", validatePersistentVolumeClaim},
 			{"TunnelCmd", validateTunnelCmd},
 			{"SSHCmd", validateSSHCmd},
+			{"CpCmd", validateCpCmd},
 			{"MySQL", validateMySQL},
 			{"FileSync", validateFileSync},
 			{"CertSync", validateCertSync},
@@ -1140,6 +1141,34 @@ func validateSSHCmd(ctx context.Context, t *testing.T, profile string) {
 	// trailing whitespace differs between native and external SSH clients, so let's trim it and call it a day
 	if strings.TrimSpace(rr.Stdout.String()) != want {
 		t.Errorf("expected minikube ssh command output to be -%q- but got *%q*. args %q", want, rr.Stdout.String(), rr.Command())
+	}
+}
+
+// validateCpCmd asserts basic "cp" command functionality
+func validateCpCmd(ctx context.Context, t *testing.T, profile string) {
+	if NoneDriver() {
+		t.Skipf("skipping: cp is unsupported by none driver")
+	}
+
+	cpPath := filepath.Join(*testdataDir, "cp-test.txt")
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "cp", cpPath, "hello_cp.txt"))
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Errorf("failed to run command by deadline. exceeded timeout : %s", rr.Command())
+	}
+	if err != nil {
+		t.Errorf("failed to run an cp command. args %q : %v", rr.Command(), err)
+	}
+
+	expected := "Test file for checking file cp process"
+	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "cat hello_cp.txt"))
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Errorf("failed to run command by deadline. exceeded timeout : %s", rr.Command())
+	}
+	if err != nil {
+		t.Errorf("failed to run an cp command. args %q : %v", rr.Command(), err)
+	}
+	if diff := cmp.Diff(expected, rr.Stdout.String()); diff != "" {
+		t.Errorf("/testdata/cp-test.txt content mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/test/integration/testdata/cp-test.txt
+++ b/test/integration/testdata/cp-test.txt
@@ -1,0 +1,1 @@
+Test file for checking file cp process


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

Add New Feature which represents scp command

Until now, it is possible to copy specific local file to specific path in minikube basically.
I mean 'basically' since it is possible to only file not directory.
And there are many more remaining tasks until now. (remaining problems are written in source code as `//TODO`)

Fix #9930