### PR TITLE
[Unit Test] Fix TestCheckDockerVersion Assertion

### DIFF
--- a/pkg/minikube/registry/drvs/docker/docker_test.go
+++ b/pkg/minikube/registry/drvs/docker/docker_test.go
@@ -86,8 +86,10 @@ func TestCheckDockerVersion(t *testing.T) {
 	for _, c := range tc {
 		t.Run("checkDockerVersion test", func(t *testing.T) {
 			s := checkDockerVersion(c.version)
-			if c.expect != s.Reason {
-				t.Errorf("Error %v expected. but got %q. (version string : %s)", c.expect, s.Reason, c.version)
+			if s.Error != nil {
+				if c.expect != s.Reason {
+					t.Errorf("Error %v expected. but got %q. (version string : %s)", c.expect, s.Reason, c.version)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
### What type of PR is this?
/area testing

### What this PR does / why we need it:

This PR fixes the unit test `TestCheckDockerVersion` bug.

### Which issue(s) this PR fixes:
Fix #10456 

### Does this PR introduce a user-facing change?

No. This PR fixes internal behaivour.

**Before this PR**

```
--- FAIL: TestCheckDockerVersion (0.00s)
    --- FAIL: TestCheckDockerVersion/checkDockerVersion_test#06 (0.00s)
        docker_test.go:90: Error PROVIDER_DOCKER_VERSION_LOW expected. but got "". (version string : linux-17.09)
    --- FAIL: TestCheckDockerVersion/checkDockerVersion_test#07 (0.00s)
        docker_test.go:90: Error PROVIDER_DOCKER_VERSION_LOW expected. but got "". (version string : linux-17.09.0)
    --- FAIL: TestCheckDockerVersion/checkDockerVersion_test#08 (0.00s)
        docker_test.go:90: Error PROVIDER_DOCKER_VERSION_LOW expected. but got "". (version string : linux-17.09.0-20180720214833-f61e0f7)
    --- FAIL: TestCheckDockerVersion/checkDockerVersion_test#12 (0.00s)
        docker_test.go:90: Error PROVIDER_DOCKER_VERSION_LOW expected. but got "". (version string : linux-18.08)
    --- FAIL: TestCheckDockerVersion/checkDockerVersion_test#13 (0.00s)
        docker_test.go:90: Error PROVIDER_DOCKER_VERSION_LOW expected. but got "". (version string : linux-18.08.0)
    --- FAIL: TestCheckDockerVersion/checkDockerVersion_test#14 (0.00s)
        docker_test.go:90: Error PROVIDER_DOCKER_VERSION_LOW expected. but got "". (version string : linux-18.08.0-20180720214833-f61e0f7)
FAIL
coverage: 19.3% of statements
FAIL	k8s.io/minikube/pkg/minikube/registry/drvs/docker	1.563s
```

**After this PR**

```
ok  	k8s.io/minikube/pkg/minikube/registry/drvs/docker	1.128s	coverage: 19.3% of statements
```

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```