### PR TITLE
Documentation: Use the proxy variable in KIC examples

### DIFF
--- a/site/content/en/docs/handbook/addons/kong-ingress.md
+++ b/site/content/en/docs/handbook/addons/kong-ingress.md
@@ -55,7 +55,7 @@ minikube tunnel
 Let's test if KIC is up and running.
 
 ```bash
-$ curl -v localhost
+$ curl -v $PROXY_IP
 
 *   Trying 127.0.0.1:80...
 * Connected to localhost (127.0.0.1) port 80 (#0)
@@ -125,7 +125,7 @@ spec:
 Let's test our ingress object.
 
 ```bash
-$ curl -i localhost/foo -H "Host: httpbin.org"
+$ curl -i ${PROXY_IP}/foo -H "Host: httpbin.org"
 
 
 HTTP/1.1 200 OK


### PR DESCRIPTION
I had a minor issue following the [Kong example page (KIC)](https://minikube.sigs.k8s.io/docs/handbook/addons/kong-ingress/), looks like it was just a typo, and the page didn't use the `PROXY_IP` variable that was defined previously. Please see the screenshot showing that running `minikube tunnel` doesn't help in my installation (Arch + KVM2 + Minikube)

Thanks!

![image](https://user-images.githubusercontent.com/2457146/183309981-40695d15-7fa9-4d27-85d3-a48face1c896.png)

