### PR TITLE
Prevent misleading "save to tar file succeeded" message from being logged

### DIFF
--- a/pkg/minikube/image/cache.go
+++ b/pkg/minikube/image/cache.go
@@ -73,7 +73,7 @@ func SaveToDir(images []string, cacheDir string, overwrite bool) error {
 			dst = localpath.SanitizeCacheDir(dst)
 			if err := saveToTarFile(image, dst, overwrite); err != nil {
 				if err == errCacheImageDoesntExist {
-					out.WarningT("The image you are trying to add {{.imageName}} doesn't exist!", out.V{"imageName": image})
+					out.WarningT("The image '{{.imageName}}' was not found; unable to add it to cache.", out.V{"imageName": image})
 					return nil
 				}
 				return errors.Wrapf(err, "caching image %q", dst)

--- a/pkg/minikube/image/cache.go
+++ b/pkg/minikube/image/cache.go
@@ -74,6 +74,7 @@ func SaveToDir(images []string, cacheDir string, overwrite bool) error {
 			if err := saveToTarFile(image, dst, overwrite); err != nil {
 				if err == errCacheImageDoesntExist {
 					out.WarningT("The image you are trying to add {{.imageName}} doesn't exist!", out.V{"imageName": image})
+					return nil
 				} else {
 					return errors.Wrapf(err, "caching image %q", dst)
 				}

--- a/pkg/minikube/image/cache.go
+++ b/pkg/minikube/image/cache.go
@@ -75,9 +75,8 @@ func SaveToDir(images []string, cacheDir string, overwrite bool) error {
 				if err == errCacheImageDoesntExist {
 					out.WarningT("The image you are trying to add {{.imageName}} doesn't exist!", out.V{"imageName": image})
 					return nil
-				} else {
-					return errors.Wrapf(err, "caching image %q", dst)
 				}
+				return errors.Wrapf(err, "caching image %q", dst)
 			}
 			klog.Infof("save to tar file %s -> %s succeeded", image, dst)
 			return nil


### PR DESCRIPTION
If we don't return early, the message `save to tar file %s -> %s succeeded` gets logged, which is incorrect because the save to tar failed since the cached image doesn't exist.

This early return will prevent the success message from being logged and possibly causing confusion.

**Before:**
Output to user:
```
❗  The image you are trying to add ubuntu doesn't exist!
```
Log output:
```
save to tar file ubuntu -> /usr/home/.minikube succeeded
```

**After:**
Output to user:
```
❗  The image 'ubuntu' was not found; unable to add it to cache.
```
Log output:
_Empty_