### PR TITLE
tests: Fix unit test failing if docker not running

### DIFF
--- a/pkg/drivers/kic/oci/info.go
+++ b/pkg/drivers/kic/oci/info.go
@@ -44,7 +44,7 @@ var (
 )
 
 // CachedDaemonInfo will run and return a docker/podman info only once per minikube run time. to avoid performance
-func CachedDaemonInfo(ociBin string) (SysInfo, error) {
+var CachedDaemonInfo = func(ociBin string) (SysInfo, error) {
 	if cachedSysInfo == nil {
 		si, err := DaemonInfo(ociBin)
 		cachedSysInfo = &si

--- a/pkg/minikube/registry/drvs/docker/docker_test.go
+++ b/pkg/minikube/registry/drvs/docker/docker_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
+	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/registry"
 )
@@ -185,6 +186,7 @@ func TestStatus(t *testing.T) {
 	}
 	for _, tt := range tests {
 		dockerVersionOrState = func() (string, registry.State) { return tt.input, registry.State{} }
+		oci.CachedDaemonInfo = func(string) (oci.SysInfo, error) { return oci.SysInfo{}, nil }
 		state := status()
 		err := state.Error
 		if (err == nil && tt.shouldReturnError) || (err != nil && !tt.shouldReturnError) {


### PR DESCRIPTION
The `TestStatus` test would call `docker system info --format "{{json .}}"` which if Docker wasn't running, would fail and result in the test failing. Mocked the call to `CachedDaemonInfo` to prevent the docker call from happening.