### PR TITLE
CI: add cron to kicbase & ISO build machines

### DIFF
--- a/hack/jenkins/build_iso.sh
+++ b/hack/jenkins/build_iso.sh
@@ -27,6 +27,9 @@ set -x -o pipefail
 # Make sure golang is installed and configured
 ./hack/jenkins/installers/check_install_golang.sh "/usr/local"
 
+# install cron jobs
+source ./hack/jenkins/installers/check_install_linux_crons.sh
+
 # Generate changelog for latest github PRs merged
 ./hack/jenkins/build_changelog.sh deploy/iso/minikube-iso/board/minikube/aarch64/rootfs-overlay/CHANGELOG
 ./hack/jenkins/build_changelog.sh deploy/iso/minikube-iso/board/minikube/x86_64/rootfs-overlay/CHANGELOG

--- a/hack/jenkins/installers/check_install_linux_crons.sh
+++ b/hack/jenkins/installers/check_install_linux_crons.sh
@@ -16,6 +16,6 @@
 
 set -e
 
-mkdir -p cron && gsutil -qm rsync "gs://minikube-builds/${MINIKUBE_LOCATION}/cron" cron || echo "FAILED TO GET CRON FILES"
+mkdir -p cron && gsutil -qm rsync "gs://minikube-builds/${MINIKUBE_LOCATION:=master}/cron" cron || echo "FAILED TO GET CRON FILES"
 sudo install cron/cleanup_and_reboot_Linux.sh /etc/cron.hourly/cleanup_and_reboot || echo "FAILED TO INSTALL CLEANUP AND REBOOT"
 sudo install cron/cleanup_go_modules.sh /etc/cron.monthly/cleanup_go_modules || echo "FAILED TO INSTALL GO MODULES CLEANUP"

--- a/hack/jenkins/kicbase_auto_build.sh
+++ b/hack/jenkins/kicbase_auto_build.sh
@@ -27,6 +27,9 @@ docker login -u ${DOCKERHUB_USER} -p ${DOCKERHUB_PASS}
 # Make sure golang is installed and configured
 ./hack/jenkins/installers/check_install_golang.sh "/usr/local" || true
 
+# install cron jobs
+source ./hack/jenkins/installers/check_install_linux_crons.sh
+
 ./hack/jenkins/build_changelog.sh ./deploy/kicbase/CHANGELOG
 
 export GOBIN=/usr/local/go/bin


### PR DESCRIPTION
The kicbase and ISO machines don't have a cron installed in them, so they have very old deps installed on the machines. Adding the cron to these machines will resolve this.