### PR TITLE
Use time-to-k8s fork to resolve Go 1.18 issue

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "site/themes/docsy"]
 	path = site/themes/docsy
 	url = https://github.com/google/docsy.git
+[submodule "hack/benchmark/time-to-k8s/time-to-k8s-repo"]
+	path = hack/benchmark/time-to-k8s/time-to-k8s-repo
+	url = https://github.com/spowelljr/time-to-k8s.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "site/themes/docsy"]
 	path = site/themes/docsy
 	url = https://github.com/google/docsy.git
-[submodule "hack/benchmark/time-to-k8s/time-to-k8s-repo"]
-	path = hack/benchmark/time-to-k8s/time-to-k8s-repo
-	url = https://github.com/tstromberg/time-to-k8s.git


### PR DESCRIPTION
PR https://github.com/tstromberg/time-to-k8s/pull/9 resolves running with Go 1.18. It hasn't been merged yet, so using our fork that has the above PR included until https://github.com/tstromberg/time-to-k8s/pull/9 gets merged.