### PR TITLE
Replace integration test "hooks" with standalone scripts

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -452,16 +452,6 @@ if [ -z "${EXTERNAL}" ]; then
   gsutil -qm cp "${HTML_OUT}" "gs://${JOB_GCS_BUCKET}.html" || true
   echo ">> uploading ${SUMMARY_OUT}"
   gsutil -qm cp "${SUMMARY_OUT}" "gs://${JOB_GCS_BUCKET}_summary.json" || true
-
-  FINISHED_ENVIRONMENTS="gs://minikube-builds/logs/${MINIKUBE_LOCATION}/${COMMIT:0:7}/finished_environments_${ROOT_JOB_ID}.txt"
-  # Ensure FINISHED_ENVIRONMENTS exists so we can append (but don't erase any existing entries in FINISHED_ENVIRONMENTS)
-  < /dev/null gsutil cp -n - "${FINISHED_ENVIRONMENTS}"
-  # Copy the job name to APPEND_TMP
-  APPEND_TMP="gs://minikube-builds/logs/${MINIKUBE_LOCATION}/${COMMIT:0:7}/$(basename $(mktemp))"
-  echo "${JOB_NAME}"\
-    | gsutil cp - "${APPEND_TMP}"
-  gsutil compose "${FINISHED_ENVIRONMENTS}" "${APPEND_TMP}" "${FINISHED_ENVIRONMENTS}"
-  gsutil rm "${APPEND_TMP}"
 else 
   # Otherwise, put the results in a predictable spot so the upload job can find them
   REPORTS_PATH=test_reports

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -142,17 +142,6 @@ fi
 # Add the out/ directory to the PATH, for using new drivers.
 export PATH="$(pwd)/out/":$PATH
 
-STARTED_ENVIRONMENTS="gs://minikube-builds/logs/${MINIKUBE_LOCATION}/${COMMIT:0:7}/started_environments_${ROOT_JOB_ID}.txt"
-# Ensure STARTED_ENVIRONMENTS exists so we can append (but don't erase any existing entries in STARTED_ENVIRONMENTS)
-< /dev/null gsutil cp -n - "${STARTED_ENVIRONMENTS}"
-# Copy the job name to APPEND_TMP
-APPEND_TMP="gs://minikube-builds/logs/${MINIKUBE_LOCATION}/${COMMIT:0:7}/$(basename $(mktemp))"
-echo "${JOB_NAME}"\
-  | gsutil cp - "${APPEND_TMP}"
-# Append
-gsutil compose "${STARTED_ENVIRONMENTS}" "${APPEND_TMP}" "${STARTED_ENVIRONMENTS}"
-gsutil rm "${APPEND_TMP}"
-
 echo
 echo ">> Downloading test inputs from ${MINIKUBE_LOCATION} ..."
 gsutil -qm cp \

--- a/hack/jenkins/minikube_set_pending.sh
+++ b/hack/jenkins/minikube_set_pending.sh
@@ -94,3 +94,5 @@ for j in ${jobs[@]}; do
   "https://storage.googleapis.com/minikube-builds/logs/${ghprbPullId}/${SHORT_COMMIT}/${j}.pending"
 done
 
+STARTED_LIST_REMOTE="gs://minikube-builds/logs/${ghprbPullId}/${SHORT_COMMIT}/started_environments_${BUILD_NUMBER}.txt"
+printf "%s\n" "${jobs[@]}" | gsutil cp - "${STARTED_LIST_REMOTE}"

--- a/hack/jenkins/test-flake-chart/sync_tests.sh
+++ b/hack/jenkins/test-flake-chart/sync_tests.sh
@@ -74,7 +74,7 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 if [[ "${MINIKUBE_LOCATION}" == "master" ]]; then
   for ENVIRONMENT in ${STARTED_LIST}; do
     SUMMARY="${BUCKET_PATH}/${ENVIRONMENT}_summary.json"
-    "${DIR}/upload_tests.sh" "${SUMMARY}"
+    "${DIR}/upload_tests.sh" "${SUMMARY}" || true
   done
 else
   "${DIR}/report_flakes.sh" "${MINIKUBE_LOCATION}" "${COMMIT:0:7}" "${FINISHED_LIST}"

--- a/hack/jenkins/test-flake-chart/sync_tests.sh
+++ b/hack/jenkins/test-flake-chart/sync_tests.sh
@@ -36,8 +36,19 @@ fi
 
 set -eu -o pipefail
 
+FINISHED_LIST_REMOTE="${BUCKET_PATH}/finished_environments_${ROOT_JOB_ID}.txt"
+# Ensure FINISHED_LIST_REMOTE exists so we can append (but don't erase any existing entries in FINISHED_LIST_REMOTE)
+< /dev/null gsutil cp -n - "${FINISHED_LIST_REMOTE}"
+# Copy the job name to APPEND_TMP
+APPEND_TMP="${BUCKET_PATH}/$(basename $(mktemp))"
+echo "${UPSTREAM_JOB}"\
+  | gsutil cp - "${APPEND_TMP}"
+# Append job name to remote finished list.
+gsutil compose "${FINISHED_LIST_REMOTE}" "${APPEND_TMP}" "${FINISHED_LIST_REMOTE}"
+gsutil rm "${APPEND_TMP}"
+
 FINISHED_LIST=$(mktemp)
-gsutil cat "${BUCKET_PATH}/finished_environments_${ROOT_JOB_ID}.txt"\
+gsutil cat "${FINISHED_LIST_REMOTE}"\
   | sort\
   | uniq > "${FINISHED_LIST}"
 

--- a/hack/jenkins/test-flake-chart/upload_tests.sh
+++ b/hack/jenkins/test-flake-chart/upload_tests.sh
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Takes a gopogh summary, extracts test data as a CSV and appends to the
-# existing CSV data in the GCS bucket.
-# Example usage: ./upload_tests.sh gopogh_summary.json
+# Takes a gopogh summary in a GCS bucket, extracts test data as a CSV and
+# appends to the existing CSV data in the flake rate GCS bucket.
+# Example usage: ./upload_tests.sh gs://some-bucket/gopogh_summary.json
 
 set -eu -o pipefail
 
@@ -28,7 +28,8 @@ fi
 TMP_DATA=$(mktemp)
 
 # Use the gopogh summary, process it, optimize the data, remove the header, and store.
-<"$1" ./test-flake-chart/process_data.sh \
+gsutil cat "$1" \
+  | ./test-flake-chart/process_data.sh \
   | ./test-flake-chart/optimize_data.sh \
   | sed "1d" > $TMP_DATA
 

--- a/hack/jenkins/upload_integration_report.sh
+++ b/hack/jenkins/upload_integration_report.sh
@@ -47,14 +47,3 @@ gsutil -qm cp "${HTML_OUT}" "gs://${JOB_GCS_BUCKET}.html" || true
 SUMMARY_OUT="$ARTIFACTS/summary.txt"
 echo ">> uploading ${SUMMARY_OUT}"
 gsutil -qm cp "${SUMMARY_OUT}" "gs://${JOB_GCS_BUCKET}_summary.json" || true
-
-FINISHED_ENVIRONMENTS="gs://minikube-builds/logs/${MINIKUBE_LOCATION}/${COMMIT:0:7}/finished_environments_${ROOT_JOB_ID}.txt"
-# Ensure FINISHED_ENVIRONMENTS exists so we can append (but don't erase any existing entries in FINISHED_ENVIRONMENTS)
-< /dev/null gsutil cp -n - "${FINISHED_ENVIRONMENTS}"
-# Copy the job name to APPEND_TMP
-APPEND_TMP="gs://minikube-builds/logs/${MINIKUBE_LOCATION}/${COMMIT:0:7}/$(basename $(mktemp))"
-echo "${JOB_NAME}"\
-  | gsutil cp - "${APPEND_TMP}"
-# Append
-gsutil compose "${FINISHED_ENVIRONMENTS}" "${APPEND_TMP}" "${FINISHED_ENVIRONMENTS}"
-gsutil rm "${APPEND_TMP}"

--- a/hack/jenkins/windows_integration_test_docker.ps1
+++ b/hack/jenkins/windows_integration_test_docker.ps1
@@ -39,15 +39,6 @@ If ($lastexitcode -gt 0) {
 	Exit $lastexitcode
 }
 
-$started_environments="gs://$gcs_bucket/started_environments_$env:ROOT_JOB_ID.txt"
-$append_tmp="gs://$gcs_bucket/tmp$(-join ((65..90) + (97..122) | Get-Random -Count 10 | % {[char]$_}))"
-# Ensure started_environments exists so we can append (but don't erase any existing entries in started_environments)
-$null | gsutil cp -n - "$started_environments"
-# Copy the Docker_Windows to append_tmp
-echo "Docker_Windows" | gsutil cp - "$append_tmp"
-gsutil compose "$started_environments" "$append_tmp" "$started_environments"
-gsutil rm "$append_tmp"
-
 ./out/minikube-windows-amd64.exe delete --all
 
 # Remove unused images and containers
@@ -96,15 +87,6 @@ gsutil -qm cp testout.txt gs://$gcs_bucket/Docker_Windowsout.txt
 gsutil -qm cp testout.json gs://$gcs_bucket/Docker_Windows.json
 gsutil -qm cp testout.html gs://$gcs_bucket/Docker_Windows.html
 gsutil -qm cp testout_summary.json gs://$gcs_bucket/Docker_Windows_summary.json
-
-$finished_environments="gs://$gcs_bucket/finished_environments_$env:ROOT_JOB_ID.txt"
-$append_tmp="gs://$gcs_bucket/tmp$(-join ((65..90) + (97..122) | Get-Random -Count 10 | % {[char]$_}))"
-# Ensure finished_environments exists so we can append (but don't erase any existing entries in finished_environments)
-$null | gsutil cp -n - "$finished_environments"
-# Copy the Docker_Windows to append_tmp
-echo "Docker_Windows" | gsutil cp - "$append_tmp"
-gsutil compose "$started_environments" "$append_tmp" "$started_environments"
-gsutil rm "$append_tmp"
 
 # Update the PR with the new info
 $json = "{`"state`": `"$env:status`", `"description`": `"Jenkins: $description`", `"target_url`": `"$env:target_url`", `"context`": `"Docker_Windows`"}"


### PR DESCRIPTION
fixes #11849.

Previously, each integration test flow had to register itself in start and finished lists. Now, we will have the minikube Jenkins job register all the tests at once. After each test completes, they trigger the "Flake Rate Upload" job which not only tries to upload, but also reports that the current test has completed.

This consolidates the flake rate system mechanisms into fewer locations. Instead of needing to modify multiple integration tests, now we only modify the minikube_set_pending script and the sync_tests script.