### PR TITLE
CNI: Update kindnetd from `v20230227-15197099` to `v20230330-48f316cd`

### DIFF
--- a/deploy/kicbase/entrypoint
+++ b/deploy/kicbase/entrypoint
@@ -447,6 +447,9 @@ enable_network_magic(){
       -e 's/-A OUTPUT \(.*\) -j DOCKER_OUTPUT/\0\n-A PREROUTING \1 -j DOCKER_OUTPUT/' \
       `# switch docker DNS SNAT rules rules to our chosen IP` \
       -e "s/--to-source :53/--to-source ${docker_host_ip}:53/g"\
+      `# nftables incompatibility between 1.8.8 and 1.8.7 omit the --dport flag on DNAT rules` \
+      `# ensure --dport on DNS rules, due to https://github.com/kubernetes-sigs/kind/issues/3054` \
+      -e "s/p -j DNAT --to-destination ${docker_embedded_dns_ip}/p --dport 53 -j DNAT --to-destination ${docker_embedded_dns_ip}/g" \
     | iptables-restore
 
   # now we can ensure that DNS is configured to use our IP

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -24,14 +24,14 @@ import (
 
 const (
 	// Version is the current version of kic
-	Version = "v0.0.38"
+	Version = "v0.0.38-1680381266-16207"
 
 	// SHA of the kic base image
-	baseImageSHA = "516db0892e1cd79b6781fc1a102fca4bf392576bbf3ca0fa01a467cb6cc0af55"
+	baseImageSHA = "426ee3dccdda8a0d40cd86fbdbe440858176d8d4d9c37319b1c702ef226aea93"
 	// The name of the GCR kicbase repository
-	gcrRepo = "gcr.io/k8s-minikube/kicbase"
+	gcrRepo = "gcr.io/k8s-minikube/kicbase-builds"
 	// The name of the Dockerhub kicbase repository
-	dockerhubRepo = "docker.io/kicbase/stable"
+	dockerhubRepo = "docker.io/kicbase/build"
 )
 
 var (

--- a/pkg/minikube/bootstrapper/images/images.go
+++ b/pkg/minikube/bootstrapper/images/images.go
@@ -170,7 +170,7 @@ func KindNet(repo string) string {
 	if repo == "" {
 		repo = "kindest"
 	}
-	return path.Join(repo, "kindnetd:v20230227-15197099")
+	return path.Join(repo, "kindnetd:v20230330-48f316cd")
 }
 
 // all calico images are from https://docs.projectcalico.org/manifests/calico.yaml

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -26,7 +26,7 @@ minikube start [flags]
       --apiserver-names strings           A set of apiserver names which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine
       --apiserver-port int                The apiserver listening port (default 8443)
       --auto-update-drivers               If set, automatically updates drivers to the latest version. Defaults to true. (default true)
-      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase:v0.0.38@sha256:516db0892e1cd79b6781fc1a102fca4bf392576bbf3ca0fa01a467cb6cc0af55")
+      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.38-1680381266-16207@sha256:426ee3dccdda8a0d40cd86fbdbe440858176d8d4d9c37319b1c702ef226aea93")
       --binary-mirror string              Location to fetch kubectl, kubelet, & kubeadm binaries from.
       --cache-images                      If true, cache docker images for the current bootstrapper and load them into the machine. Always false with --driver=none. (default true)
       --cert-expiration duration          Duration until minikube certificate expiration, defaults to three years (26280h). (default 26280h0m0s)


### PR DESCRIPTION
kindnetd commits:
bump distroless-iptables to latest: https://github.com/kubernetes-sigs/kind/commit/91ac0849c1f4793a16c5acc7faa5cb639097b363
bump kindnetd dependencies: https://github.com/kubernetes-sigs/kind/commit/385bf7b772ec9f11087da8f54074212460f77d8a