### PR TITLE
Fix update check logic

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -148,11 +148,8 @@ func runStart(cmd *cobra.Command, args []string) {
 	displayVersion(version.GetVersion())
 	go download.CleanUpOlderPreloads()
 
-	// No need to do the update check if no one is going to see it
-	if !viper.GetBool(interactive) || !viper.GetBool(dryRun) {
-		// Avoid blocking execution on optional HTTP fetches
-		go notify.MaybePrintUpdateTextFromGithub()
-	}
+	// Avoid blocking execution on optional HTTP fetches
+	go notify.MaybePrintUpdateTextFromGithub()
 
 	displayEnviron(os.Environ())
 	if viper.GetBool(force) {

--- a/pkg/minikube/notify/notify.go
+++ b/pkg/minikube/notify/notify.go
@@ -122,9 +122,6 @@ func shouldCheckURLVersion(filePath string) bool {
 	if !viper.GetBool("interactive") {
 		return false
 	}
-	if viper.GetBool("dry-run") {
-		return false
-	}
 	lastUpdateTime := timeFromFileIfExists(filePath)
 	return time.Since(lastUpdateTime).Hours() >= viper.GetFloat64(config.ReminderWaitPeriodInHours)
 }

--- a/pkg/minikube/notify/notify.go
+++ b/pkg/minikube/notify/notify.go
@@ -119,6 +119,12 @@ func shouldCheckURLVersion(filePath string) bool {
 	if !viper.GetBool(config.WantUpdateNotification) {
 		return false
 	}
+	if !viper.GetBool("interactive") {
+		return false
+	}
+	if viper.GetBool("dry-run") {
+		return false
+	}
 	lastUpdateTime := timeFromFileIfExists(filePath)
 	return time.Since(lastUpdateTime).Hours() >= viper.GetFloat64(config.ReminderWaitPeriodInHours)
 }

--- a/pkg/minikube/notify/notify_test.go
+++ b/pkg/minikube/notify/notify_test.go
@@ -36,6 +36,7 @@ import (
 )
 
 func TestShouldCheckURLVersion(t *testing.T) {
+	viper.Set("interactive", true)
 	tempDir := tests.MakeTempDir(t)
 
 	lastUpdateCheckFilePath := filepath.Join(tempDir, "last_update_check")
@@ -74,6 +75,7 @@ func TestShouldCheckURLVersion(t *testing.T) {
 }
 
 func TestShouldCheckURLBetaVersion(t *testing.T) {
+	viper.Set("interactive", true)
 	tempDir := tests.MakeTempDir(t)
 
 	lastUpdateCheckFilePath := filepath.Join(tempDir, "last_update_check")


### PR DESCRIPTION
**Before:**
Update check is skipped if `--interactive=true && --dry-run=true`

**After:**
I'm assuming the above is a mistake, refactored update check to skip if `--interactive=false`