### PR TITLE
[wip] make integration tests ouput easier to read

### DIFF
--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -193,7 +193,7 @@ func TestingKicBaseImage() bool {
 }
 
 func runMinikubeCtx(ctx context.Context, t *testing.T, p string, args ...string) (*RunResult, error) {
-	cmd := fmt.Sprintf("bash -c \"%s -p %s %s 2>&1 >> test_%s.log \"",
+	cmd := fmt.Sprintf("\"%s -p %s %s 2>&1 >> test_%s.log \"",
 		Target(), p, strings.Join(args, " "), p)
-	return Run(t, exec.CommandContext(ctx, cmd))
+	return Run(t, exec.CommandContext(ctx, "bash", "-c", cmd))
 }

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -193,7 +193,7 @@ func TestingKicBaseImage() bool {
 }
 
 func runMinikubeCtx(ctx context.Context, t *testing.T, p string, args ...string) (*RunResult, error) {
-	cmd := fmt.Sprintf("bash -c \"%s -p %s %s 2>&1 \" >> test_%s.log",
+	cmd := fmt.Sprintf("bash -c \"%s -p %s %s 2>&1 >> test_%s.log \"",
 		Target(), p, strings.Join(args, " "), p)
 	return Run(t, exec.CommandContext(ctx, cmd))
 }

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -191,3 +191,9 @@ func Seconds(n int) time.Duration {
 func TestingKicBaseImage() bool {
 	return strings.Contains(*startArgs, "base-image")
 }
+
+func runMinikubeCtx(ctx context.Context, t *testing.T, p string, args ...string) (*RunResult, error) {
+	cmd := fmt.Sprintf("bash -c \"%s -p %s %s 2>&1 \" >> test_%s.log",
+		Target(), p, strings.Join(args, " "), p)
+	return Run(t, exec.CommandContext(ctx, cmd))
+}

--- a/test/integration/pause_test.go
+++ b/test/integration/pause_test.go
@@ -102,20 +102,17 @@ func validateStartNoReconfigure(ctx context.Context, t *testing.T, profile strin
 // validatePause runs minikube pause
 func validatePause(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
-
-	args := []string{"pause", "-p", profile, "--alsologtostderr", "-v=5"}
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
+	rr, err := runMinikubeCtx(ctx, t, profile, "pause", "--alsologtostderr", "-v=5")
 	if err != nil {
 		t.Errorf("failed to pause minikube with args: %q : %v", rr.Command(), err)
 	}
+	t.Error("Test error")
 }
 
 // validateUnpause runs minikube unpause
 func validateUnpause(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
-
-	args := []string{"unpause", "-p", profile, "--alsologtostderr", "-v=5"}
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
+	rr, err := runMinikubeCtx(ctx, t, profile, "unpause", "--alsologtostderr", "-v=5")
 	if err != nil {
 		t.Errorf("failed to unpause minikube with args: %q : %v", rr.Command(), err)
 	}
@@ -125,8 +122,7 @@ func validateUnpause(ctx context.Context, t *testing.T, profile string) {
 func validateDelete(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 
-	args := []string{"delete", "-p", profile, "--alsologtostderr", "-v=5"}
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
+	rr, err := runMinikubeCtx(ctx, t, profile, "delete", "--alsologtostderr", "-v=5")
 	if err != nil {
 		t.Errorf("failed to delete minikube with args: %q : %v", rr.Command(), err)
 	}
@@ -136,7 +132,7 @@ func validateDelete(ctx context.Context, t *testing.T, profile string) {
 func validateVerifyDeleted(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), "profile", "list", "--output", "json"))
+	rr, err := runMinikubeCtx(ctx, t, profile, "list", "--output", "json")
 	if err != nil {
 		t.Errorf("failed to list profiles with json format after it was deleted. args %q: %v", rr.Command(), err)
 	}

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -156,7 +156,7 @@ func TestStartStop(t *testing.T) {
 // validateFirstStart runs the initial minikube start
 func validateFirstStart(ctx context.Context, t *testing.T, profile string, tcName string, tcVersion string, startArgs []string) {
 	defer PostMortemLogs(t, profile)
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), startArgs...))
+	rr, err := runMinikubeCtx(ctx, t, profile, startArgs...)
 	if err != nil {
 		t.Fatalf("failed starting minikube -first start-. args %q: %v", rr.Command(), err)
 	}
@@ -175,7 +175,7 @@ func validateEnableAddonWhileActive(ctx context.Context, t *testing.T, profile s
 	defer PostMortemLogs(t, profile)
 
 	// Enable an addon to assert it requests the correct image.
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), "addons", "enable", "metrics-server", "-p", profile, "--images=MetricsServer=k8s.gcr.io/echoserver:1.4", "--registries=MetricsServer=fake.domain"))
+	rr, err := runMinikubeCtx(ctx, t, profile, "addons", "enable", "metrics-server", "--images=MetricsServer=k8s.gcr.io/echoserver:1.4", "--registries=MetricsServer=fake.domain")
 	if err != nil {
 		t.Errorf("failed to enable an addon post-stop. args %q: %v", rr.Command(), err)
 	}
@@ -198,7 +198,7 @@ func validateEnableAddonWhileActive(ctx context.Context, t *testing.T, profile s
 // validateStop tests minikube stop
 func validateStop(ctx context.Context, t *testing.T, profile string, tcName string, tcVersion string, startArgs []string) {
 	defer PostMortemLogs(t, profile)
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), "stop", "-p", profile, "--alsologtostderr", "-v=3"))
+	rr, err := runMinikubeCtx(ctx, t, profile, "stop", "--alsologtostderr", "-v=3")
 	if err != nil {
 		t.Fatalf("failed stopping minikube - first stop-. args %q : %v", rr.Command(), err)
 	}


### PR DESCRIPTION
Currently, the output of minikube integration tests we have from Jenkins is a total mess.
The output of test code is mixed with the debug output of all `minikube xxx` commands we run.
If a test fails it's pretty hard to find what the actual error was.

The idea of this PR is to separate those output streams, having in gopogh isolated test output and minikube ouput in separate files, linked to the main report