### PR TITLE
Bind mount the cache directory on Linux KIC

### DIFF
--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -186,7 +186,7 @@ func CreateContainerNode(p CreateParams) error {
 		runArgs = append(runArgs, "--ip", p.IP)
 	}
 
-	if runtime.GOOS == "linux" {
+	if runtime.GOOS == "linux" && !IsExternalDaemonHost(p.OCIBinary) {
 		// make sure directory exists, to avoid docker creating it as the root user
 		if err := os.MkdirAll(detect.ImageCacheDir(), 0755); err != nil {
 			return errors.Wrap(err, "mkdir cache")

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/detect"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/util/retry"
 )
@@ -183,6 +184,11 @@ func CreateContainerNode(p CreateParams) error {
 	if p.Network != "" && p.IP != "" {
 		runArgs = append(runArgs, "--network", p.Network)
 		runArgs = append(runArgs, "--ip", p.IP)
+	}
+
+	if runtime.GOOS == "linux" {
+		// bind-mount the image cache, for faster loading of cached images (without scp)
+		runArgs = append(runArgs, "-v", fmt.Sprintf("%s:/cache", detect.ImageCacheDir()))
 	}
 
 	memcgSwap := hasMemorySwapCgroup()

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -205,14 +205,6 @@ func CreateContainerNode(p CreateParams) error {
 		// podman mounts var/lib with no-exec by default  https://github.com/containers/libpod/issues/5103
 		runArgs = append(runArgs, "--volume", fmt.Sprintf("%s:/var:exec", p.Name))
 
-		if memcgSwap {
-			runArgs = append(runArgs, fmt.Sprintf("--memory-swap=%s", p.Memory))
-		}
-
-		if memcg {
-			runArgs = append(runArgs, fmt.Sprintf("--memory=%s", p.Memory))
-		}
-
 		virtualization = "podman" // VIRTUALIZATION_PODMAN
 	}
 	if p.OCIBinary == Docker {
@@ -220,15 +212,15 @@ func CreateContainerNode(p CreateParams) error {
 		// ignore apparmore github actions docker: https://github.com/kubernetes/minikube/issues/7624
 		runArgs = append(runArgs, "--security-opt", "apparmor=unconfined")
 
-		if memcg {
-			runArgs = append(runArgs, fmt.Sprintf("--memory=%s", p.Memory))
-		}
-		if memcgSwap {
-			// Disable swap by setting the value to match
-			runArgs = append(runArgs, fmt.Sprintf("--memory-swap=%s", p.Memory))
-		}
-
 		virtualization = "docker" // VIRTUALIZATION_DOCKER
+	}
+
+	if memcg {
+		runArgs = append(runArgs, fmt.Sprintf("--memory=%s", p.Memory))
+	}
+	if memcgSwap {
+		// Disable swap by setting the value to match
+		runArgs = append(runArgs, fmt.Sprintf("--memory-swap=%s", p.Memory))
 	}
 
 	cpuCfsPeriod := true

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -187,6 +187,11 @@ func CreateContainerNode(p CreateParams) error {
 	}
 
 	if runtime.GOOS == "linux" {
+		// make sure directory exists, to avoid docker creating it as the root user
+		if err := os.MkdirAll(detect.ImageCacheDir(), 0755); err != nil {
+			return errors.Wrap(err, "mkdir cache")
+		}
+
 		// bind-mount the image cache, for faster loading of cached images (without scp)
 		runArgs = append(runArgs, "-v", fmt.Sprintf("%s:/cache", detect.ImageCacheDir()))
 	}

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -130,6 +130,11 @@ func IsKIC(name string) bool {
 	return name == Docker || name == Podman
 }
 
+// ISKIC checks if the driver is using an external host
+func IsExternal(name string) bool {
+	return oci.IsExternalDaemonHost(name)
+}
+
 // IsDocker checks if the driver docker
 func IsDocker(name string) bool {
 	return name == Docker

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -119,7 +119,7 @@ func LoadCachedImages(cc *config.ClusterConfig, runner command.Runner, images []
 			if err == nil {
 				return nil
 			}
-			if driver.IsKIC(cc.Driver) && runtime.GOOS == "linux" {
+			if driver.IsKIC(cc.Driver) && runtime.GOOS == "linux" && !driver.IsExternal(cc.Driver) {
 				klog.Infof("%q needs load: %v", image, err)
 				return volumeLoadCachedImage(runner, cc.KubernetesConfig, image, cacheDir)
 			}
@@ -402,7 +402,7 @@ func SaveCachedImages(cc *config.ClusterConfig, runner command.Runner, images []
 	for _, image := range images {
 		image := image
 		g.Go(func() error {
-			if driver.IsKIC(cc.Driver) && runtime.GOOS == "linux" {
+			if driver.IsKIC(cc.Driver) && runtime.GOOS == "linux" && !driver.IsExternal(cc.Driver) {
 				return volumeSaveCachedImage(runner, cc.KubernetesConfig, image, cacheDir)
 			}
 			return transferAndSaveCachedImage(runner, cc.KubernetesConfig, image, cacheDir)


### PR DESCRIPTION
Mount the image cache as a docker volume, instead of using scp

Avoids the copy step, but only useful when doing host bind mounts

For #14032

~~Needs a check, if the driver is actually using a local engine on Linux~~

~~(if it is a remote DOCKER_HOST, then this trick should not be used)~~

---

Example:

```console
$ minikube --alsologtostderr image load python
$ minikube ssh sudo crictl images python
IMAGE               TAG                 IMAGE ID            SIZE
python              latest              2b7ca628da40d       920MB
```

BEFORE

```
I0424 14:31:51.457312  272425 cache_images.go:286] Loading image from: /home/anders/.minikube/cache/images/amd64/python
I0424 14:31:51.457380  272425 ssh_runner.go:195] Run: stat -c "%s %y" /var/lib/minikube/images/python
I0424 14:31:51.459372  272425 ssh_runner.go:352] existence check for /var/lib/minikube/images/python: stat -c "%s %y" /var/lib/minikube/images/python: Process exited with status 1
stdout:

stderr:
stat: cannot stat '/var/lib/minikube/images/python': No such file or directory
I0424 14:31:51.459399  272425 ssh_runner.go:362] scp /home/anders/.minikube/cache/images/amd64/python --> /var/lib/minikube/images/python (393211392 bytes)
I0424 14:31:51.934622  272425 docker.go:254] Loading image: /var/lib/minikube/images/python
I0424 14:31:51.934643  272425 ssh_runner.go:195] Run: /bin/bash -c "sudo cat /var/lib/minikube/images/python | docker load"
I0424 14:32:05.565830  272425 ssh_runner.go:235] Completed: /bin/bash -c "sudo cat /var/lib/minikube/images/python | docker load": (13.631171169s)
```

AFTER

```
I0424 14:30:43.761855  271891 cache_images.go:346] Loading image from: /home/anders/.minikube/cache/images/amd64/python
I0424 14:30:43.761885  271891 docker.go:258] Loading image: /cache/python
I0424 14:30:43.761896  271891 ssh_runner.go:195] Run: /bin/bash -c "sudo cat /cache/python | docker load"
I0424 14:30:54.344900  271891 ssh_runner.go:235] Completed: /bin/bash -c "sudo cat /cache/python | docker load": (10.582986885s)
```