### PR TITLE
Fix typo in help text for minikube docker-env command

### DIFF
--- a/cmd/minikube/cmd/docker-env_test.go
+++ b/cmd/minikube/cmd/docker-env_test.go
@@ -155,7 +155,7 @@ $Env:DOCKER_HOST = "tcp://192.168.0.1:2376"
 $Env:DOCKER_CERT_PATH = "/certs"
 $Env:MINIKUBE_ACTIVE_DOCKERD = "powershell"
 # To point your shell to minikube's docker-daemon, run:
-# & minikube -p powershell docker-env | Invoke-Expression
+# & minikube -p powershell docker-env --shell powershell | Invoke-Expression
 `,
 
 			`Remove-Item Env:\\DOCKER_TLS_VERIFY
@@ -175,7 +175,7 @@ SET DOCKER_HOST=tcp://192.168.0.1:2376
 SET DOCKER_CERT_PATH=/certs
 SET MINIKUBE_ACTIVE_DOCKERD=cmd
 REM To point your shell to minikube's docker-daemon, run:
-REM @FOR /f "tokens=*" %i IN ('minikube -p cmd docker-env') DO @%i
+REM @FOR /f "tokens=*" %i IN ('minikube -p cmd docker-env --shell cmd') DO @%i
 `,
 
 			`SET DOCKER_TLS_VERIFY=
@@ -261,7 +261,7 @@ $Env:DOCKER_CERT_PATH = "/certs"
 $Env:MINIKUBE_ACTIVE_DOCKERD = "powershell-no-proxy-idempotent"
 $Env:no_proxy = "192.168.0.1"
 # To point your shell to minikube's docker-daemon, run:
-# & minikube -p powershell-no-proxy-idempotent docker-env | Invoke-Expression
+# & minikube -p powershell-no-proxy-idempotent docker-env --shell powershell | Invoke-Expression
 `,
 
 			`Remove-Item Env:\\DOCKER_TLS_VERIFY

--- a/pkg/minikube/shell/shell.go
+++ b/pkg/minikube/shell/shell.go
@@ -81,7 +81,7 @@ var shellConfigMap = map[string]shellData{
 		unsetDelimiter: "",
 		usageHint: func(s ...interface{}) string {
 			return fmt.Sprintf(`# %s
-# & %s | Invoke-Expression
+# & %s --shell powershell | Invoke-Expression
 `, s...)
 		},
 	},
@@ -94,7 +94,7 @@ var shellConfigMap = map[string]shellData{
 		unsetDelimiter: "=",
 		usageHint: func(s ...interface{}) string {
 			return fmt.Sprintf(`REM %s
-REM @FOR /f "tokens=*" %%i IN ('%s') DO @%%i
+REM @FOR /f "tokens=*" %%i IN ('%s --shell cmd') DO @%%i
 `, s...)
 		},
 	},

--- a/pkg/minikube/shell/shell_test.go
+++ b/pkg/minikube/shell/shell_test.go
@@ -31,11 +31,11 @@ func TestGenerateUsageHint(t *testing.T) {
 		{EnvConfig{""}, `# foo
 # eval $(bar)`},
 		{EnvConfig{"powershell"}, `# foo
-# & bar | Invoke-Expression`},
+# & bar --shell powershell | Invoke-Expression`},
 		{EnvConfig{"bash"}, `# foo
 # eval $(bar)`},
-		{EnvConfig{"powershell"}, `# foo
-# & bar | Invoke-Expression`},
+		{EnvConfig{"cmd"}, `REM foo
+REM @FOR /f "tokens=*" %i IN ('bar --shell cmd') DO @%i`},
 		{EnvConfig{"emacs"}, `;; foo
 ;; (with-temp-buffer (shell-command "bar" (current-buffer)) (eval-buffer))`},
 		{EnvConfig{"fish"}, `# foo


### PR DESCRIPTION
I noticed that the helper text for the `minikube docker-env` when run on Windows doesn't output commands that you can use without further editing. I've updated output text to include a more complete command.

I also found a duplicated test in the pkg/minikube/shell/shell_test.go for having your shell set to powershell, changed it to be for cmd.

before:
❯ minikube docker-env --shell cmd
SET DOCKER_TLS_VERIFY=1
SET DOCKER_HOST=tcp://127.0.0.1:1041
SET DOCKER_CERT_PATH=C:\Users\mpuck\.minikube\certs
SET MINIKUBE_ACTIVE_DOCKERD=minikube
REM To point your shell to minikube's docker-daemon, run:
REM @FOR /f "tokens=*" %i IN ('minikube -p minikube docker-env') DO @%i

❯ minikube docker-env --shell powershell
$Env:DOCKER_TLS_VERIFY = "1"
$Env:DOCKER_HOST = "tcp://127.0.0.1:1041"
$Env:DOCKER_CERT_PATH = "C:\Users\mpuck\.minikube\certs"
$Env:MINIKUBE_ACTIVE_DOCKERD = "minikube"
\# To point your shell to minikube's docker-daemon, run:
\# & minikube -p minikube docker-env | Invoke-Expression

after:
❯ ./out/minikube docker-env --shell cmd
SET DOCKER_TLS_VERIFY=1
SET DOCKER_HOST=tcp://127.0.0.1:55569
SET DOCKER_CERT_PATH=/Users/marcuspuckett/.minikube/certs
SET MINIKUBE_ACTIVE_DOCKERD=minikube
REM To point your shell to minikube's docker-daemon, run:
REM @FOR /f "tokens=*" %i IN ('minikube -p minikube docker-env --shell cmd') DO @%i

minikube on 🌱master [!+] via 🐹 v1.16.3 
❯ ./out/minikube docker-env --shell powershell
$Env:DOCKER_TLS_VERIFY = "1"
$Env:DOCKER_HOST = "tcp://127.0.0.1:55569"
$Env:DOCKER_CERT_PATH = "/Users/marcuspuckett/.minikube/certs"
$Env:MINIKUBE_ACTIVE_DOCKERD = "minikube"
\# To point your shell to minikube's docker-daemon, run:
\# & minikube -p minikube docker-env --shell powershell | Invoke-Expression