### PR TITLE
added condition for the case when user try to enable addons without kubernetes

### DIFF
--- a/cmd/minikube/cmd/config/enable.go
+++ b/cmd/minikube/cmd/config/enable.go
@@ -40,6 +40,11 @@ var addonsEnableCmd = &cobra.Command{
 		if len(args) != 1 {
 			exit.Message(reason.Usage, "usage: minikube addons enable ADDON_NAME")
 		}
+		if ClusterConfig, err := config.Load(ClusterFlagValue()); err == nil {
+			if ClusterConfig.KubernetesConfig.KubernetesVersion == constants.NoKubernetesVersion {
+				exit.Message(reason.Usage, "Cannot enable addons with --no-kubernetes passed")
+			}
+		}
 		addon := args[0]
 		// replace heapster as metrics-server because heapster is deprecated
 		if addon == "heapster" {
@@ -62,7 +67,7 @@ var addonsEnableCmd = &cobra.Command{
 			}
 			out.Styled(style.Tip, `Some dashboard features require the metrics-server addon. To enable all features please run:
 
-	minikube{{.profileArg}} addons enable metrics-server	
+	minikube{{.profileArg}} addons enable metrics-server
 
 `, out.V{"profileArg": tipProfileArg})
 

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -286,6 +286,7 @@ func provisionWithDriver(cmd *cobra.Command, ds registry.DriverState, existing *
 
 	validateFlags(cmd, driverName)
 	validateUser(driverName)
+	validateNoAddonsForNoKubernetes()
 	if driverName == oci.Docker {
 		validateDockerStorageDriver(driverName)
 	}
@@ -1651,4 +1652,12 @@ func exitGuestProvision(err error) {
 		exit.Message(reason.GuestProvisionContainerExited, "Docker container exited prematurely after it was created, consider investigating Docker's performance/health.")
 	}
 	exit.Error(reason.GuestProvision, "error provisioning guest", err)
+}
+
+func validateNoAddonsForNoKubernetes() {
+	if ClusterConfig, err := config.Load(ClusterFlagValue()); err == nil {
+		if ClusterConfig.KubernetesConfig.KubernetesVersion == constants.NoKubernetesVersion {
+			exit.Message(reason.Usage, "Cannot enable addons with --no-kubernetes passed")
+		}
+	}
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

Fixes #13487

- When user try to enable addons with `--no-kubernetes=true` an output should be logged informing that it is not possible to enable addons with `--no-kubernetes` passed. This PR works on logging that output.

