### PR TITLE
time-to-k8s: Generate weekly average benchmark charts

### DIFF
--- a/hack/benchmark/time-to-k8s/public-chart/generate-chart.go
+++ b/hack/benchmark/time-to-k8s/public-chart/generate-chart.go
@@ -53,7 +53,8 @@ type benchmarks struct {
 
 func main() {
 	latestBenchmarkPath := flag.String("csv", "", "path to the CSV file containing the latest benchmark result")
-	chartOutputPath := flag.String("output", "", "path to output the chart to")
+	dailyChartPath := flag.String("daily-chart", "", "path to write the daily chart to")
+	weeklyChartPath := flag.String("weekly-chart", "", "path to write the weekly chart to")
 	pastBenchmarksPath := flag.String("past-runs", "", "path to the JSON file containing the past benchmark results")
 	flag.Parse()
 
@@ -61,7 +62,8 @@ func main() {
 	pastBenchmarks := readInPastBenchmarks(*pastBenchmarksPath)
 	pastBenchmarks.Benchmarks = append(pastBenchmarks.Benchmarks, latestBenchmark)
 	updateRunsFile(pastBenchmarks, *pastBenchmarksPath)
-	createChart(pastBenchmarks.Benchmarks, *chartOutputPath)
+	createDailyChart(pastBenchmarks.Benchmarks, *dailyChartPath)
+	createWeeklyChart(pastBenchmarks.Benchmarks, *weeklyChartPath)
 }
 
 // readInLatestBenchmark reads in the latest benchmark result from a CSV file
@@ -151,8 +153,8 @@ func updateRunsFile(h *benchmarks, pastRunsPath string) {
 	}
 }
 
-// createChart creates a time series chart of the benchmarks
-func createChart(benchmarks []benchmark, chartOutputPath string) {
+// createDailyChart creates a time series chart of the benchmarks
+func createDailyChart(benchmarks []benchmark, chartOutputPath string) {
 	n := len(benchmarks)
 	var cmdXYs, apiXYs, k8sXYs, dnsSvcXYs, appXYs, dnsAnsXYs, totalXYs, cpuXYs plotter.XYs
 	xys := []*plotter.XYs{&cmdXYs, &apiXYs, &k8sXYs, &dnsSvcXYs, &appXYs, &dnsAnsXYs, &totalXYs, &cpuXYs}
@@ -188,6 +190,86 @@ func createChart(benchmarks []benchmark, chartOutputPath string) {
 		}
 	}
 
+	generateChart(xys, chartOutputPath, maxTotal)
+}
+
+// createWeeklyChart creates a time series chart of the benchmarks
+func createWeeklyChart(benchmarks []benchmark, chartOutputPath string) {
+	var cmdXYs, apiXYs, k8sXYs, dnsSvcXYs, appXYs, dnsAnsXYs, totalXYs, cpuXYs plotter.XYs
+	xys := []*plotter.XYs{&cmdXYs, &apiXYs, &k8sXYs, &dnsSvcXYs, &appXYs, &dnsAnsXYs, &totalXYs, &cpuXYs}
+
+	for _, xy := range xys {
+		*xy = make(plotter.XYs, 0)
+	}
+
+	weekDuration, err := time.ParseDuration("168h")
+	if err != nil {
+		log.Fatalf("failed to parse duration: %v", err)
+	}
+
+	var maxTotal float64
+	firstBenchmarkDate := benchmarks[0].Date
+	weeklyBenchmark := benchmark{Date: firstBenchmarkDate}
+	// count the number of benchmarks in the week
+	benchmarkCount := 0
+	nextWeek := firstBenchmarkDate.Add(weekDuration)
+
+	for i := 0; i <= len(benchmarks); i++ {
+		// if at the end of the benchmark list or beyond this week's period, calculate the weeks average
+		if i == len(benchmarks) || nextWeek.Before(benchmarks[i].Date) {
+			// skip adding a point if no benchmarks during the week, otherwise points will be at 0
+			if benchmarkCount != 0 {
+				xyValues := []struct {
+					xys   *plotter.XYs
+					value float64
+				}{
+					{&cmdXYs, weeklyBenchmark.Cmd},
+					{&apiXYs, weeklyBenchmark.API},
+					{&k8sXYs, weeklyBenchmark.K8s},
+					{&dnsSvcXYs, weeklyBenchmark.DNSSvc},
+					{&appXYs, weeklyBenchmark.App},
+					{&dnsAnsXYs, weeklyBenchmark.DNSAns},
+					{&totalXYs, weeklyBenchmark.Total},
+					{&cpuXYs, weeklyBenchmark.CPU},
+				}
+				for _, xyValue := range xyValues {
+					val := plotter.XY{
+						Y: xyValue.value / float64(benchmarkCount),
+						X: float64(weeklyBenchmark.Date.Unix()),
+					}
+					*xyValue.xys = append(*xyValue.xys, val)
+				}
+				if weeklyBenchmark.Total/float64(benchmarkCount) > maxTotal {
+					maxTotal = weeklyBenchmark.Total / float64(benchmarkCount)
+				}
+			}
+			weeklyBenchmark = benchmark{Date: nextWeek}
+			nextWeek = nextWeek.Add(weekDuration)
+			benchmarkCount = 0
+			// if we're at the end of the benchmark list quit
+			if i == len(benchmarks) {
+				break
+			}
+			// try running this benchmark again, this is needed incase there's a week without any benchmarks
+			i--
+			continue
+		}
+		b := benchmarks[i]
+		weeklyBenchmark.Cmd += b.Cmd
+		weeklyBenchmark.API += b.API
+		weeklyBenchmark.K8s += b.K8s
+		weeklyBenchmark.DNSSvc += b.DNSSvc
+		weeklyBenchmark.App += b.App
+		weeklyBenchmark.DNSAns += b.DNSAns
+		weeklyBenchmark.Total += b.Total
+		weeklyBenchmark.CPU += b.CPU
+		benchmarkCount++
+	}
+
+	generateChart(xys, chartOutputPath, maxTotal)
+}
+
+func generateChart(xys []*plotter.XYs, chartOutputPath string, maxTotal float64) {
 	p := plot.New()
 	p.Add(plotter.NewGrid())
 	p.Legend.Top = true
@@ -195,31 +277,30 @@ func createChart(benchmarks []benchmark, chartOutputPath string) {
 	p.X.Label.Text = "date"
 	p.X.Tick.Marker = plot.TimeTicks{Format: "2006-01-02"}
 	p.Y.Label.Text = "time (seconds)"
-	p.Y.Max = maxTotal + 15
+	p.Y.Max = maxTotal + 20
 
 	steps := []struct {
-		xys   plotter.XYs
 		rgba  color.RGBA
 		label string
 	}{
-		{cmdXYs, color.RGBA{R: 255, A: 255}, "Command Exec"},
-		{apiXYs, color.RGBA{G: 255, A: 255}, "API Server Answering"},
-		{k8sXYs, color.RGBA{B: 255, A: 255}, "Kubernetes SVC"},
-		{dnsSvcXYs, color.RGBA{R: 255, B: 255, A: 255}, "DNS SVC"},
-		{appXYs, color.RGBA{R: 255, G: 255, A: 255}, "App Running"},
-		{dnsAnsXYs, color.RGBA{G: 255, B: 255, A: 255}, "DNS Answering"},
-		{totalXYs, color.RGBA{B: 255, R: 140, A: 255}, "Total"},
-		{cpuXYs, color.RGBA{B: 57, R: 127, G: 85, A: 255}, "CPU"},
+		{color.RGBA{R: 255, A: 255}, "Command Exec"},
+		{color.RGBA{G: 255, A: 255}, "API Server Answering"},
+		{color.RGBA{B: 255, A: 255}, "Kubernetes SVC"},
+		{color.RGBA{R: 255, B: 255, A: 255}, "DNS SVC"},
+		{color.RGBA{R: 255, G: 255, A: 255}, "App Running"},
+		{color.RGBA{G: 255, B: 255, A: 255}, "DNS Answering"},
+		{color.RGBA{B: 255, R: 140, A: 255}, "Total"},
+		{color.RGBA{B: 57, R: 127, G: 85, A: 255}, "CPU"},
 	}
 
-	for _, step := range steps {
-		line, points := newLinePoints(step.xys, step.rgba)
+	for i, step := range steps {
+		line, points := newLinePoints(*xys[i], step.rgba)
 		p.Add(line, points)
 		p.Legend.Add(step.label, line)
 	}
 
 	if err := p.Save(12*vg.Inch, 8*vg.Inch, chartOutputPath); err != nil {
-		log.Fatal(err)
+		log.Fatalf("failed creating png: %v", err)
 	}
 }
 

--- a/hack/benchmark/time-to-k8s/public-chart/public-chart.sh
+++ b/hack/benchmark/time-to-k8s/public-chart/public-chart.sh
@@ -32,7 +32,7 @@ run_benchmark() {
 }
 
 generate_chart() {
-        go run ./hack/benchmark/time-to-k8s/public-chart/generate-chart.go --csv ./hack/benchmark/time-to-k8s/time-to-k8s-repo/output.csv --output ./chart.png --past-runs ./runs.json
+        go run ./hack/benchmark/time-to-k8s/public-chart/generate-chart.go --csv ./hack/benchmark/time-to-k8s/time-to-k8s-repo/output.csv --daily-chart ./daily-chart.png --weekly-chart ./weekly-chart.png --past-runs ./runs.json
 }
 
 copy() {
@@ -42,7 +42,8 @@ copy() {
 cleanup() {
 	rm ./runs.json
 	rm ./hack/benchmark/time-to-k8s/time-to-k8s-repo/output.csv
-	rm ./chart.png
+	rm ./daily-chart.png
+	rm ./weekly-chart.png
 }
 
 copy "$BUCKET/$RUNTIME-runs.json" ./runs.json
@@ -54,6 +55,7 @@ generate_chart
 
 copy ./runs.json "$BUCKET/$RUNTIME-runs.json"
 copy ./runs.json "$BUCKET/$(date +'%Y-%m-%d')-$RUNTIME.json"
-copy ./chart.png "$BUCKET/$RUNTIME-chart.png"
+copy ./daily-chart.png "$BUCKET/$RUNTIME-chart.png"
+copy ./weekly-chart.png "$BUCKET/$RUNTIME-weekly-chart.png"
 
 cleanup

--- a/site/content/en/docs/benchmarks/timeToK8s/weekly_benchmark.md
+++ b/site/content/en/docs/benchmarks/timeToK8s/weekly_benchmark.md
@@ -1,0 +1,16 @@
+---
+title: "Weekly Average Benchmark"
+description: >
+  Chart to visualize the time-to-k8s benchmark weekly average against HEAD
+weight: -99999998
+---
+
+[Benchmarking Machine Specs](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)
+
+## Docker
+
+![Docker Benchmarks](https://time-to-k8s.s3.us-west-1.amazonaws.com/docker-weekly-chart.png)
+
+## Containerd
+
+![Containerd Benchmarks](https://time-to-k8s.s3.us-west-1.amazonaws.com/containerd-weekly-chart.png)


### PR DESCRIPTION
Added a weekly average benchmark chart

Docker
![docker-weekly-chart](https://user-images.githubusercontent.com/44844360/143969444-8ae66f2c-e23c-4f80-85a5-311f69627bb0.png)

containerd
![containerd-weekly-chart](https://user-images.githubusercontent.com/44844360/143969441-b47e8d95-ec81-491f-9e16-70ed91c2d762.png)
