### PR TITLE
disable windows cleanup cron for now

### DIFF
--- a/hack/jenkins/windows_cleanup_and_reboot.ps1
+++ b/hack/jenkins/windows_cleanup_and_reboot.ps1
@@ -3,10 +3,6 @@ function Jenkins {
 	if ($?) {
 		return $TRUE
 	}
-	$common = Get-WMIObject -Class Win32_Process -Filter "Name='PowerShell.EXE'" | Where {$_.CommandLine -Like "*common.ps1*"}
-	if ($common -ne $NULL) {
-		return $TRUE
-	}
 	return $FALSE
 }
 

--- a/hack/jenkins/windows_cleanup_cron.ps1
+++ b/hack/jenkins/windows_cleanup_cron.ps1
@@ -1,1 +1,2 @@
 Schtasks /create /tn cleanup_reboot /sc MINUTE /mo 30 /tr "Powershell C:\jenkins\windows_cleanup_and_reboot.ps1" /f
+Disable-ScheduledTask -TaskName cleanup_reboot

--- a/hack/jenkins/windows_integration_test_docker.ps1
+++ b/hack/jenkins/windows_integration_test_docker.ps1
@@ -21,4 +21,4 @@ $timeout="180m"
 $env:JOB_NAME="Docker_Windows"
 $env:EXTERNAL="yes"
 
-. Powershell -File ./out/common.ps1
+. ./out/common.ps1

--- a/hack/jenkins/windows_integration_test_hyperv.ps1
+++ b/hack/jenkins/windows_integration_test_hyperv.ps1
@@ -21,4 +21,4 @@ $timeout="180m"
 $env:JOB_NAME="Hyper-V_Windows"
 $env:EXTERNAL="yes"
 
-. Powershell -File ./out/common.ps1
+. ./out/common.ps1


### PR DESCRIPTION
this cron seems to be doing more harm than good right now and we reboot machines after running tests anyway, so just disable the scheduled task until we have a better idea