### PR TITLE
Only tweet on release, not tag push

### DIFF
--- a/.github/workflows/twitter-bot.yml
+++ b/.github/workflows/twitter-bot.yml
@@ -1,9 +1,6 @@
 name: "Tweet the release"
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - 'v*'
   release:
     types: [published]
 jobs:


### PR DESCRIPTION
We were tweeting on tag push and release, resulting in a double tweet, now only tweeting on release.