### PR TITLE
Clean up accumulated golint with missing godoc

### DIFF
--- a/pkg/drivers/ssh/ssh.go
+++ b/pkg/drivers/ssh/ssh.go
@@ -85,18 +85,22 @@ func (d *Driver) DriverName() string {
 	return "ssh"
 }
 
+// GetSSHHostname returns hostname for use with ssh
 func (d *Driver) GetSSHHostname() (string, error) {
 	return d.GetIP()
 }
 
+// GetSSHUsername returns username for use with ssh
 func (d *Driver) GetSSHUsername() string {
 	return d.SSHUser
 }
 
+// GetSSHKeyPath returns the key path for SSH
 func (d *Driver) GetSSHKeyPath() string {
 	return d.SSHKeyPath
 }
 
+// PreCreateCheck checks for correct privileges and dependencies
 func (d *Driver) PreCreateCheck() error {
 	if d.SSHKey != "" {
 		if _, err := os.Stat(d.SSHKey); os.IsNotExist(err) {
@@ -107,6 +111,7 @@ func (d *Driver) PreCreateCheck() error {
 	return nil
 }
 
+// Create a host using the driver's config
 func (d *Driver) Create() error {
 	if d.SSHKey == "" {
 		log.Info("No SSH key specified. Assuming an existing key at the default location.")
@@ -134,6 +139,7 @@ func (d *Driver) Create() error {
 	return nil
 }
 
+// GetURL returns a Docker URL inside this host
 func (d *Driver) GetURL() (string, error) {
 	if err := drivers.MustBeRunning(d); err != nil {
 		return "", err
@@ -147,6 +153,7 @@ func (d *Driver) GetURL() (string, error) {
 	return fmt.Sprintf("tcp://%s", net.JoinHostPort(ip, strconv.Itoa(d.EnginePort))), nil
 }
 
+// GetState returns the state that the host is in (running, stopped, etc)
 func (d *Driver) GetState() (state.State, error) {
 	address := net.JoinHostPort(d.IPAddress, strconv.Itoa(d.SSHPort))
 
@@ -224,6 +231,7 @@ func (d *Driver) Kill() error {
 	return nil
 }
 
+// Remove a host, including any data which may have been written by it.
 func (d *Driver) Remove() error {
 	return nil
 }

--- a/pkg/minikube/bootstrapper/bsutil/kverify/kverify.go
+++ b/pkg/minikube/bootstrapper/bsutil/kverify/kverify.go
@@ -35,7 +35,7 @@ const (
 	AppsRunningKey = "apps_running"
 	// NodeReadyKey is the name used in the flags for waiting for the node status to be ready
 	NodeReadyKey = "node_ready"
-	// NodeReadyKey is the name used in the flags for waiting for the node status to be ready
+	// KubeletKey is the name used in the flags for waiting for the kubelet status to be ready
 	KubeletKey = "kubelet"
 )
 

--- a/pkg/minikube/cni/cni.go
+++ b/pkg/minikube/cni/cni.go
@@ -93,6 +93,7 @@ func New(cc config.ClusterConfig) (Manager, error) {
 	}
 }
 
+// IsDisabled checks if CNI is disabled
 func IsDisabled(cc config.ClusterConfig) bool {
 	if cc.KubernetesConfig.NetworkPlugin != "" && cc.KubernetesConfig.NetworkPlugin != "cni" {
 		return true

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -84,7 +84,10 @@ const (
 	TestDiskUsedEnv = "MINIKUBE_TEST_STORAGE_CAPACITY"
 
 	// scheduled stop constants
-	ScheduledStopEnvFile        = "/var/lib/minikube/scheduled-stop/environment"
+
+	// ScheduledStopEnvFile is the environment file for scheduled-stop
+	ScheduledStopEnvFile = "/var/lib/minikube/scheduled-stop/environment"
+	// ScheduledStopSystemdService is the service file for scheduled-stop
 	ScheduledStopSystemdService = "minikube-scheduled-stop"
 
 	// MinikubeExistingPrefix is used to save the original environment when executing docker-env

--- a/pkg/minikube/kubeconfig/extension.go
+++ b/pkg/minikube/kubeconfig/extension.go
@@ -25,6 +25,8 @@ import (
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // implementing the runtime.Object internally so we can write extensions to kubeconfig
+
+// Extension represents information to identify clusters and contexts
 type Extension struct {
 	runtime.TypeMeta `json:",inline"`
 	Version          string `json:"version"`

--- a/pkg/minikube/machine/ssh.go
+++ b/pkg/minikube/machine/ssh.go
@@ -68,6 +68,7 @@ func CreateSSHShell(api libmachine.API, cc config.ClusterConfig, n config.Node, 
 	return client.Shell(args...)
 }
 
+// GetSSHHostAddrPort returns the host address and port for ssh
 func GetSSHHostAddrPort(api libmachine.API, cc config.ClusterConfig, n config.Node) (string, int, error) {
 	host, err := getHost(api, cc, n)
 	if err != nil {

--- a/pkg/minikube/sshutil/sshutil.go
+++ b/pkg/minikube/sshutil/sshutil.go
@@ -93,6 +93,7 @@ func newSSHHost(d drivers.Driver) (*sshHost, error) {
 	}, nil
 }
 
+// KnownHost checks if this host is in the knownHosts file
 func KnownHost(host string, knownHosts string) bool {
 	fd, err := os.Open(knownHosts)
 	if err != nil {

--- a/pkg/minikube/style/style.go
+++ b/pkg/minikube/style/style.go
@@ -45,6 +45,7 @@ type Options struct {
 	Spinner bool
 }
 
+// SpinnerCharacter is which of the spinner.CharSets to use
 const SpinnerCharacter = 9
 
 // Config is a map of style name to style struct


### PR DESCRIPTION
Just the status code blocks left:

```
golint: 99%
	cmd/minikube/cmd/status.go
		Line 76: warning: exported const Starting should have comment (or a comment on this block) or be unexported (golint)
	pkg/minikube/reason/exitcodes.go
		Line 38: warning: exported const ExFailure should have comment (or a comment on this block) or be unexported (golint)
```