### PR TITLE
Fix arm64 preload upload

### DIFF
--- a/hack/preload-images/upload.go
+++ b/hack/preload-images/upload.go
@@ -67,7 +67,7 @@ func getVersionsFromFilename(filename string) (string, string) {
 	preloadVersion := parts[3]
 	k8sVersion := parts[4]
 	// this check is for "-rc" and "-beta" versions that would otherwise be stripped off
-	if len(parts) == 9 {
+	if len(parts) >= 9 && parts[5] != "cri" {
 		k8sVersion += fmt.Sprintf("-%s", parts[5])
 	}
 	return preloadVersion, k8sVersion


### PR DESCRIPTION
The `-` in `cri-o` was causing issues when generating the Kubernetes version.

**Before:**
```
preloaded-images-k8s-v18-v1.24.3-cri-o-overlay-arm64.tar.lz4
k8s version: v1.24.3-cri

preloaded-images-k8s-v18-v1.25.0-beta.0-cri-o-overlay-arm64.tar.lz4
k8s veresion: v1.25.0
```

**After:**
```
preloaded-images-k8s-v18-v1.24.3-cri-o-overlay-arm64.tar.lz4
k8s version: v1.24.3

preloaded-images-k8s-v18-v1.25.0-beta.0-cri-o-overlay-arm64.tar.lz4
k8s veresion: v1.25.0-beta.0
```