### PR TITLE
Implement a quiz-style installation instructions

### DIFF
--- a/hack/jenkins/release_build_and_upload.sh
+++ b/hack/jenkins/release_build_and_upload.sh
@@ -90,8 +90,14 @@ make checksum
 # unversioned names to avoid updating upstream Kubernetes documentation each release
 cp "out/minikube_${DEB_VERSION}-0_amd64.deb" out/minikube_latest_amd64.deb
 cp "out/minikube_${DEB_VERSION}-0_arm64.deb" out/minikube_latest_arm64.deb
+cp "out/minikube-${DEB_VERSION}-0_armhf.deb" out/minikube_latest_armhf.deb
+cp "out/minikube-${DEB_VERSION}-0_ppc64el.deb" out/minikube_latest_ppc64el.deb
+cp "out/minikube-${DEB_VERSION}-0_s390x.deb" out/minikube_latest_s390x.deb
 cp "out/minikube-${RPM_VERSION}-0.x86_64.rpm" out/minikube-latest.x86_64.rpm
 cp "out/minikube-${RPM_VERSION}-0.aarch64.rpm" out/minikube-latest.aarch64.rpm
+cp "out/minikube-${RPM_VERSION}-0.armv7hl.rpm" out/minikube-latest.armv7hl.rpm
+cp "out/minikube-${RPM_VERSION}-0.ppc64le.rpm" out/minikube-latest.ppc64le.rpm
+cp "out/minikube-${RPM_VERSION}-0.s390x.rpm" out/minikube-latest.s390x.rpm
 
 gsutil -m cp out/* "gs://$BUCKET/releases/$TAGNAME/"
 

--- a/hack/jenkins/release_build_and_upload.sh
+++ b/hack/jenkins/release_build_and_upload.sh
@@ -90,14 +90,8 @@ make checksum
 # unversioned names to avoid updating upstream Kubernetes documentation each release
 cp "out/minikube_${DEB_VERSION}-0_amd64.deb" out/minikube_latest_amd64.deb
 cp "out/minikube_${DEB_VERSION}-0_arm64.deb" out/minikube_latest_arm64.deb
-cp "out/minikube-${DEB_VERSION}-0_armhf.deb" out/minikube_latest_armhf.deb
-cp "out/minikube-${DEB_VERSION}-0_ppc64el.deb" out/minikube_latest_ppc64el.deb
-cp "out/minikube-${DEB_VERSION}-0_s390x.deb" out/minikube_latest_s390x.deb
 cp "out/minikube-${RPM_VERSION}-0.x86_64.rpm" out/minikube-latest.x86_64.rpm
 cp "out/minikube-${RPM_VERSION}-0.aarch64.rpm" out/minikube-latest.aarch64.rpm
-cp "out/minikube-${RPM_VERSION}-0.armv7hl.rpm" out/minikube-latest.armv7hl.rpm
-cp "out/minikube-${RPM_VERSION}-0.ppc64le.rpm" out/minikube-latest.ppc64le.rpm
-cp "out/minikube-${RPM_VERSION}-0.s390x.rpm" out/minikube-latest.s390x.rpm
 
 gsutil -m cp out/* "gs://$BUCKET/releases/$TAGNAME/"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ publish = "site/public/"
 command = "pwd && cd themes/docsy && git submodule update -f --init && cd ../.. && hugo"
 
 [build.environment]
-HUGO_VERSION = "0.68.3"
+HUGO_VERSION = "0.74.3"
 
 [context.production.environment]
 HUGO_ENV = "production"

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ publish = "site/public/"
 command = "pwd && cd themes/docsy && git submodule update -f --init && cd ../.. && hugo"
 
 [build.environment]
-HUGO_VERSION = "0.74.3"
+HUGO_VERSION = "0.83.1"
 
 [context.production.environment]
 HUGO_ENV = "production"

--- a/site/assets/scss/_variables_project.scss
+++ b/site/assets/scss/_variables_project.scss
@@ -23,7 +23,7 @@ $gray-800: #333 !default;
 $gray-900: #222 !default;
 $black: #000 !default;
 
-$primary: #f2771a !default;
+$primary: $mk-dark !default;
 $primary-light: $mk-light;
 $secondary: #403F4C;
 $success: #3772FF !default;
@@ -227,4 +227,17 @@ div.td-content {
 
 div.code-toolbar > .toolbar {
     top: -.3em !important;
+}
+
+.option-row {
+    margin-bottom: 0.5rem;
+}
+
+.option-button {
+    border-radius: 0.2rem !important;
+    margin-right: 0.2rem;
+}
+
+.hide {
+    display: none !important;
 }

--- a/site/assets/scss/_variables_project.scss
+++ b/site/assets/scss/_variables_project.scss
@@ -229,10 +229,6 @@ div.code-toolbar > .toolbar {
     top: -.3em !important;
 }
 
-.option-row {
-    margin-bottom: 0.5rem;
-}
-
 .option-button {
     border-radius: 0.2rem !important;
     margin-right: 0.2rem;
@@ -240,4 +236,8 @@ div.code-toolbar > .toolbar {
 
 .hide {
     display: none !important;
+}
+
+.card-body-blue {
+    background: #f3f9fa;
 }

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -20,61 +20,162 @@ All you need is Docker (or similarly compatible) container or a Virtual Machine 
 
 <h2 class="step"><span class="fa-stack fa-1x"><i class="fa fa-circle fa-stack-2x"></i><strong class="fa-stack-1x text-primary">1</strong></span>Installation</h2>
 
-{{% tabs %}}
-{{% linuxtab %}}
+Click on the buttons that describe your target platform:
 
-For Linux users, we provide 3 easy download options (for each architecture):
+{{% quiz_row base="" name="Operating system" %}}
+{{% quiz_button option="Linux" %}} {{% quiz_button option="macOS" %}} {{% quiz_button option="Windows" %}}
+{{% /quiz_row %}}
 
-### amd64 / x86_64
+{{% quiz_row base="/Linux" name="Architecture" %}}
+{{% quiz_button option="x86-64" %}} {{% quiz_button option="ARM64" %}} {{% quiz_button option="ARMv7" %}} {{% quiz_button option="ppc64" %}} {{% quiz_button option="S390x" %}}
+{{% /quiz_row %}}
 
-#### Binary download
+{{% quiz_row base="/Linux/x86-64" name="Installer type" %}}
+{{% quiz_button option="Binary download" %}} {{% quiz_button option="Debian package" %}} {{% quiz_button option="RPM package" %}}
+{{% /quiz_row %}}
 
+{{% quiz_row base="/Linux/ARM64" name="Installer type" %}}
+{{% quiz_button option="Binary download" %}} {{% quiz_button option="Debian package" %}} {{% quiz_button option="RPM package" %}}
+{{% /quiz_row %}}
 
+{{% quiz_row base="/Linux/ppc64" name="Installer type" %}}
+{{% quiz_button option="Binary download" %}}
+{{% /quiz_row %}}
+
+{{% quiz_row base="/Linux/S390x" name="Installer type" %}}
+{{% quiz_button option="Binary download" %}}
+{{% /quiz_row %}}
+
+{{% quiz_row base="/Linux/ARMv7" name="Installer type" %}}
+{{% quiz_button option="Binary download" %}} {{% quiz_button option="Debian package" %}} {{% quiz_button option="RPM package" %}}
+{{% /quiz_row %}}
+
+{{% quiz_row base="/macOS" name="Architecture" %}}
+{{% quiz_button option="x86-64" %}} {{% quiz_button option="ARM64" %}}
+{{% /quiz_row %}}
+
+{{% quiz_row base="/macOS/x86-64" name="Installer type" %}}
+{{% quiz_button option="Homebrew" %}} {{% quiz_button option="Binary download" %}}
+{{% /quiz_row %}}
+
+{{% quiz_row base="/macOS/ARM64" name="Installer type" %}}
+{{% quiz_button option="Binary download" %}}
+{{% /quiz_row %}}
+
+{{% quiz_row base="/Windows" name="Architecture" %}}
+{{% quiz_button option="x86-64" %}}
+{{% /quiz_row %}}
+
+{{% quiz_row base="/Windows/x86-64" name="Architecture" %}}
+{{% quiz_button option="Windows Package Manager" %}} {{% quiz_button option="Chocolatey" %}} {{% quiz_button option=".exe download" %}}
+{{% /quiz_row %}}
+
+{{% quiz_instruction type="/Linux/x86-64/Binary download" %}}
 ```shell
- curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
- sudo install minikube-linux-amd64 /usr/local/bin/minikube
+curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+sudo install minikube-linux-amd64 /usr/local/bin/minikube
 ```
+{{% /quiz_instruction %}}
 
-#### Debian package
-
+{{% quiz_instruction type="/Linux/x86-64/Debian package" %}}
 ```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_latest_amd64.deb
 sudo dpkg -i minikube_latest_amd64.deb
 ```
+{{% /quiz_instruction %}}
 
-#### RPM package
-
+{{% quiz_instruction type="/Linux/x86-64/RPM package" %}}
 ```shell
-curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest.x86_64.rpm
-sudo rpm -Uvh minikube-latest.x86_64.rpm
+curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest.x86-64.rpm
+sudo rpm -Uvh minikube-latest.x86-64.rpm
 ```
+{{% /quiz_instruction %}}
 
-### arm64 / aarch64
-
-#### Binary download
-
+{{% quiz_instruction type="/Linux/ARM64/Binary download" %}}
 ```shell
- curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-arm64
- sudo install minikube-linux-arm64 /usr/local/bin/minikube
+curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-arm64
+sudo install minikube-linux-arm64 /usr/local/bin/minikube
 ```
+{{% /quiz_instruction %}}
 
-#### Debian package
-
+{{% quiz_instruction type="/Linux/ARM64/Debian package" %}}
 ```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_latest_arm64.deb
 sudo dpkg -i minikube_latest_arm64.deb
 ```
+{{% /quiz_instruction %}}
 
-#### RPM package
-
+{{% quiz_instruction type="/Linux/ARM64/RPM package" %}}
 ```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest.aarch64.rpm
 sudo rpm -Uvh minikube-latest.aarch64.rpm
 ```
+{{% /quiz_instruction %}}
 
-{{% /linuxtab %}}
-{{% mactab %}}
+{{% quiz_instruction type="/Linux/ppc64/Binary download" %}}
+```shell
+curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-ppc64le
+sudo install minikube-linux-ppc64le /usr/local/bin/minikube
+```
+{{% /quiz_instruction %}}
 
+{{% quiz_instruction type="/Linux/ppc64/Debian package" %}}
+```shell
+curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_latest_ppc64le.deb
+sudo dpkg -i minikube_latest_ppc64le.deb
+```
+{{% /quiz_instruction %}}
+
+{{% quiz_instruction type="/Linux/ppc64/RPM package" %}}
+```shell
+curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest.ppc64el.rpm
+sudo rpm -Uvh minikube-latest.ppc64el.rpm
+```
+{{% /quiz_instruction %}}
+
+{{% quiz_instruction type="/Linux/S390x/Binary download" %}}
+```shell
+curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-s390x
+sudo install minikube-linux-s390x /usr/local/bin/minikube
+```
+{{% /quiz_instruction %}}
+
+{{% quiz_instruction type="/Linux/S390x/Debian package" %}}
+```shell
+curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_latest_s390x.deb
+sudo dpkg -i minikube_latest_s390x.deb
+```
+{{% /quiz_instruction %}}
+
+{{% quiz_instruction type="/Linux/S390x/RPM package" %}}
+```shell
+curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest.s390x.rpm
+sudo rpm -Uvh minikube-latest.s390x.rpm
+```
+{{% /quiz_instruction %}}
+
+{{% quiz_instruction type="/Linux/ARMv7/Binary download" %}}
+```shell
+curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-arm
+sudo install minikube-linux-arm /usr/local/bin/minikube
+```
+{{% /quiz_instruction %}}
+
+{{% quiz_instruction type="/Linux/ARMv7/Debian package" %}}
+```shell
+curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_latest_armhf.deb
+sudo dpkg -i minikube_latest_armhf.deb
+```
+{{% /quiz_instruction %}}
+
+{{% quiz_instruction type="/Linux/ARMv7/RPM package" %}}
+```shell
+curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest.armv7hl.rpm
+sudo rpm -Uvh minikube-latest.armv7hl.rpm
+```
+{{% /quiz_instruction %}}
+
+{{% quiz_instruction type="/macOS/x86-64/Homebrew" %}}
 If the [Brew Package Manager](https://brew.sh/) is installed:
 
 ```shell
@@ -87,49 +188,44 @@ If `which minikube` fails after installation via brew, you may have to remove th
 brew unlink minikube
 brew link minikube
 ```
+{{% /quiz_instruction %}}
 
-Otherwise, download minikube directly:
-
-### x86
-
+{{% quiz_instruction type="/macOS/x86-64/Binary download" %}}
 ```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-darwin-amd64
 sudo install minikube-darwin-amd64 /usr/local/bin/minikube
 ```
+{{% /quiz_instruction %}}
 
-### ARM
-
+{{% quiz_instruction type="/macOS/ARM64/Binary download" %}}
 ```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-darwin-arm64
 sudo install minikube-darwin-arm64 /usr/local/bin/minikube
 ```
+{{% /quiz_instruction %}}
 
-{{% /mactab %}}
-{{% windowstab %}}
-
-### Windows Package Manager
-
+{{% quiz_instruction type="/Windows/x86-64/Windows Package Manager" %}}
 If the [Windows Package Manager](https://docs.microsoft.com/en-us/windows/package-manager/) is installed, use the following command to install minikube:
 
 ```shell
 winget install minikube
 ```
+{{% /quiz_instruction %}}
 
-### Chocolatey
+{{% quiz_instruction type="/Windows/x86-64/Chocolatey" %}}
 If the [Chocolatey Package Manager](https://chocolatey.org/) is installed, use the following command:
 
 ```shell
 choco install minikube
 ```
+{{% /quiz_instruction %}}
 
-### Stand-alone Windows Installer
-Otherwise, download and run the [Windows installer](https://storage.googleapis.com/minikube/releases/latest/minikube-installer.exe)
+{{% quiz_instruction type="/Windows/x86-64/.exe download" %}}
+Download and run the stand-alone [minikube Windows installer](https://storage.googleapis.com/minikube/releases/latest/minikube-installer.exe).
 
+_If you used a CLI to perform the installation, you will need to close that CLI and open a new one before proceeding._
+{{% /quiz_instruction %}}
 
-_If you used a CLI to perform the installation, you will need to close that CLI and open a new one before proceeding._ 
-
-{{% /windowstab %}}
-{{% /tabs %}}
 
 <h2 class="step"><span class="fa-stack fa-1x"><i class="fa fa-circle fa-stack-2x"></i><strong class="fa-stack-1x text-primary">2</strong></span>Start your cluster</h2>
 

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -22,7 +22,7 @@ All you need is Docker (or similarly compatible) container or a Virtual Machine 
 
 {{% card %}}
 
-Click on the buttons that describe your target platform:
+Click on the buttons that describe your target platform. For other architectures, see [the release page](https://github.com/kubernetes/minikube/releases/latest) for a complete list of minikube binaries.
 
 {{% quiz_row base="" name="Operating system" %}}
 {{% quiz_button option="Linux" %}} {{% quiz_button option="macOS" %}} {{% quiz_button option="Windows" %}}

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -70,98 +70,98 @@ Click on the buttons that describe your target platform:
 {{% quiz_button option="Windows Package Manager" %}} {{% quiz_button option="Chocolatey" %}} {{% quiz_button option=".exe download" %}}
 {{% /quiz_row %}}
 
-{{% quiz_instruction type="/Linux/x86-64/Binary download" %}}
+{{% quiz_instruction id="/Linux/x86-64/Binary download" %}}
 ```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
 sudo install minikube-linux-amd64 /usr/local/bin/minikube
 ```
 {{% /quiz_instruction %}}
 
-{{% quiz_instruction type="/Linux/x86-64/Debian package" %}}
+{{% quiz_instruction id="/Linux/x86-64/Debian package" %}}
 ```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_latest_amd64.deb
 sudo dpkg -i minikube_latest_amd64.deb
 ```
 {{% /quiz_instruction %}}
 
-{{% quiz_instruction type="/Linux/x86-64/RPM package" %}}
+{{% quiz_instruction id="/Linux/x86-64/RPM package" %}}
 ```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest.x86-64.rpm
 sudo rpm -Uvh minikube-latest.x86-64.rpm
 ```
 {{% /quiz_instruction %}}
 
-{{% quiz_instruction type="/Linux/ARM64/Binary download" %}}
+{{% quiz_instruction id="/Linux/ARM64/Binary download" %}}
 ```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-arm64
 sudo install minikube-linux-arm64 /usr/local/bin/minikube
 ```
 {{% /quiz_instruction %}}
 
-{{% quiz_instruction type="/Linux/ARM64/Debian package" %}}
+{{% quiz_instruction id="/Linux/ARM64/Debian package" %}}
 ```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_latest_arm64.deb
 sudo dpkg -i minikube_latest_arm64.deb
 ```
 {{% /quiz_instruction %}}
 
-{{% quiz_instruction type="/Linux/ARM64/RPM package" %}}
+{{% quiz_instruction id="/Linux/ARM64/RPM package" %}}
 ```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest.aarch64.rpm
 sudo rpm -Uvh minikube-latest.aarch64.rpm
 ```
 {{% /quiz_instruction %}}
 
-{{% quiz_instruction type="/Linux/ppc64/Binary download" %}}
+{{% quiz_instruction id="/Linux/ppc64/Binary download" %}}
 ```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-ppc64le
 sudo install minikube-linux-ppc64le /usr/local/bin/minikube
 ```
 {{% /quiz_instruction %}}
 
-{{% quiz_instruction type="/Linux/ppc64/Debian package" %}}
+{{% quiz_instruction id="/Linux/ppc64/Debian package" %}}
 ```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_latest_ppc64le.deb
 sudo dpkg -i minikube_latest_ppc64le.deb
 ```
 {{% /quiz_instruction %}}
 
-{{% quiz_instruction type="/Linux/ppc64/RPM package" %}}
+{{% quiz_instruction id="/Linux/ppc64/RPM package" %}}
 ```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest.ppc64el.rpm
 sudo rpm -Uvh minikube-latest.ppc64el.rpm
 ```
 {{% /quiz_instruction %}}
 
-{{% quiz_instruction type="/Linux/S390x/Binary download" %}}
+{{% quiz_instruction id="/Linux/S390x/Binary download" %}}
 ```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-s390x
 sudo install minikube-linux-s390x /usr/local/bin/minikube
 ```
 {{% /quiz_instruction %}}
 
-{{% quiz_instruction type="/Linux/S390x/Debian package" %}}
+{{% quiz_instruction id="/Linux/S390x/Debian package" %}}
 ```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_latest_s390x.deb
 sudo dpkg -i minikube_latest_s390x.deb
 ```
 {{% /quiz_instruction %}}
 
-{{% quiz_instruction type="/Linux/S390x/RPM package" %}}
+{{% quiz_instruction id="/Linux/S390x/RPM package" %}}
 ```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest.s390x.rpm
 sudo rpm -Uvh minikube-latest.s390x.rpm
 ```
 {{% /quiz_instruction %}}
 
-{{% quiz_instruction type="/Linux/ARMv7/Binary download" %}}
+{{% quiz_instruction id="/Linux/ARMv7/Binary download" %}}
 ```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-arm
 sudo install minikube-linux-arm /usr/local/bin/minikube
 ```
 {{% /quiz_instruction %}}
 
-{{% quiz_instruction type="/macOS/x86-64/Homebrew" %}}
+{{% quiz_instruction id="/macOS/x86-64/Homebrew" %}}
 If the [Brew Package Manager](https://brew.sh/) is installed:
 
 ```shell
@@ -176,21 +176,21 @@ brew link minikube
 ```
 {{% /quiz_instruction %}}
 
-{{% quiz_instruction type="/macOS/x86-64/Binary download" %}}
+{{% quiz_instruction id="/macOS/x86-64/Binary download" %}}
 ```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-darwin-amd64
 sudo install minikube-darwin-amd64 /usr/local/bin/minikube
 ```
 {{% /quiz_instruction %}}
 
-{{% quiz_instruction type="/macOS/ARM64/Binary download" %}}
+{{% quiz_instruction id="/macOS/ARM64/Binary download" %}}
 ```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-darwin-arm64
 sudo install minikube-darwin-arm64 /usr/local/bin/minikube
 ```
 {{% /quiz_instruction %}}
 
-{{% quiz_instruction type="/Windows/x86-64/Windows Package Manager" %}}
+{{% quiz_instruction id="/Windows/x86-64/Windows Package Manager" %}}
 If the [Windows Package Manager](https://docs.microsoft.com/en-us/windows/package-manager/) is installed, use the following command to install minikube:
 
 ```shell
@@ -198,7 +198,7 @@ winget install minikube
 ```
 {{% /quiz_instruction %}}
 
-{{% quiz_instruction type="/Windows/x86-64/Chocolatey" %}}
+{{% quiz_instruction id="/Windows/x86-64/Chocolatey" %}}
 If the [Chocolatey Package Manager](https://chocolatey.org/) is installed, use the following command:
 
 ```shell
@@ -206,7 +206,7 @@ choco install minikube
 ```
 {{% /quiz_instruction %}}
 
-{{% quiz_instruction type="/Windows/x86-64/.exe download" %}}
+{{% quiz_instruction id="/Windows/x86-64/.exe download" %}}
 Download and run the stand-alone [minikube Windows installer](https://storage.googleapis.com/minikube/releases/latest/minikube-installer.exe).
 
 _If you used a CLI to perform the installation, you will need to close that CLI and open a new one before proceeding._

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -20,6 +20,8 @@ All you need is Docker (or similarly compatible) container or a Virtual Machine 
 
 <h2 class="step"><span class="fa-stack fa-1x"><i class="fa fa-circle fa-stack-2x"></i><strong class="fa-stack-1x text-primary">1</strong></span>Installation</h2>
 
+{{% card %}}
+
 Click on the buttons that describe your target platform:
 
 {{% quiz_row base="" name="Operating system" %}}
@@ -211,6 +213,8 @@ Download and run the stand-alone [minikube Windows installer](https://storage.go
 
 _If you used a CLI to perform the installation, you will need to close that CLI and open a new one before proceeding._
 {{% /quiz_instruction %}}
+
+{{% /card %}}
 
 
 <h2 class="step"><span class="fa-stack fa-1x"><i class="fa fa-circle fa-stack-2x"></i><strong class="fa-stack-1x text-primary">2</strong></span>Start your cluster</h2>

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -66,7 +66,7 @@ Click on the buttons that describe your target platform:
 {{% quiz_button option="x86-64" %}}
 {{% /quiz_row %}}
 
-{{% quiz_row base="/Windows/x86-64" name="Architecture" %}}
+{{% quiz_row base="/Windows/x86-64" name="Installer type" %}}
 {{% quiz_button option="Windows Package Manager" %}} {{% quiz_button option="Chocolatey" %}} {{% quiz_button option=".exe download" %}}
 {{% /quiz_row %}}
 

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -47,7 +47,7 @@ Click on the buttons that describe your target platform:
 {{% /quiz_row %}}
 
 {{% quiz_row base="/Linux/ARMv7" name="Installer type" %}}
-{{% quiz_button option="Binary download" %}} {{% quiz_button option="Debian package" %}} {{% quiz_button option="RPM package" %}}
+{{% quiz_button option="Binary download" %}}
 {{% /quiz_row %}}
 
 {{% quiz_row base="/macOS" name="Architecture" %}}
@@ -158,20 +158,6 @@ sudo rpm -Uvh minikube-latest.s390x.rpm
 ```shell
 curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-arm
 sudo install minikube-linux-arm /usr/local/bin/minikube
-```
-{{% /quiz_instruction %}}
-
-{{% quiz_instruction type="/Linux/ARMv7/Debian package" %}}
-```shell
-curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_latest_armhf.deb
-sudo dpkg -i minikube_latest_armhf.deb
-```
-{{% /quiz_instruction %}}
-
-{{% quiz_instruction type="/Linux/ARMv7/RPM package" %}}
-```shell
-curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-latest.armv7hl.rpm
-sudo rpm -Uvh minikube-latest.armv7hl.rpm
 ```
 {{% /quiz_instruction %}}
 

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -55,7 +55,7 @@ Click on the buttons that describe your target platform:
 {{% /quiz_row %}}
 
 {{% quiz_row base="/macOS/x86-64" name="Installer type" %}}
-{{% quiz_button option="Homebrew" %}} {{% quiz_button option="Binary download" %}}
+{{% quiz_button option="Binary download" %}} {{% quiz_button option="Homebrew" %}}
 {{% /quiz_row %}}
 
 {{% quiz_row base="/macOS/ARM64" name="Installer type" %}}
@@ -67,7 +67,7 @@ Click on the buttons that describe your target platform:
 {{% /quiz_row %}}
 
 {{% quiz_row base="/Windows/x86-64" name="Installer type" %}}
-{{% quiz_button option="Windows Package Manager" %}} {{% quiz_button option="Chocolatey" %}} {{% quiz_button option=".exe download" %}}
+{{% quiz_button option=".exe download" %}} {{% quiz_button option="Windows Package Manager" %}} {{% quiz_button option="Chocolatey" %}}
 {{% /quiz_row %}}
 
 {{% quiz_instruction id="/Linux/x86-64/Binary download" %}}

--- a/site/layouts/partials/hooks/body-end.html
+++ b/site/layouts/partials/hooks/body-end.html
@@ -1,3 +1,4 @@
 <!-- start: minikube override body-end partial -->
 <script language="javascript">initTabs();</script>
+<script language="javascript">initQuiz();</script>
 <!-- end: minikube override body-end partial -->

--- a/site/layouts/partials/hooks/head-end.html
+++ b/site/layouts/partials/hooks/head-end.html
@@ -2,4 +2,5 @@
 <link href="https://fonts.googleapis.com/css2?family=Lora&family=Open+Sans:wght@600;700&display=swap" rel="stylesheet">
 <link href="/css/tabs.css" rel="stylesheet">
 <script src="/js/tabs.js"></script>
+<script src="/js/quiz.js"></script>
 <!-- end: minikube override head-end partial -->

--- a/site/layouts/shortcodes/card.html
+++ b/site/layouts/shortcodes/card.html
@@ -1,0 +1,1 @@
+<div class="card"><div class="card-body card-body-blue">{{ .Inner }}</div></div>

--- a/site/layouts/shortcodes/quiz_button.html
+++ b/site/layouts/shortcodes/quiz_button.html
@@ -1,0 +1,1 @@
+<button data-quiz-id="{{ .Parent.Get "base" }}/{{ .Get "option" }}" type="button" class="btn btn-outline-primary option-button">{{ .Get "option" }}</button>

--- a/site/layouts/shortcodes/quiz_instruction.html
+++ b/site/layouts/shortcodes/quiz_instruction.html
@@ -1,4 +1,4 @@
-<div data-quiz-id="{{ with .Get "type"}}{{.}}{{end}}" class="quiz-instruction hide">
+<div data-quiz-id="{{ with .Get "id"}}{{.}}{{end}}" class="quiz-instruction hide">
 <p>Installation instructions:</p>
 {{ .Inner }}
 </div>

--- a/site/layouts/shortcodes/quiz_instruction.html
+++ b/site/layouts/shortcodes/quiz_instruction.html
@@ -1,0 +1,4 @@
+<div data-quiz-id="{{ with .Get "type"}}{{.}}{{end}}" class="quiz-instruction hide">
+<p>Installation instructions:</p>
+{{ .Inner }}
+</div>

--- a/site/layouts/shortcodes/quiz_instruction.html
+++ b/site/layouts/shortcodes/quiz_instruction.html
@@ -1,4 +1,11 @@
-<div data-quiz-id="{{ with .Get "id"}}{{.}}{{end}}" class="quiz-instruction hide">
-<p>Installation instructions:</p>
+{{ $id := .Get "id" }}
+{{ $selected := split $id "/" }}
+
+{{ $os := index $selected 1 }}
+{{ $arch := index $selected 2 }}
+{{ $installer := index $selected 3 }}
+
+<div data-quiz-id="{{ with .Get "id"}}{{.}}{{end}}" class="quiz-instruction">
+<p>To install minikube on <b>{{ $arch }}</b> <b>{{ $os }}</b> using <b>{{ replace $installer "Binary" "binary" }}</b>:</p>
 {{ .Inner }}
 </div>

--- a/site/layouts/shortcodes/quiz_row.html
+++ b/site/layouts/shortcodes/quiz_row.html
@@ -2,6 +2,7 @@
 
 {{ $hide := "" }}
 {{ if gt $level 0 }}
+    {{/* Initially we only show the top-level options */}}
     {{ $hide = "hide" }}
 {{ end }}
 
@@ -11,4 +12,3 @@
     </div>
     <div class="col-lg-10">{{ .Inner }}</div>
 </div>
-

--- a/site/layouts/shortcodes/quiz_row.html
+++ b/site/layouts/shortcodes/quiz_row.html
@@ -1,0 +1,14 @@
+{{ $level := .Get "base" | strings.Count "/" }}
+
+{{ $hide := "" }}
+{{ if gt $level 0 }}
+    {{ $hide = "hide" }}
+{{ end }}
+
+<div data-quiz-id="{{ .Get "base" }}" data-level="{{ $level }}" class="row option-row {{ $hide }}">
+    <div class="col-lg-2 my-auto">
+        <span>{{ with .Get "name"}}{{.}}{{end}}</span>
+    </div>
+    <div class="col-lg-10">{{ .Inner }}</div>
+</div>
+

--- a/site/layouts/shortcodes/quiz_row.html
+++ b/site/layouts/shortcodes/quiz_row.html
@@ -1,12 +1,6 @@
 {{ $level := .Get "base" | strings.Count "/" }}
 
-{{ $hide := "" }}
-{{ if gt $level 0 }}
-    {{/* Initially we only show the top-level options */}}
-    {{ $hide = "hide" }}
-{{ end }}
-
-<div data-quiz-id="{{ .Get "base" }}" data-level="{{ $level }}" class="row option-row {{ $hide }}">
+<div data-quiz-id="{{ .Get "base" }}" data-level="{{ $level }}" class="row option-row hide">
     <div class="col-lg-2 my-auto">
         <p>{{ with .Get "name"}}{{.}}{{end}}</p>
     </div>

--- a/site/layouts/shortcodes/quiz_row.html
+++ b/site/layouts/shortcodes/quiz_row.html
@@ -8,7 +8,7 @@
 
 <div data-quiz-id="{{ .Get "base" }}" data-level="{{ $level }}" class="row option-row {{ $hide }}">
     <div class="col-lg-2 my-auto">
-        <span>{{ with .Get "name"}}{{.}}{{end}}</span>
+        <p>{{ with .Get "name"}}{{.}}{{end}}</p>
     </div>
     <div class="col-lg-10">{{ .Inner }}</div>
 </div>

--- a/site/static/js/quiz.js
+++ b/site/static/js/quiz.js
@@ -38,7 +38,10 @@ function initQuiz() {
 
             selectQuizOption(dataContainerId);
         });
-        const userOS = getQuizUserOS();
+        let userOS = getUserOS();
+        if (userOS === 'Mac') {
+            userOS = 'macOS';
+        }
         // auto-select the OS for user
         const btn = $('.option-button[data-quiz-id=\'/' + userOS + '\']').first();
         btn.addClass('active');
@@ -49,19 +52,4 @@ function initQuiz() {
             element.classList.remove("hide");
         }
     }
-}
-
-const getQuizUserOS = () => {
-    let os = ['Linux', 'Mac', 'Windows'];
-    let userAgent = navigator.userAgent;
-    for (let currentOS of os) {
-        if (userAgent.indexOf(currentOS) !== -1) {
-            if (currentOS === 'Mac') {
-                // return the official OS name "macOS" instead
-                return 'macOS';
-            }
-            return currentOS;
-        }
-    }
-    return 'Linux';
 }

--- a/site/static/js/quiz.js
+++ b/site/static/js/quiz.js
@@ -1,0 +1,71 @@
+function selectQuizOption(selectedId) {
+    const currentLevel = selectedId.split('/').length - 1;
+    $('.option-row').each(function (i) {
+        const rowId = $(this).attr('data-quiz-id');
+        // don't hide option rows if it has a lower level
+        // e.g. when clicking "x86_64" under Linux, we don't want to hide the operating system row
+        if ($(this).attr('data-level') < currentLevel) {
+            return;
+        }
+        if (rowId === selectedId) {
+            $(this).removeClass('hide');
+            $(this).find('.option-button').removeClass('active');
+            return;
+        }
+        // hide all other option rows
+        $(this).addClass('hide');
+    });
+    // hide other answers
+    $('.quiz-instruction').addClass('hide');
+    // show the selected answer
+    $('.quiz-instruction[data-quiz-id=\'' + selectedId + '\']').removeClass('hide');
+
+    const buttons = $('.option-row[data-quiz-id=\'' + selectedId + '\']').find('.option-button');
+    // if there is only one option, auto-select that option for the user
+    if (buttons.length === 1) {
+        const btn = $(buttons[0]);
+        btn.addClass('active');
+        selectQuizOption(btn.attr('data-quiz-id'));
+    }
+}
+
+function initQuiz() {
+    try {
+        $('.option-button').click(function(e) {
+            $(this).parent().find('.option-button').removeClass('active');
+            $(this).addClass('active');
+            const dataContainerId = $(this).attr('data-quiz-id');
+
+            selectQuizOption(dataContainerId);
+        });
+        const userOS = getQuizUserOS();
+        const buttons = $('.option-button[data-quiz-id=\'/' + userOS + '\']');
+        if (buttons.length === 1) {
+            const btn = $(buttons[0]);
+            btn.addClass('active');
+            selectQuizOption(btn.attr('data-quiz-id'));
+        }
+
+    } catch(e) {
+        console.log(e);
+        const elements = document.getElementsByClassName("quiz-instruction");
+        for (let element of elements) {
+            element.classList.remove("hide");
+        }
+    }
+}
+
+const getQuizUserOS = () => {
+    let os = ['Linux', 'Mac', 'Windows'];
+    let userAgent = navigator.userAgent;
+    for (let currentOS of os) {
+        if (userAgent.indexOf(currentOS) !== -1) {
+            if (currentOS === 'Mac') {
+                // return the official OS name "macOS" instead
+                return 'macOS';
+            }
+            return currentOS;
+        }
+    }
+    return 'Linux';
+}

--- a/site/static/js/quiz.js
+++ b/site/static/js/quiz.js
@@ -21,9 +21,9 @@ function selectQuizOption(selectedId) {
     $('.quiz-instruction[data-quiz-id=\'' + selectedId + '\']').removeClass('hide');
 
     const buttons = $('.option-row[data-quiz-id=\'' + selectedId + '\']').find('.option-button');
-    // if there is only one option, auto-select that option for the user
-    if (buttons.length === 1) {
-        const btn = $(buttons[0]);
+    // auto-select the first option for the user, to reduce the number of clicks
+    if (buttons.length > 0) {
+        const btn = buttons.first();
         btn.addClass('active');
         selectQuizOption(btn.attr('data-quiz-id'));
     }
@@ -39,15 +39,11 @@ function initQuiz() {
             selectQuizOption(dataContainerId);
         });
         const userOS = getQuizUserOS();
-        const buttons = $('.option-button[data-quiz-id=\'/' + userOS + '\']');
-        if (buttons.length === 1) {
-            const btn = $(buttons[0]);
-            btn.addClass('active');
-            selectQuizOption(btn.attr('data-quiz-id'));
-        }
-
+        // auto-select the OS for user
+        const btn = $('.option-button[data-quiz-id=\'/' + userOS + '\']').first();
+        btn.addClass('active');
+        selectQuizOption(btn.attr('data-quiz-id'));
     } catch(e) {
-        console.log(e);
         const elements = document.getElementsByClassName("quiz-instruction");
         for (let element of elements) {
             element.classList.remove("hide");

--- a/site/static/js/quiz.js
+++ b/site/static/js/quiz.js
@@ -40,8 +40,10 @@ function initQuiz() {
         });
         let userOS = getUserOS();
         if (userOS === 'Mac') {
+            // use the name "macOS" to match the button
             userOS = 'macOS';
         }
+        $('.option-row[data-level=0]').removeClass('hide');
         // auto-select the OS for user
         const btn = $('.option-button[data-quiz-id=\'/' + userOS + '\']').first();
         btn.addClass('active');

--- a/site/static/js/tabs.js
+++ b/site/static/js/tabs.js
@@ -17,7 +17,7 @@ function initTabs() {
       let tabSelector = getTabSelector(this);
       $(this).find('div'+tabSelector).addClass('active');
     })
- 
+
     $('.nav-tabs a').click(function(e){
       e.preventDefault();
       var tab = $(this).parent(),


### PR DESCRIPTION
Hi,

This PR fixes #10353, see https://github.com/kubernetes/minikube/issues/10353#issuecomment-835701332

The idea is to add a "quiz" style installation page. Inspired by CUDA and PyTorch:

| CUDA                                                                                                                                          	| PyTorch                                                                                                                                       	|
|-----------------------------------------------------------------------------------------------------------------------------------------------	|-----------------------------------------------------------------------------------------------------------------------------------------------	|
| ![Screen Shot 2021-05-13 at 2 23 14 AM](https://user-images.githubusercontent.com/1311594/118086588-358d9380-b392-11eb-9566-5ae6cd175800.png) 	| ![Screen Shot 2021-05-13 at 2 23 23 AM](https://user-images.githubusercontent.com/1311594/118086590-358d9380-b392-11eb-857c-3173df1b94d4.png) 	|

Showcase:

![quiz](https://user-images.githubusercontent.com/1311594/118182373-eb92c500-b406-11eb-8823-eea399539da3.gif)


Some features:

- [x] Since this style is more scalable, I've added `ARMv7`, `ppc64` and `S390x` architecture under Linux as well
- [x] If a row has only one option, it's automatically selected. e.g. Windows -> x86_64
    ![auto-select](https://user-images.githubusercontent.com/1311594/118182387-f0577900-b406-11eb-822e-8e9dfaa823fe.gif)
- [x] The first row (OS) is automatically selected based on the user's OS

Would love to hear some feedback! Thanks!