### PR TITLE
Allow building minikube for outdated architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,10 @@ out/minikube-windows-amd64.exe: out/minikube-windows-amd64
 	$(if $(quiet),@echo "  CP       $@")
 	$(Q)cp $< $@
 
+out/minikube-linux-i686: out/minikube-linux-386
+	$(if $(quiet),@echo "  CP       $@")
+	$(Q)cp $< $@
+
 out/minikube-linux-x86_64: out/minikube-linux-amd64
 	$(if $(quiet),@echo "  CP       $@")
 	$(Q)cp $< $@
@@ -247,6 +251,10 @@ else
 	$(Q)GOOS="$(firstword $(subst -, ,$*))" GOARCH="$(lastword $(subst -, ,$(subst $(IS_EXE), ,$*)))" $(if $(call eq,$(lastword $(subst -, ,$(subst $(IS_EXE), ,$*))),arm),GOARM=$(GOARM)) \
 	go build -tags "$(MINIKUBE_BUILD_TAGS)" -ldflags="$(MINIKUBE_LDFLAGS)" -a -o $@ k8s.io/minikube/cmd/minikube
 endif
+
+out/minikube-linux-armv6:
+	$(Q)GOOS=linux GOARCH=arm GOARM=6 \
+	go build -tags "$(MINIKUBE_BUILD_TAGS)" -ldflags="$(MINIKUBE_LDFLAGS)" -a -o $@ k8s.io/minikube/cmd/minikube
 
 .PHONY: e2e-linux-amd64 e2e-linux-arm64 e2e-darwin-amd64 e2e-windows-amd64.exe
 e2e-linux-amd64: out/e2e-linux-amd64 ## build end2end binary for Linux x86 64bit

--- a/cmd/minikube/cmd/kubectl.go
+++ b/cmd/minikube/cmd/kubectl.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/detect"
 	"k8s.io/minikube/pkg/minikube/machine"
 	"k8s.io/minikube/pkg/minikube/mustload"
 	"k8s.io/minikube/pkg/minikube/node"
@@ -78,6 +79,19 @@ host. Please be aware that when using --ssh all paths will apply to the remote m
 				os.Exit(1)
 			}
 			return
+		} else {
+			supported := false
+			arch := detect.RuntimeArchitecture()
+			for _, a := range constants.SupportedArchitectures {
+				if arch == a {
+					supported = true
+					break
+				}
+			}
+			if !supported {
+				fmt.Fprintf(os.Stderr, "Not supported on: %s\n", arch)
+				os.Exit(1)
+			}
 		}
 
 		if len(args) > 1 && args[0] != "--help" {

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -120,7 +120,7 @@ func platform() string {
 
 	// This environment is exotic, let's output a bit more.
 	if vrole == "guest" || runtime.GOARCH != "amd64" {
-		if vsys != "" {
+		if vrole == "guest" && vsys != "" {
 			s.WriteString(fmt.Sprintf(" (%s/%s)", vsys, runtime.GOARCH))
 		} else {
 			s.WriteString(fmt.Sprintf(" (%s)", runtime.GOARCH))

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -50,6 +50,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/cruntime"
+	"k8s.io/minikube/pkg/minikube/detect"
 	"k8s.io/minikube/pkg/minikube/download"
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/exit"
@@ -715,9 +716,11 @@ func validateSpecifiedDriver(existing *config.ClusterConfig) {
 // validateDriver validates that the selected driver appears sane, exits if not
 func validateDriver(ds registry.DriverState, existing *config.ClusterConfig) {
 	name := ds.Name
+	os := runtime.GOOS
+	arch := detect.RuntimeArchitecture()
 	klog.Infof("validating driver %q against %+v", name, existing)
 	if !driver.Supported(name) {
-		exit.Message(reason.DrvUnsupportedOS, "The driver '{{.driver}}' is not supported on {{.os}}/{{.arch}}", out.V{"driver": name, "os": runtime.GOOS, "arch": runtime.GOARCH})
+		exit.Message(reason.DrvUnsupportedOS, "The driver '{{.driver}}' is not supported on {{.os}}/{{.arch}}", out.V{"driver": name, "os": os, "arch": arch})
 	}
 
 	// if we are only downloading artifacts for a driver, we can stop validation here

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -26,6 +26,11 @@ import (
 	"k8s.io/minikube/pkg/minikube/localpath"
 )
 
+var (
+	// SupportedArchitectures is the list of supported architectures
+	SupportedArchitectures = [5]string{"amd64", "arm", "arm64", "ppc64le", "s390x"}
+)
+
 const (
 	// DefaultKubernetesVersion is the default Kubernetes version
 	// dont update till #10545 is solved

--- a/pkg/minikube/detect/detect.go
+++ b/pkg/minikube/detect/detect.go
@@ -23,7 +23,24 @@ import (
 	"strings"
 
 	"github.com/klauspost/cpuid"
+	"golang.org/x/sys/cpu"
 )
+
+// RuntimeArchitecture returns the runtime architecture
+func RuntimeArchitecture() string {
+	arch := runtime.GOARCH
+	if arch == "arm" {
+		// runtime.GOARM
+		if !cpu.ARM.HasVFP {
+			return "armv5"
+		}
+		if !cpu.ARM.HasVFPv3 {
+			return "armv6"
+		}
+		// "arm" (== "armv7")
+	}
+	return arch
+}
 
 // IsMicrosoftWSL will return true if process is running in WSL in windows
 // checking for WSL env var based on this https://github.com/microsoft/WSL/issues/423#issuecomment-608237689

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -26,6 +26,7 @@ import (
 
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
+	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/detect"
 	"k8s.io/minikube/pkg/minikube/registry"
 )
@@ -71,13 +72,20 @@ var (
 
 // SupportedDrivers returns a list of supported drivers
 func SupportedDrivers() []string {
-	return supportedDrivers
+	arch := detect.RuntimeArchitecture()
+	for _, a := range constants.SupportedArchitectures {
+		if arch == a {
+			return supportedDrivers
+		}
+	}
+	// remote cluster only
+	return []string{SSH}
 }
 
 // DisplaySupportedDrivers returns a string with a list of supported drivers
 func DisplaySupportedDrivers() string {
 	var sd []string
-	for _, d := range supportedDrivers {
+	for _, d := range SupportedDrivers() {
 		if registry.Driver(d).Priority == registry.Experimental {
 			sd = append(sd, d+" (experimental)")
 			continue
@@ -89,7 +97,7 @@ func DisplaySupportedDrivers() string {
 
 // Supported returns if the driver is supported on this host.
 func Supported(name string) bool {
-	for _, d := range supportedDrivers {
+	for _, d := range SupportedDrivers() {
 		if name == d {
 			return true
 		}


### PR DESCRIPTION

This allows building the minikube client for some outdated 32-bit architectures:

`minikube-linux-i686`

`minikube-linux-armv6`

They can run remotely, but not locally (due to Kubernetes not being available...)

❌  Exiting due to DRV_UNSUPPORTED_OS: The driver 'docker' is not supported on linux/386

❌  Exiting due to DRV_UNSUPPORTED_OS: The driver 'docker' is not supported on linux/armv6

----

However, they can (eventually) be used with the --driver=ssh and --ssh=true

#10845

That would require minikube support for running cross-architecture, though...

#9593
