### PR TITLE
WIP: Add vagrant version of the kicbase docker image

### DIFF
--- a/deploy/kicbase/Vagrantfile
+++ b/deploy/kicbase/Vagrantfile
@@ -1,0 +1,77 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Vagrant.configure("2") do |config|
+  # start from ubuntu 20.04, this image is reasonably small as a starting point
+  # for a kubernetes node image, it doesn't contain much we don't need
+  config.vm.box = "ubuntu/focal64"
+
+  config.vm.hostname = "minikube"
+  config.vm.network "private_network", ip: "192.168.50.4"
+
+  config.vm.synced_folder '.', '/vagrant', disabled: true
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.cpus = 2
+    vb.memory = "2048"
+
+    # focal64 bug: https://bugs.launchpad.net/cloud-images/+bug/1829625
+    vb.customize [ "modifyvm", :id, "--uartmode1", "file", File::NULL ]
+  end
+
+  #if Vagrant.has_plugin?("vagrant-cachier")
+  #  config.cache.scope = :box
+  #end
+
+  config.vm.provision "shell", inline: <<-SHELL
+    echo "Installing Packages ..."
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      systemd \
+      conntrack iptables iproute2 ethtool socat util-linux mount ebtables udev kmod \
+      libseccomp2 pigz \
+      bash ca-certificates curl rsync \
+      nfs-common \
+      #EOL
+    echo "Ensuring /etc/kubernetes/manifests"
+    mkdir -p /etc/kubernetes/manifests
+
+    # install system requirements from the regular distro repositories
+    apt-get install -y --no-install-recommends \
+      iputils-ping netcat-openbsd vim-tiny net-tools \
+      lz4 \
+      gnupg \
+      sudo \
+      openssh-server \
+      dnsutils \
+      libglib2.0-0
+      # libglib2.0-0 is required for conmon, which is required for podman
+
+    # install docker
+    echo 'deb https://download.docker.com/linux/ubuntu focal stable' > /etc/apt/sources.list.d/docker.list
+      curl --no-progress-meter -L https://download.docker.com/linux/ubuntu/gpg -o docker.key && \
+      apt-key add - < docker.key && \
+      apt-get update && \
+      apt-get install -y docker-ce docker-ce-cli containerd.io
+
+    # enable docker which is default
+    systemctl enable docker.socket
+
+    # minikube relies on /etc/hosts for control-plane discovery. This prevents nefarious DNS servers from breaking it.
+    sed -ri 's/dns files/files dns/g' /etc/nsswitch.conf
+
+    # add to docker group
+    adduser vagrant docker
+  SHELL
+end

--- a/deploy/kicbase/vagrant.md
+++ b/deploy/kicbase/vagrant.md
@@ -1,0 +1,92 @@
+# Vagrant
+
+_A virtual machine version of KIC._
+
+See <https://www.vagrantup.com/>
+
+Currently only tested with the VirtualBox hypervisor and the Docker container runtime...
+
+Only missing configuration and packages, for other virtualizations systems and runtimes.
+
+## Start the virtual machine
+
+```shell
+vagrant up
+```
+
+uses the [Vagrantfile](Vagrantfile)
+
+```text
+Bringing machine 'default' up with 'virtualbox' provider...
+==> default: Importing base box 'ubuntu/focal64'...
+==> default: Matching MAC address for NAT networking...
+==> default: Checking if box 'ubuntu/focal64' version '20210803.0.0' is up to date...
+==> default: Setting the name of the VM: kicbase_default_1628606177659_66826
+==> default: Clearing any previously set network interfaces...
+==> default: Preparing network interfaces based on configuration...
+    default: Adapter 1: nat
+    default: Adapter 2: hostonly
+==> default: Forwarding ports...
+    default: 22 (guest) => 2222 (host) (adapter 1)
+==> default: Running 'pre-boot' VM customizations...
+==> default: Booting VM...
+==> default: Waiting for machine to boot. This may take a few minutes...
+    default: SSH address: 127.0.0.1:2222
+    default: SSH username: vagrant
+    default: SSH auth method: private key
+    default: 
+    default: Vagrant insecure key detected. Vagrant will automatically replace
+    default: this with a newly generated keypair for better security.
+    default: 
+    default: Inserting generated public key within guest...
+    default: Removing insecure key from the guest if it's present...
+    default: Key inserted! Disconnecting and reconnecting using new SSH key...
+==> default: Machine booted and ready!
+==> default: Checking for guest additions in VM...
+==> default: Setting hostname...
+==> default: Configuring and enabling network interfaces...
+==> default: Running provisioner: shell...
+    default: Running: inline script
+    ...
+    default: Done.
+```
+
+## Access the virtual machine
+
+```shell
+vagrant ssh
+```
+
+Uses ssh tunnel port.
+
+## Start minikube using it
+
+```shell
+minikube start --driver=ssh --native-ssh=false \
+               --ssh-ip-address=192.168.50.4 --ssh-user=vagrant --ssh-port=22 \
+               --ssh-key=$PWD/.vagrant/machines/default/virtualbox/private_key
+```
+
+Use the OpenSSH `ssh` binary, rather than the native Go SSH implementation.
+
+Note: needs the private network (192.168.50.4), not the NAT network (10.0.2.15).
+
+```text
+😄  [vagrant] minikube v1.22.0 on Ubuntu 20.04
+✨  Using the ssh driver based on user configuration
+👍  Starting control plane node vagrant in cluster vagrant
+🔗  Running remotely (CPUs=2, Memory=1987MB, Disk=39643MB) ...
+🐳  Preparing Kubernetes v1.21.2 on Docker 20.10.8 ...
+    ▪ Generating certificates and keys ...
+    ▪ Booting up control plane ...
+    ▪ Configuring RBAC rules ...
+🔎  Verifying Kubernetes components...
+    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
+🌟  Enabled addons: storage-provisioner, default-storageclass
+🏄  Done! kubectl is now configured to use "vagrant" cluster and "default" namespace by default
+```
+
+## System information
+
+* OS: Ubuntu 20.04 LTS (`focal`)
+* Box: <https://app.vagrantup.com/ubuntu/boxes/focal64>


### PR DESCRIPTION
Only for VirtualBox and Docker, for now (PoC)

For #9992

This is probably **not** the final solution (running the VM with Vagrant), but allows for testing the OS - rather than a new ISO

https://github.com/kubernetes/community/blob/master/contributors/design-proposals/cluster-lifecycle/local-cluster-ux.md#vagrant

> Since we are targeting a single command install/teardown experience, vagrant needs to be an implementation detail and not be exposed to our users.

The software installation was copied over to the Vagrantfile provisioner from the Dockerfile RUN, so should be the same...