### PR TITLE
TestPreload: Fix image list with cri-o CRI

### DIFF
--- a/test/integration/preload_test.go
+++ b/test/integration/preload_test.go
@@ -48,12 +48,7 @@ func TestPreload(t *testing.T) {
 
 	// Now, pull the busybox image into minikube
 	image := "gcr.io/k8s-minikube/busybox"
-	var cmd *exec.Cmd
-	if ContainerRuntime() == "docker" {
-		cmd = exec.CommandContext(ctx, Target(), "ssh", "-p", profile, "--", "docker", "pull", image)
-	} else {
-		cmd = exec.CommandContext(ctx, Target(), "ssh", "-p", profile, "--", "sudo", "crictl", "pull", image)
-	}
+	cmd := exec.CommandContext(ctx, Target(), "-p", profile, "image", "pull", image)
 	rr, err = Run(t, cmd)
 	if err != nil {
 		t.Fatalf("%s failed: %v", rr.Command(), err)
@@ -72,11 +67,7 @@ func TestPreload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%s failed: %v", rr.Command(), err)
 	}
-	if ContainerRuntime() == "docker" {
-		cmd = exec.CommandContext(ctx, Target(), "ssh", "-p", profile, "--", "docker", "images")
-	} else {
-		cmd = exec.CommandContext(ctx, Target(), "ssh", "-p", profile, "--", "sudo", "crictl", "image", "ls")
-	}
+	cmd = exec.CommandContext(ctx, Target(), "-p", profile, "image", "list")
 	rr, err = Run(t, cmd)
 	if err != nil {
 		t.Fatalf("%s failed: %v", rr.Command(), err)


### PR DESCRIPTION
Related: https://github.com/kubernetes/minikube/issues/12217

This will fix `TestPreload` for `Docker_Linux_crio` and `Docker_Linux_crio_arm64`, and partially fix `KVM_Linux_crio`

In `TestPreload` we're running `sudo crictl image ls` to list the images for containerd and cri-o to check if an image is present.

This works for containerd:
```
$ sudo crictl image ls
IMAGE                                     TAG                  IMAGE ID            SIZE
docker.io/kindest/kindnetd                v20230511-dc714da8   b0b1fa0f58c6e       27.7MB
gcr.io/k8s-minikube/storage-provisioner   v5                   6e38f40d628db       9.06MB
registry.k8s.io/coredns/coredns           v1.10.1              ead0a4a53df89       16.2MB
registry.k8s.io/etcd                      3.5.7-0              86b6af7dd652c       102MB
registry.k8s.io/kube-apiserver            v1.27.2              c5b13e4f7806d       33.4MB
registry.k8s.io/kube-controller-manager   v1.27.2              ac2b7465ebba9       31MB
registry.k8s.io/kube-proxy                v1.27.2              b8aa50768fd67       23.9MB
registry.k8s.io/kube-scheduler            v1.27.2              89e70da428d29       18.2MB
registry.k8s.io/pause                     3.9                  e6f1816883972       322kB
```

However, this doesn't work for cri-o:
```
$ sudo crictl image ls
IMAGE               TAG                 IMAGE ID            SIZE
```

Instead, `sudo crictl image` should be used, which works as expected:
```
$ sudo crictl image   
IMAGE                                     TAG                  IMAGE ID            SIZE
docker.io/kindest/kindnetd                v20230511-dc714da8   b0b1fa0f58c6e       65.2MB
gcr.io/k8s-minikube/storage-provisioner   v5                   6e38f40d628db       31.5MB
registry.k8s.io/coredns/coredns           v1.10.1              ead0a4a53df89       53.6MB
registry.k8s.io/etcd                      3.5.7-0              86b6af7dd652c       297MB
registry.k8s.io/kube-apiserver            v1.27.2              c5b13e4f7806d       122MB
registry.k8s.io/kube-controller-manager   v1.27.2              ac2b7465ebba9       114MB
registry.k8s.io/kube-proxy                v1.27.2              b8aa50768fd67       72.7MB
registry.k8s.io/kube-scheduler            v1.27.2              89e70da428d29       59.8MB
registry.k8s.io/pause                     3.9                  e6f1816883972       750kB
```

But an even better improvement is to use minikube's image commands, then the container runtime `if` statements can be removed from the test as minikube will run the correct commands.