### PR TITLE
Only check privileged ports for WSL

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1226,7 +1226,7 @@ func validatePorts(ports []string) error {
 			if p > 65535 || p < 1 {
 				return errors.Errorf("Sorry, one of the ports provided with --ports flag is outside range %s", ports)
 			}
-			if p < 1024 && i == 0 {
+			if detect.IsMicrosoftWSL() && p < 1024 && i == 0 {
 				return errors.Errorf("Sorry, you cannot use privileged ports on the host (below 1024) %s", ports)
 			}
 		}


### PR DESCRIPTION
Related: https://github.com/kubernetes/minikube/issues/12919

**Problem:**
We are checking for privileged ports always, but we should only be checking for it on WSL.