### PR TITLE
remove duplicated update of MinikubeISO

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -617,7 +617,6 @@ func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterC
 		out.WarningT("You cannot add or remove extra disks for an existing minikube cluster. Please first delete the cluster.")
 	}
 
-	updateStringFromFlag(cmd, &cc.MinikubeISO, isoURL)
 	updateBoolFromFlag(cmd, &cc.KeepContext, keepContext)
 	updateBoolFromFlag(cmd, &cc.EmbedCerts, embedCerts)
 	updateStringFromFlag(cmd, &cc.MinikubeISO, isoURL)


### PR DESCRIPTION
This PR removes duplicated update of `MinikubeISO` field.
The same code is in line: https://github.com/kubernetes/minikube/blob/029a9d1700eae8356536fe5e0e9f3a60b94621d4/cmd/minikube/cmd/start_flags.go#L620 and https://github.com/kubernetes/minikube/blob/029a9d1700eae8356536fe5e0e9f3a60b94621d4/cmd/minikube/cmd/start_flags.go#L623