### PR TITLE
KIC: Upgrade ubuntu minor version

### DIFF
--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -27,7 +27,7 @@ RUN cd ./cmd/auto-pause/ && go build
 
 # start from ubuntu 20.04, this image is reasonably small as a starting point
 # for a kubernetes node image, it doesn't contain much we don't need
-FROM ubuntu:focal-20210401
+FROM ubuntu:focal-20211006
 
 ARG BUILDKIT_VERSION="v0.9.3"
 ARG FUSE_OVERLAYFS_VERSION="v1.7.1"


### PR DESCRIPTION
This should also upgrade Docker and Podman packages

```
The following packages will be upgraded:
  apt base-files bind9-dnsutils bind9-host bind9-libs catatonit containerd.io
  containers-common cri-o criu crun dnsutils docker-ce docker-ce-cli
  gcc-10-base libapt-pkg6.0 libgcc-s1 libgcrypt20 libgnutls30 libhogweed5
  libicu66 libnettle7 libpam-modules libpam-modules-bin libpam-runtime
  libpam0g libprocps8 libpython3.8-minimal libpython3.8-stdlib libssl1.1
  libstdc++6 login openssl passwd podman procps python3.8 python3.8-minimal
  rsync tzdata vim-common vim-tiny xxd
43 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
```