### PR TITLE
add bind address option for cmd tunnel

### DIFF
--- a/cmd/minikube/cmd/tunnel.go
+++ b/cmd/minikube/cmd/tunnel.go
@@ -120,5 +120,5 @@ func outputTunnelStarted() {
 
 func init() {
 	tunnelCmd.Flags().BoolVarP(&cleanup, "cleanup", "c", true, "call with cleanup=true to remove old tunnels")
-	tunnelCmd.Flags().StringVar(&bindAddress, "bind-address", "", "set tunnel bind address, empty or `*' indicates that tunnel should be available for all interfaces")
+	tunnelCmd.Flags().StringVar(&bindAddress, "bind-address", "", "set tunnel bind address, empty or '*' indicates the tunnel should be available for all interfaces")
 }

--- a/cmd/minikube/cmd/tunnel.go
+++ b/cmd/minikube/cmd/tunnel.go
@@ -41,6 +41,7 @@ import (
 )
 
 var cleanup bool
+var bindAddress string
 
 // tunnelCmd represents the tunnel command
 var tunnelCmd = &cobra.Command{
@@ -93,7 +94,7 @@ var tunnelCmd = &cobra.Command{
 			sshKey := filepath.Join(localpath.MiniPath(), "machines", cname, "id_rsa")
 
 			outputTunnelStarted()
-			kicSSHTunnel := kic.NewSSHTunnel(ctx, sshPort, sshKey, clientset.CoreV1(), clientset.NetworkingV1())
+			kicSSHTunnel := kic.NewSSHTunnel(ctx, sshPort, sshKey, bindAddress, clientset.CoreV1(), clientset.NetworkingV1())
 			err = kicSSHTunnel.Start()
 			if err != nil {
 				exit.Error(reason.SvcTunnelStart, "error starting tunnel", err)
@@ -119,4 +120,5 @@ func outputTunnelStarted() {
 
 func init() {
 	tunnelCmd.Flags().BoolVarP(&cleanup, "cleanup", "c", true, "call with cleanup=true to remove old tunnels")
+	tunnelCmd.Flags().StringVar(&bindAddress, "bind-address", "", "set tunnel bind address, empty or `*' indicates that tunnel should be available for all interfaces")
 }

--- a/pkg/minikube/tunnel/kic/ssh_conn.go
+++ b/pkg/minikube/tunnel/kic/ssh_conn.go
@@ -38,7 +38,7 @@ type sshConn struct {
 	suppressStdOut bool
 }
 
-func createSSHConn(name, sshPort, sshKey string, resourcePorts []int32, resourceIP string, resourceName string) *sshConn {
+func createSSHConn(name, sshPort, sshKey, bindAddress string, resourcePorts []int32, resourceIP string, resourceName string) *sshConn {
 	// extract sshArgs
 	sshArgs := []string{
 		// TODO: document the options here
@@ -53,12 +53,25 @@ func createSSHConn(name, sshPort, sshKey string, resourcePorts []int32, resource
 	askForSudo := false
 	var privilegedPorts []int32
 	for _, port := range resourcePorts {
-		arg := fmt.Sprintf(
-			"-L %d:%s:%d",
-			port,
-			resourceIP,
-			port,
-		)
+		var arg string
+		if bindAddress == "" || bindAddress == "*" {
+			// bind on all interfaces
+			arg = fmt.Sprintf(
+				"-L %d:%s:%d",
+				port,
+				resourceIP,
+				port,
+			)
+		} else {
+			// bind on specify address only
+			arg = fmt.Sprintf(
+				"-L %s:%d:%s:%d",
+				bindAddress,
+				port,
+				resourceIP,
+				port,
+			)
+		}
 
 		// check if any port is privileged
 		if port < 1024 {

--- a/pkg/minikube/tunnel/kic/ssh_tunnel.go
+++ b/pkg/minikube/tunnel/kic/ssh_tunnel.go
@@ -37,6 +37,7 @@ type SSHTunnel struct {
 	ctx                  context.Context
 	sshPort              string
 	sshKey               string
+	bindAddress          string
 	v1Core               typed_core.CoreV1Interface
 	v1Networking         typed_networking.NetworkingV1Interface
 	LoadBalancerEmulator tunnel.LoadBalancerEmulator
@@ -45,11 +46,12 @@ type SSHTunnel struct {
 }
 
 // NewSSHTunnel ...
-func NewSSHTunnel(ctx context.Context, sshPort, sshKey string, v1Core typed_core.CoreV1Interface, v1Networking typed_networking.NetworkingV1Interface) *SSHTunnel {
+func NewSSHTunnel(ctx context.Context, sshPort, sshKey, bindAddress string, v1Core typed_core.CoreV1Interface, v1Networking typed_networking.NetworkingV1Interface) *SSHTunnel {
 	return &SSHTunnel{
 		ctx:                  ctx,
 		sshPort:              sshPort,
 		sshKey:               sshKey,
+		bindAddress:          bindAddress,
 		v1Core:               v1Core,
 		LoadBalancerEmulator: tunnel.NewLoadBalancerEmulator(v1Core),
 		v1Networking:         v1Networking,
@@ -124,7 +126,7 @@ func (t *SSHTunnel) startConnection(svc v1.Service) {
 	}
 
 	// create new ssh conn
-	newSSHConn := createSSHConn(uniqName, t.sshPort, t.sshKey, resourcePorts, svc.Spec.ClusterIP, svc.Name)
+	newSSHConn := createSSHConn(uniqName, t.sshPort, t.sshKey, t.bindAddress, resourcePorts, svc.Spec.ClusterIP, svc.Name)
 	t.conns[newSSHConn.name] = newSSHConn
 
 	go func() {
@@ -154,7 +156,7 @@ func (t *SSHTunnel) startConnectionIngress(ingress v1_networking.Ingress) {
 	resourceIP := "127.0.0.1"
 
 	// create new ssh conn
-	newSSHConn := createSSHConn(uniqName, t.sshPort, t.sshKey, resourcePorts, resourceIP, ingress.Name)
+	newSSHConn := createSSHConn(uniqName, t.sshPort, t.sshKey, t.bindAddress, resourcePorts, resourceIP, ingress.Name)
 	t.conns[newSSHConn.name] = newSSHConn
 
 	go func() {

--- a/site/content/en/docs/commands/tunnel.md
+++ b/site/content/en/docs/commands/tunnel.md
@@ -20,7 +20,8 @@ minikube tunnel [flags]
 ### Options
 
 ```
-  -c, --cleanup   call with cleanup=true to remove old tunnels (default true)
+      --bind-address string   set tunnel bind address, empty or '*' indicates the tunnel should be available for all interfaces
+  -c, --cleanup               call with cleanup=true to remove old tunnels (default true)
 ```
 
 ### Options inherited from parent commands

--- a/translations/de.json
+++ b/translations/de.json
@@ -975,6 +975,7 @@
 	"retrieving node": "Ermittele Node",
 	"scheduled stop is not supported on the none driver, skipping scheduling": "Das geplante Stoppen wird von none Treiber nicht unterstützt, überspringe Planung",
 	"service {{.namespace_name}}/{{.service_name}} has no node port": "Service {{.namespace_name}}/{{.service_name}} hat keinen Node Port",
+	"set tunnel bind address, empty or '*' indicates the tunnel should be available for all interfaces": "",
 	"stat failed": "state Fehler",
 	"status json failure": "Status json Fehler",
 	"status text failure": "Status text Fehler",

--- a/translations/es.json
+++ b/translations/es.json
@@ -975,6 +975,7 @@
 	"retrieving node": "",
 	"scheduled stop is not supported on the none driver, skipping scheduling": "",
 	"service {{.namespace_name}}/{{.service_name}} has no node port": "",
+	"set tunnel bind address, empty or '*' indicates the tunnel should be available for all interfaces": "",
 	"stat failed": "",
 	"status json failure": "",
 	"status text failure": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -941,6 +941,7 @@
 	"retrieving node": "récupération du nœud",
 	"scheduled stop is not supported on the none driver, skipping scheduling": "l'arrêt programmé n'est pas pris en charge sur le pilote none, programmation non prise en compte",
 	"service {{.namespace_name}}/{{.service_name}} has no node port": "le service {{.namespace_name}}/{{.service_name}} n'a pas de port de nœud",
+	"set tunnel bind address, empty or '*' indicates the tunnel should be available for all interfaces": "",
 	"stat failed": "stat en échec",
 	"status json failure": "état du JSON en échec",
 	"status text failure": "état du texte en échec",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -993,6 +993,7 @@
 	"saving node": "ノードを保存しています",
 	"scheduled stop is not supported on the none driver, skipping scheduling": "none ドライバーでは予定停止がサポートされていません (予約をスキップします)",
 	"service {{.namespace_name}}/{{.service_name}} has no node port": "サービス {{.namespace_name}}/{{.service_name}} は NodePort がありません",
+	"set tunnel bind address, empty or '*' indicates the tunnel should be available for all interfaces": "",
 	"startup failed": "起動に失敗しました",
 	"stat failed": "stat に失敗しました",
 	"status json failure": "status json に失敗しました",

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -985,6 +985,7 @@
 	"retrieving node": "",
 	"scheduled stop is not supported on the none driver, skipping scheduling": "",
 	"service {{.namespace_name}}/{{.service_name}} has no node port": "",
+	"set tunnel bind address, empty or '*' indicates the tunnel should be available for all interfaces": "",
 	"stat failed": "",
 	"status json failure": "",
 	"status text failure": "",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -987,6 +987,7 @@
 	"retrieving node": "przywracanie węzła",
 	"scheduled stop is not supported on the none driver, skipping scheduling": "",
 	"service {{.namespace_name}}/{{.service_name}} has no node port": "",
+	"set tunnel bind address, empty or '*' indicates the tunnel should be available for all interfaces": "",
 	"stat failed": "wykonanie komendy stat nie powiodło się",
 	"status json failure": "",
 	"status text failure": "",

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -909,6 +909,7 @@
 	"retrieving node": "",
 	"scheduled stop is not supported on the none driver, skipping scheduling": "",
 	"service {{.namespace_name}}/{{.service_name}} has no node port": "",
+	"set tunnel bind address, empty or '*' indicates the tunnel should be available for all interfaces": "",
 	"stat failed": "",
 	"status json failure": "",
 	"status text failure": "",

--- a/translations/strings.txt
+++ b/translations/strings.txt
@@ -909,6 +909,7 @@
 	"retrieving node": "",
 	"scheduled stop is not supported on the none driver, skipping scheduling": "",
 	"service {{.namespace_name}}/{{.service_name}} has no node port": "",
+	"set tunnel bind address, empty or '*' indicates the tunnel should be available for all interfaces": "",
 	"stat failed": "",
 	"status json failure": "",
 	"status text failure": "",

--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -1098,6 +1098,7 @@
 	"retrieving node": "",
 	"scheduled stop is not supported on the none driver, skipping scheduling": "",
 	"service {{.namespace_name}}/{{.service_name}} has no node port": "",
+	"set tunnel bind address, empty or '*' indicates the tunnel should be available for all interfaces": "",
 	"stat failed": "",
 	"status json failure": "",
 	"status text failure": "",


### PR DESCRIPTION
the PR added an `bind-address` option for `minikube tunnel`, so we can choose to one interface to bind with.
that's useful as I described in #14234 

`minikube tunnel --help` will show as follow:
```
➜  ~ minikube tunnel --help
tunnel creates a route to services deployed with type LoadBalancer and sets their Ingress to their ClusterIP. for a
detailed example see https://minikube.sigs.k8s.io/docs/tasks/loadbalancer

Options:
    --bind-address='':
	set tunnel bind address, empty or `*' indicates that tunnel should be available for all interfaces

    -c, --cleanup=true:
	call with cleanup=true to remove old tunnels

Usage:
  minikube tunnel [flags] [options]

Use "minikube options" for a list of global command-line options (applies to all commands).
```

fixes #14234