### PR TITLE
re-establish apiserver tunnel on restart 

### DIFF
--- a/pkg/drivers/qemu/qemu.go
+++ b/pkg/drivers/qemu/qemu.go
@@ -494,17 +494,17 @@ func (d *Driver) Stop() error {
 func (d *Driver) Remove() error {
 	s, err := d.GetState()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "get state")
 	}
 	if s == state.Running {
 		if err := d.Kill(); err != nil {
-			return err
+			return errors.Wrap(err, "kill")
 		}
 	}
 	if s != state.Stopped {
 		_, err = d.RunQMPCommand("quit")
 		if err != nil {
-			return err
+			return errors.Wrap(err, "quit")
 		}
 	}
 	return nil

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -290,6 +290,9 @@ func (k *Bootstrapper) init(cfg config.ClusterConfig) error {
 	}()
 
 	wg.Wait()
+	if cfg.APIServerPort != 0 {
+		k.tunnelToAPIServer(cfg)
+	}
 	return nil
 }
 
@@ -399,6 +402,10 @@ func (k *Bootstrapper) StartCluster(cfg config.ClusterConfig) error {
 	}
 
 	if err := bsutil.ExistingConfig(k.c); err == nil {
+		// Tunnel apiserver to guest, if needed
+		if cfg.APIServerPort != 0 {
+			k.tunnelToAPIServer(cfg)
+		}
 		klog.Infof("found existing configuration files, will attempt cluster restart")
 		rerr := k.restartControlPlane(cfg)
 		if rerr == nil {
@@ -431,6 +438,22 @@ func (k *Bootstrapper) StartCluster(cfg config.ClusterConfig) error {
 		return k.init(cfg)
 	}
 	return err
+}
+
+func (k *Bootstrapper) tunnelToAPIServer(cfg config.ClusterConfig) {
+	m, err := machine.NewAPIClient()
+	if err != nil {
+		klog.Warningf("libmachine API failed: %v", err)
+	}
+	cp, err := config.PrimaryControlPlane(&cfg)
+	if err != nil {
+		klog.Warningf("finding control plane failed: %v", err)
+	}
+	args := []string{"-f", "-NTL", fmt.Sprintf("%d:localhost:8443", cfg.APIServerPort)}
+	err = machine.CreateSSHShell(m, cfg, cp, args, false)
+	if err != nil {
+		klog.Warningf("apiserver tunnel failed: %v", err)
+	}
 }
 
 // client sets and returns a Kubernetes client to use to speak to a kubeadm launched apiserver
@@ -569,6 +592,7 @@ func (k *Bootstrapper) needsReconfigure(conf string, hostname string, port int, 
 		klog.Infof("needs reconfigure: configs differ:\n%s", rr.Output())
 		return true
 	}
+
 	// cruntime.Enable() may restart kube-apiserver but does not wait for it to return back
 	apiStatusTimeout := 3000 * time.Millisecond
 	st, err := kverify.WaitForAPIServerStatus(k.c, apiStatusTimeout, hostname, port)

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -290,6 +290,7 @@ func (k *Bootstrapper) init(cfg config.ClusterConfig) error {
 	}()
 
 	wg.Wait()
+	// Tunnel apiserver to guest, if necessary
 	if cfg.APIServerPort != 0 {
 		k.tunnelToAPIServer(cfg)
 	}
@@ -402,7 +403,7 @@ func (k *Bootstrapper) StartCluster(cfg config.ClusterConfig) error {
 	}
 
 	if err := bsutil.ExistingConfig(k.c); err == nil {
-		// Tunnel apiserver to guest, if needed
+		// If the guest already exists and was stopped, re-establish the apiserver tunnel so checks pass
 		if cfg.APIServerPort != 0 {
 			k.tunnelToAPIServer(cfg)
 		}

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -253,15 +253,6 @@ func handleAPIServer(starter Starter, cr cruntime.Manager, hostIP net.IP) (*kube
 		return nil, bs, err
 	}
 
-	// Tunnel apiserver to guest, if needed
-	if starter.Cfg.APIServerPort != 0 {
-		args := []string{"-f", "-NTL", fmt.Sprintf("%d:localhost:8443", starter.Cfg.APIServerPort)}
-		err := machine.CreateSSHShell(starter.MachineAPI, *starter.Cfg, *starter.Node, args, false)
-		if err != nil {
-			klog.Warningf("apiserver tunnel failed: %v", err)
-		}
-	}
-
 	// Write the kubeconfig to the file system after everything required (like certs) are created by the bootstrapper.
 	if err := kubeconfig.Update(kcs); err != nil {
 		return nil, bs, errors.Wrap(err, "Failed kubeconfig update")


### PR DESCRIPTION
After a `minikube start --driver=qemu2` and `minikube stop`:
Before:
```
😄  minikube v1.26.0-beta.0 on Darwin 12.3.1
✨  Using the qemu2 (experimental) driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
🔄  Restarting existing qemu2 VM for "minikube" ...
🐳  Preparing Kubernetes v1.23.6 on Docker 20.10.14 ...
🤦  Unable to restart cluster, will reset it: apiserver health: apiserver healthz never reported healthy: cluster wait timed out during healthz check
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```

After:
```
😄  minikube v1.26.0-beta.0 on Darwin 12.3.1
✨  Using the qemu2 (experimental) driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
🔄  Restarting existing qemu2 VM for "minikube" ...
🐳  Preparing Kubernetes v1.23.6 on Docker 20.10.14 ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```

This change make tunneling a little smarter, so it knows to tunnel on restart before checking the api server. This prevents the timeout and hard restart we see in the Before section.

Fixes #14171 