### PR TITLE
Document container runtimes available

### DIFF
--- a/site/content/en/docs/handbook/config.md
+++ b/site/content/en/docs/handbook/config.md
@@ -95,10 +95,11 @@ The default container runtime in minikube is Docker. You can select it explicitl
 minikube start --container-runtime=docker
 ```
 
-Other options available are:
+Options available are:
 
-* [containerd](https://github.com/containerd/containerd)
-* [cri-o](https://github.com/cri-o/cri-o)
+* [containerd]({{<ref "/docs/runtimes/containerd">}})
+* [cri-o]({{<ref "/docs/runtimes/cri-o">}})
+* [docker]({{<ref "/docs/runtimes/docker">}})
 
 ## Environment variables
 

--- a/site/content/en/docs/runtimes/_index.md
+++ b/site/content/en/docs/runtimes/_index.md
@@ -1,0 +1,26 @@
+---
+title: "Runtimes"
+linkTitle: "Runtimes"
+weight: 8
+no_list: true
+description: >
+  Configuring various container runtimes
+aliases:
+  - /docs/reference/runtimes
+---
+Kubernetes requires a container runtime to be installed.
+
+Here is what's supported:
+
+## containerd
+
+* [containerd]({{<ref "containerd.md">}})
+
+## cri-o
+
+* [cri-o]({{<ref "cri-o.md">}})
+
+## docker
+
+* [docker]({{<ref "docker.md">}})
+

--- a/site/content/en/docs/runtimes/containerd.md
+++ b/site/content/en/docs/runtimes/containerd.md
@@ -1,0 +1,10 @@
+---
+title: "containerd"
+aliases:
+    - /docs/reference/runtimes/containerd
+---
+
+Home page: <https://containerd.io>
+
+<https://github.com/containerd/containerd>
+<https://github.com/moby/buildkit>

--- a/site/content/en/docs/runtimes/cri-o.md
+++ b/site/content/en/docs/runtimes/cri-o.md
@@ -1,0 +1,11 @@
+---
+title: "cri-o"
+aliases:
+    - /docs/reference/runtimes/cri-o
+---
+
+Home page: <https://cri-o.io>
+
+See also `minikube podman-env`
+
+<https://github.com/cri-o/cri-o>

--- a/site/content/en/docs/runtimes/docker.md
+++ b/site/content/en/docs/runtimes/docker.md
@@ -1,0 +1,11 @@
+---
+title: "docker"
+aliases:
+    - /docs/reference/runtimes/docker
+---
+
+Home page: <https://docker.com>
+
+See also `minikube docker-env`
+
+<https://docs.docker.com/engine/>


### PR DESCRIPTION

Add information about the various options available for `--container-runtime`.

Also what command line clients are available, when running `--no-kubernetes`.

Closes #13358 