### PR TITLE
Add CPU time to time-to-k8s charts

### DIFF
--- a/hack/benchmark/time-to-k8s/public-chart/generate-chart.go
+++ b/hack/benchmark/time-to-k8s/public-chart/generate-chart.go
@@ -114,6 +114,10 @@ func readInLatestBenchmark(latestBenchmarkPath string) benchmark {
 	var total float64
 	for _, step := range steps {
 		*step /= float64(count)
+		// Don't add CPU time to the total time.
+		if step == &cpu {
+			continue
+		}
 		total += *step
 	}
 

--- a/hack/benchmark/time-to-k8s/public-chart/generate-chart.go
+++ b/hack/benchmark/time-to-k8s/public-chart/generate-chart.go
@@ -151,7 +151,7 @@ func updateRunsFile(h *benchmarks, pastRunsPath string) {
 func createChart(benchmarks []benchmark, chartOutputPath string) {
 	n := len(benchmarks)
 	var cmdXYs, apiXYs, k8sXYs, dnsSvcXYs, appXYs, dnsAnsXYs, totalXYs, cpuXYs plotter.XYs
-	xys := []*plotter.XYs{&cmdXYs, &apiXYs, &k8sXYs, &dnsSvcXYs, &appXYs, &dnsAnsXYs, &totalXYs}
+	xys := []*plotter.XYs{&cmdXYs, &apiXYs, &k8sXYs, &dnsSvcXYs, &appXYs, &dnsAnsXYs, &totalXYs, &cpuXYs}
 
 	for _, xy := range xys {
 		*xy = make(plotter.XYs, n)


### PR DESCRIPTION
fixes #12238.

Unfortunately, I can't pull or push to the GCS buckets, so can someone with the right permission help me test this? Thanks!
