### PR TITLE
Sync guest clock on initial and existing start

### DIFF
--- a/pkg/minikube/machine/fix.go
+++ b/pkg/minikube/machine/fix.go
@@ -74,7 +74,7 @@ func fixHost(api libmachine.API, cc *config.ClusterConfig, n *config.Node) (*hos
 	}
 
 	// Avoid reprovisioning "none" driver because provision.Detect requires SSH
-	if !driver.BareMetal(h.Driver.DriverName()) {
+	if !driver.BareMetal(driverName) {
 		e := engineOptions(*cc)
 		h.HostOptions.EngineOptions.Env = e.Env
 		err = provisionDockerMachine(h)
@@ -91,12 +91,12 @@ func fixHost(api libmachine.API, cc *config.ClusterConfig, n *config.Node) (*hos
 		return h, errors.Wrap(err, "post-start")
 	}
 
-	if driver.BareMetal(h.Driver.DriverName()) {
+	if driver.BareMetal(driverName) {
 		klog.Infof("%s is local, skipping auth/time setup (requires ssh)", driverName)
 		return h, nil
 	}
 
-	return h, ensureSyncedGuestClock(h, driverName)
+	return h, nil
 }
 
 func recreateIfNeeded(api libmachine.API, cc *config.ClusterConfig, n *config.Node, h *host.Host) (*host.Host, error) {

--- a/pkg/minikube/machine/fix.go
+++ b/pkg/minikube/machine/fix.go
@@ -91,11 +91,6 @@ func fixHost(api libmachine.API, cc *config.ClusterConfig, n *config.Node) (*hos
 		return h, errors.Wrap(err, "post-start")
 	}
 
-	if driver.BareMetal(driverName) {
-		klog.Infof("%s is local, skipping auth/time setup (requires ssh)", driverName)
-		return h, nil
-	}
-
 	return h, nil
 }
 

--- a/pkg/minikube/machine/start.go
+++ b/pkg/minikube/machine/start.go
@@ -86,14 +86,18 @@ func StartHost(api libmachine.API, cfg *config.ClusterConfig, n *config.Node) (*
 	if err != nil {
 		return nil, false, errors.Wrapf(err, "exists: %s", machineName)
 	}
+	var h *host.Host
 	if !exists {
 		klog.Infof("Provisioning new machine with config: %+v %+v", cfg, n)
-		h, err := createHost(api, cfg, n)
+		h, err = createHost(api, cfg, n)
+	} else {
+		klog.Infoln("Skipping create...Using existing machine configuration")
+		h, err = fixHost(api, cfg, n)
+	}
+	if err != nil {
 		return h, exists, err
 	}
-	klog.Infoln("Skipping create...Using existing machine configuration")
-	h, err := fixHost(api, cfg, n)
-	return h, exists, err
+	return h, exists, ensureSyncedGuestClock(h, cfg.Driver)
 }
 
 // engineOptions returns docker engine options for the dockerd running inside minikube


### PR DESCRIPTION
We have been only syncing the guest machines clock on existing start (restart), but for consistency sake we should be doing the sync on both initial start and existing start.