### PR TITLE
Remove old build tags

### DIFF
--- a/cmd/drivers/hyperkit/main.go
+++ b/cmd/drivers/hyperkit/main.go
@@ -1,5 +1,4 @@
 //go:build darwin && !arm64
-// +build darwin,!arm64
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/cmd/drivers/kvm/main-nolinux.go
+++ b/cmd/drivers/kvm/main-nolinux.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/cmd/drivers/kvm/main.go
+++ b/cmd/drivers/kvm/main.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/hack/boilerplate/boilerplate.go
+++ b/hack/boilerplate/boilerplate.go
@@ -34,7 +34,7 @@ var (
 	skippedPaths   = regexp.MustCompile(`Godeps|third_party|_gopath|_output|\.git|cluster/env.sh|vendor|test/e2e/generated/bindata.go|site/themes/docsy|test/integration/testdata`)
 	windowdNewLine = regexp.MustCompile(`\r`)
 	txtExtension   = regexp.MustCompile(`\.txt`)
-	goBuildTag     = regexp.MustCompile(`(?m)^(//go:build.*\n// \+build.*\n)+\n`)
+	goBuildTag     = regexp.MustCompile(`(?m)^(//go:build.*\n)+\n`)
 	shebang        = regexp.MustCompile(`(?m)^(#!.*\n)\n*`)
 	copyright      = regexp.MustCompile(`Copyright YEAR`)
 	copyrightReal  = regexp.MustCompile(`Copyright \d{4}`)

--- a/hack/boilerplate/fix.sh
+++ b/hack/boilerplate/fix.sh
@@ -44,7 +44,7 @@ function prepend() {
     done
 }
 
-prepend "\.go" "go" "+build"
+prepend "\.go" "go" "go:build"
 prepend "\.py" "py"
 prepend "\.sh" "sh" "#!"
 prepend Makefile Makefile

--- a/pkg/drivers/hyperkit/driver.go
+++ b/pkg/drivers/hyperkit/driver.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/pkg/drivers/hyperkit/driver_test.go
+++ b/pkg/drivers/hyperkit/driver_test.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 /*
 Copyright 2018 The Kubernetes Authors All rights reserved.

--- a/pkg/drivers/hyperkit/network.go
+++ b/pkg/drivers/hyperkit/network.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/pkg/drivers/hyperkit/network_test.go
+++ b/pkg/drivers/hyperkit/network_test.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/pkg/drivers/hyperkit/vmnet.go
+++ b/pkg/drivers/hyperkit/vmnet.go
@@ -1,5 +1,4 @@
 //go:build darwin && cgo
-// +build darwin,cgo
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/pkg/drivers/hyperkit/vmnet_stub.go
+++ b/pkg/drivers/hyperkit/vmnet_stub.go
@@ -1,5 +1,4 @@
 //go:build darwin && !cgo
-// +build darwin,!cgo
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/pkg/drivers/kic/oci/cgroups_linux.go
+++ b/pkg/drivers/kic/oci/cgroups_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2021 The Kubernetes Authors All rights reserved.

--- a/pkg/drivers/kic/oci/cgroups_other.go
+++ b/pkg/drivers/kic/oci/cgroups_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 /*
 Copyright 2021 The Kubernetes Authors All rights reserved.

--- a/pkg/drivers/kvm/disks.go
+++ b/pkg/drivers/kvm/disks.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2018 The Kubernetes Authors All rights reserved.

--- a/pkg/drivers/kvm/domain.go
+++ b/pkg/drivers/kvm/domain.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/pkg/drivers/kvm/domain_definition_arm64.go
+++ b/pkg/drivers/kvm/domain_definition_arm64.go
@@ -1,5 +1,4 @@
 //go:build linux && arm64
-// +build linux,arm64
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/pkg/drivers/kvm/domain_definition_x86.go
+++ b/pkg/drivers/kvm/domain_definition_x86.go
@@ -1,5 +1,4 @@
 //go:build linux && amd64
-// +build linux,amd64
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/pkg/drivers/kvm/gpu.go
+++ b/pkg/drivers/kvm/gpu.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2018 The Kubernetes Authors All rights reserved.

--- a/pkg/drivers/kvm/kvm.go
+++ b/pkg/drivers/kvm/kvm.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/pkg/drivers/kvm/network.go
+++ b/pkg/drivers/kvm/network.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/pkg/minikube/constants/constants_darwin.go
+++ b/pkg/minikube/constants/constants_darwin.go
@@ -1,5 +1,4 @@
 //go:build (darwin && ignore) || !gendocs
-// +build darwin,ignore !gendocs
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/pkg/minikube/constants/constants_freebsd.go
+++ b/pkg/minikube/constants/constants_freebsd.go
@@ -1,5 +1,4 @@
 //go:build (linux && ignore) || !gendocs
-// +build linux,ignore !gendocs
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/pkg/minikube/constants/constants_gendocs.go
+++ b/pkg/minikube/constants/constants_gendocs.go
@@ -1,5 +1,4 @@
 //go:build gendocs
-// +build gendocs
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/pkg/minikube/constants/constants_linux.go
+++ b/pkg/minikube/constants/constants_linux.go
@@ -1,5 +1,4 @@
 //go:build (linux && ignore) || !gendocs
-// +build linux,ignore !gendocs
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/pkg/minikube/constants/constants_windows.go
+++ b/pkg/minikube/constants/constants_windows.go
@@ -1,5 +1,4 @@
 //go:build (windows && ignore) || !gendocs
-// +build windows,ignore !gendocs
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/pkg/minikube/perf/logs_test.go
+++ b/pkg/minikube/perf/logs_test.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin
-// +build linux darwin
 
 /*
 Copyright 2020 The Kubernetes Authors All rights reserved.

--- a/pkg/minikube/registry/drvs/hyperkit/hyperkit.go
+++ b/pkg/minikube/registry/drvs/hyperkit/hyperkit.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 /*
 Copyright 2018 The Kubernetes Authors All rights reserved.

--- a/pkg/minikube/registry/drvs/hyperkit/hyperkit_test.go
+++ b/pkg/minikube/registry/drvs/hyperkit/hyperkit_test.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 /*
 Copyright 2019 The Kubernetes Authors All rights reserved.

--- a/pkg/minikube/registry/drvs/hyperv/hyperv.go
+++ b/pkg/minikube/registry/drvs/hyperv/hyperv.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
 Copyright 2018 The Kubernetes Authors All rights reserved.
@@ -99,7 +98,7 @@ func status() registry.State {
 		cmd := exec.CommandContext(ctx, path, "-NoProfile", "-NonInteractive", "@(Get-Wmiobject Win32_ComputerSystem).HypervisorPresent")
 		out, err := cmd.CombinedOutput()
 		if err != nil {
-		 	wmiError:= fmt.Errorf("%s failed:\n%s ", strings.Join(cmd.Args, " "), out)
+			wmiError := fmt.Errorf("%s failed:\n%s ", strings.Join(cmd.Args, " "), out)
 			errorMessage := fmt.Errorf("%s\n%s", cimError, wmiError)
 			fixMessage := "Start PowerShell as an Administrator"
 			return registry.State{Installed: false, Running: true, Error: errorMessage, Fix: fixMessage, Doc: docURL}

--- a/pkg/minikube/registry/drvs/hyperv/powershell.go
+++ b/pkg/minikube/registry/drvs/hyperv/powershell.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
 Copyright 2018 The Kubernetes Authors All rights reserved.

--- a/pkg/minikube/registry/drvs/hyperv/vswitch.go
+++ b/pkg/minikube/registry/drvs/hyperv/vswitch.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
 Copyright 2019 The Kubernetes Authors All rights reserved.

--- a/pkg/minikube/registry/drvs/kvm2/kvm2.go
+++ b/pkg/minikube/registry/drvs/kvm2/kvm2.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2018 The Kubernetes Authors All rights reserved.

--- a/pkg/minikube/registry/drvs/none/none.go
+++ b/pkg/minikube/registry/drvs/none/none.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2018 The Kubernetes Authors All rights reserved.

--- a/pkg/minikube/registry/drvs/parallels/parallels.go
+++ b/pkg/minikube/registry/drvs/parallels/parallels.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 /*
 Copyright 2018 The Kubernetes Authors All rights reserved.

--- a/pkg/minikube/registry/drvs/vmwarefusion/vmwarefusion.go
+++ b/pkg/minikube/registry/drvs/vmwarefusion/vmwarefusion.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 /*
 Copyright 2018 The Kubernetes Authors All rights reserved.

--- a/pkg/minikube/schedule/daemonize_unix.go
+++ b/pkg/minikube/schedule/daemonize_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
 Copyright 2020 The Kubernetes Authors All rights reserved.

--- a/pkg/minikube/schedule/daemonize_windows.go
+++ b/pkg/minikube/schedule/daemonize_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
 Copyright 2020 The Kubernetes Authors All rights reserved.

--- a/pkg/minikube/tunnel/route_darwin_test.go
+++ b/pkg/minikube/tunnel/route_darwin_test.go
@@ -1,5 +1,4 @@
 //go:build darwin && integration
-// +build darwin,integration
 
 /*
 Copyright 2018 The Kubernetes Authors All rights reserved.

--- a/pkg/minikube/tunnel/route_linux_test.go
+++ b/pkg/minikube/tunnel/route_linux_test.go
@@ -1,5 +1,4 @@
 //go:build linux && integration
-// +build linux,integration
 
 /*
 Copyright 2018 The Kubernetes Authors All rights reserved.

--- a/pkg/minikube/tunnel/route_windows_test.go
+++ b/pkg/minikube/tunnel/route_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows && integration
-// +build windows,integration
 
 /*
 Copyright 2018 The Kubernetes Authors All rights reserved.

--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
 Copyright 2019 The Kubernetes Authors All rights reserved.

--- a/test/integration/aab_offline_test.go
+++ b/test/integration/aab_offline_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/test/integration/cert_options_test.go
+++ b/test/integration/cert_options_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/test/integration/docker_test.go
+++ b/test/integration/docker_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/test/integration/error_spam_test.go
+++ b/test/integration/error_spam_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/test/integration/functional_test_mount_test.go
+++ b/test/integration/functional_test_mount_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/test/integration/functional_test_pvc_test.go
+++ b/test/integration/functional_test_pvc_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/test/integration/functional_test_tunnel_test.go
+++ b/test/integration/functional_test_tunnel_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
 Copyright 2018 The Kubernetes Authors All rights reserved.

--- a/test/integration/guest_env_test.go
+++ b/test/integration/guest_env_test.go
@@ -1,5 +1,4 @@
 //go:build iso
-// +build iso
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/test/integration/gvisor_addon_test.go
+++ b/test/integration/gvisor_addon_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/test/integration/ingress_addon_legacy_test.go
+++ b/test/integration/ingress_addon_legacy_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
 Copyright 2021 The Kubernetes Authors All rights reserved.

--- a/test/integration/kic_custom_network_test.go
+++ b/test/integration/kic_custom_network_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
 Copyright 2020 The Kubernetes Authors All rights reserved.

--- a/test/integration/mount_start_test.go
+++ b/test/integration/mount_start_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
 Copyright 2021 The Kubernetes Authors All rights reserved.

--- a/test/integration/multinode_test.go
+++ b/test/integration/multinode_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
 Copyright 2020 The Kubernetes Authors All rights reserved.

--- a/test/integration/net_test.go
+++ b/test/integration/net_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/test/integration/no_kubernetes_test.go
+++ b/test/integration/no_kubernetes_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
 Copyright 2021 The Kubernetes Authors All rights reserved.

--- a/test/integration/none_test.go
+++ b/test/integration/none_test.go
@@ -1,5 +1,4 @@
 //go:build integration && linux
-// +build integration,linux
 
 /*
 Copyright 2019 The Kubernetes Authors All rights reserved.

--- a/test/integration/pause_test.go
+++ b/test/integration/pause_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
 Copyright 2020 The Kubernetes Authors All rights reserved.

--- a/test/integration/preload_test.go
+++ b/test/integration/preload_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
 Copyright 2020 The Kubernetes Authors All rights reserved.

--- a/test/integration/scheduled_stop_test.go
+++ b/test/integration/scheduled_stop_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
 Copyright 2020 The Kubernetes Authors All rights reserved.

--- a/test/integration/skaffold_test.go
+++ b/test/integration/skaffold_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
 Copyright 2020 The Kubernetes Authors All rights reserved.

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/test/integration/status_test.go
+++ b/test/integration/status_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/third_party/go9p/clnt_stats_http.go
+++ b/third_party/go9p/clnt_stats_http.go
@@ -1,5 +1,4 @@
 //go:build httpstats
-// +build httpstats
 
 package go9p
 

--- a/third_party/go9p/srv_stats_http.go
+++ b/third_party/go9p/srv_stats_http.go
@@ -1,5 +1,4 @@
 //go:build httpstats
-// +build httpstats
 
 package go9p
 

--- a/third_party/kubeadm/app/constants/constants_unix.go
+++ b/third_party/kubeadm/app/constants/constants_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
 Copyright 2019 The Kubernetes Authors.

--- a/third_party/kubeadm/app/constants/constants_windows.go
+++ b/third_party/kubeadm/app/constants/constants_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
 Copyright 2019 The Kubernetes Authors.


### PR DESCRIPTION
Since updating to Go 1.18, removing old build tags

Go release notes:

Go 1.17 introduced //go:build lines as a more readable way to write build constraints, instead of // +build lines. As of Go 1.17, gofmt adds //go:build lines to match existing +build lines and keeps them in sync, while go vet diagnoses when they are out of sync.

Since the release of Go 1.18 marks the end of support for Go 1.16, all supported versions of Go now understand //go:build lines. In Go 1.18, go fix now removes the now-obsolete // +build lines in modules declaring go 1.17 or later in their go.mod files.

For more information, see https://go.dev/design/draft-gobuild.