### PR TITLE
Allow running docker driver with force on 1 CPU

### DIFF
--- a/cmd/minikube/cmd/node_start.go
+++ b/cmd/minikube/cmd/node_start.go
@@ -75,7 +75,7 @@ var nodeStartCmd = &cobra.Command{
 		if err != nil {
 			_, err := maybeDeleteAndRetry(cmd, *cc, *n, nil, err)
 			if err != nil {
-				node.ExitIfFatal(err)
+				node.ExitIfFatal(err, false)
 				exit.Error(reason.GuestNodeStart, "failed to start node", err)
 			}
 		}

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -218,9 +218,11 @@ func runStart(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	useForce := viper.GetBool(force)
+
 	starter, err := provisionWithDriver(cmd, ds, existing)
 	if err != nil {
-		node.ExitIfFatal(err)
+		node.ExitIfFatal(err, useForce)
 		machine.MaybeDisplayAdvice(err, ds.Name)
 		if specified {
 			// If the user specified a driver, don't fallback to anything else
@@ -280,7 +282,7 @@ func runStart(cmd *cobra.Command, args []string) {
 
 	kubeconfig, err := startWithDriver(cmd, starter, existing)
 	if err != nil {
-		node.ExitIfFatal(err)
+		node.ExitIfFatal(err, useForce)
 		exit.Error(reason.GuestStart, "failed to start node", err)
 	}
 

--- a/pkg/minikube/node/advice.go
+++ b/pkg/minikube/node/advice.go
@@ -25,12 +25,13 @@ import (
 	"k8s.io/minikube/pkg/minikube/bootstrapper/kubeadm"
 	"k8s.io/minikube/pkg/minikube/cruntime"
 	"k8s.io/minikube/pkg/minikube/exit"
+	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/reason"
 	"k8s.io/minikube/pkg/minikube/style"
 )
 
 // ExitIfFatal before exiting will try to check for different error types and provide advice if we know for sure what the error is
-func ExitIfFatal(err error) {
+func ExitIfFatal(err error, force bool) {
 	if err == nil {
 		return
 	}
@@ -52,7 +53,10 @@ func ExitIfFatal(err error) {
 		if runtime.GOOS == "windows" {
 			exit.Message(reason.RsrcInsufficientWindowsDockerCores, "Docker Desktop has less than 2 CPUs configured, but Kubernetes requires at least 2 to be available")
 		}
-		exit.Message(reason.RsrcInsufficientCores, "Docker has less than 2 CPUs available, but Kubernetes requires at least 2 to be available")
+		if !force {
+			exit.Message(reason.RsrcInsufficientCores, "Docker has less than 2 CPUs available, but Kubernetes requires at least 2 to be available")
+		}
+		out.Error(reason.RsrcInsufficientCores, "Docker has less than 2 CPUs available, but Kubernetes requires at least 2 to be available")
 	}
 
 	if errors.Is(err, kubeadm.ErrNoExecLinux) {

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -252,7 +252,7 @@ func handleAPIServer(starter Starter, cr cruntime.Manager, hostIP net.IP) (*kube
 	bs := setupKubeAdm(starter.MachineAPI, *starter.Cfg, *starter.Node, starter.Runner)
 	err = bs.StartCluster(*starter.Cfg)
 	if err != nil {
-		ExitIfFatal(err)
+		ExitIfFatal(err, false)
 		out.LogEntries("Error starting cluster", err, logs.FindProblems(cr, bs, *starter.Cfg, starter.Runner))
 		return nil, bs, err
 	}


### PR DESCRIPTION
For running on killercoda

Closes #15608

----

https://killercoda.com/examples/scenario/ubuntu-simple

`minikube start --driver=docker`