### PR TITLE
Added the arm of echoserver in the deployment section fixes#12036

### DIFF
--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -540,6 +540,7 @@ Create a sample deployment and expose it on port 8080:
 kubectl create deployment hello-minikube --image=k8s.gcr.io/echoserver:1.4
 kubectl expose deployment hello-minikube --type=NodePort --port=8080
 ```
+(On ARM64 architecture, use the image *k8s.gcr.io/echoserver-arm:1.8* instead)
 
 It may take a moment, but your deployment will soon show up when you run:
 


### PR DESCRIPTION
the command: 'kubectl create deployment hello-minikube --image=k8s.gcr.io/echoserver:1.4' doesn't work on arm64 (tested on macOS, m2 processor), 
more details: https://github.com/kubernetes/minikube/issues/12036#issuecomment-890100715
added the arm64 image, to save others time

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
