### PR TITLE
Accept "newest" as input for --kubernetes-version

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1577,7 +1577,7 @@ $ minikube config unset kubernetes-version`)
 
 	if paramVersion == "" || strings.EqualFold(paramVersion, "stable") {
 		paramVersion = constants.DefaultKubernetesVersion
-	} else if strings.EqualFold(paramVersion, "latest") {
+	} else if strings.EqualFold(paramVersion, "latest") || strings.EqualFold(paramVersion, "newest") {
 		paramVersion = constants.NewestKubernetesVersion
 	}
 

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1577,7 +1577,7 @@ $ minikube config unset kubernetes-version`)
 
 	if paramVersion == "" || strings.EqualFold(paramVersion, "stable") {
 		paramVersion = constants.DefaultKubernetesVersion
-	} else if strings.EqualFold(paramVersion, "latest") || strings.EqualFold(paramVersion, "newest") {
+	} else if strings.EqualFold(strings.ToLower(paramVersion), "latest") || strings.EqualFold(strings.ToLower(paramVersion), "newest") {
 		paramVersion = constants.NewestKubernetesVersion
 	}
 

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -73,6 +73,11 @@ func TestGetKubernetesVersion(t *testing.T) {
 			expectedVersion: constants.NewestKubernetesVersion,
 			paramVersion:    "latest",
 		},
+		{
+			description:     "kubernetes-version given as 'newest', no config",
+			expectedVersion: constants.NewestKubernetesVersion,
+			paramVersion:    "newest",
+		},
 	}
 
 	for _, test := range tests {

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -74,9 +74,19 @@ func TestGetKubernetesVersion(t *testing.T) {
 			paramVersion:    "latest",
 		},
 		{
+			description:     "kubernetes-version given as 'LATEST', no config",
+			expectedVersion: constants.NewestKubernetesVersion,
+			paramVersion:    "LATEST",
+		},
+		{
 			description:     "kubernetes-version given as 'newest', no config",
 			expectedVersion: constants.NewestKubernetesVersion,
 			paramVersion:    "newest",
+		},
+		{
+			description:     "kubernetes-version given as 'NEWEST', no config",
+			expectedVersion: constants.NewestKubernetesVersion,
+			paramVersion:    "NEWEST",
 		},
 	}
 


### PR DESCRIPTION
Adds support for #13076

# Testing

```shell
 ./out/minikube start -p testin1 --kubernetes-version=newest
* [testin1] minikube v1.24.0 on Ubuntu 20.04
* Automatically selected the docker driver. Other choices: kvm2, virtualbox, none, ssh
* Starting control plane node testin1 in cluster testin1
* Pulling base image ...
* Downloading Kubernetes v1.23.0-beta.0 preload ...
    > preloaded-images-k8s-v14-v1...: 506.33 MiB / 506.33 MiB  100.00% 25.33 Mi
    > gcr.io/k8s-minikube/kicbase: 355.78 MiB / 355.78 MiB  100.00% 9.17 MiB p/
* Creating docker container (CPUs=2, Memory=16000MB) ...
* Preparing Kubernetes v1.23.0-beta.0 on Docker 20.10.8 ...
  - Generating certificates and keys ...
  - Booting up control plane ...
  - Configuring RBAC rules ...
* Verifying Kubernetes components...
  - Using image gcr.io/k8s-minikube/storage-provisioner:v5
* Enabled addons: default-storageclass, storage-provisioner
* Done! kubectl is now configured to use "testin1" cluster and "default" namespace by default
```
