### PR TITLE
fix: quit minikube service when there is no available pods

### DIFF
--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -148,6 +148,10 @@ You may select another namespace by using 'minikube service {{.service}} -n <nam
 					out.String(fmt.Sprintf("%s\n", serviceURLs))
 				}
 			}
+			// check whether all pods of this service is crashed
+			if err := service.CheckServicePods(cname, svc.Name, namespace); err != nil {
+				exit.Error(reason.SvcUnreachable, "service not available", err)
+			}
 		}
 
 		if driver.NeedsPortForward(co.Config.Driver) && services != nil {

--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -148,7 +148,7 @@ You may select another namespace by using 'minikube service {{.service}} -n <nam
 					out.String(fmt.Sprintf("%s\n", serviceURLs))
 				}
 			}
-			// check whether all pods of this service is crashed
+			// check whether there are running pods for this service
 			if err := service.CheckServicePods(cname, svc.Name, namespace); err != nil {
 				exit.Error(reason.SvcUnreachable, "service not available", err)
 			}

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -423,7 +423,7 @@ var (
 	SvcCheckTimeout = Kind{ID: "SVC_CHECK_TIMEOUT", ExitCode: ExSvcTimeout}
 	// minikube was unable to access a service
 	SvcTimeout = Kind{ID: "SVC_TIMEOUT", ExitCode: ExSvcTimeout}
-	// minikube finds that the service has not available pods
+	// minikube found that the service has no available pods
 	SvcUnreachable = Kind{ID: "SVC_UNREACHABLE", ExitCode: ExSvcNotFound}
 	// minikube failed to list services for the specified namespace
 	SvcList = Kind{ID: "SVC_LIST", ExitCode: ExSvcError}

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -423,6 +423,8 @@ var (
 	SvcCheckTimeout = Kind{ID: "SVC_CHECK_TIMEOUT", ExitCode: ExSvcTimeout}
 	// minikube was unable to access a service
 	SvcTimeout = Kind{ID: "SVC_TIMEOUT", ExitCode: ExSvcTimeout}
+	// minikube finds that the service has not available pods
+	SvcUnreachable = Kind{ID: "SVC_UNREACHABLE", ExitCode: ExSvcNotFound}
 	// minikube failed to list services for the specified namespace
 	SvcList = Kind{ID: "SVC_LIST", ExitCode: ExSvcError}
 	// minikube failed to start a tunnel

--- a/site/content/en/docs/contrib/tests.en.md
+++ b/site/content/en/docs/contrib/tests.en.md
@@ -697,6 +697,9 @@ verifies that minikube pause works
 ## TestInsufficientStorage
 makes sure minikube status displays the correct info if there is insufficient disk space on the machine
 
+## TestInvalidService
+makes sure minikube will not start a tunnel for a unavailable service who has no running pods
+
 ## TestRunningBinaryUpgrade
 upgrades a running legacy cluster to minikube at HEAD
 

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -2315,6 +2315,9 @@ func validateInvalidService(ctx context.Context, t *testing.T, profile string) {
 
 	// try to start an invalid service. This service is linked to a pod whose image name is invalid, so this pod will never become running
 	rrApply, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "apply", "-f", filepath.Join(*testdataDir, "invalidsvc.yaml")))
+	if err != nil {
+		t.Fatalf("%s failed: %v", rrApply.Command(), err)
+	}
 	defer func() {
 		// Cleanup test configurations in advance of future tests
 		rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "delete", "-f", filepath.Join(*testdataDir, "invalidsvc.yaml")))
@@ -2322,9 +2325,6 @@ func validateInvalidService(ctx context.Context, t *testing.T, profile string) {
 			t.Fatalf("clean up %s failed: %v", rr.Command(), err)
 		}
 	}()
-	if err != nil {
-		t.Fatalf("%s failed: %v", rrApply.Command(), err)
-	}
 	time.Sleep(3 * time.Second)
 
 	// try to expose a service, this action is supposed to fail

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -106,6 +106,7 @@ func TestFunctional(t *testing.T) {
 			{"ComponentHealth", validateComponentHealth},
 			{"LogsCmd", validateLogsCmd},
 			{"LogsFileCmd", validateLogsFileCmd},
+			{"InvalidService", validateInvalidService},
 		}
 		for _, tc := range tests {
 			tc := tc
@@ -2306,5 +2307,29 @@ func validateLicenseCmd(ctx context.Context, t *testing.T, _ string) {
 	expectedString := "Apache License"
 	if !strings.Contains(string(data), expectedString) {
 		t.Errorf("expected license file to contain %q, but was not found", expectedString)
+	}
+}
+
+// validateInvalidService makes sure minikube will not start a tunnel for an unavailable service that has no running pods
+func validateInvalidService(ctx context.Context, t *testing.T, profile string) {
+
+	// try to start an invalid service. This service is linked to a pod whose image name is invalid, so this pod will never become running
+	rrApply, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "apply", "-f", filepath.Join(*testdataDir, "invalidsvc.yaml")))
+	defer func() {
+		// Cleanup test configurations in advance of future tests
+		rr, err := Run(t, exec.CommandContext(ctx, "kubectl", "--context", profile, "delete", "-f", filepath.Join(*testdataDir, "invalidsvc.yaml")))
+		if err != nil {
+			t.Fatalf("clean up %s failed: %v", rr.Command(), err)
+		}
+	}()
+	if err != nil {
+		t.Fatalf("%s failed: %v", rrApply.Command(), err)
+	}
+	time.Sleep(3 * time.Second)
+
+	// try to expose a service, this action is supposed to fail
+	rrService, err := Run(t, exec.CommandContext(context.TODO(), Target(), "service", "invalid-svc", "-p", profile))
+	if err == nil || rrService.ExitCode == 0 {
+		t.Fatalf("%s should have failed: ", rrService.Command())
 	}
 }

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -2328,7 +2328,7 @@ func validateInvalidService(ctx context.Context, t *testing.T, profile string) {
 	time.Sleep(3 * time.Second)
 
 	// try to expose a service, this action is supposed to fail
-	rrService, err := Run(t, exec.CommandContext(context.TODO(), Target(), "service", "invalid-svc", "-p", profile))
+	rrService, err := Run(t, exec.CommandContext(ctx, Target(), "service", "invalid-svc", "-p", profile))
 	if err == nil || rrService.ExitCode == 0 {
 		t.Fatalf("%s should have failed: ", rrService.Command())
 	}

--- a/test/integration/testdata/invalidsvc.yaml
+++ b/test/integration/testdata/invalidsvc.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    run: invalid-svc
+  name: invalid-svc
+  namespace: default
+spec:
+  containers:
+  - name: nginx
+    image: nonexistingimage:latest
+    ports:
+    - containerPort: 80
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    run: invalid-svc
+  name: invalid-svc
+  namespace: default
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    run: invalid-svc
+  sessionAffinity: None
+  type: NodePort

--- a/translations/de.json
+++ b/translations/de.json
@@ -953,6 +953,7 @@
 	"dry-run mode. Validates configuration, but does not mutate system state": "dry-run Modus. Validiert die Konfiguration, aber ändert den System Zustand nicht",
 	"dry-run validation complete!": "dry-run Validierung komplett!",
 	"enable failed": "aktivieren fehlgeschlagen",
+	"error checking service": "",
 	"error creating clientset": "Fehler beim Anlegen des Clientsets",
 	"error creating urls": "",
 	"error getting defaults: {{.error}}": "",

--- a/translations/es.json
+++ b/translations/es.json
@@ -951,6 +951,7 @@
 	"dry-run mode. Validates configuration, but does not mutate system state": "",
 	"dry-run validation complete!": "",
 	"enable failed": "",
+	"error checking service": "",
 	"error creating clientset": "",
 	"error creating urls": "",
 	"error getting defaults: {{.error}}": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -934,6 +934,7 @@
 	"dry-run mode. Validates configuration, but does not mutate system state": "mode simulation. Valide la configuration, mais ne modifie pas l'état du système",
 	"dry-run validation complete!": "validation de la simulation terminée !",
 	"enable failed": "échec de l'activation",
+	"error checking service": "",
 	"error creating clientset": "erreur lors de la création de l'ensemble de clients",
 	"error creating urls": "erreur lors de la création d'urls",
 	"error getting defaults: {{.error}}": "erreur lors de l'obtention des valeurs par défaut : {{.error}}",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -893,6 +893,7 @@
 	"dry-run mode. Validates configuration, but does not mutate system state": "dry-run モード。設定は検証しますが、システムの状態は変更しません",
 	"dry-run validation complete!": "dry-run の検証が終了しました！",
 	"enable failed": "有効化に失敗しました",
+	"error checking service": "",
 	"error creating clientset": "clientset 作成中にエラー",
 	"error creating urls": "URL 作成でエラー",
 	"error getting defaults: {{.error}}": "デフォルト取得中にエラー: {{.error}}",

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -953,6 +953,7 @@
 	"dry-run mode. Validates configuration, but does not mutate system state": "",
 	"dry-run validation complete!": "dry-run 검증 완료!",
 	"enable failed": "활성화가 실패하였습니다",
+	"error checking service": "",
 	"error creating clientset": "clientset 생성 오류",
 	"error creating machine client": "머신 client 생성 오류",
 	"error creating urls": "",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -963,6 +963,7 @@
 	"dry-run mode. Validates configuration, but does not mutate system state": "",
 	"dry-run validation complete!": "",
 	"enable failed": "",
+	"error checking service": "",
 	"error creating clientset": "",
 	"error creating urls": "",
 	"error getting defaults: {{.error}}": "",

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -883,6 +883,7 @@
 	"dry-run mode. Validates configuration, but does not mutate system state": "",
 	"dry-run validation complete!": "",
 	"enable failed": "",
+	"error checking service": "",
 	"error creating clientset": "",
 	"error creating urls": "",
 	"error getting defaults: {{.error}}": "",

--- a/translations/strings.txt
+++ b/translations/strings.txt
@@ -883,6 +883,7 @@
 	"dry-run mode. Validates configuration, but does not mutate system state": "",
 	"dry-run validation complete!": "",
 	"enable failed": "",
+	"error checking service": "",
 	"error creating clientset": "",
 	"error creating urls": "",
 	"error getting defaults: {{.error}}": "",

--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -1071,6 +1071,7 @@
 	"dry-run mode. Validates configuration, but does not mutate system state": "",
 	"dry-run validation complete!": "",
 	"enable failed": "开启失败",
+	"error checking service": "",
 	"error creating clientset": "",
 	"error creating urls": "",
 	"error getting defaults: {{.error}}": "",


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
fixes #14592 
When we try to run a deployment who is using a container which crashes immediately(thus no pods will be available), and then try to use minikube service to open a tunnel for it

**Before:** 
```
minikube service hello-minikube
|-----------|----------------|-------------|---------------------------|
| NAMESPACE |      NAME      | TARGET PORT |            URL            |
|-----------|----------------|-------------|---------------------------|
| default   | hello-minikube |        8080 | http://192.168.49.2:31325 |
|-----------|----------------|-------------|---------------------------|
🏃  Starting tunnel for service hello-minikube.
|-----------|----------------|-------------|------------------------|
| NAMESPACE |      NAME      | TARGET PORT |          URL           |
|-----------|----------------|-------------|------------------------|
| default   | hello-minikube |             | http://127.0.0.1:62242 |
|-----------|----------------|-------------|------------------------|
🎉  Opening service default/hello-minikube in default browser...
```
service will be exposed, although it cannot be visited.

**After**

Now if the service has no running pods, output will be like this
```
wsl@win10pc:~/workspace/minikube-fork/out$ ./minikube service bad-node
|-----------|----------|-------------|---------------------------|
| NAMESPACE |   NAME   | TARGET PORT |            URL            |
|-----------|----------|-------------|---------------------------|
| default   | bad-node |        8080 | http://192.168.49.2:32262 |
|-----------|----------|-------------|---------------------------|

❌  Exiting due to SVC_TUNNEL_START: no valid pod for service bad-node found
```
