### PR TITLE
Remove progress bar for kic download when JSON output

### DIFF
--- a/pkg/minikube/download/image.go
+++ b/pkg/minikube/download/image.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/detect"
 	"k8s.io/minikube/pkg/minikube/image"
 	"k8s.io/minikube/pkg/minikube/localpath"
+	"k8s.io/minikube/pkg/minikube/out"
 )
 
 var (
@@ -138,6 +139,12 @@ func ImageToCache(img string) error {
 		return errors.Wrap(err, "getting remote image")
 	}
 	klog.V(3).Infof("Writing image %v", tag)
+	if out.JSON {
+		if err := tarball.WriteToFile(f, tag, i); err != nil {
+			return errors.Wrap(err, "writing tarball image")
+		}
+		return nil
+	}
 	errchan := make(chan error)
 	p := pb.Full.Start64(0)
 	fn := image.Tag(ref.Name())


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/minikube/issues/15480

**Before:**
```
{"specversion":"1.0","id":"66aee6f2-af85-4dde-9028-d90c51274d26","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.step","datacontenttype":"application/json","data":{"currentstep":"0","message":"minikube v1.28.0 on Darwin 13.0.1 (arm64)","name":"Initial Minikube Setup","totalsteps":"19"}}
{"specversion":"1.0","id":"f66c2c39-a23a-4929-b53e-0d8b9909fc27","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.step","datacontenttype":"application/json","data":{"currentstep":"1","message":"Automatically selected the docker driver. Other choices: ssh, qemu2 (experimental)","name":"Selecting Driver","totalsteps":"19"}}
{"specversion":"1.0","id":"00155e05-8a50-4c1d-963e-f24062dcf79c","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.info","datacontenttype":"application/json","data":{"message":"Using Docker Desktop driver with root privileges"}}
{"specversion":"1.0","id":"97d4e6fa-ea41-4bb1-af7c-e34ec8ac4878","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.step","datacontenttype":"application/json","data":{"currentstep":"3","message":"Starting control plane node minikube in cluster minikube","name":"Starting Node","totalsteps":"19"}}
{"specversion":"1.0","id":"69a6b66c-bc12-48e0-8ded-f1dac7d061a5","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.step","datacontenttype":"application/json","data":{"currentstep":"5","message":"Pulling base image ...","name":"Pulling Base Image","totalsteps":"19"}}
{"specversion":"1.0","id":"26d23bbe-dba9-4da5-8fec-3c92162d1ff2","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.step","datacontenttype":"application/json","data":{"currentstep":"5","message":"Downloading Kubernetes v1.25.3 preload ...","name":"Pulling Base Image","totalsteps":"19"}}
{"specversion":"1.0","id":"a9752a73-cd2f-4565-8d62-15d5a90b099e","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download","datacontenttype":"application/json","data":{"artifact":"preloaded-images-k8s-v18-v1.25.3-docker-overlay2-arm64.tar.lz4","currentstep":"5","totalsteps":"19"}}
    > gcr.io/k8s-minikube/kicbase...:  6.34 MiB / 347.54 MiB  1.83% 10.59 MiB p{"specversion":"1.0","id":"5a5dbe90-e1c1-4a3d-8c68-8b97f2216cf4","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download.progress","datacontenttype":"application/json","data":{"artifact":"preloaded-images-k8s-v18-v1.25.3-docker-overlay2-arm64.tar.lz4","currentstep":"5","progress":"0.06765009779836205","totalsteps":"19"}}
    > gcr.io/k8s-minikube/kicbase...:  25.97 MiB / 347.54 MiB  7.47% 11.90 MiB {"specversion":"1.0","id":"32b3231e-152a-4eb8-8517-38cbee741aa2","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download.progress","datacontenttype":"application/json","data":{"artifact":"preloaded-images-k8s-v18-v1.25.3-docker-overlay2-arm64.tar.lz4","currentstep":"5","progress":"0.16846773814581306","totalsteps":"19"}}
    > gcr.io/k8s-minikube/kicbase...:  25.97 MiB / 347.54 MiB  7.47% 10.52 MiB {"specversion":"1.0","id":"dc3969d2-d948-42ce-991a-522d6ff64a08","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download.progress","datacontenttype":"application/json","data":{"artifact":"preloaded-images-k8s-v18-v1.25.3-docker-overlay2-arm64.tar.lz4","currentstep":"5","progress":"0.34341313144438507","totalsteps":"19"}}
    > gcr.io/k8s-minikube/kicbase...:  25.97 MiB / 347.54 MiB  7.47% 9.21 MiB p{"specversion":"1.0","id":"e4826970-5865-47a4-b2d9-6db586d18b51","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download.progress","datacontenttype":"application/json","data":{"artifact":"preloaded-images-k8s-v18-v1.25.3-docker-overlay2-arm64.tar.lz4","currentstep":"5","progress":"0.4894769495129868","totalsteps":"19"}}
    > gcr.io/k8s-minikube/kicbase...:  25.99 MiB / 347.54 MiB  7.48% 8.61 MiB p{"specversion":"1.0","id":"ef43addc-495b-40d9-a5cf-65f3ca33b993","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download.progress","datacontenttype":"application/json","data":{"artifact":"preloaded-images-k8s-v18-v1.25.3-docker-overlay2-arm64.tar.lz4","currentstep":"5","progress":"0.5522566299032594","totalsteps":"19"}}
    > gcr.io/k8s-minikube/kicbase...:  33.99 MiB / 347.54 MiB  9.78% 8.25 MiB p{"specversion":"1.0","id":"32aea89b-53ea-48d5-919c-19432156930c","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download.progress","datacontenttype":"application/json","data":{"artifact":"preloaded-images-k8s-v18-v1.25.3-docker-overlay2-arm64.tar.lz4","currentstep":"5","progress":"0.6760626404168925","totalsteps":"19"}}
    > gcr.io/k8s-minikube/kicbase...:  49.91 MiB / 347.54 MiB  14.36% 9.03 MiB {"specversion":"1.0","id":"b1bcb827-393b-432d-9022-a72b7c9a4fc7","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download.progress","datacontenttype":"application/json","data":{"artifact":"preloaded-images-k8s-v18-v1.25.3-docker-overlay2-arm64.tar.lz4","currentstep":"5","progress":"0.8055183351239094","totalsteps":"19"}}
    > gcr.io/k8s-minikube/kicbase...:  58.73 MiB / 347.54 MiB  16.90% 8.45 MiB {"specversion":"1.0","id":"af2c49ef-888d-4be3-a0c6-011600e8fac5","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download.progress","datacontenttype":"application/json","data":{"artifact":"preloaded-images-k8s-v18-v1.25.3-docker-overlay2-arm64.tar.lz4","currentstep":"5","progress":"0.9244539282294529","totalsteps":"19"}}
    > gcr.io/k8s-minikube/kicbase...:  67.15 MiB / 347.54 MiB  19.32% 8.98 MiB {"specversion":"1.0","id":"413e1f64-47d1-40fb-b51e-07f7f7d729d4","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download.progress","datacontenttype":"application/json","data":{"artifact":"preloaded-images-k8s-v18-v1.25.3-docker-overlay2-arm64.tar.lz4","currentstep":"5","progress":"1","totalsteps":"19"}}
{"specversion":"1.0","id":"0d741841-8aaa-4165-b315-bb576a8af88b","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download.progress","datacontenttype":"application/json","data":{"artifact":"preloaded-images-k8s-v18-v1.25.3-docker-overlay2-arm64.tar.lz4","currentstep":"5","progress":"1","totalsteps":"19"}}
    > gcr.io/k8s-minikube/kicbase...:  88.94 MiB / 347.54 MiB  25.59% 10.34 MiB{"specversion":"1.0","id":"94dbf195-4a4e-4940-946d-8e600775d440","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download","datacontenttype":"application/json","data":{"artifact":"kubectl.sha256","currentstep":"5","totalsteps":"19"}}
{"specversion":"1.0","id":"49640433-74eb-435d-9d4e-e218cbd32701","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download.progress","datacontenttype":"application/json","data":{"artifact":"kubectl.sha256","currentstep":"5","progress":"1","totalsteps":"19"}}
{"specversion":"1.0","id":"c10225df-22be-412d-ab88-86c62253acad","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download.progress","datacontenttype":"application/json","data":{"artifact":"kubectl.sha256","currentstep":"5","progress":"1","totalsteps":"19"}}
    > gcr.io/k8s-minikube/kicbase...:  88.94 MiB / 347.54 MiB  25.59% 10.34 MiB{"specversion":"1.0","id":"d13e1c41-2c6b-4166-9536-b961247ad6fd","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download","datacontenttype":"application/json","data":{"artifact":"kubectl","currentstep":"5","totalsteps":"19"}}
    > gcr.io/k8s-minikube/kicbase...:  106.35 MiB / 347.54 MiB  30.60% 10.88 Mi{"specversion":"1.0","id":"5760442b-3d0c-4b95-907b-6fe7259215ee","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download.progress","datacontenttype":"application/json","data":{"artifact":"kubectl","currentstep":"5","progress":"0.45898446533215576","totalsteps":"19"}}
    > gcr.io/k8s-minikube/kicbase...:  112.65 MiB / 347.54 MiB  32.41% 10.85 Mi{"specversion":"1.0","id":"d387ef99-2f56-46b5-8d39-ea69581f9e60","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download.progress","datacontenttype":"application/json","data":{"artifact":"kubectl","currentstep":"5","progress":"1","totalsteps":"19"}}
{"specversion":"1.0","id":"ba3bbc96-3d1f-4162-9fb3-8549e0f1987f","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download.progress","datacontenttype":"application/json","data":{"artifact":"kubectl","currentstep":"5","progress":"1","totalsteps":"19"}}
    > gcr.io/k8s-minikube/kicbase...:  347.54 MiB / 347.54 MiB  100.00% 13.04 M
{"specversion":"1.0","id":"fb0f0658-7a59-4b1e-8945-dab4fd9001df","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.step","datacontenttype":"application/json","data":{"currentstep":"5","message":"Download complete!","name":"Pulling Base Image","totalsteps":"19"}}
```

**After:**
```
{"specversion":"1.0","id":"d647f0cf-3243-4001-a998-a2133391e6fe","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.step","datacontenttype":"application/json","data":{"currentstep":"0","message":"minikube v1.28.0 on Darwin 13.0.1 (arm64)","name":"Initial Minikube Setup","totalsteps":"19"}}
{"specversion":"1.0","id":"e5487654-00b4-4435-944b-385f697dc518","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.step","datacontenttype":"application/json","data":{"currentstep":"1","message":"Automatically selected the docker driver. Other choices: ssh, qemu2 (experimental)","name":"Selecting Driver","totalsteps":"19"}}
{"specversion":"1.0","id":"e1917d7d-c34e-451e-8940-3af67b9cb460","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.info","datacontenttype":"application/json","data":{"message":"Using Docker Desktop driver with root privileges"}}
{"specversion":"1.0","id":"88bb0d21-caf0-4748-9b63-53776cc1d2f2","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.step","datacontenttype":"application/json","data":{"currentstep":"3","message":"Starting control plane node minikube in cluster minikube","name":"Starting Node","totalsteps":"19"}}
{"specversion":"1.0","id":"9c8515a6-3467-48fb-98ee-f64cad2d9388","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.step","datacontenttype":"application/json","data":{"currentstep":"5","message":"Pulling base image ...","name":"Pulling Base Image","totalsteps":"19"}}
{"specversion":"1.0","id":"abc35afe-2744-4973-af5b-e3add73d6d6b","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.step","datacontenttype":"application/json","data":{"currentstep":"5","message":"Downloading Kubernetes v1.25.3 preload ...","name":"Pulling Base Image","totalsteps":"19"}}
{"specversion":"1.0","id":"aa8e764d-0d53-49f2-8be0-4d4aaf102d98","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download","datacontenttype":"application/json","data":{"artifact":"preloaded-images-k8s-v18-v1.25.3-docker-overlay2-arm64.tar.lz4","currentstep":"5","totalsteps":"19"}}
{"specversion":"1.0","id":"8683d966-8b2d-4fd3-8213-412694a1b3a6","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download.progress","datacontenttype":"application/json","data":{"artifact":"preloaded-images-k8s-v18-v1.25.3-docker-overlay2-arm64.tar.lz4","currentstep":"5","progress":"0.1746009414697588","totalsteps":"19"}}
{"specversion":"1.0","id":"1326f1ee-d21c-4c5f-8bbf-a54708514350","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download.progress","datacontenttype":"application/json","data":{"artifact":"preloaded-images-k8s-v18-v1.25.3-docker-overlay2-arm64.tar.lz4","currentstep":"5","progress":"0.36961245448965924","totalsteps":"19"}}
{"specversion":"1.0","id":"2c5d9bc9-418a-48d6-b2be-17670a56a712","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download.progress","datacontenttype":"application/json","data":{"artifact":"preloaded-images-k8s-v18-v1.25.3-docker-overlay2-arm64.tar.lz4","currentstep":"5","progress":"0.5720270019698556","totalsteps":"19"}}
{"specversion":"1.0","id":"10698714-7580-4144-9b3d-123c356666aa","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download.progress","datacontenttype":"application/json","data":{"artifact":"preloaded-images-k8s-v18-v1.25.3-docker-overlay2-arm64.tar.lz4","currentstep":"5","progress":"0.7779482499838762","totalsteps":"19"}}
{"specversion":"1.0","id":"4fc8d74c-f26c-45ac-bcfd-47f5f8ee94f2","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download.progress","datacontenttype":"application/json","data":{"artifact":"preloaded-images-k8s-v18-v1.25.3-docker-overlay2-arm64.tar.lz4","currentstep":"5","progress":"0.9248400390118532","totalsteps":"19"}}
{"specversion":"1.0","id":"3a4da4b1-1f50-4e81-84e4-70224beccf8c","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download.progress","datacontenttype":"application/json","data":{"artifact":"preloaded-images-k8s-v18-v1.25.3-docker-overlay2-arm64.tar.lz4","currentstep":"5","progress":"1","totalsteps":"19"}}
{"specversion":"1.0","id":"7ed13212-9d20-4e84-bdc5-066a40fc08fc","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download.progress","datacontenttype":"application/json","data":{"artifact":"preloaded-images-k8s-v18-v1.25.3-docker-overlay2-arm64.tar.lz4","currentstep":"5","progress":"1","totalsteps":"19"}}
{"specversion":"1.0","id":"ca22b51f-ee53-4bfc-a223-e6f9898c002c","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download","datacontenttype":"application/json","data":{"artifact":"kubectl.sha256","currentstep":"5","totalsteps":"19"}}
{"specversion":"1.0","id":"bb6b0b9f-36bc-4738-837f-a84f9b9bebc8","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download.progress","datacontenttype":"application/json","data":{"artifact":"kubectl.sha256","currentstep":"5","progress":"1","totalsteps":"19"}}
{"specversion":"1.0","id":"c9bdbfc6-3411-4a07-a0de-7fbcc13fd487","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download.progress","datacontenttype":"application/json","data":{"artifact":"kubectl.sha256","currentstep":"5","progress":"1","totalsteps":"19"}}
{"specversion":"1.0","id":"a52d0611-c31a-422d-ab5d-8ec2c9b66f1d","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download","datacontenttype":"application/json","data":{"artifact":"kubectl","currentstep":"5","totalsteps":"19"}}
{"specversion":"1.0","id":"b4e47014-4440-40e6-b160-ba1f39cb1f8b","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download.progress","datacontenttype":"application/json","data":{"artifact":"kubectl","currentstep":"5","progress":"1","totalsteps":"19"}}
{"specversion":"1.0","id":"1d26ec21-2a4e-4e57-a5d2-0e187e626fa8","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.download.progress","datacontenttype":"application/json","data":{"artifact":"kubectl","currentstep":"5","progress":"1","totalsteps":"19"}}
{"specversion":"1.0","id":"1261d3f7-2071-4bbb-9b94-bb9afe457c51","source":"https://minikube.sigs.k8s.io/","type":"io.k8s.sigs.minikube.step","datacontenttype":"application/json","data":{"currentstep":"5","message":"Download complete!","name":"Pulling Base Image","totalsteps":"19"}}
```