### PR TITLE
Implement target node option for cp command

### DIFF
--- a/pkg/minikube/machine/ssh.go
+++ b/pkg/minikube/machine/ssh.go
@@ -28,7 +28,8 @@ import (
 	"k8s.io/minikube/pkg/minikube/config"
 )
 
-func getHost(api libmachine.API, cc config.ClusterConfig, n config.Node) (*host.Host, error) {
+// GetHost find node's host information by name in the given cluster.
+func GetHost(api libmachine.API, cc config.ClusterConfig, n config.Node) (*host.Host, error) {
 	machineName := config.MachineName(cc, n)
 	host, err := LoadHost(api, machineName)
 	if err != nil {
@@ -49,7 +50,7 @@ func getHost(api libmachine.API, cc config.ClusterConfig, n config.Node) (*host.
 
 // CreateSSHShell creates a new SSH shell / client
 func CreateSSHShell(api libmachine.API, cc config.ClusterConfig, n config.Node, args []string, native bool) error {
-	host, err := getHost(api, cc, n)
+	host, err := GetHost(api, cc, n)
 	if err != nil {
 		return err
 	}
@@ -70,7 +71,7 @@ func CreateSSHShell(api libmachine.API, cc config.ClusterConfig, n config.Node, 
 
 // GetSSHHostAddrPort returns the host address and port for ssh
 func GetSSHHostAddrPort(api libmachine.API, cc config.ClusterConfig, n config.Node) (string, int, error) {
-	host, err := getHost(api, cc, n)
+	host, err := GetHost(api, cc, n)
 	if err != nil {
 		return "", 0, err
 	}

--- a/site/content/en/docs/commands/cp.md
+++ b/site/content/en/docs/commands/cp.md
@@ -13,10 +13,11 @@ Copy the specified file into minikube
 
 Copy the specified file into minikube, it will be saved at path <target file absolute path> in your minikube.
 Example Command : "minikube cp a.txt /home/docker/b.txt"
+                  "minikube cp a.txt minikube-m02:/home/docker/b.txt"
 
 
 ```shell
-minikube cp <source file path> <target file absolute path> [flags]
+minikube cp <source file path> <target node name>:<target file absolute path> [flags]
 ```
 
 ### Options inherited from parent commands

--- a/site/content/en/docs/contrib/tests.en.md
+++ b/site/content/en/docs/contrib/tests.en.md
@@ -241,6 +241,9 @@ uses the minikube node add command to add a node to an existing cluster
 #### validateProfileListWithMultiNode
 make sure minikube profile list outputs correct with multinode clusters
 
+#### validateCopyFileWithMultiNode
+validateProfileListWithMultiNode make sure minikube profile list outputs correct with multinode clusters
+
 #### validateStopRunningNode
 tests the minikube node stop command
 
@@ -357,4 +360,4 @@ upgrades Kubernetes from oldest to newest
 ## TestMissingContainerUpgrade
 tests a Docker upgrade where the underlying container is missing
 
-TEST COUNT: 114
+TEST COUNT: 115

--- a/translations/de.json
+++ b/translations/de.json
@@ -98,7 +98,7 @@
 	"Consider increasing Docker Desktop's memory size.": "",
 	"Continuously listing/getting the status with optional interval duration.": "",
 	"Copy the specified file into minikube": "",
-	"Copy the specified file into minikube, it will be saved at path \u003ctarget file absolute path\u003e in your minikube.\\nExample Command : \\\"minikube cp a.txt /home/docker/b.txt\\\"\\n": "",
+	"Copy the specified file into minikube, it will be saved at path \u003ctarget file absolute path\u003e in your minikube.\\nExample Command : \\\"minikube cp a.txt /home/docker/b.txt\\\"\\n                  \\\"minikube cp a.txt minikube-m02:/home/docker/b.txt\\\"\\n": "",
 	"Could not determine a Google Cloud project, which might be ok.": "",
 	"Could not find any GCP credentials. Either run `gcloud auth application-default login` or set the GOOGLE_APPLICATION_CREDENTIALS environment variable to the path of your credentials file.": "",
 	"Could not process error from failed deletion": "",

--- a/translations/es.json
+++ b/translations/es.json
@@ -99,7 +99,7 @@
 	"Consider increasing Docker Desktop's memory size.": "Considera incrementar la memoria asignada a Docker Desktop",
 	"Continuously listing/getting the status with optional interval duration.": "",
 	"Copy the specified file into minikube": "",
-	"Copy the specified file into minikube, it will be saved at path \u003ctarget file absolute path\u003e in your minikube.\\nExample Command : \\\"minikube cp a.txt /home/docker/b.txt\\\"\\n": "",
+	"Copy the specified file into minikube, it will be saved at path \u003ctarget file absolute path\u003e in your minikube.\\nExample Command : \\\"minikube cp a.txt /home/docker/b.txt\\\"\\n                  \\\"minikube cp a.txt minikube-m02:/home/docker/b.txt\\\"\\n": "",
 	"Could not determine a Google Cloud project, which might be ok.": "No se pudo determinar un proyecto de Google Cloud que podría estar bien.",
 	"Could not find any GCP credentials. Either run `gcloud auth application-default login` or set the GOOGLE_APPLICATION_CREDENTIALS environment variable to the path of your credentials file.": "No se puedo encontrar ninguna credencial de GCP. Corre `gcloud auth application-default login` o establezca la variable de entorno GOOGLE_APPLICATION_CREDENTIALS en la ruta de su archivo de credentiales.",
 	"Could not process error from failed deletion": "No se pudo procesar el error de la eliminación fallida",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -100,7 +100,7 @@
 	"Consider increasing Docker Desktop's memory size.": "",
 	"Continuously listing/getting the status with optional interval duration.": "",
 	"Copy the specified file into minikube": "",
-	"Copy the specified file into minikube, it will be saved at path \u003ctarget file absolute path\u003e in your minikube.\\nExample Command : \\\"minikube cp a.txt /home/docker/b.txt\\\"\\n": "",
+	"Copy the specified file into minikube, it will be saved at path \u003ctarget file absolute path\u003e in your minikube.\\nExample Command : \\\"minikube cp a.txt /home/docker/b.txt\\\"\\n                  \\\"minikube cp a.txt minikube-m02:/home/docker/b.txt\\\"\\n": "",
 	"Could not determine a Google Cloud project, which might be ok.": "",
 	"Could not find any GCP credentials. Either run `gcloud auth application-default login` or set the GOOGLE_APPLICATION_CREDENTIALS environment variable to the path of your credentials file.": "",
 	"Could not process error from failed deletion": "",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -97,7 +97,7 @@
 	"Consider increasing Docker Desktop's memory size.": "",
 	"Continuously listing/getting the status with optional interval duration.": "",
 	"Copy the specified file into minikube": "",
-	"Copy the specified file into minikube, it will be saved at path \u003ctarget file absolute path\u003e in your minikube.\\nExample Command : \\\"minikube cp a.txt /home/docker/b.txt\\\"\\n": "",
+	"Copy the specified file into minikube, it will be saved at path \u003ctarget file absolute path\u003e in your minikube.\\nExample Command : \\\"minikube cp a.txt /home/docker/b.txt\\\"\\n                  \\\"minikube cp a.txt minikube-m02:/home/docker/b.txt\\\"\\n": "",
 	"Could not determine a Google Cloud project, which might be ok.": "",
 	"Could not find any GCP credentials. Either run `gcloud auth application-default login` or set the GOOGLE_APPLICATION_CREDENTIALS environment variable to the path of your credentials file.": "",
 	"Could not process error from failed deletion": "",

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -106,7 +106,7 @@
 	"Consider increasing Docker Desktop's memory size.": "",
 	"Continuously listing/getting the status with optional interval duration.": "",
 	"Copy the specified file into minikube": "",
-	"Copy the specified file into minikube, it will be saved at path \u003ctarget file absolute path\u003e in your minikube.\\nExample Command : \\\"minikube cp a.txt /home/docker/b.txt\\\"\\n": "",
+	"Copy the specified file into minikube, it will be saved at path \u003ctarget file absolute path\u003e in your minikube.\\nExample Command : \\\"minikube cp a.txt /home/docker/b.txt\\\"\\n                  \\\"minikube cp a.txt minikube-m02:/home/docker/b.txt\\\"\\n": "",
 	"Could not determine a Google Cloud project, which might be ok.": "",
 	"Could not find any GCP credentials. Either run `gcloud auth application-default login` or set the GOOGLE_APPLICATION_CREDENTIALS environment variable to the path of your credentials file.": "",
 	"Could not process error from failed deletion": "",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -104,7 +104,7 @@
 	"Consider increasing Docker Desktop's memory size.": "",
 	"Continuously listing/getting the status with optional interval duration.": "",
 	"Copy the specified file into minikube": "",
-	"Copy the specified file into minikube, it will be saved at path \u003ctarget file absolute path\u003e in your minikube.\\nExample Command : \\\"minikube cp a.txt /home/docker/b.txt\\\"\\n": "",
+	"Copy the specified file into minikube, it will be saved at path \u003ctarget file absolute path\u003e in your minikube.\\nExample Command : \\\"minikube cp a.txt /home/docker/b.txt\\\"\\n                  \\\"minikube cp a.txt minikube-m02:/home/docker/b.txt\\\"\\n": "",
 	"Could not determine a Google Cloud project, which might be ok.": "",
 	"Could not find any GCP credentials. Either run `gcloud auth application-default login` or set the GOOGLE_APPLICATION_CREDENTIALS environment variable to the path of your credentials file.": "",
 	"Could not process error from failed deletion": "",

--- a/translations/strings.txt
+++ b/translations/strings.txt
@@ -94,7 +94,7 @@
 	"Consider increasing Docker Desktop's memory size.": "",
 	"Continuously listing/getting the status with optional interval duration.": "",
 	"Copy the specified file into minikube": "",
-	"Copy the specified file into minikube, it will be saved at path \u003ctarget file absolute path\u003e in your minikube.\\nExample Command : \\\"minikube cp a.txt /home/docker/b.txt\\\"\\n": "",
+	"Copy the specified file into minikube, it will be saved at path \u003ctarget file absolute path\u003e in your minikube.\\nExample Command : \\\"minikube cp a.txt /home/docker/b.txt\\\"\\n                  \\\"minikube cp a.txt minikube-m02:/home/docker/b.txt\\\"\\n": "",
 	"Could not determine a Google Cloud project, which might be ok.": "",
 	"Could not find any GCP credentials. Either run `gcloud auth application-default login` or set the GOOGLE_APPLICATION_CREDENTIALS environment variable to the path of your credentials file.": "",
 	"Could not process error from failed deletion": "",

--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -121,7 +121,7 @@
 	"Consider increasing Docker Desktop's memory size.": "",
 	"Continuously listing/getting the status with optional interval duration.": "",
 	"Copy the specified file into minikube": "",
-	"Copy the specified file into minikube, it will be saved at path \u003ctarget file absolute path\u003e in your minikube.\\nExample Command : \\\"minikube cp a.txt /home/docker/b.txt\\\"\\n": "",
+	"Copy the specified file into minikube, it will be saved at path \u003ctarget file absolute path\u003e in your minikube.\\nExample Command : \\\"minikube cp a.txt /home/docker/b.txt\\\"\\n                  \\\"minikube cp a.txt minikube-m02:/home/docker/b.txt\\\"\\n": "",
 	"Could not determine a Google Cloud project, which might be ok.": "",
 	"Could not find any GCP credentials. Either run `gcloud auth application-default login` or set the GOOGLE_APPLICATION_CREDENTIALS environment variable to the path of your credentials file.": "",
 	"Could not get profile flag": "无法获取配置文件标志",


### PR DESCRIPTION
fixes #11146

before
```
Copy the specified file into minikube, it will be saved at path <target file absolute path> in your minikube.
Example Command : "minikube cp a.txt /home/docker/b.txt"

Usage:
  minikube cp <source file path> <target file absolute path> [flags] [options]

Use "minikube options" for a list of global command-line options (applies to all commands).
```

after
```
Copy the specified file into minikube, it will be saved at path <target file absolute path> in your minikube.
Example Command : "minikube cp a.txt /home/docker/b.txt"
                  "minikube cp a.txt minikube-m02:/home/docker/b.txt"

Usage:
  minikube cp <source file path> <target node name>:<target file absolute path> [flags] [options]

Use "minikube options" for a list of global command-line options (applies to all commands).
```