### PR TITLE
Fixes containerd configuration issue with insecure registries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ KUBERNETES_VERSION ?= $(shell egrep "DefaultKubernetesVersion =" pkg/minikube/co
 KIC_VERSION ?= $(shell egrep "Version =" pkg/drivers/kic/types.go | cut -d \" -f2)
 
 # Default to .0 for higher cache hit rates, as build increments typically don't require new ISO versions
-ISO_VERSION ?= v1.26.1-1661377864-14783
+ISO_VERSION ?= v1.26.1-1661795462-14482
 # Dashes are valid in semver, but not Linux packaging. Use ~ to delimit alpha/beta
 DEB_VERSION ?= $(subst -,~,$(RAW_VERSION))
 DEB_REVISION ?= 0

--- a/deploy/iso/minikube-iso/arch/aarch64/package/containerd-bin-aarch64/config.toml
+++ b/deploy/iso/minikube-iso/arch/aarch64/package/containerd-bin-aarch64/config.toml
@@ -57,9 +57,8 @@ oom_score = 0
       conf_dir = "/etc/cni/net.mk"
       conf_template = ""
     [plugins."io.containerd.grpc.v1.cri".registry]
-      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-          endpoint = ["https://registry-1.docker.io"]
+      config_path = "/etc/containerd/certs.d"
+
   [plugins."io.containerd.service.v1.diff-service"]
     default = ["walking"]
   [plugins."io.containerd.gc.v1.scheduler"]

--- a/deploy/iso/minikube-iso/arch/aarch64/package/containerd-bin-aarch64/config.toml.default
+++ b/deploy/iso/minikube-iso/arch/aarch64/package/containerd-bin-aarch64/config.toml.default
@@ -100,9 +100,7 @@ oom_score = 0
       max_conf_num = 1
       conf_template = ""
     [plugins."io.containerd.grpc.v1.cri".registry]
-      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-          endpoint = ["https://registry-1.docker.io"]
+      config_path = "/etc/containerd/certs.d"
     [plugins."io.containerd.grpc.v1.cri".image_decryption]
       key_model = ""
     [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]

--- a/deploy/iso/minikube-iso/arch/aarch64/package/containerd-bin-aarch64/containerd-bin.mk
+++ b/deploy/iso/minikube-iso/arch/aarch64/package/containerd-bin-aarch64/containerd-bin.mk
@@ -53,6 +53,9 @@ define CONTAINERD_BIN_AARCH64_INSTALL_TARGET_CMDS
 	$(INSTALL) -Dm644 \
 		$(CONTAINERD_BIN_AARCH64_PKGDIR)/config.toml \
 		$(TARGET_DIR)/etc/containerd/config.toml
+	$(INSTALL) -Dm644 \
+		$(CONTAINERD_BIN_AARCH64_PKGDIR)/containerd_docker_io_hosts.toml \
+		$(TARGET_DIR)/etc/containerd/docker.io/hosts.toml
 endef
 
 define CONTAINERD_BIN_AARCH64_INSTALL_INIT_SYSTEMD

--- a/deploy/iso/minikube-iso/arch/aarch64/package/containerd-bin-aarch64/containerd-bin.mk
+++ b/deploy/iso/minikube-iso/arch/aarch64/package/containerd-bin-aarch64/containerd-bin.mk
@@ -55,7 +55,7 @@ define CONTAINERD_BIN_AARCH64_INSTALL_TARGET_CMDS
 		$(TARGET_DIR)/etc/containerd/config.toml
 	$(INSTALL) -Dm644 \
 		$(CONTAINERD_BIN_AARCH64_PKGDIR)/containerd_docker_io_hosts.toml \
-		$(TARGET_DIR)/etc/containerd/docker.io/hosts.toml
+		$(TARGET_DIR)/etc/containerd/certs.d/docker.io/hosts.toml
 endef
 
 define CONTAINERD_BIN_AARCH64_INSTALL_INIT_SYSTEMD

--- a/deploy/iso/minikube-iso/arch/aarch64/package/containerd-bin-aarch64/containerd_docker_io_hosts.toml
+++ b/deploy/iso/minikube-iso/arch/aarch64/package/containerd-bin-aarch64/containerd_docker_io_hosts.toml
@@ -1,0 +1,1 @@
+server = "https://registry-1.docker.io"

--- a/deploy/iso/minikube-iso/arch/x86_64/package/containerd-bin/config.toml
+++ b/deploy/iso/minikube-iso/arch/x86_64/package/containerd-bin/config.toml
@@ -57,9 +57,8 @@ oom_score = 0
       conf_dir = "/etc/cni/net.mk"
       conf_template = ""
     [plugins."io.containerd.grpc.v1.cri".registry]
-      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-          endpoint = ["https://registry-1.docker.io"]
+      config_path = "/etc/containerd/certs.d"
+      
   [plugins."io.containerd.service.v1.diff-service"]
     default = ["walking"]
   [plugins."io.containerd.gc.v1.scheduler"]

--- a/deploy/iso/minikube-iso/arch/x86_64/package/containerd-bin/config.toml.default
+++ b/deploy/iso/minikube-iso/arch/x86_64/package/containerd-bin/config.toml.default
@@ -100,9 +100,7 @@ oom_score = 0
       max_conf_num = 1
       conf_template = ""
     [plugins."io.containerd.grpc.v1.cri".registry]
-      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-          endpoint = ["https://registry-1.docker.io"]
+      config_path = "/etc/containerd/certs.d"
     [plugins."io.containerd.grpc.v1.cri".image_decryption]
       key_model = ""
     [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]

--- a/deploy/iso/minikube-iso/arch/x86_64/package/containerd-bin/containerd-bin.mk
+++ b/deploy/iso/minikube-iso/arch/x86_64/package/containerd-bin/containerd-bin.mk
@@ -54,6 +54,9 @@ define CONTAINERD_BIN_INSTALL_TARGET_CMDS
 	$(INSTALL) -Dm644 \
 		$(CONTAINERD_BIN_PKGDIR)/config.toml \
 		$(TARGET_DIR)/etc/containerd/config.toml
+	$(INSTALL) -Dm644 \
+		$(CONTAINERD_BIN_PKGDIR)/containerd_docker_io_hosts.toml \
+		$(TARGET_DIR)/etc/containerd/certs.d/docker.io/hosts.toml
 endef
 
 define CONTAINERD_BIN_INSTALL_INIT_SYSTEMD

--- a/deploy/iso/minikube-iso/arch/x86_64/package/containerd-bin/containerd_docker_io_hosts.toml
+++ b/deploy/iso/minikube-iso/arch/x86_64/package/containerd-bin/containerd_docker_io_hosts.toml
@@ -1,0 +1,1 @@
+server = "https://registry-1.docker.io"

--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -50,6 +50,7 @@ COPY deploy/kicbase/10-network-security.conf /etc/sysctl.d/10-network-security.c
 COPY deploy/kicbase/11-tcp-mtu-probing.conf /etc/sysctl.d/11-tcp-mtu-probing.conf
 COPY deploy/kicbase/02-crio.conf /etc/crio/crio.conf.d/02-crio.conf
 COPY deploy/kicbase/containerd.toml /etc/containerd/config.toml
+COPY deploy/kicbase/containerd_docker_io_hosts.toml /etc/containerd/certs.d/docker.io/hosts.toml
 COPY deploy/kicbase/clean-install /usr/local/bin/clean-install
 COPY deploy/kicbase/entrypoint /usr/local/bin/entrypoint
 COPY --from=auto-pause /src/cmd/auto-pause/auto-pause-${TARGETARCH} /bin/auto-pause

--- a/deploy/kicbase/containerd.toml
+++ b/deploy/kicbase/containerd.toml
@@ -57,9 +57,8 @@ oom_score = 0
       conf_dir = "/etc/cni/net.mk"
       conf_template = ""
     [plugins."io.containerd.grpc.v1.cri".registry]
-      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-          endpoint = ["https://registry-1.docker.io"]
+      config_path = "/etc/containerd/certs.d"
+
   [plugins."io.containerd.service.v1.diff-service"]
     default = ["walking"]
   [plugins."io.containerd.gc.v1.scheduler"]

--- a/deploy/kicbase/containerd_docker_io_hosts.toml
+++ b/deploy/kicbase/containerd_docker_io_hosts.toml
@@ -1,0 +1,1 @@
+server = "https://registry-1.docker.io"

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -24,9 +24,9 @@ import (
 
 const (
 	// Version is the current version of kic
-	Version = "v0.0.33-1659486857-14721"
+	Version = "v0.0.33-1661795577-14482"
 	// SHA of the kic base image
-	baseImageSHA = "98c8007234ca882b63abc707dc184c585fcb5372828b49a4b639961324d291b3"
+	baseImageSHA = "e92c29880a4b3b095ed3b61b1f4a696b57c5cd5212bc8256f9599a777020645d"
 	// The name of the GCR kicbase repository
 	gcrRepo = "gcr.io/k8s-minikube/kicbase-builds"
 	// The name of the Dockerhub kicbase repository

--- a/pkg/minikube/download/iso.go
+++ b/pkg/minikube/download/iso.go
@@ -41,7 +41,7 @@ const fileScheme = "file"
 // DefaultISOURLs returns a list of ISO URL's to consult by default, in priority order
 func DefaultISOURLs() []string {
 	v := version.GetISOVersion()
-	isoBucket := "minikube-builds/iso/14783"
+	isoBucket := "minikube-builds/iso/14482"
 	return []string{
 		fmt.Sprintf("https://storage.googleapis.com/%s/minikube-%s-%s.iso", isoBucket, v, runtime.GOARCH),
 		fmt.Sprintf("https://github.com/kubernetes/minikube/releases/download/%s/minikube-%s-%s.iso", v, v, runtime.GOARCH),

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -26,7 +26,7 @@ minikube start [flags]
       --apiserver-names strings           A set of apiserver names which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine
       --apiserver-port int                The apiserver listening port (default 8443)
       --auto-update-drivers               If set, automatically updates drivers to the latest version. Defaults to true. (default true)
-      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.33-1659486857-14721@sha256:98c8007234ca882b63abc707dc184c585fcb5372828b49a4b639961324d291b3")
+      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.33-1661795577-14482@sha256:e92c29880a4b3b095ed3b61b1f4a696b57c5cd5212bc8256f9599a777020645d")
       --binary-mirror string              Location to fetch kubectl, kubelet, & kubeadm binaries from.
       --cache-images                      If true, cache docker images for the current bootstrapper and load them into the machine. Always false with --driver=none. (default true)
       --cert-expiration duration          Duration until minikube certificate expiration, defaults to three years (26280h). (default 26280h0m0s)

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -69,7 +69,7 @@ minikube start [flags]
       --insecure-registry strings         Insecure Docker registries to pass to the Docker daemon.  The default service CIDR range will automatically be added.
       --install-addons                    If set, install addons. Defaults to true. (default true)
       --interactive                       Allow user prompts for more information (default true)
-      --iso-url strings                   Locations to fetch the minikube ISO from. (default [https://storage.googleapis.com/minikube-builds/iso/14783/minikube-v1.26.1-1661377864-14783-amd64.iso,https://github.com/kubernetes/minikube/releases/download/v1.26.1-1661377864-14783/minikube-v1.26.1-1661377864-14783-amd64.iso,https://kubernetes.oss-cn-hangzhou.aliyuncs.com/minikube/iso/minikube-v1.26.1-1661377864-14783-amd64.iso])
+      --iso-url strings                   Locations to fetch the minikube ISO from. (default [https://storage.googleapis.com/minikube-builds/iso/14482/minikube-v1.26.1-1661795462-14482-amd64.iso,https://github.com/kubernetes/minikube/releases/download/v1.26.1-1661795462-14482/minikube-v1.26.1-1661795462-14482-amd64.iso,https://kubernetes.oss-cn-hangzhou.aliyuncs.com/minikube/iso/minikube-v1.26.1-1661795462-14482-amd64.iso])
       --keep-context                      This will keep the existing kubectl context and will create a minikube context.
       --kubernetes-version string         The Kubernetes version that the minikube VM will use (ex: v1.2.3, 'stable' for v1.24.4, 'latest' for v1.25.0-rc.1). Defaults to 'stable'.
       --kvm-gpu                           Enable experimental NVIDIA GPU support in minikube


### PR DESCRIPTION
- Updates containerd configuration to use the new format for specifying
  container registry mirrors.
- Updates the start code to produce files in the correct location for
  registry mirrors specified with --insecure-registry

Fixes #14480 

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

