### PR TITLE
podman: Fix network not getting deleted

### DIFF
--- a/pkg/drivers/kic/oci/network_create.go
+++ b/pkg/drivers/kic/oci/network_create.go
@@ -123,10 +123,8 @@ func tryCreateDockerNetwork(ociBin string, subnet *network.Parameters, mtu int, 
 			args = append(args, "-o")
 			args = append(args, fmt.Sprintf("com.docker.network.driver.mtu=%d", mtu))
 		}
-
-		args = append(args, fmt.Sprintf("--label=%s=%s", CreatedByLabelKey, "true"))
 	}
-	args = append(args, name)
+	args = append(args, fmt.Sprintf("--label=%s=%s", CreatedByLabelKey, "true"), name)
 
 	rr, err := runCmd(exec.Command(ociBin, args...))
 	if err != nil {

--- a/pkg/minikube/delete/delete.go
+++ b/pkg/minikube/delete/delete.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/style"
 )
 
-// PossibleLeftOvers deletes KIC & non-KIC drivers left
+// PossibleLeftOvers deletes KIC driver left overs
 func PossibleLeftOvers(ctx context.Context, cname string, driverName string) {
 	bin := ""
 	switch driverName {

--- a/test/integration/pause_test.go
+++ b/test/integration/pause_test.go
@@ -173,6 +173,13 @@ func validateVerifyDeleted(ctx context.Context, t *testing.T, profile string) {
 			t.Errorf("expected to see error and volume %q to not exist after deletion but got no error and this output: %s", rr.Command(), rr.Output())
 		}
 
+		rr, err = Run(t, exec.CommandContext(ctx, "sudo", bin, "network", "ls"))
+		if err != nil {
+			t.Errorf("failed to get list of networks: %v", err)
+		}
+		if strings.Contains(rr.Output(), profile) {
+			t.Errorf("expected network %q to not exist after deletion but contained: %s", profile, rr.Output())
+		}
 	}
 
 }


### PR DESCRIPTION
Fixes #12585

**Problem:**
```
$ sudo podman network ls
NAME      VERSION  PLUGINS
podman    0.4.0    bridge,portmap,firewall,tuning

$ minikube start --driver=podman
...

$ sudo podman network ls
NAME      VERSION  PLUGINS
podman    0.4.0    bridge,portmap,firewall,tuning
minikube  0.4.0    bridge,portmap,firewall,tuning,dnsname

$ minikube delete
...

$ sudo podman network ls
NAME      VERSION  PLUGINS
podman    0.4.0    bridge,portmap,firewall,tuning
minikube  0.4.0    bridge,portmap,firewall,tuning,dnsname
```

The root of the issue is when we delete the KIC networks we search for ones with the label `created_by.minikube.sigs.k8s.io`, however the line to append the label to the network on creation was nested within a Docker if statement and wasn't being added to Podman networks.

**Solution:**
Just moved the label append outside the if, also added a test to catch this in the future.