### PR TITLE
Wait for the CRI socket to be created properly

### DIFF
--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -277,11 +277,53 @@ func configureRuntimes(runner cruntime.CommandRunner, cc config.ClusterConfig, k
 		exit.Error(reason.RuntimeEnable, "Failed to enable container runtime", err)
 	}
 
+	// Wait for the CRI to be "live", before returning it
+	err = waitForCRISocket(runner, cr.SocketPath(), 60, 1)
+	if err != nil {
+		exit.Error(reason.RuntimeEnable, "Failed to start container runtime", err)
+	}
+
 	return cr
 }
 
 func forceSystemd() bool {
 	return viper.GetBool("force-systemd") || os.Getenv(constants.MinikubeForceSystemdEnv) == "true"
+}
+
+func pathExists(runner cruntime.CommandRunner, path string) (bool, error) {
+	_, err := runner.RunCmd(exec.Command("stat", path))
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+func waitForCRISocket(runner cruntime.CommandRunner, socket string, wait int, interval int) error {
+
+	if socket == "" || socket == "/var/run/dockershim.sock" {
+		return nil
+	}
+
+	klog.Infof("Will wait %ds for socket path %s", wait, socket)
+
+	chkPath := func() error {
+		e, err := pathExists(runner, socket)
+		if err != nil {
+			return err
+		}
+		if !e {
+			return &retry.RetriableError{Err: err}
+		}
+		return nil
+	}
+	if err := retry.Expo(chkPath, time.Duration(interval)*time.Second, time.Duration(wait)*time.Second); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // setupKubeAdm adds any requested files into the VM before Kubernetes is started


### PR DESCRIPTION
Before returning the container runtime back to
the caller. Wait for a minute (usually 1 second)

Note that this doesn't apply to the dockershim,
it only replies to runtimes that are using CRI.

----

The `systemctl restart containerd` completes right away, before the service is up and running properly.

This makes all `crictl` fail, later on. Instead wait for the CRI socket to get created, before continuing to use it.


Sample output, after this fix:

```
I0203 17:29:44.499642  639526 ssh_runner.go:149] Run: sudo systemctl daemon-reload
\ I0203 17:29:44.623605  639526 ssh_runner.go:149] Run: sudo systemctl restart containerd
| I0203 17:29:44.640926  639526 start.go:310] Will wait 60s for socket path /run/containerd/containerd.sock
I0203 17:29:44.641013  639526 ssh_runner.go:149] Run: stat /run/containerd/containerd.sock
I0203 17:29:44.646209  639526 retry.go:31] will retry after 1.164560053s: stat /run/containerd/containerd.sock: Process exited with status 1
stdout:

stderr:
stat: cannot stat '/run/containerd/containerd.sock': No such file or directory
\ I0203 17:29:45.811180  639526 ssh_runner.go:149] Run: stat /run/containerd/containerd.sock
I0203 17:29:45.826178  639526 ssh_runner.go:149] Run: containerd --version
| I0203 17:29:45.882469  639526 out.go:119] 📦  Preparing Kubernetes v1.20.2 on containerd 1.4.3 ...
```

It can be an issue for large installations, where it takes a while to start up the container runtime.

Note that this doesn't apply to Docker, it only applies to CRI and not to the kubelet dockershim.

EDIT: Actually it _will_ apply to Docker too in the future, when it starts using CRI: #9868


Closes #10355