### PR TITLE
Manage caching of HTML/JS/data.csv for public flake rate system

### DIFF
--- a/hack/jenkins/test-flake-chart/flake_chart.html
+++ b/hack/jenkins/test-flake-chart/flake_chart.html
@@ -25,5 +25,9 @@
   <body>
     <div id="chart_div"></div>
   </body>
-  <script src="flake_chart.js"></script>
+  <script>
+    const el = document.createElement('script');
+    el.setAttribute('src', `flake_chart.js?t=${Math.random()}`);
+    document.head.appendChild(el);
+  </script>
 </html>

--- a/hack/jenkins/test-flake-chart/flake_chart.html
+++ b/hack/jenkins/test-flake-chart/flake_chart.html
@@ -1,5 +1,9 @@
 <html>
   <head>
+    <meta http-equiv="CacheControl" content="no-cache, no-store, must-revalidate"/>
+    <meta http-equiv="Pragma" content="no-cache"/>
+    <meta http-equiv="Expires" content="0"/>
+    
     <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
     <script src='https://cdnjs.cloudflare.com/ajax/libs/tablesort/5.2.1/tablesort.min.js'></script>
     <!-- Include sort types you need -->

--- a/hack/jenkins/test-flake-chart/flake_chart.js
+++ b/hack/jenkins/test-flake-chart/flake_chart.js
@@ -75,7 +75,11 @@ const testStatus = {
 }
 
 async function loadTestData() {
-  const response = await fetch("data.csv");
+  const response = await fetch("data.csv", {
+    headers: {
+      "Cache-Control": "max-age=3600,must-revalidate",
+    }
+  });
   if (!response.ok) {
     const responseText = await response.text();
     throw `Failed to fetch data from GCS bucket. Error: ${responseText}`;


### PR DESCRIPTION
fixes #12055.

This disables caching for HTML+JS, and sets data.csv to be cached for at most an hour before revalidating.