### PR TITLE
Change file path for preload tar files to be organized by version

### DIFF
--- a/hack/preload-images/preload_images.go
+++ b/hack/preload-images/preload_images.go
@@ -146,7 +146,7 @@ func makePreload(cfg preloadCfg) error {
 		fmt.Printf("skip upload of %q\n", tf)
 		return nil
 	}
-	if err := uploadTarball(tf); err != nil {
+	if err := uploadTarball(tf, kv); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("uploading tarball for k8s version %s with %s", kv, cr))
 	}
 	return nil

--- a/hack/preload-images/upload.go
+++ b/hack/preload-images/upload.go
@@ -25,10 +25,10 @@ import (
 	"k8s.io/minikube/pkg/minikube/download"
 )
 
-func uploadTarball(tarballFilename string) error {
+func uploadTarball(tarballFilename, k8sVer string) error {
 	// Upload tarball to GCS
 	hostPath := path.Join("out/", tarballFilename)
-	gcsDest := fmt.Sprintf("gs://%s", download.PreloadBucket)
+	gcsDest := fmt.Sprintf("gs://%s/%s/%s", download.PreloadBucket, download.PreloadVersion, k8sVer)
 	cmd := exec.Command("gsutil", "cp", hostPath, gcsDest)
 	fmt.Printf("Running: %v\n", cmd.Args)
 	if output, err := cmd.CombinedOutput(); err != nil {

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -90,7 +90,7 @@ func TarballPath(k8sVersion, containerRuntime string) string {
 
 // remoteTarballURL returns the URL for the remote tarball in GCS
 func remoteTarballURL(k8sVersion, containerRuntime string) string {
-	return fmt.Sprintf("https://%s/%s/%s", downloadHost, PreloadBucket, TarballName(k8sVersion, containerRuntime))
+	return fmt.Sprintf("https://%s/%s/%s/%s/%s", downloadHost, PreloadBucket, PreloadVersion, k8sVersion, TarballName(k8sVersion, containerRuntime))
 }
 
 func setPreloadState(k8sVersion, containerRuntime string, value bool) {
@@ -236,7 +236,8 @@ func getStorageAttrs(name string) (*storage.ObjectAttrs, error) {
 // getChecksum returns the MD5 checksum of the preload tarball
 var getChecksum = func(k8sVersion, containerRuntime string) ([]byte, error) {
 	klog.Infof("getting checksum for %s ...", TarballName(k8sVersion, containerRuntime))
-	attrs, err := getStorageAttrs(TarballName(k8sVersion, containerRuntime))
+	filename := fmt.Sprintf("%s/%s/%s", PreloadVersion, k8sVersion, TarballName(k8sVersion, containerRuntime))
+	attrs, err := getStorageAttrs(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -44,7 +44,7 @@ const (
 	// PreloadVersion is the current version of the preloaded tarball
 	//
 	// NOTE: You may need to bump this version up when upgrading auxiliary docker images
-	PreloadVersion = "v16"
+	PreloadVersion = "v17"
 	// PreloadBucket is the name of the GCS bucket where preloaded volume tarballs exist
 	PreloadBucket = "minikube-preloaded-volume-tarballs"
 )


### PR DESCRIPTION
Currently all the preloads are stored at the root level of the bucket, it would be easier to navigate with a folder structure.

Now the structure is `<preload-version>/<kubernetes-version>/<filename>`