### PR TITLE
addons registry: Use multi-arch kube-registry-proxy image

### DIFF
--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -389,7 +389,7 @@ var Addons = map[string]*Addon{
 			"0640"),
 	}, false, "registry", "Google", "", "", map[string]string{
 		"Registry":          "registry:2.8.1@sha256:83bb78d7b28f1ac99c68133af32c93e9a1c149bcd3cb6e683a3ee56e312f1c96",
-		"KubeRegistryProxy": "google_containers/kube-registry-proxy:0.4@sha256:1040f25a5273de0d72c54865a8efd47e3292de9fb8e5353e3fa76736b854f2da",
+		"KubeRegistryProxy": "k8s-minikube/kube-registry-proxy:0.0.1@sha256:498e7da3b171e24630615854c4a2924cfb8adbd43b0f252b1458c859ca9b746c",
 	}, map[string]string{
 		"KubeRegistryProxy": "gcr.io",
 		"Registry":          "docker.io",

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -389,7 +389,7 @@ var Addons = map[string]*Addon{
 			"0640"),
 	}, false, "registry", "Google", "", "", map[string]string{
 		"Registry":          "registry:2.8.1@sha256:83bb78d7b28f1ac99c68133af32c93e9a1c149bcd3cb6e683a3ee56e312f1c96",
-		"KubeRegistryProxy": "k8s-minikube/kube-registry-proxy:0.0.1@sha256:498e7da3b171e24630615854c4a2924cfb8adbd43b0f252b1458c859ca9b746c",
+		"KubeRegistryProxy": "k8s-minikube/kube-registry-proxy:0.0.5@sha256:f107ecd58728a2df5f2bb7e087f65f5363d0019b1e1fd476e4ef16065f44abfb",
 	}, map[string]string{
 		"KubeRegistryProxy": "gcr.io",
 		"Registry":          "docker.io",


### PR DESCRIPTION
The existing kube-registry-proxy image (`gcr.io/google_containers/kube-registry-proxy`) was only built for amd64 and doesn't work for users using QEMU on arm64 machines.

The source code for the image was removed in https://github.com/kubernetes/kubernetes/pull/58564.

I took the source code, updated the nginx base image and added it to https://github.com/spowelljr/kube-registry-proxy and built the kube-registry-proxy image for our five supported architectures and pushed it to `gcr.io/k8s-minikube/kube-registry-proxy`.

It was confirmed to work by another user as well.
https://kubernetes.slack.com/archives/C1F5CT6Q1/p1684942501397369?thread_ts=1684931469.550259&cid=C1F5CT6Q1

I'm happy to move the source code into the project or into some minikube owned repo.