### PR TITLE
increase legacy minikube version for TestStoppedBinaryUpgrade to 1.6.2

### DIFF
--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -122,8 +122,7 @@ func TestStoppedBinaryUpgrade(t *testing.T) {
 	defer CleanupWithLogs(t, profile, cancel)
 
 	// Guarantee stopped upgrade compatibility from a release that is at least 1 year old
-	// NOTE: <v1.4.0 does not automatically install a hyperkit/KVM driver
-	legacyVersion := "v1.0.0"
+	legacyVersion := "v1.6.2"
 
 	if KicDriver() {
 		// first release with non-experimental KIC


### PR DESCRIPTION
We're occasionally seeing a very old bug associated with minikube versions from 1.0.0 and before when trying to start minikube. Making the old version of minikube we test slightly newer should decrease those flakes.