### PR TITLE
Fix not passing any args to test

### DIFF
--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -120,7 +120,7 @@ func TestStartStop(t *testing.T) {
 				}
 				if version.GTE(semver.MustParse("1.24.0-alpha.2")) {
 					args := []string{}
-					for _, arg := range args {
+					for _, arg := range startArgs {
 						if arg == "--extra-config=kubelet.network-plugin=cni" {
 							continue
 						}


### PR DESCRIPTION
**Problem:**
No args were getting passed to `TestStartStop` with k8s v1.24 resulting in test failures. The cause was code meant to strip out a specific flag, however, it was iterating over the brand new empty slice instead of the existing slice, resulting in all flags being removed.