### PR TITLE
add host.minikube.internal to coredns

### DIFF
--- a/site/content/en/docs/contrib/tests.en.md
+++ b/site/content/en/docs/contrib/tests.en.md
@@ -368,4 +368,3 @@ upgrades Kubernetes from oldest to newest
 ## TestMissingContainerUpgrade
 tests a Docker upgrade where the underlying container is missing
 
-TEST COUNT: 116

--- a/site/content/en/docs/contrib/tests.en.md
+++ b/site/content/en/docs/contrib/tests.en.md
@@ -265,6 +265,9 @@ tests that the node name verification works as expected
 #### validateDeployAppToMultiNode
 deploys an app to a multinode cluster and makes sure all nodes can serve traffic
 
+#### validatePodsPingHost
+uses app previously deplyed by validateDeployAppToMultiNode to verify its pods, located on different nodes, can resolve "host.minikube.internal".
+
 ## TestNetworkPlugins
 tests all supported CNI options
 Options tested: kubenet, bridge, flannel, kindnet, calico, cilium


### PR DESCRIPTION
fixes #8439

as seen from the inside a pod, `host.minikube.internal` cannot be resolved atm:

```
/ # ping host.minikube.internal
PING host.minikube.internal (92.242.132.24): 56 data bytes
^C
--- host.minikube.internal ping statistics ---
7 packets transmitted, 0 packets received, 100% packet loss
```
```
/ # nslookup  host.minikube.internal
Server:    10.96.0.10
Address 1: 10.96.0.10 kube-dns.kube-system.svc.cluster.local

Name:      host.minikube.internal
Address 1: 92.xxx.xxx.xxx unallocated.barefruit.co.uk
```

solution: we can inject custom ***hosts*** dns entries into coredns using its configmap (ref: https://coredns.io/plugins/hosts/):

### before:
```
❯ kubectl -n kube-system get configmap coredns -oyaml
apiVersion: v1
data:
  Corefile: |
    .:53 {
        errors
        health {
           lameduck 5s
        }
        ready
        kubernetes cluster.local in-addr.arpa ip6.arpa {
           pods insecure
           fallthrough in-addr.arpa ip6.arpa
           ttl 30
        }
        prometheus :9153
        forward . /etc/resolv.conf {
           max_concurrent 1000
        }
        cache 30
        loop
        reload
        loadbalance
    }
kind: ConfigMap
metadata:
  creationTimestamp: "2021-05-12T19:06:28Z"
  name: coredns
  namespace: kube-system
  resourceVersion: "253"
  uid: d8ce5f97-5198-4da4-9052-f229bd850ba6
```

### after:
```
❯ kubectl -n kube-system get configmap coredns -oyaml
apiVersion: v1
data:
  Corefile: |
    .:53 {
        errors
        health {
           lameduck 5s
        }
        ready
        kubernetes cluster.local in-addr.arpa ip6.arpa {
           pods insecure
           fallthrough in-addr.arpa ip6.arpa
           ttl 30
        }
        prometheus :9153
        hosts {
           192.168.58.1 host.minikube.internal
           fallthrough
        }
        forward . /etc/resolv.conf {
           max_concurrent 1000
        }
        cache 30
        loop
        reload
        loadbalance
    }
kind: ConfigMap
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","data":{"Corefile":".:53 {\n    errors\n    health {\n       lameduck 5s\n    }\n    ready\n    kubernetes cluster.local in-addr.arpa ip6.arpa {\n       pods insecure\n       fallthrough in-addr.arpa ip6.arpa\n       ttl 30\n    }\n    prometheus :9153\n    hosts {\n      192.168.58.1 host.minikube.internal\n      fallthrough\n    }\n    forward . /etc/resolv.conf {\n       max_concurrent 1000\n    }\n    cache 30\n    loop\n    reload\n    loadbalance\n}\n"},"kind":"ConfigMap","metadata":{"annotations":{},"creationTimestamp":"2021-05-12T19:06:28Z","managedFields":[{"apiVersion":"v1","fieldsType":"FieldsV1","fieldsV1":{"f:data":{".":{},"f:Corefile":{}}},"manager":"kubeadm","operation":"Update","time":"2021-05-12T19:06:28Z"}],"name":"coredns","namespace":"kube-system","selfLink":"/api/v1/namespaces/kube-system/configmaps/coredns","uid":"d8ce5f97-5198-4da4-9052-f229bd850ba6"}}
  creationTimestamp: "2021-05-12T19:06:28Z"
  name: coredns
  namespace: kube-system
  resourceVersion: "6224"
  uid: d8ce5f97-5198-4da4-9052-f229bd850ba6
```

note: it takes some time (<1min) for coredns to automatically notice and reload the changed configmap, picking up the changes:

back inside a pod:
```
/ # nslookup  host.minikube.internal
Server:    10.96.0.10
Address 1: 10.96.0.10 kube-dns.kube-system.svc.cluster.local

Name:      host.minikube.internal
Address 1: 192.168.58.1 host.minikube.internal
```