### PR TITLE
Replace duration chart with total duration of tests -line

### DIFF
--- a/hack/jenkins/common.ps1
+++ b/hack/jenkins/common.ps1
@@ -50,7 +50,7 @@ $elapsed=$ended-$started
 $elapsed=$elapsed/60
 $elapsed=[math]::Round($elapsed, 2)
 
-$gopogh_status=gopogh --in testout.json --out_html testout.html --out_summary testout_summary.json --name "$env:JOB_NAME" -pr $env:MINIKUBE_LOCATION --repo github.com/kubernetes/minikube/ --details $env:COMMIT
+$gopogh_status=gopogh --in testout.json --out_html testout.html --out_summary testout_summary.json --name "$env:JOB_NAME" -pr $env:MINIKUBE_LOCATION --repo github.com/kubernetes/minikube/ --details "$env:COMMIT:$(Get-Date -Format "yyyy-MM-dd")"
 
 $failures=echo $gopogh_status | jq '.NumberOfFail'
 $tests=echo $gopogh_status | jq '.NumberOfTests'

--- a/hack/jenkins/common.ps1
+++ b/hack/jenkins/common.ps1
@@ -50,7 +50,7 @@ $elapsed=$ended-$started
 $elapsed=$elapsed/60
 $elapsed=[math]::Round($elapsed, 2)
 
-$gopogh_status=gopogh --in testout.json --out_html testout.html --out_summary testout_summary.json --name "$env:JOB_NAME" -pr $env:MINIKUBE_LOCATION --repo github.com/kubernetes/minikube/ --details "$env:COMMIT:$(Get-Date -Format "yyyy-MM-dd")"
+$gopogh_status=gopogh --in testout.json --out_html testout.html --out_summary testout_summary.json --name "$env:JOB_NAME" -pr $env:MINIKUBE_LOCATION --repo github.com/kubernetes/minikube/ --details "$env:COMMIT:$(Get-Date -Format "yyyy-MM-dd"):$env:ROOT_JOB_ID"
 
 $failures=echo $gopogh_status | jq '.NumberOfFail'
 $tests=echo $gopogh_status | jq '.NumberOfTests'

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -419,7 +419,7 @@ fi
 
 touch "${HTML_OUT}"
 touch "${SUMMARY_OUT}"
-gopogh_status=$(gopogh -in "${JSON_OUT}" -out_html "${HTML_OUT}" -out_summary "${SUMMARY_OUT}" -name "${JOB_NAME}" -pr "${MINIKUBE_LOCATION}" -repo github.com/kubernetes/minikube/  -details "${COMMIT}:$(date +%Y-%m-%d)") || true
+gopogh_status=$(gopogh -in "${JSON_OUT}" -out_html "${HTML_OUT}" -out_summary "${SUMMARY_OUT}" -name "${JOB_NAME}" -pr "${MINIKUBE_LOCATION}" -repo github.com/kubernetes/minikube/  -details "${COMMIT}:$(date +%Y-%m-%d):${ROOT_JOB_ID}") || true
 fail_num=$(echo $gopogh_status | jq '.NumberOfFail')
 test_num=$(echo $gopogh_status | jq '.NumberOfTests')
 pessimistic_status="${fail_num} / ${test_num} failures"

--- a/hack/jenkins/test-flake-chart/compute_flake_rate.go
+++ b/hack/jenkins/test-flake-chart/compute_flake_rate.go
@@ -80,7 +80,7 @@ func readData(file io.Reader) []testEntry {
 	testEntries := []testEntry{}
 
 	fileReader := bufio.NewReaderSize(file, 256)
-	previousLine := []string{"", "", "", "", "", ""}
+	previousLine := []string{"", "", "", "", "", "", "", "", ""}
 	firstLine := true
 	for {
 		lineBytes, _, err := fileReader.ReadLine()
@@ -93,8 +93,8 @@ func readData(file io.Reader) []testEntry {
 		line := string(lineBytes)
 		fields := strings.Split(line, ",")
 		if firstLine {
-			if len(fields) != 6 {
-				exit(fmt.Sprintf("Data CSV in incorrect format. Expected 6 columns, but got %d", len(fields)), fmt.Errorf("bad CSV format"))
+			if len(fields) != 9 {
+				exit(fmt.Sprintf("Data CSV in incorrect format. Expected 9 columns, but got %d", len(fields)), fmt.Errorf("bad CSV format"))
 			}
 			firstLine = false
 		}
@@ -103,8 +103,8 @@ func readData(file io.Reader) []testEntry {
 				fields[i] = previousLine[i]
 			}
 		}
-		if len(fields) != 6 {
-			fmt.Printf("Found line with wrong number of columns. Expectd 6, but got %d - skipping\n", len(fields))
+		if len(fields) != 9 {
+			fmt.Printf("Found line with wrong number of columns. Expectd 9, but got %d - skipping\n", len(fields))
 			continue
 		}
 		previousLine = fields

--- a/hack/jenkins/test-flake-chart/flake_chart.js
+++ b/hack/jenkins/test-flake-chart/flake_chart.js
@@ -104,23 +104,27 @@ async function loadTestData() {
   });
   // Consume the header to ensure the data has the right number of fields.
   const header = (await lines.next()).value;
-  if (header.split(",").length != 6) {
+  if (header.split(",").length != 9) {
     document.body.removeChild(box);
-    throw `Fetched CSV data contains wrong number of fields. Expected: 6. Actual Header: "${header}"`;
+    throw `Fetched CSV data contains wrong number of fields. Expected: 9. Actual Header: "${header}"`;
   }
 
   const testData = [];
-  let lineData = ["", "", "", "", "", ""];
+  let lineData = ["", "", "", "", "", "", "", "", ""];
   for await (const line of lines) {
     let splitLine = line.split(",");
-    if (splitLine.length != 6) {
-      console.warn(`Found line with wrong number of fields. Actual: ${splitLine.length} Expected: 6. Line: "${line}"`);
+    if (splitLine.length != 9) {
+      console.warn(`Found line with wrong number of fields. Actual: ${splitLine.length} Expected: 9. Line: "${line}"`);
       continue;
     }
     splitLine = splitLine.map((value, index) => value === "" ? lineData[index] : value);
     lineData = splitLine;
     if (!isValidEnumValue(testStatus, splitLine[4])) {
       console.warn(`Invalid test status provided. Actual: ${splitLine[4]} Expected: One of ${Object.values(testStatus).join(", ")}`);
+      continue;
+    }
+    // Skip unsafe dates.
+    if (splitLine[1] === "0001-01-01") {
       continue;
     }
     testData.push({
@@ -130,6 +134,9 @@ async function loadTestData() {
       name: splitLine[3],
       status: splitLine[4],
       duration: Number(splitLine[5]),
+      rootJob: splitLine[6],
+      testCount: Number(splitLine[7]),
+      totalDuration: Number(splitLine[8]),
     });
   }
   document.body.removeChild(box);

--- a/hack/jenkins/test-flake-chart/flake_chart.js
+++ b/hack/jenkins/test-flake-chart/flake_chart.js
@@ -565,46 +565,6 @@ function displayEnvironmentChart(testData, environmentName) {
     chart.draw(data, options);
   }
   {
-    const data = new google.visualization.DataTable();
-    data.addColumn('date', 'Date');
-    for (const name of recentTopFlakes) {
-      data.addColumn('number', `Duration - ${name}`);
-      data.addColumn({ type: 'string', role: 'tooltip', 'p': { 'html': true } });
-    }
-    data.addRows(
-      orderedDates.map(dateTime => [new Date(dateTime)].concat(recentTopFlakes.map(name => {
-        const data = aggregatedRuns.get(name).get(dateTime);
-        return data !== undefined ? [
-          data.duration,
-          `<div style="padding: 1rem; font-family: 'Arial'; font-size: 14">
-            <b style="display: block">${name}</b><br>
-            <b>${data.date.toString()}</b><br>
-            <b>Average Duration:</b> ${data.duration.toFixed(2)}s<br>
-            <b>Hashes:</b><br>
-            ${data.commitHashes.map(({ hash, duration, runs }) => `  - <a href="${hashToLink(hash, environmentName)}">${hash}</a> (Average Duration: ${duration.toFixed(2)}s [${runs} runs])`).join("<br>")}
-          </div>`
-        ] : [null, null];
-      })).flat())
-    );
-    const options = {
-      title: `Average duration by day of top ${topFlakes} of recent test flakiness (past ${dateRange} days) on ${environmentName}`,
-      width: window.innerWidth,
-      height: window.innerHeight,
-      pointSize: 10,
-      pointShape: "circle",
-      vAxes: {
-        0: { title: "Average Duration (s)" },
-      },
-      tooltip: { trigger: "selection", isHtml: true }
-    };
-    const durationContainer = document.createElement("div");
-    durationContainer.style.width = "100vw";
-    durationContainer.style.height = "100vh";
-    chartsContainer.appendChild(durationContainer);
-    const chart = new google.visualization.LineChart(durationContainer);
-    chart.draw(data, options);
-  }
-  {
     // Group test runs by their date, then by their commit, and finally by test names.
     const testCountData = testData
       // Group by date.

--- a/hack/jenkins/test-flake-chart/process_data.sh
+++ b/hack/jenkins/test-flake-chart/process_data.sh
@@ -26,7 +26,30 @@ printf "Commit Hash,Test Date,Environment,Test,Status,Duration\n"
 # Turn each test in each summary file to a CSV line containing its commit hash, date, environment, test, status, and duration.
 # Example line:
 # 247982745892,2021-06-10,Docker_Linux,TestFunctional,Passed,0.5
-jq -r '((.PassedTests[]? as $name | {commit: (.Detail.Details | split(":") | .[0]), date: (.Detail.Details | split(":") | .[1]), environment: .Detail.Name, test: $name, duration: .Durations[$name], status: "Passed"}),
-          (.FailedTests[]? as $name | {commit: (.Detail.Details | split(":") | .[0]), date: (.Detail.Details | split(":") | .[1]), environment: .Detail.Name, test: $name, duration: .Durations[$name], status: "Failed"}),
-          (.SkippedTests[]? as $name | {commit: (.Detail.Details | split(":") | .[0]), date: (.Detail.Details | split(":") | .[1]), environment: .Detail.Name, test: $name, duration: 0, status: "Skipped"}))
-          | .commit + "," + .date + "," + .environment + "," + .test + "," + .status + "," + (.duration | tostring)'
+jq -r '((.PassedTests[]? as $name | {
+          commit: (.Detail.Details | split(":") | .[0]),
+          date: (.Detail.Details | split(":") | .[1]),
+          environment: .Detail.Name,
+          test: $name,
+          duration: .Durations[$name],
+          status: "Passed"}),
+        (.FailedTests[]? as $name | {
+          commit: (.Detail.Details | split(":") | .[0]),
+          date: (.Detail.Details | split(":") | .[1]),
+          environment: .Detail.Name,
+          test: $name,
+          duration: .Durations[$name],
+          status: "Failed"}),
+        (.SkippedTests[]? as $name | {
+          commit: (.Detail.Details | split(":") | .[0]),
+          date: (.Detail.Details | split(":") | .[1]),
+          environment: .Detail.Name,
+          test: $name,
+          duration: 0,
+          status: "Skipped"}))
+        | .commit + ","
+          + .date + ","
+          + .environment + ","
+          + .test + ","
+          + .status + ","
+          + (.duration | tostring)'

--- a/hack/jenkins/test-flake-chart/process_data.sh
+++ b/hack/jenkins/test-flake-chart/process_data.sh
@@ -28,21 +28,21 @@ printf "Commit Hash,Test Date,Environment,Test,Status,Duration\n"
 # 247982745892,2021-06-10,Docker_Linux,TestFunctional,Passed,0.5
 jq -r '((.PassedTests[]? as $name | {
           commit: (.Detail.Details | split(":") | .[0]),
-          date: (.Detail.Details | split(":") | .[1]),
+          date: (.Detail.Details | split(":") | .[1] | if . then . else "0001-01-01" end),
           environment: .Detail.Name,
           test: $name,
           duration: .Durations[$name],
           status: "Passed"}),
         (.FailedTests[]? as $name | {
           commit: (.Detail.Details | split(":") | .[0]),
-          date: (.Detail.Details | split(":") | .[1]),
+          date: (.Detail.Details | split(":") | .[1] | if . then . else "0001-01-01" end),
           environment: .Detail.Name,
           test: $name,
           duration: .Durations[$name],
           status: "Failed"}),
         (.SkippedTests[]? as $name | {
           commit: (.Detail.Details | split(":") | .[0]),
-          date: (.Detail.Details | split(":") | .[1]),
+          date: (.Detail.Details | split(":") | .[1] | if . then . else "0001-01-01" end),
           environment: .Detail.Name,
           test: $name,
           duration: 0,


### PR DESCRIPTION
fixes #12015.

Since no gopogh reports have been uploaded containing the root job id, all job ids are set to 0, so we currently have no averaged data and only a single instance per day. As new master integration tests complete, this chart should become more accurate.

![image](https://user-images.githubusercontent.com/22285953/127069627-e1214158-8e97-46ef-aaa4-cd4e4a5d1864.png)