### PR TITLE
clarify that Windows install commands are powershell-based

### DIFF
--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -425,7 +425,7 @@ choco install minikube
 {{% quiz_instruction id="/Windows/x86-64/Stable/.exe download" %}}
 1. Download the [latest release](https://storage.googleapis.com/minikube/releases/latest/minikube-installer.exe).  
 <br>
-    Or if you have `curl` installed, use this command:
+    Or if you have `curl` installed, use these commands via PowerShell:
     ```shell
     curl -Lo minikube.exe https://github.com/kubernetes/minikube/releases/latest/download/minikube-windows-amd64.exe
     New-Item -Path "c:\" -Name "minikube" -ItemType "directory" -Force


### PR DESCRIPTION
Someone reading this line could presume it should work at the regular Windows command line (and the curl would), but of course the 2nd and 3rd lines will not.

And if someone who may approve this might want to also revise the line after step 2 here (or move to here its point about running as admin), that would of course make sense. I just didn't want to presume to do that in this simpler commit.