### PR TITLE
Allow custom cert for ingress to be overwritten

### DIFF
--- a/cmd/minikube/cmd/config/configure.go
+++ b/cmd/minikube/cmd/config/configure.go
@@ -32,6 +32,9 @@ import (
 	"k8s.io/minikube/pkg/minikube/style"
 )
 
+var posResponses = []string{"yes", "y"}
+var negResponses = []string{"no", "n"}
+
 var addonsConfigureCmd = &cobra.Command{
 	Use:   "configure ADDON_NAME",
 	Short: "Configures the addon w/ADDON_NAME within minikube (example: minikube addons configure registry-creds). For a list of available addons use: minikube addons list",
@@ -45,8 +48,6 @@ var addonsConfigureCmd = &cobra.Command{
 		// allows for additional prompting of information when enabling addons
 		switch addon {
 		case "registry-creds":
-			posResponses := []string{"yes", "y"}
-			negResponses := []string{"no", "n"}
 
 			// Default values
 			awsAccessID := "changeme"
@@ -220,9 +221,15 @@ var addonsConfigureCmd = &cobra.Command{
 				return format.MatchString(s)
 			}
 
-			if cfg.KubernetesConfig.CustomIngressCert == "" {
-				cfg.KubernetesConfig.CustomIngressCert = AskForStaticValidatedValue("-- Enter custom cert(format is \"namespace/secret\"): ", validator)
+			customCert := AskForStaticValidatedValue("-- Enter custom cert(format is \"namespace/secret\"): ", validator)
+			if cfg.KubernetesConfig.CustomIngressCert != "" {
+				overwrite := AskForYesNoConfirmation("A custom cert for ingress has already been set. Do you want overwrite it?", posResponses, negResponses)
+				if !overwrite {
+					break
+				}
 			}
+
+			cfg.KubernetesConfig.CustomIngressCert = customCert
 
 			if err := config.SaveProfile(profile, cfg); err != nil {
 				out.ErrT(style.Fatal, "Failed to save config {{.profile}}", out.V{"profile": profile})


### PR DESCRIPTION
If you wanted to overwrite a custom cert for ingress before, you would need to recreate the cluster itself. Assuming the existing cert is called `foo/bar`:

Before:
```
$ minikube addons configure ingress
✅  ingress was successfully configured

$ cat ~/.minikube/profiles/minikube/config.json | grep Ingress
        "CustomIngressCert": "foo/bar",
        "IngressController": "ingress-nginx/controller:v1.0.4@sha256:545cff00370f28363dad31e3b59a94ba377854d3a11f18988f5f9e56841ef9ef",
```

After:
```
$ minikube addons configure ingress
-- Enter custom cert (format is "namespace/secret"): baz/bat
A custom cert for ingress has already been set. Do you want overwrite it? [y/n]: n
✅  ingress was successfully configured

$ cat ~/.minikube/profiles/minikube/config.json | grep Ingress
        "CustomIngressCert": "foo/bar",
        "IngressController": "ingress-nginx/controller:v1.0.4@sha256:545cff00370f28363dad31e3b59a94ba377854d3a11f18988f5f9e56841ef9ef",
```

```
$ minikube addons configure ingress
-- Enter custom cert (format is "namespace/secret"): baz/bat
A custom cert for ingress has already been set. Do you want overwrite it? [y/n]: y
✅  ingress was successfully configured

$ cat ~/.minikube/profiles/minikube/config.json | grep Ingress
        "CustomIngressCert": "baz/bat",
        "IngressController": "ingress-nginx/controller:v1.0.4@sha256:545cff00370f28363dad31e3b59a94ba377854d3a11f18988f5f9e56841ef9ef",
```