### PR TITLE
Fix out of bound exceptions

### DIFF
--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -107,7 +107,9 @@ func Execute() {
 		profile := ""
 		for i, a := range os.Args {
 			if a == "--context" {
-				profile = fmt.Sprintf("--profile=%s", os.Args[i+1])
+				if len(os.Args) > i+1 {
+					profile = fmt.Sprintf("--profile=%s", os.Args[i+1])
+				}
 				break
 			} else if strings.HasPrefix(a, "--context=") {
 				context := strings.Split(a, "=")[1]

--- a/hack/benchmark/cpu_usage/auto_pause/chart.go
+++ b/hack/benchmark/cpu_usage/auto_pause/chart.go
@@ -54,10 +54,10 @@ func main() {
 
 func execute() error {
 	// sessionID is generated and used at cpu usage benchmark
-	sessionID := os.Args[1]
-	if len(sessionID) == 0 {
+	if len(os.Args) <= 1 || len(os.Args[1]) == 0 {
 		return errors.New("Please identify sessionID")
 	}
+	sessionID := os.Args[1]
 
 	// Create plot instance
 	p := plot.New()

--- a/hack/benchmark/cpu_usage/idle_only/chart.go
+++ b/hack/benchmark/cpu_usage/idle_only/chart.go
@@ -53,10 +53,10 @@ func main() {
 
 func execute() error {
 	// sessionID is generated and used at cpu usage benchmark
-	sessionID := os.Args[1]
-	if len(sessionID) == 0 {
+	if len(os.Args) <= 1 || len(os.Args[1]) == 0 {
 		return errors.New("Please identify sessionID")
 	}
+	sessionID := os.Args[1]
 
 	// Create plot instance
 	p := plot.New()


### PR DESCRIPTION
**Before:**
```
./out/kubectl --context        
panic: runtime error: index out of range [2] with length 2

goroutine 1 [running]:
k8s.io/minikube/cmd/minikube/cmd.Execute()
	/Users/powellsteven/repo/minikube/cmd/minikube/cmd/root.go:111 +0x129b
main.main()
	/Users/powellsteven/repo/minikube/cmd/minikube/main.go:86 +0x255
```
**After:**
```
./out/kubectl --context        
v1.22.3
Error: flag needs an argument: --context
See 'kubectl --help' for usage.
```
**Before:**
```
go run hack/benchmark/cpu_usage/auto_pause/chart.go
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
main.execute()
	/Users/powellsteven/repo/minikube/hack/benchmark/cpu_usage/auto_pause/chart.go:57 +0x16b0
main.main()
	/Users/powellsteven/repo/minikube/hack/benchmark/cpu_usage/auto_pause/chart.go:49 +0x19
exit status 2
```
**After:**
```
go run hack/benchmark/cpu_usage/auto_pause/chart.go
Please identify sessionID
exit status 1
```
**Before:**
```
go run hack/benchmark/cpu_usage/idle_only/chart.go
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
main.execute()
	/Users/powellsteven/repo/minikube/hack/benchmark/cpu_usage/idle_only/chart.go:56 +0xcde
main.main()
	/Users/powellsteven/repo/minikube/hack/benchmark/cpu_usage/idle_only/chart.go:48 +0x19
exit status 2
```
**After:**
```
go run hack/benchmark/cpu_usage/idle_only/chart.go
Please identify sessionID
exit status 1
```