### PR TITLE
Skip waiting for kicbase downloads on VM drivers

### DIFF
--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -374,7 +374,9 @@ func Provision(cc *config.ClusterConfig, n *config.Node, apiServer bool, delOnFa
 	}
 
 	handleDownloadOnly(&cacheGroup, &kicGroup, n.KubernetesVersion, cc.KubernetesConfig.ContainerRuntime, cc.Driver)
-	waitDownloadKicBaseImage(&kicGroup)
+	if driver.IsKIC(cc.Driver) {
+		waitDownloadKicBaseImage(&kicGroup)
+	}
 
 	return startMachine(cc, n, delOnFail)
 }


### PR DESCRIPTION
When using a VM driver, the output logs contains `Successfully downloaded all kic artifacts`, which is misleading since there should be no kicbase artifacts downloaded.

Only call `waitDownloadKicBaseImage` if using a kicbase driver