### PR TITLE
Make sure to use CRI for docker if configured

### DIFF
--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -151,9 +151,12 @@ func New(c Config) (Manager, error) {
 	switch c.Type {
 	case "", "docker":
 		return &Docker{
-			Socket: c.Socket,
-			Runner: c.Runner,
-			Init:   sm,
+			Socket:            c.Socket,
+			Runner:            c.Runner,
+			ImageRepository:   c.ImageRepository,
+			KubernetesVersion: c.KubernetesVersion,
+			Init:              sm,
+			UseCRI:            (c.Socket != ""), // !dockershim
 		}, nil
 	case "crio", "cri-o":
 		return &CRIO{

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -245,6 +245,7 @@ func Provision(cc *config.ClusterConfig, n *config.Node, apiServer bool, delOnFa
 func configureRuntimes(runner cruntime.CommandRunner, cc config.ClusterConfig, kv semver.Version) cruntime.Manager {
 	co := cruntime.Config{
 		Type:              cc.KubernetesConfig.ContainerRuntime,
+		Socket:            cc.KubernetesConfig.CRISocket,
 		Runner:            runner,
 		ImageRepository:   cc.KubernetesConfig.ImageRepository,
 		KubernetesVersion: kv,


### PR DESCRIPTION
The default is still the built-in dockershim,
but make sure to honor any external CRI socket.

Also forward the other configuration such as
the Kubernetes version and Image repository.

Closes #9868

----

This can be tested with https://github.com/dims/cri-dockerd

Installed on the node, and started with something like:

`sudo cri-dockerd --container-runtime-endpoint unix:///var/run/dockershim2.sock`

minikube start  start --container-runtime=docker --cri-socket=/var/run/dockershim2.sock

