### PR TITLE
CI: Add arm64 Homebrew dir to PATH env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ out/minikube-linux-armv6: $(SOURCE_FILES) $(ASSET_FILES)
 	$(Q)GOOS=linux GOARCH=arm GOARM=6 \
 	go build -tags "$(MINIKUBE_BUILD_TAGS)" -ldflags="$(MINIKUBE_LDFLAGS)" -a -o $@ k8s.io/minikube/cmd/minikube
 
-.PHONY: e2e-linux-amd64 e2e-linux-arm64 e2e-darwin-amd64 e2e-windows-amd64.exe
+.PHONY: e2e-linux-amd64 e2e-linux-arm64 e2e-darwin-amd64 e2e-darwin-arm64 e2e-windows-amd64.exe
 e2e-linux-amd64: out/e2e-linux-amd64 ## build end2end binary for Linux x86 64bit
 e2e-linux-arm64: out/e2e-linux-arm64 ## build end2end binary for Linux ARM 64bit
 e2e-darwin-amd64: out/e2e-darwin-amd64 ## build end2end binary for Darwin x86 64bit
@@ -442,7 +442,7 @@ darwin: minikube-darwin-amd64 ## Build minikube for Darwin 64bit
 linux: minikube-linux-amd64 ## Build minikube for Linux 64bit
 
 .PHONY: e2e-cross
-e2e-cross: e2e-linux-amd64 e2e-linux-arm64 e2e-darwin-amd64 e2e-windows-amd64.exe ## End-to-end cross test
+e2e-cross: e2e-linux-amd64 e2e-linux-arm64 e2e-darwin-amd64 e2e-darwin-arm64 e2e-windows-amd64.exe ## End-to-end cross test
 
 .PHONY: checksum
 checksum: ## Generate checksums

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -77,6 +77,9 @@ function retry_github_status() {
 }
 
 if [ "$(uname)" = "Darwin" ]; then
+  if [ "$ARCH" = "arm64" ]; then
+    export PATH=$PATH:/opt/homebrew/bin
+  fi
   if ! bash setup_docker_desktop_macos.sh; then
     retry_github_status "${COMMIT}" "${JOB_NAME}" "failure" "${access_token}" "${public_log_url}" "Jenkins: docker failed to start"
     exit 1


### PR DESCRIPTION
As per Homebrew install instructions, the install path for arm64 is different than amd64:
`/usr/local for macOS Intel, /opt/homebrew for Apple Silicon`

Adding `/opt/homebrew/bin` to `PATH` on macOS arm64 to execute `brew` commands.

Also adding building `e2e-darwin-arm64` to `e2e-cross` as we need that to run tests on M1.