### PR TITLE
Revert setting snapshotter to fuse-overlayfs

### DIFF
--- a/deploy/kicbase/entrypoint
+++ b/deploy/kicbase/entrypoint
@@ -121,13 +121,13 @@ configure_containerd() {
       # if fuse is present, use fuse-overlayfs, else fallback to native
       # we do not use the ZFS snapshotter because of skew issues vs the host
       if [[ -e /dev/fuse ]]; then
-        snapshotter="fuse-overlayfs"
+        # snapshotter="fuse-overlayfs" skipping temporarily: https://github.com/kubernetes/minikube/issues/15191
       else
         snapshotter="native"
       fi
     # fuse likely implies fuse-overlayfs, we should switch to fuse-overlayfs (or native)
     elif [[ "$container_filesystem" == 'fuseblk' ]]; then
-      snapshotter="fuse-overlayfs"
+      # snapshotter="fuse-overlayfs" skipping temporarily: https://github.com/kubernetes/minikube/issues/15191
     fi
   fi
 

--- a/deploy/kicbase/entrypoint
+++ b/deploy/kicbase/entrypoint
@@ -118,16 +118,11 @@ configure_containerd() {
     # we need to switch to 'native' or 'fuse-overlayfs' on zfs
     container_filesystem="$(stat -f -c %T /kind)"
     if [[ "$container_filesystem" == 'zfs' ]]; then
-      # if fuse is present, use fuse-overlayfs, else fallback to native
       # we do not use the ZFS snapshotter because of skew issues vs the host
-      if [[ -e /dev/fuse ]]; then
-        # snapshotter="fuse-overlayfs" skipping temporarily: https://github.com/kubernetes/minikube/issues/15191
-      else
-        snapshotter="native"
-      fi
+      snapshotter="native"
     # fuse likely implies fuse-overlayfs, we should switch to fuse-overlayfs (or native)
-    elif [[ "$container_filesystem" == 'fuseblk' ]]; then
-      # snapshotter="fuse-overlayfs" skipping temporarily: https://github.com/kubernetes/minikube/issues/15191
+    # elif [[ "$container_filesystem" == 'fuseblk' ]]; then skipping temporarily: https://github.com/kubernetes/minikube/issues/15191
+    #  snapshotter="fuse-overlayfs"
     fi
   fi
 

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -24,10 +24,10 @@ import (
 
 const (
 	// Version is the current version of kic
-	Version = "v0.0.36-1668608737-15235"
+	Version = "v0.0.36-1668787669-15272"
 
 	// SHA of the kic base image
-	baseImageSHA = "471ca747fe53d13a0bc370cb0e5bc7d20f51d74c7a858907ffd6f321680cbfb8"
+	baseImageSHA = "06094fc04b5dc02fbf1e2de7723c2a6db5d24c21fd2ddda91f6daaf29038cd9c"
 	// The name of the GCR kicbase repository
 	gcrRepo = "gcr.io/k8s-minikube/kicbase-builds"
 	// The name of the Dockerhub kicbase repository

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -26,7 +26,7 @@ minikube start [flags]
       --apiserver-names strings           A set of apiserver names which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine
       --apiserver-port int                The apiserver listening port (default 8443)
       --auto-update-drivers               If set, automatically updates drivers to the latest version. Defaults to true. (default true)
-      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.36-1668608737-15235@sha256:471ca747fe53d13a0bc370cb0e5bc7d20f51d74c7a858907ffd6f321680cbfb8")
+      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.36-1668787669-15272@sha256:06094fc04b5dc02fbf1e2de7723c2a6db5d24c21fd2ddda91f6daaf29038cd9c")
       --binary-mirror string              Location to fetch kubectl, kubelet, & kubeadm binaries from.
       --cache-images                      If true, cache docker images for the current bootstrapper and load them into the machine. Always false with --driver=none. (default true)
       --cert-expiration duration          Duration until minikube certificate expiration, defaults to three years (26280h). (default 26280h0m0s)


### PR DESCRIPTION
Related https://github.com/kubernetes/minikube/issues/15191

We currently don't have `containerd-fuse-overlayfs` installed, so revert the changes in https://github.com/kubernetes/minikube/pull/15066 until it's installed.