### PR TITLE
split out minikube start and enable ingress times for mkcmp

### DIFF
--- a/pkg/minikube/perf/binary.go
+++ b/pkg/minikube/perf/binary.go
@@ -59,7 +59,7 @@ func NewBinary(b string) (*Binary, error) {
 // Name returns the name of the binary
 func (b *Binary) Name() string {
 	if b.pr != 0 {
-		return fmt.Sprintf("Minikube (PR %d)", b.pr)
+		return fmt.Sprintf("minikube (PR %d)", b.pr)
 	}
 	return filepath.Base(b.path)
 }

--- a/pkg/minikube/perf/binary_test.go
+++ b/pkg/minikube/perf/binary_test.go
@@ -31,7 +31,7 @@ func TestBinaryName(t *testing.T) {
 			binary:   Binary{path: "foo", pr: 0},
 		},
 		{
-			expected: "Minikube (PR 1)",
+			expected: "minikube (PR 1)",
 			binary:   Binary{path: "bar", pr: 1},
 		},
 	}

--- a/pkg/minikube/perf/result.go
+++ b/pkg/minikube/perf/result.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package perf
 
+type resultWrapper struct {
+	results map[string][]*result
+}
+
 type result struct {
 	logs      []string
 	timedLogs map[string]float64

--- a/pkg/minikube/perf/start.go
+++ b/pkg/minikube/perf/start.go
@@ -65,13 +65,13 @@ func collectResults(ctx context.Context, binaries []*Binary, driver string) (*re
 			if err != nil {
 				return nil, errors.Wrapf(err, "timing run %d with %s", run, binary.Name())
 			}
-			rm.addResult(binary, r)
+			rm.addResult(binary, "start", *r)
 			if runtime.GOOS != "darwin" {
 				r, err = timeEnableIngress(ctx, binary)
 				if err != nil {
 					return nil, errors.Wrapf(err, "timing run %d with %s", run, binary.Name())
 				}
-				rm.addResult(binary, r)
+				rm.addResult(binary, "ingress", *r)
 			}
 			deleteCmd := exec.CommandContext(ctx, binary.path, "delete")
 			if err := deleteCmd.Run(); err != nil {


### PR DESCRIPTION
Before:
**kvm2 Driver**
Times for minikube: 49.0s 42.8s 51.6s 42.4s 50.5s 44.3s 50.1s 42.2s 51.7s 43.8s 
Average time for minikube: 46.9s

Times for Minikube (PR 11011): 48.4s 43.7s 46.6s 36.2s 48.8s 36.2s 46.0s 43.3s 48.4s 36.8s 
Average time for Minikube (PR 11011): 43.4s

Averages Time Per Log
<details>

```
+--------------------------------------------+----------+---------------------+
|                    LOG                     | MINIKUBE | MINIKUBE (PR 11011) |
+--------------------------------------------+----------+---------------------+
| * minikube v1.19.0-beta.0 on               | 0.0s     | 0.0s                |
| Debian 9.13 (kvm/amd64)                    |          |                     |
|   - MINIKUBE_LOCATION=11011                | 0.0s     | 0.0s                |
| * Using the kvm2 driver based              | 0.0s     |                     |
| on existing profile                        |          |                     |
| * Starting control plane node              | 0.0s     | 0.0s                |
| minikube in cluster minikube               |          |                     |
| * Creating kvm2 VM (CPUs=2,                | 31.7s    | 28.5s               |
| Memory=6000MB, Disk=20000MB)               |          |                     |
| ...                                        |          |                     |
| * Preparing Kubernetes v1.20.2             | 13.7s    | 4.6s                |
| on Docker 20.10.4 ...                      |          |                     |
|   - Generating certificates                | 0.6s     | 2.4s                |
| and keys ...                               |          |                     |
|   - Booting up control plane               | 2.3s     | 9.8s                |
| ...                                        |          |                     |
|   - Configuring RBAC rules ...             | 1.0s     | 1.3s                |
| * Verifying Kubernetes                     | 0.0s     | 0.0s                |
| components...                              |          |                     |
|   - Using image                            | 1.0s     | 0.9s                |
| gcr.io/k8s-minikube/storage-provisioner:v5 |          |                     |
| * Enabled addons:                          | 0.2s     | 0.1s                |
| storage-provisioner,                       |          |                     |
| default-storageclass                       |          |                     |
| * Done! kubectl is now                     | 0.0s     | 0.0s                |
| configured to use "minikube"               |          |                     |
| cluster and "default"                      |          |                     |
| namespace by default                       |          |                     |
+--------------------------------------------+----------+---------------------+
```

</details>

**docker Driver**
Times for minikube: 22.0s 41.0s 21.0s 34.5s 21.1s 32.0s 21.0s 32.5s 21.4s 41.5s 
Average time for minikube: 28.8s

Times for Minikube (PR 11011): 22.8s 35.0s 21.5s 31.0s 21.6s 38.5s 22.1s 36.0s 22.4s 31.5s 
Average time for Minikube (PR 11011): 28.2s

Averages Time Per Log
<details>

```
+--------------------------------------------+----------+---------------------+
|                    LOG                     | MINIKUBE | MINIKUBE (PR 11011) |
+--------------------------------------------+----------+---------------------+
| * minikube v1.19.0-beta.0 on               | 0.0s     | 0.0s                |
| Debian 9.13 (kvm/amd64)                    |          |                     |
|   - MINIKUBE_LOCATION=11011                | 0.1s     | 0.1s                |
| * Using the docker driver                  | 0.1s     |                     |
| based on existing profile                  |          |                     |
| * Starting control plane node              | 0.1s     | 0.1s                |
| minikube in cluster minikube               |          |                     |
| * Creating docker container                | 6.6s     | 6.6s                |
| (CPUs=2, Memory=8000MB) ...                |          |                     |
| * Preparing Kubernetes v1.20.2             | 1.7s     | 1.7s                |
| on Docker 20.10.5 ...                      |          |                     |
|   - Generating certificates                | 2.0s     | 2.8s                |
| and keys ...                               |          |                     |
|   - Booting up control plane               | 8.8s     | 8.8s                |
| ...                                        |          |                     |
|   - Configuring RBAC rules ...             | 1.2s     | 1.2s                |
| * Verifying Kubernetes                     | 0.0s     | 0.0s                |
| components...                              |          |                     |
|   - Using image                            | 0.5s     | 0.5s                |
| gcr.io/k8s-minikube/storage-provisioner:v5 |          |                     |
| * Enabled addons:                          | 0.0s     | 0.0s                |
| storage-provisioner,                       |          |                     |
| default-storageclass                       |          |                     |
| * Done! kubectl is now                     | 0.0s     | 0.0s                |
| configured to use "minikube"               |          |                     |
| cluster and "default"                      |          |                     |
| namespace by default                       |          |                     |
+--------------------------------------------+----------+---------------------+
```

</details>

After:
**kvm2 Driver**
Times for minikube start: 54.3s 53.0s 53.9s 52.0s 52.8s 
Average time for minikube start: 53.2s

Times for minikube ingress: 26.8s 27.2s 26.2s 25.2s 24.7s 
Average time for minikube ingress: 26.0s

Times for minikube (PR 11000) start: 53.1s 53.2s 52.7s 53.8s 53.4s 
Average time for minikube (PR 11000) start: 53.2s

Times for minikube (PR 11000) ingress: 24.7s 26.7s 25.8s 26.6s 24.2s 
Average time for minikube (PR 11000) ingress: 25.6s

Averages Time Per Log
<details>

```
+--------------------------------------------+----------+---------------------+
|                    LOG                     | MINIKUBE | MINIKUBE (PR 11000) |
+--------------------------------------------+----------+---------------------+
| 😄  minikube v1.19.0-beta.0 on             | 0.1s     |                     |
| Debian rodete                              |          |                     |
| ✨  Using the kvm2 driver                  | 0.0s     |                     |
| based on existing profile                  |          |                     |
| 👍  Starting control plane                 | 0.0s     | 0.0s                |
| node minikube in cluster                   |          |                     |
| minikube                                   |          |                     |
| 🔥  Creating kvm2 VM (CPUs=2,              | 23.6s    | 23.4s               |
| Memory=6000MB, Disk=20000MB)               |          |                     |
| ...                                        |          |                     |
| 🐳  Preparing Kubernetes                   | 5.7s     | 9.4s                |
| v1.20.2 on Docker 20.10.4 ...              |          |                     |
|     ▪ Generating certificates              | 2.3s     | 1.9s                |
| and keys ...                               |          |                     |
|     ▪ Booting up control plane             | 12.8s    | 9.5s                |
| ...                                        |          |                     |
|     ▪ Configuring RBAC rules               | 1.2s     | 1.0s                |
| ...                                        |          |                     |
| 🔎  Verifying Kubernetes                   | 0.1s     | 0.1s                |
| components...                              |          |                     |
|     ▪ Using image                          | 0.5s     | 0.5s                |
| gcr.io/k8s-minikube/storage-provisioner:v5 |          |                     |
| 🌟  Enabled addons:                        | 6.9s     | 7.3s                |
| storage-provisioner,                       |          |                     |
| default-storageclass                       |          |                     |
|                                            | 0.0s     | 0.0s                |
|     ▪ Want kubectl v1.20.2?                |          |                     |
| Try 'minikube kubectl -- get               |          |                     |
| pods -A'                                   |          |                     |
| 🏄  Done! kubectl is now                   |          |                     |
| configured to use "minikube"               |          |                     |
| cluster and "default"                      |          |                     |
| namespace by default                       |          |                     |
+--------------------------------------------+----------+---------------------+
```

</details>

**docker Driver**
Times for minikube start: 41.0s 41.0s 41.4s 40.6s 39.9s 
Average time for minikube start: 40.8s

Times for minikube ingress: 23.6s 23.2s 22.7s 22.7s 23.2s 
Average time for minikube ingress: 23.1s

Times for minikube (PR 11000) start: 39.6s 40.1s 40.7s 39.8s 38.4s 
Average time for minikube (PR 11000) start: 39.7s

Times for minikube (PR 11000) ingress: 21.1s 23.1s 25.2s 22.6s 23.2s 
Average time for minikube (PR 11000) ingress: 23.0s

Averages Time Per Log
<details>

```
+--------------------------------------------+----------+---------------------+
|                    LOG                     | MINIKUBE | MINIKUBE (PR 11000) |
+--------------------------------------------+----------+---------------------+
| 😄  minikube v1.19.0-beta.0 on             | 0.2s     |                     |
| Debian rodete                              |          |                     |
| ✨  Using the docker driver                | 0.1s     |                     |
| based on existing profile                  |          |                     |
| 👍  Starting control plane                 | 0.1s     | 0.1s                |
| node minikube in cluster                   |          |                     |
| minikube                                   |          |                     |
| 🔥  Creating docker container              | 11.4s    | 11.1s               |
| (CPUs=2, Memory=8000MB) ...                |          |                     |
| 🐳  Preparing Kubernetes                   | 14.2s    | 14.0s               |
| v1.20.2 on Docker 20.10.5 ...              |          |                     |
|     ▪ Generating certificates              | 1.4s     | 1.0s                |
| and keys ...                               |          |                     |
|     ▪ Booting up control plane             | 6.2s     | 6.0s                |
| ...                                        |          |                     |
|     ▪ Configuring RBAC rules               | 1.2s     | 1.1s                |
| ...                                        |          |                     |
| 🔎  Verifying Kubernetes                   | 0.1s     | 0.1s                |
| components...                              |          |                     |
|     ▪ Using image                          | 0.5s     | 0.5s                |
| gcr.io/k8s-minikube/storage-provisioner:v5 |          |                     |
| 🌟  Enabled addons:                        | 5.6s     | 5.6s                |
| storage-provisioner,                       |          |                     |
| default-storageclass                       |          |                     |
|                                            | 0.1s     | 0.1s                |
|     ▪ Want kubectl v1.20.2?                |          |                     |
| Try 'minikube kubectl -- get               |          |                     |
| pods -A'                                   |          |                     |
| 🏄  Done! kubectl is now                   |          |                     |
| configured to use "minikube"               |          |                     |
| cluster and "default"                      |          |                     |
| namespace by default                       |          |                     |
+--------------------------------------------+----------+---------------------+
```

</details>