### PR TITLE
Fix output for autopause issue link

### DIFF
--- a/pkg/addons/addons_autopause.go
+++ b/pkg/addons/addons_autopause.go
@@ -41,7 +41,7 @@ func enableOrDisableAutoPause(cc *config.ClusterConfig, name string, val string)
 		return errors.Wrapf(err, "parsing bool: %s", name)
 	}
 	out.Infof("auto-pause addon is an alpha feature and still in early development. Please file issues to help us make it better.")
-	out.Infof("https://github.com/kubernetes/minikube/labels/co%2Fauto-pause")
+	out.Infof("https://github.com/kubernetes/minikube/labels/co/auto-pause")
 
 	if cc.KubernetesConfig.ContainerRuntime != "docker" || runtime.GOARCH != "amd64" {
 		exit.Message(reason.Usage, `auto-pause currently is only supported on docker runtime and amd64. Track progress of others here: https://github.com/kubernetes/minikube/issues/10601`)


### PR DESCRIPTION
The autopause reporting link includes a `%` which is interpreted as a format flag.  Note the `co%!F(MISSING)`:
```
$ minikube addons enable auto-pause
    ▪ Using image gcr.io/k8s-minikube/auto-pause-hook:v0.0.2
    ▪ auto-pause addon is an alpha feature and still in early development. Please file issues to help us make it better.
    ▪ https://github.com/kubernetes/minikube/labels/co%!F(MISSING)auto-pause
🌟  The 'auto-pause' addon is enabled
```

After:
```
    ▪ auto-pause addon is an alpha feature and still in early development. Please file issues to help us make it better.
    ▪ https://github.com/kubernetes/minikube/labels/co/auto-pause
```

The `%2F` doesn't seem to be necessary.