### PR TITLE
test: Increase time waiting for `minikube stop` to complete

### DIFF
--- a/test/integration/scheduled_stop_test.go
+++ b/test/integration/scheduled_stop_test.go
@@ -116,7 +116,7 @@ func TestScheduledStopUnix(t *testing.T) {
 	}
 
 	// wait for stop to complete
-	time.Sleep(15 * time.Second)
+	time.Sleep(25 * time.Second)
 	// make sure minikube timetoStop is not present
 	ensureTimeToStopNotPresent(ctx, t, profile)
 	// make sure minikube status is "Stopped"


### PR DESCRIPTION
The `TestScheduledStopUnix` is flaky, sometimes `minikube stop` takes slightly longer to run and is still in progress while we do `minikube status` which results in the test failing. I increased the timeout before running `minikube status` to stop this flakiness from happening.