### PR TITLE
Suggest remove unuseful infos about ‘minikube image build’

### DIFF
--- a/site/content/en/docs/handbook/pushing.md
+++ b/site/content/en/docs/handbook/pushing.md
@@ -319,12 +319,3 @@ For more information, see:
 * [Reference: image load command]({{< ref "/docs/commands/image.md#minikube-image-load" >}})
 
 ---
-
-## 8. Building images to in-cluster container runtime
-
-The minikube client will talk directly to the container runtime in the
-cluster, and run the build commands there - against the same storage.
-
-```shell
-minikube image build -t my_image .
-```

--- a/site/content/en/docs/handbook/pushing.md
+++ b/site/content/en/docs/handbook/pushing.md
@@ -328,7 +328,3 @@ cluster, and run the build commands there - against the same storage.
 ```shell
 minikube image build -t my_image .
 ```
-
-For more information, see:
-
-* [Reference: image build command]({{< ref "/docs/commands/image.md#minikube-image-build" >}})


### PR DESCRIPTION
I find unuseful infos when I use minikube on windows platform. I suggest to remove the info about 'minikube image build'.

![image](https://user-images.githubusercontent.com/80729205/113388465-ddda3080-93c0-11eb-943b-523d85ac78da.png)
