### PR TITLE
test: Fix having to change test byte size on new addon

### DIFF
--- a/cmd/minikube/cmd/config/addons_list_test.go
+++ b/cmd/minikube/cmd/config/addons_list_test.go
@@ -77,7 +77,6 @@ func TestAddonsList(t *testing.T) {
 			Ambassador *interface{} `json:"ambassador"`
 		}
 
-		b := make([]byte, 590)
 		r, w, err := os.Pipe()
 		if err != nil {
 			t.Fatalf("failed to create pipe: %v", err)
@@ -93,6 +92,11 @@ func TestAddonsList(t *testing.T) {
 		if err := w.Close(); err != nil {
 			t.Fatalf("failed to close pipe: %v", err)
 		}
+		info, err := r.Stat()
+		if err != nil {
+			t.Fatalf("failed to stat file: %v", err)
+		}
+		b := make([]byte, info.Size())
 		if _, err := r.Read(b); err != nil {
 			t.Fatalf("failed to read bytes: %v", err)
 		}

--- a/cmd/minikube/cmd/config/addons_list_test.go
+++ b/cmd/minikube/cmd/config/addons_list_test.go
@@ -92,17 +92,10 @@ func TestAddonsList(t *testing.T) {
 		if err := w.Close(); err != nil {
 			t.Fatalf("failed to close pipe: %v", err)
 		}
-		info, err := r.Stat()
-		if err != nil {
-			t.Fatalf("failed to stat file: %v", err)
-		}
-		b := make([]byte, info.Size())
-		if _, err := r.Read(b); err != nil {
-			t.Fatalf("failed to read bytes: %v", err)
-		}
 		got := addons{}
-		if err := json.Unmarshal(b, &got); err != nil {
-			t.Fatalf("failed to unmarshal output; output: %q; err: %v", string(b), err)
+		dec := json.NewDecoder(r)
+		if err := dec.Decode(&got); err != nil {
+			t.Fatalf("failed to decode: %v", err)
 		}
 		if got.Ambassador == nil {
 			t.Errorf("expected `ambassador` field to not be nil, but was")


### PR DESCRIPTION
Every time someone would add a new test this test fails as we make the byte slice just big enough to fit the JSON, but a new addon increases this size of the JSON and the test fails.

Changed this to use a JSON decoder which has a cleaner implementation and prevents unnecessary changes and test failures.