### PR TITLE
Make flake rate commenting more useful, and improve flake rate charts

### DIFF
--- a/hack/jenkins/test-flake-chart/flake_chart.html
+++ b/hack/jenkins/test-flake-chart/flake_chart.html
@@ -1,6 +1,10 @@
 <html>
   <head>
     <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+    <script src='https://cdnjs.cloudflare.com/ajax/libs/tablesort/5.2.1/tablesort.min.js'></script>
+    <!-- Include sort types you need -->
+    <script src='https://cdnjs.cloudflare.com/ajax/libs/tablesort/5.2.1/sorts/tablesort.number.min.js'></script>
+    
     <style>
       table {
         border: 1px solid gray;

--- a/hack/jenkins/test-flake-chart/flake_chart.js
+++ b/hack/jenkins/test-flake-chart/flake_chart.js
@@ -267,6 +267,7 @@ function createRecentFlakePercentageTable(recentFlakePercentage, previousFlakePe
   tableHeaderRow.appendChild(createCell("th", "Recent Flake Percentage"));
   tableHeaderRow.appendChild(createCell("th", "Growth (since last 15 days)"));
   table.appendChild(tableHeaderRow);
+  const tableBody = document.createElement("tbody");
   for (let i = 0; i < recentFlakePercentage.length; i++) {
     const {testName, flakeRate} = recentFlakePercentage[i];
     const row = document.createElement("tr");
@@ -276,8 +277,10 @@ function createRecentFlakePercentageTable(recentFlakePercentage, previousFlakePe
     const growth = previousFlakePercentageMap.has(testName) ?
       flakeRate - previousFlakePercentageMap.get(testName) : 0;
     row.appendChild(createCell("td", `<span style="color: ${growth === 0 ? "black" : (growth > 0 ? "red" : "green")}">${growth > 0 ? '+' + growth.toFixed(2) : growth.toFixed(2)}%</span>`));
-    table.appendChild(row);
+    tableBody.appendChild(row);
   }
+  table.appendChild(tableBody);
+  new Tablesort(table);
   return table;
 }
 
@@ -499,7 +502,11 @@ function displayEnvironmentChart(testData, environmentName) {
     chart.draw(data, options);
   }
 
-  document.body.appendChild(createRecentFlakePercentageTable(recentFlakePercentage, previousFlakePercentageMap, environmentName));
+  document.body.appendChild(
+    createRecentFlakePercentageTable(
+      recentFlakePercentage,
+      previousFlakePercentageMap,
+      environmentName));
 }
 
 async function init() {

--- a/hack/jenkins/test-flake-chart/report_flakes.sh
+++ b/hack/jenkins/test-flake-chart/report_flakes.sh
@@ -79,7 +79,7 @@ printf "These are the flake rates of all failed tests.\n|Environment|Failed Test
 # 2) Print a row in the table with the environment, test name, flake rate, and a link to the flake chart for that test.
 # 3) Append these rows to file $TMP_COMMENT.
 < "$TMP_FAILED_RATES" head -n $MAX_REPORTED_TESTS \
-  | sed -n -r -e "s/([a-zA-Z\/0-9_-]*):([a-zA-Z\/0-9_-]*),([.0-9]*)/|[\1](https:\/\/storage.googleapis.com\/minikube-flake-rate\/flake_chart.html?env=\1))|\2|\3 ([chart](https:\/\/storage.googleapis.com\/minikube-flake-rate\/flake_chart.html?env=\1\&test=\2))|/p" \
+  | sed -n -r -e "s/([a-zA-Z\/0-9_-]*):([a-zA-Z\/0-9_-]*),([.0-9]*)/|[\1](https:\/\/storage.googleapis.com\/minikube-flake-rate\/flake_chart.html?env=\1)|\2|\3 ([chart](https:\/\/storage.googleapis.com\/minikube-flake-rate\/flake_chart.html?env=\1\&test=\2))|/p" \
   >> "$TMP_COMMENT"
 
 # If there are too many failing tests, add an extra row explaining this, and a message after the table.

--- a/hack/jenkins/test-flake-chart/report_flakes.sh
+++ b/hack/jenkins/test-flake-chart/report_flakes.sh
@@ -79,11 +79,12 @@ printf "These are the flake rates of all failed tests.\n|Environment|Failed Test
 # Create variables to use for sed command.
 ENV_CHART_LINK_FORMAT="https://storage.googleapis.com/minikube-flake-rate/flake_chart.html?env=\1"
 TEST_CHART_LINK_FORMAT="${ENV_CHART_LINK_FORMAT}\&test=\2"
+TEST_GOPOGH_LINK_FORMAT="https://storage.googleapis.com/minikube-builds/logs/${PR_NUMBER}/${SHORT_COMMIT}/\1.html#fail_\2"
 # 1) Get the first $MAX_REPORTED_TESTS lines.
 # 2) Print a row in the table with the environment, test name, flake rate, and a link to the flake chart for that test.
 # 3) Append these rows to file $TMP_COMMENT.
 < "$TMP_FAILED_RATES" head -n $MAX_REPORTED_TESTS \
-  | sed -n -r -e "s|([a-zA-Z\/0-9_-]*):([a-zA-Z\/0-9_-]*),([.0-9]*)|\|[\1](${ENV_CHART_LINK_FORMAT})\|\2\|\3 ([chart](${TEST_CHART_LINK_FORMAT}))\||p" \
+  | sed -n -r -e "s|([a-zA-Z\/0-9_-]*):([a-zA-Z\/0-9_-]*),([.0-9]*)|\|[\1](${ENV_CHART_LINK_FORMAT})\|\2 ([gopogh](${TEST_GOPOGH_LINK_FORMAT}))\|\3 ([chart](${TEST_CHART_LINK_FORMAT}))\||p" \
   >> "$TMP_COMMENT"
 
 # If there are too many failing tests, add an extra row explaining this, and a message after the table.

--- a/hack/jenkins/test-flake-chart/report_flakes.sh
+++ b/hack/jenkins/test-flake-chart/report_flakes.sh
@@ -42,11 +42,11 @@ TMP_DATA=$(mktemp)
 # 5) Filter tests to only include failed tests (and only get their names and environment).
 # 6) Sort by environment, then test name.
 # 7) Store in file $TMP_DATA.
-< "${ENVIRONMENT_LIST}" sed -r "s/^/gs:\\/\\/minikube-builds\\/logs\\/${PR_NUMBER}\\/${SHORT_COMMIT}\\//; s/$/_summary.json/" \
+< "${ENVIRONMENT_LIST}" sed -r "s|^|gs://minikube-builds/logs/${PR_NUMBER}/${SHORT_COMMIT}/|; s|$|_summary.json|" \
   | (xargs gsutil ls || true) \
   | xargs gsutil cat \
   | "$DIR/process_data.sh" \
-  | sed -n -r -e "s/[0-9a-f]*,[0-9-]*,([a-zA-Z\/_0-9-]*),([a-zA-Z\/_0-9-]*),Failed,[.0-9]*/\1:\2/p" \
+  | sed -n -r -e "s|[0-9a-f]*,[0-9-]*,([a-zA-Z/_0-9-]*),([a-zA-Z/_0-9-]*),Failed,[.0-9]*|\1:\2|p" \
   | sort \
   > "$TMP_DATA"
 
@@ -60,7 +60,7 @@ TMP_FAILED_RATES="$TMP_FLAKE_RATES\_filtered"
 # 3) Join the flake rates with the failing tests to only get flake rates of failing tests.
 # 4) Sort failed test flake rates based on the flakiness of that test - stable tests should be first on the list.
 # 5) Store in file $TMP_FAILED_RATES.
-< "$TMP_FLAKE_RATES" sed -n -r -e "s/([a-zA-Z0-9_-]*),([a-zA-Z\/0-9_-]*),([.0-9]*),[.0-9]*/\1:\2,\3/p" \
+< "$TMP_FLAKE_RATES" sed -n -r -e "s|([a-zA-Z0-9_-]*),([a-zA-Z/0-9_-]*),([.0-9]*),[.0-9]*|\1:\2,\3|p" \
   | sort -t, -k1,1 \
   | join -t , -j 1 "$TMP_DATA" - \
   | sort -g -t, -k2,2 \
@@ -75,11 +75,15 @@ fi
 # Create the comment template.
 TMP_COMMENT=$(mktemp)
 printf "These are the flake rates of all failed tests.\n|Environment|Failed Tests|Flake Rate (%%)|\n|---|---|---|\n" > "$TMP_COMMENT"
+
+# Create variables to use for sed command.
+ENV_CHART_LINK_FORMAT="https://storage.googleapis.com/minikube-flake-rate/flake_chart.html?env=\1"
+TEST_CHART_LINK_FORMAT="${ENV_CHART_LINK_FORMAT}\&test=\2"
 # 1) Get the first $MAX_REPORTED_TESTS lines.
 # 2) Print a row in the table with the environment, test name, flake rate, and a link to the flake chart for that test.
 # 3) Append these rows to file $TMP_COMMENT.
 < "$TMP_FAILED_RATES" head -n $MAX_REPORTED_TESTS \
-  | sed -n -r -e "s/([a-zA-Z\/0-9_-]*):([a-zA-Z\/0-9_-]*),([.0-9]*)/|[\1](https:\/\/storage.googleapis.com\/minikube-flake-rate\/flake_chart.html?env=\1)|\2|\3 ([chart](https:\/\/storage.googleapis.com\/minikube-flake-rate\/flake_chart.html?env=\1\&test=\2))|/p" \
+  | sed -n -r -e "s|([a-zA-Z\/0-9_-]*):([a-zA-Z\/0-9_-]*),([.0-9]*)|\|[\1](${ENV_CHART_LINK_FORMAT})\|\2\|\3 ([chart](${TEST_CHART_LINK_FORMAT}))\||p" \
   >> "$TMP_COMMENT"
 
 # If there are too many failing tests, add an extra row explaining this, and a message after the table.


### PR DESCRIPTION
This PR makes multiple cosmetic changes to the flake rate charts and comment.

fixes #11882.
fixes #11994.
fixes #12037.

gopogh link in flake rate comment (rendered in VS Code): 
![image](https://user-images.githubusercontent.com/22285953/126839905-3a8eba5b-6aaf-4d26-8527-b7f4d2f0ab5f.png)

Click to sort flake rate tables: 
![image](https://user-images.githubusercontent.com/22285953/126839947-8f1b35d4-186d-4e32-8a89-64ca86f2222e.png)

By-week averaged flake rate charts (in addition to existing daily flake rate chart): 
![image](https://user-images.githubusercontent.com/22285953/126840000-031800d4-8d94-44a0-a7bf-7f5d55619008.png)
