### PR TITLE
[wip] improve preloads generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -716,7 +716,7 @@ ifndef CIBUILD
 endif
 	env $(X_BUILD_ENV) docker buildx build -f ./deploy/kicbase/Dockerfile --builder $(X_DOCKER_BUILDER) --platform $(KICBASE_ARCH) $(addprefix -t ,$(KICBASE_IMAGE_REGISTRIES)) --push  --build-arg COMMIT_SHA=${VERSION}-$(COMMIT) .
 
-out/preload-tool:
+out/preload-tool: $(shell find hack/preload-images -type f -name "*.go")
 	go build -ldflags="$(MINIKUBE_LDFLAGS)" -o $@ ./hack/preload-images/*.go
 
 .PHONY: upload-preloaded-images-tar


### PR DESCRIPTION
This PR adds caching of k8s images on host system, helping to avoid docker pull limitations on CI system, and also to speed up the generation process a little bit