### PR TITLE
Add docker.io/library to image short names

### DIFF
--- a/pkg/minikube/machine/build_images.go
+++ b/pkg/minikube/machine/build_images.go
@@ -25,6 +25,8 @@ import (
 	"runtime"
 	"strings"
 
+	dockerref "github.com/docker/distribution/reference"
+
 	"github.com/docker/machine/libmachine/state"
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
@@ -57,6 +59,14 @@ func BuildImage(path string, file string, tag string, push bool, env []string, o
 	remote := err == nil && u.Scheme != ""
 	if runtime.GOOS == "windows" && filepath.VolumeName(path) != "" {
 		remote = false
+	}
+
+	if tag != "" {
+		named, err := dockerref.ParseNormalizedNamed(tag)
+		if err != nil {
+			return errors.Wrapf(err, "couldn't parse image reference %q", tag)
+		}
+		tag = named.Name()
 	}
 
 	for _, p := range profiles { // building images to all running profiles


### PR DESCRIPTION
Kubernetes automatically looks for "docker.io/library/*", so we need to add these to the images for it to find them.

It is still possible to use qualified image names with a custom registry, and not rely on the legacy defaults.

Closes #16036

----

BEFORE

```
I0402 21:50:35.557033  104890 docker.go:329] Building image: /var/lib/minikube/build/build.1807215478
I0402 21:50:35.557089  104890 ssh_runner.go:195] Run: docker build -t myimage /var/lib/minikube/build/build.1807215478
Sending build context to Docker daemon  2.048kB
Step 1/2 : FROM busybox
 ---> 7cfbbec8963d
Step 2/2 : RUN true
 ---> Using cache
 ---> fb21a5ceaab3
Successfully built fb21a5ceaab3
Successfully tagged myimage:latest
```

AFTER

```
I0402 21:50:56.736097  105202 docker.go:336] Building image: /var/lib/minikube/build/build.2187847824
I0402 21:50:56.736148  105202 ssh_runner.go:195] Run: docker build -t docker.io/library/myimage /var/lib/minikube/build/build.2187847824
Sending build context to Docker daemon  2.048kB
Step 1/2 : FROM busybox
 ---> 7cfbbec8963d
Step 2/2 : RUN true
 ---> Using cache
 ---> fb21a5ceaab3
Successfully built fb21a5ceaab3
Successfully tagged myimage:latest
```


Note that Docker automatically hides the real name in the output, whereas containerd/buildkitd does not.

In the future, Kubernetes might allow to use a different default registry - but right now it is hard-coded...