### PR TITLE
Add "ok-to-test" label to ISO and kicbase PRs

### DIFF
--- a/hack/jenkins/build_iso.sh
+++ b/hack/jenkins/build_iso.sh
@@ -101,5 +101,8 @@ else
 	git remote add minikube-bot git@github.com:minikube-bot/minikube.git
 	git push -f minikube-bot ${branch}
 
-	gh pr create --fill --base master --head minikube-bot:${branch}
+	pr=$(gh pr create --fill --base master --head minikube-bot:${branch} \
+	      | grep -o -E "github.com/kubernetes/minikube/pull/[0-9]+" \
+	      | grep -o -E '[0-9]+')
+	gh pr comment "$pr" --body "/ok-to-test"
 fi	

--- a/hack/jenkins/kicbase_auto_build.sh
+++ b/hack/jenkins/kicbase_auto_build.sh
@@ -126,5 +126,8 @@ else
 	git remote add minikube-bot git@github.com:minikube-bot/minikube.git
 	git push -f minikube-bot ${branch}
 
-	gh pr create --fill --base master --head minikube-bot:${branch}
+	pr=$(gh pr create --fill --base master --head minikube-bot:${branch} \
+	      | grep -o -E "github.com/kubernetes/minikube/pull/[0-9]+" \
+	      | grep -o -E '[0-9]+')
+	gh pr comment "$pr" --body "/ok-to-test"
 fi


### PR DESCRIPTION
Our Jenkins ISO and kicbase release jobs create new PRs with updated versions when a build is complete. 
This PR changes release scripts to make those new ISO/kicbase PRs "ok-to-test" automatically and start integration tests
