### PR TITLE
time-to-k8s: Put weekly benchmarks first

### DIFF
--- a/site/content/en/docs/benchmarks/timeToK8s/daily_benchmark.md
+++ b/site/content/en/docs/benchmarks/timeToK8s/daily_benchmark.md
@@ -2,7 +2,7 @@
 title: "Daily Benchmark"
 description: >
   Chart to visualize the time-to-k8s benchmark daily against HEAD
-weight: -99999999
+weight: -99999998
 ---
 
 [Benchmarking Machine Specs](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)

--- a/site/content/en/docs/benchmarks/timeToK8s/weekly_benchmark.md
+++ b/site/content/en/docs/benchmarks/timeToK8s/weekly_benchmark.md
@@ -2,7 +2,7 @@
 title: "Weekly Average Benchmark"
 description: >
   Chart to visualize the time-to-k8s benchmark weekly average against HEAD
-weight: -99999998
+weight: -99999999
 ---
 
 [Benchmarking Machine Specs](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)


### PR DESCRIPTION
Put weekly benchmarks before daily benchmarks.