### PR TITLE
make metric server serve on all ipv4 interfaces

### DIFF
--- a/hack/update/kubernetes_version/templates/v1beta2/containerd-api-port.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta2/containerd-api-port.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/hack/update/kubernetes_version/templates/v1beta2/containerd-pod-network-cidr.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta2/containerd-pod-network-cidr.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "192.168.32.0/20"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/hack/update/kubernetes_version/templates/v1beta2/containerd.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta2/containerd.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/hack/update/kubernetes_version/templates/v1beta2/crio-options-gates.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta2/crio-options-gates.yaml
@@ -71,5 +71,5 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249
 mode: "iptables"

--- a/hack/update/kubernetes_version/templates/v1beta2/crio.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta2/crio.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/hack/update/kubernetes_version/templates/v1beta2/default.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta2/default.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/hack/update/kubernetes_version/templates/v1beta2/dns.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta2/dns.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/hack/update/kubernetes_version/templates/v1beta2/image-repository.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta2/image-repository.yaml
@@ -66,4 +66,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/hack/update/kubernetes_version/templates/v1beta2/options.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta2/options.yaml
@@ -68,5 +68,5 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta1.go
+++ b/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta1.go
@@ -90,7 +90,7 @@ staticPodPath: {{.StaticPodPath}}
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "{{.PodSubnet }}"
-metricsBindAddress: {{.AdvertiseAddress}}:10249
+metricsBindAddress: 0.0.0.0:10249
 {{- range $i, $val := printMapInOrder .KubeProxyOptions ": " }}
 {{$val}}
 {{- end}}

--- a/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta2.go
+++ b/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta2.go
@@ -93,7 +93,7 @@ staticPodPath: {{.StaticPodPath}}
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "{{.PodSubnet }}"
-metricsBindAddress: {{.AdvertiseAddress}}:10249
+metricsBindAddress: 0.0.0.0:10249
 {{- range $i, $val := printMapInOrder .KubeProxyOptions ": " }}
 {{$val}}
 {{- end}}

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd-api-port.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd-pod-network-cidr.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "192.168.32.0/20"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/crio-options-gates.yaml
@@ -71,5 +71,5 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/crio.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/default.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/dns.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/image-repository.yaml
@@ -66,4 +66,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/options.yaml
@@ -68,5 +68,5 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd-api-port.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd-pod-network-cidr.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "192.168.32.0/20"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/crio-options-gates.yaml
@@ -71,5 +71,5 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/crio.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/default.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/dns.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/image-repository.yaml
@@ -66,4 +66,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/options.yaml
@@ -68,5 +68,5 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd-api-port.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd-pod-network-cidr.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "192.168.32.0/20"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/crio-options-gates.yaml
@@ -71,5 +71,5 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/crio.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/default.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/dns.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/image-repository.yaml
@@ -66,4 +66,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/options.yaml
@@ -68,5 +68,5 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-api-port.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-pod-network-cidr.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "192.168.32.0/20"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio-options-gates.yaml
@@ -71,5 +71,5 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/default.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/dns.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/image-repository.yaml
@@ -66,4 +66,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/options.yaml
@@ -68,5 +68,5 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd-api-port.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd-pod-network-cidr.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "192.168.32.0/20"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/crio-options-gates.yaml
@@ -71,5 +71,5 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/crio.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/default.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/dns.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/image-repository.yaml
@@ -66,4 +66,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/options.yaml
@@ -68,5 +68,5 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd-api-port.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd-pod-network-cidr.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "192.168.32.0/20"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/crio-options-gates.yaml
@@ -71,5 +71,5 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/crio.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/default.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/dns.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/image-repository.yaml
@@ -66,4 +66,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/options.yaml
@@ -68,5 +68,5 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd-api-port.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd-pod-network-cidr.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "192.168.32.0/20"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/crio-options-gates.yaml
@@ -71,5 +71,5 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/crio.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/default.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/dns.yaml
@@ -65,4 +65,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/image-repository.yaml
@@ -66,4 +66,4 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/options.yaml
@@ -68,5 +68,5 @@ staticPodPath: /etc/kubernetes/manifests
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: "10.244.0.0/16"
-metricsBindAddress: 1.1.1.1:10249
+metricsBindAddress: 0.0.0.0:10249
 mode: "iptables"


### PR DESCRIPTION
fixes #10581

before: as detailed in the original issue's description

after:
```
I0225 03:41:17.654624 1 node.go:172] Successfully retrieved node IP: 192.168.49.3
I0225 03:41:17.654669 1 server_others.go:142] kube-proxy node IP is an IPv4 address (192.168.49.3), assume IPv4 operation
W0225 03:41:17.673421 1 server_others.go:578] Unknown proxy mode "", assuming iptables proxy
I0225 03:41:17.673524 1 server_others.go:185] Using iptables Proxier.
I0225 03:41:17.673788 1 server.go:650] Version: v1.20.2
I0225 03:41:17.674041 1 conntrack.go:52] Setting nf_conntrack_max to 524288
E0225 03:41:17.674338 1 conntrack.go:127] sysfs is not writable: {Device:sysfs Path:/sys Type:sysfs Opts:[ro nosuid nodev noexec relatime] Freq:0 Pass:0} (mount options are [ro nosuid nodev noexec relatime])
I0225 03:41:17.674408 1 conntrack.go:100] Set sysctl 'net/netfilter/nf_conntrack_tcp_timeout_established' to 86400
I0225 03:41:17.674452 1 conntrack.go:100] Set sysctl 'net/netfilter/nf_conntrack_tcp_timeout_close_wait' to 3600
I0225 03:41:17.674569 1 config.go:315] Starting service config controller
I0225 03:41:17.674580 1 shared_informer.go:240] Waiting for caches to sync for service config
I0225 03:41:17.674658 1 config.go:224] Starting endpoint slice config controller
I0225 03:41:17.674670 1 shared_informer.go:240] Waiting for caches to sync for endpoint slice config
I0225 03:41:17.774816 1 shared_informer.go:247] Caches are synced for endpoint slice config
I0225 03:41:17.774817 1 shared_informer.go:247] Caches are synced for service config
```