### PR TITLE
Add hint to translation check to documentation

### DIFF
--- a/site/content/en/docs/contrib/translations.md
+++ b/site/content/en/docs/contrib/translations.md
@@ -76,6 +76,8 @@ All translations are stored in the top-level `translations` directory.
 
 ### Testing translations
 
+* You can verify that the translations are syntactically valid by running: `go test k8s.io/minikube/pkg/minikube/translate`
+
 * Once you have all the translations you want, save the file and rebuild the minikube from scratch to pick up your new translations:
 
  ```


### PR DESCRIPTION
Added hint that one can run the translate check. This checks  whether the translations are at least syntactically correct.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
