### PR TITLE
adding new exit code word for when runtime not running 

### DIFF
--- a/pkg/drivers/kic/oci/errors.go
+++ b/pkg/drivers/kic/oci/errors.go
@@ -33,6 +33,9 @@ func (f *FailFastError) Error() string {
 	return f.Err.Error()
 }
 
+// ErrDockerRuntimeNotRunning is thrown when docker runtime is not running
+var ErrDockerRuntimeNotRunning = &FailFastError{errors.New("docker runtime is not running")}
+
 // ErrWindowsContainers is thrown when docker been configured to run windows containers instead of Linux
 var ErrWindowsContainers = &FailFastError{errors.New("docker container type is windows")}
 

--- a/pkg/drivers/kic/oci/errors.go
+++ b/pkg/drivers/kic/oci/errors.go
@@ -33,9 +33,6 @@ func (f *FailFastError) Error() string {
 	return f.Err.Error()
 }
 
-// ErrDockerRuntimeNotRunning is thrown when docker runtime is not running
-var ErrDockerRuntimeNotRunning = &FailFastError{errors.New("docker runtime is not running")}
-
 // ErrWindowsContainers is thrown when docker been configured to run windows containers instead of Linux
 var ErrWindowsContainers = &FailFastError{errors.New("docker container type is windows")}
 

--- a/pkg/minikube/bootstrapper/bsutil/kubeadm.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubeadm.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"fmt"
 	"path"
+	"strings"
 
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
@@ -30,6 +31,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/cruntime"
+	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/vmpath"
 	"k8s.io/minikube/pkg/util"
 )
@@ -63,6 +65,9 @@ func GenerateKubeadmYAML(cc config.ClusterConfig, n config.Node, r cruntime.Mana
 
 	cgroupDriver, err := r.CGroupDriver()
 	if err != nil {
+		if driver.BareMetal(cc.Driver) && r.Name() == "Docker" && strings.Contains(err.Error(), "panic") {
+			return nil, errors.Wrap(err, "Docker daemon is not running with None driver")
+		}
 		return nil, errors.Wrap(err, "getting cgroup driver")
 	}
 

--- a/pkg/minikube/bootstrapper/bsutil/kubeadm.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubeadm.go
@@ -66,7 +66,7 @@ func GenerateKubeadmYAML(cc config.ClusterConfig, n config.Node, r cruntime.Mana
 	cgroupDriver, err := r.CGroupDriver()
 	if err != nil {
 		// Whether it is a known failure and replace it with the correct ErrorType.
-		if known, err := IsKnownError(err); known {
+		if known, err := detectRuntImeError(err); known {
 			return nil, err
 		}
 		return nil, errors.Wrap(err, "getting cgroup driver")
@@ -205,8 +205,8 @@ func etcdExtraArgs(extraOpts config.ExtraOptionSlice) map[string]string {
 	return args
 }
 
-// IsKnownError replaces raw error type if the error is known.
-func IsKnownError(err error) (bool, error) {
+// detectRuntImeError replaces raw error type if the error is known.
+func detectRuntImeError(err error) (bool, error) {
 	// If docker runtime is not running, some docker command will crash and
 	// others will return a error message.
 	if strings.Contains(err.Error(), "github.com/docker/cli/cli/command/system.formatInfo") || strings.Contains(err.Error(), "Cannot connect to the Docker daemon") {

--- a/pkg/minikube/bootstrapper/bsutil/kubeadm.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubeadm.go
@@ -25,7 +25,6 @@ import (
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
-	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/bootstrapper/bsutil/ktmpl"
 	"k8s.io/minikube/pkg/minikube/cni"
 	"k8s.io/minikube/pkg/minikube/config"
@@ -65,7 +64,7 @@ func GenerateKubeadmYAML(cc config.ClusterConfig, n config.Node, r cruntime.Mana
 	cgroupDriver, err := r.CGroupDriver()
 	if err != nil {
 		if !r.Active() {
-			return nil, oci.ErrDockerRuntimeNotRunning
+			return nil, cruntime.ErrContainerRuntimeNotRunning
 		}
 		return nil, errors.Wrap(err, "getting cgroup driver")
 	}

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -145,7 +145,7 @@ type ListOptions struct {
 	Namespaces []string
 }
 
-// ErrContainerRuntimeNotRunning is thrown when docker runtime is not running
+// ErrContainerRuntimeNotRunning is thrown when container runtime is not running
 var ErrContainerRuntimeNotRunning = errors.New("container runtime is not running")
 
 // New returns an appropriately configured runtime

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -22,7 +22,9 @@ import (
 	"os/exec"
 
 	"github.com/blang/semver"
+	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
+	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/command"
 	"k8s.io/minikube/pkg/minikube/config"
@@ -143,6 +145,9 @@ type ListOptions struct {
 	// Namespaces is the namespaces to look into
 	Namespaces []string
 }
+
+// ErrContainerRuntimeNotRunning is thrown when docker runtime is not running
+var ErrContainerRuntimeNotRunning = &oci.FailFastError{Err: errors.New("container runtime is not running")}
 
 // New returns an appropriately configured runtime
 func New(c Config) (Manager, error) {

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -24,7 +24,6 @@ import (
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
-	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/command"
 	"k8s.io/minikube/pkg/minikube/config"
@@ -147,7 +146,7 @@ type ListOptions struct {
 }
 
 // ErrContainerRuntimeNotRunning is thrown when docker runtime is not running
-var ErrContainerRuntimeNotRunning = &oci.FailFastError{Err: errors.New("container runtime is not running")}
+var ErrContainerRuntimeNotRunning = errors.New("container runtime is not running")
 
 // New returns an appropriately configured runtime
 func New(c Config) (Manager, error) {

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -345,6 +345,9 @@ func setupKubeAdm(mAPI libmachine.API, cfg config.ClusterConfig, n config.Node, 
 	// update cluster and set up certs
 
 	if err := bs.UpdateCluster(cfg); err != nil {
+		if errors.Is(err, oci.ErrDockerRuntimeNotRunning) {
+			exit.Message(reason.EnvDockerUnavailable, "Docker runtime is not running.")
+		}
 		exit.Error(reason.KubernetesInstallFailed, "Failed to update cluster", err)
 	}
 

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -346,7 +346,7 @@ func setupKubeAdm(mAPI libmachine.API, cfg config.ClusterConfig, n config.Node, 
 
 	if err := bs.UpdateCluster(cfg); err != nil {
 		if errors.Is(err, cruntime.ErrContainerRuntimeNotRunning) {
-			exit.Message(reason.EnvDockerUnavailable, "Container runtime is not running.")
+			exit.Error(reason.KubernetesInstallFailedRuntimeNotRunning, "Failed to update cluster", err)
 		}
 		exit.Error(reason.KubernetesInstallFailed, "Failed to update cluster", err)
 	}

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -345,8 +345,8 @@ func setupKubeAdm(mAPI libmachine.API, cfg config.ClusterConfig, n config.Node, 
 	// update cluster and set up certs
 
 	if err := bs.UpdateCluster(cfg); err != nil {
-		if errors.Is(err, oci.ErrDockerRuntimeNotRunning) {
-			exit.Message(reason.EnvDockerUnavailable, "Docker runtime is not running.")
+		if errors.Is(err, cruntime.ErrContainerRuntimeNotRunning) {
+			exit.Message(reason.EnvDockerUnavailable, "Container runtime is not running.")
 		}
 		exit.Error(reason.KubernetesInstallFailed, "Failed to update cluster", err)
 	}

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -293,9 +293,10 @@ var (
 	AddonUnsupported = Kind{ID: "SVC_ADDON_UNSUPPORTED", ExitCode: ExSvcUnsupported}
 	AddonNotEnabled  = Kind{ID: "SVC_ADDON_NOT_ENABLED", ExitCode: ExProgramConflict}
 
-	KubernetesInstallFailed = Kind{ID: "K8S_INSTALL_FAILED", ExitCode: ExControlPlaneError}
-	KubernetesTooOld        = Kind{ID: "K8S_OLD_UNSUPPORTED", ExitCode: ExControlPlaneUnsupported}
-	KubernetesDowngrade     = Kind{
+	KubernetesInstallFailed                  = Kind{ID: "K8S_INSTALL_FAILED", ExitCode: ExControlPlaneError}
+	KubernetesInstallFailedRuntimeNotRunning = Kind{ID: "K8S_INSTALL_FAILED_CONTAINER_RUNTIME_NOT_RUNNING", ExitCode: ExRuntimeNotRunning}
+	KubernetesTooOld                         = Kind{ID: "K8S_OLD_UNSUPPORTED", ExitCode: ExControlPlaneUnsupported}
+	KubernetesDowngrade                      = Kind{
 		ID:       "K8S_DOWNGRADE_UNSUPPORTED",
 		ExitCode: ExControlPlaneUnsupported,
 		Advice: `1) Recreate the cluster with Kubernetes {{.new}}, by running:


### PR DESCRIPTION
Fixes #10165.

Throws an `ErrContainerRuntimeNotRunning` error when container commands fail/crash due container runtime not running. 

**Before PR**
As shown in #10165, if container is not running, it will output crash info.

**After PR**
Hint user that container is not running.


<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
