### PR TITLE
Fix Docker tunnel failing

### DIFF
--- a/pkg/minikube/tunnel/kic/ssh_conn.go
+++ b/pkg/minikube/tunnel/kic/ssh_conn.go
@@ -17,13 +17,16 @@ limitations under the License.
 package kic
 
 import (
+	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"runtime"
 
 	"github.com/phayes/freeport"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/style"
@@ -116,6 +119,7 @@ func createSSHConnWithRandomPorts(name, sshPort, sshKey string, svc *v1.Service)
 		// TODO: document the options here
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-o", "StrictHostKeyChecking=no",
+		"-o", "IdentitiesOnly=yes",
 		"-N",
 		"docker@127.0.0.1",
 		"-p", sshPort,
@@ -157,10 +161,14 @@ func (c *sshConn) startAndWait() error {
 		out.Step(style.Running, "Starting tunnel for service {{.service}}.", out.V{"service": c.service})
 	}
 
+	r, w := io.Pipe()
+	c.cmd.Stdout = w
+	c.cmd.Stderr = w
 	err := c.cmd.Start()
 	if err != nil {
 		return err
 	}
+	go logOutput(r, c.service)
 
 	c.activeConn = true
 	// we ignore wait error because the process will be killed
@@ -170,6 +178,13 @@ func (c *sshConn) startAndWait() error {
 	c.activeConn = false
 
 	return nil
+}
+
+func logOutput(r io.Reader, service string) {
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		klog.Infof("%s tunnel: %s", service, s.Text())
+	}
 }
 
 func (c *sshConn) stop() error {

--- a/pkg/minikube/tunnel/kic/ssh_conn.go
+++ b/pkg/minikube/tunnel/kic/ssh_conn.go
@@ -47,6 +47,7 @@ func createSSHConn(name, sshPort, sshKey, bindAddress string, resourcePorts []in
 		// TODO: document the options here
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-o", "StrictHostKeyChecking=no",
+		"-o", "IdentitiesOnly=yes",
 		"-N",
 		"docker@127.0.0.1",
 		"-p", sshPort,


### PR DESCRIPTION
Sometimes when using `minikube service` using a Docker Desktop driver the service is unable to be hit.
```
$ minikube start --driver docker
...
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
$ kubectl create deployment web --image=kicbase/echo-server:1.0
deployment.apps/web created
$ kubectl expose deployment web --type=NodePort --port=8080
service/web exposed
$ minikube service web --url
http://127.0.0.1:55188
❗  Because you are using a Docker driver on darwin, the terminal needs to be open to run it.
$ curl http://127.0.0.1:55188
curl: (7) Failed to connect to 127.0.0.1 port 55188 after 5 ms: Connection refused
```

After extensive debugging I found the cause is that the SSH connection created for the service is failing.
```
Received disconnect from 127.0.0.1 port 54219:2: Too many authentication failures
Disconnected from 127.0.0.1 port 54219
```

Setting `IdentitiesOnly=yes` on the SSH connection resolves this issue.

Also added improved logging to tunnel SSH connections:

**Before (no indication of failure):**
```
I1229 07:54:27.818130   50219 host.go:66] Checking if "minikube" exists ...
I1229 07:54:27.818429   50219 cli_runner.go:164] Run: docker container inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}},{{.GlobalIPv6Address}}{{end}}" minikube
I1229 07:54:27.896714   50219 service.go:214] Found service: &Service{ObjectMeta:{web  default  1c150658-5b47-49c1-bf66-c8a867f94da9 494 0 2022-12-29 07:54:01 -0800 PST <nil> <nil> map[app:web] map[] [] [] [{kubectl-expose Update v1 2022-12-29 07:54:01 -0800 PST FieldsV1 {"f:metadata":{"f:labels":{".":{},"f:app":{}}},"f:spec":{"f:externalTrafficPolicy":{},"f:internalTrafficPolicy":{},"f:ports":{".":{},"k:{\"port\":8080,\"protocol\":\"TCP\"}":{".":{},"f:port":{},"f:protocol":{},"f:targetPort":{}}},"f:selector":{},"f:sessionAffinity":{},"f:type":{}}} }]},Spec:ServiceSpec{Ports:[]ServicePort{ServicePort{Name:,Protocol:TCP,Port:8080,TargetPort:{0 8080 },NodePort:32013,AppProtocol:nil,},},Selector:map[string]string{app: web,},ClusterIP:10.98.245.152,Type:NodePort,ExternalIPs:[],SessionAffinity:None,LoadBalancerIP:,LoadBalancerSourceRanges:[],ExternalName:,ExternalTrafficPolicy:Cluster,HealthCheckNodePort:0,PublishNotReadyAddresses:false,SessionAffinityConfig:nil,IPFamilyPolicy:*SingleStack,ClusterIPs:[10.98.245.152],IPFamilies:[IPv4],AllocateLoadBalancerNodePorts:nil,LoadBalancerClass:nil,InternalTrafficPolicy:*Cluster,},Status:ServiceStatus{LoadBalancer:LoadBalancerStatus{Ingress:[]LoadBalancerIngress{},},Conditions:[]Condition{},},}
I1229 07:54:27.899028   50219 service.go:214] Found service: &Service{ObjectMeta:{web  default  1c150658-5b47-49c1-bf66-c8a867f94da9 494 0 2022-12-29 07:54:01 -0800 PST <nil> <nil> map[app:web] map[] [] [] [{kubectl-expose Update v1 2022-12-29 07:54:01 -0800 PST FieldsV1 {"f:metadata":{"f:labels":{".":{},"f:app":{}}},"f:spec":{"f:externalTrafficPolicy":{},"f:internalTrafficPolicy":{},"f:ports":{".":{},"k:{\"port\":8080,\"protocol\":\"TCP\"}":{".":{},"f:port":{},"f:protocol":{},"f:targetPort":{}}},"f:selector":{},"f:sessionAffinity":{},"f:type":{}}} }]},Spec:ServiceSpec{Ports:[]ServicePort{ServicePort{Name:,Protocol:TCP,Port:8080,TargetPort:{0 8080 },NodePort:32013,AppProtocol:nil,},},Selector:map[string]string{app: web,},ClusterIP:10.98.245.152,Type:NodePort,ExternalIPs:[],SessionAffinity:None,LoadBalancerIP:,LoadBalancerSourceRanges:[],ExternalName:,ExternalTrafficPolicy:Cluster,HealthCheckNodePort:0,PublishNotReadyAddresses:false,SessionAffinityConfig:nil,IPFamilyPolicy:*SingleStack,ClusterIPs:[10.98.245.152],IPFamilies:[IPv4],AllocateLoadBalancerNodePorts:nil,LoadBalancerClass:nil,InternalTrafficPolicy:*Cluster,},Status:ServiceStatus{LoadBalancer:LoadBalancerStatus{Ingress:[]LoadBalancerIngress{},},Conditions:[]Condition{},},}
I1229 07:54:27.899104   50219 host.go:66] Checking if "minikube" exists ...
I1229 07:54:27.899322   50219 cli_runner.go:164] Run: docker container inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}},{{.GlobalIPv6Address}}{{end}}" minikube
I1229 07:54:27.959733   50219 cli_runner.go:164] Run: docker container inspect -f "'{{(index (index .NetworkSettings.Ports "22/tcp") 0).HostPort}}'" minikube
I1229 07:54:29.029610   50219 out.go:177] http://127.0.0.1:55202
W1229 07:54:29.036140   50219 out.go:239] ❗  Because you are using a Docker driver on darwin, the terminal needs to be open to run it.
```

**After:**
```
I1229 09:09:18.466639   54738 host.go:66] Checking if "minikube" exists ...
I1229 09:09:18.466935   54738 cli_runner.go:164] Run: docker container inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}},{{.GlobalIPv6Address}}{{end}}" minikube
I1229 09:09:18.548004   54738 service.go:214] Found service: &Service{ObjectMeta:{web  default  1c150658-5b47-49c1-bf66-c8a867f94da9 494 0 2022-12-29 07:54:01 -0800 PST <nil> <nil> map[app:web] map[] [] [] [{kubectl-expose Update v1 2022-12-29 07:54:01 -0800 PST FieldsV1 {"f:metadata":{"f:labels":{".":{},"f:app":{}}},"f:spec":{"f:externalTrafficPolicy":{},"f:internalTrafficPolicy":{},"f:ports":{".":{},"k:{\"port\":8080,\"protocol\":\"TCP\"}":{".":{},"f:port":{},"f:protocol":{},"f:targetPort":{}}},"f:selector":{},"f:sessionAffinity":{},"f:type":{}}} }]},Spec:ServiceSpec{Ports:[]ServicePort{ServicePort{Name:,Protocol:TCP,Port:8080,TargetPort:{0 8080 },NodePort:32013,AppProtocol:nil,},},Selector:map[string]string{app: web,},ClusterIP:10.98.245.152,Type:NodePort,ExternalIPs:[],SessionAffinity:None,LoadBalancerIP:,LoadBalancerSourceRanges:[],ExternalName:,ExternalTrafficPolicy:Cluster,HealthCheckNodePort:0,PublishNotReadyAddresses:false,SessionAffinityConfig:nil,IPFamilyPolicy:*SingleStack,ClusterIPs:[10.98.245.152],IPFamilies:[IPv4],AllocateLoadBalancerNodePorts:nil,LoadBalancerClass:nil,InternalTrafficPolicy:*Cluster,},Status:ServiceStatus{LoadBalancer:LoadBalancerStatus{Ingress:[]LoadBalancerIngress{},},Conditions:[]Condition{},},}
I1229 09:09:18.549930   54738 service.go:214] Found service: &Service{ObjectMeta:{web  default  1c150658-5b47-49c1-bf66-c8a867f94da9 494 0 2022-12-29 07:54:01 -0800 PST <nil> <nil> map[app:web] map[] [] [] [{kubectl-expose Update v1 2022-12-29 07:54:01 -0800 PST FieldsV1 {"f:metadata":{"f:labels":{".":{},"f:app":{}}},"f:spec":{"f:externalTrafficPolicy":{},"f:internalTrafficPolicy":{},"f:ports":{".":{},"k:{\"port\":8080,\"protocol\":\"TCP\"}":{".":{},"f:port":{},"f:protocol":{},"f:targetPort":{}}},"f:selector":{},"f:sessionAffinity":{},"f:type":{}}} }]},Spec:ServiceSpec{Ports:[]ServicePort{ServicePort{Name:,Protocol:TCP,Port:8080,TargetPort:{0 8080 },NodePort:32013,AppProtocol:nil,},},Selector:map[string]string{app: web,},ClusterIP:10.98.245.152,Type:NodePort,ExternalIPs:[],SessionAffinity:None,LoadBalancerIP:,LoadBalancerSourceRanges:[],ExternalName:,ExternalTrafficPolicy:Cluster,HealthCheckNodePort:0,PublishNotReadyAddresses:false,SessionAffinityConfig:nil,IPFamilyPolicy:*SingleStack,ClusterIPs:[10.98.245.152],IPFamilies:[IPv4],AllocateLoadBalancerNodePorts:nil,LoadBalancerClass:nil,InternalTrafficPolicy:*Cluster,},Status:ServiceStatus{LoadBalancer:LoadBalancerStatus{Ingress:[]LoadBalancerIngress{},},Conditions:[]Condition{},},}
I1229 09:09:18.550015   54738 host.go:66] Checking if "minikube" exists ...
I1229 09:09:18.550217   54738 cli_runner.go:164] Run: docker container inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}},{{.GlobalIPv6Address}}{{end}}" minikube
I1229 09:09:18.609605   54738 cli_runner.go:164] Run: docker container inspect -f "'{{(index (index .NetworkSettings.Ports "22/tcp") 0).HostPort}}'" minikube
I1229 09:09:18.717901   54738 ssh_conn.go:186] web tunnel: Warning: Permanently added '[127.0.0.1]:55058' (ED25519) to the list of known hosts.
I1229 09:09:19.471232   54738 ssh_conn.go:186] web tunnel: Received disconnect from 127.0.0.1 port 55058:2: Too many authentication failures
I1229 09:09:19.471330   54738 ssh_conn.go:186] web tunnel: Disconnected from 127.0.0.1 port 55058
I1229 09:09:19.674575   54738 out.go:177] http://127.0.0.1:55836
W1229 09:09:19.680755   54738 out.go:239] ❗  Because you are using a Docker driver on darwin, the terminal needs to be open to run it.
```