### PR TITLE
new command "image pull: allow to load remote images directly without cache

### DIFF
--- a/cmd/minikube/cmd/image.go
+++ b/cmd/minikube/cmd/image.go
@@ -78,7 +78,7 @@ var loadImageCmd = &cobra.Command{
 		if pull {
 			// Pull image from remote registry, without doing any caching except in container runtime.
 			// This is similar to daemon.Image but it is done by the container runtime in the cluster.
-			if err := machine.DoPullImages(args, profile); err != nil {
+			if err := machine.PullImages(args, profile); err != nil {
 				exit.Error(reason.GuestImageLoad, "Failed to pull image", err)
 			}
 			return

--- a/cmd/minikube/cmd/image.go
+++ b/cmd/minikube/cmd/image.go
@@ -38,6 +38,7 @@ var imageCmd = &cobra.Command{
 }
 
 var (
+	pull      bool
 	imgDaemon bool
 	imgRemote bool
 )
@@ -72,6 +73,15 @@ var loadImageCmd = &cobra.Command{
 		profile, err := config.LoadProfile(viper.GetString(config.ProfileName))
 		if err != nil {
 			exit.Error(reason.Usage, "loading profile", err)
+		}
+
+		if pull {
+			// Pull image from remote registry, without doing any caching except in container runtime.
+			// This is similar to daemon.Image but it is done by the container runtime in the cluster.
+			if err := machine.DoPullImages(args, profile); err != nil {
+				exit.Error(reason.GuestImageLoad, "Failed to pull image", err)
+			}
+			return
 		}
 
 		var local bool
@@ -166,6 +176,7 @@ $ minikube image list
 func init() {
 	imageCmd.AddCommand(loadImageCmd)
 	imageCmd.AddCommand(removeImageCmd)
+	loadImageCmd.Flags().BoolVarP(&pull, "pull", "", false, "Pull the remote image (no caching)")
 	loadImageCmd.Flags().BoolVar(&imgDaemon, "daemon", false, "Cache image from docker daemon")
 	loadImageCmd.Flags().BoolVar(&imgRemote, "remote", false, "Cache image from remote registry")
 	imageCmd.AddCommand(listImageCmd)

--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -267,6 +267,11 @@ func (r *Containerd) LoadImage(path string) error {
 	return nil
 }
 
+// PullImage pulls an image into this runtime
+func (r *Containerd) PullImage(name string) error {
+	return pullCRIImage(r.Runner, name)
+}
+
 // RemoveImage removes a image
 func (r *Containerd) RemoveImage(name string) error {
 	return removeCRIImage(r.Runner, name)

--- a/pkg/minikube/cruntime/cri.go
+++ b/pkg/minikube/cruntime/cri.go
@@ -187,6 +187,19 @@ func killCRIContainers(cr CommandRunner, ids []string) error {
 	return nil
 }
 
+// pullCRIImage pulls image using crictl
+func pullCRIImage(cr CommandRunner, name string) error {
+	klog.Infof("Pulling image: %s", name)
+
+	crictl := getCrictlPath(cr)
+	args := append([]string{crictl, "pull"}, name)
+	c := exec.Command("sudo", args...)
+	if _, err := cr.RunCmd(c); err != nil {
+		return errors.Wrap(err, "crictl")
+	}
+	return nil
+}
+
 // removeCRIImage remove image using crictl
 func removeCRIImage(cr CommandRunner, name string) error {
 	klog.Infof("Removing image: %s", name)

--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -187,6 +187,11 @@ func (r *CRIO) LoadImage(path string) error {
 	return nil
 }
 
+// PullImage pulls an image
+func (r *CRIO) PullImage(name string) error {
+	return pullCRIImage(r.Runner, name)
+}
+
 // RemoveImage removes a image
 func (r *CRIO) RemoveImage(name string) error {
 	return removeCRIImage(r.Runner, name)

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -152,7 +152,7 @@ type ListContainersOptions struct {
 	Namespaces []string
 }
 
-// ListImageOptions are the options to use for listing images
+// ListImagesOptions are the options to use for listing images
 type ListImagesOptions struct {
 }
 

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -95,6 +95,8 @@ type Manager interface {
 
 	// Load an image idempotently into the runtime on a host
 	LoadImage(string) error
+	// Pull an image to the runtime from the container registry
+	PullImage(string) error
 
 	// ImageExists takes image name and image sha checks if an it exists
 	ImageExists(string, string) bool

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -191,6 +191,19 @@ func (r *Docker) LoadImage(path string) error {
 	return nil
 }
 
+// PullImage pulls an image
+func (r *Docker) PullImage(name string) error {
+	klog.Infof("Pulling image: %s", name)
+	if r.UseCRI {
+		return pullCRIImage(r.Runner, name)
+	}
+	c := exec.Command("docker", "pull", name)
+	if _, err := r.Runner.RunCmd(c); err != nil {
+		return errors.Wrap(err, "pull image docker.")
+	}
+	return nil
+}
+
 // RemoveImage removes a image
 func (r *Docker) RemoveImage(name string) error {
 	klog.Infof("Removing image: %s", name)

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -294,6 +294,86 @@ func transferAndLoadImage(cr command.Runner, k8s config.KubernetesConfig, src st
 	return nil
 }
 
+// pullImages pulls images to the container run time
+func pullImages(cruntime cruntime.Manager, images []string) error {
+	klog.Infof("PullImages start: %s", images)
+	start := time.Now()
+
+	defer func() {
+		klog.Infof("PullImages completed in %s", time.Since(start))
+	}()
+
+	var g errgroup.Group
+
+	for _, image := range images {
+		image := image
+		g.Go(func() error {
+			return cruntime.PullImage(image)
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return errors.Wrap(err, "error pulling images")
+	}
+	klog.Infoln("Successfully pulled images")
+	return nil
+}
+
+func DoPullImages(images []string, profile *config.Profile) error {
+	api, err := NewAPIClient()
+	if err != nil {
+		return errors.Wrap(err, "error creating api client")
+	}
+	defer api.Close()
+
+	succeeded := []string{}
+	failed := []string{}
+
+	pName := profile.Name
+
+	c, err := config.Load(pName)
+	if err != nil {
+		klog.Errorf("Failed to load profile %q: %v", pName, err)
+		return errors.Wrapf(err, "error loading config for profile :%v", pName)
+	}
+
+	for _, n := range c.Nodes {
+		m := config.MachineName(*c, n)
+
+		status, err := Status(api, m)
+		if err != nil {
+			klog.Warningf("error getting status for %s: %v", m, err)
+			continue
+		}
+
+		if status == state.Running.String() {
+			h, err := api.Load(m)
+			if err != nil {
+				klog.Warningf("Failed to load machine %q: %v", m, err)
+				continue
+			}
+			runner, err := CommandRunner(h)
+			if err != nil {
+				return err
+			}
+			cruntime, err := cruntime.New(cruntime.Config{Type: c.KubernetesConfig.ContainerRuntime, Runner: runner})
+			if err != nil {
+				return errors.Wrap(err, "error creating container runtime")
+			}
+			err = pullImages(cruntime, images)
+			if err != nil {
+				failed = append(failed, m)
+				klog.Warningf("Failed to pull images for profile %s %v", pName, err.Error())
+				continue
+			}
+			succeeded = append(succeeded, m)
+		}
+	}
+
+	klog.Infof("succeeded pulling to: %s", strings.Join(succeeded, " "))
+	klog.Infof("failed pulling to: %s", strings.Join(failed, " "))
+	return nil
+}
+
 // removeImages removes images from the container run time
 func removeImages(cruntime cruntime.Manager, images []string) error {
 	klog.Infof("RemovingImages start: %s", images)

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -318,7 +318,8 @@ func pullImages(cruntime cruntime.Manager, images []string) error {
 	return nil
 }
 
-func DoPullImages(images []string, profile *config.Profile) error {
+// PullImages pulls images to all nodes in profile
+func PullImages(images []string, profile *config.Profile) error {
 	api, err := NewAPIClient()
 	if err != nil {
 		return errors.Wrap(err, "error creating api client")
@@ -398,6 +399,7 @@ func removeImages(cruntime cruntime.Manager, images []string) error {
 	return nil
 }
 
+// RemoveImages removes images from all nodes in profile
 func RemoveImages(images []string, profile *config.Profile) error {
 	api, err := NewAPIClient()
 	if err != nil {
@@ -454,6 +456,7 @@ func RemoveImages(images []string, profile *config.Profile) error {
 	return nil
 }
 
+// ListImages lists images on all nodes in profile
 func ListImages(profile *config.Profile) error {
 	api, err := NewAPIClient()
 	if err != nil {

--- a/site/content/en/docs/commands/image.md
+++ b/site/content/en/docs/commands/image.md
@@ -139,6 +139,7 @@ minikube image load image.tar
 
 ```
       --daemon   Cache image from docker daemon
+      --pull     Pull the remote image (no caching)
       --remote   Cache image from remote registry
 ```
 


### PR DESCRIPTION
When looking at the benchmarks, there seems to be a need to pull images without too much intermediate layers...

This bypasses the local daemon and the file cache, and asks the container runtime to pull directly from the registry.

Basically the same as:

`minikube ssh -- sudo crictl pull image`