### PR TITLE
version:  new flag `--components` to list all included tools 

### DIFF
--- a/cmd/minikube/cmd/version.go
+++ b/cmd/minikube/cmd/version.go
@@ -61,12 +61,14 @@ var versionCmd = &cobra.Command{
 			// sudo podman version
 
 			versionCMDS := map[string]*exec.Cmd{
-				"docker":   exec.Command("docker", "version", "--format={{.Client.Version}}"),
-				"crictl":   exec.Command("sudo", "crictl", "version"),
-				"crio":     exec.Command("crio", "version"),
-				"runc":     exec.Command("runc", "--version"),
-				"buildctl": exec.Command("buildctl", "--version"),
-				"ctr":      exec.Command("sudo", "ctr", "version"),
+				"docker":     exec.Command("docker", "version", "--format={{.Client.Version}}"),
+				"containerd": exec.Command("containerd", "--version"),
+				"crio":       exec.Command("crio", "version"),
+				"podman":     exec.Command("sudo", "podman", "version"),
+				"crictl":     exec.Command("sudo", "crictl", "version"),
+				"buildctl":   exec.Command("buildctl", "--version"),
+				"ctr":        exec.Command("sudo", "ctr", "version"),
+				"runc":       exec.Command("runc", "--version"),
 			}
 			for k, v := range versionCMDS {
 				rr, err := runner.RunCmd(v)

--- a/cmd/minikube/cmd/version.go
+++ b/cmd/minikube/cmd/version.go
@@ -61,7 +61,7 @@ var versionCmd = &cobra.Command{
 			// sudo podman version
 
 			versionCMDS := map[string]*exec.Cmd{
-				"docker":   exec.Command("docker", "version", "--format={{.Client.Version}}min"),
+				"docker":   exec.Command("docker", "version", "--format={{.Client.Version}}"),
 				"crictl":   exec.Command("sudo", "crictl", "version"),
 				"crio":     exec.Command("crio", "version"),
 				"runc":     exec.Command("runc", "--version"),

--- a/cmd/minikube/cmd/version.go
+++ b/cmd/minikube/cmd/version.go
@@ -96,7 +96,7 @@ var versionCmd = &cobra.Command{
 						continue
 					}
 					if v != "" {
-						out.Ln("\n%s: %s\n", k, v)
+						out.Ln("\n%s:\n%s", k, v)
 					}
 				}
 			} else {

--- a/cmd/minikube/cmd/version.go
+++ b/cmd/minikube/cmd/version.go
@@ -32,9 +32,9 @@ import (
 )
 
 var (
-	versionOutput        string
-	shortVersion         bool
-	listPackagesVersions bool
+	versionOutput          string
+	shortVersion           bool
+	listComponentsVersions bool
 )
 
 var versionCmd = &cobra.Command{
@@ -49,17 +49,9 @@ var versionCmd = &cobra.Command{
 			"commit":          gitCommitID,
 		}
 
-		if listPackagesVersions {
+		if listComponentsVersions && !shortVersion {
 			co := mustload.Running(ClusterFlagValue())
 			runner := co.CP.Runner
-			// docker version --format='{{.Client.Version}}'
-			// sudo crictl version
-			// runc --version
-			// crio version
-			// buildctl --version
-			// sudo ctr version
-			// sudo podman version
-
 			versionCMDS := map[string]*exec.Cmd{
 				"docker":     exec.Command("docker", "version", "--format={{.Client.Version}}"),
 				"containerd": exec.Command("containerd", "--version"),
@@ -91,7 +83,7 @@ var versionCmd = &cobra.Command{
 					out.Ln("commit: %v", gitCommitID)
 				}
 				for k, v := range data {
-					// for backward compatibility we keep the old ways separate
+					// for backward compatibility we keep displaying the old way for these two
 					if k == "minikubeVersion" || k == "commit" {
 						continue
 					}
@@ -123,5 +115,5 @@ var versionCmd = &cobra.Command{
 func init() {
 	versionCmd.Flags().StringVarP(&versionOutput, "output", "o", "", "One of 'yaml' or 'json'.")
 	versionCmd.Flags().BoolVar(&shortVersion, "short", false, "Print just the version number.")
-	versionCmd.Flags().BoolVar(&listPackagesVersions, "packages", false, "list versions of all packages included with minikube. (cluster must be running)")
+	versionCmd.Flags().BoolVar(&listComponentsVersions, "components", false, "list versions of all components included with minikube. (the cluster must be running)")
 }

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -1721,7 +1721,7 @@ func validateNotActiveRuntimeDisabled(ctx context.Context, t *testing.T, profile
 
 // validateVersionCmd asserts minikuve version command works fine
 func validateVersionCmd(ctx context.Context, t *testing.T, profile string) { 
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "version","-o=json","--packages")
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "version","-o=json","--packages"))
 	if err !=nil {
 		t.Errorf("error version: %v" ,err)
 	}

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -1724,7 +1724,7 @@ func validateVersionCmd(ctx context.Context, t *testing.T, profile string) {
 
 	t.Run("short", func(t *testing.T) {
 		MaybeParallel(t)
-		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "version", "-o=json", "--short"))
+		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "version", "--short"))
 		if err != nil {
 			t.Errorf("failed to get version --short: %v", err)
 		}

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -1729,7 +1729,7 @@ func validateVersionCmd(ctx context.Context, t *testing.T, profile string) {
 			t.Errorf("failed to get version --short: %v", err)
 		}
 
-		_, err = semver.Make(strings.Trim(rr.Stdout.String(), "v"))
+		_, err = semver.Make(strings.TrimSpace(strings.Trim(rr.Stdout.String(), "v")))
 		if err != nil {
 			t.Errorf("failed to get a valid semver for minikube version --short:%s %v", rr.Output(), err)
 		}

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -140,6 +140,7 @@ func TestFunctional(t *testing.T) {
 			{"BuildImage", validateBuildImage},
 			{"ListImages", validateListImages},
 			{"NonActiveRuntimeDisabled", validateNotActiveRuntimeDisabled},
+			{"Version", validateVersionCmd},
 		}
 		for _, tc := range tests {
 			tc := tc
@@ -1717,6 +1718,23 @@ func validateNotActiveRuntimeDisabled(ctx context.Context, t *testing.T, profile
 	}
 }
 
+
+// validateVersionCmd asserts minikuve version command works fine
+func validateVersionCmd(ctx context.Context, t *testing.T, profile string) { 
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "version","-o=json","--packages")
+	if err !=nil {
+		t.Errorf("error version: %v" ,err)
+	}
+	got := rr.Stdout.String()
+	if !strings.Contains(got, "containerd") {
+		t.Error("expected to see containerd in the minikube version --packages")
+	}
+	
+
+
+}
+
+
 // validateUpdateContextCmd asserts basic "update-context" command functionality
 func validateUpdateContextCmd(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
@@ -1826,3 +1844,4 @@ func startHTTPProxy(t *testing.T) (*http.Server, error) {
 	}(srv, t)
 	return srv, nil
 }
+

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -1718,22 +1718,18 @@ func validateNotActiveRuntimeDisabled(ctx context.Context, t *testing.T, profile
 	}
 }
 
-
 // validateVersionCmd asserts minikuve version command works fine
-func validateVersionCmd(ctx context.Context, t *testing.T, profile string) { 
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "version","-o=json","--packages"))
-	if err !=nil {
-		t.Errorf("error version: %v" ,err)
+func validateVersionCmd(ctx context.Context, t *testing.T, profile string) {
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "version", "-o=json", "--packages"))
+	if err != nil {
+		t.Errorf("error version: %v", err)
 	}
 	got := rr.Stdout.String()
 	if !strings.Contains(got, "containerd") {
 		t.Error("expected to see containerd in the minikube version --packages")
 	}
-	
-
 
 }
-
 
 // validateUpdateContextCmd asserts basic "update-context" command functionality
 func validateUpdateContextCmd(ctx context.Context, t *testing.T, profile string) {
@@ -1844,4 +1840,3 @@ func startHTTPProxy(t *testing.T) (*http.Server, error) {
 	}(srv, t)
 	return srv, nil
 }
-

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -1720,13 +1720,27 @@ func validateNotActiveRuntimeDisabled(ctx context.Context, t *testing.T, profile
 
 // validateVersionCmd asserts minikuve version command works fine
 func validateVersionCmd(ctx context.Context, t *testing.T, profile string) {
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "version", "-o=json", "--packages"))
-	if err != nil {
-		t.Errorf("error version: %v", err)
+
+	t.Run("short", func(t *testing.T) { 
+		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "version", "-o=json", "--short"))
+		if err != nil {
+			t.Errorf("failed to get version --short: %v", err)
+		}
+		_ , err := semver.Make(rr.Stdout.String())
+		if err != nil {
+			t.Errorf("failed to get a valid semver for minikube version --short:%s %v",rr.Output(),err)
+		}
+	
 	}
-	got := rr.Stdout.String()
-	if !strings.Contains(got, "containerd") {
-		t.Error("expected to see containerd in the minikube version --packages")
+	t.Run("components", func(t *testing.T) { 
+		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "version", "-o=json", "--components"))
+		if err != nil {
+			t.Errorf("error version: %v", err)
+		}
+		got := rr.Stdout.String()
+		if !strings.Contains(got, "containerd") {
+			t.Error("expected to see containerd in the minikube version --packages")
+		}	
 	}
 
 }

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -1728,7 +1728,8 @@ func validateVersionCmd(ctx context.Context, t *testing.T, profile string) {
 		if err != nil {
 			t.Errorf("failed to get version --short: %v", err)
 		}
-		_, err = semver.Make(rr.Stdout.String())
+
+		_, err = semver.Make(strings.Trim(rr.Stdout.String(), "v"))
 		if err != nil {
 			t.Errorf("failed to get a valid semver for minikube version --short:%s %v", rr.Output(), err)
 		}

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/reason"
 	"k8s.io/minikube/pkg/util/retry"
 
+	"github.com/blang/semver"
 	"github.com/elazarl/goproxy"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/otiai10/copy"
@@ -1721,18 +1722,20 @@ func validateNotActiveRuntimeDisabled(ctx context.Context, t *testing.T, profile
 // validateVersionCmd asserts minikuve version command works fine
 func validateVersionCmd(ctx context.Context, t *testing.T, profile string) {
 
-	t.Run("short", func(t *testing.T) { 
+	t.Run("short", func(t *testing.T) {
+		MaybeParallel(t)
 		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "version", "-o=json", "--short"))
 		if err != nil {
 			t.Errorf("failed to get version --short: %v", err)
 		}
-		_ , err := semver.Make(rr.Stdout.String())
+		_, err = semver.Make(rr.Stdout.String())
 		if err != nil {
-			t.Errorf("failed to get a valid semver for minikube version --short:%s %v",rr.Output(),err)
+			t.Errorf("failed to get a valid semver for minikube version --short:%s %v", rr.Output(), err)
 		}
-	
-	}
-	t.Run("components", func(t *testing.T) { 
+	})
+
+	t.Run("components", func(t *testing.T) {
+		MaybeParallel(t)
 		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "version", "-o=json", "--components"))
 		if err != nil {
 			t.Errorf("error version: %v", err)
@@ -1740,8 +1743,8 @@ func validateVersionCmd(ctx context.Context, t *testing.T, profile string) {
 		got := rr.Stdout.String()
 		if !strings.Contains(got, "containerd") {
 			t.Error("expected to see containerd in the minikube version --packages")
-		}	
-	}
+		}
+	})
 
 }
 


### PR DESCRIPTION
Closes https://github.com/kubernetes/minikube/issues/11747


## Before this PR
```
$ minikube version
minikube version: v1.21.0
commit: 76d74191d82c47883dc7e1319ef7cebd3e00ee11
```

## After this PR
### default case
```
$ mk version 
minikube version: v1.21.0
commit: 5fb11319c4c102346501539fa70fce482d14a038-dirty

```
### json
```
$ mk version --components --output=json  | jq
{
  "buildctl": "buildctl github.com/moby/buildkit v0.8.2 9065b18ba4633c75862befca8188de4338d9f94a",
  "commit": "4e232b694f4eeb7ddaf2ea5d55c8a6d7a78334c4",
  "containerd": "containerd containerd.io 1.4.6 d71fcd7d8303cbf684402823e425e9dd2e99285d",
  "crictl": "Version:  0.1.0\nRuntimeName:  docker\nRuntimeVersion:  20.10.7\nRuntimeApiVersion:  1.41.0",
  "crio": "Version:       1.20.3\nGitCommit:     50065140109e8dc4b8fd6dc5d2b587e5cb7ed79d\nGitTreeState:  clean\nBuildDate:     2021-06-03T20:25:45Z\nGoVersion:     go1.15.2\nCompiler:      gc\nPlatform:      linux/amd64\nLinkmode:      dynamic",
  "ctr": "Client:\n  Version:  1.4.6\n  Revision: d71fcd7d8303cbf684402823e425e9dd2e99285d\n  Go version: go1.13.15\n\nServer:\n  Version:  1.4.6\n  Revision: d71fcd7d8303cbf684402823e425e9dd2e99285d\n  UUID: 84897789-18d8-458b-8bb7-b98824e7e949",
  "docker": "20.10.7",
  "minikubeVersion": "v1.21.0",
  "podman": "Version:      3.1.2\nAPI Version:  3.1.2\nGo Version:   go1.15.2\nBuilt:        Thu Jan  1 00:00:00 1970\nOS/Arch:      linux/amd64",
  "runc": "runc version 1.0.0-rc95\ncommit: b9ee9c6314599f1b4a7f497e1f1f856fe433d3b7\nspec: 1.0.2-dev\ngo: go1.13.15\nlibseccomp: 2.5.1"
}
```
### raw
```
$ mk version --components 
minikube version: v1.21.0
commit: 4e232b694f4eeb7ddaf2ea5d55c8a6d7a78334c4-dirty

runc:
runc version 1.0.0-rc95
commit: b9ee9c6314599f1b4a7f497e1f1f856fe433d3b7
spec: 1.0.2-dev
go: go1.13.15
libseccomp: 2.5.1

docker:
20.10.7

containerd:
containerd containerd.io 1.4.6 d71fcd7d8303cbf684402823e425e9dd2e99285d

crio:
Version:       1.20.3
GitCommit:     50065140109e8dc4b8fd6dc5d2b587e5cb7ed79d
GitTreeState:  clean
BuildDate:     2021-06-03T20:25:45Z
GoVersion:     go1.15.2
Compiler:      gc
Platform:      linux/amd64
Linkmode:      dynamic

ctr:
Client:
  Version:  1.4.6
  Revision: d71fcd7d8303cbf684402823e425e9dd2e99285d
  Go version: go1.13.15

Server:
  Version:  1.4.6
  Revision: d71fcd7d8303cbf684402823e425e9dd2e99285d
  UUID: 84897789-18d8-458b-8bb7-b98824e7e949

podman:
Version:      3.1.2
API Version:  3.1.2
Go Version:   go1.15.2
Built:        Thu Jan  1 00:00:00 1970
OS/Arch:      linux/amd64

crictl:
Version:  0.1.0
RuntimeName:  docker
RuntimeVersion:  20.10.7
RuntimeApiVersion:  1.41.0

buildctl:
buildctl github.com/moby/buildkit v0.8.2 9065b18ba4633c75862befca8188de4338d9f94a
22:15:01 medya/workspace/minikube
```

### yaml

```
mk version --components -o=yaml
buildctl: buildctl github.com/moby/buildkit v0.8.2 9065b18ba4633c75862befca8188de4338d9f94a
commit: 4e232b694f4eeb7ddaf2ea5d55c8a6d7a78334c4
containerd: containerd containerd.io 1.4.6 d71fcd7d8303cbf684402823e425e9dd2e99285d
crictl: |-
  Version:  0.1.0
  RuntimeName:  docker
  RuntimeVersion:  20.10.7
  RuntimeApiVersion:  1.41.0
crio: |-
  Version:       1.20.3
  GitCommit:     50065140109e8dc4b8fd6dc5d2b587e5cb7ed79d
  GitTreeState:  clean
  BuildDate:     2021-06-03T20:25:45Z
  GoVersion:     go1.15.2
  Compiler:      gc
  Platform:      linux/amd64
  Linkmode:      dynamic
ctr: |-
  Client:
    Version:  1.4.6
    Revision: d71fcd7d8303cbf684402823e425e9dd2e99285d
    Go version: go1.13.15

  Server:
    Version:  1.4.6
    Revision: d71fcd7d8303cbf684402823e425e9dd2e99285d
    UUID: 84897789-18d8-458b-8bb7-b98824e7e949
docker: 20.10.7
minikubeVersion: v1.21.0
podman: |-
  Version:      3.1.2
  API Version:  3.1.2
  Go Version:   go1.15.2
  Built:        Thu Jan  1 00:00:00 1970
  OS/Arch:      linux/amd64
runc: |-
  runc version 1.0.0-rc95
  commit: b9ee9c6314599f1b4a7f497e1f1f856fe433d3b7
  spec: 1.0.2-dev
  go: go1.13.15
  libseccomp: 2.5.1
```