### PR TITLE
remove uses of ioutil & use t.TempDir for tests

### DIFF
--- a/cmd/minikube/cmd/config/set_test.go
+++ b/cmd/minikube/cmd/config/set_test.go
@@ -66,29 +66,18 @@ func TestSetOK(t *testing.T) {
 
 func createTestConfig(t *testing.T) {
 	t.Helper()
-	td, err := os.MkdirTemp("", "config")
-	if err != nil {
-		t.Fatalf("tempdir: %v", err)
-	}
+	td := t.TempDir()
 
-	err = os.Setenv(localpath.MinikubeHome, td)
-	if err != nil {
+	if err := os.Setenv(localpath.MinikubeHome, td); err != nil {
 		t.Fatalf("error setting up test environment. could not set %s due to %+v", localpath.MinikubeHome, err)
 	}
 
 	// Not necessary, but it is a handy random alphanumeric
-	if err = os.MkdirAll(localpath.MakeMiniPath("config"), 0777); err != nil {
+	if err := os.MkdirAll(localpath.MakeMiniPath("config"), 0777); err != nil {
 		t.Fatalf("error creating temporary directory: %+v", err)
 	}
 
-	if err = os.MkdirAll(localpath.MakeMiniPath("profiles"), 0777); err != nil {
+	if err := os.MkdirAll(localpath.MakeMiniPath("profiles"), 0777); err != nil {
 		t.Fatalf("error creating temporary profiles directory: %+v", err)
 	}
-
-	t.Cleanup(func() {
-		err := os.RemoveAll(td)
-		if err != nil {
-			t.Errorf("failed to clean up temp folder  %q", td)
-		}
-	})
 }

--- a/cmd/minikube/cmd/delete_test.go
+++ b/cmd/minikube/cmd/delete_test.go
@@ -63,20 +63,9 @@ func fileNames(path string) ([]string, error) {
 }
 
 func TestDeleteProfile(t *testing.T) {
-	td, err := os.MkdirTemp("", "single")
-	if err != nil {
-		t.Fatalf("tempdir: %v", err)
-	}
+	td := t.TempDir()
 
-	t.Cleanup(func() {
-		err := os.RemoveAll(td)
-		if err != nil {
-			t.Errorf("failed to clean up temp folder  %q", td)
-		}
-	})
-
-	err = copy.Copy("../../../pkg/minikube/config/testdata/delete-single", td)
-	if err != nil {
+	if err := copy.Copy("../../../pkg/minikube/config/testdata/delete-single", td); err != nil {
 		t.Fatalf("copy: %v", err)
 	}
 
@@ -97,8 +86,7 @@ func TestDeleteProfile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err = os.Setenv(localpath.MinikubeHome, td)
-			if err != nil {
+			if err := os.Setenv(localpath.MinikubeHome, td); err != nil {
 				t.Errorf("setenv: %v", err)
 			}
 
@@ -169,24 +157,13 @@ func deleteContextTest() error {
 }
 
 func TestDeleteAllProfiles(t *testing.T) {
-	td, err := os.MkdirTemp("", "all")
-	if err != nil {
-		t.Fatalf("tempdir: %v", err)
-	}
-	defer func() { // clean up tempdir
-		err := os.RemoveAll(td)
-		if err != nil {
-			t.Errorf("failed to clean up temp folder  %q", td)
-		}
-	}()
+	td := t.TempDir()
 
-	err = copy.Copy("../../../pkg/minikube/config/testdata/delete-all", td)
-	if err != nil {
+	if err := copy.Copy("../../../pkg/minikube/config/testdata/delete-all", td); err != nil {
 		t.Fatalf("copy: %v", err)
 	}
 
-	err = os.Setenv(localpath.MinikubeHome, td)
-	if err != nil {
+	if err := os.Setenv(localpath.MinikubeHome, td); err != nil {
 		t.Errorf("error setting up test environment. could not set %s", localpath.MinikubeHome)
 	}
 

--- a/cmd/minikube/cmd/generate-docs_test.go
+++ b/cmd/minikube/cmd/generate-docs_test.go
@@ -26,15 +26,10 @@ import (
 )
 
 func TestGenerateTestDocs(t *testing.T) {
-	tempdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatalf("creating temp dir failed: %v", err)
-	}
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 	docPath := filepath.Join(tempdir, "tests.md")
 
-	err = generate.TestDocs(docPath, "../../../test/integration")
-	if err != nil {
+	if err := generate.TestDocs(docPath, "../../../test/integration"); err != nil {
 		t.Fatalf("error generating test docs: %v", err)
 	}
 	actualContents, err := os.ReadFile(docPath)

--- a/cmd/minikube/cmd/root_test.go
+++ b/cmd/minikube/cmd/root_test.go
@@ -34,8 +34,7 @@ func runCommand(f func(*cobra.Command, []string)) {
 
 func TestPreRunDirectories(t *testing.T) {
 	// Make sure we create the required directories.
-	tempDir := tests.MakeTempDir()
-	defer tests.RemoveTempDir(tempDir)
+	tests.MakeTempDir(t)
 
 	runCommand(RootCmd.PersistentPreRun)
 

--- a/deploy/minikube/schema_check.go
+++ b/deploy/minikube/schema_check.go
@@ -19,7 +19,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -40,7 +39,7 @@ func validateSchema(schemaPathString, docPathString string) {
 		log.Fatal(err)
 	}
 
-	data, err := ioutil.ReadFile(docPathString)
+	data, err := os.ReadFile(docPathString)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/addons/addons_test.go
+++ b/pkg/addons/addons_test.go
@@ -30,20 +30,9 @@ import (
 
 func createTestProfile(t *testing.T) string {
 	t.Helper()
-	td, err := os.MkdirTemp("", "profile")
-	if err != nil {
-		t.Fatalf("tempdir: %v", err)
-	}
+	td := t.TempDir()
 
-	t.Cleanup(func() {
-		err := os.RemoveAll(td)
-		t.Logf("remove path %q", td)
-		if err != nil {
-			t.Errorf("failed to clean up temp folder  %q", td)
-		}
-	})
-	err = os.Setenv(localpath.MinikubeHome, td)
-	if err != nil {
+	if err := os.Setenv(localpath.MinikubeHome, td); err != nil {
 		t.Errorf("error setting up test environment. could not set %s", localpath.MinikubeHome)
 	}
 
@@ -130,8 +119,7 @@ func TestSetAndSave(t *testing.T) {
 
 func TestStart(t *testing.T) {
 	// this test will write a config.json into MinikubeHome, create a temp dir for it
-	tempDir := tests.MakeTempDir()
-	defer tests.RemoveTempDir(tempDir)
+	tests.MakeTempDir(t)
 
 	cc := &config.ClusterConfig{
 		Name:             "start",

--- a/pkg/drivers/common_test.go
+++ b/pkg/drivers/common_test.go
@@ -25,8 +25,7 @@ import (
 )
 
 func Test_createDiskImage(t *testing.T) {
-	tmpdir := tests.MakeTempDir()
-	defer tests.RemoveTempDir(tmpdir)
+	tmpdir := tests.MakeTempDir(t)
 
 	sshPath := filepath.Join(tmpdir, "ssh")
 	if err := os.WriteFile(sshPath, []byte("mysshkey"), 0644); err != nil {

--- a/pkg/drivers/hyperkit/iso_test.go
+++ b/pkg/drivers/hyperkit/iso_test.go
@@ -17,21 +17,11 @@ limitations under the License.
 package hyperkit
 
 import (
-	"os"
 	"testing"
 )
 
 func TestExtractFile(t *testing.T) {
-	testDir, err := os.MkdirTemp(os.TempDir(), "")
-	if nil != err {
-		return
-	}
-	defer func() { // clean up tempdir
-		err := os.RemoveAll(testDir)
-		if err != nil {
-			t.Errorf("failed to clean up temp folder  %q", testDir)
-		}
-	}()
+	testDir := t.TempDir()
 
 	tests := []struct {
 		name          string

--- a/pkg/drivers/hyperkit/network_test.go
+++ b/pkg/drivers/hyperkit/network_test.go
@@ -49,8 +49,7 @@ var validLeases = []byte(`{
 }`)
 
 func Test_getIpAddressFromFile(t *testing.T) {
-	tmpdir := tests.MakeTempDir()
-	defer tests.RemoveTempDir(tmpdir)
+	tmpdir := tests.MakeTempDir(t)
 
 	dhcpFile := filepath.Join(tmpdir, "dhcp")
 	if err := os.WriteFile(dhcpFile, validLeases, 0644); err != nil {

--- a/pkg/minikube/bootstrapper/certs_test.go
+++ b/pkg/minikube/bootstrapper/certs_test.go
@@ -29,8 +29,7 @@ import (
 )
 
 func TestSetupCerts(t *testing.T) {
-	tempDir := tests.MakeTempDir()
-	defer tests.RemoveTempDir(tempDir)
+	tempDir := tests.MakeTempDir(t)
 
 	k8s := config.ClusterConfig{
 		CertExpiration: constants.DefaultCertExpiration,

--- a/pkg/minikube/extract/extract_test.go
+++ b/pkg/minikube/extract/extract_test.go
@@ -32,16 +32,7 @@ func TestExtract(t *testing.T) {
 	// The function we care about
 	functions := []string{"extract.PrintToScreen"}
 
-	tempdir, err := os.MkdirTemp("", "temptestdata")
-	if err != nil {
-		t.Fatalf("Creating temp dir: %v", err)
-	}
-	defer func() { // clean up tempdir
-		err := os.RemoveAll(tempdir)
-		if err != nil {
-			t.Errorf("failed to clean up temp folder  %q", tempdir)
-		}
-	}()
+	tempdir := t.TempDir()
 
 	src, err := os.ReadFile("testdata/test.json")
 	if err != nil {

--- a/pkg/minikube/kubeconfig/kubeconfig_test.go
+++ b/pkg/minikube/kubeconfig/kubeconfig_test.go
@@ -228,16 +228,7 @@ func TestUpdate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			tmpDir, err := os.MkdirTemp("", "")
-			if err != nil {
-				t.Fatalf("Error making temp directory %v", err)
-			}
-			defer func() { // clean up tempdir
-				err := os.RemoveAll(tmpDir)
-				if err != nil {
-					t.Errorf("failed to clean up temp folder  %q", tmpDir)
-				}
-			}()
+			tmpDir := t.TempDir()
 
 			test.cfg.SetPath(filepath.Join(tmpDir, "kubeconfig"))
 			if len(test.existingCfg) != 0 {
@@ -245,7 +236,7 @@ func TestUpdate(t *testing.T) {
 					t.Fatalf("WriteFile: %v", err)
 				}
 			}
-			err = Update(test.cfg)
+			err := Update(test.cfg)
 			if err != nil && !test.err {
 				t.Errorf("Got unexpected error: %v", err)
 			}
@@ -459,16 +450,7 @@ func TestEmptyConfig(t *testing.T) {
 }
 
 func TestNewConfig(t *testing.T) {
-	dir, err := os.MkdirTemp("", ".kube")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		err := os.RemoveAll(dir)
-		if err != nil {
-			t.Errorf("Failed to remove dir %q: %v", dir, err)
-		}
-	}()
+	dir := t.TempDir()
 
 	// setup minikube config
 	expected := api.NewConfig()
@@ -476,8 +458,7 @@ func TestNewConfig(t *testing.T) {
 
 	// write actual
 	filename := filepath.Join(dir, "config")
-	err = writeToFile(expected, filename)
-	if err != nil {
+	if err := writeToFile(expected, filename); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/minikube/localpath/localpath_test.go
+++ b/pkg/minikube/localpath/localpath_test.go
@@ -28,16 +28,7 @@ import (
 )
 
 func TestReplaceWinDriveLetterToVolumeName(t *testing.T) {
-	path, err := os.MkdirTemp("", "repwindl2vn")
-	if err != nil {
-		t.Fatalf("Error make tmp directory: %v", err)
-	}
-	defer func(path string) { // clean up tempdir
-		err := os.RemoveAll(path)
-		if err != nil {
-			t.Errorf("failed to clean up temp folder  %q", path)
-		}
-	}(path)
+	path := t.TempDir()
 
 	if runtime.GOOS != "windows" {
 		// Replace to fake func.

--- a/pkg/minikube/machine/cache_binaries_test.go
+++ b/pkg/minikube/machine/cache_binaries_test.go
@@ -88,17 +88,7 @@ func TestCacheBinariesForBootstrapper(t *testing.T) {
 	oldMinikubeHome := os.Getenv("MINIKUBE_HOME")
 	defer os.Setenv("MINIKUBE_HOME", oldMinikubeHome)
 
-	minikubeHome, err := os.MkdirTemp("/tmp", "")
-	if err != nil {
-		t.Fatalf("error during creating tmp dir: %v", err)
-	}
-
-	defer func() { // clean up tempdir
-		err := os.RemoveAll(minikubeHome)
-		if err != nil {
-			t.Errorf("failed to clean up temp folder  %q", minikubeHome)
-		}
-	}()
+	minikubeHome := t.TempDir()
 
 	var tc = []struct {
 		version, clusterBootstrapper string
@@ -147,18 +137,8 @@ func TestExcludedBinariesNotDownloaded(t *testing.T) {
 	oldMinikubeHome := os.Getenv("MINIKUBE_HOME")
 	defer os.Setenv("MINIKUBE_HOME", oldMinikubeHome)
 
-	minikubeHome, err := os.MkdirTemp("/tmp", "")
-	if err != nil {
-		t.Fatalf("error during creating tmp dir: %v", err)
-	}
+	minikubeHome := t.TempDir()
 	os.Setenv("MINIKUBE_HOME", minikubeHome)
-
-	defer func() { // clean up tempdir
-		err := os.RemoveAll(minikubeHome)
-		if err != nil {
-			t.Errorf("failed to clean up temp folder  %q", minikubeHome)
-		}
-	}()
 
 	if err := CacheBinariesForBootstrapper("v1.16.0", clusterBootstrapper, []string{binaryToExclude}, ""); err != nil {
 		t.Errorf("Failed to cache binaries: %v", err)

--- a/pkg/minikube/machine/client_test.go
+++ b/pkg/minikube/machine/client_test.go
@@ -111,8 +111,7 @@ func TestLocalClientNewHost(t *testing.T) {
 }
 
 func TestRunNotDriver(t *testing.T) {
-	tempDir := testutil.MakeTempDir()
-	defer testutil.RemoveTempDir(tempDir)
+	testutil.MakeTempDir(t)
 	StartDriver()
 	if !localbinary.CurrentBinaryIsDockerMachine {
 		t.Fatal("CurrentBinaryIsDockerMachine not set. This will break driver initialization.")
@@ -122,8 +121,7 @@ func TestRunNotDriver(t *testing.T) {
 func TestRunDriver(t *testing.T) {
 	// This test is a bit complicated. It verifies that when the root command is
 	// called with the proper environment variables, we setup the libmachine driver.
-	tempDir := testutil.MakeTempDir()
-	defer testutil.RemoveTempDir(tempDir)
+	testutil.MakeTempDir(t)
 
 	os.Setenv(localbinary.PluginEnvKey, localbinary.PluginEnvVal)
 	os.Setenv(localbinary.PluginEnvDriverName, driver.VirtualBox)

--- a/pkg/minikube/machine/cluster_test.go
+++ b/pkg/minikube/machine/cluster_test.go
@@ -72,8 +72,7 @@ var defaultClusterConfig = config.ClusterConfig{
 }
 
 func TestCreateHost(t *testing.T) {
-	tempDir := tests.MakeTempDir()
-	defer tests.RemoveTempDir(tempDir)
+	tests.MakeTempDir(t)
 
 	download.DownloadMock = download.CreateDstDownloadMock
 
@@ -120,8 +119,7 @@ func TestCreateHost(t *testing.T) {
 }
 
 func TestStartHostExists(t *testing.T) {
-	tempDir := tests.MakeTempDir()
-	defer tests.RemoveTempDir(tempDir)
+	tests.MakeTempDir(t)
 
 	download.DownloadMock = download.CreateDstDownloadMock
 
@@ -160,8 +158,7 @@ func TestStartHostExists(t *testing.T) {
 }
 
 func TestStartHostErrMachineNotExist(t *testing.T) {
-	tempDir := tests.MakeTempDir()
-	defer tests.RemoveTempDir(tempDir)
+	tests.MakeTempDir(t)
 
 	download.DownloadMock = download.CreateDstDownloadMock
 
@@ -210,8 +207,7 @@ func TestStartHostErrMachineNotExist(t *testing.T) {
 }
 
 func TestStartStoppedHost(t *testing.T) {
-	tempDir := tests.MakeTempDir()
-	defer tests.RemoveTempDir(tempDir)
+	tests.MakeTempDir(t)
 
 	download.DownloadMock = download.CreateDstDownloadMock
 
@@ -250,8 +246,7 @@ func TestStartStoppedHost(t *testing.T) {
 }
 
 func TestStartHost(t *testing.T) {
-	tempDir := tests.MakeTempDir()
-	defer tests.RemoveTempDir(tempDir)
+	tests.MakeTempDir(t)
 
 	download.DownloadMock = download.CreateDstDownloadMock
 
@@ -283,8 +278,7 @@ func TestStartHost(t *testing.T) {
 }
 
 func TestStartHostConfig(t *testing.T) {
-	tempDir := tests.MakeTempDir()
-	defer tests.RemoveTempDir(tempDir)
+	tests.MakeTempDir(t)
 
 	download.DownloadMock = download.CreateDstDownloadMock
 
@@ -328,8 +322,7 @@ func TestStopHostError(t *testing.T) {
 }
 
 func TestStopHost(t *testing.T) {
-	tempDir := tests.MakeTempDir()
-	defer tests.RemoveTempDir(tempDir)
+	tests.MakeTempDir(t)
 
 	RegisterMockDriver(t)
 	api := tests.NewMockAPI(t)
@@ -350,8 +343,7 @@ func TestStopHost(t *testing.T) {
 }
 
 func TestDeleteHost(t *testing.T) {
-	tempDir := tests.MakeTempDir()
-	defer tests.RemoveTempDir(tempDir)
+	tests.MakeTempDir(t)
 
 	RegisterMockDriver(t)
 	api := tests.NewMockAPI(t)
@@ -368,8 +360,7 @@ func TestDeleteHost(t *testing.T) {
 }
 
 func TestDeleteHostErrorDeletingVM(t *testing.T) {
-	tempDir := tests.MakeTempDir()
-	defer tests.RemoveTempDir(tempDir)
+	tests.MakeTempDir(t)
 
 	RegisterMockDriver(t)
 	api := tests.NewMockAPI(t)
@@ -387,8 +378,7 @@ func TestDeleteHostErrorDeletingVM(t *testing.T) {
 }
 
 func TestDeleteHostErrorDeletingFiles(t *testing.T) {
-	tempDir := tests.MakeTempDir()
-	defer tests.RemoveTempDir(tempDir)
+	tests.MakeTempDir(t)
 
 	RegisterMockDriver(t)
 	api := tests.NewMockAPI(t)
@@ -403,8 +393,7 @@ func TestDeleteHostErrorDeletingFiles(t *testing.T) {
 }
 
 func TestDeleteHostErrMachineNotExist(t *testing.T) {
-	tempDir := tests.MakeTempDir()
-	defer tests.RemoveTempDir(tempDir)
+	tests.MakeTempDir(t)
 
 	RegisterMockDriver(t)
 	api := tests.NewMockAPI(t)
@@ -421,8 +410,7 @@ func TestDeleteHostErrMachineNotExist(t *testing.T) {
 }
 
 func TestStatus(t *testing.T) {
-	tempDir := tests.MakeTempDir()
-	defer tests.RemoveTempDir(tempDir)
+	tests.MakeTempDir(t)
 
 	RegisterMockDriver(t)
 	api := tests.NewMockAPI(t)

--- a/pkg/minikube/machine/filesync_test.go
+++ b/pkg/minikube/machine/filesync_test.go
@@ -97,8 +97,7 @@ func TestAssetsFromDir(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			testDir := testutil.MakeTempDir()
-			defer testutil.RemoveTempDir(testDir)
+			testDir := testutil.MakeTempDir(t)
 
 			testDirs = append(testDirs, testDir)
 			testFileBaseDir := filepath.Join(testDir, test.baseDir)

--- a/pkg/minikube/notify/notify_test.go
+++ b/pkg/minikube/notify/notify_test.go
@@ -36,8 +36,7 @@ import (
 )
 
 func TestShouldCheckURLVersion(t *testing.T) {
-	tempDir := tests.MakeTempDir()
-	defer tests.RemoveTempDir(tempDir)
+	tempDir := tests.MakeTempDir(t)
 
 	lastUpdateCheckFilePath := filepath.Join(tempDir, "last_update_check")
 
@@ -75,8 +74,7 @@ func TestShouldCheckURLVersion(t *testing.T) {
 }
 
 func TestShouldCheckURLBetaVersion(t *testing.T) {
-	tempDir := tests.MakeTempDir()
-	defer tests.RemoveTempDir(tempDir)
+	tempDir := tests.MakeTempDir(t)
 
 	lastUpdateCheckFilePath := filepath.Join(tempDir, "last_update_check")
 	viper.Set(config.WantUpdateNotification, true)
@@ -169,8 +167,7 @@ var mockLatestVersionFromURL = semver.Make
 func TestMaybePrintUpdateText(t *testing.T) {
 	latestVersionFromURL = mockLatestVersionFromURL
 
-	tempDir := tests.MakeTempDir()
-	defer tests.RemoveTempDir(tempDir)
+	tempDir := tests.MakeTempDir(t)
 
 	var tc = []struct {
 		wantUpdateNotification     bool

--- a/pkg/minikube/tests/dir_utils.go
+++ b/pkg/minikube/tests/dir_utils.go
@@ -18,38 +18,25 @@ package tests
 
 import (
 	"bytes"
-	"log"
 	"os"
 	"path/filepath"
+	"testing"
 
 	"k8s.io/minikube/pkg/minikube/localpath"
 )
 
 // MakeTempDir creates the temp dir and returns the path
-func MakeTempDir() string {
-	tempDir, err := os.MkdirTemp("", "minipath")
-	if err != nil {
-		log.Fatal(err)
-	}
+func MakeTempDir(t *testing.T) string {
+	tempDir := t.TempDir()
 	tempDir = filepath.Join(tempDir, ".minikube")
-	err = os.MkdirAll(filepath.Join(tempDir, "addons"), 0777)
-	if err != nil {
-		log.Fatal(err)
+	if err := os.MkdirAll(filepath.Join(tempDir, "addons"), 0777); err != nil {
+		t.Fatal(err)
 	}
-	err = os.MkdirAll(filepath.Join(tempDir, "cache"), 0777)
-	if err != nil {
-		log.Fatal(err)
+	if err := os.MkdirAll(filepath.Join(tempDir, "cache"), 0777); err != nil {
+		t.Fatal(err)
 	}
 	os.Setenv(localpath.MinikubeHome, tempDir)
 	return localpath.MiniPath()
-}
-
-// RemoveTempDir removes the temp dir
-func RemoveTempDir(tempdir string) {
-	if filepath.Base(tempdir) == ".minikube" {
-		tempdir = filepath.Dir(tempdir)
-	}
-	os.RemoveAll(tempdir)
 }
 
 // FakeFile satisfies fdWriter

--- a/pkg/util/crypto_test.go
+++ b/pkg/util/crypto_test.go
@@ -28,16 +28,7 @@ import (
 )
 
 func TestGenerateCACert(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "")
-	defer func() { // clean up tempdir
-		err := os.RemoveAll(tmpDir)
-		if err != nil {
-			t.Errorf("failed to clean up temp folder  %q", tmpDir)
-		}
-	}()
-	if err != nil {
-		t.Fatalf("Error generating tmpdir: %v", err)
-	}
+	tmpDir := t.TempDir()
 
 	certPath := filepath.Join(tmpDir, "cert")
 	keyPath := filepath.Join(tmpDir, "key")
@@ -61,33 +52,13 @@ func TestGenerateCACert(t *testing.T) {
 }
 
 func TestGenerateSignedCert(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "")
-	defer func() { // clean up tempdir
-		err := os.RemoveAll(tmpDir)
-		if err != nil {
-			t.Errorf("failed to clean up temp folder  %q", tmpDir)
-		}
-	}()
-	if err != nil {
-		t.Fatalf("Error generating tmpdir: %v", err)
-	}
-
-	signerTmpDir, err := os.MkdirTemp("", "")
-	defer func() { // clean up tempdir
-		err := os.RemoveAll(signerTmpDir)
-		if err != nil {
-			t.Errorf("failed to clean up temp folder  %q", signerTmpDir)
-		}
-	}()
-	if err != nil {
-		t.Fatalf("Error generating signer tmpdir: %v", err)
-	}
+	tmpDir := t.TempDir()
+	signerTmpDir := t.TempDir()
 
 	validSignerCertPath := filepath.Join(signerTmpDir, "cert")
 	validSignerKeyPath := filepath.Join(signerTmpDir, "key")
 
-	err = GenerateCACert(validSignerCertPath, validSignerKeyPath, constants.APIServerName)
-	if err != nil {
+	if err := GenerateCACert(validSignerCertPath, validSignerKeyPath, constants.APIServerName); err != nil {
 		t.Fatalf("Error generating signer cert")
 	}
 

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -80,20 +80,10 @@ func TestParseKubernetesVersion(t *testing.T) {
 }
 
 func TestChownR(t *testing.T) {
-	testDir, err := os.MkdirTemp(os.TempDir(), "")
-	if nil != err {
+	testDir := t.TempDir()
+	if _, err := os.Create(testDir + "/TestChownR"); err != nil {
 		return
 	}
-	_, err = os.Create(testDir + "/TestChownR")
-	if nil != err {
-		return
-	}
-	defer func() { // clean up tempdir
-		err := os.RemoveAll(testDir)
-		if err != nil {
-			t.Errorf("failed to clean up temp folder  %q", testDir)
-		}
-	}()
 
 	cases := []struct {
 		name          string
@@ -122,7 +112,7 @@ func TestChownR(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			err = ChownR(testDir+"/TestChownR", c.uid, c.gid)
+			err := ChownR(testDir+"/TestChownR", c.uid, c.gid)
 			fileInfo, _ := os.Stat(testDir + "/TestChownR")
 			fileSys := fileInfo.Sys()
 			if (nil != err) != c.expectedError || ((false == c.expectedError) && (fileSys.(*syscall.Stat_t).Gid != uint32(c.gid) || fileSys.(*syscall.Stat_t).Uid != uint32(c.uid))) {
@@ -133,25 +123,13 @@ func TestChownR(t *testing.T) {
 }
 
 func TestMaybeChownDirRecursiveToMinikubeUser(t *testing.T) {
-	testDir, err := os.MkdirTemp(os.TempDir(), "")
-	if nil != err {
+	testDir := t.TempDir()
+	if _, err := os.Create(testDir + "/TestChownR"); nil != err {
 		return
 	}
-	_, err = os.Create(testDir + "/TestChownR")
-	if nil != err {
-		return
-	}
-
-	defer func() { // clean up tempdir
-		err := os.RemoveAll(testDir)
-		if err != nil {
-			t.Errorf("failed to clean up temp folder  %q", testDir)
-		}
-	}()
 
 	if os.Getenv("CHANGE_MINIKUBE_NONE_USER") == "" {
-		err = os.Setenv("CHANGE_MINIKUBE_NONE_USER", "1")
-		if nil != err {
+		if err := os.Setenv("CHANGE_MINIKUBE_NONE_USER", "1"); nil != err {
 			t.Error("failed to set env: CHANGE_MINIKUBE_NONE_USER")
 		}
 	}
@@ -187,7 +165,7 @@ func TestMaybeChownDirRecursiveToMinikubeUser(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			err = MaybeChownDirRecursiveToMinikubeUser(c.dir)
+			err := MaybeChownDirRecursiveToMinikubeUser(c.dir)
 			if (nil != err) != c.expectedError {
 				t.Errorf("expectedError: %v, got: %v", c.expectedError, err)
 			}

--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -274,11 +274,7 @@ func TestBinaryMirror(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), Minutes(10))
 	defer Cleanup(t, profile, cancel)
 
-	tmpDir, err := os.MkdirTemp("", "kb_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	// Start test server which will serve binary files
 	ts := httptest.NewServer(

--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -26,7 +26,6 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -275,7 +274,7 @@ func TestBinaryMirror(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), Minutes(10))
 	defer Cleanup(t, profile, cancel)
 
-	tmpDir, err := ioutil.TempDir("", "kb_test")
+	tmpDir, err := os.MkdirTemp("", "kb_test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/driver_install_or_update_test.go
+++ b/test/integration/driver_install_or_update_test.go
@@ -59,16 +59,7 @@ func TestKVMDriverInstallOrUpdate(t *testing.T) {
 	defer os.Setenv("PATH", originalPath)
 
 	for _, tc := range tests {
-		dir, err := os.MkdirTemp("", tc.name)
-		if err != nil {
-			t.Fatalf("Expected to create tempdir. test: %s, got: %v", tc.name, err)
-		}
-		defer func() {
-			err := os.RemoveAll(dir)
-			if err != nil {
-				t.Errorf("Failed to remove dir %q: %v", dir, err)
-			}
-		}()
+		dir := t.TempDir()
 
 		pwd, err := os.Getwd()
 		if err != nil {
@@ -128,16 +119,7 @@ func TestHyperKitDriverInstallOrUpdate(t *testing.T) {
 	defer os.Setenv("PATH", originalPath)
 
 	for _, tc := range tests {
-		dir, err := os.MkdirTemp("", tc.name)
-		if err != nil {
-			t.Fatalf("Expected to create tempdir. test: %s, got: %v", tc.name, err)
-		}
-		defer func() {
-			err := os.RemoveAll(dir)
-			if err != nil {
-				t.Errorf("Failed to remove dir %q: %v", dir, err)
-			}
-		}()
+		dir := t.TempDir()
 
 		pwd, err := os.Getwd()
 		if err != nil {
@@ -212,15 +194,10 @@ func TestHyperkitDriverSkipUpgrade(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			mkDir, drvPath, err := prepareTempMinikubeDirWithHyperkitDriver(tc.name, tc.path)
+			mkDir, drvPath, err := prepareTempMinikubeDirWithHyperkitDriver(t, tc.name, tc.path)
 			if err != nil {
 				t.Fatalf("Failed to prepare tempdir. test: %s, got: %v", tc.name, err)
 			}
-			defer func() {
-				if err := os.RemoveAll(mkDir); err != nil {
-					t.Errorf("Failed to remove mkDir %q: %v", mkDir, err)
-				}
-			}()
 
 			cmd := exec.Command(Target(), "start", "--download-only", "--interactive=false", "--driver=hyperkit")
 			cmd.Stdout = os.Stdout
@@ -265,15 +242,11 @@ func driverVersion(path string) (string, error) {
 
 // prepareTempMinikubeDirWithHyperkitDriver creates a temp .minikube directory
 // with structure essential to testing of hyperkit driver updates
-func prepareTempMinikubeDirWithHyperkitDriver(name, driver string) (string, string, error) {
-	temp, err := os.MkdirTemp("", name)
-	if err != nil {
-		return "", "", fmt.Errorf("failed to create tempdir: %v", err)
-	}
+func prepareTempMinikubeDirWithHyperkitDriver(t *testing.T, name, driver string) (string, string, error) {
+	temp := t.TempDir()
 	mkDir := filepath.Join(temp, ".minikube")
 	mkBinDir := filepath.Join(mkDir, "bin")
-	err = os.MkdirAll(mkBinDir, 0777)
-	if err != nil {
+	if err := os.MkdirAll(mkBinDir, 0777); err != nil {
 		return "", "", fmt.Errorf("failed to prepare tempdir: %v", err)
 	}
 

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -1059,10 +1059,7 @@ func validateCacheCmd(ctx context.Context, t *testing.T, profile string) {
 				t.Skipf("docker is not installed, skipping local image test")
 			}
 
-			dname, err := os.MkdirTemp("", profile)
-			if err != nil {
-				t.Fatalf("Cannot create temp dir: %v", err)
-			}
+			dname := t.TempDir()
 
 			message := []byte("FROM scratch\nADD Dockerfile /x")
 			err = os.WriteFile(filepath.Join(dname, "Dockerfile"), message, 0644)
@@ -1241,10 +1238,7 @@ func validateLogsCmd(ctx context.Context, t *testing.T, profile string) {
 
 // validateLogsFileCmd asserts "logs --file" command functionality
 func validateLogsFileCmd(ctx context.Context, t *testing.T, profile string) {
-	dname, err := os.MkdirTemp("", profile)
-	if err != nil {
-		t.Fatalf("Cannot create temp dir: %v", err)
-	}
+	dname := t.TempDir()
 	logFileName := filepath.Join(dname, "logs.txt")
 
 	// docs: Run `minikube logs --file logs.txt` to save the logs to a local file
@@ -1709,11 +1703,7 @@ func validateCpCmd(ctx context.Context, t *testing.T, profile string) {
 	testCpCmd(ctx, t, profile, "", srcPath, "", dstPath)
 
 	// copy from node
-	tmpDir, err := os.MkdirTemp("", "mk_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	tmpPath := filepath.Join(tmpDir, "cp-test.txt")
 	testCpCmd(ctx, t, profile, profile, dstPath, "", tmpPath)
@@ -2082,10 +2072,7 @@ func startProxyWithCustomCerts(ctx context.Context, t *testing.T) error {
 		}
 	}()
 
-	mitmDir, err := os.MkdirTemp("", "")
-	if err != nil {
-		return errors.Wrap(err, "create temp dir")
-	}
+	mitmDir := t.TempDir()
 
 	_, err = Run(t, exec.CommandContext(ctx, "tar", "xzf", "mitmproxy-6.0.2-linux.tar.gz", "-C", mitmDir))
 	if err != nil {

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -25,7 +25,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -1710,7 +1709,7 @@ func validateCpCmd(ctx context.Context, t *testing.T, profile string) {
 	testCpCmd(ctx, t, profile, "", srcPath, "", dstPath)
 
 	// copy from node
-	tmpDir, err := ioutil.TempDir("", "mk_test")
+	tmpDir, err := os.MkdirTemp("", "mk_test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/functional_test_mount_test.go
+++ b/test/integration/functional_test_mount_test.go
@@ -58,16 +58,7 @@ func validateMountCmd(ctx context.Context, t *testing.T, profile string) { // no
 	}
 
 	t.Run("any-port", func(t *testing.T) {
-		tempDir, err := os.MkdirTemp("", "mounttest")
-		defer func() { // clean up tempdir
-			err := os.RemoveAll(tempDir)
-			if err != nil {
-				t.Errorf("failed to clean up %q temp folder.", tempDir)
-			}
-		}()
-		if err != nil {
-			t.Fatalf("Unexpected error while creating tempDir: %v", err)
-		}
+		tempDir := t.TempDir()
 
 		ctx, cancel := context.WithTimeout(ctx, Minutes(10))
 
@@ -207,16 +198,7 @@ func validateMountCmd(ctx context.Context, t *testing.T, profile string) { // no
 		}
 	})
 	t.Run("specific-port", func(t *testing.T) {
-		tempDir, err := os.MkdirTemp("", "mounttest")
-		defer func() { // clean up tempdir
-			err := os.RemoveAll(tempDir)
-			if err != nil {
-				t.Errorf("failed to clean up %q temp folder.", tempDir)
-			}
-		}()
-		if err != nil {
-			t.Fatalf("Unexpected error while creating tempDir: %v", err)
-		}
+		tempDir := t.TempDir()
 
 		ctx, cancel := context.WithTimeout(ctx, Minutes(10))
 

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -29,7 +29,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -522,7 +521,7 @@ func cpTestLocalPath() string {
 
 func cpTestReadText(ctx context.Context, t *testing.T, profile, node, path string) string {
 	if node == "" {
-		expected, err := ioutil.ReadFile(path)
+		expected, err := os.ReadFile(path)
 		if err != nil {
 			t.Errorf("failed to read test file 'testdata/cp-test.txt' : %v", err)
 		}

--- a/test/integration/multinode_test.go
+++ b/test/integration/multinode_test.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -180,7 +179,7 @@ func validateCopyFileWithMultiNode(ctx context.Context, t *testing.T, profile st
 		t.Errorf("failed to decode json from status: args %q: %v", rr.Command(), err)
 	}
 
-	tmpDir, err := ioutil.TempDir("", "mk_cp_test")
+	tmpDir, err := os.MkdirTemp("", "mk_cp_test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/multinode_test.go
+++ b/test/integration/multinode_test.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
@@ -179,11 +178,7 @@ func validateCopyFileWithMultiNode(ctx context.Context, t *testing.T, profile st
 		t.Errorf("failed to decode json from status: args %q: %v", rr.Command(), err)
 	}
 
-	tmpDir, err := os.MkdirTemp("", "mk_cp_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	srcPath := cpTestLocalPath()
 	dstPath := cpTestMinikubePath()


### PR DESCRIPTION
As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code.

Also replaced instances of `os.MkdirTemp` with `t.TempDir` in tests as the latter has auto cleanup and error handling.