### PR TITLE
Doc: Fix link to GitHub open issues label for drivers

### DIFF
--- a/site/content/en/docs/drivers/docker.md
+++ b/site/content/en/docs/drivers/docker.md
@@ -72,6 +72,8 @@ The `--container-runtime` flag must be set to "containerd" or "cri-o". "containe
 
    `sudo mkdir /sys/fs/cgroup/systemd && sudo mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd`.
 
+Also see [co/docker-driver open issues](https://github.com/kubernetes/minikube/labels/co%2Fdocker-driver).
+
 ## Troubleshooting
 
 [comment]: <> (this title is used in the docs links, don't change)

--- a/site/content/en/docs/drivers/hyperv.md
+++ b/site/content/en/docs/drivers/hyperv.md
@@ -20,7 +20,7 @@ The `minikube start` command supports additional hyperv specific flags:
 
 ## Issues
 
-Also see [co/hyperv open issues](https://github.com/kubernetes/minikube/labels/co%2Fhyperv)
+Also see [co/hyperv open issues](https://github.com/kubernetes/minikube/labels/co%2Fhyperv).
 
 ## Troubleshooting
 

--- a/site/content/en/docs/drivers/kvm2.md
+++ b/site/content/en/docs/drivers/kvm2.md
@@ -36,7 +36,7 @@ The `minikube start` command supports 5 additional KVM specific flags:
 * KVM VM's cannot be used simultaneously with VirtualBox  [#4913](https://github.com/kubernetes/minikube/issues/4913)
 * On some distributions, libvirt bridge networking may fail until the host reboots
 
-Also see [co/kvm2 open issues](https://github.com/kubernetes/minikube/labels/co%2Fkvm2)
+Also see [co/kvm2-driver open issues](https://github.com/kubernetes/minikube/labels/co%2Fkvm2-driver).
 
 ### Nested Virtulization
 

--- a/site/content/en/docs/drivers/parallels.md
+++ b/site/content/en/docs/drivers/parallels.md
@@ -13,7 +13,7 @@ The Parallels driver is particularly useful for users who own Parallels Desktop 
 
 ## Issues
 
-* [Full list of open 'parallels' driver issues](https://github.com/kubernetes/minikube/labels/co%2Fparallels)
+* [Full list of open 'parallels' driver issues](https://github.com/kubernetes/minikube/labels/co%2Fparallels-driver)
 
 ## Troubleshooting
 

--- a/site/content/en/docs/drivers/podman.md
+++ b/site/content/en/docs/drivers/podman.md
@@ -43,6 +43,8 @@ podman system connection default podman-machine-default-root
 podman info
 ```
 
+Also see [co/podman-driver open issues](https://github.com/kubernetes/minikube/labels/co%2Fpodman-driver).
+
 ## Troubleshooting
 
 - Run `minikube start --alsologtostderr -v=7` to debug errors and crashes


### PR DESCRIPTION
Fixed the broken link to the open issues label for the drivers:
- kvm2
- parallels

Added a link to the open issues for the drivers:
- docker
- podman

Added a dot to the end of the sentence (nitpick) for hyperv.