### PR TITLE
Fix minikube kubectl context switching

### DIFF
--- a/cmd/minikube/cmd/kubectl.go
+++ b/cmd/minikube/cmd/kubectl.go
@@ -43,6 +43,10 @@ minikube kubectl -- get pods --namespace kube-system`,
 		co := mustload.Healthy(ClusterFlagValue())
 
 		version := co.Config.KubernetesConfig.KubernetesVersion
+
+		cluster := []string{"--cluster", ClusterFlagValue()}
+		args = append(args, cluster...)
+
 		c, err := KubectlCommand(version, args...)
 		if err != nil {
 			out.ErrLn("Error caching kubectl: %v", err)


### PR DESCRIPTION
fixes #10143 

**Before PR**
`minikube -p <profile_name> kubectl -- get ns` returned the namespaces in the current context. 

**After PR**
`minikube -p <profile_name> kubectl -- get ns` will return the namesapces in the given context(--profile). 
