### PR TITLE
cache add: improved error message when image does not exist

### DIFF
--- a/pkg/minikube/image/cache.go
+++ b/pkg/minikube/image/cache.go
@@ -34,6 +34,17 @@ import (
 	"k8s.io/minikube/pkg/util/lock"
 )
 
+type cacheError struct {
+	Err error
+}
+
+func (f *cacheError) Error() string {
+	return f.Err.Error()
+}
+
+// errCacheImageDoesntExist is thrown when image that user is trying to add does not exist
+var errCacheImageDoesntExist = &cacheError{errors.New("the image you are trying to add does not exist")}
+
 // DeleteFromCacheDir deletes tar files stored in cache dir
 func DeleteFromCacheDir(images []string) error {
 	for _, image := range images {
@@ -116,7 +127,7 @@ func saveToTarFile(iname, rawDest string) error {
 
 	img, err := retrieveImage(ref)
 	if err != nil {
-		klog.Warningf("unable to retrieve image: %v", err)
+		return errCacheImageDoesntExist
 	}
 	if img == nil {
 		return errors.Wrapf(err, "nil image for %s", iname)


### PR DESCRIPTION
Fixes #9217
Improved error message by adding message suggested by @Evalle in the corresponding issue.

**Before**
```
PS C:\Users\jenkins> minikube cache add doesnt_exist_thing:haha
E0910 18:30:13.540553    3980 cache.go:63] save image to file "doesnt_exist_thing:haha" -> "C:\\Users\\jenkins\\.minikube\\cache\\images\\doesnt_exist_thing_haha" failed: nil image for doesnt_exist_thing:haha: GET https://index.docker.io/v2/library/doesnt_exist_thing/manifests/haha: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:library/doesnt_exist_thing Type:repository]]

X Exiting due to MK_CACHE_LOAD: save to dir: caching images: caching image "C:\\Users\\jenkins\\.minikube\\cache\\images\\doesnt_exist_thing_haha": nil image for doesnt_exist_thing:haha: GET https://index.docker.io/v2/library/doesnt_exist_thing/manifests/haha: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:library/doesnt_exist_thing Type:repository]]
*
* If the above advice does not help, please let us know:
  - https://github.com/kubernetes/minikube/issues/new/choose
 ```
 
 **After**
 ```
❗  "minikube cache" will be deprecated in upcoming versions, please switch to "minikube image load"
❗  The image you are trying to add ubuntu doesn't exist!
```