### PR TITLE
Improve description for minikube cache command

### DIFF
--- a/cmd/minikube/cmd/cache.go
+++ b/cmd/minikube/cmd/cache.go
@@ -38,8 +38,8 @@ const allFlag = "all"
 // cacheCmd represents the cache command
 var cacheCmd = &cobra.Command{
 	Use:   "cache",
-	Short: "Add, delete, or push a local image into minikube",
-	Long:  "Add, delete, or push a local image into minikube",
+	Short: "Manage cache for images",
+	Long:  "Add an image into minikube as a local cache, or delete, reload the cached images",
 }
 
 // addCacheCmd represents the cache add command


### PR DESCRIPTION
fixes #12809

`minikube cache` command has sub commands that are add, delete, reload.
But current description is below.
`Add, delete, or push a local image into minikube`

It's better to use same words as the sub command names.
Also, "push" means "add" in the following document, so it makes confusion that both "add" and "push" are present in the description.
https://minikube.sigs.k8s.io/docs/handbook/pushing/#2-push-images-using-cache-command
