### PR TITLE
WIP: Create a webhook for GCP Auth addon new namespaces

### DIFF
--- a/deploy/addons/gcp-auth/gcp-auth-webhook.yaml.tmpl
+++ b/deploy/addons/gcp-auth/gcp-auth-webhook.yaml.tmpl
@@ -185,3 +185,18 @@ webhooks:
     apiVersions: ["*"]
     resources: ["serviceaccounts"]
     scope: "*"
+- name: gcp-auth-mutate-ns.k8s.io
+  failurePolicy: Ignore
+  sideEffects: None
+  admissionReviewVersions: ["v1","v1beta1"]
+  clientConfig:
+    service:
+      name: gcp-auth
+      namespace: gcp-auth
+      path: "/mutate/ns"
+  rules:
+  - operations: ["CREATE"]
+    apiGroups: ["*"]
+    apiVersions: ["*"]
+    resources: ["namespaces"]
+    scope: "*"


### PR DESCRIPTION
Fixes: #13351 (on the minikube side, depends on a separate pending PR on the webhook side)


Description:
While using the GCP-Auth addon, a client may elect to create an additional namespace.

In this case, the GCP-Auth credentials will not be available. To resolve this, we must create a webhook which will reach out to an external server tasked with assisting with these credentials.

The ultimate aim of this webhook is to connect with the [GoogleContainerTools/gcp-auth-webhook](https://github.com/GoogleContainerTools/gcp-auth-webhook) package with a request, and to in turn receive a response causing the mutation of GCP-Auth credentials.