### PR TITLE
Add JSON output to `minikube delete`

### DIFF
--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -110,6 +110,7 @@ var hostAndDirsDeleter = func(api libmachine.API, cc *config.ClusterConfig, prof
 func init() {
 	deleteCmd.Flags().BoolVar(&deleteAll, "all", false, "Set flag to delete all profiles")
 	deleteCmd.Flags().BoolVar(&purge, "purge", false, "Set this flag to delete the '.minikube' folder from your user directory.")
+	deleteCmd.Flags().StringVarP(&outputFormat, "output", "o", "text", "Format to print stdout in. Options include: [text,json]")
 
 	if err := viper.BindPFlags(deleteCmd.Flags()); err != nil {
 		exit.Error(reason.InternalBindFlags, "unable to bind flags", err)
@@ -206,7 +207,8 @@ func runDelete(cmd *cobra.Command, args []string) {
 	if len(args) > 0 {
 		exit.Message(reason.Usage, "Usage: minikube delete")
 	}
-	// register.SetEventLogPath(localpath.EventLog(ClusterFlagValue()))
+	register.SetEventLogPath(localpath.EventLog(ClusterFlagValue()))
+	out.SetJSON(outputFormat == "json")
 	register.Reg.SetStep(register.Deleting)
 	download.CleanUpOlderPreloads()
 	validProfiles, invalidProfiles, err := config.ListProfiles()
@@ -287,6 +289,7 @@ func purgeMinikubeDirectory() {
 	if err := os.RemoveAll(localpath.MiniPath()); err != nil {
 		exit.Error(reason.HostPurge, "unable to delete minikube config folder", err)
 	}
+	register.Reg.SetStep(register.Purging)
 	out.Step(style.Deleted, "Successfully purged minikube directory located at - [{{.minikubeDirectory}}]", out.V{"minikubeDirectory": localpath.MiniPath()})
 }
 
@@ -332,7 +335,7 @@ func deleteProfile(ctx context.Context, profile *config.Profile) error {
 			if err := unpauseIfNeeded(profile); err != nil {
 				klog.Warningf("failed to unpause %s : %v", profile.Name, err)
 			}
-			out.Step(style.DeletingHost, `Deleting "{{.profile_name}}" in {{.driver_name}} ...`, out.V{"profile_name": profile.Name, "driver_name": profile.Config.Driver})
+			out.Styled(style.DeletingHost, `Deleting "{{.profile_name}}" in {{.driver_name}} ...`, out.V{"profile_name": profile.Name, "driver_name": profile.Config.Driver})
 			for _, n := range profile.Config.Nodes {
 				machineName := config.MachineName(*profile.Config, n)
 				delete.PossibleLeftOvers(ctx, machineName, profile.Config.Driver)
@@ -371,7 +374,7 @@ func deleteProfile(ctx context.Context, profile *config.Profile) error {
 		return err
 	}
 
-	out.Step(style.Deleted, `Removed all traces of the "{{.name}}" cluster.`, out.V{"name": profile.Name})
+	out.Styled(style.Deleted, `Removed all traces of the "{{.name}}" cluster.`, out.V{"name": profile.Name})
 	return nil
 }
 
@@ -461,7 +464,7 @@ func deleteContext(machineName string) error {
 }
 
 func deleteInvalidProfile(profile *config.Profile) []error {
-	out.Step(style.DeletingHost, "Trying to delete invalid profile {{.profile}}", out.V{"profile": profile.Name})
+	out.Styled(style.DeletingHost, "Trying to delete invalid profile {{.profile}}", out.V{"profile": profile.Name})
 
 	var errs []error
 	pathToProfile := config.ProfileFolderPath(profile.Name, localpath.MiniPath())
@@ -487,7 +490,7 @@ func profileDeletionErr(cname string, additionalInfo string) error {
 }
 
 func uninstallKubernetes(api libmachine.API, cc config.ClusterConfig, n config.Node, bsName string) error {
-	out.Step(style.Resetting, "Uninstalling Kubernetes {{.kubernetes_version}} using {{.bootstrapper_name}} ...", out.V{"kubernetes_version": cc.KubernetesConfig.KubernetesVersion, "bootstrapper_name": bsName})
+	out.Styled(style.Resetting, "Uninstalling Kubernetes {{.kubernetes_version}} using {{.bootstrapper_name}} ...", out.V{"kubernetes_version": cc.KubernetesConfig.KubernetesVersion, "bootstrapper_name": bsName})
 	host, err := machine.LoadHost(api, config.MachineName(cc, n))
 	if err != nil {
 		return DeletionError{Err: fmt.Errorf("unable to load host: %v", err), Errtype: MissingCluster}
@@ -565,7 +568,7 @@ func handleMultipleDeletionErrors(errors []error) {
 func deleteProfileDirectory(profile string) {
 	machineDir := filepath.Join(localpath.MiniPath(), "machines", profile)
 	if _, err := os.Stat(machineDir); err == nil {
-		out.Step(style.DeletingHost, `Removing {{.directory}} ...`, out.V{"directory": machineDir})
+		out.Styled(style.DeletingHost, `Removing {{.directory}} ...`, out.V{"directory": machineDir})
 		err := os.RemoveAll(machineDir)
 		if err != nil {
 			exit.Error(reason.GuestProfileDeletion, "Unable to remove machine directory", err)

--- a/pkg/minikube/out/register/register.go
+++ b/pkg/minikube/out/register/register.go
@@ -26,6 +26,7 @@ import (
 
 // If you add a new step here, please also add it to register.Reg registry inside the init() function
 const (
+	// InitialSetup
 	InitialSetup                      RegStep = "Initial Minikube Setup"
 	SelectingDriver                   RegStep = "Selecting Driver"
 	DownloadingArtifacts              RegStep = "Downloading Artifacts"
@@ -47,9 +48,12 @@ const (
 	EnablingAddons                    RegStep = "Enabling Addons"
 	Done                              RegStep = "Done"
 
+	// Deleting
+	Deleting RegStep = "Deleting"
+	Purging  RegStep = "Puring home dir"
+
 	Stopping  RegStep = "Stopping"
 	PowerOff  RegStep = "PowerOff"
-	Deleting  RegStep = "Deleting"
 	Pausing   RegStep = "Pausing"
 	Unpausing RegStep = "Unpausing"
 )
@@ -98,7 +102,7 @@ func init() {
 			Stopping:  {Stopping, PowerOff, Done},
 			Pausing:   {Pausing, Done},
 			Unpausing: {Unpausing, Done},
-			Deleting:  {Deleting, Stopping, Deleting, Done},
+			Deleting:  {Deleting, Stopping, Done, Purging},
 		},
 	}
 }


### PR DESCRIPTION
1. Added `-o` or `--output` flag to `minikube delete`
2. Removed duplicate `Deleting` register step from `Deleting` action
3. Add `Purging` register step to `Deleting` action
4. Changed repeat steps from `Step` to `Styled`

```
$ minikube delete --all --purge -o json
{"specversion":"1.0","id":"2d0d5bff-5a3b-4958-a0f8-3da6d4a2cefb","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.info","datacontenttype":"application/json","data":{"message":"Removed all traces of the \"minikube\" cluster."}}
{"specversion":"1.0","id":"c1c41195-092d-47d6-a089-5771b87e2f82","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.step","datacontenttype":"application/json","data":{"currentstep":"2","message":"Successfully deleted all profiles","name":"Done","totalsteps":"3"}}
{"specversion":"1.0","id":"f6f04a5e-1d22-446d-8199-9ddb81b9c355","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.step","datacontenttype":"application/json","data":{"currentstep":"3","message":"Successfully purged minikube directory located at - [/Users/powellsteven/.minikube]","name":"Puring home dir","totalsteps":"3"}}
```

**Why was `Step` replaced to `Styled`?**
Steps are supposed to be distinct, the problem arises with `delete --all`. Multiple profiles may be deleted with a single command, causing duplicates of the same step to be logged.