### PR TITLE
Add support for port validation with ip

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1223,7 +1223,15 @@ func validateFlags(cmd *cobra.Command, drvName string) {
 // This function validates that the --ports are not below 1024 for the host and not outside range
 func validatePorts(ports []string) error {
 	for _, portDuplet := range ports {
-		for i, port := range strings.Split(portDuplet, ":") {
+		parts := strings.Split(portDuplet, ":")
+		if len(parts) > 2 {
+			ip := parts[0]
+			if net.ParseIP(ip) == nil {
+				return errors.Errorf("Sorry, the IP address provided with --ports flag is invalid: %s", ip)
+			}
+			parts = parts[1:]
+		}
+		for i, port := range parts {
 			p, err := strconv.Atoi(port)
 			if err != nil {
 				return errors.Errorf("Sorry, one of the ports provided with --ports flag is not valid %s", ports)

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -450,6 +450,14 @@ func TestValidatePorts(t *testing.T) {
 			ports:    []string{"8080:80", "6443:443"},
 			errorMsg: "",
 		},
+		{
+			ports:    []string{"127.0.0.1:80:80"},
+			errorMsg: "",
+		},
+		{
+			ports:    []string{"1000.0.0.1:80:80"},
+			errorMsg: "Sorry, the IP address provided with --ports flag is invalid: 1000.0.0.1",
+		},
 	}
 	if detect.IsMicrosoftWSL() {
 		tests = append(tests, portTest{


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/12919

Adds support for `--ports=127.0.0.1:80:80` in port validation.