### PR TITLE
use dl.k8s.io, not kubernetes-release bucket

### DIFF
--- a/hack/jenkins/installers/check_install_docker.sh
+++ b/hack/jenkins/installers/check_install_docker.sh
@@ -30,5 +30,5 @@ rm get-docker.sh
 sudo adduser jenkins docker || true
 
 echo "Installing latest kubectl"
-curl -LO "https://dl.k8s.io/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${ARCH}/kubectl"
+curl -LO "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/${ARCH}/kubectl"
 sudo install ./kubectl /usr/local/bin/kubectl


### PR DESCRIPTION
This commit updates the check_install_docker.sh script used in the Jenkins installers. It modifies the installation command for kubectl to use the updated URL: https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/${ARCH}/kubectl. This ensures that the latest version of kubectl is downloaded and installed during the Jenkins installation process.

The previous URL https://storage.googleapis.com/kubernetes-release/release/stable.txt is being moved.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

#### What type of PR is this?
/kind cleanup
/kind deprecation

#### What this PR does / why we need it:
There are still references to https://storage.googleapis.com/kubernetes-release instead of https://dl.k8s.io/

dl.k8s.io is the correct advertised download host and will eventually move to be fastly shielding a fully community-owned bucket

ref: https://github.com/kubernetes/k8s.io/issues/2396
