### PR TITLE
CI: return commit when getting GitHub releases

### DIFF
--- a/hack/update/docsy_version/update_docsy_version.go
+++ b/hack/update/docsy_version/update_docsy_version.go
@@ -50,11 +50,11 @@ func main() {
 }
 
 // docsyVersion returns stable version in semver format.
-func docsyVersion(ctx context.Context, owner, repo string) (stable string, err error) {
+func docsyVersion(ctx context.Context, owner, repo string) (string, error) {
 	// get Docsy version from GitHub Releases
-	stable, _, _, err = update.GHReleases(ctx, owner, repo)
-	if err != nil || !semver.IsValid(stable) {
+	stable, _, _, err := update.GHReleases(ctx, owner, repo)
+	if err != nil || !semver.IsValid(stable.Tag) {
 		return "", err
 	}
-	return stable, nil
+	return stable.Tag, nil
 }

--- a/hack/update/gh_version/update_gh_version.go
+++ b/hack/update/gh_version/update_gh_version.go
@@ -64,11 +64,11 @@ func main() {
 }
 
 // ghVersion returns stable version in semver format.
-func ghVersion(ctx context.Context, owner, repo string) (stable string, err error) {
+func ghVersion(ctx context.Context, owner, repo string) (string, error) {
 	// get gh version from GitHub Releases
-	stable, _, _, err = update.GHReleases(ctx, owner, repo)
-	if err != nil || !semver.IsValid(stable) {
+	stable, _, _, err := update.GHReleases(ctx, owner, repo)
+	if err != nil || !semver.IsValid(stable.Tag) {
 		return "", err
 	}
-	return strings.TrimPrefix(stable, "v"), nil
+	return strings.TrimPrefix(stable.Tag, "v"), nil
 }

--- a/hack/update/github.go
+++ b/hack/update/github.go
@@ -18,6 +18,7 @@ package update
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"golang.org/x/mod/semver"
@@ -34,9 +35,14 @@ const (
 	ghSearchLimit = 300
 )
 
+type Release struct {
+	Tag    string
+	Commit string
+}
+
 // GHReleases returns greatest current stable release and greatest latest rc or beta pre-release from GitHub owner/repo repository, and any error occurred.
 // If latest pre-release version is lower than the current stable release, then it will return current stable release for both.
-func GHReleases(ctx context.Context, owner, repo string) (stable, latest, edge string, err error) {
+func GHReleases(ctx context.Context, owner, repo string) (stable, latest, edge Release, err error) {
 	ghc := github.NewClient(nil)
 
 	// walk through the paginated list of up to ghSearchLimit newest releases
@@ -44,7 +50,7 @@ func GHReleases(ctx context.Context, owner, repo string) (stable, latest, edge s
 	for (opts.Page+1)*ghListPerPage <= ghSearchLimit {
 		rls, resp, err := ghc.Repositories.ListReleases(ctx, owner, repo, opts)
 		if err != nil {
-			return "", "", "", err
+			return stable, latest, edge, err
 		}
 		for _, rl := range rls {
 			ver := rl.GetTagName()
@@ -54,22 +60,26 @@ func GHReleases(ctx context.Context, owner, repo string) (stable, latest, edge s
 			// check if ver version is release (ie, 'v1.19.2') or pre-release (ie, 'v1.19.3-rc.0' or 'v1.19.0-beta.2')
 			prerls := semver.Prerelease(ver)
 			if prerls == "" {
-				if semver.Compare(ver, stable) == 1 {
-					stable = ver
+				if semver.Compare(ver, stable.Tag) == 1 {
+					stable.Tag = ver
 				}
 			} else if strings.HasPrefix(prerls, "-rc") || strings.HasPrefix(prerls, "-beta") {
-				if semver.Compare(ver, latest) == 1 {
-					latest = ver
+				if semver.Compare(ver, latest.Tag) == 1 {
+					latest.Tag = ver
 				}
 			} else if strings.Contains(prerls, "-alpha") {
-				if semver.Compare(ver, edge) == 1 {
-					edge = ver
+				if semver.Compare(ver, edge.Tag) == 1 {
+					edge.Tag = ver
 				}
 			}
 
 			// make sure that latest >= stable
-			if semver.Compare(latest, stable) == -1 {
-				latest = stable
+			if semver.Compare(latest.Tag, stable.Tag) == -1 {
+				latest.Tag = stable.Tag
+			}
+			// make sure that edge >= latest
+			if semver.Compare(edge.Tag, latest.Tag) == -1 {
+				edge.Tag = latest.Tag
 			}
 		}
 		if resp.NextPage == 0 {
@@ -77,5 +87,39 @@ func GHReleases(ctx context.Context, owner, repo string) (stable, latest, edge s
 		}
 		opts.Page = resp.NextPage
 	}
-	return stable, latest, edge, nil
+	// create a map where the key is the tag and the values is an array of releases (stable, latest, edge) that match the tag
+	releasesWithoutCommits := map[string][]*Release{}
+	for _, rl := range []*Release{&stable, &latest, &edge} {
+		releasesWithoutCommits[rl.Tag] = append(releasesWithoutCommits[rl.Tag], rl)
+	}
+	// run though the releases to find ones that don't yet have a commit and assign it
+	opts = &github.ListOptions{PerPage: ghListPerPage}
+	for (opts.Page+1)*ghListPerPage <= ghSearchLimit {
+		tags, resp, err := ghc.Repositories.ListTags(ctx, owner, repo, opts)
+		if err != nil {
+			return stable, latest, edge, err
+		}
+		for _, tag := range tags {
+			rls, ok := releasesWithoutCommits[*tag.Name]
+			if !ok {
+				continue
+			}
+			for _, rl := range rls {
+				rl.Commit = *tag.Commit.SHA
+			}
+			delete(releasesWithoutCommits, *tag.Name)
+			if len(releasesWithoutCommits) == 0 {
+				return stable, latest, edge, nil
+			}
+		}
+		if len(releasesWithoutCommits) == 0 {
+			break
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	return stable, latest, edge, fmt.Errorf("wasn't able to find commit for releases")
 }

--- a/hack/update/golint_version/update_golint_version.go
+++ b/hack/update/golint_version/update_golint_version.go
@@ -63,11 +63,11 @@ func main() {
 }
 
 // golintVersion returns stable version in semver format.
-func golintVersion(ctx context.Context, owner, repo string) (stable string, err error) {
+func golintVersion(ctx context.Context, owner, repo string) (string, error) {
 	// get Golint version from GitHub Releases
-	stable, _, _, err = update.GHReleases(ctx, owner, repo)
-	if err != nil || !semver.IsValid(stable) {
+	stable, _, _, err := update.GHReleases(ctx, owner, repo)
+	if err != nil || !semver.IsValid(stable.Tag) {
 		return "", err
 	}
-	return stable, nil
+	return stable.Tag, nil
 }

--- a/hack/update/gopogh_version/update_gopogh_version.go
+++ b/hack/update/gopogh_version/update_gopogh_version.go
@@ -83,11 +83,11 @@ func main() {
 }
 
 // gopoghVersion returns gopogh stable version in semver format.
-func gopoghVersion(ctx context.Context, owner, repo string) (stable string, err error) {
+func gopoghVersion(ctx context.Context, owner, repo string) (string, error) {
 	// get gopogh version from GitHub Releases
-	stable, _, _, err = update.GHReleases(ctx, owner, repo)
-	if err != nil || !semver.IsValid(stable) {
+	stable, _, _, err := update.GHReleases(ctx, owner, repo)
+	if err != nil || !semver.IsValid(stable.Tag) {
 		return "", err
 	}
-	return stable, nil
+	return stable.Tag, nil
 }

--- a/hack/update/gotestsum_version/update_gotestsum_version.go
+++ b/hack/update/gotestsum_version/update_gotestsum_version.go
@@ -69,11 +69,11 @@ func main() {
 }
 
 // gotestsumVersion returns gotestsum stable version in semver format.
-func gotestsumVersion(ctx context.Context, owner, repo string) (stable string, err error) {
+func gotestsumVersion(ctx context.Context, owner, repo string) (string, error) {
 	// get gotestsum version from GitHub Releases
-	stable, _, _, err = update.GHReleases(ctx, owner, repo)
-	if err != nil || !semver.IsValid(stable) {
+	stable, _, _, err := update.GHReleases(ctx, owner, repo)
+	if err != nil || !semver.IsValid(stable.Tag) {
 		return "", err
 	}
-	return stable, nil
+	return stable.Tag, nil
 }

--- a/hack/update/hugo_version/update_hugo_version.go
+++ b/hack/update/hugo_version/update_hugo_version.go
@@ -63,11 +63,11 @@ func main() {
 }
 
 // hugoVersion returns stable version in semver format.
-func hugoVersion(ctx context.Context, owner, repo string) (stable string, err error) {
+func hugoVersion(ctx context.Context, owner, repo string) (string, error) {
 	// get Hugo version from GitHub Releases
-	stable, _, _, err = update.GHReleases(ctx, owner, repo)
-	if err != nil || !semver.IsValid(stable) {
+	stable, _, _, err := update.GHReleases(ctx, owner, repo)
+	if err != nil || !semver.IsValid(stable.Tag) {
 		return "", err
 	}
-	return stable, nil
+	return stable.Tag, nil
 }

--- a/hack/update/kubernetes_version/update_kubernetes_version.go
+++ b/hack/update/kubernetes_version/update_kubernetes_version.go
@@ -133,7 +133,9 @@ func main() {
 // k8sVersions returns Kubernetes versions.
 func k8sVersions(ctx context.Context, owner, repo string) (stable, latest, latestMM, latestP0 string, err error) {
 	// get Kubernetes versions from GitHub Releases
-	stable, latest, _, err = update.GHReleases(ctx, owner, repo)
+	stableRls, latestRls, _, err := update.GHReleases(ctx, owner, repo)
+	stable = stableRls.Tag
+	latest = latestRls.Tag
 	if err != nil || !semver.IsValid(stable) || !semver.IsValid(latest) {
 		return "", "", "", "", err
 	}


### PR DESCRIPTION
Updated the `GHReleases` func to also return the commit of the release.

This will allow better automation of updating deps in the future. For example, now that we know the commit we can have GitHub action jobs run that update kicbase and ISO deps.