### PR TITLE
CI: Cloud Shell file touch failing to due no dir

### DIFF
--- a/hack/jenkins/cloud_shell_functional_tests_docker.sh
+++ b/hack/jenkins/cloud_shell_functional_tests_docker.sh
@@ -40,6 +40,7 @@ gcloud cloud-shell ssh --authorize-session << EOF
  ROOT_JOB_ID=$ROOT_JOB_ID
 
  # Prevent cloud-shell is ephemeral warnings on apt-get
+ mkdir ~/.cloudshell
  touch ~/.cloudshell/no-apt-get-warning
 
  gsutil -m cp -r gs://minikube-builds/${MINIKUBE_LOCATION}/installers .


### PR DESCRIPTION
```
touch: cannot touch '/home/g528047478195_compute/.cloudshell/no-apt-get-warning': No such file or directory
```