### PR TITLE
update start help info, deprecated --network-plugin flag

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -176,7 +176,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().String(mountUID, defaultMountUID, mountUIDDescription)
 	startCmd.Flags().StringSlice(config.AddonListFlag, nil, "Enable addons. see `minikube addons list` for a list of valid addon names.")
 	startCmd.Flags().String(criSocket, "", "The cri socket path to be used.")
-	startCmd.Flags().String(networkPlugin, "", "Kubelet network plug-in to use (default: auto)")
+	startCmd.Flags().String(networkPlugin, "", "DEPRECATED: Replaced by --cni")
 	startCmd.Flags().Bool(enableDefaultCNI, false, "DEPRECATED: Replaced by --cni=bridge")
 	startCmd.Flags().String(cniFlag, "", "CNI plug-in to use. Valid options: auto, bridge, calico, cilium, flannel, kindnet, or path to a CNI manifest (default: auto)")
 	startCmd.Flags().StringSlice(waitComponents, kverify.DefaultWaitList, fmt.Sprintf("comma separated list of Kubernetes components to verify and wait for after starting a cluster. defaults to %q, available options: %q . other acceptable values are 'all' or 'none', 'true' and 'false'", strings.Join(kverify.DefaultWaitList, ","), strings.Join(kverify.AllComponentsList, ",")))

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -93,7 +93,7 @@ minikube start [flags]
       --nat-nic-type string               NIC Type used for nat network. One of Am79C970A, Am79C973, 82540EM, 82543GC, 82545EM, or virtio (virtualbox driver only) (default "virtio")
       --native-ssh                        Use native Golang SSH client (default true). Set to 'false' to use the command line 'ssh' command when accessing the docker machine. Useful for the machine drivers when they will not start with 'Waiting for SSH'. (default true)
       --network string                    network to run minikube with. Now it is used by docker/podman and KVM drivers. If left empty, minikube will create a new network.
-      --network-plugin string             Kubelet network plug-in to use (default: auto)
+      --network-plugin string             DEPRECATED: Replaced by --cni.
       --nfs-share strings                 Local folders to share with Guest via NFS mounts (hyperkit driver only)
       --nfs-shares-root string            Where to root the NFS Shares, defaults to /nfsshares (hyperkit driver only) (default "/nfsshares")
       --no-kubernetes                     If set, minikube VM/container will start without starting or configuring Kubernetes. (only works on new clusters)

--- a/translations/de.json
+++ b/translations/de.json
@@ -373,7 +373,7 @@
 	"It seems that you are running in GCE, which means authentication should work without the GCP Auth addon. If you would still like to authenticate using a credentials file, use the --force flag.": "Es scheint, dass Sie GCE verwenden, was bedeutet, dass Authentifizierung auch ohne die GCP Auth Addons funktionieren sollte. Wenn Sie dennoch mittels Credential-Datei authentifizieren möchten, verwenden Sie --force.",
 	"Kicbase images have not been deleted. To delete images run:": "",
 	"Kill the mount process spawned by minikube start": "Töte den Mount-Prozess, der durch minikube start gestartet wurde",
-	"Kubelet network plug-in to use (default: auto)": "Verwendetes Kublet network plug-in (default: auto)",
+	"DEPRECATED: Replaced by --cni": "DEPRECATED: Ersetzt durch --cni",
 	"Kubernetes requires at least 2 CPU's to start": "Kubernetes benötigt mindestens 2 CPU's um zu starten",
 	"Kubernetes {{.new}} is now available. If you would like to upgrade, specify: --kubernetes-version={{.prefix}}{{.new}}": "Kubernetes {{.new}} ist nun verfügbar. Falls Sie aktualisieren möchten, verwenden Sie: --kubernetes-version={{.prefix}}{{.new}}",
 	"Kubernetes {{.version}} is not supported by this release of minikube": "Kubernetes {{.version}} wird von diesem Minikube Release nicht unterstützt",

--- a/translations/es.json
+++ b/translations/es.json
@@ -381,7 +381,7 @@
 	"It seems that you are running in GCE, which means authentication should work without the GCP Auth addon. If you would still like to authenticate using a credentials file, use the --force flag.": "",
 	"Kicbase images have not been deleted. To delete images run:": "",
 	"Kill the mount process spawned by minikube start": "",
-	"Kubelet network plug-in to use (default: auto)": "",
+	"DEPRECATED: Replaced by --cni": "",
 	"Kubernetes requires at least 2 CPU's to start": "",
 	"Kubernetes {{.new}} is now available. If you would like to upgrade, specify: --kubernetes-version={{.prefix}}{{.new}}": "",
 	"Kubernetes {{.version}} is not supported by this release of minikube": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -364,7 +364,7 @@
 	"It seems that you are running in GCE, which means authentication should work without the GCP Auth addon. If you would still like to authenticate using a credentials file, use the --force flag.": "Il semble que vous exécutiez GCE, ce qui signifie que l'authentification devrait fonctionner sans le module GCP Auth. Si vous souhaitez toujours vous authentifier à l'aide d'un fichier d'informations d'identification, utilisez l'indicateur --force.",
 	"Kicbase images have not been deleted. To delete images run:": "Les images Kicbase n'ont pas été supprimées. Pour supprimer des images, exécutez :",
 	"Kill the mount process spawned by minikube start": "Tuez le processus de montage généré par le démarrage de minikube",
-	"Kubelet network plug-in to use (default: auto)": "Plug-in réseau Kubelet à utiliser (par défaut : auto)",
+	"DEPRECATED: Replaced by --cni": "Déprécié: remplacé par --cni",
 	"Kubernetes requires at least 2 CPU's to start": "Kubernetes nécessite au moins 2 processeurs pour démarrer",
 	"Kubernetes {{.new}} is now available. If you would like to upgrade, specify: --kubernetes-version={{.prefix}}{{.new}}": "Kubernetes {{.new}} est désormais disponible. Si vous souhaitez effectuer une mise à niveau, spécifiez : --kubernetes-version={{.prefix}}{{.new}}",
 	"Kubernetes {{.version}} is not supported by this release of minikube": "Kubernetes {{.version}} n'est pas pris en charge par cette version de minikube",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -372,7 +372,7 @@
 	"It seems that you are running in GCE, which means authentication should work without the GCP Auth addon. If you would still like to authenticate using a credentials file, use the --force flag.": "GCE 上で実行しているようですが、これは GCP Auth アドオンなしに認証が機能すべきであることになります。それでもクレデンシャルファイルを使用した認証を希望するのであれば、--force フラグを使用してください。",
 	"Kicbase images have not been deleted. To delete images run:": "",
 	"Kill the mount process spawned by minikube start": "minikube start によって実行されたマウントプロセスを強制停止します",
-	"Kubelet network plug-in to use (default: auto)": "使用する Kubelet ネットワークプラグイン (既定値: auto)",
+	"DEPRECATED: Replaced by --cni": "非推奨: --cniに置き換えられました",
 	"Kubernetes requires at least 2 CPU's to start": "Kubernetes は起動に少なくとも 2 個の CPU が必要です",
 	"Kubernetes {{.new}} is now available. If you would like to upgrade, specify: --kubernetes-version={{.prefix}}{{.new}}": "Kubernetes {{.new}} が利用可能です。アップグレードしたい場合、--kubernetes-version={{.prefix}}{{.new}} を指定してください",
 	"Kubernetes {{.version}} is not supported by this release of minikube": "この minikube リリースは Kubernetes {{.version}} をサポートしていません",

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -397,7 +397,7 @@
 	"It seems that you are running in GCE, which means authentication should work without the GCP Auth addon. If you would still like to authenticate using a credentials file, use the --force flag.": "",
 	"Kicbase images have not been deleted. To delete images run:": "",
 	"Kill the mount process spawned by minikube start": "",
-	"Kubelet network plug-in to use (default: auto)": "",
+	"DEPRECATED: Replaced by --cni": "",
 	"Kubernetes requires at least 2 CPU's to start": "",
 	"Kubernetes {{.new}} is now available. If you would like to upgrade, specify: --kubernetes-version={{.prefix}}{{.new}}": "이제 {{.new}} 버전의 쿠버네티스를 사용할 수 있습니다. 업그레이드를 원하신다면 다음과 같이 지정하세요: --kubernetes-version={{.prefix}}{{.new}}",
 	"Kubernetes {{.version}} is not supported by this release of minikube": "{{.version}} 버전의 쿠버네티스는 설치되어 있는 버전의 minikube에서 지원되지 않습니다.",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -385,7 +385,7 @@
 	"It seems that you are running in GCE, which means authentication should work without the GCP Auth addon. If you would still like to authenticate using a credentials file, use the --force flag.": "",
 	"Kicbase images have not been deleted. To delete images run:": "",
 	"Kill the mount process spawned by minikube start": "",
-	"Kubelet network plug-in to use (default: auto)": "",
+	"DEPRECATED: Replaced by --cni": "",
 	"Kubernetes requires at least 2 CPU's to start": "",
 	"Kubernetes {{.new}} is now available. If you would like to upgrade, specify: --kubernetes-version={{.prefix}}{{.new}}": "",
 	"Kubernetes {{.version}} is not supported by this release of minikube": "",

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -350,7 +350,7 @@
 	"It seems that you are running in GCE, which means authentication should work without the GCP Auth addon. If you would still like to authenticate using a credentials file, use the --force flag.": "",
 	"Kicbase images have not been deleted. To delete images run:": "",
 	"Kill the mount process spawned by minikube start": "",
-	"Kubelet network plug-in to use (default: auto)": "",
+	"DEPRECATED: Replaced by --cni": "",
 	"Kubernetes requires at least 2 CPU's to start": "",
 	"Kubernetes {{.new}} is now available. If you would like to upgrade, specify: --kubernetes-version={{.prefix}}{{.new}}": "Доступен Kubernetes {{.new}}. Для обновления, укажите: --kubernetes-version={{.prefix}}{{.new}}",
 	"Kubernetes {{.version}} is not supported by this release of minikube": "",

--- a/translations/strings.txt
+++ b/translations/strings.txt
@@ -350,7 +350,7 @@
 	"It seems that you are running in GCE, which means authentication should work without the GCP Auth addon. If you would still like to authenticate using a credentials file, use the --force flag.": "",
 	"Kicbase images have not been deleted. To delete images run:": "",
 	"Kill the mount process spawned by minikube start": "",
-	"Kubelet network plug-in to use (default: auto)": "",
+	"DEPRECATED: Replaced by --cni": "",
 	"Kubernetes requires at least 2 CPU's to start": "",
 	"Kubernetes {{.new}} is now available. If you would like to upgrade, specify: --kubernetes-version={{.prefix}}{{.new}}": "",
 	"Kubernetes {{.version}} is not supported by this release of minikube": "",

--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -456,7 +456,7 @@
 	"It seems that you are running in GCE, which means authentication should work without the GCP Auth addon. If you would still like to authenticate using a credentials file, use the --force flag.": "",
 	"Kicbase images have not been deleted. To delete images run:": "",
 	"Kill the mount process spawned by minikube start": "",
-	"Kubelet network plug-in to use (default: auto)": "",
+	"DEPRECATED: Replaced by --cni": "已弃用，改用 --cni 来代替",
 	"Kubernetes requires at least 2 CPU's to start": "",
 	"Kubernetes {{.new}} is now available. If you would like to upgrade, specify: --kubernetes-version={{.new}}": "Kubernetes {{.new}} 现在可用了。如果您想升级，请指定 --kubernetes-version={{.new}}",
 	"Kubernetes {{.new}} is now available. If you would like to upgrade, specify: --kubernetes-version={{.prefix}}{{.new}}": "",


### PR DESCRIPTION
please see [kubernetes/minikube#14471](https://github.com/kubernetes/minikube/issues/14471)

Indicate --network-plugin flag is deprecated,The description should be updated to indicate that the flag is deprecated and --cni should be used instead.

