### PR TITLE
Update issue template to ask user to attach log file to issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/__en-US.md
+++ b/.github/ISSUE_TEMPLATE/__en-US.md
@@ -9,7 +9,7 @@ about: Report an issue
 2. 
 3.
 
-**Run `minikube logs --file=logs.txt` and attach the log file to this issue:**
+**Run `minikube logs --file=logs.txt` and drag and drop the log file into this issue**
 
 <!--- TIP: Add the "--alsologtostderr" flag to the command-line for more logs --->
 **Full output of failed command if not `minikube start`:**

--- a/.github/ISSUE_TEMPLATE/__en-US.md
+++ b/.github/ISSUE_TEMPLATE/__en-US.md
@@ -9,14 +9,10 @@ about: Report an issue
 2. 
 3.
 
-**Full output of `minikube logs` command:**
-<details>
-
-
-</details>
+**Run `minikube logs --file=logs.txt` and attach the log file to this issue:**
 
 <!--- TIP: Add the "--alsologtostderr" flag to the command-line for more logs --->
-**Full output of failed command:**
+**Full output of failed command if not `minikube start`:**
 <details>
 
 


### PR DESCRIPTION
Closes #12386

Updates issue template to ask for user to run `minikube logs --file=logs.txt` and attach the log file to the issue.