### PR TITLE
Added `--subnet` validation

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1757,7 +1757,7 @@ func validateDockerStorageDriver(drvName string) {
 func validateSubnet(subnet string) error {
 	ip, cidr, err := netutil.ParseAddr(subnet)
 	if err != nil {
-		return err
+		return errors.Errorf("Sorry, unable to parse subnet: %v", err)
 	}
 	if !ip.IsPrivate() {
 		return errors.Errorf("Sorry, the subnet %s is not a private IP", ip)

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1752,19 +1752,21 @@ func validateDockerStorageDriver(drvName string) {
 	viper.Set(preload, false)
 }
 
+// validateSubnet checks that the subnet provided has a private IP
+// and does not have a mask of more that /30
 func validateSubnet(subnet string) error {
 	ip, cidr, err := netutil.ParseAddr(subnet)
 	if err != nil {
 		return err
 	}
 	if !ip.IsPrivate() {
-		return errors.Errorf("Sorry, %s is not a private IP", ip)
+		return errors.Errorf("Sorry, the subnet %s is not a private IP", ip)
 	}
 
 	if cidr != nil {
 		mask, _ := cidr.Mask.Size()
 		if mask > 30 {
-			return errors.Errorf("Sorry, mask must be less than /30")
+			return errors.Errorf("Sorry, the subnet provided does not have a mask less than or equal to /30")
 		}
 	}
 	return nil

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -628,3 +628,40 @@ func TestValidatePorts(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSubnet(t *testing.T) {
+	type subnetTest struct {
+		subnet   string
+		errorMsg string
+	}
+	var tests = []subnetTest{
+		{
+			subnet:   "192.168.1.1",
+			errorMsg: "",
+		},
+		{
+			subnet:   "193.169.1.1",
+			errorMsg: "Sorry, 193.169.1.1 is not a private IP",
+		},
+		{
+			subnet:   "192.168.1.1/24",
+			errorMsg: "",
+		},
+		{
+			subnet:   "192.168.1.1/32",
+			errorMsg: "Sorry, mask must be less than /30",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.subnet, func(t *testing.T) {
+			gotError := ""
+			got := validateSubnet(test.subnet)
+			if got != nil {
+				gotError = got.Error()
+			}
+			if gotError != test.errorMsg {
+				t.Errorf("validateSubnet(subnet=%v): got %v, expected %v", test.subnet, got, test.errorMsg)
+			}
+		})
+	}
+}

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -641,7 +641,7 @@ func TestValidateSubnet(t *testing.T) {
 		},
 		{
 			subnet:   "193.169.1.1",
-			errorMsg: "Sorry, 193.169.1.1 is not a private IP",
+			errorMsg: "Sorry, the subnet 193.169.1.1 is not a private IP",
 		},
 		{
 			subnet:   "192.168.1.1/24",
@@ -649,7 +649,7 @@ func TestValidateSubnet(t *testing.T) {
 		},
 		{
 			subnet:   "192.168.1.1/32",
-			errorMsg: "Sorry, mask must be less than /30",
+			errorMsg: "Sorry, the subnet provided does not have a mask less than or equal to /30",
 		},
 	}
 	for _, test := range tests {

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -126,12 +126,9 @@ func lookupInInterfaces(ip net.IP) (*Parameters, *net.IPNet, error) {
 var inspect = func(addr string) (*Parameters, error) {
 
 	// extract ip from addr
-	ip, network, err := net.ParseCIDR(addr)
+	ip, network, err := ParseAddr(addr)
 	if err != nil {
-		ip = net.ParseIP(addr)
-		if ip == nil {
-			return nil, fmt.Errorf("failed parsing address %s: %w", addr, err)
-		}
+		return nil, err
 	}
 
 	n := &Parameters{}
@@ -259,6 +256,19 @@ func FreeSubnet(startSubnet string, step, tries int) (*Parameters, error) {
 		currSubnet = nextSubnet.String()
 	}
 	return nil, fmt.Errorf("no free private network subnets found with given parameters (start: %q, step: %d, tries: %d)", startSubnet, step, tries)
+}
+
+// ParseAddr will try to parse an ip or a cidr address
+func ParseAddr(addr string) (net.IP, *net.IPNet, error) {
+	ip, network, err := net.ParseCIDR(addr)
+	if err != nil {
+		ip = net.ParseIP(addr)
+		if ip == nil {
+			return nil, nil, fmt.Errorf("failed parsing address %s: %w", addr, err)
+		}
+		err = nil
+	}
+	return ip, network, err
 }
 
 // reserveSubnet returns if subnet was successfully reserved for given period:

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -114,3 +114,48 @@ func TestFreeSubnet(t *testing.T) {
 		}
 	})
 }
+
+func TestParseAddr(t *testing.T) {
+	t.Run("ValidIP", func(t *testing.T) {
+		addr := "192.168.9.0"
+		ip, _, err := ParseAddr(addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ip.String() != addr {
+			t.Errorf("expected IP = %q; got = %q", addr, ip.String())
+		}
+	})
+
+	t.Run("ValidCIDR", func(t *testing.T) {
+		addr := "192.168.9.0/30"
+		ip, cidr, err := ParseAddr(addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := "192.168.9.0"
+		if ip.String() != expected {
+			t.Errorf("expected IP = %q; got = %q", expected, ip.String())
+		}
+
+		mask, _ := cidr.Mask.Size()
+		expectedMask := 30
+		if mask != expectedMask {
+			t.Errorf("expected mask = %q; got = %q", mask, expectedMask)
+		}
+	})
+
+	t.Run("InvalidAddr", func(t *testing.T) {
+		tests := []string{
+			"192.168.9",
+			"192.168.9.0/30000",
+		}
+		for _, test := range tests {
+			_, _, err := ParseAddr(test)
+			if err == nil {
+				t.Fatalf("expected to fail since address is invalid")
+			}
+		}
+	})
+}


### PR DESCRIPTION
fixes #15517 

Added `validateSubnet` that makes sure the given subnet has a valid private IP address and if it is cidr then the mask shouldn't be greater than 30

To reduce code duplication, I refactored `inspect` to use `ParseAddr`