### PR TITLE
Lower parallelism when testing on Windows

### DIFF
--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -99,7 +99,7 @@ func setMaxParallelism() {
 
 	// Windows tests were failing from timeouts due to too much parallelism
 	if runtime.GOOS == "windows" {
-		limit = int(limit / 2)
+		limit /= 2
 	}
 
 	fmt.Fprintf(os.Stderr, "Found %d cores, limiting parallelism with --test.parallel=%d\n", maxp, limit)

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -97,7 +97,7 @@ func setMaxParallelism() {
 	// Each "minikube start" consumes up to 2 cores, though the average usage is somewhat lower
 	limit := int(math.Floor(float64(maxp) / 1.75))
 
-	// Windows tests were failing from timeouts due to too much parallelization
+	// Windows tests were failing from timeouts due to too much parallelism
 	if runtime.GOOS == "windows" {
 		limit = int(limit / 2)
 	}

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -97,6 +97,11 @@ func setMaxParallelism() {
 	// Each "minikube start" consumes up to 2 cores, though the average usage is somewhat lower
 	limit := int(math.Floor(float64(maxp) / 1.75))
 
+	// Windows tests were failing from timeouts due to too much parallelization
+	if runtime.GOOS == "windows" {
+		limit = int(limit / 2)
+	}
+
 	fmt.Fprintf(os.Stderr, "Found %d cores, limiting parallelism with --test.parallel=%d\n", maxp, limit)
 	if err := flag.Set("test.parallel", strconv.Itoa(limit)); err != nil {
 		fmt.Fprintf(os.Stderr, "Unable to set test.parallel: %v\n", err)


### PR DESCRIPTION
Windows tests are failing with `[kubelet-check] Initial timeout of 40s passed.`

This is due to too much parallelism, lowering the parallelism number on Windows to prevent the errors.