### PR TITLE
Switch place of minikube image ls and list

### DIFF
--- a/cmd/minikube/cmd/image.go
+++ b/cmd/minikube/cmd/image.go
@@ -152,7 +152,7 @@ $ minikube image rm image busybox
 $ minikube image unload image busybox
 `,
 	Args:    cobra.MinimumNArgs(1),
-	Aliases: []string{"unload"},
+	Aliases: []string{"remove", "unload"},
 	Run: func(cmd *cobra.Command, args []string) {
 		profile, err := config.LoadProfile(viper.GetString(config.ProfileName))
 		if err != nil {
@@ -226,12 +226,12 @@ var buildImageCmd = &cobra.Command{
 }
 
 var listImageCmd = &cobra.Command{
-	Use:   "list",
+	Use:   "ls",
 	Short: "List images",
 	Example: `
-$ minikube image list
+$ minikube image ls
 `,
-	Aliases: []string{"ls"},
+	Aliases: []string{"list"},
 	Run: func(cmd *cobra.Command, args []string) {
 		profile, err := config.LoadProfile(viper.GetString(config.ProfileName))
 		if err != nil {

--- a/site/content/en/docs/commands/image.md
+++ b/site/content/en/docs/commands/image.md
@@ -120,52 +120,6 @@ minikube image help [command] [flags]
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
 ```
 
-## minikube image list
-
-List images
-
-### Synopsis
-
-List images
-
-```shell
-minikube image list [flags]
-```
-
-### Aliases
-
-[ls]
-
-### Examples
-
-```
-
-$ minikube image list
-
-```
-
-### Options inherited from parent commands
-
-```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files
-  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
-  -h, --help                             
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory
-      --log_file string                  If non-empty, use this log file
-      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level)
-  -p, --profile string                   The name of the minikube VM being used. This can be set to allow having multiple instances of minikube independently. (default "minikube")
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files
-      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
-      --user string                      Specifies the user executing the operation. Useful for auditing operations executed by 3rd party tools. Defaults to the operating system username.
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
-```
-
 ## minikube image load
 
 Load a image into minikube
@@ -215,6 +169,52 @@ minikube image load image.tar
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
 ```
 
+## minikube image ls
+
+List images
+
+### Synopsis
+
+List images
+
+```shell
+minikube image ls [flags]
+```
+
+### Aliases
+
+[list]
+
+### Examples
+
+```
+
+$ minikube image ls
+
+```
+
+### Options inherited from parent commands
+
+```
+      --add_dir_header                   If true, adds the file directory to the header of the log messages
+      --alsologtostderr                  log to standard error as well as files
+  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
+  -h, --help                             
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --log_file string                  If non-empty, use this log file
+      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+      --logtostderr                      log to standard error instead of files
+      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level)
+  -p, --profile string                   The name of the minikube VM being used. This can be set to allow having multiple instances of minikube independently. (default "minikube")
+      --skip_headers                     If true, avoid header prefixes in the log messages
+      --skip_log_headers                 If true, avoid headers when opening log files
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+      --user string                      Specifies the user executing the operation. Useful for auditing operations executed by 3rd party tools. Defaults to the operating system username.
+  -v, --v Level                          number for the log level verbosity
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+```
+
 ## minikube image rm
 
 Remove one or more images
@@ -229,7 +229,7 @@ minikube image rm IMAGE [IMAGE...] [flags]
 
 ### Aliases
 
-[unload]
+[remove unload]
 
 ### Examples
 


### PR DESCRIPTION
Just to make it more similar to the docker image commands.

Both ls/list and rm/remove are equivalent commands, though.
