### PR TITLE
make options command discoverable in minikube help

### DIFF
--- a/cmd/minikube/cmd/options.go
+++ b/cmd/minikube/cmd/options.go
@@ -31,7 +31,7 @@ var optionsCmd = &cobra.Command{
 	Use:    "options",
 	Short:  "Show a list of global command-line options (applies to all commands).",
 	Long:   "Show a list of global command-line options (applies to all commands).",
-	Hidden: true,
+	Hidden: false,
 	Run:    runOptions,
 }
 


### PR DESCRIPTION
Make `options` command visible in the help output
Fixes #12708

