### PR TITLE
GUI: Add status to tray menu

### DIFF
--- a/gui/window.cpp
+++ b/gui/window.cpp
@@ -243,6 +243,18 @@ void Window::createActions()
 
     stopAction = new QAction(tr("Stop"), this);
     connect(stopAction, &QAction::triggered, this, &Window::stopMinikube);
+
+    statusAction = new QAction(tr("Status:"), this);
+    statusAction->setEnabled(false);
+}
+
+void Window::updateStatus(Cluster cluster)
+{
+    QString status = cluster.status();
+    if (status.isEmpty()) {
+        status = "Stopped";
+    }
+    statusAction->setText("Status: " + status);
 }
 
 void Window::restoreWindow()
@@ -264,6 +276,8 @@ static QString minikubePath()
 void Window::createTrayIcon()
 {
     trayIconMenu = new QMenu(this);
+    trayIconMenu->addAction(statusAction);
+    trayIconMenu->addSeparator();
     trayIconMenu->addAction(startAction);
     trayIconMenu->addAction(pauseAction);
     trayIconMenu->addAction(stopAction);
@@ -502,6 +516,7 @@ void Window::updateButtons()
         updateAdvancedButtons(cluster);
     }
     updateTrayActions(cluster);
+    updateStatus(cluster);
 }
 
 void Window::updateTrayActions(Cluster cluster)

--- a/gui/window.h
+++ b/gui/window.h
@@ -102,6 +102,7 @@ private:
     // Tray icon
     void createTrayIcon();
     void createActions();
+    void updateStatus(Cluster cluster);
     void updateTrayActions(Cluster cluster);
     QAction *minimizeAction;
     QAction *restoreAction;
@@ -109,6 +110,7 @@ private:
     QAction *startAction;
     QAction *pauseAction;
     QAction *stopAction;
+    QAction *statusAction;
     QSystemTrayIcon *trayIcon;
     QMenu *trayIconMenu;
     QIcon *trayIconIcon;


### PR DESCRIPTION
Closes https://github.com/kubernetes/minikube/issues/14057

Adds the clusters status to the tray menu.

![Screen Shot 2022-04-27 at 2 57 37 PM](https://user-images.githubusercontent.com/44844360/165639121-b06d7d72-3354-4e48-8a42-1cd3db18e27f.png)
![Screen Shot 2022-04-27 at 3 05 24 PM](https://user-images.githubusercontent.com/44844360/165639122-ba9b1877-c1a3-4d12-8d08-5197e1ea2599.png)
