### PR TITLE
Site: improve HyperKit doc to update requirements and installation

### DIFF
--- a/site/content/en/docs/drivers/includes/hyperkit_usage.inc
+++ b/site/content/en/docs/drivers/includes/hyperkit_usage.inc
@@ -6,7 +6,9 @@
 
 ## HyperKit installation
 
-* With [Brew Package Manager](https://formulae.brew.sh/formula/hyperkit#default), run:
+* minikube will automatically download HyperKit if not found on the host.
+
+* To manually install with [Brew Package Manager](https://formulae.brew.sh/formula/hyperkit#default), run:
 
 ```shell
 brew install hyperkit

--- a/site/content/en/docs/drivers/includes/hyperkit_usage.inc
+++ b/site/content/en/docs/drivers/includes/hyperkit_usage.inc
@@ -1,18 +1,18 @@
 ## Requirements
 
-- macOS 10.11+
+- macOS 10.11+, darwin/x86_64
+  - Note: no support for arm64.
 - HyperKit
 
 ## HyperKit installation
 
-* If Docker for Desktop is installed, you already have HyperKit
-* Otherwise, if you have [Brew Package Manager](https://brew.sh/), run:
+* With [Brew Package Manager](https://formulae.brew.sh/formula/hyperkit#default), run:
 
 ```shell
 brew install hyperkit
 ```
 
-* As a final alternative, you may [Install HyperKit from GitHub](https://github.com/moby/hyperkit)
+* Else, [Install HyperKit from GitHub](https://github.com/moby/hyperkit).
 
 ## Usage
 


### PR DESCRIPTION
Fixes: #14747

Fixes: #13562

- Add note on regarding lack of arm64 support for HyperKit.
- Remove note on Docker Desktop installing HyperKit
- Add note on minikube automatically installing HyperKit if not found.

**Before:**
![Screen Shot 2022-10-12 at 18 11 18](https://user-images.githubusercontent.com/93291761/195475984-3d315d54-3209-4946-84b4-db2467b9928b.png)

**After:**
![Screen Shot 2022-10-12 at 18 11 36](https://user-images.githubusercontent.com/93291761/195476009-7e1d86cd-fce4-4bf5-9756-d131a491445d.png)
