### PR TITLE
Specify VMware application names used in documentation

### DIFF
--- a/site/content/en/docs/drivers/_index.md
+++ b/site/content/en/docs/drivers/_index.md
@@ -28,7 +28,7 @@ To do so, we use the [Docker Machine](https://github.com/docker/machine) library
 * [Hyperkit]({{<ref "hyperkit.md">}}) - VM
 * [VirtualBox]({{<ref "virtualbox.md">}}) - VM
 * [Parallels]({{<ref "parallels.md">}}) - VM
-* [VMware]({{<ref "vmware.md">}}) - VM
+* [VMware Fusion]({{<ref "vmware.md">}}) - VM
 * [SSH]({{<ref "ssh.md">}}) - remote ssh
 
 ## Windows
@@ -36,5 +36,5 @@ To do so, we use the [Docker Machine](https://github.com/docker/machine) library
 * [Hyper-V]({{<ref "hyperv.md">}}) - VM (preferred)
 * [Docker]({{<ref "docker.md">}}) - VM + Container (preferred)
 * [VirtualBox]({{<ref "virtualbox.md">}}) - VM
-* [VMware]({{<ref "vmware.md">}}) - VM
+* [VMware Workstation]({{<ref "vmware.md">}}) - VM
 * [SSH]({{<ref "ssh.md">}}) - remote ssh

--- a/site/content/en/docs/drivers/includes/vmware_windows_usage.inc
+++ b/site/content/en/docs/drivers/includes/vmware_windows_usage.inc
@@ -1,6 +1,6 @@
 ## Requirements
 
-*VMware Workstation
+* VMware Workstation
 
 ## Driver Installation
 

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -16,7 +16,7 @@ All you need is Docker (or similarly compatible) container or a Virtual Machine 
 * 2GB of free memory
 * 20GB of free disk space
 * Internet connection
-* Container or virtual machine manager, such as: [Docker]({{<ref "/docs/drivers/docker">}}), [Hyperkit]({{<ref "/docs/drivers/hyperkit">}}), [Hyper-V]({{<ref "/docs/drivers/hyperv">}}), [KVM]({{<ref "/docs/drivers/kvm2">}}), [Parallels]({{<ref "/docs/drivers/parallels">}}), [Podman]({{<ref "/docs/drivers/podman">}}), [VirtualBox]({{<ref "/docs/drivers/virtualbox">}}), or [VMware]({{<ref "/docs/drivers/vmware">}})
+* Container or virtual machine manager, such as: [Docker]({{<ref "/docs/drivers/docker">}}), [Hyperkit]({{<ref "/docs/drivers/hyperkit">}}), [Hyper-V]({{<ref "/docs/drivers/hyperv">}}), [KVM]({{<ref "/docs/drivers/kvm2">}}), [Parallels]({{<ref "/docs/drivers/parallels">}}), [Podman]({{<ref "/docs/drivers/podman">}}), [VirtualBox]({{<ref "/docs/drivers/virtualbox">}}), or [VMware Fusion/Workstation]({{<ref "/docs/drivers/vmware">}})
 
 <h2 class="step"><span class="fa-stack fa-1x"><i class="fa fa-circle fa-stack-2x"></i><strong class="fa-stack-1x text-primary">1</strong></span>Installation</h2>
 


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
This PR updates the start page to specify the two VMware applications used by the VMware driver (Fusion and Workstation) and specifies the names in the associated Operating System sections on the vmware driver page as well.

Additionally, I made a small update to fix a typo that was causing a bullet point to not render properly in the vmware drivers page properly.