### PR TITLE
Change date range to be relative to the current day

### DIFF
--- a/hack/jenkins/test-flake-chart/compute_flake_rate_test.go
+++ b/hack/jenkins/test-flake-chart/compute_flake_rate_test.go
@@ -51,12 +51,12 @@ func compareEntrySlices(t *testing.T, actualData, expectedData []testEntry, extr
 
 func TestReadData(t *testing.T) {
 	actualData := readData(strings.NewReader(
-		`A,B,C,D,E,F
-		hash,2000-01-01,env1,test1,Passed,1
-		hash,2001-01-01,env2,test2,Failed,0.5
-		hash,,,test1,,0.6
-		hash,2002-01-01,,,Passed,0.9
-		hash,2003-01-01,env3,test3,Passed,2`,
+		`A,B,C,D,E,F,G,H,I
+		hash,2000-01-01,env1,test1,Passed,1,1,1,1
+		hash,2001-01-01,env2,test2,Failed,0.5,,,
+		hash,,,test1,,0.6,,,
+		hash,2002-01-01,,,Passed,0.9,,,
+		hash,2003-01-01,env3,test3,Passed,2,,,`,
 	))
 	expectedData := []testEntry{
 		{
@@ -179,7 +179,7 @@ func TestSplitData(t *testing.T) {
 }
 
 func TestFilterRecentEntries(t *testing.T) {
-	entryE1T1R1, entryE1T1R2, entryE1T1R3, entryE1T1O1, entryE1T1O2 := testEntry{
+	entryE1T1O1, entryE1T1O2, entryE1T1O3, entryE1T1O4, entryE1T1O5 := testEntry{
 		name:        "test1",
 		environment: "env1",
 		date:        simpleDate(2000, 4),
@@ -221,7 +221,7 @@ func TestFilterRecentEntries(t *testing.T) {
 		date:        simpleDate(2001, 1),
 		status:      "Passed",
 	}
-	entryE2T2R1, entryE2T2R2, entryE2T2O1 := testEntry{
+	entryE2T2R1, entryE2T2R2, entryE2T2R3 := testEntry{
 		name:        "test2",
 		environment: "env2",
 		date:        simpleDate(2003, 3),
@@ -241,34 +241,29 @@ func TestFilterRecentEntries(t *testing.T) {
 	actualData := filterRecentEntries(splitEntryMap{
 		"env1": {
 			"test1": {
-				entryE1T1R1,
-				entryE1T1R2,
-				entryE1T1R3,
 				entryE1T1O1,
 				entryE1T1O2,
+				entryE1T1O3,
+				entryE1T1O4,
+				entryE1T1O5,
 			},
 			"test2": {
+				entryE1T2O1,
 				entryE1T2R1,
 				entryE1T2R2,
-				entryE1T2O1,
 			},
 		},
 		"env2": {
 			"test2": {
 				entryE2T2R1,
 				entryE2T2R2,
-				entryE2T2O1,
+				entryE2T2R3,
 			},
 		},
-	}, 2)
+	}, simpleDate(2001, 2))
 
 	expectedData := splitEntryMap{
 		"env1": {
-			"test1": {
-				entryE1T1R1,
-				entryE1T1R2,
-				entryE1T1R3,
-			},
 			"test2": {
 				entryE1T2R1,
 				entryE1T2R2,
@@ -278,6 +273,7 @@ func TestFilterRecentEntries(t *testing.T) {
 			"test2": {
 				entryE2T2R1,
 				entryE2T2R2,
+				entryE2T2R3,
 			},
 		},
 	}

--- a/hack/jenkins/test-flake-chart/report_flakes.sh
+++ b/hack/jenkins/test-flake-chart/report_flakes.sh
@@ -103,7 +103,14 @@ TEST_GOPOGH_LINK_FORMAT='https://storage.googleapis.com/minikube-builds/logs/'${
 # 2) Print a row in the table with the environment, test name, flake rate, and a link to the flake chart for that test.
 # 3) Append these rows to file $TMP_COMMENT.
 head -n "$MAX_REPORTED_TESTS" "$TMP_FAILED_RATES" \
-  | awk '-F[:,]' '{ printf "|[%1$s]('$ENV_CHART_LINK_FORMAT')|%2$s ([gopogh]('$TEST_GOPOGH_LINK_FORMAT'))|%3$s ([chart]('$TEST_CHART_LINK_FORMAT'))|\n", $1, $2, $3 }' \
+  | awk '-F[:,]' '{
+      if ($3 != "n/a") {
+        rate_text = sprintf("%3$s ([chart]('$TEST_CHART_LINK_FORMAT'))", $1, $2, $3)
+      } else {
+        rate_text = $3
+      }
+      printf "|[%1$s]('$ENV_CHART_LINK_FORMAT')|%2$s ([gopogh]('$TEST_GOPOGH_LINK_FORMAT'))|%3$s|\n", $1, $2, rate_text
+    }' \
   >> "$TMP_COMMENT"
 
 # If there are too many failing tests, add an extra row explaining this, and a message after the table.

--- a/hack/jenkins/test-flake-chart/report_flakes.sh
+++ b/hack/jenkins/test-flake-chart/report_flakes.sh
@@ -42,11 +42,15 @@ TMP_DATA=$(mktemp)
 # 5) Filter tests to only include failed tests (and only get their names and environment).
 # 6) Sort by environment, then test name.
 # 7) Store in file $TMP_DATA.
-< "${ENVIRONMENT_LIST}" sed -r "s|^|gs://minikube-builds/logs/${PR_NUMBER}/${ROOT_JOB}/|; s|$|_summary.json|" \
+sed -r "s|^|gs://minikube-builds/logs/${PR_NUMBER}/${ROOT_JOB}/|; s|$|_summary.json|" "${ENVIRONMENT_LIST}" \
   | (xargs gsutil ls || true) \
   | xargs gsutil cat \
   | "$DIR/process_data.sh" \
-  | sed -n -r -e "s|[0-9a-f]*,[0-9-]*,([a-zA-Z/_0-9-]*),([a-zA-Z/_0-9-]*),Failed,[.0-9]*,[a-zA-Z/_0-9-]*,[0-9]*,[.0-9]*|\1:\2|p" \
+  | awk -F, 'NR>1 {
+      if ($5 == "Failed") {
+        printf "%s:%s\n", $3, $4
+      }
+    }' \
   | sort \
   > "$TMP_DATA"
 
@@ -60,7 +64,9 @@ TMP_FAILED_RATES="$TMP_FLAKE_RATES\_filtered"
 # 3) Join the flake rates with the failing tests to only get flake rates of failing tests.
 # 4) Sort failed test flake rates based on the flakiness of that test - stable tests should be first on the list.
 # 5) Store in file $TMP_FAILED_RATES.
-< "$TMP_FLAKE_RATES" sed -n -r -e "s|([a-zA-Z0-9_-]*),([a-zA-Z/0-9_-]*),([.0-9]*),[.0-9]*|\1:\2,\3|p" \
+awk -F, 'NR>1 {
+  printf "%s:%s,%s\n", $1, $2, $3
+}' "$TMP_FLAKE_RATES" \
   | sort -t, -k1,1 \
   | join -t , -j 1 "$TMP_DATA" - \
   | sort -g -t, -k2,2 \
@@ -77,14 +83,14 @@ TMP_COMMENT=$(mktemp)
 printf "These are the flake rates of all failed tests.\n|Environment|Failed Tests|Flake Rate (%%)|\n|---|---|---|\n" > "$TMP_COMMENT"
 
 # Create variables to use for sed command.
-ENV_CHART_LINK_FORMAT="https://storage.googleapis.com/minikube-flake-rate/flake_chart.html?env=\1"
-TEST_CHART_LINK_FORMAT="${ENV_CHART_LINK_FORMAT}\&test=\2"
-TEST_GOPOGH_LINK_FORMAT="https://storage.googleapis.com/minikube-builds/logs/${PR_NUMBER}/${ROOT_JOB}/\1.html#fail_\2"
+ENV_CHART_LINK_FORMAT='https://storage.googleapis.com/minikube-flake-rate/flake_chart.html?env=%1$s'
+TEST_CHART_LINK_FORMAT=${ENV_CHART_LINK_FORMAT}'&test=%2$s'
+TEST_GOPOGH_LINK_FORMAT='https://storage.googleapis.com/minikube-builds/logs/'${PR_NUMBER}'/'${ROOT_JOB}'/%1$s.html#fail_%2$s'
 # 1) Get the first $MAX_REPORTED_TESTS lines.
 # 2) Print a row in the table with the environment, test name, flake rate, and a link to the flake chart for that test.
 # 3) Append these rows to file $TMP_COMMENT.
-< "$TMP_FAILED_RATES" head -n $MAX_REPORTED_TESTS \
-  | sed -n -r -e "s|([a-zA-Z\/0-9_-]*):([a-zA-Z\/0-9_-]*),([.0-9]*)|\|[\1](${ENV_CHART_LINK_FORMAT})\|\2 ([gopogh](${TEST_GOPOGH_LINK_FORMAT}))\|\3 ([chart](${TEST_CHART_LINK_FORMAT}))\||p" \
+head -n "$MAX_REPORTED_TESTS" "$TMP_FAILED_RATES" \
+  | awk '-F[:,]' '{ printf "|[%1$s]('$ENV_CHART_LINK_FORMAT')|%2$s ([gopogh]('$TEST_GOPOGH_LINK_FORMAT'))|%3$s ([chart]('$TEST_CHART_LINK_FORMAT'))|\n", $1, $2, $3 }' \
   >> "$TMP_COMMENT"
 
 # If there are too many failing tests, add an extra row explaining this, and a message after the table.


### PR DESCRIPTION
fixes #12168.

Now the date range is relative to the current day. In addition, in order to allow tests to "dissipate", the flake rate reporting now supports entries with no associated flake rate value.