### PR TITLE
time-to-k8s: Store chart and JSON files in AWS

### DIFF
--- a/.github/workflows/time-to-k8s-public-chart.yml
+++ b/.github/workflows/time-to-k8s-public-chart.yml
@@ -11,18 +11,16 @@ jobs:
   time-to-k8s-public-chart:
     if: github.repository == 'kubernetes/minikube'
     runs-on: ubuntu-20.04
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: 'us-west-1'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
           go-version: ${{env.GO_VERSION}}
           stable: true
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
-        with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_TIME_TO_K8S_SA_KEY }}
-          export_default_credentials: true
       - name: Benchmark time-to-k8s for Docker
         run: |
           ./hack/benchmark/time-to-k8s/public-chart/public-chart.sh docker

--- a/hack/benchmark/time-to-k8s/public-chart/generate-chart.go
+++ b/hack/benchmark/time-to-k8s/public-chart/generate-chart.go
@@ -161,7 +161,7 @@ func createChart(benchmarks []benchmark, chartOutputPath string) {
 		*xy = make(plotter.XYs, n)
 	}
 
-	maxTotal := 0
+	var maxTotal float64
 
 	for i, b := range benchmarks {
 		date := float64(b.Date.Unix())

--- a/hack/benchmark/time-to-k8s/public-chart/generate-chart.go
+++ b/hack/benchmark/time-to-k8s/public-chart/generate-chart.go
@@ -161,6 +161,8 @@ func createChart(benchmarks []benchmark, chartOutputPath string) {
 		*xy = make(plotter.XYs, n)
 	}
 
+	maxTotal := 0
+
 	for i, b := range benchmarks {
 		date := float64(b.Date.Unix())
 		xyValues := []struct {
@@ -181,6 +183,9 @@ func createChart(benchmarks []benchmark, chartOutputPath string) {
 			xy.Y = xyValue.value
 			xy.X = date
 		}
+		if b.Total > maxTotal {
+			maxTotal = b.Total
+		}
 	}
 
 	p := plot.New()
@@ -190,7 +195,7 @@ func createChart(benchmarks []benchmark, chartOutputPath string) {
 	p.X.Label.Text = "date"
 	p.X.Tick.Marker = plot.TimeTicks{Format: "2006-01-02"}
 	p.Y.Label.Text = "time (seconds)"
-	p.Y.Max = 95
+	p.Y.Max = maxTotal + 15
 
 	steps := []struct {
 		xys   plotter.XYs

--- a/site/content/en/docs/benchmarks/timeToK8s/daily_benchmark.md
+++ b/site/content/en/docs/benchmarks/timeToK8s/daily_benchmark.md
@@ -9,8 +9,8 @@ weight: -99999999
 
 ## Docker
 
-![Docker Benchmarks](https://storage.googleapis.com/minikube-time-to-k8s/docker-chart.png)
+![Docker Benchmarks](https://time-to-k8s.s3.us-west-1.amazonaws.com/docker-chart.png)
 
 ## Containerd
 
-![Containerd Benchmarks](https://storage.googleapis.com/minikube-time-to-k8s/containerd-chart.png)
+![Containerd Benchmarks](https://time-to-k8s.s3.us-west-1.amazonaws.com/containerd-chart.png)


### PR DESCRIPTION
- Created AWS bucket
- Uploaded existing charts and JSON files from GCP to AWS
- Updated benchmarking code and website to use AWS
- Ran benchmark successfully on my fork using AWS
  - https://time-to-k8s.s3.us-west-1.amazonaws.com/docker-chart.png
  - https://time-to-k8s.s3.us-west-1.amazonaws.com/containerd-chart.png
- Made chart max dynamic to prevent graph from cutting into legend (will be fixed on next run)