### PR TITLE
Use fully qualified image name for kicbase image from docker hub

### DIFF
--- a/hack/jenkins/kicbase_auto_build.sh
+++ b/hack/jenkins/kicbase_auto_build.sh
@@ -46,13 +46,13 @@ if [[ -z $KIC_VERSION ]]; then
 	now=$(date +%s)
 	KV=$(egrep "Version =" pkg/drivers/kic/types.go | cut -d \" -f 2 | cut -d "-" -f 1)
 	GCR_REPO=gcr.io/k8s-minikube/kicbase-builds
-	DH_REPO=kicbase/build
+	DH_REPO=docker.io/kicbase/build
 	export KIC_VERSION=$KV-$now-$ghprbPullId
 else
 	# Actual kicbase release here
 	release=true
 	GCR_REPO=${GCR_REPO:-gcr.io/k8s-minikube/kicbase}
-	DH_REPO=${DH_REPO:-kicbase/stable}
+	DH_REPO=${DH_REPO:-docker.io/kicbase/stable}
 	export KIC_VERSION
 fi
 GCR_IMG=${GCR_REPO}:${KIC_VERSION}

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -30,7 +30,7 @@ const (
 	// The name of the GCR kicbase repository
 	gcrRepo = "gcr.io/k8s-minikube/kicbase"
 	// The name of the Dockerhub kicbase repository
-	dockerhubRepo = "kicbase/stable"
+	dockerhubRepo = "docker.io/kicbase/stable"
 )
 
 var (


### PR DESCRIPTION
This PR fixes the following error under `podman` driver, where using docker hub fallback image  would not work due to using image short name.

```
! minikube was unable to download gcr.io/k8s-minikube/kicbase:v0.0.22, but successfully downloaded kicbase/stable:v0.0.22 as a fallback image
E0515 21:21:55.185211    8544 cache.go:189] Error downloading kic artifacts:  failed to download kic base image or any fallback image
* Creating podman container (CPUs=2, Memory=2200MB) ...
! StartHost failed, but will try again: creating host: create: creating: setting up container node: preparing volume for minikube container: sudo -n podman run --rm --name minikube-preload-sidecar --label created_by.minikube.sigs.k8s.io=true --label name.minikube.sigs.k8s.io=minikube --entrypoint /usr/bin/test -v minikube:/var kicbase/stable:v0.0.22 -d /var/lib: exit status 125
stdout:

stderr:
Error: error getting default registries to try: short-name resolution enforced but cannot prompt without a TTY
```

Reference: https://www.redhat.com/en/blog/be-careful-when-pulling-images-short-name