### PR TITLE
Removed one off sudo command from test

### DIFF
--- a/test/integration/pause_test.go
+++ b/test/integration/pause_test.go
@@ -173,7 +173,7 @@ func validateVerifyDeleted(ctx context.Context, t *testing.T, profile string) {
 			t.Errorf("expected to see error and volume %q to not exist after deletion but got no error and this output: %s", rr.Command(), rr.Output())
 		}
 
-		rr, err = Run(t, exec.CommandContext(ctx, "sudo", bin, "network", "ls"))
+		rr, err = Run(t, exec.CommandContext(ctx, bin, "network", "ls"))
 		if err != nil {
 			t.Errorf("failed to get list of networks: %v", err)
 		}


### PR DESCRIPTION
**Problem:**
The `TestPause/serial/VerifyDeletedResources` on `Windows Docker` is failing at 100% because we're trying to run the `sudo` command on PowerShell which isn't supported.

**Solution:**
It doesn't make sense we're using `sudo` since there are numerous other `docker` commands in the same test that don't use `sudo`

**Before:**
```
docker ps -a
docker volumes inspect <profile>
sudo docker network ls
```

**After:**
```
docker ps -a
docker volumes inspect <profile>
docker network ls
```