### PR TITLE
Go back to upstream google/go-containerregistry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -104,7 +104,6 @@ replace (
 	git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
 	github.com/briandowns/spinner => github.com/alonyb/spinner v1.12.7
 	github.com/docker/machine => github.com/machine-drivers/machine v0.7.1-0.20210719174735-6eca26732baa
-	github.com/google/go-containerregistry => github.com/afbjorklund/go-containerregistry v0.4.1-0.20210321165649-761f6f9626b1
 	github.com/samalba/dockerclient => github.com/sayboras/dockerclient v1.0.0
 	k8s.io/api => k8s.io/api v0.21.2
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.21.2

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,6 @@ github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdc
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/VividCortex/godaemon v1.0.0 h1:aHYrScWvgaSOdAoYCdObWXLm+e1rldP9Pwb1ZvuZkQw=
 github.com/VividCortex/godaemon v1.0.0/go.mod h1:hBWe/72KbGt/lb95E+Sh9ersdYbB57Dt6CG66S1YPno=
-github.com/afbjorklund/go-containerregistry v0.4.1-0.20210321165649-761f6f9626b1 h1:AI8EIk8occ3pruhaTpkaQxQGlC1dHx3J9hAtg7t+FLI=
-github.com/afbjorklund/go-containerregistry v0.4.1-0.20210321165649-761f6f9626b1/go.mod h1:Ct15B4yir3PLOP5jsy0GNeYVaIZs/MK/Jz5any1wFW0=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af h1:wVe6/Ea46ZMeNkQjjBW6xcqyQA/j5e0D6GytH95g0gQ=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
@@ -548,6 +546,8 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-containerregistry v0.4.1 h1:Lrcj2AOoZ7WKawsoKAh2O0dH0tBqMW2lTEmozmK4Z3k=
+github.com/google/go-containerregistry v0.4.1/go.mod h1:Ct15B4yir3PLOP5jsy0GNeYVaIZs/MK/Jz5any1wFW0=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-github/v36 v36.0.0 h1:ndCzM616/oijwufI7nBRa+5eZHLldT+4yIB68ib5ogs=

--- a/pkg/minikube/download/image.go
+++ b/pkg/minikube/download/image.go
@@ -289,6 +289,7 @@ func ImageToDaemon(img string) error {
 		errchan <- err
 	}()
 	var update v1.Update
+loop:
 	for {
 		select {
 		case update = <-c:
@@ -299,7 +300,7 @@ func ImageToDaemon(img string) error {
 			if err != nil {
 				return errors.Wrap(err, "writing daemon image")
 			}
-			break
+			break loop
 		}
 	}
 	klog.V(3).Infof("Pulling image %v", ref)

--- a/pkg/minikube/download/image.go
+++ b/pkg/minikube/download/image.go
@@ -121,6 +121,10 @@ func ImageToCache(img string) error {
 	if err != nil {
 		return errors.Wrap(err, "parsing reference")
 	}
+	tag, err := name.NewTag(strings.Split(img, "@")[0])
+	if err != nil {
+		return errors.Wrap(err, "parsing tag")
+	}
 	klog.V(3).Infof("Getting image %v", ref)
 	i, err := remote.Image(ref, remote.WithPlatform(defaultPlatform))
 	if err != nil {
@@ -134,7 +138,7 @@ func ImageToCache(img string) error {
 
 		return errors.Wrap(err, "getting remote image")
 	}
-	klog.V(3).Infof("Writing image %v", ref)
+	klog.V(3).Infof("Writing image %v", tag)
 	errchan := make(chan error)
 	p := pb.Full.Start64(0)
 	fn := strings.Split(ref.Name(), "@")[0]
@@ -150,7 +154,7 @@ func ImageToCache(img string) error {
 	p.SetWidth(79)
 
 	go func() {
-		err = tarball.WriteToFile(f, ref, i, tarball.WithProgress(c))
+		err = tarball.WriteToFile(f, tag, i, tarball.WithProgress(c))
 		errchan <- err
 	}()
 	var update v1.Update
@@ -170,24 +174,25 @@ func ImageToCache(img string) error {
 }
 
 func parseImage(img string) (*name.Tag, name.Reference, error) {
-	digest, err := name.NewDigest(img)
-	if err == nil {
-		tag := digest.Tag()
-		return &tag, digest, nil
-	}
 
-	_, ok := err.(*name.ErrBadName)
-	if !ok {
-		return nil, nil, errors.Wrap(err, "new ref")
-	}
-	// ErrBadName means img contains no digest
-	// It happens if its value is name:tag for example.
-	// In this case we want to give it a second chance and try to parse it one more time using name.NewTag(img)
-	tag, err := name.NewTag(img)
+	var ref name.Reference
+	tag, err := name.NewTag(strings.Split(img, "@")[0])
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to parse image reference")
 	}
-	return &tag, tag, nil
+	digest, err := name.NewDigest(img)
+	if err != nil {
+		_, ok := err.(*name.ErrBadName)
+		if !ok {
+			return nil, nil, errors.Wrap(err, "new ref")
+		}
+		// ErrBadName means img contains no digest
+		// It happens if its value is name:tag for example.
+		ref = tag
+	} else {
+		ref = digest
+	}
+	return &tag, ref, nil
 }
 
 // CacheToDaemon loads image from tarball in the local cache directory to the local docker daemon
@@ -210,7 +215,7 @@ func CacheToDaemon(img string) error {
 		return errors.Wrap(err, "tarball")
 	}
 
-	resp, err := daemon.Write(ref, i)
+	resp, err := daemon.Write(*tag, i)
 	klog.V(2).Infof("response: %s", resp)
 	return err
 }
@@ -240,6 +245,10 @@ func ImageToDaemon(img string) error {
 	if err != nil {
 		return errors.Wrap(err, "parsing reference")
 	}
+	tag, err := name.NewTag(strings.Split(img, "@")[0])
+	if err != nil {
+		return errors.Wrap(err, "parsing tag")
+	}
 
 	if DownloadMock != nil {
 		klog.Infof("Mock download: %s -> daemon", img)
@@ -260,7 +269,7 @@ func ImageToDaemon(img string) error {
 		return errors.Wrap(err, "getting remote image")
 	}
 
-	klog.V(3).Infof("Writing image %v", ref)
+	klog.V(3).Infof("Writing image %v", tag)
 	errchan := make(chan error)
 	p := pb.Full.Start64(0)
 	fn := strings.Split(ref.Name(), "@")[0]
@@ -276,7 +285,7 @@ func ImageToDaemon(img string) error {
 	p.SetWidth(79)
 
 	go func() {
-		_, err = daemon.Write(ref, i, tarball.WithProgress(c))
+		_, err = daemon.Write(tag, i)
 		errchan <- err
 	}()
 	var update v1.Update
@@ -290,7 +299,14 @@ func ImageToDaemon(img string) error {
 			if err != nil {
 				return errors.Wrap(err, "writing daemon image")
 			}
-			return nil
+			break
 		}
 	}
+	klog.V(3).Infof("Pulling image %v", ref)
+	// Pull digest
+	cmd := exec.Command("docker", "pull", "--quiet", img)
+	if _, err := cmd.Output(); err != nil {
+		return errors.Wrap(err, "pulling remote image")
+	}
+	return nil
 }


### PR DESCRIPTION
Do the docker pull (of the manifest and its digest) explicitly,
instead of implicitly in the library. Also, no progress bar.

Pass the digest to the fetch and the tag to the tarball save,
as usual there are _no_ digests used in the tarball files.

----

This is to be able to go back to upstream / unpatched library:

https://github.com/google/go-containerregistry/releases/tag/v0.4.1

Then it can be updated by the dependa bot and its friends...

https://github.com/google/go-containerregistry/releases/tag/v0.6.0