### PR TITLE
Mention podman for macOS use

### DIFF
--- a/site/content/en/docs/drivers/_index.md
+++ b/site/content/en/docs/drivers/_index.md
@@ -30,7 +30,7 @@ To do so, we use the [Docker Machine](https://github.com/docker/machine) library
 * [Parallels]({{<ref "parallels.md">}}) - VM
 * [VMware Fusion]({{<ref "vmware.md">}}) - VM
 * [SSH]({{<ref "ssh.md">}}) - remote ssh
-* [Podman]({{<ref "podman.md">}}) - container (experimental) use `--driver=podman` to get going.
+* [Podman]({{<ref "podman.md">}}) - container (experimental)
 
 ## Windows
 

--- a/site/content/en/docs/drivers/_index.md
+++ b/site/content/en/docs/drivers/_index.md
@@ -30,6 +30,7 @@ To do so, we use the [Docker Machine](https://github.com/docker/machine) library
 * [Parallels]({{<ref "parallels.md">}}) - VM
 * [VMware Fusion]({{<ref "vmware.md">}}) - VM
 * [SSH]({{<ref "ssh.md">}}) - remote ssh
+* [Podman]({{<ref "podman.md">}}) - container (experimental) use `--driver=podman` to get going.
 
 ## Windows
 


### PR DESCRIPTION
Using podman works for macOS  on ARM. See e.g. https://pilhuhn.medium.com/using-minikube-on-m1-macs-416da593ba0c

