### PR TITLE
fixes url index out of range error in service

### DIFF
--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -260,6 +260,12 @@ func mutateURLs(serviceName string, urls []string) ([]string, error) {
 
 func openURLs(urls [][]string) {
 	for _, u := range urls {
+
+		if len(u) < 4{
+			klog.Warning("No URL found")
+			continue
+		}
+
 		_, err := url.Parse(u[3])
 		if err != nil {
 			klog.Warningf("failed to parse url %q: %v (will not open)", u[3], err)

--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -261,7 +261,7 @@ func mutateURLs(serviceName string, urls []string) ([]string, error) {
 func openURLs(urls [][]string) {
 	for _, u := range urls {
 
-		if len(u) < 4{
+		if len(u) < 4 {
 			klog.Warning("No URL found")
 			continue
 		}


### PR DESCRIPTION
* if there is no node port, service panics accessing url
* since the length of array is 3 when there is no node port, accessing u[3] results in
	index out of range

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
