### PR TITLE
CI: Fix Windows Issues

### DIFF
--- a/hack/jenkins/common.ps1
+++ b/hack/jenkins/common.ps1
@@ -34,7 +34,6 @@ rm -Force testout*
 $env:SHORT_COMMIT=$env:COMMIT.substring(0, 7)
 $gcs_bucket="minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:ROOT_JOB_ID"
 $env:MINIKUBE_SUPPRESS_DOCKER_PERFORMANCE="true"
-$GoVersion = "1.20.1"
 
 # Docker's kubectl breaks things, and comes earlier in the path than the regular kubectl. So download the expected kubectl and replace Docker's version.
 $KubeVersion = (Invoke-WebRequest -Uri 'https://dl.k8s.io/release/stable.txt' -UseBasicParsing).Content

--- a/hack/jenkins/common.ps1
+++ b/hack/jenkins/common.ps1
@@ -27,6 +27,10 @@ function Write-GithubStatus {
 	Invoke-WebRequest -Uri "https://api.github.com/repos/kubernetes/minikube/statuses/$env:COMMIT" -Headers $headers -Body $JsonBody -ContentType "application/json" -Method Post -usebasicparsing
 }
 
+# cleanup possible leftovers from previous run
+rm -r -Force test_reports
+rm -Force testout*
+
 $env:SHORT_COMMIT=$env:COMMIT.substring(0, 7)
 $gcs_bucket="minikube-builds/logs/$env:MINIKUBE_LOCATION/$env:ROOT_JOB_ID"
 $env:MINIKUBE_SUPPRESS_DOCKER_PERFORMANCE="true"

--- a/hack/jenkins/common.ps1
+++ b/hack/jenkins/common.ps1
@@ -63,22 +63,13 @@ if ($driver -eq "docker") {
 	docker system prune -a --volumes -f
 }
 
-# Download Go
-$CurrentGo = go version
-if ($CurrentGo -NotLike "*$GoVersion*") {
-  (New-Object Net.WebClient).DownloadFile("https://go.dev/dl/go$GoVersion.windows-amd64.zip", "$env:TEMP\golang.zip")
-  Remove-Item "c:\Program Files\Go\*" -Recurse
-  Add-Type -Assembly "System.IO.Compression.Filesystem"
-  [System.IO.Compression.ZipFile]::ExtractToDirectory("$env:TEMP\golang.zip", "$env:TEMP\golang")
-  Copy-Item -Path "$env:TEMP\golang\go\*" -Destination "c:\Program Files\Go\" -Recurse
-  Remove-Item "$env:TEMP\golang" -Recurse
-  Remove-Item "$env:TEMP\golang.zip"
-}
+# install/update Go if required
+gsutil.cmd -m cp -r gs://minikube-builds/$env:MINIKUBE_LOCATION/installers/check_install_golang.ps1 out/
+./out/check_install_golang.ps1
 
 # Download gopogh and gotestsum
-(New-Object Net.WebClient).DownloadFile("https://github.com/medyagh/gopogh/releases/download/v0.13.0/gopogh.exe", "C:\Go\bin\gopogh.exe")
-(New-Object Net.WebClient).DownloadFile("https://github.com/gotestyourself/gotestsum/releases/download/v1.9.0/gotestsum_1.9.0_windows_amd64.tar.gz", "$env:TEMP\gotestsum.tar.gz")
-tar --directory "C:\Go\bin\" -xzvf "$env:TEMP\gotestsum.tar.gz" "gotestsum.exe"
+go install github.com/medyagh/gopogh/cmd/gopogh@v0.13.0
+go install gotest.tools/gotestsum@v1.9.0
 
 # Grab all the scripts we'll need for integration tests
 gsutil.cmd -m cp gs://minikube-builds/$env:MINIKUBE_LOCATION/minikube-windows-amd64.exe out/

--- a/hack/jenkins/installers/check_install_golang.ps1
+++ b/hack/jenkins/installers/check_install_golang.ps1
@@ -31,6 +31,7 @@ AddToPathIfMissing -pathToAdd "C:\Program Files\Go\bin" -scope "Machine"
 AddToPathIfMissing -pathToAdd "$HOME\go\bin" -scope "User"
 
 # Download Go
+$GoVersion = "1.20.1"
 $CurrentGo = go version
 if ((!$?) -or ($CurrentGo -NotLike "*$GoVersion*")) {
     (New-Object Net.WebClient).DownloadFile("https://go.dev/dl/go$GoVersion.windows-amd64.zip", "$env:TEMP\golang.zip")

--- a/hack/jenkins/installers/check_install_golang.ps1
+++ b/hack/jenkins/installers/check_install_golang.ps1
@@ -1,0 +1,43 @@
+# Copyright 2023 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function AddToPathIfMissing {
+    param (
+        [string]$pathToAdd,
+        [string]$scope
+    )
+    $Path = [Environment]::GetEnvironmentVariable("Path", $scope)
+    if ($Path -NotLike "*$pathToAdd*" ) {
+        $Path = $Path + ";" + $pathToAdd
+	[Environment]::SetEnvironmentVariable("Path", $Path, $scope)
+	# refresh the terminals Path
+	$env:Path = [Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [Environment]::GetEnvironmentVariable("Path", "User")
+    }
+}
+
+# ensure Go is in Path
+AddToPathIfMissing -pathToAdd "C:\Program Files\Go\bin" -scope "Machine"
+AddToPathIfMissing -pathToAdd "$HOME\go\bin" -scope "User"
+
+# Download Go
+$CurrentGo = go version
+if ((!$?) -or ($CurrentGo -NotLike "*$GoVersion*")) {
+    (New-Object Net.WebClient).DownloadFile("https://go.dev/dl/go$GoVersion.windows-amd64.zip", "$env:TEMP\golang.zip")
+    Remove-Item "c:\Program Files\Go\*" -Recurse
+    Add-Type -Assembly "System.IO.Compression.Filesystem"
+    [System.IO.Compression.ZipFile]::ExtractToDirectory("$env:TEMP\golang.zip", "$env:TEMP\golang")
+    Copy-Item -Path "$env:TEMP\golang\go\*" -Destination "c:\Program Files\Go\" -Recurse
+    Remove-Item "$env:TEMP\golang" -Recurse
+    Remove-Item "$env:TEMP\golang.zip"
+}

--- a/hack/update/golang_version/update_golang_version.go
+++ b/hack/update/golang_version/update_golang_version.go
@@ -169,7 +169,7 @@ var (
 				`VERSION_TO_INSTALL=.*`: `VERSION_TO_INSTALL={{.StableVersion}}`,
 			},
 		},
-		"hack/jenkins/common.ps1": {
+		"hack/jenkins/installers/check_install_golang.ps1": {
 			Replace: map[string]string{
 				`GoVersion = ".*"`: `GoVersion = "{{.StableVersion}}"`,
 			},

--- a/hack/update/gopogh_version/update_gopogh_version.go
+++ b/hack/update/gopogh_version/update_gopogh_version.go
@@ -49,7 +49,7 @@ var (
 		},
 		"hack/jenkins/common.ps1": {
 			Replace: map[string]string{
-				`(?U)https://github.com/medyagh/gopogh/releases/download/.*/gopogh`: `https://github.com/medyagh/gopogh/releases/download/{{.StableVersion}}/gopogh`,
+				`github.com/medyagh/gopogh/cmd/gopogh@.*`: `github.com/medyagh/gopogh/cmd/gopogh@{{.StableVersion}}`,
 			},
 		},
 		"hack/jenkins/common.sh": {

--- a/hack/update/gotestsum_version/update_gotestsum_version.go
+++ b/hack/update/gotestsum_version/update_gotestsum_version.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -35,12 +34,12 @@ var (
 	schema = map[string]update.Item{
 		"hack/jenkins/common.ps1": {
 			Replace: map[string]string{
-				`(?U)https://github.com/gotestyourself/gotestsum/releases/download/.*/gotestsum_.*_`: `https://github.com/gotestyourself/gotestsum/releases/download/v{{.StableVersion}}/gotestsum_{{.StableVersion}}_`,
+				`gotest.tools/gotestsum@.*`: `gotest.tools/gotestsum@{{.StableVersion}}`,
 			},
 		},
 		"hack/jenkins/installers/check_install_gotestsum.sh": {
 			Replace: map[string]string{
-				`gotest.tools/gotestsum@.*`: `gotest.tools/gotestsum@v{{.StableVersion}}`,
+				`gotest.tools/gotestsum@.*`: `gotest.tools/gotestsum@{{.StableVersion}}`,
 			},
 		},
 	}
@@ -61,7 +60,7 @@ func main() {
 	if err != nil || stable == "" {
 		klog.Fatalf("Unable to get gotestsum stable version: %v", err)
 	}
-	data := Data{StableVersion: strings.TrimPrefix(stable, "v")}
+	data := Data{StableVersion: stable}
 	klog.Infof("gotestsum stable version: %s", data.StableVersion)
 
 	update.Apply(schema, data)


### PR DESCRIPTION
## Issue 1
The Go install for Windows assumed that Go was already manually added to the `PATH`. But we should not make this assumption as it may not be true and this will reduce manual work if new machines are added in the future. Added a function `AddToPathIfMissing` that accepts a path and adds it to `PATH` if it doesn't exist.

## Issue 2
If Go isn't installed on the machine, it wouldn't get installed because we only checked to see if the current version matched the existing version. If Go isn't installed the result of `go version` was invalid and the check would be skipped, resulting in Go not being installed and the test failing. Updated the logic so installs Go if Go isn't present or the version doesn't match what's expected.

## Issue 3
We can run into a scenario where test artifacts from a previous run still exist on the machine. This can cause incorrect reporting as if the test fails in a way that doesn't overwrite the existing artifacts, they will be used for determining the outcome of the current test.

## Improvement
gopogh and gotestsum were being installed by downloading their artifacts and untaring them. These are both available via `go install` so changed to use this method. This results in cleaner commands and `go install` won't redownload if that version is already installed, saving time.
