### PR TITLE
Add small timeout to give time for mount to come up

### DIFF
--- a/test/integration/mount_start_test.go
+++ b/test/integration/mount_start_test.go
@@ -168,4 +168,6 @@ func validateRestart(ctx context.Context, t *testing.T, profile string) {
 	if err != nil {
 		t.Fatalf("restart failed: %q : %v", rr.Command(), err)
 	}
+	// The mount takes a split second to come up, without this the validateMount test will fail
+	time.Sleep(1 * time.Second)
 }


### PR DESCRIPTION
**Problem:**
The mount takes a split second after finishing the cluster start to be up, but we run the commands to fast that the mount isn't up yet.

**Solution:**
Add a small timeout to the end of the start command to ensure the mount is up.