### PR TITLE
Ping `releases.json` file if `WantUpdateNotification` is false

### DIFF
--- a/pkg/minikube/notify/notify.go
+++ b/pkg/minikube/notify/notify.go
@@ -48,12 +48,12 @@ func MaybePrintUpdateTextFromGithub() {
 }
 
 func maybePrintUpdateText(latestReleasesURL string, betaReleasesURL string, lastUpdatePath string) {
-	if !shouldCheckURLVersion(lastUpdatePath) {
-		return
-	}
 	latestVersion, err := latestVersionFromURL(latestReleasesURL)
 	if err != nil {
 		klog.Warning(err)
+		return
+	}
+	if !shouldCheckURLVersion(lastUpdatePath) {
 		return
 	}
 	localVersion, err := version.GetSemverVersion()


### PR DESCRIPTION
Closes #12177

If `WantUpdateNotification` is set to false, we don't ping the releases.json file. The problem is we use this ping to establish user numbers, so changed order of check to ping the file first.