### PR TITLE
Fix TestForceSystemdFlag tests on containerd

### DIFF
--- a/test/integration/docker_test.go
+++ b/test/integration/docker_test.go
@@ -85,14 +85,14 @@ func TestForceSystemdFlag(t *testing.T) {
 	containerRuntime := ContainerRuntime()
 	switch containerRuntime {
 	case "docker":
-		validateDockerSystemd(t, ctx, profile)
+		validateDockerSystemd(ctx, t, profile)
 	case "containerd":
-		validateContainerdSystemd(t, ctx, profile)
+		validateContainerdSystemd(ctx, t, profile)
 	}
 
 }
 
-func validateDockerSystemd(t *testing.T, ctx context.Context, profile string) {
+func validateDockerSystemd(ctx context.Context, t *testing.T, profile string) {
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "docker info --format {{.CgroupDriver}}"))
 	if err != nil {
 		t.Errorf("failed to get docker cgroup driver. args %q: %v", rr.Command(), err)
@@ -102,7 +102,7 @@ func validateDockerSystemd(t *testing.T, ctx context.Context, profile string) {
 	}
 }
 
-func validateContainerdSystemd(t *testing.T, ctx context.Context, profile string) {
+func validateContainerdSystemd(ctx context.Context, t *testing.T, profile string) {
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "cat /etc/containerd/config.toml"))
 	if err != nil {
 		t.Errorf("failed to get docker cgroup driver. args %q: %v", rr.Command(), err)
@@ -132,8 +132,8 @@ func TestForceSystemdEnv(t *testing.T) {
 	containerRuntime := ContainerRuntime()
 	switch containerRuntime {
 	case "docker":
-		validateDockerSystemd(t, ctx, profile)
+		validateDockerSystemd(ctx, t, profile)
 	case "containerd":
-		validateContainerdSystemd(t, ctx, profile)
+		validateContainerdSystemd(ctx, t, profile)
 	}
 }

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -129,6 +129,17 @@ func KicDriver() bool {
 	return DockerDriver() || PodmanDriver()
 }
 
+// ContainerRuntime returns the name of a specific container runtime if it was specified
+func ContainerRuntime() string {
+	flag := "--container-runtime="
+	for _, s := range StartArgs() {
+		if strings.HasPrefix(s, flag) {
+			return strings.TrimPrefix(s, flag)
+		}
+	}
+	return "docker"
+}
+
 // GithubActionRunner returns true if running inside a github action runner
 func GithubActionRunner() bool {
 	// based on https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables


### PR DESCRIPTION
Currently, the tests assume the docker runtime. Fix them to work for containerd as well.

We could add support for crio to this test as well. However, I think this is of lower importance because crio defaults to systemd as cgroup manager anyways.