### PR TITLE
Replace Math.min with destructuring with custom array min.

### DIFF
--- a/hack/jenkins/test-flake-chart/flake_chart.js
+++ b/hack/jenkins/test-flake-chart/flake_chart.js
@@ -158,6 +158,14 @@ async function loadTestData() {
   return [testData, responseDate];
 }
 
+Array.prototype.min = function() {
+  return this.reduce((acc, val) => Math.min(acc, val), Number.MAX_VALUE)
+}
+
+Array.prototype.max = function() {
+  return this.reduce((acc, val) => Math.max(acc, val), -Number.MAX_VALUE)
+}
+
 Array.prototype.sum = function() {
   return this.reduce((sum, value) => sum + value, 0);
 };
@@ -297,8 +305,8 @@ function displayTestAndEnvironmentChart(testData, testName, environmentName) {
   }
   {
     const dates = testRuns.map(run => run.date.getTime());
-    const startDate = new Date(Math.min(...dates));
-    const endDate = new Date(Math.max(...dates));
+    const startDate = new Date(dates.min());
+    const endDate = new Date(dates.max());
   
     const weekDates = [];
     let currentDate = startDate;
@@ -502,8 +510,8 @@ function displayEnvironmentChart(testData, environmentName) {
   }
   {
     const dates = testData.map(run => run.date.getTime());
-    const startDate = new Date(Math.min(...dates));
-    const endDate = new Date(Math.max(...dates));
+    const startDate = new Date(dates.min());
+    const endDate = new Date(dates.max());
   
     const weekDates = [];
     let currentDate = startDate;


### PR DESCRIPTION
This was causing a problem on mobile that didn't let the charts be created.

The common suggestion of Math.min(...array), which destructures the array and passes them in as arguments one after another to min, caused a stack overflow, because of course for big arrays this would be a problem! I'm surprised this even worked on desktop seeing how many values we have. In any case, this has been resolved by just "manually" getting the max and min of the array.