### PR TITLE
Fix bash completion for kubectl symlinked to minikube by not adding `--cluster` flag for the `kubectl __complete` subcommand

### DIFF
--- a/cmd/minikube/cmd/kubectl.go
+++ b/cmd/minikube/cmd/kubectl.go
@@ -130,7 +130,7 @@ host. Please be aware that when using --ssh all paths will apply to the remote m
 			os.Exit(1)
 		}
 
-		if len(args) > 1 && args[0] != "--help" {
+		if len(args) > 1 && args[0] != "--help" && args[0] != cobra.ShellCompRequestCmd {
 			cluster := []string{"--cluster", cname}
 			args = append(cluster, args...)
 		}


### PR DESCRIPTION
Fixes #14959

Before:

```bash
$ go run ./cmd/minikube kubectl __complete ge
Error: flags cannot be placed before plugin name: --cluster
exit status 1
```

After:

```bash
$ go run ./cmd/minikube kubectl __complete ge
get	Display one or many resources
:4
Completion ended with directive: ShellCompDirectiveNoFileComp
```

Signed-off-by: Ben Krieger <ben.krieger@intel.com>