### PR TITLE
Batch logs output to speedup `minikube logs` command

### DIFF
--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -184,10 +184,12 @@ func Output(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.Cluster
 			failed = append(failed, name)
 			continue
 		}
+		l := ""
 		scanner := bufio.NewScanner(&b)
 		for scanner.Scan() {
-			out.Styled(style.Empty, scanner.Text())
+			l += scanner.Text() + "\n"
 		}
+		out.Styled(style.Empty, l)
 	}
 
 	if len(failed) > 0 {
@@ -223,10 +225,12 @@ func outputLastStart() error {
 		return fmt.Errorf("failed to open file %s: %v", fp, err)
 	}
 	defer f.Close()
+	l := ""
 	s := bufio.NewScanner(f)
 	for s.Scan() {
-		out.Styled(style.Empty, s.Text())
+		l += s.Text() + "\n"
 	}
+	out.Styled(style.Empty, l)
 	if err := s.Err(); err != nil {
 		return fmt.Errorf("failed to read file %s: %v", fp, err)
 	}

--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -158,6 +158,14 @@ func TestDownloadOnly(t *testing.T) {
 				}
 			})
 
+			t.Run("minikube logs", func(t *testing.T) {
+				ctx, cancel := context.WithTimeout(context.Background(), Seconds(5))
+				args := append([]string{"logs", "-p", profile})
+				if _, err := Run(t, exec.CommandContext(ctx, Target(), args...)); err != nil {
+					t.Errorf("minikube logs failed with error: %v", err)
+				}
+			})
+
 		})
 	}
 

--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -158,13 +158,12 @@ func TestDownloadOnly(t *testing.T) {
 				}
 			})
 
-			t.Run("minikube logs", func(t *testing.T) {
+			// checks if the duration of `minikube logs` takes longer than 5 seconds
+			t.Run("LogsDuration", func(t *testing.T) {
 				ctx, cancel := context.WithTimeout(context.Background(), Seconds(5))
 				defer cancel()
 				args := []string{"logs", "-p", profile}
-				if _, err := Run(t, exec.CommandContext(ctx, Target(), args...)); err != nil {
-					t.Errorf("minikube logs failed with error: %v", err)
-				}
+				Run(t, exec.CommandContext(ctx, Target(), args...))
 				if err := ctx.Err(); err == context.DeadlineExceeded {
 					t.Error("minikube logs expected to finish by 5 seconds, but took longer")
 				}

--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -165,7 +165,7 @@ func TestDownloadOnly(t *testing.T) {
 				if _, err := Run(t, exec.CommandContext(ctx, Target(), args...)); err != nil {
 					t.Errorf("minikube logs failed with error: %v", err)
 				}
-				if err := ctx.Err(); err != nil {
+				if err := ctx.Err(); err == context.DeadlineExceeded {
 					t.Error("minikube logs expected to finish by 5 seconds, but took longer")
 				}
 			})

--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -160,9 +160,13 @@ func TestDownloadOnly(t *testing.T) {
 
 			t.Run("minikube logs", func(t *testing.T) {
 				ctx, cancel := context.WithTimeout(context.Background(), Seconds(5))
-				args := append([]string{"logs", "-p", profile})
+				defer cancel()
+				args := []string{"logs", "-p", profile}
 				if _, err := Run(t, exec.CommandContext(ctx, Target(), args...)); err != nil {
 					t.Errorf("minikube logs failed with error: %v", err)
+				}
+				if err := ctx.Err(); err != nil {
+					t.Error("minikube logs expected to finish by 5 seconds, but took longer")
 				}
 			})
 

--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -163,7 +163,9 @@ func TestDownloadOnly(t *testing.T) {
 				ctx, cancel := context.WithTimeout(context.Background(), Seconds(5))
 				defer cancel()
 				args := []string{"logs", "-p", profile}
-				Run(t, exec.CommandContext(ctx, Target(), args...))
+				if _, err := Run(t, exec.CommandContext(ctx, Target(), args...)); err != nil {
+					t.Logf("minikube logs failed with error: %v", err)
+				}
 				if err := ctx.Err(); err == context.DeadlineExceeded {
 					t.Error("minikube logs expected to finish by 5 seconds, but took longer")
 				}


### PR DESCRIPTION
Closes #11266

Currently each line of logs calls `out.Styled`, `out.Styled` calls `klog.Flush`, so flushing on many lines repeatedly slows down the output.

The PR batches large amounts of lines into a single string before calling `out.Styled`, greatly reducing the output time.

Before:
```
minikube logs
26.578 seconds
```

After:
```
minikube logs
2.591 seconds
```