### PR TITLE
Fix TestFunctional subtests to run for all three runtimes

### DIFF
--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -699,9 +699,19 @@ func validateLogsCmd(ctx context.Context, t *testing.T, profile string) {
 	if err != nil {
 		t.Errorf("%s failed: %v", rr.Command(), err)
 	}
-	for _, word := range []string{"Docker", "apiserver", "Linux", "kubelet"} {
+	expectedWords := []string{"apiserver", "Linux", "kubelet"}
+	switch ContainerRuntime() {
+	case "docker":
+		expectedWords = append(expectedWords, "Docker")
+	case "containerd":
+		expectedWords = append(expectedWords, "containerd")
+	case "crio":
+		expectedWords = append(expectedWords, "crio")
+	}
+
+	for _, word := range expectedWords {
 		if !strings.Contains(rr.Stdout.String(), word) {
-			t.Errorf("excpeted minikube logs to include word: -%q- but got \n***%s***\n", word, rr.Output())
+			t.Errorf("expected minikube logs to include word: -%q- but got \n***%s***\n", word, rr.Output())
 		}
 	}
 }

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -617,7 +617,16 @@ func validateCacheCmd(ctx context.Context, t *testing.T, profile string) {
 		t.Run("cache_reload", func(t *testing.T) { // deleting image inside minikube node manually and expecting reload to bring it back
 			img := "k8s.gcr.io/pause:latest"
 			// deleting image inside minikube node manually
-			rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "sudo", "docker", "rmi", img))
+
+			var binary string
+			switch ContainerRuntime() {
+			case "docker":
+				binary = "docker"
+			case "containerd", "crio":
+				binary = "crictl"
+			}
+
+			rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "sudo", binary, "rmi", img))
 
 			if err != nil {
 				t.Errorf("failed to manually delete image %q : %v", rr.Command(), err)


### PR DESCRIPTION
Currently,  TestFunctional/serial/CacheCmd/cache/cache_reload and TestFunctional/parallel/LogsCmd are failing on containerd because they assume the docker container runtime. [failure gopogh](https://storage.googleapis.com/minikube-builds/logs/10225/35ba15b/Docker_Linux_containerd.html)

This change should fix subtests for all three runtimes.





