### PR TITLE
CI: Fix cron cleanup script

### DIFF
--- a/hack/jenkins/cron/cleanup_and_reboot_Linux.sh
+++ b/hack/jenkins/cron/cleanup_and_reboot_Linux.sh
@@ -117,7 +117,8 @@ function cleanup() {
 }
 
 # Give 15m for Linux-specific cleanup
-timeout 15m cleanup
+export -f cleanup
+timeout 15m bash -c cleanup
 
 # disable localkube, kubelet
 systemctl list-unit-files --state=enabled \


### PR DESCRIPTION
**Before:**
```
timeout: failed to run command ‘cleanup’: No such file or directory
```

**After:**
```
cleanup minikube...
successfully cleaned up minikube for jenkins user using /tmp/minikube
successfully cleaned up minikube for root user using /tmp/minikube

cleanup docker...
Total reclaimed space: 0B

cleanup kvm...

before the cleanup:

 - KVM domains:
 Id   Name   State
--------------------

 - KVM pools:
 Name   State   Autostart
---------------------------

 - KVM networks:
 Name      State    Autostart   Persistent
--------------------------------------------
 default   active   yes         yes

 - host networks:
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2: ens4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1460 qdisc mq state UP mode DEFAULT group default qlen 1000
    link/ether 42:01:0a:c2:00:02 brd ff:ff:ff:ff:ff:ff
3: virbr0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN mode DEFAULT group default qlen 1000
    link/ether 52:54:00:10:a2:1d brd ff:ff:ff:ff:ff:ff
4: virbr0-nic: <BROADCAST,MULTICAST> mtu 1500 qdisc fq_codel master virbr0 state DOWN mode DEFAULT group default qlen 1000
    link/ether 52:54:00:10:a2:1d brd ff:ff:ff:ff:ff:ff
5: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN mode DEFAULT group default 
    link/ether 02:42:5c:79:35:6a brd ff:ff:ff:ff:ff:ff
bridge connected to the 'default' KVM network to leave alone: virbr0

after the cleanup:

 - KVM domains:
 Id   Name   State
--------------------

 - KVM pools:
 Name   State   Autostart
---------------------------

 - KVM networks:
 Name      State    Autostart   Persistent
--------------------------------------------
 default   active   yes         yes

 - host networks:
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2: ens4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1460 qdisc mq state UP mode DEFAULT group default qlen 1000
    link/ether 42:01:0a:c2:00:02 brd ff:ff:ff:ff:ff:ff
3: virbr0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN mode DEFAULT group default qlen 1000
    link/ether 52:54:00:10:a2:1d brd ff:ff:ff:ff:ff:ff
4: virbr0-nic: <BROADCAST,MULTICAST> mtu 1500 qdisc fq_codel master virbr0 state DOWN mode DEFAULT group default qlen 1000
    link/ether 52:54:00:10:a2:1d brd ff:ff:ff:ff:ff:ff
5: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN mode DEFAULT group default 
    link/ether 02:42:5c:79:35:6a brd ff:ff:ff:ff:ff:ff
```