### PR TITLE
Update gvisor-config.toml

### DIFF
--- a/deploy/addons/gvisor/gvisor-config.toml
+++ b/deploy/addons/gvisor/gvisor-config.toml
@@ -1,6 +1,8 @@
+version = 2
 root = "/var/lib/containerd"
 state = "/run/containerd"
 oom_score = 0
+# imports
 
 [grpc]
   address = "/run/containerd/containerd.sock"
@@ -23,44 +25,46 @@ oom_score = 0
   path = ""
 
 [plugins]
-  [plugins.cgroups]
+  [plugins."io.containerd.monitor.v1.cgroups"]
     no_prometheus = false
-  [plugins.cri]
+  [plugins."io.containerd.grpc.v1.cri"]
     stream_server_address = ""
     stream_server_port = "10010"
     enable_selinux = false
-    sandbox_image = "{{default "k8s.gcr.io" .ImageRepository}}/pause:3.1"
+    sandbox_image = "{{default "k8s.gcr.io" .ImageRepository}}/pause:3.6"
     stats_collect_period = 10
-    systemd_cgroup = false
     enable_tls_streaming = false
     max_container_log_line_size = 16384
-    [plugins.cri.containerd]
+    restrict_oom_score_adj = false
+
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      discard_unpacked_layers = true
       snapshotter = "overlayfs"
-      no_pivot = false
-      [plugins.cri.containerd.default_runtime]
-        runtime_type = "io.containerd.runtime.v1.linux"
+      [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
+        runtime_type = "io.containerd.runc.v2"
+      [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
+        runtime_type = ""
         runtime_engine = ""
         runtime_root = ""
-      [plugins.cri.containerd.runtimes.untrusted]
-        runtime_type = "io.containerd.runsc.v1"
-      [plugins.cri.containerd.runtimes.runsc]
-        runtime_type = "io.containerd.runsc.v1"
-    [plugins.cri.cni]
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v2"
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+            SystemdCgroup = false
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc]
+          runtime_type = "io.containerd.runsc.v1"
+          pod_annotations = [ "dev.gvisor.*" ]
+    [plugins."io.containerd.grpc.v1.cri".cni]
       bin_dir = "/opt/cni/bin"
-      conf_dir = "/etc/cni/net.d"
+      conf_dir = "/etc/cni/net.mk"
       conf_template = ""
-    [plugins.cri.registry]
-      [plugins.cri.registry.mirrors]
-        [plugins.cri.registry.mirrors."docker.io"]
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
           endpoint = ["https://registry-1.docker.io"]
-  [plugins.diff-service]
+  [plugins."io.containerd.service.v1.diff-service"]
     default = ["walking"]
-  [plugins.linux]
-    runtime = "runc"
-    runtime_root = ""
-    no_shim = false
-    shim_debug = true
-  [plugins.scheduler]
+  [plugins."io.containerd.gc.v1.scheduler"]
     pause_threshold = 0.02
     deletion_threshold = 0
     mutation_threshold = 100

--- a/deploy/addons/gvisor/gvisor-config.toml
+++ b/deploy/addons/gvisor/gvisor-config.toml
@@ -54,6 +54,9 @@ oom_score = 0
         [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc]
           runtime_type = "io.containerd.runsc.v1"
           pod_annotations = [ "dev.gvisor.*" ]
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.untrusted]
+          runtime_type = "io.containerd.runsc.v1"
+          pod_annotations = [ "dev.gvisor.*" ]
     [plugins."io.containerd.grpc.v1.cri".cni]
       bin_dir = "/opt/cni/bin"
       conf_dir = "/etc/cni/net.mk"


### PR DESCRIPTION
containerd `config.toml` file has been updated to the `version=2` format. Update the gVisor replacement copy accordingly.

Fixes google/gvisor#7877

