### PR TITLE
Infer HyperKit HostIP as Gateway rather than hardcode to 192.168.64.1 

### DIFF
--- a/pkg/minikube/cluster/ip.go
+++ b/pkg/minikube/cluster/ip.go
@@ -128,7 +128,9 @@ func HostIP(host *host.Host, clusterName string) (net.IP, error) {
 
 		return net.ParseIP(ip), nil
 	case driver.HyperKit:
-		return net.ParseIP("192.168.64.1"), nil
+		vmIPString, _ := host.Driver.GetIP()
+		gatewayIPString := vmIPString[:strings.LastIndex(vmIPString, ".")+1] + "1"
+		return net.ParseIP(gatewayIPString), nil
 	case driver.VMware:
 		vmIPString, err := host.Driver.GetIP()
 		if err != nil {


### PR DESCRIPTION
fixes #11510 
resolves #12729 (was closed without fix)
Rather than assume 192.168.64.1 - which might not be true if dhcpd lease is already active for some other VM etc. We try to use the gateway IP is usually the hostip with the last octet as "1"  