### PR TITLE
fix minikube release twitter bot message

### DIFF
--- a/.github/workflows/twitter-bot.yml
+++ b/.github/workflows/twitter-bot.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: ethomson/send-tweet-action@v1
         with:
-          status: "minikube ${{ env.GITHUB_REF }} was just released! Check it out: https://github.com/kubernetes/minikube/blob/master/CHANGELOG.md"
+          status: "minikube ${GITHUB_REF_NAME} was just released! Check it out: https://github.com/kubernetes/minikube/blob/master/CHANGELOG.md"
           consumer-key: ${{ secrets.TWITTER_API_KEY }}
           consumer-secret: ${{ secrets.TWITTER_API_SECRET }}
           access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}


### PR DESCRIPTION
This fixes two things, the fact that we were referencing the default github env var incorrectly, and using the wrong one.