### PR TITLE
Upgrade spinner library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -105,7 +105,7 @@ require (
 
 replace (
 	git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
-	github.com/briandowns/spinner => github.com/alonyb/spinner v1.12.1
+	github.com/briandowns/spinner => github.com/alonyb/spinner v1.12.6
 	github.com/docker/machine => github.com/machine-drivers/machine v0.7.1-0.20200810185219-7d42fed1b770
 	github.com/google/go-containerregistry => github.com/afbjorklund/go-containerregistry v0.1.2-0.20210101161202-de47504a564f
 	github.com/hashicorp/go-getter => github.com/afbjorklund/go-getter v1.4.3-0.20201119203610-3f740b1eaf7d

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/alonyb/spinner v1.12.1 h1:zB6IQ29/kTR/NWHJhIgU2tXW+fhXa3K5zrDQMddd9H0=
-github.com/alonyb/spinner v1.12.1/go.mod h1:QOuQk7x+EaDASo80FEXwlwiA+j/PPIcX3FScO+3/ZPQ=
+github.com/alonyb/spinner v1.12.6 h1:mA00RZknbJVQsvIbbLIspcXNVriiOeY6OZPsmlozy7k=
+github.com/alonyb/spinner v1.12.6/go.mod h1:mQak9GHqbspjC/5iUx3qMlIho8xBS/ppAL/hX5SmPJU=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
This PR is for #10338

Upgrade spinner library to avoid spinner in environments that is not a terminal, like files or IDE's.

Here is PR of spinner library [link](https://github.com/alonyb/spinner/pull/3/files) to check differences
In library we used [go-isatty](https://github.com/mattn/go-isatty), suggested by @medyagh 

I tested in unix systems and windows powershell. It works without problem.

**Before fix**
<img width="977" alt="Screen Shot 2021-02-07 at 23 52 44" src="https://user-images.githubusercontent.com/13793894/107177335-9a0a1280-699f-11eb-80ba-b93321ca7a89.png">


**After fix**
<img width="500" alt="Screen Shot 2021-02-07 at 23 48 53" src="https://user-images.githubusercontent.com/13793894/107177120-09cbcd80-699f-11eb-8f8c-42b8a7e8524e.png">
