### PR TITLE
fix: storage provision identity got changed after every restart

### DIFF
--- a/deploy/addons/storage-provisioner/storage-provisioner.yaml.tmpl
+++ b/deploy/addons/storage-provisioner/storage-provisioner.yaml.tmpl
@@ -103,6 +103,11 @@ spec:
     image: {{.CustomRegistries.StorageProvisioner  | default .ImageRepository | default .Registries.StorageProvisioner }}{{.Images.StorageProvisioner}}
     command: ["/storage-provisioner"]
     imagePullPolicy: IfNotPresent
+    env:
+    - name: NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
     volumeMounts:
     - mountPath: /tmp
       name: tmp

--- a/pkg/storage/storage_provisioner.go
+++ b/pkg/storage/storage_provisioner.go
@@ -26,8 +26,6 @@ import (
 
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
@@ -42,14 +40,18 @@ type hostPathProvisioner struct {
 
 	// Identity of this hostPathProvisioner, generated. Used to identify "this"
 	// provisioner's PVs.
-	identity types.UID
+	identity string
 }
 
 // NewHostPathProvisioner creates a new Provisioner using host paths
 func NewHostPathProvisioner(pvDir string) controller.Provisioner {
+	nodeName := os.Getenv("NODE_NAME")
+	if nodeName == "" {
+		klog.Fatal("env variable NODE_NAME must be set so that this provisioner can identify itself")
+	}
 	return &hostPathProvisioner{
 		pvDir:    pvDir,
-		identity: uuid.NewUUID(),
+		identity: nodeName,
 	}
 }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

fix https://github.com/kubernetes/minikube/issues/16140

Before:

Storage privisioner's identity got random generated at the start. Which will be changed after every restart

After:

Pass in provisioner's identity by environment variable. This will work in single node setup but will not work well for multi node