### PR TITLE
Set output for yearly-leaderboard job

### DIFF
--- a/.github/workflows/yearly-leaderboard.yml
+++ b/.github/workflows/yearly-leaderboard.yml
@@ -27,6 +27,7 @@ jobs:
         id: yearlyLeaderboard
         run: |
           make update-yearly-leaderboard
+          echo "::set-output name=changes::$(git status --porcelain)"
         env:
           GITHUB_TOKEN: ${{ secrets.MINIKUBE_BOT_PAT }}
       - name: Create PR


### PR DESCRIPTION
Was not setting the output, so `if: ${{ steps.yearlyLeaderboard.outputs.changes != '' }}` was always failing