### PR TITLE
Add update check on `minikube status` & `minikube profile list`

### DIFF
--- a/cmd/minikube/cmd/config/profile_list.go
+++ b/cmd/minikube/cmd/config/profile_list.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/machine"
+	"k8s.io/minikube/pkg/minikube/notify"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/reason"
 	"k8s.io/minikube/pkg/minikube/style"
@@ -49,7 +50,11 @@ var profileListCmd = &cobra.Command{
 	Short: "Lists all minikube profiles.",
 	Long:  "Lists all valid minikube profiles and detects all possible invalid profiles.",
 	Run: func(cmd *cobra.Command, args []string) {
-		switch strings.ToLower(profileOutput) {
+		output := strings.ToLower(profileOutput)
+		out.SetJSON(output == "json")
+		go notify.MaybePrintUpdateTextFromGithub()
+
+		switch output {
 		case "json":
 			printProfilesJSON()
 		case "table":
@@ -204,7 +209,7 @@ func printProfilesJSON() {
 		body["valid"] = profilesOrDefault(validProfiles)
 		body["invalid"] = profilesOrDefault(invalidProfiles)
 		jsonString, _ := json.Marshal(body)
-		out.String(string(jsonString))
+		os.Stdout.Write(jsonString)
 	} else {
 		body["error"] = err
 		jsonString, _ := json.Marshal(body)

--- a/cmd/minikube/cmd/config/profile_list.go
+++ b/cmd/minikube/cmd/config/profile_list.go
@@ -213,7 +213,7 @@ func printProfilesJSON() {
 	} else {
 		body["error"] = err
 		jsonString, _ := json.Marshal(body)
-		out.String(string(jsonString))
+		os.Stdout.Write(jsonString)
 		os.Exit(reason.ExGuestError)
 	}
 }

--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/machine"
 	"k8s.io/minikube/pkg/minikube/mustload"
 	"k8s.io/minikube/pkg/minikube/node"
+	"k8s.io/minikube/pkg/minikube/notify"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/out/register"
 	"k8s.io/minikube/pkg/minikube/reason"
@@ -219,6 +220,7 @@ var statusCmd = &cobra.Command{
 		}
 
 		out.SetJSON(output == "json")
+		go notify.MaybePrintUpdateTextFromGithub()
 
 		cname := ClusterFlagValue()
 		api, cc := mustload.Partial(cname)

--- a/pkg/minikube/notify/notify.go
+++ b/pkg/minikube/notify/notify.go
@@ -122,6 +122,9 @@ func shouldCheckURLVersion(filePath string) bool {
 	if !viper.GetBool("interactive") {
 		return false
 	}
+	if out.JSON {
+		return false
+	}
 	lastUpdateTime := timeFromFileIfExists(filePath)
 	return time.Since(lastUpdateTime).Hours() >= viper.GetFloat64(config.ReminderWaitPeriodInHours)
 }


### PR DESCRIPTION
- Add update check on `minikube status` & `minikube profile list`
- Stop displaying update notifications when output is JSON
- Changed `out.String` to `os.Stdout.Write` for `minikube profile list` to match other commands
  - This is because when `out.JSON == true` `out.String` suppresses output
  - This previously wasn't a problem because `out.SetJSON` wasn't being called in `minikube profile list`