### PR TITLE
fix "no arguments passed" warning

### DIFF
--- a/pkg/minikube/out/out.go
+++ b/pkg/minikube/out/out.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/Delta456/box-cli-maker/v2"
 	"github.com/briandowns/spinner"
-	isatty "github.com/mattn/go-isatty"
+	"github.com/mattn/go-isatty"
 
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/minikube/localpath"
@@ -452,5 +452,8 @@ func applyTmpl(format string, a ...V) string {
 // Fmt applies formatting and translation
 func Fmt(format string, a ...V) string {
 	format = translate.T(format)
+	if len(a) == 0 {
+		return format
+	}
 	return applyTmpl(format, a...)
 }


### PR DESCRIPTION
fixes the warnings:
 ```
W0517 12:28:39.962153   26792 out.go:424] no arguments passed for "* If the above advice does not help, please let us know:\n" - returning raw string
W0517 12:28:39.962222   26792 out.go:424] no arguments passed for "  https://github.com/kubernetes/minikube/issues/new/choose\n\n" - returning raw string
W0517 12:28:39.962243   26792 out.go:424] no arguments passed for "* Please attach the following file to the GitHub issue:\n" - returning raw string
W0517 12:28:39.962386   26792 out.go:424] no arguments passed for "* If the above advice does not help, please let us know:\n  https://github.com/kubernetes/minikube/issues/new/choose\n\n* Please attach the following file to the GitHub issue:\n* - /Users/
```