### PR TITLE
Output kubeadm logs

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -313,12 +313,13 @@ func outputKubeadmInitSteps(logs io.Reader, wg *sync.WaitGroup) {
 
 	scanner := bufio.NewScanner(logs)
 	for scanner.Scan() {
+		line := scanner.Text()
+		klog.Info(line)
 		if nextStepIndex >= len(steps) {
-			scanner.Text()
 			continue
 		}
 		nextStep := steps[nextStepIndex]
-		if !strings.Contains(scanner.Text(), fmt.Sprintf("[%s]", nextStep.logTag)) {
+		if !strings.Contains(line, fmt.Sprintf("[%s]", nextStep.logTag)) {
 			continue
 		}
 		register.Reg.SetStep(nextStep.registerStep)


### PR DESCRIPTION
Previously, kubeadm logs were being intercepted but not being output so information was being hidden.

**Before:**
```
minikube start --alsologtostderr
...
I0801 16:33:44.960975   85239 out.go:204]     ▪ Generating certificates and keys ...
I0801 16:33:47.550836   85239 out.go:204]     ▪ Booting up control plane ...
I0801 16:33:58.607375   85239 out.go:204]     ▪ Configuring RBAC rules ...
...
```

**After:**
```
minikube start --alsologtostderr
...
I0801 16:16:12.122635   82618 kubeadm.go:317] [init] Using Kubernetes version: v1.24.3
I0801 16:16:12.122692   82618 kubeadm.go:317] [preflight] Running pre-flight checks
I0801 16:16:12.227545   82618 kubeadm.go:317] [preflight] Pulling images required for setting up a Kubernetes cluster
I0801 16:16:12.227630   82618 kubeadm.go:317] [preflight] This might take a minute or two, depending on the speed of your internet connection
I0801 16:16:12.227715   82618 kubeadm.go:317] [preflight] You can also perform this action in beforehand using 'kubeadm config images pull'
I0801 16:16:41.249173   82618 kubeadm.go:317] [certs] Using certificateDir folder "/var/lib/minikube/certs"
I0801 16:16:41.303688   82618 out.go:204]     ▪ Generating certificates and keys ...
I0801 16:16:41.303780   82618 kubeadm.go:317] [certs] Using existing ca certificate authority
I0801 16:16:41.303838   82618 kubeadm.go:317] [certs] Using existing apiserver certificate and key on disk
I0801 16:16:41.335187   82618 kubeadm.go:317] [certs] Generating "apiserver-kubelet-client" certificate and key
I0801 16:16:41.646229   82618 kubeadm.go:317] [certs] Generating "front-proxy-ca" certificate and key
I0801 16:16:41.759507   82618 kubeadm.go:317] [certs] Generating "front-proxy-client" certificate and key
I0801 16:16:41.923492   82618 kubeadm.go:317] [certs] Generating "etcd/ca" certificate and key
I0801 16:16:42.114850   82618 kubeadm.go:317] [certs] Generating "etcd/server" certificate and key
I0801 16:16:42.115117   82618 kubeadm.go:317] [certs] etcd/server serving cert is signed for DNS names [localhost minikube] and IPs [192.168.49.2 127.0.0.1 ::1]
I0801 16:16:42.338036   82618 kubeadm.go:317] [certs] Generating "etcd/peer" certificate and key
I0801 16:16:42.338193   82618 kubeadm.go:317] [certs] etcd/peer serving cert is signed for DNS names [localhost minikube] and IPs [192.168.49.2 127.0.0.1 ::1]
I0801 16:16:42.612558   82618 kubeadm.go:317] [certs] Generating "etcd/healthcheck-client" certificate and key
I0801 16:16:42.722425   82618 kubeadm.go:317] [certs] Generating "apiserver-etcd-client" certificate and key
I0801 16:16:43.007911   82618 kubeadm.go:317] [certs] Generating "sa" key and public key
I0801 16:16:43.007987   82618 kubeadm.go:317] [kubeconfig] Using kubeconfig folder "/etc/kubernetes"
I0801 16:16:43.205968   82618 kubeadm.go:317] [kubeconfig] Writing "admin.conf" kubeconfig file
I0801 16:16:43.287432   82618 kubeadm.go:317] [kubeconfig] Writing "kubelet.conf" kubeconfig file
I0801 16:16:43.400857   82618 kubeadm.go:317] [kubeconfig] Writing "controller-manager.conf" kubeconfig file
I0801 16:16:43.628441   82618 kubeadm.go:317] [kubeconfig] Writing "scheduler.conf" kubeconfig file
I0801 16:16:43.697458   82618 kubeadm.go:317] [kubelet-start] Writing kubelet environment file with flags to file "/var/lib/kubelet/kubeadm-flags.env"
I0801 16:16:43.698661   82618 kubeadm.go:317] [kubelet-start] Writing kubelet configuration to file "/var/lib/kubelet/config.yaml"
I0801 16:16:43.698694   82618 kubeadm.go:317] [kubelet-start] Starting the kubelet
I0801 16:16:43.774331   82618 kubeadm.go:317] [control-plane] Using manifest folder "/etc/kubernetes/manifests"
I0801 16:16:43.793684   82618 out.go:204]     ▪ Booting up control plane ...
I0801 16:16:43.793807   82618 kubeadm.go:317] [control-plane] Creating static Pod manifest for "kube-apiserver"
I0801 16:16:43.793887   82618 kubeadm.go:317] [control-plane] Creating static Pod manifest for "kube-controller-manager"
I0801 16:16:43.793969   82618 kubeadm.go:317] [control-plane] Creating static Pod manifest for "kube-scheduler"
I0801 16:16:43.794048   82618 kubeadm.go:317] [etcd] Creating static Pod manifest for local etcd in "/etc/kubernetes/manifests"
I0801 16:16:43.794215   82618 kubeadm.go:317] [wait-control-plane] Waiting for the kubelet to boot up the control plane as static Pods from directory "/etc/kubernetes/manifests". This can take up to 4m0s
I0801 16:16:54.275711   82618 kubeadm.go:317] [apiclient] All control plane components are healthy after 10.503972 seconds
I0801 16:16:54.275852   82618 kubeadm.go:317] [upload-config] Storing the configuration used in ConfigMap "kubeadm-config" in the "kube-system" Namespace
I0801 16:16:54.284939   82618 kubeadm.go:317] [kubelet] Creating a ConfigMap "kubelet-config" in namespace kube-system with the configuration for the kubelets in the cluster
I0801 16:16:54.805118   82618 kubeadm.go:317] [upload-certs] Skipping phase. Please see --upload-certs
I0801 16:16:54.805327   82618 kubeadm.go:317] [mark-control-plane] Marking the node minikube as control-plane by adding the labels: [node-role.kubernetes.io/control-plane node.kubernetes.io/exclude-from-external-load-balancers]
I0801 16:16:55.314751   82618 kubeadm.go:317] [bootstrap-token] Using token: msp7qu.i5n495yyksaplr03
I0801 16:16:55.373809   82618 out.go:204]     ▪ Configuring RBAC rules ...
I0801 16:16:55.373970   82618 kubeadm.go:317] [bootstrap-token] Configuring bootstrap tokens, cluster-info ConfigMap, RBAC Roles
I0801 16:16:55.374093   82618 kubeadm.go:317] [bootstrap-token] Configured RBAC rules to allow Node Bootstrap tokens to get nodes
I0801 16:16:55.379703   82618 kubeadm.go:317] [bootstrap-token] Configured RBAC rules to allow Node Bootstrap tokens to post CSRs in order for nodes to get long term certificate credentials
I0801 16:16:55.381927   82618 kubeadm.go:317] [bootstrap-token] Configured RBAC rules to allow the csrapprover controller automatically approve CSRs from a Node Bootstrap Token
I0801 16:16:55.384202   82618 kubeadm.go:317] [bootstrap-token] Configured RBAC rules to allow certificate rotation for all node client certificates in the cluster
I0801 16:16:55.386486   82618 kubeadm.go:317] [bootstrap-token] Creating the "cluster-info" ConfigMap in the "kube-public" namespace
I0801 16:16:55.394172   82618 kubeadm.go:317] [kubelet-finalize] Updating "/etc/kubernetes/kubelet.conf" to point to a rotatable kubelet client certificate and key
I0801 16:16:55.557012   82618 kubeadm.go:317] [addons] Applied essential addon: CoreDNS
I0801 16:16:55.723604   82618 kubeadm.go:317] [addons] Applied essential addon: kube-proxy
I0801 16:16:55.724560   82618 kubeadm.go:317]
I0801 16:16:55.724618   82618 kubeadm.go:317] Your Kubernetes control-plane has initialized successfully!
I0801 16:16:55.724625   82618 kubeadm.go:317]
I0801 16:16:55.724703   82618 kubeadm.go:317] To start using your cluster, you need to run the following as a regular user:
I0801 16:16:55.724708   82618 kubeadm.go:317]
I0801 16:16:55.724740   82618 kubeadm.go:317]   mkdir -p $HOME/.kube
I0801 16:16:55.724785   82618 kubeadm.go:317]   sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
I0801 16:16:55.724822   82618 kubeadm.go:317]   sudo chown $(id -u):$(id -g) $HOME/.kube/config
I0801 16:16:55.724824   82618 kubeadm.go:317]
I0801 16:16:55.724874   82618 kubeadm.go:317] Alternatively, if you are the root user, you can run:
I0801 16:16:55.724880   82618 kubeadm.go:317]
I0801 16:16:55.724919   82618 kubeadm.go:317]   export KUBECONFIG=/etc/kubernetes/admin.conf
I0801 16:16:55.724921   82618 kubeadm.go:317]
I0801 16:16:55.724975   82618 kubeadm.go:317] You should now deploy a pod network to the cluster.
I0801 16:16:55.725057   82618 kubeadm.go:317] Run "kubectl apply -f [podnetwork].yaml" with one of the options listed at:
I0801 16:16:55.725120   82618 kubeadm.go:317]   https://kubernetes.io/docs/concepts/cluster-administration/addons/
I0801 16:16:55.725124   82618 kubeadm.go:317]
I0801 16:16:55.725201   82618 kubeadm.go:317] You can now join any number of control-plane nodes by copying certificate authorities
I0801 16:16:55.725265   82618 kubeadm.go:317] and service account keys on each node and then running the following as root:
I0801 16:16:55.725267   82618 kubeadm.go:317]
I0801 16:16:55.725339   82618 kubeadm.go:317]   kubeadm join control-plane.minikube.internal:8443 --token msp7qu.i5n495yyksaplr03 \
I0801 16:16:55.725433   82618 kubeadm.go:317]   --discovery-token-ca-cert-hash sha256:44322caa51afe237a5ac046ce792f537fb519bb1811a3a9329b6a0d4443227ab \
I0801 16:16:55.725453   82618 kubeadm.go:317]   --control-plane
I0801 16:16:55.725458   82618 kubeadm.go:317]
I0801 16:16:55.725529   82618 kubeadm.go:317] Then you can join any number of worker nodes by running the following on each as root:
I0801 16:16:55.725540   82618 kubeadm.go:317]
I0801 16:16:55.725611   82618 kubeadm.go:317] kubeadm join control-plane.minikube.internal:8443 --token msp7qu.i5n495yyksaplr03 \
I0801 16:16:55.725697   82618 kubeadm.go:317]   --discovery-token-ca-cert-hash sha256:44322caa51afe237a5ac046ce792f537fb519bb1811a3a9329b6a0d4443227ab
I0801 16:16:55.729067   82618 kubeadm.go:317] W0801 23:16:12.135921    1360 initconfiguration.go:120] Usage of CRI endpoints without URL scheme is deprecated and can cause kubelet errors in the future. Automatically prepending scheme "unix" to the "criSocket" with value "/var/run/cri-dockerd.sock". Please update your configuration!
I0801 16:16:55.729176   82618 kubeadm.go:317]   [WARNING Swap]: swap is enabled; production deployments should disable swap unless testing the NodeSwap feature gate of the kubelet
I0801 16:16:55.729231   82618 kubeadm.go:317]   [WARNING SystemVerification]: missing optional cgroups: blkio
I0801 16:16:55.729329   82618 kubeadm.go:317]   [WARNING Service-Kubelet]: kubelet service is not enabled, please run 'systemctl enable kubelet.service'
...
```