### PR TITLE
Fix metrics reporting

### DIFF
--- a/hack/metrics/metrics.go
+++ b/hack/metrics/metrics.go
@@ -117,11 +117,9 @@ func exportMinikubeStart(ctx context.Context, projectID, containerRuntime string
 func getExporter(projectID, containerRuntime string) (*stackdriver.Exporter, error) {
 	return stackdriver.NewExporter(stackdriver.Options{
 		ProjectID: projectID,
-		// MetricPrefix helps uniquely identify your metrics.
-		MetricPrefix: "minikube_start",
 		// ReportingInterval sets the frequency of reporting metrics
 		// to stackdriver backend.
-		ReportingInterval:       1 * time.Second,
+		ReportingInterval:       11 * time.Second,
 		DefaultMonitoringLabels: getLabels(containerRuntime),
 	})
 }


### PR DESCRIPTION
Was getting error:
`Failed to export to Stackdriver: [rpc error: code = InvalidArgument desc = One or more TimeSeries could not be written: Field timeSeries[0].metric.type had an invalid value of "minikube_start/custom.googleapis.com/minikube/start_time": The metric type must be a URL-formatted string with a domain and non-empty path.: timeSeries[0]`

It was using `minikube_start/custom.googleapis.com/minikube/start_time` as the URL, so removed `minikube_start` by removing `MetricPrefix`.

Then was getting error:
`Failed to export to Stackdriver: rpc error: code = InvalidArgument desc = One or more TimeSeries could not be written: One or more points were written more frequently than the maximum sampling period configured for the metric.: timeSeries[0]`

Found: `Cloud Monitoring allows one write every 10 seconds` so I initially upped `ReportingInterval` to 10 seconds, but would occasionally still cause the error, so upped to 11 seconds and didn't have any issue.