### PR TITLE
Use SSH tunnel if user specifies bindAddress

### DIFF
--- a/cmd/minikube/cmd/tunnel.go
+++ b/cmd/minikube/cmd/tunnel.go
@@ -85,7 +85,7 @@ var tunnelCmd = &cobra.Command{
 			cancel()
 		}()
 
-		if driver.NeedsPortForward(co.Config.Driver) && driver.IsKIC(co.Config.Driver) {
+		if useSSHTunnel(co.Config.Driver) {
 			port, err := oci.ForwardedPort(co.Config.Driver, cname, 22)
 			if err != nil {
 				exit.Error(reason.DrvPortForward, "error getting ssh port", err)
@@ -109,6 +109,16 @@ var tunnelCmd = &cobra.Command{
 		}
 		<-done
 	},
+}
+
+func useSSHTunnel(driverName string) bool {
+	if !driver.IsKIC(driverName) {
+		return false
+	}
+	if driver.NeedsPortForward(driverName) {
+		return true
+	}
+	return bindAddress != ""
 }
 
 func outputTunnelStarted() {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/14712

Currently, if the user is on Linux and using the Docker driver, specifying the `bindAddress` doesn't take effect as `driver.NeedsPortForward` returns false and the SSH tunnel is not used.

Updated the logic gating so if the user is on Linux and using the Docker driver and they specify the `bindAddress` it will use the SSH tunnel.