### PR TITLE
Delete `minikube-integration` folder in case last test failed to delete it

### DIFF
--- a/hack/jenkins/windows_integration_setup.ps1
+++ b/hack/jenkins/windows_integration_setup.ps1
@@ -17,5 +17,5 @@ $env:KUBECONFIG="$test_home\kubeconfig"
 $env:MINIKUBE_HOME="$test_home\.minikube"
 
 # delete in case previous test was unexpectedly ended and teardown wasn't run
-rm -r $test_home
+rm -r -Force $test_home
 mkdir -p $test_home

--- a/hack/jenkins/windows_integration_setup.ps1
+++ b/hack/jenkins/windows_integration_setup.ps1
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-$test_root="$env:HOMEDRIVE$env:HOMEPATH\minikube-integration"
-$test_home="$test_root\$env:COMMIT"
+$test_home="$env:HOMEDRIVE$env:HOMEPATH\minikube-integration"
 $env:KUBECONFIG="$test_home\kubeconfig"
 $env:MINIKUBE_HOME="$test_home\.minikube"
 
+# delete in case previous test was unexpectedly ended and teardown wasn't run
+rm -r $test_home
 mkdir -p $test_home

--- a/hack/jenkins/windows_integration_teardown.ps1
+++ b/hack/jenkins/windows_integration_teardown.ps1
@@ -14,4 +14,4 @@
 
 $test_home="$env:HOMEDRIVE$env:HOMEPATH\minikube-integration"
 
-rm -r $test_home
+rm -r -Force $test_home

--- a/hack/jenkins/windows_integration_teardown.ps1
+++ b/hack/jenkins/windows_integration_teardown.ps1
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-$test_root="$env:HOMEDRIVE$env:HOMEPATH\minikube-integration"
-$test_home="$test_root\$env:COMMIT"
+$test_home="$env:HOMEDRIVE$env:HOMEPATH\minikube-integration"
 
 rm -r $test_home


### PR DESCRIPTION
**Problem:**
If the previous test was unexpectedly ended, the teardown script that deletes the `minikube-integration` folder is not run. This leaves the folder up containing the kube config and minikube home folder which can be in a bad state and affect the next test.

**Solution:**
Delete the folder on the setup script as well to ensure the folder is empty.