### PR TITLE
CI: Fix crontab on Mac machines

### DIFF
--- a/hack/jenkins/installers/check_install_osx_crons.sh
+++ b/hack/jenkins/installers/check_install_osx_crons.sh
@@ -18,6 +18,7 @@ set -e
 
 mkdir -p cron && gsutil -qm rsync "gs://minikube-builds/${MINIKUBE_LOCATION}/cron" cron || echo "FAILED TO GET CRON FILES"
 install cron/cleanup_and_reboot_Darwin.sh $HOME/cleanup_and_reboot.sh || echo "FAILED TO INSTALL CLEANUP AND REBOOT"
+echo "*/30 * * * * $HOME/cleanup_and_reboot.sh" | crontab
 install cron/cleanup_go_modules.sh $HOME/cleanup_go_modules.sh || echo "FAILED TO INSTALL GO MODULES CLEANUP"
-echo "*/30 * * * * $HOME/cleanup_and_reboot.sh\n0 0 1 * * $HOME/cleanup_go_modules.sh" | crontab
+(crontab -l ; echo "0 0 1 * * $HOME/cleanup_go_modules.sh")| crontab -
 crontab -l


### PR DESCRIPTION
`echo "*/30 * * * * $HOME/cleanup_and_reboot.sh\n0 0 1 * * $HOME/cleanup_go_modules.sh" | crontab` works correctly on `zsh` (where I tested it), but does not work on `bash` (where it's actually being ran), so updated to work on `bash`.