### PR TITLE
Use privileged pod security policy for nginx ingress addon

### DIFF
--- a/deploy/addons/ingress/ingress-rbac.yaml.tmpl
+++ b/deploy/addons/ingress/ingress-rbac.yaml.tmpl
@@ -79,7 +79,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ingress-nginx
+  name: ingress-nginx-privileged
   labels:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
@@ -87,11 +87,11 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: ingress-nginx
+  name: psp:privileged
 subjects:
-- kind: ServiceAccount
-  name: ingress-nginx
-  namespace: ingress-nginx
+- kind: Group
+  name: system:serviceaccounts:ingress-nginx
+  apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
This is a quick draft that is intended to be a fix for #11275. Mostly creating this PR to get CI running on it so I don't need to jump through all the hoops locally yet :).

Some open items:

- [ ] This assumes the cluster is using pod security policies, which appears to be a separate addon. Is this acceptable when that addon is not installed in the cluster?
- [ ] Is the privileged policy too permissive? I don't think we have another option unless we venture outside of the new PodSecurity model.
- [ ] Untested outside of my workaround in #11275.