### PR TITLE
Typo fixed on documentation page podman_usage.inc

### DIFF
--- a/site/content/en/docs/drivers/includes/podman_usage.inc
+++ b/site/content/en/docs/drivers/includes/podman_usage.inc
@@ -4,7 +4,7 @@ This is an experimental driver. Please use it only for experimental reasons unti
 
 ## Usage
 
-It's recommended to run minikube with the podman driver and [CRI-O container runtime](https://cri-o.io/) (expect when using Rootless Podman):
+It's recommended to run minikube with the podman driver and [CRI-O container runtime](https://cri-o.io/) (except when using Rootless Podman):
 
 ```shell
 minikube start --driver=podman --container-runtime=cri-o


### PR DESCRIPTION
Typo in this [documentation](https://minikube.sigs.k8s.io/docs/drivers/podman/#usage)

`It’s recommended to run minikube with the podman driver and [CRI-O container runtime](https://cri-o.io/) (expect when using Rootless Podman):`

should be:

`It’s recommended to run minikube with the podman driver and [CRI-O container runtime](https://cri-o.io/) (**except** when using Rootless Podman):`