### PR TITLE
docs: Use alpine/socat docker image

### DIFF
--- a/site/content/en/docs/handbook/registry.md
+++ b/site/content/en/docs/handbook/registry.md
@@ -47,9 +47,11 @@ with TLS certificates. Because the default service cluster IP is known to be ava
 deployed inside the cluster by creating the cluster with `minikube start --insecure-registry "10.0.0.0/24"`. Ensure the cluster
 is deleted using `minikube delete` before starting with the `--insecure-registry` flag.
 
-### docker on macOS
+## Using minikube registry addon
 
-Quick guide for configuring minikube and docker on macOS, enabling docker to push images to minikube's registry.
+### Docker on macOS or Linux
+
+This is a quick guide for configuring minikube and docker on macOS or Linux, enabling docker to push images to minikube's registry.
 
 The first step is to enable the registry addon:
 
@@ -63,7 +65,7 @@ When enabled, the registry addon exposes its port 5000 on the minikube's virtual
 In order to make docker accept pushing images to this registry, we have to redirect port 5000 on the docker virtual machine over to port 5000 on the minikube machine. We can (ab)use docker's network configuration to instantiate a container on the docker's host, and run socat there:
 
 ```shell
-docker run --rm -it --network=host alpine ash -c "apk add socat && socat TCP-LISTEN:5000,reuseaddr,fork TCP:$(minikube ip):5000"
+docker run --rm -d -p 5000:5000 alpine/socat TCP-LISTEN:5000,reuseaddr,fork TCP:$(minikube ip):5000
 ```
 
 Once socat is running it's possible to push images to the minikube registry:
@@ -105,7 +107,7 @@ On your local machine you should now be able to reach the minikube registry by u
 From this point we can (ab)use docker's network configuration to instantiate a container on the docker's host, and run socat there to redirect traffic going to the docker vm's port 5000 to port 5000 on your host workstation.
 
 ```shell
-docker run --rm -it --network=host alpine ash -c "apk add socat && socat TCP-LISTEN:5000,reuseaddr,fork TCP:host.docker.internal:5000"
+docker run --rm -d -p 5000:5000 alpine/socat TCP-LISTEN:5000,reuseaddr,fork TCP:host.docker.internal:5000
 ```
 
 Once socat is running it's possible to push images to the minikube registry from your local workstation:
@@ -116,5 +118,3 @@ docker push localhost:5000/myimage
 ```
 
 After the image is pushed, refer to it by `localhost:5000/{name}` in kubectl specs.
-
-##


### PR DESCRIPTION
It is more neat to use the `alpine/socat` image instead. Running the container in detached mode frees the console for other operations.

The instructions for Linux are the same as macOS, so I added that to the title.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
