### PR TITLE
Add --audit flag to minikube logs command

### DIFF
--- a/cmd/minikube/cmd/logs.go
+++ b/cmd/minikube/cmd/logs.go
@@ -50,6 +50,8 @@ var (
 	showProblems bool
 	// fileOutput is where to write logs to. If omitted, writes to stdout.
 	fileOutput string
+	// auditLogs only shows the audit logs
+	auditLogs bool
 )
 
 // logsCmd represents the logs command
@@ -73,7 +75,13 @@ var logsCmd = &cobra.Command{
 				exit.Error(reason.Usage, "Failed to create file", err)
 			}
 		}
-
+		if auditLogs {
+			err := logs.OutputAudit(numberOfLines)
+			if err != nil {
+				klog.Errorf("failed to output audit logs: %v", err)
+			}
+			return
+		}
 		logs.OutputOffline(numberOfLines, logOutput)
 
 		if shouldSilentFail() {
@@ -91,7 +99,6 @@ var logsCmd = &cobra.Command{
 		if err != nil {
 			exit.Error(reason.InternalNewRuntime, "Unable to get runtime", err)
 		}
-
 		if followLogs {
 			err := logs.Follow(cr, bs, *co.Config, co.CP.Runner, logOutput)
 			if err != nil {
@@ -142,4 +149,5 @@ func init() {
 	logsCmd.Flags().IntVarP(&numberOfLines, "length", "n", 60, "Number of lines back to go within the log")
 	logsCmd.Flags().StringVar(&nodeName, "node", "", "The node to get logs from. Defaults to the primary control plane.")
 	logsCmd.Flags().StringVar(&fileOutput, "file", "", "If present, writes to the provided file instead of stdout.")
+	logsCmd.Flags().BoolVar(&auditLogs, "audit", false, "Show only the audit logs")
 }

--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -208,7 +208,7 @@ func Output(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.Cluster
 }
 
 // outputAudit displays the audit logs.
-func outputAudit(lines int) error {
+func OutputAudit(lines int) error {
 	out.Styled(style.Empty, "")
 	out.Styled(style.Empty, "==> Audit <==")
 	r, err := audit.Report(lines)
@@ -252,7 +252,7 @@ func OutputOffline(lines int, logOutput *os.File) {
 	defer out.SetOutFile(os.Stdout)
 	out.SetErrFile(logOutput)
 	defer out.SetErrFile(os.Stderr)
-	if err := outputAudit(lines); err != nil {
+	if err := OutputAudit(lines); err != nil {
 		klog.Errorf("failed to output audit logs: %v", err)
 	}
 	if err := outputLastStart(); err != nil {


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
Fixes #13978 

I haven't included tests since this test seems to be checking if the `minikube logs` command output contains keywords i.e `Audit`

https://github.com/kubernetes/minikube/blob/4c725782c99de027e4d11b29549840285b9e0cb6/test/integration/functional_test.go#L1229
