### PR TITLE
kubevirt addon: use KubeVirt CR instead of deprecated ConfigMap

### DIFF
--- a/deploy/addons/kubevirt/pod.yaml.tmpl
+++ b/deploy/addons/kubevirt/pod.yaml.tmpl
@@ -10,9 +10,9 @@ data:
   uninstall.sh: |
     #!/bin/bash
 
-    kubectl delete -f /manifests/kubevirt.yaml
+    kubectl delete -f /manifests/kubevirt-cr.yaml
 
-    kubectl delete -f /manifests/kubevirt-base.yaml
+    kubectl delete -f /manifests/kubevirt-operator.yaml
 
   install.sh: |
     #!/bin/bash
@@ -20,19 +20,17 @@ data:
     export KUBEVIRT_VERSION=$(curl -s https://api.github.com/repos/kubevirt/kubevirt/releases | grep tag_name | grep -v -- - | sort -V | tail -1 | awk -F':' '{print $2}' | sed 's/,//' | xargs)
     echo $KUBEVIRT_VERSION
 
-    curl -Ls "https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml" -o /manifests/kubevirt-base.yaml
+    curl -Ls "https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml" -o /manifests/kubevirt-operator.yaml
+    kubectl create -f /manifests/kubevirt-operator.yaml
 
-    kubectl create -f /manifests/kubevirt-base.yaml
+    curl -sL "https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml" -o /manifests/kubevirt-cr.yaml
+    kubectl create -f /manifests/kubevirt-cr.yaml
 
     EMULATION=$(egrep 'svm|vmx' /proc/cpuinfo)
     if [ -z "$EMULATION" ]; then
       echo "use emulation"
-      kubectl create configmap kubevirt-config -n kubevirt --from-literal debug.useEmulation=true
-    fi;
-
-    curl -sL "https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml" -o /manifests/kubevirt.yaml
-
-    kubectl create -f /manifests/kubevirt.yaml
+      kubectl patch kubevirt kubevirt -n kubevirt --type merge --patch '{"spec": {"configuration": {"developerConfiguration": {"useEmulation": true}}}}'
+    fi
 
     sleep infinity
 ---

--- a/deploy/addons/kubevirt/pod.yaml.tmpl
+++ b/deploy/addons/kubevirt/pod.yaml.tmpl
@@ -10,7 +10,7 @@ data:
   uninstall.sh: |
     #!/bin/bash
 
-    kubectl delete -f /manifests/kubevirt-cr.yaml
+    kubectl delete kubevirt kubevirt -n kubevirt
 
     kubectl delete -f /manifests/kubevirt-operator.yaml
 
@@ -18,18 +18,38 @@ data:
     #!/bin/bash
 
     export KUBEVIRT_VERSION=$(curl -s https://api.github.com/repos/kubevirt/kubevirt/releases | grep tag_name | grep -v -- - | sort -V | tail -1 | awk -F':' '{print $2}' | sed 's/,//' | xargs)
-    echo $KUBEVIRT_VERSION
+    echo "Installing KubeVirt version: $KUBEVIRT_VERSION"
 
     curl -Ls "https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml" -o /manifests/kubevirt-operator.yaml
     kubectl create -f /manifests/kubevirt-operator.yaml
 
-    curl -sL "https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml" -o /manifests/kubevirt-cr.yaml
-    kubectl create -f /manifests/kubevirt-cr.yaml
+    HARDWARE_EMULATION=$(egrep 'svm|vmx' /proc/cpuinfo)
+    if [ -z "$HARDWARE_EMULATION" ]; then
+      echo "Using software emulation"
 
-    EMULATION=$(egrep 'svm|vmx' /proc/cpuinfo)
-    if [ -z "$EMULATION" ]; then
-      echo "use emulation"
-      kubectl patch kubevirt kubevirt -n kubevirt --type merge --patch '{"spec": {"configuration": {"developerConfiguration": {"useEmulation": true}}}}'
+      echo "
+    apiVersion: kubevirt.io/v1
+    kind: KubeVirt
+    metadata:
+      name: kubevirt
+      namespace: kubevirt
+    spec:
+      configuration:
+        developerConfiguration:
+          useEmulation: true
+    " | kubectl apply -f -
+
+    else
+
+      echo "
+    apiVersion: kubevirt.io/v1
+    kind: KubeVirt
+    metadata:
+      name: kubevirt
+      namespace: kubevirt
+    spec: {}
+    " | kubectl apply -f -
+
     fi
 
     sleep infinity


### PR DESCRIPTION
Modify the kubevirt addon (#8275) to configure KubeVirt via its operator's custom resource (`KubeVirt`), instead of via the deprecated (and ~soon~ sometime to be removed) `kubevirt-config` ConfigMap.

Also slight changes to the saved manifest file names (avoid confusing renames).