### PR TITLE
Fix test failures occuring in partially-"branching" tests

### DIFF
--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -46,7 +46,7 @@ func TestAddons(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), Minutes(40))
 	defer Cleanup(t, profile, cancel)
 
-	setupFailed := t.Run("Setup", func(t *testing.T) {
+	setupSucceeded := t.Run("Setup", func(t *testing.T) {
 		// We don't need a dummy file is we're on GCE
 		if !detect.IsOnGCE() || detect.IsCloudShell() {
 			// Set an env var to point to our dummy credentials file
@@ -105,7 +105,7 @@ func TestAddons(t *testing.T) {
 		}
 	})
 
-	if setupFailed {
+	if !setupSucceeded {
 		t.Fatalf("Failed setup for addon tests")
 	}
 

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -46,58 +46,60 @@ func TestAddons(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), Minutes(40))
 	defer Cleanup(t, profile, cancel)
 
-	// We don't need a dummy file is we're on GCE
-	if !detect.IsOnGCE() || detect.IsCloudShell() {
-		// Set an env var to point to our dummy credentials file
-		err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", filepath.Join(*testdataDir, "gcp-creds.json"))
-		defer os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
-		if err != nil {
-			t.Fatalf("Failed setting GOOGLE_APPLICATION_CREDENTIALS env var: %v", err)
+	t.Run("Setup", func(t *testing.T) {
+		// We don't need a dummy file is we're on GCE
+		if !detect.IsOnGCE() || detect.IsCloudShell() {
+			// Set an env var to point to our dummy credentials file
+			err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", filepath.Join(*testdataDir, "gcp-creds.json"))
+			defer os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
+			if err != nil {
+				t.Fatalf("Failed setting GOOGLE_APPLICATION_CREDENTIALS env var: %v", err)
+			}
+
+			err = os.Setenv("GOOGLE_CLOUD_PROJECT", "this_is_fake")
+			defer os.Unsetenv("GOOGLE_CLOUD_PROJECT")
+			if err != nil {
+				t.Fatalf("Failed setting GOOGLE_CLOUD_PROJECT env var: %v", err)
+			}
 		}
 
-		err = os.Setenv("GOOGLE_CLOUD_PROJECT", "this_is_fake")
-		defer os.Unsetenv("GOOGLE_CLOUD_PROJECT")
-		if err != nil {
-			t.Fatalf("Failed setting GOOGLE_CLOUD_PROJECT env var: %v", err)
+		args := append([]string{"start", "-p", profile, "--wait=true", "--memory=4000", "--alsologtostderr", "--addons=registry", "--addons=metrics-server", "--addons=olm", "--addons=volumesnapshots", "--addons=csi-hostpath-driver"}, StartArgs()...)
+		if !NoneDriver() && !(runtime.GOOS == "darwin" && KicDriver()) { // none driver and macos docker driver does not support ingress
+			args = append(args, "--addons=ingress")
 		}
-	}
-
-	args := append([]string{"start", "-p", profile, "--wait=true", "--memory=4000", "--alsologtostderr", "--addons=registry", "--addons=metrics-server", "--addons=olm", "--addons=volumesnapshots", "--addons=csi-hostpath-driver"}, StartArgs()...)
-	if !NoneDriver() && !(runtime.GOOS == "darwin" && KicDriver()) { // none driver and macos docker driver does not support ingress
-		args = append(args, "--addons=ingress")
-	}
-	if !arm64Platform() {
-		args = append(args, "--addons=helm-tiller")
-	}
-	if !detect.IsOnGCE() {
-		args = append(args, "--addons=gcp-auth")
-	}
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
-	if err != nil {
-		t.Fatalf("%s failed: %v", rr.Command(), err)
-	}
-
-	// If we're running the integration tests on GCE, which is frequently the case, first check to make sure we exit out properly,
-	// then use force to actually test using creds.
-	if detect.IsOnGCE() {
-		args = []string{"-p", profile, "addons", "enable", "gcp-auth"}
+		if !arm64Platform() {
+			args = append(args, "--addons=helm-tiller")
+		}
+		if !detect.IsOnGCE() {
+			args = append(args, "--addons=gcp-auth")
+		}
 		rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
-		if err == nil {
-			t.Errorf("Expected error but didn't get one. command %v, output %v", rr.Command(), rr.Output())
-		} else {
-			if !strings.Contains(rr.Output(), "It seems that you are running in GCE") {
-				t.Errorf("Unexpected error message: %v", rr.Output())
+		if err != nil {
+			t.Fatalf("%s failed: %v", rr.Command(), err)
+		}
+
+		// If we're running the integration tests on GCE, which is frequently the case, first check to make sure we exit out properly,
+		// then use force to actually test using creds.
+		if detect.IsOnGCE() {
+			args = []string{"-p", profile, "addons", "enable", "gcp-auth"}
+			rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
+			if err == nil {
+				t.Errorf("Expected error but didn't get one. command %v, output %v", rr.Command(), rr.Output())
 			} else {
-				// ok, use force here since we are in GCE
-				// do not use --force unless absolutely necessary
-				args = append(args, "--force")
-				rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
-				if err != nil {
-					t.Errorf("%s failed: %v", rr.Command(), err)
+				if !strings.Contains(rr.Output(), "It seems that you are running in GCE") {
+					t.Errorf("Unexpected error message: %v", rr.Output())
+				} else {
+					// ok, use force here since we are in GCE
+					// do not use --force unless absolutely necessary
+					args = append(args, "--force")
+					rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
+					if err != nil {
+						t.Errorf("%s failed: %v", rr.Command(), err)
+					}
 				}
 			}
 		}
-	}
+	})
 
 	// Parallelized tests
 	t.Run("parallel", func(t *testing.T) {
@@ -125,19 +127,21 @@ func TestAddons(t *testing.T) {
 		}
 	})
 
-	// Assert that disable/enable works offline
-	rr, err = Run(t, exec.CommandContext(ctx, Target(), "stop", "-p", profile))
-	if err != nil {
-		t.Errorf("failed to stop minikube. args %q : %v", rr.Command(), err)
-	}
-	rr, err = Run(t, exec.CommandContext(ctx, Target(), "addons", "enable", "dashboard", "-p", profile))
-	if err != nil {
-		t.Errorf("failed to enable dashboard addon: args %q : %v", rr.Command(), err)
-	}
-	rr, err = Run(t, exec.CommandContext(ctx, Target(), "addons", "disable", "dashboard", "-p", profile))
-	if err != nil {
-		t.Errorf("failed to disable dashboard addon: args %q : %v", rr.Command(), err)
-	}
+	t.Run("StoppedEnableDisable", func(t *testing.T) {
+		// Assert that disable/enable works offline
+		rr, err := Run(t, exec.CommandContext(ctx, Target(), "stop", "-p", profile))
+		if err != nil {
+			t.Errorf("failed to stop minikube. args %q : %v", rr.Command(), err)
+		}
+		rr, err = Run(t, exec.CommandContext(ctx, Target(), "addons", "enable", "dashboard", "-p", profile))
+		if err != nil {
+			t.Errorf("failed to enable dashboard addon: args %q : %v", rr.Command(), err)
+		}
+		rr, err = Run(t, exec.CommandContext(ctx, Target(), "addons", "disable", "dashboard", "-p", profile))
+		if err != nil {
+			t.Errorf("failed to disable dashboard addon: args %q : %v", rr.Command(), err)
+		}
+	})
 }
 
 // validateIngressAddon tests the ingress addon by deploying a default nginx pod

--- a/test/integration/functional_test_tunnel_test.go
+++ b/test/integration/functional_test_tunnel_test.go
@@ -136,7 +136,7 @@ func validateServiceStable(ctx context.Context, t *testing.T, profile string) {
 		t.Skip("The test WaitService is broken on github actions in macos https://github.com/kubernetes/minikube/issues/8434")
 	}
 	checkRoutePassword(t)
-	setupFailed := t.Run("Setup", func(t *testing.T) {
+	setupSucceeded := t.Run("Setup", func(t *testing.T) {
 		client, err := kapi.Client(profile)
 		if err != nil {
 			t.Fatalf("failed to get Kubernetes client for %q: %v", profile, err)
@@ -155,7 +155,7 @@ func validateServiceStable(ctx context.Context, t *testing.T, profile string) {
 			t.Fatal(errors.Wrap(err, "Error waiting for nginx service to be up"))
 		}
 	})
-	if setupFailed {
+	if !setupSucceeded {
 		t.Fatal("Failed setup")
 	}
 

--- a/test/integration/functional_test_tunnel_test.go
+++ b/test/integration/functional_test_tunnel_test.go
@@ -135,9 +135,8 @@ func validateServiceStable(ctx context.Context, t *testing.T, profile string) {
 	if GithubActionRunner() && runtime.GOOS == "darwin" {
 		t.Skip("The test WaitService is broken on github actions in macos https://github.com/kubernetes/minikube/issues/8434")
 	}
+	checkRoutePassword(t)
 	setupFailed := t.Run("Setup", func(t *testing.T) {
-		checkRoutePassword(t)
-
 		client, err := kapi.Client(profile)
 		if err != nil {
 			t.Fatalf("failed to get Kubernetes client for %q: %v", profile, err)

--- a/test/integration/guest_env_test.go
+++ b/test/integration/guest_env_test.go
@@ -35,11 +35,13 @@ func TestGuestEnvironment(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), Minutes(15))
 	defer CleanupWithLogs(t, profile, cancel)
 
-	args := append([]string{"start", "-p", profile, "--install-addons=false", "--memory=2048", "--wait=false"}, StartArgs()...)
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
-	if err != nil {
-		t.Errorf("failed to start minikube: args %q: %v", rr.Command(), err)
-	}
+	t.Run("Setup", func(t *testing.T) {
+		args := append([]string{"start", "-p", profile, "--install-addons=false", "--memory=2048", "--wait=false"}, StartArgs()...)
+		rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
+		if err != nil {
+			t.Errorf("failed to start minikube: args %q: %v", rr.Command(), err)
+		}
+	})
 
 	// Run as a group so that our defer doesn't happen as tests are runnings
 	t.Run("Binaries", func(t *testing.T) {

--- a/test/integration/json_output_test.go
+++ b/test/integration/json_output_test.go
@@ -55,18 +55,21 @@ func TestJSONOutput(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.command, func(t *testing.T) {
-			args := []string{test.command, "-p", profile, "--output=json", "--user=testUser"}
-			args = append(args, test.args...)
+			var ces []*cloudEvent
+			t.Run("Command", func(t *testing.T) {
+				args := []string{test.command, "-p", profile, "--output=json", "--user=testUser"}
+				args = append(args, test.args...)
 
-			rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
-			if err != nil {
-				t.Errorf("failed to clean up: args %q: %v", rr.Command(), err)
-			}
+				rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
+				if err != nil {
+					t.Errorf("failed to clean up: args %q: %v", rr.Command(), err)
+				}
 
-			ces, err := cloudEvents(t, rr)
-			if err != nil {
-				t.Fatalf("converting to cloud events: %v\n", err)
-			}
+				ces, err = cloudEvents(t, rr)
+				if err != nil {
+					t.Fatalf("converting to cloud events: %v\n", err)
+				}
+			})
 
 			t.Run("Audit", func(t *testing.T) {
 				got, err := auditContains("testUser")


### PR DESCRIPTION
Should drop flake rates of #12206, #12188, #12223.

These are only the partially-branching tests I've been able to spot. A branching test is any test/subtest without any subtests. A partially-branching test is a branching test where a failure could occur outside any of its subtests. This causes incredibly high flake rates for the partially-branching tests even if those tests may pass more of the time. This is because once test2json sees a subtest, it no longer reports the branching test's success. So only failures are reported in partially-branching tests, whereas successes are suppressed, causing 100% flake rates (even if failures are rare).

All tests should avoid containing partially-branching tests. The way I've fixed this here, is to just take any un-wrapped code and put it in a subtest like Setup or whatever better fits.

Note this DOES NOT fix any of the underlying issues for these tests, this will just fix how the errors are reported, giving us a better indication of how often they are failing, and how much of a problem these issues are.
