### PR TITLE
Fix loading an image from tar failing on existing delete

### DIFF
--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -289,7 +289,7 @@ func validateLoadImageFromFile(ctx context.Context, t *testing.T, profile string
 
 	// save image to file
 	imageFile := "busybox.tar.gz"
-	rr, err := Run(t, exec.CommandContext(ctx, "docker", "save", newImage, "|", "gzip", ">", imageFile))
+	rr, err = Run(t, exec.CommandContext(ctx, "docker", "save", newImage, "|", "gzip", ">", imageFile))
 	if err != nil {
 		t.Fatalf("failed to save image to file: %v\n%s", err, rr.Output())
 	}

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -281,9 +281,16 @@ func validateLoadImageFromFile(ctx context.Context, t *testing.T, profile string
 		t.Fatalf("failed to setup test (pull image): %v\n%s", err, rr.Output())
 	}
 
+	tag := fmt.Sprintf("load-from-file-%s", profile)
+	taggedImage := fmt.Sprintf("docker.io/library/busybox:%s", tag)
+	rr, err = Run(t, exec.CommandContext(ctx, "docker", "tag", busyboxImage, taggedImage))
+	if err != nil {
+		t.Fatalf("failed to setup test (tag image) : %v\n%s", err, rr.Output())
+	}
+
 	// save image to file
 	imageFile := "busybox.tar"
-	rr, err = Run(t, exec.CommandContext(ctx, "docker", "save", "-o", imageFile, busyboxImage))
+	rr, err = Run(t, exec.CommandContext(ctx, "docker", "save", "-o", imageFile, taggedImage))
 	if err != nil {
 		t.Fatalf("failed to save image to file: %v\n%s", err, rr.Output())
 	}
@@ -304,8 +311,8 @@ func validateLoadImageFromFile(ctx context.Context, t *testing.T, profile string
 	if err != nil {
 		t.Fatalf("listing images: %v\n%s", err, rr.Output())
 	}
-	if !strings.Contains(rr.Output(), busyboxImage) {
-		t.Fatalf("expected %s to be loaded into minikube but the image is not there", busyboxImage)
+	if !strings.Contains(rr.Output(), tag) {
+		t.Fatalf("expected %s to be loaded into minikube but the image is not there", taggedImage)
 	}
 }
 

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -281,15 +281,9 @@ func validateLoadImageFromFile(ctx context.Context, t *testing.T, profile string
 		t.Fatalf("failed to setup test (pull image): %v\n%s", err, rr.Output())
 	}
 
-	newImage := fmt.Sprintf("docker.io/library/busybox:load-from-file-%s", profile)
-	rr, err = Run(t, exec.CommandContext(ctx, "docker", "tag", busyboxImage, newImage))
-	if err != nil {
-		t.Fatalf("failed to setup test (tag image) : %v\n%s", err, rr.Output())
-	}
-
 	// save image to file
-	imageFile := "busybox.tar.gz"
-	rr, err = Run(t, exec.CommandContext(ctx, "docker", "save", newImage, "|", "gzip", ">", imageFile))
+	imageFile := "busybox.tar"
+	rr, err = Run(t, exec.CommandContext(ctx, "docker", "save", "-o", imageFile, busyboxImage))
 	if err != nil {
 		t.Fatalf("failed to save image to file: %v\n%s", err, rr.Output())
 	}
@@ -306,12 +300,12 @@ func validateLoadImageFromFile(ctx context.Context, t *testing.T, profile string
 	}
 
 	// make sure the image was correctly loaded
-	rr, err = inspectImage(ctx, t, profile, newImage)
+	rr, err = listImages(ctx, t, profile)
 	if err != nil {
 		t.Fatalf("listing images: %v\n%s", err, rr.Output())
 	}
-	if !strings.Contains(rr.Output(), fmt.Sprintf("busybox:load-from-file-%s", profile)) {
-		t.Fatalf("expected %s to be loaded into minikube but the image is not there", newImage)
+	if !strings.Contains(rr.Output(), busyboxImage) {
+		t.Fatalf("expected %s to be loaded into minikube but the image is not there", busyboxImage)
 	}
 }
 


### PR DESCRIPTION
Fixes #11992

When loading an image from tar using `image load` it would fail trying to delete the existing image because the image name is set to the src of the file, ie. `C:\this_is_a_dir\image.tar.gz` instead of `image:latest` and would fail the delete.

I added a check to compare the src and image name, and if they match, skip the delete as we don't have the actual image name.