### PR TITLE
fix coredns image name with custom image repository

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta2.go
+++ b/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta2.go
@@ -59,7 +59,8 @@ certificatesDir: {{.CertDir}}
 clusterName: mk
 controlPlaneEndpoint: {{.ControlPlaneAddress}}:{{.APIServerPort}}
 dns:
-  type: CoreDNS
+  type: CoreDNS{{ if .CoreDNSImageRepository}}
+  imageRepository: {{.CoreDNSImageRepository}}{{end}}
 etcd:
   local:
     dataDir: {{.EtcdDataDir}}

--- a/pkg/minikube/bootstrapper/bsutil/kubeadm.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubeadm.go
@@ -87,28 +87,29 @@ func GenerateKubeadmYAML(cc config.ClusterConfig, n config.Node, r cruntime.Mana
 	klog.Infof("Using pod CIDR: %s", podCIDR)
 
 	opts := struct {
-		CertDir             string
-		ServiceCIDR         string
-		PodSubnet           string
-		AdvertiseAddress    string
-		APIServerPort       int
-		KubernetesVersion   string
-		EtcdDataDir         string
-		EtcdExtraArgs       map[string]string
-		ClusterName         string
-		NodeName            string
-		DNSDomain           string
-		CRISocket           string
-		ImageRepository     string
-		ComponentOptions    []componentOptions
-		FeatureArgs         map[string]bool
-		NoTaintMaster       bool
-		NodeIP              string
-		CgroupDriver        string
-		ClientCAFile        string
-		StaticPodPath       string
-		ControlPlaneAddress string
-		KubeProxyOptions    map[string]string
+		CertDir                string
+		ServiceCIDR            string
+		PodSubnet              string
+		AdvertiseAddress       string
+		APIServerPort          int
+		KubernetesVersion      string
+		EtcdDataDir            string
+		EtcdExtraArgs          map[string]string
+		ClusterName            string
+		NodeName               string
+		DNSDomain              string
+		CRISocket              string
+		ImageRepository        string
+		CoreDNSImageRepository string
+		ComponentOptions       []componentOptions
+		FeatureArgs            map[string]bool
+		NoTaintMaster          bool
+		NodeIP                 string
+		CgroupDriver           string
+		ClientCAFile           string
+		StaticPodPath          string
+		ControlPlaneAddress    string
+		KubeProxyOptions       map[string]string
 	}{
 		CertDir:           vmpath.GuestKubernetesCertsDir,
 		ServiceCIDR:       constants.DefaultServiceCIDR,
@@ -149,6 +150,12 @@ func GenerateKubeadmYAML(cc config.ClusterConfig, n config.Node, r cruntime.Mana
 	// v1beta2 isn't required until v1.17.
 	if version.GTE(semver.MustParse("1.17.0")) {
 		configTmpl = ktmpl.V1Beta2
+	}
+	// handle the renaming of the coredns image from "coredns" to "coredns/coredns"
+	if version.GTE(semver.MustParse("1.21.0-alpha.1")) &&
+		opts.ImageRepository != "" &&
+		opts.CoreDNSImageRepository == "" {
+		opts.CoreDNSImageRepository = opts.ImageRepository + "/coredns"
 	}
 	klog.Infof("kubeadm options: %+v", opts)
 	if err := configTmpl.Execute(&b, opts); err != nil {

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.21/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.21/image-repository.yaml
@@ -36,6 +36,7 @@ clusterName: mk
 controlPlaneEndpoint: control-plane.minikube.internal:8443
 dns:
   type: CoreDNS
+  imageRepository: test/repo/coredns
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.22/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.22/image-repository.yaml
@@ -36,6 +36,7 @@ clusterName: mk
 controlPlaneEndpoint: control-plane.minikube.internal:8443
 dns:
   type: CoreDNS
+  imageRepository: test/repo/coredns
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd


### PR DESCRIPTION
`pkg/minikube/bootstrapper/images.Kubeadm` returns coredns image name in the form of `REPO/coredns/coredns:v1.8.4` for newer versions, but kubeadm templates in `pkg/minikube/bootstrapper/bsutil` still uses `REPO/coredns:v1.8.4`

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
