### PR TITLE
Run CNI tests on containerd

### DIFF
--- a/test/integration/net_test.go
+++ b/test/integration/net_test.go
@@ -34,7 +34,9 @@ import (
 
 func TestNetworkPlugins(t *testing.T) {
 	MaybeParallel(t)
-	validations(t)
+	if NoneDriver() {
+		t.Skip("skipping since test for none driver")
+	}
 
 	t.Run("group", func(t *testing.T) {
 		tests := []struct {
@@ -203,13 +205,4 @@ func TestNetworkPlugins(t *testing.T) {
 			})
 		}
 	})
-}
-
-func validations(t *testing.T) {
-	if NoneDriver() {
-		t.Skip("skipping since test for none driver")
-	}
-	if ContainerdContainerRuntime() {
-		t.Skip("skipping as this test currently times out on containerd")
-	}
 }


### PR DESCRIPTION
Previously was skipping these tests as they were timing out, let's try turning them back on now that most of the other containerd tests have been fixed.