### PR TITLE
Throw error if trying to install jq on arm64 machines

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -403,7 +403,7 @@ if ! type "jq" > /dev/null; then
     if [ "${ARCH}" == "arm64" && "${OS}" == "linux" ]; then
       sudo apt-get install jq -y
     elif [ "${ARCH}" == "arm64" ]; then
-      echo "Unable to install 'jq' automatically for arm64, please install 'jq' manually."
+      echo "Unable to install 'jq' automatically for arm64 on Darwin, please install 'jq' manually."
       exit 5
     elif [ "${OS}" != "darwin" ]; then
       curl -LO https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && sudo install jq-linux64 /usr/local/bin/jq

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -399,8 +399,11 @@ sec=$(tail -c 3 <<< $((${elapsed}00/60)))
 elapsed=$min.$sec
 
 if ! type "jq" > /dev/null; then
-echo ">> Installing jq"
-    if [ "${OS}" != "darwin" ]; then
+    echo ">> Installing jq"
+    if [ "${ARCH}" == "arm64" ]; then
+      echo "Unable to install 'jq' automatically for arm64, please install 'jq' manually."
+      exit 5
+    elif [ "${OS}" != "darwin" ]; then
       curl -LO https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && sudo install jq-linux64 /usr/local/bin/jq
     else
       curl -LO https://github.com/stedolan/jq/releases/download/jq-1.6/jq-osx-amd64 && sudo install jq-osx-amd64 /usr/local/bin/jq

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -400,7 +400,9 @@ elapsed=$min.$sec
 
 if ! type "jq" > /dev/null; then
     echo ">> Installing jq"
-    if [ "${ARCH}" == "arm64" ]; then
+    if [ "${ARCH}" == "arm64" && "${OS}" == "linux" ]; then
+      sudo apt-get install jq -y
+    elif [ "${ARCH}" == "arm64" ]; then
       echo "Unable to install 'jq' automatically for arm64, please install 'jq' manually."
       exit 5
     elif [ "${OS}" != "darwin" ]; then


### PR DESCRIPTION
**Problem:**
Scripts install amd64 instances of `jq` if not detected on system, which is unrunnable on an arm64 machine.

**Solution:**
Output message to install `jq` manually for arm64 machines and exit script.