### PR TITLE
Only wait for KIC base image when using KIC driver

### DIFF
--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -87,7 +87,9 @@ func handleDownloadOnly(cacheGroup, kicGroup *errgroup.Group, k8sVersion, contai
 		exit.Error(reason.InetCacheKubectl, "Failed to cache kubectl", err)
 	}
 	waitCacheRequiredImages(cacheGroup)
-	waitDownloadKicBaseImage(kicGroup)
+	if driver.IsKIC(driverName) {
+		waitDownloadKicBaseImage(kicGroup)
+	}
 	if err := saveImagesToTarFromConfig(); err != nil {
 		exit.Error(reason.InetCacheTar, "Failed to cache images to tar", err)
 	}


### PR DESCRIPTION
Prevent outputting message about downloading kic artifacts if not using kic driver

**Before:**
```
$ minikube start --driver qemu --download-only --alsologtostderr
...
I0502 15:19:50.838287   54902 binary.go:76] Not caching binary, using https://dl.k8s.io/release/v1.26.3/bin/darwin/arm64/kubectl?checksum=file:https://dl.k8s.io/release/v1.26.3/bin/darwin/arm64/kubectl.sha256
I0502 15:19:50.838298   54902 cache.go:193] Successfully downloaded all kic artifacts
I0502 15:19:50.842395   54902 out.go:177] ✅  Download complete!
```

**After:**
```
$ minikube start --driver qemu --download-only --alsologtostderr
...
I0502 15:22:17.692883   55316 binary.go:76] Not caching binary, using https://dl.k8s.io/release/v1.26.3/bin/darwin/arm64/kubectl?checksum=file:https://dl.k8s.io/release/v1.26.3/bin/darwin/arm64/kubectl.sha256
I0502 15:22:17.697828   55316 out.go:177] ✅  Download complete!
```