### PR TITLE
Feature: Make kubeadm.applyNodeLabels apply label to all nodes

### DIFF
--- a/pkg/minikube/bootstrapper/bootstrapper.go
+++ b/pkg/minikube/bootstrapper/bootstrapper.go
@@ -35,6 +35,7 @@ type LogOptions struct {
 
 // Bootstrapper contains all the methods needed to bootstrap a Kubernetes cluster
 type Bootstrapper interface {
+	ApplyNodeLabels(config.ClusterConfig) error
 	StartCluster(config.ClusterConfig) error
 	UpdateCluster(config.ClusterConfig) error
 	DeleteCluster(config.KubernetesConfig) error

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -1035,8 +1035,11 @@ func kubectlPath(cfg config.ClusterConfig) string {
 	return path.Join(vmpath.GuestPersistentDir, "binaries", cfg.KubernetesConfig.KubernetesVersion, "kubectl")
 }
 
+func (k *Bootstrapper) ApplyNodeLabels(cfg config.ClusterConfig) error {
+	return k.applyNodeLabels(cfg)
+}
+
 // applyNodeLabels applies minikube labels to all the nodes
-// but it's currently called only from kubeadm.StartCluster (via kubeadm.init) where there's only one - first node
 func (k *Bootstrapper) applyNodeLabels(cfg config.ClusterConfig) error {
 	// time cluster was created. time format is based on ISO 8601 (RFC 3339)
 	// converting - and : to _ because of Kubernetes label restriction
@@ -1048,8 +1051,12 @@ func (k *Bootstrapper) applyNodeLabels(cfg config.ClusterConfig) error {
 	// ensure that "primary" label is applied only to the 1st node in the cluster (used eg for placing ingress there)
 	// this is used to uniquely distinguish that from other nodes in multi-master/multi-control-plane cluster config
 	primaryLbl := "minikube.k8s.io/primary=false"
+
+	// ensure that "primary" label is not removed when apply label to all others nodes
+	applyToNodes := "-l minikube.k8s.io/primary!=true"
 	if len(cfg.Nodes) <= 1 {
 		primaryLbl = "minikube.k8s.io/primary=true"
+		applyToNodes = "--all"
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), applyTimeoutSeconds*time.Second)
@@ -1057,7 +1064,7 @@ func (k *Bootstrapper) applyNodeLabels(cfg config.ClusterConfig) error {
 	// example:
 	// sudo /var/lib/minikube/binaries/<version>/kubectl label nodes minikube.k8s.io/version=<version> minikube.k8s.io/commit=aa91f39ffbcf27dcbb93c4ff3f457c54e585cf4a-dirty minikube.k8s.io/name=p1 minikube.k8s.io/updated_at=2020_02_20T12_05_35_0700 --all --overwrite --kubeconfig=/var/lib/minikube/kubeconfig
 	cmd := exec.CommandContext(ctx, "sudo", kubectlPath(cfg),
-		"label", "nodes", verLbl, commitLbl, nameLbl, createdAtLbl, primaryLbl, "--all", "--overwrite",
+		"label", "nodes", verLbl, commitLbl, nameLbl, createdAtLbl, primaryLbl, applyToNodes, "--overwrite",
 		fmt.Sprintf("--kubeconfig=%s", path.Join(vmpath.GuestPersistentDir, "kubeconfig")))
 
 	if _, err := k.c.RunCmd(cmd); err != nil {

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -339,6 +339,9 @@ func joinCluster(starter Starter, cpBs bootstrapper.Bootstrapper, bs bootstrappe
 		return fmt.Errorf("error joining worker node to cluster: %w", err)
 	}
 
+	if err := cpBs.ApplyNodeLabels(*starter.Cfg); err != nil {
+		return fmt.Errorf("error applying node label: %w", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
The `kubeadm.applyNodeLabels` only apply labels to the primary node. With this PR it will apply labels every time a new node joins the cluster.

closes #16415