### PR TITLE
Fix German translation

### DIFF
--- a/translations/de.json
+++ b/translations/de.json
@@ -988,7 +988,7 @@
 	"zsh completion.": "",
 	"{{ .name }}: Suggestion: {{ .suggestion}}": "{{ .name }}: Vorschlag: {{ .suggestion}}",
 	"{{.Driver}} is currently using the {{.StorageDriver}} storage driver, consider switching to overlay2 for better performance": "{{.Driver}} verwendet derzeit den {{.StorageDriver}} Storage Treiber, erwäge zu overlay2 zu wechseln für bessere Performance",
-	"{{.count}} node{{if gt .count 1}}s{{end}} stopped.": "{{.count}} Node{{if get .count 1}}s{{end}} angehalten.",
+	"{{.count}} node{{if gt .count 1}}s{{end}} stopped.": "{{.count}} Node{{if gt .count 1}}s{{end}} angehalten.",
 	"{{.driver_name}} \"{{.cluster}}\" {{.machine_type}} is missing, will recreate.": "{{.driver_name}} \"{{.cluster}}\" {{.machine_type}} fehlt, wird neu erstellt.",
 	"{{.driver_name}} couldn't proceed because {{.driver_name}} service is not healthy.": "{{.driver_name}} konnte nicht weiterlaufen, da {{.driver_name}} Service nicht funktional ist.",
 	"{{.driver_name}} has less than 2 CPUs available, but Kubernetes requires at least 2 to be available": "{{.driver_name}} verfügt über weniger als 2 CPUs, aber Kubernetes benötigt mindestens 2 verfügbare CPUs",


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
The output of `minikube stop` in German caused an error

## Before
```bash
$ minikube stop
✋  Stoppe Node "minikube" ...
E0324 11:12:13.006700   92294 out.go:449] unable to parse "🛑  {{.count}} Node{{if get .count 1}}s{{end}} angehalten.\n": template: 🛑  {{.count}} Node{{if get .count 1}}s{{end}} angehalten.
:1: function "get" not defined - returning raw string.
E0324 11:12:13.006847   92294 out.go:449] unable to parse "🛑  {{.count}} Node{{if get .count 1}}s{{end}} angehalten.\n": template: 🛑  {{.count}} Node{{if get .count 1}}s{{end}} angehalten.
:1: function "get" not defined - returning raw string.
🛑  {{.count}} Node{{if get .count 1}}s{{end}} angehalten.

```

## Now

```bash
$ ./out/minikube stop
✋  Stoppe Node "minikube" ...
🛑  1 Node angehalten.
```