### PR TITLE
CI: Update GitHub Actions from Ubuntu 18.04 to 20.04

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -492,16 +492,16 @@ jobs:
           if [ "$numPass" -eq 0 ];then echo "*** 0 Passed! ***";exit 2;fi
           if [ "$numPass" -lt 33 ];then echo "*** Failed to pass at least 33 ! ***";exit 2;fi
           if [ "$numPass" -eq 0 ];then echo "*** Passed! ***";exit 0;fi
-  functional_baremetal_ubuntu18_04:
+  functional_baremetal_ubuntu20_04:
     permissions:
       contents: none
     needs: [build_minikube]
     env:
       TIME_ELAPSED: time
-      JOB_NAME: "functional_baremetal_ubuntu18_04"
+      JOB_NAME: "functional_baremetal_ubuntu20_04"
       GOPOGH_RESULT: ""
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Install kubectl
         shell: bash
@@ -576,9 +576,9 @@ jobs:
           echo 'EOF' >> $GITHUB_ENV
       - uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb
         with:
-          name: functional_baremetal_ubuntu18_04
+          name: functional_baremetal_ubuntu20_04
           path: minikube_binaries/report
-      - name: The End Result functional_baremetal_ubuntu18_04
+      - name: The End Result functional_baremetal_ubuntu20_04
         shell: bash
         run: |
           echo ${GOPOGH_RESULT}
@@ -606,7 +606,7 @@ jobs:
         functional_docker_containerd_ubuntu,
         functional_podman_ubuntu,
         functional_virtualbox_macos,
-        functional_baremetal_ubuntu18_04,
+        functional_baremetal_ubuntu20_04,
       ]
     runs-on: ubuntu-20.04
     steps:
@@ -622,7 +622,7 @@ jobs:
           cp -r ./functional_docker_containerd_ubuntu ./all_reports/
           cp -r ./functional_podman_ubuntu ./all_reports/
           cp -r ./functional_virtualbox_macos ./all_reports/
-          cp -r ./functional_baremetal_ubuntu18_04 ./all_reports/
+          cp -r ./functional_baremetal_ubuntu20_04 ./all_reports/
 
       - uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -536,6 +536,10 @@ jobs:
         run: |
           curl -LO https://github.com/medyagh/gopogh/releases/download/v0.13.0/gopogh-linux-amd64
           sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
+      - name: Set fs.protected_regular
+        shell: bash
+        run: |
+          sudo sysctl fs.protected_regular=0
       - name: Download Binaries
         uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -491,16 +491,16 @@ jobs:
           if [ "$numPass" -eq 0 ];then echo "*** 0 Passed! ***";exit 2;fi
           if [ "$numPass" -lt 33 ];then echo "*** Failed to pass at least 33 ! ***";exit 2;fi
           if [ "$numPass" -eq 0 ];then echo "*** Passed! ***";exit 0;fi
-  functional_baremetal_ubuntu18_04:
+  functional_baremetal_ubuntu20_04:
     permissions:
       contents: none
     needs: [build_minikube]
     env:
       TIME_ELAPSED: time
-      JOB_NAME: "functional_baremetal_ubuntu18_04"
+      JOB_NAME: "functional_baremetal_ubuntu20_04"
       GOPOGH_RESULT: ""
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Install kubectl
         shell: bash
@@ -576,9 +576,9 @@ jobs:
           echo 'EOF' >> $GITHUB_ENV
       - uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb
         with:
-          name: functional_baremetal_ubuntu18_04
+          name: functional_baremetal_ubuntu20_04
           path: minikube_binaries/report
-      - name: The End Result functional_baremetal_ubuntu18_04
+      - name: The End Result functional_baremetal_ubuntu20_04
         shell: bash
         run: |
           echo ${GOPOGH_RESULT}
@@ -606,7 +606,7 @@ jobs:
         functional_docker_containerd_ubuntu,
         functional_podman_ubuntu,
         functional_virtualbox_macos,
-        functional_baremetal_ubuntu18_04,
+        functional_baremetal_ubuntu20_04,
       ]
     runs-on: ubuntu-20.04
     steps:
@@ -622,7 +622,7 @@ jobs:
           cp -r ./functional_docker_containerd_ubuntu ./all_reports/
           cp -r ./functional_podman_ubuntu ./all_reports/
           cp -r ./functional_virtualbox_macos ./all_reports/
-          cp -r ./functional_baremetal_ubuntu18_04 ./all_reports/
+          cp -r ./functional_baremetal_ubuntu20_04 ./all_reports/
 
       - uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -535,6 +535,10 @@ jobs:
         run: |
           curl -LO https://github.com/medyagh/gopogh/releases/download/v0.13.0/gopogh-linux-amd64
           sudo install gopogh-linux-amd64 /usr/local/bin/gopogh
+      - name: Set fs.protected_regular
+        shell: bash
+        run: |
+          sudo sysctl fs.protected_regular=0
       - name: Download Binaries
         uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7
         with:


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/6002

Ubuntu 18.04 machines are deprecated, updating to 20.04

Also added `sudo sysctl fs.protected_regular=0` as on new Ubuntu it defaults to `fs.protected_regular=2`.

Successful run: https://github.com/spowelljr/minikube/actions/runs/3597295470/jobs/6059114527