### PR TITLE
Correct spelling in --insecure-registry validation error message

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1209,7 +1209,7 @@ func validateInsecureRegistry() {
 				i := strings.Index(addr, "//")
 				addr = addr[i+2:]
 			} else if strings.Contains(addr, "://") || strings.HasSuffix(addr, ":") {
-				exit.Message(reason.Usage, "Sorry, the address provided with the --insecure-registry flag is invalid: {{.addr}}. Expected formtas are: <ip>[:<port>], <hostname>[:<port>] or <network>/<netmask>", out.V{"addr": addr})
+				exit.Message(reason.Usage, "Sorry, the address provided with the --insecure-registry flag is invalid: {{.addr}}. Expected formats are: <ip>[:<port>], <hostname>[:<port>] or <network>/<netmask>", out.V{"addr": addr})
 			}
 			hostnameOrIP, port, err := net.SplitHostPort(addr)
 			if err != nil {
@@ -1221,15 +1221,15 @@ func validateInsecureRegistry() {
 			}
 			if !hostRe.MatchString(hostnameOrIP) && net.ParseIP(hostnameOrIP) == nil {
 				//		fmt.Printf("This is not hostname or ip %s", hostnameOrIP)
-				exit.Message(reason.Usage, "Sorry, the address provided with the --insecure-registry flag is invalid: {{.addr}}. Expected formtas are: <ip>[:<port>], <hostname>[:<port>] or <network>/<netmask>", out.V{"addr": addr})
+				exit.Message(reason.Usage, "Sorry, the address provided with the --insecure-registry flag is invalid: {{.addr}}. Expected formats are: <ip>[:<port>], <hostname>[:<port>] or <network>/<netmask>", out.V{"addr": addr})
 			}
 			if port != "" {
 				v, err := strconv.Atoi(port)
 				if err != nil {
-					exit.Message(reason.Usage, "Sorry, the address provided with the --insecure-registry flag is invalid: {{.addr}}. Expected formtas are: <ip>[:<port>], <hostname>[:<port>] or <network>/<netmask>", out.V{"addr": addr})
+					exit.Message(reason.Usage, "Sorry, the address provided with the --insecure-registry flag is invalid: {{.addr}}. Expected formats are: <ip>[:<port>], <hostname>[:<port>] or <network>/<netmask>", out.V{"addr": addr})
 				}
 				if v < 0 || v > 65535 {
-					exit.Message(reason.Usage, "Sorry, the address provided with the --insecure-registry flag is invalid: {{.addr}}. Expected formtas are: <ip>[:<port>], <hostname>[:<port>] or <network>/<netmask>", out.V{"addr": addr})
+					exit.Message(reason.Usage, "Sorry, the address provided with the --insecure-registry flag is invalid: {{.addr}}. Expected formats are: <ip>[:<port>], <hostname>[:<port>] or <network>/<netmask>", out.V{"addr": addr})
 				}
 			}
 		}

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -420,7 +420,7 @@
 	"Sorry, Kubernetes {{.version}} is not supported by this release of minikube": "죄송합니다, 쿠버네티스 {{.version}} 는 해당 minikube 버전에서 지원하지 않습니다",
 	"Sorry, completion support is not yet implemented for {{.name}}": "",
 	"Sorry, please set the --output flag to one of the following valid options: [text,json]": "",
-	"Sorry, the address provided with the --insecure-registry flag is invalid: {{.addr}}. Expected formtas are: \u003cip\u003e:\u003cport\u003e, \u003chostname\u003e:\u003cport\u003e or \u003cnetwork\u003e/\u003cnetmask\u003e": "",
+	"Sorry, the address provided with the --insecure-registry flag is invalid: {{.addr}}. Expected formats are: \u003cip\u003e:\u003cport\u003e, \u003chostname\u003e:\u003cport\u003e or \u003cnetwork\u003e/\u003cnetmask\u003e": "",
 	"Sorry, the kubeadm.{{.parameter_name}} parameter is currently not supported by --extra-config": "",
 	"Sorry, the url provided with the --registry-mirror flag is invalid: {{.url}}": "",
 	"Sorry, {{.driver}} does not allow mounts to be changed after container creation (previous mount: '{{.old}}', new mount: '{{.new}})'": "",

--- a/translations/strings.txt
+++ b/translations/strings.txt
@@ -370,7 +370,7 @@
 	"Sorry, Kubernetes {{.k8sVersion}} requires conntrack to be installed in root's path": "",
 	"Sorry, completion support is not yet implemented for {{.name}}": "",
 	"Sorry, please set the --output flag to one of the following valid options: [text,json]": "",
-	"Sorry, the address provided with the --insecure-registry flag is invalid: {{.addr}}. Expected formtas are: \u003cip\u003e:\u003cport\u003e, \u003chostname\u003e:\u003cport\u003e or \u003cnetwork\u003e/\u003cnetmask\u003e": "",
+	"Sorry, the address provided with the --insecure-registry flag is invalid: {{.addr}}. Expected formats are: \u003cip\u003e:\u003cport\u003e, \u003chostname\u003e:\u003cport\u003e or \u003cnetwork\u003e/\u003cnetmask\u003e": "",
 	"Sorry, the kubeadm.{{.parameter_name}} parameter is currently not supported by --extra-config": "",
 	"Sorry, the url provided with the --registry-mirror flag is invalid: {{.url}}": "",
 	"Sorry, {{.driver}} does not allow mounts to be changed after container creation (previous mount: '{{.old}}', new mount: '{{.new}})'": "",


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
This will correct the message
> Sorry, the address provided with the --insecure-registry flag is invalid: {{.addr}}. Expected form**tas** are: <ip>[:<port>], <hostname>[:<port>] or <network>/<netmask>

to be

> Sorry, the address provided with the --insecure-registry flag is invalid: {{.addr}}. Expected form**ats** are: <ip>[:<port>], <hostname>[:<port>] or <network>/<netmask>