### PR TITLE
Fix configuration of the metallb with empty load balancing IP range

### DIFF
--- a/cmd/minikube/cmd/config/configure.go
+++ b/cmd/minikube/cmd/config/configure.go
@@ -22,6 +22,7 @@ import (
 	"regexp"
 
 	"github.com/spf13/cobra"
+	"k8s.io/minikube/pkg/addons"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/mustload"
@@ -207,6 +208,11 @@ var addonsConfigureCmd = &cobra.Command{
 
 			if err := config.SaveProfile(profile, cfg); err != nil {
 				out.ErrT(style.Fatal, "Failed to save config {{.profile}}", out.V{"profile": profile})
+			}
+
+			// Re-enable metallb addon in order to generate template manifest files with Load Balancer Start/End IP
+			if err := addons.EnableOrDisableAddon(cfg, "metallb", "true"); err != nil {
+				out.ErrT(style.Fatal, "Failed to configure metallb IP {{.profile}}", out.V{"profile": profile})
 			}
 		case "ingress":
 			profile := ClusterFlagValue()

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -126,8 +126,8 @@ func SetBool(cc *config.ClusterConfig, name string, val string) error {
 	return nil
 }
 
-// enableOrDisableAddon updates addon status executing any commands necessary
-func enableOrDisableAddon(cc *config.ClusterConfig, name string, val string) error {
+// EnableOrDisableAddon updates addon status executing any commands necessary
+func EnableOrDisableAddon(cc *config.ClusterConfig, name string, val string) error {
 	klog.Infof("Setting addon %s=%s in %q", name, val, cc.Name)
 	enable, err := strconv.ParseBool(val)
 	if err != nil {
@@ -298,7 +298,7 @@ func enableOrDisableStorageClasses(cc *config.ClusterConfig, name string, val st
 	}
 	if !machine.IsRunning(api, config.MachineName(*cc, cp)) {
 		klog.Warningf("%q is not running, writing %s=%v to disk and skipping enablement", config.MachineName(*cc, cp), name, val)
-		return enableOrDisableAddon(cc, name, val)
+		return EnableOrDisableAddon(cc, name, val)
 	}
 
 	storagev1, err := storageclass.GetStoragev1(cc.Name)
@@ -320,7 +320,7 @@ func enableOrDisableStorageClasses(cc *config.ClusterConfig, name string, val st
 		}
 	}
 
-	return enableOrDisableAddon(cc, name, val)
+	return EnableOrDisableAddon(cc, name, val)
 }
 
 func verifyAddonStatus(cc *config.ClusterConfig, name string, val string) error {

--- a/pkg/addons/config.go
+++ b/pkg/addons/config.go
@@ -45,7 +45,7 @@ var Addons = []*Addon{
 	{
 		name:      "dashboard",
 		set:       SetBool,
-		callbacks: []setFn{enableOrDisableAddon},
+		callbacks: []setFn{EnableOrDisableAddon},
 	},
 
 	{
@@ -56,95 +56,95 @@ var Addons = []*Addon{
 	{
 		name:      "efk",
 		set:       SetBool,
-		callbacks: []setFn{enableOrDisableAddon},
+		callbacks: []setFn{EnableOrDisableAddon},
 	},
 	{
 		name:      "freshpod",
 		set:       SetBool,
-		callbacks: []setFn{enableOrDisableAddon},
+		callbacks: []setFn{EnableOrDisableAddon},
 	},
 	{
 		name:        "gvisor",
 		set:         SetBool,
 		validations: []setFn{IsRuntimeContainerd},
-		callbacks:   []setFn{enableOrDisableAddon, verifyAddonStatus},
+		callbacks:   []setFn{EnableOrDisableAddon, verifyAddonStatus},
 	},
 	{
 		name:      "helm-tiller",
 		set:       SetBool,
-		callbacks: []setFn{enableOrDisableAddon},
+		callbacks: []setFn{EnableOrDisableAddon},
 	},
 	{
 		name:      "ingress",
 		set:       SetBool,
-		callbacks: []setFn{enableOrDisableAddon, verifyAddonStatus},
+		callbacks: []setFn{EnableOrDisableAddon, verifyAddonStatus},
 	},
 	{
 		name:      "ingress-dns",
 		set:       SetBool,
-		callbacks: []setFn{enableOrDisableAddon},
+		callbacks: []setFn{EnableOrDisableAddon},
 	},
 	{
 		name:      "istio-provisioner",
 		set:       SetBool,
-		callbacks: []setFn{enableOrDisableAddon},
+		callbacks: []setFn{EnableOrDisableAddon},
 	},
 	{
 		name:      "istio",
 		set:       SetBool,
-		callbacks: []setFn{enableOrDisableAddon},
+		callbacks: []setFn{EnableOrDisableAddon},
 	},
 	{
 		name:      "kubevirt",
 		set:       SetBool,
-		callbacks: []setFn{enableOrDisableAddon},
+		callbacks: []setFn{EnableOrDisableAddon},
 	},
 	{
 		name:      "logviewer",
 		set:       SetBool,
-		callbacks: []setFn{enableOrDisableAddon},
+		callbacks: []setFn{EnableOrDisableAddon},
 	},
 	{
 		name:      "metrics-server",
 		set:       SetBool,
-		callbacks: []setFn{enableOrDisableAddon},
+		callbacks: []setFn{EnableOrDisableAddon},
 	},
 	{
 		name:      "nvidia-driver-installer",
 		set:       SetBool,
-		callbacks: []setFn{enableOrDisableAddon},
+		callbacks: []setFn{EnableOrDisableAddon},
 	},
 	{
 		name:      "nvidia-gpu-device-plugin",
 		set:       SetBool,
-		callbacks: []setFn{enableOrDisableAddon},
+		callbacks: []setFn{EnableOrDisableAddon},
 	},
 	{
 		name:      "olm",
 		set:       SetBool,
-		callbacks: []setFn{enableOrDisableAddon},
+		callbacks: []setFn{EnableOrDisableAddon},
 	},
 	{
 		name:      "registry",
 		set:       SetBool,
-		callbacks: []setFn{enableOrDisableAddon, verifyAddonStatus},
+		callbacks: []setFn{EnableOrDisableAddon, verifyAddonStatus},
 	},
 	{
 		name:      "registry-creds",
 		set:       SetBool,
-		callbacks: []setFn{enableOrDisableAddon},
+		callbacks: []setFn{EnableOrDisableAddon},
 	},
 	{
 		name:      "registry-aliases",
 		set:       SetBool,
-		callbacks: []setFn{enableOrDisableAddon},
+		callbacks: []setFn{EnableOrDisableAddon},
 		//TODO - add other settings
 		//TODO check if registry addon is enabled
 	},
 	{
 		name:      "storage-provisioner",
 		set:       SetBool,
-		callbacks: []setFn{enableOrDisableAddon},
+		callbacks: []setFn{EnableOrDisableAddon},
 	},
 	{
 		name:      "storage-provisioner-gluster",
@@ -154,32 +154,32 @@ var Addons = []*Addon{
 	{
 		name:      "metallb",
 		set:       SetBool,
-		callbacks: []setFn{enableOrDisableAddon},
+		callbacks: []setFn{EnableOrDisableAddon},
 	},
 	{
 		name:      "ambassador",
 		set:       SetBool,
-		callbacks: []setFn{enableOrDisableAddon},
+		callbacks: []setFn{EnableOrDisableAddon},
 	},
 	{
 		name:      "pod-security-policy",
 		set:       SetBool,
-		callbacks: []setFn{enableOrDisableAddon},
+		callbacks: []setFn{EnableOrDisableAddon},
 	},
 	{
 		name:      "gcp-auth",
 		set:       SetBool,
-		callbacks: []setFn{gcpauth.EnableOrDisable, enableOrDisableAddon, verifyGCPAuthAddon},
+		callbacks: []setFn{gcpauth.EnableOrDisable, EnableOrDisableAddon, verifyGCPAuthAddon},
 	},
 	{
 		name:      "volumesnapshots",
 		set:       SetBool,
-		callbacks: []setFn{enableOrDisableAddon},
+		callbacks: []setFn{EnableOrDisableAddon},
 	},
 	{
 		name:        "csi-hostpath-driver",
 		set:         SetBool,
 		validations: []setFn{IsVolumesnapshotsEnabled},
-		callbacks:   []setFn{enableOrDisableAddon, verifyAddonStatus},
+		callbacks:   []setFn{EnableOrDisableAddon, verifyAddonStatus},
 	},
 }

--- a/site/content/en/docs/contrib/addons.en.md
+++ b/site/content/en/docs/contrib/addons.en.md
@@ -43,7 +43,7 @@ To make the addon appear in `minikube addons list`, add it to `pkg/addons/config
   {
     name:      "registry",
     set:       SetBool,
-    callbacks: []setFn{enableOrDisableAddon},
+    callbacks: []setFn{EnableOrDisableAddon},
   },
 ```
 


### PR DESCRIPTION
### What type of PR is this?
/kind bug
/area addons

### What this PR does / why we need it:

This PR fixes the bug of `minikube addons configure metallb`.
Currently, when users execute `minikube addons configure metallb` first time, the load balancing IP range will be empty.
It's because minikube evaluates generate templated file, when `minikube addons enable XXXX`.
But, current flows of configuration are
1. `minikube addons enable metallb` - template manifest evaluated with empty
2. `minikube addons configure metallb` - set load balancing IP with empty

This PR fixes this.

### Which issue(s) this PR fixes:
Fix #10307

### Does this PR introduce a user-facing change?

Yes. This PR fixes metallb addon.

**Before this PR (Load Balancing IPs are empty)**

```
$ minikube addons enable metallb
$ minikube addons configure metallb
(Input IP range Start-End)
$ kubectl describe configmap config -n metallb-system
...
Data
====
config:
----
address-pools:
- name: default
  protocol: layer2
  addresses:
  - -
```

**After this PR (Load Balancing IPs are set)**

```
$ minikube addons enable metallb
$ minikube addons configure metallb
(Input IP range Start-End)
$ kubectl describe configmap config -n metallb-system
...
Data
====
config:
----
address-pools:
- name: default
  protocol: layer2
  addresses:
  - 192.168.1.10-192.168.1.30
```

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```