### PR TITLE
Fix TestDebPackageInstall test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -797,9 +797,6 @@ out/docker-machine-driver-kvm2-aarch64: out/docker-machine-driver-kvm2-arm64
 out/docker-machine-driver-kvm2_$(DEB_VERSION).deb: out/docker-machine-driver-kvm2_$(DEB_VERSION)-0_amd64.deb
 	cp $< $@
 
-out/docker-machine-driver-kvm2_$(DEB_VERSION)-$(DEB_REVISION)_amd64.deb: out/docker-machine-driver-kvm2_$(DEB_VERSION)-0_x86_64.deb
-	cp $< $@
-
 out/docker-machine-driver-kvm2_$(DEB_VERSION)-$(DEB_REVISION)_arm64.deb: out/docker-machine-driver-kvm2_$(DEB_VERSION)-0_aarch64.deb
 	cp $< $@
 


### PR DESCRIPTION
This PR fixes deb packaging for kvm2-amd64 driver

We used make rule out/docker-machine-driver-kvm2_$(DEB_VERSION)-$(DEB_REVISION)_amd64.deb: out/docker-machine-driver-kvm2_$(DEB_VERSION)-0_x86_64.deb to build amd64 deb. It took the architecture string from the target suffix, x86_64 in this case, which was incorrect. This PR changes Makefile to build amd64 deb directly.