### PR TITLE
support ancient versions of docker again (template parsing issue)

### DIFF
--- a/pkg/drivers/kic/oci/network_create.go
+++ b/pkg/drivers/kic/oci/network_create.go
@@ -172,8 +172,12 @@ type networkInspect struct {
 }
 
 var dockerInsepctGetter = func(name string) (*RunResult, error) {
-	cmd := exec.Command(Docker, "network", "inspect", name, "--format", `{"Name": "{{.Name}}","Driver": "{{.Driver}}","Subnet": "{{range .IPAM.Config}}{{.Subnet}}{{end}}","Gateway": "{{range .IPAM.Config}}{{.Gateway}}{{end}}","MTU": {{if (index .Options "com.docker.network.driver.mtu")}}{{(index .Options "com.docker.network.driver.mtu")}}{{else}}0{{end}},{{$first := true}} "ContainerIPs": [{{range $k,$v := .Containers }}{{if $first}}{{$first = false}}{{else}}, {{end}}"{{$v.IPv4Address}}"{{end}}]}`)
+	// hack -- 'support ancient versions of docker again (template parsing issue) #10362' and resolve 'Template parsing error: template: :1: unexpected "=" in operand' / 'exit status 64'
+	// note: docker v18.09.7 and older use go v1.10.8 and older, whereas support for '=' operator in go templates came in go v1.11
+	cmd := exec.Command(Docker, "network", "inspect", name, "--format", `{"Name": "{{.Name}}","Driver": "{{.Driver}}","Subnet": "{{range .IPAM.Config}}{{.Subnet}}{{end}}","Gateway": "{{range .IPAM.Config}}{{.Gateway}}{{end}}","MTU": {{if (index .Options "com.docker.network.driver.mtu")}}{{(index .Options "com.docker.network.driver.mtu")}}{{else}}0{{end}}, "ContainerIPs": [{{range $k,$v := .Containers }}"{{$v.IPv4Address}}",{{end}}]}`)
 	rr, err := runCmd(cmd)
+	// remove extra ',' after the last element in the ContainerIPs slice
+	rr.Stdout = *bytes.NewBuffer(bytes.ReplaceAll(rr.Stdout.Bytes(), []byte(",]"), []byte("]")))
 	return rr, err
 }
 

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -115,7 +115,7 @@ func status() registry.State {
 	}
 
 	klog.Infof("docker version: %s", o)
-	if s := checkDockerVersion(string(o)); s.Error != nil {
+	if s := checkDockerVersion(strings.TrimSpace(string(o))); s.Error != nil { // remove '\n' from o at the end
 		return s
 	}
 

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -188,12 +188,10 @@ func checkDockerVersion(o string) registry.State {
 			return registry.State{Installed: true, Healthy: true, Error: nil}
 		} else if k < minDockerVersion[i] {
 			return registry.State{
-				Reason:           "PROVIDER_DOCKER_VERSION_LOW",
-				Error:            oci.ErrMinDockerVersion,
 				Installed:        true,
-				Healthy:          false,
+				Healthy:          true,
 				NeedsImprovement: true,
-				Fix:              fmt.Sprintf("Upgrade %s to a newer version (Minimum supproted version is %2d.%2d.%d)", driver.FullName(driver.Docker), minDockerVersion[0], minDockerVersion[1], minDockerVersion[2]),
+				Fix:              fmt.Sprintf("Upgrade %s to a newer version (Minimum supproted version is %2d.%02d.%d)", driver.FullName(driver.Docker), minDockerVersion[0], minDockerVersion[1], minDockerVersion[2]),
 				Doc:              docURL + "#requirements"}
 		}
 	}

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -191,7 +191,7 @@ func checkDockerVersion(o string) registry.State {
 				Installed:        true,
 				Healthy:          true,
 				NeedsImprovement: true,
-				Fix:              fmt.Sprintf("Upgrade %s to a newer version (Minimum supproted version is %2d.%02d.%d)", driver.FullName(driver.Docker), minDockerVersion[0], minDockerVersion[1], minDockerVersion[2]),
+				Fix:              fmt.Sprintf("Upgrade %s to a newer version (Minimum recommended version is %2d.%02d.%d)", driver.FullName(driver.Docker), minDockerVersion[0], minDockerVersion[1], minDockerVersion[2]),
 				Doc:              docURL + "#requirements"}
 		}
 	}


### PR DESCRIPTION
fixes #10362 

as described in the original issue/comments, this pr changes the go template used to parse `docker network inspect --format` by avoiding the operator `=` that was introduced in go 1.11 (ref: https://golang.org/doc/go1.11#text/template) - to support older docker versions (eg, docker v18.09.7 uses go v1.10.8)

also, this pr fixes the error:
`Exiting due to PROVIDER_DOCKER_NOT_RUNNING: docker version: strconv.Atoi: parsing "7\n": invalid syntax`
in checkDockerVersion() while parsing the docker version - current master/main branch

### before:
```
❯ out/minikube start --driver=docker                        
😄  minikube v1.17.1 on Opensuse-Tumbleweed 
✨  Using the docker driver based on user configuration

💣  Exiting due to PROVIDER_DOCKER_NOT_RUNNING: docker version: strconv.Atoi: parsing "7\n": invalid syntax
📘  Documentation: https://minikube.sigs.k8s.io/docs/drivers/docker/
```
```
❯ docker version
Client: Docker Engine - Community
 Version:           18.09.7
 API version:       1.39
 Go version:        go1.10.8
 Git commit:        2d0083d
 Built:             Thu Jun 27 17:54:15 2019
 OS/Arch:           linux/amd64
 Experimental:      false

Server: Docker Engine - Community
 Engine:
  Version:          18.09.7
  API version:      1.39 (minimum version 1.12)
  Go version:       go1.10.8
  Git commit:       2d0083d
  Built:            Thu Jun 27 18:01:17 2019
  OS/Arch:          linux/amd64
  Experimental:     false
```
```
❯ minikube start
😄  minikube v1.17.1 on Opensuse-Tumbleweed
✨  Automatically selected the docker driver. Other choices: kvm2, ssh
💨  For improved Docker performance, enable the overlay Linux kernel module using 'modprobe overlay'
❗  docker is currently using the btrfs storage driver, consider switching to overlay2 for better performance
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=16000MB) ...
❗  This container is having trouble accessing https://k8s.gcr.io
💡  To pull new external images, you may need to configure a proxy: https://minikube.sigs.k8s.io/docs/reference/networking/proxy/
🐳  Preparing Kubernetes v1.20.2 on Docker 20.10.2 ...| E0204 15:32:19.529662    6891 start.go:99] Unable to get host IP: network inspect: docker network inspect minikube --format "{"Name": "{{.Name}}","Driver": "{{.Driver}}","Subnet": "{{range .IPAM.Config}}{{.Subnet}}{{end}}","Gateway": "{{range .IPAM.Config}}{{.Gateway}}{{end}}","MTU": {{if (index .Options "com.docker.network.driver.mtu")}}{{(index .Options "com.docker.network.driver.mtu")}}{{else}}0{{end}},{{$first := true}} "ContainerIPs": [{{range $k,$v := .Containers }}{{if $first}}{{$first = false}}{{else}}, {{end}}"{{$v.IPv4Address}}"{{end}}]}": exit status 64
stdout:

stderr:
Template parsing error: template: :1: unexpected "=" in operand
E0204 15:32:19.530306    6891 out.go:330] unable to execute Failed to setup kubeconfig: network inspect: docker network inspect minikube --format "{"Name": "{{.Name}}","Driver": "{{.Driver}}","Subnet": "{{range .IPAM.Config}}{{.Subnet}}{{end}}","Gateway": "{{range .IPAM.Config}}{{.Gateway}}{{end}}","MTU": {{if (index .Options "com.docker.network.driver.mtu")}}{{(index .Options "com.docker.network.driver.mtu")}}{{else}}0{{end}},{{$first := true}} "ContainerIPs": [{{range $k,$v := .Containers }}{{if $first}}{{$first = false}}{{else}}, {{end}}"{{$v.IPv4Address}}"{{end}}]}": exit status 64
stdout:

stderr:
Template parsing error: template: :1: unexpected "=" in operand
: template: Failed to setup kubeconfig: network inspect: docker network inspect minikube --format "{"Name": "{{.Name}}","Driver": "{{.Driver}}","Subnet": "{{range .IPAM.Config}}{{.Subnet}}{{end}}","Gateway": "{{range .IPAM.Config}}{{.Gateway}}{{end}}","MTU": {{if (index .Options "com.docker.network.driver.mtu")}}{{(index .Options "com.docker.network.driver.mtu")}}{{else}}0{{end}},{{$first := true}} "ContainerIPs": [{{range $k,$v := .Containers }}{{if $first}}{{$first = false}}{{else}}, {{end}}"{{$v.IPv4Address}}"{{end}}]}": exit status 64
stdout:

stderr:
Template parsing error: template: :1: unexpected "=" in operand
:1:253: executing "Failed to setup kubeconfig: network inspect: docker network inspect minikube --format \"{\"Name\": \"{{.Name}}\",\"Driver\": \"{{.Driver}}\",\"Subnet\": \"{{range .IPAM.Config}}{{.Subnet}}{{end}}\",\"Gateway\": \"{{range .IPAM.Config}}{{.Gateway}}{{end}}\",\"MTU\": {{if (index .Options \"com.docker.network.driver.mtu\")}}{{(index .Options \"com.docker.network.driver.mtu\")}}{{else}}0{{end}},{{$first := true}} \"ContainerIPs\": [{{range $k,$v := .Containers }}{{if $first}}{{$first = false}}{{else}}, {{end}}\"{{$v.IPv4Address}}\"{{end}}]}\": exit status 64\nstdout:\n\nstderr:\nTemplate parsing error: template: :1: unexpected \"=\" in operand\n" at <index .Options "com.docker.network.driver.mtu">: error calling index: index of untyped nil - returning raw string.


❌  Exiting due to GUEST_START: Failed to setup kubeconfig: network inspect: docker network inspect minikube --format "{"Name": "{{.Name}}","Driver": "{{.Driver}}","Subnet": "{{range .IPAM.Config}}{{.Subnet}}{{end}}","Gateway": "{{range .IPAM.Config}}{{.Gateway}}{{end}}","MTU": {{if (index .Options "com.docker.network.driver.mtu")}}{{(index .Options "com.docker.network.driver.mtu")}}{{else}}0{{end}},{{$first := true}} "ContainerIPs": [{{range $k,$v := .Containers }}{{if $first}}{{$first = false}}{{else}}, {{end}}"{{$v.IPv4Address}}"{{end}}]}": exit status 64
stdout:

stderr:
Template parsing error: template: :1: unexpected "=" in operand


😿  If the above advice does not help, please let us know:
👉  https://github.com/kubernetes/minikube/issues/new/choose
```

### after:
```
❯ docker version
Client: Docker Engine - Community
 Version:           18.09.7
 API version:       1.39
 Go version:        go1.10.8
 Git commit:        2d0083d
 Built:             Thu Jun 27 17:54:15 2019
 OS/Arch:           linux/amd64
 Experimental:      false

Server: Docker Engine - Community
 Engine:
  Version:          18.09.7
  API version:      1.39 (minimum version 1.12)
  Go version:       go1.10.8
  Git commit:       2d0083d
  Built:            Thu Jun 27 18:01:17 2019
  OS/Arch:          linux/amd64
  Experimental:     false
```
```
❯ out/minikube start
😄  minikube v1.17.1 on Opensuse-Tumbleweed
✨  Automatically selected the docker driver. Other choices: kvm2, ssh
❗  docker is currently using the btrfs storage driver, consider switching to overlay2 for better performance
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=16000MB) ...
❗  This container is having trouble accessing https://k8s.gcr.io
💡  To pull new external images, you may need to configure a proxy: https://minikube.sigs.k8s.io/docs/reference/networking/proxy/
🐳  Preparing Kubernetes v1.20.2 on Docker 20.10.2 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v4
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```
```
❯ minikube profile list
|----------|-----------|---------|--------------|------|---------|---------|-------|
| Profile  | VM Driver | Runtime |      IP      | Port | Version | Status  | Nodes |
|----------|-----------|---------|--------------|------|---------|---------|-------|
| minikube | docker    | docker  | 192.168.49.2 | 8443 | v1.20.2 | Running |     1 |
|----------|-----------|---------|--------------|------|---------|---------|-------|
```

---

### confirmed working with newer versions:

```
❯ docker version
Client:
 Version:           19.03.14
 API version:       1.40
 Go version:        go1.13.15
 Git commit:        5eb3275d4006
 Built:             Wed Dec 23 00:00:00 2020
 OS/Arch:           linux/amd64
 Experimental:      false

Server:
 Engine:
  Version:          19.03.14
  API version:      1.40 (minimum version 1.12)
  Go version:       go1.13.15
  Git commit:       5eb3275d4006
  Built:            Wed Dec 23 00:00:00 2020
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          v1.3.9
  GitCommit:        ea765aba0d05254012b0b9e595e995c09186427f
 runc:
  Version:          1.0.0-rc10
  GitCommit:        dc9208a3303feef5b3839f4323d9beb36df0a9dd
 docker-init:
  Version:          0.1.5_catatonit
  GitCommit:
```
```
❯ docker version
Client: Docker Engine - Community
 Version:           20.10.3
 API version:       1.41
 Go version:        go1.13.15
 Git commit:        48d30b5
 Built:             Fri Jan 29 14:28:23 2021
 OS/Arch:           linux/amd64
 Context:           default
 Experimental:      true

Server: Docker Engine - Community
 Engine:
  Version:          20.10.3
  API version:      1.41 (minimum version 1.12)
  Go version:       go1.13.15
  Git commit:       46229ca
  Built:            Fri Jan 29 14:31:57 2021
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          v1.4.3
  GitCommit:        269548fa27e0089a8b8278fc4fc781d7f65a939b
 runc:
  Version:          1.0.0-rc92
  GitCommit:        ff819c7e9184c13b7c2607fe6c30ae19403a7aff
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```
```
❯ out/minikube start
😄  minikube v1.17.1 on Opensuse-Tumbleweed
✨  Automatically selected the docker driver. Other choices: kvm2, ssh
❗  docker is currently using the btrfs storage driver, consider switching to overlay2 for better performance
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=16000MB) ...
🐳  Preparing Kubernetes v1.20.2 on Docker 20.10.2 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v4
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default```
```
```
❯ out/minikube profile list
|----------|-----------|---------|--------------|------|---------|---------|-------|
| Profile  | VM Driver | Runtime |      IP      | Port | Version | Status  | Nodes |
|----------|-----------|---------|--------------|------|---------|---------|-------|
| minikube | docker    | docker  | 192.168.49.2 | 8443 | v1.20.2 | Running |     1 |
|----------|-----------|---------|--------------|------|---------|---------|-------|
```
