### PR TITLE
Fix unit tests on macOS arm64

### DIFF
--- a/cmd/minikube/cmd/config/get_test.go
+++ b/cmd/minikube/cmd/config/get_test.go
@@ -31,7 +31,7 @@ func TestGetNotFound(t *testing.T) {
 func TestGetOK(t *testing.T) {
 	createTestConfig(t)
 	name := "driver"
-	err := Set(name, "virtualbox")
+	err := Set(name, "ssh")
 	if err != nil {
 		t.Fatalf("Set returned error for property %s, %+v", name, err)
 	}
@@ -39,7 +39,7 @@ func TestGetOK(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get returned error for property %s, %+v", name, err)
 	}
-	if val != "virtualbox" {
-		t.Fatalf("Get returned %s, expected virtualbox", val)
+	if val != "ssh" {
+		t.Fatalf("Get returned %s, expected ssh", val)
 	}
 }

--- a/cmd/minikube/cmd/config/set_test.go
+++ b/cmd/minikube/cmd/config/set_test.go
@@ -45,7 +45,7 @@ func TestSetNotAllowed(t *testing.T) {
 
 func TestSetOK(t *testing.T) {
 	createTestConfig(t)
-	err := Set("driver", "virtualbox")
+	err := Set("driver", "ssh")
 	defer func() {
 		err = Unset("driver")
 		if err != nil {
@@ -59,8 +59,8 @@ func TestSetOK(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get returned error for valid property: %+v", err)
 	}
-	if val != "virtualbox" {
-		t.Fatalf("Get returned %s, expected \"virtualbox\"", val)
+	if val != "ssh" {
+		t.Fatalf("Get returned %s, expected \"ssh\"", val)
 	}
 }
 

--- a/pkg/minikube/driver/driver_test.go
+++ b/pkg/minikube/driver/driver_test.go
@@ -30,19 +30,19 @@ func TestSupportedDrivers(t *testing.T) {
 	got := SupportedDrivers()
 	found := false
 	for _, s := range SupportedDrivers() {
-		if s == VirtualBox {
+		if s == SSH {
 			found = true
 		}
 	}
 
 	if found == false {
-		t.Errorf("%s not in supported drivers: %v", VirtualBox, got)
+		t.Errorf("%s not in supported drivers: %v", SSH, got)
 	}
 }
 
 func TestSupported(t *testing.T) {
-	if !Supported(VirtualBox) {
-		t.Errorf("Supported(%s) is false", VirtualBox)
+	if !Supported(SSH) {
+		t.Errorf("Supported(%s) is false", SSH)
 	}
 	if Supported("yabba?") {
 		t.Errorf("Supported(yabba?) is true")

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -19,7 +19,6 @@ package util
 import (
 	"os"
 	"os/user"
-	"runtime"
 	"syscall"
 	"testing"
 
@@ -38,7 +37,7 @@ func TestGetBinaryDownloadURL(t *testing.T) {
 	}
 
 	for _, tt := range testData {
-		url := GetBinaryDownloadURL(tt.version, tt.platform, runtime.GOARCH)
+		url := GetBinaryDownloadURL(tt.version, tt.platform, "amd64")
 		if url != tt.expectedURL {
 			t.Fatalf("Expected '%s' but got '%s'", tt.expectedURL, url)
 		}


### PR DESCRIPTION
These tests were failing on an M1 Mac. Changed all VirtualBox drivers to use SSH as M1 Mac doesn't currently support SSH.