### PR TITLE
don't run error spam test in parallel

### DIFF
--- a/test/integration/error_spam_test.go
+++ b/test/integration/error_spam_test.go
@@ -59,7 +59,6 @@ func TestErrorSpam(t *testing.T) {
 	if NoneDriver() {
 		t.Skip("none driver always shows a warning")
 	}
-	MaybeParallel(t)
 
 	profile := UniqueProfileName("nospam")
 	ctx, cancel := context.WithTimeout(context.Background(), Minutes(25))


### PR DESCRIPTION
This is an attempt to diagnose #10628, which we currently can't since it's not getting run. My assumption is that it's getting pre-empted by the functional tests then shut down for some reason.