### PR TITLE
CI: Fix update leaderboard

### DIFF
--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags-ignore:
       - 'v*-beta.*'
-  release:
-    types: [published]
 env:
   GOPROXY: https://proxy.golang.org
   GO_VERSION: '1.18.3'

--- a/hack/update_contributions.sh
+++ b/hack/update_contributions.sh
@@ -18,10 +18,8 @@ set -eu -o pipefail
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-if ! [[ -x "${DIR}/pullsheet" ]]; then
-  echo >&2 'Installing pullsheet'
-  go install github.com/google/pullsheet@latest
-fi
+echo >&2 'Installing pullsheet'
+go install github.com/google/pullsheet@latest
 
 git fetch --tags -f
 git pull https://github.com/kubernetes/minikube.git master --tags
@@ -71,6 +69,6 @@ while read -r tag_index tag_name tag_start tag_end; do
   # Print header for page.
   printf -- "---\ntitle: \"$tag_name - $tag_end\"\nlinkTitle: \"$tag_name - $tag_end\"\nweight: $tag_index\n---\n" > "$destination/$tag_name.html"
   # Add pullsheet content
-  $DIR/pullsheet leaderboard --token-path "$TMP_TOKEN" --repos kubernetes/minikube --since "$tag_start" --until "$tag_end" --hide-command --logtostderr=false --stderrthreshold=2 \
+  pullsheet leaderboard --token-path "$TMP_TOKEN" --repos kubernetes/minikube --since "$tag_start" --until "$tag_end" --hide-command --logtostderr=false --stderrthreshold=2 \
     >> "$destination/$tag_name.html"
 done <<< "$tags_with_range"


### PR DESCRIPTION
- Fixes job running on both tag push and release
- Install pullsheet on every run to ensure we have the latest version
- Fixed pathing to pullsheet binary
  - `hack/update_contributions.sh: line 74: /home/runner/work/minikube/minikube/hack/pullsheet: No such file or directory`
