### PR TITLE
Change prepareVolume func to add container name for preload side car

### DIFF
--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -100,7 +100,7 @@ func PrepareContainerNode(p CreateParams) error {
 		return errors.Wrapf(err, "creating volume for %s container", p.Name)
 	}
 	klog.Infof("Successfully created a %s volume %s", p.OCIBinary, p.Name)
-	if err := prepareVolume(p.OCIBinary, p.Image, p.Name); err != nil {
+	if err := prepareVolumeSideCar(p.OCIBinary, p.Image, p.Name); err != nil {
 		return errors.Wrapf(err, "preparing volume for %s container", p.Name)
 	}
 	klog.Infof("Successfully prepared a %s volume %s", p.OCIBinary, p.Name)

--- a/pkg/drivers/kic/oci/volumes.go
+++ b/pkg/drivers/kic/oci/volumes.go
@@ -151,9 +151,9 @@ func createVolume(ociBin string, profile string, nodeName string) error {
 	return nil
 }
 
-// prepareVolume will copy the initial content of the mount point by starting a container to check the expected content
-func prepareVolume(ociBin string, imageName string, nodeName string) error {
-	cmdArgs := []string{"run", "--rm", "--entrypoint", "/usr/bin/test"}
+// prepareVolumeSideCar will copy the initial content of the mount point by starting a temporary container to check the expected content
+func prepareVolumeSideCar(ociBin string, imageName string, nodeName string) error {
+	cmdArgs := []string{"run", "--rm", "--name", fmt.Sprintf("%s-preload-sidecar", nodeName), "--entrypoint", "/usr/bin/test"}
 	cmdArgs = append(cmdArgs, "-v", fmt.Sprintf("%s:/var", nodeName), imageName, "-d", "/var/lib")
 	cmd := exec.Command(ociBin, cmdArgs...)
 	if _, err := runCmd(cmd); err != nil {

--- a/pkg/drivers/kic/oci/volumes.go
+++ b/pkg/drivers/kic/oci/volumes.go
@@ -153,7 +153,7 @@ func createVolume(ociBin string, profile string, nodeName string) error {
 
 // prepareVolumeSideCar will copy the initial content of the mount point by starting a temporary container to check the expected content
 func prepareVolumeSideCar(ociBin string, imageName string, nodeName string) error {
-	cmdArgs := []string{"run", "--rm", "--name", fmt.Sprintf("%s-preload-sidecar", nodeName), "--entrypoint", "/usr/bin/test"}
+	cmdArgs := []string{"run", "--rm", "--name", fmt.Sprintf("%s-preload-sidecar", nodeName), "--entrypoint", "--label", fmt.Sprintf("%s=%s", CreatedByLabelKey, "true"), "/usr/bin/test"}
 	cmdArgs = append(cmdArgs, "-v", fmt.Sprintf("%s:/var", nodeName), imageName, "-d", "/var/lib")
 	cmd := exec.Command(ociBin, cmdArgs...)
 	if _, err := runCmd(cmd); err != nil {

--- a/pkg/drivers/kic/oci/volumes.go
+++ b/pkg/drivers/kic/oci/volumes.go
@@ -153,7 +153,7 @@ func createVolume(ociBin string, profile string, nodeName string) error {
 
 // prepareVolumeSideCar will copy the initial content of the mount point by starting a temporary container to check the expected content
 func prepareVolumeSideCar(ociBin string, imageName string, nodeName string) error {
-	cmdArgs := []string{"run", "--rm", "--name", fmt.Sprintf("%s-preload-sidecar", nodeName), "--entrypoint", "--label", fmt.Sprintf("%s=%s", CreatedByLabelKey, "true"), "/usr/bin/test"}
+	cmdArgs := []string{"run", "--rm", "--name", fmt.Sprintf("%s-preload-sidecar", nodeName), "--label", fmt.Sprintf("%s=%s", CreatedByLabelKey, "true"), "--label", fmt.Sprintf("%s=%s", ProfileLabelKey, nodeName), "--entrypoint", "/usr/bin/test"}
 	cmdArgs = append(cmdArgs, "-v", fmt.Sprintf("%s:/var", nodeName), imageName, "-d", "/var/lib")
 	cmd := exec.Command(ociBin, cmdArgs...)
 	if _, err := runCmd(cmd); err != nil {


### PR DESCRIPTION
### What type of PR is this?
/kind bug
/co preload

### What this PR does / why we need it:

This PR fixes the potential bug of the volume of preload-side-car container.
This PR fixes this.

### Which issue(s) this PR fixes:
Fix #10397

### Does this PR introduce a user-facing change?

No. This PR fixes internal behaivour.

**Before this PR**

`func prepareVolume`

**After this PR**

`func prepareVolumeSideCar`

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```