### PR TITLE
fix external cri-docker socket name

### DIFF
--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -43,7 +43,7 @@ import (
 const KubernetesContainerPrefix = "k8s_"
 
 const InternalDockerCRISocket = "/var/run/dockershim.sock"
-const ExternalDockerCRISocket = "/var/run/cri-dockerd.sock"
+const ExternalDockerCRISocket = "/var/run/cri-docker.sock"
 
 // ErrISOFeature is the error returned when disk image is missing features
 type ErrISOFeature struct {


### PR DESCRIPTION
This fixes minikube with kubernetes v1.24.0-alpha.1 and is verified to work with current stable, v1.23.2