### PR TITLE
minikube service list: fix table format & hide URLs

### DIFF
--- a/cmd/minikube/cmd/service_list.go
+++ b/cmd/minikube/cmd/service_list.go
@@ -65,12 +65,13 @@ var serviceListCmd = &cobra.Command{
 }
 
 // updatePortsAndURLs sets the port name to "No node port" if a service has no URLs and removes the URLs
-// if the driver needs port forwarding as the user won't be able to hit the listed URLs which could confuse users
+// if the driver needs port forwarding as the user won't be able to hit the listed URLs which could confuse them
 func updatePortsAndURLs(serviceURLs service.URLs, co mustload.ClusterController) service.URLs {
+	needsPortForward := driver.NeedsPortForward(co.Config.Driver)
 	for i := range serviceURLs {
 		if len(serviceURLs[i].URLs) == 0 {
 			serviceURLs[i].PortNames = []string{"No node port"}
-		} else if driver.NeedsPortForward(co.Config.Driver) {
+		} else if needsPortForward {
 			serviceURLs[i].URLs = []string{}
 		}
 	}


### PR DESCRIPTION
## Fix Table
### Before:
```
|-------------|----------------|--------------|-----|
|  NAMESPACE  |      NAME      | TARGET PORT  | URL |
|-------------|----------------|--------------|-----|
| default     | hello-minikube |         8080 |     |
| default     | kubernetes     | No node port |
| kube-system | kube-dns       | No node port |
|-------------|----------------|--------------|-----|
```

### After:
```
|-------------|----------------|--------------|-----|
|  NAMESPACE  |      NAME      | TARGET PORT  | URL |
|-------------|----------------|--------------|-----|
| default     | hello-minikube |         8080 |     |
| default     | kubernetes     | No node port |     |
| kube-system | kube-dns       | No node port |     |
|-------------|----------------|--------------|-----|
```

## Improve URL hiding
### Before:
URLs were only hid on macOS for users using Docker Desktop

### After:
URLS are hidden on macOS, Linux, and Windows for users using Docker Desktop