### PR TITLE
change metallb image hosting from docker.io to quay.io

### DIFF
--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -543,11 +543,11 @@ var Addons = map[string]*Addon{
 			"metallb-config.yaml",
 			"0640"),
 	}, false, "metallb", "3rd party (MetalLB)", "", "", map[string]string{
-		"Speaker":    "metallb/speaker:v0.9.6@sha256:c66585a805bed1a3b829d8fb4a4aab9d87233497244ebff96f1b88f1e7f8f991",
-		"Controller": "metallb/controller:v0.9.6@sha256:fbfdb9d3f55976b0ee38f3309d83a4ca703efcf15d6ca7889cd8189142286502",
+		"Speaker":    "metallb/speaker:v0.9.6@sha256:d34f613a88bdeba10f96a50554fb6a4a659cbc99270b1adc93e3e21fa7f6c1ad",
+		"Controller": "metallb/controller:v0.9.9@sha256:cb34fded834feea570ec26159d2030e364ec98fc58f75f555a7acf1822791604",
 	}, map[string]string{
-		"Speaker":    "docker.io",
-		"Controller": "docker.io",
+		"Speaker":    "quay.io",
+		"Controller": "quay.io",
 	}),
 	"ambassador": NewAddon([]*BinAsset{
 		MustBinAsset(addons.AmbassadorAssets,


### PR DESCRIPTION
because https://github.com/metallb/metallb/pull/784

fixes https://github.com/kubernetes/minikube/issues/16053

### before this PR
```
11:55:48 medya/workspace/minikube
metal_addon_image •1
$ kc get pods -A
NAMESPACE        NAME                               READY   STATUS         RESTARTS      AGE
kube-system      coredns-787d4945fb-tm2vs           1/1     Running        0             52s
kube-system      etcd-minikube                      1/1     Running        0             65s
kube-system      kube-apiserver-minikube            1/1     Running        0             65s
kube-system      kube-controller-manager-minikube   1/1     Running        0             65s
kube-system      kube-proxy-2swd8                   1/1     Running        0             52s
kube-system      kube-scheduler-minikube            1/1     Running        0             65s
kube-system      storage-provisioner                1/1     Running        1 (47s ago)   64s
metallb-system   controller-644c846477-2496w        0/1     ErrImagePull   0             3s
metallb-system   speaker-wvr8f                      0/1     ErrImagePull   0             3s
```

### After this PR
```
$ kc get pods -A
NAMESPACE        NAME                               READY   STATUS    RESTARTS        AGE
kube-system      coredns-787d4945fb-zdg8v           1/1     Running   0               5m54s
kube-system      etcd-minikube                      1/1     Running   0               6m7s
kube-system      kube-apiserver-minikube            1/1     Running   0               6m7s
kube-system      kube-controller-manager-minikube   1/1     Running   0               6m7s
kube-system      kube-proxy-98cb6                   1/1     Running   0               5m54s
kube-system      kube-scheduler-minikube            1/1     Running   0               6m7s
kube-system      storage-provisioner                1/1     Running   1 (5m50s ago)   6m6s
metallb-system   controller-5bc6f8ffb-9v5k6         1/1     Running   0               9s
metallb-system   speaker-vhdh8                      1/1     Running   0               9s
```