### PR TITLE
Add 'subnet' flag for docker/podman driver

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -121,6 +121,7 @@ const (
 	kicBaseImage            = "base-image"
 	ports                   = "ports"
 	network                 = "network"
+	subnet                  = "subnet"
 	startNamespace          = "namespace"
 	trace                   = "trace"
 	sshIPAddress            = "ssh-ip-address"
@@ -249,6 +250,7 @@ func initDriverFlags() {
 	// docker & podman
 	startCmd.Flags().String(listenAddress, "", "IP Address to use to expose ports (docker and podman driver only)")
 	startCmd.Flags().StringSlice(ports, []string{}, "List of ports that should be exposed (docker and podman driver only)")
+	startCmd.Flags().String(subnet, "", "Subnet to be used on kic cluster. If left empty, minikube will choose subnet address, beginning from 192.168.49.0. (docker and podman driver only)")
 }
 
 // initNetworkingFlags inits the commandline flags for connectivity related flags for start
@@ -468,6 +470,7 @@ func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, rtime str
 		MinikubeISO:             viper.GetString(isoURL),
 		KicBaseImage:            viper.GetString(kicBaseImage),
 		Network:                 viper.GetString(network),
+		Subnet:                  viper.GetString(subnet),
 		Memory:                  getMemorySize(cmd, drvName),
 		CPUs:                    getCPUCount(drvName),
 		DiskSize:                getDiskSize(),

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -92,7 +92,7 @@ func (d *Driver) Create() error {
 	if networkName == "" {
 		networkName = d.NodeConfig.ClusterName
 	}
-	if gateway, err := oci.CreateNetwork(d.OCIBinary, networkName); err != nil {
+	if gateway, err := oci.CreateNetwork(d.OCIBinary, networkName, d.NodeConfig.Subnet); err != nil {
 		out.WarningT("Unable to create dedicated network, this might result in cluster IP change after restart: {{.error}}", out.V{"error": err})
 	} else if gateway != nil {
 		params.Network = networkName

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -64,6 +64,7 @@ type Config struct {
 	KubernetesVersion string            // Kubernetes version to install
 	ContainerRuntime  string            // container runtime kic is running
 	Network           string            //  network to run with kic
+	Subnet            string            // subnet to be used on kic cluster
 	ExtraArgs         []string          // a list of any extra option to pass to oci binary during creation time, for example --expose 8080...
 	ListenAddress     string            // IP Address to listen to
 }

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -82,6 +82,7 @@ type ClusterConfig struct {
 	ExposedPorts            []string // Only used by the docker and podman driver
 	ListenAddress           string   // Only used by the docker and podman driver
 	Network                 string   // only used by docker driver
+	Subnet                  string   // only used by the docker and podman driver
 	MultiNodeRequested      bool
 	ExtraDisks              int // currently only implemented for hyperkit and kvm2
 	CertExpiration          time.Duration

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -83,6 +83,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		ContainerRuntime:  cc.KubernetesConfig.ContainerRuntime,
 		ExtraArgs:         extraArgs,
 		Network:           cc.Network,
+		Subnet:            cc.Subnet,
 		ListenAddress:     cc.ListenAddress,
 	}), nil
 }

--- a/pkg/minikube/registry/drvs/podman/podman.go
+++ b/pkg/minikube/registry/drvs/podman/podman.go
@@ -96,6 +96,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		ContainerRuntime:  cc.KubernetesConfig.ContainerRuntime,
 		ExtraArgs:         extraArgs,
 		ListenAddress:     cc.ListenAddress,
+		Subnet:            cc.Subnet,
 	}), nil
 }
 

--- a/test/integration/kic_custom_network_test.go
+++ b/test/integration/kic_custom_network_test.go
@@ -75,7 +75,7 @@ func TestKicExistingNetwork(t *testing.T) {
 	}
 	// create custom network
 	networkName := "existing-network"
-	if _, err := oci.CreateNetwork(oci.Docker, networkName); err != nil {
+	if _, err := oci.CreateNetwork(oci.Docker, networkName, ""); err != nil {
 		t.Fatalf("error creating network: %v", err)
 	}
 	defer func() {
@@ -97,6 +97,27 @@ func TestKicExistingNetwork(t *testing.T) {
 	}
 }
 
+// TestKicCustomSubnet verifies the docker/podman driver works with a custom subnet
+func TestKicCustomSubnet(t *testing.T) {
+	if !KicDriver() {
+		t.Skip("only runs with docker/podman driver")
+	}
+
+	profile := UniqueProfileName("custom-subnet")
+	ctx, cancel := context.WithTimeout(context.Background(), Minutes(5))
+	defer Cleanup(t, profile, cancel)
+
+	subnet := "192.168.60.0/24"
+	startArgs := []string{"start", "-p", profile, fmt.Sprintf("--subnet=%s", subnet)}
+	c := exec.CommandContext(ctx, Target(), startArgs...)
+	rr, err := Run(t, c)
+	if err != nil {
+		t.Fatalf("%v failed: %v\n%v", rr.Command(), err, rr.Output())
+	}
+
+	verifySubnet(ctx, t, profile, subnet)
+}
+
 func verifyNetworkExists(ctx context.Context, t *testing.T, networkName string) {
 	c := exec.CommandContext(ctx, "docker", "network", "ls", "--format", "{{.Name}}")
 	rr, err := Run(t, c)
@@ -105,5 +126,17 @@ func verifyNetworkExists(ctx context.Context, t *testing.T, networkName string) 
 	}
 	if output := rr.Output(); !strings.Contains(output, networkName) {
 		t.Fatalf("%s network is not listed by [%v]: %v", networkName, c.Args, output)
+	}
+}
+
+func verifySubnet(ctx context.Context, t *testing.T, network, subnet string) {
+	c := exec.CommandContext(ctx, "docker", "network", "inspect", network, "--format", "{{(index .IPAM.Config 0).Subnet}}")
+	rr, err := Run(t, c)
+	if err != nil {
+		t.Fatalf("%v failed: %v\n%v", rr.Command(), err, rr.Output())
+	}
+
+	if output := strings.TrimSpace(rr.Output()); !strings.Contains(output, subnet) {
+		t.Fatalf("%s subnet not match to %v", subnet, output)
 	}
 }


### PR DESCRIPTION
This PR adds support to define subnet address of the minikube docker/podman driver cluster.
Closes  #12315

Example:
`minikube start --subnet 192.168.60.0/24`

Result:
`docker network inspect minikube`

```
"IPAM": {
    "Driver": "default",
    "Options": {},
    "Config": [
        {
            "Subnet": "192.168.60.0/24",
            "Gateway": "192.168.60.1"
        }
    ]
},
```
