### PR TITLE
Fix Post installation tip for headlamp addon

### DIFF
--- a/cmd/minikube/cmd/config/flags.go
+++ b/cmd/minikube/cmd/config/flags.go
@@ -19,9 +19,16 @@ package config
 import (
 	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/mustload"
 )
 
 // ClusterFlagValue returns the current cluster name based on flags
 func ClusterFlagValue() string {
 	return viper.GetString(config.ProfileName)
+}
+
+// ClusterKubernetesVersion returns the current Kubernetes version of the cluster
+func ClusterKubernetesVersion(clusterProfile string) string {
+	_, cc := mustload.Partial(clusterProfile)
+	return cc.KubernetesConfig.KubernetesVersion
 }

--- a/translations/de.json
+++ b/translations/de.json
@@ -748,7 +748,6 @@
 	"Tip: To remove this root owned cluster, run: sudo {{.cmd}}": "Tip: Um diesen zu root gehörenden Cluster zu entfernen, führe {{.cmd}} aus",
 	"Tip: To remove this root owned cluster, run: sudo {{.cmd}} delete": "Tipp: Um diesen Root-Cluster zu entfernen, führen Sie Folgendes aus: sudo {{.cmd}} delete",
 	"To access Headlamp, use the following command:\nminikube service headlamp -n headlamp\n\n": "",
-	"To authenticate in Headlamp, fetch the Authentication Token using the following command:\n\nexport SECRET=$(kubectl get secrets --namespace headlamp -o custom-columns=\":metadata.name\" | grep \"headlamp-token\")\nkubectl get secret $SECRET --namespace headlamp --template=\\{\\{.data.token\\}\\} | base64 --decode\n\t\t\t\n": "",
 	"To connect to this cluster, use:  --context={{.name}}": "Um zu diesem Cluster zu verbinden, verwende  --context={{.name}}",
 	"To connect to this cluster, use: kubectl --context={{.name}}": "Verwenden Sie zum Herstellen einer Verbindung zu diesem Cluster: kubectl --context = {{.name}}",
 	"To connect to this cluster, use: kubectl --context={{.name}}__1": "Verwenden Sie zum Herstellen einer Verbindung zu diesem Cluster: kubectl --context = {{.name}}",

--- a/translations/es.json
+++ b/translations/es.json
@@ -750,7 +750,6 @@
 	"Tip: To remove this root owned cluster, run: sudo {{.cmd}}": "",
 	"Tip: To remove this root owned cluster, run: sudo {{.cmd}} delete": "Para eliminar este clúster de raíz, ejecuta: sudo {{.cmd}} delete",
 	"To access Headlamp, use the following command:\nminikube service headlamp -n headlamp\n\n": "",
-	"To authenticate in Headlamp, fetch the Authentication Token using the following command:\n\nexport SECRET=$(kubectl get secrets --namespace headlamp -o custom-columns=\":metadata.name\" | grep \"headlamp-token\")\nkubectl get secret $SECRET --namespace headlamp --template=\\{\\{.data.token\\}\\} | base64 --decode\n\t\t\t\n": "",
 	"To connect to this cluster, use:  --context={{.name}}": "",
 	"To connect to this cluster, use: kubectl --context={{.name}}": "Para conectarte a este clúster, usa: kubectl --context={{.name}}",
 	"To connect to this cluster, use: kubectl --context={{.name}}__1": "Para conectarte a este clúster, usa: kubectl --context={{.name}}",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -750,7 +750,6 @@
 	"Tip: To remove this root owned cluster, run: sudo {{.cmd}}": "ヒント: この root 所有クラスターの削除コマンド: sudo {{.cmd}}",
 	"Tip: To remove this root owned cluster, run: sudo {{.cmd}} delete": "ヒント: この root 所有クラスターの削除コマンド: sudo {{.cmd}} delete",
 	"To access Headlamp, use the following command:\nminikube service headlamp -n headlamp\n\n": "",
-	"To authenticate in Headlamp, fetch the Authentication Token using the following command:\n\nexport SECRET=$(kubectl get secrets --namespace headlamp -o custom-columns=\":metadata.name\" | grep \"headlamp-token\")\nkubectl get secret $SECRET --namespace headlamp --template=\\{\\{.data.token\\}\\} | base64 --decode\n\t\t\t\n": "",
 	"To connect to this cluster, use:  --context={{.name}}": "このクラスターに接続するためには、--context={{.name}} を使用します",
 	"To connect to this cluster, use: kubectl --context={{.name}}": "このクラスターに接続するためには、kubectl --context={{.name}} を使用します",
 	"To connect to this cluster, use: kubectl --context={{.name}}__1": "このクラスターに接続するためには、kubectl --context={{.name}} を使用します",

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -751,7 +751,6 @@
 	"This {{.type}} is having trouble accessing https://{{.repository}}": "",
 	"Tip: To remove this root owned cluster, run: sudo {{.cmd}}": "",
 	"To access Headlamp, use the following command:\nminikube service headlamp -n headlamp\n\n": "",
-	"To authenticate in Headlamp, fetch the Authentication Token using the following command:\n\nexport SECRET=$(kubectl get secrets --namespace headlamp -o custom-columns=\":metadata.name\" | grep \"headlamp-token\")\nkubectl get secret $SECRET --namespace headlamp --template=\\{\\{.data.token\\}\\} | base64 --decode\n\t\t\t\n": "",
 	"To connect to this cluster, use:  --context={{.name}}": "",
 	"To connect to this cluster, use: kubectl --context={{.profile_name}}": "",
 	"To disable beta notices, run: 'minikube config set WantBetaUpdateNotification false'": "",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -762,7 +762,6 @@
 	"This {{.type}} is having trouble accessing https://{{.repository}}": "",
 	"Tip: To remove this root owned cluster, run: sudo {{.cmd}}": "",
 	"To access Headlamp, use the following command:\nminikube service headlamp -n headlamp\n\n": "",
-	"To authenticate in Headlamp, fetch the Authentication Token using the following command:\n\nexport SECRET=$(kubectl get secrets --namespace headlamp -o custom-columns=\":metadata.name\" | grep \"headlamp-token\")\nkubectl get secret $SECRET --namespace headlamp --template=\\{\\{.data.token\\}\\} | base64 --decode\n\t\t\t\n": "",
 	"To connect to this cluster, use:  --context={{.name}}": "",
 	"To connect to this cluster, use: kubectl --context={{.name}}": "Aby połączyć się z klastrem użyj: kubectl --context={{.name}}",
 	"To connect to this cluster, use: kubectl --context={{.profile_name}}": "Aby połaczyć się z klastrem użyj: kubectl --context={{.profile_name}}",

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -693,7 +693,6 @@
 	"This {{.type}} is having trouble accessing https://{{.repository}}": "",
 	"Tip: To remove this root owned cluster, run: sudo {{.cmd}}": "",
 	"To access Headlamp, use the following command:\nminikube service headlamp -n headlamp\n\n": "",
-	"To authenticate in Headlamp, fetch the Authentication Token using the following command:\n\nexport SECRET=$(kubectl get secrets --namespace headlamp -o custom-columns=\":metadata.name\" | grep \"headlamp-token\")\nkubectl get secret $SECRET --namespace headlamp --template=\\{\\{.data.token\\}\\} | base64 --decode\n\t\t\t\n": "",
 	"To connect to this cluster, use:  --context={{.name}}": "",
 	"To connect to this cluster, use: kubectl --context={{.profile_name}}": "",
 	"To disable beta notices, run: 'minikube config set WantBetaUpdateNotification false'": "",

--- a/translations/strings.txt
+++ b/translations/strings.txt
@@ -693,7 +693,6 @@
 	"This {{.type}} is having trouble accessing https://{{.repository}}": "",
 	"Tip: To remove this root owned cluster, run: sudo {{.cmd}}": "",
 	"To access Headlamp, use the following command:\nminikube service headlamp -n headlamp\n\n": "",
-	"To authenticate in Headlamp, fetch the Authentication Token using the following command:\n\nexport SECRET=$(kubectl get secrets --namespace headlamp -o custom-columns=\":metadata.name\" | grep \"headlamp-token\")\nkubectl get secret $SECRET --namespace headlamp --template=\\{\\{.data.token\\}\\} | base64 --decode\n\t\t\t\n": "",
 	"To connect to this cluster, use:  --context={{.name}}": "",
 	"To connect to this cluster, use: kubectl --context={{.profile_name}}": "",
 	"To disable beta notices, run: 'minikube config set WantBetaUpdateNotification false'": "",

--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -852,7 +852,6 @@
 	"Tip: To remove this root owned cluster, run: sudo {{.cmd}}": "",
 	"Tip: To remove this root owned cluster, run: sudo {{.cmd}} delete": "提示：要移除这个由根用户拥有的集群，请运行 sudo {{.cmd}} delete",
 	"To access Headlamp, use the following command:\nminikube service headlamp -n headlamp\n\n": "",
-	"To authenticate in Headlamp, fetch the Authentication Token using the following command:\n\nexport SECRET=$(kubectl get secrets --namespace headlamp -o custom-columns=\":metadata.name\" | grep \"headlamp-token\")\nkubectl get secret $SECRET --namespace headlamp --template=\\{\\{.data.token\\}\\} | base64 --decode\n\t\t\t\n": "",
 	"To connect to this cluster, use:  --context={{.name}}": "",
 	"To connect to this cluster, use: kubectl --context={{.name}}": "如需连接到此集群，请使用 kubectl --context={{.name}}",
 	"To connect to this cluster, use: kubectl --context={{.name}}__1": "如需连接到此集群，请使用 kubectl --context={{.name}}",


### PR DESCRIPTION
For Kubernetes versions > 1.24 the tokens for service account are not created by default, this patch fixes the help command that gets printed after installation of the headlamp addon to generate a token.  

Signed-off-by: Santhosh Nagaraj S <santhosh@kinvolk.io>
