### PR TITLE
Add `--volumes` to `docker system prune`

### DIFF
--- a/.github/workflows/pr_verified.yaml
+++ b/.github/workflows/pr_verified.yaml
@@ -854,7 +854,7 @@ jobs:
           $docker_running = $?
           }
           Write-Output "Docker is running"
-          docker system prune -f 
+          docker system prune -f --volumes
       - name: Info
         shell: powershell
         run: |
@@ -949,7 +949,7 @@ jobs:
           $docker_running = $?
           }
           Write-Output "Docker is running"
-          docker system prune -f
+          docker system prune -f --volumes
       - name: Info
         continue-on-error: true
         shell: powershell

--- a/hack/jenkins/windows_cleanup_and_reboot_docker.ps1
+++ b/hack/jenkins/windows_cleanup_and_reboot_docker.ps1
@@ -15,6 +15,6 @@ if (Jenkins) {
 	exit 0
 }
 echo "doing it"
-docker system prune --all --force
+docker system prune --all --force --volumes
 Get-Process "*Docker Desktop*" | Stop-Process
 shutdown /r

--- a/hack/jenkins/windows_integration_teardown.ps1
+++ b/hack/jenkins/windows_integration_teardown.ps1
@@ -16,7 +16,7 @@ $test_home="$env:HOMEDRIVE$env:HOMEPATH\minikube-integration"
 
 if ($driver -eq "docker") {
   # Remove unused images and containers
-  docker system prune --all --force
+  docker system prune --all --force --volumes
 
   # Just shutdown Docker, it's safer than anything else
   Get-Process "*Docker Desktop*" | Stop-Process


### PR DESCRIPTION
`docker system prune`: Remove all unused containers, networks, images (both dangling and unreferenced), and optionally, volumes.

Without passing the `--volumes` flag as well, we could get dangling volumes, this will prevent that from happening.