### PR TITLE
ISO: flannel cni-plugin removed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ KUBERNETES_VERSION ?= $(shell egrep "DefaultKubernetesVersion =" pkg/minikube/co
 KIC_VERSION ?= $(shell egrep "Version =" pkg/drivers/kic/types.go | cut -d \" -f2)
 
 # Default to .0 for higher cache hit rates, as build increments typically don't require new ISO versions
-ISO_VERSION ?= v1.30.1-1684885329-16572
+ISO_VERSION ?= v1.30.1-1685640286-16613
 
 # Dashes are valid in semver, but not Linux packaging. Use ~ to delimit alpha/beta
 DEB_VERSION ?= $(subst -,~,$(RAW_VERSION))

--- a/deploy/iso/minikube-iso/arch/aarch64/package/cni-plugins-aarch64/cni-plugins.mk
+++ b/deploy/iso/minikube-iso/arch/aarch64/package/cni-plugins-aarch64/cni-plugins.mk
@@ -92,15 +92,6 @@ define CNI_PLUGINS_AARCH64_INSTALL_TARGET_CMDS
 		$(TARGET_DIR)/usr/bin/host-local
 
 	$(INSTALL) -D -m 0755 \
-		$(@D)/flannel \
-		$(TARGET_DIR)/opt/cni/bin/flannel
-
-	ln -sf \
-		../../opt/cni/bin/flannel \
-		$(TARGET_DIR)/usr/bin/flannel
-
-
-	$(INSTALL) -D -m 0755 \
 		$(@D)/dhcp \
 		$(TARGET_DIR)/opt/cni/bin/dhcp
 

--- a/deploy/iso/minikube-iso/arch/x86_64/package/cni-plugins/cni-plugins.mk
+++ b/deploy/iso/minikube-iso/arch/x86_64/package/cni-plugins/cni-plugins.mk
@@ -92,15 +92,6 @@ define CNI_PLUGINS_INSTALL_TARGET_CMDS
 		$(TARGET_DIR)/usr/bin/host-local
 
 	$(INSTALL) -D -m 0755 \
-		$(@D)/flannel \
-		$(TARGET_DIR)/opt/cni/bin/flannel
-
-	ln -sf \
-		../../opt/cni/bin/flannel \
-		$(TARGET_DIR)/usr/bin/flannel
-
-
-	$(INSTALL) -D -m 0755 \
 		$(@D)/dhcp \
 		$(TARGET_DIR)/opt/cni/bin/dhcp
 

--- a/pkg/minikube/download/iso.go
+++ b/pkg/minikube/download/iso.go
@@ -41,7 +41,7 @@ const fileScheme = "file"
 // DefaultISOURLs returns a list of ISO URL's to consult by default, in priority order
 func DefaultISOURLs() []string {
 	v := version.GetISOVersion()
-	isoBucket := "minikube-builds/iso/16572"
+	isoBucket := "minikube-builds/iso/16613"
 
 	return []string{
 		fmt.Sprintf("https://storage.googleapis.com/%s/minikube-%s-%s.iso", isoBucket, v, runtime.GOARCH),


### PR DESCRIPTION
In https://github.com/kubernetes/minikube/pull/16582 I missed that the ISO failed to build as there was no comment on the PR that it failed (follow up PR to resolve this).

The build failed with:
```
05:58:02 /usr/bin/install -D -m 0755 /home/jenkins/go/src/k8s.io/minikube/out/buildroot/output-aarch64/build/cni-plugins-aarch64-v1.3.0/flannel /home/jenkins/go/src/k8s.io/minikube/out/buildroot/output-aarch64/target/opt/cni/bin/flannel
05:58:02 /usr/bin/install: cannot stat '/home/jenkins/go/src/k8s.io/minikube/out/buildroot/output-aarch64/build/cni-plugins-aarch64-v1.3.0/flannel': No such file or directory
05:58:02 make[2]: *** [package/pkg-generic.mk:342: /home/jenkins/go/src/k8s.io/minikube/out/buildroot/output-aarch64/build/cni-plugins-aarch64-v1.3.0/.stamp_target_installed] Error 1
```

https://github.com/kubernetes/minikube/pull/16582 updated cni-plugins from v0.8.5 to v1.3.0. In v1.0.0 they dropped flannel from the project, so we're now attempting to copy a file that doesn't exist, failing the build.

We can safely just remove the copy as our flannel yamls handle installing the flannel cni-plugin
https://github.com/kubernetes/minikube/blob/40e86860211a515d2801a08d269b970b3cac232e/pkg/minikube/cni/flannel.yaml#L141-L152