### PR TITLE
create network: use locks and reservations to solve race condition

### DIFF
--- a/pkg/drivers/kic/oci/network_create.go
+++ b/pkg/drivers/kic/oci/network_create.go
@@ -35,9 +35,6 @@ import (
 // it is one octet more than the one used by KVM to avoid possible conflict
 const firstSubnetAddr = "192.168.49.0"
 
-// big enough for a cluster of 254 nodes
-const defaultSubnetMask = 24
-
 // name of the default bridge network, used to lookup the MTU (see #9528)
 const dockerDefaultBridge = "bridge"
 
@@ -71,30 +68,44 @@ func CreateNetwork(ociBin string, networkName string) (net.IP, error) {
 	if err != nil {
 		klog.Warningf("failed to get mtu information from the %s's default network %q: %v", ociBin, defaultBridgeName, err)
 	}
-	// Rather than iterate through all of the valid subnets, give up at 20 to avoid a lengthy user delay for something that is unlikely to work.
-	// will be like 192.168.49.0/24 ,...,192.168.239.0/24
-	subnet, err := network.FreeSubnet(firstSubnetAddr, 10, 20)
-	if err != nil {
-		klog.Errorf("error while trying to create network: %v", err)
-		return nil, errors.Wrap(err, "un-retryable")
+
+	// retry up to 5 times to create container network
+	attempts := 0
+	subnetAddr := firstSubnetAddr
+	for attempts < 5 {
+		// Rather than iterate through all of the valid subnets, give up at 20 to avoid a lengthy user delay for something that is unlikely to work.
+		// will be like 192.168.49.0/24,..., 192.168.220.0/24 (in increment steps of 9)
+		subnet, err := network.FreeSubnet(subnetAddr, 9, 20)
+		if err != nil {
+			klog.Errorf("failed to find free subnet for %s network %s after %d attempts: %v", ociBin, networkName, 20, err)
+			return nil, fmt.Errorf("un-retryable: %w", err)
+		}
+		info.gateway, err = tryCreateDockerNetwork(ociBin, subnet, info.mtu, networkName)
+		if err == nil {
+			klog.Infof("%s network %s %s created", ociBin, networkName, subnet.CIDR)
+			return info.gateway, nil
+		}
+		// don't retry if error is not adddress is taken
+		if !(errors.Is(err, ErrNetworkSubnetTaken) || errors.Is(err, ErrNetworkGatewayTaken)) {
+			klog.Errorf("error while trying to create %s network %s %s: %v", ociBin, networkName, subnet.CIDR, err)
+			return nil, fmt.Errorf("un-retryable: %w", err)
+		}
+		klog.Warningf("failed to create %s network %s %s, will retry: %v", ociBin, networkName, subnet.CIDR, err)
+		subnetAddr = subnet.IP
+		attempts++
 	}
-	info.gateway, err = tryCreateDockerNetwork(ociBin, subnet.IP, defaultSubnetMask, info.mtu, networkName)
-	if err != nil {
-		return info.gateway, fmt.Errorf("failed to create network after 20 attempts")
-	}
-	return info.gateway, nil
+	return info.gateway, fmt.Errorf("failed to create %s network %s", ociBin, networkName)
 }
 
-func tryCreateDockerNetwork(ociBin string, subnetAddr string, subnetMask int, mtu int, name string) (net.IP, error) {
-	gateway := net.ParseIP(subnetAddr)
-	gateway.To4()[3]++ // first ip for gateway
-	klog.Infof("attempt to create network %s/%d with subnet: %s and gateway %s and MTU of %d ...", subnetAddr, subnetMask, name, gateway, mtu)
+func tryCreateDockerNetwork(ociBin string, subnet *network.Parameters, mtu int, name string) (net.IP, error) {
+	gateway := net.ParseIP(subnet.Gateway)
+	klog.Infof("attempt to create %s network %s %s with gateway %s and MTU of %d ...", ociBin, name, subnet.CIDR, subnet.Gateway, mtu)
 	args := []string{
 		"network",
 		"create",
 		"--driver=bridge",
-		fmt.Sprintf("--subnet=%s", fmt.Sprintf("%s/%d", subnetAddr, subnetMask)),
-		fmt.Sprintf("--gateway=%s", gateway),
+		fmt.Sprintf("--subnet=%s", subnet.CIDR),
+		fmt.Sprintf("--gateway=%s", subnet.Gateway),
 	}
 	if ociBin == Docker {
 		// options documentation https://docs.docker.com/engine/reference/commandline/network_create/#bridge-driver-options
@@ -125,7 +136,7 @@ func tryCreateDockerNetwork(ociBin string, subnetAddr string, subnetMask int, mt
 		if strings.Contains(rr.Output(), "is being used by a network interface") {
 			return nil, ErrNetworkGatewayTaken
 		}
-		return nil, errors.Wrapf(err, "create network %s", fmt.Sprintf("%s %s/%d", name, subnetAddr, subnetMask))
+		return nil, fmt.Errorf("create %s network %s %s with gateway %s and MTU of %d: %w", ociBin, name, subnet.CIDR, subnet.Gateway, mtu, err)
 	}
 	return gateway, nil
 }

--- a/pkg/drivers/kvm/network.go
+++ b/pkg/drivers/kvm/network.go
@@ -169,8 +169,8 @@ func (d *Driver) createNetwork() error {
 		subnetAddr := firstSubnetAddr
 		for attempts < 5 {
 			// Rather than iterate through all of the valid subnets, give up at 20 to avoid a lengthy user delay for something that is unlikely to work.
-			// will be like 192.168.39.0/24,..., 192.168.229.0/24 (in increment steps of 10)
-			subnet, err := network.FreeSubnet(subnetAddr, 10, 20)
+			// will be like 192.168.39.0/24,..., 192.168.248.0/24 (in increment steps of 11)
+			subnet, err := network.FreeSubnet(subnetAddr, 11, 20)
 			if err != nil {
 				log.Debugf("failed to find free subnet for KVM network %s after %d attempts: %v", d.PrivateNetwork, 20, err)
 				return fmt.Errorf("un-retryable: %w", err)

--- a/pkg/drivers/kvm/network.go
+++ b/pkg/drivers/kvm/network.go
@@ -149,8 +149,9 @@ func (d *Driver) createNetwork() error {
 	// It is assumed that the libvirt/kvm installation has already created this network
 	netd, err := conn.LookupNetworkByName(d.Network)
 	if err != nil {
-		return errors.Wrapf(err, "KVM network %s doesn't exist", d.Network)
+		return errors.Wrapf(err, "%s KVM network doesn't exist", d.Network)
 	}
+	log.Debugf("found existing %s KVM network", d.Network)
 	if netd != nil {
 		_ = netd.Free()
 	}
@@ -163,48 +164,47 @@ func (d *Driver) createNetwork() error {
 			_ = netp.Free()
 		}
 	}()
-	if err != nil {
-		// retry up to 5 times to create kvm network
-		attempts := 0
-		subnetAddr := firstSubnetAddr
-		for attempts < 5 {
-			// Rather than iterate through all of the valid subnets, give up at 20 to avoid a lengthy user delay for something that is unlikely to work.
-			// will be like 192.168.39.0/24,..., 192.168.248.0/24 (in increment steps of 11)
-			subnet, err := network.FreeSubnet(subnetAddr, 11, 20)
-			if err != nil {
-				log.Debugf("failed to find free subnet for KVM network %s after %d attempts: %v", d.PrivateNetwork, 20, err)
-				return fmt.Errorf("un-retryable: %w", err)
-			}
-			// create the XML for the private network from our networkTmpl
-			tryNet := kvmNetwork{
-				Name:       d.PrivateNetwork,
-				Parameters: *subnet,
-			}
-			tmpl := template.Must(template.New("network").Parse(networkTmpl))
-			var networkXML bytes.Buffer
-			if err := tmpl.Execute(&networkXML, tryNet); err != nil {
-				return fmt.Errorf("executing KVM network template: %w", err)
-			}
-			// define the network using our template
-			network, err := conn.NetworkDefineXML(networkXML.String())
-			if err != nil {
-				return fmt.Errorf("defining KVM network %s %s from xml %s: %w", d.PrivateNetwork, subnet.CIDR, networkXML.String(), err)
-			}
-			// and finally create & start it
-			log.Debugf("Trying to create KVM network %s %s...", d.PrivateNetwork, subnet.CIDR)
-			if err := network.Create(); err != nil {
-				log.Debugf("Failed to create KVM network %s %s, will retry: %v", d.PrivateNetwork, subnet.CIDR, err)
-				subnetAddr = subnet.IP
-				attempts++
-				continue
-			}
-			log.Debugf("KVM network %s %s created", d.PrivateNetwork, subnet.CIDR)
-			return nil
-		}
-		return fmt.Errorf("failed to create KVM network %s: %w", d.PrivateNetwork, err)
+	if err == nil {
+		log.Debugf("found existing private KVM network %s", d.PrivateNetwork)
+		return nil
 	}
 
-	return nil
+	// retry up to 5 times to create kvm network
+	for attempts, subnetAddr := 0, firstSubnetAddr; attempts < 5; attempts++ {
+		// Rather than iterate through all of the valid subnets, give up at 20 to avoid a lengthy user delay for something that is unlikely to work.
+		// will be like 192.168.39.0/24,..., 192.168.248.0/24 (in increment steps of 11)
+		var subnet *network.Parameters
+		subnet, err = network.FreeSubnet(subnetAddr, 11, 20)
+		if err != nil {
+			log.Debugf("failed to find free subnet for private KVM network %s after %d attempts: %v", d.PrivateNetwork, 20, err)
+			return fmt.Errorf("un-retryable: %w", err)
+		}
+		// create the XML for the private network from our networkTmpl
+		tryNet := kvmNetwork{
+			Name:       d.PrivateNetwork,
+			Parameters: *subnet,
+		}
+		tmpl := template.Must(template.New("network").Parse(networkTmpl))
+		var networkXML bytes.Buffer
+		if err = tmpl.Execute(&networkXML, tryNet); err != nil {
+			return fmt.Errorf("executing private KVM network template: %w", err)
+		}
+		// define the network using our template
+		var network *libvirt.Network
+		network, err = conn.NetworkDefineXML(networkXML.String())
+		if err != nil {
+			return fmt.Errorf("defining private KVM network %s %s from xml %s: %w", d.PrivateNetwork, subnet.CIDR, networkXML.String(), err)
+		}
+		// and finally create & start it
+		log.Debugf("trying to create private KVM network %s %s...", d.PrivateNetwork, subnet.CIDR)
+		if err = network.Create(); err == nil {
+			log.Debugf("private KVM network %s %s created", d.PrivateNetwork, subnet.CIDR)
+			return nil
+		}
+		log.Debugf("failed to create private KVM network %s %s, will retry: %v", d.PrivateNetwork, subnet.CIDR, err)
+		subnetAddr = subnet.IP
+	}
+	return fmt.Errorf("failed to create private KVM network %s: %w", d.PrivateNetwork, err)
 }
 
 func (d *Driver) deleteNetwork() error {


### PR DESCRIPTION
fixes #10833

as described in the example given in the issue's description, and as @medyagh suggested, we can use locks to resolve race condition while competing over a free network segment

this pr implements free network subnet _reservations_ that would expire after the _reservation period_, which is set to one minute by default, and also have a retry mechanism if create network fails, utilising [sync.Map](https://pkg.go.dev/sync#Map) that is _safe for concurrent use by multiple goroutines without additional locking or coordination_

also, to further avoid overlaps between free network scans (ie, kvm starts from 192.168.39.0 and container starts from 192.168.49.0, both with increment steps of 10), increment steps for the kvm is 11 and for the containers is 9