### PR TITLE
Use minikube's own busybox images

### DIFF
--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -293,7 +293,7 @@ func validateRegistryAddon(ctx context.Context, t *testing.T, profile string) {
 		t.Logf("pre-cleanup %s failed: %v (not a problem)", rr.Command(), err)
 	}
 
-	rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "run", "--rm", "registry-test", "--restart=Never", "--image=busybox", "-it", "--", "sh", "-c", "wget --spider -S http://registry.kube-system.svc.cluster.local"))
+	rr, err = Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "run", "--rm", "registry-test", "--restart=Never", "--image=gcr.io/k8s-minikube/busybox", "-it", "--", "sh", "-c", "wget --spider -S http://registry.kube-system.svc.cluster.local"))
 	if err != nil {
 		t.Errorf("failed to hit registry.kube-system.svc.cluster.local. args %q failed: %v", rr.Command(), err)
 	}

--- a/test/integration/preload_test.go
+++ b/test/integration/preload_test.go
@@ -52,7 +52,7 @@ func TestPreload(t *testing.T) {
 	}
 
 	// Now, pull the busybox image into minikube
-	image := "busybox"
+	image := "gcr.io/k8s-minikube/busybox"
 	var cmd *exec.Cmd
 	if ContainerRuntime() == "docker" {
 		cmd = exec.CommandContext(ctx, Target(), "ssh", "-p", profile, "--", "docker", "pull", image)

--- a/test/integration/testdata/build/Dockerfile
+++ b/test/integration/testdata/build/Dockerfile
@@ -1,3 +1,3 @@
-FROM busybox
+FROM gcr.io/k8s-minikube/busybox
 RUN true
 ADD content.txt /

--- a/test/integration/testdata/busybox-mount-test.yaml
+++ b/test/integration/testdata/busybox-mount-test.yaml
@@ -9,7 +9,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: mount-munger
-      image: busybox:1.28.4-glibc
+      image: gcr.io/k8s-minikube/busybox:1.28.4-glibc
       command: ["/bin/sh", "-c", "--"]
       args:
         - cat /mount-9p/created-by-test;

--- a/test/integration/testdata/busybox.yaml
+++ b/test/integration/testdata/busybox.yaml
@@ -6,7 +6,7 @@ metadata:
     integration-test: busybox
 spec:
   containers:
-    - image: busybox:1.28.4-glibc
+    - image: gcr.io/k8s-minikube/busybox:1.28.4-glibc
       command:
         - sleep
         - "3600"

--- a/test/integration/testdata/multinodes/multinode-pod-dns-test.yaml
+++ b/test/integration/testdata/multinodes/multinode-pod-dns-test.yaml
@@ -20,7 +20,7 @@ spec:
         # https://github.com/docker-library/busybox/issues/48
         # note: k8s.gcr.io/e2e-test-images/agnhost:2.32
         # has similar issues (ie, resolves but returns exit code 1)
-        image: busybox:1.28
+        image: gcr.io/k8s-minikube/busybox:1.28
         command:
           - sleep
           - "3600"


### PR DESCRIPTION
**Problem:**
We're using busybox images from Docker Hub, which get rate limited and cause our tests to fail.

**Solution:**
Push busybox images to minikube's own image repository and use that image to prevent the rate limiting.