### PR TITLE
Add checksum to the preload tarball download

### DIFF
--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -144,9 +144,10 @@ func Preload(k8sVersion, containerRuntime string) error {
 
 	checksum, err := getChecksum(k8sVersion, containerRuntime)
 	if err != nil {
-		return errors.Wrap(err, "getting checksum")
+		klog.Warningf("No checksum for preloaded tarball for k8s version %s", k8sVersion)
+	} else if checksum != "" {
+		url += "?checksum=" + checksum
 	}
-	url += "?checksum=" + checksum
 
 	if err := download(url, targetPath); err != nil {
 		return errors.Wrapf(err, "download failed: %s", url)

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -142,9 +142,11 @@ func Preload(k8sVersion, containerRuntime string) error {
 	out.Step(style.FileDownload, "Downloading Kubernetes {{.version}} preload ...", out.V{"version": k8sVersion})
 	url := remoteTarballURL(k8sVersion, containerRuntime)
 
-	if checksum, err := getChecksum(k8sVersion, containerRuntime); err == nil {
-		url += "?checksum=" + checksum
+	checksum, err := getChecksum(k8sVersion, containerRuntime)
+	if err != nil {
+		return errors.Wrap(err, "getting checksum")
 	}
+	url += "?checksum=" + checksum
 
 	if err := download(url, targetPath); err != nil {
 		return errors.Wrapf(err, "download failed: %s", url)

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -145,7 +145,7 @@ func Preload(k8sVersion, containerRuntime string) error {
 	checksum, err := getChecksum(k8sVersion, containerRuntime)
 	var realPath string
 	if err != nil {
-		klog.Warningf("No checksum for preloaded tarball for k8s version %s", k8sVersion)
+		klog.Warningf("No checksum for preloaded tarball for k8s version %s: %v", k8sVersion, err)
 		realPath = targetPath
 		tmp, err := ioutil.TempFile(targetDir(), TarballName(k8sVersion, containerRuntime)+".*")
 		if err != nil {


### PR DESCRIPTION
Check the checksum before putting the download into the cache,
leave the previous checksum file even if it is now redundant.

Closes #11061