### PR TITLE
Kill mount process before stopping nodes

### DIFF
--- a/cmd/minikube/cmd/stop.go
+++ b/cmd/minikube/cmd/stop.go
@@ -130,6 +130,10 @@ func stopProfile(profile string) int {
 	api, cc := mustload.Partial(profile)
 	defer api.Close()
 
+	if err := killMountProcess(); err != nil {
+		out.WarningT("Unable to kill mount process: {{.error}}", out.V{"error": err})
+	}
+
 	for _, n := range cc.Nodes {
 		machineName := config.MachineName(*cc, n)
 
@@ -137,10 +141,6 @@ func stopProfile(profile string) int {
 		if !nonexistent {
 			stoppedNodes++
 		}
-	}
-
-	if err := killMountProcess(); err != nil {
-		out.WarningT("Unable to kill mount process: {{.error}}", out.V{"error": err})
 	}
 
 	if !keepActive {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/12649

**Problem:**
`minikube stop` with the Hyper-V driver and with mount enabled takes 9 minutes to complete. But stopping with the mount process killed takes a normal amount of time.

**Solution:**
Change order of operations to kill mount process before stopping nodes.

Before: `minikube stop` took 9 minutes on my machine
Now: `minikube stop` took 23 seconds