### PR TITLE
QEMU: Rename `user` network to `builtin` and update documentation

### DIFF
--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -302,7 +302,7 @@ docker-cli install instructions: https://minikube.sigs.k8s.io/docs/tutorials/doc
 			if err != nil {
 				exit.Message(reason.DrvPortForward, "Error getting port binding for '{{.driver_name}} driver: {{.error}}", out.V{"driver_name": driverName, "error": err})
 			}
-		} else if driver.IsQEMU(driverName) && pkgnetwork.IsBuiltin(co.Config.Network) {
+		} else if driver.IsQEMU(driverName) && pkgnetwork.IsBuiltinQEMU(co.Config.Network) {
 			port = d.(*qemu.Driver).EnginePort
 		}
 

--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -302,7 +302,7 @@ docker-cli install instructions: https://minikube.sigs.k8s.io/docs/tutorials/doc
 			if err != nil {
 				exit.Message(reason.DrvPortForward, "Error getting port binding for '{{.driver_name}} driver: {{.error}}", out.V{"driver_name": driverName, "error": err})
 			}
-		} else if driver.IsQEMU(driverName) && pkgnetwork.IsUser(co.Config.Network) {
+		} else if driver.IsQEMU(driverName) && pkgnetwork.IsBuiltin(co.Config.Network) {
 			port = d.(*qemu.Driver).EnginePort
 		}
 

--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -126,7 +126,7 @@ var mountCmd = &cobra.Command{
 		if co.CP.Host.Driver.DriverName() == driver.None {
 			exit.Message(reason.Usage, `'none' driver does not support 'minikube mount' command`)
 		}
-		if driver.IsQEMU(co.Config.Driver) && pkgnetwork.IsBuiltin(co.Config.Network) {
+		if driver.IsQEMU(co.Config.Driver) && pkgnetwork.IsBuiltinQEMU(co.Config.Network) {
 			msg := "minikube mount is not currently implemented with the builtin network on QEMU"
 			if runtime.GOOS == "darwin" {
 				msg += ", try starting minikube with '--network=socket_vmnet'"

--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -126,8 +126,8 @@ var mountCmd = &cobra.Command{
 		if co.CP.Host.Driver.DriverName() == driver.None {
 			exit.Message(reason.Usage, `'none' driver does not support 'minikube mount' command`)
 		}
-		if driver.IsQEMU(co.Config.Driver) && pkgnetwork.IsUser(co.Config.Network) {
-			msg := "minikube mount is not currently implemented with the user network on QEMU"
+		if driver.IsQEMU(co.Config.Driver) && pkgnetwork.IsBuiltin(co.Config.Network) {
+			msg := "minikube mount is not currently implemented with the builtin network on QEMU"
 			if runtime.GOOS == "darwin" {
 				msg += ", try starting minikube with '--network=socket_vmnet'"
 			}

--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -87,7 +87,7 @@ var serviceCmd = &cobra.Command{
 		cname := ClusterFlagValue()
 		co := mustload.Healthy(cname)
 
-		if driver.IsQEMU(co.Config.Driver) && pkgnetwork.IsBuiltin(co.Config.Network) {
+		if driver.IsQEMU(co.Config.Driver) && pkgnetwork.IsBuiltinQEMU(co.Config.Network) {
 			msg := "minikube service is not currently implemented with the builtin network on QEMU"
 			if runtime.GOOS == "darwin" {
 				msg += ", try starting minikube with '--network=socket_vmnet'"

--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -87,8 +87,8 @@ var serviceCmd = &cobra.Command{
 		cname := ClusterFlagValue()
 		co := mustload.Healthy(cname)
 
-		if driver.IsQEMU(co.Config.Driver) && pkgnetwork.IsUser(co.Config.Network) {
-			msg := "minikube service is not currently implemented with the user network on QEMU"
+		if driver.IsQEMU(co.Config.Driver) && pkgnetwork.IsBuiltin(co.Config.Network) {
+			msg := "minikube service is not currently implemented with the builtin network on QEMU"
 			if runtime.GOOS == "darwin" {
 				msg += ", try starting minikube with '--network=socket_vmnet'"
 			}

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -477,17 +477,19 @@ func getNetwork(driverName string) string {
 		if detect.SocketVMNetInstalled() {
 			n = "socket_vmnet"
 		} else {
-			n = "user"
+			n = "builtin"
 		}
 		out.Styled(style.Internet, "Automatically selected the {{.network}} network", out.V{"network": n})
 	case "user":
+		n = "builtin"
+	case "builtin":
 	default:
-		exit.Message(reason.Usage, "--network with QEMU must be 'user' or 'socket_vmnet'")
+		exit.Message(reason.Usage, "--network with QEMU must be 'builtin' or 'socket_vmnet'")
 	}
-	if n == "user" {
+	if n == "builtin" {
 		msg := "You are using the QEMU driver without a dedicated network, which doesn't support `minikube service` & `minikube tunnel` commands."
 		if runtime.GOOS == "darwin" {
-			msg += "\nTo try the experimental dedicated network see: https://minikube.sigs.k8s.io/docs/drivers/qemu/#networking"
+			msg += "\nTo try the dedicated network see: https://minikube.sigs.k8s.io/docs/drivers/qemu/#networking"
 		}
 		out.WarningT(msg)
 	}

--- a/cmd/minikube/cmd/tunnel.go
+++ b/cmd/minikube/cmd/tunnel.go
@@ -58,8 +58,8 @@ var tunnelCmd = &cobra.Command{
 		cname := ClusterFlagValue()
 		co := mustload.Healthy(cname)
 
-		if driver.IsQEMU(co.Config.Driver) && pkgnetwork.IsUser(co.Config.Network) {
-			msg := "minikube tunnel is not currently implemented with the user network on QEMU"
+		if driver.IsQEMU(co.Config.Driver) && pkgnetwork.IsBuiltin(co.Config.Network) {
+			msg := "minikube tunnel is not currently implemented with the builtin network on QEMU"
 			if runtime.GOOS == "darwin" {
 				msg += ", try starting minikube with '--network=socket_vmnet'"
 			}

--- a/cmd/minikube/cmd/tunnel.go
+++ b/cmd/minikube/cmd/tunnel.go
@@ -58,7 +58,7 @@ var tunnelCmd = &cobra.Command{
 		cname := ClusterFlagValue()
 		co := mustload.Healthy(cname)
 
-		if driver.IsQEMU(co.Config.Driver) && pkgnetwork.IsBuiltin(co.Config.Network) {
+		if driver.IsQEMU(co.Config.Driver) && pkgnetwork.IsBuiltinQEMU(co.Config.Network) {
 			msg := "minikube tunnel is not currently implemented with the builtin network on QEMU"
 			if runtime.GOOS == "darwin" {
 				msg += ", try starting minikube with '--network=socket_vmnet'"

--- a/pkg/drivers/qemu/qemu.go
+++ b/pkg/drivers/qemu/qemu.go
@@ -89,7 +89,7 @@ func (d *Driver) GetMachineName() string {
 }
 
 func (d *Driver) GetSSHHostname() (string, error) {
-	if network.IsBuiltin(d.Network) {
+	if network.IsBuiltinQEMU(d.Network) {
 		return "localhost", nil
 	}
 	return d.IPAddress, nil
@@ -146,7 +146,7 @@ func NewDriver(hostName, storePath string) drivers.Driver {
 }
 
 func (d *Driver) GetIP() (string, error) {
-	if network.IsBuiltin(d.Network) {
+	if network.IsBuiltinQEMU(d.Network) {
 		return "127.0.0.1", nil
 	}
 	return d.IPAddress, nil

--- a/pkg/drivers/qemu/qemu.go
+++ b/pkg/drivers/qemu/qemu.go
@@ -88,7 +88,7 @@ func (d *Driver) GetMachineName() string {
 }
 
 func (d *Driver) GetSSHHostname() (string, error) {
-	if d.Network == "user" {
+	if d.Network == "builtin" {
 		return "localhost", nil
 	}
 	return d.IPAddress, nil
@@ -145,7 +145,7 @@ func NewDriver(hostName, storePath string) drivers.Driver {
 }
 
 func (d *Driver) GetIP() (string, error) {
-	if d.Network == "user" {
+	if d.Network == "builtin" {
 		return "127.0.0.1", nil
 	}
 	return d.IPAddress, nil
@@ -213,7 +213,7 @@ func (d *Driver) PreCreateCheck() error {
 func (d *Driver) Create() error {
 	var err error
 	switch d.Network {
-	case "user":
+	case "builtin":
 		minPort, maxPort, err := parsePortRange(d.LocalPorts)
 		log.Debugf("port range: %d -> %d", minPort, maxPort)
 		if err != nil {
@@ -412,7 +412,7 @@ func (d *Driver) Start() error {
 	)
 
 	switch d.Network {
-	case "user":
+	case "builtin":
 		startCmd = append(startCmd,
 			"-nic", fmt.Sprintf("user,model=virtio,hostfwd=tcp::%d-:22,hostfwd=tcp::%d-:2376,hostname=%s", d.SSHPort, d.EnginePort, d.GetMachineName()),
 		)
@@ -459,7 +459,7 @@ func (d *Driver) Start() error {
 	}
 
 	switch d.Network {
-	case "user":
+	case "builtin":
 		d.IPAddress = "127.0.0.1"
 	case "socket_vmnet":
 		var err error

--- a/pkg/drivers/qemu/qemu.go
+++ b/pkg/drivers/qemu/qemu.go
@@ -40,6 +40,7 @@ import (
 	"github.com/pkg/errors"
 
 	pkgdrivers "k8s.io/minikube/pkg/drivers"
+	"k8s.io/minikube/pkg/network"
 )
 
 const (
@@ -88,7 +89,7 @@ func (d *Driver) GetMachineName() string {
 }
 
 func (d *Driver) GetSSHHostname() (string, error) {
-	if d.Network == "builtin" {
+	if network.IsBuiltin(d.Network) {
 		return "localhost", nil
 	}
 	return d.IPAddress, nil
@@ -145,7 +146,7 @@ func NewDriver(hostName, storePath string) drivers.Driver {
 }
 
 func (d *Driver) GetIP() (string, error) {
-	if d.Network == "builtin" {
+	if network.IsBuiltin(d.Network) {
 		return "127.0.0.1", nil
 	}
 	return d.IPAddress, nil
@@ -213,7 +214,7 @@ func (d *Driver) PreCreateCheck() error {
 func (d *Driver) Create() error {
 	var err error
 	switch d.Network {
-	case "builtin":
+	case "builtin", "user":
 		minPort, maxPort, err := parsePortRange(d.LocalPorts)
 		log.Debugf("port range: %d -> %d", minPort, maxPort)
 		if err != nil {
@@ -412,7 +413,7 @@ func (d *Driver) Start() error {
 	)
 
 	switch d.Network {
-	case "builtin":
+	case "builtin", "user":
 		startCmd = append(startCmd,
 			"-nic", fmt.Sprintf("user,model=virtio,hostfwd=tcp::%d-:22,hostfwd=tcp::%d-:2376,hostname=%s", d.SSHPort, d.EnginePort, d.GetMachineName()),
 		)
@@ -459,7 +460,7 @@ func (d *Driver) Start() error {
 	}
 
 	switch d.Network {
-	case "builtin":
+	case "builtin", "user":
 		d.IPAddress = "127.0.0.1"
 	case "socket_vmnet":
 		var err error

--- a/pkg/minikube/cluster/ip.go
+++ b/pkg/minikube/cluster/ip.go
@@ -58,9 +58,7 @@ func HostIP(host *host.Host, clusterName string) (net.IP, error) {
 			return []byte{}, errors.Wrap(err, "Error converting VM/Host IP address to IPv4 address")
 		}
 		return net.IPv4(vmIP[0], vmIP[1], vmIP[2], byte(1)), nil
-	case driver.QEMU:
-		fallthrough
-	case driver.QEMU2:
+	case driver.QEMU, driver.QEMU2:
 		ipString, err := host.Driver.GetIP()
 		if err != nil {
 			return []byte{}, errors.Wrap(err, "Error getting IP address")

--- a/pkg/minikube/driver/endpoint.go
+++ b/pkg/minikube/driver/endpoint.go
@@ -46,7 +46,7 @@ func ControlPlaneEndpoint(cc *config.ClusterConfig, cp *config.Node, driverName 
 			hostname = cc.KubernetesConfig.APIServerName
 		}
 		return hostname, ips[0], port, err
-	} else if IsQEMU(driverName) && network.IsBuiltin(cc.Network) {
+	} else if IsQEMU(driverName) && network.IsBuiltinQEMU(cc.Network) {
 		return "localhost", net.IPv4(127, 0, 0, 1), cc.APIServerPort, nil
 	}
 

--- a/pkg/minikube/driver/endpoint.go
+++ b/pkg/minikube/driver/endpoint.go
@@ -46,7 +46,7 @@ func ControlPlaneEndpoint(cc *config.ClusterConfig, cp *config.Node, driverName 
 			hostname = cc.KubernetesConfig.APIServerName
 		}
 		return hostname, ips[0], port, err
-	} else if IsQEMU(driverName) && network.IsUser(cc.Network) {
+	} else if IsQEMU(driverName) && network.IsBuiltin(cc.Network) {
 		return "localhost", net.IPv4(127, 0, 0, 1), cc.APIServerPort, nil
 	}
 

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -648,7 +648,7 @@ func startMachine(cfg *config.ClusterConfig, node *config.Node, delOnFail bool) 
 		return runner, preExists, m, host, errors.Wrap(err, "Failed to validate network")
 	}
 
-	if driver.IsQEMU(host.Driver.DriverName()) && network.IsBuiltin(cfg.Network) {
+	if driver.IsQEMU(host.Driver.DriverName()) && network.IsBuiltinQEMU(cfg.Network) {
 		apiServerPort, err := getPort()
 		if err != nil {
 			return runner, preExists, m, host, errors.Wrap(err, "Failed to find apiserver port")

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -648,7 +648,7 @@ func startMachine(cfg *config.ClusterConfig, node *config.Node, delOnFail bool) 
 		return runner, preExists, m, host, errors.Wrap(err, "Failed to validate network")
 	}
 
-	if driver.IsQEMU(host.Driver.DriverName()) && network.IsUser(cfg.Network) {
+	if driver.IsQEMU(host.Driver.DriverName()) && network.IsBuiltin(cfg.Network) {
 		apiServerPort, err := getPort()
 		if err != nil {
 			return runner, preExists, m, host, errors.Wrap(err, "Failed to find apiserver port")

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -181,8 +181,8 @@ var isSubnetTaken = func(subnet string) (bool, error) {
 	return false, nil
 }
 
-// IsBuiltin returns if network is builtin or the legacy value user.
-func IsBuiltin(network string) bool {
+// IsBuiltinQEMU returns if network is builtin or the legacy value user.
+func IsBuiltinQEMU(network string) bool {
 	if network == "user" {
 		return true
 	}

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -181,9 +181,9 @@ var isSubnetTaken = func(subnet string) (bool, error) {
 	return false, nil
 }
 
-// IsUser returns if network is user.
-func IsUser(network string) bool {
-	return network == "user"
+// IsBuiltin returns if network is builtin.
+func IsBuiltin(network string) bool {
+	return network == "builtin"
 }
 
 // FreeSubnet will try to find free private network beginning with startSubnet, incrementing it in steps up to number of tries.

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -181,8 +181,11 @@ var isSubnetTaken = func(subnet string) (bool, error) {
 	return false, nil
 }
 
-// IsBuiltin returns if network is builtin.
+// IsBuiltin returns if network is builtin or the legacy value user.
 func IsBuiltin(network string) bool {
+	if network == "user" {
+		return true
+	}
 	return network == "builtin"
 }
 

--- a/site/content/en/docs/drivers/qemu.md
+++ b/site/content/en/docs/drivers/qemu.md
@@ -31,19 +31,26 @@ minikube start supports some qemu specific flags:
 
 ## Networking
 
-The QEMU driver has two networking options, `user` & `socket_vmnet`.
+The QEMU driver has two networking options: `socket_vmnet` and `user`. `socket_vmnet` will give you full minikube networking functionality, such as the `service` and `tunnel` commands. On the other hand, the `user` network is built-in to QEMU but is not a dedicated network and therefore commands such as `service` and `tunnel` are not available. [socket_vmnet](https://github.com/lima-vm/socket_vmnet) can be installed via brew or from source (instructions below).
 
 {{% tabs %}}
-{{% tab "socket_vmnet - needs installation" %}}
+{{% tab "socket_vmnet" %}}
 
 ### Requirements
 
-Requires macOS 10.15 or later and socket_vmnet.
+Requires macOS 10.15 or later and [socket_vmnet](https://github.com/lima-vm/socket_vmnet).
 
-[lima-vm/socket_vmnet](https://github.com/lima-vm/socket_vmnet) install instructions:
+### Install socket_vmnet via [brew](https://brew.sh/)
+```shell
+brew install socket_vmnet
+brew tap homebrew/services
+HOMEBREW=$(which brew) && sudo ${HOMEBREW} services start socket_vmnet
+```
+
+### Install socket_vmnet from source (requires [Go](https://go.dev/))
 ```shell
 git clone https://github.com/lima-vm/socket_vmnet.git && cd socket_vmnet
-sudo make PREFIX=/opt/socket_vmnet install
+sudo make install
 ```
 
 ### Usage
@@ -52,16 +59,39 @@ sudo make PREFIX=/opt/socket_vmnet install
 minikube start --driver qemu --network socket_vmnet
 ```
 
-The `socket_vmnet` network is a dedicated network and supports the `minikube service` and `minikube tunnel` commands.
 {{% /tab %}}
-{{% tab "user - limited functionality" %}}
-The `user` network is not a dedicated network, it doesn't support some networking commands such as `minikube service` and `minikube tunnel`, and its IP address is not reachable from the host.
+{{% tab "user - QEMU built-in" %}}
+### Usage
+
+```shell
+minikube start --driver qemu --network user
+````
 {{% /tab %}}
 {{% /tabs %}}
 
 ## Known Issues
 
-### 1. Start stuck with `user` network on corp machine or custom DNS
+{{% tabs %}}
+{{% tab "socket_vmnet" %}}
+##  `/var/db/dhcpd_leases` errors
+
+If you're seeing errors related to `/var/db/dhcpd_leases` we recommend the following:
+
+1. Uninstall `socket_vmnet`:
+
+```shell
+# if installed via brew
+HOMEBREW=$(which brew) && sudo ${HOMEBREW_PREFIX}/bin/brew services stop socket_vmnet
+brew uninstall socket_vmnet
+
+# if installed from source
+cd socket_vmnet && sudo make uninstall
+```
+2. Reboot
+3. [Reinstall `socket_vmnet`](#requirements)
+{{% /tab %}}
+{{% tab "user" %}}
+## Start stuck on corp machine or with custom DNS
 
 When using the `user` network (default) the guest uses **only** the first `nameserver` entry in the hosts `/etc/resolv.conf` for DNS lookup. If your first `nameserver` entry is a corporate/internal DNS it's likely it will cause an issue. If you see the warning `❗ This VM is having trouble accessing https://registry.k8s.io` on `minikube start` you are likely being affected by this. This may prevent your cluster from starting entirely and you won't be able to pull remote images. More details can be found at: [#15021](https://github.com/kubernetes/minikube/issues/15021)
 
@@ -69,24 +99,8 @@ When using the `user` network (default) the guest uses **only** the first `names
 
 1. If possible, reorder your `/etc/resolv.conf` to have a general `nameserver` entry first (eg. `8.8.8.8`) and reboot your machine.
 2. Use `--network=socket_vmnet`
-
-### 2. `/var/db/dhcpd_leases` errors
-
-If you're seeing errors related to `/var/db/dhcpd_leases` we recommend the following:
-
-1. Uninstall `socket_vmnet`:
-
-```shell
-cd socket_vmnet
-sudo make uninstall
-```
-2. Reboot
-3. Reinstall `socket_vmnet`:
-
-```shell
-cd socket_vmnet
-sudo make install
-```
+{{% /tab %}}
+{{% /tabs %}}
 
 [Full list of open 'qemu' driver issues](https://github.com/kubernetes/minikube/labels/co%2Fqemu-driver)
 

--- a/site/content/en/docs/drivers/qemu.md
+++ b/site/content/en/docs/drivers/qemu.md
@@ -9,7 +9,7 @@ aliases:
 
 ## Overview
 
-The `qemu` driver users QEMU (system) for VM creation.
+The `qemu` driver uses QEMU (system) for VM creation.
 
 <https://www.qemu.org/>
 
@@ -31,10 +31,10 @@ minikube start supports some qemu specific flags:
 
 ## Networking
 
-The QEMU driver has two networking options: `socket_vmnet` and `user`. `socket_vmnet` will give you full minikube networking functionality, such as the `service` and `tunnel` commands. On the other hand, the `user` network is built-in to QEMU but is not a dedicated network and therefore commands such as `service` and `tunnel` are not available. [socket_vmnet](https://github.com/lima-vm/socket_vmnet) can be installed via brew or from source (instructions below).
+The QEMU driver has two networking options: `socket_vmnet` and `builtin`. `socket_vmnet` will give you full minikube networking functionality, such as the `service` and `tunnel` commands. On the other hand, the `builtin` network is not a dedicated network and therefore commands such as `service` and `tunnel` are not available. [socket_vmnet](https://github.com/lima-vm/socket_vmnet) can be installed via brew or from source (instructions below).
 
 {{% tabs %}}
-{{% tab "socket_vmnet" %}}
+{{% tab socket_vmnet %}}
 
 ### Requirements
 
@@ -60,11 +60,11 @@ minikube start --driver qemu --network socket_vmnet
 ```
 
 {{% /tab %}}
-{{% tab "user - QEMU built-in" %}}
+{{% tab builtin %}}
 ### Usage
 
 ```shell
-minikube start --driver qemu --network user
+minikube start --driver qemu --network builtin
 ````
 {{% /tab %}}
 {{% /tabs %}}
@@ -72,7 +72,7 @@ minikube start --driver qemu --network user
 ## Known Issues
 
 {{% tabs %}}
-{{% tab "socket_vmnet" %}}
+{{% tab socket_vmnet %}}
 ##  `/var/db/dhcpd_leases` errors
 
 If you're seeing errors related to `/var/db/dhcpd_leases` we recommend the following:
@@ -90,10 +90,10 @@ cd socket_vmnet && sudo make uninstall
 2. Reboot
 3. [Reinstall `socket_vmnet`](#requirements)
 {{% /tab %}}
-{{% tab "user" %}}
+{{% tab builtin %}}
 ## Start stuck on corp machine or with custom DNS
 
-When using the `user` network (default) the guest uses **only** the first `nameserver` entry in the hosts `/etc/resolv.conf` for DNS lookup. If your first `nameserver` entry is a corporate/internal DNS it's likely it will cause an issue. If you see the warning `❗ This VM is having trouble accessing https://registry.k8s.io` on `minikube start` you are likely being affected by this. This may prevent your cluster from starting entirely and you won't be able to pull remote images. More details can be found at: [#15021](https://github.com/kubernetes/minikube/issues/15021)
+When using the `builtin` network (default) the guest uses **only** the first `nameserver` entry in the hosts `/etc/resolv.conf` for DNS lookup. If your first `nameserver` entry is a corporate/internal DNS it's likely it will cause an issue. If you see the warning `❗ This VM is having trouble accessing https://registry.k8s.io` on `minikube start` you are likely being affected by this. This may prevent your cluster from starting entirely and you won't be able to pull remote images. More details can be found at: [#15021](https://github.com/kubernetes/minikube/issues/15021)
 
 #### Workarounds:
 


### PR DESCRIPTION
Site:
- Updated references from `user` to `builtin`
- Added more information about the differences between the `socket_vmnet` and `builtin` network options
- Added install/uninstall instructions for `socket_vmnet` via brew
- Moved known issues into a tabbed component so user can see issues specific to their network option

QEMU:
- Updated references from `user` to `builtin`
- Still supports the `user` flag, but will rewrite the value to `builtin` on cluster creation