### PR TITLE
iso: make sure to capture failures through pipes

### DIFF
--- a/hack/jenkins/build_iso.sh
+++ b/hack/jenkins/build_iso.sh
@@ -19,7 +19,7 @@
 # 	ISO_BUCKET = the bucket location to upload the ISO (e.g. minikube-builds/PR_NUMBER)
 # 	ISO_VERSION = the suffix for the iso (i.e. minikube-$(ISO_VERSION).iso)
 
-set -x
+set -x -o pipefail
 
 # Make sure gh is installed and configured
 ./hack/jenkins/installers/check_install_gh.sh


### PR DESCRIPTION
We were swallowing failures by piping our make command to tee. This should fix that and display errors correctly.
