### PR TITLE
Remove container-runtime flag from later versions

### DIFF
--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -462,11 +462,14 @@ func (r *Containerd) CGroupDriver() (string, error) {
 
 // KubeletOptions returns kubelet options for a containerd
 func (r *Containerd) KubeletOptions() map[string]string {
-	return map[string]string{
-		"container-runtime":          "remote",
+	opts := map[string]string{
 		"container-runtime-endpoint": fmt.Sprintf("unix://%s", r.SocketPath()),
 		"image-service-endpoint":     fmt.Sprintf("unix://%s", r.SocketPath()),
 	}
+	if r.KubernetesVersion.LT(semver.MustParse("1.24.0-alpha.0")) {
+		opts["container-runtime"] = "remote"
+	}
+	return opts
 }
 
 // ListContainers returns a list of managed by this container runtime

--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -464,7 +464,6 @@ func (r *Containerd) CGroupDriver() (string, error) {
 func (r *Containerd) KubeletOptions() map[string]string {
 	opts := map[string]string{
 		"container-runtime-endpoint": fmt.Sprintf("unix://%s", r.SocketPath()),
-		"image-service-endpoint":     fmt.Sprintf("unix://%s", r.SocketPath()),
 	}
 	if r.KubernetesVersion.LT(semver.MustParse("1.24.0-alpha.0")) {
 		opts["container-runtime"] = "remote"

--- a/pkg/minikube/cruntime/cri.go
+++ b/pkg/minikube/cruntime/cri.go
@@ -247,9 +247,7 @@ func stopCRIContainers(cr CommandRunner, ids []string) error {
 // populateCRIConfig sets up /etc/crictl.yaml
 func populateCRIConfig(cr CommandRunner, socket string) error {
 	cPath := "/etc/crictl.yaml"
-	tmpl := `runtime-endpoint: unix://{{.Socket}}
-image-endpoint: unix://{{.Socket}}
-`
+	tmpl := "runtime-endpoint: unix://{{.Socket}}\n"
 	t, err := template.New("crictl").Parse(tmpl)
 	if err != nil {
 		return err

--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -360,7 +360,6 @@ func (r *CRIO) CGroupDriver() (string, error) {
 func (r *CRIO) KubeletOptions() map[string]string {
 	opts := map[string]string{
 		"container-runtime-endpoint": fmt.Sprintf("unix://%s", r.SocketPath()),
-		"image-service-endpoint":     fmt.Sprintf("unix://%s", r.SocketPath()),
 	}
 	if r.KubernetesVersion.LT(semver.MustParse("1.24.0-alpha.0")) {
 		opts["container-runtime"] = "remote"

--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -358,11 +358,14 @@ func (r *CRIO) CGroupDriver() (string, error) {
 
 // KubeletOptions returns kubelet options for a runtime.
 func (r *CRIO) KubeletOptions() map[string]string {
-	return map[string]string{
-		"container-runtime":          "remote",
-		"container-runtime-endpoint": r.SocketPath(),
-		"image-service-endpoint":     r.SocketPath(),
+	opts := map[string]string{
+		"container-runtime-endpoint": fmt.Sprintf("unix://%s", r.SocketPath()),
+		"image-service-endpoint":     fmt.Sprintf("unix://%s", r.SocketPath()),
 	}
+	if r.KubernetesVersion.LT(semver.MustParse("1.24.0-alpha.0")) {
+		opts["container-runtime"] = "remote"
+	}
+	return opts
 }
 
 // ListContainers returns a list of managed by this container runtime

--- a/pkg/minikube/cruntime/cruntime_test.go
+++ b/pkg/minikube/cruntime/cruntime_test.go
@@ -154,20 +154,16 @@ func TestKubeletOptions(t *testing.T) {
 		{"docker", "1.23.0", map[string]string{"container-runtime": "docker"}},
 		{"docker", "1.24.0", map[string]string{
 			"container-runtime-endpoint": "unix:///var/run/cri-dockerd.sock",
-			"image-service-endpoint":     "unix:///var/run/cri-dockerd.sock",
 		}},
 		{"crio", "1.25.0", map[string]string{
 			"container-runtime-endpoint": "unix:///var/run/crio/crio.sock",
-			"image-service-endpoint":     "unix:///var/run/crio/crio.sock",
 		}},
 		{"containerd", "1.23.0", map[string]string{
 			"container-runtime":          "remote",
 			"container-runtime-endpoint": "unix:///run/containerd/containerd.sock",
-			"image-service-endpoint":     "unix:///run/containerd/containerd.sock",
 		}},
 		{"containerd", "1.24.0", map[string]string{
 			"container-runtime-endpoint": "unix:///run/containerd/containerd.sock",
-			"image-service-endpoint":     "unix:///run/containerd/containerd.sock",
 		}},
 	}
 	for _, tc := range tests {

--- a/pkg/minikube/cruntime/cruntime_test.go
+++ b/pkg/minikube/cruntime/cruntime_test.go
@@ -148,30 +148,39 @@ func TestCGroupDriver(t *testing.T) {
 func TestKubeletOptions(t *testing.T) {
 	var tests = []struct {
 		runtime string
+		version string
 		want    map[string]string
 	}{
-		{"docker", map[string]string{"container-runtime": "docker"}},
-		{"crio", map[string]string{
-			"container-runtime":          "remote",
-			"container-runtime-endpoint": "/var/run/crio/crio.sock",
-			"image-service-endpoint":     "/var/run/crio/crio.sock",
+		{"docker", "1.23.0", map[string]string{"container-runtime": "docker"}},
+		{"docker", "1.24.0", map[string]string{
+			"container-runtime-endpoint": "unix:///var/run/cri-dockerd.sock",
+			"image-service-endpoint":     "unix:///var/run/cri-dockerd.sock",
 		}},
-		{"containerd", map[string]string{
+		{"crio", "1.25.0", map[string]string{
+			"container-runtime-endpoint": "unix:///var/run/crio/crio.sock",
+			"image-service-endpoint":     "unix:///var/run/crio/crio.sock",
+		}},
+		{"containerd", "1.23.0", map[string]string{
 			"container-runtime":          "remote",
+			"container-runtime-endpoint": "unix:///run/containerd/containerd.sock",
+			"image-service-endpoint":     "unix:///run/containerd/containerd.sock",
+		}},
+		{"containerd", "1.24.0", map[string]string{
 			"container-runtime-endpoint": "unix:///run/containerd/containerd.sock",
 			"image-service-endpoint":     "unix:///run/containerd/containerd.sock",
 		}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.runtime, func(t *testing.T) {
-			r, err := New(Config{Type: tc.runtime})
+			kv := semver.MustParse(tc.version)
+			r, err := New(Config{Type: tc.runtime, KubernetesVersion: kv})
 			if err != nil {
-				t.Fatalf("New(%s): %v", tc.runtime, err)
+				t.Fatalf("New(%s, %s): %v", tc.runtime, tc.version, err)
 			}
 
 			got := r.KubeletOptions()
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("KubeletOptions(%s) returned diff (-want +got):\n%s", tc.runtime, diff)
+				t.Errorf("KubeletOptions(%s, %s) returned diff (-want +got):\n%s", tc.runtime, tc.version, diff)
 			}
 		})
 	}

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -384,7 +384,6 @@ func (r *Docker) KubeletOptions() map[string]string {
 	if r.UseCRI {
 		opts := map[string]string{
 			"container-runtime-endpoint": fmt.Sprintf("unix://%s", r.SocketPath()),
-			"image-service-endpoint":     fmt.Sprintf("unix://%s", r.SocketPath()),
 		}
 		if r.KubernetesVersion.LT(semver.MustParse("1.24.0-alpha.0")) {
 			opts["container-runtime"] = "remote"

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -382,11 +382,14 @@ func (r *Docker) CGroupDriver() (string, error) {
 // KubeletOptions returns kubelet options for a runtime.
 func (r *Docker) KubeletOptions() map[string]string {
 	if r.UseCRI {
-		return map[string]string{
-			"container-runtime":          "remote",
-			"container-runtime-endpoint": r.SocketPath(),
-			"image-service-endpoint":     r.SocketPath(),
+		opts := map[string]string{
+			"container-runtime-endpoint": fmt.Sprintf("unix://%s", r.SocketPath()),
+			"image-service-endpoint":     fmt.Sprintf("unix://%s", r.SocketPath()),
 		}
+		if r.KubernetesVersion.LT(semver.MustParse("1.24.0-alpha.0")) {
+			opts["container-runtime"] = "remote"
+		}
+		return opts
 	}
 	return map[string]string{
 		"container-runtime": "docker",


### PR DESCRIPTION

The `--container-runtime` flag was deprecated in k8s 1.24, and removed in k8s 1.27

Add the extra `unix://` prefix everywhere, and remove the redundant endpoint config.

Closes #16112