### PR TITLE
(docs) update install instructions for MacOS  

### DIFF
--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -81,10 +81,10 @@ If the [Brew Package Manager](https://brew.sh/) installed:
 brew install minikube
 ```
 
-If `which minikube` fails after installation via brew, you may have to remove the minikube cask and link the binary:
+If `which minikube` fails after installation via brew, you may have to remove the old minikube links and link the newly installed binary:
 
 ```shell
-brew cask remove minikube
+brew unlink minikube
 brew link minikube
 ```
 


### PR DESCRIPTION
- cask is now denoted as a flag `--cask`

Removing this now doesn't make much sense. I think it should be an attempt to unlink minikube:

```shell
brew unlink minikube
```

 and linking it again:

```shell
brew link minikube
```

![image](https://user-images.githubusercontent.com/10052309/106585051-89275000-650c-11eb-8505-345c305d8076.png)

# Before

![image](https://user-images.githubusercontent.com/10052309/106585236-bb38b200-650c-11eb-9884-f3c468897d04.png)

# After

![image](https://user-images.githubusercontent.com/10052309/106589061-2f755480-6511-11eb-986f-b3dcee0757d8.png)
