### PR TITLE
Updates E2E test images registry

### DIFF
--- a/test/integration/testdata/multinodes/multinode-pod-dns-test.yaml
+++ b/test/integration/testdata/multinodes/multinode-pod-dns-test.yaml
@@ -18,7 +18,7 @@ spec:
       - name: busybox
         # flaky nslookup in busybox versions newer than 1.28:
         # https://github.com/docker-library/busybox/issues/48
-        # note: gcr.io/kubernetes-e2e-test-images/dnsutils:1.3
+        # note: k8s.gcr.io/e2e-test-images/agnhost:2.32
         # has similar issues (ie, resolves but returns exit code 1)
         image: busybox:1.28
         command:

--- a/test/integration/testdata/netcat-deployment-nomaster.yaml
+++ b/test/integration/testdata/netcat-deployment-nomaster.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         # dnsutils is easier to debug DNS issues with than the standard busybox image
         - name: dnsutils
-          image: gcr.io/kubernetes-e2e-test-images/dnsutils
+          image: k8s.gcr.io/e2e-test-images/agnhost:2.32
           command:
             ["/bin/sh", "-c", "while true; do echo hello | nc -l -p 8080; done"]
       affinity:

--- a/test/integration/testdata/netcat-deployment.yaml
+++ b/test/integration/testdata/netcat-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         # dnsutils is easier to debug DNS issues with than the standard busybox image
         - name: dnsutils
-          image: gcr.io/kubernetes-e2e-test-images/dnsutils:1.3
+          image: k8s.gcr.io/e2e-test-images/agnhost:2.32
           command:
             ["/bin/sh", "-c", "while true; do echo hello | nc -l -p 8080; done"]
 ---


### PR DESCRIPTION
We're moving away from google.com gcp projects. These images are now on community-owned infra.

Note that the dnsutils image has been centralized into the agnhost image.

Related: https://github.com/kubernetes/k8s.io/issues/1522

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
