### PR TITLE
Create page with all tests for an environment in flake rate charts

### DIFF
--- a/hack/jenkins/test-flake-chart/flake_chart.html
+++ b/hack/jenkins/test-flake-chart/flake_chart.html
@@ -1,6 +1,18 @@
 <html>
   <head>
     <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+    <style>
+      table {
+        border: 1px solid gray;
+        margin-left: auto;
+        margin-right: auto;
+        border-collapse: collapse;
+      }
+      td, th {
+        border-bottom: 1px solid gray;
+        padding: 8px;
+      }
+    </style>
   </head>
   <body>
     <div id="chart_div"></div>

--- a/hack/jenkins/test-flake-chart/flake_chart.js
+++ b/hack/jenkins/test-flake-chart/flake_chart.js
@@ -270,6 +270,7 @@ function displayEnvironmentChart(testData, environmentName) {
       return data !== undefined ? [
         data.flakeRate,
         `<div style="padding: 1rem; font-family: 'Arial'; font-size: 14">
+          <b style="display: block">${name}</b><br>
           <b>${data.date.toString()}</b><br>
           <b>Flake Percentage:</b> ${data.flakeRate.toFixed(2)}%<br>
           <b>Hashes:</b><br>

--- a/hack/jenkins/test-flake-chart/flake_chart.js
+++ b/hack/jenkins/test-flake-chart/flake_chart.js
@@ -191,7 +191,7 @@ function displayTestAndEnvironmentChart(testData, testName, environmentName) {
   chart.draw(data, options);
 }
 
-function createRecentFlakePercentageTable(recentFlakePercentage) {
+function createRecentFlakePercentageTable(recentFlakePercentage, environmentName) {
   const createCell = (elementType, text) => {
     const element = document.createElement(elementType);
     element.innerHTML = text;
@@ -205,7 +205,7 @@ function createRecentFlakePercentageTable(recentFlakePercentage) {
   table.appendChild(tableHeaderRow);
   for (const {testName, flakeRate} of recentFlakePercentage){
     const row = document.createElement("tr");
-    row.appendChild(createCell("td", testName));
+    row.appendChild(createCell("td", `<a href="${window.location.pathname}?env=${environmentName}&test=${testName}">${testName}</a>`));
     row.appendChild(createCell("td", `${flakeRate.toFixed(2)}%`)).style.textAlign = "right";
     table.appendChild(row);
   }
@@ -292,7 +292,7 @@ function displayEnvironmentChart(testData, environmentName) {
   const chart = new google.visualization.LineChart(document.getElementById('chart_div'));
   chart.draw(data, options);
 
-  document.body.appendChild(createRecentFlakePercentageTable(recentFlakePercentage));
+  document.body.appendChild(createRecentFlakePercentageTable(recentFlakePercentage, environmentName));
 }
 
 async function init() {

--- a/hack/jenkins/test-flake-chart/flake_chart.js
+++ b/hack/jenkins/test-flake-chart/flake_chart.js
@@ -191,6 +191,27 @@ function displayTestAndEnvironmentChart(testData, testName, environmentName) {
   chart.draw(data, options);
 }
 
+function createRecentFlakePercentageTable(recentFlakePercentage) {
+  const createCell = (elementType, text) => {
+    const element = document.createElement(elementType);
+    element.innerHTML = text;
+    return element;
+  }
+
+  const table = document.createElement("table");
+  const tableHeaderRow = document.createElement("tr");
+  tableHeaderRow.appendChild(createCell("th", "Test Name")).style.textAlign = "left";
+  tableHeaderRow.appendChild(createCell("th", "Recent Flake Percentage"));
+  table.appendChild(tableHeaderRow);
+  for (const {testName, flakeRate} of recentFlakePercentage){
+    const row = document.createElement("tr");
+    row.appendChild(createCell("td", testName));
+    row.appendChild(createCell("td", `${flakeRate.toFixed(2)}%`)).style.textAlign = "right";
+    table.appendChild(row);
+  }
+  return table;
+}
+
 function displayEnvironmentChart(testData, environmentName) {
   // Number of days to use to look for "flaky-est" tests.
   const dateRange = 15;
@@ -231,10 +252,9 @@ function displayEnvironmentChart(testData, environmentName) {
       testName,
       flakeRate: totalCount === 0 ? 0 : flakeCount / totalCount,
     };
-  });
+  }).sort((a, b) => b.flakeRate - a.flakeRate);
 
   const recentTopFlakes = recentFlakePercentage
-    .sort((a, b) => b.flakeRate - a.flakeRate)
     .slice(0, topFlakes)
     .map(({testName}) => testName);
 
@@ -271,6 +291,8 @@ function displayEnvironmentChart(testData, environmentName) {
   };
   const chart = new google.visualization.LineChart(document.getElementById('chart_div'));
   chart.draw(data, options);
+
+  document.body.appendChild(createRecentFlakePercentageTable(recentFlakePercentage));
 }
 
 async function init() {


### PR DESCRIPTION
fixes #11758.

In order to view it, just use the env query parameter, instead of both env and test.

The main chart only shows the charts of the top 10 flak-iest tests, since all the tests can make it very hard to read.

Main chart:
![image](https://user-images.githubusercontent.com/22285953/123459096-b26b7a00-d59a-11eb-83be-ea00d7f38312.png)

Below (contains all flake rates):
![image](https://user-images.githubusercontent.com/22285953/123459187-cf07b200-d59a-11eb-8420-599c25e82ba2.png)
