### PR TITLE
CI: Fix overwriting previous cron

### DIFF
--- a/hack/jenkins/installers/check_install_osx_crons.sh
+++ b/hack/jenkins/installers/check_install_osx_crons.sh
@@ -19,5 +19,5 @@ set -e
 mkdir -p cron && gsutil -qm rsync "gs://minikube-builds/${MINIKUBE_LOCATION}/cron" cron || echo "FAILED TO GET CRON FILES"
 install cron/cleanup_and_reboot_Darwin.sh $HOME/cleanup_and_reboot.sh || echo "FAILED TO INSTALL CLEANUP AND REBOOT"
 install cron/cleanup_go_modules.sh $HOME/cleanup_go_modules.sh || echo "FAILED TO INSTALL GO MODULES CLEANUP"
-echo "echo "*/30 * * * * $HOME/cleanup_and_reboot.sh\n0 0 1 * * $HOME/cleanup_go_modules.sh" | crontab
+echo "*/30 * * * * $HOME/cleanup_and_reboot.sh\n0 0 1 * * $HOME/cleanup_go_modules.sh" | crontab
 crontab -l

--- a/hack/jenkins/installers/check_install_osx_crons.sh
+++ b/hack/jenkins/installers/check_install_osx_crons.sh
@@ -18,7 +18,6 @@ set -e
 
 mkdir -p cron && gsutil -qm rsync "gs://minikube-builds/${MINIKUBE_LOCATION}/cron" cron || echo "FAILED TO GET CRON FILES"
 install cron/cleanup_and_reboot_Darwin.sh $HOME/cleanup_and_reboot.sh || echo "FAILED TO INSTALL CLEANUP AND REBOOT"
-echo "*/30 * * * * $HOME/cleanup_and_reboot.sh" | crontab
 install cron/cleanup_go_modules.sh $HOME/cleanup_go_modules.sh || echo "FAILED TO INSTALL GO MODULES CLEANUP"
-echo "0 0 1 * * $HOME/cleanup_go_modules.sh" | crontab
+echo "echo "*/30 * * * * $HOME/cleanup_and_reboot.sh\n0 0 1 * * $HOME/cleanup_go_modules.sh" | crontab
 crontab -l


### PR DESCRIPTION
Was writing two cron job on Mac using `<cron> | crontab` however that overwrites the entire crontab, so the second job was overwriting the first job resulting in the Mac machines not getting cleaned up and rebooted.
