### PR TITLE
chore: use log.Printf

### DIFF
--- a/third_party/go9p/clnt_clnt.go
+++ b/third_party/go9p/clnt_clnt.go
@@ -220,7 +220,7 @@ func (clnt *Clnt) recv() {
 				if r.Rc.Type != Rerror {
 					r.Err = &Error{"invalid response", EINVAL}
 					log.Printf("TTT %v\n", r.Tc)
-					log.Printf("RRR %v", r.Rc)
+					log.Printf("RRR %v\n", r.Rc)
 				} else {
 					if r.Err == nil {
 						r.Err = &Error{r.Rc.Error, r.Rc.Errornum}

--- a/third_party/go9p/clnt_clnt.go
+++ b/third_party/go9p/clnt_clnt.go
@@ -219,8 +219,8 @@ func (clnt *Clnt) recv() {
 			if r.Tc.Type != r.Rc.Type-1 {
 				if r.Rc.Type != Rerror {
 					r.Err = &Error{"invalid response", EINVAL}
-					log.Println(fmt.Sprintf("TTT %v", r.Tc))
-					log.Println(fmt.Sprintf("RRR %v", r.Rc))
+					log.Printf("TTT %v\n", r.Tc)
+					log.Printf("RRR %v", r.Rc)
 				} else {
 					if r.Err == nil {
 						r.Err = &Error{r.Rc.Error, r.Rc.Errornum}

--- a/third_party/go9p/srv_conn.go
+++ b/third_party/go9p/srv_conn.go
@@ -105,7 +105,7 @@ func (conn *Conn) recv() {
 			}
 			fc, err, fcsize := Unpack(buf, conn.Dotu)
 			if err != nil {
-				log.Println(fmt.Sprintf("invalid packet : %v %v", err, buf))
+				log.Printf"invalid packet : %v %v", err, buf)
 				conn.conn.Close()
 				conn.close()
 				return

--- a/third_party/go9p/srv_conn.go
+++ b/third_party/go9p/srv_conn.go
@@ -105,7 +105,7 @@ func (conn *Conn) recv() {
 			}
 			fc, err, fcsize := Unpack(buf, conn.Dotu)
 			if err != nil {
-				log.Printf"invalid packet : %v %v", err, buf)
+				log.Printf("invalid packet : %v %v\n", err, buf)
 				conn.conn.Close()
 				conn.close()
 				return


### PR DESCRIPTION
fix: should use log.Printf(...) instead of log.Println(fmt.Sprintf(...)) (S1038)