### PR TITLE
`minikube version`: add `--components` flag to list all included software

### DIFF
--- a/cmd/minikube/cmd/version.go
+++ b/cmd/minikube/cmd/version.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cmd/minikube/cmd/version.go
+++ b/cmd/minikube/cmd/version.go
@@ -1,12 +1,9 @@
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,18 +15,23 @@ package cmd
 
 import (
 	"encoding/json"
+	"os/exec"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
+	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/minikube/exit"
+	"k8s.io/minikube/pkg/minikube/mustload"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/reason"
 	"k8s.io/minikube/pkg/version"
 )
 
 var (
-	versionOutput string
-	shortVersion  bool
+	versionOutput          string
+	shortVersion           bool
+	listComponentsVersions bool
 )
 
 var versionCmd = &cobra.Command{
@@ -43,12 +45,48 @@ var versionCmd = &cobra.Command{
 			"minikubeVersion": minikubeVersion,
 			"commit":          gitCommitID,
 		}
+
+		if listComponentsVersions && !shortVersion {
+			co := mustload.Running(ClusterFlagValue())
+			runner := co.CP.Runner
+			versionCMDS := map[string]*exec.Cmd{
+				"docker":     exec.Command("docker", "version", "--format={{.Client.Version}}"),
+				"containerd": exec.Command("containerd", "--version"),
+				"crio":       exec.Command("crio", "version"),
+				"podman":     exec.Command("sudo", "podman", "version"),
+				"crictl":     exec.Command("sudo", "crictl", "version"),
+				"buildctl":   exec.Command("buildctl", "--version"),
+				"ctr":        exec.Command("sudo", "ctr", "version"),
+				"runc":       exec.Command("runc", "--version"),
+			}
+			for k, v := range versionCMDS {
+				rr, err := runner.RunCmd(v)
+				if err != nil {
+					klog.Warningf("error getting %s's version: %v", k, err)
+					data[k] = "error"
+				} else {
+					data[k] = strings.TrimSpace(rr.Stdout.String())
+				}
+
+			}
+
+		}
+
 		switch versionOutput {
 		case "":
 			if !shortVersion {
 				out.Ln("minikube version: %v", minikubeVersion)
 				if gitCommitID != "" {
 					out.Ln("commit: %v", gitCommitID)
+				}
+				for k, v := range data {
+					// for backward compatibility we keep displaying the old way for these two
+					if k == "minikubeVersion" || k == "commit" {
+						continue
+					}
+					if v != "" {
+						out.Ln("\n%s:\n%s", k, v)
+					}
 				}
 			} else {
 				out.Ln("%v", minikubeVersion)
@@ -74,4 +112,5 @@ var versionCmd = &cobra.Command{
 func init() {
 	versionCmd.Flags().StringVarP(&versionOutput, "output", "o", "", "One of 'yaml' or 'json'.")
 	versionCmd.Flags().BoolVar(&shortVersion, "short", false, "Print just the version number.")
+	versionCmd.Flags().BoolVar(&listComponentsVersions, "components", false, "list versions of all components included with minikube. (the cluster must be running)")
 }

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -1908,8 +1908,11 @@ func validateVersionCmd(ctx context.Context, t *testing.T, profile string) {
 			t.Errorf("error version: %v", err)
 		}
 		got := rr.Stdout.String()
-		if !strings.Contains(got, "containerd") {
-			t.Error("expected to see containerd in the minikube version --packages")
+		for _, c := range []string{"buildctl", "commit", "containerd", "crictl", "crio", "ctr", "docker", "minikubeVersion", "podman", "run"} {
+			if !strings.Contains(got, c) {
+				t.Errorf("expected to see %q in the minikube version --components but got:\n%s", c, got)
+			}
+
 		}
 	})
 

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/reason"
 	"k8s.io/minikube/pkg/util/retry"
 
+	"github.com/blang/semver/v4"
 	"github.com/elazarl/goproxy"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/otiai10/copy"

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -154,6 +154,7 @@ func TestFunctional(t *testing.T) {
 			{"BuildImage", validateBuildImage},
 			{"ListImages", validateListImages},
 			{"NonActiveRuntimeDisabled", validateNotActiveRuntimeDisabled},
+			{"Version", validateVersionCmd},
 		}
 		for _, tc := range tests {
 			tc := tc
@@ -1849,6 +1850,7 @@ func startHTTPProxy(t *testing.T) (*http.Server, error) {
 	}(srv, t)
 	return srv, nil
 }
+<<<<<<< HEAD
 
 func startMinikubeWithProxy(ctx context.Context, t *testing.T, profile string, proxyEnv string, addr string) {
 	// Use more memory so that we may reliably fit MySQL and nginx
@@ -1879,3 +1881,36 @@ func startMinikubeWithProxy(ctx context.Context, t *testing.T, profile string, p
 		t.Errorf("start stderr=%s, want: *%s*", rr.Stderr.String(), want)
 	}
 }
+||||||| parent of 730473887 (add --components flag for verion command)
+=======
+
+// validateVersionCmd asserts `minikube version` command works fine for both --short and --components
+func validateVersionCmd(ctx context.Context, t *testing.T, profile string) {
+
+	t.Run("short", func(t *testing.T) {
+		MaybeParallel(t)
+		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "version", "--short"))
+		if err != nil {
+			t.Errorf("failed to get version --short: %v", err)
+		}
+
+		_, err = semver.Make(strings.TrimSpace(strings.Trim(rr.Stdout.String(), "v")))
+		if err != nil {
+			t.Errorf("failed to get a valid semver for minikube version --short:%s %v", rr.Output(), err)
+		}
+	})
+
+	t.Run("components", func(t *testing.T) {
+		MaybeParallel(t)
+		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "version", "-o=json", "--components"))
+		if err != nil {
+			t.Errorf("error version: %v", err)
+		}
+		got := rr.Stdout.String()
+		if !strings.Contains(got, "containerd") {
+			t.Error("expected to see containerd in the minikube version --packages")
+		}
+	})
+
+}
+>>>>>>> 730473887 (add --components flag for verion command)

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -1851,7 +1851,6 @@ func startHTTPProxy(t *testing.T) (*http.Server, error) {
 	}(srv, t)
 	return srv, nil
 }
-<<<<<<< HEAD
 
 func startMinikubeWithProxy(ctx context.Context, t *testing.T, profile string, proxyEnv string, addr string) {
 	// Use more memory so that we may reliably fit MySQL and nginx
@@ -1882,8 +1881,6 @@ func startMinikubeWithProxy(ctx context.Context, t *testing.T, profile string, p
 		t.Errorf("start stderr=%s, want: *%s*", rr.Stderr.String(), want)
 	}
 }
-||||||| parent of 730473887 (add --components flag for verion command)
-=======
 
 // validateVersionCmd asserts `minikube version` command works fine for both --short and --components
 func validateVersionCmd(ctx context.Context, t *testing.T, profile string) {
@@ -1917,4 +1914,3 @@ func validateVersionCmd(ctx context.Context, t *testing.T, profile string) {
 	})
 
 }
->>>>>>> 730473887 (add --components flag for verion command)


### PR DESCRIPTION
Closes https://github.com/kubernetes/minikube/issues/11747


## Before this PR
```
$ minikube version
minikube version: v1.21.0
commit: 76d74191d82c47883dc7e1319ef7cebd3e00ee11
```

## After this PR
### default case
```
$ mk version 
minikube version: v1.21.0
commit: 5fb11319c4c102346501539fa70fce482d14a038-dirty

```
### json
```
$ mk version --components --output=json  | jq
{
  "buildctl": "buildctl github.com/moby/buildkit v0.8.2 9065b18ba4633c75862befca8188de4338d9f94a",
  "commit": "4e232b694f4eeb7ddaf2ea5d55c8a6d7a78334c4",
  "containerd": "containerd containerd.io 1.4.6 d71fcd7d8303cbf684402823e425e9dd2e99285d",
  "crictl": "Version:  0.1.0\nRuntimeName:  docker\nRuntimeVersion:  20.10.7\nRuntimeApiVersion:  1.41.0",
  "crio": "Version:       1.20.3\nGitCommit:     50065140109e8dc4b8fd6dc5d2b587e5cb7ed79d\nGitTreeState:  clean\nBuildDate:     2021-06-03T20:25:45Z\nGoVersion:     go1.15.2\nCompiler:      gc\nPlatform:      linux/amd64\nLinkmode:      dynamic",
  "ctr": "Client:\n  Version:  1.4.6\n  Revision: d71fcd7d8303cbf684402823e425e9dd2e99285d\n  Go version: go1.13.15\n\nServer:\n  Version:  1.4.6\n  Revision: d71fcd7d8303cbf684402823e425e9dd2e99285d\n  UUID: 84897789-18d8-458b-8bb7-b98824e7e949",
  "docker": "20.10.7",
  "minikubeVersion": "v1.21.0",
  "podman": "Version:      3.1.2\nAPI Version:  3.1.2\nGo Version:   go1.15.2\nBuilt:        Thu Jan  1 00:00:00 1970\nOS/Arch:      linux/amd64",
  "runc": "runc version 1.0.0-rc95\ncommit: b9ee9c6314599f1b4a7f497e1f1f856fe433d3b7\nspec: 1.0.2-dev\ngo: go1.13.15\nlibseccomp: 2.5.1"
}
```
### raw
```
$ mk version --components 
minikube version: v1.21.0
commit: 4e232b694f4eeb7ddaf2ea5d55c8a6d7a78334c4-dirty

runc:
runc version 1.0.0-rc95
commit: b9ee9c6314599f1b4a7f497e1f1f856fe433d3b7
spec: 1.0.2-dev
go: go1.13.15
libseccomp: 2.5.1

docker:
20.10.7

containerd:
containerd containerd.io 1.4.6 d71fcd7d8303cbf684402823e425e9dd2e99285d

crio:
Version:       1.20.3
GitCommit:     50065140109e8dc4b8fd6dc5d2b587e5cb7ed79d
GitTreeState:  clean
BuildDate:     2021-06-03T20:25:45Z
GoVersion:     go1.15.2
Compiler:      gc
Platform:      linux/amd64
Linkmode:      dynamic

ctr:
Client:
  Version:  1.4.6
  Revision: d71fcd7d8303cbf684402823e425e9dd2e99285d
  Go version: go1.13.15

Server:
  Version:  1.4.6
  Revision: d71fcd7d8303cbf684402823e425e9dd2e99285d
  UUID: 84897789-18d8-458b-8bb7-b98824e7e949

podman:
Version:      3.1.2
API Version:  3.1.2
Go Version:   go1.15.2
Built:        Thu Jan  1 00:00:00 1970
OS/Arch:      linux/amd64

crictl:
Version:  0.1.0
RuntimeName:  docker
RuntimeVersion:  20.10.7
RuntimeApiVersion:  1.41.0

buildctl:
buildctl github.com/moby/buildkit v0.8.2 9065b18ba4633c75862befca8188de4338d9f94a
22:15:01 medya/workspace/minikube
```

### yaml

```
mk version --components -o=yaml
buildctl: buildctl github.com/moby/buildkit v0.8.2 9065b18ba4633c75862befca8188de4338d9f94a
commit: 4e232b694f4eeb7ddaf2ea5d55c8a6d7a78334c4
containerd: containerd containerd.io 1.4.6 d71fcd7d8303cbf684402823e425e9dd2e99285d
crictl: |-
  Version:  0.1.0
  RuntimeName:  docker
  RuntimeVersion:  20.10.7
  RuntimeApiVersion:  1.41.0
crio: |-
  Version:       1.20.3
  GitCommit:     50065140109e8dc4b8fd6dc5d2b587e5cb7ed79d
  GitTreeState:  clean
  BuildDate:     2021-06-03T20:25:45Z
  GoVersion:     go1.15.2
  Compiler:      gc
  Platform:      linux/amd64
  Linkmode:      dynamic
ctr: |-
  Client:
    Version:  1.4.6
    Revision: d71fcd7d8303cbf684402823e425e9dd2e99285d
    Go version: go1.13.15

  Server:
    Version:  1.4.6
    Revision: d71fcd7d8303cbf684402823e425e9dd2e99285d
    UUID: 84897789-18d8-458b-8bb7-b98824e7e949
docker: 20.10.7
minikubeVersion: v1.21.0
podman: |-
  Version:      3.1.2
  API Version:  3.1.2
  Go Version:   go1.15.2
  Built:        Thu Jan  1 00:00:00 1970
  OS/Arch:      linux/amd64
runc: |-
  runc version 1.0.0-rc95
  commit: b9ee9c6314599f1b4a7f497e1f1f856fe433d3b7
  spec: 1.0.2-dev
  go: go1.13.15
  libseccomp: 2.5.1
```