### PR TITLE
crio: use drop in configuration files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ KUBERNETES_VERSION ?= $(shell egrep "DefaultKubernetesVersion =" pkg/minikube/co
 KIC_VERSION ?= $(shell egrep "Version =" pkg/drivers/kic/types.go | cut -d \" -f2)
 
 # Default to .0 for higher cache hit rates, as build increments typically don't require new ISO versions
-ISO_VERSION ?= v1.25.0-1644071583-13563
+ISO_VERSION ?= v1.25.0-1644344644-13531
 # Dashes are valid in semver, but not Linux packaging. Use ~ to delimit alpha/beta
 DEB_VERSION ?= $(subst -,~,$(RAW_VERSION))
 DEB_REVISION ?= 0

--- a/deploy/iso/minikube-iso/package/crio-bin/02-crio.conf
+++ b/deploy/iso/minikube-iso/package/crio-bin/02-crio.conf
@@ -1,0 +1,8 @@
+[crio.image]
+# pause_image = ""
+
+[crio.network]
+# cni_default_network = ""
+
+[crio.runtime]
+# cgroup_manager = ""

--- a/deploy/iso/minikube-iso/package/crio-bin/crio-bin.mk
+++ b/deploy/iso/minikube-iso/package/crio-bin/crio-bin.mk
@@ -39,6 +39,7 @@ endef
 define CRIO_BIN_INSTALL_TARGET_CMDS
 	mkdir -p $(TARGET_DIR)/usr/share/containers/oci/hooks.d
 	mkdir -p $(TARGET_DIR)/etc/containers/oci/hooks.d
+	mkdir -p $(TARGET_DIR)/etc/crio/crio.conf.d
 
 	$(INSTALL) -Dm755 \
 		$(@D)/bin/crio \
@@ -55,6 +56,9 @@ define CRIO_BIN_INSTALL_TARGET_CMDS
 	$(INSTALL) -Dm644 \
 		$(CRIO_BIN_PKGDIR)/registries.conf \
 		$(TARGET_DIR)/etc/containers/registries.conf
+	$(INSTALL) -Dm644 \
+		$(CRIO_BIN_PKGDIR)/02-crio.conf \
+		$(TARGET_DIR)/etc/crio/crio.conf.d/02-crio.conf
 
 	mkdir -p $(TARGET_DIR)/etc/sysconfig
 	echo 'CRIO_OPTIONS="--log-level=debug"' > $(TARGET_DIR)/etc/sysconfig/crio

--- a/deploy/kicbase/02-crio.conf
+++ b/deploy/kicbase/02-crio.conf
@@ -1,0 +1,8 @@
+[crio.image]
+# pause_image = ""
+
+[crio.network]
+# cni_default_network = ""
+
+[crio.runtime]
+# cgroup_manager = ""

--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -43,6 +43,7 @@ ARG CRIO_VERSION="1.22"
 # copy in static files (configs, scripts)
 COPY deploy/kicbase/10-network-security.conf /etc/sysctl.d/10-network-security.conf
 COPY deploy/kicbase/11-tcp-mtu-probing.conf /etc/sysctl.d/11-tcp-mtu-probing.conf
+COPY deploy/kicbase/02-crio.conf /etc/crio/crio.conf.d/02-crio.conf
 COPY deploy/kicbase/clean-install /usr/local/bin/clean-install
 COPY deploy/kicbase/entrypoint /usr/local/bin/entrypoint
 COPY --from=0 /src/cmd/auto-pause/auto-pause /bin/auto-pause

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -24,9 +24,9 @@ import (
 
 const (
 	// Version is the current version of kic
-	Version = "v0.0.29-1644071658-13563"
+	Version = "v0.0.29-1644344181-13531"
 	// SHA of the kic base image
-	baseImageSHA = "8ab41333bf2f1906510725cbb2cc2ee50fc11b9a8a3edda7585ae0371c3fa2f7"
+	baseImageSHA = "02c921df998f95e849058af14de7045efc3954d90320967418a0d1f182bbc0b2"
 	// The name of the GCR kicbase repository
 	gcrRepo = "gcr.io/k8s-minikube/kicbase-builds"
 	// The name of the Dockerhub kicbase repository

--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -41,7 +41,7 @@ import (
 
 const (
 	// CRIOConfFile is the path to the CRI-O configuration
-	crioConfigFile = "/etc/crio/crio.conf"
+	crioConfigFile = "/etc/crio/crio.conf.d/02-crio.conf"
 )
 
 // CRIO contains CRIO runtime state
@@ -57,7 +57,7 @@ type CRIO struct {
 func generateCRIOConfig(cr CommandRunner, imageRepository string, kv semver.Version) error {
 	pauseImage := images.Pause(kv, imageRepository)
 
-	c := exec.Command("/bin/bash", "-c", fmt.Sprintf("sudo sed -e 's|^pause_image = .*$|pause_image = \"%s\"|' -i %s", pauseImage, crioConfigFile))
+	c := exec.Command("/bin/bash", "-c", fmt.Sprintf("sudo sed -e 's|^.*pause_image = .*$|pause_image = \"%s\"|' -i %s", pauseImage, crioConfigFile))
 	if _, err := cr.RunCmd(c); err != nil {
 		return errors.Wrap(err, "generateCRIOConfig")
 	}
@@ -73,8 +73,7 @@ func generateCRIOConfig(cr CommandRunner, imageRepository string, kv semver.Vers
 }
 
 func (r *CRIO) forceSystemd() error {
-	// remove `cgroup_manager` since cri-o defaults to `systemd` if nothing set
-	c := exec.Command("/bin/bash", "-c", fmt.Sprintf("sudo sed -e 's|^cgroup_manager = .*$||' -i %s", crioConfigFile))
+	c := exec.Command("/bin/bash", "-c", fmt.Sprintf("sudo sed -e 's|^.*cgroup_manager = .*$|cgroup_manager = \"systemd\"|' -i %s", crioConfigFile))
 	if _, err := r.Runner.RunCmd(c); err != nil {
 		return errors.Wrap(err, "force systemd")
 	}

--- a/pkg/minikube/download/iso.go
+++ b/pkg/minikube/download/iso.go
@@ -40,7 +40,7 @@ const fileScheme = "file"
 // DefaultISOURLs returns a list of ISO URL's to consult by default, in priority order
 func DefaultISOURLs() []string {
 	v := version.GetISOVersion()
-	isoBucket := "minikube-builds/iso/13563"
+	isoBucket := "minikube-builds/iso/13531"
 	return []string{
 		fmt.Sprintf("https://storage.googleapis.com/%s/minikube-%s.iso", isoBucket, v),
 		fmt.Sprintf("https://github.com/kubernetes/minikube/releases/download/%s/minikube-%s.iso", v, v),

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -68,7 +68,7 @@ minikube start [flags]
       --insecure-registry strings         Insecure Docker registries to pass to the Docker daemon.  The default service CIDR range will automatically be added.
       --install-addons                    If set, install addons. Defaults to true. (default true)
       --interactive                       Allow user prompts for more information (default true)
-      --iso-url strings                   Locations to fetch the minikube ISO from. (default [https://storage.googleapis.com/minikube-builds/iso/13563/minikube-v1.25.0-1644071583-13563.iso,https://github.com/kubernetes/minikube/releases/download/v1.25.0-1644071583-13563/minikube-v1.25.0-1644071583-13563.iso,https://kubernetes.oss-cn-hangzhou.aliyuncs.com/minikube/iso/minikube-v1.25.0-1644071583-13563.iso])
+      --iso-url strings                   Locations to fetch the minikube ISO from. (default [https://storage.googleapis.com/minikube-builds/iso/13531/minikube-v1.25.0-1644344644-13531.iso,https://github.com/kubernetes/minikube/releases/download/v1.25.0-1644344644-13531/minikube-v1.25.0-1644344644-13531.iso,https://kubernetes.oss-cn-hangzhou.aliyuncs.com/minikube/iso/minikube-v1.25.0-1644344644-13531.iso])
       --keep-context                      This will keep the existing kubectl context and will create a minikube context.
       --kubernetes-version string         The Kubernetes version that the minikube VM will use (ex: v1.2.3, 'stable' for v1.23.3, 'latest' for v1.23.4-rc.0). Defaults to 'stable'.
       --kvm-gpu                           Enable experimental NVIDIA GPU support in minikube

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -26,7 +26,7 @@ minikube start [flags]
       --apiserver-names strings           A set of apiserver names which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine
       --apiserver-port int                The apiserver listening port (default 8443)
       --auto-update-drivers               If set, automatically updates drivers to the latest version. Defaults to true. (default true)
-      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.29-1644071658-13563@sha256:8ab41333bf2f1906510725cbb2cc2ee50fc11b9a8a3edda7585ae0371c3fa2f7")
+      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.29-1644344181-13531@sha256:02c921df998f95e849058af14de7045efc3954d90320967418a0d1f182bbc0b2")
       --binary-mirror string              Location to fetch kubectl, kubelet, & kubeadm binaries from.
       --cache-images                      If true, cache docker images for the current bootstrapper and load them into the machine. Always false with --driver=none. (default true)
       --cert-expiration duration          Duration until minikube certificate expiration, defaults to three years (26280h). (default 26280h0m0s)


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/12552

Created files that will be copied to the drop-in configuration directory. They have all their values commented out, but the code has been updated to uncomment and change the values there instead of the main configuration file which may or may not be empty.