### PR TITLE
bridge cni: Make sure to create the directory for cni config

### DIFF
--- a/pkg/minikube/cni/bridge.go
+++ b/pkg/minikube/cni/bridge.go
@@ -19,6 +19,7 @@ package cni
 import (
 	"bytes"
 	"fmt"
+	"os/exec"
 	"text/template"
 
 	"github.com/pkg/errors"
@@ -82,6 +83,10 @@ func (c Bridge) netconf() (assets.CopyableFile, error) {
 func (c Bridge) Apply(r Runner) error {
 	if len(c.cc.Nodes) > 1 {
 		return fmt.Errorf("bridge CNI is incompatible with multi-node clusters")
+	}
+
+	if _, err := r.RunCmd(exec.Command("sudo", "mkdir", "-p", "/etc/cni/net.d")); err != nil {
+		return err
 	}
 
 	f, err := c.netconf()


### PR DESCRIPTION
Otherwise it will be created with the mktemp permissions
and become unreadable (0700), making chmod fail later on.

Fixes error seen in https://github.com/kubernetes/minikube/issues/10852#issuecomment-801849771

`💣  Error starting cluster: apply cni: cni apply: copy: chmod /etc/cni/net.d/1-k8s.conf: permission denied`