### PR TITLE
update slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ See minikube in action [here](https://minikube.sigs.k8s.io/docs/handbook/control
 
 minikube is a Kubernetes [#sig-cluster-lifecycle](https://github.com/kubernetes/community/tree/master/sig-cluster-lifecycle)  project.
 
-* [**#minikube on Kubernetes Slack**](https://kubernetes.slack.com) - Live chat with minikube developers!
+* [**#minikube on Kubernetes Slack**](https://kubernetes.slack.com/messages/minikube) - Live chat with minikube developers!
 * [minikube-users mailing list](https://groups.google.com/g/minikube-users)
 * [minikube-dev mailing list](https://groups.google.com/g/minikube-dev)
 


### PR DESCRIPTION
Fix: link address doesn't match "minikube" channel
