### PR TITLE
Add new build tags to go9p

### DIFF
--- a/third_party/go9p/clnt_stats_http.go
+++ b/third_party/go9p/clnt_stats_http.go
@@ -1,3 +1,4 @@
+//go:build httpstats
 // +build httpstats
 
 package go9p

--- a/third_party/go9p/srv_stats_http.go
+++ b/third_party/go9p/srv_stats_http.go
@@ -1,3 +1,4 @@
+//go:build httpstats
 // +build httpstats
 
 package go9p


### PR DESCRIPTION
Ran `go fmt ./...`  these two files are missing the new go build tags.