### PR TITLE
Update registry.md with instructions to avoid common pitfalls

### DIFF
--- a/site/content/en/docs/handbook/registry.md
+++ b/site/content/en/docs/handbook/registry.md
@@ -42,7 +42,8 @@ You can use the `--insecure-registry` flag on the
 
 One nifty hack is to allow the kubelet running in minikube to talk to registries deployed inside a pod in the cluster without backing them
 with TLS certificates. Because the default service cluster IP is known to be available at 10.0.0.1, users can pull images from registries
-deployed inside the cluster by creating the cluster with `minikube start --insecure-registry "10.0.0.0/24"`.
+deployed inside the cluster by creating the cluster with `minikube start --insecure-registry "10.0.0.0/24"`. If using macOS, ensure the cluster
+is deleted using `minikube delete` before starting with the `--insecure-registry` flag.
 
 ### docker on macOS
 
@@ -53,6 +54,7 @@ The first step is to enable the registry addon:
 ```shell
 minikube addons enable registry
 ```
+> Note: Minikube will generate a port and request you use that port when enabling registry. That instruction is not related to this guide.
 
 When enabled, the registry addon exposes its port 5000 on the minikube's virtual machine.
 

--- a/site/content/en/docs/handbook/registry.md
+++ b/site/content/en/docs/handbook/registry.md
@@ -42,7 +42,7 @@ You can use the `--insecure-registry` flag on the
 
 One nifty hack is to allow the kubelet running in minikube to talk to registries deployed inside a pod in the cluster without backing them
 with TLS certificates. Because the default service cluster IP is known to be available at 10.0.0.1, users can pull images from registries
-deployed inside the cluster by creating the cluster with `minikube start --insecure-registry "10.0.0.0/24"`. If using macOS, ensure the cluster
+deployed inside the cluster by creating the cluster with `minikube start --insecure-registry "10.0.0.0/24"`. Ensure the cluster
 is deleted using `minikube delete` before starting with the `--insecure-registry` flag.
 
 ### docker on macOS


### PR DESCRIPTION
I recently attempted to follow this guide and ran into two issues.
1. I already had a cluster running when I ran `minikube start --insecure-registry` and as such the insecure registry flag wasn't respected. I needed to run `minikube delete` and then could run the start command. As far as I'm aware the hard reset is only necessary on MacOS.
2. I was confused by the output from `minikube addons enable registry`. There is a big message of `Registry addon with docker driver uses port <generated-port> please use that instead of default port 5000` and so I switched a few things over to the generated port and nothing connected. Retrying with only port 5000 worked successfully.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
