### PR TITLE
Print profile driver, container runtime, and Kubernetes version on load

### DIFF
--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 
+	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/minikube/localpath"
 )
 
@@ -171,7 +172,15 @@ func encode(w io.Writer, m MinikubeConfig) error {
 
 // Load loads the Kubernetes and machine config for the current machine
 func Load(profile string, miniHome ...string) (*ClusterConfig, error) {
-	return DefaultLoader.LoadConfigFromFile(profile, miniHome...)
+	cc, err := DefaultLoader.LoadConfigFromFile(profile, miniHome...)
+	if err == nil {
+		klog.Infof("Loaded profile config \"%s\": Driver=%s, ContainerRuntime=%s, KubernetesVersion=%s",
+			profile,
+			cc.Driver,
+			cc.KubernetesConfig.ContainerRuntime,
+			cc.KubernetesConfig.KubernetesVersion)
+	}
+	return cc, err
 }
 
 // Write writes the Kubernetes and machine config for the current machine

--- a/pkg/minikube/config/profile.go
+++ b/pkg/minikube/config/profile.go
@@ -287,7 +287,7 @@ func removeChildNodes(inValidPs []*Profile, nodeNames map[string]bool) (ps []*Pr
 
 // LoadProfile loads type Profile based on its name
 func LoadProfile(name string, miniHome ...string) (*Profile, error) {
-	cfg, err := DefaultLoader.LoadConfigFromFile(name, miniHome...)
+	cfg, err := Load(name, miniHome...)
 	p := &Profile{
 		Name:   name,
 		Config: cfg,


### PR DESCRIPTION
fixes #11977.

Whenever a profile is loaded, some of its settings are printed out. Whenever profiles are listed, this also logs.

Example: `minikube -p mk2 addons enable dashboard --alsologtostderr`
```
... Stuff ...
I0810 13:39:50.012993  195672 config.go:177] Profile "mk2": Driver=docker, ContainerRuntime=docker, KubernetesVersion=v1.21.3
... Stuff ...
```