### PR TITLE
Fix ingress addon role resource's referenced configmap

### DIFF
--- a/deploy/addons/ingress/ingress-deploy.yaml.tmpl
+++ b/deploy/addons/ingress/ingress-deploy.yaml.tmpl
@@ -215,7 +215,7 @@ rules:
     resources:
       - configmaps
     resourceNames:
-      - ingress-controller-leader-nginx
+      - ingress-controller-leader
     verbs:
       - get
       - update


### PR DESCRIPTION
Fixes #12445 
