### PR TITLE
Enable portmap for the default cni bridge

### DIFF
--- a/pkg/minikube/cni/bridge.go
+++ b/pkg/minikube/cni/bridge.go
@@ -33,17 +33,27 @@ var bridgeConf = template.Must(template.New("bridge").Parse(`
 {
   "cniVersion": "0.3.1",
   "name": "bridge",
-  "type": "bridge",
-  "bridge": "bridge",
-  "addIf": "true",
-  "isDefaultGateway": true,
-  "forceAddress": false,
-  "ipMasq": true,
-  "hairpinMode": true,
-  "ipam": {
-      "type": "host-local",
-      "subnet": "{{.PodCIDR}}"
-  }
+  "plugins": [
+    {
+      "type": "bridge",
+      "bridge": "bridge",
+      "addIf": "true",
+      "isDefaultGateway": true,
+      "forceAddress": false,
+      "ipMasq": true,
+      "hairpinMode": true,
+      "ipam": {
+          "type": "host-local",
+          "subnet": "{{.PodCIDR}}"
+      }
+    },
+    {
+      "type": "portmap",
+      "capabilities": {
+          "portMappings": true
+      }
+    }
+  ]
 }
 `))
 
@@ -65,7 +75,7 @@ func (c Bridge) netconf() (assets.CopyableFile, error) {
 		return nil, err
 	}
 
-	return assets.NewMemoryAssetTarget(b.Bytes(), "/etc/cni/net.d/1-k8s.conf", "0644"), nil
+	return assets.NewMemoryAssetTarget(b.Bytes(), "/etc/cni/net.d/1-k8s.conflist", "0644"), nil
 }
 
 // Apply enables the CNI


### PR DESCRIPTION
Otherwise the registry addon will not work, since it uses
hostPort 5000 (which in turn requires port mapping enabled)

Closes #10778