### PR TITLE
preloads: Add option to upload arm64 preloads

### DIFF
--- a/hack/preload-images/preload_images.go
+++ b/hack/preload-images/preload_images.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"runtime/debug"
@@ -47,6 +48,8 @@ var (
 	noUpload            = flag.Bool("no-upload", false, "Do not upload tarballs to GCS")
 	force               = flag.Bool("force", false, "Generate the preload tarball even if it's already exists")
 	limit               = flag.Int("limit", 0, "Limit the number of tarballs to generate")
+	armUpload           = flag.Bool("arm-upload", false, "Upload the arm64 preload tarballs to GCS")
+	armPreloadsDir      = flag.String("arm-preloads-dir", "artifacts", "Directory containing the arm64 preload tarballs")
 )
 
 type preloadCfg struct {
@@ -60,6 +63,13 @@ func (p preloadCfg) String() string {
 
 func main() {
 	flag.Parse()
+
+	if *armUpload {
+		if err := uploadArmTarballs(*armPreloadsDir); err != nil {
+			log.Fatal(err)
+		}
+		return
+	}
 
 	// used by pkg/minikube/download.PreloadExists()
 	viper.Set("preload", "true")

--- a/hack/preload-images/upload.go
+++ b/hack/preload-images/upload.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os/exec"
 	"path"
+	"strings"
 
 	"github.com/pkg/errors"
 	"k8s.io/minikube/pkg/minikube/download"
@@ -35,4 +36,38 @@ func uploadTarball(tarballFilename, k8sVer string) error {
 		return errors.Wrapf(err, "uploading %s to GCS bucket: %v\n%s", hostPath, err, string(output))
 	}
 	return nil
+}
+
+func uploadArmTarballs(preloadsDir string) error {
+	b, err := exec.Command("ls", preloadsDir).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to read files: %v\n%s", err, string(b))
+	}
+	files := strings.Split(string(b), "\n")
+	if len(files) == 0 {
+		return fmt.Errorf("no preload files found")
+	}
+	files = files[:len(files)-1]
+	for _, file := range files {
+		preloadVersion, k8sVersion := getVersionsFromFilename(file)
+		hostPath := path.Join(preloadsDir, file)
+		gcsDest := fmt.Sprintf("gs://%s/%s/%s/", download.PreloadBucket, preloadVersion, k8sVersion)
+		cmd := exec.Command("gsutil", "cp", hostPath, gcsDest)
+		fmt.Printf("Running: %v\n", cmd.Args)
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return errors.Wrapf(err, "uploading %s to GCS bucket: %v\n%s", hostPath, err, string(output))
+		}
+	}
+	return nil
+}
+
+func getVersionsFromFilename(filename string) (string, string) {
+	parts := strings.Split(filename, "-")
+	preloadVersion := parts[3]
+	k8sVersion := parts[4]
+	// this check is for "-rc" and "-beta" versions that would otherwise be stripped off
+	if len(parts) == 9 {
+		k8sVersion += fmt.Sprintf("-%s", parts[5])
+	}
+	return preloadVersion, k8sVersion
 }

--- a/hack/preload-images/upload.go
+++ b/hack/preload-images/upload.go
@@ -47,6 +47,7 @@ func uploadArmTarballs(preloadsDir string) error {
 	if len(files) == 0 {
 		return fmt.Errorf("no preload files found")
 	}
+	// remove trailing whitespace entry
 	files = files[:len(files)-1]
 	for _, file := range files {
 		preloadVersion, k8sVersion := getVersionsFromFilename(file)


### PR DESCRIPTION
Since the addition of structured preloads the upload process for arm64 preloads is more advanced. I wrote a simple func in the existing `preload-tools` binary that will upload the preloads to the correct folders.