### PR TITLE
Show the version of the cri-dockerd component

### DIFF
--- a/cmd/minikube/cmd/version.go
+++ b/cmd/minikube/cmd/version.go
@@ -54,16 +54,17 @@ var versionCmd = &cobra.Command{
 			co := mustload.Running(ClusterFlagValue())
 			runner := co.CP.Runner
 			versionCMDS := map[string]*exec.Cmd{
-				"docker":     exec.Command("docker", "--version"),
-				"dockerd":    exec.Command("dockerd", "--version"),
-				"containerd": exec.Command("containerd", "--version"),
-				"crio":       exec.Command("crio", "--version"),
-				"podman":     exec.Command("sudo", "podman", "--version"),
-				"crictl":     exec.Command("sudo", "crictl", "--version"),
-				"buildctl":   exec.Command("buildctl", "--version"),
-				"ctr":        exec.Command("ctr", "--version"),
-				"runc":       exec.Command("runc", "--version"),
-				"crun":       exec.Command("crun", "--version"),
+				"docker":      exec.Command("docker", "--version"),
+				"dockerd":     exec.Command("dockerd", "--version"),
+				"cri-dockerd": exec.Command("cri-dockerd", "--version"),
+				"containerd":  exec.Command("containerd", "--version"),
+				"crio":        exec.Command("crio", "--version"),
+				"podman":      exec.Command("sudo", "podman", "--version"),
+				"crictl":      exec.Command("sudo", "crictl", "--version"),
+				"buildctl":    exec.Command("buildctl", "--version"),
+				"ctr":         exec.Command("ctr", "--version"),
+				"runc":        exec.Command("runc", "--version"),
+				"crun":        exec.Command("crun", "--version"),
 			}
 			for k, v := range versionCMDS {
 				rr, err := runner.RunCmd(v)


### PR DESCRIPTION
Currently shows:

```console
$ cri-dockerd --version
cri-dockerd 0.2.0 (HEAD)
```

```go
var (
	// Version of the product
	Version = "0.2.0"
	// PreRelease is set during the build
	PreRelease = ""
	// GitCommit is set during the build
	GitCommit = "HEAD"
	// BuildTime is set during the build
	BuildTime = "<unknown>"
)
```

See #12103

----

Possibly could set the version and commit at link-time, similar to the other programs ?

```
CONTAINERD_BIN_VERSION = v1.5.8
CONTAINERD_BIN_COMMIT = 1e5ef943eb76627a6d3b6de8cd1ef6537f393a71
```

But support for doing it is currently missing from the upstream Makefile, so who cares...