### PR TITLE
Support setting addons from environmental variables

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -147,7 +147,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().String(containerRuntime, constants.DefaultContainerRuntime, fmt.Sprintf("The container runtime to be used (%s).", strings.Join(cruntime.ValidRuntimes(), ", ")))
 	startCmd.Flags().Bool(createMount, false, "This will start the mount daemon and automatically mount files into minikube.")
 	startCmd.Flags().String(mountString, constants.DefaultMountDir+":/minikube-host", "The argument to pass the minikube mount command on start.")
-	startCmd.Flags().StringSlice(config.AddonListName, nil, "Enable addons. see `minikube addons list` for a list of valid addon names.")
+	startCmd.Flags().StringSlice(config.AddonList, nil, "Enable addons. see `minikube addons list` for a list of valid addon names.")
 	startCmd.Flags().String(criSocket, "", "The cri socket path to be used.")
 	startCmd.Flags().String(networkPlugin, "", "Kubelet network plug-in to use (default: auto)")
 	startCmd.Flags().Bool(enableDefaultCNI, false, "DEPRECATED: Replaced by --cni=bridge")

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -147,7 +147,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().String(containerRuntime, constants.DefaultContainerRuntime, fmt.Sprintf("The container runtime to be used (%s).", strings.Join(cruntime.ValidRuntimes(), ", ")))
 	startCmd.Flags().Bool(createMount, false, "This will start the mount daemon and automatically mount files into minikube.")
 	startCmd.Flags().String(mountString, constants.DefaultMountDir+":/minikube-host", "The argument to pass the minikube mount command on start.")
-	startCmd.Flags().StringSlice(config.AddonList, nil, "Enable addons. see `minikube addons list` for a list of valid addon names.")
+	startCmd.Flags().StringSlice(config.AddonListFlag, nil, "Enable addons. see `minikube addons list` for a list of valid addon names.")
 	startCmd.Flags().String(criSocket, "", "The cri socket path to be used.")
 	startCmd.Flags().String(networkPlugin, "", "Kubelet network plug-in to use (default: auto)")
 	startCmd.Flags().Bool(enableDefaultCNI, false, "DEPRECATED: Replaced by --cni=bridge")

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -147,7 +147,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().String(containerRuntime, constants.DefaultContainerRuntime, fmt.Sprintf("The container runtime to be used (%s).", strings.Join(cruntime.ValidRuntimes(), ", ")))
 	startCmd.Flags().Bool(createMount, false, "This will start the mount daemon and automatically mount files into minikube.")
 	startCmd.Flags().String(mountString, constants.DefaultMountDir+":/minikube-host", "The argument to pass the minikube mount command on start.")
-	startCmd.Flags().StringSliceVar(&config.AddonList, "addons", nil, "Enable addons. see `minikube addons list` for a list of valid addon names.")
+	startCmd.Flags().StringSlice(config.AddonListName, nil, "Enable addons. see `minikube addons list` for a list of valid addon names.")
 	startCmd.Flags().String(criSocket, "", "The cri socket path to be used.")
 	startCmd.Flags().String(networkPlugin, "", "Kubelet network plug-in to use (default: auto)")
 	startCmd.Flags().Bool(enableDefaultCNI, false, "DEPRECATED: Replaced by --cni=bridge")

--- a/pkg/addons/validations.go
+++ b/pkg/addons/validations.go
@@ -64,7 +64,7 @@ func IsVolumesnapshotsEnabled(cc *config.ClusterConfig, _, value string) error {
 	isCsiDriverEnabled, _ := strconv.ParseBool(value)
 	// assets.Addons[].IsEnabled() returns the current status of the addon or default value.
 	// config.AddonList contains list of addons to be enabled.
-	addonList := viper.GetStringSlice(config.AddonList)
+	addonList := viper.GetStringSlice(config.AddonListFlag)
 	isVolumesnapshotsEnabled := assets.Addons[volumesnapshotsAddon].IsEnabled(cc) || contains(addonList, volumesnapshotsAddon)
 	if isCsiDriverEnabled && !isVolumesnapshotsEnabled {
 		// just print out a warning directly, we don't want to return any errors since

--- a/pkg/addons/validations.go
+++ b/pkg/addons/validations.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/cruntime"
@@ -63,7 +64,8 @@ func IsVolumesnapshotsEnabled(cc *config.ClusterConfig, _, value string) error {
 	isCsiDriverEnabled, _ := strconv.ParseBool(value)
 	// assets.Addons[].IsEnabled() returns the current status of the addon or default value.
 	// config.AddonList contains list of addons to be enabled.
-	isVolumesnapshotsEnabled := assets.Addons[volumesnapshotsAddon].IsEnabled(cc) || contains(config.AddonList, volumesnapshotsAddon)
+	addonList := viper.GetStringSlice(config.AddonListName)
+	isVolumesnapshotsEnabled := assets.Addons[volumesnapshotsAddon].IsEnabled(cc) || contains(addonList, volumesnapshotsAddon)
 	if isCsiDriverEnabled && !isVolumesnapshotsEnabled {
 		// just print out a warning directly, we don't want to return any errors since
 		// that would prevent the addon from being enabled (callbacks wouldn't be run)

--- a/pkg/addons/validations.go
+++ b/pkg/addons/validations.go
@@ -64,7 +64,7 @@ func IsVolumesnapshotsEnabled(cc *config.ClusterConfig, _, value string) error {
 	isCsiDriverEnabled, _ := strconv.ParseBool(value)
 	// assets.Addons[].IsEnabled() returns the current status of the addon or default value.
 	// config.AddonList contains list of addons to be enabled.
-	addonList := viper.GetStringSlice(config.AddonListName)
+	addonList := viper.GetStringSlice(config.AddonList)
 	isVolumesnapshotsEnabled := assets.Addons[volumesnapshotsAddon].IsEnabled(cc) || contains(addonList, volumesnapshotsAddon)
 	if isCsiDriverEnabled && !isVolumesnapshotsEnabled {
 		// just print out a warning directly, we don't want to return any errors since

--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -56,6 +56,8 @@ const (
 	AddonImages = "addon-images"
 	// AddonRegistries stores custom addon images config
 	AddonRegistries = "addon-registries"
+	// AddonListName represents the key for addons parameter
+	AddonListName = "addons"
 )
 
 var (
@@ -67,8 +69,6 @@ var (
 	DockerOpt []string
 	// ExtraOptions contains extra options (if any)
 	ExtraOptions ExtraOptionSlice
-	// AddonList contains the list of addons
-	AddonList []string
 )
 
 // ErrNotExist is the error returned when a config does not exist

--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -56,8 +56,8 @@ const (
 	AddonImages = "addon-images"
 	// AddonRegistries stores custom addon images config
 	AddonRegistries = "addon-registries"
-	// AddonList represents the key for addons parameter
-	AddonList = "addons"
+	// AddonListFlag represents the key for addons parameter
+	AddonListFlag = "addons"
 )
 
 var (

--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -56,8 +56,8 @@ const (
 	AddonImages = "addon-images"
 	// AddonRegistries stores custom addon images config
 	AddonRegistries = "addon-registries"
-	// AddonListName represents the key for addons parameter
-	AddonListName = "addons"
+	// AddonList represents the key for addons parameter
+	AddonList = "addons"
 )
 
 var (

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -171,7 +171,7 @@ func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 	}()
 
 	// enable addons, both old and new!
-	addonList := viper.GetStringSlice(config.AddonListName)
+	addonList := viper.GetStringSlice(config.AddonList)
 	if starter.ExistingAddons != nil {
 		if viper.GetBool("force") {
 			addons.Force = true

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -171,7 +171,7 @@ func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 	}()
 
 	// enable addons, both old and new!
-	addonList := viper.GetStringSlice(config.AddonList)
+	addonList := viper.GetStringSlice(config.AddonListFlag)
 	if starter.ExistingAddons != nil {
 		if viper.GetBool("force") {
 			addons.Force = true

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -171,12 +171,13 @@ func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 	}()
 
 	// enable addons, both old and new!
+	addonList := viper.GetStringSlice(config.AddonListName)
 	if starter.ExistingAddons != nil {
 		if viper.GetBool("force") {
 			addons.Force = true
 		}
 		wg.Add(1)
-		go addons.Start(&wg, starter.Cfg, starter.ExistingAddons, config.AddonList)
+		go addons.Start(&wg, starter.Cfg, starter.ExistingAddons, addonList)
 	}
 
 	if apiServer {


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

This PR fixes #11171 

**Description**
This PR adds support for setting addons from environmental variables (along with flags).

Examples:
1. `minikube start --addons=registry,olm`  - will populate the addons list with "registry" and "olm" addons.
2. `MINIKUBE_ADDONS="registry olm" minikube start` - will populate the addons list with "registry" and "olm" addons.
3. `MINIKUBE_ADDONS="registry olm" minikube start --addons=registry` - will populate the addons list with "registry" addon only as the flag will take precedence.

**Note For Reviewers**
A global variable called `addonList` was removed as it was no longer getting referenced in the code. Instead of using the global variable, `viper.GetStringSlice()` is used.


<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
