### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/cmd/minikube/cmd/config/set_test.go
+++ b/cmd/minikube/cmd/config/set_test.go
@@ -66,12 +66,9 @@ func TestSetOK(t *testing.T) {
 
 func createTestConfig(t *testing.T) {
 	t.Helper()
-	td, err := os.MkdirTemp("", "config")
-	if err != nil {
-		t.Fatalf("tempdir: %v", err)
-	}
+	td := t.TempDir()
 
-	err = os.Setenv(localpath.MinikubeHome, td)
+	err := os.Setenv(localpath.MinikubeHome, td)
 	if err != nil {
 		t.Fatalf("error setting up test environment. could not set %s due to %+v", localpath.MinikubeHome, err)
 	}

--- a/cmd/minikube/cmd/delete_test.go
+++ b/cmd/minikube/cmd/delete_test.go
@@ -63,19 +63,9 @@ func fileNames(path string) ([]string, error) {
 }
 
 func TestDeleteProfile(t *testing.T) {
-	td, err := os.MkdirTemp("", "single")
-	if err != nil {
-		t.Fatalf("tempdir: %v", err)
-	}
+	td := t.TempDir()
 
-	t.Cleanup(func() {
-		err := os.RemoveAll(td)
-		if err != nil {
-			t.Errorf("failed to clean up temp folder  %q", td)
-		}
-	})
-
-	err = copy.Copy("../../../pkg/minikube/config/testdata/delete-single", td)
+	err := copy.Copy("../../../pkg/minikube/config/testdata/delete-single", td)
 	if err != nil {
 		t.Fatalf("copy: %v", err)
 	}
@@ -169,18 +159,9 @@ func deleteContextTest() error {
 }
 
 func TestDeleteAllProfiles(t *testing.T) {
-	td, err := os.MkdirTemp("", "all")
-	if err != nil {
-		t.Fatalf("tempdir: %v", err)
-	}
-	defer func() { // clean up tempdir
-		err := os.RemoveAll(td)
-		if err != nil {
-			t.Errorf("failed to clean up temp folder  %q", td)
-		}
-	}()
+	td := t.TempDir()
 
-	err = copy.Copy("../../../pkg/minikube/config/testdata/delete-all", td)
+	err := copy.Copy("../../../pkg/minikube/config/testdata/delete-all", td)
 	if err != nil {
 		t.Fatalf("copy: %v", err)
 	}

--- a/cmd/minikube/cmd/generate-docs_test.go
+++ b/cmd/minikube/cmd/generate-docs_test.go
@@ -26,14 +26,10 @@ import (
 )
 
 func TestGenerateTestDocs(t *testing.T) {
-	tempdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatalf("creating temp dir failed: %v", err)
-	}
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 	docPath := filepath.Join(tempdir, "tests.md")
 
-	err = generate.TestDocs(docPath, "../../../test/integration")
+	err := generate.TestDocs(docPath, "../../../test/integration")
 	if err != nil {
 		t.Fatalf("error generating test docs: %v", err)
 	}

--- a/pkg/addons/addons_test.go
+++ b/pkg/addons/addons_test.go
@@ -30,19 +30,8 @@ import (
 
 func createTestProfile(t *testing.T) string {
 	t.Helper()
-	td, err := os.MkdirTemp("", "profile")
-	if err != nil {
-		t.Fatalf("tempdir: %v", err)
-	}
-
-	t.Cleanup(func() {
-		err := os.RemoveAll(td)
-		t.Logf("remove path %q", td)
-		if err != nil {
-			t.Errorf("failed to clean up temp folder  %q", td)
-		}
-	})
-	err = os.Setenv(localpath.MinikubeHome, td)
+	td := t.TempDir()
+	err := os.Setenv(localpath.MinikubeHome, td)
 	if err != nil {
 		t.Errorf("error setting up test environment. could not set %s", localpath.MinikubeHome)
 	}

--- a/pkg/drivers/hyperkit/iso_test.go
+++ b/pkg/drivers/hyperkit/iso_test.go
@@ -17,21 +17,11 @@ limitations under the License.
 package hyperkit
 
 import (
-	"os"
 	"testing"
 )
 
 func TestExtractFile(t *testing.T) {
-	testDir, err := os.MkdirTemp(os.TempDir(), "")
-	if nil != err {
-		return
-	}
-	defer func() { // clean up tempdir
-		err := os.RemoveAll(testDir)
-		if err != nil {
-			t.Errorf("failed to clean up temp folder  %q", testDir)
-		}
-	}()
+	testDir := t.TempDir()
 
 	tests := []struct {
 		name          string

--- a/pkg/minikube/extract/extract_test.go
+++ b/pkg/minikube/extract/extract_test.go
@@ -32,16 +32,7 @@ func TestExtract(t *testing.T) {
 	// The function we care about
 	functions := []string{"extract.PrintToScreen"}
 
-	tempdir, err := os.MkdirTemp("", "temptestdata")
-	if err != nil {
-		t.Fatalf("Creating temp dir: %v", err)
-	}
-	defer func() { // clean up tempdir
-		err := os.RemoveAll(tempdir)
-		if err != nil {
-			t.Errorf("failed to clean up temp folder  %q", tempdir)
-		}
-	}()
+	tempdir := t.TempDir()
 
 	src, err := os.ReadFile("testdata/test.json")
 	if err != nil {

--- a/pkg/minikube/kubeconfig/kubeconfig_test.go
+++ b/pkg/minikube/kubeconfig/kubeconfig_test.go
@@ -228,16 +228,7 @@ func TestUpdate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			tmpDir, err := os.MkdirTemp("", "")
-			if err != nil {
-				t.Fatalf("Error making temp directory %v", err)
-			}
-			defer func() { // clean up tempdir
-				err := os.RemoveAll(tmpDir)
-				if err != nil {
-					t.Errorf("failed to clean up temp folder  %q", tmpDir)
-				}
-			}()
+			tmpDir := t.TempDir()
 
 			test.cfg.SetPath(filepath.Join(tmpDir, "kubeconfig"))
 			if len(test.existingCfg) != 0 {
@@ -245,7 +236,7 @@ func TestUpdate(t *testing.T) {
 					t.Fatalf("WriteFile: %v", err)
 				}
 			}
-			err = Update(test.cfg)
+			err := Update(test.cfg)
 			if err != nil && !test.err {
 				t.Errorf("Got unexpected error: %v", err)
 			}
@@ -459,16 +450,7 @@ func TestEmptyConfig(t *testing.T) {
 }
 
 func TestNewConfig(t *testing.T) {
-	dir, err := os.MkdirTemp("", ".kube")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		err := os.RemoveAll(dir)
-		if err != nil {
-			t.Errorf("Failed to remove dir %q: %v", dir, err)
-		}
-	}()
+	dir := t.TempDir()
 
 	// setup minikube config
 	expected := api.NewConfig()
@@ -476,7 +458,7 @@ func TestNewConfig(t *testing.T) {
 
 	// write actual
 	filename := filepath.Join(dir, "config")
-	err = writeToFile(expected, filename)
+	err := writeToFile(expected, filename)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/minikube/localpath/localpath_test.go
+++ b/pkg/minikube/localpath/localpath_test.go
@@ -28,16 +28,7 @@ import (
 )
 
 func TestReplaceWinDriveLetterToVolumeName(t *testing.T) {
-	path, err := os.MkdirTemp("", "repwindl2vn")
-	if err != nil {
-		t.Fatalf("Error make tmp directory: %v", err)
-	}
-	defer func(path string) { // clean up tempdir
-		err := os.RemoveAll(path)
-		if err != nil {
-			t.Errorf("failed to clean up temp folder  %q", path)
-		}
-	}(path)
+	path := t.TempDir()
 
 	if runtime.GOOS != "windows" {
 		// Replace to fake func.

--- a/pkg/minikube/machine/cache_binaries_test.go
+++ b/pkg/minikube/machine/cache_binaries_test.go
@@ -88,17 +88,7 @@ func TestCacheBinariesForBootstrapper(t *testing.T) {
 	oldMinikubeHome := os.Getenv("MINIKUBE_HOME")
 	defer os.Setenv("MINIKUBE_HOME", oldMinikubeHome)
 
-	minikubeHome, err := os.MkdirTemp("/tmp", "")
-	if err != nil {
-		t.Fatalf("error during creating tmp dir: %v", err)
-	}
-
-	defer func() { // clean up tempdir
-		err := os.RemoveAll(minikubeHome)
-		if err != nil {
-			t.Errorf("failed to clean up temp folder  %q", minikubeHome)
-		}
-	}()
+	minikubeHome := t.TempDir()
 
 	var tc = []struct {
 		version, clusterBootstrapper string
@@ -147,18 +137,8 @@ func TestExcludedBinariesNotDownloaded(t *testing.T) {
 	oldMinikubeHome := os.Getenv("MINIKUBE_HOME")
 	defer os.Setenv("MINIKUBE_HOME", oldMinikubeHome)
 
-	minikubeHome, err := os.MkdirTemp("/tmp", "")
-	if err != nil {
-		t.Fatalf("error during creating tmp dir: %v", err)
-	}
+	minikubeHome := t.TempDir()
 	os.Setenv("MINIKUBE_HOME", minikubeHome)
-
-	defer func() { // clean up tempdir
-		err := os.RemoveAll(minikubeHome)
-		if err != nil {
-			t.Errorf("failed to clean up temp folder  %q", minikubeHome)
-		}
-	}()
 
 	if err := CacheBinariesForBootstrapper("v1.16.0", clusterBootstrapper, []string{binaryToExclude}, ""); err != nil {
 		t.Errorf("Failed to cache binaries: %v", err)

--- a/pkg/util/crypto_test.go
+++ b/pkg/util/crypto_test.go
@@ -28,16 +28,7 @@ import (
 )
 
 func TestGenerateCACert(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "")
-	defer func() { // clean up tempdir
-		err := os.RemoveAll(tmpDir)
-		if err != nil {
-			t.Errorf("failed to clean up temp folder  %q", tmpDir)
-		}
-	}()
-	if err != nil {
-		t.Fatalf("Error generating tmpdir: %v", err)
-	}
+	tmpDir := t.TempDir()
 
 	certPath := filepath.Join(tmpDir, "cert")
 	keyPath := filepath.Join(tmpDir, "key")
@@ -61,32 +52,14 @@ func TestGenerateCACert(t *testing.T) {
 }
 
 func TestGenerateSignedCert(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "")
-	defer func() { // clean up tempdir
-		err := os.RemoveAll(tmpDir)
-		if err != nil {
-			t.Errorf("failed to clean up temp folder  %q", tmpDir)
-		}
-	}()
-	if err != nil {
-		t.Fatalf("Error generating tmpdir: %v", err)
-	}
+	tmpDir := t.TempDir()
 
-	signerTmpDir, err := os.MkdirTemp("", "")
-	defer func() { // clean up tempdir
-		err := os.RemoveAll(signerTmpDir)
-		if err != nil {
-			t.Errorf("failed to clean up temp folder  %q", signerTmpDir)
-		}
-	}()
-	if err != nil {
-		t.Fatalf("Error generating signer tmpdir: %v", err)
-	}
+	signerTmpDir := t.TempDir()
 
 	validSignerCertPath := filepath.Join(signerTmpDir, "cert")
 	validSignerKeyPath := filepath.Join(signerTmpDir, "key")
 
-	err = GenerateCACert(validSignerCertPath, validSignerKeyPath, constants.APIServerName)
+	err := GenerateCACert(validSignerCertPath, validSignerKeyPath, constants.APIServerName)
 	if err != nil {
 		t.Fatalf("Error generating signer cert")
 	}

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -80,20 +80,11 @@ func TestParseKubernetesVersion(t *testing.T) {
 }
 
 func TestChownR(t *testing.T) {
-	testDir, err := os.MkdirTemp(os.TempDir(), "")
+	testDir := t.TempDir()
+	_, err := os.Create(testDir + "/TestChownR")
 	if nil != err {
 		return
 	}
-	_, err = os.Create(testDir + "/TestChownR")
-	if nil != err {
-		return
-	}
-	defer func() { // clean up tempdir
-		err := os.RemoveAll(testDir)
-		if err != nil {
-			t.Errorf("failed to clean up temp folder  %q", testDir)
-		}
-	}()
 
 	cases := []struct {
 		name          string
@@ -133,21 +124,11 @@ func TestChownR(t *testing.T) {
 }
 
 func TestMaybeChownDirRecursiveToMinikubeUser(t *testing.T) {
-	testDir, err := os.MkdirTemp(os.TempDir(), "")
+	testDir := t.TempDir()
+	_, err := os.Create(testDir + "/TestChownR")
 	if nil != err {
 		return
 	}
-	_, err = os.Create(testDir + "/TestChownR")
-	if nil != err {
-		return
-	}
-
-	defer func() { // clean up tempdir
-		err := os.RemoveAll(testDir)
-		if err != nil {
-			t.Errorf("failed to clean up temp folder  %q", testDir)
-		}
-	}()
 
 	if os.Getenv("CHANGE_MINIKUBE_NONE_USER") == "" {
 		err = os.Setenv("CHANGE_MINIKUBE_NONE_USER", "1")

--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -27,7 +27,6 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -276,11 +275,7 @@ func TestBinaryMirror(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), Minutes(10))
 	defer Cleanup(t, profile, cancel)
 
-	tmpDir, err := ioutil.TempDir("", "kb_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	// Start test server which will serve binary files
 	ts := httptest.NewServer(

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -26,7 +26,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -1637,11 +1636,7 @@ func validateCpCmd(ctx context.Context, t *testing.T, profile string) {
 	testCpCmd(ctx, t, profile, "", srcPath, "", dstPath)
 
 	// copy from node
-	tmpDir, err := ioutil.TempDir("", "mk_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	tmpPath := filepath.Join(tmpDir, "cp-test.txt")
 	testCpCmd(ctx, t, profile, profile, dstPath, "", tmpPath)
@@ -2010,10 +2005,7 @@ func startProxyWithCustomCerts(ctx context.Context, t *testing.T) error {
 		}
 	}()
 
-	mitmDir, err := os.MkdirTemp("", "")
-	if err != nil {
-		return errors.Wrap(err, "create temp dir")
-	}
+	mitmDir := t.TempDir()
 
 	_, err = Run(t, exec.CommandContext(ctx, "tar", "xzf", "mitmproxy-6.0.2-linux.tar.gz", "-C", mitmDir))
 	if err != nil {

--- a/test/integration/functional_test_mount_test.go
+++ b/test/integration/functional_test_mount_test.go
@@ -59,16 +59,7 @@ func validateMountCmd(ctx context.Context, t *testing.T, profile string) { // no
 	}
 
 	t.Run("any-port", func(t *testing.T) {
-		tempDir, err := os.MkdirTemp("", "mounttest")
-		defer func() { // clean up tempdir
-			err := os.RemoveAll(tempDir)
-			if err != nil {
-				t.Errorf("failed to clean up %q temp folder.", tempDir)
-			}
-		}()
-		if err != nil {
-			t.Fatalf("Unexpected error while creating tempDir: %v", err)
-		}
+		tempDir := t.TempDir()
 
 		ctx, cancel := context.WithTimeout(ctx, Minutes(10))
 
@@ -208,16 +199,7 @@ func validateMountCmd(ctx context.Context, t *testing.T, profile string) { // no
 		}
 	})
 	t.Run("specific-port", func(t *testing.T) {
-		tempDir, err := os.MkdirTemp("", "mounttest")
-		defer func() { // clean up tempdir
-			err := os.RemoveAll(tempDir)
-			if err != nil {
-				t.Errorf("failed to clean up %q temp folder.", tempDir)
-			}
-		}()
-		if err != nil {
-			t.Fatalf("Unexpected error while creating tempDir: %v", err)
-		}
+		tempDir := t.TempDir()
 
 		ctx, cancel := context.WithTimeout(ctx, Minutes(10))
 

--- a/test/integration/multinode_test.go
+++ b/test/integration/multinode_test.go
@@ -23,9 +23,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
-	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
@@ -181,11 +179,7 @@ func validateCopyFileWithMultiNode(ctx context.Context, t *testing.T, profile st
 		t.Errorf("failed to decode json from status: args %q: %v", rr.Command(), err)
 	}
 
-	tmpDir, err := ioutil.TempDir("", "mk_cp_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	srcPath := cpTestLocalPath()
 	dstPath := cpTestMinikubePath()


### PR DESCRIPTION
A small testing enhancement here.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir