### PR TITLE
Included githubactions in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "ok-to-test"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+        interval: "weekly"
+    labels:
+      - "ok-to-test"


### PR DESCRIPTION
- Included githubactions in the dependabot config
- Included "ok-to-test" label as this avoids someone manually doing it.

