### PR TITLE
[doc] Add hint for using rootless containers in multi-node tutorial

### DIFF
--- a/site/content/en/docs/tutorials/multi_node.md
+++ b/site/content/en/docs/tutorials/multi_node.md
@@ -16,7 +16,10 @@ date: 2019-11-24
 
 ## Caveat
 
-Default [host-path volume provisioner]({{< ref "/docs/handbook/persistent_volumes" >}}) doesn't support multi-node clusters ([#12360](https://github.com/kubernetes/minikube/issues/12360)). To be able to provision or claim volumes in multi-node clusters, you could use [CSI Hostpath Driver]({{< ref "/docs/tutorials/volume_snapshots_and_csi" >}}) addon.
+- Default [host-path volume provisioner]({{< ref "/docs/handbook/persistent_volumes" >}}) doesn't support multi-node clusters ([#12360](https://github.com/kubernetes/minikube/issues/12360)). To be able to provision or claim volumes in multi-node clusters, you could use [CSI Hostpath Driver]({{< ref "/docs/tutorials/volume_snapshots_and_csi" >}}) addon.
+
+- If you use rootless Docker containers, you won't have a bridge network for your cluster, which means that you would need a port forward to communicate with the service.
+```minikube service list -p multinode-demo``` only shows service URLs that are directly accessible. Therefore you won't see the service URL in the last step if you use rootless containers.
 
 ## Tutorial
 


### PR DESCRIPTION
This PR adds a hint to the multi-node tutorial as requested in #16271 .
When using rootless containers for this tutorial, the user won't see the service URL because the service URL is not directly accessible by the user.
This is due to a missing bridge network when using rootless containers.