### PR TITLE
Add 'qemu' to list of issue template drivers

### DIFF
--- a/.github/ISSUE_TEMPLATE/__en-US.yaml
+++ b/.github/ISSUE_TEMPLATE/__en-US.yaml
@@ -49,6 +49,6 @@ body:
         - SSH
         - VMware
         - Parallels
-        - Qemu
+        - QEMU
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/__en-US.yaml
+++ b/.github/ISSUE_TEMPLATE/__en-US.yaml
@@ -49,5 +49,6 @@ body:
         - SSH
         - VMware
         - Parallels
+        - Qemu
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/ru.yaml
+++ b/.github/ISSUE_TEMPLATE/ru.yaml
@@ -47,6 +47,6 @@ body:
         - SSH
         - VMware
         - Parallels
-        - Qemu
+        - QEMU
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/ru.yaml
+++ b/.github/ISSUE_TEMPLATE/ru.yaml
@@ -47,5 +47,6 @@ body:
         - SSH
         - VMware
         - Parallels
+        - Qemu
     validations:
       required: false


### PR DESCRIPTION
Fixes: #15111

Adds an additional network driver 'Qemu' to the valid list of Drivers used in creating a new issue.

Only EN and RU templates use the driver dropdown.

**Before:**

![Screen Shot 2022-10-11 at 16 05 56](https://user-images.githubusercontent.com/93291761/195214258-58b47774-71c6-40d5-aa22-69b76d2f1880.png)

**After:**

Same as above but with `Qemu` as a drop down option.