### PR TITLE
Cleanup ssh tunnels on cancel

### DIFF
--- a/pkg/minikube/tunnel/kic/ssh_tunnel.go
+++ b/pkg/minikube/tunnel/kic/ssh_tunnel.go
@@ -59,6 +59,7 @@ func (t *SSHTunnel) Start() error {
 	for {
 		select {
 		case <-t.ctx.Done():
+			defer t.stopAllConnections()
 			_, err := t.LoadBalancerEmulator.Cleanup()
 			if err != nil {
 				klog.Errorf("error cleaning up: %v", err)
@@ -128,6 +129,15 @@ func (t *SSHTunnel) stopMarkedConnections() {
 		}
 		delete(t.conns, sshConn.name)
 		delete(t.connsToStop, sshConn.name)
+	}
+}
+
+func (t *SSHTunnel) stopAllConnections() {
+	for _, conn := range t.conns {
+		err := conn.stop()
+		if err != nil {
+			klog.Errorf("error stopping ssh tunnel: %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
**Details**
In **pkg/minikube/tunnel/kic/ssh_tunnel.go** the interrupt signal is caught and it stops the LoadBalancerEmulator. However, it assumes that the interrupt will also propagate to the children ssh tunnels, which are running in a goroutine inside `startConnections`.
The interrupt, however, kills the goroutine and the blocking call which waits for the child process to finish. This leaves the ssh tunnels dangling.
On the other hand, if `CTRL + C` is sent on the same terminal as `minikube tunnel` and the clean-up routine included killing all ssh tunnels, the OS would error with "process already finished".

This leads to accumulation of processes and is likely to happen. Since `minikube tunnel` is a blocking command, users will tend to detach it from the terminal and kill it with a `SIGINT` (as proposed in https://github.com/kubernetes/minikube/issues/3647).

**Approaches**
There are two proposed approaches. This PR takes the approach of having the tunnel know if is running or not. The second approach is to have the parent of all connections managed and know which processes should be killed.

The first approach, proposed with this PR, also addresses https://github.com/kubernetes/minikube/issues/8511, by letting the process owner hold the knowledge if the process is running or not. Since the ssh tunnels are started inside `startAndWait()` on **pkg/minikube/tunnel/kic/ssh_conn.go**, and a blocking call to `Wait()` is made, the owner can know when the process is started, finished, or killed.

The second approach is more oriented towards the cleaning up of the ssh tunnels, and isolates changes to only **pkg/minikube/tunnel/kic/ssh_tunnel.go**. However it relies on `sync`. The second approach can be seen here: https://github.com/m-lima/minikube/tree/issue/10752-managed-kill

**Output**
With this PR, users will be notified of connections being closed (as opposed to the silent death that happens now). E.g:
```
$ minikube tunnel
🏃  Starting tunnel for service serviceA.
🏃  Starting tunnel for service serviceB.
🏃  Starting tunnel for service serviceC.
^C✋  Tunnel for service serviceB stopped.
✋  Tunnel for service serviceA stopped.
✋  Tunnel for service serviceC stopped.
```

Also, when detaching from the terminal, all ssh tunnels will be reaped, also outputting to the terminal (if not redirected by the user). E.g:
```
$ minikube tunnel
🏃  Starting tunnel for service serviceA.
🏃  Starting tunnel for service serviceB.
🏃  Starting tunnel for service serviceC.
```
On another terminal:
```
kill -INT <PID>
```
Main terminal:
```
✋  Stopping tunnel for service serviceA.
✋  Stopping tunnel for service serviceB.
✋  Stopping tunnel for service serviceC.
```

fixes #10752 
