### PR TITLE
Fix conditional exclusion for alpha.

### DIFF
--- a/hack/preload-images/kubernetes.go
+++ b/hack/preload-images/kubernetes.go
@@ -36,7 +36,7 @@ func recentK8sVersions() ([]string, error) {
 	var releases []string
 	for _, r := range list {
 		// Exclude "alpha" releases.
-		if !strings.Contains(r.GetTagName(), "alpha") {
+		if strings.Contains(r.GetTagName(), "alpha") {
 			continue
 		}
 		releases = append(releases, r.GetTagName())


### PR DESCRIPTION
Fixes: #13118
Fixes a bug in: #13119

Fix bug as we want to exclude alpha.

**Before:**
If NOT contains alpha....
  continue

**After:**
If contains alpha...
  continue