### PR TITLE
Update roadmap items that have been completed

### DIFF
--- a/site/content/en/docs/contrib/roadmap.en.md
+++ b/site/content/en/docs/contrib/roadmap.en.md
@@ -19,9 +19,9 @@ Please send a PR to suggest any improvements to it.
 
 ## (#2) Documentation
 
-- [x] Consolidate Kubernetes documentation that references minikube
-- [x] Delete outdated documentation
-- [x] Add documentation for new features
+- [ ] Consolidate Kubernetes documentation that references minikube
+- [ ] Delete outdated documentation
+- [ ] Add documentation for new features
 
 ## (#3) ARM64 Support
 
@@ -29,10 +29,10 @@ Please send a PR to suggest any improvements to it.
 - [x] Add Mac M1 VM support (experimental, will improve by end of 2022)
 
 ## (#4) Docker
-- [x] Remove the Docker Desktop requirement on Mac and Windows
+- [ ] Remove the Docker Desktop requirement on Mac and Windows
 - [x] Continue supporting Docker as a container runtime (with CRI)
 
 ## (#5) libmachine Refactor
 
-- [x] Add new driver (with QEMU) to replace HyperKit, primarily for Mac arm64
-- [x] Fix the provisioner, remove legacy Swarm, and add support for other runtimes
+- [x] Add new driver (with QEMU) to replace HyperKit, primarily for Mac arm64 (experimental, will improve by end of 2022)
+- [ ] Fix the provisioner, remove legacy Swarm, and add support for other runtimes

--- a/site/content/en/docs/contrib/roadmap.en.md
+++ b/site/content/en/docs/contrib/roadmap.en.md
@@ -14,25 +14,25 @@ Please send a PR to suggest any improvements to it.
 
 ## (#1) GUI
 
-- [ ] Be able to start, stop, pause, and delete clusters via a GUI
-- [ ] Application available for all supported platforms: Linux, macOS, Windows
+- [x] Be able to start, stop, pause, and delete clusters via a GUI (prototype state)
+- [x] Application available for all supported platforms: Linux, macOS, Windows
 
 ## (#2) Documentation
 
-- [ ] Consolidate Kubernetes documentation that references minikube
-- [ ] Delete outdated documentation
-- [ ] Add documentation for new features
+- [x] Consolidate Kubernetes documentation that references minikube
+- [x] Delete outdated documentation
+- [x] Add documentation for new features
 
 ## (#3) ARM64 Support
 
-- [ ] Add Linux VM support
-- [ ] Add Mac M1 VM support
+- [x] Add Linux VM support
+- [x] Add Mac M1 VM support (experimental, will improve by end of 2022)
 
 ## (#4) Docker
-- [ ] Remove the Docker Desktop requirement on Mac and Windows
-- [ ] Continue supporting Docker as a container runtime (with CRI)
+- [x] Remove the Docker Desktop requirement on Mac and Windows
+- [x] Continue supporting Docker as a container runtime (with CRI)
 
 ## (#5) libmachine Refactor
 
-- [ ] Add new driver (with QEMU) to replace HyperKit, primarily for Mac arm64
-- [ ] Fix the provisioner, remove legacy Swarm, and add support for other runtimes
+- [x] Add new driver (with QEMU) to replace HyperKit, primarily for Mac arm64
+- [x] Fix the provisioner, remove legacy Swarm, and add support for other runtimes


### PR DESCRIPTION
Before:

```
- [ ] Be able to start, stop, pause, and delete clusters via a GUI
- [ ] Application available for all supported platforms: Linux, macOS, Windows

- [ ] Add Linux VM support
- [ ] Add Mac M1 VM support

- [ ] Continue supporting Docker as a container runtime (with CRI)

- [ ] Add new driver (with QEMU) to replace HyperKit, primarily for Mac arm64
```

After:

```
- [x] Be able to start, stop, pause, and delete clusters via a GUI
- [x] Application available for all supported platforms: Linux, macOS, Windows

- [x] Add Linux VM support
- [x] Add Mac M1 VM support (experimental, will improve by end of 2022)

- [x] Continue supporting Docker as a container runtime (with CRI)

- [x] Add new driver (with QEMU) to replace HyperKit, primarily for Mac arm64 (experimental, will improve by end of 2022)
```

