### PR TITLE
Increase timeout for creating IP address for KVM by 1m

### DIFF
--- a/pkg/drivers/kvm/kvm.go
+++ b/pkg/drivers/kvm/kvm.go
@@ -309,8 +309,8 @@ func (d *Driver) waitForStaticIP(conn *libvirt.Connect) error {
 
 		return nil
 	}
-	if err := retry.Local(query, 1*time.Minute); err != nil {
-		return fmt.Errorf("machine %s didn't return IP after 1 minute", d.MachineName)
+	if err := retry.Local(query, 2*time.Minute); err != nil {
+		return fmt.Errorf("machine %s didn't return IP after 2 minutes", d.MachineName)
 	}
 
 	log.Info("Reserving static IP address...")


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

Fixes https://github.com/kubernetes/minikube/issues/3566

Starting minikube with KVM with `minikube start --driver=kvm2` returned this error consistently:
```
😿  Failed to start kvm2 VM. Running "minikube delete" may fix it: creating host: create: Error creating machine: Error in driver during machine creation: IP not available after waiting: machine minikube didn't return IP after 1 minute

❌  Exiting due to GUEST_PROVISION: Failed to start host: creating host: create: Error creating machine: Error in driver during machine creation: IP not available after waiting: machine minikube didn't return IP after 1 minute
```

The suggestions in https://github.com/kubernetes/minikube/issues/3566 (e.g. firewall changes, `sudo systemctl restart libvirtd.service`) did not fix the issue for me.

DHCP did not have enough time to throw an IP. This is the result immediately after `minikube start --driver=kvm2` timed out:
```
virsh net-dhcp-leases mk-minikube
 Expiry Time   MAC address   Protocol   IP address   Hostname   Client ID or DUID
-----------------------------------------------------------------------------------
```

A few seconds later, an IP address was provided:
```
virsh net-dhcp-leases mk-minikube
 Expiry Time           MAC address         Protocol   IP address         Hostname   Client ID or DUID
----------------------------------------------------------------------------------------------------------
 2022-09-16 09:23:31   52:54:00:ca:cc:bd   ipv4       192.168.39.60/24   minikube   01:52:54:00:ca:cc:bd
```

Validation that `virbr1` has an address:
```
arp -e
Address                  HWtype  HWaddress           Flags Mask            Iface
10.0.2.3                 ether   52:54:00:12:35:03   C                     eth0
192.168.122.124          ether   52:54:00:5e:79:f7   C                     virbr0
192.168.39.134           ether   52:54:00:be:1c:2a   C                     virbr1
_gateway                 ether   52:54:00:12:35:02   C                     eth0
```

Increasing the timeout to 2m and trying again fixed the issue! DHCP needed more time to resolve.