### PR TITLE
ui: break down usage for no profile found

### DIFF
--- a/cmd/minikube/cmd/config/profile_list.go
+++ b/cmd/minikube/cmd/config/profile_list.go
@@ -77,7 +77,7 @@ func printProfilesTable() {
 	}
 
 	if len(validProfiles) == 0 {
-		exit.Message(reason.Usage, "No minikube profile was found. You can create one using `minikube start`.")
+		exit.Message(reason.UsageNoProfileRunning, "No minikube profile was found. ")
 	}
 
 	updateProfilesStatus(validProfiles)

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -72,7 +72,12 @@ func (k *Kind) IssueURLs() []string {
 
 // Sections are ordered roughly by stack dependencies
 var (
-	Usage       = Kind{ID: "MK_USAGE", ExitCode: ExProgramUsage}
+	Usage                 = Kind{ID: "MK_USAGE", ExitCode: ExProgramUsage}
+	UsageNoProfileRunning = Kind{ID: "MK_USAGE_NO_PROFILE", ExitCode: ExProgramUsage,
+		Advice: `You can create one using 'minikube start'.
+		`,
+		Style: style.Caching,
+	}
 	Interrupted = Kind{ID: "MK_INTERRUPTED", ExitCode: ExProgramConflict}
 
 	WrongBinaryWSL = Kind{ID: "MK_WRONG_BINARY_WSL", ExitCode: ExProgramUnsupported}


### PR DESCRIPTION
for better end user metric gathering breaking down the exit code words

creating new Exit Code Word MK_USAGE_NO_PROFILE and better icon (rather than a scary one that looks like an internal error)
### before
```
$ minikube profile list

❌  Exiting due to MK_USAGE: No minikube profile was found. You can create one using `minikube start`.
```

### after
```
🤹  Exiting due to MK_USAGE_NO_PROFILE: No minikube profile was found. 
💡  Suggestion: 

    You can create one using 'minikube start'.
```