### PR TITLE
Make flake rates only report hashes once and add links to the gopogh files

### DIFF
--- a/hack/jenkins/test-flake-chart/flake_chart.js
+++ b/hack/jenkins/test-flake-chart/flake_chart.js
@@ -139,6 +139,8 @@ async function init() {
     // Filter to only contain unskipped runs of the requested test and requested environment.
     .filter(test => test.name === desiredTest && test.environment === desiredEnvironment && test.status !== testStatus.SKIPPED)
     .groupBy(test => test.date.getTime());
+  
+  const hashToLink = (hash, environment) => `https://storage.googleapis.com/minikube-builds/logs/master/${hash.substring(0,7)}/${environment}.html`;
 
   data.addRows(
     groups
@@ -167,14 +169,14 @@ async function init() {
           <b>${groupData.date.toString()}</b><br>
           <b>Flake Percentage:</b> ${groupData.flakeRate.toFixed(2)}%<br>
           <b>Hashes:</b><br>
-          ${groupData.commitHashes.map(({ hash, failures, runs }) => `  - ${hash} (Failures: ${failures}/${runs})`).join("<br>")}
+          ${groupData.commitHashes.map(({ hash, failures, runs }) => `  - <a href="${hashToLink(hash, desiredEnvironment)}">${hash}</a> (Failures: ${failures}/${runs})`).join("<br>")}
         </div>`,
         groupData.duration,
         `<div style="padding: 1rem">
           <b>${groupData.date.toString()}</b><br>
           <b>Average Duration:</b> ${groupData.duration.toFixed(2)}s<br>
           <b>Hashes:</b><br>
-          ${groupData.commitHashes.map(({ hash, runs, duration }) => `  - ${hash} (Average of ${runs}: ${duration.toFixed(2)}s)`).join("<br>")}
+          ${groupData.commitHashes.map(({ hash, runs, duration }) => `  - <a href="${hashToLink(hash, desiredEnvironment)}">${hash}</a> (Average of ${runs}: ${duration.toFixed(2)}s)`).join("<br>")}
         </div>`,
       ])
   );

--- a/hack/jenkins/test-flake-chart/flake_chart.js
+++ b/hack/jenkins/test-flake-chart/flake_chart.js
@@ -165,14 +165,14 @@ async function init() {
       .map(groupData => [
         groupData.date,
         groupData.flakeRate,
-        `<div style="padding: 1rem">
+        `<div style="padding: 1rem; font-family: 'Arial'; font-size: 14">
           <b>${groupData.date.toString()}</b><br>
           <b>Flake Percentage:</b> ${groupData.flakeRate.toFixed(2)}%<br>
           <b>Hashes:</b><br>
           ${groupData.commitHashes.map(({ hash, failures, runs }) => `  - <a href="${hashToLink(hash, desiredEnvironment)}">${hash}</a> (Failures: ${failures}/${runs})`).join("<br>")}
         </div>`,
         groupData.duration,
-        `<div style="padding: 1rem">
+        `<div style="padding: 1rem; font-family: 'Arial'; font-size: 14">
           <b>${groupData.date.toString()}</b><br>
           <b>Average Duration:</b> ${groupData.duration.toFixed(2)}s<br>
           <b>Hashes:</b><br>


### PR DESCRIPTION
fixes #11759.
fixes #11737.

Also improves fonts, because they looked ugly.

![image](https://user-images.githubusercontent.com/22285953/123318293-e9328900-d4e3-11eb-89c2-a63e2ce9a01b.png)