### PR TITLE
Don't set conntrack parameters in kube-proxy

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta1.go
+++ b/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta1.go
@@ -93,6 +93,10 @@ clusterCIDR: "{{.PodSubnet }}"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s
 {{- range $i, $val := printMapInOrder .KubeProxyOptions ": " }}
 {{$val}}
 {{- end}}

--- a/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta2.go
+++ b/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta2.go
@@ -96,6 +96,10 @@ clusterCIDR: "{{.PodSubnet }}"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s
 {{- range $i, $val := printMapInOrder .KubeProxyOptions ": " }}
 {{$val}}
 {{- end}}

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd-api-port.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd-pod-network-cidr.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "192.168.32.0/20"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/containerd.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/crio-options-gates.yaml
@@ -74,4 +74,8 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/crio.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/default.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/dns.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/image-repository.yaml
@@ -69,3 +69,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.14/options.yaml
@@ -71,4 +71,8 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd-api-port.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd-pod-network-cidr.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "192.168.32.0/20"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/containerd.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/crio-options-gates.yaml
@@ -74,4 +74,8 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/crio.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/default.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/dns.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/image-repository.yaml
@@ -69,3 +69,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.15/options.yaml
@@ -71,4 +71,8 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd-api-port.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd-pod-network-cidr.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "192.168.32.0/20"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/containerd.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/crio-options-gates.yaml
@@ -74,4 +74,8 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/crio.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/default.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/dns.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/image-repository.yaml
@@ -69,3 +69,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.16/options.yaml
@@ -71,4 +71,8 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-api-port.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd-pod-network-cidr.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "192.168.32.0/20"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/containerd.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio-options-gates.yaml
@@ -74,4 +74,8 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/crio.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/default.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/dns.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/image-repository.yaml
@@ -69,3 +69,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.17/options.yaml
@@ -71,4 +71,8 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd-api-port.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd-pod-network-cidr.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "192.168.32.0/20"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/containerd.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/crio-options-gates.yaml
@@ -74,4 +74,8 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/crio.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/default.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/dns.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/image-repository.yaml
@@ -69,3 +69,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.18/options.yaml
@@ -71,4 +71,8 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd-api-port.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd-pod-network-cidr.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "192.168.32.0/20"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/containerd.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/crio-options-gates.yaml
@@ -74,4 +74,8 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/crio.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/default.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/dns.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/image-repository.yaml
@@ -69,3 +69,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.19/options.yaml
@@ -71,4 +71,8 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd-api-port.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd-pod-network-cidr.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "192.168.32.0/20"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/containerd.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/crio-options-gates.yaml
@@ -74,4 +74,8 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/crio.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/default.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/dns.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/image-repository.yaml
@@ -69,3 +69,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.20/options.yaml
@@ -71,4 +71,8 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.21/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.21/containerd-api-port.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.21/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.21/containerd-pod-network-cidr.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "192.168.32.0/20"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.21/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.21/containerd.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.21/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.21/crio-options-gates.yaml
@@ -74,4 +74,8 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.21/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.21/crio.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.21/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.21/default.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.21/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.21/dns.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.21/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.21/image-repository.yaml
@@ -69,3 +69,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.21/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.21/options.yaml
@@ -71,4 +71,8 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.22/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.22/containerd-api-port.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.22/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.22/containerd-pod-network-cidr.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "192.168.32.0/20"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.22/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.22/containerd.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.22/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.22/crio-options-gates.yaml
@@ -74,4 +74,8 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s
 mode: "iptables"

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.22/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.22/crio.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.22/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.22/default.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.22/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.22/dns.yaml
@@ -68,3 +68,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.22/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.22/image-repository.yaml
@@ -69,3 +69,7 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.22/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.22/options.yaml
@@ -71,4 +71,8 @@ clusterCIDR: "10.244.0.0/16"
 metricsBindAddress: 0.0.0.0:10249
 conntrack:
   maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s
 mode: "iptables"


### PR DESCRIPTION
Fixes #11513 


Before:
![Screenshot from 2021-07-12 18-20-05](https://user-images.githubusercontent.com/13137996/125256316-ad9b1a00-e33f-11eb-9fab-2ea6bbd9dd96.png)

After:
![Screenshot from 2021-07-12 18-19-34](https://user-images.githubusercontent.com/13137996/125256380-bd1a6300-e33f-11eb-9418-ff7ff2939817.png)
![Screenshot from 2021-07-12 18-20-24](https://user-images.githubusercontent.com/13137996/125256441-cacfe880-e33f-11eb-9697-e44df96bbb9a.png)

