### PR TITLE
`TestScheduledStopWindows`: increase sleep to 1 minute

### DIFF
--- a/test/integration/scheduled_stop_test.go
+++ b/test/integration/scheduled_stop_test.go
@@ -44,7 +44,7 @@ func TestScheduledStopWindows(t *testing.T) {
 		t.Skip("test only runs on windows")
 	}
 	profile := UniqueProfileName("scheduled-stop")
-	ctx, cancel := context.WithTimeout(context.Background(), Minutes(5))
+	ctx, cancel := context.WithTimeout(context.Background(), Minutes(6))
 	defer CleanupWithLogs(t, profile, cancel)
 	startMinikube(ctx, t, profile)
 
@@ -65,7 +65,7 @@ func TestScheduledStopWindows(t *testing.T) {
 	stopMinikube(ctx, t, profile, []string{"--schedule", "5s"})
 
 	// wait for stop to complete
-	time.Sleep(15 * time.Second)
+	time.Sleep(time.Minute)
 	// make sure minikube timetoStop is not present
 	ensureTimeToStopNotPresent(ctx, t, profile)
 	// make sure minikube status is "Stopped"


### PR DESCRIPTION
Tested `minikube stop` on new Windows CI and takes up to 17 seconds for stop to complete.

Current `TestScheduledStopWindows` value: 15 second sleep - 5 seconds for schedule stop to occur = 10 seconds, so sleep is not long enough for stop to finish.

Increase sleep to one minute which leaves us 55 seconds to stop, but giving extra as tests are running in parallel and are CPU bound.

Also added an extra minute for the test to complete since the sleep increased.