### PR TITLE
bump golangci-lint to v1.45.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ MINIKUBE_RELEASES_URL=https://github.com/kubernetes/minikube/releases/download
 KERNEL_VERSION ?= 4.19.202
 # latest from https://github.com/golangci/golangci-lint/releases 
 # update this only by running `make update-golint-version`
-GOLINT_VERSION ?= v1.44.2
+GOLINT_VERSION ?= v1.45.0
 # Limit number of default jobs, to avoid the CI builds running out of memory
 GOLINT_JOBS ?= 4
 # see https://github.com/golangci/golangci-lint#memory-usage-of-golangci-lint

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -43,6 +43,8 @@ import (
 	gopshost "github.com/shirou/gopsutil/v3/host"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"k8s.io/klog/v2"
 	cmdcfg "k8s.io/minikube/cmd/minikube/cmd/config"
@@ -108,7 +110,7 @@ func platform() string {
 	// Show the distro version if possible
 	hi, err := gopshost.Info()
 	if err == nil {
-		s.WriteString(fmt.Sprintf("%s %s", strings.Title(hi.Platform), hi.PlatformVersion))
+		s.WriteString(fmt.Sprintf("%s %s", cases.Title(language.Und).String(hi.Platform), hi.PlatformVersion))
 		klog.Infof("hostinfo: %+v", hi)
 	} else {
 		klog.Warningf("gopshost.Info returned error: %v", err)

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -24,6 +24,8 @@ import (
 	"strconv"
 	"strings"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/constants"
@@ -221,7 +223,7 @@ func FullName(name string) string {
 		}
 		return "Docker"
 	default:
-		return strings.Title(name)
+		return cases.Title(language.Und).String(name)
 	}
 }
 


### PR DESCRIPTION
fixes #13810

golangci-lint v1.45.0 now supports go v1.18: https://github.com/golangci/golangci-lint/releases/tag/v1.45.0

note: after we merge this pr, we should be able to bump `go.mod`'s go version from 1.17 to 1.18 as well

this pr also replaces deprecated `strings.Title` with the `golang.org/x/text/cases`:
```
...
= make lint =============================================================
golangci/golangci-lint info checking GitHub for tag 'v1.45.0'
golangci/golangci-lint info found version: 1.45.0 for v1.45.0/linux/amd64
golangci/golangci-lint info installed out/linters/golangci-lint
cmd/minikube/cmd/start.go:111:38: SA1019: strings.Title is deprecated: The rule Title uses for word boundaries does not handle Unicode punctuation properly. Use golang.org/x/text/cases instead. (staticcheck)
                s.WriteString(fmt.Sprintf("%s %s", strings.Title(hi.Platform), hi.PlatformVersion))
                                                   ^
pkg/minikube/driver/driver.go:224:10: SA1019: strings.Title is deprecated: The rule Title uses for word boundaries does not handle Unicode punctuation properly. Use golang.org/x/text/cases instead. (staticcheck)
                return strings.Title(name)
                       ^
make[1]: *** [Makefile:509: lint-ci] Error 1
...
```

### after:
```
$ make clean && make && make docker-machine-driver-kvm2 && make test
rm -rf ./out
rm -f pkg/minikube/assets/assets.go
rm -f pkg/minikube/translate/translations.go
rm -rf ./vendor
rm -rf /tmp/tmp.*.minikube_*
go build  -tags "" -ldflags="-X k8s.io/minikube/pkg/version.version=v1.25.2 -X k8s.io/minikube/pkg/version.isoVersion=v1.25.2 -X k8s.io/minikube/pkg/version.gitCommitID="3f25d3ec4ff86f089f3771e01cba8c52830620f1-dirty" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" -o out/minikube k8s.io/minikube/cmd/minikube
GOARCH=amd64 \
go build \
        -installsuffix "static" \
        -ldflags="-X k8s.io/minikube/pkg/drivers/kvm.version=v1.25.2 -X k8s.io/minikube/pkg/drivers/kvm.gitCommitID="3f25d3ec4ff86f089f3771e01cba8c52830620f1-dirty"" \
        -tags "libvirt.1.3.1 without_lxc" \
        -o out/docker-machine-driver-kvm2-amd64 \
        k8s.io/minikube/cmd/drivers/kvm
chmod +X out/docker-machine-driver-kvm2-amd64
cp out/docker-machine-driver-kvm2-amd64 out/docker-machine-driver-kvm2
MINIKUBE_LDFLAGS="-X k8s.io/minikube/pkg/version.version=v1.25.2 -X k8s.io/minikube/pkg/version.isoVersion=v1.25.2 -X k8s.io/minikube/pkg/version.gitCommitID="3f25d3ec4ff86f089f3771e01cba8c52830620f1-dirty" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" ./test.sh
= make lint =============================================================
golangci/golangci-lint info checking GitHub for tag 'v1.45.0'
golangci/golangci-lint info found version: 1.45.0 for v1.45.0/linux/amd64
golangci/golangci-lint info installed out/linters/golangci-lint
ok
= go mod ================================================================
ok
= boilerplate ===========================================================
ok
= schema_check ==========================================================
ok
= go test ===============================================================
ok      k8s.io/minikube/cmd/minikube/cmd        0.098s  coverage: 19.2% of statements
ok      k8s.io/minikube/cmd/minikube/cmd/config 0.144s  coverage: 25.6% of statements
ok      k8s.io/minikube/pkg/addons      0.109s  coverage: 25.2% of statements
ok      k8s.io/minikube/pkg/drivers     0.025s  coverage: 18.9% of statements
ok      k8s.io/minikube/pkg/drivers/hyperkit    0.024s  coverage: 77.3% of statements
ok      k8s.io/minikube/pkg/drivers/kic/oci     6.046s  coverage: 19.9% of statements
ok      k8s.io/minikube/pkg/drivers/kvm 0.028s  coverage: 4.1% of statements
ok      k8s.io/minikube/pkg/minikube/assets     0.047s  coverage: 19.7% of statements
ok      k8s.io/minikube/pkg/minikube/audit      0.016s  coverage: 72.8% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper       1.454s  coverage: 48.1% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper/bsutil        0.091s  coverage: 61.9% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper/bsutil/ktmpl  0.022s  coverage: 100.0% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper/images        0.008s  coverage: 96.5% of statements
ok      k8s.io/minikube/pkg/minikube/cluster    0.074s  coverage: 13.3% of statements
ok      k8s.io/minikube/pkg/minikube/command    0.065s  coverage: 11.7% of statements
ok      k8s.io/minikube/pkg/minikube/config     0.095s  coverage: 71.9% of statements
ok      k8s.io/minikube/pkg/minikube/cruntime   0.064s  coverage: 28.5% of statements
ok      k8s.io/minikube/pkg/minikube/docker     0.073s  coverage: 20.8% of statements
ok      k8s.io/minikube/pkg/minikube/download   1.038s  coverage: 25.8% of statements
ok      k8s.io/minikube/pkg/minikube/driver     0.068s  coverage: 49.0% of statements
ok      k8s.io/minikube/pkg/minikube/driver/auxdriver   0.034s  coverage: 19.0% of statements
ok      k8s.io/minikube/pkg/minikube/extract    0.049s  coverage: 56.2% of statements
ok      k8s.io/minikube/pkg/minikube/image      0.056s  coverage: 5.1% of statements
ok      k8s.io/minikube/pkg/minikube/kubeconfig 0.036s  coverage: 81.5% of statements
ok      k8s.io/minikube/pkg/minikube/localpath  0.008s  coverage: 47.4% of statements
ok      k8s.io/minikube/pkg/minikube/logs       0.057s  coverage: 0.8% of statements
ok      k8s.io/minikube/pkg/minikube/machine    0.055s  coverage: 20.3% of statements
ok      k8s.io/minikube/pkg/minikube/mustload   0.035s  coverage: 10.5% of statements
ok      k8s.io/minikube/pkg/minikube/notify     0.040s  coverage: 83.5% of statements
ok      k8s.io/minikube/pkg/minikube/out        0.023s  coverage: 66.0% of statements
ok      k8s.io/minikube/pkg/minikube/out/register       0.016s  coverage: 55.4% of statements
ok      k8s.io/minikube/pkg/minikube/perf       4.012s  coverage: 21.2% of statements
ok      k8s.io/minikube/pkg/minikube/proxy      0.024s  coverage: 68.7% of statements
ok      k8s.io/minikube/pkg/minikube/reason     0.032s  coverage: 70.0% of statements
ok      k8s.io/minikube/pkg/minikube/registry   0.025s  coverage: 77.0% of statements
ok      k8s.io/minikube/pkg/minikube/registry/drvs/docker       0.021s  coverage: 20.2% of statements
ok      k8s.io/minikube/pkg/minikube/service    0.026s  coverage: 84.2% of statements
ok      k8s.io/minikube/pkg/minikube/shell      0.017s  coverage: 94.4% of statements
ok      k8s.io/minikube/pkg/minikube/storageclass       0.014s  coverage: 100.0% of statements
ok      k8s.io/minikube/pkg/minikube/style      0.008s  coverage: 100.0% of statements
ok      k8s.io/minikube/pkg/minikube/sysinit    0.015s  coverage: 4.5% of statements
ok      k8s.io/minikube/pkg/minikube/translate  0.122s  coverage: 45.5% of statements
ok      k8s.io/minikube/pkg/minikube/tunnel     1.426s  coverage: 63.8% of statements
ok      k8s.io/minikube/pkg/util        0.696s  coverage: 75.7% of statements
ok      k8s.io/minikube/pkg/util/lock   0.003s  coverage: 22.2% of statements
ok      k8s.io/minikube/pkg/util/retry  0.002s  coverage: 0.0% of statements
ok
```