### PR TITLE
Upgrade go version from 1.15.5 to 1.15.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Download Dependencies
         run: go mod download
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install libvirt
         run: |
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install libvirt
         run: |

--- a/.github/workflows/iso.yml
+++ b/.github/workflows/iso.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Download Dependencies
         run: go mod download
@@ -71,7 +71,7 @@ jobs:
           make checksum
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install kubectl
         shell: bash

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Download Dependencies
         run: go mod download
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install libvirt
         run: |
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install libvirt
         run: |
@@ -114,7 +114,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install gopogh
 
@@ -199,7 +199,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install gopogh
 
@@ -344,7 +344,7 @@ jobs:
           echo "------------------------"
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install tools
         continue-on-error: true
@@ -480,7 +480,7 @@ jobs:
           Get-WmiObject -class Win32_ComputerSystem
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install tools
         continue-on-error: true
@@ -586,7 +586,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install gopogh
 
@@ -716,7 +716,7 @@ jobs:
           echo "------------------------"
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install tools
         continue-on-error: true
@@ -809,7 +809,7 @@ jobs:
           Get-WmiObject -class Win32_ComputerSystem
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install tools
         continue-on-error: true
@@ -990,7 +990,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install gopogh
 
@@ -1072,7 +1072,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install gopogh
 
@@ -1184,7 +1184,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install gopogh
 
@@ -1268,7 +1268,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install gopogh
 
@@ -1375,7 +1375,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install gopogh
 
@@ -1457,7 +1457,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install gopogh
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Download Dependencies
         run: go mod download
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install libvirt
         run: |
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install libvirt
         run: |
@@ -112,7 +112,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install gopogh
 
@@ -197,7 +197,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install gopogh
 
@@ -342,7 +342,7 @@ jobs:
           echo "------------------------"
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install tools
         continue-on-error: true
@@ -478,7 +478,7 @@ jobs:
           Get-WmiObject -class Win32_ComputerSystem
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install tools
         continue-on-error: true
@@ -620,7 +620,7 @@ jobs:
           echo "------------------------"
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install tools
         continue-on-error: true
@@ -713,7 +713,7 @@ jobs:
           Get-WmiObject -class Win32_ComputerSystem
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install tools
         continue-on-error: true
@@ -776,7 +776,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install gopogh
 
@@ -988,7 +988,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install gopogh
         shell: bash
@@ -1069,7 +1069,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install gopogh
 
@@ -1181,7 +1181,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
 
       - name: Install gopogh
@@ -1265,7 +1265,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install gopogh
 
@@ -1372,7 +1372,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install gopogh
 
@@ -1454,7 +1454,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Install gopogh
 

--- a/.github/workflows/pr_verified.yaml
+++ b/.github/workflows/pr_verified.yaml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
       - name: Download Dependencies
         run: go mod download
@@ -71,7 +71,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
 
       - name: Install tools
@@ -160,7 +160,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
           stable: true
 
       - name: Install tools

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ RPM_VERSION ?= $(DEB_VERSION)
 RPM_REVISION ?= 0
 
 # used by hack/jenkins/release_build_and_upload.sh and KVM_BUILD_IMAGE, see also BUILD_IMAGE below
-GO_VERSION ?= 1.15.5
+GO_VERSION ?= 1.15.8
 
 INSTALL_SIZE ?= $(shell du out/minikube-windows-amd64.exe | cut -f1)
 BUILDROOT_BRANCH ?= 2020.02.8
@@ -44,10 +44,9 @@ COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
 COMMIT ?= $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}")
 COMMIT_SHORT = $(shell git rev-parse --short HEAD 2> /dev/null || true)
 HYPERKIT_BUILD_IMAGE 	?= karalabe/xgo-1.12.x
-# NOTE: "latest" as of 2020-05-13. kube-cross images aren't updated as often as Kubernetes
+
+# NOTE: "latest" as of 2021-02-06. kube-cross images aren't updated as often as Kubernetes
 # https://github.com/kubernetes/kubernetes/blob/master/build/build-image/cross/VERSION
-
-
 #
 # TODO: See https://github.com/kubernetes/minikube/issues/10276
 #BUILD_IMAGE 	?= us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:v$(GO_VERSION)-1

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -39,7 +39,7 @@ if [ "$(uname)" != "Darwin" ]; then
 fi
 
 # installing golang so we could do go get for gopogh
-sudo ./installers/check_install_golang.sh "1.15.5" "/usr/local" || true
+sudo ./installers/check_install_golang.sh "1.15.8" "/usr/local" || true
 
 # install docker and kubectl if not present
 sudo ./installers/check_install_docker.sh


### PR DESCRIPTION
Same as kubernetes, wait with go1.16 until later.
(currently only needed for darwin-arm64 build)