### PR TITLE
Fix compilation of minikube gui on qt5

### DIFF
--- a/gui/commandrunner.cpp
+++ b/gui/commandrunner.cpp
@@ -5,6 +5,7 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonParseError>
+#include <QDebug>
 
 CommandRunner::CommandRunner(QDialog *parent)
 {

--- a/gui/updater.cpp
+++ b/gui/updater.cpp
@@ -49,7 +49,7 @@ static void logUpdateCheck()
         return;
     }
     QTextStream stream(&file);
-    stream << QDateTime::currentDateTime().toString() << Qt::endl;
+    stream << QDateTime::currentDateTime().toString() << "\n";
 }
 
 void Updater::checkForUpdates()


### PR DESCRIPTION

commandrunner.cpp:133:20: error: invalid use of incomplete type ‘class QDebug’

updater.cpp:52:62: error: ‘endl’ is not a member of ‘Qt’
