### PR TITLE
try image without sha before failing

### DIFF
--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -42,6 +42,9 @@ var (
 		// the fallback of BaseImage in case gcr.io is not available. stored in docker hub
 		// same image is push to https://github.com/kicbase/stable
 		fmt.Sprintf("%s:%s@sha256:%s", dockerhubRepo, Version, baseImageSHA),
+		// try without sha because #11068
+		fmt.Sprintf("%s:%s", dockerhubRepo, Version),
+		fmt.Sprintf("%s:%s", gcrRepo, Version),
 	}
 )
 

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -43,8 +43,8 @@ var (
 		// same image is push to https://github.com/kicbase/stable
 		fmt.Sprintf("%s:%s@sha256:%s", dockerhubRepo, Version, baseImageSHA),
 		// try without sha because #11068
-		fmt.Sprintf("%s:%s", dockerhubRepo, Version),
 		fmt.Sprintf("%s:%s", gcrRepo, Version),
+		fmt.Sprintf("%s:%s", dockerhubRepo, Version),
 	}
 )
 


### PR DESCRIPTION
for some corps/enterprise users it doesn't work when we try to pull image with SHA we should try at least to pull wihtout sha before failing
https://github.com/kubernetes/minikube/issues/11068