### PR TITLE
fix zsh completion

### DIFF
--- a/cmd/minikube/cmd/completion.go
+++ b/cmd/minikube/cmd/completion.go
@@ -273,6 +273,7 @@ __minikube_convert_bash_to_zsh() {
 	-e "s/${LWORD}compopt${RWORD}/__minikube_compopt/g" \
 	-e "s/${LWORD}declare${RWORD}/__minikube_declare/g" \
 	-e "s/\\\$(type${RWORD}/\$(__minikube_type/g" \
+	-e "s/aliashash\[\"\([a-z]*\)\"\]/aliashash[\1]/g" \
 	<<'BASH_COMPLETION_EOF'
 `
 
@@ -292,7 +293,7 @@ __minikube_convert_bash_to_zsh() {
 	}
 
 	buf := new(bytes.Buffer)
-	err = cmd.GenZshCompletion(buf)
+	err = cmd.GenBashCompletion(buf)
 	if err != nil {
 		return errors.Wrap(err, "Error generating zsh completion")
 	}


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
my previous fix is wrong
zsh completion is not working in v1.24.0-beta.0
revert wrong change (https://github.com/kubernetes/minikube/pull/12420) and re-fix

**before PR (v1.24.0-beta.0)**
tab completion does not work
```zsh
$ out/minikube version
minikube version: v1.24.0-beta.0
commit: 06b3f0a03b012632c86627e227cfeb29b12aed5c
$ out/minikube completion zsh > before.completion.txt
```
[before.completion.txt](https://github.com/kubernetes/minikube/files/7462777/before.completion.txt)
![Screenshot from 2021-11-03 02-47-40](https://user-images.githubusercontent.com/32242766/139918562-2e500b31-7f93-4c77-8913-140e125a8b64.png)

**after PR**
completion works
```zsh
$ out/minikube version
minikube version: v1.24.0-beta.0
commit: ca928b43ed86ed65056700dba67ec1a5e0b5714e
$ out/minikube completion zsh > after.completion.txt 
```
[after.completion.txt](https://github.com/kubernetes/minikube/files/7462749/after.completion.txt)
![Screenshot from 2021-11-03 02-45-25](https://user-images.githubusercontent.com/32242766/139918169-bc07cf23-fd24-4146-b2a4-f2b20564ea49.png)

**stable release**
completion is broken
```zsh
$ out/minikube version
minikube version: v1.23.2
commit:  0a0ad764652082477c00d51d2475284b5d39ceed
$ out/minikube completion zsh > v1.23.completion.txt
```
[v1.23.completion.txt](https://github.com/kubernetes/minikube/files/7462826/v1.23.completion.txt)
![Screenshot from 2021-11-03 02-49-49](https://user-images.githubusercontent.com/32242766/139918875-307e8425-9fb9-454f-9afc-48a1eb4def90.png)

