### PR TITLE
Update --container-runtime docs to "crio" instead of "cri-o"

### DIFF
--- a/site/content/en/docs/handbook/config.md
+++ b/site/content/en/docs/handbook/config.md
@@ -98,7 +98,7 @@ minikube start --container-runtime=docker
 Options available are:
 
 * [containerd]({{<ref "/docs/runtimes/containerd">}})
-* [cri-o]({{<ref "/docs/runtimes/cri-o">}})
+* [crio]({{<ref "/docs/runtimes/cri-o">}})
 * [docker]({{<ref "/docs/runtimes/docker">}})
 
 See <https://kubernetes.io/docs/setup/production-environment/container-runtimes/>


### PR DESCRIPTION
Mapped by this [issue](https://github.com/kubernetes/minikube/issues/15246). If you provide "cri-o" as config runtime, minikube will validate podman related commands agains "crio" word.

fixes #15246 

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
