### PR TITLE
integration test: improve TestUpgrade to use legacy kubeconfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,6 +301,7 @@ integration-versioned: out/minikube ## Trigger minikube integration testing, log
 .PHONY: functional
 functional: integration-functional-only
 
+
 .PHONY: integration-functional-only
 integration-functional-only: out/minikube$(IS_EXE) ## Trigger only functioanl tests in integration test, logs to ./out/testout_COMMIT.txt
 	go test -ldflags="${MINIKUBE_LDFLAGS}" -v -test.timeout=20m $(INTEGRATION_TESTS_TO_RUN) --tags="$(MINIKUBE_INTEGRATION_BUILD_TAGS)" $(TEST_ARGS) -test.run TestFunctional 2>&1 | tee "./out/testout_$(COMMIT_SHORT).txt"

--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,6 @@ integration-versioned: out/minikube ## Trigger minikube integration testing, log
 .PHONY: functional
 functional: integration-functional-only
 
-
 .PHONY: integration-functional-only
 integration-functional-only: out/minikube$(IS_EXE) ## Trigger only functioanl tests in integration test, logs to ./out/testout_COMMIT.txt
 	go test -ldflags="${MINIKUBE_LDFLAGS}" -v -test.timeout=20m $(INTEGRATION_TESTS_TO_RUN) --tags="$(MINIKUBE_INTEGRATION_BUILD_TAGS)" $(TEST_ARGS) -test.run TestFunctional 2>&1 | tee "./out/testout_$(COMMIT_SHORT).txt"

--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -63,7 +63,7 @@ func legacyStartArgs() []string {
 	return strings.Split(strings.Replace(*startArgs, "--driver", "--vm-driver", -1), " ")
 }
 
-// TestRunningBinaryUpgrade does an upgrade test on a running cluster
+// TestRunningBinaryUpgrade upgrades a running legacy cluster to head minikube
 func TestRunningBinaryUpgrade(t *testing.T) {
 	// not supported till v1.10, and passing new images to old releases isn't supported anyways
 	if TestingKicBaseImage() {
@@ -127,7 +127,7 @@ func TestRunningBinaryUpgrade(t *testing.T) {
 	}
 }
 
-// TestStoppedBinaryUpgrade does an upgrade test on a stopped cluster
+// TestStoppedBinaryUpgrade starts a legacy minikube and stops it and then upgrades to head minikube
 func TestStoppedBinaryUpgrade(t *testing.T) {
 	// not supported till v1.10, and passing new images to old releases isn't supported anyways
 	if TestingKicBaseImage() {

--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -92,7 +92,26 @@ func TestRunningBinaryUpgrade(t *testing.T) {
 	args := append([]string{"start", "-p", profile, "--memory=2200"}, legacyStartArgs()...)
 	rr := &RunResult{}
 	r := func() error {
-		rr, err = Run(t, exec.CommandContext(ctx, tf.Name(), args...))
+		c := exec.CommandContext(ctx, tf.Name(), args...)
+		legacyEnv := []string{}
+		// replace the global KUBECONFIG with a fresh kubeconfig
+		// because for minikube<1.17.0 it can not read the new kubeconfigs that have extra "Extenions" block
+		// see: https://github.com/kubernetes/minikube/issues/10210
+		for _, e := range os.Environ() {
+			if !strings.Contains(e, "KUBECONFIG") { // get all global envs except the Kubeconfig which is used by new versions of minikubes
+				legacyEnv = append(legacyEnv, e)
+			}
+		}
+		// using a fresh kubeconfig for this test
+		legacyKubeConfig, err := ioutil.TempFile("", "legacy_kubeconfig")
+		if err != nil {
+			t.Fatalf("failed to create temp file for legacy kubeconfig %v", err)
+		}
+
+		defer os.Remove(legacyKubeConfig.Name()) // clean up
+		legacyEnv = append(legacyEnv, fmt.Sprintf("KUBECONFIG=%s", legacyKubeConfig.Name()))
+		c.Env = legacyEnv
+		rr, err = Run(t, c)
 		return err
 	}
 

--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -141,9 +141,9 @@ func TestStoppedBinaryUpgrade(t *testing.T) {
 	r := func() error {
 		c := exec.CommandContext(ctx, tf.Name(), args...)
 		legacyEnv := []string{}
-		// replace KUBECONFIG env glboally with our own one for this test
-		// because older minikube than 1.17.0 can not read the new kubeconfigs with "Extenions"
-		// https://github.com/kubernetes/minikube/issues/10210
+		// replace the global KUBECONFIG with a fresh kubeconfig
+		// because for minikube<1.17.0 it can not read the new kubeconfigs that have extra "Extenions" block
+		// see: https://github.com/kubernetes/minikube/issues/10210
 		for _, e := range os.Environ() {
 			if !strings.Contains(e, "KUBECONFIG") { // get all global envs except the Kubeconfig which is used by new versions of minikubes
 				legacyEnv = append(legacyEnv, e)


### PR DESCRIPTION
closes https://github.com/kubernetes/minikube/issues/10210