### PR TITLE
Remove duplicated k8s versions from preload generation

### DIFF
--- a/hack/preload-images/preload_images.go
+++ b/hack/preload-images/preload_images.go
@@ -32,6 +32,7 @@ import (
 	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/download"
+	"k8s.io/minikube/pkg/util"
 )
 
 const (
@@ -134,21 +135,7 @@ func collectK8sVers() ([]string, error) {
 		constants.NewestKubernetesVersion,
 		constants.OldestKubernetesVersion,
 	}, k8sVersions...)
-	return removeDuplicates(versions), nil
-}
-
-func removeDuplicates(versions []string) []string {
-	prevVersions := make(map[string]bool)
-	for i := 0; i < len(versions); i++ {
-		v := versions[i]
-		if ok := prevVersions[v]; !ok {
-			prevVersions[v] = true
-			continue
-		}
-		versions = append(versions[:i], versions[i+1:]...)
-		i--
-	}
-	return versions
+	return util.RemoveDuplicateStrings(versions), nil
 }
 
 func makePreload(cfg preloadCfg) error {

--- a/hack/preload-images/preload_images.go
+++ b/hack/preload-images/preload_images.go
@@ -129,11 +129,26 @@ func collectK8sVers() ([]string, error) {
 		}
 		k8sVersions = recent
 	}
-	return append([]string{
+	versions := append([]string{
 		constants.DefaultKubernetesVersion,
 		constants.NewestKubernetesVersion,
 		constants.OldestKubernetesVersion,
-	}, k8sVersions...), nil
+	}, k8sVersions...)
+	return removeDuplicates(versions), nil
+}
+
+func removeDuplicates(versions []string) []string {
+	prevVersions := make(map[string]bool)
+	for i := 0; i < len(versions); i++ {
+		v := versions[i]
+		if ok := prevVersions[v]; !ok {
+			prevVersions[v] = true
+			continue
+		}
+		versions = append(versions[:i], versions[i+1:]...)
+		i--
+	}
+	return versions
 }
 
 func makePreload(cfg preloadCfg) error {

--- a/pkg/minikube/machine/start.go
+++ b/pkg/minikube/machine/start.go
@@ -51,6 +51,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/registry"
 	"k8s.io/minikube/pkg/minikube/style"
 	"k8s.io/minikube/pkg/minikube/vmpath"
+	"k8s.io/minikube/pkg/util"
 	"k8s.io/minikube/pkg/util/lock"
 )
 
@@ -108,15 +109,7 @@ func engineOptions(cfg config.ClusterConfig) *engine.Options {
 	// get docker env from user specifiec config
 	dockerEnv = append(dockerEnv, cfg.DockerEnv...)
 
-	// remove duplicates
-	seen := map[string]bool{}
-	uniqueEnvs := []string{}
-	for e := range dockerEnv {
-		if !seen[dockerEnv[e]] {
-			seen[dockerEnv[e]] = true
-			uniqueEnvs = append(uniqueEnvs, dockerEnv[e])
-		}
-	}
+	uniqueEnvs := util.RemoveDuplicateStrings(dockerEnv)
 
 	o := engine.Options{
 		Env:              uniqueEnvs,

--- a/pkg/minikube/proxy/proxy.go
+++ b/pkg/minikube/proxy/proxy.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/out"
+	"k8s.io/minikube/pkg/util"
 )
 
 // EnvVars are variables we plumb through to the underlying container runtime
@@ -184,16 +185,7 @@ func SetDockerEnv() []string {
 		}
 	}
 
-	// remove duplicates
-	seen := map[string]bool{}
-	uniqueEnvs := []string{}
-	for e := range config.DockerEnv {
-		if !seen[config.DockerEnv[e]] {
-			seen[config.DockerEnv[e]] = true
-			uniqueEnvs = append(uniqueEnvs, config.DockerEnv[e])
-		}
-	}
-	config.DockerEnv = uniqueEnvs
+	config.DockerEnv = util.RemoveDuplicateStrings(config.DockerEnv)
 
 	return config.DockerEnv
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -109,3 +109,17 @@ func MaybeChownDirRecursiveToMinikubeUser(dir string) error {
 func ParseKubernetesVersion(version string) (semver.Version, error) {
 	return semver.Make(version[1:])
 }
+
+// RemoveDuplicateStrings takes a string slice and returns a slice without duplicates
+func RemoveDuplicateStrings(initial []string) []string {
+	var result []string
+	m := make(map[string]bool, len(initial))
+	for _, v := range initial {
+		if _, ok := m[v]; ok {
+			continue
+		}
+		m[v] = true
+		result = append(result, v)
+	}
+	return result
+}

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestGetBinaryDownloadURL(t *testing.T) {
@@ -168,6 +169,48 @@ func TestMaybeChownDirRecursiveToMinikubeUser(t *testing.T) {
 			err := MaybeChownDirRecursiveToMinikubeUser(c.dir)
 			if (nil != err) != c.expectedError {
 				t.Errorf("expectedError: %v, got: %v", c.expectedError, err)
+			}
+		})
+	}
+}
+
+func TestRemoveDuplicateStrings(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		slice []string
+		want  []string
+	}{
+		{
+			desc:  "NoDuplicates",
+			slice: []string{"alpha", "bravo", "charlie"},
+			want:  []string{"alpha", "bravo", "charlie"},
+		},
+		{
+			desc:  "AdjacentDuplicates",
+			slice: []string{"alpha", "bravo", "bravo", "charlie"},
+			want:  []string{"alpha", "bravo", "charlie"},
+		},
+		{
+			desc:  "NonAdjacentDuplicates",
+			slice: []string{"alpha", "bravo", "alpha", "charlie"},
+			want:  []string{"alpha", "bravo", "charlie"},
+		},
+		{
+			desc:  "MultipleDuplicates",
+			slice: []string{"alpha", "bravo", "alpha", "alpha", "charlie", "charlie", "alpha", "bravo"},
+			want:  []string{"alpha", "bravo", "charlie"},
+		},
+		{
+			desc:  "UnsortedDuplicates",
+			slice: []string{"charlie", "bravo", "alpha", "bravo"},
+			want:  []string{"charlie", "bravo", "alpha"},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := RemoveDuplicateStrings(tc.slice)
+			if diff := cmp.Diff(got, tc.want); diff != "" {
+				t.Errorf("RemoveDuplicateStrings(%v) = %v, want: %v", tc.slice, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
`constants.DefaultKubernetesVersion`, `constants.NewestKubernetesVersion`, and `constants.OldestKubernetesVersion` are pushed onto an array with all Kubernetes versions.

When `constants.DefaultKubernetesVersion` & `constants.NewestKubernetesVersion` were both `v1.24.3` the generation for `v1.24.3` occurred three times.

Added a loop that removes duplicates so duplicate preload generation doesn't occur.