### PR TITLE
storage-provisioner-gluster: use the Gluster project's container-image

### DIFF
--- a/deploy/addons/aliyun_mirror.json
+++ b/deploy/addons/aliyun_mirror.json
@@ -24,7 +24,7 @@
   "k8s.gcr.io/sig-storage/csi-snapshotter": "registry.cn-hangzhou.aliyuncs.com/google_containers/csi-snapshotter",
   "k8s.gcr.io/sig-storage/csi-provisioner": "registry.cn-hangzhou.aliyuncs.com/google_containers/csi-provisioner",
   "registry": "registry.cn-hangzhou.aliyuncs.com/google_containers/registry",
-  "quay.io/nixpanic/glusterfs-server": "registry.cn-hangzhou.aliyuncs.com/google_containers/glusterfs-server",
+  "docker.io/gluster/gluster-centos": "registry.cn-hangzhou.aliyuncs.com/google_containers/glusterfs-server",
   "heketi/heketi": "registry.cn-hangzhou.aliyuncs.com/google_containers/heketi",
   "coredns/coredns": "registry.cn-hangzhou.aliyuncs.com/google_containers/coredns",
   "kindest/kindnetd": "registry.cn-hangzhou.aliyuncs.com/google_containers/kindnetd",

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -188,10 +188,8 @@ var Addons = map[string]*Addon{
 	}, false, "storage-provisioner-gluster", "", "", map[string]string{
 		"Heketi":                 "heketi/heketi:10@sha256:76d5a6a3b7cf083d1e99efa1c15abedbc5c8b73bef3ade299ce9a4c16c9660f8",
 		"GlusterfileProvisioner": "gluster/glusterfile-provisioner:latest@sha256:9961a35cb3f06701958e202324141c30024b195579e5eb1704599659ddea5223",
-		"GlusterfsServer":        "nixpanic/glusterfs-server:pr_fake-disk@sha256:3c58ae9d4e2007758954879d3f4095533831eb757c64ca6a0e32d1fc53fb6034",
-	}, map[string]string{
-		"GlusterfsServer": "quay.io",
-	}),
+		"GlusterfsServer":        "gluster/gluster-centos:latest@sha256:8167034b9abf2d16581f3f4571507ce7d716fb58b927d7627ef72264f802e908",
+	}, nil),
 	"efk": NewAddon([]*BinAsset{
 		MustBinAsset(addons.EfkAssets,
 			"efk/elasticsearch-rc.yaml.tmpl",


### PR DESCRIPTION
Use docker.io/gluster/gluster-centos:latest instead of a temporary image
that had a change which needed to get merged. All required features are
included in the 'official' container-image.

Fixes: #14469