### PR TITLE
Stop using --memory-swap if it is not available

### DIFF
--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -181,8 +181,10 @@ func CreateContainerNode(p CreateParams) error {
 		runArgs = append(runArgs, "--security-opt", "apparmor=unconfined")
 
 		runArgs = append(runArgs, fmt.Sprintf("--memory=%s", p.Memory))
-		// Disable swap by setting the value to match
-		runArgs = append(runArgs, fmt.Sprintf("--memory-swap=%s", p.Memory))
+		if memcgSwap {
+			// Disable swap by setting the value to match
+			runArgs = append(runArgs, fmt.Sprintf("--memory-swap=%s", p.Memory))
+		}
 
 		virtualization = "docker" // VIRTUALIZATION_DOCKER
 	}


### PR DESCRIPTION
With Debian and Ubuntu kernels, it needs to be configured.

And now with cgroups v2, it starts throwing errors at run.

Addition to PR #10468

For #10371