### PR TITLE
windows: support renaming binary to `kubectl.exe` and  running as kubectl

### DIFF
--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -100,6 +100,7 @@ func Execute() {
 	}
 
 	_, callingCmd := filepath.Split(os.Args[0])
+	callingCmd = strings.TrimSuffix(callingCmd, ".exe")
 
 	if callingCmd == "kubectl" {
 		// If the user is using the minikube binary as kubectl, allow them to specify the kubectl context without also specifying minikube profile

--- a/cmd/minikube/main.go
+++ b/cmd/minikube/main.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/pflag"
 	"k8s.io/klog/v2"
@@ -67,6 +68,7 @@ func main() {
 
 	// Don't parse flags when running as kubectl
 	_, callingCmd := filepath.Split(os.Args[0])
+	callingCmd = strings.TrimSuffix(callingCmd, ".exe")
 	parse := callingCmd != "kubectl"
 	setFlags(parse)
 

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -645,7 +645,11 @@ func validateMinikubeKubectl(ctx context.Context, t *testing.T, profile string) 
 func validateMinikubeKubectlDirectCall(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 	dir := filepath.Dir(Target())
-	dstfn := filepath.Join(dir, "kubectl")
+	newName := "kubectl"
+	if runtime.GOOS == "windows" {
+		newName += ".exe"
+	}
+	dstfn := filepath.Join(dir, newName)
 	err := os.Link(Target(), dstfn)
 
 	if err != nil {


### PR DESCRIPTION
Closes #11838

We support renaming the minikube binary to `kubectl` and the binary will run as kubectl. However, we don't support renaming the binary to `kubectl.exe` on Windows and running as kubectl.

This PR adds support for this and also makes the the Windows test pass.