### PR TITLE
Fix kvm2-arm64  build error

### DIFF
--- a/installers/linux/kvm/Dockerfile.arm64
+++ b/installers/linux/kvm/Dockerfile.arm64
@@ -12,23 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG GO_VERSION
 
 RUN apt update
 
-RUN echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports hirsute main universe multiverse" >> /etc/apt/sources.list && \
-    echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports hirsute-updates main universe restricted multiverse" >> /etc/apt/sources.list && \
+RUN echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal main universe multiverse" >> /etc/apt/sources.list && \
+    echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-updates main universe restricted multiverse" >> /etc/apt/sources.list && \
     dpkg --add-architecture arm64 && \
     (apt update || true)
 
-RUN apt install -y \
+RUN DEBIAN_FRONTEND=noninteractive \
+    apt install \
+    -o APT::Immediate-Configure=false -y \
     gcc-aarch64-linux-gnu \
     make \
     pkg-config \
     curl \
-    libvirt-dev:arm64
+    libvirt-dev:arm64 \
+    dpkg --configure -a
 
 RUN curl -sSL https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 

--- a/installers/linux/kvm/Dockerfile.arm64
+++ b/installers/linux/kvm/Dockerfile.arm64
@@ -30,7 +30,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
     make \
     pkg-config \
     curl \
-    libvirt-dev:arm64 \
+    libvirt-dev:arm64 && \
     dpkg --configure -a
 
 RUN curl -sSL https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz | tar -C /usr/local -xzf -


### PR DESCRIPTION
This PR fixes the 
```
14:48:11 GPG error: http://security.ubuntu.com/ubuntu hirsute-security InRelease: gpgv, gpgv2 or gpgv1 required for verification, but neither seems installed[0m[91m
14:48:11 [The repository 'http://security.ubuntu.com/ubuntu hirsute-security InRelease' is not signed.
``` 
error.

Related: https://stackoverflow.com/questions/66319610/gpg-error-in-ubuntu-21-04-after-second-apt-get-update-during-docker-build 