### PR TITLE
[Unit Test] Fix unit test failing boilerplate, TestGenerateDocs

### DIFF
--- a/cmd/minikube/cmd/completion.go
+++ b/cmd/minikube/cmd/completion.go
@@ -40,7 +40,7 @@ const longDescription = `Outputs minikube shell completion for the given shell (
 		$ minikube completion fish > ~/.config/fish/completions/minikube.fish # for fish users
 	Ubuntu:
 		$ apt-get install bash-completion
-		$ source /etc/bash-completion
+		$ source /etc/bash_completion
 		$ source <(minikube completion bash) # for bash users
 		$ source <(minikube completion zsh) # for zsh users
 		$ minikube completion fish > ~/.config/fish/completions/minikube.fish # for fish users

--- a/hack/jenkins/cloud_shell_functional_tests_docker.sh
+++ b/hack/jenkins/cloud_shell_functional_tests_docker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Copyright 2019 The Kubernetes Authors All rights reserved.
-#   
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at


### PR DESCRIPTION
### What type of PR is this?
/area testing
/kind failing-test
/kind bug

### What this PR does / why we need it:

This PR fixes the unit test `boilerplate`, `TestGenerateDocs` bug.

### Which issue(s) this PR fixes:
Fix #10972 

### Does this PR introduce a user-facing change?

No. This PR fixes unit test error.

**Before this PR**

```
% make test
MINIKUBE_LDFLAGS="-X k8s.io/minikube/pkg/version.version=v1.18.1 -X k8s.io/minikube/pkg/version.isoVersion=v1.18.0-1616464260-10647 -X k8s.io/minikube/pkg/version.gitCommitID="7253f46a5b566b93fb6fe95144e314e9b9368017" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" ./test.sh
= make lint =============================================================
ok
= go mod ================================================================
ok
= boilerplate ===========================================================
boilerplate missing: /Users/kentaiso/go/src/k8s.io/minikube/hack/jenkins/cloud_shell_functional_tests_docker.sh
consider running: /Users/kentaiso/go/src/k8s.io/minikube/hack/boilerplate/fix.sh
= schema_check ==========================================================
ok
= go test ===============================================================
--- FAIL: TestGenerateDocs (0.02s)
    --- FAIL: TestGenerateDocs/completion (0.00s)
        generate-docs_test.go:49: Docs are not updated. Please run `make generate-docs` to update commands documentation:   (
              	"""
              	... // 23 identical lines
              		Ubuntu:
              			$ apt-get install bash-completion
            - 			$ source /etc/bash-completion
            + 			$ source /etc/bash_completion
              			$ source <(minikube completion bash) # for bash users
              			$ source <(minikube completion zsh) # for zsh users
              	... // 35 identical lines
              	"""
              )
...
E0401 20:56:28.144184   50084 out.go:218] [unset errFile]: ! Local proxy ignored: not passing HTTP_PROXY=127.0.0.1:3128 to docker env.
E0401 20:56:28.145437   50084 out.go:218] [unset errFile]: ! Local proxy ignored: not passing HTTP_PROXY=127.0.0.1:3128 to docker env.
E0401 20:56:28.145612   50084 out.go:218] [unset errFile]: ! Local proxy ignored: not passing HTTP_PROXY=localhost:3128 to docker env.
E0401 20:56:28.145847   50084 out.go:218] [unset errFile]: ! Local proxy ignored: not passing HTTP_PROXY=localhost:3128 to docker env.
E0401 20:56:28.146005   50084 out.go:218] [unset errFile]: ! Local proxy ignored: not passing HTTP_PROXY=http://localhost:3128 to docker env.
E0401 20:56:28.146228   50084 out.go:218] [unset errFile]: ! Local proxy ignored: not passing HTTP_PROXY=http://localhost:3128 to docker env.
E0401 20:56:28.146408   50084 out.go:218] [unset errFile]: ! Local proxy ignored: not passing HTTP_PROXY=http://127.0.0.1:3128 to docker env.
E0401 20:56:28.146640   50084 out.go:218] [unset errFile]: ! Local proxy ignored: not passing HTTP_PROXY=http://127.0.0.1:3128 to docker env.
FAIL
coverage: 18.8% of statements
FAIL	k8s.io/minikube/cmd/minikube/cmd	16.547s
...
FAIL
make: *** [test] Error 40
```

**After this PR**

```
% make test
MINIKUBE_LDFLAGS="-X k8s.io/minikube/pkg/version.version=v1.18.1 -X k8s.io/minikube/pkg/version.isoVersion=v1.18.0-1616464260-10647 -X k8s.io/minikube/pkg/version.gitCommitID="7253f46a5b566b93fb6fe95144e314e9b9368017-dirty" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" ./test.sh
= make lint =============================================================
ok
= go mod ================================================================
ok
= boilerplate ===========================================================
ok
= schema_check ==========================================================
ok
= go test ===============================================================
...
ok
```

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```