### PR TITLE
CI: Fix conformance tests script

### DIFF
--- a/hack/conformance_tests.sh
+++ b/hack/conformance_tests.sh
@@ -73,9 +73,10 @@ documentation_url: https://minikube.sigs.k8s.io/docs/
 product_logo_url: https://raw.githubusercontent.com/kubernetes/minikube/master/images/logo/logo.svg
 type: installer
 description: minikube runs a local Kubernetes cluster on macOS, Linux, and Windows.
+contact_email_address: minikube-dev@googlegroups.com
 EOF
 
-cat <<EOF >README.md
+cat <<"EOF" >README.md
 # Reproducing the test results
 
 ## Run minikube with docker driver


### PR DESCRIPTION
Without wrapping `EOF` in quotes, it attempts to run the code in the backticks, resulting in the following:
```
14:46:28 ./hack/conformance_tests.sh: line 78: console: command not found
14:46:28 ./hack/conformance_tests.sh: command substitution: line 79: syntax error near unexpected token `newline'
14:46:28 ./hack/conformance_tests.sh: command substitution: line 79: `% cd <minikube dir>'
14:46:28 ++ console
14:46:28 ./hack/conformance_tests.sh: line 78: console: command not found
14:46:28 ./hack/conformance_tests.sh: command substitution: line 79: syntax error near unexpected token `newline'
14:46:28 ./hack/conformance_tests.sh: command substitution: line 79: `% cd <minikube dir>'
```