### PR TITLE
Fix out stylized function formatting with an empty map instead of nothing.

### DIFF
--- a/pkg/minikube/out/out_style.go
+++ b/pkg/minikube/out/out_style.go
@@ -54,7 +54,7 @@ func applyStyle(st style.Enum, useColor bool, format string) (string, bool) {
 func stylized(st style.Enum, useColor bool, format string, a ...V) (string, bool) {
 	var spinner bool
 	if a == nil {
-		a = []V{{}}
+		a = []V{}
 	}
 	format, spinner = applyStyle(st, useColor, format)
 	return Fmt(format, a...), spinner


### PR DESCRIPTION
fixes #11236.

This is a much better solution to #11236 since it more accurately preserves the intent of templating - that is since `a` is optional, not including it should avoid all formatting.

`stylized(style.Option, true, "Some format {{rawthingy}}")`
Before: Attempts to format string and throws error message
After: Returns originally string without attempting formatting.