### PR TITLE
add arch to binary and image cache paths

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -52,6 +52,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/cruntime"
+	"k8s.io/minikube/pkg/minikube/detect"
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/kubeconfig"
 	"k8s.io/minikube/pkg/minikube/machine"
@@ -753,7 +754,7 @@ func (k *Bootstrapper) UpdateCluster(cfg config.ClusterConfig) error {
 	}
 
 	if cfg.KubernetesConfig.ShouldLoadCachedImages {
-		if err := machine.LoadCachedImages(&cfg, k.c, images, constants.ImageCacheDir, false); err != nil {
+		if err := machine.LoadCachedImages(&cfg, k.c, images, detect.ImageCacheDir(), false); err != nil {
 			out.FailureT("Unable to load cached images: {{.error}}", out.V{"error": err})
 		}
 	}

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -184,10 +184,6 @@ var (
 
 	// ISOCacheDir is the path to the virtual machine image cache directory
 	ISOCacheDir = localpath.MakeMiniPath("cache", "iso")
-	// KICCacheDir is the path to the container node image cache directory
-	KICCacheDir = localpath.MakeMiniPath("cache", "kic")
-	// ImageCacheDir is the path to the container image cache directory
-	ImageCacheDir = localpath.MakeMiniPath("cache", "images")
 
 	// DefaultNamespaces are Kubernetes namespaces used by minikube, including addons
 	DefaultNamespaces = []string{

--- a/pkg/minikube/detect/detect.go
+++ b/pkg/minikube/detect/detect.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/klauspost/cpuid"
 	"golang.org/x/sys/cpu"
+	"k8s.io/minikube/pkg/minikube/localpath"
 )
 
 // RuntimeOS returns the runtime operating system
@@ -112,4 +113,14 @@ func DockerInstalledViaSnap() bool {
 func GithubActionRunner() bool {
 	// based on https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables
 	return os.Getenv("GITHUB_ACTIONS") == "true"
+}
+
+// ImageCacheDir returns the path to the container image cache directory for the current architecture
+func ImageCacheDir() string {
+	return filepath.Join(localpath.MakeMiniPath("cache", "images"), runtime.GOARCH)
+}
+
+// KICCacheDir returns the path to the container node image cache directory for the current architecture
+func KICCacheDir() string {
+	return filepath.Join(localpath.MakeMiniPath("cache", "kic"), runtime.GOARCH)
 }

--- a/pkg/minikube/download/binary.go
+++ b/pkg/minikube/download/binary.go
@@ -55,7 +55,7 @@ func binaryWithChecksumURL(binaryName, version, osName, archName, binaryURL stri
 
 // Binary will download a binary onto the host
 func Binary(binary, version, osName, archName, binaryURL string) (string, error) {
-	targetDir := localpath.MakeMiniPath("cache", osName, version)
+	targetDir := localpath.MakeMiniPath("cache", osName, archName, version)
 	targetFilepath := path.Join(targetDir, binary)
 	targetLock := targetFilepath + ".lock"
 

--- a/pkg/minikube/download/image.go
+++ b/pkg/minikube/download/image.go
@@ -33,7 +33,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
-	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/detect"
 	"k8s.io/minikube/pkg/minikube/localpath"
 )
 
@@ -46,7 +46,7 @@ var (
 
 // imagePathInCache returns path in local cache directory
 func imagePathInCache(img string) string {
-	f := filepath.Join(constants.KICCacheDir, path.Base(img)+".tar")
+	f := filepath.Join(detect.KICCacheDir(), path.Base(img)+".tar")
 	f = localpath.SanitizeCacheDir(f)
 	return f
 }
@@ -222,7 +222,7 @@ func CacheToDaemon(img string) error {
 
 // ImageToDaemon downloads img (if not present in daemon) and writes it to the local docker daemon
 func ImageToDaemon(img string) error {
-	fileLock := filepath.Join(constants.KICCacheDir, path.Base(img)+".d.lock")
+	fileLock := filepath.Join(detect.KICCacheDir(), path.Base(img)+".d.lock")
 	fileLock = localpath.SanitizeCacheDir(fileLock)
 
 	releaser, err := lockDownload(fileLock)

--- a/pkg/minikube/image/cache.go
+++ b/pkg/minikube/image/cache.go
@@ -28,7 +28,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 	"k8s.io/klog/v2"
-	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/detect"
 	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/util/lock"
@@ -48,7 +48,7 @@ var errCacheImageDoesntExist = &cacheError{errors.New("the image you are trying 
 // DeleteFromCacheDir deletes tar files stored in cache dir
 func DeleteFromCacheDir(images []string) error {
 	for _, image := range images {
-		path := filepath.Join(constants.ImageCacheDir, image)
+		path := filepath.Join(detect.ImageCacheDir(), image)
 		path = localpath.SanitizeCacheDir(path)
 		klog.Infoln("Deleting image in cache at ", path)
 		if err := os.Remove(path); err != nil {

--- a/pkg/minikube/image/image.go
+++ b/pkg/minikube/image/image.go
@@ -36,7 +36,7 @@ import (
 
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
-	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/detect"
 	"k8s.io/minikube/pkg/minikube/localpath"
 )
 
@@ -198,7 +198,7 @@ func retrieveRemote(ref name.Reference, p v1.Platform) (v1.Image, error) {
 
 // imagePathInCache returns path in local cache directory
 func imagePathInCache(img string) string {
-	f := filepath.Join(constants.ImageCacheDir, img)
+	f := filepath.Join(detect.ImageCacheDir(), img)
 	f = localpath.SanitizeCacheDir(f)
 	return f
 }
@@ -278,7 +278,7 @@ func fixPlatform(ref name.Reference, img v1.Image, p v1.Platform) (v1.Image, err
 }
 
 func cleanImageCacheDir() error {
-	err := filepath.Walk(constants.ImageCacheDir, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(localpath.MakeMiniPath("cache", "images"), func(path string, info os.FileInfo, err error) error {
 		// If error is not nil, it's because the path was already deleted and doesn't exist
 		// Move on to next path
 		if err != nil {

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -41,8 +41,8 @@ import (
 	"k8s.io/minikube/pkg/minikube/bootstrapper"
 	"k8s.io/minikube/pkg/minikube/command"
 	"k8s.io/minikube/pkg/minikube/config"
-	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/cruntime"
+	"k8s.io/minikube/pkg/minikube/detect"
 	"k8s.io/minikube/pkg/minikube/image"
 	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/minikube/out"
@@ -65,7 +65,7 @@ func CacheImagesForBootstrapper(imageRepository string, version string, clusterB
 		return errors.Wrap(err, "cached images list")
 	}
 
-	if err := image.SaveToDir(images, constants.ImageCacheDir, false); err != nil {
+	if err := image.SaveToDir(images, detect.ImageCacheDir(), false); err != nil {
 		return errors.Wrapf(err, "Caching images for %s", clusterBootstrapper)
 	}
 
@@ -192,11 +192,11 @@ func CacheAndLoadImages(images []string, profiles []*config.Profile, overwrite b
 	}
 
 	// This is the most important thing
-	if err := image.SaveToDir(images, constants.ImageCacheDir, overwrite); err != nil {
+	if err := image.SaveToDir(images, detect.ImageCacheDir(), overwrite); err != nil {
 		return errors.Wrap(err, "save to dir")
 	}
 
-	return DoLoadImages(images, profiles, constants.ImageCacheDir, overwrite)
+	return DoLoadImages(images, profiles, detect.ImageCacheDir(), overwrite)
 }
 
 // DoLoadImages loads images to all profiles
@@ -382,7 +382,7 @@ func SaveAndCacheImages(images []string, profiles []*config.Profile) error {
 		return nil
 	}
 
-	return DoSaveImages(images, "", profiles, constants.ImageCacheDir)
+	return DoSaveImages(images, "", profiles, detect.ImageCacheDir())
 }
 
 // DoSaveImages saves images from all profiles

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -228,7 +228,7 @@ func saveImagesToTarFromConfig() error {
 	if len(images) == 0 {
 		return nil
 	}
-	return image.SaveToDir(images, constants.ImageCacheDir, false)
+	return image.SaveToDir(images, detect.ImageCacheDir(), false)
 }
 
 // CacheAndLoadImagesInConfig loads the images currently in the config file


### PR DESCRIPTION
This path adds an extra directory to the cache baths for important minikube binary and image cache paths. This will allow users to run multiple arch binaries without corrupting their cache. Note that this does not affect preloads in any way.

Fixes #9593 
Fixes #12274 