### PR TITLE
site: improve none docs

### DIFF
--- a/site/content/en/docs/drivers/includes/none_usage.inc
+++ b/site/content/en/docs/drivers/includes/none_usage.inc
@@ -4,10 +4,8 @@ A Linux VM with the following:
 
 * systemd or OpenRC
 * a Container Runtime Interface (CRI), such as Docker or CRI-O
-
-If using Kubernetes v1.24+ & Docker CRI you will also need the following:
-* [cri-dockerd](https://github.com/Mirantis/cri-dockerd)
-* [containernetworking-plugins](https://github.com/containernetworking/plugins)
+* [containernetworking-plugins]({{<ref "/docs/faq/#how-do-i-install-containernetworking-plugins-for-none-driver" >}})
+* [cri-dockerd](https://github.com/Mirantis/cri-dockerd) (Only if using Docker CRI)
 
 This VM must also meet the [kubeadm requirements](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/), such as:
 

--- a/site/content/en/docs/faq/_index.md
+++ b/site/content/en/docs/faq/_index.md
@@ -188,5 +188,18 @@ Minikube is an open community and we are always willing to help users from any c
   
 3. Use a proxy server/VPN, if you have one. <br/> *Note: please obey the local laws. In some area, using an unauthorized proxy server/VPN is ILLEGAL* 
 
+## How do I install containernetworking-plugins for none driver?
 
+Go to [containernetworking-plugins](https://github.com/containernetworking/plugins/releases) to find the latest version.
 
+Then execute the following:
+```shell
+CNI_PLUGIN_VERSION="<version_here>"
+CNI_PLUGIN_TAR="cni-plugins-linux-amd64-$CNI_PLUGIN_VERSION.tgz" # change arch if not on amd64
+CNI_PLUGIN_INSTALL_DIR="/opt/cni/bin"
+
+curl -LO "https://github.com/containernetworking/plugins/releases/download/$CNI_PLUGIN_VERSION/$CNI_PLUGIN_TAR"
+sudo mkdir -p "$CNI_PLUGIN_INSTALL_DIR"
+sudo tar -xf "$CNI_PLUGIN_TAR" -C "$CNI_PLUGIN_INSTALL_DIR"
+rm "$CNI_PLUGIN_TAR"
+```


### PR DESCRIPTION
- `containernetworking-plugins` was marked an only being needed for Docker CRI, which is untrue, all CRIs need it
- Removed `If using Kubernetes v1.24+` wording, as v1.23 and older are no longer actively maintained, so just assume users are on v1.24+ for docs simplicity
- Added FAQ for how to install `containernetworking-plugins` for none driver, as the repo doesn't have explicit install instructions
- Linked to the above FAQ entry in the none docs

<img width="1106" alt="Screenshot 2023-05-08 at 4 26 24 PM" src="https://user-images.githubusercontent.com/44844360/236958212-22564dfa-8988-4c51-baa0-24313012bed7.png">