### PR TITLE
Updated windows commands to reflect recent changes

### DIFF
--- a/site/content/en/docs/handbook/registry.md
+++ b/site/content/en/docs/handbook/registry.md
@@ -83,13 +83,19 @@ The first step is to enable the registry addon:
 minikube addons enable registry
 ```
 
-When enabled, the registry addon exposes its port 5000 on the minikube's virtual machine.
+When enabled, the registry addon exposes its port 80 on the minikube's virtual machine. You can confirm this by:
+```shell
+kubectl get service --namespace kube-system
+> NAME       TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)                  AGE
+> kube-dns   ClusterIP   10.96.0.10     <none>        53/UDP,53/TCP,9153/TCP   54m
+> registry   ClusterIP   10.98.34.133   <none>        80/TCP,443/TCP           37m
+```
 
-In order to make docker accept pushing images to this registry, we have to redirect port 5000 on the docker virtual machine over to port 5000 on the minikube machine. Unfortunately, the docker vm cannot directly see the IP address of the minikube vm. To fix this, you will have to add one more level of redirection.
+In order to make docker accept pushing images to this registry, we have to redirect port 5000 on the docker virtual machine over to port 80 on the minikube registry service. Unfortunately, the docker vm cannot directly see the IP address of the minikube vm. To fix this, you will have to add one more level of redirection.
 
 Use kubectl port-forward to map your local workstation to the minikube vm
 ```shell
-kubectl port-forward --namespace kube-system <name of the registry vm> 5000:5000
+kubectl port-forward --namespace kube-system service/registry 5000:80
 ```
 
 On your local machine you should now be able to reach the minikube registry by using `curl http://localhost:5000/v2/_catalog`


### PR DESCRIPTION
The current windows commands to setup a local registry no longer worked for me. The registry addon is setup to listen on port 80, not port 5000. It is unclear if this is a bug or intentional. If it is intentional, the changes in this PR should get this documentation up to date.

Specifically, this PR updates the port forward from 5000:5000 to 5000:80, and adds another line to make it more clear that the "registry vm" is the registry service as obtained from the list of services.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
