### PR TITLE
CI: Fix file change output

### DIFF
--- a/.github/workflows/update-k8s-versions.yml
+++ b/.github/workflows/update-k8s-versions.yml
@@ -26,8 +26,6 @@ jobs:
           t=$(echo $t | head -n 1)
           echo "title=$t" >> $GITHUB_OUTPUT
           c=$(git status --porcelain)
-          c="${c//$'\n'/'%0A'}"
-          c="${c//$'\r'/'%0D'}"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
           echo "changes<<EOF" >> $GITHUB_OUTPUT
           echo "$c" >> $GITHUB_OUTPUT

--- a/.github/workflows/update-kubeadm-constants.yml
+++ b/.github/workflows/update-kubeadm-constants.yml
@@ -24,8 +24,6 @@ jobs:
         run: |
           make update-kubeadm-constants
           c=$(git status --porcelain)
-          c="${c//$'\n'/'%0A'}"
-          c="${c//$'\r'/'%0D'}"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
           echo "changes<<EOF" >> $GITHUB_OUTPUT
           echo "$c" >> $GITHUB_OUTPUT

--- a/.github/workflows/update-ubuntu-version.yml
+++ b/.github/workflows/update-ubuntu-version.yml
@@ -26,8 +26,6 @@ jobs:
           make update-ubuntu-version
           echo "NEW_VERSION=$(DEP=ubuntu make get-dependency-version)" >> $GITHUB_OUTPUT
           c=$(git status --porcelain)
-          c="${c//$'\n'/'%0A'}"
-          c="${c//$'\r'/'%0D'}"
           echo "changes<<EOF" >> $GITHUB_OUTPUT
           echo "$c" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
After changing to `$GITHUB_OUTPUT` `%0A` is showing up instead of an expected newline:

```
 M pkg/minikube/constants/constants.go%0A M site/content/en/docs/commands/start.md
```

Removing the replacing the newlines