### PR TITLE
Move node config deletion out of drainNode and into Delete

### DIFF
--- a/pkg/minikube/node/node.go
+++ b/pkg/minikube/node/node.go
@@ -82,7 +82,7 @@ func Add(cc *config.ClusterConfig, n config.Node, delOnFail bool) error {
 
 // drainNode drains then deletes (removes) node from cluster.
 func drainNode(cc config.ClusterConfig, name string) (*config.Node, error) {
-	n, index, err := Retrieve(cc, name)
+	n, _, err := Retrieve(cc, name)
 	if err != nil {
 		return n, errors.Wrap(err, "retrieve")
 	}
@@ -130,8 +130,7 @@ func drainNode(cc config.ClusterConfig, name string) (*config.Node, error) {
 	}
 	klog.Infof("successfully deleted node %q", name)
 
-	cc.Nodes = append(cc.Nodes[:index], cc.Nodes[index+1:]...)
-	return n, config.SaveProfile(viper.GetString(config.ProfileName), &cc)
+	return n, nil
 }
 
 // Delete calls drainNode to remove node from cluster and deletes the host.
@@ -152,7 +151,13 @@ func Delete(cc config.ClusterConfig, name string) (*config.Node, error) {
 		return n, err
 	}
 
-	return n, nil
+	_, index, err := Retrieve(cc, name)
+	if err != nil {
+		return n, errors.Wrap(err, "retrieve")
+	}
+
+	cc.Nodes = append(cc.Nodes[:index], cc.Nodes[index+1:]...)
+	return n, config.SaveProfile(viper.GetString(config.ProfileName), &cc)
 }
 
 // Retrieve finds the node by name in the given cluster

--- a/site/content/en/docs/contrib/tests.en.md
+++ b/site/content/en/docs/contrib/tests.en.md
@@ -256,6 +256,9 @@ tests the minikube node stop command
 #### validateStartNodeAfterStop
 tests the minikube node start command on an existing stopped node
 
+#### validateRestartKeepsNodes
+restarts minikube cluster and checks if the reported node list is unchanged
+
 #### validateStopMultiNodeCluster
 runs minikube stop on a multinode cluster
 


### PR DESCRIPTION
Previously, drainNode would delete the node from the config, but this means the machine can no longer be properly cleaned up if the node is drained for non-deletion reasons (rejoining a cluster).

This fixes 2 issues, first using an old version of the config after calling drainNode, second losing track of machines after drainNode has been called.

fixes #11687.

In particular, this PR fixes what happens when restarting a >2 multinode.
<details><summary>Before</summary>

```
$ minikube start -n 3
😄  minikube v1.21.0 on Debian rodete
✨  Automatically selected the docker driver. Other choices: kvm2, ssh
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=2200MB) ...
🐳  Preparing Kubernetes v1.20.7 on Docker 20.10.7 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔗  Configuring CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass

👍  Starting node minikube-m02 in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=2200MB) ...
🌐  Found network options:
    ▪ NO_PROXY=192.168.49.2
🐳  Preparing Kubernetes v1.20.7 on Docker 20.10.7 ...
    ▪ env NO_PROXY=192.168.49.2
🔎  Verifying Kubernetes components...

👍  Starting node minikube-m03 in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=2200MB) ...
🌐  Found network options:
    ▪ NO_PROXY=192.168.49.2,192.168.49.3
🐳  Preparing Kubernetes v1.20.7 on Docker 20.10.7 ...
    ▪ env NO_PROXY=192.168.49.2
    ▪ env NO_PROXY=192.168.49.2,192.168.49.3
🔎  Verifying Kubernetes components...
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
$ minikube stop
✋  Stopping node "minikube"  ...
🛑  Powering off "minikube" via SSH ...
✋  Stopping node "minikube-m02"  ...
🛑  Powering off "minikube-m02" via SSH ...
✋  Stopping node "minikube-m03"  ...
🛑  Powering off "minikube-m03" via SSH ...
🛑  3 nodes stopped.
$ minikube start
😄  minikube v1.21.0 on Debian rodete
✨  Using the docker driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔄  Restarting existing docker container for "minikube" ...
🐳  Preparing Kubernetes v1.20.7 on Docker 20.10.7 ...
🔗  Configuring CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass
👍  Starting node minikube-m02 in cluster minikube
🚜  Pulling base image ...
🔄  Restarting existing docker container for "minikube-m02" ...
🌐  Found network options:
    ▪ NO_PROXY=192.168.49.2
🐳  Preparing Kubernetes v1.20.7 on Docker 20.10.7 ...
    ▪ env NO_PROXY=192.168.49.2
🔎  Verifying Kubernetes components...
👍  Starting node minikube-m03 in cluster minikube
🚜  Pulling base image ...
🔄  Restarting existing docker container for "minikube-m03" ...
🌐  Found network options:
    ▪ NO_PROXY=192.168.49.2,192.168.49.3
🐳  Preparing Kubernetes v1.20.7 on Docker 20.10.7 ...
    ▪ env NO_PROXY=192.168.49.2
    ▪ env NO_PROXY=192.168.49.2,192.168.49.3
🔎  Verifying Kubernetes components...
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
$ minikube node list
minikube	192.168.49.2
minikube-m03	192.168.49.4
minikube-m03	192.168.49.4
```
</details>

<details><summary>After</summary>

```
$ minikube start -n 3
😄  minikube v1.21.0 on Debian rodete
✨  Automatically selected the docker driver. Other choices: kvm2, ssh
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=2200MB) ...
🐳  Preparing Kubernetes v1.20.7 on Docker 20.10.7 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔗  Configuring CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass

👍  Starting node minikube-m02 in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=2200MB) ...
🌐  Found network options:
    ▪ NO_PROXY=192.168.49.2
🐳  Preparing Kubernetes v1.20.7 on Docker 20.10.7 ...
    ▪ env NO_PROXY=192.168.49.2
🔎  Verifying Kubernetes components...

👍  Starting node minikube-m03 in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=2200MB) ...
🌐  Found network options:
    ▪ NO_PROXY=192.168.49.2,192.168.49.3
🐳  Preparing Kubernetes v1.20.7 on Docker 20.10.7 ...
    ▪ env NO_PROXY=192.168.49.2
    ▪ env NO_PROXY=192.168.49.2,192.168.49.3
🔎  Verifying Kubernetes components...
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
$ minikube stop
✋  Stopping node "minikube"  ...
🛑  Powering off "minikube" via SSH ...
✋  Stopping node "minikube-m02"  ...
🛑  Powering off "minikube-m02" via SSH ...
✋  Stopping node "minikube-m03"  ...
🛑  Powering off "minikube-m03" via SSH ...
🛑  3 nodes stopped.
$ minikube start
😄  minikube v1.21.0 on Debian rodete
✨  Using the docker driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔄  Restarting existing docker container for "minikube" ...
🐳  Preparing Kubernetes v1.20.7 on Docker 20.10.7 ...
🔗  Configuring CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass
👍  Starting node minikube-m02 in cluster minikube
🚜  Pulling base image ...
🔄  Restarting existing docker container for "minikube-m02" ...
🌐  Found network options:
    ▪ NO_PROXY=192.168.49.2
🐳  Preparing Kubernetes v1.20.7 on Docker 20.10.7 ...
    ▪ env NO_PROXY=192.168.49.2
🔎  Verifying Kubernetes components...
👍  Starting node minikube-m03 in cluster minikube
🚜  Pulling base image ...
🔄  Restarting existing docker container for "minikube-m03" ...
🌐  Found network options:
    ▪ NO_PROXY=192.168.49.2,192.168.49.3
🐳  Preparing Kubernetes v1.20.7 on Docker 20.10.7 ...
    ▪ env NO_PROXY=192.168.49.2
    ▪ env NO_PROXY=192.168.49.2,192.168.49.3
🔎  Verifying Kubernetes components...
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
$ minikube node list
minikube	192.168.49.2
minikube-m02	192.168.49.3
minikube-m03	192.168.49.4
```
</details>