### PR TITLE
docs: remove vmware_windows_usage.inc from vmware driver mac section

### DIFF
--- a/site/content/en/docs/drivers/vmware.md
+++ b/site/content/en/docs/drivers/vmware.md
@@ -11,7 +11,7 @@ The vmware driver supports virtualization across all VMware based hypervisors.
 
 {{% tabs %}}
 {{% mactab %}}
-{{% readfile file="/docs/drivers/includes/vmware_macos_usage.inc" %}} vmware_windows_usage.inc
+{{% readfile file="/docs/drivers/includes/vmware_macos_usage.inc" %}}
 {{% /mactab %}}
 {{% linuxtab %}}
 No documentation is available yet.


### PR DESCRIPTION
Not sure why `vmware_windows_usage.inc` should be mentioned on the mac tab for vmware driver support for minikube. Looks like a small typo.
