### PR TITLE
Generate one log file per minikube command

### DIFF
--- a/cmd/minikube/main.go
+++ b/cmd/minikube/main.go
@@ -18,6 +18,8 @@ package main
 
 import (
 	"bytes"
+	"crypto/sha1"
+	"encoding/hex"
 	"flag"
 	"fmt"
 	"log"
@@ -123,6 +125,39 @@ func (lb machineLogBridge) Write(b []byte) (n int, err error) {
 	return len(b), nil
 }
 
+// checkLogFileMaxSize checks if a file's size is greater than or equal to max size in KB
+func checkLogFileMaxSize(file string, maxSizeKB int64) bool {
+	f, err := os.Stat(file)
+	if err != nil {
+		return false
+	}
+	kb := (f.Size() / 1024)
+	return kb >= maxSizeKB
+}
+
+// logFileName generates a default logfile name in the form minikube_<argv[1]>_<hash>_<count>.log from args
+func logFileName(dir string, logIdx int64) string {
+	h := sha1.New()
+	for _, s := range os.Args {
+		if _, err := h.Write([]byte(s)); err != nil {
+			klog.Warningf("Unable to add arg %s to log filename hash: %v", s, err)
+		}
+	}
+	hs := hex.EncodeToString(h.Sum(nil))
+	var logfilePath string
+	// check if subcommand specified
+	if len(os.Args) < 2 {
+		logfilePath = filepath.Join(dir, fmt.Sprintf("minikube_%s_%d.log", hs, logIdx))
+	} else {
+		logfilePath = filepath.Join(dir, fmt.Sprintf("minikube_%s_%s_%d.log", os.Args[1], hs, logIdx))
+	}
+	// if log has reached max size 1M, generate new logfile name by incrementing count
+	if checkLogFileMaxSize(logfilePath, 1024) {
+		return logFileName(dir, logIdx+1)
+	}
+	return logfilePath
+}
+
 // setFlags sets the flags
 func setFlags() {
 	// parse flags beyond subcommand - get aroung go flag 'limitations':
@@ -145,6 +180,20 @@ func setFlags() {
 		}
 	}
 	setLastStartFlags()
+
+	// set default log_file name but don't override user's preferences
+	if !pflag.CommandLine.Changed("log_file") {
+		// default log_file dir to $TMP
+		dir := os.TempDir()
+		// set log_dir to user input if specified
+		if pflag.CommandLine.Changed("log_dir") && pflag.Lookup("log_dir").Value.String() != "" {
+			dir = pflag.Lookup("log_dir").Value.String()
+		}
+		l := logFileName(dir, 0)
+		if err := pflag.Set("log_file", l); err != nil {
+			klog.Warningf("Unable to set default flag value for log_file: %v", err)
+		}
+	}
 
 	// make sure log_dir exists if log_file is not also set - the log_dir is mutually exclusive with the log_file option
 	// ref: https://github.com/kubernetes/klog/blob/52c62e3b70a9a46101f33ebaf0b100ec55099975/klog.go#L491

--- a/site/content/en/docs/handbook/troubleshooting.md
+++ b/site/content/en/docs/handbook/troubleshooting.md
@@ -19,15 +19,15 @@ Example:
 
 ## Post-mortem minikube debug logs
 
-minikube stores post-mortem INFO logs in the temporary directory of your system. On macOS or Linux, it's easy to get a list of recent INFO logs:
+minikube stores post-mortem logs in the temporary directory of your system. One log file is created per subcommand and any subsequent invocations of the subcommand with the same args will append to the same file. If the log file has exceeded 1MB in size, a new log file is created. On macOS or Linux, it's easy to get a list of recent logs:
 
 ```shell
-find $TMPDIR -mtime -1 -type f -name "*minikube*INFO*" -ls  2>/dev/null
+find $TMPDIR -mtime -1 -type f -name "*minikube*" -ls  2>/dev/null
 ```
 
-For instance, this shows:
+For instance after running `minikube start`, the above comamnd will show:
 
-`-rw-r--r-- 1 user  grp  718 Aug 18 12:40 /var/folders/n1/qxvd9kc/T//minikube.mac.user.log.INFO.20200818-124017.63501`
+`-rw-r--r-- 1 user  grp  718 Aug 18 12:40 /var/folders/n1/qxvd9kc/T//minikube_start_dc950831e1a232e0318a6d6ca82aaf4f4a8a048b_0.log`
 
 These are plain text log files: you may rename them to "<filename>.log" and then drag/drop them into a GitHub issue for further analysis by the minikube team. You can quickly inspect the final lines of any of these logs via:
   

--- a/test/integration/error_spam_test.go
+++ b/test/integration/error_spam_test.go
@@ -115,8 +115,9 @@ func TestErrorSpam(t *testing.T) {
 		expectedLogFiles int // number of logfiles expected after running command runCount times
 	}{
 		{
-			command:          "logs",
-			runCount:         15, // calling this 15 times should create 2 files with 1 greater than 1M
+			command:          "start",
+			args:             []string{"--dry-run", "--log_dir", os.TempDir()},
+			runCount:         120, // calling this 15 times should create 2 files with 1 greater than 1M
 			expectedLogFiles: 2,
 		},
 		{
@@ -142,6 +143,12 @@ func TestErrorSpam(t *testing.T) {
 		t.Run(test.command, func(t *testing.T) {
 			args := []string{test.command, "-p", profile}
 			args = append(args, test.args...)
+			// before starting the test, ensure no other logs from the current command are written
+			logFiles, err := getLogFiles(test.command)
+			if err != nil {
+				t.Errorf("failed to find tmp log files: command %s : %v", test.command, err)
+			}
+			cleanupLogFiles(t, logFiles)
 			// run command runCount times
 			for i := 0; i < test.runCount; i++ {
 				rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
@@ -150,7 +157,7 @@ func TestErrorSpam(t *testing.T) {
 				}
 			}
 			// get log files generated above
-			logFiles, err := getLogFiles(test.command)
+			logFiles, err = getLogFiles(test.command)
 			if err != nil {
 				t.Errorf("failed to find tmp log files: command %s : %v", test.command, err)
 			}

--- a/test/integration/error_spam_test.go
+++ b/test/integration/error_spam_test.go
@@ -117,7 +117,7 @@ func TestErrorSpam(t *testing.T) {
 		{
 			command:          "start",
 			args:             []string{"--dry-run", "--log_dir", os.TempDir()},
-			runCount:         120, // calling this 15 times should create 2 files with 1 greater than 1M
+			runCount:         120, // calling this 120 times should create 2 files with 1 greater than 1M
 			expectedLogFiles: 2,
 		},
 		{
@@ -176,7 +176,7 @@ func TestErrorSpam(t *testing.T) {
 					if isSmall && !foundSmall {
 						foundSmall = true
 					} else if isSmall && foundSmall {
-						t.Errorf("expected to find only one file less than 1M: cmd %s:", test.command)
+						t.Errorf("expected to find only one file less than 1MB: cmd %s:", test.command)
 					}
 				}
 			}


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
fixes https://github.com/kubernetes/minikube/issues/9156 based on https://github.com/kubernetes/minikube/issues/9156#issuecomment-696195859

- By default if `log_file` is not specified, we write to `$TMPDIR/minikube_<argv[1]>_<hash>.log`
- if `log_dir` specified, we write to `$LOG_DIR/minikube_<argv[1]>_<hash>.log`
- Any binary runs with same args will result in logs being appended to the same logfile

### before
```sh
for i in {1..3}; do minikube status; done
```
creates
```
minikube.hostname.user.log.INFO.20210209-141816.44848
minikube.hostname.user.log.INFO.20210209-141818.44872
minikube.hostname.user.log.INFO.20210209-141819.44913
minikube.hostname.user.log.WARNING.20210209-141816.44848
minikube.hostname.user.log.WARNING.20210209-141818.44872
minikube.hostname.user.log.WARNING.20210209-141819.44913
```
each containing 
```
Log file created at: 2021/02/09 14:23:21
Running on machine: hostname
Binary: Built with gc go1.15.7 for darwin/amd64
Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg
```
### after
```sh
for i in {1..3}; do ./out/minikube status; done
```
creates
```
minikube_status_f744034489211de89319363bc95da8daa2870d09.log
```
containing
```
Log file created at: 2021/02/09 14:22:15
Running on machine: hostname
Binary: Built with gc go1.14.15 for darwin/amd64
Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg
Log file created at: 2021/02/09 14:22:16
Running on machine: hostname
Binary: Built with gc go1.14.15 for darwin/amd64
Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg
Log file created at: 2021/02/09 14:22:16
Running on machine: hostname
Binary: Built with gc go1.14.15 for darwin/amd64
Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg
```