### PR TITLE
fix twitter bot message

### DIFF
--- a/.github/workflows/twitter-bot.yml
+++ b/.github/workflows/twitter-bot.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: ethomson/send-tweet-action@288f9339e0412e3038dce350e0da5ecdf12133a6
         with:
-          status: "minikube ${GITHUB_REF_NAME} was just released! Check it out: https://github.com/kubernetes/minikube/blob/master/CHANGELOG.md"
+          status: "minikube ${{github.ref_name}} was just released! Check it out: https://github.com/kubernetes/minikube/blob/master/CHANGELOG.md"
           consumer-key: ${{ secrets.TWITTER_API_KEY }}
           consumer-secret: ${{ secrets.TWITTER_API_SECRET }}
           access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}


### PR DESCRIPTION
I noticed that the environment variable `GITHUB_REF_NAME` was not inserted correctly in the Twitter message and test and fixed it.

Tweet of bot :
https://mobile.twitter.com/minikube_dev/status/1525219984204521472

## result of test

my test action code of my test repo ( using `${{github.ref_name}}` ) :
https://github.com/loftkun/ethomson-send-tweet-action-example/blob/main/.github/workflows/twitter-bot.yml#L15

result of test tweet ( tag name (`v1.23.4-beta.0`) in tweet message is correct. ):
https://mobile.twitter.com/loftkun/status/1525253664872484864

## trial and error

At first I thought `{` was missing, so I testd following code using `${{GITHUB_REF_NAME}}`

```yaml
status: "this is tweet action test : ${{GITHUB_REF_NAME }} was just released!"
```
But Action job result output the following error message.

```log
Invalid workflow file: .github/workflows/twitter-bot.yml#L15
The workflow is not valid. .github/workflows/twitter-bot.yml (Line: 15, Col: 19): Unrecognized named-value: 'GITHUB_REF_NAME'. Located at position 1 within expression: GITHUB_REF_NAME
```
So I used `github.ref_name` instead.

```yaml
status: "this is tweet action test : ${{github.ref_name}} was just released!"
```
I have confirmed, as noted above, that my test tweets correctly contain the name of the tag.
