### PR TITLE
Updated dashboard URL detection logic for DashboardCmd test

### DIFF
--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -588,15 +588,14 @@ func validateDashboardCmd(ctx context.Context, t *testing.T, profile string) {
 
 // dashboardURL gets the dashboard URL from the command stdout.
 func dashboardURL(b *bufio.Reader) (string, error) {
-	scanner := bufio.NewScanner(b)
-
 	// match http://127.0.0.1:XXXXX/api/v1/namespaces/kubernetes-dashboard/services/http:kubernetes-dashboard:/proxy/
 	dashURLRegexp := regexp.MustCompile(`^http:\/\/127\.0\.0\.1:[0-9]{5}\/api\/v1\/namespaces\/kubernetes-dashboard\/services\/http:kubernetes-dashboard:\/proxy\/$`)
 
-	for scanner.Scan() {
-		s := scanner.Text()
-		if dashURLRegexp.MatchString(s) {
-			return s, nil
+	s := bufio.NewScanner(b)
+	for s.Scan() {
+		t := s.Text()
+		if dashURLRegexp.MatchString(t) {
+			return t, nil
 		}
 	}
 	return "", fmt.Errorf("output didn't produce a URL")

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package integration
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -546,8 +547,11 @@ func validateStatusCmd(ctx context.Context, t *testing.T, profile string) {
 func validateDashboardCmd(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 
+	mctx, cancel := context.WithTimeout(ctx, Seconds(300))
+	defer cancel()
+
 	args := []string{"dashboard", "--url", "-p", profile, "--alsologtostderr", "-v=1"}
-	ss, err := Start(t, exec.CommandContext(ctx, Target(), args...))
+	ss, err := Start(t, exec.CommandContext(mctx, Target(), args...))
 	if err != nil {
 		t.Errorf("failed to run minikube dashboard. args %q : %v", args, err)
 	}
@@ -555,13 +559,12 @@ func validateDashboardCmd(ctx context.Context, t *testing.T, profile string) {
 		ss.Stop(t)
 	}()
 
-	start := time.Now()
-	s, err := ReadLineWithTimeout(ss.Stdout, Seconds(300))
+	s, err := dashboardURL(ss.Stdout)
 	if err != nil {
 		if runtime.GOOS == "windows" {
-			t.Skipf("failed to read url within %s: %v\noutput: %q\n", time.Since(start), err, s)
+			t.Skip(err)
 		}
-		t.Fatalf("failed to read url within %s: %v\noutput: %q\n", time.Since(start), err, s)
+		t.Fatal(err)
 	}
 
 	u, err := url.Parse(strings.TrimSpace(s))
@@ -581,6 +584,18 @@ func validateDashboardCmd(ctx context.Context, t *testing.T, profile string) {
 		}
 		t.Errorf("%s returned status code %d, expected %d.\nbody:\n%s", u, resp.StatusCode, http.StatusOK, body)
 	}
+}
+
+// dashboardURL gets the dashboard URL from the command stdout.
+func dashboardURL(b *bufio.Reader) (string, error) {
+	s := bufio.NewScanner(b)
+	for s.Scan() {
+		l := s.Text()
+		if strings.HasPrefix(l, "http") {
+			return l, nil
+		}
+	}
+	return "", fmt.Errorf("output didn't produce a URL")
 }
 
 // validateDryRun asserts that the dry-run mode quickly exits with the right code

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -559,7 +559,7 @@ func validateDashboardCmd(ctx context.Context, t *testing.T, profile string) {
 		ss.Stop(t)
 	}()
 
-	s, err := dashboardURL(t, ss.Stdout)
+	s, err := dashboardURL(ss.Stdout)
 	if err != nil {
 		if runtime.GOOS == "windows" {
 			t.Skip(err)
@@ -587,14 +587,11 @@ func validateDashboardCmd(ctx context.Context, t *testing.T, profile string) {
 }
 
 // dashboardURL gets the dashboard URL from the command stdout.
-func dashboardURL(t *testing.T, b *bufio.Reader) (string, error) {
+func dashboardURL(b *bufio.Reader) (string, error) {
 	scanner := bufio.NewScanner(b)
 
 	// match http://127.0.0.1:XXXXX/api/v1/namespaces/kubernetes-dashboard/services/http:kubernetes-dashboard:/proxy/
-	dashURLRegexp, err := regexp.Compile(`^http:\/\/127\.0\.0\.1:[0-9]{5}\/api\/v1\/namespaces\/kubernetes-dashboard\/services\/http:kubernetes-dashboard:\/proxy\/$`)
-	if err != nil {
-		t.Fatalf("dashboard URL regex is invalid: %v", err)
-	}
+	dashURLRegexp := regexp.MustCompile(`^http:\/\/127\.0\.0\.1:[0-9]{5}\/api\/v1\/namespaces\/kubernetes-dashboard\/services\/http:kubernetes-dashboard:\/proxy\/$`)
 
 	for scanner.Scan() {
 		s := scanner.Text()

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -588,7 +588,7 @@ func validateDashboardCmd(ctx context.Context, t *testing.T, profile string) {
 
 // dashboardURL gets the dashboard URL from the command stdout.
 func dashboardURL(t *testing.T, b *bufio.Reader) (string, error) {
-	s := bufio.NewScanner(b)
+	scanner := bufio.NewScanner(b)
 
 	// match http://127.0.0.1:XXXXX/api/v1/namespaces/kubernetes-dashboard/services/http:kubernetes-dashboard:/proxy/
 	dashURLRegexp, err := regexp.Compile(`^http:\/\/127\.0\.0\.1:[0-9]{5}\/api\/v1\/namespaces\/kubernetes-dashboard\/services\/http:kubernetes-dashboard:\/proxy\/$`)
@@ -596,10 +596,10 @@ func dashboardURL(t *testing.T, b *bufio.Reader) (string, error) {
 		t.Fatalf("dashboard URL regex is invalid: %v", err)
 	}
 
-	for s.Scan() {
-		l := s.Text()
-		if dashURLRegexp.MatchString(l) {
-			return l, nil
+	for scanner.Scan() {
+		s := scanner.Text()
+		if dashURLRegexp.MatchString(s) {
+			return s, nil
 		}
 	}
 	return "", fmt.Errorf("output didn't produce a URL")

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -598,6 +598,9 @@ func dashboardURL(b *bufio.Reader) (string, error) {
 			return t, nil
 		}
 	}
+	if err := s.Err(); err != nil {
+		return "", fmt.Errorf("failed reading input: %v", err)
+	}
 	return "", fmt.Errorf("output didn't produce a URL")
 }
 

--- a/test/integration/util_test.go
+++ b/test/integration/util_test.go
@@ -26,31 +26,6 @@ import (
 	"k8s.io/minikube/pkg/minikube/localpath"
 )
 
-// ReadLineWithTimeout reads a line of text from a buffer with a timeout
-func ReadLineWithTimeout(b *bufio.Reader, timeout time.Duration) (string, error) {
-	s := make(chan string)
-	e := make(chan error)
-	go func() {
-		read, err := b.ReadString('\n')
-		if err != nil {
-			e <- err
-		} else {
-			s <- read
-		}
-		close(s)
-		close(e)
-	}()
-
-	select {
-	case line := <-s:
-		return line, nil
-	case err := <-e:
-		return "", err
-	case <-time.After(timeout):
-		return "", fmt.Errorf("timeout after %s", timeout)
-	}
-}
-
 // UniqueProfileName returns a reasonably unique profile name
 func UniqueProfileName(prefix string) string {
 	if *forceProfile != "" {


### PR DESCRIPTION
Fixes #10504

PR #10462 changed logging some info from stderr to stdout. The DashboardCmd test checked stdout for the first line and would use that as the dashboard URL. The change in #10462 made new lines
(`-%20Using%20image%20kubernetesui/dashboard:v2.1.0`) output to stdout before the dashboard URL and tried to curl those messages, resulting in the test failing.

This PR loops through the stdout messages until it finds a line that start with `http` and uses that as the dashboard URL.