### PR TITLE
Add -l/--light option for profile list command.

### DIFF
--- a/site/content/en/docs/commands/profile.md
+++ b/site/content/en/docs/commands/profile.md
@@ -89,6 +89,7 @@ minikube profile list [flags]
 ### Options
 
 ```
+  -l, --light           If true, returns list of profiles faster by skipping validating the status of the cluster.
   -o, --output string   The output format. One of 'json', 'table' (default "table")
 ```
 

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -768,50 +768,98 @@ func validateProfileCmd(ctx context.Context, t *testing.T, profile string) {
 	})
 
 	t.Run("profile_list", func(t *testing.T) {
+		// helper function to run command then, return target profile line from table output.
+		extractrofileListFunc := func(rr *RunResult) string {
+			listLines := strings.Split(strings.TrimSpace(rr.Stdout.String()), "\n")
+			for i := 3; i < (len(listLines) - 1); i++ {
+				profileLine := listLines[i]
+				if strings.Contains(profileLine, profile) {
+					return profileLine
+				}
+			}
+			return ""
+		}
+
 		// List profiles
+		start := time.Now()
 		rr, err := Run(t, exec.CommandContext(ctx, Target(), "profile", "list"))
+		elapsed := time.Since(start)
 		if err != nil {
 			t.Errorf("failed to list profiles: args %q : %v", rr.Command(), err)
 		}
+		t.Logf("Took %q to run %q", elapsed, rr.Command())
 
-		// Table output
-		listLines := strings.Split(strings.TrimSpace(rr.Stdout.String()), "\n")
-		profileExists := false
-		for i := 3; i < (len(listLines) - 1); i++ {
-			profileLine := listLines[i]
-			if strings.Contains(profileLine, profile) {
-				profileExists = true
-				break
-			}
-		}
-		if !profileExists {
+		profileLine := extractrofileListFunc(rr)
+		if profileLine == "" {
 			t.Errorf("expected 'profile list' output to include %q but got *%q*. args: %q", profile, rr.Stdout.String(), rr.Command())
+		}
+
+		// List profiles with light option.
+		start = time.Now()
+		lrr, err := Run(t, exec.CommandContext(ctx, Target(), "profile", "list", "-l"))
+		lightElapsed := time.Since(start)
+		if err != nil {
+			t.Errorf("failed to list profiles: args %q : %v", lrr.Command(), err)
+		}
+		t.Logf("Took %q to run %q", lightElapsed, lrr.Command())
+
+		profileLine = extractrofileListFunc(lrr)
+		if profileLine == "" || !strings.Contains(profileLine, "Skipped") {
+			t.Errorf("expected 'profile list' output to include %q with 'Skipped' status but got *%q*. args: %q", profile, rr.Stdout.String(), rr.Command())
+		}
+
+		if lightElapsed > 3*time.Second {
+			t.Errorf("expected running time of '%q' is less than 3 seconds. Took %q ", lrr.Command(), lightElapsed)
 		}
 	})
 
 	t.Run("profile_json_output", func(t *testing.T) {
-		// Json output
-		rr, err := Run(t, exec.CommandContext(ctx, Target(), "profile", "list", "--output", "json"))
+		// helper function to run command then, return target profile object from json output.
+		extractProfileObjFunc := func(rr *RunResult) *config.Profile {
+			var jsonObject map[string][]config.Profile
+			err := json.Unmarshal(rr.Stdout.Bytes(), &jsonObject)
+			if err != nil {
+				t.Errorf("failed to decode json from profile list: args %q: %v", rr.Command(), err)
+				return nil
+			}
+
+			for _, profileObject := range jsonObject["valid"] {
+				if profileObject.Name == profile {
+					return &profileObject
+				}
+			}
+			return nil
+		}
+
+		start := time.Now()
+		rr, err := Run(t, exec.CommandContext(ctx, Target(), "profile", "list", "-o", "json"))
+		elapsed := time.Since(start)
 		if err != nil {
 			t.Errorf("failed to list profiles with json format. args %q: %v", rr.Command(), err)
 		}
-		var jsonObject map[string][]map[string]interface{}
-		err = json.Unmarshal(rr.Stdout.Bytes(), &jsonObject)
-		if err != nil {
-			t.Errorf("failed to decode json from profile list: args %q: %v", rr.Command(), err)
-		}
-		validProfiles := jsonObject["valid"]
-		profileExists := false
-		for _, profileObject := range validProfiles {
-			if profileObject["Name"] == profile {
-				profileExists = true
-				break
-			}
-		}
-		if !profileExists {
+		t.Logf("Took %q to run %q", elapsed, rr.Command())
+
+		pr := extractProfileObjFunc(rr)
+		if pr == nil {
 			t.Errorf("expected the json of 'profile list' to include %q but got *%q*. args: %q", profile, rr.Stdout.String(), rr.Command())
 		}
 
+		start = time.Now()
+		lrr, err := Run(t, exec.CommandContext(ctx, Target(), "profile", "list", "-o", "json", "--light"))
+		lightElapsed := time.Since(start)
+		if err != nil {
+			t.Errorf("failed to list profiles with json format. args %q: %v", lrr.Command(), err)
+		}
+		t.Logf("Took %q to run %q", lightElapsed, lrr.Command())
+
+		pr = extractProfileObjFunc(lrr)
+		if pr == nil || pr.Status != "Skipped" {
+			t.Errorf("expected the json of 'profile list' to include 'Skipped' status for %q but got *%q*. args: %q", profile, lrr.Stdout.String(), lrr.Command())
+		}
+
+		if lightElapsed > 3*time.Second {
+			t.Errorf("expected running time of '%q' is less than 3 seconds. Took %q ", lrr.Command(), lightElapsed)
+		}
 	})
 }
 


### PR DESCRIPTION
If option is true, Doens't try to get profiles from container and read
current status.

fix #10147 
```shell
❯ minikube profile list -h
Lists all valid minikube profiles and detects all possible invalid profiles.

Options:
  -l, --light=false: If true, only display vaild profiles and do not check status.
  -o, --output='table': The output format. One of 'json', 'table'

Usage:
  minikube profile list [flags] [options]

Use "minikube options" for a list of global command-line options (applies to all commands).
❯ minikube profile list
|--------------------------------|-----------|---------|---------------|------|---------|---------|-------|
|            Profile             | VM Driver | Runtime |      IP       | Port | Version | Status  | Nodes |
|--------------------------------|-----------|---------|---------------|------|---------|---------|-------|
| minikube                       | docker    | docker  | 192.168.49.2  | 8443 | v1.20.0 | Stopped |     1 |
| multinode-20210127144027-24120 | docker    | docker  | 192.168.49.57 | 8443 | v1.20.2 | Stopped |     2 |
|--------------------------------|-----------|---------|---------------|------|---------|---------|-------|
❯ minikube profile list -l
|--------------------------------|-----------|---------|---------------|------|---------|---------|-------|
|            Profile             | VM Driver | Runtime |      IP       | Port | Version | Status  | Nodes |
|--------------------------------|-----------|---------|---------------|------|---------|---------|-------|
| minikube                       | docker    | docker  | 192.168.49.2  | 8443 | v1.20.0 | Skipped |     1 |
| multinode-20210127144027-24120 | docker    | docker  | 192.168.49.57 | 8443 | v1.20.2 | Skipped |     2 |
|--------------------------------|-----------|---------|---------------|------|---------|---------|-------|
❯ minikube profile list --light
|--------------------------------|-----------|---------|---------------|------|---------|---------|-------|
|            Profile             | VM Driver | Runtime |      IP       | Port | Version | Status  | Nodes |
|--------------------------------|-----------|---------|---------------|------|---------|---------|-------|
| minikube                       | docker    | docker  | 192.168.49.2  | 8443 | v1.20.0 | Skipped |     1 |
| multinode-20210127144027-24120 | docker    | docker  | 192.168.49.57 | 8443 | v1.20.2 | Skipped |     2 |
|--------------------------------|-----------|---------|---------------|------|---------|---------|-------|
```
