### PR TITLE
Update kvm docker machine base image

### DIFF
--- a/.github/workflows/functional_verified.yml
+++ b/.github/workflows/functional_verified.yml
@@ -46,7 +46,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libvirt-dev
-          ls -la ./out
           MINIKUBE_BUILD_IN_DOCKER=y make cross e2e-cross debs
           strings out/docker-machine-driver-kvm2-amd64 | grep ^LIBVIRT | sort
           shasum -a 256 out/docker-machine-driver-kvm2-amd64

--- a/.github/workflows/functional_verified.yml
+++ b/.github/workflows/functional_verified.yml
@@ -46,10 +46,16 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libvirt-dev
+          ls -la ./out
           MINIKUBE_BUILD_IN_DOCKER=y make cross e2e-cross debs
           strings out/docker-machine-driver-kvm2-amd64 | grep ^LIBVIRT | sort
+          shasum -a 256 out/docker-machine-driver-kvm2-amd64
+          ls -la ./out
           cp -r test/integration/testdata ./out
           strings out/docker-machine-driver-kvm2-amd64 | grep ^LIBVIRT | sort
+          shasum -a 256 out/docker-machine-driver-kvm2-amd64
+          ls -la ./out
+          shasum -a 256 out/minikube-linux-amd64
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         with:
           name: minikube_binaries

--- a/.github/workflows/functional_verified.yml
+++ b/.github/workflows/functional_verified.yml
@@ -47,7 +47,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libvirt-dev
           MINIKUBE_BUILD_IN_DOCKER=y make cross e2e-cross debs
+          strings out/docker-machine-driver-kvm2-amd64 | grep ^LIBVIRT | sort
           cp -r test/integration/testdata ./out
+          strings out/docker-machine-driver-kvm2-amd64 | grep ^LIBVIRT | sort
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         with:
           name: minikube_binaries

--- a/.github/workflows/functional_verified.yml
+++ b/.github/workflows/functional_verified.yml
@@ -47,14 +47,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libvirt-dev
           MINIKUBE_BUILD_IN_DOCKER=y make cross e2e-cross debs
-          strings out/docker-machine-driver-kvm2-amd64 | grep ^LIBVIRT | sort
-          shasum -a 256 out/docker-machine-driver-kvm2-amd64
-          ls -la ./out
           cp -r test/integration/testdata ./out
-          strings out/docker-machine-driver-kvm2-amd64 | grep ^LIBVIRT | sort
-          shasum -a 256 out/docker-machine-driver-kvm2-amd64
-          ls -la ./out
-          shasum -a 256 out/minikube-linux-amd64
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         with:
           name: minikube_binaries

--- a/Makefile
+++ b/Makefile
@@ -911,8 +911,6 @@ out/docker-machine-driver-kvm2-%:
 ifeq ($(MINIKUBE_BUILD_IN_DOCKER),y)
 	docker image inspect -f '{{.Id}} {{.RepoTags}}' $(KVM_BUILD_IMAGE_AMD64) || $(MAKE) kvm-image-amd64
 	$(call DOCKER,$(KVM_BUILD_IMAGE_AMD64),/usr/bin/make $@ COMMIT=$(COMMIT))
-	strings $@ | grep ^LIBVIRT | sort
-	shasum -a 256 $@
 else
 	$(if $(quiet),@echo "  GO       $@")
 	uname -a

--- a/Makefile
+++ b/Makefile
@@ -901,7 +901,7 @@ else
 		-buildvcs=false \
 		-installsuffix "static" \
 		-ldflags="$(KVM2_LDFLAGS)" \
-		-tags "libvirt.1.3.1 without_lxc" \
+		-tags "libvirt_without_lxc" \
 		-o $@ \
 		k8s.io/minikube/cmd/drivers/kvm
 endif
@@ -911,15 +911,14 @@ out/docker-machine-driver-kvm2-%:
 ifeq ($(MINIKUBE_BUILD_IN_DOCKER),y)
 	docker image inspect -f '{{.Id}} {{.RepoTags}}' $(KVM_BUILD_IMAGE_AMD64) || $(MAKE) kvm-image-amd64
 	$(call DOCKER,$(KVM_BUILD_IMAGE_AMD64),/usr/bin/make $@ COMMIT=$(COMMIT))
-	# make extra sure that we are linking with the older version of libvirt (1.3.1)
-	test "`strings $@ | grep '^LIBVIRT_[0-9]' | sort | tail -n 1`" = "LIBVIRT_1.2.9"
 else
 	$(if $(quiet),@echo "  GO       $@")
 	$(Q)GOARCH=$* \
 	go build \
+	        -buildvcs=false \
 		-installsuffix "static" \
 		-ldflags="$(KVM2_LDFLAGS)" \
-		-tags "libvirt.1.3.1 without_lxc" \
+		-tags "libvirt_without_lxc" \
 		-o $@ \
 		k8s.io/minikube/cmd/drivers/kvm
 endif

--- a/Makefile
+++ b/Makefile
@@ -913,7 +913,6 @@ ifeq ($(MINIKUBE_BUILD_IN_DOCKER),y)
 	$(call DOCKER,$(KVM_BUILD_IMAGE_AMD64),/usr/bin/make $@ COMMIT=$(COMMIT))
 else
 	$(if $(quiet),@echo "  GO       $@")
-	uname -a
 	$(Q)GOARCH=$* \
 	go build \
 	        -buildvcs=false \

--- a/Makefile
+++ b/Makefile
@@ -911,8 +911,10 @@ out/docker-machine-driver-kvm2-%:
 ifeq ($(MINIKUBE_BUILD_IN_DOCKER),y)
 	docker image inspect -f '{{.Id}} {{.RepoTags}}' $(KVM_BUILD_IMAGE_AMD64) || $(MAKE) kvm-image-amd64
 	$(call DOCKER,$(KVM_BUILD_IMAGE_AMD64),/usr/bin/make $@ COMMIT=$(COMMIT))
+	strings $@ | grep ^LIBVIRT | sort
 else
 	$(if $(quiet),@echo "  GO       $@")
+	uname -a
 	$(Q)GOARCH=$* \
 	go build \
 	        -buildvcs=false \

--- a/Makefile
+++ b/Makefile
@@ -912,6 +912,7 @@ ifeq ($(MINIKUBE_BUILD_IN_DOCKER),y)
 	docker image inspect -f '{{.Id}} {{.RepoTags}}' $(KVM_BUILD_IMAGE_AMD64) || $(MAKE) kvm-image-amd64
 	$(call DOCKER,$(KVM_BUILD_IMAGE_AMD64),/usr/bin/make $@ COMMIT=$(COMMIT))
 	strings $@ | grep ^LIBVIRT | sort
+	shasum -a 256 $@
 else
 	$(if $(quiet),@echo "  GO       $@")
 	uname -a

--- a/hack/jenkins/minikube_cross_build_and_upload.sh
+++ b/hack/jenkins/minikube_cross_build_and_upload.sh
@@ -39,6 +39,7 @@ declare -rx DEB_VER="$(make deb_version)"
 
 docker kill $(docker ps -q) || true
 docker rm $(docker ps -aq) || true
+docker system prune -a --volumes -f
 make -j 16 \
   all \
   minikube-darwin-arm64 \

--- a/installers/linux/kvm/Dockerfile.amd64
+++ b/installers/linux/kvm/Dockerfile.amd64
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/gcp-runtimes/ubuntu_16_0_4
+FROM gcr.io/gcp-runtimes/ubuntu_20_0_4
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		gcc \


### PR DESCRIPTION
- Updated `without_lxc` to `libvirt_without_lxc` as per https://gitlab.com/libvirt/libvirt-go-module/-/merge_requests/34
- Updated base image of `docker-machine-driver-kvm2-amd64` builder from Ubuntu 16.04 to Ubuntu 20.04 to fix libvirt build error
- Added `docker system prune -a --volumes -f` to cross build to clear out previous run artifacts

This makes the build on https://github.com/kubernetes/minikube/pull/15537 complete