### PR TITLE
fix potential nil pointer dereference

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -746,7 +746,8 @@ func validateDriver(ds registry.DriverState, existing *config.ClusterConfig) {
 		return
 	}
 
-	if r := reason.MatchKnownIssue(reason.Kind{}, st.Error, runtime.GOOS); r != nil && r.ID != "" {
+	r := reason.MatchKnownIssue(reason.Kind{}, st.Error, runtime.GOOS)
+	if r != nil && r.ID != "" {
 		exitIfNotForced(*r, st.Error.Error())
 	}
 

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -746,8 +746,7 @@ func validateDriver(ds registry.DriverState, existing *config.ClusterConfig) {
 		return
 	}
 
-	r := reason.MatchKnownIssue(reason.Kind{}, st.Error, runtime.GOOS)
-	if r.ID != "" {
+	if r := reason.MatchKnownIssue(reason.Kind{}, st.Error, runtime.GOOS); r != nil && r.ID != "" {
 		exitIfNotForced(*r, st.Error.Error())
 	}
 


### PR DESCRIPTION
fixes #10813

check first if the returned value of reason.MatchKnownIssue is nil before checking its properties