### PR TITLE
Fix QEMU delete errors

### DIFF
--- a/pkg/drivers/qemu/qemu.go
+++ b/pkg/drivers/qemu/qemu.go
@@ -709,7 +709,7 @@ func (d *Driver) RunQMPCommand(command string) (map[string]interface{}, error) {
 	}
 	var response qmpResponse
 	if err := json.Unmarshal(buf[:nr], &response); err != nil {
-		return nil, errors.Wrap(err, "unmarshal qmp_capabilities reponse")
+		return nil, errors.Wrap(err, "unmarshal qmp_capabilities response")
 	}
 	// expecting empty response
 	if len(response.Return) != 0 {

--- a/pkg/drivers/qemu/qemu.go
+++ b/pkg/drivers/qemu/qemu.go
@@ -667,7 +667,7 @@ func (d *Driver) RunQMPCommand(command string) (map[string]interface{}, error) {
 	var buf [1024]byte
 	nr, err := conn.Read(buf[:])
 	if err != nil {
-		return nil, errors.Wrap(err, "read initial response")
+		return nil, errors.Wrap(err, "read initial resp")
 	}
 	type qmpInitialResponse struct {
 		QMP struct {
@@ -685,7 +685,7 @@ func (d *Driver) RunQMPCommand(command string) (map[string]interface{}, error) {
 
 	var initialResponse qmpInitialResponse
 	if err := json.Unmarshal(buf[:nr], &initialResponse); err != nil {
-		return nil, errors.Wrap(err, "unmarshal initial response")
+		return nil, errors.Wrap(err, "unmarshal initial resp")
 	}
 
 	// run 'qmp_capabilities' to switch to command mode
@@ -702,14 +702,14 @@ func (d *Driver) RunQMPCommand(command string) (map[string]interface{}, error) {
 	}
 	nr, err = conn.Read(buf[:])
 	if err != nil {
-		return nil, errors.Wrap(err, "read qmp_capabilities response")
+		return nil, errors.Wrap(err, "read qmp_capabilities resp")
 	}
 	type qmpResponse struct {
 		Return map[string]interface{} `json:"return"`
 	}
 	var response qmpResponse
 	if err := json.Unmarshal(buf[:nr], &response); err != nil {
-		return nil, errors.Wrap(err, "unmarshal qmp_capabilities response")
+		return nil, errors.Wrap(err, "unmarshal qmp_capabilities resp")
 	}
 	// expecting empty response
 	if len(response.Return) != 0 {
@@ -726,14 +726,14 @@ func (d *Driver) RunQMPCommand(command string) (map[string]interface{}, error) {
 	}
 	nr, err = conn.Read(buf[:])
 	if err != nil {
-		return nil, errors.Wrap(err, "read command response")
+		return nil, errors.Wrap(err, "read command resp")
 	}
 
 	// Sometimes QEMU returns two JSON objects with the first object being the command response
 	// and the second object being an event log (unimportant)
 	firstRespObj := strings.Split(string(buf[:nr]), "\n")[0]
 	if err := json.Unmarshal([]byte(firstRespObj), &response); err != nil {
-		return nil, errors.Wrap(err, "unmarshal command response")
+		return nil, errors.Wrap(err, "unmarshal command resp")
 	}
 	if strings.HasPrefix(command, "query-") {
 		return response.Return, nil


### PR DESCRIPTION
Sometimes QEMU was returning two JSON objects in the response and minikube was failing to unmarshal the response as it's only expecting one JSON object.

Response:
```
{"return": {}}
{"timestamp": {"seconds": 1663094607, "microseconds": 836663}, "event": "SHUTDOWN", "data": {"guest": false, "reason": "host-qmp-quit"}}
```

Split the response on `\n` and only unmarshal the first JSON object.

Also wrapped returns on all the errors for better logging.