### PR TITLE
Load image from cache and retrieve sha value from registry

### DIFF
--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -136,6 +136,7 @@ func beginDownloadKicBaseImage(g *errgroup.Group, cc *config.ClusterConfig, down
 		}()
 		for _, img := range append([]string{baseImg}, kic.FallbackImages...) {
 			var err error
+			var isFromCache bool
 
 			if driver.IsDocker(cc.Driver) && download.ImageExistsInDaemon(img) && !downloadOnly {
 				klog.Infof("%s exists in daemon, skipping load", img)
@@ -161,19 +162,20 @@ func beginDownloadKicBaseImage(g *errgroup.Group, cc *config.ClusterConfig, down
 				err = download.CacheToDaemon(img)
 				if err == nil {
 					klog.Infof("successfully loaded %s from cached tarball", img)
-					finalImg = img
-					return nil
+					isFromCache = true
 				}
 			}
 
 			if driver.IsDocker(cc.Driver) {
-				klog.Infof("failed to load %s, will try remote image if available: %v", img, err)
-
 				klog.Infof("Downloading %s to local daemon", img)
 				err = download.ImageToDaemon(img)
 				if err == nil {
 					klog.Infof("successfully downloaded %s", img)
 					finalImg = img
+					return nil
+				} else if isFromCache {
+					klog.Infof("use image loaded from cache %s", strings.Split(img, "@")[0])
+					finalImg = strings.Split(img, "@")[0]
 					return nil
 				}
 			}


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

fix #13768 

Would it be possible to use `kicbase` image without `sha256`?

Besides, there are some fallback images without `sha256` as well, https://github.com/kubernetes/minikube/blob/58c4142ab9154c8c8e6855b9815404cf0c1f1274/pkg/drivers/kic/types.go#L46-L47

Basically, the image with `sha256` would be immutable whereas image with tag is mutable. But as we can see, the sha256 introduced some issues if we want to use cache and run Minikube offline.

If the `kicbase` image is loaded from a tar file, the DIGEST would be lost, referring to [Digest is lost after loading a saved image #22011](https://github.com/moby/moby/issues/22011) in Moby, which would result in an error, `Unable to find image registry.cn-hangzhou.aliyuncs.com/google_containers/kicbase:v0.0.30@sha256:02c921df998f95e849058af14de7045efc3954d90320967418a0d1f182bbc0b2`

If we do so, the `kicbase` image would like the following, as the loading from cache step is before pulling image from remote in which `DIGEST` is filled. https://github.com/kubernetes/minikube/blob/58c4142ab9154c8c8e6855b9815404cf0c1f1274/pkg/minikube/node/cache.go#L148-L174

```bash
$ docker images --digests
REPOSITORY                    TAG       DIGEST    IMAGE ID       CREATED       SIZE
gcr.io/k8s-minikube/kicbase   v0.0.30   <none>    1312ccd2422d   4 weeks ago   1.14GB
```

Related to the following issues
1. Fix handling of image digests in the minikube cache #10075 in Minikube
2. [Calculate digest from tarball #895](https://github.com/google/go-containerregistry/issues/895) in go-containerregistry
3. [Digest is lost after loading a saved image #22011](https://github.com/moby/moby/issues/22011) in Moby
4. [Docker build should compute image digests #32016](https://github.com/moby/moby/issues/32016) in Moby