### PR TITLE
Use golang.org/x/term

### DIFF
--- a/cmd/minikube/cmd/config/prompt.go
+++ b/cmd/minikube/cmd/config/prompt.go
@@ -23,7 +23,7 @@ import (
 	"os"
 	"strings"
 
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/minikube/out"
 )
@@ -94,15 +94,14 @@ func concealableAskForStaticValue(readWriter io.ReadWriter, promptString string,
 		var (
 			response string
 			err      error
-			term     *terminal.Terminal
 		)
 
 		if hidden {
-			term = terminal.NewTerminal(readWriter, "")
-			response, err = term.ReadPassword(promptString)
+			t := term.NewTerminal(readWriter, "")
+			response, err = t.ReadPassword(promptString)
 		} else {
-			term = terminal.NewTerminal(readWriter, promptString)
-			response, err = term.ReadLine()
+			t := term.NewTerminal(readWriter, promptString)
+			response, err = t.ReadLine()
 		}
 
 		if err != nil {
@@ -121,12 +120,12 @@ func concealableAskForStaticValue(readWriter io.ReadWriter, promptString string,
 func AskForPasswordValue(s string) string {
 
 	stdInFd := int(os.Stdin.Fd())
-	oldState, err := terminal.MakeRaw(stdInFd)
+	oldState, err := term.MakeRaw(stdInFd)
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer func() {
-		if err := terminal.Restore(stdInFd, oldState); err != nil {
+		if err := term.Restore(stdInFd, oldState); err != nil {
 			klog.Errorf("terminal restore failed: %v", err)
 		}
 	}()

--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57
+	golang.org/x/term v0.0.0-20210406210042-72f3dc4e9b72
 	golang.org/x/text v0.3.6
 	google.golang.org/api v0.44.0
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1275,6 +1275,8 @@ golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57 h1:F5Gozwx4I1xtr/sr/8CFbb57iKi3297KFs0QDbGN60A=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210406210042-72f3dc4e9b72 h1:VqE9gduFZ4dbR7XoL77lHFp0/DyDUBKSXK7CMFkVcV0=
+golang.org/x/term v0.0.0-20210406210042-72f3dc4e9b72/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/minikube/command/kic_runner.go
+++ b/pkg/minikube/command/kic_runner.go
@@ -30,7 +30,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/assets"
@@ -280,7 +280,7 @@ func (k *kicRunner) Remove(f assets.CopyableFile) error {
 // isTerminal returns true if the writer w is a terminal
 func isTerminal(w io.Writer) bool {
 	if v, ok := (w).(*os.File); ok {
-		return terminal.IsTerminal(int(v.Fd()))
+		return term.IsTerminal(int(v.Fd()))
 	}
 	return false
 }


### PR DESCRIPTION
The `golang.org/x/crypto/ssh/terminal` package is deprecated and merely a
wrapper around `golang.org/x/term`. Thus, use the latter directly.
