### PR TITLE
containerd preload: discard unpacked layers to reduce size

### DIFF
--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -90,6 +90,7 @@ oom_score = 0
 
 	[plugins."io.containerd.grpc.v1.cri"]
       [plugins."io.containerd.grpc.v1.cri".containerd]
+        discard_unpacked_layers = true
         [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
             runtime_type = "io.containerd.runc.v2"

--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -46,7 +46,8 @@ const (
 	containerdNamespaceRoot = "/run/containerd/runc/k8s.io"
 	// ContainerdConfFile is the path to the containerd configuration
 	containerdConfigFile     = "/etc/containerd/config.toml"
-	containerdConfigTemplate = `root = "/var/lib/containerd"
+	containerdConfigTemplate = `version = 2
+root = "/var/lib/containerd"
 state = "/run/containerd"
 oom_score = 0
 [grpc]
@@ -76,9 +77,9 @@ oom_score = 0
   address = "/run/containerd-fuse-overlayfs.sock"
 
 [plugins]
-  [plugins.cgroups]
+  [plugins."io.containerd.monitor.v1.cgroups"]
     no_prometheus = false
-  [plugins.cri]
+  [plugins."io.containerd.grpc.v1.cri"]
     stream_server_address = ""
     stream_server_port = "10010"
     enable_selinux = false
@@ -88,38 +89,36 @@ oom_score = 0
     max_container_log_line_size = 16384
     restrict_oom_score_adj = {{ .RestrictOOMScoreAdj }}
 
-	[plugins."io.containerd.grpc.v1.cri"]
-      [plugins."io.containerd.grpc.v1.cri".containerd]
-        discard_unpacked_layers = true
-        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
-          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
-            runtime_type = "io.containerd.runc.v2"
-            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
-              SystemdCgroup = {{ .SystemdCgroup }}
-
-    [plugins.cri.containerd]
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      discard_unpacked_layers = true
       snapshotter = "{{ .Snapshotter }}"
-      [plugins.cri.containerd.default_runtime]
+      [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
         runtime_type = "io.containerd.runc.v2"
-      [plugins.cri.containerd.untrusted_workload_runtime]
+      [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
         runtime_type = ""
         runtime_engine = ""
         runtime_root = ""
-    [plugins.cri.cni]
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v2"
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+            SystemdCgroup = {{ .SystemdCgroup }}
+
+    [plugins."io.containerd.grpc.v1.cri".cni]
       bin_dir = "/opt/cni/bin"
       conf_dir = "{{.CNIConfDir}}"
       conf_template = ""
-    [plugins.cri.registry]
-      [plugins.cri.registry.mirrors]
-        [plugins.cri.registry.mirrors."docker.io"]
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
           endpoint = ["https://registry-1.docker.io"]
         {{ range .InsecureRegistry -}}
-        [plugins.cri.registry.mirrors."{{. -}}"]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{. -}}"]
           endpoint = ["http://{{. -}}"]
         {{ end -}}
-  [plugins.diff-service]
+  [plugins."io.containerd.service.v1.diff-service"]
     default = ["walking"]
-  [plugins.scheduler]
+  [plugins."io.containerd.gc.v1.scheduler"]
     pause_threshold = 0.02
     deletion_threshold = 0
     mutation_threshold = 100

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -44,7 +44,7 @@ const (
 	// PreloadVersion is the current version of the preloaded tarball
 	//
 	// NOTE: You may need to bump this version up when upgrading auxiliary docker images
-	PreloadVersion = "v13"
+	PreloadVersion = "v14"
 	// PreloadBucket is the name of the GCS bucket where preloaded volume tarballs exist
 	PreloadBucket = "minikube-preloaded-volume-tarballs"
 )


### PR DESCRIPTION
Closes https://github.com/kubernetes/minikube/issues/9946
Fixes https://github.com/kubernetes/minikube/issues/12355

**Before:**
`preloaded-images-k8s-v13-v1.22.2-containerd-overlay2-amd64.tar.lz4`
Size: 930MB

**After:**
`preloaded-images-k8s-v13-v1.22.2-containerd-overlay2-amd64.tar.lz4`
Size: 580MB

Size reduction:
`-350MB (37.6%)`