### PR TITLE
Add --no-kubernetes flag  to start minikube without kubernetes

### DIFF
--- a/cmd/minikube/cmd/config/profile_list.go
+++ b/cmd/minikube/cmd/config/profile_list.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/minikube/pkg/minikube/bootstrapper/bsutil/kverify"
 	"k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/machine"
@@ -165,7 +166,7 @@ func profilesToTableData(profiles []*config.Profile) [][]string {
 		}
 
 		k8sVersion := p.Config.KubernetesConfig.KubernetesVersion
-		if k8sVersion == "v0.0.0" { // for --no-kubernetes flag
+		if k8sVersion == constants.NoKubernetesVersion { // for --no-kubernetes flag
 			k8sVersion = "N/A"
 		}
 		data = append(data, []string{p.Name, p.Config.Driver, p.Config.KubernetesConfig.ContainerRuntime, cp.IP, strconv.Itoa(cp.Port), k8sVersion, p.Status, strconv.Itoa(len(p.Config.Nodes))})

--- a/cmd/minikube/cmd/config/profile_list.go
+++ b/cmd/minikube/cmd/config/profile_list.go
@@ -164,7 +164,11 @@ func profilesToTableData(profiles []*config.Profile) [][]string {
 			exit.Error(reason.GuestCpConfig, "error getting primary control plane", err)
 		}
 
-		data = append(data, []string{p.Name, p.Config.Driver, p.Config.KubernetesConfig.ContainerRuntime, cp.IP, strconv.Itoa(cp.Port), p.Config.KubernetesConfig.KubernetesVersion, p.Status, strconv.Itoa(len(p.Config.Nodes))})
+		k8sVersion := p.Config.KubernetesConfig.KubernetesVersion
+		if k8sVersion == "v0.0.0" { // for --no-kubernetes flag
+			k8sVersion = "N/A"
+		}
+		data = append(data, []string{p.Name, p.Config.Driver, p.Config.KubernetesConfig.ContainerRuntime, cp.IP, strconv.Itoa(cp.Port), k8sVersion, p.Status, strconv.Itoa(len(p.Config.Nodes))})
 	}
 	return data
 }

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1529,7 +1529,9 @@ func isBaseImageApplicable(drv string) bool {
 func getKubernetesVersion(old *config.ClusterConfig) string {
 	if viper.GetBool(noKubernetes) {
 		klog.Infof("No Kubernetes flag is set, setting Kubernetes version to %s", constants.NoKubernetesVersion)
-		viper.Set(kubernetesVersion, constants.NoKubernetesVersion)
+		if old != nil {
+			old.KubernetesConfig.KubernetesVersion = constants.NoKubernetesVersion
+		}
 	}
 
 	paramVersion := viper.GetString(kubernetesVersion)

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -437,7 +437,7 @@ func showKubectlInfo(kcs *kubeconfig.Settings, k8sVersion string, machineName st
 		register.Reg.SetStep(register.Done)
 		out.Step(style.Ready, "Done! minikube is ready without Kubernetes!")
 		out.BoxedWithConfig(box.Config{Py: 1, Px: 4, Type: "Round", Color: "Green"}, style.Tip, "Things to try without Kubernetes ...", `- "minikube ssh" to SSH into minikube's node.
-- "minikube docker-env" to build images by pointing to the docker inside minikube
+- "minikube docker-env" to point your docker-cli to the docker inside minikube.
 - "minikube image" to build images without docker`)
 		return nil
 	}

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -433,7 +433,7 @@ func displayEnviron(env []string) {
 }
 
 func showKubectlInfo(kcs *kubeconfig.Settings, k8sVersion string, machineName string) error {
-	if k8sVersion == "v0.0.0" {
+	if k8sVersion == constants.NoKubernetesVersion {
 		register.Reg.SetStep(register.Done)
 		out.Step(style.Ready, "Done! minikube is ready without Kubernetes!")
 		out.BoxedWithConfig(box.Config{Py: 1, Px: 4, Type: "Round", Color: "Green"}, style.Tip, "Things to try without Kubernetes ...", `- "minikube ssh" to SSH into minikube's node.

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1530,7 +1530,7 @@ func isBaseImageApplicable(drv string) bool {
 
 func getKubernetesVersion(old *config.ClusterConfig) string {
 	if viper.GetBool(noKubernetes) {
-		klog.Info("No Kubernetes flag is set, setting Kubernetes version to v0.0.0")
+		klog.Infof("No Kubernetes flag is set, setting Kubernetes version to %s", constants.NoKubernetesVersion)
 		viper.Set(kubernetesVersion, constants.NoKubernetesVersion)
 	}
 

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1475,22 +1475,12 @@ func autoSetDriverOptions(cmd *cobra.Command, drvName string) (err error) {
 // validateKubernetesVersion ensures that the requested version is reasonable
 func validateKubernetesVersion(old *config.ClusterConfig) {
 	nvs, _ := semver.Make(strings.TrimPrefix(getKubernetesVersion(old), version.VersionPrefix))
-	oldestVersion, err := semver.Make(strings.TrimPrefix(constants.OldestKubernetesVersion, version.VersionPrefix))
-	if err != nil {
-		exit.Message(reason.InternalSemverParse, "Unable to parse oldest Kubernetes version from constants: {{.error}}", out.V{"error": err})
-	}
-	defaultVersion, err := semver.Make(strings.TrimPrefix(constants.DefaultKubernetesVersion, version.VersionPrefix))
-	if err != nil {
-		exit.Message(reason.InternalSemverParse, "Unable to parse default Kubernetes version from constants: {{.error}}", out.V{"error": err})
-	}
-
-	zeroVersion, err := semver.Make("0.0.0")
-	if err != nil {
-		exit.Message(reason.InternalSemverParse, "Unable to parse v0.0.0 Kubernetes : {{.error}}", out.V{"error": err})
-	}
+	oldestVersion := semver.MustParse(strings.TrimPrefix(constants.OldestKubernetesVersion, version.VersionPrefix))
+	defaultVersion := semver.MustParse(strings.TrimPrefix(constants.DefaultKubernetesVersion, version.VersionPrefix))
+	zeroVersion := semver.MustParse(strings.TrimPrefix(constants.NoKubernetesVersion, version.VersionPrefix))
 
 	if nvs.Equals(zeroVersion) {
-		klog.Info("No kuberentes version set for minikube, setting Kubernetes version to v0.0.0")
+		klog.Infof("No Kuberentes version set for minikube, setting Kubernetes version to %s", constants.NoKubernetesVersion)
 		return
 	}
 	if nvs.LT(oldestVersion) {
@@ -1541,8 +1531,7 @@ func isBaseImageApplicable(drv string) bool {
 func getKubernetesVersion(old *config.ClusterConfig) string {
 	if viper.GetBool(noKubernetes) {
 		klog.Info("No Kubernetes flag is set, setting Kubernetes version to v0.0.0")
-		viper.Set(kubernetesVersion, "v0.0.0")
-
+		viper.Set(kubernetesVersion, constants.NoKubernetesVersion)
 	}
 
 	paramVersion := viper.GetString(kubernetesVersion)

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -442,8 +442,6 @@ func showKubectlInfo(kcs *kubeconfig.Settings, k8sVersion string, machineName st
 		return nil
 	}
 
-	// here are some ideas to do without Kubernetes:
-
 	// To be shown at the end, regardless of exit path
 	defer func() {
 		register.Reg.SetStep(register.Done)

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -438,7 +438,7 @@ func showKubectlInfo(kcs *kubeconfig.Settings, k8sVersion string, machineName st
 		out.Step(style.Ready, "Done! minikube is ready without Kubernetes!")
 		out.BoxedWithConfig(box.Config{Py: 1, Px: 4, Type: "Round", Color: "Green"}, style.Tip, "Things to try without Kubernetes ...", `- "minikube ssh" to SSH into minikube's node.
 - "minikube docker-env" to point your docker-cli to the docker inside minikube.
-- "minikube image" to build images without docker`)
+- "minikube image" to build images without docker.`)
 		return nil
 	}
 

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -55,6 +55,7 @@ const (
 	nfsSharesRoot           = "nfs-shares-root"
 	nfsShare                = "nfs-share"
 	kubernetesVersion       = "kubernetes-version"
+	noKubernetes            = "no-kubernetes"
 	hostOnlyCIDR            = "host-only-cidr"
 	containerRuntime        = "container-runtime"
 	criSocket               = "cri-socket"
@@ -164,6 +165,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().Bool(installAddons, true, "If set, install addons. Defaults to true.")
 	startCmd.Flags().IntP(nodes, "n", 1, "The number of nodes to spin up. Defaults to 1.")
 	startCmd.Flags().Bool(preload, true, "If set, download tarball of preloaded images if available to improve start time. Defaults to true.")
+	startCmd.Flags().Bool(noKubernetes, false, "If set, minikube VM/container will start without starting or configuring Kubernetes. (only works on new clusters)")
 	startCmd.Flags().Bool(deleteOnFailure, false, "If set, delete the current cluster if start fails and try again. Defaults to false.")
 	startCmd.Flags().Bool(forceSystemd, false, "If set, force the container runtime to use systemd as cgroup manager. Defaults to false.")
 	startCmd.Flags().StringP(network, "", "", "network to run minikube with. Now it is used by docker/podman and KVM drivers. If left empty, minikube will create a new network.")

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -40,6 +40,9 @@ const (
 	NewestKubernetesVersion = "v1.22.4-rc.0"
 	// OldestKubernetesVersion is the oldest Kubernetes version to test against
 	OldestKubernetesVersion = "v1.14.0"
+	// NoKubernetesVersion is the version used when users does NOT want to install kubernetes
+	NoKubernetesVersion = "v0.0.0"
+
 	// DefaultClusterName is the default nane for the k8s cluster
 	DefaultClusterName = "minikube"
 	// DockerDaemonPort is the port Docker daemon listening inside a minikube node (vm or container).

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -290,7 +290,7 @@ func Provision(cc *config.ClusterConfig, n *config.Node, apiServer bool, delOnFa
 	register.Reg.SetStep(register.StartingNode)
 	name := config.MachineName(*cc, *n)
 
-	// for sake of trasnlation process be easy we make the code a bit more verbose and the if statements may seem unnessecary
+	// for sake of trasnlation process be easy we make the code a bit more verbose and the if statements may seem unnecessary
 	if cc.KubernetesConfig.KubernetesVersion == constants.NoKubernetesVersion {
 		out.Step(style.ThumbsUp, "Starting minikube without Kubernetes {{.name}} in cluster {{.cluster}}", out.V{"name": name, "cluster": cc.Name})
 	} else {

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -89,7 +89,7 @@ type Starter struct {
 // Start spins up a guest and starts the Kubernetes node.
 func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 	var kcs *kubeconfig.Settings
-	if starter.Node.KubernetesVersion == "v0.0.0" {
+	if starter.Node.KubernetesVersion == constants.NoKubernetesVersion { // do not bootstrap cluster if --no-kubernetes
 		return kcs, config.Write(viper.GetString(config.ProfileName), starter.Cfg)
 	}
 	// wait for preloaded tarball to finish downloading before configuring runtimes
@@ -294,7 +294,7 @@ func Provision(cc *config.ClusterConfig, n *config.Node, apiServer bool, delOnFa
 	if !apiServer {
 		startingPhrase = "Starting worker node"
 	}
-	if cc.KubernetesConfig.KubernetesVersion == "v0.0.0" {
+	if cc.KubernetesConfig.KubernetesVersion == constants.NoKubernetesVersion {
 		startingPhrase = "Starting minikube without Kubernetes"
 	}
 

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -290,15 +290,15 @@ func Provision(cc *config.ClusterConfig, n *config.Node, apiServer bool, delOnFa
 	register.Reg.SetStep(register.StartingNode)
 	name := config.MachineName(*cc, *n)
 
-	nodeTitle := "Starting control plane node"
+	startingPhrase := "Starting control plane node"
 	if !apiServer {
-		nodeTitle = "Starting worker node"
+		startingPhrase = "Starting worker node"
 	}
 	if cc.KubernetesConfig.KubernetesVersion == "v0.0.0" {
-		nodeTitle = "Starting minikube without Kubernetes"
+		startingPhrase = "Starting minikube without Kubernetes"
 	}
 
-	out.Step(style.ThumbsUp, "{{.nodeName}} {{.name}} in cluster {{.cluster}}", out.V{"nodeName": nodeTitle, "name": name, "cluster": cc.Name})
+	out.Step(style.ThumbsUp, "{{.nodeName}} {{.name}} in cluster {{.cluster}}", out.V{"nodeName": startingPhrase, "name": name, "cluster": cc.Name})
 
 	if driver.IsKIC(cc.Driver) {
 		beginDownloadKicBaseImage(&kicGroup, cc, viper.GetBool("download-only"))

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -290,15 +290,17 @@ func Provision(cc *config.ClusterConfig, n *config.Node, apiServer bool, delOnFa
 	register.Reg.SetStep(register.StartingNode)
 	name := config.MachineName(*cc, *n)
 
-	startingPhrase := "Starting control plane node"
-	if !apiServer {
-		startingPhrase = "Starting worker node"
-	}
+	// for sake of trasnlation process be easy we make the code a bit more verbose and the if statements may seem unnessecary
 	if cc.KubernetesConfig.KubernetesVersion == constants.NoKubernetesVersion {
-		startingPhrase = "Starting minikube without Kubernetes"
-	}
+		out.Step(style.ThumbsUp, "Starting minikube without Kubernetes {{.name}} in cluster {{.cluster}}", out.V{"name": name, "cluster": cc.Name})
+	} else {
+		if apiServer {
+			out.Step(style.ThumbsUp, "Starting control plane node {{.name}} in cluster {{.cluster}}", out.V{"name": name, "cluster": cc.Name})
+		} else {
+			out.Step(style.ThumbsUp, "Starting worker node {{.name}} in cluster {{.cluster}}", out.V{"name": name, "cluster": cc.Name})
+		}
 
-	out.Step(style.ThumbsUp, "{{.nodeName}} {{.name}} in cluster {{.cluster}}", out.V{"nodeName": startingPhrase, "name": name, "cluster": cc.Name})
+	}
 
 	if driver.IsKIC(cc.Driver) {
 		beginDownloadKicBaseImage(&kicGroup, cc, viper.GetBool("download-only"))

--- a/pkg/minikube/out/out.go
+++ b/pkg/minikube/out/out.go
@@ -134,13 +134,13 @@ func BoxedErr(format string, a ...V) {
 }
 
 // BoxedWithConfig writes a templated message in a box with customized style config to stdout
-func BoxedWithConfig(cfg box.Config, st style.Enum, title string, format string, a ...V) {
+func BoxedWithConfig(cfg box.Config, st style.Enum, title string, text string, a ...V) {
 	if st != style.None {
 		title = Sprintf(st, title)
 	}
 	// need to make sure no newlines are in the title otherwise box-cli-maker panics
 	title = strings.ReplaceAll(title, "\n", "")
-	boxedCommon(String, cfg, title, format, a...)
+	boxedCommon(String, cfg, title, text, a...)
 }
 
 // Sprintf is used for returning the string (doesn't write anything)

--- a/test/integration/no_kubernetes.go
+++ b/test/integration/no_kubernetes.go
@@ -123,7 +123,7 @@ func validateProfileListNoK8S(ctx context.Context, t *testing.T, profile string)
 }
 
 // validateStartNoArgs valides that minikube start with no args works
-func validateStartNorArgs(ctx context.Context, t *testing.T, profile string) {
+func validateStartNoArgs(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 
 	args := append([]string{"start", "-p", profile, "--no-kubernetes"}, StartArgs()...)

--- a/test/integration/no_kubernetes.go
+++ b/test/integration/no_kubernetes.go
@@ -27,7 +27,7 @@ import (
 )
 
 // TestNoKubernetes tests starting minikube without Kubernetes,
-// for usecases where user only needs to use the container runtime (docker,containerd,crio) inside minikube
+// for use cases where user only needs to use the container runtime (docker, containerd, crio) inside minikube
 func TestNoKubernetes(t *testing.T) {
 	MaybeParallel(t)
 

--- a/test/integration/no_kubernetes.go
+++ b/test/integration/no_kubernetes.go
@@ -111,7 +111,7 @@ func validateProfileListNoK8S(ctx context.Context, t *testing.T, profile string)
 	}
 
 	if !strings.Contains(rr.Output(), "N/A") {
-		t.Fatalf("expected N/A in the profile list for kubernets version but got : %q : %v", rr.Command(), rr.Output())
+		t.Fatalf("expected N/A in the profile list for kubernetes version but got : %q : %v", rr.Command(), rr.Output())
 	}
 
 	args = []string{"profile", "list", "--output=json"}

--- a/test/integration/no_kubernetes.go
+++ b/test/integration/no_kubernetes.go
@@ -1,0 +1,135 @@
+//go:build integration
+// +build integration
+
+/*
+Copyright 2021 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestNoKubernetes tests starting minikube without Kubernetes,
+// for usecases where user only needs to use the container runtime (docker,containerd,crio) inside minikube
+func TestNoKubernetes(t *testing.T) {
+	MaybeParallel(t)
+
+	type validateFunc func(context.Context, *testing.T, string)
+	profile := UniqueProfileName("NoKubernetes")
+	ctx, cancel := context.WithTimeout(context.Background(), Minutes(5))
+	defer Cleanup(t, profile, cancel)
+
+	// Serial tests
+	t.Run("serial", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			validator validateFunc
+		}{
+			{"Start", validateStartNoK8S},
+			{"VerifyK8sNotRunning", validateK8SNotRunning},
+			{"ProfileList", validateProfileListNoK8S},
+			{"Stop", validateStopNoK8S},
+			{"StartNoArgs", validateStartNorArgs},
+			{"VerifyK8sNotRunningSecond", validateK8SNotRunning},
+		}
+
+		for _, tc := range tests {
+			tc := tc
+
+			if ctx.Err() == context.DeadlineExceeded {
+				t.Fatalf("Unable to run more tests (deadline exceeded)")
+			}
+
+			t.Run(tc.name, func(t *testing.T) {
+				tc.validator(ctx, t, profile)
+				if t.Failed() && *postMortemLogs {
+					PostMortemLogs(t, profile)
+				}
+			})
+		}
+	})
+}
+
+// validateStartNoK8S starts a minikube cluster without kuberentes started/configured
+func validateStartNoK8S(ctx context.Context, t *testing.T, profile string) {
+	defer PostMortemLogs(t, profile)
+
+	args := append([]string{"start", "-p", profile, "--no-kubernetes"}, StartArgs()...)
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
+	if err != nil {
+		t.Fatalf("failed to start minikube with args: %q : %v", rr.Command(), err)
+	}
+}
+
+// validateK8SNotRunning validates that there is no kubernetes running inside minikube
+func validateK8SNotRunning(ctx context.Context, t *testing.T, profile string) {
+	defer PostMortemLogs(t, profile)
+
+	args := []string{"ssh", "-p", profile, "sudo systemctl is-active --quiet service kubelet"}
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
+	if err == nil {
+		t.Fatalf("Expected Kubelet not to be running and but it is running : %q : %v", rr.Command(), err)
+	}
+}
+
+// validateStopNoK8S validates that minikube is stopped after a --no-kubernetes start
+func validateStopNoK8S(ctx context.Context, t *testing.T, profile string) {
+	defer PostMortemLogs(t, profile)
+
+	args := []string{"stop", "-p", profile}
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
+	if err != nil {
+		t.Fatalf("Failed to stop minikbue %q : %v", rr.Command(), err)
+	}
+}
+
+// validateProfileListNoK8S validates that profile list works with --no-kubernetes
+func validateProfileListNoK8S(ctx context.Context, t *testing.T, profile string) {
+	defer PostMortemLogs(t, profile)
+
+	args := []string{"profile", "list"}
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
+	if err != nil {
+		t.Fatalf("Profile list failed : %q : %v", rr.Command(), err)
+	}
+
+	if !strings.Contains(rr.Output(), "N/A") {
+		t.Fatalf("expected N/A in the profile list for kubernets version but got : %q : %v", rr.Command(), rr.Output())
+	}
+
+	args = []string{"profile", "list", "--output=json"}
+	rr, err = Run(t, exec.CommandContext(ctx, Target(), args...))
+	if err != nil {
+		t.Fatalf("Profile list --output=json failed : %q : %v", rr.Command(), err)
+	}
+
+}
+
+// validateStartNorArgs valides that minikube start with no args works
+func validateStartNorArgs(ctx context.Context, t *testing.T, profile string) {
+	defer PostMortemLogs(t, profile)
+
+	args := append([]string{"start", "-p", profile, "--no-kubernetes"}, StartArgs()...)
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
+	if err != nil {
+		t.Fatalf("failed to start minikube with args: %q : %v", rr.Command(), err)
+	}
+
+}

--- a/test/integration/no_kubernetes.go
+++ b/test/integration/no_kubernetes.go
@@ -67,7 +67,7 @@ func TestNoKubernetes(t *testing.T) {
 	})
 }
 
-// validateStartNoK8S starts a minikube cluster without kuberentes started/configured
+// validateStartNoK8S starts a minikube cluster without kubernetes started/configured
 func validateStartNoK8S(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 

--- a/test/integration/no_kubernetes.go
+++ b/test/integration/no_kubernetes.go
@@ -46,7 +46,7 @@ func TestNoKubernetes(t *testing.T) {
 			{"VerifyK8sNotRunning", validateK8SNotRunning},
 			{"ProfileList", validateProfileListNoK8S},
 			{"Stop", validateStopNoK8S},
-			{"StartNoArgs", validateStartNorArgs},
+			{"StartNoArgs", validateStartNoArgs},
 			{"VerifyK8sNotRunningSecond", validateK8SNotRunning},
 		}
 

--- a/test/integration/no_kubernetes.go
+++ b/test/integration/no_kubernetes.go
@@ -122,7 +122,7 @@ func validateProfileListNoK8S(ctx context.Context, t *testing.T, profile string)
 
 }
 
-// validateStartNorArgs valides that minikube start with no args works
+// validateStartNoArgs valides that minikube start with no args works
 func validateStartNorArgs(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 

--- a/test/integration/no_kubernetes.go
+++ b/test/integration/no_kubernetes.go
@@ -96,7 +96,7 @@ func validateStopNoK8S(ctx context.Context, t *testing.T, profile string) {
 	args := []string{"stop", "-p", profile}
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
-		t.Fatalf("Failed to stop minikbue %q : %v", rr.Command(), err)
+		t.Fatalf("Failed to stop minikube %q : %v", rr.Command(), err)
 	}
 }
 

--- a/test/integration/no_kubernetes_test.go
+++ b/test/integration/no_kubernetes_test.go
@@ -31,6 +31,9 @@ import (
 func TestNoKubernetes(t *testing.T) {
 	MaybeParallel(t)
 
+	if NoneDriver() {
+		t.Skip("None driver does not need --no-kubernetes test")
+	}
 	type validateFunc func(context.Context, *testing.T, string)
 	profile := UniqueProfileName("NoKubernetes")
 	ctx, cancel := context.WithTimeout(context.Background(), Minutes(5))

--- a/test/integration/no_kubernetes_test.go
+++ b/test/integration/no_kubernetes_test.go
@@ -126,7 +126,7 @@ func validateProfileListNoK8S(ctx context.Context, t *testing.T, profile string)
 func validateStartNoArgs(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 
-	args := append([]string{"start", "-p", profile, "--no-kubernetes"}, StartArgs()...)
+	args := append([]string{"start", "-p", profile}, StartArgs()...)
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
 		t.Fatalf("failed to start minikube with args: %q : %v", rr.Command(), err)


### PR DESCRIPTION
based on a survery comment that asked they wish they could start minikbue without kubernetes

```
$ time mk start --no-kubernetes
😄  minikube v1.24.0-beta.0 on Darwin 11.6 (arm64)
✨  Automatically selected the docker driver
👍  Starting minikube without Kubernetes minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=1988MB) ...
🏄  Done! minikube is ready without Kubernetes!
╭─────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                         │
│                        💡  Things to try without Kubernetes ...                         │
│                                                                                         │
│    - "minikube ssh" to SSH into minikube's node.                                        │
│    - "minikube docker-env" to build images by pointing to the docker inside minikube    │
│    - "minikube image" to build images without docker                                    │
│                                                                                         │
╰─────────────────────────────────────────────────────────────────────────────────────────╯

real    0m7.277s
user    0m2.730s
sys     0m1.320s
```


$ mk profile list

```

|----------|-----------|---------|--------------|------|---------|---------|-------|
| Profile  | VM Driver | Runtime |      IP      | Port | Version | Status  | Nodes |
|----------|-----------|---------|--------------|------|---------|---------|-------|
| minikube | docker    | docker  | 192.168.49.2 | 8443 | N/A     | Stopped |     1 |
|----------|-----------|---------|--------------|------|---------|---------|-------|
```


list of the procs running inside minikube

```
docker@minikube:~$ ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.3  0.4  21380  9368 ?        Ss   22:47   0:00 /sbin/init
root         174  0.0  0.3  28468  7076 ?        S<s  22:47   0:00 /lib/systemd/systemd-journald
message+     186  0.0  0.1   6812  3184 ?        Ss   22:47   0:00 /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation
root         189  1.0  2.0 1481208 41376 ?       Ssl  22:47   0:00 /usr/bin/containerd
root         196  0.0  0.3  12212  6468 ?        Ss   22:47   0:00 sshd: /usr/sbin/sshd -D [listener] 0 of 10-100 startups
root         464  0.1  3.3 1437968 68904 ?       Ssl  22:47   0:00 /usr/bin/dockerd -H tcp://0.0.0.0:2376 -H unix:///var/run/docker.sock --default-ulimit=nof
root         631  0.0  0.3  12324  6344 ?        Ss   22:48   0:00 sshd: docker [priv]
docker       633  0.0  0.1  12324  2996 ?        S    22:48   0:00 sshd: docker@pts/1
docker       634  0.0  0.1   3876  3108 pts/1    Ss   22:48   0:00 -bash
docker       642  0.0  0.1   5468  2400 pts/1    R+   22:48   0:00 ps aux
```

closes https://github.com/kubernetes/minikube/issues/12845 
TODO it should close https://github.com/kubernetes/minikube/issues/12844