### PR TITLE
Move license command to other section in help

### DIFF
--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -282,7 +282,6 @@ func init() {
 				updateCheckCmd,
 				versionCmd,
 				optionsCmd,
-				licenseCmd,
 			},
 		},
 	}
@@ -290,6 +289,7 @@ func init() {
 
 	// Ungrouped commands will show up in the "Other Commands" section
 	RootCmd.AddCommand(completionCmd)
+	RootCmd.AddCommand(licenseCmd)
 	templates.ActsAsRootCommand(RootCmd, []string{"options"}, groups...)
 
 	if err := viper.BindPFlags(RootCmd.PersistentFlags()); err != nil {


### PR DESCRIPTION
Moved command from `Troubleshooting` to `Other` section

**Before:**
```
$ minikube --help
...
Troubleshooting Commands:
  ssh-key          Retrieve the ssh identity key path of the specified node
  ssh-host         Retrieve the ssh host key of the specified node
  ip               Retrieves the IP address of the specified node
  logs             Returns logs to debug a local Kubernetes cluster
  update-check     Print current and latest version number
  version          Print the version of minikube
  options          Show a list of global command-line options (applies to all commands).
  license          Outputs the licenses of dependencies to a directory

Other Commands:
  completion       Generate command completion for a shell
```

**After:**
```
$ minikube --help
...
Troubleshooting Commands:
  ssh-key          Retrieve the ssh identity key path of the specified node
  ssh-host         Retrieve the ssh host key of the specified node
  ip               Retrieves the IP address of the specified node
  logs             Returns logs to debug a local Kubernetes cluster
  update-check     Print current and latest version number
  version          Print the version of minikube
  options          Show a list of global command-line options (applies to all commands).

Other Commands:
  completion       Generate command completion for a shell
  license          Outputs the licenses of dependencies to a directory
```