### PR TITLE
cmd: warn user about global config when given profile name

### DIFF
--- a/cmd/minikube/cmd/config/set.go
+++ b/cmd/minikube/cmd/config/set.go
@@ -36,7 +36,10 @@ var configSetCmd = &cobra.Command{
 			exit.Message(reason.Usage, "not enough arguments ({{.ArgCount}}).\nusage: minikube config set PROPERTY_NAME PROPERTY_VALUE", out.V{"ArgCount": len(args)})
 		}
 		if len(args) > 2 {
-			exit.Message(reason.Usage, "toom any arguments ({{.ArgCount}}).\nusage: minikube config set PROPERTY_NAME PROPERTY_VALUE", out.V{"ArgCount": len(args)})
+			exit.Message(reason.Usage, "too many arguments ({{.ArgCount}}).\nusage: minikube config set PROPERTY_NAME PROPERTY_VALUE", out.V{"ArgCount": len(args)})
+		}
+		if cmd.Flags().Lookup(config.ProfileName).Changed {
+			exit.Message(reason.Usage, "Persistent config is global. Setting a specific profile name is not allowed.")
 		}
 		err := Set(args[0], args[1])
 		if err != nil {

--- a/cmd/minikube/cmd/config/set.go
+++ b/cmd/minikube/cmd/config/set.go
@@ -40,7 +40,7 @@ These values can be overwritten by flags or environment variables at runtime.`,
 			exit.Message(reason.Usage, "too many arguments ({{.ArgCount}}).\nusage: minikube config set PROPERTY_NAME PROPERTY_VALUE", out.V{"ArgCount": len(args)})
 		}
 		if cmd.Flags().Lookup(config.ProfileName).Changed {
-			exit.Message(reason.Usage, "Persistent config is global. Setting a specific profile name is not allowed.")
+			out.BoxedErr("Persistent config is global. Setting a specific profile name for global config is ignored.")
 		}
 		err := Set(args[0], args[1])
 		if err != nil {

--- a/cmd/minikube/cmd/config/set.go
+++ b/cmd/minikube/cmd/config/set.go
@@ -30,7 +30,8 @@ var configSetCmd = &cobra.Command{
 	Use:   "set PROPERTY_NAME PROPERTY_VALUE",
 	Short: "Sets an individual value in a minikube config file",
 	Long: `Sets the PROPERTY_NAME config value to PROPERTY_VALUE
-	These values can be overwritten by flags or environment variables at runtime.`,
+Config values are global and will be applied to all profiles.
+These values can be overwritten by flags or environment variables at runtime.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 2 {
 			exit.Message(reason.Usage, "not enough arguments ({{.ArgCount}}).\nusage: minikube config set PROPERTY_NAME PROPERTY_VALUE", out.V{"ArgCount": len(args)})

--- a/site/content/en/docs/commands/config.md
+++ b/site/content/en/docs/commands/config.md
@@ -189,7 +189,8 @@ Sets an individual value in a minikube config file
 ### Synopsis
 
 Sets the PROPERTY_NAME config value to PROPERTY_VALUE
-	These values can be overwritten by flags or environment variables at runtime.
+Config values are global and will be applied to all profiles.
+These values can be overwritten by flags or environment variables at runtime.
 
 ```shell
 minikube config set PROPERTY_NAME PROPERTY_VALUE [flags]

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -1035,13 +1035,14 @@ func validateConfigCmd(ctx context.Context, t *testing.T, profile string) {
 		{[]string{"unset", "cpus"}, "", ""},
 		{[]string{"get", "cpus"}, "", "Error: specified key could not be found in config"},
 		{[]string{"set", "cpus", "2"}, "", "! These changes will take effect upon a minikube delete and then a minikube start"},
+		{[]string{"-p", profile, "set", "cpus", "2"}, "", "X Exiting due to MK_USAGE: Persistent config is global. Setting a specific profile name is not allowed."},
 		{[]string{"get", "cpus"}, "2", ""},
 		{[]string{"unset", "cpus"}, "", ""},
 		{[]string{"get", "cpus"}, "", "Error: specified key could not be found in config"},
 	}
 
 	for _, tc := range tests {
-		args := append([]string{"-p", profile, "config"}, tc.args...)
+		args := append([]string{"config"}, tc.args...)
 		rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 		if err != nil && tc.wantErr == "" {
 			t.Errorf("failed to config minikube. args %q : %v", rr.Command(), err)

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -1035,7 +1035,7 @@ func validateConfigCmd(ctx context.Context, t *testing.T, profile string) {
 		{[]string{"unset", "cpus"}, "", ""},
 		{[]string{"get", "cpus"}, "", "Error: specified key could not be found in config"},
 		{[]string{"set", "cpus", "2"}, "", "! These changes will take effect upon a minikube delete and then a minikube start"},
-		{[]string{"-p", profile, "set", "cpus", "2"}, "", "X Exiting due to MK_USAGE: Persistent config is global. Setting a specific profile name is not allowed."},
+		{[]string{"-p", profile, "set", "cpus", "2"}, "", "Persistent config is global. Setting a specific profile name for global config is ignored."},
 		{[]string{"get", "cpus"}, "2", ""},
 		{[]string{"unset", "cpus"}, "", ""},
 		{[]string{"get", "cpus"}, "", "Error: specified key could not be found in config"},
@@ -1049,11 +1049,11 @@ func validateConfigCmd(ctx context.Context, t *testing.T, profile string) {
 		}
 
 		got := strings.TrimSpace(rr.Stdout.String())
-		if got != tc.wantOut {
+		if !strings.Contains(got, tc.wantOut) {
 			t.Errorf("expected config output for %q to be -%q- but got *%q*", rr.Command(), tc.wantOut, got)
 		}
 		got = strings.TrimSpace(rr.Stderr.String())
-		if got != tc.wantErr {
+		if !strings.Contains(got, tc.wantErr) {
 			t.Errorf("expected config error for %q to be -%q- but got *%q*", rr.Command(), tc.wantErr, got)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Peixuan Ding <dingpeixuan911@gmail.com>

Hi, this one fixes #11343 

It basically returns an error when `--profile` is given.

Let me know if we should just throw a warning message instead. Thanks!

![Screenshot from 2021-05-08 01-27-10](https://user-images.githubusercontent.com/1311594/117527781-8a996600-af9c-11eb-87b1-8617765e9c33.png)

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
