### PR TITLE
Add output parameter to the docker-env none shell

### DIFF
--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -20,6 +20,7 @@ limitations under the License.
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -33,6 +34,7 @@ import (
 	apiWait "k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 	"k8s.io/klog/v2"
 
 	kconst "k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -384,12 +386,94 @@ func dockerSetScript(ec DockerEnvConfig, w io.Writer) error {
 		dockerSetEnvTmpl = dockerEnvTCPTmpl
 	}
 	envVars := dockerEnvVars(ec)
+	if ec.Shell == "none" {
+		switch outputFormat {
+		case "":
+			// shell "none"
+			break
+		case "text":
+			for k, v := range envVars {
+				_, err := fmt.Fprintf(w, "%s=%s\n", k, v)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		case "json":
+			json, err := json.Marshal(envVars)
+			if err != nil {
+				return err
+			}
+			_, err = w.Write(json)
+			if err != nil {
+				return err
+			}
+			_, err = w.Write([]byte{'\n'})
+			if err != nil {
+				return err
+			}
+			return nil
+		case "yaml":
+			yaml, err := yaml.Marshal(envVars)
+			if err != nil {
+				return err
+			}
+			_, err = w.Write(yaml)
+			if err != nil {
+				return err
+			}
+			return nil
+		default:
+			exit.Message(reason.InternalOutputUsage, "error: --output must be 'text', 'yaml' or 'json'")
+		}
+	}
 	return shell.SetScript(ec.EnvConfig, w, dockerSetEnvTmpl, dockerShellCfgSet(ec, envVars))
 }
 
 // dockerSetScript writes out a shell-compatible 'docker-env unset' script
 func dockerUnsetScript(ec DockerEnvConfig, w io.Writer) error {
 	vars := dockerEnvNames(ec)
+	if ec.Shell == "none" {
+		switch outputFormat {
+		case "":
+			// shell "none"
+			break
+		case "text":
+			for _, n := range vars {
+				_, err := fmt.Fprintf(w, "%s\n", n)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		case "json":
+			json, err := json.Marshal(vars)
+			if err != nil {
+				return err
+			}
+			_, err = w.Write(json)
+			if err != nil {
+				return err
+			}
+			_, err = w.Write([]byte{'\n'})
+			if err != nil {
+				return err
+			}
+			return nil
+		case "yaml":
+			yaml, err := yaml.Marshal(vars)
+			if err != nil {
+				return err
+			}
+			_, err = w.Write(yaml)
+			if err != nil {
+				return err
+			}
+			return nil
+		default:
+			exit.Message(reason.InternalOutputUsage, "error: --output must be 'text', 'yaml' or 'json'")
+		}
+	}
 	return shell.UnsetScript(ec.EnvConfig, w, vars)
 }
 
@@ -508,5 +592,6 @@ func init() {
 	dockerEnvCmd.Flags().BoolVar(&sshHost, "ssh-host", false, "Use SSH connection instead of HTTPS (port 2376)")
 	dockerEnvCmd.Flags().BoolVar(&sshAdd, "ssh-add", false, "Add SSH identity key to SSH authentication agent")
 	dockerEnvCmd.Flags().StringVar(&shell.ForceShell, "shell", "", "Force environment to be configured for a specified shell: [fish, cmd, powershell, tcsh, bash, zsh], default is auto-detect")
+	dockerEnvCmd.Flags().StringVarP(&outputFormat, "output", "o", "", "One of 'text', 'yaml' or 'json'.")
 	dockerEnvCmd.Flags().BoolVarP(&dockerUnset, "unset", "u", false, "Unset variables instead of setting them")
 }

--- a/cmd/minikube/cmd/docker-env_test.go
+++ b/cmd/minikube/cmd/docker-env_test.go
@@ -18,10 +18,14 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"gopkg.in/yaml.v2"
 )
 
 type FakeNoProxyGetter struct {
@@ -36,13 +40,16 @@ func (f FakeNoProxyGetter) GetNoProxyVar() (string, string) {
 func TestGenerateDockerScripts(t *testing.T) {
 	var tests = []struct {
 		shell         string
+		output        string
 		config        DockerEnvConfig
 		noProxyGetter *FakeNoProxyGetter
 		wantSet       string
 		wantUnset     string
+		diffOpts      []cmp.Option
 	}{
 		{
 			"bash",
+			"",
 			DockerEnvConfig{profile: "dockerdriver", driver: "docker", hostIP: "127.0.0.1", port: 32842, certsDir: "/certs"},
 			nil,
 			`export DOCKER_TLS_VERIFY="1"
@@ -58,9 +65,11 @@ unset DOCKER_HOST;
 unset DOCKER_CERT_PATH;
 unset MINIKUBE_ACTIVE_DOCKERD;
 `,
+			nil,
 		},
 		{
 			"bash",
+			"",
 			DockerEnvConfig{profile: "dockerdriver", driver: "docker", ssh: true, username: "root", hostname: "host", sshport: 22},
 			nil,
 			`export DOCKER_HOST="ssh://root@host:22"
@@ -74,9 +83,11 @@ unset DOCKER_HOST;
 unset DOCKER_CERT_PATH;
 unset MINIKUBE_ACTIVE_DOCKERD;
 `,
+			nil,
 		},
 		{
 			"bash",
+			"",
 			DockerEnvConfig{profile: "bash", driver: "kvm2", hostIP: "127.0.0.1", port: 2376, certsDir: "/certs"},
 			nil,
 			`export DOCKER_TLS_VERIFY="1"
@@ -92,9 +103,11 @@ unset DOCKER_HOST;
 unset DOCKER_CERT_PATH;
 unset MINIKUBE_ACTIVE_DOCKERD;
 `,
+			nil,
 		},
 		{
 			"bash",
+			"",
 			DockerEnvConfig{profile: "ipv6", driver: "kvm2", hostIP: "fe80::215:5dff:fe00:a903", port: 2376, certsDir: "/certs"},
 			nil,
 			`export DOCKER_TLS_VERIFY="1"
@@ -110,9 +123,11 @@ unset DOCKER_HOST;
 unset DOCKER_CERT_PATH;
 unset MINIKUBE_ACTIVE_DOCKERD;
 `,
+			nil,
 		},
 		{
 			"fish",
+			"",
 			DockerEnvConfig{profile: "fish", driver: "kvm2", hostIP: "127.0.0.1", port: 2376, certsDir: "/certs"},
 			nil,
 			`set -gx DOCKER_TLS_VERIFY "1";
@@ -128,9 +143,11 @@ set -e DOCKER_HOST;
 set -e DOCKER_CERT_PATH;
 set -e MINIKUBE_ACTIVE_DOCKERD;
 `,
+			nil,
 		},
 		{
 			"powershell",
+			"",
 			DockerEnvConfig{profile: "powershell", driver: "hyperv", hostIP: "192.168.0.1", port: 2376, certsDir: "/certs"},
 			nil,
 			`$Env:DOCKER_TLS_VERIFY = "1"
@@ -146,9 +163,11 @@ Remove-Item Env:\\DOCKER_HOST
 Remove-Item Env:\\DOCKER_CERT_PATH
 Remove-Item Env:\\MINIKUBE_ACTIVE_DOCKERD
 `,
+			nil,
 		},
 		{
 			"cmd",
+			"",
 			DockerEnvConfig{profile: "cmd", driver: "hyperv", hostIP: "192.168.0.1", port: 2376, certsDir: "/certs"},
 			nil,
 			`SET DOCKER_TLS_VERIFY=1
@@ -164,9 +183,11 @@ SET DOCKER_HOST=
 SET DOCKER_CERT_PATH=
 SET MINIKUBE_ACTIVE_DOCKERD=
 `,
+			nil,
 		},
 		{
 			"emacs",
+			"",
 			DockerEnvConfig{profile: "emacs", driver: "hyperv", hostIP: "192.168.0.1", port: 2376, certsDir: "/certs"},
 			nil,
 			`(setenv "DOCKER_TLS_VERIFY" "1")
@@ -181,9 +202,11 @@ SET MINIKUBE_ACTIVE_DOCKERD=
 (setenv "DOCKER_CERT_PATH" nil)
 (setenv "MINIKUBE_ACTIVE_DOCKERD" nil)
 `,
+			nil,
 		},
 		{
 			"bash",
+			"",
 			DockerEnvConfig{profile: "bash-no-proxy", driver: "kvm2", hostIP: "127.0.0.1", port: 2376, certsDir: "/certs", noProxy: true},
 			&FakeNoProxyGetter{"NO_PROXY", "127.0.0.1"},
 			`export DOCKER_TLS_VERIFY="1"
@@ -202,9 +225,11 @@ unset DOCKER_CERT_PATH;
 unset MINIKUBE_ACTIVE_DOCKERD;
 unset NO_PROXY;
 `,
+			nil,
 		},
 		{
 			"bash",
+			"",
 			DockerEnvConfig{profile: "bash-no-proxy-lower", driver: "kvm2", hostIP: "127.0.0.1", port: 2376, certsDir: "/certs", noProxy: true},
 			&FakeNoProxyGetter{"no_proxy", "127.0.0.1"},
 			`export DOCKER_TLS_VERIFY="1"
@@ -223,9 +248,11 @@ unset DOCKER_CERT_PATH;
 unset MINIKUBE_ACTIVE_DOCKERD;
 unset no_proxy;
 `,
+			nil,
 		},
 		{
 			"powershell",
+			"",
 			DockerEnvConfig{profile: "powershell-no-proxy-idempotent", driver: "hyperv", hostIP: "192.168.0.1", port: 2376, certsDir: "/certs", noProxy: true},
 			&FakeNoProxyGetter{"no_proxy", "192.168.0.1"},
 			`$Env:DOCKER_TLS_VERIFY = "1"
@@ -243,9 +270,11 @@ Remove-Item Env:\\DOCKER_CERT_PATH
 Remove-Item Env:\\MINIKUBE_ACTIVE_DOCKERD
 Remove-Item Env:\\no_proxy
 `,
+			nil,
 		},
 		{
 			"bash",
+			"",
 			DockerEnvConfig{profile: "sh-no-proxy-add", driver: "kvm2", hostIP: "127.0.0.1", port: 2376, certsDir: "/certs", noProxy: true},
 			&FakeNoProxyGetter{"NO_PROXY", "192.168.0.1,10.0.0.4"},
 			`export DOCKER_TLS_VERIFY="1"
@@ -264,9 +293,11 @@ unset DOCKER_CERT_PATH;
 unset MINIKUBE_ACTIVE_DOCKERD;
 unset NO_PROXY;
 `,
+			nil,
 		},
 		{
 			"none",
+			"",
 			DockerEnvConfig{profile: "noneshell", driver: "docker", hostIP: "127.0.0.1", port: 32842, certsDir: "/certs"},
 			nil,
 			`DOCKER_TLS_VERIFY=1
@@ -279,11 +310,91 @@ DOCKER_HOST
 DOCKER_CERT_PATH
 MINIKUBE_ACTIVE_DOCKERD
 `,
+			nil,
+		},
+		{
+			"none",
+			"text",
+			DockerEnvConfig{profile: "nonetext", driver: "docker", hostIP: "127.0.0.1", port: 32842, certsDir: "/certs"},
+			nil,
+			`DOCKER_TLS_VERIFY=1
+DOCKER_HOST=tcp://127.0.0.1:32842
+DOCKER_CERT_PATH=/certs
+MINIKUBE_ACTIVE_DOCKERD=nonetext
+`,
+			`DOCKER_TLS_VERIFY
+DOCKER_HOST
+DOCKER_CERT_PATH
+MINIKUBE_ACTIVE_DOCKERD
+`,
+			[]cmp.Option{
+				cmpopts.AcyclicTransformer("SplitLines", func(s string) []string {
+					return strings.Split(s, "\n")
+				}),
+				cmpopts.SortSlices(func(a, b string) bool {
+					return a < b
+				}),
+			},
+		},
+		{
+			"none",
+			"json",
+			DockerEnvConfig{profile: "nonejson", driver: "docker", hostIP: "127.0.0.1", port: 32842, certsDir: "/certs"},
+			nil,
+			`{
+				"DOCKER_TLS_VERIFY": "1",
+				"DOCKER_HOST": "tcp://127.0.0.1:32842",
+				"DOCKER_CERT_PATH": "/certs",
+				"MINIKUBE_ACTIVE_DOCKERD": "nonejson"
+			}`,
+			`[
+				"DOCKER_TLS_VERIFY",
+				"DOCKER_HOST",
+				"DOCKER_CERT_PATH",
+				"MINIKUBE_ACTIVE_DOCKERD"
+			]`,
+			[]cmp.Option{
+				cmp.FilterValues(func(x, y string) bool {
+					return json.Valid([]byte(x)) && json.Valid([]byte(y))
+				},
+					cmp.Transformer("ParseJSON", func(in string) (out interface{}) {
+						if err := json.Unmarshal([]byte(in), &out); err != nil {
+							panic(err) // should never occur given previous filter to ensure valid JSON
+						}
+						return out
+					})),
+			},
+		},
+		{
+			"none",
+			"yaml",
+			DockerEnvConfig{profile: "noneyaml", driver: "docker", hostIP: "127.0.0.1", port: 32842, certsDir: "/certs"},
+			nil,
+			`DOCKER_TLS_VERIFY: "1"
+DOCKER_HOST: tcp://127.0.0.1:32842
+DOCKER_CERT_PATH: /certs
+MINIKUBE_ACTIVE_DOCKERD: noneyaml
+`,
+			`- DOCKER_TLS_VERIFY
+- DOCKER_HOST
+- DOCKER_CERT_PATH
+- MINIKUBE_ACTIVE_DOCKERD
+`,
+			[]cmp.Option{
+				cmpopts.AcyclicTransformer("ParseYAML", func(in string) (out interface{}) {
+					if err := yaml.Unmarshal([]byte(in), &out); err != nil {
+						return nil
+					}
+					return out
+				}),
+			},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.config.profile, func(t *testing.T) {
 			tc.config.EnvConfig.Shell = tc.shell
+			// set global variable
+			outputFormat = tc.output
 			defaultNoProxyGetter = tc.noProxyGetter
 			var b []byte
 			buf := bytes.NewBuffer(b)
@@ -291,7 +402,7 @@ MINIKUBE_ACTIVE_DOCKERD
 				t.Errorf("setScript(%+v) error: %v", tc.config, err)
 			}
 			got := buf.String()
-			if diff := cmp.Diff(tc.wantSet, got); diff != "" {
+			if diff := cmp.Diff(tc.wantSet, got, tc.diffOpts...); diff != "" {
 				t.Errorf("setScript(%+v) mismatch (-want +got):\n%s\n\nraw output:\n%s\nquoted: %q", tc.config, diff, got, got)
 			}
 
@@ -300,7 +411,7 @@ MINIKUBE_ACTIVE_DOCKERD
 				t.Errorf("unsetScript(%+v) error: %v", tc.config, err)
 			}
 			got = buf.String()
-			if diff := cmp.Diff(tc.wantUnset, got); diff != "" {
+			if diff := cmp.Diff(tc.wantUnset, got, tc.diffOpts...); diff != "" {
 				t.Errorf("unsetScript(%+v) mismatch (-want +got):\n%s\n\nraw output:\n%s\nquoted: %q", tc.config, diff, got, got)
 			}
 

--- a/site/content/en/docs/commands/docker-env.md
+++ b/site/content/en/docs/commands/docker-env.md
@@ -20,11 +20,12 @@ minikube docker-env [flags]
 ### Options
 
 ```
-      --no-proxy       Add machine IP to NO_PROXY environment variable
-      --shell string   Force environment to be configured for a specified shell: [fish, cmd, powershell, tcsh, bash, zsh], default is auto-detect
-      --ssh-add        Add SSH identity key to SSH authentication agent
-      --ssh-host       Use SSH connection instead of HTTPS (port 2376)
-  -u, --unset          Unset variables instead of setting them
+      --no-proxy        Add machine IP to NO_PROXY environment variable
+  -o, --output string   One of 'text', 'yaml' or 'json'.
+      --shell string    Force environment to be configured for a specified shell: [fish, cmd, powershell, tcsh, bash, zsh], default is auto-detect
+      --ssh-add         Add SSH identity key to SSH authentication agent
+      --ssh-host        Use SSH connection instead of HTTPS (port 2376)
+  -u, --unset           Unset variables instead of setting them
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
```console
$ ./out/minikube docker-env --shell none --output json | jq
{
  "DOCKER_CERT_PATH": "/home/anders/.minikube/certs",
  "DOCKER_HOST": "tcp://192.168.49.2:2376",
  "DOCKER_TLS_VERIFY": "1",
  "MINIKUBE_ACTIVE_DOCKERD": "minikube"
}
```

Closes #12242

The test is actually longer than the code, due to the complexity in comparing maps and arrays in formats without sorting.
