### PR TITLE
wait for pods to get IPs

### DIFF
--- a/test/integration/multinode_test.go
+++ b/test/integration/multinode_test.go
@@ -28,9 +28,11 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"k8s.io/minikube/cmd/minikube/cmd"
 	"k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/util/retry"
 )
 
 // TestMultiNode tests all multi node cluster functionality
@@ -487,20 +489,31 @@ func validateDeployAppToMultiNode(ctx context.Context, t *testing.T, profile str
 	}
 
 	// resolve Pod IPs
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), "kubectl", "-p", profile, "--", "get", "pods", "-o", "jsonpath='{.items[*].status.podIP}'"))
-	if err != nil {
-		t.Errorf("failed to retrieve Pod IPs")
+	resolvePodIPs := func() error {
+		rr, err := Run(t, exec.CommandContext(ctx, Target(), "kubectl", "-p", profile, "--", "get", "pods", "-o", "jsonpath='{.items[*].status.podIP}'"))
+		if err != nil {
+			err := fmt.Errorf("failed to retrieve Pod IPs (may be temporary): %v", err)
+			t.Logf(err.Error())
+			return err
+		}
+		podIPs := strings.Split(strings.Trim(rr.Stdout.String(), "'"), " ")
+		if len(podIPs) != 2 {
+			err := fmt.Errorf("expected 2 Pod IPs but got %d (may be temporary), output: %q", len(podIPs), rr.Output())
+			t.Logf(err.Error())
+			return err
+		} else if podIPs[0] == podIPs[1] {
+			err := fmt.Errorf("expected 2 different pod IPs but got %s and %s (may be temporary), output: %q", podIPs[0], podIPs[1], rr.Output())
+			t.Logf(err.Error())
+			return err
+		}
+		return nil
 	}
-	podIPs := strings.Split(strings.Trim(rr.Stdout.String(), "'"), " ")
-	if len(podIPs) != 2 {
-		t.Errorf("expected 2 Pod IPs but got %d, output: %q", len(podIPs), rr.Output())
-	} else if podIPs[0] == podIPs[1] {
-		t.Errorf("expected 2 different pod IPs but got %s and %s. output: %q", podIPs[0], podIPs[1], rr.Output())
-
+	if err := retry.Expo(resolvePodIPs, 1*time.Second, Seconds(120)); err != nil {
+		t.Errorf("failed to resolve pod IPs: %v", err)
 	}
 
 	// get Pod names
-	rr, err = Run(t, exec.CommandContext(ctx, Target(), "kubectl", "-p", profile, "--", "get", "pods", "-o", "jsonpath='{.items[*].metadata.name}'"))
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), "kubectl", "-p", profile, "--", "get", "pods", "-o", "jsonpath='{.items[*].metadata.name}'"))
 	if err != nil {
 		t.Errorf("failed get Pod names")
 	}


### PR DESCRIPTION
fixes #15870

i could replicate the original issue with --driver=docker and --container-runtime=docker on both linux and macos and observed that the busybox pod on the cp node gets ip after ~5sec while the other busybox pod takes significantly longer but eventually (after ~40sec) gets ip on the second node

with this pr we retry until both pods get IPs (max 120sec) so that the multinode tests don't fail because of this delay

the below screenshot from linux (similarly on macos) shows that there's a delay between two pods getting ip - marked with a red rectangle

on a side note, but i think still interesting, both pods were marked as having `Ready` condition while only one had ip, which probably should not happen (based on the [Pod Lifecycle](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions)), but that's potentially a separate topic - marked with amber rectangle on the screenshot, which is the reason why we cannot wait for the pods to become eg `Ready` but retry instead
![linux](https://user-images.githubusercontent.com/6320846/223855009-fa277e91-b2ed-40ff-988b-886d00a4fb65.png)