### PR TITLE
GUI: Refresh cluster list when reopening GUI

### DIFF
--- a/gui/window.cpp
+++ b/gui/window.cpp
@@ -224,10 +224,16 @@ void Window::createActions()
     connect(minimizeAction, &QAction::triggered, this, &QWidget::hide);
 
     restoreAction = new QAction(tr("&Restore"), this);
-    connect(restoreAction, &QAction::triggered, this, &QWidget::showNormal);
+    connect(restoreAction, &QAction::triggered, this, &Window::restoreWindow);
 
     quitAction = new QAction(tr("&Quit"), this);
     connect(quitAction, &QAction::triggered, qApp, &QCoreApplication::quit);
+}
+
+void Window::restoreWindow()
+{
+    QWidget::showNormal();
+    updateClusters();
 }
 
 static QString minikubePath()

--- a/gui/window.h
+++ b/gui/window.h
@@ -174,6 +174,7 @@ private:
     QLabel *createLabel(QString title, QString text, QFormLayout *form, bool isLink);
 
     void checkForMinikube();
+    void restoreWindow();
     QProcessEnvironment setMacEnv();
     QStackedWidget *stackedWidget;
     bool isBasicView;


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/14001

Cluster list (advanced view) and button (basic view) now update when re-opening the GUI from the tray icon.