### PR TITLE
none driver: fix image build

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1581,7 +1581,7 @@ func validateInsecureRegistry() {
 	}
 }
 
-func createNode(cc config.ClusterConfig, kubeNodeName string, existing *config.ClusterConfig) (config.ClusterConfig, config.Node, error) {
+func createNode(cc config.ClusterConfig, existing *config.ClusterConfig) (config.ClusterConfig, config.Node, error) {
 	// Create the initial node, which will necessarily be a control plane
 	if existing != nil {
 		cp, err := config.PrimaryControlPlane(existing)
@@ -1608,7 +1608,6 @@ func createNode(cc config.ClusterConfig, kubeNodeName string, existing *config.C
 		Port:              cc.KubernetesConfig.NodePort,
 		KubernetesVersion: getKubernetesVersion(&cc),
 		ContainerRuntime:  getContainerRuntime(&cc),
-		Name:              kubeNodeName,
 		ControlPlane:      true,
 		Worker:            true,
 	}

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -329,11 +329,7 @@ func generateClusterConfig(cmd *cobra.Command, existing *config.ClusterConfig, k
 		proxy.SetDockerEnv()
 	}
 
-	var kubeNodeName string
-	if driver.BareMetal(cc.Driver) {
-		kubeNodeName = "m01"
-	}
-	return createNode(cc, kubeNodeName, existing)
+	return createNode(cc, existing)
 }
 
 func getCPUCount(drvName string) int {

--- a/pkg/minikube/node/node.go
+++ b/pkg/minikube/node/node.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/kapi"
 	"k8s.io/minikube/pkg/minikube/config"
-	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/machine"
 )
 
@@ -156,10 +155,6 @@ func Delete(cc config.ClusterConfig, name string) (*config.Node, error) {
 
 // Retrieve finds the node by name in the given cluster
 func Retrieve(cc config.ClusterConfig, name string) (*config.Node, int, error) {
-	if driver.BareMetal(cc.Driver) {
-		name = "m01"
-	}
-
 	for i, n := range cc.Nodes {
 		if n.Name == name {
 			return &n, i, nil


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/16385

The cause was from the below lines:
https://github.com/kubernetes/minikube/blob/6d9a5bfaa1a14d120ab38827a5eef24991e68e31/cmd/minikube/cmd/start_flags.go#L333-L335
https://github.com/kubernetes/minikube/blob/6d9a5bfaa1a14d120ab38827a5eef24991e68e31/pkg/minikube/machine/build_images.go#L85-L87

The none driver if statement was causing `n.Name` to be `m01`, which then caused `nodeName != n.Name` to be `true` as `nodeName` was empty but `n.Name` was `m01`, hitting the `continue` causing no build to occur.

**Before:**
```
$ sudo -E minikube image build -t test:latest ../test --alsologtostderr
I0427 01:52:48.094340   44206 out.go:296] Setting OutFile to fd 1 ...
I0427 01:52:48.094538   44206 out.go:348] isatty.IsTerminal(1) = true
I0427 01:52:48.094558   44206 out.go:309] Setting ErrFile to fd 2...
I0427 01:52:48.094564   44206 out.go:348] isatty.IsTerminal(2) = true
I0427 01:52:48.094675   44206 root.go:336] Updating PATH: /home/jenkins/.minikube/bin
W0427 01:52:48.094794   44206 root.go:312] Error reading config file at /home/jenkins/.minikube/config/config.json: open /home/jenkins/.minikube/config/config.json: no such file or directory
I0427 01:52:48.095219   44206 config.go:182] Loaded profile config "minikube": Driver=none, ContainerRuntime=docker, KubernetesVersion=v1.26.3
I0427 01:52:48.095624   44206 config.go:182] Loaded profile config "minikube": Driver=none, ContainerRuntime=docker, KubernetesVersion=v1.26.3
I0427 01:52:48.095652   44206 build_images.go:123] succeeded building to: 
I0427 01:52:48.095661   44206 build_images.go:124] failed building to: 
```

**After:**
```
$ sudo -E minikube image build -t test:latest ../test --alsologtostderr
I0427 02:01:40.472852   53708 out.go:296] Setting OutFile to fd 1 ...
I0427 02:01:40.473042   53708 out.go:348] isatty.IsTerminal(1) = true
I0427 02:01:40.473057   53708 out.go:309] Setting ErrFile to fd 2...
I0427 02:01:40.473074   53708 out.go:348] isatty.IsTerminal(2) = true
I0427 02:01:40.473188   53708 root.go:336] Updating PATH: /home/jenkins/.minikube/bin
W0427 02:01:40.473344   53708 root.go:312] Error reading config file at /home/jenkins/.minikube/config/config.json: open /home/jenkins/.minikube/config/config.json: no such file or directory
I0427 02:01:40.473828   53708 config.go:182] Loaded profile config "minikube": Driver=none, ContainerRuntime=docker, KubernetesVersion=v1.26.3
I0427 02:01:40.474332   53708 config.go:182] Loaded profile config "minikube": Driver=none, ContainerRuntime=docker, KubernetesVersion=v1.26.3
I0427 02:01:40.474558   53708 exec_runner.go:51] Run: systemctl --version
I0427 02:01:40.476643   53708 kubeconfig.go:92] found "minikube" server: "https://10.138.0.48:8443"
I0427 02:01:40.476673   53708 api_server.go:166] Checking apiserver status ...
I0427 02:01:40.476705   53708 exec_runner.go:51] Run: sudo pgrep -xnf kube-apiserver.*minikube.*
I0427 02:01:40.494438   53708 exec_runner.go:51] Run: sudo egrep ^[0-9]+:freezer: /proc/52175/cgroup
I0427 02:01:40.505467   53708 api_server.go:182] apiserver freezer: "3:freezer:/kubepods/burstable/pod1946fe5227089af505b39a701a0481e2/07fc6ee85cae390207e47a22099cb9e1b2de1ad57543609274fe168b0c04af49"
I0427 02:01:40.505529   53708 exec_runner.go:51] Run: sudo cat /sys/fs/cgroup/freezer/kubepods/burstable/pod1946fe5227089af505b39a701a0481e2/07fc6ee85cae390207e47a22099cb9e1b2de1ad57543609274fe168b0c04af49/freezer.state
I0427 02:01:40.515685   53708 api_server.go:204] freezer state: "THAWED"
I0427 02:01:40.515717   53708 api_server.go:253] Checking apiserver healthz at https://10.138.0.48:8443/healthz ...
I0427 02:01:40.519666   53708 api_server.go:279] https://10.138.0.48:8443/healthz returned 200:
ok
I0427 02:01:40.519877   53708 build_images.go:151] Building image from path: /tmp/build.2939681210.tar
I0427 02:01:40.519916   53708 exec_runner.go:51] Run: sudo mkdir -p /var/lib/minikube/build
I0427 02:01:40.530156   53708 exec_runner.go:151] cp: /tmp/build.2939681210.tar --> /var/lib/minikube/build/build.2939681210.tar (2048 bytes)
I0427 02:01:40.530283   53708 exec_runner.go:51] Run: sudo cp -a /tmp/minikube2208548583 /var/lib/minikube/build/build.2939681210.tar
I0427 02:01:40.540666   53708 exec_runner.go:51] Run: sudo mkdir -p /var/lib/minikube/build/build.2939681210
I0427 02:01:40.549022   53708 exec_runner.go:51] Run: sudo tar -C /var/lib/minikube/build/build.2939681210 -xf /var/lib/minikube/build/build.2939681210.tar
I0427 02:01:40.559651   53708 docker.go:336] Building image: /var/lib/minikube/build/build.2939681210
I0427 02:01:40.559708   53708 exec_runner.go:51] Run: docker build -t test:latest /var/lib/minikube/build/build.2939681210
#1 [internal] load .dockerignore
#1 transferring context: 2B done
#1 DONE 0.0s

#2 [internal] load build definition from Dockerfile
#2 transferring dockerfile: 73B done
#2 DONE 0.0s

#3 [internal] load metadata for docker.io/library/alpine:latest
#3 DONE 0.6s

#4 [1/2] FROM docker.io/library/alpine:latest@sha256:124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126
#4 CACHED

#5 [2/2] RUN echo "hello"
#5 0.248 hello
#5 DONE 0.3s

#6 exporting to image
#6 exporting layers 0.0s done
#6 writing image sha256:2d1a7a3871bc40aa321d870a4e13bb50ee452be61a536273799cd881dcb6b6f2 done
#6 naming to docker.io/library/test:latest done
#6 DONE 0.0s
I0427 02:01:41.635100   53708 exec_runner.go:84] Completed: docker build -t test:latest /var/lib/minikube/build/build.2939681210: (1.075360167s)
I0427 02:01:41.635158   53708 exec_runner.go:51] Run: sudo rm -rf /var/lib/minikube/build/build.2939681210
I0427 02:01:41.660332   53708 exec_runner.go:51] Run: sudo rm -f /var/lib/minikube/build/build.2939681210.tar
I0427 02:01:41.687267   53708 build_images.go:207] Built test:latest from /tmp/build.2939681210.tar
I0427 02:01:41.687303   53708 build_images.go:123] succeeded building to: minikube
I0427 02:01:41.687318   53708 build_images.go:124] failed building to: 
```