### PR TITLE
Return an ErrorType when 'docker version' command crashes and provide an advice.

### DIFF
--- a/pkg/drivers/kic/oci/errors.go
+++ b/pkg/drivers/kic/oci/errors.go
@@ -33,6 +33,9 @@ func (f *FailFastError) Error() string {
 	return f.Err.Error()
 }
 
+// ErrDockerDaemonNotRunning is thrown when docker been configured to run windows containers instead of Linux
+var ErrDockerDaemonNotRunning = &FailFastError{errors.New("docker daemon is not running")}
+
 // ErrWindowsContainers is thrown when docker been configured to run windows containers instead of Linux
 var ErrWindowsContainers = &FailFastError{errors.New("docker container type is windows")}
 

--- a/pkg/minikube/bootstrapper/bsutil/kubeadm.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubeadm.go
@@ -26,6 +26,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
+	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/bootstrapper/bsutil/ktmpl"
 	"k8s.io/minikube/pkg/minikube/cni"
 	"k8s.io/minikube/pkg/minikube/config"
@@ -66,7 +67,7 @@ func GenerateKubeadmYAML(cc config.ClusterConfig, n config.Node, r cruntime.Mana
 	cgroupDriver, err := r.CGroupDriver()
 	if err != nil {
 		if driver.BareMetal(cc.Driver) && r.Name() == "Docker" && strings.Contains(err.Error(), "panic") {
-			return nil, errors.Wrap(err, "Docker daemon is not running with None driver")
+			return nil, oci.ErrDockerNotRunning
 		}
 		return nil, errors.Wrap(err, "getting cgroup driver")
 	}

--- a/pkg/minikube/bootstrapper/bsutil/kubeadm.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubeadm.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"fmt"
 	"path"
+	"strings"
 
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
@@ -30,6 +31,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/cruntime"
+	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/vmpath"
 	"k8s.io/minikube/pkg/util"
 )
@@ -63,6 +65,9 @@ func GenerateKubeadmYAML(cc config.ClusterConfig, n config.Node, r cruntime.Mana
 
 	cgroupDriver, err := r.CGroupDriver()
 	if err != nil {
+		if driver.BareMetal(cc.Driver) && r.Name() == "Docker" && strings.Contains(err.Error(), "panic") {
+			return nil, errors.Wrap(err, "Docker daemon is not running with None driver")
+		}
 		return nil, errors.Wrap(err, "getting cgroup driver")
 	}
 

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -297,6 +297,9 @@ func setupKubeAdm(mAPI libmachine.API, cfg config.ClusterConfig, n config.Node, 
 	// update cluster and set up certs
 
 	if err := bs.UpdateCluster(cfg); err != nil {
+		if errors.Is(err, oci.ErrDockerNotRunning) {
+			exit.Message(reason.EnvDockerUnavailable, "Docker deamon is not running.")
+		}
 		exit.Error(reason.KubernetesInstallFailed, "Failed to update cluster", err)
 	}
 


### PR DESCRIPTION
Return an ErrorType when 'docker version' command crashes due to docker daemon is not running and provide an advice to users. This fixes #10165 

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
