### PR TITLE
test: Updated skaffold test to help prevent Docker Hub pull limit

### DIFF
--- a/test/integration/testdata/skaffold/base/Dockerfile
+++ b/test/integration/testdata/skaffold/base/Dockerfile
@@ -1,0 +1,5 @@
+FROM gcr.io/distroless/base
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
+CMD ["./app"]

--- a/test/integration/testdata/skaffold/leeroy-app/Dockerfile
+++ b/test/integration/testdata/skaffold/leeroy-app/Dockerfile
@@ -1,10 +1,11 @@
-FROM golang:1.12.9-alpine3.10 as builder
+ARG BASE
+FROM golang:1.18 as builder
+WORKDIR /code
 COPY app.go .
-RUN go build -o /app .
+COPY go.mod .
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app .
 
-FROM alpine:3.10
-# Define GOTRACEBACK to mark this container as using the Go language runtime
-# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
-ENV GOTRACEBACK=single
-CMD ["./app"]
+FROM $BASE
 COPY --from=builder /app .

--- a/test/integration/testdata/skaffold/leeroy-app/go.mod
+++ b/test/integration/testdata/skaffold/leeroy-app/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/microservices/leeroy-app
+
+go 1.18

--- a/test/integration/testdata/skaffold/leeroy-app/kubernetes/deployment.yaml
+++ b/test/integration/testdata/skaffold/leeroy-app/kubernetes/deployment.yaml
@@ -33,3 +33,4 @@ spec:
         image: leeroy-app
         ports:
         - containerPort: 50051
+          name: http

--- a/test/integration/testdata/skaffold/leeroy-web/Dockerfile
+++ b/test/integration/testdata/skaffold/leeroy-web/Dockerfile
@@ -1,10 +1,11 @@
-FROM golang:1.12.9-alpine3.10 as builder
+ARG BASE
+FROM golang:1.18 as builder
+WORKDIR /code
 COPY web.go .
-RUN go build -o /web .
+COPY go.mod .
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app .
 
-FROM alpine:3.10
-# Define GOTRACEBACK to mark this container as using the Go language runtime
-# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
-ENV GOTRACEBACK=single
-CMD ["./web"]
-COPY --from=builder /web .
+FROM $BASE
+COPY --from=builder /app .

--- a/test/integration/testdata/skaffold/leeroy-web/go.mod
+++ b/test/integration/testdata/skaffold/leeroy-web/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/microservices/leeroy-web
+
+go 1.18

--- a/test/integration/testdata/skaffold/skaffold.yaml
+++ b/test/integration/testdata/skaffold/skaffold.yaml
@@ -1,18 +1,33 @@
-apiVersion: skaffold/v2beta5
+apiVersion: skaffold/v4beta5
 kind: Config
 build:
   artifacts:
     - image: leeroy-web
       context: leeroy-web
+      requires:
+        - image: base
+          alias: BASE
     - image: leeroy-app
       context: leeroy-app
-deploy:
-  kubectl:
-    manifests:
-      - leeroy-web/kubernetes/*
-      - leeroy-app/kubernetes/*
+      requires:
+        - image: base
+          alias: BASE
+    - image: base
+      context: base
+manifests:
+  rawYaml:
+    - leeroy-web/kubernetes/*
+    - leeroy-app/kubernetes/*
 portForward:
   - resourceType: deployment
     resourceName: leeroy-web
     port: 8080
     localPort: 9000
+  - resourceType: deployment
+    resourceName: leeroy-app
+    port: http
+    localPort: 9001
+profiles:
+  - name: gcb
+    build:
+      googleCloudBuild: {}


### PR DESCRIPTION
Old Skaffold test was pulling image from `alpine:3.10`, new test pulls from `gcr.io/distroless/base` which will help prevent Docker Hub rate limits.