### PR TITLE
Revert "bump golang version to 1.17.5"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
       - "!deploy/iso/**"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.17.5'
+  GO_VERSION: '1.17.3'
 jobs:
   build_minikube:
     runs-on: ubuntu-20.04

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,7 @@ on:
       - master  
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.17.5'
+  GO_VERSION: '1.17.3'
 jobs:
   generate-docs:
     runs-on: ubuntu-20.04

--- a/.github/workflows/functional_verified.yml
+++ b/.github/workflows/functional_verified.yml
@@ -21,7 +21,7 @@ on:
       - deleted
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.17.5'
+  GO_VERSION: '1.17.3'
 
 jobs:
   # Runs before all other jobs

--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -7,7 +7,7 @@ on:
   release:
     types: [published]
 env:
-  GO_VERSION: '1.17.5'
+  GO_VERSION: '1.17.3'
 jobs:
   update-leaderboard:
     runs-on: ubuntu-20.04

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,7 +14,7 @@ on:
       - "!deploy/iso/**"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.17.5'
+  GO_VERSION: '1.17.3'
 jobs:
   # Runs before all other jobs
   # builds the minikube binaries

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ on:
       - "!deploy/iso/**"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.17.5'
+  GO_VERSION: '1.17.3'
 jobs:
   # Runs before all other jobs
   # builds the minikube binaries

--- a/.github/workflows/time-to-k8s-public-chart.yml
+++ b/.github/workflows/time-to-k8s-public-chart.yml
@@ -6,7 +6,7 @@ on:
     - cron: "0 2,14 * * *"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.17.5'
+  GO_VERSION: '1.17.3'
 jobs:
   time-to-k8s-public-chart:
     if: github.repository == 'kubernetes/minikube'

--- a/.github/workflows/time-to-k8s.yml
+++ b/.github/workflows/time-to-k8s.yml
@@ -5,7 +5,7 @@ on:
     types: [released]
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.17.5'
+  GO_VERSION: '1.17.3'
 jobs:
   benchmark:
     runs-on: ubuntu-20.04

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -6,7 +6,7 @@ on:
       - "translations/**"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.17.5'
+  GO_VERSION: '1.17.3'
 jobs:
   unit_test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/update-golang-version.yml
+++ b/.github/workflows/update-golang-version.yml
@@ -6,7 +6,7 @@ on:
     - cron: "0 9 * * 1"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.17.5'
+  GO_VERSION: '1.17.3'
 jobs:
   bump-golang-version:
     runs-on: ubuntu-20.04

--- a/.github/workflows/update-golint-version.yml
+++ b/.github/workflows/update-golint-version.yml
@@ -6,7 +6,7 @@ on:
     - cron: "0 10 * * 1"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.17.5'
+  GO_VERSION: '1.17.3'
 jobs:
   bump-golint-version:
     runs-on: ubuntu-20.04

--- a/.github/workflows/update-k8s-versions.yml
+++ b/.github/workflows/update-k8s-versions.yml
@@ -6,7 +6,7 @@ on:
     - cron: "0 8 * * 1"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.17.5'
+  GO_VERSION: '1.17.3'
 jobs:
   bump-k8s-versions:
     runs-on: ubuntu-20.04

--- a/.github/workflows/update-kubadm-constants.yml
+++ b/.github/workflows/update-kubadm-constants.yml
@@ -6,7 +6,7 @@ on:
     - cron: "0 6 * * 1"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.17.5'
+  GO_VERSION: '1.17.3'
 jobs:
   bump-k8s-versions:
     runs-on: ubuntu-20.04

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,9 @@ RPM_REVISION ?= 0
 
 # used by hack/jenkins/release_build_and_upload.sh and KVM_BUILD_IMAGE, see also BUILD_IMAGE below
 # update this only by running `make update-golang-version`
-GO_VERSION ?= 1.17.5
+GO_VERSION ?= 1.17.3
 # update this only by running `make update-golang-version`
-GO_K8S_VERSION_PREFIX ?= v1.24.0
+GO_K8S_VERSION_PREFIX ?= v1.23.0
 
 # replace "x.y.0" => "x.y". kube-cross and golang.org/dl use different formats for x.y.0 go versions
 KVM_GO_VERSION ?= $(GO_VERSION:.0=)

--- a/hack/jenkins/installers/check_install_golang.sh
+++ b/hack/jenkins/installers/check_install_golang.sh
@@ -22,7 +22,7 @@ if (($# < 1)); then
   exit 1
 fi
 
-VERSION_TO_INSTALL=1.17.5
+VERSION_TO_INSTALL=1.17.3
 INSTALL_PATH=${1}
 
 function current_arch() {


### PR DESCRIPTION
Causing build failures
```
docker run --rm -e GOCACHE=/app/.cache -e IN_DOCKER=1 --user 1001:121 -w /app -v /home/runner/work/minikube/minikube:/app -v /home/runner/go:/go --init us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:v1.24.0-go1.17.5-buster.0 /bin/bash -c '/usr/bin/make out/minikube-linux-amd64'

Unable to find image 'us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:v1.24.0-go1.17.5-buster.0' locally

docker: Error response from daemon: manifest for us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:v1.24.0-go1.17.5-buster.0 not found: manifest unknown: Failed to fetch "v1.24.0-go1.17.5-buster.0" from request "/v2/k8s-artifacts-prod/build-image/kube-cross/manifests/v1.24.0-go1.17.5-buster.0".
```

https://github.com/kubernetes/minikube/runs/4510261399?check_suite_focus=true