### PR TITLE
Print proper value of mount type using info print statement

### DIFF
--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -193,7 +193,7 @@ var mountCmd = &cobra.Command{
 			bindIP = "127.0.0.1"
 		}
 		out.Step(style.Mounting, "Mounting host path {{.sourcePath}} into VM as {{.destinationPath}} ...", out.V{"sourcePath": hostPath, "destinationPath": vmPath})
-		out.Infof("Mount type:   {{.name}}", out.V{"type": cfg.Type})
+		out.Infof("Mount type:   {{.name}}", out.V{"name": cfg.Type})
 		out.Infof("User ID:      {{.userID}}", out.V{"userID": cfg.UID})
 		out.Infof("Group ID:     {{.groupID}}", out.V{"groupID": cfg.GID})
 		out.Infof("Version:      {{.version}}", out.V{"version": cfg.Version})


### PR DESCRIPTION
This is a Trivial change.
Before PR the "Mount type" is always printed as empty string - since the Infof() stmt is incorrect. The change should not affect any other functionality ...

```
minikube mount /tmp:/myhosttmp --v=7

📁  Mounting host path /tmp into VM as /myhosttmp ...
    ▪ Mount type:              <<<< MISSING VALUE
    ▪ User ID:      docker
    ▪ Group ID:     docker
    ▪ Version:      9p2000.L
    ▪ Message Size: 262144
    ▪ Options:      map[]
    ▪ Bind Address: 192.168.205.1:53992
```

After PR:
```
minikube mount /tmp:/myhosttmp --v=7

📁  Mounting host path /tmp into VM as /myhosttmp ...
    ▪ Mount type:   9p                       <<< Now CORRECT value is printed
    ▪ User ID:      docker
    ▪ Group ID:     docker
    ▪ Version:      9p2000.L
    ▪ Message Size: 262144
    ▪ Options:      map[]
    ▪ Bind Address: 192.168.205.1:53992
```
