### PR TITLE
Fix running a non-existent command in upload_integration_report

### DIFF
--- a/hack/jenkins/upload_integration_report.sh
+++ b/hack/jenkins/upload_integration_report.sh
@@ -49,5 +49,5 @@ echo ">> uploading ${SUMMARY_OUT}"
 gsutil -qm cp "${SUMMARY_OUT}" "gs://${JOB_GCS_BUCKET}_summary.json" || true
 
 if [[ "${MINIKUBE_LOCATION}" == "master" ]]; then
-  ./test-flake-chart/jenkins_upload_tests.sh "${SUMMARY_OUT}"
+  ./test-flake-chart/upload_tests.sh "${SUMMARY_OUT}"
 fi


### PR DESCRIPTION
fixes #11741

jenkins_upload_tests does not exist, upload_tests does.