### PR TITLE
Fix addon registry doesn't follow Minikube DNS domain name configuration (--dns-domain)

### DIFF
--- a/deploy/addons/registry/registry-proxy.yaml.tmpl
+++ b/deploy/addons/registry/registry-proxy.yaml.tmpl
@@ -28,6 +28,6 @@ spec:
           hostPort: 5000
         env:
         - name: REGISTRY_HOST
-          value: registry.kube-system.svc.cluster.local
+          value: registry.kube-system.svc.{{.NetworkInfo.DNSDomain}}
         - name: REGISTRY_PORT
           value: "80"

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -929,6 +929,7 @@ func GenerateTemplateData(addon *Addon, cc *config.ClusterConfig, netInfo Networ
 	// Network info for generating template
 	opts.NetworkInfo["ControlPlaneNodeIP"] = netInfo.ControlPlaneNodeIP
 	opts.NetworkInfo["ControlPlaneNodePort"] = fmt.Sprint(netInfo.ControlPlaneNodePort)
+	opts.NetworkInfo["DNSDomain"] = cfg.DNSDomain
 
 	// Append postfix "/" to registries
 	for k, v := range opts.Registries {


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

- Registry bug 
minikube-with-bug-registry version
minikube-with-bug-registry -p cluster-unfixed start --dns-domain cluster.xpt
minikube-with-bug-registry -p cluster-unfixed status
minikube-with-bug-registry -p cluster-unfixed addons enable registry
kubectl -n kube-system  get pods | grep registry-proxy-
kubectl -n kube-system logs registry-proxy-m5v47 | head -n 3
nc -v $(minikube -p cluster-unfixed ip) 5000
minikube-with-bug-registry -p cluster-unfixed logs

[logs-unfixed.txt](https://github.com/kubernetes/minikube/files/10355025/logs-unfixed.txt)

<img width="1475" alt="minikube-bug" src="https://user-images.githubusercontent.com/7689017/210787063-fecc3a86-521a-447e-af08-13da53427086.png">

- Registry bug fixed
minikube-master-fix-registry version
minikube-master-fix-registry -p cluster-fixed start --dns-domain cluster.xpt
minikube-master-fix-registry -p cluster-fixed status
minikube-master-fix-registry -p cluster-fixed addons enable registry
kubectl -n kube-system  get pods | grep registry-proxy-
kubectl -n kube-system logs registry-proxy-m5v47 | head -n 3
nc -v $(minikube -p cluster-fixed ip) 5000
minikube-master-fix-registry -p cluster-fixed ssh sudo cat /etc/kubernetes/addons/registry-proxy.yaml
minikube-master-fix-registry -p cluster-fixed logs

[logs-fixed.txt](https://github.com/kubernetes/minikube/files/10354987/logs-fixed.txt)

<img width="1471" alt="minikube-fixed" src="https://user-images.githubusercontent.com/7689017/210787108-8b8fbbf5-53b5-4004-a7f3-d6429cf3d2fd.png">

