### PR TITLE
CNI/bridge: Ensure pod communications are allowed

### DIFF
--- a/pkg/minikube/cni/bridge.go
+++ b/pkg/minikube/cni/bridge.go
@@ -30,12 +30,13 @@ import (
 // bridge is what minikube defaulted to when `--enable-default-cni=true`
 // ref: https://www.cni.dev/plugins/current/main/bridge/
 // ref: https://www.cni.dev/plugins/current/meta/portmap/
+// ref: https://www.cni.dev/plugins/current/meta/firewall/
 
 // note: "cannot set hairpin mode and promiscuous mode at the same time"
 // ref: https://github.com/containernetworking/plugins/blob/7e9ada51e751740541969e1ea5a803cbf45adcf3/plugins/main/bridge/bridge.go#L424
 var bridgeConf = template.Must(template.New("bridge").Parse(`
 {
-  "cniVersion": "0.3.1",
+  "cniVersion": "0.4.0",
   "name": "bridge",
   "plugins": [
     {
@@ -56,6 +57,9 @@ var bridgeConf = template.Must(template.New("bridge").Parse(`
       "capabilities": {
           "portMappings": true
       }
+    },
+    {
+       "type": "firewall"
     }
   ]
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

Using `none` driver with `docker` runtime, the `bridge` CNI is selected since Minikube v1.29.0, but pods cannot communicate, this PR adds the `firewall` plugin to the CNI config to set up the correct `iptables` rules.

I found the solution here: https://github.com/containernetworking/plugins/issues/430#issuecomment-567917273

The config for reference:
* https://github.com/containernetworking/plugins/blob/v1.2.0/plugins/meta/firewall/firewall.go#L33-L68
* https://www.cni.dev/plugins/current/meta/firewall/

Tested and working for my use case, but I am not entirely sure about all the implications of this change.

Fixes medyagh/setup-minikube#110
