### PR TITLE
Import the external docker-machine drivers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.14
 	github.com/Delta456/box-cli-maker/v2 v2.3.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.15.0
-	github.com/Parallels/docker-machine-parallels/v2 v2.0.1
 	github.com/VividCortex/godaemon v1.0.0
 	github.com/blang/semver/v4 v4.0.0
 	github.com/briandowns/spinner v1.11.1
@@ -33,7 +32,6 @@ require (
 	github.com/johanneswuerbach/nfsexports v0.0.0-20200318065542-c48c3734757f
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/klauspost/cpuid v1.2.0
-	github.com/machine-drivers/docker-machine-driver-vmware v0.1.5
 	github.com/mattbaird/jsonpatch v0.0.0-20200820163806-098863c1fc24
 	github.com/mattn/go-isatty v0.0.19
 	github.com/mitchellh/go-ps v1.0.0
@@ -87,6 +85,7 @@ require (
 	github.com/docker/cli v24.0.2+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/google/go-github/v43 v43.0.0
+	github.com/hashicorp/go-version v1.6.0
 	github.com/juju/clock v1.0.3
 	github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b
 	github.com/juju/mutex/v2 v2.0.0
@@ -152,7 +151,6 @@ require (
 	github.com/gookit/color v1.5.2 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect
-	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -284,8 +284,6 @@ github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb0
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/Parallels/docker-machine-parallels/v2 v2.0.1 h1:3Rj+4tcm/UqMU5g2bLJmpxD0ssn1BB5am4Cd6yUDbVI=
-github.com/Parallels/docker-machine-parallels/v2 v2.0.1/go.mod h1:NKwI5KryEmEHMZVj80t9JQcfXWZp4/ZYNBuw4C5sQ9E=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
@@ -568,8 +566,6 @@ github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6
 github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v0.0.0-20180621001606-093424bec097/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v1.4.2-0.20190924003213-a8608b5b67c7/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/docker/docker v17.12.0-ce-rc1.0.20181225093023-5ddb1d410a8b+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/docker/docker v17.12.0-ce-rc1.0.20190115220918-5ec31380a5d3+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v20.10.14+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v24.0.2+incompatible h1:eATx+oLz9WdNVkQrr0qjQ8HvRJ4bOOxfzEo8R+dA3cg=
 github.com/docker/docker v24.0.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
@@ -966,7 +962,6 @@ github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjG
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
@@ -1100,8 +1095,6 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/lunixbochs/vtclean v0.0.0-20160125035106-4fbf7632a2c6/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/lyft/protoc-gen-star v0.6.0/go.mod h1:TGAoBVkt8w7MPG72TrKIu85MIdXwDuzJYeZuUPFPNwA=
-github.com/machine-drivers/docker-machine-driver-vmware v0.1.5 h1:51GqJ84u9EBATnn8rWsHNavcuRPlCLnDmvjzZVuliwY=
-github.com/machine-drivers/docker-machine-driver-vmware v0.1.5/go.mod h1:dTnTzUH3uzhMo0ddV1zRjGYWcVhQWwqiHPxz5l+HPd0=
 github.com/machine-drivers/machine v0.7.1-0.20230328203412-ddb74f7e6e56 h1:C2yN1rj/WG98W6hcWNsO4Icczt+63rVvrUSczaGpVbE=
 github.com/machine-drivers/machine v0.7.1-0.20230328203412-ddb74f7e6e56/go.mod h1:yvZ+/PEaFkg2SJx14jjWgoO8QV0R9+W87n+BJQwTwgY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -1429,7 +1422,6 @@ github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546/go.mod h1:TrYk7fJV
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
-github.com/sirupsen/logrus v1.3.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
@@ -1525,7 +1517,6 @@ github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.12/go.mod h1:sSBEIC79qR6OvcmsD4U3KABeOTxDqQtdDnaFuUN30b8=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/vbatts/tar-split v0.11.3 h1:hLFqsOLQ1SsppQNTMpkpPXClLDfC2A3Zgy9OUU+RVck=
@@ -1661,7 +1652,6 @@ golang.org/x/crypto v0.0.0-20171113213409-9f005a07e0d3/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181009213950-7c1a557ab941/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190422162423-af44ce270edf/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
 golang.org/x/crypto v0.0.0-20190424203555-c05e17bb3b2d/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -1676,7 +1666,6 @@ golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=

--- a/pkg/drivers/parallels/LICENSE
+++ b/pkg/drivers/parallels/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2015-2020 Parallels IP Holdings GmbH.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pkg/drivers/parallels/parallels.go
+++ b/pkg/drivers/parallels/parallels.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +build !darwin
+
+package parallels
+
+import "github.com/docker/machine/libmachine/drivers"
+
+func NewDriver(hostName, storePath string) drivers.Driver {
+	return drivers.NewDriverNotSupported("parallels", hostName, storePath)
+}

--- a/pkg/drivers/parallels/parallels_darwin.go
+++ b/pkg/drivers/parallels/parallels_darwin.go
@@ -1,0 +1,812 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+ * Copyright (c) 2015-2020 Parallels IP Holdings GmbH.  Licensed under the MIT License.
+ */
+
+package parallels
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/docker/machine/libmachine/log"
+	"github.com/docker/machine/libmachine/mcnflag"
+	"github.com/docker/machine/libmachine/mcnutils"
+	"github.com/docker/machine/libmachine/ssh"
+	"github.com/docker/machine/libmachine/state"
+	"github.com/hashicorp/go-version"
+)
+
+const (
+	isoFilename                 = "boot2docker.iso"
+	shareFolderNamePrefix       = "docker_machine_share_"
+	minDiskSize                 = 32
+	defaultCPU                  = 1
+	defaultMemory               = 1024
+	defaultVideoSize            = 64
+	defaultBoot2DockerURL       = ""
+	defaultShareFolder          = "/Users"
+	defaultNoShare              = false
+	defaultDiskSize             = 20000
+	defaultSSHPort              = 22
+	defaultSSHUser              = "docker"
+	defaultNestedVirtualization = false
+)
+
+var (
+	reMachineNotFound  = regexp.MustCompile(`Failed to get VM config: The virtual machine could not be found..*`)
+	reParallelsVersion = regexp.MustCompile(`.* (\d+\.\d+\.\d+).*`)
+	reParallelsEdition = regexp.MustCompile(`edition="(.+)"`)
+	reSharedAdapterIP  = regexp.MustCompile(`\s*IPv4 address:\s*(\d+\.\d+\.\d+\.\d+)`)
+	reSharedFolder     = regexp.MustCompile(`\s*(.+) \(\+\) path='(.+)' mode=.+`)
+
+	errMachineExist              = errors.New("machine already exists")
+	errMachineNotExist           = errors.New("machine does not exist")
+	errSharedNetworkNotConnected = errors.New("Your Mac host is not connected to Shared network. Please, ensure this option is set: 'Parallels Desktop' -> 'Preferences' -> 'Network' -> 'Shared' -> 'Connect Mac to this network'")
+
+	v11, _ = version.NewVersion("11.0.0")
+)
+
+// Driver for Parallels Desktop
+type Driver struct {
+	*drivers.BaseDriver
+	CPU                  int
+	Memory               int
+	VideoSize            int
+	DiskSize             int
+	Boot2DockerURL       string
+	NoShare              bool
+	ShareFolders         []string
+	NestedVirtualization bool
+}
+
+// NewDriver creates a new Parallels Desktop driver with default settings
+func NewDriver(hostName, storePath string) drivers.Driver {
+	return &Driver{
+		BaseDriver: &drivers.BaseDriver{
+			MachineName: hostName,
+			StorePath:   storePath,
+			SSHUser:     defaultSSHUser,
+			SSHPort:     defaultSSHPort,
+		},
+		CPU:                  defaultCPU,
+		Memory:               defaultMemory,
+		VideoSize:            defaultVideoSize,
+		DiskSize:             defaultDiskSize,
+		Boot2DockerURL:       defaultBoot2DockerURL,
+		NoShare:              defaultNoShare,
+		NestedVirtualization: defaultNestedVirtualization,
+	}
+}
+
+// Create a host using the driver's config
+func (d *Driver) Create() error {
+	var (
+		err error
+	)
+
+	b2dutils := mcnutils.NewB2dUtils(d.StorePath)
+	if err = b2dutils.CopyIsoToMachineDir(d.Boot2DockerURL, d.MachineName); err != nil {
+		return err
+	}
+
+	log.Infof("Creating SSH key...")
+	sshKeyPath := d.GetSSHKeyPath()
+	log.Debugf("SSH key: %s", sshKeyPath)
+	if err = ssh.GenerateSSHKey(sshKeyPath); err != nil {
+		return err
+	}
+
+	log.Infof("Creating Parallels Desktop VM...")
+
+	ver, err := getParallelsVersion()
+	if err != nil {
+		return err
+	}
+
+	absStorePath, _ := filepath.Abs(d.ResolveStorePath("."))
+	if err = prlctl("create", d.MachineName,
+		"--distribution", "boot2docker",
+		"--dst", absStorePath,
+		"--no-hdd"); err != nil {
+		return err
+	}
+
+	cpus := d.CPU
+	if cpus < 1 {
+		cpus = int(runtime.NumCPU())
+	}
+	if cpus > 32 {
+		cpus = 32
+	}
+
+	videoSize := d.VideoSize
+	if videoSize < 2 {
+		videoSize = defaultVideoSize
+	}
+
+	if err = prlctl("set", d.MachineName,
+		"--select-boot-device", "off",
+		"--cpus", fmt.Sprintf("%d", cpus),
+		"--memsize", fmt.Sprintf("%d", d.Memory),
+		"--videosize", fmt.Sprintf("%d", videoSize),
+		"--cpu-hotplug", "off",
+		"--on-window-close", "keep-running",
+		"--longer-battery-life", "on",
+		"--3d-accelerate", "off",
+		"--device-bootorder", "cdrom0"); err != nil {
+		return err
+	}
+
+	if d.NestedVirtualization {
+		if err = prlctl("set", d.MachineName,
+			"--nested-virt", "on"); err != nil {
+			return err
+		}
+	}
+
+	absISOPath, _ := filepath.Abs(d.ResolveStorePath(isoFilename))
+	if err = prlctl("set", d.MachineName,
+		"--device-set", "cdrom0",
+		"--iface", "sata",
+		"--position", "0",
+		"--image", absISOPath,
+		"--connect"); err != nil {
+		return err
+	}
+
+	initialDiskSize := minDiskSize
+
+	// Fix for [GH-67]. Create a bigger disk on Parallels Desktop 13.0.*
+	constraints, _ := version.NewConstraint(">= 13.0.0, < 13.1.0")
+	if constraints.Check(ver) {
+		initialDiskSize = 1891
+	}
+
+	// Create a small plain disk. It will be converted and expanded later
+	if err = prlctl("set", d.MachineName,
+		"--device-add", "hdd",
+		"--iface", "sata",
+		"--position", "1",
+		"--image", d.diskPath(),
+		"--type", "plain",
+		"--size", fmt.Sprintf("%d", initialDiskSize)); err != nil {
+		return err
+	}
+
+	if err = d.generateDiskImage(d.DiskSize); err != nil {
+		return err
+	}
+
+	// Enable headless mode
+	if err = prlctl("set", d.MachineName,
+		"--startup-view", "headless"); err != nil {
+		return err
+	}
+
+	// Don't share any additional folders
+	if err = prlctl("set", d.MachineName,
+		"--shf-host-defined", "off"); err != nil {
+		return err
+	}
+
+	// Enable time sync, don't touch timezone (this part is buggy)
+	if err = prlctl("set", d.MachineName, "--time-sync", "on"); err != nil {
+		return err
+	}
+	if err = prlctl("set", d.MachineName,
+		"--disable-timezone-sync", "on"); err != nil {
+		return err
+	}
+
+	// Configure Shared Folders
+	if err = prlctl("set", d.MachineName,
+		"--shf-host", "on",
+		"--shared-cloud", "off",
+		"--shared-profile", "off",
+		"--smart-mount", "off"); err != nil {
+		return err
+	}
+
+	if !d.NoShare {
+		for i, f := range d.ShareFolders {
+			// Ensure the path is absolute and is available
+			fAbs, err := filepath.Abs(f)
+			if err != nil {
+				return err
+			}
+			if _, err := os.Stat(fAbs); err != nil {
+				if os.IsNotExist(err) {
+					log.Infof("Host path '%s' does not exist. Skipping sharing it with the machine...", fAbs)
+					continue
+				}
+				return err
+			}
+
+			if err = prlctl("set", d.MachineName,
+				"--shf-host-add", fmt.Sprintf("%s%d", shareFolderNamePrefix, i),
+				"--path", fAbs); err != nil {
+				return err
+			}
+		}
+	}
+
+	log.Infof("Starting Parallels Desktop VM...")
+
+	// Don't use Start() since it expects to have a dhcp lease already
+	if err = prlctl("start", d.MachineName); err != nil {
+		return err
+	}
+
+	var ip string
+
+	log.Infof("Waiting for VM to come online...")
+	for i := 1; i <= 60; i++ {
+		ip, err = d.getIPfromDHCPLease()
+		if err != nil {
+			log.Debugf("Not there yet %d/%d, error: %s", i, 60, err)
+			time.Sleep(2 * time.Second)
+			continue
+		}
+
+		if ip != "" {
+			log.Debugf("Got an ip: %s", ip)
+			conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", ip, d.SSHPort), time.Duration(2*time.Second))
+			if err != nil {
+				log.Debugf("SSH Daemon not responding yet: %s", err)
+				time.Sleep(2 * time.Second)
+				continue
+			}
+			conn.Close()
+			break
+		}
+	}
+
+	if ip == "" {
+		return fmt.Errorf("Machine didn't return an IP after 120 seconds, aborting")
+	}
+
+	d.IPAddress = ip
+
+	if err := d.Start(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DriverName returns the name of the driver as it is registered
+func (d *Driver) DriverName() string {
+	return "parallels"
+}
+
+// GetIP returns an IP or hostname that this host is available at
+// e.g. 1.2.3.4 or docker-host-d60b70a14d3a.cloudapp.net
+func (d *Driver) GetIP() (string, error) {
+	// Assume that Parallels Desktop hosts don't have IPs unless they are running
+	s, err := d.GetState()
+	if err != nil {
+		return "", err
+	}
+	if s != state.Running {
+		return "", drivers.ErrHostIsNotRunning
+	}
+
+	ip, err := d.getIPfromDHCPLease()
+	if err != nil {
+		return "", err
+	}
+
+	return ip, nil
+}
+
+// GetSSHHostname returns hostname for use with ssh
+func (d *Driver) GetSSHHostname() (string, error) {
+	return d.GetIP()
+}
+
+// GetURL returns a Docker compatible host URL for connecting to this host
+// e.g. tcp://1.2.3.4:2376
+func (d *Driver) GetURL() (string, error) {
+	ip, err := d.GetIP()
+	if err != nil {
+		return "", err
+	}
+	if ip == "" {
+		return "", nil
+	}
+	return fmt.Sprintf("tcp://%s:2376", ip), nil
+}
+
+// GetState returns the state that the host is in (running, stopped, etc)
+func (d *Driver) GetState() (state.State, error) {
+	stdout, stderr, err := prlctlOutErr("list", d.MachineName, "--output", "status", "--no-header")
+	if err != nil {
+		if reMachineNotFound.FindString(stderr) != "" {
+			return state.Error, errMachineNotExist
+		}
+		return state.Error, err
+	}
+
+	switch stdout {
+	case "running\n":
+		return state.Running, nil
+	case "paused\n":
+		return state.Paused, nil
+	case "suspended\n":
+		return state.Saved, nil
+	case "stopping\n":
+		return state.Stopping, nil
+	case "stopped\n":
+		return state.Stopped, nil
+	}
+	return state.None, nil
+}
+
+// Kill stops a host forcefully
+func (d *Driver) Kill() error {
+	return prlctl("stop", d.MachineName, "--kill")
+}
+
+// PreCreateCheck allows for pre-create operations to make sure a driver is ready for creation
+func (d *Driver) PreCreateCheck() error {
+	// Check platform type
+	if runtime.GOOS != "darwin" {
+		return fmt.Errorf("Driver \"parallels\" works only on macOS!")
+	}
+
+	// Check Parallels Desktop version
+	ver, err := getParallelsVersion()
+	if err != nil {
+		return err
+	}
+
+	if ver.LessThan(v11) {
+		return fmt.Errorf("Driver \"parallels\" supports only Parallels Desktop 11 and higher. You use: Parallels Desktop %s.", ver)
+	}
+
+	// Check Parallels Desktop edition
+	edit, err := getParallelsEdition()
+	if err != nil {
+		return err
+	}
+
+	log.Debugf("Found Parallels Desktop version: %d, edition: %s", ver, edit)
+
+	switch edit {
+	case "pro", "business":
+		break
+	default:
+		return fmt.Errorf("Docker Machine can be used only with Parallels Desktop Pro or Business edition. You use: %s edition", edit)
+	}
+
+	// Check whether the host is connected to Shared network
+	if err := checkSharedNetworkConnected(); err != nil {
+		return err
+	}
+
+	// Downloading boot2docker to cache should be done here to make sure
+	// that a download failure will not leave a machine half created.
+	b2dutils := mcnutils.NewB2dUtils(d.StorePath)
+	if err := b2dutils.UpdateISOCache(d.Boot2DockerURL); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Remove a host
+func (d *Driver) Remove() error {
+	s, err := d.GetState()
+	if err != nil {
+		if err == errMachineNotExist {
+			log.Infof("machine does not exist, assuming it has been removed already")
+			return nil
+		}
+		return err
+	}
+	if s == state.Running {
+		if err := d.Kill(); err != nil {
+			return err
+		}
+	}
+	return prlctl("delete", d.MachineName)
+}
+
+// Restart a host. This may just call Stop(); Start() if the provider does not
+// have any special restart behaviour.
+func (d *Driver) Restart() error {
+	if err := d.Stop(); err != nil {
+		return err
+	}
+	return d.Start()
+}
+
+// GetCreateFlags registers the flags this driver adds to
+// "docker hosts create"
+func (d *Driver) GetCreateFlags() []mcnflag.Flag {
+	return []mcnflag.Flag{
+		mcnflag.IntFlag{
+			EnvVar: "PARALLELS_MEMORY_SIZE",
+			Name:   "parallels-memory",
+			Usage:  "Size of memory for host in MB",
+			Value:  defaultMemory,
+		},
+		mcnflag.IntFlag{
+			EnvVar: "PARALLELS_CPU_COUNT",
+			Name:   "parallels-cpu-count",
+			Usage:  "number of CPUs for the machine (-1 to use the number of CPUs available)",
+			Value:  defaultCPU,
+		},
+		mcnflag.IntFlag{
+			EnvVar: "PARALLELS_VIDEO_SIZE",
+			Name:   "parallels-video-size",
+			Usage:  "Size of video memory for host in MB",
+			Value:  defaultVideoSize,
+		},
+		mcnflag.IntFlag{
+			EnvVar: "PARALLELS_DISK_SIZE",
+			Name:   "parallels-disk-size",
+			Usage:  "Size of disk for host in MB",
+			Value:  defaultDiskSize,
+		},
+		mcnflag.StringFlag{
+			EnvVar: "PARALLELS_BOOT2DOCKER_URL",
+			Name:   "parallels-boot2docker-url",
+			Usage:  "The URL of the boot2docker image. Defaults to the latest available version",
+			Value:  defaultBoot2DockerURL,
+		},
+		mcnflag.BoolFlag{
+			Name:  "parallels-no-share",
+			Usage: "Disable the mount of shared folder",
+		},
+		mcnflag.StringSliceFlag{
+			Name:  "parallels-share-folder",
+			Usage: "Path to the directory which should be shared with the machine. Default: /Users",
+			Value: []string{defaultShareFolder},
+		},
+		mcnflag.BoolFlag{
+			Name:  "parallels-nested-virtualization",
+			Usage: "Enable nested virutalization",
+		},
+	}
+}
+
+// SetConfigFromFlags configures the driver with the object that was returned
+// by RegisterCreateFlags
+func (d *Driver) SetConfigFromFlags(opts drivers.DriverOptions) error {
+	d.CPU = opts.Int("parallels-cpu-count")
+	d.Memory = opts.Int("parallels-memory")
+	d.VideoSize = opts.Int("parallels-video-size")
+	d.DiskSize = opts.Int("parallels-disk-size")
+	d.Boot2DockerURL = opts.String("parallels-boot2docker-url")
+	d.SetSwarmConfigFromFlags(opts)
+	d.SSHUser = defaultSSHUser
+	d.SSHPort = defaultSSHPort
+	d.NoShare = opts.Bool("parallels-no-share")
+	d.ShareFolders = opts.StringSlice("parallels-share-folder")
+	d.NestedVirtualization = opts.Bool("parallels-nested-virtualization")
+
+	return nil
+}
+
+// Start a host
+func (d *Driver) Start() error {
+	// Check whether the host is connected to Shared network
+	if err := checkSharedNetworkConnected(); err != nil {
+		return err
+	}
+
+	s, err := d.GetState()
+	if err != nil {
+		return err
+	}
+
+	switch s {
+	case state.Stopped, state.Saved, state.Paused:
+		if err = prlctl("start", d.MachineName); err != nil {
+			return err
+		}
+		log.Infof("Waiting for VM to start...")
+	case state.Running:
+		break
+	default:
+		log.Infof("VM not in restartable state")
+	}
+
+	if err = drivers.WaitForSSH(d); err != nil {
+		return err
+	}
+
+	d.IPAddress, err = d.GetIP()
+	if err != nil {
+		return err
+	}
+
+	// Mount Share Folder
+	shareFoldersMap, err := d.getShareFolders()
+	if err != nil {
+		return err
+	}
+
+	if !d.NoShare {
+		for shareName, sharePath := range shareFoldersMap {
+			if err := d.mountShareFolder(shareName, sharePath); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// Stop a host gracefully
+func (d *Driver) Stop() error {
+	if err := prlctl("stop", d.MachineName); err != nil {
+		return err
+	}
+	for {
+		s, err := d.GetState()
+		if err != nil {
+			return err
+		}
+		if s == state.Running {
+			time.Sleep(1 * time.Second)
+		} else {
+			break
+		}
+	}
+	return nil
+}
+
+func (d *Driver) getIPfromDHCPLease() (string, error) {
+
+	DHCPLeaseFile := "/Library/Preferences/Parallels/parallels_dhcp_leases"
+
+	stdout, _, err := prlctlOutErr("list", "-i", d.MachineName)
+	macRe := regexp.MustCompile("net0.* mac=([0-9A-F]{12}) card=.*")
+	macMatch := macRe.FindAllStringSubmatch(stdout, 1)
+
+	if len(macMatch) != 1 {
+		return "", fmt.Errorf("MAC address for NIC: nic0 on Virtual Machine: %s not found!\n", d.MachineName)
+	}
+	mac := macMatch[0][1]
+
+	if len(mac) != 12 {
+		return "", fmt.Errorf("Not a valid MAC address: %s. It should be exactly 12 digits.", mac)
+	}
+
+	leases, err := ioutil.ReadFile(DHCPLeaseFile)
+	if err != nil {
+		return "", err
+	}
+
+	ipRe := regexp.MustCompile("(.*)=\"(.*),(.*)," + strings.ToLower(mac) + ",.*\"")
+	mostRecentIP := ""
+	mostRecentLease := uint64(0)
+	for _, l := range ipRe.FindAllStringSubmatch(string(leases), -1) {
+		ip := l[1]
+		expiry, _ := strconv.ParseUint(l[2], 10, 64)
+		leaseTime, _ := strconv.ParseUint(l[3], 10, 32)
+		log.Debugf("Found lease: %s for MAC: %s, expiring at %d, leased for %d s.\n", ip, mac, expiry, leaseTime)
+		if mostRecentLease <= expiry-leaseTime {
+			mostRecentIP = ip
+			mostRecentLease = expiry - leaseTime
+		}
+	}
+
+	if len(mostRecentIP) == 0 {
+		return "", fmt.Errorf("IP lease not found for MAC address %s in: %s\n", mac, DHCPLeaseFile)
+	}
+	log.Debugf("Found IP lease: %s for MAC address %s\n", mostRecentIP, mac)
+
+	return mostRecentIP, nil
+}
+
+func (d *Driver) diskPath() string {
+	absDiskPath, _ := filepath.Abs(d.ResolveStorePath("disk.hdd"))
+	return absDiskPath
+}
+
+func (d *Driver) getShareFolders() (map[string]string, error) {
+	stdout, _, err := prlctlOutErr("list", "--info", d.MachineName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse Shared Folder name (ID) and path
+	res := make(map[string]string)
+	for _, match := range reSharedFolder.FindAllStringSubmatch(string(stdout), -1) {
+		sName := match[1]
+		sPath := match[2]
+		log.Debugf("Found the configured shared folder. Name: %q, Path: %q\n", sName, sPath)
+		res[sName] = sPath
+	}
+	return res, nil
+}
+
+// Mounts shared folder to the specified guest path. It is assumed that host and guest paths are the same
+func (d *Driver) mountShareFolder(shareName string, mountPoint string) error {
+	// Check the host path is available
+	if _, err := os.Stat(mountPoint); err != nil {
+		if os.IsNotExist(err) {
+			log.Infof("Host path %q does not exist. Skipping mount to VM...", mountPoint)
+			return nil
+		}
+		return err
+	}
+
+	// Ensure that the share is available on the guest side
+	checkCmd := fmt.Sprintf("sudo modprobe prl_fs && grep -w %q /proc/fs/prl_fs/sf_list", shareName)
+	if _, err := drivers.RunSSHCommandFromDriver(d, checkCmd); err != nil {
+		log.Infof("Shared folder %q is unavailable. Skipping mount to VM...", shareName)
+		return nil
+	}
+
+	// Mount the shared folder
+	log.Infof("Mounting shared folder %q ...", mountPoint)
+	mountCmd := fmt.Sprintf("sudo mkdir -p %q && sudo mount -t prl_fs %q %q", mountPoint, shareName, mountPoint)
+	if _, err := drivers.RunSSHCommandFromDriver(d, mountCmd); err != nil {
+		return fmt.Errorf("Error mounting shared folder: %s", err)
+	}
+
+	return nil
+}
+
+// Make a boot2docker VM disk image.
+func (d *Driver) generateDiskImage(size int) error {
+	tarBuf, err := mcnutils.MakeDiskImage(d.publicSSHKeyPath())
+	if err != nil {
+		return err
+	}
+
+	minSizeBytes := int64(minDiskSize) << 20 // usually won't fit in 32-bit int (max 2GB)
+
+	//Expand the initial image if needed
+	if bufLen := int64(tarBuf.Len()); bufLen > minSizeBytes {
+		bufLenMBytes := bufLen>>20 + 1
+		if err = prldisktool("resize",
+			"--hdd", d.diskPath(),
+			"--size", fmt.Sprintf("%d", bufLenMBytes)); err != nil {
+			return err
+		}
+	}
+
+	// Find hds file
+	hdsList, err := filepath.Glob(d.diskPath() + "/*.hds")
+	if err != nil {
+		return err
+	}
+	if len(hdsList) == 0 {
+		return fmt.Errorf("Could not find *.hds image in %s", d.diskPath())
+	}
+	hdsPath := hdsList[0]
+	log.Debugf("HDS image path: %s", hdsPath)
+
+	// Write tar to the hds file
+	hds, err := os.OpenFile(hdsPath, os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer hds.Close()
+	hds.Seek(0, os.SEEK_SET)
+	_, err = hds.Write(tarBuf.Bytes())
+	if err != nil {
+		return err
+	}
+	hds.Close()
+
+	// Convert image to expanding type and resize it
+	if err := prldisktool("convert", "--expanding", "--merge",
+		"--hdd", d.diskPath()); err != nil {
+		return err
+	}
+
+	if err := prldisktool("resize",
+		"--hdd", d.diskPath(),
+		"--size", fmt.Sprintf("%d", size)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *Driver) publicSSHKeyPath() string {
+	return d.GetSSHKeyPath() + ".pub"
+}
+
+// Detects Parallels Desktop major version
+func getParallelsVersion() (*version.Version, error) {
+	stdout, _, err := prlctlOutErr("--version")
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse Parallels Desktop version
+	verRaw := reParallelsVersion.FindStringSubmatch(string(stdout))
+	if verRaw == nil {
+		return nil, fmt.Errorf("Parallels Desktop version could not be fetched: %s", stdout)
+	}
+
+	ver, err := version.NewVersion(verRaw[1])
+	if err != nil {
+		return nil, err
+	}
+
+	return ver, nil
+}
+
+// Detects Parallels Desktop edition
+func getParallelsEdition() (string, error) {
+	stdout, _, err := prlsrvctlOutErr("info", "--license")
+	if err != nil {
+		return "", err
+	}
+
+	// Parse Parallels Desktop version
+	res := reParallelsEdition.FindStringSubmatch(string(stdout))
+	if res == nil {
+		return "", fmt.Errorf("Driver \"parallels\" requires Parallels Desktop license to be activated. More info: https://kb.parallels.com/en/124225")
+	}
+
+	return res[1], nil
+}
+
+// Checks whether the host is connected to Shared network
+func checkSharedNetworkConnected() error {
+	stdout, _, err := prlsrvctlOutErr("net", "info", "Shared")
+	if err != nil {
+		return err
+	}
+
+	// Parse the IPv4 of Shared network adapter
+	res := reSharedAdapterIP.FindStringSubmatch(string(stdout))
+	if res == nil {
+		return errSharedNetworkNotConnected
+	}
+
+	sharedNetworkIP := net.ParseIP(res[1])
+	log.Debugf("IP address of Shared network adapter: %s", sharedNetworkIP)
+
+	hostAddrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return err
+	}
+	log.Debugf("All host interface addressess: %v", hostAddrs)
+
+	// Check if the there is an interface with the Shared network adapter's IP assigned
+	for _, netAddr := range hostAddrs {
+		ipAddr := netAddr.(*net.IPNet).IP
+		if ipAddr.Equal(sharedNetworkIP) {
+			log.Debugf("Parallels Shared network adapter is connected")
+			return nil
+		}
+	}
+
+	return errSharedNetworkNotConnected
+}

--- a/pkg/drivers/parallels/prlctl.go
+++ b/pkg/drivers/parallels/prlctl.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parallels
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/docker/machine/libmachine/log"
+)
+
+func detectCmdInPath(cmd string) string {
+	if path, err := exec.LookPath(cmd); err == nil {
+		return path
+	}
+	return cmd
+}
+
+var (
+	prlctlCmd      = detectCmdInPath("prlctl")
+	prlsrvctlCmd   = detectCmdInPath("prlsrvctl")
+	prldisktoolCmd = detectCmdInPath("prl_disk_tool")
+
+	errPrlctlNotFound      = errors.New("Could not detect `prlctl` binary! Make sure Parallels Desktop Pro or Business edition is installed")
+	errPrlsrvctlNotFound   = errors.New("Could not detect `prlsrvctl` binary! Make sure Parallels Desktop Pro or Business edition is installed")
+	errPrldisktoolNotFound = errors.New("Could not detect `prl_disk_tool` binary! Make sure Parallels Desktop Pro or Business edition is installed")
+)
+
+func runCmd(cmdName string, args []string, notFound error) (string, string, error) {
+	cmd := exec.Command(cmdName, args...)
+	if os.Getenv("MACHINE_DEBUG") != "" {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	log.Debugf("executing: %v %v", cmdName, strings.Join(args, " "))
+
+	err := cmd.Run()
+	if err != nil {
+		if ee, ok := err.(*exec.Error); ok && ee.Err == exec.ErrNotFound {
+			err = notFound
+		}
+	}
+	return stdout.String(), stderr.String(), err
+}
+
+func prlctl(args ...string) error {
+	_, _, err := runCmd(prlctlCmd, args, errPrlctlNotFound)
+	return err
+}
+
+func prlctlOutErr(args ...string) (string, string, error) {
+	return runCmd(prlctlCmd, args, errPrlctlNotFound)
+}
+
+func prlsrvctl(args ...string) error {
+	_, _, err := runCmd(prlsrvctlCmd, args, errPrlsrvctlNotFound)
+	return err
+}
+
+func prlsrvctlOutErr(args ...string) (string, string, error) {
+	return runCmd(prlsrvctlCmd, args, errPrlsrvctlNotFound)
+}
+
+func prldisktool(args ...string) error {
+	_, _, err := runCmd(prldisktoolCmd, args, errPrldisktoolNotFound)
+	return err
+}

--- a/pkg/drivers/parallels/version.go
+++ b/pkg/drivers/parallels/version.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parallels
+
+import "fmt"
+
+// GitCommit that was compiled. This will be filled in by the compiler.
+var GitCommit string
+
+// Version number that is being run at the moment.
+const Version = "2.0.1"
+
+// FullVersion formats the version to be printed.
+func FullVersion() string {
+	return fmt.Sprintf("%s, build %s", Version, GitCommit)
+}

--- a/pkg/drivers/vmware/LICENSE
+++ b/pkg/drivers/vmware/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkg/drivers/vmware/config.go
+++ b/pkg/drivers/vmware/config.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+ * Copyright 2017 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package vmware
+
+import (
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/docker/machine/libmachine/mcnflag"
+)
+
+const (
+	defaultSSHUser     = "docker"
+	defaultSSHPass     = "tcuser"
+	defaultDiskSize    = 20000
+	defaultCPU         = 1
+	defaultMemory      = 1024
+	defaultWaitIP      = 30000
+	defaultNetworkType = "nat"
+)
+
+// Config specifies the configuration of driver VMware
+type Config struct {
+	*drivers.BaseDriver
+
+	Memory         int
+	DiskSize       int
+	CPU            int
+	ISO            string
+	Boot2DockerURL string
+
+	SSHPassword    string
+	ConfigDriveISO string
+	ConfigDriveURL string
+	NoShare        bool
+
+	WaitIP         int
+	NetworkType    string
+}
+
+// NewConfig creates a new Config
+func NewConfig(hostname, storePath string) *Config {
+	return &Config{
+		CPU:            defaultCPU,
+		Memory:         defaultMemory,
+		DiskSize:       defaultDiskSize,
+		SSHPassword:    defaultSSHPass,
+		WaitIP:         defaultWaitIP,
+		NetworkType:    defaultNetworkType,
+		BaseDriver: &drivers.BaseDriver{
+			SSHUser:     defaultSSHUser,
+			MachineName: hostname,
+			StorePath:   storePath,
+		},
+	}
+}
+
+// GetCreateFlags registers the flags this driver adds to
+// "docker hosts create"
+func (c *Config) GetCreateFlags() []mcnflag.Flag {
+	return []mcnflag.Flag{
+		mcnflag.StringFlag{
+			EnvVar: "VMWARE_BOOT2DOCKER_URL",
+			Name:   "vmware-boot2docker-url",
+			Usage:  "URL for boot2docker image",
+			Value:  "",
+		},
+		mcnflag.StringFlag{
+			EnvVar: "VMWARE_CONFIGDRIVE_URL",
+			Name:   "vmware-configdrive-url",
+			Usage:  "URL for cloud-init configdrive",
+			Value:  "",
+		},
+		mcnflag.IntFlag{
+			EnvVar: "VMWARE_CPU_COUNT",
+			Name:   "vmware-cpu-count",
+			Usage:  "number of CPUs for the machine (-1 to use the number of CPUs available)",
+			Value:  defaultCPU,
+		},
+		mcnflag.IntFlag{
+			EnvVar: "VMWARE_MEMORY_SIZE",
+			Name:   "vmware-memory-size",
+			Usage:  "size of memory for host VM (in MB)",
+			Value:  defaultMemory,
+		},
+		mcnflag.IntFlag{
+			EnvVar: "VMWARE_DISK_SIZE",
+			Name:   "vmware-disk-size",
+			Usage:  "size of disk for host VM (in MB)",
+			Value:  defaultDiskSize,
+		},
+		mcnflag.StringFlag{
+			EnvVar: "VMWARE_SSH_USER",
+			Name:   "vmware-ssh-user",
+			Usage:  "SSH user",
+			Value:  defaultSSHUser,
+		},
+		mcnflag.StringFlag{
+			EnvVar: "VMWARE_SSH_PASSWORD",
+			Name:   "vmware-ssh-password",
+			Usage:  "SSH password",
+			Value:  defaultSSHPass,
+		},
+		mcnflag.BoolFlag{
+			EnvVar: "VMWARE_NO_SHARE",
+			Name:   "vmware-no-share",
+			Usage:  "Disable the mount of your home directory",
+		},
+		mcnflag.IntFlag{
+			EnvVar: "VMWARE_WAIT_IP",
+			Name:   "vmware-wait-ip",
+			Usage:  "time to wait for vmrun to get an ip (in milliseconds)",
+			Value:  defaultWaitIP,
+		},
+		mcnflag.StringFlag{
+			EnvVar: "VMWARE_NETWORK_TYPE",
+			Name:   "vmware-network-type",
+			Usage:  "Network connection type to use (e.g. 'nat', 'bridged', 'hostonly')",
+			Value:  defaultNetworkType,
+		},
+	}
+}

--- a/pkg/drivers/vmware/driver.go
+++ b/pkg/drivers/vmware/driver.go
@@ -1,0 +1,689 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+ * Copyright 2017 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package vmware
+
+import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/docker/machine/libmachine/log"
+	"github.com/docker/machine/libmachine/mcnutils"
+	"github.com/docker/machine/libmachine/ssh"
+	"github.com/docker/machine/libmachine/state"
+	cryptossh "golang.org/x/crypto/ssh"
+)
+
+const (
+	isoFilename    = "boot2docker.iso"
+	isoConfigDrive = "configdrive.iso"
+)
+
+// Driver for VMware
+type Driver struct {
+	*Config
+}
+
+func NewDriver(hostname, storePath string) drivers.Driver {
+	return &Driver{
+		Config: NewConfig(hostname, storePath),
+	}
+}
+
+func (d *Driver) GetSSHHostname() (string, error) {
+	return d.GetIP()
+}
+
+func (d *Driver) GetSSHUsername() string {
+	if d.SSHUser == "" {
+		d.SSHUser = "docker"
+	}
+
+	return d.SSHUser
+}
+
+// DriverName returns the name of the driver
+func (d *Driver) DriverName() string {
+	return "vmware"
+}
+
+func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
+	d.Memory = flags.Int("vmware-memory-size")
+	d.CPU = flags.Int("vmware-cpu-count")
+	d.DiskSize = flags.Int("vmware-disk-size")
+	d.Boot2DockerURL = flags.String("vmware-boot2docker-url")
+	d.ConfigDriveURL = flags.String("vmware-configdrive-url")
+	d.ISO = d.ResolveStorePath(isoFilename)
+	d.ConfigDriveISO = d.ResolveStorePath(isoConfigDrive)
+	d.SetSwarmConfigFromFlags(flags)
+	d.SSHUser = flags.String("vmware-ssh-user")
+	d.SSHPassword = flags.String("vmware-ssh-password")
+	d.SSHPort = 22
+	d.NoShare = flags.Bool("vmware-no-share")
+	d.WaitIP = flags.Int("vmware-wait-ip")
+	d.NetworkType = flags.String("vmware-network-type")
+
+	// We support a maximum of 16 cpu to be consistent with Virtual Hardware 10
+	// specs.
+	if d.CPU < 1 {
+		d.CPU = int(runtime.NumCPU())
+	}
+	if d.CPU > 16 {
+		d.CPU = 16
+	}
+
+	return nil
+}
+
+func (d *Driver) GetURL() (string, error) {
+	ip, err := d.GetIP()
+	if err != nil {
+		return "", err
+	}
+	if ip == "" {
+		return "", nil
+	}
+	return fmt.Sprintf("tcp://%s", net.JoinHostPort(ip, "2376")), nil
+}
+
+func (d *Driver) GetIP() (ip string, err error) {
+	s, err := d.GetState()
+	if err != nil {
+		return "", err
+	}
+
+	if s != state.Running {
+		return "", drivers.ErrHostIsNotRunning
+	}
+
+	// attempt to find the address from vmrun
+	if ip, err := d.getIPfromVmrun(); err == nil {
+		return ip, err
+	}
+
+	// determine MAC address for VM
+	macaddr, err := d.getMacAddressFromVmx()
+	if err != nil {
+		return "", err
+	}
+
+	// attempt to find the address in the vmnet configuration
+	if ip, err = d.getIPfromVmnetConfiguration(macaddr); err == nil {
+		return ip, err
+	}
+
+	// address not found in vmnet so look for a DHCP lease
+	ip, err = d.getIPfromDHCPLease(macaddr)
+	if err != nil {
+		return "", err
+	}
+
+	return ip, nil
+}
+
+func (d *Driver) GetState() (state.State, error) {
+	// VMRUN only tells use if the vm is running or not
+	vmxp, err := filepath.EvalSymlinks(d.vmxPath())
+	if err != nil {
+		return state.Error, err
+	}
+
+	if stdout, _, _ := vmrun("list"); strings.Contains(stdout, vmxp) {
+		return state.Running, nil
+	}
+	return state.Stopped, nil
+}
+
+// PreCreateCheck checks that the machine creation process can be started safely.
+func (d *Driver) PreCreateCheck() error {
+	// Downloading boot2docker to cache should be done here to make sure
+	// that a download failure will not leave a machine half created.
+	b2dutils := mcnutils.NewB2dUtils(d.StorePath)
+	return b2dutils.UpdateISOCache(d.Boot2DockerURL)
+}
+
+func (d *Driver) Create() error {
+	os.MkdirAll(filepath.Join(d.StorePath, "machines", d.GetMachineName()), 0755)
+
+	b2dutils := mcnutils.NewB2dUtils(d.StorePath)
+	if err := b2dutils.CopyIsoToMachineDir(d.Boot2DockerURL, d.MachineName); err != nil {
+		return err
+	}
+
+	// download cloud-init config drive
+	if d.ConfigDriveURL != "" {
+		if err := b2dutils.DownloadISO(d.ResolveStorePath("."), isoConfigDrive, d.ConfigDriveURL); err != nil {
+			return err
+		}
+	}
+
+	log.Infof("Creating SSH key...")
+	if err := ssh.GenerateSSHKey(d.GetSSHKeyPath()); err != nil {
+		return err
+	}
+
+	log.Infof("Creating VM...")
+	if err := os.MkdirAll(d.ResolveStorePath("."), 0755); err != nil {
+		return err
+	}
+
+	if _, err := os.Stat(d.vmxPath()); err == nil {
+		return ErrMachineExist
+	}
+
+	// Generate vmx config file from template
+	vmxt := template.Must(template.New("vmx").Parse(vmx))
+	vmxfile, err := os.Create(d.vmxPath())
+	if err != nil {
+		return err
+	}
+	vmxt.Execute(vmxfile, d)
+
+	// Generate vmdk file
+	diskImg := d.ResolveStorePath(fmt.Sprintf("%s.vmdk", d.MachineName))
+	if _, err := os.Stat(diskImg); err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+
+		if err := vdiskmanager(diskImg, d.DiskSize); err != nil {
+			return err
+		}
+	}
+
+	return d.Start()
+}
+
+func (d *Driver) Start() error {
+	log.Infof("Starting %s...", d.MachineName)
+	vmrun("start", d.vmxPath(), "nogui")
+
+	var ip string
+	var err error
+
+	log.Infof("Waiting for VM to come online...")
+	for i := 1; i <= 60; i++ {
+		ip, err = d.GetIP()
+		if err != nil {
+			log.Debugf("Not there yet %d/%d, error: %s", i, 60, err)
+			time.Sleep(2 * time.Second)
+			continue
+		}
+
+		if ip != "" {
+			log.Debugf("Got an ip: %s", ip)
+			conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", ip, 22), time.Duration(2*time.Second))
+			if err != nil {
+				log.Debugf("SSH Daemon not responding yet: %s", err)
+				time.Sleep(2 * time.Second)
+				continue
+			}
+			conn.Close()
+			break
+		}
+	}
+
+	if ip == "" {
+		return fmt.Errorf("Machine didn't return an IP after 120 seconds, aborting")
+	}
+
+	// we got an IP, let's copy ssh keys over
+	d.IPAddress = ip
+
+	// Do not execute the rest of boot2docker specific configuration
+	// The upload of the public ssh key uses a ssh connection,
+	// this works without installed vmware client tools
+	if d.ConfigDriveURL != "" {
+		var keyfh *os.File
+		var keycontent []byte
+
+		log.Infof("Copy public SSH key to %s [%s]", d.MachineName, d.IPAddress)
+
+		// create .ssh folder in users home
+		if err := executeSSHCommand(fmt.Sprintf("mkdir -p /home/%s/.ssh", d.SSHUser), d); err != nil {
+			return err
+		}
+
+		// read generated public ssh key
+		if keyfh, err = os.Open(d.publicSSHKeyPath()); err != nil {
+			return err
+		}
+		defer keyfh.Close()
+
+		if keycontent, err = ioutil.ReadAll(keyfh); err != nil {
+			return err
+		}
+
+		// add public ssh key to authorized_keys
+		if err := executeSSHCommand(fmt.Sprintf("echo '%s' > /home/%s/.ssh/authorized_keys", string(keycontent), d.SSHUser), d); err != nil {
+			return err
+		}
+
+		// make it secure
+		if err := executeSSHCommand(fmt.Sprintf("chmod 600 /home/%s/.ssh/authorized_keys", d.SSHUser), d); err != nil {
+			return err
+		}
+
+		log.Debugf("Leaving create sequence early, configdrive found")
+		return nil
+	}
+
+	// Generate a tar keys bundle
+	if err := d.generateKeyBundle(); err != nil {
+		return err
+	}
+
+	// Test if /var/lib/boot2docker exists
+	vmrun("-gu", d.SSHUser, "-gp", d.SSHPassword, "directoryExistsInGuest", d.vmxPath(), "/var/lib/boot2docker")
+
+	// Copy SSH keys bundle
+	vmrun("-gu", d.SSHUser, "-gp", d.SSHPassword, "CopyFileFromHostToGuest", d.vmxPath(), d.ResolveStorePath("userdata.tar"), "/home/docker/userdata.tar")
+
+	// Expand tar file.
+	vmrun("-gu", d.SSHUser, "-gp", d.SSHPassword, "runScriptInGuest", d.vmxPath(), "/bin/sh", "sudo sh -c \"tar xvf /home/docker/userdata.tar -C /home/docker > /var/log/userdata.log 2>&1 && chown -R docker:staff /home/docker\"")
+
+	// copy to /var/lib/boot2docker
+	vmrun("-gu", d.SSHUser, "-gp", d.SSHPassword, "runScriptInGuest", d.vmxPath(), "/bin/sh", "sudo /bin/mv /home/docker/userdata.tar /var/lib/boot2docker/userdata.tar")
+
+	// Enable Shared Folders
+	vmrun("-gu", d.SSHUser, "-gp", d.SSHPassword, "enableSharedFolders", d.vmxPath())
+
+	shareName, hostDir, shareDir := getShareDriveAndName()
+	if hostDir != "" && !d.NoShare {
+		if _, err := os.Stat(hostDir); err != nil && !os.IsNotExist(err) {
+			return err
+		} else if !os.IsNotExist(err) {
+			// add shared folder, create mountpoint and mount it.
+			vmrun("-gu", d.SSHUser, "-gp", d.SSHPassword, "addSharedFolder", d.vmxPath(), shareName, hostDir)
+			command := mountCommand(shareName, shareDir)
+			vmrun("-gu", d.SSHUser, "-gp", d.SSHPassword, "runScriptInGuest", d.vmxPath(), "/bin/sh", command)
+		}
+	}
+	return nil
+}
+
+func (d *Driver) Stop() error {
+	_, _, err := vmrun("stop", d.vmxPath(), "nogui")
+	return err
+}
+
+func (d *Driver) Restart() error {
+	// Stop VM gracefully
+	if err := d.Stop(); err != nil {
+		return err
+	}
+	// Start it again and mount shared folder
+	return d.Start()
+}
+
+func (d *Driver) Kill() error {
+	_, _, err := vmrun("stop", d.vmxPath(), "hard nogui")
+	return err
+}
+
+func (d *Driver) Remove() error {
+	s, _ := d.GetState()
+	if s == state.Running {
+		if err := d.Kill(); err != nil {
+			return fmt.Errorf("Error stopping VM before deletion")
+		}
+	}
+	log.Infof("Deleting %s...", d.MachineName)
+	vmrun("deleteVM", d.vmxPath(), "nogui")
+	return nil
+}
+
+func (d *Driver) Upgrade() error {
+	return fmt.Errorf("VMware does not currently support the upgrade operation")
+}
+
+func (d *Driver) vmxPath() string {
+	return d.ResolveStorePath(fmt.Sprintf("%s.vmx", d.MachineName))
+}
+
+func (d *Driver) vmdkPath() string {
+	return d.ResolveStorePath(fmt.Sprintf("%s.vmdk", d.MachineName))
+}
+
+func (d *Driver) getMacAddressFromVmx() (string, error) {
+	var vmxfh *os.File
+	var vmxcontent []byte
+	var err error
+
+	if vmxfh, err = os.Open(d.vmxPath()); err != nil {
+		return "", err
+	}
+	defer vmxfh.Close()
+
+	if vmxcontent, err = ioutil.ReadAll(vmxfh); err != nil {
+		return "", err
+	}
+
+	// Look for generatedAddress as we're passing a VMX with addressType = "generated".
+	var macaddr string
+	vmxparse := regexp.MustCompile(`^ethernet0.generatedAddress\s*=\s*"(.*?)"\s*$`)
+	for _, line := range strings.Split(string(vmxcontent), "\n") {
+		if matches := vmxparse.FindStringSubmatch(line); matches == nil {
+			continue
+		} else {
+			macaddr = strings.ToLower(matches[1])
+		}
+	}
+
+	if macaddr == "" {
+		return "", fmt.Errorf("couldn't find MAC address in VMX file %s", d.vmxPath())
+	}
+
+	log.Debugf("MAC address in VMX: %s", macaddr)
+
+	return macaddr, nil
+}
+
+func (d *Driver) getIPfromVmrun() (string, error) {
+	vmx := d.vmxPath()
+
+	ip := regexp.MustCompile(`\d+\.\d+\.\d+\.\d+`)
+	stdout, _, _ := vmrun_wait(time.Duration(d.WaitIP)*time.Millisecond, "getGuestIPAddress", vmx, "-wait")
+	if match := ip.FindString(stdout); match != "" {
+		return match, nil
+	}
+
+	return "", fmt.Errorf("could not get IP from vmrun")
+}
+
+func (d *Driver) getIPfromVmnetConfiguration(macaddr string) (string, error) {
+
+	// DHCP lease table for NAT vmnet interface
+	confFiles, _ := filepath.Glob(DhcpConfigFiles())
+	for _, conffile := range confFiles {
+		log.Debugf("Trying to find IP address in configuration file: %s", conffile)
+		if ipaddr, err := d.getIPfromVmnetConfigurationFile(conffile, macaddr); err == nil {
+			return ipaddr, err
+		}
+	}
+
+	return "", fmt.Errorf("IP not found for MAC %s in vmnet configuration files", macaddr)
+}
+
+func (d *Driver) getIPfromVmnetConfigurationFile(conffile, macaddr string) (string, error) {
+	var conffh *os.File
+	var confcontent []byte
+
+	var currentip string
+	var lastipmatch string
+	var lastmacmatch string
+
+	var err error
+
+	if conffh, err = os.Open(conffile); err != nil {
+		return "", err
+	}
+	defer conffh.Close()
+
+	if confcontent, err = ioutil.ReadAll(conffh); err != nil {
+		return "", err
+	}
+
+	// find all occurrences of 'host .* { .. }' and extract
+	// out of the inner block the MAC and IP addresses
+
+	// key = MAC, value = IP
+	m := make(map[string]string)
+
+	// Begin of a host block, that contains the IP, MAC
+	hostbegin := regexp.MustCompile(`^host (.+?) {`)
+	// End of a host block
+	hostend := regexp.MustCompile(`^}`)
+
+	// Get the IP address.
+	ip := regexp.MustCompile(`^\s*fixed-address (.+?);\r?$`)
+	// Get the MAC address associated.
+	mac := regexp.MustCompile(`^\s*hardware ethernet (.+?);\r?$`)
+
+	// we use a block depth so that just in case inner blocks exists
+	// we are not being fooled by them
+	blockdepth := 0
+	for _, line := range strings.Split(string(confcontent), "\n") {
+
+		if matches := hostbegin.FindStringSubmatch(line); matches != nil {
+			blockdepth = blockdepth + 1
+			continue
+		}
+
+		// we are only in interested in endings if we in a block. Otherwise we will count
+		// ending of non host blocks as well
+		if matches := hostend.FindStringSubmatch(line); blockdepth > 0 && matches != nil {
+			blockdepth = blockdepth - 1
+
+			if blockdepth == 0 {
+				// add data
+				m[lastmacmatch] = lastipmatch
+
+				// reset all temp var holders
+				lastipmatch = ""
+				lastmacmatch = ""
+			}
+
+			continue
+		}
+
+		// only if we are within the first level of a block
+		// we are looking for addresses to extract
+		if blockdepth == 1 {
+			if matches := ip.FindStringSubmatch(line); matches != nil {
+				lastipmatch = matches[1]
+				continue
+			}
+
+			if matches := mac.FindStringSubmatch(line); matches != nil {
+				lastmacmatch = strings.ToLower(matches[1])
+				continue
+			}
+		}
+	}
+
+	log.Debugf("Following IPs found %s", m)
+
+	// map is filled to now lets check if we have a MAC associated to an IP
+	currentip, ok := m[strings.ToLower(macaddr)]
+
+	if !ok {
+		return "", fmt.Errorf("IP not found for MAC %s in vmnet configuration", macaddr)
+	}
+
+	log.Debugf("IP found in vmnet configuration file: %s", currentip)
+
+	return currentip, nil
+
+}
+
+func (d *Driver) getIPfromDHCPLease(macaddr string) (string, error) {
+
+	// DHCP lease table for NAT vmnet interface
+	leasesFiles, _ := filepath.Glob(DhcpLeaseFiles())
+	for _, dhcpfile := range leasesFiles {
+		log.Debugf("Trying to find IP address in leases file: %s", dhcpfile)
+		if ipaddr, err := d.getIPfromDHCPLeaseFile(dhcpfile, macaddr); err == nil {
+			return ipaddr, err
+		}
+	}
+
+	return "", fmt.Errorf("IP not found for MAC %s in DHCP leases", macaddr)
+}
+
+func (d *Driver) getIPfromDHCPLeaseFile(dhcpfile, macaddr string) (string, error) {
+	var dhcpfh *os.File
+	var dhcpcontent []byte
+	var lastipmatch string
+	var currentip string
+	var lastleaseendtime time.Time
+	var currentleadeendtime time.Time
+	var err error
+
+	if dhcpfh, err = os.Open(dhcpfile); err != nil {
+		return "", err
+	}
+	defer dhcpfh.Close()
+
+	if dhcpcontent, err = ioutil.ReadAll(dhcpfh); err != nil {
+		return "", err
+	}
+
+	// Get the IP from the lease table.
+	leaseip := regexp.MustCompile(`^lease (.+?) {\r?$`)
+	// Get the lease end date time.
+	leaseend := regexp.MustCompile(`^\s*ends \d (.+?);\r?$`)
+	// Get the MAC address associated.
+	leasemac := regexp.MustCompile(`^\s*hardware ethernet (.+?);\r?$`)
+
+	for _, line := range strings.Split(string(dhcpcontent), "\n") {
+
+		if matches := leaseip.FindStringSubmatch(line); matches != nil {
+			lastipmatch = matches[1]
+			continue
+		}
+
+		if matches := leaseend.FindStringSubmatch(line); matches != nil {
+			lastleaseendtime, _ = time.Parse("2006/01/02 15:04:05", matches[1])
+			continue
+		}
+
+		if matches := leasemac.FindStringSubmatch(line); matches != nil && matches[1] == macaddr && currentleadeendtime.Before(lastleaseendtime) {
+			currentip = lastipmatch
+			currentleadeendtime = lastleaseendtime
+		}
+	}
+
+	if currentip == "" {
+		return "", fmt.Errorf("IP not found for MAC %s in DHCP leases", macaddr)
+	}
+
+	log.Debugf("IP found in DHCP lease table: %s", currentip)
+
+	return currentip, nil
+}
+
+func (d *Driver) publicSSHKeyPath() string {
+	return d.GetSSHKeyPath() + ".pub"
+}
+
+// Make a boot2docker userdata.tar key bundle
+func (d *Driver) generateKeyBundle() error {
+	log.Debugf("Creating Tar key bundle...")
+
+	magicString := "boot2docker, this is vmware speaking"
+
+	tf, err := os.Create(d.ResolveStorePath("userdata.tar"))
+	if err != nil {
+		return err
+	}
+	defer tf.Close()
+	var fileWriter = tf
+
+	tw := tar.NewWriter(fileWriter)
+	defer tw.Close()
+
+	// magicString first so we can figure out who originally wrote the tar.
+	file := &tar.Header{Name: magicString, Size: int64(len(magicString))}
+	if err := tw.WriteHeader(file); err != nil {
+		return err
+	}
+	if _, err := tw.Write([]byte(magicString)); err != nil {
+		return err
+	}
+	// .ssh/key.pub => authorized_keys
+	file = &tar.Header{Name: ".ssh", Typeflag: tar.TypeDir, Mode: 0700}
+	if err := tw.WriteHeader(file); err != nil {
+		return err
+	}
+	pubKey, err := ioutil.ReadFile(d.publicSSHKeyPath())
+	if err != nil {
+		return err
+	}
+	file = &tar.Header{Name: ".ssh/authorized_keys", Size: int64(len(pubKey)), Mode: 0644}
+	if err := tw.WriteHeader(file); err != nil {
+		return err
+	}
+	if _, err := tw.Write([]byte(pubKey)); err != nil {
+		return err
+	}
+	file = &tar.Header{Name: ".ssh/authorized_keys2", Size: int64(len(pubKey)), Mode: 0644}
+	if err := tw.WriteHeader(file); err != nil {
+		return err
+	}
+	if _, err := tw.Write([]byte(pubKey)); err != nil {
+		return err
+	}
+
+	return tw.Close()
+}
+
+// execute command over SSH with user / password authentication
+func executeSSHCommand(command string, d *Driver) error {
+	log.Debugf("Execute executeSSHCommand: %s", command)
+
+	config := &cryptossh.ClientConfig{
+		User: d.SSHUser,
+		Auth: []cryptossh.AuthMethod{
+			cryptossh.Password(d.SSHPassword),
+		},
+	}
+
+	client, err := cryptossh.Dial("tcp", fmt.Sprintf("%s:%d", d.IPAddress, d.SSHPort), config)
+	if err != nil {
+		log.Debugf("Failed to dial:", err)
+		return err
+	}
+
+	session, err := client.NewSession()
+	if err != nil {
+		log.Debugf("Failed to create session: " + err.Error())
+		return err
+	}
+	defer session.Close()
+
+	var b bytes.Buffer
+	session.Stdout = &b
+
+	if err := session.Run(command); err != nil {
+		log.Debugf("Failed to run: " + err.Error())
+		return err
+	}
+	log.Debugf("Stdout from executeSSHCommand: %s", b.String())
+
+	return nil
+}
+
+func mountCommand(shareName, shareDir string) string {
+	// Replace C:\ to / due to Windows/Linux path difference
+	shareDir = strings.Replace(shareDir, "C:\\", "/", 1)
+	return "[ ! -d " + shareDir + " ]&& sudo mkdir " + shareDir + "; sudo mount --bind /mnt/hgfs/" + shareDir + " " + shareDir + " || [ -f /usr/local/bin/vmhgfs-fuse ]&& sudo /usr/local/bin/vmhgfs-fuse -o allow_other .host:/" + shareName + " " + shareDir + " || sudo mount -t vmhgfs -o uid=$(id -u),gid=$(id -g) .host:/" + shareName + " " + shareDir
+}

--- a/pkg/drivers/vmware/driver_test.go
+++ b/pkg/drivers/vmware/driver_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vmware
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/docker/machine/libmachine/state"
+)
+
+var skip = !check(vmrunbin) || !check(vdiskmanbin)
+
+func check(path string) bool {
+	_, err := os.Stat(path)
+	if err != nil {
+		log.Printf("%q is missing", path)
+		return false
+	}
+
+	return true
+}
+
+func TestSetConfigFromFlags(t *testing.T) {
+	driver := NewDriver("default", "path")
+
+	checkFlags := &drivers.CheckDriverOptions{
+		FlagsValues: map[string]interface{}{},
+		CreateFlags: driver.GetCreateFlags(),
+	}
+
+	err := driver.SetConfigFromFlags(checkFlags)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(checkFlags.InvalidFlags) != 0 {
+		t.Fatalf("expect len(checkFlags.InvalidFlags) == 0; got %d", len(checkFlags.InvalidFlags))
+	}
+}
+
+func TestDriver(t *testing.T) {
+	// skip driver tests
+	if true {
+		t.Skip()
+	}
+
+	path, err := ioutil.TempDir("", "vmware-driver-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.RemoveAll(path)
+
+	driver := NewDriver("default", path)
+
+	checkFlags := &drivers.CheckDriverOptions{
+		FlagsValues: map[string]interface{}{},
+		CreateFlags: driver.GetCreateFlags(),
+	}
+
+	err = driver.SetConfigFromFlags(checkFlags)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	driver.(*Driver).Boot2DockerURL = "https://github.com/boot2docker/boot2docker/releases/download/v17.10.0-ce-rc2/boot2docker.iso"
+
+	err = driver.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer driver.Remove()
+
+	st, err := driver.GetState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st != state.Running {
+		t.Fatalf("expect state == Running; got %s", st.String())
+	}
+
+	ip, err := driver.GetIP()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ip == "" {
+		t.Fatal("expect ip non-zero; got ''")
+	}
+
+	username := driver.GetSSHUsername()
+	if username == "" {
+		t.Fatal("expect username non-zero; got ''")
+	}
+
+	key := driver.GetSSHKeyPath()
+	if key == "" {
+		t.Fatal("expect key non-zero; got ''")
+	}
+
+	port, err := driver.GetSSHPort()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if port == 0 {
+		t.Fatal("expect port not 0; got 0")
+	}
+
+	host, err := driver.GetSSHHostname()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if host == "" {
+		t.Fatal("expect host non-zero; got ''")
+	}
+}

--- a/pkg/drivers/vmware/vmrun.go
+++ b/pkg/drivers/vmware/vmrun.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+ * Copyright 2017 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package vmware
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/docker/machine/libmachine/log"
+)
+
+var (
+	vmrunbin    = setVmwareCmd("vmrun")
+	vdiskmanbin = setVmwareCmd("vmware-vdiskmanager")
+)
+
+var (
+	ErrMachineExist    = errors.New("machine already exists")
+	ErrMachineNotExist = errors.New("machine does not exist")
+	ErrVMRUNNotFound   = errors.New("VMRUN not found")
+)
+
+func init() {
+	// vmrun with nogui on VMware Fusion through at least 8.0.1 doesn't work right
+	// if the umask is set to not allow world-readable permissions
+	SetUmask()
+}
+
+func isMachineDebugEnabled() bool {
+	return os.Getenv("MACHINE_DEBUG") != ""
+}
+
+func vmrun(args ...string) (string, string, error) {
+	cmd := exec.Command(vmrunbin, args...)
+	return vmrun_cmd(cmd)
+}
+
+func vmrun_wait(timeout time.Duration, args ...string) (string, string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, vmrunbin, args...)
+	return vmrun_cmd(cmd)
+}
+
+func vmrun_cmd(cmd *exec.Cmd) (string, string, error) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+
+	if isMachineDebugEnabled() {
+		// write stdout to stderr because stdout is used for parsing sometimes
+		cmd.Stdout = io.MultiWriter(os.Stderr, cmd.Stdout)
+		cmd.Stderr = io.MultiWriter(os.Stderr, cmd.Stderr)
+	}
+
+	log.Debugf("executing: %v", strings.Join(cmd.Args, " "))
+
+	err := cmd.Run()
+	if err != nil {
+		if ee, ok := err.(*exec.Error); ok && ee == exec.ErrNotFound {
+			err = ErrVMRUNNotFound
+		}
+	}
+
+	return stdout.String(), stderr.String(), err
+}
+
+// Make a vmdk disk image with the given size (in MB).
+func vdiskmanager(dest string, size int) error {
+	cmd := exec.Command(vdiskmanbin, "-c", "-t", "0", "-s", fmt.Sprintf("%dMB", size), "-a", "lsilogic", dest)
+	if isMachineDebugEnabled() {
+		// write stdout to stderr because stdout is used for parsing sometimes
+		cmd.Stdout = os.Stderr
+		cmd.Stderr = os.Stderr
+	}
+
+	if stdout := cmd.Run(); stdout != nil {
+		if ee, ok := stdout.(*exec.Error); ok && ee == exec.ErrNotFound {
+			return ErrVMRUNNotFound
+		}
+	}
+	return nil
+}

--- a/pkg/drivers/vmware/vmware.go
+++ b/pkg/drivers/vmware/vmware.go
@@ -1,0 +1,44 @@
+//go:build !darwin && !linux && !windows
+
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vmware
+
+import "github.com/docker/machine/libmachine/drivers"
+
+func NewDriver(hostName, storePath string) drivers.Driver {
+	return drivers.NewDriverNotSupported("vmware", hostName, storePath)
+}
+
+func DhcpConfigFiles() string {
+	return ""
+}
+
+func DhcpLeaseFiles() string {
+	return ""
+}
+
+func SetUmask() {
+}
+
+func setVmwareCmd(cmd string) string {
+	return ""
+}
+
+func getShareDriveAndName() (string, string, string) {
+	return "", "", ""
+}

--- a/pkg/drivers/vmware/vmware_darwin.go
+++ b/pkg/drivers/vmware/vmware_darwin.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vmware
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+)
+
+func DhcpConfigFiles() string {
+	return "/Library/Preferences/VMware Fusion/vmnet*/dhcpd.conf"
+}
+
+func DhcpLeaseFiles() string {
+	return "/var/db/vmware/*.leases"
+}
+
+func SetUmask() {
+	_ = syscall.Umask(022)
+}
+
+// detect the vmrun and vmware-vdiskmanager cmds' path if needed
+func setVmwareCmd(cmd string) string {
+	if path, err := exec.LookPath(cmd); err == nil {
+		return path
+	}
+	for _, fp := range []string{
+		"/Applications/VMware Fusion.app/Contents/Library/",
+	} {
+		p := filepath.Join(fp, cmd)
+		_, err := os.Stat(p)
+		if err == nil {
+			return p
+		}
+	}
+	return cmd
+}
+
+func getShareDriveAndName() (string, string, string) {
+	return "Users", "/Users", "/hosthome"
+}

--- a/pkg/drivers/vmware/vmware_linux.go
+++ b/pkg/drivers/vmware/vmware_linux.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vmware
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func DhcpConfigFiles() string {
+	return "/etc/vmware/vmnet*/dhcpd/dhcpd.conf"
+}
+
+func DhcpLeaseFiles() string {
+	return "/etc/vmware/vmnet*/dhcpd/dhcpd.leases"
+}
+
+func SetUmask() {
+	_ = syscall.Umask(022)
+}
+
+// detect the vmrun and vmware-vdiskmanager cmds' path if needed
+func setVmwareCmd(cmd string) string {
+	if path, err := exec.LookPath(cmd); err == nil {
+		return path
+	}
+	return cmd
+}
+
+func getShareDriveAndName() (string, string, string) {
+	return "hosthome", "/home", "/hosthome"
+}

--- a/pkg/drivers/vmware/vmware_windows.go
+++ b/pkg/drivers/vmware/vmware_windows.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vmware
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+// https://docs.microsoft.com/en-us/windows/deployment/usmt/usmt-recognized-environment-variables
+
+func DhcpConfigFiles() string {
+	return filepath.Join(os.Getenv("ALLUSERSPROFILE"), `VMware\vmnetdhcp.conf`)
+}
+
+func DhcpLeaseFiles() string {
+	return filepath.Join(os.Getenv("ALLUSERSPROFILE"), `VMware\vmnetdhcp.leases`)
+}
+
+func SetUmask() {
+}
+
+func setVmwareCmd(cmd string) string {
+	cmd = cmd + ".exe"
+	DefaultVMWareWSProductionRegistryKey := `SOFTWARE\WOW6432Node\VMware, Inc.`
+	DefaultVMwareCorePathKey := "Core"
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, DefaultVMWareWSProductionRegistryKey, registry.QUERY_VALUE)
+	if err != nil {
+		return ""
+	}
+	defer k.Close()
+	production, _, err := k.GetStringValue(DefaultVMwareCorePathKey)
+	if err != nil {
+		return ""
+	}
+
+	//Get the VMware Product Install Path
+	DefaultVMwareWSRegistryKey := fmt.Sprintf(`SOFTWARE\WOW6432Node\VMware, Inc.\%s`, production)
+	DefaultVMwareWSInstallPathKey := "InstallPath"
+
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE, DefaultVMwareWSRegistryKey, registry.QUERY_VALUE)
+	if err != nil {
+		return ""
+	}
+	defer key.Close()
+
+	value, _, err := key.GetStringValue(DefaultVMwareWSInstallPathKey)
+	if err != nil {
+		return ""
+	}
+	windowsInstallDir := value
+	return filepath.Join(windowsInstallDir, cmd)
+}
+
+func getShareDriveAndName() (string, string, string) {
+	return "Users", os.Getenv("PUBLIC"), "/hosthome"
+}

--- a/pkg/drivers/vmware/vmx.go
+++ b/pkg/drivers/vmware/vmx.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+ * Copyright 2017 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package vmware
+
+const vmx = `
+.encoding = "UTF-8"
+config.version = "8"
+displayName = "{{.MachineName}}"
+ethernet0.present = "TRUE"
+ethernet0.connectionType = "{{.NetworkType}}"
+ethernet0.virtualDev = "vmxnet3"
+ethernet0.wakeOnPcktRcv = "FALSE"
+ethernet0.addressType = "generated"
+ethernet0.linkStatePropagation.enable = "TRUE"
+pciBridge0.present = "TRUE"
+pciBridge4.present = "TRUE"
+pciBridge4.virtualDev = "pcieRootPort"
+pciBridge4.functions = "8"
+pciBridge5.present = "TRUE"
+pciBridge5.virtualDev = "pcieRootPort"
+pciBridge5.functions = "8"
+pciBridge6.present = "TRUE"
+pciBridge6.virtualDev = "pcieRootPort"
+pciBridge6.functions = "8"
+pciBridge7.present = "TRUE"
+pciBridge7.virtualDev = "pcieRootPort"
+pciBridge7.functions = "8"
+pciBridge0.pciSlotNumber = "17"
+pciBridge4.pciSlotNumber = "21"
+pciBridge5.pciSlotNumber = "22"
+pciBridge6.pciSlotNumber = "23"
+pciBridge7.pciSlotNumber = "24"
+scsi0.pciSlotNumber = "160"
+usb.pciSlotNumber = "32"
+ethernet0.pciSlotNumber = "192"
+sound.pciSlotNumber = "33"
+vmci0.pciSlotNumber = "35"
+sata0.pciSlotNumber = "36"
+floppy0.present = "FALSE"
+guestOS = "other3xlinux-64"
+hpet0.present = "TRUE"
+sata0.present = "TRUE"
+sata0:1.present = "TRUE"
+sata0:1.fileName = "{{.ISO}}"
+sata0:1.deviceType = "cdrom-image"
+{{ if .ConfigDriveURL }}
+sata0:2.present = "TRUE"
+sata0:2.fileName = "{{.ConfigDriveISO}}"
+sata0:2.deviceType = "cdrom-image"
+{{ end }}
+vmci0.present = "TRUE"
+mem.hotadd = "TRUE"
+memsize = "{{.Memory}}"
+powerType.powerOff = "soft"
+powerType.powerOn = "soft"
+powerType.reset = "soft"
+powerType.suspend = "soft"
+scsi0.present = "TRUE"
+scsi0.virtualDev = "pvscsi"
+scsi0:0.fileName = "{{.MachineName}}.vmdk"
+scsi0:0.present = "TRUE"
+tools.synctime = "TRUE"
+virtualHW.productCompatibility = "hosted"
+virtualHW.version = "10"
+msg.autoanswer = "TRUE"
+uuid.action = "create"
+numvcpus = "{{.CPU}}"
+hgfs.mapRootShare = "FALSE"
+hgfs.linkRootShare = "FALSE"
+`

--- a/pkg/minikube/registry/drvs/parallels/parallels.go
+++ b/pkg/minikube/registry/drvs/parallels/parallels.go
@@ -22,8 +22,8 @@ import (
 	"fmt"
 	"os/exec"
 
-	parallels "github.com/Parallels/docker-machine-parallels/v2"
 	"github.com/docker/machine/libmachine/drivers"
+	"k8s.io/minikube/pkg/drivers/parallels"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/download"
 	"k8s.io/minikube/pkg/minikube/driver"
@@ -43,7 +43,6 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("unable to register: %v", err))
 	}
-
 }
 
 func configure(cfg config.ClusterConfig, n config.Node) (interface{}, error) {

--- a/pkg/minikube/registry/drvs/vmware/vmware.go
+++ b/pkg/minikube/registry/drvs/vmware/vmware.go
@@ -20,7 +20,8 @@ import (
 	"fmt"
 	"os/exec"
 
-	vmwcfg "github.com/machine-drivers/docker-machine-driver-vmware/pkg/drivers/vmware/config"
+	"github.com/docker/machine/libmachine/drivers"
+	"k8s.io/minikube/pkg/drivers/vmware"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/download"
 	"k8s.io/minikube/pkg/minikube/driver"
@@ -34,6 +35,7 @@ func init() {
 		Config:   configure,
 		Default:  false,
 		Priority: registry.Deprecated,
+		Init:     func() drivers.Driver { return vmware.NewDriver("", "") },
 		Status:   status,
 	})
 	if err != nil {
@@ -42,7 +44,7 @@ func init() {
 }
 
 func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
-	d := vmwcfg.NewConfig(config.MachineName(cc, n), localpath.MiniPath())
+	d := vmware.NewDriver(config.MachineName(cc, n), localpath.MiniPath()).(*vmware.Driver)
 	d.Boot2DockerURL = download.LocalISOResource(cc.MinikubeISO)
 	d.Memory = cc.Memory
 	d.CPU = cc.CPUs
@@ -55,11 +57,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 }
 
 func status() registry.State {
-	_, err := exec.LookPath("docker-machine-driver-vmware")
-	if err != nil {
-		return registry.State{Error: err, Fix: "Install docker-machine-driver-vmware", Doc: "https://minikube.sigs.k8s.io/docs/reference/drivers/vmware/"}
-	}
-	_, err = exec.LookPath("vmrun")
+	_, err := exec.LookPath("vmrun")
 	if err != nil {
 		return registry.State{Error: err, Fix: "Install vmrun", Doc: "https://minikube.sigs.k8s.io/docs/reference/drivers/vmware/"}
 	}


### PR DESCRIPTION
Currently we import code from some external third-party repositories for the machine drivers. This makes it harder to upgrade libmachine.

Bring all the drivers in-tree*, for the refactor. It would be possible to link them separately again afterwards, as done for hyperkit and kvm.

\* some of the drivers still live in libmachine, though

But there are no non-libmachine driver repositories...

----

The alternative would be to just remove these proprietary drivers, as they are going to be hard to test either way.

As far as I know, neither is working very good on the ARM platform  - there are some other open issues about them?

* https://github.com/kubernetes/minikube/issues/11219

* https://github.com/kubernetes/minikube/issues/14661
