### PR TITLE
Add --file flag to 'minikube logs' to automatically put logs into a file.

### DIFF
--- a/cmd/minikube/cmd/logs.go
+++ b/cmd/minikube/cmd/logs.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"k8s.io/klog/v2"
 	cmdcfg "k8s.io/minikube/cmd/minikube/cmd/config"
 	"k8s.io/minikube/pkg/minikube/cluster"
 	"k8s.io/minikube/pkg/minikube/cruntime"
@@ -59,10 +60,15 @@ var logsCmd = &cobra.Command{
 
 		if fileOutput != "" {
 			logOutput, err = os.Create(fileOutput)
+			defer func() {
+				err := logOutput.Close()
+				if err != nil {
+					klog.Warning("Failed to close file: %v", err)
+				}
+			}()
 			if err != nil {
 				exit.Error(reason.Usage, "Failed to create file", err)
 			}
-			defer logOutput.Close()
 		}
 
 		logs.OutputOffline(numberOfLines, logOutput)

--- a/pkg/minikube/bootstrapper/bsutil/kverify/system_pods.go
+++ b/pkg/minikube/bootstrapper/bsutil/kverify/system_pods.go
@@ -20,6 +20,7 @@ package kverify
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -150,7 +151,7 @@ func podStatusMsg(pod core.Pod) string {
 func announceProblems(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.ClusterConfig, cr command.Runner) {
 	problems := logs.FindProblems(r, bs, cfg, cr)
 	if len(problems) > 0 {
-		logs.OutputProblems(problems, 5)
+		logs.OutputProblems(problems, 5, os.Stderr)
 		time.Sleep(kconst.APICallRetryInterval * 15)
 	}
 }

--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -21,6 +21,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"regexp"
@@ -93,7 +94,7 @@ type logRunner interface {
 const lookBackwardsCount = 400
 
 // Follow follows logs from multiple files in tail(1) format
-func Follow(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.ClusterConfig, cr logRunner) error {
+func Follow(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.ClusterConfig, cr logRunner, logOutput io.Writer) error {
 	cs := []string{}
 	for _, v := range logCommands(r, bs, cfg, 0, true) {
 		cs = append(cs, v+" &")
@@ -101,8 +102,8 @@ func Follow(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.Cluster
 	cs = append(cs, "wait")
 
 	cmd := exec.Command("/bin/bash", "-c", strings.Join(cs, " "))
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stdout
+	cmd.Stdout = logOutput
+	cmd.Stderr = logOutput
 	if _, err := cr.RunCmd(cmd); err != nil {
 		return errors.Wrapf(err, "log follow")
 	}
@@ -146,7 +147,10 @@ func FindProblems(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.C
 }
 
 // OutputProblems outputs discovered problems.
-func OutputProblems(problems map[string][]string, maxLines int) {
+func OutputProblems(problems map[string][]string, maxLines int, logOutput *os.File) {
+	out.SetErrFile(logOutput)
+	defer out.SetErrFile(os.Stderr)
+
 	for name, lines := range problems {
 		out.FailureT("Problems detected in {{.name}}:", out.V{"name": name})
 		if len(lines) > maxLines {
@@ -159,7 +163,7 @@ func OutputProblems(problems map[string][]string, maxLines int) {
 }
 
 // Output displays logs from multiple sources in tail(1) format
-func Output(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.ClusterConfig, runner command.Runner, lines int) error {
+func Output(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.ClusterConfig, runner command.Runner, lines int, logOutput *os.File) error {
 	cmds := logCommands(r, bs, cfg, lines, false)
 	cmds["kernel"] = "uptime && uname -a && grep PRETTY /etc/os-release"
 
@@ -167,6 +171,9 @@ func Output(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.Cluster
 	for k := range cmds {
 		names = append(names, k)
 	}
+
+	out.SetOutFile(logOutput)
+	defer out.SetOutFile(os.Stdout)
 
 	sort.Strings(names)
 	failed := []string{}
@@ -238,13 +245,16 @@ func outputLastStart() error {
 }
 
 // OutputOffline outputs logs that don't need a running cluster.
-func OutputOffline(lines int) {
+func OutputOffline(lines int, logOutput *os.File) {
+	out.SetOutFile(logOutput)
+	defer out.SetOutFile(os.Stdout)
 	if err := outputAudit(lines); err != nil {
 		klog.Errorf("failed to output audit logs: %v", err)
 	}
 	if err := outputLastStart(); err != nil {
 		klog.Errorf("failed to output last start logs: %v", err)
 	}
+
 	out.Styled(style.Empty, "")
 }
 

--- a/site/content/en/docs/commands/logs.md
+++ b/site/content/en/docs/commands/logs.md
@@ -20,6 +20,7 @@ minikube logs [flags]
 ### Options
 
 ```
+      --file string   If present, writes to the provided file instead of stdout.
   -f, --follow        Show only the most recent journal entries, and continuously print new entries as they are appended to the journal.
   -n, --length int    Number of lines back to go within the log (default 60)
       --node string   The node to get logs from. Defaults to the primary control plane.


### PR DESCRIPTION
fixes #11231.

Before:
```
$ minikube logs

==> Audit <==
|---------------|--------------------------------------------|----------|-------------|---------|-------------------------------|-------------------------------|
|    Command    |                    Args                    | Profile  |    User     | Version |          Start Time           |           End Time            |
|---------------|--------------------------------------------|----------|-------------|---------|-------------------------------|-------------------------------|
| generate-docs | --path ./site/content/en/docs/commands/    | minikube | andriydzikh | v1.19.0 | Thu, 29 Apr 2021 13:58:18 PDT | Thu, 29 Apr 2021 13:58:18 PDT |
|               | --test-path                                |          |             |         |                               |                               |
|               | ./site/content/en/docs/contrib/tests.en.md |          |             |         |                               |                               |
| start         |                                            | minikube | andriydzikh | v1.19.0 | Thu, 29 Apr 2021 14:06:56 PDT | Thu, 29 Apr 2021 14:08:05 PDT |
... Continued
```
After:
```
andriydzikh@andriydzikh-glaptop:~/minikube$ minikube logs --file f
```
After file:
```
* 
* ==> Audit <==
* |---------------|--------------------------------------------|----------|-------------|---------|-------------------------------|-------------------------------|
|    Command    |                    Args                    | Profile  |    User     | Version |          Start Time           |           End Time            |
|---------------|--------------------------------------------|----------|-------------|---------|-------------------------------|-------------------------------|
| generate-docs | --path ./site/content/en/docs/commands/    | minikube | andriydzikh | v1.19.0 | Thu, 29 Apr 2021 13:58:18 PDT | Thu, 29 Apr 2021 13:58:18 PDT |
|               | --test-path                                |          |             |         |                               |                               |
|               | ./site/content/en/docs/contrib/tests.en.md |          |             |         |                               |                               |
| start         |                                            | minikube | andriydzikh | v1.19.0 | Thu, 29 Apr 2021 14:06:56 PDT | Thu, 29 Apr 2021 14:08:05 PDT |
... Continued
```