### PR TITLE
fix for #12659, utilize absolute path when tilde starts ssh-key path

### DIFF
--- a/pkg/minikube/registry/drvs/ssh/ssh.go
+++ b/pkg/minikube/registry/drvs/ssh/ssh.go
@@ -70,7 +70,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 	if strings.HasPrefix(cc.SSHKey, "~") {
 		dirname, err := os.UserHomeDir()
 		if err != nil {
-			return nil, errors.Errorf("Error determining path to ssh key")
+			return nil, errors.Errorf("Error determining path to ssh key: %v", err)
 		}
 		d.SSHKey = filepath.Join(dirname, cc.SSHKey[1:])
 	} else {


### PR DESCRIPTION
Fixes #12659 , when using a relative path with ~ the path would not be recognized correctly if used with an equal sign.

Behavior is as currently working in GO per golang/go#4140

Solution here is to use the user home directory and joining to the relative path when a relative path is used like: minikube -p test start --driver=ssh --ssh-key=~/.ssh/id_rsa --ssh-ip-address=mytestkube

Let me know if any comments or suggested changes, thanks!