### PR TITLE
Allow running podman as experimental driver

### DIFF
--- a/pkg/minikube/driver/driver_darwin.go
+++ b/pkg/minikube/driver/driver_darwin.go
@@ -27,6 +27,7 @@ var supportedDrivers = func() []string {
 		// on darwin/arm64 only docker and ssh are supported yet
 		return []string{
 			Docker,
+			Podman,
 			SSH,
 		}
 	}
@@ -37,6 +38,7 @@ var supportedDrivers = func() []string {
 		HyperKit,
 		VMware,
 		Docker,
+		Podman,
 		SSH,
 	}
 }()

--- a/pkg/minikube/driver/driver_windows.go
+++ b/pkg/minikube/driver/driver_windows.go
@@ -33,6 +33,7 @@ var supportedDrivers = []string{
 	HyperV,
 	VMware,
 	Docker,
+	Podman,
 	SSH,
 }
 

--- a/site/content/en/docs/drivers/podman.md
+++ b/site/content/en/docs/drivers/podman.md
@@ -39,6 +39,8 @@ sudo -k -n podman version
 ```shell
 podman machine init --cpus 2 --memory 2048 --disk-size 20
 podman machine start
+podman system connection default podman-machine-default-root
+podman info
 ```
 
 ## Troubleshooting

--- a/site/content/en/docs/drivers/podman.md
+++ b/site/content/en/docs/drivers/podman.md
@@ -11,14 +11,13 @@ The podman driver is an alternative container runtime to the [Docker]({{< ref "/
 
 ## Requirements
 
-- Linux operating system
 - Install [podman](https://podman.io/getting-started/installation.html)
 
 {{% readfile file="/docs/drivers/includes/podman_usage.inc" %}}
 
 ## Known Issues
 
-- Podman requirements passwordless running of sudo. If you run into an error about sudo, do the following:
+- On Linux, Podman requires passwordless running of sudo. If you run into an error about sudo, do the following:
 
 ```shell
 $ sudo visudo
@@ -33,6 +32,13 @@ Be sure this text is *after* `#includedir /etc/sudoers.d`. To confirm it worked,
 
 ```shell
 sudo -k -n podman version
+```
+
+- On all other operating systems, make sure to create and start the virtual machine that is needed for Podman.
+
+```shell
+podman machine init --cpus 2 --memory 2048 --disk-size 20
+podman machine start
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
Currently podman is being blocked in "start", we should allow it as an experimental driver.

```
brew install podman

podman machine init --cpus 2 --memory 2048 --disk-size 20
podman machine start
podman system connection default podman-machine-default-root
podman info

minikube start --driver=podman
```

Since it is marked as Experimental (when not on Linux), it will **not** be selected unless requested.

Closes #12547