### PR TITLE
Remove deprecated global-housekeeping-interval flag

### DIFF
--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -235,7 +235,7 @@ type FlagHints struct {
 
 // FlagDefaults returns suggested defaults based on a driver
 func FlagDefaults(name string) FlagHints {
-	fh := FlagHints{ExtraOptions: []string{"kubelet.global-housekeeping-interval=60m", "kubelet.housekeeping-interval=5m"}}
+	fh := FlagHints{ExtraOptions: []string{"kubelet.housekeeping-interval=5m"}}
 	if name != None {
 		fh.CacheImages = true
 		return fh

--- a/pkg/minikube/driver/driver_test.go
+++ b/pkg/minikube/driver/driver_test.go
@@ -85,7 +85,7 @@ func TestMachineType(t *testing.T) {
 }
 
 func TestFlagDefaults(t *testing.T) {
-	expected := FlagHints{CacheImages: true, ExtraOptions: []string{"kubelet.global-housekeeping-interval=60m", "kubelet.housekeeping-interval=5m"}}
+	expected := FlagHints{CacheImages: true, ExtraOptions: []string{"kubelet.housekeeping-interval=5m"}}
 	if diff := cmp.Diff(FlagDefaults(VirtualBox), expected); diff != "" {
 		t.Errorf("defaults mismatch (-want +got):\n%s", diff)
 	}
@@ -98,7 +98,7 @@ func TestFlagDefaults(t *testing.T) {
 
 	expected = FlagHints{
 		CacheImages:  false,
-		ExtraOptions: []string{"kubelet.global-housekeeping-interval=60m", "kubelet.housekeeping-interval=5m", fmt.Sprintf("kubelet.resolv-conf=%s", tf.Name())},
+		ExtraOptions: []string{"kubelet.housekeeping-interval=5m", fmt.Sprintf("kubelet.resolv-conf=%s", tf.Name())},
 	}
 	systemdResolvConf = tf.Name()
 	if diff := cmp.Diff(FlagDefaults(None), expected); diff != "" {


### PR DESCRIPTION
kubelet v1.23: `--global-housekeeping-interval`: `Interval between global housekeepings (default 1m0s) (DEPRECATED: This is a cadvisor flag that was mistakenly registered with the Kubelet. Due to legacy concerns, it will follow the standard CLI deprecation timeline before being removed.)`