### PR TITLE
CI: Fix cron restarting active machines

### DIFF
--- a/hack/jenkins/cron/cleanup_and_reboot_Linux.sh
+++ b/hack/jenkins/cron/cleanup_and_reboot_Linux.sh
@@ -124,4 +124,7 @@ systemctl list-unit-files --state=enabled \
         | xargs systemctl disable
 
 # update and reboot
-apt update -y && apt upgrade -y && apt-get autoclean && reboot
+check_jenkins
+apt update -y && apt upgrade -y && apt-get autoclean
+check_jenkins
+reboot


### PR DESCRIPTION
The check if  Jenkins was running was only being checked at the start of the script. This caused an issue as the cron would start, Jenkins wouldn't be running so it starts the cleanup and reboot process, then during the process a job was picked up by the machine, but we didn't check if a job was running before rebooting, causing job sometimes being terminated.

This was most commonly affecting our Jenkins jobs that ran on a cron, the machines would be restarted 6 minutes past the hour. Both the restart cron and job kicked off at the top of the hour, but the restart cron would start slightly before causing it to not detect the job and would reboot once it finished.