### PR TITLE
The cluster doesn't have to be healthy for kubectl

### DIFF
--- a/cmd/minikube/cmd/kubectl.go
+++ b/cmd/minikube/cmd/kubectl.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
+	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
-	"k8s.io/minikube/pkg/minikube/mustload"
 	"k8s.io/minikube/pkg/minikube/node"
 	"k8s.io/minikube/pkg/minikube/out"
 )
@@ -40,9 +40,12 @@ Examples:
 minikube kubectl -- --help
 minikube kubectl -- get pods --namespace kube-system`,
 	Run: func(cmd *cobra.Command, args []string) {
-		_, cc := mustload.Partial(ClusterFlagValue())
+		cc, err := config.Load(ClusterFlagValue())
 
-		version := cc.KubernetesConfig.KubernetesVersion
+		version := constants.DefaultKubernetesVersion
+		if err == nil {
+			version = cc.KubernetesConfig.KubernetesVersion
+		}
 
 		cluster := []string{"--cluster", ClusterFlagValue()}
 		args = append(args, cluster...)

--- a/cmd/minikube/cmd/kubectl.go
+++ b/cmd/minikube/cmd/kubectl.go
@@ -40,9 +40,9 @@ Examples:
 minikube kubectl -- --help
 minikube kubectl -- get pods --namespace kube-system`,
 	Run: func(cmd *cobra.Command, args []string) {
-		co := mustload.Healthy(ClusterFlagValue())
+		_, cc := mustload.Partial(ClusterFlagValue())
 
-		version := co.Config.KubernetesConfig.KubernetesVersion
+		version := cc.KubernetesConfig.KubernetesVersion
 
 		cluster := []string{"--cluster", ClusterFlagValue()}
 		args = append(args, cluster...)


### PR DESCRIPTION
We only want to match the kubectl version with it

Closes #10717


BEFORE

```console
$ kubectl version --client --output=json
🤷  The control plane node must be running for this command
👉  To start a cluster, run: "minikube start"
```

AFTER

```console
$ kubectl version --client --output=json
{
  "clientVersion": {
    "major": "1",
    "minor": "20",
    "gitVersion": "v1.20.2",
    "gitCommit": "faecb196815e248d3ecfb03c680a4507229c2a56",
    "gitTreeState": "clean",
    "buildDate": "2021-01-13T13:28:09Z",
    "goVersion": "go1.15.5",
    "compiler": "gc",
    "platform": "linux/amd64"
  }
}
```