### PR TITLE
crio: allow ping in containers

### DIFF
--- a/deploy/iso/minikube-iso/package/crio-bin/crio.conf
+++ b/deploy/iso/minikube-iso/package/crio-bin/crio.conf
@@ -164,6 +164,7 @@ default_capabilities = [
 # List of default sysctls. If it is empty or commented out, only the sysctls
 # defined in the container json file by the user/kube will be added.
 default_sysctls = [
+	"net.ipv4.ping_group_range=0 2147483647", # Allow all users to emit ICMP ECHO msgs, i.e. ping
 ]
 
 # List of additional devices. specified as


### PR DESCRIPTION
This allows users to emit ICMP echo messages via an IPPROTO_ICMP socket, i.e. ping another pod. Useful for debugging network connectivity in minikube pods.
