### PR TITLE
Removed "use {port} instead of default 5000" message when disabling registry addon

### DIFF
--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -198,7 +198,9 @@ https://github.com/kubernetes/minikube/issues/7332`, out.V{"driver_name": cc.Dri
 			if err != nil {
 				return errors.Wrap(err, "registry port")
 			}
-			out.Styled(style.Tip, `Registry addon on with {{.driver}} uses {{.port}} please use that instead of default 5000`, out.V{"driver": cc.Driver, "port": port})
+			if enable {
+				out.Styled(style.Tip, `Registry addon on with {{.driver}} uses {{.port}} please use that instead of default 5000`, out.V{"driver": cc.Driver, "port": port})
+			}
 			out.Styled(style.Documentation, `For more information see: https://minikube.sigs.k8s.io/docs/drivers/{{.driver}}`, out.V{"driver": cc.Driver})
 		}
 	}


### PR DESCRIPTION
Fixes #10789

Added `if statement` to check whether registry addon is enabled before outputting 

> Registry addon on with {driver} uses {port} please use that instead of default 5000
