### PR TITLE
CI: Always require Docker to be running

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -81,7 +81,7 @@ if [ "$(uname)" = "Darwin" ]; then
     export PATH=$PATH:/opt/homebrew/bin
   fi
 
-  if [ "$DRIVER" = "docker" ] && ! bash setup_docker_desktop_macos.sh; then
+  if ! bash setup_docker_desktop_macos.sh; then
     retry_github_status "${COMMIT}" "${JOB_NAME}" "failure" "${access_token}" "${public_log_url}" "Jenkins: docker failed to start"
     exit 1
   fi


### PR DESCRIPTION
Some tests use `docker pull` which will require Docker to be running, so make sure Docker is running even if we aren't testing the docker driver.
