### PR TITLE
Add API for saving an image to a local path

### DIFF
--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -274,6 +274,16 @@ func (r *Containerd) PullImage(name string) error {
 	return pullCRIImage(r.Runner, name)
 }
 
+// SaveImage save an image from this runtime
+func (r *Containerd) SaveImage(name string, path string) error {
+	klog.Infof("Saving image %s: %s", name, path)
+	c := exec.Command("sudo", "ctr", "-n=k8s.io", "images", "export", path, name)
+	if _, err := r.Runner.RunCmd(c); err != nil {
+		return errors.Wrapf(err, "ctr images export")
+	}
+	return nil
+}
+
 // RemoveImage removes a image
 func (r *Containerd) RemoveImage(name string) error {
 	return removeCRIImage(r.Runner, name)

--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -193,6 +193,16 @@ func (r *CRIO) PullImage(name string) error {
 	return pullCRIImage(r.Runner, name)
 }
 
+// SaveImage saves an image from this runtime
+func (r *CRIO) SaveImage(name string, path string) error {
+	klog.Infof("Saving image %s: %s", name, path)
+	c := exec.Command("sudo", "podman", "save", name, "-o", path)
+	if _, err := r.Runner.RunCmd(c); err != nil {
+		return errors.Wrap(err, "crio save image")
+	}
+	return nil
+}
+
 // RemoveImage removes a image
 func (r *CRIO) RemoveImage(name string) error {
 	return removeCRIImage(r.Runner, name)

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -99,6 +99,8 @@ type Manager interface {
 	PullImage(string) error
 	// Build an image idempotently into the runtime on a host
 	BuildImage(string, string, string, bool, []string, []string) error
+	// Save an image from the runtime on a host
+	SaveImage(string, string) error
 
 	// ImageExists takes image name and image sha checks if an it exists
 	ImageExists(string, string) bool

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -205,6 +205,16 @@ func (r *Docker) PullImage(name string) error {
 	return nil
 }
 
+// SaveImage saves an image from this runtime
+func (r *Docker) SaveImage(name string, path string) error {
+	klog.Infof("Saving image %s: %s", name, path)
+	c := exec.Command("docker", "save", name, "-o", path)
+	if _, err := r.Runner.RunCmd(c); err != nil {
+		return errors.Wrap(err, "saveimage docker.")
+	}
+	return nil
+}
+
 // RemoveImage removes a image
 func (r *Docker) RemoveImage(name string) error {
 	klog.Infof("Removing image: %s", name)


### PR DESCRIPTION
This function SaveImage is the opposite of LoadImage,
useful for saving built images to the cache directory.

This is an alternative to using the push functionality,
which requires a registry (similar to the pull function).

For #11130
