### PR TITLE
Renew expired kubeadm certs

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/files.go
+++ b/pkg/minikube/bootstrapper/bsutil/files.go
@@ -19,16 +19,11 @@ package bsutil
 
 import (
 	"os/exec"
-	"path"
 
 	"github.com/pkg/errors"
 	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/command"
-	"k8s.io/minikube/pkg/minikube/vmpath"
 )
-
-// KubeadmYamlPath is the path to the kubeadm configuration
-var KubeadmYamlPath = path.Join(vmpath.GuestEphemeralDir, "kubeadm.yaml")
 
 const (
 	// KubeletServiceFile is the file for the systemd kubelet.service

--- a/pkg/minikube/bootstrapper/certs.go
+++ b/pkg/minikube/bootstrapper/certs.go
@@ -140,6 +140,10 @@ func SetupCerts(cmd command.Runner, k8s config.ClusterConfig, n config.Node) err
 	if err := installCertSymlinks(cmd, caCerts); err != nil {
 		return errors.Wrapf(err, "certificate symlinks")
 	}
+
+	if err := generateKubeadmCerts(cmd, k8s); err != nil {
+		return fmt.Errorf("failed to renew kubeadm certs: %v", err)
+	}
 	return nil
 }
 
@@ -344,6 +348,33 @@ func generateProfileCerts(cfg config.ClusterConfig, n config.Node, ccs CACerts, 
 	return xfer, nil
 }
 
+func generateKubeadmCerts(cmd command.Runner, cc config.ClusterConfig) error {
+	needsRefresh := false
+	certs := []string{"apiserver-etcd-client", "apiserver-kubelet-client", "etcd-server", "etcd-healthcheck-client", "etcd-peer", "front-proxy-client"}
+	for _, cert := range certs {
+		certPath := []string{vmpath.GuestPersistentDir, "certs"}
+		// certs starting with "etcd-" are in the "etcd" dir
+		// ex: etcd-server => etcd/server
+		if strings.HasPrefix(cert, "etcd-") {
+			certPath = append(certPath, "etcd")
+		}
+		certPath = append(certPath, strings.TrimPrefix(cert, "etcd-")+".crt")
+		if !isKubeadmCertValid(cmd, path.Join(certPath...)) {
+			needsRefresh = true
+		}
+	}
+	if !needsRefresh {
+		return nil
+	}
+	out.WarningT("kubeadm certificates have expired. Generating new ones...")
+	kubeadmPath := path.Join(vmpath.GuestPersistentDir, "binaries", cc.KubernetesConfig.KubernetesVersion)
+	bashCmd := fmt.Sprintf("sudo env PATH=\"%s:$PATH\" kubeadm certs renew all --config %s", kubeadmPath, constants.KubeadmYamlPath)
+	if _, err := cmd.RunCmd(exec.Command("/bin/bash", "-c", bashCmd)); err != nil {
+		return fmt.Errorf("failed to renew kubeadm certs: %v", err)
+	}
+	return nil
+}
+
 // isValidPEMCertificate checks whether the input file is a valid PEM certificate (with at least one CERTIFICATE block)
 func isValidPEMCertificate(filePath string) (bool, error) {
 	fileBytes, err := os.ReadFile(filePath)
@@ -540,6 +571,34 @@ func isValid(certPath, keyPath string) bool {
 		klog.Infof("cert expired %s: expiration: %s, now: %s", certPath, cert.NotAfter, time.Now())
 		os.Remove(certPath)
 		os.Remove(keyPath)
+		return false
+	}
+
+	return true
+}
+
+func isKubeadmCertValid(cmd command.Runner, certPath string) bool {
+	rr, err := cmd.RunCmd(exec.Command("cat", certPath))
+	if err != nil {
+		klog.Infof("failed to read cert file %s: %v", certPath, err)
+		// if reading the cert failed it's likely first start and it doesn't exist yet so mark as valid
+		return true
+	}
+
+	certData, _ := pem.Decode(rr.Stdout.Bytes())
+	if certData == nil {
+		klog.Infof("failed to decode cert file %s", certPath)
+		return false
+	}
+
+	cert, err := x509.ParseCertificate(certData.Bytes)
+	if err != nil {
+		klog.Infof("failed to parse cert file %s: %v\n", certPath, err)
+		return false
+	}
+
+	if cert.NotAfter.Before(time.Now()) {
+		klog.Infof("cert expired %s: expiration: %s, now: %s", certPath, cert.NotAfter, time.Now())
 		return false
 	}
 

--- a/pkg/minikube/bootstrapper/certs_test.go
+++ b/pkg/minikube/bootstrapper/certs_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"k8s.io/minikube/pkg/minikube/command"
 	"k8s.io/minikube/pkg/minikube/config"
@@ -55,6 +56,7 @@ func TestSetupCerts(t *testing.T) {
 	expected := map[string]string{
 		`sudo /bin/bash -c "test -s /usr/share/ca-certificates/mycert.pem && ln -fs /usr/share/ca-certificates/mycert.pem /etc/ssl/certs/mycert.pem"`:             "-",
 		`sudo /bin/bash -c "test -s /usr/share/ca-certificates/minikubeCA.pem && ln -fs /usr/share/ca-certificates/minikubeCA.pem /etc/ssl/certs/minikubeCA.pem"`: "-",
+		`date -u +%d-%m-%y-%T`: time.Now().Format("02-01-06-15:04:05"),
 	}
 	f := command.NewFakeCommandRunner()
 	f.SetCommandToOutput(expected)

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -238,7 +238,7 @@ func (k *Bootstrapper) init(cfg config.ClusterConfig) error {
 		return errors.Wrap(err, "clearing stale configs")
 	}
 
-	conf := bsutil.KubeadmYamlPath
+	conf := constants.KubeadmYamlPath
 	ctx, cancel := context.WithTimeout(context.Background(), initTimeoutMinutes*time.Minute)
 	defer cancel()
 	kr, kw := io.Pipe()
@@ -429,7 +429,7 @@ func (k *Bootstrapper) StartCluster(cfg config.ClusterConfig) error {
 		// Fall-through to init
 	}
 
-	conf := bsutil.KubeadmYamlPath
+	conf := constants.KubeadmYamlPath
 	if _, err := k.c.RunCmd(exec.Command("sudo", "cp", conf+".new", conf)); err != nil {
 		return errors.Wrap(err, "cp")
 	}
@@ -678,7 +678,7 @@ func (k *Bootstrapper) restartControlPlane(cfg config.ClusterConfig) error {
 	}
 
 	// If the cluster is running, check if we have any work to do.
-	conf := bsutil.KubeadmYamlPath
+	conf := constants.KubeadmYamlPath
 
 	if !k.needsReconfigure(conf, hostname, port, client, cfg.KubernetesConfig.KubernetesVersion) {
 		klog.Infof("Taking a shortcut, as the cluster seems to be properly configured")
@@ -982,7 +982,7 @@ func (k *Bootstrapper) UpdateNode(cfg config.ClusterConfig, n config.Node, r cru
 	}
 
 	if n.ControlPlane {
-		files = append(files, assets.NewMemoryAssetTarget(kubeadmCfg, bsutil.KubeadmYamlPath+".new", "0640"))
+		files = append(files, assets.NewMemoryAssetTarget(kubeadmCfg, constants.KubeadmYamlPath+".new", "0640"))
 	}
 
 	// Installs compatibility shims for non-systemd environments

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -18,11 +18,13 @@ package constants
 
 import (
 	"errors"
+	"path"
 	"path/filepath"
 	"time"
 
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
+	"k8s.io/minikube/pkg/minikube/vmpath"
 )
 
 var (
@@ -203,4 +205,7 @@ var (
 
 	// ErrMachineMissing is returned when virtual machine does not exist due to user interrupt cancel(i.e. Ctrl + C)
 	ErrMachineMissing = errors.New("machine does not exist")
+
+	// KubeadmYamlPath is the path to the kubeadm configuration
+	KubeadmYamlPath = path.Join(vmpath.GuestEphemeralDir, "kubeadm.yaml")
 )

--- a/translations/de.json
+++ b/translations/de.json
@@ -980,6 +980,7 @@
 	"invalid kubernetes version": "Invalide Kubernetes Version",
 	"json encoding failure": "",
 	"keep the kube-context active after cluster is stopped. Defaults to false.": "Halte den kube-context aktiv, wenn der Cluster gestoppt ist. Default: false",
+	"kubeadm certificates have expired. Generating new ones...": "",
 	"kubeadm detected a TCP port conflict with another process: probably another local Kubernetes installation. Run lsof -p\u003cport\u003e to find the process and kill it": "kubeadm erkannte einen TCP Port Konflikt mit anderen Prozessen: wahrscheinlich eine andere lokale Kubernetes Installation. Führe lsof -p\u003cport\u003e aus um den Prozess zu finden und zu töten",
 	"kubectl and minikube configuration will be stored in {{.home_folder}}": "Konfiguration von Kubectl und minikube wird in {{.home_folder}} gespeichert",
 	"kubectl not found. If you need it, try: 'minikube kubectl -- get pods -A'": "kubectl nicht gefunden. Falls Sie es benötigen, versuchen Sie 'minikube kubectl -- get pods -A' aufzurufen",

--- a/translations/es.json
+++ b/translations/es.json
@@ -976,6 +976,7 @@
 	"invalid kubernetes version": "",
 	"json encoding failure": "",
 	"keep the kube-context active after cluster is stopped. Defaults to false.": "",
+	"kubeadm certificates have expired. Generating new ones...": "",
 	"kubeadm detected a TCP port conflict with another process: probably another local Kubernetes installation. Run lsof -p\u003cport\u003e to find the process and kill it": "",
 	"kubectl and minikube configuration will be stored in {{.home_folder}}": "La configuración de kubectl y de minikube se almacenará en {{.home_folder}}",
 	"kubectl not found. If you need it, try: 'minikube kubectl -- get pods -A'": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -961,6 +961,7 @@
 	"invalid kubernetes version": "version kubernetes invalide",
 	"json encoding failure": "échec de l'encodage json",
 	"keep the kube-context active after cluster is stopped. Defaults to false.": "garder le kube-context actif après l'arrêt du cluster. La valeur par défaut est false.",
+	"kubeadm certificates have expired. Generating new ones...": "",
 	"kubeadm detected a TCP port conflict with another process: probably another local Kubernetes installation. Run lsof -p\u003cport\u003e to find the process and kill it": "kubeadm a détecté un conflit de port TCP avec un autre processus : probablement une autre installation locale de Kubernetes. Exécutez lsof -p\u003cport\u003e pour trouver le processus et le tuer",
 	"kubectl and minikube configuration will be stored in {{.home_folder}}": "Les configurations kubectl et minikube seront stockées dans le dossier {{.home_folder}}.",
 	"kubectl not found. If you need it, try: 'minikube kubectl -- get pods -A'": "kubectl introuvable. Si vous en avez besoin, essayez : 'minikube kubectl -- get pods -A'",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -918,6 +918,7 @@
 	"invalid kubernetes version": "無効な Kubernetes バージョン",
 	"json encoding failure": "json エンコード失敗",
 	"keep the kube-context active after cluster is stopped. Defaults to false.": "クラスター停止後に kube-context をアクティブのままにします。デフォルトは false です。",
+	"kubeadm certificates have expired. Generating new ones...": "",
 	"kubeadm detected a TCP port conflict with another process: probably another local Kubernetes installation. Run lsof -p\u003cport\u003e to find the process and kill it": "kubeadm が他のプロセス (おそらくローカルにインストールされた他の Kubernetes) との TCP ポート衝突を検出しました。 lsof -p\u003cport\u003e を実行してそのプロセスを特定し、停止してください",
 	"kubectl and minikube configuration will be stored in {{.home_folder}}": "kubectl と minikube の構成は {{.home_folder}} に保存されます",
 	"kubectl not found. If you need it, try: 'minikube kubectl -- get pods -A'": "kubectl が見つかりません。kubectl が必要な場合、'minikube kubectl -- get pods -A' を試してください",

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -980,6 +980,7 @@
 	"invalid kubernetes version": "",
 	"json encoding failure": "",
 	"keep the kube-context active after cluster is stopped. Defaults to false.": "",
+	"kubeadm certificates have expired. Generating new ones...": "",
 	"kubeadm detected a TCP port conflict with another process: probably another local Kubernetes installation. Run lsof -p\u003cport\u003e to find the process and kill it": "",
 	"kubectl and minikube configuration will be stored in {{.home_folder}}": "kubectl 과 minikube 환경 정보는 {{.home_folder}} 에 저장될 것입니다",
 	"kubectl not found in PATH, but is required for the dashboard. Installation guide: https://kubernetes.io/docs/tasks/tools/install-kubectl/": "kubectl 이 PATH 에 없습니다, 하지만 이는 대시보드에서 필요로 합니다. 설치 가이드:https://kubernetes.io/docs/tasks/tools/install-kubectl/",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -988,6 +988,7 @@
 	"invalid kubernetes version": "Nieprawidłowa wersja Kubernetesa",
 	"json encoding failure": "",
 	"keep the kube-context active after cluster is stopped. Defaults to false.": "",
+	"kubeadm certificates have expired. Generating new ones...": "",
 	"kubeadm detected a TCP port conflict with another process: probably another local Kubernetes installation. Run lsof -p\u003cport\u003e to find the process and kill it": "",
 	"kubectl and minikube configuration will be stored in {{.home_folder}}": "konfiguracja minikube i kubectl będzie przechowywana w katalogu {{.home_folder}}",
 	"kubectl not found in PATH, but is required for the dashboard. Installation guide: https://kubernetes.io/docs/tasks/tools/install-kubectl/": "kubectl nie zostało odnalezione w zmiennej środowiskowej ${PATH}. Instrukcja instalacji:  https://kubernetes.io/docs/tasks/tools/install-kubectl/",

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -908,6 +908,7 @@
 	"invalid kubernetes version": "",
 	"json encoding failure": "",
 	"keep the kube-context active after cluster is stopped. Defaults to false.": "",
+	"kubeadm certificates have expired. Generating new ones...": "",
 	"kubeadm detected a TCP port conflict with another process: probably another local Kubernetes installation. Run lsof -p\u003cport\u003e to find the process and kill it": "",
 	"kubectl and minikube configuration will be stored in {{.home_folder}}": "",
 	"kubectl not found. If you need it, try: 'minikube kubectl -- get pods -A'": "",

--- a/translations/strings.txt
+++ b/translations/strings.txt
@@ -908,6 +908,7 @@
 	"invalid kubernetes version": "",
 	"json encoding failure": "",
 	"keep the kube-context active after cluster is stopped. Defaults to false.": "",
+	"kubeadm certificates have expired. Generating new ones...": "",
 	"kubeadm detected a TCP port conflict with another process: probably another local Kubernetes installation. Run lsof -p\u003cport\u003e to find the process and kill it": "",
 	"kubectl and minikube configuration will be stored in {{.home_folder}}": "",
 	"kubectl not found. If you need it, try: 'minikube kubectl -- get pods -A'": "",

--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -1096,6 +1096,7 @@
 	"invalid kubernetes version": "",
 	"json encoding failure": "",
 	"keep the kube-context active after cluster is stopped. Defaults to false.": "",
+	"kubeadm certificates have expired. Generating new ones...": "",
 	"kubeadm detected a TCP port conflict with another process: probably another local Kubernetes installation. Run lsof -p\u003cport\u003e to find the process and kill it": "kubeadm 检测一个到与其他进程的 TCP 端口冲突：或许是另外的本地安装的 Kubernetes 导致。执行 lsof -p\u003cport\u003e  查找并杀死这些进程",
 	"kubectl and minikube configuration will be stored in {{.home_folder}}": "kubectl 和 minikube 配置将存储在 {{.home_folder}} 中",
 	"kubectl not found. If you need it, try: 'minikube kubectl -- get pods -A'": "",


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/16201

Explanation for below commands in before and after:
```
$ sudo timedatectl set-time 2024-03-03
$ minikube ssh -- sudo service kubelet restart
```
When testing my changes I ran into the kubelet certs being expired. I found the following comment https://github.com/kubernetes/kubeadm/issues/2054#issuecomment-595318438:
> normally this will not happen because the kubelet certificate manager has logic to monitor for certificate expiration and it will auto-rotate your client certificates once ~70% of the expiration period is reached. by forcing a date you are bypassing this mechanism and you end up with a certificate which was not rotated.

Manually forcing the date forward beyond kubelets certs expiration date was resulting in the certs not being rotated at all, so set the time less than a year, restart the kubelet service to force the certs rotation, then move time forward to make kubeadm certs be expired, but not far enough to make the kubelet certs expired. This would be handled for us if a cluster was running for a year.

```
# start minikube
# kubeadm expiration: 2024-04-07 kubelet expiration: 2024-04-07
# set time to 2024-03-03
# refresh kubelet certs
# kubeadm expiration: 2024-04-07 kubelet expiration: 2025-03-03
# set time to 2025-02-02
# kubeadm expiration: 2024-04-07 (EXPIRED) kubelet expiration: 2025-03-03 (VALID)
```

**Before:**
```
$ minikube start
$ sudo timedatectl set-ntp no
$ sudo timedatectl set-time 2024-03-03
$ minikube ssh -- sudo service kubelet restart
$ minikube stop
$ sudo timedatectl set-time 2025-02-02
$ minikube start
...
W0810 00:00:52.022507    4629 certs.go:521] WARNING: could not validate bounds for certificate apiserver-kubelet-client: the certificate has expired: NotBefore: 2023-04-04 17:14:07 +0000 UTC, NotAfter: 2024-04-04 17:14:09 +0000 UTC
error execution phase certs/apiserver-kubelet-client: [certs] certificate apiserver-kubelet-client not signed by CA certificate ca: x509: certificate has expired or is not yet valid: current time 2025-08-10T00:00:52Z is after 2024-04-04T17:14:09Z
To see the stack trace of this error execute with --v=5 or higher


╭───────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                           │
│    😿  If the above advice does not help, please let us know:                             │
│    👉  https://github.com/kubernetes/minikube/issues/new/choose                           │
│                                                                                           │
│    Please run `minikube logs --file=logs.txt` and attach logs.txt to the GitHub issue.    │
│                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────╯
```

**After:**
```
$ minikube start
$ sudo timedatectl set-ntp no
$ sudo timedatectl set-time 2024-03-03
$ minikube ssh -- sudo service kubelet restart
$ minikube stop
$ sudo timedatectl set-time 2025-02-02
$ minikube start
😄  minikube v1.30.1 on Debian 11.6 (amd64)
✨  Using the docker driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔄  Restarting existing docker container for "minikube" ...
❗  This container is having trouble accessing https://registry.k8s.io
💡  To pull new external images, you may need to configure a proxy: https://minikube.sigs.k8s.io/docs/reference/networking/proxy/
🐳  Preparing Kubernetes v1.26.3 on Docker 23.0.2 ...
❗  kubeadm certificates have expired. Generating new ones...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```

```
❗  This container is having trouble accessing https://registry.k8s.io
💡  To pull new external images, you may need to configure a proxy: https://minikube.sigs.k8s.io/docs/reference/networking/proxy/
```
Is due to SSL certs being expired with forced time change