### PR TITLE
CI: fix Golang install on M1 Macs

### DIFF
--- a/hack/jenkins/installers/check_install_golang.sh
+++ b/hack/jenkins/installers/check_install_golang.sh
@@ -30,7 +30,7 @@ function current_arch() {
   "x86_64" | "i386")
      echo "amd64"
   ;;
-  "aarch64")
+  "aarch64" | "arm64")
     echo "arm64"
   ;;
   *)


### PR DESCRIPTION
Error logs:
```
++ ./installers/check_install_golang.sh /usr/local
+ (( 1 < 1 ))
+ VERSION_TO_INSTALL=1.19.1
+ INSTALL_PATH=/usr/local
++ current_arch
++ case $(arch) in
+++ arch
+++ arch
++ echo 'unexpected arch: arm64. use amd64'
unexpected arch: arm64. use amd64
++ echo amd64
+ ARCH=amd64
+ check_and_install_golang
+ go version
+ sudo chown -R ****:**** /usr/local/go
chown: ****: illegal group name
++ true
```

Is trying to install amd64 version of Go on arm64 machines