### PR TITLE
Print a message about preserving kicbase image when `minkube delete --purge --all` used

### DIFF
--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -554,6 +554,30 @@ func ListContainersByLabel(ctx context.Context, ociBin string, label string, war
 	return names, err
 }
 
+// ListImagesRepository returns all the images names
+func ListImagesRepository(ctx context.Context, ociBin string) ([]string, error) {
+	rr, err := runCmd(exec.CommandContext(ctx, ociBin, "images", "--format", "{{.Repository}}:{{.Tag}}"))
+	if err != nil {
+		return nil, err
+	}
+	s := bufio.NewScanner(bytes.NewReader(rr.Stdout.Bytes()))
+	var names []string
+	for s.Scan() {
+		n := strings.TrimSpace(s.Text())
+		if n != "" {
+			// add docker.io prefix to image name
+			if !strings.Contains(n, ".io/") {
+				n = "docker.io/" + n
+			}
+			names = append(names, n)
+		}
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+	return names, nil
+}
+
 // PointToHostDockerDaemon will unset env variables that point to docker inside minikube
 // to make sure it points to the docker daemon installed by user.
 func PointToHostDockerDaemon() error {


### PR DESCRIPTION
This PR introduce printing additional info about preserving kicbase image and generates
image deletion command for user when running `minikube delete`.
Message is printed only when `--purge` option is used.

E.g.
```
$ minikube delete --all --purge
🔥  Deleting "minikube" in docker ...
🔥  Removing /home/piotr/.minikube/machines/minikube ...
💀  Removed all traces of the "minikube" cluster.
🔥  Successfully deleted all profiles
💀  Successfully purged minikube directory located at - [/home/piotr/.minikube]
📌  Kicbase images have not been deleted. To delete images run:
    ▪ docker rmi gcr.io/k8s-minikube/kicbase:v0.0.28
```

Fixes: #10708
