### PR TITLE
Thank PR reviewers and issue-commenters in hack/release_notes.sh.

### DIFF
--- a/hack/.gitignore
+++ b/hack/.gitignore
@@ -1,1 +1,3 @@
 release-notes
+pullsheet
+gh_token.txt

--- a/hack/release_notes.sh
+++ b/hack/release_notes.sh
@@ -18,6 +18,11 @@ set -eu -o pipefail
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
+if ! [[ -r "${DIR}/gh_token.txt" ]]; then
+  echo "Missing '${DIR}/gh_token.txt'. Please create a GitHub token at https://github.com/settings/tokens and store in '${DIR}/gh_token.txt'."
+  exit 1
+fi
+
 install_release_notes_helper() {
   release_notes_workdir="$(mktemp -d)"
   trap 'rm -rf -- ${release_notes_workdir}' RETURN
@@ -26,19 +31,26 @@ install_release_notes_helper() {
   cd "${release_notes_workdir}"
   go mod init release-notes
   GOBIN="$DIR" go get github.com/corneliusweig/release-notes
+  GOBIN="$DIR" go get github.com/google/pullsheet
   cd -
 }
 
-if ! [[ -x "${DIR}/release-notes" ]]; then
+if ! [[ -x "${DIR}/release-notes" ]] || ! [[ -x "${DIR}/pullsheet" ]]; then
   echo >&2 'Installing release-notes'
   install_release_notes_helper
 fi
 
 git pull git@github.com:kubernetes/minikube master --tags
 recent=$(git describe --abbrev=0)
+recent_date=$(git log -1 --format=%as $recent)
 
 "${DIR}/release-notes" kubernetes minikube --since $recent
 
+echo ""
 echo "Thank you to our contributors for this release!"
 echo ""
 git log "$recent".. --format="%aN" --reverse | sort | uniq | awk '{printf "- %s\n", $0 }'
+echo ""
+echo "Thank you to our PR reviewers for this release!"
+echo ""
+"${DIR}/pullsheet" reviews --since "$recent_date" --repos kubernetes/minikube --token-path $DIR/gh_token.txt | awk -F ',' 'function cmp_value_order(i1,v1,i2,v2){ return v1 < v2 } NR>1{arr[$4] += $6 + $7}END{PROCINFO["sorted_in"] = "cmp_value_order"; for (a in arr) printf "- %s (%d comments)\n", a, arr[a]}'

--- a/hack/release_notes.sh
+++ b/hack/release_notes.sh
@@ -54,3 +54,7 @@ echo ""
 echo "Thank you to our PR reviewers for this release!"
 echo ""
 "${DIR}/pullsheet" reviews --since "$recent_date" --repos kubernetes/minikube --token-path $DIR/gh_token.txt | awk -F ',' 'function cmp_value_order(i1,v1,i2,v2){ return v1 < v2 } NR>1{arr[$4] += $6 + $7}END{PROCINFO["sorted_in"] = "cmp_value_order"; for (a in arr) printf "- %s (%d comments)\n", a, arr[a]}'
+echo ""
+echo "Thank you to our triage members for this release!"
+echo ""
+"${DIR}/pullsheet" issue-comments --since "$recent_date" --repos kubernetes/minikube --token-path $DIR/gh_token.txt | awk -F ',' 'function cmp_value_order(i1,v1,i2,v2){ return v1 < v2 } NR>1{arr[$4] += $7}END{PROCINFO["sorted_in"] = "cmp_value_order"; for (a in arr) printf "- %s (%d comments)\n", a, arr[a]}' | head -n 5


### PR DESCRIPTION
fixes #10671.

Before:
```
$ ./release_notes.sh 2> /dev/null
Already up to date.
* Revert "Run test2json during the test and not afterwards" [#11273](https://github.com/kubernetes/minikube/pull/11273)
* Add minikube prow testing docker image [#11251](https://github.com/kubernetes/minikube/pull/11251)
* Bump github.com/shirou/gopsutil/v3 from 3.21.3 to 3.21.4 [#11259](https://github.com/kubernetes/minikube/pull/11259)
* spelling [#11186](https://github.com/kubernetes/minikube/pull/11186)
* Output GitHub issue message to stderr [#11230](https://github.com/kubernetes/minikube/pull/11230)
* Update olm addon to v0.17.0 [#10947](https://github.com/kubernetes/minikube/pull/10947)
* ci: Make separate image for the remove functional test [#11248](https://github.com/kubernetes/minikube/pull/11248)
* Run test2json during the test and not afterwards [#11250](https://github.com/kubernetes/minikube/pull/11250)
* warn about performance for certain versions of kubernetes [#11217](https://github.com/kubernetes/minikube/pull/11217)
* Fix out stylized function formatting with an empty map instead of nothing. [#11243](https://github.com/kubernetes/minikube/pull/11243)
* Bump github.com/Azure/azure-sdk-for-go from 43.0.0+incompatible to 43.3.0+incompatible [#11261](https://github.com/kubernetes/minikube/pull/11261)
* Bump cloud.google.com/go/storage from 1.13.0 to 1.15.0 [#11263](https://github.com/kubernetes/minikube/pull/11263)
* Bump github.com/hashicorp/go-retryablehttp from 0.6.8 to 0.7.0 [#11260](https://github.com/kubernetes/minikube/pull/11260)
* update releases-beta.json to include v1.20.0-beta.0 [#11244](https://github.com/kubernetes/minikube/pull/11244)
* Fixed gsutil copy for releases-beta.json [#11245](https://github.com/kubernetes/minikube/pull/11245)
Thank you to our contributors for this release!

- Anders F Björklund
- Andriy Dzikh
- dependabot[bot]
- Ilya Zuyev
- Medya Ghazizadeh
- minikube-bot
- Sharif Elgamal
- Steven Powell
- Tomas Kral
- Yanshu
- zhangshj
```
After:
```
$ ./release_notes.sh 2> /dev/null
Already up to date.
* site: fixed CPU benchmarking typos and small formatting [#11279](https://github.com/kubernetes/minikube/pull/11279)
* Revert "Run test2json during the test and not afterwards" [#11273](https://github.com/kubernetes/minikube/pull/11273)
* Add minikube prow testing docker image [#11251](https://github.com/kubernetes/minikube/pull/11251)
* Bump github.com/shirou/gopsutil/v3 from 3.21.3 to 3.21.4 [#11259](https://github.com/kubernetes/minikube/pull/11259)
* spelling [#11186](https://github.com/kubernetes/minikube/pull/11186)
* Output GitHub issue message to stderr [#11230](https://github.com/kubernetes/minikube/pull/11230)
* Update olm addon to v0.17.0 [#10947](https://github.com/kubernetes/minikube/pull/10947)
* ci: Make separate image for the remove functional test [#11248](https://github.com/kubernetes/minikube/pull/11248)
* Run test2json during the test and not afterwards [#11250](https://github.com/kubernetes/minikube/pull/11250)
* warn about performance for certain versions of kubernetes [#11217](https://github.com/kubernetes/minikube/pull/11217)
* Fix out stylized function formatting with an empty map instead of nothing. [#11243](https://github.com/kubernetes/minikube/pull/11243)
* Bump github.com/Azure/azure-sdk-for-go from 43.0.0+incompatible to 43.3.0+incompatible [#11261](https://github.com/kubernetes/minikube/pull/11261)
* Bump cloud.google.com/go/storage from 1.13.0 to 1.15.0 [#11263](https://github.com/kubernetes/minikube/pull/11263)
* Bump github.com/hashicorp/go-retryablehttp from 0.6.8 to 0.7.0 [#11260](https://github.com/kubernetes/minikube/pull/11260)
* update releases-beta.json to include v1.20.0-beta.0 [#11244](https://github.com/kubernetes/minikube/pull/11244)
* Fixed gsutil copy for releases-beta.json [#11245](https://github.com/kubernetes/minikube/pull/11245)

Thank you to our contributors for this release!

- Anders F Björklund
- Andriy Dzikh
- dependabot[bot]
- Ilya Zuyev
- Medya Ghazizadeh
- minikube-bot
- Sharif Elgamal
- Steven Powell
- Tomas Kral
- Yanshu
- zhangshj

Thank you to our PR reviewers for this release!

- medyagh (20 comments)
- spowelljr (2 comments)
- afbjorklund (1 comments)

Thank you to our triage members for this release!

- medyagh (18 comments)
- afbjorklund (10 comments)
- andriyDev (6 comments)
- spowelljr (3 comments)
- MullinsN (2 comments)
```

Note pullsheet throws off lots of logs to stderr, so piping error output to /dev/null is very useful.

Unfortunately, it is difficult to get names of users (although in practice this can likely be done manually by copying from the contributor list). This is due to the fact that GitHub does not track names of users very well, even though a user's git commits do contain their name for the most part - so even modifying pullsheet directly to pass names would not work.

A possible mitigation to this is to have pullsheet return one random commit from each reviewer and then lookup those in git to extract their names although this is way more complicated and will break if a reviewer has never had a PR merged. Assembling the release notes is a manual process anyway, so usernames will likely be fine.