### PR TITLE
CI: remove test_summary.json

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -493,6 +493,7 @@ ${SUDO_PREFIX} rm -f "${KUBECONFIG}" || true
 ${SUDO_PREFIX} rm -f "${TEST_OUT}" || true
 ${SUDO_PREFIX} rm -f "${JSON_OUT}" || true
 ${SUDO_PREFIX} rm -f "${HTML_OUT}" || true
+${SUDO_PREFIX} rm -f "${SUMMARY_OUT}" || true
 
 rmdir "${TEST_HOME}" || true
 echo ">> ${TEST_HOME} completed at $(date)"


### PR DESCRIPTION
`SUMMARY_OUT` wasn't getting deleted, which caused the following command (`rmdir "${TEST_HOME}"`) to fail.

```
11:04:27 rmdir: /Users/****/minikube-integration/15452-1870: Directory not empty
```