### PR TITLE
Exit if --kubernetes-version and --no-kubernetes are specified.

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1540,14 +1540,16 @@ func isBaseImageApplicable(drv string) bool {
 }
 
 func getKubernetesVersion(old *config.ClusterConfig) string {
+	var paramVersion string
 	if viper.GetBool(noKubernetes) {
 		klog.Infof("No Kubernetes flag is set, setting Kubernetes version to %s", constants.NoKubernetesVersion)
 		if old != nil {
 			old.KubernetesConfig.KubernetesVersion = constants.NoKubernetesVersion
 		}
+		paramVersion = viper.GetString(constants.NoKubernetesVersion)
+	} else {
+		paramVersion = viper.GetString(kubernetesVersion)
 	}
-
-	paramVersion := viper.GetString(kubernetesVersion)
 
 	// try to load the old version first if the user didn't specify anything
 	if paramVersion == "" && old != nil {

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1540,16 +1540,15 @@ func isBaseImageApplicable(drv string) bool {
 }
 
 func getKubernetesVersion(old *config.ClusterConfig) string {
-	var paramVersion string
 	if viper.GetBool(noKubernetes) {
 		klog.Infof("No Kubernetes flag is set, setting Kubernetes version to %s", constants.NoKubernetesVersion)
 		if old != nil {
 			old.KubernetesConfig.KubernetesVersion = constants.NoKubernetesVersion
 		}
-		paramVersion = viper.GetString(constants.NoKubernetesVersion)
-	} else {
-		paramVersion = viper.GetString(kubernetesVersion)
+		return viper.GetString(constants.NoKubernetesVersion)
 	}
+
+	paramVersion := viper.GetString(kubernetesVersion)
 
 	// try to load the old version first if the user didn't specify anything
 	if paramVersion == "" && old != nil {

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1541,11 +1541,15 @@ func isBaseImageApplicable(drv string) bool {
 
 func getKubernetesVersion(old *config.ClusterConfig) string {
 	if viper.GetBool(noKubernetes) {
+		// Exit if --kubernetes-version is specified.
+		if viper.GetString(kubernetesVersion) != "" {
+			exit.Message(reason.Usage, "cannot specify --kubernetes-version with --no-kubernetes")
+		}
+
 		klog.Infof("No Kubernetes flag is set, setting Kubernetes version to %s", constants.NoKubernetesVersion)
 		if old != nil {
 			old.KubernetesConfig.KubernetesVersion = constants.NoKubernetesVersion
 		}
-		return viper.GetString(constants.NoKubernetesVersion)
 	}
 
 	paramVersion := viper.GetString(kubernetesVersion)

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1543,7 +1543,10 @@ func getKubernetesVersion(old *config.ClusterConfig) string {
 	if viper.GetBool(noKubernetes) {
 		// Exit if --kubernetes-version is specified.
 		if viper.GetString(kubernetesVersion) != "" {
-			exit.Message(reason.Usage, "cannot specify --kubernetes-version with --no-kubernetes")
+			exit.Message(reason.Usage, `cannot specify --kubernetes-version with --no-kubernetes,
+to unset a global config run:
+
+$ minikube config unset kubernetes-version`)
 		}
 
 		klog.Infof("No Kubernetes flag is set, setting Kubernetes version to %s", constants.NoKubernetesVersion)

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -89,7 +89,10 @@ type Starter struct {
 // Start spins up a guest and starts the Kubernetes node.
 func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 	var kcs *kubeconfig.Settings
-	if starter.Node.KubernetesVersion == constants.NoKubernetesVersion { // do not bootstrap cluster if --no-kubernetes
+	// Do not bootstrap cluster if --no-kubernetes.
+	if viper.GetBool("no-kubernetes") ||
+		starter.Node.KubernetesVersion == constants.NoKubernetesVersion {
+		starter.Node.KubernetesVersion = constants.NoKubernetesVersion
 		return kcs, config.Write(viper.GetString(config.ProfileName), starter.Cfg)
 	}
 	// wait for preloaded tarball to finish downloading before configuring runtimes

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -89,7 +89,7 @@ type Starter struct {
 // Start spins up a guest and starts the Kubernetes node.
 func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 	var kcs *kubeconfig.Settings
-	if starter.Node.KubernetesVersion == constants.NoKubernetesVersion {
+	if starter.Node.KubernetesVersion == constants.NoKubernetesVersion { // do not bootstrap cluster if --no-kubernetes
 		return kcs, config.Write(viper.GetString(config.ProfileName), starter.Cfg)
 	}
 	// wait for preloaded tarball to finish downloading before configuring runtimes

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -89,10 +89,7 @@ type Starter struct {
 // Start spins up a guest and starts the Kubernetes node.
 func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 	var kcs *kubeconfig.Settings
-	// Do not bootstrap cluster if --no-kubernetes.
-	if viper.GetBool("no-kubernetes") ||
-		starter.Node.KubernetesVersion == constants.NoKubernetesVersion {
-		starter.Node.KubernetesVersion = constants.NoKubernetesVersion
+	if starter.Node.KubernetesVersion == constants.NoKubernetesVersion {
 		return kcs, config.Write(viper.GetString(config.ProfileName), starter.Cfg)
 	}
 	// wait for preloaded tarball to finish downloading before configuring runtimes

--- a/test/integration/no_kubernetes_test.go
+++ b/test/integration/no_kubernetes_test.go
@@ -45,6 +45,7 @@ func TestNoKubernetes(t *testing.T) {
 			name      string
 			validator validateFunc
 		}{
+			{"ErrorStartNoK8sWithVersion", errorStartNoK8sWithVersion},
 			{"Start", validateStartNoK8S},
 			{"VerifyK8sNotRunning", validateK8SNotRunning},
 			{"ProfileList", validateProfileListNoK8S},
@@ -68,6 +69,17 @@ func TestNoKubernetes(t *testing.T) {
 			})
 		}
 	})
+}
+
+// ErrorStartNoK8sWithVersion expect an error when starting a minikube cluster without kubernetes and with a kubernetes version.
+func errorStartNoK8sWithVersion(ctx context.Context, t *testing.T, profile string) {
+	defer PostMortemLogs(t, profile)
+
+	args := append([]string{"start", "-p", profile, "--no-kubernetes", "--kubernetes-version=1.20"}, StartArgs()...)
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
+	if err == nil {
+		t.Fatalf("expected an error but none was thrown with args: %q", rr.Command())
+	}
 }
 
 // validateStartNoK8S starts a minikube cluster without kubernetes started/configured

--- a/test/integration/no_kubernetes_test.go
+++ b/test/integration/no_kubernetes_test.go
@@ -45,7 +45,7 @@ func TestNoKubernetes(t *testing.T) {
 			name      string
 			validator validateFunc
 		}{
-			{"ErrorStartNoK8sWithVersion", errorStartNoK8sWithVersion},
+			{"StartNoK8sWithVersion", validateStartNoK8sWithVersion},
 			{"Start", validateStartNoK8S},
 			{"VerifyK8sNotRunning", validateK8SNotRunning},
 			{"ProfileList", validateProfileListNoK8S},
@@ -71,8 +71,8 @@ func TestNoKubernetes(t *testing.T) {
 	})
 }
 
-// ErrorStartNoK8sWithVersion expect an error when starting a minikube cluster without kubernetes and with a kubernetes version.
-func errorStartNoK8sWithVersion(ctx context.Context, t *testing.T, profile string) {
+// validateStartNoK8sWithVersion expect an error when starting a minikube cluster without kubernetes and with a kubernetes version.
+func validateStartNoK8sWithVersion(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 
 	args := append([]string{"start", "-p", profile, "--no-kubernetes", "--kubernetes-version=1.20"}, StartArgs()...)


### PR DESCRIPTION
Fixes #12871 

Disallow running minikube with both --no-kubernetes and --kubernetes-version

With config:

```
{
  "kubernetes-version": "1.21.5"
}
```

Before:

`minikube start --no-kubernetes`

```
😄  minikube v1.24.0 on Darwin 11.6.1
🆕  Kubernetes 1.22.3 is now available. If you would like to upgrade, specify: --kubernetes-version=v1.22.3
✨  Using the docker driver based on existing profile
👍  Starting minikube without Kubernetes minikube in cluster minikube
🚜  Pulling base image ...
🏃  Updating the running docker "minikube" container ...
🐳  Preparing Kubernetes v1.21.5 on Docker 20.10.8 ...

❌  Exiting due to K8S_INSTALL_FAILED: kubeadm images: version too old: 0.0.0

╭───────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                           │
│    😿  If the above advice does not help, please let us know:                             │
│    👉  https://github.com/kubernetes/minikube/issues/new/choose                           │
│                                                                                           │
│    Please run `minikube logs --file=logs.txt` and attach logs.txt to the GitHub issue.    │
│                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────╯
```

After:

`minikube start --no-kubernetes`

```
😄  minikube v1.24.0 on Darwin 11.6.1

❌  Exiting due to MK_USAGE: cannot specify --kubernetes-version with --no-kubernetes,
to unset a global config run:

$ minikube config unset kubernetes-version

```