### PR TITLE
Fix CNI issue related to picking up wrong CNI  

### DIFF
--- a/pkg/drivers/kvm/domain.go
+++ b/pkg/drivers/kvm/domain.go
@@ -65,11 +65,11 @@ const domainTmpl = `
       <target dev='hda' bus='virtio'/>
     </disk>
     <interface type='network'>
-      <source network='{{.Network}}'/>
+      <source network='{{.PrivateNetwork}}'/>
       <model type='virtio'/>
     </interface>
     <interface type='network'>
-      <source network='{{.PrivateNetwork}}'/>
+      <source network='{{.Network}}'/>
       <model type='virtio'/>
     </interface>
     <serial type='pty'>

--- a/pkg/minikube/cni/kindnet.go
+++ b/pkg/minikube/cni/kindnet.go
@@ -130,7 +130,8 @@ spec:
       volumes:
       - name: cni-cfg
         hostPath:
-          path: /etc/cni/net.d
+          path: {{.CNIConfDir}}
+          type: DirectoryOrCreate
       - name: xtables-lock
         hostPath:
           path: /run/xtables.lock
@@ -158,6 +159,7 @@ func (c KindNet) manifest() (assets.CopyableFile, error) {
 		DefaultRoute: "0.0.0.0/0", // assumes IPv4
 		PodCIDR:      DefaultPodCIDR,
 		ImageName:    images.KindNet(c.cc.KubernetesConfig.ImageRepository),
+		CNIConfDir:   CustomCNIConfDir,
 	}
 
 	b := bytes.Buffer{}

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -111,7 +111,7 @@ minikube start [flags]
   -h, --help                             
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
-      --log_file string                  If non-empty, use this log file (default "")
+      --log_file string                  If non-empty, use this log file
       --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
       --logtostderr                      log to standard error instead of files
       --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level)

--- a/site/content/en/docs/tutorials/includes/hello-deployment.yaml
+++ b/site/content/en/docs/tutorials/includes/hello-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
-              matchExpressions: [{ key: app, operator: In, values: [hello-from] }]
+              matchExpressions: [{ key: app, operator: In, values: [hello] }]
             topologyKey: "kubernetes.io/hostname"
       containers:
       - name: hello-from

--- a/site/content/en/docs/tutorials/multi_node.md
+++ b/site/content/en/docs/tutorials/multi_node.md
@@ -22,23 +22,24 @@ date: 2019-11-24
 minikube start --nodes 2 -p multinode-demo
 ```
 ```
-😄  [multinode-demo] minikube v1.16.0 on Darwin 10.15.7
-✨  Automatically selected the docker driver. Other choices: hyperkit, virtualbox
+😄  [multinode-demo] minikube v1.18.1 on Opensuse-Tumbleweed 
+✨  Automatically selected the docker driver
 👍  Starting control plane node multinode-demo in cluster multinode-demo
-🔥  Creating docker container (CPUs=2, Memory=2200MB) ...
-🐳  Preparing Kubernetes v1.20.0 on Docker 20.10.0 ...
-🔗  Configuring CNI (Container Networking Interface) ...
+🔥  Creating docker container (CPUs=2, Memory=8000MB) ...
+🐳  Preparing Kubernetes v1.20.2 on Docker 20.10.3 ...
     ▪ Generating certificates and keys ...
     ▪ Booting up control plane ...
     ▪ Configuring RBAC rules ...
+🔗  Configuring CNI (Container Networking Interface) ...
 🔎  Verifying Kubernetes components...
+    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
 🌟  Enabled addons: storage-provisioner, default-storageclass
 
 👍  Starting node multinode-demo-m02 in cluster multinode-demo
-🔥  Creating docker container (CPUs=2, Memory=2200MB) ...
+🔥  Creating docker container (CPUs=2, Memory=8000MB) ...
 🌐  Found network options:
     ▪ NO_PROXY=192.168.49.2
-🐳  Preparing Kubernetes v1.20.0 on Docker 20.10.0 ...
+🐳  Preparing Kubernetes v1.20.2 on Docker 20.10.3 ...
     ▪ env NO_PROXY=192.168.49.2
 🔎  Verifying Kubernetes components...
 🏄  Done! kubectl is now configured to use "multinode-demo" cluster and "default" namespace by default
@@ -50,9 +51,9 @@ minikube start --nodes 2 -p multinode-demo
 kubectl get nodes
 ```
 ```
-NAME                 STATUS   ROLES    AGE   VERSION
-multinode-demo       Ready    master   72s   v1.18.2
-multinode-demo-m02   Ready    <none>   33s   v1.18.2
+NAME                 STATUS   ROLES                  AGE   VERSION
+multinode-demo       Ready    control-plane,master   99s   v1.20.2
+multinode-demo-m02   Ready    <none>                 73s   v1.20.2
 ```
 
 - You can also check the status of your nodes:
@@ -68,7 +69,6 @@ host: Running
 kubelet: Running
 apiserver: Running
 kubeconfig: Configured
-timeToStop: Nonexistent
 
 multinode-demo-m02
 type: Worker
@@ -106,9 +106,9 @@ service/hello created
 kubectl get pods -o wide
 ```
 ```
-NAME                    READY   STATUS    RESTARTS   AGE   IP           NODE             NOMINATED NODE   READINESS GATES
-hello-c7b8df44f-qbhxh   1/1     Running   0          31s   10.244.0.3   multinode-demo   <none>           <none>
-hello-c7b8df44f-xv4v6   1/1     Running   0          31s   10.244.0.2   multinode-demo   <none>           <none>
+NAME                     READY   STATUS    RESTARTS   AGE   IP           NODE                 NOMINATED NODE   READINESS GATES
+hello-695c67cf9c-bzrzk   1/1     Running   0          22s   10.244.1.2   multinode-demo-m02   <none>           <none>
+hello-695c67cf9c-frcvw   1/1     Running   0          22s   10.244.0.3   multinode-demo       <none>           <none>
 ```
 
 - Look at our service, to know what URL to hit
@@ -117,31 +117,31 @@ hello-c7b8df44f-xv4v6   1/1     Running   0          31s   10.244.0.2   multinod
 minikube service list -p multinode-demo
 ```
 ```
-|-------------|------------|--------------|-----------------------------|
-|  NAMESPACE  |    NAME    | TARGET PORT  |             URL             |
-|-------------|------------|--------------|-----------------------------|
-| default     | hello      |           80 | http://192.168.64.226:31000 |
-| default     | kubernetes | No node port |                             |
-| kube-system | kube-dns   | No node port |                             |
-|-------------|------------|--------------|-----------------------------|
+|-------------|------------|--------------|---------------------------|
+|  NAMESPACE  |    NAME    | TARGET PORT  |            URL            |
+|-------------|------------|--------------|---------------------------|
+| default     | hello      |           80 | http://192.168.49.2:31000 |
+| default     | kubernetes | No node port |                           |
+| kube-system | kube-dns   | No node port |                           |
+|-------------|------------|--------------|---------------------------|
 ```
 
 - Let's hit the URL a few times and see what comes back
 
 ```shell
-curl  http://192.168.64.226:31000
+curl  http://192.168.49.2:31000
 ```
 ```
-Hello from hello-c7b8df44f-qbhxh (10.244.0.3)
+Hello from hello-695c67cf9c-frcvw (10.244.0.3)
 
-curl  http://192.168.64.226:31000
-Hello from hello-c7b8df44f-qbhxh (10.244.0.3)
+curl  http://192.168.49.2:31000
+Hello from hello-695c67cf9c-bzrzk (10.244.1.2)
 
-curl  http://192.168.64.226:31000
-Hello from hello-c7b8df44f-xv4v6 (10.244.0.2)
+curl  http://192.168.49.2:31000
+Hello from hello-695c67cf9c-bzrzk (10.244.1.2)
 
-curl  http://192.168.64.226:31000
-Hello from hello-c7b8df44f-xv4v6 (10.244.0.2)
+curl  http://192.168.49.2:31000
+Hello from hello-695c67cf9c-frcvw (10.244.0.3)
 ```
 
 - Multiple nodes!

--- a/test/integration/testdata/multinodes/multinode-pod-dns-test.yaml
+++ b/test/integration/testdata/multinodes/multinode-pod-dns-test.yaml
@@ -1,32 +1,35 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: hello
+  name: busybox
+  labels:
+    app: busybox
 spec:
   replicas: 2
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 100%
   selector:
     matchLabels:
-      app: hello
+      app: busybox
   template:
     metadata:
       labels:
-        app: hello
+        app: busybox
     spec:
+      containers:
+      - name: busybox
+        # flaky nslookup in busybox versions newer than 1.28:
+        # https://github.com/docker-library/busybox/issues/48
+        # note: gcr.io/kubernetes-e2e-test-images/dnsutils:1.3
+        # has similar issues (ie, resolves but returns exit 1)
+        image: busybox:1.28
+        command:
+          - sleep
+          - "3600"
+        imagePullPolicy: IfNotPresent
+      restartPolicy: Always
       affinity:
         # ⬇⬇⬇ This ensures pods will land on separate hosts
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
-              matchExpressions: [{ key: app, operator: In, values: [hello-from] }]
+              matchExpressions: [{ key: app, operator: In, values: [busybox] }]
             topologyKey: "kubernetes.io/hostname"
-      containers:
-      - name: hello-from
-        image: pbitty/hello-from:latest
-        ports:
-          - name: http
-            containerPort: 80
-      terminationGracePeriodSeconds: 1


### PR DESCRIPTION
fixes #10984

and also:

helps #7538
fixes #8055
fixes #8480
fixes #8949
fixes #9825
fixes #10044
fixes #10969
(and maybe others...)

## examples
given in the original issue description #10984 and also in other issues' description listed above

## problem
dns resolution doesn't work in multinode clusters with kindnet cni in pods on nodes where CoreDNS is ***not*** present

## explanation
as also discussed in #8480, #10384, https://github.com/containers/podman/issues/2370 => https://github.com/cri-o/cri-o/issues/2121, https://github.com/cri-o/cri-o/issues/2411, and specifically in k8s documentation:

[Network Plugin Requirements](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/#network-plugin-requirements):
```
The CNI plugin is selected by passing Kubelet the --network-plugin=cni command-line option.
Kubelet reads a file from --cni-conf-dir (default /etc/cni/net.d) and uses the CNI configuration from that file to set up each pod's network.
The CNI configuration file must match the CNI specification, and any required CNI plugins referenced by the configuration must be present in --cni-bin-dir (default /opt/cni/bin).
If there are multiple CNI configuration files in the directory, the kubelet uses the configuration file that comes first by name in lexicographic order.
```
and also because of:
[kubeadm "Init workflow"](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#init-workflow) - step 8:
```
Installs a DNS server (CoreDNS) and the kube-proxy addon components via the API server. ... Please note that although the DNS server is deployed, it will not be scheduled until CNI is installed.
```
and so, yes, because eg `87-podman-bridge.conflist` already exists in `/etc/cni/net.d`, it gets picked up by kubelet and during `kubeadm init phase addon` brings CoreDNS immediately up within the 'wrong' (ie, 10.88.0.x) network
note: other pods (created after cluster is up and the requested cni addon is deployed) will comply and get net from cni and defined Pod CIDR range of 10.244.0.0/24, but will not be able to reach CoreDNS (residing in another network) on the other node (usually - on master node, but can 'migrate' to a minion node after restart)

## proposal
idea with this pr is to **test alternative** to *empty/restore* of `/etc/cni/net.d` before/after `kubeadm init`, proposing to use a ***separate (empty) directory for cni configuration*** and thus forcing CoreDNS to wait for cni to initialise first and then get the 'right' ip for itself (btw, while waiting, CoreDNS deployment will be rescaled to 1, so it'll start with one instance only)

this can be achived by adapting cni deployment just by changing the `volumes / name: cni-cfg` - `hostPath / path` from default `/etc/cni/net.d` to eg `/etc/cni/net.mk` (configurable via cni.CustomCNIConfDir and/or `--extra-config=kubelet.cni-conf-dir` minikube flag), and supplying this custom path also to kubelet via `--cni-conf-dir` flag

*note*: `type: DirectoryOrCreate` should also be added to cni deployment for this hostPath - if not already there (as is the case with kindnet, but some other cnis have it)

also, in this pr there are a couple of other smaller fixes related to the TestMultiNode/serial/DeployApp2Nodes dns test so it works as expected

---

## [multinode-demo](https://minikube.sigs.k8s.io/docs/tutorials/multi_node/)
note: i've also updated multinode-demo deployment yaml so that it actually created pods on different nodes (as intended) and updated the example on the website to reflect it

```
❯ minikube start --nodes 2 -p multinode-demo                                           
😄  [multinode-demo] minikube v1.18.1 on Opensuse-Tumbleweed 
✨  Automatically selected the docker driver
❗  docker is currently using the btrfs storage driver, consider switching to overlay2 for better performance
👍  Starting control plane node multinode-demo in cluster multinode-demo
🔥  Creating docker container (CPUs=2, Memory=8000MB) ...
🐳  Preparing Kubernetes v1.20.2 on Docker 20.10.3 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔗  Configuring CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass

👍  Starting node multinode-demo-m02 in cluster multinode-demo
🔥  Creating docker container (CPUs=2, Memory=8000MB) ...
🌐  Found network options:
    ▪ NO_PROXY=192.168.49.2
🐳  Preparing Kubernetes v1.20.2 on Docker 20.10.3 ...
    ▪ env NO_PROXY=192.168.49.2
🔎  Verifying Kubernetes components...
🏄  Done! kubectl is now configured to use "multinode-demo" cluster and "default" namespace by default
```
```
❯ kubectl get nodes
NAME                 STATUS   ROLES                  AGE   VERSION
multinode-demo       Ready    control-plane,master   99s   v1.20.2
multinode-demo-m02   Ready    <none>                 73s   v1.20.2
```
```
❯ minikube status -p multinode-demo
multinode-demo
type: Control Plane
host: Running
kubelet: Running
apiserver: Running
kubeconfig: Configured

multinode-demo-m02
type: Worker
host: Running
kubelet: Running
```
```
❯ kubectl apply -f hello-deployment.yaml
deployment.apps/hello created
```
```
❯ kubectl rollout status deployment/hello
deployment "hello" successfully rolled out
```
```
❯ kubectl apply -f hello-svc.yaml
service/hello created
```
```
❯ kubectl get pods -o wide
NAME                     READY   STATUS    RESTARTS   AGE   IP           NODE                 NOMINATED NODE   READINESS GATES
hello-695c67cf9c-bzrzk   1/1     Running   0          22s   10.244.1.2   multinode-demo-m02   <none>           <none>
hello-695c67cf9c-frcvw   1/1     Running   0          22s   10.244.0.3   multinode-demo       <none>           <none>
```
```
❯ minikube service list -p multinode-demo
|-------------|------------|--------------|---------------------------|
|  NAMESPACE  |    NAME    | TARGET PORT  |            URL            |
|-------------|------------|--------------|---------------------------|
| default     | hello      |           80 | http://192.168.49.2:31000 |
| default     | kubernetes | No node port |
| kube-system | kube-dns   | No node port |
|-------------|------------|--------------|---------------------------|
```
```
❯ curl  http://192.168.49.2:31000
Hello from hello-695c67cf9c-frcvw (10.244.0.3)%
❯ curl  http://192.168.49.2:31000
Hello from hello-695c67cf9c-bzrzk (10.244.1.2)%
❯ curl  http://192.168.49.2:31000
Hello from hello-695c67cf9c-bzrzk (10.244.1.2)%
❯ curl  http://192.168.49.2:31000
Hello from hello-695c67cf9c-frcvw (10.244.0.3)%
❯ curl  http://192.168.49.2:31000
Hello from hello-695c67cf9c-bzrzk (10.244.1.2)%
❯ curl  http://192.168.49.2:31000
Hello from hello-695c67cf9c-frcvw (10.244.0.3)%
```