### PR TITLE
Add log file to GitHub issue output

### DIFF
--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -199,7 +199,7 @@ https://github.com/kubernetes/minikube/issues/7332`, out.V{"driver_name": cc.Dri
 				return errors.Wrap(err, "registry port")
 			}
 			if enable {
-				out.Boxed(style.Tip, `Registry addon with {{.driver}} driver uses port {{.port}} please use that instead of default port 5000`, out.V{"driver": cc.Driver, "port": port})
+				out.Boxed(`Registry addon with {{.driver}} driver uses port {{.port}} please use that instead of default port 5000`, out.V{"driver": cc.Driver, "port": port})
 			}
 			out.Styled(style.Documentation, `For more information see: https://minikube.sigs.k8s.io/docs/drivers/{{.driver}}`, out.V{"driver": cc.Driver})
 		}

--- a/pkg/minikube/out/out.go
+++ b/pkg/minikube/out/out.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -384,8 +385,9 @@ func getLatestLogFilePath() (string, error) {
 		lastModName = file.Name()
 		lastModTime = file.ModTime()
 	}
+	fullPath := filepath.Join(tmpdir, lastModName)
 
-	return tmpdir + lastModName, nil
+	return fullPath, nil
 }
 
 func displayLogLocationMessage() error {

--- a/pkg/minikube/out/out.go
+++ b/pkg/minikube/out/out.go
@@ -334,7 +334,7 @@ func wantsColor(w fdWriter) bool {
 
 // LogEntries outputs an error along with any important log entries.
 func LogEntries(msg string, err error, entries map[string][]string) {
-	DisplayError(msg, err)
+	displayError(msg, err)
 
 	for name, lines := range entries {
 		Step(style.Failure, "Problems detected in {{.entry}}:", V{"entry": name})
@@ -347,8 +347,8 @@ func LogEntries(msg string, err error, entries map[string][]string) {
 	}
 }
 
-// DisplayError prints the error and displays the standard minikube error messaging
-func DisplayError(msg string, err error) {
+// displayError prints the error and displays the standard minikube error messaging
+func displayError(msg string, err error) {
 	klog.Warningf(fmt.Sprintf("%s: %v", msg, err))
 	if JSON {
 		FatalT("{{.msg}}: {{.err}}", V{"msg": translate.T(msg), "err": err})

--- a/pkg/minikube/out/out.go
+++ b/pkg/minikube/out/out.go
@@ -397,12 +397,10 @@ func displayGitHubIssueMessage() {
 		klog.Warningf("failed to diplay GitHub issue message: %v", err)
 	}
 
-	msg := `If the above advice does not help, please let us know:
-https://github.com/kubernetes/minikube/issues/new/choose
-
-Please attach the following file to the GitHub issue:
-- `
-	msg += logPath
+	msg := Sprintf(style.Sad, "If the above advice does not help, please let us know:")
+	msg += Sprintf(style.URL, "https://github.com/kubernetes/minikube/issues/new/choose\n")
+	msg += Sprintf(style.Empty, "Please attach the following file to the GitHub issue:")
+	msg += Sprintf(style.Empty, "- {{.logPath}}", V{"logPath": logPath})
 
 	Boxed(msg)
 }

--- a/pkg/minikube/out/out.go
+++ b/pkg/minikube/out/out.go
@@ -371,7 +371,7 @@ func DisplayError(msg string, err error) {
 func getLatestLogFileName() (string, error) {
 	dir := os.Getenv("TMPDIR")
 	if dir == "" {
-		dir = "/tmp"
+		dir = "/tmp/"
 	}
 	args := fmt.Sprintf("cd %s && echo %s$(ls -t *minikube_*_*_*log | head -1)", dir, dir)
 	c := exec.Command("/bin/bash", "-c", args)

--- a/pkg/minikube/out/out.go
+++ b/pkg/minikube/out/out.go
@@ -369,7 +369,11 @@ func DisplayError(msg string, err error) {
 }
 
 func getLatestLogFileName() (string, error) {
-	args := "cd $TMPDIR && echo $TMPDIR$(ls -t *minikube_*_*_*log | head -1)"
+	dir := os.Getenv("TMPDIR")
+	if dir == "" {
+		dir = "/tmp"
+	}
+	args := fmt.Sprintf("cd %s && echo %s$(ls -t *minikube_*_*_*log | head -1)", dir, dir)
 	c := exec.Command("/bin/bash", "-c", args)
 	o, err := c.Output()
 	if err != nil {

--- a/pkg/minikube/out/out_reason.go
+++ b/pkg/minikube/out/out_reason.go
@@ -36,6 +36,7 @@ package out
 import (
 	"strings"
 
+	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/minikube/out/register"
 	"k8s.io/minikube/pkg/minikube/reason"
 	"k8s.io/minikube/pkg/minikube/style"
@@ -117,4 +118,10 @@ func displayText(k reason.Kind, format string, a ...V) {
 		ErrT(style.URL, "https://github.com/kubernetes/minikube/issues/new/choose")
 	}
 	Ln("")
+	logFileName, err := getLatestLogFileName()
+	if err != nil {
+		klog.Warning(err)
+		return
+	}
+	ErrT(style.Tip, "If you are able to drag and drop the following log-file into the issue, we'll be able to make faster progress: {{.logFileName}}", V{"logFileName": logFileName})
 }

--- a/pkg/minikube/out/out_reason.go
+++ b/pkg/minikube/out/out_reason.go
@@ -116,12 +116,9 @@ func displayText(k reason.Kind, format string, a ...V) {
 		ErrT(style.Empty, "")
 		ErrT(style.Sad, "If the above advice does not help, please let us know: ")
 		ErrT(style.URL, "https://github.com/kubernetes/minikube/issues/new/choose")
+		if err := displayLogLocationMessage(); err != nil {
+			klog.Warningf("failed to display log location message: %v", err)
+		}
 	}
 	Ln("")
-	logFileName, err := getLatestLogFileName()
-	if err != nil {
-		klog.Warning(err)
-		return
-	}
-	ErrT(style.Tip, "If you are able to drag and drop the following log-file into the issue, we'll be able to make faster progress: {{.logFileName}}", V{"logFileName": logFileName})
 }

--- a/pkg/minikube/out/out_reason.go
+++ b/pkg/minikube/out/out_reason.go
@@ -36,7 +36,6 @@ package out
 import (
 	"strings"
 
-	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/minikube/out/register"
 	"k8s.io/minikube/pkg/minikube/reason"
 	"k8s.io/minikube/pkg/minikube/style"
@@ -114,11 +113,7 @@ func displayText(k reason.Kind, format string, a ...V) {
 
 	if k.NewIssueLink {
 		ErrT(style.Empty, "")
-		ErrT(style.Sad, "If the above advice does not help, please let us know: ")
-		ErrT(style.URL, "https://github.com/kubernetes/minikube/issues/new/choose")
-		if err := displayLogLocationMessage(); err != nil {
-			klog.Warningf("failed to display log location message: %v", err)
-		}
+		displayGitHubIssueMessage()
 	}
 	Ln("")
 }

--- a/pkg/minikube/out/out_test.go
+++ b/pkg/minikube/out/out_test.go
@@ -114,3 +114,20 @@ func TestErr(t *testing.T) {
 		t.Errorf("Err() = %q, want %q", got, want)
 	}
 }
+
+func TestGetLatestLogFile(t *testing.T) {
+	td := os.Getenv("TMPDIR")
+	want := fmt.Sprintf("%sminikube_test_test_test.log", td)
+	f, err := os.Create(want)
+	if err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+	defer os.Remove(f.Name())
+	got, err := getLatestLogFileName()
+	if err != nil {
+		t.Fatalf("failed to get latest log file name: %v", err)
+	}
+	if got != want {
+		t.Errorf("getLatestLogFile() = %q; want %q", got, want)
+	}
+}

--- a/pkg/minikube/out/out_test.go
+++ b/pkg/minikube/out/out_test.go
@@ -155,10 +155,10 @@ func TestLatestLogPath(t *testing.T) {
 		os.Args = tt.args
 		got, err := latestLogFilePath()
 		if err != nil {
-			t.Fatalf("failed latestLogFilePath(): %v", err)
+			t.Fatalf("os.Args = %s; latestLogFilePath() failed with error = %v", tt.args, err)
 		}
 		if got != tt.want {
-			t.Errorf("oa.Args = %s; latestLogFilePath() = %q; wanted to contain %q", tt.args, got, tt.want)
+			t.Errorf("os.Args = %s; latestLogFilePath() = %q; wanted %q", tt.args, got, tt.want)
 		}
 	}
 }

--- a/pkg/minikube/out/out_test.go
+++ b/pkg/minikube/out/out_test.go
@@ -19,6 +19,7 @@ package out
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -117,11 +118,8 @@ func TestErr(t *testing.T) {
 }
 
 func createLogFile() (string, error) {
-	td := os.Getenv("TMPDIR")
-	if td == "" {
-		td = "/tmp/"
-	}
-	name := fmt.Sprintf("%sminikube_test_test_test.log", td)
+	td := os.TempDir()
+	name := filepath.Join(td, "minikube_test_test_test.log")
 	f, err := os.Create(name)
 	if err != nil {
 		return "", fmt.Errorf("failed to create log file: %v", err)

--- a/pkg/minikube/out/out_test.go
+++ b/pkg/minikube/out/out_test.go
@@ -118,7 +118,7 @@ func TestErr(t *testing.T) {
 func TestGetLatestLogFile(t *testing.T) {
 	td := os.Getenv("TMPDIR")
 	if td == "" {
-		td = "/tmp"
+		td = "/tmp/"
 	}
 	want := fmt.Sprintf("%sminikube_test_test_test.log", td)
 	f, err := os.Create(want)

--- a/pkg/minikube/out/out_test.go
+++ b/pkg/minikube/out/out_test.go
@@ -21,9 +21,9 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"testing"
 
+	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/minikube/style"
 	"k8s.io/minikube/pkg/minikube/tests"
 	"k8s.io/minikube/pkg/minikube/translate"
@@ -128,22 +128,7 @@ func createLogFile() (string, error) {
 	return f.Name(), nil
 }
 
-func TestGetLatestLogPath(t *testing.T) {
-	want, err := createLogFile()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(want)
-	got, err := getLatestLogFilePath()
-	if err != nil {
-		t.Fatalf("failed to get latest log file name: %v", err)
-	}
-	if got != want {
-		t.Errorf("getLatestLogPath() = %q; want %q", got, want)
-	}
-}
-
-func TestDisplayLogLocationMessage(t *testing.T) {
+func TestLatestLogPath(t *testing.T) {
 	filename, err := createLogFile()
 	if err != nil {
 		t.Fatal(err)
@@ -156,7 +141,7 @@ func TestDisplayLogLocationMessage(t *testing.T) {
 	}{
 		{
 			[]string{"minikube", "start"},
-			"lastStart.txt",
+			localpath.LastStartLog(),
 		},
 		{
 			[]string{"minikube", "status"},
@@ -168,14 +153,12 @@ func TestDisplayLogLocationMessage(t *testing.T) {
 		oldArgs := os.Args
 		defer func() { os.Args = oldArgs }()
 		os.Args = tt.args
-		f := tests.NewFakeFile()
-		SetErrFile(f)
-		if err := displayLogLocationMessage(); err != nil {
-			t.Fatalf("failed to displayLogLocationMessage: %v", err)
+		got, err := latestLogFilePath()
+		if err != nil {
+			t.Fatalf("failed latestLogFilePath(): %v", err)
 		}
-		got := f.String()
-		if !strings.Contains(got, tt.want) {
-			t.Errorf("displayLogLocationMessage() = %q; wanted to contain %q", got, tt.want)
+		if got != tt.want {
+			t.Errorf("oa.Args = %s; latestLogFilePath() = %q; wanted to contain %q", tt.args, got, tt.want)
 		}
 	}
 }

--- a/pkg/minikube/out/out_test.go
+++ b/pkg/minikube/out/out_test.go
@@ -117,6 +117,9 @@ func TestErr(t *testing.T) {
 
 func TestGetLatestLogFile(t *testing.T) {
 	td := os.Getenv("TMPDIR")
+	if td == "" {
+		td = "/tmp"
+	}
 	want := fmt.Sprintf("%sminikube_test_test_test.log", td)
 	f, err := os.Create(want)
 	if err != nil {


### PR DESCRIPTION
Closes #9398

Adds a line to the output when we tell the user to create a GitHub issue. The line contains the path of the latest log file to be attached to the GitHub issue to aid in debugging the issue.

Tested on Mac and Linux so far, will test on Windows as well.

Before
```
❌  Exiting due to GUEST_START: wait 6m0s for node: waiting for apps_running: expected k8s-apps: missing components: kube-dns

😿  If the above advice does not help, please let us know: 
👉  https://github.com/kubernetes/minikube/issues/new/choose
```

After
```
❌  Exiting due to GUEST_START: wait 6m0s for node: waiting for apps_running: expected k8s-apps: missing components: kube-dns

╭────────────────────────────────────────────────────────────────────╮
│                                                                    │
│    😿  If the above advice does not help, please let us know:      │
│    👉  https://github.com/kubernetes/minikube/issues/new/choose    │
│                                                                    │
│    Please attach the following file to the GitHub issue:           │
│    - /Users/powellsteven/.minikube/logs/lastStart.txt              │
│                                                                    │
╰────────────────────────────────────────────────────────────────────╯
```
