### PR TITLE
CI: Build arm64 kvm image on actual arm64

### DIFF
--- a/.github/workflows/functional_verified.yml
+++ b/.github/workflows/functional_verified.yml
@@ -39,7 +39,6 @@ jobs:
         with:
           go-version: ${{env.GO_VERSION}}
           cache-dependency-path: ./go.sum
-      - uses: docker/setup-buildx-action@4b4e9c3e2d4531116a6f8ba8e71fc6e2cb6e6c8c
       - name: Download Dependencies
         run: go mod download
       - name: Build Binaries

--- a/.github/workflows/functional_verified.yml
+++ b/.github/workflows/functional_verified.yml
@@ -39,6 +39,8 @@ jobs:
         with:
           go-version: ${{env.GO_VERSION}}
           cache-dependency-path: ./go.sum
+      - uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18
+      - uses: docker/setup-buildx-action@4b4e9c3e2d4531116a6f8ba8e71fc6e2cb6e6c8c
       - name: Download Dependencies
         run: go mod download
       - name: Build Binaries

--- a/.github/workflows/functional_verified.yml
+++ b/.github/workflows/functional_verified.yml
@@ -39,7 +39,6 @@ jobs:
         with:
           go-version: ${{env.GO_VERSION}}
           cache-dependency-path: ./go.sum
-      - uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18
       - uses: docker/setup-buildx-action@4b4e9c3e2d4531116a6f8ba8e71fc6e2cb6e6c8c
       - name: Download Dependencies
         run: go mod download

--- a/Makefile
+++ b/Makefile
@@ -871,15 +871,15 @@ out/docker-machine-driver-kvm2-$(RPM_VERSION)-0.%.rpm: out/docker-machine-driver
 
 .PHONY: kvm-image-amd64
 kvm-image-amd64: installers/linux/kvm/Dockerfile.amd64  ## Convenient alias to build the docker container
-	docker build --platform linux/amd64 --build-arg "GO_VERSION=$(KVM_GO_VERSION)" -t $(KVM_BUILD_IMAGE_AMD64) -f $< $(dir $<)
+	docker build --build-arg "GO_VERSION=$(KVM_GO_VERSION)" -t $(KVM_BUILD_IMAGE_AMD64) -f $< $(dir $<)
 	@echo ""
 	@echo "$(@) successfully built"
 
 .PHONY: kvm-image-arm64
 kvm-image-arm64: installers/linux/kvm/Dockerfile.arm64  ## Convenient alias to build the docker container
-	# below line allows building multi-arch images
+	# line below installs QEMU static binaries to allow docker multi-arch build, see: https://github.com/docker/setup-qemu-action
 	docker run --rm --privileged tonistiigi/binfmt:latest --install all
-	docker build --platform linux/arm64 --build-arg "GO_VERSION=$(KVM_GO_VERSION)" -t $(KVM_BUILD_IMAGE_ARM64) -f $< $(dir $<)
+	docker buildx build --load --platform linux/arm64 --build-arg "GO_VERSION=$(KVM_GO_VERSION)" -t $(KVM_BUILD_IMAGE_ARM64) -f $< $(dir $<)
 	@echo ""
 	@echo "$(@) successfully built"
 

--- a/Makefile
+++ b/Makefile
@@ -877,6 +877,8 @@ kvm-image-amd64: installers/linux/kvm/Dockerfile.amd64  ## Convenient alias to b
 
 .PHONY: kvm-image-arm64
 kvm-image-arm64: installers/linux/kvm/Dockerfile.arm64  ## Convenient alias to build the docker container
+	# below line is required to build from amd64 machine: https://github.com/docker/buildx/issues/495#issuecomment-754688157
+	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 	docker build --platform linux/arm64 --build-arg "GO_VERSION=$(KVM_GO_VERSION)" -t $(KVM_BUILD_IMAGE_ARM64) -f $< $(dir $<)
 	@echo ""
 	@echo "$(@) successfully built"

--- a/Makefile
+++ b/Makefile
@@ -871,13 +871,13 @@ out/docker-machine-driver-kvm2-$(RPM_VERSION)-0.%.rpm: out/docker-machine-driver
 
 .PHONY: kvm-image-amd64
 kvm-image-amd64: installers/linux/kvm/Dockerfile.amd64  ## Convenient alias to build the docker container
-	docker build --build-arg "GO_VERSION=$(KVM_GO_VERSION)" -t $(KVM_BUILD_IMAGE_AMD64) -f $< $(dir $<)
+	docker build --platform linux/amd64 --build-arg "GO_VERSION=$(KVM_GO_VERSION)" -t $(KVM_BUILD_IMAGE_AMD64) -f $< $(dir $<)
 	@echo ""
 	@echo "$(@) successfully built"
 
 .PHONY: kvm-image-arm64
 kvm-image-arm64: installers/linux/kvm/Dockerfile.arm64  ## Convenient alias to build the docker container
-	docker build --build-arg "GO_VERSION=$(KVM_GO_VERSION)" -t $(KVM_BUILD_IMAGE_ARM64) -f $< $(dir $<)
+	docker build --platform linux/arm64 --build-arg "GO_VERSION=$(KVM_GO_VERSION)" -t $(KVM_BUILD_IMAGE_ARM64) -f $< $(dir $<)
 	@echo ""
 	@echo "$(@) successfully built"
 

--- a/Makefile
+++ b/Makefile
@@ -877,8 +877,8 @@ kvm-image-amd64: installers/linux/kvm/Dockerfile.amd64  ## Convenient alias to b
 
 .PHONY: kvm-image-arm64
 kvm-image-arm64: installers/linux/kvm/Dockerfile.arm64  ## Convenient alias to build the docker container
-	# below line is required to build from amd64 machine: https://github.com/docker/buildx/issues/495#issuecomment-754688157
-	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+	# below line allows building multi-arch images
+	docker run --rm --privileged tonistiigi/binfmt:latest --install all
 	docker build --platform linux/arm64 --build-arg "GO_VERSION=$(KVM_GO_VERSION)" -t $(KVM_BUILD_IMAGE_ARM64) -f $< $(dir $<)
 	@echo ""
 	@echo "$(@) successfully built"

--- a/Makefile
+++ b/Makefile
@@ -879,7 +879,7 @@ kvm-image-amd64: installers/linux/kvm/Dockerfile.amd64  ## Convenient alias to b
 kvm-image-arm64: installers/linux/kvm/Dockerfile.arm64  ## Convenient alias to build the docker container
 	# line below installs QEMU static binaries to allow docker multi-arch build, see: https://github.com/docker/setup-qemu-action
 	docker run --rm --privileged tonistiigi/binfmt:latest --install all
-	docker buildx build --load --platform linux/arm64 --build-arg "GO_VERSION=$(KVM_GO_VERSION)" -t $(KVM_BUILD_IMAGE_ARM64) -f $< $(dir $<)
+	docker buildx build --platform linux/arm64 --build-arg "GO_VERSION=$(KVM_GO_VERSION)" -t $(KVM_BUILD_IMAGE_ARM64) -f $< $(dir $<)
 	@echo ""
 	@echo "$(@) successfully built"
 

--- a/installers/linux/kvm/Dockerfile.arm64
+++ b/installers/linux/kvm/Dockerfile.arm64
@@ -14,30 +14,20 @@
 
 FROM ubuntu:20.04
 
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y --no-install-recommends \
+                ca-certificates \
+                gcc \
+                libc6-dev \
+                make \
+                pkg-config \
+                curl \
+                libvirt-dev \
+                git \
+        && rm -rf /var/lib/apt/lists/*
+
 ARG GO_VERSION
 
-RUN apt update
-
-RUN echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal main universe multiverse" >> /etc/apt/sources.list && \
-    echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-updates main universe restricted multiverse" >> /etc/apt/sources.list && \
-    dpkg --add-architecture arm64 && \
-    (apt update || true)
-
-RUN DEBIAN_FRONTEND=noninteractive \
-    apt install \
-    -o APT::Immediate-Configure=false -y \
-    gcc-aarch64-linux-gnu \
-    make \
-    pkg-config \
-    curl \
-    libvirt-dev:arm64 && \
-    dpkg --configure -a
-
-RUN curl -sSL https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl -sSL https://go.dev/dl/go${GO_VERSION}.linux-arm64.tar.gz | tar -C /usr/local -xzf -
 
 ENV GOPATH /go
-
-ENV CC=aarch64-linux-gnu-gcc
-ENV CGO_ENABLED=1
-ENV PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/go/bin


### PR DESCRIPTION
We're currently building our arm64 KVM docker machine image on an amd64 base image and hacking arm64 dependencies in. This is resulting in flaky building that's been resulting in 404s when trying to apt install.

```
10:58:42 #6 13.76 E: Failed to fetch http://security.ubuntu.com/ubuntu/dists/focal-security/main/binary-arm64/Packages  404  Not Found [IP: 91.189.91.39 80]
10:58:42 #6 13.76 E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/focal/restricted/binary-arm64/Packages  404  Not Found [IP: 185.125.190.39 80]
10:58:42 #6 13.76 E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/focal-updates/multiverse/binary-arm64/Packages  404  Not Found [IP: 185.125.190.39 80]
10:58:42 #6 13.76 E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/focal-backports/universe/binary-arm64/Packages  404  Not Found [IP: 185.125.190.39 80]
```

Set `--platform linux/aXX64` on the build so the base image uses its respective arch. Then we can install the deps like normal.