### PR TITLE
fix: trim docker.io to prevent always writing to daemon

### DIFF
--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -604,7 +604,7 @@ func dockerImagesPreloaded(runner command.Runner, images []string) bool {
 	}
 	preloadedImages := map[string]struct{}{}
 	for _, i := range strings.Split(rr.Stdout.String(), "\n") {
-		i = trimDockerIO(i)
+		i = TrimDockerIO(i)
 		preloadedImages[i] = struct{}{}
 	}
 
@@ -612,7 +612,7 @@ func dockerImagesPreloaded(runner command.Runner, images []string) bool {
 
 	// Make sure images == imgs
 	for _, i := range images {
-		i = trimDockerIO(i)
+		i = TrimDockerIO(i)
 		if _, ok := preloadedImages[i]; !ok {
 			klog.Infof("%s wasn't preloaded", i)
 			return false
@@ -642,13 +642,6 @@ func addDockerIO(name string) string {
 		return reg + "/" + usr + "/" + img
 	}
 	return reg + "/" + img
-}
-
-// Remove docker.io prefix since it won't be included in images names
-// when we call 'docker images'
-func trimDockerIO(name string) string {
-	name = strings.TrimPrefix(name, "docker.io/")
-	return name
 }
 
 func dockerBoundToContainerd(runner command.Runner) bool {

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/docker"
 	"k8s.io/minikube/pkg/minikube/download"
+	"k8s.io/minikube/pkg/minikube/image"
 	"k8s.io/minikube/pkg/minikube/style"
 	"k8s.io/minikube/pkg/minikube/sysinit"
 )
@@ -604,7 +605,7 @@ func dockerImagesPreloaded(runner command.Runner, images []string) bool {
 	}
 	preloadedImages := map[string]struct{}{}
 	for _, i := range strings.Split(rr.Stdout.String(), "\n") {
-		i = download.TrimDockerIO(i)
+		i = image.TrimDockerIO(i)
 		preloadedImages[i] = struct{}{}
 	}
 
@@ -612,7 +613,7 @@ func dockerImagesPreloaded(runner command.Runner, images []string) bool {
 
 	// Make sure images == imgs
 	for _, i := range images {
-		i = download.TrimDockerIO(i)
+		i = image.TrimDockerIO(i)
 		if _, ok := preloadedImages[i]; !ok {
 			klog.Infof("%s wasn't preloaded", i)
 			return false

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/command"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/docker"
-	download "k8s.io/minikube/pkg/minikube/download"
+	"k8s.io/minikube/pkg/minikube/download"
 	"k8s.io/minikube/pkg/minikube/style"
 	"k8s.io/minikube/pkg/minikube/sysinit"
 )

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/command"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/docker"
-	"k8s.io/minikube/pkg/minikube/download"
+	download "k8s.io/minikube/pkg/minikube/download"
 	"k8s.io/minikube/pkg/minikube/style"
 	"k8s.io/minikube/pkg/minikube/sysinit"
 )
@@ -604,7 +604,7 @@ func dockerImagesPreloaded(runner command.Runner, images []string) bool {
 	}
 	preloadedImages := map[string]struct{}{}
 	for _, i := range strings.Split(rr.Stdout.String(), "\n") {
-		i = TrimDockerIO(i)
+		i = download.TrimDockerIO(i)
 		preloadedImages[i] = struct{}{}
 	}
 
@@ -612,7 +612,7 @@ func dockerImagesPreloaded(runner command.Runner, images []string) bool {
 
 	// Make sure images == imgs
 	for _, i := range images {
-		i = TrimDockerIO(i)
+		i = download.TrimDockerIO(i)
 		if _, ok := preloadedImages[i]; !ok {
 			klog.Infof("%s wasn't preloaded", i)
 			return false

--- a/pkg/minikube/download/image.go
+++ b/pkg/minikube/download/image.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/minikube/detect"
+	"k8s.io/minikube/pkg/minikube/image"
 	"k8s.io/minikube/pkg/minikube/localpath"
 )
 
@@ -69,19 +70,13 @@ func ImageExistsInCache(img string) bool {
 
 var checkImageExistsInCache = ImageExistsInCache
 
-// Remove docker.io prefix since it won't be included in image names
-// when we call `docker images`.
-func TrimDockerIO(name string) string {
-	return strings.TrimPrefix(name, "docker.io/")
-}
-
 // ImageExistsInDaemon if img exist in local docker daemon
 func ImageExistsInDaemon(img string) bool {
 	// Check if image exists locally
 	klog.Infof("Checking for %s in local docker daemon", img)
 	cmd := exec.Command("docker", "images", "--format", "{{.Repository}}:{{.Tag}}@{{.Digest}}")
 	if output, err := cmd.Output(); err == nil {
-		if strings.Contains(string(output), TrimDockerIO(img)) {
+		if strings.Contains(string(output), image.TrimDockerIO(img)) {
 			klog.Infof("Found %s in local docker daemon, skipping pull", img)
 			return true
 		}

--- a/pkg/minikube/download/image.go
+++ b/pkg/minikube/download/image.go
@@ -69,11 +69,10 @@ func ImageExistsInCache(img string) bool {
 
 var checkImageExistsInCache = ImageExistsInCache
 
-// Remove docker.io prefix since it won't be included in images names
-// when we call 'docker images'
+// Remove docker.io prefix since it won't be included in image names
+// when we call `docker images`.
 func TrimDockerIO(name string) string {
-	name = strings.TrimPrefix(name, "docker.io/")
-	return name
+	return strings.TrimPrefix(name, "docker.io/")
 }
 
 // ImageExistsInDaemon if img exist in local docker daemon

--- a/pkg/minikube/download/image.go
+++ b/pkg/minikube/download/image.go
@@ -69,13 +69,20 @@ func ImageExistsInCache(img string) bool {
 
 var checkImageExistsInCache = ImageExistsInCache
 
+// Remove docker.io prefix since it won't be included in images names
+// when we call 'docker images'
+func TrimDockerIO(name string) string {
+	name = strings.TrimPrefix(name, "docker.io/")
+	return name
+}
+
 // ImageExistsInDaemon if img exist in local docker daemon
 func ImageExistsInDaemon(img string) bool {
 	// Check if image exists locally
 	klog.Infof("Checking for %s in local docker daemon", img)
 	cmd := exec.Command("docker", "images", "--format", "{{.Repository}}:{{.Tag}}@{{.Digest}}")
 	if output, err := cmd.Output(); err == nil {
-		if strings.Contains(string(output), img) {
+		if strings.Contains(string(output), TrimDockerIO(img)) {
 			klog.Infof("Found %s in local docker daemon, skipping pull", img)
 			return true
 		}

--- a/pkg/minikube/image/image.go
+++ b/pkg/minikube/image/image.go
@@ -319,3 +319,9 @@ func normalizeTagName(image string) string {
 	}
 	return base + ":" + tag
 }
+
+// Remove docker.io prefix since it won't be included in image names
+// when we call `docker images`.
+func TrimDockerIO(name string) string {
+	return strings.TrimPrefix(name, "docker.io/")
+}


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

Since the `docker images` will output `Repository` without the `docker.io` prefix. I originally decided to trim this prefix from the `img` param in `ImageExistsInDaemon`.

But then I discovered the `trimDockerIO` function, so I move it from the `pkg/minikube/cruntime` package into `pkg/minikube/download` to achieve code reuse.

Thanks for the review. 😃
