### PR TITLE
Update ubuntu image

### DIFF
--- a/installers/linux/kvm/Dockerfile.amd64
+++ b/installers/linux/kvm/Dockerfile.amd64
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/gcp-runtimes/ubuntu_16_0_4
+FROM gcr.io/gcp-runtimes/ubuntu_20_0_4
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		gcc \


### PR DESCRIPTION
Update Ubuntu from 16.04 to 20.04

Before:
93 vulnerabilities

After:
22 vulnerabilities