### PR TITLE
Make sync_tests.sh remove any _integration suffix

### DIFF
--- a/hack/jenkins/test-flake-chart/sync_tests.sh
+++ b/hack/jenkins/test-flake-chart/sync_tests.sh
@@ -39,9 +39,10 @@ set -eu -o pipefail
 FINISHED_LIST_REMOTE="${BUCKET_PATH}/finished_environments_${ROOT_JOB_ID}.txt"
 # Ensure FINISHED_LIST_REMOTE exists so we can append (but don't erase any existing entries in FINISHED_LIST_REMOTE)
 < /dev/null gsutil cp -n - "${FINISHED_LIST_REMOTE}"
-# Copy the job name to APPEND_TMP
+# Copy the job name to APPEND_TMP. If the job name ends in "_integration" remove it.
 APPEND_TMP="${BUCKET_PATH}/$(basename $(mktemp))"
 echo "${UPSTREAM_JOB}"\
+  | sed -r 's/_integration$//'\
   | gsutil cp - "${APPEND_TMP}"
 # Append job name to remote finished list.
 gsutil compose "${FINISHED_LIST_REMOTE}" "${APPEND_TMP}" "${FINISHED_LIST_REMOTE}"


### PR DESCRIPTION
This assumes all integration test job names are "<environment>_integration" or "<environment>". With only some minor modification, this is true of our current jobs.