### PR TITLE
Fix Markdown rendering issue on /docs/drivers/docker

### DIFF
--- a/site/content/en/docs/drivers/docker.md
+++ b/site/content/en/docs/drivers/docker.md
@@ -42,7 +42,6 @@ Start a cluster using the rootless docker driver:
 ```shell
 dockerd-rootless-setuptool.sh install -f
 docker context use rootless
-
 minikube start --driver=docker --container-runtime=containerd
 ```
 


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

Fixes: https://github.com/kubernetes/minikube/issues/13491

**This PR:**
- Fixes bad formatting on the code panel
- Fixes `--` being rendered as `-`

**Root Cause**
The extra line break caused the Markdown renderer to insert an additional `<p>` tag within the code body. This resulted in a badly formatted view.

**Before:**
<img width="552" alt="Screen Shot 2022-02-02 at 10 01 36 pm" src="https://user-images.githubusercontent.com/2032296/152145854-d012b1cf-6034-480c-adca-3ae156143d1c.png">


**After:**
<img width="557" alt="Screen Shot 2022-02-02 at 10 02 08 pm" src="https://user-images.githubusercontent.com/2032296/152145936-4b122c81-a9bc-44af-a67b-00a58cb36666.png">

