### PR TITLE
install proper version of golang in arm64 kvm installer dockerfile

### DIFF
--- a/.github/workflows/functional_verified.yml
+++ b/.github/workflows/functional_verified.yml
@@ -8,6 +8,7 @@ on:
       - "**.yml"
       - "**.yaml"
       - "Makefile"
+      - "**Dockerfile**"
       - "!deploy/kicbase/**"
       - "!deploy/iso/**"
     types:

--- a/installers/linux/kvm/Dockerfile.arm64
+++ b/installers/linux/kvm/Dockerfile.arm64
@@ -33,7 +33,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
     libvirt-dev:arm64 && \
     dpkg --configure -a
 
-RUN curl -sSL https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz | tar -C /usr/local -xzf -
+RUN curl -sSL https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 
 ENV GOPATH /go
 


### PR DESCRIPTION
This is breaking our github action arm64 functional tests. We're installing the arm64 golang on an amd64 dockerfile which breaks a bunch of stuff.