### PR TITLE
add docker-env and podman-env to minikube status

### DIFF
--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -252,8 +252,7 @@ var dockerEnvCmd = &cobra.Command{
 		sh := shell.EnvConfig{
 			Shell: shl,
 		}
-		cname := ClusterFlagValue()
-		co := mustload.Running(cname)
+
 		if dockerUnset {
 			if err := dockerUnsetScript(DockerEnvConfig{EnvConfig: sh}, os.Stdout); err != nil {
 				exit.Error(reason.InternalEnvScript, "Error generating unset output", err)
@@ -265,6 +264,9 @@ var dockerEnvCmd = &cobra.Command{
 			out.SetSilent(true)
 			exit.SetShell(true)
 		}
+
+		cname := ClusterFlagValue()
+		co := mustload.Running(cname)
 
 		driverName := co.CP.Host.DriverName
 

--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -252,7 +252,8 @@ var dockerEnvCmd = &cobra.Command{
 		sh := shell.EnvConfig{
 			Shell: shl,
 		}
-
+		cname := ClusterFlagValue()
+		co := mustload.Running(cname)
 		if dockerUnset {
 			if err := dockerUnsetScript(DockerEnvConfig{EnvConfig: sh}, os.Stdout); err != nil {
 				exit.Error(reason.InternalEnvScript, "Error generating unset output", err)
@@ -265,8 +266,6 @@ var dockerEnvCmd = &cobra.Command{
 			exit.SetShell(true)
 		}
 
-		cname := ClusterFlagValue()
-		co := mustload.Running(cname)
 		driverName := co.CP.Host.DriverName
 
 		if driverName == driver.None {

--- a/go.sum
+++ b/go.sum
@@ -740,6 +740,7 @@ github.com/opencontainers/selinux v1.3.1-0.20190929122143-5215b1806f52/go.mod h1
 github.com/otiai10/copy v1.5.0 h1:SoXDGnlTUZoqB/wSuj/Y5L6T5i6iN4YRAcMCd+JnLNU=
 github.com/otiai10/copy v1.5.0/go.mod h1:XWfuS3CrI0R6IE0FbgHsEazaXO8G0LpMp9o8tos0x4E=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
+github.com/otiai10/curr v1.0.0 h1:TJIWdbX0B+kpNagQrjgq8bCMrbhiuX73M2XwgtDMoOI=
 github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
 github.com/otiai10/mint v1.3.2 h1:VYWnrP5fXmz1MXvjuUvcBrXSjGE6xjON+axB/UrpO3E=

--- a/site/content/en/docs/commands/status.md
+++ b/site/content/en/docs/commands/status.md
@@ -23,7 +23,7 @@ minikube status [flags]
 
 ```
   -f, --format string         Go template format string for the status output.  The format for Go templates can be found here: https://golang.org/pkg/text/template/
-                              For the list accessible variables for the template, see the struct values here: https://godoc.org/k8s.io/minikube/cmd/minikube/cmd#Status (default "{{.Name}}\ntype: Control Plane\nhost: {{.Host}}\nkubelet: {{.Kubelet}}\napiserver: {{.APIServer}}\nkubeconfig: {{.Kubeconfig}}\ntimeToStop: {{.TimeToStop}}\n\n")
+                              For the list accessible variables for the template, see the struct values here: https://godoc.org/k8s.io/minikube/cmd/minikube/cmd#Status (default "{{.Name}}\ntype: Control Plane\nhost: {{.Host}}\nkubelet: {{.Kubelet}}\napiserver: {{.APIServer}}\nkubeconfig: {{.Kubeconfig}}\ntimeToStop: {{.TimeToStop}}\n{{- if .DockerEnv }}\ndocker-env: {{.DockerEnv}}\n{{- end }}\n{{- if .PodManEnv }}\npodman-env: {{.PodManEnv}}\n{{- end }}\n\n")
   -l, --layout string         output layout (EXPERIMENTAL, JSON only): 'nodes' or 'cluster' (default "nodes")
   -n, --node string           The node to check status for. Defaults to control plane. Leave blank with default format for status on all nodes.
   -o, --output string         minikube status --output OUTPUT. json, text (default "text")

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -271,6 +271,9 @@ func validateDockerEnv(ctx context.Context, t *testing.T, profile string) {
 	if !strings.Contains(rr.Output(), "Running") {
 		t.Fatalf("expected status output to include 'Running' after eval docker-env but got: *%s*", rr.Output())
 	}
+	if !strings.Contains(rr.Output(), "in-use") {
+		t.Fatalf("expected status output to include `in-use` after eval docker-env but got *%s*", rr.Output())
+	}
 
 	mctx, cancel = context.WithTimeout(ctx, Seconds(60))
 	defer cancel()


### PR DESCRIPTION
Signed-off-by: Tharun <rajendrantharun@live.com>

Before: `minikube status`
<img width="500" alt="Screen Shot 2021-03-23 at 2 36 18 PM" src="https://user-images.githubusercontent.com/14926492/112121356-2df90c00-8be5-11eb-846c-df642b20bfea.png">

After: `minikube docker-env` and `minikube-status` and `minikube docker-env --unset`
<img width="597" alt="Screen Shot 2021-03-23 at 2 37 17 PM" src="https://user-images.githubusercontent.com/14926492/112121496-53861580-8be5-11eb-8cc7-42025a9c632b.png">

`minikube status --output=json` result:
<img width="1234" alt="Screen Shot 2021-03-23 at 3 36 54 PM" src="https://user-images.githubusercontent.com/14926492/112130211-44f02c00-8bee-11eb-8eae-07f62577fc63.png">

Fixes #6535