### PR TITLE
fix scheduled stop test for containerd on docker driver

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -691,6 +691,11 @@ func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterC
 		cc.KicBaseImage = viper.GetString(kicBaseImage)
 	}
 
+	// If this cluster was stopped by a scheduled stop, clear the config
+	if cc.ScheduledStop != nil && time.Until(time.Unix(cc.ScheduledStop.InitiationTime, 0).Add(cc.ScheduledStop.Duration)) <= 0 {
+		cc.ScheduledStop = nil
+	}
+
 	return cc
 }
 

--- a/pkg/minikube/schedule/daemonize_unix.go
+++ b/pkg/minikube/schedule/daemonize_unix.go
@@ -38,7 +38,7 @@ import (
 func KillExisting(profiles []string) {
 	for _, profile := range profiles {
 		if err := killPIDForProfile(profile); err != nil {
-			klog.Errorf("error killng PID for profile %s: %v", profile, err)
+			klog.Warningf("error killng PID for profile %s: %v", profile, err)
 		}
 		_, cc := mustload.Partial(profile)
 		cc.ScheduledStop = nil

--- a/test/integration/scheduled_stop_test.go
+++ b/test/integration/scheduled_stop_test.go
@@ -94,29 +94,30 @@ func TestScheduledStopUnix(t *testing.T) {
 	}
 
 	// schedule a second stop which should cancel the first scheduled stop
-	stopMinikube(ctx, t, profile, []string{"--schedule", "8s"})
+	stopMinikube(ctx, t, profile, []string{"--schedule", "15s"})
 	if processRunning(t, pid) {
 		t.Fatalf("process %v running but should have been killed on reschedule of stop", pid)
 	}
-	checkPID(t, profile)
+	pid = checkPID(t, profile)
 
 	// cancel the shutdown and make sure minikube is still running after 8 seconds
 	// sleep 12 just to be safe
 	stopMinikube(ctx, t, profile, []string{"--cancel-scheduled"})
-	time.Sleep(12 * time.Second)
+	time.Sleep(25 * time.Second)
 	// make sure minikube status is "Running"
 	ensureMinikubeStatus(ctx, t, profile, "Host", state.Running.String())
 	// make sure minikube timetoStop is not present
 	ensureTimeToStopNotPresent(ctx, t, profile)
 
 	// schedule another stop, make sure minikube status is "Stopped"
-	stopMinikube(ctx, t, profile, []string{"--schedule", "5s"})
+	stopMinikube(ctx, t, profile, []string{"--schedule", "15s"})
+	time.Sleep(15 * time.Second)
 	if processRunning(t, pid) {
 		t.Fatalf("process %v running but should have been killed on reschedule of stop", pid)
 	}
 
 	// wait for stop to complete
-	time.Sleep(25 * time.Second)
+	time.Sleep(30 * time.Second)
 	// make sure minikube timetoStop is not present
 	ensureTimeToStopNotPresent(ctx, t, profile)
 	// make sure minikube status is "Stopped"


### PR DESCRIPTION
For whatever reason, if you schedule a stop of less than 15 seconds for containerd on the docker driver, the stop will crash kubernetes instead of just stopping it. Increasing the wait to 15 seconds fixes the test.