### PR TITLE
Make sure to return valid containerd version

### DIFF
--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -146,6 +146,7 @@ func parseContainerdVersion(line string) (string, error) {
 	words := strings.Split(line, " ")
 	if len(words) >= 4 && words[0] == "containerd" {
 		version := strings.Replace(words[2], "v", "", 1)
+		version = strings.SplitN(version, "~", 2)[0]
 		if _, err := semver.Parse(version); err != nil {
 			parts := strings.SplitN(version, "-", 2)
 			return parts[0], nil

--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -140,6 +140,21 @@ func (r *Containerd) Style() style.Enum {
 	return style.Containerd
 }
 
+// parseContainerdVersion parses version from containerd --version
+func parseContainerdVersion(line string) (string, error) {
+	// containerd github.com/containerd/containerd v1.0.0 89623f28b87a6004d4b785663257362d1658a729
+	words := strings.Split(line, " ")
+	if len(words) >= 4 && words[0] == "containerd" {
+		version := strings.Replace(words[2], "v", "", 1)
+		if _, err := semver.Parse(version); err != nil {
+			parts := strings.SplitN(version, "-", 2)
+			return parts[0], nil
+		}
+		return version, nil
+	}
+	return "", fmt.Errorf("unknown version: %q", line)
+}
+
 // Version retrieves the current version of this runtime
 func (r *Containerd) Version() (string, error) {
 	c := exec.Command("containerd", "--version")
@@ -147,12 +162,11 @@ func (r *Containerd) Version() (string, error) {
 	if err != nil {
 		return "", errors.Wrapf(err, "containerd check version.")
 	}
-	// containerd github.com/containerd/containerd v1.2.0 c4446665cb9c30056f4998ed953e6d4ff22c7c39
-	words := strings.Split(rr.Stdout.String(), " ")
-	if len(words) >= 4 && words[0] == "containerd" {
-		return strings.Replace(words[2], "v", "", 1), nil
+	version, err := parseContainerdVersion(rr.Stdout.String())
+	if err != nil {
+		return "", err
 	}
-	return "", fmt.Errorf("unknown version: %q", rr.Stdout.String())
+	return version, nil
 }
 
 // SocketPath returns the path to the socket file for containerd

--- a/pkg/minikube/cruntime/containerd_test.go
+++ b/pkg/minikube/cruntime/containerd_test.go
@@ -40,3 +40,26 @@ func TestAddRepoTagToImageName(t *testing.T) {
 		})
 	}
 }
+
+func TestParseContainerdVersion(t *testing.T) {
+	var tests = []struct {
+		version string
+		want    string
+	}{
+		{"containerd github.com/containerd/containerd v1.2.0 c4446665cb9c30056f4998ed953e6d4ff22c7c39", "1.2.0"},
+		{"containerd github.com/containerd/containerd v1.2.1-rc.0 de1f167ab96338a9f5c2b17347abf84bdf1dd411", "1.2.1-rc.0"},
+		{"containerd github.com/containerd/containerd 1.4.4-0ubuntu1 ", "1.4.4-0ubuntu1"},
+		{"containerd github.com/containerd/containerd 1.5.2-0ubuntu1~21.04.2 ", "1.5.2"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.version, func(t *testing.T) {
+			got, err := parseContainerdVersion(tc.version)
+			if err != nil {
+				t.Fatalf("parse(%s): %v", tc.version, err)
+			}
+			if got != tc.want {
+				t.Errorf("expected version to be: %q but got %q", tc.want, got)
+			}
+		})
+	}
+}

--- a/pkg/minikube/cruntime/containerd_test.go
+++ b/pkg/minikube/cruntime/containerd_test.go
@@ -49,7 +49,8 @@ func TestParseContainerdVersion(t *testing.T) {
 		{"containerd github.com/containerd/containerd v1.2.0 c4446665cb9c30056f4998ed953e6d4ff22c7c39", "1.2.0"},
 		{"containerd github.com/containerd/containerd v1.2.1-rc.0 de1f167ab96338a9f5c2b17347abf84bdf1dd411", "1.2.1-rc.0"},
 		{"containerd github.com/containerd/containerd 1.4.4-0ubuntu1 ", "1.4.4-0ubuntu1"},
-		{"containerd github.com/containerd/containerd 1.5.2-0ubuntu1~21.04.2 ", "1.5.2"},
+		{"containerd github.com/containerd/containerd 1.5.2-0ubuntu1~21.04.2 ", "1.5.2-0ubuntu1"},
+		{"containerd github.com/containerd/containerd 1.5.4~ds1 1.5.4~ds1-1", "1.5.4"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.version, func(t *testing.T) {


### PR DESCRIPTION
For instance ubuntu put their packaging version into it.
Only return the major, minor and patch no in that case.

Closes #12043