### PR TITLE
Update kindnetd image and entrypoint

### DIFF
--- a/deploy/kicbase/entrypoint
+++ b/deploy/kicbase/entrypoint
@@ -451,7 +451,20 @@ enable_network_magic(){
 
   # now we can ensure that DNS is configured to use our IP
   cp /etc/resolv.conf /etc/resolv.conf.original
-  sed -e "s/${docker_embedded_dns_ip}/${docker_host_ip}/g" /etc/resolv.conf.original >/etc/resolv.conf
+  replaced="$(sed -e "s/${docker_embedded_dns_ip}/${docker_host_ip}/g" /etc/resolv.conf.original)"
+  if [[ "${KIND_DNS_SEARCH+x}" == "" ]]; then
+    # No DNS search set, just pass through as is
+    echo "$replaced" >/etc/resolv.conf
+  elif [[ -z "$KIND_DNS_SEARCH" ]]; then
+    # Empty search - remove all current search clauses
+    echo "$replaced" | grep -v "^search" >/etc/resolv.conf
+  else
+    # Search set - remove all current search clauses, and add the configured search
+    {
+      echo "search $KIND_DNS_SEARCH";
+      echo "$replaced" | grep -v "^search";
+    } >/etc/resolv.conf
+  fi
 
   local files_to_update=(
     /etc/kubernetes/manifests/etcd.yaml

--- a/pkg/minikube/bootstrapper/images/images.go
+++ b/pkg/minikube/bootstrapper/images/images.go
@@ -170,7 +170,7 @@ func KindNet(repo string) string {
 	if repo == "" {
 		repo = "kindest"
 	}
-	return path.Join(repo, "kindnetd:v20221004-44d545d1")
+	return path.Join(repo, "kindnetd:v20230227-15197099")
 }
 
 // all calico images are from https://docs.projectcalico.org/manifests/calico.yaml


### PR DESCRIPTION
kindnetd commits:
Bumped Go and distroless-iptables: https://github.com/kubernetes-sigs/kind/commit/151970993a333eca5eba8e73fc5c79991d019b1a