### PR TITLE
Support mounting with the --no-kubernetes flag

### DIFF
--- a/pkg/minikube/node/config.go
+++ b/pkg/minikube/node/config.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/cruntime"
+	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/minikube/out"
@@ -55,7 +56,7 @@ func configureMounts(wg *sync.WaitGroup, cc config.ClusterConfig) {
 	wg.Add(1)
 	defer wg.Done()
 
-	if !cc.Mount {
+	if !cc.Mount || driver.IsKIC(cc.Driver) {
 		return
 	}
 

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -148,9 +148,7 @@ func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 		}
 	}
 
-	if !driver.IsKIC(starter.Cfg.Driver) {
-		go configureMounts(&wg, *starter.Cfg)
-	}
+	go configureMounts(&wg, *starter.Cfg)
 
 	wg.Add(1)
 	go func() {

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -90,11 +90,13 @@ type Starter struct {
 
 // Start spins up a guest and starts the Kubernetes node.
 func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
+	var wg sync.WaitGroup
 	stop8ks, err := handleNoKubernetes(starter)
 	if err != nil {
 		return nil, err
 	}
 	if stop8ks {
+		configureMounts(&wg, *starter.Cfg)
 		return nil, config.Write(viper.GetString(config.ProfileName), starter.Cfg)
 	}
 
@@ -146,7 +148,6 @@ func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 		}
 	}
 
-	var wg sync.WaitGroup
 	if !driver.IsKIC(starter.Cfg.Driver) {
 		go configureMounts(&wg, *starter.Cfg)
 	}

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -91,11 +91,11 @@ type Starter struct {
 // Start spins up a guest and starts the Kubernetes node.
 func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 	var wg sync.WaitGroup
-	stop8ks, err := handleNoKubernetes(starter)
+	stopk8s, err := handleNoKubernetes(starter)
 	if err != nil {
 		return nil, err
 	}
-	if stop8ks {
+	if stopk8s {
 		configureMounts(&wg, *starter.Cfg)
 		return nil, config.Write(viper.GetString(config.ProfileName), starter.Cfg)
 	}

--- a/test/integration/mount_start_test.go
+++ b/test/integration/mount_start_test.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 const (
@@ -99,6 +100,8 @@ func validateStartWithMount(ctx context.Context, t *testing.T, profile string) {
 	if err != nil {
 		t.Fatalf("failed to start minikube with args: %q : %v", rr.Command(), err)
 	}
+	// The mount takes a split second to come up, without this the validateMount test will fail
+	time.Sleep(1 * time.Second)
 }
 
 // validateMount checks if the cluster has a folder mounted

--- a/test/integration/mount_start_test.go
+++ b/test/integration/mount_start_test.go
@@ -93,7 +93,7 @@ func validateStartWithMount(ctx context.Context, t *testing.T, profile string) {
 	// We have to increment this because if you have two mounts with the same port, when you kill one cluster the mount will break for the other
 	mountStartPort++
 
-	args := []string{"start", "-p", profile, "--memory=2048", "--mount", "--mount-gid", mountGID, "--mount-msize", mountMSize, "--mount-port", mountPort(), "--mount-uid", mountUID}
+	args := []string{"start", "-p", profile, "--memory=2048", "--mount", "--mount-gid", mountGID, "--mount-msize", mountMSize, "--mount-port", mountPort(), "--mount-uid", mountUID, "--no-kubernetes"}
 	args = append(args, StartArgs()...)
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/13003

**Problem:**
If the `--no-kubernetes` flag is used, file mounting is skipped.

**Solution:**
Make sure mounting occurs whether `--no-kubernetes` is passed or not.