### PR TITLE
test: Add target for the test report as html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ _cgo_export.*
 
 _testmain.go
 
+test-report.html
 coverage.html
 
 *.exe

--- a/.gitignore
+++ b/.gitignore
@@ -22,9 +22,6 @@ _cgo_export.*
 
 _testmain.go
 
-test-report.html
-coverage.html
-
 *.exe
 *.test
 *.prof

--- a/Makefile
+++ b/Makefile
@@ -374,6 +374,11 @@ out/test-report.json: $(SOURCE_FILES) $(GOTEST_FILES)
 	-coverprofile=out/coverage.out -json > out/test-report.json
 out/coverage.out: out/test-report.json
 
+# Generate go test report (from gotest) as a a HTML page
+test-report.html: out/test-report.json
+	$(if $(quiet),@echo "  REPORT   $@")
+	$(Q)go-test-report < $< -o $@
+
 # Generate go coverage report (from gotest) as a HTML page
 coverage.html: out/coverage.out
 	$(if $(quiet),@echo "  COVER    $@")

--- a/Makefile
+++ b/Makefile
@@ -368,19 +368,19 @@ gotest: $(SOURCE_GENERATED) ## Trigger minikube test
 	$(Q)go test -tags "$(MINIKUBE_BUILD_TAGS)" -ldflags="$(MINIKUBE_LDFLAGS)" $(MINIKUBE_TEST_FILES)
 
 # Run the gotest, while recording JSON report and coverage
-out/test-report.json: $(SOURCE_FILES) $(GOTEST_FILES)
+out/unittest.json: $(SOURCE_FILES) $(GOTEST_FILES)
 	$(if $(quiet),@echo "  TEST     $@")
 	$(Q)go test -tags "$(MINIKUBE_BUILD_TAGS)" -ldflags="$(MINIKUBE_LDFLAGS)" $(MINIKUBE_TEST_FILES) \
-	-coverprofile=out/coverage.out -json > out/test-report.json
-out/coverage.out: out/test-report.json
+	-coverprofile=out/coverage.out -json > out/unittest.json
+out/coverage.out: out/unittest.json
 
 # Generate go test report (from gotest) as a a HTML page
-test-report.html: out/test-report.json
+out/unittest.html: out/unittest.json
 	$(if $(quiet),@echo "  REPORT   $@")
 	$(Q)go-test-report < $< -o $@
 
 # Generate go coverage report (from gotest) as a HTML page
-coverage.html: out/coverage.out
+out/coverage.html: out/coverage.out
 	$(if $(quiet),@echo "  COVER    $@")
 	$(Q)go tool cover -html=$< -o $@
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,5 +7,5 @@ sonar.exclusions=**/*_test.go,pkg/minikube/assets/assets.go,pkg/minikube/transla
 sonar.tests=cmd,pkg
 sonar.test.inclusions=**/*_test.go
 
-sonar.go.tests.reportPaths=out/test-report.json
+sonar.go.tests.reportPaths=out/unittest.json
 sonar.go.coverage.reportPaths=out/coverage.out


### PR DESCRIPTION
Just something I did during lunch, easier to read than the JSON

`go get -u github.com/vakenbolt/go-test-report`