### PR TITLE
Remove quotes from fields of Windows Installer

### DIFF
--- a/installers/windows/minikube.nsi
+++ b/installers/windows/minikube.nsi
@@ -142,11 +142,11 @@ Section "Install"
 	WriteRegStr HKLM "${UNINSTALLDIR}" "QuietUninstallString" "$\"$INSTDIR\uninstall.exe$\" /S"
 	WriteRegStr HKLM "${UNINSTALLDIR}" "InstallLocation" "$\"$INSTDIR$\""
 	WriteRegStr HKLM "${UNINSTALLDIR}" "DisplayIcon" "$\"$INSTDIR\logo.ico$\""
-	WriteRegStr HKLM "${UNINSTALLDIR}" "Publisher" "$\"${COMPANYNAME}$\""
-	WriteRegStr HKLM "${UNINSTALLDIR}" "HelpLink" "$\"${HELPURL}$\""
-	WriteRegStr HKLM "${UNINSTALLDIR}" "URLUpdateInfo" "$\"${UPDATEURL}$\""
-	WriteRegStr HKLM "${UNINSTALLDIR}" "URLInfoAbout" "$\"${ABOUTURL}$\""
-	WriteRegStr HKLM "${UNINSTALLDIR}" "DisplayVersion" "$\"${VERSIONMAJOR}.${VERSIONMINOR}.${VERSIONBUILD}$\""
+	WriteRegStr HKLM "${UNINSTALLDIR}" "Publisher" "${COMPANYNAME}"
+	WriteRegStr HKLM "${UNINSTALLDIR}" "HelpLink" "${HELPURL}"
+	WriteRegStr HKLM "${UNINSTALLDIR}" "URLUpdateInfo" "${UPDATEURL}"
+	WriteRegStr HKLM "${UNINSTALLDIR}" "URLInfoAbout" "${ABOUTURL}"
+	WriteRegStr HKLM "${UNINSTALLDIR}" "DisplayVersion" "${VERSIONMAJOR}.${VERSIONMINOR}.${VERSIONBUILD}"
 	WriteRegDWORD HKLM "${UNINSTALLDIR}" "VersionMajor" ${VERSIONMAJOR}
 	WriteRegDWORD HKLM "${UNINSTALLDIR}" "VersionMinor" ${VERSIONMINOR}
 	


### PR DESCRIPTION
fixes #12365 

When installing minikube with `minikube-installer.exe` in Windows, some fields (Publisher, HelpLink, URLUpdateInfo, URLInfoAbout, and DisplayVersion)  appears with double quotes in the Windows Control Panel.
This PR fixed them.

Before:
![before](https://user-images.githubusercontent.com/49514648/132518756-013bfe9d-8c31-4709-97df-4eca0aa9c100.png)
After:
![after](https://user-images.githubusercontent.com/49514648/132518772-79231b68-da46-4438-b5ce-cfc84f3ee94d.png)
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
