### PR TITLE
Updated English GitHub issue template to require minikube logs

### DIFF
--- a/.github/ISSUE_TEMPLATE/__en-US.md
+++ b/.github/ISSUE_TEMPLATE/__en-US.md
@@ -9,16 +9,14 @@ about: Report an issue
 2. 
 3.
 
+**Full output of `minikube logs` command:**
+<details>
+
+
+</details>
+
 <!--- TIP: Add the "--alsologtostderr" flag to the command-line for more logs --->
-**Full output of failed command:** 
-
-
-
-**Full output of `minikube start` command used, if not already included:**
-
-
-
-**Optional: Full output of `minikube logs` command:**
+**Full output of failed command:**
 <details>
 
 


### PR DESCRIPTION
`minikube start` logs are now automatically included in `minikube logs`, so updated messaging to require `minikube logs` and not ask for `minikube start`.