### PR TITLE
Fix wrong use of loop variable in parallel test

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/versions_test.go
+++ b/pkg/minikube/bootstrapper/bsutil/versions_test.go
@@ -49,7 +49,7 @@ func TestVersionIsBetween(t *testing.T) {
 			ver:         semver.MustParse("2.8.0"),
 			gte:         semver.MustParse("1.7.0"),
 			lte:         semver.MustParse("1.9.0"),
-			expected:    true,
+			expected:    false,
 		},
 		{
 			description: "equal to max version",
@@ -66,22 +66,23 @@ func TestVersionIsBetween(t *testing.T) {
 			expected:    true,
 		},
 		{
-			description: "alpha between",
+			description: "alpha before",
 			ver:         semver.MustParse("1.8.0-alpha.0"),
 			gte:         semver.MustParse("1.8.0"),
 			lte:         semver.MustParse("1.9.0"),
-			expected:    true,
+			expected:    false,
 		},
 		{
 			description: "beta greater than alpha",
 			ver:         semver.MustParse("1.8.0-beta.1"),
-			gte:         semver.MustParse("1.8.0"),
-			lte:         semver.MustParse("1.8.0-alpha.0"),
-			expected:    false,
+			gte:         semver.MustParse("1.8.0-alpha.0"),
+			lte:         semver.MustParse("1.8.0"),
+			expected:    true,
 		},
 	}
 
 	for _, test := range tests {
+		test := test // capture range variable
 		t.Run(test.description, func(t *testing.T) {
 			t.Parallel()
 			between := versionIsBetween(test.ver, test.gte, test.lte)


### PR DESCRIPTION
This fixes an occurrence of a loop variable being incorrectly captured
in a parallel test (`TestVersionIsBetween`). With the previous code,
only the last test case is actually exercised. To work around this
problem, we create a local coapy of the range variable before the
parallel test, as suggested in the documentation for the `testing`
package:

https://pkg.go.dev/testing#hdr-Subtests_and_Sub_benchmarks

Some assertions had to be changed as they were incorrect.

Issue was found using the `loopvarcapture` linter.
