### PR TITLE
Add old and new version to 'update-ubuntu-version' automation

### DIFF
--- a/.github/workflows/update-ubuntu-version.yml
+++ b/.github/workflows/update-ubuntu-version.yml
@@ -22,7 +22,9 @@ jobs:
       - name: Bump Ubuntu version
         id: bumpUbuntu
         run: |
+          echo "OLD_VERSION=$(DEP=ubuntu make get-dependency-version)" >> $GITHUB_OUTPUT
           make update-ubuntu-version
+          echo "NEW_VERSION=$(DEP=ubuntu make get-dependency-version)" >> $GITHUB_OUTPUT
           c=$(git status --porcelain)
           c="${c//$'\n'/'%0A'}"
           c="${c//$'\r'/'%0D'}"
@@ -35,14 +37,14 @@ jobs:
         uses: peter-evans/create-pull-request@284f54f989303d2699d373481a0cfa13ad5a6666
         with:
           token: ${{ secrets.MINIKUBE_BOT_PAT }}
-          commit-message: update ubuntu:focal image version
+          commit-message: 'Kicbase: Bump ubuntu:focal from ${{ steps.bumpUbuntu.outputs.OLD_VERSION }} to ${{ steps.bumpUbuntu.outpus.NEW_VERSION }}'
           committer: minikube-bot <minikube-bot@google.com>
           author: minikube-bot <minikube-bot@google.com>
           branch: auto_bump_ubuntu_version
           push-to-fork: minikube-bot/minikube
           base: master
           delete-branch: true
-          title: 'Kicbase: Bump ubuntu:focal image version'
+          title: 'Kicbase: Bump ubuntu:focal from ${{ steps.bumpUbuntu.outputs.OLD_VERSION }} to ${{ steps.bumpUbuntu.outpus.NEW_VERSION }}'
           body: |
             The ubuntu:focal image released a new version
 

--- a/hack/update/get_version/get_version.go
+++ b/hack/update/get_version/get_version.go
@@ -41,6 +41,7 @@ var dependencies = map[string]dependency{
 	"hugo":           {"netlify.toml", `HUGO_VERSION = "(.*)"`},
 	"metrics-server": {"pkg/minikube/assets/addons.go", `metrics-server/metrics-server:(.*)@`},
 	"runc":           {"deploy/iso/minikube-iso/package/runc-master/runc-master.mk", `RUNC_MASTER_VERSION = (.*)`},
+	"ubuntu":         {"deploy/kicbase/Dockerfile", `UBUNTU_FOCAL_IMAGE="(.*)"`},
 }
 
 func main() {


### PR DESCRIPTION
This PR solves issue #16450.

As a follow-up of #15772, this adds retrieving both the old and new versions of `ubuntu:focal` from the base image and including this information in the PR. The logic is taken from the other automations that implement this feature, e.g. `update-cri-o`.