### PR TITLE
Make sure that ssh driver gets an ip address

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1097,6 +1097,13 @@ func validateFlags(cmd *cobra.Command, drvName string) {
 		}
 	}
 
+	if driver.IsSSH(drvName) {
+		sshIPAddress := viper.GetString(sshIPAddress)
+		if sshIPAddress == "" {
+			exit.Message(reason.Usage, "No IP address provided. Try specifying --ssh-ip-address, or see https://minikube.sigs.k8s.io/docs/drivers/ssh/")
+		}
+	}
+
 	// validate kubeadm extra args
 	if invalidOpts := bsutil.FindInvalidExtraConfigFlags(config.ExtraOptions); len(invalidOpts) > 0 {
 		out.WarningT(

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1102,6 +1102,13 @@ func validateFlags(cmd *cobra.Command, drvName string) {
 		if sshIPAddress == "" {
 			exit.Message(reason.Usage, "No IP address provided. Try specifying --ssh-ip-address, or see https://minikube.sigs.k8s.io/docs/drivers/ssh/")
 		}
+
+		if net.ParseIP(sshIPAddress) == nil {
+			_, err := net.LookupIP(sshIPAddress)
+			if err != nil {
+				exit.Error(reason.Usage, "Could not resolve IP address", err)
+			}
+		}
 	}
 
 	// validate kubeadm extra args


### PR DESCRIPTION

BEFORE

```
✨  Using the ssh driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🤦  StartHost failed, but will try again: config: please provide an IP address
😿  Failed to start ssh bare metal machine. Running "minikube delete" may fix it: config: please provide an IP address

❌  Exiting due to GUEST_PROVISION: Failed to start host: config: please provide an IP address

😿  If the above advice does not help, please let us know: 
👉  https://github.com/kubernetes/minikube/issues/new/choose

```

AFTER

```
✨  Using the ssh driver based on user configuration

❌  Exiting due to MK_USAGE: No IP address provided. Try specifying --ssh-ip-address, or see https://minikube.sigs.k8s.io/docs/drivers/ssh/

```

Closes #10244