### PR TITLE
Don't redownload kicbase when already loaded

### DIFF
--- a/pkg/minikube/download/download_test.go
+++ b/pkg/minikube/download/download_test.go
@@ -32,7 +32,6 @@ func TestDownload(t *testing.T) {
 	t.Run("BinaryDownloadPreventsMultipleDownload", testBinaryDownloadPreventsMultipleDownload)
 	t.Run("PreloadDownloadPreventsMultipleDownload", testPreloadDownloadPreventsMultipleDownload)
 	t.Run("ImageToCache", testImageToCache)
-	t.Run("ImageToDaemon", testImageToDaemon)
 	t.Run("PreloadNotExists", testPreloadNotExists)
 	t.Run("PreloadChecksumMismatch", testPreloadChecksumMismatch)
 	t.Run("PreloadExistsCaching", testPreloadExistsCaching)
@@ -160,31 +159,6 @@ func testPreloadChecksumMismatch(t *testing.T) {
 }
 
 func testImageToCache(t *testing.T) {
-	downloadNum := 0
-	DownloadMock = mockSleepDownload(&downloadNum)
-
-	checkImageExistsInCache = func(img string) bool { return downloadNum > 0 }
-
-	var group sync.WaitGroup
-	group.Add(2)
-	dlCall := func() {
-		if err := ImageToCache("testimg"); err != nil {
-			t.Errorf("Failed to download preload: %+v", err)
-		}
-		group.Done()
-	}
-
-	go dlCall()
-	go dlCall()
-
-	group.Wait()
-
-	if downloadNum != 1 {
-		t.Errorf("Expected only 1 download attempt but got %v!", downloadNum)
-	}
-}
-
-func testImageToDaemon(t *testing.T) {
 	downloadNum := 0
 	DownloadMock = mockSleepDownload(&downloadNum)
 

--- a/pkg/minikube/download/image.go
+++ b/pkg/minikube/download/image.go
@@ -122,7 +122,7 @@ func ImageToCache(img string) error {
 	if err != nil {
 		return errors.Wrap(err, "parsing reference")
 	}
-	tag, err := name.NewTag(strings.Split(img, "@")[0])
+	tag, err := name.NewTag(image.Tag(img))
 	if err != nil {
 		return errors.Wrap(err, "parsing tag")
 	}
@@ -142,7 +142,7 @@ func ImageToCache(img string) error {
 	klog.V(3).Infof("Writing image %v", tag)
 	errchan := make(chan error)
 	p := pb.Full.Start64(0)
-	fn := strings.Split(ref.Name(), "@")[0]
+	fn := image.Tag(ref.Name())
 	// abbreviate filename for progress
 	maxwidth := 30 - len("...")
 	if len(fn) > maxwidth {
@@ -177,7 +177,7 @@ func ImageToCache(img string) error {
 func parseImage(img string) (*name.Tag, name.Reference, error) {
 
 	var ref name.Reference
-	tag, err := name.NewTag(strings.Split(img, "@")[0])
+	tag, err := name.NewTag(image.Tag(img))
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to parse image reference")
 	}
@@ -225,7 +225,7 @@ func CacheToDaemon(img string) (string, error) {
 	cmd := exec.Command("docker", "pull", "--quiet", img)
 	if _, err := cmd.Output(); err != nil {
 		klog.Warning(err)
-		return strings.Split(img, "@")[0], err
+		return image.Tag(img), err
 	}
 
 	return img, nil

--- a/pkg/minikube/download/image.go
+++ b/pkg/minikube/download/image.go
@@ -221,8 +221,8 @@ func CacheToDaemon(img string) (string, error) {
 	}
 
 	cmd := exec.Command("docker", "pull", "--quiet", img)
-	if _, err := cmd.Output(); err != nil {
-		klog.Warning(err)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		klog.Warningf("failed to pull image digest (expected if offline): %s: %v", output, err)
 		img = image.Tag(img)
 	}
 

--- a/pkg/minikube/download/image.go
+++ b/pkg/minikube/download/image.go
@@ -222,106 +222,11 @@ func CacheToDaemon(img string) (string, error) {
 		return img, err
 	}
 
-	if err := pullDigest(img); err != nil {
+	cmd := exec.Command("docker", "pull", "--quiet", img)
+	if _, err := cmd.Output(); err != nil {
 		klog.Warning(err)
 		return strings.Split(img, "@")[0], err
 	}
 
 	return img, nil
-}
-
-// ImageToDaemon downloads img (if not present in daemon) and writes it to the local docker daemon
-func ImageToDaemon(img string) error {
-	fileLock := filepath.Join(detect.KICCacheDir(), path.Base(img)+".d.lock")
-	fileLock = localpath.SanitizeCacheDir(fileLock)
-
-	releaser, err := lockDownload(fileLock)
-	if releaser != nil {
-		defer releaser.Release()
-	}
-	if err != nil {
-		return err
-	}
-
-	if checkImageExistsInDaemon(img) {
-		klog.Infof("%s exists in daemon, skipping pull", img)
-		return nil
-	}
-	// buffered channel
-	c := make(chan v1.Update, 200)
-
-	klog.Infof("Writing %s to local daemon", img)
-	ref, err := name.ParseReference(img)
-	if err != nil {
-		return errors.Wrap(err, "parsing reference")
-	}
-	tag, err := name.NewTag(strings.Split(img, "@")[0])
-	if err != nil {
-		return errors.Wrap(err, "parsing tag")
-	}
-
-	if DownloadMock != nil {
-		klog.Infof("Mock download: %s -> daemon", img)
-		return DownloadMock(img, "daemon")
-	}
-
-	klog.V(3).Infof("Getting image %v", ref)
-	i, err := remote.Image(ref, remote.WithPlatform(defaultPlatform))
-	if err != nil {
-		if strings.Contains(err.Error(), "GitHub Docker Registry needs login") {
-			ErrGithubNeedsLogin := errors.New(err.Error())
-			return ErrGithubNeedsLogin
-		} else if strings.Contains(err.Error(), "UNAUTHORIZED") {
-			ErrNeedsLogin := errors.New(err.Error())
-			return ErrNeedsLogin
-		}
-
-		return errors.Wrap(err, "getting remote image")
-	}
-
-	klog.V(3).Infof("Writing image %v", tag)
-	errchan := make(chan error)
-	p := pb.Full.Start64(0)
-	fn := strings.Split(ref.Name(), "@")[0]
-	// abbreviate filename for progress
-	maxwidth := 30 - len("...")
-	if len(fn) > maxwidth {
-		fn = fn[0:maxwidth] + "..."
-	}
-	p.Set("prefix", "    > "+fn+": ")
-	p.Set(pb.Bytes, true)
-
-	// Just a hair less than 80 (standard terminal width) for aesthetics & pasting into docs
-	p.SetWidth(79)
-
-	go func() {
-		_, err = daemon.Write(tag, i)
-		errchan <- err
-	}()
-	var update v1.Update
-loop:
-	for {
-		select {
-		case update = <-c:
-			p.SetCurrent(update.Complete)
-			p.SetTotal(update.Total)
-		case err = <-errchan:
-			p.Finish()
-			if err != nil {
-				return errors.Wrap(err, "writing daemon image")
-			}
-			break loop
-		}
-	}
-	klog.V(3).Infof("Pulling image %v", ref)
-	// Pull digest
-	return pullDigest(img)
-}
-
-func pullDigest(img string) error {
-	cmd := exec.Command("docker", "pull", "--quiet", img)
-	if _, err := cmd.Output(); err != nil {
-		return errors.Wrap(err, "pulling image digest")
-	}
-	return nil
 }

--- a/pkg/minikube/download/image.go
+++ b/pkg/minikube/download/image.go
@@ -195,6 +195,9 @@ func parseImage(img string) (*name.Tag, name.Reference, error) {
 }
 
 // CacheToDaemon loads image from tarball in the local cache directory to the local docker daemon
+// It returns the img that was loaded into the daemon
+// If online it will be: image:tag@sha256
+// If offline it will be: image:tag
 func CacheToDaemon(img string) (string, error) {
 	p := imagePathInCache(img)
 

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -147,19 +147,17 @@ func beginDownloadKicBaseImage(g *errgroup.Group, cc *config.ClusterConfig, down
 			err = download.ImageToCache(img)
 			if err == nil {
 				klog.Infof("successfully saved %s as a tarball", img)
-				finalImg = img
 			}
-			if downloadOnly {
-				return err
+			if downloadOnly && err == nil {
+				return nil
 			}
 
 			if cc.Driver == driver.Podman {
 				return fmt.Errorf("not yet implemented, see issue #8426")
 			}
-			if driver.IsDocker(cc.Driver) {
+			if driver.IsDocker(cc.Driver) && err == nil {
 				klog.Infof("Loading %s from local cache", img)
-				finalImg, err = download.CacheToDaemon(img)
-				if err == nil {
+				if finalImg, err = download.CacheToDaemon(img); err == nil {
 					klog.Infof("successfully loaded and using %s from cached tarball", img)
 					return nil
 				}

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -129,9 +129,11 @@ func beginDownloadKicBaseImage(g *errgroup.Group, cc *config.ClusterConfig, down
 		var finalImg string
 		// If we end up using a fallback image, notify the user
 		defer func() {
-			if finalImg != "" && image.Tag(finalImg) != image.Tag(baseImg) {
-				out.WarningT(fmt.Sprintf("minikube was unable to download %s, but successfully downloaded %s as a fallback image", image.Tag(baseImg), image.Tag(finalImg)))
+			if finalImg != "" {
 				cc.KicBaseImage = finalImg
+				if image.Tag(finalImg) != image.Tag(baseImg) {
+					out.WarningT(fmt.Sprintf("minikube was unable to download %s, but successfully downloaded %s as a fallback image", image.Tag(baseImg), image.Tag(finalImg)))
+				}
 			}
 		}()
 		for _, img := range append([]string{baseImg}, kic.FallbackImages...) {

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -163,14 +163,6 @@ func beginDownloadKicBaseImage(g *errgroup.Group, cc *config.ClusterConfig, down
 					klog.Infof("successfully loaded and using %s from cached tarball", img)
 					return nil
 				}
-
-				klog.Infof("Downloading %s to local daemon", img)
-				err = download.ImageToDaemon(img)
-				if err == nil {
-					klog.Infof("successfully downloaded %s", img)
-					finalImg = img
-					return nil
-				}
 			}
 			klog.Infof("failed to download %s, will try fallback image if available: %v", img, err)
 		}

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -176,7 +176,7 @@ func waitDownloadKicBaseImage(g *errgroup.Group) {
 		if err != nil {
 			if errors.Is(err, image.ErrGithubNeedsLogin) {
 				klog.Warningf("Error downloading kic artifacts: %v", err)
-				out.ErrT(style.Connectivity, "Unfortunately, could not download the base image {{.image_name}} ", out.V{"image_name": strings.Split(kic.BaseImage, "@")[0]})
+				out.ErrT(style.Connectivity, "Unfortunately, could not download the base image {{.image_name}} ", out.V{"image_name": image.Tag(kic.BaseImage)})
 				out.WarningT("In order to use the fall back image, you need to log in to the github packages registry")
 				out.Styled(style.Documentation, `Please visit the following link for documentation around this: 
 	https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages#authenticating-to-github-packages


### PR DESCRIPTION
**Problem:**
Starting minikube when the kicbase image isn't loaded into Docker (mainly first time users or first start after an update),  after loading the kicbase image from cache into Docker, the kicbase image is completely redownloaded from the internet directly to Docker. This unnecessary download causes the start time to make much longer than necessary.

**Cause:**
The cause is that loading the image from the minikube dir into Docker the SHA of the image is lost (expected behavior). Following the load from cache is a call to download the image from the internet, before the download starts it checks if the image already exists, but it includes the SHA in that comparison, but the image loaded from the cache doesn't have the SHA so the image exists check fails, so it runs `daemon.Write` to download the kicbase image. `daemon.Write` does not respect Docker's cache, so it completely redownloads the kicbase image (385 MB) which takes a considerable amount of time.

**Solution:**
I learned that `daemon.Write` doesn't even include the hash, we do a `docker pull <image>` after it's downloaded to get the SHA. So I added the same to the end of the func that loads the image from the cache into Docker, only log a warning if it fails incase the user is offline. This fix resulted in `ImageToDaemon` not being needed anymore as the only value the function was adding was setting the hash via `docker pull <image>` which cache load now does, so I fully removed `ImageToDaemon`.

**Before:**
```
$ time minikube start
😄  minikube v1.28.0 on Darwin 13.1 (arm64)
✨  Automatically selected the docker driver. Other choices: ssh, qemu2 (experimental)
📌  Using Docker Desktop driver with root privileges
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
    > gcr.io/k8s-minikube/kicbase...:  0 B [_____________________] ?% ? p/s 41s
🔥  Creating docker container (CPUs=2, Memory=4000MB) ...
🐳  Preparing Kubernetes v1.25.3 on Docker 20.10.21 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default

real	1m14.976s
user	0m6.138s
sys	0m10.619s
```

**After:**
```
$ time ./out/minikube start
😄  minikube v1.28.0 on Darwin 13.1 (arm64)
✨  Automatically selected the docker driver. Other choices: ssh, qemu2 (experimental)
📌  Using Docker Desktop driver with root privileges
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=4000MB) ...
🐳  Preparing Kubernetes v1.25.3 on Docker 20.10.21 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default

real	0m31.400s
user	0m3.205s
sys	0m2.292s
```

**Result:**
**43.6s or 58% reduction in start time**

**Additional Fix 1:**
When starting minikube while offline the following confusing message is printed:
`❗  minikube was unable to download gcr.io/k8s-minikube/kicbase:v0.0.36, but successfully downloaded gcr.io/k8s-minikube/kicbase:v0.0.36 as a fallback image`

This was caused because the comparison behind the scenes was comparing the expected image which had a SHA and the image that was actually loaded that didn't have a SHA due to being unable to pull the SHA from the internet resulting in the comparison failing and outputting the message. Stripped the SHAs before doing the comparison to get the expected output of not printing the message.

**Before (no internet connection and message is printed):**
```
$ minikube start
😄  minikube v1.28.0 on Darwin 13.1 (arm64)
✨  Automatically selected the docker driver. Other choices: ssh, qemu2 (experimental)
📌  Using Docker Desktop driver with root privileges
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
❗  minikube was unable to download gcr.io/k8s-minikube/kicbase:v0.0.36, but successfully downloaded gcr.io/k8s-minikube/kicbase:v0.0.36 as a fallback image
🔥  Creating docker container (CPUs=2, Memory=4000MB) ...
❗  This container is having trouble accessing https://registry.k8s.io
💡  To pull new external images, you may need to configure a proxy: https://minikube.sigs.k8s.io/docs/reference/networking/proxy/
🐳  Preparing Kubernetes v1.25.3 on Docker 20.10.21 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
```

**After (no internet connection and no message is printed)**
```
$ minikube start
😄  minikube v1.28.0 on Darwin 13.1 (arm64)
✨  Automatically selected the docker driver. Other choices: ssh, qemu2 (experimental)
📌  Using Docker Desktop driver with root privileges
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=4000MB) ...
❗  This container is having trouble accessing https://registry.k8s.io
💡  To pull new external images, you may need to configure a proxy: https://minikube.sigs.k8s.io/docs/reference/networking/proxy/
🐳  Preparing Kubernetes v1.25.3 on Docker 20.10.21 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
```

**Additional Fix 2:**
When using `--download-only` the kicbase image download would return after the first kicbase was attempted to be downloaded, regardless if the download was successful or not. Fixed the logic so if the first image fails it will retry with fallback images as expected.

**Before:**
```
I1216 14:19:26.618571   11726 cache.go:147] Downloading gcr.io/k8s-minikube/kicbase-builds:v0.0.36-1668787669-15272@sha256:06094fc04b5dc02fbf1e2de7723c2a6db5d24c21fd2ddda91f6daaf29038cd9c to local cache
I1216 14:19:26.618711   11726 image.go:60] Checking for gcr.io/k8s-minikube/kicbase-builds:v0.0.36-1668787669-15272@sha256:06094fc04b5dc02fbf1e2de7723c2a6db5d24c21fd2ddda91f6daaf29038cd9c in local cache directory
I1216 14:19:26.618849   11726 image.go:120] Writing gcr.io/k8s-minikube/kicbase-builds:v0.0.36-1668787669-15272@sha256:06094fc04b5dc02fbf1e2de7723c2a6db5d24c21fd2ddda91f6daaf29038cd9c to local cache
E1216 14:19:26.620027   11726 cache.go:203] Error downloading kic artifacts:  getting remote image: Get "https://gcr.io/v2/": dial tcp: lookup gcr.io: no such host
```

**After:**
```
I1216 14:24:03.568076   12993 cache.go:146] Downloading gcr.io/k8s-minikube/kicbase-builds:v0.0.36-1668787669-15272@sha256:06094fc04b5dc02fbf1e2de7723c2a6db5d24c21fd2ddda91f6daaf29038cd9c to local cache
I1216 14:24:03.568211   12993 image.go:60] Checking for gcr.io/k8s-minikube/kicbase-builds:v0.0.36-1668787669-15272@sha256:06094fc04b5dc02fbf1e2de7723c2a6db5d24c21fd2ddda91f6daaf29038cd9c in local cache directory
I1216 14:24:03.568347   12993 image.go:118] Writing gcr.io/k8s-minikube/kicbase-builds:v0.0.36-1668787669-15272@sha256:06094fc04b5dc02fbf1e2de7723c2a6db5d24c21fd2ddda91f6daaf29038cd9c to local cache
I1216 14:24:03.570327   12993 cache.go:165] failed to download gcr.io/k8s-minikube/kicbase-builds:v0.0.36-1668787669-15272@sha256:06094fc04b5dc02fbf1e2de7723c2a6db5d24c21fd2ddda91f6daaf29038cd9c, will try fallback image if available: getting remote image: Get "https://gcr.io/v2/": dial tcp: lookup gcr.io: no such host
I1216 14:24:03.570338   12993 image.go:76] Checking for docker.io/kicbase/build:v0.0.36-1668787669-15272@sha256:06094fc04b5dc02fbf1e2de7723c2a6db5d24c21fd2ddda91f6daaf29038cd9c in local docker daemon
I1216 14:24:03.632463   12993 cache.go:146] Downloading docker.io/kicbase/build:v0.0.36-1668787669-15272@sha256:06094fc04b5dc02fbf1e2de7723c2a6db5d24c21fd2ddda91f6daaf29038cd9c to local cache
I1216 14:24:03.632605   12993 image.go:60] Checking for docker.io/kicbase/build:v0.0.36-1668787669-15272@sha256:06094fc04b5dc02fbf1e2de7723c2a6db5d24c21fd2ddda91f6daaf29038cd9c in local cache directory
I1216 14:24:03.632657   12993 image.go:118] Writing docker.io/kicbase/build:v0.0.36-1668787669-15272@sha256:06094fc04b5dc02fbf1e2de7723c2a6db5d24c21fd2ddda91f6daaf29038cd9c to local cache
I1216 14:24:03.634069   12993 cache.go:165] failed to download docker.io/kicbase/build:v0.0.36-1668787669-15272@sha256:06094fc04b5dc02fbf1e2de7723c2a6db5d24c21fd2ddda91f6daaf29038cd9c, will try fallback image if available: getting remote image: Get "https://index.docker.io/v2/": dial tcp: lookup index.docker.io: no such host
I1216 14:24:03.634088   12993 image.go:76] Checking for gcr.io/k8s-minikube/kicbase-builds:v0.0.36-1668787669-15272 in local docker daemon
I1216 14:24:03.688544   12993 cache.go:146] Downloading gcr.io/k8s-minikube/kicbase-builds:v0.0.36-1668787669-15272 to local cache
I1216 14:24:03.688697   12993 image.go:60] Checking for gcr.io/k8s-minikube/kicbase-builds:v0.0.36-1668787669-15272 in local cache directory
I1216 14:24:03.688736   12993 image.go:118] Writing gcr.io/k8s-minikube/kicbase-builds:v0.0.36-1668787669-15272 to local cache
I1216 14:24:03.690219   12993 cache.go:165] failed to download gcr.io/k8s-minikube/kicbase-builds:v0.0.36-1668787669-15272, will try fallback image if available: getting remote image: Get "https://gcr.io/v2/": dial tcp: lookup gcr.io: no such host
I1216 14:24:03.690234   12993 image.go:76] Checking for docker.io/kicbase/build:v0.0.36-1668787669-15272 in local docker daemon
I1216 14:24:03.752520   12993 cache.go:146] Downloading docker.io/kicbase/build:v0.0.36-1668787669-15272 to local cache
I1216 14:24:03.752638   12993 image.go:60] Checking for docker.io/kicbase/build:v0.0.36-1668787669-15272 in local cache directory
I1216 14:24:03.752664   12993 image.go:118] Writing docker.io/kicbase/build:v0.0.36-1668787669-15272 to local cache
I1216 14:24:03.754372   12993 cache.go:165] failed to download docker.io/kicbase/build:v0.0.36-1668787669-15272, will try fallback image if available: getting remote image: Get "https://index.docker.io/v2/": dial tcp: lookup index.docker.io: no such host
```