### PR TITLE
CI: add workflow to hide past minikube-bot comments

### DIFF
--- a/.github/workflows/hide-minikube-bot-comments.yml
+++ b/.github/workflows/hide-minikube-bot-comments.yml
@@ -1,7 +1,7 @@
-name: minimize
+name: hide-minikube-bot-comments
 on: issue_comment
 jobs:
-  minimize:
+  hide-comments:
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/hide-minikube-bot-comments.yml
+++ b/.github/workflows/hide-minikube-bot-comments.yml
@@ -1,0 +1,8 @@
+name: minimize
+on: issue_comment
+jobs:
+  minimize:
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: spowelljr/hide-minikube-bot-comments@3e2cbc9fcd07d17eeea7dab7ac90a27cb29f8bce


### PR DESCRIPTION
On PR comment, checks to hide minikube-bot comments:

The last performance and flake rate comments are skipped, but all previous performance and flake rate comments will be hidden.

Example in action: https://github.com/spowelljr/minikube/pull/373/