### PR TITLE
Add registry.k8s.io as a containerd registry endpoint.

### DIFF
--- a/deploy/iso/minikube-iso/package/containerd-bin/config.toml
+++ b/deploy/iso/minikube-iso/package/containerd-bin/config.toml
@@ -103,6 +103,8 @@ oom_score = 0
       [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
         [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
           endpoint = ["https://registry-1.docker.io"]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."k8s.gcr.io"]
+          endpoint = ["https://registry.k8s.io","https://k8s.gcr.io"]
     [plugins."io.containerd.grpc.v1.cri".image_decryption]
       key_model = ""
     [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]


### PR DESCRIPTION
Related:
  - https://github.com/kubernetes/k8s.io/issues/3411

The Kubernetes project is moving away from k8s.gcr.io to registry.k8s.io

registy.k8s.io is currently redirecting to k8s.gcr.io. Each time
minikube is started using containerd as a runtime, the container images
from k8s.gcr.io will be pulled through registry.k8s.io.

Annonce: https://groups.google.com/g/kubernetes-sig-testing/c/U7b_im9vRrM/m/7qywJeUTBQAJ

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
