### PR TITLE
mount: Fix `--mode` not being respected

### DIFF
--- a/pkg/minikube/cluster/mount.go
+++ b/pkg/minikube/cluster/mount.go
@@ -90,6 +90,9 @@ func Mount(r mountRunner, source string, target string, c *MountConfig) error {
 		}
 		return &MountError{ErrorType: MountErrorUnknown, UnderlyingError: errors.Wrapf(err, "mount with cmd %s ", rr.Command())}
 	}
+	if _, err := r.RunCmd(exec.Command("/bin/bash", "-c", fmt.Sprintf("sudo chmod %o %s", c.Mode, target))); err != nil {
+		return &MountError{ErrorType: MountErrorUnknown, UnderlyingError: errors.Wrap(err, "chmod folder")}
+	}
 
 	klog.Infof("mount successful: %q", rr.Output())
 	return nil

--- a/pkg/minikube/cluster/mount.go
+++ b/pkg/minikube/cluster/mount.go
@@ -59,6 +59,8 @@ const (
 	MountErrorUnknown = iota
 	// MountErrorConnect
 	MountErrorConnect
+	// MountErrorChmod
+	MountErrorChmod
 )
 
 // MountError wrapper around errors in the `Mount` function
@@ -91,7 +93,7 @@ func Mount(r mountRunner, source string, target string, c *MountConfig) error {
 		return &MountError{ErrorType: MountErrorUnknown, UnderlyingError: errors.Wrapf(err, "mount with cmd %s ", rr.Command())}
 	}
 	if _, err := r.RunCmd(exec.Command("/bin/bash", "-c", fmt.Sprintf("sudo chmod %o %s", c.Mode, target))); err != nil {
-		return &MountError{ErrorType: MountErrorUnknown, UnderlyingError: errors.Wrap(err, "chmod folder")}
+		return &MountError{ErrorType: MountErrorChmod, UnderlyingError: errors.Wrap(err, "chmod folder")}
 	}
 
 	klog.Infof("mount successful: %q", rr.Output())


### PR DESCRIPTION
**Before:**
```
$ minikube mount ./test123:/minikube-host --mode=0777
$ minikube ssh -- ls -la /
drwxr-xr-x   1 docker docker   64 Nov 23 23:53 minikube-host
Mode: 0755
```

**After:**
```
$ minikube mount ./test123:/minikube-host --mode=0777
$ minikube ssh -- ls -la /
drwxrwxrwx   1 docker docker   64 Nov 23 23:53 minikube-host
Mode: 0777
```

Test added in https://github.com/kubernetes/minikube/pull/12930