### PR TITLE
Add message to discourage the use of the virtualbox driver

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -127,6 +127,10 @@ var settings = []Setting{
 		set:  SetBool,
 	},
 	{
+		name: config.WantVirtualBoxDriverWarning,
+		set:  SetBool,
+	},
+	{
 		name: config.ProfileName,
 		set:  SetString,
 	},

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -305,6 +305,7 @@ func setupViper() {
 	viper.SetDefault(config.WantUpdateNotification, true)
 	viper.SetDefault(config.ReminderWaitPeriodInHours, 24)
 	viper.SetDefault(config.WantNoneDriverWarning, true)
+	viper.SetDefault(config.WantVirtualBoxDriverWarning, true)
 }
 
 func addToPath(dir string) {

--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -38,6 +38,8 @@ const (
 	ReminderWaitPeriodInHours = "ReminderWaitPeriodInHours"
 	// WantNoneDriverWarning is the key for WantNoneDriverWarning
 	WantNoneDriverWarning = "WantNoneDriverWarning"
+	// WantVirtualBoxDriverWarning is the key for WantVirtualBoxDriverWarning
+	WantVirtualBoxDriverWarning = "WantVirtualBoxDriverWarning"
 	// ProfileName represents the key for the global profile parameter
 	ProfileName = "profile"
 	// UserFlag is the key for the global user flag (ex. --user=user1)

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -193,14 +193,7 @@ func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 
 	// discourage use of the virtualbox driver
 	if starter.Cfg.Driver == driver.VirtualBox && viper.GetBool(config.WantVirtualBoxDriverWarning) {
-		var altDriverList strings.Builder
-		for _, choice := range driver.Choices(true) {
-			if choice.Name != "virtualbox" {
-				altDriverList.WriteString(fmt.Sprintf("\n\t- %s", choice.Name))
-			}
-		}
-
-		out.Boxed("There are alternative drivers to virtualbox for better performance and support, consider using them {{.drivers}} \nTo turn this warning off use `minikube config set WantVirtualBoxDriverWarning false`", out.V{"drivers": altDriverList.String()})
+		warnVirtualBox()
 	}
 
 	if apiServer {
@@ -742,4 +735,16 @@ func addCoreDNSEntry(runner command.Runner, name, ip string, cc config.ClusterCo
 	klog.Infof("{%q: %s} host record injected into CoreDNS", name, ip)
 
 	return nil
+}
+
+// prints a warning to the console against the use of the 'virtualbox' driver
+func warnVirtualBox() {
+	var altDriverList strings.Builder
+	for _, choice := range driver.Choices(true) {
+		if choice.Name != "virtualbox" {
+			altDriverList.WriteString(fmt.Sprintf("\n\t- %s", choice.Name))
+		}
+	}
+
+	out.Boxed("There are alternative drivers to virtualbox for better performance and support, consider using them {{.drivers}} \nTo turn this warning off use `minikube config set WantVirtualBoxDriverWarning false`", out.V{"drivers": altDriverList.String()})
 }

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -746,5 +746,7 @@ func warnVirtualBox() {
 		}
 	}
 
-	out.Boxed("There are alternative drivers to virtualbox for better performance and support, consider using them {{.drivers}} \nTo turn this warning off use `minikube config set WantVirtualBoxDriverWarning false`", out.V{"drivers": altDriverList.String()})
+	if altDriverList.Len() != 0 {
+		out.Boxed("There are alternative drivers to virtualbox for better performance and support, consider using them {{.drivers}} \nTo turn this warning off use `minikube config set WantVirtualBoxDriverWarning false`", out.V{"drivers": altDriverList.String()})
+	}
 }

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -61,6 +61,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/out/register"
 	"k8s.io/minikube/pkg/minikube/proxy"
 	"k8s.io/minikube/pkg/minikube/reason"
+	"k8s.io/minikube/pkg/minikube/registry"
 	"k8s.io/minikube/pkg/minikube/style"
 	"k8s.io/minikube/pkg/minikube/vmpath"
 	"k8s.io/minikube/pkg/util"
@@ -737,11 +738,11 @@ func addCoreDNSEntry(runner command.Runner, name, ip string, cc config.ClusterCo
 	return nil
 }
 
-// prints a warning to the console against the use of the 'virtualbox' driver
+// prints a warning to the console against the use of the 'virtualbox' driver, if alternatives are available
 func warnVirtualBox() {
 	var altDriverList strings.Builder
 	for _, choice := range driver.Choices(true) {
-		if choice.Name != "virtualbox" {
+		if choice.Name != "virtualbox" && choice.Priority != registry.Discouraged && !(choice.Name == "vmware" && !choice.State.Installed) {
 			altDriverList.WriteString(fmt.Sprintf("\n\t- %s", choice.Name))
 		}
 	}

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -191,6 +191,23 @@ func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 		go addons.Start(&wg, starter.Cfg, starter.ExistingAddons, addonList)
 	}
 
+	// discourage use of the virtualbox driver
+	if starter.Cfg.Driver == driver.VirtualBox && viper.GetBool(config.WantVirtualBoxDriverWarning) {
+		var altDriverList strings.Builder
+		for _, d := range driver.Choices(true) {
+			if d.Name != "virtualbox" {
+				altDriverList.WriteString(fmt.Sprintf("\t- %s\n", d.Name))
+			}
+		}
+
+		out.ErrT(style.Empty, "")
+		out.WarningT("The 'virtualbox' driver could be troublesome to work with, do not use if you aren't familiar with it")
+		out.ErrT(style.Tip, "You could instead use one of the drivers listed below:")
+		out.ErrT(style.Empty, altDriverList.String())
+		out.ErrT(style.Documentation, "For more information, see: https://minikube.sigs.k8s.io/docs/reference/drivers/virtualbox/")
+		out.ErrT(style.Empty, "")
+	}
+
 	if apiServer {
 		// special ops for none , like change minikube directory.
 		// multinode super doesn't work on the none driver

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -194,18 +194,13 @@ func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 	// discourage use of the virtualbox driver
 	if starter.Cfg.Driver == driver.VirtualBox && viper.GetBool(config.WantVirtualBoxDriverWarning) {
 		var altDriverList strings.Builder
-		for _, d := range driver.Choices(true) {
-			if d.Name != "virtualbox" {
-				altDriverList.WriteString(fmt.Sprintf("\t- %s\n", d.Name))
+		for _, choice := range driver.Choices(true) {
+			if choice.Name != "virtualbox" {
+				altDriverList.WriteString(fmt.Sprintf("\n\t- %s", choice.Name))
 			}
 		}
 
-		out.ErrT(style.Empty, "")
-		out.WarningT("The 'virtualbox' driver could be troublesome to work with, do not use if you aren't familiar with it")
-		out.ErrT(style.Tip, "You could instead use one of the drivers listed below:")
-		out.ErrT(style.Empty, altDriverList.String())
-		out.ErrT(style.Documentation, "For more information, see: https://minikube.sigs.k8s.io/docs/reference/drivers/virtualbox/")
-		out.ErrT(style.Empty, "")
+		out.Boxed("There are alternative drivers to virtualbox for better performance and support, consider using them {{.drivers}} \nTo turn this warning off use `minikube config set WantVirtualBoxDriverWarning false`", out.V{"drivers": altDriverList.String()})
 	}
 
 	if apiServer {

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -738,16 +738,16 @@ func addCoreDNSEntry(runner command.Runner, name, ip string, cc config.ClusterCo
 	return nil
 }
 
-// prints a warning to the console against the use of the 'virtualbox' driver, if alternatives are available
+// prints a warning to the console against the use of the 'virtualbox' driver, if alternatives are available and healthy
 func warnVirtualBox() {
 	var altDriverList strings.Builder
 	for _, choice := range driver.Choices(true) {
-		if choice.Name != "virtualbox" && choice.Priority != registry.Discouraged && !(choice.Name == "vmware" && !(choice.State.Installed && choice.State.Healthy)) {
+		if choice.Name != "virtualbox" && choice.Priority != registry.Discouraged && choice.State.Installed && choice.State.Healthy {
 			altDriverList.WriteString(fmt.Sprintf("\n\t- %s", choice.Name))
 		}
 	}
 
 	if altDriverList.Len() != 0 {
-		out.Boxed("There are alternative drivers to virtualbox for better performance and support, consider using them {{.drivers}} \nTo turn this warning off use `minikube config set WantVirtualBoxDriverWarning false`", out.V{"drivers": altDriverList.String()})
+		out.Boxed("You have selected Virtualbox driver, but there are better options, for better performance and support consider using a different driver: {{.drivers}} \nTo turn off this suggestion run \n`minikube config set WantVirtualBoxDriverWarning false`", out.V{"drivers": altDriverList.String()})
 	}
 }

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -742,7 +742,7 @@ func addCoreDNSEntry(runner command.Runner, name, ip string, cc config.ClusterCo
 func warnVirtualBox() {
 	var altDriverList strings.Builder
 	for _, choice := range driver.Choices(true) {
-		if choice.Name != "virtualbox" && choice.Priority != registry.Discouraged && !(choice.Name == "vmware" && !choice.State.Installed) {
+		if choice.Name != "virtualbox" && choice.Priority != registry.Discouraged && !(choice.Name == "vmware" && !(choice.State.Installed && choice.State.Healthy)) {
 			altDriverList.WriteString(fmt.Sprintf("\n\t- %s", choice.Name))
 		}
 	}

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -748,6 +748,17 @@ func warnVirtualBox() {
 	}
 
 	if altDriverList.Len() != 0 {
-		out.Boxed("You have selected Virtualbox driver, but there are better options, for better performance and support consider using a different driver: {{.drivers}} \nTo turn off this suggestion run \n`minikube config set WantVirtualBoxDriverWarning false`", out.V{"drivers": altDriverList.String()})
+		out.Boxed(`You have selected "virtualbox" driver, but there are better options !
+For better performance and support consider using a different driver: {{.drivers}}
+
+To turn off this warning run:
+
+	$ minikube config set WantVirtualBoxDriverWarning false
+
+
+To learn more about on minikube drivers checkout https://minikube.sigs.k8s.io/docs/drivers/
+To see benchmarks checkout https://minikube.sigs.k8s.io/docs/benchmarks/cpuusage/
+
+`, out.V{"drivers": altDriverList.String()})
 	}
 }

--- a/site/content/en/docs/commands/config.md
+++ b/site/content/en/docs/commands/config.md
@@ -30,6 +30,7 @@ Configurable fields:
  * WantBetaUpdateNotification
  * ReminderWaitPeriodInHours
  * WantNoneDriverWarning
+ * WantVirtualBoxDriverWarning
  * profile
  * bootstrapper
  * insecure-registry


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
fixes #11913

<details>
<summary> Before: </summary>
<br>

```
$ minikube start --driver=virtualbox
😄  minikube v1.22.0 on distro
✨  Using the virtualbox driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🔥  Creating virtualbox VM (CPUs=2, Memory=3800MB, Disk=20000MB) ...
🐳  Preparing Kubernetes v1.21.2 on Docker 20.10.6 ...
❌  Unable to load cached images: loading cached images: stat /home/.minikube/cache/images/k8s.gcr.io/kube-scheduler_v1.21.2: no such file or directory
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5

📘  For more information, see: https://minikube.sigs.k8s.io/docs/reference/drivers/virtualbox/

🔎  Verifying Kubernetes components...
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```

</details>


<details open>
<summary>After:</summary>
<br>

```
$ minikube start --driver=virtualbox
😄  minikube v1.22.0 on Debian bullseye/sid
✨  Using the virtualbox driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
🏃  Updating the running virtualbox "minikube" VM ...
🐳  Preparing Kubernetes v1.21.2 on Docker 20.10.6 ...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass
╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                 │
│    You have selected Virtualbox driver, but there are better options, for better performance and support consider using a different driver:     │
│            - kvm2                                                                                                                               │
│    To turn off this suggestion run                                                                                                              │
│    `minikube config set WantVirtualBoxDriverWarning false`                                                                                      │
│                                                                                                                                                 │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
🔎  Verifying Kubernetes components...
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```
</details>