### PR TITLE
Silent fail when user trying to generate log file if cluster not running

### DIFF
--- a/cmd/minikube/cmd/logs.go
+++ b/cmd/minikube/cmd/logs.go
@@ -76,7 +76,7 @@ var logsCmd = &cobra.Command{
 
 		logs.OutputOffline(numberOfLines, logOutput)
 
-		if shouldSoftFail() {
+		if shouldSilentFail() {
 			return
 		}
 
@@ -112,10 +112,10 @@ var logsCmd = &cobra.Command{
 	},
 }
 
-// shouldSoftFail returns true if the user specifies the --file flag and the host isn't running
+// shouldSilentFail returns true if the user specifies the --file flag and the host isn't running
 // This is to prevent outputting the message 'The control plane node must be running for this command' which confuses
 // many users while gathering logs to report their issue as the message makes them think the log file wasn't generated
-func shouldSoftFail() bool {
+func shouldSilentFail() bool {
 	if fileOutput == "" {
 		return false
 	}


### PR DESCRIPTION
**Problem:**
Our GitHub issue template tells users to run `minikube logs --file=logs.txt` to generate log files and upload them to the issue.

The problem arises when if the host isn't running (which is common if you're reporting an issue) the following occurs:
```
$ minikube logs --file=logs.txt
🤷  The control plane node must be running for this command
👉  To start a cluster, run: "minikube start"
```
This confuses many users as the message states `The control plane node must be running for this command` and they think that their log file wasn't generated and results in a log file not being attached to the issue.

**Solution:**
If the user specified the `--file` flag and the host is not running, I've suppressed outputting the above message to not confuse the user.