### PR TITLE
fix ingress for k8s v1.19

### DIFF
--- a/deploy/addons/ingress/ingress-deploy.yaml.tmpl
+++ b/deploy/addons/ingress/ingress-deploy.yaml.tmpl
@@ -299,7 +299,7 @@ metadata:
   namespace: ingress-nginx
 spec:
   type: NodePort
-  {{- if eq .IngressAPIVersion "v1"}}
+  {{- if and (eq .IngressAPIVersion "v1") (not .LegacyKubernetesVersion)}}
   ipFamilyPolicy: SingleStack
   ipFamilies:
     - IPv4

--- a/deploy/addons/ingress/ingress-deploy.yaml.tmpl
+++ b/deploy/addons/ingress/ingress-deploy.yaml.tmpl
@@ -299,7 +299,7 @@ metadata:
   namespace: ingress-nginx
 spec:
   type: NodePort
-  {{- if and (eq .IngressAPIVersion "v1") (not .LegacyKubernetesVersion)}}
+  {{- if and (eq .IngressAPIVersion "v1") (not .PreOneTwentyKubernetes)}}
   ipFamilyPolicy: SingleStack
   ipFamilies:
     - IPv4

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -790,33 +790,33 @@ func GenerateTemplateData(addon *Addon, cfg config.KubernetesConfig, netInfo Net
 	}
 
 	opts := struct {
-		LegacyKubernetesVersion bool
-		Arch                    string
-		ExoticArch              string
-		ImageRepository         string
-		LoadBalancerStartIP     string
-		LoadBalancerEndIP       string
-		CustomIngressCert       string
-		IngressAPIVersion       string
-		ContainerRuntime        string
-		Images                  map[string]string
-		Registries              map[string]string
-		CustomRegistries        map[string]string
-		NetworkInfo             map[string]string
+		PreOneTwentyKubernetes bool
+		Arch                   string
+		ExoticArch             string
+		ImageRepository        string
+		LoadBalancerStartIP    string
+		LoadBalancerEndIP      string
+		CustomIngressCert      string
+		IngressAPIVersion      string
+		ContainerRuntime       string
+		Images                 map[string]string
+		Registries             map[string]string
+		CustomRegistries       map[string]string
+		NetworkInfo            map[string]string
 	}{
-		LegacyKubernetesVersion: false,
-		Arch:                    a,
-		ExoticArch:              ea,
-		ImageRepository:         cfg.ImageRepository,
-		LoadBalancerStartIP:     cfg.LoadBalancerStartIP,
-		LoadBalancerEndIP:       cfg.LoadBalancerEndIP,
-		CustomIngressCert:       cfg.CustomIngressCert,
-		IngressAPIVersion:       "v1", // api version for ingress (eg, "v1beta1"; defaults to "v1" for k8s 1.19+)
-		ContainerRuntime:        cfg.ContainerRuntime,
-		Images:                  images,
-		Registries:              addon.Registries,
-		CustomRegistries:        customRegistries,
-		NetworkInfo:             make(map[string]string),
+		PreOneTwentyKubernetes: false,
+		Arch:                   a,
+		ExoticArch:             ea,
+		ImageRepository:        cfg.ImageRepository,
+		LoadBalancerStartIP:    cfg.LoadBalancerStartIP,
+		LoadBalancerEndIP:      cfg.LoadBalancerEndIP,
+		CustomIngressCert:      cfg.CustomIngressCert,
+		IngressAPIVersion:      "v1", // api version for ingress (eg, "v1beta1"; defaults to "v1" for k8s 1.19+)
+		ContainerRuntime:       cfg.ContainerRuntime,
+		Images:                 images,
+		Registries:             addon.Registries,
+		CustomRegistries:       customRegistries,
+		NetworkInfo:            make(map[string]string),
 	}
 	if opts.ImageRepository != "" && !strings.HasSuffix(opts.ImageRepository, "/") {
 		opts.ImageRepository += "/"
@@ -835,7 +835,7 @@ func GenerateTemplateData(addon *Addon, cfg config.KubernetesConfig, netInfo Net
 		opts.IngressAPIVersion = "v1beta1"
 	}
 	if semver.MustParseRange("<1.20.0")(v) {
-		opts.LegacyKubernetesVersion = true
+		opts.PreOneTwentyKubernetes = true
 	}
 
 	// Network info for generating template

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -239,7 +239,7 @@ var Addons = map[string]*Addon{
 			"0640"),
 	}, false, "ingress", "", map[string]string{
 		// https://github.com/kubernetes/ingress-nginx/blob/14f6b32032b709d3e0f614ca85954c3583c5fe3d/deploy/static/provider/kind/deploy.yaml#L330
-		"IngressController": "ingress-nginx/controller:v1.0.4@sha256:545cff00370f28363dad31e3b59a94ba377854d3a11f18988f5f9e56841ef9ef",
+		"IngressController": "ingress-nginx/controller:v1.1.0@sha256:f766669fdcf3dc26347ed273a55e754b427eb4411ee075a53f30718b4499076a",
 		// https://github.com/kubernetes/ingress-nginx/blob/14f6b32032b709d3e0f614ca85954c3583c5fe3d/deploy/static/provider/kind/deploy.yaml#L620
 		"KubeWebhookCertgenCreate": "k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660",
 		// https://github.com/kubernetes/ingress-nginx/blob/14f6b32032b709d3e0f614ca85954c3583c5fe3d/deploy/static/provider/kind/deploy.yaml#L670
@@ -790,31 +790,33 @@ func GenerateTemplateData(addon *Addon, cfg config.KubernetesConfig, netInfo Net
 	}
 
 	opts := struct {
-		Arch                string
-		ExoticArch          string
-		ImageRepository     string
-		LoadBalancerStartIP string
-		LoadBalancerEndIP   string
-		CustomIngressCert   string
-		IngressAPIVersion   string
-		ContainerRuntime    string
-		Images              map[string]string
-		Registries          map[string]string
-		CustomRegistries    map[string]string
-		NetworkInfo         map[string]string
+		LegacyKubernetesVersion bool
+		Arch                    string
+		ExoticArch              string
+		ImageRepository         string
+		LoadBalancerStartIP     string
+		LoadBalancerEndIP       string
+		CustomIngressCert       string
+		IngressAPIVersion       string
+		ContainerRuntime        string
+		Images                  map[string]string
+		Registries              map[string]string
+		CustomRegistries        map[string]string
+		NetworkInfo             map[string]string
 	}{
-		Arch:                a,
-		ExoticArch:          ea,
-		ImageRepository:     cfg.ImageRepository,
-		LoadBalancerStartIP: cfg.LoadBalancerStartIP,
-		LoadBalancerEndIP:   cfg.LoadBalancerEndIP,
-		CustomIngressCert:   cfg.CustomIngressCert,
-		IngressAPIVersion:   "v1", // api version for ingress (eg, "v1beta1"; defaults to "v1" for k8s 1.19+)
-		ContainerRuntime:    cfg.ContainerRuntime,
-		Images:              images,
-		Registries:          addon.Registries,
-		CustomRegistries:    customRegistries,
-		NetworkInfo:         make(map[string]string),
+		LegacyKubernetesVersion: false,
+		Arch:                    a,
+		ExoticArch:              ea,
+		ImageRepository:         cfg.ImageRepository,
+		LoadBalancerStartIP:     cfg.LoadBalancerStartIP,
+		LoadBalancerEndIP:       cfg.LoadBalancerEndIP,
+		CustomIngressCert:       cfg.CustomIngressCert,
+		IngressAPIVersion:       "v1", // api version for ingress (eg, "v1beta1"; defaults to "v1" for k8s 1.19+)
+		ContainerRuntime:        cfg.ContainerRuntime,
+		Images:                  images,
+		Registries:              addon.Registries,
+		CustomRegistries:        customRegistries,
+		NetworkInfo:             make(map[string]string),
 	}
 	if opts.ImageRepository != "" && !strings.HasSuffix(opts.ImageRepository, "/") {
 		opts.ImageRepository += "/"
@@ -831,6 +833,9 @@ func GenerateTemplateData(addon *Addon, cfg config.KubernetesConfig, netInfo Net
 	}
 	if semver.MustParseRange("<1.19.0")(v) {
 		opts.IngressAPIVersion = "v1beta1"
+	}
+	if semver.MustParseRange("<1.20.0")(v) {
+		opts.LegacyKubernetesVersion = true
 	}
 
 	// Network info for generating template


### PR DESCRIPTION
fixes #13172

bonus: upgrades ingress-nginx/controller to the latest v1.1.0

example output:

```
❯ minikube start --kubernetes-version=v1.19.6
😄  minikube v1.24.0 on Opensuse-Tumbleweed
✨  Automatically selected the docker driver. Other choices: kvm2, ssh
💨  For improved Docker performance, enable the overlay Linux kernel module using 'modprobe overlay'
❗  docker is currently using the btrfs storage driver, consider switching to overlay2 for better performance
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=16000MB) ...
🐳  Preparing Kubernetes v1.19.6 on Docker 20.10.11 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass

❗  /home/prezha/bin/k8s/kubectl is version 1.23.0, which may have incompatibilites with Kubernetes 1.19.6.
    ▪ Want kubectl v1.19.6? Try 'minikube kubectl -- get pods -A'
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```
```
❯ minikube addons enable ingress
    ▪ Using image k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1
    ▪ Using image k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1
    ▪ Using image k8s.gcr.io/ingress-nginx/controller:v1.1.0
🔎  Verifying ingress addon...
🌟  The 'ingress' addon is enabled
```
```
❯ kubectl get ns
NAME              STATUS   AGE
default           Active   39s
ingress-nginx     Active   25s
kube-node-lease   Active   41s
kube-public       Active   41s
kube-system       Active   41s
````