### PR TITLE
CoreDNS early scale down to 1 replica

### DIFF
--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -32,7 +32,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"golang.org/x/sync/errgroup"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
+	kconst "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	cmdcfg "k8s.io/minikube/cmd/minikube/cmd/config"
 	"k8s.io/minikube/pkg/addons"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
@@ -123,6 +125,11 @@ func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 		if err := kubeconfig.Update(kcs); err != nil {
 			return nil, errors.Wrap(err, "Failed kubeconfig update")
 		}
+
+		// scale down CoreDNS from default 2 to 1 replica
+		if err := kapi.ScaleDeployment(starter.Cfg.Name, meta.NamespaceSystem, kconst.CoreDNSDeploymentName, 1); err != nil {
+			klog.Errorf("Unable to scale down deployment %q in namespace %q to 1 replica: %v", kconst.CoreDNSDeploymentName, meta.NamespaceSystem, err)
+		}
 	} else {
 		bs, err = cluster.Bootstrapper(starter.MachineAPI, viper.GetString(cmdcfg.Bootstrapper), *starter.Cfg, starter.Runner)
 		if err != nil {
@@ -160,12 +167,6 @@ func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 		wg.Add(1)
 		go addons.Start(&wg, starter.Cfg, starter.ExistingAddons, config.AddonList)
 	}
-
-	wg.Add(1)
-	go func() {
-		rescaleCoreDNS(starter.Cfg, starter.Runner)
-		wg.Done()
-	}()
 
 	if apiServer {
 		// special ops for none , like change minikube directory.
@@ -587,17 +588,5 @@ func prepareNone() {
 
 	if err := util.MaybeChownDirRecursiveToMinikubeUser(localpath.MiniPath()); err != nil {
 		exit.Message(reason.HostHomeChown, "Failed to change permissions for {{.minikube_dir_path}}: {{.error}}", out.V{"minikube_dir_path": localpath.MiniPath(), "error": err})
-	}
-}
-
-// rescaleCoreDNS attempts to reduce coredns replicas from 2 to 1 to improve CPU overhead
-// no worries if this doesn't work
-func rescaleCoreDNS(cc *config.ClusterConfig, runner command.Runner) {
-	kubectl := kapi.KubectlBinaryPath(cc.KubernetesConfig.KubernetesVersion)
-	cmd := exec.Command("sudo", "KUBECONFIG=/var/lib/minikube/kubeconfig", kubectl, "scale", "deployment", "--replicas=1", "coredns", "-n=kube-system")
-	if _, err := runner.RunCmd(cmd); err != nil {
-		klog.Warningf("unable to scale coredns replicas to 1: %v", err)
-	} else {
-		klog.Infof("successfully scaled coredns replicas to 1")
 	}
 }


### PR DESCRIPTION
fixes #10655

this pr proposes to scale down the number of CoreDNS replica to 1 immediately after the master node is initialised, thus stabilising the whole system faster

also, metrics got a bit better (-5sec; both pr's `out` and released `minikube-rls` are based on the latest v1.18.0-beta.0):

```
out/minikube start  2.48s user 1.39s system 6% cpu 55.720 total
minikube-rls start  2.38s user 1.67s system 6% cpu 59.158 total
```
```
out/minikube start --vm-driver=docker --nodes=3  4.84s user 2.54s system 8% cpu 1:27.61 total
minikube-rls start --vm-driver=docker --nodes=3  4.40s user 2.70s system 7% cpu 1:32.79 total
```
```
out/minikube start --vm-driver=docker --nodes=3 --wait=all  6.52s user 2.68s system 4% cpu 3:31.89 total
minikube-rls start --vm-driver=docker --nodes=3 --wait=all  6.59s user 2.99s system 4% cpu 3:37.16 total
```