### PR TITLE
CI: remove setup-go cache true lines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Download Dependencies
         run: go mod download
@@ -52,7 +51,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Install libvirt
         run: |
@@ -72,7 +70,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Install libvirt
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Generate Docs
         id: gendocs

--- a/.github/workflows/functional_verified.yml
+++ b/.github/workflows/functional_verified.yml
@@ -38,7 +38,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Download Dependencies
         run: go mod download

--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Update Leaderboard
         id: leaderboard

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -28,7 +28,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Download Dependencies
         run: go mod download
@@ -56,7 +55,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Install libvirt
         run: |
@@ -76,7 +74,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Install libvirt
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Download Dependencies
         run: go mod download
@@ -54,7 +53,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Install libvirt
         run: |
@@ -74,7 +72,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Install libvirt
         run: |

--- a/.github/workflows/sync-minikube.yml
+++ b/.github/workflows/sync-minikube.yml
@@ -26,7 +26,6 @@ jobs:
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
 
       - name: Build

--- a/.github/workflows/time-to-k8s-public-chart.yml
+++ b/.github/workflows/time-to-k8s-public-chart.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Benchmark time-to-k8s for Docker driver with Docker runtime
         run: |
@@ -49,7 +48,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Disable firewall
         run: |

--- a/.github/workflows/time-to-k8s.yml
+++ b/.github/workflows/time-to-k8s.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: time-to-k8s Benchmark
         id: timeToK8sBenchmark

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Install libvirt
         run: |

--- a/.github/workflows/update-buildkit-version.yml
+++ b/.github/workflows/update-buildkit-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Bump buildkit Version
         id: bumpBuildkit

--- a/.github/workflows/update-cloud-spanner-emulator-version.yml
+++ b/.github/workflows/update-cloud-spanner-emulator-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Bump cloud-spanner-emulator version
         id: bumpCloudSpannerEmulator

--- a/.github/workflows/update-containerd-version.yml
+++ b/.github/workflows/update-containerd-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Bump containerd Version
         id: bumpContainerd

--- a/.github/workflows/update-cri-o-version.yml
+++ b/.github/workflows/update-cri-o-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Bump cri-o Version
         id: bumpCrio

--- a/.github/workflows/update-docsy-version.yml
+++ b/.github/workflows/update-docsy-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Bump Docsy version
         id: bumpDocsy

--- a/.github/workflows/update-gh-version.yml
+++ b/.github/workflows/update-gh-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Bump gh version
         id: bumpGh

--- a/.github/workflows/update-golang-version.yml
+++ b/.github/workflows/update-golang-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Bump Golang Versions
         id: bumpGolang

--- a/.github/workflows/update-golint-version.yml
+++ b/.github/workflows/update-golint-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Bump Golint Versions
         id: bumpGolint

--- a/.github/workflows/update-gopogh-version.yml
+++ b/.github/workflows/update-gopogh-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Bump gopogh Versions
         id: bumpGopogh

--- a/.github/workflows/update-gotestsum-version.yml
+++ b/.github/workflows/update-gotestsum-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Bump Gotestsum Versions
         id: bumpGotestsum

--- a/.github/workflows/update-hugo-version.yml
+++ b/.github/workflows/update-hugo-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Bump Hugo version
         id: bumpHugo

--- a/.github/workflows/update-k8s-versions.yml
+++ b/.github/workflows/update-k8s-versions.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Bump Kubernetes Versions
         id: bumpk8s

--- a/.github/workflows/update-kubeadm-constants.yml
+++ b/.github/workflows/update-kubeadm-constants.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Bump Kubeadm Constants for Kubernetes Images
         id: bumpKubeadmConsts

--- a/.github/workflows/yearly-leaderboard.yml
+++ b/.github/workflows/yearly-leaderboard.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: ${{env.GO_VERSION}}
-          cache: true
           cache-dependency-path: ./go.sum
       - name: Update Yearly Leaderboard
         id: yearlyLeaderboard


### PR DESCRIPTION
Since we upgraded to `actions/setup-go@v4.0.0` in https://github.com/kubernetes/minikube/pull/16101 cache is enabled by default, so removed redundant lines enabling cache.