### PR TITLE
Updates knative minimum resource requirements

### DIFF
--- a/site/content/en/docs/faq/_index.md
+++ b/site/content/en/docs/faq/_index.md
@@ -101,10 +101,10 @@ minikube start --extra-config kubeadm.ignore-preflight-errors=SystemVerification
 
 ## What is the minimum resource allocation necessary for a Knative setup using minikube?
 
-Please allocate sufficient resources for Knative setup using minikube, especially when running minikube cluster on your local machine. We recommend allocating at least 6 CPUs and 8G memory:
+Please allocate sufficient resources for Knative setup using minikube, especially when running minikube cluster on your local machine. We recommend allocating at least 3 CPUs and 3G memory.
 
 ```shell
-minikube start --cpus 6 --memory 8000
+minikube start --cpus 3 --memory 3072
 ```
 
 ## Do I need to install kubectl locally?


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

We currently recommend a minimum of 3 GB RAM / 3 CPUs when running Knative on minikube, so this PR updates the minikube FAQ to use those recommendations. 

(my guess is the 6 CPU / 8G ram is from when istio was a hard requirement, but that hasn't been the case for a while now)

xref: https://github.com/knative-sandbox/kn-plugin-quickstart/issues/382