### PR TITLE
site: fix tabs CSS, echo-server images, added ingress Docker Desktop step

### DIFF
--- a/site/content/en/docs/handbook/accessing.md
+++ b/site/content/en/docs/handbook/accessing.md
@@ -41,7 +41,7 @@ Services of type `NodePort` can be exposed via the `minikube service <service-na
 1. Create a Kubernetes deployment
 
     ```shell
-    kubectl create deployment hello-minikube1 --image=k8s.gcr.io/echoserver:1.4
+    kubectl create deployment hello-minikube1 --image=kicbase/echo-server:1.0
     ```
 
 2. Create a Kubernetes service type NodePort
@@ -159,7 +159,7 @@ Services of type `LoadBalancer` can be exposed via the `minikube tunnel` command
 2. Create a Kubernetes deployment
 
     ```shell
-    kubectl create deployment hello-minikube1 --image=k8s.gcr.io/echoserver:1.4
+    kubectl create deployment hello-minikube1 --image=kicbase/echo-server:1.0
     ```
 
 3. Create a Kubernetes service with type LoadBalancer

--- a/site/content/en/docs/handbook/deploying.md
+++ b/site/content/en/docs/handbook/deploying.md
@@ -11,7 +11,7 @@ aliases:
 ## kubectl
 
 ```shell
-kubectl create deployment hello-minikube1 --image=k8s.gcr.io/echoserver:1.4
+kubectl create deployment hello-minikube1 --image=kicbase/echo-server:1.0
 kubectl expose deployment hello-minikube1 --type=LoadBalancer --port=8080
 ```
 

--- a/site/content/en/docs/handbook/kubectl.md
+++ b/site/content/en/docs/handbook/kubectl.md
@@ -77,7 +77,7 @@ minikube kubectl -- get pods
 Creating a deployment inside kubernetes cluster
 
 ```shell
-minikube kubectl -- create deployment hello-minikube --image=k8s.gcr.io/echoserver:1.4
+minikube kubectl -- create deployment hello-minikube --image=kicbase/echo-server:1.0
 ```
 
 Exposing the deployment with a NodePort service

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -676,6 +676,10 @@ NAME              CLASS   HOSTS   ADDRESS          PORTS   AGE
 example-ingress   nginx   *       <your_ip_here>   80      5m45s
 ```
 
+**Note for Docker Desktop Users:**
+<br>
+To get ingress to work you'll need to open a new terminal window and run `minikube tunnel` and in the following step use `0.0.0.0` in place of `<ip_from_above>`.
+
 Now verify that the ingress works
 ```shell
 $ curl <ip_from_above>/foo

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -603,8 +603,8 @@ metadata:
     app: foo
 spec:
   containers:
-  - name: foo-app
-    image: kicbase/echo-server:1.0
+    - name: foo-app
+      image: 'kicbase/echo-server:1.0'
 ---
 kind: Service
 apiVersion: v1
@@ -614,8 +614,7 @@ spec:
   selector:
     app: foo
   ports:
-  # Default port used by the image
-  - port: 8080
+    - port: 8080
 ---
 kind: Pod
 apiVersion: v1
@@ -625,8 +624,8 @@ metadata:
     app: bar
 spec:
   containers:
-  - name: bar-app
-    image: kicbase/echo-server:1.0
+    - name: bar-app
+      image: 'kicbase/echo-server:1.0'
 ---
 kind: Service
 apiVersion: v1
@@ -636,8 +635,7 @@ spec:
   selector:
     app: bar
   ports:
-  # Default port used by the image
-  - port: 8080
+    - port: 8080
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -645,22 +643,22 @@ metadata:
   name: example-ingress
 spec:
   rules:
-  - http:
-      paths:
-      - pathType: Prefix
-        path: "/foo"
-        backend:
-          service:
-            name: foo-service
-            port:
-              number: 8080
-      - pathType: Prefix
-        path: "/bar"
-        backend:
-          service:
-            name: bar-service
-            port:
-              number: 8080
+    - http:
+        paths:
+          - pathType: Prefix
+            path: /foo
+            backend:
+              service:
+                name: foo-service
+                port:
+                  number: 8080
+          - pathType: Prefix
+            path: /bar
+            backend:
+              service:
+                name: bar-service
+                port:
+                  number: 8080
 ---
 ```
 
@@ -678,7 +676,7 @@ example-ingress   nginx   *       <your_ip_here>   80      5m45s
 
 **Note for Docker Desktop Users:**
 <br>
-To get ingress to work you'll need to open a new terminal window and run `minikube tunnel` and in the following step use `0.0.0.0` in place of `<ip_from_above>`.
+To get ingress to work you'll need to open a new terminal window and run `minikube tunnel` and in the following step use `127.0.0.1` in place of `<ip_from_above>`.
 
 Now verify that the ingress works
 ```shell

--- a/site/content/en/docs/tutorials/ambassador_ingress_controller.md
+++ b/site/content/en/docs/tutorials/ambassador_ingress_controller.md
@@ -56,7 +56,7 @@ this [post](https://blog.getambassador.io/new-kubernetes-1-18-extends-ingress-c3
 First, let's create a Kubernetes deployment and service which we will talk to via Ambassador.
 
 ```shell script
-kubectl create deployment hello-minikube --image=k8s.gcr.io/echoserver:1.4
+kubectl create deployment hello-minikube --image=kicbase/echo-server:1.0
 kubectl expose deployment hello-minikube --port=8080
 ```
 
@@ -105,7 +105,7 @@ that maps a target backend service to a given host or prefix.
 
 Let's create another Kubernetes deployment and service that we will expose via Ambassador -
 ```shell script
-kubectl create deployment mapping-minikube --image=k8s.gcr.io/echoserver:1.4
+kubectl create deployment mapping-minikube --image=kicbase/echo-server:1.0
 kubectl expose deployment mapping-minikube --port=8080
 ```
 

--- a/site/static/css/tabs.css
+++ b/site/static/css/tabs.css
@@ -20,6 +20,7 @@ div.code-tabs li.nav-tab {
     border-left: 1px solid #ccc;
     border-right: 1px solid #ccc;
     margin-right: 0.5em;
+    margin-bottom: 0;
 
     border-top-left-radius: 4px;
     border-top-right-radius: 4px;
@@ -52,6 +53,10 @@ div.code-tabs div.highlight {
     background-color: #fff;
 }
 
+.tab-content .tab-pane .highlight {
+    margin-top: 1.25em;
+    margin-bottom: 1.25em;
+}
 
 div.code-tabs a.nav-tab {
     all: unset;

--- a/site/static/css/tabs.css
+++ b/site/static/css/tabs.css
@@ -54,7 +54,6 @@ div.code-tabs div.highlight {
 }
 
 .tab-content .tab-pane .highlight {
-    margin-top: 1.25em;
     margin-bottom: 1.25em;
 }
 


### PR DESCRIPTION
Updating Docsy/Hugo resulted in tabs formatting being a bit off, fixed the oddities:
- space between tabs and container
- No margin between code blocks and following line

**Before:**
![Screenshot 2022-12-28 at 12 58 07 PM](https://user-images.githubusercontent.com/44844360/209871239-99a4a58c-2cf9-402d-a484-bf2bdc795a54.png)


**After:**
![Screenshot 2022-12-28 at 1 21 51 PM](https://user-images.githubusercontent.com/44844360/209873433-6629f65c-29cd-4dbe-b8bd-7f357186fad8.png)

