### PR TITLE
add retry check storage for preload generation

### DIFF
--- a/hack/preload-images/generate.go
+++ b/hack/preload-images/generate.go
@@ -135,12 +135,12 @@ func generateTarball(kubernetesVersion, containerRuntime, tarballFilename string
 
 func verifyStorage(containerRuntime string) error {
 	if containerRuntime == "docker" || containerRuntime == "containerd" {
-		if err := verifyDockerStorage(); err != nil {
+		if err := retry.Expo(verifyDockerStorage, 100*time.Microsecond, time.Minute*2); err != nil {
 			return errors.Wrap(err, "Docker storage type is incompatible")
 		}
 	}
 	if containerRuntime == "cri-o" {
-		if err := verifyPodmanStorage(); err != nil {
+		if err := retry.Expo(verifyPodmanStorage, 100*time.Microsecond, time.Minute*2); err != nil {
 			return errors.Wrap(err, "Podman storage type is incompatible")
 		}
 	}

--- a/hack/preload-images/preload_images.go
+++ b/hack/preload-images/preload_images.go
@@ -152,7 +152,7 @@ func makePreload(cfg preloadCfg) error {
 	return nil
 }
 
-func verifyDockerStorage() error {
+var verifyDockerStorage = func() error {
 	cmd := exec.Command("docker", "exec", profile, "docker", "info", "-f", "{{.Info.Driver}}")
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
@@ -167,7 +167,7 @@ func verifyDockerStorage() error {
 	return nil
 }
 
-func verifyPodmanStorage() error {
+var verifyPodmanStorage = func() error {
 	cmd := exec.Command("docker", "exec", profile, "sudo", "podman", "info", "-f", "json")
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr


### PR DESCRIPTION
attempt to reduce the errors like this:
```
09:37:08 WithError(generating tarball for k8s version v1.22.4 with docker: verifying storage: Docker storage type is incompatible: [docker exec generate-preloaded-images-tar docker info -f {{.Info.Driver}}]: exit status 1:
09:37:08 template: :1:7: executing "" at <.Info.Driver>: nil pointer evaluating *types.Info.Driver
09:37:08 )=generating tarball for k8s version v1.22.4 with docker: verifying storage: Docker storage type is incompatible: [docker exec generate-preloaded-images-tar docker info -f {{.Info.Driver}}]: exit status 1:
09:37:08 template: :1:7: executing "" at <.Info.Driver>: nil pointer evaluating *types.Info.Driver
09:37:08  called from:
09:37:08 goroutine 1 [running]:
09:37:08 runtime/debug.Stack()
09:37:08 	/usr/local/go/src/runtime/debug/stack.go:24 +0x65
09:37:08 main.exit({0xc000e66140, 0x126}, {0x1c9b020, 0xc000e7e138})
09:37:08 	/home/jenkins/go/src/k8s.io/minikube/hack/preload-images/preload_images.go:192 +0x50
09:37:08 main.main()
09:37:08 	/home/jenkins/go/src/k8s.io/minikube/hack/preload-images/preload_images.go:109 +0x2b5
09:37:08 * Removed all traces of the "generate-preloaded-images-tar" cluster.
```