### PR TITLE
Upgrade kubernetes dashboard from v2.3.1 to v2.5.1

### DIFF
--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -134,7 +134,7 @@ var Addons = map[string]*Addon{
 		MustBinAsset(addons.DashboardAssets, "dashboard/dashboard-secret.yaml", vmpath.GuestAddonsDir, "dashboard-secret.yaml", "0640"),
 		MustBinAsset(addons.DashboardAssets, "dashboard/dashboard-svc.yaml", vmpath.GuestAddonsDir, "dashboard-svc.yaml", "0640"),
 	}, false, "dashboard", "kubernetes", map[string]string{
-		"Dashboard":      "kubernetesui/dashboard:v2.5.0@sha256:ec27f462cf1946220f5a9ace416a84a57c18f98c777876a8054405d1428cc92e",
+		"Dashboard":      "kubernetesui/dashboard:v2.5.0@sha256:1b020f566b5d65a0273c3f4ed16f37dedcb95ee2c9fa6f1c42424ec10b2fd2d7",
 		"MetricsScraper": "kubernetesui/metrics-scraper:v1.0.7@sha256:36d5b3f60e1a144cc5ada820910535074bdf5cf73fb70d1ff1681537eef4e172",
 	}, nil),
 	"default-storageclass": NewAddon([]*BinAsset{

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -134,7 +134,7 @@ var Addons = map[string]*Addon{
 		MustBinAsset(addons.DashboardAssets, "dashboard/dashboard-secret.yaml", vmpath.GuestAddonsDir, "dashboard-secret.yaml", "0640"),
 		MustBinAsset(addons.DashboardAssets, "dashboard/dashboard-svc.yaml", vmpath.GuestAddonsDir, "dashboard-svc.yaml", "0640"),
 	}, false, "dashboard", "kubernetes", map[string]string{
-		"Dashboard":      "kubernetesui/dashboard:v2.5.0@sha256:1b020f566b5d65a0273c3f4ed16f37dedcb95ee2c9fa6f1c42424ec10b2fd2d7",
+		"Dashboard":      "kubernetesui/dashboard:v2.5.1@sha256:cc746e7a0b1eec0db01cbabbb6386b23d7af97e79fa9e36bb883a95b7eb96fe2]",
 		"MetricsScraper": "kubernetesui/metrics-scraper:v1.0.7@sha256:36d5b3f60e1a144cc5ada820910535074bdf5cf73fb70d1ff1681537eef4e172",
 	}, nil),
 	"default-storageclass": NewAddon([]*BinAsset{

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -134,7 +134,7 @@ var Addons = map[string]*Addon{
 		MustBinAsset(addons.DashboardAssets, "dashboard/dashboard-secret.yaml", vmpath.GuestAddonsDir, "dashboard-secret.yaml", "0640"),
 		MustBinAsset(addons.DashboardAssets, "dashboard/dashboard-svc.yaml", vmpath.GuestAddonsDir, "dashboard-svc.yaml", "0640"),
 	}, false, "dashboard", "kubernetes", map[string]string{
-		"Dashboard":      "kubernetesui/dashboard:v2.5.1@sha256:cc746e7a0b1eec0db01cbabbb6386b23d7af97e79fa9e36bb883a95b7eb96fe2]",
+		"Dashboard":      "kubernetesui/dashboard:v2.5.1@sha256:cc746e7a0b1eec0db01cbabbb6386b23d7af97e79fa9e36bb883a95b7eb96fe2",
 		"MetricsScraper": "kubernetesui/metrics-scraper:v1.0.7@sha256:36d5b3f60e1a144cc5ada820910535074bdf5cf73fb70d1ff1681537eef4e172",
 	}, nil),
 	"default-storageclass": NewAddon([]*BinAsset{

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -134,7 +134,7 @@ var Addons = map[string]*Addon{
 		MustBinAsset(addons.DashboardAssets, "dashboard/dashboard-secret.yaml", vmpath.GuestAddonsDir, "dashboard-secret.yaml", "0640"),
 		MustBinAsset(addons.DashboardAssets, "dashboard/dashboard-svc.yaml", vmpath.GuestAddonsDir, "dashboard-svc.yaml", "0640"),
 	}, false, "dashboard", "kubernetes", map[string]string{
-		"Dashboard":      "kubernetesui/dashboard:v2.3.1@sha256:ec27f462cf1946220f5a9ace416a84a57c18f98c777876a8054405d1428cc92e",
+		"Dashboard":      "kubernetesui/dashboard:v2.5.0@sha256:ec27f462cf1946220f5a9ace416a84a57c18f98c777876a8054405d1428cc92e",
 		"MetricsScraper": "kubernetesui/metrics-scraper:v1.0.7@sha256:36d5b3f60e1a144cc5ada820910535074bdf5cf73fb70d1ff1681537eef4e172",
 	}, nil),
 	"default-storageclass": NewAddon([]*BinAsset{

--- a/pkg/minikube/bootstrapper/images/images.go
+++ b/pkg/minikube/bootstrapper/images/images.go
@@ -121,7 +121,7 @@ func dashboardFrontend(repo string) string {
 		repo = "docker.io"
 	}
 	// See 'kubernetes-dashboard' in deploy/addons/dashboard/dashboard-dp.yaml
-	return path.Join(repo, "kubernetesui", "dashboard:v2.5.0")
+	return path.Join(repo, "kubernetesui", "dashboard:v2.5.1")
 }
 
 // dashboardMetrics returns the image used for the dashboard metrics scraper

--- a/pkg/minikube/bootstrapper/images/images.go
+++ b/pkg/minikube/bootstrapper/images/images.go
@@ -121,7 +121,7 @@ func dashboardFrontend(repo string) string {
 		repo = "docker.io"
 	}
 	// See 'kubernetes-dashboard' in deploy/addons/dashboard/dashboard-dp.yaml
-	return path.Join(repo, "kubernetesui", "dashboard:v2.3.1")
+	return path.Join(repo, "kubernetesui", "dashboard:v2.5.0")
 }
 
 // dashboardMetrics returns the image used for the dashboard metrics scraper

--- a/pkg/minikube/bootstrapper/images/images_test.go
+++ b/pkg/minikube/bootstrapper/images/images_test.go
@@ -94,7 +94,7 @@ k8s.gcr.io/coredns/coredns:v1.8.4
 func TestAuxiliary(t *testing.T) {
 	want := []string{
 		"gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
-		"docker.io/kubernetesui/dashboard:v2.3.1",
+		"docker.io/kubernetesui/dashboard:v2.5.0",
 		"docker.io/kubernetesui/metrics-scraper:v1.0.7",
 	}
 	got := auxiliary("")
@@ -106,7 +106,7 @@ func TestAuxiliary(t *testing.T) {
 func TestAuxiliaryMirror(t *testing.T) {
 	want := []string{
 		"test.mirror/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
-		"test.mirror/kubernetesui/dashboard:v2.3.1",
+		"test.mirror/kubernetesui/dashboard:v2.5.0",
 		"test.mirror/kubernetesui/metrics-scraper:v1.0.7",
 	}
 	got := auxiliary("test.mirror")

--- a/pkg/minikube/bootstrapper/images/images_test.go
+++ b/pkg/minikube/bootstrapper/images/images_test.go
@@ -94,7 +94,7 @@ k8s.gcr.io/coredns/coredns:v1.8.4
 func TestAuxiliary(t *testing.T) {
 	want := []string{
 		"gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
-		"docker.io/kubernetesui/dashboard:v2.5.0",
+		"docker.io/kubernetesui/dashboard:v2.5.1",
 		"docker.io/kubernetesui/metrics-scraper:v1.0.7",
 	}
 	got := auxiliary("")
@@ -106,7 +106,7 @@ func TestAuxiliary(t *testing.T) {
 func TestAuxiliaryMirror(t *testing.T) {
 	want := []string{
 		"test.mirror/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
-		"test.mirror/kubernetesui/dashboard:v2.5.0",
+		"test.mirror/kubernetesui/dashboard:v2.5.1",
 		"test.mirror/kubernetesui/metrics-scraper:v1.0.7",
 	}
 	got := auxiliary("test.mirror")

--- a/pkg/minikube/bootstrapper/images/kubeadm_test.go
+++ b/pkg/minikube/bootstrapper/images/kubeadm_test.go
@@ -43,7 +43,7 @@ func TestKubeadmImages(t *testing.T) {
 			"k8s.gcr.io/etcd:3.4.3-0",
 			"k8s.gcr.io/pause:3.1",
 			"gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
-			"docker.io/kubernetesui/dashboard:v2.5.0",
+			"docker.io/kubernetesui/dashboard:v2.5.1",
 			"docker.io/kubernetesui/metrics-scraper:v1.0.7",
 		}},
 		{"v1.16.1", "mirror.k8s.io", false, []string{
@@ -55,7 +55,7 @@ func TestKubeadmImages(t *testing.T) {
 			"mirror.k8s.io/etcd:3.3.15-0",
 			"mirror.k8s.io/pause:3.1",
 			"mirror.k8s.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
-			"mirror.k8s.io/kubernetesui/dashboard:v2.5.0",
+			"mirror.k8s.io/kubernetesui/dashboard:v2.5.1",
 			"mirror.k8s.io/kubernetesui/metrics-scraper:v1.0.7",
 		}},
 		{"v1.15.0", "", false, []string{
@@ -67,7 +67,7 @@ func TestKubeadmImages(t *testing.T) {
 			"k8s.gcr.io/etcd:3.3.10",
 			"k8s.gcr.io/pause:3.1",
 			"gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
-			"docker.io/kubernetesui/dashboard:v2.5.0",
+			"docker.io/kubernetesui/dashboard:v2.5.1",
 			"docker.io/kubernetesui/metrics-scraper:v1.0.7",
 		}},
 		{"v1.14.0", "", false, []string{
@@ -79,7 +79,7 @@ func TestKubeadmImages(t *testing.T) {
 			"k8s.gcr.io/etcd:3.3.10",
 			"k8s.gcr.io/pause:3.1",
 			"gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
-			"docker.io/kubernetesui/dashboard:v2.5.0",
+			"docker.io/kubernetesui/dashboard:v2.5.1",
 			"docker.io/kubernetesui/metrics-scraper:v1.0.7",
 		}},
 		{"v1.13.0", "", false, []string{
@@ -91,7 +91,7 @@ func TestKubeadmImages(t *testing.T) {
 			"k8s.gcr.io/etcd:3.2.24",
 			"k8s.gcr.io/pause:3.1",
 			"gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
-			"docker.io/kubernetesui/dashboard:v2.5.0",
+			"docker.io/kubernetesui/dashboard:v2.5.1",
 			"docker.io/kubernetesui/metrics-scraper:v1.0.7",
 		}},
 		{"v1.12.0", "", false, []string{
@@ -103,7 +103,7 @@ func TestKubeadmImages(t *testing.T) {
 			"k8s.gcr.io/etcd:3.2.24",
 			"k8s.gcr.io/pause:3.1",
 			"gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
-			"docker.io/kubernetesui/dashboard:v2.5.0",
+			"docker.io/kubernetesui/dashboard:v2.5.1",
 			"docker.io/kubernetesui/metrics-scraper:v1.0.7",
 		}},
 		{"v1.11.0", "", true, nil},

--- a/pkg/minikube/bootstrapper/images/kubeadm_test.go
+++ b/pkg/minikube/bootstrapper/images/kubeadm_test.go
@@ -43,7 +43,7 @@ func TestKubeadmImages(t *testing.T) {
 			"k8s.gcr.io/etcd:3.4.3-0",
 			"k8s.gcr.io/pause:3.1",
 			"gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
-			"docker.io/kubernetesui/dashboard:v2.3.1",
+			"docker.io/kubernetesui/dashboard:v2.5.0",
 			"docker.io/kubernetesui/metrics-scraper:v1.0.7",
 		}},
 		{"v1.16.1", "mirror.k8s.io", false, []string{
@@ -55,7 +55,7 @@ func TestKubeadmImages(t *testing.T) {
 			"mirror.k8s.io/etcd:3.3.15-0",
 			"mirror.k8s.io/pause:3.1",
 			"mirror.k8s.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
-			"mirror.k8s.io/kubernetesui/dashboard:v2.3.1",
+			"mirror.k8s.io/kubernetesui/dashboard:v2.5.0",
 			"mirror.k8s.io/kubernetesui/metrics-scraper:v1.0.7",
 		}},
 		{"v1.15.0", "", false, []string{
@@ -67,7 +67,7 @@ func TestKubeadmImages(t *testing.T) {
 			"k8s.gcr.io/etcd:3.3.10",
 			"k8s.gcr.io/pause:3.1",
 			"gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
-			"docker.io/kubernetesui/dashboard:v2.3.1",
+			"docker.io/kubernetesui/dashboard:v2.5.0",
 			"docker.io/kubernetesui/metrics-scraper:v1.0.7",
 		}},
 		{"v1.14.0", "", false, []string{
@@ -79,7 +79,7 @@ func TestKubeadmImages(t *testing.T) {
 			"k8s.gcr.io/etcd:3.3.10",
 			"k8s.gcr.io/pause:3.1",
 			"gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
-			"docker.io/kubernetesui/dashboard:v2.3.1",
+			"docker.io/kubernetesui/dashboard:v2.5.0",
 			"docker.io/kubernetesui/metrics-scraper:v1.0.7",
 		}},
 		{"v1.13.0", "", false, []string{
@@ -91,7 +91,7 @@ func TestKubeadmImages(t *testing.T) {
 			"k8s.gcr.io/etcd:3.2.24",
 			"k8s.gcr.io/pause:3.1",
 			"gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
-			"docker.io/kubernetesui/dashboard:v2.3.1",
+			"docker.io/kubernetesui/dashboard:v2.5.0",
 			"docker.io/kubernetesui/metrics-scraper:v1.0.7",
 		}},
 		{"v1.12.0", "", false, []string{
@@ -103,7 +103,7 @@ func TestKubeadmImages(t *testing.T) {
 			"k8s.gcr.io/etcd:3.2.24",
 			"k8s.gcr.io/pause:3.1",
 			"gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
-			"docker.io/kubernetesui/dashboard:v2.3.1",
+			"docker.io/kubernetesui/dashboard:v2.5.0",
 			"docker.io/kubernetesui/metrics-scraper:v1.0.7",
 		}},
 		{"v1.11.0", "", true, nil},

--- a/pkg/minikube/cruntime/containerd_test.go
+++ b/pkg/minikube/cruntime/containerd_test.go
@@ -27,7 +27,7 @@ func TestAddRepoTagToImageName(t *testing.T) {
 		imgName string
 		want    string
 	}{
-		{"kubernetesui/dashboard:v2.1.0", "docker.io/kubernetesui/dashboard:v2.1.0"},
+		{"kubernetesui/dashboard:v2.5.0", "docker.io/kubernetesui/dashboard:v2.5.0"},
 		{"kubernetesui/metrics-scraper:v1.0.4", "docker.io/kubernetesui/metrics-scraper:v1.0.4"},
 		{"gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(), "gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion()},
 	}

--- a/pkg/minikube/cruntime/containerd_test.go
+++ b/pkg/minikube/cruntime/containerd_test.go
@@ -27,7 +27,7 @@ func TestAddRepoTagToImageName(t *testing.T) {
 		imgName string
 		want    string
 	}{
-		{"kubernetesui/dashboard:v2.5.0", "docker.io/kubernetesui/dashboard:v2.5.0"},
+		{"kubernetesui/dashboard:v2.5.1", "docker.io/kubernetesui/dashboard:v2.5.1"},
 		{"kubernetesui/metrics-scraper:v1.0.7", "docker.io/kubernetesui/metrics-scraper:v1.0.7"},
 		{"gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(), "gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion()},
 	}

--- a/pkg/minikube/cruntime/containerd_test.go
+++ b/pkg/minikube/cruntime/containerd_test.go
@@ -28,7 +28,7 @@ func TestAddRepoTagToImageName(t *testing.T) {
 		want    string
 	}{
 		{"kubernetesui/dashboard:v2.5.0", "docker.io/kubernetesui/dashboard:v2.5.0"},
-		{"kubernetesui/metrics-scraper:v1.0.4", "docker.io/kubernetesui/metrics-scraper:v1.0.4"},
+		{"kubernetesui/metrics-scraper:v1.0.7", "docker.io/kubernetesui/metrics-scraper:v1.0.7"},
 		{"gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(), "gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion()},
 	}
 	for _, tc := range tests {

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -431,10 +431,10 @@ func testPause(ctx context.Context, t *testing.T, profile string) {
 // Remove container-specific prefixes for naming consistency
 // for example in `docker` runtime we get this:
 // 		$ docker@minikube:~$ sudo crictl images -o json | grep dash
-// 	         "kubernetesui/dashboard:v2.5.0"
+// 	         "kubernetesui/dashboard:v2.5.1"
 // but for 'containerd' we get full name
 // 		$ docker@minikube:~$  sudo crictl images -o json | grep dash
-//        	 "docker.io/kubernetesui/dashboard:v2.5.0"
+//        	 "docker.io/kubernetesui/dashboard:v2.5.1"
 func trimImageName(name string) string {
 	name = strings.TrimPrefix(name, "docker.io/")
 	name = strings.TrimPrefix(name, "localhost/")

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -431,10 +431,10 @@ func testPause(ctx context.Context, t *testing.T, profile string) {
 // Remove container-specific prefixes for naming consistency
 // for example in `docker` runtime we get this:
 // 		$ docker@minikube:~$ sudo crictl images -o json | grep dash
-// 	         "kubernetesui/dashboard:v2.1.0"
+// 	         "kubernetesui/dashboard:v2.5.0"
 // but for 'containerd' we get full name
 // 		$ docker@minikube:~$  sudo crictl images -o json | grep dash
-//        	 "docker.io/kubernetesui/dashboard:v2.1.0"
+//        	 "docker.io/kubernetesui/dashboard:v2.5.0"
 func trimImageName(name string) string {
 	name = strings.TrimPrefix(name, "docker.io/")
 	name = strings.TrimPrefix(name, "localhost/")


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
Kubernetes dashboard has been upgraded to v2.5.1 now, and this PR fixed the version of dashboard to v2.5.1 in minikube.
https://github.com/kubernetes/dashboard/releases