### PR TITLE
wip: pass ClusterConfig to driver by pointer

### DIFF
--- a/pkg/minikube/machine/cluster_test.go
+++ b/pkg/minikube/machine/cluster_test.go
@@ -38,7 +38,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/tests"
 )
 
-func createMockDriverHost(c config.ClusterConfig, n config.Node) (interface{}, error) {
+func createMockDriverHost(c *config.ClusterConfig, n config.Node) (interface{}, error) {
 	return nil, nil
 }
 

--- a/pkg/minikube/machine/start.go
+++ b/pkg/minikube/machine/start.go
@@ -137,7 +137,7 @@ func createHost(api libmachine.API, cfg *config.ClusterConfig, n *config.Node) (
 	if def.Empty() {
 		return nil, fmt.Errorf("unsupported/missing driver: %s", cfg.Driver)
 	}
-	dd, err := def.Config(*cfg, *n)
+	dd, err := def.Config(cfg, *n)
 	if err != nil {
 		return nil, errors.Wrap(err, "config")
 	}

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -53,7 +53,7 @@ func init() {
 	}
 }
 
-func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
+func configure(cc *config.ClusterConfig, n config.Node) (interface{}, error) {
 	mounts := make([]oci.Mount, len(cc.ContainerVolumeMounts))
 	for i, spec := range cc.ContainerVolumeMounts {
 		var err error
@@ -71,7 +71,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 
 	return kic.NewDriver(kic.Config{
 		ClusterName:       cc.Name,
-		MachineName:       config.MachineName(cc, n),
+		MachineName:       config.MachineName(*cc, n),
 		StorePath:         localpath.MiniPath(),
 		ImageDigest:       cc.KicBaseImage,
 		Mounts:            mounts,

--- a/pkg/minikube/registry/drvs/hyperkit/hyperkit.go
+++ b/pkg/minikube/registry/drvs/hyperkit/hyperkit.go
@@ -59,7 +59,7 @@ func init() {
 	}
 }
 
-func configure(cfg config.ClusterConfig, n config.Node) (interface{}, error) {
+func configure(cfg *config.ClusterConfig, n config.Node) (interface{}, error) {
 	u := cfg.UUID
 	if u == "" {
 		u = uuid.NewUUID().String()
@@ -67,7 +67,7 @@ func configure(cfg config.ClusterConfig, n config.Node) (interface{}, error) {
 
 	return &hyperkit.Driver{
 		BaseDriver: &drivers.BaseDriver{
-			MachineName: config.MachineName(cfg, n),
+			MachineName: config.MachineName(*cfg, n),
 			StorePath:   localpath.MiniPath(),
 			SSHUser:     "docker",
 		},

--- a/pkg/minikube/registry/drvs/hyperv/hyperv.go
+++ b/pkg/minikube/registry/drvs/hyperv/hyperv.go
@@ -55,7 +55,7 @@ func init() {
 }
 
 func configure(cfg *config.ClusterConfig, n config.Node) (interface{}, error) {
-	d := hyperv.NewDriver(config.MachineName(cfg, n), localpath.MiniPath())
+	d := hyperv.NewDriver(config.MachineName(*cfg, n), localpath.MiniPath())
 	d.Boot2DockerURL = download.LocalISOResource(cfg.MinikubeISO)
 	d.VSwitch = cfg.HypervVirtualSwitch
 	if d.VSwitch == "" && cfg.HypervUseExternalSwitch {

--- a/pkg/minikube/registry/drvs/hyperv/hyperv.go
+++ b/pkg/minikube/registry/drvs/hyperv/hyperv.go
@@ -54,7 +54,7 @@ func init() {
 	}
 }
 
-func configure(cfg config.ClusterConfig, n config.Node) (interface{}, error) {
+func configure(cfg *config.ClusterConfig, n config.Node) (interface{}, error) {
 	d := hyperv.NewDriver(config.MachineName(cfg, n), localpath.MiniPath())
 	d.Boot2DockerURL = download.LocalISOResource(cfg.MinikubeISO)
 	d.VSwitch = cfg.HypervVirtualSwitch

--- a/pkg/minikube/registry/drvs/kvm2/kvm2.go
+++ b/pkg/minikube/registry/drvs/kvm2/kvm2.go
@@ -72,8 +72,8 @@ type kvmDriver struct {
 	NUMANodeCount  int
 }
 
-func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
-	name := config.MachineName(cc, n)
+func configure(cc *config.ClusterConfig, n config.Node) (interface{}, error) {
+	name := config.MachineName(*cc, n)
 	return kvmDriver{
 		BaseDriver: &drivers.BaseDriver{
 			MachineName: name,
@@ -96,7 +96,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 }
 
 // if network is not user-defined it defaults to "mk-<cluster_name>"
-func privateNetwork(cc config.ClusterConfig) string {
+func privateNetwork(cc *config.ClusterConfig) string {
 	if cc.Network == "" {
 		return fmt.Sprintf("mk-%s", cc.KubernetesConfig.ClusterName)
 	}

--- a/pkg/minikube/registry/drvs/none/none.go
+++ b/pkg/minikube/registry/drvs/none/none.go
@@ -45,9 +45,9 @@ func init() {
 	}
 }
 
-func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
+func configure(cc *config.ClusterConfig, n config.Node) (interface{}, error) {
 	return none.NewDriver(none.Config{
-		MachineName:      config.MachineName(cc, n),
+		MachineName:      config.MachineName(*cc, n),
 		StorePath:        localpath.MiniPath(),
 		ContainerRuntime: cc.KubernetesConfig.ContainerRuntime,
 	}), nil

--- a/pkg/minikube/registry/drvs/parallels/parallels.go
+++ b/pkg/minikube/registry/drvs/parallels/parallels.go
@@ -46,8 +46,8 @@ func init() {
 
 }
 
-func configure(cfg config.ClusterConfig, n config.Node) (interface{}, error) {
-	d := parallels.NewDriver(config.MachineName(cfg, n), localpath.MiniPath()).(*parallels.Driver)
+func configure(cfg *config.ClusterConfig, n config.Node) (interface{}, error) {
+	d := parallels.NewDriver(config.MachineName(*cfg, n), localpath.MiniPath()).(*parallels.Driver)
 	d.Boot2DockerURL = download.LocalISOResource(cfg.MinikubeISO)
 	d.Memory = cfg.Memory
 	d.CPU = cfg.CPUs

--- a/pkg/minikube/registry/drvs/podman/podman.go
+++ b/pkg/minikube/registry/drvs/podman/podman.go
@@ -66,7 +66,7 @@ func init() {
 	}
 }
 
-func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
+func configure(cc *config.ClusterConfig, n config.Node) (interface{}, error) {
 	mounts := make([]oci.Mount, len(cc.ContainerVolumeMounts))
 	for i, spec := range cc.ContainerVolumeMounts {
 		var err error
@@ -84,7 +84,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 
 	return kic.NewDriver(kic.Config{
 		ClusterName:       cc.Name,
-		MachineName:       config.MachineName(cc, n),
+		MachineName:       config.MachineName(*cc, n),
 		StorePath:         localpath.MiniPath(),
 		ImageDigest:       strings.Split(cc.KicBaseImage, "@")[0], // for podman does not support docker images references with both a tag and digest.
 		Mounts:            mounts,

--- a/pkg/minikube/registry/drvs/ssh/ssh.go
+++ b/pkg/minikube/registry/drvs/ssh/ssh.go
@@ -44,9 +44,9 @@ func init() {
 	}
 }
 
-func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
+func configure(cc *config.ClusterConfig, n config.Node) (interface{}, error) {
 	d := ssh.NewDriver(ssh.Config{
-		MachineName:      config.MachineName(cc, n),
+		MachineName:      config.MachineName(*cc, n),
 		StorePath:        localpath.MiniPath(),
 		ContainerRuntime: cc.KubernetesConfig.ContainerRuntime,
 	})

--- a/pkg/minikube/registry/drvs/virtualbox/virtualbox.go
+++ b/pkg/minikube/registry/drvs/virtualbox/virtualbox.go
@@ -52,8 +52,8 @@ func init() {
 	}
 }
 
-func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
-	d := virtualbox.NewDriver(config.MachineName(cc, n), localpath.MiniPath())
+func configure(cc *config.ClusterConfig, n config.Node) (interface{}, error) {
+	d := virtualbox.NewDriver(config.MachineName(*cc, n), localpath.MiniPath())
 	d.Boot2DockerURL = download.LocalISOResource(cc.MinikubeISO)
 	d.Memory = cc.Memory
 	d.CPU = cc.CPUs

--- a/pkg/minikube/registry/drvs/vmware/vmware.go
+++ b/pkg/minikube/registry/drvs/vmware/vmware.go
@@ -41,8 +41,8 @@ func init() {
 	}
 }
 
-func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
-	d := vmwcfg.NewConfig(config.MachineName(cc, n), localpath.MiniPath())
+func configure(cc *config.ClusterConfig, n config.Node) (interface{}, error) {
+	d := vmwcfg.NewConfig(config.MachineName(*cc, n), localpath.MiniPath())
 	d.Boot2DockerURL = download.LocalISOResource(cc.MinikubeISO)
 	d.Memory = cc.Memory
 	d.CPU = cc.CPUs

--- a/pkg/minikube/registry/registry.go
+++ b/pkg/minikube/registry/registry.go
@@ -64,7 +64,7 @@ type Registry interface {
 }
 
 // Configurator emits a struct to be marshalled into JSON for Machine Driver
-type Configurator func(config.ClusterConfig, config.Node) (interface{}, error)
+type Configurator func(*config.ClusterConfig, config.Node) (interface{}, error)
 
 // Loader is a function that loads a byte stream and creates a driver.
 type Loader func() drivers.Driver


### PR DESCRIPTION
When we change the Fallback image in the ClusterConfig the Driver has a Copy of this config and when it changes the fallback image it wont be reflcted in the driver

attempt to debug this
https://github.com/kubernetes/minikube/issues/11068