### PR TITLE
docker/podman driver: warn only once for slow running commands 

### DIFF
--- a/pkg/drivers/kic/oci/cli_runner.go
+++ b/pkg/drivers/kic/oci/cli_runner.go
@@ -24,6 +24,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -31,6 +32,9 @@ import (
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/style"
 )
+
+var Lock sync.Mutex
+var WarningPrintedSet = make(map[string]bool)
 
 // RunResult holds the results of a Runner
 type RunResult struct {
@@ -133,10 +137,15 @@ func runCmd(cmd *exec.Cmd, warnSlow ...bool) (*RunResult, error) {
 	elapsed := time.Since(start)
 	if warn {
 		if elapsed > warnTime {
-			out.WarningT(`Executing "{{.command}}" took an unusually long time: {{.duration}}`, out.V{"command": rr.Command(), "duration": elapsed})
-			// Don't show any restarting hint, when running podman locally (on linux, with sudo). Only when having a service.
-			if cmd.Args[0] != "sudo" {
-				out.ErrT(style.Tip, `Restarting the {{.name}} service may improve performance.`, out.V{"name": cmd.Args[0]})
+			Lock.Lock()
+			defer Lock.Unlock()
+			if _, ok := WarningPrintedSet[rr.Command()]; !ok {
+				out.WarningT(`Executing "{{.command}}" took an unusually long time: {{.duration}}`, out.V{"command": rr.Command(), "duration": elapsed})
+				// Don't show any restarting hint, when running podman locally (on linux, with sudo). Only when having a service.
+				if cmd.Args[0] != "sudo" {
+					out.ErrT(style.Tip, `Restarting the {{.name}} service may improve performance.`, out.V{"name": cmd.Args[0]})
+				}
+				WarningPrintedSet[rr.Command()] = true
 			}
 		}
 

--- a/pkg/drivers/kic/oci/cli_runner_test.go
+++ b/pkg/drivers/kic/oci/cli_runner_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package oci
 
 import (

--- a/pkg/drivers/kic/oci/cli_runner_test.go
+++ b/pkg/drivers/kic/oci/cli_runner_test.go
@@ -1,0 +1,44 @@
+package oci
+
+import (
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+
+	"k8s.io/minikube/pkg/minikube/out"
+	"k8s.io/minikube/pkg/minikube/tests"
+)
+
+func TestCliRunnerOnlyPrintOnce(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		return
+	}
+	f1 := tests.NewFakeFile()
+	out.SetErrFile(f1)
+
+	cmd := exec.Command("sleep", "3")
+	_, err := runCmd(cmd, true)
+
+	if err != nil {
+		t.Errorf("runCmd has error: %v", err)
+	}
+
+	if !strings.Contains(f1.String(), "Executing \"sleep 3\" took an unusually long time") {
+		t.Errorf("runCmd does not print the correct log, instead print :%v", f1.String())
+	}
+
+	f2 := tests.NewFakeFile()
+	out.SetErrFile(f2)
+
+	cmd = exec.Command("sleep", "3")
+	_, err = runCmd(cmd, true)
+
+	if err != nil {
+		t.Errorf("runCmd has error: %v", err)
+	}
+
+	if strings.Contains(f2.String(), "Executing \"sleep 3\" took an unusually long time") {
+		t.Errorf("runCmd does not print the correct log, instead print :%v", f2.String())
+	}
+}

--- a/pkg/drivers/kic/oci/cli_runner_test.go
+++ b/pkg/drivers/kic/oci/cli_runner_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/tests"
 )
 
-func TestCliRunnerOnlyPrintOnce(t *testing.T) {
+func TestRunCmdWarnSlowOnce(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		return
 	}


### PR DESCRIPTION
verifying this by reduing the warn time to 0.1 second 

```
zyanshu@zyanshukvm:~/minikube$ ./out/minikube start
😄  minikube v1.17.1 on Debian rodete (kvm/amd64)
    ▪ MINIKUBE_ACTIVE_DOCKERD=minikube
✨  Automatically selected the docker driver. Other choices: kvm2, ssh
👍  Starting control plane node minikube in cluster minikube
🔥  Creating docker container (CPUs=2, Memory=26100MB) ...
❗  Executing "docker ps -a --format {{.Names}}" took an unusually long time: 50.811946ms
💡  Restarting the docker service may improve performance.
❗  Executing "docker container inspect minikube --format={{.State.Status}}" took an unusually long time: 49.798492ms
💡  Restarting the docker service may improve performance.
🐳  Preparing Kubernetes v1.20.2 on Docker 20.10.2 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v4
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```