### PR TITLE
Fix PR Bot warnings

### DIFF
--- a/pkg/minikube/perf/result_manager.go
+++ b/pkg/minikube/perf/result_manager.go
@@ -92,7 +92,7 @@ func (rm *resultManager) summarizeResults(binaries []*Binary) {
 	t.SetHeader([]string{"Command", binaries[0].Name(), binaries[1].Name()})
 	for _, v := range table {
 		// Add warning sign if PR average is 5 seconds higher than average at HEAD
-		if len(v) > 3 {
+		if len(v) >= 3 {
 			prTime, _ := strconv.ParseFloat(v[2][:len(v[2])-1], 64)
 			headTime, _ := strconv.ParseFloat(v[1][:len(v[1])-1], 64)
 			if prTime-headTime > threshold {


### PR DESCRIPTION
**Problem:**
If the PR takes 5 seconds longer than HEAD to run we have code to output a warning in the comment to catch the reviewers attention, but it's currently not output the warning.

**Solution:**
It just seems to be an off by one error in the if check.

We currently require there to be exactly two args to mkcmp (HEAD binary and PR binary):
```
func validateArgs(args []string) error {
        if len(args) != 2 {
                return errors.New("mkcmp requires two minikube binaries to compare: mkcmp [path to first binary] [path to second binary]")
        }
        return nil
}
```
Then we create a string slice with the size of the number of binaries + 1 (2 + 1):
```
        for i := range table {
                table[i] = make([]string, len(binaries)+1)
        }
```

However, when we loop over the values, we check if the length of the string slice generated above is > 3, which is not possible:
```
for _, v := range table {
                // Add warning sign if PR average is 5 seconds higher than average at HEAD
                if len(v) > 3 {
                        prTime, _ := strconv.ParseFloat(v[2][:len(v[2])-1], 64)
                        headTime, _ := strconv.ParseFloat(v[1][:len(v[1])-1], 64)
                        if prTime-headTime > threshold {
                                v[0] = fmt.Sprintf("⚠️  %s", v[0])
                                v[2] = fmt.Sprintf("%s ⚠️", v[2])
                        }
                }
                t.Append(v)
        }
```

So simply converted the check to >=