### PR TITLE
Explicitly remove podman volume and network

### DIFF
--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -260,9 +260,25 @@ func deletePossibleKicLeftOver(ctx context.Context, cname string, driverName str
 		}
 	}
 
+	if bin == oci.Podman {
+		// podman volume does not support --filter
+		err := oci.RemoveVolume(bin, cname)
+		if err != nil {
+			klog.Warningf("error deleting volume %s (might be okay).'\n:%v", cname, err)
+		}
+	}
+
 	errs := oci.DeleteAllVolumesByLabel(ctx, bin, delLabel)
 	if errs != nil { // it will not error if there is nothing to delete
 		klog.Warningf("error deleting volumes (might be okay).\nTo see the list of volumes run: 'docker volume ls'\n:%v", errs)
+	}
+
+	if bin == oci.Podman {
+		// podman network does not support --filter
+		err := oci.RemoveNetwork(bin, cname)
+		if err != nil {
+			klog.Warningf("error deleting network %s (might be okay).'\n:%v", cname, err)
+		}
 	}
 
 	errs = oci.DeleteKICNetworks(bin)

--- a/pkg/drivers/kic/oci/errors.go
+++ b/pkg/drivers/kic/oci/errors.go
@@ -54,6 +54,9 @@ var ErrDaemonInfo = errors.New("daemon info not responding")
 // ErrInsufficientDockerStorage is thrown when there is not more storage for docker
 var ErrInsufficientDockerStorage = &FailFastError{errors.New("insufficient docker storage, no space left on device")}
 
+// ErrVolumeNotFound is when given volume was not found
+var ErrVolumeNotFound = errors.New("kic volume not found")
+
 // ErrNetworkSubnetTaken is thrown when a subnet is taken by another network
 var ErrNetworkSubnetTaken = errors.New("subnet is taken")
 


### PR DESCRIPTION
The --filter and --label functionality was broken,
in earlier versions of podman (before version 3.0)

Closes #9705