### PR TITLE
Document .localhost usage

### DIFF
--- a/site/content/en/docs/handbook/addons/ingress-dns.md
+++ b/site/content/en/docs/handbook/addons/ingress-dns.md
@@ -254,8 +254,8 @@ Hostname: hello-world-app-557ff7dbd8-64mtv
 
 ## Known issues
 
-### .localhost domains will not resolve on chromium
-.localhost domains will not correctly resolve on chromium since it is used as a loopback address. Instead use .test, .example, or .invalid
+### .localhost always resolves to the loopback address
+.localhost will often resolve to the loopback address (see [RFC 2606](https://datatracker.ietf.org/doc/html/rfc2606#section-2) and [RFC 6761](https://datatracker.ietf.org/doc/html/rfc6761#section-6.3)), so it can't be used for `minikube ip`. Instead use .test, .example, or .invalid
 
 ### .local is a reserved TLD
 Do not use .local as this is a reserved TLD for mDNS and bind9 DNS servers


### PR DESCRIPTION
This is just a minor edit that adds links to some RFCs, providing an explanation for why `.localhost` doesn't resolve to `minikube ip` even if you try.