### PR TITLE
Modify MetricsServer to use v1 api version (instead of v1beta1).

### DIFF
--- a/deploy/addons/metrics-server/metrics-apiservice.yaml.tmpl
+++ b/deploy/addons/metrics-server/metrics-apiservice.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1beta1.metrics.k8s.io


### PR DESCRIPTION
fixes #11568.

The current v1beta1 no longer contains a "kind" of APIService. Using the v1 version works.