### PR TITLE
fix: service CLI command not honoring --wait arg

### DIFF
--- a/pkg/minikube/service/service.go
+++ b/pkg/minikube/service/service.go
@@ -261,11 +261,6 @@ func WaitForService(api libmachine.API, cname string, namespace string, service 
 		interval = 1
 	}
 
-	err := CheckService(cname, namespace, service)
-	if err != nil {
-		return nil, &SVCNotFoundError{err}
-	}
-
 	chkSVC := func() error { return CheckService(cname, namespace, service) }
 
 	if err := retry.Expo(chkSVC, time.Duration(interval)*time.Second, time.Duration(wait)*time.Second); err != nil {

--- a/pkg/minikube/service/service_test.go
+++ b/pkg/minikube/service/service_test.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"testing"
 	"text/template"
+	"time"
 
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/host"
@@ -261,7 +262,12 @@ func (s MockServiceInterface) Get(ctx context.Context, name string, _ meta.GetOp
 		}
 	}
 
-	return nil, nil
+	return nil, errors.New("Service not found")
+}
+
+func (s MockServiceInterface) Create(ctx context.Context, service *core.Service, _ meta.CreateOptions) (*core.Service, error) {
+	s.ServiceList.Items = append(s.ServiceList.Items, *service)
+	return service, nil
 }
 
 func TestGetServiceListFromServicesByLabel(t *testing.T) {
@@ -896,6 +902,14 @@ func TestWaitAndMaybeOpenService(t *testing.T) {
 			expected:    []string{},
 			err:         true,
 		},
+		{
+			description: "correctly return serviceURLs for a delayed service",
+			namespace:   "default",
+			service:     "mock-dashboard-delayed",
+			api:         defaultAPI,
+			https:       true,
+			expected:    []string{"http://127.0.0.1:1111"},
+		},
 	}
 	defer revertK8sClient(K8s)
 	for _, test := range tests {
@@ -905,8 +919,33 @@ func TestWaitAndMaybeOpenService(t *testing.T) {
 				endpointsMap: endpointNamespaces,
 			}
 
+			go func() {
+				// wait for the delayed mock service to be created
+				time.Sleep(2 * time.Second)
+
+				_, _ = serviceNamespaces[test.namespace].Create(context.Background(), &core.Service{
+					ObjectMeta: meta.ObjectMeta{
+						Name:      "mock-dashboard-delayed",
+						Namespace: "default",
+						Labels:    map[string]string{"mock": "mock"},
+					},
+					Spec: core.ServiceSpec{
+						Ports: []core.ServicePort{
+							{
+								Name:     "port1",
+								NodePort: int32(1111),
+								Port:     int32(11111),
+								TargetPort: intstr.IntOrString{
+									IntVal: int32(11111),
+								},
+							},
+						},
+					},
+				}, meta.CreateOptions{})
+			}()
+
 			var urlList []string
-			urlList, err := WaitForService(test.api, "minikube", test.namespace, test.service, defaultTemplate, test.urlMode, test.https, 1, 0)
+			urlList, err := WaitForService(test.api, "minikube", test.namespace, test.service, defaultTemplate, test.urlMode, test.https, 5, 0)
 			if test.err && err == nil {
 				t.Fatalf("WaitForService expected to fail for test: %v", test)
 			}


### PR DESCRIPTION
The minikube service <service> CLI command has a --wait argument documented that enabled the user to wait the given seconds for a service to be available in the cluster, but this was being ignored.

The logic for waiting was already implemented, but was being overriden by an unneeded early return. I removed that, and added a test case that verifies this feature is working as intended, since it was untested.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
