### PR TITLE
Add longer default kubelet housekeeping intervals

### DIFF
--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -235,7 +235,7 @@ type FlagHints struct {
 
 // FlagDefaults returns suggested defaults based on a driver
 func FlagDefaults(name string) FlagHints {
-	fh := FlagHints{}
+	fh := FlagHints{ExtraOptions: []string{"kubelet.global-housekeeping-interval=60m", "kubelet.housekeeping-interval=5m"}}
 	if name != None {
 		fh.CacheImages = true
 		return fh

--- a/pkg/minikube/driver/driver_test.go
+++ b/pkg/minikube/driver/driver_test.go
@@ -85,7 +85,7 @@ func TestMachineType(t *testing.T) {
 }
 
 func TestFlagDefaults(t *testing.T) {
-	expected := FlagHints{CacheImages: true}
+	expected := FlagHints{CacheImages: true, ExtraOptions: []string{"kubelet.global-housekeeping-interval=60m", "kubelet.housekeeping-interval=5m"}}
 	if diff := cmp.Diff(FlagDefaults(VirtualBox), expected); diff != "" {
 		t.Errorf("defaults mismatch (-want +got):\n%s", diff)
 	}
@@ -98,7 +98,7 @@ func TestFlagDefaults(t *testing.T) {
 
 	expected = FlagHints{
 		CacheImages:  false,
-		ExtraOptions: []string{fmt.Sprintf("kubelet.resolv-conf=%s", tf.Name())},
+		ExtraOptions: []string{"kubelet.global-housekeeping-interval=60m", "kubelet.housekeeping-interval=5m", fmt.Sprintf("kubelet.resolv-conf=%s", tf.Name())},
 	}
 	systemdResolvConf = tf.Name()
 	if diff := cmp.Diff(FlagDefaults(None), expected); diff != "" {


### PR DESCRIPTION
Related https://github.com/kubernetes/minikube/issues/13166

We're going to do a little trial run before release to see if increasing kubelet's housekeeping intervals improves CPU usage.

Changed `global-housekeeping-interval` from 1 minute to 1 hour and `housekeeping-interval` from 10 seconds to 5 minutes.