### PR TITLE
Clarify documentation for using ingress-dns plugin on Linux with Network Manager

### DIFF
--- a/site/content/en/docs/handbook/addons/ingress-dns.md
+++ b/site/content/en/docs/handbook/addons/ingress-dns.md
@@ -61,6 +61,8 @@ minikube addons enable ingress-dns
 {{% tabs %}}
 {{% linuxtab %}}
 
+## Linux OS with resolvconf
+
 Update the file `/etc/resolvconf/resolv.conf.d/base` to have the following contents.
 
 ```
@@ -86,15 +88,34 @@ If your Linux OS does not use `systemctl`, run the following commands.
 
 See https://linux.die.net/man/5/resolver
 
-When you are using Network Manager with the `dnsmasq` plugin, you can add an additional configuration file, but you need
-to restart NetworkManager to activate the change.
+## Linux OS with Network Manager
+
+Network Manager can run integrated caching DNS server - `dnsmasq` plugin and can be configured to use separate nameservers per domain. 
+
+Edit /etc/NetworkManager/NetworkManager.conf and set `dns=dnsmasq`
+
+```
+[main]
+dns=dnsmasq
+```
+Also see `dns=` in [NetworkManager.conf](https://developer.gnome.org/NetworkManager/stable/NetworkManager.conf.html).
+
+Configure dnsmasq to handle .test domain 
 
 ```bash
+sudo mkdir /etc/NetworkManager/dnsmasq.d/
 echo "server=/test/$(minikube ip)" >/etc/NetworkManager/dnsmasq.d/minikube.conf
-systemctl restart NetworkManager.service
 ```
 
-Also see `dns=` in [NetworkManager.conf](https://developer.gnome.org/NetworkManager/stable/NetworkManager.conf.html).
+Restart Network Manager
+```
+systemctl restart NetworkManager.service
+```
+Ensure your /etc/resolv.conf  contains only single nameserver
+```bash
+cat /etc/resolv.conf | grep nameserver
+nameserver 127.0.0.1
+```
 
 {{% /linuxtab %}}
 


### PR DESCRIPTION
Details for ingress-dns setup on Linux with Network Manager
verified on 
openSUSE Leap 15.3
NetworkManager 1.22.10
Dnsmasq version 2.86

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
