### PR TITLE
Site: add a note for default profile name in Docker Desktop Replacement doc

### DIFF
--- a/site/content/en/docs/tutorials/docker_desktop_replacement.md
+++ b/site/content/en/docs/tutorials/docker_desktop_replacement.md
@@ -87,32 +87,32 @@ minikube start --container-runtime=docker --vm=true
 <h2 class="step"><span class="fa-stack fa-1x"><i class="fa fa-circle fa-stack-2x"></i><strong class="fa-stack-1x text-primary">3</strong></span>Point Docker CLI to minikube</h2>
 Use the `minikube docker-env` command to point your terminal's Docker CLI to the Docker instance inside minikube.
 
-<br>Note: the default minikube profile name is "minikube".
+<br>Note: if you are using a different profile name than default (minikube) you can pass it by -p.
 
 {{% tabs %}}
 {{% tab "bash/zsh" %}}
 ```
-eval $(minikube -p <profile> docker-env)
+eval $(minikube docker-env)
 ```
 {{% /tab %}}
 {{% tab PowerShell %}}
 ```
-& minikube -p <profile> docker-env --shell powershell | Invoke-Expression
+& minikube docker-env --shell powershell | Invoke-Expression
 ```
 {{% /tab %}}
 {{% tab cmd %}}
 ```
-@FOR /f "tokens=*" %i IN ('minikube -p <profile> docker-env --shell cmd') DO @%i
+@FOR /f "tokens=*" %i IN ('minikube docker-env --shell cmd') DO @%i
 ```
 {{% /tab %}}
 {{% tab fish %}}
 ```
-minikube -p <profile> docker-env | source
+minikube docker-env | source
 ```
 {{% /tab %}}
 {{% tab tcsh %}}
 ```
-eval `minikube -p <profile> docker-env`
+eval `minikube docker-env`
 ```
 {{% /tab %}}
 {{% /tabs %}}

--- a/site/content/en/docs/tutorials/docker_desktop_replacement.md
+++ b/site/content/en/docs/tutorials/docker_desktop_replacement.md
@@ -87,7 +87,7 @@ minikube start --container-runtime=docker --vm=true
 <h2 class="step"><span class="fa-stack fa-1x"><i class="fa fa-circle fa-stack-2x"></i><strong class="fa-stack-1x text-primary">3</strong></span>Point Docker CLI to minikube</h2>
 Use the `minikube docker-env` command to point your terminal's Docker CLI to the Docker instance inside minikube.
 
-<br>Note: the default minikube profile name is "default".
+<br>Note: the default minikube profile name is "minikube".
 
 {{% tabs %}}
 {{% tab "bash/zsh" %}}

--- a/site/content/en/docs/tutorials/docker_desktop_replacement.md
+++ b/site/content/en/docs/tutorials/docker_desktop_replacement.md
@@ -87,6 +87,8 @@ minikube start --container-runtime=docker --vm=true
 <h2 class="step"><span class="fa-stack fa-1x"><i class="fa fa-circle fa-stack-2x"></i><strong class="fa-stack-1x text-primary">3</strong></span>Point Docker CLI to minikube</h2>
 Use the `minikube docker-env` command to point your terminal's Docker CLI to the Docker instance inside minikube.
 
+<br>Note: the default minikube profile name is "default".
+
 {{% tabs %}}
 {{% tab "bash/zsh" %}}
 ```


### PR DESCRIPTION
Fixes: #14946

Per request, added a note to indicate the default profile name, which will help first-time users of minikube.

**Before:**
![Screen Shot 2022-10-11 at 16 54 45](https://user-images.githubusercontent.com/93291761/195219103-cc3258fe-32aa-4382-9a3e-6fa0496a87cd.png)

**After:**
![Screen Shot 2022-10-12 at 17 34 13](https://user-images.githubusercontent.com/93291761/195472359-86735ed7-e6ec-400f-9dc8-332f89a2e5be.png)

