### PR TITLE
add resource limit for my sql pod in case it cause oom on node

### DIFF
--- a/test/integration/testdata/mysql.yaml
+++ b/test/integration/testdata/mysql.yaml
@@ -25,6 +25,11 @@ spec:
     spec:
       containers:
       - image: mysql:5.6
+        resources:
+          requests:
+            memory: "500Mi"
+          limits:
+            memory: "550Mi"      
         name: mysql
         env:
           # Use secret in real usage


### PR DESCRIPTION
We do see flakiness of test due to OOM issue, so add limit for mysql pod which consume the most memory in the integration test.

The flakiness test issue:https://github.com/kubernetes/minikube/issues/10130

