### PR TITLE
Make sure to log errors from DaemonInfo

### DIFF
--- a/pkg/drivers/kic/oci/info.go
+++ b/pkg/drivers/kic/oci/info.go
@@ -252,9 +252,11 @@ func dockerSystemInfo() (dockerSysInfo, error) {
 	var ds dockerSysInfo
 	rawJSON, err := dockerInfoGetter()
 	if err != nil {
+		klog.Warningf("docker info: %v", err)
 		return ds, errors.Wrap(err, "docker system info")
 	}
 	if err := json.Unmarshal([]byte(strings.TrimSpace(rawJSON)), &ds); err != nil {
+		klog.Warningf("unmarshal docker info: %v", err)
 		return ds, errors.Wrapf(err, "unmarshal docker system info")
 	}
 
@@ -272,10 +274,12 @@ func podmanSystemInfo() (podmanSysInfo, error) {
 	var ps podmanSysInfo
 	rawJSON, err := podmanInfoGetter()
 	if err != nil {
+		klog.Warningf("podman info: %v", err)
 		return ps, errors.Wrap(err, "podman system info")
 	}
 
 	if err := json.Unmarshal([]byte(strings.TrimSpace(rawJSON)), &ps); err != nil {
+		klog.Warningf("unmarshal podman info: %v", err)
 		return ps, errors.Wrapf(err, "unmarshal podman system info")
 	}
 	klog.Infof("podman info: %+v", ps)


### PR DESCRIPTION
Currently hiding errors, from running or parsing output from `system info`