### PR TITLE
Add unpause command under pause in docs

### DIFF
--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -573,6 +573,11 @@ Pause Kubernetes without impacting deployed applications:
 minikube pause
 ```
 
+Unpause a paused instance:
+```shell
+minikube unpause
+```
+
 Halt the cluster:
 
 ```shell


### PR DESCRIPTION
Closes #12130

In the `Manage your cluster` in the `Start` docs we show the user how to pause minikube, but not how to unpause minikube. Now the user won't mistakenly think they have the run `minikube start` again.

![Screen Shot 2021-08-05 at 9 19 46 AM](https://user-images.githubusercontent.com/44844360/128385787-3a2c64f7-e0cc-4bc9-a888-9d0551926db4.png)
