### PR TITLE
Add check for Docker Desktop 4.16.0

### DIFF
--- a/pkg/minikube/registry/drvs/docker/docker_test.go
+++ b/pkg/minikube/registry/drvs/docker/docker_test.go
@@ -135,8 +135,8 @@ func TestCheckDockerVersion(t *testing.T) {
 	}...)
 
 	for _, c := range tc {
-		t.Run("checkDockerVersion test", func(t *testing.T) {
-			s := checkDockerVersion(c.version)
+		t.Run("checkDockerEngineVersion test", func(t *testing.T) {
+			s := checkDockerEngineVersion(c.version)
 			if s.Error != nil {
 				if c.expect != s.Reason {
 					t.Errorf("Error %v expected. but got %q. (version string : %s)", c.expect, s.Reason, c.version)

--- a/pkg/minikube/registry/drvs/docker/docker_test.go
+++ b/pkg/minikube/registry/drvs/docker/docker_test.go
@@ -64,7 +64,7 @@ func stringToIntSlice(t *testing.T, s string) []int {
 	return []int{int(sem.Major), int(sem.Minor), int(sem.Patch)}
 }
 
-func TestCheckDockerVersion(t *testing.T) {
+func TestCheckDockerEngineVersion(t *testing.T) {
 	recParts := stringToIntSlice(t, recommendedDockerVersion)
 	minParts := stringToIntSlice(t, minDockerVersion)
 
@@ -148,5 +148,25 @@ func TestCheckDockerVersion(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestCheckDockerDesktopVersion(t *testing.T) {
+	tests := []struct {
+		input             string
+		shouldReturnState bool
+	}{
+		{"Docker Desktop", false},
+		{"Cat Desktop 4.16.0", false},
+		{"Docker Playground 4.16.0", false},
+		{"Docker Desktop 4.15.0", false},
+		{"Docker Desktop 4.16.0", true},
+		{"  Docker  Desktop  4.16.0  ", true},
+	}
+	for _, tt := range tests {
+		state := checkDockerDesktopVersion(tt.input)
+		if (state == nil && tt.shouldReturnState) || (state != nil && !tt.shouldReturnState) {
+			t.Errorf("checkDockerDesktopVersion(%q) = %v; expected shouldRetunState = %t", tt.input, state, tt.shouldReturnState)
+		}
 	}
 }


### PR DESCRIPTION
```
$ docker version --format {{.Server.Platform.Name}}
Docker Desktop 4.16.0 (95345)

$ ./out/minikube start --driver docker
😄  minikube v1.28.0 on Darwin 13.1 (arm64)
✨  Using the docker driver based on user configuration

💣  Exiting due to PROVIDER_DOCKER_DESKTOP_VERSION_BAD: Docker Desktop 4.16.0 has a regression that prevents minikube from starting
💡  Suggestion: Update Docker Desktop to 4.16.1 or greater

```