### PR TITLE
Add configurable port for minikube mount

### DIFF
--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -190,7 +190,13 @@ var mountCmd = &cobra.Command{
 			}
 		}()
 
-		cluster.Mount(co.CP.Runner, ip.String(), vmPath, cfg)
+		err = cluster.Mount(co.CP.Runner, ip.String(), vmPath, cfg)
+		if err != nil {
+			if rtErr, ok := err.(*cluster.MountError); ok && rtErr.ErrorType == cluster.MountErrorConnect {
+				exit.Error(reason.GuestMountCouldNotConnect, "mount could not connect", rtErr)
+			}
+			exit.Error(reason.GuestMount, "mount failed", err)
+		}
 		out.Step(style.Success, "Successfully mounted {{.sourcePath}} to {{.destinationPath}}", out.V{"sourcePath": hostPath, "destinationPath": vmPath})
 		out.Ln("")
 		out.Styled(style.Notice, "NOTE: This process must stay alive for the mount to be accessible ...")

--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -50,6 +50,7 @@ const (
 // placeholders for flag values
 var (
 	mountIP      string
+	mountPort    uint16
 	mountVersion string
 	mountType    string
 	isKill       bool
@@ -202,6 +203,7 @@ var mountCmd = &cobra.Command{
 
 func init() {
 	mountCmd.Flags().StringVar(&mountIP, "ip", "", "Specify the ip that the mount should be setup on")
+	mountCmd.Flags().Uint16Var(&mountPort, "port", 0, "Specify the port that the mount should be setup on, where 0 means any free port.")
 	mountCmd.Flags().StringVar(&mountType, "type", nineP, "Specify the mount filesystem type (supported types: 9p)")
 	mountCmd.Flags().StringVar(&mountVersion, "9p-version", defaultMountVersion, "Specify the 9p version that the mount should use")
 	mountCmd.Flags().BoolVar(&isKill, "kill", false, "Kill the mount process spawned by minikube start")
@@ -212,9 +214,9 @@ func init() {
 	mountCmd.Flags().IntVar(&mSize, "msize", defaultMsize, "The number of bytes to use for 9p packet payload")
 }
 
-// getPort asks the kernel for a free open port that is ready to use
+// getPort uses the requested port or asks the kernel for a free open port that is ready to use
 func getPort() (int, error) {
-	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("localhost:%d", mountPort))
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -190,10 +190,7 @@ var mountCmd = &cobra.Command{
 			}
 		}()
 
-		err = cluster.Mount(co.CP.Runner, ip.String(), vmPath, cfg)
-		if err != nil {
-			exit.Error(reason.GuestMount, "mount failed", err)
-		}
+		cluster.Mount(co.CP.Runner, ip.String(), vmPath, cfg)
 		out.Step(style.Success, "Successfully mounted {{.sourcePath}} to {{.destinationPath}}", out.V{"sourcePath": hostPath, "destinationPath": vmPath})
 		out.Ln("")
 		out.Styled(style.Notice, "NOTE: This process must stay alive for the mount to be accessible ...")

--- a/pkg/minikube/cluster/mount.go
+++ b/pkg/minikube/cluster/mount.go
@@ -27,8 +27,6 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/minikube/command"
-	"k8s.io/minikube/pkg/minikube/exit"
-	"k8s.io/minikube/pkg/minikube/reason"
 )
 
 // MountConfig defines the options available to the Mount command
@@ -56,26 +54,45 @@ type mountRunner interface {
 	RunCmd(*exec.Cmd) (*command.RunResult, error)
 }
 
+const (
+	// MountErrorUnknown failed with unknown error
+	MountErrorUnknown = iota
+	// MountErrorConnect
+	MountErrorConnect
+)
+
+// MountError wrapper around errors in the `Mount` function
+type MountError struct {
+	// ErrorType enum for more info about the error
+	ErrorType int
+	// UnderlyingError the error being wrapped
+	UnderlyingError error
+}
+
+func (m *MountError) Error() string {
+	return m.UnderlyingError.Error()
+}
+
 // Mount runs the mount command from the 9p client on the VM to the 9p server on the host
-func Mount(r mountRunner, source string, target string, c *MountConfig) {
+func Mount(r mountRunner, source string, target string, c *MountConfig) error {
 	if err := Unmount(r, target); err != nil {
-		exit.Error(reason.GuestMount, "mount failed", errors.Wrap(err, "umount"))
+		return &MountError{ErrorType: MountErrorUnknown, UnderlyingError: errors.Wrap(err, "umount")}
 	}
 
 	if _, err := r.RunCmd(exec.Command("/bin/bash", "-c", fmt.Sprintf("sudo mkdir -m %o -p %s", c.Mode, target))); err != nil {
-		exit.Error(reason.GuestMount, "mount failed", errors.Wrap(err, "create folder pre-mount"))
+		return &MountError{ErrorType: MountErrorUnknown, UnderlyingError: errors.Wrap(err, "create folder pre-mount")}
 	}
 
 	rr, err := r.RunCmd(exec.Command("/bin/bash", "-c", mntCmd(source, target, c)))
 	if err != nil {
 		if strings.Contains(rr.Stderr.String(), "Connection timed out") {
-			exit.Error(reason.GuestMountCouldNotConnect, "mount could not connect", err)
-		} else {
-			exit.Error(reason.GuestMount, "mount failed", errors.Wrapf(err, "mount with cmd %s ", rr.Command()))
+			return &MountError{ErrorType: MountErrorConnect, UnderlyingError: err}
 		}
+		return &MountError{ErrorType: MountErrorUnknown, UnderlyingError: errors.Wrapf(err, "mount with cmd %s ", rr.Command())}
 	}
 
 	klog.Infof("mount successful: %q", rr.Output())
+	return nil
 }
 
 // returns either a raw UID number, or the subshell to resolve it.

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -321,6 +321,15 @@ var (
 	GuestLoadHost = Kind{ID: "GUEST_LOAD_HOST", ExitCode: ExGuestError}
 	// minkube failed to create a mount
 	GuestMount = Kind{ID: "GUEST_MOUNT", ExitCode: ExGuestError}
+	// mount on guest was unable to connect to host mount server
+	GuestMountCouldNotConnect = Kind{
+		ID:       "GUEST_MOUNT_COULD_NOT_CONNECT",
+		ExitCode: ExGuestError,
+		Advice: `If the host has a firewall:
+		
+		1. Allow a port through the firewall
+		2. Specify "--port=<port_number>" for "minikube mount"`,
+	}
 	// minkube failed to update a mount
 	GuestMountConflict = Kind{ID: "GUEST_MOUNT_CONFLICT", ExitCode: ExGuestConflict}
 	// minikube failed to add a node to the cluster

--- a/test/integration/functional_test_mount_test.go
+++ b/test/integration/functional_test_mount_test.go
@@ -22,11 +22,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -56,151 +58,242 @@ func validateMountCmd(ctx context.Context, t *testing.T, profile string) { // no
 		t.Skip("skipping: mount broken on windows: https://github.com/kubernetes/minikube/issues/8303")
 	}
 
-	tempDir, err := ioutil.TempDir("", "mounttest")
-	defer func() { // clean up tempdir
-		err := os.RemoveAll(tempDir)
-		if err != nil {
-			t.Errorf("failed to clean up %q temp folder.", tempDir)
-		}
-	}()
-	if err != nil {
-		t.Fatalf("Unexpected error while creating tempDir: %v", err)
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, Minutes(10))
-
-	args := []string{"mount", "-p", profile, fmt.Sprintf("%s:%s", tempDir, guestMount), "--alsologtostderr", "-v=1"}
-	ss, err := Start(t, exec.CommandContext(ctx, Target(), args...))
-	if err != nil {
-		t.Fatalf("%v failed: %v", args, err)
-	}
-
-	defer func() {
-		if t.Failed() {
-			t.Logf("%q failed, getting debug info...", t.Name())
-			rr, err := Run(t, exec.Command(Target(), "-p", profile, "ssh", "mount | grep 9p; ls -la /mount-9p; cat /mount-9p/pod-dates"))
+	t.Run("any-port", func(t *testing.T) {
+		tempDir, err := ioutil.TempDir("", "mounttest")
+		defer func() { // clean up tempdir
+			err := os.RemoveAll(tempDir)
 			if err != nil {
-				t.Logf("debugging command %q failed : %v", rr.Command(), err)
-			} else {
-				t.Logf("(debug) %s:\n%s", rr.Command(), rr.Stdout)
+				t.Errorf("failed to clean up %q temp folder.", tempDir)
+			}
+		}()
+		if err != nil {
+			t.Fatalf("Unexpected error while creating tempDir: %v", err)
+		}
+
+		ctx, cancel := context.WithTimeout(ctx, Minutes(10))
+
+		args := []string{"mount", "-p", profile, fmt.Sprintf("%s:%s", tempDir, guestMount), "--alsologtostderr", "-v=1"}
+		ss, err := Start(t, exec.CommandContext(ctx, Target(), args...))
+		if err != nil {
+			t.Fatalf("%v failed: %v", args, err)
+		}
+
+		defer func() {
+			if t.Failed() {
+				t.Logf("%q failed, getting debug info...", t.Name())
+				rr, err := Run(t, exec.Command(Target(), "-p", profile, "ssh", "mount | grep 9p; ls -la /mount-9p; cat /mount-9p/pod-dates"))
+				if err != nil {
+					t.Logf("debugging command %q failed : %v", rr.Command(), err)
+				} else {
+					t.Logf("(debug) %s:\n%s", rr.Command(), rr.Stdout)
+				}
+			}
+
+			// Cleanup in advance of future tests
+			rr, err := Run(t, exec.Command(Target(), "-p", profile, "ssh", "sudo umount -f /mount-9p"))
+			if err != nil {
+				t.Logf("%q: %v", rr.Command(), err)
+			}
+			ss.Stop(t)
+			cancel()
+			if *cleanup {
+				os.RemoveAll(tempDir)
+			}
+		}()
+
+		// Write local files
+		testMarker := fmt.Sprintf("test-%d", time.Now().UnixNano())
+		wantFromTest := []byte(testMarker)
+		for _, name := range []string{createdByTest, createdByTestRemovedByPod, testMarker} {
+			p := filepath.Join(tempDir, name)
+			err := ioutil.WriteFile(p, wantFromTest, 0644)
+			t.Logf("wrote %q to %s", wantFromTest, p)
+			if err != nil {
+				t.Errorf("WriteFile %s: %v", p, err)
 			}
 		}
 
-		// Cleanup in advance of future tests
-		rr, err := Run(t, exec.Command(Target(), "-p", profile, "ssh", "sudo umount -f /mount-9p"))
-		if err != nil {
-			t.Logf("%q: %v", rr.Command(), err)
+		// Block until the mount succeeds to avoid file race
+		checkMount := func() error {
+			_, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "findmnt -T /mount-9p | grep 9p"))
+			return err
 		}
+
+		start := time.Now()
+		if err := retry.Expo(checkMount, time.Millisecond*500, Seconds(15)); err != nil {
+			// For local testing, allow macOS users to click prompt. If they don't, skip the test.
+			if runtime.GOOS == "darwin" {
+				t.Skip("skipping: mount did not appear, likely because macOS requires prompt to allow non-codesigned binaries to listen on non-localhost port")
+			}
+			t.Fatalf("/mount-9p did not appear within %s: %v", time.Since(start), err)
+		}
+
+		// Assert that we can access the mount without an error. Display for debugging.
+		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "--", "ls", "-la", guestMount))
+		if err != nil {
+			t.Fatalf("failed verifying accessing to the mount. args %q : %v", rr.Command(), err)
+		}
+		t.Logf("guest mount directory contents\n%s", rr.Stdout)
+
+		// Assert that the mount contains our unique test marker, as opposed to a stale mount
+		tp := filepath.Join("/mount-9p", testMarker)
+		rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "cat", tp))
+		if err != nil {
+			t.Fatalf("failed to verify the mount contains unique test marked: args %q: %v", rr.Command(), err)
+		}
+
+		if !bytes.Equal(rr.Stdout.Bytes(), wantFromTest) {
+			// The mount is hosed, exit fast before wasting time launching pods.
+			t.Fatalf("%s = %q, want %q", tp, rr.Stdout.Bytes(), wantFromTest)
+		}
+
+		// Start the "busybox-mount" pod.
+		rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "replace", "--force", "-f", filepath.Join(*testdataDir, "busybox-mount-test.yaml")))
+		if err != nil {
+			t.Fatalf("failed to 'kubectl replace' for busybox-mount-test. args %q : %v", rr.Command(), err)
+		}
+
+		if _, err := PodWait(ctx, t, profile, "default", "integration-test=busybox-mount", Minutes(4)); err != nil {
+			t.Fatalf("failed waiting for busybox-mount pod: %v", err)
+		}
+
+		// Read the file written by pod startup
+		p := filepath.Join(tempDir, createdByPod)
+		got, err := ioutil.ReadFile(p)
+		if err != nil {
+			t.Errorf("failed to read file created by pod %q: %v", p, err)
+		}
+		wantFromPod := []byte("test\n")
+		if !bytes.Equal(got, wantFromPod) {
+			t.Errorf("the content of the file %q is %q, but want it to be: *%q*", p, got, wantFromPod)
+		}
+
+		// test that file written from host was read in by the pod via cat /mount-9p/written-by-host;
+		rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "logs", "busybox-mount"))
+		if err != nil {
+			t.Errorf("failed to get kubectl logs for busybox-mount. args %q : %v", rr.Command(), err)
+		}
+		if !bytes.Equal(rr.Stdout.Bytes(), wantFromTest) {
+			t.Errorf("busybox-mount logs = %q, want %q", rr.Stdout.Bytes(), wantFromTest)
+		}
+
+		// test file timestamps are correct
+		for _, name := range []string{createdByTest, createdByPod} {
+			gp := path.Join(guestMount, name)
+			// test that file written from host was read in by the pod via cat /mount-9p/fromhost;
+			rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "stat", gp))
+			if err != nil {
+				t.Errorf("failed to stat the file %q iniside minikube : args %q: %v", gp, rr.Command(), err)
+			}
+
+			if runtime.GOOS == "windows" {
+				if strings.Contains(rr.Stdout.String(), "Access: 1970-01-01") {
+					t.Errorf("expected to get valid access time but got: %q", rr.Stdout)
+				}
+			}
+
+			if strings.Contains(rr.Stdout.String(), "Modify: 1970-01-01") {
+				t.Errorf("expected to get valid modify time but got: %q", rr.Stdout)
+			}
+		}
+
+		p = filepath.Join(tempDir, createdByTestRemovedByPod)
+		if _, err := os.Stat(p); err == nil {
+			t.Errorf("expected file %q to be removed but exists !", p)
+		}
+
+		p = filepath.Join(tempDir, createdByPodRemovedByTest)
+		if err := os.Remove(p); err != nil {
+			t.Errorf("failed to remove file %q: %v", p, err)
+		}
+	})
+	t.Run("specific-port", func(t *testing.T) {
+		tempDir, err := ioutil.TempDir("", "mounttest")
+		defer func() { // clean up tempdir
+			err := os.RemoveAll(tempDir)
+			if err != nil {
+				t.Errorf("failed to clean up %q temp folder.", tempDir)
+			}
+		}()
+		if err != nil {
+			t.Fatalf("Unexpected error while creating tempDir: %v", err)
+		}
+
+		ctx, cancel := context.WithTimeout(ctx, Minutes(10))
+
+		args := []string{"mount", "-p", profile, fmt.Sprintf("%s:%s", tempDir, guestMount), "--alsologtostderr", "-v=1", "--port", "46464"}
+		ss, err := Start(t, exec.CommandContext(ctx, Target(), args...))
+		if err != nil {
+			t.Fatalf("%v failed: %v", args, err)
+		}
+
+		defer func() {
+			if t.Failed() {
+				t.Logf("%q failed, getting debug info...", t.Name())
+				rr, err := Run(t, exec.Command(Target(), "-p", profile, "ssh", "mount | grep 9p; ls -la /mount-9p; cat /mount-9p/pod-dates"))
+				if err != nil {
+					t.Logf("debugging command %q failed : %v", rr.Command(), err)
+				} else {
+					t.Logf("(debug) %s:\n%s", rr.Command(), rr.Stdout)
+				}
+			}
+
+			// Cleanup in advance of future tests
+			rr, err := Run(t, exec.Command(Target(), "-p", profile, "ssh", "sudo umount -f /mount-9p"))
+			if err != nil {
+				t.Logf("%q: %v", rr.Command(), err)
+			}
+			ss.Stop(t)
+			cancel()
+			if *cleanup {
+				os.RemoveAll(tempDir)
+			}
+		}()
+
+		// Block until the mount succeeds to avoid file race
+		checkMount := func() error {
+			_, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "findmnt -T /mount-9p | grep 9p"))
+			return err
+		}
+
+		start := time.Now()
+		if err := retry.Expo(checkMount, time.Millisecond*500, Seconds(15)); err != nil {
+			// For local testing, allow macOS users to click prompt. If they don't, skip the test.
+			if runtime.GOOS == "darwin" {
+				t.Skip("skipping: mount did not appear, likely because macOS requires prompt to allow non-codesigned binaries to listen on non-localhost port")
+			}
+			t.Fatalf("/mount-9p did not appear within %s: %v", time.Since(start), err)
+		}
+
+		// Assert that we can access the mount without an error. Display for debugging.
+		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "--", "ls", "-la", guestMount))
+		if err != nil {
+			t.Fatalf("failed verifying accessing to the mount. args %q : %v", rr.Command(), err)
+		}
+		t.Logf("guest mount directory contents\n%s", rr.Stdout)
+
 		ss.Stop(t)
-		cancel()
-		if *cleanup {
-			os.RemoveAll(tempDir)
-		}
-	}()
-
-	// Write local files
-	testMarker := fmt.Sprintf("test-%d", time.Now().UnixNano())
-	wantFromTest := []byte(testMarker)
-	for _, name := range []string{createdByTest, createdByTestRemovedByPod, testMarker} {
-		p := filepath.Join(tempDir, name)
-		err := ioutil.WriteFile(p, wantFromTest, 0644)
-		t.Logf("wrote %q to %s", wantFromTest, p)
-		if err != nil {
-			t.Errorf("WriteFile %s: %v", p, err)
-		}
-	}
-
-	// Block until the mount succeeds to avoid file race
-	checkMount := func() error {
-		_, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "findmnt -T /mount-9p | grep 9p"))
-		return err
-	}
-
-	start := time.Now()
-	if err := retry.Expo(checkMount, time.Millisecond*500, Seconds(15)); err != nil {
-		// For local testing, allow macOS users to click prompt. If they don't, skip the test.
-		if runtime.GOOS == "darwin" {
-			t.Skip("skipping: mount did not appear, likely because macOS requires prompt to allow non-codesigned binaries to listen on non-localhost port")
-		}
-		t.Fatalf("/mount-9p did not appear within %s: %v", time.Since(start), err)
-	}
-
-	// Assert that we can access the mount without an error. Display for debugging.
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "--", "ls", "-la", guestMount))
-	if err != nil {
-		t.Fatalf("failed verifying accessing to the mount. args %q : %v", rr.Command(), err)
-	}
-	t.Logf("guest mount directory contents\n%s", rr.Stdout)
-
-	// Assert that the mount contains our unique test marker, as opposed to a stale mount
-	tp := filepath.Join("/mount-9p", testMarker)
-	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "cat", tp))
-	if err != nil {
-		t.Fatalf("failed to verify the mount contains unique test marked: args %q: %v", rr.Command(), err)
-	}
-
-	if !bytes.Equal(rr.Stdout.Bytes(), wantFromTest) {
-		// The mount is hosed, exit fast before wasting time launching pods.
-		t.Fatalf("%s = %q, want %q", tp, rr.Stdout.Bytes(), wantFromTest)
-	}
-
-	// Start the "busybox-mount" pod.
-	rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "replace", "--force", "-f", filepath.Join(*testdataDir, "busybox-mount-test.yaml")))
-	if err != nil {
-		t.Fatalf("failed to 'kubectl replace' for busybox-mount-test. args %q : %v", rr.Command(), err)
-	}
-
-	if _, err := PodWait(ctx, t, profile, "default", "integration-test=busybox-mount", Minutes(4)); err != nil {
-		t.Fatalf("failed waiting for busybox-mount pod: %v", err)
-	}
-
-	// Read the file written by pod startup
-	p := filepath.Join(tempDir, createdByPod)
-	got, err := ioutil.ReadFile(p)
-	if err != nil {
-		t.Errorf("failed to read file created by pod %q: %v", p, err)
-	}
-	wantFromPod := []byte("test\n")
-	if !bytes.Equal(got, wantFromPod) {
-		t.Errorf("the content of the file %q is %q, but want it to be: *%q*", p, got, wantFromPod)
-	}
-
-	// test that file written from host was read in by the pod via cat /mount-9p/written-by-host;
-	rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "logs", "busybox-mount"))
-	if err != nil {
-		t.Errorf("failed to get kubectl logs for busybox-mount. args %q : %v", rr.Command(), err)
-	}
-	if !bytes.Equal(rr.Stdout.Bytes(), wantFromTest) {
-		t.Errorf("busybox-mount logs = %q, want %q", rr.Stdout.Bytes(), wantFromTest)
-	}
-
-	// test file timestamps are correct
-	for _, name := range []string{createdByTest, createdByPod} {
-		gp := path.Join(guestMount, name)
-		// test that file written from host was read in by the pod via cat /mount-9p/fromhost;
-		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "ssh", "stat", gp))
-		if err != nil {
-			t.Errorf("failed to stat the file %q iniside minikube : args %q: %v", gp, rr.Command(), err)
-		}
-
-		if runtime.GOOS == "windows" {
-			if strings.Contains(rr.Stdout.String(), "Access: 1970-01-01") {
-				t.Errorf("expected to get valid access time but got: %q", rr.Stdout)
+		t.Logf("reading mount text")
+		mountText := func() string {
+			str := ""
+			var err error = nil
+			for err == nil {
+				var add string
+				add, err = ss.Stdout.ReadString(0)
+				str += add
 			}
+			if err != io.EOF {
+				t.Fatalf("failed to read stdout of mount cmd. err: %v", err)
+			}
+			return str
+		}()
+		t.Logf("done reading mount text")
+		match, err := regexp.Match("Bind Address:\\s*[0-9.]+:46464", []byte(mountText))
+		if err != nil {
+			t.Fatalf("failed to match regex pattern. err: %v", err)
 		}
-
-		if strings.Contains(rr.Stdout.String(), "Modify: 1970-01-01") {
-			t.Errorf("expected to get valid modify time but got: %q", rr.Stdout)
+		if !match {
+			t.Fatalf("failed to find bind address with port 46464. Mount command out: \n%v", mountText)
 		}
-	}
-
-	p = filepath.Join(tempDir, createdByTestRemovedByPod)
-	if _, err := os.Stat(p); err == nil {
-		t.Errorf("expected file %q to be removed but exists !", p)
-	}
-
-	p = filepath.Join(tempDir, createdByPodRemovedByTest)
-	if err := os.Remove(p); err != nil {
-		t.Errorf("failed to remove file %q: %v", p, err)
-	}
+	})
 }


### PR DESCRIPTION
fixes #11978.

Now users can specify what port to use for mounting (in addition to allowing random port assignment). Also, adds advice for timing out mounting to check firewall.