### PR TITLE
Make the ssh driver opt-in and not default

### DIFF
--- a/pkg/minikube/registry/drvs/ssh/ssh.go
+++ b/pkg/minikube/registry/drvs/ssh/ssh.go
@@ -35,7 +35,7 @@ func init() {
 		Alias:    []string{driver.AliasSSH},
 		Config:   configure,
 		Status:   status,
-		Priority: registry.Fallback,
+		Priority: registry.Discouraged, // requires external VM
 		Init:     func() drivers.Driver { return ssh.NewDriver(ssh.Config{}) },
 	})
 	if err != nil {


### PR DESCRIPTION
It needs an external VM with an IP address

Closes: #10268

BEFORE

```
* Automatically selected the ssh driver
* Starting control plane node minikube in cluster minikube

X Exiting due to GUEST_PROVISION: Failed to start host: config: please provide an IP address
```

AFTER

```
* Unable to pick a default driver. Here is what was considered, in preference order:
  - virtualbox: Not installed: unable to find VBoxManage in $PATH
  - vmware: Not installed: exec: "docker-machine-driver-vmware": executable file not found in $PATH
  - docker: Not installed: exec: "docker": executable file not found in $PATH
  - kvm2: Not installed: exec: "virsh": executable file not found in $PATH
  - podman: Not installed: exec: "podman": executable file not found in $PATH

X Exiting due to DRV_NOT_DETECTED: No possible driver was detected. Try specifying --driver, or see https://minikube.sigs.k8s.io/docs/start/
```
