### PR TITLE
Require crictl to be installed for none driver

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1844,6 +1844,12 @@ func validateBareMetal(drvName string) {
 			exit.Message(reason.GuestMissingConntrack, "Sorry, Kubernetes {{.k8sVersion}} requires conntrack to be installed in root's path", out.V{"k8sVersion": version.String()})
 		}
 	}
+	// crictl is required starting with Kubernetes 1.24, for all runtimes since the removal of dockershim
+	if version.GTE(semver.MustParse("1.24.0-alpha.0")) {
+		if _, err := exec.LookPath("crictl"); err != nil {
+			exit.Message(reason.GuestMissingConntrack, "Sorry, Kubernetes {{.k8sVersion}} requires crictl to be installed in root's path", out.V{"k8sVersion": version.String()})
+		}
+	}
 }
 
 func exitIfNotForced(r reason.Kind, message string, v ...out.V) {

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -376,6 +376,8 @@ var (
 	GuestDrvMismatch = Kind{ID: "GUEST_DRIVER_MISMATCH", ExitCode: ExGuestConflict, Style: style.Conflict}
 	// minikube could not find conntrack on the host, which is required from Kubernetes 1.18 onwards
 	GuestMissingConntrack = Kind{ID: "GUEST_MISSING_CONNTRACK", ExitCode: ExGuestUnsupported}
+	// minikube could not find crictl on the host, which is required from Kubernetes 1.24 onwards
+	GuestMissingCrictl = Kind{ID: "GUEST_MISSING_CRICTL", ExitCode: ExGuestUnsupported}
 
 	// minikube failed to get the host IP to use from within the VM
 	IfHostIP = Kind{ID: "IF_HOST_IP", ExitCode: ExLocalNetworkError}

--- a/translations/strings.txt
+++ b/translations/strings.txt
@@ -572,6 +572,7 @@
 	"Skipped switching kubectl context for {{.profile_name}} because --keep-context was set.": "",
 	"Some dashboard features require the metrics-server addon. To enable all features please run:\n\n\tminikube{{.profileArg}} addons enable metrics-server\t\n\n": "",
 	"Sorry, Kubernetes {{.k8sVersion}} requires conntrack to be installed in root's path": "",
+	"Sorry, Kubernetes {{.k8sVersion}} requires crictl to be installed in root's path": "",
 	"Sorry, completion support is not yet implemented for {{.name}}": "",
 	"Sorry, please set the --output flag to one of the following valid options: [text,json]": "",
 	"Sorry, the IP provided with the --listen-address flag is invalid: {{.listenAddr}}.": "",


### PR DESCRIPTION
Before Kubernetes 1.24, it was possible to use the Docker runtime
without installing the "crictl" debugging tool (from cri-tools).

It was always required for the other non-Docker container runtimes,
but they are still not supported for minikube - or so it claims...