### PR TITLE
Refactored to remove config.ExtraOptions

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1199,7 +1199,8 @@ func validateFlags(cmd *cobra.Command, drvName string) {
 	}
 
 	// validate kubeadm extra args
-	if invalidOpts := bsutil.FindInvalidExtraConfigFlags(config.ExtraOptions); len(invalidOpts) > 0 {
+	extraOptions := getExtraOptions()
+	if invalidOpts := bsutil.FindInvalidExtraConfigFlags(extraOptions); len(invalidOpts) > 0 {
 		out.WarningT(
 			"These --extra-config parameters are invalid: {{.invalid_extra_opts}}",
 			out.V{"invalid_extra_opts": invalidOpts},
@@ -1212,7 +1213,7 @@ func validateFlags(cmd *cobra.Command, drvName string) {
 	}
 
 	// check that kubeadm extra args contain only allowed parameters
-	for param := range config.ExtraOptions.AsMap().Get(bsutil.Kubeadm) {
+	for param := range extraOptions.AsMap().Get(bsutil.Kubeadm) {
 		if !config.ContainsParam(bsutil.KubeadmExtraArgsAllowed[bsutil.KubeadmCmdParam], param) &&
 			!config.ContainsParam(bsutil.KubeadmExtraArgsAllowed[bsutil.KubeadmConfigParam], param) {
 			exit.Message(reason.Usage, "Sorry, the kubeadm.{{.parameter_name}} parameter is currently not supported by --extra-config", out.V{"parameter_name": param})
@@ -1472,17 +1473,19 @@ func autoSetDriverOptions(cmd *cobra.Command, drvName string) (err error) {
 	err = nil
 	hints := driver.FlagDefaults(drvName)
 	if len(hints.ExtraOptions) > 0 {
+		extraOptionVals := getExtraOptions()
 		for _, eo := range hints.ExtraOptions {
-			if config.ExtraOptions.Exists(eo) {
+			if extraOptionVals.Exists(eo) {
 				klog.Infof("skipping extra-config %q.", eo)
 				continue
 			}
 			klog.Infof("auto setting extra-config to %q.", eo)
-			err = config.ExtraOptions.Set(eo)
+			err = extraOptionVals.Set(eo)
 			if err != nil {
 				err = errors.Wrapf(err, "setting extra option %s", eo)
 			}
 		}
+		viper.Set(extraOptions, extraOptionVals)
 	}
 
 	if !cmd.Flags().Changed(cacheImages) {

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -124,6 +124,7 @@ const (
 	listenAddress           = "listen-address"
 	extraDisks              = "extra-disks"
 	certExpiration          = "cert-expiration"
+	extraOptions            = "extra-config"
 )
 
 var (
@@ -179,7 +180,7 @@ func initMinikubeFlags() {
 func initKubernetesFlags() {
 	startCmd.Flags().String(kubernetesVersion, "", fmt.Sprintf("The Kubernetes version that the minikube VM will use (ex: v1.2.3, 'stable' for %s, 'latest' for %s). Defaults to 'stable'.", constants.DefaultKubernetesVersion, constants.NewestKubernetesVersion))
 	startCmd.Flags().String(startNamespace, "default", "The named space to activate after start")
-	startCmd.Flags().Var(&config.ExtraOptions, "extra-config",
+	startCmd.Flags().String(extraOptions, "",
 		`A set of key=value pairs that describe configuration that may be passed to different components.
 		The key should be '.' separated, and the first part before the dot is the component to apply the configuration to.
 		Valid components are: kubelet, kubeadm, apiserver, controller-manager, etcd, proxy, scheduler
@@ -402,6 +403,18 @@ func getCNIConfig(cmd *cobra.Command) string {
 	return chosenCNI
 }
 
+func getExtraOptions() config.ExtraOptionSlice {
+	extraOptionVals := config.ExtraOptionSlice{}
+	val := viper.GetString(extraOptions)
+	if val == "" {
+		return extraOptionVals
+	}
+	if err := extraOptionVals.Set(val); err != nil {
+		klog.Errorf("Invalid %s flag provided, flag will be ignored", extraOptions)
+	}
+	return extraOptionVals
+}
+
 // generateNewConfigFromFlags generate a config.ClusterConfig based on flags
 func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, drvName string) config.ClusterConfig {
 	var cc config.ClusterConfig
@@ -480,7 +493,7 @@ func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, drvName s
 			NetworkPlugin:          chosenNetworkPlugin,
 			ServiceCIDR:            viper.GetString(serviceCIDR),
 			ImageRepository:        getRepository(cmd, k8sVersion),
-			ExtraOptions:           config.ExtraOptions,
+			ExtraOptions:           getExtraOptions(),
 			ShouldLoadCachedImages: viper.GetBool(cacheImages),
 			CNI:                    getCNIConfig(cmd),
 			NodePort:               viper.GetInt(apiServerPort),
@@ -680,8 +693,8 @@ func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterC
 		cc.KubernetesConfig.KubernetesVersion = getKubernetesVersion(existing)
 	}
 
-	if cmd.Flags().Changed("extra-config") {
-		cc.KubernetesConfig.ExtraOptions = config.ExtraOptions
+	if cmd.Flags().Changed(extraOptions) {
+		cc.KubernetesConfig.ExtraOptions = getExtraOptions()
 	}
 
 	if cmd.Flags().Changed(cniFlag) || cmd.Flags().Changed(enableDefaultCNI) {

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -403,6 +403,7 @@ func getCNIConfig(cmd *cobra.Command) string {
 	return chosenCNI
 }
 
+// getExtraOptions gets Kubernetes extra options from flags
 func getExtraOptions() config.ExtraOptionSlice {
 	extraOptionVals := config.ExtraOptionSlice{}
 	val := viper.GetString(extraOptions)
@@ -410,7 +411,7 @@ func getExtraOptions() config.ExtraOptionSlice {
 		return extraOptionVals
 	}
 	if err := extraOptionVals.Set(val); err != nil {
-		klog.Errorf("Invalid %s flag provided, flag will be ignored", extraOptions)
+		klog.Errorf("Invalid %s flag provided, flag will be ignored: %v", extraOptions, err)
 	}
 	return extraOptionVals
 }

--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -61,8 +61,6 @@ var (
 	DockerEnv []string
 	// DockerOpt contains the option parameters
 	DockerOpt []string
-	// ExtraOptions contains extra options (if any)
-	ExtraOptions ExtraOptionSlice
 )
 
 // ErrNotExist is the error returned when a config does not exist

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -477,7 +477,7 @@ func setupKubeAdm(mAPI libmachine.API, cfg config.ClusterConfig, n config.Node, 
 	if err != nil {
 		exit.Error(reason.InternalBootstrapper, "Failed to get bootstrapper", err)
 	}
-	for _, eo := range config.ExtraOptions {
+	for _, eo := range cfg.KubernetesConfig.ExtraOptions {
 		out.Infof("{{.extra_option_component_name}}.{{.key}}={{.value}}", out.V{"extra_option_component_name": eo.Component, "key": eo.Key, "value": eo.Value})
 	}
 	// Loads cached images, generates config files, download binaries

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -45,7 +45,7 @@ minikube start [flags]
       --dry-run                           dry-run mode. Validates configuration, but does not mutate system state
       --embed-certs                       if true, will embed the certs in kubeconfig.
       --enable-default-cni                DEPRECATED: Replaced by --cni=bridge
-      --extra-config ExtraOption          A set of key=value pairs that describe configuration that may be passed to different components.
+      --extra-config string               A set of key=value pairs that describe configuration that may be passed to different components.
                                           		The key should be '.' separated, and the first part before the dot is the component to apply the configuration to.
                                           		Valid components are: kubelet, kubeadm, apiserver, controller-manager, etcd, proxy, scheduler
                                           		Valid kubeadm parameters: ignore-preflight-errors, dry-run, kubeconfig, kubeconfig-dir, node-name, cri-socket, experimental-upload-certs, certificate-key, rootfs, skip-phases, pod-network-cidr


### PR DESCRIPTION
Refactored the `--extra-config` flag to a string flag and removed the `config.ExtraConfig` object to prevent modifying a global variable.