### PR TITLE
The gopsutil cpu implementation changed in v3

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -979,8 +979,8 @@ func validateCPUCount(drvName string) {
 	var cpuCount int
 	if driver.BareMetal(drvName) {
 
-		// Uses the gopsutil cpu package to count the number of physical cpu cores
-		ci, err := cpu.Counts(false)
+		// Uses the gopsutil cpu package to count the number of logical cpu cores
+		ci, err := cpu.Counts(true)
 		if err != nil {
 			klog.Warningf("Unable to get CPU info: %v", err)
 		} else {

--- a/pkg/minikube/machine/info.go
+++ b/pkg/minikube/machine/info.go
@@ -181,6 +181,7 @@ var (
 //  cachedCPUInfo will return a cached cpu info
 func cachedCPUInfo() ([]cpu.InfoStat, error) {
 	if cachedCPU == nil {
+		// one InfoStat per thread
 		i, err := cpu.Info()
 		cachedCPU = &i
 		cachedCPUErr = &err


### PR DESCRIPTION
Was supposed to return the number of vCPU (i.e. nproc)
Before, both "physical" and "logical" returned the same.

The returned information should match cpuinfo and lscpu:
    CPU(s) = Socket(s) x Core(s) each x Thread(s) each

Closes #10260
