### PR TITLE
metallb-addon: Update metallb from 0.8.2 to 0.9.6

### DIFF
--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -486,8 +486,8 @@ var Addons = map[string]*Addon{
 			"metallb-config.yaml",
 			"0640"),
 	}, false, "metallb", map[string]string{
-		"Speaker":    "metallb/speaker:v0.8.2@sha256:f1941498a28cdb332429e25d18233683da6949ecfc4f6dacf12b1416d7d38263",
-		"Controller": "metallb/controller:v0.8.2@sha256:5c050e59074e152711737d2bb9ede96dff67016c80cf25cdf5fc46109718a583",
+		"Speaker":    "metallb/speaker:v0.9.6@sha256:c66585a805bed1a3b829d8fb4a4aab9d87233497244ebff96f1b88f1e7f8f991",
+		"Controller": "metallb/controller:v0.9.6@sha256:fbfdb9d3f55976b0ee38f3309d83a4ca703efcf15d6ca7889cd8189142286502",
 	}, nil),
 	"ambassador": NewAddon([]*BinAsset{
 		MustBinAsset(


### PR DESCRIPTION
This change isn't strictly necessary but the newer versions of metallb contain some really nice quality of life improvements, and better support newer (installed by default) versions of kubernetes better.

A sample of some improvements this brings to metallb add-on installed by minikube:
- [Layer2 doesn't update when when ip changes](https://github.com/metallb/metallb/pull/520) - this hit me, and might be hitting others
- [Allow spaces in configs](https://github.com/metallb/metallb/pull/500) - quality of life
- [selflink is deprecated](https://github.com/metallb/metallb/pull/812) - Kubernetes deprecation (seeing this is in the logs is what originally caused me to look into upgrading it)

Note: Happy to update any relevant tests, I didn't see any for this but I didn't look THAT closely, just let me know. I've been running this successfully with `minikube addons enable metallb --images="Controller=metallb/controller:v0.9.6,Speaker=metallb/speaker:v0.9.6"` for days now.