### PR TITLE
Updated URL and remove zsh note

### DIFF
--- a/site/content/en/docs/handbook/kubectl.md
+++ b/site/content/en/docs/handbook/kubectl.md
@@ -50,5 +50,4 @@ minikube kubectl -- --help
 
 ### Shell autocompletion
 
-After applying the alias or the symbolic link you can follow https://kubernetes.io/docs/tasks/tools/install-kubectl/#enabling-shell-autocompletion to enable shell-autocompletion.
-When using zsh and the alias approach you also have to execute `setopt complete_aliases`.
+After applying the alias or the symbolic link you can follow https://kubernetes.io/docs/tasks/tools/included/optional-kubectl-configs-bash-linux/ to enable shell-autocompletion.


### PR DESCRIPTION
The URL was outdated.
Removed the zsh note, too. I think it makes sense that it gets explained on the target page, not here.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
