### PR TITLE
site: Fix generate-docs on arm64

### DIFF
--- a/pkg/generate/rewrite.go
+++ b/pkg/generate/rewrite.go
@@ -55,6 +55,10 @@ func rewriteFlags(command *cobra.Command) error {
 		}, {
 			flag:  "mount-string",
 			usage: "The argument to pass the minikube mount command on start.",
+		}, {
+			flag:       "iso-url",
+			usage:      "Locations to fetch the minikube ISO from. The list depends on the machine architecture.",
+			defaultVal: "[]",
 		}},
 	}
 	rws, ok := rewrites[command.Name()]

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -69,7 +69,7 @@ minikube start [flags]
       --insecure-registry strings         Insecure Docker registries to pass to the Docker daemon.  The default service CIDR range will automatically be added.
       --install-addons                    If set, install addons. Defaults to true. (default true)
       --interactive                       Allow user prompts for more information (default true)
-      --iso-url strings                   Locations to fetch the minikube ISO from. (default [https://storage.googleapis.com/minikube/iso/minikube-v1.27.0-amd64.iso,https://github.com/kubernetes/minikube/releases/download/v1.27.0/minikube-v1.27.0-amd64.iso,https://kubernetes.oss-cn-hangzhou.aliyuncs.com/minikube/iso/minikube-v1.27.0-amd64.iso])
+      --iso-url strings                   Locations to fetch the minikube ISO from. The list depends on the machine architecture.
       --keep-context                      This will keep the existing kubectl context and will create a minikube context.
       --kubernetes-version string         The Kubernetes version that the minikube VM will use (ex: v1.2.3, 'stable' for v1.25.1, 'latest' for v1.25.1). Defaults to 'stable'.
       --kvm-gpu                           Enable experimental NVIDIA GPU support in minikube


### PR DESCRIPTION
Every time I run `make generate-docs` on an arm64 machine it wants to overwrite the `iso-url` defaults with arm64 values. This is annoying to constantly revert, also the docs are tied to amd64 which can be misleading. 
```
-      --iso-url strings                   Locations to fetch the minikube ISO from. (default [https://storage.googleapis.com/minikube/iso/minikube-v1.27.0-amd64.iso,https://github.com/kubernetes/minikube/releases/download/v1.27.0/minikube-v1.27.0-amd64.iso,https://kubernetes.oss-cn-hangzhou.aliyuncs.com/minikube/iso/minikube-v1.27.0-amd64.iso])
+      --iso-url strings                   Locations to fetch the minikube ISO from. (default [https://storage.googleapis.com/minikube/iso/minikube-v1.27.0-arm64.iso,https://github.com/kubernetes/minikube/releases/download/v1.27.0/minikube-v1.27.0-arm64.iso,https://kubernetes.oss-cn-hangzhou.aliyuncs.com/minikube/iso/minikube-v1.27.0-arm64.iso])
```

Replaced the flag description on the website to indicate that the list depends on the machine arch.