### PR TITLE
Fix minikube tunnel repeated printout of status

### DIFF
--- a/pkg/minikube/tunnel/reporter.go
+++ b/pkg/minikube/tunnel/reporter.go
@@ -18,6 +18,7 @@ package tunnel
 
 import (
 	"fmt"
+	"reflect"
 
 	"io"
 	"strings"
@@ -38,7 +39,7 @@ type simpleReporter struct {
 const noErrors = "no errors"
 
 func (r *simpleReporter) Report(tunnelState *Status) {
-	if r.lastState == tunnelState {
+	if reflect.DeepEqual(r.lastState, tunnelState) {
 		return
 	}
 	r.lastState = tunnelState

--- a/pkg/minikube/tunnel/reporter_test.go
+++ b/pkg/minikube/tunnel/reporter_test.go
@@ -103,11 +103,11 @@ Got:	  "%s"`, tc.name, tc.expectedOutput, out.output)
 	// testing deduplication
 	out := &recordingWriter{}
 	reporter := newReporter(out)
-	reporter.Report(testCases[0].tunnelState)
-	reporter.Report(testCases[0].tunnelState)
-	reporter.Report(testCases[1].tunnelState)
-	reporter.Report(testCases[1].tunnelState)
-	reporter.Report(testCases[0].tunnelState)
+	reporter.Report(testCases[0].tunnelState.Clone())
+	reporter.Report(testCases[0].tunnelState.Clone())
+	reporter.Report(testCases[1].tunnelState.Clone())
+	reporter.Report(testCases[1].tunnelState.Clone())
+	reporter.Report(testCases[0].tunnelState.Clone())
 
 	expectedOutput := fmt.Sprintf("%s%s%s",
 		testCases[0].expectedOutput,


### PR DESCRIPTION
The check to suppress repeated status printout does not work, it compares pointers, while the state is always cloned when it is passed to the Report function. Do the DeepEqual check instead and change the test to be real.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
