### PR TITLE
CI: Add binary checksums to release GitHub page

### DIFF
--- a/hack/jenkins/release_github_page.sh
+++ b/hack/jenkins/release_github_page.sh
@@ -61,7 +61,11 @@ ${RELEASE_NOTES}
 
 See [Getting Started](https://minikube.sigs.k8s.io/docs/start/)
 
-## ISO Checksum
+## Binary Checksums
+
+$(cat binary_checksums.txt)
+
+## ISO Checksums
 
 amd64: \`${ISO_SHA256_AMD64}\`  
 arm64: \`${ISO_SHA256_ARM64}\`"

--- a/hack/jenkins/release_update_releases_json.go
+++ b/hack/jenkins/release_update_releases_json.go
@@ -163,7 +163,9 @@ func getSHA(operatingSystem, arch string) (string, error) {
 		return "", fmt.Errorf("failed to read file %q: %v", filePath, err)
 	}
 	// trim off new line character
-	return string(b[:len(b)-1]), nil
+	sha := string(b[:len(b)-1])
+	fmt.Printf("%s-%s: `%s`\n", operatingSystem, arch, sha)
+	return sha, nil
 }
 
 func updateJSON(path string, r releases) error {

--- a/hack/jenkins/release_update_releases_json.sh
+++ b/hack/jenkins/release_update_releases_json.sh
@@ -41,7 +41,7 @@ git status
 
 if ! [[ "${VERSION_BUILD}" =~ ^[0-9]+$ ]]; then
   go run "${DIR}/release_update_releases_json.go" --releases-file deploy/minikube/releases-beta.json --version "$TAGNAME" --legacy
-  go run "${DIR}/release_update_releases_json.go" --releases-file deploy/minikube/releases-beta-v2.json --version "$TAGNAME"
+  go run "${DIR}/release_update_releases_json.go" --releases-file deploy/minikube/releases-beta-v2.json --version "$TAGNAME" > binary_checksums.txt
 
   git add -A
   git commit -m "Update releases-beta.json & releases-beta-v2.json to include ${TAGNAME}"
@@ -56,13 +56,13 @@ if ! [[ "${VERSION_BUILD}" =~ ^[0-9]+$ ]]; then
   gsutil cp deploy/minikube/releases-beta-v2.json gs://minikube/releases-beta-v2.json
 else
   go run "${DIR}/release_update_releases_json.go" --releases-file deploy/minikube/releases.json --version "$TAGNAME" --legacy
-  go run "${DIR}/release_update_releases_json.go" --releases-file deploy/minikube/releases-v2.json --version "$TAGNAME"
+  go run "${DIR}/release_update_releases_json.go" --releases-file deploy/minikube/releases-v2.json --version "$TAGNAME" > binary_checksums.txt
 
   #Update the front page of our documentation
   now=$(date +"%b %d, %Y")
   sed -i "s/Latest Release: .* (/Latest Release: ${TAGNAME} - ${now} (/" site/content/en/docs/_index.md
 
-  git add -A
+  git add deploy/minikube/*
   git commit -m "Update releases.json & releases-v2.json to include ${TAGNAME}"
   git remote add minikube-bot git@github.com:minikube-bot/minikube.git
   git push -f minikube-bot jenkins-releases.json-${TAGNAME}


### PR DESCRIPTION
Example of GitHub release page:

## Installation

See [Getting Started](https://minikube.sigs.k8s.io/docs/start/)

## Binary Checksums

darwin-amd64: `cdfbbbdd01de8e8819d7d917f155c7a7cc6236af1ac97c4ae6f3ff9252b150b7`
darwin-arm64: `39f90dc37d5cf4b6d150b177a4c9d2967d9d923cd8eb7d5b99268987a0287aba`
linux-amd64: `a988b7c890d9dc34033155b8b721827b3eff0e22c3d436409a8a3310aa564547`
linux-arm: `5319911f90d173d3f1156082e608c3d7bde5e0d0d5706e61a968972b44e8885d`
linux-arm64: `7b6e79f51e671d2708afe8daea4d0bc0d9464992d9cf3d4415f608205c26a6ff`
linux-ppc64le: `bc8794ae7b5f3a02151085a316b02a39463dbac279ac0698b9d0edaef562b11e`
linux-s390x: `efc5765244660a48b6ef3c866b9db3b3a05913ef22c37e0286a221498c88469c`
windows-amd64.exe: `08c06e6ddff4f2e47a2d094365aeb85a3ac8ad1b86361db9b06a02f3668bd5a3`

## ISO Checksums

amd64: `e64268d4f07b4c754719544a6dcd14760df6b1032a42db519c04e61f66c88453`
arm64: `40904486a3a6b558cfb2fca164bc874e783e3cd5337537ba7576a558f958171a`