### PR TITLE
GUI: Cleanup & Improvements

### DIFF
--- a/gui/window.cpp
+++ b/gui/window.cpp
@@ -491,13 +491,6 @@ void Window::createClusterGroupBox()
     clusterLayout->addWidget(clusterListView);
     clusterLayout->addLayout(bottomButtonLayout);
     clusterGroupBox->setLayout(clusterLayout);
-
-    startButton->setEnabled(false);
-    stopButton->setEnabled(false);
-    pauseButton->setEnabled(false);
-    deleteButton->setEnabled(false);
-    sshButton->setEnabled(false);
-    dashboardButton->setEnabled(false);
 }
 
 void Window::updateButtons()

--- a/gui/window.cpp
+++ b/gui/window.cpp
@@ -156,7 +156,7 @@ void Window::createBasicView()
     connect(basicStopButton, &QAbstractButton::clicked, this, &Window::stopMinikube);
     connect(basicPauseButton, &QAbstractButton::clicked, this, &Window::pauseOrUnpauseMinikube);
     connect(basicDeleteButton, &QAbstractButton::clicked, this, &Window::deleteMinikube);
-    connect(basicRefreshButton, &QAbstractButton::clicked, this, &Window::updateClusters);
+    connect(basicRefreshButton, &QAbstractButton::clicked, this, &Window::updateClustersTable);
     connect(advancedViewButton, &QAbstractButton::clicked, this, &Window::toAdvancedView);
 }
 
@@ -165,6 +165,7 @@ void Window::toAdvancedView()
     isBasicView = false;
     stackedWidget->setCurrentIndex(1);
     resize(600, 400);
+    updateButtons();
 }
 
 void Window::toBasicView()
@@ -172,6 +173,7 @@ void Window::toBasicView()
     isBasicView = true;
     stackedWidget->setCurrentIndex(0);
     resize(200, 250);
+    updateButtons();
 }
 
 void Window::createAdvancedView()
@@ -182,7 +184,7 @@ void Window::createAdvancedView()
     connect(stopButton, &QAbstractButton::clicked, this, &Window::stopMinikube);
     connect(pauseButton, &QAbstractButton::clicked, this, &Window::pauseOrUnpauseMinikube);
     connect(deleteButton, &QAbstractButton::clicked, this, &Window::deleteMinikube);
-    connect(refreshButton, &QAbstractButton::clicked, this, &Window::updateClusters);
+    connect(refreshButton, &QAbstractButton::clicked, this, &Window::updateClustersTable);
     connect(createButton, &QAbstractButton::clicked, this, &Window::initMachine);
     connect(trayIcon, &QSystemTrayIcon::messageClicked, this, &Window::messageClicked);
 
@@ -246,7 +248,7 @@ void Window::createActions()
 void Window::restoreWindow()
 {
     QWidget::showNormal();
-    updateClusters();
+    updateClustersTable();
 }
 
 static QString minikubePath()
@@ -282,7 +284,7 @@ void Window::startMinikube(QStringList moreArgs)
     QStringList args = { "start", "-o", "json" };
     args << moreArgs;
     bool success = sendMinikubeCommand(args, text);
-    updateClusters();
+    updateClustersTable();
     if (success) {
         return;
     }
@@ -299,39 +301,40 @@ void Window::stopMinikube()
 {
     QStringList args = { "stop", "-p", selectedClusterName() };
     sendMinikubeCommand(args);
-    updateClusters();
+    updateClustersTable();
 }
 
 void Window::pauseMinikube()
 {
     QStringList args = { "pause", "-p", selectedClusterName() };
     sendMinikubeCommand(args);
-    updateClusters();
+    updateClustersTable();
 }
 
 void Window::unpauseMinikube()
 {
     QStringList args = { "unpause", "-p", selectedClusterName() };
     sendMinikubeCommand(args);
-    updateClusters();
+    updateClustersTable();
 }
 
 void Window::deleteMinikube()
 {
     QStringList args = { "delete", "-p", selectedClusterName() };
     sendMinikubeCommand(args);
-    updateClusters();
+    updateClustersTable();
 }
 
-void Window::updateClusters()
+void Window::updateClustersTable()
 {
     QString cluster = selectedClusterName();
-    clusterModel->setClusters(getClusters());
+    updateClusterList();
+    clusterModel->setClusters(clusterList);
     setSelectedClusterName(cluster);
     updateButtons();
 }
 
-ClusterList Window::getClusters()
+void Window::updateClusterList()
 {
     ClusterList clusters;
     QStringList args = { "profile", "list", "-o", "json" };
@@ -366,7 +369,7 @@ ClusterList Window::getClusters()
             clusters << cluster;
         }
     }
-    return clusters;
+    clusterList = clusters;
 }
 
 Cluster Window::createClusterObject(QJsonObject obj)
@@ -417,7 +420,7 @@ QString Window::selectedClusterName()
         return "minikube";
     }
     QModelIndex index = clusterListView->currentIndex();
-    QVariant variant = index.data(Qt::DisplayRole);
+    QVariant variant = index.siblingAtColumn(0).data(Qt::DisplayRole);
     if (variant.isNull()) {
         return QString();
     }
@@ -439,7 +442,8 @@ void Window::createClusterGroupBox()
 {
     clusterGroupBox = new QGroupBox(tr("Clusters"));
 
-    ClusterList clusters = getClusters();
+    updateClusterList();
+    ClusterList clusters = clusterList;
     clusterModel = new ClusterModel(clusters);
 
     clusterListView = new QTableView();
@@ -487,6 +491,13 @@ void Window::createClusterGroupBox()
     clusterLayout->addWidget(clusterListView);
     clusterLayout->addLayout(bottomButtonLayout);
     clusterGroupBox->setLayout(clusterLayout);
+
+    startButton->setEnabled(false);
+    stopButton->setEnabled(false);
+    pauseButton->setEnabled(false);
+    deleteButton->setEnabled(false);
+    sshButton->setEnabled(false);
+    dashboardButton->setEnabled(false);
 }
 
 void Window::updateButtons()
@@ -506,11 +517,8 @@ void Window::updateTrayActions(Cluster cluster)
     bool isPaused = cluster.status() == "Paused";
     pauseAction->setEnabled(isRunning || isPaused);
     stopAction->setEnabled(isRunning || isPaused);
-    QString pauseLabel = tr("Pause");
-    if (isPaused) {
-        pauseLabel = tr("Unpause");
-    }
-    pauseAction->setText(pauseLabel);
+    pauseAction->setText(getPauseLabel(isRunning));
+    startAction->setText(getStartLabel(isRunning));
 }
 
 Cluster Window::selectedCluster()
@@ -519,7 +527,7 @@ Cluster Window::selectedCluster()
     if (clusterName.isEmpty()) {
         return Cluster();
     }
-    ClusterList clusters = getClusters();
+    ClusterList clusters = clusterList;
     ClusterHash clusterHash;
     for (int i = 0; i < clusters.size(); i++) {
         Cluster cluster = clusters.at(i);
@@ -542,11 +550,24 @@ void Window::updateBasicButtons(Cluster cluster)
 #else
     basicSSHButton->setEnabled(false);
 #endif
-    QString pauseLabel = tr("Pause");
+    basicPauseButton->setText(getPauseLabel(isPaused));
+    basicStartButton->setText(getStartLabel(isRunning));
+}
+
+QString Window::getPauseLabel(bool isPaused)
+{
     if (isPaused) {
-        pauseLabel = tr("Unpause");
+        return tr("Unpause");
     }
-    basicPauseButton->setText(pauseLabel);
+    return tr("Pause");
+}
+
+QString Window::getStartLabel(bool isRunning)
+{
+    if (isRunning) {
+        return tr("Reload");
+    }
+    return tr("Start");
 }
 
 void Window::pauseOrUnpauseMinikube()
@@ -574,11 +595,8 @@ void Window::updateAdvancedButtons(Cluster cluster)
 #else
     sshButton->setEnabled(false);
 #endif
-    QString pauseLabel = tr("Pause");
-    if (isPaused) {
-        pauseLabel = tr("Unpause");
-    }
-    pauseButton->setText(pauseLabel);
+    pauseButton->setText(getPauseLabel(isPaused));
+    startButton->setText(getStartLabel(isRunning));
 }
 
 bool Window::sendMinikubeCommand(QStringList cmds)
@@ -788,7 +806,7 @@ QLabel *Window::createLabel(QString title, QString text, QFormLayout *form, bool
 void Window::initMachine()
 {
     askName();
-    updateClusters();
+    updateClustersTable();
 }
 
 void Window::sshConsole()

--- a/gui/window.h
+++ b/gui/window.h
@@ -144,10 +144,11 @@ private:
     QString selectedClusterName();
     void setSelectedClusterName(QString cluster);
     Cluster selectedCluster();
-    ClusterList getClusters();
-    void updateClusters();
+    void updateClusterList();
+    void updateClustersTable();
     ClusterModel *clusterModel;
     QTableView *clusterListView;
+    ClusterList clusterList;
 
     // Create cluster
     void askCustom();
@@ -179,6 +180,8 @@ private:
 
     void checkForMinikube();
     void restoreWindow();
+    QString getPauseLabel(bool isPaused);
+    QString getStartLabel(bool isRunning);
     QProcessEnvironment setMacEnv();
     QStackedWidget *stackedWidget;
     bool isBasicView;


### PR DESCRIPTION
Closes https://github.com/kubernetes/minikube/issues/14058

1. Changed text of start button from `Start` to `Reload` when the cluster is already running. This change is to prevent confusion to users who may think the cluster is not started.

2. Fixed clicking any cell in row, before you'd have to click specifically the cell that had the proflle name, otherwise you wouldn't be able to take action against the cluster. This has been fixed and now clicking any cell in the row allows you to take action against the cluster.

3. Fixed making a `minikube profile list` call every time a row was clicked in the cluster list. Now `minikube profile list` is only called on GUI start or when an action is taken. This makes the GUI much more snappier.

4. Fixed buttons being out of sync when switching between the basic and advanced view.