### PR TITLE
CI: add macos-11 to remove deprecated macos-10.15

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -395,7 +395,7 @@ jobs:
       JOB_NAME: "functional_virtualbox_macos"
       GOPOGH_RESULT: ""
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - name: Install kubectl
         shell: bash

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -395,7 +395,7 @@ jobs:
       JOB_NAME: "functional_virtualbox_macos"
       GOPOGH_RESULT: ""
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - name: Install kubectl
         shell: bash

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -395,7 +395,7 @@ jobs:
       JOB_NAME: "functional_virtualbox_macos"
       GOPOGH_RESULT: ""
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - name: Install kubectl
         shell: bash

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -395,7 +395,7 @@ jobs:
       JOB_NAME: "functional_virtualbox_macos"
       GOPOGH_RESULT: ""
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - name: Install kubectl
         shell: bash

--- a/.github/workflows/time-to-k8s-public-chart.yml
+++ b/.github/workflows/time-to-k8s-public-chart.yml
@@ -31,7 +31,7 @@ jobs:
           ./hack/benchmark/time-to-k8s/public-chart/public-chart.sh docker containerd
   time-to-k8s-public-chart-virtualbox:
     if: github.repository == 'kubernetes/minikube'
-    runs-on: macos-10.15
+    runs-on: macos-11
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/time-to-k8s-public-chart.yml
+++ b/.github/workflows/time-to-k8s-public-chart.yml
@@ -31,7 +31,7 @@ jobs:
           ./hack/benchmark/time-to-k8s/public-chart/public-chart.sh docker containerd
   time-to-k8s-public-chart-virtualbox:
     if: github.repository == 'kubernetes/minikube'
-    runs-on: macos-11
+    runs-on: macos-12
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Reference: https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/
