### PR TITLE
pr-flake-rate: Default links to last 90 days

### DIFF
--- a/hack/jenkins/test-flake-chart/report_flakes.sh
+++ b/hack/jenkins/test-flake-chart/report_flakes.sh
@@ -100,7 +100,7 @@ TMP_COMMENT=$(mktemp)
 printf "These are the flake rates of all failed tests.\n|Environment|Failed Tests|Flake Rate (%%)|\n|---|---|---|\n" > "$TMP_COMMENT"
 
 # Create variables to use for sed command.
-ENV_CHART_LINK_FORMAT='https://storage.googleapis.com/minikube-flake-rate/flake_chart.html?env=%1$s'
+ENV_CHART_LINK_FORMAT='https://storage.googleapis.com/minikube-flake-rate/flake_chart.html?env=%1$s&period=last90'
 TEST_CHART_LINK_FORMAT=${ENV_CHART_LINK_FORMAT}'&test=%2$s'
 TEST_GOPOGH_LINK_FORMAT='https://storage.googleapis.com/minikube-builds/logs/'${PR_NUMBER}'/'${ROOT_JOB}'/%1$s.html#fail_%2$s'
 # 1) Get the first $MAX_REPORTED_TESTS lines.


### PR DESCRIPTION
![Screen Shot 2022-03-30 at 2 49 35 PM](https://user-images.githubusercontent.com/44844360/160936871-aeb78a3f-b13d-4624-89c4-ec57f0f0fd77.png)

**Before:**
The `Environment` and `Flake Rate (%)` links are linking to all-time data and take a long time to load.

**After:**
The `Environment` and `Flake Rate (%)` links are linking to last 90 days data and load much faster.