### PR TITLE
Clean up ssh tunnels during exit.

### DIFF
--- a/pkg/minikube/tunnel/kic/ssh_conn.go
+++ b/pkg/minikube/tunnel/kic/ssh_conn.go
@@ -29,10 +29,11 @@ import (
 )
 
 type sshConn struct {
-	name    string
-	service string
-	cmd     *exec.Cmd
-	ports   []int
+	name       string
+	service    string
+	cmd        *exec.Cmd
+	ports      []int
+	activeConn bool
 }
 
 func createSSHConn(name, sshPort, sshKey string, svc *v1.Service) *sshConn {
@@ -87,9 +88,10 @@ func createSSHConn(name, sshPort, sshKey string, svc *v1.Service) *sshConn {
 	cmd := exec.Command(command, sshArgs...)
 
 	return &sshConn{
-		name:    name,
-		service: svc.Name,
-		cmd:     cmd,
+		name:       name,
+		service:    svc.Name,
+		cmd:        cmd,
+		activeConn: false,
 	}
 }
 
@@ -127,10 +129,11 @@ func createSSHConnWithRandomPorts(name, sshPort, sshKey string, svc *v1.Service)
 	cmd := exec.Command("ssh", sshArgs...)
 
 	return &sshConn{
-		name:    name,
-		service: svc.Name,
-		cmd:     cmd,
-		ports:   usedPorts,
+		name:       name,
+		service:    svc.Name,
+		cmd:        cmd,
+		ports:      usedPorts,
+		activeConn: false,
 	}, nil
 }
 
@@ -142,14 +145,21 @@ func (c *sshConn) startAndWait() error {
 		return err
 	}
 
+	c.activeConn = true
 	// we ignore wait error because the process will be killed
 	_ = c.cmd.Wait()
+
+	// Wait is finished for connection, mark false.
+	c.activeConn = false
 
 	return nil
 }
 
 func (c *sshConn) stop() error {
-	out.Step(style.Stopping, "Stopping tunnel for service {{.service}}.", out.V{"service": c.service})
-
-	return c.cmd.Process.Kill()
+	if c.activeConn {
+		out.Step(style.Stopping, "Stopping tunnel for service {{.service}}.", out.V{"service": c.service})
+		return c.cmd.Process.Kill()
+	}
+	out.Step(style.Stopping, "Stopped tunnel for service {{.service}}.", out.V{"service": c.service})
+	return nil
 }

--- a/pkg/minikube/tunnel/kic/ssh_conn.go
+++ b/pkg/minikube/tunnel/kic/ssh_conn.go
@@ -157,6 +157,7 @@ func (c *sshConn) startAndWait() error {
 
 func (c *sshConn) stop() error {
 	if c.activeConn {
+		c.activeConn = false
 		out.Step(style.Stopping, "Stopping tunnel for service {{.service}}.", out.V{"service": c.service})
 		return c.cmd.Process.Kill()
 	}

--- a/pkg/minikube/tunnel/kic/ssh_tunnel.go
+++ b/pkg/minikube/tunnel/kic/ssh_tunnel.go
@@ -63,6 +63,7 @@ func (t *SSHTunnel) Start() error {
 			if err != nil {
 				klog.Errorf("error cleaning up: %v", err)
 			}
+			t.stopActiveConnections()
 			return err
 		default:
 		}
@@ -117,6 +118,15 @@ func (t *SSHTunnel) startConnection(svc v1.Service) {
 	err := t.LoadBalancerEmulator.PatchServiceIP(t.v1Core.RESTClient(), svc, "127.0.0.1")
 	if err != nil {
 		klog.Errorf("error patching service: %v", err)
+	}
+}
+
+func (t *SSHTunnel) stopActiveConnections() {
+	for _, conn := range t.conns {
+		err := conn.stop()
+		if err != nil {
+			klog.Errorf("error stopping ssh tunnel: %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
fixes #10752 
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

Before PR: 
  PID TTY           TIME CMD
 1417 ttys000    0:00.14 /bin/bash --rcfile /Applications/GoLand.app/Contents/plugins/terminal/jediterm-bash.in -i
 1696 ttys001    0:00.07 login -pf vishal
 1698 ttys001    0:00.12 -bash
 7548 ttys001    0:00.25 minikube tunnel
 7565 ttys001    0:00.25 minikube tunnel


After PR (Deleting is successful with no stray tunnels) : 
  PID TTY           TIME CMD
 1417 ttys000    0:00.14 /bin/bash --rcfile /Applications/GoLand.app/Contents/plugins/terminal/jediterm-bash.in -i
 1696 ttys001    0:00.07 login -pf vishal
 1698 ttys001    0:00.12 -bash
