### PR TITLE
register node add initial step

### DIFF
--- a/cmd/minikube/cmd/node_add.go
+++ b/cmd/minikube/cmd/node_add.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/mustload"
 	"k8s.io/minikube/pkg/minikube/node"
 	"k8s.io/minikube/pkg/minikube/out"
+	"k8s.io/minikube/pkg/minikube/out/register"
 	"k8s.io/minikube/pkg/minikube/reason"
 	"k8s.io/minikube/pkg/minikube/style"
 )
@@ -70,6 +71,7 @@ var nodeAddCmd = &cobra.Command{
 			}
 		}
 
+		register.Reg.SetStep(register.InitialSetup)
 		if err := node.Add(cc, n, false); err != nil {
 			_, err := maybeDeleteAndRetry(cmd, *cc, n, nil, err)
 			if err != nil {


### PR DESCRIPTION
Before: 
```
$ minikube node add
😄  Adding node m03 to cluster minikube
E1104 13:15:49.142076   53098 register.go:141] unexpected first step: ""
👍  Starting node minikube-m03 in cluster minikube
E1104 13:15:49.162276   53098 register.go:141] unexpected first step: ""
🚜  Pulling base image ...
E1104 13:15:49.428759   53098 register.go:141] unexpected first step: ""
🔥  Creating docker container (CPUs=2, Memory=2200MB) ...| E1104 13:16:14.208955   53098 register.go:141] unexpected first step: ""

🐳  Preparing Kubernetes v1.22.3 on Docker 20.10.8 ...\ E1104 13:16:24.055722   53098 register.go:141] unexpected first step: ""

🔎  Verifying Kubernetes components...
🏄  Successfully added m03 to minikube!
```

After:
```
$ minikube node add 
😄  Adding node m02 to cluster minikube
👍  Starting node minikube-m02 in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=2200MB) ...
🐳  Preparing Kubernetes v1.22.3 on Docker 20.10.8 ...
🔎  Verifying Kubernetes components...
🏄  Successfully added m02 to minikube!
```
