### PR TITLE
Show last start and audit logs on `minikube logs` if minikube not running

### DIFF
--- a/cmd/minikube/cmd/logs.go
+++ b/cmd/minikube/cmd/logs.go
@@ -23,7 +23,6 @@ import (
 	"github.com/spf13/viper"
 	cmdcfg "k8s.io/minikube/cmd/minikube/cmd/config"
 	"k8s.io/minikube/pkg/minikube/cluster"
-	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/cruntime"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/logs"
@@ -53,10 +52,7 @@ var logsCmd = &cobra.Command{
 	Short: "Returns logs to debug a local Kubernetes cluster",
 	Long:  `Gets the logs of the running instance, used for debugging minikube, not user code.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if !isClusterRunning() {
-			logs.OutputOffline(numberOfLines)
-			return
-		}
+		logs.OutputOffline(numberOfLines)
 
 		co := mustload.Running(ClusterFlagValue())
 
@@ -89,16 +85,6 @@ var logsCmd = &cobra.Command{
 			os.Exit(reason.ExSvcError)
 		}
 	},
-}
-
-func isClusterRunning() bool {
-	if _, err := config.Load(ClusterFlagValue()); err != nil {
-		if config.IsNotExist(err) {
-			return false
-		}
-		exit.Error(reason.HostConfigLoad, "Error getting cluster config", err)
-	}
-	return true
 }
 
 func init() {

--- a/cmd/minikube/cmd/logs.go
+++ b/cmd/minikube/cmd/logs.go
@@ -54,7 +54,7 @@ var logsCmd = &cobra.Command{
 	Long:  `Gets the logs of the running instance, used for debugging minikube, not user code.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if !isClusterRunning() {
-			logs.OutputMinikubeLogs(numberOfLines)
+			logs.OutputOffline(numberOfLines)
 			return
 		}
 

--- a/go.sum
+++ b/go.sum
@@ -733,7 +733,6 @@ github.com/opencontainers/runtime-spec v1.0.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/
 github.com/opencontainers/selinux v1.3.1-0.20190929122143-5215b1806f52/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
 github.com/otiai10/copy v1.0.2 h1:DDNipYy6RkIkjMwy+AWzgKiNTyj2RUI9yEMeETEpVyc=
 github.com/otiai10/copy v1.0.2/go.mod h1:c7RpqBkwMom4bYTSkLSym4VSJz/XtncWRAj/J4PEIMY=
-github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95 h1:+OLn68pqasWca0z5ryit9KGfp3sUsW4Lqg32iRMJyzs=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/mint v1.3.0 h1:Ady6MKVezQwHBkGzLFbrsywyp09Ah7rkmfjV3Bcr5uc=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
@@ -1009,7 +1008,6 @@ golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.1 h1:Kvvh58BN8Y9/lBi7hTekvtMpm07eUZ0ck5pRHpsMWrY=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=

--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -243,6 +243,16 @@ func outputLastStart() error {
 	return nil
 }
 
+// OutputMinikubeLogs outputs the audit and last start logs only
+func OutputMinikubeLogs(lines int) {
+	if err := outputAudit(lines); err != nil {
+		klog.Errorf("failed to output audit logs: %v", err)
+	}
+	if err := outputLastStart(); err != nil {
+		klog.Errorf("failed to output last start logs: %v", err)
+	}
+}
+
 // logCommands returns a list of commands that would be run to receive the anticipated logs
 func logCommands(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.ClusterConfig, length int, follow bool) map[string]string {
 	cmds := bs.LogCommands(cfg, bootstrapper.LogOptions{Lines: length, Follow: follow})

--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -243,8 +243,8 @@ func outputLastStart() error {
 	return nil
 }
 
-// OutputMinikubeLogs outputs the audit and last start logs only
-func OutputMinikubeLogs(lines int) {
+// OutputOffline outputs logs that don't need a running cluster.
+func OutputOffline(lines int) {
 	if err := outputAudit(lines); err != nil {
 		klog.Errorf("failed to output audit logs: %v", err)
 	}

--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -190,16 +190,6 @@ func Output(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.Cluster
 		}
 	}
 
-	if err := outputAudit(lines); err != nil {
-		klog.Errorf("failed to output audit logs: %v", err)
-		failed = append(failed, "audit")
-	}
-
-	if err := outputLastStart(); err != nil {
-		klog.Errorf("failed to output last start logs: %v", err)
-		failed = append(failed, "last start")
-	}
-
 	if len(failed) > 0 {
 		return fmt.Errorf("unable to fetch logs for: %s", strings.Join(failed, ", "))
 	}
@@ -251,6 +241,7 @@ func OutputOffline(lines int) {
 	if err := outputLastStart(); err != nil {
 		klog.Errorf("failed to output last start logs: %v", err)
 	}
+	out.Styled(style.Empty, "")
 }
 
 // logCommands returns a list of commands that would be run to receive the anticipated logs


### PR DESCRIPTION
Closes #10729

The first thing the `minkube logs` command does is tries loading the running cluster, and if the cluster config does not exist (not running), exits within the load function with the message:
```
🤷  Profile "minikube" not found. Run "minikube profile list" to view all profiles.
👉  To start a cluster, run: "minikube start"
```

But if a user is having a problem starting minikube and wants to create a GitHub issue, this prevents them from getting the logs they need to provide in the issue.

I moved the last start and audit logs output before the cluster load to ensure they're output regardless of the status of the cluster.

Running `minikube logs` on non-running cluster:
Before:
```
🤷  Profile "minikube" not found. Run "minikube profile list" to view all profiles.
👉  To start a cluster, run: "minikube start"
```

Now:
```
==> Audit <==
...

==> Last Start <==
...

🤷  Profile "minikube" not found. Run "minikube profile list" to view all profiles.
👉  To start a cluster, run: "minikube start"
```