### PR TITLE
Fix: differentiate ISO make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,10 +287,10 @@ out/e2e-%: out/minikube-%
 out/e2e-windows-amd64.exe: out/e2e-windows-amd64
 	cp $< $@
 
-minikube-iso-amd64: minikube-iso-x86_64
-minikube-iso-arm64: minikube-iso-aarch64
+minikube-iso-amd64: minikube-iso-board-x86_64
+minikube-iso-arm64: minikube-iso-board-aarch64
 
-minikube-iso-%: deploy/iso/minikube-iso/board/minikube/%/rootfs-overlay/usr/bin/auto-pause # build minikube iso
+minikube-iso-board-%: deploy/iso/minikube-iso/board/minikube/%/rootfs-overlay/usr/bin/auto-pause # build minikube iso
 	echo $(VERSION_JSON) > deploy/iso/minikube-iso/board/minikube/$*/rootfs-overlay/version.json
 	echo $(ISO_VERSION) > deploy/iso/minikube-iso/board/minikube/$*/rootfs-overlay/etc/VERSION
 	cp deploy/iso/minikube-iso/arch/$*/Config.in.tmpl deploy/iso/minikube-iso/Config.in
@@ -802,7 +802,7 @@ push-gvisor-addon-image: gvisor-addon-image
 	$(MAKE) push-docker IMAGE=$(REGISTRY)/gvisor-addon:$(GVISOR_TAG)
 
 .PHONY: release-iso
-release-iso: minikube-iso-aarch64 minikube-iso-x86_64 checksum  ## Build and release .iso files
+release-iso: minikube-iso-board-aarch64 minikube-iso-board-x86_64 checksum  ## Build and release .iso files
 	gsutil cp out/minikube-amd64.iso gs://$(ISO_BUCKET)/minikube-$(ISO_VERSION)-amd64.iso
 	gsutil cp out/minikube-amd64.iso.sha256 gs://$(ISO_BUCKET)/minikube-$(ISO_VERSION)-amd64.iso.sha256
 	gsutil cp out/minikube-arm64.iso gs://$(ISO_BUCKET)/minikube-$(ISO_VERSION)-arm64.iso


### PR DESCRIPTION
Fixes #16156 

Resulting build exits cleanly without the extra, invalid auto-pause build error.

```
$ make out/minikube-amd64.iso
docker run --rm --workdir /mnt --volume /home/ubuntu/minikube:/mnt  \
	--user 1000:1000 --env HOME=/tmp --env IN_DOCKER=1 \
	gcr.io/k8s-minikube/buildroot-image /bin/bash -lc '/usr/bin/make minikube-iso-amd64'
GOOS=linux GOARCH=amd64 go build -o deploy/iso/minikube-iso/board/minikube/x86_64/rootfs-overlay/usr/bin/auto-pause cmd/auto-pause/auto-pause.go
...
ln -snf /mnt/out/buildroot/output-x86_64/host/x86_64-minikube-linux-gnu/sysroot /mnt/out/buildroot/output-x86_64/staging
make[1]: Leaving directory '/mnt/out/buildroot'
# x86_64 ISO is still BIOS rather than EFI because of AppArmor issues for KVM, and Gen 2 issues for Hyper-V
if [ "x86_64" = "aarch64" ]; then \
                mv /mnt/out/buildroot/output-aarch64/images/boot.iso /mnt/out/minikube-arm64.iso; \
        else \
                mv /mnt/out/buildroot/output-x86_64/images/rootfs.iso9660 /mnt/out/minikube-amd64.iso; \
        fi;
rm deploy/iso/minikube-iso/board/minikube/x86_64/rootfs-overlay/usr/bin/auto-pause
```
