### PR TITLE
Add brackets around variable name to prevent scoping problems

### DIFF
--- a/hack/jenkins/common.ps1
+++ b/hack/jenkins/common.ps1
@@ -50,7 +50,7 @@ $elapsed=$ended-$started
 $elapsed=$elapsed/60
 $elapsed=[math]::Round($elapsed, 2)
 
-$gopogh_status=gopogh --in testout.json --out_html testout.html --out_summary testout_summary.json --name "$env:JOB_NAME" -pr $env:MINIKUBE_LOCATION --repo github.com/kubernetes/minikube/ --details "$env:COMMIT:$(Get-Date -Format "yyyy-MM-dd"):$env:ROOT_JOB_ID"
+$gopogh_status=gopogh --in testout.json --out_html testout.html --out_summary testout_summary.json --name "$env:JOB_NAME" -pr $env:MINIKUBE_LOCATION --repo github.com/kubernetes/minikube/ --details "${env:COMMIT}:$(Get-Date -Format "yyyy-MM-dd"):$env:ROOT_JOB_ID"
 
 $failures=echo $gopogh_status | jq '.NumberOfFail'
 $tests=echo $gopogh_status | jq '.NumberOfTests'


### PR DESCRIPTION
Previously, the details field was only containing the date. This is because powershell bad. It was interpreting "$env:COMMIT:" as a variable with no name in the scope of env:COMMIT. Now this is resolved and Windows flake charts will be fixed once this PR is merged and the bad gopogh summaries are deleted.

Before (gopogh summary):
```
"Detail": {
    "Name": "Docker_Windows",
    "Details": "2021-07-28:19730",
    "PR": "master",
    "RepoName": "github.com/kubernetes/minikube/"
}
```
After (gopogh summary):
```
"Detail": {
    "Name": "Docker_Windows",
    "Details": "237498abca8724:2021-07-28:19730",
    "PR": "master",
    "RepoName": "github.com/kubernetes/minikube/"
}
```