### PR TITLE
Updated windows kubectl alias documentation

### DIFF
--- a/site/content/en/docs/handbook/kubectl.md
+++ b/site/content/en/docs/handbook/kubectl.md
@@ -51,9 +51,18 @@ ln -s $(which minikube) /usr/local/bin/kubectl
 {{% windowstab %}}
 You can also alias kubectl for easier usage.
 
+Powershell.
+
 ```shell
 function kubectl { minikube kubectl -- $args }
 ```
+
+Command Prompt.
+
+```shell
+doskey kubectl=minikube kubectl $*
+```
+
 
 {{% /windowstab %}}
 


### PR DESCRIPTION
1. Addresses Issue #13314
2. Added Documentation for Windows Command Prompt and Powershell. 

