### PR TITLE
GUI: Fix first dashboard start crashing app

### DIFF
--- a/gui/operator.cpp
+++ b/gui/operator.cpp
@@ -21,6 +21,7 @@ Operator::Operator(AdvancedView *advancedView, BasicView *basicView, CommandRunn
     m_stackedWidget = stackedWidget;
     m_parent = parent;
     m_isBasicView = true;
+    dashboardProcess = NULL;
 
     connect(m_basicView, &BasicView::start, this, &Operator::startMinikube);
     connect(m_basicView, &BasicView::stop, this, &Operator::stopMinikube);


### PR DESCRIPTION
Sometimes `dashboardProcess` isn't properly init yet and results in the check `if (dashboardProcess)` passing when it shouldn't. Resulting in `dashboardProcess->terminate()` running against `NULL` and crashing the app.

So setting `dashboardProcess = NULL` so it will fail the conditional check on the first pass and prevent the app from crashing.