### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/cmd/minikube/cmd/config/set_test.go
+++ b/cmd/minikube/cmd/config/set_test.go
@@ -68,9 +68,7 @@ func createTestConfig(t *testing.T) {
 	t.Helper()
 	td := t.TempDir()
 
-	if err := os.Setenv(localpath.MinikubeHome, td); err != nil {
-		t.Fatalf("error setting up test environment. could not set %s due to %+v", localpath.MinikubeHome, err)
-	}
+	t.Setenv(localpath.MinikubeHome, td)
 
 	// Not necessary, but it is a handy random alphanumeric
 	if err := os.MkdirAll(localpath.MakeMiniPath("config"), 0777); err != nil {

--- a/cmd/minikube/cmd/delete_test.go
+++ b/cmd/minikube/cmd/delete_test.go
@@ -86,9 +86,7 @@ func TestDeleteProfile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := os.Setenv(localpath.MinikubeHome, td); err != nil {
-				t.Errorf("setenv: %v", err)
-			}
+			t.Setenv(localpath.MinikubeHome, td)
 
 			beforeProfiles, err := fileNames(filepath.Join(localpath.MiniPath(), "profiles"))
 			if err != nil {
@@ -163,9 +161,7 @@ func TestDeleteAllProfiles(t *testing.T) {
 		t.Fatalf("copy: %v", err)
 	}
 
-	if err := os.Setenv(localpath.MinikubeHome, td); err != nil {
-		t.Errorf("error setting up test environment. could not set %s", localpath.MinikubeHome)
-	}
+	t.Setenv(localpath.MinikubeHome, td)
 
 	pFiles, err := fileNames(filepath.Join(localpath.MiniPath(), "profiles"))
 	if err != nil {

--- a/cmd/minikube/cmd/docker-env_test.go
+++ b/cmd/minikube/cmd/docker-env_test.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
-	"os"
 	"strings"
 	"testing"
 
@@ -443,7 +442,7 @@ func TestValidDockerProxy(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		os.Setenv("ALL_PROXY", tc.proxy)
+		t.Setenv("ALL_PROXY", tc.proxy)
 		valid := isValidDockerProxy("ALL_PROXY")
 		if tc.isValid && valid != tc.isValid {
 			t.Errorf("Expect %#v to be valid docker proxy", tc.proxy)

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -172,13 +171,6 @@ func TestGenerateCfgFromFlagsHTTPProxyHandling(t *testing.T) {
 	// Set default disk size value in lieu of flag init
 	viper.SetDefault(humanReadableDiskSize, defaultDiskSize)
 
-	originalEnv := os.Getenv("HTTP_PROXY")
-	defer func() {
-		err := os.Setenv("HTTP_PROXY", originalEnv)
-		if err != nil {
-			t.Fatalf("Error reverting env HTTP_PROXY to it's original value. Got err: %s", err)
-		}
-	}()
 	k8sVersion := constants.NewestKubernetesVersion
 	rtime := constants.DefaultContainerRuntime
 	var tests = []struct {
@@ -222,9 +214,7 @@ func TestGenerateCfgFromFlagsHTTPProxyHandling(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			cmd := &cobra.Command{}
-			if err := os.Setenv("HTTP_PROXY", test.proxy); err != nil {
-				t.Fatalf("Unexpected error setting HTTP_PROXY: %v", err)
-			}
+			t.Setenv("HTTP_PROXY", test.proxy)
 
 			cfg.DockerEnv = []string{} // clear docker env to avoid pollution
 			proxy.SetDockerEnv()

--- a/pkg/addons/addons_test.go
+++ b/pkg/addons/addons_test.go
@@ -32,9 +32,7 @@ func createTestProfile(t *testing.T) string {
 	t.Helper()
 	td := t.TempDir()
 
-	if err := os.Setenv(localpath.MinikubeHome, td); err != nil {
-		t.Errorf("error setting up test environment. could not set %s", localpath.MinikubeHome)
-	}
+	t.Setenv(localpath.MinikubeHome, td)
 
 	// Not necessary, but it is a handy random alphanumeric
 	name := filepath.Base(td)

--- a/pkg/drivers/kic/oci/oci_test.go
+++ b/pkg/drivers/kic/oci/oci_test.go
@@ -22,10 +22,10 @@ import (
 )
 
 func TestPointToHostDockerDaemonEmpty(t *testing.T) {
-	_ = os.Setenv("DOCKER_HOST", "foo_host")
-	_ = os.Setenv("DOCKER_CERT_PATH", "foo_cert_path")
-	_ = os.Setenv("DOCKER_TLS_VERIFY", "foo_tls_verify")
-	_ = os.Setenv("MINIKUBE_ACTIVE_DOCKERD", "minikube")
+	t.Setenv("DOCKER_HOST", "foo_host")
+	t.Setenv("DOCKER_CERT_PATH", "foo_cert_path")
+	t.Setenv("DOCKER_TLS_VERIFY", "foo_tls_verify")
+	t.Setenv("MINIKUBE_ACTIVE_DOCKERD", "minikube")
 
 	_ = os.Unsetenv("MINIKUBE_EXISTING_DOCKER_HOST")
 	_ = os.Unsetenv("MINIKUBE_EXISTING_DOCKER_CERT_PATH")
@@ -45,13 +45,14 @@ func TestPointToHostDockerDaemonEmpty(t *testing.T) {
 }
 
 func TestPointToHostDockerDaemon(t *testing.T) {
-	_ = os.Setenv("DOCKER_HOST", "foo_host")
-	_ = os.Setenv("DOCKER_CERT_PATH", "foo_cert_path")
-	_ = os.Setenv("DOCKER_TLS_VERIFY", "foo_tls_verify")
+	t.Setenv("DOCKER_HOST", "foo_host")
+	t.Setenv("DOCKER_CERT_PATH", "foo_cert_path")
+	t.Setenv("DOCKER_TLS_VERIFY", "foo_tls_verify")
+	t.Setenv("MINIKUBE_ACTIVE_DOCKERD", "minikube")
 
-	_ = os.Setenv("MINIKUBE_EXISTING_DOCKER_HOST", "bar_host")
-	_ = os.Setenv("MINIKUBE_EXISTING_DOCKER_CERT_PATH", "bar_cert_path")
-	_ = os.Setenv("MINIKUBE_EXISTING_DOCKER_TLS_VERIFY", "bar_tls_verify")
+	t.Setenv("MINIKUBE_EXISTING_DOCKER_HOST", "bar_host")
+	t.Setenv("MINIKUBE_EXISTING_DOCKER_CERT_PATH", "bar_cert_path")
+	t.Setenv("MINIKUBE_EXISTING_DOCKER_TLS_VERIFY", "bar_tls_verify")
 
 	if err := PointToHostDockerDaemon(); err != nil {
 		t.Fatalf("failed to set docker environment: got %v", err)
@@ -72,8 +73,8 @@ func TestPointToHostDockerDaemon(t *testing.T) {
 }
 
 func TestPointToHostPodmanEmpty(t *testing.T) {
-	_ = os.Setenv("CONTAINER_HOST", "foo_host")
-	_ = os.Setenv("MINIKUBE_ACTIVE_PODMAN", "minikube")
+	t.Setenv("CONTAINER_HOST", "foo_host")
+	t.Setenv("MINIKUBE_ACTIVE_PODMAN", "minikube")
 
 	_ = os.Unsetenv("MINIKUBE_EXISTING_CONTAINER_HOST")
 
@@ -91,9 +92,10 @@ func TestPointToHostPodmanEmpty(t *testing.T) {
 }
 
 func TestPointToHostPodman(t *testing.T) {
-	_ = os.Setenv("CONTAINER_HOST", "foo_host")
+	t.Setenv("CONTAINER_HOST", "foo_host")
+	t.Setenv("MINIKUBE_ACTIVE_PODMAN", "minikube")
 
-	_ = os.Setenv("MINIKUBE_EXISTING_CONTAINER_HOST", "bar_host")
+	t.Setenv("MINIKUBE_EXISTING_CONTAINER_HOST", "bar_host")
 
 	if err := PointToHostPodman(); err != nil {
 		t.Fatalf("failed to set podman environment: got %v", err)
@@ -130,8 +132,8 @@ func TestDaemonHost(t *testing.T) {
 		{"docker", "", "ssh://127.0.0.1/bar", "127.0.0.1", true},
 	}
 	for _, test := range tests {
-		_ = os.Setenv("CONTAINER_HOST", test.containerHost)
-		_ = os.Setenv("DOCKER_HOST", test.dockerHost)
+		t.Setenv("CONTAINER_HOST", test.containerHost)
+		t.Setenv("DOCKER_HOST", test.dockerHost)
 		if v := IsExternalDaemonHost(test.driver); v != test.expectedExternal {
 			t.Errorf("invalid result of IsExternalDaemonHost. got: %v, want: %v", v, test.expectedExternal)
 		}

--- a/pkg/minikube/kubeconfig/kubeconfig_test.go
+++ b/pkg/minikube/kubeconfig/kubeconfig_test.go
@@ -456,7 +456,7 @@ func TestUpdateIP(t *testing.T) {
 		},
 	}
 
-	os.Setenv(localpath.MinikubeHome, "/home/la-croix")
+	t.Setenv(localpath.MinikubeHome, "/home/la-croix")
 
 	for _, test := range tests {
 		test := test
@@ -492,8 +492,7 @@ func TestUpdateIP(t *testing.T) {
 }
 
 func TestMissingContext(t *testing.T) {
-	t.Parallel()
-	os.Setenv(localpath.MinikubeHome, "/home/la-croix")
+	t.Setenv(localpath.MinikubeHome, "/home/la-croix")
 	configFilename := tempFile(t, kubeConfigMissingContext)
 	defer os.Remove(configFilename)
 	if _, err := UpdateEndpoint("minikube", "192.168.10.100", 8080, configFilename, nil); err != nil {
@@ -796,7 +795,7 @@ func TestGetKubeConfigPath(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		os.Setenv(clientcmd.RecommendedConfigPathEnvVar, test.input)
+		t.Setenv(clientcmd.RecommendedConfigPathEnvVar, test.input)
 		if result := PathFromEnv(); result != os.ExpandEnv(test.want) {
 			t.Errorf("Expected first split chunk, got: %s", result)
 		}

--- a/pkg/minikube/localpath/localpath_test.go
+++ b/pkg/minikube/localpath/localpath_test.go
@@ -18,7 +18,6 @@ package localpath
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -70,17 +69,10 @@ func TestMiniPath(t *testing.T) {
 		{"/tmp/", "/tmp"},
 		{"", homedir.HomeDir()},
 	}
-	originalEnv := os.Getenv(MinikubeHome)
-	defer func() { // revert to pre-test env var
-		err := os.Setenv(MinikubeHome, originalEnv)
-		if err != nil {
-			t.Fatalf("Error reverting env %s to its original value (%s) var after test ", MinikubeHome, originalEnv)
-		}
-	}()
 	for _, tc := range testCases {
 		t.Run(tc.env, func(t *testing.T) {
 			expectedPath := filepath.Join(tc.basePath, ".minikube")
-			os.Setenv(MinikubeHome, tc.env)
+			t.Setenv(MinikubeHome, tc.env)
 			path := MiniPath()
 			if path != expectedPath {
 				t.Errorf("MiniPath expected to return '%s', but got '%s'", expectedPath, path)

--- a/pkg/minikube/machine/cache_binaries_test.go
+++ b/pkg/minikube/machine/cache_binaries_test.go
@@ -18,7 +18,6 @@ package machine
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -85,9 +84,6 @@ func TestCopyBinary(t *testing.T) {
 func TestCacheBinariesForBootstrapper(t *testing.T) {
 	download.DownloadMock = download.CreateDstDownloadMock
 
-	oldMinikubeHome := os.Getenv("MINIKUBE_HOME")
-	defer os.Setenv("MINIKUBE_HOME", oldMinikubeHome)
-
 	minikubeHome := t.TempDir()
 
 	var tc = []struct {
@@ -110,7 +106,7 @@ func TestCacheBinariesForBootstrapper(t *testing.T) {
 	}
 	for _, test := range tc {
 		t.Run(test.version, func(t *testing.T) {
-			os.Setenv("MINIKUBE_HOME", test.minikubeHome)
+			t.Setenv("MINIKUBE_HOME", test.minikubeHome)
 			err := CacheBinariesForBootstrapper(test.version, test.clusterBootstrapper, nil, "")
 			if err != nil && !test.err {
 				t.Fatalf("Got unexpected error %v", err)
@@ -134,11 +130,8 @@ func TestExcludedBinariesNotDownloaded(t *testing.T) {
 		return download.CreateDstDownloadMock(src, dst)
 	}
 
-	oldMinikubeHome := os.Getenv("MINIKUBE_HOME")
-	defer os.Setenv("MINIKUBE_HOME", oldMinikubeHome)
-
 	minikubeHome := t.TempDir()
-	os.Setenv("MINIKUBE_HOME", minikubeHome)
+	t.Setenv("MINIKUBE_HOME", minikubeHome)
 
 	if err := CacheBinariesForBootstrapper("v1.16.0", clusterBootstrapper, []string{binaryToExclude}, ""); err != nil {
 		t.Errorf("Failed to cache binaries: %v", err)

--- a/pkg/minikube/machine/client_test.go
+++ b/pkg/minikube/machine/client_test.go
@@ -123,8 +123,8 @@ func TestRunDriver(t *testing.T) {
 	// called with the proper environment variables, we setup the libmachine driver.
 	testutil.MakeTempDir(t)
 
-	os.Setenv(localbinary.PluginEnvKey, localbinary.PluginEnvVal)
-	os.Setenv(localbinary.PluginEnvDriverName, driver.VirtualBox)
+	t.Setenv(localbinary.PluginEnvKey, localbinary.PluginEnvVal)
+	t.Setenv(localbinary.PluginEnvDriverName, driver.VirtualBox)
 
 	// Capture stdout and reset it later.
 	old := os.Stdout

--- a/pkg/minikube/out/out_test.go
+++ b/pkg/minikube/out/out_test.go
@@ -60,7 +60,7 @@ func TestOutT(t *testing.T) {
 		for _, override := range []bool{true, false} {
 			t.Run(fmt.Sprintf("%s-override-%v", tc.message, override), func(t *testing.T) {
 				// Set MINIKUBE_IN_STYLE=<override>
-				os.Setenv(OverrideEnv, strconv.FormatBool(override))
+				t.Setenv(OverrideEnv, strconv.FormatBool(override))
 				f := tests.NewFakeFile()
 				SetOutFile(f)
 				Step(tc.style, tc.message, tc.params)
@@ -78,7 +78,7 @@ func TestOutT(t *testing.T) {
 }
 
 func TestOut(t *testing.T) {
-	os.Setenv(OverrideEnv, "")
+	t.Setenv(OverrideEnv, "")
 
 	testCases := []struct {
 		format string
@@ -108,7 +108,7 @@ func TestOut(t *testing.T) {
 }
 
 func TestErr(t *testing.T) {
-	os.Setenv(OverrideEnv, "0")
+	t.Setenv(OverrideEnv, "0")
 	f := tests.NewFakeFile()
 	SetErrFile(f)
 	Err("xyz123 %s\n", "%s%%%d")

--- a/pkg/minikube/proxy/proxy_test.go
+++ b/pkg/minikube/proxy/proxy_test.go
@@ -134,17 +134,7 @@ func TestCheckEnv(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%s in %s", tc.ip, tc.envName), func(t *testing.T) {
-			originalEnv := os.Getenv(tc.envName)
-			defer func() { // revert to pre-test env var
-				err := os.Setenv(tc.envName, originalEnv)
-				if err != nil {
-					t.Fatalf("Error reverting env (%s) to its original value (%s) var after test ", tc.envName, originalEnv)
-				}
-			}()
-
-			if err := os.Setenv(tc.envName, tc.mockEnvValue); err != nil {
-				t.Error("Error setting env var for taste case")
-			}
+			t.Setenv(tc.envName, tc.mockEnvValue)
 			if got := checkEnv(tc.ip, tc.envName); got != tc.want {
 				t.Errorf("CheckEnv(%v,%v) got  %v ; want is %v", tc.ip, tc.envName, got, tc.want)
 			}
@@ -166,17 +156,8 @@ func TestIsIPExcluded(t *testing.T) {
 		{"foo", "1.2.3.4", false},
 	}
 	for _, tc := range testCases {
-		originalEnv := os.Getenv("NO_PROXY")
-		defer func() { // revert to pre-test env var
-			err := os.Setenv("NO_PROXY", originalEnv)
-			if err != nil {
-				t.Fatalf("Error reverting env NO_PROXY to its original value (%s) var after test ", originalEnv)
-			}
-		}()
 		t.Run(fmt.Sprintf("exclude %s NO_PROXY(%v)", tc.ip, tc.env), func(t *testing.T) {
-			if err := os.Setenv("NO_PROXY", tc.env); err != nil {
-				t.Errorf("Error during setting env: %v", err)
-			}
+			t.Setenv("NO_PROXY", tc.env)
 			if excluded := IsIPExcluded(tc.ip); excluded != tc.excluded {
 				t.Fatalf("IsIPExcluded(%v) should return %v. NO_PROXY=%v", tc.ip, tc.excluded, tc.env)
 			}
@@ -196,18 +177,9 @@ func TestExcludeIP(t *testing.T) {
 		{"foo", "", true},
 		{"foo", "1.2.3.4", true},
 	}
-	originalEnv := os.Getenv("NO_PROXY")
-	defer func() { // revert to pre-test env var
-		err := os.Setenv("NO_PROXY", originalEnv)
-		if err != nil {
-			t.Fatalf("Error reverting env NO_PROXY to its original value (%s) var after test ", originalEnv)
-		}
-	}()
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("exclude %s NO_PROXY(%s)", tc.ip, tc.env), func(t *testing.T) {
-			if err := os.Setenv("NO_PROXY", tc.env); err != nil {
-				t.Errorf("Error during setting env: %v", err)
-			}
+			t.Setenv("NO_PROXY", tc.env)
 			err := ExcludeIP(tc.ip)
 			if err != nil && !tc.wantAErr {
 				t.Errorf("ExcludeIP(%v) returned unexpected error %v", tc.ip, err)

--- a/pkg/minikube/service/service_test.go
+++ b/pkg/minikube/service/service_test.go
@@ -557,14 +557,6 @@ func revertK8sClient(k K8sClient) {
 }
 
 func TestGetCoreClient(t *testing.T) {
-	originalEnv := os.Getenv("KUBECONFIG")
-	defer func() {
-		err := os.Setenv("KUBECONFIG", originalEnv)
-		if err != nil {
-			t.Fatalf("Error reverting env KUBECONFIG to its original value. Got err (%s)", err)
-		}
-	}()
-
 	mockK8sConfig := `apiVersion: v1
 clusters:
 - cluster:
@@ -616,7 +608,7 @@ users:
 			if err != nil {
 				t.Fatalf("Unexpected error when writing to file %v. Error: %v", test.kubeconfigPath, err)
 			}
-			os.Setenv("KUBECONFIG", mockK8sConfigPath)
+			t.Setenv("KUBECONFIG", mockK8sConfigPath)
 
 			k8s := K8sClientGetter{}
 			_, err = k8s.GetCoreClient("minikube")

--- a/pkg/minikube/shell/shell_test.go
+++ b/pkg/minikube/shell/shell_test.go
@@ -123,10 +123,7 @@ set -e bar;`},
 }
 
 func TestDetectSet(t *testing.T) {
-	orgShellEnv := os.Getenv("SHELL")
-	defer os.Setenv("SHELL", orgShellEnv)
-
-	os.Setenv("SHELL", "/bin/bash")
+	t.Setenv("SHELL", "/bin/bash")
 	if s, err := Detect(); err != nil {
 		t.Fatalf("unexpected error: '%v' during shell detection. Returned shell: %s", err, s)
 	} else if s == "" {

--- a/pkg/minikube/storageclass/storageclass_test.go
+++ b/pkg/minikube/storageclass/storageclass_test.go
@@ -235,7 +235,7 @@ func TestGetStoragev1(t *testing.T) {
 	defer os.Remove(configFile.Name())
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			if err := setK8SConfig(test.config, configFile.Name()); err != nil {
+			if err := setK8SConfig(t, test.config, configFile.Name()); err != nil {
 				t.Fatalf(err.Error())
 			}
 
@@ -251,13 +251,13 @@ func TestGetStoragev1(t *testing.T) {
 	}
 }
 
-func setK8SConfig(config, kubeconfigPath string) error {
+func setK8SConfig(t *testing.T, config, kubeconfigPath string) error {
 	mockK8sConfigByte := []byte(config)
 	mockK8sConfigPath := kubeconfigPath
 	err := os.WriteFile(mockK8sConfigPath, mockK8sConfigByte, 0644)
 	if err != nil {
 		return fmt.Errorf("Unexpected error when writing to file %v. Error: %v", kubeconfigPath, err)
 	}
-	os.Setenv("KUBECONFIG", mockK8sConfigPath)
+	t.Setenv("KUBECONFIG", mockK8sConfigPath)
 	return nil
 }

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -129,9 +129,7 @@ func TestMaybeChownDirRecursiveToMinikubeUser(t *testing.T) {
 	}
 
 	if os.Getenv("CHANGE_MINIKUBE_NONE_USER") == "" {
-		if err := os.Setenv("CHANGE_MINIKUBE_NONE_USER", "1"); nil != err {
-			t.Error("failed to set env: CHANGE_MINIKUBE_NONE_USER")
-		}
+		t.Setenv("CHANGE_MINIKUBE_NONE_USER", "1")
 	}
 
 	if os.Getenv("SUDO_USER") == "" {
@@ -139,11 +137,7 @@ func TestMaybeChownDirRecursiveToMinikubeUser(t *testing.T) {
 		if nil != err {
 			t.Error("fail to get user")
 		}
-		os.Setenv("SUDO_USER", user.Username)
-		err = os.Setenv("SUDO_USER", user.Username)
-		if nil != err {
-			t.Error("failed to set env: SUDO_USER")
-		}
+		t.Setenv("SUDO_USER", user.Username)
 	}
 
 	cases := []struct {

--- a/test/integration/skaffold_test.go
+++ b/test/integration/skaffold_test.go
@@ -89,8 +89,7 @@ func TestSkaffold(t *testing.T) {
 		}
 	}
 
-	oldPath := os.Getenv("PATH")
-	os.Setenv("PATH", fmt.Sprintf("%s%s%s", filepath.Dir(abs), pathSeparator, os.Getenv("PATH")))
+	t.Setenv("PATH", fmt.Sprintf("%s%s%s", filepath.Dir(abs), pathSeparator, os.Getenv("PATH")))
 
 	// make sure 'docker' and 'minikube' are now in PATH
 	for _, binary := range []string{"minikube", "docker"} {
@@ -99,10 +98,6 @@ func TestSkaffold(t *testing.T) {
 			t.Fatalf("%q is not in path", binary)
 		}
 	}
-
-	defer func() {
-		os.Setenv("PATH", oldPath)
-	}()
 
 	// make sure "skaffold run" exits without failure
 	cmd := exec.CommandContext(ctx, tf.Name(), "run", "--minikube-profile", profile, "--kube-context", profile, "--status-check=true", "--port-forward=false", "--interactive=false")


### PR DESCRIPTION
A testing cleanup.

This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

```go
func TestFoo(t *testing.T) {
	// before
	key := "ENV"
	originalEnv := os.Getenv(key)
	
	if err := os.Setenv(key, "new value"); err != nil {
		t.Fatal(err)
	}
	defer func() {
		if err := os.Setenv(key, originalEnv); err != nil {
			t.Logf("failed to set env %s back to original value: %v", key, err)
		}
	}()
	
	// after
	t.Setenv(key, "new value")
}
```

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
