### PR TITLE
Refactor tmp dir detection to improve testability

### DIFF
--- a/pkg/minikube/command/kic_runner_test.go
+++ b/pkg/minikube/command/kic_runner_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package command
+
+import (
+	"os"
+	"testing"
+)
+
+func TestKICRunner(t *testing.T) {
+	t.Parallel()
+
+	t.Run("TestTempDirectory", func(t *testing.T) {
+		t.Parallel()
+
+		home, err := os.UserHomeDir()
+		if err != nil {
+			t.Fatalf("failed to get user home directory: %v", err)
+		}
+
+		tests := []struct {
+			in   bool
+			want string
+		}{
+			{false, ""},
+			{true, home},
+		}
+
+		for _, tt := range tests {
+			got, err := tempDirectory(tt.in)
+			if err != nil {
+				t.Fatalf("failed to get temp directory: %v", err)
+			}
+
+			if got != tt.want {
+				t.Errorf("tempDirectory(%t) = %s; want %s", tt.in, got, tt.want)
+			}
+		}
+	})
+}


### PR DESCRIPTION
Testing to prevent: #10407

In its current state, testing the temp directory detection logic is quite difficult to do due to the size of the function the logic is nested within. Due to the difficulty of the testing, tests have not been implemented and resulted in a bug (#10372) being merged that should easily be caught with tests. This PR refactors the temp directory setting logic into its own function, allowing unit tests to easily be written for it. Unit tests are included in this PR that will prevent the bug from being merged again.