### PR TITLE
GUI: Check for updates again after 24 hours of usage

### DIFF
--- a/gui/window.h
+++ b/gui/window.h
@@ -97,6 +97,9 @@ public:
 protected:
     void closeEvent(QCloseEvent *event) override;
 
+signals:
+    void updateCheck();
+
 private slots:
     void messageClicked();
     void updateButtons();
@@ -215,6 +218,7 @@ private:
     void checkForUpdates();
     QString getRequest(QString url);
     void notifyUpdate(QString latest, QString link);
+    void setupUpdateChecking();
 };
 
 #endif // QT_NO_SYSTEMTRAYICON


### PR DESCRIPTION
Currently we're only checking for update on initial GUI startup, but users can be using the GUI for extended periods of time and they won't be notified of new updates. Now after 24 hours since the last check the GUI will again check for an update.