### PR TITLE
kvm2 driver: Add flag --kvm-numa-count" support topology-manager simulate numa 

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -65,6 +65,7 @@ const (
 	kvmQemuURI              = "kvm-qemu-uri"
 	kvmGPU                  = "kvm-gpu"
 	kvmHidden               = "kvm-hidden"
+	kvmNUMACount            = "kvm-numa-count"
 	minikubeEnvPrefix       = "MINIKUBE"
 	installAddons           = "install-addons"
 	defaultDiskSize         = "20000mb"
@@ -193,6 +194,7 @@ func initDriverFlags() {
 	startCmd.Flags().String(kvmQemuURI, "qemu:///system", "The KVM QEMU connection URI. (kvm2 driver only)")
 	startCmd.Flags().Bool(kvmGPU, false, "Enable experimental NVIDIA GPU support in minikube")
 	startCmd.Flags().Bool(kvmHidden, false, "Hide the hypervisor signature from the guest in minikube (kvm2 driver only)")
+	startCmd.Flags().Int(kvmNUMACount, 1, "Simulate numa node count in minikube. (kvm2 driver only)")
 
 	// virtualbox
 	startCmd.Flags().String(hostOnlyCIDR, "192.168.99.1/24", "The CIDR to be used for the minikube VM (virtualbox driver only)")
@@ -338,6 +340,7 @@ func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k
 			KVMQemuURI:              viper.GetString(kvmQemuURI),
 			KVMGPU:                  viper.GetBool(kvmGPU),
 			KVMHidden:               viper.GetBool(kvmHidden),
+			KVMNUMACount:            viper.GetInt(kvmNUMACount),
 			DisableDriverMounts:     viper.GetBool(disableDriverMounts),
 			UUID:                    viper.GetString(uuid),
 			NoVTXCheck:              viper.GetBool(noVTXCheck),
@@ -543,6 +546,10 @@ func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterC
 
 	if cmd.Flags().Changed(kvmHidden) {
 		cc.KVMHidden = viper.GetBool(kvmHidden)
+	}
+
+	if cmd.Flags().Changed(kvmNUMACount) {
+		cc.KVMNUMACount = viper.GetInt(kvmNUMACount)
 	}
 
 	if cmd.Flags().Changed(disableDriverMounts) {

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -133,6 +133,7 @@ func TestMirrorCountry(t *testing.T) {
 			cmd := &cobra.Command{}
 			viper.SetDefault(imageRepository, test.imageRepository)
 			viper.SetDefault(imageMirrorCountry, test.mirrorCountry)
+			viper.SetDefault(kvmNUMACount, 1)
 			config, _, err := generateClusterConfig(cmd, nil, k8sVersion, "none")
 			if err != nil {
 				t.Fatalf("Got unexpected error %v during config generation", err)

--- a/pkg/drivers/kvm/domain.go
+++ b/pkg/drivers/kvm/domain.go
@@ -44,7 +44,11 @@ const domainTmpl = `
     </kvm>
     {{end}}
   </features>
-  <cpu mode='host-passthrough'/>
+  <cpu mode='host-passthrough'>
+  {{if gt .NUMANodeCount 1}}
+  {{.NUMANodeXML}}
+  {{end}}
+  </cpu>
   <os>
     <type>hvm</type>
     <boot dev='cdrom'/>
@@ -158,14 +162,12 @@ func (d *Driver) createDomain() (*libvirt.Domain, error) {
 		}
 		d.PrivateMAC = mac.String()
 	}
-
 	// create the XML for the domain using our domainTmpl template
 	tmpl := template.Must(template.New("domain").Parse(domainTmpl))
 	var domainXML bytes.Buffer
 	if err := tmpl.Execute(&domainXML, d); err != nil {
 		return nil, errors.Wrap(err, "executing domain xml")
 	}
-
 	conn, err := getConnection(d.ConnectionURI)
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting libvirt connection")

--- a/pkg/drivers/kvm/kvm.go
+++ b/pkg/drivers/kvm/kvm.go
@@ -320,11 +320,11 @@ func (d *Driver) Create() (err error) {
 	}
 
 	if d.NUMANodeCount > 1 {
-		NUMAXML, err := NumaXml(d.CPU, d.Memory, d.NUMANodeCount)
+		numaXML, err := numaXML(d.CPU, d.Memory, d.NUMANodeCount)
 		if err != nil {
 			return errors.Wrap(err, "creating NUMA XML")
 		}
-		d.NUMANodeXML = NUMAXML
+		d.NUMANodeXML = numaXML
 	}
 
 	store := d.ResolveStorePath(".")

--- a/pkg/drivers/kvm/kvm.go
+++ b/pkg/drivers/kvm/kvm.go
@@ -320,7 +320,7 @@ func (d *Driver) Create() (err error) {
 	}
 
 	if d.NUMANodeCount > 1 {
-		NUMAXML, err := GetNUMAXml(d.CPU, d.Memory, d.NUMANodeCount)
+		NUMAXML, err := NumaXml(d.CPU, d.Memory, d.NUMANodeCount)
 		if err != nil {
 			return errors.Wrap(err, "creating NUMA XML")
 		}

--- a/pkg/drivers/kvm/kvm.go
+++ b/pkg/drivers/kvm/kvm.go
@@ -81,6 +81,12 @@ type Driver struct {
 
 	// QEMU Connection URI
 	ConnectionURI string
+
+	// NUMA node count default value is 1
+	NUMANodeCount int
+
+	// NUMA XML
+	NUMANodeXML string
 }
 
 const (
@@ -301,7 +307,6 @@ func (d *Driver) Start() (err error) {
 func (d *Driver) Create() (err error) {
 	log.Info("Creating KVM machine...")
 	defer log.Infof("KVM machine creation complete!")
-
 	err = d.createNetwork()
 	if err != nil {
 		return errors.Wrap(err, "creating network")
@@ -312,6 +317,14 @@ func (d *Driver) Create() (err error) {
 		if err != nil {
 			return errors.Wrap(err, "creating devices")
 		}
+	}
+
+	if d.NUMANodeCount > 1 {
+		NUMAXML, err := GetNUMAXml(d.CPU, d.Memory, d.NUMANodeCount)
+		if err != nil {
+			return errors.Wrap(err, "creating NUMA XML")
+		}
+		d.NUMANodeXML = NUMAXML
 	}
 
 	store := d.ResolveStorePath(".")

--- a/pkg/drivers/kvm/numa.go
+++ b/pkg/drivers/kvm/numa.go
@@ -40,9 +40,9 @@ type NUMA struct {
 	CPUTopology string
 }
 
-// GetNUMAXml generate numa xml
+// NumaXml generate numa xml
 // evenly distributed cpu core & memory to each numa node
-func GetNUMAXml(cpu, memory, numaCount int) (string, error) {
+func NumaXml(cpu, memory, numaCount int) (string, error) {
 	if numaCount < 1 {
 		return "", fmt.Errorf("numa node count must >= 1")
 	}

--- a/pkg/drivers/kvm/numa.go
+++ b/pkg/drivers/kvm/numa.go
@@ -24,8 +24,8 @@ import (
 	"text/template"
 )
 
-// NUMATmpl NUMA XML Template
-const NUMATmpl = `
+// numaTmpl NUMA XML Template
+const numaTmpl = `
 <numa>
   {{- range $idx,$val :=. }}
   <cell id='{{$idx}}' cpus='{{$val.CPUTopology}}' memory='{{$val.Memory}}' unit='MiB'/>
@@ -33,16 +33,19 @@ const NUMATmpl = `
 </numa>
 `
 
-// NUMA this struct use for NUMATmpl
+// NUMA this struct use for numaTmpl
 type NUMA struct {
-	CPUCount    int
-	Memory      int
+	// cpu count on numa node
+	CPUCount int
+	// memory on numa node
+	Memory int
+	// cpu sequence on numa node eg: 0,1,2,3
 	CPUTopology string
 }
 
-// NumaXml generate numa xml
+// numaXML generate numa xml
 // evenly distributed cpu core & memory to each numa node
-func NumaXml(cpu, memory, numaCount int) (string, error) {
+func numaXML(cpu, memory, numaCount int) (string, error) {
 	if numaCount < 1 {
 		return "", fmt.Errorf("numa node count must >= 1")
 	}
@@ -81,10 +84,10 @@ func NumaXml(cpu, memory, numaCount int) (string, error) {
 		numaNodes[i].Memory++
 	}
 
-	tmpl := template.Must(template.New("numa").Parse(NUMATmpl))
-	var NUMAXML bytes.Buffer
-	if err := tmpl.Execute(&NUMAXML, numaNodes); err != nil {
+	tmpl := template.Must(template.New("numa").Parse(numaTmpl))
+	var numaXML bytes.Buffer
+	if err := tmpl.Execute(&numaXML, numaNodes); err != nil {
 		return "", fmt.Errorf("couldn't generate numa XML: %v", err)
 	}
-	return NUMAXML.String(), nil
+	return numaXML.String(), nil
 }

--- a/pkg/drivers/kvm/numa.go
+++ b/pkg/drivers/kvm/numa.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2021 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvm
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+	"text/template"
+)
+
+// NUMATmpl NUMA XML Template
+const NUMATmpl = `
+<numa>
+  {{- range $idx,$val :=. }}
+  <cell id='{{$idx}}' cpus='{{$val.CPUTopology}}' memory='{{$val.Memory}}' unit='MiB'/>
+  {{- end }}
+</numa>
+`
+
+// NUMA this struct use for NUMATmpl
+type NUMA struct {
+	CPUCount    int
+	Memory      int
+	CPUTopology string
+}
+
+// GetNUMAXml generate numa xml
+// evenly distributed cpu core & memory to each numa node
+func GetNUMAXml(cpu, memory, numaCount int) (string, error) {
+	if numaCount < 1 {
+		return "", fmt.Errorf("numa node count must >= 1")
+	}
+	if cpu < numaCount {
+		return "", fmt.Errorf("cpu count must >= numa node count")
+	}
+	numaNodes := make([]*NUMA, numaCount)
+	CPUSeq := 0
+	cpuBaseCount := cpu / numaCount
+	cpuExtraCount := cpu % numaCount
+
+	for i := range numaNodes {
+		numaNodes[i] = &NUMA{CPUCount: cpuBaseCount}
+	}
+
+	for i := 0; i < cpuExtraCount; i++ {
+		numaNodes[i].CPUCount++
+	}
+	for i := range numaNodes {
+		CPUTopologySlice := make([]string, 0)
+		for seq := CPUSeq; seq < CPUSeq+numaNodes[i].CPUCount; seq++ {
+			CPUTopologySlice = append(CPUTopologySlice, strconv.Itoa(seq))
+		}
+		numaNodes[i].CPUTopology = strings.Join(CPUTopologySlice, ",")
+		CPUSeq += numaNodes[i].CPUCount
+	}
+
+	memoryBaseCount := memory / numaCount
+	memoryExtraCount := memory % numaCount
+
+	for i := range numaNodes {
+		numaNodes[i].Memory = memoryBaseCount
+	}
+
+	for i := 0; i < memoryExtraCount; i++ {
+		numaNodes[i].Memory++
+	}
+
+	tmpl := template.Must(template.New("numa").Parse(NUMATmpl))
+	var NUMAXML bytes.Buffer
+	if err := tmpl.Execute(&NUMAXML, numaNodes); err != nil {
+		return "", fmt.Errorf("couldn't generate numa XML: %v", err)
+	}
+	return NUMAXML.String(), nil
+}

--- a/pkg/drivers/kvm/numa_test.go
+++ b/pkg/drivers/kvm/numa_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2021 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvm
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetNUMAXml(t *testing.T) {
+	_, err := GetNUMAXml(1, 1024, 0)
+	if err == nil {
+		t.Errorf("check invalid numa count failed: %s", err)
+	}
+
+	xml, err := GetNUMAXml(10, 10240, 8)
+	expXML := `<numa>
+  <cell id='0' cpus='0,1' memory='1280' unit='MiB'/>
+  <cell id='1' cpus='2,3' memory='1280' unit='MiB'/>
+  <cell id='2' cpus='4' memory='1280' unit='MiB'/>
+  <cell id='3' cpus='5' memory='1280' unit='MiB'/>
+  <cell id='4' cpus='6' memory='1280' unit='MiB'/>
+  <cell id='5' cpus='7' memory='1280' unit='MiB'/>
+  <cell id='6' cpus='8' memory='1280' unit='MiB'/>
+  <cell id='7' cpus='9' memory='1280' unit='MiB'/>
+</numa>`
+	if err != nil {
+		t.Errorf("gen xml failed: %s", err)
+	}
+	if strings.TrimSpace(xml) != expXML {
+		t.Errorf("gen xml: %s not match expect xml: %s", xml, expXML)
+	}
+
+}

--- a/pkg/drivers/kvm/numa_test.go
+++ b/pkg/drivers/kvm/numa_test.go
@@ -22,12 +22,12 @@ import (
 )
 
 func TestGetNUMAXml(t *testing.T) {
-	_, err := GetNUMAXml(1, 1024, 0)
+	_, err := NumaXml(1, 1024, 0)
 	if err == nil {
 		t.Errorf("check invalid numa count failed: %s", err)
 	}
 
-	xml, err := GetNUMAXml(10, 10240, 8)
+	xml, err := NumaXml(10, 10240, 8)
 	expXML := `<numa>
   <cell id='0' cpus='0,1' memory='1280' unit='MiB'/>
   <cell id='1' cpus='2,3' memory='1280' unit='MiB'/>

--- a/pkg/drivers/kvm/numa_test.go
+++ b/pkg/drivers/kvm/numa_test.go
@@ -21,13 +21,13 @@ import (
 	"testing"
 )
 
-func TestGetNUMAXml(t *testing.T) {
-	_, err := NumaXml(1, 1024, 0)
+func TestNumaXml(t *testing.T) {
+	_, err := numaXML(1, 1024, 0)
 	if err == nil {
 		t.Errorf("check invalid numa count failed: %s", err)
 	}
 
-	xml, err := NumaXml(10, 10240, 8)
+	xml, err := numaXML(10, 10240, 8)
 	expXML := `<numa>
   <cell id='0' cpus='0,1' memory='1280' unit='MiB'/>
   <cell id='1' cpus='2,3' memory='1280' unit='MiB'/>

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -56,6 +56,7 @@ type ClusterConfig struct {
 	KVMQemuURI              string   // Only used by kvm2
 	KVMGPU                  bool     // Only used by kvm2
 	KVMHidden               bool     // Only used by kvm2
+	KVMNUMACount            int      // Only used by kvm2
 	DockerOpt               []string // Each entry is formatted as KEY=VALUE.
 	DisableDriverMounts     bool     // Only used by virtualbox
 	NFSShare                []string

--- a/pkg/minikube/registry/drvs/kvm2/kvm2.go
+++ b/pkg/minikube/registry/drvs/kvm2/kvm2.go
@@ -68,6 +68,7 @@ type kvmDriver struct {
 	GPU            bool
 	Hidden         bool
 	ConnectionURI  string
+	NUMANodeCount  int
 }
 
 func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
@@ -89,6 +90,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		GPU:            cc.KVMGPU,
 		Hidden:         cc.KVMHidden,
 		ConnectionURI:  cc.KVMQemuURI,
+		NUMANodeCount:  cc.KVMNUMACount,
 	}, nil
 }
 

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -70,6 +70,7 @@ minikube start [flags]
       --kvm-gpu                           Enable experimental NVIDIA GPU support in minikube
       --kvm-hidden                        Hide the hypervisor signature from the guest in minikube (kvm2 driver only)
       --kvm-network string                The KVM network name. (kvm2 driver only) (default "default")
+      --kvm-numa-count int                Simulate numa node count in minikube. (kvm2 driver only) (default 1)
       --kvm-qemu-uri string               The KVM QEMU connection URI. (kvm2 driver only) (default "qemu:///system")
       --memory string                     Amount of RAM to allocate to Kubernetes (format: <number>[<unit>], where unit = b, k, m or g).
       --mount                             This will start the mount daemon and automatically mount files into minikube.

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -70,7 +70,7 @@ minikube start [flags]
       --kvm-gpu                           Enable experimental NVIDIA GPU support in minikube
       --kvm-hidden                        Hide the hypervisor signature from the guest in minikube (kvm2 driver only)
       --kvm-network string                The KVM network name. (kvm2 driver only) (default "default")
-      --kvm-numa-count int                Simulate numa node count in minikube. (kvm2 driver only) (default 1)
+      --kvm-numa-count int                Simulate numa node count in minikube, supported numa node count range is 1-8 (kvm2 driver only) (default 1)
       --kvm-qemu-uri string               The KVM QEMU connection URI. (kvm2 driver only) (default "qemu:///system")
       --memory string                     Amount of RAM to allocate to Kubernetes (format: <number>[<unit>], where unit = b, k, m or g).
       --mount                             This will start the mount daemon and automatically mount files into minikube.


### PR DESCRIPTION
kvm2 driver support simulate numa node
ref: https://kubernetes.io/docs/tasks/administer-cluster/topology-manager/#topology-manager-policies
```
you can use --kvm-numa-count define kvm vm numa count, use --extra-config=kubelet.topology-manager-policy=none/best-effort
/restricted/single-numa-node config kubelet Topology Manager Policies

minikube start --driver=kvm2  --kvm-numa-count=2 --extra-config=kubelet.topology-manager-policy=best-effort

❯ minikube ssh
                         _             _            
            _         _ ( )           ( )           
  ___ ___  (_)  ___  (_)| |/')  _   _ | |_      __  
/' _ ` _ `\| |/' _ `\| || , <  ( ) ( )| '_`\  /'__`\
| ( ) ( ) || || ( ) || || |\`\ | (_) || |_) )(  ___/
(_) (_) (_)(_)(_) (_)(_)(_) (_)`\___/'(_,__/'`\____)

$ /bin/toolbox 
Trying to pull docker://fedora:latest...
Getting image source signatures
Copying blob f147208a1e03 done  
Copying config a78267678b done  
Writing manifest to image destination
Storing signatures
8818f2a63b341c3bcfa41fc6879115e692482d0d65c450029cc9bdcba5879c2d
8818f2a63b341c3bcfa41fc6879115e692482d0d65c450029cc9bdcba5879c2d
Untagged: docker.io/library/fedora:latest
Deleted: a78267678b7e6e849c7e960b09227b737a38d5073a5071b041a16bd4b609ef92
Spawning container docker-fedora-latest on /var/lib/toolbox/docker-fedora-latest.
Press ^] three times within 1s to kill container.
[root@minikube ~]# yum install numactl -y
[root@minikube ~]# numactl  -H
available: 2 nodes (0-1)
node 0 cpus: 0 1 2 3
node 0 size: 16034 MB
node 0 free: 15349 MB
node 1 cpus: 4 5 6 7
node 1 size: 16126 MB
node 1 free: 13300 MB
node distances:
node   0   1 
  0:  10  20 
  1:  20  10 
```

closes https://github.com/kubernetes/minikube/issues/10668