### PR TITLE
Handle latest hyperkit version string

### DIFF
--- a/pkg/minikube/registry/drvs/hyperkit/hyperkit.go
+++ b/pkg/minikube/registry/drvs/hyperkit/hyperkit.go
@@ -121,8 +121,9 @@ func isNewerVersion(currentVersion string, specificVersion string) (bool, error)
 	// Convert hyperkit version to time.Date to compare whether hyperkit version is not old.
 	layout := "20060102"
 	currentVersionDate, err := time.Parse(layout, currentVersion)
+	// newer versions of hyperkit no longer have a data embedded in their version
 	if err != nil {
-		return false, errors.Wrap(err, "parse date")
+		return true, nul
 	}
 	specificVersionDate, err := time.Parse(layout, specificVersion)
 	if err != nil {

--- a/pkg/minikube/registry/drvs/hyperkit/hyperkit_test.go
+++ b/pkg/minikube/registry/drvs/hyperkit/hyperkit_test.go
@@ -25,6 +25,7 @@ import (
 var (
 	versionOutputType1 = "hyperkit: v0.20190201-11-gc0dd46\n\nHomepage: https://github.com/docker/hyperkit\nLicense: BSD\n\n"
 	versionOutputType2 = "hyperkit: 0.20190201\n\nHomepage: https://github.com/docker/hyperkit\nLicense: BSD\n\n"
+	versionOutputType3 = "hyperkit: 40cbd5\n\nHomepage: https://github.com/docker/hyperkit\nLicense: BSD"
 )
 
 func TestSplitHyperKitVersion(t *testing.T) {
@@ -40,6 +41,11 @@ func TestSplitHyperKitVersion(t *testing.T) {
 			desc:    "split type2 output to YYYYMMDD format",
 			version: "0.20190201",
 			expect:  "20190201",
+		},
+		{
+			desc:    "split type3 output to YYYYMMDD format",
+			version: "40cdb5",
+			expect:  "0",
 		},
 		{
 			desc:    "non split YYYYMMDD output to YYYYMMDD format",
@@ -75,6 +81,11 @@ func TestConvertVersionToDate(t *testing.T) {
 			desc:          "split type2 output to YYYYMMDD format",
 			versionOutput: versionOutputType2,
 			expect:        "20190201",
+		},
+		{
+			desc:          "split type3 output to YYYYMMDD format",
+			versionOutput: versionOutputType3,
+			expect:        "0",
 		},
 		{
 			desc:          "split semver output to YYYYMMDD format",


### PR DESCRIPTION
Several years ago, hyperkit switched from using a data-based version to using a shortened build hash.  The version currently used by Canonical Multipass, for example, displays as such:

hyperkit: 40cbd5

Homepage: https://github.com/docker/hyperkit
License: BSD

This change adds a test that attempts to parse the new version.