### PR TITLE
CI: Fix Ubuntu PR title

### DIFF
--- a/hack/update/get_version/get_version.go
+++ b/hack/update/get_version/get_version.go
@@ -43,7 +43,7 @@ var dependencies = map[string]dependency{
 	"hugo":           {"netlify.toml", `HUGO_VERSION = "(.*)"`},
 	"metrics-server": {"pkg/minikube/assets/addons.go", `metrics-server/metrics-server:(.*)@`},
 	"runc":           {"deploy/iso/minikube-iso/package/runc-master/runc-master.mk", `RUNC_MASTER_VERSION = (.*)`},
-	"ubuntu":         {"deploy/kicbase/Dockerfile", `UBUNTU_FOCAL_IMAGE="(.*)"`},
+	"ubuntu":         {"deploy/kicbase/Dockerfile", `ubuntu:jammy-(.*)"`},
 }
 
 func main() {


### PR DESCRIPTION
The variable to get the Ubuntu version changed when moving from Ubuntu 20.04 to 22.04, resulting in the automated PR title to update Ubuntu being `Kicbase: Bump ubuntu:jammy from  to`. Fixed the regexp to resolve this