### PR TITLE
add validateImageRepository func for validates --image-repository args

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1088,6 +1088,10 @@ func validateFlags(cmd *cobra.Command, drvName string) {
 		validateListenAddress(viper.GetString(listenAddress))
 	}
 
+	if cmd.Flags().Changed(imageRepository) {
+		validateImageRepository(viper.GetString(imageRepository))
+	}
+
 	if cmd.Flags().Changed(containerRuntime) {
 		runtime := strings.ToLower(viper.GetString(containerRuntime))
 
@@ -1205,6 +1209,18 @@ func validateRegistryMirror() {
 			}
 
 		}
+	}
+}
+
+// This function validates if the --image-repository
+// args match the format of registry.cn-hangzhou.aliyuncs.com/google_containers
+func validateImageRepository(imagRepo string) {
+	URL, err := url.Parse(imagRepo)
+	if err != nil {
+		klog.Errorln("Error Parsing URL: ", err)
+	}
+	if URL.Scheme != "" || strings.HasSuffix(URL.Path, "/") {
+		exit.Message(reason.Usage, "Sorry, the url provided with the --image-repository flag is invalid: {{.url}}", out.V{"url": imagRepo})
 	}
 }
 

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -311,3 +311,46 @@ func TestBaseImageFlagDriverCombo(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateImageRepository(t *testing.T) {
+	var tests = []struct {
+		imageRepository      string
+		vaildImageRepository string
+	}{
+		{
+			imageRepository:      "auto",
+			vaildImageRepository: "auto",
+		},
+		{
+			imageRepository:      "http://registry.test.com/google_containers/",
+			vaildImageRepository: "registry.test.com/google_containers",
+		},
+		{
+			imageRepository:      "https://registry.test.com/google_containers/",
+			vaildImageRepository: "registry.test.com/google_containers",
+		},
+		{
+			imageRepository:      "registry.test.com/google_containers/",
+			vaildImageRepository: "registry.test.com/google_containers",
+		},
+		{
+			imageRepository:      "http://registry.test.com/google_containers",
+			vaildImageRepository: "registry.test.com/google_containers",
+		},
+		{
+			imageRepository:      "https://registry.test.com/google_containers",
+			vaildImageRepository: "registry.test.com/google_containers",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.imageRepository, func(t *testing.T) {
+			vaildImageRepository := validateImageRepository(test.imageRepository)
+			if vaildImageRepository != test.vaildImageRepository {
+				t.Errorf("validateImageRepository(imageRepo=%v): got %v, expected %v",
+					test.imageRepository, vaildImageRepository, test.vaildImageRepository)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
add validateImageRepository func for validates --image-repository args
This PR fix two error:
1. when --image-repository endswith "/", k8s can't start, because static pod image contain "//"
2. when --image-repository startswieh "http" or "https", it will think of http or https as a domain name.

`error msg:`
E0309 13:57:24.340121   73314 cache.go:63] save image to file "http:/harbor.corp.qunar.com/google_images/dashboard:v2.1.0" -> "/home/minikube/.minikube/cache/images/http_/harbor.corp.qunar.com/google_images/dashboard_v2.1.0" failed: nil image for http:/harbor.corp.qunar.com/google_images/dashboard:v2.1.0: Get "https://http/v2/": dial tcp: lookup http on 192.168.101.58:53: server misbehaving
