### PR TITLE
site: Automatically generate integration test documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -360,7 +360,7 @@ test: $(SOURCE_GENERATED) ## Trigger minikube test
 
 .PHONY: generate-docs
 generate-docs: out/minikube ## Automatically generate commands documentation.
-	out/minikube generate-docs --path ./site/content/en/docs/commands/
+	out/minikube generate-docs --path ./site/content/en/docs/commands/ --test-path ./site/content/en/docs/contrib/tests.en.md
 
 .PHONY: gotest
 gotest: $(SOURCE_GENERATED) ## Trigger minikube test

--- a/cmd/minikube/cmd/generate-docs.go
+++ b/cmd/minikube/cmd/generate-docs.go
@@ -28,6 +28,7 @@ import (
 )
 
 var docsPath string
+var testPath string
 
 // generateDocs represents the generate-docs command
 var generateDocs = &cobra.Command{
@@ -44,14 +45,16 @@ var generateDocs = &cobra.Command{
 		}
 
 		// generate docs
-		if err := generate.Docs(RootCmd, docsPath); err != nil {
+		if err := generate.Docs(RootCmd, docsPath, testPath); err != nil {
 			exit.Error(reason.InternalGenerateDocs, "Unable to generate docs", err)
 		}
 		out.Step(style.Documentation, "Docs have been saved at - {{.path}}", out.V{"path": docsPath})
+		out.Step(style.Documentation, "Test docs have been saved at - {{.path}}", out.V{"path": testPath})
 	},
 }
 
 func init() {
 	generateDocs.Flags().StringVar(&docsPath, "path", "", "The path on the file system where the docs in markdown need to be saved")
+	generateDocs.Flags().StringVar(&testPath, "test-path", "", "The path on the file system where the testing docs in markdown need to be saved")
 	RootCmd.AddCommand(generateDocs)
 }

--- a/pkg/generate/docs.go
+++ b/pkg/generate/docs.go
@@ -19,10 +19,14 @@ package generate
 import (
 	"bytes"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -33,7 +37,7 @@ import (
 
 // Docs generates docs for minikube command
 func Docs(root *cobra.Command, path string) error {
-	cmds := root.Commands()
+	/*cmds := root.Commands()
 	for _, c := range cmds {
 		if c.Hidden {
 			klog.Infof("Skipping generating doc for %s as it's a hidden command", c.Name())
@@ -46,8 +50,8 @@ func Docs(root *cobra.Command, path string) error {
 		if err := saveDocForCommand(c, []byte(contents), path); err != nil {
 			return errors.Wrapf(err, "saving doc for %s", c.Name())
 		}
-	}
-	return nil
+	}*/
+	return tests()
 }
 
 // DocForCommand returns the specific doc for that command
@@ -162,4 +166,74 @@ func saveDocForCommand(command *cobra.Command, contents []byte, path string) err
 		klog.Warningf("error removing %s", fp)
 	}
 	return ioutil.WriteFile(fp, contents, 0o644)
+}
+
+func tests() error {
+	counter := 0
+	err := filepath.Walk("test/integration", func(path string, info os.FileInfo, err error) error {
+		if info.IsDir() || !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		fset := token.NewFileSet()
+		r, e := ioutil.ReadFile(path)
+		if e != nil {
+			return errors.Wrap(e, fmt.Sprintf("error reading file %s", path))
+		}
+		file, e := parser.ParseFile(fset, "", r, parser.ParseComments)
+		if e != nil {
+			return errors.Wrap(e, fmt.Sprintf("error parsing file %s", path))
+		}
+
+		ast.Inspect(file, func(x ast.Node) bool {
+			if fd, ok := x.(*ast.FuncDecl); ok {
+				fnName := fd.Name.Name
+				if !shouldParse(fnName) {
+					return true
+				}
+				subtest := false
+				if strings.HasPrefix(fnName, "valid") {
+					subtest = true
+					fnName = fmt.Sprintf("\t%s", fnName)
+				}
+				fmt.Println(fnName)
+				counter++
+				comments := fd.Doc
+				if comments == nil {
+					if subtest {
+						fmt.Print("\t")
+					}
+					fmt.Println("NEEDS DOC")
+					fmt.Println("")
+					return true
+				}
+				for _, comment := range comments.List {
+					if strings.Contains(comment.Text, "TODO") {
+						continue
+					}
+					if subtest {
+						fmt.Print("\t")
+					}
+					fmt.Println(comment.Text)
+				}
+				fmt.Println("")
+			}
+			return true
+		})
+		return nil
+	})
+
+	fmt.Printf("TEST COUNT: %d\n", counter)
+	return err
+}
+
+func shouldParse(name string) bool {
+	if strings.HasPrefix(name, "Test") && !strings.HasPrefix(name, "TestMain") {
+		return true
+	}
+
+	if strings.HasPrefix(name, "valid") {
+		return true
+	}
+
+	return false
 }

--- a/pkg/generate/testdocs.go
+++ b/pkg/generate/testdocs.go
@@ -64,24 +64,36 @@ func testDocs(docPath string) error {
 				}
 
 				if strings.HasPrefix(fnName, "valid") {
-					writeSubTest(fnName, buf)
+					e := writeSubTest(fnName, buf)
+					if e != nil {
+						return false
+					}
 				} else {
-					writeTest(fnName, buf)
+					e := writeTest(fnName, buf)
+					if e != nil {
+						return false
+					}
 				}
 
 				counter++
 				comments := fd.Doc
 				if comments == nil {
-					writeComment("NEEDS DOC\n", buf)
-					return true
+					e := writeComment("NEEDS DOC\n", buf)
+					return e == nil
 				}
 				for _, comment := range comments.List {
 					if strings.Contains(comment.Text, "TODO") {
 						continue
 					}
-					writeComment(comment.Text, buf)
+					e := writeComment(comment.Text, buf)
+					if e != nil {
+						return false
+					}
 				}
-				buf.WriteString("\n")
+				_, e := buf.WriteString("\n")
+				if e != nil {
+					return false
+				}
 			}
 			return true
 		})

--- a/pkg/generate/testdocs.go
+++ b/pkg/generate/testdocs.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2021 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generate
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"k8s.io/minikube/pkg/minikube/out"
+)
+
+func testDocs(docPath string) error {
+	counter := 0
+	buf := bytes.NewBuffer([]byte{})
+	date := time.Now().Format("2006-01-02")
+	title := out.Fmt(title, out.V{"Command": "Integration Tests", "Description": "All minikube integration tests", "Date": date})
+	_, err := buf.Write([]byte(title))
+	if err != nil {
+		return err
+	}
+
+	err = filepath.Walk("test/integration", func(path string, info os.FileInfo, err error) error {
+		if info.IsDir() || !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		fset := token.NewFileSet()
+		r, e := ioutil.ReadFile(path)
+		if e != nil {
+			return errors.Wrap(e, fmt.Sprintf("error reading file %s", path))
+		}
+		file, e := parser.ParseFile(fset, "", r, parser.ParseComments)
+		if e != nil {
+			return errors.Wrap(e, fmt.Sprintf("error parsing file %s", path))
+		}
+
+		ast.Inspect(file, func(x ast.Node) bool {
+			if fd, ok := x.(*ast.FuncDecl); ok {
+				fnName := fd.Name.Name
+				if !shouldParse(fnName) {
+					return true
+				}
+
+				if strings.HasPrefix(fnName, "valid") {
+					writeSubTest(fnName, buf)
+				} else {
+					writeTest(fnName, buf)
+				}
+
+				counter++
+				comments := fd.Doc
+				if comments == nil {
+					writeComment("NEEDS DOC\n", buf)
+					return true
+				}
+				for _, comment := range comments.List {
+					if strings.Contains(comment.Text, "TODO") {
+						continue
+					}
+					writeComment(comment.Text, buf)
+				}
+				buf.WriteString("\n")
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = buf.WriteString(fmt.Sprintf("TEST COUNT: %d\n", counter))
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(docPath, buf.Bytes(), 0o644)
+	return err
+}
+
+func shouldParse(name string) bool {
+	if strings.HasPrefix(name, "Test") && !strings.HasPrefix(name, "TestMain") {
+		return true
+	}
+
+	if strings.HasPrefix(name, "valid") {
+		return true
+	}
+
+	return false
+}
+
+func writeTest(testName string, w *bytes.Buffer) error {
+	_, err := w.WriteString("## " + testName + "\n")
+	return err
+}
+
+func writeSubTest(testName string, w *bytes.Buffer) error {
+	_, err := w.WriteString("#### " + testName + "\n")
+	return err
+}
+
+func writeComment(comment string, w *bytes.Buffer) error {
+	// Remove the leading // from the testdoc comments
+	comment = comment[3:]
+	_, err := w.WriteString(comment + "\n")
+	return err
+}

--- a/site/content/en/docs/contrib/tests.en.md
+++ b/site/content/en/docs/contrib/tests.en.md
@@ -1,0 +1,348 @@
+---
+title: "Integration Tests"
+description: >
+  All minikube integration tests
+---
+
+
+## TestDownloadOnly
+TestDownloadOnly makes sure the --download-only parameter in minikube start caches the appropriate images and tarballs.
+
+## TestDownloadOnlyKic
+TestDownloadOnlyKic makes sure --download-only caches the docker driver images as well.
+
+## TestOffline
+TestOffline makes sure minikube works without internet, once the user has cached the necessary images.
+This test has to run after TestDownloadOnly.
+
+## TestAddons
+TestAddons tests addons that require no special environment in parallel
+
+#### validateIngressAddon
+validateIngressAddon tests the ingress addon by deploying a default nginx pod
+
+#### validateRegistryAddon
+validateRegistryAddon tests the registry addon
+
+#### validateMetricsServerAddon
+validateMetricsServerAddon tests the metrics server addon by making sure "kubectl top pods" returns a sensible result
+
+#### validateHelmTillerAddon
+validateHelmTillerAddon tests the helm tiller addon by running "helm version" inside the cluster
+
+#### validateOlmAddon
+validateOlmAddon tests the OLM addon
+
+#### validateCSIDriverAndSnapshots
+validateCSIDriverAndSnapshots tests the csi hostpath driver by creating a persistent volume, snapshotting it and restoring it.
+
+#### validateGCPAuthAddon
+validateGCPAuthAddon tests the GCP Auth addon with either phony or real credentials and makes sure the files are mounted into pods correctly
+
+## TestCertOptions
+TestCertOptions makes sure minikube certs respect the --apiserver-ips and --apiserver-names parameters
+
+## TestDockerFlags
+TestDockerFlags makes sure the --docker-env and --docker-opt parameters are respected
+
+## TestForceSystemdFlag
+TestForceSystemdFlag tests the --force-systemd flag, as one would expect.
+
+#### validateDockerSystemd
+validateDockerSystemd makes sure the --force-systemd flag worked with the docker container runtime
+
+#### validateContainerdSystemd
+validateContainerdSystemd makes sure the --force-systemd flag worked with the containerd container runtime
+
+## TestForceSystemdEnv
+TestForceSystemdEnv makes sure the MINIKUBE_FORCE_SYSTEMD environment variable works just as well as the --force-systemd flag
+
+## TestKVMDriverInstallOrUpdate
+TestKVMDriverInstallOrUpdate makes sure our docker-machine-driver-kvm2 binary can be installed properly
+
+## TestHyperKitDriverInstallOrUpdate
+TestHyperKitDriverInstallOrUpdate makes sure our docker-machine-driver-hyperkit binary can be installed properly
+
+## TestHyperkitDriverSkipUpgrade
+TestHyperkitDriverSkipUpgrade makes sure our docker-machine-driver-hyperkit binary can be installed properly
+
+## TestErrorSpam
+TestErrorSpam asserts that there are no unexpected errors displayed in minikube command outputs.
+
+## TestFunctional
+TestFunctional are functionality tests which can safely share a profile in parallel
+
+#### validateNodeLabels
+validateNodeLabels checks if minikube cluster is created with correct kubernetes's node label
+
+#### validateLoadImage
+validateLoadImage makes sure that `minikube load image` works as expected
+
+#### validateRemoveImage
+validateRemoveImage makes sures that `minikube rm image` works as expected
+
+#### validateDockerEnv
+check functionality of minikube after evaling docker-env
+
+#### validateStartWithProxy
+validateStartWithProxy makes sure minikube start respects the HTTP_PROXY environment variable
+
+#### validateAuditAfterStart
+validateAuditAfterStart makes sure the audit log contains the correct logging after minikube start
+
+#### validateSoftStart
+validateSoftStart validates that after minikube already started, a "minikube start" should not change the configs.
+
+#### validateKubeContext
+validateKubeContext asserts that kubectl is properly configured (race-condition prone!)
+
+#### validateKubectlGetPods
+validateKubectlGetPods asserts that `kubectl get pod -A` returns non-zero content
+
+#### validateMinikubeKubectl
+validateMinikubeKubectl validates that the `minikube kubectl` command returns content
+
+#### validateMinikubeKubectlDirectCall
+validateMinikubeKubectlDirectCall validates that calling minikube's kubectl
+
+#### validateExtraConfig
+validateExtraConfig verifies minikube with --extra-config works as expected
+
+#### validateComponentHealth
+validateComponentHealth asserts that all Kubernetes components are healthy
+NOTE: It expects all components to be Ready, so it makes sense to run it close after only those tests that include '--wait=all' start flag
+
+#### validateStatusCmd
+validateStatusCmd makes sure minikube status outputs correctly
+
+#### validateDashboardCmd
+validateDashboardCmd asserts that the dashboard command works
+
+#### validateDryRun
+validateDryRun asserts that the dry-run mode quickly exits with the right code
+
+#### validateCacheCmd
+validateCacheCmd tests functionality of cache command (cache add, delete, list)
+
+#### validateConfigCmd
+validateConfigCmd asserts basic "config" command functionality
+
+#### validateLogsCmd
+validateLogsCmd asserts basic "logs" command functionality
+
+#### validateProfileCmd
+validateProfileCmd asserts "profile" command functionality
+
+#### validateServiceCmd
+validateServiceCmd asserts basic "service" command functionality
+
+#### validateAddonsCmd
+validateAddonsCmd asserts basic "addon" command functionality
+
+#### validateSSHCmd
+validateSSHCmd asserts basic "ssh" command functionality
+
+#### validateCpCmd
+validateCpCmd asserts basic "cp" command functionality
+
+#### validateMySQL
+validateMySQL validates a minimalist MySQL deployment
+
+#### validateFileSync
+validateFileSync to check existence of the test file
+
+#### validateCertSync
+validateCertSync to check existence of the test certificate
+
+#### validateUpdateContextCmd
+validateUpdateContextCmd asserts basic "update-context" command functionality
+
+#### validateMountCmd
+validateMountCmd verifies the minikube mount command works properly
+
+#### validatePersistentVolumeClaim
+validatePersistentVolumeClaim makes sure PVCs work properly
+
+#### validateTunnelCmd
+validateTunnelCmd makes sure the minikube tunnel command works as expected
+
+#### validateTunnelStart
+validateTunnelStart starts `minikube tunnel`
+
+#### validateServiceStable
+validateServiceStable starts nginx pod, nginx service and waits nginx having loadbalancer ingress IP
+
+#### validateAccessDirect
+validateAccessDirect validates if the test service can be accessed with LoadBalancer IP from host
+
+#### validateDNSDig
+validateDNSDig validates if the DNS forwarding works by dig command DNS lookup
+NOTE: DNS forwarding is experimental: https://minikube.sigs.k8s.io/docs/handbook/accessing/#dns-resolution-experimental
+
+#### validateDNSDscacheutil
+validateDNSDscacheutil validates if the DNS forwarding works by dscacheutil command DNS lookup
+NOTE: DNS forwarding is experimental: https://minikube.sigs.k8s.io/docs/handbook/accessing/#dns-resolution-experimental
+
+#### validateAccessDNS
+validateAccessDNS validates if the test service can be accessed with DNS forwarding from host
+NOTE: DNS forwarding is experimental: https://minikube.sigs.k8s.io/docs/handbook/accessing/#dns-resolution-experimental
+
+#### validateTunnelDelete
+validateTunnelDelete stops `minikube tunnel`
+
+## TestGuestEnvironment
+TestGuestEnvironment verifies files and packges installed inside minikube ISO/Base image
+
+## TestGvisorAddon
+TestGvisorAddon tests the functionality of the gVisor addon
+
+## TestJSONOutput
+TestJSONOutput makes sure json output works properly for the start, pause, unpause, and stop commands
+
+#### validateDistinctCurrentSteps
+ validateDistinctCurrentSteps makes sure each step has a distinct step number
+
+#### validateIncreasingCurrentSteps
+validateIncreasingCurrentSteps verifies that for a successful minikube start, 'current step' should be increasing
+
+## TestErrorJSONOutput
+TestErrorJSONOutput makes sure json output can print errors properly
+
+## TestKicCustomNetwork
+TestKicCustomNetwork verifies the docker driver works with a custom network
+
+## TestKicExistingNetwork
+TestKicExistingNetwork verifies the docker driver and run with an existing network
+
+## TestingKicBaseImage
+TestingKicBaseImage will return true if the integraiton test is running against a passed --base-image flag
+
+## TestMultiNode
+TestMultiNode tests all multi node cluster functionality
+
+#### validateMultiNodeStart
+validateMultiNodeStart makes sure a 2 node cluster can start
+
+#### validateAddNodeToMultiNode
+validateAddNodeToMultiNode uses the minikube node add command to add a node to an existing cluster
+
+#### validateProfileListWithMultiNode
+validateProfileListWithMultiNode make sure minikube profile list outputs correct with multinode clusters
+
+#### validateStopRunningNode
+validateStopRunningNode tests the minikube node stop command
+
+#### validateStartNodeAfterStop
+validateStartNodeAfterStop tests the minikube node start command on an existing stopped node
+
+#### validateStopMultiNodeCluster
+validateStopMultiNodeCluster runs minikube stop on a multinode cluster
+
+#### validateRestartMultiNodeCluster
+validateRestartMultiNodeCluster verifies a soft restart on a multinode cluster works
+
+#### validateDeleteNodeFromMultiNode
+validateDeleteNodeFromMultiNode tests the minikube node delete command
+
+#### validateNameConflict
+validateNameConflict tests that the node name verification works as expected
+
+#### validateDeployAppToMultiNode
+validateDeployAppToMultiNode deploys an app to a multinode cluster and makes sure all nodes can serve traffic
+
+## TestNetworkPlugins
+TestNetworkPlugins tests all supported CNI options
+Options tested: kubenet, bridge, flannel, kindnet, calico, cilium
+Flags tested: enable-default-cni (legacy), false (CNI off), auto-detection
+
+## TestChangeNoneUser
+TestChangeNoneUser tests to make sure the CHANGE_MINIKUBE_NONE_USER environemt variable is respected
+and changes the minikube file permissions from root to the correct user.
+
+## TestPause
+TestPause tests minikube pause functionality
+
+#### validateFreshStart
+validateFreshStart just starts a new minikube cluster
+
+#### validateStartNoReconfigure
+validateStartNoReconfigure validates that starting a running cluster does not invoke reconfiguration
+
+#### validatePause
+validatePause runs minikube pause
+
+#### validateUnpause
+validateUnpause runs minikube unpause
+
+#### validateDelete
+validateDelete deletes the unpaused cluster
+
+#### validateVerifyDeleted
+validateVerifyDeleted makes sure no left over left after deleting a profile such as containers or volumes
+
+#### validateStatus
+validateStatus makes sure paused clusters show up in minikube status correctly
+
+## TestDebPackageInstall
+TestPackageInstall tests installation of .deb packages with minikube itself and with kvm2 driver
+on various debian/ubuntu docker images
+
+## TestPreload
+TestPreload verifies the preload tarballs get pulled in properly by minikube
+
+## TestScheduledStopWindows
+TestScheduledStopWindows tests the schedule stop functionality on Windows
+
+## TestScheduledStopUnix
+TestScheduledStopWindows tests the schedule stop functionality on Unix
+
+## TestSkaffold
+TestSkaffold makes sure skaffold run can be run with minikube
+
+## TestStartStop
+TestStartStop tests starting, stopping and restarting a minikube clusters with various Kubernetes versions and configurations
+The oldest supported, newest supported and default Kubernetes versions are always tested.
+
+#### validateFirstStart
+validateFirstStart runs the initial minikube start
+
+#### validateDeploying
+validateDeploying deploys an app the minikube cluster
+
+#### validateStop
+validateStop tests minikube stop
+
+#### validateEnableAddonAfterStop
+validateEnableAddonAfterStop makes sure addons can be enabled on a stopped cluster
+
+#### validateSecondStart
+validateSecondStart verifies that starting a stopped cluster works
+
+#### validateAppExistsAfterStop
+validateAppExistsAfterStop verifies that a user's app will not vanish after a minikube stop
+
+#### validateAddonAfterStop
+validateAddonAfterStop validates that an addon which was enabled when minikube is stopped will be enabled and working..
+
+#### validateKubernetesImages
+validateKubernetesImages verifies that a restarted cluster contains all the necessary images
+
+#### validatePauseAfterStart
+validatePauseAfterStart verifies that minikube pause works
+
+## TestInsufficientStorage
+TestInsufficientStorage makes sure minikube status displays the correct info if there is insufficient disk space on the machine
+
+## TestRunningBinaryUpgrade
+TestRunningBinaryUpgrade upgrades a running legacy cluster to minikube at HEAD
+
+## TestStoppedBinaryUpgrade
+TestStoppedBinaryUpgrade starts a legacy minikube, stops it, and then upgrades to minikube at HEAD
+
+## TestKubernetesUpgrade
+TestKubernetesUpgrade upgrades Kubernetes from oldest to newest
+
+## TestMissingContainerUpgrade
+TestMissingContainerUpgrade tests a Docker upgrade where the underlying container is missing
+
+TEST COUNT: 110

--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/localpath"
 )
 
+// TestDownloadOnly makes sure the --download-only parameter in minikube start caches the appropriate images and tarballs.
 func TestDownloadOnly(t *testing.T) {
 	// Stores the startup run result for later error messages
 	var rrr *RunResult
@@ -187,6 +188,7 @@ func TestDownloadOnly(t *testing.T) {
 
 }
 
+// TestDownloadOnlyKic makes sure --download-only caches the docker driver images as well.
 func TestDownloadOnlyKic(t *testing.T) {
 	if !KicDriver() {
 		t.Skip("skipping, only for docker or podman driver")

--- a/test/integration/aab_offline_test.go
+++ b/test/integration/aab_offline_test.go
@@ -26,7 +26,8 @@ import (
 	"testing"
 )
 
-// TestOffline makes sure minikube works without internet, once it the user has already cached the images, This test has to run after TestDownloadOnly
+// TestOffline makes sure minikube works without internet, once the user has cached the necessary images.
+// This test has to run after TestDownloadOnly.
 func TestOffline(t *testing.T) {
 	MaybeParallel(t)
 	rt := ContainerRuntime()

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -40,7 +40,7 @@ import (
 	"k8s.io/minikube/pkg/util/retry"
 )
 
-// TestAddons tests addons that require no special environment -- in parallel
+// TestAddons tests addons that require no special environment in parallel
 func TestAddons(t *testing.T) {
 	profile := UniqueProfileName("addons")
 	ctx, cancel := context.WithTimeout(context.Background(), Minutes(40))
@@ -140,6 +140,7 @@ func TestAddons(t *testing.T) {
 	}
 }
 
+// validateIngressAddon tests the ingress addon by deploying a default nginx pod
 func validateIngressAddon(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 	if NoneDriver() || (runtime.GOOS == "darwin" && KicDriver()) {
@@ -224,6 +225,7 @@ func validateIngressAddon(ctx context.Context, t *testing.T, profile string) {
 	}
 }
 
+// validateRegistryAddon tests the registry addon
 func validateRegistryAddon(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 
@@ -300,6 +302,7 @@ func validateRegistryAddon(ctx context.Context, t *testing.T, profile string) {
 	}
 }
 
+// validateMetricsServerAddon tests the metrics server addon by making sure "kubectl top pods" returns a sensible result
 func validateMetricsServerAddon(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 
@@ -343,6 +346,7 @@ func validateMetricsServerAddon(ctx context.Context, t *testing.T, profile strin
 	}
 }
 
+// validateHelmTillerAddon tests the helm tiller addon by running "helm version" inside the cluster
 func validateHelmTillerAddon(ctx context.Context, t *testing.T, profile string) {
 
 	defer PostMortemLogs(t, profile)
@@ -400,6 +404,7 @@ func validateHelmTillerAddon(ctx context.Context, t *testing.T, profile string) 
 	}
 }
 
+// validateOlmAddon tests the OLM addon
 func validateOlmAddon(ctx context.Context, t *testing.T, profile string) {
 	t.Skipf("Skipping olm test till this timeout issue is solved https://github.com/operator-framework/operator-lifecycle-manager/issues/1534#issuecomment-632342257")
 	defer PostMortemLogs(t, profile)
@@ -463,6 +468,7 @@ func validateOlmAddon(ctx context.Context, t *testing.T, profile string) {
 	}
 }
 
+// validateCSIDriverAndSnapshots tests the csi hostpath driver by creating a persistent volume, snapshotting it and restoring it.
 func validateCSIDriverAndSnapshots(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 
@@ -562,6 +568,7 @@ func validateCSIDriverAndSnapshots(ctx context.Context, t *testing.T, profile st
 	}
 }
 
+// validateGCPAuthAddon tests the GCP Auth addon with either phony or real credentials and makes sure the files are mounted into pods correctly
 func validateGCPAuthAddon(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 

--- a/test/integration/cert_options_test.go
+++ b/test/integration/cert_options_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 )
 
+// TestCertOptions makes sure minikube certs respect the --apiserver-ips and --apiserver-names parameters
 func TestCertOptions(t *testing.T) {
 	if NoneDriver() {
 		t.Skip("skipping: none driver does not support ssh or bundle docker")

--- a/test/integration/docker_test.go
+++ b/test/integration/docker_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 )
 
+// TestDockerFlags makes sure the --docker-env and --docker-opt parameters are respected
 func TestDockerFlags(t *testing.T) {
 	if NoneDriver() {
 		t.Skip("skipping: none driver does not support ssh or bundle docker")
@@ -68,6 +69,7 @@ func TestDockerFlags(t *testing.T) {
 	}
 }
 
+// TestForceSystemdFlag tests the --force-systemd flag, as one would expect.
 func TestForceSystemdFlag(t *testing.T) {
 	if NoneDriver() {
 		t.Skip("skipping: none driver does not support ssh or bundle docker")
@@ -95,6 +97,7 @@ func TestForceSystemdFlag(t *testing.T) {
 
 }
 
+// validateDockerSystemd makes sure the --force-systemd flag worked with the docker container runtime
 func validateDockerSystemd(ctx context.Context, t *testing.T, profile string) {
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "docker info --format {{.CgroupDriver}}"))
 	if err != nil {
@@ -105,6 +108,7 @@ func validateDockerSystemd(ctx context.Context, t *testing.T, profile string) {
 	}
 }
 
+// validateContainerdSystemd makes sure the --force-systemd flag worked with the containerd container runtime
 func validateContainerdSystemd(ctx context.Context, t *testing.T, profile string) {
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "cat /etc/containerd/config.toml"))
 	if err != nil {
@@ -115,6 +119,7 @@ func validateContainerdSystemd(ctx context.Context, t *testing.T, profile string
 	}
 }
 
+// TestForceSystemdEnv makes sure the MINIKUBE_FORCE_SYSTEMD environment variable works just as well as the --force-systemd flag
 func TestForceSystemdEnv(t *testing.T) {
 	if NoneDriver() {
 		t.Skip("skipping: none driver does not support ssh or bundle docker")

--- a/test/integration/driver_install_or_update_test.go
+++ b/test/integration/driver_install_or_update_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/minikube/pkg/version"
 )
 
+// TestKVMDriverInstallOrUpdate makes sure our docker-machine-driver-kvm2 binary can be installed properly
 func TestKVMDriverInstallOrUpdate(t *testing.T) {
 	if NoneDriver() {
 		t.Skip("Skip none driver.")
@@ -53,7 +54,7 @@ func TestKVMDriverInstallOrUpdate(t *testing.T) {
 		path string
 	}{
 		{name: "driver-without-version-support", path: filepath.Join(*testdataDir, "kvm2-driver-without-version")},
-		{name: "driver-with-older-version", path: filepath.Join(*testdataDir, "kvm2-driver-without-version")},
+		{name: "driver-with-older-version", path: filepath.Join(*testdataDir, "kvm2-driver-older-version")},
 	}
 
 	originalPath := os.Getenv("PATH")
@@ -181,6 +182,7 @@ func TestHyperKitDriverInstallOrUpdate(t *testing.T) {
 	}
 }
 
+// TestHyperkitDriverSkipUpgrade makes sure our docker-machine-driver-hyperkit binary can be installed properly
 func TestHyperkitDriverSkipUpgrade(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("Skip if not darwin.")

--- a/test/integration/driver_install_or_update_test.go
+++ b/test/integration/driver_install_or_update_test.go
@@ -110,6 +110,7 @@ func TestKVMDriverInstallOrUpdate(t *testing.T) {
 	}
 }
 
+// TestHyperKitDriverInstallOrUpdate makes sure our docker-machine-driver-hyperkit binary can be installed properly
 func TestHyperKitDriverInstallOrUpdate(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("Skip if not darwin.")
@@ -122,7 +123,7 @@ func TestHyperKitDriverInstallOrUpdate(t *testing.T) {
 		path string
 	}{
 		{name: "driver-without-version-support", path: filepath.Join(*testdataDir, "hyperkit-driver-without-version")},
-		{name: "driver-with-older-version", path: filepath.Join(*testdataDir, "hyperkit-driver-without-version")},
+		{name: "driver-with-older-version", path: filepath.Join(*testdataDir, "hyperkit-driver-older-version")},
 	}
 
 	originalPath := os.Getenv("PATH")

--- a/test/integration/error_spam_test.go
+++ b/test/integration/error_spam_test.go
@@ -54,7 +54,7 @@ var stderrAllow = []string{
 // stderrAllowRe combines rootCauses into a single regex
 var stderrAllowRe = regexp.MustCompile(strings.Join(stderrAllow, "|"))
 
-// TestErrorSpam asserts that there are no errors displayed in UI.
+// TestErrorSpam asserts that there are no unexpected errors displayed in minikube command outputs.
 func TestErrorSpam(t *testing.T) {
 	if NoneDriver() {
 		t.Skip("none driver always shows a warning")

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -355,6 +355,7 @@ func validateDockerEnv(ctx context.Context, t *testing.T, profile string) {
 	}
 }
 
+// validateStartWithProxy makes sure minikube start respects the HTTP_PROXY environment variable
 func validateStartWithProxy(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 
@@ -388,6 +389,7 @@ func validateStartWithProxy(ctx context.Context, t *testing.T, profile string) {
 
 }
 
+// validateAuditAfterStart makes sure the audit log contains the correct logging after minikube start
 func validateAuditAfterStart(ctx context.Context, t *testing.T, profile string) {
 	got, err := auditContains(profile)
 	if err != nil {
@@ -490,6 +492,7 @@ func validateMinikubeKubectlDirectCall(ctx context.Context, t *testing.T, profil
 	}
 }
 
+// validateExtraConfig verifies minikube with --extra-config works as expected
 func validateExtraConfig(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 
@@ -536,7 +539,7 @@ func imageID(image string) string {
 }
 
 // validateComponentHealth asserts that all Kubernetes components are healthy
-// note: it expects all components to be Ready, so it makes sense to run it close after only those tests that include '--wait=all' start flag (ie, with extra wait)
+// NOTE: It expects all components to be Ready, so it makes sense to run it close after only those tests that include '--wait=all' start flag
 func validateComponentHealth(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 
@@ -588,6 +591,7 @@ func validateComponentHealth(ctx context.Context, t *testing.T, profile string) 
 	}
 }
 
+// validateStatusCmd makes sure minikube status outputs correctly
 func validateStatusCmd(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "status"))

--- a/test/integration/functional_test_mount_test.go
+++ b/test/integration/functional_test_mount_test.go
@@ -43,6 +43,7 @@ const (
 	createdByPodRemovedByTest = "created-by-pod-removed-by-test"
 )
 
+// validateMountCmd verifies the minikube mount command works properly
 func validateMountCmd(ctx context.Context, t *testing.T, profile string) { // nolint
 	if NoneDriver() {
 		t.Skip("skipping: none driver does not support mount")

--- a/test/integration/functional_test_pvc_test.go
+++ b/test/integration/functional_test_pvc_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/minikube/pkg/util/retry"
 )
 
+// validatePersistentVolumeClaim makes sure PVCs work properly
 func validatePersistentVolumeClaim(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 

--- a/test/integration/functional_test_tunnel_test.go
+++ b/test/integration/functional_test_tunnel_test.go
@@ -48,6 +48,7 @@ var (
 	domain   = "nginx-svc.default.svc.cluster.local."
 )
 
+// validateTunnelCmd makes sure the minikube tunnel command works as expected
 func validateTunnelCmd(ctx context.Context, t *testing.T, profile string) {
 	ctx, cancel := context.WithTimeout(ctx, Minutes(20))
 	type validateFunc func(context.Context, *testing.T, string)

--- a/test/integration/gvisor_addon_test.go
+++ b/test/integration/gvisor_addon_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 )
 
+// TestGvisorAddon tests the functionality of the gVisor addon
 func TestGvisorAddon(t *testing.T) {
 	if NoneDriver() {
 		t.Skip("Can't run containerd backend with none driver")

--- a/test/integration/json_output_test.go
+++ b/test/integration/json_output_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/reason"
 )
 
+// TestJSONOutput makes sure json output works properly for the start, pause, unpause, and stop commands
 func TestJSONOutput(t *testing.T) {
 	profile := UniqueProfileName("json-output")
 	ctx, cancel := context.WithTimeout(context.Background(), Minutes(40))
@@ -98,7 +99,7 @@ func TestJSONOutput(t *testing.T) {
 	}
 }
 
-//  make sure each step has a distinct step number
+//  validateDistinctCurrentSteps makes sure each step has a distinct step number
 func validateDistinctCurrentSteps(ctx context.Context, t *testing.T, ces []*cloudEvent) {
 	steps := map[string]string{}
 	for _, ce := range ces {
@@ -113,7 +114,7 @@ func validateDistinctCurrentSteps(ctx context.Context, t *testing.T, ces []*clou
 	}
 }
 
-// for successful minikube start, 'current step' should be increasing
+// validateIncreasingCurrentSteps verifies that for a successful minikube start, 'current step' should be increasing
 func validateIncreasingCurrentSteps(ctx context.Context, t *testing.T, ces []*cloudEvent) {
 	step := -1
 	for _, ce := range ces {
@@ -132,6 +133,7 @@ func validateIncreasingCurrentSteps(ctx context.Context, t *testing.T, ces []*cl
 	}
 }
 
+// TestErrorJSONOutput makes sure json output can print errors properly
 func TestErrorJSONOutput(t *testing.T) {
 	profile := UniqueProfileName("json-output-error")
 	ctx, cancel := context.WithTimeout(context.Background(), Minutes(2))
@@ -154,8 +156,8 @@ func TestErrorJSONOutput(t *testing.T) {
 	if last.Type() != register.NewError("").Type() {
 		t.Fatalf("last cloud event is not of type error: %v", last)
 	}
-	last.validateData(t, "exitcode", fmt.Sprintf("%v", reason.ExDriverUnsupported))
-	last.validateData(t, "message", fmt.Sprintf("The driver 'fail' is not supported on %s/%s", runtime.GOOS, runtime.GOARCH))
+	last.checkData(t, "exitcode", fmt.Sprintf("%v", reason.ExDriverUnsupported))
+	last.checkData(t, "message", fmt.Sprintf("The driver 'fail' is not supported on %s/%s", runtime.GOOS, runtime.GOARCH))
 }
 
 type cloudEvent struct {
@@ -175,7 +177,7 @@ func newCloudEvent(t *testing.T, ce cloudevents.Event) *cloudEvent {
 	}
 }
 
-func (c *cloudEvent) validateData(t *testing.T, key, value string) {
+func (c *cloudEvent) checkData(t *testing.T, key, value string) {
 	v, ok := c.data[key]
 	if !ok {
 		t.Fatalf("expected key %s does not exist in cloud event", key)

--- a/test/integration/kic_custom_network_test.go
+++ b/test/integration/kic_custom_network_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/minikube/pkg/drivers/kic/oci"
 )
 
+// TestKicCustomNetwork verifies the docker driver works with a custom network
 func TestKicCustomNetwork(t *testing.T) {
 	if !KicDriver() {
 		t.Skip("only runs with docker driver")
@@ -66,6 +67,7 @@ func TestKicCustomNetwork(t *testing.T) {
 	}
 }
 
+// TestKicExistingNetwork verifies the docker driver and run with an existing network
 func TestKicExistingNetwork(t *testing.T) {
 	if !KicDriver() {
 		t.Skip("only runs with docker driver")

--- a/test/integration/multinode_test.go
+++ b/test/integration/multinode_test.go
@@ -231,6 +231,7 @@ func validateStartNodeAfterStop(ctx context.Context, t *testing.T, profile strin
 	}
 }
 
+// validateStopMultiNodeCluster runs minikube stop on a multinode cluster
 func validateStopMultiNodeCluster(ctx context.Context, t *testing.T, profile string) {
 	// Run minikube stop on the cluster
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "stop"))

--- a/test/integration/multinode_test.go
+++ b/test/integration/multinode_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/config"
 )
 
+// TestMultiNode tests all multi node cluster functionality
 func TestMultiNode(t *testing.T) {
 	if NoneDriver() {
 		t.Skip("none driver does not support multinode")
@@ -53,7 +54,7 @@ func TestMultiNode(t *testing.T) {
 			{"DeleteNode", validateDeleteNodeFromMultiNode},
 			{"StopMultiNode", validateStopMultiNodeCluster},
 			{"RestartMultiNode", validateRestartMultiNodeCluster},
-			{"ValidateNameConflict", validatNameConflict},
+			{"ValidateNameConflict", validateNameConflict},
 		}
 		for _, tc := range tests {
 			tc := tc
@@ -68,6 +69,7 @@ func TestMultiNode(t *testing.T) {
 	})
 }
 
+// validateMultiNodeStart makes sure a 2 node cluster can start
 func validateMultiNodeStart(ctx context.Context, t *testing.T, profile string) {
 	// Start a 2 node cluster with the --nodes param
 	startArgs := append([]string{"start", "-p", profile, "--wait=true", "--memory=2200", "--nodes=2", "-v=8", "--alsologtostderr"}, StartArgs()...)
@@ -92,6 +94,7 @@ func validateMultiNodeStart(ctx context.Context, t *testing.T, profile string) {
 
 }
 
+// validateAddNodeToMultiNode uses the minikube node add command to add a node to an existing cluster
 func validateAddNodeToMultiNode(ctx context.Context, t *testing.T, profile string) {
 	// Add a node to the current cluster
 	addArgs := []string{"node", "add", "-p", profile, "-v", "3", "--alsologtostderr"}
@@ -115,6 +118,7 @@ func validateAddNodeToMultiNode(ctx context.Context, t *testing.T, profile strin
 	}
 }
 
+// validateProfileListWithMultiNode make sure minikube profile list outputs correct with multinode clusters
 func validateProfileListWithMultiNode(ctx context.Context, t *testing.T, profile string) {
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), "profile", "list", "--output", "json"))
 	if err != nil {
@@ -153,6 +157,7 @@ func validateProfileListWithMultiNode(ctx context.Context, t *testing.T, profile
 
 }
 
+// validateStopRunningNode tests the minikube node stop command
 func validateStopRunningNode(ctx context.Context, t *testing.T, profile string) {
 	// Run minikube node stop on that node
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "node", "stop", ThirdNodeName))
@@ -186,6 +191,7 @@ func validateStopRunningNode(ctx context.Context, t *testing.T, profile string) 
 	}
 }
 
+// validateStartNodeAfterStop tests the minikube node start command on an existing stopped node
 func validateStartNodeAfterStop(ctx context.Context, t *testing.T, profile string) {
 	if DockerDriver() {
 		rr, err := Run(t, exec.Command("docker", "version", "-f", "{{.Server.Version}}"))
@@ -254,6 +260,7 @@ func validateStopMultiNodeCluster(ctx context.Context, t *testing.T, profile str
 	}
 }
 
+// validateRestartMultiNodeCluster verifies a soft restart on a multinode cluster works
 func validateRestartMultiNodeCluster(ctx context.Context, t *testing.T, profile string) {
 	if DockerDriver() {
 		rr, err := Run(t, exec.Command("docker", "version", "-f", "{{.Server.Version}}"))
@@ -303,8 +310,8 @@ func validateRestartMultiNodeCluster(ctx context.Context, t *testing.T, profile 
 	}
 }
 
+// validateDeleteNodeFromMultiNode tests the minikube node delete command
 func validateDeleteNodeFromMultiNode(ctx context.Context, t *testing.T, profile string) {
-
 	// Start the node back up
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "node", "delete", ThirdNodeName))
 	if err != nil {
@@ -353,7 +360,8 @@ func validateDeleteNodeFromMultiNode(ctx context.Context, t *testing.T, profile 
 	}
 }
 
-func validatNameConflict(ctx context.Context, t *testing.T, profile string) {
+// validateNameConflict tests that the node name verification works as expected
+func validateNameConflict(ctx context.Context, t *testing.T, profile string) {
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), "node", "list", "-p", profile))
 	if err != nil {
 		t.Errorf("failed to run node list. args %q : %v", rr.Command(), err)
@@ -389,6 +397,7 @@ func validatNameConflict(ctx context.Context, t *testing.T, profile string) {
 	}
 }
 
+// validateDeployAppToMultiNode deploys an app to a multinode cluster and makes sure all nodes can serve traffic
 func validateDeployAppToMultiNode(ctx context.Context, t *testing.T, profile string) {
 	// Create a deployment for app
 	_, err := Run(t, exec.CommandContext(ctx, Target(), "kubectl", "-p", profile, "--", "apply", "-f", "./testdata/multinodes/multinode-pod-dns-test.yaml"))

--- a/test/integration/net_test.go
+++ b/test/integration/net_test.go
@@ -32,6 +32,9 @@ import (
 	"k8s.io/minikube/pkg/util/retry"
 )
 
+// TestNetworkPlugins tests all supported CNI options
+// Options tested: kubenet, bridge, flannel, kindnet, calico, cilium
+// Flags tested: enable-default-cni (legacy), false (CNI off), auto-detection
 func TestNetworkPlugins(t *testing.T) {
 	MaybeParallel(t)
 	if NoneDriver() {

--- a/test/integration/none_test.go
+++ b/test/integration/none_test.go
@@ -32,7 +32,8 @@ import (
 	"k8s.io/minikube/pkg/minikube/localpath"
 )
 
-// None-driver specific test for CHANGE_MINIKUBE_NONE_USER
+// TestChangeNoneUser tests to make sure the CHANGE_MINIKUBE_NONE_USER environemt variable is respected
+// and changes the minikube file permissions from root to the correct user.
 func TestChangeNoneUser(t *testing.T) {
 	if !NoneDriver() {
 		t.Skip("Only test none driver.")

--- a/test/integration/pause_test.go
+++ b/test/integration/pause_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/minikube/cmd/minikube/cmd"
 )
 
+// TestPause tests minikube pause functionality
 func TestPause(t *testing.T) {
 	MaybeParallel(t)
 
@@ -68,6 +69,7 @@ func TestPause(t *testing.T) {
 	})
 }
 
+// validateFreshStart just starts a new minikube cluster
 func validateFreshStart(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 
@@ -97,6 +99,7 @@ func validateStartNoReconfigure(ctx context.Context, t *testing.T, profile strin
 	}
 }
 
+// validatePause runs minikube pause
 func validatePause(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 
@@ -107,6 +110,7 @@ func validatePause(ctx context.Context, t *testing.T, profile string) {
 	}
 }
 
+// validateUnpause runs minikube unpause
 func validateUnpause(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 
@@ -117,6 +121,7 @@ func validateUnpause(ctx context.Context, t *testing.T, profile string) {
 	}
 }
 
+// validateDelete deletes the unpaused cluster
 func validateDelete(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 
@@ -127,7 +132,7 @@ func validateDelete(ctx context.Context, t *testing.T, profile string) {
 	}
 }
 
-// make sure no left over left after deleting a profile such as containers or volumes
+// validateVerifyDeleted makes sure no left over left after deleting a profile such as containers or volumes
 func validateVerifyDeleted(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 
@@ -171,6 +176,7 @@ func validateVerifyDeleted(ctx context.Context, t *testing.T, profile string) {
 
 }
 
+// validateStatus makes sure paused clusters show up in minikube status correctly
 func validateStatus(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 

--- a/test/integration/pkg_install_test.go
+++ b/test/integration/pkg_install_test.go
@@ -1,23 +1,7 @@
+// +build integration
+
 /*
 Copyright 2021 The Kubernetes Authors All rights reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
-// build integration
-
-/*
-Copyright 2016 The Kubernetes Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -48,7 +32,6 @@ var distros = []string{
 	"debian:latest",
 	"debian:10",
 	"debian:9",
-	//
 	"ubuntu:latest",
 	"ubuntu:20.10",
 	"ubuntu:20.04",
@@ -58,7 +41,7 @@ var distros = []string{
 var timeout = Minutes(10)
 
 // TestPackageInstall tests installation of .deb packages with minikube itself and with kvm2 driver
-//   on debian/ubuntu docker images enumerated in "distros"
+// on various debian/ubuntu docker images
 func TestDebPackageInstall(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/test/integration/preload_test.go
+++ b/test/integration/preload_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 )
 
+// TestPreload verifies the preload tarballs get pulled in properly by minikube
 func TestPreload(t *testing.T) {
 	if NoneDriver() {
 		t.Skipf("skipping %s - incompatible with none driver", t.Name())

--- a/test/integration/scheduled_stop_test.go
+++ b/test/integration/scheduled_stop_test.go
@@ -37,12 +37,10 @@ import (
 	"k8s.io/minikube/pkg/util/retry"
 )
 
+// TestScheduledStopWindows tests the schedule stop functionality on Windows
 func TestScheduledStopWindows(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("test only runs on windows")
-	}
-	if NoneDriver() {
-		t.Skip("--schedule does not work with the none driver")
 	}
 	profile := UniqueProfileName("scheduled-stop")
 	ctx, cancel := context.WithTimeout(context.Background(), Minutes(5))
@@ -73,6 +71,7 @@ func TestScheduledStopWindows(t *testing.T) {
 	ensureMinikubeStatus(ctx, t, profile, "Host", state.Stopped.String())
 }
 
+// TestScheduledStopWindows tests the schedule stop functionality on Unix
 func TestScheduledStopUnix(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test only runs on unix")

--- a/test/integration/skaffold_test.go
+++ b/test/integration/skaffold_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/minikube/pkg/util/retry"
 )
 
+// TestSkaffold makes sure skaffold run can be run with minikube
 func TestSkaffold(t *testing.T) {
 	if NoneDriver() {
 		t.Skip("none driver doesn't support `minikube docker-env`; skaffold depends on this command")

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -35,6 +35,8 @@ import (
 	"k8s.io/minikube/pkg/minikube/constants"
 )
 
+// TestStartStop tests starting, stopping and restarting a minikube clusters with various Kubernetes versions and configurations
+// The oldest supported, newest supported and default Kubernetes versions are always tested.
 func TestStartStop(t *testing.T) {
 	MaybeParallel(t)
 
@@ -150,6 +152,7 @@ func TestStartStop(t *testing.T) {
 	})
 }
 
+// validateFirstStart runs the initial minikube start
 func validateFirstStart(ctx context.Context, t *testing.T, profile string, tcName string, tcVersion string, startArgs []string) {
 	defer PostMortemLogs(t, profile)
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), startArgs...))
@@ -158,6 +161,7 @@ func validateFirstStart(ctx context.Context, t *testing.T, profile string, tcNam
 	}
 }
 
+// validateDeploying deploys an app the minikube cluster
 func validateDeploying(ctx context.Context, t *testing.T, profile string, tcName string, tcVersion string, startArgs []string) {
 	defer PostMortemLogs(t, profile)
 	if !strings.Contains(tcName, "cni") {
@@ -165,6 +169,7 @@ func validateDeploying(ctx context.Context, t *testing.T, profile string, tcName
 	}
 }
 
+// validateStop tests minikube stop
 func validateStop(ctx context.Context, t *testing.T, profile string, tcName string, tcVersion string, startArgs []string) {
 	defer PostMortemLogs(t, profile)
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), "stop", "-p", profile, "--alsologtostderr", "-v=3"))
@@ -173,6 +178,7 @@ func validateStop(ctx context.Context, t *testing.T, profile string, tcName stri
 	}
 }
 
+// validateEnableAddonAfterStop makes sure addons can be enabled on a stopped cluster
 func validateEnableAddonAfterStop(ctx context.Context, t *testing.T, profile string, tcName string, tcVersion string, startArgs []string) {
 	defer PostMortemLogs(t, profile)
 	// The none driver never really stops
@@ -191,6 +197,7 @@ func validateEnableAddonAfterStop(ctx context.Context, t *testing.T, profile str
 
 }
 
+// validateSecondStart verifies that starting a stopped cluster works
 func validateSecondStart(ctx context.Context, t *testing.T, profile string, tcName string, tcVersion string, startArgs []string) {
 	defer PostMortemLogs(t, profile)
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), startArgs...))
@@ -227,12 +234,14 @@ func validateAddonAfterStop(ctx context.Context, t *testing.T, profile string, t
 	}
 }
 
+// validateKubernetesImages verifies that a restarted cluster contains all the necessary images
 func validateKubernetesImages(ctx context.Context, t *testing.T, profile string, tcName string, tcVersion string, startArgs []string) {
 	if !NoneDriver() {
 		testPulledImages(ctx, t, profile, tcVersion)
 	}
 }
 
+// validatePauseAfterStart verifies that minikube pause works
 func validatePauseAfterStart(ctx context.Context, t *testing.T, profile string, tcName string, tcVersion string, startArgs []string) {
 	defer PostMortemLogs(t, profile)
 	testPause(ctx, t, profile)

--- a/test/integration/status_test.go
+++ b/test/integration/status_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/localpath"
 )
 
+// TestInsufficientStorage makes sure minikube status displays the correct info if there is insufficient disk space on the machine
 func TestInsufficientStorage(t *testing.T) {
 	if !KicDriver() {
 		t.Skip("only runs with docker driver")

--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -63,7 +63,7 @@ func legacyStartArgs() []string {
 	return strings.Split(strings.Replace(*startArgs, "--driver", "--vm-driver", -1), " ")
 }
 
-// TestRunningBinaryUpgrade upgrades a running legacy cluster to head minikube
+// TestRunningBinaryUpgrade upgrades a running legacy cluster to minikube at HEAD
 func TestRunningBinaryUpgrade(t *testing.T) {
 	// not supported till v1.10, and passing new images to old releases isn't supported anyways
 	if TestingKicBaseImage() {
@@ -132,7 +132,7 @@ func TestRunningBinaryUpgrade(t *testing.T) {
 	}
 }
 
-// TestStoppedBinaryUpgrade starts a legacy minikube and stops it and then upgrades to head minikube
+// TestStoppedBinaryUpgrade starts a legacy minikube, stops it, and then upgrades to minikube at HEAD
 func TestStoppedBinaryUpgrade(t *testing.T) {
 	// not supported till v1.10, and passing new images to old releases isn't supported anyways
 	if TestingKicBaseImage() {


### PR DESCRIPTION
This adds functionality to `make generate-docs` that goes through all files in `test/integration`, finds anything that starts with "Test" or "validate" and throws all that info, along with the docs comments, into a file on our website.

This PR also adds missing documentation and fixes tests when appropriate.

Fixes #11117