### PR TITLE
Doc: add mapped permission issue on start with virtualbox driver

### DIFF
--- a/site/content/en/docs/drivers/virtualbox.md
+++ b/site/content/en/docs/drivers/virtualbox.md
@@ -21,6 +21,16 @@ minikube start supports some VirtualBox specific flags:
 
 ## Issues
 
+### System policy prevents management of local virtualized systems
+
+If you are facing this problem you need to add your user to libvirt group:
+
+```shell
+sudo usermod -a -G libvirt $USER
+```
+
+### Other
+
 * [Full list of open 'virtualbox' driver issues](https://github.com/kubernetes/minikube/labels/co%2Fvirtualbox)
 
 ## Troubleshooting


### PR DESCRIPTION
I've mapped this behaviour with minikube start on fedora 36, the process was not finishing the start because my user wasn't in the libvirt group.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
