### PR TITLE
Fix incorrect user and profile in audit logging

### DIFF
--- a/pkg/minikube/audit/audit.go
+++ b/pkg/minikube/audit/audit.go
@@ -58,7 +58,7 @@ func args() string {
 
 // Log details about the executed command.
 func LogCommandStart() (string, error) {
-	if len(os.Args) < 2 || !shouldLog() {
+	if !shouldLog() {
 		return "", nil
 	}
 	id := uuid.New().String()


### PR DESCRIPTION
1. Fixed minikube home directory not existing before trying to write to audit log (first use or after `--purge`)

**Before (throws error about directory not existing):**
```
$ minikube stop
E0712 11:43:34.803850   47538 root.go:88] failed to log command start to audit: failed to open the audit log: open /Users/powellsteven/.minikube/logs/audit.json: no such file or directory
🤷  Profile "minikube" not found. Run "minikube profile list" to view all profiles.
👉  To start a cluster, run: "minikube start"
```

**After:**
```
$ minikube stop
🤷  Profile "minikube" not found. Run "minikube profile list" to view all profiles.
👉  To start a cluster, run: "minikube start"
```

2. Fixed trying to update audit log after `--purge`

**Before (throws error about directory not existing):**
```
$ minikube delete --all --purge
💀  Removed all traces of the "p5" cluster.
🔥  Successfully deleted all profiles
💀  Successfully purged minikube directory located at - [/Users/powellsteven/.minikube]
E0712 11:43:31.110111   47526 root.go:93] failed to log command end to audit: failed to open the audit log: open /Users/powellsteven/.minikube/logs/audit.json: no such file or directory
```

**After:**
```
$ minikube delete --all --purge
💀  Removed all traces of the "p5" cluster.
🔥  Successfully deleted all profiles
💀  Successfully purged minikube directory located at - [/Users/powellsteven/.minikube]
```

3. Fixed audit log not logging the correct profile and user

**Before (profile logged as `minikube` instead `p5` & user logged as `powellsteven` instead of `cloud-code`:**
```
$ minikube stop -p p5 --user cloud-code
...
$ minikube logs --audit

==> Audit <==
|---------|-------------------------|----------|--------------|---------|---------------------|----------|
| Command |          Args           | Profile  |     User     | Version |     Start Time      | End Time |
|---------|-------------------------|----------|--------------|---------|---------------------|----------|
| stop    | -p p5 --user cloud-code | minikube | powellsteven | v1.26.0 | 12 Jul 22 11:52 PDT |          |
|---------|-------------------------|----------|--------------|---------|---------------------|----------|

```

**After:**
```
$ minikube stop -p p5 --user cloud-code
...
$ minikube logs --audit

==> Audit <==
|---------|-------------------------|---------|------------|---------|---------------------|----------|
| Command |          Args           | Profile |    User    | Version |     Start Time      | End Time |
|---------|-------------------------|---------|------------|---------|---------------------|----------|
| stop    | -p p5 --user cloud-code | p5      | cloud-code | v1.26.0 | 12 Jul 22 11:51 PDT |          |
|---------|-------------------------|---------|------------|---------|---------------------|----------|
```

The root of the audit logging problem is that before https://github.com/kubernetes/minikube/pull/13307 we would add the audit entry after the command ended. But with the PR we are now adding the audit entry at the before the command, and before the flags are even parsed, so the user and profile flags were defaulting to default values. So moved the audit logging after the flags are parsed, resulting in the correct values. Also moved to after the minikube directory is created preventing the minikube home directory not existing errors.