### PR TITLE
`minikube addons list` shows addons if cluster does not exist

### DIFF
--- a/cmd/minikube/cmd/config/addons_list.go
+++ b/cmd/minikube/cmd/config/addons_list.go
@@ -52,7 +52,10 @@ var addonsListCmd = &cobra.Command{
 			exit.Message(reason.Usage, "usage: minikube addons list")
 		}
 
-		_, cc := mustload.Partial(ClusterFlagValue())
+		var cc *config.ClusterConfig
+		if config.ProfileExists(ClusterFlagValue()) {
+			_, cc = mustload.Partial(ClusterFlagValue())
+		}
 		switch strings.ToLower(addonListOutput) {
 		case "list":
 			printAddonsList(cc)
@@ -98,18 +101,26 @@ var printAddonsList = func(cc *config.ClusterConfig) {
 
 	var tData [][]string
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"Addon Name", "Profile", "Status", "Maintainer"})
 	table.SetAutoFormatHeaders(true)
 	table.SetBorders(tablewriter.Border{Left: true, Top: true, Right: true, Bottom: true})
 	table.SetCenterSeparator("|")
+	if cc == nil {
+		table.SetHeader([]string{"Addon Name", "Maintainer"})
+	} else {
+		table.SetHeader([]string{"Addon Name", "Profile", "Status", "Maintainer"})
+	}
 
 	for _, addonName := range addonNames {
 		addonBundle := assets.Addons[addonName]
-		enabled := addonBundle.IsEnabled(cc)
 		maintainer := addonBundle.Maintainer
 		if maintainer == "" {
 			maintainer = "unknown (third-party)"
 		}
+		if cc == nil {
+			tData = append(tData, []string{addonName, maintainer})
+			continue
+		}
+		enabled := addonBundle.IsEnabled(cc)
 		tData = append(tData, []string{addonName, cc.Name, fmt.Sprintf("%s %s", stringFromStatus(enabled), iconFromStatus(enabled)), maintainer})
 	}
 


### PR DESCRIPTION
Closes https://github.com/kubernetes/minikube/issues/12736

**Before:**
```
$ minikube addons list
🤷  Profile "minikube" not found. Run "minikube profile list" to view all profiles.
👉  To start a cluster, run: "minikube start"
```

**Now:**
```
$ minikube addons list
|-----------------------------|-----------------------|
|         ADDON NAME          |      MAINTAINER       |
|-----------------------------|-----------------------|
| ambassador                  | unknown (third-party) |
| auto-pause                  | google                |
| csi-hostpath-driver         | kubernetes            |
| dashboard                   | kubernetes            |
| default-storageclass        | kubernetes            |
| efk                         | unknown (third-party) |
| freshpod                    | google                |
| gcp-auth                    | google                |
| gvisor                      | google                |
| helm-tiller                 | unknown (third-party) |
| ingress                     | unknown (third-party) |
| ingress-dns                 | unknown (third-party) |
| istio                       | unknown (third-party) |
| istio-provisioner           | unknown (third-party) |
| kubevirt                    | unknown (third-party) |
| logviewer                   | google                |
| metallb                     | unknown (third-party) |
| metrics-server              | kubernetes            |
| nvidia-driver-installer     | google                |
| nvidia-gpu-device-plugin    | unknown (third-party) |
| olm                         | unknown (third-party) |
| pod-security-policy         | unknown (third-party) |
| portainer                   | portainer.io          |
| registry                    | google                |
| registry-aliases            | unknown (third-party) |
| registry-creds              | unknown (third-party) |
| storage-provisioner         | kubernetes            |
| storage-provisioner-gluster | unknown (third-party) |
| volumesnapshots             | kubernetes            |
|-----------------------------|-----------------------|
```