### PR TITLE
fix addons map race condition

### DIFF
--- a/pkg/addons/addons_test.go
+++ b/pkg/addons/addons_test.go
@@ -126,10 +126,15 @@ func TestStart(t *testing.T) {
 		KubernetesConfig: config.KubernetesConfig{},
 	}
 
+	toEnable := ToEnable(cc, map[string]bool{}, []string{"dashboard"})
+	enabled := make(chan []string, 1)
 	var wg sync.WaitGroup
 	wg.Add(1)
-	go Start(&wg, cc, map[string]bool{}, []string{"dashboard"})
+	go Enable(&wg, cc, toEnable, enabled)
 	wg.Wait()
+	if ea, ok := <-enabled; ok {
+		UpdateConfig(cc, ea)
+	}
 
 	if !assets.Addons["dashboard"].IsEnabled(cc) {
 		t.Errorf("expected dashboard to be enabled")


### PR DESCRIPTION
fixes #15705

from the issue's logs, we see that we can hit a race condition over concurrent reading and writing to the addons map - eg, we have addons.Start()  [called asynchronously](https://github.com/kubernetes/minikube/blob/1784105c66c9060eaa447efa3dab6ac2918167ca/pkg/minikube/node/start.go#L179), that might try to update the addons map (eg, [here](https://github.com/kubernetes/minikube/blob/1784105c66c9060eaa447efa3dab6ac2918167ca/pkg/addons/addons.go#L497) and [here](https://github.com/kubernetes/minikube/blob/1784105c66c9060eaa447efa3dab6ac2918167ca/pkg/addons/addons.go#L514)), while we also have multiple places where we potentially try to read the addons map at the same time (as being a part of the cluster config)

now, because it makes sense to try to enable addons concurrently, this pr tries to guard against that situation by splitting the addons.Start() into addons.Enable() (that is thread-safe and does the actual work of concurrently enabling addons) and addons.ToEnable() and addons.UpdateConfig() that are not thread-safe and therefore should be called synchronously before and after the addons.Enable is started as a goroutine
this way, we do not need to try to cover with locks all the places where we concurrently read the map - currently and in the future

attached are the logs from local test runs for TestAddons and TestMultiNode on ubuntu 20.04, ubuntu 22.04 vms and opensuse with docker & kvm2 driver and containerd container runtime - all passed:

- [TestAddons - docker@ubuntu2004 - PASS.log](https://github.com/kubernetes/minikube/files/10501578/TestAddons.-.docker%40ubuntu2004.-.PASS.log)
- [TestAddons - docker@ubuntu2204 - PASS.log](https://github.com/kubernetes/minikube/files/10501580/TestAddons.-.docker%40ubuntu2204.-.PASS.log)
- [TestAddons - kvm2@opensuse - PASS.log](https://github.com/kubernetes/minikube/files/10501584/TestAddons.-.kvm2%40opensuse.-.PASS.log)
- [TestMultiNode - docker@ubuntu2004 - PASS.log](https://github.com/kubernetes/minikube/files/10501585/TestMultiNode.-.docker%40ubuntu2004.-.PASS.log)
- [TestMultiNode - docker@ubuntu2204 - PASS.log](https://github.com/kubernetes/minikube/files/10501587/TestMultiNode.-.docker%40ubuntu2204.-.PASS.log)
- [TestMultiNode - kvm2@opensuse - PASS.log](https://github.com/kubernetes/minikube/files/10501695/TestMultiNode.-.kvm2%40opensuse.-.PASS.log)
