### PR TITLE
Add useful tools in the Kicbase Docker image

### DIFF
--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -63,6 +63,7 @@ RUN echo "Ensuring scripts are executable ..." \
       libseccomp2 pigz \
       bash ca-certificates curl rsync \
       nfs-common \
+      iputils-ping netcat-openbsd vim-tiny \
     && find /lib/systemd/system/sysinit.target.wants/ -name "systemd-tmpfiles-setup.service" -delete \
     && rm -f /lib/systemd/system/multi-user.target.wants/* \
     && rm -f /etc/systemd/system/*.wants/* \

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -24,13 +24,13 @@ import (
 
 const (
 	// Version is the current version of kic
-	Version = "v0.0.22"
+	Version = "v0.0.22-1620785771-11384"
 	// SHA of the kic base image
-	baseImageSHA = "7cc3a3cb6e51c628d8ede157ad9e1f797e8d22a1b3cedc12d3f1999cb52f962e"
+	baseImageSHA = "f5844fe35994179bbad8dda27d4912304a2fedccdf0bf93ce8b2ec2b3b83af1c"
 	// The name of the GCR kicbase repository
-	gcrRepo = "gcr.io/k8s-minikube/kicbase"
+	gcrRepo = "gcr.io/k8s-minikube/kicbase-builds"
 	// The name of the Dockerhub kicbase repository
-	dockerhubRepo = "kicbase/stable"
+	dockerhubRepo = "kicbase/build"
 )
 
 var (

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -26,7 +26,7 @@ minikube start [flags]
       --apiserver-names strings           A set of apiserver names which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine
       --apiserver-port int                The apiserver listening port (default 8443)
       --auto-update-drivers               If set, automatically updates drivers to the latest version. Defaults to true. (default true)
-      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase:v0.0.22@sha256:7cc3a3cb6e51c628d8ede157ad9e1f797e8d22a1b3cedc12d3f1999cb52f962e")
+      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.22-1620785771-11384@sha256:f5844fe35994179bbad8dda27d4912304a2fedccdf0bf93ce8b2ec2b3b83af1c")
       --cache-images                      If true, cache docker images for the current bootstrapper and load them into the machine. Always false with --driver=none. (default true)
       --cni string                        CNI plug-in to use. Valid options: auto, bridge, calico, cilium, flannel, kindnet, or path to a CNI manifest (default: auto)
       --container-runtime string          The container runtime to be used (docker, cri-o, containerd). (default "docker")

--- a/site/content/en/docs/handbook/host-access.md
+++ b/site/content/en/docs/handbook/host-access.md
@@ -11,7 +11,7 @@ aliases:
 
 The service running on your host must either be bound to all IP's (0.0.0.0) and interfaces, or to the IP and interface your VM is bridged against. If the service is bound only to localhost (127.0.0.1), this will not work.
 
-### host.minikube.internal
+### `host.minikube.internal`
 
 To make it easier to access your host, minikube v1.10 adds a hostname entry `host.minikube.internal` to `/etc/hosts`. The IP which `host.minikube.internal` resolves to is different across drivers, and may be different across clusters.
 
@@ -32,8 +32,20 @@ PING host.minikube.internal (192.168.64.1): 56 data bytes
 64 bytes from 192.168.64.1: seq=0 ttl=64 time=0.225 ms
 ```
 
-To test connectivity to a specific TCP service listening on your host, use `telnet host.minikube.internal <port>`. Here are how to interpret the different messages:
+To test connectivity to a specific TCP service listening on your host, use `nc -vz host.minikube.internal <port>`:
 
-* `<nothing>`: You are connected! Hit Ctrl-D to get back to a shell prompt.
+```sh
+$ nc -vz host.minikube.internal 8000
+Connection to host.minikube.internal 8000 port [tcp/*] succeeded!
+```
+
+Here are how to interpret the different messages:
+* `Connection succeeded`: You are connected!
 * `Connection refused`: the service is not listening on the port, at least not across all interfaces
-* `Connection closed by foreign host`: the service is listening, but decided that your telnet client did not meet the protocol handshake requirements. Using a real client will likely work.
+
+{{% alert title="Note" color="primary" %}}
+When using an older version of minikube, you may have to manually install tools like `ping` and `netcat` within the minikube image:
+```sh
+sudo apt install iputils-ping netcat-openbsd
+```
+{{% /alert %}}


### PR DESCRIPTION
closes #11372, #11375

- Added `vi` for easier file editing
- Added `ping` since it's one of the troubleshooting tools
- Added `netcat` and replace `telnet` in the docs with `netcat` since `netcat` is more preferred. (See https://github.com/kubernetes/minikube/issues/11372#issuecomment-838997494)

![Screenshot from 2021-05-11 21-50-25](https://user-images.githubusercontent.com/1311594/117906451-ef0d3b80-b2a2-11eb-8ce5-3404240aaf52.png)
