### PR TITLE
Docs add windows versions of commands

### DIFF
--- a/site/content/en/docs/handbook/addons/ingress-dns.md
+++ b/site/content/en/docs/handbook/addons/ingress-dns.md
@@ -58,15 +58,8 @@ minikube addons enable ingress-dns
 
 <h3 class="step"><span class="fa-stack fa-1x"><i class="fa fa-circle fa-stack-2x"></i><strong class="fa-stack-1x text-primary">3</strong></span>Add the `minikube ip` as a DNS server</h2>
 
-{{% card %}}
-
-{{% quiz_row base="" name="Operating system" %}}
-{{% quiz_button option="Linux" %}} {{% quiz_button option="macOS" %}} {{% quiz_button option="Windows" %}}
-{{% /quiz_row %}}
-
-{{% card %}}
-
-{{% quiz_instruction_plain id="/Linux" %}}
+{{% tabs %}}
+{{% linuxtab %}}
 
 Update the file `/etc/resolvconf/resolv.conf.d/base` to have the following contents.
 
@@ -103,9 +96,9 @@ systemctl restart NetworkManager.service
 
 Also see `dns=` in [NetworkManager.conf](https://developer.gnome.org/NetworkManager/stable/NetworkManager.conf.html).
 
-{{% /quiz_instruction_plain %}}
+{{% /linuxtab %}}
 
-{{% quiz_instruction_plain id="/macOS" %}}
+{{% mactab %}}
 
 Create a file in `/etc/resolver/minikube-test` with the following content.
 
@@ -124,9 +117,9 @@ See https://www.unix.com/man-page/opendarwin/5/resolver/
 
 Note that the `port` feature does not work as documented.
 
-{{% /quiz_instruction_plain %}}
+{{% /mactab %}}
 
-{{% quiz_instruction_plain id="/Windows" %}}
+{{% windowstab %}}
 
 Open `Powershell` as Administrator and execute the following.
 ```sh
@@ -138,11 +131,8 @@ The following will remove any matching rules before creating a new one. This is 
 Get-DnsClientNrptRule | Where-Object {$_.Namespace -eq '.test'} | Remove-DnsClientNrptRule -Force; Add-DnsClientNrptRule -Namespace ".test" -NameServers "$(minikube ip)"
 ```
 
-{{% /quiz_instruction_plain %}}
-
-{{% /card %}}
-
-{{% /card %}}
+{{% /windowstab %}}
+{{% /tabs %}}
 
 ## Testing
 

--- a/site/content/en/docs/handbook/config.md
+++ b/site/content/en/docs/handbook/config.md
@@ -124,10 +124,34 @@ Some features can only be accessed by minikube specific environment variables, h
 
 ### Example: Disabling emoji
 
+{{% tabs %}}
+
+{{% linuxtab %}}
+
 ```shell
 export MINIKUBE_IN_STYLE=false
 minikube start
 ```
+
+{{% /linuxtab %}}
+
+{{% mactab %}}
+
+```shell
+export MINIKUBE_IN_STYLE=false
+minikube start
+```
+
+{{% /mactab %}}
+
+{{% windowstab %}}
+
+```shell
+$env:MINIKUBE_IN_STYLE=false
+```
+
+{{% /windowstab %}}
+{{% /tabs %}}
 
 ### Making environment values persistent
 

--- a/site/content/en/docs/handbook/config.md
+++ b/site/content/en/docs/handbook/config.md
@@ -159,7 +159,7 @@ minikube start
 To make the exported variables persistent across reboots:
 
 * Linux and macOS: Add these declarations to `~/.bashrc` or wherever your shells environment variables are stored.
-* Windows: Either add these declarations to your `~\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1` or run the following in a powershell terminal:
+* Windows: Either add these declarations to your `~\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1` or run the following in a PowerShell terminal:
 ```shell
 [Environment]::SetEnvironmentVariable("key", "value", [EnvironmentVariableTarget]::User)
 ```

--- a/site/content/en/docs/handbook/config.md
+++ b/site/content/en/docs/handbook/config.md
@@ -148,6 +148,7 @@ minikube start
 
 ```shell
 $env:MINIKUBE_IN_STYLE=false
+minikube start
 ```
 
 {{% /windowstab %}}
@@ -158,4 +159,7 @@ $env:MINIKUBE_IN_STYLE=false
 To make the exported variables persistent across reboots:
 
 * Linux and macOS: Add these declarations to `~/.bashrc` or wherever your shells environment variables are stored.
-* Windows: Add these declarations via [system settings](https://support.microsoft.com/en-au/help/310519/how-to-manage-environment-variables-in-windows-xp) or using [setx](https://stackoverflow.com/questions/5898131/set-a-persistent-environment-variable-from-cmd-exe)
+* Windows: Either add these declarations to your `~\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1` or run the following in a powershell terminal:
+```shell
+[Environment]::SetEnvironmentVariable("key", "value", [EnvironmentVariableTarget]::User)
+```

--- a/site/content/en/docs/handbook/kubectl.md
+++ b/site/content/en/docs/handbook/kubectl.md
@@ -16,13 +16,54 @@ However if `kubectl` is not installed locally, minikube already includes kubectl
 minikube kubectl -- <kubectl commands>
 ```
 
-You can also `alias kubectl="minikube kubectl --"` for easier usage.
+{{% tabs %}}
+
+{{% linuxtab %}}
+You can also alias kubectl for easier usage.
+
+```shell
+alias kubectl="minikube kubectl --"
+```
 
 Alternatively, you can create a symbolic link to minikube's binary named 'kubectl'.
 
 ```shell
 ln -s $(which minikube) /usr/local/bin/kubectl
 ```
+
+{{% /linuxtab %}}
+
+{{% mactab %}}
+You can also alias kubectl for easier usage.
+
+```shell
+alias kubectl="minikube kubectl --"
+```
+
+Alternatively, you can create a symbolic link to minikube's binary named 'kubectl'.
+
+```shell
+ln -s $(which minikube) /usr/local/bin/kubectl
+```
+
+{{% /mactab %}}
+
+{{% windowstab %}}
+You can also alias kubectl for easier usage.
+
+```shell
+Set-Alias -Name "kubectl" -Value "minikube kubectl --"
+```
+
+Alternatively, you can create a symbolic link to minikube's binary named 'kubectl'.
+
+```shell
+New-Item -Path (Get-Command minikube).Path -ItemType SymbolicLink -Value C:\minikube\minikube.exe
+```
+
+{{% /windowstab %}}
+
+{{% /tabs %}}
 
 Get pods
 

--- a/site/content/en/docs/handbook/kubectl.md
+++ b/site/content/en/docs/handbook/kubectl.md
@@ -52,13 +52,7 @@ ln -s $(which minikube) /usr/local/bin/kubectl
 You can also alias kubectl for easier usage.
 
 ```shell
-Set-Alias -Name "kubectl" -Value "minikube kubectl --"
-```
-
-Alternatively, you can create a symbolic link to minikube's binary named 'kubectl'.
-
-```shell
-New-Item -Path (Get-Command minikube).Path -ItemType SymbolicLink -Value C:\minikube\minikube.exe
+function kubectl { minikube kubectl -- $args }
 ```
 
 {{% /windowstab %}}

--- a/site/content/en/docs/handbook/pushing.md
+++ b/site/content/en/docs/handbook/pushing.md
@@ -66,7 +66,7 @@ eval $(minikube docker-env)
 ```
 {{% /mactab %}}
 {{% windowstab %}}
-Powershell
+PowerShell
 ```shell
 & minikube -p minikube docker-env --shell powershell | Invoke-Expression
 ```

--- a/site/content/en/docs/handbook/pushing.md
+++ b/site/content/en/docs/handbook/pushing.md
@@ -54,9 +54,29 @@ This means you don't have to build on your host machine and push the image into 
 
 To point your terminal to use the docker daemon inside minikube run this:
 
+{{% tabs %}}
+{{% linuxtab %}}
 ```shell
 eval $(minikube docker-env)
 ```
+{{% /linuxtab %}}
+{{% mactab %}}
+```shell
+eval $(minikube docker-env)
+```
+{{% /mactab %}}
+{{% windowstab %}}
+Powershell
+```shell
+& minikube -p minikube docker-env --shell powershell | Invoke-Expression
+```
+
+cmd
+```shell
+@FOR /f "tokens=*" %i IN ('minikube -p minikube docker-env --shell cmd') DO @%i
+```
+{{% /windowstab %}}
+{{% /tabs %}}
 
 Now any 'docker' command you run in this current terminal will run against the docker inside minikube cluster.
 
@@ -139,6 +159,8 @@ For more information, see:
 
 ## 3. Pushing directly to in-cluster CRI-O. (podman-env)
 
+{{% tabs %}}
+{{% linuxtab %}}
 This is similar to docker-env but only for CRI-O runtime.
 To push directly to CRI-O, configure podman client on your host using the podman-env command in your shell:
 
@@ -147,9 +169,6 @@ eval $(minikube podman-env)
 ```
 
 You should now be able to use podman client on the command line on your host machine talking to the podman service inside the minikube VM:
-
-{{% tabs %}}
-{{% linuxtab %}}
 
 ```shell
 podman-remote help
@@ -167,12 +186,20 @@ Note: On Linux the remote client is called "podman-remote", while the local prog
 
 {{% /linuxtab %}}
 {{% mactab %}}
+This is similar to docker-env but only for CRI-O runtime.
+To push directly to CRI-O, configure podman client on your host using the podman-env command in your shell:
+
+```shell
+eval $(minikube podman-env)
+```
+
+You should now be able to use podman client on the command line on your host machine talking to the podman service inside the minikube VM:
 
 ```shell
 podman help
 ```
 
-now you can 'build' against the storage inside minikube, which is instantly accessible to kubernetes cluster.
+Now you can 'build' against the storage inside minikube, which is instantly accessible to kubernetes cluster.
 
 ```shell
 podman build -t my_image .
@@ -184,8 +211,22 @@ Note: On macOS the remote client is called "podman", since there is no local "po
 
 {{% /mactab %}}
 {{% windowstab %}}
+This is similar to docker-env but only for CRI-O runtime.
+To push directly to CRI-O, configure podman client on your host using the podman-env command in your shell:
 
-now you can 'build' against the storage inside minikube, which is instantly accessible to kubernetes cluster.
+Powershell
+```shell
+& minikube -p minikube podman-env --shell powershell | Invoke-Expression
+```
+
+cmd
+```shell
+@FOR /f "tokens=*" %i IN ('minikube -p minikube podman-env --shell cmd') DO @%i
+```
+
+You should now be able to use podman client on the command line on your host machine talking to the podman service inside the minikube VM:
+
+Now you can 'build' against the storage inside minikube, which is instantly accessible to kubernetes cluster.
 
 ```shell
 podman help

--- a/site/content/en/docs/handbook/pushing.md
+++ b/site/content/en/docs/handbook/pushing.md
@@ -226,7 +226,7 @@ cmd
 
 You should now be able to use podman client on the command line on your host machine talking to the podman service inside the minikube VM:
 
-Now you can 'build' against the storage inside minikube, which is instantly accessible to kubernetes cluster.
+Now you can 'build' against the storage inside minikube, which is instantly accessible to Kubernetes cluster.
 
 ```shell
 podman help

--- a/site/content/en/docs/handbook/pushing.md
+++ b/site/content/en/docs/handbook/pushing.md
@@ -199,7 +199,7 @@ You should now be able to use Podman client on the command line on your host mac
 podman help
 ```
 
-Now you can 'build' against the storage inside minikube, which is instantly accessible to kubernetes cluster.
+Now you can 'build' against the storage inside minikube, which is instantly accessible to Kubernetes cluster.
 
 ```shell
 podman build -t my_image .

--- a/site/content/en/docs/handbook/pushing.md
+++ b/site/content/en/docs/handbook/pushing.md
@@ -212,7 +212,7 @@ Note: On macOS the remote client is called "podman", since there is no local "po
 {{% /mactab %}}
 {{% windowstab %}}
 This is similar to docker-env but only for CRI-O runtime.
-To push directly to CRI-O, configure podman client on your host using the podman-env command in your shell:
+To push directly to CRI-O, configure Podman client on your host using the podman-env command in your shell:
 
 PowerShell
 ```shell

--- a/site/content/en/docs/handbook/pushing.md
+++ b/site/content/en/docs/handbook/pushing.md
@@ -214,7 +214,7 @@ Note: On macOS the remote client is called "podman", since there is no local "po
 This is similar to docker-env but only for CRI-O runtime.
 To push directly to CRI-O, configure podman client on your host using the podman-env command in your shell:
 
-Powershell
+PowerShell
 ```shell
 & minikube -p minikube podman-env --shell powershell | Invoke-Expression
 ```

--- a/site/content/en/docs/handbook/pushing.md
+++ b/site/content/en/docs/handbook/pushing.md
@@ -187,7 +187,7 @@ Note: On Linux the remote client is called "podman-remote", while the local prog
 {{% /linuxtab %}}
 {{% mactab %}}
 This is similar to docker-env but only for CRI-O runtime.
-To push directly to CRI-O, configure podman client on your host using the podman-env command in your shell:
+To push directly to CRI-O, configure Podman client on your host using the podman-env command in your shell:
 
 ```shell
 eval $(minikube podman-env)

--- a/site/content/en/docs/handbook/pushing.md
+++ b/site/content/en/docs/handbook/pushing.md
@@ -224,7 +224,7 @@ cmd
 @FOR /f "tokens=*" %i IN ('minikube -p minikube podman-env --shell cmd') DO @%i
 ```
 
-You should now be able to use podman client on the command line on your host machine talking to the podman service inside the minikube VM:
+You should now be able to use Podman client on the command line on your host machine talking to the Podman service inside the minikube VM:
 
 Now you can 'build' against the storage inside minikube, which is instantly accessible to Kubernetes cluster.
 

--- a/site/content/en/docs/handbook/pushing.md
+++ b/site/content/en/docs/handbook/pushing.md
@@ -193,7 +193,7 @@ To push directly to CRI-O, configure Podman client on your host using the podman
 eval $(minikube podman-env)
 ```
 
-You should now be able to use podman client on the command line on your host machine talking to the podman service inside the minikube VM:
+You should now be able to use Podman client on the command line on your host machine talking to the Podman service inside the minikube VM:
 
 ```shell
 podman help


### PR DESCRIPTION
This addresses #12968 but I don't think it completely resolves/closes it so I'll leave that up to the issue creator/maintainers to decide.

This PR adds windows versions of commands where I know them/as they exist, and implements the tabbing feature for these cases.

Also updated an existing case that was using the card style for multi-OS command examples. 