### PR TITLE
Retain full container name when passing --image-repository

### DIFF
--- a/pkg/minikube/bootstrapper/images/images.go
+++ b/pkg/minikube/bootstrapper/images/images.go
@@ -138,19 +138,19 @@ func storageProvisioner(mirror string) string {
 // dashboardFrontend returns the image used for the dashboard frontend
 func dashboardFrontend(repo string) string {
 	if repo == "" {
-		repo = "docker.io/kubernetesui"
+		repo = "docker.io"
 	}
 	// See 'kubernetes-dashboard' in deploy/addons/dashboard/dashboard-dp.yaml
-	return path.Join(repo, "dashboard:v2.1.0")
+	return path.Join(repo, "kubernetesui", "dashboard:v2.1.0")
 }
 
 // dashboardMetrics returns the image used for the dashboard metrics scraper
 func dashboardMetrics(repo string) string {
 	if repo == "" {
-		repo = "docker.io/kubernetesui"
+		repo = "docker.io"
 	}
 	// See 'dashboard-metrics-scraper' in deploy/addons/dashboard/dashboard-dp.yaml
-	return path.Join(repo, "metrics-scraper:v1.0.4")
+	return path.Join(repo, "kubernetesui", "metrics-scraper:v1.0.4")
 }
 
 // KindNet returns the image used for kindnet

--- a/pkg/minikube/bootstrapper/images/images_test.go
+++ b/pkg/minikube/bootstrapper/images/images_test.go
@@ -96,9 +96,9 @@ func TestAuxiliary(t *testing.T) {
 
 func TestAuxiliaryMirror(t *testing.T) {
 	want := []string{
-		"test.mirror/storage-provisioner:" + version.GetStorageProvisionerVersion(),
-		"test.mirror/dashboard:v2.1.0",
-		"test.mirror/metrics-scraper:v1.0.4",
+		"test.mirror/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
+		"test.mirror/kubernetesui/dashboard:v2.1.0",
+		"test.mirror/kubernetesui/metrics-scraper:v1.0.4",
 	}
 	got := auxiliary("test.mirror")
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/pkg/minikube/bootstrapper/images/kubeadm_test.go
+++ b/pkg/minikube/bootstrapper/images/kubeadm_test.go
@@ -54,9 +54,9 @@ func TestKubeadmImages(t *testing.T) {
 			"mirror.k8s.io/coredns:1.6.2",
 			"mirror.k8s.io/etcd:3.3.15-0",
 			"mirror.k8s.io/pause:3.1",
-			"mirror.k8s.io/storage-provisioner:" + version.GetStorageProvisionerVersion(),
-			"mirror.k8s.io/dashboard:v2.1.0",
-			"mirror.k8s.io/metrics-scraper:v1.0.4",
+			"mirror.k8s.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
+			"mirror.k8s.io/kubernetesui/dashboard:v2.1.0",
+			"mirror.k8s.io/kubernetesui/metrics-scraper:v1.0.4",
 		}},
 		{"v1.15.0", "", false, []string{
 			"k8s.gcr.io/kube-proxy:v1.15.0",

--- a/pkg/minikube/bootstrapper/images/repo.go
+++ b/pkg/minikube/bootstrapper/images/repo.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package images
 
+import "path"
+
 // DefaultKubernetesRepo is the default Kubernetes repository
 const DefaultKubernetesRepo = "k8s.gcr.io"
 
@@ -29,8 +31,8 @@ func kubernetesRepo(mirror string) string {
 
 // minikubeRepo returns the official minikube repository, or an alternate
 func minikubeRepo(mirror string) string {
-	if mirror != "" {
-		return mirror
+	if mirror == "" {
+		mirror = "gcr.io"
 	}
-	return "gcr.io/k8s-minikube"
+	return path.Join(mirror, "k8s-minikube")
 }

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -120,7 +120,7 @@ func beginDownloadKicBaseImage(g *errgroup.Group, cc *config.ClusterConfig, down
 	g.Go(func() error {
 		baseImg := cc.KicBaseImage
 		if baseImg == kic.BaseImage && len(cc.KubernetesConfig.ImageRepository) != 0 {
-			baseImg = strings.Replace(baseImg, "gcr.io/k8s-minikube", cc.KubernetesConfig.ImageRepository, 1)
+			baseImg = strings.Replace(baseImg, "gcr.io", cc.KubernetesConfig.ImageRepository, 1)
 			cc.KicBaseImage = baseImg
 		}
 		var finalImg string


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
This PR updates how the container image names are changed when the `--image-repository` flag is passed.

Previously, a container image like `gcr.io/k8s-minikube/storage-provisioner` would be changed to `registry.example.com/storage-provisioner`. With this PR, it is now changed to `registry.example.com/k8s-minikube/storage-provisioner`, i.e. the registry hostname is the only part that is replaced.

Fixes #11934 
