### PR TITLE
Check if go mod tidy || make generate-docs create file changes in CI

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -30,7 +30,7 @@ then
     then
         go mod tidy -v && git diff --quiet go.* && echo ok || (((exitcode += 2)) && echo ERROR: Please run go mod tidy)
         echo "= generate docs ========================================================="
-        make generate-docs > /dev/null 2>&1 && git diff --quiet site && echo ok || (((exitcode += 3)) && echo ERROR: Please run make generate docs)
+        make generate-docs > /dev/null 2>&1 && git diff --quiet site && echo ok || (((exitcode += 3)) && echo ERROR: Please run make generate-docs)
     else
         go mod tidy -v && echo ok || ((exitcode += 2))
     fi

--- a/test.sh
+++ b/test.sh
@@ -17,6 +17,7 @@
 set -eu -o pipefail
 
 TESTSUITE="${TESTSUITE:-all}" # if env variable not set run all the tests
+CI="${CI:-false}" # if env variable not set don't run CI tests
 exitcode=0
 
 if [[ "$TESTSUITE" = "lint" ]] || [[ "$TESTSUITE" = "all" ]] || [[ "$TESTSUITE" = "lintall" ]]
@@ -25,7 +26,14 @@ then
     make -s lint-ci && echo ok || ((exitcode += 4))
     echo "= go mod ================================================================"
     go mod download 2>&1 | grep -v "go: finding" || true
-    go mod tidy -v && git diff --quiet && echo ok || (((exitcode += 2)) && echo ERROR: Please run go mod tidy)
+    if [[ "$CI" = "true" ]]
+    then
+        go mod tidy -v && git diff --quiet go.* && echo ok || (((exitcode += 2)) && echo ERROR: Please run go mod tidy)
+        echo "= generate docs ========================================================="
+        make generate-docs > /dev/null 2>&1 && git diff --quiet site && echo ok || (((exitcode += 3)) && echo ERROR: Please run make generate docs)
+    else
+        go mod tidy -v && echo ok || ((exitcode += 2))
+    fi
 fi
 
 


### PR DESCRIPTION
In my previous PR #11027, I added a command to check if there were file changes after running go mod tidy. However, the flaw with the logic is that if the user wants to run `make test` before they commit their changes, the file changes would be detected and would alert the user to run `go mod tidy`, even if they go modules are perfectly fine.

To prevent this from happening, I added a check to see if the command is being run inside CI. GitHub actions sets `CI=true` by default (https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables). Now, if the user runs `make test` locally, it doesn't warn them if they have uncommitted changes, but in CI it will throw an exit code and have a message to run `go mod tidy`.

I also added `make generate docs` to the linting script as it is more in-line with linting than unit testing. This generate docs test will also only run in CI.