### PR TITLE
Add `--extra-disks` capability to kvm2 driver

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -168,7 +168,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().StringP(network, "", "", "network to run minikube with. Now it is used by docker/podman and KVM drivers. If left empty, minikube will create a new network.")
 	startCmd.Flags().StringVarP(&outputFormat, "output", "o", "text", "Format to print stdout in. Options include: [text,json]")
 	startCmd.Flags().StringP(trace, "", "", "Send trace events. Options include: [gcp]")
-	startCmd.Flags().Int(extraDisks, 0, "Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit driver)")
+	startCmd.Flags().Int(extraDisks, 0, "Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit and kvm2 drivers)")
 }
 
 // initKubernetesFlags inits the commandline flags for Kubernetes related options
@@ -730,7 +730,7 @@ func interpretWaitFlag(cmd cobra.Command) map[string]bool {
 }
 
 func checkExtraDiskOptions(cmd *cobra.Command, driverName string) {
-	supportedDrivers := []string{driver.HyperKit}
+	supportedDrivers := []string{driver.HyperKit, driver.KVM2}
 
 	if cmd.Flags().Changed(extraDisks) {
 		supported := false

--- a/pkg/drivers/kvm/disks.go
+++ b/pkg/drivers/kvm/disks.go
@@ -1,0 +1,80 @@
+// +build linux
+
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvm
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"text/template"
+
+	"github.com/docker/machine/libmachine/log"
+	"github.com/pkg/errors"
+	"k8s.io/minikube/pkg/drivers"
+	"k8s.io/minikube/pkg/util"
+)
+
+// extraDisksTmpl ExtraDisks XML Template
+const extraDisksTmpl = `
+<disk type='file' device='disk'>
+  <driver name='qemu' type='raw' cache='default' io='threads' />
+  <source file='{{.DiskPath}}'/>
+  <target dev='{{.DiskLogicalName}}' bus='virtio'/>
+</disk>
+`
+
+// ExtraDisks holds the extra disks configuration
+type ExtraDisks struct {
+	DiskPath        string
+	DiskLogicalName string
+}
+
+// getExtraDiskXML returns the XML that can be added to the libvirt domain XML
+// for additional disks
+func getExtraDiskXML(diskpath string, logicalName string) (string, error) {
+	var extraDisk ExtraDisks
+	extraDisk.DiskLogicalName = logicalName
+	extraDisk.DiskPath = diskpath
+	tmpl := template.Must(template.New("").Parse(extraDisksTmpl))
+	var extraDisksXML bytes.Buffer
+	if err := tmpl.Execute(&extraDisksXML, extraDisk); err != nil {
+		return "", fmt.Errorf("couldn't generate extra disks XML: %v", err)
+	}
+	return extraDisksXML.String(), nil
+}
+
+// createExtraDisks creates the extra disk files
+func createExtraDisk(d *Driver, index int) (string, error) {
+	diskPath := drivers.ExtraDiskPath(d.BaseDriver, index)
+	log.Infof("Creating raw disk image: %s of size %v", diskPath, d.DiskSize)
+
+	if _, err := os.Stat(diskPath); os.IsNotExist(err) {
+		file, err := os.OpenFile(diskPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+		if err != nil {
+			return "", errors.Wrap(err, "open")
+		}
+		defer file.Close()
+
+		if err := file.Truncate(util.ConvertMBToBytes(d.DiskSize)); err != nil {
+			return "", errors.Wrap(err, "truncate")
+		}
+	}
+	return diskPath, nil
+
+}

--- a/pkg/drivers/kvm/domain_definition_arm64.go
+++ b/pkg/drivers/kvm/domain_definition_arm64.go
@@ -77,6 +77,9 @@ const domainTmpl = `
     {{if .GPU}}
     {{.DevicesXML}}
     {{end}}
+    {{if gt .ExtraDisks 0}}
+    {{.ExtraDisksXML}}
+    {{end}}
   </devices>
 </domain>
 `

--- a/pkg/drivers/kvm/domain_definition_x86.go
+++ b/pkg/drivers/kvm/domain_definition_x86.go
@@ -75,6 +75,9 @@ const domainTmpl = `
     {{if .GPU}}
     {{.DevicesXML}}
     {{end}}
+    {{if gt .ExtraDisks 0}}
+    {{.ExtraDisksXML}}
+    {{end}}
   </devices>
 </domain>
 `

--- a/pkg/drivers/kvm/kvm.go
+++ b/pkg/drivers/kvm/kvm.go
@@ -88,6 +88,12 @@ type Driver struct {
 
 	// NUMA XML
 	NUMANodeXML string
+
+	// Extra Disks
+	ExtraDisks int
+
+	// Extra Disks XML
+	ExtraDisksXML []string
 }
 
 const (
@@ -350,6 +356,26 @@ func (d *Driver) Create() (err error) {
 	log.Infof("Building disk image from %s", d.Boot2DockerURL)
 	if err = pkgdrivers.MakeDiskImage(d.BaseDriver, d.Boot2DockerURL, d.DiskSize); err != nil {
 		return errors.Wrap(err, "error creating disk")
+	}
+
+	if d.ExtraDisks > 20 {
+		// Limiting the number of disks to 20 arbitrarily. If more disks are
+		// needed, the logical name generation has to changed to create them if
+		// the form hdaa, hdab, etc
+		return errors.Wrap(err, "cannot create more than 20 extra disks")
+	}
+	for i := 0; i < d.ExtraDisks; i++ {
+		diskpath, err := createExtraDisk(d, i)
+		if err != nil {
+			return errors.Wrap(err, "creating extra disks")
+		}
+		// Starting the logical names for the extra disks from hdd as the cdrom device is set to hdc.
+		// TODO: Enhance the domain template to use variable for the logical name of the main disk and the cdrom disk.
+		extraDisksXML, err := getExtraDiskXML(diskpath, fmt.Sprintf("hd%v", string(rune('d'+i))))
+		if err != nil {
+			return errors.Wrap(err, "creating extraDisk XML")
+		}
+		d.ExtraDisksXML = append(d.ExtraDisksXML, extraDisksXML)
 	}
 
 	if err := ensureDirPermissions(store); err != nil {

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -83,7 +83,7 @@ type ClusterConfig struct {
 	ListenAddress           string   // Only used by the docker and podman driver
 	Network                 string   // only used by docker driver
 	MultiNodeRequested      bool
-	ExtraDisks              int // currently only implemented for hyperkit
+	ExtraDisks              int // currently only implemented for hyperkit and kvm2
 }
 
 // KubernetesConfig contains the parameters used to configure the VM Kubernetes.

--- a/pkg/minikube/registry/drvs/kvm2/kvm2.go
+++ b/pkg/minikube/registry/drvs/kvm2/kvm2.go
@@ -70,6 +70,7 @@ type kvmDriver struct {
 	Hidden         bool
 	ConnectionURI  string
 	NUMANodeCount  int
+	ExtraDisks     int
 }
 
 func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
@@ -92,6 +93,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		Hidden:         cc.KVMHidden,
 		ConnectionURI:  cc.KVMQemuURI,
 		NUMANodeCount:  cc.KVMNUMACount,
+		ExtraDisks:     cc.ExtraDisks,
 	}, nil
 }
 

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -48,7 +48,7 @@ minikube start [flags]
                                           		The key should be '.' separated, and the first part before the dot is the component to apply the configuration to.
                                           		Valid components are: kubelet, kubeadm, apiserver, controller-manager, etcd, proxy, scheduler
                                           		Valid kubeadm parameters: ignore-preflight-errors, dry-run, kubeconfig, kubeconfig-dir, node-name, cri-socket, experimental-upload-certs, certificate-key, rootfs, skip-phases, pod-network-cidr
-      --extra-disks int                   Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit driver)
+      --extra-disks int                   Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit and kvm2 drivers)
       --feature-gates string              A set of key=value pairs that describe feature gates for alpha/experimental features.
       --force                             Force minikube to perform possibly dangerous operations
       --force-systemd                     If set, force the container runtime to use systemd as cgroup manager. Defaults to false.


### PR DESCRIPTION
Having additional disks on the nodes is a requirement for developers
working on the storage components in Kubernetes. This commit adds the
extra-disks feature to the kvm2 driver.

Output:

```
$ minikube start --profile msecondary --driver=kvm2 --network=mk-default --nodes=2 --extra-disks=3 --addons=olm
😄  [msecondary] minikube v1.22.0 on Fedora 34
    ▪ KUBECONFIG=/home/rtalur/.kube/config
✨  Using the kvm2 driver based on user configuration
👍  Starting control plane node msecondary in cluster msecondary
🔥  Creating kvm2 VM (CPUs=4, Memory=16384MB, Disk=20000MB) ...
🐳  Preparing Kubernetes v1.21.3 on Docker 20.10.8 ...
❌  Unable to load cached images: loading cached images: stat /home/rtalur/.minikube/cache/images/docker.io/kubernetesui/dashboard_v2.1.0: no such file or directory
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔗  Configuring CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image quay.io/operator-framework/olm:v0.17.0
    ▪ Using image quay.io/operator-framework/upstream-community-operators:07bbc13
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass, olm

👍  Starting node msecondary-m02 in cluster msecondary
🔥  Creating kvm2 VM (CPUs=4, Memory=16384MB, Disk=20000MB) ...
🌐  Found network options:
    ▪ NO_PROXY=192.168.39.145
🐳  Preparing Kubernetes v1.21.3 on Docker 20.10.8 ...
    ▪ env NO_PROXY=192.168.39.145
🔎  Verifying Kubernetes components...

❗  /home/rtalur/.local/bin/kubectl is version 0.21.0-beta.1, which may have incompatibilites with Kubernetes 1.21.3.
    ▪ Want kubectl v1.21.3? Try 'minikube kubectl -- get pods -A'
🏄  Done! kubectl is now configured to use "msecondary" cluster and "default" namespace by default
```

Devices in the VMs:
```
$ minikube --profile msecondary node list
msecondary      192.168.39.145
msecondary-m02  192.168.39.92
{0} 14:57:31 rtalur@rastartower [~]
$ minikube --profile msecondary ssh -- lsblk
NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
vda    253:0    0 19.5G  0 disk
`-vda1 253:1    0 19.5G  0 part /mnt/vda1
vdb    253:16   0 19.5G  0 disk
vdc    253:32   0 19.5G  0 disk
vdd    253:48   0 19.5G  0 disk
{0} 14:57:43 rtalur@rastartower [~]
$ minikube --profile msecondary ssh --node msecondary-m02 -- lsblk
NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
vda    253:0    0 19.5G  0 disk
`-vda1 253:1    0 19.5G  0 part /mnt/vda1
vdb    253:16   0 19.5G  0 disk
vdc    253:32   0 19.5G  0 disk
vdd    253:48   0 19.5G  0 disk
```

Disk files on the host with the VM running and after the cleanup:
```
$ ls -lash ~/.minikube/machines/msecondary/*.rawdisk
4.0K -rw-r--r--. 1 qemu qemu 20G Aug 25 14:50 /home/rtalur/.minikube/machines/msecondary/msecondary-0.rawdisk
4.0K -rw-r--r--. 1 qemu qemu 20G Aug 25 14:50 /home/rtalur/.minikube/machines/msecondary/msecondary-1.rawdisk
4.0K -rw-r--r--. 1 qemu qemu 20G Aug 25 14:50 /home/rtalur/.minikube/machines/msecondary/msecondary-2.rawdisk
4.0G -rw-r--r--. 1 qemu qemu 20G Aug 25 14:59 /home/rtalur/.minikube/machines/msecondary/msecondary.rawdisk
{0} 14:59:20 rtalur@rastartower [~]
$ minikube --profile msecondary delete
🔥  Deleting "msecondary" in kvm2 ...
🔥  Deleting "msecondary-m02" in kvm2 ...
💀  Removed all traces of the "msecondary" cluster.
{0} 14:59:59 rtalur@rastartower [~]
$ ls -lash ~/.minikube/machines/msecondary/*.rawdisk
ls: cannot access '/home/rtalur/.minikube/machines/msecondary/*.rawdisk': No such file or directory
```
Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>

