### PR TITLE
Update notify package to support `releases-v2.json`

### DIFF
--- a/cmd/minikube/cmd/update-check.go
+++ b/cmd/minikube/cmd/update-check.go
@@ -36,11 +36,11 @@ var updateCheckCmd = &cobra.Command{
 			exit.Error(reason.InetVersionUnavailable, "Unable to fetch latest version info", err)
 		}
 
-		if len(r) < 1 {
+		if len(r.Releases) < 1 {
 			exit.Message(reason.InetVersionEmpty, "Update server returned an empty list")
 		}
 
 		out.Ln("CurrentVersion: %s", version.GetVersion())
-		out.Ln("LatestVersion: %s", r[0].Name)
+		out.Ln("LatestVersion: %s", r.Releases[0].Name)
 	},
 }

--- a/deploy/minikube/release_sanity_test.go
+++ b/deploy/minikube/release_sanity_test.go
@@ -68,9 +68,14 @@ func TestBetaReleasesJSON(t *testing.T) {
 }
 
 func checkReleases(t *testing.T, rs notify.Releases) {
-	for _, r := range rs {
+	for _, r := range rs.Releases {
 		fmt.Printf("Checking release: %s\n", r.Name)
-		for platform, sha := range r.Checksums {
+		checksums := map[string]string{
+			"darwin":  r.Checksums.Darwin,
+			"linux":   r.Checksums.Linux,
+			"windows": r.Checksums.Windows,
+		}
+		for platform, sha := range checksums {
 			fmt.Printf("Checking SHA for %s.\n", platform)
 			actualSha, err := getSHAFromURL(util.GetBinaryDownloadURL(r.Name, platform, runtime.GOARCH))
 			if err != nil {

--- a/pkg/minikube/notify/notify_test.go
+++ b/pkg/minikube/notify/notify_test.go
@@ -95,7 +95,7 @@ func TestShouldCheckURLBetaVersion(t *testing.T) {
 }
 
 type URLHandlerCorrect struct {
-	releases Releases
+	releases []Release
 }
 
 func (h *URLHandlerCorrect) ServeHTTP(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Closes https://github.com/kubernetes/minikube/issues/13407
Follow up to https://github.com/kubernetes/minikube/pull/13541

Updates the notify package to support the new `releases-v2.json` schema.