### PR TITLE
Update prow image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ GVISOR_TAG ?= latest
 AUTOPAUSE_HOOK_TAG ?= v0.0.2
 
 # prow-test tag to push changes to
-PROW_TEST_TAG ?= v0.0.2
+PROW_TEST_TAG ?= v0.0.3
 
 # storage provisioner tag to push changes to
 # NOTE: you will need to bump the PreloadVersion if you change this

--- a/deploy/prow/Dockerfile
+++ b/deploy/prow/Dockerfile
@@ -52,7 +52,7 @@ RUN echo "Installing Packages ..." \
             procps \
             python \
             python-dev \
-            python-pip \
+            python3-pip \
             rsync \
             software-properties-common \
             unzip \


### PR DESCRIPTION
Our prow image was last created back in February, we need to update the image with a Go version that supports generics.

Image is already built and pushed
`gcr.io/k8s-minikube/prow-test:v0.0.3`