### PR TITLE
Kicbase: Resolve docker build deprecation

### DIFF
--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -148,7 +148,7 @@ RUN export ARCH=$(dpkg --print-architecture | sed 's/armhf/arm-v7/') && \
     sh -c "echo 'deb https://download.docker.com/linux/ubuntu ${DIST} stable' > /etc/apt/sources.list.d/docker.list" && \
     curl -L https://download.docker.com/linux/ubuntu/gpg -o docker.key && \
     apt-key add - < docker.key && \
-    clean-install docker-ce docker-ce-cli containerd.io
+    clean-install docker-ce docker-ce-cli containerd.io docker-buildx-plugin
 
 # install buildkit
 RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/' | sed 's/armhf/arm-v7/') \

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -24,14 +24,14 @@ import (
 
 const (
 	// Version is the current version of kic
-	Version = "v0.0.39"
+	Version = "v0.0.39-1680813808-16252"
 
 	// SHA of the kic base image
-	baseImageSHA = "bf2d9f1e9d837d8deea073611d2605405b6be904647d97ebd9b12045ddfe1106"
+	baseImageSHA = "4d62d233cf4143189be209981d7b5b8b7fbf20ac03586d159c4c05276e84e45f"
 	// The name of the GCR kicbase repository
-	gcrRepo = "gcr.io/k8s-minikube/kicbase"
+	gcrRepo = "gcr.io/k8s-minikube/kicbase-builds"
 	// The name of the Dockerhub kicbase repository
-	dockerhubRepo = "docker.io/kicbase/stable"
+	dockerhubRepo = "docker.io/kicbase/build"
 )
 
 var (

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -26,7 +26,7 @@ minikube start [flags]
       --apiserver-names strings           A set of apiserver names which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine
       --apiserver-port int                The apiserver listening port (default 8443)
       --auto-update-drivers               If set, automatically updates drivers to the latest version. Defaults to true. (default true)
-      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase:v0.0.39@sha256:bf2d9f1e9d837d8deea073611d2605405b6be904647d97ebd9b12045ddfe1106")
+      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.39-1680813808-16252@sha256:4d62d233cf4143189be209981d7b5b8b7fbf20ac03586d159c4c05276e84e45f")
       --binary-mirror string              Location to fetch kubectl, kubelet, & kubeadm binaries from.
       --cache-images                      If true, cache docker images for the current bootstrapper and load them into the machine. Always false with --driver=none. (default true)
       --cert-expiration duration          Duration until minikube certificate expiration, defaults to three years (26280h). (default 26280h0m0s)

--- a/test/integration/image_test.go
+++ b/test/integration/image_test.go
@@ -95,7 +95,11 @@ func validateImageBuildWithBuildArg(ctx context.Context, t *testing.T, profile s
 	if err != nil {
 		t.Fatalf("failed to build image with args: %q : %v", rr.Command(), err)
 	}
-	output := rr.Stderr.String()
+	output := rr.Stdout.String()
+	// kicbase Docker uses buildx plugin which outputs build logs to stderr
+	if KicDriver() {
+		output = rr.Stderr.String()
+	}
 	if !strings.Contains(output, "test_env_str") {
 		t.Fatalf("failed to pass build-args with args: %q : %s", rr.Command(), output)
 	}

--- a/test/integration/image_test.go
+++ b/test/integration/image_test.go
@@ -95,11 +95,7 @@ func validateImageBuildWithBuildArg(ctx context.Context, t *testing.T, profile s
 	if err != nil {
 		t.Fatalf("failed to build image with args: %q : %v", rr.Command(), err)
 	}
-	output := rr.Stdout.String()
-	// kicbase Docker uses buildx plugin which outputs build logs to stderr
-	if KicDriver() {
-		output = rr.Stderr.String()
-	}
+	output := rr.Output()
 	if !strings.Contains(output, "test_env_str") {
 		t.Fatalf("failed to pass build-args with args: %q : %s", rr.Command(), output)
 	}

--- a/test/integration/image_test.go
+++ b/test/integration/image_test.go
@@ -95,7 +95,7 @@ func validateImageBuildWithBuildArg(ctx context.Context, t *testing.T, profile s
 	if err != nil {
 		t.Fatalf("failed to build image with args: %q : %v", rr.Command(), err)
 	}
-	output := rr.Stdout.String()
+	output := rr.Stderr.String()
 	if !strings.Contains(output, "test_env_str") {
 		t.Fatalf("failed to pass build-args with args: %q : %s", rr.Command(), output)
 	}


### PR DESCRIPTION
**Before:**
```
docker@minikube:~$ docker build
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            Install the buildx component to build images with BuildKit:
            https://docs.docker.com/go/buildx/

"docker build" requires exactly 1 argument.
See 'docker build --help'.

Usage:  docker build [OPTIONS] PATH | URL | -

Build an image from a Dockerfile
```

**After:**
```
docker@minikube:~$ docker build
ERROR: "docker buildx build" requires exactly 1 argument.
See 'docker buildx build --help'.

Usage:  docker buildx build [OPTIONS] PATH | URL | -

Start a build
```