### PR TITLE
Allow to set the dashboard proxyfied port

### DIFF
--- a/cmd/minikube/cmd/dashboard.go
+++ b/cmd/minikube/cmd/dashboard.go
@@ -67,6 +67,10 @@ var dashboardCmd = &cobra.Command{
 			}
 		}
 
+		if dashboardExposedPort < 0 || dashboardExposedPort > 65535 {
+			exit.Message(reason.HostKubectlProxy, "Invalid port")
+		}
+
 		kubectlVersion := co.Config.KubernetesConfig.KubernetesVersion
 		var err error
 

--- a/cmd/minikube/cmd/dashboard.go
+++ b/cmd/minikube/cmd/dashboard.go
@@ -24,6 +24,7 @@ import (
 	"os/exec"
 	"os/user"
 	"regexp"
+	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -44,7 +45,8 @@ import (
 )
 
 var (
-	dashboardURLMode bool
+	dashboardURLMode     bool
+	dashboardExposedPort int
 	// Matches: 127.0.0.1:8001
 	// TODO(tstromberg): Get kubectl to implement a stable supported output format.
 	hostPortRe = regexp.MustCompile(`127.0.0.1:\d{4,}`)
@@ -92,7 +94,7 @@ var dashboardCmd = &cobra.Command{
 		}
 
 		out.ErrT(style.Launch, "Launching proxy ...")
-		p, hostPort, err := kubectlProxy(kubectlVersion, cname)
+		p, hostPort, err := kubectlProxy(kubectlVersion, cname, dashboardExposedPort)
 		if err != nil {
 			exit.Error(reason.HostKubectlProxy, "kubectl proxy", err)
 		}
@@ -126,10 +128,10 @@ var dashboardCmd = &cobra.Command{
 }
 
 // kubectlProxy runs "kubectl proxy", returning host:port
-func kubectlProxy(kubectlVersion string, contextName string) (*exec.Cmd, string, error) {
+func kubectlProxy(kubectlVersion string, contextName string, port int) (*exec.Cmd, string, error) {
 	// port=0 picks a random system port
 
-	kubectlArgs := []string{"--context", contextName, "proxy", "--port=0"}
+	kubectlArgs := []string{"--context", contextName, "proxy", "--port", strconv.Itoa(port)}
 
 	var cmd *exec.Cmd
 	if kubectl, err := exec.LookPath("kubectl"); err == nil {
@@ -217,4 +219,5 @@ func checkURL(url string) error {
 
 func init() {
 	dashboardCmd.Flags().BoolVar(&dashboardURLMode, "url", false, "Display dashboard URL instead of opening a browser")
+	dashboardCmd.Flags().IntVar(&dashboardExposedPort, "port", 0, "Exposed port of the proxyfied dashboard. Set to 0 to pick a random port.")
 }

--- a/site/content/en/docs/commands/dashboard.md
+++ b/site/content/en/docs/commands/dashboard.md
@@ -20,7 +20,8 @@ minikube dashboard [flags]
 ### Options
 
 ```
-      --url   Display dashboard URL instead of opening a browser
+      --port int   Exposed port of the proxyfied dashboard. Set to 0 to pick a random port.
+      --url        Display dashboard URL instead of opening a browser
 ```
 
 ### Options inherited from parent commands

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -815,7 +815,7 @@ func validateDashboardCmd(ctx context.Context, t *testing.T, profile string) {
 	mctx, cancel := context.WithTimeout(ctx, Seconds(300))
 	defer cancel()
 
-	args := []string{"dashboard", "--url", "-p", profile, "--alsologtostderr", "-v=1"}
+	args := []string{"dashboard", "--url", "--port", "36195", "-p", profile, "--alsologtostderr", "-v=1"}
 	ss, err := Start(t, exec.CommandContext(mctx, Target(), args...))
 	if err != nil {
 		t.Errorf("failed to run minikube dashboard. args %q : %v", args, err)

--- a/translations/de.json
+++ b/translations/de.json
@@ -215,6 +215,7 @@
 	"Existing disk is missing new features ({{.error}}). To upgrade, run 'minikube delete'": "",
 	"Exiting": "Wird beendet",
 	"Exiting due to {{.fatal_code}}: {{.fatal_msg}}": "",
+	"Exposed port of the proxyfied dashboard. Set to 0 to pick a random port.": "",
 	"External Adapter on which external switch will be created if no external switch is found. (hyperv driver only)": "",
 	"Fail check if container paused": "",
 	"Failed runtime": "",

--- a/translations/es.json
+++ b/translations/es.json
@@ -220,6 +220,7 @@
 	"Existing disk is missing new features ({{.error}}). To upgrade, run 'minikube delete'": "",
 	"Exiting": "Saliendo",
 	"Exiting due to {{.fatal_code}}: {{.fatal_msg}}": "",
+	"Exposed port of the proxyfied dashboard. Set to 0 to pick a random port.": "",
 	"External Adapter on which external switch will be created if no external switch is found. (hyperv driver only)": "",
 	"Fail check if container paused": "",
 	"Failed runtime": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -218,6 +218,7 @@
 	"Existing disk is missing new features ({{.error}}). To upgrade, run 'minikube delete'": "Il manque de nouvelles fonctionnalités sur le disque existant ({{.error}}). Pour mettre à niveau, exécutez 'minikube delete'",
 	"Exiting": "Fermeture…",
 	"Exiting due to {{.fatal_code}}: {{.fatal_msg}}": "Fermeture en raison de {{.fatal_code}} : {{.fatal_msg}}",
+	"Exposed port of the proxyfied dashboard. Set to 0 to pick a random port.": "",
 	"External Adapter on which external switch will be created if no external switch is found. (hyperv driver only)": "L'adaptateur externe sur lequel un commutateur externe sera créé si aucun commutateur externe n'est trouvé. (pilote hyperv uniquement)",
 	"Fail check if container paused": "Échec de la vérification si le conteneur est en pause",
 	"Failed runtime": "Échec de l'exécution",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -208,6 +208,7 @@
 	"Exiting": "終了しています",
 	"Exiting due to {{.fatal_code}}: {{.fatal_msg}}": "",
 	"Exiting.": "終了しています",
+	"Exposed port of the proxyfied dashboard. Set to 0 to pick a random port.": "",
 	"External Adapter on which external switch will be created if no external switch is found. (hyperv driver only)": "",
 	"Fail check if container paused": "",
 	"Failed runtime": "",

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -232,6 +232,7 @@
 	"Executing \"{{.command}}\" took an unusually long time: {{.duration}}": "",
 	"Existing disk is missing new features ({{.error}}). To upgrade, run 'minikube delete'": "",
 	"Exiting due to {{.fatal_code}}: {{.fatal_msg}}": "",
+	"Exposed port of the proxyfied dashboard. Set to 0 to pick a random port.": "",
 	"External Adapter on which external switch will be created if no external switch is found. (hyperv driver only)": "",
 	"Fail check if container paused": "",
 	"Failed runtime": "런타임이 실패하였습니다",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -223,6 +223,7 @@
 	"Executing \"{{.command}}\" took an unusually long time: {{.duration}}": "",
 	"Existing disk is missing new features ({{.error}}). To upgrade, run 'minikube delete'": "",
 	"Exiting due to {{.fatal_code}}: {{.fatal_msg}}": "",
+	"Exposed port of the proxyfied dashboard. Set to 0 to pick a random port.": "",
 	"External Adapter on which external switch will be created if no external switch is found. (hyperv driver only)": "",
 	"Fail check if container paused": "",
 	"Failed runtime": "",

--- a/translations/strings.txt
+++ b/translations/strings.txt
@@ -201,6 +201,7 @@
 	"Executing \"{{.command}}\" took an unusually long time: {{.duration}}": "",
 	"Existing disk is missing new features ({{.error}}). To upgrade, run 'minikube delete'": "",
 	"Exiting due to {{.fatal_code}}: {{.fatal_msg}}": "",
+	"Exposed port of the proxyfied dashboard. Set to 0 to pick a random port.": "",
 	"External Adapter on which external switch will be created if no external switch is found. (hyperv driver only)": "",
 	"Fail check if container paused": "",
 	"Failed runtime": "",

--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -280,6 +280,7 @@
 	"Exiting due to driver incompatibility": "由于驱动程序不兼容而退出",
 	"Exiting due to {{.fatal_code}}: {{.fatal_msg}}": "",
 	"Exiting.": "正在退出。",
+	"Exposed port of the proxyfied dashboard. Set to 0 to pick a random port.": "",
 	"External Adapter on which external switch will be created if no external switch is found. (hyperv driver only)": "",
 	"Fail check if container paused": "",
 	"Failed runtime": "",


### PR DESCRIPTION
Add a `--port` option to `minikube dashboard`, still defaults to `0` to use a random port.

As the value of the port is not accessible elsewhere than from the `minikube dashboard` output, it can be sometimes useful to set the port in advance to be able to use it.
