### PR TITLE
rootless: recommend containerd over cri-o

### DIFF
--- a/site/content/en/docs/drivers/docker.md
+++ b/site/content/en/docs/drivers/docker.md
@@ -49,7 +49,7 @@ minikube start --driver=docker --container-runtime=containerd
 Unlike Podman driver, it is not necessary to set the `rootless` property of minikube (`minikube config set rootless true`).
 When the `rootless` property is explicitly set but the current Docker host is not rootless, minikube fails with an error.
 
-The `--container-runtime` flag must be set to "containerd" or "cri-o".
+The `--container-runtime` flag must be set to "containerd" or "cri-o". "containerd" is recommended.
 {{% /tab %}}
 {{% /tabs %}}
 

--- a/site/content/en/docs/drivers/includes/podman_usage.inc
+++ b/site/content/en/docs/drivers/includes/podman_usage.inc
@@ -4,7 +4,7 @@ This is an experimental driver. Please use it only for experimental reasons unti
 
 ## Usage
 
-It's recommended to run minikube with the podman driver and [CRI-O container runtime](https://cri-o.io/): 
+It's recommended to run minikube with the podman driver and [CRI-O container runtime](https://cri-o.io/) (expect when using Rootless Podman):
 
 ```shell
 minikube start --driver=podman --container-runtime=cri-o
@@ -29,6 +29,12 @@ To use Podman without `sudo` (i.e., Rootless Podman), set the `rootless` propert
 
 ```shell
 minikube config set rootless true
+```
+
+For Rootless Podman, it is recommended to set `--container-runtime` to `containerd`:
+
+```shell
+minikube start --driver=podman --container-runtime=containerd
 ```
 
 See the [Rootless Docker](https://minikube.sigs.k8s.io/docs/drivers/docker/#rootless-docker) section for the requirements and the restrictions.


### PR DESCRIPTION
containerd seems more stable for rootless

Workaround for #14400

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
