### PR TITLE
docker driver: relax version constraint

### DIFF
--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -166,6 +166,9 @@ func checkDockerVersion(o string) registry.State {
 		}
 	}
 
+	hintInstallOfficial := fmt.Sprintf("Install the official release of %s (Minimum recommended version is %2d.%02d.%d, current version is %s)",
+		driver.FullName(driver.Docker), minDockerVersion[0], minDockerVersion[1], minDockerVersion[2], parts[1])
+
 	p := strings.SplitN(parts[1], ".", 3)
 	switch l := len(p); l {
 	case 2:
@@ -174,12 +177,13 @@ func checkDockerVersion(o string) registry.State {
 		// remove postfix string for unstable(test/nightly) channel. https://docs.docker.com/engine/install/
 		p[2] = strings.SplitN(p[2], "-", 2)[0]
 	default:
+		// When Docker (Moby) was installed from the source code, the version string is typically set to "dev", or "library-import".
 		return registry.State{
-			Reason:    "PROVIDER_DOCKER_VERSION_PARSING_FAILED",
-			Error:     errors.Errorf("expected version format is \"<year>.<month>.{patch}\". but got %s", parts[1]),
-			Installed: true,
-			Healthy:   false,
-			Doc:       docURL,
+			Installed:        true,
+			Healthy:          true,
+			NeedsImprovement: true,
+			Fix:              hintInstallOfficial,
+			Doc:              docURL,
 		}
 	}
 
@@ -187,11 +191,11 @@ func checkDockerVersion(o string) registry.State {
 		k, err := strconv.Atoi(s)
 		if err != nil {
 			return registry.State{
-				Reason:    "PROVIDER_DOCKER_VERSION_PARSING_FAILED",
-				Error:     errors.Wrap(err, "docker version"),
-				Installed: true,
-				Healthy:   false,
-				Doc:       docURL,
+				Installed:        true,
+				Healthy:          true,
+				NeedsImprovement: true,
+				Fix:              hintInstallOfficial,
+				Doc:              docURL,
 			}
 		}
 

--- a/pkg/minikube/registry/drvs/docker/docker_test.go
+++ b/pkg/minikube/registry/drvs/docker/docker_test.go
@@ -18,11 +18,13 @@ package docker
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 )
 
 type testCase struct {
-	version, expect string
+	version, expect   string
+	expectFixContains string
 }
 
 func appendVersionVariations(tc []testCase, v []int, reason string) []testCase {
@@ -81,12 +83,41 @@ func TestCheckDockerVersion(t *testing.T) {
 		tc = appendVersionVariations(tc, v, "PROVIDER_DOCKER_VERSION_LOW")
 	}
 
+	tc = append(tc, []testCase{
+		{
+			// "dev" is set when Docker (Moby) was installed with `make binary && make install`
+			version: "linux-dev",
+			expect:  "",
+			expectFixContains: fmt.Sprintf("Install the official release of Docker (Minimum recommended version is %02d.%02d.%d, current version is dev)",
+				minDockerVersion[0], minDockerVersion[1], minDockerVersion[2]),
+		},
+		{
+			// "library-import" is set when Docker (Moby) was installed with `go build github.com/docker/docker/cmd/dockerd` (unrecommended, but valid)
+			version: "linux-library-import",
+			expect:  "",
+			expectFixContains: fmt.Sprintf("Install the official release of Docker (Minimum recommended version is %02d.%02d.%d, current version is library-import)",
+				minDockerVersion[0], minDockerVersion[1], minDockerVersion[2]),
+		},
+		{
+			// "foo.bar.baz" is a triplet that cannot be parsed as "%02d.%02d.%d"
+			version: "linux-foo.bar.baz",
+			expect:  "",
+			expectFixContains: fmt.Sprintf("Install the official release of Docker (Minimum recommended version is %02d.%02d.%d, current version is foo.bar.baz)",
+				minDockerVersion[0], minDockerVersion[1], minDockerVersion[2]),
+		},
+	}...)
+
 	for _, c := range tc {
 		t.Run("checkDockerVersion test", func(t *testing.T) {
 			s := checkDockerVersion(c.version)
 			if s.Error != nil {
 				if c.expect != s.Reason {
 					t.Errorf("Error %v expected. but got %q. (version string : %s)", c.expect, s.Reason, c.version)
+				}
+			}
+			if c.expectFixContains != "" {
+				if !strings.Contains(s.Fix, c.expectFixContains) {
+					t.Errorf("Error expected Fix to contain %q, but got %q", c.expectFixContains, s.Fix)
 				}
 			}
 		})

--- a/pkg/minikube/registry/drvs/docker/docker_test.go
+++ b/pkg/minikube/registry/drvs/docker/docker_test.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 /*
 Copyright 2019 The Kubernetes Authors All rights reserved.
 


### PR DESCRIPTION
When Docker (Moby) was installed from the source code, the version string is typically set to ["dev"](https://github.com/moby/moby/blob/v20.10.6/hack/make.sh#L42), or ["library-import"](https://github.com/moby/moby/blob/v20.10.6/dockerversion/version_lib.go#L10).

Previously, minikube could not start with these versions.

--- 
Before:
```console
$ minikube start --driver=docker
* minikube v1.20.0 on Ubuntu 21.04
* Using the docker driver based on user configuration

X Exiting due to PROVIDER_DOCKER_NOT_RUNNING: expected version format is "<year>.<month>.{patch}". but got dev
* Documentation: https://minikube.sigs.k8s.io/docs/drivers/docker/
```

After:
```console
$ minikube start --driver=docker
 ...
* minikube v1.20.0 on Ubuntu 21.04
* Using the docker driver based on existing profile
! For improved Docker performance, Install the official release of Docker (Minimum recommended version is 18.09.0, current version is dev)
* Starting control plane node minikube in cluster minikube
...
 ```