### PR TITLE
Add an issue template for Japanese

### DIFF
--- a/.github/ISSUE_TEMPLATE/ja.md
+++ b/.github/ISSUE_TEMPLATE/ja.md
@@ -1,0 +1,20 @@
+---
+name: 日本語
+about: 問題の報告
+labels: l/ja
+---
+<!--- 再現手順には、使用した「minikube start」コマンドを含めてください --->
+**問題を再現するための手順:** 
+
+1.
+2. 
+3.
+
+**`minikube logs --file=logs.txt` を実行して、このissueにログファイルをドラッグ&ドロップしてください**
+
+<!--- ヒント: より多くのログを出力させるには、コマンドラインに「--alsologtostderr」フラグを追加してください --->
+**`minikube start` ではない場合は、失敗したコマンドの全出力:**
+<details>
+
+
+</details>


### PR DESCRIPTION
fixes #12403
Adds ja.md in .github/ISSUE_TEMPLATE based on the latest __en-US.md.