### PR TITLE
Silent output when talking to a shell

### DIFF
--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -260,6 +260,11 @@ var dockerEnvCmd = &cobra.Command{
 			return
 		}
 
+		if !out.IsTerminal(os.Stdout) {
+			out.SetSilent(true)
+			exit.SetShell(true)
+		}
+
 		cname := ClusterFlagValue()
 		co := mustload.Running(cname)
 		driverName := co.CP.Host.DriverName

--- a/cmd/minikube/cmd/podman-env.go
+++ b/cmd/minikube/cmd/podman-env.go
@@ -153,6 +153,11 @@ var podmanEnvCmd = &cobra.Command{
 			return
 		}
 
+		if !out.IsTerminal(os.Stdout) {
+			out.SetSilent(true)
+			exit.SetShell(true)
+		}
+
 		cname := ClusterFlagValue()
 		co := mustload.Running(cname)
 		driverName := co.CP.Host.DriverName

--- a/pkg/minikube/exit/exit.go
+++ b/pkg/minikube/exit/exit.go
@@ -18,6 +18,7 @@ limitations under the License.
 package exit
 
 import (
+	"fmt"
 	"os"
 	"runtime"
 
@@ -26,6 +27,15 @@ import (
 	"k8s.io/minikube/pkg/minikube/reason"
 	"k8s.io/minikube/pkg/minikube/style"
 )
+
+var (
+	shell bool
+)
+
+// SetShell configures if we are doing a shell configuration or not
+func SetShell(s bool) {
+	shell = s
+}
 
 // Message outputs a templated message and exits without interpretation
 func Message(r reason.Kind, format string, args ...out.V) {
@@ -54,7 +64,15 @@ func Message(r reason.Kind, format string, args ...out.V) {
 		out.Error(r, "Exiting due to {{.fatal_code}}: {{.fatal_msg}}", args...)
 	}
 
-	os.Exit(r.ExitCode)
+	Code(r.ExitCode)
+}
+
+// Code will exit with a code
+func Code(code int) {
+	if shell {
+		out.Output(os.Stdout, fmt.Sprintf("false exit code %d\n", code))
+	}
+	os.Exit(code)
 }
 
 // Advice is syntactic sugar to output a message with dynamically generated advice

--- a/pkg/minikube/mustload/mustload.go
+++ b/pkg/minikube/mustload/mustload.go
@@ -20,7 +20,6 @@ package mustload
 import (
 	"fmt"
 	"net"
-	"os"
 
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/host"
@@ -175,5 +174,5 @@ func ExampleCmd(cname string, action string) string {
 func exitTip(action string, profile string, code int) {
 	command := ExampleCmd(profile, action)
 	out.Styled(style.Workaround, `To start a cluster, run: "{{.command}}"`, out.V{"command": command})
-	os.Exit(code)
+	exit.Code(code)
 }

--- a/pkg/minikube/out/out.go
+++ b/pkg/minikube/out/out.go
@@ -243,10 +243,7 @@ func FailureT(format string, a ...V) {
 
 // IsTerminal returns whether we have a terminal or not
 func IsTerminal(w fdWriter) bool {
-	fd := w.Fd()
-	isT := isatty.IsTerminal(fd)
-	klog.Infof("isatty.IsTerminal(%d) = %v\n", fd, isT)
-	return isT
+	return isatty.IsTerminal(w.Fd())
 }
 
 // SetSilent configures whether output is disabled or not
@@ -259,7 +256,7 @@ func SetSilent(q bool) {
 func SetOutFile(w fdWriter) {
 	klog.Infof("Setting OutFile to fd %d ...", w.Fd())
 	outFile = w
-	useColor = wantsColor(w.Fd())
+	useColor = wantsColor(w)
 }
 
 // SetJSON configures printing to STDOUT in JSON
@@ -272,11 +269,11 @@ func SetJSON(j bool) {
 func SetErrFile(w fdWriter) {
 	klog.Infof("Setting ErrFile to fd %d...", w.Fd())
 	errFile = w
-	useColor = wantsColor(w.Fd())
+	useColor = wantsColor(w)
 }
 
 // wantsColor determines if the user might want colorized output.
-func wantsColor(fd uintptr) bool {
+func wantsColor(w fdWriter) bool {
 	// First process the environment: we allow users to force colors on or off.
 	//
 	// MINIKUBE_IN_STYLE=[1, T, true, TRUE]
@@ -308,8 +305,8 @@ func wantsColor(fd uintptr) bool {
 		return false
 	}
 
-	isT := isatty.IsTerminal(fd)
-	klog.Infof("isatty.IsTerminal(%d) = %v\n", fd, isT)
+	isT := IsTerminal(w)
+	klog.Infof("isatty.IsTerminal(%d) = %v\n", w.Fd(), isT)
 	return isT
 }
 


### PR DESCRIPTION
If the output is not a terminal, then assume that we are running
docker-env or podman-env under "eval" or similar shell construct.

So don't output all the interactive information, but only return
the actual exit code for some further troubleshooting (perhaps).

Closes #10761

----

BEFORE

```console
$ eval $(minikube docker-env)
🤷: command not found
$ minikube docker-env
🤷  The control plane node must be running for this command
👉  To start a cluster, run: "minikube start"
```
or, even worse:
```console
$ export MINIKUBE_IN_STYLE=false
$ eval $(minikube docker-env)
CHANGELOG.md: command not found
$ minikube docker-env
* The control plane node must be running for this command
  - To start a cluster, run: "minikube start"
```


AFTER

```
$ eval $(minikube docker-env)
$
$ minikube docker-env
🤷  The control plane node must be running for this command
👉  To start a cluster, run: "minikube start"
```