### PR TITLE
fixes #12659, use absolute path when tilde is used in front of path for ssh-key

### DIFF
--- a/pkg/minikube/registry/drvs/ssh/ssh.go
+++ b/pkg/minikube/registry/drvs/ssh/ssh.go
@@ -27,6 +27,9 @@ import (
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/minikube/registry"
+
+        "os/user"
+	"path/filepath"
 )
 
 func init() {
@@ -63,7 +66,18 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 
 	d.IPAddress = cc.SSHIPAddress
 	d.SSHUser = cc.SSHUser
-	d.SSHKey = cc.SSHKey
+	
+	//If ~ is in the front of the path to ssh-key then convert to the absolute path
+	if len(cc.SSHKey) > 0 && cc.SSHKey[0] == '~' {
+		usr, err := user.Current()
+		if err != nil {
+			return nil, errors.Errorf("Error determining path to ssh key")
+		}
+		d.SSHKey = filepath.Join(usr.HomeDir, cc.SSHKey[1:])
+	} else {
+		d.SSHKey = cc.SSHKey
+	}
+
 	d.SSHPort = cc.SSHPort
 
 	return d, nil


### PR DESCRIPTION
Fixes #12659 , when using a relative path with ~ the path would not be recognized correctly if used with an equal sign.

Behavior is as currently working in GO per https://github.com/golang/go/issues/4140

Solution here is to use the user home directory and joining to the relative path when a relative path is used like: minikube -p test start --driver=ssh --ssh-key=~/.ssh/id_rsa --ssh-ip-address=mytestkube

Let me know if any comments or suggested changes, thanks!