### PR TITLE
Fix for minikube addons list bug with install addons set to false

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -46,6 +46,7 @@ import (
 	"github.com/spf13/viper"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
+	"k8s.io/minikube/pkg/addons"
 	"k8s.io/minikube/pkg/minikube/command"
 	netutil "k8s.io/minikube/pkg/network"
 
@@ -344,7 +345,10 @@ func provisionWithDriver(cmd *cobra.Command, ds registry.DriverState, existing *
 	}
 
 	var existingAddons map[string]bool
-	if viper.GetBool(installAddons) {
+	if viper.GetBool(disableAddons) {
+		addons.DisableAddons(&cc)
+	} else {
+		// configure existing addons
 		existingAddons = map[string]bool{}
 		if existing != nil && existing.Addons != nil {
 			existingAddons = existing.Addons

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -72,7 +72,7 @@ const (
 	kvmHidden               = "kvm-hidden"
 	kvmNUMACount            = "kvm-numa-count"
 	minikubeEnvPrefix       = "MINIKUBE"
-	installAddons           = "install-addons"
+	disableAddons           = "disable-addons"
 	defaultDiskSize         = "20000mb"
 	keepContext             = "keep-context"
 	createMount             = "mount"
@@ -187,7 +187,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().Duration(waitTimeout, 6*time.Minute, "max time to wait per Kubernetes or host to be healthy.")
 	startCmd.Flags().Bool(nativeSSH, true, "Use native Golang SSH client (default true). Set to 'false' to use the command line 'ssh' command when accessing the docker machine. Useful for the machine drivers when they will not start with 'Waiting for SSH'.")
 	startCmd.Flags().Bool(autoUpdate, true, "If set, automatically updates drivers to the latest version. Defaults to true.")
-	startCmd.Flags().Bool(installAddons, true, "If set, install addons. Defaults to true.")
+	startCmd.Flags().Bool(disableAddons, false, "If set, disable all addons (default false).")
 	startCmd.Flags().IntP(nodes, "n", 1, "The number of nodes to spin up. Defaults to 1.")
 	startCmd.Flags().Bool(preload, true, "If set, download tarball of preloaded images if available to improve start time. Defaults to true.")
 	startCmd.Flags().Bool(noKubernetes, false, "If set, minikube VM/container will start without starting or configuring Kubernetes. (only works on new clusters)")

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -570,3 +570,14 @@ func UpdateConfig(cc *config.ClusterConfig, enabled []string) {
 		}
 	}
 }
+
+// Disable all addons in the cluster configuration
+func DisableAddons(cc *config.ClusterConfig) {
+	for _, a := range Addons {
+		if err := Set(cc, a.name, "false"); err != nil {
+			out.Step(style.Failure, `"Error disabling '{{.minikube_addon}}' addon`, out.V{"minikube_addon": a.name})
+		} else {
+			out.Step(style.AddonDisable, `"The '{{.minikube_addon}}' addon is disabled`, out.V{"minikube_addon": a.name})
+		}
+	}
+}

--- a/pkg/addons/addons_test.go
+++ b/pkg/addons/addons_test.go
@@ -140,3 +140,22 @@ func TestStart(t *testing.T) {
 		t.Errorf("expected dashboard to be enabled")
 	}
 }
+
+func TestStartWithAddonsDisabled(t *testing.T) {
+	// this test will write a config.json into MinikubeHome, create a temp dir for it
+	tests.MakeTempDir(t)
+
+	cc := &config.ClusterConfig{
+		Name:             "start",
+		CPUs:             2,
+		Memory:           2500,
+		KubernetesConfig: config.KubernetesConfig{},
+	}
+
+	DisableAddons(cc)
+	for _, a := range Addons {
+		if assets.Addons[a.name].IsEnabled(cc) {
+			t.Errorf("addon '%v' expected to be disabled", a.name)
+		}
+	}
+}

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -35,6 +35,7 @@ minikube start [flags]
       --cpus string                       Number of CPUs allocated to Kubernetes. Use "max" to use the maximum number of CPUs. (default "2")
       --cri-socket string                 The cri socket path to be used.
       --delete-on-failure                 If set, delete the current cluster if start fails and try again. Defaults to false.
+      --disable-addons                    If set, disable all addons (default false).
       --disable-driver-mounts             Disables the filesystem mounts provided by the hypervisors
       --disable-metrics                   If set, disables metrics reporting (CPU and memory usage), this can improve CPU usage. Defaults to false.
       --disable-optimizations             If set, disables optimizations that are set for local Kubernetes. Including decreasing CoreDNS replicas from 2 to 1. Defaults to false.
@@ -67,7 +68,6 @@ minikube start [flags]
       --image-mirror-country string       Country code of the image mirror to be used. Leave empty to use the global one. For Chinese mainland users, set it to cn.
       --image-repository string           Alternative image repository to pull docker images from. This can be used when you have limited access to gcr.io. Set it to "auto" to let minikube decide one for you. For Chinese mainland users, you may use local gcr.io mirrors such as registry.cn-hangzhou.aliyuncs.com/google_containers
       --insecure-registry strings         Insecure Docker registries to pass to the Docker daemon.  The default service CIDR range will automatically be added.
-      --install-addons                    If set, install addons. Defaults to true. (default true)
       --interactive                       Allow user prompts for more information (default true)
       --iso-url strings                   Locations to fetch the minikube ISO from. The list depends on the machine architecture.
       --keep-context                      This will keep the existing kubectl context and will create a minikube context.

--- a/test/integration/docker_test.go
+++ b/test/integration/docker_test.go
@@ -41,7 +41,7 @@ func TestDockerFlags(t *testing.T) {
 	defer CleanupWithLogs(t, profile, cancel)
 
 	// Use the most verbose logging for the simplest test. If it fails, something is very wrong.
-	args := append([]string{"start", "-p", profile, "--cache-images=false", "--memory=2048", "--install-addons=false", "--wait=false", "--docker-env=FOO=BAR", "--docker-env=BAZ=BAT", "--docker-opt=debug", "--docker-opt=icc=true", "--alsologtostderr", "-v=5"}, StartArgs()...)
+	args := append([]string{"start", "-p", profile, "--cache-images=false", "--memory=2048", "--disable-addons=true", "--wait=false", "--docker-env=FOO=BAR", "--docker-env=BAZ=BAT", "--docker-opt=debug", "--docker-opt=icc=true", "--alsologtostderr", "-v=5"}, StartArgs()...)
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
 		t.Errorf("failed to start minikube with args: %q : %v", rr.Command(), err)

--- a/test/integration/guest_env_test.go
+++ b/test/integration/guest_env_test.go
@@ -36,7 +36,7 @@ func TestGuestEnvironment(t *testing.T) {
 	defer CleanupWithLogs(t, profile, cancel)
 
 	t.Run("Setup", func(t *testing.T) {
-		args := append([]string{"start", "-p", profile, "--install-addons=false", "--memory=2048", "--wait=false", "--disable-metrics=true"}, StartArgs()...)
+		args := append([]string{"start", "-p", profile, "--disable-addons=true", "--memory=2048", "--wait=false", "--disable-metrics=true"}, StartArgs()...)
 		rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 		if err != nil {
 			t.Errorf("failed to start minikube: args %q: %v", rr.Command(), err)

--- a/test/integration/pause_test.go
+++ b/test/integration/pause_test.go
@@ -76,7 +76,7 @@ func TestPause(t *testing.T) {
 func validateFreshStart(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 
-	args := append([]string{"start", "-p", profile, "--memory=2048", "--install-addons=false", "--wait=all"}, StartArgs()...)
+	args := append([]string{"start", "-p", profile, "--memory=2048", "--disable-addons=true", "--wait=all"}, StartArgs()...)
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
 		t.Fatalf("failed to start minikube with args: %q : %v", rr.Command(), err)


### PR DESCRIPTION
Fixes #15710 

The --install-addons flag can be a bit confusing, since it skips starting all addons, but it does not touch the cluster configuration either. 

This brings `minikube addons list` to a bit of a split brain situation, since it displays the list based on the cluster configuration and if a particular addon does not have a configuration record, it falls back to the default 'unconfigured' value.

Changing the default 'unconfigured' value would introduce a bug when we run `minikube start` without the --install-addons=true.

Based on previous release notes, I believe the reason for introducing the flag was to save some time during boot when no addons needed. Checking every addon status from the live cluster would take relatively long time and would not provide great user experience.

I believe a better flag name would be `--disable-addons` with default value false. This would not introduce any change in behaviour but would be a 'better fit' description for disabling all addons in the cluster, and with this flag name, we could add styled log output about disabling the addons, providing informative, good user experience.

Please find the changes and additional tests in the PR.

Output with the fix:

```
msagi@miklos-mbp minikube % ./out/minikube start --disable-addons=true
😄  minikube v1.29.0 on Darwin 13.1
✨  Automatically selected the hyperkit driver. Other choices: virtualbox, ssh
🌑  "The 'auto-pause' addon is disabled
🌑  "The 'dashboard' addon is disabled
🌑  "The 'default-storageclass' addon is disabled
🌑  "The 'efk' addon is disabled
🌑  "The 'freshpod' addon is disabled
🌑  "The 'gvisor' addon is disabled
🌑  "The 'helm-tiller' addon is disabled
🌑  "The 'ingress' addon is disabled
🌑  "The 'ingress-dns' addon is disabled
🌑  "The 'istio-provisioner' addon is disabled
🌑  "The 'istio' addon is disabled
🌑  "The 'kong' addon is disabled
🌑  "The 'kubevirt' addon is disabled
🌑  "The 'logviewer' addon is disabled
🌑  "The 'metrics-server' addon is disabled
🌑  "The 'nvidia-driver-installer' addon is disabled
🌑  "The 'nvidia-gpu-device-plugin' addon is disabled
🌑  "The 'olm' addon is disabled
🌑  "The 'registry' addon is disabled
🌑  "The 'registry-creds' addon is disabled
🌑  "The 'registry-aliases' addon is disabled
🌑  "The 'storage-provisioner' addon is disabled
🌑  "The 'storage-provisioner-gluster' addon is disabled
🌑  "The 'metallb' addon is disabled
🌑  "The 'ambassador' addon is disabled
🌑  "The 'pod-security-policy' addon is disabled
🌑  "The 'gcp-auth' addon is disabled
🌑  "The 'volumesnapshots' addon is disabled
🌑  "The 'csi-hostpath-driver' addon is disabled
🌑  "The 'portainer' addon is disabled
🌑  "The 'inaccel' addon is disabled
🌑  "The 'headlamp' addon is disabled
🌑  "The 'cloud-spanner' addon is disabled
👍  Starting control plane node minikube in cluster minikube
💾  Downloading Kubernetes v1.26.1 preload ...
    > preloaded-images-k8s-v18-v1...:  397.05 MiB / 397.05 MiB  100.00% 15.74 M
🔥  Creating hyperkit VM (CPUs=2, Memory=6000MB, Disk=20000MB) ...
❗  Image was not built for the current minikube version. To resolve this you can delete and recreate your minikube cluster using the latest images. Expected minikube version: v1.29.0-1674856271-15565 -> Actual minikube version: v1.29.0
❗  This VM is having trouble accessing https://registry.k8s.io
💡  To pull new external images, you may need to configure a proxy: https://minikube.sigs.k8s.io/docs/reference/networking/proxy/
🐳  Preparing Kubernetes v1.26.1 on Docker 20.10.23 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default

msagi@miklos-mbp minikube % kubectl get pods -A
NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE
kube-system   coredns-787d4945fb-ljlmn           1/1     Running   0          16m
kube-system   etcd-minikube                      1/1     Running   0          16m
kube-system   kube-apiserver-minikube            1/1     Running   0          16m
kube-system   kube-controller-manager-minikube   1/1     Running   0          16m
kube-system   kube-proxy-67sbm                   1/1     Running   0          16m
kube-system   kube-scheduler-minikube            1/1     Running   0          16m

msagi@miklos-mbp minikube % ./out/minikube addons list           
|-----------------------------|----------|--------------|--------------------------------|
|         ADDON NAME          | PROFILE  |    STATUS    |           MAINTAINER           |
|-----------------------------|----------|--------------|--------------------------------|
| ambassador                  | minikube | disabled     | 3rd party (Ambassador)         |
| auto-pause                  | minikube | disabled     | Google                         |
| cloud-spanner               | minikube | disabled     | Google                         |
| csi-hostpath-driver         | minikube | disabled     | Kubernetes                     |
| dashboard                   | minikube | disabled     | Kubernetes                     |
| default-storageclass        | minikube | disabled     | Kubernetes                     |
| efk                         | minikube | disabled     | 3rd party (Elastic)            |
| freshpod                    | minikube | disabled     | Google                         |
| gcp-auth                    | minikube | disabled     | Google                         |
| gvisor                      | minikube | disabled     | Google                         |
| headlamp                    | minikube | disabled     | 3rd party (kinvolk.io)         |
| helm-tiller                 | minikube | disabled     | 3rd party (Helm)               |
| inaccel                     | minikube | disabled     | 3rd party (InAccel             |
|                             |          |              | [info@inaccel.com])            |
| ingress                     | minikube | disabled     | Kubernetes                     |
| ingress-dns                 | minikube | disabled     | Google                         |
| istio                       | minikube | disabled     | 3rd party (Istio)              |
| istio-provisioner           | minikube | disabled     | 3rd party (Istio)              |
| kong                        | minikube | disabled     | 3rd party (Kong HQ)            |
| kubevirt                    | minikube | disabled     | 3rd party (KubeVirt)           |
| logviewer                   | minikube | disabled     | 3rd party (unknown)            |
| metallb                     | minikube | disabled     | 3rd party (MetalLB)            |
| metrics-server              | minikube | disabled     | Kubernetes                     |
| nvidia-driver-installer     | minikube | disabled     | Google                         |
| nvidia-gpu-device-plugin    | minikube | disabled     | 3rd party (Nvidia)             |
| olm                         | minikube | disabled     | 3rd party (Operator Framework) |
| pod-security-policy         | minikube | disabled     | 3rd party (unknown)            |
| portainer                   | minikube | disabled     | 3rd party (Portainer.io)       |
| registry                    | minikube | disabled     | Google                         |
| registry-aliases            | minikube | disabled     | 3rd party (unknown)            |
| registry-creds              | minikube | disabled     | 3rd party (UPMC Enterprises)   |
| storage-provisioner         | minikube | disabled     | Google                         |
| storage-provisioner-gluster | minikube | disabled     | 3rd party (Gluster)            |
| volumesnapshots             | minikube | disabled     | Kubernetes                     |
|-----------------------------|----------|--------------|--------------------------------|
💡  To see addons list for other profiles use: `minikube addons -p name list`

msagi@miklos-mbp minikube % ./out/minikube addons enable storage-provisioner
💡  storage-provisioner is an addon maintained by Google. For any concerns contact minikube on GitHub.
You can view the list of minikube maintainers at: https://github.com/kubernetes/minikube/blob/master/OWNERS
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  The 'storage-provisioner' addon is enabled

msagi@miklos-mbp minikube % ./out/minikube stop                             
✋  Stopping node "minikube"  ...
🛑  1 node stopped.

msagi@miklos-mbp minikube % ./out/minikube start
😄  minikube v1.29.0 on Darwin 13.1
✨  Using the hyperkit driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
🔄  Restarting existing hyperkit VM for "minikube" ...
❗  Image was not built for the current minikube version. To resolve this you can delete and recreate your minikube cluster using the latest images. Expected minikube version: v1.29.0-1674856271-15565 -> Actual minikube version: v1.29.0
❗  This VM is having trouble accessing https://registry.k8s.io
💡  To pull new external images, you may need to configure a proxy: https://minikube.sigs.k8s.io/docs/reference/networking/proxy/
🐳  Preparing Kubernetes v1.26.1 on Docker 20.10.23 ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default

msagi@miklos-mbp minikube % ./out/minikube addons list                      
|-----------------------------|----------|--------------|--------------------------------|
|         ADDON NAME          | PROFILE  |    STATUS    |           MAINTAINER           |
|-----------------------------|----------|--------------|--------------------------------|
| ambassador                  | minikube | disabled     | 3rd party (Ambassador)         |
| auto-pause                  | minikube | disabled     | Google                         |
| cloud-spanner               | minikube | disabled     | Google                         |
| csi-hostpath-driver         | minikube | disabled     | Kubernetes                     |
| dashboard                   | minikube | disabled     | Kubernetes                     |
| default-storageclass        | minikube | disabled     | Kubernetes                     |
| efk                         | minikube | disabled     | 3rd party (Elastic)            |
| freshpod                    | minikube | disabled     | Google                         |
| gcp-auth                    | minikube | disabled     | Google                         |
| gvisor                      | minikube | disabled     | Google                         |
| headlamp                    | minikube | disabled     | 3rd party (kinvolk.io)         |
| helm-tiller                 | minikube | disabled     | 3rd party (Helm)               |
| inaccel                     | minikube | disabled     | 3rd party (InAccel             |
|                             |          |              | [info@inaccel.com])            |
| ingress                     | minikube | disabled     | Kubernetes                     |
| ingress-dns                 | minikube | disabled     | Google                         |
| istio                       | minikube | disabled     | 3rd party (Istio)              |
| istio-provisioner           | minikube | disabled     | 3rd party (Istio)              |
| kong                        | minikube | disabled     | 3rd party (Kong HQ)            |
| kubevirt                    | minikube | disabled     | 3rd party (KubeVirt)           |
| logviewer                   | minikube | disabled     | 3rd party (unknown)            |
| metallb                     | minikube | disabled     | 3rd party (MetalLB)            |
| metrics-server              | minikube | disabled     | Kubernetes                     |
| nvidia-driver-installer     | minikube | disabled     | Google                         |
| nvidia-gpu-device-plugin    | minikube | disabled     | 3rd party (Nvidia)             |
| olm                         | minikube | disabled     | 3rd party (Operator Framework) |
| pod-security-policy         | minikube | disabled     | 3rd party (unknown)            |
| portainer                   | minikube | disabled     | 3rd party (Portainer.io)       |
| registry                    | minikube | disabled     | Google                         |
| registry-aliases            | minikube | disabled     | 3rd party (unknown)            |
| registry-creds              | minikube | disabled     | 3rd party (UPMC Enterprises)   |
| storage-provisioner         | minikube | enabled ✅   | Google                         |
| storage-provisioner-gluster | minikube | disabled     | 3rd party (Gluster)            |
| volumesnapshots             | minikube | disabled     | Kubernetes                     |
|-----------------------------|----------|--------------|--------------------------------|
💡  To see addons list for other profiles use: `minikube addons -p name list`
```
