### PR TITLE
Use 'gh auth' to get gh token for leaderboard update

### DIFF
--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -19,6 +19,8 @@ jobs:
         run: |
           make update-leaderboard
           echo "::set-output name=changes::$(git status --porcelain)"
+        env:
+          GITHUB_TOKEN: ${{ secrets.MINIKUBE_BOT_PAT }}
       - name: Create PR
         if: ${{ steps.leaderboard.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
Previously, a user-populated file was required for the GH token. Now this token is parsed from 'gh auth' output, so as long as gh auth is configured correctly, the script should work!