### PR TITLE
Changed x86 to amd64 in installation guide to reflect actual architecture name

### DIFF
--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -25,7 +25,7 @@ All you need is Docker (or similarly compatible) container or a Virtual Machine 
 
 For Linux users, we provide 3 easy download options (for each architecture):
 
-### amd64
+### amd64 / x86_64
 
 #### Binary download
 
@@ -49,7 +49,7 @@ curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest
 sudo rpm -ivh minikube-latest.x86_64.rpm
 ```
 
-### ARM64
+### arm64 / aarch64
 
 #### Binary download
 

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -25,7 +25,7 @@ All you need is Docker (or similarly compatible) container or a Virtual Machine 
 
 For Linux users, we provide 3 easy download options (for each architecture):
 
-### x86
+### amd64
 
 #### Binary download
 

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -49,7 +49,7 @@ curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest
 sudo rpm -ivh minikube-latest.x86_64.rpm
 ```
 
-### ARM
+### ARM64
 
 #### Binary download
 


### PR DESCRIPTION
Minikube installation guide has multiple architectures to choose from - including "x86".
Actual links however lead to amd64 versions of minicube. This might mislead potential x86 users into thinking they are downloading package for 32-bit version of Linux.