### PR TITLE
Add resource requests & limits for mysql test

### DIFF
--- a/test/integration/testdata/mysql.yaml
+++ b/test/integration/testdata/mysql.yaml
@@ -24,8 +24,15 @@ spec:
         app: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mysql:5.7
         name: mysql
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "600m"           
+          limits:
+            memory: "700Mi"
+            cpu: "700m"
         env:
           # Use secret in real usage
         - name: MYSQL_ROOT_PASSWORD


### PR DESCRIPTION
fixes #10185 

Deployments under test/integration do not contain resource limits & requests. By adding limits & requests, it will prevent over consuming the node resources