### PR TITLE
Skip updating to rc version of Golang

### DIFF
--- a/hack/update/golang_version/update_golang_version.go
+++ b/hack/update/golang_version/update_golang_version.go
@@ -154,6 +154,11 @@ func main() {
 	if err != nil || stable == "" || stableMM == "" {
 		klog.Fatalf("Unable to get Golang stable version: %v", err)
 	}
+	// skip rc versions
+	if strings.Contains(stable, "rc") {
+		klog.Warningf("Golang stable version is a release candidate, skipping: %s", stable)
+		return
+	}
 	data := Data{StableVersion: stable, StableVersionMM: stableMM, K8SVersion: k8sVersion}
 	klog.Infof("Golang stable version: %s", data.StableVersion)
 


### PR DESCRIPTION
Prevent creating automated PRs that update to rc version of Golang such as https://github.com/kubernetes/minikube/pull/13732