### PR TITLE
Prevent downloading duplicate binaries already present in preload

### DIFF
--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -47,9 +47,9 @@ const (
 	PreloadBucket = "minikube-preloaded-volume-tarballs"
 
 	// Enumeration for preload existence cache.
-	preloadExistsUNKNOWN = 0
-	preloadExistsMISSING = 1
-	preloadExistsEXISTS  = 2
+	preloadExistsUNKNOWN = 0 // Value when preload status has not been checked.
+	preloadExistsMISSING = 1 // Value when preload has been checked and is missing.
+	preloadExistsEXISTS  = 2 // Value when preload has been checked and is present.
 )
 
 var (

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -50,8 +50,8 @@ const (
 // Enumeration for preload existence cache.
 const (
 	preloadUnknown = iota // Value when preload status has not been checked.
-	preloadMissing = iota // Value when preload has been checked and is missing.
-	preloadPresent = iota // Value when preload has been checked and is present.
+	preloadMissing        // Value when preload has been checked and is missing.
+	preloadPresent        // Value when preload has been checked and is present.
 )
 
 var (

--- a/pkg/minikube/machine/cache_binaries.go
+++ b/pkg/minikube/machine/cache_binaries.go
@@ -28,12 +28,28 @@ import (
 	"k8s.io/minikube/pkg/minikube/download"
 )
 
+// isExcluded returns whether `binary` is expected to be excluded, based on `excludedBinaries`.
+func isExcluded(binary string, excludedBinaries []string) bool {
+	if excludedBinaries == nil {
+		return false
+	}
+	for _, excludedBinary := range excludedBinaries {
+		if binary == excludedBinary {
+			return true
+		}
+	}
+	return false
+}
+
 // CacheBinariesForBootstrapper will cache binaries for a bootstrapper
-func CacheBinariesForBootstrapper(version string, clusterBootstrapper string) error {
+func CacheBinariesForBootstrapper(version string, clusterBootstrapper string, excludeBinaries []string) error {
 	binaries := bootstrapper.GetCachedBinaryList(clusterBootstrapper)
 
 	var g errgroup.Group
 	for _, bin := range binaries {
+		if isExcluded(bin, excludeBinaries) {
+			continue
+		}
 		bin := bin // https://golang.org/doc/faq#closures_and_goroutines
 		g.Go(func() error {
 			if _, err := download.Binary(bin, version, "linux", runtime.GOARCH); err != nil {

--- a/pkg/minikube/machine/cache_binaries_test.go
+++ b/pkg/minikube/machine/cache_binaries_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 
 	"k8s.io/minikube/pkg/minikube/assets"
@@ -129,5 +130,38 @@ func TestCacheBinariesForBootstrapper(t *testing.T) {
 				t.Fatalf("Expected error but got %v", err)
 			}
 		})
+	}
+}
+
+func TestExcludedBinariesNotDownloaded(t *testing.T) {
+	clusterBootstrapper := bootstrapper.Kubeadm
+	binaryList := bootstrapper.GetCachedBinaryList(clusterBootstrapper)
+	binaryToExclude := binaryList[0]
+
+	download.DownloadMock = func(src, dst string) error {
+		if strings.Contains(src, binaryToExclude) {
+			t.Errorf("Excluded binary was downloaded! Binary to exclude: %s", binaryToExclude)
+		}
+		return download.CreateDstDownloadMock(src, dst)
+	}
+
+	oldMinikubeHome := os.Getenv("MINIKUBE_HOME")
+	defer os.Setenv("MINIKUBE_HOME", oldMinikubeHome)
+
+	minikubeHome, err := ioutil.TempDir("/tmp", "")
+	if err != nil {
+		t.Fatalf("error during creating tmp dir: %v", err)
+	}
+	os.Setenv("MINIKUBE_HOME", minikubeHome)
+
+	defer func() { // clean up tempdir
+		err := os.RemoveAll(minikubeHome)
+		if err != nil {
+			t.Errorf("failed to clean up temp folder  %q", minikubeHome)
+		}
+	}()
+
+	if err := CacheBinariesForBootstrapper("v1.16.0", clusterBootstrapper, []string{binaryToExclude}); err != nil {
+		t.Errorf("Failed to cache binaries: %v", err)
 	}
 }

--- a/pkg/minikube/machine/cache_binaries_test.go
+++ b/pkg/minikube/machine/cache_binaries_test.go
@@ -121,7 +121,7 @@ func TestCacheBinariesForBootstrapper(t *testing.T) {
 	for _, test := range tc {
 		t.Run(test.version, func(t *testing.T) {
 			os.Setenv("MINIKUBE_HOME", test.minikubeHome)
-			err := CacheBinariesForBootstrapper(test.version, test.clusterBootstrapper)
+			err := CacheBinariesForBootstrapper(test.version, test.clusterBootstrapper, nil)
 			if err != nil && !test.err {
 				t.Fatalf("Got unexpected error %v", err)
 			}

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -69,7 +69,7 @@ func beginCacheKubernetesImages(g *errgroup.Group, imageRepository string, k8sVe
 	})
 }
 
-// HandleDownloadOnly caches appropariate binaries and images
+// handleDownloadOnly caches appropariate binaries and images
 func handleDownloadOnly(cacheGroup, kicGroup *errgroup.Group, k8sVersion string) {
 	// If --download-only, complete the remaining downloads and exit.
 	if !viper.GetBool("download-only") {
@@ -102,7 +102,7 @@ func CacheKubectlBinary(k8sVersion string) (string, error) {
 
 // doCacheBinaries caches Kubernetes binaries in the foreground
 func doCacheBinaries(k8sVersion string) error {
-	return machine.CacheBinariesForBootstrapper(k8sVersion, viper.GetString(cmdcfg.Bootstrapper))
+	return machine.CacheBinariesForBootstrapper(k8sVersion, viper.GetString(cmdcfg.Bootstrapper), constants.KubernetesReleaseBinaries)
 }
 
 // beginDownloadKicBaseImage downloads the kic image
@@ -191,7 +191,7 @@ func waitDownloadKicBaseImage(g *errgroup.Group) {
 	klog.Info("Successfully downloaded all kic artifacts")
 }
 
-// WaitCacheRequiredImages blocks until the required images are all cached.
+// waitCacheRequiredImages blocks until the required images are all cached.
 func waitCacheRequiredImages(g *errgroup.Group) {
 	if !viper.GetBool(cacheImages) {
 		return

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -70,12 +70,12 @@ func beginCacheKubernetesImages(g *errgroup.Group, imageRepository string, k8sVe
 }
 
 // handleDownloadOnly caches appropariate binaries and images
-func handleDownloadOnly(cacheGroup, kicGroup *errgroup.Group, k8sVersion string) {
+func handleDownloadOnly(cacheGroup, kicGroup *errgroup.Group, k8sVersion, containerRuntime string) {
 	// If --download-only, complete the remaining downloads and exit.
 	if !viper.GetBool("download-only") {
 		return
 	}
-	if err := doCacheBinaries(k8sVersion); err != nil {
+	if err := doCacheBinaries(k8sVersion, containerRuntime); err != nil {
 		exit.Error(reason.InetCacheBinaries, "Failed to cache binaries", err)
 	}
 	if _, err := CacheKubectlBinary(k8sVersion); err != nil {
@@ -101,8 +101,12 @@ func CacheKubectlBinary(k8sVersion string) (string, error) {
 }
 
 // doCacheBinaries caches Kubernetes binaries in the foreground
-func doCacheBinaries(k8sVersion string) error {
-	return machine.CacheBinariesForBootstrapper(k8sVersion, viper.GetString(cmdcfg.Bootstrapper), constants.KubernetesReleaseBinaries)
+func doCacheBinaries(k8sVersion, containerRuntime string) error {
+	existingBinaries := constants.KubernetesReleaseBinaries
+	if !download.PreloadExists(k8sVersion, containerRuntime) {
+		existingBinaries = nil
+	}
+	return machine.CacheBinariesForBootstrapper(k8sVersion, viper.GetString(cmdcfg.Bootstrapper), existingBinaries)
 }
 
 // beginDownloadKicBaseImage downloads the kic image

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -288,7 +288,7 @@ func Provision(cc *config.ClusterConfig, n *config.Node, apiServer bool, delOnFa
 		return nil, false, nil, nil, errors.Wrap(err, "Failed to save config")
 	}
 
-	handleDownloadOnly(&cacheGroup, &kicGroup, n.KubernetesVersion)
+	handleDownloadOnly(&cacheGroup, &kicGroup, n.KubernetesVersion, cc.KubernetesConfig.ContainerRuntime)
 	waitDownloadKicBaseImage(&kicGroup)
 
 	return startMachine(cc, n, delOnFail)

--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -132,6 +132,9 @@ func TestDownloadOnly(t *testing.T) {
 			})
 
 			t.Run("binaries", func(t *testing.T) {
+				if preloadExists {
+					t.Skip("Preload exists, binaries are present within.")
+				}
 				// checking binaries downloaded (kubelet,kubeadm)
 				for _, bin := range constants.KubernetesReleaseBinaries {
 					fp := filepath.Join(localpath.MiniPath(), "cache", "linux", v, bin)


### PR DESCRIPTION
fixes #9098.

Before
```
$ minikube start --download-only
😄  minikube v1.20.0 on Debian rodete
✨  Automatically selected the docker driver. Other choices: kvm2, ssh, none
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
💾  Downloading Kubernetes v1.20.2 preload ...
    > preloaded-images-k8s-v10-v1...: 491.71 MiB / 491.71 MiB  100.00% 22.69 Mi
    > kubelet.sha256: 64 B / 64 B [--------------------------] 100.00% ? p/s 0s
    > kubeadm.sha256: 64 B / 64 B [--------------------------] 100.00% ? p/s 0s
    > kubectl.sha256: 64 B / 64 B [--------------------------] 100.00% ? p/s 0s
    > gcr.io/k8s-minikube/kicbase...: 358.10 MiB / 358.10 MiB  100.00% 13.37 Mi
    > kubeadm: 37.40 MiB / 37.40 MiB [-------------] 100.00% 19.08 MiB p/s 2.2s
    > kubectl: 38.37 MiB / 38.37 MiB [-------------] 100.00% 17.89 MiB p/s 2.3s
    > kubelet: 108.73 MiB / 108.73 MiB [-----------] 100.00% 20.55 MiB p/s 5.5s
✅  Download complete!
```
After
```
$ minikube start --download-only
😄  minikube v1.20.0 on Debian rodete
✨  Automatically selected the docker driver. Other choices: kvm2, none, ssh
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
💾  Downloading Kubernetes v1.20.2 preload ...
    > preloaded-images-k8s-v10-v1...: 491.71 MiB / 491.71 MiB  100.00% 21.03 Mi
    > gcr.io/k8s-minikube/kicbase...: 358.09 MiB / 358.10 MiB  100.00% 14.94 Mi
    > kubectl.sha256: 64 B / 64 B [--------------------------] 100.00% ? p/s 0s
    > kubectl: 38.37 MiB / 38.37 MiB [-------------] 100.00% 19.40 MiB p/s 2.2s
✅  Download complete!
```
Note kubectl is still downloaded since the host requires it to be present. This does mean that downloading a Linux preload on a Linux host will still duplicate downloads for kubectl.