### PR TITLE
Add too high k8s version validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,6 +87,7 @@ require (
 	golang.org/x/sys v0.0.0-20210514084401-e8d321eab015
 	golang.org/x/term v0.0.0-20210406210042-72f3dc4e9b72
 	golang.org/x/text v0.3.6
+	golang.org/x/tools v0.1.3 // indirect
 	gonum.org/v1/plot v0.9.0
 	google.golang.org/api v0.47.0
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1400,8 +1400,9 @@ golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.1 h1:wGiQel/hW0NnEkJUk8lbzkX2gFJU6PFxf1v5OlCfuOs=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.3 h1:L69ShwSZEyCsLKoAxDKeMvLDZkumEe8gXUZAjab0tX8=
+golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/hack/preload-images/preload_images.go
+++ b/hack/preload-images/preload_images.go
@@ -31,6 +31,7 @@ import (
 	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/download"
+	"k8s.io/minikube/pkg/minikube/github"
 )
 
 const (
@@ -113,7 +114,7 @@ out:
 
 func collectK8sVers() ([]string, error) {
 	if k8sVersions == nil {
-		recent, err := recentK8sVersions()
+		recent, err := github.RecentK8sVersions()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/minikube/github/github.go
+++ b/pkg/minikube/github/github.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubernetes Authors All rights reserved.
+Copyright 2021 The Kubernetes Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,18 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package github
 
 import (
 	"context"
 
 	"github.com/google/go-github/github"
-
-	"k8s.io/klog/v2"
 )
 
-// recentK8sVersions returns the most recent k8s version, usually around 30
-func recentK8sVersions() ([]string, error) {
+// RecentK8sVersions returns the most recent k8s version, usually around 30
+func RecentK8sVersions() ([]string, error) {
 	client := github.NewClient(nil)
 	k8s := "kubernetes"
 	list, _, err := client.Repositories.ListReleases(context.Background(), k8s, k8s, &github.ListOptions{})
@@ -36,6 +34,5 @@ func recentK8sVersions() ([]string, error) {
 	for _, r := range list {
 		releases = append(releases, r.GetTagName())
 	}
-	klog.InfoS("Got releases", "releases", releases)
 	return releases, nil
 }

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -296,8 +296,10 @@ var (
 	KubernetesInstallFailed                  = Kind{ID: "K8S_INSTALL_FAILED", ExitCode: ExControlPlaneError}
 	KubernetesInstallFailedRuntimeNotRunning = Kind{ID: "K8S_INSTALL_FAILED_CONTAINER_RUNTIME_NOT_RUNNING", ExitCode: ExRuntimeNotRunning}
 	KubernetesTooOld                         = Kind{ID: "K8S_OLD_UNSUPPORTED", ExitCode: ExControlPlaneUnsupported}
-	KubernetesTooNew                         = Kind{ID: "K8S_NEW_UNSUPPORTED", ExitCode: ExControlPlaneUnsupported}
-	KubernetesDowngrade                      = Kind{
+	KubernetesReleaseFetchFailed             = Kind{ID: "K8S_RELEASE_FETCH_FAILED", ExitCode: ExControlPlaneUnsupported}
+	KubernetesVersionNotFound                = Kind{ID: "K8S_VERSION_NOT_FOUND", ExitCode: ExControlPlaneUnsupported}
+
+	KubernetesDowngrade = Kind{
 		ID:       "K8S_DOWNGRADE_UNSUPPORTED",
 		ExitCode: ExControlPlaneUnsupported,
 		Advice: `1) Recreate the cluster with Kubernetes {{.new}}, by running:

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -296,6 +296,7 @@ var (
 	KubernetesInstallFailed                  = Kind{ID: "K8S_INSTALL_FAILED", ExitCode: ExControlPlaneError}
 	KubernetesInstallFailedRuntimeNotRunning = Kind{ID: "K8S_INSTALL_FAILED_CONTAINER_RUNTIME_NOT_RUNNING", ExitCode: ExRuntimeNotRunning}
 	KubernetesTooOld                         = Kind{ID: "K8S_OLD_UNSUPPORTED", ExitCode: ExControlPlaneUnsupported}
+	KubernetesTooNew                         = Kind{ID: "K8S_NEW_UNSUPPORTED", ExitCode: ExControlPlaneUnsupported}
 	KubernetesDowngrade                      = Kind{
 		ID:       "K8S_DOWNGRADE_UNSUPPORTED",
 		ExitCode: ExControlPlaneUnsupported,

--- a/site/content/en/docs/contrib/errorcodes.en.md
+++ b/site/content/en/docs/contrib/errorcodes.en.md
@@ -411,6 +411,8 @@ minikube has no current cluster running
 
 "K8S_OLD_UNSUPPORTED" (Exit code ExControlPlaneUnsupported)  
 
-"K8S_NEW_UNSUPPORTED" (Exit code ExControlPlaneUnsupported)
+"K8S_DOWNGRADE_UNSUPPORTED" (Exit code ExControlPlaneUnsupported)
 
-"K8S_DOWNGRADE_UNSUPPORTED" (Exit code ExControlPlaneUnsupported)  
+"K8S_RELEASE_FETCH_FAILED"  (Exit code ExControlPlaneUnsupported)
+
+"K8S_VERSION_NOT_FOUND"     (Exit code ExControlPlaneUnsupported)

--- a/site/content/en/docs/contrib/errorcodes.en.md
+++ b/site/content/en/docs/contrib/errorcodes.en.md
@@ -414,5 +414,3 @@ minikube has no current cluster running
 "K8S_NEW_UNSUPPORTED" (Exit code ExControlPlaneUnsupported)
 
 "K8S_DOWNGRADE_UNSUPPORTED" (Exit code ExControlPlaneUnsupported)  
-
-

--- a/site/content/en/docs/contrib/errorcodes.en.md
+++ b/site/content/en/docs/contrib/errorcodes.en.md
@@ -411,5 +411,8 @@ minikube has no current cluster running
 
 "K8S_OLD_UNSUPPORTED" (Exit code ExControlPlaneUnsupported)  
 
+"K8S_NEW_UNSUPPORTED" (Exit code ExControlPlaneUnsupported)
+
 "K8S_DOWNGRADE_UNSUPPORTED" (Exit code ExControlPlaneUnsupported)  
+
 


### PR DESCRIPTION
fixes #11627
This PR introduces another constraint to `validateKubernetesVersion` function, checking if version is less or equal than the newest supported version.
