### PR TITLE
Update image repo for prow-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -883,12 +883,12 @@ push-auto-pause-hook-image: auto-pause-hook-image
 
 .PHONY: prow-test-image
 prow-test-image:
-	docker build --build-arg "GO_VERSION=$(GO_VERSION)"  -t docker.io/azhao155/prow-test:$(PROW_TEST_TAG) ./deploy/prow
+	docker build --build-arg "GO_VERSION=$(GO_VERSION)"  -t $(REGISTRY)/prow-test:$(PROW_TEST_TAG) ./deploy/prow
 
 .PHONY: push-prow-test-image
 push-prow-test-image: prow-test-image
-	docker login docker.io/azhao155
-	$(MAKE) push-docker IMAGE=docker.io/azhao155/prow-test:$(PROW_TEST_TAG)	
+	docker login gcr.io/k8s-minikube
+	$(MAKE) push-docker IMAGE=$(REGISTRY)/prow-test:$(PROW_TEST_TAG)
 
 .PHONY: out/performance-bot
 out/performance-bot:


### PR DESCRIPTION
pushed the image: gcr.io/k8s-minikube/prow-test:v0.0.1

```
...
 ---> 560ec8f9f2e7
Step 5/7 : COPY wrapper.sh /usr/local/bin/
 ---> ae42d9ea73bd
Step 6/7 : ENTRYPOINT ["wrapper.sh", "/bin/bash"]
 ---> Running in 8a9aa89a3eef
Removing intermediate container 8a9aa89a3eef
 ---> 327c9949a51b
Step 7/7 : VOLUME ["/var/lib/docker"]
 ---> Running in 34b9b46857b1
Removing intermediate container 34b9b46857b1
 ---> 8e08afa2ce6f
Successfully built 8e08afa2ce6f
Successfully tagged gcr.io/k8s-minikube/prow-test:v0.0.1
docker login gcr.io/k8s-minikube
Authenticating with existing credentials...
WARNING! Your password will be stored unencrypted in /home/zyanshu/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Login Succeeded
make push-docker IMAGE=gcr.io/k8s-minikube/prow-test:v0.0.1
make[1]: Entering directory '/home/zyanshu/minikube'
Error response from daemon: manifest for gcr.io/k8s-minikube/prow-test:v0.0.1 not found: manifest unknown: Failed to fetch "v0.0.1" from request "/v2/k8s-minikube/prow-test/manife
sts/v0.0.1".
Image doesn't exist in registry
⚠️  'Are you sure you want to push gcr.io/k8s-minikube/prow-test:v0.0.1 ?'
Do you want to proceed? (Y/N): y
docker push gcr.io/k8s-minikube/prow-test:v0.0.1
The push refers to repository [gcr.io/k8s-minikube/prow-test]
77fdda4a9ab3: Pushed
a64aa45e3c32: Pushed
e2c6ff462357: Layer already exists
v0.0.1: digest: sha256:d5abb748144031f706799fee9986b428ed2fda5425d75f43452939f683646d86 size: 950
make[1]: Leaving directory '/home/zyanshu/minikube'
```