### PR TITLE
audit log: set default max size

### DIFF
--- a/pkg/minikube/audit/audit.go
+++ b/pkg/minikube/audit/audit.go
@@ -121,7 +121,11 @@ func LogCommandEnd(id string) error {
 }
 
 func getStartIndex(entryCount int) int {
-	maxEntries := viper.GetInt(config.MaxAuditEntries)
+	// default to 1000 entries
+	maxEntries := 1000
+	if viper.IsSet(config.MaxAuditEntries) {
+		maxEntries = viper.GetInt(config.MaxAuditEntries)
+	}
 	startIndex := entryCount - maxEntries
 	if maxEntries <= 0 || startIndex <= 0 {
 		return 0


### PR DESCRIPTION
I was looking at some of our CI machines and the audit logging was failing:
```
E0519 17:42:33.138427  334137 logFile.go:53] failed to close the audit log: invalid argument
```

Then I looked at the size of the file:
```
-rw-r--r-- 1 perf perf 651M May 19 17:44 /home/perf/.minikube/logs/audit.json
```

It has over 1.6 million lines of audits:
```
1621891 /home/perf/.minikube/logs/audit.json
```

This PR sets the default number of audit lines to 1000 if not explicitly set by the user.