### PR TITLE
pr-bot: Fix first run taking longer

### DIFF
--- a/hack/jenkins/prbot.sh
+++ b/hack/jenkins/prbot.sh
@@ -52,3 +52,5 @@ if [ $? -gt 0 ]; then
 fi
 output=$(cat mkcmp.log)
 gh pr comment ${MINIKUBE_LOCATION} --body "${output}"
+
+docker system prune -a --volumes -f

--- a/pkg/minikube/perf/start.go
+++ b/pkg/minikube/perf/start.go
@@ -100,11 +100,16 @@ func average(nums []float64) float64 {
 
 func downloadArtifacts(ctx context.Context, binaries []*Binary, driver string, runtime string) error {
 	for _, b := range binaries {
-		c := exec.CommandContext(ctx, b.path, "start", fmt.Sprintf("--driver=%s", driver), "--download-only", fmt.Sprintf("--container-runtime=%s", runtime))
+		c := exec.CommandContext(ctx, b.path, "start", fmt.Sprintf("--driver=%s", driver), fmt.Sprintf("--container-runtime=%s", runtime))
 		c.Stderr = os.Stderr
 		log.Printf("Running: %v...", c.Args)
 		if err := c.Run(); err != nil {
-			return errors.Wrap(err, "downloading artifacts")
+			return errors.Wrap(err, "artifact download start")
+		}
+		c = exec.CommandContext(ctx, b.path, "delete")
+		log.Printf("Running: %v...", c.Args)
+		if err := c.Run(); err != nil {
+			return errors.Wrap(err, "artifact download delete")
 		}
 	}
 	return nil


### PR DESCRIPTION
**Problem:**
`minikube start --download-only` saves the kic image to `~/.minikube/cache`, however the first benchmark loads the cached kic image into Docker which takes 20+ seconds, which skews the start times for the PR-bot.

**Solution:**
Instead of doing `minikube start --download-only` before starting the benchmark, now doing a `minikube start` followed by a `minikube delete` which ensures the kic image is already in Docker for the first benchmark run.

Also doing `docker system prune -a --volumes -f` as we're not clearing out artifacts after and the machines are accumulating many images.