### PR TITLE
Don't retry cluster creation if socket_vmnet permissions are denied

### DIFF
--- a/pkg/drivers/qemu/qemu.go
+++ b/pkg/drivers/qemu/qemu.go
@@ -467,7 +467,10 @@ func (d *Driver) Start() error {
 	if stdout, stderr, err := startFunc(startProgram, startCmd...); err != nil {
 		fmt.Printf("OUTPUT: %s\n", stdout)
 		fmt.Printf("ERROR: %s\n", stderr)
-		return err
+		if stderr == "Failed to connect to \"/var/run/socket_vmnet\": Permission denied\n" {
+			exit.Message(reason.QemuSocketVmnetPermission, stderr+"\n\n")
+		}
+
 	}
 
 	switch d.Network {

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -518,4 +518,14 @@ var (
 		  minikube start{{.profile}} --driver qemu --network user`),
 		Style: style.SeeNoEvil,
 	}
+
+	// permission denied for socket_vmnet
+	QemuSocketVmnetPermission = Kind{
+		ID:       "PR_QEMU_SOCKET_VMNET_DENIED",
+		ExitCode: ExHostPermission,
+		Advice: translate.T(`socket_vmnet was installed with an incorrect group, 
+		delete this cluster 'minikube delete' and update the 
+		group 'sudo chown root:$(id -ng) /var/run/socket_vmnet' and try again.`),
+		Style: style.Conflict,
+	}
 )


### PR DESCRIPTION
The creation of a QEMU-based cluster should be terminated and not be retried if the permissions for socket_vmnet are not correct.

Fixes #16647.