### PR TITLE
Add ability to create extra disks on qemu2 vms

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -196,7 +196,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().StringP(network, "", "", "network to run minikube with. Now it is used by docker/podman and KVM drivers. If left empty, minikube will create a new network.")
 	startCmd.Flags().StringVarP(&outputFormat, "output", "o", "text", "Format to print stdout in. Options include: [text,json]")
 	startCmd.Flags().StringP(trace, "", "", "Send trace events. Options include: [gcp]")
-	startCmd.Flags().Int(extraDisks, 0, "Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit and kvm2 drivers)")
+	startCmd.Flags().Int(extraDisks, 0, "Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit, kvm2, and qemu2 drivers)")
 	startCmd.Flags().Duration(certExpiration, constants.DefaultCertExpiration, "Duration until minikube certificate expiration, defaults to three years (26280h).")
 	startCmd.Flags().String(binaryMirror, "", "Location to fetch kubectl, kubelet, & kubeadm binaries from.")
 	startCmd.Flags().Bool(disableOptimizations, false, "If set, disables optimizations that are set for local Kubernetes. Including decreasing CoreDNS replicas from 2 to 1. Defaults to false.")
@@ -940,7 +940,7 @@ func interpretWaitFlag(cmd cobra.Command) map[string]bool {
 }
 
 func checkExtraDiskOptions(cmd *cobra.Command, driverName string) {
-	supportedDrivers := []string{driver.HyperKit, driver.KVM2}
+	supportedDrivers := []string{driver.HyperKit, driver.KVM2, driver.QEMU2}
 
 	if cmd.Flags().Changed(extraDisks) {
 		supported := false

--- a/pkg/drivers/common.go
+++ b/pkg/drivers/common.go
@@ -56,6 +56,35 @@ func ExtraDiskPath(d *drivers.BaseDriver, diskID int) string {
 	return filepath.Join(d.ResolveStorePath("."), file)
 }
 
+// CreateRawDisk creates a new raw disk image.
+//
+// Example usage:
+//
+//	path := ExtraDiskPath(baseDriver, diskID)
+//	err := CreateRawDisk(path, baseDriver.DiskSize)
+func CreateRawDisk(diskPath string, sizeMB int) error {
+	log.Infof("Creating raw disk image: %s of size %vMB", diskPath, sizeMB)
+
+	_, err := os.Stat(diskPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			// un-handle-able error stat-ing the disk file
+			return errors.Wrap(err, "stat")
+		}
+		// disk file does not exist; create it
+		file, err := os.OpenFile(diskPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+		if err != nil {
+			return errors.Wrap(err, "open")
+		}
+		defer file.Close()
+
+		if err := file.Truncate(util.ConvertMBToBytes(sizeMB)); err != nil {
+			return errors.Wrap(err, "truncate")
+		}
+	}
+	return nil
+}
+
 // CommonDriver is the common driver base class
 type CommonDriver struct{}
 

--- a/pkg/drivers/kvm/disks.go
+++ b/pkg/drivers/kvm/disks.go
@@ -21,13 +21,7 @@ package kvm
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"text/template"
-
-	"github.com/docker/machine/libmachine/log"
-	"github.com/pkg/errors"
-	"k8s.io/minikube/pkg/drivers"
-	"k8s.io/minikube/pkg/util"
 )
 
 // extraDisksTmpl ExtraDisks XML Template
@@ -57,24 +51,4 @@ func getExtraDiskXML(diskpath string, logicalName string) (string, error) {
 		return "", fmt.Errorf("couldn't generate extra disks XML: %v", err)
 	}
 	return extraDisksXML.String(), nil
-}
-
-// createExtraDisks creates the extra disk files
-func createExtraDisk(d *Driver, index int) (string, error) {
-	diskPath := drivers.ExtraDiskPath(d.BaseDriver, index)
-	log.Infof("Creating raw disk image: %s of size %v", diskPath, d.DiskSize)
-
-	if _, err := os.Stat(diskPath); os.IsNotExist(err) {
-		file, err := os.OpenFile(diskPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
-		if err != nil {
-			return "", errors.Wrap(err, "open")
-		}
-		defer file.Close()
-
-		if err := file.Truncate(util.ConvertMBToBytes(d.DiskSize)); err != nil {
-			return "", errors.Wrap(err, "truncate")
-		}
-	}
-	return diskPath, nil
-
 }

--- a/pkg/drivers/kvm/kvm.go
+++ b/pkg/drivers/kvm/kvm.go
@@ -365,8 +365,8 @@ func (d *Driver) Create() (err error) {
 		return errors.Wrap(err, "cannot create more than 20 extra disks")
 	}
 	for i := 0; i < d.ExtraDisks; i++ {
-		diskpath, err := createExtraDisk(d, i)
-		if err != nil {
+		diskpath := pkgdrivers.ExtraDiskPath(d.BaseDriver, i)
+		if err := pkgdrivers.CreateRawDisk(diskpath, d.DiskSize); err != nil {
 			return errors.Wrap(err, "creating extra disks")
 		}
 		// Starting the logical names for the extra disks from hdd as the cdrom device is set to hdc.

--- a/pkg/drivers/qemu/qemu.go
+++ b/pkg/drivers/qemu/qemu.go
@@ -83,6 +83,7 @@ type Driver struct {
 	MACAddress            string
 	SocketVMNetPath       string
 	SocketVMNetClientPath string
+	ExtraDisks            int
 }
 
 func (d *Driver) GetMachineName() string {
@@ -267,6 +268,16 @@ func (d *Driver) Create() error {
 		}
 	}
 
+	if d.ExtraDisks > 0 {
+		log.Info("Creating extra disk images...")
+		for i := 0; i < d.ExtraDisks; i++ {
+			path := pkgdrivers.ExtraDiskPath(d.BaseDriver, i)
+			if err := pkgdrivers.CreateRawDisk(path, d.DiskSize); err != nil {
+				return err
+			}
+		}
+	}
+
 	log.Info("Starting QEMU VM...")
 	return d.Start()
 }
@@ -440,6 +451,15 @@ func (d *Driver) Start() error {
 		startCmd = append(startCmd,
 			"-device",
 			"virtio-9p-pci,id=fs0,fsdev=fsdev0,mount_tag=config-2")
+	}
+
+	for i := 0; i < d.ExtraDisks; i++ {
+		// use a higher index for extra disks to reduce ID collision with current or future
+		// low-indexed devices (e.g., firmware, ISO CDROM, cloud config, and network device)
+		index := i + 10
+		startCmd = append(startCmd,
+			"-drive", fmt.Sprintf("file=%s,index=%d,media=disk,format=raw,if=virtio", pkgdrivers.ExtraDiskPath(d.BaseDriver, i), index),
+		)
 	}
 
 	if d.VirtioDrives {

--- a/pkg/minikube/registry/drvs/qemu2/qemu2.go
+++ b/pkg/minikube/registry/drvs/qemu2/qemu2.go
@@ -196,6 +196,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		MACAddress:            mac,
 		SocketVMNetPath:       cc.SocketVMnetPath,
 		SocketVMNetClientPath: cc.SocketVMnetClientPath,
+		ExtraDisks:            cc.ExtraDisks,
 	}, nil
 }
 

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -52,7 +52,7 @@ minikube start [flags]
                                           		The key should be '.' separated, and the first part before the dot is the component to apply the configuration to.
                                           		Valid components are: kubelet, kubeadm, apiserver, controller-manager, etcd, proxy, scheduler
                                           		Valid kubeadm parameters: ignore-preflight-errors, dry-run, kubeconfig, kubeconfig-dir, node-name, cri-socket, experimental-upload-certs, certificate-key, rootfs, skip-phases, pod-network-cidr
-      --extra-disks int                   Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit and kvm2 drivers)
+      --extra-disks int                   Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit, kvm2, and qemu2 drivers)
       --feature-gates string              A set of key=value pairs that describe feature gates for alpha/experimental features.
       --force                             Force minikube to perform possibly dangerous operations
       --force-systemd                     If set, force the container runtime to use systemd as cgroup manager. Defaults to false.

--- a/translations/de.json
+++ b/translations/de.json
@@ -456,6 +456,7 @@
 	"Noticed you have an activated podman-env on {{.driver_name}} driver in this terminal:": "Aktivives podman-env am Treiber {{.driver_name}} in diesem Terminal erkannt:",
 	"Number of CPUs allocated to the minikube VM": "Anzahl der CPUs, die der minikube-VM zugeordnet sind",
 	"Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit and kvm2 drivers)": "Anzahl der Extra-Disks, die erstellt und an die Minikube VM geängt werden (derzeit nur im hyperkit und kvm2 Treiber implementiert)",
+	"Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit, kvm2, and qemu2 drivers)": "",
 	"Number of lines back to go within the log": "Anzahl der Zeilen, die im Log zurückgegangen werden soll",
 	"OS release is {{.pretty_name}}": "Die Betriebssystem-Version ist {{.pretty_name}}",
 	"One of 'text', 'yaml' or 'json'.": "Entweder 'text', 'yaml' oder 'json'.",

--- a/translations/es.json
+++ b/translations/es.json
@@ -463,7 +463,7 @@
 	"Noticed you have an activated docker-env on {{.driver_name}} driver in this terminal:": "",
 	"Noticed you have an activated podman-env on {{.driver_name}} driver in this terminal:": "",
 	"Number of CPUs allocated to the minikube VM": "Número de CPU asignadas a la VM de minikube",
-	"Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit and kvm2 drivers)": "",
+	"Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit, kvm2, and qemu2 drivers)": "",
 	"Number of lines back to go within the log": "",
 	"OS release is {{.pretty_name}}": "",
 	"One of 'text', 'yaml' or 'json'.": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -445,6 +445,7 @@
 	"Noticed you have an activated docker-env on {{.driver_name}} driver in this terminal:": "Vous avez remarqué que vous avez un docker-env activé sur le pilote {{.driver_name}} dans ce terminal :",
 	"Noticed you have an activated podman-env on {{.driver_name}} driver in this terminal:": "Vous avez remarqué que vous avez un pilote podman-env activé sur {{.driver_name}} dans ce terminal :",
 	"Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit and kvm2 drivers)": "Nombre de disques supplémentaires créés et attachés à la machine virtuelle minikube (actuellement implémenté uniquement pour les pilotes hyperkit et kvm2)",
+	"Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit, kvm2, and qemu2 drivers)": "",
 	"Number of lines back to go within the log": "Nombre de lignes à remonter dans le journal",
 	"OS release is {{.pretty_name}}": "La version du système d'exploitation est {{.pretty_name}}",
 	"One of 'text', 'yaml' or 'json'.": "Un parmi 'text', 'yaml' ou 'json'.",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -431,6 +431,7 @@
 	"Noticed you have an activated docker-env on {{.driver_name}} driver in this terminal:": "通知: このターミナルでは、{{.driver_name}} ドライバーの docker-env が有効になっています:",
 	"Noticed you have an activated podman-env on {{.driver_name}} driver in this terminal:": "通知: このターミナルでは、{{.driver_name}} ドライバーの podman-env が有効になっています:",
 	"Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit and kvm2 drivers)": "作成して minikube VM に接続する追加ディスク数 (現在、hyperkit と kvm2 ドライバーでのみ実装されています)",
+	"Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit, kvm2, and qemu2 drivers)": "",
 	"Number of lines back to go within the log": "ログ中で遡る行数",
 	"OS release is {{.pretty_name}}": "OS リリースは {{.pretty_name}} です",
 	"One of 'text', 'yaml' or 'json'.": "'text'、'yaml'、'json' のいずれか。",

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -476,7 +476,7 @@
 	"None of the known repositories in your location are accessible. Using {{.image_repository_name}} as fallback.": "",
 	"Noticed you have an activated docker-env on {{.driver_name}} driver in this terminal:": "",
 	"Noticed you have an activated podman-env on {{.driver_name}} driver in this terminal:": "",
-	"Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit and kvm2 drivers)": "",
+	"Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit, kvm2, and qemu2 drivers)": "",
 	"Number of lines back to go within the log": "",
 	"OS release is {{.pretty_name}}": "",
 	"One of 'text', 'yaml' or 'json'.": "",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -468,7 +468,7 @@
 	"Number of CPUs allocated to Kubernetes.": "Liczba procesorów przypisana do Kubernetesa",
 	"Number of CPUs allocated to the minikube VM": "Liczba procesorów przypisana do maszyny wirtualnej minikube",
 	"Number of CPUs allocated to the minikube VM.": "Liczba procesorów przypisana do maszyny wirtualnej minikube",
-	"Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit and kvm2 drivers)": "",
+	"Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit, kvm2, and qemu2 drivers)": "",
 	"Number of lines back to go within the log": "",
 	"OS release is {{.pretty_name}}": "Wersja systemu operacyjnego to {{.pretty_name}}",
 	"One of 'text', 'yaml' or 'json'.": "",

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -426,7 +426,7 @@
 	"None of the known repositories in your location are accessible. Using {{.image_repository_name}} as fallback.": "",
 	"Noticed you have an activated docker-env on {{.driver_name}} driver in this terminal:": "",
 	"Noticed you have an activated podman-env on {{.driver_name}} driver in this terminal:": "",
-	"Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit and kvm2 drivers)": "",
+	"Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit, kvm2, and qemu2 drivers)": "",
 	"Number of lines back to go within the log": "",
 	"OS release is {{.pretty_name}}": "",
 	"One of 'text', 'yaml' or 'json'.": "",

--- a/translations/strings.txt
+++ b/translations/strings.txt
@@ -426,7 +426,7 @@
 	"None of the known repositories in your location are accessible. Using {{.image_repository_name}} as fallback.": "",
 	"Noticed you have an activated docker-env on {{.driver_name}} driver in this terminal:": "",
 	"Noticed you have an activated podman-env on {{.driver_name}} driver in this terminal:": "",
-	"Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit and kvm2 drivers)": "",
+	"Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit, kvm2, and qemu2 drivers)": "",
 	"Number of lines back to go within the log": "",
 	"OS release is {{.pretty_name}}": "",
 	"One of 'text', 'yaml' or 'json'.": "",

--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -543,7 +543,7 @@
 	"Noticed you have an activated docker-env on {{.driver_name}} driver in this terminal:": "",
 	"Noticed you have an activated podman-env on {{.driver_name}} driver in this terminal:": "",
 	"Number of CPUs allocated to the minikube VM": "分配给 minikube 虚拟机的 CPU 的数量",
-	"Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit and kvm2 drivers)": "",
+	"Number of extra disks created and attached to the minikube VM (currently only implemented for hyperkit, kvm2, and qemu2 drivers)": "",
 	"Number of lines back to go within the log": "",
 	"OS release is {{.pretty_name}}": "",
 	"One of 'text', 'yaml' or 'json'.": "",


### PR DESCRIPTION
Add the ability to create and attach extra disks to qemu2 vms.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
