### PR TITLE
Show suggestion for rejected unhealthy drivers

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -591,6 +591,9 @@ func selectDriver(existing *config.ClusterConfig) (registry.DriverState, []regis
 		out.Step(style.ThumbsDown, "Unable to pick a default driver. Here is what was considered, in preference order:")
 		for _, r := range rejects {
 			out.Infof("{{ .name }}: {{ .rejection }}", out.V{"name": r.Name, "rejection": r.Rejection})
+			if r.Suggestion != "" {
+				out.Infof("{{ .name }}: Suggestion: {{ .suggestion}}", out.V{"name": r.Name, "suggestion": r.Suggestion})
+			}
 		}
 		exit.Message(reason.DrvNotDetected, "No possible driver was detected. Try specifying --driver, or see https://minikube.sigs.k8s.io/docs/start/")
 	}

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -289,6 +289,7 @@ func Suggest(options []registry.DriverState) (registry.DriverState, []registry.D
 
 			if !ds.State.Healthy {
 				ds.Rejection = fmt.Sprintf("Not healthy: %v", ds.State.Error)
+				ds.Suggestion = fmt.Sprintf("%s <%s>", ds.State.Fix, ds.State.Doc)
 				rejects = append(rejects, ds)
 				continue
 			}

--- a/pkg/minikube/registry/global.go
+++ b/pkg/minikube/registry/global.go
@@ -72,6 +72,8 @@ type DriverState struct {
 	State    State
 	// Rejection is why we chose not to use this driver
 	Rejection string
+	// Suggestion is how the user could improve health
+	Suggestion string
 }
 
 func (d DriverState) String() string {

--- a/translations/de.json
+++ b/translations/de.json
@@ -903,6 +903,7 @@
 	"version yaml failure": "",
 	"zsh completion failed": "",
 	"zsh completion.": "",
+	"{{ .name }}: Suggestion: {{ .suggestion}}": "",
 	"{{ .name }}: {{ .rejection }}": "",
 	"{{.Driver}} is currently using the {{.StorageDriver}} storage driver, consider switching to overlay2 for better performance": "",
 	"{{.count}} nodes stopped.": "",

--- a/translations/es.json
+++ b/translations/es.json
@@ -908,6 +908,7 @@
 	"version yaml failure": "",
 	"zsh completion failed": "",
 	"zsh completion.": "",
+	"{{ .name }}: Suggestion: {{ .suggestion}}": "",
 	"{{ .name }}: {{ .rejection }}": "",
 	"{{.Driver}} is currently using the {{.StorageDriver}} storage driver, consider switching to overlay2 for better performance": "",
 	"{{.count}} nodes stopped.": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -910,6 +910,7 @@
 	"version yaml failure": "échec de la version du YAML",
 	"zsh completion failed": "complétion de zsh en échec",
 	"zsh completion.": "",
+	"{{ .name }}: Suggestion: {{ .suggestion}}": "",
 	"{{ .name }}: {{ .rejection }}": "{{ .name }} : {{ .rejection }}",
 	"{{.Driver}} is currently using the {{.StorageDriver}} storage driver, consider switching to overlay2 for better performance": "",
 	"{{.count}} nodes stopped.": "{{.count}} nœud(s) arrêté(s).",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -920,6 +920,7 @@
 	"version yaml failure": "YAML でバージョンを表示するのに失敗しました",
 	"zsh completion failed": "zsh の補完が失敗しました",
 	"zsh completion.": "",
+	"{{ .name }}: Suggestion: {{ .suggestion}}": "",
 	"{{ .name }}: {{ .rejection }}": "{{ .name }}: {{ .rejection }}",
 	"{{.Driver}} is currently using the {{.StorageDriver}} storage driver, consider switching to overlay2 for better performance": "",
 	"{{.cluster}} IP has been updated to point at {{.ip}}": "{{.cluster}} の IP アドレスは {{.ip}} へと更新されました",

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -920,6 +920,7 @@
 	"version yaml failure": "",
 	"zsh completion failed": "zsh 완성이 실패하였습니다",
 	"zsh completion.": "",
+	"{{ .name }}: Suggestion: {{ .suggestion}}": "",
 	"{{ .name }}: {{ .rejection }}": "",
 	"{{.Driver}} is currently using the {{.StorageDriver}} storage driver, consider switching to overlay2 for better performance": "",
 	"{{.count}} nodes stopped.": "{{.count}}개의 노드가 중지되었습니다.",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -922,6 +922,7 @@
 	"version yaml failure": "",
 	"zsh completion failed": "",
 	"zsh completion.": "",
+	"{{ .name }}: Suggestion: {{ .suggestion}}": "",
 	"{{ .name }}: {{ .rejection }}": "",
 	"{{.Driver}} is currently using the {{.StorageDriver}} storage driver, consider switching to overlay2 for better performance": "",
 	"{{.addonName}} was successfully enabled": "{{.addonName}} został aktywowany pomyślnie",

--- a/translations/strings.txt
+++ b/translations/strings.txt
@@ -848,6 +848,7 @@
 	"version yaml failure": "",
 	"zsh completion failed": "",
 	"zsh completion.": "",
+	"{{ .name }}: Suggestion: {{ .suggestion}}": "",
 	"{{ .name }}: {{ .rejection }}": "",
 	"{{.Driver}} is currently using the {{.StorageDriver}} storage driver, consider switching to overlay2 for better performance": "",
 	"{{.count}} nodes stopped.": "",

--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -1030,6 +1030,7 @@
 	"version yaml failure": "",
 	"zsh completion failed": "",
 	"zsh completion.": "",
+	"{{ .name }}: Suggestion: {{ .suggestion}}": "",
 	"{{ .name }}: {{ .rejection }}": "",
 	"{{.Driver}} is currently using the {{.StorageDriver}} storage driver, consider switching to overlay2 for better performance": "",
 	"{{.count}} nodes stopped.": "",


### PR DESCRIPTION
Normally how to add root permissions for the user, to be able to
run the "docker" or "podman" driver (through group or through sudo)

Example: (modified here to show all kinds of drivers, and their output)

```
👎  Unable to pick a default driver. Here is what was considered, in preference order:
    ▪ none: Not installed: running the 'none' driver as a regular user requires sudo permissions
    ▪ podman: Not healthy: "sudo -k -n podman version --format {{.Version}}" exit status 1: sudo: a password is required
    ▪ podman: Suggestion: Add your user to the 'sudoers' file: 'anders ALL=(ALL) NOPASSWD: /usr/bin/podman' <https://podman.io>
    ▪ vmware: Not installed: exec: "docker-machine-driver-vmware": executable file not found in $PATH
    ▪ docker: Not healthy: "docker version --format {{.Server.Os}}-{{.Server.Version}}" exit status 1: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get http://%2Fvar%2Frun%2Fdocker.sock/v1.24/version: dial unix /var/run/docker.sock: connect: permission denied
    ▪ docker: Suggestion: Add your user to the 'docker' group: 'sudo usermod -aG docker $USER && newgrp docker' <https://docs.docker.com/engine/install/linux-postinstall/>
    ▪ kvm2: Not installed: exec: "virsh": executable file not found in $PATH
    ▪ ssh: virtualbox is preferred
```

Note that the preference order etc is wrong, but that is fixed in PR #11355

Closes #10007