### PR TITLE
Fix multinode file copying test on Windows

### DIFF
--- a/test/integration/multinode_test.go
+++ b/test/integration/multinode_test.go
@@ -193,7 +193,7 @@ func validateCopyFileWithMultiNode(ctx context.Context, t *testing.T, profile st
 		// copy local to node
 		testCpCmd(ctx, t, profile, "", srcPath, n.Name, dstPath)
 
-		// copy back from node to lcoal
+		// copy back from node to local
 		tmpPath := filepath.Join(tmpDir, fmt.Sprintf("cp-test_%s.txt", n.Name))
 		testCpCmd(ctx, t, profile, n.Name, dstPath, "", tmpPath)
 
@@ -202,7 +202,7 @@ func validateCopyFileWithMultiNode(ctx context.Context, t *testing.T, profile st
 			if n.Name == n2.Name {
 				continue
 			}
-			fp := filepath.Join("/home/docker", fmt.Sprintf("cp-test_%s_%s.txt", n.Name, n2.Name))
+			fp := fmt.Sprintf("/home/docker/cp-test_%s_%s.txt", n.Name, n2.Name)
 			testCpCmd(ctx, t, profile, n.Name, dstPath, n2.Name, fp)
 		}
 	}

--- a/test/integration/multinode_test.go
+++ b/test/integration/multinode_test.go
@@ -27,6 +27,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -202,7 +203,7 @@ func validateCopyFileWithMultiNode(ctx context.Context, t *testing.T, profile st
 			if n.Name == n2.Name {
 				continue
 			}
-			fp := fmt.Sprintf("/home/docker/cp-test_%s_%s.txt", n.Name, n2.Name)
+			fp := path.Join("/home/docker", fmt.Sprintf("cp-test_%s_%s.txt", n.Name, n2.Name))
 			testCpCmd(ctx, t, profile, n.Name, dstPath, n2.Name, fp)
 		}
 	}


### PR DESCRIPTION
**Problem:**
`TestMultiNode/serial/CopyFile` failing at 100% on Windows Docker & Hyper-V. This is due to setting the location to copy the file into the minikube cluster using `filepath.Join`, we give it `filepath.Join("/home/docker", "cp-test")` but because we're running it on Windows the slashes get changed and returns `\home\docker\cp-test` which isn't a valid path within the cluster.

**Solution:**
Hardcode the slashes to Unix style since that's never going to change.