### PR TITLE
Remove WSLENV empty check from IsMicrosoftWSL

### DIFF
--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -174,7 +174,7 @@ func NeedsPortForward(name string) bool {
 // checking for WSL env var based on this https://github.com/microsoft/WSL/issues/423#issuecomment-608237689
 // also based on https://github.com/microsoft/vscode/blob/90a39ba0d49d75e9a4d7e62a6121ad946ecebc58/resources/win32/bin/code.sh#L24
 func IsMicrosoftWSL() bool {
-	return os.Getenv("WSL_DISTRO_NAME") != "" || os.Getenv("WSLPATH") != "" || os.Getenv("WSLENV") != ""
+	return os.Getenv("WSL_DISTRO_NAME") != "" || os.Getenv("WSLPATH") != ""
 }
 
 // HasResourceLimits returns true if driver can set resource limits such as memory size or CPU count.


### PR DESCRIPTION
Closes #10689

Removed WSLENV empty check from IsMicrosoftWSL due to Windows Terminal setting the variable outside of WSL.

https://github.com/kubernetes/minikube/pull/10711#issuecomment-790207680
> We have code that tries to detect if we're trying to run a Windows executable within a WSL shell, which should be running a Linux binary. The most reliable way to do that is to check environment variables that WSL sets. Unfortunately, one of the 3 variables we picked (WSLENV) is set by Windows Terminal, outside of WSL, as a way of carrying data across connections. This is causing some Windows users to not be able to use minikube in a valid config.