### PR TITLE
Fix embed-certs global config

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -172,7 +172,7 @@ var settings = []Setting{
 		setMap: SetMap,
 	},
 	{
-		name: "embed-certs",
+		name: config.EmbedCerts,
 		set:  SetBool,
 	},
 	{

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -301,6 +301,7 @@ func setupViper() {
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
 
+	viper.RegisterAlias(config.EmbedCerts, embedCerts)
 	viper.SetDefault(config.WantUpdateNotification, true)
 	viper.SetDefault(config.ReminderWaitPeriodInHours, 24)
 	viper.SetDefault(config.WantReportError, false)

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -169,7 +169,6 @@ func runStart(cmd *cobra.Command, args []string) {
 		out.WarningT("Profile name '{{.name}}' is not valid", out.V{"name": ClusterFlagValue()})
 		exit.Message(reason.Usage, "Only alphanumeric and dashes '-' are permitted. Minimum 2 characters, starting with alphanumeric.")
 	}
-
 	existing, err := config.Load(ClusterFlagValue())
 	if err != nil && !config.IsNotExist(err) {
 		kind := reason.HostConfigLoad

--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -58,6 +58,8 @@ const (
 	AddonRegistries = "addon-registries"
 	// AddonListFlag represents the key for addons parameter
 	AddonListFlag = "addons"
+	// EmbedCerts represents the config for embedding certificates in kubeconfig
+	EmbedCerts = "EmbedCerts"
 )
 
 var (

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -34,7 +34,7 @@ type Profile struct {
 type ClusterConfig struct {
 	Name                    string
 	KeepContext             bool   // used by start and profile command to or not to switch kubectl's current context
-	EmbedCerts              bool   `json:"embed-certs"` // used by kubeconfig.Setup
+	EmbedCerts              bool   // used by kubeconfig.Setup
 	MinikubeISO             string // ISO used for VM-drivers.
 	KicBaseImage            string // base-image used for docker/podman drivers.
 	Memory                  int

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -34,7 +34,7 @@ type Profile struct {
 type ClusterConfig struct {
 	Name                    string
 	KeepContext             bool   // used by start and profile command to or not to switch kubectl's current context
-	EmbedCerts              bool   // used by kubeconfig.Setup
+	EmbedCerts              bool   `json:"embed-certs"` // used by kubeconfig.Setup
 	MinikubeISO             string // ISO used for VM-drivers.
 	KicBaseImage            string // base-image used for docker/podman drivers.
 	Memory                  int

--- a/site/content/en/docs/commands/config.md
+++ b/site/content/en/docs/commands/config.md
@@ -41,7 +41,7 @@ Configurable fields:
  * hyperv-virtual-switch
  * disable-driver-mounts
  * cache
- * embed-certs
+ * EmbedCerts
  * native-ssh
 
 ```shell


### PR DESCRIPTION
fixes #11253
Fix embed-certs global config by adding `embed-certs` json tag to `EmbedCerts` field in `ClusterConfig` struct.

Unmarshaler in https://github.com/kubernetes/minikube/blob/master/pkg/minikube/config/config.go#L199 wasn't able to deserialize  `embed-certs` json  field into `EmbedCerts` string member variable in `ClusterConfig`. 

That's why existing config in https://github.com/kubernetes/minikube/blob/master/cmd/minikube/cmd/start.go#L173 was created without given flag. 

Now global config option successfully initialises cert embedding on cluster creation
