### PR TITLE
ci : overhaul pr bot's mkcmp output

### DIFF
--- a/pkg/minikube/perf/result_manager.go
+++ b/pkg/minikube/perf/result_manager.go
@@ -73,25 +73,37 @@ func (rm *resultManager) summarizeResults(binaries []*Binary) {
 	}
 	table[0][0] = "minikube start"
 	table[1][0] = "enable ingress"
+	var totalTimes map[string]map[string][]float64
 	for i, b := range binaries {
 		for t := range rm.results[b].results {
-			//fmt.Printf("Times for %s %s: ", b.Name(), t)
 			index := 0
 			if t == "ingress" {
 				index = 1
 			}
-			totalTimes := rm.totalTimes(b, t)
-			table[index][i+1] = fmt.Sprintf("%.1fs", average(totalTimes))
-			//fmt.Printf("Average time for %s %s: %.1fs\n\n", b.Name(), t, average(totalTimes))
+			totalTimes[t][b.Name()] = rm.totalTimes(b, t)
+			table[index][i+1] = fmt.Sprintf("%.1fs", average(totalTimes[t][b.Name()]))
 		}
 	}
-
 	t := tablewriter.NewWriter(os.Stdout)
 	t.SetHeader([]string{"Command", binaries[0].Name(), binaries[1].Name()})
 	for _, v := range table {
 		t.Append(v)
 	}
 	t.Render()
+
+	fmt.Println("<details>")
+	fmt.Println()
+	for timing, times := range totalTimes {
+		for b, t := range times {
+			fmt.Printf("Times for %s %s: ", b, timing)
+			for _, tt := range t {
+				fmt.Printf("%.1fs ", tt)
+			}
+			fmt.Println()
+		}
+	}
+	fmt.Println()
+	fmt.Println("</details>")
 
 	// print out summary per log
 	//rm.summarizeTimesPerLog(binaries)

--- a/pkg/minikube/perf/result_manager.go
+++ b/pkg/minikube/perf/result_manager.go
@@ -67,20 +67,34 @@ func (rm *resultManager) totalTimes(binary *Binary, t string) []float64 {
 
 func (rm *resultManager) summarizeResults(binaries []*Binary) {
 	// print total and average times
-	for _, b := range binaries {
+	table := make([][]string, 2)
+	for i := range table {
+		table[i] = make([]string, len(binaries)+1)
+	}
+	table[0][0] = "minikube start"
+	table[1][0] = "enable ingress"
+	for i, b := range binaries {
 		for t := range rm.results[b].results {
-			fmt.Printf("Times for %s %s: ", b.Name(), t)
-			totalTimes := rm.totalTimes(b, t)
-			for _, tt := range totalTimes {
-				fmt.Printf("%.1fs ", tt)
+			//fmt.Printf("Times for %s %s: ", b.Name(), t)
+			index := 0
+			if t == "ingress" {
+				index = 1
 			}
-			fmt.Println()
-			fmt.Printf("Average time for %s %s: %.1fs\n\n", b.Name(), t, average(totalTimes))
+			totalTimes := rm.totalTimes(b, t)
+			table[index][i+1] = fmt.Sprintf("%.1fs", average(totalTimes))
+			//fmt.Printf("Average time for %s %s: %.1fs\n\n", b.Name(), t, average(totalTimes))
 		}
 	}
 
+	t := tablewriter.NewWriter(os.Stdout)
+	t.SetHeader([]string{"Command", binaries[0].Name(), binaries[1].Name()})
+	for _, v := range table {
+		t.Append(v)
+	}
+	t.Render()
+
 	// print out summary per log
-	rm.summarizeTimesPerLog(binaries)
+	//rm.summarizeTimesPerLog(binaries)
 }
 
 func (rm *resultManager) summarizeTimesPerLog(binaries []*Binary) {

--- a/pkg/minikube/perf/result_manager.go
+++ b/pkg/minikube/perf/result_manager.go
@@ -92,7 +92,9 @@ func (rm *resultManager) summarizeResults(binaries []*Binary) {
 	for _, v := range table {
 		t.Append(v)
 	}
+	fmt.Println("```")
 	t.Render()
+	fmt.Println("```")
 	fmt.Println()
 
 	fmt.Println("<details>")

--- a/pkg/minikube/perf/result_manager.go
+++ b/pkg/minikube/perf/result_manager.go
@@ -73,7 +73,7 @@ func (rm *resultManager) summarizeResults(binaries []*Binary) {
 	}
 	table[0][0] = "minikube start"
 	table[1][0] = "enable ingress"
-	var totalTimes map[string]map[string][]float64
+	totalTimes := make(map[string]map[string][]float64)
 	for i, b := range binaries {
 		for t := range rm.results[b].results {
 			index := 0

--- a/pkg/minikube/perf/start.go
+++ b/pkg/minikube/perf/start.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	// runs is the number of times each binary will be timed for 'minikube start'
-	runs = 5
+	runs = 2
 )
 
 // CompareMinikubeStart compares the time to run `minikube start` between two minikube binaries

--- a/pkg/minikube/perf/start.go
+++ b/pkg/minikube/perf/start.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	// runs is the number of times each binary will be timed for 'minikube start'
-	runs = 2
+	runs = 5
 )
 
 // CompareMinikubeStart compares the time to run `minikube start` between two minikube binaries

--- a/pkg/minikube/perf/start.go
+++ b/pkg/minikube/perf/start.go
@@ -66,7 +66,7 @@ func collectResults(ctx context.Context, binaries []*Binary, driver string) (*re
 				return nil, errors.Wrapf(err, "timing run %d with %s", run, binary.Name())
 			}
 			rm.addResult(binary, "start", *r)
-			if runtime.GOOS != "darwin" {
+			if !skipIngress(driver) {
 				r, err = timeEnableIngress(ctx, binary)
 				if err != nil {
 					return nil, errors.Wrapf(err, "timing run %d with %s", run, binary.Name())
@@ -127,4 +127,8 @@ func timeEnableIngress(ctx context.Context, binary *Binary) (*result, error) {
 		return nil, errors.Wrapf(err, "timing cmd: %v", enableCmd.Args)
 	}
 	return r, nil
+}
+
+func skipIngress(driver string) bool {
+	return runtime.GOOS == "darwin" && driver == "docker"
 }


### PR DESCRIPTION
**BEFORE**:
**kvm2 Driver**
Times for minikube start: 53.0s 54.8s 50.3s 47.1s 56.1s 
Average time for minikube start: 52.2s

Times for minikube ingress: 44.2s 35.2s 37.8s 43.3s 35.2s 
Average time for minikube ingress: 39.1s

Times for minikube (PR 11082) start: 46.2s 46.4s 46.9s 47.5s 50.5s 
Average time for minikube (PR 11082) start: 47.5s

Times for minikube (PR 11082) ingress: 35.8s 43.3s 42.2s 36.2s 42.7s 
Average time for minikube (PR 11082) ingress: 40.1s

Averages Time Per Log
<details>

```
+--------------------------------------------+----------+---------------------+
|                    LOG                     | MINIKUBE | MINIKUBE (PR 11082) |
+--------------------------------------------+----------+---------------------+
| * minikube v1.19.0 on Debian               | 0.0s     | 0.0s                |
| 9.13 (kvm/amd64)                           |          |                     |
|   - MINIKUBE_LOCATION=11082                | 0.0s     | 0.0s                |
| * Using the kvm2 driver based              | 0.0s     |                     |
| on existing profile                        |          |                     |
| * Starting control plane node              | 0.0s     | 0.0s                |
| minikube in cluster minikube               |          |                     |
| * Creating kvm2 VM (CPUs=2,                | 33.2s    | 29.1s               |
| Memory=6000MB, Disk=20000MB)               |          |                     |
| ...                                        |          |                     |
| * Preparing Kubernetes v1.20.2             | 13.9s    | 7.6s                |
| on Docker 20.10.4 ...                      |          |                     |
|   - Generating certificates                | 0.5s     | 1.5s                |
| and keys ...                               |          |                     |
|   - Booting up control plane               | 2.4s     | 6.9s                |
| ...                                        |          |                     |
|   - Configuring RBAC rules ...             | 1.0s     | 1.2s                |
| * Verifying Kubernetes                     | 0.0s     | 0.0s                |
| components...                              |          |                     |
|   - Using image                            | 0.9s     | 0.9s                |
| gcr.io/k8s-minikube/storage-provisioner:v5 |          |                     |
| * Enabled addons:                          | 0.2s     | 0.2s                |
| storage-provisioner,                       |          |                     |
| default-storageclass                       |          |                     |
| * Done! kubectl is now                     | 0.0s     | 0.0s                |
| configured to use "minikube"               |          |                     |
| cluster and "default"                      |          |                     |
| namespace by default                       |          |                     |
+--------------------------------------------+----------+---------------------+
```

</details>

**docker Driver**
Times for minikube start: 21.7s 21.6s 21.0s 21.4s 21.5s 
Average time for minikube start: 21.4s

Times for minikube ingress: 39.0s 35.5s 32.5s 34.6s 37.5s 
Average time for minikube ingress: 35.8s

Times for minikube (PR 11082) start: 22.2s 21.1s 21.3s 21.3s 22.0s 
Average time for minikube (PR 11082) start: 21.6s

Times for minikube (PR 11082) ingress: 32.5s 32.5s 37.0s 37.0s 34.5s 
Average time for minikube (PR 11082) ingress: 34.7s

Averages Time Per Log
<details>

```
+--------------------------------------------+----------+---------------------+
|                    LOG                     | MINIKUBE | MINIKUBE (PR 11082) |
+--------------------------------------------+----------+---------------------+
| * minikube v1.19.0 on Debian               | 0.0s     | 0.0s                |
| 9.13 (kvm/amd64)                           |          |                     |
|   - MINIKUBE_LOCATION=11082                | 0.1s     | 0.1s                |
| * Using the docker driver                  | 0.1s     |                     |
| based on existing profile                  |          |                     |
| * Starting control plane node              | 0.1s     | 0.1s                |
| minikube in cluster minikube               |          |                     |
| * Creating docker container                | 6.7s     | 6.5s                |
| (CPUs=2, Memory=8000MB) ...                |          |                     |
| * Preparing Kubernetes v1.20.2             | 1.7s     | 3.9s                |
| on Docker 20.10.5 ...                      |          |                     |
|   - Generating certificates                | 2.3s     | 2.2s                |
| and keys ...                               |          |                     |
|   - Booting up control plane               | 8.6s     | 6.8s                |
| ...                                        |          |                     |
|   - Configuring RBAC rules ...             | 1.2s     | 1.2s                |
| * Verifying Kubernetes                     | 0.0s     | 0.0s                |
| components...                              |          |                     |
|   - Using image                            | 0.5s     | 0.5s                |
| gcr.io/k8s-minikube/storage-provisioner:v5 |          |                     |
| * Enabled addons:                          | 0.0s     | 0.0s                |
| storage-provisioner,                       |          |                     |
| default-storageclass                       |          |                     |
| * Done! kubectl is now                     | 0.0s     | 0.0s                |
| configured to use "minikube"               |          |                     |
| cluster and "default"                      |          |                     |
| namespace by default                       |          |                     |
+--------------------------------------------+----------+---------------------+
```

</details>

**AFTER**:
**kvm2 Driver**
```
+----------------+----------+---------------------+
|    COMMAND     | MINIKUBE | MINIKUBE (PR 11087) |
+----------------+----------+---------------------+
| minikube start | 53.3s    | 52.6s               |
| enable ingress | 29.0s    | 28.7s               |
+----------------+----------+---------------------+
```

<details>

Times for minikube start: 53.1s 53.2s 53.5s 53.3s 53.7s 
Times for minikube (PR 11087) start: 50.9s 52.6s 52.6s 53.4s 53.4s 

Times for minikube ingress: 28.7s 27.1s 27.2s 33.6s 28.7s 
Times for minikube (PR 11087) ingress: 26.1s 26.1s 28.7s 28.1s 34.3s 

</details>

**docker Driver**
```
+----------------+----------+---------------------+
|    COMMAND     | MINIKUBE | MINIKUBE (PR 11087) |
+----------------+----------+---------------------+
| minikube start | 40.2s    | 39.8s               |
| enable ingress | 25.7s    | 25.5s               |
+----------------+----------+---------------------+
```

<details>

Times for minikube start: 39.4s 41.4s 40.8s 39.7s 39.8s 
Times for minikube (PR 11087) start: 39.6s 39.4s 39.8s 40.0s 40.2s 

Times for minikube ingress: 25.7s 22.7s 27.2s 26.2s 26.7s 
Times for minikube (PR 11087) ingress: 25.2s 26.7s 23.7s 26.7s 25.2s 

</details>
