### PR TITLE
Replace yield iterator with simple await array

### DIFF
--- a/hack/jenkins/test-flake-chart/flake_chart.js
+++ b/hack/jenkins/test-flake-chart/flake_chart.js
@@ -103,9 +103,20 @@ async function loadTestData() {
     throw `Fetched CSV data contains wrong number of fields. Expected: 9. Actual Header: "${header}"`;
   }
 
+  progressBarPrompt.textContent = "Parsing data...";
+  progressBar.setAttribute("max", lines.length);
+
   const testData = [];
   let lineData = ["", "", "", "", "", "", "", "", ""];
   for (let i = 1; i < lines.length; i++) {
+    if (i % 30000 === 0) {
+      await new Promise(resolve => {
+        setTimeout(() => {
+          progressBar.setAttribute("value", i);
+          resolve();
+        });
+      });
+    }
     const line = lines[i];
     let splitLine = line.split(",");
     if (splitLine.length != 9) {


### PR DESCRIPTION
fixes #12110.

Previously, we were using an async generator - this is very slow. Simply awaiting an array and then iterating is much faster. On my machine, on master it takes ~8s to download + parse. With this PR it takes ~3s to download + parse. Also simplified the code and added a progress bar specifically for parsing.