### PR TITLE
kicbase: Update Ubuntu base image

### DIFF
--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -37,7 +37,7 @@ RUN if [ "$PREBUILT_AUTO_PAUSE" != "true" ]; then cd ./cmd/auto-pause/ && go bui
 
 # start from ubuntu 20.04, this image is reasonably small as a starting point
 # for a kubernetes node image, it doesn't contain much we don't need
-FROM ubuntu:focal-20230301 as kicbase
+FROM ubuntu:focal-20230308 as kicbase
 
 ARG BUILDKIT_VERSION="v0.11.2"
 ARG FUSE_OVERLAYFS_VERSION="v1.7.1"

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -24,10 +24,10 @@ import (
 
 const (
 	// Version is the current version of kic
-	Version = "v0.0.37-1678473806-15991"
+	Version = "v0.0.37-1678988071-16068"
 
 	// SHA of the kic base image
-	baseImageSHA = "c7e2010fcc4584b4a079087c1c0a443479e9062a1998351b11de5747bc1c557f"
+	baseImageSHA = "57f4012deea6a123117f6ae1c93cff056cdb7d4e3b534ed0e03818b49099d014"
 	// The name of the GCR kicbase repository
 	gcrRepo = "gcr.io/k8s-minikube/kicbase-builds"
 	// The name of the Dockerhub kicbase repository

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -26,7 +26,7 @@ minikube start [flags]
       --apiserver-names strings           A set of apiserver names which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine
       --apiserver-port int                The apiserver listening port (default 8443)
       --auto-update-drivers               If set, automatically updates drivers to the latest version. Defaults to true. (default true)
-      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.37-1678473806-15991@sha256:c7e2010fcc4584b4a079087c1c0a443479e9062a1998351b11de5747bc1c557f")
+      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.37-1678988071-16068@sha256:57f4012deea6a123117f6ae1c93cff056cdb7d4e3b534ed0e03818b49099d014")
       --binary-mirror string              Location to fetch kubectl, kubelet, & kubeadm binaries from.
       --cache-images                      If true, cache docker images for the current bootstrapper and load them into the machine. Always false with --driver=none. (default true)
       --cert-expiration duration          Duration until minikube certificate expiration, defaults to three years (26280h). (default 26280h0m0s)


### PR DESCRIPTION
Fixes CVEs:
[CVE-2022-4415](https://nvd.nist.gov/vuln/detail/CVE-2022-4415)
[CVE-2022-3821](https://nvd.nist.gov/vuln/detail/CVE-2022-3821)