### PR TITLE
site: Update echo-server image

### DIFF
--- a/site/content/en/docs/handbook/controls.md
+++ b/site/content/en/docs/handbook/controls.md
@@ -25,7 +25,7 @@ minikube dashboard
 Once started, you can interact with your cluster using `kubectl`, just like any other Kubernetes cluster. For instance, starting a server:
 
 ```shell
-kubectl create deployment hello-minikube --image=k8s.gcr.io/echoserver:1.4
+kubectl create deployment hello-minikube --image=kicbase/echo-server:1.0
 ```
 
 Exposing a service as a NodePort

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -539,8 +539,8 @@ minikube dashboard
 Create a sample deployment and expose it on port 80:
 
 ```shell
-kubectl create deployment hello-minikube --image=docker.io/nginx:1.23
-kubectl expose deployment hello-minikube --type=NodePort --port=80
+kubectl create deployment hello-minikube --image=kicbase/echo-server:1.0
+kubectl expose deployment hello-minikube --type=NodePort --port=8080
 ```
 
 It may take a moment, but your deployment will soon show up when you run:
@@ -558,19 +558,19 @@ minikube service hello-minikube
 Alternatively, use kubectl to forward the port:
 
 ```shell
-kubectl port-forward service/hello-minikube 7080:80
+kubectl port-forward service/hello-minikube 7080:8080
 ```
 
 Tada! Your application is now available at [http://localhost:7080/](http://localhost:7080/).
 
-You should be able to see the request metadata from nginx such as the `CLIENT VALUES`, `SERVER VALUES`, `HEADERS RECEIVED` and the `BODY` in the application output. Try changing the path of the request and observe the changes in the `CLIENT VALUES`. Similarly, you can do a POST request to the same and observe the body show up in `BODY` section of the output.
+You should be able to see the request metadata in the application output. Try changing the path of the request and observe the changes. Similarly, you can do a POST request and observe the body show up in the output.
 {{% /tab %}}
 {{% tab LoadBalancer %}}
 To access a LoadBalancer deployment, use the "minikube tunnel" command. Here is an example deployment:
 
 ```shell
-kubectl create deployment balanced --image=docker.io/nginx:1.23
-kubectl expose deployment balanced --type=LoadBalancer --port=80
+kubectl create deployment balanced --image=kicbase/echo-server:1.0
+kubectl expose deployment balanced --type=LoadBalancer --port=8080
 ```
 
 In another window, start the tunnel to create a routable IP for the 'balanced' deployment:
@@ -585,7 +585,7 @@ To find the routable IP, run this command and examine the `EXTERNAL-IP` column:
 kubectl get services balanced
 ```
 
-Your deployment is now available at &lt;EXTERNAL-IP&gt;:80
+Your deployment is now available at &lt;EXTERNAL-IP&gt;:8080
 {{% /tab %}}
 {{% tab Ingress %}}
 Enable ingress addon:
@@ -604,7 +604,7 @@ metadata:
 spec:
   containers:
   - name: foo-app
-    image: docker.io/ealen/echo-server:0.7.0
+    image: kicbase/echo-server:1.0
 ---
 kind: Service
 apiVersion: v1
@@ -615,7 +615,7 @@ spec:
     app: foo
   ports:
   # Default port used by the image
-  - port: 80
+  - port: 8080
 ---
 kind: Pod
 apiVersion: v1
@@ -626,7 +626,7 @@ metadata:
 spec:
   containers:
   - name: bar-app
-    image: docker.io/ealen/echo-server:0.7.0
+    image: kicbase/echo-server:1.0
 ---
 kind: Service
 apiVersion: v1
@@ -637,7 +637,7 @@ spec:
     app: bar
   ports:
   # Default port used by the image
-  - port: 80
+  - port: 8080
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -653,14 +653,14 @@ spec:
           service:
             name: foo-service
             port:
-              number: 80
+              number: 8080
       - pathType: Prefix
         path: "/bar"
         backend:
           service:
             name: bar-service
             port:
-              number: 80
+              number: 8080
 ---
 ```
 
@@ -678,8 +678,13 @@ example-ingress   nginx   *       <your_ip_here>   80      5m45s
 
 Now verify that the ingress works
 ```shell
-curl <ip_from_above>/foo
-curl <ip_from_above>/bar
+$ curl <ip_from_above>/foo
+Request served by foo-app
+...
+
+$ curl <ip_from_above>/bar
+Request served by bar-app
+...
 ```
 {{% /tab %}}
 {{% /tabs %}}


### PR DESCRIPTION
Closes https://github.com/kubernetes/minikube/issues/11107
Closes https://github.com/kubernetes/minikube/issues/15086

**Problem:**
Original image was `k8s.gcr.io/echoserver:1.4` but it didn't work on arm64.

Updated image to `nginx:1.23` but it wasn't an echo-server, just displayed the nginx welcome screen.

Added image `ealen/echo-server:0.7.0` to ingress tutorial, but image has a critical CVE.
```
✗ Critical severity vulnerability found in zlib/zlib
  Description: Out-of-bounds Write
  Info: https://security.snyk.io/vuln/SNYK-ALPINE316-ZLIB-2976176
  Introduced through: zlib/zlib@1.2.12-r1, apk-tools/apk-tools@2.12.9-r3
  From: zlib/zlib@1.2.12-r1
  From: apk-tools/apk-tools@2.12.9-r3 > zlib/zlib@1.2.12-r1
  Fixed in: 1.2.12-r2
```

**Solution:**
Updated all references to `kicbase/echo-server:1.0`

- Image works on both amd64 & arm64
- Image is a true echo-server
```
Request served by hello-minikube-564c59b4dd-4tch4

HTTP/1.1 GET /test123

Host: 192.168.105.34:31791
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
Accept-Encoding: gzip, deflate
Accept-Language: en-US,en;q=0.9
Connection: keep-alive
Upgrade-Insecure-Requests: 1
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36
```
- Image has no CVEs
```
Testing kicbase/echo-server:1.0...

Package manager:   linux
Project name:      docker-image|kicbase/echo-server
Docker image:      kicbase/echo-server:1.0
Platform:          linux/arm64
Licenses:          enabled

✔ Tested kicbase/echo-server:1.0 for known issues, no vulnerable paths found.

Note that we do not currently have vulnerability data for your image.

-------------------------------------------------------

Testing kicbase/echo-server:1.0...

Package manager:   gomodules
Target file:       /bin/echo-server
Project name:      github.com/jmalloc/echo-server
Docker image:      kicbase/echo-server:1.0
Licenses:          enabled

✔ Tested 9 dependencies for known issues, no vulnerable paths found.


Tested 2 projects, no vulnerable paths were found.
```