### PR TITLE
Add solution message for socket_vmnet permission denied

### DIFF
--- a/pkg/drivers/qemu/qemu.go
+++ b/pkg/drivers/qemu/qemu.go
@@ -509,6 +509,8 @@ func cmdOutErr(cmdStr string, args ...string) (string, string, error) {
 	if err != nil {
 		if ee, ok := err.(*exec.Error); ok && ee == exec.ErrNotFound {
 			err = fmt.Errorf("mystery error: %v", ee)
+		} else {
+			err = fmt.Errorf("%s: %v", strings.Trim(stderrStr, "\n"), err)
 		}
 	} else {
 		// also catch error messages in stderr, even if the return code looks OK

--- a/pkg/minikube/reason/known_issues.go
+++ b/pkg/minikube/reason/known_issues.go
@@ -578,6 +578,16 @@ Alternatively, you can try upgrading to the latest hyperkit version, or using an
 		},
 		Regexp: re(`VBoxManage not found. Make sure VirtualBox is installed and VBoxManage is in the path`),
 	},
+
+	// QEMU
+	{
+		Kind: Kind{
+			ID:       "PR_QEMU_SOCKET_VMNET_DENIED",
+			ExitCode: ExProviderError,
+			Advice:   "socket_vmnet was installed with an incorrect group, delete this cluster 'minikube delete' and update the group 'sudo chown root:$(stat -f \"%Sg\" ~) /var/run/socket_vmnet' and try again.",
+		},
+		Regexp: re(`Failed to connect to "/var/run/socket_vmnet": Permission denied`),
+	},
 }
 
 // driverIssues are specific to a libmachine driver


### PR DESCRIPTION
```
$ minikube start --driver qemu --network socket_vmnet
😄  minikube v1.28.0 on Darwin 13.1 (arm64)
✨  Using the qemu2 driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🔥  Creating qemu2 VM (CPUs=2, Memory=4000MB, Disk=20000MB) ...\ OUTPUT: 
ERROR: Failed to connect to "/var/run/socket_vmnet": Permission denied


🔥  Deleting "minikube" in qemu2 ...
🤦  StartHost failed, but will try again: creating host: create: creating: Failed to connect to "/var/run/socket_vmnet": Permission denied: exit status 1
🔥  Creating qemu2 VM (CPUs=2, Memory=4000MB, Disk=20000MB) ...- OUTPUT: 
ERROR: Failed to connect to "/var/run/socket_vmnet": Permission denied


😿  Failed to start qemu2 VM. Running "minikube delete" may fix it: creating host: create: creating: Failed to connect to "/var/run/socket_vmnet": Permission denied: exit status 1

❌  Exiting due to PR_QEMU_SOCKET_VMNET_DENIED: Failed to start host: creating host: create: creating: Failed to connect to "/var/run/socket_vmnet": Permission denied: exit status 1
💡  Suggestion: socket_vmnet was installed with an incorrect group, delete this cluster 'minikube delete' and update the group 'sudo chown root:$(stat -f "%Sg" ~) /var/run/socket_vmnet' and try again.
```