### PR TITLE
Create automated time-to-k8s benchmarks on release

### DIFF
--- a/.github/workflows/time-to-k8s.yml
+++ b/.github/workflows/time-to-k8s.yml
@@ -1,7 +1,7 @@
 name: "time-to-k8s benchmark"
 on:
-    release:
-      types: [released]
+  release:
+    types: [released]
 jobs:
   benchmark:
     runs-on: ubuntu-18.04

--- a/.github/workflows/time-to-k8s.yml
+++ b/.github/workflows/time-to-k8s.yml
@@ -1,9 +1,7 @@
 name: "time-to-k8s benchmark"
 on:
-  pull_request:
-    types: [opened]
-  #  release:
-  #    types: [released]
+    release:
+      types: [released]
 jobs:
   benchmark:
     runs-on: ubuntu-18.04

--- a/.github/workflows/time-to-k8s.yml
+++ b/.github/workflows/time-to-k8s.yml
@@ -1,0 +1,20 @@
+name: "time-to-k8s benchmark"
+on:
+  pull_request:
+    types: [opened]
+  #  release:
+  #    types: [released]
+jobs:
+  benchmark:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Checkout submodules
+      run: git submodule update --init
+    - uses: actions/setup-go@v2
+      with:
+          go-version: 1.16.5
+          stable: true
+    - name: Benchmark
+      run: |
+          ./hack/benchmark/time-to-k8s/time-to-k8s.sh ${{ secrets.MINIKUBE_BOT_PAT }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "site/themes/docsy"]
 	path = site/themes/docsy
 	url = https://github.com/google/docsy.git
-[submodule "hack/benchmark/time-to-k8s/time-to-k8s"]
-	path = hack/benchmark/time-to-k8s/time-to-k8s
+[submodule "hack/benchmark/time-to-k8s/time-to-k8s-repo"]
+	path = hack/benchmark/time-to-k8s/time-to-k8s-repo
 	url = https://github.com/tstromberg/time-to-k8s.git

--- a/hack/benchmark/time-to-k8s/time-to-k8s.sh
+++ b/hack/benchmark/time-to-k8s/time-to-k8s.sh
@@ -51,7 +51,7 @@ run_benchmark() {
 	pwd
 	( cd ./hack/benchmark/time-to-k8s/time-to-k8s-repo/ &&
 		git submodule update --init &&
-		go run . --config local-kubernetes.yaml --iterations 1 --output output.csv )
+		go run . --config local-kubernetes.yaml --iterations 5 --output output.csv )
 }
 
 generate_chart() {


### PR DESCRIPTION
Closes #11651

Updated `time-to-k8s.sh` script to automate creating a PR when there's a new release, ran using GitHub Actions.