### PR TITLE
Need to exit if unable to cache kubectl

### DIFF
--- a/cmd/minikube/cmd/kubectl.go
+++ b/cmd/minikube/cmd/kubectl.go
@@ -50,6 +50,7 @@ minikube kubectl -- get pods --namespace kube-system`,
 		c, err := KubectlCommand(version, args...)
 		if err != nil {
 			out.ErrLn("Error caching kubectl: %v", err)
+			os.Exit(1)
 		}
 
 		klog.Infof("Running %s %v", c.Path, args)


### PR DESCRIPTION
Avoid crashing, should there be any issue with downloading and caching `kubectl`:

```
Error caching kubectl: download failed: https://storage.googleapis.com/kubernetes-release/release/v1.20.2/bin/linux/amd64/kubectl?checksum=file:https://storage.googleapis.com/kubernetes-release/release/v1.20.2/bin/linux/amd64/kubectl.sha256: getter: &{Ctx:context.Background Src:https://storage.googleapis.com/kubernetes-release/release/v1.20.2/bin/linux/amd64/kubectl?checksum=file:https://storage.googleapis.com/kubernetes-release/release/v1.20.2/bin/linux/amd64/kubectl.sha256 Dst:/root/.minikube/cache/linux/v1.20.2/kubectl.download Pwd: Mode:2 Umask:---------- Detectors:[0x30e2d90 0x30e2d90 0x30e2d90 0x30e2d90 0x30e2d90 0x30e2d90 0x30e2d90] Decompressors:map[bz2:0x30e2d90 gz:0x30e2d90 tar.bz2:0x30e2d90 tar.gz:0x30e2d90 tar.xz:0x30e2d90 tbz2:0x30e2d90 tgz:0x30e2d90 txz:0x30e2d90 xz:0x30e2d90 zip:0x30e2d90] Getters:map[file:0xc000b18c80 http:0xc000b10640 https:0xc000b10660] Dir:false ProgressListener:0x30a6200 Options:[0x1193860]}: invalid checksum: Error downloading checksum file: Get "https://storage.googleapis.com/kubernetes-release/release/v1.20.2/bin/linux/amd64/kubectl.sha256": x509: certificate signed by unknown authority
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1b59910]
```