### PR TITLE
Skip mount start test on Docker Windows

### DIFF
--- a/pkg/minikube/reason/known_issues.go
+++ b/pkg/minikube/reason/known_issues.go
@@ -17,6 +17,8 @@ limitations under the License.
 package reason
 
 import (
+	"fmt"
+	"os"
 	"regexp"
 
 	"k8s.io/minikube/pkg/minikube/style"
@@ -219,6 +221,21 @@ var hostIssues = []match{
 	{
 		Kind:   HostHomePermission,
 		Regexp: re(`/.minikube/.*: permission denied`),
+	},
+	{
+		Kind: Kind{
+			ID:       "HOST_NOTIFICATION_PLATFORM",
+			ExitCode: ExHostUnsupported,
+			Advice: fmt.Sprintf(`It seems you're running Windows in headless mode.
+Docker Desktop is trying to output a notification but the notification platform is unavailable due to being in headless mode.
+
+You can run Windows in a non-headless mode or you can likely supresses the notifications by enabling file sharing, you can do this two ways:
+1. Enable "Use the WSL 2 based engine" in Docker Desktop
+or
+2. Enable file sharing in Docker Desktop for the %s%s directory`, os.Getenv("HOMEDRIVE"), os.Getenv("HOMEPATH")),
+		},
+		Regexp: re(`The notification platform is unavailable`),
+		GOOS:   []string{"windows"},
 	},
 }
 

--- a/pkg/minikube/reason/known_issues.go
+++ b/pkg/minikube/reason/known_issues.go
@@ -229,7 +229,7 @@ var hostIssues = []match{
 			Advice: fmt.Sprintf(`It seems you're running Windows in headless mode.
 Docker Desktop is trying to output a notification but the notification platform is unavailable due to being in headless mode.
 
-You can run Windows in a non-headless mode or you can likely supresses the notifications by enabling file sharing, you can do this two ways:
+You can run Windows in a non-headless mode or you can likely suppresses the notifications by enabling file sharing, you can do this two ways:
 1. Enable "Use the WSL 2 based engine" in Docker Desktop
 or
 2. Enable file sharing in Docker Desktop for the %s%s directory`, os.Getenv("HOMEDRIVE"), os.Getenv("HOMEPATH")),

--- a/test/integration/mount_start_test.go
+++ b/test/integration/mount_start_test.go
@@ -33,7 +33,7 @@ func TestMountStart(t *testing.T) {
 	}
 	if KicDriver() && runtime.GOOS == "windows" {
 		t.Skip(`skipping: Docker driver on Windows fails mounting due to 'The notification platform is unavailable'
-TODO: Fix 'The notification platform is unavailable' error from occuring: https://github.com/kubernetes/minikube/issues/12931`)
+TODO: Fix 'The notification platform is unavailable' error from occurring: https://github.com/kubernetes/minikube/issues/12931`)
 	}
 
 	type validateFunc func(context.Context, *testing.T, string)

--- a/test/integration/mount_start_test.go
+++ b/test/integration/mount_start_test.go
@@ -22,6 +22,7 @@ package integration
 import (
 	"context"
 	"os/exec"
+	"runtime"
 	"testing"
 )
 
@@ -29,6 +30,9 @@ import (
 func TestMountStart(t *testing.T) {
 	if NoneDriver() {
 		t.Skip("skipping: none driver does not support mount")
+	}
+	if KicDriver() && runtime.GOOS == "windows" {
+		t.Skip("skipping: Docker driver on Windows fails mounting due to 'The notification platform is unavailable'")
 	}
 
 	type validateFunc func(context.Context, *testing.T, string)

--- a/test/integration/mount_start_test.go
+++ b/test/integration/mount_start_test.go
@@ -32,7 +32,8 @@ func TestMountStart(t *testing.T) {
 		t.Skip("skipping: none driver does not support mount")
 	}
 	if KicDriver() && runtime.GOOS == "windows" {
-		t.Skip("skipping: Docker driver on Windows fails mounting due to 'The notification platform is unavailable'")
+		t.Skip(`skipping: Docker driver on Windows fails mounting due to 'The notification platform is unavailable'
+TODO: Fix 'The notification platform is unavailable' error from occuring: https://github.com/kubernetes/minikube/issues/12931`)
 	}
 
 	type validateFunc func(context.Context, *testing.T, string)


### PR DESCRIPTION
<img width="987" alt="Screen Shot 2021-11-08 at 10 15 30 AM" src="https://user-images.githubusercontent.com/44844360/140768008-6e050c42-11bb-4345-8c1f-f7a2d08a00a2.png">

Failing with:
```
! StartHost failed, but will try again: creating host: create: creating: create kic node: create container: docker run -d -t --privileged --device /dev/fuse --security-opt seccomp=unconfined --tmpfs /tmp --tmpfs /run -v /lib/modules:/lib/modules:ro --hostname mount-start-1-20211108094938-6932 --name mount-start-1-20211108094938-6932 --label created_by.minikube.sigs.k8s.io=true --label name.minikube.sigs.k8s.io=mount-start-1-20211108094938-6932 --label role.minikube.sigs.k8s.io= --label mode.minikube.sigs.k8s.io=mount-start-1-20211108094938-6932 --network mount-start-1-20211108094938-6932 --ip 192.168.49.2 --volume mount-start-1-20211108094938-6932:/var --security-opt apparmor=unconfined --memory=2048mb --memory-swap=2048mb --cpus=2 -e container=docker --expose 8443 --volume=C:\Users\jenkins.minikube8:/minikube-host --publish=127.0.0.1::8443 --publish=127.0.0.1::22 --publish=127.0.0.1::2376 --publish=127.0.0.1::5000 --publish=127.0.0.1::32443 gcr.io/k8s-minikube/kicbase:v0.0.28@sha256:4780f1897569d2bf
77aafb3d133a08d42b4fe61127f06fcfc90c2c5d902d893c: exit status 125
	stdout:
	
	stderr:
	docker: Error response from daemon: status code not OK but 500: {"Message":"Unhandled exception: The notification platform is unavailable.\r\n\r\nThe notification platform is unavailable.\r\n","StackTrace":"   at Windows.UI.Notifications.ToastNotificationManager.CreateToastNotifier(String applicationId)\r\n   at Docker.WPF.PromptShareDirectory.<PromptUserAsync>d__0.MoveNext() in C:\\workspaces\\stable-2.3.x\\src\\github.com\\docker\\pinata\\win\\src\\Docker.WPF\\PromptShareDirectory.cs:line 25\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Docker.ApiServices.Mounting.FileSharing.<DoShareAsync>d__6.MoveNext() in C:\\workspaces\\stable-2.3.x\\src\\github.com\\docker\\pinata\\win\\src\\Docker.ApiServices\\Mounting\\FileSharing.cs:line 80\r\n--- End of stack trace from previous location whe
re exception was thrown ---\r\n   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Docker.ApiServices.Mounting.FileSharing.<ShareAsync>d__4.MoveNext() in C:\\workspaces\\stable-2.3.x\\src\\github.com\\docker\\pinata\\win\\src\\Docker.ApiServices\\Mounting\\FileSharing.cs:line 47\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Docker.HttpApi.Controllers.FilesharingController.<ShareDirectory>d__2.MoveNext() in C:\\workspaces\\stable-2.3.x\\src\\github.com\\docker\\pinata\\win\\src\\Docker.HttpApi\\Controllers\\FilesharingController.cs:line 21\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.ExceptionServices.Exceptio
nDispatchInfo.Throw()\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at System.Threading.Tasks.TaskHelpersExtensions.<CastToObject>d__1`1.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at System.Web.Http.Controllers.ApiControllerActionInvoker.<InvokeActionAsyncCore>d__1.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at System.Web.Http.Controllers.ActionFilterResult.<ExecuteAsync>d__5.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.Excepti
onServices.ExceptionDispatchInfo.Throw()\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at System.Web.Http.Dispatcher.HttpControllerDispatcher.<SendAsync>d__15.MoveNext()"}.
	See 'docker run --help'.
	
	* Failed to start docker container. Running "minikube delete -p mount-start-1-20211108094938-6932" may fix it: recreate: creating host: create: creating: create kic node: create container: docker run -d -t --privileged --device /dev/fuse --security-opt seccomp=unconfined --tmpfs /tmp --tmpfs /run -v /lib/modules:/lib/modules:ro --hostname mount-start-1-20211108094938-6932 --name mount-start-1-20211108094938-6932 --label created_by.minikube.sigs.k8s.io=true --label name.minikube.sigs.k8s.io=mount-start-1-20211108094938-6932 --label role.minikube.sigs.k8s.io= --label mode.minikube.sigs.k8s.io=mount-start-1-20211108094938-6932 --network mount-start-1-20211108094938-6932 --ip 192.168.49.2 --volume mount-start-1-20211108094938-6932:/var --security-opt apparmor=unconfined --memory=2048mb --memory-swap=2048mb --cpus=2 -e container=docker --expose 8443 --volume=C:\Users\jenkins.minikube8:/minikube-host --publish=127.0.0.1::8443 --publish=127.0.0.1::22 --publish=127.0.0.1::2376 --publish=127.0.0.1::5000 --pub
lish=127.0.0.1::32443 gcr.io/k8s-minikube/kicbase:v0.0.28@sha256:4780f1897569d2bf77aafb3d133a08d42b4fe61127f06fcfc90c2c5d902d893c: exit status 125
	stdout:
	
	stderr:
	docker: Error response from daemon: status code not OK but 500: {"Message":"Unhandled exception: The notification platform is unavailable.\r\n\r\nThe notification platform is unavailable.\r\n","StackTrace":"   at Windows.UI.Notifications.ToastNotificationManager.CreateToastNotifier(String applicationId)\r\n   at Docker.WPF.PromptShareDirectory.<PromptUserAsync>d__0.MoveNext() in C:\\workspaces\\stable-2.3.x\\src\\github.com\\docker\\pinata\\win\\src\\Docker.WPF\\PromptShareDirectory.cs:line 25\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Docker.ApiServices.Mounting.FileSharing.<DoShareAsync>d__6.MoveNext() in C:\\workspaces\\stable-2.3.x\\src\\github.com\\docker\\pinata\\win\\src\\Docker.ApiServices\\Mounting\\FileSharing.cs:line 80\r\n--- End of stack trace from previous location whe
re exception was thrown ---\r\n   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Docker.ApiServices.Mounting.FileSharing.<ShareAsync>d__4.MoveNext() in C:\\workspaces\\stable-2.3.x\\src\\github.com\\docker\\pinata\\win\\src\\Docker.ApiServices\\Mounting\\FileSharing.cs:line 47\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at Docker.HttpApi.Controllers.FilesharingController.<ShareDirectory>d__2.MoveNext() in C:\\workspaces\\stable-2.3.x\\src\\github.com\\docker\\pinata\\win\\src\\Docker.HttpApi\\Controllers\\FilesharingController.cs:line 21\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.ExceptionServices.Exceptio
nDispatchInfo.Throw()\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at System.Threading.Tasks.TaskHelpersExtensions.<CastToObject>d__1`1.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at System.Web.Http.Controllers.ApiControllerActionInvoker.<InvokeActionAsyncCore>d__1.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at System.Web.Http.Controllers.ActionFilterResult.<ExecuteAsync>d__5.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.Excepti
onServices.ExceptionDispatchInfo.Throw()\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at System.Web.Http.Dispatcher.HttpControllerDispatcher.<SendAsync>d__15.MoveNext()"}.
	See 'docker run --help'.

```

Might be possible to fix this, but worth skipping for now.