### PR TITLE
Enable handing over the kubeadm --v flag

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/extraconfig.go
+++ b/pkg/minikube/bootstrapper/bsutil/extraconfig.go
@@ -74,6 +74,7 @@ var KubeadmExtraArgsAllowed = map[int][]string{
 		"certificate-key",
 		"rootfs",
 		"skip-phases",
+		"v",
 	},
 	KubeadmConfigParam: {
 		"pod-network-cidr",

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -47,7 +47,7 @@ minikube start [flags]
       --extra-config ExtraOption          A set of key=value pairs that describe configuration that may be passed to different components.
                                           		The key should be '.' separated, and the first part before the dot is the component to apply the configuration to.
                                           		Valid components are: kubelet, kubeadm, apiserver, controller-manager, etcd, proxy, scheduler
-                                          		Valid kubeadm parameters: ignore-preflight-errors, dry-run, kubeconfig, kubeconfig-dir, node-name, cri-socket, experimental-upload-certs, certificate-key, rootfs, skip-phases, pod-network-cidr
+                                          		Valid kubeadm parameters: ignore-preflight-errors, dry-run, kubeconfig, kubeconfig-dir, node-name, cri-socket, experimental-upload-certs, certificate-key, rootfs, skip-phases, v, pod-network-cidr
       --feature-gates string              A set of key=value pairs that describe feature gates for alpha/experimental features.
       --force                             Force minikube to perform possibly dangerous operations
       --force-systemd                     If set, force the container runtime to use sytemd as cgroup manager. Defaults to false.


### PR DESCRIPTION
Hi,

I was debugging minikube today and my problem was that it was stuck somewhere in kubeadm, waiting for the control plane to come up. Maybe I missed some flags but it was very hard to debug until I build a custom binary which allows specifying `--v`
for the `kubeadm init` call.

It would be very nice, to have this enabled per default.