### PR TITLE
Enable Google analytics on minikube website

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -59,7 +59,7 @@ anchor = "smart"
 [services]
 [services.googleAnalytics]
 # Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
-#id = "UA-00000000-0"
+id = "G-JPP6RFM2BP"
 
 # Language configuration
 [languages]


### PR DESCRIPTION
related to https://github.com/kubernetes/website/issues/37801