### PR TITLE
ssh: validate the ssh-key parameter if given

### DIFF
--- a/pkg/drivers/ssh/ssh.go
+++ b/pkg/drivers/ssh/ssh.go
@@ -18,12 +18,15 @@ package ssh
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
 	"path"
 	"strconv"
 	"time"
+
+	"golang.org/x/crypto/ssh"
 
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/engine"
@@ -101,6 +104,16 @@ func (d *Driver) PreCreateCheck() error {
 	if d.SSHKey != "" {
 		if _, err := os.Stat(d.SSHKey); os.IsNotExist(err) {
 			return fmt.Errorf("SSH key does not exist: %q", d.SSHKey)
+		}
+
+		key, err := ioutil.ReadFile(d.SSHKey)
+		if err != nil {
+			return err
+		}
+
+		_, err = ssh.ParsePrivateKey(key)
+		if err != nil {
+			return errors.Wrapf(err, "SSH key does not parse: %q", d.SSHKey)
 		}
 	}
 


### PR DESCRIPTION
Fixes the old (2016) TODO* from docker-machine, and might help to troubleshoot #10289

\* https://github.com/docker/machine/blob/bd45ab13d88c32a3dd701485983354514abc41fa/drivers/generic/generic.go#L114

BEFORE:

🤦  StartHost failed, but will try again: creating host: create: creating: usermod: NewSession: new client: new client: Error creating new native config from ssh using: vagrant, &{[] [/home/anders/.minikube/machines/minikube/bogus]}: ssh: no key found

AFTER:

`precreate: SSH key does not parse: "/tmp/bogus": ssh: no key found`