### PR TITLE
Fix error picking non-default alternate drivers

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -214,7 +214,7 @@ func runStart(cmd *cobra.Command, args []string) {
 			// Walk down the rest of the options
 			for _, alt := range alts {
 				// Skip non-default drivers
-				if !ds.Default {
+				if !alt.Default {
 					continue
 				}
 				out.WarningT("Startup with {{.old_driver}} driver failed, trying with alternate driver {{.new_driver}}: {{.error}}", out.V{"old_driver": ds.Name, "new_driver": alt.Name, "error": err})


### PR DESCRIPTION
We should not select drivers like "ssh" or "none",
unless explicitly requested by the user. Wrong var...

Fix small  bug from PR #10554
When fixing issue from PR #7389