### PR TITLE
bug: return error on invalid function name in extract.TranslatableStrings

### DIFF
--- a/pkg/minikube/extract/extract.go
+++ b/pkg/minikube/extract/extract.go
@@ -91,7 +91,7 @@ func newExtractor(functionsToCheck []string) (*state, error) {
 		// Functions must be of the form "package.function"
 		t2 := strings.Split(t, ".")
 		if len(t2) < 2 {
-			return nil, errors.Wrap(nil, fmt.Sprintf("Invalid function string %s. Needs package name as well.", t))
+			return nil, errors.Errorf("invalid function string %s. Needs package name as well", t)
 		}
 		f := funcType{
 			pack: t2[0],

--- a/pkg/minikube/extract/extract_test.go
+++ b/pkg/minikube/extract/extract_test.go
@@ -18,6 +18,7 @@ package extract
 
 import (
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -83,4 +84,13 @@ func TestExtract(t *testing.T) {
 		t.Fatalf("Translation JSON not equal: expected %v, got %v", expected, got)
 	}
 
+}
+
+func TestExtractShouldReturnErrorOnFunctionWithoutPackage(t *testing.T) {
+	expected := errors.New("Initializing: invalid function string missing_package. Needs package name as well")
+	funcs := []string{"missing_package"}
+	err := TranslatableStrings([]string{}, funcs, "")
+	if err == nil || err.Error() != expected.Error() {
+		t.Fatalf("expected %v, got %v", expected, err)
+	}
 }


### PR DESCRIPTION
> Wrap returns an error annotating err with a stack trace at the point Wrap is called,
 and the supplied message. If err is nil, Wrap returns nil.
https://pkg.go.dev/github.com/pkg/errors#Wrap

https://github.com/kubernetes/minikube/commit/97e2cd11538cc3aedf5550a48553297620521331#r51011973
