### PR TITLE
Allow running none driver with force on 1 CPU

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -197,6 +197,11 @@ func (k *Bootstrapper) init(cfg config.ClusterConfig) error {
 		"Port-10250", // For "none" users who already have a kubelet online
 		"Swap",       // For "none" users who have swap configured
 	}
+	if version.GE(semver.MustParse("1.13.0")) {
+		ignore = append(ignore,
+			"NumCPU", // For "none" users who have too few CPUs
+		)
+	}
 	if version.GE(semver.MustParse("1.20.0")) {
 		ignore = append(ignore,
 			"Mem", // For "none" users who have too little memory


### PR DESCRIPTION
For running on killercoda

Closes #15609

-----

Here is how to try minikube on the new killercoda:

https://killercoda.com/examples/scenario/ubuntu-simple

```shell
sudo apt update
sudo apt install -y conntrack socat

curl -LO https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.0/cri-dockerd_0.3.0.3-0.ubuntu-focal_amd64.deb
sudo dpkg -i cri-dockerd_0.3.0.3-0.ubuntu-focal_amd64.deb

curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_latest_amd64.deb
sudo dpkg -i minikube_latest_amd64.deb
```

`minikube start --driver=none`