### PR TITLE
fix go sum

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1621,6 +1621,7 @@ google.golang.org/api v0.50.0/go.mod h1:4bNT5pAuq5ji4SRZm+5QIkjny9JAyVD/3gaSihNe
 google.golang.org/api v0.51.0/go.mod h1:t4HdrdoNgyN5cbEfm7Lum0lcLDLiise1F8qDKX00sOU=
 google.golang.org/api v0.54.0/go.mod h1:7C4bFFOvVDGXjfDTAsgGwDgAxRDeQ4X8NvUedIt6z3k=
 google.golang.org/api v0.55.0/go.mod h1:38yMfeP1kfjsl8isn0tliTjIb1rJXcQi4UXlbqivdVE=
+google.golang.org/api v0.56.0/go.mod h1:38yMfeP1kfjsl8isn0tliTjIb1rJXcQi4UXlbqivdVE=
 google.golang.org/api v0.57.0 h1:4t9zuDlHLcIx0ZEhmXEeFVCRsiOgpgn2QOH9N0MNjPI=
 google.golang.org/api v0.57.0/go.mod h1:dVPlbZyBo2/OjBpmvNdpn2GRm6rPy75jyU7bmhdrMgI=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=


### PR DESCRIPTION
Causing kicbase build to fail:
```
------
 > [linux/amd64 stage-0 4/4] RUN cd ./cmd/auto-pause/ && go build:
#110 4.692 go: github.com/spf13/viper@v1.9.0 requires
#110 4.692 	github.com/sagikazarmark/crypt@v0.1.0 requires
#110 4.692 	google.golang.org/api@v0.56.0: missing go.sum entry; to add it:
#110 4.692 	go mod download google.golang.org/api
------
```