### PR TITLE
Enabling RISC-V support

### DIFF
--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	// SupportedArchitectures is the list of supported architectures
-	SupportedArchitectures = [5]string{"amd64", "arm", "arm64", "ppc64le", "s390x"}
+	SupportedArchitectures = [6]string{"amd64", "arm", "arm64", "ppc64le", "s390x", "riscv64"}
 )
 
 const (


### PR DESCRIPTION
This is required to launch minikube on a 64bit RISC-V board

Currently testing under Qemu.
