### PR TITLE
auto-pause: initialize the pause state from the current state

### DIFF
--- a/cmd/auto-pause/auto-pause.go
+++ b/cmd/auto-pause/auto-pause.go
@@ -37,7 +37,7 @@ var done = make(chan struct{})
 var mu sync.Mutex
 
 // TODO: initialize with current state (handle the case that user enables auto-pause after it is already paused)
-var runtimePaused = false
+var runtimePaused bool
 var version = "0.0.1"
 
 // TODO: #10597 make this configurable to support containerd/cri-o
@@ -46,6 +46,10 @@ var runtime = "docker"
 func main() {
 	// TODO: #10595 make this configurable
 	const interval = time.Minute * 1
+
+	// Check current state
+	CheckIfPaused()
+
 	// channel for incoming messages
 	go func() {
 		for {
@@ -120,4 +124,18 @@ func runUnpause() {
 	runtimePaused = false
 
 	out.Step(style.Unpause, "Unpaused {{.count}} containers", out.V{"count": len(uids)})
+}
+
+func CheckIfPaused() {
+	mu.Lock()
+	defer mu.Unlock()
+
+	r := command.NewExecRunner(true)
+	cr, err := cruntime.New(cruntime.Config{Type: runtime, Runner: r})
+	if err != nil {
+		exit.Error(reason.InternalNewRuntime, "Failed runtime", err)
+	}
+
+	runtimePaused, err = cluster.CheckIfPaused(cr, []string{"kube-system"})
+	out.Step(style.Check, "containers paused status: {{.paused}}", out.V{"paused": runtimePaused})
 }

--- a/pkg/minikube/cluster/pause.go
+++ b/pkg/minikube/cluster/pause.go
@@ -103,3 +103,16 @@ func unpause(cr cruntime.Manager, r command.Runner, namespaces []string) ([]stri
 
 	return ids, nil
 }
+
+func CheckIfPaused(cr cruntime.Manager, namespaces []string) (bool, error) {
+	ids, err := cr.ListContainers(cruntime.ListOptions{State: cruntime.Paused, Namespaces: namespaces})
+	if err != nil {
+		return true, errors.Wrap(err, "list paused")
+	}
+
+	if len(ids) > 0 {
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -263,6 +263,7 @@ var (
 	GuestStatus           = Kind{ID: "GUEST_STATUS", ExitCode: ExGuestError}
 	GuestStopTimeout      = Kind{ID: "GUEST_STOP_TIMEOUT", ExitCode: ExGuestTimeout}
 	GuestUnpause          = Kind{ID: "GUEST_UNPAUSE", ExitCode: ExGuestError}
+	GuestCheckPaused      = Kind{ID: "GUEST_CHECK_PAUSED", ExitCode: ExGuestError}
 	GuestDrvMismatch      = Kind{ID: "GUEST_DRIVER_MISMATCH", ExitCode: ExGuestConflict, Style: style.Conflict}
 	GuestMissingConntrack = Kind{ID: "GUEST_MISSING_CONNTRACK", ExitCode: ExGuestUnsupported}
 


### PR DESCRIPTION
1. restart auto-pause service while paused:
```
Mar 30 08:23:21 minikube auto-pause[7411]: W0330 08:23:21.278673    7411 out.go:154] [unset outFile]: * Paused 13 containers
Mar 30 08:24:15 minikube systemd[1]: Stopping Auto Pause Service...
Mar 30 08:24:15 minikube systemd[1]: auto-pause.service: Succeeded.
Mar 30 08:24:15 minikube systemd[1]: Stopped Auto Pause Service.
Mar 30 08:24:15 minikube systemd[1]: Started Auto Pause Service.
Mar 30 08:24:15 minikube auto-pause[7879]: I0330 08:24:15.290659    7879 exec_runner.go:52] Run: systemctl --version
Mar 30 08:24:15 minikube auto-pause[7879]: I0330 08:24:15.293778    7879 exec_runner.go:52] Run: docker ps --filter status=paused --filter=name=k8s_.*_(kube-system)_ --format={{.ID}}
Mar 30 08:24:15 minikube auto-pause[7879]: W0330 08:24:15.344897    7879 out.go:154] [unset outFile]: * containers paused status: true
Mar 30 08:24:15 minikube auto-pause[7879]: Starting auto-pause server 0.0.1 at port 8080
```
pause doesn't run anymore.

1. restart auto-pause service while unpaused:
```
Mar 30 08:22:20 minikube systemd[1]: Stopping Auto Pause Service...
Mar 30 08:22:20 minikube systemd[1]: auto-pause.service: Succeeded.
Mar 30 08:22:20 minikube systemd[1]: Stopped Auto Pause Service.
Mar 30 08:22:20 minikube systemd[1]: Started Auto Pause Service.
Mar 30 08:22:20 minikube auto-pause[7411]: I0330 08:22:20.677704    7411 exec_runner.go:52] Run: systemctl --version
Mar 30 08:22:20 minikube auto-pause[7411]: I0330 08:22:20.680873    7411 exec_runner.go:52] Run: docker ps --filter status=paused --filter=name=k8s_.*_(kube-system)_ --format={{.ID}}
Mar 30 08:22:20 minikube auto-pause[7411]: W0330 08:22:20.727186    7411 out.go:154] [unset outFile]: * containers paused status: false
Mar 30 08:22:20 minikube auto-pause[7411]: Starting auto-pause server 0.0.1 at port 8080
Mar 30 08:23:20 minikube auto-pause[7411]: I0330 08:23:20.728371    7411 exec_runner.go:52] Run: sudo systemctl disable kubelet
Mar 30 08:23:20 minikube sudo[7739]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/usr/bin/systemctl disable kubelet
Mar 30 08:23:20 minikube sudo[7739]: pam_env(sudo:session): Unable to open env file: /etc/default/locale: No such file or directory
Mar 30 08:23:20 minikube sudo[7739]: pam_unix(sudo:session): session opened for user root by (uid=0)
Mar 30 08:23:20 minikube sudo[7739]: pam_unix(sudo:session): session closed for user root
Mar 30 08:23:20 minikube auto-pause[7411]: I0330 08:23:20.921073    7411 exec_runner.go:52] Run: sudo systemctl stop kubelet
Mar 30 08:23:20 minikube sudo[7754]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/usr/bin/systemctl stop kubelet
Mar 30 08:23:20 minikube sudo[7754]: pam_env(sudo:session): Unable to open env file: /etc/default/locale: No such file or directory
Mar 30 08:23:20 minikube sudo[7754]: pam_unix(sudo:session): session opened for user root by (uid=0)
Mar 30 08:23:21 minikube sudo[7754]: pam_unix(sudo:session): session closed for user root
Mar 30 08:23:21 minikube auto-pause[7411]: I0330 08:23:21.002208    7411 exec_runner.go:52] Run: docker ps --filter status=running --filter=name=k8s_.*_(kube-system)_ --format={{.I
D}}
Mar 30 08:23:21 minikube auto-pause[7411]: I0330 08:23:21.050375    7411 docker.go:291] Pausing containers: [244d97ee5c1c 1791784cb1ad b67f5187424d 299dad827593 bdb40b5332bb f48898
288d6b 768161befb01 fe0be987cfc4 740035d2dbba b7e0a02d4ece d2e17547b25f 1b393e735268 cce5f1ff772b]
Mar 30 08:23:21 minikube auto-pause[7411]: I0330 08:23:21.050494    7411 exec_runner.go:52] Run: docker pause 244d97ee5c1c 1791784cb1ad b67f5187424d 299dad827593 bdb40b5332bb f4889
8288d6b 768161befb01 fe0be987cfc4 740035d2dbba b7e0a02d4ece d2e17547b25f 1b393e735268 cce5f1ff772b
Mar 30 08:23:21 minikube auto-pause[7411]: W0330 08:23:21.278673    7411 out.go:154] [unset outFile]: * Paused 13 containers
```
pause run 
