### PR TITLE
Enable Parallels driver on darwin arm64

### DIFF
--- a/pkg/minikube/driver/driver_darwin.go
+++ b/pkg/minikube/driver/driver_darwin.go
@@ -31,6 +31,7 @@ var supportedDrivers = func() []string {
 			Docker,
 			Podman,
 			SSH,
+			Parallels,
 		}
 	}
 	// PowerPC does not support podman


### PR DESCRIPTION
Creating a PR so a user can test the Parallels driver on darwin arm64. If it works successfully we can merge the PR.