### PR TITLE
Refactor hack/release_notes.sh pullsheet commands and use sort instead of awk sorting

### DIFF
--- a/hack/release_notes.sh
+++ b/hack/release_notes.sh
@@ -56,8 +56,11 @@ git log "$recent".. --format="%aN" --reverse | sort | uniq | awk '{printf "- %s\
 echo ""
 echo "Thank you to our PR reviewers for this release!"
 echo ""
-"${DIR}/pullsheet" reviews --since "$recent_date" --repos kubernetes/minikube --token-path $DIR/gh_token.txt | awk -F ',' 'function cmp_value_order(i1,v1,i2,v2){ return v1 < v2 } NR>1{arr[$4] += $6 + $7}END{PROCINFO["sorted_in"] = "cmp_value_order"; for (a in arr) printf "- %s (%d comments)\n", a, arr[a]}'
+AWK_FORMAT_ITEM='{printf "- %s (%d comments)\n", $2, $1}'
+AWK_REVIEW_COMMENTS='NR>1{arr[$4] += $6 + $7}END{for (a in arr) printf "%d %s\n", arr[a], a}'
+"${DIR}/pullsheet" reviews --since "$recent_date" --repos kubernetes/minikube --token-path $DIR/gh_token.txt | awk -F ',' "$AWK_REVIEW_COMMENTS" | sort -k1nr -k2d  | awk -F ' ' "$AWK_FORMAT_ITEM"
 echo ""
 echo "Thank you to our triage members for this release!"
 echo ""
-"${DIR}/pullsheet" issue-comments --since "$recent_date" --repos kubernetes/minikube --token-path $DIR/gh_token.txt | awk -F ',' 'function cmp_value_order(i1,v1,i2,v2){ return v1 < v2 } NR>1{arr[$4] += $7}END{PROCINFO["sorted_in"] = "cmp_value_order"; for (a in arr) printf "- %s (%d comments)\n", a, arr[a]}' | head -n 5
+AWK_ISSUE_COMMENTS='NR>1{arr[$4] += $7}END{for (a in arr) printf "%d %s\n", arr[a], a}'
+"${DIR}/pullsheet" issue-comments --since "$recent_date" --repos kubernetes/minikube --token-path $DIR/gh_token.txt | awk -F ',' "$AWK_ISSUE_COMMENTS" | sort -k1nr -k2d  | awk -F ' ' "$AWK_FORMAT_ITEM" | head -n 5


### PR DESCRIPTION
fixes #11365.

Awk sorting doesn't work on Mac (I've tried everything I can think of).

Before (Mac):
```
$ hack/release_notes.sh 2> /dev/null
* alias: switch place of minikube image ls and list [#11349](https://github.com/kubernetes/minikube/pull/11349)
* Use upgrade instead of install for the RPM installation [#11354](https://github.com/kubernetes/minikube/pull/11354)
* Bump google.golang.org/api from 0.45.0 to 0.46.0 [#11362](https://github.com/kubernetes/minikube/pull/11362)
* Add missing arm64 tarballs to the release page [#11350](https://github.com/kubernetes/minikube/pull/11350)
* Bump github.com/otiai10/copy from 1.5.1 to 1.6.0 [#11360](https://github.com/kubernetes/minikube/pull/11360)
* Updated URL and remove zsh note [#11369](https://github.com/kubernetes/minikube/pull/11369)
* Revert "base-image: Allow using podman as well as docker daemon" [#11356](https://github.com/kubernetes/minikube/pull/11356)
* fix flaky OLM addon test by increasing timeout limit [#11337](https://github.com/kubernetes/minikube/pull/11337)
* completion: add specific shell completion [#11191](https://github.com/kubernetes/minikube/pull/11191)
* docs: fix format issue for Contributor Guide [#11338](https://github.com/kubernetes/minikube/pull/11338)
* docs: fix sidebar current page highlight issue [#11341](https://github.com/kubernetes/minikube/pull/11341)
* base-image: Allow using podman as well as docker daemon [#11063](https://github.com/kubernetes/minikube/pull/11063)
* improve french translation [#11342](https://github.com/kubernetes/minikube/pull/11342)
* Refactoring generate/update config file code. [#10899](https://github.com/kubernetes/minikube/pull/10899)
* unify integration test names for uploading [#11340](https://github.com/kubernetes/minikube/pull/11340)
* update translation strings [#11339](https://github.com/kubernetes/minikube/pull/11339)
* ci: combine run_tests.sh and common.sh for integration testing [#11317](https://github.com/kubernetes/minikube/pull/11317)
* docker driver: allow  development version of docker (moby) [#11309](https://github.com/kubernetes/minikube/pull/11309)
* Fix output for autopause issue link [#11316](https://github.com/kubernetes/minikube/pull/11316)
* update releases.json to include v1.20.0 [#11318](https://github.com/kubernetes/minikube/pull/11318)

For a more detailed changelog, including changes occuring in pre-release versions, see [CHANGELOG.md](https://github.com/kubernetes/minikube/blob/master/CHANGELOG.md).

Thank you to our contributors for this release!

- Akihiro Suda
- Alessandro Lenzen
- Anders F Björklund
- Brian de Alwis
- Daehyeok Mun
- Li Zhijian
- Medya Gh
- Medya Ghazizadeh
- Peixuan Ding
- Sharif Elgamal
- Thomas Güttler
- dependabot[bot]
- minikube-bot

Thank you to our PR reviewers for this release!

- medyagh (7 comments)
- afbjorklund (4 comments)
- spowelljr (4 comments)
- sharifelgamal (1 comments)

Thank you to our triage members for this release!

- r4j4h (1 comments)
- valeriaverboloz (1 comments)
- Srikrishnabh (4 comments)
- vaibhavmagon (1 comments)
- y0zg (1 comments)
```
After (Mac):
```
$ hack/release_notes.sh 2> /dev/null
* alias: switch place of minikube image ls and list [#11349](https://github.com/kubernetes/minikube/pull/11349)
* Use upgrade instead of install for the RPM installation [#11354](https://github.com/kubernetes/minikube/pull/11354)
* Bump google.golang.org/api from 0.45.0 to 0.46.0 [#11362](https://github.com/kubernetes/minikube/pull/11362)
* Add missing arm64 tarballs to the release page [#11350](https://github.com/kubernetes/minikube/pull/11350)
* Bump github.com/otiai10/copy from 1.5.1 to 1.6.0 [#11360](https://github.com/kubernetes/minikube/pull/11360)
* Updated URL and remove zsh note [#11369](https://github.com/kubernetes/minikube/pull/11369)
* Revert "base-image: Allow using podman as well as docker daemon" [#11356](https://github.com/kubernetes/minikube/pull/11356)
* fix flaky OLM addon test by increasing timeout limit [#11337](https://github.com/kubernetes/minikube/pull/11337)
* completion: add specific shell completion [#11191](https://github.com/kubernetes/minikube/pull/11191)
* docs: fix format issue for Contributor Guide [#11338](https://github.com/kubernetes/minikube/pull/11338)
* docs: fix sidebar current page highlight issue [#11341](https://github.com/kubernetes/minikube/pull/11341)
* base-image: Allow using podman as well as docker daemon [#11063](https://github.com/kubernetes/minikube/pull/11063)
* improve french translation [#11342](https://github.com/kubernetes/minikube/pull/11342)
* Refactoring generate/update config file code. [#10899](https://github.com/kubernetes/minikube/pull/10899)
* unify integration test names for uploading [#11340](https://github.com/kubernetes/minikube/pull/11340)
* update translation strings [#11339](https://github.com/kubernetes/minikube/pull/11339)
* ci: combine run_tests.sh and common.sh for integration testing [#11317](https://github.com/kubernetes/minikube/pull/11317)
* docker driver: allow  development version of docker (moby) [#11309](https://github.com/kubernetes/minikube/pull/11309)
* Fix output for autopause issue link [#11316](https://github.com/kubernetes/minikube/pull/11316)
* update releases.json to include v1.20.0 [#11318](https://github.com/kubernetes/minikube/pull/11318)

For a more detailed changelog, including changes occuring in pre-release versions, see [CHANGELOG.md](https://github.com/kubernetes/minikube/blob/master/CHANGELOG.md).

Thank you to our contributors for this release!

- Akihiro Sudaadministrator@5665 minikube %
- Alessandro Lenzen
- Anders F Björklund
- Andriy Dzikh
- Brian de Alwis
- Daehyeok Mun
- Li Zhijian
- Medya Gh
- Medya Ghazizadeh
- Peixuan Ding
- Sharif Elgamal
- Thomas Güttler
- dependabot[bot]
- minikube-bot

Thank you to our PR reviewers for this release!

- medyagh (7 comments)
- afbjorklund (4 comments)
- spowelljr (4 comments)
- sharifelgamal (1 comments)

Thank you to our triage members for this release!

- afbjorklund (34 comments)
- medyagh (9 comments)
- dinever (6 comments)
- AkihiroSuda (4 comments)
- Srikrishnabh (4 comments)
```