### PR TITLE
docs: fix sidebar current page highlight issue

### DIFF
--- a/site/layouts/partials/sidebar-tree.html
+++ b/site/layouts/partials/sidebar-tree.html
@@ -85,7 +85,7 @@
           <!-- always show pages in the current section -->
           {{ if $activeSection }}
               {{ $showPage = true }}
-              {{ $activePage := eq . $p }}
+              {{ $activePage = eq . $p }}
           {{ end }}
 
          <!-- show handbook unless we are in a very long section -->


### PR DESCRIPTION
Fixes the issue where the sidebar doesn't support highlight on the selected page.

| Before                                                                                                          | After                                                                                                          |
|-----------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
| ![Before](https://user-images.githubusercontent.com/1311594/117516174-5dca5c00-af66-11eb-880e-2c0ff8e12e8c.gif) | ![After](https://user-images.githubusercontent.com/1311594/117516167-599e3e80-af66-11eb-8f68-d6ac9e5fda73.gif) |

Thanks!