### PR TITLE
fix kvm2-arm64 scripts

### DIFF
--- a/.github/workflows/pr_verified.yaml
+++ b/.github/workflows/pr_verified.yaml
@@ -40,7 +40,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libvirt-dev
-          make cross e2e-cross debs
+          MINIKUBE_BUILD_IN_DOCKER=y make cross e2e-cross debs
           cp -r test/integration/testdata ./out
           whoami
           echo github ref $GITHUB_REF

--- a/hack/jenkins/minikube_cross_build_and_upload.sh
+++ b/hack/jenkins/minikube_cross_build_and_upload.sh
@@ -46,6 +46,8 @@ make -j 16 \
   out/minikube_${DEB_VER}_amd64.deb \
   out/minikube_${DEB_VER}_arm64.deb \
   out/docker-machine-driver-kvm2_$(make deb_version_base).deb \
+  out/docker-machine-driver-kvm2_$(DEB_VER)-0_amd64.deb \
+  out/docker-machine-driver-kvm2_$(DEB_VER)-0_arm64.deb \
 && failed=$? || failed=$?
 
 BUILT_VERSION=$("out/minikube-$(go env GOOS)-$(go env GOARCH)" version)

--- a/hack/jenkins/minikube_cross_build_and_upload.sh
+++ b/hack/jenkins/minikube_cross_build_and_upload.sh
@@ -46,8 +46,8 @@ make -j 16 \
   out/minikube_${DEB_VER}_amd64.deb \
   out/minikube_${DEB_VER}_arm64.deb \
   out/docker-machine-driver-kvm2_$(make deb_version_base).deb \
-  out/docker-machine-driver-kvm2_${DEB_VER}-0_amd64.deb \
-  out/docker-machine-driver-kvm2_${DEB_VER}-0_arm64.deb \
+  out/docker-machine-driver-kvm2_${DEB_VER}_amd64.deb \
+  out/docker-machine-driver-kvm2_${DEB_VER}_arm64.deb \
 && failed=$? || failed=$?
 
 BUILT_VERSION=$("out/minikube-$(go env GOOS)-$(go env GOARCH)" version)
@@ -72,7 +72,7 @@ fi
 cp -r test/integration/testdata out/
 
 # Don't upload the buildroot artifacts if they exist
-rm -r out/buildroot || true
+rm -rf out/buildroot
 
 # At this point, the out directory contains the jenkins scripts (populated by jenkins),
 # testdata, and our build output. Push the changes to GCS so that worker nodes can re-use them.

--- a/hack/jenkins/minikube_cross_build_and_upload.sh
+++ b/hack/jenkins/minikube_cross_build_and_upload.sh
@@ -46,8 +46,8 @@ make -j 16 \
   out/minikube_${DEB_VER}_amd64.deb \
   out/minikube_${DEB_VER}_arm64.deb \
   out/docker-machine-driver-kvm2_$(make deb_version_base).deb \
-  out/docker-machine-driver-kvm2_$(DEB_VER)-0_amd64.deb \
-  out/docker-machine-driver-kvm2_$(DEB_VER)-0_arm64.deb \
+  out/docker-machine-driver-kvm2_${DEB_VER}-0_amd64.deb \
+  out/docker-machine-driver-kvm2_${DEB_VER}-0_arm64.deb \
 && failed=$? || failed=$?
 
 BUILT_VERSION=$("out/minikube-$(go env GOOS)-$(go env GOARCH)" version)


### PR DESCRIPTION
This PR does some minor fixes related to building and testing of kvm2 driver for arm64:
- GitHub Action pr_verified flow is fixed. `MINIKUBE_BUILD_IN_DOCKER=y` wasn't set before and it caused driver cross-compilation to fail
- `docker-machine-driver-kvm2_$VERSION_arm64.deb` uploaded to PR GCS buckets
       

