### PR TITLE
docs: Suggest using alias for minikube kubectl --

### DIFF
--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -454,10 +454,14 @@ If you already have kubectl installed, you can now use it to access your shiny n
 kubectl get po -A
 ```
 
-Alternatively, minikube can download the appropriate version of kubectl, if you don't mind the double-dashes in the command-line:
+Alternatively, minikube can download the appropriate version of kubectl and you should be able to use it like this:
 
 ```shell
 minikube kubectl -- get po -A
+```
+If you've downloaded kubectl through minikube, you can make your life easier by adding the following to your shell config:
+```shell
+alias kubectl="minikube kubectl --"
 ```
 
 Initially, some services such as the storage-provisioner, may not yet be in a Running state. This is a normal condition during cluster bring-up, and will resolve itself momentarily. For additional insight into your cluster state, minikube bundles the Kubernetes Dashboard, allowing you to get easily acclimated to your new environment:

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -459,7 +459,7 @@ Alternatively, minikube can download the appropriate version of kubectl and you 
 ```shell
 minikube kubectl -- get po -A
 ```
-If you've downloaded kubectl through minikube, you can make your life easier by adding the following to your shell config:
+You can also make your life easier by adding the following to your shell config:
 ```shell
 alias kubectl="minikube kubectl --"
 ```


### PR DESCRIPTION
Adding the following in the shell config:
```bash
alias kubectl="minikube kubectl --"
```
can be really helpful for the users who have downloaded kubectl via minikube :)

fixes #11996 