### PR TITLE
CI: fix restarting Docker macOS

### DIFF
--- a/hack/jenkins/setup_docker_desktop_macos.sh
+++ b/hack/jenkins/setup_docker_desktop_macos.sh
@@ -22,6 +22,7 @@ if docker system info > /dev/null 2>&1; then
 fi
 
 # kill docker first
+osascript -e 'quit app "Docker Desktop"'
 osascript -e 'quit app "Docker"'
 
 # wait 2 minutes for it to start back up

--- a/hack/jenkins/setup_docker_desktop_macos.sh
+++ b/hack/jenkins/setup_docker_desktop_macos.sh
@@ -21,7 +21,9 @@ if docker system info > /dev/null 2>&1; then
   exit 0
 fi
 
-# kill docker first
+# kill Docker so we can freshly start it
+# IMPORTANT: Docker Desktop has to be stopped before Docker Engine
+# See https://github.com/kubernetes/minikube/pull/16150
 osascript -e 'quit app "Docker Desktop"'
 osascript -e 'quit app "Docker"'
 


### PR DESCRIPTION
`osascript -e 'quit app "Docker"'` results in Docker Engine being stopped, but not Docker Desktop itself.

This results in a limbo state where the following error is output: `ERROR: Error response from daemon: Bad response from Docker engine`

Trying to restart Docker via `open --background -a Docker` while in this state doesn't actually result in a change since Docker Desktop is still running.

By stopping Docker Desktop and Docker Engine we get an expected error from Docker: `ERROR: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?`

Which then results in `open --background -a Docker` properly restarting Docker Desktop.

Note that Docker Engine has to be stopped after Docker Desktop, otherwise it will result in `ERROR: Error response from daemon: Bad response from Docker engine` and is in this state until Docker Engine is stopped again.