### PR TITLE
Fix auto-pause on VMs (detect right control-plane IP)

### DIFF
--- a/deploy/addons/auto-pause/haproxy.cfg.tmpl
+++ b/deploy/addons/auto-pause/haproxy.cfg.tmpl
@@ -28,10 +28,10 @@ backend k8s-api-https
     #tcp-request inspect-delay 10s
     #tcp-request content lua.foo_action
     tcp-request inspect-delay 10s
-    tcp-request content lua.unpause 192.168.49.2 8080
+    tcp-request content lua.unpause {{.NetworkInfo.ControlPlaneNodeIP}} 8080
     tcp-request content reject if { var(req.blocked) -m bool }
     option tcplog
     option tcp-check
     default-server inter 10s downinter 5s rise 2 fall 2 slowstart 60s maxconn 250 maxqueue 256 weight 100
-    server k8s-api-1 192.168.49.2:8443 check
+    server k8s-api-1 {{.NetworkInfo.ControlPlaneNodeIP}}:8443 check
 

--- a/deploy/addons/auto-pause/haproxy.cfg.tmpl
+++ b/deploy/addons/auto-pause/haproxy.cfg.tmpl
@@ -33,5 +33,5 @@ backend k8s-api-https
     option tcplog
     option tcp-check
     default-server inter 10s downinter 5s rise 2 fall 2 slowstart 60s maxconn 250 maxqueue 256 weight 100
-    server k8s-api-1 {{.NetworkInfo.ControlPlaneNodeIP}}:8443 check
+    server k8s-api-1 {{.NetworkInfo.ControlPlaneNodeIP}}:{{.NetworkInfo.ControlPlaneNodePort}} check
 

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -220,8 +220,6 @@ https://github.com/kubernetes/minikube/issues/7332`, out.V{"driver_name": cc.Dri
 	if len(cc.Nodes) >= 1 {
 		networkInfo.ControlPlaneNodeIP = cc.Nodes[0].IP
 		networkInfo.ControlPlaneNodePort = cc.Nodes[0].Port
-		fmt.Printf("+%v", networkInfo)
-		fmt.Println(cc.Nodes[0].Port)
 	} else {
 		out.WarningT("At least needs control plane nodes to enable addon")
 	}

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -219,6 +219,9 @@ https://github.com/kubernetes/minikube/issues/7332`, out.V{"driver_name": cc.Dri
 	var networkInfo assets.NetworkInfo
 	if len(cc.Nodes) >= 1 {
 		networkInfo.ControlPlaneNodeIP = cc.Nodes[0].IP
+		networkInfo.ControlPlaneNodePort = cc.Nodes[0].Port
+		fmt.Printf("+%v", networkInfo)
+		fmt.Println(cc.Nodes[0].Port)
 	} else {
 		out.WarningT("At least needs control plane nodes to enable addon")
 	}

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -42,7 +42,8 @@ type Addon struct {
 
 // NetworkInfo contains control plane node IP address used for add on template
 type NetworkInfo struct {
-	ControlPlaneNodeIP string
+	ControlPlaneNodeIP   string
+	ControlPlaneNodePort int
 }
 
 // NewAddon creates a new Addon
@@ -660,7 +661,7 @@ var Addons = map[string]*Addon{
 }
 
 // GenerateTemplateData generates template data for template assets
-func GenerateTemplateData(addon *Addon, cfg config.KubernetesConfig, networkInfo NetworkInfo) interface{} {
+func GenerateTemplateData(addon *Addon, cfg config.KubernetesConfig, netInfo NetworkInfo) interface{} {
 
 	a := runtime.GOARCH
 	// Some legacy docker images still need the -arch suffix
@@ -697,7 +698,8 @@ func GenerateTemplateData(addon *Addon, cfg config.KubernetesConfig, networkInfo
 	}
 
 	// Network info for generating template
-	opts.NetworkInfo["ControlPlaneNodeIP"] = networkInfo.ControlPlaneNodeIP
+	opts.NetworkInfo["ControlPlaneNodeIP"] = netInfo.ControlPlaneNodeIP
+	opts.NetworkInfo["ControlPlaneNodePort"] = fmt.Sprint(netInfo.ControlPlaneNodePort)
 
 	if opts.Images == nil {
 		opts.Images = make(map[string]string) // Avoid nil access when rendering

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -88,13 +88,13 @@ var Addons = map[string]*Addon{
 			"auto-pause-hook.yaml",
 			"0640"),
 		MustBinAsset(
-			"deploy/addons/auto-pause/haproxy.cfg",
-			"/var/lib/minikube/",
+			"deploy/addons/auto-pause/haproxy.cfg.tmpl",
+			vmpath.GuestPersistentDir,
 			"haproxy.cfg",
 			"0640"),
 		MustBinAsset(
 			"deploy/addons/auto-pause/unpause.lua",
-			"/var/lib/minikube/",
+			vmpath.GuestPersistentDir,
 			"unpause.lua",
 			"0640"),
 		MustBinAsset(


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/11414


# before this PR

```
Try kubectl - this time it is trying to reach the auto-sleep proxy port
$ kubectl get po -A
The connection to the server 192.168.99.151:32443 was refused - did you specify the right host or port?

```

# after this PR

```


$ mk addons enable auto-pause
$ mk status
minikube
type: Control Plane
host: Running
kubelet: Running
apiserver: Running
kubeconfig: Configured

18:28:07 medya/workspace/minikube
$ kc get pods -A
NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE
auto-pause    auto-pause-proxy-dc6979c79-tgm27   1/1     Running   0          32s
auto-pause    env-inject-846bbd58bc-zg9vs        1/1     Running   0          33s
kube-system   coredns-74ff55c5b-ftpqv            1/1     Running   0          34s
kube-system   etcd-minikube                      0/1     Running   0          48s
kube-system   kube-apiserver-minikube            1/1     Running   0          48s
kube-system   kube-controller-manager-minikube   0/1     Running   0          48s
kube-system   kube-proxy-p6gf8                   1/1     Running   0          33s
kube-system   kube-scheduler-minikube            0/1     Running   0          48s
kube-system   storage-provisioner                1/1     Running   1          48s
18:28:12 medya/workspace/minikube



$ sleep 60

18:29:27 medya/workspace/minikube
autopause-vm •3
$ mk status
minikube
type: Control Plane
host: Running
kubelet: Stopped
apiserver: Paused
kubeconfig: Configured

18:29:30 medya/workspace/minikube
autopause-vm •3
$ kc get pods -A
NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE
auto-pause    auto-pause-proxy-dc6979c79-tgm27   1/1     Running   0          119s
auto-pause    env-inject-846bbd58bc-zg9vs        1/1     Running   0          2m
kube-system   coredns-74ff55c5b-ftpqv            1/1     Running   0          2m1s
kube-system   etcd-minikube                      1/1     Running   0          2m15s
kube-system   kube-apiserver-minikube            1/1     Running   0          2m15s
kube-system   kube-controller-manager-minikube   1/1     Running   0          2m15s
kube-system   kube-proxy-p6gf8                   1/1     Running   0          2m
kube-system   kube-scheduler-minikube            1/1     Running   0          2m15s
kube-system   storage-provisioner                1/1     Running   1          2m15s
18:29:39 medya/workspace/minikube
autopause-vm •3
$ mk status
minikube
type: Control Plane
host: Running
kubelet: Running
apiserver: Running
kubeconfig: Configured

18:29:44 medya/workspace/minikube

```