### PR TITLE
GUI: Fix first dashboard start crashing app

### DIFF
--- a/gui/operator.cpp
+++ b/gui/operator.cpp
@@ -404,13 +404,14 @@ void Operator::dashboardBrowser()
     QStringList arguments = { "dashboard", "-p", selectedClusterName() };
     process->start(program, arguments);
 
+    dashboardStarted = true;
     dashboardProcess = process;
     dashboardProcess->waitForStarted();
 }
 
 void Operator::dashboardClose()
 {
-    if (dashboardProcess) {
+    if (dashboardProcess && dashboardStarted) {
         dashboardProcess->terminate();
         dashboardProcess->waitForFinished();
     }

--- a/gui/operator.h
+++ b/gui/operator.h
@@ -67,6 +67,7 @@ private:
     Updater *m_updater;
     bool m_isBasicView;
     QProcess *dashboardProcess;
+    bool dashboardStarted;
     QStackedWidget *m_stackedWidget;
     QDialog *m_parent;
 };


### PR DESCRIPTION
**Before:**
Occasionally, when starting the dashboard the app would crash. This was due to `dashboardProcess` pointer not being empty as [QScopedPointer](https://doc.qt.io/qt-6/qscopedpointer.html#details) was initing the pointer. This resulted in `dashboardProcess->terminate()` being called and then crashing the app.

**After:**
Added a `dashboardStarted` bool so now `dashboardProcess` has to be not empty and `dashboardStarted` has to be true before running terminate.
