### PR TITLE
Increase test timeout for Docker Windows

### DIFF
--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -949,7 +949,7 @@ func validateDryRun(ctx context.Context, t *testing.T, profile string) {
 	// dry-run mode should always be able to finish quickly (<5s) expect Docker Windows
 	timeout := Seconds(5)
 	if runtime.GOOS == "windows" && DockerDriver() {
-		timeout = Seconds(10)
+		timeout = Seconds(20)
 	}
 	mctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -946,8 +946,12 @@ func dashboardURL(b *bufio.Reader) (string, error) {
 
 // validateDryRun asserts that the dry-run mode quickly exits with the right code
 func validateDryRun(ctx context.Context, t *testing.T, profile string) {
-	// dry-run mode should always be able to finish quickly (<5s)
-	mctx, cancel := context.WithTimeout(ctx, Seconds(5))
+	// dry-run mode should always be able to finish quickly (<5s) expect Docker Windows
+	timeout := Seconds(5)
+	if runtime.GOOS == "windows" && DockerDriver() {
+		timeout = Seconds(10)
+	}
+	mctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	// docs: Run `minikube start --dry-run --memory 250MB`
@@ -985,8 +989,12 @@ func validateDryRun(ctx context.Context, t *testing.T, profile string) {
 
 // validateInternationalLanguage asserts that the language used can be changed with environment variables
 func validateInternationalLanguage(ctx context.Context, t *testing.T, profile string) {
-	// dry-run mode should always be able to finish quickly (<5s)
-	mctx, cancel := context.WithTimeout(ctx, Seconds(5))
+	// dry-run mode should always be able to finish quickly (<5s) except Docker Windows
+	timeout := Seconds(5)
+	if runtime.GOOS == "windows" && DockerDriver() {
+		timeout = Seconds(10)
+	}
+	mctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	// Too little memory!

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -949,7 +949,7 @@ func validateDryRun(ctx context.Context, t *testing.T, profile string) {
 	// dry-run mode should always be able to finish quickly (<5s) expect Docker Windows
 	timeout := Seconds(5)
 	if runtime.GOOS == "windows" && DockerDriver() {
-		timeout = Seconds(20)
+		timeout = Seconds(10)
 	}
 	mctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -970,7 +970,7 @@ func validateDryRun(ctx context.Context, t *testing.T, profile string) {
 		}
 	}
 
-	dctx, cancel := context.WithTimeout(ctx, Seconds(5))
+	dctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	// docs: Run `minikube start --dry-run`
 	startArgs = append([]string{"start", "-p", profile, "--dry-run", "--alsologtostderr", "-v=1"}, StartArgs()...)


### PR DESCRIPTION
`TestFunctional/parallel/InternationalLanguage` & `TestFunctional/parallel/DryRun` are failing on Docker Windows at 100% because the test timeout is too short.