### PR TITLE
ci: add bot to announce minikube release on twitter

### DIFF
--- a/.github/workflows/twitter-bot.yml
+++ b/.github/workflows/twitter-bot.yml
@@ -1,7 +1,10 @@
 name: "Tweet the release"
 on:
+  push:
+    tags:
+      - 'v*'
   release:
-    types: [released]
+    types: [published]
 jobs:
   twitter-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/twitter-bot.yml
+++ b/.github/workflows/twitter-bot.yml
@@ -1,0 +1,15 @@
+name: "Tweet the release"
+on:
+  release:
+    types: [released]
+jobs:
+  twitter-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ethomson/send-tweet-action@v1
+        with:
+          status: "A new minikube version just released ! check it out https://github.com/kubernetes/minikube/blob/master/CHANGELOG.md"
+          consumer-key: ${{ secrets.TWITTER_API_KEY }}
+          consumer-secret: ${{ secrets.TWITTER_API_SECRET }}
+          access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+          access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}


### PR DESCRIPTION
- Basic Example will tweet a minikube releae to miniube's official twitter https://twitter.com/minikube_dev