### PR TITLE
Handle CRI config of NetworkPlugin and PauseImage

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/kubelet.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubelet.go
@@ -90,9 +90,12 @@ func extraKubeletOpts(mc config.ClusterConfig, nc config.Node, r cruntime.Manage
 		extraOpts["hostname-override"] = nodeName
 	}
 
-	pauseImage := images.Pause(version, k8s.ImageRepository)
-	if _, ok := extraOpts["pod-infra-container-image"]; !ok && k8s.ImageRepository != "" && pauseImage != "" && k8s.ContainerRuntime != remoteContainerRuntime {
-		extraOpts["pod-infra-container-image"] = pauseImage
+	// Handled by CRI in 1.24+, and not by kubelet
+	if version.LT(semver.MustParse("1.24.0-alpha.2")) {
+		pauseImage := images.Pause(version, k8s.ImageRepository)
+		if _, ok := extraOpts["pod-infra-container-image"]; !ok && k8s.ImageRepository != "" && pauseImage != "" && k8s.ContainerRuntime != remoteContainerRuntime {
+			extraOpts["pod-infra-container-image"] = pauseImage
+		}
 	}
 
 	// parses a map of the feature gates for kubelet

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -147,6 +147,8 @@ type Config struct {
 	Socket string
 	// Runner is the CommandRunner object to execute commands with
 	Runner CommandRunner
+	// NetworkPlugin name of networking plugin ("cni")
+	NetworkPlugin string
 	// ImageRepository image repository to download image from
 	ImageRepository string
 	// KubernetesVersion Kubernetes version
@@ -219,6 +221,7 @@ func New(c Config) (Manager, error) {
 		return &Docker{
 			Socket:            sp,
 			Runner:            c.Runner,
+			NetworkPlugin:     c.NetworkPlugin,
 			ImageRepository:   c.ImageRepository,
 			KubernetesVersion: c.KubernetesVersion,
 			Init:              sm,
@@ -335,15 +338,4 @@ func CheckKernelCompatibility(cr CommandRunner, major, minor int) error {
 		return NewErrServiceVersion("kernel", expected, actual)
 	}
 	return nil
-}
-
-func ConfigureNetworkPlugin(r Manager, cr CommandRunner, networkPlugin string) error {
-	// Only supported for Docker with cri-dockerd
-	if r.Name() != "Docker" {
-		if networkPlugin != "cni" {
-			return fmt.Errorf("unknown network plugin: %s", networkPlugin)
-		}
-		return nil
-	}
-	return dockerConfigureNetworkPlugin(cr, networkPlugin)
 }

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -385,6 +385,7 @@ func configureRuntimes(runner cruntime.CommandRunner, cc config.ClusterConfig, k
 		Type:              cc.KubernetesConfig.ContainerRuntime,
 		Socket:            cc.KubernetesConfig.CRISocket,
 		Runner:            runner,
+		NetworkPlugin:     cc.KubernetesConfig.NetworkPlugin,
 		ImageRepository:   cc.KubernetesConfig.ImageRepository,
 		KubernetesVersion: kv,
 		InsecureRegistry:  cc.InsecureRegistry,
@@ -404,12 +405,7 @@ func configureRuntimes(runner cruntime.CommandRunner, cc config.ClusterConfig, k
 	// make sure container runtime is restarted afterwards for these changes to take effect
 	disableLoopback := co.Type == constants.CRIO
 	if err := cni.ConfigureLoopbackCNI(runner, disableLoopback); err != nil {
-		klog.Warningf("unable to name loopback interface in dockerConfigureNetworkPlugin: %v", err)
-	}
-	if kv.GTE(semver.MustParse("1.24.0-alpha.2")) {
-		if err := cruntime.ConfigureNetworkPlugin(cr, runner, cc.KubernetesConfig.NetworkPlugin); err != nil {
-			exit.Error(reason.RuntimeEnable, "Failed to configure network plugin", err)
-		}
+		klog.Warningf("unable to name loopback interface in configureRuntimes: %v", err)
 	}
 	// ensure all default CNI(s) are properly configured on each and every node (re)start
 	// make sure container runtime is restarted afterwards for these changes to take effect


### PR DESCRIPTION
These have been removed from the kubelet, and are supposed to be
handled by the CRI config. Remove the earlier Docker-only hacks.

This fixes the issue where kubeadm said 3.7, and docker ran 3.6...

**k8s.gcr.io/pause:3.7**
**k8s.gcr.io/pause:3.6**
k8s.gcr.io/kube-scheduler:v1.24.1
k8s.gcr.io/kube-proxy:v1.24.1
k8s.gcr.io/kube-controller-manager:v1.24.1
k8s.gcr.io/kube-apiserver:v1.24.1
k8s.gcr.io/etcd:3.5.3-0
k8s.gcr.io/coredns/coredns:v1.8.6
gcr.io/k8s-minikube/storage-provisioner:v5

Also removes the old flag, which avoids a warning from kubeadm

`Flag --pod-infra-container-image has been deprecated, will be removed in 1.27. Image garbage collector will get sandbox image information from CRI.`