### PR TITLE
Use canonical image name if one exists remotely

### DIFF
--- a/pkg/minikube/image/cache.go
+++ b/pkg/minikube/image/cache.go
@@ -20,7 +20,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -34,11 +33,6 @@ import (
 	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/util/lock"
-)
-
-const (
-	legacyDefaultDomain = "index.docker.io"
-	defaultDomain       = "docker.io"
 )
 
 type cacheError struct {
@@ -142,9 +136,6 @@ func saveToTarFile(iname, rawDest string) error {
 	}
 	if img == nil {
 		return errors.Wrapf(err, "nil image for %s", iname)
-	}
-	if strings.HasPrefix(cname, legacyDefaultDomain) {
-		cname = strings.Replace(cname, legacyDefaultDomain, defaultDomain, 1)
 	}
 
 	// use new canonical name

--- a/pkg/minikube/image/cache.go
+++ b/pkg/minikube/image/cache.go
@@ -138,13 +138,15 @@ func saveToTarFile(iname, rawDest string) error {
 		return errors.Wrapf(err, "nil image for %s", iname)
 	}
 
-	// use new canonical name
-	ref, err = name.ParseReference(cname, name.WeakValidation)
-	if err != nil {
-		return errors.Wrapf(err, "parsing image ref name for %s", cname)
-	}
-	if ref == nil {
-		return errors.Wrapf(err, "nil reference for %s", cname)
+	if cname != iname {
+		// use new canonical name
+		ref, err = name.ParseReference(cname, name.WeakValidation)
+		if err != nil {
+			return errors.Wrapf(err, "parsing image ref name for %s", cname)
+		}
+		if ref == nil {
+			return errors.Wrapf(err, "nil reference for %s", cname)
+		}
 	}
 
 	err = writeImage(img, dst, ref)

--- a/pkg/minikube/image/cache.go
+++ b/pkg/minikube/image/cache.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -33,6 +34,11 @@ import (
 	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/util/lock"
+)
+
+const (
+	legacyDefaultDomain = "index.docker.io"
+	defaultDomain       = "docker.io"
 )
 
 type cacheError struct {
@@ -121,6 +127,7 @@ func saveToTarFile(iname, rawDest string) error {
 		return errors.Wrapf(err, "making cache image directory: %s", dst)
 	}
 
+	// use given short name
 	ref, err := name.ParseReference(iname, name.WeakValidation)
 	if err != nil {
 		return errors.Wrapf(err, "parsing image ref name for %s", iname)
@@ -129,12 +136,24 @@ func saveToTarFile(iname, rawDest string) error {
 		return errors.Wrapf(err, "nil reference for %s", iname)
 	}
 
-	img, err := retrieveImage(ref)
+	img, cname, err := retrieveImage(ref, iname)
 	if err != nil {
 		return errCacheImageDoesntExist
 	}
 	if img == nil {
 		return errors.Wrapf(err, "nil image for %s", iname)
+	}
+	if strings.HasPrefix(cname, legacyDefaultDomain) {
+		cname = strings.Replace(cname, legacyDefaultDomain, defaultDomain, 1)
+	}
+
+	// use new canonical name
+	ref, err = name.ParseReference(cname, name.WeakValidation)
+	if err != nil {
+		return errors.Wrapf(err, "parsing image ref name for %s", cname)
+	}
+	if ref == nil {
+		return errors.Wrapf(err, "nil reference for %s", cname)
 	}
 
 	err = writeImage(img, dst, ref)


### PR DESCRIPTION
Testing with one image from remote, and one image that only exists in daemon:

```console
$ docker pull hello-world
latest: Pulling from library/hello-world
b8dfde127a29: Pull complete 
Digest: sha256:f2266cbfc127c960fd30e76b7c792dc23b588c0db76233517e1891a4e357d519
Status: Downloaded newer image for hello-world:latest
docker.io/library/hello-world:latest
$ docker tag hello-world hw
```

```console
$ docker images
REPOSITORY    TAG       IMAGE ID       CREATED       SIZE
hello-world   latest    d1165f221234   6 weeks ago   13.3kB
hw            latest    d1165f221234   6 weeks ago   13.3kB
```

----

When adding an image to the cache, check if it exists remote.
If it does, then use the canonical name when saving to cache.

`docker.io/library/hello-world:latest`

If **not** checking with the remote registry, or it doesn't exist,
then use the short name when saving to cache - like before...

`hw:latest`

This means that cri-o will add the "localhost" prefix, when loading:

```
IMAGE                                     TAG                  IMAGE ID            SIZE
docker.io/library/hello-world             latest               d1165f2212346       17.7kB
localhost/hw                              latest               d1165f2212346       17.7kB
```

But the regular images will work with any runtime, including cri-o.

Closes #11126 (and #8554)