### PR TITLE
site: Add info about gcp-auth to registry handbook page

### DIFF
--- a/site/content/en/docs/handbook/registry.md
+++ b/site/content/en/docs/handbook/registry.md
@@ -29,6 +29,8 @@ registry-creds was successfully configured
 $ minikube addons enable registry-creds
 ```
 
+**Google Artifact Registry**: minikube has an addon, `gcp-auth`, which maps credentials into minikube to support pulling from Google Artifact Registry. Run `minikube addons enable gcp-auth` to configure the authentication. You can refer to the full docs [here](https://minikube.sigs.k8s.io/docs/handbook/addons/gcp-auth/).
+
 For additional information on private container registries, see [this page](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
 
 We recommend you use _ImagePullSecrets_, but if you would like to configure access on the minikube VM you can place the `.dockercfg` in the `/home/docker` directory or the `config.json` in the `/var/lib/kubelet` directory. Make sure to restart your kubelet (for kubeadm) process with `sudo systemctl restart kubelet`.


### PR DESCRIPTION
It's hard to distinguish Google Container Registry and Google Artifact Registry. They have to be configured differently. I think it wouldn't hurt to emphasize that in the docs.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
