### PR TITLE
Use `IsPrivate` function provided by `net` pkg

### DIFF
--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -22,32 +22,6 @@ import (
 	"time"
 )
 
-func TestIsSubnetPrivate(t *testing.T) {
-	tests := []struct {
-		subnet   string
-		expected bool
-	}{
-		{"9.255.255.255", false},
-		{"10.0.0.0", true},
-		{"10.255.255.255", true},
-		{"11.0.0.0", false},
-		{"172.15.255.255", false},
-		{"172.16.0.0", true},
-		{"172.31.255.255", true},
-		{"172.32.0.0", false},
-		{"192.167.255.255", false},
-		{"192.168.0.0", true},
-		{"192.168.255.255", true},
-		{"192.169.0.0", false},
-	}
-	for _, test := range tests {
-		got := isSubnetPrivate(test.subnet)
-		if got != test.expected {
-			t.Errorf("isSubnetPrivate(%q) = %t; expected = %t", test.subnet, got, test.expected)
-		}
-	}
-}
-
 func TestFreeSubnet(t *testing.T) {
 	reserveSubnet = func(subnet string, period time.Duration) bool { return true }
 
@@ -65,6 +39,11 @@ func TestFreeSubnet(t *testing.T) {
 
 	t.Run("FirstSubnetTaken", func(t *testing.T) {
 		count := 0
+		originalIsSubnetTaken := isSubnetTaken
+		defer func() {
+			isSubnetTaken = originalIsSubnetTaken
+		}()
+
 		isSubnetTaken = func(subnet string) (bool, error) {
 			count++
 			return count == 1, nil
@@ -83,11 +62,17 @@ func TestFreeSubnet(t *testing.T) {
 
 	t.Run("FirstSubnetIPV6NetworkFound", func(t *testing.T) {
 		count := 0
+		originalInspect := inspect
+		defer func() {
+			inspect = originalInspect
+		}()
+
 		inspect = func(addr string) (*Parameters, error) {
 			count++
-			p := &Parameters{IP: addr}
+			p := &Parameters{IP: addr, IsPrivate: true}
 			if count == 1 {
 				p.IP = "0.0.0.0"
+				p.IsPrivate = false
 			}
 			return p, nil
 		}


### PR DESCRIPTION
Fixes #15544

Removed `isSubnetPrivate` function and started using the default `IsPrivate` function provided by the `net` pkg. Updated test cases and added restoration of mocked functions to avoid side effects on subsequent tests.
