### PR TITLE
CI: Remove assigning MINIKUBE_VERSION to VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ VERSION_MAJOR ?= 1
 VERSION_MINOR ?= 29
 VERSION_BUILD ?= 0
 RAW_VERSION=$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_BUILD)
-VERSION ?= $(MINIKUBE_VERSION)
 VERSION ?= v$(RAW_VERSION)
 
 KUBERNETES_VERSION ?= $(shell egrep "DefaultKubernetesVersion =" pkg/minikube/constants/constants.go | cut -d \" -f2)


### PR DESCRIPTION
In https://github.com/kubernetes/minikube/pull/15716 I added `VERSION ?= $(MINIKUBE_VERSION)` so on ISO/Kicbase build immediately prior to release we could force the minikube version prior to truly releasing and bumping the version. However, `MINIKUBE_VERSION` is a variable set later on in the Makefile and when we're not manually setting it sets `VERSION` to `ISO_VERSION` which is not intended.

I updated CI so we override the `VERSION` variable so this line can be removed and minikube version goes back to expected.