### PR TITLE
CI: Automate updating CNI plugins in kicbase

### DIFF
--- a/hack/update/cni_plugins_version/update_cni_plugins_version.go
+++ b/hack/update/cni_plugins_version/update_cni_plugins_version.go
@@ -44,6 +44,11 @@ var (
 				`CNI_PLUGINS_VERSION = .*`: `CNI_PLUGINS_VERSION = {{.Version}}`,
 			},
 		},
+		"deploy/kicbase/Dockerfile": {
+			Replace: map[string]string{
+				`CNI_PLUGINS_VERSION=.*`: `CNI_PLUGINS_VERSION="{{.Version}}"`,
+			},
+		},
 	}
 )
 


### PR DESCRIPTION
Now that https://github.com/kubernetes/minikube/pull/16069 is merged, need to add updating the CNI plugins version in the kicbase