### PR TITLE
testing: Use GCR image to prevent Docker Hub rate limits

### DIFF
--- a/test/integration/testdata/image-build/test-arg/Dockerfile
+++ b/test/integration/testdata/image-build/test-arg/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM gcr.io/google-containers/alpine-with-bash:1.0
 ARG ENV_A
 ARG ENV_B
 RUN echo "test-build-arg" $ENV_A $ENV_B

--- a/test/integration/testdata/image-build/test-env/Dockerfile
+++ b/test/integration/testdata/image-build/test-env/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM gcr.io/google-containers/alpine-with-bash:1.0
 ARG AAA
 RUN echo "test-build-arg" $AAA
 CMD ["/bin/sh", "-c"]

--- a/test/integration/testdata/image-build/test-f/inner/Dockerfile
+++ b/test/integration/testdata/image-build/test-f/inner/Dockerfile
@@ -1,3 +1,3 @@
-FROM alpine:latest
+FROM gcr.io/google-containers/alpine-with-bash:1.0
 
 CMD ["/bin/sh", "-c"]

--- a/test/integration/testdata/image-build/test-ignore/Dockerfile
+++ b/test/integration/testdata/image-build/test-ignore/Dockerfile
@@ -1,3 +1,3 @@
-FROM alpine:latest
+FROM gcr.io/google-containers/alpine-with-bash:1.0
 
 CMD ["/bin/sh", "-c"]

--- a/test/integration/testdata/image-build/test-normal/Dockerfile
+++ b/test/integration/testdata/image-build/test-normal/Dockerfile
@@ -1,3 +1,3 @@
-FROM alpine:latest
+FROM gcr.io/google-containers/alpine-with-bash:1.0
 
 CMD ["/bin/sh", "-c"]


### PR DESCRIPTION
Some of our CI machines are running into rate limiting pulling images from Docker Hub. Change images to pull from GCR instead.

```
#3 ERROR: failed to copy: httpReadSeeker: failed open: unexpected status code https://registry-1.docker.io/v2/library/alpine/manifests/sha256:b5a5b7ce4eabc8414bf367761a28f4e8b16952ce5de537c15ed917b71b245f11: 429 Too Many Requests - Server message: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```