### PR TITLE
Add method for customized box output

### DIFF
--- a/pkg/minikube/out/out.go
+++ b/pkg/minikube/out/out.go
@@ -68,6 +68,8 @@ var (
 	JSON = false
 	// spin is spinner showed at starting minikube
 	spin = spinner.New(spinner.CharSets[style.SpinnerCharacter], 100*time.Millisecond)
+	// defaultBoxCfg is the default style config for cli box output
+	defaultBoxCfg = box.Config{Py: 1, Px: 4, Type: "Round", Color: "Red"}
 )
 
 // MaxLogEntries controls the number of log entries to show for each source
@@ -113,23 +115,33 @@ func Styled(st style.Enum, format string, a ...V) {
 	}
 }
 
-func boxedCommon(printFunc func(format string, a ...interface{}), format string, a ...V) {
-	box := box.New(box.Config{Py: 1, Px: 4, Type: "Round"})
-	if useColor {
-		box.Config.Color = "Red"
+func boxedCommon(printFunc func(format string, a ...interface{}), cfg box.Config, title string, format string, a ...V) {
+	box := box.New(cfg)
+	if !useColor {
+		box.Config.Color = ""
 	}
 	str := Sprintf(style.None, format, a...)
-	printFunc(box.String("", strings.TrimSpace(str)))
+	printFunc(box.String(title, strings.TrimSpace(str)))
 }
 
-// Boxed writes a stylized and templated message in a box to stdout
+// Boxed writes a stylized and templated message in a box to stdout using the default style config
 func Boxed(format string, a ...V) {
-	boxedCommon(String, format, a...)
+	boxedCommon(String, defaultBoxCfg, "", format, a...)
 }
 
-// BoxedErr writes a stylized and templated message in a box to stderr
+// BoxedErr writes a stylized and templated message in a box to stderr using the default style config
 func BoxedErr(format string, a ...V) {
-	boxedCommon(Err, format, a...)
+	boxedCommon(Err, defaultBoxCfg, "", format, a...)
+}
+
+// BoxedWithConfig writes a templated message in a box with customized style config to stdout
+func BoxedWithConfig(cfg box.Config, st style.Enum, title string, format string, a ...V) {
+	if st != style.None {
+		title = Sprintf(st, title)
+	}
+	// need to make sure no newlines are in the title otherwise box-cli-maker panics
+	title = strings.ReplaceAll(title, "\n", "")
+	boxedCommon(String, cfg, title, format, a...)
 }
 
 // Sprintf is used for returning the string (doesn't write anything)


### PR DESCRIPTION
Part of #11207

This gives developers the ability to print out customized box output.

For example:

```go
boxCfg := box.Config{
	Py:       1,
	Px:       2,
	TitlePos: "Inside",
	Type:     "Double",
	Color:    "Yellow",
}

out.BoxedWithConfig(boxCfg, style.Warning, "Warning", "This is a warning")
```
![Screenshot from 2021-06-20 23-37-26](https://user-images.githubusercontent.com/1311594/122703865-7cd43300-d220-11eb-826e-862f2b14f918.png)


