### PR TITLE
Remove unnecessary icacls check

### DIFF
--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -262,10 +262,6 @@ func (d *Driver) prepareSSH() error {
 			if icaclsCmdErr != nil {
 				return errors.Wrap(icaclsCmdErr, fmt.Sprintf("unable to execute icacls to set permissions: %s", icaclsCmdOut))
 			}
-
-			if !strings.Contains(string(icaclsCmdOut), "Successfully processed 1 files; Failed processing 0 files") {
-				klog.Errorf("icacls failed applying permissions - err - [%s], output - [%s]", icaclsCmdErr, strings.TrimSpace(string(icaclsCmdOut)))
-			}
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/13868

**Problem:**
We have a string comparison checking if the command successfully based on the output of the command. However, the string comparison is hard coded to English, so if the users OS is in a different language, the check will fail and we output to the user that the command failed, which is false.

**Solution:**
I did some checking and found the following:
```
> icacls cat
cat NT AUTHORITY\SYSTEM:(I)(OI)(CI)(F)
    BUILTIN\Administrators:(I)(OI)(CI)(F)
    mini-manual-2\jenkins:(I)(OI)(CI)(F)

> $?
True

> icacls dog
dog: The system cannot find the file specified.
Successfully processed 0 files; Failed processing 1 files

> $?
False
```
If the command fails, it will be detected as an error, which we already have a check for, so the string comparison check is redundant and can safely be removed.