### PR TITLE
Introduce alias native for none driver

### DIFF
--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -59,6 +59,8 @@ const (
 	AliasKVM = "kvm"
 	// AliasSSH is driver name alias for ssh
 	AliasSSH = "generic"
+	// AliasNative is driver name alias for None driver
+	AliasNative = "native"
 )
 
 var (

--- a/pkg/minikube/registry/drvs/none/none.go
+++ b/pkg/minikube/registry/drvs/none/none.go
@@ -34,6 +34,7 @@ import (
 func init() {
 	if err := registry.Register(registry.DriverDef{
 		Name:     driver.None,
+		Alias:    []string{driver.AliasNative},
 		Config:   configure,
 		Init:     func() drivers.Driver { return none.NewDriver(none.Config{}) },
 		Status:   status,


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

First step to rename none to native, introducing the alias `native` for none driver.

Running the following will be equivalent
```
$ minikube start --driver=none
$ minikube start --driver=native
```

Ref: https://github.com/kubernetes/minikube/issues/7772