### PR TITLE
Fix golint warnings

### DIFF
--- a/pkg/generate/errorcodes.go
+++ b/pkg/generate/errorcodes.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/out"
 )
 
+// ErrorCodes generates error codes
 func ErrorCodes(docPath string, pathsToCheck []string) error {
 	buf := bytes.NewBuffer([]byte{})
 	date := time.Now().Format("2006-01-02")

--- a/pkg/generate/testdocs.go
+++ b/pkg/generate/testdocs.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/out"
 )
 
+// TestDocs generates list of tests
 func TestDocs(docPath string, pathToCheck string) error {
 	buf := bytes.NewBuffer([]byte{})
 	date := time.Now().Format("2006-01-02")

--- a/pkg/minikube/assets/aliyun_mirror.go
+++ b/pkg/minikube/assets/aliyun_mirror.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/minikube/deploy/addons"
 )
 
+// AliyunMirror list of images from Aliyun mirror
 var AliyunMirror = loadAliyunMirror()
 
 func loadAliyunMirror() map[string]string {
@@ -39,6 +40,7 @@ func loadAliyunMirror() map[string]string {
 	return mirror
 }
 
+// FixAddonImagesAndRegistries fixes images & registries in addon
 func FixAddonImagesAndRegistries(addon *Addon, images map[string]string, registries map[string]string) (customImages, customRegistries map[string]string) {
 	customImages = make(map[string]string)
 	customRegistries = make(map[string]string)

--- a/pkg/minikube/assets/vm_assets.go
+++ b/pkg/minikube/assets/vm_assets.go
@@ -60,6 +60,8 @@ type CopyableFile interface {
 }
 
 type writeFn func(d []byte) (n int, err error)
+
+// BaseCopyableFile is something that can be copied and written
 type BaseCopyableFile struct {
 	ReadableFile
 
@@ -69,26 +71,32 @@ type BaseCopyableFile struct {
 	targetName string
 }
 
+// Write is for write something into the file
 func (r *BaseCopyableFile) Write(d []byte) (n int, err error) {
 	return r.writer(d)
 }
 
+// SetLength is for setting the length
 func (r *BaseCopyableFile) SetLength(length int) {
 	r.length = length
 }
 
+// GetTargetPath returns target path
 func (r *BaseCopyableFile) GetTargetPath() string {
 	return filepath.Join(r.GetTargetDir(), r.GetTargetName())
 }
 
+// GetTargetDir returns target dir
 func (r *BaseCopyableFile) GetTargetDir() string {
 	return r.targetDir
 }
 
+// GetTargetName returns target name
 func (r *BaseCopyableFile) GetTargetName() string {
 	return r.targetName
 }
 
+// NewBaseCopyableFile creates a new instance of BaseCopyableFile
 func NewBaseCopyableFile(source ReadableFile, writer writeFn, targetDir, targetName string) *BaseCopyableFile {
 	return &BaseCopyableFile{
 		ReadableFile: source,

--- a/pkg/minikube/cluster/mount.go
+++ b/pkg/minikube/cluster/mount.go
@@ -58,9 +58,9 @@ type mountRunner interface {
 const (
 	// MountErrorUnknown failed with unknown error
 	MountErrorUnknown = iota
-	// MountErrorConnect
+	// MountErrorConnect failed to connect
 	MountErrorConnect
-	// MountErrorChmod
+	// MountErrorChmod failed to chmod
 	MountErrorChmod
 )
 

--- a/pkg/minikube/cni/cilium.go
+++ b/pkg/minikube/cni/cilium.go
@@ -808,7 +808,7 @@ func (c Cilium) CIDR() string {
 	return DefaultPodCIDR
 }
 
-// GenerateKubeadmYAML generates the .yaml file
+// GenerateCiliumYAML generates the .yaml file
 func GenerateCiliumYAML() ([]byte, error) {
 
 	podCIDR := DefaultPodCIDR

--- a/pkg/minikube/command/fake_runner.go
+++ b/pkg/minikube/command/fake_runner.go
@@ -142,6 +142,7 @@ func (f *FakeCommandRunner) Copy(file assets.CopyableFile) error {
 	return nil
 }
 
+// CopyFrom copy content from file to the stored map.
 func (f *FakeCommandRunner) CopyFrom(file assets.CopyableFile) error {
 	v, ok := f.fileMap.Load(file.GetSourcePath())
 	if !ok {
@@ -161,6 +162,7 @@ func (f *FakeCommandRunner) Remove(file assets.CopyableFile) error {
 	return nil
 }
 
+// ReadableFile implements interface (without implementation)
 func (f *FakeCommandRunner) ReadableFile(sourcePath string) (assets.ReadableFile, error) {
 	return nil, nil
 }

--- a/pkg/minikube/command/ssh_runner.go
+++ b/pkg/minikube/command/ssh_runner.go
@@ -44,7 +44,7 @@ var (
 )
 
 // SSHRunner runs commands through SSH.
-
+//
 // It implements the CommandRunner interface.
 type SSHRunner struct {
 	d drivers.Driver
@@ -499,6 +499,7 @@ func (s *SSHRunner) CopyFrom(f assets.CopyableFile) error {
 	return g.Wait()
 }
 
+// ReadableFile returns assets.ReadableFile for the sourcePath (via `stat` command)
 func (s *SSHRunner) ReadableFile(sourcePath string) (assets.ReadableFile, error) {
 	klog.V(4).Infof("NewsshReadableFile: %s -> %s", sourcePath)
 

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -172,6 +172,7 @@ func IsSSH(name string) bool {
 	return name == SSH
 }
 
+// AllowsPreload returns if preload is allowed for the driver
 func AllowsPreload(driverName string) bool {
 	return !BareMetal(driverName) && !IsSSH(driverName)
 }

--- a/pkg/minikube/image/image.go
+++ b/pkg/minikube/image/image.go
@@ -203,6 +203,7 @@ func imagePathInCache(img string) string {
 	return f
 }
 
+// UploadCachedImage uploads cached image
 func UploadCachedImage(imgName string) error {
 	tag, err := name.NewTag(imgName, name.WeakValidation)
 	if err != nil {

--- a/pkg/minikube/notify/notify.go
+++ b/pkg/minikube/notify/notify.go
@@ -47,7 +47,7 @@ func MaybePrintUpdateTextFromGithub() {
 	maybePrintUpdateText(GithubMinikubeReleasesURL, GithubMinikubeBetaReleasesURL, lastUpdateCheckFilePath)
 }
 
-// MaybePrintUpdateTextFromGithub prints update text if needed, from Aliyun mirror
+// MaybePrintUpdateTextFromAliyunMirror prints update text if needed, from Aliyun mirror
 func MaybePrintUpdateTextFromAliyunMirror() {
 	maybePrintUpdateText(GithubMinikubeReleasesAliyunURL, GithubMinikubeBetaReleasesAliyunURL, lastUpdateCheckFilePath)
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

Fixed all warnings:

```
➜ make golint
pkg/generate/errorcodes.go:33:1: exported function ErrorCodes should have comment or be unexported
pkg/generate/testdocs.go:36:1: exported function TestDocs should have comment or be unexported
pkg/minikube/assets/aliyun_mirror.go:27:5: exported var AliyunMirror should have comment or be unexported
pkg/minikube/assets/aliyun_mirror.go:42:1: exported function FixAddonImagesAndRegistries should have comment or be unexported
pkg/minikube/assets/vm_assets.go:63:6: exported type BaseCopyableFile should have comment or be unexported
pkg/minikube/assets/vm_assets.go:76:1: exported method BaseCopyableFile.SetLength should have comment or be unexported
pkg/minikube/assets/vm_assets.go:80:1: exported method BaseCopyableFile.GetTargetPath should have comment or be unexported
pkg/minikube/assets/vm_assets.go:84:1: exported method BaseCopyableFile.GetTargetDir should have comment or be unexported
pkg/minikube/assets/vm_assets.go:88:1: exported method BaseCopyableFile.GetTargetName should have comment or be unexported
pkg/minikube/assets/vm_assets.go:92:1: exported function NewBaseCopyableFile should have comment or be unexported
pkg/minikube/cluster/mount.go:61:2: comment on exported const MountErrorConnect should be of the form "MountErrorConnect ..."
pkg/minikube/cluster/mount.go:63:2: comment on exported const MountErrorChmod should be of the form "MountErrorChmod ..."
pkg/minikube/cni/cilium.go:811:1: comment on exported function GenerateCiliumYAML should be of the form "GenerateCiliumYAML ..."
pkg/minikube/command/fake_runner.go:145:1: exported method FakeCommandRunner.CopyFrom should have comment or be unexported
pkg/minikube/command/fake_runner.go:164:1: exported method FakeCommandRunner.ReadableFile should have comment or be unexported
pkg/minikube/command/ssh_runner.go:48:1: comment on exported type SSHRunner should be of the form "SSHRunner ..." (with optional leading article)
pkg/minikube/command/ssh_runner.go:502:1: exported method SSHRunner.ReadableFile should have comment or be unexported
pkg/minikube/driver/driver.go:175:1: exported function AllowsPreload should have comment or be unexported
pkg/minikube/image/image.go:206:1: exported function UploadCachedImage should have comment or be unexported
pkg/minikube/notify/notify.go:50:1: comment on exported function MaybePrintUpdateTextFromAliyunMirror should be of the form "MaybePrintUpdateTextFromAliyunMirror ..."
Found 20 lint suggestions; failing.
Makefile:484: recipe for target 'golint' failed
make: *** [golint] Error 1
```
