### PR TITLE
Pre-cleanup for GitHub actions self-hosted machines

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -332,7 +332,8 @@ jobs:
           $docker_running = $?
           }
           Write-Output "Docker is running"
-          docker system prune -f 
+          docker system prune -f
+          docker system prune --volumes -f
       - name: Info
         shell: powershell
         run: |
@@ -471,6 +472,7 @@ jobs:
           }
           Write-Output "Docker is running"
           docker system prune -f
+          docker system prune --volumes -f
       - name: Info
         continue-on-error: true
         shell: powershell

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -711,6 +711,13 @@ jobs:
         with:
           name: minikube_binaries
 
+      - name: Pre-cleanup
+        continue-on-error: true
+        run: |
+          minikube_binaries/minikube-linux-arm64 delete --all --purge || true
+          docker kill $(docker ps -aq) || true
+          docker system prune --volumes --force || true
+
       - name: Run Integration Test
         continue-on-error: false
         # bash {0} to allow test to continue to next step. in case of

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -330,7 +330,8 @@ jobs:
           $docker_running = $?
           }
           Write-Output "Docker is running"
-          docker system prune -f 
+          docker system prune -f
+          docker system prune --volumes -f
       - name: Info
         shell: powershell
         run: |
@@ -469,6 +470,7 @@ jobs:
           }
           Write-Output "Docker is running"
           docker system prune -f
+          docker system prune --volumes -f
       - name: Info
         continue-on-error: true
         shell: powershell

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -709,6 +709,13 @@ jobs:
         with:
           name: minikube_binaries
 
+      - name: Pre-cleanup
+        continue-on-error: true
+        run: |
+          minikube_binaries/minikube-linux-arm64 delete --all --purge || true
+          docker kill $(docker ps -aq) || true
+          docker system prune --volumes --force || true
+
       - name: Run Integration Test
         continue-on-error: false
         # bash {0} to allow test to continue to next step. in case of


### PR DESCRIPTION
This PR:
- adds a cleanup step to remove all minikube/docker leftovers on arm64 external runner machines
- adds `docker system prune --volumes` for windows self-hosted jobs (`docker system prune` is already there, but it doesn't remove volumes by default)
