### PR TITLE
Use different base images for functional tests

### DIFF
--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -216,7 +216,7 @@ func validateLoadImage(ctx context.Context, t *testing.T, profile string) {
 	}
 	defer PostMortemLogs(t, profile)
 	// pull busybox
-	busyboxImage := "busybox:latest"
+	busyboxImage := "busybox:uclibc"
 	rr, err := Run(t, exec.CommandContext(ctx, "docker", "pull", busyboxImage))
 	if err != nil {
 		t.Fatalf("failed to setup test (pull image): %v\n%s", err, rr.Output())
@@ -257,7 +257,7 @@ func validateRemoveImage(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 
 	// pull busybox
-	busyboxImage := "busybox:latest"
+	busyboxImage := "busybox:glibc"
 	rr, err := Run(t, exec.CommandContext(ctx, "docker", "pull", busyboxImage))
 	if err != nil {
 		t.Fatalf("failed to setup test (pull image): %v\n%s", err, rr.Output())


### PR DESCRIPTION
In case that LoadImage and RemoveImage interfere

See if this helps with the recent LoadImage failures ?

```
2021-05-09T19:35:19.4527422Z     functional_test.go:233: (dbg) Done: ./minikube-linux-amd64 -p functional-20210509193059-2354 image load docker.io/library/busybox:load-functional-20210509193059-2354: (1.465292986s)
2021-05-09T19:35:19.4530125Z     functional_test.go:303: (dbg) Run:  ./minikube-linux-amd64 ssh -p functional-20210509193059-2354 -- docker image inspect docker.io/library/busybox:load-functional-20210509193059-2354
2021-05-09T19:35:19.9958299Z     functional_test.go:303: (dbg) Non-zero exit: ./minikube-linux-amd64 ssh -p functional-20210509193059-2354 -- docker image inspect docker.io/library/busybox:load-functional-20210509193059-2354: exit status 1 (543.300133ms)
2021-05-09T19:35:19.9959693Z         
2021-05-09T19:35:19.9960248Z         -- stdout --
2021-05-09T19:35:19.9960628Z         	[]
2021-05-09T19:35:19.9961980Z         	Error: No such image: docker.io/library/busybox:load-functional-20210509193059-2354
2021-05-09T19:35:19.9962758Z         
2021-05-09T19:35:19.9963288Z         -- /stdout --
2021-05-09T19:35:19.9963686Z         ** stderr ** 
2021-05-09T19:35:19.9964193Z         	ssh: Process exited with status 1
2021-05-09T19:35:19.9964641Z         
2021-05-09T19:35:19.9965020Z         ** /stderr **
2021-05-09T19:35:19.9965565Z     functional_test.go:241: listing images: exit status 1
2021-05-09T19:35:19.9966093Z         
2021-05-09T19:35:19.9966627Z         -- stdout --
2021-05-09T19:35:19.9966996Z         	[]
2021-05-09T19:35:19.9968815Z         	Error: No such image: docker.io/library/busybox:load-functional-20210509193059-2354
2021-05-09T19:35:19.9969632Z         
2021-05-09T19:35:19.9970204Z         -- /stdout --
2021-05-09T19:35:19.9970605Z         ** stderr ** 
2021-05-09T19:35:19.9971109Z         	ssh: Process exited with status 1
2021-05-09T19:35:19.9971559Z         
2021-05-09T19:35:19.9971937Z         ** /stderr **
```

Would have been nice if `minikube image load` returned errors...

```
2021-05-09T19:35:23.4454304Z         	I0509 19:35:10.969852    9221 cache_images.go:280] Loading image from: /home/runner/work/minikube/minikube/minikube_binaries/testhome/.minikube/cache/images/minikube-local-cache-test_functional-20210509193059-2354
2021-05-09T19:35:23.4455771Z         	I0509 19:35:10.969878    9221 cache_images.go:82] LoadImages completed in 115.431191ms
2021-05-09T19:35:23.4459269Z         	W0509 19:35:10.969886    9221 cache_images.go:253] Failed to load cached images for profile functional-20210509193059-2354. make sure the profile is running. loading cached images: stat /home/runner/work/minikube/minikube/minikube_binaries/testhome/.minikube/cache/images/minikube-local-cache-test_functional-20210509193059-2354: no such file or directory
2021-05-09T19:35:23.4461305Z         	I0509 19:35:10.969899    9221 cache_images.go:261] succeeded pushing to: 
2021-05-09T19:35:23.4462545Z         	I0509 19:35:10.969903    9221 cache_images.go:262] failed pushing to: functional-20210509193059-2354
```