### PR TITLE
none-driver: check cri-dockerd & dockerd runtimes

### DIFF
--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -107,8 +107,8 @@ func (r *Docker) SocketPath() string {
 // Available returns an error if it is not possible to use this runtime on a host
 func (r *Docker) Available() error {
 	var err error
-	if _, err = exec.LookPath("docker"); err == nil {
-		return nil
+	if _, err = exec.LookPath("docker"); err != nil {
+		return err
 	}
 	if _, err = exec.LookPath("cri-dockerd"); err == nil {
 		return nil
@@ -116,7 +116,7 @@ func (r *Docker) Available() error {
 	if _, err = exec.LookPath("dockerd"); err == nil {
 		return nil
 	}
-	return errors.New("runtimes were not found: docker, cri-dockerd, dockerd")
+	return errors.New("runtimes were not found: cri-dockerd, dockerd")
 }
 
 // Active returns if docker is active on the host

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -106,17 +106,17 @@ func (r *Docker) SocketPath() string {
 
 // Available returns an error if it is not possible to use this runtime on a host
 func (r *Docker) Available() error {
-	var err error
-	if _, err = exec.LookPath("docker"); err != nil {
-		return err
+	// If Kubernetes version >= 1.24, require both cri-dockerd and dockerd.
+	if r.KubernetesVersion.GTE(semver.Version{Major: 1, Minor: 24}) {
+		if _, err := exec.LookPath("cri-dockerd"); err != nil {
+			return err
+		}
+		if _, err := exec.LookPath("dockerd"); err != nil {
+			return err
+		}
 	}
-	if _, err = exec.LookPath("cri-dockerd"); err == nil {
-		return nil
-	}
-	if _, err = exec.LookPath("dockerd"); err == nil {
-		return nil
-	}
-	return errors.New("runtimes were not found: cri-dockerd, dockerd")
+	_, err := exec.LookPath("docker")
+	return err
 }
 
 // Active returns if docker is active on the host

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/docker"
 	"k8s.io/minikube/pkg/minikube/download"
-	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/style"
 	"k8s.io/minikube/pkg/minikube/sysinit"
 )
@@ -110,11 +109,9 @@ func (r *Docker) Available() error {
 	// If Kubernetes version >= 1.24, require both cri-dockerd and dockerd.
 	if r.KubernetesVersion.GTE(semver.Version{Major: 1, Minor: 24}) {
 		if _, err := exec.LookPath("cri-dockerd"); err != nil {
-			out.ErrT(style.Fatal, `cri-dockerd is not installed, please install using these instructions: https://github.com/Mirantis/cri-dockerd#build-and-install, {{.error}}`, out.V{"error": err})
 			return err
 		}
 		if _, err := exec.LookPath("dockerd"); err != nil {
-			out.ErrT(style.Fatal, `dockerd is not installed, please install using these instructions: https://docs.docker.com/engine/reference/commandline/dockerd/, {{.error}}`, out.V{"error": err})
 			return err
 		}
 	}

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/docker"
 	"k8s.io/minikube/pkg/minikube/download"
+	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/style"
 	"k8s.io/minikube/pkg/minikube/sysinit"
 )
@@ -109,9 +110,11 @@ func (r *Docker) Available() error {
 	// If Kubernetes version >= 1.24, require both cri-dockerd and dockerd.
 	if r.KubernetesVersion.GTE(semver.Version{Major: 1, Minor: 24}) {
 		if _, err := exec.LookPath("cri-dockerd"); err != nil {
+			out.ErrT(style.Fatal, `cri-dockerd is not installed, please install using these instructions: https://github.com/Mirantis/cri-dockerd#build-and-install, {{.error}}`, out.V{"error": err})
 			return err
 		}
 		if _, err := exec.LookPath("dockerd"); err != nil {
+			out.ErrT(style.Fatal, `dockerd is not installed, please install using these instructions: https://docs.docker.com/engine/reference/commandline/dockerd/, {{.error}}`, out.V{"error": err})
 			return err
 		}
 	}

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -106,8 +106,17 @@ func (r *Docker) SocketPath() string {
 
 // Available returns an error if it is not possible to use this runtime on a host
 func (r *Docker) Available() error {
-	_, err := exec.LookPath("docker")
-	return err
+	var err error
+	if _, err = exec.LookPath("docker"); err == nil {
+		return nil
+	}
+	if _, err = exec.LookPath("cri-dockerd"); err == nil {
+		return nil
+	}
+	if _, err = exec.LookPath("dockerd"); err == nil {
+		return nil
+	}
+	return errors.New("runtimes were not found: docker, cri-dockerd, dockerd")
 }
 
 // Active returns if docker is active on the host

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -157,6 +157,11 @@ func IsMock(name string) bool {
 	return name == Mock
 }
 
+// IsNone checks if the driver is a none
+func IsNone(name string) bool {
+	return name == None
+}
+
 // IsKVM checks if the driver is a KVM[2]
 func IsKVM(name string) bool {
 	return name == KVM2 || name == AliasKVM

--- a/pkg/minikube/machine/start.go
+++ b/pkg/minikube/machine/start.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/blang/semver"
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/engine"
@@ -311,6 +312,23 @@ func postStartSetup(h *host.Host, mc config.ClusterConfig) error {
 
 	if driver.IsMock(h.DriverName) {
 		return nil
+	}
+
+	if driver.IsNone(h.DriverName) {
+		// If Kubernetes version >= 1.24, require both cri-dockerd and dockerd.
+		k8sVer, err := semver.ParseTolerant(mc.KubernetesConfig.KubernetesVersion)
+		if err != nil {
+			klog.Errorf("unable to parse Kubernetes version: %s", mc.KubernetesConfig.KubernetesVersion)
+			return err
+		}
+		if k8sVer.GTE(semver.Version{Major: 1, Minor: 24}) {
+			if _, err := exec.LookPath("cri-dockerd"); err != nil {
+				exit.Message(reason.NotFoundCriDockerD, "")
+			}
+			if _, err := exec.LookPath("dockerd"); err != nil {
+				exit.Message(reason.NotFoundDockerD, "")
+			}
+		}
 	}
 
 	klog.Infof("creating required directories: %v", requiredDirectories)

--- a/pkg/minikube/machine/start.go
+++ b/pkg/minikube/machine/start.go
@@ -314,7 +314,8 @@ func postStartSetup(h *host.Host, mc config.ClusterConfig) error {
 		return nil
 	}
 
-	if driver.IsNone(h.DriverName) {
+	// If none driver with docker container-runtime, require cri-dockerd and dockerd.
+	if driver.IsNone(h.DriverName) && mc.KubernetesConfig.ContainerRuntime == constants.Docker {
 		// If Kubernetes version >= 1.24, require both cri-dockerd and dockerd.
 		k8sVer, err := semver.ParseTolerant(mc.KubernetesConfig.KubernetesVersion)
 		if err != nil {

--- a/pkg/minikube/machine/start.go
+++ b/pkg/minikube/machine/start.go
@@ -323,10 +323,10 @@ func postStartSetup(h *host.Host, mc config.ClusterConfig) error {
 		}
 		if k8sVer.GTE(semver.Version{Major: 1, Minor: 24}) {
 			if _, err := exec.LookPath("cri-dockerd"); err != nil {
-				exit.Message(reason.NotFoundCriDockerD, "")
+				exit.Message(reason.NotFoundCriDockerD, "\n\n")
 			}
 			if _, err := exec.LookPath("dockerd"); err != nil {
-				exit.Message(reason.NotFoundDockerD, "")
+				exit.Message(reason.NotFoundDockerD, "\n\n")
 			}
 		}
 	}

--- a/pkg/minikube/machine/start.go
+++ b/pkg/minikube/machine/start.go
@@ -323,10 +323,10 @@ func postStartSetup(h *host.Host, mc config.ClusterConfig) error {
 		}
 		if k8sVer.GTE(semver.Version{Major: 1, Minor: 24}) {
 			if _, err := exec.LookPath("cri-dockerd"); err != nil {
-				exit.Message(reason.NotFoundCriDockerD, "\n\n")
+				exit.Message(reason.NotFoundCriDockerd, "\n\n")
 			}
 			if _, err := exec.LookPath("dockerd"); err != nil {
-				exit.Message(reason.NotFoundDockerD, "\n\n")
+				exit.Message(reason.NotFoundDockerd, "\n\n")
 			}
 		}
 	}

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -461,7 +461,7 @@ var (
 		Style: style.SeeNoEvil,
 	}
 
-	NotFoundCriDockerD = Kind{
+	NotFoundCriDockerd = Kind{
 		ID:       "NOT_FOUND_CRI_DOCKERD",
 		ExitCode: ExProgramNotFound,
 		Advice: translate.T(`The none driver with Kubernetes v1.24+ requires cri-dockerd.
@@ -471,7 +471,7 @@ var (
 		https://github.com/Mirantis/cri-dockerd#build-and-install`),
 		Style: style.Docker,
 	}
-	NotFoundDockerD = Kind{
+	NotFoundDockerd = Kind{
 		ID:       "NOT_FOUND_DOCKERD",
 		ExitCode: ExProgramNotFound,
 		Advice: translate.T(`The none driver with Kubernetes v1.24+ requires dockerd.

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -474,7 +474,7 @@ var (
 	NotFoundDockerd = Kind{
 		ID:       "NOT_FOUND_DOCKERD",
 		ExitCode: ExProgramNotFound,
-		Advice: translate.T(`The none driver with Kubernetes v1.24+ requires dockerd.
+		Advice: translate.T(`The none driver with Kubernetes v1.24+ and the docker container-runtime requires dockerd.
 		
 		Please install dockerd using these instructions:
 

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -464,7 +464,7 @@ var (
 	NotFoundCriDockerd = Kind{
 		ID:       "NOT_FOUND_CRI_DOCKERD",
 		ExitCode: ExProgramNotFound,
-		Advice: translate.T(`The none driver with Kubernetes v1.24+ requires cri-dockerd.
+		Advice: translate.T(`The none driver with Kubernetes v1.24+ and the docker container-runtime requires cri-dockerd.
 		
 		Please install cri-dockerd using these instructions:
 

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -478,7 +478,7 @@ var (
 		
 		Please install dockerd using these instructions:
 
-		https://docs.docker.com/engine/reference/commandline/dockerd/`),
+		https://docs.docker.com/engine/install/`),
 		Style: style.Docker,
 	}
 )

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -460,4 +460,25 @@ var (
 		`),
 		Style: style.SeeNoEvil,
 	}
+
+	NotFoundCriDockerD = Kind{
+		ID:       "NOT_FOUND_CRI_DOCKERD",
+		ExitCode: ExProgramNotFound,
+		Advice: translate.T(`The none driver with Kubernetes v1.24+ requires cri-dockerd.
+		
+		Please install cri-dockerd using these instructions:
+
+		https://github.com/Mirantis/cri-dockerd#build-and-install`),
+		Style: style.Docker,
+	}
+	NotFoundDockerD = Kind{
+		ID:       "NOT_FOUND_DOCKERD",
+		ExitCode: ExProgramNotFound,
+		Advice: translate.T(`The none driver with Kubernetes v1.24+ requires dockerd.
+		
+		Please install dockerd using these instructions:
+
+		https://docs.docker.com/engine/reference/commandline/dockerd/`),
+		Style: style.Docker,
+	}
 )


### PR DESCRIPTION
Fixes #14410, #14460

Check for `cri-dockerd` and `dockerd` in addition to `docker`, to help the user tell whether they have all the requirements to run the docker container runtime.

Checks for both `cri-dockerd` and `dockerd` only apply if the Kubernetes version is greater than or equal to v1.24.

---

Run minikube with `none` driver:
`sudo -E ./out/minikube start --driver=none`

---

If CONNTRACK is missing, install with: `sudo apt-get install -y conntrack`
```
❌  Exiting due to GUEST_MISSING_CONNTRACK: Sorry, Kubernetes 1.24.2 requires conntrack to be installed in root's path
```
---

**Before**: Linux system without `cri-dockerd` installed with k8s >= v.1.24.

```
$ sudo -E ./out/minikube start --driver=none
😄  minikube v1.26.0 on Debian rodete (kvm/amd64)
✨  Using the none driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🤹  Running on localhost (CPUs=48, Memory=181315MB, Disk=142997MB) ...
ℹ️  OS release is Debian GNU/Linux rodete

❌  Exiting due to RUNTIME_ENABLE: Temporary Error: sudo crictl version: exit status 1
stdout:

stderr:
time="2022-07-15T18:33:39Z" level=fatal msg="unable to determine runtime API version: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial unix /var/run/cri-dockerd.sock: connect: connection refused\""


╭───────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                           │
│    😿  If the above advice does not help, please let us know:                             │
│    👉  https://github.com/kubernetes/minikube/issues/new/choose                           │
│                                                                                           │
│    Please run `minikube logs --file=logs.txt` and attach logs.txt to the GitHub issue.    │
│                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────╯
```
---
**After**: Linux system without `cri-dockerd` installed with k8s >= v.1.24.

```
$ sudo -E ./out/minikube start --driver=none
😄  minikube v1.26.0 on Debian rodete (kvm/amd64)
✨  Using the none driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
🔄  Restarting existing none bare metal machine for "minikube" ...

🐳  Exiting due to NOT_FOUND_CRI_DOCKERD:

💡  Suggestion: 

    The none driver with Kubernetes v1.24+ and the docker container-runtime requires cri-dockerd.
    
    Please install cri-dockerd using these instructions:
    
    https://github.com/Mirantis/cri-dockerd#build-and-install
```

---
Next, install `cri-dockerd`, ([installation guide](https://github.com/Mirantis/cri-dockerd#build-and-install)).

Note: if you encounter the error `crictl` not found:

```
$ sudo -E ./out/minikube start --driver=none
[sudo] password for klaases: 
😄  minikube v1.26.0 on Debian rodete (kvm/amd64)
✨  Using the none driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
🔄  Restarting existing none bare metal machine for "minikube" ...
ℹ️  OS release is Debian GNU/Linux rodete

❌  Exiting due to RUNTIME_ENABLE: Temporary Error: sudo crictl version: exit status 1
stdout:

stderr:
sudo: crictl: command not found
...

```
By default, `crictl` will work from `/usr/local/bin/`, however minikube requires `crictl` to be in `/usr/bin/` ([more information](https://github.com/kubernetes/minikube/issues/5547#issuecomment-556984525)).

Manually fix `sudo crictl` by running the following command:
`sudo cp /usr/local/bin/crictl /usr/bin/crictl`

---

**After**: Linux system with `cri-dockerd` installed with Kubernetes >= 1.24.

```
sudo -E ./out/minikube start --driver=none
😄  minikube v1.26.0 on Debian rodete (kvm/amd64)
✨  Using the none driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
🏃  Updating the running none "minikube" bare metal machine ...
ℹ️  OS release is Debian GNU/Linux rodete
🐳  Preparing Kubernetes v1.24.2 on Docker 20.10.2 ...
🤹  Configuring local host environment ...

❗  The 'none' driver is designed for experts who need to integrate with an existing VM
💡  Most users should use the newer 'docker' driver instead, which does not require root!
📘  For more information, see: https://minikube.sigs.k8s.io/docs/reference/drivers/none/

❗  kubectl and minikube configuration will be stored in /root
❗  To use kubectl or minikube commands as your own user, you may need to relocate them. For example, to overwrite your own settings, run:

    ▪ sudo mv /root/.kube /root/.minikube $HOME
    ▪ sudo chown -R $USER $HOME/.kube $HOME/.minikube

💡  This can also be done automatically by setting the env var CHANGE_MINIKUBE_NONE_USER=true
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: default-storageclass, storage-provisioner
💡  kubectl not found. If you need it, try: 'minikube kubectl -- get pods -A'
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```

---
**After**: Linux system without `cri-dockerd` installed and with older version of Kubernetes less than 1.24.

---

1. Uninstall `cri-dockerd`, or make unavailable with:`sudo mv cri-dockerd cri-dockerd1`
2. Downgrade Kubernetes (this did not work, need to instead use a minikube flag like `--kubernetes-version=v1.23.0`):

   - `curl -LO https://dl.k8s.io/release/v1.23.0/bin/linux/amd64/kubectl`
   - `sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl`
   - `kubectl version --client`
   - `Client Version: version.Info{Major:"1", Minor:"23" ...`

Note: that a profile cannot be used with the `none` driver.
```
❌  Exiting due to DRV_UNSUPPORTED_PROFILE: The 'none driver does not support multiple profiles: https://minikube.sigs.k8s.io/docs/reference/drivers/none/
```

Note: downgrading with `--kubernetes-version=v1.23.0` also did not work.
```
sudo -E ./out/minikube start --driver=none --kubernetes-version=v1.23.0
😄  minikube v1.26.0 on Debian rodete (kvm/amd64)

🙈  Exiting due to K8S_DOWNGRADE_UNSUPPORTED: Unable to safely downgrade existing Kubernetes v1.24.2 cluster to v1.23.0
💡  Suggestion: 

    1) Recreate the cluster with Kubernetes 1.23.0, by running:
    
    minikube delete
    minikube start --kubernetes-version=v1.23.0
    
    2) Create a second cluster with Kubernetes 1.23.0, by running:
    
    minikube start -p minikube2 --kubernetes-version=v1.23.0
    
    3) Use the existing cluster at version Kubernetes 1.24.2, by running:
    
    minikube start --kubernetes-version=v1.24.2
```

Running `minikube delete` and `minikube start --kubernetes-version=v1.23.0` work, however even after running minikube with v.1.23, `sudo -E ./out/minikube start --driver=none --kubernetes-version=v1.23.0` produces the above error.

The solution was to **completely restart the Linux system**.

Subsequent tests with and without `--force` and both worked as expected.

```
$ sudo -E ./out/minikube start --driver=none --kubernetes-version=v1.23.0 --force
😄  minikube v1.26.0 on Debian rodete (kvm/amd64)
❗  minikube skips various validations when --force is supplied; this may lead to unexpected behavior
✨  Using the none driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🤹  Running on localhost (CPUs=48, Memory=181315MB, Disk=142997MB) ...
ℹ️  OS release is Debian GNU/Linux rodete
🐳  Preparing Kubernetes v1.23.0 on Docker 20.10.2 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🤹  Configuring local host environment ...

❗  The 'none' driver is designed for experts who need to integrate with an existing VM
💡  Most users should use the newer 'docker' driver instead, which does not require root!
📘  For more information, see: https://minikube.sigs.k8s.io/docs/reference/drivers/none/

❗  kubectl and minikube configuration will be stored in /root
❗  To use kubectl or minikube commands as your own user, you may need to relocate them. For example, to overwrite your own settings, run:

    ▪ sudo mv /root/.kube /root/.minikube $HOME
    ▪ sudo chown -R $USER $HOME/.kube $HOME/.minikube

💡  This can also be done automatically by setting the env var CHANGE_MINIKUBE_NONE_USER=true
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: default-storageclass, storage-provisioner
💡  kubectl not found. If you need it, try: 'minikube kubectl -- get pods -A'
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```