### PR TITLE
Limit number of audit entries

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -168,6 +168,10 @@ var settings = []Setting{
 		name: config.Rootless,
 		set:  SetBool,
 	},
+	{
+		name: config.MaxAuditEntries,
+		set:  SetInt,
+	},
 }
 
 // ConfigCmd represents the config command

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -325,6 +325,7 @@ func setupViper() {
 	viper.SetDefault(config.ReminderWaitPeriodInHours, 24)
 	viper.SetDefault(config.WantNoneDriverWarning, true)
 	viper.SetDefault(config.WantVirtualBoxDriverWarning, true)
+	viper.SetDefault(config.MaxAuditEntries, 1000)
 }
 
 func addToPath(dir string) {

--- a/pkg/minikube/audit/audit.go
+++ b/pkg/minikube/audit/audit.go
@@ -98,6 +98,9 @@ func LogCommandEnd(id string) error {
 		return err
 	}
 	var entriesNeedsToUpdate int
+
+	startIndex := getStartIndex(len(rowSlice))
+	rowSlice = rowSlice[startIndex:]
 	for _, v := range rowSlice {
 		if v.id == id {
 			v.endTime = time.Now().Format(constants.TimeFormat)
@@ -116,6 +119,15 @@ func LogCommandEnd(id string) error {
 		return fmt.Errorf("failed to find a log row with id equals to %v", id)
 	}
 	return nil
+}
+
+func getStartIndex(entryCount int) int {
+	maxEntries := viper.GetInt(config.MaxAuditEntries)
+	startIndex := entryCount - maxEntries
+	if maxEntries <= 0 || startIndex <= 0 {
+		return 0
+	}
+	return startIndex
 }
 
 // shouldLog returns if the command should be logged.

--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -54,6 +54,8 @@ const (
 	AddonListFlag = "addons"
 	// EmbedCerts represents the config for embedding certificates in kubeconfig
 	EmbedCerts = "EmbedCerts"
+	// MaxAuditEntries is the maximum number of audit entries to retain
+	MaxAuditEntries = "MaxAuditEntries"
 )
 
 var (


### PR DESCRIPTION
Closes https://github.com/kubernetes/minikube/issues/14543

- Added feature to cap amount of audit entries
  - Once limit is passed, the oldest entries are trimmed
  - By default limits audit entries to 1,000 lines
- Added config option `MaxAuditEntries`
  - Allows to customize the max amount of audit entries to retain
  - `minikube config set MaxAuditEntries <number>`
  - Setting to `0` will set to unlimited audit entries
- Added test to ensure cap and `MaxAuditEntries` are working