### PR TITLE
[addons/storage-provisioner-gluster] Use gluster's official container…

### DIFF
--- a/deploy/addons/aliyun_mirror.json
+++ b/deploy/addons/aliyun_mirror.json
@@ -24,7 +24,7 @@
   "k8s.gcr.io/sig-storage/csi-snapshotter": "registry.cn-hangzhou.aliyuncs.com/google_containers/csi-snapshotter",
   "k8s.gcr.io/sig-storage/csi-provisioner": "registry.cn-hangzhou.aliyuncs.com/google_containers/csi-provisioner",
   "docker.io/registry": "registry.cn-hangzhou.aliyuncs.com/google_containers/registry",
-  "docker.io/gluster/gluster-centos": "registry.cn-hangzhou.aliyuncs.com/google_containers/glusterfs-server",
+  "ghcr.io/gluster/gluster-containers": "registry.cn-hangzhou.aliyuncs.com/google_containers/glusterfs-server",
   "docker.io/heketi/heketi": "registry.cn-hangzhou.aliyuncs.com/google_containers/heketi",
   "docker.io/coredns/coredns": "registry.cn-hangzhou.aliyuncs.com/google_containers/coredns",
   "docker.io/kindest/kindnetd": "registry.cn-hangzhou.aliyuncs.com/google_containers/kindnetd",

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -193,10 +193,10 @@ var Addons = map[string]*Addon{
 	}, false, "storage-provisioner-gluster", "3rd party (Gluster)", "", "", map[string]string{
 		"Heketi":                 "heketi/heketi:10@sha256:76d5a6a3b7cf083d1e99efa1c15abedbc5c8b73bef3ade299ce9a4c16c9660f8",
 		"GlusterfileProvisioner": "gluster/glusterfile-provisioner:latest@sha256:9961a35cb3f06701958e202324141c30024b195579e5eb1704599659ddea5223",
-		"GlusterfsServer":        "gluster/gluster-centos:latest@sha256:8167034b9abf2d16581f3f4571507ce7d716fb58b927d7627ef72264f802e908",
+		"GlusterfsServer":        "gluster/gluster-containers:glfs10.2-centos@sha256:961c1d8169ec61831c7b0650f9d099460581a46b2778202590f438ea7f857e21",
 	}, map[string]string{
 		"Heketi":                 "docker.io",
-		"GlusterfsServer":        "docker.io",
+		"GlusterfsServer":        "ghcr.io",
 		"GlusterfileProvisioner": "docker.io",
 	}),
 	"efk": NewAddon([]*BinAsset{


### PR DESCRIPTION
… images

I have omitted the sha256 sum as we only ever provide the `latest`(aka `centos`) and `fedora`
tags. We don't have versioned releases. Including the SHA sum would require us to update the sum
here on every new release which would be a hassle.

Signed-off-by: black.dragon74 <nickk.2974@gmail.com>

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
