### PR TITLE
CI: include all environments in flake comments

### DIFF
--- a/hack/jenkins/test-flake-chart/compute_flake_rate.go
+++ b/hack/jenkins/test-flake-chart/compute_flake_rate.go
@@ -169,10 +169,6 @@ func filterRecentEntries(splitEntries splitEntryMap, dateCutoff time.Time) split
 	filteredEntries := make(splitEntryMap)
 
 	for environment, environmentSplit := range splitEntries {
-		// Ignore kvm crio tests until they're back under control
-		if environment == "KVM_Linux_crio" {
-			continue
-		}
 		for test, testSplit := range environmentSplit {
 			for _, entry := range testSplit {
 				if !entry.date.Before(dateCutoff) {

--- a/hack/jenkins/test-flake-chart/report_flakes.sh
+++ b/hack/jenkins/test-flake-chart/report_flakes.sh
@@ -85,11 +85,7 @@ awk -F, 'NR>1 {
   | sort -g -t, -k2,2 \
   >> "$TMP_FAILED_RATES"
 
-# Filter out arm64, crio, and QEMU tests until they're more stable
-TMP_FAILED_RATES_FILTERED=$(mktemp)
-grep -v "arm64\|crio\|QEMU" "$TMP_FAILED_RATES" > "$TMP_FAILED_RATES_FILTERED"
-
-FAILED_RATES_LINES=$(wc -l < "$TMP_FAILED_RATES_FILTERED")
+FAILED_RATES_LINES=$(wc -l < "$TMP_FAILED_RATES")
 if [[ "$FAILED_RATES_LINES" -eq 0 ]]; then
   echo "No failed tests! Aborting without commenting..." 1>&2
   exit 0
@@ -106,7 +102,7 @@ TEST_GOPOGH_LINK_FORMAT='https://storage.googleapis.com/minikube-builds/logs/'${
 # 1) Get the first $MAX_REPORTED_TESTS lines.
 # 2) Print a row in the table with the environment, test name, flake rate, and a link to the flake chart for that test.
 # 3) Append these rows to file $TMP_COMMENT.
-head -n "$MAX_REPORTED_TESTS" "$TMP_FAILED_RATES_FILTERED" \
+head -n "$MAX_REPORTED_TESTS" "$TMP_FAILED_RATES" \
   | awk '-F[:,]' '{
       if ($3 != "n/a") {
         rate_text = sprintf("%3$s ([chart]('$TEST_CHART_LINK_FORMAT'))", $1, $2, $3)


### PR DESCRIPTION
Previously we omitted arm64, cri-o, and QEMU tests from the flake chart due to their high failure rate, but now that we only show tests with less than 50% flake this shouldn't be a problem anymore so show all environments in the flake comments, which could help us detect more failures in PRs.