### PR TITLE
 Show the container runtime when running without kubernetes #13432 

### DIFF
--- a/pkg/minikube/node/config.go
+++ b/pkg/minikube/node/config.go
@@ -51,6 +51,11 @@ func showVersionInfo(k8sVersion string, cr cruntime.Manager) {
 	}
 }
 
+func showNotK8sVersionInfo(cr cruntime.Manager) {
+	version, _ := cr.Version()
+	out.Step(cr.Style(), "Preparing {{.runtime}} {{.runtimeVersion}} ...", out.V{"runtime": cr.Name(), "runtimeVersion": version})
+}
+
 // configureMounts configures any requested filesystem mounts
 func configureMounts(wg *sync.WaitGroup, cc config.ClusterConfig) {
 	wg.Add(1)

--- a/pkg/minikube/node/config.go
+++ b/pkg/minikube/node/config.go
@@ -51,7 +51,7 @@ func showVersionInfo(k8sVersion string, cr cruntime.Manager) {
 	}
 }
 
-func showNotK8sVersionInfo(cr cruntime.Manager) {
+func showNoK8sVersionInfo(cr cruntime.Manager) {
 	version, _ := cr.Version()
 	out.Step(cr.Style(), "Preparing {{.runtime}} {{.runtimeVersion}} ...", out.V{"runtime": cr.Name(), "runtimeVersion": version})
 }

--- a/pkg/minikube/node/config.go
+++ b/pkg/minikube/node/config.go
@@ -52,7 +52,17 @@ func showVersionInfo(k8sVersion string, cr cruntime.Manager) {
 }
 
 func showNoK8sVersionInfo(cr cruntime.Manager) {
-	version, _ := cr.Version()
+	err := cruntime.CheckCompatibility(cr)
+	if err != nil {
+		klog.Warningf("%s check compatibility failed: %v", cr.Name(), err)
+
+	}
+
+	version, err := cr.Version()
+	if err != nil {
+		klog.Warningf("%s get version failed: %v", cr.Name(), err)
+	}
+
 	out.Step(cr.Style(), "Preparing {{.runtime}} {{.runtimeVersion}} ...", out.V{"runtime": cr.Name(), "runtimeVersion": version})
 }
 

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -102,7 +102,7 @@ func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 		if err = cruntime.CheckCompatibility(cr); err != nil {
 			return nil, err
 		}
-		
+
 		showNotK8sVersionInfo(cr)
 
 		configureMounts(&wg, *starter.Cfg)

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -346,7 +346,7 @@ func Provision(cc *config.ClusterConfig, n *config.Node, apiServer bool, delOnFa
 
 	// Be explicit with each case for the sake of translations
 	if cc.KubernetesConfig.KubernetesVersion == constants.NoKubernetesVersion {
-		out.Step(style.ThumbsUp, "Starting minikube without Kubernetes {{.name}} in cluster {{.cluster}}", out.V{"name": name, "cluster": cc.Name})
+		out.Step(style.ThumbsUp, "Starting minikube without Kubernetes in cluster {{.cluster}}", out.V{"cluster": cc.Name})
 	} else {
 		if apiServer {
 			out.Step(style.ThumbsUp, "Starting control plane node {{.name}} in cluster {{.cluster}}", out.V{"name": name, "cluster": cc.Name})

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -99,10 +99,6 @@ func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 		nv := semver.Version{Major: 0, Minor: 0, Patch: 0}
 		cr := configureRuntimes(starter.Runner, *starter.Cfg, nv)
 
-		if err = cruntime.CheckCompatibility(cr); err != nil {
-			return nil, err
-		}
-
 		showNoK8sVersionInfo(cr)
 
 		configureMounts(&wg, *starter.Cfg)

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -97,7 +97,14 @@ func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 	}
 	if stopk8s {
 		nv := semver.Version{Major: 0, Minor: 0, Patch: 0}
-		configureRuntimes(starter.Runner, *starter.Cfg, nv)
+		cr := configureRuntimes(starter.Runner, *starter.Cfg, nv)
+
+		if err = cruntime.CheckCompatibility(cr); err != nil {
+			return nil, err
+		}
+		
+		showNotK8sVersionInfo(cr)
+
 		configureMounts(&wg, *starter.Cfg)
 		return nil, config.Write(viper.GetString(config.ProfileName), starter.Cfg)
 	}

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -103,7 +103,7 @@ func Start(starter Starter, apiServer bool) (*kubeconfig.Settings, error) {
 			return nil, err
 		}
 
-		showNotK8sVersionInfo(cr)
+		showNoK8sVersionInfo(cr)
 
 		configureMounts(&wg, *starter.Cfg)
 		return nil, config.Write(viper.GetString(config.ProfileName), starter.Cfg)


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

fixes #13432
In summary it is to show the runtime used when --no-kubernetes option is used to start minikube.
Also improves the readability of the sentence "Starting minikube without Kubernetes {machine name} in cluster {cluster}" by removing the machine name.


Changes to UI
Before:
![image](https://user-images.githubusercontent.com/18228506/169543505-56ae854f-4716-45cd-b8aa-49ef7288152f.png)

After:
![image](https://user-images.githubusercontent.com/18228506/169543730-77231979-0b7e-4fff-8816-6315f8c7a120.png)

