### PR TITLE
update AliyunMirror image prefix

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -430,7 +430,7 @@ func getRepository(cmd *cobra.Command, k8sVersion string) string {
 		repository = autoSelectedRepository
 	}
 
-	if repository == "registry.cn-hangzhou.aliyuncs.com/google_containers" {
+	if repository == constants.AliyunMirror {
 		download.SetAliyunMirror()
 	}
 

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -192,7 +192,7 @@ func EnableOrDisableAddon(cc *config.ClusterConfig, name string, val string) err
 		exit.Error(reason.HostSaveProfile, "Failed to persist images", err)
 	}
 
-	if cc.KubernetesConfig.ImageRepository == "registry.cn-hangzhou.aliyuncs.com/google_containers" {
+	if cc.KubernetesConfig.ImageRepository == constants.AliyunMirror {
 		images, customRegistries = assets.FixAddonImagesAndRegistries(addon, images, customRegistries)
 	}
 

--- a/pkg/minikube/bootstrapper/images/images.go
+++ b/pkg/minikube/bootstrapper/images/images.go
@@ -130,6 +130,10 @@ func coreDNS(v semver.Version, mirror string) string {
 		cv = findLatestTagFromRepository(fmt.Sprintf(tagURLTemplate, kubernetesRepo(mirror), imageName), cv)
 	}
 
+	if mirror == constants.AliyunMirror {
+		imageName = "coredns"
+	}
+
 	return fmt.Sprintf("%s:%s", path.Join(kubernetesRepo(mirror), imageName), cv)
 }
 
@@ -161,7 +165,14 @@ func auxiliary(mirror string) []string {
 
 // storageProvisioner returns the minikube storage provisioner image
 func storageProvisioner(mirror string) string {
-	return path.Join(minikubeRepo(mirror), "storage-provisioner:"+version.GetStorageProvisionerVersion())
+	cv := version.GetStorageProvisionerVersion()
+	in := "k8s-minikube/storage-provisioner:" + cv
+	if mirror == "" {
+		mirror = "gcr.io"
+	} else if mirror == constants.AliyunMirror {
+		in = "storage-provisioner:" + cv
+	}
+	return path.Join(mirror, in)
 }
 
 // KindNet returns the image used for kindnet

--- a/pkg/minikube/bootstrapper/images/images_test.go
+++ b/pkg/minikube/bootstrapper/images/images_test.go
@@ -127,6 +127,46 @@ func TestGetLatestTag(t *testing.T) {
 	}
 }
 
+func TestEssentialsAliyunMirror(t *testing.T) {
+	var testCases = []struct {
+		version string
+		images  []string
+	}{
+
+		{"v1.21.0", strings.Split(strings.Trim(`
+registry.cn-hangzhou.aliyuncs.com/google_containers/kube-apiserver:v1.21.0
+registry.cn-hangzhou.aliyuncs.com/google_containers/kube-controller-manager:v1.21.0
+registry.cn-hangzhou.aliyuncs.com/google_containers/kube-scheduler:v1.21.0
+registry.cn-hangzhou.aliyuncs.com/google_containers/kube-proxy:v1.21.0
+registry.cn-hangzhou.aliyuncs.com/google_containers/pause:3.4.1
+registry.cn-hangzhou.aliyuncs.com/google_containers/etcd:3.4.13-0
+registry.cn-hangzhou.aliyuncs.com/google_containers/coredns:v1.8.0
+`, "\n"), "\n")},
+		{"v1.22.0", strings.Split(strings.Trim(`
+registry.cn-hangzhou.aliyuncs.com/google_containers/kube-apiserver:v1.22.0
+registry.cn-hangzhou.aliyuncs.com/google_containers/kube-controller-manager:v1.22.0
+registry.cn-hangzhou.aliyuncs.com/google_containers/kube-scheduler:v1.22.0
+registry.cn-hangzhou.aliyuncs.com/google_containers/kube-proxy:v1.22.0
+registry.cn-hangzhou.aliyuncs.com/google_containers/pause:3.5
+registry.cn-hangzhou.aliyuncs.com/google_containers/etcd:3.5.0-0
+registry.cn-hangzhou.aliyuncs.com/google_containers/coredns:v1.8.4
+`, "\n"), "\n")},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.version, func(t *testing.T) {
+			v, err := semver.Make(strings.TrimPrefix(tc.version, "v"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := tc.images
+			got := essentials("registry.cn-hangzhou.aliyuncs.com/google_containers", v)
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("images mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestAuxiliary(t *testing.T) {
 	want := []string{
 		"gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
@@ -142,6 +182,16 @@ func TestAuxiliaryMirror(t *testing.T) {
 		"test.mirror/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
 	}
 	got := auxiliary("test.mirror")
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("images mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestAuxiliaryAliyunMirror(t *testing.T) {
+	want := []string{
+		"registry.cn-hangzhou.aliyuncs.com/google_containers/storage-provisioner:" + version.GetStorageProvisionerVersion(),
+	}
+	got := auxiliary("registry.cn-hangzhou.aliyuncs.com/google_containers")
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("images mismatch (-want +got):\n%s", diff)
 	}

--- a/pkg/minikube/bootstrapper/images/repo.go
+++ b/pkg/minikube/bootstrapper/images/repo.go
@@ -16,8 +16,6 @@ limitations under the License.
 
 package images
 
-import "path"
-
 // DefaultKubernetesRepo is the default Kubernetes repository
 const DefaultKubernetesRepo = "k8s.gcr.io"
 
@@ -27,12 +25,4 @@ func kubernetesRepo(mirror string) string {
 		return mirror
 	}
 	return DefaultKubernetesRepo
-}
-
-// minikubeRepo returns the official minikube repository, or an alternate
-func minikubeRepo(mirror string) string {
-	if mirror == "" {
-		mirror = "gcr.io"
-	}
-	return path.Join(mirror, "k8s-minikube")
 }

--- a/pkg/minikube/bootstrapper/images/repo_test.go
+++ b/pkg/minikube/bootstrapper/images/repo_test.go
@@ -44,27 +44,3 @@ func Test_kubernetesRepo(t *testing.T) {
 	}
 
 }
-
-func Test_minikubeRepo(t *testing.T) {
-	tests := []struct {
-		mirror string
-		want   string
-	}{
-		{
-			"",
-			"gcr.io/k8s-minikube",
-		},
-		{
-			"mirror.k8s.io",
-			"mirror.k8s.io/k8s-minikube",
-		},
-	}
-
-	for _, tc := range tests {
-		got := minikubeRepo(tc.mirror)
-		if !cmp.Equal(got, tc.want) {
-			t.Errorf("mirror miss match, want: %s, got: %s", tc.want, got)
-		}
-	}
-
-}

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -145,6 +145,9 @@ const (
 	MountTypeFlag = "type"
 	// MountUIDFlag is the flag used to set the mount UID
 	MountUIDFlag = "uid"
+
+	// Mirror CN
+	AliyunMirror = "registry.cn-hangzhou.aliyuncs.com/google_containers"
 )
 
 var (
@@ -177,7 +180,7 @@ var (
 	// ImageRepositories contains all known image repositories
 	ImageRepositories = map[string][]string{
 		"global": {""},
-		"cn":     {"registry.cn-hangzhou.aliyuncs.com/google_containers"},
+		"cn":     {AliyunMirror},
 	}
 	// KubernetesReleaseBinaries are Kubernetes release binaries required for
 	// kubeadm (kubelet, kubeadm) and the addon manager (kubectl)

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -261,7 +261,7 @@ func imagesInConfigFile() ([]string, error) {
 
 func updateKicImageRepo(imgName string, repo string) string {
 	image := strings.TrimPrefix(imgName, "gcr.io/")
-	if repo == "registry.cn-hangzhou.aliyuncs.com/google_containers" {
+	if repo == constants.AliyunMirror {
 		// for aliyun registry must strip namespace from image name, e.g.
 		//   registry.cn-hangzhou.aliyuncs.com/google_containers/k8s-minikube/kicbase:v0.0.25 will not work
 		//   registry.cn-hangzhou.aliyuncs.com/google_containers/kicbase:v0.0.25 does work


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

fix #13768 

The `coredns` image is cached under `.minikube/cache/images/amd64/registry.cn-hangzhou.aliyuncs.com/google_containers/coredns/coredns_v1.8.6`.

The right path should be `.minikube/cache/images/amd64/registry.cn-hangzhou.aliyuncs.com/google_containers/coredns_v1.8.6`

Could you kindly review this PR?