### PR TITLE
fix images for aliyun registry

### DIFF
--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -721,7 +721,7 @@ func overrideDefaults(defaultMap, overrideMap map[string]string) map[string]stri
 
 // SelectAndPersistImages selects which images to use based on addon default images, previously persisted images, and newly requested images - which are then persisted for future enables.
 func SelectAndPersistImages(addon *Addon, cc *config.ClusterConfig) (images, customRegistries map[string]string, err error) {
-	addonDefaultImages := addon.Images
+	addonDefaultImages := fixAddonImages(cc.KubernetesConfig.ImageRepository, addon.Images)
 	if addonDefaultImages == nil {
 		addonDefaultImages = make(map[string]string)
 	}
@@ -774,6 +774,23 @@ func SelectAndPersistImages(addon *Addon, cc *config.ClusterConfig) (images, cus
 		// Whether err is nil or not we still return here.
 	}
 	return images, customRegistries, err
+}
+
+// fixes addon image names according to image repository used
+func fixAddonImages(repo string, images map[string]string) map[string]string {
+	if repo == "registry.cn-hangzhou.aliyuncs.com/google_containers" {
+		// for aliyun registry must strip namespace from image name, e.g.
+		//   registry.cn-hangzhou.aliyuncs.com/google_containers/k8s-minikube/storage-provisioner:v5 will not work
+		//   registry.cn-hangzhou.aliyuncs.com/google_containers/storage-provisioner:v5 does work
+		newImages := make(map[string]string)
+		for name, image := range images {
+			image = strings.TrimPrefix(image, "k8s-minikube/")
+			image = strings.TrimPrefix(image, "kubernetesui/")
+			newImages[name] = image
+		}
+		return newImages
+	}
+	return images
 }
 
 // GenerateTemplateData generates template data for template assets

--- a/pkg/minikube/image/image.go
+++ b/pkg/minikube/image/image.go
@@ -155,11 +155,15 @@ func retrieveImage(ref name.Reference, imgName string) (v1.Image, string, error)
 		}
 	}
 	if useRemote {
+		ref, canonicalName, err := fixRemoteImageName(ref, imgName)
+		if err != nil {
+			return nil, "", err
+		}
 		img, err = retrieveRemote(ref, defaultPlatform)
 		if err == nil {
 			img, err = fixPlatform(ref, img, defaultPlatform)
 			if err == nil {
-				return img, canonicalName(ref), nil
+				return img, canonicalName, nil
 			}
 		}
 	}
@@ -316,4 +320,24 @@ func normalizeTagName(image string) string {
 		tag = parts[len(parts)-1]
 	}
 	return base + ":" + tag
+}
+
+func fixRemoteImageName(ref name.Reference, imgName string) (name.Reference, string, error) {
+	const aliyunMirror = "registry.cn-hangzhou.aliyuncs.com/google_containers/"
+	if strings.HasPrefix(imgName, aliyunMirror) {
+		// for aliyun registry must strip namespace from image name, e.g.
+		//   registry.cn-hangzhou.aliyuncs.com/google_containers/coredns/coredns:v1.8.0 will not work
+		//   registry.cn-hangzhou.aliyuncs.com/google_containers/coredns:1.8.0 does work
+		image := strings.TrimPrefix(imgName, aliyunMirror)
+		image = strings.TrimPrefix(image, "k8s-minikube/")
+		image = strings.TrimPrefix(image, "kubernetesui/")
+		image = strings.TrimPrefix(image, "coredns/")
+		image = strings.ReplaceAll(image, "coredns:v", "coredns:")
+		remoteRef, err := name.ParseReference(aliyunMirror+image, name.WeakValidation)
+		if err != nil {
+			return nil, "", err
+		}
+		return remoteRef, canonicalName(ref), nil
+	}
+	return ref, canonicalName(ref), nil
 }


### PR DESCRIPTION
for aliyun registry must strip namespace for addon images, e.g.
`registry.cn-hangzhou.aliyuncs.com/google_containers/k8s-minikube/storage-provisioner:v5` will not work, but
`registry.cn-hangzhou.aliyuncs.com/google_containers/storage-provisioner:v5` does work

fixes #11476

related to kubernetes/minikube#10770