### PR TITLE
Fix TestNetworkPlugins/group/auto/KubeletFlags on containerd/crio

### DIFF
--- a/test/integration/net_test.go
+++ b/test/integration/net_test.go
@@ -108,8 +108,11 @@ func TestNetworkPlugins(t *testing.T) {
 						out := rr.Stdout.String()
 
 						if tc.kubeletPlugin == "" {
-							if strings.Contains(out, "--network-plugin") {
+							if strings.Contains(out, "--network-plugin") && ContainerRuntime() == "docker" {
 								t.Errorf("expected no network plug-in, got %s", out)
+							}
+							if !strings.Contains(out, "--network-plugin=cni") && ContainerRuntime() != "docker" {
+								t.Errorf("expected cni network plugin with conatinerd/crio, got %s", out)
 							}
 						} else {
 							if !strings.Contains(out, fmt.Sprintf("--network-plugin=%s", tc.kubeletPlugin)) {

--- a/test/integration/net_test.go
+++ b/test/integration/net_test.go
@@ -92,34 +92,16 @@ func TestNetworkPlugins(t *testing.T) {
 				}
 				if !t.Failed() {
 					t.Run("KubeletFlags", func(t *testing.T) {
-						var rr *RunResult
-						var err error
-
 						// none does not support 'minikube ssh'
+						rr, err := Run(t, exec.CommandContext(ctx, Target(), "ssh", "-p", profile, "pgrep -a kubelet"))
 						if NoneDriver() {
 							rr, err = Run(t, exec.CommandContext(ctx, "pgrep", "-a", "kubelet"))
-						} else {
-							rr, err = Run(t, exec.CommandContext(ctx, Target(), "ssh", "-p", profile, "pgrep -a kubelet"))
 						}
-
 						if err != nil {
 							t.Fatalf("ssh failed: %v", err)
 						}
 						out := rr.Stdout.String()
-
-						if tc.kubeletPlugin == "" {
-							if strings.Contains(out, "--network-plugin") && ContainerRuntime() == "docker" {
-								t.Errorf("expected no network plug-in, got %s", out)
-							}
-							if !strings.Contains(out, "--network-plugin=cni") && ContainerRuntime() != "docker" {
-								t.Errorf("expected cni network plugin with conatinerd/crio, got %s", out)
-							}
-						} else {
-							if !strings.Contains(out, fmt.Sprintf("--network-plugin=%s", tc.kubeletPlugin)) {
-								t.Errorf("expected --network-plugin=%s, got %s", tc.kubeletPlugin, out)
-							}
-						}
-
+						verifyKubeletFlagsOutput(t, tc.kubeletPlugin, out)
 					})
 				}
 
@@ -208,4 +190,17 @@ func TestNetworkPlugins(t *testing.T) {
 			})
 		}
 	})
+}
+
+func verifyKubeletFlagsOutput(t *testing.T, kubeletPlugin, out string) {
+	if kubeletPlugin == "" {
+		if strings.Contains(out, "--network-plugin") && ContainerRuntime() == "docker" {
+			t.Errorf("expected no network plug-in, got %s", out)
+		}
+		if !strings.Contains(out, "--network-plugin=cni") && ContainerRuntime() != "docker" {
+			t.Errorf("expected cni network plugin with conatinerd/crio, got %s", out)
+		}
+	} else if !strings.Contains(out, fmt.Sprintf("--network-plugin=%s", kubeletPlugin)) {
+		t.Errorf("expected --network-plugin=%s, got %s", kubeletPlugin, out)
+	}
 }


### PR DESCRIPTION
For docker runtime, if we don't pass in `--network-plugin` to `minikube start`, then it isn't passed in to the kubelet.

For containerd/crio, if we pass in nothing then `--network-plugin=cni` is passed in  to the kubelet. This modifies the test to take the runtime into account.

fixes https://github.com/kubernetes/minikube/issues/10429