### PR TITLE
site:add note for failing echoserver image on m1

### DIFF
--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -176,6 +176,9 @@ It may take a moment, but your deployment will soon show up when you run:
 kubectl get services hello-minikube
 ```
 
+> :warning: On M1-based machines (`arm64` architecture) the `echoserver:1.4` image currently fails to start.
+> Your best bet is to build a custom `echoserver` image and deploy that as is outlined in [#11107](/../../issues/11107#).
+
 The easiest way to access this service is to let minikube launch a web browser for you:
 
 ```shell


### PR DESCRIPTION
As was discussed in https://github.com/kubernetes/minikube/issues/11107# on m1-based machines the `echoserver:1.4` (and any other available version) does not start. 

This commit adds a hint for people experiencing this, and links to the issue where a work around is mentioned.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
