### PR TITLE
Add "resume" as an alias for "unpause"

### DIFF
--- a/cmd/minikube/cmd/unpause.go
+++ b/cmd/minikube/cmd/unpause.go
@@ -39,9 +39,9 @@ import (
 
 // unpauseCmd represents the docker-pause command
 var unpauseCmd = &cobra.Command{
-	Use:   "unpause",
+	Use:     "unpause",
 	Aliases: []string{"resume"},
-	Short: "unpause Kubernetes",
+	Short:   "unpause Kubernetes",
 	Run: func(cmd *cobra.Command, args []string) {
 		cname := ClusterFlagValue()
 		register.SetEventLogPath(localpath.EventLog(cname))

--- a/cmd/minikube/cmd/unpause.go
+++ b/cmd/minikube/cmd/unpause.go
@@ -40,6 +40,7 @@ import (
 // unpauseCmd represents the docker-pause command
 var unpauseCmd = &cobra.Command{
 	Use:   "unpause",
+	Aliases: []string{"resume"},
 	Short: "unpause Kubernetes",
 	Run: func(cmd *cobra.Command, args []string) {
 		cname := ClusterFlagValue()

--- a/site/content/en/docs/commands/unpause.md
+++ b/site/content/en/docs/commands/unpause.md
@@ -17,6 +17,10 @@ unpause Kubernetes
 minikube unpause [flags]
 ```
 
+### Aliases
+
+[resume]
+
 ### Options
 
 ```

--- a/site/content/en/docs/contrib/tests.en.md
+++ b/site/content/en/docs/contrib/tests.en.md
@@ -365,4 +365,3 @@ upgrades Kubernetes from oldest to newest
 ## TestMissingContainerUpgrade
 tests a Docker upgrade where the underlying container is missing
 
-TEST COUNT: 116


### PR DESCRIPTION
This PR adds an alias for the "unpause" command for "resume".  I always make a mistaken running `minikube resume` and then realize that it's `unpause`.

An alternative would be to use a `SuggestFor: ["resume"]`.

And yes, I should be using auto-pause.