### PR TITLE
Fix/minikube status for scheduled stop

### DIFF
--- a/pkg/minikube/schedule/daemonize_unix.go
+++ b/pkg/minikube/schedule/daemonize_unix.go
@@ -28,7 +28,9 @@ import (
 	"github.com/VividCortex/godaemon"
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
+	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/localpath"
+	"k8s.io/minikube/pkg/minikube/mustload"
 )
 
 // KillExisting kills existing scheduled stops by looking up the PID
@@ -37,6 +39,11 @@ func KillExisting(profiles []string) {
 	for _, profile := range profiles {
 		if err := killPIDForProfile(profile); err != nil {
 			klog.Errorf("error killng PID for profile %s: %v", profile, err)
+		}
+		_, cc := mustload.Partial(profile)
+		cc.ScheduledStop = nil
+		if err := config.SaveProfile(profile, cc); err != nil {
+			klog.Errorf("error saving profile for profile %s: %v", profile, err)
 		}
 	}
 }

--- a/test/integration/scheduled_stop_test.go
+++ b/test/integration/scheduled_stop_test.go
@@ -105,7 +105,10 @@ func TestScheduledStopUnix(t *testing.T) {
 	// sleep 12 just to be safe
 	stopMinikube(ctx, t, profile, []string{"--cancel-scheduled"})
 	time.Sleep(12 * time.Second)
+	// make sure minikube status is "Running"
 	ensureMinikubeStatus(ctx, t, profile, "Host", state.Running.String())
+	// make sure minikube timetoStop is not present
+	ensureTimeToStopNotPresent(ctx, t, profile)
 
 	// schedule another stop, make sure minikube status is "Stopped"
 	stopMinikube(ctx, t, profile, []string{"--schedule", "5s"})


### PR DESCRIPTION
This pr fixes the `minikube status` field `TimeToStop` when all `scheduledStop` is cancelled.

Before:
<img width="499" alt="Screen Shot 2021-03-24 at 12 00 13 PM" src="https://user-images.githubusercontent.com/14926492/112265447-850be900-8c98-11eb-8cb6-2dafddfd9f6a.png">

After:
<img width="708" alt="Screen Shot 2021-03-24 at 9 43 08 PM" src="https://user-images.githubusercontent.com/14926492/112344322-fc1d9d80-8ce9-11eb-9948-498610d1ebd7.png">

Fixes #10907
