### PR TITLE
Added error check for extra quotation for extra-config.

### DIFF
--- a/pkg/minikube/config/extra_options.go
+++ b/pkg/minikube/config/extra_options.go
@@ -66,14 +66,11 @@ func (es *ExtraOptionSlice) Exists(value string) bool {
 // Set parses the string value into a slice
 func (es *ExtraOptionSlice) Set(value string) error {
 
-	// Check doesn't start or end with an opening quotation.
-	if strings.HasPrefix(value, "“") || strings.HasSuffix(value, "“") {
-		return fmt.Errorf("invalid value: canot contain quotation: %q", value)
-	}
-
-	// Check doesn't start or end with a closing quotation.
-	if strings.HasPrefix(value, "”") || strings.HasSuffix(value, "”") {
-		return fmt.Errorf("invalid value: canot contain quotation: %q", value)
+	// Check we don't end with suffix quotation.
+	prefixExists := strings.HasPrefix(value, "”") || strings.HasPrefix(value, "”")
+	suffixExists := strings.HasSuffix(value, "”") || strings.HasSuffix(value, "”")
+	if !prefixExists && suffixExists {
+		return fmt.Errorf("invalid value: cannot contain end quotation: %q", value)
 	}
 
 	// The component is the value before the first dot.

--- a/pkg/minikube/config/extra_options.go
+++ b/pkg/minikube/config/extra_options.go
@@ -65,7 +65,13 @@ func (es *ExtraOptionSlice) Exists(value string) bool {
 
 // Set parses the string value into a slice
 func (es *ExtraOptionSlice) Set(value string) error {
-	// Check doesn't start or end with a quotation.
+
+	// Check doesn't start or end with an opening quotation.
+	if strings.HasPrefix(value, "“") || strings.HasSuffix(value, "“") {
+		return fmt.Errorf("invalid value: canot contain quotation: %q", value)
+	}
+
+	// Check doesn't start or end with a closing quotation.
 	if strings.HasPrefix(value, "”") || strings.HasSuffix(value, "”") {
 		return fmt.Errorf("invalid value: canot contain quotation: %q", value)
 	}

--- a/pkg/minikube/config/extra_options.go
+++ b/pkg/minikube/config/extra_options.go
@@ -65,6 +65,11 @@ func (es *ExtraOptionSlice) Exists(value string) bool {
 
 // Set parses the string value into a slice
 func (es *ExtraOptionSlice) Set(value string) error {
+	// Check doesn't start or end with a quotation.
+	if strings.HasPrefix(value, "”") || strings.HasSuffix(value, "”") {
+		return fmt.Errorf("invalid value: canot contain quotation: %q", value)
+	}
+
 	// The component is the value before the first dot.
 	componentSplit := strings.SplitN(value, ".", 2)
 	if len(componentSplit) < 2 {

--- a/pkg/minikube/config/extra_options.go
+++ b/pkg/minikube/config/extra_options.go
@@ -67,8 +67,8 @@ func (es *ExtraOptionSlice) Exists(value string) bool {
 func (es *ExtraOptionSlice) Set(value string) error {
 
 	// Check we don't end with suffix quotation.
-	prefixExists := strings.HasPrefix(value, "”") || strings.HasPrefix(value, "”")
-	suffixExists := strings.HasSuffix(value, "”") || strings.HasSuffix(value, "”")
+	prefixExists := strings.HasPrefix(value, "”") || strings.HasPrefix(value, "“")
+	suffixExists := strings.HasSuffix(value, "”") || strings.HasSuffix(value, "“")
 	if !prefixExists && suffixExists {
 		return fmt.Errorf("invalid value: cannot contain end quotation: %q", value)
 	}

--- a/pkg/minikube/config/extra_options.go
+++ b/pkg/minikube/config/extra_options.go
@@ -70,7 +70,7 @@ func (es *ExtraOptionSlice) Set(value string) error {
 	prefixExists := strings.HasPrefix(value, "”") || strings.HasPrefix(value, "“")
 	suffixExists := strings.HasSuffix(value, "”") || strings.HasSuffix(value, "“")
 	if !prefixExists && suffixExists {
-		return fmt.Errorf("invalid value: cannot contain end quotation: %q", value)
+		return fmt.Errorf("invalid value: extra-config cannot contain end quotation: %q", value)
 	}
 
 	// The component is the value before the first dot.

--- a/pkg/minikube/config/extra_options_test.go
+++ b/pkg/minikube/config/extra_options_test.go
@@ -133,7 +133,10 @@ func TestSet(t *testing.T) {
 
 func TestExists(t *testing.T) {
 	extraOptions := ExtraOptionSlice{}
-	extraOptions.Set("")
+	err := extraOptions.Set("")
+	if err != nil {
+		t.Errorf("Set empty value string fails.")
+	}
 
 	for _, tc := range []struct {
 		searchString string

--- a/pkg/minikube/config/extra_options_test.go
+++ b/pkg/minikube/config/extra_options_test.go
@@ -132,10 +132,10 @@ func TestSet(t *testing.T) {
 }
 
 func TestExists(t *testing.T) {
-	extraOptions := ExtraOptionSlice{}
-	err := extraOptions.Set("")
-	if err != nil {
-		t.Errorf("Set empty value string fails.")
+	extraOptions := ExtraOptionSlice{
+		ExtraOption{Component: "c1", Key: "bar", Value: "c1-bar"},
+		ExtraOption{Component: "c1", Key: "baz", Value: "c1-baz"},
+		ExtraOption{Component: "c2", Key: "bar", Value: "c2-bar"},
 	}
 
 	for _, tc := range []struct {

--- a/pkg/minikube/config/extra_options_test.go
+++ b/pkg/minikube/config/extra_options_test.go
@@ -94,6 +94,8 @@ func createEqualError(value string) error {
 
 func TestSet(t *testing.T) {
 	extraOptions := ExtraOptionSlice{}
+
+	// Examples which will error from checks from the Set function.
 	for _, tc := range []struct {
 		valuesToSet string
 		expErr      error
@@ -112,6 +114,7 @@ func TestSet(t *testing.T) {
 		}
 	}
 
+	// Examples which will not error from the Set function.
 	for _, tc := range []struct {
 		valuesToSet string
 		extraOption ExtraOptionSlice


### PR DESCRIPTION
fixes #8694 

Here is the output with the PR changes: 
vishals-MacBook-Pro:minikube vishal$ ./out/minikube start --driver=docker --extra-config=etcd.client-cert-auth=false”
Error: invalid argument "etcd.client-cert-auth=false”" for "--extra-config" flag: invalid value: cannot contain end quotation: "etcd.client-cert-auth=false”"
See 'minikube start --help' for usage.

Before, the ./out/minikube start command would just hang. This PR handles the case where end of --extra-config value has an open/close quotation because that's where the hanging behavior occurs.


<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
