### PR TITLE
ensure --memory flag is within syslimit

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -959,12 +959,13 @@ func memoryLimits(drvName string) (int, int, error) {
 	return sysLimit, containerLimit, nil
 }
 
-// suggestMemoryAllocation calculates the default memory footprint in MiB
-func suggestMemoryAllocation(sysLimit int, containerLimit int, nodes int) int {
-	if mem := viper.GetInt(memory); mem != 0 {
+// suggestMemoryAllocation calculates the default memory footprint in MiB.
+func suggestMemoryAllocation(sysLimit, containerLimit, nodes int) int {
+	if mem := viper.GetInt(memory); mem != 0 && mem < sysLimit {
 		return mem
 	}
-	fallback := 2200
+
+	const fallback = 2200
 	maximum := 6000
 
 	if sysLimit > 0 && fallback > sysLimit {


### PR DESCRIPTION
Fixes: #12951

Before (without mb):

`minikube start --memory=16385`

```
😄  minikube v1.24.0 on Darwin 11.6.1
✨  Automatically selected the docker driver

❌  Exiting due to RSRC_OVER_ALLOC_MEM: Requested memory allocation 16385MB is more than your system limit 16384MB.
💡  Suggestion: Start minikube with less memory allocated: 'minikube start --memory=16385mb'
```

Before: (with mb):

`minikube start --memory=16385mb`

```
😄  minikube v1.24.0 on Darwin 11.6.1
✨  Automatically selected the docker driver

❌  Exiting due to RSRC_OVER_ALLOC_MEM: Requested memory allocation 16385MB is more than your system limit 16384MB.
💡  Suggestion: Start minikube with less memory allocated: 'minikube start --memory=1985mb'
```

After (without mb):

`minikube start --memory=16385`

```
😄  minikube v1.24.0 on Darwin 11.6.1
✨  Automatically selected the docker driver

❌  Exiting due to RSRC_OVER_ALLOC_MEM: Requested memory allocation 16385MB is more than your system limit 16384MB.
💡  Suggestion: Start minikube with less memory allocated: 'minikube start --memory=1985mb'
```

After (with mb):

`minikube start --memory=16385mb`

```
😄  minikube v1.24.0 on Darwin 11.6.1
✨  Automatically selected the docker driver

❌  Exiting due to RSRC_OVER_ALLOC_MEM: Requested memory allocation 16385MB is more than your system limit 16384MB.
💡  Suggestion: Start minikube with less memory allocated: 'minikube start --memory=1985mb'
```