### PR TITLE
Add `--user` flag to GUI commands

### DIFF
--- a/gui/window.cpp
+++ b/gui/window.cpp
@@ -519,7 +519,7 @@ bool Window::sendMinikubeCommand(QStringList cmds, QString &text)
     if (program.isEmpty()) {
         return false;
     }
-    QStringList arguments;
+    QStringList arguments = { "--user", "minikube-gui" };
     arguments << cmds;
 
     QProcess *process = new QProcess(this);


### PR DESCRIPTION
Add `--user` flag to GUI commands so the audit logs properly shows where the commands are coming from.

```
==> Audit <==
|---------|---------------------|----------|--------------|---------|-------------------------------|-------------------------------|
| Command |        Args         | Profile  |     User     | Version |          Start Time           |           End Time            |
|---------|---------------------|----------|--------------|---------|-------------------------------|-------------------------------|
| delete  | --user minikube-gui | minikube | minikube-gui | v1.25.2 | Mon, 18 Apr 2022 15:52:01 PDT | Mon, 18 Apr 2022 15:52:01 PDT |
|---------|---------------------|----------|--------------|---------|-------------------------------|-------------------------------|
```