### PR TITLE
Improve Docker Windows integration clean slate

### DIFF
--- a/hack/jenkins/windows_integration_test_docker.ps1
+++ b/hack/jenkins/windows_integration_test_docker.ps1
@@ -48,11 +48,10 @@ echo "Docker_Windows" | gsutil cp - "$append_tmp"
 gsutil compose "$started_environments" "$append_tmp" "$started_environments"
 gsutil rm "$append_tmp"
 
-# Remove unused images and containers
-docker system prune --all --force
-
-
 ./out/minikube-windows-amd64.exe delete --all
+
+# Remove unused images and containers
+docker system prune --all --force --volumes
 
 ./out/windows_integration_setup.ps1
 


### PR DESCRIPTION
- Do `minikube delete` before `docker prune`
  - Because prune won't clear resources in use by minikube, so changing order ensures a better clean slate
- Also clear Docker volumes