### PR TITLE
docs: update minikube drivers to call out apple silicon support

### DIFF
--- a/site/content/en/docs/drivers/_index.md
+++ b/site/content/en/docs/drivers/_index.md
@@ -31,6 +31,14 @@ To do so, we use the [Docker Machine](https://github.com/docker/machine) library
 * [VMware Fusion]({{<ref "vmware.md">}}) - VM
 * [SSH]({{<ref "ssh.md">}}) - remote ssh
 
+### macOS M1 (Silicon)
+
+The following drivers support macOS M1 users:
+* Docker
+
+You can also follow along with experimental driver options:
+* [Podman]({{<ref "podman.md">}}) 
+
 ## Windows
 
 * [Hyper-V]({{<ref "hyperv.md">}}) - VM (preferred)


### PR DESCRIPTION
Closes #13572 

This pull request adds details on Apple Silicon support for minikube driver options. This will help users not need to search very hard for non-docker driver options and help users get right into what driver choices are available.

Let me know if there is any information missing or if there are supplementary pieces to add to the `Requires an ISO that supports arm64` comments for parallels/vmware. 