### PR TITLE
fix: panic when environment variables are empty

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -441,6 +441,9 @@ func displayVersion(version string) {
 func displayEnviron(env []string) {
 	for _, kv := range env {
 		bits := strings.SplitN(kv, "=", 2)
+		if len(bits) < 2 {
+			continue
+		}
 		k := bits[0]
 		v := bits[1]
 		if strings.HasPrefix(k, "MINIKUBE_") || k == constants.KubeconfigEnvVar {


### PR DESCRIPTION
On mac OS, environment variables like: OLDPWD are usually empty. May trigger panics like:

```bash
😄  minikube v1.26.0 on Darwin 11.6.5
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
k8s.io/minikube/cmd/minikube/cmd.displayEnviron({0xc000a69a40?, 0x1c, 0xb?})
	/private/tmp/minikube-20220623-65769-c2xa25/cmd/minikube/cmd/start.go:445 +0x252
k8s.io/minikube/cmd/minikube/cmd.runStart(0x7316040?, {0x5d07e13?, 0x0?, 0x0?})
	/private/tmp/minikube-20220623-65769-c2xa25/cmd/minikube/cmd/start.go:157 +0x245
github.com/spf13/cobra.(*Command).execute(0x7316040, {0x73736d8, 0x0, 0x0})
	/Users/brew/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:876 +0x67b
github.com/spf13/cobra.(*Command).ExecuteC(0x7313fc0)
	/Users/brew/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:990 +0x3b4
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/brew/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:918
k8s.io/minikube/cmd/minikube/cmd.Execute()
	/private/tmp/minikube-20220623-65769-c2xa25/cmd/minikube/cmd/root.go:170 +0xca5
main.main()
	/private/tmp/minikube-20220623-65769-c2xa25/cmd/minikube/main.go:88 +0x255
```

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
