### PR TITLE
Fix Makefile 'drivers' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,7 +325,7 @@ all: cross drivers e2e-cross cross-tars exotic retro out/gvisor-addon ## Build a
 
 .PHONY: drivers
 drivers: ## Build Hyperkit and KVM2 drivers
-drivers: docker-machine-driver-hyperkit \ 
+drivers: docker-machine-driver-hyperkit \
 	 docker-machine-driver-kvm2 \
 	 out/docker-machine-driver-kvm2-amd64 \
 	 out/docker-machine-driver-kvm2-arm64


### PR DESCRIPTION
This PR fixes a type in Makefile which led to `make: *** No rule to make target '\', needed by 'drivers'.  Stop.` error