### PR TITLE
Add and fix err checks in bsutil and sysinit packages

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/binaries.go
+++ b/pkg/minikube/bootstrapper/bsutil/binaries.go
@@ -81,10 +81,10 @@ func TransferBinaries(cfg config.KubernetesConfig, c command.Runner, sm sysinit.
 func binariesExist(cfg config.KubernetesConfig, c command.Runner) (bool, error) {
 	dir := binRoot(cfg.KubernetesVersion)
 	rr, err := c.RunCmd(exec.Command("sudo", "ls", dir))
-	stdout := rr.Stdout.String()
 	if err != nil {
 		return false, err
 	}
+	stdout := rr.Stdout.String()
 	foundBinaries := map[string]struct{}{}
 	for _, binary := range strings.Split(stdout, "\n") {
 		foundBinaries[binary] = struct{}{}

--- a/pkg/minikube/sysinit/openrc.go
+++ b/pkg/minikube/sysinit/openrc.go
@@ -108,8 +108,11 @@ func (s *OpenRC) Start(svc string) error {
 	defer cb()
 
 	rr, err := s.r.RunCmd(exec.CommandContext(ctx, "sudo", "service", svc, "start"))
+	if err != nil {
+		return err
+	}
 	klog.Infof("start output: %s", rr.Output())
-	return err
+	return nil
 }
 
 // Disable does nothing
@@ -149,8 +152,11 @@ func (s *OpenRC) Unmask(svc string) error {
 // Restart restarts a service
 func (s *OpenRC) Restart(svc string) error {
 	rr, err := s.r.RunCmd(exec.Command("sudo", "service", svc, "restart"))
+	if err != nil {
+		return err
+	}
 	klog.Infof("restart output: %s", rr.Output())
-	return err
+	return nil
 }
 
 // Reload reloads a service
@@ -162,8 +168,11 @@ func (s *OpenRC) Reload(svc string) error {
 // Stop stops a service
 func (s *OpenRC) Stop(svc string) error {
 	rr, err := s.r.RunCmd(exec.Command("sudo", "service", svc, "stop"))
+	if err != nil {
+		return err
+	}
 	klog.Infof("stop output: %s", rr.Output())
-	return err
+	return nil
 }
 
 // ForceStop stops a service with prejuidice


### PR DESCRIPTION
I'm diving into CodeQL at the moment and just looked at default alerts for minikube and saw [this alert](https://lgtm.com/projects/g/kubernetes/minikube/snapshot/abf6d2aa8144c707a9ce9097a3bb047c170eeb6e/files/pkg/minikube/bootstrapper/bsutil/binaries.go?sort=name&dir=ASC&mode=heatmap) and [this one](https://lgtm.com/projects/g/kubernetes/minikube/snapshot/abf6d2aa8144c707a9ce9097a3bb047c170eeb6e/files/pkg/minikube/sysinit/openrc.go?sort=name&dir=ASC&mode=heatmap) on minikube and thought it would be nice to have it fixed since they could (in theory) result to a nil pointer access.

There are other alerts available [here](https://lgtm.com/projects/g/kubernetes/minikube/?mode=list), most of them are false positive and not important but some might be interesting :)!