### PR TITLE
Fix: check if addon is enabled before doing validation

### DIFF
--- a/cmd/minikube/cmd/config/disable.go
+++ b/cmd/minikube/cmd/config/disable.go
@@ -20,8 +20,8 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/minikube/pkg/addons"
 	"k8s.io/minikube/pkg/minikube/assets"
-	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/exit"
+	"k8s.io/minikube/pkg/minikube/mustload"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/reason"
 	"k8s.io/minikube/pkg/minikube/style"
@@ -40,14 +40,10 @@ var addonsDisableCmd = &cobra.Command{
 		if addon == "heapster" {
 			exit.Message(reason.AddonUnsupported, "The heapster addon is depreciated. please try to disable metrics-server instead")
 		}
-		cc, err := config.Load(ClusterFlagValue())
-		if err != nil {
-			exit.Error(reason.InternalConfigView, "loading profile", err)
-		}
+		_, cc := mustload.Partial(ClusterFlagValue())
 		validAddon, ok := assets.Addons[addon]
-
 		if !ok {
-			exit.Message(reason.InternalAddonDisable, `"'{{.minikube_addon}}' is not a valid minikube addon`, out.V{"minikube_addon": addon})
+			exit.Message(reason.AddonUnsupported, `"'{{.minikube_addon}}' is not a valid minikube addon`, out.V{"minikube_addon": addon})
 		}
 		if validAddon.IsEnabled(cc) {
 			err := addons.SetAndSave(ClusterFlagValue(), addon, "false")

--- a/cmd/minikube/cmd/config/disable.go
+++ b/cmd/minikube/cmd/config/disable.go
@@ -42,22 +42,20 @@ var addonsDisableCmd = &cobra.Command{
 		}
 		cc, err := config.Load(ClusterFlagValue())
 		if err != nil {
-			exit.Error(reason.InternalAddonDisable, "loading profile", err)
+			exit.Error(reason.InternalConfigView, "loading profile", err)
 		}
 		validAddon, ok := assets.Addons[addon]
-		if ok {
-			if validAddon.IsEnabled(cc) {
-				err := addons.SetAndSave(ClusterFlagValue(), addon, "false")
-				if err != nil {
-					exit.Error(reason.InternalAddonDisable, "disable failed", err)
-				}
-			} else {
-				out.Step(style.AddonDisable, `"The '{{.minikube_addon}}' addon is disabled`, out.V{"minikube_addon": addon})
-			}
 
-		} else {
-			out.Step(style.AddonDisable, `"The '{{.minikube_addon}}' seems not to be a valid minikube addon`, out.V{"minikube_addon": addon})
+		if !ok {
+			exit.Message(reason.InternalAddonDisable, `"'{{.minikube_addon}}' is not a valid minikube addon`, out.V{"minikube_addon": addon})
 		}
+		if validAddon.IsEnabled(cc) {
+			err := addons.SetAndSave(ClusterFlagValue(), addon, "false")
+			if err != nil {
+				exit.Error(reason.InternalAddonDisable, "disable failed", err)
+			}
+		}
+		out.Styled(style.AddonDisable, `"The '{{.minikube_addon}}' addon is disabled`, out.V{"minikube_addon": addon})
 	},
 }
 

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -156,6 +156,11 @@ func TestAddons(t *testing.T) {
 		if err != nil {
 			t.Errorf("failed to disable dashboard addon: args %q : %v", rr.Command(), err)
 		}
+		// Disable a non-enabled addon
+		rr, err = Run(t, exec.CommandContext(ctx, Target(), "addons", "disable", "gvisor", "-p", profile))
+		if err != nil {
+			t.Errorf("failed to disable non-enabled addon: args %q : %v", rr.Command(), err)
+		}
 	})
 }
 

--- a/translations/de.json
+++ b/translations/de.json
@@ -1,5 +1,6 @@
 {
 	"\n\n": "",
+	"\"'{{.minikube_addon}}' is not a valid minikube addon": "",
 	"\"The '{{.minikube_addon}}' addon is disabled": "Das {{.minikube_addon}} Addon ist deaktiviert",
 	"\"minikube cache\" will be deprecated in upcoming versions, please switch to \"minikube image load\"": "\"minikube cache\" wird in der nächsten Version veraltet (deprecated) sein, bitte wechsle zu \"minikube image load\"",
 	"\"{{.context}}\" context has been updated to point to {{.hostname}}:{{.port}}": "Der Kontext \"{{.context}}\" wurde aktualisiert, um auf {{.hostname}}:{{.port}} zu zeigen",

--- a/translations/es.json
+++ b/translations/es.json
@@ -1,5 +1,6 @@
 {
 	"\n\n": "",
+	"\"'{{.minikube_addon}}' is not a valid minikube addon": "",
 	"\"The '{{.minikube_addon}}' addon is disabled": "El complemento \"{{.minikube_addon}}\" está desactivado",
 	"\"minikube cache\" will be deprecated in upcoming versions, please switch to \"minikube image load\"": "",
 	"\"{{.context}}\" context has been updated to point to {{.hostname}}:{{.port}}": "El contexto \"{{.context}}\" ha sido actualizado para apuntar a {{.hostname}}:{{.port}}",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -1,5 +1,6 @@
 {
 	"\n\n": "",
+	"\"'{{.minikube_addon}}' is not a valid minikube addon": "",
 	"\"The '{{.minikube_addon}}' addon is disabled": "Le module \"{{.minikube_addon}}\" est désactivé",
 	"\"minikube cache\" will be deprecated in upcoming versions, please switch to \"minikube image load\"": "\"minikube cache\" sera obsolète dans les prochaines versions, veuillez passer à \"minikube image load\"",
 	"\"{{.context}}\" context has been updated to point to {{.hostname}}:{{.port}}": "Le contexte \"{{.context}}\" a été mis à jour pour pointer vers {{.hostname}}:{{.port}}",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -1,5 +1,6 @@
 {
 	"\n\n": "",
+	"\"'{{.minikube_addon}}' is not a valid minikube addon": "",
 	"\"The '{{.minikube_addon}}' addon is disabled": "'{{.minikube_addon}}' アドオンが無効です",
 	"\"minikube cache\" will be deprecated in upcoming versions, please switch to \"minikube image load\"": "「minikube cache」は今後のバージョンで廃止予定になりますので、「minikube image load」に切り替えてください",
 	"\"{{.context}}\" context has been updated to point to {{.hostname}}:{{.port}}": "「{{.context}}」コンテキストが更新されて、{{.hostname}}:{{.port}} を指すようになりました",

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -1,5 +1,6 @@
 {
 	"\n\n": "",
+	"\"'{{.minikube_addon}}' is not a valid minikube addon": "",
 	"\"The '{{.minikube_addon}}' addon is disabled": "\"The '{{.minikube_addon}}' 이 비활성화되었습니다",
 	"\"minikube cache\" will be deprecated in upcoming versions, please switch to \"minikube image load\"": "\"minikube cache\"는 추후 버전에서 사용 중단됩니다. \"minikube image load\"로 전환하십시오",
 	"\"{{.context}}\" context has been updated to point to {{.hostname}}:{{.port}}": "\"{{.context}}\" 컨텍스트가 {{.hostname}}:{{.port}}로 갱신되었습니다.",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -1,5 +1,6 @@
 {
 	"\n\n": "",
+	"\"'{{.minikube_addon}}' is not a valid minikube addon": "",
 	"\"The '{{.minikube_addon}}' addon is disabled": "",
 	"\"minikube cache\" will be deprecated in upcoming versions, please switch to \"minikube image load\"": "",
 	"\"{{.context}}\" context has been updated to point to {{.hostname}}:{{.port}}": "",

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -1,5 +1,6 @@
 {
 	"\n\n": "",
+	"\"'{{.minikube_addon}}' is not a valid minikube addon": "",
 	"\"The '{{.minikube_addon}}' addon is disabled": "\"Дополнение '{{.minikube_addon}}' выключено",
 	"\"minikube cache\" will be deprecated in upcoming versions, please switch to \"minikube image load\"": "",
 	"\"{{.context}}\" context has been updated to point to {{.hostname}}:{{.port}}": "Контекст \"{{.context}}\" был обновлён и теперь указывает на {{.hostname}}:{{.port}}",

--- a/translations/strings.txt
+++ b/translations/strings.txt
@@ -1,5 +1,6 @@
 {
 	"\n\n": "",
+	"\"'{{.minikube_addon}}' is not a valid minikube addon": "",
 	"\"The '{{.minikube_addon}}' addon is disabled": "",
 	"\"minikube cache\" will be deprecated in upcoming versions, please switch to \"minikube image load\"": "",
 	"\"{{.context}}\" context has been updated to point to {{.hostname}}:{{.port}}": "",

--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -1,5 +1,6 @@
 {
 	"\n\n": "",
+	"\"'{{.minikube_addon}}' is not a valid minikube addon": "",
 	"\"The '{{.minikube_addon}}' addon is disabled": "'{{.minikube_addon}}' 插件已被禁用",
 	"\"minikube cache\" will be deprecated in upcoming versions, please switch to \"minikube image load\"": "\"minikube cache\" 将在即将发布的版本中弃用，请切换至 \"minikube image load\"",
 	"\"{{.context}}\" context has been updated to point to {{.hostname}}:{{.port}}": "",


### PR DESCRIPTION
Fixes: #15432, #15429, #15431, #15430

```
$ ./out/minikube addons list
|-----------------------------|----------|--------------|--------------------------------|
|         ADDON NAME          | PROFILE  |    STATUS    |           MAINTAINER           |
|-----------------------------|----------|--------------|--------------------------------|
| ambassador                  | minikube | disabled     | 3rd party (Ambassador)         |
| auto-pause                  | minikube | disabled     | Google                         |
| cloud-spanner               | minikube | disabled     | Google                         |
| csi-hostpath-driver         | minikube | disabled     | Kubernetes                     |
| dashboard                   | minikube | disabled     | Kubernetes                     |
| default-storageclass        | minikube | enabled ✅   | Kubernetes                     |
| efk                         | minikube | disabled     | 3rd party (Elastic)            |
| freshpod                    | minikube | disabled     | Google                         |
| gcp-auth                    | minikube | disabled     | Google                         |
| gvisor                      | minikube | disabled     | Google                         |
| headlamp                    | minikube | disabled     | 3rd party (kinvolk.io)         |
| helm-tiller                 | minikube | disabled     | 3rd party (Helm)               |
| inaccel                     | minikube | disabled     | 3rd party (InAccel             |
|                             |          |              | [info@inaccel.com])            |
| ingress                     | minikube | disabled     | Kubernetes                     |
| ingress-dns                 | minikube | disabled     | Google                         |
| istio                       | minikube | disabled     | 3rd party (Istio)              |
| istio-provisioner           | minikube | disabled     | 3rd party (Istio)              |
| kong                        | minikube | disabled     | 3rd party (Kong HQ)            |
| kubevirt                    | minikube | disabled     | 3rd party (KubeVirt)           |
| logviewer                   | minikube | disabled     | 3rd party (unknown)            |
| metallb                     | minikube | disabled     | 3rd party (MetalLB)            |
| metrics-server              | minikube | disabled     | Kubernetes                     |
| nvidia-driver-installer     | minikube | disabled     | Google                         |
| nvidia-gpu-device-plugin    | minikube | disabled     | 3rd party (Nvidia)             |
| olm                         | minikube | disabled     | 3rd party (Operator Framework) |
| pod-security-policy         | minikube | disabled     | 3rd party (unknown)            |
| portainer                   | minikube | disabled     | 3rd party (Portainer.io)       |
| registry                    | minikube | disabled     | Google                         |
| registry-aliases            | minikube | disabled     | 3rd party (unknown)            |
| registry-creds              | minikube | disabled     | 3rd party (UPMC Enterprises)   |
| storage-provisioner         | minikube | enabled ✅   | Google                         |
| storage-provisioner-gluster | minikube | disabled     | 3rd party (Gluster)            |
| volumesnapshots             | minikube | disabled     | Kubernetes                     |
|-----------------------------|----------|--------------|--------------------------------|
```

Before
```
$ minikube addons disable gvisor

❌  Exiting due to MK_ADDON_DISABLE: run callbacks: running validations: [
This addon can only be enabled with the containerd runtime backend. To enable this backend, please first stop minikube with:

minikube stop

and then start minikube again with the following flags:

minikube start --container-runtime=containerd --docker-opt containerd=/var/run/containerd/containerd.sock]

╭───────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                           │
│    😿  If the above advice does not help, please let us know:                             │
│    👉  https://github.com/kubernetes/minikube/issues/new/choose                           │
│                                                                                           │
│    Please run `minikube logs --file=logs.txt` and attach logs.txt to the GitHub issue.    │
│    Please also attach the following file to the GitHub issue:                             │
│    - /tmp/minikube_addons_569b151b47196d038af25537206255c050ace6fd_0.log                  │
│                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────╯
```
After
```
$ ./out/minikube addons disable gvisor
🌑  "The 'gvisor' addon is disabled
```
Before:
```
 minikube addons disable gcp-auth

❌  Exiting due to MK_ADDON_DISABLE: run callbacks: running callbacks: [Process exited with status 1]

╭───────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                           │
│    😿  If the above advice does not help, please let us know:                             │
│    👉  https://github.com/kubernetes/minikube/issues/new/choose                           │
│                                                                                           │
│    Please run `minikube logs --file=logs.txt` and attach logs.txt to the GitHub issue.    │
│    Please also attach the following file to the GitHub issue:                             │
│    - /tmp/minikube_addons_2c4fde7ba5d6af1ee47e28fd9619be21ed484a50_0.log                  │
│                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────╯
```
After:
```
$ ./out/minikube addons disable gcp-auth
🌑  "The 'gcp-auth' addon is disabled
```
Before:
```
$ minikube addons disable testing

❌  Exiting due to MK_ADDON_DISABLE: run callbacks: testing is not a valid addon

╭───────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                           │
│    😿  If the above advice does not help, please let us know:                             │
│    👉  https://github.com/kubernetes/minikube/issues/new/choose                           │
│                                                                                           │
│    Please run `minikube logs --file=logs.txt` and attach logs.txt to the GitHub issue.    │
│    Please also attach the following file to the GitHub issue:                             │
│    - /tmp/minikube_addons_4755f700bf6c955ce4ad0731b6be6682109661fe_0.log                  │
│                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────╯

```
After:
```
$ ./out/minikube addons disable testing

❌  Exiting due to MK_ADDON_DISABLE: "'testing' is not a valid minikube addon

```