### PR TITLE
docs: add missing OutFile parameter

### DIFF
--- a/site/content/en/docs/tutorials/setup_minikube_gui.md
+++ b/site/content/en/docs/tutorials/setup_minikube_gui.md
@@ -44,7 +44,7 @@ open dist/minikube.app
 {{% windowstab %}}
 1. Download the zipped folder via PowerShell (below) or via your [browser](https://storage.googleapis.com/minikube-gui/nightly/minikube-gui-windows.zip) (faster)
 ```shell
-Invoke-WebRequest -Uri 'https://storage.googleapis.com/minikube-gui/nightly/minikube-gui-windows.zip' -UseBasicParsing
+Invoke-WebRequest -OutFile 'minikube-gui-windows.zip' -Uri 'https://storage.googleapis.com/minikube-gui/nightly/minikube-gui-windows.zip' -UseBasicParsing
 ```
 
 2. Unzip


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

https://minikube.sigs.k8s.io/docs/tutorials/setup_minikube_gui/ - the OutFile parameter is missing in the windows steps tab. It should be like in the installation section https://minikube.sigs.k8s.io/docs/start/:
```
-OutFile
Specifies the output file for which this cmdlet saves the response body. Enter a path and filename. If you omit the path, the default is the current location.
```

Before:
![image](https://user-images.githubusercontent.com/47745270/206221433-2ba1abba-596c-4bdc-82d7-27c3dc1ff36e.png)

After:
![image](https://user-images.githubusercontent.com/47745270/206221526-620e81af-bda7-4355-a016-471e687afd9f.png)
