### PR TITLE
Add ingress pod to logs output

### DIFF
--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -289,6 +289,8 @@ func logCommands(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.Cl
 	return cmds
 }
 
+// enabledAddonPods returns the pod names for enabled addons
+// this does not currently include all addons, mostly just addons that we occasionaly get users reporting issues with
 func enabledAddonPods(cfg config.ClusterConfig) []string {
 	addonPodMap := map[string]string{
 		"dashboard":           "kubernetes-dashboard",

--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -80,8 +80,6 @@ var importantPods = []string{
 	"coredns",
 	"kube-scheduler",
 	"kube-proxy",
-	"kubernetes-dashboard",
-	"storage-provisioner",
 	"kube-controller-manager",
 }
 
@@ -267,9 +265,8 @@ func OutputOffline(lines int, logOutput *os.File) {
 func logCommands(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.ClusterConfig, length int, follow bool) map[string]string {
 	cmds := bs.LogCommands(cfg, bootstrapper.LogOptions{Lines: length, Follow: follow})
 	pods := importantPods
-	if assets.Addons["gcp-auth"].IsEnabled(&cfg) {
-		pods = append(pods, "gcp-auth")
-	}
+	addonPods := enabledAddonPods(cfg)
+	pods = append(pods, addonPods...)
 	for _, pod := range pods {
 		ids, err := r.ListContainers(cruntime.ListContainersOptions{Name: pod})
 		if err != nil {
@@ -290,4 +287,20 @@ func logCommands(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.Cl
 	cmds["container status"] = cruntime.ContainerStatusCommand()
 
 	return cmds
+}
+
+func enabledAddonPods(cfg config.ClusterConfig) []string {
+	addonPodMap := map[string]string{
+		"dashboard":           "kubernetes-dashboard",
+		"gcp-auth":            "gcp-auth",
+		"ingress":             "controller_ingress",
+		"storage-provisioner": "storage-provisioner",
+	}
+	addonsPods := []string{}
+	for addon, podName := range addonPodMap {
+		if assets.Addons[addon].IsEnabled(&cfg) {
+			addonsPods = append(addonsPods, podName)
+		}
+	}
+	return addonsPods
 }

--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -290,7 +290,7 @@ func logCommands(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.Cl
 }
 
 // enabledAddonPods returns the pod names for enabled addons
-// this does not currently include all addons, mostly just addons that we occasionaly get users reporting issues with
+// this does not currently include all addons, mostly just addons that we occasionally get users reporting issues with
 func enabledAddonPods(cfg config.ClusterConfig) []string {
 	addonPodMap := map[string]string{
 		"dashboard":           "kubernetes-dashboard",

--- a/pkg/minikube/logs/logs_test.go
+++ b/pkg/minikube/logs/logs_test.go
@@ -18,6 +18,8 @@ package logs
 
 import (
 	"testing"
+
+	"k8s.io/minikube/pkg/minikube/config"
 )
 
 func TestIsProblem(t *testing.T) {
@@ -59,5 +61,31 @@ func TestIsProblem(t *testing.T) {
 				t.Fatalf("IsProblem(%s)=%v, want %v", tc.input, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestEnabledAddonPods(t *testing.T) {
+	cfg := config.ClusterConfig{
+		Addons: map[string]bool{
+			"dashboard":           true,
+			"gcp-auth":            true,
+			"ingress":             true,
+			"storage-provisioner": true,
+		},
+	}
+
+	got := enabledAddonPods(cfg)
+	expectedPods := []string{"kubernetes-dashboard", "gcp-auth", "controller_ingress", "storage-provisioner"}
+	for _, expectedPod := range expectedPods {
+		found := false
+		for _, pod := range got {
+			if expectedPod == pod {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("%q was not found; got = %s", expectedPod, got)
+		}
 	}
 }


### PR DESCRIPTION
- Add ingress pod to logs output
- Refactor logic to make it easy to add new addons to logs in the future
- Move existing addon pods to new logic to save checking for pod that may not exist