### PR TITLE
Add missing arm64 tarballs to the release page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -595,7 +595,9 @@ out/repodata/repomd.xml: out/minikube-$(RPM_VERSION).rpm
 
 .SECONDEXPANSION:
 TAR_TARGETS_linux-amd64   := out/minikube-linux-amd64 out/docker-machine-driver-kvm2
+TAR_TARGETS_linux-arm64   := out/minikube-linux-arm64 #out/docker-machine-driver-kvm2
 TAR_TARGETS_darwin-amd64  := out/minikube-darwin-amd64 out/docker-machine-driver-hyperkit
+TAR_TARGETS_darwin-arm64  := out/minikube-darwin-arm64 #out/docker-machine-driver-hyperkit
 TAR_TARGETS_windows-amd64 := out/minikube-windows-amd64.exe
 out/minikube-%.tar.gz: $$(TAR_TARGETS_$$*)
 	$(if $(quiet),@echo "  TAR      $@")

--- a/hack/jenkins/release_build_and_upload.sh
+++ b/hack/jenkins/release_build_and_upload.sh
@@ -48,7 +48,10 @@ make verify-iso
 env BUILD_IN_DOCKER=y \
   make -j 16 \
   all \
+  out/minikube-linux-arm64 \
+  out/minikube-linux-arm64.tar.gz \
   out/minikube-darwin-arm64 \
+  out/minikube-darwin-arm64.tar.gz \
   out/minikube-installer.exe \
   "out/minikube_${DEB_VERSION}-${DEB_REVISION}_amd64.deb" \
   "out/minikube_${DEB_VERSION}-${DEB_REVISION}_arm64.deb" \


### PR DESCRIPTION
These files were missing from the installation page:
* minikube-linux-arm64.tar.gz
* minikube-darwin-arm64.tar.gz

They are used by some packaging, like the `0install`

The arm64 build targets for the drivers are currently missing, (#9805)
but they should be downloaded at runtime anyway so exclude them.
