### PR TITLE
recommend kindnet for multinode even for non-docker cr

### DIFF
--- a/pkg/minikube/cni/cni.go
+++ b/pkg/minikube/cni/cni.go
@@ -129,15 +129,6 @@ func chooseDefault(cc config.ClusterConfig) Manager {
 		return Bridge{}
 	}
 
-	if cc.KubernetesConfig.ContainerRuntime != "docker" {
-		if driver.IsKIC(cc.Driver) {
-			klog.Infof("%q driver + %s runtime found, recommending kindnet", cc.Driver, cc.KubernetesConfig.ContainerRuntime)
-			return KindNet{cc: cc}
-		}
-		klog.Infof("%q driver + %s runtime found, recommending bridge", cc.Driver, cc.KubernetesConfig.ContainerRuntime)
-		return Bridge{cc: cc}
-	}
-
 	if driver.BareMetal(cc.Driver) {
 		klog.Infof("Driver %s used, CNI unnecessary in this configuration, recommending no CNI", cc.Driver)
 		return Disabled{cc: cc}
@@ -148,6 +139,15 @@ func chooseDefault(cc config.ClusterConfig) Manager {
 		// inside pod for multi node clusters. See https://github.com/kubernetes/minikube/issues/9838.
 		klog.Infof("%d nodes found, recommending kindnet", len(cc.Nodes))
 		return KindNet{cc: cc}
+	}
+
+	if cc.KubernetesConfig.ContainerRuntime != "docker" {
+		if driver.IsKIC(cc.Driver) {
+			klog.Infof("%q driver + %s runtime found, recommending kindnet", cc.Driver, cc.KubernetesConfig.ContainerRuntime)
+			return KindNet{cc: cc}
+		}
+		klog.Infof("%q driver + %s runtime found, recommending bridge", cc.Driver, cc.KubernetesConfig.ContainerRuntime)
+		return Bridge{cc: cc}
 	}
 
 	klog.Infof("CNI unnecessary in this configuration, recommending no CNI")


### PR DESCRIPTION
fixes #11181
fixes #10822

as seen in logs:

```
...
	I0412 19:29:13.415595   10718 cni.go:81] Creating CNI manager for ""
	I0412 19:29:13.415600   10718 cni.go:137] "kvm2" driver + containerd runtime found, recommending bridge
...
	W0412 19:33:06.922040   10718 out.go:222] X Exiting due to GUEST_START: adding node: cni apply: bridge CNI is incompatible with multi-node clusters
	X Exiting due to GUEST_START: adding node: cni apply: bridge CNI is incompatible with multi-node clusters
```
or
```
...
	I0423 23:35:53.975499   16935 cni.go:93] Creating CNI manager for ""
	I0423 23:35:53.975507   16935 cni.go:151] "kvm2" driver + crio runtime found, recommending bridge
	I0423 23:35:53.977976   16935 out.go:157] 
	W0423 23:35:53.978096   16935 out.go:222] X Exiting due to GUEST_START: adding node: cni apply: bridge CNI is incompatible with multi-node clusters
	X Exiting due to GUEST_START: adding node: cni apply: bridge CNI is incompatible with multi-node clusters
...
