### PR TITLE
Build kicbase image for all architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -682,7 +682,7 @@ docker-multi-arch-builder:
 	env $(X_BUILD_ENV) docker buildx rm --builder $(X_DOCKER_BUILDER) || true
 	env $(X_BUILD_ENV) docker buildx create --name $(X_DOCKER_BUILDER) --buildkitd-flags '--debug' || true
 
-KICBASE_ARCH = linux/arm64,linux/amd64
+KICBASE_ARCH = linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x
 KICBASE_IMAGE_GCR ?= $(REGISTRY)/kicbase:$(KIC_VERSION)
 KICBASE_IMAGE_HUB ?= kicbase/stable:$(KIC_VERSION)
 KICBASE_IMAGE_REGISTRIES ?= $(KICBASE_IMAGE_GCR) $(KICBASE_IMAGE_HUB)


### PR DESCRIPTION
Synchronize ALL_ARCH and KICBASE_ARCH

Build release image for all 5 kubernetes arch:

`ALL_ARCH = amd64 arm arm64 ppc64le s390x`

#9762

#11658

Otherwise the minikube binary won't run (with docker)