### PR TITLE
Run test2json during the test and not afterwards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -339,6 +339,7 @@ integration-functional-only: out/minikube$(IS_EXE) ## Trigger only functioanl te
 
 .PHONY: html_report
 html_report: ## Generate HTML  report out of the last ran integration test logs.
+	@#TODO the json needs to be recorded when the go test is run, for timestamps to work properly
 	@go tool test2json -t < "./out/testout_$(COMMIT_SHORT).txt" > "./out/testout_$(COMMIT_SHORT).json"
 	@gopogh -in "./out/testout_$(COMMIT_SHORT).json" -out ./out/testout_$(COMMIT_SHORT).html -name "$(shell git rev-parse --abbrev-ref HEAD)" -pr "" -repo github.com/kubernetes/minikube/  -details "${COMMIT_SHORT}"
 	@echo "-------------------------- Open HTML Report in Browser: ---------------------------"

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -316,6 +316,10 @@ if test -f "${TEST_OUT}"; then
   rm "${TEST_OUT}" || true # clean up previous runs of same build
 fi
 touch "${TEST_OUT}"
+if test -f "${JSON_OUT}"; then
+  rm "${JSON_OUT}" || true # clean up previous runs of same build
+fi
+touch "${JSON_OUT}"
 
 if [ ! -z "${CONTAINER_RUNTIME}" ]
 then
@@ -326,9 +330,10 @@ ${SUDO_PREFIX}${E2E_BIN} \
   -minikube-start-args="--driver=${VM_DRIVER} ${EXTRA_START_ARGS}" \
   -test.timeout=${TIMEOUT} -test.v \
   ${EXTRA_TEST_ARGS} \
-  -binary="${MINIKUBE_BIN}" 2>&1 | tee "${TEST_OUT}"
+  -binary="${MINIKUBE_BIN}" 2>&1 | tee "${TEST_OUT}" | go tool test2json -t > "${JSON_OUT}"
 
 result=${PIPESTATUS[0]} # capture the exit code of the first cmd in pipe.
+cat "${TEST_OUT}"
 set +x
 echo ">> ${E2E_BIN} exited with ${result} at $(date)"
 echo ""
@@ -353,17 +358,6 @@ JOB_GCS_BUCKET="minikube-builds/logs/${MINIKUBE_LOCATION}/${SHORT_COMMIT}/${JOB_
 echo ">> Copying ${TEST_OUT} to gs://${JOB_GCS_BUCKET}out.txt"
 gsutil -qm cp "${TEST_OUT}" "gs://${JOB_GCS_BUCKET}out.txt"
 
-
-echo ">> Attmpting to convert test logs to json"
-if test -f "${JSON_OUT}"; then
-  rm "${JSON_OUT}" || true # clean up previous runs of same build
-fi
-
-touch "${JSON_OUT}"
-
-# Generate JSON output
-echo ">> Running go test2json"
-go tool test2json -t < "${TEST_OUT}" > "${JSON_OUT}" || true
 
 if ! type "jq" > /dev/null; then
 echo ">> Installing jq"

--- a/hack/jenkins/run_tests.sh
+++ b/hack/jenkins/run_tests.sh
@@ -305,6 +305,10 @@ if test -f "${TEST_OUT}"; then
   rm "${TEST_OUT}" || true # clean up previous runs of same build
 fi
 touch "${TEST_OUT}"
+if test -f "${JSON_OUT}"; then
+  rm "${JSON_OUT}" || true # clean up previous runs of same build
+fi
+touch "${JSON_OUT}"
 
 if [ ! -z "${CONTAINER_RUNTIME}" ]
 then
@@ -315,9 +319,10 @@ ${SUDO_PREFIX}${E2E_BIN} \
   -minikube-start-args="--driver=${VM_DRIVER} ${EXTRA_START_ARGS}" \
   -test.timeout=${TIMEOUT} -test.v \
   ${EXTRA_TEST_ARGS} \
-  -binary="${MINIKUBE_BIN}" 2>&1 | tee "${TEST_OUT}"
+  -binary="${MINIKUBE_BIN}" 2>&1 | tee "${TEST_OUT}" | go tool test2json -t > "${JSON_OUT}"
 
 result=${PIPESTATUS[0]} # capture the exit code of the first cmd in pipe.
+cat "${TEST_OUT}"
 set +x
 echo ">> ${E2E_BIN} exited with ${result} at $(date)"
 echo ""
@@ -338,17 +343,6 @@ sec=$(tail -c 3 <<< $((${elapsed}00/60)))
 elapsed=$min.$sec
 
 
-
-echo ">> Attmpting to convert test logs to json"
-if test -f "${JSON_OUT}"; then
-  rm "${JSON_OUT}" || true # clean up previous runs of same build
-fi
-
-touch "${JSON_OUT}"
-
-# Generate JSON output
-echo ">> Running go test2json"
-go tool test2json -t < "${TEST_OUT}" > "${JSON_OUT}" || true
 
 if ! type "jq" > /dev/null; then
 echo ">> Installing jq"


### PR DESCRIPTION
Running it after the test is completed, means that the timestamps
of the output will be wrong (not reflecting the actual test run).

This should use "go test -json" instead of the "test2json" pipe,
but need something like "gotestsum" to show both out and json...

Issue #11249

----

This is only a beginning of the cleanup, haven't touched GitHub Actions.
This half-way approach will make _all_ output show only after test is done.

The plan is to use another tool like "gotestsum", to show both at once...
When using "go test", it can show text or it can show json. But not both.