### PR TITLE
fix boilerplate check for time-to-k8s git submodule

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -45,7 +45,7 @@ then
     readonly BDIR="${ROOT_DIR}/hack/boilerplate"
     pushd . >/dev/null
     cd ${BDIR}
-    missing="$(go run boilerplate.go -rootdir ${ROOT_DIR} -boilerplate-dir ${BDIR} | egrep -v '/assets.go|/translations.go|/site/themes/|/site/node_modules|\./out|/hugo/' || true)"
+    missing="$(go run boilerplate.go -rootdir ${ROOT_DIR} -boilerplate-dir ${BDIR} | egrep -v '/assets.go|/translations.go|/site/themes/|/site/node_modules|\./out|/hugo/|hack/benchmark/time-to-k8s/time-to-k8s-repo' || true)"
     if [[ -n "${missing}" ]]; then
         echo "boilerplate missing: $missing"
         echo "consider running: ${BDIR}/fix.sh"


### PR DESCRIPTION
fix makefile test[.sh] / boilerplate check to ignore `time-to-k8s` git submodule

### before
```
❯ make clean && make && make test
rm -rf ./out
rm -f pkg/minikube/assets/assets.go
rm -f pkg/minikube/translate/translations.go
rm -rf ./vendor
rm -rf /tmp/tmp.*.minikube_*
go build  -tags "" -ldflags="-X k8s.io/minikube/pkg/version.version=v1.22.0 -X k8s.io/minikube/pkg/version.isoVersion=v1.22.0-1628622362-12032 -X k8s.io/minikube/pkg/version.gitCommitID="c3c4d0455dfed89650fdf54f9f70d551912b4969" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" -o out/minikube k8s.io/minikube/cmd/minikube
MINIKUBE_LDFLAGS="-X k8s.io/minikube/pkg/version.version=v1.22.0 -X k8s.io/minikube/pkg/version.isoVersion=v1.22.0-1628622362-12032 -X k8s.io/minikube/pkg/version.gitCommitID="c3c4d0455dfed89650fdf54f9f70d551912b4969" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" ./test.sh
= make lint =============================================================
golangci/golangci-lint info checking GitHub for tag 'v1.41.1'
golangci/golangci-lint info found version: 1.41.1 for v1.41.1/linux/amd64
golangci/golangci-lint info installed out/linters/golangci-lint
ok
= go mod ================================================================
ok
= boilerplate ===========================================================
boilerplate missing: /home/prezha/dev/k8s/minikube/github.com/prezha/minikube/hack/benchmark/time-to-k8s/time-to-k8s-repo/time-to-k8s.go
consider running: /home/prezha/dev/k8s/minikube/github.com/prezha/minikube/hack/boilerplate/fix.sh
= schema_check ==========================================================
ok
= go test ===============================================================
ok      k8s.io/minikube/cmd/minikube/cmd        0.151s  coverage: 17.6% of statements
ok      k8s.io/minikube/cmd/minikube/cmd/config 0.050s  coverage: 21.0% of statements
ok      k8s.io/minikube/pkg/addons      0.062s  coverage: 28.6% of statements
ok      k8s.io/minikube/pkg/drivers     0.037s  coverage: 18.9% of statements
ok      k8s.io/minikube/pkg/drivers/hyperkit    0.020s  coverage: 77.3% of statements
ok      k8s.io/minikube/pkg/drivers/kic/oci     6.035s  coverage: 19.0% of statements
ok      k8s.io/minikube/pkg/drivers/kvm 0.035s  coverage: 4.3% of statements
ok      k8s.io/minikube/pkg/minikube/assets     0.061s  coverage: 24.8% of statements
ok      k8s.io/minikube/pkg/minikube/audit      0.048s  coverage: 72.8% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper       0.835s  coverage: 54.3% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper/bsutil        0.185s  coverage: 61.6% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper/bsutil/ktmpl  0.028s  coverage: 100.0% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper/images        0.036s  coverage: 100.0% of statements
ok      k8s.io/minikube/pkg/minikube/cluster    0.065s  coverage: 13.3% of statements
ok      k8s.io/minikube/pkg/minikube/command    0.072s  coverage: 14.2% of statements
ok      k8s.io/minikube/pkg/minikube/config     0.091s  coverage: 71.9% of statements
ok      k8s.io/minikube/pkg/minikube/cruntime   0.078s  coverage: 29.5% of statements
ok      k8s.io/minikube/pkg/minikube/docker     0.087s  coverage: 20.8% of statements
ok      k8s.io/minikube/pkg/minikube/download   1.093s  coverage: 26.2% of statements
ok      k8s.io/minikube/pkg/minikube/driver     0.093s  coverage: 50.7% of statements
ok      k8s.io/minikube/pkg/minikube/driver/auxdriver   0.030s  coverage: 19.0% of statements
ok      k8s.io/minikube/pkg/minikube/extract    0.004s  coverage: 59.5% of statements
ok      k8s.io/minikube/pkg/minikube/image      0.032s  coverage: 6.3% of statements
ok      k8s.io/minikube/pkg/minikube/kubeconfig 0.025s  coverage: 81.5% of statements
ok      k8s.io/minikube/pkg/minikube/localpath  0.012s  coverage: 47.4% of statements
ok      k8s.io/minikube/pkg/minikube/logs       0.055s  coverage: 0.8% of statements
ok      k8s.io/minikube/pkg/minikube/machine    0.062s  coverage: 23.6% of statements
ok      k8s.io/minikube/pkg/minikube/mustload   0.030s  coverage: 10.5% of statements
ok      k8s.io/minikube/pkg/minikube/notify     0.046s  coverage: 84.3% of statements
ok      k8s.io/minikube/pkg/minikube/out        0.048s  coverage: 62.4% of statements
ok      k8s.io/minikube/pkg/minikube/out/register       0.021s  coverage: 55.4% of statements
ok      k8s.io/minikube/pkg/minikube/perf       4.034s  coverage: 21.2% of statements
ok      k8s.io/minikube/pkg/minikube/proxy      0.040s  coverage: 68.7% of statements
ok      k8s.io/minikube/pkg/minikube/reason     0.014s  coverage: 70.0% of statements
ok      k8s.io/minikube/pkg/minikube/registry   0.041s  coverage: 77.0% of statements
ok      k8s.io/minikube/pkg/minikube/registry/drvs/docker       0.027s  coverage: 19.8% of statements
ok      k8s.io/minikube/pkg/minikube/service    0.029s  coverage: 84.2% of statements
ok      k8s.io/minikube/pkg/minikube/shell      0.023s  coverage: 94.3% of statements
ok      k8s.io/minikube/pkg/minikube/storageclass       0.017s  coverage: 100.0% of statements
ok      k8s.io/minikube/pkg/minikube/style      0.021s  coverage: 100.0% of statements
ok      k8s.io/minikube/pkg/minikube/sysinit    0.018s  coverage: 4.5% of statements
ok      k8s.io/minikube/pkg/minikube/translate  0.074s  coverage: 45.5% of statements
ok      k8s.io/minikube/pkg/minikube/tunnel     1.447s  coverage: 63.8% of statements
ok      k8s.io/minikube/pkg/util        0.467s  coverage: 75.7% of statements
ok      k8s.io/minikube/pkg/util/lock   0.022s  coverage: 22.2% of statements
ok      k8s.io/minikube/pkg/util/retry  0.003s  coverage: 0.0% of statements
ok
make: *** [Makefile:378: test] Error 8
```
### after
```
❯ make clean && make && make test
rm -rf ./out
rm -f pkg/minikube/assets/assets.go
rm -f pkg/minikube/translate/translations.go
rm -rf ./vendor
rm -rf /tmp/tmp.*.minikube_*
go build  -tags "" -ldflags="-X k8s.io/minikube/pkg/version.version=v1.22.0 -X k8s.io/minikube/pkg/version.isoVersion=v1.22.0-1628622362-12032 -X k8s.io/minikube/pkg/version.gitCommitID="c3c4d0455dfed89650fdf54f9f70d551912b4969-dirty" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" -o out/minikube k8s.io/minikube/cmd/minikube
MINIKUBE_LDFLAGS="-X k8s.io/minikube/pkg/version.version=v1.22.0 -X k8s.io/minikube/pkg/version.isoVersion=v1.22.0-1628622362-12032 -X k8s.io/minikube/pkg/version.gitCommitID="c3c4d0455dfed89650fdf54f9f70d551912b4969-dirty" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" ./test.sh
= make lint =============================================================
golangci/golangci-lint info checking GitHub for tag 'v1.41.1'
golangci/golangci-lint info found version: 1.41.1 for v1.41.1/linux/amd64
golangci/golangci-lint info installed out/linters/golangci-lint
ok
= go mod ================================================================
ok
= boilerplate ===========================================================
ok
= schema_check ==========================================================
ok
= go test ===============================================================
ok      k8s.io/minikube/cmd/minikube/cmd        0.139s  coverage: 17.6% of statements
ok      k8s.io/minikube/cmd/minikube/cmd/config 0.059s  coverage: 21.0% of statements
ok      k8s.io/minikube/pkg/addons      0.161s  coverage: 28.6% of statements
ok      k8s.io/minikube/pkg/drivers     0.021s  coverage: 18.9% of statements
ok      k8s.io/minikube/pkg/drivers/hyperkit    0.046s  coverage: 77.3% of statements
ok      k8s.io/minikube/pkg/drivers/kic/oci     6.037s  coverage: 19.0% of statements
ok      k8s.io/minikube/pkg/drivers/kvm 0.078s  coverage: 4.3% of statements
ok      k8s.io/minikube/pkg/minikube/assets     0.097s  coverage: 24.8% of statements
ok      k8s.io/minikube/pkg/minikube/audit      0.038s  coverage: 72.8% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper       1.027s  coverage: 54.3% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper/bsutil        0.123s  coverage: 61.6% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper/bsutil/ktmpl  0.033s  coverage: 100.0% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper/images        0.003s  coverage: 100.0% of statements
ok      k8s.io/minikube/pkg/minikube/cluster    0.119s  coverage: 13.3% of statements
ok      k8s.io/minikube/pkg/minikube/command    0.042s  coverage: 14.2% of statements
ok      k8s.io/minikube/pkg/minikube/config     0.043s  coverage: 71.9% of statements
ok      k8s.io/minikube/pkg/minikube/cruntime   0.067s  coverage: 29.5% of statements
ok      k8s.io/minikube/pkg/minikube/docker     0.103s  coverage: 20.8% of statements
ok      k8s.io/minikube/pkg/minikube/download   1.041s  coverage: 26.2% of statements
ok      k8s.io/minikube/pkg/minikube/driver     0.069s  coverage: 50.7% of statements
ok      k8s.io/minikube/pkg/minikube/driver/auxdriver   0.042s  coverage: 19.0% of statements
ok      k8s.io/minikube/pkg/minikube/extract    0.014s  coverage: 59.5% of statements
ok      k8s.io/minikube/pkg/minikube/image      0.046s  coverage: 6.3% of statements
ok      k8s.io/minikube/pkg/minikube/kubeconfig 0.059s  coverage: 81.5% of statements
ok      k8s.io/minikube/pkg/minikube/localpath  0.010s  coverage: 47.4% of statements
ok      k8s.io/minikube/pkg/minikube/logs       0.083s  coverage: 0.8% of statements
ok      k8s.io/minikube/pkg/minikube/machine    0.095s  coverage: 23.6% of statements
ok      k8s.io/minikube/pkg/minikube/mustload   0.030s  coverage: 10.5% of statements
ok      k8s.io/minikube/pkg/minikube/notify     0.035s  coverage: 84.3% of statements
ok      k8s.io/minikube/pkg/minikube/out        0.072s  coverage: 62.4% of statements
ok      k8s.io/minikube/pkg/minikube/out/register       0.022s  coverage: 55.4% of statements
ok      k8s.io/minikube/pkg/minikube/perf       4.015s  coverage: 21.2% of statements
ok      k8s.io/minikube/pkg/minikube/proxy      0.056s  coverage: 68.7% of statements
ok      k8s.io/minikube/pkg/minikube/reason     0.016s  coverage: 70.0% of statements
ok      k8s.io/minikube/pkg/minikube/registry   0.073s  coverage: 77.0% of statements
ok      k8s.io/minikube/pkg/minikube/registry/drvs/docker       0.033s  coverage: 19.8% of statements
ok      k8s.io/minikube/pkg/minikube/service    0.031s  coverage: 84.2% of statements
ok      k8s.io/minikube/pkg/minikube/shell      0.006s  coverage: 94.3% of statements
ok      k8s.io/minikube/pkg/minikube/storageclass       0.017s  coverage: 100.0% of statements
ok      k8s.io/minikube/pkg/minikube/style      0.066s  coverage: 100.0% of statements
ok      k8s.io/minikube/pkg/minikube/sysinit    0.020s  coverage: 4.5% of statements
ok      k8s.io/minikube/pkg/minikube/translate  0.090s  coverage: 45.5% of statements
ok      k8s.io/minikube/pkg/minikube/tunnel     1.426s  coverage: 63.8% of statements
ok      k8s.io/minikube/pkg/util        0.705s  coverage: 75.7% of statements
ok      k8s.io/minikube/pkg/util/lock   0.003s  coverage: 22.2% of statements
ok      k8s.io/minikube/pkg/util/retry  0.002s  coverage: 0.0% of statements
ok
```
