### PR TITLE
Fix registry when custom images provided

### DIFF
--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -221,7 +221,7 @@ func EnableOrDisableAddon(cc *config.ClusterConfig, name string, val string) err
 		out.WarningT("At least needs control plane nodes to enable addon")
 	}
 
-	data := assets.GenerateTemplateData(addon, cc.KubernetesConfig, networkInfo, images, customRegistries, enable)
+	data := assets.GenerateTemplateData(addon, cc, networkInfo, images, customRegistries, enable)
 	return enableOrDisableAddonInternal(cc, addon, runner, data, enable)
 }
 

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -785,6 +785,8 @@ func SelectAndPersistImages(addon *Addon, cc *config.ClusterConfig) (images, cus
 		}
 		// Use newly configured custom images.
 		images = overrideDefaults(addonDefaultImages, newImages)
+		// Store custom addon images to be written.
+		cc.CustomAddonImages = mergeMaps(cc.CustomAddonImages, newImages)
 	}
 
 	// Use previously configured custom registries.

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -902,11 +902,11 @@ func GenerateTemplateData(addon *Addon, cc *config.ClusterConfig, netInfo Networ
 			opts.Registries[name] = "" // Avoid nil access when rendering
 		}
 
+		// tl;dr If the user specified a custom image remove the default registry
 		// Without the line below, if you try to overwrite an image the default registry is still used in the templating
 		// Example - image name: MetricsScraper, default registry: docker.io, default image: kubernetesui/metrics-scraper
 		// Passed on addon enable: --images=MetricsScraper=k8s.gcr.io/echoserver:1.4
 		// Without this line the resulting image would be docker.io/k8s.gcr.io/echoserver:1.4
-		// Therefore, if the user specified a custom image remove the default registry
 		if _, ok := cc.CustomAddonImages[name]; ok {
 			opts.Registries[name] = ""
 		}

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -785,8 +785,6 @@ func SelectAndPersistImages(addon *Addon, cc *config.ClusterConfig) (images, cus
 		}
 		// Use newly configured custom images.
 		images = overrideDefaults(addonDefaultImages, newImages)
-		// Store custom addon images to be written.
-		cc.CustomAddonImages = mergeMaps(cc.CustomAddonImages, images)
 	}
 
 	// Use previously configured custom registries.


### PR DESCRIPTION
Related: https://github.com/kubernetes/minikube/pull/14521

**Before:**
```
minikube addons enable dashboard --images=MetricsScraper=k8s.gcr.io/echoserver:1.4
...
# Resulting (incorrect) image: docker.io/k8s.gcr.io/echoserver:1.4
```

**After:**
```
minikube addons enable dashboard --images=MetricsScraper=k8s.gcr.io/echoserver:1.4
...
# Resulting (correct) image: k8s.gcr.io/echoserver:1.4
```

Don't use default registry if custom image is defined.