### PR TITLE
Fix bug in AUX Driver Download URL for ARM64

### DIFF
--- a/pkg/minikube/download/driver.go
+++ b/pkg/minikube/download/driver.go
@@ -33,7 +33,7 @@ func driverWithChecksumURL(name string, v semver.Version) string {
 	return fmt.Sprintf("%s?checksum=file:%s.sha256", base, base)
 }
 func driverWithArchAndChecksumURL(name string, v semver.Version) string {
-	base := fmt.Sprintf("https://github.com/kubernetes/minikube/releases/download/v%s-%s/%s", v, runtime.GOARCH, name)
+	base := fmt.Sprintf("https://github.com/kubernetes/minikube/releases/download/v%s/%s-%s", v, name, runtime.GOARCH)
 	return fmt.Sprintf("%s?checksum=file:%s.sha256", base, base)
 }
 


### PR DESCRIPTION
A bug exists in the way that the downloads are made for ARM64.

Without the architecture, the default works fine.

**Before:**
`https://github.com/kubernetes/minikube/releases/download/v1.24.0-arm64/docker-machine-driver-kvm2`

**After:**
`https://github.com/kubernetes/minikube/releases/download/v1.24.0/docker-machine-driver-kvm2-arm64`