### PR TITLE
Fix translations not looking for correct file.

### DIFF
--- a/pkg/minikube/translate/translate.go
+++ b/pkg/minikube/translate/translate.go
@@ -19,7 +19,6 @@ package translate
 import (
 	"encoding/json"
 	"fmt"
-	"path"
 	"strings"
 
 	"github.com/cloudfoundry-attic/jibber_jabber"
@@ -70,14 +69,12 @@ func DetermineLocale() {
 
 	// Load translations for preferred language into memory.
 	p := preferredLanguage.String()
-	translationFile := path.Join("translations", fmt.Sprintf("%s.json", p))
-	t, err := translations.Translations.ReadFile(translationFile)
+	t, err := translations.Translations.ReadFile(fmt.Sprintf("%s.json", p))
 	if err != nil {
 		// Attempt to find a more broad locale, e.g. fr instead of fr-FR.
 		if strings.Contains(p, "-") {
 			p = strings.Split(p, "-")[0]
-			translationFile := path.Join("translations", fmt.Sprintf("%s.json", p))
-			t, err = translations.Translations.ReadFile(translationFile)
+			t, err = translations.Translations.ReadFile(fmt.Sprintf("%s.json", p))
 			if err != nil {
 				klog.V(1).Infof("Failed to load translation file for %s: %v", p, err)
 				return

--- a/site/content/en/docs/contrib/tests.en.md
+++ b/site/content/en/docs/contrib/tests.en.md
@@ -130,6 +130,9 @@ asserts that the dashboard command works
 #### validateDryRun
 asserts that the dry-run mode quickly exits with the right code
 
+#### validateInternationalLanguage
+asserts that the language used can be changed with environment variables
+
 #### validateCacheCmd
 tests functionality of cache command (cache add, delete, list)
 


### PR DESCRIPTION
fixes #11697.

Before:
```
$ minikube start
😄  minikube v1.21.0 on Debian rodete
✨  Automatically selected the docker driver. Other choices: kvm2, ssh
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=3900MB) ...
$ LC_ALL=fr minikube start
😄  minikube v1.21.0 on Debian rodete
✨  Using the docker driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🤷  docker "minikube" container is missing, will recreate.
```
After:
```
$ minikube start
😄  minikube v1.21.0 on Debian rodete
✨  Automatically selected the docker driver. Other choices: kvm2, ssh
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=3900MB) ...
$ LC_ALL=fr minikube start
😄  minikube v1.21.0 sur Debian rodete
✨  Utilisation du pilote docker basé sur le profil existant
👍  Démarrage du noeud de plan de contrôle minikube dans le cluster minikube
🚜  Pulling base image ...
🤷  docker "minikube" container est manquant, il va être recréé.
```
Note I terminated minikube early so thats why there are error messages in the second half.