### PR TITLE
Sort rejected drivers by their preference order

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -28,6 +28,7 @@ import (
 	"os/user"
 	"regexp"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -589,7 +590,11 @@ func selectDriver(existing *config.ClusterConfig) (registry.DriverState, []regis
 	pick, alts, rejects := driver.Suggest(choices)
 	if pick.Name == "" {
 		out.Step(style.ThumbsDown, "Unable to pick a default driver. Here is what was considered, in preference order:")
+		sort.Slice(rejects, func(i, j int) bool { return rejects[i].Priority > rejects[j].Priority })
 		for _, r := range rejects {
+			if !r.Default {
+				continue
+			}
 			out.Infof("{{ .name }}: {{ .rejection }}", out.V{"name": r.Name, "rejection": r.Rejection})
 			if r.Suggestion != "" {
 				out.Infof("{{ .name }}: Suggestion: {{ .suggestion}}", out.V{"name": r.Name, "suggestion": r.Suggestion})

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -590,7 +590,12 @@ func selectDriver(existing *config.ClusterConfig) (registry.DriverState, []regis
 	pick, alts, rejects := driver.Suggest(choices)
 	if pick.Name == "" {
 		out.Step(style.ThumbsDown, "Unable to pick a default driver. Here is what was considered, in preference order:")
-		sort.Slice(rejects, func(i, j int) bool { return rejects[i].Priority > rejects[j].Priority })
+		sort.Slice(rejects, func(i, j int) bool {
+			if rejects[i].Priority == rejects[j].Priority {
+				return rejects[i].Preference > rejects[j].Preference
+			}
+			return rejects[i].Priority > rejects[j].Priority
+		})
 		for _, r := range rejects {
 			if !r.Default {
 				continue

--- a/pkg/minikube/registry/global.go
+++ b/pkg/minikube/registry/global.go
@@ -66,11 +66,16 @@ var (
 
 // DriverState is metadata relating to a driver and status
 type DriverState struct {
-	Name       string
-	Default    bool
+	// Name is the name of the driver used internally
+	Name string
+	// Default drivers are selected automatically
+	Default bool
+	// Preference is the original priority from driver
 	Preference Priority
-	Priority   Priority
-	State      State
+	// Priority is the effective priority with health
+	Priority Priority
+	// State is the state of driver and dependencies
+	State State
 	// Rejection is why we chose not to use this driver
 	Rejection string
 	// Suggestion is how the user could improve health

--- a/pkg/minikube/registry/global.go
+++ b/pkg/minikube/registry/global.go
@@ -66,10 +66,11 @@ var (
 
 // DriverState is metadata relating to a driver and status
 type DriverState struct {
-	Name     string
-	Default  bool
-	Priority Priority
-	State    State
+	Name       string
+	Default    bool
+	Preference Priority
+	Priority   Priority
+	State      State
 	// Rejection is why we chose not to use this driver
 	Rejection string
 	// Suggestion is how the user could improve health
@@ -112,6 +113,7 @@ func Available(vm bool) []DriverState {
 		s := d.Status()
 		klog.Infof("%s default: %v priority: %d, state: %+v", d.Name, d.Default, d.Priority, s)
 
+		preference := d.Priority
 		priority := d.Priority
 		if !s.Healthy {
 			priority = Unhealthy
@@ -119,10 +121,10 @@ func Available(vm bool) []DriverState {
 
 		if vm {
 			if IsVM(d.Name) {
-				sts = append(sts, DriverState{Name: d.Name, Default: d.Default, Priority: priority, State: s})
+				sts = append(sts, DriverState{Name: d.Name, Default: d.Default, Preference: preference, Priority: priority, State: s})
 			}
 		} else {
-			sts = append(sts, DriverState{Name: d.Name, Default: d.Default, Priority: priority, State: s})
+			sts = append(sts, DriverState{Name: d.Name, Default: d.Default, Preference: preference, Priority: priority, State: s})
 		}
 	}
 

--- a/pkg/minikube/registry/global_test.go
+++ b/pkg/minikube/registry/global_test.go
@@ -93,16 +93,18 @@ func TestGlobalAvailable(t *testing.T) {
 
 	expected := []DriverState{
 		{
-			Name:     "healthy-bar",
-			Default:  true,
-			Priority: Default,
-			State:    State{Healthy: true},
+			Name:       "healthy-bar",
+			Default:    true,
+			Preference: Default,
+			Priority:   Default,
+			State:      State{Healthy: true},
 		},
 		{
-			Name:     "unhealthy-foo",
-			Default:  true,
-			Priority: Unhealthy,
-			State:    State{Healthy: false},
+			Name:       "unhealthy-foo",
+			Default:    true,
+			Preference: Default,
+			Priority:   Unhealthy,
+			State:      State{Healthy: false},
 		},
 	}
 


### PR DESCRIPTION
Don't show drivers not being selected by default

Closes #10009

BEFORE

* Unable to pick a default driver. Here is what was considered, in preference order:
  - vmware: Not installed: exec: "docker-machine-driver-vmware": executable file not found in $PATH
  - docker: Not installed: exec: "docker": executable file not found in $PATH
  - kvm2: Not installed: exec: "virsh": executable file not found in $PATH
  - none: Not installed: exec: "iptables": executable file not found in $PATH
  - podman: Not installed: exec: "podman": executable file not found in $PATH
  - virtualbox: Not installed: unable to find VBoxManage in $PATH


AFTER

* Unable to pick a default driver. Here is what was considered, in preference order:
  - docker: Not installed: exec: "docker": executable file not found in $PATH
  - kvm2: Not installed: exec: "virsh": executable file not found in $PATH
  - vmware: Not installed: exec: "docker-machine-driver-vmware": executable file not found in $PATH
  - podman: Not installed: exec: "podman": executable file not found in $PATH
  - virtualbox: Not installed: unable to find VBoxManage in $PATH

The priority was being clobbered for unhealthy drivers, so save original priority as "preference"