### PR TITLE
Jenkins release job: check if built minikube binary reports 'dirty' commit id

### DIFF
--- a/hack/jenkins/minikube_cross_build_and_upload.sh
+++ b/hack/jenkins/minikube_cross_build_and_upload.sh
@@ -48,7 +48,16 @@ make -j 16 \
   out/docker-machine-driver-kvm2_$(make deb_version_base).deb \
 && failed=$? || failed=$?
 
-"out/minikube-$(go env GOOS)-$(go env GOARCH)" version
+BUILT_VERSION=$("out/minikube-$(go env GOOS)-$(go env GOARCH)" version)
+echo ${BUILT_VERSION}
+
+COMMIT=$(echo ${BUILT_VERSION} | grep 'commit:' | awk '{print $2}')
+if (echo ${COMMIT} | grep -q dirty); then
+  echo "'minikube version' reports dirty commit: ${COMMIT}"
+  exit 1
+fi
+
+
 
 gsutil cp "gs://${bucket}/logs/index.html" \
   "gs://${bucket}/logs/${ghprbPullId}/index.html"

--- a/hack/jenkins/release_build_and_upload.sh
+++ b/hack/jenkins/release_build_and_upload.sh
@@ -55,6 +55,16 @@ env BUILD_IN_DOCKER=y \
   "out/docker-machine-driver-kvm2_${DEB_VERSION}-0_amd64.deb" \
   "out/docker-machine-driver-kvm2-${RPM_VERSION}-0.x86_64.rpm"
 
+# check if 'commit: <commit-id>' line contains '-dirty' commit suffix
+BUILT_VERSION=$("out/minikube-$(go env GOOS)-$(go env GOARCH)" version)
+echo ${BUILT_VERSION}
+
+COMMIT=$(echo ${BUILT_VERSION} | grep 'commit:' | awk '{print $2}')
+if (echo ${COMMIT} | grep -q dirty); then
+  echo "'minikube version' reports dirty commit: ${COMMIT}"
+  exit 1
+fi
+
 # Don't upload temporary copies, avoid unused duplicate files in the release storage
 rm -f out/minikube-linux-x86_64
 rm -f out/minikube-linux-aarch64


### PR DESCRIPTION
To avoid issues like https://github.com/kubernetes/minikube/issues/10684

This PR adds a check for both release and PR jenkins jobs to verify, that minikube binary does not not contain 'dirty' git revision