### PR TITLE
Optimize tunnel report formatting 

### DIFF
--- a/pkg/minikube/tunnel/reporter.go
+++ b/pkg/minikube/tunnel/reporter.go
@@ -67,7 +67,7 @@ func (r *simpleReporter) Report(tunnelState *Status) {
 		loadbalancer emulator: %s
 `, minikubeError, routerError, lbError)
 
-	_, err := r.out.Write([]byte(fmt.Sprintf(
+	_, err := fmt.Fprintf(r.out,
 		`Status:	
 	machine: %s
 	pid: %d
@@ -79,7 +79,7 @@ func (r *simpleReporter) Report(tunnelState *Status) {
 		tunnelState.TunnelID.Route,
 		minikubeState,
 		managedServices,
-		errors)))
+		errors)
 	if err != nil {
 		klog.Errorf("failed to report state %s", err)
 	}


### PR DESCRIPTION
This PR replaces `fmt.Sprintf` call with `fmt.Fprintf`.

The `w.Write([]byte(fmt.Sprintf(...)))` pattern is quite inefficient, it allocates
3x more than `fmt.Fprintf`.

This is quite small change, but I hope it will be helpful.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
