### PR TITLE
Optimize audit logging

### DIFF
--- a/pkg/minikube/audit/logFile.go
+++ b/pkg/minikube/audit/logFile.go
@@ -30,6 +30,10 @@ var currentLogFile *os.File
 
 // openAuditLog opens the audit log file or creates it if it doesn't exist.
 func openAuditLog() error {
+	// this is so we can manually set the log file for tests
+	if currentLogFile != nil {
+		return nil
+	}
 	lp := localpath.AuditLog()
 	f, err := os.OpenFile(lp, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0644)
 	if err != nil {
@@ -44,6 +48,7 @@ func closeAuditLog() {
 	if err := currentLogFile.Close(); err != nil {
 		klog.Errorf("failed to close the audit log: %v", err)
 	}
+	currentLogFile = nil
 }
 
 // appendToLog appends the row to the log file.

--- a/pkg/minikube/audit/report_test.go
+++ b/pkg/minikube/audit/report_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package audit
 
 import (
+	"io"
 	"os"
 	"testing"
 )
@@ -30,18 +31,18 @@ func TestReport(t *testing.T) {
 
 	s := `{"data":{"args":"-p mini1","command":"start","endTime":"Wed, 03 Feb 2021 15:33:05 MST","profile":"mini1","startTime":"Wed, 03 Feb 2021 15:30:33 MST","user":"user1"},"datacontenttype":"application/json","id":"9b7593cb-fbec-49e5-a3ce-bdc2d0bfb208","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.si  gs.minikube.audit"}
 {"data":{"args":"-p mini1","command":"start","endTime":"Wed, 03 Feb 2021 15:33:05 MST","profile":"mini1","startTime":"Wed, 03 Feb 2021 15:30:33 MST","user":"user1"},"datacontenttype":"application/json","id":"9b7593cb-fbec-49e5-a3ce-bdc2d0bfb208","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.si  gs.minikube.audit"}
-{"data":{"args":"--user user2","command":"logs","endTime":"Tue, 02 Feb 2021 16:46:20 MST","profile":"minikube","startTime":"Tue, 02 Feb 2021 16:46:00 MST","user":"user2"},"datacontenttype":"application/json","id":"fec03227-2484-48b6-880a-88fd010b5efd","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.audit"}`
+{"data":{"args":"--user user2","command":"logs","endTime":"Tue, 02 Feb 2021 16:46:20 MST","profile":"minikube","startTime":"Tue, 02 Feb 2021 16:46:00 MST","user":"user2"},"datacontenttype":"application/json","id":"fec03227-2484-48b6-880a-88fd010b5efd","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.audit"}
+`
 
 	if _, err := f.WriteString(s); err != nil {
 		t.Fatalf("failed writing to file: %v", err)
 	}
-	if _, err := f.Seek(0, 0); err != nil {
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
 		t.Fatalf("failed seeking to start of file: %v", err)
 	}
 
-	oldLogFile := *currentLogFile
-	defer func() { currentLogFile = &oldLogFile }()
 	currentLogFile = f
+	defer closeAuditLog()
 
 	wantedLines := 2
 	r, err := Report(wantedLines)


### PR DESCRIPTION
Related https://github.com/kubernetes/minikube/issues/14543 

**Base Case (empty audit log):**
```
$ ls -lah ~/.minikube/logs
-rw-r--r--   1 powellsteven  primarygroup     0B Jul 15 12:58 audit.json
$ minikube options
# average time 0.531s
```

**Before (with 5.5 MB audit log):**
```
$ ls -lah ~/.minikube/logs
-rw-r--r--   1 powellsteven  primarygroup   5.5M Jul 15 12:52 audit.json
$ minikube options
# average time 9.81s
```

**After (with 5.5 MB audit log):**
```
$ ls -lah ~/.minikube/logs
-rw-r--r--   1 powellsteven  primarygroup   5.5M Jul 15 12:52 audit.json
$ minikube options
# average time 0.714s
```

### **92.8% reduction**

**Cause of problem:**
```
auditContents += string(auditLog) + "\n"
```
Appending the contents to a string variable is what was taking up all the time.

**Solution:**
```
currentLogFile.WriteString(string(auditLog) + "\n")
```
Writing to the file every time instead of concatenating to a string resolved the bottleneck.

Also made small changes to the tests, discovered the tests were using the main `audit.json` file instead of the tmp file the tests were creating.