### PR TITLE
Support CRI-O runtime with Rootless Docker driver (`--driver=docker --container-runtime=cri-o`)

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -509,9 +509,8 @@ func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, drvName s
 			exit.Message(reason.Usage, "Ensure your {{.driver_name}} is running and is healthy.", out.V{"driver_name": driver.FullName(drvName)})
 		}
 		if si.Rootless {
-			if cc.KubernetesConfig.ContainerRuntime != "containerd" {
-				exit.Message(reason.Usage, "Container runtime must be set to \"containerd\" for rootless")
-				// TODO: support cri-o (https://kubernetes.io/docs/tasks/administer-cluster/kubelet-in-userns/#configuring-cri)
+			if cc.KubernetesConfig.ContainerRuntime == "docker" {
+				exit.Message(reason.Usage, "--container-runtime must be set to \"containerd\" or \"cri-o\" for rootless")
 			}
 			// KubeletInUserNamespace feature gate is essential for rootless driver.
 			// See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-in-userns/

--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -147,11 +148,50 @@ func enableIPForwarding(cr CommandRunner) error {
 	return nil
 }
 
+// enableRootless enables configurations for running CRI-O in Rootless Docker.
+//
+// 1. Create /etc/systemd/system/crio.service.d/10-rootless.conf to set _CRIO_ROOTLESS=1
+// 2. Create /etc/crio/crio.conf.d/10-fuse-overlayfs.conf to enable fuse-overlayfs
+// 3. Reload systemd
+//
+// See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-in-userns/#configuring-cri
+func (r *CRIO) enableRootless() error {
+	files := map[string]string{
+		"/etc/systemd/system/crio.service.d/10-rootless.conf": `[Service]
+Environment="_CRIO_ROOTLESS=1"
+`,
+		"/etc/crio/crio.conf.d/10-fuse-overlayfs.conf": `[crio]
+storage_driver = "overlay"
+storage_option = ["overlay.mount_program=/usr/local/bin/fuse-overlayfs"]
+`,
+	}
+	for target, content := range files {
+		targetDir := filepath.Dir(target)
+		c := exec.Command("sudo", "mkdir", "-p", targetDir)
+		if _, err := r.Runner.RunCmd(c); err != nil {
+			return errors.Wrapf(err, "failed to create directory %q", targetDir)
+		}
+		asset := assets.NewMemoryAssetTarget([]byte(content), target, "0644")
+		err := r.Runner.Copy(asset)
+		asset.Close()
+		if err != nil {
+			return errors.Wrapf(err, "failed to create %q", target)
+		}
+	}
+	// reload systemd to apply our changes on /etc/systemd
+	if err := r.Init.Reload("crio"); err != nil {
+		return err
+	}
+	if r.Init.Active("crio") {
+		if err := r.Init.Restart("crio"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Enable idempotently enables CRIO on a host
 func (r *CRIO) Enable(disOthers, forceSystemd, inUserNamespace bool) error {
-	if inUserNamespace {
-		return errors.New("inUserNamespace must not be true for cri-o (yet)")
-	}
 	if disOthers {
 		if err := disableOthers(r, r.Runner); err != nil {
 			klog.Warningf("disableOthers: %v", err)
@@ -171,6 +211,12 @@ func (r *CRIO) Enable(disOthers, forceSystemd, inUserNamespace bool) error {
 			return err
 		}
 	}
+	if inUserNamespace {
+		if err := r.enableRootless(); err != nil {
+			return err
+		}
+	}
+	// NOTE: before we start crio explicitly here, crio might be already started automatically
 	return r.Init.Start("crio")
 }
 

--- a/site/content/en/docs/drivers/includes/docker_usage.inc
+++ b/site/content/en/docs/drivers/includes/docker_usage.inc
@@ -32,7 +32,7 @@ docker context use rootless
 minikube start --driver=docker --container-runtime=containerd
 ```
 
-The `--container-runtime` flag must be currently set to "containerd".
+The `--container-runtime` flag must be set to "containerd" or "cri-o".
 
 The restrictions of rootless `kind` apply to minikube with rootless docker as well.
 


### PR DESCRIPTION
Follow-up to PR #12359 (containerd runtime with Rootless Docker driver).

Usage (needs [cgroup v2](https://rootlesscontaine.rs/getting-started/common/cgroup2/)):
```
dockerd-rootless-setuptool.sh install
docker context use rootless
minikube start --driver=docker --container-runtime=cri-o
```

See `site/content/en/docs/drivers/includes/docker_usage.inc`


---

Tested on Ubuntu 21.10 host, Rootless Docker 20.10.10

```console
$ kubectl get nodes -o wide
NAME       STATUS   ROLES                  AGE    VERSION   INTERNAL-IP    EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
minikube   Ready    control-plane,master   104s   v1.22.3   192.168.49.2   <none>        Ubuntu 20.04.2 LTS   5.13.0-20-generic   cri-o://1.22.0

$ kubectl get pods -A
NAMESPACE     NAME                               READY   STATUS    RESTARTS      AGE
kube-system   coredns-78fcd69978-kpsfg           1/1     Running   0             79s
kube-system   etcd-minikube                      1/1     Running   0             85s
kube-system   kindnet-546zq                      1/1     Running   0             79s
kube-system   kube-apiserver-minikube            1/1     Running   0             93s
kube-system   kube-controller-manager-minikube   1/1     Running   0             92s
kube-system   kube-proxy-w45xb                   1/1     Running   0             79s
kube-system   kube-scheduler-minikube            1/1     Running   0             86s
kube-system   storage-provisioner                1/1     Running   1 (48s ago)   89s
```


<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
