### PR TITLE
Add support for multiple --mountstring arguments to `minikube start --mount`

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -161,7 +161,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().Bool(embedCerts, false, "if true, will embed the certs in kubeconfig.")
 	startCmd.Flags().String(containerRuntime, constants.DefaultContainerRuntime, fmt.Sprintf("The container runtime to be used (%s).", strings.Join(cruntime.ValidRuntimes(), ", ")))
 	startCmd.Flags().Bool(createMount, false, "This will start the mount daemon and automatically mount files into minikube.")
-	startCmd.Flags().String(mountString, constants.DefaultMountDir+":/minikube-host", "The argument to pass the minikube mount command on start.")
+	startCmd.Flags().StringArray(mountString, []string{constants.DefaultMountDir + ":/minikube-host"}, "The argument to pass the minikube mount command on start.")
 	startCmd.Flags().String(mount9PVersion, defaultMount9PVersion, mount9PVersionDescription)
 	startCmd.Flags().String(mountGID, defaultMountGID, mountGIDDescription)
 	startCmd.Flags().String(mountIPFlag, defaultMountIP, mountIPDescription)
@@ -171,6 +171,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().Uint16(mountPortFlag, defaultMountPort, mountPortDescription)
 	startCmd.Flags().String(mountTypeFlag, defaultMountType, mountTypeDescription)
 	startCmd.Flags().String(mountUID, defaultMountUID, mountUIDDescription)
+	
 	startCmd.Flags().StringSlice(config.AddonListFlag, nil, "Enable addons. see `minikube addons list` for a list of valid addon names.")
 	startCmd.Flags().String(criSocket, "", "The cri socket path to be used.")
 	startCmd.Flags().String(networkPlugin, "", "Kubelet network plug-in to use (default: auto)")
@@ -516,7 +517,7 @@ func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, drvName s
 	}
 	cc.VerifyComponents = interpretWaitFlag(*cmd)
 	if viper.GetBool(createMount) && driver.IsKIC(drvName) {
-		cc.ContainerVolumeMounts = []string{viper.GetString(mountString)}
+		cc.ContainerVolumeMounts = viper.GetStringSlice(mountString)
 	}
 
 	if detect.IsCloudShell() {


### PR DESCRIPTION
fixes #12733

Previously `minikube start --mount` could be passed a `--mount-string` argument which would create the minikube container with the specified host folder or docker volume mounted at the specified location (provided the minikube container did not already exist). e.g.
```
minikube start --mount  --mount-string "host_volume:/mount_point"
```
would mount the `host_volume` docker volume at `/mount_point` in the minikube container. If multiple `--mount-string` arguments were provided, only the last would be used by minikube.

This PR changes minikube so that multiple `--mount-string` arguments are supported. e.g.
```
minikube start --mount  --mount-string "host_volume1:/mount_point1"  --mount-string "host_volume2:/mount_point2"
```
would mount the `host_volume1` docker volume at `/mount_point1` in the minikube container and  `host_volume2` at `/mount_point2`. 


<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
