### PR TITLE
Don't error if we can't retrieve logs from a pod during `minikube logs`

### DIFF
--- a/cmd/minikube/cmd/logs.go
+++ b/cmd/minikube/cmd/logs.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/logs"
 	"k8s.io/minikube/pkg/minikube/mustload"
+	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/reason"
 )
 
@@ -96,7 +97,11 @@ var logsCmd = &cobra.Command{
 			logs.OutputProblems(problems, numberOfProblems, logOutput)
 			return
 		}
-		logs.Output(cr, bs, *co.Config, co.CP.Runner, numberOfLines, logOutput)
+		err = logs.Output(cr, bs, *co.Config, co.CP.Runner, numberOfLines, logOutput)
+		if err != nil {
+			out.Ln("")
+			out.WarningT("{{.error}}", out.V{"error": err})
+		}
 	},
 }
 

--- a/cmd/minikube/cmd/logs.go
+++ b/cmd/minikube/cmd/logs.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/logs"
 	"k8s.io/minikube/pkg/minikube/mustload"
-	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/reason"
 )
 
@@ -97,13 +96,7 @@ var logsCmd = &cobra.Command{
 			logs.OutputProblems(problems, numberOfProblems, logOutput)
 			return
 		}
-		err = logs.Output(cr, bs, *co.Config, co.CP.Runner, numberOfLines, logOutput)
-		if err != nil {
-			out.Ln("")
-			// Avoid exit.Error, since it outputs the issue URL
-			out.WarningT("{{.error}}", out.V{"error": err})
-			os.Exit(reason.ExSvcError)
-		}
+		logs.Output(cr, bs, *co.Config, co.CP.Runner, numberOfLines, logOutput)
 	},
 }
 

--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -163,7 +163,7 @@ func OutputProblems(problems map[string][]string, maxLines int, logOutput *os.Fi
 }
 
 // Output displays logs from multiple sources in tail(1) format
-func Output(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.ClusterConfig, runner command.Runner, lines int, logOutput *os.File) {
+func Output(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.ClusterConfig, runner command.Runner, lines int, logOutput *os.File) error {
 	cmds := logCommands(r, bs, cfg, lines, false)
 	cmds["kernel"] = "uptime && uname -a && grep PRETTY /etc/os-release"
 
@@ -176,6 +176,7 @@ func Output(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.Cluster
 	defer out.SetOutFile(os.Stdout)
 
 	sort.Strings(names)
+	failed := []string{}
 	for i, name := range names {
 		if i > 0 {
 			out.Styled(style.Empty, "")
@@ -187,6 +188,7 @@ func Output(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.Cluster
 		c.Stderr = &b
 		if rr, err := runner.RunCmd(c); err != nil {
 			klog.Errorf("command %s failed with error: %v output: %q", rr.Command(), err, rr.Output())
+			failed = append(failed, name)
 			continue
 		}
 		l := ""
@@ -196,6 +198,11 @@ func Output(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.Cluster
 		}
 		out.Styled(style.Empty, l)
 	}
+
+	if len(failed) > 0 {
+		return fmt.Errorf("unable to fetch logs for: %s", strings.Join(failed, ", "))
+	}
+	return nil
 }
 
 // outputAudit displays the audit logs.

--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -163,7 +163,7 @@ func OutputProblems(problems map[string][]string, maxLines int, logOutput *os.Fi
 }
 
 // Output displays logs from multiple sources in tail(1) format
-func Output(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.ClusterConfig, runner command.Runner, lines int, logOutput *os.File) error {
+func Output(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.ClusterConfig, runner command.Runner, lines int, logOutput *os.File) {
 	cmds := logCommands(r, bs, cfg, lines, false)
 	cmds["kernel"] = "uptime && uname -a && grep PRETTY /etc/os-release"
 
@@ -176,7 +176,6 @@ func Output(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.Cluster
 	defer out.SetOutFile(os.Stdout)
 
 	sort.Strings(names)
-	failed := []string{}
 	for i, name := range names {
 		if i > 0 {
 			out.Styled(style.Empty, "")
@@ -188,8 +187,6 @@ func Output(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.Cluster
 		c.Stderr = &b
 		if rr, err := runner.RunCmd(c); err != nil {
 			klog.Errorf("command %s failed with error: %v output: %q", rr.Command(), err, rr.Output())
-			failed = append(failed, name)
-			continue
 		}
 		l := ""
 		scanner := bufio.NewScanner(&b)
@@ -198,11 +195,6 @@ func Output(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.Cluster
 		}
 		out.Styled(style.Empty, l)
 	}
-
-	if len(failed) > 0 {
-		return fmt.Errorf("unable to fetch logs for: %s", strings.Join(failed, ", "))
-	}
-	return nil
 }
 
 // outputAudit displays the audit logs.

--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -187,6 +187,7 @@ func Output(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.Cluster
 		c.Stderr = &b
 		if rr, err := runner.RunCmd(c); err != nil {
 			klog.Errorf("command %s failed with error: %v output: %q", rr.Command(), err, rr.Output())
+			continue
 		}
 		l := ""
 		scanner := bufio.NewScanner(&b)


### PR DESCRIPTION
Fixes #12128

**Problem:**
If we can't retrieve logs from a pod when running the `minikube logs` command fail, a non-zero exit code is returned.

This doesn't make sense for a few reasons:
1. `minikube logs` is a debugging command, as long as it accurately attempts to retrieve logs shouldn't return an error
2. If we fail to get the last start or audit logs we don't return an error, this change would follow convention

**Solution:**
Stop returning a non-zero exit code if we can't retrieve logs from a pod.