### PR TITLE
auto-pause: Using time.Ticker instead of time.Timer to fire idle time-out event.

### DIFF
--- a/cmd/auto-pause/auto-pause.go
+++ b/cmd/auto-pause/auto-pause.go
@@ -64,6 +64,15 @@ func main() {
 				fmt.Printf("Got request\n")
 				if runtimePaused {
 					runUnpause()
+					idleTimeout.Reset(interval)
+					// Drain the timeout channel in case of racing condition.
+					for {
+						select {
+						case <-idleTimeout.C:
+						default:
+							break
+						}
+					}
 				}
 
 				done <- struct{}{}


### PR DESCRIPTION
Fix #10596 

Using time.Ticker to replace time.Timer to solve the timer memory leak issue. Refer to [this blog](https://www.fatalerrors.org/a/use-with-caution-time.after-can-cause-memory-leak-golang.html) for more details.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
