### PR TITLE
Improve icacls error logging

### DIFF
--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -260,7 +260,7 @@ func (d *Driver) prepareSSH() error {
 			icaclsCmdOut, icaclsCmdErr := icaclsCmd.CombinedOutput()
 
 			if icaclsCmdErr != nil {
-				return errors.Wrap(icaclsCmdErr, "unable to execute icacls to set permissions")
+				return errors.Wrap(icaclsCmdErr, fmt.Sprintf("unable to execute icacls to set permissions: %s", icaclsCmdOut))
 			}
 
 			if !strings.Contains(string(icaclsCmdOut), "Successfully processed 1 files; Failed processing 0 files") {


### PR DESCRIPTION
We have a user experiencing an issues with icacls https://github.com/kubernetes/minikube/issues/13404. The problem is right now we're only logging the error the command returns which is just `exit status 1`. The output of the command contains more useful information, that could help with debugging.

For example I did `icacls cat123`:
Error: `exit status 2`
Output: `cat123: The system cannot find the file specified.
Successfully processed 0 files; Failed processing 1 files`