### PR TITLE
unify integration test names for uploading

### DIFF
--- a/hack/jenkins/upload_integration_report.sh
+++ b/hack/jenkins/upload_integration_report.sh
@@ -24,11 +24,9 @@
 set -x
 
 # upload results to GCS
-if [[ -z "${FILE_NAME}" ]]; then
-	FILE_NAME=${UPSTREAM_JOB}
-fi
+UPSTREAM_JOB=${UPSTREAM_JOB%"_integration"}
 
-JOB_GCS_BUCKET="minikube-builds/logs/${MINIKUBE_LOCATION}/${COMMIT:0:7}/${FILE_NAME}"
+JOB_GCS_BUCKET="minikube-builds/logs/${MINIKUBE_LOCATION}/${COMMIT:0:7}/${UPSTREAM_JOB}"
 
 ARTIFACTS=artifacts/test_reports
 


### PR DESCRIPTION
This will allow gopogh links for hyperkit and docker macos jobs to be formed properly.