### PR TITLE
[Ingress Addon] Fix bug which the networking.k8s.io/v1 ingress is always rejected

### DIFF
--- a/deploy/addons/ingress/ingress-dp.yaml.tmpl
+++ b/deploy/addons/ingress/ingress-dp.yaml.tmpl
@@ -180,6 +180,9 @@ spec:
           secret:
             secretName: ingress-nginx-admission
 ---
+# Currently(v0.44.0), ValidatingWebhookConfiguration of this validates v1beta1 request
+# TODO(govargo): check this after upstream ingress-nginx can validate v1 version
+# https://github.com/kubernetes/ingress-nginx/blob/controller-v0.44.0/internal/admission/controller/main.go#L46-L52
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -197,7 +200,6 @@ webhooks:
           - networking.k8s.io
         apiVersions:
           - v1beta1
-          - v1
         operations:
           - CREATE
           - UPDATE

--- a/test/integration/testdata/nginx-ingv1.yaml
+++ b/test/integration/testdata/nginx-ingv1.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: nginx-ingress
@@ -12,6 +12,9 @@ spec:
     http:
       paths:
       - path: "/"
+        pathType: Prefix
         backend:
-          serviceName: nginx
-          servicePort: 80
+          service:
+            name: nginx
+            port:
+              number: 80

--- a/test/integration/testdata/nginx-ingv1beta.yaml
+++ b/test/integration/testdata/nginx-ingv1beta.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: nginx-ingress
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+  labels:
+    integration-test: ingress
+spec:
+  rules:
+  - host: nginx.example.com
+    http:
+      paths:
+      - path: "/"
+        backend:
+          serviceName: nginx
+          servicePort: 80


### PR DESCRIPTION
### What type of PR is this?
/kind bug
/addon ingress
/kind regression
/priority important-soon

### What this PR does / why we need it:

This PR will fix the bug which the `networking.k8s.io/v1` ingress is alwalys rejected.
As I described at https://github.com/kubernetes/minikube/issues/11121#issuecomment-826148630, upstream ingress-nginx(v0.44.0 and v0.45.0(latest)) doesn't allow `networking.k8s.io/v1` ingress.
Ingress-nginx admission controller only support(validate) `networking.k8s.io/v1beta1` ingress. `networking.k8s.io/v1` ingress is not supported(validated).
But our ValidatingWebhookConfiguration manifest check both `networking.k8s.io/v1beta1` and `networking.k8s.io/v1`.
https://github.com/kubernetes/minikube/blob/f854a086b11bee9d07016d671da4bed71f0a5f47/deploy/addons/ingress/ingress-dp.yaml.tmpl#L196-L200
I removed `networking.k8s.io/v1` check from ValidatingWebhookConfiguration manifest.

And I add a integration test pattern to check if `networking.k8s.io/v1` ingress works.

### Which issue(s) this PR fixes:
Fix #11121 

### Does this PR introduce a user-facing change?

Yes. This PR allows to create `networking.k8s.io/v1` ingress.

**Before this PR**

`networking.k8s.io/v1` ingress is always rejected by Validating Webhook.

```
"failed to process webhook request" err="rejecting admission review because the request does not contain an Ingress resource but networking.k8s.io/v1, Kind=Ingress with name nginx-ingress in namespace default"
```

**After this PR**

`networking.k8s.io/v1` ingress can be created.

```
ingress.networking.k8s.io/nginx-ingress created
```

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```