### PR TITLE
Site: Add macOS Hyperkit NFS Mounts Documentation

### DIFF
--- a/site/content/en/docs/handbook/mount.md
+++ b/site/content/en/docs/handbook/mount.md
@@ -74,7 +74,7 @@ Some hypervisors, have built-in host folder sharing. Driver mounts are reliable 
 | VirtualBox | Windows | C://Users | /c/Users |
 | VMware Fusion | macOS | /Users | /mnt/hgfs/Users |
 | KVM | Linux | Unsupported | |
-| HyperKit | Linux | Unsupported (see NFS mounts) | |
+| HyperKit | macOS | Unsupported | |
 
 These mounts can be disabled by passing `--disable-driver-mounts` to `minikube start`.
 

--- a/site/content/en/docs/handbook/mount.md
+++ b/site/content/en/docs/handbook/mount.md
@@ -74,9 +74,13 @@ Some hypervisors, have built-in host folder sharing. Driver mounts are reliable 
 | VirtualBox | Windows | C://Users | /c/Users |
 | VMware Fusion | macOS | /Users | /mnt/hgfs/Users |
 | KVM | Linux | Unsupported | |
-| HyperKit | macOS | Unsupported | |
+| HyperKit | macOS | Supported |  |
 
 These mounts can be disabled by passing `--disable-driver-mounts` to `minikube start`.
+
+HyperKit mounts can use the following flags:
+`--nfs-share=[]`: Local folders to share with Guest via NFS mounts
+`--nfs-shares-root='/nfsshares'`: Where to root the NFS Shares, defaults to /nfsshares
 
 ## File Sync
 


### PR DESCRIPTION
Fixes #12898

Correct documentation for macOS as Hyperkit is not supported on Linux.

Before:
`| HyperKit | Linux | Unsupported (see NFS mounts) | |`

After:
`| HyperKit | macOS | Unsupported | |`
