### PR TITLE
OLM: stop testing OLM and warn users about the addon

### DIFF
--- a/cmd/minikube/cmd/config/enable.go
+++ b/cmd/minikube/cmd/config/enable.go
@@ -49,6 +49,9 @@ var addonsEnableCmd = &cobra.Command{
 		if addon == "ambassador" {
 			out.Styled(style.Warning, "The ambassador addon has stopped working as of v1.23.0, for more details visit: https://github.com/datawire/ambassador-operator/issues/73")
 		}
+		if addon == "olm" {
+			out.Styled(style.Warning, "The OLM addon has stopped working, for more details visit: https://github.com/operator-framework/operator-lifecycle-manager/issues/2534")
+		}
 		viper.Set(config.AddonImages, images)
 		viper.Set(config.AddonRegistries, registries)
 		err := addons.SetAndSave(ClusterFlagValue(), addon, "true")

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -66,7 +66,7 @@ func TestAddons(t *testing.T) {
 			t.Fatalf("Failed setting GOOGLE_CLOUD_PROJECT env var: %v", err)
 		}
 
-		args := append([]string{"start", "-p", profile, "--wait=true", "--memory=4000", "--alsologtostderr", "--addons=registry", "--addons=metrics-server", "--addons=olm", "--addons=volumesnapshots", "--addons=csi-hostpath-driver", "--addons=gcp-auth"}, StartArgs()...)
+		args := append([]string{"start", "-p", profile, "--wait=true", "--memory=4000", "--alsologtostderr", "--addons=registry", "--addons=metrics-server", "--addons=volumesnapshots", "--addons=csi-hostpath-driver", "--addons=gcp-auth"}, StartArgs()...)
 		if !NoneDriver() { // none driver does not support ingress
 			args = append(args, "--addons=ingress", "--addons=ingress-dns")
 		}
@@ -446,7 +446,7 @@ func validateHelmTillerAddon(ctx context.Context, t *testing.T, profile string) 
 
 // validateOlmAddon tests the OLM addon
 func validateOlmAddon(ctx context.Context, t *testing.T, profile string) {
-	t.Skip("Skipping Olm addon till images are fixed")
+	t.Skip("Skipping OLM addon test until https://github.com/operator-framework/operator-lifecycle-manager/issues/2534 is resolved")
 	defer PostMortemLogs(t, profile)
 	start := time.Now()
 


### PR DESCRIPTION
Related https://github.com/operator-framework/operator-lifecycle-manager/issues/2534

The OLM addon hash keeps changing and is breaking the addon. We are going to skip testing OLM and warn uses that the addon no longer works until the above issue is resolved.