### PR TITLE
Addon: bump metrics-server to v0.4.2

### DIFF
--- a/deploy/addons/metrics-server/metrics-server-deployment.yaml.tmpl
+++ b/deploy/addons/metrics-server/metrics-server-deployment.yaml.tmpl
@@ -11,16 +11,58 @@ spec:
   selector:
     matchLabels:
       k8s-app: metrics-server
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
   template:
     metadata:
       name: metrics-server
       labels:
         k8s-app: metrics-server
     spec:
+      serviceAccountName: metrics-server
+      volumes:
+      # mount in tmp so we can safely use from-scratch images and/or read-only containers
+      - name: tmp-dir
+        emptyDir: {}
+      priorityClassName: system-cluster-critical
       containers:
       - name: metrics-server
         image: {{.CustomRegistries.MetricsServer  | default .ImageRepository | default .Registries.MetricsServer }}{{.Images.MetricsServer}}
         imagePullPolicy: IfNotPresent
-        command:
-        - /metrics-server
-        - --source=kubernetes.summary_api:https://kubernetes.default?kubeletHttps=true&kubeletPort=10250&insecure=true
+        args:
+          - --cert-dir=/tmp
+          - --secure-port=4443
+          - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+          - --kubelet-use-node-status-port
+          - --metric-resolution=15s
+          - --kubelet-insecure-tls
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        ports:
+        - name: https
+          containerPort: 4443
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz?exclude=livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
+          failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            path: /livez?exclude=readyz
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
+          failureThreshold: 3
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
+        volumeMounts:
+        - name: tmp-dir
+          mountPath: /tmp

--- a/deploy/addons/metrics-server/metrics-server-rbac.yaml.tmpl
+++ b/deploy/addons/metrics-server/metrics-server-rbac.yaml.tmpl
@@ -1,0 +1,87 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:aggregated-metrics-reader
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+- apiGroups: ["metrics.k8s.io"]
+  resources: ["pods", "nodes"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: metrics-server-auth-reader
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics-server:system:auth-delegator
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:metrics-server
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - nodes
+      - nodes/stats
+      - namespaces
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:metrics-server
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-server
+subjects:
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system

--- a/deploy/addons/metrics-server/metrics-server-service.yaml.tmpl
+++ b/deploy/addons/metrics-server/metrics-server-service.yaml.tmpl
@@ -12,6 +12,7 @@ spec:
   selector:
     k8s-app: metrics-server
   ports:
-  - port: 443
+  - name: https
+    port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https

--- a/pkg/addons/config.go
+++ b/pkg/addons/config.go
@@ -112,7 +112,7 @@ var Addons = []*Addon{
 	{
 		name:      "metrics-server",
 		set:       SetBool,
-		callbacks: []setFn{EnableOrDisableAddon},
+		callbacks: []setFn{EnableOrDisableAddon, verifyAddonStatus},
 	},
 	{
 		name:      "nvidia-driver-installer",

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -269,12 +269,17 @@ var Addons = map[string]*Addon{
 			"metrics-server-deployment.yaml",
 			"0640"),
 		MustBinAsset(
+			"deploy/addons/metrics-server/metrics-server-rbac.yaml.tmpl",
+			vmpath.GuestAddonsDir,
+			"metrics-server-rbac.yaml",
+			"0640"),
+		MustBinAsset(
 			"deploy/addons/metrics-server/metrics-server-service.yaml.tmpl",
 			vmpath.GuestAddonsDir,
 			"metrics-server-service.yaml",
 			"0640"),
 	}, false, "metrics-server", map[string]string{
-		"MetricsServer": fmt.Sprintf("metrics-server-%s:v0.2.1", runtime.GOARCH),
+		"MetricsServer": "metrics-server/metrics-server:v0.4.2@sha256:dbc33d7d35d2a9cc5ab402005aa7a0d13be6192f3550c7d42cba8d2d5e3a5d62",
 	}, map[string]string{
 		"MetricsServer": "k8s.gcr.io",
 	}),

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -333,7 +333,6 @@ func validateMetricsServerAddon(ctx context.Context, t *testing.T, profile strin
 		return nil
 	}
 
-	// metrics-server takes some time to be able to collect metrics
 	if err := retry.Expo(checkMetricsServer, time.Second*3, Minutes(6)); err != nil {
 		t.Errorf("failed checking metric server: %v", err.Error())
 	}


### PR DESCRIPTION
### What type of PR is this?
/kind process
/area addons

### What this PR does / why we need it:

This PR bump the metrics-server addon to v0.4.2(latest).
Current metrics-server's version is v0.2.1. So, there is a breaking change in metrics-server([ref](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.4.0)).
I updated the entire manifests with reference to the upstream.
Upstream: https://github.com/kubernetes-sigs/metrics-server/tree/v0.4.2/manifests/base

This upgrade includes 2.75x speed up to be able to get metrics data.
Old: 88s → New: 33s

### Which issue(s) this PR fixes:
Fix #10949 

### Does this PR introduce a user-facing change?

Yes, this PR change metrics-server addon's image tag from `v.0.2.1` to `v0.4.2`.

**Before this PR**

```
./out/minikube addons enable metrics-server
    ▪ Using image k8s.gcr.io/metrics-server-amd64:v0.2.1
🌟  The 'metrics-server' addon is enabled
```

It takes 1m28s to be able to metrics data(`kubectl top pods -n kube-system`) in my local pc.

**After this PR**

```
/out/minikube addons enable metrics-server
    ▪ Using image k8s.gcr.io/metrics-server/metrics-server:v0.4.2
🌟  The 'metrics-server' addon is enable
```

It takes 33s to be able to metrics data(`kubectl top pods -n kube-system`) in my local pc.
And I confirmed the metrics-server & kubernetes dashboard work fine.

<img width="1408" alt="スクリーンショット 2021-03-30 0 19 09" src="https://user-images.githubusercontent.com/44902466/112859359-b730a700-90ed-11eb-8ea5-d0586d62a820.png">

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```