### PR TITLE
Fix image related bugs when enabling addons

### DIFF
--- a/cmd/minikube/cmd/config/enable.go
+++ b/cmd/minikube/cmd/config/enable.go
@@ -66,8 +66,12 @@ You can view the list of minikube maintainers at: https://github.com/kubernetes/
 				}
 			}
 		}
-		viper.Set(config.AddonImages, images)
-		viper.Set(config.AddonRegistries, registries)
+		if images != "" {
+			viper.Set(config.AddonImages, images)
+		}
+		if registries != "" {
+			viper.Set(config.AddonRegistries, registries)
+		}
 		err := addons.SetAndSave(ClusterFlagValue(), addon, "true")
 		if err != nil && !errors.Is(err, addons.ErrSkipThisAddon) {
 			exit.Error(reason.InternalAddonEnable, "enable failed", err)

--- a/pkg/minikube/assets/addons_test.go
+++ b/pkg/minikube/assets/addons_test.go
@@ -18,10 +18,13 @@ package assets
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/tests"
 )
 
 // mapsEqual returns true if and only if `a` contains all the same pairs as `b`.
@@ -152,6 +155,18 @@ func TestOverrideDefautls(t *testing.T) {
 func TestSelectAndPersistImages(t *testing.T) {
 	gcpAuth := Addons["gcp-auth"]
 	gcpAuthImages := gcpAuth.Images
+
+	// this test will write to ~/.minikube/profiles/minikube/config.json so need to create the file
+	home := tests.MakeTempDir(t)
+	profilePath := filepath.Join(home, "profiles", "minikube")
+	if err := os.MkdirAll(profilePath, 0777); err != nil {
+		t.Fatalf("failed to create profile directory: %v", err)
+	}
+	f, err := os.Create(filepath.Join(profilePath, "config.json"))
+	if err != nil {
+		t.Fatalf("failed to create config file: %v", err)
+	}
+	defer f.Close()
 
 	type expected struct {
 		numImages           int

--- a/pkg/minikube/assets/addons_test.go
+++ b/pkg/minikube/assets/addons_test.go
@@ -16,7 +16,13 @@ limitations under the License.
 
 package assets
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+
+	"github.com/spf13/viper"
+	"k8s.io/minikube/pkg/minikube/config"
+)
 
 // mapsEqual returns true if and only if `a` contains all the same pairs as `b`.
 func mapsEqual(a, b map[string]string) bool {
@@ -140,5 +146,215 @@ func TestOverrideDefautls(t *testing.T) {
 		if actualMap := overrideDefaults(test.defaultMap, test.overrideMap); !mapsEqual(actualMap, test.expectedMap) {
 			t.Errorf("Override defaults (defaults=%v, overrides=%v) differs from expected map: Actual: %v Expected: %v", test.defaultMap, test.overrideMap, actualMap, test.expectedMap)
 		}
+	}
+}
+
+func TestSelectAndPersistImages(t *testing.T) {
+	gcpAuth := Addons["gcp-auth"]
+	gcpAuthImages := gcpAuth.Images
+
+	type expected struct {
+		numImages           int
+		numRegistries       int
+		numCustomImages     int
+		numCustomRegistries int
+	}
+
+	test := func(t *testing.T, cc *config.ClusterConfig, e expected) (images, registries map[string]string) {
+		images, registries, err := SelectAndPersistImages(gcpAuth, cc)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(images) != e.numImages {
+			t.Errorf("expected %d images but got %v", e.numImages, images)
+		}
+		if len(registries) != e.numRegistries {
+			t.Errorf("expected %d registries but got %v", e.numRegistries, registries)
+		}
+		if len(cc.CustomAddonImages) != e.numCustomImages {
+			t.Errorf("expected %d CustomAddonImages in config but got %+v", e.numCustomImages, cc.CustomAddonImages)
+		}
+		if len(cc.CustomAddonRegistries) != e.numCustomRegistries {
+			t.Errorf("expected %d CustomAddonRegistries in config but got %+v", e.numCustomRegistries, cc.CustomAddonRegistries)
+		}
+		return images, registries
+	}
+
+	t.Run("NoCustomImage", func(t *testing.T) {
+		cc := &config.ClusterConfig{}
+		e := expected{numImages: 2}
+		images, _ := test(t, cc, e)
+		checkMatches(t, "KubeWebhookCertgen", images, gcpAuthImages)
+		checkMatches(t, "GCPAuthWebhook", images, gcpAuthImages)
+	})
+
+	t.Run("ExistingCustomImage", func(t *testing.T) {
+		cc := &config.ClusterConfig{
+			CustomAddonImages: map[string]string{
+				"GCPAuthWebhook": "test123",
+			},
+		}
+		e := expected{numImages: 2, numCustomImages: 1}
+		images, _ := test(t, cc, e)
+		checkMatches(t, "KubeWebhookCertgen", images, gcpAuthImages)
+		checkMatches(t, "GCPAuthWebhook", images, cc.CustomAddonImages)
+	})
+
+	t.Run("NewCustomImage", func(t *testing.T) {
+		cc := &config.ClusterConfig{}
+		e := expected{numImages: 2, numCustomImages: 1}
+		addonImages := setAddonImages("GCPAuthWebhook", "test123")
+		defer viper.Reset()
+		images, _ := test(t, cc, e)
+		checkMatches(t, "KubeWebhookCertgen", images, gcpAuthImages)
+		checkMatches(t, "GCPAuthWebhook", images, addonImages)
+	})
+
+	t.Run("NewAndExistingCustomImages", func(t *testing.T) {
+		cc := &config.ClusterConfig{
+			CustomAddonImages: map[string]string{
+				"GCPAuthWebhook": "test123",
+			},
+		}
+		e := expected{numImages: 2, numCustomImages: 2}
+		addonImages := setAddonImages("KubeWebhookCertgen", "test456")
+		defer viper.Reset()
+		images, _ := test(t, cc, e)
+		checkMatches(t, "KubeWebhookCertgen", images, addonImages)
+		checkMatches(t, "GCPAuthWebhook", images, cc.CustomAddonImages)
+	})
+
+	t.Run("NewOverwritesExistingCustomImage", func(t *testing.T) {
+		cc := &config.ClusterConfig{
+			CustomAddonImages: map[string]string{
+				"GCPAuthWebhook": "test123",
+			},
+		}
+		e := expected{numImages: 2, numCustomImages: 1}
+		addonImages := setAddonImages("GCPAuthWebhook", "test456")
+		defer viper.Reset()
+		images, _ := test(t, cc, e)
+		checkMatches(t, "KubeWebhookCertgen", images, gcpAuthImages)
+		checkMatches(t, "GCPAuthWebhook", images, addonImages)
+	})
+
+	t.Run("NewUnrelatedCustomImageWithExistingCustomImage", func(t *testing.T) {
+		cc := &config.ClusterConfig{
+			CustomAddonImages: map[string]string{
+				"GCPAuthWebhook": "test123",
+			},
+		}
+		e := expected{numImages: 2, numCustomImages: 1}
+		setAddonImages("IngressDNS", "test456")
+		defer viper.Reset()
+		images, _ := test(t, cc, e)
+		checkMatches(t, "KubeWebhookCertgen", images, gcpAuthImages)
+		checkMatches(t, "GCPAuthWebhook", images, cc.CustomAddonImages)
+	})
+
+	t.Run("NewCustomImageWithExistingUnrelatedCustomImage", func(t *testing.T) {
+		cc := &config.ClusterConfig{
+			CustomAddonImages: map[string]string{
+				"IngressDNS": "test123",
+			},
+		}
+		e := expected{numImages: 2, numCustomImages: 2}
+		addonImages := setAddonImages("GCPAuthWebhook", "test456")
+		defer viper.Reset()
+		images, _ := test(t, cc, e)
+		checkMatches(t, "KubeWebhookCertgen", images, gcpAuthImages)
+		checkMatches(t, "GCPAuthWebhook", images, addonImages)
+	})
+
+	t.Run("ExistingCustomRegistry", func(t *testing.T) {
+		cc := &config.ClusterConfig{
+			CustomAddonRegistries: map[string]string{
+				"GCPAuthWebhook": "test123",
+			},
+		}
+		e := expected{numImages: 2, numRegistries: 1, numCustomRegistries: 1}
+		_, registries := test(t, cc, e)
+		checkMatches(t, "GCPAuthWebhook", registries, cc.CustomAddonRegistries)
+	})
+
+	t.Run("NewCustomRegistry", func(t *testing.T) {
+		cc := &config.ClusterConfig{}
+		e := expected{numImages: 2, numRegistries: 1, numCustomRegistries: 1}
+		addonRegistries := setAddonRegistries("GCPAuthWebhook", "test123")
+		defer viper.Reset()
+		_, registries := test(t, cc, e)
+		checkMatches(t, "GCPAuthWebhook", registries, addonRegistries)
+	})
+
+	t.Run("NewAndExistingCustomRegistries", func(t *testing.T) {
+		cc := &config.ClusterConfig{
+			CustomAddonRegistries: map[string]string{
+				"GCPAuthWebhook": "test123",
+			},
+		}
+		e := expected{numImages: 2, numRegistries: 2, numCustomRegistries: 2}
+		addonRegistries := setAddonRegistries("KubeWebhookCertgen", "test456")
+		defer viper.Reset()
+		_, registries := test(t, cc, e)
+		checkMatches(t, "GCPAuthWebhook", registries, cc.CustomAddonRegistries)
+		checkMatches(t, "KubeWebhookCertgen", registries, addonRegistries)
+	})
+
+	t.Run("NewOverwritesExistingCustomRegistry", func(t *testing.T) {
+		cc := &config.ClusterConfig{
+			CustomAddonRegistries: map[string]string{
+				"GCPAuthWebhook": "test123",
+			},
+		}
+		e := expected{numImages: 2, numRegistries: 1, numCustomRegistries: 1}
+		addonRegistries := setAddonRegistries("GCPAuthWebhook", "test456")
+		defer viper.Reset()
+		_, registries := test(t, cc, e)
+		checkMatches(t, "GCPAuthWebhook", registries, addonRegistries)
+	})
+
+	t.Run("NewUnrelatedCustomRegistryWithExistingCustomRegistry", func(t *testing.T) {
+		cc := &config.ClusterConfig{
+			CustomAddonRegistries: map[string]string{
+				"GCPAuthWebhook": "test123",
+			},
+		}
+		e := expected{numImages: 2, numRegistries: 1, numCustomRegistries: 1}
+		setAddonRegistries("IngressDNS", "test456")
+		defer viper.Reset()
+		_, registries := test(t, cc, e)
+		checkMatches(t, "GCPAuthWebhook", registries, cc.CustomAddonRegistries)
+	})
+
+	t.Run("NewCustomRegistryWithExistingUnrelatedCustomRegistry", func(t *testing.T) {
+		cc := &config.ClusterConfig{
+			CustomAddonRegistries: map[string]string{
+				"IngressDNS": "test123",
+			},
+		}
+		e := expected{numImages: 2, numRegistries: 1, numCustomRegistries: 2}
+		addonRegistries := setAddonRegistries("GCPAuthWebhook", "test456")
+		defer viper.Reset()
+		_, registries := test(t, cc, e)
+		checkMatches(t, "GCPAuthWebhook", registries, addonRegistries)
+	})
+}
+
+func setAddonImages(k, v string) map[string]string {
+	return setFlag(config.AddonImages, k, v)
+}
+
+func setAddonRegistries(k, v string) map[string]string {
+	return setFlag(config.AddonRegistries, k, v)
+}
+
+func setFlag(name, k, v string) map[string]string {
+	viper.Set(name, fmt.Sprintf("%s=%s", k, v))
+	return map[string]string{k: v}
+}
+
+func checkMatches(t *testing.T, name string, got, expected map[string]string) {
+	if expected[name] != got[name] {
+		t.Errorf("expected %q to be %q, but got %q", name, expected[name], got[name])
 	}
 }


### PR DESCRIPTION
## Bug 1
In `SelectAndPersistImages` we have `if viper.IsSet(config.AddonImages)` and `if viper.IsSet(config.AddonRegistries)`. However, in cmd we have `viper.Set(config.AddonImages, images)` and `viper.Set(config.AddonRegistries, registries)` so `viper.IsSet` is always true and more advanced logic is being performed when not needed. To resolve this I wrapped the `viper.Set` lines with `if <var> != "" {` as it doesn't make sense to set the variable if it's empty.

## Bug 2
In `SelectAndPersistImages` if an addon image was passed via flag but the image isn't used in the addon we're enabling we would output the message `Ignoring unknown custom image {{.name}}` but we didn't strip it from the map, so it was actually getting saved to the cluster config even though we said we were ignoring it. Resolved this by removing the image from the map if we encounter this.

## Bug 3
Saved custom images were being ignored if a different image was being passed via flag. Example, image1 one is saved to the cluster config already, addon is enabled and image2 is passed a custom image via flag, image1 custom image will be ignored and and will use default image while image2 use the custom image as expected. This was resolved by replacing `images = overrideDefaults(addonDefaultImages, newImages)` with `images = overrideDefaults(images, newImages)`.

## Bug 4
Existing custom registries saved to the cluster config were getting stripped when a new custom registry was passed via flag while `SelectAndPersistImages` was returning the existing custom registry. Resolved this so now the existing custom registry is not being stripped and what's being returned from `SelectAndPersistImages` matches what is stored in the cluster config.

Also added in-depth tests for `SelectAndPersistImages`.