### PR TITLE
mount: fix `Bad file descriptor`

### DIFF
--- a/test/integration/functional_test_mount_test.go
+++ b/test/integration/functional_test_mount_test.go
@@ -50,6 +50,13 @@ func validateMountCmd(ctx context.Context, t *testing.T, profile string) { // no
 	if NoneDriver() {
 		t.Skip("skipping: none driver does not support mount")
 	}
+	if HyperVDriver() {
+		t.Skip("skipping: mount broken on hyperv: https://github.com/kubernetes/minikube/issues/5029")
+	}
+
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping: mount broken on windows: https://github.com/kubernetes/minikube/issues/8303")
+	}
 
 	t.Run("any-port", func(t *testing.T) {
 		tempDir, err := os.MkdirTemp("", "mounttest")

--- a/test/integration/functional_test_mount_test.go
+++ b/test/integration/functional_test_mount_test.go
@@ -50,16 +50,8 @@ func validateMountCmd(ctx context.Context, t *testing.T, profile string) { // no
 	if NoneDriver() {
 		t.Skip("skipping: none driver does not support mount")
 	}
-	if HyperVDriver() {
-		t.Skip("skipping: mount broken on hyperv: https://github.com/kubernetes/minikube/issues/5029")
-	}
-
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping: mount broken on windows: https://github.com/kubernetes/minikube/issues/8303")
-	}
 
 	t.Run("any-port", func(t *testing.T) {
-		t.Skip("Skipping until https://github.com/kubernetes/minikube/issues/12301 is resolved.")
 		tempDir, err := os.MkdirTemp("", "mounttest")
 		defer func() { // clean up tempdir
 			err := os.RemoveAll(tempDir)

--- a/third_party/go9p/srv_fcall.go
+++ b/third_party/go9p/srv_fcall.go
@@ -193,12 +193,6 @@ func (srv *Srv) walk(req *SrvReq) {
 		return
 	}
 
-	/* we can't walk open files */
-	if fid.opened {
-		req.RespondError(Ebaduse)
-		return
-	}
-
 	if tc.Fid != tc.Newfid {
 		req.Newfid = conn.FidNew(tc.Newfid)
 		if req.Newfid == nil {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/12301

Removed the `if fid.opened` then `req.RespondError(Ebaduse)`, the comment for the statement is `/* we can't walk open files */`, but when the check is skipped we can walk the supposedly open files fine, so I feel confident we can skip this check.