### PR TITLE
Add message to view contributions leaderboard to release_notes.sh.

### DIFF
--- a/hack/release_notes.sh
+++ b/hack/release_notes.sh
@@ -65,5 +65,10 @@ echo ""
 AWK_ISSUE_COMMENTS='NR>1{arr[$4] += $7}END{for (a in arr) printf "%d %s\n", arr[a], a}'
 "${DIR}/pullsheet" issue-comments --since "$recent_date" --repos kubernetes/minikube --token-path $DIR/gh_token.txt --logtostderr=false --stderrthreshold=2 | awk -F ',' "$AWK_ISSUE_COMMENTS" | sort -k1nr -k2d  | awk -F ' ' "$AWK_FORMAT_ITEM" | head -n 5
 
+if [[ "$recent" != *"beta"* ]]; then
+  echo ""
+  echo "Check out our [contributions leaderboard](https://minikube.sigs.k8s.io/docs/contrib/leaderboard/$recent/) for this release!"
+fi
+
 echo ""
 echo "Don't forget to run \"hack/update_contributions.sh\"!"

--- a/hack/release_notes.sh
+++ b/hack/release_notes.sh
@@ -71,4 +71,4 @@ if [[ "$recent" != *"beta"* ]]; then
 fi
 
 echo ""
-echo "Don't forget to run \"hack/update_contributions.sh\"!"
+echo "Don't forget to run \"make update-leaderboard\"!"


### PR DESCRIPTION
fixes #11485.

Before:
```
$ hack/release_notes.sh 
Collecting pull request that were merged since the last release: v1.20.0 (2021-05-06 21:44:15 +0000 UTC)
<PRs>

For a more detailed changelog, including changes occuring in pre-release versions, see [CHANGELOG.md](https://github.com/kubernetes/minikube/blob/master/CHANGELOG.md).

Thank you to our contributors for this release!

<contributors>

Thank you to our PR reviewers for this release!

- medyagh (96 comments)
- ilya-zuyev (14 comments)
- afbjorklund (10 comments)
- spowelljr (9 comments)
- sharifelgamal (1 comments)

Thank you to our triage members for this release!

- afbjorklund (34 comments)
- medyagh (32 comments)
- ilya-zuyev (10 comments)
- spowelljr (6 comments)
- AlbertMarashi (5 comments)

Don't forget to run "hack/update_contributions.sh"!
```
After:
```
$ hack/release_notes.sh 
Collecting pull request that were merged since the last release: v1.20.0 (2021-05-06 21:44:15 +0000 UTC)
<PRs>

For a more detailed changelog, including changes occuring in pre-release versions, see [CHANGELOG.md](https://github.com/kubernetes/minikube/blob/master/CHANGELOG.md).

Thank you to our contributors for this release!

<contributors>

Thank you to our PR reviewers for this release!

- medyagh (96 comments)
- ilya-zuyev (14 comments)
- afbjorklund (10 comments)
- spowelljr (9 comments)
- sharifelgamal (1 comments)

Thank you to our triage members for this release!

- afbjorklund (34 comments)
- medyagh (32 comments)
- ilya-zuyev (10 comments)
- spowelljr (6 comments)
- AlbertMarashi (5 comments)

Check out our [contributions leaderboard](https://minikube.sigs.k8s.io/docs/contrib/leaderboard/v1.20.0/) for this release!

Don't forget to run "hack/update_contributions.sh"!
```