### PR TITLE
Parse report data correctly in report_flakes

### DIFF
--- a/hack/jenkins/test-flake-chart/report_flakes.sh
+++ b/hack/jenkins/test-flake-chart/report_flakes.sh
@@ -46,7 +46,7 @@ TMP_DATA=$(mktemp)
   | (xargs gsutil ls || true) \
   | xargs gsutil cat \
   | "$DIR/process_data.sh" \
-  | sed -n -r -e "s|[0-9a-f]*,[0-9-]*,([a-zA-Z/_0-9-]*),([a-zA-Z/_0-9-]*),Failed,[.0-9]*|\1:\2|p" \
+  | sed -n -r -e "s|[0-9a-f]*,[0-9-]*,([a-zA-Z/_0-9-]*),([a-zA-Z/_0-9-]*),Failed,[.0-9]*,[a-zA-Z/_0-9-]*,[0-9]*,[.0-9]*|\1:\2|p" \
   | sort \
   > "$TMP_DATA"
 


### PR DESCRIPTION
Report flakes is currently broken, this fixes this by matching the sed script to the number of fields in the data.csv.