### PR TITLE
stop setting ACLs on preload tarball

### DIFF
--- a/hack/preload-images/upload.go
+++ b/hack/preload-images/upload.go
@@ -34,19 +34,5 @@ func uploadTarball(tarballFilename string) error {
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return errors.Wrapf(err, "uploading %s to GCS bucket: %v\n%s", hostPath, err, string(output))
 	}
-	// Make tarball public to all users
-	gcsPath := fmt.Sprintf("%s/%s", gcsDest, tarballFilename)
-	cmd = exec.Command("gsutil", "acl", "ch", "-u", "AllUsers:R", gcsPath)
-	fmt.Printf("Running: %v\n", cmd.Args)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		fmt.Printf(`Failed to update ACLs on this tarball in GCS. Please run
-		
-gsutil acl ch -u AllUsers:R %s
-
-manually to make this link public, or rerun this script to rebuild and reupload the tarball.
-		
-		`, gcsPath)
-		return errors.Wrapf(err, "uploading %s to GCS bucket: %v\n%s", hostPath, err, string(output))
-	}
 	return nil
 }


### PR DESCRIPTION
Our GCP project now enforces BUCKET level ACLs on GCS instead of object level ACLs, so we can no longer and no longer want to set ACLs on each preload tarball as we upload them