### PR TITLE
kicbase: don't build cri-dockerd from source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -702,6 +702,11 @@ KICBASE_IMAGE_GCR ?= $(REGISTRY)/kicbase:$(KIC_VERSION)
 KICBASE_IMAGE_HUB ?= kicbase/stable:$(KIC_VERSION)
 KICBASE_IMAGE_REGISTRIES ?= $(KICBASE_IMAGE_GCR) $(KICBASE_IMAGE_HUB)
 
+CRI_DOCKERD_VERSION ?= $(shell egrep "CRI_DOCKERD_VERSION=" deploy/kicbase/Dockerfile | cut -d \" -f2)
+.PHONY: update-cri-dockerd
+update-cri-dockerd:
+	hack/update/cri_dockerd/update_cri_dockerd.sh $(CRI_DOCKERD_VERSION) $(KICBASE_ARCH)
+
 .PHONY: local-kicbase
 local-kicbase: ## Builds the kicbase image and tags it local/kicbase:latest and local/kicbase:$(KIC_VERSION)-$(COMMIT_SHORT)
 	docker build -f ./deploy/kicbase/Dockerfile -t local/kicbase:$(KIC_VERSION)  --build-arg COMMIT_SHA=${VERSION}-$(COMMIT) --cache-from $(KICBASE_IMAGE_GCR) .

--- a/deploy/addons/metrics-server/metrics-server-deployment.yaml.tmpl
+++ b/deploy/addons/metrics-server/metrics-server-deployment.yaml.tmpl
@@ -47,14 +47,14 @@ spec:
           protocol: TCP
         readinessProbe:
           httpGet:
-            path: /readyz?exclude=livez
+            path: /readyz
             port: https
             scheme: HTTPS
           periodSeconds: 10
           failureThreshold: 3
         livenessProbe:
           httpGet:
-            path: /livez?exclude=readyz
+            path: /livez
             port: https
             scheme: HTTPS
           periodSeconds: 10

--- a/deploy/addons/metrics-server/metrics-server-deployment.yaml.tmpl
+++ b/deploy/addons/metrics-server/metrics-server-deployment.yaml.tmpl
@@ -47,14 +47,14 @@ spec:
           protocol: TCP
         readinessProbe:
           httpGet:
-            path: /readyz
+            path: /readyz?exclude=livez
             port: https
             scheme: HTTPS
           periodSeconds: 10
           failureThreshold: 3
         livenessProbe:
           httpGet:
-            path: /livez
+            path: /livez?exclude=readyz
             port: https
             scheme: HTTPS
           periodSeconds: 10

--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -18,22 +18,30 @@
 # https://systemd.io/CONTAINER_INTERFACE/
 
 
-# multi-tage docker build so we can build auto-pause for arm64
-FROM golang:1.17
+# multi-stage docker build so we can build auto-pause for arm64
+FROM golang:1.17 as auto-pause
 WORKDIR /src
-# becaue auto-pause binary depends on minikube's code we need to pass the whole source code as the context
-ADD . .
+# auto-pause depends on core minikube code so we need to pass the whole source code as the context
+# copy in the minimal amount of source code possible
+COPY pkg/ ./pkg
+COPY cmd/ ./cmd
+COPY deploy/addons ./deploy/addons
+COPY translations/ ./translations
+COPY third_party/ ./third_party
+COPY go.mod go.sum ./
+ARG TARGETARCH
+ENV GOARCH=${TARGETARCH}
 RUN cd ./cmd/auto-pause/ && go build 
 
 # cri-dockerd static
-FROM golang:1.16
+FROM golang:1.16 as cri-dockerd
 RUN git clone -n https://github.com/Mirantis/cri-dockerd && \
     cd cri-dockerd && git checkout a4d1895a2659ea9974bd7528a706592ab8b74181 && \
     cd src && env CGO_ENABLED=0 go build -ldflags '-X github.com/Mirantis/cri-dockerd/version.GitCommit=a4d1895' -o cri-dockerd
 
 # start from ubuntu 20.04, this image is reasonably small as a starting point
 # for a kubernetes node image, it doesn't contain much we don't need
-FROM ubuntu:focal-20220316
+FROM ubuntu:focal-20220316 as kicbase
 
 ARG BUILDKIT_VERSION="v0.10.3"
 ARG FUSE_OVERLAYFS_VERSION="v1.7.1"
@@ -46,10 +54,10 @@ COPY deploy/kicbase/11-tcp-mtu-probing.conf /etc/sysctl.d/11-tcp-mtu-probing.con
 COPY deploy/kicbase/02-crio.conf /etc/crio/crio.conf.d/02-crio.conf
 COPY deploy/kicbase/clean-install /usr/local/bin/clean-install
 COPY deploy/kicbase/entrypoint /usr/local/bin/entrypoint
-COPY --from=0 /src/cmd/auto-pause/auto-pause /bin/auto-pause
-COPY --from=1 /go/cri-dockerd/src/cri-dockerd /usr/bin/cri-dockerd
-COPY --from=1 /go/cri-dockerd/packaging/systemd/cri-docker.service /usr/lib/systemd/system/cri-docker.service
-COPY --from=1 /go/cri-dockerd/packaging/systemd/cri-docker.socket /usr/lib/systemd/system/cri-docker.socket
+COPY --from=auto-pause /src/cmd/auto-pause/auto-pause /bin/auto-pause
+COPY --from=cri-dockerd /go/cri-dockerd/src/cri-dockerd /usr/bin/cri-dockerd
+COPY --from=cri-dockerd /go/cri-dockerd/packaging/systemd/cri-docker.service /usr/lib/systemd/system/cri-docker.service
+COPY --from=cri-dockerd /go/cri-dockerd/packaging/systemd/cri-docker.socket /usr/lib/systemd/system/cri-docker.socket
 
 # Install dependencies, first from apt, then from release tarballs.
 # NOTE: we use one RUN to minimize layers.
@@ -162,9 +170,9 @@ RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/') && \
     curl -LO https://downloadcontent.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_20.04/Release.key && \
     apt-key add - < Release.key && \
     if [ "$ARCH" != "ppc64le" ]; then \
-    	clean-install containers-common catatonit conmon containernetworking-plugins cri-tools podman-plugins crun; \
+       clean-install containers-common conmon containernetworking-plugins cri-tools crun podman podman-plugins catatonit; \
     else \
-    	clean-install containers-common conmon containernetworking-plugins crun; \
+       clean-install containers-common conmon containernetworking-plugins crun; \
     fi
 
 # install cri-o based on https://github.com/cri-o/cri-o/blob/release-1.22/README.md#installing-cri-o

--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -170,9 +170,9 @@ RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/') && \
     curl -LO https://downloadcontent.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_20.04/Release.key && \
     apt-key add - < Release.key && \
     if [ "$ARCH" != "ppc64le" ]; then \
-       clean-install containers-common conmon containernetworking-plugins cri-tools crun podman-plugins catatonit; \
+        	clean-install containers-common catatonit conmon containernetworking-plugins cri-tools podman-plugins crun; \
     else \
-       clean-install containers-common conmon containernetworking-plugins crun; \
+       		clean-install containers-common conmon containernetworking-plugins crun; \
     fi
 
 # install cri-o based on https://github.com/cri-o/cri-o/blob/release-1.22/README.md#installing-cri-o

--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -170,9 +170,9 @@ RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/') && \
     curl -LO https://downloadcontent.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_20.04/Release.key && \
     apt-key add - < Release.key && \
     if [ "$ARCH" != "ppc64le" ]; then \
-        	clean-install containers-common catatonit conmon containernetworking-plugins cri-tools podman-plugins crun; \
+        clean-install containers-common catatonit conmon containernetworking-plugins cri-tools podman-plugins crun; \
     else \
-       		clean-install containers-common conmon containernetworking-plugins crun; \
+       	clean-install containers-common conmon containernetworking-plugins crun; \
     fi
 
 # install cri-o based on https://github.com/cri-o/cri-o/blob/release-1.22/README.md#installing-cri-o

--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -170,7 +170,7 @@ RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/') && \
     curl -LO https://downloadcontent.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_20.04/Release.key && \
     apt-key add - < Release.key && \
     if [ "$ARCH" != "ppc64le" ]; then \
-       clean-install containers-common conmon containernetworking-plugins cri-tools crun podman podman-plugins catatonit; \
+       clean-install containers-common conmon containernetworking-plugins cri-tools crun podman-plugins catatonit; \
     else \
        clean-install containers-common conmon containernetworking-plugins crun; \
     fi

--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -33,12 +33,6 @@ ARG TARGETARCH
 ENV GOARCH=${TARGETARCH}
 RUN cd ./cmd/auto-pause/ && go build 
 
-# cri-dockerd static
-FROM golang:1.16 as cri-dockerd
-RUN git clone -n https://github.com/Mirantis/cri-dockerd && \
-    cd cri-dockerd && git checkout a4d1895a2659ea9974bd7528a706592ab8b74181 && \
-    cd src && env CGO_ENABLED=0 go build -ldflags '-X github.com/Mirantis/cri-dockerd/version.GitCommit=a4d1895' -o cri-dockerd
-
 # start from ubuntu 20.04, this image is reasonably small as a starting point
 # for a kubernetes node image, it doesn't contain much we don't need
 FROM ubuntu:focal-20220316 as kicbase
@@ -47,6 +41,8 @@ ARG BUILDKIT_VERSION="v0.10.3"
 ARG FUSE_OVERLAYFS_VERSION="v1.7.1"
 ARG CONTAINERD_FUSE_OVERLAYFS_VERSION="1.0.3"
 ARG CRIO_VERSION="1.22"
+ARG CRI_DOCKERD_VERSION="a4d1895a2659ea9974bd7528a706592ab8b74181"
+ARG TARGETARCH
 
 # copy in static files (configs, scripts)
 COPY deploy/kicbase/10-network-security.conf /etc/sysctl.d/10-network-security.conf
@@ -55,9 +51,7 @@ COPY deploy/kicbase/02-crio.conf /etc/crio/crio.conf.d/02-crio.conf
 COPY deploy/kicbase/clean-install /usr/local/bin/clean-install
 COPY deploy/kicbase/entrypoint /usr/local/bin/entrypoint
 COPY --from=auto-pause /src/cmd/auto-pause/auto-pause /bin/auto-pause
-COPY --from=cri-dockerd /go/cri-dockerd/src/cri-dockerd /usr/bin/cri-dockerd
-COPY --from=cri-dockerd /go/cri-dockerd/packaging/systemd/cri-docker.service /usr/lib/systemd/system/cri-docker.service
-COPY --from=cri-dockerd /go/cri-dockerd/packaging/systemd/cri-docker.socket /usr/lib/systemd/system/cri-docker.socket
+
 
 # Install dependencies, first from apt, then from release tarballs.
 # NOTE: we use one RUN to minimize layers.
@@ -125,6 +119,12 @@ ARG COMMIT_SHA
 # which is an ubuntu 20.10 with an entry-point that helps running systemd
 # could be changed to any debian that can run systemd
 USER root
+
+# Install cri-dockerd from pre-compiled binaries stored in GCS, this is way faster than building from source in multi-arch
+RUN echo "Installing cri-dockerd" && \
+	curl -L "https://storage.googleapis.com/kicbase-artifacts/cri-dockerd/${CRI_DOCKERD_VERSION}/${TARGETARCH}/cri-dockerd" -o /usr/bin/cri-dockerd && \
+	curl -L "https://storage.googleapis.com/kicbase-artifacts/cri-dockerd/${CRI_DOCKERD_VERSION}/cri-docker.socket" -o /usr/lib/systemd/system/cri-docker.socket && \
+	curl -L "https://storage.googleapis.com/kicbase-artifacts/cri-dockerd/${CRI_DOCKERD_VERSION}/cri-docker.service" -o /usr/lib/systemd/system/cri-docker.service
 
 # install system requirements from the regular distro repositories
 RUN clean-install \

--- a/hack/update/cri_dockerd/update_cri_dockerd.sh
+++ b/hack/update/cri_dockerd/update_cri_dockerd.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eux -o pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: update_cri_dockerd.sh <version> <archlist>" >&2
+  exit 1
+fi
+
+readonly version=$1
+archlist=$2
+
+IFS=, read -a archarray <<< "$archlist"
+
+tmpdir=$(mktemp -d)
+pushd $tmpdir
+git clone -n https://github.com/Mirantis/cri-dockerd
+cd cri-dockerd
+git checkout $version
+cd src
+
+for (( i=0; i < ${#archarray[*]}; i++ ))
+do
+	arch=${archarray[i]#"linux/"}
+	env GOOS=linux GOARCH=$arch CGO_ENABLED=0 go build -ldflags '-X github.com/Mirantis/cri-dockerd/version.GitCommit=a4d1895' -o cri-dockerd-$arch
+	gsutil cp cri-dockerd-$arch gs://kicbase-artifacts/cri-dockerd/$version/$arch/cri-dockerd
+
+done
+
+cd ..
+gsutil cp ./packaging/systemd/cri-docker.service gs://kicbase-artifacts/cri-dockerd/$version/cri-docker.service
+gsutil cp ./packaging/systemd/cri-docker.socket gs://kicbase-artifacts/cri-dockerd/$version/cri-docker.socket
+
+popd
+rm -rf $tmpdir

--- a/hack/update/cri_dockerd/update_cri_dockerd.sh
+++ b/hack/update/cri_dockerd/update_cri_dockerd.sh
@@ -36,7 +36,7 @@ cd src
 for (( i=0; i < ${#archarray[*]}; i++ ))
 do
 	arch=${archarray[i]#"linux/"}
-	env GOOS=linux GOARCH=$arch CGO_ENABLED=0 go build -ldflags '-X github.com/Mirantis/cri-dockerd/version.GitCommit=a4d1895' -o cri-dockerd-$arch
+	env GOOS=linux GOARCH=$arch CGO_ENABLED=0 go build -ldflags "-X github.com/Mirantis/cri-dockerd/version.GitCommit=${version:0:7}" -o cri-dockerd-$arch
 	gsutil cp cri-dockerd-$arch gs://kicbase-artifacts/cri-dockerd/$version/$arch/cri-dockerd
 
 done

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -24,13 +24,13 @@ import (
 
 const (
 	// Version is the current version of kic
-	Version = "v0.0.31"
+	Version = "v0.0.31-1653596720-14230"
 	// SHA of the kic base image
-	baseImageSHA = "c3375f1b260bd936aa532a0c749626e07d94ab129a7f2395e95345aa04ca708c"
+	baseImageSHA = "e953786303ac8350802546ee187d34e89f0007072a54fdbcc2f86a1fb8575418"
 	// The name of the GCR kicbase repository
-	gcrRepo = "gcr.io/k8s-minikube/kicbase"
+	gcrRepo = "gcr.io/k8s-minikube/kicbase-builds"
 	// The name of the Dockerhub kicbase repository
-	dockerhubRepo = "docker.io/kicbase/stable"
+	dockerhubRepo = "docker.io/kicbase/build"
 )
 
 var (

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -26,7 +26,7 @@ minikube start [flags]
       --apiserver-names strings           A set of apiserver names which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine
       --apiserver-port int                The apiserver listening port (default 8443)
       --auto-update-drivers               If set, automatically updates drivers to the latest version. Defaults to true. (default true)
-      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase:v0.0.31@sha256:c3375f1b260bd936aa532a0c749626e07d94ab129a7f2395e95345aa04ca708c")
+      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.31-1653596720-14230@sha256:e953786303ac8350802546ee187d34e89f0007072a54fdbcc2f86a1fb8575418")
       --binary-mirror string              Location to fetch kubectl, kubelet, & kubeadm binaries from.
       --cache-images                      If true, cache docker images for the current bootstrapper and load them into the machine. Always false with --driver=none. (default true)
       --cert-expiration duration          Duration until minikube certificate expiration, defaults to three years (26280h). (default 26280h0m0s)


### PR DESCRIPTION
kicbase was taking over 4 hours to build, because we were building both auto-pause and cri-dockerd from source for 5 different architectures, 4 of which use qemu for cross-compilation. 

This PR grabs pre-compiled cri-dockerd binaries currently stored in GCS and copies them into the images. This takes the kicbase build back under 2 hours, which is where it was before we were forced to add cri-dockerd.