### PR TITLE
CI: Fix cron pathing on M1

### DIFF
--- a/hack/jenkins/cron/cleanup_and_reboot_Darwin.sh
+++ b/hack/jenkins/cron/cleanup_and_reboot_Darwin.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copyright 2019 The Kubernetes Authors All rights reserved.
 #
@@ -18,15 +18,18 @@
 set -uf -o pipefail
 
 PATH=/usr/local/bin:/sbin:/usr/local/sbin:$PATH
+if [ "$(uname -p)" = "arm" ]; then
+  PATH=$PATH:/opt/homebrew/bin
+fi
 
 # cleanup shared between Linux and macOS
 function check_jenkins() {
   jenkins_pid="$(pidof java)"
-  if [[ "${jenkins_pid}" = "" ]]; then
+  if [ "${jenkins_pid}" = "" ]; then
           return
   fi
   pstree "${jenkins_pid}" \
-        | egrep -i 'bash|integration|e2e|minikube' \
+        | grep -E -i 'bash|integration|e2e|minikube' \
         && echo "tests are is running on pid ${jenkins_pid} ..." \
         && exit 1
 }
@@ -42,7 +45,7 @@ logger "cleanup_and_reboot is happening!"
 killall java
 
 # clean docker left overs
-docker rm -f -v $(docker ps -aq) >/dev/null 2>&1 || true
+docker rm -f -v "$(docker ps -aq)" >/dev/null 2>&1 || true
 docker volume prune -f || true
 docker volume ls || true
 docker system df || true


### PR DESCRIPTION
The cron job `cleanup_and_reboot_Darwin.sh` was restarting the M1 machines when a job was actively running.

I discovered the cause was related to Homebrew installing to `/opt/homebrew` on M1 machines instead of `/usr/local` on Intel Macs.

In the cron script the command `pidof` is run, which is installed via Homebrew. So `PATH` didn't include the path to `pidof`.

So `jenkins_pid="$(pidof java)"` resulted in `jenkins_pid` being empty, which passed `if [ "${jenkins_pid}" = "" ]` resulting in the machine thinking a job wasn't running.

Added a check where if the machine is an M1 machine it adds the Homebrew dir to `PATH` and a few other small cleanups.