### PR TITLE
GUI: Fix pause tray button having wrong text

### DIFF
--- a/gui/window.cpp
+++ b/gui/window.cpp
@@ -593,7 +593,7 @@ void Window::updateTrayActions(Cluster cluster)
     bool isPaused = cluster.status() == "Paused";
     pauseAction->setEnabled(isRunning || isPaused);
     stopAction->setEnabled(isRunning || isPaused);
-    pauseAction->setText(getPauseLabel(isRunning));
+    pauseAction->setText(getPauseLabel(isPaused));
     startAction->setText(getStartLabel(isRunning));
 }
 


### PR DESCRIPTION
The `Pause` tray icon would have the wrong text, so when the cluster was running it would say `Unpause` and when it was paused it would say `Pause`.