### PR TITLE
add new flag --last-start-only to only show last start logs 

### DIFF
--- a/cmd/minikube/cmd/logs.go
+++ b/cmd/minikube/cmd/logs.go
@@ -52,6 +52,8 @@ var (
 	fileOutput string
 	// auditLogs only shows the audit logs
 	auditLogs bool
+	// lastStartOnly shows logs from last start
+	lastStartOnly bool
 )
 
 // logsCmd represents the logs command
@@ -111,6 +113,12 @@ var logsCmd = &cobra.Command{
 			logs.OutputProblems(problems, numberOfProblems, logOutput)
 			return
 		}
+		if lastStartOnly {
+			err := logs.OutputLastStart()
+			if err != nil {
+				klog.Errorf("failed to output last start logs: %V", err)
+			}
+		}
 		err = logs.Output(cr, bs, *co.Config, co.CP.Runner, numberOfLines, logOutput)
 		if err != nil {
 			out.Ln("")
@@ -150,4 +158,5 @@ func init() {
 	logsCmd.Flags().StringVar(&nodeName, "node", "", "The node to get logs from. Defaults to the primary control plane.")
 	logsCmd.Flags().StringVar(&fileOutput, "file", "", "If present, writes to the provided file instead of stdout.")
 	logsCmd.Flags().BoolVar(&auditLogs, "audit", false, "Show only the audit logs")
+	logsCmd.Flags().BoolVar(&lastStartOnly, "last-start-only", false, "Show logs from last start.")
 }

--- a/cmd/minikube/cmd/logs.go
+++ b/cmd/minikube/cmd/logs.go
@@ -80,7 +80,7 @@ var logsCmd = &cobra.Command{
 		if lastStartOnly {
 			err := logs.OutputLastStart()
 			if err != nil {
-				klog.Errorf("failed to output last start logs: %V", err)
+				klog.Errorf("failed to output last start logs: %v", err)
 			}
 			return
 		}

--- a/cmd/minikube/cmd/logs.go
+++ b/cmd/minikube/cmd/logs.go
@@ -77,13 +77,13 @@ var logsCmd = &cobra.Command{
 				exit.Error(reason.Usage, "Failed to create file", err)
 			}
 		}
-                if lastStartOnly {
-                        err := logs.OutputLastStart()
-                        if err != nil {
-                                klog.Errorf("failed to output last start logs: %V", err)
-                        }
-                        return
-                }
+		if lastStartOnly {
+			err := logs.OutputLastStart()
+			if err != nil {
+				klog.Errorf("failed to output last start logs: %V", err)
+			}
+			return
+		}
 		if auditLogs {
 			err := logs.OutputAudit(numberOfLines)
 			if err != nil {

--- a/cmd/minikube/cmd/logs.go
+++ b/cmd/minikube/cmd/logs.go
@@ -159,5 +159,5 @@ func init() {
 	logsCmd.Flags().StringVar(&nodeName, "node", "", "The node to get logs from. Defaults to the primary control plane.")
 	logsCmd.Flags().StringVar(&fileOutput, "file", "", "If present, writes to the provided file instead of stdout.")
 	logsCmd.Flags().BoolVar(&auditLogs, "audit", false, "Show only the audit logs")
-	logsCmd.Flags().BoolVar(&lastStartOnly, "last-start-only", false, "Show logs from last start.")
+	logsCmd.Flags().BoolVar(&lastStartOnly, "last-start-only", false, "Show only the last start logs.")
 }

--- a/cmd/minikube/cmd/logs.go
+++ b/cmd/minikube/cmd/logs.go
@@ -77,6 +77,13 @@ var logsCmd = &cobra.Command{
 				exit.Error(reason.Usage, "Failed to create file", err)
 			}
 		}
+                if lastStartOnly {
+                        err := logs.OutputLastStart()
+                        if err != nil {
+                                klog.Errorf("failed to output last start logs: %V", err)
+                        }
+                        return
+                }
 		if auditLogs {
 			err := logs.OutputAudit(numberOfLines)
 			if err != nil {
@@ -112,12 +119,6 @@ var logsCmd = &cobra.Command{
 			problems := logs.FindProblems(cr, bs, *co.Config, co.CP.Runner)
 			logs.OutputProblems(problems, numberOfProblems, logOutput)
 			return
-		}
-		if lastStartOnly {
-			err := logs.OutputLastStart()
-			if err != nil {
-				klog.Errorf("failed to output last start logs: %V", err)
-			}
 		}
 		err = logs.Output(cr, bs, *co.Config, co.CP.Runner, numberOfLines, logOutput)
 		if err != nil {

--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -221,7 +221,7 @@ func OutputAudit(lines int) error {
 }
 
 // outputLastStart outputs the last start logs.
-func outputLastStart() error {
+func OutputLastStart() error {
 	out.Styled(style.Empty, "")
 	out.Styled(style.Empty, "==> Last Start <==")
 	fp := localpath.LastStartLog()
@@ -256,7 +256,7 @@ func OutputOffline(lines int, logOutput *os.File) {
 	if err := OutputAudit(lines); err != nil {
 		klog.Errorf("failed to output audit logs: %v", err)
 	}
-	if err := outputLastStart(); err != nil {
+	if err := OutputLastStart(); err != nil {
 		klog.Errorf("failed to output last start logs: %v", err)
 	}
 

--- a/site/content/en/docs/commands/logs.md
+++ b/site/content/en/docs/commands/logs.md
@@ -20,12 +20,13 @@ minikube logs [flags]
 ### Options
 
 ```
-      --audit         Show only the audit logs
-      --file string   If present, writes to the provided file instead of stdout.
-  -f, --follow        Show only the most recent journal entries, and continuously print new entries as they are appended to the journal.
-  -n, --length int    Number of lines back to go within the log (default 60)
-      --node string   The node to get logs from. Defaults to the primary control plane.
-      --problems      Show only log entries which point to known problems
+      --audit             Show only the audit logs
+      --file string       If present, writes to the provided file instead of stdout.
+  -f, --follow            Show only the most recent journal entries, and continuously print new entries as they are appended to the journal.
+      --last-start-only   Show only the last start logs.
+  -n, --length int        Number of lines back to go within the log (default 60)
+      --node string       The node to get logs from. Defaults to the primary control plane.
+      --problems          Show only log entries which point to known problems
 ```
 
 ### Options inherited from parent commands

--- a/translations/de.json
+++ b/translations/de.json
@@ -601,6 +601,7 @@
 	"Show a list of global command-line options (applies to all commands).": "Zeige eine Liste von globalen Kommandozeilen Parametern (die auf alle Befehle angewendet werden können)",
 	"Show only log entries which point to known problems": "Zeige nur Log Einträge, die auf bekannte Probleme hinweisen",
 	"Show only the audit logs": "",
+	"Show only the last start logs.": "",
 	"Show only the most recent journal entries, and continuously print new entries as they are appended to the journal.": "Zeige die aktuellsten Journal Einträge und gebe neue Einträge aus, sobald diese im Journal eingetragen werden.",
 	"Simulate numa node count in minikube, supported numa node count range is 1-8 (kvm2 driver only)": "Simuliere den Numa Node Count in Minikube, der unterstützte Numa Node Count Bereich ist 1-8 (nur kvm2 Treiber)",
 	"Skipped switching kubectl context for {{.profile_name}} because --keep-context was set.": "Wechsel des kubectl Kontexts für {{.profile_name}} übersprungen, weil --keep-context gesetzt wurde.",

--- a/translations/es.json
+++ b/translations/es.json
@@ -606,6 +606,7 @@
 	"Show a list of global command-line options (applies to all commands).": "",
 	"Show only log entries which point to known problems": "",
 	"Show only the audit logs": "",
+	"Show only the last start logs.": "",
 	"Show only the most recent journal entries, and continuously print new entries as they are appended to the journal.": "",
 	"Simulate numa node count in minikube, supported numa node count range is 1-8 (kvm2 driver only)": "",
 	"Skipped switching kubectl context for {{.profile_name}} because --keep-context was set.": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -587,6 +587,7 @@
 	"Show a list of global command-line options (applies to all commands).": "Affiche une liste des options de ligne de commande globales (s'applique à toutes les commandes).",
 	"Show only log entries which point to known problems": "Afficher uniquement les entrées de journal qui pointent vers des problèmes connus",
 	"Show only the audit logs": "Afficher uniquement les journaux d'audit",
+	"Show only the last start logs.": "",
 	"Show only the most recent journal entries, and continuously print new entries as they are appended to the journal.": "Affichez uniquement les entrées de journal les plus récentes et imprimez en continu de nouvelles entrées au fur et à mesure qu'elles sont ajoutées au journal.",
 	"Simulate numa node count in minikube, supported numa node count range is 1-8 (kvm2 driver only)": "Simulez le nombre de nœuds numa dans minikube, la plage de nombre de nœuds numa pris en charge est de 1 à 8 (pilote kvm2 uniquement)",
 	"Skipped switching kubectl context for {{.profile_name}} because --keep-context was set.": "Changement de contexte kubectl ignoré pour {{.profile_name}} car --keep-context a été défini.",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -569,6 +569,7 @@
 	"Show a list of global command-line options (applies to all commands).": "(全コマンドに適用される) グローバルコマンドラインオプションの一覧を表示します。",
 	"Show only log entries which point to known problems": "既知の問題を示すログエントリーのみ表示します",
 	"Show only the audit logs": "監査ログのみ表示します",
+	"Show only the last start logs.": "",
 	"Show only the most recent journal entries, and continuously print new entries as they are appended to the journal.": "直近のジャーナルエントリーのみ表示し、ジャーナルに追加された新しいエントリーを連続して表示します。",
 	"Simulate numa node count in minikube, supported numa node count range is 1-8 (kvm2 driver only)": "minikube 中の NUMA ノードカウントをシミュレートします (対応 NUMA ノードカウント範囲は 1～8 (kvm2 ドライバーのみ))",
 	"Skipped switching kubectl context for {{.profile_name}} because --keep-context was set.": "--keep-context が設定されたので、{{.profile_name}} 用 kubectl コンテキストの切替をスキップしました。",

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -616,6 +616,7 @@
 	"Show a list of global command-line options (applies to all commands).": "",
 	"Show only log entries which point to known problems": "",
 	"Show only the audit logs": "",
+	"Show only the last start logs.": "",
 	"Show only the most recent journal entries, and continuously print new entries as they are appended to the journal.": "",
 	"Simulate numa node count in minikube, supported numa node count range is 1-8 (kvm2 driver only)": "",
 	"Skipped switching kubectl context for {{.profile_name}} because --keep-context was set.": "",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -620,6 +620,7 @@
 	"Show a list of global command-line options (applies to all commands).": "",
 	"Show only log entries which point to known problems": "Pokaż logi które wskazują na znane problemy",
 	"Show only the audit logs": "",
+	"Show only the last start logs.": "",
 	"Show only the most recent journal entries, and continuously print new entries as they are appended to the journal.": "",
 	"Simulate numa node count in minikube, supported numa node count range is 1-8 (kvm2 driver only)": "",
 	"Skipped switching kubectl context for {{.profile_name}} because --keep-context was set.": "Zignorowano zmianę kontekstu kubectl dla {{.profile_name}} ponieważ --keep-context zostało przekazane",

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -564,6 +564,7 @@
 	"Show a list of global command-line options (applies to all commands).": "",
 	"Show only log entries which point to known problems": "",
 	"Show only the audit logs": "",
+	"Show only the last start logs.": "",
 	"Show only the most recent journal entries, and continuously print new entries as they are appended to the journal.": "",
 	"Simulate numa node count in minikube, supported numa node count range is 1-8 (kvm2 driver only)": "",
 	"Skipped switching kubectl context for {{.profile_name}} because --keep-context was set.": "",

--- a/translations/strings.txt
+++ b/translations/strings.txt
@@ -564,6 +564,7 @@
 	"Show a list of global command-line options (applies to all commands).": "",
 	"Show only log entries which point to known problems": "",
 	"Show only the audit logs": "",
+	"Show only the last start logs.": "",
 	"Show only the most recent journal entries, and continuously print new entries as they are appended to the journal.": "",
 	"Simulate numa node count in minikube, supported numa node count range is 1-8 (kvm2 driver only)": "",
 	"Skipped switching kubectl context for {{.profile_name}} because --keep-context was set.": "",

--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -703,6 +703,7 @@
 	"Show a list of global command-line options (applies to all commands).": "显示全局命令行选项列表 (应用于所有命令)。",
 	"Show only log entries which point to known problems": "",
 	"Show only the audit logs": "",
+	"Show only the last start logs.": "",
 	"Show only the most recent journal entries, and continuously print new entries as they are appended to the journal.": "",
 	"Simulate numa node count in minikube, supported numa node count range is 1-8 (kvm2 driver only)": "",
 	"Skipped switching kubectl context for {{.profile_name}} because --keep-context was set.": "",


### PR DESCRIPTION
I closed my last PR. Here is a re-subbmission for a cleaner branch:


This PR adds the `minikube logs --last-start-only` flag feature as requested here: https://github.com/kubernetes/minikube/issues/15700

Before the PR:
```
$ minikube logs --last-start-only
Error: unknown flag: --last-start-only
See 'minikube logs --help' for usage.

```

After PR: 
```
$ minikube logs --last-start-only

==> Last Start <==
Log file created at: 2023/02/01 20:55:49
Running on machine: Nicks-MBP
Binary: Built with gc go1.19.5 for darwin/amd64
Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg
I0201 20:55:49.529075   63168 out.go:296] Setting OutFile to fd 1 ...
I0201 20:55:49.529464   63168 out.go:348] isatty.IsTerminal(1) = true
I0201 20:55:49.529469   63168 out.go:309] Setting ErrFile to fd 2...
I0201 20:55:49.529477   63168 out.go:348] isatty.IsTerminal(2) = true
I0201 20:55:49.529607   63168 root.go:334] Updating PATH: /Users/nick/.minikube/bin
W0201 20:55:49.529733   63168 root.go:311] Error reading config file at /Users/nick/.minikube/config/config.json: open /Users/nick/.minikube/config/config.json: no such file or directory
I0201 20:55:49.530772   63168 out.go:303] Setting JSON to false
I0201 20:55:49.573892   63168 start.go:125] hostinfo: {"hostname":"Nicks-MBP.home","uptime":5641601,"bootTime":1669664948,"procs":409,"os":"darwin","platform":"darwin","platformFamily":"Standalone Workstation","platformVersion":"12.6.1","kernelVersion":"21.6.0","kernelArch":"x86_64","virtualizationSystem":"","virtualizationRole":"","hostId":"2e97756e-e296-517d-96d1-91d34cd120f0"}
W0201 20:55:49.573997   63168 start.go:133] gopshost.Virtualization returned error: not implemented yet
I0201 20:55:49.579787   63168 out.go:177] 😄  minikube v0.0.0-unset on Darwin 12.6.1
I0201 20:55:49.588916   63168 notify.go:220] Checking for updates...
I0201 20:55:49.589715   63168 config.go:180] Loaded profile config "minikube": Driver=docker, ContainerRuntime=docker, KubernetesVersion=v1.26.1
...
```

