### PR TITLE
CI: fix not updating cri-dockerd version

### DIFF
--- a/hack/jenkins/linux_integration_tests_none.sh
+++ b/hack/jenkins/linux_integration_tests_none.sh
@@ -70,21 +70,26 @@ if ! which socat &>/dev/null; then
 fi
 
 # cri-dockerd is required for Kubernetes v1.24+ with none driver
-if ! cri-dockerd --version &>/dev/null; then
-  echo "WARNING: cri-dockerd is not installed. will try to install."
-  CRI_DOCKERD_VERSION="v0.3.1"
+CRI_DOCKERD_VERSION="0.3.1"
+if [[ $(cri-dockerd --version 2>&1) != *"$CRI_DOCKERD_VERSION"* ]]; then
+  echo "WARNING: expected version of cri-dockerd is not installed. will try to install."
+  sudo systemctl stop cri-docker.socket || true
+  sudo systemctl stop cri-docker.service || true
   CRI_DOCKERD_COMMIT="9a87d6ae274ecf0f23776920964d6484bd679282"
   CRI_DOCKERD_BASE_URL="https://storage.googleapis.com/kicbase-artifacts/cri-dockerd/${CRI_DOCKERD_COMMIT}"
   sudo curl -L "${CRI_DOCKERD_BASE_URL}/amd64/cri-dockerd" -o /usr/bin/cri-dockerd
   sudo curl -L "${CRI_DOCKERD_BASE_URL}/cri-docker.socket" -o /usr/lib/systemd/system/cri-docker.socket
   sudo curl -L "${CRI_DOCKERD_BASE_URL}/cri-docker.service" -o /usr/lib/systemd/system/cri-docker.service
   sudo chmod +x /usr/bin/cri-dockerd
+  sudo systemctl daemon-reload
+  sudo systemctl enable cri-docker.service
+  sudo systemctl enable --now cri-docker.socket
 fi
 
 # crictl is required for Kubernetes v1.24+ with none driver
-if ! crictl &>/dev/null; then
-  echo "WARNING: crictl is not installed. will try to install."
-  CRICTL_VERSION="v1.17.0"
+CRICTL_VERSION="v1.17.0"
+if [[ $(crictl --version) != *"$CRICTL_VERSION"* ]]; then
+  echo "WARNING: expected version of crictl is not installed. will try to install."
   curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/$CRICTL_VERSION/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz --output crictl-${CRICTL_VERSION}-linux-amd64.tar.gz
   sudo tar zxvf crictl-$CRICTL_VERSION-linux-amd64.tar.gz -C /usr/local/bin
 fi

--- a/hack/update/cri_dockerd_version/update_cri_dockerd_version.go
+++ b/hack/update/cri_dockerd_version/update_cri_dockerd_version.go
@@ -47,7 +47,7 @@ var (
 		},
 		"hack/jenkins/linux_integration_tests_none.sh": {
 			Replace: map[string]string{
-				`CRI_DOCKERD_VERSION=".*"`: `CRI_DOCKERD_VERSION="v{{.Version}}"`,
+				`CRI_DOCKERD_VERSION=".*"`: `CRI_DOCKERD_VERSION="{{.Version}}"`,
 				`CRI_DOCKERD_COMMIT=".*"`:  `CRI_DOCKERD_COMMIT="{{.FullCommit}}"`,
 			},
 		},


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/16381

Added checking if the version of cri-dockerd matches the version we expect, it if doesn't install the latest version of cri-dockerd. Also added the same for crictl.