### PR TITLE
Skip metallb PodSecurityPolicy object for kubernetes 1.25+

### DIFF
--- a/deploy/addons/metallb/metallb.yaml.tmpl
+++ b/deploy/addons/metallb/metallb.yaml.tmpl
@@ -5,35 +5,6 @@ metadata:
     app: metallb
   name: metallb-system
 ---
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  labels:
-    app: metallb
-  name: speaker
-  namespace: metallb-system
-spec:
-  allowPrivilegeEscalation: false
-  allowedCapabilities:
-  - NET_ADMIN
-  - NET_RAW
-  - SYS_ADMIN
-  fsGroup:
-    rule: RunAsAny
-  hostNetwork: true
-  hostPorts:
-  - max: 7472
-    min: 7472
-  privileged: true
-  runAsUser:
-    rule: RunAsAny
-  seLinux:
-    rule: RunAsAny
-  supplementalGroups:
-    rule: RunAsAny
-  volumes:
-  - '*'
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/deploy/addons/metallb/metallb.yaml.tmpl
+++ b/deploy/addons/metallb/metallb.yaml.tmpl
@@ -4,8 +4,7 @@ metadata:
   labels:
     app: metallb
   name: metallb-system
----
-{{- if and (eq .KubernetesVersion.Major 1 ) (lt .KubernetesVersion.Minor 25) }}
+---{{ if .LegacyPodSecurityPolicy }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -34,8 +33,7 @@ spec:
     rule: RunAsAny
   volumes:
   - '*'
----
-{{- end }}
+---{{ end }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/deploy/addons/metallb/metallb.yaml.tmpl
+++ b/deploy/addons/metallb/metallb.yaml.tmpl
@@ -5,6 +5,37 @@ metadata:
     app: metallb
   name: metallb-system
 ---
+{{- if and (eq .KubernetesVersion.Major 1 ) (lt .KubernetesVersion.Minor 25) }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  labels:
+    app: metallb
+  name: speaker
+  namespace: metallb-system
+spec:
+  allowPrivilegeEscalation: false
+  allowedCapabilities:
+  - NET_ADMIN
+  - NET_RAW
+  - SYS_ADMIN
+  fsGroup:
+    rule: RunAsAny
+  hostNetwork: true
+  hostPorts:
+  - max: 7472
+    min: 7472
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+{{- end }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -858,38 +858,45 @@ func GenerateTemplateData(addon *Addon, cc *config.ClusterConfig, netInfo Networ
 		ea = "-" + runtime.GOARCH
 	}
 
+	v, err := util.ParseKubernetesVersion(cfg.KubernetesVersion)
+	if err != nil {
+		return errors.Wrap(err, "parsing Kubernetes version")
+	}
+
 	opts := struct {
-		KubernetesVersion      map[string]uint64
-		PreOneTwentyKubernetes bool
-		Arch                   string
-		ExoticArch             string
-		ImageRepository        string
-		LoadBalancerStartIP    string
-		LoadBalancerEndIP      string
-		CustomIngressCert      string
-		IngressAPIVersion      string
-		ContainerRuntime       string
-		RegistryAliases        string
-		Images                 map[string]string
-		Registries             map[string]string
-		CustomRegistries       map[string]string
-		NetworkInfo            map[string]string
+		KubernetesVersion       map[string]uint64
+		PreOneTwentyKubernetes  bool
+		Arch                    string
+		ExoticArch              string
+		ImageRepository         string
+		LoadBalancerStartIP     string
+		LoadBalancerEndIP       string
+		CustomIngressCert       string
+		IngressAPIVersion       string
+		ContainerRuntime        string
+		RegistryAliases         string
+		Images                  map[string]string
+		Registries              map[string]string
+		CustomRegistries        map[string]string
+		NetworkInfo             map[string]string
+		LegacyPodSecurityPolicy bool
 	}{
-		KubernetesVersion:      make(map[string]uint64),
-		PreOneTwentyKubernetes: false,
-		Arch:                   a,
-		ExoticArch:             ea,
-		ImageRepository:        cfg.ImageRepository,
-		LoadBalancerStartIP:    cfg.LoadBalancerStartIP,
-		LoadBalancerEndIP:      cfg.LoadBalancerEndIP,
-		CustomIngressCert:      cfg.CustomIngressCert,
-		RegistryAliases:        cfg.RegistryAliases,
-		IngressAPIVersion:      "v1", // api version for ingress (eg, "v1beta1"; defaults to "v1" for k8s 1.19+)
-		ContainerRuntime:       cfg.ContainerRuntime,
-		Images:                 images,
-		Registries:             addon.Registries,
-		CustomRegistries:       customRegistries,
-		NetworkInfo:            make(map[string]string),
+		KubernetesVersion:       make(map[string]uint64),
+		PreOneTwentyKubernetes:  false,
+		Arch:                    a,
+		ExoticArch:              ea,
+		ImageRepository:         cfg.ImageRepository,
+		LoadBalancerStartIP:     cfg.LoadBalancerStartIP,
+		LoadBalancerEndIP:       cfg.LoadBalancerEndIP,
+		CustomIngressCert:       cfg.CustomIngressCert,
+		RegistryAliases:         cfg.RegistryAliases,
+		IngressAPIVersion:       "v1", // api version for ingress (eg, "v1beta1"; defaults to "v1" for k8s 1.19+)
+		ContainerRuntime:        cfg.ContainerRuntime,
+		Images:                  images,
+		Registries:              addon.Registries,
+		CustomRegistries:        customRegistries,
+		NetworkInfo:             make(map[string]string),
+		LegacyPodSecurityPolicy: v.LT(semver.Version{Major: 1, Minor: 25}),
 	}
 	if opts.ImageRepository != "" && !strings.HasSuffix(opts.ImageRepository, "/") {
 		opts.ImageRepository += "/"
@@ -900,26 +907,11 @@ func GenerateTemplateData(addon *Addon, cc *config.ClusterConfig, netInfo Networ
 
 	// maintain backwards compatibility with k8s < v1.19
 	// by using v1beta1 instead of v1 api version for ingress
-	v, err := util.ParseKubernetesVersion(cfg.KubernetesVersion)
-	if err != nil {
-		return errors.Wrap(err, "parsing Kubernetes version")
-	}
 	if semver.MustParseRange("<1.19.0")(v) {
 		opts.IngressAPIVersion = "v1beta1"
 	}
 	if semver.MustParseRange("<1.20.0")(v) {
 		opts.PreOneTwentyKubernetes = true
-	}
-
-	// Store kubernetes version in opts
-	kv, err := util.ParseKubernetesVersion(cfg.KubernetesVersion)
-	if err != nil {
-		return errors.Wrap(err, "parsing Kubernetes version")
-	}
-	opts.KubernetesVersion = map[string]uint64{
-		"Major": kv.Major,
-		"Minor": kv.Minor,
-		"Patch": kv.Patch,
 	}
 
 	// Network info for generating template

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -859,6 +859,7 @@ func GenerateTemplateData(addon *Addon, cc *config.ClusterConfig, netInfo Networ
 	}
 
 	opts := struct {
+		KubernetesVersion      map[string]uint64
 		PreOneTwentyKubernetes bool
 		Arch                   string
 		ExoticArch             string
@@ -874,6 +875,7 @@ func GenerateTemplateData(addon *Addon, cc *config.ClusterConfig, netInfo Networ
 		CustomRegistries       map[string]string
 		NetworkInfo            map[string]string
 	}{
+		KubernetesVersion:      make(map[string]uint64),
 		PreOneTwentyKubernetes: false,
 		Arch:                   a,
 		ExoticArch:             ea,
@@ -907,6 +909,17 @@ func GenerateTemplateData(addon *Addon, cc *config.ClusterConfig, netInfo Networ
 	}
 	if semver.MustParseRange("<1.20.0")(v) {
 		opts.PreOneTwentyKubernetes = true
+	}
+
+	// Store kubernetes version in opts
+	kv, err := util.ParseKubernetesVersion(cfg.KubernetesVersion)
+	if err != nil {
+		return errors.Wrap(err, "parsing Kubernetes version")
+	}
+	opts.KubernetesVersion = map[string]uint64{
+		"Major": kv.Major,
+		"Minor": kv.Minor,
+		"Patch": kv.Patch,
 	}
 
 	// Network info for generating template


### PR DESCRIPTION
Minikube MetalLB addon can't be installed on kubernetes cluster 1.25.0, because it installs PodSecurityPolicy `policy/v1beta1` object that is deprecated with kubernetes 1.25. 
MetalLB solves this by removing object altogether: https://github.com/metallb/metallb/pull/1569 
I made PR that exposes Kubernetes version and conditionally enables psp object for <1.25. Project uses older templating library so `semver` and `semverCompare` can't be used.