### PR TITLE
site: support nested tabs

### DIFF
--- a/site/static/js/tabs.js
+++ b/site/static/js/tabs.js
@@ -1,8 +1,8 @@
 /* Tabs JS implementation. Borrowed from Skaffold */
 function initTabs() {
   try{
-    $('.tab-content').find('.tab-pane').each(function(idx, item) {
-      var navTabs = $(this).closest('.code-tabs').find('.nav-tabs'),
+    $('.tab-content').children('.tab-pane').each(function(idx, item) {
+      var navTabs = $(this).closest('.code-tabs').children('.nav-tabs'),
           title = escape($(this).attr('title')).replace(/%20/g, ' '),
           os = escape($(this).attr('os') || '');
       navTabs.append('<li class="nav-tab '+os+'"><a href="#" class="nav-tab">'+title+'</a></li>');
@@ -23,8 +23,9 @@ function initTabs() {
       var tab = $(this).parent(),
           tabIndex = tab.index(),
           tabPanel = $(this).closest('.code-tabs'),
-          tabPane = tabPanel.find('.tab-pane').eq(tabIndex);
-      tabPanel.find('.active').removeClass('active');
+          tabPane = tabPanel.find('.tab-content:first').children('.tab-pane').eq(tabIndex);
+      tab.siblings().removeClass('active');
+      tabPane.siblings().removeClass('active');
       tab.addClass('active');
       tabPane.addClass('active');
     });


### PR DESCRIPTION
The `find`s are too general to support nested tabs, so replaced with `children` to not touch nested tabs.

**Before:**
![Screen Shot 2022-03-15 at 12 08 03 PM](https://user-images.githubusercontent.com/44844360/158453032-b15cd6f7-a323-4c28-817f-5caff63ab7d3.png)


**After:**
![Screen Shot 2022-03-15 at 12 07 03 PM](https://user-images.githubusercontent.com/44844360/158453052-c760842a-eb36-4f92-9e1c-f6894805e277.png)
