### PR TITLE
change authentication for jenkins job

### DIFF
--- a/hack/jenkins/minikube_set_pending.sh
+++ b/hack/jenkins/minikube_set_pending.sh
@@ -69,8 +69,8 @@ function retry_github_status() {
 
   while [[ "${attempt}" -lt 8 ]]; do
     local out=$(mktemp)
-    code=$(curl -o "${out}" -s --write-out "%{http_code}" -L \
-      "https://api.github.com/repos/kubernetes/minikube/statuses/${commit}?access_token=${token}" \
+    code=$(curl -o "${out}" -s --write-out "%{http_code}" -L  -u minikube-bot:$token \
+      "https://api.github.com/repos/kubernetes/minikube/statuses/${commit}" \
       -H "Content-Type: application/json" \
       -X POST \
       -d "{\"state\": \"${state}\", \"description\": \"Jenkins\", \"target_url\": \"${target}\", \"context\": \"${context}\"}" || echo 999)


### PR DESCRIPTION
We're getting the following error updating github statuses:
```
{
 "message": "Must specify access token via Authorization header. https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param",
   "documentation_url": "https://docs.github.com/v3/#oauth2-token-sent-in-a-header"
 }
```

so I'm switching how we authenticate our API calls to github