### PR TITLE
Support Ingress on MacOS, driver docker

### DIFF
--- a/cmd/minikube/cmd/tunnel.go
+++ b/cmd/minikube/cmd/tunnel.go
@@ -86,7 +86,7 @@ var tunnelCmd = &cobra.Command{
 			sshPort := strconv.Itoa(port)
 			sshKey := filepath.Join(localpath.MiniPath(), "machines", cname, "id_rsa")
 
-			kicSSHTunnel := kic.NewSSHTunnel(ctx, sshPort, sshKey, clientset.CoreV1())
+			kicSSHTunnel := kic.NewSSHTunnel(ctx, sshPort, sshKey, clientset.CoreV1(), clientset.NetworkingV1())
 			err = kicSSHTunnel.Start()
 			if err != nil {
 				exit.Error(reason.SvcTunnelStart, "error starting tunnel", err)

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -153,16 +153,8 @@ func EnableOrDisableAddon(cc *config.ClusterConfig, name string, val string) err
 	// to match both ingress and ingress-dns addons
 	if strings.HasPrefix(name, "ingress") && enable {
 		if driver.IsKIC(cc.Driver) {
-			if runtime.GOOS == "windows" {
+			if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
 				out.Styled(style.Tip, `After the addon is enabled, please run "minikube tunnel" and your ingress resources would be available at "127.0.0.1"`)
-			} else if runtime.GOOS != "linux" {
-				exit.Message(reason.Usage, `Due to networking limitations of driver {{.driver_name}} on {{.os_name}}, {{.addon_name}} addon is not supported.
-Alternatively to use this addon you can use a vm-based driver:
-
-	'minikube start --vm=true'
-
-To track the update on this work in progress feature please check:
-https://github.com/kubernetes/minikube/issues/7332`, out.V{"driver_name": cc.Driver, "os_name": runtime.GOOS, "addon_name": name})
 			} else if driver.BareMetal(cc.Driver) {
 				out.WarningT(`Due to networking limitations of driver {{.driver_name}}, {{.addon_name}} addon is not fully supported. Try using a different driver.`,
 					out.V{"driver_name": cc.Driver, "addon_name": name})

--- a/pkg/minikube/out/out.go
+++ b/pkg/minikube/out/out.go
@@ -118,7 +118,7 @@ func Styled(st style.Enum, format string, a ...V) {
 func boxedCommon(printFunc func(format string, a ...interface{}), cfg box.Config, title string, format string, a ...V) {
 	box := box.New(cfg)
 	if !useColor {
-		box.Config.Color = ""
+		box.Config.Color = nil
 	}
 	str := Sprintf(style.None, format, a...)
 	printFunc(box.String(title, strings.TrimSpace(str)))

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -29,7 +29,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -68,7 +67,7 @@ func TestAddons(t *testing.T) {
 		}
 
 		args := append([]string{"start", "-p", profile, "--wait=true", "--memory=4000", "--alsologtostderr", "--addons=registry", "--addons=metrics-server", "--addons=olm", "--addons=volumesnapshots", "--addons=csi-hostpath-driver"}, StartArgs()...)
-		if !NoneDriver() && !(runtime.GOOS == "darwin" && KicDriver()) { // none driver and macos docker driver does not support ingress
+		if !NoneDriver() { // none driver does not support ingress
 			args = append(args, "--addons=ingress")
 		}
 		if !arm64Platform() {
@@ -155,7 +154,7 @@ func TestAddons(t *testing.T) {
 // validateIngressAddon tests the ingress addon by deploying a default nginx pod
 func validateIngressAddon(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
-	if NoneDriver() || (runtime.GOOS == "darwin" && KicDriver()) {
+	if NoneDriver() {
 		t.Skipf("skipping: ingress not supported ")
 	}
 


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

Could you please kindly review this PR?

fixes #7332 

How to use

1. Enable nginx-ingress
    ```
    minikube addons enable ingress
    ```
2. Create a service and ingress
    ```
    kubectl create deployment web --image=gcr.io/google-samples/hello-app:1.0
    kubectl expose deployment web --port=8080
    kubectl apply -f https://k8s.io/examples/service/networking/example-ingress.yaml
    ```
3. Add the following line to the bottom of the /etc/hosts file.
    ```
    127.0.0.1 hello-world.info
    ```
4. Create tunnel
    sudo permission will be asked for it. It needs password
    ```
    minikube tunnel
    ```
5. Verify that the Ingress controller is directing traffic:
    ```
    curl hello-world.info
    ````