### PR TITLE
site: add alternative certs dir 

### DIFF
--- a/site/content/en/docs/handbook/vpn_and_proxy.md
+++ b/site/content/en/docs/handbook/vpn_and_proxy.md
@@ -93,6 +93,10 @@ Ask your IT department for the appropriate PEM file, and add it to:
 
 `~/.minikube/files/etc/ssl/certs`
 
+or
+
+`~/.minikube/certs`
+
 Then run `minikube delete` and `minikube start`.
 
 #### downloading binaries: proxyconnect tcp: tls: oversized record received with length 20527


### PR DESCRIPTION
For x509: certificate signed by unknown authority problem in minikube since version v1.20.0 I just found `~/.minikube/certs` dir.
I pasted my PEM files over there and it solve my problem.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
