### PR TITLE
Don't allow enabling addon on a paused cluster

### DIFF
--- a/cmd/minikube/cmd/config/disable.go
+++ b/cmd/minikube/cmd/config/disable.go
@@ -35,7 +35,7 @@ var addonsDisableCmd = &cobra.Command{
 		if len(args) != 1 {
 			exit.Message(reason.Usage, "usage: minikube addons disable ADDON_NAME")
 		}
-		err := addons.CheckPaused(ClusterFlagValue(), false)
+		err := addons.VerifyNotPaused(ClusterFlagValue(), false)
 		if err != nil {
 			exit.Error(reason.InternalAddonDisablePaused, "disable failed", err)
 		}

--- a/cmd/minikube/cmd/config/disable.go
+++ b/cmd/minikube/cmd/config/disable.go
@@ -35,7 +35,10 @@ var addonsDisableCmd = &cobra.Command{
 		if len(args) != 1 {
 			exit.Message(reason.Usage, "usage: minikube addons disable ADDON_NAME")
 		}
-
+		err := addons.CheckPaused(ClusterFlagValue(), false)
+		if err != nil {
+			exit.Error(reason.InternalAddonDisablePaused, "disable failed", err)
+		}
 		addon := args[0]
 		if addon == "heapster" {
 			exit.Message(reason.AddonUnsupported, "The heapster addon is depreciated. please try to disable metrics-server instead")
@@ -46,7 +49,7 @@ var addonsDisableCmd = &cobra.Command{
 			exit.Message(reason.AddonUnsupported, `"'{{.minikube_addon}}' is not a valid minikube addon`, out.V{"minikube_addon": addon})
 		}
 		if validAddon.IsEnabled(cc) {
-			err := addons.SetAndSave(ClusterFlagValue(), addon, "false")
+			err = addons.SetAndSave(ClusterFlagValue(), addon, "false")
 			if err != nil {
 				exit.Error(reason.InternalAddonDisable, "disable failed", err)
 			}

--- a/cmd/minikube/cmd/config/enable.go
+++ b/cmd/minikube/cmd/config/enable.go
@@ -48,7 +48,7 @@ var addonsEnableCmd = &cobra.Command{
 			exit.Message(reason.Usage, "You cannot enable addons on a cluster without Kubernetes, to enable Kubernetes on your cluster, run: minikube start --kubernetes-version=stable")
 		}
 
-		err = addons.CheckPaused(ClusterFlagValue(), true)
+		err = addons.VerifyNotPaused(ClusterFlagValue(), true)
 		if err != nil {
 			exit.Error(reason.InternalAddonEnablePaused, "enabled failed", err)
 		}

--- a/cmd/minikube/cmd/config/enable.go
+++ b/cmd/minikube/cmd/config/enable.go
@@ -48,6 +48,10 @@ var addonsEnableCmd = &cobra.Command{
 			exit.Message(reason.Usage, "You cannot enable addons on a cluster without Kubernetes, to enable Kubernetes on your cluster, run: minikube start --kubernetes-version=stable")
 		}
 
+		err = addons.CheckPaused(ClusterFlagValue(), true)
+		if err != nil {
+			exit.Error(reason.InternalAddonEnablePaused, "enabled failed", err)
+		}
 		addon := args[0]
 		isDeprecated, replacement, msg := addons.Deprecations(addon)
 		if isDeprecated && replacement == "" {

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -292,8 +292,13 @@ func EnableOrDisableAddon(cc *config.ClusterConfig, name string, val string) err
 		return errors.Wrap(err, "check paused")
 	}
 	if runtimePaused {
-		out.Styled(style.Shrug, `Can't enable addon on a paused cluster, please unpause the cluster firstly.`)
-		return errors.New("Can't enable addon on a paused cluster, please unpause the cluster firstly.")
+		action := "disable"
+		if enable {
+			action = "enable"
+		}
+		msg := fmt.Sprintf("can't %s addon on a paused cluster, please unpause the cluster firstly.", action)
+		out.Styled(style.Shrug, msg)
+		return errors.New(msg)
 	}
 	bail, err := addonSpecificChecks(cc, name, enable, runner)
 	if err != nil {

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -632,7 +632,7 @@ func CheckPaused(profile string, enable bool) error {
 		if enable {
 			action = "enable"
 		}
-		msg := fmt.Sprintf("can't %s addon on a paused cluster, please unpause the cluster firstly.", action)
+		msg := fmt.Sprintf("Can't %s addon on a paused cluster, please unpause the cluster first.", action)
 		out.Styled(style.Shrug, msg)
 		return errors.New(msg)
 	}

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
+	"github.com/docker/machine/libmachine/state"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 
@@ -611,6 +612,15 @@ func VerifyNotPaused(profile string, enable bool) error {
 	host, err := machine.LoadHost(api, config.MachineName(*cc, cp))
 	if err != nil {
 		return errors.Wrap(err, "get host")
+	}
+
+	s, err := host.Driver.GetState()
+	if err != nil {
+		return errors.Wrap(err, "get state")
+	}
+	if s != state.Running {
+		// can't check the status of pods on a non-running cluster
+		return nil
 	}
 
 	runner, err := machine.CommandRunner(host)

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -637,14 +637,14 @@ func VerifyNotPaused(profile string, enable bool) error {
 	if err != nil {
 		return errors.Wrap(err, "check paused")
 	}
-	if runtimePaused {
-		action := "disable"
-		if enable {
-			action = "enable"
-		}
-		msg := fmt.Sprintf("Can't %s addon on a paused cluster, please unpause the cluster first.", action)
-		out.Styled(style.Shrug, msg)
-		return errors.New(msg)
+	if !runtimePaused {
+		return nil
 	}
-	return nil
+	action := "disable"
+	if enable {
+		action = "enable"
+	}
+	msg := fmt.Sprintf("Can't %s addon on a paused cluster, please unpause the cluster first.", action)
+	out.Styled(style.Shrug, msg)
+	return errors.New(msg)
 }

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -588,8 +588,8 @@ func UpdateConfigToDisable(cc *config.ClusterConfig) {
 	}
 }
 
-// CheckPaused checks whether the cluster is paused before enable/disable an addon.
-func CheckPaused(profile string, enable bool) error {
+// VerifyNotPaused verifies the cluster is not paused before enable/disable an addon.
+func VerifyNotPaused(profile string, enable bool) error {
 	klog.Info("checking whether the cluster is paused")
 
 	cc, err := config.Load(profile)

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -284,6 +284,9 @@ func EnableOrDisableAddon(cc *config.ClusterConfig, name string, val string) err
 
 	crName := cc.KubernetesConfig.ContainerRuntime
 	cr, err := cruntime.New(cruntime.Config{Type: crName, Runner: runner})
+	if err != nil {
+		return errors.Wrap(err, "container runtime")
+	}
 	runtimePaused, err := cluster.CheckIfPaused(cr, []string{"kube-system"})
 	if err != nil {
 		return errors.Wrap(err, "check paused")

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -85,6 +85,11 @@ var (
 	InternalAddonDisable = Kind{ID: "MK_ADDON_DISABLE", ExitCode: ExProgramError}
 	// minikube could not enable an addon, e.g. dashboard addon
 	InternalAddonEnable = Kind{ID: "MK_ADDON_ENABLE", ExitCode: ExProgramError}
+	// minikube could not enable an addon on a paused cluster
+	InternalAddonEnablePaused = Kind{ID: "MK_ADDON_ENABLE_PAUSED", ExitCode: ExProgramConflict}
+	// minikube could not disable an addon on a paused cluster
+	InternalAddonDisablePaused = Kind{ID: "MK_ADDON_DISABLE_PAUSED", ExitCode: ExProgramConflict}
+
 	// minikube failed to update internal configuration, such as the cached images config map
 	InternalAddConfig = Kind{ID: "MK_ADD_CONFIG", ExitCode: ExProgramError}
 	// minikube failed to create a cluster bootstrapper


### PR DESCRIPTION
fixes #15857

Tested in my local environment, when trying to enable `auto-pause` on a paused cluster, it gives following output and exit immediately:
```
$ minikube addons enable auto-pause
💡  auto-pause is an addon maintained by Google. For any concerns contact minikube on GitHub.
You can view the list of minikube maintainers at: https://github.com/kubernetes/minikube/blob/master/OWNERS
🤷  Can't enable addon on a paused cluster, please unpause the cluster firstly.
    ▪ auto-pause addon is an alpha feature and still in early development. Please file issues to help us make it better.
    ▪ https://github.com/kubernetes/minikube/labels/co/auto-pause

❌  Exiting due to MK_ADDON_ENABLE: run callbacks: running callbacks: [Can't enable addon on a paused cluster, please unpause the cluster firstly.]

```

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
