### PR TITLE
Don't use kubelet network-plugin or cni-conf-dir with k8s 1.24

### DIFF
--- a/pkg/minikube/cni/cni.go
+++ b/pkg/minikube/cni/cni.go
@@ -24,6 +24,7 @@ import (
 	"path"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/kapi"
@@ -33,6 +34,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/vmpath"
+	"k8s.io/minikube/pkg/util"
 )
 
 const (
@@ -211,18 +213,27 @@ func configureCNI(cc *config.ClusterConfig, cnm Manager) error {
 			Network = "kindnet"
 			return nil
 		}
-		// for containerd and docker: auto-set custom CNI via kubelet's 'cni-conf-dir' param, if not user-specified
-		eo := fmt.Sprintf("kubelet.cni-conf-dir=%s", CustomConfDir)
-		if !cc.KubernetesConfig.ExtraOptions.Exists(eo) {
-			klog.Infof("auto-setting extra-config to %q", eo)
-			if err := cc.KubernetesConfig.ExtraOptions.Set(eo); err != nil {
-				return fmt.Errorf("failed auto-setting extra-config %q: %v", eo, err)
+		version, err := util.ParseKubernetesVersion(cc.KubernetesConfig.KubernetesVersion)
+		if err != nil {
+			return err
+		}
+		// The CNI configuration is handled by CRI in 1.24+
+		if version.LT(semver.MustParse("1.24.0-alpha.2")) {
+			// for containerd and docker: auto-set custom CNI via kubelet's 'cni-conf-dir' param, if not user-specified
+			eo := fmt.Sprintf("kubelet.cni-conf-dir=%s", CustomConfDir)
+			if !cc.KubernetesConfig.ExtraOptions.Exists(eo) {
+				klog.Infof("auto-setting extra-config to %q", eo)
+				if err := cc.KubernetesConfig.ExtraOptions.Set(eo); err != nil {
+					return fmt.Errorf("failed auto-setting extra-config %q: %v", eo, err)
+				}
+				ConfDir = CustomConfDir
+				klog.Infof("extra-config set to %q", eo)
+			} else {
+				// respect user-specified custom CNI Config Directory
+				ConfDir = cc.KubernetesConfig.ExtraOptions.Get("cni-conf-dir", "kubelet")
 			}
-			ConfDir = CustomConfDir
-			klog.Infof("extra-config set to %q", eo)
 		} else {
-			// respect user-specified custom CNI Config Directory
-			ConfDir = cc.KubernetesConfig.ExtraOptions.Get("cni-conf-dir", "kubelet")
+			ConfDir = CustomConfDir
 		}
 	}
 	return nil

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -336,3 +336,14 @@ func CheckKernelCompatibility(cr CommandRunner, major, minor int) error {
 	}
 	return nil
 }
+
+func ConfigureNetworkPlugin(r Manager, cr CommandRunner, networkPlugin string) error {
+	// Only supported for Docker with cri-dockerd
+	if r.Name() != "Docker" {
+		if networkPlugin != "cni" {
+			return fmt.Errorf("unknown network plugin: %s", networkPlugin)
+		}
+		return nil
+	}
+	return dockerConfigureNetworkPlugin(r, cr, networkPlugin)
+}

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/bootstrapper/images"
+	"k8s.io/minikube/pkg/minikube/cni"
 	"k8s.io/minikube/pkg/minikube/command"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/docker"
@@ -685,7 +686,7 @@ func dockerConfigureNetworkPlugin(r Manager, cr CommandRunner, networkPlugin str
 	if networkPlugin == "cni" {
 		args += " --cni-bin-dir=" + CNIBinDir
 		args += " --cni-cache-dir=" + CNICacheDir
-		args += " --cni-conf-dir=" + CNIConfDir
+		args += " --cni-conf-dir=" + cni.ConfDir
 	}
 
 	opts := struct {

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -17,12 +17,15 @@ limitations under the License.
 package cruntime
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strings"
+	"text/template"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -664,4 +667,52 @@ func dockerBoundToContainerd(runner command.Runner) bool {
 // ImagesPreloaded returns true if all images have been preloaded
 func (r *Docker) ImagesPreloaded(images []string) bool {
 	return dockerImagesPreloaded(r.Runner, images)
+}
+
+const (
+	CNIBinDir   = "/opt/cni/bin"
+	CNIConfDir  = "/etc/cni/net.d"
+	CNICacheDir = "/var/lib/cni/cache"
+)
+
+func dockerConfigureNetworkPlugin(r Manager, cr CommandRunner, networkPlugin string) error {
+	if networkPlugin == "" {
+		// no-op plugin
+		return nil
+	}
+
+	args := ""
+	if networkPlugin == "cni" {
+		args += " --cni-bin-dir=" + CNIBinDir
+		args += " --cni-cache-dir=" + CNICacheDir
+		args += " --cni-conf-dir=" + CNIConfDir
+	}
+
+	opts := struct {
+		NetworkPlugin  string
+		ExtraArguments string
+	}{
+		NetworkPlugin:  networkPlugin,
+		ExtraArguments: args,
+	}
+
+	const CRIDockerServiceConfFile = "/etc/systemd/system/cri-docker.service.d/10-cni.conf"
+	var CRIDockerServiceConfTemplate = template.Must(template.New("criDockerServiceConfTemplate").Parse(`[Service]
+ExecStart=
+ExecStart=/usr/bin/cri-dockerd --container-runtime-endpoint fd:// --network-plugin={{.NetworkPlugin}}{{.ExtraArguments}}`))
+
+	b := bytes.Buffer{}
+	if err := CRIDockerServiceConfTemplate.Execute(&b, opts); err != nil {
+		return errors.Wrap(err, "failed to execute template")
+	}
+	criDockerService := b.Bytes()
+	c := exec.Command("sudo", "mkdir", "-p", filepath.Dir(CRIDockerServiceConfFile))
+	if _, err := cr.RunCmd(c); err != nil {
+		return errors.Wrapf(err, "failed to create directory")
+	}
+	svc := assets.NewMemoryAssetTarget(criDockerService, CRIDockerServiceConfFile, "0644")
+	if err := cr.Copy(svc); err != nil {
+		return errors.Wrap(err, "failed to copy template")
+	}
+	return nil
 }

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -397,6 +397,12 @@ func configureRuntimes(runner cruntime.CommandRunner, cc config.ClusterConfig, k
 		}
 	}
 
+	if kv.GTE(semver.MustParse("1.24.0-alpha.2")) {
+		if err := cruntime.ConfigureNetworkPlugin(cr, runner, cc.KubernetesConfig.NetworkPlugin); err != nil {
+			exit.Error(reason.RuntimeEnable, "Failed to configure network plugin", err)
+		}
+	}
+
 	inUserNamespace := strings.Contains(cc.KubernetesConfig.FeatureGates, "KubeletInUserNamespace=true")
 	err = cr.Enable(disableOthers, forceSystemd(), inUserNamespace)
 	if err != nil {

--- a/test/integration/net_test.go
+++ b/test/integration/net_test.go
@@ -28,8 +28,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"k8s.io/minikube/pkg/kapi"
+	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/reason"
+	"k8s.io/minikube/pkg/util"
 	"k8s.io/minikube/pkg/util/retry"
 )
 
@@ -122,7 +125,11 @@ func TestNetworkPlugins(t *testing.T) {
 							t.Fatalf("ssh failed: %v", err)
 						}
 						out := rr.Stdout.String()
-						verifyKubeletFlagsOutput(t, tc.kubeletPlugin, out)
+						c, err := config.Load(profile)
+						if err != nil {
+							t.Errorf("failed to load cluster config: %v", err)
+						}
+						verifyKubeletFlagsOutput(t, c.KubernetesConfig.KubernetesVersion, tc.kubeletPlugin, out)
 					})
 				}
 
@@ -242,7 +249,14 @@ func validateHairpinMode(ctx context.Context, t *testing.T, profile string, hair
 	}
 }
 
-func verifyKubeletFlagsOutput(t *testing.T, kubeletPlugin, out string) {
+func verifyKubeletFlagsOutput(t *testing.T, k8sVersion, kubeletPlugin, out string) {
+	version, err := util.ParseKubernetesVersion(k8sVersion)
+	if err != nil {
+		t.Errorf("failed to parse kubernetes version %s: %v", k8sVersion, err)
+	}
+	if version.GTE(semver.MustParse("1.24.0-alpha.2")) {
+		return
+	}
 	if kubeletPlugin == "" {
 		if strings.Contains(out, "--network-plugin") && ContainerRuntime() == "docker" {
 			t.Errorf("expected no network plug-in, got %s", out)

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -59,6 +59,7 @@ func TestStartStop(t *testing.T) {
 				"--feature-gates",
 				"ServerSideApply=true",
 				"--network-plugin=cni",
+				// TODO: Remove network-plugin config when newest is 1.24
 				"--extra-config=kubelet.network-plugin=cni",
 				"--extra-config=kubeadm.pod-network-cidr=192.168.111.111/16",
 			}},


### PR DESCRIPTION
These flags have been removed, and cause bootstrapping to fail.

The kubelet never starts which causes the cluster to self-destruct.

Closes #13945

Tested with `v1.24.0-rc.0`, using cri-dockerd without and without CNI