### PR TITLE
site: update the links for hyperv documenation

### DIFF
--- a/deploy/iso/minikube-iso/arch/x86_64/package/hyperv-daemons/hv_fcopy_daemon.service
+++ b/deploy/iso/minikube-iso/arch/x86_64/package/hyperv-daemons/hv_fcopy_daemon.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Hyper-V FCOPY Daemon
-Documentation=https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/reference/integration-services#hyper-v-guest-service-interface
+Documentation=https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/reference/integration-services#hyper-v-guest-service-interface
 BindsTo=sys-devices-virtual-misc-vmbus\x21hv_fcopy.device
 
 [Service]

--- a/deploy/iso/minikube-iso/arch/x86_64/package/hyperv-daemons/hv_kvp_daemon.service
+++ b/deploy/iso/minikube-iso/arch/x86_64/package/hyperv-daemons/hv_kvp_daemon.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Hyper-V Key Value Pair Daemon
-Documentation=https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/reference/integration-services#hyper-v-data-exchange-service-kvp
+Documentation=https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/reference/integration-services#hyper-v-data-exchange-service-kvp
 BindsTo=sys-devices-virtual-misc-vmbus\x21hv_kvp.device
 
 [Service]

--- a/deploy/iso/minikube-iso/arch/x86_64/package/hyperv-daemons/hv_vss_daemon.service
+++ b/deploy/iso/minikube-iso/arch/x86_64/package/hyperv-daemons/hv_vss_daemon.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Hyper-V VSS Daemon
-Documentation=https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/reference/integration-services#hyper-v-volume-shadow-copy-requestor
+Documentation=https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/reference/integration-services#hyper-v-volume-shadow-copy-requestor
 BindsTo=sys-devices-virtual-misc-vmbus\x21hv_vss.device
 
 [Service]


### PR DESCRIPTION
The website has changed, update to the new website
https://docs.microsoft.com ——> https://learn.microsoft.com/