### PR TITLE
Select WSL VM IP when performing mounting

### DIFF
--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -31,6 +31,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/minikube/cluster"
+	"k8s.io/minikube/pkg/minikube/detect"
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/mustload"
@@ -111,7 +112,18 @@ var mountCmd = &cobra.Command{
 		var ip net.IP
 		var err error
 		if mountIP == "" {
-			ip, err = cluster.HostIP(co.CP.Host, co.Config.Name)
+			if detect.IsMicrosoftWSL() {
+				ip, err = func() (net.IP, error) {
+					conn, err := net.Dial("udp", "8.8.8.8:80")
+					defer conn.Close()
+					if err != nil {
+						return nil, err
+					}
+					return conn.LocalAddr().(*net.UDPAddr).IP, nil
+				}()
+			} else {
+				ip, err = cluster.HostIP(co.CP.Host, co.Config.Name)
+			}
 			if err != nil {
 				exit.Error(reason.IfHostIP, "Error getting the host IP address to use from within the VM", err)
 			}

--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -116,10 +116,10 @@ var mountCmd = &cobra.Command{
 				klog.Infof("Selecting IP for WSL. This may be incorrect...")
 				ip, err = func() (net.IP, error) {
 					conn, err := net.Dial("udp", "8.8.8.8:80")
-					defer conn.Close()
 					if err != nil {
 						return nil, err
 					}
+					defer conn.Close()
 					return conn.LocalAddr().(*net.UDPAddr).IP, nil
 				}()
 			} else {

--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -113,6 +113,7 @@ var mountCmd = &cobra.Command{
 		var err error
 		if mountIP == "" {
 			if detect.IsMicrosoftWSL() {
+				klog.Infof("Selecting IP for WSL. This may be incorrect...")
 				ip, err = func() (net.IP, error) {
 					conn, err := net.Dial("udp", "8.8.8.8:80")
 					defer conn.Close()


### PR DESCRIPTION
fixes #12304.

WSL Docker integration makes any WSL minikube instances actually on the main host. This means the cluster HostIP refers to the main Windows instance, not WSL. By getting the WSL IP, the mount correctly accesses WSL and the mounting server.

WSL IP addr:
```
$ ip addr
...
6: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
    link/ether 00:15:5d:19:09:0e brd ff:ff:ff:ff:ff:ff
    inet 172.31.95.230/20 brd 172.31.95.255 scope global eth0
       valid_lft forever preferred_lft forever
    inet6 fe80::215:5dff:fe19:90e/64 scope link
       valid_lft forever preferred_lft forever
```

Before:
```
$ out/minikube mount deploy/addons:/addons
📁  Mounting host path deploy/addons into VM as /addons ...
    ▪ Mount type:
    ▪ User ID:      docker
    ▪ Group ID:     docker
    ▪ Version:      9p2000.L
    ▪ Message Size: 262144
    ▪ Permissions:  755 (-rwxr-xr-x)
    ▪ Options:      map[]
    ▪ Bind Address: 192.168.49.1:42917
🚀  Userspace file server: ufs starting
🛑  Userspace file server is shutdown

❌  Exiting due to GUEST_MOUNT: mount with cmd /bin/bash -c "sudo mount -t 9p -o dfltgid=$(grep ^docker: /etc/group | cut -d: -f3),dfltuid=$(id -u docker),msize=262144,port=42917,trans=tcp,version=9p2000.L 192.168.49.1 /addons" : /bin/bash -c "sudo mount -t 9p -o dfltgid=$(grep ^docker: /etc/group | cut -d: -f3),dfltuid=$(id -u docker),msize=262144,port=42917,trans=tcp,version=9p2000.L 192.168.49.1 /addons": Process exited with status 32
stdout:

stderr:
mount: /addons: mount(2) system call failed: Connection refused.
```
After:
```
$ out/minikube mount deploy/addons:/addons
📁  Mounting host path deploy/addons into VM as /addons ...
    ▪ Mount type:
    ▪ User ID:      docker
    ▪ Group ID:     docker
    ▪ Version:      9p2000.L
    ▪ Message Size: 262144
    ▪ Permissions:  755 (-rwxr-xr-x)
    ▪ Options:      map[]
    ▪ Bind Address: 172.31.95.230:33117
🚀  Userspace file server: ufs starting
✅  Successfully mounted deploy/addons to /addons

📌  NOTE: This process must stay alive for the mount to be accessible ...
```