### PR TITLE
CI: Fix upload_all_reports

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -570,9 +570,9 @@ jobs:
           echo 'EOF' >> $GITHUB_ENV
       - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
         with:
-          name: none_ubuntu18_04
+          name: functional_baremetal_ubuntu18_04
           path: minikube_binaries/report
-      - name: The End Result - None on Ubuntu 18:04
+      - name: The End Result functional_baremetal_ubuntu18_04
         shell: bash
         run: |
           echo ${GOPOGH_RESULT}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -572,9 +572,9 @@ jobs:
           echo 'EOF' >> $GITHUB_ENV
       - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
         with:
-          name: none_ubuntu18_04
+          name: functional_baremetal_ubuntu18_04
           path: minikube_binaries/report
-      - name: The End Result - None on Ubuntu 18:04
+      - name: The End Result functional_baremetal_ubuntu18_04
         shell: bash
         run: |
           echo ${GOPOGH_RESULT}


### PR DESCRIPTION
```
Run mkdir -p all_reports
  mkdir -p all_reports
  ls -lah
  cp -r ./functional_docker_ubuntu ./all_reports/
  cp -r ./functional_docker_containerd_ubuntu ./all_reports/
  cp -r ./functional_podman_ubuntu ./all_reports/
  cp -r ./functional_virtualbox_macos ./all_reports/
  cp -r ./functional_baremetal_ubuntu18_04 ./all_reports/
  shell: /usr/bin/bash {0}
  env:
    GOPROXY: https://proxy.golang.org
    GO_VERSION: 1.18.3
total 36K
drwxr-xr-x 9 runner docker 4.0K Jun 22 17:47 .
drwxr-xr-x 3 runner docker 4.0K Jun 22 7:47 ..
drwxr-xr-x 2 runner docker 4.0K Jun 22 17:47 all_reports
drwxr-xr-x 2 runner docker 4.0K Jun 22 17:47 functional_docker_containerd_ubuntu
drwxr-xr-x 2 runner docker 4.0K Jun 22 17:47 functional_docker_ubuntu
drwxr-xr-x 2 runner docker 4.0K Jun 22 17:47 functional_podman_ubuntu
drwxr-xr-x 2 runner docker 4.0K Jun 22 17:47 functional_virtualbox_macos
drwxr-xr-x 3 runner docker 4.0K Jun 22 17:47 minikube_binaries
drwxr-xr-x 2 runner docker 4.0K Jun 22 17:47 none_ubuntu18_04
cp: cannot stat './functional_baremetal_ubuntu18_04': No such file or directory
Error: Process completed with exit code 1.
```

The job name was `none_ubuntu18_04` so it was creating a `none_ubuntu18_04` folder, but was looking to copy the folder `functional_baremetal_ubuntu18_04` resulting in it failing.

Renamed the job to match the standard