### PR TITLE
Make sure to pass the platform for the kicbase

### DIFF
--- a/pkg/minikube/image/image.go
+++ b/pkg/minikube/image/image.go
@@ -195,7 +195,7 @@ func WriteImageToCache(img string) error {
 		return errors.Wrap(err, "parsing reference")
 	}
 	klog.V(3).Infof("Getting image %v", ref)
-	i, err := remote.Image(ref)
+	i, err := remote.Image(ref, remote.WithPlatform(defaultPlatform))
 	if err != nil {
 		if strings.Contains(err.Error(), "GitHub Docker Registry needs login") {
 			ErrGithubNeedsLogin = errors.New(err.Error())
@@ -253,7 +253,7 @@ func WriteImageToDaemon(img string) error {
 		return errors.Wrap(err, "parsing reference")
 	}
 	klog.V(3).Infof("Getting image %v", ref)
-	i, err := remote.Image(ref)
+	i, err := remote.Image(ref, remote.WithPlatform(defaultPlatform))
 	if err != nil {
 		if strings.Contains(err.Error(), "GitHub Docker Registry needs login") {
 			ErrGithubNeedsLogin = errors.New(err.Error())


### PR DESCRIPTION
Otherwise it will _always_ download linux/amd64

```go
var defaultPlatform = v1.Platform{
        Architecture: "amd64",
        OS:           "linux",
}
```

Closes #11102

Tested OK on arm64.

✅  Download complete!
ubuntu@ubuntu:~$ docker load < ~/.minikube/cache/kic/kicbase_v0.0.20@sha256_0250dab3644403384bd54f566921c6b57138eecffbb861f9392feef9b2ec44f6.tar 
The image gcr.io/k8s-minikube/kicbase:v0.0.20 already exists, renaming the old one with ID sha256:c6f4fc187bc15575face2a1d7ac05431f861a21ead31664e890c346c57bc1997 to empty string
Loaded image: gcr.io/k8s-minikube/kicbase:v0.0.20
