### PR TITLE
Only skip downloading kic if --download-only=false

### DIFF
--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -137,12 +137,10 @@ func beginDownloadKicBaseImage(g *errgroup.Group, cc *config.ClusterConfig, down
 		for _, img := range append([]string{baseImg}, kic.FallbackImages...) {
 			var err error
 
-			if driver.IsDocker(cc.Driver) {
-				if download.ImageExistsInDaemon(img) {
-					klog.Infof("%s exists in daemon, skipping load", img)
-					finalImg = img
-					return nil
-				}
+			if driver.IsDocker(cc.Driver) && download.ImageExistsInDaemon(img) && !downloadOnly {
+				klog.Infof("%s exists in daemon, skipping load", img)
+				finalImg = img
+				return nil
 			}
 
 			klog.Infof("Downloading %s to local cache", img)


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/13452

**Problem:**
If the kic image already exists in Docker we skip downloading the kic image to cache. However, this causes issues if `--download-only` is specified as you can have the kic image loaded in Docker but not in the cache, resulting in the `cache` directory not containing the kic and confusing users why their offline usage isn't working.

**Solution:**
Only skip downloading the kic image if `--download-only=false` to prevent the above from happening. Also, the download checks for the existence of the file before downloading, so it will skip the download if the file is already in the cache, so this PR does not result in more unnecessary downloading.