### PR TITLE
Added env to suppress Docker performance messages

### DIFF
--- a/hack/jenkins/common.ps1
+++ b/hack/jenkins/common.ps1
@@ -29,6 +29,7 @@ function Write-GithubStatus {
 
 $env:SHORT_COMMIT=$env:COMMIT.substring(0, 7)
 $gcs_bucket="minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:ROOT_JOB_ID"
+$env:MINIKUBE_SUPPRESS_DOCKER_PERFORMANCE=true
 
 # Docker's kubectl breaks things, and comes earlier in the path than the regular kubectl. So download the expected kubectl and replace Docker's version.
 (New-Object Net.WebClient).DownloadFile("https://dl.k8s.io/release/v1.20.0/bin/windows/amd64/kubectl.exe", "C:\Program Files\Docker\Docker\resources\bin\kubectl.exe")

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -33,6 +33,7 @@ readonly TEST_HOME="${TEST_ROOT}/${OS_ARCH}-${DRIVER}-${CONTAINER_RUNTIME}-${MIN
 export GOPATH="$HOME/go"
 export KUBECONFIG="${TEST_HOME}/kubeconfig"
 export PATH=$PATH:"/usr/local/bin/:/usr/local/go/bin/:$GOPATH/bin"
+export MINIKUBE_SUPPRESS_DOCKER_PERFORMANCE=true
 
 readonly TIMEOUT=${1:-120m}
 

--- a/pkg/drivers/kic/oci/cli_runner.go
+++ b/pkg/drivers/kic/oci/cli_runner.go
@@ -21,8 +21,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -84,6 +86,17 @@ func PrefixCmd(cmd *exec.Cmd) *exec.Cmd {
 	return cmd
 }
 
+func suppressDockerMessage() bool {
+	envKey := "MINIKUBE_SUPPRESS_DOCKER_PERFORMANCE"
+	env := os.Getenv(envKey)
+	suppress, err := strconv.ParseBool(env)
+	if err != nil {
+		klog.Errorf("failed to parse bool from the %s env, defaulting to 'false'; received: %s: %v", envKey, env, err)
+		return false
+	}
+	return suppress
+}
+
 // runCmd runs a command exec.Command against docker daemon or podman
 func runCmd(cmd *exec.Cmd, warnSlow ...bool) (*RunResult, error) {
 	cmd = PrefixCmd(cmd)
@@ -135,7 +148,7 @@ func runCmd(cmd *exec.Cmd, warnSlow ...bool) (*RunResult, error) {
 	start := time.Now()
 	err := cmd.Run()
 	elapsed := time.Since(start)
-	if warn && !out.JSON {
+	if warn && !out.JSON && !suppressDockerMessage() {
 		if elapsed > warnTime {
 			warnLock.Lock()
 			_, ok := alreadyWarnedCmds[rr.Command()]

--- a/pkg/drivers/kic/oci/cli_runner.go
+++ b/pkg/drivers/kic/oci/cli_runner.go
@@ -91,7 +91,9 @@ func suppressDockerMessage() bool {
 	env := os.Getenv(envKey)
 	suppress, err := strconv.ParseBool(env)
 	if err != nil {
-		klog.Errorf("failed to parse bool from the %s env, defaulting to 'false'; received: %s: %v", envKey, env, err)
+		msg := fmt.Sprintf("failed to parse bool from the %s env, defaulting to 'false'; received: %s: %v", envKey, env, err)
+		klog.Warning(msg)
+		out.Styled(style.Warning, msg)
 		return false
 	}
 	return suppress

--- a/site/content/en/docs/handbook/config.md
+++ b/site/content/en/docs/handbook/config.md
@@ -114,13 +114,11 @@ Some features can only be accessed by minikube specific environment variables, h
 
 * **MINIKUBE_IN_STYLE** - (bool) manually sets whether or not emoji and colors should appear in minikube. Set to false or 0 to disable this feature, true or 1 to force it to be turned on.
 
-* **MINIKUBE_WANTUPDATENOTIFICATION** - (bool) sets whether the user wants an update notification for new minikube versions
-
-* **MINIKUBE_REMINDERWAITPERIODINHOURS** - (int) sets the number of hours to check for an update notification
-
 * **CHANGE_MINIKUBE_NONE_USER** - (bool) automatically change ownership of ~/.minikube to the value of $SUDO_USER
 
 * **MINIKUBE_ENABLE_PROFILING** - (int, `1` enables it) enables trace profiling to be generated for minikube
+
+* **MINIKUBE_SUPPRESS_DOCKER_PERFORMANCE** - (bool) suppresses Docker performance warnings when Docker is slow
 
 ### Example: Disabling emoji
 

--- a/site/content/en/docs/tutorials/continuous_integration.md
+++ b/site/content/en/docs/tutorials/continuous_integration.md
@@ -46,6 +46,6 @@ curl -LO \
   https://storage.googleapis.com/kubernetes-release/release/$kv/bin/linux/amd64/kubectl \
   && install kubectl /tmp/
 
-export MINIKUBE_WANTUPDATENOTIFICATION=false
+minikube config set WantUpdateNotification false
 /tmp/minikube-linux-amd64 start --driver=docker
 ```

--- a/site/content/en/docs/tutorials/continuous_integration.md
+++ b/site/content/en/docs/tutorials/continuous_integration.md
@@ -46,6 +46,6 @@ curl -LO \
   https://storage.googleapis.com/kubernetes-release/release/$kv/bin/linux/amd64/kubectl \
   && install kubectl /tmp/
 
-minikube config set WantUpdateNotification false
+/tmp/minikube-linux-amd64 config set WantUpdateNotification false
 /tmp/minikube-linux-amd64 start --driver=docker
 ```


### PR DESCRIPTION
We're having issues where Docker performance messages are being output to stderr and is making tests where we check to see if stederr is empty fail, for example `TestFunctional/parallel/ImageCommands/ImageLoadFromFile`.

Then passed the new env to tests so they messages will stop being displayed.