### PR TITLE
Add support for goimports as well as go fmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -418,6 +418,15 @@ gofmt: ## Run go fmt and list the files differs from gofmt's
 vet: ## Run go vet
 	@go vet $(SOURCE_PACKAGES)
 
+.PHONY: imports
+imports: ## Run goimports and modify files in place
+	@goimports -w $(SOURCE_DIRS)
+
+.PHONY: goimports
+goimports: ## Run goimports and list the files differs from goimport's
+	@goimports -l $(SOURCE_DIRS)
+	@test -z "`goimports -l $(SOURCE_DIRS)`"
+
 .PHONY: golint
 golint: pkg/minikube/assets/assets.go pkg/minikube/translate/translations.go ## Run golint
 	@golint -set_exit_status $(SOURCE_PACKAGES)


### PR DESCRIPTION
Convenience targets, instead of "make lint"

Because golangci-lint is so big and slow...

----

I usually only run `go fmt` on my own patches.

And then get reprimanded by CI for `goimports`.