### PR TITLE
tests: Shorten qmp path

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -28,7 +28,7 @@
 
 readonly OS_ARCH="${OS}-${ARCH}"
 readonly TEST_ROOT="${HOME}/minikube-integration"
-readonly TEST_HOME="${TEST_ROOT}/${OS_ARCH}-${DRIVER}-${CONTAINER_RUNTIME}-${MINIKUBE_LOCATION}-$$-${COMMIT}"
+readonly TEST_HOME="${TEST_ROOT}/$$-${COMMIT:0:7}"
 
 export GOPATH="$HOME/go"
 export KUBECONFIG="${TEST_HOME}/kubeconfig"

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -28,7 +28,7 @@
 
 readonly OS_ARCH="${OS}-${ARCH}"
 readonly TEST_ROOT="${HOME}/minikube-integration"
-readonly TEST_HOME="${TEST_ROOT}/$$-${COMMIT:0:7}"
+readonly TEST_HOME="${TEST_ROOT}/${MINIKUBE_LOCATION}-$$"
 
 export GOPATH="$HOME/go"
 export KUBECONFIG="${TEST_HOME}/kubeconfig"

--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -63,7 +63,7 @@ func TestStartStop(t *testing.T) {
 				"--network-plugin=cni",
 				"--extra-config=kubeadm.pod-network-cidr=192.168.111.111/16",
 			}},
-			{"default-k8s-different-port", constants.DefaultKubernetesVersion, []string{
+			{"default-k8s-diff-port", constants.DefaultKubernetesVersion, []string{
 				"--apiserver-port=8444",
 			}},
 			{"no-preload", constants.NewestKubernetesVersion, []string{

--- a/test/integration/util_test.go
+++ b/test/integration/util_test.go
@@ -34,8 +34,8 @@ func UniqueProfileName(prefix string) string {
 	if NoneDriver() {
 		return "minikube"
 	}
-	// example: prefix-20200413162239-3215
-	return fmt.Sprintf("%s-%s-%d", prefix, time.Now().Format("20060102150405"), os.Getpid())
+	// example: prefix-162239
+	return fmt.Sprintf("%s-%s", prefix, time.Now().Format("150405"))
 }
 
 // auditContains checks if the provided string is contained within the logs.


### PR DESCRIPTION
Most the tests on QEMU are failing due to the qmp path being too long.
```
I1004 10:38:26.286981    8680 main.go:134] libmachine: STDERR: qemu-system-aarch64: -qmp unix:/Users/jenkins/minikube-integration/darwin-arm64-qemu2--15070-5426-113d61471aea8d1d728ca9022a145b9e97990c51/.minikube/machines/default-k8s-different-port-20221004103818-6060/monitor,server,nowait: UNIX socket path '/Users/jenkins/minikube-integration/darwin-arm64-qemu2--15070-5426-113d61471aea8d1d728ca9022a145b9e97990c51/.minikube/machines/default-k8s-different-port-20221004103818-6060/monitor' is too long
Path must be less than 104 bytes
```

Shortened unnecessary info from paths while still ensuring they're unique.

**Before:**
`/Users/jenkins/minikube-integration/darwin-arm64-qemu2--15070-5426-113d61471aea8d1d728ca9022a145b9e97990c51/.minikube/machines/default-k8s-different-port-20221004103818-6060/monitor`
181 characters

**After:**
`/Users/jenkins/minikube-integration/15070-5426/.minikube/machines/default-k8s-diff-port-103818/monitor`
102 characters