### PR TITLE
tests: Split up ServiceCmd test into sub-tests and fix on Windows

### DIFF
--- a/site/content/en/docs/contrib/tests.en.md
+++ b/site/content/en/docs/contrib/tests.en.md
@@ -293,17 +293,23 @@ Steps:
 #### validateServiceCmd
 asserts basic "service" command functionality
 
-Steps:
-- Create a new `k8s.gcr.io/echoserver` deployment
-- Run `minikube service list` to make sure the newly created service is correctly listed in the output
-- Run `minikube service` with `--https --url` to make sure the HTTPS endpoint URL of the service is printed
-- Run `minikube service` with `--url --format={{.IP}}` to make sure the IP address of the service is printed
-- Run `minikube service` with a regular `--url` to make sure the HTTP endpoint URL of the service is printed
+#### validateServiceCmdDeployApp
+Create a new `k8s.gcr.io/echoserver` deployment
+
+#### validateServiceCmdList
+Run `minikube service list` to make sure the newly created service is correctly listed in the output
 
 #### validateServiceCmdJSON
+Run `minikube service list -o JSON` and make sure the services are correctly listed as JSON output
 
-Steps:
-- Run `minikube service list -o JSON` and make sure the services are correctly listed as JSON output
+#### validateServiceCmdHTTPS
+Run `minikube service` with `--https --url` to make sure the HTTPS endpoint URL of the service is printed
+
+#### validateServiceCmdFormat
+Run `minikube service` with `--url --format={{.IP}}` to make sure the IP address of the service is printed
+
+#### validateServiceCmdURL
+Run `minikube service` with a regular `--url` to make sure the HTTP endpoint URL of the service is printed
 
 #### validateServiceCmdConnect
 

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -1539,16 +1540,10 @@ func validateServiceCmdFormat(ctx context.Context, t *testing.T, profile string)
 			t.Errorf("failed to get service url with custom format. args %q: %v", rr.Command(), err)
 		}
 
-		endpoint := strings.TrimSpace(rr.Stdout.String())
-		t.Logf("found endpoint for hello-node: %s", endpoint)
+		stringIP := strings.TrimSpace(rr.Stdout.String())
 
-		u, err := url.Parse(endpoint)
-		if err != nil {
-			t.Fatalf("failed to parse %q: %v", endpoint, err)
-		}
-
-		if strings.TrimSpace(rr.Stdout.String()) != u.Hostname() {
-			t.Errorf("expected 'service --format={{.IP}}' output to be -%q- but got *%q* . args %q.", u.Hostname(), rr.Stdout.String(), rr.Command())
+		if ip := net.ParseIP(stringIP); ip == nil {
+			t.Fatalf("%q is not a valid IP", stringIP)
 		}
 	})
 }

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -1579,7 +1579,7 @@ func validateServiceCmdURL(ctx context.Context, t *testing.T, profile string) {
 }
 
 // isUnexpectedServiceError is used to prevent failing ServiceCmd tests on Docker Desktop due to DeadlineExceeded errors.
-// Due to networking contraints Docker Desktop requires creating an SSH tunnel to connect to a service. This command has
+// Due to networking constraints Docker Desktop requires creating an SSH tunnel to connect to a service. This command has
 // to be left running to keep the SSH tunnel connected, so for the ServiceCmd tests we set a timeout context so we can
 // check the output and then the command is terminated, otherwise it would keep runnning forever. So if using Docker
 // Desktop and the DeadlineExceeded, consider it an expected error.

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -1501,7 +1501,7 @@ func validateServiceCmdJSON(ctx context.Context, t *testing.T, profile string) {
 // validateServiceCmdHTTPS Run `minikube service` with `--https --url` to make sure the HTTPS endpoint URL of the service is printed
 func validateServiceCmdHTTPS(ctx context.Context, t *testing.T, profile string) {
 	t.Run("HTTPS", func(t *testing.T) {
-		cmdCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		cmdCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 		defer cancel()
 		cmd := exec.CommandContext(cmdCtx, Target(), "-p", profile, "service", "--namespace=default", "--https", "--url", "hello-node")
 		rr, err := Run(t, cmd)
@@ -1532,7 +1532,7 @@ func validateServiceCmdHTTPS(ctx context.Context, t *testing.T, profile string) 
 // validateServiceCmdFormat Run `minikube service` with `--url --format={{.IP}}` to make sure the IP address of the service is printed
 func validateServiceCmdFormat(ctx context.Context, t *testing.T, profile string) {
 	t.Run("Format", func(t *testing.T) {
-		cmdCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		cmdCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 		defer cancel()
 		cmd := exec.CommandContext(cmdCtx, Target(), "-p", profile, "service", "hello-node", "--url", "--format={{.IP}}")
 		rr, err := Run(t, cmd)
@@ -1551,7 +1551,7 @@ func validateServiceCmdFormat(ctx context.Context, t *testing.T, profile string)
 // validateServiceCmdURL Run `minikube service` with a regular `--url` to make sure the HTTP endpoint URL of the service is printed
 func validateServiceCmdURL(ctx context.Context, t *testing.T, profile string) {
 	t.Run("URL", func(t *testing.T) {
-		cmdCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		cmdCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 		defer cancel()
 		cmd := exec.CommandContext(cmdCtx, Target(), "-p", profile, "service", "hello-node", "--url")
 		rr, err := Run(t, cmd)


### PR DESCRIPTION
## Fix 1
`TestFunctional/parallel/ServiceCmd` recently had a child test added to it (`ServiceJSONOutput`), making `ServiceCmd` a parent. This causes a problem in regard to `gopogh` as `gopogh` ignores test parents so if a child test fails it only marks the child as failed instead of all the parents as well (one test failure vs one + # of parent tests). However, `ServiceCmd` itself has lots of test logic in it itself but these test failures will always be hidden to how `gopogh` works. So to solve this I moved all the testing in `ServiceCmd` into sub-tests. Now `ServiceCmd` is just a caller for a bunch of child tests, now test failures will show as expected.

## Fix 2
`ServiceCmd` had a 100% failure rate on Windows. This was related to the networking constraints Docker Desktop has requiring creating an SSH tunnel to connect to a service. This command has to be left running to keep the SSH tunnel connected so the command keeps running until the user kills it. This causes an issue in testing as we can't keep a command running forever so we need a way to stop it. The existing way to solve this was an odd custom implementation of `context` in the form of the function `killContext`. After the provided timeout it would call `Process.Signal(os.Interrupt)` to kill the command, while this worked on macOS, on Windows it would produce the error `Failed to sent interrupt to proc not supported by windows` and would fail the test. To solve this I simply used `WithTimeout` to create a timeout for the command and let Go handle killing the process.