### PR TITLE
CI: Leave existing Docker Desktop instance running

### DIFF
--- a/hack/jenkins/setup_docker_desktop_windows.ps1
+++ b/hack/jenkins/setup_docker_desktop_windows.ps1
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-Get-Process "*Docker Desktop*" | Stop-Process
+if (Get-Process "*Docker Desktop*") {
+  Write-Host "Docker is already running!"
+  exit 0
+}
 
 $attempt = 1
 while($attempt -le 10) {


### PR DESCRIPTION
In CI, Windows machines are set to start Docker Desktop on startup, so let's not close it and try restarting it again.