### PR TITLE
Adds suggestion for runtime_enable kind of errors

### DIFF
--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -454,11 +454,11 @@ func configureRuntimes(runner cruntime.CommandRunner, cc config.ClusterConfig, k
 	if err = cr.Enable(disableOthers, cgroupDriver(cc), inUserNamespace); err != nil {
 		// if this makes sense, should we extend this logic to the other exit.Error(RUNTIME_ENABLE) ?
 		switch strings.ToLower(cr.Name()) {
-		case "docker":
+		case constants.Docker:
 			exit.Error(reason.RuntimeDockerEnable, "Failed to enable docker/cri-docker", err)
-		case "cri-o":
+		case constants.CRIO:
 			exit.Error(reason.RuntimeCrioEnable, "Failed to enable cri-o", err)
-		case "containerd":
+		case constants.Containerd:
 			exit.Error(reason.RuntimeContainerdEnable, "Failed to enable containerd", err)
 		default:
 			exit.Error(reason.RuntimeEnable, "Failed to enable container runtime", err)

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -455,11 +455,11 @@ func configureRuntimes(runner cruntime.CommandRunner, cc config.ClusterConfig, k
 		// if this makes sense, should we extend this logic to the other exit.Error(RUNTIME_ENABLE) ?
 		switch strings.ToLower(cr.Name()) {
 		case constants.Docker:
-			exit.Error(reason.RuntimeDockerCRICTL, "Failed to enable docker/cri-docker", err)
+			exit.Error(reason.RuntimeDockerCrictl, "Failed to enable docker/cri-docker", err)
 		case constants.CRIO:
-			exit.Error(reason.RuntimeCrioEnable, "Failed to enable cri-o", err)
+			exit.Error(reason.RuntimeCrioCrictl, "Failed to enable cri-o", err)
 		case constants.Containerd:
-			exit.Error(reason.RuntimeContainerdEnable, "Failed to enable containerd", err)
+			exit.Error(reason.RuntimeContainerdCrictl, "Failed to enable containerd", err)
 		default:
 			exit.Error(reason.RuntimeEnable, "Failed to enable container runtime", err)
 		}

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -451,7 +451,6 @@ func configureRuntimes(runner cruntime.CommandRunner, cc config.ClusterConfig, k
 
 	disableOthers := !driver.BareMetal(cc.Driver)
 	if err = cr.Enable(disableOthers, cgroupDriver(cc), inUserNamespace); err != nil {
-		// if this makes sense, should we extend this logic to the other exit.Error(RUNTIME_ENABLE) ?
 		switch strings.ToLower(cr.Name()) {
 		case constants.Docker:
 			exit.Error(reason.RuntimeDockerCrictl, "Failed to enable docker/cri-docker", err)

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -455,7 +455,7 @@ func configureRuntimes(runner cruntime.CommandRunner, cc config.ClusterConfig, k
 		// if this makes sense, should we extend this logic to the other exit.Error(RUNTIME_ENABLE) ?
 		switch strings.ToLower(cr.Name()) {
 		case constants.Docker:
-			exit.Error(reason.RuntimeDockerEnable, "Failed to enable docker/cri-docker", err)
+			exit.Error(reason.RuntimeDockerCRICTL, "Failed to enable docker/cri-docker", err)
 		case constants.CRIO:
 			exit.Error(reason.RuntimeCrioEnable, "Failed to enable cri-o", err)
 		case constants.Containerd:

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -446,7 +446,6 @@ func configureRuntimes(runner cruntime.CommandRunner, cc config.ClusterConfig, k
 		}
 		if err != nil {
 			klog.Warningf("cannot ensure containerd is configured properly and reloaded for docker - cluster might be unstable: %v", err)
-			// exit with error and recommend to check the installation doc for docker/cri-docker ?
 		}
 	}
 

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -453,11 +453,11 @@ func configureRuntimes(runner cruntime.CommandRunner, cc config.ClusterConfig, k
 	if err = cr.Enable(disableOthers, cgroupDriver(cc), inUserNamespace); err != nil {
 		switch strings.ToLower(cr.Name()) {
 		case constants.Docker:
-			exit.Error(reason.RuntimeDockerCrictl, "Failed to enable docker/cri-docker", err)
+			exit.Error(reason.RuntimeDockerEnable, "Failed to enable docker/cri-docker", err)
 		case constants.CRIO:
-			exit.Error(reason.RuntimeCrioCrictl, "Failed to enable cri-o", err)
+			exit.Error(reason.RuntimeCrioEnable, "Failed to enable cri-o", err)
 		case constants.Containerd:
-			exit.Error(reason.RuntimeContainerdCrictl, "Failed to enable containerd", err)
+			exit.Error(reason.RuntimeContainerdEnable, "Failed to enable containerd", err)
 		default:
 			exit.Error(reason.RuntimeEnable, "Failed to enable container runtime", err)
 		}

--- a/pkg/minikube/reason/known_issues.go
+++ b/pkg/minikube/reason/known_issues.go
@@ -1206,15 +1206,13 @@ var runtimeIssues = []match{
 	},
 	{
 		Kind: Kind{
-			ID:       "RUNTIME_DOCKER_CRICTL",
+			ID:       "RUNTIME_DOCKER_ENABLE",
 			ExitCode: ExRuntimeError,
 			Advice:   "It seems like docker/cri-docker could be misconfigured. Please make sure that you followed the recommended installation procedure",
 			URL:      "https://kubernetes.io/docs/setup/production-environment/container-runtimes/#docker",
 			Issues:   []int{},
 		},
-		// This regexp should match everything related to the crictl command failure,
-		// an rpc error, and anything related to cri-docker
-		Regexp: re(`(.*bin/crictl.*exit status.*)|(.*rpc error.*)|(.*cri-docker.*)`),
+		Regexp: re(`.*bin/crictl.*exit status.*`),
 		GOOS:   []string{"linux"},
 	},
 }

--- a/pkg/minikube/reason/known_issues.go
+++ b/pkg/minikube/reason/known_issues.go
@@ -1204,6 +1204,19 @@ var runtimeIssues = []match{
 		Regexp: re(`sudo systemctl restart crio: exit status 5`),
 		GOOS:   []string{"linux"},
 	},
+	{
+		Kind: Kind{
+			ID:       "RUNTIME_DOCKER_ENABLE",
+			ExitCode: ExRuntimeError,
+			Advice:   "It seems like docker/cri-docker could be misconfigured. Please make sure that you followed the recommended installation procedure",
+			URL:      "https://kubernetes.io/docs/setup/production-environment/container-runtimes/#docker",
+			Issues:   []int{},
+		},
+		// This regexp should match everything related to the crictl command failure,
+		// an rpc error, and anytghing related to cri-docker
+		Regexp: re(`(.*bin/crictl.*exit status.*)|(.*rpc error.*)|(.*cri-docker.*)`),
+		GOOS:   []string{"linux"},
+	},
 }
 
 // controlPlaneIssues are Kubernetes deployment issues

--- a/pkg/minikube/reason/known_issues.go
+++ b/pkg/minikube/reason/known_issues.go
@@ -1208,12 +1208,12 @@ var runtimeIssues = []match{
 		Kind: Kind{
 			ID:       "RUNTIME_DOCKER_ENABLE",
 			ExitCode: ExRuntimeError,
-			Advice:   "It seems like docker/cri-docker could be misconfigured. Please make sure that you followed the recommended installation procedure",
+			Advice:   "It seems like docker/cri-docker could be misconfigured. Please make sure that you followed the recommended installation procedure and have crictl installed",
 			URL:      "https://kubernetes.io/docs/setup/production-environment/container-runtimes/#docker",
 			Issues:   []int{},
 		},
 		// This regexp should match everything related to the crictl command failure,
-		// an rpc error, and anytghing related to cri-docker
+		// an rpc error, and anything related to cri-docker
 		Regexp: re(`(.*bin/crictl.*exit status.*)|(.*rpc error.*)|(.*cri-docker.*)`),
 		GOOS:   []string{"linux"},
 	},

--- a/pkg/minikube/reason/known_issues.go
+++ b/pkg/minikube/reason/known_issues.go
@@ -1206,9 +1206,9 @@ var runtimeIssues = []match{
 	},
 	{
 		Kind: Kind{
-			ID:       "RUNTIME_DOCKER_ENABLE",
+			ID:       "RUNTIME_DOCKER_CRICTL",
 			ExitCode: ExRuntimeError,
-			Advice:   "It seems like docker/cri-docker could be misconfigured. Please make sure that you followed the recommended installation procedure and have crictl installed",
+			Advice:   "It seems like docker/cri-docker could be misconfigured. Please make sure that you followed the recommended installation procedure",
 			URL:      "https://kubernetes.io/docs/setup/production-environment/container-runtimes/#docker",
 			Issues:   []int{},
 		},

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -412,11 +412,11 @@ var (
 	// minikube failed to enable the current container runtime
 	RuntimeEnable = Kind{ID: "RUNTIME_ENABLE", ExitCode: ExRuntimeError}
 	// minikube failed to enable docker as container runtime
-	RuntimeDockerCrictl = Kind{ID: "RUNTIME_DOCKER_CRICTL", ExitCode: ExRuntimeError}
+	RuntimeDockerEnable = Kind{ID: "RUNTIME_DOCKER_ENABLE", ExitCode: ExRuntimeError}
 	// minikube failed to enable containerd as container runtime
-	RuntimeContainerdCrictl = Kind{ID: "RUNTIME_CONTAINERD_CRICTL", ExitCode: ExRuntimeError}
+	RuntimeContainerdEnable = Kind{ID: "RUNTIME_CONTAINERD_ENABLE", ExitCode: ExRuntimeError}
 	// minikube failed to enable crio as container runtime
-	RuntimeCrioCrictl = Kind{ID: "RUNTIME_CRIO_CRICTL", ExitCode: ExRuntimeError}
+	RuntimeCrioEnable = Kind{ID: "RUNTIME_CRIO_ENABLE", ExitCode: ExRuntimeError}
 	// minikube failed to cache images for the current container runtime
 	RuntimeCache = Kind{ID: "RUNTIME_CACHE", ExitCode: ExRuntimeError}
 

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -412,11 +412,11 @@ var (
 	// minikube failed to enable the current container runtime
 	RuntimeEnable = Kind{ID: "RUNTIME_ENABLE", ExitCode: ExRuntimeError}
 	// minikube failed to enable docker as container runtime
-	RuntimeDockerCRICTL = Kind{ID: "RUNTIME_DOCKER_CRICTL", ExitCode: ExRuntimeError}
+	RuntimeDockerCrictl = Kind{ID: "RUNTIME_DOCKER_CRICTL", ExitCode: ExRuntimeError}
 	// minikube failed to enable containerd as container runtime
-	RuntimeContainerdCRICTL = Kind{ID: "RUNTIME_CONTAINERD_CRICTL", ExitCode: ExRuntimeError}
+	RuntimeContainerdCrictl = Kind{ID: "RUNTIME_CONTAINERD_CRICTL", ExitCode: ExRuntimeError}
 	// minikube failed to enable crio as container runtime
-	RuntimeCrioCRICTL = Kind{ID: "RUNTIME_CRIO_CRICTL", ExitCode: ExRuntimeError}
+	RuntimeCrioCrictl = Kind{ID: "RUNTIME_CRIO_CRICTL", ExitCode: ExRuntimeError}
 	// minikube failed to cache images for the current container runtime
 	RuntimeCache = Kind{ID: "RUNTIME_CACHE", ExitCode: ExRuntimeError}
 

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -412,11 +412,11 @@ var (
 	// minikube failed to enable the current container runtime
 	RuntimeEnable = Kind{ID: "RUNTIME_ENABLE", ExitCode: ExRuntimeError}
 	// minikube failed to enable docker as container runtime
-	RuntimeDockerEnable = Kind{ID: "RUNTIME_DOCKER_ENABLE", ExitCode: ExRuntimeError}
+	RuntimeDockerCRICTL = Kind{ID: "RUNTIME_DOCKER_CRICTL", ExitCode: ExRuntimeError}
 	// minikube failed to enable containerd as container runtime
-	RuntimeContainerdEnable = Kind{ID: "RUNTIME_CONTAINERD_ENABLE", ExitCode: ExRuntimeError}
+	RuntimeContainerdCRICTL = Kind{ID: "RUNTIME_CONTAINERD_CRICTL", ExitCode: ExRuntimeError}
 	// minikube failed to enable crio as container runtime
-	RuntimeCrioEnable = Kind{ID: "RUNTIME_CRIO_ENABLE", ExitCode: ExRuntimeError}
+	RuntimeCrioCRICTL = Kind{ID: "RUNTIME_CRIO_CRICTL", ExitCode: ExRuntimeError}
 	// minikube failed to cache images for the current container runtime
 	RuntimeCache = Kind{ID: "RUNTIME_CACHE", ExitCode: ExRuntimeError}
 

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -411,6 +411,12 @@ var (
 
 	// minikube failed to enable the current container runtime
 	RuntimeEnable = Kind{ID: "RUNTIME_ENABLE", ExitCode: ExRuntimeError}
+	// minikube failed to enable docker as container runtime
+	RuntimeDockerEnable = Kind{ID: "RUNTIME_DOCKER_ENABLE", ExitCode: ExRuntimeError}
+	// minikube failed to enable containerd as container runtime
+	RuntimeContainerdEnable = Kind{ID: "RUNTIME_CONTAINERD_ENABLE", ExitCode: ExRuntimeError}
+	// minikube failed to enable crio as container runtime
+	RuntimeCrioEnable = Kind{ID: "RUNTIME_CRIO_ENABLE", ExitCode: ExRuntimeError}
 	// minikube failed to cache images for the current container runtime
 	RuntimeCache = Kind{ID: "RUNTIME_CACHE", ExitCode: ExRuntimeError}
 


### PR DESCRIPTION
We're trying to reproduce an error for a RUNTIME_ENABLE reason,
so that we can provide specific solutions for that class of errors.

## how to reproduce:
`Tested inside an ubuntu kinetic w/ 3cpu 3Gmemory`
Executing the following on a freshly provisioned box, I was able to reproduce a RUNTIME_ENABLE kind of error.
```bash
#!/bin/bash

ARCH="amd64"
DEST="/opt/cni/bin"
CRI_DOCKERD_VERSION="v0.3.1"
CRICTL_VERSION="v1.26.1"
CNI_PLUGINS_VERSION="v1.2.0"
DOWNLOAD_DIR="/usr/local/bin"

if [ $EUID -ne 0 ]
then
        echo "Must run as root!"
        exit
fi

echo "Installing dependencies"
apt-get install conntrack apt-transport-https ca-certificates curl -y

if ! hash docker
then
        echo "Getting docker sh'ing get.docker.com"
        curl -Ssl https://get.docker.com | sh -
        usermod -aG docker $(id -un)
else
        echo "docker already installed.. not doing anything"
fi

echo "Getting cri-dockerd"
curl -LO https://github.com/Mirantis/cri-dockerd/releases/download/$CRI_DOCKERD_VERSION/cri-dockerd_0.3.1.3-0.ubuntu-jammy_amd64.deb
dpkg -i cri-dockerd_0.3.1.3-0.ubuntu-jammy_amd64.deb

#### These are provided by `minikube start`
# echo "Getting kübernetes components"
# sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
# echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
# sudo apt-get update
# sudo apt-get install -y kubelet kubeadm kubectl
# sudo apt-mark hold kubelet kubeadm kubectl

curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.26.1/crictl-v1.26.1-linux-amd64.tar.gz | tar -C $DOWNLOAD_DIR -xz
# cp crictl /usr/bin
cat <<EOF | tee /usr/local/bin/crictl
echo "🤯"
exit -1
EOF
```

The command is
`sudo -E minikube start --driver=none --container-runtime=docker`

### BEFORE:
```
😄  minikube v1.29.0 on Ubuntu 22.10 (kvm/amd64)
✨  Using the none driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
🔄  Restarting existing none bare metal machine for "minikube" ...
ℹ️  OS release is Ubuntu 22.10
E0403 16:16:11.241087    6745 start.go:413] unable to disable preinstalled bridge CNI(s): failed to disable all bridge cni configs in "/etc/cni/net.d": sudo find /etc/cni/net.d -maxdepth 1 -type f ( ( -name *bridge* -or -name *podman* ) -and -not -name *.mk_disabled ) -printf "%p, " -exec sh -c "sudo mv {} {}.mk_disabled" ;: exit status 1
stdout:

stderr:
find: ‘/etc/cni/net.d’: No such file or directory

❌  Exiting due to RUNTIME_ENABLE: Failed to start container runtime: Temporary Error: sudo /usr/local/bin/crictl version: exit status 2
stdout:
🤯

stderr:
/usr/local/bin/crictl: 2: exit: Illegal number: -1


╭───────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                           │
│    😿  If the above advice does not help, please let us know:                             │
│    👉  https://github.com/kubernetes/minikube/issues/new/choose                           │
│                                                                                           │
│    Please run `minikube logs --file=logs.txt` and attach logs.txt to the GitHub issue.    │
│                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────╯


```
### AFTER:
```
😄  minikube v1.29.0 on Ubuntu 22.10 (kvm/amd64)
✨  Using the none driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🤹  Running on localhost (CPUs=4, Memory=3919MB, Disk=4781MB) ...
ℹ️  OS release is Ubuntu 22.10
E0403 15:52:09.070157    4510 start.go:413] unable to disable preinstalled bridge CNI(s): failed to disable all bridge cni configs in "/etc/cni/net.d": sudo find /etc/cni/net.d -maxdepth 1 -type f ( ( -name *bridge* -or -name *podman* ) -and -not -name *.mk_disabled ) -printf "%p, " -exec sh -c "sudo mv {} {}.mk_disabled" ;: exit status 1
stdout:

stderr:
find: ‘/etc/cni/net.d’: No such file or directory

❌  Exiting due to RUNTIME_DOCKER_ENABLE: Temporary Error: sudo /usr/local/bin/crictl version: exit status 2
stdout:
🤯

stderr:
/usr/local/bin/crictl: 2: exit: Illegal number: -1

💡  Suggestion: It seems like docker/cri-docker could be misconfigured. Please make sure that you followed the recommended installation procedure
📘  Documentation: https://kubernetes.io/docs/setup/production-environment/container-runtimes/#docker
```

works towards #15897 solution