### PR TITLE
Exec Unit Testing, not find asset method, then add it.

### DIFF
--- a/pkg/minikube/assets/vm_assets.go
+++ b/pkg/minikube/assets/vm_assets.go
@@ -21,8 +21,11 @@ import (
 	"fmt"
 	"html/template"
 	"io"
+	"io/ioutil"
 	"os"
 	"path"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -290,4 +293,21 @@ func (m *BinAsset) Read(p []byte) (int, error) {
 // Seek resets the reader to offset
 func (m *BinAsset) Seek(offset int64, whence int) (int64, error) {
 	return m.reader.Seek(offset, whence)
+}
+
+//Get file bytes from filePath
+func Asset(sourcePath string) ([]byte, error) {
+	execDirAbsPath, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("getting exec dir abspath is error: %v", err)
+	}
+	if runtime.GOOS == "windows" {
+		replacePathDelimiter := strings.Replace(execDirAbsPath, "\\", "/", -1)
+		execDirAbsPath = replacePathDelimiter[:strings.Index(replacePathDelimiter, "minikube")+len("minikube")]
+	}
+	contents, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", execDirAbsPath, sourcePath))
+	if err != nil {
+		return nil, fmt.Errorf("asset %s can't read by error: %v", sourcePath, err)
+	}
+	return contents, nil
 }

--- a/pkg/minikube/translate/translate.go
+++ b/pkg/minikube/translate/translate.go
@@ -19,6 +19,7 @@ package translate
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"path"
 	"strings"
 
@@ -123,4 +124,13 @@ func SetPreferredLanguage(s string) {
 // GetPreferredLanguage returns the preferred language tag.
 func GetPreferredLanguage() language.Tag {
 	return preferredLanguage
+}
+
+//Get translationFile bytes from filePath
+func Asset(translationFile string) ([]byte,error){
+	t, err := ioutil.ReadFile(translationFile)
+	if err != nil {
+		return nil, fmt.Errorf("asset %s can't read by error: %v", translationFile, err)
+	}
+	return t, nil
 }


### PR DESCRIPTION
E.g. execute Unit Testing on my windows, `minikube/cmd/minikube/cmd/config/config_test.go`,  it prompt like below:
![image](https://user-images.githubusercontent.com/80729205/116016822-63739800-a670-11eb-89fb-7ed0fb2c0e38.png)
![image](https://user-images.githubusercontent.com/80729205/116016910-ac2b5100-a670-11eb-885a-5aa426869c29.png)


