### PR TITLE
Replace go get with go install

### DIFF
--- a/hack/release_notes.sh
+++ b/hack/release_notes.sh
@@ -28,21 +28,10 @@ function cleanup_token() {
 }
 trap cleanup_token EXIT
 
-install_release_notes_helper() {
-  release_notes_workdir="$(mktemp -d)"
-  trap 'rm -rf -- ${release_notes_workdir}' RETURN
-
-  # See https://stackoverflow.com/questions/56842385/using-go-get-to-download-binaries-without-adding-them-to-go-mod for this workaround
-  cd "${release_notes_workdir}"
-  go mod init release-notes
-  GOBIN="$DIR" go get github.com/corneliusweig/release-notes
-  GOBIN="$DIR" go get github.com/google/pullsheet
-  cd -
-}
-
 if ! [[ -x "${DIR}/release-notes" ]] || ! [[ -x "${DIR}/pullsheet" ]]; then
   echo >&2 'Installing release-notes'
-  install_release_notes_helper
+  go install github.com/corneliusweig/release-notes@latest
+  go install github.com/google/pullsheet@latest
 fi
 
 git pull https://github.com/kubernetes/minikube.git master --tags

--- a/hack/update_contributions.sh
+++ b/hack/update_contributions.sh
@@ -18,20 +18,9 @@ set -eu -o pipefail
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-install_pullsheet() {
-  pullsheet_workdir="$(mktemp -d)"
-  trap 'rm -rf -- ${pullsheet_workdir}' RETURN
-
-  # See https://stackoverflow.com/questions/56842385/using-go-get-to-download-binaries-without-adding-them-to-go-mod for this workaround
-  cd "${pullsheet_workdir}"
-  go mod init ps
-  GOBIN="$DIR" go get github.com/google/pullsheet
-  cd -
-}
-
 if ! [[ -x "${DIR}/pullsheet" ]]; then
   echo >&2 'Installing pullsheet'
-  install_pullsheet
+  go install github.com/google/pullsheet@latest
 fi
 
 git fetch --tags -f


### PR DESCRIPTION
As of Go 1.18

go get no longer builds or installs packages in module-aware mode. go get is now dedicated to adjusting dependencies in go.mod. Effectively, the -d flag is always enabled. To install the latest version of an executable outside the context of the current module, use [go install example.com/cmd@latest](https://golang.org/ref/mod#go-install). Any [version query](https://golang.org/ref/mod#version-queries) may be used instead of latest. This form of go install was added in Go 1.16, so projects supporting older versions may need to provide install instructions for both go install and go get. go get now reports an error when used outside a module, since there is no go.mod file to update. In GOPATH mode (with GO111MODULE=off), go get still builds and installs packages, as before.
