### PR TITLE
Don't output Docker performance issues when user wants JSON

### DIFF
--- a/pkg/drivers/kic/oci/cli_runner.go
+++ b/pkg/drivers/kic/oci/cli_runner.go
@@ -135,7 +135,7 @@ func runCmd(cmd *exec.Cmd, warnSlow ...bool) (*RunResult, error) {
 	start := time.Now()
 	err := cmd.Run()
 	elapsed := time.Since(start)
-	if warn {
+	if warn && !out.JSON {
 		if elapsed > warnTime {
 			warnLock.Lock()
 			_, ok := alreadyWarnedCmds[rr.Command()]

--- a/third_party/kubeadm/app/constants/constants_unix.go
+++ b/third_party/kubeadm/app/constants/constants_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/third_party/kubeadm/app/constants/constants_windows.go
+++ b/third_party/kubeadm/app/constants/constants_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*


### PR DESCRIPTION
**Problem:**
If Docker is being slow we output a message to the user notifying them. When the user passes `--output=json` we ouput the messages as JSON, the problem is we have places if our code where we try to decode the output and three JSON objects instead of one breaks our code.

Example:
```
What we expect:
$ minikube status --output=json
{"Name":"minikube","Host":"Running","Kubelet":"Running","APIServer":"Running","Kubeconfig":"Configured","Worker":false}

What we get:
$ minikube status --output=json
failed to decode json from status: args "minikube status --output=json": invalid character '{' after top-level value

Because behind the scenes this is getting returned:
{"specversion":"1.0","id":"b4bb9624-647f-4c30-88c8-6016693a8193","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.warning","datacontenttype":"application/json","data":{"message":"Executing \"docker system info --format \"{{json .}}\"\" took an unusually long time: 113.00953ms"}}
{"specversion":"1.0","id":"5e333af2-34d0-4f48-88db-33d15aef2e70","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.error","datacontenttype":"application/json","data":{"message":"Restarting the docker service may improve performance."}}
{"Name":"minikube","Host":"Running","Kubelet":"Running","APIServer":"Running","Kubeconfig":"Configured","Worker":false}
```

**Solution:**
Don't output Docker error messages if JSON is requested.

This will fix our `Docker Windows` `TestMultiNode/serial/CopyFile`, `TestInsufficientStorage`, `TestNoKubernetes/serial/StartWithK8s`, `TestPause/serial/VerifyStatus` & `TestFunctional/parallel/StatusCmd`