### PR TITLE
Site: Docker Desktop on Linux unsupported

### DIFF
--- a/site/content/en/docs/drivers/docker.md
+++ b/site/content/en/docs/drivers/docker.md
@@ -61,6 +61,8 @@ The `--container-runtime` flag must be set to "containerd" or "cri-o". "containe
 
 ## Known Issues
 
+- Docker Desktop on Linux is not yet supported by minikube, see [#14202](https://github.com/kubernetes/minikube/issues/14202)
+
 - The following Docker runtime security options are currently *unsupported and will not work* with the Docker driver (see [#9607](https://github.com/kubernetes/minikube/issues/9607)):
   - [userns-remap](https://docs.docker.com/engine/security/userns-remap/)
 

--- a/site/content/en/docs/drivers/docker.md
+++ b/site/content/en/docs/drivers/docker.md
@@ -61,7 +61,7 @@ The `--container-runtime` flag must be set to "containerd" or "cri-o". "containe
 
 ## Known Issues
 
-- Docker Desktop on Linux is not yet supported by minikube, see [#14202](https://github.com/kubernetes/minikube/issues/14202)
+- On Linux, Docker Desktop is not yet supported by minikube, see [#14202](https://github.com/kubernetes/minikube/issues/14202).
 
 - The following Docker runtime security options are currently *unsupported and will not work* with the Docker driver (see [#9607](https://github.com/kubernetes/minikube/issues/9607)):
   - [userns-remap](https://docs.docker.com/engine/security/userns-remap/)


### PR DESCRIPTION
Fixes: #14540

Adds documentation for Docker Desktop being unsupported on Linux.

---

![Screen Shot 2022-08-31 at 15 55 01](https://user-images.githubusercontent.com/93291761/187799068-71d465ba-51e3-4439-9915-001cce030a1a.png)

---

Want to view the site locally? Clone this PR and run `make site`, then go to: `http://localhost:1313/docs/drivers/docker/`.

Note: you may need to replace `1313` with whatever port that Hugo provides.