### PR TITLE
Fix TestKubernetesUpgrade

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -571,6 +571,10 @@ func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterC
 	updateBoolFromFlag(cmd, &cc.KubernetesConfig.ShouldLoadCachedImages, cacheImages)
 	updateIntFromFlag(cmd, &cc.KubernetesConfig.NodePort, apiServerPort)
 
+	if cmd.Flags().Changed(kubernetesVersion) {
+		cc.KubernetesConfig.KubernetesVersion = getKubernetesVersion(existing)
+	}
+
 	if cmd.Flags().Changed("extra-config") {
 		cc.KubernetesConfig.ExtraOptions = config.ExtraOptions
 	}

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -562,6 +562,7 @@ func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterC
 	updateIntFromFlag(cmd, &cc.SSHPort, sshSSHPort)
 	updateStringFromFlag(cmd, &cc.KubernetesConfig.Namespace, startNamespace)
 	updateStringFromFlag(cmd, &cc.KubernetesConfig.APIServerName, apiServerName)
+	updateStringSliceFromFlag(cmd, &cc.KubernetesConfig.APIServerNames, "apiserver-names")
 	updateStringFromFlag(cmd, &cc.KubernetesConfig.DNSDomain, dnsDomain)
 	updateStringFromFlag(cmd, &cc.KubernetesConfig.FeatureGates, featureGates)
 	updateStringFromFlag(cmd, &cc.KubernetesConfig.ContainerRuntime, containerRuntime)

--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -266,7 +266,7 @@ func TestKubernetesUpgrade(t *testing.T) {
 	}
 
 	if cv.ServerVersion.GitVersion != constants.NewestKubernetesVersion {
-		t.Fatalf("expected server version %s is not the same with latest version %s", cv.ServerVersion.GitVersion, constants.NewestKubernetesVersion)
+		t.Fatalf("server version %s is not the same with the expected version %s after upgrade", cv.ServerVersion.GitVersion, constants.NewestKubernetesVersion)
 	}
 
 	t.Logf("Attempting to downgrade Kubernetes (should fail)")


### PR DESCRIPTION
Hi,

This PR fixes #11376. The issue seems to be 50637dd1498504c1f15aa911319cd148c963633e accidentally removed these lines:

```go
	if cmd.Flags().Changed(kubernetesVersion) {
		cc.KubernetesConfig.KubernetesVersion = getKubernetesVersion(existing)
	}
```

https://github.com/kubernetes/minikube/commit/50637dd1498504c1f15aa911319cd148c963633e#diff-0e864ab4025634664724909a47c34fbcae246ad52307eaaaa58153f0b256a8b4L636-L638

Testing result after the fix:

<details>

```
go build  -tags "" -ldflags="-X k8s.io/minikube/pkg/version.version=v1.20.0 -X k8s.io/minikube/pkg/version.isoVersion=v1.20.0 -X k8s.io/minikube/pkg/version.gitCommitID="d156e5cbed1675d44126b89bb176b3b399e3d2b7" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" -o out/minikube k8s.io/minikube/cmd/minikube
go test -ldflags="-X k8s.io/minikube/pkg/version.version=v1.20.0 -X k8s.io/minikube/pkg/version.isoVersion=v1.20.0 -X k8s.io/minikube/pkg/version.gitCommitID="d156e5cbed1675d44126b89bb176b3b399e3d2b7" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" -v -test.timeout=90m ./test/integration --tags="integration " -minikube-start-args=--driver=docker -test.run TestKubernetesUpgrade 2>&1 | tee "./out/testout_d156e5cbe.txt"
Found 16 cores, limiting parallelism with --test.parallel=9
=== RUN   TestKubernetesUpgrade
=== PAUSE TestKubernetesUpgrade
=== CONT  TestKubernetesUpgrade
    version_upgrade_test.go:227: (dbg) Run:  out/minikube start -p kubernetes-upgrade-20210512215149-95553 --memory=2200 --kubernetes-version=v1.14.0 --alsologtostderr -v=1 --driver=docker
    version_upgrade_test.go:227: (dbg) Done: out/minikube start -p kubernetes-upgrade-20210512215149-95553 --memory=2200 --kubernetes-version=v1.14.0 --alsologtostderr -v=1 --driver=docker: (1m44.14501526s)
    version_upgrade_test.go:232: (dbg) Run:  out/minikube stop -p kubernetes-upgrade-20210512215149-95553
    version_upgrade_test.go:232: (dbg) Done: out/minikube stop -p kubernetes-upgrade-20210512215149-95553: (19.438593985s)
    version_upgrade_test.go:237: (dbg) Run:  out/minikube -p kubernetes-upgrade-20210512215149-95553 status --format={{.Host}}
    version_upgrade_test.go:237: (dbg) Non-zero exit: out/minikube -p kubernetes-upgrade-20210512215149-95553 status --format={{.Host}}: exit status 7 (224.761294ms)

        -- stdout --
        	Stopped

        -- /stdout --
    version_upgrade_test.go:239: status error: exit status 7 (may be ok)
    version_upgrade_test.go:248: (dbg) Run:  out/minikube start -p kubernetes-upgrade-20210512215149-95553 --memory=2200 --kubernetes-version=v1.22.0-alpha.1 --alsologtostderr -v=1 --driver=docker
    version_upgrade_test.go:248: (dbg) Done: out/minikube start -p kubernetes-upgrade-20210512215149-95553 --memory=2200 --kubernetes-version=v1.22.0-alpha.1 --alsologtostderr -v=1 --driver=docker: (1m41.768097038s)
    version_upgrade_test.go:253: (dbg) Run:  kubectl --context kubernetes-upgrade-20210512215149-95553 version --output=json
    version_upgrade_test.go:272: Attempting to downgrade Kubernetes (should fail)
    version_upgrade_test.go:274: (dbg) Run:  out/minikube start -p kubernetes-upgrade-20210512215149-95553 --memory=2200 --kubernetes-version=v1.14.0 --driver=docker
    version_upgrade_test.go:274: (dbg) Non-zero exit: out/minikube start -p kubernetes-upgrade-20210512215149-95553 --memory=2200 --kubernetes-version=v1.14.0 --driver=docker: exit status 106 (210.804351ms)

        -- stdout --
        	* [kubernetes-upgrade-20210512215149-95553] minikube v1.20.0 on Darwin 10.15.7
        	  - KUBECONFIG=/Users/pding200/.kube/config-linear-dev



        -- /stdout --
        ** stderr **
        	X Exiting due to K8S_DOWNGRADE_UNSUPPORTED: Unable to safely downgrade existing Kubernetes v1.22.0-alpha.1 cluster to v1.14.0
        	* Suggestion:

        	    1) Recreate the cluster with Kubernetes 1.14.0, by running:

        	    minikube delete -p kubernetes-upgrade-20210512215149-95553
        	    minikube start -p kubernetes-upgrade-20210512215149-95553 --kubernetes-version=v1.14.0

        	    2) Create a second cluster with Kubernetes 1.14.0, by running:

        	    minikube start -p kubernetes-upgrade-20210512215149-955532 --kubernetes-version=v1.14.0

        	    3) Use the existing cluster at version Kubernetes 1.22.0-alpha.1, by running:

        	    minikube start -p kubernetes-upgrade-20210512215149-95553 --kubernetes-version=v1.22.0-alpha.1


        ** /stderr **
    version_upgrade_test.go:278: Attempting restart after unsuccessful downgrade
    version_upgrade_test.go:280: (dbg) Run:  out/minikube start -p kubernetes-upgrade-20210512215149-95553 --memory=2200 --kubernetes-version=v1.22.0-alpha.1 --alsologtostderr -v=1 --driver=docker
    version_upgrade_test.go:280: (dbg) Done: out/minikube start -p kubernetes-upgrade-20210512215149-95553 --memory=2200 --kubernetes-version=v1.22.0-alpha.1 --alsologtostderr -v=1 --driver=docker: (1m27.421891854s)
    helpers_test.go:171: Cleaning up "kubernetes-upgrade-20210512215149-95553" profile ...
    helpers_test.go:174: (dbg) Run:  out/minikube delete -p kubernetes-upgrade-20210512215149-95553
    helpers_test.go:174: (dbg) Done: out/minikube delete -p kubernetes-upgrade-20210512215149-95553: (16.78051616s)
--- PASS: TestKubernetesUpgrade (330.12s)
PASS
Tests completed in 5m30.122456543s (result code 0)
ok  	k8s.io/minikube/test/integration	332.075s
```
</details>

Thanks!