### PR TITLE
metallb addon: Ask user for config values even if already set

### DIFF
--- a/cmd/minikube/cmd/config/configure.go
+++ b/cmd/minikube/cmd/config/configure.go
@@ -199,13 +199,9 @@ var addonsConfigureCmd = &cobra.Command{
 				return net.ParseIP(s) != nil
 			}
 
-			if cfg.KubernetesConfig.LoadBalancerStartIP == "" {
-				cfg.KubernetesConfig.LoadBalancerStartIP = AskForStaticValidatedValue("-- Enter Load Balancer Start IP: ", validator)
-			}
+			cfg.KubernetesConfig.LoadBalancerStartIP = AskForStaticValidatedValue("-- Enter Load Balancer Start IP: ", validator)
 
-			if cfg.KubernetesConfig.LoadBalancerEndIP == "" {
-				cfg.KubernetesConfig.LoadBalancerEndIP = AskForStaticValidatedValue("-- Enter Load Balancer End IP: ", validator)
-			}
+			cfg.KubernetesConfig.LoadBalancerEndIP = AskForStaticValidatedValue("-- Enter Load Balancer End IP: ", validator)
 
 			if err := config.SaveProfile(profile, cfg); err != nil {
 				out.ErrT(style.Fatal, "Failed to save config {{.profile}}", out.V{"profile": profile})


### PR DESCRIPTION
Closes #12051

**Problem:**
Currently, once you configure the metallb addon you can't change the values unless you manully edit the config.json file or start a new cluster.

**Solution:**
Now asks user to enter config values every time `minikube addons configure metallb` is run.

**Before (doesn't ask for values second time):**
```
$ minikube addons configure metallb
-- Enter Load Balancer Start IP: 1.1.1.1
-- Enter Load Balancer End IP: 1.1.1.1
    ▪ Using image metallb/speaker:v0.9.6
    ▪ Using image metallb/controller:v0.9.6
✅  metallb was successfully configured

$ minikube addons configure metallb
    ▪ Using image metallb/speaker:v0.9.6
    ▪ Using image metallb/controller:v0.9.6
✅  metallb was successfully configured
```

**After (asks for values second time):**
```
$ minikube addons configure metallb
-- Enter Load Balancer Start IP: 1.1.1.1
-- Enter Load Balancer End IP: 1.1.1.1
    ▪ Using image metallb/speaker:v0.9.6
    ▪ Using image metallb/controller:v0.9.6
✅  metallb was successfully configured

$ minikube addons configure metallb
-- Enter Load Balancer Start IP: 1.1.1.1
-- Enter Load Balancer End IP: 1.1.1.1
    ▪ Using image metallb/speaker:v0.9.6
    ▪ Using image metallb/controller:v0.9.6
✅  metallb was successfully configured
```