### PR TITLE
Add crun version report in minikube version

### DIFF
--- a/cmd/minikube/cmd/version.go
+++ b/cmd/minikube/cmd/version.go
@@ -63,6 +63,7 @@ var versionCmd = &cobra.Command{
 				"buildctl":   exec.Command("buildctl", "--version"),
 				"ctr":        exec.Command("ctr", "--version"),
 				"runc":       exec.Command("runc", "--version"),
+				"crun":       exec.Command("crun", "--version"),
 			}
 			for k, v := range versionCMDS {
 				rr, err := runner.RunCmd(v)

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -2137,7 +2137,7 @@ func validateVersionCmd(ctx context.Context, t *testing.T, profile string) {
 			t.Errorf("error version: %v", err)
 		}
 		got := rr.Stdout.String()
-		for _, c := range []string{"buildctl", "commit", "containerd", "crictl", "crio", "ctr", "docker", "minikubeVersion", "podman", "run"} {
+		for _, c := range []string{"buildctl", "commit", "containerd", "crictl", "crio", "ctr", "docker", "minikubeVersion", "podman", "runc", "crun"} {
 			if !strings.Contains(got, c) {
 				t.Errorf("expected to see %q in the minikube version --components but got:\n%s", c, got)
 			}


### PR DESCRIPTION
closes #12027 

### raw
```bash
crun:
crun version 0.20.1.5-925d-dirty
```

### json
```json
{
    "crun": "crun version 0.20.1.5-925d-dirty"
}
```