### PR TITLE
Support rootless Podman driver, take 2 (Usage: `minikube config set rootless true`)

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -163,6 +163,10 @@ var settings = []Setting{
 		name: "native-ssh",
 		set:  SetBool,
 	},
+	{
+		name: config.Rootless,
+		set:  SetBool,
+	},
 }
 
 // ConfigCmd represents the config command

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -72,6 +72,12 @@ var RootCmd = &cobra.Command{
 			out.WarningT("User name '{{.username}}' is not valid", out.V{"username": userName})
 			exit.Message(reason.Usage, "User name must be 60 chars or less.")
 		}
+		// viper maps $MINIKUBE_ROOTLESS to "rootless" property automatically, but it does not do vice versa,
+		// so we map "rootless" property to $MINIKUBE_ROOTLESS expliclity here.
+		// $MINIKUBE_ROOTLESS is referred by KIC runner, which is decoupled from viper.
+		if viper.GetBool(config.Rootless) {
+			os.Setenv(constants.MinikubeRootlessEnv, "true")
+		}
 	},
 }
 
@@ -206,6 +212,7 @@ func init() {
 	RootCmd.PersistentFlags().StringP(config.ProfileName, "p", constants.DefaultClusterName, `The name of the minikube VM being used. This can be set to allow having multiple instances of minikube independently.`)
 	RootCmd.PersistentFlags().StringP(configCmd.Bootstrapper, "b", "kubeadm", "The name of the cluster bootstrapper that will set up the Kubernetes cluster.")
 	RootCmd.PersistentFlags().String(config.UserFlag, "", "Specifies the user executing the operation. Useful for auditing operations executed by 3rd party tools. Defaults to the operating system username.")
+	RootCmd.PersistentFlags().Bool(config.Rootless, false, "Force to use rootless driver (docker and podman driver only)")
 
 	groups := templates.CommandGroups{
 		{

--- a/pkg/drivers/kic/oci/info.go
+++ b/pkg/drivers/kic/oci/info.go
@@ -59,7 +59,7 @@ func CachedDaemonInfo(ociBin string) (SysInfo, error) {
 func DaemonInfo(ociBin string) (SysInfo, error) {
 	if ociBin == Podman {
 		p, err := podmanSystemInfo()
-		cachedSysInfo = &SysInfo{CPUs: p.Host.Cpus, TotalMemory: p.Host.MemTotal, OSType: p.Host.Os, Swarm: false, StorageDriver: p.Store.GraphDriverName}
+		cachedSysInfo = &SysInfo{CPUs: p.Host.Cpus, TotalMemory: p.Host.MemTotal, OSType: p.Host.Os, Swarm: false, Rootless: p.Host.Security.Rootless, StorageDriver: p.Store.GraphDriverName}
 		return *cachedSysInfo, err
 	}
 	d, err := dockerSystemInfo()
@@ -213,8 +213,10 @@ type podmanSysInfo struct {
 		Hostname    string `json:"hostname"`
 		Kernel      string `json:"kernel"`
 		Os          string `json:"os"`
-		Rootless    bool   `json:"rootless"`
-		Uptime      string `json:"uptime"`
+		Security    struct {
+			Rootless bool `json:"rootless"`
+		} `json:"security"`
+		Uptime string `json:"uptime"`
 	} `json:"host"`
 	Registries struct {
 		Search []string `json:"search"`

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -312,7 +312,7 @@ func createContainer(ociBin string, image string, opts ...createOpt) error {
 
 	// to run nested container from privileged container in podman https://bugzilla.redhat.com/show_bug.cgi?id=1687713
 	// only add when running locally (linux), when running remotely it needs to be configured on server in libpod.conf
-	if ociBin == Podman && runtime.GOOS == "linux" {
+	if ociBin == Podman && runtime.GOOS == "linux" && !IsRootlessForced() {
 		args = append(args, "--cgroup-manager", "cgroupfs")
 	}
 
@@ -342,7 +342,7 @@ func StartContainer(ociBin string, container string) error {
 
 	// to run nested container from privileged container in podman https://bugzilla.redhat.com/show_bug.cgi?id=1687713
 	// only add when running locally (linux), when running remotely it needs to be configured on server in libpod.conf
-	if ociBin == Podman && runtime.GOOS == "linux" {
+	if ociBin == Podman && runtime.GOOS == "linux" && !IsRootlessForced() {
 		args = append(args, "--cgroup-manager", "cgroupfs")
 	}
 

--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -44,6 +44,8 @@ const (
 	ProfileName = "profile"
 	// UserFlag is the key for the global user flag (ex. --user=user1)
 	UserFlag = "user"
+	// Rootless is the key for the global rootless parameter (boolean)
+	Rootless = "rootless"
 	// AddonImages stores custom addon images config
 	AddonImages = "addon-images"
 	// AddonRegistries stores custom addon images config

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -99,6 +99,8 @@ const (
 	TestDiskUsedEnv = "MINIKUBE_TEST_STORAGE_CAPACITY"
 	// TestDiskAvailableEnv is used in integration tests for insufficient storage with 'minikube status' (in GiB)
 	TestDiskAvailableEnv = "MINIKUBE_TEST_AVAILABLE_STORAGE"
+	// MinikubeRootlessEnv is used to force Rootless Docker/Podman driver
+	MinikubeRootlessEnv = "MINIKUBE_ROOTLESS"
 
 	// scheduled stop constants
 

--- a/site/content/en/docs/drivers/docker.md
+++ b/site/content/en/docs/drivers/docker.md
@@ -46,6 +46,9 @@ docker context use rootless
 minikube start --driver=docker --container-runtime=containerd
 ```
 
+Unlike Podman driver, it is not necessary to set the `rootless` property of minikube (`minikube config set rootless true`).
+When the `rootless` property is explicitly set but the current Docker host is not rootless, minikube fails with an error.
+
 The `--container-runtime` flag must be set to "containerd" or "cri-o".
 {{% /tab %}}
 {{% /tabs %}}

--- a/site/content/en/docs/drivers/includes/podman_usage.inc
+++ b/site/content/en/docs/drivers/includes/podman_usage.inc
@@ -21,3 +21,14 @@ To make podman the default driver:
 ```shell
 minikube config set driver podman
 ```
+
+## Rootless Podman
+
+By default, minikube executes Podman with `sudo`.
+To use Podman without `sudo` (i.e., Rootless Podman), set the `rootless` property to `true`:
+
+```shell
+minikube config set rootless true
+```
+
+See the [Rootless Docker](https://minikube.sigs.k8s.io/docs/drivers/docker/#rootless-docker) section for the requirements and the restrictions.


### PR DESCRIPTION
Usage: 
```
minikube config set rootless true
minikube start --driver=podman --container-runtime=cri-o
```
The container runtime can be set to `containerd` too.

Tested on Podman 4.0.2, Ubuntu 21.10.

Needs cgroup v2 (as in Rootless Docker): https://rootlesscontaine.rs/getting-started/common/cgroup2/
See also `site/content/en/docs/drivers/includes/podman_usage.inc`

Fixes #8719
Fixes #12460
Replaces PR #12901

Changes from PR #12901 (take 1): `rootless` is now a config property.
In the previous PR, `--rootless` was implemented as a flag for `minikube start`


<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->