### PR TITLE
Fix TestErrorJSONOutput test

### DIFF
--- a/test/integration/json_output_test.go
+++ b/test/integration/json_output_test.go
@@ -155,7 +155,7 @@ func TestErrorJSONOutput(t *testing.T) {
 		t.Fatalf("last cloud event is not of type error: %v", last)
 	}
 	last.validateData(t, "exitcode", fmt.Sprintf("%v", reason.ExDriverUnsupported))
-	last.validateData(t, "message", fmt.Sprintf("The driver 'fail' is not supported on %s", runtime.GOOS))
+	last.validateData(t, "message", fmt.Sprintf("The driver 'fail' is not supported on %s/%s", runtime.GOOS, runtime.GOARCH))
 }
 
 type cloudEvent struct {


### PR DESCRIPTION
This PR fixes TestErrorJSONOutput integration test
The problem was that after https://github.com/kubernetes/minikube/pull/10452 the error message about incorrect minikube driver changed from `The driver ${driver} is not supported on ${os}` to `The driver ${driver} is not supported on ${os}/${arch}`

Before:
```
➜  minikube git:(master) go test  -v -test.timeout=20m ./test/integration --tags=integration -test.run TestErrorJSONOutput
Found 12 cores, limiting parallelism with --test.parallel=6
=== RUN   TestErrorJSONOutput
    json_output_test.go:144: (dbg) Run:  out/minikube start -p json-output-error-20210212151048-59605 --memory=2200 --output=json --wait=true --driver=fail
    json_output_test.go:144: (dbg) Non-zero exit: out/minikube start -p json-output-error-20210212151048-59605 --memory=2200 --output=json --wait=true --driver=fail: exit status 56 (369.230899ms)
        
        -- stdout --
                {"data":{"currentstep":"0","message":"[json-output-error-20210212151048-59605] minikube v1.17.1 on Darwin 11.2","name":"Initial Minikube Setup","totalsteps":"18"},"datacontenttype":"application/json","id":"872f7d71-07b2-46a1-a1ba-d923f06360db","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.step"}
                {"data":{"advice":"","exitcode":"56","issues":"","message":"The driver 'fail' is not supported on darwin/amd64","name":"DRV_UNSUPPORTED_OS","url":""},"datacontenttype":"application/json","id":"cdde7759-4ee5-4c12-b363-a3a134dc9371","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.error"}
        
        -- /stdout --
    json_output_test.go:184: values in cloud events do not match:
        Actual:
        'The driver 'fail' is not supported on darwin/amd64'
        Expected:
        'The driver 'fail' is not supported on darwin'
    helpers_test.go:171: Cleaning up "json-output-error-20210212151048-59605" profile ...
    helpers_test.go:174: (dbg) Run:  out/minikube delete -p json-output-error-20210212151048-59605
    helpers_test.go:174: (dbg) Done: out/minikube delete -p json-output-error-20210212151048-59605: (3.615536727s)
--- FAIL: TestErrorJSONOutput (3.99s)
FAIL
Tests completed in 3.985965147s (result code 1)
FAIL    k8s.io/minikube/test/integration        4.967s
FAIL
```

After:
```
➜  minikube git:(ilyaz/fix_TestErrorJSONOutput) go test  -v -test.timeout=20m ./test/integration --tags=integration -test.run TestErrorJSONOutput
Found 12 cores, limiting parallelism with --test.parallel=6
=== RUN   TestErrorJSONOutput
    json_output_test.go:144: (dbg) Run:  out/minikube start -p json-output-error-20210212151018-59313 --memory=2200 --output=json --wait=true --driver=fail
    json_output_test.go:144: (dbg) Non-zero exit: out/minikube start -p json-output-error-20210212151018-59313 --memory=2200 --output=json --wait=true --driver=fail: exit status 56 (444.152326ms)
        
        -- stdout --
                {"data":{"currentstep":"0","message":"[json-output-error-20210212151018-59313] minikube v1.17.1 on Darwin 11.2","name":"Initial Minikube Setup","totalsteps":"18"},"datacontenttype":"application/json","id":"7b12189d-9480-4689-ab68-fd97ecd36618","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.step"}
                {"data":{"advice":"","exitcode":"56","issues":"","message":"The driver 'fail' is not supported on darwin/amd64","name":"DRV_UNSUPPORTED_OS","url":""},"datacontenttype":"application/json","id":"fa0542ac-584a-451b-a656-88b3c1b979f9","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.error"}
        
        -- /stdout --
    helpers_test.go:171: Cleaning up "json-output-error-20210212151018-59313" profile ...
    helpers_test.go:174: (dbg) Run:  out/minikube delete -p json-output-error-20210212151018-59313
    helpers_test.go:174: (dbg) Done: out/minikube delete -p json-output-error-20210212151018-59313: (3.486683144s)
--- PASS: TestErrorJSONOutput (3.93s)
PASS
Tests completed in 3.932005807s (result code 0)
ok      k8s.io/minikube/test/integration        4.784s
```