### PR TITLE
feat: added configure option to registry-alieases addon

### DIFF
--- a/deploy/addons/registry-aliases/registry-aliases-config.tmpl
+++ b/deploy/addons/registry-aliases/registry-aliases-config.tmpl
@@ -9,11 +9,14 @@ metadata:
 data:
   # Add additional hosts separated by new-line
   registryAliases: >-
+   {{- if .RegistryAliases}}
+   {{ .RegistryAliases}}
+   {{- else}}
     example.org
     example.com
     test.com
     test.org
+   {{- end}}
     registry.minikube
   # default registry address in minikube when enabled via minikube addons enable registry
   registrySvc: registry.kube-system.svc.cluster.local
-

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -811,6 +811,7 @@ func GenerateTemplateData(addon *Addon, cfg config.KubernetesConfig, netInfo Net
 		CustomIngressCert      string
 		IngressAPIVersion      string
 		ContainerRuntime       string
+		RegistryAliases        string
 		Images                 map[string]string
 		Registries             map[string]string
 		CustomRegistries       map[string]string
@@ -823,6 +824,7 @@ func GenerateTemplateData(addon *Addon, cfg config.KubernetesConfig, netInfo Net
 		LoadBalancerStartIP:    cfg.LoadBalancerStartIP,
 		LoadBalancerEndIP:      cfg.LoadBalancerEndIP,
 		CustomIngressCert:      cfg.CustomIngressCert,
+		RegistryAliases:        cfg.RegistryAliases,
 		IngressAPIVersion:      "v1", // api version for ingress (eg, "v1beta1"; defaults to "v1" for k8s 1.19+)
 		ContainerRuntime:       cfg.ContainerRuntime,
 		Images:                 images,

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -118,6 +118,7 @@ type KubernetesConfig struct {
 	LoadBalancerStartIP string // currently only used by MetalLB addon
 	LoadBalancerEndIP   string // currently only used by MetalLB addon
 	CustomIngressCert   string // used by Ingress addon
+	RegistryAliases     string // currently only used by registry-aliases addon
 	ExtraOptions        ExtraOptionSlice
 
 	ShouldLoadCachedImages bool


### PR DESCRIPTION
Fixes #12643 

Demo:

```
$   ./out/minikube ssh -- cat /etc/hosts
127.0.0.1	localhost
::1	localhost ip6-localhost ip6-loopback
fe00::0	ip6-localnet
ff00::0	ip6-mcastprefix
ff02::1	ip6-allnodes
ff02::2	ip6-allrouters
192.168.49.2	minikube
192.168.49.1	host.minikube.internal
192.168.49.2	control-plane.minikube.internal

$ ./out/minikube addons enable registry
    ▪ Using image registry:2.7.1
    ▪ Using image gcr.io/google_containers/kube-registry-proxy:0.4
🔎  Verifying registry addon...
🌟  The 'registry' addon is enabled

$   ./out/minikube ssh -- cat /etc/hosts
127.0.0.1	localhost
::1	localhost ip6-localhost ip6-loopback
fe00::0	ip6-localnet
ff00::0	ip6-mcastprefix
ff02::1	ip6-allnodes
ff02::2	ip6-allrouters
192.168.49.2	minikube
192.168.49.1	host.minikube.internal
192.168.49.2	control-plane.minikube.internal

$ ./out/minikube addons configure registry-aliases
-- Enter registry aliases separated by space: github.com gitlab.com
    ▪ Using image quay.io/rhdevelopers/core-dns-patcher
    ▪ Using image alpine:3.11
    ▪ Using image gcr.io/google_containers/pause:3.1
✅  registry-aliases was successfully configured

$ kubectl -n kube-system get pods
NAME                                    READY   STATUS              RESTARTS       AGE
coredns-64897985d-vnwc6                 1/1     Running             0              4m11s
etcd-minikube                           1/1     Running             0              4m23s
kube-apiserver-minikube                 1/1     Running             0              4m23s
kube-controller-manager-minikube        1/1     Running             0              4m23s
kube-proxy-8knnv                        1/1     Running             0              4m11s
kube-scheduler-minikube                 1/1     Running             0              4m23s
registry-aliases-hosts-update-p9xd2     0/1     Init:0/1            0              7s
registry-aliases-patch-core-dns-f7qjp   0/1     ContainerCreating   0              7s
registry-g9v6x                          1/1     Running             0              3m43s
registry-proxy-tsmcr                    1/1     Running             0              3m43s
storage-provisioner                     1/1     Running             2 (4m8s ago)   4m21s

$   ./out/minikube ssh -- cat /etc/hosts
127.0.0.1	localhost
::1	localhost ip6-localhost ip6-loopback
fe00::0	ip6-localnet
ff00::0	ip6-mcastprefix
ff02::1	ip6-allnodes
ff02::2	ip6-allrouters
192.168.49.2	minikube
192.168.49.1	host.minikube.internal
192.168.49.2	control-plane.minikube.internal
10.106.31.109	github.com
10.106.31.109	gitlab.com
10.106.31.109	registry.minikube
```
Validation
```
$ ./out/minikube addons configure registry-aliases
-- Enter registry aliases separated by space: adsfasfasdfasdfasdfadsfsadf sadfasdfadsfasdfasdf
--Invalid input, please enter a value:-- Enter registry aliases separated by space: sdfasdfasdf asdfa sdfasd fasdfasdfasdf
--Invalid input, please enter a value:-- Enter registry aliases separated by space: ^C

```

Enhancements:
 - Documentation/User guides should be updated
 - The daemonset used to update the `/etc/hosts` file only performs the update once which doesn't seem ideal.
 - The validation regexp could be improved/simplified if desired.
