### PR TITLE
kvm: provide solution if user doesn't belong to libvirt group

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -746,6 +746,11 @@ func validateDriver(ds registry.DriverState, existing *config.ClusterConfig) {
 		return
 	}
 
+	r := reason.MatchKnownIssue(reason.Kind{}, st.Error, runtime.GOOS)
+	if r.ID != "" {
+		exitIfNotForced(*r, st.Error.Error())
+	}
+
 	if !st.Installed {
 		exit.Message(reason.Kind{
 			ID:       fmt.Sprintf("PROVIDER_%s_NOT_FOUND", strings.ToUpper(name)),

--- a/pkg/minikube/reason/known_issues.go
+++ b/pkg/minikube/reason/known_issues.go
@@ -365,6 +365,18 @@ var providerIssues = []match{
 	// KVM hypervisor
 	{
 		Kind: Kind{
+			ID:       "PR_KVM_USER_PERMISSION",
+			ExitCode: ExProviderPermission,
+			Style:    style.NotAllowed,
+			Advice:   "Ensure that you are a member of the appropriate libvirt group (remember to relogin for group changes to take effect!)",
+			URL:      "https://minikube.sigs.k8s.io/docs/reference/drivers/kvm2/",
+			Issues:   []int{5617, 10070},
+		},
+		Regexp: re(`libvirt group membership check failed`),
+		GOOS:   []string{"linux"},
+	},
+	{
+		Kind: Kind{
 			ID:       "PR_KVM_CAPABILITIES",
 			ExitCode: ExProviderUnavailable,
 			Advice:   "Your host does not support KVM virtualization. Ensure that qemu-kvm is installed, and run 'virt-host-validate' to debug the problem",


### PR DESCRIPTION
fixes #5617
fixes #10070

for kvm driver, as described in original issues, if user does not belong to libvirt group, we fail with a generic confusing message
here we check that and provide a more descriptive solution message if not

### example (after)
```
❯ id
uid=1000(prezha) gid=100(users) groups=100(users),459(docker)
```
```
❯ minikube start --driver=kvm2
😄  minikube v1.18.0 on Opensuse-Tumbleweed
✨  Using the kvm2 driver based on user configuration

🚫  Exiting due to PR_KVM_USER_PERMISSION: libvirt group membership check failed:
user is not a member of the appropriate libvirt group
💡  Suggestion: Ensure that you are a member of the appropriate libvirt group (remember to relogin for group changes to take effect!)
📘  Documentation: https://minikube.sigs.k8s.io/docs/reference/drivers/kvm2/
🍿  Related issues:
    ▪ https://github.com/kubernetes/minikube/issues/5617
    ▪ https://github.com/kubernetes/minikube/issues/10070
```

```
❯ minikube start --driver=kvm2 --alsologtostderr -v=9
I0304 01:28:48.201151    1629 out.go:239] Setting OutFile to fd 1 ...
I0304 01:28:48.201206    1629 out.go:291] isatty.IsTerminal(1) = true
I0304 01:28:48.201211    1629 out.go:252] Setting ErrFile to fd 2...
I0304 01:28:48.201215    1629 out.go:291] isatty.IsTerminal(2) = true
I0304 01:28:48.201284    1629 root.go:308] Updating PATH: /home/prezha/.minikube/bin
I0304 01:28:48.201437    1629 out.go:246] Setting JSON to false
I0304 01:28:48.225822    1629 start.go:108] hostinfo: {"hostname":"codex.triplepoint.tech","uptime":7886,"bootTime":1614813443,"procs":416,"os":"linux","platform":"opensuse-tumbleweed","platformFamily":"","platformVersion":"","kernelVersion":"5.10.16-1-default","kernelArch":"x86_64","virtualizationSystem":"kvm","virtualizationRole":"host","hostId":"8fbb1ced-553b-443c-a3a1-fd6724e8ce90"}
I0304 01:28:48.226056    1629 start.go:118] virtualization: kvm host
I0304 01:28:48.237151    1629 out.go:129] 😄  minikube v1.18.0 on Opensuse-Tumbleweed
😄  minikube v1.18.0 on Opensuse-Tumbleweed
I0304 01:28:48.237467    1629 notify.go:126] Checking for updates...
I0304 01:28:48.237777    1629 driver.go:323] Setting default libvirt URI to qemu:///system
I0304 01:28:48.243203    1629 out.go:129] ✨  Using the kvm2 driver based on user configuration
✨  Using the kvm2 driver based on user configuration
I0304 01:28:48.243272    1629 start.go:276] selected driver: kvm2
I0304 01:28:48.243297    1629 start.go:718] validating driver "kvm2" against <nil>
I0304 01:28:48.243335    1629 start.go:729] status for kvm2: {Installed:true Healthy:false Running:true NeedsImprovement:false Error:libvirt group membership check failed:
user is not a member of the appropriate libvirt group Reason:PR_KVM_USER_PERMISSION Fix:Check that libvirtd is properly installed and that you are a member of the appropriate libvirt group (remember to relogin for group changes to take effect!) Doc:https://minikube.sigs.k8s.io/docs/reference/drivers/kvm2/}
I0304 01:28:48.246662    1629 out.go:129]

W0304 01:28:48.246878    1629 out.go:191] 🚫  Exiting due to PR_KVM_USER_PERMISSION: libvirt group membership check failed:
user is not a member of the appropriate libvirt group
🚫  Exiting due to PR_KVM_USER_PERMISSION: libvirt group membership check failed:
user is not a member of the appropriate libvirt group
W0304 01:28:48.247126    1629 out.go:191] 💡  Suggestion: Ensure that you are a member of the appropriate libvirt group (remember to relogin for group changes to take effect!)
💡  Suggestion: Ensure that you are a member of the appropriate libvirt group (remember to relogin for group changes to take effect!)
W0304 01:28:48.247252    1629 out.go:191] 📘  Documentation: https://minikube.sigs.k8s.io/docs/reference/drivers/kvm2/
📘  Documentation: https://minikube.sigs.k8s.io/docs/reference/drivers/kvm2/
W0304 01:28:48.247350    1629 out.go:191] 🍿  Related issues:
🍿  Related issues:
W0304 01:28:48.247497    1629 out.go:191]     ▪ https://github.com/kubernetes/minikube/issues/5617
    ▪ https://github.com/kubernetes/minikube/issues/5617
W0304 01:28:48.247615    1629 out.go:191]     ▪ https://github.com/kubernetes/minikube/issues/10070
    ▪ https://github.com/kubernetes/minikube/issues/10070
I0304 01:28:48.253543    1629 out.go:129]
```