### PR TITLE
Fix "kubelet Default-Start contains no runlevels" error

### DIFF
--- a/pkg/minikube/sysinit/systemd.go
+++ b/pkg/minikube/sysinit/systemd.go
@@ -59,7 +59,10 @@ func (s *Systemd) Disable(svc string) error {
 
 // DisableNow disables a service and stops it too (not waiting for next restart)
 func (s *Systemd) DisableNow(svc string) error {
-	_, err := s.r.RunCmd(exec.Command("sudo", "systemctl", "disable", "--now", svc))
+	cmd := exec.Command("sudo", "systemctl", "disable", "--now", svc)
+	// See https://github.com/kubernetes/minikube/issues/11615#issuecomment-861794258
+	cmd.Env = append(cmd.Env, "SYSTEMCTL_SKIP_SYSV=1")
+	_, err := s.r.RunCmd(cmd)
 	return err
 }
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/11813

Just set `SYSTEMCTL_SKIP_SYSV` for "systemctl disable --now" to suppress attempts to interract with sysv scripts