### PR TITLE
Add some clarification on mounts needed for none

### DIFF
--- a/site/content/en/docs/drivers/none.md
+++ b/site/content/en/docs/drivers/none.md
@@ -38,6 +38,16 @@ This document is written for system integrators who wish to run minikube within 
 
 * minikube and the Kubernetes services it starts may interfere with other running software on the system. For instance, minikube will start and stop container runtimes via systemd, such as docker, containerd, cri-o.
 
+### Persistent storage
+
+* minikube expects that some mount points used for volumes are bind-mounted or symlinked to a persistent location:
+
+   * `/data`
+   * `/tmp/hostpath_pv`
+   * `/tmp/hostpath-provisioner`
+
+If you don't have a dedicated disk to use for these, you can use the `/var` partition which is _usually_ persistent.
+
 ### Data loss
 
 With the `none` driver, minikube will overwrite the following system paths:

--- a/site/content/en/docs/handbook/persistent_volumes.md
+++ b/site/content/en/docs/handbook/persistent_volumes.md
@@ -15,14 +15,16 @@ minikube supports [PersistentVolumes](https://kubernetes.io/docs/concepts/storag
 
 minikube is configured to persist files stored under the following directories, which are made in the Minikube VM (or on your localhost if running on bare metal).  You may lose data from other directories on reboots.
 
-* `/data`
+* `/data`*
 * `/var/lib/minikube`
 * `/var/lib/docker`
 * `/var/lib/containerd`
 * `/var/lib/buildkit`
 * `/var/lib/containers`
-* `/tmp/hostpath_pv`
-* `/tmp/hostpath-provisioner`
+* `/tmp/hostpath_pv`*
+* `/tmp/hostpath-provisioner`*
+
+\* mount point for another directory, stored under `/var` or on a separate data disk
 
 Here is an example PersistentVolume config to persist data in the '/data' directory:
 


### PR DESCRIPTION
Normally these are provided by "minikube-automount",
but with the none driver you are on your own (as usual)

Closes #13038 