### PR TITLE
Fix not prepending `unix://` to CRI socket

### DIFF
--- a/hack/update/kubernetes_version/templates/v1beta3/containerd-api-port.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta3/containerd-api-port.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /run/containerd/containerd.sock
+  criSocket: unix:///run/containerd/containerd.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/hack/update/kubernetes_version/templates/v1beta3/containerd-pod-network-cidr.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta3/containerd-pod-network-cidr.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /run/containerd/containerd.sock
+  criSocket: unix:///run/containerd/containerd.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/hack/update/kubernetes_version/templates/v1beta3/containerd.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta3/containerd.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /run/containerd/containerd.sock
+  criSocket: unix:///run/containerd/containerd.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/hack/update/kubernetes_version/templates/v1beta3/crio-options-gates.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta3/crio-options-gates.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/crio/crio.sock
+  criSocket: unix:///var/run/crio/crio.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/hack/update/kubernetes_version/templates/v1beta3/crio.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta3/crio.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/crio/crio.sock
+  criSocket: unix:///var/run/crio/crio.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/hack/update/kubernetes_version/templates/v1beta3/default.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta3/default.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/dockershim.sock
+  criSocket: unix:///var/run/dockershim.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/hack/update/kubernetes_version/templates/v1beta3/dns.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta3/dns.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/dockershim.sock
+  criSocket: unix:///var/run/dockershim.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/hack/update/kubernetes_version/templates/v1beta3/image-repository.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta3/image-repository.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/dockershim.sock
+  criSocket: unix:///var/run/dockershim.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/hack/update/kubernetes_version/templates/v1beta3/options.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta3/options.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/dockershim.sock
+  criSocket: unix:///var/run/dockershim.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta3.go
+++ b/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta3.go
@@ -34,7 +34,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: {{if .CRISocket}}{{.CRISocket}}{{else}}/var/run/dockershim.sock{{end}}
+  criSocket: {{if .CRISocket}}{{if .PrependCriSocketUnix}}unix://{{end}}{{.CRISocket}}{{else}}{{if .PrependCriSocketUnix}}unix://{{end}}/var/run/dockershim.sock{{end}}
   name: "{{.NodeName}}"
   kubeletExtraArgs:
     node-ip: {{.NodeIP}}

--- a/pkg/minikube/bootstrapper/bsutil/kubeadm.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubeadm.go
@@ -124,6 +124,7 @@ func GenerateKubeadmYAML(cc config.ClusterConfig, n config.Node, r cruntime.Mana
 		KubeProxyOptions           map[string]string
 		ResolvConfSearchRegression bool
 		KubeletConfigOpts          map[string]string
+		PrependCriSocketUnix       bool
 	}{
 		CertDir:           vmpath.GuestKubernetesCertsDir,
 		ServiceCIDR:       constants.DefaultServiceCIDR,
@@ -168,6 +169,9 @@ func GenerateKubeadmYAML(cc config.ClusterConfig, n config.Node, r cruntime.Mana
 	// v1beta3 isn't required until v1.23.
 	if version.GTE(semver.MustParse("1.23.0")) {
 		configTmpl = ktmpl.V1Beta3
+	}
+	if version.GTE(semver.MustParse("1.24.0-alpha.2")) {
+		opts.PrependCriSocketUnix = true
 	}
 	klog.Infof("kubeadm options: %+v", opts)
 	b := bytes.Buffer{}

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.24/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.24/containerd-api-port.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /run/containerd/containerd.sock
+  criSocket: unix:///run/containerd/containerd.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.24/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.24/containerd-pod-network-cidr.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /run/containerd/containerd.sock
+  criSocket: unix:///run/containerd/containerd.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.24/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.24/containerd.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /run/containerd/containerd.sock
+  criSocket: unix:///run/containerd/containerd.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.24/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.24/crio-options-gates.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/crio/crio.sock
+  criSocket: unix:///var/run/crio/crio.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.24/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.24/crio.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/crio/crio.sock
+  criSocket: unix:///var/run/crio/crio.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.24/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.24/default.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/dockershim.sock
+  criSocket: unix:///var/run/dockershim.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.24/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.24/dns.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/dockershim.sock
+  criSocket: unix:///var/run/dockershim.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.24/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.24/image-repository.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/dockershim.sock
+  criSocket: unix:///var/run/dockershim.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.24/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.24/options.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/dockershim.sock
+  criSocket: unix:///var/run/dockershim.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.25/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.25/containerd-api-port.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /run/containerd/containerd.sock
+  criSocket: unix:///run/containerd/containerd.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.25/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.25/containerd-pod-network-cidr.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /run/containerd/containerd.sock
+  criSocket: unix:///run/containerd/containerd.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.25/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.25/containerd.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /run/containerd/containerd.sock
+  criSocket: unix:///run/containerd/containerd.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.25/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.25/crio-options-gates.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/crio/crio.sock
+  criSocket: unix:///var/run/crio/crio.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.25/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.25/crio.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/crio/crio.sock
+  criSocket: unix:///var/run/crio/crio.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.25/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.25/default.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/dockershim.sock
+  criSocket: unix:///var/run/dockershim.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.25/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.25/dns.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/dockershim.sock
+  criSocket: unix:///var/run/dockershim.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.25/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.25/image-repository.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/dockershim.sock
+  criSocket: unix:///var/run/dockershim.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.25/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.25/options.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/dockershim.sock
+  criSocket: unix:///var/run/dockershim.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.26/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.26/containerd-api-port.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /run/containerd/containerd.sock
+  criSocket: unix:///run/containerd/containerd.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.26/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.26/containerd-pod-network-cidr.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /run/containerd/containerd.sock
+  criSocket: unix:///run/containerd/containerd.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.26/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.26/containerd.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /run/containerd/containerd.sock
+  criSocket: unix:///run/containerd/containerd.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.26/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.26/crio-options-gates.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/crio/crio.sock
+  criSocket: unix:///var/run/crio/crio.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.26/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.26/crio.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/crio/crio.sock
+  criSocket: unix:///var/run/crio/crio.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.26/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.26/default.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/dockershim.sock
+  criSocket: unix:///var/run/dockershim.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.26/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.26/dns.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/dockershim.sock
+  criSocket: unix:///var/run/dockershim.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.26/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.26/image-repository.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/dockershim.sock
+  criSocket: unix:///var/run/dockershim.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.26/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.26/options.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/dockershim.sock
+  criSocket: unix:///var/run/dockershim.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.27/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.27/containerd-api-port.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /run/containerd/containerd.sock
+  criSocket: unix:///run/containerd/containerd.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.27/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.27/containerd-pod-network-cidr.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /run/containerd/containerd.sock
+  criSocket: unix:///run/containerd/containerd.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.27/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.27/containerd.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /run/containerd/containerd.sock
+  criSocket: unix:///run/containerd/containerd.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.27/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.27/crio-options-gates.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/crio/crio.sock
+  criSocket: unix:///var/run/crio/crio.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.27/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.27/crio.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/crio/crio.sock
+  criSocket: unix:///var/run/crio/crio.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.27/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.27/default.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/dockershim.sock
+  criSocket: unix:///var/run/dockershim.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.27/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.27/dns.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/dockershim.sock
+  criSocket: unix:///var/run/dockershim.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.27/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.27/image-repository.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/dockershim.sock
+  criSocket: unix:///var/run/dockershim.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.27/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.27/options.yaml
@@ -11,7 +11,7 @@ bootstrapTokens:
       - signing
       - authentication
 nodeRegistration:
-  criSocket: /var/run/dockershim.sock
+  criSocket: unix:///var/run/dockershim.sock
   name: "mk"
   kubeletExtraArgs:
     node-ip: 1.1.1.1


### PR DESCRIPTION
Starting minikube would make kubeadm output the following warning:
```
Usage of CRI endpoints without URL scheme is deprecated and can cause kubelet errors in the future. Automatically prepending scheme "unix" to the "criSocket" with value "/var/run/cri-dockerd.sock". Please update your configuration!
```

Prepended `unix://` to the CRI socket