### PR TITLE
Fix: path [commands/completion.md]

### DIFF
--- a/site/content/en/docs/commands/completion.md
+++ b/site/content/en/docs/commands/completion.md
@@ -23,7 +23,7 @@ Outputs minikube shell completion for the given shell (bash, zsh or fish)
 		$ minikube completion fish > ~/.config/fish/completions/minikube.fish # for fish users
 	Ubuntu:
 		$ apt-get install bash-completion
-		$ source /etc/bash-completion
+		$ source /etc/bash_completion
 		$ source <(minikube completion bash) # for bash users
 		$ source <(minikube completion zsh) # for zsh users
 		$ minikube completion fish > ~/.config/fish/completions/minikube.fish # for fish users


### PR DESCRIPTION
[site/content/en/docs/commands/completion.md]
Replaced dash (-) for underscore (_) Line 26 => source /etc/bash_completion
