### PR TITLE
Allow manual triggering of GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: build
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,6 @@
 name: "generate-docs"
 on:
+  workflow_dispatch:
   push:
     branches:
       - master  

--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -1,5 +1,6 @@
 name: "update-leaderboard"
 on:
+  workflow_dispatch:
   push:
     tags-ignore:
       - 'v*-beta.*'

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,5 +1,6 @@
 name: Master
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,5 +1,6 @@
 name: PR
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - "go.mod"

--- a/.github/workflows/pr_verified.yaml
+++ b/.github/workflows/pr_verified.yaml
@@ -1,5 +1,6 @@
 name: PR_Verified
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - "go.mod"

--- a/.github/workflows/time-to-k8s.yml
+++ b/.github/workflows/time-to-k8s.yml
@@ -1,5 +1,6 @@
 name: "time-to-k8s benchmark"
 on:
+  workflow_dispatch:
   release:
     types: [released]
 env:

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -1,5 +1,6 @@
 name: Translations Validation
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - "translations/**"

--- a/.github/workflows/twitter-bot.yml
+++ b/.github/workflows/twitter-bot.yml
@@ -1,5 +1,6 @@
 name: "Tweet the release"
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v*'

--- a/.github/workflows/update-k8s-versions.yml
+++ b/.github/workflows/update-k8s-versions.yml
@@ -1,5 +1,6 @@
 name: "update-kubernetes-versions"
 on:
+  workflow_dispatch:
   schedule:
     # every Monday at around 1 am pacific/8 am UTC
     - cron: "0 8 * * 1"


### PR DESCRIPTION
**Problem:**
Some of our GitHub Actions have triggers to only run on release (time-to-k8s, update-leaderboards, etc).
The problem arises when the job fails and we need to update the workflow yaml. This is because re-running a job uses the same yaml that ran the first time, even if it's updated on HEAD.

**Solution:**
Allow the ability to manually trigger jobs by adding the `workflow_dispatch` event to our jobs.
Adding this event allows us to go into the Actions page and run the job as pictured below:
![image](https://user-images.githubusercontent.com/44844360/124976707-7990c380-dfe4-11eb-81fd-4ca1d0222efe.png)
The jobs will continue to run on release, but also allows us to run them manually if needed.
