### PR TITLE
Change minimum required Go version to 1.16 in docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -866,8 +866,7 @@ site/themes/docsy/assets/vendor/bootstrap/package.js: ## update the website docs
 out/hugo/hugo:
 	mkdir -p out
 	test -d out/hugo || git clone https://github.com/gohugoio/hugo.git out/hugo
-	go get golang.org/dl/go1.16 && go1.16 download
-	(cd out/hugo && go1.16 build --tags extended)
+	(cd out/hugo && go build --tags extended)
 
 .PHONY: site
 site: site/themes/docsy/assets/vendor/bootstrap/package.js out/hugo/hugo ## Serve the documentation site to localhost

--- a/site/content/en/docs/contrib/building/binaries.md
+++ b/site/content/en/docs/contrib/building/binaries.md
@@ -7,7 +7,7 @@ weight: 2
 
 ## Prerequisites
 
-* A recent Go distribution (>=1.12)
+* A recent Go distribution (>=1.16)
 * If you are on Windows, you'll need Docker to be installed.
 * 4GB of RAM
 

--- a/site/content/en/docs/contrib/building/iso.md
+++ b/site/content/en/docs/contrib/building/iso.md
@@ -10,7 +10,7 @@ The minikube ISO is booted by each hypervisor to provide a stable minimal Linux 
 
 ## Prerequisites
 
-* A recent Go distribution (>=1.12)
+* A recent Go distribution (>=1.16)
 * If you are on Windows, you'll need Docker to be installed.
 * 4GB of RAM
 * Build tools:


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

Hi,

Since the usage of `embed` was introduced in 02b996e0116eb1899880894accb62d626e1ad3b1, Go < 1.16 will no longer build the minikube binary. So I upgraded the minimum required version to 1.16 in the docs.

Thanks!