### PR TITLE
Allow passing a command line argument to hack/release_notes.sh for the desired tag to compare against.

### DIFF
--- a/hack/release_notes.sh
+++ b/hack/release_notes.sh
@@ -35,7 +35,7 @@ if ! [[ -x "${DIR}/release-notes" ]]; then
 fi
 
 git pull git@github.com:kubernetes/minikube master --tags
-recent=$(git describe --abbrev=0)
+recent=${1:-$(git describe --abbrev=0)}
 
 "${DIR}/release-notes" kubernetes minikube --since $recent
 


### PR DESCRIPTION
fixes #11278.

Before:
```
$ hack/release_notes.sh
Already up to date.
Collecting pull request that were merged since the last release: v1.20.0-beta.0 (2021-04-30 23:06:50 +0000 UTC)
* Revert "Run test2json during the test and not afterwards" [#11273](https://github.com/kubernetes/minikube/pull/11273)
* Add minikube prow testing docker image [#11251](https://github.com/kubernetes/minikube/pull/11251)
* Bump github.com/shirou/gopsutil/v3 from 3.21.3 to 3.21.4 [#11259](https://github.com/kubernetes/minikube/pull/11259)
* spelling [#11186](https://github.com/kubernetes/minikube/pull/11186)
* Output GitHub issue message to stderr [#11230](https://github.com/kubernetes/minikube/pull/11230)
* Update olm addon to v0.17.0 [#10947](https://github.com/kubernetes/minikube/pull/10947)
* ci: Make separate image for the remove functional test [#11248](https://github.com/kubernetes/minikube/pull/11248)
* Run test2json during the test and not afterwards [#11250](https://github.com/kubernetes/minikube/pull/11250)
* warn about performance for certain versions of kubernetes [#11217](https://github.com/kubernetes/minikube/pull/11217)
* Fix out stylized function formatting with an empty map instead of nothing. [#11243](https://github.com/kubernetes/minikube/pull/11243)
* Bump github.com/Azure/azure-sdk-for-go from 43.0.0+incompatible to 43.3.0+incompatible [#11261](https://github.com/kubernetes/minikube/pull/11261)
* Bump cloud.google.com/go/storage from 1.13.0 to 1.15.0 [#11263](https://github.com/kubernetes/minikube/pull/11263)
* Bump github.com/hashicorp/go-retryablehttp from 0.6.8 to 0.7.0 [#11260](https://github.com/kubernetes/minikube/pull/11260)
* update releases-beta.json to include v1.20.0-beta.0 [#11244](https://github.com/kubernetes/minikube/pull/11244)
* Fixed gsutil copy for releases-beta.json [#11245](https://github.com/kubernetes/minikube/pull/11245)
Thank you to our contributors for this release!

- Anders F Björklund
- Andriy Dzikh
- dependabot[bot]
- Ilya Zuyev
- Medya Ghazizadeh
- minikube-bot
- Sharif Elgamal
- Steven Powell
- Tomas Kral
- Yanshu
- zhangshj
```
After:
```
$ hack/release_notes.sh v1.19.0
Already up to date.
Collecting pull request that were merged since the last release: v1.19.0 (2021-04-10 00:30:30 +0000 UTC)
* Revert "Run test2json during the test and not afterwards" [#11273](https://github.com/kubernetes/minikube/pull/11273)
* Add minikube prow testing docker image [#11251](https://github.com/kubernetes/minikube/pull/11251)
* Bump github.com/shirou/gopsutil/v3 from 3.21.3 to 3.21.4 [#11259](https://github.com/kubernetes/minikube/pull/11259)
* spelling [#11186](https://github.com/kubernetes/minikube/pull/11186)
* Output GitHub issue message to stderr [#11230](https://github.com/kubernetes/minikube/pull/11230)
* Update olm addon to v0.17.0 [#10947](https://github.com/kubernetes/minikube/pull/10947)
* ci: Make separate image for the remove functional test [#11248](https://github.com/kubernetes/minikube/pull/11248)
* Run test2json during the test and not afterwards [#11250](https://github.com/kubernetes/minikube/pull/11250)
* warn about performance for certain versions of kubernetes [#11217](https://github.com/kubernetes/minikube/pull/11217)
* Fix out stylized function formatting with an empty map instead of nothing. [#11243](https://github.com/kubernetes/minikube/pull/11243)
* Bump github.com/Azure/azure-sdk-for-go from 43.0.0+incompatible to 43.3.0+incompatible [#11261](https://github.com/kubernetes/minikube/pull/11261)
* Bump cloud.google.com/go/storage from 1.13.0 to 1.15.0 [#11263](https://github.com/kubernetes/minikube/pull/11263)
* Bump github.com/hashicorp/go-retryablehttp from 0.6.8 to 0.7.0 [#11260](https://github.com/kubernetes/minikube/pull/11260)
* update releases-beta.json to include v1.20.0-beta.0 [#11244](https://github.com/kubernetes/minikube/pull/11244)
* Fixed gsutil copy for releases-beta.json [#11245](https://github.com/kubernetes/minikube/pull/11245)
* Release 1.20.0-beta.0 [#11241](https://github.com/kubernetes/minikube/pull/11241)
* ci: add functional contained [#11190](https://github.com/kubernetes/minikube/pull/11190)
* Update ISO to v1.20.0-beta.0 [#11233](https://github.com/kubernetes/minikube/pull/11233)
* Updated English GitHub issue template to require minikube logs [#11238](https://github.com/kubernetes/minikube/pull/11238)
* Update kicbase to v0.0.21 [#11239](https://github.com/kubernetes/minikube/pull/11239)
* improve how cni and cruntimes work together v2 [#11209](https://github.com/kubernetes/minikube/pull/11209)
* containerd: fix disabling non-active runtimes using unmask  [#11232](https://github.com/kubernetes/minikube/pull/11232)
* Add cpu usage benchmark command `make cpu-benchmark` and website docs [#11140](https://github.com/kubernetes/minikube/pull/11140)
* improve how cni and cruntimes work together [#11185](https://github.com/kubernetes/minikube/pull/11185)
* Add feature to opt-in to get notifications for beta releases [#11169](https://github.com/kubernetes/minikube/pull/11169)
* cri: Add API for saving an image to a local path [#11128](https://github.com/kubernetes/minikube/pull/11128)
* Correct typo in start_flags.go [#11206](https://github.com/kubernetes/minikube/pull/11206)
* Make sure to capture errors in auto kicbase builds [#11212](https://github.com/kubernetes/minikube/pull/11212)
* ci: mkcmp: skip ingress for containerd runtime, take 2 [#11210](https://github.com/kubernetes/minikube/pull/11210)
* Make sure to pass the platform for the kicbase [#11208](https://github.com/kubernetes/minikube/pull/11208)
* Bump google.golang.org/api from 0.44.0 to 0.45.0 [#11198](https://github.com/kubernetes/minikube/pull/11198)
* Add some zh-CN translations [#11203](https://github.com/kubernetes/minikube/pull/11203)
* Use golang.org/x/term [#11003](https://github.com/kubernetes/minikube/pull/11003)
* Add code for downloading kicbase image to cache [#10918](https://github.com/kubernetes/minikube/pull/10918)
* [Ingress Addon] Fix bug which the networking.k8s.io/v1 ingress is always rejected [#11189](https://github.com/kubernetes/minikube/pull/11189)
* bump kindnet to v20210326-1e038dc5 [#11178](https://github.com/kubernetes/minikube/pull/11178)
* ISO: Upgrade buildroot minor version [#11054](https://github.com/kubernetes/minikube/pull/11054)
* Update kicbase base image [#11055](https://github.com/kubernetes/minikube/pull/11055)
* New command: `build` to build images using minikube [#11164](https://github.com/kubernetes/minikube/pull/11164)
* Add checksum to the preload tarball download [#11132](https://github.com/kubernetes/minikube/pull/11132)
* UI: Add log file to GitHub issue output [#11158](https://github.com/kubernetes/minikube/pull/11158)
* fix flake integration tests: cleanups and timeouts [#11176](https://github.com/kubernetes/minikube/pull/11176)
* Move preload arm64  generation to Jenkins [#11095](https://github.com/kubernetes/minikube/pull/11095)
* Check for uint32 overflow in go9p third party [#11080](https://github.com/kubernetes/minikube/pull/11080)
* docker/podman: Use canonical image name if one exists remotely [#11168](https://github.com/kubernetes/minikube/pull/11168)
* Revert "ci: mkcmp: skip testing ingress for containerd" [#11173](https://github.com/kubernetes/minikube/pull/11173)
* site: Update contribution guide.en.md [#11172](https://github.com/kubernetes/minikube/pull/11172)
* Change 'minikube version --short' to only print the version without a prompt. [#11167](https://github.com/kubernetes/minikube/pull/11167)
* Correct typo in timeout value in comment [#11133](https://github.com/kubernetes/minikube/pull/11133)
* KVM2: Increase timeout value in driver validation to 6 seconds [#11114](https://github.com/kubernetes/minikube/pull/11114)
* ci: bump timeout for github action [#11154](https://github.com/kubernetes/minikube/pull/11154)
* Better to use "0777" than "0o777",instead of only in Go [#11122](https://github.com/kubernetes/minikube/pull/11122)
* test: Add target for the test report as html [#11157](https://github.com/kubernetes/minikube/pull/11157)
* Mock the docker call when calling it from tests [#11160](https://github.com/kubernetes/minikube/pull/11160)
* Make golint clean again by adding comments [#11155](https://github.com/kubernetes/minikube/pull/11155)
* Upgrade Docker, from 20.10.4 to 20.10.6 [#11099](https://github.com/kubernetes/minikube/pull/11099)
* ci:Pre-cleanup for GitHub actions self-hosted machines [#11151](https://github.com/kubernetes/minikube/pull/11151)
* fix insufficient memory issues [#11030](https://github.com/kubernetes/minikube/pull/11030)
* bump golangci-lint to latest v1.39.0 [#11150](https://github.com/kubernetes/minikube/pull/11150)
* fix "index out of range" in integration.validateDeployAppToMultiNode [#11152](https://github.com/kubernetes/minikube/pull/11152)
* new command "image pull: allow to load remote images directly without cache [#11127](https://github.com/kubernetes/minikube/pull/11127)
* skip dry-run on hyperv [#11148](https://github.com/kubernetes/minikube/pull/11148)
* Check if go mod tidy || make generate-docs create file changes in CI [#11050](https://github.com/kubernetes/minikube/pull/11050)
* prevent multiple /etc/hosts entries for control-plane.minikube.internal [#11081](https://github.com/kubernetes/minikube/pull/11081)
* ci: move non-functional tests to pr verfied [#11143](https://github.com/kubernetes/minikube/pull/11143)
* Upgrade crio to 1.20.2 [#11111](https://github.com/kubernetes/minikube/pull/11111)
* site: Automatically generate integration test documentation [#11120](https://github.com/kubernetes/minikube/pull/11120)
* Bump golang.org/x/text from 0.3.5 to 0.3.6 [#11142](https://github.com/kubernetes/minikube/pull/11142)
* site: Add some more definitions of image terminology [#11129](https://github.com/kubernetes/minikube/pull/11129)
* Bump github.com/otiai10/copy from 1.5.0 to 1.5.1 [#11135](https://github.com/kubernetes/minikube/pull/11135)
* site: update FAQ [#11119](https://github.com/kubernetes/minikube/pull/11119)
* ci: mkcmp: skip testing ingress for containerd [#11118](https://github.com/kubernetes/minikube/pull/11118)
* test: mock to avoid network calls for mirror unit tests [#11086](https://github.com/kubernetes/minikube/pull/11086)
* ci: pr-bot add containerd to mkcmp and warn if too slow [#11097](https://github.com/kubernetes/minikube/pull/11097)
* ci: Add configuration for sonarqube code scanning [#11092](https://github.com/kubernetes/minikube/pull/11092)
* Check if Docker installed via Snap Package Manager [#11088](https://github.com/kubernetes/minikube/pull/11088)
* Address security concerns with the go code [#11082](https://github.com/kubernetes/minikube/pull/11082)
* ci : overhaul pr bot's mkcmp output [#11096](https://github.com/kubernetes/minikube/pull/11096)
* site: Add Image Build benchmarking page  [#11093](https://github.com/kubernetes/minikube/pull/11093)
* don't run error spam test in parallel [#11087](https://github.com/kubernetes/minikube/pull/11087)
* site: Address concerns highlighted by code scanning [#11079](https://github.com/kubernetes/minikube/pull/11079)
* Bump github.com/cheggaaa/pb/v3 from 3.0.7 to 3.0.8 [#11085](https://github.com/kubernetes/minikube/pull/11085)
* Bump google.golang.org/api from 0.43.0 to 0.44.0 [#11071](https://github.com/kubernetes/minikube/pull/11071)
* Upgrade go version from 1.16.0 to 1.16.1 [#11066](https://github.com/kubernetes/minikube/pull/11066)
* Fix gofmt and add it to the list of linters [#11065](https://github.com/kubernetes/minikube/pull/11065)
* Fix typo in japanese translation [#11053](https://github.com/kubernetes/minikube/pull/11053)
* update releases.json to include v1.19.0 [#11051](https://github.com/kubernetes/minikube/pull/11051)
Thank you to our contributors for this release!

- Anders F Björklund
- Andriy Dzikh
- csiepka
- dependabot[bot]
- Ed Vinyard
- hiroygo
- Hu Shuai
- ilya-zuyev
- Ilya Zuyev
- Kenta Iso
- Kent Iso
- Medya Gh
- Medya Ghazizadeh
- Michael Captain
- minikube-bot
- Predrag Rogic
- Sharif Elgamal
- Steven Powell
- Tobias Klauser
- Tomas Kral
- Yanshu
- zhangshj
- 李龙峰
```