### PR TITLE
test spam: add cgroup warnning to whitelist

### DIFF
--- a/test/integration/error_spam_test.go
+++ b/test/integration/error_spam_test.go
@@ -40,12 +40,14 @@ var stderrAllow = []string{
 	`docker.*issue.*performance`,
 	// "* Suggestion: enable overlayfs kernel module on your Linux"
 	`Suggestion.*overlayfs`,
+	// jenkins VMs (debian 9) cgoups don't allow setting memory
+	`Your cgroup does not allow setting memory.`,
 }
 
 // stderrAllowRe combines rootCauses into a single regex
 var stderrAllowRe = regexp.MustCompile(strings.Join(stderrAllow, "|"))
 
-// TestErrorSpam asserts that there are no errors displayed
+// TestErrorSpam asserts that there are no errors displayed in UI.
 func TestErrorSpam(t *testing.T) {
 	if NoneDriver() {
 		t.Skip("none driver always shows a warning")


### PR DESCRIPTION
currently this is the only failing test on Docker Linux Docker Runtime
https://storage.googleapis.com/minikube-builds/logs/10630/85eb356/Docker_Linux.html#fail_TestErrorSpam

and it is due to jenkins machine cgroups not allowing --memory