### PR TITLE
Ignore KVM CRI-O flake test results for now

### DIFF
--- a/hack/jenkins/test-flake-chart/compute_flake_rate.go
+++ b/hack/jenkins/test-flake-chart/compute_flake_rate.go
@@ -168,8 +168,8 @@ func filterRecentEntries(splitEntries splitEntryMap, dateCutoff time.Time) split
 	filteredEntries := make(splitEntryMap)
 
 	for environment, environmentSplit := range splitEntries {
-		// Ignore arm64 tests until they're back under control
-		if strings.Contains(environment, "arm64") {
+		// Ignore kvm crio tests until they're back under control
+		if environment == "KVM_Linux_crio" {
 			continue
 		}
 		for test, testSplit := range environmentSplit {

--- a/hack/jenkins/test-flake-chart/compute_flake_rate.go
+++ b/hack/jenkins/test-flake-chart/compute_flake_rate.go
@@ -73,7 +73,7 @@ type testEntry struct {
 	duration    float32
 }
 
-// A map with keys of (environment, test_name) to values of slcies of TestEntry.
+// A map with keys of (environment, test_name) to values of slices of TestEntry.
 type splitEntryMap map[string]map[string][]testEntry
 
 // Reads CSV `file` and consumes each line to be a single TestEntry.
@@ -168,6 +168,10 @@ func filterRecentEntries(splitEntries splitEntryMap, dateCutoff time.Time) split
 	filteredEntries := make(splitEntryMap)
 
 	for environment, environmentSplit := range splitEntries {
+		// Ignore arm64 tests until they're back under control
+		if strings.Contains(environment, "arm64") {
+			continue
+		}
 		for test, testSplit := range environmentSplit {
 			for _, entry := range testSplit {
 				if !entry.date.Before(dateCutoff) {


### PR DESCRIPTION
There are so many failing tests for KVM crio that flooding the issues with failing test warnings is counter-productive. let's fix those tests then reenable it.
