### PR TITLE
Always use cni unless running with dockershim

### DIFF
--- a/site/content/en/docs/drivers/includes/none_usage.inc
+++ b/site/content/en/docs/drivers/includes/none_usage.inc
@@ -14,6 +14,7 @@ This VM must also meet the [kubeadm requirements](https://kubernetes.io/docs/set
 * iptables (in legacy mode)
 * conntrack
 * crictl
+* cni-plugins
 * SELinux permissive
 * cgroups v1 (v2 is not yet supported by Kubernetes)
 

--- a/site/content/en/docs/drivers/includes/ssh_usage.inc
+++ b/site/content/en/docs/drivers/includes/ssh_usage.inc
@@ -13,6 +13,7 @@ This VM must also meet the [kubeadm requirements](https://kubernetes.io/docs/set
 * iptables (in legacy mode)
 * conntrack
 * crictl
+* cni-plugins
 * SELinux permissive
 * cgroups v1 (v2 is not yet supported by Kubernetes)
 

--- a/test/integration/net_test.go
+++ b/test/integration/net_test.go
@@ -82,13 +82,13 @@ func TestNetworkPlugins(t *testing.T) {
 				// collect debug logs
 				defer debugLogs(t, profile)
 
-				if usingCNI() && tc.name == "false" {
+				if ContainerRuntime() != "docker" && tc.name == "false" {
 					// CNI is required for current container runtime
 					validateFalseCNI(ctx, t, profile)
 					return
 				}
 
-				if usingCNI() && tc.name == "kubenet" {
+				if ContainerRuntime() != "docker" && tc.name == "kubenet" {
 					// CNI is disabled when --network-plugin=kubenet option is passed. See cni.New(..) function
 					t.Skipf("Skipping the test as %s container runtimes requires CNI", ContainerRuntime())
 				}

--- a/test/integration/net_test.go
+++ b/test/integration/net_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/blang/semver/v4"
 	"k8s.io/minikube/pkg/kapi"
 	"k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/reason"
 	"k8s.io/minikube/pkg/util"
 	"k8s.io/minikube/pkg/util/retry"
@@ -57,7 +58,8 @@ func TestNetworkPlugins(t *testing.T) {
 			namespace     string
 			hairpin       bool
 		}{
-			{"auto", []string{}, "", "", "", true},
+			// kindnet CNI is used by default and hairpin is enabled
+			{"auto", []string{}, "", "", "", usingCNI()},
 			{"kubenet", []string{"--network-plugin=kubenet"}, "kubenet", "", "", true},
 			{"bridge", []string{"--cni=bridge"}, "cni", "", "", true},
 			{"enable-default-cni", []string{"--enable-default-cni=true"}, "cni", "", "", true},
@@ -80,15 +82,14 @@ func TestNetworkPlugins(t *testing.T) {
 				// collect debug logs
 				defer debugLogs(t, profile)
 
-				if ContainerRuntime() != "docker" && tc.name == "false" {
+				if usingCNI() && tc.name == "false" {
 					// CNI is required for current container runtime
 					validateFalseCNI(ctx, t, profile)
 					return
 				}
 
-				if ContainerRuntime() != "docker" && tc.name == "kubenet" {
+				if usingCNI() && tc.name == "kubenet" {
 					// CNI is disabled when --network-plugin=kubenet option is passed. See cni.New(..) function
-					// But for containerd/crio CNI has to be configured
 					t.Skipf("Skipping the test as %s container runtimes requires CNI", ContainerRuntime())
 				}
 
@@ -210,6 +211,21 @@ func TestNetworkPlugins(t *testing.T) {
 			})
 		}
 	})
+}
+
+// usingCNI checks if not using dockershim
+func usingCNI() bool {
+	if ContainerRuntime() != "docker" {
+		return true
+	}
+	version, err := util.ParseKubernetesVersion(constants.DefaultKubernetesVersion)
+	if err != nil {
+		return false
+	}
+	if version.GTE(semver.MustParse("1.24.0-alpha.2")) {
+		return true
+	}
+	return false
 }
 
 // validateFalseCNI checks that minikube returns and error


### PR DESCRIPTION
Since cri-dockerd 0.2.5, it now defaults to cni.

So when using cri (not dockershim), use cni too.

----

Closes #14760