### PR TITLE
Use upgrade instead of install for the RPM installation

### DIFF
--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -46,7 +46,7 @@ sudo dpkg -i minikube_latest_amd64.deb
 
 ```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest.x86_64.rpm
-sudo rpm -ivh minikube-latest.x86_64.rpm
+sudo rpm -Uvh minikube-latest.x86_64.rpm
 ```
 
 ### arm64 / aarch64
@@ -69,7 +69,7 @@ sudo dpkg -i minikube_latest_arm64.deb
 
 ```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest.aarch64.rpm
-sudo rpm -ivh minikube-latest.aarch64.rpm
+sudo rpm -Uvh minikube-latest.aarch64.rpm
 ```
 
 {{% /linuxtab %}}


### PR DESCRIPTION
-U installs or upgrades the package currently installed to a newer version, so it might be preferable to -i.
