### PR TITLE
Fix OLM addon by pinning to correct versions of images

### DIFF
--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -224,7 +224,7 @@ func EnableOrDisableAddon(cc *config.ClusterConfig, name string, val string) err
 		out.WarningT("At least needs control plane nodes to enable addon")
 	}
 
-	data := assets.GenerateTemplateData(addon, cc.KubernetesConfig, networkInfo, images, customRegistries)
+	data := assets.GenerateTemplateData(addon, cc.KubernetesConfig, networkInfo, images, customRegistries, enable)
 	return enableOrDisableAddonInternal(cc, addon, runner, data, enable)
 }
 

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -310,9 +310,9 @@ var Addons = map[string]*Addon{
 			"olm.yaml",
 			"0640"),
 	}, false, "olm", "third-party (operator framework)", map[string]string{
-		"OLM": "operator-framework/olm@sha256:c49039da04a4a3c39dd9fd0cefd9f8edb7e9921b629d5ecb6ef5a6f4e1917504",
+		"OLM": "operator-framework/olm@sha256:e74b2ac57963c7f3ba19122a8c31c9f2a0deb3c0c5cac9e5323ccffd0ca198ed",
 		// operator-framework/community-operators was deprecated: https://github.com/operator-framework/community-operators#repository-is-obsolete; switching to OperatorHub.io instead
-		"UpstreamCommunityOperators": "operatorhubio/catalog@sha256:83542ccd73403a84817cb06a408cf39b51c8e22990936072ff4b51d57ca20d0a",
+		"UpstreamCommunityOperators": "operatorhubio/catalog@sha256:35f25af956dcc171577ab3b5f7f7e8f78ebb77d9e773a888d4561a3aab94824c",
 	}, map[string]string{
 		"OLM":                        "quay.io",
 		"UpstreamCommunityOperators": "quay.io",

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -310,9 +310,9 @@ var Addons = map[string]*Addon{
 			"olm.yaml",
 			"0640"),
 	}, false, "olm", "third-party (operator framework)", map[string]string{
-		"OLM": "operator-framework/olm@sha256:e74b2ac57963c7f3ba19122a8c31c9f2a0deb3c0c5cac9e5323ccffd0ca198ed",
+		"OLM": "operator-framework/olm@sha256:c49039da04a4a3c39dd9fd0cefd9f8edb7e9921b629d5ecb6ef5a6f4e1917504",
 		// operator-framework/community-operators was deprecated: https://github.com/operator-framework/community-operators#repository-is-obsolete; switching to OperatorHub.io instead
-		"UpstreamCommunityOperators": "operatorhubio/catalog:latest@sha256:53fad78977d83dde0c27b3183c2acc25ec153ae466e1b3c9a7efb517691b77b7",
+		"UpstreamCommunityOperators": "operatorhubio/catalog@sha256:83542ccd73403a84817cb06a408cf39b51c8e22990936072ff4b51d57ca20d0a",
 	}, map[string]string{
 		"OLM":                        "quay.io",
 		"UpstreamCommunityOperators": "quay.io",
@@ -781,7 +781,7 @@ func SelectAndPersistImages(addon *Addon, cc *config.ClusterConfig) (images, cus
 }
 
 // GenerateTemplateData generates template data for template assets
-func GenerateTemplateData(addon *Addon, cfg config.KubernetesConfig, netInfo NetworkInfo, images, customRegistries map[string]string) interface{} {
+func GenerateTemplateData(addon *Addon, cfg config.KubernetesConfig, netInfo NetworkInfo, images, customRegistries map[string]string, enable bool) interface{} {
 
 	a := runtime.GOARCH
 	// Some legacy docker images still need the -arch suffix
@@ -857,23 +857,25 @@ func GenerateTemplateData(addon *Addon, cfg config.KubernetesConfig, netInfo Net
 			opts.Registries[name] = "" // Avoid nil access when rendering
 		}
 
-		if override, ok := opts.CustomRegistries[name]; ok {
-			out.Infof("Using image {{.registry}}{{.image}}", out.V{
-				"registry": override,
-				// removing the SHA from UI
-				// SHA example gcr.io/k8s-minikube/gcp-auth-webhook:v0.0.4@sha256:65e9e69022aa7b0eb1e390e1916e3bf67f75ae5c25987f9154ef3b0e8ab8528b
-				"image": strings.Split(image, "@")[0],
-			})
-		} else if opts.ImageRepository != "" {
-			out.Infof("Using image {{.registry}}{{.image}} (global image repository)", out.V{
-				"registry": opts.ImageRepository,
-				"image":    image,
-			})
-		} else {
-			out.Infof("Using image {{.registry}}{{.image}}", out.V{
-				"registry": opts.Registries[name],
-				"image":    strings.Split(image, "@")[0],
-			})
+		if enable {
+			if override, ok := opts.CustomRegistries[name]; ok {
+				out.Infof("Using image {{.registry}}{{.image}}", out.V{
+					"registry": override,
+					// removing the SHA from UI
+					// SHA example gcr.io/k8s-minikube/gcp-auth-webhook:v0.0.4@sha256:65e9e69022aa7b0eb1e390e1916e3bf67f75ae5c25987f9154ef3b0e8ab8528b
+					"image": strings.Split(image, "@")[0],
+				})
+			} else if opts.ImageRepository != "" {
+				out.Infof("Using image {{.registry}}{{.image}} (global image repository)", out.V{
+					"registry": opts.ImageRepository,
+					"image":    image,
+				})
+			} else {
+				out.Infof("Using image {{.registry}}{{.image}}", out.V{
+					"registry": opts.Registries[name],
+					"image":    strings.Split(image, "@")[0],
+				})
+			}
 		}
 	}
 	return opts

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -312,7 +312,7 @@ var Addons = map[string]*Addon{
 	}, false, "olm", "third-party (operator framework)", map[string]string{
 		"OLM": "operator-framework/olm@sha256:e74b2ac57963c7f3ba19122a8c31c9f2a0deb3c0c5cac9e5323ccffd0ca198ed",
 		// operator-framework/community-operators was deprecated: https://github.com/operator-framework/community-operators#repository-is-obsolete; switching to OperatorHub.io instead
-		"UpstreamCommunityOperators": "operatorhubio/catalog@sha256:35f25af956dcc171577ab3b5f7f7e8f78ebb77d9e773a888d4561a3aab94824c",
+		"UpstreamCommunityOperators": "operatorhubio/catalog@sha256:e08a1cd21fe72dd1be92be738b4bf1515298206dac5479c17a4b3ed119e30bd4",
 	}, map[string]string{
 		"OLM":                        "quay.io",
 		"UpstreamCommunityOperators": "quay.io",

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -451,22 +451,22 @@ func validateOlmAddon(ctx context.Context, t *testing.T, profile string) {
 	start := time.Now()
 
 	if _, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "wait", "--for=condition=ready", "--namespace=olm", "pod", "--selector=app=catalog-operator", "--timeout=90s")); err != nil {
-		t.Fatalf("failed waititing for pod catalog-operator: %v", err)
+		t.Fatalf("failed waiting for pod catalog-operator: %v", err)
 	}
 	t.Logf("catalog-operator stabilized in %s", time.Since(start))
 
 	if _, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "wait", "--for=condition=ready", "--namespace=olm", "pod", "--selector=app=olm-operator", "--timeout=90s")); err != nil {
-		t.Fatalf("failed waititing for pod olm-operator: %v", err)
+		t.Fatalf("failed waiting for pod olm-operator: %v", err)
 	}
 	t.Logf("olm-operator stabilized in %s", time.Since(start))
 
 	if _, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "wait", "--for=condition=ready", "--namespace=olm", "pod", "--selector=app=packageserver", "--timeout=90s")); err != nil {
-		t.Fatalf("failed waititing for pod olm-operator: %v", err)
+		t.Fatalf("failed waiting for pod olm-operator: %v", err)
 	}
 	t.Logf("packageserver stabilized in %s", time.Since(start))
 
 	if _, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "wait", "--for=condition=ready", "--namespace=olm", "pod", "--selector=olm.catalogSource=operatorhubio-catalog", "--timeout=90s")); err != nil {
-		t.Fatalf("failed waititing for pod operatorhubio-catalog: %v", err)
+		t.Fatalf("failed waiting for pod operatorhubio-catalog: %v", err)
 	}
 	t.Logf("operatorhubio-catalog stabilized in %s", time.Since(start))
 


### PR DESCRIPTION
This also prevents confusing output when disabling an addon:

Before:
```
$ mk addons disable olm
    ▪ Using image quay.io/operator-framework/olm
    ▪ Using image quay.io/operatorhubio/catalog
🌑  "The 'olm' addon is disabled
```

After:
```
$ mk addons disable olm
🌑  "The 'olm' addon is disabled
```
