### PR TITLE
tests: Enable `TestPreload` for arm64

### DIFF
--- a/test/integration/preload_test.go
+++ b/test/integration/preload_test.go
@@ -32,17 +32,13 @@ func TestPreload(t *testing.T) {
 		t.Skipf("skipping %s - incompatible with none driver", t.Name())
 	}
 
-	if arm64Platform() {
-		t.Skipf("skipping %s - not yet supported on arm64. See https://github.com/kubernetes/minikube/issues/10144", t.Name())
-	}
-
 	profile := UniqueProfileName("test-preload")
 	ctx, cancel := context.WithTimeout(context.Background(), Minutes(40))
 	defer CleanupWithLogs(t, profile, cancel)
 
 	startArgs := []string{"start", "-p", profile, "--memory=2200", "--alsologtostderr", "--wait=true", "--preload=false"}
 	startArgs = append(startArgs, StartArgs()...)
-	k8sVersion := "v1.17.0"
+	k8sVersion := "v1.24.4"
 	startArgs = append(startArgs, fmt.Sprintf("--kubernetes-version=%s", k8sVersion))
 
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), startArgs...))
@@ -63,10 +59,10 @@ func TestPreload(t *testing.T) {
 		t.Fatalf("%s failed: %v", rr.Command(), err)
 	}
 
-	// Restart minikube with v1.17.3, which has a preloaded tarball
+	// Restart minikube with v1.24.6, which has a preloaded tarball
 	startArgs = []string{"start", "-p", profile, "--memory=2200", "--alsologtostderr", "-v=1", "--wait=true"}
 	startArgs = append(startArgs, StartArgs()...)
-	k8sVersion = "v1.17.3"
+	k8sVersion = "v1.24.6"
 	startArgs = append(startArgs, fmt.Sprintf("--kubernetes-version=%s", k8sVersion))
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), startArgs...))
 	if err != nil {


### PR DESCRIPTION
`TestPreload` was disabled on arm64 due to not having arm64 preloads at the time, we now have those.

However, Kubernetes doesn't have arm64 binaries for v1.17.0

Example: https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/darwin/arm64/kubectl
```
<Error>
<Code>NoSuchKey</Code>
<Message>The specified key does not exist.</Message>
<Details>No such object: kubernetes-release/release/v1.17.0/bin/darwin/arm64/kubectl</Details>
</Error>
```

So updated to a more recent Kubernetes version.