### PR TITLE
Fix port validation error on specifying tcp/udp or range of ports.

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1245,7 +1245,7 @@ func validateFlags(cmd *cobra.Command, drvName string) {
 	validateInsecureRegistry()
 }
 
-// This function validates that the --ports are not below 1024 for the host and not outside range
+// validatePorts validates that the --ports are not below 1024 for the host and not outside range
 func validatePorts(ports []string) error {
 	_, portBindingsMap, err := nat.ParsePortSpecs(ports)
 	if err != nil {

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/Delta456/box-cli-maker/v2"
 	"github.com/blang/semver/v4"
+	"github.com/docker/go-connections/nat"
 	"github.com/docker/machine/libmachine/ssh"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -1246,24 +1247,20 @@ func validateFlags(cmd *cobra.Command, drvName string) {
 
 // This function validates that the --ports are not below 1024 for the host and not outside range
 func validatePorts(ports []string) error {
-	for _, portDuplet := range ports {
-		parts := strings.Split(portDuplet, ":")
-		if len(parts) > 2 {
-			ip := parts[0]
-			if net.ParseIP(ip) == nil {
-				return errors.Errorf("Sorry, the IP address provided with --ports flag is invalid: %s", ip)
-			}
-			parts = parts[1:]
-		}
-		for i, port := range parts {
-			p, err := strconv.Atoi(port)
+	_, portBindingsMap, err := nat.ParsePortSpecs(ports)
+	if err != nil {
+		return errors.Errorf("Sorry, one of the ports provided with --ports flag is not valid %s (%v)", ports, err)
+	}
+	for _, portBindings := range portBindingsMap {
+		for _, portBinding := range portBindings {
+			p, err := strconv.Atoi(portBinding.HostPort)
 			if err != nil {
 				return errors.Errorf("Sorry, one of the ports provided with --ports flag is not valid %s", ports)
 			}
 			if p > 65535 || p < 1 {
 				return errors.Errorf("Sorry, one of the ports provided with --ports flag is outside range %s", ports)
 			}
-			if detect.IsMicrosoftWSL() && p < 1024 && i == 0 {
+			if detect.IsMicrosoftWSL() && p < 1024 {
 				return errors.Errorf("Sorry, you cannot use privileged ports on the host (below 1024) %s", ports)
 			}
 		}

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -462,40 +462,124 @@ func TestValidateRuntime(t *testing.T) {
 }
 
 func TestValidatePorts(t *testing.T) {
+	isMicrosoftWSL := detect.IsMicrosoftWSL()
 	type portTest struct {
+		isTarget bool
 		ports    []string
 		errorMsg string
 	}
 	var tests = []portTest{
 		{
-			ports:    []string{"test:80"},
-			errorMsg: "Sorry, one of the ports provided with --ports flag is not valid [test:80]",
+			isTarget: true,
+			ports:    []string{"8080:80"},
+			errorMsg: "",
 		},
 		{
+			isTarget: true,
+			ports:    []string{"8080:80/tcp", "8080:80/udp"},
+			errorMsg: "",
+		},
+		{
+			isTarget: true,
+			ports:    []string{"test:8080"},
+			errorMsg: "Sorry, one of the ports provided with --ports flag is not valid [test:8080] (Invalid hostPort: test)",
+		},
+		{
+			isTarget: true,
 			ports:    []string{"0:80"},
 			errorMsg: "Sorry, one of the ports provided with --ports flag is outside range [0:80]",
 		},
 		{
-			ports:    []string{"8080:80", "6443:443"},
+			isTarget: true,
+			ports:    []string{"0:80/tcp"},
+			errorMsg: "Sorry, one of the ports provided with --ports flag is outside range [0:80/tcp]",
+		},
+		{
+			isTarget: true,
+			ports:    []string{"65536:80/udp"},
+			errorMsg: "Sorry, one of the ports provided with --ports flag is not valid [65536:80/udp] (Invalid hostPort: 65536)",
+		},
+		{
+			isTarget: true,
+			ports:    []string{"0-1:80-81/tcp"},
+			errorMsg: "Sorry, one of the ports provided with --ports flag is outside range [0-1:80-81/tcp]",
+		},
+		{
+			isTarget: true,
+			ports:    []string{"0-1:80-81/udp"},
+			errorMsg: "Sorry, one of the ports provided with --ports flag is outside range [0-1:80-81/udp]",
+		},
+		{
+			isTarget: !isMicrosoftWSL,
+			ports:    []string{"80:80", "1023-1025:8023-8025", "1023-1025:8023-8025/tcp", "1023-1025:8023-8025/udp"},
 			errorMsg: "",
 		},
 		{
-			ports:    []string{"127.0.0.1:80:80"},
-			errorMsg: "",
-		},
-		{
-			ports:    []string{"1000.0.0.1:80:80"},
-			errorMsg: "Sorry, the IP address provided with --ports flag is invalid: 1000.0.0.1",
-		},
-	}
-	if detect.IsMicrosoftWSL() {
-		tests = append(tests, portTest{
+			isTarget: isMicrosoftWSL,
 			ports:    []string{"80:80"},
 			errorMsg: "Sorry, you cannot use privileged ports on the host (below 1024) [80:80]",
-		})
+		},
+		{
+			isTarget: isMicrosoftWSL,
+			ports:    []string{"1023-1025:8023-8025"},
+			errorMsg: "Sorry, you cannot use privileged ports on the host (below 1024) [1023-1025:8023-8025]",
+		},
+		{
+			isTarget: isMicrosoftWSL,
+			ports:    []string{"1023-1025:8023-8025/tcp"},
+			errorMsg: "Sorry, you cannot use privileged ports on the host (below 1024) [1023-1025:8023-8025/tcp]",
+		},
+		{
+			isTarget: isMicrosoftWSL,
+			ports:    []string{"1023-1025:8023-8025/udp"},
+			errorMsg: "Sorry, you cannot use privileged ports on the host (below 1024) [1023-1025:8023-8025/udp]",
+		},
+		{
+			isTarget: true,
+			ports:    []string{"127.0.0.1:8080:80", "127.0.0.1:8081:80/tcp", "127.0.0.1:8081:80/udp", "127.0.0.1:8082-8083:8082-8083/tcp"},
+			errorMsg: "",
+		},
+		{
+			isTarget: true,
+			ports:    []string{"1000.0.0.1:80:80"},
+			errorMsg: "Sorry, one of the ports provided with --ports flag is not valid [1000.0.0.1:80:80] (Invalid ip address: 1000.0.0.1)",
+		},
+		{
+			isTarget: !isMicrosoftWSL,
+			ports:    []string{"127.0.0.1:80:80", "127.0.0.1:81:81/tcp", "127.0.0.1:81:81/udp", "127.0.0.1:82-83:82-83/tcp", "127.0.0.1:82-83:82-83/udp"},
+			errorMsg: "",
+		},
+		{
+			isTarget: isMicrosoftWSL,
+			ports:    []string{"127.0.0.1:80:80"},
+			errorMsg: "Sorry, you cannot use privileged ports on the host (below 1024) [127.0.0.1:80:80]",
+		},
+		{
+			isTarget: isMicrosoftWSL,
+			ports:    []string{"127.0.0.1:81:81/tcp"},
+			errorMsg: "Sorry, you cannot use privileged ports on the host (below 1024) [127.0.0.1:81:81/tcp]",
+		},
+		{
+			isTarget: isMicrosoftWSL,
+			ports:    []string{"127.0.0.1:81:81/udp"},
+			errorMsg: "Sorry, you cannot use privileged ports on the host (below 1024) [127.0.0.1:81:81/udp]",
+		},
+		{
+			isTarget: isMicrosoftWSL,
+			ports:    []string{"127.0.0.1:80-83:80-83/tcp"},
+			errorMsg: "Sorry, you cannot use privileged ports on the host (below 1024) [127.0.0.1:80-83:80-83/tcp]",
+		},
+		{
+			isTarget: isMicrosoftWSL,
+			ports:    []string{"127.0.0.1:80-83:80-83/udp"},
+			errorMsg: "Sorry, you cannot use privileged ports on the host (below 1024) [127.0.0.1:80-83:80-83/udp]",
+		},
 	}
 	for _, test := range tests {
 		t.Run(strings.Join(test.ports, ","), func(t *testing.T) {
+			if !test.isTarget {
+				return
+			}
 			gotError := ""
 			got := validatePorts(test.ports)
 			if got != nil {

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -464,6 +464,8 @@ func TestValidateRuntime(t *testing.T) {
 func TestValidatePorts(t *testing.T) {
 	isMicrosoftWSL := detect.IsMicrosoftWSL()
 	type portTest struct {
+		// isTarget indicates whether or not the test case is covered
+		// because validatePorts behaves differently depending on whether process is running in WSL in windows or not.
 		isTarget bool
 		ports    []string
 		errorMsg string


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

Fixed #13809

### Tests

```sh
$ ./out/minikube start --driver=docker --ports=127.0.0.1:8080:8080/tcp 
😄  minikube v1.25.2 on Darwin 12.2.1 (arm64)
✨  Using the docker driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=4000MB) ...
🐳  Preparing Kubernetes v1.23.3 on Docker 20.10.12 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default

$ docker ps 
CONTAINER ID   IMAGE                                 COMMAND                  CREATED          STATUS          PORTS                                                                                                                                                            NAMES
71a90cb64130   gcr.io/k8s-minikube/kicbase:v0.0.30   "/usr/local/bin/entr…"   23 seconds ago   Up 22 seconds   127.0.0.1:8080->8080/tcp, 127.0.0.1:51870->22/tcp, 127.0.0.1:51871->2376/tcp, 127.0.0.1:51873->5000/tcp, 127.0.0.1:51869->8443/tcp, 127.0.0.1:51872->32443/tcp   minikube
```

```sh
$ ./out/minikube start --driver=docker --ports=127.0.0.1:8080:8080/udp
😄  minikube v1.25.2 on Darwin 12.2.1 (arm64)
✨  Using the docker driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=4000MB) ...
🐳  Preparing Kubernetes v1.23.3 on Docker 20.10.12 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default

$ docker ps
CONTAINER ID   IMAGE                                 COMMAND                  CREATED          STATUS          PORTS                                                                                                                                                            NAMES
d5de1e011cb3   gcr.io/k8s-minikube/kicbase:v0.0.30   "/usr/local/bin/entr…"   18 seconds ago   Up 17 seconds   127.0.0.1:8080->8080/udp, 127.0.0.1:52360->22/tcp, 127.0.0.1:52356->2376/tcp, 127.0.0.1:52358->5000/tcp, 127.0.0.1:52359->8443/tcp, 127.0.0.1:52357->32443/tcp   minikube
```

```sh
$ ./out/minikube start --driver=docker --ports=127.0.0.1:8080-8081:8080-8081
😄  minikube v1.25.2 on Darwin 12.2.1 (arm64)
✨  Using the docker driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=4000MB) ...
🐳  Preparing Kubernetes v1.23.3 on Docker 20.10.12 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default

$ docker ps
CONTAINER ID   IMAGE                                 COMMAND                  CREATED          STATUS          PORTS                                                                                                                                                                      NAMES
be4e51639805   gcr.io/k8s-minikube/kicbase:v0.0.30   "/usr/local/bin/entr…"   18 seconds ago   Up 18 seconds   127.0.0.1:8080-8081->8080-8081/tcp, 127.0.0.1:53079->22/tcp, 127.0.0.1:53080->2376/tcp, 127.0.0.1:53077->5000/tcp, 127.0.0.1:53078->8443/tcp, 127.0.0.1:53076->32443/tcp   minikube
```

```sh
$ ./out/minikube start --driver=docker --ports=127.0.0.1:8080-8081:8080-8081/udp
😄  minikube v1.25.2 on Darwin 12.2.1 (arm64)
✨  Using the docker driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=4000MB) ...
🐳  Preparing Kubernetes v1.23.3 on Docker 20.10.12 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default

$ docker ps
CONTAINER ID   IMAGE                                 COMMAND                  CREATED          STATUS          PORTS                                                                                                                                                                      NAMES
355278e5ca5a   gcr.io/k8s-minikube/kicbase:v0.0.30   "/usr/local/bin/entr…"   17 seconds ago   Up 16 seconds   127.0.0.1:8080-8081->8080-8081/udp, 127.0.0.1:53570->22/tcp, 127.0.0.1:53571->2376/tcp, 127.0.0.1:53568->5000/tcp, 127.0.0.1:53569->8443/tcp, 127.0.0.1:53567->32443/tcp   minikube
```