### PR TITLE
Add VMware as a provider for Linux & Windows

### DIFF
--- a/site/content/en/docs/drivers/_index.md
+++ b/site/content/en/docs/drivers/_index.md
@@ -36,4 +36,5 @@ To do so, we use the [Docker Machine](https://github.com/docker/machine) library
 * [Hyper-V]({{<ref "hyperv.md">}}) - VM (preferred)
 * [Docker]({{<ref "docker.md">}}) - VM + Container (preferred)
 * [VirtualBox]({{<ref "virtualbox.md">}}) - VM
+* [VMware]({{<ref "vmware.md">}}) - VM
 * [SSH]({{<ref "ssh.md">}}) - remote ssh


### PR DESCRIPTION
There are Linux & Windows tabs at https://minikube.sigs.k8s.io/docs/drivers/vmware/, connecting them here.
