### PR TITLE
CI: remove old gopogh & gotestsum installs

### DIFF
--- a/hack/jenkins/common.ps1
+++ b/hack/jenkins/common.ps1
@@ -73,6 +73,10 @@ gsutil.cmd -m cp -r gs://minikube-builds/$env:MINIKUBE_LOCATION/installers/check
 # Download gopogh and gotestsum
 go install github.com/medyagh/gopogh/cmd/gopogh@v0.13.0
 go install gotest.tools/gotestsum@v1.9.0
+# temporary: remove the old install of gopogh & gotestsum as it's taking priority over our current install, preventing updating
+if (Test-Path "C:\Go") {
+    Remove-Item "C:\Go" -Recurse -Force
+}
 
 # Grab all the scripts we'll need for integration tests
 gsutil.cmd -m cp gs://minikube-builds/$env:MINIKUBE_LOCATION/minikube-windows-amd64.exe out/

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -429,6 +429,8 @@ fi
 
 echo ">> Installing gopogh"
 go install github.com/medyagh/gopogh/cmd/gopogh@v0.13.0
+# temporary: remove the old install of gopogh as it's taking priority over our current install, preventing updating
+sudo rm -f /usr/local/bin/gopogh
 
 
 echo ">> Running gopogh"


### PR DESCRIPTION
In https://github.com/kubernetes/minikube/pull/15955 & https://github.com/kubernetes/minikube/pull/15954 I updated our CI scripts to install gopogh & gotestsum via `go install`. The problem is that the previously installed locations have priority over the new ones so if we were to update the versions the old ones would continue to be called and the update wouldn't take effect. This PR removes the previously installed locations so the new install locations will be used, this can be removed once these scripts have run on all machines.