### PR TITLE
Add configuration for sonarqube code scanning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,9 +21,7 @@ _cgo_gotypes.go
 _cgo_export.*
 
 _testmain.go
-test-report.json
 
-coverage.out
 coverage.html
 
 *.exe

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ _cgo_gotypes.go
 _cgo_export.*
 
 _testmain.go
+test-report.json
+
+coverage.out
+coverage.html
 
 *.exe
 *.test

--- a/Makefile
+++ b/Makefile
@@ -367,12 +367,14 @@ gotest: $(SOURCE_GENERATED) ## Trigger minikube test
 	$(if $(quiet),@echo "  TEST     $@")
 	$(Q)go test -tags "$(MINIKUBE_BUILD_TAGS)" -ldflags="$(MINIKUBE_LDFLAGS)" $(MINIKUBE_TEST_FILES)
 
+# Run the gotest, while recording JSON report and coverage
 out/test-report.json: $(SOURCE_FILES) $(GOTEST_FILES)
 	$(if $(quiet),@echo "  TEST     $@")
 	$(Q)go test -tags "$(MINIKUBE_BUILD_TAGS)" -ldflags="$(MINIKUBE_LDFLAGS)" $(MINIKUBE_TEST_FILES) \
-	-json -coverprofile=out/coverage.out > out/test-report.json
-
+	-coverprofile=out/coverage.out -json > out/test-report.json
 out/coverage.out: out/test-report.json
+
+# Generate go coverage report (from gotest) as a HTML page
 coverage.html: out/coverage.out
 	$(if $(quiet),@echo "  COVER    $@")
 	$(Q)go tool cover -html=$< -o $@

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,7 @@ SOURCE_PACKAGES = ./cmd/... ./pkg/... ./test/...
 
 SOURCE_GENERATED = pkg/minikube/assets/assets.go pkg/minikube/translate/translations.go
 SOURCE_FILES = $(shell find $(CMD_SOURCE_DIRS) -type f -name "*.go" | grep -v _test.go)
+GOTEST_FILES = $(shell find $(CMD_SOURCE_DIRS) -type f -name "*.go" | grep _test.go)
 
 # kvm2 ldflags
 KVM2_LDFLAGS := -X k8s.io/minikube/pkg/drivers/kvm.version=$(VERSION) -X k8s.io/minikube/pkg/drivers/kvm.gitCommitID=$(COMMIT)
@@ -365,6 +366,15 @@ generate-docs: out/minikube ## Automatically generate commands documentation.
 gotest: $(SOURCE_GENERATED) ## Trigger minikube test
 	$(if $(quiet),@echo "  TEST     $@")
 	$(Q)go test -tags "$(MINIKUBE_BUILD_TAGS)" -ldflags="$(MINIKUBE_LDFLAGS)" $(MINIKUBE_TEST_FILES)
+
+test-report.json: $(SOURCE_FILES) $(GOTEST_FILES)
+	$(if $(quiet),@echo "  TEST     $@")
+	$(Q)go test -tags "$(MINIKUBE_BUILD_TAGS)" -ldflags="$(MINIKUBE_LDFLAGS)" -json $(MINIKUBE_TEST_FILES) -coverprofile=coverage.out > test-report.json
+
+coverage.out: test-report.json
+coverage.html: coverage.out
+	$(if $(quiet),@echo "  COVER    $@")
+	$(Q)go tool cover -html=$< -o $@
 
 .PHONY: extract
 extract: ## Compile extract tool

--- a/Makefile
+++ b/Makefile
@@ -367,12 +367,13 @@ gotest: $(SOURCE_GENERATED) ## Trigger minikube test
 	$(if $(quiet),@echo "  TEST     $@")
 	$(Q)go test -tags "$(MINIKUBE_BUILD_TAGS)" -ldflags="$(MINIKUBE_LDFLAGS)" $(MINIKUBE_TEST_FILES)
 
-test-report.json: $(SOURCE_FILES) $(GOTEST_FILES)
+out/test-report.json: $(SOURCE_FILES) $(GOTEST_FILES)
 	$(if $(quiet),@echo "  TEST     $@")
-	$(Q)go test -tags "$(MINIKUBE_BUILD_TAGS)" -ldflags="$(MINIKUBE_LDFLAGS)" -json $(MINIKUBE_TEST_FILES) -coverprofile=coverage.out > test-report.json
+	$(Q)go test -tags "$(MINIKUBE_BUILD_TAGS)" -ldflags="$(MINIKUBE_LDFLAGS)" $(MINIKUBE_TEST_FILES) \
+	-json -coverprofile=out/coverage.out > out/test-report.json
 
-coverage.out: test-report.json
-coverage.html: coverage.out
+out/coverage.out: out/test-report.json
+coverage.html: out/coverage.out
 	$(if $(quiet),@echo "  COVER    $@")
 	$(Q)go tool cover -html=$< -o $@
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,11 @@
+sonar.projectKey=minikube
+sonar.sourceEncoding=UTF-8
+
+sonar.sources=cmd,pkg
+sonar.exclusions=**/*_test.go,pkg/minikube/assets/assets.go,pkg/minikube/translate/translations.go
+
+sonar.tests=cmd,pkg
+sonar.test.inclusions=**/*_test.go
+
+sonar.go.tests.reportPaths=test-report.json
+sonar.go.coverage.reportPaths=coverage.out

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,5 +7,5 @@ sonar.exclusions=**/*_test.go,pkg/minikube/assets/assets.go,pkg/minikube/transla
 sonar.tests=cmd,pkg
 sonar.test.inclusions=**/*_test.go
 
-sonar.go.tests.reportPaths=test-report.json
-sonar.go.coverage.reportPaths=coverage.out
+sonar.go.tests.reportPaths=out/test-report.json
+sonar.go.coverage.reportPaths=out/coverage.out


### PR DESCRIPTION
Add configuration for scanning minikube with sonarqube:

https://www.sonarsource.com/go

The coverage.html can be used stand-alone, for coverage:

https://blog.golang.org/cover

----
![sonarqube-minikube](https://user-images.githubusercontent.com/10364051/114579688-6472f580-9c7e-11eb-83a1-511a46b11e16.png)

