### PR TITLE
Add mask and unmask to the disable and enable

### DIFF
--- a/pkg/minikube/cruntime/cruntime_test.go
+++ b/pkg/minikube/cruntime/cruntime_test.go
@@ -486,6 +486,7 @@ func (f *FakeRunner) systemctl(args []string, root bool) (string, error) { // no
 	}
 
 	for _, svc := range svcs {
+		svc = strings.Replace(svc, ".service", "", 1)
 		state, ok := f.services[svc]
 		if !ok {
 			return out, fmt.Errorf("unknown fake service: %s", svc)
@@ -526,6 +527,11 @@ func (f *FakeRunner) systemctl(args []string, root bool) (string, error) { // no
 				return out, nil
 			}
 			return out, fmt.Errorf("%s cat unimplemented", svc)
+		case "enable":
+		case "disable":
+		case "mask":
+		case "unmask":
+			f.t.Logf("fake systemctl: %s %s: %v", svc, action, state)
 		default:
 			return out, fmt.Errorf("unimplemented fake action: %q", action)
 		}
@@ -587,7 +593,8 @@ func TestDisable(t *testing.T) {
 		runtime string
 		want    []string
 	}{
-		{"docker", []string{"sudo", "systemctl", "stop", "-f", "docker.socket", "sudo", "systemctl", "stop", "-f", "docker"}},
+		{"docker", []string{"sudo", "systemctl", "stop", "-f", "docker.socket", "sudo", "systemctl", "stop", "-f", "docker.service",
+			"sudo", "systemctl", "disable", "docker.socket", "sudo", "systemctl", "mask", "docker.service"}},
 		{"crio", []string{"sudo", "systemctl", "stop", "-f", "crio"}},
 		{"containerd", []string{"sudo", "systemctl", "stop", "-f", "containerd"}},
 	}

--- a/pkg/minikube/sysinit/openrc.go
+++ b/pkg/minikube/sysinit/openrc.go
@@ -122,6 +122,11 @@ func (s *OpenRC) DisableNow(svc string) error {
 	return fmt.Errorf("disable now is not implemented for OpenRC! PRs to fix are welcomed")
 }
 
+// Mask does nothing
+func (s *OpenRC) Mask(svc string) error {
+	return nil
+}
+
 // Enable does nothing
 func (s *OpenRC) Enable(svc string) error {
 	return nil
@@ -130,6 +135,11 @@ func (s *OpenRC) Enable(svc string) error {
 // EnableNow  not implemented for openRC
 func (s *OpenRC) EnableNow(svc string) error {
 	return fmt.Errorf("enable now is not implemented for OpenRC! PRs to fix are welcomed")
+}
+
+// Unmask does nothing
+func (s *OpenRC) Unmask(svc string) error {
+	return nil
 }
 
 // Restart restarts a service

--- a/pkg/minikube/sysinit/sysinit.go
+++ b/pkg/minikube/sysinit/sysinit.go
@@ -44,11 +44,17 @@ type Manager interface {
 	// Disable disables a service and stops it right after.
 	DisableNow(string) error
 
+	// Mask prevents a service from being started
+	Mask(string) error
+
 	// Enable enables a service
 	Enable(string) error
 
 	// EnableNow enables a service and starts it right after.
 	EnableNow(string) error
+
+	// Unmask allows a service to be started
+	Unmask(string) error
 
 	// Start starts a service idempotently
 	Start(string) error

--- a/pkg/minikube/sysinit/systemd.go
+++ b/pkg/minikube/sysinit/systemd.go
@@ -58,6 +58,12 @@ func (s *Systemd) DisableNow(svc string) error {
 	return err
 }
 
+// Mask prevents a service from being started
+func (s *Systemd) Mask(svc string) error {
+	_, err := s.r.RunCmd(exec.Command("sudo", "systemctl", "mask", svc))
+	return err
+}
+
 // Enable enables a service
 func (s *Systemd) Enable(svc string) error {
 	if svc == "kubelet" {
@@ -73,6 +79,12 @@ func (s *Systemd) EnableNow(svc string) error {
 		return errors.New("please don't enable kubelet as it creates a race condition; if it starts on systemd boot it will pick up /etc/hosts before we have time to configure /etc/hosts")
 	}
 	_, err := s.r.RunCmd(exec.Command("sudo", "systemctl", "enable", "--now", svc))
+	return err
+}
+
+// Unmask allows a service to be started
+func (s *Systemd) Unmask(svc string) error {
+	_, err := s.r.RunCmd(exec.Command("sudo", "systemctl", "unmask", svc))
 	return err
 }
 


### PR DESCRIPTION
To make sure that the docker daemon is **not** started up again

```
docker@minikube:~$ sudo systemctl start docker.socket
Job failed. See "journalctl -xe" for details.
docker@minikube:~$ sudo systemctl start docker.service
Failed to start docker.service: Unit docker.service is masked.
```

This is when running another container runtime, such as containerd