### PR TITLE
cache-invalidation based on image's contentDigest(a.k.a. imageId)

### DIFF
--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -410,6 +410,17 @@ func inspect(ociBin string, containerNameOrID, format string) ([]string, error) 
 	return lines, err
 }
 
+// IsImageLoaded
+// takes a binary name OCIBIN to call,
+// and a contentDigest(a.k.a. ImageID) CD to look for
+func IsImageLoaded(ociBin, cd string) (bool, error) {
+	rr, err := runCmd(exec.Command(ociBin, "images", "--no-trunc", "--format", "{{.ID}}"))
+	if err != nil {
+		return false, err
+	}
+	return strings.Contains(rr.Stdout.String(), cd), err
+}
+
 /*
 This is adapted from:
 https://github.com/kubernetes/kubernetes/blob/07a5488b2a8f67add543da72e8819407d8314204/pkg/kubelet/dockershim/helpers.go#L115-L155

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -26,8 +26,8 @@ const (
 	// Version is the current version of kic
 	Version = "v0.0.36-1674600772-15703"
 
-	// SHA of the kic base image
-	baseImageSHA = "2d98ad015e4d4e62e5732f2fee3fee64134bacf791a9271872bbd57d47937d5f"
+	// SHA of compressed image, used as a registry reference
+	distributionDigest = "2d98ad015e4d4e62e5732f2fee3fee64134bacf791a9271872bbd57d47937d5f"
 	// The name of the GCR kicbase repository
 	gcrRepo = "gcr.io/k8s-minikube/kicbase-builds"
 	// The name of the Dockerhub kicbase repository
@@ -36,13 +36,13 @@ const (
 
 var (
 	// BaseImage is the base image is used to spin up kic containers. it uses same base-image as kind.
-	BaseImage = fmt.Sprintf("%s:%s@sha256:%s", gcrRepo, Version, baseImageSHA)
+	BaseImage = fmt.Sprintf("%s:%s@sha256:%s", gcrRepo, Version, distributionDigest)
 
 	// FallbackImages are backup base images in case gcr isn't available
 	FallbackImages = []string{
 		// the fallback of BaseImage in case gcr.io is not available. stored in docker hub
 		// same image is push to https://github.com/kicbase/stable
-		fmt.Sprintf("%s:%s@sha256:%s", dockerhubRepo, Version, baseImageSHA),
+		fmt.Sprintf("%s:%s@sha256:%s", dockerhubRepo, Version, distributionDigest),
 		// try without sha because #11068
 		fmt.Sprintf("%s:%s", gcrRepo, Version),
 		fmt.Sprintf("%s:%s", dockerhubRepo, Version),

--- a/pkg/minikube/download/image.go
+++ b/pkg/minikube/download/image.go
@@ -46,8 +46,8 @@ var (
 	}
 )
 
-// imagePathInCache returns path in local cache directory
-func imagePathInCache(img string) string {
+// ImagePathInCache returns path in local cache directory
+func ImagePathInCache(img string) string {
 	f := filepath.Join(detect.KICCacheDir(), path.Base(img)+".tar")
 	f = localpath.SanitizeCacheDir(f)
 	return f
@@ -55,7 +55,7 @@ func imagePathInCache(img string) string {
 
 // ImageExistsInCache if img exist in local cache directory
 func ImageExistsInCache(img string) bool {
-	f := imagePathInCache(img)
+	f := ImagePathInCache(img)
 
 	// Check if image exists locally
 	klog.Infof("Checking for %s in local cache directory", img)
@@ -88,7 +88,7 @@ func ImageExistsInDaemon(img string) bool {
 
 // ImageToCache downloads img (if not present in cache) and writes it to the local cache directory
 func ImageToCache(img string) error {
-	f := imagePathInCache(img)
+	f := ImagePathInCache(img)
 	fileLock := f + ".lock"
 
 	releaser, err := lockDownload(fileLock)
@@ -206,7 +206,7 @@ func parseImage(img string) (*name.Tag, name.Reference, error) {
 // If online it will be: image:tag@sha256
 // If offline it will be: image:tag
 func CacheToDaemon(img string) (string, error) {
-	p := imagePathInCache(img)
+	p := ImagePathInCache(img)
 
 	tag, ref, err := parseImage(img)
 	if err != nil {

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -17,7 +17,10 @@ limitations under the License.
 package node
 
 import (
+	"archive/tar"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"runtime"
@@ -31,6 +34,7 @@ import (
 	"k8s.io/klog/v2"
 	cmdcfg "k8s.io/minikube/cmd/minikube/cmd/config"
 	"k8s.io/minikube/pkg/drivers/kic"
+	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/download"
@@ -119,7 +123,6 @@ func beginDownloadKicBaseImage(g *errgroup.Group, cc *config.ClusterConfig, down
 
 	klog.Infof("Beginning downloading kic base image for %s with %s", cc.Driver, cc.KubernetesConfig.ContainerRuntime)
 	register.Reg.SetStep(register.PullingBaseImage)
-	out.Step(style.Pulling, "Pulling base image ...")
 	g.Go(func() error {
 		baseImg := cc.KicBaseImage
 		if baseImg == kic.BaseImage && len(cc.KubernetesConfig.ImageRepository) != 0 {
@@ -137,23 +140,45 @@ func beginDownloadKicBaseImage(g *errgroup.Group, cc *config.ClusterConfig, down
 			}
 		}()
 		for _, img := range append([]string{baseImg}, kic.FallbackImages...) {
-			var err error
 
-			if driver.IsDocker(cc.Driver) && download.ImageExistsInDaemon(img) && !downloadOnly {
-				klog.Infof("%s exists in daemon, skipping load", img)
+			// 1. check if image is already in minikube cache
+			cached, err := isImageAlreadyCached(img)
+			if err != nil {
+				return err
+			}
+
+			// if we don't have the specified image
+			// we try to pull it from remote, to the minikube cache
+			// if we have it already.. we're good
+			// takes into account the --download-only flag
+			if !cached || downloadOnly {
+				out.Step(style.Pulling, "Pulling base image to minikube cache ...")
+				klog.Infof("Downloading %s to minikube cache", img)
+				err = pullImageToMinikubeCache(img)
+				if err == nil && downloadOnly {
+					return nil
+				} else if err != nil {
+					return err
+				}
+			}
+
+			// 2. We check that the image is loaded inside the kicDriver
+			cd, err := getContentDigestFromTarball(img)
+			if err != nil {
+				return err
+			}
+			stored, err := isImageInKicDriver(cc.Driver, cd)
+			if err != nil {
+				return err
+			}
+			if stored {
+				klog.Infof("%s already present in KicDriver", img)
 				finalImg = img
 				return nil
 			}
 
-			klog.Infof("Downloading %s to local cache", img)
-			err = download.ImageToCache(img)
-			if err == nil {
-				klog.Infof("successfully saved %s as a tarball", img)
-			}
-			if downloadOnly && err == nil {
-				return nil
-			}
-
+			out.Step(style.Waiting, "Loading KicDriver with base image ...")
+			// if we don't have the cached image in KicDriver.. we're loading it
 			if cc.Driver == driver.Podman {
 				return fmt.Errorf("not yet implemented, see issue #8426")
 			}
@@ -253,4 +278,89 @@ func updateKicImageRepo(imgName string, repo string) string {
 		image = strings.TrimPrefix(image, "k8s-minikube/")
 	}
 	return path.Join(repo, image)
+}
+
+// isImageAlreadyCached
+// given an IMG(img[:tag[@digest]]),
+// it sanitizes the string as a path to minikube cache
+// and looks for the referenced tarball
+func isImageAlreadyCached(img string) (bool, error) {
+	fname := download.ImagePathInCache(img)
+	exists, err := func(p string) (bool, error) {
+		_, err := os.Stat(p)
+		if err == nil {
+			return true, nil
+		}
+
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+
+		return false, err
+	}(fname)
+	if err != nil {
+		return false, err
+	}
+
+	return exists, err
+}
+
+// pullImageToMinikubeCache
+// given an IMG, it saves it in .tar format inside the minikube cache
+// if successful, it reads the contentDigest from the .tar file
+// and saves all the information as a repositories.json entry
+func pullImageToMinikubeCache(img string) error {
+	return download.ImageToCache(img)
+}
+
+// isImageInKicDriver
+// takes a contentDigest CD as a parameter,
+// checks if the corresponding image is loaded inside the kicDriver
+// TODO: perhaps we should call the kic pkg, that in turn should call the oci pkg?
+func isImageInKicDriver(ociBin, cd string) (bool, error) {
+	return oci.IsImageLoaded(ociBin, cd)
+}
+
+// getContentDigestFromTarball
+// takes an IMG as a parameter, finds the related tarball.
+// walks tarball header for manifest.json and return the Config hash
+func getContentDigestFromTarball(img string) (string, error) {
+	var manifest = "manifest.json"
+
+	tarPath := download.ImagePathInCache(img)
+	fd, err := os.Open(tarPath)
+	if err != nil {
+		return "", err
+	}
+	defer fd.Close()
+
+	tr := tar.NewReader(fd)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return "", fmt.Errorf("reached EOF in %s while looking for manifest", tarPath)
+		}
+		if err != nil {
+			return "", err
+		}
+
+		if hdr.Name == manifest {
+			data, err := io.ReadAll(tr)
+			if err != nil {
+				return "", err
+			}
+
+			imgCfg := []struct {
+				Cfg string `json:"Config"`
+			}{}
+			err = json.Unmarshal(data, &imgCfg)
+			if err != nil {
+				return "", err
+			}
+
+			cd := strings.TrimPrefix(imgCfg[0].Cfg, "sha256:")
+			cd = strings.TrimSuffix(cd, ".json")
+			return cd, nil
+		}
+	}
 }


### PR DESCRIPTION
In order to accomplish contentDigest-based cache-invalidation,
this proposes a very simple mechanism based on cache's filesystem:

KicDriver's stored images are checked against the cache based on contentDigest,
the contentDigest from the cached image is retrieved reading the manifest.json file inside the tarball,
the tarball is selected based on sanitized image name.

related to #15677 
solves #currently_nothing.. but would facilitate the work in accomplishing #15491 
and solving related issues..