### PR TITLE
sqash kicbase to be one layer

### DIFF
--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -243,8 +243,6 @@ RUN rm -rf \
   /usr/share/doc/* \
   /usr/share/man/* \
   /usr/share/local/*
-# tell systemd that it is in docker (it will check for the container env)
-# https://systemd.io/CONTAINER_INTERFACE/
 RUN echo "kic! Build: ${COMMIT_SHA} Time :$(date)" > "/kic.txt"
 # squash
 FROM scratch

--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -37,7 +37,7 @@ RUN if [ "$PREBUILT_AUTO_PAUSE" != "true" ]; then cd ./cmd/auto-pause/ && go bui
 
 # start from ubuntu 20.04, this image is reasonably small as a starting point
 # for a kubernetes node image, it doesn't contain much we don't need
-FROM ubuntu:focal-20221019 as kicbase
+FROM ubuntu:focal-20221019 as build
 
 ARG BUILDKIT_VERSION="v0.11.2"
 ARG FUSE_OVERLAYFS_VERSION="v1.7.1"
@@ -107,15 +107,6 @@ RUN echo "Ensuring scripts are executable ..." \
     && systemctl disable udev.service \
  && echo "Modifying /etc/nsswitch.conf to prefer hosts" \
     && sed -i /etc/nsswitch.conf -re 's#^(hosts:\s*).*#\1dns files#'
-
-# tell systemd that it is in docker (it will check for the container env)
-# https://systemd.io/CONTAINER_INTERFACE/
-ENV container docker
-# systemd exits on SIGRTMIN+3, not SIGTERM (which re-executes it)
-# https://bugzilla.redhat.com/show_bug.cgi?id=1201657
-STOPSIGNAL SIGRTMIN+3
-# NOTE: this is *only* for documentation, the entrypoint is overridden later
-ENTRYPOINT [ "/usr/local/bin/entrypoint", "/sbin/init" ]
 
 ARG COMMIT_SHA
 # using base image created by kind https://github.com/kubernetes-sigs/kind/blob/b6bc1125/images/base/Dockerfile
@@ -235,7 +226,6 @@ RUN sed -ri 's/dns files/files dns/g' /etc/nsswitch.conf
 # https://github.com/kubernetes/minikube/issues/10520
 RUN sed -ri 's/mountopt = "nodev,metacopy=on"/mountopt = "nodev"/g' /etc/containers/storage.conf
 
-EXPOSE 22
 # create docker user for minikube ssh. to match VM using "docker" as username
 RUN adduser --ingroup docker --disabled-password --gecos '' docker
 RUN adduser docker sudo
@@ -253,4 +243,18 @@ RUN rm -rf \
   /usr/share/doc/* \
   /usr/share/man/* \
   /usr/share/local/*
+# tell systemd that it is in docker (it will check for the container env)
+# https://systemd.io/CONTAINER_INTERFACE/
 RUN echo "kic! Build: ${COMMIT_SHA} Time :$(date)" > "/kic.txt"
+# squash
+FROM scratch
+COPY --from=build / /
+EXPOSE 22
+# tell systemd that it is in docker (it will check for the container env)
+# https://systemd.io/CONTAINER_INTERFACE/
+ENV container docker
+# systemd exits on SIGRTMIN+3, not SIGTERM (which re-executes it)
+# https://bugzilla.redhat.com/show_bug.cgi?id=1201657
+STOPSIGNAL SIGRTMIN+3
+# NOTE: this is *only* for documentation, the entrypoint is overridden later
+ENTRYPOINT [ "/usr/local/bin/entrypoint", "/sbin/init" ]

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -24,10 +24,10 @@ import (
 
 const (
 	// Version is the current version of kic
-	Version = "v0.0.37-1675368987-15776"
+	Version = "v0.0.37-1675391123-15776"
 
 	// SHA of the kic base image
-	baseImageSHA = "7759e8c11a756c515acc9dc60c415bd733a1648e5f0c885a2fd07d22b1ac4f7e"
+	baseImageSHA = "88e2fc0a6ad1f27dce3f012b7716d07cc4efc368fc128667681554f203c657a6"
 	// The name of the GCR kicbase repository
 	gcrRepo = "gcr.io/k8s-minikube/kicbase-builds"
 	// The name of the Dockerhub kicbase repository

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -24,10 +24,10 @@ import (
 
 const (
 	// Version is the current version of kic
-	Version = "v0.0.37-1675280603-15763"
+	Version = "v0.0.37-1675368987-15776"
 
 	// SHA of the kic base image
-	baseImageSHA = "9f474b7ba8542a6ea1d4410955102c8c63c61d74579375db5b45bbc427946de8"
+	baseImageSHA = "7759e8c11a756c515acc9dc60c415bd733a1648e5f0c885a2fd07d22b1ac4f7e"
 	// The name of the GCR kicbase repository
 	gcrRepo = "gcr.io/k8s-minikube/kicbase-builds"
 	// The name of the Dockerhub kicbase repository

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -26,7 +26,7 @@ minikube start [flags]
       --apiserver-names strings           A set of apiserver names which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine
       --apiserver-port int                The apiserver listening port (default 8443)
       --auto-update-drivers               If set, automatically updates drivers to the latest version. Defaults to true. (default true)
-      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.37-1675368987-15776@sha256:7759e8c11a756c515acc9dc60c415bd733a1648e5f0c885a2fd07d22b1ac4f7e")
+      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.37-1675391123-15776@sha256:88e2fc0a6ad1f27dce3f012b7716d07cc4efc368fc128667681554f203c657a6")
       --binary-mirror string              Location to fetch kubectl, kubelet, & kubeadm binaries from.
       --cache-images                      If true, cache docker images for the current bootstrapper and load them into the machine. Always false with --driver=none. (default true)
       --cert-expiration duration          Duration until minikube certificate expiration, defaults to three years (26280h). (default 26280h0m0s)

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -26,7 +26,7 @@ minikube start [flags]
       --apiserver-names strings           A set of apiserver names which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine
       --apiserver-port int                The apiserver listening port (default 8443)
       --auto-update-drivers               If set, automatically updates drivers to the latest version. Defaults to true. (default true)
-      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.37-1675280603-15763@sha256:9f474b7ba8542a6ea1d4410955102c8c63c61d74579375db5b45bbc427946de8")
+      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.37-1675368987-15776@sha256:7759e8c11a756c515acc9dc60c415bd733a1648e5f0c885a2fd07d22b1ac4f7e")
       --binary-mirror string              Location to fetch kubectl, kubelet, & kubeadm binaries from.
       --cache-images                      If true, cache docker images for the current bootstrapper and load them into the machine. Always false with --driver=none. (default true)
       --cert-expiration duration          Duration until minikube certificate expiration, defaults to three years (26280h). (default 26280h0m0s)


### PR DESCRIPTION
this seems to save 60 mb, if it doesnt affect any test failures, it is better to save 50 mb

local/kicbase                                         v0.0.37-1675280603-15763                                50a8ac90621f   2 minutes ago   951MB
local/kicbase                                         v0.0.37-1675212214-15763                                796749b92811   25 hours ago    1.06GB


it seems like pulling image with one single layer is faster  (49 to 35seconds)

```
squash_kicbase ✓
$ time docker pull gcr.io/k8s-minikube/kicbase-builds:v0.0.37-1675368987-15776
v0.0.37-1675368987-15776: Pulling from k8s-minikube/kicbase-builds
97de421c754c: Pull complete 
Digest: sha256:7759e8c11a756c515acc9dc60c415bd733a1648e5f0c885a2fd07d22b1ac4f7e
Status: Downloaded newer image for gcr.io/k8s-minikube/kicbase-builds:v0.0.37-1675368987-15776
gcr.io/k8s-minikube/kicbase-builds:v0.0.37-1675368987-15776

real	0m35.542s
user	0m0.103s
sys	0m0.110s
13:27:11 medya/workspace/minikube
squash_kicbase ✓
$ time docker rmi gcr.io/k8s-minikube/kicbase-builds:v0.0.37-1675368987-15776
Untagged: gcr.io/k8s-minikube/kicbase-builds:v0.0.37-1675368987-15776
Untagged: gcr.io/k8s-minikube/kicbase-builds@sha256:7759e8c11a756c515acc9dc60c415bd733a1648e5f0c885a2fd07d22b1ac4f7e
Deleted: sha256:e5841f1bb90c15db7195d17fef1e441e00482b1caf12438c9e6ae7cca00b926f
Deleted: sha256:4d2f55b4dbcd615279070c4cd6b38ef60320e81f91a81427658ca74e6839d358

real	0m0.605s
user	0m0.013s
sys	0m0.020s
13:27:21 medya/workspace/minikube
squash_kicbase ✓
$ time docker pull gcr.io/k8s-minikube/kicbase-builds:v0.0.37-1675280603-15763
v0.0.37-1675280603-15763: Pulling from k8s-minikube/kicbase-builds
4e7e0215f4ad: Pulling fs layer 
a6aefc808893: Pull complete 
4639e0f594a2: Pull complete 
dc81fd977535: Pull complete 
89898b396668: Pull complete 
3429b75c3884: Pull complete 
7d971c4890ac: Pull complete 
d2465147167b: Pull complete 
07422bc8c17a: Pull complete 
71c104212d33: Pull complete 
e22e94b0b12b: Pull complete 
35fc5777a9c4: Pull complete 
8060794726c8: Pull complete 
f589fa5c4fbc: Pull complete 
da2354ac5260: Pull complete 
b2ca0add8df3: Pull complete 
aae386d2a551: Pull complete 
8aa16703b151: Pull complete 
3a49cfc3759c: Pull complete 
db04b06d286c: Pull complete 
561eceb3753e: Pull complete 
f230b9ba7830: Pull complete 
83c5d428a564: Pull complete 
e7f41c05989b: Pull complete 
4fc0132817f4: Pull complete 
a0f2b4482aed: Pull complete 
ee0419841f5c: Pull complete 
bf5178fe09b9: Pull complete 
4f4fb700ef54: Pull complete 
16d7c2300e53: Pull complete 
deea3385170e: Pull complete 
524db24d6028: Pull complete 
195607cc54e9: Pull complete 
a6e64e7f431b: Pull complete 
ac10b1a44be1: Pull complete 
8126621d2390: Pull complete 
8de2303a5dfc: Pull complete 
9def47c6391a: Pull complete 
7bd0f9519ed4: Pull complete 
8e7bcdf897c9: Pull complete 
a4dc96055b2a: Pull complete 
Digest: sha256:9f474b7ba8542a6ea1d4410955102c8c63c61d74579375db5b45bbc427946de8
Status: Downloaded newer image for gcr.io/k8s-minikube/kicbase-builds:v0.0.37-1675280603-15763
gcr.io/k8s-minikube/kicbase-builds:v0.0.37-1675280603-15763

real	0m49.391s
user	0m0.163s
sys	0m0.151s

```