### PR TITLE
Check for args length to prevent out of bounds panic

### DIFF
--- a/cmd/minikube/main.go
+++ b/cmd/minikube/main.go
@@ -158,7 +158,7 @@ func setFlags() {
 
 // setLastStartFlags sets the log_file flag to lastStart.txt if start command and user doesn't specify log_file or log_dir flags.
 func setLastStartFlags() {
-	if os.Args[1] != "start" {
+	if len(os.Args) < 2 || os.Args[1] != "start" {
 		return
 	}
 	if pflag.CommandLine.Changed("log_file") || pflag.CommandLine.Changed("log_dir") {

--- a/pkg/minikube/audit/audit.go
+++ b/pkg/minikube/audit/audit.go
@@ -52,7 +52,7 @@ func args() string {
 
 // Log details about the executed command.
 func Log(startTime time.Time) {
-	if !shouldLog() {
+	if len(os.Args) < 2 || !shouldLog() {
 		return
 	}
 	r := newRow(os.Args[1], args(), userName(), version.GetVersion(), startTime, time.Now())

--- a/pkg/minikube/audit/audit_test.go
+++ b/pkg/minikube/audit/audit_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/user"
 	"testing"
+	"time"
 
 	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/config"
@@ -166,5 +167,14 @@ func TestAudit(t *testing.T) {
 				t.Errorf("os.Args = %q; isDeletePurge() = %t; want %t", os.Args, got, test.want)
 			}
 		}
+	})
+
+	// Check if logging with limited args causes a panic
+	t.Run("Log", func(t *testing.T) {
+		oldArgs := os.Args
+		defer func() { os.Args = oldArgs }()
+		os.Args = []string{"minikube"}
+
+		Log(time.Now())
 	})
 }

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -17,10 +17,12 @@ limitations under the License.
 package integration
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"math"
 	"os"
+	"os/exec"
 	"runtime"
 	"strconv"
 	"strings"
@@ -60,6 +62,13 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 	fmt.Printf("Tests completed in %s (result code %d)\n", time.Since(start), code)
 	os.Exit(code)
+}
+
+func TestMainNoArgs(t *testing.T) {
+	rr, err := Run(t, exec.CommandContext(context.Background(), Target()))
+	if err != nil {
+		t.Fatalf("failed running minikube with no args %q: %v", rr.Command(), err)
+	}
 }
 
 // setMaxParallelism caps the max parallelism. Go assumes 1 core per test, whereas minikube needs 2 cores per test.


### PR DESCRIPTION
Added missing arg length checks that could result in out of bounds panics.
