### PR TITLE
Add the current user's name to log file hashes to prevent collision.

### DIFF
--- a/cmd/minikube/main.go
+++ b/cmd/minikube/main.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/user"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -32,6 +33,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"k8s.io/minikube/pkg/minikube/localpath"
+
 	// Register drivers
 	_ "k8s.io/minikube/pkg/minikube/registry/drvs"
 
@@ -141,6 +143,15 @@ func checkLogFileMaxSize(file string, maxSizeKB int64) bool {
 // logFileName generates a default logfile name in the form minikube_<argv[1]>_<hash>_<count>.log from args
 func logFileName(dir string, logIdx int64) string {
 	h := sha1.New()
+	user, err := user.Current()
+	if err != nil {
+		klog.Warningf("Unable to get username to add to log filename hash: %v", err)
+	} else {
+		_, err := h.Write([]byte(user.Username))
+		if err != nil {
+			klog.Warningf("Unable to add username %s to log filename hash: %v", user.Username, err)
+		}
+	}
 	for _, s := range os.Args {
 		if _, err := h.Write([]byte(s)); err != nil {
 			klog.Warningf("Unable to add arg %s to log filename hash: %v", s, err)


### PR DESCRIPTION
Related to #11242. Also discussed in triage.

Previously, log file hashes included the whole command being executed. Now in addition, the current user's name is also mixed in. This will prevent many permission errors due to multiple users opening the same file (from running the same command).

Before:
User 1:
```
user1 $ minikube status
minikube
type: Control Plane
host: Running
kubelet: Running
apiserver: Running
kubeconfig: Configured
```
User 2:
```
user2 $ minikube status
minikube
type: Control Plane
host: Running
kubelet: Running
apiserver: Running
kubeconfig: Configured
user2 $ ls /tmp | grep minikube
minikube_status_fb2feb4a2226806e2b4f9a77bad9875c0572b6ed_0.log
```
After:
User 1:
```
user1 $ minikube status
minikube
type: Control Plane
host: Running
kubelet: Running
apiserver: Running
kubeconfig: Configured
```
User 2:
```
user2 $ minikube status
minikube
type: Control Plane
host: Running
kubelet: Running
apiserver: Running
kubeconfig: Configured
user2 $ ls /tmp | grep minikube
minikube_status_00ea4c7fceaa4b61415be366d142d0847ccfce39_0.log
minikube_status_5d806d243961aaef0f535b5f4fe45369b3dd90ac_0.log
```