### PR TITLE
Fix TestFunctional/parallel/LoadImage by using diff base images

### DIFF
--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -216,7 +216,7 @@ func validateLoadImage(ctx context.Context, t *testing.T, profile string) {
 	}
 	defer PostMortemLogs(t, profile)
 	// pull busybox
-	busyboxImage := "busybox:latest"
+	busyboxImage := "busybox:1.33"
 	rr, err := Run(t, exec.CommandContext(ctx, "docker", "pull", busyboxImage))
 	if err != nil {
 		t.Fatalf("failed to setup test (pull image): %v\n%s", err, rr.Output())
@@ -257,7 +257,7 @@ func validateRemoveImage(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 
 	// pull busybox
-	busyboxImage := "busybox:latest"
+	busyboxImage := "busybox:1.32"
 	rr, err := Run(t, exec.CommandContext(ctx, "docker", "pull", busyboxImage))
 	if err != nil {
 		t.Fatalf("failed to setup test (pull image): %v\n%s", err, rr.Output())


### PR DESCRIPTION
Closes #11330
Closes #11268

If you crictl rmi <image> other images that share the same image ID are deleted as well.

Example:
```
$ out/minikube ssh -p minikube -- sudo crictl img
docker.io/library/busybox                 remove-minikube      c55b0f125dc65       818kB
docker.io/library/busybox                 load-minikube        c55b0f125dc65       818kB

$ out/minikube ssh -p minikube -- sudo crictl rmi docker.io/library/busybox:remove-minikube
Deleted: docker.io/library/busybox:remove-minikube
Deleted: docker.io/library/busybox:load-minikube
```

Using a different image will prevent the current issue where the ImageRemove tests deletes the image loaded by the LoadImage test since they use the same image.