### PR TITLE
site: change wording for memory change

### DIFF
--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -605,10 +605,10 @@ Halt the cluster:
 minikube stop
 ```
 
-Increase the default memory limit (requires a restart):
+Change the default memory limit (requires a restart):
 
 ```shell
-minikube config set memory 16384
+minikube config set memory 9001
 ```
 
 Browse the catalog of easily installed Kubernetes services:


### PR DESCRIPTION
I am using  minikube in a environment with limited  memory (a VM)

The start guide shows the use of this command:

`minikube config set memory 16384`

Which returns a Docker error since only 16001 of memory could be reserved.

If we reframe the intent slightly to show how to *change* the default memory limit, as opposed to *increasing* it then the proposed change will still convey the same info. In addition, those with limited memory will be less likely to encounter this error.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
