### PR TITLE
Make recreating nodes correctly manage cluster node array.

### DIFF
--- a/pkg/minikube/node/node.go
+++ b/pkg/minikube/node/node.go
@@ -81,13 +81,13 @@ func Add(cc *config.ClusterConfig, n config.Node, delOnFail bool) error {
 }
 
 // drainNode drains then deletes (removes) node from cluster.
-func drainNode(cc config.ClusterConfig, name string) (*config.Node, error) {
-	n, index, err := Retrieve(cc, name)
+func drainNode(cc *config.ClusterConfig, name string) (*config.Node, error) {
+	n, index, err := Retrieve(*cc, name)
 	if err != nil {
 		return n, errors.Wrap(err, "retrieve")
 	}
 
-	m := config.MachineName(cc, *n)
+	m := config.MachineName(*cc, *n)
 	api, err := machine.NewAPIClient()
 	if err != nil {
 		return n, err
@@ -131,12 +131,12 @@ func drainNode(cc config.ClusterConfig, name string) (*config.Node, error) {
 	klog.Infof("successfully deleted node %q", name)
 
 	cc.Nodes = append(cc.Nodes[:index], cc.Nodes[index+1:]...)
-	return n, config.SaveProfile(viper.GetString(config.ProfileName), &cc)
+	return n, config.SaveProfile(viper.GetString(config.ProfileName), cc)
 }
 
 // Delete calls drainNode to remove node from cluster and deletes the host.
 func Delete(cc config.ClusterConfig, name string) (*config.Node, error) {
-	n, err := drainNode(cc, name)
+	n, err := drainNode(&cc, name)
 	if err != nil {
 		return n, err
 	}

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -240,7 +240,7 @@ func joinCluster(starter Starter, cpBs bootstrapper.Bootstrapper, bs bootstrappe
 	// You must delete the existing Node or change the name of this new joining Node"
 	if starter.PreExists {
 		klog.Infof("removing existing worker node %q before attempting to rejoin cluster: %+v", starter.Node.Name, starter.Node)
-		if _, err := drainNode(*starter.Cfg, starter.Node.Name); err != nil {
+		if _, err := drainNode(starter.Cfg, starter.Node.Name); err != nil {
 			klog.Errorf("error removing existing worker node before rejoining cluster, will continue anyway: %v", err)
 		}
 		klog.Infof("successfully removed existing worker node %q from cluster: %+v", starter.Node.Name, starter.Node)
@@ -261,6 +261,7 @@ func joinCluster(starter Starter, cpBs bootstrapper.Bootstrapper, bs bootstrappe
 
 			return err
 		}
+		starter.Cfg.Nodes = append(starter.Cfg.Nodes, *starter.Node)
 		return nil
 	}
 	if err := retry.Expo(join, 10*time.Second, 3*time.Minute); err != nil {


### PR DESCRIPTION
fixes #11687.

Previously, nodes were drained (but only manipulating a local node array - fixed), but then once they were rejoined, they were not readded to the node array.