### PR TITLE
Fixed SIGSEGV in kubectl when k8s not running

### DIFF
--- a/cmd/minikube/cmd/kubectl.go
+++ b/cmd/minikube/cmd/kubectl.go
@@ -56,8 +56,10 @@ host. Please be aware that when using --ssh all paths will apply to the remote m
 		cc, err := config.Load(ClusterFlagValue())
 
 		version := constants.DefaultKubernetesVersion
+		binaryMirror := ""
 		if err == nil {
 			version = cc.KubernetesConfig.KubernetesVersion
+			binaryMirror = cc.BinaryMirror
 		}
 
 		cname := ClusterFlagValue()
@@ -99,7 +101,7 @@ host. Please be aware that when using --ssh all paths will apply to the remote m
 			args = append(cluster, args...)
 		}
 
-		c, err := KubectlCommand(version, cc.BinaryMirror, args...)
+		c, err := KubectlCommand(version, binaryMirror, args...)
 		if err != nil {
 			out.ErrLn("Error caching kubectl: %v", err)
 			os.Exit(1)


### PR DESCRIPTION
Fixes #13619
