### PR TITLE
fix documentation typo for minikube image load command

### DIFF
--- a/cmd/minikube/cmd/image.go
+++ b/cmd/minikube/cmd/image.go
@@ -76,8 +76,8 @@ func saveFile(r io.Reader) (string, error) {
 // loadImageCmd represents the image load command
 var loadImageCmd = &cobra.Command{
 	Use:     "load IMAGE | ARCHIVE | -",
-	Short:   "Load a image into minikube",
-	Long:    "Load a image into minikube",
+	Short:   "Load an image into minikube",
+	Long:    "Load an image into minikube",
 	Example: "minikube image load image\nminikube image load image.tar",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {

--- a/site/content/en/docs/commands/image.md
+++ b/site/content/en/docs/commands/image.md
@@ -124,11 +124,11 @@ minikube image help [command] [flags]
 
 ## minikube image load
 
-Load a image into minikube
+Load an image into minikube
 
 ### Synopsis
 
-Load a image into minikube
+Load an image into minikube
 
 ```shell
 minikube image load IMAGE | ARCHIVE | - [flags]

--- a/translations/de.json
+++ b/translations/de.json
@@ -385,7 +385,7 @@
 	"Lists all valid default values for PROPERTY_NAME": "Zeige alle Standard-Werte für PROPERTY_NAME",
 	"Lists all valid minikube profiles and detects all possible invalid profiles.": "Zeige alle Minikube Profilel und erkenne alle möglicherweise ungültigen Profile.",
 	"Lists the URLs for the services in your local cluster": "Zeigt die URLs für die Services in ihrem lokalen Cluster",
-	"Load a image into minikube": "Lade ein Image in Minikube",
+	"Load an image into minikube": "Lade ein Image in Minikube",
 	"Local folders to share with Guest via NFS mounts (hyperkit driver only)": "Lokale Ordner, die über NFS-Bereitstellungen für Gast freigegeben werden (nur Hyperkit-Treiber)",
 	"Local proxy ignored: not passing {{.name}}={{.value}} to docker env.": "Lokaler Proxy ignoriert: reiche {{.name}}={{.value}} an docker env weiter.",
 	"Location of the VPNKit socket used for networking. If empty, disables Hyperkit VPNKitSock, if 'auto' uses Docker for Mac VPNKit connection, otherwise uses the specified VSock (hyperkit driver only)": "Speicherort des VPNKit-Sockets, der für das Netzwerk verwendet wird. Wenn leer, wird Hyperkit VPNKitSock deaktiviert. Wenn 'auto' die Docker for Mac VPNKit-Verbindung verwendet, wird andernfalls der angegebene VSock verwendet (nur Hyperkit-Treiber).",

--- a/translations/es.json
+++ b/translations/es.json
@@ -394,7 +394,7 @@
 	"Lists all valid default values for PROPERTY_NAME": "",
 	"Lists all valid minikube profiles and detects all possible invalid profiles.": "",
 	"Lists the URLs for the services in your local cluster": "",
-	"Load a image into minikube": "",
+	"Load an image into minikube": "",
 	"Local folders to share with Guest via NFS mounts (hyperkit driver only)": "Carpetas locales que se compartirán con el invitado mediante activaciones de NFS (solo con el controlador de hyperkit)",
 	"Local proxy ignored: not passing {{.name}}={{.value}} to docker env.": "",
 	"Location of the VPNKit socket used for networking. If empty, disables Hyperkit VPNKitSock, if 'auto' uses Docker for Mac VPNKit connection, otherwise uses the specified VSock (hyperkit driver only)": "Ubicación del socket de VPNKit que se utiliza para ofrecer funciones de red. Si se deja en blanco, se inhabilita VPNKitSock de Hyperkit; si se define como \"auto\", se utiliza Docker para las conexiones de VPNKit en Mac. Con cualquier otro valor, se utiliza el VSock especificado (solo con el controlador de hyperkit)",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -374,7 +374,7 @@
 	"Lists all valid default values for PROPERTY_NAME": "Répertorie toutes les valeurs par défaut valides pour PROPERTY_NAME",
 	"Lists all valid minikube profiles and detects all possible invalid profiles.": "Répertorie tous les profils minikube valides et détecte tous les profils invalides possibles.",
 	"Lists the URLs for the services in your local cluster": "Répertorie les URL des services de votre cluster local",
-	"Load a image into minikube": "Charger une image dans minikube",
+	"Load an image into minikube": "Charger une image dans minikube",
 	"Local folders to share with Guest via NFS mounts (hyperkit driver only)": "Dossiers locaux à partager avec l'invité par des installations NFS (pilote hyperkit uniquement).",
 	"Local proxy ignored: not passing {{.name}}={{.value}} to docker env.": "Proxy local ignoré : ne pas passer {{.name}}={{.value}} à docker env.",
 	"Location of the VPNKit socket used for networking. If empty, disables Hyperkit VPNKitSock, if 'auto' uses Docker for Mac VPNKit connection, otherwise uses the specified VSock (hyperkit driver only)": "Emplacement du socket VPNKit exploité pour la mise en réseau. Si la valeur est vide, désactive Hyperkit VPNKitSock. Si la valeur affiche \"auto\", utilise la connexion VPNKit de Docker pour Mac. Sinon, utilise le VSock spécifié (pilote hyperkit uniquement).",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -383,7 +383,7 @@
 	"Lists all valid default values for PROPERTY_NAME": "PROPERTY_NAME 用の有効な minikube プロファイルを一覧表示します",
 	"Lists all valid minikube profiles and detects all possible invalid profiles.": "有効な minikube プロファイルを一覧表示し、無効の可能性のあるプロファイルを全て検知します",
 	"Lists the URLs for the services in your local cluster": "ローカルクラスターのサービス用 URL を一覧表示します",
-	"Load a image into minikube": "minikube にイメージを読み込ませます",
+	"Load an image into minikube": "minikube にイメージを読み込ませます",
 	"Local folders to share with Guest via NFS mounts (hyperkit driver only)": "NFS マウントを介してゲストと共有するローカルフォルダー (hyperkit ドライバーのみ)",
 	"Local proxy ignored: not passing {{.name}}={{.value}} to docker env.": "ローカルプロキシーは無視されました: docker env に {{.name}}={{.value}} は渡されません。",
 	"Location of the VPNKit socket used for networking. If empty, disables Hyperkit VPNKitSock, if 'auto' uses Docker for Mac VPNKit connection, otherwise uses the specified VSock (hyperkit driver only)": "ネットワーキングに使用する VPNKit ソケットのロケーション。空の場合、Hyperkit VPNKitSock が無効になり、'auto' の場合、Docker for Mac の VPNKit 接続が使用され、それ以外の場合、指定された VSock が使用されます (hyperkit ドライバーのみ)",

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -410,7 +410,7 @@
 	"Lists all valid default values for PROPERTY_NAME": "",
 	"Lists all valid minikube profiles and detects all possible invalid profiles.": "",
 	"Lists the URLs for the services in your local cluster": "",
-	"Load a image into minikube": "",
+	"Load an image into minikube": "",
 	"Local folders to share with Guest via NFS mounts (hyperkit driver only)": "",
 	"Local proxy ignored: not passing {{.name}}={{.value}} to docker env.": "",
 	"Location of the VPNKit socket used for networking. If empty, disables Hyperkit VPNKitSock, if 'auto' uses Docker for Mac VPNKit connection, otherwise uses the specified VSock (hyperkit driver only)": "",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -398,7 +398,7 @@
 	"Lists all valid default values for PROPERTY_NAME": "Wylistuj wszystkie prawidłowe domyślne wartości dla opcji konfiguracyjnej PROPERTY_NAME",
 	"Lists all valid minikube profiles and detects all possible invalid profiles.": "Wylistuj wszystkie prawidłowe profile minikube i wykryj wszystkie nieprawidłowe profile.",
 	"Lists the URLs for the services in your local cluster": "Wylistuj adresy URL serwisów w twoim lokalnym klastrze",
-	"Load a image into minikube": "Załaduj obraz do minikube",
+	"Load an image into minikube": "Załaduj obraz do minikube",
 	"Local folders to share with Guest via NFS mounts (hyperkit driver only)": "Lokalne katalogi do współdzielenia z Guestem poprzez NFS (tylko sterownik hyperkit)",
 	"Local proxy ignored: not passing {{.name}}={{.value}} to docker env.": "",
 	"Location of the VPNKit socket used for networking. If empty, disables Hyperkit VPNKitSock, if 'auto' uses Docker for Mac VPNKit connection, otherwise uses the specified VSock (hyperkit driver only)": "",

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -363,7 +363,7 @@
 	"Lists all valid default values for PROPERTY_NAME": "",
 	"Lists all valid minikube profiles and detects all possible invalid profiles.": "",
 	"Lists the URLs for the services in your local cluster": "",
-	"Load a image into minikube": "",
+	"Load an image into minikube": "",
 	"Local folders to share with Guest via NFS mounts (hyperkit driver only)": "",
 	"Local proxy ignored: not passing {{.name}}={{.value}} to docker env.": "",
 	"Location of the VPNKit socket used for networking. If empty, disables Hyperkit VPNKitSock, if 'auto' uses Docker for Mac VPNKit connection, otherwise uses the specified VSock (hyperkit driver only)": "",

--- a/translations/strings.txt
+++ b/translations/strings.txt
@@ -363,7 +363,7 @@
 	"Lists all valid default values for PROPERTY_NAME": "",
 	"Lists all valid minikube profiles and detects all possible invalid profiles.": "",
 	"Lists the URLs for the services in your local cluster": "",
-	"Load a image into minikube": "",
+	"Load an image into minikube": "",
 	"Local folders to share with Guest via NFS mounts (hyperkit driver only)": "",
 	"Local proxy ignored: not passing {{.name}}={{.value}} to docker env.": "",
 	"Location of the VPNKit socket used for networking. If empty, disables Hyperkit VPNKitSock, if 'auto' uses Docker for Mac VPNKit connection, otherwise uses the specified VSock (hyperkit driver only)": "",

--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -471,7 +471,7 @@
 	"Lists all valid default values for PROPERTY_NAME": "",
 	"Lists all valid minikube profiles and detects all possible invalid profiles.": "",
 	"Lists the URLs for the services in your local cluster": "",
-	"Load a image into minikube": "",
+	"Load an image into minikube": "",
 	"Local folders to share with Guest via NFS mounts (hyperkit driver only)": "通过 NFS 装载与访客共享的本地文件夹（仅限 hyperkit 驱动程序）",
 	"Local proxy ignored: not passing {{.name}}={{.value}} to docker env.": "",
 	"Location of the VPNKit socket used for networking. If empty, disables Hyperkit VPNKitSock, if 'auto' uses Docker for Mac VPNKit connection, otherwise uses the specified VSock (hyperkit driver only)": "用于网络连接的 VPNKit 套接字的位置。如果为空，则停用 Hyperkit VPNKitSock；如果为“auto”，则将 Docker 用于 Mac VPNKit 连接；否则使用指定的 VSock（仅限 hyperkit 驱动程序）",


### PR DESCRIPTION
Fixes a typo in the description of the `minikube load image` command.

"Load a image into minikube" -> "Load an image into minikube"