### PR TITLE
Do not allow running darwin/amd64 minikube binary on darwin/arm64 systems

### DIFF
--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -19,13 +19,14 @@ package cmd
 import (
 	"flag"
 	"fmt"
-	"k8s.io/minikube/pkg/minikube/notify"
-	"k8s.io/minikube/pkg/version"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
+
+	"k8s.io/minikube/pkg/minikube/notify"
+	"k8s.io/minikube/pkg/version"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -97,7 +97,7 @@ func Execute() {
 
 	if runtime.GOOS == "darwin" && detect.IsAmd64M1Emulation() {
 		exit.Message(reason.WrongBinaryM1, "You are trying to run amd64 binary on M1 system. Please use darwin/arm64 binary instead (Download at {{.url}}.",
-			out.V{"url": notify.DownloadUrl(version.GetVersion(), "darwin", "amd64")})
+			out.V{"url": notify.DownloadURL(version.GetVersion(), "darwin", "amd64")})
 	}
 
 	_, callingCmd := filepath.Split(os.Args[0])

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -19,6 +19,8 @@ package cmd
 import (
 	"flag"
 	"fmt"
+	"k8s.io/minikube/pkg/minikube/notify"
+	"k8s.io/minikube/pkg/version"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -94,7 +96,8 @@ func Execute() {
 	}
 
 	if runtime.GOOS == "darwin" && detect.IsAmd64M1Emulation() {
-		exit.Message(reason.WrongBinaryM1, "You are trying to run amd64 binary on M1 system. Please use darwin/arm64 binary instead.")
+		exit.Message(reason.WrongBinaryM1, "You are trying to run amd64 binary on M1 system. Please use darwin/arm64 binary instead (Download at {{.url}}.",
+			out.V{"url": notify.DownloadUrl(version.GetVersion(), "darwin", "amd64")})
 	}
 
 	_, callingCmd := filepath.Split(os.Args[0])

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -93,6 +93,10 @@ func Execute() {
 		}
 	}
 
+	if runtime.GOOS == "darwin" && detect.IsAmd64M1Emulation() {
+		exit.Message(reason.WrongBinaryM1, "You are trying to run amd64 binary on M1 system. Please use darwin/arm64 binary instead.")
+	}
+
 	_, callingCmd := filepath.Split(os.Args[0])
 
 	if callingCmd == "kubectl" {

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/hectane/go-acl v0.0.0-20190604041725-da78bae5fc95 // indirect
 	github.com/hooklift/assert v0.0.0-20170704181755-9d1defd6d214 // indirect
 	github.com/hooklift/iso9660 v0.0.0-20170318115843-1cf07e5970d8
-	github.com/intel-go/cpuid v0.0.0-20181003105527-1a4a6f06a1c6 // indirect
+	github.com/intel-go/cpuid v0.0.0-20181003105527-1a4a6f06a1c6
 	github.com/johanneswuerbach/nfsexports v0.0.0-20200318065542-c48c3734757f
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/errors v0.0.0-20190806202954-0232dcc7464d // indirect
@@ -50,6 +50,7 @@ require (
 	github.com/juju/utils v0.0.0-20180820210520-bf9cc5bdd62d // indirect
 	github.com/juju/version v0.0.0-20180108022336-b64dbd566305 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
+	github.com/klauspost/cpuid v1.2.0
 	github.com/libvirt/libvirt-go v3.9.0+incompatible
 	github.com/machine-drivers/docker-machine-driver-vmware v0.1.1
 	github.com/mattbaird/jsonpatch v0.0.0-20200820163806-098863c1fc24

--- a/go.sum
+++ b/go.sum
@@ -642,6 +642,7 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/klauspost/compress v1.11.2/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.3 h1:dB4Bn0tN3wdCzQxnS8r06kV74qN/TAfaIS0bVE8h3jc=
 github.com/klauspost/compress v1.11.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/cpuid v1.2.0 h1:NMpwD2G9JSFOE1/TJjGSo5zG7Yb2bTe7eq1jH+irmeE=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -808,6 +809,7 @@ github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3
 github.com/otiai10/copy v1.5.0 h1:SoXDGnlTUZoqB/wSuj/Y5L6T5i6iN4YRAcMCd+JnLNU=
 github.com/otiai10/copy v1.5.0/go.mod h1:XWfuS3CrI0R6IE0FbgHsEazaXO8G0LpMp9o8tos0x4E=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
+github.com/otiai10/curr v1.0.0 h1:TJIWdbX0B+kpNagQrjgq8bCMrbhiuX73M2XwgtDMoOI=
 github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
 github.com/otiai10/mint v1.3.2 h1:VYWnrP5fXmz1MXvjuUvcBrXSjGE6xjON+axB/UrpO3E=

--- a/pkg/minikube/detect/detect.go
+++ b/pkg/minikube/detect/detect.go
@@ -17,11 +17,12 @@ limitations under the License.
 package detect
 
 import (
-	. "github.com/klauspost/cpuid"
 	"net/http"
 	"os"
 	"runtime"
 	"strings"
+
+	"github.com/klauspost/cpuid"
 )
 
 // IsMicrosoftWSL will return true if process is running in WSL in windows
@@ -49,5 +50,5 @@ func IsCloudShell() bool {
 
 // IsAmd64M1Emulation  determines whether amd64 minikube binary is running on M1 mac in emulation mode
 func IsAmd64M1Emulation() bool {
-	return runtime.GOARCH == "amd64" && strings.HasPrefix(CPU.BrandName, "VirtualApple")
+	return runtime.GOARCH == "amd64" && strings.HasPrefix(cpuid.CPU.BrandName, "VirtualApple")
 }

--- a/pkg/minikube/detect/detect.go
+++ b/pkg/minikube/detect/detect.go
@@ -17,8 +17,11 @@ limitations under the License.
 package detect
 
 import (
+	. "github.com/klauspost/cpuid"
 	"net/http"
 	"os"
+	"runtime"
+	"strings"
 )
 
 // IsMicrosoftWSL will return true if process is running in WSL in windows
@@ -42,4 +45,9 @@ func IsOnGCE() bool {
 func IsCloudShell() bool {
 	_, e := os.LookupEnv("CLOUDSHELL_ENVIRONMENT")
 	return e
+}
+
+// IsAmd64M1Emulation  determines whether amd64 minikube binary is running on M1 mac in emulation mode
+func IsAmd64M1Emulation() bool {
+	return runtime.GOARCH == "amd64" && strings.HasPrefix(CPU.BrandName, "VirtualApple")
 }

--- a/pkg/minikube/notify/notify.go
+++ b/pkg/minikube/notify/notify.go
@@ -152,3 +152,16 @@ func getTimeFromFileIfExists(path string) time.Time {
 	}
 	return timeInFile
 }
+
+// DownloadUrl returns a URL to get minikube binary version ver for platform os/arch
+func DownloadUrl(ver, os, arch string) string {
+	if ver == "" || strings.HasSuffix(ver, "-unset") || os == "" || arch == "" {
+		return "https://github.com/kubernetes/minikube/releases"
+	}
+	sfx := ""
+	if os == "windows" {
+		sfx = ".exe"
+	}
+	return fmt.Sprintf("https://github.com/kubernetes/minikube/releases/download/%s/minikube-%s-%s%s",
+		ver, os, arch, sfx)
+}

--- a/pkg/minikube/notify/notify.go
+++ b/pkg/minikube/notify/notify.go
@@ -153,8 +153,8 @@ func getTimeFromFileIfExists(path string) time.Time {
 	return timeInFile
 }
 
-// DownloadUrl returns a URL to get minikube binary version ver for platform os/arch
-func DownloadUrl(ver, os, arch string) string {
+// DownloadURL returns a URL to get minikube binary version ver for platform os/arch
+func DownloadURL(ver, os, arch string) string {
 	if ver == "" || strings.HasSuffix(ver, "-unset") || os == "" || arch == "" {
 		return "https://github.com/kubernetes/minikube/releases"
 	}

--- a/pkg/minikube/notify/notify_test.go
+++ b/pkg/minikube/notify/notify_test.go
@@ -235,3 +235,33 @@ func TestMaybePrintUpdateText(t *testing.T) {
 		})
 	}
 }
+
+func TestDownloadURL(t *testing.T) {
+	const urlBase = "https://github.com/kubernetes/minikube/releases/download/"
+	type args struct {
+		ver  string
+		os   string
+		arch string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"linux-amd64", args{"foo", "linux", "amd64"}, urlBase + "foo/minikube-linux-amd64"},
+		{"linux-arm64", args{"foo", "linux", "arm64"}, urlBase + "foo/minikube-linux-arm64"},
+		{"darwin-amd64", args{"foo", "darwin", "amd64"}, urlBase + "foo/minikube-darwin-amd64"},
+		{"darwin-arm64", args{"foo", "darwin", "arm64"}, urlBase + "foo/minikube-darwin-arm64"},
+		{"windows", args{"foo", "windows", "amd64"}, urlBase + "foo/minikube-windows-amd64.exe"},
+		{"linux-unset", args{"foo-unset", "linux", "amd64"}, "https://github.com/kubernetes/minikube/releases"},
+		{"linux-unset", args{"foo-unset", "windows", "arm64"}, "https://github.com/kubernetes/minikube/releases"},
+		{"windows-zzz", args{"bar", "windows", "zzz"}, urlBase + "bar/minikube-windows-zzz.exe"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DownloadURL(tt.args.ver, tt.args.os, tt.args.arch); got != tt.want {
+				t.Errorf("DownloadURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -81,6 +81,7 @@ var (
 	Interrupted = Kind{ID: "MK_INTERRUPTED", ExitCode: ExProgramConflict}
 
 	WrongBinaryWSL = Kind{ID: "MK_WRONG_BINARY_WSL", ExitCode: ExProgramUnsupported}
+	WrongBinaryM1  = Kind{ID: "MK_WRONG_BINARY_M1", ExitCode: ExProgramUnsupported}
 
 	NewAPIClient             = Kind{ID: "MK_NEW_APICLIENT", ExitCode: ExProgramError}
 	InternalAddonEnable      = Kind{ID: "MK_ADDON_ENABLE", ExitCode: ExProgramError}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/10928

Before:

```
ilyaz@mymac --- z/minikube ‹master*➔ ?› » out/minikube-darwin-amd64  start
😄  minikube v1.19.0-beta.0 on Darwin 11.2
✨  Using the docker driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
💾  Downloading Kubernetes v1.20.2 preload ...
    > preloaded-images-k8s-v10-v1...: 491.71 MiB / 491.71 MiB  100.00% 5.45 MiB
    > gcr.io/k8s-minikube/kicbase...: 353.96 MiB / 353.96 MiB  100.00% 3.58 MiB
🔄  Restarting existing docker container for "minikube" ...
🐳  Preparing Kubernetes v1.20.2 on Docker 20.10.3 ...
💢  initialization failed, will try again: wait: /bin/bash -c "sudo env PATH=/var/lib/minikube/binaries/v1.20.2:$PATH kubeadm init --config /var/tmp/minikube/kubeadm.yaml  --ignore-preflight-errors=DirAvailable--etc-kubernetes-manifests,DirAvailable--var-lib-minikube,DirAvailable--var-lib-minikube-etcd,FileAvailable--etc-kubernetes-manifests-kube-scheduler.yaml,FileAvailable--etc-kubernetes-manifests-kube-apiserver.yaml,FileAvailable--etc-kubernetes-manifests-kube-controller-manager.yaml,FileAvailable--etc-kubernetes-manifests-etcd.yaml,Port-10250,Swap,Mem,SystemVerification,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables": Process exited with status 139 from signal SEGV
stdout:

stderr:
qemu: uncaught target signal 11 (Segmentation fault) - core dumped


💣  Error starting cluster: wait: /bin/bash -c "sudo env PATH=/var/lib/minikube/binaries/v1.20.2:$PATH kubeadm init --config /var/tmp/minikube/kubeadm.yaml  --ignore-preflight-errors=DirAvailable--etc-kubernetes-manifests,DirAvailable--var-lib-minikube,DirAvailable--var-lib-minikube-etcd,FileAvailable--etc-kubernetes-manifests-kube-scheduler.yaml,FileAvailable--etc-kubernetes-manifests-kube-apiserver.yaml,FileAvailable--etc-kubernetes-manifests-kube-controller-manager.yaml,FileAvailable--etc-kubernetes-manifests-etcd.yaml,Port-10250,Swap,Mem,SystemVerification,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables": Process exited with status 139 from signal SEGV
stdout:

stderr:
SIGSEGV: segmentation violation
PC=0x0 m=0 sigcode=0

goroutine 1 [running]:
qemu: uncaught target signal 11 (Segmentation fault) - core dumped


😿  minikube is exiting due to an error. If the above message is not useful, open an issue:
👉  https://github.com/kubernetes/minikube/issues/new/choose

❌  Exiting due to GUEST_START: wait: /bin/bash -c "sudo env PATH=/var/lib/minikube/binaries/v1.20.2:$PATH kubeadm init --config /var/tmp/minikube/kubeadm.yaml  --ignore-preflight-errors=DirAvailable--etc-kubernetes-manifests,DirAvailable--var-lib-minikube,DirAvailable--var-lib-minikube-etcd,FileAvailable--etc-kubernetes-manifests-kube-scheduler.yaml,FileAvailable--etc-kubernetes-manifests-kube-apiserver.yaml,FileAvailable--etc-kubernetes-manifests-kube-controller-manager.yaml,FileAvailable--etc-kubernetes-manifests-etcd.yaml,Port-10250,Swap,Mem,SystemVerification,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables": Process exited with status 139 from signal SEGV
stdout:

stderr:
SIGSEGV: segmentation violation
PC=0x0 m=0 sigcode=0
```

After:
```
ilyaz@mymac --- z/minikube ‹ilyaz/do_not_run_amd64_on_m1* ?› » out/minikube-darwin-amd64 start

❌  Exiting due to MK_WRONG_BINARY_M1: You are trying to run amd64 binary on M1 system. Please use darwin/arm64 binary instead (Download at https://github.com/kubernetes/minikube/releases/download/v1.19.0-beta.0/minikube-darwin-amd64.
```