### PR TITLE
fix deprecated image in helm addon

### DIFF
--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -467,9 +467,9 @@ var Addons = map[string]*Addon{
 			"helm-tiller-svc.yaml",
 			"0640"),
 	}, false, "helm-tiller", "", map[string]string{
-		"Tiller": "kubernetes-helm/tiller:v2.16.12@sha256:6003775d503546087266eda39418d221f9afb5ccfe35f637c32a1161619a3f9c",
+		"Tiller": "helm/tiller:v2.16.12@sha256:6003775d503546087266eda39418d221f9afb5ccfe35f637c32a1161619a3f9c",
 	}, map[string]string{
-		"Tiller": "gcr.io",
+		"Tiller": "ghcr.io",
 	}),
 	"ingress-dns": NewAddon([]*BinAsset{
 		MustBinAsset(addons.IngressDNSAssets,

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -469,6 +469,8 @@ var Addons = map[string]*Addon{
 	}, false, "helm-tiller", "", map[string]string{
 		"Tiller": "helm/tiller:v2.16.12@sha256:6003775d503546087266eda39418d221f9afb5ccfe35f637c32a1161619a3f9c",
 	}, map[string]string{
+		// GCR is deprecated in helm
+		// https://github.com/helm/helm/issues/10004#issuecomment-894478908
 		"Tiller": "ghcr.io",
 	}),
 	"ingress-dns": NewAddon([]*BinAsset{


### PR DESCRIPTION
closes https://github.com/kubernetes/minikube/issues/12376
Because helm dropped their GCR images:

- https://github.com/helm/helm/issues/8346
- https://github.com/helm/helm/issues/10004#issuecomment-894478908