### PR TITLE
minikube kubectl: The --cluster flags should be prepended

### DIFF
--- a/cmd/minikube/cmd/kubectl.go
+++ b/cmd/minikube/cmd/kubectl.go
@@ -48,7 +48,7 @@ minikube kubectl -- get pods --namespace kube-system`,
 		}
 
 		cluster := []string{"--cluster", ClusterFlagValue()}
-		args = append(args, cluster...)
+		args = append(cluster, args...)
 
 		c, err := KubectlCommand(version, args...)
 		if err != nil {


### PR DESCRIPTION
Not appended, because it will break exec

Closes #10791