### PR TITLE
correct GPU flag in documentation

### DIFF
--- a/site/content/en/docs/drivers/kvm2.md
+++ b/site/content/en/docs/drivers/kvm2.md
@@ -22,7 +22,7 @@ aliases:
 
 The `minikube start` command supports 5 additional KVM specific flags:
 
-* **`--gpu`**: Enable experimental NVIDIA GPU support in minikube
+* **`--kvm-gpu`**: Enable experimental NVIDIA GPU support in minikube
 * **`--hidden`**: Hide the hypervisor signature from the guest in minikube
 * **`--kvm-network`**:  The KVM default network name
 * **`--network`**:  The dedicated KVM private network name


### PR DESCRIPTION
Using `minikube version: v1.25.2`, the correct flag is:
```
--kvm-gpu=false: Enable experimental NVIDIA GPU support in minikube
```

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
