### PR TITLE
Fix csi hostpath custom registry error

### DIFF
--- a/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-plugin.yaml.tmpl
+++ b/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-plugin.yaml.tmpl
@@ -137,7 +137,7 @@ spec:
           - --health-port=9898
 
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v3.3.0
+          image: {{.CustomRegistries.Provisioner  | default .ImageRepository | default .Registries.Provisioner }}{{.Images.Provisioner}}
           args:
             - -v=5
             - --csi-address=/csi/csi.sock


### PR DESCRIPTION
Fix the problem that the image address in the csi hostpath template is fixed and cannot be customized.