### PR TITLE
CI: Stop killing docker process

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -270,10 +270,14 @@ function cleanup_procs() {
   # cleaning up stale hyperkits
   if type -P hyperkit; then
     for pid in $(pgrep hyperkit); do
+      info=$(ps -f -p "$pid")
+      if [[ $info == *"com.docker.hyperkit"* ]]; then
+        continue
+      fi
       echo "Killing stale hyperkit $pid"
-      ps -f -p $pid || true
-      kill $pid || true
-      kill -9 $pid || true
+      echo "$info" || true
+      kill "$pid" || true
+      kill -9 "$pid" || true
     done
   fi
 


### PR DESCRIPTION
**Problem:**
The test `TestDownloadOnly/v1.16.0/preload-exists` was failing 100% of the time on macOS. I tried reproducing locally on my machine but the test always passed. I looked into the test output for `TestDownloadOnly/v1.16.0/json-events` and saw the log `docker version returned error: exit status 1`. This would normally fail the test, but because `--force` is passed into the start args the start operation continues and the test ends up passing. The log indicates that Docker Desktop on the host is not running, but we have multiple lines before that output the Docker version successfully.

**Cause:**
I found the root of the cause is `Killing stale hyperkit 22779`, we clean up any stale HyperKit processes, however Docker Desktop has its own HyperKit process, so we end up killing it, which causes Docker Desktop to restart, and it isn't finished restarting by the time the testing starts.

**Solution:**
Skip killing processes that have `com.docker.hyperkit` in them.

**Docker HyperKit process:**
```
  UID   PID  PPID   C STIME   TTY           TIME CMD
810883 84154 84128   0  2:52PM ??         0:32.06 com.docker.hyperkit
```

**minikube Hyperkit process:**
```
  UID   PID  PPID   C STIME   TTY           TIME CMD
    0 85210     1   0  2:55PM ttys000    6:08.83 /usr/local/bin/hyperkit
```

