### PR TITLE
GUI: Link to `lastStart.txt` on failed start

### DIFF
--- a/gui/window.cpp
+++ b/gui/window.cpp
@@ -697,13 +697,12 @@ void Window::outputFailedStart(QString text)
         errorMessage->setStyleSheet("background-color:white;");
         createLabel("Link to documentation", url, &form, true);
         createLabel("Link to related issue", issues, &form, true);
-        // Enabling once https://github.com/kubernetes/minikube/issues/13925 is fixed
-        // QLabel *fileLabel = new QLabel(this);
-        // fileLabel->setOpenExternalLinks(true);
-        // fileLabel->setWordWrap(true);
-        // QString logFile = QDir::homePath() + "/.minikube/logs/lastStart.txt";
-        // fileLabel->setText("<a href='file:///" + logFile + "'>View log file</a>");
-        // form.addRow(fileLabel);
+        QLabel *fileLabel = new QLabel(this);
+        fileLabel->setOpenExternalLinks(true);
+        fileLabel->setWordWrap(true);
+        QString logFile = QDir::homePath() + "/.minikube/logs/lastStart.txt";
+        fileLabel->setText("<a href='file:///" + logFile + "'>View log file</a>");
+        form.addRow(fileLabel);
         QDialogButtonBox buttonBox(Qt::Horizontal, &dialog);
         buttonBox.addButton(QString(tr("OK")), QDialogButtonBox::AcceptRole);
         connect(&buttonBox, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);


### PR DESCRIPTION
Link to `lastStart.txt` file when start fails, was previously written but was commented out until  https://github.com/kubernetes/minikube/issues/13994 was fixed, it has now been fixed and am enabling it.

<img width="602" alt="Screen Shot 2022-04-25 at 3 28 23 PM" src="https://user-images.githubusercontent.com/44844360/165185473-4f6d4a23-d2c1-4845-b46f-bc5ba5a0b8bd.png">
<img width="1718" alt="Screen Shot 2022-04-25 at 3 28 41 PM" src="https://user-images.githubusercontent.com/44844360/165185477-e60b6a1c-038c-42a7-8b18-4eb624652f11.png">
