### PR TITLE
Set specific GO_VERSION env for leaderboard workflow

### DIFF
--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -6,6 +6,8 @@ on:
       - 'v*-beta.*'
   release:
     types: [published]
+env:
+  GO_VERSION: 1.16.4
 jobs:
   update-leaderboard:
     runs-on: ubuntu-latest

--- a/hack/update/golang_version/update_golang_version.go
+++ b/hack/update/golang_version/update_golang_version.go
@@ -70,6 +70,11 @@ var (
 				`GO_VERSION: '.*`: `GO_VERSION: '{{.StableVersion}}'`,
 			},
 		},
+		".github/workflows/leaderboard.yml": {
+			Replace: map[string]string{
+				`GO_VERSION: '.*`: `GO_VERSION: '{{.StableVersion}}'`,
+			},
+		},
 		".github/workflows/translations.yml": {
 			Replace: map[string]string{
 				`GO_VERSION: '.*`: `GO_VERSION: '{{.StableVersion}}'`,


### PR DESCRIPTION
https://github.com/kubernetes/minikube/runs/3080009605?check_suite_focus=true This broke.