### PR TITLE
Image save command

### DIFF
--- a/pkg/minikube/command/command_runner.go
+++ b/pkg/minikube/command/command_runner.go
@@ -75,6 +75,9 @@ type Runner interface {
 	// Copy is a convenience method that runs a command to copy a file
 	Copy(assets.CopyableFile) error
 
+	// CopyFrom is a convenience method that runs a command to copy a file back
+	CopyFrom(assets.CopyableFile) error
+
 	// Remove is a convenience method that runs a command to remove a file
 	Remove(assets.CopyableFile) error
 }

--- a/pkg/minikube/command/exec_runner.go
+++ b/pkg/minikube/command/exec_runner.go
@@ -184,6 +184,24 @@ func (e *execRunner) Copy(f assets.CopyableFile) error {
 	return writeFile(dst, f, os.FileMode(perms))
 }
 
+// CopyFrom copies a file
+func (e *execRunner) CopyFrom(f assets.CopyableFile) error {
+	src := path.Join(f.GetTargetDir(), f.GetTargetName())
+
+	dst := f.GetSourcePath()
+	klog.Infof("cp: %s --> %s (%d bytes)", src, dst, f.GetLength())
+	if f.GetLength() == 0 {
+		klog.Warningf("0 byte asset: %+v", f)
+	}
+
+	perms, err := strconv.ParseInt(f.GetPermissions(), 8, 0)
+	if err != nil || perms > 07777 {
+		return errors.Wrapf(err, "error converting permissions %s to integer", f.GetPermissions())
+	}
+
+	return writeFile(dst, f, os.FileMode(perms))
+}
+
 // Remove removes a file
 func (e *execRunner) Remove(f assets.CopyableFile) error {
 	dst := filepath.Join(f.GetTargetDir(), f.GetTargetName())

--- a/pkg/minikube/command/fake_runner.go
+++ b/pkg/minikube/command/fake_runner.go
@@ -142,6 +142,19 @@ func (f *FakeCommandRunner) Copy(file assets.CopyableFile) error {
 	return nil
 }
 
+func (f *FakeCommandRunner) CopyFrom(file assets.CopyableFile) error {
+	v, ok := f.fileMap.Load(file.GetSourcePath())
+	if !ok {
+		return fmt.Errorf("not found in map")
+	}
+	b := v.(bytes.Buffer)
+	_, err := io.Copy(file, &b)
+	if err != nil {
+		return errors.Wrapf(err, "error writing file: %+v", file)
+	}
+	return nil
+}
+
 // Remove removes the filename, file contents key value pair from the stored map
 func (f *FakeCommandRunner) Remove(file assets.CopyableFile) error {
 	f.fileMap.Delete(file.GetSourcePath())

--- a/pkg/minikube/command/kic_runner.go
+++ b/pkg/minikube/command/kic_runner.go
@@ -204,6 +204,15 @@ func (k *kicRunner) Copy(f assets.CopyableFile) error {
 	return k.copy(tf.Name(), dst)
 }
 
+// CopyFrom copies a file
+func (k *kicRunner) CopyFrom(f assets.CopyableFile) error {
+	src := f.GetTargetPath()
+	dst := f.GetSourcePath()
+
+	klog.Infof("%s (direct): %s --> %s", k.ociBin, src, dst)
+	return k.copyFrom(src, dst)
+}
+
 // tempDirectory returns the directory to use as the temp directory
 // or an empty string if it should use the os default temp directory.
 func tempDirectory(isMinikubeSnap bool, isDockerSnap bool) (string, error) {
@@ -227,6 +236,14 @@ func (k *kicRunner) copy(src string, dst string) error {
 		return copyToPodman(src, fullDest)
 	}
 	return copyToDocker(src, fullDest)
+}
+
+func (k *kicRunner) copyFrom(src string, dst string) error {
+	fullSource := fmt.Sprintf("%s:%s", k.nameOrID, src)
+	if k.ociBin == oci.Podman {
+		return copyToPodman(fullSource, dst)
+	}
+	return copyToDocker(fullSource, dst)
 }
 
 func (k *kicRunner) chmod(dst string, perm string) error {

--- a/pkg/minikube/command/ssh_runner.go
+++ b/pkg/minikube/command/ssh_runner.go
@@ -17,11 +17,14 @@ limitations under the License.
 package command
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"io"
 	"os/exec"
 	"path"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -370,6 +373,85 @@ func (s *SSHRunner) Copy(f assets.CopyableFile) error {
 	out, err := sess.CombinedOutput(scp)
 	if err != nil {
 		return fmt.Errorf("%s: %s\noutput: %s", scp, err, out)
+	}
+	return g.Wait()
+}
+
+// CopyFrom copies a file from the remote over SSH.
+func (s *SSHRunner) CopyFrom(f assets.CopyableFile) error {
+	dst := path.Join(path.Join(f.GetTargetDir(), f.GetTargetName()))
+
+	sess, err := s.session()
+	if err != nil {
+		return errors.Wrap(err, "NewSession")
+	}
+	defer func() {
+		if err := sess.Close(); err != nil {
+			if err != io.EOF {
+				klog.Errorf("session close: %v", err)
+			}
+		}
+	}()
+
+	cmd := exec.Command("stat", "-c", "%s", dst)
+	rr, err := s.RunCmd(cmd)
+	if err != nil {
+		return fmt.Errorf("%s: %v", cmd, err)
+	}
+	length, err := strconv.Atoi(strings.TrimSuffix(rr.Stdout.String(), "\n"))
+	if err != nil {
+		return err
+	}
+	src := f.GetSourcePath()
+	klog.Infof("scp %s --> %s (%d bytes)", dst, src, length)
+	f.SetLength(length)
+
+	r, err := sess.StdoutPipe()
+	if err != nil {
+		return errors.Wrap(err, "StdoutPipe")
+	}
+	w, err := sess.StdinPipe()
+	if err != nil {
+		return errors.Wrap(err, "StdinPipe")
+	}
+	// The scpcmd below *should not* return until all data is copied and the
+	// StdinPipe is closed. But let's use errgroup to make it explicit.
+	var g errgroup.Group
+	var copied int64
+
+	g.Go(func() error {
+		defer w.Close()
+		br := bufio.NewReader(r)
+		fmt.Fprint(w, "\x00")
+		b, err := br.ReadBytes('\n')
+		if err != nil {
+			return errors.Wrap(err, "ReadBytes")
+		}
+		if b[0] != 'C' {
+			return fmt.Errorf("unexpected: %v", b)
+		}
+		fmt.Fprint(w, "\x00")
+
+		copied = 0
+		for copied < int64(length) {
+			n, err := io.CopyN(f, br, int64(length))
+			if err != nil {
+				return errors.Wrap(err, "io.CopyN")
+			}
+			copied += n
+		}
+		fmt.Fprint(w, "\x00")
+		err = sess.Wait()
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	scp := fmt.Sprintf("sudo scp -f %s", f.GetTargetPath())
+	err = sess.Start(scp)
+	if err != nil {
+		return fmt.Errorf("%s: %s", scp, err)
 	}
 	return g.Wait()
 }

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -65,6 +65,8 @@ type CommandRunner interface {
 	WaitCmd(sc *command.StartedCmd) (*command.RunResult, error)
 	// Copy is a convenience method that runs a command to copy a file
 	Copy(assets.CopyableFile) error
+	// CopyFrom is a convenience method that runs a command to copy a file back
+	CopyFrom(assets.CopyableFile) error
 	// Remove is a convenience method that runs a command to remove a file
 	Remove(assets.CopyableFile) error
 }

--- a/pkg/minikube/cruntime/cruntime_test.go
+++ b/pkg/minikube/cruntime/cruntime_test.go
@@ -236,6 +236,10 @@ func (f *FakeRunner) Copy(assets.CopyableFile) error {
 	return nil
 }
 
+func (f *FakeRunner) CopyFrom(assets.CopyableFile) error {
+	return nil
+}
+
 func (f *FakeRunner) Remove(assets.CopyableFile) error {
 	return nil
 }

--- a/pkg/minikube/image/image.go
+++ b/pkg/minikube/image/image.go
@@ -33,10 +33,12 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/daemon"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
 
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/localpath"
 )
 
 const (
@@ -189,6 +191,62 @@ func retrieveRemote(ref name.Reference, p v1.Platform) (v1.Image, error) {
 		klog.Infof("remote lookup for %+v: %v", ref, err)
 	}
 	return img, err
+}
+
+// imagePathInCache returns path in local cache directory
+func imagePathInCache(img string) string {
+	f := filepath.Join(constants.ImageCacheDir, img)
+	f = localpath.SanitizeCacheDir(f)
+	return f
+}
+
+func UploadCachedImage(imgName string) error {
+	tag, err := name.NewTag(imgName, name.WeakValidation)
+	if err != nil {
+		klog.Infof("error parsing image name %s tag %v ", imgName, err)
+		return err
+	}
+	return uploadImage(tag, imagePathInCache(imgName))
+}
+
+func uploadImage(tag name.Tag, p string) error {
+	var err error
+	var img v1.Image
+
+	if !useDaemon && !useRemote {
+		return fmt.Errorf("neither daemon nor remote")
+	}
+
+	img, err = tarball.ImageFromPath(p, &tag)
+	if err != nil {
+		return errors.Wrap(err, "tarball")
+	}
+	ref := name.Reference(tag)
+
+	klog.Infof("uploading image: %+v from: %s", ref, p)
+	if useDaemon {
+		return uploadDaemon(ref, img)
+	}
+	if useRemote {
+		return uploadRemote(ref, img, defaultPlatform)
+	}
+	return nil
+}
+
+func uploadDaemon(ref name.Reference, img v1.Image) error {
+	resp, err := daemon.Write(ref, img)
+	if err != nil {
+		klog.Warningf("daemon load for %s: %v\n%s", ref, err, resp)
+	}
+	return err
+}
+
+func uploadRemote(ref name.Reference, img v1.Image, p v1.Platform) error {
+	err := remote.Write(ref, img, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithPlatform(p))
+	if err != nil {
+		klog.Warningf("remote push for %s: %v", ref, err)
+	}
+	return err
 }
 
 // See https://github.com/kubernetes/minikube/issues/10402

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -317,6 +317,8 @@ var (
 	GuestImageRemove = Kind{ID: "GUEST_IMAGE_REMOVE", ExitCode: ExGuestError}
 	// minikube failed to build an image
 	GuestImageBuild = Kind{ID: "GUEST_IMAGE_BUILD", ExitCode: ExGuestError}
+	// minikube failed to push or save an image
+	GuestImageSave = Kind{ID: "GUEST_IMAGE_SAVE", ExitCode: ExGuestError}
 	// minikube failed to load host
 	GuestLoadHost = Kind{ID: "GUEST_LOAD_HOST", ExitCode: ExGuestError}
 	// minkube failed to create a mount

--- a/site/content/en/docs/commands/image.md
+++ b/site/content/en/docs/commands/image.md
@@ -264,3 +264,51 @@ $ minikube image unload image busybox
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
 ```
 
+## minikube image save
+
+Save a image from minikube
+
+### Synopsis
+
+Save a image from minikube
+
+```shell
+minikube image save IMAGE [ARCHIVE | -] [flags]
+```
+
+### Examples
+
+```
+minikube image save image
+minikube image save image image.tar
+```
+
+### Options
+
+```
+      --daemon   Cache image to docker daemon
+      --remote   Cache image to remote registry
+```
+
+### Options inherited from parent commands
+
+```
+      --add_dir_header                   If true, adds the file directory to the header of the log messages
+      --alsologtostderr                  log to standard error as well as files
+  -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
+  -h, --help                             
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --log_file string                  If non-empty, use this log file
+      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+      --logtostderr                      log to standard error instead of files
+      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level)
+  -p, --profile string                   The name of the minikube VM being used. This can be set to allow having multiple instances of minikube independently. (default "minikube")
+      --skip_headers                     If true, avoid header prefixes in the log messages
+      --skip_log_headers                 If true, avoid headers when opening log files
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+      --user string                      Specifies the user executing the operation. Useful for auditing operations executed by 3rd party tools. Defaults to the operating system username.
+  -v, --v Level                          number for the log level verbosity
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+```
+

--- a/site/content/en/docs/contrib/errorcodes.en.md
+++ b/site/content/en/docs/contrib/errorcodes.en.md
@@ -381,6 +381,9 @@ minikube failed to remove an image
 "GUEST_IMAGE_BUILD" (Exit code ExGuestError)  
 minikube failed to build an image  
 
+"GUEST_IMAGE_SAVE" (Exit code ExGuestError)  
+minikube failed to push or save an image  
+
 "GUEST_LOAD_HOST" (Exit code ExGuestError)  
 minikube failed to load host  
 


### PR DESCRIPTION
Implements the `minikube image save` command:

`minikube --alsologtostderr image load --pull busybox`

`minikube --alsologtostderr image save busybox busybox.tar`

It looks big because of the somewhat silly structure of "machine", and the missing CopyFrom functionality for VM "assets":

`NewFileAsset: busybox.tar -> /var/lib/minikube/images/busybox.tar`

`scp /var/lib/minikube/images/busybox.tar --> busybox.tar (1463808 bytes)`


Closes #11130
