### PR TITLE
feat: implement a prototype for sudominikube

### DIFF
--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -45,7 +45,7 @@ import (
 )
 
 var (
-	dirs = [...]string{
+	Dirs = [...]string{
 		localpath.MiniPath(),
 		localpath.MakeMiniPath("certs"),
 		localpath.MakeMiniPath("machines"),
@@ -64,7 +64,7 @@ var RootCmd = &cobra.Command{
 	Short: "minikube quickly sets up a local Kubernetes cluster",
 	Long:  `minikube provisions and manages local Kubernetes clusters optimized for development workflows.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		for _, path := range dirs {
+		for _, path := range Dirs {
 			if err := os.MkdirAll(path, 0777); err != nil {
 				exit.Error(reason.HostHomeMkdir, "Error creating minikube directory", err)
 			}
@@ -147,7 +147,7 @@ func Execute() {
 			f.Usage = translate.T(f.Usage)
 		})
 
-		c.SetUsageTemplate(usageTemplate())
+		c.SetUsageTemplate(UsageTemplate())
 	}
 	RootCmd.Short = translate.T(RootCmd.Short)
 	RootCmd.Long = translate.T(RootCmd.Long)
@@ -176,10 +176,10 @@ func Execute() {
 	}
 }
 
-// usageTemplate just calls translate.T on the default usage template
+// UsageTemplate just calls translate.T on the default usage template
 // explicitly using the raw string instead of calling c.UsageTemplate()
 // so the extractor can find this monstrosity of a string
-func usageTemplate() string {
+func UsageTemplate() string {
 	return fmt.Sprintf(`%s:{{if .Runnable}}
   {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
   {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
@@ -260,7 +260,7 @@ func init() {
 			Message: translate.T("Networking and Connectivity Commands:"),
 			Commands: []*cobra.Command{
 				serviceCmd,
-				tunnelCmd,
+				TunnelCmd,
 			},
 		},
 		{
@@ -291,6 +291,7 @@ func init() {
 	// Ungrouped commands will show up in the "Other Commands" section
 	RootCmd.AddCommand(completionCmd)
 	RootCmd.AddCommand(licenseCmd)
+	RootCmd.AddCommand(sudominikubeCmd)
 	templates.ActsAsRootCommand(RootCmd, []string{"options"}, groups...)
 
 	if err := viper.BindPFlags(RootCmd.PersistentFlags()); err != nil {
@@ -298,11 +299,11 @@ func init() {
 	}
 
 	translate.DetermineLocale()
-	cobra.OnInitialize(initConfig)
+	cobra.OnInitialize(InitConfig)
 }
 
-// initConfig reads in config file and ENV variables if set.
-func initConfig() {
+// InitConfig reads in config file and ENV variables if set.
+func InitConfig() {
 	configPath := localpath.ConfigFile()
 	viper.SetConfigFile(configPath)
 	viper.SetConfigType("json")

--- a/cmd/minikube/cmd/root_test.go
+++ b/cmd/minikube/cmd/root_test.go
@@ -38,7 +38,7 @@ func TestPreRunDirectories(t *testing.T) {
 
 	runCommand(RootCmd.PersistentPreRun)
 
-	for _, dir := range dirs {
+	for _, dir := range Dirs {
 		_, err := os.Stat(dir)
 		if os.IsNotExist(err) {
 			t.Fatalf("Directory %s does not exist.", dir)

--- a/cmd/minikube/cmd/sudominikube.go
+++ b/cmd/minikube/cmd/sudominikube.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"os"
+	"runtime"
+
+	"github.com/spf13/cobra"
+	"k8s.io/minikube/pkg/minikube/detect"
+	"k8s.io/minikube/pkg/minikube/download"
+	"k8s.io/minikube/pkg/minikube/exit"
+	"k8s.io/minikube/pkg/minikube/reason"
+	"k8s.io/minikube/pkg/minikube/sudominikube"
+)
+
+var sudominikubeCmd = &cobra.Command{
+	Use:   "sudominikube",
+	Short: "commands related with installation of sudominikube",
+	Long:  "commands related with installation of sudominikube",
+}
+
+var (
+	downloadPath string
+)
+
+var installCmd = &cobra.Command{
+	Use:   "install",
+	Short: "download and install sudominikube",
+	Long:  "download and install sudominikube at /opt/minikube/bin, sudo password will be required.",
+	Run: func(cmd *cobra.Command, args []string) {
+		location := downloadPath
+		if downloadPath == "" {
+			l, err := os.MkdirTemp("/tmp", "sudominikube")
+			if err != nil {
+				exit.Error(reason.Usage, "creating folder for download", err)
+			}
+			location = l
+		}
+		// downloading sudominikube
+		err := download.SudoMinikube(location, runtime.GOOS, detect.EffectiveArch())
+		if err != nil {
+			exit.Error(reason.SudoMinkubeInstall, "error when downloading sudominikube", err)
+		}
+		// install minikube
+		err = sudominikube.InstallSudoMinikube(location)
+		if err != nil {
+			exit.Error(reason.SudoMinkubeInstall, "error when installing sudominikube", err)
+		}
+
+	},
+}
+
+func init() {
+	installCmd.Flags().StringVar(&downloadPath, "download-path", "", "location of download")
+	sudominikubeCmd.AddCommand(installCmd)
+}

--- a/cmd/minikube/util/util.go
+++ b/cmd/minikube/util/util.go
@@ -1,0 +1,248 @@
+package util
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"encoding/hex"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/user"
+	"path/filepath"
+	"regexp"
+	"strconv"
+
+	mlog "github.com/docker/machine/libmachine/log"
+	"github.com/spf13/pflag"
+	"k8s.io/klog/v2"
+	"k8s.io/minikube/pkg/minikube/localpath"
+	_ "k8s.io/minikube/pkg/provision" // this is extracted directly from minikube/main.go
+
+	dconfig "github.com/docker/cli/cli/config"
+	ddocker "github.com/docker/cli/cli/context/docker"
+	dstore "github.com/docker/cli/cli/context/store"
+)
+
+const MinikubeEnableProfile = "MINIKUBE_ENABLE_PROFILING"
+
+var (
+	// This regex is intentionally very specific, it's supposed to surface
+	// unexpected errors from libmachine to the user.
+	machineLogErrorRe   = regexp.MustCompile(`VirtualizationException`)
+	machineLogWarningRe = regexp.MustCompile(`(?i)warning`)
+	// This regex is to filter out logs that contain environment variables which could contain sensitive information
+	machineLogEnvironmentRe = regexp.MustCompile(`&exec\.Cmd`)
+)
+
+// BridgeLogMessages bridges non-glog logs into klog
+func BridgeLogMessages() {
+	log.SetFlags(log.Lshortfile)
+	log.SetOutput(stdLogBridge{})
+	mlog.SetErrWriter(machineLogBridge{})
+	mlog.SetOutWriter(machineLogBridge{})
+	mlog.SetDebug(true)
+}
+
+type stdLogBridge struct{}
+
+// Write parses the standard logging line and passes its components to klog
+func (lb stdLogBridge) Write(b []byte) (n int, err error) {
+	// Split "d.go:23: message" into "d.go", "23", and "message".
+	parts := bytes.SplitN(b, []byte{':'}, 3)
+	if len(parts) != 3 || len(parts[0]) < 1 || len(parts[2]) < 1 {
+		klog.Errorf("bad log format: %s", b)
+		return
+	}
+
+	file := string(parts[0])
+	text := string(parts[2][1:]) // skip leading space
+	line, err := strconv.Atoi(string(parts[1]))
+	if err != nil {
+		text = fmt.Sprintf("bad line number: %s", b)
+		line = 0
+	}
+	klog.Infof("stdlog: %s:%d %s", file, line, text)
+	return len(b), nil
+}
+
+// libmachine log bridge
+type machineLogBridge struct{}
+
+// Write passes machine driver logs to klog
+func (lb machineLogBridge) Write(b []byte) (n int, err error) {
+	if machineLogEnvironmentRe.Match(b) {
+		return len(b), nil
+	} else if machineLogErrorRe.Match(b) {
+		klog.Errorf("libmachine: %s", b)
+	} else if machineLogWarningRe.Match(b) {
+		klog.Warningf("libmachine: %s", b)
+	} else {
+		klog.Infof("libmachine: %s", b)
+	}
+	return len(b), nil
+}
+
+// checkLogFileMaxSize checks if a file's size is greater than or equal to max size in KB
+func checkLogFileMaxSize(file string, maxSizeKB int64) bool {
+	f, err := os.Stat(file)
+	if err != nil {
+		return false
+	}
+	kb := (f.Size() / 1024)
+	return kb >= maxSizeKB
+}
+
+// logFileName generates a default logfile name in the form minikube_<argv[1]>_<hash>_<count>.log from args
+func logFileName(dir string, logIdx int64) string {
+	h := sha1.New()
+	user, err := user.Current()
+	if err != nil {
+		klog.Warningf("Unable to get username to add to log filename hash: %v", err)
+	} else {
+		_, err := h.Write([]byte(user.Username))
+		if err != nil {
+			klog.Warningf("Unable to add username %s to log filename hash: %v", user.Username, err)
+		}
+	}
+	for _, s := range pflag.Args() {
+		if _, err := h.Write([]byte(s)); err != nil {
+			klog.Warningf("Unable to add arg %s to log filename hash: %v", s, err)
+		}
+	}
+	hs := hex.EncodeToString(h.Sum(nil))
+	var logfilePath string
+	// check if subcommand specified
+	if len(pflag.Args()) < 1 {
+		logfilePath = filepath.Join(dir, fmt.Sprintf("minikube_%s_%d.log", hs, logIdx))
+	} else {
+		logfilePath = filepath.Join(dir, fmt.Sprintf("minikube_%s_%s_%d.log", pflag.Arg(0), hs, logIdx))
+	}
+	// if log has reached max size 1M, generate new logfile name by incrementing count
+	if checkLogFileMaxSize(logfilePath, 1024) {
+		return logFileName(dir, logIdx+1)
+	}
+	return logfilePath
+}
+
+// SetFlags sets the flags
+func SetFlags(parse bool) {
+	// parse flags beyond subcommand - get around go flag 'limitations':
+	// "Flag parsing stops just before the first non-flag argument" (ref: https://pkg.go.dev/flag#hdr-Command_line_flag_syntax)
+	pflag.CommandLine.ParseErrorsWhitelist.UnknownFlags = true
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	// avoid 'pflag: help requested' error, as help will be defined later by cobra cmd.Execute()
+	pflag.BoolP("help", "h", false, "")
+	if parse {
+		pflag.Parse()
+	}
+
+	// set default flag value for logtostderr and alsologtostderr but don't override user's preferences
+	if !pflag.CommandLine.Changed("logtostderr") {
+		if err := pflag.Set("logtostderr", "false"); err != nil {
+			klog.Warningf("Unable to set default flag value for logtostderr: %v", err)
+		}
+	}
+	if !pflag.CommandLine.Changed("alsologtostderr") {
+		if err := pflag.Set("alsologtostderr", "false"); err != nil {
+			klog.Warningf("Unable to set default flag value for alsologtostderr: %v", err)
+		}
+	}
+	setLastStartFlags()
+
+	// set default log_file name but don't override user's preferences
+	if !pflag.CommandLine.Changed("log_file") {
+		// default log_file dir to $TMP
+		dir := os.TempDir()
+		// set log_dir to user input if specified
+		if pflag.CommandLine.Changed("log_dir") && pflag.Lookup("log_dir").Value.String() != "" {
+			dir = pflag.Lookup("log_dir").Value.String()
+		}
+		l := logFileName(dir, 0)
+		if err := pflag.Set("log_file", l); err != nil {
+			klog.Warningf("Unable to set default flag value for log_file: %v", err)
+		}
+	}
+
+	// make sure log_dir exists if log_file is not also set - the log_dir is mutually exclusive with the log_file option
+	// ref: https://github.com/kubernetes/klog/blob/52c62e3b70a9a46101f33ebaf0b100ec55099975/klog.go#L491
+	if pflag.Lookup("log_file") != nil && pflag.Lookup("log_file").Value.String() == "" &&
+		pflag.Lookup("log_dir") != nil && pflag.Lookup("log_dir").Value.String() != "" {
+		if err := os.MkdirAll(pflag.Lookup("log_dir").Value.String(), 0755); err != nil {
+			klog.Warningf("unable to create log directory: %v", err)
+		}
+	}
+}
+
+// setLastStartFlags sets the log_file flag to lastStart.txt if start command and user doesn't specify log_file or log_dir flags.
+func setLastStartFlags() {
+	if pflag.Arg(0) != "start" {
+		return
+	}
+	if pflag.CommandLine.Changed("log_file") || pflag.CommandLine.Changed("log_dir") {
+		return
+	}
+	fp := localpath.LastStartLog()
+	dp := filepath.Dir(fp)
+	if err := os.MkdirAll(dp, 0755); err != nil {
+		klog.Warningf("Unable to make log dir %s: %v", dp, err)
+	}
+	if _, err := os.Create(fp); err != nil {
+		klog.Warningf("Unable to create/truncate file %s: %v", fp, err)
+	}
+	if err := pflag.Set("log_file", fp); err != nil {
+		klog.Warningf("Unable to set default flag value for log_file: %v", err)
+	}
+}
+
+// PropagateDockerContextToEnv propagates the current context in ~/.docker/config.json to $DOCKER_HOST,
+// so that google/go-containerregistry can pick it up.
+func PropagateDockerContextToEnv() {
+	if os.Getenv("DOCKER_HOST") != "" {
+		// Already explicitly set
+		return
+	}
+	currentContext := os.Getenv("DOCKER_CONTEXT")
+	if currentContext == "" {
+		dockerConfigDir := dconfig.Dir()
+		if _, err := os.Stat(dockerConfigDir); err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				klog.Warning(err)
+			}
+			return
+		}
+		cf, err := dconfig.Load(dockerConfigDir)
+		if err != nil {
+			klog.Warningf("Unable to load the current Docker config from %q", dockerConfigDir)
+			return
+		}
+		currentContext = cf.CurrentContext
+	}
+	if currentContext == "" {
+		return
+	}
+	storeConfig := dstore.NewConfig(
+		func() interface{} { return &ddocker.EndpointMeta{} },
+		dstore.EndpointTypeGetter(ddocker.DockerEndpoint, func() interface{} { return &ddocker.EndpointMeta{} }),
+	)
+	st := dstore.New(dconfig.ContextStoreDir(), storeConfig)
+	md, err := st.GetMetadata(currentContext)
+	if err != nil {
+		klog.Warningf("Unable to resolve the current Docker CLI context %q: %v", currentContext, err)
+		return
+	}
+	dockerEP, ok := md.Endpoints[ddocker.DockerEndpoint]
+	if !ok {
+		// No warning (the context is not for Docker)
+		return
+	}
+	dockerEPMeta, ok := dockerEP.(ddocker.EndpointMeta)
+	if !ok {
+		klog.Warningf("expected docker.EndpointMeta, got %T", dockerEP)
+		return
+	}
+	if dockerEPMeta.Host != "" {
+		os.Setenv("DOCKER_HOST", dockerEPMeta.Host)
+	}
+}

--- a/cmd/sudominikube/cmd/root.go
+++ b/cmd/sudominikube/cmd/root.go
@@ -1,0 +1,116 @@
+package cmd
+
+import (
+	"flag"
+	"os"
+	"runtime"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"k8s.io/klog/v2"
+	"k8s.io/kubectl/pkg/util/templates"
+	cmdfull "k8s.io/minikube/cmd/minikube/cmd"
+	configCmd "k8s.io/minikube/cmd/minikube/cmd/config"
+
+	"k8s.io/minikube/pkg/drivers/kic/oci"
+	"k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/exit"
+	"k8s.io/minikube/pkg/minikube/reason"
+	"k8s.io/minikube/pkg/minikube/translate"
+)
+
+const (
+	MinikubeConfig = "minikube-config"
+	KubeConfig     = "kube-config"
+)
+
+var RootCmd = &cobra.Command{
+	Use:               "sudominikube",
+	Short:             "sudominikube executes some of minikube's function without inputing sudo password everytime",
+	Long:              "sudominikube executes some of minikube's function without inputing sudo password everytime",
+	PersistentPreRun:  cmdfull.RootCmd.PersistentPreRun,
+	PersistentPostRun: cmdfull.RootCmd.PersistentPostRun,
+}
+
+func init() {
+	// it will be called in init() of minikube/cmd
+	// klog.InitFlags(nil)
+
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine) // avoid `generate-docs_test.go` complaining about "Docs are not updated"
+
+	RootCmd.PersistentFlags().StringP(config.ProfileName, "p", constants.DefaultClusterName, `The name of the minikube VM being used. This can be set to allow having multiple instances of minikube independently.`)
+	RootCmd.PersistentFlags().StringP(configCmd.Bootstrapper, "b", "kubeadm", "The name of the cluster bootstrapper that will set up the Kubernetes cluster.")
+	RootCmd.PersistentFlags().String(config.UserFlag, "", "Specifies the user executing the operation. Useful for auditing operations executed by 3rd party tools. Defaults to the operating system username.")
+	RootCmd.PersistentFlags().Bool(config.SkipAuditFlag, false, "Skip recording the current command in the audit logs.")
+	RootCmd.PersistentFlags().Bool(config.Rootless, false, "Force to use rootless driver (docker and podman driver only)")
+
+	// To make sudominikube can be pointed to correct minikube abd kubectl configs, two global additional arguments are added
+	RootCmd.PersistentFlags().String(MinikubeConfig, "", "Specifies the location of minikube's home folder (MINIKUBE_HOME)")
+	RootCmd.PersistentFlags().String(KubeConfig, "", "Specifies the location of kubectl's config file (KUBECONFIG)")
+
+	groups := templates.CommandGroups{
+		{
+			Message: translate.T("Sudo Commands:"),
+			Commands: []*cobra.Command{
+				// add commands here
+				TunnelCmd,
+			},
+		},
+		{
+			Message: translate.T("Basic Commands:"),
+			Commands: []*cobra.Command{
+				// add commands here
+				versionCmd,
+			},
+		},
+	}
+	groups.Add(RootCmd)
+	templates.ActsAsRootCommand(RootCmd, []string{"options"}, groups...)
+
+	if err := viper.BindPFlags(RootCmd.PersistentFlags()); err != nil {
+		exit.Error(reason.InternalBindFlags, "Unable to bind flags", err)
+	}
+	// it will be called in init() of minikube/cmd
+	// translate.DetermineLocale()
+	// it will be called in init() of minikube/cmd
+	// cobra.OnInitialize(cmdfull.InitConfig)
+}
+
+func Execute() {
+	// Check whether this is a windows binary (.exe) running inisde WSL.
+	if runtime.GOOS != "linux" {
+		exit.Message(reason.DrvUnsupportedOS, "sudominikube only works in linux")
+	}
+
+	for _, c := range RootCmd.Commands() {
+		c.Short = translate.T(c.Short)
+		c.Long = translate.T(c.Long)
+		c.Flags().VisitAll(func(f *pflag.Flag) {
+			f.Usage = translate.T(f.Usage)
+		})
+
+		c.SetUsageTemplate(cmdfull.UsageTemplate())
+	}
+	RootCmd.Short = translate.T(RootCmd.Short)
+	RootCmd.Long = translate.T(RootCmd.Long)
+	RootCmd.Flags().VisitAll(func(f *pflag.Flag) {
+		f.Usage = translate.T(f.Usage)
+	})
+
+	// Universally ensure that we never speak to the wrong DOCKER_HOST
+	if err := oci.PointToHostDockerDaemon(); err != nil {
+		klog.Errorf("oci env: %v", err)
+	}
+
+	if err := oci.PointToHostPodman(); err != nil {
+		klog.Errorf("oci env: %v", err)
+	}
+
+	if err := RootCmd.Execute(); err != nil {
+		// Cobra already outputs the error, typically because the user provided an unknown command.
+		defer os.Exit(reason.ExProgramUsage)
+	}
+}

--- a/cmd/sudominikube/cmd/tunnel.go
+++ b/cmd/sudominikube/cmd/tunnel.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	cmdfull "k8s.io/minikube/cmd/minikube/cmd"
+)
+
+var TunnelCmd = &cobra.Command{
+	Use:              "tunnel",
+	Short:            "Connect to LoadBalancer services",
+	Long:             `tunnel creates a route to services deployed with type LoadBalancer and sets their Ingress to their ClusterIP. for a detailed example see https://minikube.sigs.k8s.io/docs/tasks/loadbalancer`,
+	PersistentPreRun: cmdfull.TunnelCmd.PersistentPreRun,
+	Run: func(cmd *cobra.Command, args []string) {
+		// point minikube to correct minikube abd kubectl configs
+		minikubeConfig := viper.GetString(MinikubeConfig)
+		kubeConfig := viper.GetString(KubeConfig)
+		os.Setenv("MINIKUBE_HOME", minikubeConfig)
+		os.Setenv("KUBECONFIG", kubeConfig)
+		cmdfull.TunnelCmd.Run(cmd, args)
+	},
+}

--- a/cmd/sudominikube/cmd/version.go
+++ b/cmd/sudominikube/cmd/version.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"encoding/json"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+	"k8s.io/minikube/pkg/minikube/exit"
+	"k8s.io/minikube/pkg/minikube/out"
+	"k8s.io/minikube/pkg/minikube/reason"
+	"k8s.io/minikube/pkg/version"
+)
+
+var (
+	versionOutput string
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version of minikube",
+	Long:  `Print the version of minikube.`,
+	Run: func(command *cobra.Command, args []string) {
+		minikubeVersion := version.GetVersion()
+		gitCommitID := version.GetGitCommitID()
+		data := map[string]interface{}{
+			"minikubeVersion": minikubeVersion,
+			"commit":          gitCommitID,
+		}
+		switch versionOutput {
+		case "":
+			out.Ln("minikube version: %v", minikubeVersion)
+			if gitCommitID != "" {
+				out.Ln("commit: %v", gitCommitID)
+			}
+		case "json":
+			json, err := json.Marshal(data)
+			if err != nil {
+				exit.Error(reason.InternalJSONMarshal, "version json failure", err)
+			}
+			out.Ln(string(json))
+		case "yaml":
+			yaml, err := yaml.Marshal(data)
+			if err != nil {
+				exit.Error(reason.InternalYamlMarshal, "version yaml failure", err)
+			}
+			out.Ln(string(yaml))
+		default:
+			exit.Message(reason.InternalOutputUsage, "error: --output must be 'yaml' or 'json'")
+		}
+	},
+}
+
+func init() {
+	versionCmd.Flags().StringVarP(&versionOutput, "output", "o", "", "One of 'yaml' or 'json'.")
+}

--- a/cmd/sudominikube/main.go
+++ b/cmd/sudominikube/main.go
@@ -18,10 +18,11 @@ package main
 
 import (
 	"os"
-	"path/filepath"
-	"strings"
 
 	"k8s.io/klog/v2"
+
+	"k8s.io/minikube/cmd/minikube/util"
+	"k8s.io/minikube/cmd/sudominikube/cmd"
 
 	// Register drivers
 	_ "k8s.io/minikube/pkg/minikube/registry/drvs"
@@ -32,8 +33,6 @@ import (
 	"github.com/google/slowjam/pkg/stacklog"
 	"github.com/pkg/profile"
 
-	"k8s.io/minikube/cmd/minikube/cmd"
-	"k8s.io/minikube/cmd/minikube/util"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/machine"
 	"k8s.io/minikube/pkg/minikube/out"
@@ -46,11 +45,7 @@ func main() {
 
 	util.PropagateDockerContextToEnv()
 
-	// Don't parse flags when running as kubectl
-	_, callingCmd := filepath.Split(os.Args[0])
-	callingCmd = strings.TrimSuffix(callingCmd, ".exe")
-	parse := callingCmd != "kubectl"
-	util.SetFlags(parse)
+	util.SetFlags(true)
 
 	s := stacklog.MustStartFromEnv("STACKLOG_PATH")
 	defer s.Stop()

--- a/pkg/minikube/download/sudominikube.go
+++ b/pkg/minikube/download/sudominikube.go
@@ -1,0 +1,26 @@
+package download
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	sudominikubeVersion = "v0.0.1-test"
+)
+
+func SudoMinikube(dir, osName, archName string) error {
+	targetFileName := filepath.Join(dir, "sudominikube")
+	downloadURL := fmt.Sprintf("https://github.com/ComradeProgrammer/minikube/releases/download/%s/sudominikube-%s-%s", sudominikubeVersion, osName, archName)
+	if err := download(downloadURL, targetFileName); err != nil {
+		return err
+	}
+	if data, err := exec.Command("sudo", "chmod", "777", targetFileName).CombinedOutput(); err != nil {
+		return errors.WithMessagef(err, "failed to give permission: %s", string(data))
+	}
+
+	return nil
+}

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -499,4 +499,5 @@ var (
 		  minikube start{{.profile}} --driver qemu --network user`),
 		Style: style.SeeNoEvil,
 	}
+	SudoMinkubeInstall = Kind{ID: "SUDO_MINIKUBE_INSTALL", ExitCode: ExProgramError}
 )

--- a/pkg/minikube/sudominikube/sudominikube.go
+++ b/pkg/minikube/sudominikube/sudominikube.go
@@ -1,0 +1,98 @@
+package sudominikube
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"k8s.io/minikube/pkg/version"
+)
+
+const sudoersd = `
+%minikube ALL=(root:root) NOPASSWD:NOSETENV: /opt/minikube/bin/sudominikube
+`
+const SudominikubeLocation = "/opt/minikube/bin"
+
+// InstallSudoMinikube installs the sudominikube
+// param location:  path to the folder where sudominikube is downloaded
+func InstallSudoMinikube(location string) error {
+	data, err := exec.Command("sudo", "groupadd", "-f", "minikube").CombinedOutput()
+	if err != nil {
+		return errors.WithMessagef(err, "failed to run groupadd: %s", string(data))
+	}
+
+	user := os.Getenv("USER")
+	data, err = exec.Command("sudo", "usermod", "-a", "-G", "minikube", user).CombinedOutput()
+	if err != nil {
+		return errors.WithMessagef(err, "failed to run usermod: %s", string(data))
+	}
+	// verify the download
+	if err := VerifySudoMinikube(filepath.Join(location, "sudominikube")); err != nil {
+		return errors.WithMessage(err, "invalid sudominikube ")
+	}
+	// move it to  /opt/minikube/bin with sudo permission
+	data, err = exec.Command("sudo", "mkdir", "-p", SudominikubeLocation).CombinedOutput()
+	if err != nil {
+		return errors.WithMessagef(err, "failed to create folder %s bin: %s", SudominikubeLocation, string(data))
+	}
+	data, err = exec.Command("sudo", "cp", filepath.Join(location, "sudominikube"), SudominikubeLocation).CombinedOutput()
+	if err != nil {
+		return errors.WithMessagef(err, "failed to copy sudominikube to %s: %s", SudominikubeLocation, string(data))
+	}
+
+	// generate sudoer.d/sudominikube
+	f, err := os.OpenFile(filepath.Join(location, "sudo_minikube"), os.O_CREATE|os.O_WRONLY, 0666)
+	if err != nil {
+		return errors.WithMessage(err, "failed to create sudo_minikube file in download folder")
+	}
+	_, err = f.WriteString(sudoersd)
+	if err != nil {
+		return errors.WithMessage(err, "failed to write sudo_minikube file")
+	}
+	f.Close()
+	data, err = exec.Command("sudo", "mv", filepath.Join(location, "sudo_minikube"), "/etc/sudoers.d").CombinedOutput()
+	if err != nil {
+		return errors.WithMessagef(err, "failed to move sudo_minikube to /etc/sudoers.d: %s", string(data))
+	}
+	data, err = exec.Command("sudo", "chown", "root:root", "/etc/sudoers.d/sudo_minikube").CombinedOutput()
+	if err != nil {
+		return errors.WithMessagef(err, "failed to change owner /etc/sudoers.d/sudo_minikube: %s", string(data))
+	}
+	return nil
+}
+
+// VerifySudoMinikube checks whether sudominikube binary is compatible with minikube
+// parameter path: location of sudominikube binary
+func VerifySudoMinikube(path string) error {
+	// sudo is required here because the sudominikube binary may be
+	// downloaded to somewhere where the user has no permission
+	cmd := exec.Command("sudo", path, "version", "-o", "json")
+	data, err := cmd.CombinedOutput()
+	if err != nil {
+		return errors.Wrap(err, "failed to execute sudominikube version")
+	}
+	var ver map[string]string
+	if err := json.Unmarshal(data, &ver); err != nil {
+		return err
+	}
+
+	minikubeVersion := version.GetVersion()
+	// gitCommitID := version.GetGitCommitID()
+	if ver["minikubeVersion"] != minikubeVersion {
+		return fmt.Errorf("inconsistent minikubeVersion, minikube: %s, sudominikube: %s", minikubeVersion, ver["minikubeVersion"])
+	}
+	// if ver["commit"] != gitCommitID {
+	// 	return fmt.Errorf("inconsistent commitID, minikube: %s, sudominikbube: %s", gitCommitID, ver["commit"])
+	// }
+
+	return nil
+}
+
+// return whether current program is sudominikube or minikube
+func IsSudoMinikube() bool {
+	return strings.HasSuffix(os.Args[0], "sudominikube")
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

fix #15847

This draft pr contains the following things:
- it adds an executable called "sudominikube". Current it support "tunnel" command
- it adds an a command called "minikube sudominikube install", which install sudominikube to /opt/minikube/bin, add a user group called "minikube", add current user to group 'minikube', and add sudominikube to sudoers.d /etc/sudoers.d.
- it modifies the logic of "minikube tunnel" command. It will try to detect whether sudominikube exists, and if so, it will try to use `sudo sudominikube tunnel` to start a tunnel, so the user won't need to enter a password 


