### PR TITLE
Fixing previously renamed func from GetAllVersionsFromURL to AllVersionsFromURL

### DIFF
--- a/deploy/minikube/release_sanity_test.go
+++ b/deploy/minikube/release_sanity_test.go
@@ -48,7 +48,7 @@ func getSHAFromURL(url string) (string, error) {
 }
 
 func TestReleasesJSON(t *testing.T) {
-	releases, err := notify.GetAllVersionsFromURL(notify.GithubMinikubeReleasesURL)
+	releases, err := notify.AllVersionsFromURL(notify.GithubMinikubeReleasesURL)
 	if err != nil {
 		t.Fatalf("Error getting releases.json: %v", err)
 	}


### PR DESCRIPTION
I forgot to update one of the func callers after I renamed the func.