### PR TITLE
Fix status taking a long time on docker driver

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -68,6 +68,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/notify"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/out/register"
+	"k8s.io/minikube/pkg/minikube/pause"
 	"k8s.io/minikube/pkg/minikube/reason"
 	"k8s.io/minikube/pkg/minikube/style"
 	pkgtrace "k8s.io/minikube/pkg/trace"
@@ -407,6 +408,8 @@ func startWithDriver(cmd *cobra.Command, starter node.Starter, existing *config.
 			}
 		}
 	}
+
+	pause.RemovePausedFile(starter.Runner)
 
 	return kubeconfig, nil
 }

--- a/pkg/minikube/bootstrapper/bsutil/kverify/api_server.go
+++ b/pkg/minikube/bootstrapper/bsutil/kverify/api_server.go
@@ -207,6 +207,7 @@ func APIServerStatus(cr command.Runner, hostname string, port int) (state.State,
 	return apiServerHealthz(hostname, port)
 }
 
+// nonFreezerServerStatus is the alternative flow if the guest does not have the freezer cgroup so different methods to detect the apiserver status are used
 func nonFreezerServerStatus(cr command.Runner, hostname string, port int) (state.State, error) {
 	rr, err := cr.RunCmd(exec.Command("ls"))
 	if err != nil {

--- a/pkg/minikube/bootstrapper/bsutil/kverify/api_server.go
+++ b/pkg/minikube/bootstrapper/bsutil/kverify/api_server.go
@@ -174,7 +174,7 @@ func APIServerStatus(cr command.Runner, hostname string, port int) (state.State,
 	rr, err := cr.RunCmd(exec.Command("sudo", "egrep", "^[0-9]+:freezer:", fmt.Sprintf("/proc/%d/cgroup", pid)))
 	if err != nil {
 		klog.Warningf("unable to find freezer cgroup: %v", err)
-		return apiServerHealthz(hostname, port)
+		return nonFreezerServerStatus(cr, hostname, port)
 
 	}
 	freezer := strings.TrimSpace(rr.Stdout.String())
@@ -182,7 +182,7 @@ func APIServerStatus(cr command.Runner, hostname string, port int) (state.State,
 	fparts := strings.Split(freezer, ":")
 	if len(fparts) != 3 {
 		klog.Warningf("unable to parse freezer - found %d parts: %s", len(fparts), freezer)
-		return apiServerHealthz(hostname, port)
+		return nonFreezerServerStatus(cr, hostname, port)
 	}
 
 	rr, err = cr.RunCmd(exec.Command("sudo", "cat", path.Join("/sys/fs/cgroup/freezer", fparts[2], "freezer.state")))
@@ -196,12 +196,23 @@ func APIServerStatus(cr command.Runner, hostname string, port int) (state.State,
 			klog.Warningf("unable to get freezer state: %s", rr.Stderr.String())
 		}
 
-		return apiServerHealthz(hostname, port)
+		return nonFreezerServerStatus(cr, hostname, port)
 	}
 
 	fs := strings.TrimSpace(rr.Stdout.String())
 	klog.Infof("freezer state: %q", fs)
 	if fs == "FREEZING" || fs == "FROZEN" {
+		return state.Paused, nil
+	}
+	return apiServerHealthz(hostname, port)
+}
+
+func nonFreezerServerStatus(cr command.Runner, hostname string, port int) (state.State, error) {
+	rr, err := cr.RunCmd(exec.Command("ls"))
+	if err != nil {
+		return state.None, err
+	}
+	if strings.Contains(rr.Stdout.String(), "paused") {
 		return state.Paused, nil
 	}
 	return apiServerHealthz(hostname, port)

--- a/pkg/minikube/pause/pause.go
+++ b/pkg/minikube/pause/pause.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2022 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pause
+
+import (
+	"os/exec"
+
+	"k8s.io/klog/v2"
+	"k8s.io/minikube/pkg/minikube/command"
+)
+
+const pausedFile = "paused"
+
+// CreatePausedFile creates a file in the minikube cluster to indicate that the apiserver is paused
+func CreatePausedFile(r command.Runner) {
+	if _, err := r.RunCmd(exec.Command("touch", pausedFile)); err != nil {
+		klog.Errorf("failed to create paused file, apiserver may display incorrect status")
+	}
+}
+
+// RemovePausedFile removes a file in minikube cluster to indicate that the apiserver is unpaused
+func RemovePausedFile(r command.Runner) {
+	if _, err := r.RunCmd(exec.Command("rm", "-f", pausedFile)); err != nil {
+		klog.Errorf("failed to remove paused file, apiserver may display incorrect status")
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/15076

**Problem:**
While using the docker driver, `minikube status` when the apiserver was paused took 16 seconds, and would incorrectly report that the apiserver was `Stopped`. This is due to Kicbase not having the freezer cgroup and and falling back to HTTP calls, which all fail since the apiserver is paused, so after numerous retries it reports that the apiserver is `Stopped`.

**Solution:**
When the user pauses the `kube-system` namespace create a file in the cluster to indicate that the apiserver is paused. When the user unpauses the `kube-system` namespace the file is deleted. When checking the status if freezer is not on the system it looks for the file and if it's found it reports back that the apiserver is paused, otherwise if does the existing HTTP calls.

**Before:**
`minikube status` while apiserver is paused takes 16 seconds and apiserver status is `Stopped` (wrong).
```
$ time minikube status
minikube
type: Control Plane
host: Running
kubelet: Stopped
apiserver: Stopped
kubeconfig: Configured


real	0m15.906s
```

**After:**
`minikube status` while apiserver is paused takes 0.5 seconds and apiserver status is `Paused` (correct).
```
$ time minikube status
minikube
type: Control Plane
host: Running
kubelet: Stopped
apiserver: Paused
kubeconfig: Configured


real	0m0.517s
```

**Result: 97% time reduction in `minikube status` command while now reporting the correct status.**