### PR TITLE
CNI kindnet: Update from v20230330-48f316cd to v20230511-dc714da8

### DIFF
--- a/pkg/minikube/bootstrapper/images/images.go
+++ b/pkg/minikube/bootstrapper/images/images.go
@@ -170,7 +170,7 @@ func KindNet(repo string) string {
 	if repo == "" {
 		repo = "kindest"
 	}
-	return path.Join(repo, "kindnetd:v20230510-486859a6")
+	return path.Join(repo, "kindnetd:v20230511-dc714da8")
 }
 
 // all calico images are from https://github.com/projectcalico/calico/blob/master/manifests/calico.yaml

--- a/pkg/minikube/bootstrapper/images/images.go
+++ b/pkg/minikube/bootstrapper/images/images.go
@@ -170,7 +170,7 @@ func KindNet(repo string) string {
 	if repo == "" {
 		repo = "kindest"
 	}
-	return path.Join(repo, "kindnetd:v20230330-48f316cd")
+	return path.Join(repo, "kindnetd:v20230510-486859a6")
 }
 
 // all calico images are from https://github.com/projectcalico/calico/blob/master/manifests/calico.yaml


### PR DESCRIPTION
- Fixes 1 critical and 3 high CVEs
- Updates distroless-iptables from v0.2.2 to v0.2.3
- Change base image from Ubuntu to Debian