### PR TITLE
update prune instructions to not prune minikube itself

### DIFF
--- a/pkg/drivers/kic/oci/cli_runner.go
+++ b/pkg/drivers/kic/oci/cli_runner.go
@@ -145,7 +145,7 @@ func runCmd(cmd *exec.Cmd, warnSlow ...bool) (*RunResult, error) {
 			warnLock.Unlock()
 
 			if !ok {
-				out.WarningT(`Executing this command "{{.command}}" took an unusually long time: {{.duration}}`, out.V{"command": rr.Command(), "duration": elapsed})
+				out.WarningT(`Executing "{{.command}}" took an unusually long time: {{.duration}}`, out.V{"command": rr.Command(), "duration": elapsed})
 				// Don't show any restarting hint, when running podman locally (on linux, with sudo). Only when having a service.
 				if cmd.Args[0] != "sudo" {
 					out.ErrT(style.Tip, `Restarting or pruning the {{.name}} service may improve performance.`, out.V{"name": cmd.Args[0]})

--- a/pkg/drivers/kic/oci/cli_runner.go
+++ b/pkg/drivers/kic/oci/cli_runner.go
@@ -145,11 +145,17 @@ func runCmd(cmd *exec.Cmd, warnSlow ...bool) (*RunResult, error) {
 			warnLock.Unlock()
 
 			if !ok {
-				out.WarningT(`Executing "{{.command}}" took an unusually long time: {{.duration}}`, out.V{"command": rr.Command(), "duration": elapsed})
+				out.WarningT(`Executing this command "{{.command}}" took an unusually long time: {{.duration}}`, out.V{"command": rr.Command(), "duration": elapsed})
 				// Don't show any restarting hint, when running podman locally (on linux, with sudo). Only when having a service.
 				if cmd.Args[0] != "sudo" {
-					out.ErrT(style.Tip, `Restarting the {{.name}} service may improve performance.`, out.V{"name": cmd.Args[0]})
+					out.ErrT(style.Tip, `Restarting or pruning the {{.name}} service may improve performance.`, out.V{"name": cmd.Args[0]})
+					out.Infof(`To prune run: $ docker system prune --filter="label!=created_by.minikube.sigs.k8s.io=true"`)
+					if runtime.GOOS != "linux" {
+						out.Infof(`To restart: Click Docker 🐳 in the system tray and then click "Restart Docker"`, out.V{"icon": style.Docker})
+					}
+
 				}
+
 			}
 		}
 

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -173,8 +173,9 @@ var (
 		ID:       "RSRC_DOCKER_STORAGE",
 		ExitCode: ExInsufficientStorage,
 		Advice: `Try one or more of the following to free up space on the device:
-	
-			1. Run "docker system prune" to remove unused Docker data (optionally with "-a")
+			1. Remove unused Docker data (optionally with "-a") 
+			Run:
+				$ docker system prune --filter="label!=created_by.minikube.sigs.k8s.io=true"
 			2. Increase the storage allocated to Docker for Desktop by clicking on:
 				Docker icon > Preferences > Resources > Disk Image Size
 			3. Run "minikube ssh -- docker system prune" if using the Docker container runtime`,

--- a/site/content/en/docs/drivers/docker.md
+++ b/site/content/en/docs/drivers/docker.md
@@ -15,7 +15,7 @@ The Docker driver allows you to install Kubernetes into an existing Docker insta
 
 - Cross platform (linux, macOS, Windows)
 - No hypervisor required when run on Linux
-- Experimental support for [WSL2](https://docs.microsoft.com/en-us/windows/wsl/wsl2-install) on Windows 10
+- Support for [WSL2](https://docs.microsoft.com/en-us/windows/wsl/wsl2-install) on Windows 10
 
 ## Known Issues
 
@@ -34,6 +34,14 @@ The Docker driver allows you to install Kubernetes into an existing Docker insta
 ## Troubleshooting
 
 [comment]: <> (this title is used in the docs links, don't change)
+
+### Prune docker to avoid performance downgrade in minikube
+ the following command will prune all on unused/stopped containers, volumes on your docker.
+ ```shell
+ docker system prune --filter="label!=created_by.minikube.sigs.k8s.io=true"
+   ```
+After pruning on MacOS or Windows consider restaring docker (Click Docker 🐳 in the system tray and then click "Restart Docker")
+
 
 ### Verify Docker container type is Linux
 


### PR DESCRIPTION
closes https://github.com/kubernetes/minikube/issues/10773

### Before this PR
```
$ mk start
😄  minikube v1.18.1 on Darwin 11.2.3
✨  Using the docker driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
❗  Executing "docker container inspect minikube --format={{.State.Status}}" took an unusually long time: 140.562388ms
💡  Restarting the docker service may improve performance.
🏃  Updating the running docker "minikube" container ...
🐳  Preparing Kubernetes v1.20.2 on Docker 20.10.3 ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v4
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by defaul
```


### After this PR
fix the suggestion not to prune minikube itself (if it is stopped)

```
😄  minikube v1.18.1 on Darwin 11.2.3
✨  Using the docker driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
❗  Executing "docker container inspect minikube --format={{.State.Status}}" took an unusually long time: 196.475601ms
💡  Restarting or pruning the docker service may improve performance.
    ▪ To prune run: $ docker system prune --filter="label!=created_by.minikube.sigs.k8s.io=true"
    ▪ To restart: Click Docker 🐳 in the system tray and then click "Restart Docker"
🔄  Restarting existing docker container for "minikube" ...
🐳  Preparing Kubernetes v1.20.2 on Docker 20.10.3 ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v4
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```