### PR TITLE
improve kvm network delete/cleanup

### DIFF
--- a/pkg/drivers/kvm/network.go
+++ b/pkg/drivers/kvm/network.go
@@ -230,7 +230,7 @@ func (d *Driver) deleteNetwork() error {
 		return network.Undefine()
 	}
 	if err := retry.Local(destroy, 10*time.Second); err != nil {
-		return errors.Wrap(err, "destroying network")
+		return errors.Wrap(err, "deleting network")
 	}
 	log.Debugf("Network %s deleted", d.PrivateNetwork)
 

--- a/pkg/drivers/kvm/network.go
+++ b/pkg/drivers/kvm/network.go
@@ -201,7 +201,7 @@ func (d *Driver) deleteNetwork() error {
 			log.Warnf("Network %s does not exist. Skipping deletion", d.PrivateNetwork)
 			return nil
 		}
-		return errors.Wrapf(err, "failed looking for network %s", d.PrivateNetwork)
+		return errors.Wrapf(err, "failed looking up network %s", d.PrivateNetwork)
 	}
 	defer func() { _ = network.Free() }()
 	log.Debugf("Network %s exists", d.PrivateNetwork)
@@ -221,8 +221,7 @@ func (d *Driver) deleteNetwork() error {
 		}
 		if active {
 			log.Debugf("Destroying active network %s", d.PrivateNetwork)
-			err := network.Destroy()
-			if err != nil {
+			if err := network.Destroy(); err != nil {
 				return err
 			}
 		}

--- a/pkg/drivers/kvm/network.go
+++ b/pkg/drivers/kvm/network.go
@@ -214,7 +214,7 @@ func (d *Driver) deleteNetwork() error {
 	// when we reach this point, it means it is safe to delete the network
 
 	log.Debugf("Trying to delete network %s...", d.PrivateNetwork)
-	destroy := func() error {
+	delete := func() error {
 		active, err := network.IsActive()
 		if err != nil {
 			return err
@@ -229,7 +229,7 @@ func (d *Driver) deleteNetwork() error {
 		log.Debugf("Undefining inactive network %s", d.PrivateNetwork)
 		return network.Undefine()
 	}
-	if err := retry.Local(destroy, 10*time.Second); err != nil {
+	if err := retry.Local(delete, 10*time.Second); err != nil {
 		return errors.Wrap(err, "deleting network")
 	}
 	log.Debugf("Network %s deleted", d.PrivateNetwork)


### PR DESCRIPTION
this pr should further improve kvm private network delete/cleanup, like situations where the `--delete` flag leaves `minikube-net` behind in inactive state after a failed start, or when such minikube-net cannot be reused on subsequent `start`s

improvement on previous issues:
#9666
#9610
#9049
#8952

also potentially improves / fixes #10040

details:

before: we try to reactivate inactive net and then to destroy it (as inactive net cannot be destroyed)
after: transition states are:

1. nonexistent => done
2. repeat/retry:
    - active => destroy => undefine => done
    - inactive => undefine => done  

example: https://github.com/kubernetes/minikube/pull/10439#issue-571512328

if this proves working as expected in practice, we would probably be able to remove the repeat/retry wrapper as not needed

---

note: i remember that we ask users to provide output of `virsh net-list` to troubleshoot issues - we should ask for `virsh net-list --all` instead, as otherwise inactive nets will not be shown; also noting that the command should be run as root user, as regular user will probably not see any nets
i've tried to locate those references in docs (around https://minikube.sigs.k8s.io/docs/drivers/kvm2/) and propose these changes, but couldn't find it :(