### PR TITLE
Update Windows installer script to create system-wide shortcut

### DIFF
--- a/installers/windows/minikube.nsi
+++ b/installers/windows/minikube.nsi
@@ -121,6 +121,8 @@ Function .onInit
 FunctionEnd
 
 Section "Install"
+  SetShellVarContext all
+
 	# Files for the install directory - to build the installer, these should be in the same directory as the install script (this file)
 	SetOutPath $INSTDIR
 	# Files added here should be removed by the uninstaller (see section "uninstall")
@@ -166,6 +168,7 @@ Section "Install"
 SectionEnd
 
 Section "Uninstall"
+  SetShellVarContext all
 
 	# Remove Start Menu launcher
 	Delete /REBOOTOK "$SMPROGRAMS\${COMPANYNAME}\${APPNAME}.lnk"

--- a/installers/windows/minikube.nsi
+++ b/installers/windows/minikube.nsi
@@ -121,8 +121,8 @@ Function .onInit
 FunctionEnd
 
 Section "Install"
-  # Required to create a system-wide Start Menu shortcut 
-  SetShellVarContext all
+	# Required to create a system-wide Start Menu shortcut 
+	SetShellVarContext all
 
 	# Files for the install directory - to build the installer, these should be in the same directory as the install script (this file)
 	SetOutPath $INSTDIR
@@ -169,8 +169,8 @@ Section "Install"
 SectionEnd
 
 Section "Uninstall"
-  # Required to remove the system-wide Start Menu shortcut
-  SetShellVarContext all
+	# Required to remove the system-wide Start Menu shortcut
+	SetShellVarContext all
 
 	# Remove Start Menu launcher
 	Delete /REBOOTOK "$SMPROGRAMS\${COMPANYNAME}\${APPNAME}.lnk"

--- a/installers/windows/minikube.nsi
+++ b/installers/windows/minikube.nsi
@@ -121,6 +121,7 @@ Function .onInit
 FunctionEnd
 
 Section "Install"
+  # Required to create a system-wide Start Menu shortcut 
   SetShellVarContext all
 
 	# Files for the install directory - to build the installer, these should be in the same directory as the install script (this file)
@@ -168,6 +169,7 @@ Section "Install"
 SectionEnd
 
 Section "Uninstall"
+  # Required to remove the system-wide Start Menu shortcut
   SetShellVarContext all
 
 	# Remove Start Menu launcher


### PR DESCRIPTION
Related issue: https://github.com/kubernetes/minikube/issues/13029
Problem: when using the Windows installer, it only creates a shortcut in the Start Menu for the user installing minikube. Since the installation process is a system-wide process, it should also create a Start Menu shortcut for other users on the machine.

Implemented the solution suggested by [https://github.com/xenophonf](xenophonf) - who opened the issue.
Tested both install and uninstall locally using a Windows 10 - Version 21H2 machine, and got the new expected behaviour.
