### PR TITLE
wip: new flag --static-ip to allow random IP

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -113,6 +113,7 @@ const (
 	kicBaseImage            = "base-image"
 	ports                   = "ports"
 	network                 = "network"
+	staticIP                = "static-ip"
 	startNamespace          = "namespace"
 	trace                   = "trace"
 	sshIPAddress            = "ssh-ip-address"
@@ -169,6 +170,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().Bool(deleteOnFailure, false, "If set, delete the current cluster if start fails and try again. Defaults to false.")
 	startCmd.Flags().Bool(forceSystemd, false, "If set, force the container runtime to use systemd as cgroup manager. Defaults to false.")
 	startCmd.Flags().StringP(network, "", "", "network to run minikube with. Now it is used by docker/podman and KVM drivers. If left empty, minikube will create a new network.")
+	startCmd.Flags().Bool(staticIP, true, "if set to false will let driver choose ranom IP for node. (useful when sharing network with multiple clusters)")
 	startCmd.Flags().StringVarP(&outputFormat, "output", "o", "text", "Format to print stdout in. Options include: [text,json]")
 	startCmd.Flags().StringP(trace, "", "", "Send trace events. Options include: [gcp]")
 	startCmd.Flags().Int(extraDisks, 0, "Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit and kvm2 drivers)")
@@ -427,6 +429,7 @@ func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, drvName s
 		MinikubeISO:             viper.GetString(isoURL),
 		KicBaseImage:            viper.GetString(kicBaseImage),
 		Network:                 viper.GetString(network),
+		StaticIP:                viper.GetBool(staticIP),
 		Memory:                  getMemorySize(cmd, drvName),
 		CPUs:                    getCPUCount(drvName),
 		DiskSize:                getDiskSize(),
@@ -624,6 +627,7 @@ func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterC
 		out.WarningT("You cannot add or remove extra disks for an existing minikube cluster. Please first delete the cluster.")
 	}
 
+	updateBoolFromFlag(cmd, &cc.StaticIP, staticIP)
 	updateBoolFromFlag(cmd, &cc.KeepContext, keepContext)
 	updateBoolFromFlag(cmd, &cc.EmbedCerts, embedCerts)
 	updateStringFromFlag(cmd, &cc.MinikubeISO, isoURL)

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -55,6 +55,7 @@ type Driver struct {
 	exec       command.Runner
 	NodeConfig Config
 	OCIBinary  string // docker,podman
+	StaticIP   bool   // weather to make a static IP or not for the control-plane
 }
 
 // NewDriver returns a fully configured Kic driver
@@ -94,7 +95,7 @@ func (d *Driver) Create() error {
 	}
 	if gateway, err := oci.CreateNetwork(d.OCIBinary, networkName); err != nil {
 		out.WarningT("Unable to create dedicated network, this might result in cluster IP change after restart: {{.error}}", out.V{"error": err})
-	} else if gateway != nil {
+	} else if gateway != nil && d.StaticIP {
 		params.Network = networkName
 		ip := gateway.To4()
 		// calculate the container IP based on guessing the machine index

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -66,4 +66,5 @@ type Config struct {
 	Network           string            //  network to run with kic
 	ExtraArgs         []string          // a list of any extra option to pass to oci binary during creation time, for example --expose 8080...
 	ListenAddress     string            // IP Address to listen to
+	StaticIP          bool              // currently could only be used by Docker if set to false will let the driver choose random IP.
 }

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -87,6 +87,7 @@ type ClusterConfig struct {
 	CertExpiration          time.Duration
 	Mount                   bool
 	MountString             string
+	StaticIP                bool // if set to false will let driver(docker) to choose random IP, currently only implemneted by Docker driver
 }
 
 // KubernetesConfig contains the parameters used to configure the VM Kubernetes.

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -84,6 +84,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		ExtraArgs:         extraArgs,
 		Network:           cc.Network,
 		ListenAddress:     cc.ListenAddress,
+		StaticIP:          cc.StaticIP,
 	}), nil
 }
 


### PR DESCRIPTION
trying to help a user on slack who wanted to have two minikube clusters on the same docker network

```
Chris Tomkins:bird: Today at 9:56 AM
I have a need (for lab purposes only) to create two Minikube clusters on the same Docker bridge, e.g.:
minikube -p cluster-a start --network-plugin=cni --extra-config=kubeadm.pod-network-cidr=10.200.0.0/16 --service-cluster-ip-range=10.201.0.0/16 --network cttest
minikube -p cluster-b start --network-plugin=cni --extra-config=kubeadm.pod-network-cidr=10.210.0.0/16 --service-cluster-ip-range=10.211.0.0/16 --network cttest```
```

example usage:

```
$ mk start --static-ip=false
😄  minikube v1.24.0 on Darwin 12.0.1 (arm64)
✨  Automatically selected the docker driver
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
💾  Downloading Kubernetes v1.22.4 preload ...
    > preloaded-images-k8s-v14-v1...: 252.09 MiB / 252.09 MiB  100.00% 29.13 Mi
🔥  Creating docker container (CPUs=2, Memory=1988MB) ...
🐳  Preparing Kubernetes v1.22.4 on Docker 20.10.8 ...
❌  Unable to load cached images: loading cached images: stat /Users/medya/.minikube/cache/images/k8s.gcr.io/kube-proxy_v1.22.4: no such file or directory
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```