### PR TITLE
Add gcp-auth to logs output if enabled

### DIFF
--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
+	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/audit"
 	"k8s.io/minikube/pkg/minikube/bootstrapper"
 	"k8s.io/minikube/pkg/minikube/command"
@@ -265,7 +266,11 @@ func OutputOffline(lines int, logOutput *os.File) {
 // logCommands returns a list of commands that would be run to receive the anticipated logs
 func logCommands(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.ClusterConfig, length int, follow bool) map[string]string {
 	cmds := bs.LogCommands(cfg, bootstrapper.LogOptions{Lines: length, Follow: follow})
-	for _, pod := range importantPods {
+	pods := importantPods
+	if assets.Addons["gcp-auth"].IsEnabled(&cfg) {
+		pods = append(pods, "gcp-auth")
+	}
+	for _, pod := range pods {
 		ids, err := r.ListContainers(cruntime.ListContainersOptions{Name: pod})
 		if err != nil {
 			klog.Errorf("Failed to list containers for %q: %v", pod, err)


### PR DESCRIPTION
Adds `gcp-auth` pod logs to `minikube logs` output if enabled.

```
...
{"level":"info","ts":"2023-01-19T00:05:12.349Z","caller":"etcdserver/server.go:851","msg":"starting etcd server","local-member-id":"8688e899f7831fc7","local-server-version":"3.5.4","cluster-version":"to_be_decided"}
{"level":"info","ts":"2023-01-19T00:05:12.349Z","caller":"etcdserver/server.go:736","msg":"started as single-node; fast-forwarding election ticks","local-member-id":"8688e899f7831fc7","forward-ticks":9,"forward-duration":"900ms","election-ticks":10,"election-timeout":"1s"}
{"level":"info","ts":"2023-01-19T00:05:12.349Z","logger":"raft","caller":"etcdserver/zap_raft.go:77","msg":"8688e899f7831fc7 switched to configuration voters=(9694253945895198663)"}
{"level":"info","ts":"2023-01-19T00:05:12.349Z","caller":"membership/cluster.go:421","msg":"added member","cluster-id":"9d8fdeb88b6def78","local-member-id":"8688e899f7831fc7","added-peer-id":"8688e899f7831fc7","added-peer-peer-urls":["https://192.168.67.2:2380"]}
{"level":"info","ts":"2023-01-19T00:05:12.350Z","caller":"embed/etcd.go:688","msg":"starting with client TLS","tls-info":"cert = /var/lib/minikube/certs/etcd/server.crt, key = /var/lib/minikube/certs/etcd/server.key, client-cert=, client-key=, trusted-ca = /var/lib/minikube/certs/etcd/ca.crt, client-cert-auth = true, crl-file = ","cipher-suites":[]}
{"level":"info","ts":"2023-01-19T00:05:12.350Z","caller":"embed/etcd.go:581","msg":"serving peer traffic","address":"192.168.67.2:2380"}
{"level":"info","ts":"2023-01-19T00:05:12.350Z","caller":"embed/etcd.go:553","msg":"cmux::serve","address":"192.168.67.2:2380"}
{"level":"info","ts":"2023-01-19T00:05:12.350Z","caller":"embed/etcd.go:277","msg":"now serving peer/client/metrics","local-member-id":"8688e899f7831fc7","initial-advertise-peer-urls":["https://192.168.67.2:2380"],"listen-peer-urls":["https://192.168.67.2:2380"],"advertise-client-urls":["https://192.168.67.2:2379"],"listen-client-urls":["https://127.0.0.1:2379","https://192.168.67.2:2379"],"listen-metrics-urls":["http://127.0.0.1:2381"]}
{"level":"info","ts":"2023-01-19T00:05:12.350Z","caller":"embed/etcd.go:763","msg":"serving metrics","address":"http://127.0.0.1:2381"}
{"level":"info","ts":"2023-01-19T00:05:12.947Z","logger":"raft","caller":"etcdserver/zap_raft.go:77","msg":"8688e899f7831fc7 is starting a new election at term 1"}
{"level":"info","ts":"2023-01-19T00:05:12.947Z","logger":"raft","caller":"etcdserver/zap_raft.go:77","msg":"8688e899f7831fc7 became pre-candidate at term 1"}
{"level":"info","ts":"2023-01-19T00:05:12.947Z","logger":"raft","caller":"etcdserver/zap_raft.go:77","msg":"8688e899f7831fc7 received MsgPreVoteResp from 8688e899f7831fc7 at term 1"}
{"level":"info","ts":"2023-01-19T00:05:12.947Z","logger":"raft","caller":"etcdserver/zap_raft.go:77","msg":"8688e899f7831fc7 became candidate at term 2"}
{"level":"info","ts":"2023-01-19T00:05:12.947Z","logger":"raft","caller":"etcdserver/zap_raft.go:77","msg":"8688e899f7831fc7 received MsgVoteResp from 8688e899f7831fc7 at term 2"}
{"level":"info","ts":"2023-01-19T00:05:12.947Z","logger":"raft","caller":"etcdserver/zap_raft.go:77","msg":"8688e899f7831fc7 became leader at term 2"}
{"level":"info","ts":"2023-01-19T00:05:12.947Z","logger":"raft","caller":"etcdserver/zap_raft.go:77","msg":"raft.node: 8688e899f7831fc7 elected leader 8688e899f7831fc7 at term 2"}
{"level":"info","ts":"2023-01-19T00:05:12.947Z","caller":"etcdserver/server.go:2042","msg":"published local member to cluster through raft","local-member-id":"8688e899f7831fc7","local-member-attributes":"{Name:minikube ClientURLs:[https://192.168.67.2:2379]}","request-path":"/0/members/8688e899f7831fc7/attributes","cluster-id":"9d8fdeb88b6def78","publish-timeout":"7s"}
{"level":"info","ts":"2023-01-19T00:05:12.947Z","caller":"embed/serve.go:98","msg":"ready to serve client requests"}
{"level":"info","ts":"2023-01-19T00:05:12.947Z","caller":"etcdserver/server.go:2507","msg":"setting up initial cluster version using v2 API","cluster-version":"3.5"}
{"level":"info","ts":"2023-01-19T00:05:12.947Z","caller":"embed/serve.go:98","msg":"ready to serve client requests"}
{"level":"info","ts":"2023-01-19T00:05:12.947Z","caller":"etcdmain/main.go:44","msg":"notifying init daemon"}
{"level":"info","ts":"2023-01-19T00:05:12.947Z","caller":"etcdmain/main.go:50","msg":"successfully notified init daemon"}
{"level":"info","ts":"2023-01-19T00:05:12.948Z","caller":"membership/cluster.go:584","msg":"set initial cluster version","cluster-id":"9d8fdeb88b6def78","local-member-id":"8688e899f7831fc7","cluster-version":"3.5"}
{"level":"info","ts":"2023-01-19T00:05:12.948Z","caller":"api/capability.go:75","msg":"enabled capabilities for version","cluster-version":"3.5"}
{"level":"info","ts":"2023-01-19T00:05:12.948Z","caller":"etcdserver/server.go:2531","msg":"cluster version is updated","cluster-version":"3.5"}
{"level":"info","ts":"2023-01-19T00:05:12.948Z","caller":"embed/serve.go:188","msg":"serving client traffic securely","address":"192.168.67.2:2379"}
{"level":"info","ts":"2023-01-19T00:05:12.948Z","caller":"embed/serve.go:188","msg":"serving client traffic securely","address":"127.0.0.1:2379"}


==> gcp-auth [3240cc993b5c] <==
2023/01/19 00:05:53 GCP Auth Webhook started!


==> kernel <==
 00:06:00 up 16:38,  0 users,  load average: 0.85, 0.50, 0.41
Linux minikube 5.15.49-linuxkit #1 SMP PREEMPT Tue Sep 13 07:51:32 UTC 2022 aarch64 aarch64 aarch64 GNU/Linux
PRETTY_NAME="Ubuntu 20.04.5 LTS"


==> kube-apiserver [48869b831200] <==
W0119 00:05:13.463325       1 genericapiserver.go:656] Skipping API events.k8s.io/v1beta1 because it has no resources.
I0119 00:05:13.463805       1 plugins.go:158] Loaded 12 mutating admission controller(s) successfully in the following order: NamespaceLifecycle,LimitRanger,ServiceAccount,NodeRestriction,TaintNodesByCondition,Priority,DefaultTolerationSeconds,DefaultStorageClass,StorageObjectInUseProtection,RuntimeClass,DefaultIngressClass,MutatingAdmissionWebhook.
I0119 00:05:13.463814       1 plugins.go:161] Loaded 11 validating admission controller(s) successfully in the following order: LimitRanger,ServiceAccount,PodSecurity,Priority,PersistentVolumeClaimResize,RuntimeClass,CertificateApproval,CertificateSigning,CertificateSubjectRestriction,ValidatingAdmissionWebhook,ResourceQuota.
W0119 00:05:13.473766       1 genericapiserver.go:656] Skipping API apiregistration.k8s.io/v1beta1 because it has no resources.
I0119 00:05:14.171563       1 dynamic_cafile_content.go:157] "Starting controller" name="request-header::/var/lib/minikube/certs/front-proxy-ca.crt"
I0119 00:05:14.171615       1 secure_serving.go:210] Serving securely on [::]:8443
I0119 00:05:14.171635       1 tlsconfig.go:240] "Starting DynamicServingCertificateController"
I0119 00:05:14.171646       1 dynamic_cafile_content.go:157] "Starting controller" name="client-ca-bundle::/var/lib/minikube/certs/ca.crt"
I0119 00:05:14.171741       1 dynamic_serving_content.go:132] "Starting controller" name="aggregator-proxy-cert::/var/lib/minikube/certs/front-proxy-client.crt::/var/lib/minikube/certs/front-proxy-client.key"
I0119 00:05:14.171758       1 apiservice_controller.go:97] Starting APIServiceRegistrationController
I0119 00:05:14.171768       1 cache.go:32] Waiting for caches to sync for APIServiceRegistrationController controller
I0119 00:05:14.171783       1 controller.go:80] Starting OpenAPI V3 AggregationController
I0119 00:05:14.171846       1 customresource_discovery_controller.go:209] Starting DiscoveryController
I0119 00:05:14.171861       1 available_controller.go:491] Starting AvailableConditionController
I0119 00:05:14.171867       1 cache.go:32] Waiting for caches to sync for AvailableConditionController controller
I0119 00:05:14.171884       1 autoregister_controller.go:141] Starting autoregister controller
I0119 00:05:14.171887       1 cache.go:32] Waiting for caches to sync for autoregister controller
I0119 00:05:14.171913       1 crdregistration_controller.go:111] Starting crd-autoregister controller
I0119 00:05:14.171924       1 shared_informer.go:255] Waiting for caches to sync for crd-autoregister
I0119 00:05:14.171928       1 controller.go:85] Starting OpenAPI controller
I0119 00:05:14.171939       1 controller.go:85] Starting OpenAPI V3 controller
I0119 00:05:14.171963       1 cluster_authentication_trust_controller.go:440] Starting cluster_authentication_trust_controller controller
I0119 00:05:14.171975       1 nonstructuralschema_controller.go:192] Starting NonStructuralSchemaConditionController
I0119 00:05:14.171977       1 shared_informer.go:255] Waiting for caches to sync for cluster_authentication_trust_controller
I0119 00:05:14.171769       1 apf_controller.go:300] Starting API Priority and Fairness config controller
I0119 00:05:14.171996       1 crd_finalizer.go:266] Starting CRDFinalizer
I0119 00:05:14.172261       1 controller.go:83] Starting OpenAPI AggregationController
...
```

This will help debug GCP-Auth issues