### PR TITLE
Fix wrong error message on memory validation

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -93,7 +93,7 @@ var settings = []Setting{
 	{
 		name:        "memory",
 		set:         SetString,
-		validations: []setFn{IsValidDiskSize},
+		validations: []setFn{IsValidMemory},
 		callbacks:   []setFn{RequiresRestartMsg},
 	},
 	{

--- a/cmd/minikube/cmd/config/set_test.go
+++ b/cmd/minikube/cmd/config/set_test.go
@@ -39,7 +39,7 @@ func TestSetNotAllowed(t *testing.T) {
 		t.Fatalf("Set did not return error for unallowed value: %+v", err)
 	}
 	err = Set("memory", "10a")
-	if err == nil || err.Error() != "run validations for \"memory\" with value of \"10a\": [invalid disk size: invalid size: '10a']" {
+	if err == nil || err.Error() != "run validations for \"memory\" with value of \"10a\": [invalid memory size: invalid size: '10a']" {
 		t.Fatalf("Set did not return error for unallowed value: %+v", err)
 	}
 }

--- a/cmd/minikube/cmd/config/validations.go
+++ b/cmd/minikube/cmd/config/validations.go
@@ -53,6 +53,15 @@ func IsValidDiskSize(name string, disksize string) error {
 	return nil
 }
 
+// IsValidMemory checks if a string is a valid memory size
+func IsValidMemory(name string, memsize string) error {
+	_, err := units.FromHumanSize(memsize)
+	if err != nil {
+		return fmt.Errorf("invalid memory size: %v", err)
+	}
+	return nil
+}
+
 // IsValidURL checks if a location is a valid URL
 func IsValidURL(name string, location string) error {
 	_, err := url.Parse(location)


### PR DESCRIPTION

Before:

❌  Exiting due to MK_CONFIG_SET: run validations for "memory" with value of "foo": [invalid disk size: invalid size: 'foo']

After:

❌  Exiting due to MK_CONFIG_SET: run validations for "memory" with value of "foo": [invalid memory size: invalid size: 'foo']
