### PR TITLE
Check if Docker installed via Snap Package Manager

### DIFF
--- a/pkg/minikube/command/kic_runner.go
+++ b/pkg/minikube/command/kic_runner.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -35,6 +34,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/assets"
+	"k8s.io/minikube/pkg/minikube/detect"
 )
 
 // kicRunner runs commands inside a container
@@ -187,7 +187,7 @@ func (k *kicRunner) Copy(f assets.CopyableFile) error {
 	}
 	klog.Infof("%s (temp): %s --> %s (%d bytes)", k.ociBin, src, dst, f.GetLength())
 
-	tmpFolder, err := tempDirectory(isMinikubeSnap(), isDockerSnap())
+	tmpFolder, err := tempDirectory(detect.MinikubeInstalledViaSnap(), detect.DockerInstalledViaSnap())
 	if err != nil {
 		return errors.Wrap(err, "determining temp directory")
 	}
@@ -219,26 +219,6 @@ func tempDirectory(isMinikubeSnap bool, isDockerSnap bool) (string, error) {
 		return "", errors.Wrap(err, "detecting home dir")
 	}
 	return home, nil
-}
-
-// isMinikubeSnap returns true if the minikube binary path includes "snap".
-func isMinikubeSnap() bool {
-	ex, err := os.Executable()
-	if err != nil {
-		return false
-	}
-	exPath := filepath.Dir(ex)
-	return strings.Contains(exPath, "snap")
-}
-
-// isDockerSnap returns true if Docker binary path includes "snap".
-func isDockerSnap() bool {
-	c := exec.Command("which", "docker")
-	o, err := c.Output()
-	if err != nil {
-		return false
-	}
-	return strings.Contains(string(o), "snap")
 }
 
 func (k *kicRunner) copy(src string, dst string) error {

--- a/pkg/minikube/command/kic_runner_test.go
+++ b/pkg/minikube/command/kic_runner_test.go
@@ -33,21 +33,24 @@ func TestKICRunner(t *testing.T) {
 		}
 
 		tests := []struct {
-			in   bool
-			want string
+			isMinikubeSnap bool
+			isDockerSnap   bool
+			want           string
 		}{
-			{false, ""},
-			{true, home},
+			{false, false, ""},
+			{true, true, home},
+			{false, true, home},
+			{true, false, home},
 		}
 
 		for _, tt := range tests {
-			got, err := tempDirectory(tt.in)
+			got, err := tempDirectory(tt.isMinikubeSnap, tt.isDockerSnap)
 			if err != nil {
 				t.Fatalf("failed to get temp directory: %v", err)
 			}
 
 			if got != tt.want {
-				t.Errorf("tempDirectory(%t) = %s; want %s", tt.in, got, tt.want)
+				t.Errorf("tempDirectory(%t, %t) = %s; want %s", tt.isMinikubeSnap, tt.isDockerSnap, got, tt.want)
 			}
 		}
 	})

--- a/pkg/minikube/detect/detect.go
+++ b/pkg/minikube/detect/detect.go
@@ -19,6 +19,8 @@ package detect
 import (
 	"net/http"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -51,4 +53,26 @@ func IsCloudShell() bool {
 // IsAmd64M1Emulation  determines whether amd64 minikube binary is running on M1 mac in emulation mode
 func IsAmd64M1Emulation() bool {
 	return runtime.GOARCH == "amd64" && strings.HasPrefix(cpuid.CPU.BrandName, "VirtualApple")
+}
+
+// MinikubeInstalledViaSnap returns true if the minikube binary path includes "snap".
+func MinikubeInstalledViaSnap() bool {
+	ex, err := os.Executable()
+	if err != nil {
+		return false
+	}
+	exPath := filepath.Dir(ex)
+
+	return strings.Contains(exPath, "snap")
+}
+
+// DockerInstalledViaSnap returns true if the Docker binary path includes "snap".
+func DockerInstalledViaSnap() bool {
+	c := exec.Command("which", "docker")
+	o, err := c.Output()
+	if err != nil {
+		return false
+	}
+
+	return strings.Contains(string(o), "snap")
 }


### PR DESCRIPTION
Closes #10772

The root of the issue is that packages installed via Snap have their own tmp folder and can't actually access `/tmp`. minikube writes a memory asset to the `/tmp` folder that Docker later copies, but if installed via Snap fails due to having different tmp dirs. We added code to check if minikube is installed via Snap, and if it is, we write the memory asset to the users home dir instead.

However, the issue is if Docker is installed via Snap and minikube is not, because we only check if minikube is installed via Snap, we write the memory asset to the `/tmp` dir, but Docker can't access `/tmp` so it fails.

I added a check to see if Docker is installed via Snap, and if minikube or Docker is installed via Snap, writes the memory asset to the users home dir instead.