### PR TITLE
fix qemu firmware path locations

### DIFF
--- a/pkg/drivers/qemu/qemu.go
+++ b/pkg/drivers/qemu/qemu.go
@@ -337,10 +337,6 @@ func (d *Driver) Start() error {
 
 	if d.MachineType != "" {
 		machineType := d.MachineType
-		if runtime.GOOS == "darwin" {
-			// highmem=off needed, see https://patchwork.kernel.org/project/qemu-devel/patch/20201126215017.41156-9-agraf@csgraf.de/#23800615 for details
-			machineType += ",highmem=off"
-		}
 		startCmd = append(startCmd,
 			"-M", machineType,
 		)

--- a/pkg/drivers/qemu/qemu.go
+++ b/pkg/drivers/qemu/qemu.go
@@ -270,6 +270,10 @@ func parsePortRange(rawPortRange string) (int, int, error) {
 
 	portRange := strings.Split(rawPortRange, "-")
 
+	if len(portRange) < 2 {
+		return 0, 0, errors.New("Invalid port range, must be at least of length 2")
+	}
+
 	minPort, err := strconv.Atoi(portRange[0])
 	if err != nil {
 		return 0, 0, errors.Wrap(err, "Invalid port range")
@@ -378,7 +382,7 @@ func (d *Driver) Start() error {
 	// hardware acceleration is important, it increases performance by 10x
 	if runtime.GOOS == "darwin" {
 		startCmd = append(startCmd, "-accel", "hvf")
-	} else if runtime.GOOS == "linux" {
+	} else if _, err := os.Stat("/dev/kvm"); err == nil && runtime.GOOS == "linux" {
 		startCmd = append(startCmd, "-accel", "kvm")
 	}
 

--- a/pkg/drivers/qemu/qemu.go
+++ b/pkg/drivers/qemu/qemu.go
@@ -380,10 +380,10 @@ func (d *Driver) Start() error {
 	}
 
 	// hardware acceleration is important, it increases performance by 10x
+	// kvm acceleration doesn't currently work for linux, it's incompatible with our chosen CPU
+	// once that's fixed we should add a branch for linux
 	if runtime.GOOS == "darwin" {
 		startCmd = append(startCmd, "-accel", "hvf")
-	} else if runtime.GOOS == "linux" {
-		startCmd = append(startCmd, "-accel", "kvm")
 	}
 
 	startCmd = append(startCmd,
@@ -427,9 +427,10 @@ func (d *Driver) Start() error {
 
 	// other options
 	// "-enable-kvm" if its available
-	if _, err := os.Stat("/dev/kvm"); err == nil {
+	// TODO (#14171): re-enable this once kvm acceleration is fixed
+	/*if _, err := os.Stat("/dev/kvm"); err == nil {
 		startCmd = append(startCmd, "-enable-kvm")
-	}
+	}*/
 
 	if d.CloudConfigRoot != "" {
 		startCmd = append(startCmd,

--- a/pkg/drivers/qemu/qemu.go
+++ b/pkg/drivers/qemu/qemu.go
@@ -380,10 +380,10 @@ func (d *Driver) Start() error {
 	}
 
 	// hardware acceleration is important, it increases performance by 10x
-	// kvm acceleration doesn't currently work for linux, it's incompatible with our chosen CPU
-	// once that's fixed we should add a branch for linux
 	if runtime.GOOS == "darwin" {
 		startCmd = append(startCmd, "-accel", "hvf")
+	} else if runtime.GOOS == "linux" {
+		startCmd = append(startCmd, "-accel", "kvm")
 	}
 
 	startCmd = append(startCmd,
@@ -424,13 +424,6 @@ func (d *Driver) Start() error {
 	}
 
 	startCmd = append(startCmd, "-daemonize")
-
-	// other options
-	// "-enable-kvm" if its available
-	// TODO (#14171): re-enable this once kvm acceleration is fixed
-	/*if _, err := os.Stat("/dev/kvm"); err == nil {
-		startCmd = append(startCmd, "-enable-kvm")
-	}*/
 
 	if d.CloudConfigRoot != "" {
 		startCmd = append(startCmd,

--- a/pkg/drivers/qemu/qemu.go
+++ b/pkg/drivers/qemu/qemu.go
@@ -339,7 +339,7 @@ func (d *Driver) Start() error {
 		machineType := d.MachineType
 		if runtime.GOOS == "darwin" {
 			// highmem=off needed, see https://patchwork.kernel.org/project/qemu-devel/patch/20201126215017.41156-9-agraf@csgraf.de/#23800615 for details
-			machineType += ",accel=hvf,highmem=off"
+			machineType += ",highmem=off"
 		}
 		startCmd = append(startCmd,
 			"-M", machineType,
@@ -377,6 +377,13 @@ func (d *Driver) Start() error {
 				"-display", "none",
 			)
 		}
+	}
+
+	// hardware acceleration is important, it increases performance by 10x
+	if runtime.GOOS == "darwin" {
+		startCmd = append(startCmd, "-accel", "hvf")
+	} else if runtime.GOOS == "linux" {
+		startCmd = append(startCmd, "-accel", "kvm")
 	}
 
 	startCmd = append(startCmd,

--- a/pkg/drivers/qemu/qemu.go
+++ b/pkg/drivers/qemu/qemu.go
@@ -38,6 +38,7 @@ import (
 	"github.com/docker/machine/libmachine/mcnutils"
 	"github.com/docker/machine/libmachine/ssh"
 	"github.com/docker/machine/libmachine/state"
+	"github.com/pkg/errors"
 
 	pkgdrivers "k8s.io/minikube/pkg/drivers"
 )
@@ -79,11 +80,9 @@ type Driver struct {
 	DiskPath         string
 	CacheMode        string
 	IOMode           string
-	//	conn             *libvirt.Connect
-	//	VM               *libvirt.Domain
-	UserDataFile    string
-	CloudConfigRoot string
-	LocalPorts      string
+	UserDataFile     string
+	CloudConfigRoot  string
+	LocalPorts       string
 }
 
 func (d *Driver) GetMachineName() string {
@@ -273,19 +272,19 @@ func parsePortRange(rawPortRange string) (int, int, error) {
 
 	minPort, err := strconv.Atoi(portRange[0])
 	if err != nil {
-		return 0, 0, fmt.Errorf("invalid port range")
+		return 0, 0, errors.Wrap(err, "Invalid port range")
 	}
 	maxPort, err := strconv.Atoi(portRange[1])
 	if err != nil {
-		return 0, 0, fmt.Errorf("invalid port range")
+		return 0, 0, errors.Wrap(err, "Invalid port range")
 	}
 
 	if maxPort < minPort {
-		return 0, 0, fmt.Errorf("invalid port range")
+		return 0, 0, errors.New("Invalid port range")
 	}
 
 	if maxPort-minPort < 2 {
-		return 0, 0, fmt.Errorf("port range must be minimum 2 ports")
+		return 0, 0, errors.New("Port range must be minimum 2 ports")
 	}
 
 	return minPort, maxPort, nil

--- a/pkg/minikube/registry/drvs/qemu2/qemu2.go
+++ b/pkg/minikube/registry/drvs/qemu2/qemu2.go
@@ -68,7 +68,6 @@ func qemuFirmwarePath() (string, error) {
 	arch := runtime.GOARCH
 	// For macOS, find the correct brew installation path for qemu firmware
 	if runtime.GOOS == "darwin" {
-		//return "/opt/homebrew/Cellar/qemu/6.2.0_1/share/qemu/edk2-aarch64-code.fd", nil
 		p := "/usr/local/Cellar/qemu"
 		fw := "share/qemu/edk2-x86_64-code.fd"
 		if arch == "arm64" {
@@ -86,6 +85,7 @@ func qemuFirmwarePath() (string, error) {
 			}
 		}
 	}
+
 	switch arch {
 	case "amd64":
 		return "/usr/share/OVMF/OVMF_CODE.fd", nil

--- a/pkg/minikube/registry/drvs/qemu2/qemu2.go
+++ b/pkg/minikube/registry/drvs/qemu2/qemu2.go
@@ -114,11 +114,12 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		qemuMachine = "" // default
 		qemuCPU = ""     // default
 	case "arm64":
+		qemuMachine = "virt"
+		qemuCPU = "cortex-a72"
 		// highmem=off needed, see https://patchwork.kernel.org/project/qemu-devel/patch/20201126215017.41156-9-agraf@csgraf.de/#23800615 for details
 		if runtime.GOOS == "darwin" {
 			qemuMachine = "virt,highmem=off"
-			qemuCPU = "cortex-a72"
-		} else if runtime.GOOS == "linux" {
+		} else if _, err := os.Stat("/dev/kvm"); err == nil {
 			qemuMachine = "virt,gic-version=3"
 			qemuCPU = "host"
 		}

--- a/pkg/minikube/registry/drvs/qemu2/qemu2.go
+++ b/pkg/minikube/registry/drvs/qemu2/qemu2.go
@@ -68,11 +68,16 @@ func qemuFirmwarePath() (string, error) {
 	arch := runtime.GOARCH
 	// For macOS, find the correct brew installation path for qemu firmware
 	if runtime.GOOS == "darwin" {
-		p := "/usr/local/Cellar/qemu"
-		fw := "share/qemu/edk2-x86_64-code.fd"
-		if arch == "arm64" {
+		var p, fw string
+		switch arch {
+		case "amd64":
+			p = "/usr/local/Cellar/qemu"
+			fw = "share/qemu/edk2-x86_64-code.fd"
+		case "arm64":
 			p = "/opt/homebrew/Cellar/qemu"
 			fw = "share/qemu/edk2-aarch64-code.fd"
+		default:
+			return "", fmt.Errorf("unknown arch: %s", arch)
 		}
 
 		v, err := ioutil.ReadDir(p)
@@ -109,8 +114,13 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		qemuMachine = "" // default
 		qemuCPU = ""     // default
 	case "arm64":
-		qemuMachine = "virt"
-		qemuCPU = "cortex-a72"
+		if runtime.GOOS == "darwin" {
+			qemuMachine = "virt"
+			qemuCPU = "cortex-a72"
+		} else if runtime.GOOS == "linux" {
+			qemuMachine = "gic-version=3"
+			qemuCPU = "host"
+		}
 	default:
 		return nil, fmt.Errorf("unknown arch: %s", runtime.GOARCH)
 	}

--- a/pkg/minikube/registry/drvs/qemu2/qemu2.go
+++ b/pkg/minikube/registry/drvs/qemu2/qemu2.go
@@ -114,11 +114,12 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		qemuMachine = "" // default
 		qemuCPU = ""     // default
 	case "arm64":
+		// highmem=off needed, see https://patchwork.kernel.org/project/qemu-devel/patch/20201126215017.41156-9-agraf@csgraf.de/#23800615 for details
 		if runtime.GOOS == "darwin" {
-			qemuMachine = "virt"
+			qemuMachine = "virt,highmem=off"
 			qemuCPU = "cortex-a72"
 		} else if runtime.GOOS == "linux" {
-			qemuMachine = "gic-version=3"
+			qemuMachine = "virt,gic-version=3"
 			qemuCPU = "host"
 		}
 	default:


### PR DESCRIPTION
This PR figures out the location of the qemu firmware path dynamically, rather than hardcoding a version path. Note that this still requires qemu to be installed by homebrew. 

This also allows x86_64 macOS machines to take advantage of hvf hardware acceleration for the qemu2 driver.

Fixes #14176 
