### PR TITLE
Add flag "--listen-address" for docker and podman driver

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1079,6 +1079,10 @@ func validateFlags(cmd *cobra.Command, drvName string) {
 		validateChangedMemoryFlags(drvName)
 	}
 
+	if cmd.Flags().Changed(listenAddress) {
+		validateListenAddress(viper.GetString(listenAddress))
+	}
+
 	if cmd.Flags().Changed(containerRuntime) {
 		runtime := strings.ToLower(viper.GetString(containerRuntime))
 
@@ -1196,6 +1200,14 @@ func validateRegistryMirror() {
 			}
 
 		}
+	}
+}
+
+// This function validates if the --listen-address
+// match the format 0.0.0.0
+func validateListenAddress(listenAddr string) {
+	if len(listenAddr) > 0 && net.ParseIP(listenAddr) == nil {
+		exit.Message(reason.Usage, "Sorry, the IP provided with the --listen-address flag is invalid: {{.listenAddr}}.", out.V{"listenAddr": listenAddr})
 	}
 }
 

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -116,6 +116,7 @@ const (
 	sshSSHPort              = "ssh-port"
 	defaultSSHUser          = "root"
 	defaultSSHPort          = 22
+	listenAddress           = "listen-address"
 )
 
 var (
@@ -215,6 +216,7 @@ func initDriverFlags() {
 	startCmd.Flags().String(hypervExternalAdapter, "", "External Adapter on which external switch will be created if no external switch is found. (hyperv driver only)")
 
 	// docker & podman
+	startCmd.Flags().String(listenAddress, "", fmt.Sprintf("IP Address to use to expose ports (docker driver only)"))
 	startCmd.Flags().StringSlice(ports, []string{}, "List of ports that should be exposed (docker and podman driver only)")
 }
 
@@ -322,6 +324,7 @@ func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k
 			CPUs:                    viper.GetInt(cpus),
 			DiskSize:                diskSize,
 			Driver:                  drvName,
+			ListenAddress:           viper.GetString(listenAddress),
 			HyperkitVpnKitSock:      viper.GetString(vpnkitSock),
 			HyperkitVSockPorts:      viper.GetStringSlice(vsockPorts),
 			NFSShare:                viper.GetStringSlice(nfsShare),

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -215,8 +215,10 @@ func initDriverFlags() {
 	startCmd.Flags().Bool(hypervUseExternalSwitch, false, "Whether to use external switch over Default Switch if virtual switch not explicitly specified. (hyperv driver only)")
 	startCmd.Flags().String(hypervExternalAdapter, "", "External Adapter on which external switch will be created if no external switch is found. (hyperv driver only)")
 
-	// docker & podman
+	// docker
 	startCmd.Flags().String(listenAddress, "", "IP Address to use to expose ports (docker driver only)")
+
+	// docker & podman
 	startCmd.Flags().StringSlice(ports, []string{}, "List of ports that should be exposed (docker and podman driver only)")
 }
 

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -216,7 +216,7 @@ func initDriverFlags() {
 	startCmd.Flags().String(hypervExternalAdapter, "", "External Adapter on which external switch will be created if no external switch is found. (hyperv driver only)")
 
 	// docker & podman
-	startCmd.Flags().String(listenAddress, "", fmt.Sprintf("IP Address to use to expose ports (docker driver only)"))
+	startCmd.Flags().String(listenAddress, "", "IP Address to use to expose ports (docker driver only)")
 	startCmd.Flags().StringSlice(ports, []string{}, "List of ports that should be exposed (docker and podman driver only)")
 }
 

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -215,10 +215,8 @@ func initDriverFlags() {
 	startCmd.Flags().Bool(hypervUseExternalSwitch, false, "Whether to use external switch over Default Switch if virtual switch not explicitly specified. (hyperv driver only)")
 	startCmd.Flags().String(hypervExternalAdapter, "", "External Adapter on which external switch will be created if no external switch is found. (hyperv driver only)")
 
-	// docker
-	startCmd.Flags().String(listenAddress, "", "IP Address to use to expose ports (docker driver only)")
-
 	// docker & podman
+	startCmd.Flags().String(listenAddress, "", "IP Address to use to expose ports (docker and podman driver only)")
 	startCmd.Flags().StringSlice(ports, []string{}, "List of ports that should be exposed (docker and podman driver only)")
 }
 

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -106,7 +106,7 @@ func (d *Driver) Create() error {
 
 	listAddr := oci.DefaultBindIPV4
 	if d.NodeConfig.ListenAddress != "" && d.NodeConfig.ListenAddress != listAddr {
-		out.Step(style.Tip, "Minikube is not meant for production use. You are opening non-local traffic")
+		out.Step(style.Tip, "minikube is not meant for production use. You are opening non-local traffic")
 		out.WarningT("Listening to {{.listenAddr}}. This is not recommended and can cause a security vulnerability. Use at your own risk",
 			out.V{"listenAddr": d.NodeConfig.ListenAddress})
 		listAddr = d.NodeConfig.ListenAddress

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -102,8 +102,13 @@ func (d *Driver) Create() error {
 		params.IP = ip.String()
 	}
 	drv := d.DriverName()
+
 	listAddr := oci.DefaultBindIPV4
-	if oci.IsExternalDaemonHost(drv) {
+	if d.NodeConfig.ListenAddress != "" {
+		out.WarningT("Listening to {{.listenAddr}}. Please be advised",
+			out.V{"listenAddr": d.NodeConfig.ListenAddress})
+		listAddr = d.NodeConfig.ListenAddress
+	} else if oci.IsExternalDaemonHost(drv) {
 		out.WarningT("Listening to 0.0.0.0 on external docker host {{.host}}. Please be advised",
 			out.V{"host": oci.DaemonHost(drv)})
 		listAddr = "0.0.0.0"

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -105,7 +105,7 @@ func (d *Driver) Create() error {
 
 	listAddr := oci.DefaultBindIPV4
 	if d.NodeConfig.ListenAddress != "" && d.NodeConfig.ListenAddress != listAddr {
-		out.WarningT("Listening to {{.listenAddr}}. Please be advised",
+		out.WarningT("Listening to {{.listenAddr}}. This is not recommended and can cause a security vulnerability. Use at your own risk",
 			out.V{"listenAddr": d.NodeConfig.ListenAddress})
 		listAddr = d.NodeConfig.ListenAddress
 	} else if oci.IsExternalDaemonHost(drv) {

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -107,6 +107,7 @@ func (d *Driver) Create() error {
 	if d.NodeConfig.ListenAddress != "" && d.NodeConfig.ListenAddress != listAddr {
 		out.WarningT("Listening to {{.listenAddr}}. This is not recommended and can cause a security vulnerability. Use at your own risk",
 			out.V{"listenAddr": d.NodeConfig.ListenAddress})
+		out.Infof("minikube is not meant for production use. you are opening non-local traffic")
 		listAddr = d.NodeConfig.ListenAddress
 	} else if oci.IsExternalDaemonHost(drv) {
 		out.WarningT("Listening to 0.0.0.0 on external docker host {{.host}}. Please be advised",

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/download"
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/out"
+	"k8s.io/minikube/pkg/minikube/style"
 	"k8s.io/minikube/pkg/minikube/sysinit"
 	"k8s.io/minikube/pkg/util/retry"
 )
@@ -105,9 +106,9 @@ func (d *Driver) Create() error {
 
 	listAddr := oci.DefaultBindIPV4
 	if d.NodeConfig.ListenAddress != "" && d.NodeConfig.ListenAddress != listAddr {
+		out.Step(style.Tip, "Minikube is not meant for production use. You are opening non-local traffic")
 		out.WarningT("Listening to {{.listenAddr}}. This is not recommended and can cause a security vulnerability. Use at your own risk",
 			out.V{"listenAddr": d.NodeConfig.ListenAddress})
-		out.Infof("minikube is not meant for production use. you are opening non-local traffic")
 		listAddr = d.NodeConfig.ListenAddress
 	} else if oci.IsExternalDaemonHost(drv) {
 		out.WarningT("Listening to 0.0.0.0 on external docker host {{.host}}. Please be advised",

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -104,7 +104,7 @@ func (d *Driver) Create() error {
 	drv := d.DriverName()
 
 	listAddr := oci.DefaultBindIPV4
-	if d.NodeConfig.ListenAddress != "" {
+	if d.NodeConfig.ListenAddress != "" && d.NodeConfig.ListenAddress != listAddr {
 		out.WarningT("Listening to {{.listenAddr}}. Please be advised",
 			out.V{"listenAddr": d.NodeConfig.ListenAddress})
 		listAddr = d.NodeConfig.ListenAddress

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -62,4 +62,5 @@ type Config struct {
 	ContainerRuntime  string            // container runtime kic is running
 	Network           string            //  network to run with kic
 	ExtraArgs         []string          // a list of any extra option to pass to oci binary during creation time, for example --expose 8080...
+	ListenAddress     string            // IP Address to listen to
 }

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -77,8 +77,8 @@ type ClusterConfig struct {
 	StartHostTimeout        time.Duration
 	ScheduledStop           *ScheduledStopConfig
 	ExposedPorts            []string // Only used by the docker and podman driver
+	ListenAddress           string   // Only used by the docker and podman driver
 	Network                 string   // only used by docker driver
-	ListenAddress           string   // Only used by docker driver
 	MultiNodeRequested      bool
 }
 

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -78,6 +78,7 @@ type ClusterConfig struct {
 	ScheduledStop           *ScheduledStopConfig
 	ExposedPorts            []string // Only used by the docker and podman driver
 	Network                 string   // only used by docker driver
+	ListenAddress           string   // Only used by docker driver
 	MultiNodeRequested      bool
 }
 

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -83,6 +83,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		ContainerRuntime:  cc.KubernetesConfig.ContainerRuntime,
 		ExtraArgs:         extraArgs,
 		Network:           cc.Network,
+		ListenAddress:     cc.ListenAddress,
 	}), nil
 }
 

--- a/pkg/minikube/registry/drvs/podman/podman.go
+++ b/pkg/minikube/registry/drvs/podman/podman.go
@@ -89,6 +89,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		KubernetesVersion: cc.KubernetesConfig.KubernetesVersion,
 		ContainerRuntime:  cc.KubernetesConfig.ContainerRuntime,
 		ExtraArgs:         extraArgs,
+		ListenAddress:     cc.ListenAddress,
 	}), nil
 }
 

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -71,7 +71,7 @@ minikube start [flags]
       --kvm-hidden                        Hide the hypervisor signature from the guest in minikube (kvm2 driver only)
       --kvm-network string                The KVM network name. (kvm2 driver only) (default "default")
       --kvm-qemu-uri string               The KVM QEMU connection URI. (kvm2 driver only) (default "qemu:///system")
-      --listen-address string             IP Address to use to expose ports (docker driver only)
+      --listen-address string             IP Address to use to expose ports (docker and podman driver only)
       --memory string                     Amount of RAM to allocate to Kubernetes (format: <number>[<unit>], where unit = b, k, m or g).
       --mount                             This will start the mount daemon and automatically mount files into minikube.
       --mount-string string               The argument to pass the minikube mount command on start.

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -71,6 +71,7 @@ minikube start [flags]
       --kvm-hidden                        Hide the hypervisor signature from the guest in minikube (kvm2 driver only)
       --kvm-network string                The KVM network name. (kvm2 driver only) (default "default")
       --kvm-qemu-uri string               The KVM QEMU connection URI. (kvm2 driver only) (default "qemu:///system")
+      --listen-address string             IP Address to use to expose ports (docker driver only)
       --memory string                     Amount of RAM to allocate to Kubernetes (format: <number>[<unit>], where unit = b, k, m or g).
       --mount                             This will start the mount daemon and automatically mount files into minikube.
       --mount-string string               The argument to pass the minikube mount command on start.


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
Allow a user to set what IP to listen on when binding ports for the docker and podman driver.

Warns the user when used during start.

Example:
```
$ ./out/minikube-linux-amd64 start --driver=docker --listen-address=0.0.0.0
😄  minikube v1.18.0-beta.0 on Ubuntu 20.04
✨  Using the docker driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🔥  Creating docker container (CPUs=2, Memory=6300MB) ...
💡  minikube is not meant for production use. You are opening non-local traffic
❗  Listening to 0.0.0.0. This is not recommended and can cause a security vulnerability. Use at your own risk
🐳  Preparing Kubernetes v1.20.2 on Docker 20.10.3 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v4
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```

Fixes #8008 