### PR TITLE
Allow download_test to mock checksum retrieval

### DIFF
--- a/pkg/minikube/download/download_test.go
+++ b/pkg/minikube/download/download_test.go
@@ -85,7 +85,8 @@ func testPreloadDownloadPreventsMultipleDownload(t *testing.T) {
 		return nil, nil
 	}
 	checkPreloadExists = func(k8sVersion, containerRuntime string, forcePreload ...bool) bool { return true }
-	compareChecksum = func(k8sVersion, containerRuntime, path string) error { return nil }
+	getChecksum = func(k8sVersion, containerRuntime string) (string, error) { return "check", nil }
+	ensureChecksumValid = func(k8sVersion, containerRuntime, path string) error { return nil }
 
 	var group sync.WaitGroup
 	group.Add(2)


### PR DESCRIPTION
fixes #11446.

Previously, download_test would request actual checksums for preloads during tests. This can slow tests down since it has to deal with networking, and also means if a preload is missing, the test fails. Now these issues are both resolved.