### PR TITLE
Add format flag to the `image ls` command

### DIFF
--- a/cmd/minikube/cmd/image.go
+++ b/cmd/minikube/cmd/image.go
@@ -54,6 +54,7 @@ var (
 	dockerFile string
 	buildEnv   []string
 	buildOpt   []string
+	format     string
 )
 
 func saveFile(r io.Reader) (string, error) {
@@ -331,7 +332,7 @@ $ minikube image ls
 			exit.Error(reason.Usage, "loading profile", err)
 		}
 
-		if err := machine.ListImages(profile); err != nil {
+		if err := machine.ListImages(profile, format); err != nil {
 			exit.Error(reason.GuestImageList, "Failed to list images", err)
 		}
 	},
@@ -396,6 +397,7 @@ func init() {
 	saveImageCmd.Flags().BoolVar(&imgDaemon, "daemon", false, "Cache image to docker daemon")
 	saveImageCmd.Flags().BoolVar(&imgRemote, "remote", false, "Cache image to remote registry")
 	imageCmd.AddCommand(saveImageCmd)
+	listImageCmd.Flags().StringVar(&format, "format", "short", "Format output. One of: short|table|json|yaml")
 	imageCmd.AddCommand(listImageCmd)
 	imageCmd.AddCommand(tagImageCmd)
 	imageCmd.AddCommand(pushImageCmd)

--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -240,13 +240,8 @@ func (r *CRIO) ImageExists(name string, sha string) bool {
 }
 
 // ListImages returns a list of images managed by this container runtime
-func (r *CRIO) ListImages(ListImagesOptions) ([]string, error) {
-	c := exec.Command("sudo", "podman", "images", "--format", "{{.Repository}}:{{.Tag}}")
-	rr, err := r.Runner.RunCmd(c)
-	if err != nil {
-		return nil, errors.Wrapf(err, "podman images")
-	}
-	return strings.Split(strings.TrimSpace(rr.Stdout.String()), "\n"), nil
+func (r *CRIO) ListImages(ListImagesOptions) ([]ListImage, error) {
+	return listCRIImages(r.Runner)
 }
 
 // LoadImage loads an image into this runtime
@@ -464,16 +459,6 @@ func crioImagesPreloaded(runner command.Runner, images []string) bool {
 	rr, err := runner.RunCmd(exec.Command("sudo", "crictl", "images", "--output", "json"))
 	if err != nil {
 		return false
-	}
-	type crictlImages struct {
-		Images []struct {
-			ID          string      `json:"id"`
-			RepoTags    []string    `json:"repoTags"`
-			RepoDigests []string    `json:"repoDigests"`
-			Size        string      `json:"size"`
-			UID         interface{} `json:"uid"`
-			Username    string      `json:"username"`
-		} `json:"images"`
 	}
 
 	var jsonImages crictlImages

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -113,7 +113,7 @@ type Manager interface {
 	// ImageExists takes image name and optionally image sha to check if an image exists
 	ImageExists(string, string) bool
 	// ListImages returns a list of images managed by this container runtime
-	ListImages(ListImagesOptions) ([]string, error)
+	ListImages(ListImagesOptions) ([]ListImage, error)
 
 	// RemoveImage remove image based on name
 	RemoveImage(string) error
@@ -166,6 +166,13 @@ type ListContainersOptions struct {
 
 // ListImagesOptions are the options to use for listing images
 type ListImagesOptions struct {
+}
+
+type ListImage struct {
+	ID          string   `json:"id" yaml:"id"`
+	RepoDigests []string `json:"repoDigests" yaml:"repoDigests"`
+	RepoTags    []string `json:"repoTags" yaml:"repoTags"`
+	Size        string   `json:"size" yaml:"size"`
 }
 
 // ErrContainerRuntimeNotRunning is thrown when container runtime is not running

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cruntime
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -25,6 +26,7 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
+	units "github.com/docker/go-units"
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/minikube/assets"
@@ -183,22 +185,43 @@ func (r *Docker) ImageExists(name string, sha string) bool {
 }
 
 // ListImages returns a list of images managed by this container runtime
-func (r *Docker) ListImages(ListImagesOptions) ([]string, error) {
-	c := exec.Command("docker", "images", "--format", "{{.Repository}}:{{.Tag}}")
+func (r *Docker) ListImages(ListImagesOptions) ([]ListImage, error) {
+	c := exec.Command("docker", "images", "--no-trunc", "--format", "{{json .}}")
 	rr, err := r.Runner.RunCmd(c)
 	if err != nil {
 		return nil, errors.Wrapf(err, "docker images")
 	}
-	short := strings.Split(rr.Stdout.String(), "\n")
-	imgs := []string{}
-	for _, img := range short {
+	type dockerImage struct {
+		ID         string `json:"ID"`
+		Repository string `json:"Repository"`
+		Tag        string `json:"Tag"`
+		Size       string `json:"Size"`
+	}
+	images := strings.Split(rr.Stdout.String(), "\n")
+	result := []ListImage{}
+	for _, img := range images {
 		if img == "" {
 			continue
 		}
-		img = addDockerIO(img)
-		imgs = append(imgs, img)
+
+		var jsonImage dockerImage
+		if err := json.Unmarshal([]byte(img), &jsonImage); err != nil {
+			return nil, errors.Wrap(err, "Image convert problem")
+		}
+		size, err := units.FromHumanSize(jsonImage.Size)
+		if err != nil {
+			return nil, errors.Wrap(err, "Image size convert problem")
+		}
+
+		repoTag := fmt.Sprintf("%s:%s", jsonImage.Repository, jsonImage.Tag)
+		result = append(result, ListImage{
+			ID:          strings.TrimPrefix(jsonImage.ID, "sha256:"),
+			RepoDigests: []string{},
+			RepoTags:    []string{addDockerIO(repoTag)},
+			Size:        fmt.Sprintf("%d", size),
+		})
 	}
-	return imgs, nil
+	return result, nil
 }
 
 // LoadImage loads an image into this runtime

--- a/site/content/en/docs/commands/image.md
+++ b/site/content/en/docs/commands/image.md
@@ -196,6 +196,12 @@ $ minikube image ls
 
 ```
 
+### Options
+
+```
+      --format string   Format output. One of: short|table|json|yaml (default "short")
+```
+
 ### Options inherited from parent commands
 
 ```

--- a/translations/de.json
+++ b/translations/de.json
@@ -296,6 +296,7 @@
 	"For more information, see: {{.url}}": "",
 	"Force environment to be configured for a specified shell: [fish, cmd, powershell, tcsh, bash, zsh], default is auto-detect": "",
 	"Force minikube to perform possibly dangerous operations": "minikube zwingen, möglicherweise gefährliche Operationen durchzuführen",
+	"Format output. One of: short|table|json|yaml": "",
 	"Format to print stdout in. Options include: [text,json]": "",
 	"Found docker, but the docker service isn't running. Try restarting the docker service.": "",
 	"Found driver(s) but none were healthy. See above for suggestions how to fix installed drivers.": "",

--- a/translations/es.json
+++ b/translations/es.json
@@ -305,6 +305,7 @@
 	"For more information, see: {{.url}}": "",
 	"Force environment to be configured for a specified shell: [fish, cmd, powershell, tcsh, bash, zsh], default is auto-detect": "",
 	"Force minikube to perform possibly dangerous operations": "Permite forzar minikube para que realice operaciones potencialmente peligrosas",
+	"Format output. One of: short|table|json|yaml": "",
 	"Format to print stdout in. Options include: [text,json]": "",
 	"Found docker, but the docker service isn't running. Try restarting the docker service.": "",
 	"Found driver(s) but none were healthy. See above for suggestions how to fix installed drivers.": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -285,6 +285,7 @@
 	"For more information, see: {{.url}}": "Pour plus d'informations, voir : {{.url}}",
 	"Force environment to be configured for a specified shell: [fish, cmd, powershell, tcsh, bash, zsh], default is auto-detect": "Forcer l'environnement à être configuré pour un shell spécifié : [fish, cmd, powershell, tcsh, bash, zsh], la valeur par défaut est la détection automatique",
 	"Force minikube to perform possibly dangerous operations": "Oblige minikube à réaliser des opérations possiblement dangereuses.",
+	"Format output. One of: short|table|json|yaml": "",
 	"Format to print stdout in. Options include: [text,json]": "Format dans lequel imprimer la sortie standard. Les options incluent : [text,json]",
 	"Found docker, but the docker service isn't running. Try restarting the docker service.": "Docker trouvé, mais le service docker ne fonctionne pas. Essayez de redémarrer le service Docker.",
 	"Found driver(s) but none were healthy. See above for suggestions how to fix installed drivers.": "Pilote(s) trouvé(s) mais aucun n'était en fonctionnement. Voir ci-dessus pour des suggestions sur la façon de réparer les pilotes installés.",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -293,6 +293,7 @@
 	"For more information, see: {{.url}}": "",
 	"Force environment to be configured for a specified shell: [fish, cmd, powershell, tcsh, bash, zsh], default is auto-detect": "",
 	"Force minikube to perform possibly dangerous operations": "minikube で危険な可能性のある操作を強制的に実行します",
+	"Format output. One of: short|table|json|yaml": "",
 	"Format to print stdout in. Options include: [text,json]": "",
 	"Found docker, but the docker service isn't running. Try restarting the docker service.": "",
 	"Found driver(s) but none were healthy. See above for suggestions how to fix installed drivers.": "",

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -320,6 +320,7 @@
 	"For more information, see: {{.url}}": "",
 	"Force environment to be configured for a specified shell: [fish, cmd, powershell, tcsh, bash, zsh], default is auto-detect": "",
 	"Force minikube to perform possibly dangerous operations": "",
+	"Format output. One of: short|table|json|yaml": "",
 	"Format to print stdout in. Options include: [text,json]": "",
 	"Found docker, but the docker service isn't running. Try restarting the docker service.": "",
 	"Found driver(s) but none were healthy. See above for suggestions how to fix installed drivers.": "",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -306,6 +306,7 @@
 	"For more information, see: {{.url}}": "",
 	"Force environment to be configured for a specified shell: [fish, cmd, powershell, tcsh, bash, zsh], default is auto-detect": "",
 	"Force minikube to perform possibly dangerous operations": "Wymuś wykonanie potencjalnie niebezpiecznych operacji",
+	"Format output. One of: short|table|json|yaml": "",
 	"Format to print stdout in. Options include: [text,json]": "",
 	"Found docker, but the docker service isn't running. Try restarting the docker service.": "",
 	"Found driver(s) but none were healthy. See above for suggestions how to fix installed drivers.": "",

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -277,6 +277,7 @@
 	"For more information, see: {{.url}}": "",
 	"Force environment to be configured for a specified shell: [fish, cmd, powershell, tcsh, bash, zsh], default is auto-detect": "",
 	"Force minikube to perform possibly dangerous operations": "",
+	"Format output. One of: short|table|json|yaml": "",
 	"Format to print stdout in. Options include: [text,json]": "",
 	"Found docker, but the docker service isn't running. Try restarting the docker service.": "",
 	"Found driver(s) but none were healthy. See above for suggestions how to fix installed drivers.": "",

--- a/translations/strings.txt
+++ b/translations/strings.txt
@@ -277,6 +277,7 @@
 	"For more information, see: {{.url}}": "",
 	"Force environment to be configured for a specified shell: [fish, cmd, powershell, tcsh, bash, zsh], default is auto-detect": "",
 	"Force minikube to perform possibly dangerous operations": "",
+	"Format output. One of: short|table|json|yaml": "",
 	"Format to print stdout in. Options include: [text,json]": "",
 	"Found docker, but the docker service isn't running. Try restarting the docker service.": "",
 	"Found driver(s) but none were healthy. See above for suggestions how to fix installed drivers.": "",

--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -374,6 +374,7 @@
 	"For more information, see: {{.url}}": "",
 	"Force environment to be configured for a specified shell: [fish, cmd, powershell, tcsh, bash, zsh], default is auto-detect": "强制为指定的 shell 配置环境：[fish, cmd, powershell, tcsh, bash, zsh]，默认为 auto-detect",
 	"Force minikube to perform possibly dangerous operations": "强制 minikube 执行可能有风险的操作",
+	"Format output. One of: short|table|json|yaml": "",
 	"Format to print stdout in. Options include: [text,json]": "",
 	"Found docker, but the docker service isn't running. Try restarting the docker service.": "",
 	"Found driver(s) but none were healthy. See above for suggestions how to fix installed drivers.": "",


### PR DESCRIPTION

This PR adds `format` flag which can modify output of `image ls` command.
`format` flag supports following values: `short`, `table`, `json`, `yaml`. Examples:

`minikube image ls` - default value for `format` flag is `short` so it is backward compatible with previous versions
```
k8s.gcr.io/pause:3.5
k8s.gcr.io/kube-scheduler:v1.22.3
k8s.gcr.io/kube-proxy:v1.22.3
k8s.gcr.io/kube-controller-manager:v1.22.3
k8s.gcr.io/kube-apiserver:v1.22.3
k8s.gcr.io/etcd:3.5.0-0
k8s.gcr.io/coredns/coredns:v1.8.4
gcr.io/k8s-minikube/storage-provisioner:v5
docker.io/kubernetesui/metrics-scraper:v1.0.7
docker.io/kubernetesui/dashboard:v2.3.1
docker.io/kindest/kindnetd:v20210326-1e038dc5
```


`minikube image ls --format table`

```
|-----------------------------------------|--------------------|---------------|--------|
|                  Image                  |        Tag         |   Image ID    |  Size  |
|-----------------------------------------|--------------------|---------------|--------|
| k8s.gcr.io/coredns/coredns              | v1.8.4             | 8d147537fb7d1 | 47.7MB |
| k8s.gcr.io/etcd                         | 3.5.0-0            | 0048118155842 | 296MB  |
| k8s.gcr.io/kube-proxy                   | v1.22.3            | 6120bd723dced | 105MB  |
| k8s.gcr.io/pause                        | 3.5                | ed210e3e4a5ba | 690kB  |
| docker.io/kindest/kindnetd              | v20210326-1e038dc5 | 6de166512aa22 | 120MB  |
| docker.io/kubernetesui/dashboard        | v2.3.1             | e1482a24335a6 | 223MB  |
| docker.io/kubernetesui/metrics-scraper  | v1.0.7             | 7801cfc6d5c07 | 34.5MB |
| gcr.io/k8s-minikube/storage-provisioner | v5                 | 6e38f40d628db | 31.5MB |
| k8s.gcr.io/kube-apiserver               | v1.22.3            | 53224b502ea4d | 130MB  |
| k8s.gcr.io/kube-controller-manager      | v1.22.3            | 05c905cef780c | 123MB  |
| k8s.gcr.io/kube-scheduler               | v1.22.3            | 0aa9c7e31d307 | 53.9MB |
|-----------------------------------------|--------------------|---------------|--------|
```

`minikube image ls --format yaml`
```
- id: 53224b502ea4de7925ca5ed3d8a43dd4b500b2e8e4872bf9daea1fc3fec05edc
  repoDigests:
  - k8s.gcr.io/kube-apiserver@sha256:412c3b47185fd1c665ee15bcd6a3b04a79752a875230c6530e170c5344328293
  - k8s.gcr.io/kube-apiserver@sha256:6ee1c59e9c1fb570e7958e267a6993988eaa22448beb70d99de7afb21e862e9d
  repoTags:
  - k8s.gcr.io/kube-apiserver:v1.22.3
  size: "129549551"
- id: 0aa9c7e31d307d1012fb9e63c274f1110868709a2c39f770dd82120cd2b8fe0f
  repoDigests:
  - k8s.gcr.io/kube-scheduler@sha256:7f8233b2bfeb39bd9c6c2f34f6f634678133f78008e98dee5ec73f0a87ac66cd
  - k8s.gcr.io/kube-scheduler@sha256:cac7ea67201a84c00f3e8d9be51877c25fb539055ac404c4a9d2dd4c79d3fdab
  repoTags:
  - k8s.gcr.io/kube-scheduler:v1.22.3
  size: "53912661"
- id: ed210e3e4a5bae1237f1bb44d72a05a2f1e5c6bfe7a7e73da179e2534269c459
  repoDigests:
  - k8s.gcr.io/pause@sha256:1ff6c18fbef2045af6b9c16bf034cc421a29027b800e4f9b68ae9b1cb3e9ae07
  - k8s.gcr.io/pause@sha256:369201a612f7b2b585a8e6ca99f77a36bcdbd032463d815388a96800b63ef2c8
  repoTags:
  - k8s.gcr.io/pause:3.5
  size: "689969
```

Closes #11165