### PR TITLE
Change cpus config field to string to support max value

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -75,7 +75,7 @@ var settings = []Setting{
 	},
 	{
 		name:        "cpus",
-		set:         SetInt,
+		set:         SetString,
 		validations: []setFn{IsValidCPUs},
 		callbacks:   []setFn{RequiresRestartMsg},
 	},


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/15468

**Before:**
```
$ minikube config set cpus max

❌  Exiting due to MK_CONFIG_SET: set: strconv.Atoi: parsing "max": invalid syntax

╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                         │
│    😿  If the above advice does not help, please let us know:                                                           │
│    👉  https://github.com/kubernetes/minikube/issues/new/choose                                                         │
│                                                                                                                         │
│    Please run `minikube logs --file=logs.txt` and attach logs.txt to the GitHub issue.                                  │
│    Please also attach the following file to the GitHub issue:                                                           │
│    - /var/folders/9l/6wpxv6wd1b901m1146r579wc00rqw3/T/minikube_config_15c3e99d63670bb33f9e3453813a4d46a56daa07_0.log    │
│                                                                                                                         │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

**After:**
```
$ minikube config set cpus max
❗  These changes will take effect upon a minikube delete and then a minikube start
```