### PR TITLE
Add last start logs to minikube logs output

### DIFF
--- a/cmd/minikube/main.go
+++ b/cmd/minikube/main.go
@@ -29,8 +29,8 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/klog/v2"
 
-	// Register drivers
 	"k8s.io/minikube/pkg/minikube/localpath"
+	// Register drivers
 	_ "k8s.io/minikube/pkg/minikube/registry/drvs"
 
 	// Force exp dependency

--- a/cmd/minikube/main.go
+++ b/cmd/minikube/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strconv"
 
@@ -145,7 +144,7 @@ func setFlags() {
 		}
 	}
 	if os.Args[1] == "start" {
-		fp := filepath.Join(localpath.MiniPath(), "logs", "lastStart.txt")
+		fp := localpath.LastStartLog()
 		if err := os.Remove(fp); err != nil {
 			klog.Warningf("Unable to delete file %s: %v", err)
 		}

--- a/cmd/minikube/main.go
+++ b/cmd/minikube/main.go
@@ -165,17 +165,12 @@ func setLastStartFlags() {
 		return
 	}
 	fp := localpath.LastStartLog()
-	if err := os.Remove(fp); err != nil && !os.IsNotExist(err) {
-		klog.Warningf("Unable to delete file %s: %v", err)
-	}
 	dp := filepath.Dir(fp)
-	if _, err := os.Stat(dp); err != nil {
-		if !os.IsNotExist(err) {
-			klog.Warningf("Unable to get log folder %s: %v", dp, err)
-		}
-		if err := os.MkdirAll(dp, 0755); err != nil {
-			klog.Warningf("Unable to make log folder %s: %v", dp, err)
-		}
+	if err := os.MkdirAll(dp, 0755); err != nil {
+		klog.Warningf("Unable to make log dir %s: %v", dp, err)
+	}
+	if _, err := os.Create(fp); err != nil {
+		klog.Warningf("Unable to create/truncate file %s: %v", fp, err)
 	}
 	if err := pflag.Set("log_file", fp); err != nil {
 		klog.Warningf("Unable to set default flag value for log_file: %v", err)

--- a/cmd/minikube/main.go
+++ b/cmd/minikube/main.go
@@ -145,7 +145,7 @@ func setFlags() {
 	}
 	if os.Args[1] == "start" {
 		fp := localpath.LastStartLog()
-		if err := os.Remove(fp); err != nil {
+		if err := os.Remove(fp); err != nil && !os.IsNotExist(err) {
 			klog.Warningf("Unable to delete file %s: %v", err)
 		}
 		if !pflag.CommandLine.Changed("log_file") {

--- a/cmd/minikube/main.go
+++ b/cmd/minikube/main.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 
@@ -29,6 +30,7 @@ import (
 	"k8s.io/klog/v2"
 
 	// Register drivers
+	"k8s.io/minikube/pkg/minikube/localpath"
 	_ "k8s.io/minikube/pkg/minikube/registry/drvs"
 
 	// Force exp dependency
@@ -140,6 +142,17 @@ func setFlags() {
 	if !pflag.CommandLine.Changed("alsologtostderr") {
 		if err := pflag.Set("alsologtostderr", "false"); err != nil {
 			klog.Warningf("Unable to set default flag value for alsologtostderr: %v", err)
+		}
+	}
+	if os.Args[1] == "start" {
+		fp := filepath.Join(localpath.MiniPath(), "logs", "lastStart.txt")
+		if err := os.Remove(fp); err != nil {
+			klog.Warningf("Unable to delete file %s: %v", err)
+		}
+		if !pflag.CommandLine.Changed("log_file") {
+			if err := pflag.Set("log_file", fp); err != nil {
+				klog.Warningf("Unable to set default flag value for log_file: %v", err)
+			}
 		}
 	}
 

--- a/cmd/minikube/main.go
+++ b/cmd/minikube/main.go
@@ -156,7 +156,7 @@ func setFlags() {
 	}
 }
 
-// setLastStartFlags sets the log_file & log_dir flags if start command and no flags provided.
+// setLastStartFlags sets the log_file flag to lastStart.txt if start command and user doesn't specify log_file or log_dir flags.
 func setLastStartFlags() {
 	if os.Args[1] != "start" {
 		return

--- a/cmd/minikube/main.go
+++ b/cmd/minikube/main.go
@@ -177,9 +177,7 @@ func setLastStartFlags() {
 			klog.Warningf("Unable to make log folder %s: %v", dp, err)
 		}
 	}
-	if !pflag.CommandLine.Changed("log_file") && !pflag.CommandLine.Changed("log_dir") {
-		if err := pflag.Set("log_file", fp); err != nil {
-			klog.Warningf("Unable to set default flag value for log_file: %v", err)
-		}
+	if err := pflag.Set("log_file", fp); err != nil {
+		klog.Warningf("Unable to set default flag value for log_file: %v", err)
 	}
 }

--- a/pkg/minikube/localpath/localpath.go
+++ b/pkg/minikube/localpath/localpath.go
@@ -74,6 +74,11 @@ func AuditLog() string {
 	return filepath.Join(MiniPath(), "logs", "audit.json")
 }
 
+// LastStartLog returns the path to the last start log.
+func LastStartLog() string {
+	return filepath.Join(MiniPath(), "logs", "lastStart.txt")
+}
+
 // ClientCert returns client certificate path, used by kubeconfig
 func ClientCert(name string) string {
 	new := filepath.Join(Profile(name), "client.crt")

--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -232,6 +232,9 @@ func outputLastStart() error {
 	for s.Scan() {
 		out.Step(style.Empty, s.Text())
 	}
+	if err := s.Err(); err != nil {
+		return fmt.Errorf("failed to read file %s: %v", fp, err)
+	}
 	return nil
 }
 

--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -21,7 +21,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"regexp"
@@ -224,11 +223,15 @@ func outputLastStart() error {
 	out.Step(style.Empty, "")
 	out.Step(style.Empty, "==> Last Start <==")
 	fp := localpath.LastStartLog()
-	l, err := ioutil.ReadFile(fp)
+	f, err := os.Open(fp)
 	if err != nil {
-		return fmt.Errorf("failed to read file %s: %v", fp, err)
+		return fmt.Errorf("failed to open file %s: %v", fp, err)
 	}
-	out.Step(style.Empty, string(l))
+	defer f.Close()
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		out.Step(style.Empty, s.Text())
+	}
 	return nil
 }
 

--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -224,6 +224,11 @@ func outputLastStart() error {
 	out.Step(style.Empty, "==> Last Start <==")
 	fp := localpath.LastStartLog()
 	f, err := os.Open(fp)
+	if os.IsNotExist(err) {
+		msg := fmt.Sprintf("Last start log file not found at %s", fp)
+		out.Step(style.Empty, msg)
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("failed to open file %s: %v", fp, err)
 	}

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -797,7 +797,7 @@ func validateLogsCmd(ctx context.Context, t *testing.T, profile string) {
 	if err != nil {
 		t.Errorf("%s failed: %v", rr.Command(), err)
 	}
-	expectedWords := []string{"apiserver", "Linux", "kubelet", "Audit"}
+	expectedWords := []string{"apiserver", "Linux", "kubelet", "Audit", "Last Start"}
 	switch ContainerRuntime() {
 	case "docker":
 		expectedWords = append(expectedWords, "Docker")


### PR DESCRIPTION
Implements: #10336

Instead of saving the start logs to the tmp directory with an irregular file name, the start logs are now stored in `.minikube/logs/lastStart.txt`. The contents of this file will be replaced the next time a start command is run.

The `minikube logs` command how outputs a `Last Start` section using the logs in `lastStart.txt`.