### PR TITLE
Add listen-apiserver-port for docker driver

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1088,6 +1088,10 @@ func validateFlags(cmd *cobra.Command, drvName string) {
 		validateListenAddress(viper.GetString(listenAddress))
 	}
 
+	if cmd.Flags().Changed(listenAPIServerPort) {
+		validateListenAPIServerPort(viper.GetInt(listenAPIServerPort))
+	}
+
 	if cmd.Flags().Changed(imageRepository) {
 		viper.Set(imageRepository, validateImageRepository(viper.GetString(imageRepository)))
 	}
@@ -1241,6 +1245,14 @@ func validateImageRepository(imagRepo string) (vaildImageRepo string) {
 func validateListenAddress(listenAddr string) {
 	if len(listenAddr) > 0 && net.ParseIP(listenAddr) == nil {
 		exit.Message(reason.Usage, "Sorry, the IP provided with the --listen-address flag is invalid: {{.listenAddr}}.", out.V{"listenAddr": listenAddr})
+	}
+}
+
+// This function validates if the --listen-apiserver-port
+// is valid
+func validateListenAPIServerPort(listenAPIServerPort int) {
+	if listenAPIServerPort < 0 || listenAPIServerPort > 65535 {
+		exit.Message(reason.Usage, "Sorry, the port provided with the --listen-apiserver-port flag is invalid: {{.listenAPIServerPort}}.", out.V{"listenAPIServerPort": listenAPIServerPort})
 	}
 }
 

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -118,6 +118,7 @@ const (
 	defaultSSHUser          = "root"
 	defaultSSHPort          = 22
 	listenAddress           = "listen-address"
+	listenAPIServerPort     = "listen-apiserver-port"
 )
 
 var (
@@ -219,6 +220,7 @@ func initDriverFlags() {
 
 	// docker & podman
 	startCmd.Flags().String(listenAddress, "", "IP Address to use to expose ports (docker and podman driver only)")
+	startCmd.Flags().Int(listenAPIServerPort, 0, "Port that apiserver exposed (docker and podman driver only). Use it with --listen-address=0.0.0.0(for remote access) --apiserver-ips=HostIP(for certificate).")
 	startCmd.Flags().StringSlice(ports, []string{}, "List of ports that should be exposed (docker and podman driver only)")
 }
 
@@ -369,6 +371,7 @@ func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, drvName s
 		DiskSize:                diskSize,
 		Driver:                  drvName,
 		ListenAddress:           viper.GetString(listenAddress),
+		ListenAPIServerPort:     viper.GetInt(listenAPIServerPort),
 		HyperkitVpnKitSock:      viper.GetString(vpnkitSock),
 		HyperkitVSockPorts:      viper.GetStringSlice(vsockPorts),
 		NFSShare:                viper.GetStringSlice(nfsShare),

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -116,10 +116,16 @@ func (d *Driver) Create() error {
 		listAddr = "0.0.0.0"
 	}
 
+	listenAPIServerPort := 0
+	if d.NodeConfig.ListenAPIServerPort != 0 {
+		listenAPIServerPort = d.NodeConfig.ListenAPIServerPort
+	}
+
 	// control plane specific options
 	params.PortMappings = append(params.PortMappings,
 		oci.PortMapping{
 			ListenAddress: listAddr,
+			HostPort:      int32(listenAPIServerPort),
 			ContainerPort: int32(params.APIServerPort),
 		},
 		oci.PortMapping{

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -502,8 +502,13 @@ func generatePortMappings(portMappings ...PortMapping) []string {
 	result := make([]string, 0, len(portMappings))
 	for _, pm := range portMappings {
 		// let docker pick a host port by leaving it as ::
-		// example --publish=127.0.0.17::8443 will get a random host port for 8443
-		publish := fmt.Sprintf("--publish=%s::%d", pm.ListenAddress, pm.ContainerPort)
+		// example --publish=127.0.0.17:8443:8443 will get a fixed host port for 8443
+		publish := ""
+		if pm.HostPort != 0 {
+			publish = fmt.Sprintf("--publish=%s:%d:%d", pm.ListenAddress, pm.HostPort, pm.ContainerPort)
+		} else {
+			publish = fmt.Sprintf("--publish=%s::%d", pm.ListenAddress, pm.ContainerPort)
+		}
 		result = append(result, publish)
 	}
 	return result

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -24,13 +24,13 @@ import (
 
 const (
 	// Version is the current version of kic
-	Version = "v0.0.19-1617905290-11019"
+	Version = "v0.0.19"
 	// SHA of the kic base image
-	baseImageSHA = "f52f5c903f19f6ad4767954309d3127280dbf0b9255b840fe665c34d5bb3c1c6"
+	baseImageSHA = "4d7ca4cd5eda77ade1a15fb898d22ed0111d76106858d1cae25be9b110ec4b4a"
 	// The name of the GCR kicbase repository
-	gcrRepo = "gcr.io/k8s-minikube/kicbase-builds"
+	gcrRepo = "gcr.io/k8s-minikube/kicbase"
 	// The name of the Dockerhub kicbase repository
-	dockerhubRepo = "kicbase/build"
+	dockerhubRepo = "kicbase/stable"
 )
 
 var (
@@ -47,20 +47,21 @@ var (
 
 // Config is configuration for the kic driver used by registry
 type Config struct {
-	ClusterName       string            // The cluster the container belongs to
-	MachineName       string            // maps to the container name being created
-	CPU               int               // Number of CPU cores assigned to the container
-	Memory            int               // max memory in MB
-	StorePath         string            // libmachine store path
-	OCIBinary         string            // oci tool to use (docker, podman,...)
-	ImageDigest       string            // image name with sha to use for the node
-	Mounts            []oci.Mount       // mounts
-	APIServerPort     int               // Kubernetes api server port inside the container
-	PortMappings      []oci.PortMapping // container port mappings
-	Envs              map[string]string // key,value of environment variables passed to the node
-	KubernetesVersion string            // Kubernetes version to install
-	ContainerRuntime  string            // container runtime kic is running
-	Network           string            //  network to run with kic
-	ExtraArgs         []string          // a list of any extra option to pass to oci binary during creation time, for example --expose 8080...
-	ListenAddress     string            // IP Address to listen to
+	ClusterName         string            // The cluster the container belongs to
+	MachineName         string            // maps to the container name being created
+	CPU                 int               // Number of CPU cores assigned to the container
+	Memory              int               // max memory in MB
+	StorePath           string            // libmachine store path
+	OCIBinary           string            // oci tool to use (docker, podman,...)
+	ImageDigest         string            // image name with sha to use for the node
+	Mounts              []oci.Mount       // mounts
+	APIServerPort       int               // Kubernetes api server port inside the container
+	PortMappings        []oci.PortMapping // container port mappings
+	Envs                map[string]string // key,value of environment variables passed to the node
+	KubernetesVersion   string            // Kubernetes version to install
+	ContainerRuntime    string            // container runtime kic is running
+	Network             string            //  network to run with kic
+	ExtraArgs           []string          // a list of any extra option to pass to oci binary during creation time, for example --expose 8080...
+	ListenAddress       string            // IP Address to listen to
+	ListenAPIServerPort int               // apiserver Port to listen to
 }

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -79,6 +79,7 @@ type ClusterConfig struct {
 	ScheduledStop           *ScheduledStopConfig
 	ExposedPorts            []string // Only used by the docker and podman driver
 	ListenAddress           string   // Only used by the docker and podman driver
+	ListenAPIServerPort     int      // Only used by the docker and podman driver
 	Network                 string   // only used by docker driver
 	MultiNodeRequested      bool
 }

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -70,20 +70,21 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 	}
 
 	return kic.NewDriver(kic.Config{
-		ClusterName:       cc.Name,
-		MachineName:       config.MachineName(cc, n),
-		StorePath:         localpath.MiniPath(),
-		ImageDigest:       cc.KicBaseImage,
-		Mounts:            mounts,
-		CPU:               cc.CPUs,
-		Memory:            cc.Memory,
-		OCIBinary:         oci.Docker,
-		APIServerPort:     cc.Nodes[0].Port,
-		KubernetesVersion: cc.KubernetesConfig.KubernetesVersion,
-		ContainerRuntime:  cc.KubernetesConfig.ContainerRuntime,
-		ExtraArgs:         extraArgs,
-		Network:           cc.Network,
-		ListenAddress:     cc.ListenAddress,
+		ClusterName:         cc.Name,
+		MachineName:         config.MachineName(cc, n),
+		StorePath:           localpath.MiniPath(),
+		ImageDigest:         cc.KicBaseImage,
+		Mounts:              mounts,
+		CPU:                 cc.CPUs,
+		Memory:              cc.Memory,
+		OCIBinary:           oci.Docker,
+		APIServerPort:       cc.Nodes[0].Port,
+		KubernetesVersion:   cc.KubernetesConfig.KubernetesVersion,
+		ContainerRuntime:    cc.KubernetesConfig.ContainerRuntime,
+		ExtraArgs:           extraArgs,
+		Network:             cc.Network,
+		ListenAddress:       cc.ListenAddress,
+		ListenAPIServerPort: cc.ListenAPIServerPort,
 	}), nil
 }
 

--- a/pkg/minikube/registry/drvs/podman/podman.go
+++ b/pkg/minikube/registry/drvs/podman/podman.go
@@ -83,19 +83,20 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 	}
 
 	return kic.NewDriver(kic.Config{
-		ClusterName:       cc.Name,
-		MachineName:       config.MachineName(cc, n),
-		StorePath:         localpath.MiniPath(),
-		ImageDigest:       strings.Split(cc.KicBaseImage, "@")[0], // for podman does not support docker images references with both a tag and digest.
-		Mounts:            mounts,
-		CPU:               cc.CPUs,
-		Memory:            cc.Memory,
-		OCIBinary:         oci.Podman,
-		APIServerPort:     cc.Nodes[0].Port,
-		KubernetesVersion: cc.KubernetesConfig.KubernetesVersion,
-		ContainerRuntime:  cc.KubernetesConfig.ContainerRuntime,
-		ExtraArgs:         extraArgs,
-		ListenAddress:     cc.ListenAddress,
+		ClusterName:         cc.Name,
+		MachineName:         config.MachineName(cc, n),
+		StorePath:           localpath.MiniPath(),
+		ImageDigest:         strings.Split(cc.KicBaseImage, "@")[0], // for podman does not support docker images references with both a tag and digest.
+		Mounts:              mounts,
+		CPU:                 cc.CPUs,
+		Memory:              cc.Memory,
+		OCIBinary:           oci.Podman,
+		APIServerPort:       cc.Nodes[0].Port,
+		KubernetesVersion:   cc.KubernetesConfig.KubernetesVersion,
+		ContainerRuntime:    cc.KubernetesConfig.ContainerRuntime,
+		ExtraArgs:           extraArgs,
+		ListenAddress:       cc.ListenAddress,
+		ListenAPIServerPort: cc.ListenAPIServerPort,
 	}), nil
 }
 

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -26,7 +26,7 @@ minikube start [flags]
       --apiserver-names strings           A set of apiserver names which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine
       --apiserver-port int                The apiserver listening port (default 8443)
       --auto-update-drivers               If set, automatically updates drivers to the latest version. Defaults to true. (default true)
-      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.19-1617905290-11019@sha256:f52f5c903f19f6ad4767954309d3127280dbf0b9255b840fe665c34d5bb3c1c6")
+      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase:v0.0.19@sha256:4d7ca4cd5eda77ade1a15fb898d22ed0111d76106858d1cae25be9b110ec4b4a")
       --cache-images                      If true, cache docker images for the current bootstrapper and load them into the machine. Always false with --driver=none. (default true)
       --cni string                        CNI plug-in to use. Valid options: auto, bridge, calico, cilium, flannel, kindnet, or path to a CNI manifest (default: auto)
       --container-runtime string          The container runtime to be used (docker, cri-o, containerd). (default "docker")
@@ -64,7 +64,7 @@ minikube start [flags]
       --insecure-registry strings         Insecure Docker registries to pass to the Docker daemon.  The default service CIDR range will automatically be added.
       --install-addons                    If set, install addons. Defaults to true. (default true)
       --interactive                       Allow user prompts for more information (default true)
-      --iso-url strings                   Locations to fetch the minikube ISO from. (default [https://storage.googleapis.com/minikube-builds/iso/11019/minikube-v1.19.0-1617859429-11019.iso,https://github.com/kubernetes/minikube/releases/download/v1.19.0-1617859429-11019/minikube-v1.19.0-1617859429-11019.iso,https://kubernetes.oss-cn-hangzhou.aliyuncs.com/minikube/iso/minikube-v1.19.0-1617859429-11019.iso])
+      --iso-url strings                   Locations to fetch the minikube ISO from. (default [https://storage.googleapis.com/minikube/iso/minikube-v1.19.0.iso,https://github.com/kubernetes/minikube/releases/download/v1.19.0/minikube-v1.19.0.iso,https://kubernetes.oss-cn-hangzhou.aliyuncs.com/minikube/iso/minikube-v1.19.0.iso])
       --keep-context                      This will keep the existing kubectl context and will create a minikube context.
       --kubernetes-version string         The Kubernetes version that the minikube VM will use (ex: v1.2.3, 'stable' for v1.20.2, 'latest' for v1.20.5-rc.0). Defaults to 'stable'.
       --kvm-gpu                           Enable experimental NVIDIA GPU support in minikube
@@ -73,6 +73,7 @@ minikube start [flags]
       --kvm-numa-count int                Simulate numa node count in minikube, supported numa node count range is 1-8 (kvm2 driver only) (default 1)
       --kvm-qemu-uri string               The KVM QEMU connection URI. (kvm2 driver only) (default "qemu:///system")
       --listen-address string             IP Address to use to expose ports (docker and podman driver only)
+      --listen-apiserver-port int         Port that apiserver exposed (docker and podman driver only). Use it with --listen-address=0.0.0.0(for remote access) --apiserver-ips=HostIP(for certificate).
       --memory string                     Amount of RAM to allocate to Kubernetes (format: <number>[<unit>], where unit = b, k, m or g).
       --mount                             This will start the mount daemon and automatically mount files into minikube.
       --mount-string string               The argument to pass the minikube mount command on start.


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
Hi,
This change will have apiserver exposed on a fixed port, even though minikube is restarted.
Would it be possible to review and approve this change?

Fixes #11041 
Thanks
