### PR TITLE
GUI: Support setting permission on HyperKit machine driver

### DIFF
--- a/gui/window.h
+++ b/gui/window.h
@@ -181,7 +181,8 @@ private:
     QProcessEnvironment env;
 #if __APPLE__
     void hyperkitPermission();
-    void showHyperKitMessage();
+    bool hyperkitPermissionFix(QStringList args, QString text);
+    bool showHyperKitMessage();
 #endif
 
     // Error messaging

--- a/gui/window.h
+++ b/gui/window.h
@@ -179,6 +179,10 @@ private:
     Cluster createClusterObject(QJsonObject obj);
     QProcess *dashboardProcess;
     QProcessEnvironment env;
+#if __APPLE__
+    void hyperkitPermission();
+    void showHyperKitMessage();
+#endif
 
     // Error messaging
     void outputFailedStart(QString text);


### PR DESCRIPTION
Closes https://github.com/kubernetes/minikube/issues/14091

**How It Works:**
If a start fails on Mac, it checks the error message to see if the cause of the error was due to the `docker-machine-driver-hyperkit` not having the proper permissions set. If this is the case we notify the user of the issue via the message box shown below and once they click OK a terminal instance is automatically opened with the command that will apply the required permissions to the file, the user just has to enter their password to execute the command. After they enter the command the terminal closes and the start retries again.

![Screen Shot 2022-05-04 at 3 10 06 PM](https://user-images.githubusercontent.com/44844360/166834203-b983fb37-2041-42f8-80d2-78ed011bca56.png)
![Screen Shot 2022-05-03 at 11 23 15 AM](https://user-images.githubusercontent.com/44844360/166518825-fdd5385e-d85d-4754-ba51-d03fe0068f4f.png)
