### PR TITLE
Fix the error output of minikube version --components command

### DIFF
--- a/cmd/minikube/cmd/version.go
+++ b/cmd/minikube/cmd/version.go
@@ -53,13 +53,14 @@ var versionCmd = &cobra.Command{
 			co := mustload.Running(ClusterFlagValue())
 			runner := co.CP.Runner
 			versionCMDS := map[string]*exec.Cmd{
-				"docker":     exec.Command("docker", "version", "--format={{.Client.Version}}"),
+				"docker":     exec.Command("docker", "--version"),
+				"dockerd":    exec.Command("dockerd", "--version"),
 				"containerd": exec.Command("containerd", "--version"),
-				"crio":       exec.Command("crio", "version"),
-				"podman":     exec.Command("sudo", "podman", "version"),
-				"crictl":     exec.Command("sudo", "crictl", "version"),
+				"crio":       exec.Command("crio", "--version"),
+				"podman":     exec.Command("sudo", "podman", "--version"),
+				"crictl":     exec.Command("sudo", "crictl", "--version"),
 				"buildctl":   exec.Command("buildctl", "--version"),
-				"ctr":        exec.Command("sudo", "ctr", "version"),
+				"ctr":        exec.Command("ctr", "--version"),
 				"runc":       exec.Command("runc", "--version"),
 			}
 			for k, v := range versionCMDS {

--- a/cmd/minikube/cmd/version.go
+++ b/cmd/minikube/cmd/version.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"encoding/json"
 	"os/exec"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -86,7 +87,13 @@ var versionCmd = &cobra.Command{
 				if gitCommitID != "" {
 					out.Ln("commit: %v", gitCommitID)
 				}
-				for k, v := range data {
+				keys := make([]string, 0, len(data))
+				for k := range data {
+					keys = append(keys, k)
+				}
+				sort.Strings(keys)
+				for _, k := range keys {
+					v := data[k]
 					// for backward compatibility we keep displaying the old way for these two
 					if k == "minikubeVersion" || k == "commit" {
 						continue

--- a/cmd/minikube/cmd/version.go
+++ b/cmd/minikube/cmd/version.go
@@ -69,7 +69,10 @@ var versionCmd = &cobra.Command{
 					klog.Warningf("error getting %s's version: %v", k, err)
 					data[k] = "error"
 				} else {
-					data[k] = strings.TrimSpace(rr.Stdout.String())
+					version := rr.Stdout.String()
+					// remove extra lines after the version
+					version = strings.Split(version, "\n")[0]
+					data[k] = strings.TrimSpace(version)
 				}
 
 			}


### PR DESCRIPTION
The daemons might not be running, and it was duplicating some of the information.

Also sort the output and remove some of the line noise (especially crio is _awful_ here)

Fixes #12083

Nothing much we can do, about the total lack of formatting of the --version commands. 😔

----

BEFORE
```
minikube version: v1.22.0
commit: a03fbcf166e6f74ef224d4a63be4277d017bb62e

runc:
runc version 1.0.0-rc95
commit: b9ee9c6314599f1b4a7f497e1f1f856fe433d3b7
spec: 1.0.2-dev
go: go1.13.15
libseccomp: 2.5.1

containerd:
containerd containerd.io 1.4.6 d71fcd7d8303cbf684402823e425e9dd2e99285d

podman:
Version:      3.2.2
API Version:  3.2.2
Go Version:   go1.15.2
Built:        Thu Jan  1 00:00:00 1970
OS/Arch:      linux/amd64

crictl:
Version:  0.1.0
RuntimeName:  cri-o
RuntimeVersion:  1.20.3
RuntimeApiVersion:  v1alpha1

docker:
error

crio:
Version:       1.20.3
GitCommit:     50065140109e8dc4b8fd6dc5d2b587e5cb7ed79d
GitTreeState:  clean
BuildDate:     2021-06-03T20:25:45Z
GoVersion:     go1.15.2
Compiler:      gc
Platform:      linux/amd64
Linkmode:      dynamic

buildctl:
buildctl github.com/moby/buildkit v0.8.2 9065b18ba4633c75862befca8188de4338d9f94a

ctr:
error
```

AFTER
```
minikube version: v1.22.0
commit: 6e571d830f76ccc87dd56cf893f50e2e8f8c6306

buildctl:
buildctl github.com/moby/buildkit v0.8.2 9065b18ba4633c75862befca8188de4338d9f94a

containerd:
containerd containerd.io 1.4.6 d71fcd7d8303cbf684402823e425e9dd2e99285d

crictl:
crictl version unknown

crio:
crio version 1.20.3

ctr:
ctr containerd.io 1.4.6

docker:
Docker version 20.10.7, build f0df350

dockerd:
Docker version 20.10.7, build b0f5bc3

podman:
podman version 3.2.2

runc:
runc version 1.0.0-rc95
```
