### PR TITLE
`image load`: overwrite same image unless `--overwrite=false`

### DIFF
--- a/cmd/minikube/cmd/cache.go
+++ b/cmd/minikube/cmd/cache.go
@@ -52,7 +52,7 @@ var addCacheCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		out.WarningT("\"minikube cache\" will be deprecated in upcoming versions, please switch to \"minikube image load\"")
 		// Cache and load images into docker daemon
-		if err := machine.CacheAndLoadImages(args, cacheAddProfiles()); err != nil {
+		if err := machine.CacheAndLoadImages(args, cacheAddProfiles(), false); err != nil {
 			exit.Error(reason.InternalCacheLoad, "Failed to cache and load images", err)
 		}
 		// Add images to config file

--- a/cmd/minikube/cmd/image.go
+++ b/cmd/minikube/cmd/image.go
@@ -137,7 +137,7 @@ var loadImageCmd = &cobra.Command{
 		} else if local {
 			// Load images from local files, without doing any caching or checks in container runtime
 			// This is similar to tarball.Image but it is done by the container runtime in the cluster.
-			if err := machine.DoLoadImages(args, []*config.Profile{profile}, "", false); err != nil {
+			if err := machine.DoLoadImages(args, []*config.Profile{profile}, "", overwrite); err != nil {
 				exit.Error(reason.GuestImageLoad, "Failed to load image", err)
 			}
 		}

--- a/cmd/minikube/cmd/image.go
+++ b/cmd/minikube/cmd/image.go
@@ -45,6 +45,7 @@ var (
 	pull       bool
 	imgDaemon  bool
 	imgRemote  bool
+	overWrite  bool
 	tag        string
 	push       bool
 	dockerFile string
@@ -130,7 +131,7 @@ var loadImageCmd = &cobra.Command{
 		if imgDaemon || imgRemote {
 			image.UseDaemon(imgDaemon)
 			image.UseRemote(imgRemote)
-			if err := machine.CacheAndLoadImages(args, []*config.Profile{profile}, true); err != nil {
+			if err := machine.CacheAndLoadImages(args, []*config.Profile{profile}, overWrite); err != nil {
 				exit.Error(reason.GuestImageLoad, "Failed to load image", err)
 			}
 		} else if local {
@@ -248,6 +249,7 @@ func init() {
 	loadImageCmd.Flags().BoolVarP(&pull, "pull", "", false, "Pull the remote image (no caching)")
 	loadImageCmd.Flags().BoolVar(&imgDaemon, "daemon", false, "Cache image from docker daemon")
 	loadImageCmd.Flags().BoolVar(&imgRemote, "remote", false, "Cache image from remote registry")
+	loadImageCmd.Flags().BoolVar(&overWrite, "over-write", true, "Over write the existing image if the name:tag of the images are the same")
 	imageCmd.AddCommand(loadImageCmd)
 	imageCmd.AddCommand(removeImageCmd)
 	buildImageCmd.Flags().StringVarP(&tag, "tag", "t", "", "Tag to apply to the new image (optional)")

--- a/cmd/minikube/cmd/image.go
+++ b/cmd/minikube/cmd/image.go
@@ -137,7 +137,7 @@ var loadImageCmd = &cobra.Command{
 		} else if local {
 			// Load images from local files, without doing any caching or checks in container runtime
 			// This is similar to tarball.Image but it is done by the container runtime in the cluster.
-			if err := machine.DoLoadImages(args, []*config.Profile{profile}, ""); err != nil {
+			if err := machine.DoLoadImages(args, []*config.Profile{profile}, "", false); err != nil {
 				exit.Error(reason.GuestImageLoad, "Failed to load image", err)
 			}
 		}
@@ -249,7 +249,7 @@ func init() {
 	loadImageCmd.Flags().BoolVarP(&pull, "pull", "", false, "Pull the remote image (no caching)")
 	loadImageCmd.Flags().BoolVar(&imgDaemon, "daemon", false, "Cache image from docker daemon")
 	loadImageCmd.Flags().BoolVar(&imgRemote, "remote", false, "Cache image from remote registry")
-	loadImageCmd.Flags().BoolVar(&overwrite, "overwrite", true, "Overwrite the existing image if the name:tag of the images are the same")
+	loadImageCmd.Flags().BoolVar(&overwrite, "overwrite", true, "Overwrite image even if same image:tag name exists")
 	imageCmd.AddCommand(loadImageCmd)
 	imageCmd.AddCommand(removeImageCmd)
 	buildImageCmd.Flags().StringVarP(&tag, "tag", "t", "", "Tag to apply to the new image (optional)")

--- a/cmd/minikube/cmd/image.go
+++ b/cmd/minikube/cmd/image.go
@@ -130,7 +130,7 @@ var loadImageCmd = &cobra.Command{
 		if imgDaemon || imgRemote {
 			image.UseDaemon(imgDaemon)
 			image.UseRemote(imgRemote)
-			if err := machine.CacheAndLoadImages(args, []*config.Profile{profile}); err != nil {
+			if err := machine.CacheAndLoadImages(args, []*config.Profile{profile}, true); err != nil {
 				exit.Error(reason.GuestImageLoad, "Failed to load image", err)
 			}
 		} else if local {

--- a/cmd/minikube/cmd/image.go
+++ b/cmd/minikube/cmd/image.go
@@ -45,7 +45,7 @@ var (
 	pull       bool
 	imgDaemon  bool
 	imgRemote  bool
-	overWrite  bool
+	overwrite  bool
 	tag        string
 	push       bool
 	dockerFile string
@@ -131,7 +131,7 @@ var loadImageCmd = &cobra.Command{
 		if imgDaemon || imgRemote {
 			image.UseDaemon(imgDaemon)
 			image.UseRemote(imgRemote)
-			if err := machine.CacheAndLoadImages(args, []*config.Profile{profile}, overWrite); err != nil {
+			if err := machine.CacheAndLoadImages(args, []*config.Profile{profile}, overwrite); err != nil {
 				exit.Error(reason.GuestImageLoad, "Failed to load image", err)
 			}
 		} else if local {
@@ -249,7 +249,7 @@ func init() {
 	loadImageCmd.Flags().BoolVarP(&pull, "pull", "", false, "Pull the remote image (no caching)")
 	loadImageCmd.Flags().BoolVar(&imgDaemon, "daemon", false, "Cache image from docker daemon")
 	loadImageCmd.Flags().BoolVar(&imgRemote, "remote", false, "Cache image from remote registry")
-	loadImageCmd.Flags().BoolVar(&overWrite, "over-write", true, "Over write the existing image if the name:tag of the images are the same")
+	loadImageCmd.Flags().BoolVar(&overwrite, "overwrite", true, "Overwrite the existing image if the name:tag of the images are the same")
 	imageCmd.AddCommand(loadImageCmd)
 	imageCmd.AddCommand(removeImageCmd)
 	buildImageCmd.Flags().StringVarP(&tag, "tag", "t", "", "Tag to apply to the new image (optional)")

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -872,7 +872,7 @@ func (k *Bootstrapper) UpdateCluster(cfg config.ClusterConfig) error {
 	}
 
 	if cfg.KubernetesConfig.ShouldLoadCachedImages {
-		if err := machine.LoadCachedImages(&cfg, k.c, images, constants.ImageCacheDir); err != nil {
+		if err := machine.LoadCachedImages(&cfg, k.c, images, constants.ImageCacheDir, false); err != nil {
 			out.FailureT("Unable to load cached images: {{.error}}", out.V{"error": err})
 		}
 	}

--- a/pkg/minikube/image/cache.go
+++ b/pkg/minikube/image/cache.go
@@ -64,14 +64,14 @@ func DeleteFromCacheDir(images []string) error {
 // The cache directory currently caches images using the imagename_tag
 // For example, k8s.gcr.io/kube-addon-manager:v6.5 would be
 // stored at $CACHE_DIR/k8s.gcr.io/kube-addon-manager_v6.5
-func SaveToDir(images []string, cacheDir string) error {
+func SaveToDir(images []string, cacheDir string, force ...bool) error {
 	var g errgroup.Group
 	for _, image := range images {
 		image := image
 		g.Go(func() error {
 			dst := filepath.Join(cacheDir, image)
 			dst = localpath.SanitizeCacheDir(dst)
-			if err := saveToTarFile(image, dst); err != nil {
+			if err := saveToTarFile(image, dst, force...); err != nil {
 				if err == errCacheImageDoesntExist {
 					out.WarningT("The image you are trying to add {{.imageName}} doesn't exist!", out.V{"imageName": image})
 				} else {
@@ -90,7 +90,7 @@ func SaveToDir(images []string, cacheDir string) error {
 }
 
 // saveToTarFile caches an image
-func saveToTarFile(iname, rawDest string) error {
+func saveToTarFile(iname, rawDest string, force ...bool) error {
 	iname = normalizeTagName(iname)
 	start := time.Now()
 	defer func() {
@@ -112,7 +112,12 @@ func saveToTarFile(iname, rawDest string) error {
 	}
 	defer releaser.Release()
 
-	if _, err := os.Stat(dst); err == nil {
+	f := false
+	if len(force) > 0 {
+		f = force[0]
+	}
+
+	if _, err := os.Stat(dst); !f && err == nil {
 		klog.Infof("%s exists", dst)
 		return nil
 	}

--- a/pkg/minikube/image/cache.go
+++ b/pkg/minikube/image/cache.go
@@ -64,14 +64,14 @@ func DeleteFromCacheDir(images []string) error {
 // The cache directory currently caches images using the imagename_tag
 // For example, k8s.gcr.io/kube-addon-manager:v6.5 would be
 // stored at $CACHE_DIR/k8s.gcr.io/kube-addon-manager_v6.5
-func SaveToDir(images []string, cacheDir string, force ...bool) error {
+func SaveToDir(images []string, cacheDir string, overwrite bool) error {
 	var g errgroup.Group
 	for _, image := range images {
 		image := image
 		g.Go(func() error {
 			dst := filepath.Join(cacheDir, image)
 			dst = localpath.SanitizeCacheDir(dst)
-			if err := saveToTarFile(image, dst, force...); err != nil {
+			if err := saveToTarFile(image, dst, overwrite); err != nil {
 				if err == errCacheImageDoesntExist {
 					out.WarningT("The image you are trying to add {{.imageName}} doesn't exist!", out.V{"imageName": image})
 				} else {
@@ -90,7 +90,7 @@ func SaveToDir(images []string, cacheDir string, force ...bool) error {
 }
 
 // saveToTarFile caches an image
-func saveToTarFile(iname, rawDest string, force ...bool) error {
+func saveToTarFile(iname, rawDest string, overwrite bool) error {
 	iname = normalizeTagName(iname)
 	start := time.Now()
 	defer func() {
@@ -112,12 +112,7 @@ func saveToTarFile(iname, rawDest string, force ...bool) error {
 	}
 	defer releaser.Release()
 
-	f := false
-	if len(force) > 0 {
-		f = force[0]
-	}
-
-	if _, err := os.Stat(dst); !f && err == nil {
+	if _, err := os.Stat(dst); !overwrite && err == nil {
 		klog.Infof("%s exists", dst)
 		return nil
 	}

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -63,14 +63,19 @@ func CacheImagesForBootstrapper(imageRepository string, version string, clusterB
 }
 
 // LoadCachedImages loads previously cached images into the container runtime
-func LoadCachedImages(cc *config.ClusterConfig, runner command.Runner, images []string, cacheDir string) error {
+func LoadCachedImages(cc *config.ClusterConfig, runner command.Runner, images []string, cacheDir string, force ...bool) error {
 	cr, err := cruntime.New(cruntime.Config{Type: cc.KubernetesConfig.ContainerRuntime, Runner: runner})
 	if err != nil {
 		return errors.Wrap(err, "runtime")
 	}
 
+	f := false
+	if len(force) > 0 {
+		f = force[0]
+	}
+
 	// Skip loading images if images already exist
-	if cr.ImagesPreloaded(images) {
+	if !f && cr.ImagesPreloaded(images) {
 		klog.Infof("Images are preloaded, skipping loading")
 		return nil
 	}
@@ -165,7 +170,7 @@ func LoadLocalImages(cc *config.ClusterConfig, runner command.Runner, images []s
 	for _, image := range images {
 		image := image
 		g.Go(func() error {
-			return transferAndLoadImage(runner, cc.KubernetesConfig, image)
+			return transferAndLoadImage(runner, cc.KubernetesConfig, image, image)
 		})
 	}
 	if err := g.Wait(); err != nil {
@@ -176,21 +181,21 @@ func LoadLocalImages(cc *config.ClusterConfig, runner command.Runner, images []s
 }
 
 // CacheAndLoadImages caches and loads images to all profiles
-func CacheAndLoadImages(images []string, profiles []*config.Profile) error {
+func CacheAndLoadImages(images []string, profiles []*config.Profile, force ...bool) error {
 	if len(images) == 0 {
 		return nil
 	}
 
 	// This is the most important thing
-	if err := image.SaveToDir(images, constants.ImageCacheDir); err != nil {
+	if err := image.SaveToDir(images, constants.ImageCacheDir, force...); err != nil {
 		return errors.Wrap(err, "save to dir")
 	}
 
-	return DoLoadImages(images, profiles, constants.ImageCacheDir)
+	return DoLoadImages(images, profiles, constants.ImageCacheDir, force...)
 }
 
 // DoLoadImages loads images to all profiles
-func DoLoadImages(images []string, profiles []*config.Profile, cacheDir string) error {
+func DoLoadImages(images []string, profiles []*config.Profile, cacheDir string, force ...bool) error {
 	api, err := NewAPIClient()
 	if err != nil {
 		return errors.Wrap(err, "api")
@@ -234,7 +239,7 @@ func DoLoadImages(images []string, profiles []*config.Profile, cacheDir string) 
 				}
 				if cacheDir != "" {
 					// loading image names, from cache
-					err = LoadCachedImages(c, cr, images, cacheDir)
+					err = LoadCachedImages(c, cr, images, cacheDir, force...)
 				} else {
 					// loading image files
 					err = LoadLocalImages(c, cr, images)
@@ -259,20 +264,26 @@ func DoLoadImages(images []string, profiles []*config.Profile, cacheDir string) 
 func transferAndLoadCachedImage(cr command.Runner, k8s config.KubernetesConfig, imgName string, cacheDir string) error {
 	src := filepath.Join(cacheDir, imgName)
 	src = localpath.SanitizeCacheDir(src)
-	return transferAndLoadImage(cr, k8s, src)
+	return transferAndLoadImage(cr, k8s, src, imgName)
 }
 
 // transferAndLoadImage transfers and loads a single image
-func transferAndLoadImage(cr command.Runner, k8s config.KubernetesConfig, src string) error {
+func transferAndLoadImage(cr command.Runner, k8s config.KubernetesConfig, src string, imgName string) error {
 	r, err := cruntime.New(cruntime.Config{Type: k8s.ContainerRuntime, Runner: cr})
 	if err != nil {
 		return errors.Wrap(err, "runtime")
 	}
+
+	if err := r.RemoveImage(imgName); err != nil {
+		klog.Warningf("remove image: %v", err)
+	}
+
 	klog.Infof("Loading image from: %s", src)
 	filename := filepath.Base(src)
 	if _, err := os.Stat(src); err != nil {
 		return err
 	}
+
 	dst := path.Join(loadRoot, filename)
 	f, err := assets.NewFileAsset(src, loadRoot, filename, "0644")
 	if err != nil {

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -269,13 +269,9 @@ func transferAndLoadImage(cr command.Runner, k8s config.KubernetesConfig, src st
 		return errors.Wrap(err, "runtime")
 	}
 
-	exists, err := imageExists(r, imgName)
-	if err != nil {
-		return err
-	}
-
-	if exists {
-		if err := r.RemoveImage(imgName); err != nil {
+	if err := r.RemoveImage(imgName); err != nil {
+		errStr := strings.ToLower(err.Error())
+		if !strings.Contains(errStr, "no such image") {
 			return errors.Wrap(err, "removing image")
 		}
 	}
@@ -305,20 +301,6 @@ func transferAndLoadImage(cr command.Runner, k8s config.KubernetesConfig, src st
 
 	klog.Infof("Transferred and loaded %s from cache", src)
 	return nil
-}
-
-func imageExists(r cruntime.Manager, image string) (bool, error) {
-	images, err := r.ListImages(cruntime.ListImagesOptions{})
-	if err != nil {
-		return false, errors.Wrap(err, "listing images")
-	}
-	for _, i := range images {
-		if i == image {
-			return true, nil
-		}
-	}
-
-	return false, nil
 }
 
 // pullImages pulls images to the container run time

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -216,7 +216,7 @@ func saveImagesToTarFromConfig() error {
 	if len(images) == 0 {
 		return nil
 	}
-	return image.SaveToDir(images, constants.ImageCacheDir)
+	return image.SaveToDir(images, constants.ImageCacheDir, false)
 }
 
 // CacheAndLoadImagesInConfig loads the images currently in the config file
@@ -229,7 +229,7 @@ func CacheAndLoadImagesInConfig(profiles []*config.Profile) error {
 	if len(images) == 0 {
 		return nil
 	}
-	return machine.CacheAndLoadImages(images, profiles)
+	return machine.CacheAndLoadImages(images, profiles, false)
 }
 
 func imagesInConfigFile() ([]string, error) {

--- a/site/content/en/docs/commands/image.md
+++ b/site/content/en/docs/commands/image.md
@@ -192,6 +192,11 @@ minikube image ls [flags]
 $ minikube image ls
 
 ```
+      --daemon       Cache image from docker daemon
+      --over-write   Over write the existing image if the name:tag of the images are the same (default true)
+      --pull         Pull the remote image (no caching)
+      --remote       Cache image from remote registry
+```
 
 ### Options inherited from parent commands
 

--- a/site/content/en/docs/commands/image.md
+++ b/site/content/en/docs/commands/image.md
@@ -142,9 +142,10 @@ minikube image load image.tar
 ### Options
 
 ```
-      --daemon   Cache image from docker daemon
-      --pull     Pull the remote image (no caching)
-      --remote   Cache image from remote registry
+      --daemon       Cache image from docker daemon
+      --over-write   Over write the existing image if the name:tag of the images are the same (default true)
+      --pull         Pull the remote image (no caching)
+      --remote       Cache image from remote registry
 ```
 
 ### Options inherited from parent commands
@@ -191,11 +192,6 @@ minikube image ls [flags]
 
 $ minikube image ls
 
-```
-      --daemon       Cache image from docker daemon
-      --over-write   Over write the existing image if the name:tag of the images are the same (default true)
-      --pull         Pull the remote image (no caching)
-      --remote       Cache image from remote registry
 ```
 
 ### Options inherited from parent commands

--- a/site/content/en/docs/commands/image.md
+++ b/site/content/en/docs/commands/image.md
@@ -142,10 +142,10 @@ minikube image load image.tar
 ### Options
 
 ```
-      --daemon       Cache image from docker daemon
-      --over-write   Over write the existing image if the name:tag of the images are the same (default true)
-      --pull         Pull the remote image (no caching)
-      --remote       Cache image from remote registry
+      --daemon      Cache image from docker daemon
+      --overwrite   Overwrite the existing image if the name:tag of the images are the same (default true)
+      --pull        Pull the remote image (no caching)
+      --remote      Cache image from remote registry
 ```
 
 ### Options inherited from parent commands

--- a/site/content/en/docs/commands/image.md
+++ b/site/content/en/docs/commands/image.md
@@ -143,7 +143,7 @@ minikube image load image.tar
 
 ```
       --daemon      Cache image from docker daemon
-      --overwrite   Overwrite the existing image if the name:tag of the images are the same (default true)
+      --overwrite   Overwrite image even if same image:tag name exists (default true)
       --pull        Pull the remote image (no caching)
       --remote      Cache image from remote registry
 ```

--- a/translations/de.json
+++ b/translations/de.json
@@ -402,6 +402,7 @@
 	"Options:      {{.options}}": "",
 	"Output format. Accepted values: [json]": "",
 	"Outputs minikube shell completion for the given shell (bash, zsh or fish)\n\n\tThis depends on the bash-completion binary.  Example installation instructions:\n\tOS X:\n\t\t$ brew install bash-completion\n\t\t$ source $(brew --prefix)/etc/bash_completion\n\t\t$ minikube completion bash \u003e ~/.minikube-completion  # for bash users\n\t\t$ minikube completion zsh \u003e ~/.minikube-completion  # for zsh users\n\t\t$ source ~/.minikube-completion\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\tUbuntu:\n\t\t$ apt-get install bash-completion\n\t\t$ source /etc/bash_completion\n\t\t$ source \u003c(minikube completion bash) # for bash users\n\t\t$ source \u003c(minikube completion zsh) # for zsh users\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\n\tAdditionally, you may want to output the completion to a file and source in your .bashrc\n\n\tNote for zsh users: [1] zsh completions are only supported in versions of zsh \u003e= 5.2\n\tNote for fish users: [2] please refer to this docs for more details https://fishshell.com/docs/current/#tab-completion\n": "",
+	"Over write the existing image if the name:tag of the images are the same": "",
 	"Path to the Dockerfile to use (optional)": "",
 	"Pause": "",
 	"Paused {{.count}} containers": "",

--- a/translations/de.json
+++ b/translations/de.json
@@ -402,7 +402,7 @@
 	"Options:      {{.options}}": "",
 	"Output format. Accepted values: [json]": "",
 	"Outputs minikube shell completion for the given shell (bash, zsh or fish)\n\n\tThis depends on the bash-completion binary.  Example installation instructions:\n\tOS X:\n\t\t$ brew install bash-completion\n\t\t$ source $(brew --prefix)/etc/bash_completion\n\t\t$ minikube completion bash \u003e ~/.minikube-completion  # for bash users\n\t\t$ minikube completion zsh \u003e ~/.minikube-completion  # for zsh users\n\t\t$ source ~/.minikube-completion\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\tUbuntu:\n\t\t$ apt-get install bash-completion\n\t\t$ source /etc/bash_completion\n\t\t$ source \u003c(minikube completion bash) # for bash users\n\t\t$ source \u003c(minikube completion zsh) # for zsh users\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\n\tAdditionally, you may want to output the completion to a file and source in your .bashrc\n\n\tNote for zsh users: [1] zsh completions are only supported in versions of zsh \u003e= 5.2\n\tNote for fish users: [2] please refer to this docs for more details https://fishshell.com/docs/current/#tab-completion\n": "",
-	"Overwrite the existing image if the name:tag of the images are the same": "",
+	"Overwrite image even if same image:tag name exists": "",
 	"Path to the Dockerfile to use (optional)": "",
 	"Pause": "",
 	"Paused {{.count}} containers": "",

--- a/translations/de.json
+++ b/translations/de.json
@@ -402,7 +402,7 @@
 	"Options:      {{.options}}": "",
 	"Output format. Accepted values: [json]": "",
 	"Outputs minikube shell completion for the given shell (bash, zsh or fish)\n\n\tThis depends on the bash-completion binary.  Example installation instructions:\n\tOS X:\n\t\t$ brew install bash-completion\n\t\t$ source $(brew --prefix)/etc/bash_completion\n\t\t$ minikube completion bash \u003e ~/.minikube-completion  # for bash users\n\t\t$ minikube completion zsh \u003e ~/.minikube-completion  # for zsh users\n\t\t$ source ~/.minikube-completion\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\tUbuntu:\n\t\t$ apt-get install bash-completion\n\t\t$ source /etc/bash_completion\n\t\t$ source \u003c(minikube completion bash) # for bash users\n\t\t$ source \u003c(minikube completion zsh) # for zsh users\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\n\tAdditionally, you may want to output the completion to a file and source in your .bashrc\n\n\tNote for zsh users: [1] zsh completions are only supported in versions of zsh \u003e= 5.2\n\tNote for fish users: [2] please refer to this docs for more details https://fishshell.com/docs/current/#tab-completion\n": "",
-	"Over write the existing image if the name:tag of the images are the same": "",
+	"Overwrite the existing image if the name:tag of the images are the same": "",
 	"Path to the Dockerfile to use (optional)": "",
 	"Pause": "",
 	"Paused {{.count}} containers": "",

--- a/translations/es.json
+++ b/translations/es.json
@@ -407,7 +407,7 @@
 	"Options:      {{.options}}": "",
 	"Output format. Accepted values: [json]": "",
 	"Outputs minikube shell completion for the given shell (bash, zsh or fish)\n\n\tThis depends on the bash-completion binary.  Example installation instructions:\n\tOS X:\n\t\t$ brew install bash-completion\n\t\t$ source $(brew --prefix)/etc/bash_completion\n\t\t$ minikube completion bash \u003e ~/.minikube-completion  # for bash users\n\t\t$ minikube completion zsh \u003e ~/.minikube-completion  # for zsh users\n\t\t$ source ~/.minikube-completion\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\tUbuntu:\n\t\t$ apt-get install bash-completion\n\t\t$ source /etc/bash_completion\n\t\t$ source \u003c(minikube completion bash) # for bash users\n\t\t$ source \u003c(minikube completion zsh) # for zsh users\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\n\tAdditionally, you may want to output the completion to a file and source in your .bashrc\n\n\tNote for zsh users: [1] zsh completions are only supported in versions of zsh \u003e= 5.2\n\tNote for fish users: [2] please refer to this docs for more details https://fishshell.com/docs/current/#tab-completion\n": "",
-	"Overwrite the existing image if the name:tag of the images are the same": "",
+	"Overwrite image even if same image:tag name exists": "",
 	"Path to the Dockerfile to use (optional)": "",
 	"Pause": "",
 	"Paused {{.count}} containers": "",

--- a/translations/es.json
+++ b/translations/es.json
@@ -407,6 +407,7 @@
 	"Options:      {{.options}}": "",
 	"Output format. Accepted values: [json]": "",
 	"Outputs minikube shell completion for the given shell (bash, zsh or fish)\n\n\tThis depends on the bash-completion binary.  Example installation instructions:\n\tOS X:\n\t\t$ brew install bash-completion\n\t\t$ source $(brew --prefix)/etc/bash_completion\n\t\t$ minikube completion bash \u003e ~/.minikube-completion  # for bash users\n\t\t$ minikube completion zsh \u003e ~/.minikube-completion  # for zsh users\n\t\t$ source ~/.minikube-completion\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\tUbuntu:\n\t\t$ apt-get install bash-completion\n\t\t$ source /etc/bash_completion\n\t\t$ source \u003c(minikube completion bash) # for bash users\n\t\t$ source \u003c(minikube completion zsh) # for zsh users\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\n\tAdditionally, you may want to output the completion to a file and source in your .bashrc\n\n\tNote for zsh users: [1] zsh completions are only supported in versions of zsh \u003e= 5.2\n\tNote for fish users: [2] please refer to this docs for more details https://fishshell.com/docs/current/#tab-completion\n": "",
+	"Over write the existing image if the name:tag of the images are the same": "",
 	"Path to the Dockerfile to use (optional)": "",
 	"Pause": "",
 	"Paused {{.count}} containers": "",

--- a/translations/es.json
+++ b/translations/es.json
@@ -407,7 +407,7 @@
 	"Options:      {{.options}}": "",
 	"Output format. Accepted values: [json]": "",
 	"Outputs minikube shell completion for the given shell (bash, zsh or fish)\n\n\tThis depends on the bash-completion binary.  Example installation instructions:\n\tOS X:\n\t\t$ brew install bash-completion\n\t\t$ source $(brew --prefix)/etc/bash_completion\n\t\t$ minikube completion bash \u003e ~/.minikube-completion  # for bash users\n\t\t$ minikube completion zsh \u003e ~/.minikube-completion  # for zsh users\n\t\t$ source ~/.minikube-completion\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\tUbuntu:\n\t\t$ apt-get install bash-completion\n\t\t$ source /etc/bash_completion\n\t\t$ source \u003c(minikube completion bash) # for bash users\n\t\t$ source \u003c(minikube completion zsh) # for zsh users\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\n\tAdditionally, you may want to output the completion to a file and source in your .bashrc\n\n\tNote for zsh users: [1] zsh completions are only supported in versions of zsh \u003e= 5.2\n\tNote for fish users: [2] please refer to this docs for more details https://fishshell.com/docs/current/#tab-completion\n": "",
-	"Over write the existing image if the name:tag of the images are the same": "",
+	"Overwrite the existing image if the name:tag of the images are the same": "",
 	"Path to the Dockerfile to use (optional)": "",
 	"Pause": "",
 	"Paused {{.count}} containers": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -405,7 +405,7 @@
 	"Options:      {{.options}}": "",
 	"Output format. Accepted values: [json]": "",
 	"Outputs minikube shell completion for the given shell (bash, zsh or fish)\n\n\tThis depends on the bash-completion binary.  Example installation instructions:\n\tOS X:\n\t\t$ brew install bash-completion\n\t\t$ source $(brew --prefix)/etc/bash_completion\n\t\t$ minikube completion bash \u003e ~/.minikube-completion  # for bash users\n\t\t$ minikube completion zsh \u003e ~/.minikube-completion  # for zsh users\n\t\t$ source ~/.minikube-completion\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\tUbuntu:\n\t\t$ apt-get install bash-completion\n\t\t$ source /etc/bash_completion\n\t\t$ source \u003c(minikube completion bash) # for bash users\n\t\t$ source \u003c(minikube completion zsh) # for zsh users\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\n\tAdditionally, you may want to output the completion to a file and source in your .bashrc\n\n\tNote for zsh users: [1] zsh completions are only supported in versions of zsh \u003e= 5.2\n\tNote for fish users: [2] please refer to this docs for more details https://fishshell.com/docs/current/#tab-completion\n": "",
-	"Over write the existing image if the name:tag of the images are the same": "",
+	"Overwrite the existing image if the name:tag of the images are the same": "",
 	"Path to the Dockerfile to use (optional)": "",
 	"Pause": "",
 	"Paused {{.count}} containers": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -405,7 +405,7 @@
 	"Options:      {{.options}}": "",
 	"Output format. Accepted values: [json]": "",
 	"Outputs minikube shell completion for the given shell (bash, zsh or fish)\n\n\tThis depends on the bash-completion binary.  Example installation instructions:\n\tOS X:\n\t\t$ brew install bash-completion\n\t\t$ source $(brew --prefix)/etc/bash_completion\n\t\t$ minikube completion bash \u003e ~/.minikube-completion  # for bash users\n\t\t$ minikube completion zsh \u003e ~/.minikube-completion  # for zsh users\n\t\t$ source ~/.minikube-completion\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\tUbuntu:\n\t\t$ apt-get install bash-completion\n\t\t$ source /etc/bash_completion\n\t\t$ source \u003c(minikube completion bash) # for bash users\n\t\t$ source \u003c(minikube completion zsh) # for zsh users\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\n\tAdditionally, you may want to output the completion to a file and source in your .bashrc\n\n\tNote for zsh users: [1] zsh completions are only supported in versions of zsh \u003e= 5.2\n\tNote for fish users: [2] please refer to this docs for more details https://fishshell.com/docs/current/#tab-completion\n": "",
-	"Overwrite the existing image if the name:tag of the images are the same": "",
+	"Overwrite image even if same image:tag name exists": "",
 	"Path to the Dockerfile to use (optional)": "",
 	"Pause": "",
 	"Paused {{.count}} containers": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -405,6 +405,7 @@
 	"Options:      {{.options}}": "",
 	"Output format. Accepted values: [json]": "",
 	"Outputs minikube shell completion for the given shell (bash, zsh or fish)\n\n\tThis depends on the bash-completion binary.  Example installation instructions:\n\tOS X:\n\t\t$ brew install bash-completion\n\t\t$ source $(brew --prefix)/etc/bash_completion\n\t\t$ minikube completion bash \u003e ~/.minikube-completion  # for bash users\n\t\t$ minikube completion zsh \u003e ~/.minikube-completion  # for zsh users\n\t\t$ source ~/.minikube-completion\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\tUbuntu:\n\t\t$ apt-get install bash-completion\n\t\t$ source /etc/bash_completion\n\t\t$ source \u003c(minikube completion bash) # for bash users\n\t\t$ source \u003c(minikube completion zsh) # for zsh users\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\n\tAdditionally, you may want to output the completion to a file and source in your .bashrc\n\n\tNote for zsh users: [1] zsh completions are only supported in versions of zsh \u003e= 5.2\n\tNote for fish users: [2] please refer to this docs for more details https://fishshell.com/docs/current/#tab-completion\n": "",
+	"Over write the existing image if the name:tag of the images are the same": "",
 	"Path to the Dockerfile to use (optional)": "",
 	"Pause": "",
 	"Paused {{.count}} containers": "",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -397,6 +397,7 @@
 	"Options:      {{.options}}": "",
 	"Output format. Accepted values: [json]": "",
 	"Outputs minikube shell completion for the given shell (bash, zsh or fish)\n\n\tThis depends on the bash-completion binary.  Example installation instructions:\n\tOS X:\n\t\t$ brew install bash-completion\n\t\t$ source $(brew --prefix)/etc/bash_completion\n\t\t$ minikube completion bash \u003e ~/.minikube-completion  # for bash users\n\t\t$ minikube completion zsh \u003e ~/.minikube-completion  # for zsh users\n\t\t$ source ~/.minikube-completion\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\tUbuntu:\n\t\t$ apt-get install bash-completion\n\t\t$ source /etc/bash_completion\n\t\t$ source \u003c(minikube completion bash) # for bash users\n\t\t$ source \u003c(minikube completion zsh) # for zsh users\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\n\tAdditionally, you may want to output the completion to a file and source in your .bashrc\n\n\tNote for zsh users: [1] zsh completions are only supported in versions of zsh \u003e= 5.2\n\tNote for fish users: [2] please refer to this docs for more details https://fishshell.com/docs/current/#tab-completion\n": "",
+	"Over write the existing image if the name:tag of the images are the same": "",
 	"Path to the Dockerfile to use (optional)": "",
 	"Pause": "",
 	"Paused {{.count}} containers": "",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -397,7 +397,7 @@
 	"Options:      {{.options}}": "",
 	"Output format. Accepted values: [json]": "",
 	"Outputs minikube shell completion for the given shell (bash, zsh or fish)\n\n\tThis depends on the bash-completion binary.  Example installation instructions:\n\tOS X:\n\t\t$ brew install bash-completion\n\t\t$ source $(brew --prefix)/etc/bash_completion\n\t\t$ minikube completion bash \u003e ~/.minikube-completion  # for bash users\n\t\t$ minikube completion zsh \u003e ~/.minikube-completion  # for zsh users\n\t\t$ source ~/.minikube-completion\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\tUbuntu:\n\t\t$ apt-get install bash-completion\n\t\t$ source /etc/bash_completion\n\t\t$ source \u003c(minikube completion bash) # for bash users\n\t\t$ source \u003c(minikube completion zsh) # for zsh users\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\n\tAdditionally, you may want to output the completion to a file and source in your .bashrc\n\n\tNote for zsh users: [1] zsh completions are only supported in versions of zsh \u003e= 5.2\n\tNote for fish users: [2] please refer to this docs for more details https://fishshell.com/docs/current/#tab-completion\n": "",
-	"Overwrite the existing image if the name:tag of the images are the same": "",
+	"Overwrite image even if same image:tag name exists": "",
 	"Path to the Dockerfile to use (optional)": "",
 	"Pause": "",
 	"Paused {{.count}} containers": "",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -397,7 +397,7 @@
 	"Options:      {{.options}}": "",
 	"Output format. Accepted values: [json]": "",
 	"Outputs minikube shell completion for the given shell (bash, zsh or fish)\n\n\tThis depends on the bash-completion binary.  Example installation instructions:\n\tOS X:\n\t\t$ brew install bash-completion\n\t\t$ source $(brew --prefix)/etc/bash_completion\n\t\t$ minikube completion bash \u003e ~/.minikube-completion  # for bash users\n\t\t$ minikube completion zsh \u003e ~/.minikube-completion  # for zsh users\n\t\t$ source ~/.minikube-completion\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\tUbuntu:\n\t\t$ apt-get install bash-completion\n\t\t$ source /etc/bash_completion\n\t\t$ source \u003c(minikube completion bash) # for bash users\n\t\t$ source \u003c(minikube completion zsh) # for zsh users\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\n\tAdditionally, you may want to output the completion to a file and source in your .bashrc\n\n\tNote for zsh users: [1] zsh completions are only supported in versions of zsh \u003e= 5.2\n\tNote for fish users: [2] please refer to this docs for more details https://fishshell.com/docs/current/#tab-completion\n": "",
-	"Over write the existing image if the name:tag of the images are the same": "",
+	"Overwrite the existing image if the name:tag of the images are the same": "",
 	"Path to the Dockerfile to use (optional)": "",
 	"Pause": "",
 	"Paused {{.count}} containers": "",

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -424,7 +424,7 @@
 	"Options:      {{.options}}": "옵션:      {{.options}}",
 	"Output format. Accepted values: [json]": "",
 	"Outputs minikube shell completion for the given shell (bash, zsh or fish)\n\n\tThis depends on the bash-completion binary.  Example installation instructions:\n\tOS X:\n\t\t$ brew install bash-completion\n\t\t$ source $(brew --prefix)/etc/bash_completion\n\t\t$ minikube completion bash \u003e ~/.minikube-completion  # for bash users\n\t\t$ minikube completion zsh \u003e ~/.minikube-completion  # for zsh users\n\t\t$ source ~/.minikube-completion\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\tUbuntu:\n\t\t$ apt-get install bash-completion\n\t\t$ source /etc/bash_completion\n\t\t$ source \u003c(minikube completion bash) # for bash users\n\t\t$ source \u003c(minikube completion zsh) # for zsh users\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\n\tAdditionally, you may want to output the completion to a file and source in your .bashrc\n\n\tNote for zsh users: [1] zsh completions are only supported in versions of zsh \u003e= 5.2\n\tNote for fish users: [2] please refer to this docs for more details https://fishshell.com/docs/current/#tab-completion\n": "",
-	"Overwrite the existing image if the name:tag of the images are the same": "",
+	"Overwrite image even if same image:tag name exists": "",
 	"Path to the Dockerfile to use (optional)": "",
 	"Pause": "",
 	"Paused {{.count}} containers": "",

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -424,6 +424,7 @@
 	"Options:      {{.options}}": "옵션:      {{.options}}",
 	"Output format. Accepted values: [json]": "",
 	"Outputs minikube shell completion for the given shell (bash, zsh or fish)\n\n\tThis depends on the bash-completion binary.  Example installation instructions:\n\tOS X:\n\t\t$ brew install bash-completion\n\t\t$ source $(brew --prefix)/etc/bash_completion\n\t\t$ minikube completion bash \u003e ~/.minikube-completion  # for bash users\n\t\t$ minikube completion zsh \u003e ~/.minikube-completion  # for zsh users\n\t\t$ source ~/.minikube-completion\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\tUbuntu:\n\t\t$ apt-get install bash-completion\n\t\t$ source /etc/bash_completion\n\t\t$ source \u003c(minikube completion bash) # for bash users\n\t\t$ source \u003c(minikube completion zsh) # for zsh users\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\n\tAdditionally, you may want to output the completion to a file and source in your .bashrc\n\n\tNote for zsh users: [1] zsh completions are only supported in versions of zsh \u003e= 5.2\n\tNote for fish users: [2] please refer to this docs for more details https://fishshell.com/docs/current/#tab-completion\n": "",
+	"Over write the existing image if the name:tag of the images are the same": "",
 	"Path to the Dockerfile to use (optional)": "",
 	"Pause": "",
 	"Paused {{.count}} containers": "",

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -424,7 +424,7 @@
 	"Options:      {{.options}}": "옵션:      {{.options}}",
 	"Output format. Accepted values: [json]": "",
 	"Outputs minikube shell completion for the given shell (bash, zsh or fish)\n\n\tThis depends on the bash-completion binary.  Example installation instructions:\n\tOS X:\n\t\t$ brew install bash-completion\n\t\t$ source $(brew --prefix)/etc/bash_completion\n\t\t$ minikube completion bash \u003e ~/.minikube-completion  # for bash users\n\t\t$ minikube completion zsh \u003e ~/.minikube-completion  # for zsh users\n\t\t$ source ~/.minikube-completion\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\tUbuntu:\n\t\t$ apt-get install bash-completion\n\t\t$ source /etc/bash_completion\n\t\t$ source \u003c(minikube completion bash) # for bash users\n\t\t$ source \u003c(minikube completion zsh) # for zsh users\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\n\tAdditionally, you may want to output the completion to a file and source in your .bashrc\n\n\tNote for zsh users: [1] zsh completions are only supported in versions of zsh \u003e= 5.2\n\tNote for fish users: [2] please refer to this docs for more details https://fishshell.com/docs/current/#tab-completion\n": "",
-	"Over write the existing image if the name:tag of the images are the same": "",
+	"Overwrite the existing image if the name:tag of the images are the same": "",
 	"Path to the Dockerfile to use (optional)": "",
 	"Pause": "",
 	"Paused {{.count}} containers": "",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -417,6 +417,7 @@
 	"Output format. Accepted values: [json]": "",
 	"Outputs minikube shell completion for the given shell (bash or zsh)": "Zwraca autouzupełnianie poleceń minikube dla danej powłoki (bash, zsh)",
 	"Outputs minikube shell completion for the given shell (bash, zsh or fish)\n\n\tThis depends on the bash-completion binary.  Example installation instructions:\n\tOS X:\n\t\t$ brew install bash-completion\n\t\t$ source $(brew --prefix)/etc/bash_completion\n\t\t$ minikube completion bash \u003e ~/.minikube-completion  # for bash users\n\t\t$ minikube completion zsh \u003e ~/.minikube-completion  # for zsh users\n\t\t$ source ~/.minikube-completion\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\tUbuntu:\n\t\t$ apt-get install bash-completion\n\t\t$ source /etc/bash_completion\n\t\t$ source \u003c(minikube completion bash) # for bash users\n\t\t$ source \u003c(minikube completion zsh) # for zsh users\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\n\tAdditionally, you may want to output the completion to a file and source in your .bashrc\n\n\tNote for zsh users: [1] zsh completions are only supported in versions of zsh \u003e= 5.2\n\tNote for fish users: [2] please refer to this docs for more details https://fishshell.com/docs/current/#tab-completion\n": "",
+	"Over write the existing image if the name:tag of the images are the same": "",
 	"Path to the Dockerfile to use (optional)": "",
 	"Pause": "",
 	"Paused {{.count}} containers": "",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -417,7 +417,7 @@
 	"Output format. Accepted values: [json]": "",
 	"Outputs minikube shell completion for the given shell (bash or zsh)": "Zwraca autouzupełnianie poleceń minikube dla danej powłoki (bash, zsh)",
 	"Outputs minikube shell completion for the given shell (bash, zsh or fish)\n\n\tThis depends on the bash-completion binary.  Example installation instructions:\n\tOS X:\n\t\t$ brew install bash-completion\n\t\t$ source $(brew --prefix)/etc/bash_completion\n\t\t$ minikube completion bash \u003e ~/.minikube-completion  # for bash users\n\t\t$ minikube completion zsh \u003e ~/.minikube-completion  # for zsh users\n\t\t$ source ~/.minikube-completion\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\tUbuntu:\n\t\t$ apt-get install bash-completion\n\t\t$ source /etc/bash_completion\n\t\t$ source \u003c(minikube completion bash) # for bash users\n\t\t$ source \u003c(minikube completion zsh) # for zsh users\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\n\tAdditionally, you may want to output the completion to a file and source in your .bashrc\n\n\tNote for zsh users: [1] zsh completions are only supported in versions of zsh \u003e= 5.2\n\tNote for fish users: [2] please refer to this docs for more details https://fishshell.com/docs/current/#tab-completion\n": "",
-	"Over write the existing image if the name:tag of the images are the same": "",
+	"Overwrite the existing image if the name:tag of the images are the same": "",
 	"Path to the Dockerfile to use (optional)": "",
 	"Pause": "",
 	"Paused {{.count}} containers": "",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -417,7 +417,7 @@
 	"Output format. Accepted values: [json]": "",
 	"Outputs minikube shell completion for the given shell (bash or zsh)": "Zwraca autouzupełnianie poleceń minikube dla danej powłoki (bash, zsh)",
 	"Outputs minikube shell completion for the given shell (bash, zsh or fish)\n\n\tThis depends on the bash-completion binary.  Example installation instructions:\n\tOS X:\n\t\t$ brew install bash-completion\n\t\t$ source $(brew --prefix)/etc/bash_completion\n\t\t$ minikube completion bash \u003e ~/.minikube-completion  # for bash users\n\t\t$ minikube completion zsh \u003e ~/.minikube-completion  # for zsh users\n\t\t$ source ~/.minikube-completion\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\tUbuntu:\n\t\t$ apt-get install bash-completion\n\t\t$ source /etc/bash_completion\n\t\t$ source \u003c(minikube completion bash) # for bash users\n\t\t$ source \u003c(minikube completion zsh) # for zsh users\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\n\tAdditionally, you may want to output the completion to a file and source in your .bashrc\n\n\tNote for zsh users: [1] zsh completions are only supported in versions of zsh \u003e= 5.2\n\tNote for fish users: [2] please refer to this docs for more details https://fishshell.com/docs/current/#tab-completion\n": "",
-	"Overwrite the existing image if the name:tag of the images are the same": "",
+	"Overwrite image even if same image:tag name exists": "",
 	"Path to the Dockerfile to use (optional)": "",
 	"Pause": "",
 	"Paused {{.count}} containers": "",

--- a/translations/strings.txt
+++ b/translations/strings.txt
@@ -377,7 +377,7 @@
 	"Options:      {{.options}}": "",
 	"Output format. Accepted values: [json]": "",
 	"Outputs minikube shell completion for the given shell (bash, zsh or fish)\n\n\tThis depends on the bash-completion binary.  Example installation instructions:\n\tOS X:\n\t\t$ brew install bash-completion\n\t\t$ source $(brew --prefix)/etc/bash_completion\n\t\t$ minikube completion bash \u003e ~/.minikube-completion  # for bash users\n\t\t$ minikube completion zsh \u003e ~/.minikube-completion  # for zsh users\n\t\t$ source ~/.minikube-completion\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\tUbuntu:\n\t\t$ apt-get install bash-completion\n\t\t$ source /etc/bash_completion\n\t\t$ source \u003c(minikube completion bash) # for bash users\n\t\t$ source \u003c(minikube completion zsh) # for zsh users\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\n\tAdditionally, you may want to output the completion to a file and source in your .bashrc\n\n\tNote for zsh users: [1] zsh completions are only supported in versions of zsh \u003e= 5.2\n\tNote for fish users: [2] please refer to this docs for more details https://fishshell.com/docs/current/#tab-completion\n": "",
-	"Overwrite the existing image if the name:tag of the images are the same": "",
+	"Overwrite image even if same image:tag name exists": "",
 	"Path to the Dockerfile to use (optional)": "",
 	"Pause": "",
 	"Paused {{.count}} containers": "",

--- a/translations/strings.txt
+++ b/translations/strings.txt
@@ -377,6 +377,7 @@
 	"Options:      {{.options}}": "",
 	"Output format. Accepted values: [json]": "",
 	"Outputs minikube shell completion for the given shell (bash, zsh or fish)\n\n\tThis depends on the bash-completion binary.  Example installation instructions:\n\tOS X:\n\t\t$ brew install bash-completion\n\t\t$ source $(brew --prefix)/etc/bash_completion\n\t\t$ minikube completion bash \u003e ~/.minikube-completion  # for bash users\n\t\t$ minikube completion zsh \u003e ~/.minikube-completion  # for zsh users\n\t\t$ source ~/.minikube-completion\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\tUbuntu:\n\t\t$ apt-get install bash-completion\n\t\t$ source /etc/bash_completion\n\t\t$ source \u003c(minikube completion bash) # for bash users\n\t\t$ source \u003c(minikube completion zsh) # for zsh users\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\n\tAdditionally, you may want to output the completion to a file and source in your .bashrc\n\n\tNote for zsh users: [1] zsh completions are only supported in versions of zsh \u003e= 5.2\n\tNote for fish users: [2] please refer to this docs for more details https://fishshell.com/docs/current/#tab-completion\n": "",
+	"Over write the existing image if the name:tag of the images are the same": "",
 	"Path to the Dockerfile to use (optional)": "",
 	"Pause": "",
 	"Paused {{.count}} containers": "",

--- a/translations/strings.txt
+++ b/translations/strings.txt
@@ -377,7 +377,7 @@
 	"Options:      {{.options}}": "",
 	"Output format. Accepted values: [json]": "",
 	"Outputs minikube shell completion for the given shell (bash, zsh or fish)\n\n\tThis depends on the bash-completion binary.  Example installation instructions:\n\tOS X:\n\t\t$ brew install bash-completion\n\t\t$ source $(brew --prefix)/etc/bash_completion\n\t\t$ minikube completion bash \u003e ~/.minikube-completion  # for bash users\n\t\t$ minikube completion zsh \u003e ~/.minikube-completion  # for zsh users\n\t\t$ source ~/.minikube-completion\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\tUbuntu:\n\t\t$ apt-get install bash-completion\n\t\t$ source /etc/bash_completion\n\t\t$ source \u003c(minikube completion bash) # for bash users\n\t\t$ source \u003c(minikube completion zsh) # for zsh users\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\n\tAdditionally, you may want to output the completion to a file and source in your .bashrc\n\n\tNote for zsh users: [1] zsh completions are only supported in versions of zsh \u003e= 5.2\n\tNote for fish users: [2] please refer to this docs for more details https://fishshell.com/docs/current/#tab-completion\n": "",
-	"Over write the existing image if the name:tag of the images are the same": "",
+	"Overwrite the existing image if the name:tag of the images are the same": "",
 	"Path to the Dockerfile to use (optional)": "",
 	"Pause": "",
 	"Paused {{.count}} containers": "",

--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -488,7 +488,7 @@
 	"Options:      {{.options}}": "",
 	"Output format. Accepted values: [json]": "",
 	"Outputs minikube shell completion for the given shell (bash, zsh or fish)\n\n\tThis depends on the bash-completion binary.  Example installation instructions:\n\tOS X:\n\t\t$ brew install bash-completion\n\t\t$ source $(brew --prefix)/etc/bash_completion\n\t\t$ minikube completion bash \u003e ~/.minikube-completion  # for bash users\n\t\t$ minikube completion zsh \u003e ~/.minikube-completion  # for zsh users\n\t\t$ source ~/.minikube-completion\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\tUbuntu:\n\t\t$ apt-get install bash-completion\n\t\t$ source /etc/bash_completion\n\t\t$ source \u003c(minikube completion bash) # for bash users\n\t\t$ source \u003c(minikube completion zsh) # for zsh users\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\n\tAdditionally, you may want to output the completion to a file and source in your .bashrc\n\n\tNote for zsh users: [1] zsh completions are only supported in versions of zsh \u003e= 5.2\n\tNote for fish users: [2] please refer to this docs for more details https://fishshell.com/docs/current/#tab-completion\n": "",
-	"Overwrite the existing image if the name:tag of the images are the same": "",
+	"Overwrite image even if same image:tag name exists": "",
 	"Path to the Dockerfile to use (optional)": "",
 	"Pause": "暂停",
 	"Paused kubelet and {{.count}} containers": "已暂停 kubelet 和 {{.count}} 个容器",

--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -488,7 +488,7 @@
 	"Options:      {{.options}}": "",
 	"Output format. Accepted values: [json]": "",
 	"Outputs minikube shell completion for the given shell (bash, zsh or fish)\n\n\tThis depends on the bash-completion binary.  Example installation instructions:\n\tOS X:\n\t\t$ brew install bash-completion\n\t\t$ source $(brew --prefix)/etc/bash_completion\n\t\t$ minikube completion bash \u003e ~/.minikube-completion  # for bash users\n\t\t$ minikube completion zsh \u003e ~/.minikube-completion  # for zsh users\n\t\t$ source ~/.minikube-completion\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\tUbuntu:\n\t\t$ apt-get install bash-completion\n\t\t$ source /etc/bash_completion\n\t\t$ source \u003c(minikube completion bash) # for bash users\n\t\t$ source \u003c(minikube completion zsh) # for zsh users\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\n\tAdditionally, you may want to output the completion to a file and source in your .bashrc\n\n\tNote for zsh users: [1] zsh completions are only supported in versions of zsh \u003e= 5.2\n\tNote for fish users: [2] please refer to this docs for more details https://fishshell.com/docs/current/#tab-completion\n": "",
-	"Over write the existing image if the name:tag of the images are the same": "",
+	"Overwrite the existing image if the name:tag of the images are the same": "",
 	"Path to the Dockerfile to use (optional)": "",
 	"Pause": "暂停",
 	"Paused kubelet and {{.count}} containers": "已暂停 kubelet 和 {{.count}} 个容器",

--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -488,6 +488,7 @@
 	"Options:      {{.options}}": "",
 	"Output format. Accepted values: [json]": "",
 	"Outputs minikube shell completion for the given shell (bash, zsh or fish)\n\n\tThis depends on the bash-completion binary.  Example installation instructions:\n\tOS X:\n\t\t$ brew install bash-completion\n\t\t$ source $(brew --prefix)/etc/bash_completion\n\t\t$ minikube completion bash \u003e ~/.minikube-completion  # for bash users\n\t\t$ minikube completion zsh \u003e ~/.minikube-completion  # for zsh users\n\t\t$ source ~/.minikube-completion\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\tUbuntu:\n\t\t$ apt-get install bash-completion\n\t\t$ source /etc/bash_completion\n\t\t$ source \u003c(minikube completion bash) # for bash users\n\t\t$ source \u003c(minikube completion zsh) # for zsh users\n\t\t$ minikube completion fish \u003e ~/.config/fish/completions/minikube.fish # for fish users\n\n\tAdditionally, you may want to output the completion to a file and source in your .bashrc\n\n\tNote for zsh users: [1] zsh completions are only supported in versions of zsh \u003e= 5.2\n\tNote for fish users: [2] please refer to this docs for more details https://fishshell.com/docs/current/#tab-completion\n": "",
+	"Over write the existing image if the name:tag of the images are the same": "",
 	"Path to the Dockerfile to use (optional)": "",
 	"Pause": "暂停",
 	"Paused kubelet and {{.count}} containers": "已暂停 kubelet 和 {{.count}} 个容器",


### PR DESCRIPTION
Closes #11276

Before:
If you had an image already loaded into minikube, and then created a new image with the same name:tag as one already loaded into minikube and ran `minikube image load` it would skip loading the image since it detected a matching name:tag, even though the image itself is different.

After:
`minikube image load` will load the image, even if an image with the existing name:tag is already loaded into minikube.