### PR TITLE
Fix profile list when profiles directory is missing

### DIFF
--- a/cmd/minikube/cmd/config/profile_list.go
+++ b/cmd/minikube/cmd/config/profile_list.go
@@ -205,7 +205,7 @@ func printProfilesJSON() {
 	updateProfilesStatus(validProfiles)
 
 	var body = map[string]interface{}{}
-	if err == nil || config.IsNotExist(err) {
+	if err == nil || os.IsNotExist(err) {
 		body["valid"] = profilesOrDefault(validProfiles)
 		body["invalid"] = profilesOrDefault(invalidProfiles)
 		jsonString, _ := json.Marshal(body)


### PR DESCRIPTION
This was reported in [1] and fixed in [2] in 2019, but later it was
broken by [3] in commit c3aafaeeb4541b0cd5303afe211fe281dbf5e4f3.
    
`listProfiles()` can return `os.ErrNotExist` from `os.ReadDir()` so it
must be tested with `os.IsNotExist()`.
    
[1] https://github.com/kubernetes/minikube/issues/5898
[2] https://github.com/kubernetes/minikube/pull/5955
[3] https://github.com/kubernetes/minikube/pull/6440

Fixes #15593