### PR TITLE
Fix golang installation script for arm64

### DIFF
--- a/hack/jenkins/installers/check_install_golang.sh
+++ b/hack/jenkins/installers/check_install_golang.sh
@@ -34,6 +34,7 @@ function current_arch() {
     echo "arm64"
   ;;
   *)
+    echo "unexpected arch: $(arch)" 1>&2
     echo "amd64"
   ;;
   esac

--- a/hack/jenkins/installers/check_install_golang.sh
+++ b/hack/jenkins/installers/check_install_golang.sh
@@ -34,7 +34,7 @@ function current_arch() {
     echo "arm64"
   ;;
   *)
-    echo "unexpected arch: $(arch)" 1>&2
+    echo "unexpected arch: $(arch). use amd64" 1>&2
     echo "amd64"
   ;;
   esac

--- a/hack/jenkins/installers/check_install_golang.sh
+++ b/hack/jenkins/installers/check_install_golang.sh
@@ -25,7 +25,21 @@ fi
 VERSION_TO_INSTALL=${1}
 INSTALL_PATH=${2}
 
-ARCH=${ARCH:=amd64}
+function current_arch() {
+  case $(arch) in
+  "x86_64")
+     echo "amd64"
+  ;;
+  "aarch64")
+    echo "arm64"
+  ;;
+  *)
+    echo "amd64"
+  ;;
+  esac
+}
+
+ARCH=${ARCH:=$(current_arch)}
 
 # installs or updates golang if right version doesn't exists
 function check_and_install_golang() {
@@ -62,7 +76,7 @@ function install_golang() {
   # using sudo because previously installed versions might have been installed by a different user.
   # as it was the case on jenkins VM.
   sudo curl -qL -O "https://storage.googleapis.com/golang/go${1}.${INSTALLOS}-${ARCH}.tar.gz" &&
-    sudo tar -xzf go${1}.${INSTALLOS}-amd64.tar.gz &&
+    sudo tar -xzf go${1}.${INSTALLOS}-${ARCH}.tar.gz &&
     sudo rm -rf "${2}/go" &&
     sudo mv go "${2}/" && sudo chown -R $(whoami): ${2}/go
   popd >/dev/null


### PR DESCRIPTION
This PR fixes `fix_install_golang.sh` ci script. 
Currently is has hardcoded `amd64` version of go tarball and fails on linux/aarch64