### PR TITLE
Fix running `minikube delete` before `MINIKUBE_HOME` set

### DIFF
--- a/hack/jenkins/common.ps1
+++ b/hack/jenkins/common.ps1
@@ -63,9 +63,6 @@ gsutil.cmd -m cp -r gs://minikube-builds/$env:MINIKUBE_LOCATION/testdata .
 gsutil.cmd -m cp -r gs://minikube-builds/$env:MINIKUBE_LOCATION/windows_integration_setup.ps1 out/
 gsutil.cmd -m cp -r gs://minikube-builds/$env:MINIKUBE_LOCATION/windows_integration_teardown.ps1 out/
 
-# Make sure an old minikube instance isn't running
-./out/minikube-windows-amd64.exe delete --all
-
 ./out/windows_integration_setup.ps1
 
 $started=Get-Date -UFormat %s

--- a/hack/jenkins/windows_integration_setup.ps1
+++ b/hack/jenkins/windows_integration_setup.ps1
@@ -16,6 +16,9 @@ $test_home="$env:HOMEDRIVE$env:HOMEPATH\minikube-integration"
 $env:KUBECONFIG="$test_home\kubeconfig"
 $env:MINIKUBE_HOME="$test_home\.minikube"
 
+# Make sure an old minikube instance isn't running
+./out/minikube-windows-amd64.exe delete --all --purge
+
 if ($driver -eq "docker") {
   # Remove unused images and containers
   docker system prune --all --force --volumes


### PR DESCRIPTION
**Problem:**
We were running `minikube delete` before `MINIKUBE_HOME` is set, so the delete was pointless.

**Solution:**
Move the delete to after `MINIKUBE_HOME` is set.
