### PR TITLE
Fixed typo uninstll on qemu workaround for /var/db/dhcpd_leases errors

### DIFF
--- a/site/content/en/docs/drivers/qemu.md
+++ b/site/content/en/docs/drivers/qemu.md
@@ -74,7 +74,6 @@ If you're seeing errors related to `/var/db/dhcpd_leases` we recommend the follo
 ```shell
 cd socket_vmnet
 sudo make uninstall
-sudo rm /var/run/socket_vmnet
 ```
 2. Reboot
 3. Reinsitall `socket_vmnet`:

--- a/site/content/en/docs/drivers/qemu.md
+++ b/site/content/en/docs/drivers/qemu.md
@@ -73,7 +73,7 @@ If you're seeing errors related to `/var/db/dhcpd_leases` we recommend the follo
 1. Uninstall `socket_vmnet`:
 ```shell
 cd socket_vmnet
-sudo make uninstll
+sudo make uninstall
 sudo rm /var/run/socket_vmnet
 ```
 2. Reboot


### PR DESCRIPTION
Fixing a typo while trying the workaround on m1 macbook

The make uninstall, already removes  `/var/run/socket_vmnet`
