### PR TITLE
start including macOS tests in flake reports

### DIFF
--- a/hack/jenkins/test-flake-chart/report_flakes.sh
+++ b/hack/jenkins/test-flake-chart/report_flakes.sh
@@ -85,9 +85,9 @@ awk -F, 'NR>1 {
   | sort -g -t, -k2,2 \
   >> "$TMP_FAILED_RATES"
 
-# Filter out arm64, macOS and windows tests until they're more stable
+# Filter out arm64 and crio tests until they're more stable
 TMP_FAILED_RATES_FILTERED=$(mktemp)
-grep -v "arm64\|macOS\|crio" "$TMP_FAILED_RATES" > "$TMP_FAILED_RATES_FILTERED"
+grep -v "arm64\|crio" "$TMP_FAILED_RATES" > "$TMP_FAILED_RATES_FILTERED"
 
 FAILED_RATES_LINES=$(wc -l < "$TMP_FAILED_RATES_FILTERED")
 if [[ "$FAILED_RATES_LINES" -eq 0 ]]; then


### PR DESCRIPTION
our macOS tests are starting to stabilize, so let's include them in the flake reports for PRs again