### PR TITLE
GUI: Add start, pause/unpause, and stop to tray

### DIFF
--- a/gui/window.h
+++ b/gui/window.h
@@ -102,9 +102,13 @@ private:
     // Tray icon
     void createTrayIcon();
     void createActions();
+    void updateTrayActions(Cluster cluster);
     QAction *minimizeAction;
     QAction *restoreAction;
     QAction *quitAction;
+    QAction *startAction;
+    QAction *pauseAction;
+    QAction *stopAction;
     QSystemTrayIcon *trayIcon;
     QMenu *trayIconMenu;
     QIcon *trayIconIcon;
@@ -112,7 +116,7 @@ private:
     // Basic view
     void createBasicView();
     void toBasicView();
-    void updateBasicButtons();
+    void updateBasicButtons(Cluster cluster);
     QPushButton *basicStartButton;
     QPushButton *basicStopButton;
     QPushButton *basicPauseButton;
@@ -125,7 +129,7 @@ private:
     void createAdvancedView();
     void toAdvancedView();
     void createClusterGroupBox();
-    void updateAdvancedButtons();
+    void updateAdvancedButtons(Cluster cluster);
     QPushButton *startButton;
     QPushButton *stopButton;
     QPushButton *pauseButton;


### PR DESCRIPTION
Closes https://github.com/kubernetes/minikube/issues/14009

Added start, pause/unpause, and stop to tray context menu that can be accessed by right clicking on the tray icon.

Pause & Stop will be disabled is the cluster is not running.

<img width="116" alt="Screen Shot 2022-04-26 at 1 33 33 PM" src="https://user-images.githubusercontent.com/44844360/165387496-8a24674f-50bc-43ca-9f48-467a69ab02ff.png">
