### PR TITLE
prevent oci try to create overlapping network

### DIFF
--- a/pkg/drivers/kic/oci/network_create.go
+++ b/pkg/drivers/kic/oci/network_create.go
@@ -28,7 +28,7 @@ import (
 	"github.com/pkg/errors"
 
 	"k8s.io/klog/v2"
-	"k8s.io/minikube/pkg/util"
+	"k8s.io/minikube/pkg/network"
 )
 
 // firstSubnetAddr subnet to be used on first kic cluster
@@ -76,7 +76,7 @@ func CreateNetwork(ociBin string, networkName string) (net.IP, error) {
 	// Rather than iterate through all of the valid subnets, give up at 20 to avoid a lengthy user delay for something that is unlikely to work.
 	// will be like 192.168.49.0/24 ,...,192.168.239.0/24
 	for attempts < 2 {
-		subnet, err := util.GetFreePrivateNetwork(subnetAddr, 10, 10)
+		subnet, err := network.FreeSubnet(subnetAddr, 10, 10)
 		if err != nil {
 			klog.Warningf("failed to find free private network subnet starting with %q, step %d, tries %d: %v", subnetAddr, 10, 10, err)
 		}

--- a/pkg/drivers/kvm/network.go
+++ b/pkg/drivers/kvm/network.go
@@ -159,7 +159,8 @@ func (d *Driver) createNetwork() error {
 	if err != nil {
 		subnet, err := network.FreeSubnet(firstSubnetAddr, 10, 20)
 		if err != nil {
-			return errors.Wrapf(err, "failed to find free private network subnet starting with %q, step: %d, tries:%d", firstSubnetAddr, 10, 20)
+			log.Debugf("error while trying to create network: %v", err)
+			return errors.Wrap(err, "un-retryable")
 		}
 		tryNet := kvmNetwork{
 			Name:       d.PrivateNetwork,

--- a/pkg/drivers/kvm/network.go
+++ b/pkg/drivers/kvm/network.go
@@ -31,6 +31,7 @@ import (
 	"github.com/docker/machine/libmachine/log"
 	libvirt "github.com/libvirt/libvirt-go"
 	"github.com/pkg/errors"
+	"k8s.io/minikube/pkg/util"
 	"k8s.io/minikube/pkg/util/retry"
 )
 
@@ -38,15 +39,24 @@ import (
 // https://play.golang.org/p/m8TNTtygK0
 const networkTmpl = `
 <network>
-  <name>{{.PrivateNetwork}}</name>
+  <name>{{.Name}}</name>
   <dns enable='no'/>
-  <ip address='192.168.39.1' netmask='255.255.255.0'>
+  <ip address='{{.Network.Gateway}}' netmask='{{.Network.Netmask}}'>
     <dhcp>
-      <range start='192.168.39.2' end='192.168.39.254'/>
+      <range start='{{.Network.ClientMin}}' end='{{.Network.ClientMax}}'/>
     </dhcp>
   </ip>
 </network>
 `
+
+type kvmNetwork struct {
+	Name string
+	util.Network
+}
+
+// firstSubnetAddr is starting subnet to try for new KVM cluster,
+// avoiding possible conflict with other local networks by further incrementing it up to 20 times by 10.
+const firstSubnetAddr = "192.168.39.0"
 
 // setupNetwork ensures that the network with `name` is started (active)
 // and has the autostart feature set.
@@ -145,10 +155,19 @@ func (d *Driver) createNetwork() error {
 	// Only create the private network if it does not already exist
 	netp, err := conn.LookupNetworkByName(d.PrivateNetwork)
 	if err != nil {
+		subnet, err := util.GetFreePrivateNetwork(firstSubnetAddr, 10, 20)
+		if err != nil {
+			return errors.Wrapf(err, "failed to find free private network subnet starting with %q, step: %d, tries:%d", firstSubnetAddr, 10, 20)
+		}
+		tryNet := kvmNetwork{
+			Name:    d.PrivateNetwork,
+			Network: *subnet,
+		}
+
 		// create the XML for the private network from our networkTmpl
 		tmpl := template.Must(template.New("network").Parse(networkTmpl))
 		var networkXML bytes.Buffer
-		if err := tmpl.Execute(&networkXML, d); err != nil {
+		if err := tmpl.Execute(&networkXML, tryNet); err != nil {
 			return errors.Wrap(err, "executing network template")
 		}
 
@@ -173,6 +192,7 @@ func (d *Driver) createNetwork() error {
 		if err := retry.Local(create, 10*time.Second); err != nil {
 			return errors.Wrapf(err, "creating network %s", d.PrivateNetwork)
 		}
+		log.Debugf("Network %s created", d.PrivateNetwork)
 	}
 	defer func() {
 		if netp != nil {

--- a/pkg/minikube/cluster/ip.go
+++ b/pkg/minikube/cluster/ip.go
@@ -47,7 +47,11 @@ func HostIP(host *host.Host, clusterName string) (net.IP, error) {
 		}
 		return net.ParseIP(ip), nil
 	case driver.KVM2:
-		return net.ParseIP("192.168.39.1"), nil
+		ip, err := host.Driver.GetIP()
+		if err != nil {
+			return []byte{}, errors.Wrap(err, "Error getting VM/Host IP address")
+		}
+		return net.ParseIP(ip), nil
 	case driver.HyperV:
 		v := reflect.ValueOf(host.Driver).Elem()
 		var hypervVirtualSwitch string

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -206,5 +206,5 @@ func FreeSubnet(startSubnet string, step, tries int) (*Parameters, error) {
 		}
 		startSubnet = nextSubnet.String()
 	}
-	return nil, fmt.Errorf("no free private network subnets found with given parameters")
+	return nil, fmt.Errorf("no free private network subnets found with given parameters (start: %q, step: %d, tries: %d)", startSubnet, step, tries)
 }

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -66,10 +66,10 @@ type Interface struct {
 	IfaceMAC  string
 }
 
-// Inspect initialises IPv4 network parameters struct from given address.
+// inspect initialises IPv4 network parameters struct from given address.
 // address can be single address (like "192.168.17.42"), network address (like "192.168.17.0"), or in cidr form (like "192.168.17.42/24 or "192.168.17.0/24").
 // If addr is valid existsing interface address, network struct will also contain info about the respective interface.
-func Inspect(addr string) (*Parameters, error) {
+func inspect(addr string) (*Parameters, error) {
 	n := &Parameters{}
 
 	// extract ip from addr
@@ -147,9 +147,9 @@ func Inspect(addr string) (*Parameters, error) {
 	return n, nil
 }
 
-// IsSubnetTaken returns if local network subnet exists and any error occurred.
+// isSubnetTaken returns if local network subnet exists and any error occurred.
 // If will return false in case of an error.
-func IsSubnetTaken(subnet string) (bool, error) {
+func isSubnetTaken(subnet string) (bool, error) {
 	ips, err := net.InterfaceAddrs()
 	if err != nil {
 		return false, errors.Wrap(err, "listing local networks")
@@ -166,8 +166,8 @@ func IsSubnetTaken(subnet string) (bool, error) {
 	return false, nil
 }
 
-// IsSubnetPrivate returns if subnet is a private network.
-func IsSubnetPrivate(subnet string) bool {
+// isSubnetPrivate returns if subnet is a private network.
+func isSubnetPrivate(subnet string) bool {
 	for _, ipnet := range privateSubnets {
 		if ipnet.Contains(net.ParseIP(subnet)) {
 			return true
@@ -179,13 +179,13 @@ func IsSubnetPrivate(subnet string) bool {
 // FreeSubnet will try to find free private network beginning with startSubnet, incrementing it in steps up to number of tries.
 func FreeSubnet(startSubnet string, step, tries int) (*Parameters, error) {
 	for try := 0; try < tries; try++ {
-		n, err := Inspect(startSubnet)
+		n, err := inspect(startSubnet)
 		if err != nil {
 			return nil, err
 		}
 		startSubnet = n.IP
-		if IsSubnetPrivate(startSubnet) {
-			taken, err := IsSubnetTaken(startSubnet)
+		if isSubnetPrivate(startSubnet) {
+			taken, err := isSubnetTaken(startSubnet)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/util/network.go
+++ b/pkg/util/network.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2021 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+
+	"github.com/pkg/errors"
+	"k8s.io/klog/v2"
+)
+
+var (
+	// valid private networks (RFC1918)
+	privateNetworks = []net.IPNet{
+		// 10.0.0.0/8
+		{
+			IP:   []byte{10, 0, 0, 0},
+			Mask: []byte{255, 0, 0, 0},
+		},
+		// 172.16.0.0/12
+		{
+			IP:   []byte{172, 16, 0, 0},
+			Mask: []byte{255, 240, 0, 0},
+		},
+		// 192.168.0.0/16
+		{
+			IP:   []byte{192, 168, 0, 0},
+			Mask: []byte{255, 255, 0, 0},
+		},
+	}
+)
+
+// Network contains main network parameters.
+type Network struct {
+	IP        string // IP address of the network
+	Netmask   string // form: 4-byte ('a.b.c.d')
+	CIDR      string // form: CIDR
+	Gateway   string // first IP address (assumed, not checked !)
+	ClientMin string // second IP address
+	ClientMax string // last IP address before broadcastS
+	Broadcast string // last IP address
+	Interface
+}
+
+// Interface contains main network interface parameters.
+type Interface struct {
+	IfaceName string
+	IfaceIPv4 string
+	IfaceMTU  int
+	IfaceMAC  string
+}
+
+// GetNetworkFrom initialises IPv4 network struct from given address.
+// address can be single address (like "192.168.17.42"), network address (like "192.168.17.0"), or in cidr form (like "192.168.17.42/24 or "192.168.17.0/24").
+// If addr is valid existsing interface address, network struct will also contain info about the respective interface.
+func GetNetworkFrom(addr string) (*Network, error) {
+	n := &Network{}
+
+	// extract ip from addr
+	ip, network, err := net.ParseCIDR(addr)
+	if err != nil {
+		ip = net.ParseIP(addr)
+		if ip == nil {
+			return nil, errors.Wrapf(err, "parsing address %q", addr)
+		}
+	}
+
+	// check local interfaces
+	ifaces, _ := net.Interfaces()
+	for _, iface := range ifaces {
+		ifAddrs, err := iface.Addrs()
+		if err != nil {
+			return nil, errors.Wrapf(err, "listing addresses of network interface %+v", iface)
+		}
+		for _, ifAddr := range ifAddrs {
+			ifip, lan, err := net.ParseCIDR(ifAddr.String())
+			if err != nil {
+				return nil, errors.Wrapf(err, "parsing address of network iface %+v", ifAddr)
+			}
+			if lan.Contains(ip) {
+				n.IfaceName = iface.Name
+				n.IfaceIPv4 = ifip.To4().String()
+				n.IfaceMTU = iface.MTU
+				n.IfaceMAC = iface.HardwareAddr.String()
+				n.Gateway = n.IfaceIPv4
+				network = lan
+				break
+			}
+		}
+	}
+
+	if network == nil {
+		ipnet := &net.IPNet{
+			IP:   ip,
+			Mask: ip.DefaultMask(), // assume default network mask
+		}
+		_, network, err = net.ParseCIDR(ipnet.String())
+		if err != nil {
+			return nil, errors.Wrapf(err, "determining network address from %q", addr)
+		}
+	}
+
+	n.IP = network.IP.String()
+	n.Netmask = net.IP(network.Mask).String() // form: 4-byte ('a.b.c.d')
+	n.CIDR = network.String()
+
+	networkIP := binary.BigEndian.Uint32(network.IP)                      // IP address of the network
+	networkMask := binary.BigEndian.Uint32(network.Mask)                  // network mask
+	broadcastIP := (networkIP & networkMask) | (networkMask ^ 0xffffffff) // last network IP address
+
+	broadcast := make(net.IP, 4)
+	binary.BigEndian.PutUint32(broadcast, broadcastIP)
+	n.Broadcast = broadcast.String()
+
+	gateway := net.ParseIP(n.Gateway).To4() // has to be converted to 4-byte representation!
+	if gateway == nil {
+		gateway = make(net.IP, 4)
+		binary.BigEndian.PutUint32(gateway, networkIP+1) // assume first network IP address
+		n.Gateway = gateway.String()
+	}
+	gatewayIP := binary.BigEndian.Uint32(gateway)
+
+	min := make(net.IP, 4)
+	binary.BigEndian.PutUint32(min, gatewayIP+1) // clients-from: first network IP address after gateway
+	n.ClientMin = min.String()
+
+	max := make(net.IP, 4)
+	binary.BigEndian.PutUint32(max, broadcastIP-1) // clients-from: last network IP address before broadcast
+	n.ClientMax = max.String()
+
+	return n, nil
+}
+
+// IsNetworkTaken returns if local network subnet exists and any error occurred.
+// If will return false in case of an error.
+func IsNetworkTaken(subnet string) (bool, error) {
+	ips, err := net.InterfaceAddrs()
+	if err != nil {
+		return false, errors.Wrap(err, "listing local networks")
+	}
+	for _, ip := range ips {
+		_, lan, err := net.ParseCIDR(ip.String())
+		if err != nil {
+			return false, errors.Wrapf(err, "parsing network iface address %q", ip)
+		}
+		if lan.Contains(net.ParseIP(subnet)) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// IsNetworkPrivate returns if subnet is a private network.
+func IsNetworkPrivate(subnet string) bool {
+	for _, ipnet := range privateNetworks {
+		if ipnet.Contains(net.ParseIP(subnet)) {
+			return true
+		}
+	}
+	return false
+}
+
+// GetFreePrivateNetwork will try to find an free private network starting with subnet, incrementing it in steps up to number of tries.
+func GetFreePrivateNetwork(subnet string, step, tries int) (*Network, error) {
+	for try := 0; try < tries; try++ {
+		n, err := GetNetworkFrom(subnet)
+		if err != nil {
+			return nil, err
+		}
+		subnet = n.IP
+		if IsNetworkPrivate(subnet) {
+			taken, err := IsNetworkTaken(subnet)
+			if err != nil {
+				return nil, err
+			}
+			if !taken {
+				klog.Infof("using free private subnet %s: %+v", n.CIDR, n)
+				return n, nil
+			}
+			klog.Infof("skipping subnet %s that is taken: %+v", n.CIDR, n)
+		} else {
+			klog.Infof("skipping subnet %s that is not private", n.CIDR)
+		}
+		ones, _ := net.ParseIP(n.IP).DefaultMask().Size()
+		newSubnet := net.ParseIP(subnet).To4()
+		if ones <= 16 {
+			newSubnet[1] += byte(step)
+		} else {
+			newSubnet[2] += byte(step)
+		}
+		subnet = newSubnet.String()
+	}
+	return nil, fmt.Errorf("no free private network subnets found with given parameters")
+}


### PR DESCRIPTION
fixes #10005

make sure that the candidate for new container network does not overlap with any existing local networks

**notes**:
- the issue seen below with stale/inactive kvm network (even after `--delete` flag) is resolved in pr #10479 
- we can try to use new `GetNetworkFrom()` (in pkg/network/network.go) for getting any interface's `mtu` (i know there were some issues with it)
- having params in kvm's `networkTmpl` opens possibility to have different private network for each cluster (needs more work to have that if we want to); ref: https://github.com/kubernetes/minikube/issues/9049#issuecomment-679192676


## example


### before

set docker net to kvm's default (static) one to simulate conflict:
```
❯ grep "const firstSubnetAddr" pkg/drivers/kic/oci/network_create.go
const firstSubnetAddr = "192.168.39.0"

❯ grep "ip address" pkg/drivers/kvm/network.go
  <ip address='192.168.39.1' netmask='255.255.255.0'>
```

```
❯ out/minikube start --driver=docker -p docker-192.168.39.0
😄  [docker-192.168.39.0] minikube v1.17.1 on Opensuse-Tumbleweed
✨  Using the docker driver based on user configuration
❗  docker is currently using the btrfs storage driver, consider switching to overlay2 for better performance
👍  Starting control plane node docker-192.168.39.0 in cluster docker-192.168.39.0
🔥  Creating docker container (CPUs=2, Memory=16000MB) ...
🐳  Preparing Kubernetes v1.20.2 on Docker 20.10.2 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v4
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "docker-192.168.39.0" cluster and "default" namespace by default
```

```
❯ ip -4 -br -o a s
lo               UNKNOWN        127.0.0.1/8
virbr0           DOWN           192.168.122.1/24
wlp113s0         UP             192.168.42.17/24
br-08ada8d5dfa4  UP             172.22.0.1/16
docker0          DOWN           172.17.0.1/16
br-ec7e0d3126e7  UP             192.168.39.1/24
```

```
❯ out/minikube start --driver=kvm -p kvm-192.168.39.0
😄  [kvm-192.168.39.0] minikube v1.17.1 on Opensuse-Tumbleweed
✨  Using the kvm2 driver based on user configuration
💿  Downloading VM boot image ...
    > minikube-v1.17.0.iso.sha256: 65 B / 65 B [-------------] 100.00% ? p/s 0s
    > minikube-v1.17.0.iso: 212.69 MiB / 212.69 MiB [] 100.00% 24.09 MiB p/s 9s
👍  Starting control plane node kvm-192.168.39.0 in cluster kvm-192.168.39.0
💾  Downloading Kubernetes v1.20.2 preload ...
    > preloaded-images-k8s-v8-v1....: 491.22 MiB / 491.22 MiB  100.00% 21.47 Mi
🔥  Creating kvm2 VM (CPUs=2, Memory=6000MB, Disk=20000MB) ...
🤦  StartHost failed, but will try again: creating host: create: Error creating machine: Error in driver during machine creation: creating network: creating network minikube-net: virError(Code=1, Domain=0, Message='internal error: Network is already in use by interface br-ec7e0d3126e7')
🔄  Restarting existing kvm2 VM for "kvm-192.168.39.0" ...
😿  Failed to start kvm2 VM. Running "minikube delete -p kvm-192.168.39.0" may fix it: driver start: ensuring active networks: deleting inoperable network minikube-net: destroying network: virError(Code=55, Domain=19, Message='Requested operation is not valid: network 'minikube-net' is not active')

❌  Exiting due to GUEST_PROVISION: Failed to start host: driver start: ensuring active networks: deleting inoperable network minikube-net: destroying network: virError(Code=55, Domain=19, Message='Requested operation is not valid: network 'minikube-net' is not active')

😿  If the above advice does not help, please let us know:
👉  https://github.com/kubernetes/minikube/issues/new/choose
```

```
❯ minikube profile list
|---------------------|-----------|---------|--------------|------|---------|---------|-------|
|       Profile       | VM Driver | Runtime |      IP      | Port | Version | Status  | Nodes |
|---------------------|-----------|---------|--------------|------|---------|---------|-------|
| docker-192.168.39.0 | docker    | docker  | 192.168.39.2 | 8443 | v1.20.2 | Running |     1 |
| kvm-192.168.39.0    | kvm2      | docker  |              | 8443 | v1.20.2 | Unknown |     1 |
|---------------------|-----------|---------|--------------|------|---------|---------|-------|
```

```
❯ minikube delete --all
🔥  Deleting "docker-192.168.39.0" in docker ...
🔥  Removing /home/prezha/.minikube/machines/docker-192.168.39.0 ...
💀  Removed all traces of the "docker-192.168.39.0" cluster.
🔥  Deleting "kvm-192.168.39.0" in kvm2 ...
💀  Removed all traces of the "kvm-192.168.39.0" cluster.
🔥  Successfully deleted all profiles
```

```
# virsh net-list --all
 Name           State      Autostart   Persistent
---------------------------------------------------
 default        active     yes         yes
 minikube-net   inactive   yes         yes
```

### after

simulate conflict:
```
❯ grep "const firstSubnetAddr" pkg/drivers/kic/oci/network_create.go
const firstSubnetAddr = "192.168.49.0"

❯ grep "const firstSubnetAddr" pkg/drivers/kvm/network.go
const firstSubnetAddr = "192.168.49.0"
```

```
❯ out/minikube start --driver=docker -p docker-192.168.49.0
😄  [docker-192.168.49.0] minikube v1.17.1 on Opensuse-Tumbleweed
✨  Using the docker driver based on user configuration
❗  docker is currently using the btrfs storage driver, consider switching to overlay2 for better performance
👍  Starting control plane node docker-192.168.49.0 in cluster docker-192.168.49.0
🔥  Creating docker container (CPUs=2, Memory=16000MB) ...
🐳  Preparing Kubernetes v1.20.2 on Docker 20.10.2 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v4
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "docker-192.168.49.0" cluster and "default" namespace by default
```

```
❯ out/minikube start --driver=kvm -p kvm-192.168.49.0
😄  [kvm-192.168.49.0] minikube v1.17.1 on Opensuse-Tumbleweed
✨  Using the kvm2 driver based on user configuration
👍  Starting control plane node kvm-192.168.49.0 in cluster kvm-192.168.49.0
💾  Downloading Kubernetes v1.20.2 preload ...
    > preloaded-images-k8s-v8-v1....: 491.22 MiB / 491.22 MiB  100.00% 25.11 Mi
🔥  Creating kvm2 VM (CPUs=2, Memory=6000MB, Disk=20000MB) ...
🐳  Preparing Kubernetes v1.20.2 on Docker 20.10.2 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v4
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "kvm-192.168.49.0" cluster and "default" namespace by default
```

```
❯ ip -4 -br -o a s
lo               UNKNOWN        127.0.0.1/8
virbr0           UP             192.168.122.1/24
wlp113s0         UP             192.168.42.17/24
br-08ada8d5dfa4  UP             172.22.0.1/16
docker0          DOWN           172.17.0.1/16
br-33a6261ee1e8  UP             192.168.49.1/24
virbr1           UP             192.168.69.1/24
```

```
❯ minikube profile list
|---------------------|-----------|---------|---------------|------|---------|---------|-------|
|       Profile       | VM Driver | Runtime |      IP       | Port | Version | Status  | Nodes |
|---------------------|-----------|---------|---------------|------|---------|---------|-------|
| docker-192.168.49.0 | docker    | docker  | 192.168.49.2  | 8443 | v1.20.2 | Running |     1 |
| kvm-192.168.49.0    | kvm2      | docker  | 192.168.69.72 | 8443 | v1.20.2 | Running |     1 |
|---------------------|-----------|---------|---------------|------|---------|---------|-------|
```

```
❯ minikube delete --all
🔥  Deleting "docker-192.168.49.0" in docker ...
🔥  Removing /home/prezha/.minikube/machines/docker-192.168.49.0 ...
💀  Removed all traces of the "docker-192.168.49.0" cluster.
🔥  Deleting "kvm-192.168.49.0" in kvm2 ...
💀  Removed all traces of the "kvm-192.168.49.0" cluster.
🔥  Successfully deleted all profiles
```

```
codex:~ # virsh net-list --all
 Name      State    Autostart   Persistent
--------------------------------------------
 default   active   yes         yes
```
---

same goes for the other side:

```
❯ grep "const firstSubnetAddr" pkg/drivers/kic/oci/network_create.go
const firstSubnetAddr = "192.168.39.0"

❯ grep "const firstSubnetAddr" pkg/drivers/kvm/network.go
const firstSubnetAddr = "192.168.39.0"
```

```
❯ out/minikube start --driver=kvm -p kvm-192.168.39.0
😄  [kvm-192.168.39.0] minikube v1.17.1 on Opensuse-Tumbleweed
✨  Using the kvm2 driver based on user configuration
👍  Starting control plane node kvm-192.168.39.0 in cluster kvm-192.168.39.0
🔥  Creating kvm2 VM (CPUs=2, Memory=6000MB, Disk=20000MB) ...
🐳  Preparing Kubernetes v1.20.2 on Docker 20.10.2 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v4
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "kvm-192.168.39.0" cluster and "default" namespace by default
```

```
❯ out/minikube start --driver=docker -p docker-192.168.39.0
😄  [docker-192.168.39.0] minikube v1.17.1 on Opensuse-Tumbleweed
✨  Using the docker driver based on user configuration
❗  docker is currently using the btrfs storage driver, consider switching to overlay2 for better performance
👍  Starting control plane node docker-192.168.39.0 in cluster docker-192.168.39.0
🔥  Creating docker container (CPUs=2, Memory=16000MB) ...
🐳  Preparing Kubernetes v1.20.2 on Docker 20.10.2 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v4
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "docker-192.168.39.0" cluster and "default" namespace by default
```

```
❯ ip -4 -br -o a s
lo               UNKNOWN        127.0.0.1/8
virbr0           UP             192.168.122.1/24
wlp113s0         UP             192.168.42.17/24
br-08ada8d5dfa4  UP             172.22.0.1/16
docker0          DOWN           172.17.0.1/16
virbr1           UP             192.168.39.1/24
br-8616cbd0a692  UP             192.168.49.1/24
```

```
❯ minikube profile list
|---------------------|-----------|---------|----------------|------|---------|---------|-------|
|       Profile       | VM Driver | Runtime |       IP       | Port | Version | Status  | Nodes |
|---------------------|-----------|---------|----------------|------|---------|---------|-------|
| docker-192.168.39.0 | docker    | docker  | 192.168.49.2   | 8443 | v1.20.2 | Running |     1 |
| kvm-192.168.39.0    | kvm2      | docker  | 192.168.39.174 | 8443 | v1.20.2 | Running |     1 |
|---------------------|-----------|---------|----------------|------|---------|---------|-------|
```
---
## additional examples (as per @medyagh's suggestion)

### current master

```
❯ docker network list
NETWORK ID     NAME                 DRIVER    SCOPE
d4c6d1af63d9   br-test00            bridge    local
4caf32131f3f   br-test01            bridge    local
bafaa95e04c9   br-test02            bridge    local
82697145172a   br-test03            bridge    local
3fb60e8289eb   br-test04            bridge    local
f6bd05bf4625   br-test05            bridge    local
f62e9c91fe42   br-test06            bridge    local
a4dc3444d406   br-test07            bridge    local
661f7a0277f9   br-test08            bridge    local
de4b38920f04   br-test09            bridge    local
9816f4fd95a3   bridge               bridge    local
790f8998f0f6   host                 host      local
a9347ae22f3e   minikube             bridge    local
ee746e6d9be7   none                 null      local
```
```
❯ ip -4 -br -o a s
lo               UNKNOWN        127.0.0.1/8
virbr0           DOWN           192.168.122.1/24
wlp113s0         UP             192.168.42.17/24
docker0          DOWN           172.17.0.1/16
br-d4c6d1af63d9  DOWN           192.168.49.1/24
br-4caf32131f3f  DOWN           192.168.59.1/24
br-bafaa95e04c9  DOWN           192.168.70.1/24
br-82697145172a  DOWN           192.168.82.1/24
br-3fb60e8289eb  DOWN           192.168.95.1/24
br-f6bd05bf4625  DOWN           192.168.109.1/24
br-f62e9c91fe42  DOWN           192.168.124.1/24
br-a4dc3444d406  DOWN           192.168.140.1/24
br-661f7a0277f9  DOWN           192.168.157.1/24
br-de4b38920f04  DOWN           192.168.175.1/24
```
```
❯ minikube start                             
stacklog: logging to stack.slog, sampling every 125ms
😄  minikube v1.17.1 on Opensuse-Tumbleweed 
✨  Automatically selected the docker driver. Other choices: kvm2, ssh
❗  docker is currently using the btrfs storage driver, consider switching to overlay2 for better performance
👍  Starting control plane node minikube in cluster minikube
🔥  Creating docker container (CPUs=2, Memory=16000MB) ...
🐳  Preparing Kubernetes v1.20.2 on Docker 20.10.2 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v4
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
stacklog: stopped. stored 428 samples to stack.slog
```
```
 ip -4 -br -o a s
lo               UNKNOWN        127.0.0.1/8
virbr0           DOWN           192.168.122.1/24
wlp113s0         UP             192.168.42.17/24
docker0          DOWN           172.17.0.1/16
br-d4c6d1af63d9  DOWN           192.168.49.1/24
br-4caf32131f3f  DOWN           192.168.59.1/24
br-bafaa95e04c9  DOWN           192.168.70.1/24
br-82697145172a  DOWN           192.168.82.1/24
br-3fb60e8289eb  DOWN           192.168.95.1/24
br-f6bd05bf4625  DOWN           192.168.109.1/24
br-f62e9c91fe42  DOWN           192.168.124.1/24
br-a4dc3444d406  DOWN           192.168.140.1/24
br-661f7a0277f9  DOWN           192.168.157.1/24
br-de4b38920f04  DOWN           192.168.175.1/24
br-a9347ae22f3e  UP             192.168.194.1/24
```

`slowjam` [oci.CreateNetwork] duration: 1 sec
> [ '265: machine.timedCreateHost', 'oci.CreateNetwork', '#808000',  new Date(1874), new Date(2874) ],

### pull request

```
❯ docker network list
NETWORK ID     NAME                 DRIVER    SCOPE
46c634fb4fda   br-test00            bridge    local
2c6a49c30e38   br-test01            bridge    local
6c6ad70ee603   br-test02            bridge    local
83e070309643   br-test03            bridge    local
2cac664e256c   br-test04            bridge    local
8fd544819864   br-test05            bridge    local
bacded214b6b   br-test06            bridge    local
40d9ff702bdc   br-test07            bridge    local
57f7eb9a4178   br-test08            bridge    local
1c6e55082f96   br-test09            bridge    local
9816f4fd95a3   bridge               bridge    local
790f8998f0f6   host                 host      local
817b88552774   minikube             bridge    local
ee746e6d9be7   none                 null      local
```
```
❯ ip -4 -br -o a s
lo               UNKNOWN        127.0.0.1/8
virbr0           DOWN           192.168.122.1/24
wlp113s0         UP             192.168.42.17/24
br-08ada8d5dfa4  UP             172.22.0.1/16
docker0          DOWN           172.17.0.1/16
br-46c634fb4fda  DOWN           192.168.49.1/24
br-2c6a49c30e38  DOWN           192.168.59.1/24
br-6c6ad70ee603  DOWN           192.168.69.1/24
br-83e070309643  DOWN           192.168.79.1/24
br-2cac664e256c  DOWN           192.168.89.1/24
br-8fd544819864  DOWN           192.168.99.1/24
br-bacded214b6b  DOWN           192.168.109.1/24
br-40d9ff702bdc  DOWN           192.168.119.1/24
br-57f7eb9a4178  DOWN           192.168.129.1/24
br-1c6e55082f96  DOWN           192.168.139.1/24
```
```
❯ minikube start
stacklog: logging to stack.slog, sampling every 125ms
😄  minikube v1.17.1 on Opensuse-Tumbleweed
✨  Automatically selected the docker driver. Other choices: kvm2, ssh
❗  docker is currently using the btrfs storage driver, consider switching to overlay2 for better performance
👍  Starting control plane node minikube in cluster minikube
🔥  Creating docker container (CPUs=2, Memory=16000MB) ...
🐳  Preparing Kubernetes v1.20.2 on Docker 20.10.2 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v4
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
stacklog: stopped. stored 422 samples to stack.slog
```
```
❯ ip -4 -br -o a s
lo               UNKNOWN        127.0.0.1/8
virbr0           DOWN           192.168.122.1/24
wlp113s0         UP             192.168.42.17/24
docker0          DOWN           172.17.0.1/16
br-46c634fb4fda  DOWN           192.168.49.1/24
br-2c6a49c30e38  DOWN           192.168.59.1/24
br-6c6ad70ee603  DOWN           192.168.69.1/24
br-83e070309643  DOWN           192.168.79.1/24
br-2cac664e256c  DOWN           192.168.89.1/24
br-8fd544819864  DOWN           192.168.99.1/24
br-bacded214b6b  DOWN           192.168.109.1/24
br-40d9ff702bdc  DOWN           192.168.119.1/24
br-57f7eb9a4178  DOWN           192.168.129.1/24
br-1c6e55082f96  DOWN           192.168.139.1/24
br-817b88552774  UP             192.168.149.1/24
```

`slowjam` [oci.CreateNetwork] duration: 0.751 sec
> [ '278: machine.timedCreateHost', 'oci.CreateNetwork', '#da70d6',  new Date(1749), new Date(2500) ],
