### PR TITLE
Provide advice when running windows binary (.exe) inside WSL

### DIFF
--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/audit"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/minikube/out"
@@ -97,6 +98,17 @@ func Execute() {
 			os.Args = append([]string{RootCmd.Use, callingCmd, profile, "--"}, os.Args[1:]...)
 		} else {
 			os.Args = append([]string{RootCmd.Use, callingCmd, "--"}, os.Args[1:]...)
+		}
+	} else if filepath.Ext(callingCmd) == ".exe" && driver.IsMicrosoftWSL() {
+		var found = false
+		for _, a := range os.Args {
+			if a == "--force" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			exit.Message(reason.WrongBinary, "Cannot run Windows binary inside WSL, please download linux binary from https://minikube.sigs.k8s.io/docs/start/. Or you can use '--force' to force execution which would be at your own risk.")
 		}
 	}
 	for _, c := range RootCmd.Commands() {

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -108,7 +108,7 @@ func Execute() {
 			}
 		}
 		if !found {
-			exit.Message(reason.WrongBinaryWSL, "You are trying to run windows .exe binary inside WSL, for better integration please use Linux binary instead (Download at https://minikube.sigs.k8s.io/docs/start/.). Otherwise if you still want to do this, you can do it using --force"
+			exit.Message(reason.WrongBinaryWSL, "You are trying to run windows .exe binary inside WSL, for better integration please use Linux binary instead (Download at https://minikube.sigs.k8s.io/docs/start/.). Otherwise if you still want to do this, you can do it using --force")
 		}
 	}
 	for _, c := range RootCmd.Commands() {

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -108,7 +108,7 @@ func Execute() {
 			}
 		}
 		if !found {
-			exit.Message(reason.WrongBinary, "Cannot run Windows binary inside WSL, please download linux binary from https://minikube.sigs.k8s.io/docs/start/. Or you can use '--force' to force execution which would be at your own risk.")
+			exit.Message(reason.WrongBinaryWSL, "You are trying to run windows .exe binary inside WSL, for better integration please use Linux binary instead (Download at https://minikube.sigs.k8s.io/docs/start/.). Otherwise if you still want to do this, you can do it using --force"
 		}
 	}
 	for _, c := range RootCmd.Commands() {

--- a/cmd/minikube/main.go
+++ b/cmd/minikube/main.go
@@ -24,13 +24,9 @@ import (
 	"os"
 	"regexp"
 	"strconv"
-  "path/filepath"
 
 	"github.com/spf13/pflag"
 	"k8s.io/klog/v2"
-  "k8s.io/minikube/pkg/minikube/driver"
-  "k8s.io/minikube/pkg/minikube/exit"
-  "k8s.io/minikube/pkg/minikube/reason"
 
 	// Register drivers
 	_ "k8s.io/minikube/pkg/minikube/registry/drvs"
@@ -76,11 +72,6 @@ func main() {
 	}
 	out.SetOutFile(os.Stdout)
 	out.SetErrFile(os.Stderr)
-
-  if filepath.Ext(os.Args[0]) == ".exe" && driver.IsMicrosoftWSL() {
-    exit.Message(reason.WslExeConflict, "Cannot run windows binary inside WSL.")
-  }
-
 	cmd.Execute()
 }
 

--- a/cmd/minikube/main.go
+++ b/cmd/minikube/main.go
@@ -24,9 +24,13 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+  "path/filepath"
 
 	"github.com/spf13/pflag"
 	"k8s.io/klog/v2"
+  "k8s.io/minikube/pkg/minikube/driver"
+  "k8s.io/minikube/pkg/minikube/exit"
+  "k8s.io/minikube/pkg/minikube/reason"
 
 	// Register drivers
 	_ "k8s.io/minikube/pkg/minikube/registry/drvs"
@@ -72,6 +76,11 @@ func main() {
 	}
 	out.SetOutFile(os.Stdout)
 	out.SetErrFile(os.Stderr)
+
+  if filepath.Ext(os.Args[0]) == ".exe" && driver.IsMicrosoftWSL() {
+    exit.Message(reason.WslExeConflict, "Cannot run windows binary inside WSL.")
+  }
+
 	cmd.Execute()
 }
 

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -190,7 +190,7 @@ var (
 
 	RsrcInsufficientStorage = Kind{ID: "RSRC_INSUFFICIENT_STORAGE", ExitCode: ExInsufficientStorage, Style: style.UnmetRequirement}
 
-	WrongBinary        = Kind{ID: "WRONG_BINARY", ExitCode: ExHostError}
+	WrongBinaryWSL     = Kind{ID: "WRONG_BINARY_WSL", ExitCode: ExHostError}
 	HostHomeMkdir      = Kind{ID: "HOST_HOME_MKDIR", ExitCode: ExHostPermission}
 	HostHomeChown      = Kind{ID: "HOST_HOME_CHOWN", ExitCode: ExHostPermission}
 	HostBrowser        = Kind{ID: "HOST_BROWSER", ExitCode: ExHostError}

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -190,6 +190,7 @@ var (
 
 	RsrcInsufficientStorage = Kind{ID: "RSRC_INSUFFICIENT_STORAGE", ExitCode: ExInsufficientStorage, Style: style.UnmetRequirement}
 
+	WrongBinary        = Kind{ID: "WRONG_BINARY", ExitCode: ExHostError}
 	HostHomeMkdir      = Kind{ID: "HOST_HOME_MKDIR", ExitCode: ExHostPermission}
 	HostHomeChown      = Kind{ID: "HOST_HOME_CHOWN", ExitCode: ExHostPermission}
 	HostBrowser        = Kind{ID: "HOST_BROWSER", ExitCode: ExHostError}
@@ -286,7 +287,6 @@ var (
 	EnvMultiConflict     = Kind{ID: "ENV_MULTINODE_CONFLICT", ExitCode: ExGuestConflict}
 	EnvDockerUnavailable = Kind{ID: "ENV_DOCKER_UNAVAILABLE", ExitCode: ExRuntimeUnavailable}
 	EnvPodmanUnavailable = Kind{ID: "ENV_PODMAN_UNAVAILABLE", ExitCode: ExRuntimeUnavailable}
-	WslExeConflict = Kind{ID: "WSL_EXE_CONFLICT", ExitCode: ExGuestConflict}
 
 	AddonUnsupported = Kind{ID: "SVC_ADDON_UNSUPPORTED", ExitCode: ExSvcUnsupported}
 	AddonNotEnabled  = Kind{ID: "SVC_ADDON_NOT_ENABLED", ExitCode: ExProgramConflict}

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -286,6 +286,7 @@ var (
 	EnvMultiConflict     = Kind{ID: "ENV_MULTINODE_CONFLICT", ExitCode: ExGuestConflict}
 	EnvDockerUnavailable = Kind{ID: "ENV_DOCKER_UNAVAILABLE", ExitCode: ExRuntimeUnavailable}
 	EnvPodmanUnavailable = Kind{ID: "ENV_PODMAN_UNAVAILABLE", ExitCode: ExRuntimeUnavailable}
+	WslExeConflict = Kind{ID: "WSL_EXE_CONFLICT", ExitCode: ExGuestConflict}
 
 	AddonUnsupported = Kind{ID: "SVC_ADDON_UNSUPPORTED", ExitCode: ExSvcUnsupported}
 	AddonNotEnabled  = Kind{ID: "SVC_ADDON_NOT_ENABLED", ExitCode: ExProgramConflict}

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -75,6 +75,8 @@ var (
 	Usage       = Kind{ID: "MK_USAGE", ExitCode: ExProgramUsage}
 	Interrupted = Kind{ID: "MK_INTERRUPTED", ExitCode: ExProgramConflict}
 
+	WrongBinaryWSL = Kind{ID: "MK_WRONG_BINARY_WSL", ExitCode: ExProgramUnsupported}
+
 	NewAPIClient             = Kind{ID: "MK_NEW_APICLIENT", ExitCode: ExProgramError}
 	InternalAddonEnable      = Kind{ID: "MK_ADDON_ENABLE", ExitCode: ExProgramError}
 	InternalAddConfig        = Kind{ID: "MK_ADD_CONFIG", ExitCode: ExProgramError}
@@ -190,7 +192,6 @@ var (
 
 	RsrcInsufficientStorage = Kind{ID: "RSRC_INSUFFICIENT_STORAGE", ExitCode: ExInsufficientStorage, Style: style.UnmetRequirement}
 
-	WrongBinaryWSL     = Kind{ID: "WRONG_BINARY_WSL", ExitCode: ExHostError}
 	HostHomeMkdir      = Kind{ID: "HOST_HOME_MKDIR", ExitCode: ExHostPermission}
 	HostHomeChown      = Kind{ID: "HOST_HOME_CHOWN", ExitCode: ExHostPermission}
 	HostBrowser        = Kind{ID: "HOST_BROWSER", ExitCode: ExHostError}


### PR DESCRIPTION
Fixes #10311 

Throws out MK_WRONG_BINARY_WSL error if user tries to run windows binary (.exe) inside WSL and advises them either to run with '--force' or download correct binary.

**Before PR**
```
#  Inside WSL on windows 10
$  ./minikube-windows-amd64.exe start --dry-run
😄  minikube v1.17.1 on Microsoft Windows 10 Education 10.0.19041 Build 19041
✨  Automatically selected the docker driver. Other choices: virtualbox, ssh
🌵  dry-run validation complete!
```

**After PR**
```
# Inside WSL on windows 10

$ ./minikube-windows-amd64.exe start --dry-run --force
😄  minikube v1.17.1 on Microsoft Windows 10 Education 10.0.19041 Build 19041
❗  minikube skips various validations when --force is supplied; this may lead to unexpected behavior
✨  Automatically selected the docker driver. Other choices: virtualbox, ssh
🌵  dry-run validation complete!

$ ./minikube-windows-amd64.exe start --dry-run

❌  Exiting due to MK_WRONG_BINARY_WSL: You are trying to run windows .exe binary inside WSL, for better integration please use Linux binary instead (Download at https://minikube.sigs.k8s.io/docs/start/.). Otherwise if you still want to do this, you can do it using --force
```


<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
