### PR TITLE
Detect if go.sum changed after running go mod tidy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
     paths:
+      - "go.mod"
       - "**.go"
       - "Makefile"
       - "!deploy/kicbase/**"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
     paths:
+      - "go.mod"
       - "**.go"
       - "**.yml"
       - "**.yaml"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,6 +2,7 @@ name: PR
 on:
   pull_request:
     paths:
+      - "go.mod"
       - "**.go"
       - "**.yml"
       - "**.yaml"

--- a/.github/workflows/pr_verified.yaml
+++ b/.github/workflows/pr_verified.yaml
@@ -2,6 +2,7 @@ name: PR_Verified
 on:
   pull_request:
     paths:
+      - "go.mod"
       - "**.go"
       - "**.yml"
       - "**.yaml"

--- a/test.sh
+++ b/test.sh
@@ -25,7 +25,7 @@ then
     make -s lint-ci && echo ok || ((exitcode += 4))
     echo "= go mod ================================================================"
     go mod download 2>&1 | grep -v "go: finding" || true
-    go mod tidy -v && echo ok || ((exitcode += 2))
+    go mod tidy -v && git diff --quiet && echo ok || ((exitcode += 2)) && echo ERROR: Please run go mod tidy
 fi
 
 

--- a/test.sh
+++ b/test.sh
@@ -25,7 +25,7 @@ then
     make -s lint-ci && echo ok || ((exitcode += 4))
     echo "= go mod ================================================================"
     go mod download 2>&1 | grep -v "go: finding" || true
-    go mod tidy -v && git diff --quiet && echo ok || ((exitcode += 2)) && echo ERROR: Please run go mod tidy
+    go mod tidy -v && git diff --quiet && echo ok || (((exitcode += 2)) && echo ERROR: Please run go mod tidy)
 fi
 
 


### PR DESCRIPTION
Currently, we run `go mod tidy` in `make test` and check if the go.mod changed and fail if it did. However, we don't check if the go.sum changed.

This becomes a problem when we go to release, `go mod tidy` is ran which will correct the go.sum, but makes the commit dirty and we have to make a PR to update the go.sum and run the release again.

This will detect if the go.sum should be updated during the PR unit test check in GitHub and will notify us, preventing the above issue.

Also updated workflow so PR tests are run if the go.mod file is updated. This will prevent some issues where packages are updated, new docs need to be generated, but the linting job isn't run, so we're left unaware until later.