### PR TITLE
fix:  do not let users run --no-kubernetes on the none driver

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1126,6 +1126,10 @@ func validateFlags(cmd *cobra.Command, drvName string) {
 
 	validateCPUCount(drvName)
 
+	if drvName == driver.None && viper.GetBool(noKubernetes) {
+		exit.Message(reason.Usage, "Cannot use the option --no-kubernetes on the {{.name}} driver", out.V{"name": drvName})
+	}
+
 	if cmd.Flags().Changed(memory) {
 		validateChangedMemoryFlags(drvName)
 	}


### PR DESCRIPTION
Fixes #12934 

Signed-off-by: Pablo Caderno <kaderno@gmail.com>

```
$ sudo ./out/minikube start --no-kubernetes --driver=none
[sudo] password for: 
😄  minikube v1.24.0 on Ubuntu 20.04
✨  Using the none driver based on user configuration

❌  Exiting due to MK_USAGE: Cannot use the option --no-kuberenes on the 'none driver
```