### PR TITLE
Verify and fix image platform

### DIFF
--- a/pkg/minikube/image/image.go
+++ b/pkg/minikube/image/image.go
@@ -19,7 +19,6 @@ package image
 import (
 	"context"
 	"fmt"
-	"github.com/docker/docker/pkg/platform"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"io/ioutil"
 	"os"
@@ -200,13 +199,13 @@ func fixPlatform(ref name.Reference, img v1.Image, p v1.Platform) (v1.Image, err
 		return img, err
 	}
 
-	if cfg.Architecture == platform.Architecture {
+	if cfg.Architecture == p.Architecture {
 		return img, nil
 	}
 	klog.Warningf("image %s arch mismatch: want %s got %s. fixing",
-		ref, platform.Architecture, cfg.Architecture)
+		ref, p.Architecture, cfg.Architecture)
 
-	cfg.Architecture = platform.Architecture
+	cfg.Architecture = p.Architecture
 	img, err = mutate.ConfigFile(img, cfg)
 	if err != nil {
 		klog.Warningf("failed to change config for %s: %v", ref, err)

--- a/pkg/minikube/image/image.go
+++ b/pkg/minikube/image/image.go
@@ -19,7 +19,6 @@ package image
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -33,8 +32,10 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/daemon"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
+
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/minikube/constants"

--- a/pkg/minikube/image/image.go
+++ b/pkg/minikube/image/image.go
@@ -192,6 +192,8 @@ func retrieveRemote(ref name.Reference, p v1.Platform) (v1.Image, error) {
 	return remote.Image(ref, remote.WithPlatform(p))
 }
 
+// See https://github.com/kubernetes/minikube/issues/10402
+// check if downloaded image Architecture field matches the requested and fix it otherwise
 func fixPlatform(ref name.Reference, img v1.Image, p v1.Platform) (v1.Image, error) {
 	cfg, err := img.ConfigFile()
 	if err != nil {

--- a/pkg/minikube/image/image.go
+++ b/pkg/minikube/image/image.go
@@ -182,14 +182,14 @@ func retrieveImage(ref name.Reference) (v1.Image, error) {
 	return fixPlatform(ref, img, defaultPlatform)
 }
 
-func retrieveRemote(ref name.Reference, platform v1.Platform) (v1.Image, error) {
-	img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithPlatform(platform))
+func retrieveRemote(ref name.Reference, p v1.Platform) (v1.Image, error) {
+	img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithPlatform(p))
 	if err == nil {
 		return img, nil
 	}
 
 	klog.Warningf("authn lookup for %+v (trying anon): %+v", ref, err)
-	return remote.Image(ref)
+	return remote.Image(ref, remote.WithPlatform(p))
 }
 
 func fixPlatform(ref name.Reference, img v1.Image, p v1.Platform) (v1.Image, error) {

--- a/pkg/minikube/image/image.go
+++ b/pkg/minikube/image/image.go
@@ -190,13 +190,12 @@ func retrieveRemote(ref name.Reference, platform v1.Platform) (v1.Image, error) 
 	}
 
 	klog.Warningf("authn lookup for %+v (trying anon): %+v", ref, err)
-	img, err = remote.Image(ref)
-	return img, err
+	return remote.Image(ref)
 }
 
 func fixPlatform(ref name.Reference, img v1.Image, p v1.Platform) (v1.Image, error) {
 	cfg, err := img.ConfigFile()
-	if err != nil {} else {
+	if err != nil {
 		klog.Warningf("failed to get config for %s: %v", ref, err)
 		return img, err
 	}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/10402

This PR add a workaround to fix incorrect manifests in images retrieved from remote registries.
