### PR TITLE
GUI: Fix opening window during command running

### DIFF
--- a/gui/commandrunner.cpp
+++ b/gui/commandrunner.cpp
@@ -18,11 +18,13 @@ CommandRunner::CommandRunner(QDialog *parent)
 
 void CommandRunner::executeMinikubeCommand(QStringList args)
 {
+    m_isRunning = true;
     m_output = "";
     QStringList userArgs = { "--user", "minikube-gui" };
     args << userArgs;
     m_process = new QProcess(m_parent);
-    connect(m_process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this, &CommandRunner::executionCompleted);
+    connect(m_process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this,
+            &CommandRunner::executionCompleted);
     connect(m_process, &QProcess::readyReadStandardError, this, &CommandRunner::errorReady);
     connect(m_process, &QProcess::readyReadStandardOutput, this, &CommandRunner::outputReady);
     m_process->setProcessEnvironment(m_env);
@@ -163,6 +165,7 @@ void CommandRunner::requestClusters()
 
 void CommandRunner::executionCompleted()
 {
+    m_isRunning = false;
     QString cmd = m_command;
     m_command = "";
     QString output = m_output;
@@ -211,4 +214,9 @@ void CommandRunner::minikubePath()
     }
     QStringList path = { "/usr/local/bin" };
     m_minikubePath = QStandardPaths::findExecutable("minikube", path);
+}
+
+bool CommandRunner::isRunning()
+{
+    return m_isRunning;
 }

--- a/gui/commandrunner.h
+++ b/gui/commandrunner.h
@@ -25,6 +25,7 @@ public:
     void deleteMinikube(QStringList args);
     void stopCommand();
     void requestClusters();
+    bool isRunning();
 
 signals:
     void startingExecution();
@@ -53,6 +54,7 @@ private:
     QString m_command;
     QDialog *m_parent;
     QStringList m_args;
+    bool m_isRunning;
 };
 
 #endif // COMMANDRUNNER_H

--- a/gui/errormessage.cpp
+++ b/gui/errormessage.cpp
@@ -13,7 +13,8 @@ ErrorMessage::ErrorMessage(QDialog *parent, QIcon icon)
     m_icon = icon;
 }
 
-void ErrorMessage::error(QString errorCode, QString advice, QString message, QString url, QString issues)
+void ErrorMessage::error(QString errorCode, QString advice, QString message, QString url,
+                         QString issues)
 {
 
     m_dialog = new QDialog(m_parent);

--- a/gui/errormessage.h
+++ b/gui/errormessage.h
@@ -14,7 +14,8 @@ class ErrorMessage : public QObject
 public:
     explicit ErrorMessage(QDialog *parent, QIcon icon);
 
-    void error(QString errorCode, QString advice, QString errorMessage, QString url, QString issues);
+    void error(QString errorCode, QString advice, QString errorMessage, QString url,
+               QString issues);
     QLabel *createLabel(QString title, QString text, QFormLayout *form, bool isLink);
 
 private:

--- a/gui/operator.cpp
+++ b/gui/operator.cpp
@@ -5,7 +5,10 @@
 #include <QJsonDocument>
 #include <QStandardPaths>
 
-Operator::Operator(AdvancedView *advancedView, BasicView *basicView, CommandRunner *commandRunner, ErrorMessage *errorMessage, ProgressWindow *progressWindow, Tray *tray, HyperKit *hyperKit, Updater *updater, QStackedWidget *stackedWidget, QDialog *parent)
+Operator::Operator(AdvancedView *advancedView, BasicView *basicView, CommandRunner *commandRunner,
+                   ErrorMessage *errorMessage, ProgressWindow *progressWindow, Tray *tray,
+                   HyperKit *hyperKit, Updater *updater, QStackedWidget *stackedWidget,
+                   QDialog *parent)
 {
     m_advancedView = advancedView;
     m_basicView = basicView;
@@ -37,14 +40,16 @@ Operator::Operator(AdvancedView *advancedView, BasicView *basicView, CommandRunn
     connect(m_advancedView, &AdvancedView::dashboard, this, &Operator::dashboardBrowser);
     connect(m_advancedView, &AdvancedView::basic, this, &Operator::toBasicView);
     connect(m_advancedView, &AdvancedView::createCluster, this, &Operator::createCluster);
-    connect(m_advancedView->clusterListView, SIGNAL(clicked(QModelIndex)), this, SLOT(updateButtons()));
+    connect(m_advancedView->clusterListView, SIGNAL(clicked(QModelIndex)), this,
+            SLOT(updateButtons()));
 
     connect(m_commandRunner, &CommandRunner::startingExecution, this, &Operator::commandStarting);
     connect(m_commandRunner, &CommandRunner::executionEnded, this, &Operator::commandEnding);
     connect(m_commandRunner, &CommandRunner::output, this, &Operator::commandOutput);
     connect(m_commandRunner, &CommandRunner::error, this, &Operator::commandError);
     connect(m_commandRunner, &CommandRunner::updatedClusters, this, &Operator::clustersReceived);
-    connect(m_commandRunner, &CommandRunner::startCommandStarting, this, &Operator::startCommandStarting);
+    connect(m_commandRunner, &CommandRunner::startCommandStarting, this,
+            &Operator::startCommandStarting);
 
     connect(m_progressWindow, &ProgressWindow::cancelled, this, &Operator::cancelCommand);
 
@@ -185,6 +190,8 @@ void Operator::restoreWindow()
     if (wasVisible) {
         return;
     }
+    if (m_commandRunner->isRunning())
+        return;
     updateClusters();
 }
 

--- a/gui/operator.h
+++ b/gui/operator.h
@@ -18,7 +18,9 @@ class Operator : public QObject
     Q_OBJECT
 
 public:
-    Operator(AdvancedView *advancedView, BasicView *basicView, CommandRunner *commandRunner, ErrorMessage *errorMessage, ProgressWindow *progressWindow, Tray *tray, HyperKit *hyperKit, Updater *updater, QStackedWidget *stackedWidget, QDialog *parent);
+    Operator(AdvancedView *advancedView, BasicView *basicView, CommandRunner *commandRunner,
+             ErrorMessage *errorMessage, ProgressWindow *progressWindow, Tray *tray,
+             HyperKit *hyperKit, Updater *updater, QStackedWidget *stackedWidget, QDialog *parent);
 
 public slots:
     void startMinikube();

--- a/gui/tray.cpp
+++ b/gui/tray.cpp
@@ -1,8 +1,8 @@
 #include "tray.h"
 
-#include<QAction>
-#include<QCoreApplication>
-#include<QMenu>
+#include <QAction>
+#include <QCoreApplication>
+#include <QMenu>
 
 Tray::Tray(QIcon icon)
 {

--- a/gui/updater.cpp
+++ b/gui/updater.cpp
@@ -13,7 +13,6 @@
 #include <QStandardPaths>
 #include <QDir>
 
-
 Updater::Updater(QVersionNumber version, QIcon icon)
 {
     m_version = version;
@@ -22,7 +21,8 @@ Updater::Updater(QVersionNumber version, QIcon icon)
 
 static bool checkedForUpdateRecently()
 {
-    QString filePath = QStandardPaths::locate(QStandardPaths::HomeLocation, "/.minikube-gui/last_update_check");
+    QString filePath = QStandardPaths::locate(QStandardPaths::HomeLocation,
+                                              "/.minikube-gui/last_update_check");
     if (filePath == "") {
         return false;
     }
@@ -32,14 +32,14 @@ static bool checkedForUpdateRecently()
     }
     QTextStream in(&file);
     QString line = in.readLine();
-    QDateTime nextCheck = QDateTime::fromString(line).addSecs(60*60*24);
+    QDateTime nextCheck = QDateTime::fromString(line).addSecs(60 * 60 * 24);
     QDateTime now = QDateTime::currentDateTime();
     return nextCheck > now;
 }
 
 static void logUpdateCheck()
 {
-    QDir dir = QDir(QDir::homePath() +  "/.minikube-gui");
+    QDir dir = QDir(QDir::homePath() + "/.minikube-gui");
     if (!dir.exists()) {
         dir.mkpath(".");
     }

--- a/gui/window.cpp
+++ b/gui/window.cpp
@@ -108,7 +108,8 @@ Window::Window()
     hyperKit = new HyperKit(*trayIconIcon);
     updater = new Updater(version, *trayIconIcon);
 
-    op = new Operator(advancedView, basicView, commandRunner, errorMessage, progressWindow, tray, hyperKit, updater, stackedWidget, this);
+    op = new Operator(advancedView, basicView, commandRunner, errorMessage, progressWindow, tray,
+                      hyperKit, updater, stackedWidget, this);
 
     stackedWidget->addWidget(basicView->basicView);
     stackedWidget->addWidget(advancedView->advancedView);


### PR DESCRIPTION
When the GUI window it reopened, it runs a cluster update list, however, we weren't checking if there was already a command running. This resulted in the update list command clobbering the previously running command and causing the GUI to crash. With this PR we now check if a command is already running before trying to update the cluster list.

This PR also includes formatting fixes.