### PR TITLE
Add kubeadm image versions for kubernetes 1.22

### DIFF
--- a/pkg/minikube/bootstrapper/images/images.go
+++ b/pkg/minikube/bootstrapper/images/images.go
@@ -31,8 +31,11 @@ func Pause(v semver.Version, mirror string) string {
 	// Note: changing this logic requires bumping the preload version
 	// Should match `PauseVersion` in:
 	// https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/constants/constants.go
-	pv := "3.4.1"
+	pv := "3.5"
 	// https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/constants/constants_unix.go
+	if semver.MustParseRange("<1.22.0-alpha.3")(v) {
+		pv = "3.4.1"
+	}
 	if semver.MustParseRange("<1.21.0-alpha.3")(v) {
 		pv = "3.2"
 	}
@@ -71,8 +74,10 @@ func coreDNS(v semver.Version, mirror string) string {
 	if semver.MustParseRange("<1.21.0-alpha.1")(v) {
 		in = "coredns"
 	}
-	cv := "v1.8.0"
+	cv := "v1.8.4"
 	switch v.Minor {
+	case 21:
+		cv = "v1.8.0"
 	case 20, 19:
 		cv = "1.7.0"
 	case 18:
@@ -96,7 +101,7 @@ func etcd(v semver.Version, mirror string) string {
 	// Note: changing this logic requires bumping the preload version
 	// Should match `DefaultEtcdVersion` in:
 	// https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/constants/constants.go
-	ev := "3.4.13-3"
+	ev := "3.5.0-0"
 
 	switch v.Minor {
 	case 19, 20, 21:

--- a/pkg/minikube/bootstrapper/images/images_test.go
+++ b/pkg/minikube/bootstrapper/images/images_test.go
@@ -66,6 +66,15 @@ k8s.gcr.io/pause:3.4.1
 k8s.gcr.io/etcd:3.4.13-0
 k8s.gcr.io/coredns/coredns:v1.8.0
 `, "\n"), "\n")},
+		{"v1.22.0", strings.Split(strings.Trim(`
+k8s.gcr.io/kube-apiserver:v1.22.0
+k8s.gcr.io/kube-controller-manager:v1.22.0
+k8s.gcr.io/kube-scheduler:v1.22.0
+k8s.gcr.io/kube-proxy:v1.22.0
+k8s.gcr.io/pause:3.5
+k8s.gcr.io/etcd:3.5.0-0
+k8s.gcr.io/coredns/coredns:v1.8.4
+`, "\n"), "\n")},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.version, func(t *testing.T) {

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -43,7 +43,7 @@ const (
 	// PreloadVersion is the current version of the preloaded tarball
 	//
 	// NOTE: You may need to bump this version up when upgrading auxiliary docker images
-	PreloadVersion = "v11"
+	PreloadVersion = "v12"
 	// PreloadBucket is the name of the GCS bucket where preloaded volume tarballs exist
 	PreloadBucket = "minikube-preloaded-volume-tarballs"
 )


### PR DESCRIPTION
Again, the images were wrong in the preload

Same as: ~~#11426~~

This leads to duplication, in the 1.22.0 cluster:

```
IMAGE                                     TAG                 IMAGE ID            SIZE
busybox                                   latest              42b97d3c2ae95       1.24MB
gcr.io/k8s-minikube/storage-provisioner   v5                  6e38f40d628db       31.5MB
k8s.gcr.io/coredns/coredns                v1.8.0              296a6d5035e2d       42.5MB
k8s.gcr.io/coredns/coredns                v1.8.4              8d147537fb7d1       47.6MB
k8s.gcr.io/etcd                           3.4.13-3            d1f2268f5826f       253MB
k8s.gcr.io/etcd                           3.5.0-0             0048118155842       295MB
k8s.gcr.io/kube-apiserver                 v1.22.0             838d692cbe28e       128MB
k8s.gcr.io/kube-controller-manager        v1.22.0             5344f96781f4d       122MB
k8s.gcr.io/kube-proxy                     v1.22.0             bbad1636b30d8       104MB
k8s.gcr.io/kube-scheduler                 v1.22.0             3db3d153007f7       52.7MB
k8s.gcr.io/pause                          3.4.1               0f8457a4c2eca       683kB
k8s.gcr.io/pause                          3.5                 ed210e3e4a5ba       683kB
kubernetesui/dashboard                    v2.1.0              9a07b5b4bfac0       226MB
kubernetesui/metrics-scraper              v1.0.4              86262685d9abb       36.9MB
```

Which increases the size by +300MB