### PR TITLE
Remove dashboard and metrics-scraper from preload

### DIFF
--- a/pkg/minikube/bootstrapper/images/images.go
+++ b/pkg/minikube/bootstrapper/images/images.go
@@ -104,8 +104,6 @@ func auxiliary(mirror string) []string {
 	// Note: changing this list requires bumping the preload version
 	return []string{
 		storageProvisioner(mirror),
-		dashboardFrontend(mirror),
-		dashboardMetrics(mirror),
 		// NOTE: kindnet is also used when the Docker driver is used with a non-Docker runtime
 	}
 }
@@ -113,24 +111,6 @@ func auxiliary(mirror string) []string {
 // storageProvisioner returns the minikube storage provisioner image
 func storageProvisioner(mirror string) string {
 	return path.Join(minikubeRepo(mirror), "storage-provisioner:"+version.GetStorageProvisionerVersion())
-}
-
-// dashboardFrontend returns the image used for the dashboard frontend
-func dashboardFrontend(repo string) string {
-	if repo == "" {
-		repo = "docker.io"
-	}
-	// See 'kubernetes-dashboard' in deploy/addons/dashboard/dashboard-dp.yaml
-	return path.Join(repo, "kubernetesui", "dashboard:v2.5.1")
-}
-
-// dashboardMetrics returns the image used for the dashboard metrics scraper
-func dashboardMetrics(repo string) string {
-	if repo == "" {
-		repo = "docker.io"
-	}
-	// See 'dashboard-metrics-scraper' in deploy/addons/dashboard/dashboard-dp.yaml
-	return path.Join(repo, "kubernetesui", "metrics-scraper:v1.0.7")
 }
 
 // KindNet returns the image used for kindnet

--- a/pkg/minikube/bootstrapper/images/images_test.go
+++ b/pkg/minikube/bootstrapper/images/images_test.go
@@ -94,8 +94,6 @@ k8s.gcr.io/coredns/coredns:v1.8.4
 func TestAuxiliary(t *testing.T) {
 	want := []string{
 		"gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
-		"docker.io/kubernetesui/dashboard:v2.5.1",
-		"docker.io/kubernetesui/metrics-scraper:v1.0.7",
 	}
 	got := auxiliary("")
 	if diff := cmp.Diff(want, got); diff != "" {
@@ -106,8 +104,6 @@ func TestAuxiliary(t *testing.T) {
 func TestAuxiliaryMirror(t *testing.T) {
 	want := []string{
 		"test.mirror/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
-		"test.mirror/kubernetesui/dashboard:v2.5.1",
-		"test.mirror/kubernetesui/metrics-scraper:v1.0.7",
 	}
 	got := auxiliary("test.mirror")
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/pkg/minikube/bootstrapper/images/kubeadm_test.go
+++ b/pkg/minikube/bootstrapper/images/kubeadm_test.go
@@ -43,8 +43,6 @@ func TestKubeadmImages(t *testing.T) {
 			"k8s.gcr.io/etcd:3.4.3-0",
 			"k8s.gcr.io/pause:3.1",
 			"gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
-			"docker.io/kubernetesui/dashboard:v2.5.1",
-			"docker.io/kubernetesui/metrics-scraper:v1.0.7",
 		}},
 		{"v1.16.1", "mirror.k8s.io", false, []string{
 			"mirror.k8s.io/kube-proxy:v1.16.1",
@@ -55,8 +53,6 @@ func TestKubeadmImages(t *testing.T) {
 			"mirror.k8s.io/etcd:3.3.15-0",
 			"mirror.k8s.io/pause:3.1",
 			"mirror.k8s.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
-			"mirror.k8s.io/kubernetesui/dashboard:v2.5.1",
-			"mirror.k8s.io/kubernetesui/metrics-scraper:v1.0.7",
 		}},
 		{"v1.15.0", "", false, []string{
 			"k8s.gcr.io/kube-proxy:v1.15.0",
@@ -67,8 +63,6 @@ func TestKubeadmImages(t *testing.T) {
 			"k8s.gcr.io/etcd:3.3.10",
 			"k8s.gcr.io/pause:3.1",
 			"gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
-			"docker.io/kubernetesui/dashboard:v2.5.1",
-			"docker.io/kubernetesui/metrics-scraper:v1.0.7",
 		}},
 		{"v1.14.0", "", false, []string{
 			"k8s.gcr.io/kube-proxy:v1.14.0",
@@ -79,8 +73,6 @@ func TestKubeadmImages(t *testing.T) {
 			"k8s.gcr.io/etcd:3.3.10",
 			"k8s.gcr.io/pause:3.1",
 			"gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
-			"docker.io/kubernetesui/dashboard:v2.5.1",
-			"docker.io/kubernetesui/metrics-scraper:v1.0.7",
 		}},
 		{"v1.13.0", "", false, []string{
 			"k8s.gcr.io/kube-proxy:v1.13.0",
@@ -91,8 +83,6 @@ func TestKubeadmImages(t *testing.T) {
 			"k8s.gcr.io/etcd:3.2.24",
 			"k8s.gcr.io/pause:3.1",
 			"gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
-			"docker.io/kubernetesui/dashboard:v2.5.1",
-			"docker.io/kubernetesui/metrics-scraper:v1.0.7",
 		}},
 		{"v1.12.0", "", false, []string{
 			"k8s.gcr.io/kube-proxy:v1.12.0",
@@ -103,8 +93,6 @@ func TestKubeadmImages(t *testing.T) {
 			"k8s.gcr.io/etcd:3.2.24",
 			"k8s.gcr.io/pause:3.1",
 			"gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
-			"docker.io/kubernetesui/dashboard:v2.5.1",
-			"docker.io/kubernetesui/metrics-scraper:v1.0.7",
 		}},
 		{"v1.11.0", "", true, nil},
 		{"v1.10.0", "", true, nil},

--- a/pkg/minikube/cruntime/containerd_test.go
+++ b/pkg/minikube/cruntime/containerd_test.go
@@ -27,8 +27,6 @@ func TestAddRepoTagToImageName(t *testing.T) {
 		imgName string
 		want    string
 	}{
-		{"kubernetesui/dashboard:v2.5.1", "docker.io/kubernetesui/dashboard:v2.5.1"},
-		{"kubernetesui/metrics-scraper:v1.0.7", "docker.io/kubernetesui/metrics-scraper:v1.0.7"},
 		{"gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(), "gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion()},
 	}
 	for _, tc := range tests {

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -44,7 +44,7 @@ const (
 	// PreloadVersion is the current version of the preloaded tarball
 	//
 	// NOTE: You may need to bump this version up when upgrading auxiliary docker images
-	PreloadVersion = "v17"
+	PreloadVersion = "v18"
 	// PreloadBucket is the name of the GCS bucket where preloaded volume tarballs exist
 	PreloadBucket = "minikube-preloaded-volume-tarballs"
 )


### PR DESCRIPTION
Remove `dashboard` & `metrics-scraper` from preload so we don't have to bump the preload as often, will also result in a small preload size. The dashboard addon is disabled by default, so this shouldn't slow down a typical start.