### PR TITLE
Fix flake rates being commented about when no failed tests are present.

### DIFF
--- a/hack/jenkins/test-flake-chart/report_flakes.sh
+++ b/hack/jenkins/test-flake-chart/report_flakes.sh
@@ -61,7 +61,7 @@ TMP_FAILED_RATES="$TMP_FLAKE_RATES\_filtered"
   > "$TMP_FAILED_RATES"
 
 FAILED_RATES_LINES=$(wc -l < "$TMP_FAILED_RATES")
-if [[ "$FAILED_RATES_LINES" -gt 30 ]]; then
+if [[ "$FAILED_RATES_LINES" -eq 0 ]]; then
   echo "No failed tests! Aborting without commenting..." 1>&2
   exit 0
 fi


### PR DESCRIPTION
fixes #11682.

I did it right the first time, then I refactored and copy-pasted, and then it was broken. :'( But now it's fixed!