### PR TITLE
Support DOCKER_HOST not being numeric IP

### DIFF
--- a/pkg/minikube/driver/endpoint.go
+++ b/pkg/minikube/driver/endpoint.go
@@ -35,16 +35,16 @@ func ControlPlaneEndpoint(cc *config.ClusterConfig, cp *config.Node, driverName 
 		}
 		hostname := oci.DaemonHost(driverName)
 
-		ip := net.ParseIP(hostname)
-		if ip == nil {
-			return hostname, ip, port, fmt.Errorf("failed to parse ip for %q", hostname)
+		ips, err := net.LookupIP(hostname)
+		if err != nil || len(ips) == 0 {
+			return hostname, nil, port, fmt.Errorf("failed to lookup ip for %q", hostname)
 		}
 
 		// https://github.com/kubernetes/minikube/issues/3878
 		if cc.KubernetesConfig.APIServerName != constants.APIServerName {
 			hostname = cc.KubernetesConfig.APIServerName
 		}
-		return hostname, ip, port, err
+		return hostname, ips[0], port, err
 	}
 
 	// https://github.com/kubernetes/minikube/issues/3878
@@ -56,9 +56,7 @@ func ControlPlaneEndpoint(cc *config.ClusterConfig, cp *config.Node, driverName 
 	if err != nil || len(ips) == 0 {
 		return hostname, nil, cp.Port, fmt.Errorf("failed to lookup ip for %q", cp.IP)
 	}
-	// get last IP as it's IPv4
-	ip := ips[len(ips)-1]
-	return hostname, ip, cp.Port, nil
+	return hostname, ips[0], cp.Port, nil
 }
 
 // AutoPauseProxyEndpoint returns the endpoint for the auto-pause (reverse proxy to api-sever)

--- a/pkg/minikube/driver/endpoint.go
+++ b/pkg/minikube/driver/endpoint.go
@@ -54,7 +54,7 @@ func ControlPlaneEndpoint(cc *config.ClusterConfig, cp *config.Node, driverName 
 	}
 	ips, err := net.LookupIP(cp.IP)
 	if err != nil || len(ips) == 0 {
-		return hostname, net.IP{}, cp.Port, fmt.Errorf("failed to lookup ip for %q", cp.IP)
+		return hostname, nil, cp.Port, fmt.Errorf("failed to lookup ip for %q", cp.IP)
 	}
 	// get last IP as it's IPv4
 	ip := ips[len(ips)-1]

--- a/pkg/minikube/driver/endpoint.go
+++ b/pkg/minikube/driver/endpoint.go
@@ -52,10 +52,12 @@ func ControlPlaneEndpoint(cc *config.ClusterConfig, cp *config.Node, driverName 
 	if cc.KubernetesConfig.APIServerName != constants.APIServerName {
 		hostname = cc.KubernetesConfig.APIServerName
 	}
-	ip := net.ParseIP(cp.IP)
-	if ip == nil {
-		return hostname, ip, cp.Port, fmt.Errorf("failed to parse ip for %q", cp.IP)
+	ips, err := net.LookupIP(cp.IP)
+	if err != nil || len(ips) == 0 {
+		return hostname, net.IP{}, cp.Port, fmt.Errorf("failed to lookup ip for %q", cp.IP)
 	}
+	// get last IP as it's IPv4
+	ip := ips[len(ips)-1]
 	return hostname, ip, cp.Port, nil
 }
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/10158

We always assumed that the IP was going to be numeric, but people are using hostnames and `localhost`, so adding an IP lookup to get the true IP.