### PR TITLE
Filter out latest unique MM versions

### DIFF
--- a/hack/update/kubeadm_constants/update_kubeadm_constants.go
+++ b/hack/update/kubeadm_constants/update_kubeadm_constants.go
@@ -70,7 +70,8 @@ func main() {
 		if err != nil {
 			klog.Fatal(err)
 		}
-		imageVersions = append(imageVersions, stableImageVersion, latestImageVersion, edgeImageVersion)
+		uniqueMM := filterLatestUniqueMM([]string{stableImageVersion, latestImageVersion, edgeImageVersion})
+		imageVersions = append(imageVersions, uniqueMM...)
 	} else if semver.IsValid(inputVersion) {
 		imageVersions = append(imageVersions, inputVersion)
 	} else {
@@ -104,6 +105,23 @@ func main() {
 
 		update.Apply(ctx, schema, data, "", "", -1)
 	}
+}
+
+func filterLatestUniqueMM(versions []string) []string {
+	if len(versions) < 2 {
+		return versions
+	}
+	semver.Sort(versions)
+	uniqueMMVersions := []string{}
+	last := versions[0]
+	for _, ver := range versions {
+		if semver.MajorMinor(last) != semver.MajorMinor(ver) {
+			uniqueMMVersions = append(uniqueMMVersions, last)
+		}
+		last = ver
+	}
+	uniqueMMVersions = append(uniqueMMVersions, last)
+	return uniqueMMVersions
 }
 
 func getKubeadmImagesMapString(version string) (string, error) {


### PR DESCRIPTION
**Problem:**
We were pulling the stable, latest, and edge versions of Kubernetes from their GitHub releases page. We then iterate over each version in the previously stated order and update the kubeadm constants file. The issue was that the edge version was earlier than stable and latest, so it overwrote the kubeadm constants with earlier versions.

Example of what happened: 
stable: `v1.24.1`, latest `v1.24.2-rc.0`, edge `v1.24.0-alpha.4`
So we updated the kubeadm constants file with the stable version (`pause: 3.7`), then updated the file with latest (`pause: 3.7`), and then updated the file with edge (`pause: 3.6`). Because edge went last, it overwrote the the previous work with an earlier version.

**Solution:**
Take the three versions, sort them, then only loop over the latest version of each each MajorMinor, for example, in the previous example we would only iterate over `v1.24.2-rc.0`, but if we added `v1.23.6` to the version list would iterate over `v1.23.6` & `v1.24.2-rc.0` as they have different MajorMinor versions.