### PR TITLE
Match the lower case of the podman error message

### DIFF
--- a/pkg/drivers/kic/oci/network_create.go
+++ b/pkg/drivers/kic/oci/network_create.go
@@ -218,7 +218,7 @@ func podmanNetworkInspect(name string) (netInfo, error) {
 	rr, err := runCmd(cmd)
 	if err != nil {
 		logDockerNetworkInspect(Podman, name)
-		if strings.Contains(rr.Output(), "No such network") {
+		if strings.Contains(rr.Output(), "no such network") {
 
 			return info, ErrNetworkNotFound
 		}


### PR DESCRIPTION
Turns out that Docker says "No such network",
but Podman says "no such network". Little nuances.

----

This will fix the "error 125" results when inspecting the network.

```console
$ docker network inspect foo
[]
Error: No such network: foo
$ echo $?
1
$ sudo podman network inspect foo
[]
Error: error inspecting object: no such network foo
$ echo $?
125
```

Closes #12679 #12683