### PR TITLE
Remove setting event log path on delete

### DIFF
--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -207,7 +207,6 @@ func runDelete(cmd *cobra.Command, args []string) {
 	if len(args) > 0 {
 		exit.Message(reason.Usage, "Usage: minikube delete")
 	}
-	register.SetEventLogPath(localpath.EventLog(ClusterFlagValue()))
 	out.SetJSON(outputFormat == "json")
 	register.Reg.SetStep(register.Deleting)
 	download.CleanUpOlderPreloads()


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/14021

**Problem:**
On Windows, `minikube delete` results in logging to the `events.json` file at the same time it's trying to delete the profile's directory and results in:
```
$ minikube delete
! "minikube" profile does not exist, trying anyways.
* Trying to delete invalid profile minikube
X remove C:\Users\<user>\.minikube\profiles\minikube\events.json: The process cannot access the file because it is being used by another process.
```

**Solution:**
Return to not setting the event log path for the delete command.