### PR TITLE
Replace PreloadExists check with actual check of preload tarball location.

### DIFF
--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -103,7 +103,7 @@ func CacheKubectlBinary(k8sVersion string) (string, error) {
 // doCacheBinaries caches Kubernetes binaries in the foreground
 func doCacheBinaries(k8sVersion, containerRuntime string) error {
 	existingBinaries := constants.KubernetesReleaseBinaries
-	if !download.PreloadExists(k8sVersion, containerRuntime) {
+	if _, err := os.Stat(download.TarballPath(k8sVersion, containerRuntime)); err != nil {
 		existingBinaries = nil
 	}
 	return machine.CacheBinariesForBootstrapper(k8sVersion, viper.GetString(cmdcfg.Bootstrapper), existingBinaries)


### PR DESCRIPTION
fixes #11526.

Previously, we were using PreloadExists to check if preload is locally cached, except PreloadExists actually checks if a remote tarball exists. Now the check has been replaced with a simple os.Stat.

We should rename PreloadExists....