### PR TITLE
Add a sanity test for beta releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -637,7 +637,7 @@ release-hyperkit-driver: install-hyperkit-driver checksum ## Copy hyperkit using
 
 .PHONY: check-release
 check-release: ## Execute go test
-	go test -v ./deploy/minikube/release_sanity_test.go -tags=release
+	go test -timeout 42m -v ./deploy/minikube/release_sanity_test.go
 
 buildroot-image: $(ISO_BUILD_IMAGE) # convenient alias to build the docker container
 $(ISO_BUILD_IMAGE): deploy/iso/minikube-iso/Dockerfile

--- a/deploy/minikube/release_sanity_test.go
+++ b/deploy/minikube/release_sanity_test.go
@@ -45,7 +45,7 @@ func getSHAFromURL(url string) (string, error) {
 	return hex.EncodeToString(b[:]), nil
 }
 
-// TestBetaReleasesJSON checks if all *GA* releases
+// TestReleasesJSON checks if all *GA* releases
 // 	enlisted in https://storage.googleapis.com/minikube/releases.json
 //	are available to download and have correct hashsum
 func TestReleasesJSON(t *testing.T) {

--- a/deploy/minikube/release_sanity_test.go
+++ b/deploy/minikube/release_sanity_test.go
@@ -1,5 +1,3 @@
-// +build release
-
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.
 
@@ -47,13 +45,30 @@ func getSHAFromURL(url string) (string, error) {
 	return hex.EncodeToString(b[:]), nil
 }
 
+// TestBetaReleasesJSON checks if all *GA* releases
+// 	enlisted in https://storage.googleapis.com/minikube/releases.json
+//	are available to download and have correct hashsum
 func TestReleasesJSON(t *testing.T) {
-	releases, err := notify.GetAllVersionsFromURL(notify.GithubMinikubeReleasesURL)
+	releases, err := notify.AllVersionsFromURL(notify.GithubMinikubeReleasesURL)
 	if err != nil {
 		t.Fatalf("Error getting releases.json: %v", err)
 	}
+	checkReleases(t, releases)
+}
 
-	for _, r := range releases {
+// TestBetaReleasesJSON checks if all *BETA* releases
+// 	enlisted in https://storage.googleapis.com/minikube/releases-beta.json
+//	are available to download and have correct hashsum
+func TestBetaReleasesJSON(t *testing.T) {
+	releases, err := notify.AllVersionsFromURL(notify.GithubMinikubeBetaReleasesURL)
+	if err != nil {
+		t.Fatalf("Error getting releases-bets.json: %v", err)
+	}
+	checkReleases(t, releases)
+}
+
+func checkReleases(t *testing.T, rs notify.Releases) {
+	for _, r := range rs {
 		fmt.Printf("Checking release: %s\n", r.Name)
 		for platform, sha := range r.Checksums {
 			fmt.Printf("Checking SHA for %s.\n", platform)

--- a/deploy/minikube/releases-beta.json
+++ b/deploy/minikube/releases-beta.json
@@ -18,9 +18,9 @@
   {
       "name": "v1.20.0-beta.0",
       "checksums": {
-          "darwin": "",
-          "linux": "",
-          "windows": ""
+          "darwin": "686f8d7c06c93f28543f982ec56a68544ab2ad6c7f70b39ede5174d7bac29651",
+          "linux": "fe0796852c9ef266597fc93fa4b7a88d2cab9ba7008f0e9f644b633c51d269a1",
+          "windows": "84a0686c90ab88d04a0aab57b8cadacf9197d3ea6b467f9f807d071efe7fad3c"
       }
   }
 ]


### PR DESCRIPTION
This PR extends `make check-release` target to validate beta releases along with GA
