### PR TITLE
configure container runtimes for clusters without Kubernetes too

### DIFF
--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -96,6 +96,8 @@ func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 		return nil, err
 	}
 	if stopk8s {
+		nv := semver.Version{Major: 0, Minor: 0, Patch: 0}
+		configureRuntimes(starter.Runner, *starter.Cfg, nv)
 		configureMounts(&wg, *starter.Cfg)
 		return nil, config.Write(viper.GetString(config.ProfileName), starter.Cfg)
 	}


### PR DESCRIPTION
Was missing to set up the container runtime (CRI) properly,
when running minikube without kubernetes (--no-kubernetes)

Closes #13433