### PR TITLE
The DefaultKubernetesRepo changed for 1.25.0

### DIFF
--- a/pkg/minikube/bootstrapper/images/images.go
+++ b/pkg/minikube/bootstrapper/images/images.go
@@ -51,10 +51,10 @@ func Pause(v semver.Version, mirror string) string {
 	if pVersion, ok := constants.KubeadmImages[majorMinorVersion][imageName]; ok {
 		pv = pVersion
 	} else {
-		pv = findLatestTagFromRepository(fmt.Sprintf(tagURLTemplate, kubernetesRepo(mirror), imageName), pv)
+		pv = findLatestTagFromRepository(fmt.Sprintf(tagURLTemplate, kubernetesRepo(mirror, v), imageName), pv)
 	}
 
-	return fmt.Sprintf("%s:%s", path.Join(kubernetesRepo(mirror), imageName), pv)
+	return fmt.Sprintf("%s:%s", path.Join(kubernetesRepo(mirror, v), imageName), pv)
 }
 
 // essentials returns images needed too bootstrap a Kubernetes
@@ -74,7 +74,7 @@ func essentials(mirror string, v semver.Version) []string {
 
 // componentImage returns a Kubernetes component image to pull
 func componentImage(name string, v semver.Version, mirror string) string {
-	return fmt.Sprintf("%s:v%s", path.Join(kubernetesRepo(mirror), name), v)
+	return fmt.Sprintf("%s:v%s", path.Join(kubernetesRepo(mirror, v), name), v)
 }
 
 // fixes 13136 by getting the latest image version from the k8s.gcr.io repository instead of hardcoded
@@ -127,14 +127,14 @@ func coreDNS(v semver.Version, mirror string) string {
 	if cVersion, ok := constants.KubeadmImages[majorMinorVersion][imageName]; ok {
 		cv = cVersion
 	} else {
-		cv = findLatestTagFromRepository(fmt.Sprintf(tagURLTemplate, kubernetesRepo(mirror), imageName), cv)
+		cv = findLatestTagFromRepository(fmt.Sprintf(tagURLTemplate, kubernetesRepo(mirror, v), imageName), cv)
 	}
 
 	if mirror == constants.AliyunMirror {
 		imageName = "coredns"
 	}
 
-	return fmt.Sprintf("%s:%s", path.Join(kubernetesRepo(mirror), imageName), cv)
+	return fmt.Sprintf("%s:%s", path.Join(kubernetesRepo(mirror, v), imageName), cv)
 }
 
 // etcd returns the image used for etcd
@@ -148,10 +148,10 @@ func etcd(v semver.Version, mirror string) string {
 	if eVersion, ok := constants.KubeadmImages[majorMinorVersion][imageName]; ok {
 		ev = eVersion
 	} else {
-		ev = findLatestTagFromRepository(fmt.Sprintf(tagURLTemplate, kubernetesRepo(mirror), imageName), ev)
+		ev = findLatestTagFromRepository(fmt.Sprintf(tagURLTemplate, kubernetesRepo(mirror, v), imageName), ev)
 	}
 
-	return fmt.Sprintf("%s:%s", path.Join(kubernetesRepo(mirror), imageName), ev)
+	return fmt.Sprintf("%s:%s", path.Join(kubernetesRepo(mirror, v), imageName), ev)
 }
 
 // auxiliary returns images that are helpful for running minikube

--- a/pkg/minikube/bootstrapper/images/kubeadm_test.go
+++ b/pkg/minikube/bootstrapper/images/kubeadm_test.go
@@ -34,6 +34,26 @@ func TestKubeadmImages(t *testing.T) {
 		{"invalid", "", true, nil},
 		{"v0.0.1", "", true, nil}, // too old
 		{"v2.0.0", "", true, nil}, // too new
+		{"v1.25.0", "", false, []string{
+			"registry.k8s.io/kube-apiserver:v1.25.0",
+			"registry.k8s.io/kube-controller-manager:v1.25.0",
+			"registry.k8s.io/kube-scheduler:v1.25.0",
+			"registry.k8s.io/kube-proxy:v1.25.0",
+			"registry.k8s.io/coredns/coredns:v1.9.3",
+			"registry.k8s.io/etcd:3.5.4-0",
+			"registry.k8s.io/pause:3.8",
+			"gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
+		}},
+		{"v1.24.0", "", false, []string{
+			"k8s.gcr.io/kube-apiserver:v1.24.0",
+			"k8s.gcr.io/kube-controller-manager:v1.24.0",
+			"k8s.gcr.io/kube-scheduler:v1.24.0",
+			"k8s.gcr.io/kube-proxy:v1.24.0",
+			"k8s.gcr.io/coredns/coredns:v1.8.6",
+			"k8s.gcr.io/etcd:3.5.3-0",
+			"k8s.gcr.io/pause:3.7",
+			"gcr.io/k8s-minikube/storage-provisioner:" + version.GetStorageProvisionerVersion(),
+		}},
 		{"v1.17.0", "", false, []string{
 			"k8s.gcr.io/kube-proxy:v1.17.0",
 			"k8s.gcr.io/kube-scheduler:v1.17.0",

--- a/pkg/minikube/bootstrapper/images/repo.go
+++ b/pkg/minikube/bootstrapper/images/repo.go
@@ -16,13 +16,28 @@ limitations under the License.
 
 package images
 
-// DefaultKubernetesRepo is the default Kubernetes repository
-const DefaultKubernetesRepo = "k8s.gcr.io"
+import (
+	"github.com/blang/semver/v4"
+)
+
+// OldDefaultKubernetesRepo is the old default Kubernetes repository
+const OldDefaultKubernetesRepo = "k8s.gcr.io"
+
+// NewDefaultKubernetesRepo is the new default Kubernetes repository
+const NewDefaultKubernetesRepo = "registry.k8s.io"
 
 // kubernetesRepo returns the official Kubernetes repository, or an alternate
-func kubernetesRepo(mirror string) string {
+func kubernetesRepo(mirror string, v semver.Version) string {
 	if mirror != "" {
 		return mirror
 	}
-	return DefaultKubernetesRepo
+	return DefaultKubernetesRepo(v)
+}
+
+func DefaultKubernetesRepo(kv semver.Version) string {
+	// these (-1.24) should probably be moved too
+	if kv.LT(semver.MustParse("1.25.0-alpha.1")) {
+		return OldDefaultKubernetesRepo
+	}
+	return NewDefaultKubernetesRepo
 }

--- a/pkg/minikube/bootstrapper/images/repo_test.go
+++ b/pkg/minikube/bootstrapper/images/repo_test.go
@@ -19,25 +19,40 @@ package images
 import (
 	"testing"
 
+	"github.com/blang/semver/v4"
 	"github.com/google/go-cmp/cmp"
 )
 
 func Test_kubernetesRepo(t *testing.T) {
+	kv := semver.MustParse("1.23.0")
 	tests := []struct {
-		mirror string
-		want   string
+		mirror  string
+		version semver.Version
+		want    string
 	}{
 		{
 			"",
-			DefaultKubernetesRepo,
+			kv,
+			DefaultKubernetesRepo(kv),
 		},
 		{
 			"mirror.k8s.io",
+			kv,
 			"mirror.k8s.io",
+		},
+		{
+			"",
+			semver.MustParse("1.24.0"),
+			OldDefaultKubernetesRepo,
+		},
+		{
+			"",
+			semver.MustParse("1.25.0"),
+			NewDefaultKubernetesRepo,
 		},
 	}
 	for _, tc := range tests {
-		got := kubernetesRepo(tc.mirror)
+		got := kubernetesRepo(tc.mirror, tc.version)
 		if !cmp.Equal(got, tc.want) {
 			t.Errorf("mirror miss match, want: %s, got: %s", tc.want, got)
 		}


### PR DESCRIPTION
See: https://github.com/kubernetes/kubernetes/commit/50bea1dad89930ad565526910aadc314b9e9f38b

* https://github.com/kubernetes/kubeadm/issues/2671

Changing the old releases would mean having to redo the old preload as well.

But it could be a good idea to make sure that 1.25.0 comes out the right way...