### PR TITLE
Using Get-CmiInstance to detect Hyper-V availability

### DIFF
--- a/pkg/minikube/registry/drvs/hyperv/hyperv.go
+++ b/pkg/minikube/registry/drvs/hyperv/hyperv.go
@@ -91,13 +91,19 @@ func status() registry.State {
 	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, path, "-NoProfile", "-NonInteractive", "@(Get-Wmiobject Win32_ComputerSystem).HypervisorPresent")
+	cmd := exec.CommandContext(ctx, path, "-NoProfile", "-NonInteractive", "@(Get-CimInstance Win32_ComputerSystem).HypervisorPresent")
 	out, err := cmd.CombinedOutput()
 
 	if err != nil {
-		errorMessage := fmt.Errorf("%s failed:\n%s", strings.Join(cmd.Args, " "), out)
-		fixMessage := "Start PowerShell as an Administrator"
-		return registry.State{Installed: false, Running: true, Error: errorMessage, Fix: fixMessage, Doc: docURL}
+		cimError := fmt.Errorf("%s failed:\n%s ", strings.Join(cmd.Args, " "), out)
+		cmd := exec.CommandContext(ctx, path, "-NoProfile", "-NonInteractive", "@(Get-Wmiobject Win32_ComputerSystem).HypervisorPresent")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+		 	wmiError:= fmt.Errorf("%s failed:\n%s ", strings.Join(cmd.Args, " "), out)
+			errorMessage := fmt.Errorf("%s\n%s", cimError, wmiError)
+			fixMessage := "Start PowerShell as an Administrator"
+			return registry.State{Installed: false, Running: true, Error: errorMessage, Fix: fixMessage, Doc: docURL}
+		}
 	}
 
 	// Get-Wmiobject does not return an error code for false


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

**Replacing deprecated Get-Wmiobject with Get-CimInstance to detect Hyper-V availability.**
Fixes #13571