### PR TITLE
CI: only setup docker if using docker driver

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -80,7 +80,8 @@ if [ "$(uname)" = "Darwin" ]; then
   if [ "$ARCH" = "arm64" ]; then
     export PATH=$PATH:/opt/homebrew/bin
   fi
-  if ! bash setup_docker_desktop_macos.sh; then
+
+  if [ "$DRIVER" = "docker" ] && ! bash setup_docker_desktop_macos.sh; then
     retry_github_status "${COMMIT}" "${JOB_NAME}" "failure" "${access_token}" "${public_log_url}" "Jenkins: docker failed to start"
     exit 1
   fi


### PR DESCRIPTION
Before we would ensure Docker was running before running any macOS tests, regardless if the test was testing the Docker driver or not. This would prevent starting HyperKit and QEMU tests if something is wrong with Docker on the machine. Now we only check that Docker is running if we're testing the Docker driver.