### PR TITLE
Change 'minikube version --short' to only print the version without a prompt.

### DIFF
--- a/cmd/minikube/cmd/version.go
+++ b/cmd/minikube/cmd/version.go
@@ -45,9 +45,13 @@ var versionCmd = &cobra.Command{
 		}
 		switch versionOutput {
 		case "":
-			out.Ln("minikube version: %v", minikubeVersion)
-			if !shortVersion && gitCommitID != "" {
-				out.Ln("commit: %v", gitCommitID)
+			if !shortVersion {
+				out.Ln("minikube version: %v", minikubeVersion)
+				if gitCommitID != "" {
+					out.Ln("commit: %v", gitCommitID)
+				}
+			} else {
+				out.Ln("%v", minikubeVersion)
 			}
 		case "json":
 			json, err := json.Marshal(data)


### PR DESCRIPTION
fixes #11104.

Before:
```
$ minikube version --short
minikube version: v1.19.0
```
After:
```
$ minikube version --short
v1.19.0
```