### PR TITLE
Order time-to-k8s benchmarks from newest to oldest

### DIFF
--- a/hack/benchmark/time-to-k8s/time-to-k8s.sh
+++ b/hack/benchmark/time-to-k8s/time-to-k8s.sh
@@ -43,7 +43,7 @@ generate_chart() {
 }
 
 create_page() {
-	printf -- "---\ntitle: \"%s Benchmark\"\nlinkTitle: \"%s Benchmark\"\nweight: 1\n---\n\n![time-to-k8s](/images/benchmarks/timeToK8s/%s.png)\n" "$1" "$1" "$1" > ./site/content/en/docs/benchmarks/timeToK8s/"$1".md
+	printf -- "---\ntitle: \"%s Benchmark\"\nlinkTitle: \"%s Benchmark\"\nweight: -$(date +'%Y%m%d')\n---\n\n![time-to-k8s](/images/benchmarks/timeToK8s/%s.png)\n" "$1" "$1" "$1" > ./site/content/en/docs/benchmarks/timeToK8s/"$1".md
 }
 
 cleanup() {

--- a/site/content/en/docs/benchmarks/timeToK8s/v1.20.0.md
+++ b/site/content/en/docs/benchmarks/timeToK8s/v1.20.0.md
@@ -1,7 +1,7 @@
 ---
 title: "v1.20.0 Benchmark"
 linkTitle: "v1.20.0 Benchmark"
-weight: 1
+weight: -20210506
 ---
 
 ![time-to-k8s](/images/benchmarks/timeToK8s/v1.20.0.png)

--- a/site/content/en/docs/benchmarks/timeToK8s/v1.21.0.md
+++ b/site/content/en/docs/benchmarks/timeToK8s/v1.21.0.md
@@ -1,7 +1,7 @@
 ---
 title: "v1.21.0 Benchmark"
 linkTitle: "v1.21.0 Benchmark"
-weight: 1
+weight: -20210611
 ---
 
 ![time-to-k8s](/images/benchmarks/timeToK8s/v1.21.0.png)

--- a/site/content/en/docs/benchmarks/timeToK8s/v1.22.0.md
+++ b/site/content/en/docs/benchmarks/timeToK8s/v1.22.0.md
@@ -1,7 +1,7 @@
 ---
 title: "v1.22.0 Benchmark"
 linkTitle: "v1.22.0 Benchmark"
-weight: 1
+weight: -20210707
 ---
 
 ![time-to-k8s](/images/benchmarks/timeToK8s/v1.22.0.png)


### PR DESCRIPTION
Closes #12013

Was ordering from oldest to newest, reversing the order as people most likely want to see the latest benchmarks first.