### PR TITLE
GUI: Add `/usr/local/bin` to `PATH` env on Mac

### DIFF
--- a/gui/window.cpp
+++ b/gui/window.cpp
@@ -82,6 +82,7 @@
 #include <QDir>
 #include <QFontDialog>
 #include <QStackedWidget>
+#include <QProcessEnvironment>
 
 #ifndef QT_NO_TERMWIDGET
 #include <QApplication>
@@ -114,6 +115,14 @@ Window::Window()
 
     setWindowTitle(tr("minikube"));
     setWindowIcon(*trayIconIcon);
+}
+
+QProcessEnvironment Window::setMacEnv()
+{
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    QString path = env.value("PATH");
+    env.insert("PATH", path + ":/usr/local/bin");
+    return env;
 }
 
 void Window::createBasicView()
@@ -523,6 +532,12 @@ bool Window::sendMinikubeCommand(QStringList cmds, QString &text)
     arguments << cmds;
 
     QProcess *process = new QProcess(this);
+#if __APPLE__
+    if (env.isEmpty()) {
+        env = setMacEnv();
+    }
+    process->setProcessEnvironment(env);
+#endif
     process->start(program, arguments);
     this->setCursor(Qt::WaitCursor);
     bool timedOut = process->waitForFinished(300 * 1000);

--- a/gui/window.h
+++ b/gui/window.h
@@ -57,6 +57,7 @@
 #include <QSystemTrayIcon>
 #include <QFormLayout>
 #include <QStackedWidget>
+#include <QProcessEnvironment>
 
 #ifndef QT_NO_SYSTEMTRAYICON
 
@@ -166,12 +167,14 @@ private:
     void dashboardBrowser();
     Cluster createClusterObject(QJsonObject obj);
     QProcess *dashboardProcess;
+    QProcessEnvironment env;
 
     // Error messaging
     void outputFailedStart(QString text);
     QLabel *createLabel(QString title, QString text, QFormLayout *form, bool isLink);
 
     void checkForMinikube();
+    QProcessEnvironment setMacEnv();
     QStackedWidget *stackedWidget;
     bool isBasicView;
 };


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/13999

**Problem:**
On Mac, the `PATH` env doesn't point to `/user/local/bin` by default, so when starting minikube it can't find the binaries for the drivers.

**Solution:**
If on Mac, append `/usr/local/bin` to the `PATH` env.

Creating the `QProcessEnvironment` once and saving it since the documentation states:
`However, note that repeated calls to this function will recreate the QProcessEnvironment object, which is a non-trivial operation.`