### PR TITLE
add new extra component to --wait=all to validate a healthy cluster

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/kverify/kverify.go
+++ b/pkg/minikube/bootstrapper/bsutil/kverify/kverify.go
@@ -37,8 +37,8 @@ const (
 	NodeReadyKey = "node_ready"
 	// KubeletKey is the name used in the flags for waiting for the kubelet status to be ready
 	KubeletKey = "kubelet"
-	// OperationalKey is the name used for waiting for pods in CorePodsList to be Ready
-	OperationalKey = "operational"
+	// ExtraKey is the name used for extra waiting for pods in CorePodsList to be Ready
+	ExtraKey = "extra"
 )
 
 //  vars related to the --wait flag
@@ -46,9 +46,9 @@ var (
 	// DefaultComponents is map of the the default components to wait for
 	DefaultComponents = map[string]bool{APIServerWaitKey: true, SystemPodsWaitKey: true}
 	// NoWaitComponents is map of componets to wait for if specified 'none' or 'false'
-	NoComponents = map[string]bool{APIServerWaitKey: false, SystemPodsWaitKey: false, DefaultSAWaitKey: false, AppsRunningKey: false, NodeReadyKey: false, KubeletKey: false, OperationalKey: false}
+	NoComponents = map[string]bool{APIServerWaitKey: false, SystemPodsWaitKey: false, DefaultSAWaitKey: false, AppsRunningKey: false, NodeReadyKey: false, KubeletKey: false, ExtraKey: false}
 	// AllComponents is map for waiting for all components.
-	AllComponents = map[string]bool{APIServerWaitKey: true, SystemPodsWaitKey: true, DefaultSAWaitKey: true, AppsRunningKey: true, NodeReadyKey: true, KubeletKey: true, OperationalKey: true}
+	AllComponents = map[string]bool{APIServerWaitKey: true, SystemPodsWaitKey: true, DefaultSAWaitKey: true, AppsRunningKey: true, NodeReadyKey: true, KubeletKey: true, ExtraKey: true}
 	// DefaultWaitList is list of all default components to wait for. only names to be used for start flags.
 	DefaultWaitList = []string{APIServerWaitKey, SystemPodsWaitKey}
 	// AllComponentsList list of all valid components keys to wait for. only names to be used used for start flags.
@@ -62,7 +62,7 @@ var (
 		"kube-proxy",
 		"kube-scheduler",
 	}
-	// CorePodsList is a list of essential pods for running kurnetes to wait for them to be operational ("Ready")
+	// CorePodsList is a list of essential pods for running kurnetes to extra wait for them to be Ready
 	CorePodsList = []string{
 		"kube-dns", // coredns
 		"etcd",

--- a/pkg/minikube/bootstrapper/bsutil/kverify/kverify.go
+++ b/pkg/minikube/bootstrapper/bsutil/kverify/kverify.go
@@ -60,6 +60,15 @@ var (
 		"kube-proxy",
 		"kube-scheduler",
 	}
+	// SystemPodsList is a list of essential pods for running kurnetes to wait for them to be Ready
+	SystemPodsList = []string{
+		"kube-dns", // coredns
+		"etcd",
+		"kube-apiserver",
+		"kube-controller-manager",
+		"kube-proxy",
+		"kube-scheduler",
+	}
 )
 
 // ShouldWait will return true if the config says need to wait

--- a/pkg/minikube/bootstrapper/bsutil/kverify/kverify.go
+++ b/pkg/minikube/bootstrapper/bsutil/kverify/kverify.go
@@ -37,6 +37,8 @@ const (
 	NodeReadyKey = "node_ready"
 	// KubeletKey is the name used in the flags for waiting for the kubelet status to be ready
 	KubeletKey = "kubelet"
+	// OperationalKey is the name used for waiting for pods in CorePodsList to be Ready
+	OperationalKey = "operational"
 )
 
 //  vars related to the --wait flag
@@ -44,9 +46,9 @@ var (
 	// DefaultComponents is map of the the default components to wait for
 	DefaultComponents = map[string]bool{APIServerWaitKey: true, SystemPodsWaitKey: true}
 	// NoWaitComponents is map of componets to wait for if specified 'none' or 'false'
-	NoComponents = map[string]bool{APIServerWaitKey: false, SystemPodsWaitKey: false, DefaultSAWaitKey: false, AppsRunningKey: false, NodeReadyKey: false, KubeletKey: false}
+	NoComponents = map[string]bool{APIServerWaitKey: false, SystemPodsWaitKey: false, DefaultSAWaitKey: false, AppsRunningKey: false, NodeReadyKey: false, KubeletKey: false, OperationalKey: false}
 	// AllComponents is map for waiting for all components.
-	AllComponents = map[string]bool{APIServerWaitKey: true, SystemPodsWaitKey: true, DefaultSAWaitKey: true, AppsRunningKey: true, NodeReadyKey: true, KubeletKey: true}
+	AllComponents = map[string]bool{APIServerWaitKey: true, SystemPodsWaitKey: true, DefaultSAWaitKey: true, AppsRunningKey: true, NodeReadyKey: true, KubeletKey: true, OperationalKey: true}
 	// DefaultWaitList is list of all default components to wait for. only names to be used for start flags.
 	DefaultWaitList = []string{APIServerWaitKey, SystemPodsWaitKey}
 	// AllComponentsList list of all valid components keys to wait for. only names to be used used for start flags.
@@ -60,8 +62,8 @@ var (
 		"kube-proxy",
 		"kube-scheduler",
 	}
-	// SystemPodsList is a list of essential pods for running kurnetes to wait for them to be Ready
-	SystemPodsList = []string{
+	// CorePodsList is a list of essential pods for running kurnetes to wait for them to be operational ("Ready")
+	CorePodsList = []string{
 		"kube-dns", // coredns
 		"etcd",
 		"kube-apiserver",

--- a/pkg/minikube/bootstrapper/bsutil/kverify/pod_ready.go
+++ b/pkg/minikube/bootstrapper/bsutil/kverify/pod_ready.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2021 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kverify verifies a running Kubernetes cluster is healthy
+package kverify
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	kconst "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+)
+
+// WaitForPodReadyByLabel waits for pod with label ([key:]val) in a namespace to be in Ready condition.
+// If namespace is not provided, it defaults to "kube-system".
+// If label key is not provided, it will try with "component" and "k8s-app".
+func WaitForPodReadyByLabel(cs *kubernetes.Clientset, label, namespace string, timeout time.Duration) error {
+	klog.Infof("waiting %v for pod with %q label in %q namespace to be Ready ...", timeout, label, namespace)
+	start := time.Now()
+	defer func() {
+		klog.Infof("duration metric: took %v to run WaitForPodReadyByLabel for pod with %q label in %q namespace ...", time.Since(start), label, namespace)
+	}()
+
+	if namespace == "" {
+		namespace = "kube-system"
+	}
+
+	lkey := ""
+	lval := ""
+	l := strings.Split(label, ":")
+	switch len(l) {
+	case 1: // treat as no label key provided, just val
+		lval = strings.TrimSpace(l[0])
+	case 2:
+		lkey = strings.TrimSpace(l[0])
+		lval = strings.TrimSpace(l[1])
+	default:
+		return fmt.Errorf("pod label %q is malformed", label)
+	}
+
+	checkReady := func() (bool, error) {
+		if time.Since(start) > timeout {
+			return false, fmt.Errorf("wait for pod with %q label in %q namespace to be Ready timed out", label, namespace)
+		}
+
+		pods, err := cs.CoreV1().Pods(namespace).List(meta.ListOptions{})
+		if err != nil {
+			klog.Infof("error listing pods in %q namespace, will retry: %v", namespace, err)
+			return false, nil
+		}
+		for _, pod := range pods.Items {
+			for k, v := range pod.ObjectMeta.Labels {
+				if ((lkey == "" && (k == "component" || k == "k8s-app")) || lkey == k) && v == lval {
+					return checkPodStatus(&pod)
+				}
+			}
+		}
+		klog.Infof("pod with %q label in %q namespace was not found, will retry", label, namespace)
+		return false, nil
+	}
+
+	if err := wait.PollImmediate(kconst.APICallRetryInterval, kconst.DefaultControlPlaneTimeout, checkReady); err != nil {
+		return errors.Wrapf(err, "wait pod Ready")
+	}
+
+	return nil
+}
+
+// WaitForPodReadyByName waits for pod with name in a namespace to be in Ready condition.
+// If namespace is not provided, it defaults to "kube-system".
+func WaitForPodReadyByName(cs *kubernetes.Clientset, name, namespace string, timeout time.Duration) error {
+	klog.Infof("waiting %v for pod %q in %q namespace to be Ready ...", timeout, name, namespace)
+	start := time.Now()
+	defer func() {
+		klog.Infof("duration metric: took %v to run WaitForPodReadyByName for pod %q in %q namespace ...", time.Since(start), name, namespace)
+	}()
+
+	if namespace == "" {
+		namespace = "kube-system"
+	}
+
+	checkReady := func() (bool, error) {
+		if time.Since(start) > timeout {
+			return false, fmt.Errorf("wait for pod %q in %q namespace to be Ready timed out", name, namespace)
+		}
+
+		pod, err := cs.CoreV1().Pods(namespace).Get(name, meta.GetOptions{})
+		if err != nil {
+			klog.Infof("error getting pod %q in %q namespace, will retry: %v", name, namespace, err)
+			return false, nil
+		}
+		return checkPodStatus(pod)
+	}
+
+	if err := wait.PollImmediate(kconst.APICallRetryInterval, kconst.DefaultControlPlaneTimeout, checkReady); err != nil {
+		return errors.Wrapf(err, "wait pod Ready")
+	}
+
+	return nil
+}
+
+// checkPodStatus returns if pod is Ready and any error occurred.
+func checkPodStatus(pod *core.Pod) (bool, error) {
+	if pod.Status.Phase != core.PodRunning {
+		klog.Infof("pod %q in %q namespace is not Running, will retry: %+v", pod.Name, pod.Namespace, pod.Status)
+		return false, nil
+	}
+	for _, c := range pod.Status.Conditions {
+		if c.Type == core.PodReady {
+			if c.Status != core.ConditionTrue {
+				klog.Infof("pod %q in %q namespace is not Ready, will retry: %+v", pod.Name, pod.Namespace, c)
+				return false, nil
+			}
+			klog.Infof("pod %q in %q namespace is Ready ...", pod.Name, pod.Namespace)
+			return true, nil
+		}
+	}
+	return false, fmt.Errorf("pod %q in %q namespace does not have %q status: %+v", pod.Name, pod.Namespace, core.PodReady, pod.Status)
+}

--- a/pkg/minikube/bootstrapper/bsutil/kverify/pod_ready.go
+++ b/pkg/minikube/bootstrapper/bsutil/kverify/pod_ready.go
@@ -31,12 +31,12 @@ import (
 	kconst "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
-// WaitOperational calls WaitForPodReadyByLabel for each pod in labels list and returns any errors occurred.
-func WaitOperational(cs *kubernetes.Clientset, labels []string, timeout time.Duration) error {
-	klog.Info("waiting for kube-system core pods %s to be Ready ...", labels)
-	pStart := time.Now()
+// WaitExtra calls WaitForPodReadyByLabel for each pod in labels list and returns any errors occurred.
+func WaitExtra(cs *kubernetes.Clientset, labels []string, timeout time.Duration) error {
+	klog.Infof("extra waiting for kube-system core pods %s to be Ready ...", labels)
+	start := time.Now()
 	defer func() {
-		klog.Infof("duration metric: took %s for waiting for kube-system core pods to be Ready ...", time.Since(pStart))
+		klog.Infof("duration metric: took %s for extra waiting for kube-system core pods to be Ready ...", time.Since(start))
 	}()
 
 	var errs []string
@@ -84,7 +84,6 @@ func WaitForPodReadyByLabel(cs *kubernetes.Clientset, label, namespace string, t
 		if time.Since(start) > timeout {
 			return false, fmt.Errorf("wait for pod with %q label in %q namespace to be Ready timed out", label, namespace)
 		}
-
 		pods, err := cs.CoreV1().Pods(namespace).List(meta.ListOptions{})
 		if err != nil {
 			klog.Infof("error listing pods in %q namespace, will retry: %v", namespace, err)
@@ -110,7 +109,6 @@ func WaitForPodReadyByLabel(cs *kubernetes.Clientset, label, namespace string, t
 		klog.Infof("pod with %q label in %q namespace was not found, will retry", label, namespace)
 		return false, nil
 	}
-
 	if err := wait.PollImmediate(kconst.APICallRetryInterval, kconst.DefaultControlPlaneTimeout, checkReady); err != nil {
 		return errors.Wrapf(err, "wait pod Ready")
 	}
@@ -136,7 +134,6 @@ func WaitForPodReadyByName(cs *kubernetes.Clientset, name, namespace string, tim
 		if time.Since(start) > timeout {
 			return false, fmt.Errorf("wait for pod %q in %q namespace to be Ready timed out", name, namespace)
 		}
-
 		pod, err := cs.CoreV1().Pods(namespace).Get(name, meta.GetOptions{})
 		if err != nil {
 			klog.Infof("error getting pod %q in %q namespace, will retry: %v", name, namespace, err)
@@ -154,7 +151,6 @@ func WaitForPodReadyByName(cs *kubernetes.Clientset, name, namespace string, tim
 		}
 		return false, nil
 	}
-
 	if err := wait.PollImmediate(kconst.APICallRetryInterval, kconst.DefaultControlPlaneTimeout, checkReady); err != nil {
 		return errors.Wrapf(err, "wait pod Ready")
 	}

--- a/pkg/minikube/bootstrapper/bsutil/kverify/system_pods.go
+++ b/pkg/minikube/bootstrapper/bsutil/kverify/system_pods.go
@@ -36,40 +36,25 @@ import (
 	"k8s.io/minikube/pkg/util/retry"
 )
 
-// WaitForSystemPods verifies essential pods for running kurnetes is running
+// WaitForSystemPods verifies essential pods for running kurnetes are Ready
 func WaitForSystemPods(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.ClusterConfig, cr command.Runner, client *kubernetes.Clientset, start time.Time, timeout time.Duration) error {
-	klog.Info("waiting for kube-system pods to appear ...")
+	klog.Info("waiting for kube-system pods to be Ready ...")
 	pStart := time.Now()
+	defer func() {
+		klog.Infof("duration metric: took %s for waiting for kube-system pods to be Ready ...", time.Since(pStart))
+	}()
 
-	podList := func() error {
-		if time.Since(start) > minLogCheckTime {
-			announceProblems(r, bs, cfg, cr)
-			time.Sleep(kconst.APICallRetryInterval * 5)
-		}
+	if time.Since(start) > minLogCheckTime {
+		announceProblems(r, bs, cfg, cr)
+		time.Sleep(kconst.APICallRetryInterval * 5)
+	}
 
-		// Wait for any system pod, as waiting for apiserver may block until etcd
-		pods, err := client.CoreV1().Pods("kube-system").List(meta.ListOptions{})
-		if err != nil {
-			klog.Warningf("pod list returned error: %v", err)
+	for _, label := range SystemPodsList {
+		if err := WaitForPodReadyByLabel(client, label, "kube-system", timeout); err != nil {
 			return err
 		}
-
-		klog.Infof("%d kube-system pods found", len(pods.Items))
-		for _, pod := range pods.Items {
-			klog.Infof(podStatusMsg(pod))
-		}
-
-		if len(pods.Items) < 2 {
-			return fmt.Errorf("only %d pod(s) have shown up", len(pods.Items))
-		}
-
-		return nil
 	}
 
-	if err := retry.Local(podList, timeout); err != nil {
-		return fmt.Errorf("apiserver never returned a pod list")
-	}
-	klog.Infof("duration metric: took %s to wait for pod list to return data ...", time.Since(pStart))
 	return nil
 }
 

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -477,12 +477,8 @@ func (k *Bootstrapper) WaitForNode(cfg config.ClusterConfig, n config.Node, time
 
 	if n.ControlPlane {
 		if cfg.VerifyComponents[kverify.APIServerWaitKey] {
-			if err := kverify.WaitForAPIServerProcess(cr, k, cfg, k.c, start, timeout); err != nil {
-				return errors.Wrap(err, "wait for apiserver proc")
-			}
-
-			if err := kverify.WaitForHealthyAPIServer(cr, k, cfg, k.c, client, start, hostname, port, timeout); err != nil {
-				return errors.Wrap(err, "wait for healthy API server")
+			if err := kverify.WaitForPodReadyByLabel(client, "component: kube-apiserver", "kube-system", timeout); err != nil {
+				return errors.Wrapf(err, "waiting for API server pod to be Ready")
 			}
 		}
 

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -256,7 +256,6 @@ func validateDockerEnv(ctx context.Context, t *testing.T, profile string) {
 	if !strings.Contains(rr.Output(), expectedImgInside) {
 		t.Fatalf("expected 'docker images' to have %q inside minikube. but the output is: *%s*", expectedImgInside, rr.Output())
 	}
-
 }
 
 func validateStartWithProxy(ctx context.Context, t *testing.T, profile string) {
@@ -269,7 +268,7 @@ func validateStartWithProxy(ctx context.Context, t *testing.T, profile string) {
 
 	// Use more memory so that we may reliably fit MySQL and nginx
 	// changing api server so later in soft start we verify it didn't change
-	startArgs := append([]string{"start", "-p", profile, "--memory=4000", fmt.Sprintf("--apiserver-port=%d", apiPortTest), "--wait=true"}, StartArgs()...)
+	startArgs := append([]string{"start", "-p", profile, "--memory=4000", fmt.Sprintf("--apiserver-port=%d", apiPortTest), "--wait=all"}, StartArgs()...)
 	c := exec.CommandContext(ctx, Target(), startArgs...)
 	env := os.Environ()
 	env = append(env, fmt.Sprintf("HTTP_PROXY=%s", srv.Addr))
@@ -401,7 +400,6 @@ func validateMinikubeKubectlDirectCall(ctx context.Context, t *testing.T, profil
 	if err != nil {
 		t.Fatalf("failed to run kubectl directly. args %q: %v", rr.Command(), err)
 	}
-
 }
 
 func validateExtraConfig(ctx context.Context, t *testing.T, profile string) {
@@ -409,7 +407,7 @@ func validateExtraConfig(ctx context.Context, t *testing.T, profile string) {
 
 	start := time.Now()
 	// The tests before this already created a profile, starting minikube with different --extra-config cmdline option.
-	startArgs := []string{"start", "-p", profile, "--extra-config=apiserver.enable-admission-plugins=NamespaceAutoProvision"}
+	startArgs := []string{"start", "-p", profile, "--extra-config=apiserver.enable-admission-plugins=NamespaceAutoProvision", "--wait=all"}
 	c := exec.CommandContext(ctx, Target(), startArgs...)
 	rr, err := Run(t, c)
 	if err != nil {
@@ -427,7 +425,6 @@ func validateExtraConfig(ctx context.Context, t *testing.T, profile string) {
 	if !strings.Contains(afterCfg.Config.KubernetesConfig.ExtraOptions.String(), expectedExtraOptions) {
 		t.Errorf("expected ExtraOptions to contain %s but got %s", expectedExtraOptions, afterCfg.Config.KubernetesConfig.ExtraOptions.String())
 	}
-
 }
 
 // imageID returns a docker image id for image `image` and current architecture

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -448,6 +448,7 @@ func imageID(image string) string {
 }
 
 // validateComponentHealth asserts that all Kubernetes components are healthy
+// note: it expects all components to be Ready, so it makes sense to run it close after only those tests that include '--wait=all' start flag (ie, with extra wait)
 func validateComponentHealth(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 


### PR DESCRIPTION
fixes #9936
fixes #10130

i've slightly improved `validateComponentHealth` functional test, but in this pr i'm also proposing to change how we check if a pod is actually available -

currently, we rely on pod's `Running` status, and according to `Pod phase` 
(ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase):
```
The phase of a Pod is a simple, high-level summary of where the Pod is in its lifecycle. The phase is not intended to be a comprehensive rollup of observations of container or Pod state, nor is it intended to be a comprehensive state machine.

The number and meanings of Pod phase values are tightly guarded. Other than what is documented here, nothing should be assumed about Pods that have a given phase value.

Running - The Pod has been bound to a node, and all of the containers have been created. At least one container is still running, or is in the process of starting or restarting.
```
so it is prereq but not sufficient to consider it operational - we should use `Pod conditions`/`Ready` instead (ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions):
```
ContainersReady: all containers in the Pod are ready.
Initialized: all init containers have started successfully.
Ready: the Pod is able to serve requests and should be added to the load balancing pools of all matching Services.
```
i've changed accordingly how we wait for `api server` in `kubeadm.WaitForNode` as well as `kverify.WaitForSystemPods` - these changes should improve the odds for `validateComponentHealth` functional test not to fail, as well as overall stability

three ***additional notes***:
1. depending on how it would be used, we can either reduce `kverify.SystemPodsList` (eg, remove currently redundant 'kube-apiserver' from the list -or- amend the `kverify.*Components` and remove `APIServerWaitKey` if `SystemPodsWaitKey` is defined, as it's using the `SystemPodsList`)
2. if this makes sense, we can revisit how we wait for api server in other places (currently using `cmd.waitForAPIServerProcess` in docker-env, and `kverify.waitForAPIServerProcess` in apiserver used in `kubeadmin.restartControlPlane`)
3. we are using `healthz` endpoint that is deprecated (ref: https://kubernetes.io/docs/reference/using-api/health-checks/#api-endpoints-for-health):
```
The Kubernetes API server provides 3 API endpoints (healthz, livez and readyz) to indicate the current status of the API server. 
The healthz endpoint is deprecated (since Kubernetes v1.16), and you should use the more specific livez and readyz endpoints instead
```

---

## time metrics (all completed successfully - here are just resulting values for brevity)
### before
```
❯ time minikube start --driver=docker
minikube start --driver=docker  9.03s user 3.60s system 14% cpu 1:27.75 total
```
### after
```
❯ time minikube start --driver=docker
minikube start --driver=docker  10.54s user 4.22s system 8% cpu 2:52.82 total
```
```
❯ time minikube start --driver=docker --wait=all
minikube start --driver=docker --wait=all  10.19s user 3.95s system 7% cpu 2:58.58 total
```
```
❯ time minikube start --driver=docker --wait=none
minikube start --driver=docker --wait=none  9.66s user 3.93s system 15% cpu 1:28.81 total
```
expectedly, here the time increased for 'plain' `minikube start` - explanation:
default value for `wait` flag is `kverify.DefaultWaitList`: `APIServerWaitKey, SystemPodsWaitKey`, so, in the `kubeadmin.WaitForNode` it will trigger `WaitForPodReadyByLabel` for all system components (incl. apiserver) => currently, `minikube start` equals to `minikube start --wait=all`

on the other hand:
- as in this pr, `--wait=all` _will_ force wait for all system components to become fully operational
- if `--wait=none`, then wait does not happen (no additional wait time is added): should we change the default value for `--wait` to `none` then, or we should trigger this strict_check only if explicitly asked for (and also with `--all`)?
---
one thing may be worth mentioning: just `--wait` flag, w/o specifying `=xxx` does not work as (i've) expected - ie, it's not taking the default value (`kverify.DefaultWaitList`), but it's 'greedy':
```
❯ minikube start --driver=docker --wait --alsologtostderr -v=99
...
W0209 16:24:12.243601   26050 start_flags.go:705] The value "--alsologtostderr" is invalid for --wait flag. valid options are "apiserver,system_pods,default_sa,apps_running,node_ready,kubelet"
...
```
(and that could be explained with the fact that `=` is optional anyway...)