### PR TITLE
docs: fix format issue for Contributor Guide

### DIFF
--- a/site/content/en/docs/contrib/guide.en.md
+++ b/site/content/en/docs/contrib/guide.en.md
@@ -19,7 +19,7 @@ We'd love to accept your patches! Before we can take them, [please fill out eith
 
 * ["good first issue"](https://github.com/kubernetes/minikube/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)  -  issues where there is a clear path to resolution
 * ["help wanted"](https://github.com/kubernetes/minikube/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22+) - issues where we've identified a need but not resources to work on them
-"priority/important-soon" or "priority/important-longterm: - high impact issues that need to be addressed in the next couple of releases.
+* ["priority/important-soon"](https://github.com/kubernetes/minikube/issues?q=is%3Aopen+is%3Aissue+label%3Apriority%2Fimportant-soon) or ["priority/important-longterm"](https://github.com/kubernetes/minikube/issues?q=is%3Aopen+is%3Aissue+label%3Apriority%2Fimportant-longterm) - high impact issues that need to be addressed in the next couple of releases.
 
 * Ask on the #minikube Slack if you aren't sure
 


### PR DESCRIPTION
Hi,

This PR fixes the format issue for the Contributor Guide.

Before:
![docs-before](https://user-images.githubusercontent.com/1311594/117513500-d679ea00-af5f-11eb-8759-98b66aad1ccc.png)
After:
![docs-after](https://user-images.githubusercontent.com/1311594/117513505-d8dc4400-af5f-11eb-86d4-f536ae78f193.png)

Thanks!