### PR TITLE
fix inconsistencies in proxy documentation

### DIFF
--- a/site/content/en/docs/handbook/vpn_and_proxy.md
+++ b/site/content/en/docs/handbook/vpn_and_proxy.md
@@ -18,7 +18,7 @@ If a HTTP proxy is required to access the internet, you may need to pass the pro
 * `HTTPS_PROXY` - The URL to your HTTPS proxy
 * `NO_PROXY` - A comma-separated list of hosts which should not go through the proxy.
 
-The NO_PROXY variable here is important: Without setting it, minikube may not be able to access resources within the VM. minikube uses two IP ranges, which should not go through the proxy:
+The NO_PROXY variable here is important: Without setting it, minikube may not be able to access resources within the VM. minikube uses four default IP ranges, which should not go through the proxy:
 
 * **192.168.59.0/24**: Used by the minikube VM. Configurable for some hypervisors via `--host-only-cidr`
 * **192.168.39.0/24**: Used by the minikube kvm2 driver.
@@ -34,7 +34,7 @@ One important note: If NO_PROXY is required by non-Kubernetes applications, such
 ```shell
 export HTTP_PROXY=http://<proxy hostname:port>
 export HTTPS_PROXY=https://<proxy hostname:port>
-export NO_PROXY=localhost,127.0.0.1,10.96.0.0/12,192.168.59.0/24,192.168.39.0/24
+export NO_PROXY=localhost,127.0.0.1,10.96.0.0/12,192.168.59.0/24,192.168.49.0/24,192.168.39.0/24
 
 minikube start
 ```
@@ -46,7 +46,7 @@ To make the exported variables permanent, consider adding the declarations to ~/
 ```shell
 set HTTP_PROXY=http://<proxy hostname:port>
 set HTTPS_PROXY=https://<proxy hostname:port>
-set NO_PROXY=localhost,127.0.0.1,10.96.0.0/12,192.168.59.0/24,192.168.39.0/24
+set NO_PROXY=localhost,127.0.0.1,10.96.0.0/12,192.168.59.0/24,192.168.49.0/24,192.168.39.0/24
 
 minikube start
 ```


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

This small PR fixes some inconsistencies I encountered in the documentation for proxy settings in minikube.
Namely:

1. The description for `NO_PROXY` mentioned two subnets but listed four -- I have adapted the text here
2. In the example for the `NO_PROXY` environment variable, one of the subnets listed above was not included, which leads to minikube complaining on start-up. Maybe this is intentional but it does not seem to be documented.