### PR TITLE
Instructions for adding a dns-server on windows

### DIFF
--- a/site/content/en/docs/handbook/addons/ingress-dns.md
+++ b/site/content/en/docs/handbook/addons/ingress-dns.md
@@ -101,8 +101,15 @@ systemctl restart NetworkManager.service
 Also see `dns=` in [NetworkManager.conf](https://developer.gnome.org/NetworkManager/stable/NetworkManager.conf.html).
 
 #### Windows
+Open `Powershell` as Administrator and execute the following
+```sh
+Add-DnsClientNrptRule -Namespace ".test" -NameServers "$(minikube ip)"
+```
 
-TODO
+The following will remove any matching rules, before creating one. This is helpful if your minikube has a new ip
+```sh
+Get-DnsClientNrptRule | Where-Object {$_.Namespace -eq '.test'} | Remove-DnsClientNrptRule -Force; Add-DnsClientNrptRule -Namespace ".test" -NameServers "$(minikube ip)"
+```
 
 ## Testing
 


### PR DESCRIPTION
The documentation for the ingress-dns addon, is missing instructions for how to add the minikube ip as a dns server on Windows. 

This Pull Request replaces the TODO with instructions

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
