### PR TITLE
update suggestion messaging for --no-kubernetes

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -432,13 +432,24 @@ func displayEnviron(env []string) {
 	}
 }
 
-func showKubectlInfo(kcs *kubeconfig.Settings, k8sVersion string, machineName string) error {
+func showKubectlInfo(kcs *kubeconfig.Settings, k8sVersion, machineName string) error {
 	if k8sVersion == constants.NoKubernetesVersion {
 		register.Reg.SetStep(register.Done)
 		out.Step(style.Ready, "Done! minikube is ready without Kubernetes!")
-		out.BoxedWithConfig(box.Config{Py: 1, Px: 4, Type: "Round", Color: "Green"}, style.Tip, "Things to try without Kubernetes ...", `- "minikube ssh" to SSH into minikube's node.
+
+		// Runtime message.
+		boxConfig := box.Config{Py: 1, Px: 4, Type: "Round", Color: "Green"}
+		switch viper.GetString(containerRuntime) {
+		case constants.DefaultContainerRuntime:
+			out.BoxedWithConfig(boxConfig, style.Tip, "Things to try without Kubernetes ...", `- "minikube ssh" to SSH into minikube's node.
 - "minikube docker-env" to point your docker-cli to the docker inside minikube.
 - "minikube image" to build images without docker.`)
+		case constants.Containerd:
+			out.BoxedWithConfig(boxConfig, style.Tip, "Things to try without Kubernetes ...", `- "minikube ssh" to SSH into minikube's node.`)
+		case constants.CRIO:
+			out.BoxedWithConfig(boxConfig, style.Tip, "Things to try without Kubernetes ...", `- "minikube ssh" to SSH into minikube's node.
+- "minikube podman-env" to point your podman-cli to the podman inside minikube`)
+		}
 		return nil
 	}
 

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -445,10 +445,12 @@ func showKubectlInfo(kcs *kubeconfig.Settings, k8sVersion, machineName string) e
 - "minikube docker-env" to point your docker-cli to the docker inside minikube.
 - "minikube image" to build images without docker.`)
 		case constants.Containerd:
-			out.BoxedWithConfig(boxConfig, style.Tip, "Things to try without Kubernetes ...", `- "minikube ssh" to SSH into minikube's node.`)
+			out.BoxedWithConfig(boxConfig, style.Tip, "Things to try without Kubernetes ...", `- "minikube ssh" to SSH into minikube's node.
+- "minikube image" to build images without docker.`)
 		case constants.CRIO:
 			out.BoxedWithConfig(boxConfig, style.Tip, "Things to try without Kubernetes ...", `- "minikube ssh" to SSH into minikube's node.
-- "minikube podman-env" to point your podman-cli to the podman inside minikube`)
+- "minikube podman-env" to point your podman-cli to the podman inside minikube.
+- "minikube image" to build images without docker.`)
 		}
 		return nil
 	}

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -56,6 +56,8 @@ const (
 	SSHPort = 22
 	// RegistryAddonPort os the default registry addon port
 	RegistryAddonPort = 5000
+	// Containerd is the default name and spelling for the containerd container runtime
+	Containerd = "containerd"
 	// CRIO is the default name and spelling for the cri-o container runtime
 	CRIO = "crio"
 	// DefaultContainerRuntime is our default container runtime


### PR DESCRIPTION
Fixes #12857 

Replaces #12925

Before:

`minikube start --no-kubernetes `

```
😄  minikube v1.24.0 on Darwin 11.6.1
✨  Automatically selected the docker driver
👍  Starting minikube without Kubernetes minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=1985MB) ...
🏄  Done! minikube is ready without Kubernetes!
╭───────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                       │
│                       💡  Things to try without Kubernetes ...                        │
│                                                                                       │
│    - "minikube ssh" to SSH into minikube's node.                                      │
│    - "minikube docker-env" to point your docker-cli to the docker inside minikube.    │
│    - "minikube image" to build images without docker.                                 │
│                                                                                       │
╰───────────────────────────────────────────────────────────────────────────────────────╯
```

After:

`minikube start --no-kubernetes --container-runtime=docker`

```
😄  minikube v1.24.0 on Darwin 11.6.1
✨  Automatically selected the docker driver
👍  Starting minikube without Kubernetes minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=1985MB) ...
🏄  Done! minikube is ready without Kubernetes!
╭───────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                       │
│                       💡  Things to try without Kubernetes ...                        │
│                                                                                       │
│    - "minikube ssh" to SSH into minikube's node.                                      │
│    - "minikube docker-env" to point your docker-cli to the docker inside minikube.    │
│    - "minikube image" to build images without docker.                                 │
│                                                                                       │
╰───────────────────────────────────────────────────────────────────────────────────────╯
```

`minikube delete --all`

```
🔥  Deleting "minikube" in docker ...
🔥  Removing /Users/x/.minikube/machines/minikube ...
💀  Removed all traces of the "minikube" cluster.
🔥  Successfully deleted all profiles
```

`minikube start --no-kubernetes --container-runtime=containerd`

```
😄  minikube v1.24.0 on Darwin 11.6.1
✨  Using the docker driver based on existing profile
👍  Starting minikube without Kubernetes minikube in cluster minikube
🚜  Pulling base image ...
🏃  Updating the running docker "minikube" container ...
🏄  Done! minikube is ready without Kubernetes!
╭──────────────────────────────────────────────────────────╮
│                                                          │
│         💡  Things to try without Kubernetes ...         │
│                                                          │
│    - "minikube ssh" to SSH into minikube's node.         │
│    - "minikube image" to build images without docker.    │
│                                                          │
╰──────────────────────────────────────────────────────────╯
```

`minikube delete --all`

```
🔥  Deleting "minikube" in docker ...
🔥  Removing /Users/x/.minikube/machines/minikube ...
💀  Removed all traces of the "minikube" cluster.
🔥  Successfully deleted all profiles
```

`minikube start --no-kubernetes --container-runtime=crio`

```
😄  minikube v1.24.0 on Darwin 11.6.1
✨  Automatically selected the docker driver
👍  Starting minikube without Kubernetes minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=1985MB) ...
🏄  Done! minikube is ready without Kubernetes!
╭───────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                       │
│                       💡  Things to try without Kubernetes ...                        │
│                                                                                       │
│    - "minikube ssh" to SSH into minikube's node.                                      │
│    - "minikube podman-env" to point your podman-cli to the podman inside minikube.    │
│    - "minikube image" to build images without docker.                                 │
│                                                                                       │
╰───────────────────────────────────────────────────────────────────────────────────────╯
```
