### PR TITLE
Minikube stop - correct the number of stopped nodes

### DIFF
--- a/cmd/minikube/cmd/stop.go
+++ b/cmd/minikube/cmd/stop.go
@@ -119,7 +119,9 @@ func runStop(cmd *cobra.Command, args []string) {
 	}
 
 	register.Reg.SetStep(register.Done)
-	if stoppedNodes > 0 {
+	if stoppedNodes == 1 {
+		out.Step(style.Stopped, `{{.count}} node stopped.`, out.V{"count": stoppedNodes})
+	} else if stoppedNodes > 1 {
 		out.Step(style.Stopped, `{{.count}} nodes stopped.`, out.V{"count": stoppedNodes})
 	}
 }


### PR DESCRIPTION
Minikube stop - correct the number of stopped nodes
fixes https://github.com/kubernetes/minikube/issues/11740

with 1 nodes o/p: 

necuser@necuser-HP-ProBook-430-G6:~/minikube$ ./out/minikube start
😄  minikube v1.21.0 on Ubuntu 18.04
❗  Kubernetes 1.21.0 has a known performance issue on cluster startup. It might take 2 to 3 minutes for a cluster to start.
❗  For more information, see: https://github.com/kubernetes/kubeadm/issues/2395
✨  Using the kvm2 driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
🔄  Restarting existing kvm2 VM for "minikube" ...
🐳  Preparing Kubernetes v1.21.0 on Docker 20.10.2 ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
necuser@necuser-HP-ProBook-430-G6:~/minikube$ ./out/minikube stop
✋  Stopping node "minikube"  ...
🛑  1 node stopped.
