### PR TITLE
tests: fix setting bad DOCKER_HOST for TestDownloadOnlyKic

### DIFF
--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -219,12 +219,10 @@ func TestDownloadOnlyKic(t *testing.T) {
 
 	cRuntime := ContainerRuntime()
 
-	args := []string{"start", "--download-only", "-p", profile, "--force", "--alsologtostderr"}
+	args := []string{"start", "--download-only", "-p", profile, "--alsologtostderr"}
 	args = append(args, StartArgs()...)
 
 	cmd := exec.CommandContext(ctx, Target(), args...)
-	// make sure this works even if docker daemon isn't running
-	cmd.Env = append(os.Environ(), "DOCKER_HOST=/does/not/exist")
 	if _, err := Run(t, cmd); err != nil {
 		t.Errorf("start with download only failed %q : %v", args, err)
 	}


### PR DESCRIPTION
This test starting breaking when Docker Engine updated to 23.0.0