### PR TITLE
Fixes validation on image repository URL when it contains port but no scheme

### DIFF
--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -347,6 +347,14 @@ func TestValidateImageRepository(t *testing.T) {
 			validImageRepository: "auto",
 		},
 		{
+			imageRepository:      "$$$$invalid",
+			validImageRepository: "auto",
+		},
+		{
+			imageRepository:      "",
+			validImageRepository: "auto",
+		},
+		{
 			imageRepository:      "http://registry.test.com/google_containers/",
 			validImageRepository: "registry.test.com/google_containers",
 		},
@@ -368,6 +376,10 @@ func TestValidateImageRepository(t *testing.T) {
 		},
 		{
 			imageRepository:      "https://registry.test.com:6666/google_containers",
+			validImageRepository: "registry.test.com:6666/google_containers",
+		},
+		{
+			imageRepository:      "registry.test.com:6666/google_containers",
 			validImageRepository: "registry.test.com:6666/google_containers",
 		},
 	}


### PR DESCRIPTION
Refactor the way validations are done to use regular expression
Explicitly use "auto" as the imageRepo instead of an empty string when URL received is invalid
Fixes #13022
