### PR TITLE
[WIP] Bump go version to 1.16.0 in CI scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
       - "!deploy/iso/**"
 env:
   GOPROXY: https://proxy.golang.org
+  GO_VERSION: 1.16.0
 jobs:
   build_minikube:
     runs-on: ubuntu-18.04
@@ -17,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Download Dependencies
         run: go mod download
@@ -44,7 +45,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install libvirt
         run: |
@@ -63,7 +64,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install libvirt
         run: |

--- a/.github/workflows/iso.yml
+++ b/.github/workflows/iso.yml
@@ -5,6 +5,7 @@ on:
       - "deploy/iso/**"
 env:
   GOPROXY: https://proxy.golang.org
+  GO_VERSION: 1.16.0
 jobs:
   build_test_iso:
     runs-on: [self-hosted, debian9, baremetal, equinix]
@@ -20,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Download Dependencies
         run: go mod download
@@ -71,7 +72,7 @@ jobs:
           make checksum
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install kubectl
         shell: bash

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,6 +12,7 @@ on:
       - "!deploy/iso/**"
 env:
   GOPROXY: https://proxy.golang.org
+  GO_VERSION: 1.16.0
 jobs:
   # Runs before all other jobs
   # builds the minikube binaries
@@ -21,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Download Dependencies
         run: go mod download
@@ -48,7 +49,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install libvirt
         run: |
@@ -67,7 +68,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install libvirt
         run: |
@@ -114,7 +115,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install gopogh
 
@@ -199,7 +200,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install gopogh
 
@@ -344,7 +345,7 @@ jobs:
           echo "------------------------"
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install tools
         continue-on-error: true
@@ -480,7 +481,7 @@ jobs:
           Get-WmiObject -class Win32_ComputerSystem
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install tools
         continue-on-error: true
@@ -586,7 +587,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install gopogh
 
@@ -716,7 +717,7 @@ jobs:
           echo "------------------------"
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install tools
         continue-on-error: true
@@ -809,7 +810,7 @@ jobs:
           Get-WmiObject -class Win32_ComputerSystem
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install tools
         continue-on-error: true
@@ -892,7 +893,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.2'
+          go-version: ${{env.GO_VERSION}}
           stable: true
 
       - name: Download Binaries
@@ -990,7 +991,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install gopogh
 
@@ -1072,7 +1073,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install gopogh
 
@@ -1184,7 +1185,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install gopogh
 
@@ -1268,7 +1269,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install gopogh
 
@@ -1375,7 +1376,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install gopogh
 
@@ -1457,7 +1458,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install gopogh
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,7 @@ on:
       - "!deploy/iso/**"
 env:
   GOPROXY: https://proxy.golang.org
+  GO_VERSION: 1.16.0
 jobs:
   # Runs before all other jobs
   # builds the minikube binaries
@@ -19,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Download Dependencies
         run: go mod download
@@ -46,7 +47,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install libvirt
         run: |
@@ -65,7 +66,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install libvirt
         run: |
@@ -112,7 +113,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install gopogh
 
@@ -197,7 +198,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install gopogh
 
@@ -342,7 +343,7 @@ jobs:
           echo "------------------------"
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install tools
         continue-on-error: true
@@ -478,7 +479,7 @@ jobs:
           Get-WmiObject -class Win32_ComputerSystem
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install tools
         continue-on-error: true
@@ -620,7 +621,7 @@ jobs:
           echo "------------------------"
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install tools
         continue-on-error: true
@@ -713,7 +714,7 @@ jobs:
           Get-WmiObject -class Win32_ComputerSystem
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install tools
         continue-on-error: true
@@ -776,7 +777,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install gopogh
 
@@ -891,7 +892,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.2'
+          go-version: ${{env.GO_VERSION}}
           stable: true
 
       - name: Download Binaries
@@ -988,7 +989,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install gopogh
         shell: bash
@@ -1069,7 +1070,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install gopogh
 
@@ -1181,7 +1182,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
 
       - name: Install gopogh
@@ -1265,7 +1266,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install gopogh
 
@@ -1372,7 +1373,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install gopogh
 
@@ -1454,7 +1455,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Install gopogh
 

--- a/.github/workflows/pr_verified.yaml
+++ b/.github/workflows/pr_verified.yaml
@@ -19,6 +19,7 @@ on:
       - deleted
 env:
   GOPROXY: https://proxy.golang.org
+  GO_VERSION: 1.16.0
 
 jobs:
   # Runs before all other jobs
@@ -30,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
       - name: Download Dependencies
         run: go mod download
@@ -71,7 +72,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
 
       - name: Install tools
@@ -160,7 +161,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: ${{env.GO_VERSION}}
           stable: true
 
       - name: Install tools

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -39,7 +39,7 @@ if [ "$(uname)" != "Darwin" ]; then
 fi
 
 # installing golang so we could do go get for gopogh
-sudo ./installers/check_install_golang.sh "1.15.8" "/usr/local" || true
+sudo ./installers/check_install_golang.sh "1.16" "/usr/local" || true
 
 # install docker and kubectl if not present
 sudo ./installers/check_install_docker.sh


### PR DESCRIPTION
This PR updates GitHub Actions and Jenkins scripts to use go 1.16.0