### PR TITLE
Wip: Update "Get started" page to use minikube syntax

### DIFF
--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -166,14 +166,14 @@ minikube dashboard
 Create a sample deployment and expose it on port 8080:
 
 ```shell
-kubectl create deployment hello-minikube --image=k8s.gcr.io/echoserver:1.4
-kubectl expose deployment hello-minikube --type=NodePort --port=8080
+minikube kubectl create deployment hello-minikube -- --image=k8s.gcr.io/echoserver:1.4
+minikube kubectl expose deployment hello-minikube -- --type=NodePort --port=8080
 ```
 
 It may take a moment, but your deployment will soon show up when you run:
 
 ```shell
-kubectl get services hello-minikube
+minikube kubectl get services hello-minikube
 ```
 
 The easiest way to access this service is to let minikube launch a web browser for you:
@@ -185,7 +185,7 @@ minikube service hello-minikube
 Alternatively, use kubectl to forward the port:
 
 ```shell
-kubectl port-forward service/hello-minikube 7080:8080
+minikube kubectl port-forward service/hello-minikube 7080:8080
 ```
 
 Tada! Your application is now available at [http://localhost:7080/](http://localhost:7080/)
@@ -195,8 +195,8 @@ Tada! Your application is now available at [http://localhost:7080/](http://local
 To access a LoadBalancer deployment, use the "minikube tunnel" command. Here is an example deployment:
 
 ```shell
-kubectl create deployment balanced --image=k8s.gcr.io/echoserver:1.4  
-kubectl expose deployment balanced --type=LoadBalancer --port=8080
+minikube kubectl create deployment balanced -- --image=k8s.gcr.io/echoserver:1.4  
+minikube kubectl expose deployment balanced -- --type=LoadBalancer --port=8080
 ```
 
 In another window, start the tunnel to create a routable IP for the 'balanced' deployment:
@@ -208,7 +208,7 @@ minikube tunnel
 To find the routable IP, run this command and examine the `EXTERNAL-IP` column:
 
 ```shell
-kubectl get services balanced
+minikube kubectl get services balanced
 ```
 
 Your deployment is now available at &lt;EXTERNAL-IP&gt;:8080


### PR DESCRIPTION
Users of this documentation are likely setting up minikube without the kubectl command available on their local environment. Other issues have been opened regarding this in the past. I haven't added further instructions myself to line 146 but it may be helpful to express the difference between a standalone kubectl command and the double-dashes used by minikube to stop parsing flags. 

The changes made continue to make use of minikube through the remainder of the page instead of using kubectl directly.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
