### PR TITLE
Fix a download link to use arm64 instead of amd64

### DIFF
--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -97,7 +97,7 @@ func Execute() {
 
 	if runtime.GOOS == "darwin" && detect.IsAmd64M1Emulation() {
 		exit.Message(reason.WrongBinaryM1, "You are trying to run amd64 binary on M1 system. Please use darwin/arm64 binary instead (Download at {{.url}}.)",
-			out.V{"url": notify.DownloadURL(version.GetVersion(), "darwin", "amd64")})
+			out.V{"url": notify.DownloadURL(version.GetVersion(), "darwin", "arm64")})
 	}
 
 	_, callingCmd := filepath.Split(os.Args[0])


### PR DESCRIPTION
Currently, the error message is correct, but the download link is still pointing `amd64`. We need to download `arm64` binary.
```
$ minikube version --short

❌  Exiting due to MK_WRONG_BINARY_M1: You are trying to run amd64 binary on M1 system.
Please use darwin/arm64 binary instead
(Download at https://github.com/kubernetes/minikube/releases/download/v1.21.0/minikube-darwin-amd64.)
```