### PR TITLE
disable dockerd for container runtime

### DIFF
--- a/pkg/minikube/cruntime/cruntime_test.go
+++ b/pkg/minikube/cruntime/cruntime_test.go
@@ -557,7 +557,7 @@ func TestDisable(t *testing.T) {
 		runtime string
 		want    []string
 	}{
-		{"docker", []string{"sudo", "systemctl", "stop", "-f", "docker"}},
+		{"docker", []string{"sudo", "systemctl", "stop", "-f", "docker.socket", "sudo", "systemctl", "stop", "-f", "docker"}},
 		{"crio", []string{"sudo", "systemctl", "stop", "-f", "crio"}},
 		{"containerd", []string{"sudo", "systemctl", "stop", "-f", "containerd"}},
 	}

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -137,6 +137,10 @@ func (r *Docker) Restart() error {
 
 // Disable idempotently disables Docker on a host
 func (r *Docker) Disable() error {
+	// because #10373
+	if err := r.Init.ForceStop("docker.socket"); err != nil {
+		return err
+	}
 	return r.Init.ForceStop("docker")
 }
 

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -139,7 +139,7 @@ func (r *Docker) Restart() error {
 func (r *Docker) Disable() error {
 	// because #10373
 	if err := r.Init.ForceStop("docker.socket"); err != nil {
-		return err
+		klog.ErrorS(err, "Failed to stop", "service", "docker.socket")
 	}
 	return r.Init.ForceStop("docker")
 }


### PR DESCRIPTION
### Before this PR
```

medya@~/workspace/minikube (master) $ minikube start --container-runtime=containerd

medya@~/workspace/minikube (master) $ minikube ssh

docker@minikube:~$ sudo systemctl status docker
● docker.service - Docker Application Container Engine
     Loaded: loaded (/lib/systemd/system/docker.service; enabled; vendor preset: enabled)
     Active: active (running) since Fri 2021-02-05 20:01:08 UTC; 32s ago
```


### After this PR (docker will not be running for containerd anymore)

```
medya@~/workspace/minikube (docker_running_containerd) $ ./out/minikube start --container-runtime=containerd
medya@~/workspace/minikube (docker_running_containerd) $ minikube ssh

docker@minikube:~$ sudo systemctl status docker
● docker.service - Docker Application Container Engine
     Loaded: loaded (/lib/systemd/system/docker.service; enabled; vendor preset: enabled)
     Active: inactive (dead) since Fri 2021-02-05 20:19:25 UTC; 38s ago
TriggeredBy: ● docker.socket
       Docs: https://docs.docker.com
   Main PID: 176 (code=exited, status=0/SUCCESS)

Feb 05 20:19:17 minikube dockerd[176]: time="2021-02-05T20:19:17.225076700Z" level=info msg="Docker daemon" commit=8891c58 graphdriver(s)=
overlay2 version=20.10.2
Feb 05 20:19:17 minikube dockerd[176]: time="2021-02-05T20:19:17.225464600Z" level=info msg="Daemon has completed initialization"
Feb 05 20:19:17 minikube systemd[1]: Started Docker Application Container Engine.
Feb 05 20:19:17 minikube dockerd[176]: time="2021-02-05T20:19:17.280759300Z" level=info msg="API listen on /run/docker.sock"
Feb 05 20:19:25 minikube systemd[1]: Stopping Docker Application Container Engine...
Feb 05 20:19:25 minikube dockerd[176]: time="2021-02-05T20:19:25.083406200Z" level=info msg="Processing signal 'terminated'"
Feb 05 20:19:25 minikube dockerd[176]: time="2021-02-05T20:19:25.086049600Z" level=info msg="stopping event stream following graceful shut
down" error="<nil>" module=libcontainerd namespace=moby
Feb 05 20:19:25 minikube dockerd[176]: time="2021-02-05T20:19:25.086634900Z" level=info msg="Daemon shutdown complete"
Feb 05 20:19:25 minikube systemd[1]: docker.service: Succeeded.
```

closes 
https://github.com/kubernetes/minikube/issues/10373