### PR TITLE
don't let root own the go installation folder on CI machines

### DIFF
--- a/hack/jenkins/installers/check_install_golang.sh
+++ b/hack/jenkins/installers/check_install_golang.sh
@@ -50,6 +50,8 @@ function check_and_install_golang() {
     return
   fi
 
+  sudo chown -R jenkins:jenkins "$INSTALL_PATH"/go
+
   # golang has been installed and check its version
   if [[ $(go version | cut -d' ' -f 3) =~ go(([0-9]+)\.([0-9]+).([0-9]+)*) ]]; then
     HOST_VERSION=${BASH_REMATCH[1]}
@@ -86,6 +88,7 @@ function install_golang() {
   sudo rm -rf "$GO_DIR"
   sudo mkdir -p "$GO_DIR"
   sudo tar -C "$GO_DIR" --strip-components=1 -xzf "$GO_TGZ"
+  sudo chown -R jenkins:jenkins "$GO_DIR"
 
   popd >/dev/null
   echo "installed in $GO_DIR: $($GO_DIR/bin/go version)"

--- a/hack/jenkins/installers/check_install_gotestsum.sh
+++ b/hack/jenkins/installers/check_install_gotestsum.sh
@@ -17,8 +17,8 @@
 set -eux -o pipefail
 
 function install_gotestsum() {
-  sudo rm -f $(which gotestsum)
-  sudo PATH="$PATH" GOBIN="$GOROOT/bin" go install gotest.tools/gotestsum@v1.6.4
+  rm -f $(which gotestsum)
+  GOBIN="$GOROOT/bin" go install gotest.tools/gotestsum@v1.6.4
 }
 
 which gotestsum || install_gotestsum


### PR DESCRIPTION
for some reason running sudo makes go very sad and in turn makes our developers very sad

this should allow gotestsum to actually run and install