### PR TITLE
Fix ingress-controller pod rolling updates

### DIFF
--- a/deploy/addons/ingress/ingress-deploy.yaml.tmpl
+++ b/deploy/addons/ingress/ingress-deploy.yaml.tmpl
@@ -340,6 +340,10 @@ spec:
       app.kubernetes.io/name: ingress-nginx
       app.kubernetes.io/instance: ingress-nginx
       app.kubernetes.io/component: controller
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   revisionHistoryLimit: 10
   minReadySeconds: 0
   template:


### PR DESCRIPTION
fixes #12903
Fixes pods not being scheduled when ingress deployment is patched by using a rolling update with maxUnavailable 1