### PR TITLE
VM drivers: Fix images getting removed on stop/start

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -929,7 +929,12 @@ func (k *Bootstrapper) UpdateCluster(cfg config.ClusterConfig) error {
 	}
 
 	if err := r.Preload(cfg); err != nil {
-		klog.Infof("preload failed, will try to load cached images: %v", err)
+		switch err.(type) {
+		case *cruntime.ErrISOFeature:
+			out.ErrT(style.Tip, "Existing disk is missing new features ({{.error}}). To upgrade, run 'minikube delete'", out.V{"error": err})
+		default:
+			klog.Infof("preload failed, will try to load cached images: %v", err)
+		}
 	}
 
 	if cfg.KubernetesConfig.ShouldLoadCachedImages {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/12217

For full details see: https://github.com/kubernetes/minikube/issues/12217#issuecomment-1583303474

The short is that on a VM driver using the containerd or cri-o runtime, when starting after a stop, we would check for the existence of preload images prior to CRIs being configured and started, resulting in an empty image list being returned. This would then trigger to untar the preload and overwrite all the existing image on the machine. There's another preload check later on after the CRIs are configured and started, which is why the wasn't an issue with Docker.