### PR TITLE
Add link to last release in hack/release_notes.sh.

### DIFF
--- a/hack/release_notes.sh
+++ b/hack/release_notes.sh
@@ -42,3 +42,6 @@ recent=$(git describe --abbrev=0)
 echo "Thank you to our contributors for this release!"
 echo ""
 git log "$recent".. --format="%aN" --reverse | sort | uniq | awk '{printf "- %s\n", $0 }'
+
+echo ""
+echo "These release notes are relative to our [last release](https://github.com/kubernetes/minikube/releases/tag/$recent)."


### PR DESCRIPTION
fixes #11278.

Before:
```
$ hack/release_notes.sh
Already up to date.
Collecting pull request that were merged since the last release: v1.20.0-beta.0 (2021-04-30 23:06:50 +0000 UTC)
* site: fixed CPU benchmarking typos and small formatting [#11279](https://github.com/kubernetes/minikube/pull/11279)
* Revert "Run test2json during the test and not afterwards" [#11273](https://github.com/kubernetes/minikube/pull/11273)
* Add minikube prow testing docker image [#11251](https://github.com/kubernetes/minikube/pull/11251)
* Bump github.com/shirou/gopsutil/v3 from 3.21.3 to 3.21.4 [#11259](https://github.com/kubernetes/minikube/pull/11259)
* spelling [#11186](https://github.com/kubernetes/minikube/pull/11186)
* Output GitHub issue message to stderr [#11230](https://github.com/kubernetes/minikube/pull/11230)
* Update olm addon to v0.17.0 [#10947](https://github.com/kubernetes/minikube/pull/10947)
* ci: Make separate image for the remove functional test [#11248](https://github.com/kubernetes/minikube/pull/11248)
* Run test2json during the test and not afterwards [#11250](https://github.com/kubernetes/minikube/pull/11250)
* warn about performance for certain versions of kubernetes [#11217](https://github.com/kubernetes/minikube/pull/11217)
* Fix out stylized function formatting with an empty map instead of nothing. [#11243](https://github.com/kubernetes/minikube/pull/11243)
* Bump github.com/Azure/azure-sdk-for-go from 43.0.0+incompatible to 43.3.0+incompatible [#11261](https://github.com/kubernetes/minikube/pull/11261)
* Bump cloud.google.com/go/storage from 1.13.0 to 1.15.0 [#11263](https://github.com/kubernetes/minikube/pull/11263)
* Bump github.com/hashicorp/go-retryablehttp from 0.6.8 to 0.7.0 [#11260](https://github.com/kubernetes/minikube/pull/11260)
* update releases-beta.json to include v1.20.0-beta.0 [#11244](https://github.com/kubernetes/minikube/pull/11244)
* Fixed gsutil copy for releases-beta.json [#11245](https://github.com/kubernetes/minikube/pull/11245)
Thank you to our contributors for this release!

- Anders F Björklund
- Andriy Dzikh
- dependabot[bot]
- Ilya Zuyev
- Medya Ghazizadeh
- minikube-bot
- Sharif Elgamal
- Steven Powell
- Tomas Kral
- Yanshu
- zhangshj
```
After:
```
$ hack/release_notes.sh
Already up to date.
Collecting pull request that were merged since the last release: v1.20.0-beta.0 (2021-04-30 23:06:50 +0000 UTC)
* site: fixed CPU benchmarking typos and small formatting [#11279](https://github.com/kubernetes/minikube/pull/11279)
* Revert "Run test2json during the test and not afterwards" [#11273](https://github.com/kubernetes/minikube/pull/11273)
* Add minikube prow testing docker image [#11251](https://github.com/kubernetes/minikube/pull/11251)
* Bump github.com/shirou/gopsutil/v3 from 3.21.3 to 3.21.4 [#11259](https://github.com/kubernetes/minikube/pull/11259)
* spelling [#11186](https://github.com/kubernetes/minikube/pull/11186)
* Output GitHub issue message to stderr [#11230](https://github.com/kubernetes/minikube/pull/11230)
* Update olm addon to v0.17.0 [#10947](https://github.com/kubernetes/minikube/pull/10947)
* ci: Make separate image for the remove functional test [#11248](https://github.com/kubernetes/minikube/pull/11248)
* Run test2json during the test and not afterwards [#11250](https://github.com/kubernetes/minikube/pull/11250)
* warn about performance for certain versions of kubernetes [#11217](https://github.com/kubernetes/minikube/pull/11217)
* Fix out stylized function formatting with an empty map instead of nothing. [#11243](https://github.com/kubernetes/minikube/pull/11243)
* Bump github.com/Azure/azure-sdk-for-go from 43.0.0+incompatible to 43.3.0+incompatible [#11261](https://github.com/kubernetes/minikube/pull/11261)
* Bump cloud.google.com/go/storage from 1.13.0 to 1.15.0 [#11263](https://github.com/kubernetes/minikube/pull/11263)
* Bump github.com/hashicorp/go-retryablehttp from 0.6.8 to 0.7.0 [#11260](https://github.com/kubernetes/minikube/pull/11260)
* update releases-beta.json to include v1.20.0-beta.0 [#11244](https://github.com/kubernetes/minikube/pull/11244)
* Fixed gsutil copy for releases-beta.json [#11245](https://github.com/kubernetes/minikube/pull/11245)
Thank you to our contributors for this release!

- Anders F Björklund
- Andriy Dzikh
- dependabot[bot]
- Ilya Zuyev
- Medya Ghazizadeh
- minikube-bot
- Sharif Elgamal
- Steven Powell
- Tomas Kral
- Yanshu
- zhangshj

These release notes are relative to our [last release](https://github.com/kubernetes/minikube/releases/tag/v1.20.0-beta.0).
```