### PR TITLE
CI: fix kube-cross registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ HYPERKIT_BUILD_IMAGE ?= gcr.io/k8s-minikube/xcgo:go1.19.5
 # https://github.com/kubernetes/kubernetes/blob/master/build/build-image/cross/VERSION
 #
 
-BUILD_IMAGE 	?= us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:$(GO_K8S_VERSION_PREFIX)-go$(GO_VERSION)-bullseye.0
+BUILD_IMAGE 	?= registry.k8s.io/build-image/kube-cross:$(GO_K8S_VERSION_PREFIX)-go$(GO_VERSION)-bullseye.0
 
 ISO_BUILD_IMAGE ?= $(REGISTRY)/buildroot-image
 


### PR DESCRIPTION
Closes https://github.com/kubernetes/minikube/issues/16478

As per https://github.com/kubernetes/kubernetes/blob/f319dab8d9e7d0a0909871d9dd869c950ce0ca91/test/images/sample-apiserver/Makefile#L28

The registry path for `kube-cross` is `registry.k8s.io/build-image/kube-cross`

Confirmed it works:
```
$ docker pull registry.k8s.io/build-image/kube-cross:v1.27.0-go1.20.4-bullseye.0
v1.27.0-go1.20.4-bullseye.0: Pulling from build-image/kube-cross
```