### PR TITLE
CI: only comment tests with < 50% flake rate

### DIFF
--- a/hack/jenkins/test-flake-chart/report_flakes.sh
+++ b/hack/jenkins/test-flake-chart/report_flakes.sh
@@ -78,7 +78,7 @@ awk -F, 'NR>1 {
 # 4) Sort failed test flake rates based on the flakiness of that test - stable tests should be first on the list.
 # 5) Append to file $TMP_FAILED_RATES.
 awk -F, 'NR>1 {
-  printf "%s:%s,%s\n", $1, $2, $3
+  if ($3 < 50) printf "%s:%s,%s\n", $1, $2, $3
 }' "$TMP_FLAKE_RATES" \
   | sort -t, -k1,1 \
   | join -t , -j 1 "$TMP_DATA" - \


### PR DESCRIPTION
Comment example: https://github.com/kubernetes/minikube/pull/16214#issuecomment-1493759787

Now will only output tests that have a flake < 50%
