### PR TITLE
Podman: fix `minikube delete` for Podman v4

### DIFF
--- a/pkg/drivers/kic/oci/network.go
+++ b/pkg/drivers/kic/oci/network.go
@@ -158,12 +158,7 @@ func ForwardedPort(ociBin string, ociID string, contPort int) (int, error) {
 	var v semver.Version
 
 	if ociBin == Podman {
-		rr, err = runCmd(exec.Command(Podman, "version", "--format", "{{.Version}}"))
-		if err != nil {
-			return 0, errors.Wrapf(err, "podman version")
-		}
-		output := strings.TrimSpace(rr.Stdout.String())
-		v, err = semver.Make(output)
+		v, err = podmanVersion()
 		if err != nil {
 			return 0, errors.Wrapf(err, "podman version")
 		}

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/docker/machine/libmachine/state"
 	"github.com/pkg/errors"
 
@@ -735,4 +736,13 @@ func IsExternalDaemonHost(driver string) bool {
 		}
 	}
 	return false
+}
+
+func podmanVersion() (semver.Version, error) {
+	rr, err := runCmd(exec.Command(Podman, "version", "--format", "{{.Version}}"))
+	if err != nil {
+		return semver.Version{}, errors.Wrapf(err, "podman version")
+	}
+	output := strings.TrimSpace(rr.Stdout.String())
+	return semver.Make(output)
 }


### PR DESCRIPTION
The "minikube" network was not deleted due to the breaking change of `podman network inspect` in Podman v4.

Fixes #13861

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
