### PR TITLE
CI: Fix time-to-k8s

### DIFF
--- a/hack/benchmark/time-to-k8s/chart.go
+++ b/hack/benchmark/time-to-k8s/chart.go
@@ -275,8 +275,6 @@ func createChart(chartPath string, values []plotter.Values, totals []float64, na
 		return err
 	}
 
-	data.TimeChart = chartPath
-
 	return nil
 }
 

--- a/hack/benchmark/time-to-k8s/cpu.go
+++ b/hack/benchmark/time-to-k8s/cpu.go
@@ -97,8 +97,6 @@ func createCPUChart(chartPath string, values []plotter.Values, names []string) e
 		return err
 	}
 
-	data.CPUChart = chartPath
-
 	return nil
 }
 

--- a/hack/benchmark/time-to-k8s/page.go
+++ b/hack/benchmark/time-to-k8s/page.go
@@ -18,9 +18,10 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"log"
 	"os"
+	"os/exec"
+	"strings"
 	"text/template"
 	"time"
 )
@@ -31,12 +32,12 @@ linkTitle: "{{.Version}} Benchmark"
 weight: -{{.Weight}}
 ---
 
-![time-to-k8s]({{.TimeChart}})
+![time-to-k8s](/images/benchmarks/timeToK8s/{{.Version}}-time.png)
 
 {{.TimeMarkdown}}
 
 
-![cpu-to-k8s]({{.CPUChart}})
+![cpu-to-k8s](/images/benchmarks/timeToK8s/{{.Version}}-cpu.png)
 
 {{.CPUMarkdown}}
 `
@@ -44,9 +45,7 @@ weight: -{{.Weight}}
 type Data struct {
 	Version      string
 	Weight       string
-	TimeChart    string
 	TimeMarkdown string
-	CPUChart     string
 	CPUMarkdown  string
 }
 
@@ -59,8 +58,13 @@ func main() {
 
 	flag.Parse()
 
-	t := time.Now()
-	data.Weight = fmt.Sprintf("%d%d%d", t.Year(), t.Month(), t.Day())
+	data.Weight = time.Now().Format("20060102")
+
+	version, err := exec.Command("minikube", "version", "--short").Output()
+	if err != nil {
+		log.Fatalf("failed to get minikube version: %v", err)
+	}
+	data.Version = strings.Split(string(version), "\n")[0]
 
 	// map of the apps (minikube, kind, k3d) and their runs
 	apps := make(map[string]runs)
@@ -89,7 +93,6 @@ func main() {
 
 	// generate page and save
 	tmpl, err := template.New("msg").Parse(page)
-
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -98,11 +101,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("fail to create file under path %s, with err %s", *pagePath, err)
 	}
+	defer f.Close()
 
 	if err = tmpl.Execute(f, data); err != nil {
 		log.Fatalf("fail to populate the page with err %s", err)
 	}
-
-	f.Close()
-
 }

--- a/hack/benchmark/time-to-k8s/page.go
+++ b/hack/benchmark/time-to-k8s/page.go
@@ -101,9 +101,10 @@ func main() {
 	if err != nil {
 		log.Fatalf("fail to create file under path %s, with err %s", *pagePath, err)
 	}
-	defer f.Close()
 
 	if err = tmpl.Execute(f, data); err != nil {
 		log.Fatalf("fail to populate the page with err %s", err)
 	}
+
+	f.Close()
 }


### PR DESCRIPTION
- Fix weight not having leading 0s on single digit values, causing entry to be at the bottom instead of at top of page
- Fix `title` & `linkTitle` missing version due to version not being set anywhere
- Fix image paths, was pointing to repo path, not web hosting location for images