### PR TITLE
Fix trying to pause multiple containers with runc

### DIFF
--- a/pkg/minikube/cruntime/cri.go
+++ b/pkg/minikube/cruntime/cri.go
@@ -140,13 +140,14 @@ func listCRIContainers(cr CommandRunner, root string, o ListContainersOptions) (
 
 // pauseContainers pauses a list of containers
 func pauseCRIContainers(cr CommandRunner, root string, ids []string) error {
-	args := []string{"runc"}
+	baseArgs := []string{"runc"}
 	if root != "" {
-		args = append(args, "--root", root)
+		baseArgs = append(baseArgs, "--root", root)
 	}
-	args = append(args, "pause")
+	baseArgs = append(baseArgs, "pause")
 	for _, id := range ids {
-		args := append(args, id)
+		args := baseArgs
+		args = append(args, id)
 		if _, err := cr.RunCmd(exec.Command("sudo", args...)); err != nil {
 			return errors.Wrap(err, "runc")
 		}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/12284

**Problem:**
`runc` only supports pausing one container at a time. The container IDs were being looped over properly, but was appending to the previous command causing multiple container IDs being provided.

**Before:**
```
// assuming container IDs 123, 456, 789
sudo runc --root /run/containerd/runc/k8s.io pause 123
sudo runc --root /run/containerd/runc/k8s.io pause 123 456
sudo runc --root /run/containerd/runc/k8s.io pause 123 456 789
```

**After:**
```
// assuming container IDs 123, 456, 789
sudo runc --root /run/containerd/runc/k8s.io pause 123
sudo runc --root /run/containerd/runc/k8s.io pause 456
sudo runc --root /run/containerd/runc/k8s.io pause 789
```
