### PR TITLE
Refactor checkRemotePreloadExists to no longer include caching logic

### DIFF
--- a/pkg/minikube/download/download_test.go
+++ b/pkg/minikube/download/download_test.go
@@ -208,7 +208,6 @@ func testPreloadExistsCaching(t *testing.T) {
 	checkCalled := false
 	checkRemotePreloadExists = func(k8sVersion, containerRuntime string) bool {
 		checkCalled = true
-		setPreloadState(k8sVersion, containerRuntime, doesPreloadExist)
 		return doesPreloadExist
 	}
 	existence := PreloadExists("v1", "c1", "docker", true)

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -106,19 +106,16 @@ var checkRemotePreloadExists = func(k8sVersion, containerRuntime string) bool {
 	resp, err := http.Head(url)
 	if err != nil {
 		klog.Warningf("%s fetch error: %v", url, err)
-		setPreloadState(k8sVersion, containerRuntime, false)
 		return false
 	}
 
 	// note: err won't be set if it's a 404
 	if resp.StatusCode != 200 {
 		klog.Warningf("%s status code: %d", url, resp.StatusCode)
-		setPreloadState(k8sVersion, containerRuntime, false)
 		return false
 	}
 
 	klog.Infof("Found remote preload: %s", url)
-	setPreloadState(k8sVersion, containerRuntime, true)
 	return true
 }
 
@@ -152,7 +149,9 @@ func PreloadExists(k8sVersion, containerRuntime, driverName string, forcePreload
 		return true
 	}
 
-	return checkRemotePreloadExists(k8sVersion, containerRuntime)
+	existence := checkRemotePreloadExists(k8sVersion, containerRuntime)
+	setPreloadState(k8sVersion, containerRuntime, existence)
+	return existence
 }
 
 var checkPreloadExists = PreloadExists

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -110,7 +110,7 @@ var checkRemotePreloadExists = func(k8sVersion, containerRuntime string) bool {
 	}
 
 	// note: err won't be set if it's a 404
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		klog.Warningf("%s status code: %d", url, resp.StatusCode)
 		return false
 	}


### PR DESCRIPTION
Previously, checkRemotePreloadExists triggered the caching logic itself. Now this has been moved into PreloadExists.

Related to #11892. Thank you @ilya-zuyev and @spowelljr for the great recommendations!