### PR TITLE
Add support for tcsh in docker-env subcommand

### DIFF
--- a/pkg/minikube/shell/shell.go
+++ b/pkg/minikube/shell/shell.go
@@ -125,6 +125,17 @@ REM @FOR /f "tokens=*" %%i IN ('%s') DO @%%i
 `, s...)
 		},
 	},
+	"tcsh": {
+		prefix:         "setenv ",
+		suffix:         "\";\n",
+		delimiter:      " \"",
+		unsetPrefix:    "unsetenv ",
+		unsetSuffix:    ";\n",
+		unsetDelimiter: "",
+		usageHint: func(s ...interface{}) string {
+			return fmt.Sprintf("\n: \"%s\"\n: eval `%s`\n", s...)
+		},
+	},
 	"none": {
 		prefix:         "",
 		suffix:         "\n",


### PR DESCRIPTION
fixes #12308.

Result:
```
$ SHELL=tcsh minikube -p minikube docker-env
setenv DOCKER_TLS_VERIFY "1";
setenv DOCKER_HOST "tcp://192.168.50.145:2376";
setenv DOCKER_CERT_PATH "/home/andriydzikh/.minikube/certs";
setenv MINIKUBE_ACTIVE_DOCKERD "minikube";

: "To point your shell to minikube's docker-daemon, run:"
: eval `minikube -p minikube docker-env`
```