### PR TITLE
completion: add specific shell completion

### DIFF
--- a/cmd/minikube/cmd/completion.go
+++ b/cmd/minikube/cmd/completion.go
@@ -77,23 +77,50 @@ var completionCmd = &cobra.Command{
 		}
 		if args[0] != "bash" && args[0] != "zsh" && args[0] != "fish" {
 			exit.Message(reason.Usage, "Sorry, completion support is not yet implemented for {{.name}}", out.V{"name": args[0]})
-		} else if args[0] == "bash" {
-			err := GenerateBashCompletion(os.Stdout, cmd.Parent())
-			if err != nil {
-				exit.Error(reason.InternalCompletion, "bash completion failed", err)
-			}
-		} else if args[0] == "zsh" {
-			err := GenerateZshCompletion(os.Stdout, cmd.Parent())
-			if err != nil {
-				exit.Error(reason.InternalCompletion, "zsh completion failed", err)
-			}
-		} else {
-			err := GenerateFishCompletion(os.Stdout, cmd.Parent())
-			if err != nil {
-				exit.Error(reason.InternalCompletion, "fish completion failed", err)
-			}
 		}
 	},
+}
+
+var bashCmd = &cobra.Command{
+	Use:   "bash",
+	Short: "bash completion.",
+	Long:  "Generate command completion for bash.",
+	Run: func(cmd *cobra.Command, args []string) {
+		err := GenerateBashCompletion(os.Stdout, cmd.Root())
+		if err != nil {
+			exit.Error(reason.InternalCompletion, "bash completion failed", err)
+		}
+	},
+}
+
+var zshCmd = &cobra.Command{
+	Use:   "zsh",
+	Short: "zsh completion.",
+	Long:  "Generate command completion for zsh.",
+	Run: func(cmd *cobra.Command, args []string) {
+		err := GenerateZshCompletion(os.Stdout, cmd.Root())
+		if err != nil {
+			exit.Error(reason.InternalCompletion, "zsh completion failed", err)
+		}
+	},
+}
+
+var fishCmd = &cobra.Command{
+	Use:   "fish",
+	Short: "fish completion.",
+	Long:  "Generate command completion for fish .",
+	Run: func(cmd *cobra.Command, args []string) {
+		err := GenerateFishCompletion(os.Stdout, cmd.Root())
+		if err != nil {
+			exit.Error(reason.InternalCompletion, "fish completion failed", err)
+		}
+	},
+}
+
+func init() {
+	completionCmd.AddCommand(bashCmd)
+	completionCmd.AddCommand(zshCmd)
+	completionCmd.AddCommand(fishCmd)
 }
 
 // GenerateBashCompletion generates the completion for the bash shell

--- a/site/content/en/docs/commands/completion.md
+++ b/site/content/en/docs/commands/completion.md
@@ -60,3 +60,140 @@ minikube completion SHELL [flags]
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
 ```
 
+## minikube completion bash
+
+bash completion.
+
+### Synopsis
+
+Generate command completion for bash.
+
+```shell
+minikube completion bash [flags]
+```
+
+### Options inherited from parent commands
+
+```
+      --add_dir_header                   If true, adds the file directory to the header of the log messages
+      --alsologtostderr                  log to standard error as well as files
+  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
+  -h, --help                             
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --log_file string                  If non-empty, use this log file
+      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+      --logtostderr                      log to standard error instead of files
+      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level)
+  -p, --profile string                   The name of the minikube VM being used. This can be set to allow having multiple instances of minikube independently. (default "minikube")
+      --skip_headers                     If true, avoid header prefixes in the log messages
+      --skip_log_headers                 If true, avoid headers when opening log files
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+      --user string                      Specifies the user executing the operation. Useful for auditing operations executed by 3rd party tools. Defaults to the operating system username.
+  -v, --v Level                          number for the log level verbosity
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+```
+
+## minikube completion fish
+
+fish completion.
+
+### Synopsis
+
+Generate command completion for fish .
+
+```shell
+minikube completion fish [flags]
+```
+
+### Options inherited from parent commands
+
+```
+      --add_dir_header                   If true, adds the file directory to the header of the log messages
+      --alsologtostderr                  log to standard error as well as files
+  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
+  -h, --help                             
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --log_file string                  If non-empty, use this log file
+      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+      --logtostderr                      log to standard error instead of files
+      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level)
+  -p, --profile string                   The name of the minikube VM being used. This can be set to allow having multiple instances of minikube independently. (default "minikube")
+      --skip_headers                     If true, avoid header prefixes in the log messages
+      --skip_log_headers                 If true, avoid headers when opening log files
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+      --user string                      Specifies the user executing the operation. Useful for auditing operations executed by 3rd party tools. Defaults to the operating system username.
+  -v, --v Level                          number for the log level verbosity
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+```
+
+## minikube completion help
+
+Help about any command
+
+### Synopsis
+
+Help provides help for any command in the application.
+Simply type completion help [path to command] for full details.
+
+```shell
+minikube completion help [command] [flags]
+```
+
+### Options inherited from parent commands
+
+```
+      --add_dir_header                   If true, adds the file directory to the header of the log messages
+      --alsologtostderr                  log to standard error as well as files
+  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
+  -h, --help                             
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --log_file string                  If non-empty, use this log file
+      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+      --logtostderr                      log to standard error instead of files
+      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level)
+  -p, --profile string                   The name of the minikube VM being used. This can be set to allow having multiple instances of minikube independently. (default "minikube")
+      --skip_headers                     If true, avoid header prefixes in the log messages
+      --skip_log_headers                 If true, avoid headers when opening log files
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+      --user string                      Specifies the user executing the operation. Useful for auditing operations executed by 3rd party tools. Defaults to the operating system username.
+  -v, --v Level                          number for the log level verbosity
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+```
+
+## minikube completion zsh
+
+zsh completion.
+
+### Synopsis
+
+Generate command completion for zsh.
+
+```shell
+minikube completion zsh [flags]
+```
+
+### Options inherited from parent commands
+
+```
+      --add_dir_header                   If true, adds the file directory to the header of the log messages
+      --alsologtostderr                  log to standard error as well as files
+  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
+  -h, --help                             
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --log_file string                  If non-empty, use this log file
+      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+      --logtostderr                      log to standard error instead of files
+      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level)
+  -p, --profile string                   The name of the minikube VM being used. This can be set to allow having multiple instances of minikube independently. (default "minikube")
+      --skip_headers                     If true, avoid header prefixes in the log messages
+      --skip_log_headers                 If true, avoid headers when opening log files
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+      --user string                      Specifies the user executing the operation. Useful for auditing operations executed by 3rd party tools. Defaults to the operating system username.
+  -v, --v Level                          number for the log level verbosity
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+```
+


### PR DESCRIPTION
completion: add specific shell completion

Previously, `minikube completion` is unable to auto-complete the
specific shell as other go-lang applications. For example, when user
type below command:
```
minikube$ minikube completion <tab> <tab>
```
In minikube, there is no candidate shells coming up, which is different
from kubectl:
```
$ kubectl completion <tab> <tab>
bash  zsh
```

After this patch, as following, the candidata shell appears:
```
minikube$ minikube completion <tab> <tab>
bash  fish  zsh
```

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
