### PR TITLE
Revert "Run test2json during the test and not afterwards"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -339,7 +339,6 @@ integration-functional-only: out/minikube$(IS_EXE) ## Trigger only functioanl te
 
 .PHONY: html_report
 html_report: ## Generate HTML  report out of the last ran integration test logs.
-	@#TODO the json needs to be recorded when the go test is run, for timestamps to work properly
 	@go tool test2json -t < "./out/testout_$(COMMIT_SHORT).txt" > "./out/testout_$(COMMIT_SHORT).json"
 	@gopogh -in "./out/testout_$(COMMIT_SHORT).json" -out ./out/testout_$(COMMIT_SHORT).html -name "$(shell git rev-parse --abbrev-ref HEAD)" -pr "" -repo github.com/kubernetes/minikube/  -details "${COMMIT_SHORT}"
 	@echo "-------------------------- Open HTML Report in Browser: ---------------------------"

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -316,10 +316,6 @@ if test -f "${TEST_OUT}"; then
   rm "${TEST_OUT}" || true # clean up previous runs of same build
 fi
 touch "${TEST_OUT}"
-if test -f "${JSON_OUT}"; then
-  rm "${JSON_OUT}" || true # clean up previous runs of same build
-fi
-touch "${JSON_OUT}"
 
 if [ ! -z "${CONTAINER_RUNTIME}" ]
 then
@@ -330,10 +326,9 @@ ${SUDO_PREFIX}${E2E_BIN} \
   -minikube-start-args="--driver=${VM_DRIVER} ${EXTRA_START_ARGS}" \
   -test.timeout=${TIMEOUT} -test.v \
   ${EXTRA_TEST_ARGS} \
-  -binary="${MINIKUBE_BIN}" 2>&1 | tee "${TEST_OUT}" | go tool test2json -t > "${JSON_OUT}"
+  -binary="${MINIKUBE_BIN}" 2>&1 | tee "${TEST_OUT}"
 
 result=${PIPESTATUS[0]} # capture the exit code of the first cmd in pipe.
-cat "${TEST_OUT}"
 set +x
 echo ">> ${E2E_BIN} exited with ${result} at $(date)"
 echo ""
@@ -358,6 +353,17 @@ JOB_GCS_BUCKET="minikube-builds/logs/${MINIKUBE_LOCATION}/${SHORT_COMMIT}/${JOB_
 echo ">> Copying ${TEST_OUT} to gs://${JOB_GCS_BUCKET}out.txt"
 gsutil -qm cp "${TEST_OUT}" "gs://${JOB_GCS_BUCKET}out.txt"
 
+
+echo ">> Attmpting to convert test logs to json"
+if test -f "${JSON_OUT}"; then
+  rm "${JSON_OUT}" || true # clean up previous runs of same build
+fi
+
+touch "${JSON_OUT}"
+
+# Generate JSON output
+echo ">> Running go test2json"
+go tool test2json -t < "${TEST_OUT}" > "${JSON_OUT}" || true
 
 if ! type "jq" > /dev/null; then
 echo ">> Installing jq"


### PR DESCRIPTION
Reverts kubernetes/minikube#11250

Losing streaming logs in jenkins isn't worth fixing timestamps, we should probably use something like [gotestsum](https://github.com/gotestyourself/gotestsum) to do this properly