### PR TITLE
Move legacy version selection to its own function so tests are synced

### DIFF
--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -58,6 +58,26 @@ func installRelease(version string) (f *os.File, err error) {
 	return tf, nil
 }
 
+func legacyVersion() string {
+	// Should be a version from the last 6 months
+	version := "v1.6.2"
+	if KicDriver() {
+		if arm64Platform() {
+			// arm64 KIC driver is supported starting from v1.17.0
+			version = "v1.17.0"
+		} else {
+			// v1.8.0 would be selected, but: https://github.com/kubernetes/minikube/issues/8740
+			version = "v1.9.0"
+		}
+	}
+	// the version containerd in ISO was upgraded to 1.4.2
+	// we need it to use runc.v2 plugin
+	if ContainerRuntime() == "containerd" {
+		version = "v1.16.0"
+	}
+	return version
+}
+
 // legacyStartArgs returns the arguments normally used for starting older versions of minikube
 func legacyStartArgs() []string {
 	return strings.Split(strings.ReplaceAll(*startArgs, "--driver", "--vm-driver"), " ")
@@ -76,26 +96,10 @@ func TestRunningBinaryUpgrade(t *testing.T) {
 
 	defer CleanupWithLogs(t, profile, cancel)
 
-	// Should be a version from the last 6 months
-	legacyVersion := "v1.6.2"
-	if KicDriver() {
-		if arm64Platform() {
-			// arm64 KIC driver is supported starting from v1.17.0
-			legacyVersion = "v1.17.0"
-		} else {
-			// v1.8.0 would be selected, but: https://github.com/kubernetes/minikube/issues/8740
-			legacyVersion = "v1.9.0"
-		}
-	}
-	// the version containerd in ISO was upgraded to 1.4.2
-	// we need it to use runc.v2 plugin
-	if ContainerRuntime() == "containerd" {
-		legacyVersion = "v1.16.0"
-	}
-
-	tf, err := installRelease(legacyVersion)
+	desiredLegacyVersion := legacyVersion()
+	tf, err := installRelease(desiredLegacyVersion)
 	if err != nil {
-		t.Fatalf("%s release installation failed: %v", legacyVersion, err)
+		t.Fatalf("%s release installation failed: %v", desiredLegacyVersion, err)
 	}
 	defer os.Remove(tf.Name())
 
@@ -127,13 +131,13 @@ func TestRunningBinaryUpgrade(t *testing.T) {
 
 	// Retry up to two times, to allow flakiness for the legacy release
 	if err := retry.Expo(r, 1*time.Second, Minutes(30), 2); err != nil {
-		t.Fatalf("legacy %s start failed: %v", legacyVersion, err)
+		t.Fatalf("legacy %s start failed: %v", desiredLegacyVersion, err)
 	}
 
 	args = append([]string{"start", "-p", profile, "--memory=2200", "--alsologtostderr", "-v=1"}, StartArgs()...)
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
-		t.Fatalf("upgrade from %s to HEAD failed: %s: %v", legacyVersion, rr.Command(), err)
+		t.Fatalf("upgrade from %s to HEAD failed: %s: %v", desiredLegacyVersion, rr.Command(), err)
 	}
 }
 
@@ -150,30 +154,10 @@ func TestStoppedBinaryUpgrade(t *testing.T) {
 
 	defer CleanupWithLogs(t, profile, cancel)
 
-	// Guarantee stopped upgrade compatibility from a release that is at least 1 year old
-	// NOTE: <v1.4.0 does not automatically install a hyperkit/KVM driver
-	legacyVersion := "v1.0.0"
-
-	if KicDriver() {
-		// first release with non-experimental KIC
-		legacyVersion = "v1.8.0"
-		if arm64Platform() {
-			// first release with non-experimental arm64 KIC
-			legacyVersion = "v1.17.0"
-		} else {
-			// v1.8.0 would be selected, but: https://github.com/kubernetes/minikube/issues/8740
-			legacyVersion = "v1.9.0"
-		}
-	}
-	if ContainerRuntime() == "containerd" {
-		// the version containerd in ISO was upgraded to 1.4.2
-		// we need it to use runc.v2 plugin
-		legacyVersion = "v1.16.0"
-	}
-
-	tf, err := installRelease(legacyVersion)
+	desiredLegacyVersion := legacyVersion()
+	tf, err := installRelease(desiredLegacyVersion)
 	if err != nil {
-		t.Fatalf("%s release installation failed: %v", legacyVersion, err)
+		t.Fatalf("%s release installation failed: %v", desiredLegacyVersion, err)
 	}
 	defer os.Remove(tf.Name())
 
@@ -205,7 +189,7 @@ func TestStoppedBinaryUpgrade(t *testing.T) {
 
 	// Retry up to two times, to allow flakiness for the legacy release
 	if err := retry.Expo(r, 1*time.Second, Minutes(30), 2); err != nil {
-		t.Fatalf("legacy %s start failed: %v", legacyVersion, err)
+		t.Fatalf("legacy %s start failed: %v", desiredLegacyVersion, err)
 	}
 
 	rr, err = Run(t, exec.CommandContext(ctx, tf.Name(), "-p", profile, "stop"))
@@ -216,14 +200,14 @@ func TestStoppedBinaryUpgrade(t *testing.T) {
 	args = append([]string{"start", "-p", profile, "--memory=2200", "--alsologtostderr", "-v=1"}, StartArgs()...)
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
-		t.Fatalf("upgrade from %s to HEAD failed: %s: %v", legacyVersion, rr.Command(), err)
+		t.Fatalf("upgrade from %s to HEAD failed: %s: %v", desiredLegacyVersion, rr.Command(), err)
 	}
 
 	t.Run("MinikubeLogs", func(t *testing.T) {
 		args := []string{"logs", "-p", profile}
 		rr, err = Run(t, exec.CommandContext(ctx, Target(), args...))
 		if err != nil {
-			t.Fatalf("`minikube logs` after upgrade to HEAD from %s failed: %v", legacyVersion, err)
+			t.Fatalf("`minikube logs` after upgrade to HEAD from %s failed: %v", desiredLegacyVersion, err)
 		}
 	})
 }


### PR DESCRIPTION
TestStoppedBinaryUpgrade seemed to be out of sync with TestRunningBinaryUpgrade. On my machine, this broke the TestStoppedBinaryUpgrade test (my machine doesn't have virtualbox, so the v1.0.0 minikube didn't have support for any of my drivers). These two tests should be testing with the same version anyway.

This may also fix TestStoppedBinaryUpgrade for integration tests.