### PR TITLE
Add network policy documentation (addresses roadmap item)

### DIFF
--- a/site/content/en/docs/_index.md
+++ b/site/content/en/docs/_index.md
@@ -20,8 +20,7 @@ minikube quickly sets up a local Kubernetes cluster on macOS, Linux, and Windows
 * Deploy as a VM, a container, or on bare-metal
 * Multiple container runtimes (CRI-O, containerd, docker)
 * Direct API endpoint for blazing fast [image load and build]({{< ref "/docs/handbook/pushing.md" >}})
-* Support for creating and testing [network policy]({{< ref "docs/handbook/network_policy.md" >}}) (both Kubernetes and Calico network policy)
-* Advanced features such as [LoadBalancer]({{< ref "/docs/handbook/accessing.md#loadbalancer-access" >}}), filesystem mounts, and FeatureGates
+* Advanced features such as [LoadBalancer]({{< ref "/docs/handbook/accessing.md#loadbalancer-access" >}}), filesystem mounts, FeatureGates, and [network policy]({{< ref "docs/handbook/network_policy.md" >}})
 * [Addons]({{< ref "/docs/handbook/deploying.md#addons" >}}) for easily installed Kubernetes applications
 * Supports common [CI environments](https://github.com/minikube-ci/examples)
 

--- a/site/content/en/docs/_index.md
+++ b/site/content/en/docs/_index.md
@@ -20,6 +20,7 @@ minikube quickly sets up a local Kubernetes cluster on macOS, Linux, and Windows
 * Deploy as a VM, a container, or on bare-metal
 * Multiple container runtimes (CRI-O, containerd, docker)
 * Direct API endpoint for blazing fast [image load and build]({{< ref "/docs/handbook/pushing.md" >}})
+* Support for creating and testing [network policy]({{< ref "docs/handbook/network_policy.md" >}}) (both Kubernetes and Calico network policy)
 * Advanced features such as [LoadBalancer]({{< ref "/docs/handbook/accessing.md#loadbalancer-access" >}}), filesystem mounts, and FeatureGates
 * [Addons]({{< ref "/docs/handbook/deploying.md#addons" >}}) for easily installed Kubernetes applications
 * Supports common [CI environments](https://github.com/minikube-ci/examples)

--- a/site/content/en/docs/handbook/filesync.md
+++ b/site/content/en/docs/handbook/filesync.md
@@ -1,6 +1,6 @@
 ---
 title: "File Sync"
-weight: 12
+weight: 13
 description: >
   How to sync files into minikube
 aliases:

--- a/site/content/en/docs/handbook/mount.md
+++ b/site/content/en/docs/handbook/mount.md
@@ -1,7 +1,7 @@
 ---
 title: "Mounting filesystems"
 date: 2017-01-05
-weight: 11
+weight: 12
 description: >
   How to mount a host directory into the VM
 aliases:

--- a/site/content/en/docs/handbook/network_policy.md
+++ b/site/content/en/docs/handbook/network_policy.md
@@ -9,6 +9,8 @@ aliases:
   - /docs/reference/network_policy
 ---
 
+Minikube allows users to create and test network policies in the local Kubernetes cluster. This is useful since it allows the network policies to be, considered, built, and evaluated during the application development, as an integral part of the process rather than "bolted on" at the end of development.
+
 [Kubernetes NetworkPolicies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) allow the control of pod network traffic passing through the cluster, at the the IP address or port level (OSI layer 3 or 4). The linked page provides much more information about the functionality and implementation.
 
 However, the [prerequisites](https://kubernetes.io/docs/concepts/services-networking/network-policies/#prerequisites) note that Network policies are implemented by the Container Network Interface (CNI) network plugin. Therefore to use or test network policies in any Kubernetes cluster, you must be using a networking solution which supports NetworkPolicy. Creating a NetworkPolicy resource without a controller that implements it will have no effect.
@@ -24,7 +26,7 @@ However, Minikube can support [NetworkPolicies](https://kubernetes.io/docs/conce
 
 ## Enabling Calico on a Minikube cluster
 
-It is possible to replace the CNI on a running Minikube cluster, but it is probably easiest to follow the instructions on the [Get Started!]({{<ref "/docs/start/" >}}) page to build the Minikube cluster with Calico installed from the outset.
+It is possible to replace the CNI on a running Minikube cluster, but it is significantly easier to simply append the `--cni calico` flag to the `minikube start` command when following the instructions on the [Get Started!]({{<ref "/docs/start/" >}}) page to build the Minikube cluster with Calico installed from the outset.
 
 ## Kubernetes Network Policy example
 

--- a/site/content/en/docs/handbook/network_policy.md
+++ b/site/content/en/docs/handbook/network_policy.md
@@ -1,0 +1,70 @@
+---
+title: "Network Policy"
+linkTitle: "Network Policy"
+weight: 10
+date: 2022-01-31
+description: >
+  Controlling traffic flowing through the cluster
+aliases:
+  - /docs/reference/network_policy
+---
+
+[Kubernetes NetworkPolicies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) allow the control of pod network traffic passing through the cluster, at the the IP address or port level (OSI layer 3 or 4). The linked page provides much more information about the functionality and implementation.
+
+However, the [prerequisites](https://kubernetes.io/docs/concepts/services-networking/network-policies/#prerequisites) note that Network policies are implemented by the Container Network Interface (CNI) network plugin. Therefore to use or test network policies in any Kubernetes cluster, you must be using a networking solution which supports NetworkPolicy. Creating a NetworkPolicy resource without a controller that implements it will have no effect.
+
+A vanilla Minikube installation (`minikube start`) does not support any NetworkPolicies, since the default CNI, [Kindnet](https://github.com/aojea/kindnet), does not support Network Policies, [by design](https://github.com/kubernetes-sigs/kind/issues/842#issuecomment-528824670).
+
+However, Minikube can support [NetworkPolicies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) if a supported CNI, such as [Calico](https://projectcalico.docs.tigera.io/about/about-calico), is installed. In addition, in this scenario both [Kubernetes network policy](https://projectcalico.docs.tigera.io/security/kubernetes-network-policy) and [Calico network policy](https://projectcalico.docs.tigera.io/security/calico-network-policy) are supported.
+
+**Calico network policy** provides a richer set of policy capabilities than **Kubernetes network policy** including:
+* policy ordering/priority
+* deny rules
+* more flexible match rules
+
+## Enabling Calico on a Minikube cluster
+
+It is possible to replace the CNI on a running Minikube cluster, but it is probably easiest to follow the instructions on the [Get Started!]({{<ref "/docs/start/" >}}) page to build the Minikube cluster with Calico installed from the outset.
+
+## Kubernetes Network Policy example
+
+The [Kubernetes documentation on declaring network policy](https://kubernetes.io/docs/tasks/administer-cluster/declare-network-policy/) is a good place to start to understand the possibilities. In addition, the tutorials in [Further reading]({{< ref "#further-reading" >}}) below give much more guidance. 
+
+The YAML below from the [Kubernetes NetworkPolicies](https://kubernetes.io/docs/concepts/services-networking/network-policies/#default-deny-all-ingress-traffic) documentation shows a very simple default ingress isolation policy or a namespace by creating a NetworkPolicy that selects all pods but does not allow any ingress traffic to those pods.
+
+```yaml
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+```
+
+## Calico Network Policy example
+
+The [Calico network policy documentation](https://projectcalico.docs.tigera.io/security/calico-policy) is the best place to learn about the extended feature set of Calico network policy and how it coexists with Kubernetes network policy.
+
+The YAML below from the [Calico policy tutorial](https://projectcalico.docs.tigera.io/security/tutorials/calico-policy) shows a very simple default deny **Global** Calico Network Policy (not available with vanilla Kubernetes network policy) that is often used as a starting point for an effective zero-trust network model. Note that **Global** Calico Network Policies are not namespaced and affect all pods that match the policy selector. In contrast, Kubernetes Network Policies are namespaced, so you would need to create a default deny policy per namespace to achieve the same effect. In this example pods in the kube-system namespace are excluded to keep Kubernetes itself running smoothly.
+
+```yaml
+---
+apiVersion: projectcalico.org/v3
+kind: GlobalNetworkPolicy
+metadata:
+  name: default-deny
+spec:
+  selector: projectcalico.org/namespace != "kube-system"
+  types:
+  - Ingress
+  - Egress
+```
+
+## Further reading
+
+This [Advanced Kubernetes policy tutorial](https://projectcalico.docs.tigera.io/security/tutorials/kubernetes-policy-advanced) gives an example of what can be achieved with Kubernetes network policy. It walks through using Kubernetes NetworkPolicy to define more complex network policies.
+
+This [Calico policy tutorial](https://projectcalico.docs.tigera.io/security/tutorials/calico-policy) demonstrates the extended functionalities Calico network policy offers over and above vanilla Kubernetes network policies. To demonstrate this, this tutorial follows a similar approach to the tutorial above, but instead uses Calico network policies and highlights differences between the two policy types, making use of features that are not available in Kubernetes network policies. 

--- a/site/content/en/docs/handbook/network_policy.md
+++ b/site/content/en/docs/handbook/network_policy.md
@@ -11,7 +11,7 @@ aliases:
 
 Minikube allows users to create and test network policies in the local Kubernetes cluster. This is useful since it allows the network policies to be, considered, built, and evaluated during the application development, as an integral part of the process rather than "bolted on" at the end of development.
 
-[Kubernetes NetworkPolicies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) allow the control of pod network traffic passing through the cluster, at the the IP address or port level (OSI layer 3 or 4). The linked page provides much more information about the functionality and implementation.
+[Kubernetes NetworkPolicies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) allow the control of pod network traffic passing through the cluster, at the IP address or port level (OSI layer 3 or 4). The linked page provides much more information about the functionality and implementation.
 
 However, the [prerequisites](https://kubernetes.io/docs/concepts/services-networking/network-policies/#prerequisites) note that Network policies are implemented by the Container Network Interface (CNI) network plugin. Therefore to use or test network policies in any Kubernetes cluster, you must be using a networking solution which supports NetworkPolicy. Creating a NetworkPolicy resource without a controller that implements it will have no effect.
 

--- a/site/content/en/docs/handbook/network_policy.md
+++ b/site/content/en/docs/handbook/network_policy.md
@@ -24,7 +24,7 @@ However, minikube can support [NetworkPolicies](https://kubernetes.io/docs/conce
 * deny rules
 * more flexible match rules
 
-## Enabling Calico on a Minikube cluster
+## Enabling Calico on a minikube cluster
 
 It is possible to replace the CNI on a running Minikube cluster, but it is significantly easier to simply append the `--cni calico` flag to the `minikube start` command when following the instructions on the [Get Started!]({{<ref "/docs/start/" >}}) page to build the Minikube cluster with Calico installed from the outset.
 

--- a/site/content/en/docs/handbook/network_policy.md
+++ b/site/content/en/docs/handbook/network_policy.md
@@ -17,7 +17,7 @@ However, the [prerequisites](https://kubernetes.io/docs/concepts/services-networ
 
 A vanilla minikube installation (`minikube start`) does not support any NetworkPolicies, since the default CNI, [Kindnet](https://github.com/aojea/kindnet), does not support Network Policies, [by design](https://github.com/kubernetes-sigs/kind/issues/842#issuecomment-528824670).
 
-However, Minikube can support [NetworkPolicies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) if a supported CNI, such as [Calico](https://projectcalico.docs.tigera.io/about/about-calico), is installed. In addition, in this scenario both [Kubernetes network policy](https://projectcalico.docs.tigera.io/security/kubernetes-network-policy) and [Calico network policy](https://projectcalico.docs.tigera.io/security/calico-network-policy) are supported.
+However, minikube can support [NetworkPolicies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) if a supported CNI, such as [Calico](https://projectcalico.docs.tigera.io/about/about-calico), is installed. In addition, in this scenario both [Kubernetes network policy](https://projectcalico.docs.tigera.io/security/kubernetes-network-policy) and [Calico network policy](https://projectcalico.docs.tigera.io/security/calico-network-policy) are supported.
 
 **Calico network policy** provides a richer set of policy capabilities than **Kubernetes network policy** including:
 * policy ordering/priority

--- a/site/content/en/docs/handbook/network_policy.md
+++ b/site/content/en/docs/handbook/network_policy.md
@@ -15,7 +15,7 @@ minikube allows users to create and test network policies in the local Kubernete
 
 However, the [prerequisites](https://kubernetes.io/docs/concepts/services-networking/network-policies/#prerequisites) note that Network policies are implemented by the Container Network Interface (CNI) network plugin. Therefore to use or test network policies in any Kubernetes cluster, you must be using a networking solution which supports NetworkPolicy. Creating a NetworkPolicy resource without a controller that implements it will have no effect.
 
-A vanilla Minikube installation (`minikube start`) does not support any NetworkPolicies, since the default CNI, [Kindnet](https://github.com/aojea/kindnet), does not support Network Policies, [by design](https://github.com/kubernetes-sigs/kind/issues/842#issuecomment-528824670).
+A vanilla minikube installation (`minikube start`) does not support any NetworkPolicies, since the default CNI, [Kindnet](https://github.com/aojea/kindnet), does not support Network Policies, [by design](https://github.com/kubernetes-sigs/kind/issues/842#issuecomment-528824670).
 
 However, Minikube can support [NetworkPolicies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) if a supported CNI, such as [Calico](https://projectcalico.docs.tigera.io/about/about-calico), is installed. In addition, in this scenario both [Kubernetes network policy](https://projectcalico.docs.tigera.io/security/kubernetes-network-policy) and [Calico network policy](https://projectcalico.docs.tigera.io/security/calico-network-policy) are supported.
 

--- a/site/content/en/docs/handbook/network_policy.md
+++ b/site/content/en/docs/handbook/network_policy.md
@@ -26,7 +26,7 @@ However, minikube can support [NetworkPolicies](https://kubernetes.io/docs/conce
 
 ## Enabling Calico on a minikube cluster
 
-It is possible to replace the CNI on a running Minikube cluster, but it is significantly easier to simply append the `--cni calico` flag to the `minikube start` command when following the instructions on the [Get Started!]({{<ref "/docs/start/" >}}) page to build the Minikube cluster with Calico installed from the outset.
+It is possible to replace the CNI on a running minikube cluster, but it is significantly easier to simply append the `--cni calico` flag to the `minikube start` command when following the instructions on the [Get Started!]({{<ref "/docs/start/" >}}) page to build the minikube cluster with Calico installed from the outset.
 
 ## Kubernetes Network Policy example
 

--- a/site/content/en/docs/handbook/network_policy.md
+++ b/site/content/en/docs/handbook/network_policy.md
@@ -9,7 +9,7 @@ aliases:
   - /docs/reference/network_policy
 ---
 
-Minikube allows users to create and test network policies in the local Kubernetes cluster. This is useful since it allows the network policies to be, considered, built, and evaluated during the application development, as an integral part of the process rather than "bolted on" at the end of development.
+minikube allows users to create and test network policies in the local Kubernetes cluster. This is useful since it allows the network policies to be, considered, built, and evaluated during the application development, as an integral part of the process rather than "bolted on" at the end of development.
 
 [Kubernetes NetworkPolicies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) allow the control of pod network traffic passing through the cluster, at the IP address or port level (OSI layer 3 or 4). The linked page provides much more information about the functionality and implementation.
 

--- a/site/content/en/docs/handbook/persistent_volumes.md
+++ b/site/content/en/docs/handbook/persistent_volumes.md
@@ -1,7 +1,7 @@
 ---
 title: "Persistent Volumes"
 linkTitle: "Persistent Volumes"
-weight: 10
+weight: 11
 date: 2019-08-01
 description: >
   About persistent volumes (hostPath)


### PR DESCRIPTION
This PR adds:

1. the new "Network Policy" handbook page that addresses what network policy is, how to enable support for it on a Minikube cluster, and how to create and test network policies in the local Kubernetes cluster.
2. Minikube's support for network policy to the "Highlights" list on the docs front page.

This PR also begins to address the Minikube Roadmap item: [Usage documentation for 3 leading CNI providers](https://minikube.sigs.k8s.io/docs/contrib/roadmap/#3-support-all-kubernetes-features) since it explains how to use Calico network policy as well as vanilla K8s network policy.

This PR **can** be approved in isolation. However please note that I intend to create a separate PR soon that will propose modernising the Calico deployment method with Minikube to match the current preferred install method. I will discuss it with Minikube maintainers on the #minikube Slack.