### PR TITLE
Reduce time limit on TestStartStop to fix occasional KVM_containerd timeout

### DIFF
--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -79,7 +79,7 @@ func TestStartStop(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				MaybeParallel(t)
 				profile := UniqueProfileName(tc.name)
-				ctx, cancel := context.WithTimeout(context.Background(), Minutes(40))
+				ctx, cancel := context.WithTimeout(context.Background(), Minutes(30))
 				defer Cleanup(t, profile, cancel)
 				type validateStartStopFunc func(context.Context, *testing.T, string, string, string, []string)
 				if !strings.Contains(tc.name, "docker") && NoneDriver() {


### PR DESCRIPTION
About every 20% of the time, the KVM_Containerd integration test times out and only ~160 tests are run instead of the expected ~210. This can be seen in https://github.com/kubernetes/minikube/pull/10424 with this [gopogh](https://storage.googleapis.com/minikube-builds/logs/10424/90cd9c3/KVM_Linux_containerd.html)

After searching through jenkins logs for KVM_containerd, I found that the test seems to be timing out in the middle of TestStartStop:
- [example 1](https://a646c87040050000000000000000001.proxy.googleprod.com/job/Docker_Linux_containerd_integration/497/consoleText)
- [example 2](https://a646c87040050000000000000000001.proxy.googleprod.com/job/Docker_Linux_containerd_integration/497/consoleText) (/var/lib/jenkins/go/src/k8s.io/minikube/test/integration/start_stop_delete_test.go:89)

A successful TestStartStop seems to take [15 minutes](https://a646c87040050000000000000000001.proxy.googleprod.com/job/Docker_Linux_containerd_integration/513/consoleText) (--- PASS: TestStartStop (902.41s)) so reducing the time limit on this test to 25 minutes should still provide more than enough time to run it.