### PR TITLE
Add timeout to apiserver health check.

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/kverify/api_server.go
+++ b/pkg/minikube/bootstrapper/bsutil/kverify/api_server.go
@@ -232,7 +232,7 @@ func apiServerHealthzNow(hostname string, port int) (state.State, error) {
 		Proxy:           nil, // Avoid using a proxy to speak to a local host
 		TLSClientConfig: &tls.Config{RootCAs: pool},
 	}
-	client := &http.Client{Transport: tr}
+	client := &http.Client{Transport: tr, Timeout: 5 * time.Second}
 	resp, err := client.Get(url)
 	// Connection refused, usually.
 	if err != nil {


### PR DESCRIPTION
fixes #11628.

A timeout of 5 second is used (fairly short), since all uses of this function have their own timeout and retry mechanisms.