### PR TITLE
Fix pre command flags

### DIFF
--- a/cmd/minikube/main.go
+++ b/cmd/minikube/main.go
@@ -229,7 +229,7 @@ func setFlags(parse bool) {
 
 // setLastStartFlags sets the log_file flag to lastStart.txt if start command and user doesn't specify log_file or log_dir flags.
 func setLastStartFlags() {
-	if len(os.Args) < 2 || os.Args[1] != "start" {
+	if pflag.Arg(0) != "start" {
 		return
 	}
 	if pflag.CommandLine.Changed("log_file") || pflag.CommandLine.Changed("log_dir") {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/13994

**Problem:**
Having a flag before the command (ex. `minikube --alsologtostderr start`) would break instances that were coded to look for the command using `os.Args[1]`. This would result in issues such as not creating a `lastStart.txt` and not properly detecting if a purge delete was occurring.

**Solution:**
Replaced instances of `os.Args[1]` with `pflag.Arg(0)`. `pflag.Arg` returns all args from `os.Args[1:]` that aren't flags, resulting in only true args (ex. `minikube --alsologtostderr start --driver docker` -> `pflag.Args() = ["start"]`). `pflag.Arg()` will also return an empty string if trying to access a non-existing arg index.