### PR TITLE
Correct typo in start_flags.go

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -524,7 +524,7 @@ func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterC
 			klog.Warningf("error calculate memory size in mb : %v", err)
 		}
 		if memInMB != cc.Memory {
-			out.WarningT("You cannot change the memory size for an exiting minikube cluster. Please first delete the cluster.")
+			out.WarningT("You cannot change the memory size for an existing minikube cluster. Please first delete the cluster.")
 		}
 	}
 


### PR DESCRIPTION
### Steps to reproduce the issue:
`minikube start --memory=2G`

### Current Output (truncated):
😄  minikube v1.14.1 on Linuxmint 19.3
✨  Using the docker driver based on existing profile
❗  You cannot change the memory size for an exiting minikube cluster. Please first delete the cluster.

### Correction:
"exiting" to "existing" in output

### Expected output:
❗  You cannot change the memory size for an existing minikube cluster. Please first delete the cluster.