### PR TITLE
Fix `minikube start` not working without `sudo` on none driver

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -547,7 +547,7 @@ jobs:
           chmod a+x e2e-*
           chmod a+x minikube-*
           START_TIME=$(date -u +%s)
-          KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome sudo -E ./e2e-linux-amd64 -minikube-start-args=--driver=none -test.timeout=10m -test.v -timeout-multiplier=1.5 -test.run TestFunctional -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+          KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--driver=none -test.timeout=10m -test.v -timeout-multiplier=1.5 -test.run TestFunctional -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
           END_TIME=$(date -u +%s)
           TIME_ELAPSED=$(($END_TIME-$START_TIME))
           min=$((${TIME_ELAPSED}/60))

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -667,7 +667,7 @@ jobs:
           chmod a+x minikube-*
           MINIKUBE_HOME=$(pwd)/testhome ./minikube-linux-amd64 delete --all --purge
           START_TIME=$(date -u +%s)
-          KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome sudo -E ./e2e-linux-amd64 -minikube-start-args=--driver=none -test.timeout=10m -test.v -timeout-multiplier=1.5 -test.run TestFunctional -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
+          KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-linux-amd64 -minikube-start-args=--driver=none -test.timeout=10m -test.v -timeout-multiplier=1.5 -test.run TestFunctional -binary=./minikube-linux-amd64 2>&1 | tee ./report/testout.txt
           END_TIME=$(date -u +%s)
           TIME_ELAPSED=$(($END_TIME-$START_TIME))
           min=$((${TIME_ELAPSED}/60))

--- a/Makefile
+++ b/Makefile
@@ -367,7 +367,7 @@ integration: out/minikube$(IS_EXE) ## Trigger minikube integration test, logs to
 
 .PHONY: integration-none-driver
 integration-none-driver: e2e-linux-$(GOARCH) out/minikube-linux-$(GOARCH)  ## Trigger minikube none driver test, logs to ./out/testout_COMMIT.txt
-	sudo -E out/e2e-linux-$(GOARCH) -testdata-dir "test/integration/testdata" -minikube-start-args="--driver=none" -test.v -test.timeout=60m -binary=out/minikube-linux-amd64 $(TEST_ARGS) 2>&1 | tee "./out/testout_$(COMMIT_SHORT).txt"
+	out/e2e-linux-$(GOARCH) -testdata-dir "test/integration/testdata" -minikube-start-args="--driver=none" -test.v -test.timeout=60m -binary=out/minikube-linux-amd64 $(TEST_ARGS) 2>&1 | tee "./out/testout_$(COMMIT_SHORT).txt"
 
 .PHONY: integration-versioned
 integration-versioned: out/minikube ## Trigger minikube integration testing, logs to ./out/testout_COMMIT.txt

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -292,7 +292,7 @@ function cleanup_procs() {
   if [[ "${kprocs}" != "" ]]; then
     echo "error: killing hung kubectl processes ..."
     ps -f -p ${kprocs} || true
-    sudo kill ${kprocs} || true
+    kill ${kprocs} || true
   fi
 
 
@@ -302,10 +302,10 @@ function cleanup_procs() {
     echo "Found stale api servers listening on 8443 processes to kill: "
     for p in $none_procs
     do
-      echo "Kiling stale none driver:  $p"
-      sudo ps -f -p $p || true
-      sudo kill $p || true
-      sudo kill -9 $p || true
+      echo "Killing stale none driver: $p"
+      ps -f -p $p || true
+      kill $p || true
+      kill -9 $p || true
     done
   fi
 }

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -123,7 +123,6 @@ echo "driver:    ${DRIVER}"
 echo "runtime:   ${CONTAINER_RUNTIME}"
 echo "job:       ${JOB_NAME}"
 echo "test home: ${TEST_HOME}"
-echo "sudo:      ${SUDO_PREFIX}"
 echo "kernel:    $(uname -v)"
 echo "uptime:    $(uptime)"
 # Setting KUBECONFIG prevents the version check from erroring out due to permission issues
@@ -293,7 +292,7 @@ function cleanup_procs() {
   if [[ "${kprocs}" != "" ]]; then
     echo "error: killing hung kubectl processes ..."
     ps -f -p ${kprocs} || true
-    sudo -E kill ${kprocs} || true
+    sudo kill ${kprocs} || true
   fi
 
 
@@ -304,9 +303,9 @@ function cleanup_procs() {
     for p in $none_procs
     do
       echo "Kiling stale none driver:  $p"
-      sudo -E ps -f -p $p || true
-      sudo -E kill $p || true
-      sudo -E kill -9 $p || true
+      sudo ps -f -p $p || true
+      sudo kill $p || true
+      sudo kill -9 $p || true
     done
   fi
 }
@@ -387,7 +386,7 @@ touch "${JSON_OUT}"
 
 gotestsum --jsonfile "${JSON_OUT}" -f standard-verbose --raw-command -- \
   go tool test2json -t \
-  ${SUDO_PREFIX}${E2E_BIN} \
+  ${E2E_BIN} \
     -minikube-start-args="--driver=${DRIVER} ${EXTRA_START_ARGS}" \
     -test.timeout=${TIMEOUT} -test.v \
     ${EXTRA_TEST_ARGS} \
@@ -484,16 +483,16 @@ else
 fi
 
 echo ">> Cleaning up after ourselves ..."
-timeout 3m ${SUDO_PREFIX}${MINIKUBE_BIN} tunnel --cleanup || true
-timeout 5m ${SUDO_PREFIX}${MINIKUBE_BIN} delete --all --purge >/dev/null 2>/dev/null || true
+timeout 3m ${MINIKUBE_BIN} tunnel --cleanup || true
+timeout 5m ${MINIKUBE_BIN} delete --all --purge >/dev/null 2>/dev/null || true
 cleanup_stale_routes || true
 
-${SUDO_PREFIX} rm -Rf "${MINIKUBE_HOME}" || true
-${SUDO_PREFIX} rm -f "${KUBECONFIG}" || true
-${SUDO_PREFIX} rm -f "${TEST_OUT}" || true
-${SUDO_PREFIX} rm -f "${JSON_OUT}" || true
-${SUDO_PREFIX} rm -f "${HTML_OUT}" || true
-${SUDO_PREFIX} rm -f "${SUMMARY_OUT}" || true
+rm -Rf "${MINIKUBE_HOME}" || true
+rm -f "${KUBECONFIG}" || true
+rm -f "${TEST_OUT}" || true
+rm -f "${JSON_OUT}" || true
+rm -f "${HTML_OUT}" || true
+rm -f "${SUMMARY_OUT}" || true
 
 rmdir "${TEST_HOME}" || true
 echo ">> ${TEST_HOME} completed at $(date)"

--- a/hack/jenkins/linux_integration_tests_none.sh
+++ b/hack/jenkins/linux_integration_tests_none.sh
@@ -31,9 +31,6 @@ DRIVER="none"
 JOB_NAME="none_Linux"
 EXTRA_START_ARGS="--bootstrapper=kubeadm"
 
-SUDO_PREFIX="sudo -E "
-export KUBECONFIG="/root/.kube/config"
-
 if ! kubeadm &>/dev/null; then
   echo "WARNING: kubeadm is not installed. will try to install."
   curl -LO "https://dl.k8s.io/release/$(curl -sSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubeadm"

--- a/hack/jenkins/linux_integration_tests_none.sh
+++ b/hack/jenkins/linux_integration_tests_none.sh
@@ -31,6 +31,9 @@ DRIVER="none"
 JOB_NAME="none_Linux"
 EXTRA_START_ARGS="--bootstrapper=kubeadm"
 
+# add install location of iptables and conntrack to PATH
+PATH="/usr/sbin:$PATH"
+
 if ! kubeadm &>/dev/null; then
   echo "WARNING: kubeadm is not installed. will try to install."
   curl -LO "https://dl.k8s.io/release/$(curl -sSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubeadm"

--- a/pkg/minikube/command/command_runner.go
+++ b/pkg/minikube/command/command_runner.go
@@ -210,7 +210,7 @@ func writeFile(dst string, f assets.CopyableFile, perms os.FileMode) error {
 		return fmt.Errorf("%s: expected to write %d bytes, but wrote %d instead", dst, f.GetLength(), n)
 	}
 
-	if err := w.Chmod(os.FileMode(perms)); err != nil {
+	if err := w.Chmod(perms); err != nil {
 		return errors.Wrap(err, "chmod")
 	}
 

--- a/pkg/minikube/command/command_runner.go
+++ b/pkg/minikube/command/command_runner.go
@@ -209,5 +209,10 @@ func writeFile(dst string, f assets.CopyableFile, perms os.FileMode) error {
 	if n != int64(f.GetLength()) {
 		return fmt.Errorf("%s: expected to write %d bytes, but wrote %d instead", dst, f.GetLength(), n)
 	}
+
+	if err := w.Chmod(os.FileMode(perms)); err != nil {
+		return errors.Wrap(err, "chmod")
+	}
+
 	return w.Close()
 }

--- a/pkg/minikube/command/exec_runner.go
+++ b/pkg/minikube/command/exec_runner.go
@@ -162,23 +162,24 @@ func (e *execRunner) Copy(f assets.CopyableFile) error {
 		// write to temp location ...
 		tmpfile, err := os.CreateTemp("", "minikube")
 		if err != nil {
-			return errors.Wrapf(err, "error creating tempfile")
+			return errors.Wrap(err, "error creating tempfile")
 		}
 		defer os.Remove(tmpfile.Name())
-		err = writeFile(tmpfile.Name(), f, os.FileMode(perms))
-		if err != nil {
+
+		// ... set the file permission ...
+		if err := tmpfile.Chmod(os.FileMode(perms)); err != nil {
+			return errors.Wrap(err, "error setting file permissions")
+		}
+
+		if err := writeFile(tmpfile.Name(), f, os.FileMode(perms)); err != nil {
 			return errors.Wrapf(err, "error writing to tempfile %s", tmpfile.Name())
 		}
 
-		// ... then use sudo to move to target ...
-		_, err = e.RunCmd(exec.Command("sudo", "cp", "-a", tmpfile.Name(), dst))
-		if err != nil {
+		// ... then use sudo to move to target
+		if _, err := e.RunCmd(exec.Command("sudo", "cp", "-a", tmpfile.Name(), dst)); err != nil {
 			return errors.Wrapf(err, "error copying tempfile %s to dst %s", tmpfile.Name(), dst)
 		}
-
-		// ... then fix file permission that should have been fine because of "cp -a"
-		err = os.Chmod(dst, os.FileMode(perms))
-		return err
+		return nil
 	}
 	return writeFile(dst, f, os.FileMode(perms))
 }

--- a/pkg/minikube/command/exec_runner.go
+++ b/pkg/minikube/command/exec_runner.go
@@ -166,11 +166,6 @@ func (e *execRunner) Copy(f assets.CopyableFile) error {
 		}
 		defer os.Remove(tmpfile.Name())
 
-		// ... set the file permission ...
-		if err := tmpfile.Chmod(os.FileMode(perms)); err != nil {
-			return errors.Wrap(err, "error setting file permissions")
-		}
-
 		if err := writeFile(tmpfile.Name(), f, os.FileMode(perms)); err != nil {
 			return errors.Wrapf(err, "error writing to tempfile %s", tmpfile.Name())
 		}

--- a/site/content/en/docs/drivers/includes/none_usage.inc
+++ b/site/content/en/docs/drivers/includes/none_usage.inc
@@ -21,8 +21,6 @@ This VM must also meet the [kubeadm requirements](https://kubernetes.io/docs/set
 
 ## Usage
 
-The none driver requires minikube to be run as root, until [#3760](https://github.com/kubernetes/minikube/issues/3760) can be addressed.
-
 ```shell
 minikube start --driver=none
 ```

--- a/site/content/en/docs/drivers/includes/none_usage.inc
+++ b/site/content/en/docs/drivers/includes/none_usage.inc
@@ -24,7 +24,7 @@ This VM must also meet the [kubeadm requirements](https://kubernetes.io/docs/set
 The none driver requires minikube to be run as root, until [#3760](https://github.com/kubernetes/minikube/issues/3760) can be addressed.
 
 ```shell
-sudo -E minikube start --driver=none
+minikube start --driver=none
 ```
 
 To make `none` the default driver:

--- a/site/content/en/docs/drivers/none.md
+++ b/site/content/en/docs/drivers/none.md
@@ -68,7 +68,7 @@ As Kubernetes has full access to both your filesystem as well as your docker ima
 * Many `minikube` commands are not supported, such as: `dashboard`, `mount`, `ssh`
 * minikube with the `none` driver has a confusing permissions model, as some commands need to be run as root ("start"), and others by a regular user ("dashboard")
 * CoreDNS detects resolver loop, goes into CrashLoopBackOff - [#3511](https://github.com/kubernetes/minikube/issues/3511)
-* Some versions of Linux have a version of docker that is newer than what Kubernetes expects. To overwrite this, run minikube with the following parameters: `sudo -E minikube start --driver=none --kubernetes-version v1.11.8 --extra-config kubeadm.ignore-preflight-errors=SystemVerification`
+* Some versions of Linux have a version of docker that is newer than what Kubernetes expects. To overwrite this, run minikube with the following parameters: `minikube start --driver=none --kubernetes-version v1.11.8 --extra-config kubeadm.ignore-preflight-errors=SystemVerification`
 
 * [Full list of open 'none' driver issues](https://github.com/kubernetes/minikube/labels/co%2Fnone-driver)
 

--- a/test/integration/none_test.go
+++ b/test/integration/none_test.go
@@ -31,11 +31,11 @@ import (
 	"k8s.io/minikube/pkg/minikube/localpath"
 )
 
-// TestChangeNoneUser tests to make sure the CHANGE_MINIKUBE_NONE_USER environemt variable is respected
+// TestChangeNoneUser tests to make sure the CHANGE_MINIKUBE_NONE_USER environment variable is respected
 // and changes the minikube file permissions from root to the correct user.
 func TestChangeNoneUser(t *testing.T) {
-	if !NoneDriver() {
-		t.Skip("Only test none driver.")
+	if !NoneDriver() || os.Getenv("SUDO_USER") == "" {
+		t.Skip("Test requires none driver and SUDO_USER env to not be empty")
 	}
 	MaybeParallel(t)
 
@@ -64,11 +64,7 @@ func TestChangeNoneUser(t *testing.T) {
 		t.Errorf("%s failed: %v", rr.Command(), err)
 	}
 
-	username := os.Getenv("SUDO_USER")
-	if username == "" {
-		t.Fatal("Expected $SUDO_USER env to not be empty")
-	}
-	u, err := user.Lookup(username)
+	u, err := user.Lookup(os.Getenv("SUDO_USER"))
 	if err != nil {
 		t.Fatalf("Getting user failed: %v", err)
 	}

--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -69,6 +69,10 @@ func legacyVersion() string {
 			version = "v1.9.0"
 		}
 	}
+	if NoneDriver() {
+		// oldest version where none driver doesn't have to be run as root
+		version = "v1.16.0"
+	}
 	// the version containerd in ISO was upgraded to 1.4.2
 	// we need it to use runc.v2 plugin
 	// note: Test*BinaryUpgrade require minikube v1.22+ to satisfy newer containerd config structure


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/16400
Closes https://github.com/kubernetes/minikube/issues/16393

Discovered that the regression was caused by https://github.com/kubernetes/minikube/commit/fd549f396dbd39385baefe88dcead0ccf99f1bff

https://github.com/kubernetes/minikube/blob/fd549f396dbd39385baefe88dcead0ccf99f1bff/pkg/minikube/cni/cni.go#L171-L175

Before, no CNI would be used, but now if using Docker CRI with K8s v1.24+, we default to using the bridge CNI and it's failing to `chmod` the bridge conflist `chmod /etc/cni/net.d/1-k8s.conflist: permission denied`.

The cause of the chmod permission error is we were calling `os.Chmod` on files in the `/var/lib/minikube/binaries/<K8s_version>` dir which has the ownership of `root:root`, causing the error.

Changed it so we chmod the file in the tmp dir before we copy them to their destination, as we may not have permission to chmod them after we copy them, like above.

Also removed `sudo -E` from none docs and none tests so we will catch something like this going forward.