### PR TITLE
cache add: improved error message when image does not exist

### DIFF
--- a/pkg/minikube/image/cache.go
+++ b/pkg/minikube/image/cache.go
@@ -60,7 +60,11 @@ func SaveToDir(images []string, cacheDir string) error {
 			dst := filepath.Join(cacheDir, image)
 			dst = localpath.SanitizeCacheDir(dst)
 			if err := saveToTarFile(image, dst); err != nil {
-				klog.Errorf("save image to file %q -> %q failed: %v", image, dst, err)
+				klog.Errorf("save image to file %q -> %q failed: \n" +
+									"The image you're trying to add to the cache doesn't exist" +
+									"locally on your machine: try to build or to pull it first",
+									image, dst)
+
 				return errors.Wrapf(err, "caching image %q", dst)
 			}
 			klog.Infof("save to tar file %s -> %s succeeded", image, dst)


### PR DESCRIPTION
Fixes #9217
Improved error message by adding message suggested by @Evalle in the corresponding issue.

**Before**
```
PS C:\Users\jenkins> minikube cache add doesnt_exist_thing:haha
E0910 18:30:13.540553    3980 cache.go:63] save image to file "doesnt_exist_thing:haha" -> "C:\\Users\\jenkins\\.minikube\\cache\\images\\doesnt_exist_thing_haha" failed: nil image for doesnt_exist_thing:haha: GET https://index.docker.io/v2/library/doesnt_exist_thing/manifests/haha: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:library/doesnt_exist_thing Type:repository]]

X Exiting due to MK_CACHE_LOAD: save to dir: caching images: caching image "C:\\Users\\jenkins\\.minikube\\cache\\images\\doesnt_exist_thing_haha": nil image for doesnt_exist_thing:haha: GET https://index.docker.io/v2/library/doesnt_exist_thing/manifests/haha: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:library/doesnt_exist_thing Type:repository]]
*
* If the above advice does not help, please let us know:
  - https://github.com/kubernetes/minikube/issues/new/choose
```
**After**
```
❗  "minikube cache" will be deprecated in upcoming versions, please switch to "minikube image load"
E0313 20:40:33.864613  105224 cache.go:63] save image to file "linux" -> "/home/atripolka/.minikube/cache/images/linux" failed: 
The image you're trying to add to the cache doesn't exist locally on your machine: try to build or to pull it first

❌  Exiting due to MK_CACHE_LOAD: save to dir: caching images: caching image "/home/atripolka/.minikube/cache/images/linux": nil image for linux:latest: GET https://index.docker.io/v2/library/linux/manifests/latest: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:library/linux Type:repository]]
😿  If the above advice does not help, please let us know: 
👉  https://github.com/kubernetes/minikube/issues/new/choose

```
