### PR TITLE
Directly code golang version to update to

### DIFF
--- a/hack/jenkins/installers/check_install_golang.sh
+++ b/hack/jenkins/installers/check_install_golang.sh
@@ -22,7 +22,7 @@ if (($# < 1)); then
   exit 1
 fi
 
-VERSION_TO_INSTALL=$(grep '^GO_VERSION' Makefile | awk '{ print $3 }')
+VERSION_TO_INSTALL=1.17.2
 INSTALL_PATH=${1}
 
 function current_arch() {

--- a/hack/update/golang_version/update_golang_version.go
+++ b/hack/update/golang_version/update_golang_version.go
@@ -118,6 +118,11 @@ var (
 				`GO_K8S_VERSION_PREFIX \?= v1.*`: `GO_K8S_VERSION_PREFIX ?= {{.K8SVersion}}`,
 			},
 		},
+		"hack/jenkins/installers/check_install_golang.sh": {
+			Replace: map[string]string{
+				`VERSION_TO_INSTALL=.*`: `VERSION_TO_INSTALL={{.StableVersion}}`,
+			},
+		},
 	}
 
 	// PR data


### PR DESCRIPTION
**Problem:**
With many of our integration tests we just copy the required test files into the machine, however, the `golang_install` script pulls the version from the `Makefile` which during integration testing is not there, so it's possible some machines aren't going to get updated.

**Solution:**
Hard code the go version to install in the script but update it with the golang update script.