### PR TITLE
Add missing reference to --embed-certs in the docs

### DIFF
--- a/site/content/en/docs/handbook/untrusted_certs.md
+++ b/site/content/en/docs/handbook/untrusted_certs.md
@@ -28,8 +28,8 @@ mkdir -p $HOME/.minikube/certs
 cp my_company.pem $HOME/.minikube/certs/my_company.pem
 ```
 
-Then restart minikube to sync the certificates:
+Then restart minikube with the `--embed-certs` flag to sync the certificates:
 
 ```shell
-minikube start
+minikube start --embed-certs
 ```


### PR DESCRIPTION
This caught me by surprise - took me a while to understand why the certificates in `$HOME/.minikube/certs` weren't working.