### PR TITLE
remove podman cni config when custom cni is used

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -351,7 +351,8 @@ func (k *Bootstrapper) applyCNI(cfg config.ClusterConfig, registerStep ...bool) 
 		return errors.Wrap(err, "cni apply")
 	}
 
-	if cfg.KubernetesConfig.ContainerRuntime == constants.CRIO {
+	_, custom := cnm.(cni.Custom)
+	if cfg.KubernetesConfig.ContainerRuntime == constants.CRIO && !custom {
 		if err := cruntime.UpdateCRIONet(k.c, cnm.CIDR()); err != nil {
 			return errors.Wrap(err, "update crio")
 		}

--- a/pkg/minikube/cni/custom.go
+++ b/pkg/minikube/cni/custom.go
@@ -21,8 +21,10 @@ import (
 	"path"
 
 	"github.com/pkg/errors"
+	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/sysinit"
 )
 
 // Custom is a CNI manager than applies a user-specified manifest
@@ -51,6 +53,9 @@ func NewCustom(cc config.ClusterConfig, manifest string) (Custom, error) {
 
 // Apply enables the CNI
 func (c Custom) Apply(r Runner) error {
+	if err := c.addFakeConfig(r); err != nil {
+		return errors.Wrap(err, "create fake cni config")
+	}
 	m, err := assets.NewFileAsset(c.manifest, path.Dir(manifestPath()), path.Base(manifestPath()), "0644")
 	if err != nil {
 		return errors.Wrap(err, "manifest")
@@ -62,4 +67,24 @@ func (c Custom) Apply(r Runner) error {
 // CIDR returns the default CIDR used by this CNI
 func (c Custom) CIDR() string {
 	return DefaultPodCIDR
+}
+
+// addFakeConfig adds a fake CNI configuration file to the node to prevent
+// podman CNI to serve ip addresses to pods in case 3rd party CNI is enabled
+func (c Custom) addFakeConfig(r Runner) error {
+	klog.Infof("creating fake CNI config")
+	fakeCNI := `{
+  "cniVersion": "0.4.0",
+  "name": "fake",
+  "type": "host-local"
+}`
+
+	b := []byte(fakeCNI)
+	fakeCNIAsset := assets.NewMemoryAssetTarget(b, "/etc/cni/net.d/86-fake.conf", "0644")
+	if err := r.Copy(fakeCNIAsset); err != nil {
+		return errors.Wrapf(err, "copy")
+	}
+
+	// crio service must be restarted otherwise the podman cni is still used
+	return sysinit.New(r).Restart(c.cc.KubernetesConfig.ContainerRuntime)
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:
1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
When a custom CNI is defined via --cni flag it might take a while to populate the CNIs configuration into /etc/cni/net.d.
Minikube comes up and in case of crio or containerd runtime it has a CNI configuration in /etc/cni/net,d already.
Now if pods using pod network (such as coredns) come up BEFORE the custom CNIs config file is populated, this pod ip address is served by podman. Subsequent pods will be served by the custom CNI but won't be able to communicate with the pods using podman CNI.
This PR removes all CNI configs from /etc/cni/net.d just before the custom CNI manifest is applied.