### PR TITLE
Upgrade ingress addon files according to upstream(ingress-nginx v0.44.0)

### DIFF
--- a/deploy/addons/ingress/ingress-configmap.yaml.tmpl
+++ b/deploy/addons/ingress/ingress-configmap.yaml.tmpl
@@ -13,28 +13,46 @@
 # limitations under the License.
 
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    addonmanager.kubernetes.io/mode: Reconcile
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/component: controller
+    addonmanager.kubernetes.io/mode: EnsureExists
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
 data:
   # see https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md for all possible options and their description
   hsts: "false"
-kind: ConfigMap
-metadata:
-  name: nginx-load-balancer-conf
-  namespace: kube-system
-  labels:
-    addonmanager.kubernetes.io/mode: EnsureExists
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: tcp-services
-  namespace: kube-system
+  namespace: ingress-nginx
   labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/component: controller
     addonmanager.kubernetes.io/mode: EnsureExists
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: udp-services
-  namespace: kube-system
+  namespace: ingress-nginx
   labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/component: controller
     addonmanager.kubernetes.io/mode: EnsureExists

--- a/deploy/addons/ingress/ingress-dp.yaml.tmpl
+++ b/deploy/addons/ingress/ingress-dp.yaml.tmpl
@@ -13,30 +13,76 @@
 # limitations under the License.
 
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/component: controller
+    addonmanager.kubernetes.io/mode: Reconcile
+  name: ingress-nginx-controller-admission
+  namespace: ingress-nginx
+spec:
+  type: ClusterIP
+  ports:
+    - name: https-webhook
+      port: 443
+      targetPort: webhook
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/component: controller
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/component: controller
+    addonmanager.kubernetes.io/mode: Reconcile
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: https
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/component: controller
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ingress-nginx-controller
-  namespace: kube-system
+  namespace: ingress-nginx
   labels:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/part-of: kube-system
     app.kubernetes.io/component: controller
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
-  replicas: 1
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      # maxUnavailable needs to be 1 so that port conflicts between the old and new pod doesn't happen when using hostPort
-      maxUnavailable: 1
-      maxSurge: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: ingress-nginx
       app.kubernetes.io/instance: ingress-nginx
       app.kubernetes.io/component: controller
+      addonmanager.kubernetes.io/mode: Reconcile
+  revisionHistoryLimit: 10
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  minReadySeconds: 0
   template:
     metadata:
       labels:
@@ -46,7 +92,7 @@ spec:
         addonmanager.kubernetes.io/mode: Reconcile
         gcp-auth-skip-secret: "true"
     spec:
-      serviceAccountName: ingress-nginx
+      dnsPolicy: ClusterFirst
       containers:
         - name: controller
           image: {{.CustomRegistries.IngressController  | default .ImageRepository | default .Registries.IngressController }}{{.Images.IngressController}}
@@ -58,7 +104,8 @@ spec:
                   - /wait-shutdown
           args:
             - /nginx-ingress-controller
-            - --configmap=$(POD_NAMESPACE)/nginx-load-balancer-conf
+            - --ingress-class=nginx
+            - --configmap=$(POD_NAMESPACE)/ingress-nginx-controller
             - --report-node-internal-ip-address
             - --tcp-services-configmap=$(POD_NAMESPACE)/tcp-services
             - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
@@ -67,7 +114,7 @@ spec:
             - --validating-webhook-key=/usr/local/certificates/key
             {{if .CustomIngressCert}}
             - --default-ssl-certificate={{ .CustomIngressCert }} 
-           {{end}}
+            {{end}}
           securityContext:
             capabilities:
               drop:
@@ -85,6 +132,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: LD_PRELOAD
+              value: /usr/local/lib/libmimalloc.so
           livenessProbe:
             httpGet:
               path: /healthz
@@ -94,13 +143,14 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1
             successThreshold: 1
-            failureThreshold: 3
+            failureThreshold: 5
           readinessProbe:
             httpGet:
               path: /healthz
               port: 10254
               scheme: HTTP
             initialDelaySeconds: 10
+            periodSeconds: 10
             timeoutSeconds: 1
             successThreshold: 1
             failureThreshold: 3
@@ -124,24 +174,24 @@ spec:
             requests:
               cpu: 100m
               memory: 90Mi
+      serviceAccountName: ingress-nginx
       volumes:
         - name: webhook-cert
           secret:
             secretName: ingress-nginx-admission
-
 ---
-
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: admission-webhook
+    addonmanager.kubernetes.io/mode: Reconcile
   name: ingress-nginx-admission
-  namespace: kube-system
 webhooks:
   - name: validate.nginx.ingress.kubernetes.io
+    matchPolicy: Equivalent
     rules:
       - apiGroups:
           - networking.k8s.io
@@ -160,45 +210,9 @@ webhooks:
       - v1beta1
     clientConfig:
       service:
-        namespace: kube-system
+        namespace: ingress-nginx
         name: ingress-nginx-controller-admission
         path: /networking/v1beta1/ingresses
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: ingress-nginx-admission
-  labels:
-    app.kubernetes.io/name: ingress-nginx
-    app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/component: admission-webhook
-  namespace: kube-system
-rules:
-  - apiGroups:
-      - admissionregistration.k8s.io
-    resources:
-      - validatingwebhookconfigurations
-    verbs:
-      - get
-      - update
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: ingress-nginx-admission
-  labels:
-    app.kubernetes.io/name: ingress-nginx
-    app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/component: admission-webhook
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: ingress-nginx-admission
-subjects:
-  - kind: ServiceAccount
-    name: ingress-nginx-admission
-    namespace: kube-system
 ---
 apiVersion: batch/v1
 kind: Job
@@ -208,7 +222,8 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: admission-webhook
-  namespace: kube-system
+    addonmanager.kubernetes.io/mode: Reconcile
+  namespace: ingress-nginx
 spec:
   template:
     metadata:
@@ -217,6 +232,7 @@ spec:
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/component: admission-webhook
+        addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:
         - name: create
@@ -224,17 +240,20 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - create
-            - --host=ingress-nginx-controller-admission,ingress-nginx-controller-admission.kube-system.svc
-            - --namespace=kube-system
+            - --host=ingress-nginx-controller-admission,ingress-nginx-controller-admission.$(POD_NAMESPACE).svc
+            - --namespace=$(POD_NAMESPACE)
             - --secret-name=ingress-nginx-admission
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
       restartPolicy: OnFailure
       serviceAccountName: ingress-nginx-admission
       securityContext:
         runAsNonRoot: true
         runAsUser: 2000
-
 ---
-
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -243,7 +262,8 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: admission-webhook
-  namespace: kube-system
+    addonmanager.kubernetes.io/mode: Reconcile
+  namespace: ingress-nginx
 spec:
   template:
     metadata:
@@ -252,41 +272,26 @@ spec:
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/component: admission-webhook
+        addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:
         - name: patch
           image: {{.CustomRegistries.KubeWebhookCertgenPatch  | default .ImageRepository | default .Registries.KubeWebhookCertgenPatch }}{{.Images.KubeWebhookCertgenPatch}}
-          imagePullPolicy:
+          imagePullPolicy: IfNotPresent
           args:
             - patch
             - --webhook-name=ingress-nginx-admission
-            - --namespace=kube-system
+            - --namespace=$(POD_NAMESPACE)
             - --patch-mutating=false
             - --secret-name=ingress-nginx-admission
             - --patch-failure-policy=Fail
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
       restartPolicy: OnFailure
       serviceAccountName: ingress-nginx-admission
       securityContext:
         runAsNonRoot: true
         runAsUser: 2000
----
-
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app.kubernetes.io/name: ingress-nginx
-    app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/component: controller
-    addonmanager.kubernetes.io/mode: Reconcile
-  name: ingress-nginx-controller-admission
-  namespace: kube-system
-spec:
-  ports:
-    - name: https-webhook
-      port: 443
-      targetPort: webhook
-  selector:
-    app.kubernetes.io/name: ingress-nginx
-    app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/component: controller

--- a/deploy/addons/ingress/ingress-rbac.yaml.tmpl
+++ b/deploy/addons/ingress/ingress-rbac.yaml.tmpl
@@ -1,34 +1,23 @@
 ---
-
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: ingress-nginx
-  namespace: kube-system
-  labels:
-    addonmanager.kubernetes.io/mode: Reconcile
-
----
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: ingress-nginx-admission
   labels:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/component: controller
     addonmanager.kubernetes.io/mode: Reconcile
-  namespace: kube-system
-
+  name: ingress-nginx
+  namespace: ingress-nginx
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: system::ingress-nginx
   labels:
-    kubernetes.io/bootstrapping: rbac-defaults
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    addonmanager.kubernetes.io/mode: Reconcile
+  name: ingress-nginx
 rules:
   - apiGroups:
       - ''
@@ -86,17 +75,34 @@ rules:
       - get
       - list
       - watch
-
 ---
-
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ingress-nginx
+subjects:
+- kind: ServiceAccount
+  name: ingress-nginx
+  namespace: ingress-nginx
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: system::ingress-nginx
-  namespace: kube-system
   labels:
-    kubernetes.io/bootstrapping: rbac-defaults
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/component: controller
     addonmanager.kubernetes.io/mode: Reconcile
+  name: ingress-nginx
+  namespace: ingress-nginx
 rules:
   - apiGroups:
       - ''
@@ -122,7 +128,6 @@ rules:
     verbs:
       - get
       - list
-      - update
       - watch
   - apiGroups:
       - extensions
@@ -166,56 +171,79 @@ rules:
   - apiGroups:
       - ''
     resources:
-      - endpoints
-    verbs:
-      - get
-  - apiGroups:
-      - ''
-    resources:
       - events
     verbs:
       - create
       - patch
-
 ---
-
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: system::ingress-nginx
-  namespace: kube-system
   labels:
-    kubernetes.io/bootstrapping: rbac-defaults
-    addonmanager.kubernetes.io/mode: EnsureExists
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/component: controller
+    addonmanager.kubernetes.io/mode: Reconcile
+  name: ingress-nginx
+  namespace: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: system::ingress-nginx
+  name: ingress-nginx
 subjects:
 - kind: ServiceAccount
   name: ingress-nginx
-  namespace: kube-system
-
+  namespace: ingress-nginx
 ---
-
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ingress-nginx-admission
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/component: admission-webhook
+    addonmanager.kubernetes.io/mode: Reconcile
+  namespace: ingress-nginx
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ingress-nginx-admission
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/component: admission-webhook
+    addonmanager.kubernetes.io/mode: Reconcile
+  namespace: ingress-nginx
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system::ingress-nginx
+  name: ingress-nginx-admission
   labels:
-    kubernetes.io/bootstrapping: rbac-defaults
-    addonmanager.kubernetes.io/mode: EnsureExists
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/component: admission-webhook
+    addonmanager.kubernetes.io/mode: Reconcile
+  namespace: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system::ingress-nginx
+  name: ingress-nginx-admission
 subjects:
-- kind: ServiceAccount
-  name: ingress-nginx
-  namespace: kube-system
-
+  - kind: ServiceAccount
+    name: ingress-nginx-admission
+    namespace: ingress-nginx
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -224,9 +252,8 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: admission-webhook
-    kubernetes.io/bootstrapping: rbac-defaults
-    addonmanager.kubernetes.io/mode: EnsureExists
-  namespace: kube-system
+    addonmanager.kubernetes.io/mode: Reconcile
+  namespace: ingress-nginx
 rules:
   - apiGroups:
       - ''
@@ -235,20 +262,17 @@ rules:
     verbs:
       - get
       - create
-
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: system::ingress-nginx-admission
+  name: ingress-nginx-admission
   labels:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: admission-webhook
-    kubernetes.io/bootstrapping: rbac-defaults
-    addonmanager.kubernetes.io/mode: EnsureExists
-  namespace: kube-system
+    addonmanager.kubernetes.io/mode: Reconcile
+  namespace: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -256,4 +280,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ingress-nginx-admission
-    namespace: kube-system
+    namespace: ingress-nginx

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -281,7 +281,11 @@ func enableOrDisableAddonInternal(cc *config.ClusterConfig, addon *assets.Addon,
 }
 
 func verifyAddonStatus(cc *config.ClusterConfig, name string, val string) error {
-	return verifyAddonStatusInternal(cc, name, val, "kube-system")
+	ns := "kube-system"
+	if name == "ingress" {
+		ns = "ingress-nginx"
+	}
+	return verifyAddonStatusInternal(cc, name, val, ns)
 }
 
 func verifyAddonStatusInternal(cc *config.ClusterConfig, name string, val string, ns string) error {

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -226,11 +226,11 @@ var Addons = map[string]*Addon{
 			"ingress-dp.yaml",
 			"0640"),
 	}, false, "ingress", map[string]string{
-		"IngressController":        "k8s-artifacts-prod/ingress-nginx/controller:v0.40.2@sha256:46ba23c3fbaafd9e5bd01ea85b2f921d9f2217be082580edc22e6c704a83f02f",
-		"KubeWebhookCertgenCreate": "jettech/kube-webhook-certgen:v1.2.2@sha256:da8122a78d7387909cf34a0f34db0cce672da1379ee4fd57c626a4afe9ac12b7",
-		"KubeWebhookCertgenPatch":  "jettech/kube-webhook-certgen:v1.3.0@sha256:ff01fba91131ed260df3f3793009efbf9686f5a5ce78a85f81c386a4403f7689",
+		"IngressController":        "ingress-nginx/controller:v0.44.0@sha256:3dd0fac48073beaca2d67a78c746c7593f9c575168a17139a9955a82c63c4b9a",
+		"KubeWebhookCertgenCreate": "docker.io/jettech/kube-webhook-certgen:v1.5.1@sha256:950833e19ade18cd389d647efb88992a7cc077abedef343fa59e012d376d79b7",
+		"KubeWebhookCertgenPatch":  "docker.io/jettech/kube-webhook-certgen:v1.5.1@sha256:950833e19ade18cd389d647efb88992a7cc077abedef343fa59e012d376d79b7",
 	}, map[string]string{
-		"IngressController": "us.gcr.io",
+		"IngressController": "k8s.gcr.io",
 	}),
 	"istio-provisioner": NewAddon([]*BinAsset{
 		MustBinAsset(

--- a/site/content/en/docs/tutorials/custom_cert_ingress.md
+++ b/site/content/en/docs/tutorials/custom_cert_ingress.md
@@ -39,6 +39,6 @@ $ minikube addons enable ingress
 ```
 - Verify if custom certificate was enabled
 ```
-$ kubectl -n kube-system get deployment ingress-nginx-controller -o yaml | grep "kube-system"
+$ kubectl -n ingress-nginx get deployment ingress-nginx-controller -o yaml | grep "kube-system"
 - --default-ssl-certificate=kube-system/mkcert
 ```

--- a/site/content/en/docs/tutorials/nginx_tcp_udp_ingress.md
+++ b/site/content/en/docs/tutorials/nginx_tcp_udp_ingress.md
@@ -121,7 +121,7 @@ kubectl apply -f redis-service.yaml
 To add a TCP service to the nginx ingress controller you can run the following command:
 
 ```shell
-kubectl patch configmap tcp-services -n kube-system --patch '{"data":{"6379":"default/redis-service:6379"}}'
+kubectl patch configmap tcp-services -n ingress-nginx --patch '{"data":{"6379":"default/redis-service:6379"}}'
 ```
 
 Where:
@@ -133,7 +133,7 @@ Where:
 We can verify that our resource was patched with the following command:
 
 ```shell
-kubectl get configmap tcp-services -n kube-system -o yaml
+kubectl get configmap tcp-services -n ingress-nginx -o yaml
 ```
 
 We should see something like this:
@@ -148,9 +148,9 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: EnsureExists
   name: tcp-services
-  namespace: kube-system
+  namespace: ingress-nginx
   resourceVersion: "2857"
-  selfLink: /api/v1/namespaces/kube-system/configmaps/tcp-services
+  selfLink: /api/v1/namespaces/ingress-nginx/configmaps/tcp-services
   uid: 4f7fac22-e467-11e9-b543-080027057910
 ```
 
@@ -183,7 +183,7 @@ Create a file called `ingress-nginx-controller-patch.yaml` and paste the content
 Next apply the changes with the following command:
 
 ```shell
-kubectl patch deployment ingress-nginx-controller --patch "$(cat ingress-nginx-controller-patch.yaml)" -n kube-system
+kubectl patch deployment ingress-nginx-controller --patch "$(cat ingress-nginx-controller-patch.yaml)" -n ingress-nginx
 ```
 
 ### Test your connection
@@ -211,8 +211,8 @@ If you were not able to connect please review your steps above.
 In the above example we did the following:
 
 - Created a redis deployment and service in the `default` namespace
-- Patched the `tcp-services` configmap in the `kube-system` namespace
-- Patched the `ingress-nginx-controller` deployment in the `kube-system` namespace
+- Patched the `tcp-services` configmap in the `ingress-nginx` namespace
+- Patched the `ingress-nginx-controller` deployment in the `ingress-nginx` namespace
 - Connected to our service from the host via port 6379
 
 You can apply the same steps that were applied to `tcp-services` to the `udp-services` configmap as well if you have a

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -148,11 +148,11 @@ func validateIngressAddon(ctx context.Context, t *testing.T, profile string) {
 		t.Fatalf("failed to get Kubernetes client: %v", client)
 	}
 
-	if err := kapi.WaitForDeploymentToStabilize(client, "kube-system", "ingress-nginx-controller", Minutes(6)); err != nil {
+	if err := kapi.WaitForDeploymentToStabilize(client, "ingress-nginx", "ingress-nginx-controller", Minutes(6)); err != nil {
 		t.Errorf("failed waiting for ingress-controller deployment to stabilize: %v", err)
 	}
-	if _, err := PodWait(ctx, t, profile, "kube-system", "app.kubernetes.io/name=ingress-nginx", Minutes(12)); err != nil {
-		t.Fatalf("failed waititing for nginx-ingress-controller : %v", err)
+	if _, err := PodWait(ctx, t, profile, "ingress-nginx", "app.kubernetes.io/name=ingress-nginx", Minutes(12)); err != nil {
+		t.Fatalf("failed waititing for ingress-nginx-controller : %v", err)
 	}
 
 	createIngress := func() error {

--- a/test/integration/testdata/nginx-ing.yaml
+++ b/test/integration/testdata/nginx-ing.yaml
@@ -1,7 +1,9 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: nginx-ingress
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
   labels:
     integration-test: ingress
 spec:
@@ -9,7 +11,7 @@ spec:
   - host: nginx.example.com
     http:
       paths:
-      - path: /
+      - path: "/"
         backend:
           serviceName: nginx
           servicePort: 80


### PR DESCRIPTION
### What type of PR is this?
/area addons
/kind cleanup

### What this PR does / why we need it:

This PR upgrades ingress addon according to upstream([kubernets/ingress-nginx](https://github.com/kubernetes/ingress-nginx)).
Our minikube's ingress manifest files are very old, because they have been held since 2016, https://github.com/kubernetes/minikube/commit/f1fb26adc6c62fb4f5991ae42ab1889c92e4a2c0.
Our ingress addon's manifests are very different from [upstream ones](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-3.23.0/deploy/static/provider/kind/deploy.yaml).
So, there are many differnces in this PR...

This PR upgrade ingress addon's version and K8s apiVersions.

### Which issue(s) this PR fixes:
Fix #10855

### Does this PR introduce a user-facing change?

Yes, this PR change ingress addon's version(to v0.44.0) and K8s apiVersions.

**Before this PR**

```
Namespace: kube-system
ValidatingWebhookConfiguration: admissionregistration.k8s.io/v1beta1
RoleBinding: rbac.authorization.k8s.io/v1beta1
nginx controller: k8s-artifacts-prod/ingress-nginx/controller:v0.40.2
Ingress: extensions/v1beta1
```

**After this PR**

```
Namespace: ingress-nginx
ValidatingWebhookConfiguration: admissionregistration.k8s.io/v1
RoleBinding: rbac.authorization.k8s.io/v1
nginx controller: ingress-nginx/controller:v0.44.0
Ingress: networking.k8s.io/v1beta1
```

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```