### PR TITLE
make sure path to logs directory exists

### DIFF
--- a/pkg/minikube/audit/logFile.go
+++ b/pkg/minikube/audit/logFile.go
@@ -19,7 +19,6 @@ package audit
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/minikube/out/register"
@@ -31,9 +30,6 @@ var currentLogFile *os.File
 // setLogFile sets the logPath and creates the log file if it doesn't exist.
 func setLogFile() error {
 	lp := localpath.AuditLog()
-	if err := os.MkdirAll(filepath.Dir(lp), 0755); err != nil {
-		return fmt.Errorf("unable to create directory: %w", err)
-	}
 	f, err := os.OpenFile(lp, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0644)
 	if err != nil {
 		return fmt.Errorf("unable to open %s: %v", lp, err)

--- a/pkg/minikube/audit/logFile.go
+++ b/pkg/minikube/audit/logFile.go
@@ -19,6 +19,7 @@ package audit
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/minikube/out/register"
@@ -30,6 +31,9 @@ var currentLogFile *os.File
 // setLogFile sets the logPath and creates the log file if it doesn't exist.
 func setLogFile() error {
 	lp := localpath.AuditLog()
+	if err := os.MkdirAll(filepath.Dir(lp), 0755); err != nil {
+		return fmt.Errorf("unable to create directory: %w", err)
+	}
 	f, err := os.OpenFile(lp, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0644)
 	if err != nil {
 		return fmt.Errorf("unable to open %s: %v", lp, err)

--- a/pkg/minikube/audit/logFile_test.go
+++ b/pkg/minikube/audit/logFile_test.go
@@ -20,12 +20,19 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
+
+	"k8s.io/minikube/pkg/minikube/localpath"
 )
 
 func TestLogFile(t *testing.T) {
 	t.Run("SetLogFile", func(t *testing.T) {
+		// make sure logs directory exists
+		if err := os.MkdirAll(filepath.Dir(localpath.AuditLog()), 0755); err != nil {
+			t.Fatalf("Error creating audit directory: %v", err)
+		}
 		if err := setLogFile(); err != nil {
 			t.Error(err)
 		}

--- a/pkg/minikube/audit/logFile_test.go
+++ b/pkg/minikube/audit/logFile_test.go
@@ -31,7 +31,7 @@ func TestLogFile(t *testing.T) {
 	t.Run("SetLogFile", func(t *testing.T) {
 		// make sure logs directory exists
 		if err := os.MkdirAll(filepath.Dir(localpath.AuditLog()), 0755); err != nil {
-			t.Fatalf("Error creating audit directory: %v", err)
+			t.Fatalf("Error creating logs directory: %v", err)
 		}
 		if err := setLogFile(); err != nil {
 			t.Error(err)


### PR DESCRIPTION
fixes #10804

the error description is in the issue, here is a small fix to make sure the path to the directory exists before calling os.OpenFile