### PR TITLE
Fix the docs generation to be more deterministic

### DIFF
--- a/pkg/generate/docs.go
+++ b/pkg/generate/docs.go
@@ -56,6 +56,9 @@ func DocForCommand(command *cobra.Command) (string, error) {
 	if err := generateTitle(command, buf); err != nil {
 		return "", errors.Wrap(err, "generating title")
 	}
+	if err := rewriteLogFile(); err != nil {
+		return "", errors.Wrap(err, "rewriting log_file")
+	}
 	if err := rewriteFlags(command); err != nil {
 		return "", errors.Wrap(err, "rewriting flags")
 	}

--- a/pkg/generate/rewrite.go
+++ b/pkg/generate/rewrite.go
@@ -20,7 +20,23 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
+
+// rewriteLogFile resets the magic "log_file" flag
+// otherwise it starts out under $TMP somewhere
+// and shows up as Changed, to default value ""
+func rewriteLogFile() error {
+	flag := pflag.Lookup("log_file")
+	if flag != nil {
+		// don't show the default value
+		err := pflag.Set("log_file", "")
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
 type rewrite struct {
 	flag       string


### PR DESCRIPTION
Was failing unit tests:

```diff
-      --log_file string                  If non-empty, use this log file
+      --log_file string                  If non-empty, use this log file (default "")
```