### PR TITLE
Make warning for running amd64 binary on M1 more visible

### DIFF
--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -95,7 +95,7 @@ func Execute() {
 	}
 
 	if runtime.GOOS == "darwin" && detect.IsAmd64M1Emulation() {
-		out.Boxed("You are trying to run amd64 binary on M1 system.\nPlease consider running the darwin/arm64 binary instead.\nDownload at {{.url}}",
+		out.Boxed("You are trying to run the amd64 binary on an M1 system.\nPlease consider running the darwin/arm64 binary instead.\nDownload at {{.url}}",
 			out.V{"url": notify.DownloadURL(version.GetVersion(), "darwin", "arm64")})
 	}
 

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -95,7 +95,7 @@ func Execute() {
 	}
 
 	if runtime.GOOS == "darwin" && detect.IsAmd64M1Emulation() {
-		out.Infof("You are trying to run amd64 binary on M1 system. Please consider running darwin/arm64 binary instead (Download at {{.url}}.)",
+		out.Boxed("You are trying to run amd64 binary on M1 system.\nPlease consider running the darwin/arm64 binary instead.\nDownload at {{.url}}",
 			out.V{"url": notify.DownloadURL(version.GetVersion(), "darwin", "arm64")})
 	}
 


### PR DESCRIPTION
Before:
```
$ ./minikube-darwin-amd64 start
    ▪ You are trying to run amd64 binary on M1 system. Please consider running darwin/arm64 binary instead (Download at https://github.com/kubernetes/minikube/releases/download/v1.24.0/minikube-darwin-arm64.)
😄  minikube v1.24.0 on Darwin 12.0.1
✨  Automatically selected the docker driver
👍  Starting control plane node minikube in cluster minikube
...
```

After:
```
$ ./minikube-darwin-amd64 start 
╭────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                            │
│    You are trying to run the amd64 binary on an M1 system.                                                 │
│    Please consider running the darwin/arm64 binary instead.                                                │
│    Download at https://github.com/kubernetes/minikube/releases/download/v1.24.0/minikube-darwin-arm64      │
│                                                                                                            │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
😄  minikube v1.24.0 on Darwin 12.0.1
✨  Automatically selected the docker driver
👍  Starting control plane node minikube in cluster minikube
...
```