### PR TITLE
Add auto-pause webhook to inject env into pods for redirecting in-cluster kubectl request to reverse proxy of api server.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ _testmain.go
 *.prof
 
 /deploy/kicbase/auto-pause
+/deploy/addons/auto-pause/auto-pause-hook
 /out
 /_gopath
 

--- a/Makefile
+++ b/Makefile
@@ -826,12 +826,12 @@ out/auto-pause-hook: $(SOURCE_GENERATED) ## Build auto-pause hook addon
 
 .PHONY: auto-pause-hook-image
 auto-pause-hook-image: out/auto-pause-hook  ## Build docker image for auto-pause hook
-	docker build -t docker.io/azhao155/auto-pause-hook:1.5 -f deploy/addons/auto-pause/Dockerfile .
+	docker build -t docker.io/azhao155/auto-pause-hook:1.7 -f deploy/addons/auto-pause/Dockerfile .
 
 .PHONY: push-auto-pause-hook-image
 push-auto-pause-hook-image: auto-pause-hook-image
 	docker login docker.io/azhao155
-	$(MAKE) push-docker IMAGE=docker.io/azhao155/auto-pause-hook:1.5
+	$(MAKE) push-docker IMAGE=docker.io/azhao155/auto-pause-hook:1.7
 
 .PHONY: out/performance-bot
 out/performance-bot:

--- a/Makefile
+++ b/Makefile
@@ -826,12 +826,12 @@ out/auto-pause-hook: $(SOURCE_GENERATED) ## Build auto-pause hook addon
 
 .PHONY: auto-pause-hook-image
 auto-pause-hook-image: out/auto-pause-hook  ## Build docker image for auto-pause hook
-	docker build -t docker.io/azhao155/auto-pause-hook:1.3 -f deploy/addons/auto-pause/Dockerfile .
+	docker build -t docker.io/azhao155/auto-pause-hook:1.5 -f deploy/addons/auto-pause/Dockerfile .
 
 .PHONY: push-auto-pause-hook-image
 push-auto-pause-hook-image: auto-pause-hook-image
 	docker login docker.io/azhao155
-	$(MAKE) push-docker IMAGE=docker.io/azhao155/auto-pause-hook:1.3
+	$(MAKE) push-docker IMAGE=docker.io/azhao155/auto-pause-hook:1.5
 
 .PHONY: out/performance-bot
 out/performance-bot:

--- a/Makefile
+++ b/Makefile
@@ -819,6 +819,20 @@ out/mkcmp:
 deploy/kicbase/auto-pause: $(SOURCE_GENERATED) $(SOURCE_FILES)
 	GOOS=linux GOARCH=$(GOARCH) go build -o $@ cmd/auto-pause/auto-pause.go
 
+.PHONY: out/auto-pause-hook
+out/auto-pause-hook: $(SOURCE_GENERATED) ## Build auto-pause hook addon
+	$(if $(quiet),@echo "  GO       $@")
+	$(Q)GOOS=linux CGO_ENABLED=0 go build -a --ldflags '-extldflags "-static"' -tags netgo -installsuffix netgo -o $@ cmd/auto-pause/auto-pause-hook/main.go cmd/auto-pause/auto-pause-hook/config.go cmd/auto-pause/auto-pause-hook/certs.go
+
+.PHONY: auto-pause-hook-image
+auto-pause-hook-image: out/auto-pause-hook  ## Build docker image for auto-pause hook
+	docker build -t docker.io/azhao155/auto-pause-hook:1.3 -f deploy/addons/auto-pause/Dockerfile .
+
+.PHONY: push-auto-pause-hook-image
+push-auto-pause-hook-image: auto-pause-hook-image
+	docker login docker.io/azhao155
+	$(MAKE) push-docker IMAGE=docker.io/azhao155/auto-pause-hook:1.3
+
 .PHONY: out/performance-bot
 out/performance-bot:
 	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o $@ cmd/performance/pr-bot/bot.go

--- a/cmd/auto-pause/auto-pause-hook/certs.go
+++ b/cmd/auto-pause/auto-pause-hook/certs.go
@@ -28,6 +28,7 @@ import (
 	"time"
 )
 
+// generate https certs for the webhook server
 func gencerts() (caCert []byte, serverCert []byte, serverKey []byte) {
 	var caPEM, serverCertPEM, serverPrivKeyPEM *bytes.Buffer
 	// CA config

--- a/cmd/auto-pause/auto-pause-hook/certs.go
+++ b/cmd/auto-pause/auto-pause-hook/certs.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	cryptorand "crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+)
+
+func gencerts() (caCert []byte, serverCert []byte, serverKey []byte) {
+	var caPEM, serverCertPEM, serverPrivKeyPEM *bytes.Buffer
+	// CA config
+	ca := &x509.Certificate{
+		SerialNumber: big.NewInt(2020),
+		Subject: pkix.Name{
+			Organization: []string{"velotio.com"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(1, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	// CA private key
+	caPrivKey, err := rsa.GenerateKey(cryptorand.Reader, 4096)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	// Self signed CA certificate
+	caBytes, err := x509.CreateCertificate(cryptorand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	// PEM encode CA cert
+	caPEM = new(bytes.Buffer)
+	_ = pem.Encode(caPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caBytes,
+	})
+
+	dnsNames := []string{"webhook",
+		"webhook.auto-pause", "webhook.auto-pause.svc"}
+	commonName := "webhook.auto-pause.svc"
+
+	// server cert config
+	cert := &x509.Certificate{
+		DNSNames:     dnsNames,
+		SerialNumber: big.NewInt(1658),
+		Subject: pkix.Name{
+			CommonName:   commonName,
+			Organization: []string{"velotio.com"},
+		},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(1, 0, 0),
+		SubjectKeyId: []byte{1, 2, 3, 4, 6},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+
+	// server private key
+	serverPrivKey, err := rsa.GenerateKey(cryptorand.Reader, 4096)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	// sign the server cert
+	serverCertBytes, err := x509.CreateCertificate(cryptorand.Reader, cert, ca, &serverPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	// PEM encode the  server cert and key
+	serverCertPEM = new(bytes.Buffer)
+	_ = pem.Encode(serverCertPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: serverCertBytes,
+	})
+
+	serverPrivKeyPEM = new(bytes.Buffer)
+	_ = pem.Encode(serverPrivKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(serverPrivKey),
+	})
+
+	return caPEM.Bytes(), serverCertPEM.Bytes(), serverPrivKeyPEM.Bytes()
+}

--- a/cmd/auto-pause/auto-pause-hook/certs.go
+++ b/cmd/auto-pause/auto-pause-hook/certs.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/cmd/auto-pause/auto-pause-hook/config.go
+++ b/cmd/auto-pause/auto-pause-hook/config.go
@@ -31,6 +31,11 @@ import (
 	"github.com/golang/glog"
 )
 
+var (
+	webhookName       = "env-inject-webhook"
+	webhookConfigName = "env-inject.zyanshu.io"
+)
+
 // get a clientset with in-cluster config.
 func getClient() *kubernetes.Clientset {
 	config, err := rest.InClusterConfig()
@@ -81,9 +86,9 @@ func configTLS(clientset *kubernetes.Clientset, serverCert []byte, serverKey []b
 func selfRegistration(clientset *kubernetes.Clientset, caCert []byte) {
 	time.Sleep(10 * time.Second)
 	client := clientset.AdmissionregistrationV1().MutatingWebhookConfigurations()
-	_, err := client.Get("env-inject-webhook", metav1.GetOptions{})
+	_, err := client.Get(webhookName, metav1.GetOptions{})
 	if err == nil {
-		if err2 := client.Delete("env-inject-webhook", &metav1.DeleteOptions{}); err2 != nil {
+		if err2 := client.Delete(webhookName, &metav1.DeleteOptions{}); err2 != nil {
 			glog.Fatal(err2)
 		}
 	}
@@ -92,11 +97,11 @@ func selfRegistration(clientset *kubernetes.Clientset, caCert []byte) {
 
 	webhookConfig := &v1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "env-inject-webhook",
+			Name: webhookName,
 		},
 		Webhooks: []v1.MutatingWebhook{
 			{
-				Name: "env-inject.zyanshu.io",
+				Name: webhookConfigName,
 				Rules: []v1.RuleWithOperations{
 					{
 						Operations: []v1.OperationType{v1.Create, v1.Update},

--- a/cmd/auto-pause/auto-pause-hook/config.go
+++ b/cmd/auto-pause/auto-pause-hook/config.go
@@ -1,10 +1,5 @@
 /*
-This file is a modified version of
-https://github.com/caesarxuchao/example-webhook-admission-controller/blob/master/config.go
-*/
-
-/*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/auto-pause/auto-pause-hook/config.go
+++ b/cmd/auto-pause/auto-pause-hook/config.go
@@ -1,0 +1,140 @@
+/*
+This file is a modified version of
+https://github.com/caesarxuchao/example-webhook-admission-controller/blob/master/config.go
+*/
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"log"
+	"time"
+
+	v1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/golang/glog"
+)
+
+// get a clientset with in-cluster config.
+func getClient() *kubernetes.Clientset {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		glog.Fatal(err)
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		glog.Fatal(err)
+	}
+	return clientset
+}
+
+// retrieve the CA cert that will signed the cert used by the
+// "GenericAdmissionWebhook" plugin admission controller.
+func getAPIServerCert(clientset *kubernetes.Clientset) []byte {
+	c, err := clientset.CoreV1().ConfigMaps("kube-system").Get("extension-apiserver-authentication", metav1.GetOptions{})
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	pem, ok := c.Data["requestheader-client-ca-file"]
+	if !ok {
+		glog.Fatalf(fmt.Sprintf("cannot find the ca.crt in the configmap, configMap.Data is %#v", c.Data))
+	}
+	glog.Info("client-ca-file=", pem)
+	return []byte(pem)
+}
+
+func configTLS(clientset *kubernetes.Clientset, serverCert []byte, serverKey []byte) *tls.Config {
+	cert := getAPIServerCert(clientset)
+	apiserverCA := x509.NewCertPool()
+	apiserverCA.AppendCertsFromPEM(cert)
+
+	sCert, err := tls.X509KeyPair(serverCert, serverKey)
+	if err != nil {
+		glog.Fatal(err)
+	}
+	return &tls.Config{
+		Certificates: []tls.Certificate{sCert},
+		ClientCAs:    apiserverCA,
+		ClientAuth:   tls.VerifyClientCertIfGiven, // TODO: actually require client cert
+	}
+}
+
+// register this example webhook admission controller with the kube-apiserver
+// by creating externalAdmissionHookConfigurations.
+func selfRegistration(clientset *kubernetes.Clientset, caCert []byte) {
+	time.Sleep(10 * time.Second)
+	client := clientset.AdmissionregistrationV1().MutatingWebhookConfigurations()
+	_, err := client.Get("env-inject-webhook", metav1.GetOptions{})
+	if err == nil {
+		if err2 := client.Delete("env-inject-webhook", &metav1.DeleteOptions{}); err2 != nil {
+			glog.Fatal(err2)
+		}
+	}
+	var failurePolicy v1.FailurePolicyType = v1.Fail
+	var sideEffects v1.SideEffectClass = v1.SideEffectClassNone
+
+	webhookConfig := &v1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "env-inject-webhook",
+		},
+		Webhooks: []v1.MutatingWebhook{
+			{
+				Name: "env-inject.zyanshu.io",
+				Rules: []v1.RuleWithOperations{
+					{
+						Operations: []v1.OperationType{v1.Create, v1.Update},
+						Rule: v1.Rule{
+							APIGroups:   []string{""},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"pods"},
+						},
+					},
+					{
+						Operations: []v1.OperationType{v1.Create, v1.Update},
+						Rule: v1.Rule{
+							APIGroups:   []string{"extensions"},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"deployments"},
+						},
+					},
+				},
+				FailurePolicy: &failurePolicy,
+				ClientConfig: v1.WebhookClientConfig{
+					Service: &v1.ServiceReference{
+						Namespace: "auto-pause",
+						Name:      "webhook",
+					},
+					CABundle: caCert,
+				},
+				AdmissionReviewVersions: []string{"v1"},
+				SideEffects:             &sideEffects,
+			},
+		},
+	}
+	if _, err := client.Create(webhookConfig); err != nil {
+		glog.Fatalf("Client creation failed with %s", err)
+	}
+	log.Println("CLIENT CREATED")
+}

--- a/cmd/auto-pause/auto-pause-hook/main.go
+++ b/cmd/auto-pause/auto-pause-hook/main.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"strconv"
 
 	"github.com/golang/glog"
 	"github.com/mattbaird/jsonpatch"
@@ -32,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/minikube/pkg/minikube/constants"
 )
 
 var (
@@ -132,7 +134,7 @@ func patchConfig(pod *corev1.Pod) ([]byte, error) {
 
 	configEnv := []corev1.EnvVar{
 		{Name: "KUBERNETES_SERVICE_HOST", Value: "192.168.49.2"},
-		{Name: "KUBERNETES_SERVICE_PORT", Value: "32443"}}
+		{Name: "KUBERNETES_SERVICE_PORT", Value: strconv.Itoa(constants.AutoPauseProxyPort)}}
 	for idx, container := range pod.Spec.Containers {
 		patch = append(patch, addEnv(container.Env, configEnv, fmt.Sprintf("/spec/containers/%d/env", idx))...)
 	}

--- a/cmd/auto-pause/auto-pause-hook/main.go
+++ b/cmd/auto-pause/auto-pause-hook/main.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/mattbaird/jsonpatch"
+
+	v1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+var (
+	runtimeScheme = runtime.NewScheme()
+	codecs        = serializer.NewCodecFactory(runtimeScheme)
+	deserializer  = codecs.UniversalDeserializer()
+
+	// TODO(https://github.com/kubernetes/kubernetes/issues/57982)
+	defaulter = runtime.ObjectDefaulter(runtimeScheme)
+)
+
+// the Path of the JSON patch is a JSON pointer value
+// so we need to escape any "/"s in the key we add to the annotation
+// https://tools.ietf.org/html/rfc6901
+func escapeJSONPointer(s string) string {
+	esc := strings.Replace(s, "~", "~0", -1)
+	esc = strings.Replace(esc, "/", "~1", -1)
+	return esc
+}
+
+var minikubeSystemNamespaces = []string{
+	metav1.NamespaceSystem,
+	metav1.NamespacePublic,
+	"auto-pause",
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	log.Println("Handling a request")
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("error: %v", err)
+		return
+	}
+
+	contentType := r.Header.Get("Content-Type")
+	if contentType != "application/json" {
+		log.Printf("Wrong content type. Got: %s", contentType)
+		return
+	}
+
+	admReq := v1.AdmissionReview{}
+	admResp := v1.AdmissionReview{}
+
+	if _, _, err := deserializer.Decode(body, nil, &admReq); err != nil {
+		log.Printf("Could not decode body: %v", err)
+		admResp.Response = admissionError(err)
+	} else {
+		admResp.Response = getAdmissionDecision(&admReq)
+	}
+
+	admResp.APIVersion = "admission.k8s.io/v1"
+	admResp.Kind = "AdmissionReview"
+	resp, err := json.Marshal(admResp)
+	if err != nil {
+		log.Printf("error marshalling decision: %v", err)
+	}
+	log.Printf(string(resp))
+	if _, err := w.Write(resp); err != nil {
+		log.Printf("error writing response %v", err)
+	}
+}
+
+func admissionError(err error) *v1.AdmissionResponse {
+	return &v1.AdmissionResponse{
+		Result: &metav1.Status{Message: err.Error()},
+	}
+}
+
+func getAdmissionDecision(admReq *v1.AdmissionReview) *v1.AdmissionResponse {
+	req := admReq.Request
+	var pod corev1.Pod
+
+	err := json.Unmarshal(req.Object.Raw, &pod)
+	if err != nil {
+		log.Printf("Could not unmarshal raw object: %v", err)
+		return admissionError(err)
+	}
+
+	log.Printf("AdmissionReview for Kind=%v Namespace=%v Name=%v UID=%v Operation=%v UserInfo=%v",
+		req.Kind, req.Namespace, req.Name, req.UID, req.Operation, req.UserInfo)
+
+	if !shouldInject(&pod.ObjectMeta) {
+		log.Printf("Skipping inject for %s %s", pod.Namespace, pod.Name)
+		return &v1.AdmissionResponse{
+			Allowed: true,
+			UID:     req.UID,
+		}
+	}
+
+	patch, err := patchConfig(&pod)
+
+	if err != nil {
+		log.Printf("Error creating conduit patch: %v", err)
+		return admissionError(err)
+	}
+
+	jsonPatchType := v1.PatchTypeJSONPatch
+
+	return &v1.AdmissionResponse{
+		Allowed:   true,
+		Patch:     patch,
+		PatchType: &jsonPatchType,
+		UID:       req.UID,
+	}
+}
+
+func patchConfig(pod *corev1.Pod) ([]byte, error) {
+	var patch []jsonpatch.JsonPatchOperation
+
+	configEnv := []corev1.EnvVar{
+		{Name: "KUBERNETES_SERVICE_HOST", Value: "192.168.49.2"},
+		{Name: "KUBERNETES_SERVICE_PORT", Value: "32443"}}
+	for idx, container := range pod.Spec.Containers {
+		patch = append(patch, addEnv(container.Env, configEnv, fmt.Sprintf("/spec/containers/%d/env", idx))...)
+	}
+	return json.Marshal(patch)
+}
+
+// addEnv performs the mutation(s) needed to add the extra environment variables to the target
+// resource
+func addEnv(target, envVars []corev1.EnvVar, basePath string) (patch []jsonpatch.JsonPatchOperation) {
+	first := len(target) == 0
+	var value interface{}
+	for _, envVar := range envVars {
+		value = envVar
+		path := basePath
+		if first {
+			first = false
+			value = []corev1.EnvVar{envVar}
+		} else {
+			path = path + "/-"
+		}
+		patch = append(patch, jsonpatch.JsonPatchOperation{
+			Operation: "add",
+			Path:      path,
+			Value:     value,
+		})
+	}
+	return patch
+}
+
+func shouldInject(metadata *metav1.ObjectMeta) bool {
+	shouldInject := true
+
+	// don't attempt to inject pods in the Kubernetes system namespaces
+	for _, ns := range minikubeSystemNamespaces {
+		if metadata.Namespace == ns {
+			shouldInject = false
+		}
+	}
+
+	return shouldInject
+}
+
+func main() {
+	addr := flag.String("addr", ":8080", "address to serve on")
+
+	http.HandleFunc("/", handler)
+
+	flag.CommandLine.Parse([]string{}) // hack fix for https://github.com/kubernetes/kubernetes/issues/17162
+
+	log.Printf("Starting HTTPS webhook server on %+v", *addr)
+	cacert, serverCert, serverKey := gencerts()
+	clientset := getClient()
+	server := &http.Server{
+		Addr:      *addr,
+		TLSConfig: configTLS(clientset, serverCert, serverKey),
+	}
+	go selfRegistration(clientset, cacert)
+	server.ListenAndServeTLS("", "")
+}

--- a/cmd/auto-pause/auto-pause-hook/main.go
+++ b/cmd/auto-pause/auto-pause-hook/main.go
@@ -44,12 +44,6 @@ var (
 
 var targetIP *string
 
-var minikubeSystemNamespaces = []string{
-	metav1.NamespaceSystem,
-	metav1.NamespacePublic,
-	"auto-pause",
-}
-
 func handler(w http.ResponseWriter, r *http.Request) {
 	log.Println("Handling a request")
 
@@ -93,7 +87,7 @@ func admissionError(err error) *v1.AdmissionResponse {
 	}
 }
 
-// Create the admission descision for the request
+// Create the admission decision for the request
 func AdmissionDecision(admReq *v1.AdmissionReview) *v1.AdmissionResponse {
 	req := admReq.Request
 	var pod corev1.Pod
@@ -169,7 +163,7 @@ func main() {
 
 	log.Printf("Starting HTTPS webhook server on %+v and target ip is %v", *addr, *targetIP)
 	cacert, serverCert, serverKey := gencerts()
-	clientset := Client()
+	clientset := client()
 	server := &http.Server{
 		Addr:      *addr,
 		TLSConfig: configTLS(clientset, serverCert, serverKey),

--- a/cmd/auto-pause/auto-pause-hook/main.go
+++ b/cmd/auto-pause/auto-pause-hook/main.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/deploy/addons/auto-pause/Dockerfile
+++ b/deploy/addons/auto-pause/Dockerfile
@@ -1,0 +1,4 @@
+FROM golang:1.8
+
+ADD out/auto-pause-hook /auto-pause-hook
+ENTRYPOINT ["/auto-pause-hook"]

--- a/deploy/addons/auto-pause/Dockerfile
+++ b/deploy/addons/auto-pause/Dockerfile
@@ -1,3 +1,2 @@
 FROM golang:1.8
-
-ADD out/auto-pause-hook /auto-pause-hook
+ADD auto-pause-hook /auto-pause-hook

--- a/deploy/addons/auto-pause/Dockerfile
+++ b/deploy/addons/auto-pause/Dockerfile
@@ -1,4 +1,3 @@
 FROM golang:1.8
 
 ADD out/auto-pause-hook /auto-pause-hook
-ENTRYPOINT ["/auto-pause-hook"]

--- a/deploy/addons/auto-pause/auto-pause-hook.yaml
+++ b/deploy/addons/auto-pause/auto-pause-hook.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: auto-pause
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: env-inject
+  name: env-inject
+  namespace: auto-pause
+spec:
+  selector:
+    matchLabels:
+      app: env-inject
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: env-inject
+      name: env-inject
+    spec:
+      containers:
+        - name: webhook
+          image: docker.io/azhao155/auto-pause-hook:1.3
+          ports:
+            - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    role: webhook
+  name: webhook
+  namespace: auto-pause
+spec:
+  ports:
+    - port: 443
+      targetPort: 8080
+  selector:
+    app: env-inject
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: auto-pause

--- a/deploy/addons/auto-pause/auto-pause-hook.yaml.tmpl
+++ b/deploy/addons/auto-pause/auto-pause-hook.yaml.tmpl
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: webhook
-          image: docker.io/azhao155/auto-pause-hook:1.3
+          image: {{.CustomRegistries.AutoPauseHook  | default .ImageRepository | default .Registries.AutoPauseHook }}{{.Images.AutoPauseHook}}
           ports:
             - containerPort: 8080
 ---

--- a/deploy/addons/auto-pause/auto-pause-hook.yaml.tmpl
+++ b/deploy/addons/auto-pause/auto-pause-hook.yaml.tmpl
@@ -26,6 +26,8 @@ spec:
           image: {{.CustomRegistries.AutoPauseHook  | default .ImageRepository | default .Registries.AutoPauseHook }}{{.Images.AutoPauseHook}}
           ports:
             - containerPort: 8080
+          command: ["/auto-pause-hook"]
+          args: ["-targetIP={{.NetworkInfo.CPNodeIP}}"]            
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/addons/auto-pause/auto-pause-hook.yaml.tmpl
+++ b/deploy/addons/auto-pause/auto-pause-hook.yaml.tmpl
@@ -27,7 +27,7 @@ spec:
           ports:
             - containerPort: 8080
           command: ["/auto-pause-hook"]
-          args: ["-targetIP={{.NetworkInfo.CPNodeIP}}"]            
+          args: ["-targetIP={{.NetworkInfo.ControlPlaneNodeIP}}"]            
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/addons/auto-pause/auto-pause.yaml.tmpl
+++ b/deploy/addons/auto-pause/auto-pause.yaml.tmpl
@@ -11,6 +11,7 @@ metadata:
   namespace: auto-pause
   labels:
     app: auto-pause-proxy
+    auto-pause-skip: "true"
 spec:
   replicas: 1
   selector:

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/libvirt/libvirt-go v3.9.0+incompatible
 	github.com/machine-drivers/docker-machine-driver-vmware v0.1.1
+	github.com/mattbaird/jsonpatch v0.0.0-20200820163806-098863c1fc24 // indirect
 	github.com/mattn/go-isatty v0.0.12
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/moby/hyperkit v0.0.0-20210108224842-2f061e447e14

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/evanphx/json-patch v4.5.0+incompatible // indirect
 	github.com/go-logr/logr v0.3.0 // indirect
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/google/go-cmp v0.5.5
 	github.com/google/go-containerregistry v0.4.1
 	github.com/google/go-github v17.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -354,6 +354,7 @@ github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3 h1:zN2lZNZRflqFyxVaTIU61KNKQ9C0055u9CAfpmqUvo4=
 github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3/go.mod h1:nPpo7qLxd6XL3hWJG/O60sR8ZKfMCiIoNap5GvD12KU=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -632,6 +633,8 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/marten-seemann/qtls v0.2.3/go.mod h1:xzjG7avBwGGbdZ8dTGxlBnLArsVKLvwmjgmPuiQEcYk=
 github.com/maruel/panicparse v1.5.0/go.mod h1:aOutY/MUjdj80R0AEVI9qE2zHqig+67t2ffUDDiLzAM=
+github.com/mattbaird/jsonpatch v0.0.0-20200820163806-098863c1fc24 h1:uYuGXJBAi1umT+ZS4oQJUgKtfXCAYTR+n9zw1ViT0vA=
+github.com/mattbaird/jsonpatch v0.0.0-20200820163806-098863c1fc24/go.mod h1:M1qoD/MqPgTZIk0EWKB38wE28ACRfVcn+cU08jyArI0=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6 h1:6Su7aK7lXmJ/U79bYtBjLNaha4Fs1Rg9plHpcH+vvnE=

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -218,7 +218,7 @@ https://github.com/kubernetes/minikube/issues/7332`, out.V{"driver_name": cc.Dri
 
 	var networkInfo assets.NetworkInfo
 	if len(cc.Nodes) >= 1 {
-		networkInfo.CPNodeIP = cc.Nodes[0].IP
+		networkInfo.ControlPlaneNodeIP = cc.Nodes[0].IP
 	} else {
 		out.WarningT("At least needs control plane nodes to enable addon")
 	}

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -216,7 +216,14 @@ https://github.com/kubernetes/minikube/issues/7332`, out.V{"driver_name": cc.Dri
 		}
 	}
 
-	data := assets.GenerateTemplateData(addon, cc.KubernetesConfig)
+	var networkInfo assets.NetworkInfo
+	if len(cc.Nodes) >= 1 {
+		networkInfo.CPNodeIP = cc.Nodes[0].IP
+	} else {
+		out.WarningT("At least needs control plane nodes to enable addon")
+	}
+
+	data := assets.GenerateTemplateData(addon, cc.KubernetesConfig, networkInfo)
 	return enableOrDisableAddonInternal(cc, addon, runner, data, enable)
 }
 

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -78,6 +78,11 @@ var Addons = map[string]*Addon{
 			"auto-pause.yaml",
 			"0640"),
 		MustBinAsset(
+			"deploy/addons/auto-pause/auto-pause-hook.yaml.tmpl",
+			vmpath.GuestAddonsDir,
+			"auto-pause-hook.yaml",
+			"0640"),
+		MustBinAsset(
 			"deploy/addons/auto-pause/haproxy.cfg",
 			"/var/lib/minikube/",
 			"haproxy.cfg",
@@ -95,9 +100,11 @@ var Addons = map[string]*Addon{
 
 		//GuestPersistentDir
 	}, false, "auto-pause", map[string]string{
-		"haproxy": "haproxy:2.3.5",
+		"haproxy":       "haproxy:2.3.5",
+		"AutoPauseHook": "azhao155/auto-pause-hook:1.3",
 	}, map[string]string{
-		"haproxy": "gcr.io",
+		"haproxy":       "gcr.io",
+		"AutoPauseHook": "docker.io",
 	}),
 	"dashboard": NewAddon([]*BinAsset{
 		// We want to create the kubernetes-dashboard ns first so that every subsequent object can be created

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -101,7 +101,7 @@ var Addons = map[string]*Addon{
 		//GuestPersistentDir
 	}, false, "auto-pause", map[string]string{
 		"haproxy":       "haproxy:2.3.5",
-		"AutoPauseHook": "azhao155/auto-pause-hook:1.3",
+		"AutoPauseHook": "azhao155/auto-pause-hook:1.5",
 	}, map[string]string{
 		"haproxy":       "gcr.io",
 		"AutoPauseHook": "docker.io",

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -40,11 +40,9 @@ type Addon struct {
 	Registries map[string]string
 }
 
-// NetworkInfo is network relevant info
+// NetworkInfo contains control plane node IP address used for add on template
 type NetworkInfo struct {
-	CPNodeIP           string
-	CPNodePort         int
-	AutoPauseProxyPort int
+	ControlPlaneNodeIP string
 }
 
 // NewAddon creates a new Addon
@@ -107,10 +105,8 @@ var Addons = map[string]*Addon{
 
 		//GuestPersistentDir
 	}, false, "auto-pause", map[string]string{
-		"haproxy":       "haproxy:2.3.5",
-		"AutoPauseHook": "azhao155/auto-pause-hook:1.7",
+		"AutoPauseHook": "azhao155/auto-pause-hook:1.13",
 	}, map[string]string{
-		"haproxy":       "gcr.io",
 		"AutoPauseHook": "docker.io",
 	}),
 	"dashboard": NewAddon([]*BinAsset{
@@ -675,7 +671,7 @@ func GenerateTemplateData(addon *Addon, cfg config.KubernetesConfig, networkInfo
 	}
 
 	// Network info for generating template
-	opts.NetworkInfo["CPNodeIP"] = networkInfo.CPNodeIP
+	opts.NetworkInfo["ControlPlaneNodeIP"] = networkInfo.ControlPlaneNodeIP
 
 	if opts.Images == nil {
 		opts.Images = make(map[string]string) // Avoid nil access when rendering


### PR DESCRIPTION
Start minikube with auto-pause
```
zyanshu@zyanshukvm:~/minikube$  ./out/minikube  start --addons=auto-pause
😄  minikube v1.18.1 on Debian rodete (kvm/amd64)
✨  Automatically selected the docker driver. Other choices: kvm2, ssh
👍  Starting control plane node minikube in cluster minikube
🔥  Creating docker container (CPUs=2, Memory=26100MB) ...
🐳  Preparing Kubernetes v1.20.2 on Docker 20.10.3 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v4
    ▪ Using image gcr.io/haproxy:2.3.5
    ▪ Using image docker.io/azhao155/auto-pause-hook:1.5
    ▪ auto-pause addon is an alpha feature and still in early development. Please file issues to help us make it better.
    ▪ https://github.com/kubernetes/minikube/labels/co%2Fauto-pause
🌟  Enabled addons: storage-provisioner, default-storageclass, auto-pause
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```
env-inject will be created under auto-pause namespace

```
zyanshu@zyanshukvm:~/minikube$ kubectl get pods -A
NAMESPACE     NAME                               READY   STATUS             RESTARTS   AGE
auto-pause    auto-pause-proxy-dc6979c79-4x9mh   1/1     Running            0          39s
auto-pause    env-inject-547b5d649d-gjnqg        1/1     Running            0          39s
kube-system   coredns-74ff55c5b-dv48v            0/1     CrashLoopBackOff   1          39s
kube-system   etcd-minikube                      0/1     Running            0          53s
kube-system   kube-apiserver-minikube            1/1     Running            0          53s
kube-system   kube-controller-manager-minikube   0/1     Running            0          53s
kube-system   kube-proxy-b9x8r                   1/1     Running            0          39s
kube-system   kube-scheduler-minikube            0/1     Running            0          53s
kube-system   storage-provisioner                1/1     Running            0          52s
```
Deploy etcd-operator
```
zyanshu@zyanshukvm:~/etcd-operator$ kubectl apply -f example/deployment.yaml
deployment.apps/etcd-operator created
```
etcd-operator is running now
```
zyanshu@zyanshukvm:~/minikube$ kubectl get pods -A
NAMESPACE     NAME                               READY   STATUS             RESTARTS   AGE
auto-pause    auto-pause-proxy-dc6979c79-hxx9b   1/1     Running            0          3m38s
auto-pause    env-inject-547b5d649d-hpz98        1/1     Running            0          3m38s
default       etcd-operator-7f8df45d-fwgvh       1/1     Running            0          63s
kube-system   coredns-74ff55c5b-wpk94            0/1     CrashLoopBackOff   6          3m38s
kube-system   etcd-minikube                      1/1     Running            0          3m53s
kube-system   kube-apiserver-minikube            1/1     Running            0          3m53s
kube-system   kube-controller-manager-minikube   1/1     Running            0          3m53s
kube-system   kube-proxy-ssvrv                   1/1     Running            0          3m38s
kube-system   kube-scheduler-minikube            1/1     Running            0          3m53s
kube-system   storage-provisioner                1/1     Running            1          3m52s
```
Check env of etcd-operator
```
zyanshu@zyanshukvm:~/minikube$ kubectl exec etcd-operator-7f8df45d-fwgvh -- env
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HOSTNAME=etcd-operator-7f8df45d-fwgvh
KUBERNETES_SERVICE_HOST=192.168.49.2
KUBERNETES_SERVICE_PORT=32443
MY_POD_NAMESPACE=default
MY_POD_NAME=etcd-operator-7f8df45d-fwgvh
KUBERNETES_SERVICE_PORT_HTTPS=443
KUBERNETES_PORT=tcp://10.96.0.1:443
KUBERNETES_PORT_443_TCP=tcp://10.96.0.1:443
KUBERNETES_PORT_443_TCP_PROTO=tcp
KUBERNETES_PORT_443_TCP_PORT=443
KUBERNETES_PORT_443_TCP_ADDR=10.96.0.1
HOME=/home/etcd-operator
```

It's already pointing to reverse proxy.
Deploy etcd-cluster
```
zyanshu@zyanshukvm:~/etcd-operator$ kubectl create -f ./example/example-etcd-cluster.yaml
etcdcluster.etcd.database.coreos.com/example-etcd-cluster created
```
etcd-cluster is deployed
```
zyanshu@zyanshukvm:~/minikube$ kubectl get pods
 
NAME                              READY     STATUS    RESTARTS   AGE
etcd-operator-7f8df45d-fwgvh      1/1       Running   0          9m
example-etcd-cluster-9bxfh657qq   1/1       Running   0          23s
example-etcd-cluster-ntzp4hrw79   1/1       Running   0          8m
example-etcd-cluster-xwlpqrzj2q   1/1       Running   0          9m
```






