### PR TITLE
Fix intersected log boxes when running with --alsologtostderr

### DIFF
--- a/pkg/minikube/out/out.go
+++ b/pkg/minikube/out/out.go
@@ -114,17 +114,12 @@ func Styled(st style.Enum, format string, a ...V) {
 }
 
 func boxedCommon(printFunc func(format string, a ...interface{}), format string, a ...V) {
-	str := Sprintf(style.None, format, a...)
-	str = strings.TrimSpace(str)
 	box := box.New(box.Config{Py: 1, Px: 4, Type: "Round"})
 	if useColor {
 		box.Config.Color = "Red"
 	}
-	str = box.String("", str)
-	lines := strings.Split(str, "\n")
-	for _, line := range lines {
-		printFunc(line + "\n")
-	}
+	str := Sprintf(style.None, format, a...)
+	printFunc(box.String("", strings.TrimSpace(str)))
 }
 
 // Boxed writes a stylized and templated message in a box to stdout


### PR DESCRIPTION
After:
```
W0617 19:58:23.319857   76868 out.go:231] 💣  Error starting cluster: boom
💣  Error starting cluster: boom
W0617 19:58:23.319867   76868 out.go:231] 

W0617 19:58:23.320538   76868 out.go:231] ╭────────────────────────────────────────────────────────────────────╮
│                                                                    │
│    😿  If the above advice does not help, please let us know:      │
│    👉  https://github.com/kubernetes/minikube/issues/new/choose    │
│                                                                    │
│    Please attach the following file to the GitHub issue:           │
│    - /Users/izuyev/.minikube/logs/lastStart.txt                    │
│                                                                    │
╰────────────────────────────────────────────────────────────────────╯
╭────────────────────────────────────────────────────────────────────╮
│                                                                    │
│    😿  If the above advice does not help, please let us know:      │
│    👉  https://github.com/kubernetes/minikube/issues/new/choose    │
│                                                                    │
│    Please attach the following file to the GitHub issue:           │
│    - /Users/izuyev/.minikube/logs/lastStart.txt                    │
│                                                                    │
╰────────────────────────────────────────────────────────────────────╯

```