### PR TITLE
cleanup: Check for scanner errors

### DIFF
--- a/cmd/minikube/cmd/config/addons_list_test.go
+++ b/cmd/minikube/cmd/config/addons_list_test.go
@@ -60,6 +60,9 @@ func TestAddonsList(t *testing.T) {
 				pipeCount += strings.Count(buf.Text(), "|")
 				got += buf.Text()
 			}
+			if err := buf.Err(); err != nil {
+				t.Errorf("failed to read stdout: %v", err)
+			}
 			// The lines we pull should look something like
 			// |------------|------------|(------|)
 			// | ADDON NAME | MAINTAINER |( DOCS |)

--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -501,7 +501,7 @@ func readEventLog(name string) ([]cloudevents.Event, time.Time, error) {
 		events = append(events, ev)
 	}
 
-	return events, st.ModTime(), nil
+	return events, st.ModTime(), scanner.Err()
 }
 
 // clusterState converts Status structs into a ClusterState struct

--- a/hack/jenkins/test-flake-chart/process_last_90/process_last_90.go
+++ b/hack/jenkins/test-flake-chart/process_last_90/process_last_90.go
@@ -87,12 +87,12 @@ func main() {
 		validDate = true
 		write(dw, line)
 	}
+	if err := s.Err(); err != nil {
+		log.Fatalf("failed to read file: %v", err)
+	}
 
 	if err := dw.Flush(); err != nil {
 		log.Fatalf("failed to flush data writer: %v", err)
-	}
-	if err := s.Err(); err != nil {
-		log.Fatalf("scanner had an error: %v", err)
 	}
 	if err := data.Close(); err != nil {
 		log.Fatalf("failed to close source file: %v", err)

--- a/pkg/drivers/kic/oci/network_create.go
+++ b/pkg/drivers/kic/oci/network_create.go
@@ -326,7 +326,7 @@ func networkNamesByLabel(ociBin string, label string) ([]string, error) {
 		lines = append(lines, strings.TrimSpace(scanner.Text()))
 	}
 
-	return lines, nil
+	return lines, scanner.Err()
 }
 
 // DeleteAllKICKNetworksByLabel deletes all networks that have a specific label

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -407,6 +407,12 @@ func inspect(ociBin string, containerNameOrID, format string) ([]string, error) 
 	for scanner.Scan() {
 		lines = append(lines, scanner.Text())
 	}
+	if scanErr := scanner.Err(); scanErr != nil {
+		klog.Warningf("failed to read output: %v", scanErr)
+		if err == nil {
+			err = scanErr
+		}
+	}
 	return lines, err
 }
 
@@ -473,6 +479,9 @@ func isUsernsRemapEnabled(ociBin string) bool {
 	for scanner.Scan() {
 		lines = append(lines, scanner.Text())
 	}
+	if err := scanner.Err(); err != nil {
+		klog.Warningf("failed to read output: %v", err)
+	}
 
 	if len(lines) > 0 {
 		if strings.Contains(lines[0], "name=userns") {
@@ -533,7 +542,7 @@ func ListContainersByLabel(ctx context.Context, ociBin string, label string, war
 			names = append(names, n)
 		}
 	}
-	return names, err
+	return names, s.Err()
 }
 
 // ListImagesRepository returns all the images names
@@ -554,10 +563,7 @@ func ListImagesRepository(ctx context.Context, ociBin string) ([]string, error) 
 			names = append(names, n)
 		}
 	}
-	if err := s.Err(); err != nil {
-		return nil, err
-	}
-	return names, nil
+	return names, s.Err()
 }
 
 // PointToHostDockerDaemon will unset env variables that point to docker inside minikube

--- a/pkg/drivers/kic/oci/volumes.go
+++ b/pkg/drivers/kic/oci/volumes.go
@@ -119,6 +119,12 @@ func allVolumesByLabel(ociBin string, label string) ([]string, error) {
 			vols = append(vols, v)
 		}
 	}
+	if scanErr := s.Err(); scanErr != nil {
+		klog.Warningf("failed to read output: %v", scanErr)
+		if err == nil {
+			err = scanErr
+		}
+	}
 	return vols, err
 }
 

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -341,6 +341,9 @@ func outputKubeadmInitSteps(logs io.Reader, wg *sync.WaitGroup) {
 
 		nextStepIndex++
 	}
+	if err := scanner.Err(); err != nil {
+		klog.Warningf("failed to read logs: %v", err)
+	}
 	wg.Done()
 }
 

--- a/pkg/minikube/command/command_runner.go
+++ b/pkg/minikube/command/command_runner.go
@@ -138,7 +138,7 @@ func teePrefix(prefix string, r io.Reader, w io.Writer, logger func(format strin
 	if line.Len() > 0 {
 		logger("%s%s", prefix, line.String())
 	}
-	return nil
+	return scanner.Err()
 }
 
 // fileExists checks that the same file exists on the other end

--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -139,6 +139,9 @@ func FindProblems(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.C
 				problems = append(problems, l)
 			}
 		}
+		if err := scanner.Err(); err != nil {
+			klog.Warningf("failed to read output: %v", err)
+		}
 		if len(problems) > 0 {
 			pMap[name] = problems
 		}
@@ -197,6 +200,10 @@ func Output(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg config.Cluster
 		scanner := bufio.NewScanner(&b)
 		for scanner.Scan() {
 			l += scanner.Text() + "\n"
+		}
+		if err := scanner.Err(); err != nil {
+			klog.Errorf("failed to read output: %v", err)
+			failed = append(failed, name)
 		}
 		out.Styled(style.Empty, l)
 	}

--- a/pkg/minikube/registry/drvs/hyperv/powershell.go
+++ b/pkg/minikube/registry/drvs/hyperv/powershell.go
@@ -62,6 +62,9 @@ func parseLines(stdout string) []string {
 	for s.Scan() {
 		resp = append(resp, s.Text())
 	}
+	if err := s.Err(); err != nil {
+		klog.Warningf("failed to read stdout: %v", err)
+	}
 
 	return resp
 }

--- a/pkg/minikube/sshutil/sshutil.go
+++ b/pkg/minikube/sshutil/sshutil.go
@@ -120,6 +120,9 @@ func KnownHost(host string, knownHosts string) bool {
 			}
 		}
 	}
+	if err := scanner.Err(); err != nil {
+		klog.Warningf("failed to read file: %v", err)
+	}
 
 	return false
 }

--- a/pkg/minikube/tunnel/kic/ssh_conn.go
+++ b/pkg/minikube/tunnel/kic/ssh_conn.go
@@ -186,6 +186,9 @@ func logOutput(r io.Reader, service string) {
 	for s.Scan() {
 		klog.Infof("%s tunnel: %s", service, s.Text())
 	}
+	if err := s.Err(); err != nil {
+		klog.Warningf("failed to read: %v", err)
+	}
 }
 
 func (c *sshConn) stop() error {

--- a/test/integration/util_test.go
+++ b/test/integration/util_test.go
@@ -52,5 +52,5 @@ func auditContains(substr string) (bool, error) {
 			return true, nil
 		}
 	}
-	return false, nil
+	return false, s.Err()
 }


### PR DESCRIPTION
There are many places in our code where we don't check for `Scanner` errors. When `scanner.Scan()` stops returning `true` it could have hit the end of the buffer, or it could have encountered an error. So after `scanner.Scan()` check to see if it encountered an error and return the error or log it depending on the case.