### PR TITLE
Github Template: Advise users of delay in triaging issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/__en-US.yaml
+++ b/.github/ISSUE_TEMPLATE/__en-US.yaml
@@ -1,6 +1,10 @@
 name: English
 description: Report an issue
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file an issue. It may take awhile for the community to respond. Please visit [Triaging Minikube Issues](https://minikube.sigs.k8s.io/docs/contrib/triage/) if you would like to contribute.
   - type: textarea
     id: problem
     attributes:

--- a/.github/ISSUE_TEMPLATE/__en-US.yaml
+++ b/.github/ISSUE_TEMPLATE/__en-US.yaml
@@ -4,7 +4,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to file an issue. It may take awhile for the community to respond. Please visit [Triaging Minikube Issues](https://minikube.sigs.k8s.io/docs/contrib/triage/) if you would like to contribute.
+
+        [//]: # (Thanks for taking the time to file an issue. It may take awhile for the community to respond. Please visit [Triaging Minikube Issues](https://minikube.sigs.k8s.io/docs/contrib/triage/) if you would like to contribute.)
+        
   - type: textarea
     id: problem
     attributes:


### PR DESCRIPTION
Fixes: #15064

Creates a text section at the top of the EN issue template advising the user about delays in triaging issues, with a link to the minikube triage webpage.