### PR TITLE
fix kubelet localStorageCapacityIsolation option

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta3.go
+++ b/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta3.go
@@ -78,6 +78,9 @@ authentication:
   x509:
     clientCAFile: {{.ClientCAFile}}
 cgroupDriver: {{.CgroupDriver}}
+{{- range $key, $val := .KubeletConfigOpts}}
+{{$key}}: {{$val}}
+{{- end}}
 clusterDomain: "{{if .DNSDomain}}{{.DNSDomain}}{{else}}cluster.local{{end}}"
 # disable disk resource management by default
 imageGCHighThresholdPercent: 100

--- a/pkg/minikube/bootstrapper/bsutil/kubeadm_test.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubeadm_test.go
@@ -307,3 +307,27 @@ func TestEtcdExtraArgs(t *testing.T) {
 		t.Errorf("machines mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestKubeletConfig(t *testing.T) {
+	expected := map[string]string{
+		"localStorageCapacityIsolation": "false",
+	}
+	extraOpts := append(getExtraOpts(), []config.ExtraOption{
+		{
+			Component: Kubelet,
+			Key:       "unsupported-config-option",
+			Value:     "any",
+		}, {
+			Component: Kubelet,
+			Key:       "localStorageCapacityIsolation",
+			Value:     "false",
+		}, {
+			Component: Kubelet,
+			Key:       "kubelet.cgroups-per-qos",
+			Value:     "false",
+		}}...)
+	actual := kubeletConfigOpts(extraOpts)
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Errorf("machines mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/pkg/minikube/bootstrapper/bsutil/kubelet.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubelet.go
@@ -36,6 +36,11 @@ import (
 	"k8s.io/minikube/pkg/util"
 )
 
+// kubeletConfigParams are the only allowed kubelet parameters for kubeadmin config file and not to be used as kubelet flags
+var kubeletConfigParams = []string{
+	"localStorageCapacityIsolation",
+}
+
 func extraKubeletOpts(mc config.ClusterConfig, nc config.Node, r cruntime.Manager) (map[string]string, error) {
 	k8s := mc.KubernetesConfig
 	version, err := util.ParseKubernetesVersion(k8s.KubernetesVersion)
@@ -93,6 +98,11 @@ func extraKubeletOpts(mc config.ClusterConfig, nc config.Node, r cruntime.Manage
 
 	if kubeletFeatureArgs != "" {
 		extraOpts["feature-gates"] = kubeletFeatureArgs
+	}
+
+	// filter out non-flag extra kubelet config options
+	for _, opt := range kubeletConfigParams {
+		delete(extraOpts, opt)
 	}
 
 	return extraOpts, nil


### PR DESCRIPTION
fixes: #14728
fixes: #15099 (btrfs + k8s 1.25.2 + docker)
fixes: #15050 (btrfs + k8s 1.25.0 + docker)

it might help with #14819 (btrfs + docker, but k8s version is not shared: issue was reported on 20th Aug, so it, in theory, could be k8s [v1.25.0-beta.0](https://github.com/kubernetes/kubernetes/releases/tag/v1.25.0-beta.0), but minikube is v1.26.1 shipped with DefaultKubernetesVersion = "v1.24.3")

i don't think i ever had issues with btrfs + docker + k8s/minikube and also, official [OverlayFS and Docker Performance](https://docs.docker.com/storage/storagedriver/overlayfs-driver/#overlayfs-and-docker-performance) claims that:
> _In certain circumstances_, overlay2 **_may perform better_** than btrfs as well. However, ...

but i know some users reported problems earlier, so, in case of such a combination, this pr should automatically:
- enable `LocalStorageCapacityIsolation` as **_feature flag_** for k8s _before v1.25.0-beta.0_ and
- enable `localStorageCapacityIsolation` as **_config option_** for k8s _v1.25.0-beta.0 and newer_

should they wish, users will also have the option to override this by passing eg, `--extra-config="kubelet.localStorageCapacityIsolation=true"` (which is default) for k8s >= v1.25.0-beta.0 (last example below demonstrates that case)

### before

$ docker exec -ti docker /bin/bash
root@docker:/# journalctl -f
```
...
Nov 09 01:31:37 docker systemd[1]: kubelet.service: Main process exited, code=exited, status=1/FAILURE
Nov 09 01:31:37 docker systemd[1]: kubelet.service: Failed with result 'exit-code'.
Nov 09 01:31:38 docker systemd[1]: kubelet.service: Scheduled restart job, restart counter is at 3802.
Nov 09 01:31:38 docker systemd[1]: Stopped kubelet: The Kubernetes Node Agent.
Nov 09 01:31:38 docker systemd[1]: Started kubelet: The Kubernetes Node Agent.
Nov 09 01:31:38 docker kubelet[76607]: Flag --container-runtime has been deprecated, will be removed in 1.27 as the only valid value is 'remote'
Nov 09 01:31:38 docker kubelet[76607]: Flag --feature-gates has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Nov 09 01:31:38 docker kubelet[76607]: Flag --runtime-request-timeout has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Nov 09 01:31:38 docker kubelet[76607]: E1109 01:31:38.711920   76607 run.go:74] "command failed" err="failed to set feature gates from initial flags-based config: cannot set feature gate LocalStorageCapacityIsolation to false, feature is locked to true"
Nov 09 01:31:38 docker systemd[1]: kubelet.service: Main process exited, code=exited, status=1/FAILURE
Nov 09 01:31:38 docker systemd[1]: kubelet.service: Failed with result 'exit-code'.
...
```

### after

$ time minikube start --driver=docker --kubernetes-version=1.25.3 -p btrfs-docker-k8s1.25.3
```
😄  [btrfs-docker-k8s1.25.3] minikube v1.28.0 on Opensuse-Tumbleweed
✨  Using the docker driver based on user configuration
❗  docker is currently using the btrfs storage driver, consider switching to overlay2 for better performance
📌  Using Docker driver with root privileges
👍  Starting control plane node btrfs-docker-k8s1.25.3 in cluster btrfs-docker-k8s1.25.3
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=15900MB) ...
🐳  Preparing Kubernetes v1.25.3 on Docker 20.10.20 ...
    ▪ kubelet.localStorageCapacityIsolation=false
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "btrfs-docker-k8s1.25.3" cluster and "default" namespace by default

real    0m31.322s
user    0m2.170s
sys     0m1.091s
```

$ docker exec -ti btrfs-docker-k8s1.25.3 cat /var/lib/kubelet/config.yaml | grep -A1 "kind: KubeletConfiguration"
```
kind: KubeletConfiguration
localStorageCapacityIsolation: false
```

$ docker exec -ti btrfs-docker-k8s1.25.3 cat /etc/systemd/system/kubelet.service.d/10-kubeadm.conf | grep -i "localStorageCapacityIsolation"
```
(null)
```

---

$ time minikube start --driver=docker --kubernetes-version=1.24.7 -p btrfs-docker-k8s1.24.7
```
😄  [btrfs-docker-k8s1.24.7] minikube v1.28.0 on Opensuse-Tumbleweed
✨  Using the docker driver based on user configuration
❗  docker is currently using the btrfs storage driver, consider switching to overlay2 for better performance
📌  Using Docker driver with root privileges
👍  Starting control plane node btrfs-docker-k8s1.24.7 in cluster btrfs-docker-k8s1.24.7
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=15900MB) ...
🐳  Preparing Kubernetes v1.24.7 on Docker 20.10.20 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "btrfs-docker-k8s1.24.7" cluster and "default" namespace by default

real    0m28.820s
user    0m2.220s
sys     0m1.144s
```

$ docker exec -ti btrfs-docker-k8s1.24.7 cat /var/lib/kubelet/config.yaml | grep -A1 "kind: KubeletConfiguration"
```
kind: KubeletConfiguration
logging:
```

$ docker exec -ti btrfs-docker-k8s1.24.7 cat /etc/systemd/system/kubelet.service.d/10-kubeadm.conf | grep -i "localStorageCapacityIsolation"
```
ExecStart=/var/lib/minikube/binaries/v1.24.7/kubelet --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --config=/var/lib/kubelet/config.yaml --container-runtime=remote --container-runtime-endpoint=/var/run/cri-dockerd.sock --feature-gates=LocalStorageCapacityIsolation=false --hostname-override=btrfs-docker-k8s1.24.7 --image-service-endpoint=/var/run/cri-dockerd.sock --kubeconfig=/etc/kubernetes/kubelet.conf --node-ip=192.168.58.2 --runtime-request-timeout=15m
```

---

$ time minikube start --driver=docker --kubernetes-version=1.25.3 -p btrfs-docker-k8s1.25.3-ec --extra-config="kubelet.localStorageCapacityIsolation=true"
```
😄  [btrfs-docker-k8s1.25.3-ec] minikube v1.28.0 on Opensuse-Tumbleweed
✨  Using the docker driver based on user configuration
❗  docker is currently using the btrfs storage driver, consider switching to overlay2 for better performance
📌  Using Docker driver with root privileges
👍  Starting control plane node btrfs-docker-k8s1.25.3-ec in cluster btrfs-docker-k8s1.25.3-ec
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=15900MB) ...
🐳  Preparing Kubernetes v1.25.3 on Docker 20.10.20 ...
    ▪ kubelet.localStorageCapacityIsolation=true
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "btrfs-docker-k8s1.25.3-ec" cluster and "default" namespace by default

real    0m29.488s
user    0m2.293s
sys     0m1.169s
```

$ docker exec -ti btrfs-docker-k8s1.25.3-ec cat /var/lib/kubelet/config.yaml | grep -A1 "kind: KubeletConfiguration"
```
kind: KubeletConfiguration
localStorageCapacityIsolation: true
```

$ docker exec -ti btrfs-docker-k8s1.25.3-ec cat /etc/systemd/system/kubelet.service.d/10-kubeadm.conf | grep -i "localStorageCapacityIsolation"
```
(null)
```

---

$ minikube profile list
```
|---------------------------|-----------|---------|--------------|------|---------|---------|-------|--------|
|          Profile          | VM Driver | Runtime |      IP      | Port | Version | Status  | Nodes | Active |
|---------------------------|-----------|---------|--------------|------|---------|---------|-------|--------|
| btrfs-docker-k8s1.24.7    | docker    | docker  | 192.168.58.2 | 8443 | v1.24.7 | Running |     1 |        |
| btrfs-docker-k8s1.25.3    | docker    | docker  | 192.168.49.2 | 8443 | v1.25.3 | Running |     1 |        |
| btrfs-docker-k8s1.25.3-ec | docker    | docker  | 192.168.67.2 | 8443 | v1.25.3 | Running |     1 |        |
|---------------------------|-----------|---------|--------------|------|---------|---------|-------|--------|
```