### PR TITLE
Fix IstioOperator CustomResourceDefinition for istio-provisioner addon

### DIFF
--- a/deploy/addons/istio-provisioner/istio-operator.yaml.tmpl
+++ b/deploy/addons/istio-provisioner/istio-operator.yaml.tmpl
@@ -25,10 +25,14 @@ spec:
     shortNames:
     - iop
   scope: Namespaced
-  subresources:
-    status: {}
   versions:
   - name: v1alpha1
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
 ...


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

This PR fixes a bug that prevents enabling the istio-provisioner addon.
The following error was occurring:
`error: error validating "/etc/kubernetes/addons/istio-operator.yaml": error validating data: ValidationError(CustomResourceDefinition.spec): unknown field "subresources" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec; if you choose to ignore these errors, turn validation off with --validate=false`