### PR TITLE
CI: Use last 90 days for flake issues

### DIFF
--- a/hack/jenkins/test-flake-chart/compute_flake_rate.sh
+++ b/hack/jenkins/test-flake-chart/compute_flake_rate.sh
@@ -161,7 +161,7 @@ for ROW in $(cat ${MID_FLAKES_ISSUES}); do
   # Clear $ISSUE_BODY_TMP and fill with the standard header.
   printf "This test has high flake rates for the following environments:\n\n|Environment|Flake Rate (%%)|\n|---|---|\n" > "${ISSUE_BODY_TMP}"
 
-  TEST_CHART_LINK_FORMAT='https://storage.googleapis.com/minikube-flake-rate/flake_chart.html?env=%1$s&test='${TEST_NAME}
+  TEST_CHART_LINK_FORMAT='https://storage.googleapis.com/minikube-flake-rate/flake_chart.html?env=%1$s&test='${TEST_NAME}'&period=last90'
   # 1) Filter $MID_FLAKES_DATA to only include entries with the given test name
   # 2) Sort by flake rates in descending order
   # 3) Format the entry into a row in the table


### PR DESCRIPTION
Link the flake charts in the flake issues to last 90 days. Using all-time is too large and usually fails to load.

Example of issue: https://github.com/kubernetes/minikube/issues/12217