### PR TITLE
Fix small bug in TestStartStop

### DIFF
--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -85,7 +85,7 @@ func TestStartStop(t *testing.T) {
 				if !strings.Contains(tc.name, "docker") && NoneDriver() {
 					t.Skipf("skipping %s - incompatible with none driver", t.Name())
 				}
-				if strings.Contains(tc.name, "disable_driver_mounts") && !VirtualboxDriver() {
+				if strings.Contains(tc.name, "disable-driver-mounts") && !VirtualboxDriver() {
 					t.Skipf("skipping %s - only runs on virtualbox", t.Name())
 				}
 


### PR DESCRIPTION
We only want to run the disable-driver-mounts test on virtualbox. The test name is disable-driver-mounts, but right now we are checking for disable_driver_mounts 