### PR TITLE
minor spelling errors

### DIFF
--- a/pkg/drivers/kic/oci/types.go
+++ b/pkg/drivers/kic/oci/types.go
@@ -186,7 +186,7 @@ const (
 	MountPropagationBidirectional MountPropagation = 2
 )
 
-// MountPropagationValueToName is a map of valid MountPropogation values to
+// MountPropagationValueToName is a map of valid MountPropagation values to
 // their string names
 var MountPropagationValueToName = map[MountPropagation]string{
 	MountPropagationNone:            "None",
@@ -194,7 +194,7 @@ var MountPropagationValueToName = map[MountPropagation]string{
 	MountPropagationBidirectional:   "Bidirectional",
 }
 
-// MountPropagationNameToValue is a map of valid MountPropogation names to
+// MountPropagationNameToValue is a map of valid MountPropagation names to
 // their values
 var MountPropagationNameToValue = map[string]MountPropagation{
 	"None":            MountPropagationNone,

--- a/site/content/en/docs/contrib/json_output.en.md
+++ b/site/content/en/docs/contrib/json_output.en.md
@@ -6,7 +6,7 @@ description: >
   How to add logs to facilitate JSON output
 ---
 
-This document is written for minikube contributors who need to add logs to the minikube log registry for sucessful JSON output.
+This document is written for minikube contributors who need to add logs to the minikube log registry for successful JSON output.
 You may need to add logs to the registry if the `TestJSONOutput` integration test is failing on your PR.
 
 ### Background

--- a/site/content/en/docs/handbook/pushing.md
+++ b/site/content/en/docs/handbook/pushing.md
@@ -319,3 +319,16 @@ For more information, see:
 * [Reference: image load command]({{< ref "/docs/commands/image.md#minikube-image-load" >}})
 
 ---
+
+## 8. Building images to in-cluster container runtime
+
+The minikube client will talk directly to the container runtime in the
+cluster, and run the build commands there - against the same storage.
+
+```shell
+minikube image build -t my_image .
+```
+
+For more information, see:
+
+* [Reference: image build command]({{< ref "/docs/commands/image.md#minikube-image-build" >}})

--- a/site/content/en/docs/handbook/pushing.md
+++ b/site/content/en/docs/handbook/pushing.md
@@ -319,12 +319,3 @@ For more information, see:
 * [Reference: image load command]({{< ref "/docs/commands/image.md#minikube-image-load" >}})
 
 ---
-
-## 8. Building images to in-cluster container runtime
-
-The minikube client will talk directly to the container runtime in the
-cluster, and run the build commands there - against the same storage.
-
-```shell
-minikube image build -t my_image .
-```

--- a/site/content/en/docs/handbook/pushing.md
+++ b/site/content/en/docs/handbook/pushing.md
@@ -328,7 +328,3 @@ cluster, and run the build commands there - against the same storage.
 ```shell
 minikube image build -t my_image .
 ```
-
-For more information, see:
-
-* [Reference: image build command]({{< ref "/docs/commands/image.md#minikube-image-build" >}})


### PR DESCRIPTION
This will correct the message

> MountPropagationValueToName is a map of valid Mount**Propogation** values to

> MountPropagationNameToValue is a map of valid Mount**Propogation** names to

> This document is written for minikube contributors who need to add logs to the minikube log registry for **sucessful** JSON output.

to be

> MountPropagationValueToName is a map of valid MountPro**pa**gation values to

> MountPropagationNameToValue is a map of valid MountPro**pa**gation names to

> This document is written for minikube contributors who need to add logs to the minikube log registry for su**cce**ssful JSON output.