### PR TITLE
Accept space before port in DashboardProxy Regex

### DIFF
--- a/cmd/minikube/cmd/dashboard.go
+++ b/cmd/minikube/cmd/dashboard.go
@@ -47,9 +47,9 @@ import (
 var (
 	dashboardURLMode     bool
 	dashboardExposedPort int
-	// Matches: 127.0.0.1:8001
+	// Matches: "127.0.0.1:8001" or "127.0.0.1 40012" etc.
 	// TODO(tstromberg): Get kubectl to implement a stable supported output format.
-	hostPortRe = regexp.MustCompile(`127.0.0.1:\d{4,}`)
+	hostPortRe = regexp.MustCompile(`127.0.0.1(:| )\d{4,}`)
 )
 
 // dashboardCmd represents the dashboard command


### PR DESCRIPTION
Fixes the hostPortRegex in DashboardCmd to accept " " or ":" between the port and the host. Seems MacOS kubectl returns "host port" while some other flavors of kubectl return "host:port". This fixes the latest flakes on TestFunctional/parallel/DashboardCmd. Fixes #12595
