### PR TITLE
refactor: avoiding repetitive code

### DIFF
--- a/pkg/minikube/registry/global.go
+++ b/pkg/minikube/registry/global.go
@@ -123,14 +123,10 @@ func Available(vm bool) []DriverState {
 		if !s.Healthy {
 			priority = Unhealthy
 		}
-
-		if vm {
-			if IsVM(d.Name) {
-				sts = append(sts, DriverState{Name: d.Name, Default: d.Default, Preference: preference, Priority: priority, State: s})
-			}
-		} else {
-			sts = append(sts, DriverState{Name: d.Name, Default: d.Default, Preference: preference, Priority: priority, State: s})
+		if vm && !IsVM(d.Name) {
+			continue
 		}
+		sts = append(sts, DriverState{Name: d.Name, Default: d.Default, Preference: preference, Priority: priority, State: s})
 	}
 
 	// Descending priority for predictability

--- a/pkg/minikube/registry/global.go
+++ b/pkg/minikube/registry/global.go
@@ -111,6 +111,9 @@ func Available(vm bool) []DriverState {
 	klog.Infof("Querying for installed drivers using PATH=%s", os.Getenv("PATH"))
 
 	for _, d := range globalRegistry.List() {
+		if vm && !IsVM(d.Name) {
+			continue
+		}
 		if d.Status == nil {
 			klog.Errorf("%q does not implement Status", d.Name)
 			continue
@@ -122,9 +125,6 @@ func Available(vm bool) []DriverState {
 		priority := d.Priority
 		if !s.Healthy {
 			priority = Unhealthy
-		}
-		if vm && !IsVM(d.Name) {
-			continue
 		}
 		sts = append(sts, DriverState{Name: d.Name, Default: d.Default, Preference: preference, Priority: priority, State: s})
 	}


### PR DESCRIPTION
avoiding repetitive code where checking if the instance is vm or not which wont' make a difference as the core functionality is still the same.