### PR TITLE
QEMU: Add advice if bootpd blocked by firewall

### DIFF
--- a/pkg/drivers/qemu/qemu.go
+++ b/pkg/drivers/qemu/qemu.go
@@ -41,6 +41,8 @@ import (
 	"github.com/pkg/errors"
 
 	pkgdrivers "k8s.io/minikube/pkg/drivers"
+	"k8s.io/minikube/pkg/minikube/exit"
+	"k8s.io/minikube/pkg/minikube/reason"
 	"k8s.io/minikube/pkg/network"
 )
 
@@ -493,7 +495,9 @@ func (d *Driver) Start() error {
 			time.Sleep(2 * time.Second)
 		}
 
-		if err != nil {
+		if isBootpdError(err) {
+			exit.Error(reason.IfBootpdFirewall, "ip not found", err)
+		} else if err != nil {
 			return errors.Wrap(err, "IP address never found in dhcp leases file")
 		}
 		log.Debugf("IP: %s", d.IPAddress)
@@ -502,6 +506,13 @@ func (d *Driver) Start() error {
 	log.Infof("Waiting for VM to start (ssh -p %d docker@%s)...", d.SSHPort, d.IPAddress)
 
 	return WaitForTCPWithDelay(fmt.Sprintf("%s:%d", d.IPAddress, d.SSHPort), time.Second)
+}
+
+func isBootpdError(err error) bool {
+	if runtime.GOOS != "darwin" {
+		return false
+	}
+	return strings.Contains(err.Error(), "could not find an IP address")
 }
 
 func cmdOutErr(cmdStr string, args ...string) (string, string, error) {

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -396,6 +396,14 @@ var (
 	IfSSHClient = Kind{ID: "IF_SSH_CLIENT", ExitCode: ExLocalNetworkError}
 	// minikube failed to create a dedicated network
 	IfDedicatedNetwork = Kind{ID: "IF_DEDICATED_NETWORK", ExitCode: ExLocalNetworkError}
+	// minikube failed to populate dchpd_leases file due to bootpd being blocked by firewall
+	IfBootpdFirewall = Kind{
+		ID:       "ID_BOOTPD_FIREWALL",
+		ExitCode: ExLocalNetworkError,
+		Advice: translate.T(`Your firewall is likely blocking bootpd, to unblock it run:
+	/usr/libexec/ApplicationFirewall/socketfilterfw --add /usr/libexec/bootpd
+	/usr/libexec/ApplicationFirewall/socketfilterfw --unblock /usr/libexec/bootpd`),
+	}
 
 	// minikube failed to cache kubernetes binaries for the current runtime
 	InetCacheBinaries = Kind{ID: "INET_CACHE_BINARIES", ExitCode: ExInternetError}


### PR DESCRIPTION
Outputs advice on how to unblock bootpd if we detect it's being blocked by firewall on macOS. Also exit early if we detect it's being blocked, resulting in exiting 1m11s faster than before.

**Before:**
```
$ time minikube start --driver qemu
😄  minikube v1.30.1 on Darwin 13.4 (arm64)
✨  Using the qemu2 driver based on user configuration
🌐  Automatically selected the socket_vmnet network
👍  Starting control plane node minikube in cluster minikube
🔥  Creating qemu2 VM (CPUs=2, Memory=4000MB, Disk=20000MB) ...
🔥  Deleting "minikube" in qemu2 ...
🤦  StartHost failed, but will try again: creating host: create: creating: IP address never found in dhcp leases file: failed to get IP address: could not find an IP address for 26:36:d9:8a:e:73
🔥  Creating qemu2 VM (CPUs=2, Memory=4000MB, Disk=20000MB) ...
😿  Failed to start qemu2 VM. Running "minikube delete" may fix it: creating host: create: creating: IP address never found in dhcp leases file: failed to get IP address: could not find an IP address for 82:31:2c:b6:f5:ab

❌  Exiting due to GUEST_PROVISION: error provisioning guest: Failed to start host: creating host: create: creating: IP address never found in dhcp leases file: failed to get IP address: could not find an IP address for 82:31:2c:b6:f5:ab

╭───────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                           │
│    😿  If the above advice does not help, please let us know:                             │
│    👉  https://github.com/kubernetes/minikube/issues/new/choose                           │
│                                                                                           │
│    Please run `minikube logs --file=logs.txt` and attach logs.txt to the GitHub issue.    │
│                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────╯


real	2m11.052s
user	0m0.667s
sys	0m0.643s
```

**After:**
```
$ time minikube start --driver qemu
😄  minikube v1.30.1 on Darwin 13.4 (arm64)
✨  Using the qemu2 driver based on user configuration
🌐  Automatically selected the socket_vmnet network
👍  Starting control plane node minikube in cluster minikube
🔥  Creating qemu2 VM (CPUs=2, Memory=4000MB, Disk=20000MB) ...

❌  Exiting due to ID_BOOTPD_FIREWALL: ip not found: failed to get IP address: could not find an IP address for a2:6d:d5:57:e9:ac
💡  Suggestion: 

    Your firewall is likely blocking bootpd, to unblock it run:
    /usr/libexec/ApplicationFirewall/socketfilterfw --add /usr/libexec/bootpd
    /usr/libexec/ApplicationFirewall/socketfilterfw --unblock /usr/libexec/bootpd

╭───────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                           │
│    😿  If the above advice does not help, please let us know:                             │
│    👉  https://github.com/kubernetes/minikube/issues/new/choose                           │
│                                                                                           │
│    Please run `minikube logs --file=logs.txt` and attach logs.txt to the GitHub issue.    │
│                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────╯


real	1m0.738s
user	0m0.428s
sys	0m0.313s
```