### PR TITLE
Update Kong addon images

### DIFF
--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -283,8 +283,8 @@ var Addons = map[string]*Addon{
 			"kong-ingress-controller.yaml",
 			"0640"),
 	}, false, "kong", "3rd party (Kong HQ)", "", "https://minikube.sigs.k8s.io/docs/handbook/addons/kong-ingress/", map[string]string{
-		"Kong":        "kong:2.7@sha256:4d3e93207305ace881fe9e95ac27717b6fbdd9e0ec1873c34e94908a4f4c9335",
-		"KongIngress": "kong/kubernetes-ingress-controller:2.1.1@sha256:60e4102ab2da7f61e9c478747f0762d06a6166b5f300526b237ed7354c3cb4c8",
+		"Kong":        "kong:2.8.3@sha256:f49d166f8cc73543970c4cb17efb881688535712c552d294723f0e550e78556d",
+		"KongIngress": "kong/kubernetes-ingress-controller:2.7@sha256:5616bab3246eba6ccfbd59a6739a36623e87f98e76262664cff60622e24fb3e5",
 	}, map[string]string{
 		"Kong":        "docker.io",
 		"KongIngress": "docker.io",


### PR DESCRIPTION
**Before:**

`kong:2.7@sha256:4d3e93207305ace881fe9e95ac27717b6fbdd9e0ec1873c34e94908a4f4c9335`
<details>
<summary>CVEs</summary>

```
✗ Low severity vulnerability found in curl/libcurl
  Description: CVE-2022-35252
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-CURL-3011747
  Introduced through: curl/libcurl@7.79.1-r0, git/git@2.32.0-r0
  From: curl/libcurl@7.79.1-r0
  From: git/git@2.32.0-r0 > curl/libcurl@7.79.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 7.79.1-r3

✗ Low severity vulnerability found in busybox/busybox
  Description: ALPINE-13661
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-BUSYBOX-2606934
  Introduced through: busybox/busybox@1.33.1-r6, alpine-baselayout/alpine-baselayout@3.2.0-r16, bash/bash@5.1.4-r0, ca-certificates/ca-certificates@20191127-r5, busybox/ssl_client@1.33.1-r6
  From: busybox/busybox@1.33.1-r6
  From: alpine-baselayout/alpine-baselayout@3.2.0-r16 > busybox/busybox@1.33.1-r6
  From: bash/bash@5.1.4-r0 > busybox/busybox@1.33.1-r6
  and 2 more...
  Image layer: 'then apk add --no-cache --virtual .build-deps curl wget tar ca-certificates'
  Fixed in: 1.33.1-r7

✗ Medium severity vulnerability found in openssl/libcrypto1.1
  Description: Inadequate Encryption Strength
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-OPENSSL-2941807
  Introduced through: openssl/libcrypto1.1@1.1.1l-r0, openssl/libssl1.1@1.1.1l-r0, apk-tools/apk-tools@2.12.7-r0, libretls/libretls@3.3.3p1-r2, ca-certificates/ca-certificates@20191127-r5, curl/libcurl@7.79.1-r0, openssl/openssl@1.1.1l-r0
  From: openssl/libcrypto1.1@1.1.1l-r0
  From: openssl/libssl1.1@1.1.1l-r0 > openssl/libcrypto1.1@1.1.1l-r0
  From: apk-tools/apk-tools@2.12.7-r0 > openssl/libcrypto1.1@1.1.1l-r0
  and 11 more...
  Image layer: 'then apk add --no-cache --virtual .build-deps curl wget tar ca-certificates'
  Fixed in: 1.1.1q-r0

✗ Medium severity vulnerability found in git/git
  Description: Link Following
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-GIT-3053989
  Introduced through: git/git@2.32.0-r0, git/perl-git@2.32.0-r0, git/git-perl@2.32.0-r0
  From: git/git@2.32.0-r0
  From: git/perl-git@2.32.0-r0 > git/git@2.32.0-r0
  From: git/git-perl@2.32.0-r0 > git/git@2.32.0-r0
  and 3 more...
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 2.32.4-r0

✗ Medium severity vulnerability found in expat/expat
  Description: Resource Exhaustion
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-EXPAT-2407754
  Introduced through: expat/expat@2.4.1-r0, git/git@2.32.0-r0
  From: expat/expat@2.4.1-r0
  From: git/git@2.32.0-r0 > expat/expat@2.4.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 2.4.5-r0

✗ Medium severity vulnerability found in curl/libcurl
  Description: Insufficiently Protected Credentials
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-CURL-2804931
  Introduced through: curl/libcurl@7.79.1-r0, git/git@2.32.0-r0
  From: curl/libcurl@7.79.1-r0
  From: git/git@2.32.0-r0 > curl/libcurl@7.79.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 7.79.1-r1

✗ Medium severity vulnerability found in curl/libcurl
  Description: Insufficiently Protected Credentials
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-CURL-2804937
  Introduced through: curl/libcurl@7.79.1-r0, git/git@2.32.0-r0
  From: curl/libcurl@7.79.1-r0
  From: git/git@2.32.0-r0 > curl/libcurl@7.79.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 7.79.1-r1

✗ Medium severity vulnerability found in curl/libcurl
  Description: Allocation of Resources Without Limits or Throttling
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-CURL-2938005
  Introduced through: curl/libcurl@7.79.1-r0, git/git@2.32.0-r0
  From: curl/libcurl@7.79.1-r0
  From: git/git@2.32.0-r0 > curl/libcurl@7.79.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 7.79.1-r2

✗ Medium severity vulnerability found in curl/libcurl
  Description: Allocation of Resources Without Limits or Throttling
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-CURL-2938010
  Introduced through: curl/libcurl@7.79.1-r0, git/git@2.32.0-r0
  From: curl/libcurl@7.79.1-r0
  From: git/git@2.32.0-r0 > curl/libcurl@7.79.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 7.79.1-r2

✗ Medium severity vulnerability found in curl/libcurl
  Description: Out-of-bounds Write
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-CURL-2938015
  Introduced through: curl/libcurl@7.79.1-r0, git/git@2.32.0-r0
  From: curl/libcurl@7.79.1-r0
  From: git/git@2.32.0-r0 > curl/libcurl@7.79.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 7.79.1-r2

✗ High severity vulnerability found in zlib/zlib
  Description: Out-of-bounds Write
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-ZLIB-2434419
  Introduced through: zlib/zlib@1.2.11-r3, apk-tools/apk-tools@2.12.7-r0, curl/libcurl@7.79.1-r0, git/git@2.32.0-r0, perl/perl@5.32.1-r0, zlib/zlib-dev@1.2.11-r3
  From: zlib/zlib@1.2.11-r3
  From: apk-tools/apk-tools@2.12.7-r0 > zlib/zlib@1.2.11-r3
  From: curl/libcurl@7.79.1-r0 > zlib/zlib@1.2.11-r3
  and 4 more...
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 1.2.12-r0

✗ High severity vulnerability found in openssl/libcrypto1.1
  Description: Loop with Unreachable Exit Condition ('Infinite Loop')
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-OPENSSL-2426333
  Introduced through: openssl/libcrypto1.1@1.1.1l-r0, openssl/libssl1.1@1.1.1l-r0, apk-tools/apk-tools@2.12.7-r0, libretls/libretls@3.3.3p1-r2, ca-certificates/ca-certificates@20191127-r5, curl/libcurl@7.79.1-r0, openssl/openssl@1.1.1l-r0
  From: openssl/libcrypto1.1@1.1.1l-r0
  From: openssl/libssl1.1@1.1.1l-r0 > openssl/libcrypto1.1@1.1.1l-r0
  From: apk-tools/apk-tools@2.12.7-r0 > openssl/libcrypto1.1@1.1.1l-r0
  and 11 more...
  Image layer: 'then apk add --no-cache --virtual .build-deps curl wget tar ca-certificates'
  Fixed in: 1.1.1n-r0

✗ High severity vulnerability found in ncurses/ncurses-terminfo-base
  Description: Out-of-bounds Read
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-NCURSES-2952571
  Introduced through: ncurses/ncurses-terminfo-base@6.2_p20210612-r0, ncurses/ncurses-libs@6.2_p20210612-r0, readline/readline@8.1.0-r0
  From: ncurses/ncurses-terminfo-base@6.2_p20210612-r0
  From: ncurses/ncurses-libs@6.2_p20210612-r0 > ncurses/ncurses-terminfo-base@6.2_p20210612-r0
  From: ncurses/ncurses-libs@6.2_p20210612-r0
  and 1 more...
  Image layer: Introduced by your base image (alpine:3.14.3)
  Fixed in: 6.2_p20210612-r1

✗ High severity vulnerability found in libretls/libretls
  Description: Loop with Unreachable Exit Condition ('Infinite Loop')
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-LIBRETLS-2432985
  Introduced through: libretls/libretls@3.3.3p1-r2, busybox/ssl_client@1.33.1-r6
  From: libretls/libretls@3.3.3p1-r2
  From: busybox/ssl_client@1.33.1-r6 > libretls/libretls@3.3.3p1-r2
  Image layer: Introduced by your base image (alpine:3.14.3)
  Fixed in: 3.3.3p1-r3

✗ High severity vulnerability found in git/git
  Description: Uncontrolled Search Path Element
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-GIT-2635653
  Introduced through: git/git@2.32.0-r0, git/perl-git@2.32.0-r0, git/git-perl@2.32.0-r0
  From: git/git@2.32.0-r0
  From: git/perl-git@2.32.0-r0 > git/git@2.32.0-r0
  From: git/git-perl@2.32.0-r0 > git/git@2.32.0-r0
  and 3 more...
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 2.32.1-r0

✗ High severity vulnerability found in git/git
  Description: Uncontrolled Search Path Element
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-GIT-2949333
  Introduced through: git/git@2.32.0-r0, git/perl-git@2.32.0-r0, git/git-perl@2.32.0-r0
  From: git/git@2.32.0-r0
  From: git/perl-git@2.32.0-r0 > git/git@2.32.0-r0
  From: git/git-perl@2.32.0-r0 > git/git@2.32.0-r0
  and 3 more...
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 2.32.3-r0

✗ High severity vulnerability found in git/git
  Description: Out-of-bounds Write
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-GIT-3053990
  Introduced through: git/git@2.32.0-r0, git/perl-git@2.32.0-r0, git/git-perl@2.32.0-r0
  From: git/git@2.32.0-r0
  From: git/perl-git@2.32.0-r0 > git/git@2.32.0-r0
  From: git/git-perl@2.32.0-r0 > git/git@2.32.0-r0
  and 3 more...
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 2.32.4-r0

✗ High severity vulnerability found in expat/expat
  Description: Integer Overflow or Wraparound
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-EXPAT-2342108
  Introduced through: expat/expat@2.4.1-r0, git/git@2.32.0-r0
  From: expat/expat@2.4.1-r0
  From: git/git@2.32.0-r0 > expat/expat@2.4.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 2.4.3-r0

✗ High severity vulnerability found in expat/expat
  Description: Incorrect Calculation
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-EXPAT-2342116
  Introduced through: expat/expat@2.4.1-r0, git/git@2.32.0-r0
  From: expat/expat@2.4.1-r0
  From: git/git@2.32.0-r0 > expat/expat@2.4.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 2.4.3-r0

✗ High severity vulnerability found in expat/expat
  Description: Integer Overflow or Wraparound
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-EXPAT-2342146
  Introduced through: expat/expat@2.4.1-r0, git/git@2.32.0-r0
  From: expat/expat@2.4.1-r0
  From: git/git@2.32.0-r0 > expat/expat@2.4.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 2.4.3-r0

✗ High severity vulnerability found in expat/expat
  Description: Integer Overflow or Wraparound
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-EXPAT-2342147
  Introduced through: expat/expat@2.4.1-r0, git/git@2.32.0-r0
  From: expat/expat@2.4.1-r0
  From: git/git@2.32.0-r0 > expat/expat@2.4.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 2.4.3-r0

✗ High severity vulnerability found in expat/expat
  Description: Integer Overflow or Wraparound
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-EXPAT-2342153
  Introduced through: expat/expat@2.4.1-r0, git/git@2.32.0-r0
  From: expat/expat@2.4.1-r0
  From: git/git@2.32.0-r0 > expat/expat@2.4.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 2.4.3-r0

✗ High severity vulnerability found in expat/expat
  Description: Integer Overflow or Wraparound
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-EXPAT-2393732
  Introduced through: expat/expat@2.4.1-r0, git/git@2.32.0-r0
  From: expat/expat@2.4.1-r0
  From: git/git@2.32.0-r0 > expat/expat@2.4.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 2.4.4-r0

✗ High severity vulnerability found in expat/expat
  Description: Integer Overflow or Wraparound
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-EXPAT-2407744
  Introduced through: expat/expat@2.4.1-r0, git/git@2.32.0-r0
  From: expat/expat@2.4.1-r0
  From: git/git@2.32.0-r0 > expat/expat@2.4.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 2.4.5-r0

✗ High severity vulnerability found in expat/expat
  Description: Use After Free
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-EXPAT-3062884
  Introduced through: expat/expat@2.4.1-r0, git/git@2.32.0-r0
  From: expat/expat@2.4.1-r0
  From: git/git@2.32.0-r0 > expat/expat@2.4.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 2.5.0-r0

✗ High severity vulnerability found in curl/libcurl
  Description: Improper Authentication
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-CURL-2804934
  Introduced through: curl/libcurl@7.79.1-r0, git/git@2.32.0-r0
  From: curl/libcurl@7.79.1-r0
  From: git/git@2.32.0-r0 > curl/libcurl@7.79.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 7.79.1-r1

✗ High severity vulnerability found in curl/libcurl
  Description: CVE-2022-27775
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-CURL-2804941
  Introduced through: curl/libcurl@7.79.1-r0, git/git@2.32.0-r0
  From: curl/libcurl@7.79.1-r0
  From: git/git@2.32.0-r0 > curl/libcurl@7.79.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 7.79.1-r1

✗ High severity vulnerability found in curl/libcurl
  Description: Loop with Unreachable Exit Condition ('Infinite Loop')
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-CURL-2938007
  Introduced through: curl/libcurl@7.79.1-r0, git/git@2.32.0-r0
  From: curl/libcurl@7.79.1-r0
  From: git/git@2.32.0-r0 > curl/libcurl@7.79.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 7.79.1-r2

✗ High severity vulnerability found in curl/libcurl
  Description: Improper Certificate Validation
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-CURL-2938016
  Introduced through: curl/libcurl@7.79.1-r0, git/git@2.32.0-r0
  From: curl/libcurl@7.79.1-r0
  From: git/git@2.32.0-r0 > curl/libcurl@7.79.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 7.79.1-r2

✗ High severity vulnerability found in busybox/busybox
  Description: CVE-2022-28391
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-BUSYBOX-2440608
  Introduced through: busybox/busybox@1.33.1-r6, alpine-baselayout/alpine-baselayout@3.2.0-r16, bash/bash@5.1.4-r0, ca-certificates/ca-certificates@20191127-r5, busybox/ssl_client@1.33.1-r6
  From: busybox/busybox@1.33.1-r6
  From: alpine-baselayout/alpine-baselayout@3.2.0-r16 > busybox/busybox@1.33.1-r6
  From: bash/bash@5.1.4-r0 > busybox/busybox@1.33.1-r6
  and 2 more...
  Image layer: 'then apk add --no-cache --virtual .build-deps curl wget tar ca-certificates'
  Fixed in: 1.33.1-r7

✗ Critical severity vulnerability found in zlib/zlib
  Description: Out-of-bounds Write
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-ZLIB-2976174
  Introduced through: zlib/zlib@1.2.11-r3, apk-tools/apk-tools@2.12.7-r0, curl/libcurl@7.79.1-r0, git/git@2.32.0-r0, perl/perl@5.32.1-r0, zlib/zlib-dev@1.2.11-r3
  From: zlib/zlib@1.2.11-r3
  From: apk-tools/apk-tools@2.12.7-r0 > zlib/zlib@1.2.11-r3
  From: curl/libcurl@7.79.1-r0 > zlib/zlib@1.2.11-r3
  and 4 more...
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 1.2.12-r2

✗ Critical severity vulnerability found in pcre2/pcre2
  Description: Out-of-bounds Read
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-PCRE2-2869382
  Introduced through: pcre2/pcre2@10.36-r0, git/git@2.32.0-r0
  From: pcre2/pcre2@10.36-r0
  From: git/git@2.32.0-r0 > pcre2/pcre2@10.36-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 10.36-r1

✗ Critical severity vulnerability found in pcre2/pcre2
  Description: Out-of-bounds Read
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-PCRE2-2869399
  Introduced through: pcre2/pcre2@10.36-r0, git/git@2.32.0-r0
  From: pcre2/pcre2@10.36-r0
  From: git/git@2.32.0-r0 > pcre2/pcre2@10.36-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 10.36-r1

✗ Critical severity vulnerability found in expat/expat
  Description: Integer Overflow or Wraparound
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-EXPAT-2342148
  Introduced through: expat/expat@2.4.1-r0, git/git@2.32.0-r0
  From: expat/expat@2.4.1-r0
  From: git/git@2.32.0-r0 > expat/expat@2.4.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 2.4.3-r0

✗ Critical severity vulnerability found in expat/expat
  Description: Integer Overflow or Wraparound
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-EXPAT-2342152
  Introduced through: expat/expat@2.4.1-r0, git/git@2.32.0-r0
  From: expat/expat@2.4.1-r0
  From: git/git@2.32.0-r0 > expat/expat@2.4.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 2.4.3-r0

✗ Critical severity vulnerability found in expat/expat
  Description: Integer Overflow or Wraparound
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-EXPAT-2342154
  Introduced through: expat/expat@2.4.1-r0, git/git@2.32.0-r0
  From: expat/expat@2.4.1-r0
  From: git/git@2.32.0-r0 > expat/expat@2.4.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 2.4.3-r0

✗ Critical severity vulnerability found in expat/expat
  Description: Integer Overflow or Wraparound
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-EXPAT-2393734
  Introduced through: expat/expat@2.4.1-r0, git/git@2.32.0-r0
  From: expat/expat@2.4.1-r0
  From: git/git@2.32.0-r0 > expat/expat@2.4.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 2.4.4-r0

✗ Critical severity vulnerability found in expat/expat
  Description: Integer Overflow or Wraparound
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-EXPAT-2407748
  Introduced through: expat/expat@2.4.1-r0, git/git@2.32.0-r0
  From: expat/expat@2.4.1-r0
  From: git/git@2.32.0-r0 > expat/expat@2.4.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 2.4.5-r0

✗ Critical severity vulnerability found in expat/expat
  Description: Improper Encoding or Escaping of Output
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-EXPAT-2407750
  Introduced through: expat/expat@2.4.1-r0, git/git@2.32.0-r0
  From: expat/expat@2.4.1-r0
  From: git/git@2.32.0-r0 > expat/expat@2.4.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 2.4.5-r0

✗ Critical severity vulnerability found in expat/expat
  Description: Exposure of Resource to Wrong Sphere
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-EXPAT-2407755
  Introduced through: expat/expat@2.4.1-r0, git/git@2.32.0-r0
  From: expat/expat@2.4.1-r0
  From: git/git@2.32.0-r0 > expat/expat@2.4.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 2.4.5-r0

✗ Critical severity vulnerability found in expat/expat
  Description: Use After Free
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-EXPAT-3028182
  Introduced through: expat/expat@2.4.1-r0, git/git@2.32.0-r0
  From: expat/expat@2.4.1-r0
  From: git/git@2.32.0-r0 > expat/expat@2.4.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 2.4.9-r0

✗ Critical severity vulnerability found in curl/libcurl
  Description: Incorrect Default Permissions
  Info: https://security.snyk.io/vuln/SNYK-ALPINE314-CURL-2938017
  Introduced through: curl/libcurl@7.79.1-r0, git/git@2.32.0-r0
  From: curl/libcurl@7.79.1-r0
  From: git/git@2.32.0-r0 > curl/libcurl@7.79.1-r0
  Image layer: 'apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates'
  Fixed in: 7.79.1-r2
```
</details>

`kong/kubernetes-ingress-controller:2.1.1@sha256:60e4102ab2da7f61e9c478747f0762d06a6166b5f300526b237ed7354c3cb4c8`

<details>
<summary>CVEs</summary>

```
✗ Medium severity vulnerability found in github.com/prometheus/client_golang/prometheus/promhttp
  Description: Denial of Service (DoS)
  Info: https://security.snyk.io/vuln/SNYK-GOLANG-GITHUBCOMPROMETHEUSCLIENTGOLANGPROMETHEUSPROMHTTP-2401819
  Introduced through: github.com/prometheus/client_golang/prometheus/promhttp@1.11.0
  From: github.com/prometheus/client_golang/prometheus/promhttp@1.11.0
  Fixed in: 1.11.1

✗ High severity vulnerability found in gopkg.in/yaml.v3
  Description: Denial of Service (DoS)
  Info: https://security.snyk.io/vuln/SNYK-GOLANG-GOPKGINYAMLV3-2841557
  Introduced through: gopkg.in/yaml.v3@#496545a6307b
  From: gopkg.in/yaml.v3@#496545a6307b
  Fixed in: 3.0.0
```
</details>

**After:**

`kong:2.8.3@sha256:f49d166f8cc73543970c4cb17efb881688535712c552d294723f0e550e78556d`
**No CVEs**

`kong/kubernetes-ingress-controller:2.7@sha256:5616bab3246eba6ccfbd59a6739a36623e87f98e76262664cff60622e24fb3e5`
**No CVEs**