### PR TITLE
bump golangci-lint to latest v1.39.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ MINIKUBE_RELEASES_URL=https://github.com/kubernetes/minikube/releases/download
 
 KERNEL_VERSION ?= 4.19.171
 # latest from https://github.com/golangci/golangci-lint/releases
-GOLINT_VERSION ?= v1.30.0
+GOLINT_VERSION ?= v1.39.0
 # Limit number of default jobs, to avoid the CI builds running out of memory
 GOLINT_JOBS ?= 4
 # see https://github.com/golangci/golangci-lint#memory-usage-of-golangci-lint

--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -140,7 +140,7 @@ var settings = []Setting{
 	},
 	{
 		name: Bootstrapper,
-		set:  SetString, //TODO(r2d4): more validation here?
+		set:  SetString,
 	},
 	{
 		name: config.ShowDriverDeprecationNotification,

--- a/cmd/minikube/cmd/config/prompt.go
+++ b/cmd/minikube/cmd/config/prompt.go
@@ -133,7 +133,7 @@ func AskForPasswordValue(s string) string {
 
 	result, err := concealableAskForStaticValue(os.Stdin, s, true)
 	if err != nil {
-		log.Fatal(err)
+		defer log.Fatal(err)
 	}
 	return result
 }

--- a/cmd/minikube/cmd/delete_test.go
+++ b/cmd/minikube/cmd/delete_test.go
@@ -159,7 +159,7 @@ func TestDeleteAllProfiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("tempdir: %v", err)
 	}
-	defer func() { //clean up tempdir
+	defer func() { // clean up tempdir
 		err := os.RemoveAll(td)
 		if err != nil {
 			t.Errorf("failed to clean up temp folder  %q", td)

--- a/cmd/minikube/cmd/podman-env.go
+++ b/cmd/minikube/cmd/podman-env.go
@@ -274,7 +274,7 @@ func podmanEnvVars(ec PodmanEnvConfig) map[string]string {
 		constants.PodmanContainerHostEnv:   podmanURL(ec.username, ec.hostname, ec.port),
 		constants.PodmanContainerSSHKeyEnv: ec.keypath,
 	}
-	//common
+	// common
 	env0 := map[string]string{
 		constants.MinikubeActivePodmanEnv: ec.profile,
 	}

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -155,7 +155,7 @@ func Execute() {
 
 	if err := RootCmd.Execute(); err != nil {
 		// Cobra already outputs the error, typically because the user provided an unknown command.
-		os.Exit(reason.ExProgramUsage)
+		defer os.Exit(reason.ExProgramUsage)
 	}
 }
 

--- a/hack/help_text/gen_help_text.go
+++ b/hack/help_text/gen_help_text.go
@@ -44,6 +44,6 @@ func main() {
 	err = cmd.GenerateBashCompletion(f, cmd.RootCmd)
 	if err != nil {
 		fmt.Println(err)
-		os.Exit(1)
+		defer os.Exit(1)
 	}
 }

--- a/pkg/addons/config.go
+++ b/pkg/addons/config.go
@@ -143,8 +143,8 @@ var Addons = []*Addon{
 		name:      "registry-aliases",
 		set:       SetBool,
 		callbacks: []setFn{EnableOrDisableAddon},
-		//TODO - add other settings
-		//TODO check if registry addon is enabled
+		// TODO - add other settings
+		// TODO check if registry addon is enabled
 	},
 	{
 		name:      "storage-provisioner",

--- a/pkg/drivers/hyperkit/driver.go
+++ b/pkg/drivers/hyperkit/driver.go
@@ -340,13 +340,13 @@ func (t tempError) Error() string {
 	return "Temporary error: " + t.Err.Error()
 }
 
-//recoverFromUncleanShutdown searches for an existing hyperkit.pid file in
-//the machine directory. If it can't find it, a clean shutdown is assumed.
-//If it finds the pid file, it checks for a running hyperkit process with that pid
-//as the existence of a file might not indicate an unclean shutdown but an actual running
-//hyperkit server. This is an error situation - we shouldn't start minikube as there is likely
-//an instance running already. If the PID in the pidfile does not belong to a running hyperkit
-//process, we can safely delete it, and there is a good chance the machine will recover when restarted.
+// recoverFromUncleanShutdown searches for an existing hyperkit.pid file in
+// the machine directory. If it can't find it, a clean shutdown is assumed.
+// If it finds the pid file, it checks for a running hyperkit process with that pid
+// as the existence of a file might not indicate an unclean shutdown but an actual running
+// hyperkit server. This is an error situation - we shouldn't start minikube as there is likely
+// an instance running already. If the PID in the pidfile does not belong to a running hyperkit
+// process, we can safely delete it, and there is a good chance the machine will recover when restarted.
 func (d *Driver) recoverFromUncleanShutdown() error {
 	stateDir := filepath.Join(d.StorePath, "machines", d.MachineName)
 	pidFile := filepath.Join(stateDir, pidFileName)

--- a/pkg/drivers/hyperkit/iso_test.go
+++ b/pkg/drivers/hyperkit/iso_test.go
@@ -27,7 +27,7 @@ func TestExtractFile(t *testing.T) {
 	if nil != err {
 		return
 	}
-	defer func() { //clean up tempdir
+	defer func() { // clean up tempdir
 		err := os.RemoveAll(testDir)
 		if err != nil {
 			t.Errorf("failed to clean up temp folder  %q", testDir)

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -103,7 +103,7 @@ var Addons = map[string]*Addon{
 			"auto-pause.service",
 			"0640"),
 
-		//GuestPersistentDir
+		// GuestPersistentDir
 	}, false, "auto-pause", map[string]string{
 		"AutoPauseHook": "azhao155/auto-pause-hook:1.13",
 	}, map[string]string{

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -186,9 +186,9 @@ func (k *Bootstrapper) init(cfg config.ClusterConfig) error {
 	}
 
 	ignore := []string{
-		fmt.Sprintf("DirAvailable-%s", strings.Replace(vmpath.GuestManifestsDir, "/", "-", -1)),
-		fmt.Sprintf("DirAvailable-%s", strings.Replace(vmpath.GuestPersistentDir, "/", "-", -1)),
-		fmt.Sprintf("DirAvailable-%s", strings.Replace(bsutil.EtcdDataDir(), "/", "-", -1)),
+		fmt.Sprintf("DirAvailable-%s", strings.ReplaceAll(vmpath.GuestManifestsDir, "/", "-")),
+		fmt.Sprintf("DirAvailable-%s", strings.ReplaceAll(vmpath.GuestPersistentDir, "/", "-")),
+		fmt.Sprintf("DirAvailable-%s", strings.ReplaceAll(bsutil.EtcdDataDir(), "/", "-")),
 		"FileAvailable--etc-kubernetes-manifests-kube-scheduler.yaml",
 		"FileAvailable--etc-kubernetes-manifests-kube-apiserver.yaml",
 		"FileAvailable--etc-kubernetes-manifests-kube-controller-manager.yaml",

--- a/pkg/minikube/config/profile_test.go
+++ b/pkg/minikube/config/profile_test.go
@@ -278,7 +278,7 @@ func TestGetPrimaryControlPlane(t *testing.T) {
 
 	for _, tc := range tests {
 		// To save converted config file from old style config at ./testdata/.minikube,
-		//rather than at env(MINIKUBE_HOME) which depends on test environment
+		// rather than at env(MINIKUBE_HOME) which depends on test environment
 		originalMinikubeHomeEnv := os.Getenv("MINIKUBE_HOME")
 		err = os.Setenv("MINIKUBE_HOME", miniDir)
 		if err != nil {

--- a/pkg/minikube/cruntime/cruntime_test.go
+++ b/pkg/minikube/cruntime/cruntime_test.go
@@ -522,7 +522,7 @@ func (f *FakeRunner) systemctl(args []string, root bool) (string, error) { // no
 				out += "[Unit]\n"
 				out += "Description=Docker Application Container Engine\n"
 				out += "Documentation=https://docs.docker.com\n"
-				//out += "BindsTo=containerd.service\n"
+				// out += "BindsTo=containerd.service\n"
 				return out, nil
 			}
 			return out, fmt.Errorf("%s cat unimplemented", svc)

--- a/pkg/minikube/delete/delete.go
+++ b/pkg/minikube/delete/delete.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/style"
 )
 
-//PossibleLeftOvers deletes KIC & non-KIC drivers left
+// PossibleLeftOvers deletes KIC & non-KIC drivers left
 func PossibleLeftOvers(ctx context.Context, cname string, driverName string) {
 	bin := ""
 	switch driverName {

--- a/pkg/minikube/extract/extract.go
+++ b/pkg/minikube/extract/extract.go
@@ -415,7 +415,7 @@ func checkBinaryExpression(b *ast.BinaryExpr) string {
 		}
 	}
 
-	//Check the right side
+	// Check the right side
 	if l, ok := b.Y.(*ast.BasicLit); ok {
 		if x := checkString(l.Value); x != "" {
 			s += x

--- a/pkg/minikube/extract/extract_test.go
+++ b/pkg/minikube/extract/extract_test.go
@@ -36,7 +36,7 @@ func TestExtract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Creating temp dir: %v", err)
 	}
-	defer func() { //clean up tempdir
+	defer func() { // clean up tempdir
 		err := os.RemoveAll(tempdir)
 		if err != nil {
 			t.Errorf("failed to clean up temp folder  %q", tempdir)

--- a/pkg/minikube/kubeconfig/kubeconfig_test.go
+++ b/pkg/minikube/kubeconfig/kubeconfig_test.go
@@ -233,7 +233,7 @@ func TestUpdate(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Error making temp directory %v", err)
 			}
-			defer func() { //clean up tempdir
+			defer func() { // clean up tempdir
 				err := os.RemoveAll(tmpDir)
 				if err != nil {
 					t.Errorf("failed to clean up temp folder  %q", tmpDir)

--- a/pkg/minikube/localpath/localpath.go
+++ b/pkg/minikube/localpath/localpath.go
@@ -142,12 +142,12 @@ func MachinePath(machine string, miniHome ...string) string {
 func SanitizeCacheDir(image string) string {
 	if runtime.GOOS == "windows" && hasWindowsDriveLetter(image) {
 		// not sanitize Windows drive letter.
-		s := image[:2] + strings.Replace(image[2:], ":", "_", -1)
+		s := image[:2] + strings.ReplaceAll(image[2:], ":", "_")
 		klog.Infof("windows sanitize: %s -> %s", image, s)
 		return s
 	}
 	// ParseReference cannot have a : in the directory path
-	return strings.Replace(image, ":", "_", -1)
+	return strings.ReplaceAll(image, ":", "_")
 }
 
 func hasWindowsDriveLetter(s string) bool {
@@ -197,7 +197,7 @@ func getWindowsVolumeNameCmd(d string) (string, error) {
 		return "", err
 	}
 
-	outs := strings.Split(strings.Replace(string(stdout), "\r", "", -1), "\n")
+	outs := strings.Split(strings.ReplaceAll(string(stdout), "\r", ""), "\n")
 
 	var vname string
 	for _, l := range outs {

--- a/pkg/minikube/localpath/localpath_test.go
+++ b/pkg/minikube/localpath/localpath_test.go
@@ -33,7 +33,7 @@ func TestReplaceWinDriveLetterToVolumeName(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error make tmp directory: %v", err)
 	}
-	defer func(path string) { //clean up tempdir
+	defer func(path string) { // clean up tempdir
 		err := os.RemoveAll(path)
 		if err != nil {
 			t.Errorf("failed to clean up temp folder  %q", path)

--- a/pkg/minikube/machine/cache_binaries_test.go
+++ b/pkg/minikube/machine/cache_binaries_test.go
@@ -93,7 +93,7 @@ func TestCacheBinariesForBootstrapper(t *testing.T) {
 		t.Fatalf("error during creating tmp dir: %v", err)
 	}
 
-	defer func() { //clean up tempdir
+	defer func() { // clean up tempdir
 		err := os.RemoveAll(minikubeHome)
 		if err != nil {
 			t.Errorf("failed to clean up temp folder  %q", minikubeHome)

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -432,7 +432,7 @@ func setupKubeconfig(h *host.Host, cc *config.ClusterConfig, n *config.Node, clu
 	}
 
 	if cc.KubernetesConfig.APIServerName != constants.APIServerName {
-		addr = strings.Replace(addr, n.IP, cc.KubernetesConfig.APIServerName, -1)
+		addr = strings.ReplaceAll(addr, n.IP, cc.KubernetesConfig.APIServerName)
 	}
 	kcs := &kubeconfig.Settings{
 		ClusterName:          clusterName,

--- a/pkg/minikube/notify/notify_test.go
+++ b/pkg/minikube/notify/notify_test.go
@@ -62,7 +62,7 @@ func TestShouldCheckURL(t *testing.T) {
 	// test that update notifications get triggered if it has been longer than 24 hours
 	viper.Set(config.ReminderWaitPeriodInHours, 24)
 
-	//time.Time{} returns time -> January 1, year 1, 00:00:00.000000000 UTC.
+	// time.Time{} returns time -> January 1, year 1, 00:00:00.000000000 UTC.
 	if err := writeTimeToFile(lastUpdateCheckFilePath, time.Time{}); err != nil {
 		t.Errorf("write failed: %v", err)
 	}

--- a/pkg/minikube/out/out.go
+++ b/pkg/minikube/out/out.go
@@ -386,9 +386,9 @@ func applyTmpl(format string, a ...V) string {
 
 	// escape any outstanding '%' signs so that they don't get interpreted
 	// as a formatting directive down the line
-	out = strings.Replace(out, "%", "%%", -1)
+	out = strings.ReplaceAll(out, "%", "%%")
 	// avoid doubling up in case this function is called multiple times
-	out = strings.Replace(out, "%%%%", "%%", -1)
+	out = strings.ReplaceAll(out, "%%%%", "%%")
 	return out
 }
 

--- a/pkg/minikube/out/register/cloud_events.go
+++ b/pkg/minikube/out/register/cloud_events.go
@@ -35,7 +35,7 @@ const (
 var (
 	outputFile io.Writer = os.Stdout
 
-	//GetUUID returns the UUID function to use
+	// GetUUID returns the UUID function to use
 	GetUUID = randomID
 
 	eventFile *os.File

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -171,7 +171,7 @@ func checkDockerVersion(o string) registry.State {
 	case 2:
 		p = append(p, "0") // patch version not found
 	case 3:
-		//remove postfix string for unstable(test/nightly) channel. https://docs.docker.com/engine/install/
+		// remove postfix string for unstable(test/nightly) channel. https://docs.docker.com/engine/install/
 		p[2] = strings.SplitN(p[2], "-", 2)[0]
 	default:
 		return registry.State{

--- a/pkg/util/crypto_test.go
+++ b/pkg/util/crypto_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestGenerateCACert(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "")
-	defer func() { //clean up tempdir
+	defer func() { // clean up tempdir
 		err := os.RemoveAll(tmpDir)
 		if err != nil {
 			t.Errorf("failed to clean up temp folder  %q", tmpDir)
@@ -63,7 +63,7 @@ func TestGenerateCACert(t *testing.T) {
 
 func TestGenerateSignedCert(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "")
-	defer func() { //clean up tempdir
+	defer func() { // clean up tempdir
 		err := os.RemoveAll(tmpDir)
 		if err != nil {
 			t.Errorf("failed to clean up temp folder  %q", tmpDir)
@@ -74,7 +74,7 @@ func TestGenerateSignedCert(t *testing.T) {
 	}
 
 	signerTmpDir, err := ioutil.TempDir("", "")
-	defer func() { //clean up tempdir
+	defer func() { // clean up tempdir
 		err := os.RemoveAll(signerTmpDir)
 		if err != nil {
 			t.Errorf("failed to clean up temp folder  %q", signerTmpDir)

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -89,7 +89,7 @@ func TestChownR(t *testing.T) {
 	if nil != err {
 		return
 	}
-	defer func() { //clean up tempdir
+	defer func() { // clean up tempdir
 		err := os.RemoveAll(testDir)
 		if err != nil {
 			t.Errorf("failed to clean up temp folder  %q", testDir)
@@ -143,7 +143,7 @@ func TestMaybeChownDirRecursiveToMinikubeUser(t *testing.T) {
 		return
 	}
 
-	defer func() { //clean up tempdir
+	defer func() { // clean up tempdir
 		err := os.RemoveAll(testDir)
 		if err != nil {
 			t.Errorf("failed to clean up temp folder  %q", testDir)

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -1444,7 +1444,7 @@ func validateCertSync(ctx context.Context, t *testing.T, profile string) {
 		}
 
 		// Strip carriage returned by ssh
-		got := strings.Replace(rr.Stdout.String(), "\r", "", -1)
+		got := strings.ReplaceAll(rr.Stdout.String(), "\r", "")
 		if diff := cmp.Diff(string(want), got); diff != "" {
 			t.Errorf("failed verify pem file. minikube_test.pem -> %s mismatch (-want +got):\n%s", vp, diff)
 		}

--- a/test/integration/functional_test_mount_test.go
+++ b/test/integration/functional_test_mount_test.go
@@ -57,7 +57,7 @@ func validateMountCmd(ctx context.Context, t *testing.T, profile string) { // no
 	}
 
 	tempDir, err := ioutil.TempDir("", "mounttest")
-	defer func() { //clean up tempdir
+	defer func() { // clean up tempdir
 		err := os.RemoveAll(tempDir)
 		if err != nil {
 			t.Errorf("failed to clean up %q temp folder.", tempDir)

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -400,7 +400,7 @@ func PVCWait(ctx context.Context, t *testing.T, profile string, ns string, name 
 	return wait.PollImmediate(1*time.Second, timeout, f)
 }
 
-//// VolumeSnapshotWait waits for volume snapshot to be ready to use
+// VolumeSnapshotWait waits for volume snapshot to be ready to use
 func VolumeSnapshotWait(ctx context.Context, t *testing.T, profile string, ns string, name string, timeout time.Duration) error {
 	t.Helper()
 

--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -60,7 +60,7 @@ func installRelease(version string) (f *os.File, err error) {
 
 // legacyStartArgs returns the arguments normally used for starting older versions of minikube
 func legacyStartArgs() []string {
-	return strings.Split(strings.Replace(*startArgs, "--driver", "--vm-driver", -1), " ")
+	return strings.Split(strings.ReplaceAll(*startArgs, "--driver", "--vm-driver"), " ")
 }
 
 // TestRunningBinaryUpgrade upgrades a running legacy cluster to minikube at HEAD


### PR DESCRIPTION
- bumping https://github.com/golangci/golangci-lint/releases
- fixing all new lints issues discovered by the golangci-lint