### PR TITLE
Goroutine leak fix

### DIFF
--- a/cmd/minikube/cmd/dashboard.go
+++ b/cmd/minikube/cmd/dashboard.go
@@ -172,8 +172,8 @@ func kubectlProxy(kubectlVersion string, contextName string) (*exec.Cmd, string,
 
 // readByteWithTimeout returns a byte from a reader or an indicator that a timeout has occurred.
 func readByteWithTimeout(r io.ByteReader, timeout time.Duration) (byte, bool, error) {
-	bc := make(chan byte)
-	ec := make(chan error)
+	bc := make(chan byte, 1)
+	ec := make(chan error, 1)
 	go func() {
 		b, err := r.ReadByte()
 		if err != nil {

--- a/cmd/minikube/cmd/dashboard.go
+++ b/cmd/minikube/cmd/dashboard.go
@@ -172,8 +172,8 @@ func kubectlProxy(kubectlVersion string, contextName string) (*exec.Cmd, string,
 
 // readByteWithTimeout returns a byte from a reader or an indicator that a timeout has occurred.
 func readByteWithTimeout(r io.ByteReader, timeout time.Duration) (byte, bool, error) {
-	bc := make(chan byte, 1)
-	ec := make(chan error, 1)
+	bc := make(chan byte)
+	ec := make(chan error)
 	go func() {
 		b, err := r.ReadByte()
 		if err != nil {


### PR DESCRIPTION
A goroutine leak could occur as a result of timeouts when the function `readByteWithTimeout` is called after a user calls `minikube dashboard`. This is not likely to result in in an issue, but general best practice should be to use buffered channels in the same function as the capacity is known. 

The function in question is the following file
https://github.com/kubernetes/minikube/blob/fe0a1774a6be272a255f6de1930fb81a82430e28/cmd/minikube/cmd/dashboard.go#L174-L195

The same functionality is replicated here: https://play.golang.org/p/L5PNk76iJga. Notice that one hanging goroutine results from the forced timeout