### PR TITLE
Disable all drivers except "docker" and "ssh" on darwin/arm64

### DIFF
--- a/cmd/drivers/hyperkit/main.go
+++ b/cmd/drivers/hyperkit/main.go
@@ -1,5 +1,4 @@
-// +build darwin
-// -build arm64
+// +build darwin,!arm64
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/cmd/drivers/hyperkit/main.go
+++ b/cmd/drivers/hyperkit/main.go
@@ -1,4 +1,5 @@
 // +build darwin
+// -build arm64
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -722,7 +722,7 @@ func validateDriver(ds registry.DriverState, existing *config.ClusterConfig) {
 	name := ds.Name
 	klog.Infof("validating driver %q against %+v", name, existing)
 	if !driver.Supported(name) {
-		exit.Message(reason.DrvUnsupportedOS, "The driver '{{.driver}}' is not supported on {{.os}}/{{.arch}}", out.V{"driver": d, "os": runtime.GOOS, "arch": runtime.GOARCH}
+		exit.Message(reason.DrvUnsupportedOS, "The driver '{{.driver}}' is not supported on {{.os}}/{{.arch}}", out.V{"driver": d, "os": runtime.GOOS, "arch": runtime.GOARCH})
 	}
 
 	// if we are only downloading artifacts for a driver, we can stop validation here

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -722,7 +722,7 @@ func validateDriver(ds registry.DriverState, existing *config.ClusterConfig) {
 	name := ds.Name
 	klog.Infof("validating driver %q against %+v", name, existing)
 	if !driver.Supported(name) {
-		exit.Message(reason.DrvUnsupportedOS, "The driver '{{.driver}}' is not supported on {{.os}}/{{.arch}}", out.V{"driver": d, "os": runtime.GOOS, "arch": runtime.GOARCH})
+		exit.Message(reason.DrvUnsupportedOS, "The driver '{{.driver}}' is not supported on {{.os}}/{{.arch}}", out.V{"driver": name, "os": runtime.GOOS, "arch": runtime.GOARCH})
 	}
 
 	// if we are only downloading artifacts for a driver, we can stop validation here

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -573,7 +573,7 @@ func selectDriver(existing *config.ClusterConfig) (registry.DriverState, []regis
 		}
 		ds := driver.Status(d)
 		if ds.Name == "" {
-			exit.Message(reason.DrvUnsupportedOS, "The driver '{{.driver}}' is not supported on {{.os}}", out.V{"driver": d, "os": runtime.GOOS})
+			exit.Message(reason.DrvUnsupportedOS, "The driver '{{.driver}}' is not supported on {{.os}}/{{.arch}}", out.V{"driver": d, "os": runtime.GOOS, "arch": runtime.GOARCH})
 		}
 		out.Step(style.Sparkle, `Using the {{.driver}} driver based on user configuration`, out.V{"driver": ds.String()})
 		return ds, nil, true
@@ -583,7 +583,7 @@ func selectDriver(existing *config.ClusterConfig) (registry.DriverState, []regis
 	if d := viper.GetString("vm-driver"); d != "" {
 		ds := driver.Status(viper.GetString("vm-driver"))
 		if ds.Name == "" {
-			exit.Message(reason.DrvUnsupportedOS, "The driver '{{.driver}}' is not supported on {{.os}}", out.V{"driver": d, "os": runtime.GOOS})
+			exit.Message(reason.DrvUnsupportedOS, "The driver '{{.driver}}' is not supported on {{.os}}/{{.arch}}", out.V{"driver": d, "os": runtime.GOOS, "arch": runtime.GOARCH})
 		}
 		out.Step(style.Sparkle, `Using the {{.driver}} driver based on user configuration`, out.V{"driver": ds.String()})
 		return ds, nil, true
@@ -722,7 +722,7 @@ func validateDriver(ds registry.DriverState, existing *config.ClusterConfig) {
 	name := ds.Name
 	klog.Infof("validating driver %q against %+v", name, existing)
 	if !driver.Supported(name) {
-		exit.Message(reason.DrvUnsupportedOS, "The driver '{{.driver}}' is not supported on {{.os}}", out.V{"driver": name, "os": runtime.GOOS})
+		exit.Message(reason.DrvUnsupportedOS, "The driver '{{.driver}}' is not supported on {{.os}}/{{.arch}}", out.V{"driver": d, "os": runtime.GOOS, "arch": runtime.GOARCH}
 	}
 
 	// if we are only downloading artifacts for a driver, we can stop validation here

--- a/pkg/minikube/driver/driver_darwin.go
+++ b/pkg/minikube/driver/driver_darwin.go
@@ -16,18 +16,30 @@ limitations under the License.
 
 package driver
 
-import "os/exec"
+import (
+	"os/exec"
+	"runtime"
+)
 
 // supportedDrivers is a list of supported drivers on Darwin.
-var supportedDrivers = []string{
-	VirtualBox,
-	Parallels,
-	VMwareFusion,
-	HyperKit,
-	VMware,
-	Docker,
-	SSH,
-}
+var supportedDrivers []string = func() []string {
+	if runtime.GOARCH == "arm64" {
+		// on darwin/arm64 only docker and ssh are supported yet
+		return []string{
+			Docker,
+			SSH,
+		}
+	}
+	return []string{
+		VirtualBox,
+		Parallels,
+		VMwareFusion,
+		HyperKit,
+		VMware,
+		Docker,
+		SSH,
+	}
+}()
 
 func VBoxManagePath() string {
 	cmd := "VBoxManage"

--- a/translations/de.json
+++ b/translations/de.json
@@ -510,7 +510,7 @@
 	"The cri socket path to be used.": "",
 	"The docker-env command is incompatible with multi-node clusters. Use the 'registry' add-on: https://minikube.sigs.k8s.io/docs/handbook/registry/": "",
 	"The docker-env command is only compatible with the \"docker\" runtime, but this cluster was configured to use the \"{{.runtime}}\" runtime.": "",
-	"The driver '{{.driver}}' is not supported on {{.os}}": "Der Treiber '{{.driver}}' wird auf {{.os}} nicht unterstützt",
+	"The driver '{{.driver}}' is not supported on {{.os}}/{{.arch}}": "Der Treiber '{{.driver}}' wird auf {{.os}}/{{.arch}} nicht unterstützt",
 	"The existing \"{{.name}}\" cluster was created using the \"{{.old}}\" driver, which is incompatible with requested \"{{.new}}\" driver.": "",
 	"The existing node configuration appears to be corrupt. Run 'minikube delete'": "",
 	"The heapster addon is depreciated. please try to disable metrics-server instead": "",

--- a/translations/es.json
+++ b/translations/es.json
@@ -511,7 +511,7 @@
 	"The cri socket path to be used.": "",
 	"The docker-env command is incompatible with multi-node clusters. Use the 'registry' add-on: https://minikube.sigs.k8s.io/docs/handbook/registry/": "",
 	"The docker-env command is only compatible with the \"docker\" runtime, but this cluster was configured to use the \"{{.runtime}}\" runtime.": "",
-	"The driver '{{.driver}}' is not supported on {{.os}}": "El controlador \"{{.driver}}\" no se puede utilizar en {{.os}}",
+	"The driver '{{.driver}}' is not supported on {{.os}}/{{.arch}}": "El controlador \"{{.driver}}\" no se puede utilizar en {{.os}}/{{.arch}}",
 	"The existing \"{{.name}}\" cluster was created using the \"{{.old}}\" driver, which is incompatible with requested \"{{.new}}\" driver.": "",
 	"The existing node configuration appears to be corrupt. Run 'minikube delete'": "",
 	"The heapster addon is depreciated. please try to disable metrics-server instead": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -513,7 +513,7 @@
 	"The cri socket path to be used.": "",
 	"The docker-env command is incompatible with multi-node clusters. Use the 'registry' add-on: https://minikube.sigs.k8s.io/docs/handbook/registry/": "",
 	"The docker-env command is only compatible with the \"docker\" runtime, but this cluster was configured to use the \"{{.runtime}}\" runtime.": "",
-	"The driver '{{.driver}}' is not supported on {{.os}}": "Le pilote \"{{.driver}}\" n'est pas compatible avec {{.os}}.",
+	"The driver '{{.driver}}' is not supported on {{.os}}/{{.arch}}": "Le pilote \"{{.driver}}\" n'est pas compatible avec {{.os}}/{{.arch}}.",
 	"The existing \"{{.name}}\" cluster was created using the \"{{.old}}\" driver, which is incompatible with requested \"{{.new}}\" driver.": "",
 	"The existing node configuration appears to be corrupt. Run 'minikube delete'": "",
 	"The heapster addon is depreciated. please try to disable metrics-server instead": "",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -507,7 +507,7 @@
 	"The cri socket path to be used.": "",
 	"The docker-env command is incompatible with multi-node clusters. Use the 'registry' add-on: https://minikube.sigs.k8s.io/docs/handbook/registry/": "",
 	"The docker-env command is only compatible with the \"docker\" runtime, but this cluster was configured to use the \"{{.runtime}}\" runtime.": "",
-	"The driver '{{.driver}}' is not supported on {{.os}}": "ドライバ「{{.driver}}」は、{{.os}} ではサポートされていません",
+	"The driver '{{.driver}}' is not supported on {{.os}}/{{.arch}}": "ドライバ「{{.driver}}」は、{{.os}}/{{.arch}} ではサポートされていません",
 	"The existing \"{{.name}}\" cluster was created using the \"{{.old}}\" driver, which is incompatible with requested \"{{.new}}\" driver.": "",
 	"The existing node configuration appears to be corrupt. Run 'minikube delete'": "",
 	"The heapster addon is depreciated. please try to disable metrics-server instead": "",

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -480,7 +480,7 @@
 	"The cri socket path to be used.": "",
 	"The docker-env command is incompatible with multi-node clusters. Use the 'registry' add-on: https://minikube.sigs.k8s.io/docs/handbook/registry/": "",
 	"The docker-env command is only compatible with the \"docker\" runtime, but this cluster was configured to use the \"{{.runtime}}\" runtime.": "",
-	"The driver '{{.driver}}' is not supported on {{.os}}": "",
+	"The driver '{{.driver}}' is not supported on {{.os}}/{{.arch}}": "",
 	"The existing \"{{.name}}\" cluster was created using the \"{{.old}}\" driver, which is incompatible with requested \"{{.new}}\" driver.": "",
 	"The heapster addon is depreciated. please try to disable metrics-server instead": "",
 	"The hyperv virtual switch name. Defaults to first found. (hyperv driver only)": "",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -524,7 +524,7 @@
 	"The docker service is currently not active": "Serwis docker jest nieaktywny",
 	"The docker-env command is incompatible with multi-node clusters. Use the 'registry' add-on: https://minikube.sigs.k8s.io/docs/handbook/registry/": "",
 	"The docker-env command is only compatible with the \"docker\" runtime, but this cluster was configured to use the \"{{.runtime}}\" runtime.": "",
-	"The driver '{{.driver}}' is not supported on {{.os}}": "Sterownik '{{.driver}} jest niewspierany przez system {{.os}}",
+	"The driver '{{.driver}}' is not supported on {{.os}}/{{.arch}}": "Sterownik '{{.driver}} jest niewspierany przez system {{.os}}/{{.arch}}",
 	"The existing \"{{.name}}\" cluster was created using the \"{{.old}}\" driver, which is incompatible with requested \"{{.new}}\" driver.": "",
 	"The existing node configuration appears to be corrupt. Run 'minikube delete'": "",
 	"The heapster addon is depreciated. please try to disable metrics-server instead": "",

--- a/translations/strings.txt
+++ b/translations/strings.txt
@@ -426,7 +426,7 @@
 	"The cri socket path to be used.": "",
 	"The docker-env command is incompatible with multi-node clusters. Use the 'registry' add-on: https://minikube.sigs.k8s.io/docs/handbook/registry/": "",
 	"The docker-env command is only compatible with the \"docker\" runtime, but this cluster was configured to use the \"{{.runtime}}\" runtime.": "",
-	"The driver '{{.driver}}' is not supported on {{.os}}": "",
+	"The driver '{{.driver}}' is not supported on {{.os}}/{{.arch}}": "",
 	"The existing \"{{.name}}\" cluster was created using the \"{{.old}}\" driver, which is incompatible with requested \"{{.new}}\" driver.": "",
 	"The heapster addon is depreciated. please try to disable metrics-server instead": "",
 	"The hyperv virtual switch name. Defaults to first found. (hyperv driver only)": "",

--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -613,7 +613,7 @@
 	"The cri socket path to be used.": "",
 	"The docker-env command is incompatible with multi-node clusters. Use the 'registry' add-on: https://minikube.sigs.k8s.io/docs/handbook/registry/": "",
 	"The docker-env command is only compatible with the \"docker\" runtime, but this cluster was configured to use the \"{{.runtime}}\" runtime.": "",
-	"The driver '{{.driver}}' is not supported on {{.os}}": "{{.os}} 不支持驱动程序“{{.driver}}”",
+	"The driver '{{.driver}}' is not supported on {{.os}}/{{.arch}}": "{{.os}} 不支持驱动程序“{{.driver}}/{{.arch}}”",
 	"The existing \"{{.name}}\" cluster was created using the \"{{.old}}\" driver, which is incompatible with requested \"{{.new}}\" driver.": "",
 	"The existing node configuration appears to be corrupt. Run 'minikube delete'": "",
 	"The heapster addon is depreciated. please try to disable metrics-server instead": "",


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/10120

This PR fixes the list of supported minikube drivers for darwin/arm64 platform.

Before:
```
develop@Devs-Mac-mini --- z/minikube ‹master› out/minikube start --driver=hyperkit                                                                                                                                    60 ↵
* minikube v1.17.1 on Darwin 11.1 (arm64)
* Using the hyperkit driver based on existing profile
* Starting control plane node minikube in cluster minikube
* Restarting existing hyperkit VM for "minikube" ...
! StartHost failed, but will try again: driver start: hyperkit crashed! command line:
  hyperkit loglevel=3 console=ttyS0 console=tty0 noembed nomodeset norestore waitusb=10 systemd.legacy_systemd_cgroup_controller=yes random.trust_cpu=on hw_rng_model=virtio base host=minikube
* Restarting existing hyperkit VM for "minikube" ...
* Failed to start hyperkit VM. Running "minikube delete" may fix it: driver start: hyperkit crashed! command line:
  hyperkit loglevel=3 console=ttyS0 console=tty0 noembed nomodeset norestore waitusb=10 systemd.legacy_systemd_cgroup_controller=yes random.trust_cpu=on hw_rng_model=virtio base host=minikube

X Exiting due to PR_HYPERKIT_CRASHED: Failed to start host: driver start: hyperkit crashed! command line:
  hyperkit loglevel=3 console=ttyS0 console=tty0 noembed nomodeset norestore waitusb=10 systemd.legacy_systemd_cgroup_controller=yes random.trust_cpu=on hw_rng_model=virtio base host=minikube
* Suggestion: Hyperkit is broken. Upgrade to the latest hyperkit version and/or Docker for Desktop. Alternatively, you may choose an alternate --driver
* Related issues:
  - https://github.com/kubernetes/minikube/issues/6079
  - https://github.com/kubernetes/minikube/issues/5780
```

After:
```
develop@Devs-Mac-mini --- z/minikube ‹ilyaz/disable_hyperv_on_m1› » out/minikube start --driver=hyperkit
* minikube v1.17.1 on Darwin 11.1 (arm64)
* Using the hyperkit driver based on user configuration

X Exiting due to DRV_UNSUPPORTED_OS: The driver 'hyperkit' is not supported on darwin/arm64
```

Translated messages fixed as well:

```
develop@Devs-Mac-mini --- z/minikube ‹ilyaz/disable_hyperv_on_m1› LC_ALL=fr out/minikube start --driver=hyperkit                                                                                                      56 ↵
* minikube v1.17.1 sur Darwin 11.1 (arm64)
* Utilisation du pilote hyperkit basé sur la configuration de l'utilisateur

X Exiting due to DRV_UNSUPPORTED_OS: Le pilote "hyperkit" n'est pas compatible avec darwin/arm64.
```