### PR TITLE
Add cleanup and reboot to preload generation

### DIFF
--- a/hack/jenkins/preload_generation.sh
+++ b/hack/jenkins/preload_generation.sh
@@ -23,7 +23,6 @@ set -eux -o pipefail
 mkdir -p cron && gsutil -qm rsync "gs://minikube-builds/${MINIKUBE_LOCATION}/cron" cron || echo "FAILED TO GET CRON FILES"
 sudo install cron/cleanup_and_reboot_Linux.sh /etc/cron.hourly/cleanup_and_reboot || echo "FAILED TO INSTALL CLEANUP"
 
-
 # Make sure the right golang version is installed based on Makefile
 ./hack/jenkins/installers/check_install_golang.sh /usr/local
 

--- a/hack/jenkins/preload_generation.sh
+++ b/hack/jenkins/preload_generation.sh
@@ -20,7 +20,7 @@
 
 set -eux -o pipefail
 
-mkdir -p cron && gsutil -qm rsync "gs://minikube-builds/${MINIKUBE_LOCATION}/cron" cron || echo "FAILED TO GET CRON FILES"
+mkdir -p cron && gsutil -qm rsync "gs://minikube-builds/master/cron" cron || echo "FAILED TO GET CRON FILES"
 sudo install cron/cleanup_and_reboot_Linux.sh /etc/cron.hourly/cleanup_and_reboot || echo "FAILED TO INSTALL CLEANUP"
 
 # Make sure the right golang version is installed based on Makefile

--- a/hack/jenkins/preload_generation.sh
+++ b/hack/jenkins/preload_generation.sh
@@ -20,6 +20,10 @@
 
 set -eux -o pipefail
 
+mkdir -p cron && gsutil -qm rsync "gs://minikube-builds/${MINIKUBE_LOCATION}/cron" cron || echo "FAILED TO GET CRON FILES"
+sudo install cron/cleanup_and_reboot_Linux.sh /etc/cron.hourly/cleanup_and_reboot || echo "FAILED TO INSTALL CLEANUP"
+
+
 # Make sure the right golang version is installed based on Makefile
 ./hack/jenkins/installers/check_install_golang.sh /usr/local
 


### PR DESCRIPTION
We should install a cron to automatically clean up and reboot the preload generation server.

---
Background:
We recently encountered a service failure in the preload generation server due to lack of disk space. The /tmp directory contained over 350 GB of data that was no longer needed.

By cleaning up, we aim to ensure that our services perform with additional relaibility.