### PR TITLE
fix: minikube delete exclude networks from other profiles

### DIFF
--- a/pkg/drivers/kic/oci/network_create.go
+++ b/pkg/drivers/kic/oci/network_create.go
@@ -133,7 +133,7 @@ func tryCreateDockerNetwork(ociBin string, subnet *network.Parameters, mtu int, 
 			args = append(args, fmt.Sprintf("com.docker.network.driver.mtu=%d", mtu))
 		}
 	}
-	args = append(args, fmt.Sprintf("--label=%s=%s", CreatedByLabelKey, "true"), name)
+	args = append(args, fmt.Sprintf("--label=%s=%s", CreatedByLabelKey, "true"), fmt.Sprintf("--label=%s=%s", ProfileLabelKey, name), name)
 
 	rr, err := runCmd(exec.Command(ociBin, args...))
 	if err != nil {
@@ -320,10 +320,10 @@ func networkNamesByLabel(ociBin string, label string) ([]string, error) {
 	return lines, nil
 }
 
-// DeleteKICNetworks deletes all networks created by kic
-func DeleteKICNetworks(ociBin string) []error {
+// DeleteAllKICKNetworksByLabel deletes all networks that have a specific label
+func DeleteKICNetworksByLabel(ociBin string, label string) []error {
 	var errs []error
-	ns, err := networkNamesByLabel(ociBin, CreatedByLabelKey)
+	ns, err := networkNamesByLabel(ociBin, label)
 	if err != nil {
 		return []error{errors.Wrap(err, "list all volume")}
 	}

--- a/pkg/minikube/delete/delete.go
+++ b/pkg/minikube/delete/delete.go
@@ -64,7 +64,7 @@ func PossibleLeftOvers(ctx context.Context, cname string, driverName string) {
 		klog.Warningf("error deleting volumes (might be okay).\nTo see the list of volumes run: 'docker volume ls'\n:%v", errs)
 	}
 
-	errs = oci.DeleteKICNetworks(bin)
+	errs = oci.DeleteKICNetworksByLabel(bin, delLabel)
 	if errs != nil {
 		klog.Warningf("error deleting leftover networks (might be okay).\nTo see the list of networks: 'docker network ls'\n:%v", errs)
 	}

--- a/test/integration/kic_custom_network_test.go
+++ b/test/integration/kic_custom_network_test.go
@@ -78,7 +78,7 @@ func TestKicExistingNetwork(t *testing.T) {
 		t.Fatalf("error creating network: %v", err)
 	}
 	defer func() {
-		if err := oci.DeleteKICNetworks(oci.Docker); err != nil {
+		if err := oci.DeleteKICNetworksByLabel(oci.Docker, networkName); err != nil {
 			t.Logf("error deleting kic network, may need to delete manually: %v", err)
 		}
 	}()


### PR DESCRIPTION
Fixes: #12635


