### PR TITLE
 Add 5 minute timeout to deleting a profile

### DIFF
--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -285,19 +285,19 @@ func timedDeleteProfile(timeoutDuration time.Duration, profile *config.Profile) 
 		timeout <- true
 	}()
 
-	createFinished := make(chan bool, 1)
+	deleteFinished := make(chan bool, 1)
 	var err error
 	go func() {
 		err = deleteProfile(profile)
-		createFinished <- true
+		deleteFinished <- true
 	}()
 
 	select {
-	case <-createFinished:
+	case <-deleteFinished:
 		if err != nil {
 			// Wait for all the logs to reach the client
 			time.Sleep(2 * time.Second)
-			return errors.Wrap(err, "create")
+			return errors.Wrap(err, "delete")
 		}
 		return nil
 	case <-timeout:

--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -110,7 +110,8 @@ func deleteContainersAndVolumes(ociBin string) {
 		klog.Infof("error delete containers by label %q (might be okay): %+v", delLabel, errs)
 	}
 
-	errs = oci.DeleteAllVolumesByLabel(ociBin, delLabel)
+	ctx := context.Background()
+	errs = oci.DeleteAllVolumesByLabel(ctx, ociBin, delLabel)
 	if len(errs) > 0 { // it will not error if there is nothing to delete
 		klog.Warningf("error delete volumes by label %q (might be okay): %+v", delLabel, errs)
 	}
@@ -120,7 +121,7 @@ func deleteContainersAndVolumes(ociBin string) {
 		return
 	}
 
-	errs = oci.PruneAllVolumesByLabel(ociBin, delLabel)
+	errs = oci.PruneAllVolumesByLabel(ctx, ociBin, delLabel)
 	if len(errs) > 0 { // it will not error if there is nothing to delete
 		klog.Warningf("error pruning volumes by label %q (might be okay): %+v", delLabel, errs)
 	}
@@ -258,7 +259,7 @@ func deletePossibleKicLeftOver(cname string, driverName string) {
 		}
 	}
 
-	errs := oci.DeleteAllVolumesByLabel(bin, delLabel)
+	errs := oci.DeleteAllVolumesByLabel(ctx, bin, delLabel)
 	if errs != nil { // it will not error if there is nothing to delete
 		klog.Warningf("error deleting volumes (might be okay).\nTo see the list of volumes run: 'docker volume ls'\n:%v", errs)
 	}
@@ -273,7 +274,7 @@ func deletePossibleKicLeftOver(cname string, driverName string) {
 		return
 	}
 
-	errs = oci.PruneAllVolumesByLabel(bin, delLabel)
+	errs = oci.PruneAllVolumesByLabel(ctx, bin, delLabel)
 	if len(errs) > 0 { // it will not error if there is nothing to delete
 		klog.Warningf("error pruning volume (might be okay):\n%v", errs)
 	}

--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -247,7 +247,7 @@ func deletePossibleKicLeftOver(ctx context.Context, cname string, driverName str
 		return
 	}
 
-	klog.Infof("deleting possible KIC leftovers for %s (driver=%s) with timeout of 5m...", cname, driverName)
+	klog.Infof("deleting possible KIC leftovers for %s (driver=%s) ...", cname, driverName)
 	delLabel := fmt.Sprintf("%s=%s", oci.ProfileLabelKey, cname)
 	cs, err := oci.ListContainersByLabel(ctx, bin, delLabel)
 	if err == nil && len(cs) > 0 {

--- a/cmd/minikube/cmd/node_delete.go
+++ b/cmd/minikube/cmd/node_delete.go
@@ -17,6 +17,9 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
+	"time"
+
 	"github.com/spf13/cobra"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/driver"
@@ -48,7 +51,9 @@ var nodeDeleteCmd = &cobra.Command{
 
 		if driver.IsKIC(co.Config.Driver) {
 			machineName := config.MachineName(*co.Config, *n)
-			deletePossibleKicLeftOver(machineName, co.Config.Driver)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			defer cancel()
+			deletePossibleKicLeftOver(ctx, machineName, co.Config.Driver)
 		}
 
 		out.Step(style.Deleted, "Node {{.name}} was successfully deleted.", out.V{"name": name})

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -130,7 +131,7 @@ func platform() string {
 // runStart handles the executes the flow of "minikube start"
 func runStart(cmd *cobra.Command, args []string) {
 	register.SetEventLogPath(localpath.EventLog(ClusterFlagValue()))
-
+	ctx := context.Background()
 	out.SetJSON(outputFormat == "json")
 	if err := pkgtrace.Initialize(viper.GetString(trace)); err != nil {
 		exit.Message(reason.Usage, "error initializing tracing: {{.Error}}", out.V{"Error": err.Error()})
@@ -219,7 +220,7 @@ func runStart(cmd *cobra.Command, args []string) {
 					klog.Warningf("%s profile does not exist, trying anyways.", ClusterFlagValue())
 				}
 
-				err = deleteProfile(profile)
+				err = deleteProfile(ctx, profile)
 				if err != nil {
 					out.WarningT("Failed to delete cluster {{.name}}, proceeding with retry anyway.", out.V{"name": ClusterFlagValue()})
 				}
@@ -482,7 +483,7 @@ func maybeDeleteAndRetry(cmd *cobra.Command, existing config.ClusterConfig, n co
 			out.ErrT(style.Meh, `"{{.name}}" profile does not exist, trying anyways.`, out.V{"name": existing.Name})
 		}
 
-		err = deleteProfile(profile)
+		err = deleteProfile(context.Background(), profile)
 		if err != nil {
 			out.WarningT("Failed to delete cluster {{.name}}, proceeding with retry anyway.", out.V{"name": existing.Name})
 		}
@@ -697,7 +698,7 @@ func validateSpecifiedDriver(existing *config.ClusterConfig) {
 			out.ErrT(style.Meh, `"{{.name}}" profile does not exist, trying anyways.`, out.V{"name": existing.Name})
 		}
 
-		err = deleteProfile(profile)
+		err = deleteProfile(context.Background(), profile)
 		if err != nil {
 			out.WarningT("Failed to delete cluster {{.name}}.", out.V{"name": existing.Name})
 		}

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -72,6 +72,7 @@ func NewDriver(c Config) *Driver {
 
 // Create a host using the driver's config
 func (d *Driver) Create() error {
+	ctx := context.Background()
 	params := oci.CreateParams{
 		Mounts:        d.NodeConfig.Mounts,
 		Name:          d.NodeConfig.MachineName,
@@ -136,7 +137,7 @@ func (d *Driver) Create() error {
 		// if container was created by minikube it is safe to delete and recreate it.
 		if oci.IsCreatedByMinikube(d.OCIBinary, params.Name) {
 			klog.Info("Found already existing abandoned minikube container, will try to delete.")
-			if err := oci.DeleteContainer(d.OCIBinary, params.Name); err != nil {
+			if err := oci.DeleteContainer(ctx, d.OCIBinary, params.Name); err != nil {
 				klog.Errorf("Failed to delete a conflicting minikube container %s. You might need to restart your %s daemon and delete it manually and try again: %v", params.Name, params.OCIBinary, err)
 			}
 		} else {
@@ -338,7 +339,7 @@ func (d *Driver) Remove() error {
 		klog.Infof("could not find the container %s to remove it. will try anyways", d.MachineName)
 	}
 
-	if err := oci.DeleteContainer(d.NodeConfig.OCIBinary, d.MachineName); err != nil {
+	if err := oci.DeleteContainer(context.Background(), d.NodeConfig.OCIBinary, d.MachineName); err != nil {
 		if strings.Contains(err.Error(), "is already in progress") {
 			return errors.Wrap(err, "stuck delete")
 		}

--- a/pkg/drivers/kic/oci/volumes.go
+++ b/pkg/drivers/kic/oci/volumes.go
@@ -19,6 +19,7 @@ package oci
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"os/exec"
 	"runtime"
@@ -31,7 +32,7 @@ import (
 
 // DeleteAllVolumesByLabel deletes all volumes that have a specific label
 // if there is no volume to delete it will return nil
-func DeleteAllVolumesByLabel(ociBin string, label string, warnSlow ...bool) []error {
+func DeleteAllVolumesByLabel(ctx context.Context, ociBin string, label string, warnSlow ...bool) []error {
 	var deleteErrs []error
 	klog.Infof("trying to delete all %s volumes with label %s", ociBin, label)
 
@@ -42,7 +43,7 @@ func DeleteAllVolumesByLabel(ociBin string, label string, warnSlow ...bool) []er
 	}
 
 	for _, v := range vs {
-		if _, err := runCmd(exec.Command(ociBin, "volume", "rm", "--force", v), warnSlow...); err != nil {
+		if _, err := runCmd(exec.CommandContext(ctx, ociBin, "volume", "rm", "--force", v), warnSlow...); err != nil {
 			deleteErrs = append(deleteErrs, fmt.Errorf("deleting %q", v))
 		}
 	}
@@ -53,10 +54,10 @@ func DeleteAllVolumesByLabel(ociBin string, label string, warnSlow ...bool) []er
 // PruneAllVolumesByLabel deletes all volumes that have a specific label
 // if there is no volume to delete it will return nil
 // example: docker volume prune -f --filter label=name.minikube.sigs.k8s.io=minikube
-func PruneAllVolumesByLabel(ociBin string, label string, warnSlow ...bool) []error {
+func PruneAllVolumesByLabel(ctx context.Context, ociBin string, label string, warnSlow ...bool) []error {
 	var deleteErrs []error
 	klog.Infof("trying to prune all %s volumes with label %s", ociBin, label)
-	cmd := exec.Command(ociBin, "volume", "prune", "-f", "--filter", "label="+label)
+	cmd := exec.CommandContext(ctx, ociBin, "volume", "prune", "-f", "--filter", "label="+label)
 	if _, err := runCmd(cmd, warnSlow...); err != nil {
 		deleteErrs = append(deleteErrs, errors.Wrapf(err, "prune volume by label %s", label))
 	}


### PR DESCRIPTION
Right now if the docker daemon is stuck then `minikube delete` will hang forever, which is a really poor user experience and also causes our integration tests to timeout in a pretty bad way.

I fixed this by passing in a `context.Context` to our deletion `exec.Cmd` calls, with a 5 minute timeout per profile. Since we didn't previously pass in context anywhere, I did have to add it into a few different files, so this change was bigger than initially expected.

Fixes https://github.com/kubernetes/minikube/issues/10331