### PR TITLE
`minikube cp` now supports providing directory as a target

### DIFF
--- a/cmd/minikube/cmd/cp.go
+++ b/cmd/minikube/cmd/cp.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"path"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -102,14 +101,14 @@ func setDstFileNameFromSrc(dst, src string) string {
 	var dd, df, sf string
 	switch {
 	case guestToHost:
-		_, sf = path.Split(src)
+		_, sf = pt.Split(src)
 		dd, df = filepath.Split(dst)
 	case guestToGuest:
-		_, sf = path.Split(src)
-		dd, df = path.Split(dst)
+		_, sf = pt.Split(src)
+		dd, df = pt.Split(dst)
 	default:
 		_, sf = filepath.Split(src)
-		dd, df = path.Split(dst)
+		dd, df = pt.Split(dst)
 	}
 
 	// if dst is empty, dd and df will be empty, so return dst
@@ -133,7 +132,7 @@ func setDstFileNameFromSrc(dst, src string) string {
 		return filepath.Join(dd, sf)
 	}
 
-	return path.Join(dd, sf)
+	return pt.Join(dd, sf)
 }
 
 // split path to node name and file path

--- a/cmd/minikube/cmd/cp.go
+++ b/cmd/minikube/cmd/cp.go
@@ -17,6 +17,9 @@ limitations under the License.
 package cmd
 
 import (
+	"path"
+	"path/filepath"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -56,8 +59,10 @@ Example Command : "minikube cp a.txt /home/docker/b.txt" +
 	minikube cp <source file path> <target file absolute path> (example: "minikube cp a/b.txt /copied.txt")`)
 		}
 
-		src := newRemotePath(args[0])
-		dst := newRemotePath(args[1])
+		srcPath := args[0]
+		dstPath := setDstFileNameFromSrc(args[1], srcPath)
+		src := newRemotePath(srcPath)
+		dst := newRemotePath(dstPath)
 		validateArgs(src, dst)
 
 		co := mustload.Running(ClusterFlagValue())
@@ -81,6 +86,54 @@ Example Command : "minikube cp a.txt /home/docker/b.txt" +
 }
 
 func init() {
+}
+
+// setDstFileNameFromSrc sets the src filename as dst filename
+// when the dst file name is not provided and ends with a `/`.
+// Otherwise this function is a no-op and returns the passed dst.
+func setDstFileNameFromSrc(dst, src string) string {
+	srcPath := newRemotePath(src)
+	dstPath := newRemotePath(dst)
+	guestToHost := srcPath.node != "" && dstPath.node == ""
+	guestToGuest := srcPath.node != "" && dstPath.node != ""
+
+	// Since Host can be any OS and Guest can only be linux, use
+	// filepath and path respectively
+	var dd, df, sf string
+	switch {
+	case guestToHost:
+		_, sf = path.Split(src)
+		dd, df = filepath.Split(dst)
+	case guestToGuest:
+		_, sf = path.Split(src)
+		dd, df = path.Split(dst)
+	default:
+		_, sf = filepath.Split(src)
+		dd, df = path.Split(dst)
+	}
+
+	// if dst is empty, dd and df will be empty, so return dst
+	// validation will be happening in `validateArgs`
+	if dd == "" && df == "" {
+		return ""
+	}
+
+	// if filename is already provided, return dst
+	if df != "" {
+		return dst
+	}
+
+	// if src filename is empty, return dst
+	if sf == "" {
+		return dst
+	}
+
+	// https://github.com/kubernetes/minikube/pull/15519/files#r1261750910
+	if guestToHost {
+		return filepath.Join(dd, sf)
+	}
+
+	return path.Join(dd, sf)
 }
 
 // split path to node name and file path

--- a/cmd/minikube/cmd/cp_test.go
+++ b/cmd/minikube/cmd/cp_test.go
@@ -60,3 +60,26 @@ func TestParsePath(t *testing.T) {
 		}
 	}
 }
+
+func TestSetDstFileNameFromSrc(t *testing.T) {
+	cases := []struct {
+		src  string
+		dst  string
+		want string
+	}{
+		{"./a/b", "/c/", "/c/b"},
+		{"./a/b", "node:/c/", "node:/c/b"},
+		{"./a", "/c/", "/c/a"},
+		{"", "/c/", "/c/"},
+		{"./a/b", "", ""},
+		{"./a/b", "/c", "/c"},
+		{"./a/", "/c/", "/c/"},
+	}
+
+	for _, c := range cases {
+		got := setDstFileNameFromSrc(c.dst, c.src)
+		if c.want != got {
+			t.Fatalf("wrong dst path for src=%s & dst=%s. want: %q, got: %q", c.src, c.dst, c.want, got)
+		}
+	}
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

fixes #15338 

# Description

Currently, `minikube cp` command accepts only absolute file path for the copying destination. However, this might be inconvinient when the file name of the source and destination is same. Why not infer the destination file name from source like unix `cp` command.

This change allows us to infer the destination file name from source file when the destination path ends with a forward slash `/`. 

> Note: if the destination is a directory, we already throw an error saying the destination is a directory. However, if we append a forward slash at the end, the `cp` operation is a no-op.

## Before

```bash
$ minikube cp ./OWNERS /home/docker/ 
$ minikube ssh
docker@minikube:~$ pwd
/home/docker
docker@minikube:~$ ll # `OWNERS` file is not copied here
total 32
drwxr-xr-x 1 docker docker 4096 Dec 15 10:29 ./
drwxr-xr-x 1 root   root   4096 Oct 25 18:41 ../
-rw-r--r-- 1 docker docker  220 Oct 25 18:41 .bash_logout
-rw-r--r-- 1 docker docker 3771 Oct 25 18:41 .bashrc
-rw-r--r-- 1 docker docker  807 Oct 25 18:41 .profile
drwxr-xr-x 1 docker docker 4096 Dec 15 10:29 .ssh/
-rw-r--r-- 1 docker docker    0 Dec 15 10:29 .sudo_as_admin_successful
```

This is a no-op. The status code (`echo $?`) is also `0`.

## After

```bash
$ minikube cp ./OWNERS /home/docker/
$ minikube ssh
Last login: Thu Dec 15 12:14:02 2022 from 192.168.76.1
docker@minikube:~$ pwd
/home/docker
docker@minikube:~$ ll
total 40
drwxr-xr-x 1 docker docker 4096 Dec 15 12:18 ./
drwxr-xr-x 1 root   root   4096 Oct 25 18:41 ../
-rw------- 1 docker docker    7 Dec 15 12:15 .bash_history
-rw-r--r-- 1 docker docker  220 Oct 25 18:41 .bash_logout
-rw-r--r-- 1 docker docker 3771 Oct 25 18:41 .bashrc
-rw-r--r-- 1 docker docker  807 Oct 25 18:41 .profile
drwxr-xr-x 1 docker docker 4096 Dec 15 10:29 .ssh/
-rw-r--r-- 1 docker docker    0 Dec 15 10:29 .sudo_as_admin_successful
-rw-r--r-- 1 root   root    348 Dec 15 11:51 OWNERS # <-- `OWNERS` file is copied here
docker@minikube:~$
```

Owners file is copied to the destination directory. The file name is infered from the source file
