### PR TITLE
ssh: support default key path for built-in ssh

### DIFF
--- a/pkg/minikube/sshutil/sshutil.go
+++ b/pkg/minikube/sshutil/sshutil.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"net"
 	"os"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
+	"k8s.io/client-go/util/homedir"
 	"k8s.io/klog/v2"
 
 	"k8s.io/minikube/pkg/util/retry"
@@ -40,9 +42,12 @@ func NewSSHClient(d drivers.Driver) (*ssh.Client, error) {
 		return nil, errors.Wrap(err, "Error creating new ssh host from driver")
 
 	}
+	defaultKeyPath := filepath.Join(homedir.HomeDir(), ".ssh", "id_rsa")
 	auth := &machinessh.Auth{}
 	if h.SSHKeyPath != "" {
 		auth.Keys = []string{h.SSHKeyPath}
+	} else {
+		auth.Keys = []string{defaultKeyPath}
 	}
 
 	klog.Infof("new ssh client: %+v", h)


### PR DESCRIPTION
Minikube has an internal ssh client that _always_ uses NativeClient.
And since it doesn't support not giving a ssh key, it fails without one.

Make it default to the usual location (`~/.ssh/id_rsa`), if none is given...
This makes it possible to start, without --ssh-key but with --native-ssh=false

----

Support for `ssh-agent` is **not** possible without changing API
(currently it only allows SSH key paths, not SSH auth methods)

It would be nice to expose this SSH more structured from sshutil,
so it can be used from other parts of minikube (e.g. podman-env)