### PR TITLE
Removes storage_driver option from /etc/docker/daemon.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ KUBERNETES_VERSION ?= $(shell egrep "DefaultKubernetesVersion =" pkg/minikube/co
 KIC_VERSION ?= $(shell egrep "Version =" pkg/drivers/kic/types.go | cut -d \" -f2)
 
 # Default to .0 for higher cache hit rates, as build increments typically don't require new ISO versions
-ISO_VERSION ?= v1.30.1
+ISO_VERSION ?= v1.30.1-1681929734-16235
 
 # Dashes are valid in semver, but not Linux packaging. Use ~ to delimit alpha/beta
 DEB_VERSION ?= $(subst -,~,$(RAW_VERSION))

--- a/deploy/iso/minikube-iso/arch/aarch64/package/docker-bin-aarch64/daemon.json
+++ b/deploy/iso/minikube-iso/arch/aarch64/package/docker-bin-aarch64/daemon.json
@@ -5,6 +5,5 @@
   "log-driver": "json-file",
   "log-opts": {
     "max-size": "100m"
-  },
-  "storage-driver": "overlay2"
+  }
 }

--- a/deploy/iso/minikube-iso/arch/x86_64/package/docker-bin/daemon.json
+++ b/deploy/iso/minikube-iso/arch/x86_64/package/docker-bin/daemon.json
@@ -5,6 +5,5 @@
   "log-driver": "json-file",
   "log-opts": {
     "max-size": "100m"
-  },
-  "storage-driver": "overlay2"
+  }
 }

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -216,7 +216,7 @@ func New(c Config) (Manager, error) {
 		// There is no more dockershim socket, in Kubernetes version 1.24 and beyond
 		if sp == "" && c.KubernetesVersion.GTE(semver.MustParse("1.24.0-alpha.0")) {
 			sp = ExternalDockerCRISocket
-			cs = "cri-docker.socket"
+			cs = "cri-docker"
 		}
 		return &Docker{
 			Socket:            sp,

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -162,7 +162,7 @@ func (r *Docker) Enable(disOthers bool, cgroupDriver string, inUserNamespace boo
 	}
 
 	if r.CRIService != "" {
-		if err := r.Init.Enable("cri-docker.socket"); err != nil {
+		if err := r.Init.Enable(r.CRIService); err != nil {
 			return err
 		}
 		if err := r.Init.Unmask(r.CRIService); err != nil {
@@ -174,7 +174,7 @@ func (r *Docker) Enable(disOthers bool, cgroupDriver string, inUserNamespace boo
 		if err := r.Init.Restart(r.CRIService); err != nil {
 			return err
 		}
-		if err := r.Init.Restart("cri-docker"); err != nil {
+		if err := r.Init.Restart(r.CRIService); err != nil {
 			return err
 		}
 	}

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -535,8 +535,7 @@ func (r *Docker) setCGroup(driver string) error {
 "log-driver": "json-file",
 "log-opts": {
 	"max-size": "100m"
-},
-"storage-driver": "overlay2"
+}
 }
 `, driver)
 	ma := assets.NewMemoryAsset([]byte(daemonConfig), "/etc/docker", "daemon.json", "0644")

--- a/pkg/minikube/download/iso.go
+++ b/pkg/minikube/download/iso.go
@@ -41,7 +41,7 @@ const fileScheme = "file"
 // DefaultISOURLs returns a list of ISO URL's to consult by default, in priority order
 func DefaultISOURLs() []string {
 	v := version.GetISOVersion()
-	isoBucket := "minikube/iso"
+	isoBucket := "minikube-builds/iso/16235"
 
 	return []string{
 		fmt.Sprintf("https://storage.googleapis.com/%s/minikube-%s-%s.iso", isoBucket, v, runtime.GOARCH),


### PR DESCRIPTION
This setting is applied by minikube in both /etc/docker/daemon.json and as an override to the service file in
/etc/systemd/system/docker.service.d/10-machine.conf, during provision phase.

If two such directives are set, docker.service will not start

fixes #16231 