### PR TITLE
Add audit logs to minikube logs output

### DIFF
--- a/pkg/minikube/audit/audit.go
+++ b/pkg/minikube/audit/audit.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/viper"
 	"k8s.io/klog"
 	"k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/version"
 )
 
 // userName pulls the user flag, if empty gets the os username.
@@ -54,7 +55,7 @@ func Log(startTime time.Time) {
 	if !shouldLog() {
 		return
 	}
-	e := newEntry(os.Args[1], args(), userName(), startTime, time.Now())
+	e := newEntry(os.Args[1], args(), userName(), version.GetVersion(), startTime, time.Now())
 	if err := appendToLog(e); err != nil {
 		klog.Error(err)
 	}

--- a/pkg/minikube/audit/audit.go
+++ b/pkg/minikube/audit/audit.go
@@ -55,8 +55,8 @@ func Log(startTime time.Time) {
 	if !shouldLog() {
 		return
 	}
-	e := newEntry(os.Args[1], args(), userName(), version.GetVersion(), startTime, time.Now())
-	if err := appendToLog(e); err != nil {
+	r := newRow(os.Args[1], args(), userName(), version.GetVersion(), startTime, time.Now())
+	if err := appendToLog(r); err != nil {
 		klog.Error(err)
 	}
 }

--- a/pkg/minikube/audit/audit.go
+++ b/pkg/minikube/audit/audit.go
@@ -17,8 +17,6 @@ limitations under the License.
 package audit
 
 import (
-	"bufio"
-	"fmt"
 	"os"
 	"os/user"
 	"strings"
@@ -77,33 +75,4 @@ func shouldLog() bool {
 		}
 	}
 	return true
-}
-
-// Retrieve the last n lines from the log.
-func Retrieve(n int) (string, error) {
-	if n <= 0 {
-		return "", fmt.Errorf("number of lines to retrieve must be 1 or greater")
-	}
-	if currentLogFile == nil {
-		if err := setLogFile(); err != nil {
-			return "", fmt.Errorf("failed to set the log file: %v", err)
-		}
-	}
-	var l []string
-	s := bufio.NewScanner(currentLogFile)
-	for s.Scan() {
-		// pop off the earliest line if already at desired log length
-		if len(l) == n {
-			l = l[1:]
-		}
-		l = append(l, s.Text())
-	}
-	if err := s.Err(); err != nil {
-		return "", fmt.Errorf("failed to read from audit file: %v", err)
-	}
-	t, err := linesToTable(l)
-	if err != nil {
-		return "", fmt.Errorf("failed to convert lines to table: %v", err)
-	}
-	return t, nil
 }

--- a/pkg/minikube/audit/audit.go
+++ b/pkg/minikube/audit/audit.go
@@ -17,6 +17,8 @@ limitations under the License.
 package audit
 
 import (
+	"bufio"
+	"fmt"
 	"os"
 	"os/user"
 	"strings"
@@ -75,4 +77,33 @@ func shouldLog() bool {
 		}
 	}
 	return true
+}
+
+// Retrieve the last n lines from the log.
+func Retrieve(n int) (string, error) {
+	if n <= 0 {
+		return "", fmt.Errorf("number of lines to retrieve must be 1 or greater")
+	}
+	if currentLogFile == nil {
+		if err := setLogFile(); err != nil {
+			return "", fmt.Errorf("failed to set the log file: %v", err)
+		}
+	}
+	var l []string
+	s := bufio.NewScanner(currentLogFile)
+	for s.Scan() {
+		// pop off the earliest line if already at desired log length
+		if len(l) == n {
+			l = l[1:]
+		}
+		l = append(l, s.Text())
+	}
+	if err := s.Err(); err != nil {
+		return "", fmt.Errorf("failed to read from audit file: %v", err)
+	}
+	t, err := linesToTable(l)
+	if err != nil {
+		return "", fmt.Errorf("failed to convert lines to table: %v", err)
+	}
+	return t, nil
 }

--- a/pkg/minikube/audit/entry.go
+++ b/pkg/minikube/audit/entry.go
@@ -71,12 +71,16 @@ func (e *singleEntry) toMap() map[string]string {
 }
 
 // newEntry returns a new audit type.
-func newEntry(command string, args string, user string, version string, startTime time.Time, endTime time.Time) *singleEntry {
+func newEntry(command string, args string, user string, version string, startTime time.Time, endTime time.Time, profile ...string) *singleEntry {
+	p := viper.GetString(config.ProfileName)
+	if len(profile) > 0 {
+		p = profile[0]
+	}
 	return &singleEntry{
 		args:      args,
 		command:   command,
 		endTime:   endTime.Format(constants.TimeFormat),
-		profile:   viper.GetString(config.ProfileName),
+		profile:   p,
 		startTime: startTime.Format(constants.TimeFormat),
 		user:      user,
 		version:   version,
@@ -103,7 +107,7 @@ func logsToEntries(logs []string) ([]singleEntry, error) {
 }
 
 // entriesToTable converts audit lines into a formatted table.
-func entriesToTable(entries []singleEntry, headers []string) (string, error) {
+func entriesToTable(entries []singleEntry, headers []string) string {
 	c := [][]string{}
 	for _, e := range entries {
 		c = append(c, e.toFields())
@@ -117,5 +121,5 @@ func entriesToTable(entries []singleEntry, headers []string) (string, error) {
 	t.SetCenterSeparator("|")
 	t.AppendBulk(c)
 	t.Render()
-	return b.String(), nil
+	return b.String()
 }

--- a/pkg/minikube/audit/entry.go
+++ b/pkg/minikube/audit/entry.go
@@ -58,10 +58,10 @@ func (e *entry) toFields() []string {
 	return []string{d["command"], d["args"], d["profile"], d["user"], d["startTime"], d["endTime"]}
 }
 
-// linesToFields converts audit lines into arrays of fields.
-func linesToFields(lines []string) ([][]string, error) {
+// logsToFields converts audit logs into arrays of fields.
+func logsToFields(logs []string) ([][]string, error) {
 	c := [][]string{}
-	for _, l := range lines {
+	for _, l := range logs {
 		e := &entry{}
 		if err := json.Unmarshal([]byte(l), e); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal %q: %v", l, err)
@@ -71,11 +71,11 @@ func linesToFields(lines []string) ([][]string, error) {
 	return c, nil
 }
 
-// linesToTable converts audit lines into a formatted table.
-func linesToTable(lines []string, headers []string) (string, error) {
-	f, err := linesToFields(lines)
+// logsToTable converts audit lines into a formatted table.
+func logsToTable(logs []string, headers []string) (string, error) {
+	f, err := logsToFields(logs)
 	if err != nil {
-		return "", fmt.Errorf("failed to convert lines to fields: %v", err)
+		return "", fmt.Errorf("failed to convert logs to fields: %v", err)
 	}
 	b := new(bytes.Buffer)
 	t := tablewriter.NewWriter(b)

--- a/pkg/minikube/audit/entry.go
+++ b/pkg/minikube/audit/entry.go
@@ -72,14 +72,14 @@ func linesToFields(lines []string) ([][]string, error) {
 }
 
 // linesToTable converts audit lines into a formatted table.
-func linesToTable(lines []string) (string, error) {
+func linesToTable(lines []string, headers []string) (string, error) {
 	f, err := linesToFields(lines)
 	if err != nil {
 		return "", fmt.Errorf("failed to convert lines to fields: %v", err)
 	}
 	b := new(bytes.Buffer)
 	t := tablewriter.NewWriter(b)
-	t.SetHeader([]string{"Command", "Args", "Profile", "User", "Start Time", "End Time"})
+	t.SetHeader(headers)
 	t.SetAutoFormatHeaders(false)
 	t.SetBorders(tablewriter.Border{Left: true, Top: true, Right: true, Bottom: true})
 	t.SetCenterSeparator("|")

--- a/pkg/minikube/audit/entry_test.go
+++ b/pkg/minikube/audit/entry_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2020 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package audit
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/constants"
+)
+
+func TestEntry(t *testing.T) {
+	c := "start"
+	a := "--alsologtostderr"
+	p := "profile1"
+	u := "user1"
+	st := time.Now()
+	stFormatted := st.Format(constants.TimeFormat)
+	et := time.Now()
+	etFormatted := et.Format(constants.TimeFormat)
+
+	// save current profile in case something depends on it
+	oldProfile := viper.GetString(config.ProfileName)
+	viper.Set(config.ProfileName, p)
+	e := newEntry(c, a, u, st, et)
+	viper.Set(config.ProfileName, oldProfile)
+
+	t.Run("TestNewEntry", func(t *testing.T) {
+		d := e.Data
+
+		tests := []struct {
+			key  string
+			want string
+		}{
+			{"command", c},
+			{"args", a},
+			{"profile", p},
+			{"user", u},
+			{"startTime", stFormatted},
+			{"endTime", etFormatted},
+		}
+
+		for _, tt := range tests {
+			got := d[tt.key]
+
+			if got != tt.want {
+				t.Errorf("Data[%q] = %s; want %s", tt.key, got, tt.want)
+			}
+		}
+	})
+
+	t.Run("TestType", func(t *testing.T) {
+		got := e.Type()
+		want := "io.k8s.sigs.minikube.audit"
+
+		if got != want {
+			t.Errorf("Type() = %s; want %s", got, want)
+		}
+	})
+
+	t.Run("TestToField", func(t *testing.T) {
+		got := e.toFields()
+		gotString := strings.Join(got, ",")
+		want := []string{c, a, p, u, stFormatted, etFormatted}
+		wantString := strings.Join(want, ",")
+
+		if gotString != wantString {
+			t.Errorf("toFields() = %s; want %s", gotString, wantString)
+		}
+	})
+}

--- a/pkg/minikube/audit/entry_test.go
+++ b/pkg/minikube/audit/entry_test.go
@@ -17,12 +17,12 @@ limitations under the License.
 package audit
 
 import (
+	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/spf13/viper"
-	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 )
 
@@ -31,37 +31,32 @@ func TestEntry(t *testing.T) {
 	a := "--alsologtostderr"
 	p := "profile1"
 	u := "user1"
+	v := "v0.17.1"
 	st := time.Now()
 	stFormatted := st.Format(constants.TimeFormat)
 	et := time.Now()
 	etFormatted := et.Format(constants.TimeFormat)
 
-	// save current profile in case something depends on it
-	oldProfile := viper.GetString(config.ProfileName)
-	viper.Set(config.ProfileName, p)
-	e := newEntry(c, a, u, st, et)
-	viper.Set(config.ProfileName, oldProfile)
+	e := newEntry(c, a, u, v, st, et, p)
 
 	t.Run("TestNewEntry", func(t *testing.T) {
-		d := e.Data
-
 		tests := []struct {
 			key  string
+			got  string
 			want string
 		}{
-			{"command", c},
-			{"args", a},
-			{"profile", p},
-			{"user", u},
-			{"startTime", stFormatted},
-			{"endTime", etFormatted},
+			{"command", e.command, c},
+			{"args", e.args, a},
+			{"profile", e.profile, p},
+			{"user", e.user, u},
+			{"version", e.version, v},
+			{"startTime", e.startTime, stFormatted},
+			{"endTime", e.endTime, etFormatted},
 		}
 
 		for _, tt := range tests {
-			got := d[tt.key]
-
-			if got != tt.want {
-				t.Errorf("Data[%q] = %s; want %s", tt.key, got, tt.want)
+			if tt.got != tt.want {
+				t.Errorf("singleEntry.%s = %s; want %s", tt.key, tt.got, tt.want)
 			}
 		}
 	})
@@ -75,14 +70,70 @@ func TestEntry(t *testing.T) {
 		}
 	})
 
+	t.Run("TestToMap", func(t *testing.T) {
+		m := e.toMap()
+
+		tests := []struct {
+			key  string
+			want string
+		}{
+			{"command", c},
+			{"args", a},
+			{"profile", p},
+			{"user", u},
+			{"version", v},
+			{"startTime", stFormatted},
+			{"endTime", etFormatted},
+		}
+
+		for _, tt := range tests {
+			got := m[tt.key]
+			if got != tt.want {
+				t.Errorf("map[%s] = %s; want %s", tt.key, got, tt.want)
+			}
+		}
+	})
+
 	t.Run("TestToField", func(t *testing.T) {
 		got := e.toFields()
 		gotString := strings.Join(got, ",")
-		want := []string{c, a, p, u, stFormatted, etFormatted}
+		want := []string{c, a, p, u, v, stFormatted, etFormatted}
 		wantString := strings.Join(want, ",")
 
 		if gotString != wantString {
 			t.Errorf("toFields() = %s; want %s", gotString, wantString)
+		}
+	})
+
+	t.Run("TestAssignFields", func(t *testing.T) {
+		l := fmt.Sprintf(`{"data":{"args":"%s","command":"%s","endTime":"%s","profile":"%s","startTime":"%s","user":"%s","version":"v0.17.1"},"datacontenttype":"application/json","id":"bc6ec9d4-0d08-4b57-ac3b-db8d67774768","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.audit"}`, a, c, etFormatted, p, stFormatted, u)
+
+		e := &singleEntry{}
+		if err := json.Unmarshal([]byte(l), e); err != nil {
+			t.Fatalf("failed to unmarshal log:: %v", err)
+		}
+
+		e.assignFields()
+
+		tests := []struct {
+			key  string
+			got  string
+			want string
+		}{
+			{"command", e.command, c},
+			{"args", e.args, a},
+			{"profile", e.profile, p},
+			{"user", e.user, u},
+			{"version", e.version, v},
+			{"startTime", e.startTime, stFormatted},
+			{"endTime", e.endTime, etFormatted},
+		}
+
+		for _, tt := range tests {
+			if tt.got != tt.want {
+				t.Errorf("singleEntry.%s = %s; want %s", tt.key, tt.got, tt.want)
+
+			}
 		}
 	})
 }

--- a/pkg/minikube/audit/logFile.go
+++ b/pkg/minikube/audit/logFile.go
@@ -39,14 +39,14 @@ func setLogFile() error {
 }
 
 // appendToLog appends the audit entry to the log file.
-func appendToLog(entry *singleEntry) error {
+func appendToLog(row *row) error {
 	if currentLogFile == nil {
 		if err := setLogFile(); err != nil {
 			return err
 		}
 	}
-	e := register.CloudEvent(entry, entry.toMap())
-	bs, err := e.MarshalJSON()
+	ce := register.CloudEvent(row, row.toMap())
+	bs, err := ce.MarshalJSON()
 	if err != nil {
 		return fmt.Errorf("error marshalling event: %v", err)
 	}

--- a/pkg/minikube/audit/logFile.go
+++ b/pkg/minikube/audit/logFile.go
@@ -38,7 +38,7 @@ func setLogFile() error {
 	return nil
 }
 
-// appendToLog appends the audit entry to the log file.
+// appendToLog appends the row to the log file.
 func appendToLog(row *row) error {
 	if currentLogFile == nil {
 		if err := setLogFile(); err != nil {

--- a/pkg/minikube/audit/logFile.go
+++ b/pkg/minikube/audit/logFile.go
@@ -39,13 +39,13 @@ func setLogFile() error {
 }
 
 // appendToLog appends the audit entry to the log file.
-func appendToLog(entry *entry) error {
+func appendToLog(entry *singleEntry) error {
 	if currentLogFile == nil {
 		if err := setLogFile(); err != nil {
 			return err
 		}
 	}
-	e := register.CloudEvent(entry, entry.Data)
+	e := register.CloudEvent(entry, entry.toMap())
 	bs, err := e.MarshalJSON()
 	if err != nil {
 		return fmt.Errorf("error marshalling event: %v", err)

--- a/pkg/minikube/audit/logFile.go
+++ b/pkg/minikube/audit/logFile.go
@@ -30,7 +30,7 @@ var currentLogFile *os.File
 // setLogFile sets the logPath and creates the log file if it doesn't exist.
 func setLogFile() error {
 	lp := localpath.AuditLog()
-	f, err := os.OpenFile(lp, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(lp, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0644)
 	if err != nil {
 		return fmt.Errorf("unable to open %s: %v", lp, err)
 	}
@@ -45,7 +45,7 @@ func appendToLog(entry *entry) error {
 			return err
 		}
 	}
-	e := register.CloudEvent(entry, entry.data)
+	e := register.CloudEvent(entry, entry.Data)
 	bs, err := e.MarshalJSON()
 	if err != nil {
 		return fmt.Errorf("error marshalling event: %v", err)

--- a/pkg/minikube/audit/logFile_test.go
+++ b/pkg/minikube/audit/logFile_test.go
@@ -42,7 +42,7 @@ func TestLogFile(t *testing.T) {
 		defer func() { currentLogFile = &oldLogFile }()
 		currentLogFile = f
 
-		e := newEntry("start", "-v", "user1", time.Now(), time.Now())
+		e := newEntry("start", "-v", "user1", "v0.17.1", time.Now(), time.Now())
 		if err := appendToLog(e); err != nil {
 			t.Fatalf("Error appendingToLog: %v", err)
 		}

--- a/pkg/minikube/audit/logFile_test.go
+++ b/pkg/minikube/audit/logFile_test.go
@@ -42,8 +42,8 @@ func TestLogFile(t *testing.T) {
 		defer func() { currentLogFile = &oldLogFile }()
 		currentLogFile = f
 
-		e := newEntry("start", "-v", "user1", "v0.17.1", time.Now(), time.Now())
-		if err := appendToLog(e); err != nil {
+		r := newRow("start", "-v", "user1", "v0.17.1", time.Now(), time.Now())
+		if err := appendToLog(r); err != nil {
 			t.Fatalf("Error appendingToLog: %v", err)
 		}
 

--- a/pkg/minikube/audit/report.go
+++ b/pkg/minikube/audit/report.go
@@ -21,15 +21,16 @@ import (
 	"fmt"
 )
 
+// RawReport contains the information required to generate formatted reports.
 type RawReport struct {
 	headers []string
 	rows    []row
 }
 
-// Report is created from the log file.
-func Report(lines int) (*RawReport, error) {
-	if lines <= 0 {
-		return nil, fmt.Errorf("number of lines must be 1 or greater")
+// Report is created using the last n lines from the log file.
+func Report(lastNLines int) (*RawReport, error) {
+	if lastNLines <= 0 {
+		return nil, fmt.Errorf("last n lines must be 1 or greater")
 	}
 	if currentLogFile == nil {
 		if err := setLogFile(); err != nil {
@@ -40,7 +41,7 @@ func Report(lines int) (*RawReport, error) {
 	s := bufio.NewScanner(currentLogFile)
 	for s.Scan() {
 		// pop off the earliest line if already at desired log length
-		if len(logs) == lines {
+		if len(logs) == lastNLines {
 			logs = logs[1:]
 		}
 		logs = append(logs, s.Text())
@@ -61,5 +62,5 @@ func Report(lines int) (*RawReport, error) {
 
 // ASCIITable creates a formatted table using the headers and rows from the report.
 func (rr *RawReport) ASCIITable() string {
-	return rowsToTable(rr.rows, rr.headers)
+	return rowsToASCIITable(rr.rows, rr.headers)
 }

--- a/pkg/minikube/audit/report.go
+++ b/pkg/minikube/audit/report.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2020 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package audit
+
+import (
+	"bufio"
+	"fmt"
+)
+
+type Data struct {
+	headers []string
+	logs    []string
+}
+
+// Report is created from the log file.
+func Report(lines int) (*Data, error) {
+	if lines <= 0 {
+		return nil, fmt.Errorf("number of lines must be 1 or greater")
+	}
+	if currentLogFile == nil {
+		if err := setLogFile(); err != nil {
+			return nil, fmt.Errorf("failed to set the log file: %v", err)
+		}
+	}
+	var l []string
+	s := bufio.NewScanner(currentLogFile)
+	for s.Scan() {
+		// pop off the earliest line if already at desired log length
+		if len(l) == lines {
+			l = l[1:]
+		}
+		l = append(l, s.Text())
+	}
+	if err := s.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read from audit file: %v", err)
+	}
+	r := &Data{
+		[]string{"Command", "Args", "Profile", "User", "Start Time", "End Time"},
+		l,
+	}
+	return r, nil
+}
+
+// Table creates a formatted table using last n lines from the report.
+func (r *Data) Table() (string, error) {
+	t, err := linesToTable(r.logs, r.headers)
+	if err != nil {
+		return "", fmt.Errorf("failed to convert lines to table: %v", err)
+	}
+	return t, nil
+}

--- a/pkg/minikube/audit/report.go
+++ b/pkg/minikube/audit/report.go
@@ -60,10 +60,6 @@ func Report(lines int) (*Data, error) {
 }
 
 // Table creates a formatted table using entries from the report.
-func (r *Data) Table() (string, error) {
-	t, err := entriesToTable(r.entries, r.headers)
-	if err != nil {
-		return "", fmt.Errorf("failed to convert logs to table: %v", err)
-	}
-	return t, nil
+func (r *Data) Table() string {
+	return entriesToTable(r.entries, r.headers)
 }

--- a/pkg/minikube/audit/report.go
+++ b/pkg/minikube/audit/report.go
@@ -21,13 +21,13 @@ import (
 	"fmt"
 )
 
-type Data struct {
+type RawReport struct {
 	headers []string
-	entries []singleEntry
+	rows    []row
 }
 
 // Report is created from the log file.
-func Report(lines int) (*Data, error) {
+func Report(lines int) (*RawReport, error) {
 	if lines <= 0 {
 		return nil, fmt.Errorf("number of lines must be 1 or greater")
 	}
@@ -48,18 +48,18 @@ func Report(lines int) (*Data, error) {
 	if err := s.Err(); err != nil {
 		return nil, fmt.Errorf("failed to read from audit file: %v", err)
 	}
-	e, err := logsToEntries(logs)
+	rows, err := logsToRows(logs)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert logs to entries: %v", err)
+		return nil, fmt.Errorf("failed to convert logs to rows: %v", err)
 	}
-	r := &Data{
+	r := &RawReport{
 		[]string{"Command", "Args", "Profile", "User", "Version", "Start Time", "End Time"},
-		e,
+		rows,
 	}
 	return r, nil
 }
 
-// Table creates a formatted table using entries from the report.
-func (r *Data) Table() string {
-	return entriesToTable(r.entries, r.headers)
+// ASCIITable creates a formatted table using the headers and rows from the report.
+func (rr *RawReport) ASCIITable() string {
+	return rowsToTable(rr.rows, rr.headers)
 }

--- a/pkg/minikube/audit/report.go
+++ b/pkg/minikube/audit/report.go
@@ -55,11 +55,11 @@ func Report(lines int) (*Data, error) {
 	return r, nil
 }
 
-// Table creates a formatted table using last n lines from the report.
+// Table creates a formatted table using last n logs from the report.
 func (r *Data) Table() (string, error) {
-	t, err := linesToTable(r.logs, r.headers)
+	t, err := logsToTable(r.logs, r.headers)
 	if err != nil {
-		return "", fmt.Errorf("failed to convert lines to table: %v", err)
+		return "", fmt.Errorf("failed to convert logs to table: %v", err)
 	}
 	return t, nil
 }

--- a/pkg/minikube/audit/report_test.go
+++ b/pkg/minikube/audit/report_test.go
@@ -50,13 +50,7 @@ func TestAuditReport(t *testing.T) {
 		t.Fatalf("failed to create report: %v", err)
 	}
 
-	if len(r.logs) != wantedLines {
-		t.Fatalf("report has %d lines of logs, want %d", len(r.logs), wantedLines)
+	if len(r.entries) != wantedLines {
+		t.Fatalf("report has %d lines of logs, want %d", len(r.entries), wantedLines)
 	}
-
-	t.Run("TestTable", func(t *testing.T) {
-		if _, err := r.Table(); err != nil {
-			t.Errorf("failed to create table from report: %v", err)
-		}
-	})
 }

--- a/pkg/minikube/audit/report_test.go
+++ b/pkg/minikube/audit/report_test.go
@@ -50,7 +50,7 @@ func TestAuditReport(t *testing.T) {
 		t.Fatalf("failed to create report: %v", err)
 	}
 
-	if len(r.entries) != wantedLines {
-		t.Fatalf("report has %d lines of logs, want %d", len(r.entries), wantedLines)
+	if len(r.rows) != wantedLines {
+		t.Fatalf("report has %d lines of logs, want %d", len(r.rows), wantedLines)
 	}
 }

--- a/pkg/minikube/audit/report_test.go
+++ b/pkg/minikube/audit/report_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 )
 
-func TestAuditReport(t *testing.T) {
+func TestReport(t *testing.T) {
 	f, err := ioutil.TempFile("", "audit.json")
 	if err != nil {
 		t.Fatalf("failed creating temporary file: %v", err)

--- a/pkg/minikube/audit/report_test.go
+++ b/pkg/minikube/audit/report_test.go
@@ -51,6 +51,6 @@ func TestReport(t *testing.T) {
 	}
 
 	if len(r.rows) != wantedLines {
-		t.Fatalf("report has %d lines of logs, want %d", len(r.rows), wantedLines)
+		t.Errorf("report has %d lines of logs, want %d", len(r.rows), wantedLines)
 	}
 }

--- a/pkg/minikube/audit/report_test.go
+++ b/pkg/minikube/audit/report_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2020 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package audit
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestAuditReport(t *testing.T) {
+	f, err := ioutil.TempFile("", "audit.json")
+	if err != nil {
+		t.Fatalf("failed creating temporary file: %v", err)
+	}
+	defer os.Remove(f.Name())
+
+	s := `{"data":{"args":"-p mini1","command":"start","endTime":"Wed, 03 Feb 2021 15:33:05 MST","profile":"mini1","startTime":"Wed, 03 Feb 2021 15:30:33 MST","user":"user1"},"datacontenttype":"application/json","id":"9b7593cb-fbec-49e5-a3ce-bdc2d0bfb208","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.si  gs.minikube.audit"}
+{"data":{"args":"-p mini1","command":"start","endTime":"Wed, 03 Feb 2021 15:33:05 MST","profile":"mini1","startTime":"Wed, 03 Feb 2021 15:30:33 MST","user":"user1"},"datacontenttype":"application/json","id":"9b7593cb-fbec-49e5-a3ce-bdc2d0bfb208","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.si  gs.minikube.audit"}
+{"data":{"args":"--user user2","command":"logs","endTime":"Tue, 02 Feb 2021 16:46:20 MST","profile":"minikube","startTime":"Tue, 02 Feb 2021 16:46:00 MST","user":"user2"},"datacontenttype":"application/json","id":"fec03227-2484-48b6-880a-88fd010b5efd","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.audit"}`
+
+	if _, err := f.WriteString(s); err != nil {
+		t.Fatalf("failed writing to file: %v", err)
+	}
+	if _, err := f.Seek(0, 0); err != nil {
+		t.Fatalf("failed seeking to start of file: %v", err)
+	}
+
+	oldLogFile := *currentLogFile
+	defer func() { currentLogFile = &oldLogFile }()
+	currentLogFile = f
+
+	wantedLines := 2
+	r, err := Report(wantedLines)
+	if err != nil {
+		t.Fatalf("failed to create report: %v", err)
+	}
+
+	if len(r.logs) != wantedLines {
+		t.Fatalf("report has %d lines of logs, want %d", len(r.logs), wantedLines)
+	}
+
+	t.Run("TestTable", func(t *testing.T) {
+		if _, err := r.Table(); err != nil {
+			t.Errorf("failed to create table from report: %v", err)
+		}
+	})
+}

--- a/pkg/minikube/audit/row.go
+++ b/pkg/minikube/audit/row.go
@@ -45,7 +45,8 @@ func (e *row) Type() string {
 	return "io.k8s.sigs.minikube.audit"
 }
 
-// assignFields converts the map values to their proper fields
+// assignFields converts the map values to their proper fields,
+// to be used when converting from JSON Cloud Event format.
 func (e *row) assignFields() {
 	e.args = e.Data["args"]
 	e.command = e.Data["command"]
@@ -56,7 +57,8 @@ func (e *row) assignFields() {
 	e.version = e.Data["version"]
 }
 
-// toMap combines fields into a string map
+// toMap combines fields into a string map,
+// to be used when converting to JSON Cloud Event format.
 func (e *row) toMap() map[string]string {
 	return map[string]string{
 		"args":      e.args,
@@ -69,7 +71,7 @@ func (e *row) toMap() map[string]string {
 	}
 }
 
-// newRow returns a new audit type.
+// newRow creates a new audit row.
 func newRow(command string, args string, user string, version string, startTime time.Time, endTime time.Time, profile ...string) *row {
 	p := viper.GetString(config.ProfileName)
 	if len(profile) > 0 {
@@ -86,7 +88,8 @@ func newRow(command string, args string, user string, version string, startTime 
 	}
 }
 
-// toFields converts a row to an array of fields.
+// toFields converts a row to an array of fields,
+// to be used when converting to a table.
 func (e *row) toFields() []string {
 	return []string{e.command, e.args, e.profile, e.user, e.version, e.startTime, e.endTime}
 }
@@ -105,8 +108,8 @@ func logsToRows(logs []string) ([]row, error) {
 	return rows, nil
 }
 
-// rowsToTable converts audit rows into a formatted table.
-func rowsToTable(rows []row, headers []string) string {
+// rowsToASCIITable converts rows into a formatted ASCII table.
+func rowsToASCIITable(rows []row, headers []string) string {
 	c := [][]string{}
 	for _, r := range rows {
 		c = append(c, r.toFields())

--- a/pkg/minikube/audit/row_test.go
+++ b/pkg/minikube/audit/row_test.go
@@ -70,7 +70,7 @@ func TestRow(t *testing.T) {
 		}
 	})
 
-	t.Run("ToMap", func(t *testing.T) {
+	t.Run("toMap", func(t *testing.T) {
 		m := r.toMap()
 
 		tests := []struct {
@@ -94,7 +94,7 @@ func TestRow(t *testing.T) {
 		}
 	})
 
-	t.Run("ToFields", func(t *testing.T) {
+	t.Run("toFields", func(t *testing.T) {
 		got := r.toFields()
 		gotString := strings.Join(got, ",")
 		want := []string{c, a, p, u, v, stFormatted, etFormatted}
@@ -105,7 +105,7 @@ func TestRow(t *testing.T) {
 		}
 	})
 
-	t.Run("AssignFields", func(t *testing.T) {
+	t.Run("assignFields", func(t *testing.T) {
 		l := fmt.Sprintf(`{"data":{"args":"%s","command":"%s","endTime":"%s","profile":"%s","startTime":"%s","user":"%s","version":"v0.17.1"},"datacontenttype":"application/json","id":"bc6ec9d4-0d08-4b57-ac3b-db8d67774768","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.audit"}`, a, c, etFormatted, p, stFormatted, u)
 
 		r := &row{}

--- a/pkg/minikube/audit/row_test.go
+++ b/pkg/minikube/audit/row_test.go
@@ -39,7 +39,7 @@ func TestRow(t *testing.T) {
 
 	r := newRow(c, a, u, v, st, et, p)
 
-	t.Run("TestNewRow", func(t *testing.T) {
+	t.Run("NewRow", func(t *testing.T) {
 		tests := []struct {
 			key  string
 			got  string
@@ -61,7 +61,7 @@ func TestRow(t *testing.T) {
 		}
 	})
 
-	t.Run("TestType", func(t *testing.T) {
+	t.Run("Type", func(t *testing.T) {
 		got := r.Type()
 		want := "io.k8s.sigs.minikube.audit"
 
@@ -70,7 +70,7 @@ func TestRow(t *testing.T) {
 		}
 	})
 
-	t.Run("TestToMap", func(t *testing.T) {
+	t.Run("ToMap", func(t *testing.T) {
 		m := r.toMap()
 
 		tests := []struct {
@@ -94,7 +94,7 @@ func TestRow(t *testing.T) {
 		}
 	})
 
-	t.Run("TestToField", func(t *testing.T) {
+	t.Run("ToFields", func(t *testing.T) {
 		got := r.toFields()
 		gotString := strings.Join(got, ",")
 		want := []string{c, a, p, u, v, stFormatted, etFormatted}
@@ -105,7 +105,7 @@ func TestRow(t *testing.T) {
 		}
 	})
 
-	t.Run("TestAssignFields", func(t *testing.T) {
+	t.Run("AssignFields", func(t *testing.T) {
 		l := fmt.Sprintf(`{"data":{"args":"%s","command":"%s","endTime":"%s","profile":"%s","startTime":"%s","user":"%s","version":"v0.17.1"},"datacontenttype":"application/json","id":"bc6ec9d4-0d08-4b57-ac3b-db8d67774768","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.audit"}`, a, c, etFormatted, p, stFormatted, u)
 
 		r := &row{}

--- a/pkg/minikube/audit/row_test.go
+++ b/pkg/minikube/audit/row_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/constants"
 )
 
-func TestEntry(t *testing.T) {
+func TestRow(t *testing.T) {
 	c := "start"
 	a := "--alsologtostderr"
 	p := "profile1"
@@ -37,32 +37,32 @@ func TestEntry(t *testing.T) {
 	et := time.Now()
 	etFormatted := et.Format(constants.TimeFormat)
 
-	e := newEntry(c, a, u, v, st, et, p)
+	r := newRow(c, a, u, v, st, et, p)
 
-	t.Run("TestNewEntry", func(t *testing.T) {
+	t.Run("TestNewRow", func(t *testing.T) {
 		tests := []struct {
 			key  string
 			got  string
 			want string
 		}{
-			{"command", e.command, c},
-			{"args", e.args, a},
-			{"profile", e.profile, p},
-			{"user", e.user, u},
-			{"version", e.version, v},
-			{"startTime", e.startTime, stFormatted},
-			{"endTime", e.endTime, etFormatted},
+			{"command", r.command, c},
+			{"args", r.args, a},
+			{"profile", r.profile, p},
+			{"user", r.user, u},
+			{"version", r.version, v},
+			{"startTime", r.startTime, stFormatted},
+			{"endTime", r.endTime, etFormatted},
 		}
 
 		for _, tt := range tests {
 			if tt.got != tt.want {
-				t.Errorf("singleEntry.%s = %s; want %s", tt.key, tt.got, tt.want)
+				t.Errorf("row.%s = %s; want %s", tt.key, tt.got, tt.want)
 			}
 		}
 	})
 
 	t.Run("TestType", func(t *testing.T) {
-		got := e.Type()
+		got := r.Type()
 		want := "io.k8s.sigs.minikube.audit"
 
 		if got != want {
@@ -71,7 +71,7 @@ func TestEntry(t *testing.T) {
 	})
 
 	t.Run("TestToMap", func(t *testing.T) {
-		m := e.toMap()
+		m := r.toMap()
 
 		tests := []struct {
 			key  string
@@ -95,7 +95,7 @@ func TestEntry(t *testing.T) {
 	})
 
 	t.Run("TestToField", func(t *testing.T) {
-		got := e.toFields()
+		got := r.toFields()
 		gotString := strings.Join(got, ",")
 		want := []string{c, a, p, u, v, stFormatted, etFormatted}
 		wantString := strings.Join(want, ",")
@@ -108,25 +108,25 @@ func TestEntry(t *testing.T) {
 	t.Run("TestAssignFields", func(t *testing.T) {
 		l := fmt.Sprintf(`{"data":{"args":"%s","command":"%s","endTime":"%s","profile":"%s","startTime":"%s","user":"%s","version":"v0.17.1"},"datacontenttype":"application/json","id":"bc6ec9d4-0d08-4b57-ac3b-db8d67774768","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.audit"}`, a, c, etFormatted, p, stFormatted, u)
 
-		e := &singleEntry{}
-		if err := json.Unmarshal([]byte(l), e); err != nil {
-			t.Fatalf("failed to unmarshal log:: %v", err)
+		r := &row{}
+		if err := json.Unmarshal([]byte(l), r); err != nil {
+			t.Fatalf("failed to unmarshal log: %v", err)
 		}
 
-		e.assignFields()
+		r.assignFields()
 
 		tests := []struct {
 			key  string
 			got  string
 			want string
 		}{
-			{"command", e.command, c},
-			{"args", e.args, a},
-			{"profile", e.profile, p},
-			{"user", e.user, u},
-			{"version", e.version, v},
-			{"startTime", e.startTime, stFormatted},
-			{"endTime", e.endTime, etFormatted},
+			{"command", r.command, c},
+			{"args", r.args, a},
+			{"profile", r.profile, p},
+			{"user", r.user, u},
+			{"version", r.version, v},
+			{"startTime", r.startTime, stFormatted},
+			{"endTime", r.endTime, etFormatted},
 		}
 
 		for _, tt := range tests {

--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -206,7 +206,7 @@ func outputAudit(lines int) error {
 	out.Step(style.Empty, "==> Audit <==")
 	r, err := audit.Report(lines)
 	if err != nil {
-		return fmt.Errorf("failed to create audit report with error: %v", err)
+		return fmt.Errorf("failed to create audit report: %v", err)
 	}
 	out.Step(style.Empty, r.ASCIITable())
 	return nil

--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -208,7 +208,7 @@ func outputAudit(lines int) error {
 	if err != nil {
 		return fmt.Errorf("failed to create audit report with error: %v", err)
 	}
-	out.Step(style.Empty, r.Table())
+	out.Step(style.Empty, r.ASCIITable())
 	return nil
 }
 

--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
+	"k8s.io/minikube/pkg/minikube/audit"
 	"k8s.io/minikube/pkg/minikube/bootstrapper"
 	"k8s.io/minikube/pkg/minikube/command"
 	"k8s.io/minikube/pkg/minikube/config"
@@ -188,10 +189,25 @@ func Output(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.Cluster
 		}
 	}
 
+	outputAudit(lines, failed)
+
 	if len(failed) > 0 {
 		return fmt.Errorf("unable to fetch logs for: %s", strings.Join(failed, ", "))
 	}
 	return nil
+}
+
+// outputAudit displays the audit logs.
+func outputAudit(lines int, failed []string) {
+	out.Step(style.Empty, "")
+	out.Step(style.Empty, "==> Audit <==")
+	a, err := audit.Retrieve(lines)
+	if err != nil {
+		klog.Errorf("failed to get audit logs with error: %v", err)
+		failed = append(failed, "audit")
+		return
+	}
+	out.Step(style.Empty, a)
 }
 
 // logCommands returns a list of commands that would be run to receive the anticipated logs

--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -208,11 +208,7 @@ func outputAudit(lines int) error {
 	if err != nil {
 		return fmt.Errorf("failed to create audit report with error: %v", err)
 	}
-	t, err := r.Table()
-	if err != nil {
-		return fmt.Errorf("failed to create audit table with error: %v", err)
-	}
-	out.Step(style.Empty, t)
+	out.Step(style.Empty, r.Table())
 	return nil
 }
 

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -722,7 +722,7 @@ func validateLogsCmd(ctx context.Context, t *testing.T, profile string) {
 	if err != nil {
 		t.Errorf("%s failed: %v", rr.Command(), err)
 	}
-	expectedWords := []string{"apiserver", "Linux", "kubelet"}
+	expectedWords := []string{"apiserver", "Linux", "kubelet", "Audit"}
 	switch ContainerRuntime() {
 	case "docker":
 		expectedWords = append(expectedWords, "Docker")

--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -196,6 +196,13 @@ func TestStoppedBinaryUpgrade(t *testing.T) {
 	if err != nil {
 		t.Fatalf("upgrade from %s to HEAD failed: %s: %v", legacyVersion, rr.Command(), err)
 	}
+
+	t.Run("MinikubeLogs", func(t *testing.T) {
+		rr, err = Run(t, exec.CommandContext(ctx, Target(), "logs"))
+		if err != nil {
+			t.Fatalf("minikube logs after upgrade to HEAD failed: %v", err)
+		}
+	})
 }
 
 // TestKubernetesUpgrade upgrades Kubernetes from oldest to newest

--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -198,7 +198,8 @@ func TestStoppedBinaryUpgrade(t *testing.T) {
 	}
 
 	t.Run("MinikubeLogs", func(t *testing.T) {
-		rr, err = Run(t, exec.CommandContext(ctx, Target(), "logs"))
+		args := []string{"logs", "-p", profile}
+		rr, err = Run(t, exec.CommandContext(ctx, Target(), args...))
 		if err != nil {
 			t.Fatalf("`minikube logs` after upgrade to HEAD from %s failed: %v", legacyVersion, err)
 		}

--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -200,7 +200,7 @@ func TestStoppedBinaryUpgrade(t *testing.T) {
 	t.Run("MinikubeLogs", func(t *testing.T) {
 		rr, err = Run(t, exec.CommandContext(ctx, Target(), "logs"))
 		if err != nil {
-			t.Fatalf("minikube logs after upgrade to HEAD failed: %v", err)
+			t.Fatalf("`minikube logs` after upgrade to HEAD from %s failed: %v", legacyVersion, err)
 		}
 	})
 }


### PR DESCRIPTION
Implements: #10335 

Implementation reads in audit logs from file, converts the logs from JSON to structs, converts the structs into table cells, and finally converts the cells into a formatted table. Also added minikube version to the audit logging.

```
==> Audit <==
|---------|-------------------|----------|--------------|---------|-------------------------------|-------------------------------|
| Command |       Args        | Profile  |     User     | Version |          Start Time           |           End Time            |
|---------|-------------------|----------|--------------|---------|-------------------------------|-------------------------------|
| start   | --alsologtostderr | minikube | powellsteven | v1.17.1 | Fri, 12 Feb 2021 12:58:01 MST | Fri, 12 Feb 2021 12:58:49 MST |
| logs    | --user=cat        | minikube | cat          | v1.17.1 | Fri, 12 Feb 2021 13:00:12 MST | Fri, 12 Feb 2021 13:00:27 MST |
| delete  | --all             | minikube | powellsteven | v1.17.1 | Fri, 12 Feb 2021 13:00:38 MST | Fri, 12 Feb 2021 13:00:42 MST |
|---------|-------------------|----------|--------------|---------|-------------------------------|-------------------------------|
```