### PR TITLE
Implement experimental QEMU on Windows code

### DIFF
--- a/pkg/drivers/qemu/qemu.go
+++ b/pkg/drivers/qemu/qemu.go
@@ -395,10 +395,6 @@ func (d *Driver) Start() error {
 		// On Linux, enable the Kernel Virtual Machine accelerator.
 		startCmd = append(startCmd,
 			"-accel", "kvm")
-		//} else if runtime.GOOS == "windows" {
-		//	// On Windows, enable the WHPX (Hyper-V) accelerator.
-		//	startCmd = append(startCmd,
-		//		"-accel", "whpx")
 	}
 
 	startCmd = append(startCmd,

--- a/pkg/drivers/qemu/qemu.go
+++ b/pkg/drivers/qemu/qemu.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math/rand"
 	"net"
 	"os"
@@ -169,21 +170,23 @@ func checkPid(pid int) error {
 }
 
 func (d *Driver) GetState() (state.State, error) {
-	if _, err := os.Stat(d.pidfilePath()); err != nil {
-		return state.Stopped, nil
-	}
-	p, err := os.ReadFile(d.pidfilePath())
-	if err != nil {
-		return state.Error, err
-	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(p)))
-	if err != nil {
-		return state.Error, err
-	}
-	if err := checkPid(pid); err != nil {
-		// No pid, remove pidfile
-		os.Remove(d.pidfilePath())
-		return state.Stopped, nil
+	if runtime.GOOS != "windows" {
+		if _, err := os.Stat(d.pidfilePath()); err != nil {
+			return state.Stopped, nil
+		}
+		p, err := os.ReadFile(d.pidfilePath())
+		if err != nil {
+			return state.Error, err
+		}
+		pid, err := strconv.Atoi(strings.TrimSpace(string(p)))
+		if err != nil {
+			return state.Error, err
+		}
+		if err := checkPid(pid); err != nil {
+			// No pid, remove pidfile
+			os.Remove(d.pidfilePath())
+			return state.Stopped, nil
+		}
 	}
 	ret, err := d.RunQMPCommand("query-status")
 	if err != nil {
@@ -392,6 +395,10 @@ func (d *Driver) Start() error {
 		// On Linux, enable the Kernel Virtual Machine accelerator.
 		startCmd = append(startCmd,
 			"-accel", "kvm")
+		//} else if runtime.GOOS == "windows" {
+		//	// On Windows, enable the WHPX (Hyper-V) accelerator.
+		//	startCmd = append(startCmd,
+		//		"-accel", "whpx")
 	}
 
 	startCmd = append(startCmd,
@@ -424,8 +431,10 @@ func (d *Driver) Start() error {
 		return fmt.Errorf("unknown network: %s", d.Network)
 	}
 
-	startCmd = append(startCmd,
-		"-daemonize")
+	if runtime.GOOS != "windows" {
+		startCmd = append(startCmd,
+			"-daemonize")
+	}
 
 	if d.CloudConfigRoot != "" {
 		startCmd = append(startCmd,
@@ -452,7 +461,11 @@ func (d *Driver) Start() error {
 		startCmd = append([]string{d.SocketVMNetPath, d.Program}, startCmd...)
 	}
 
-	if stdout, stderr, err := cmdOutErr(startProgram, startCmd...); err != nil {
+	startFunc := cmdOutErr
+	if runtime.GOOS == "windows" {
+		startFunc = cmdStart
+	}
+	if stdout, stderr, err := startFunc(startProgram, startCmd...); err != nil {
 		fmt.Printf("OUTPUT: %s\n", stdout)
 		fmt.Printf("ERROR: %s\n", stderr)
 		return err
@@ -519,6 +532,12 @@ func cmdOutErr(cmdStr string, args ...string) (string, string, error) {
 		}
 	}
 	return stdoutStr, stderrStr, err
+}
+
+func cmdStart(cmdStr string, args ...string) (string, string, error) {
+	cmd := exec.Command(cmdStr, args...)
+	log.Debugf("executing: %s %s", cmdStr, strings.Join(args, " "))
+	return "", "", cmd.Start()
 }
 
 func (d *Driver) Stop() error {
@@ -793,7 +812,7 @@ func WaitForTCPWithDelay(addr string, duration time.Duration) error {
 			continue
 		}
 		defer conn.Close()
-		if _, err := conn.Read(make([]byte, 1)); err != nil {
+		if _, err := conn.Read(make([]byte, 1)); err != nil && err != io.EOF {
 			time.Sleep(duration)
 			continue
 		}

--- a/pkg/minikube/registry/drvs/qemu2/qemu2.go
+++ b/pkg/minikube/registry/drvs/qemu2/qemu2.go
@@ -70,6 +70,9 @@ func qemuFirmwarePath(customPath string) (string, error) {
 	if customPath != "" {
 		return customPath, nil
 	}
+	if runtime.GOOS == "windows" {
+		return "C:\\Program Files\\qemu\\share\\edk2-x86_64-code.fd", nil
+	}
 	arch := runtime.GOARCH
 	// For macOS, find the correct brew installation path for qemu firmware
 	if runtime.GOOS == "darwin" {


### PR DESCRIPTION
```
$ ./out/minikube.exe start --driver qemu
* minikube v1.29.0 on Microsoft Windows 10 Enterprise N 10.0.19045.2546 Build 19045.2546
* Using the qemu2 driver based on user configuration
* Automatically selected the user network
! You are using the QEMU driver without a dedicated network, which doesn't support `minikube service` & `minikube tunnel` commands.
* Starting control plane node minikube in cluster minikube
* Creating qemu2 VM (CPUs=2, Memory=6000MB, Disk=20000MB) ...
* Preparing Kubernetes v1.26.1 on Docker 20.10.23 ...
  - Generating certificates and keys ...
  - Booting up control plane ...
  - Configuring RBAC rules ...
* Configuring bridge CNI (Container Networking Interface) ...
  - Using image gcr.io/k8s-minikube/storage-provisioner:v5
* Verifying Kubernetes components...
* Enabled addons: storage-provisioner, default-storageclass
* Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default

```