### PR TITLE
Add link to minikube blog posts and presentations

### DIFF
--- a/site/content/en/docs/presentations/_index.md
+++ b/site/content/en/docs/presentations/_index.md
@@ -1,0 +1,100 @@
+---
+title: "Presentations"
+weight: 3.5
+description: >
+  Available online presentations about minikube
+---
+
+Presentations about the minikube project, mostly from the Kubernetes blog and the KubeCon conference.
+
+## Kubernetes Blog
+
+### 2016
+
+2016-05-30, Kubernetes 1.3, Minikube 0.1.0
+
+* _This is the initial release of Minikube._
+
+2016-07-11, Kubernetes 1.3, Minikube 0.5.0
+
+* <https://kubernetes.io/blog/2016/07/minikube-easily-run-kubernetes-locally/>
+
+### 2019
+
+2019-03-28, Kubernetes 1.14, Minikube 1.0.0
+
+* <https://kubernetes.io/blog/2019/03/28/running-kubernetes-locally-on-linux-with-minikube-now-with-kubernetes-1.14-support/>
+
+## KubeCon + CloudNativeCon
+
+### KubeCon NA 2016 (Seattle, Washington)
+
+<https://cnkc16.sched.com/?searchstring=minikube>
+
+### KubeCon EU 2017 (Berlin, Germany)
+
+<https://cloudnativeeu2017.sched.com/?searchstring=minikube>
+
+### KubeCon NA 2017 (Austin, Texas)
+
+<https://kccncna17.sched.com/?searchstring=minikube>
+
+### KubeCon EU 2018 (Copenhagen, Denmark)
+
+<https://kccnceu18.sched.com/?searchstring=minikube>
+
+* <https://www.youtube.com/watch?v=4x0CZmF_U5o> (28:30)
+  * "Minikube Intro"
+  * Dan Lorenc, Google
+
+### KubeCon NA 2018 (Seattle, Washington)
+
+<https://kccna18.sched.com/?searchstring=minikube>
+
+* <https://www.youtube.com/watch?v=2yBOVlonHQw> (38:49)
+  * "Intro: Minikube"
+  * Thomas Strömberg & Bálint Pató, Google
+
+* <https://www.youtube.com/watch?v=46-FXiSEfE4> (44:05)
+  * "Deep Dive: Minikube"
+  * Bálint Pató & Thomas Strömberg, Google
+
+### KubeCon EU 2019 (Barcelona, Spain)
+
+<https://kccnceu19.sched.com/?searchstring=minikube>
+
+* _No results found for minikube_
+
+### KubeCon NA 2019 (San Diego, California)
+
+<https://kccncna19.sched.com/?searchstring=minikube>
+
+* <https://www.youtube.com/watch?v=3giynG20f3I> (47:27)
+  * "Minikube"
+  * Thomas Strömberg & Medya Ghazizadeh, Google
+
+### KubeCon EU 2020 (Amsterdam, Netherlands) - Virtual
+
+<https://kccnceu20.sched.com/?searchstring=minikube>
+
+* <https://www.youtube.com/watch?v=xdoOmSSCxo8> (37:31)
+  * "Minikube"
+  * Rohit Anand, NEC Corporation & Medya Ghazizadeh, Google
+
+* <https://www.youtube.com/watch?v=tvreJem3xIw> (36:10)
+  * "Improving the Performance of Your Kubernetes Cluster"
+  * Priya Wadhwa, Google
+
+### KubeCon NA 2020 (Boston, Massachusetts) - Virtual
+
+<https://kccncna20.sched.com/?searchstring=minikube>
+
+* _No results found for minikube_
+
+## Other conferences
+
+### Helm Summit EU 2019 (Amsterdam, The Netherlands)
+
+* <https://www.youtube.com/watch?v=Ww7JvxKY478> (35:26)
+  * "Dancing with Helm, Skaffold and Minikube!"
+  * Medya Ghazizadeh, Google

--- a/site/content/en/docs/presentations/_index.md
+++ b/site/content/en/docs/presentations/_index.md
@@ -65,6 +65,14 @@ Presentations about the minikube project, mostly from the Kubernetes blog and th
 
 * _No results found for minikube_
 
+### KubeCon CN 2019 (Shanghai, China)
+
+<https://kccncosschn19eng.sched.com/?searchstring=minikube>
+
+* <https://www.youtube.com/watch?v=ahb-_NBtOL0> (33:21)
+  * "Minikube: Bringing Kubernetes to the Next Billion Users"
+  * Thomas Strömberg, Google
+
 ### KubeCon NA 2019 (San Diego, California)
 
 <https://kccncna19.sched.com/?searchstring=minikube>


### PR DESCRIPTION
From 2016 to 2020, two blog posts and four KubeCons.