### PR TITLE
configure the crictl yaml file to avoid the warning

### DIFF
--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -84,7 +84,10 @@ func (r *Docker) Version() (string, error) {
 
 // SocketPath returns the path to the socket file for Docker
 func (r *Docker) SocketPath() string {
-	return r.Socket
+	if r.Socket != "" {
+		return r.Socket
+	}
+	return "/var/run/dockershim.sock"
 }
 
 // Available returns an error if it is not possible to use this runtime on a host
@@ -106,6 +109,10 @@ func (r *Docker) Enable(disOthers, forceSystemd bool) error {
 		if err := disableOthers(r, r.Runner); err != nil {
 			klog.Warningf("disableOthers: %v", err)
 		}
+	}
+
+	if err := populateCRIConfig(r.Runner, r.SocketPath()); err != nil {
+		return err
 	}
 
 	if forceSystemd {

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -286,12 +286,7 @@ func testPulledImages(ctx context.Context, t *testing.T, profile string, version
 		Tags []string `json:"repoTags"`
 	}{}
 
-	// crictl includes warnings in STDOUT before printing JSON output
-	// this step trims the warnings before JSON output begins
-	// See #10175 for details on fixing these warnings
 	stdout := rr.Stdout.String()
-	index := strings.Index(stdout, "{")
-	stdout = stdout[index:]
 
 	err = json.Unmarshal([]byte(stdout), &jv)
 	if err != nil {


### PR DESCRIPTION
fixes #10175

Kubernetes doesn't require crictl for docker, until the cri-dockerd is in use.
Adding the /etc/crictl.yaml to avoid the crictl warning.
Tested locally.
