### PR TITLE
Support changing apiserver-ips when restarting minikube

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -677,6 +677,12 @@ func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterC
 		cc.VerifyComponents = interpretWaitFlag(*cmd)
 	}
 
+	if cmd.Flags().Changed("apiserver-ips") {
+		// IPSlice not supported in Viper
+		// https://github.com/spf13/viper/issues/460
+		cc.KubernetesConfig.APIServerIPs = apiServerIPs
+	}
+
 	// Handle flags and legacy configuration upgrades that do not contain KicBaseImage
 	if cmd.Flags().Changed(kicBaseImage) || cc.KicBaseImage == "" {
 		cc.KicBaseImage = viper.GetString(kicBaseImage)


### PR DESCRIPTION
After commit bee6815, we could not change the apiserver-ips after
initial `minikube start`. Revert to previous behavior where both
apiserver-ips and apiserver-names were taken always into account
and certs were updated accordingly.

Fixes #9818

NOTE: This is more or less https://github.com/kubernetes/minikube/pull/9876 rebased on top of current master.
