### PR TITLE
Find gateway ip from lima

### DIFF
--- a/pkg/drivers/kic/oci/network.go
+++ b/pkg/drivers/kic/oci/network.go
@@ -81,7 +81,7 @@ func RoutableHostIPFromInside(ociBin string, clusterName string, containerName s
 	if runtime.GOOS == "linux" {
 		return containerGatewayIP(ociBin, containerName)
 	}
-	// try lima host record
+	// on macos, try lima host record
 	if runtime.GOOS == "darwin" {
 		gatewayIP, err :=  digDNS(ociBin, containerName, "host.lima.internal")
 		if err != nil {

--- a/pkg/drivers/kic/oci/network.go
+++ b/pkg/drivers/kic/oci/network.go
@@ -82,13 +82,15 @@ func RoutableHostIPFromInside(ociBin string, clusterName string, containerName s
 		return containerGatewayIP(ociBin, containerName)
 	}
 	// try lima host record
-	gatewayIP, err :=  digDNS(ociBin, containerName, "host.lima.internal")
-	if err != nil {
-		return nil, errors.Wrap(err, "get lima name")
-	}
-	if gatewayIP != nil {
-		klog.Infof("Will use the following gateway IP: %s (ociBin: %s, GOOS: %s)", gatewayIP, ociBin, runtime.GOOS)
-		return gatewayIP, nil
+	if runtime.GOOS == "darwin" {
+		gatewayIP, err :=  digDNS(ociBin, containerName, "host.lima.internal")
+		if err != nil {
+			return nil, errors.Wrap(err, "get gateway ip from lima host name")
+		}
+		if gatewayIP != nil {
+			klog.Infof("Will use the following gateway IP: %s (ociBin: %s, GOOS: %s)", gatewayIP, ociBin, runtime.GOOS)
+			return gatewayIP, nil
+		}	
 	}
 
 	return nil, fmt.Errorf("RoutableHostIPFromInside is currently only implemented for linux")

--- a/pkg/drivers/kic/oci/network.go
+++ b/pkg/drivers/kic/oci/network.go
@@ -88,7 +88,6 @@ func RoutableHostIPFromInside(ociBin string, clusterName string, containerName s
 			return nil, errors.Wrap(err, "get gateway ip from lima host name")
 		}
 		if gatewayIP != nil {
-			klog.Infof("Will use the following gateway IP: %s (ociBin: %s, GOOS: %s)", gatewayIP, ociBin, runtime.GOOS)
 			return gatewayIP, nil
 		}	
 	}

--- a/pkg/drivers/kic/oci/network.go
+++ b/pkg/drivers/kic/oci/network.go
@@ -81,6 +81,15 @@ func RoutableHostIPFromInside(ociBin string, clusterName string, containerName s
 	if runtime.GOOS == "linux" {
 		return containerGatewayIP(ociBin, containerName)
 	}
+	// try lima host record
+	gatewayIP, err :=  digDNS(ociBin, containerName, "host.lima.internal")
+	if err != nil {
+		return nil, errors.Wrap(err, "get lima name")
+	}
+	if gatewayIP != nil {
+		klog.Infof("Will use the following gateway IP: %s (ociBin: %s, GOOS: %s)", gatewayIP, ociBin, runtime.GOOS)
+		return gatewayIP, nil
+	}
 
 	return nil, fmt.Errorf("RoutableHostIPFromInside is currently only implemented for linux")
 }

--- a/pkg/minikube/cni/cilium.go
+++ b/pkg/minikube/cni/cilium.go
@@ -129,10 +129,10 @@ data:
   sidecar-istio-proxy-image: "cilium/istio_proxy"
 
   # Name of the cluster. Only relevant when building a mesh of clusters.
-  cluster-name: default
+  cluster-name: cluster
   # Unique ID of the cluster. Must be unique across all conneted clusters and
   # in the range of 1 and 255. Only relevant when building a mesh of clusters.
-  cluster-id: ""
+  cluster-id: "1"
 
   # Encapsulation mode for communication between nodes
   # Possible values:
@@ -299,6 +299,22 @@ rules:
   - list
   - watch
   - delete
+  - apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  # To remove node taints
+  - nodes
+  # To set NetworkUnavailable false on startup
+  - nodes/status
+  verbs:
+  - patch
 - apiGroups:
   - discovery.k8s.io
   resources:
@@ -444,7 +460,7 @@ spec:
           httpGet:
             host: '127.0.0.1'
             path: /healthz
-            port: 9876
+            port: 9879
             scheme: HTTP
             httpHeaders:
             - name: "brief"
@@ -461,7 +477,7 @@ spec:
           httpGet:
             host: '127.0.0.1'
             path: /healthz
-            port: 9876
+            port: 9879
             scheme: HTTP
             httpHeaders:
             - name: "brief"
@@ -508,7 +524,7 @@ spec:
               key: custom-cni-conf
               name: cilium-config
               optional: true
-        image: "quay.io/cilium/cilium:v1.9.9@sha256:a85d5cff13f8231c2e267d9fc3c6e43d24be4a75dac9f641c11ec46e7f17624d"
+        image: "quay.io/cilium/cilium:v1.12.3@sha256:30de50c4dc0a1e1077e9e7917a54d5cab253058b3f779822aec00f5c817ca826"
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -570,7 +586,7 @@ spec:
           # same directory where we install cilium cni plugin so that exec permissions
           # are available.
           - 'cp /usr/bin/cilium-mount /hostbin/cilium-mount && nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT; rm /hostbin/cilium-mount'
-        image: "quay.io/cilium/cilium:v1.9.9@sha256:a85d5cff13f8231c2e267d9fc3c6e43d24be4a75dac9f641c11ec46e7f17624d"
+        image: "quay.io/cilium/cilium:v1.12.3@sha256:30de50c4dc0a1e1077e9e7917a54d5cab253058b3f779822aec00f5c817ca826"
         imagePullPolicy: IfNotPresent
         volumeMounts:
           - mountPath: /hostproc
@@ -600,7 +616,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: "quay.io/cilium/cilium:v1.9.9@sha256:a85d5cff13f8231c2e267d9fc3c6e43d24be4a75dac9f641c11ec46e7f17624d"
+        image: "quay.io/cilium/cilium:v1.12.3@sha256:30de50c4dc0a1e1077e9e7917a54d5cab253058b3f779822aec00f5c817ca826"
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -762,7 +778,7 @@ spec:
               key: debug
               name: cilium-config
               optional: true
-        image: "quay.io/cilium/operator-generic:v1.9.9@sha256:3726a965cd960295ca3c5e7f2b543c02096c0912c6652eb8bbb9ce54bcaa99d8"
+        image: "quay.io/cilium/operator-generic:v1.12.3@sha256:816ec1da586139b595eeb31932c61a7c13b07fb4a0255341c0e0f18608e84eff"
         imagePullPolicy: IfNotPresent
         name: cilium-operator
         livenessProbe:


### PR DESCRIPTION
# Context

When installing minikube on MacOS on a VM built with [lima-vm/lima: Linux virtual machines, typically on macOS, for running containerd](https://github.com/lima-vm/lima), minikube fails to find the gateway ip and complain about it:

```sh
./out/minikube -p miniforge start --rootless=false --container-runtime=containerd --cpus=4 --cni=cilium --disk-size=20000mb  --dns-domain=cluster.local --driver=podman --memory=7916m --nodes=1 
...
📦  Préparation de Kubernetes v1.25.3 sur containerd 1.6.9...
E1029 11:35:16.036962   77006 start.go:130] Unable to get host IP: RoutableHostIPFromInside is currently only implemented for linux
...
🏄  Terminé ! kubectl est maintenant configuré pour utiliser "miniforge" cluster et espace de noms "default" par défaut.
```

This PR add a lookup on the `host.lima.internal` record name to find the gateway for Darwin OSs, in a similar way it is done for `docker` hosts a few lines above in the code.

# Implementation

In `pkg/drivers/kic/oci/network.go`, if running under MacOS, get the gateway from the `host.lima.internal` record which is added for hosts provisioned by Lima VM (see: [`The host.lima.internal name is predefined to specify the gateway address to the host`](https://github.com/lima-vm/lima/blob/082576f99cb4fbb3844b69df21c2e13c65bd58be/examples/default.yaml#L344)).

The check on the name occur only for darwin OS as Lima is mostly use on them.
The check is not restricted to the podman driver because perhaps other drivers can make use of Qemu VM provisioned with Lima.

# Tests

This has been tested with a VM build with Lima v0.12.0, with the podman driver and minikube master.

After applying this patch, the startup text doesn't complain anymore about not finding the gateway ip.

At one point i added a debug statement which was shown in the logs:
```sh
$ minikube logs | grep ociBin
I1029 12:57:11.667710   82495 network.go:91] Will use the following gateway IP: 192.168.5.2 (ociBin: podman, GOOS: darwin)
```
