### PR TITLE
Add ability to create extra disks on hyperkit vms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ KUBERNETES_VERSION ?= $(shell egrep "DefaultKubernetesVersion =" pkg/minikube/co
 KIC_VERSION ?= $(shell egrep "Version =" pkg/drivers/kic/types.go | cut -d \" -f2)
 
 # Default to .0 for higher cache hit rates, as build increments typically don't require new ISO versions
-ISO_VERSION ?= v1.22.0
+ISO_VERSION ?= v1.22.0-1627488369-11483
 # Dashes are valid in semver, but not Linux packaging. Use ~ to delimit alpha/beta
 DEB_VERSION ?= $(subst -,~,$(RAW_VERSION))
 DEB_REVISION ?= 0

--- a/deploy/iso/minikube-iso/package/automount/minikube-automount
+++ b/deploy/iso/minikube-iso/package/automount/minikube-automount
@@ -9,9 +9,15 @@ MAGIC="boot2docker, please format-me"
 # If there is a partition with `boot2docker-data` as its label, use it and be
 # very happy. Thus, you can come along if you feel like a room without a roof.
 BOOT2DOCKER_DATA=`blkid -o device -l -t LABEL=$LABEL`
-UNPARTITIONED_HD="/dev/$(lsblk | grep disk | cut -f1 -d' ')"
+DISKS="$(lsblk | grep disk | cut -f1 -d' ')"
 echo $BOOT2DOCKER_DATA
-if [ ! -n "$BOOT2DOCKER_DATA" ]; then
+for DISK in $DISKS; do
+    if [ -n "$BOOT2DOCKER_DATA" ]; then
+        # The primary minikube disk has been found or provisioned; stop provisioning other disks
+        break
+    fi
+
+    UNPARTITIONED_HD="/dev/$DISK"
     echo "Is the disk unpartitioned?, test for the 'boot2docker format-me' string"
 
     # Is the disk unpartitioned?, test for the 'boot2docker format-me' string
@@ -61,10 +67,10 @@ if [ ! -n "$BOOT2DOCKER_DATA" ]; then
                     BOOT2DOCKER_DATA=`echo "${UNPARTITIONED_HD}1"`
                     mkfs.ext4 -i 2048 -L $LABEL $BOOT2DOCKER_DATA
                 else
-                    echo "Disk unpartitioned but something is there... not doing anything"
+                    echo "Disk ($UNPARTITIONED_HD) unpartitioned but something is there... not doing anything"
                 fi
             else
-                echo "Partition table found on disk, not doing anything"
+                echo "Partition table found on disk ($UNPARTITIONED_HD), not doing anything"
             fi
         fi
     else
@@ -72,7 +78,7 @@ if [ ! -n "$BOOT2DOCKER_DATA" ]; then
         # TODO: mount all Linux partitions and look for a /var/lib/docker...
         BOOT2DOCKER_DATA=`blkid | grep -e 'TYPE="btrfs"'  -e 'TYPE="ext4"' | head -n 1 | sed 's/:.*//'`
     fi
-fi
+done
 
 echo $BOOT2DOCKER_DATA
 

--- a/pkg/drivers/common.go
+++ b/pkg/drivers/common.go
@@ -17,6 +17,7 @@ limitations under the License.
 package drivers
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -39,6 +40,12 @@ import (
 // GetDiskPath returns the path of the machine disk image
 func GetDiskPath(d *drivers.BaseDriver) string {
 	return filepath.Join(d.ResolveStorePath("."), d.GetMachineName()+".rawdisk")
+}
+
+// ExtraDiskPath returns the path of an additional disk suffixed with an ID.
+func ExtraDiskPath(d *drivers.BaseDriver, diskID int) string {
+	file := fmt.Sprintf("%s-%d.rawdisk", d.GetMachineName(), diskID)
+	return filepath.Join(d.ResolveStorePath("."), file)
 }
 
 // CommonDriver is the common driver base class

--- a/pkg/drivers/hyperkit/driver.go
+++ b/pkg/drivers/hyperkit/driver.go
@@ -64,6 +64,7 @@ type Driver struct {
 	UUID           string
 	VpnKitSock     string
 	VSockPorts     []string
+	ExtraDisks     int
 }
 
 // NewDriver creates a new driver for a host
@@ -228,6 +229,13 @@ func (d *Driver) createHost() (*hyperkit.HyperKit, error) {
 			Size: d.DiskSize,
 			Trim: true,
 		},
+	}
+	for i := 0; i < d.ExtraDisks; i++ {
+		h.Disks = append(h.Disks, &hyperkit.RawDisk{
+			Path: pkgdrivers.ExtraDiskPath(d.BaseDriver, i),
+			Size: d.DiskSize,
+			Trim: true,
+		})
 	}
 
 	return h, nil

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -83,6 +83,7 @@ type ClusterConfig struct {
 	ListenAddress           string   // Only used by the docker and podman driver
 	Network                 string   // only used by docker driver
 	MultiNodeRequested      bool
+	ExtraDisks              int // currently only implemented for hyperkit
 }
 
 // KubernetesConfig contains the parameters used to configure the VM Kubernetes.

--- a/pkg/minikube/download/iso.go
+++ b/pkg/minikube/download/iso.go
@@ -40,7 +40,7 @@ const fileScheme = "file"
 // DefaultISOURLs returns a list of ISO URL's to consult by default, in priority order
 func DefaultISOURLs() []string {
 	v := version.GetISOVersion()
-	isoBucket := "minikube/iso"
+	isoBucket := "minikube-builds/iso/11483"
 	return []string{
 		fmt.Sprintf("https://storage.googleapis.com/%s/minikube-%s.iso", isoBucket, v),
 		fmt.Sprintf("https://github.com/kubernetes/minikube/releases/download/%s/minikube-%s.iso", v, v),

--- a/pkg/minikube/registry/drvs/hyperkit/hyperkit.go
+++ b/pkg/minikube/registry/drvs/hyperkit/hyperkit.go
@@ -81,6 +81,7 @@ func configure(cfg config.ClusterConfig, n config.Node) (interface{}, error) {
 		VpnKitSock:     cfg.HyperkitVpnKitSock,
 		VSockPorts:     cfg.HyperkitVSockPorts,
 		Cmdline:        "loglevel=3 console=ttyS0 console=tty0 noembed nomodeset norestore waitusb=10 systemd.legacy_systemd_cgroup_controller=yes random.trust_cpu=on hw_rng_model=virtio base host=" + cfg.Name,
+		ExtraDisks:     cfg.ExtraDisks,
 	}, nil
 }
 

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -48,6 +48,7 @@ minikube start [flags]
                                           		The key should be '.' separated, and the first part before the dot is the component to apply the configuration to.
                                           		Valid components are: kubelet, kubeadm, apiserver, controller-manager, etcd, proxy, scheduler
                                           		Valid kubeadm parameters: ignore-preflight-errors, dry-run, kubeconfig, kubeconfig-dir, node-name, cri-socket, experimental-upload-certs, certificate-key, rootfs, skip-phases, pod-network-cidr
+      --extra-disks int                   Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit driver)
       --feature-gates string              A set of key=value pairs that describe feature gates for alpha/experimental features.
       --force                             Force minikube to perform possibly dangerous operations
       --force-systemd                     If set, force the container runtime to use systemd as cgroup manager. Defaults to false.
@@ -64,7 +65,7 @@ minikube start [flags]
       --insecure-registry strings         Insecure Docker registries to pass to the Docker daemon.  The default service CIDR range will automatically be added.
       --install-addons                    If set, install addons. Defaults to true. (default true)
       --interactive                       Allow user prompts for more information (default true)
-      --iso-url strings                   Locations to fetch the minikube ISO from. (default [https://storage.googleapis.com/minikube/iso/minikube-v1.22.0.iso,https://github.com/kubernetes/minikube/releases/download/v1.22.0/minikube-v1.22.0.iso,https://kubernetes.oss-cn-hangzhou.aliyuncs.com/minikube/iso/minikube-v1.22.0.iso])
+      --iso-url strings                   Locations to fetch the minikube ISO from. (default [https://storage.googleapis.com/minikube-builds/iso/11483/minikube-v1.22.0-1627488369-11483.iso,https://github.com/kubernetes/minikube/releases/download/v1.22.0-1627488369-11483/minikube-v1.22.0-1627488369-11483.iso,https://kubernetes.oss-cn-hangzhou.aliyuncs.com/minikube/iso/minikube-v1.22.0-1627488369-11483.iso])
       --keep-context                      This will keep the existing kubectl context and will create a minikube context.
       --kubernetes-version string         The Kubernetes version that the minikube VM will use (ex: v1.2.3, 'stable' for v1.21.3, 'latest' for v1.22.0-rc.0). Defaults to 'stable'.
       --kvm-gpu                           Enable experimental NVIDIA GPU support in minikube


### PR DESCRIPTION
Add the ability to create and attach extra disks to hyperkit vms.

For example, if I wish to add 3 extra disk to my minikube VM, each 10GB in size, the command with the 2 new options would look like below. 
```sh
> minikube start --driver=hyperkit --extra-disks=3 --extra-disk-size=10gb
```
In the minikube VM, I would expect to see the extra disks (in addition to `vda` and `vda1` normally present) available in `/dev` as shown below.
```sh
> minikube ssh
$  ls /dev/vd*
vda
vda1
vdb
vdc
vdd
```

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

Fixes #3883 
This will be useful for me for developing on Rook, and I think it maybe useful for others doing other types of storage development on Kubernetes with minikube.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
