### PR TITLE
update prow-test tag to v0.0.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ GVISOR_TAG ?= latest
 AUTOPAUSE_HOOK_TAG ?= v0.0.2
 
 # prow-test tag to push changes to
-PROW_TEST_TAG ?= v0.0.1
+PROW_TEST_TAG ?= v0.0.2
 
 # storage provisioner tag to push changes to
 # NOTE: you will need to bump the PreloadVersion if you change this


### PR DESCRIPTION
We needed a new prow-test image with a newer version of golang, so here it is.