### PR TITLE
Add addon support for portainer

### DIFF
--- a/deploy/addons/assets.go
+++ b/deploy/addons/assets.go
@@ -131,4 +131,8 @@ var (
 	// CsiHostpathDriverAssets assets for csi-hostpath-driver addon
 	//go:embed csi-hostpath-driver/deploy/*.tmpl csi-hostpath-driver/rbac/*.tmpl
 	CsiHostpathDriverAssets embed.FS
+
+	// PortainerAssets assets for portainer addon
+	//go:embed portainer/portainer.yaml.tmpl
+	PortainerAssets embed.FS
 )

--- a/deploy/addons/portainer/portainer.yaml.tmpl
+++ b/deploy/addons/portainer/portainer.yaml.tmpl
@@ -1,0 +1,143 @@
+---
+# Source: portainer/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: portainer
+---
+# Source: portainer/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: portainer-sa-clusteradmin
+  namespace: portainer
+  labels:
+    app.kubernetes.io/name: portainer
+    app.kubernetes.io/instance: portainer
+    app.kubernetes.io/version: "ce-latest-ee-2.4.0"
+---
+# Source: portainer/templates/pvc.yaml
+kind: "PersistentVolumeClaim"
+apiVersion: "v1"
+metadata:
+  name: portainer
+  namespace: portainer  
+  annotations:
+    volume.alpha.kubernetes.io/storage-class: "generic"
+  labels:
+    io.portainer.kubernetes.application.stack: portainer
+    app.kubernetes.io/name: portainer
+    app.kubernetes.io/instance: portainer
+    app.kubernetes.io/version: "ce-latest-ee-2.4.0"
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: "10Gi"
+---
+# Source: portainer/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: portainer
+  labels:
+    app.kubernetes.io/name: portainer
+    app.kubernetes.io/instance: portainer
+    app.kubernetes.io/version: "ce-latest-ee-2.4.0"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  namespace: portainer
+  name: portainer-sa-clusteradmin
+---
+# Source: portainer/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: portainer
+  namespace: portainer
+  labels:
+    io.portainer.kubernetes.application.stack: portainer
+    app.kubernetes.io/name: portainer
+    app.kubernetes.io/instance: portainer
+    app.kubernetes.io/version: "ce-latest-ee-2.4.0"
+    kubernetes.io/minikube-addons-endpoint: portainer
+spec:
+  type: NodePort
+  ports:
+    - port: 9000
+      targetPort: 9000
+      protocol: TCP
+      name: http
+      nodePort: 30777
+    - port: 30776
+      targetPort: 30776
+      protocol: TCP
+      name: edge
+      nodePort: 30776
+  selector:
+    app.kubernetes.io/name: portainer
+    app.kubernetes.io/instance: portainer
+---
+# Source: portainer/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: portainer
+  namespace: portainer
+  labels:
+    io.portainer.kubernetes.application.stack: portainer
+    app.kubernetes.io/name: portainer
+    app.kubernetes.io/instance: portainer
+    app.kubernetes.io/version: "ce-latest-ee-2.4.0"
+spec:
+  replicas: 1
+  strategy:
+    type: "Recreate"
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: portainer
+      app.kubernetes.io/instance: portainer
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: portainer
+        app.kubernetes.io/instance: portainer
+    spec:
+      nodeSelector:
+        {}
+      serviceAccountName: portainer-sa-clusteradmin
+      volumes:
+         - name: "data"
+           persistentVolumeClaim:
+             claimName: portainer      
+      containers:
+        - name: portainer
+          image: "portainer/portainer-ce:latest"
+          imagePullPolicy: Always
+          args:  [ '--tunnel-port','30776' ]          
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          ports:
+            - name: http
+              containerPort: 9000
+              protocol: TCP
+            - name: tcp-edge
+              containerPort: 8000
+              protocol: TCP              
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 9000
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 9000
+          resources:
+            {}
+

--- a/pkg/addons/config.go
+++ b/pkg/addons/config.go
@@ -187,4 +187,9 @@ var Addons = []*Addon{
 		validations: []setFn{IsVolumesnapshotsEnabled},
 		callbacks:   []setFn{EnableOrDisableAddon, verifyAddonStatus},
 	},
+	{
+		name:      "portainer",
+		set:       SetBool,
+		callbacks: []setFn{EnableOrDisableAddon},
+	},
 }

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -672,7 +672,7 @@ var Addons = map[string]*Addon{
 			vmpath.GuestAddonsDir,
 			"portainer.yaml",
 			"0640"),
-	}, false, "portainer", "", nil, nil),
+	}, false, "portainer", "portainer.io", nil, nil),
 }
 
 // parseMapString creates a map based on `str` which is encoded as <key1>=<value1>,<key2>=<value2>,...

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -666,6 +666,13 @@ var Addons = map[string]*Addon{
 		"Snapshotter":           "k8s.gcr.io",
 		"Provisioner":           "k8s.gcr.io",
 	}),
+	"portainer": NewAddon([]*BinAsset{
+		MustBinAsset(addons.PortainerAssets,
+			"portainer/portainer.yaml.tmpl",
+			vmpath.GuestAddonsDir,
+			"portainer.yaml",
+			"0640"),
+	}, false, "portainer", "", nil, nil),
 }
 
 // parseMapString creates a map based on `str` which is encoded as <key1>=<value1>,<key2>=<value2>,...


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
Portainer is a free, open source toolset for managing containerized applications. It works with Kubernetes, Docker, Docker Swarm, Azure ACI in both data centres and at the edge.

Portainer removes the complexity associated with orchestrators so developers can deploy apps quickly, easily and accurately. In addition to managing apps, it can be used to observe the behavior of containers, manage the underlying platform and provide the security and governance necessary for organization to deploy containers widely.
This add-on service will be enabled on nodeport 30777 and internally runs on 9000 port. 
