### PR TITLE
docs: Minikube dashboard remove deprecated port parameter

### DIFF
--- a/site/content/en/docs/commands/dashboard.md
+++ b/site/content/en/docs/commands/dashboard.md
@@ -20,8 +20,7 @@ minikube dashboard [flags]
 ### Options
 
 ```
-      --port int   Exposed port of the proxyfied dashboard. Set to 0 to pick a random port.
-      --url        Display dashboard URL instead of opening a browser
+      --url boolean     Display dashboard URL instead of opening a browser
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
I'm using minikube version 1.22.0  which does not support port param

```
$ minikube version
minikube version: v1.22.0
commit: a03fbcf166e6f74ef224d4a63be4277d017bb62e
```

```
$ minikube dashboard --help
Access the Kubernetes dashboard running within the minikube cluster

Options:
      --url=false: Display dashboard URL instead of opening a browser

Usage:
  minikube dashboard [flags] [options]

Use "minikube options" for a list of global command-line options (applies to all commands).
```

