### PR TITLE
fix issue #11348 zsh completion broken

### DIFF
--- a/cmd/minikube/cmd/completion.go
+++ b/cmd/minikube/cmd/completion.go
@@ -292,7 +292,7 @@ __minikube_convert_bash_to_zsh() {
 	}
 
 	buf := new(bytes.Buffer)
-	err = cmd.GenBashCompletion(buf)
+	err = cmd.GenZshCompletion(buf)
 	if err != nil {
 		return errors.Wrap(err, "Error generating zsh completion")
 	}


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

Fix https://github.com/kubernetes/minikube/issues/11348.

In `GenerateZshCompletion` changed `GenBashCompletion` to `GenZshCompletion`.

This is a minimal fix.
However, there is a much bigger and better fix.
Please consider  https://github.com/kubernetes/minikube/pull/11329.