### PR TITLE
CI: update GitHub Actions runners

### DIFF
--- a/.github/workflows/functional_verified.yml
+++ b/.github/workflows/functional_verified.yml
@@ -69,6 +69,7 @@ jobs:
         shell: bash
         run: |
           sudo apt update
+          sudo apt upgrade -y
           sudo apt install -y jq docker git cron
           sudo usermod -aG docker $USER
 
@@ -81,9 +82,8 @@ jobs:
           fi
           sudo touch /var/run/job.in.progress
           rm -rf cleanup.sh install_cleanup.sh
-          # after this PR is merged, update URLs to get the scripts from github master
-          wget https://storage.googleapis.com/minikube-ci-utils/cleanup.sh
-          wget https://storage.googleapis.com/minikube-ci-utils/install_cleanup.sh
+          wget https://raw.githubusercontent.com/kubernetes/minikube/master/hack/gh_actions/cleanup.sh
+          wget https://raw.githubusercontent.com/kubernetes/minikube/master/hack/gh_actions/install_cleanup.sh
           chmod +x cleanup.sh install_cleanup.sh
           ./install_cleanup.sh
 


### PR DESCRIPTION
Our 3 arm64 GitHub Actions self-hosted runners were not being updated in CI resulting in really old deps including Docker, added `apt upgrade` to resolve this.

There was a comment from 2+ years ago: `after this PR is merged, update URLs to get the scripts from github master`
So implemented what the comment was asking. The file had since had changes but they weren't being picked up since was still using pulling the file from GCS, now pulls the file from the master branch.