### PR TITLE
Change podman priority to default on Linux

### DIFF
--- a/pkg/minikube/registry/drvs/podman/podman.go
+++ b/pkg/minikube/registry/drvs/podman/podman.go
@@ -38,13 +38,19 @@ import (
 	"k8s.io/minikube/pkg/minikube/registry"
 )
 
+var docURL = "https://minikube.sigs.k8s.io/docs/drivers/podman/"
+
 // minReqPodmanVer is required the minimum version of podman to be installed for podman driver.
-var minReqPodmanVer = semver.Version{Major: 1, Minor: 7, Patch: 0}
+var minReqPodmanVer = semver.Version{Major: 2, Minor: 1, Patch: 0}
 
 func init() {
-	priority := registry.Experimental
+	priority := registry.Default
+	if runtime.GOOS != "linux" {
+		// requires external VM set up
+		priority = registry.Experimental
+	}
 	// Staged rollout for default:
-	// - Linux
+	// - Linux (sudo podman)
 	// - macOS (podman-remote)
 	// - Windows (podman-remote)
 
@@ -92,11 +98,6 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 }
 
 func status() registry.State {
-	docURL := "https://minikube.sigs.k8s.io/docs/drivers/podman/"
-	if runtime.GOARCH != "amd64" {
-		return registry.State{Error: fmt.Errorf("podman driver is not supported on %q systems yet", runtime.GOARCH), Installed: false, Healthy: false, Fix: "Try other drivers", Doc: docURL}
-	}
-
 	podman, err := exec.LookPath(oci.Podman)
 	if err != nil {
 		return registry.State{Error: err, Installed: false, Healthy: false, Fix: "Install Podman", Doc: docURL}

--- a/site/content/en/docs/drivers/podman.md
+++ b/site/content/en/docs/drivers/podman.md
@@ -7,23 +7,17 @@ aliases:
 
 ## Overview
 
-{{% pageinfo %}}
-This driver is experimental and in active development. Help wanted!
-{{% /pageinfo %}}
-
 The podman driver is an alternative container runtime to the [Docker]({{< ref "/docs/drivers/docker.md" >}}) driver.
 
 ## Requirements
 
-- Linux or macOS operating systems on amd64 architecture
+- Linux operating system
 - Install [podman](https://podman.io/getting-started/installation.html)
 
 {{% readfile file="/docs/drivers/includes/podman_usage.inc" %}}
 
 ## Known Issues
 
-- Podman driver is not supported on non-amd64 architectures such as arm yet. For non-amd64 archs please use [other drivers]({{< ref "/docs/drivers/_index.md" >}})
-- Podman v2 driver is not supported yet.
 - Podman requirements passwordless running of sudo. If you run into an error about sudo, do the following:
 
 ```shell


### PR DESCRIPTION
Requires Podman 2.1 or greater (such as 3.0)

Podman is *not* yet supported for Mac or Win.
See #8003 regarding running with podman-remote

Closes #10237