### PR TITLE
fix legacy in test missing container

### DIFF
--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -307,7 +307,7 @@ func TestMissingContainerUpgrade(t *testing.T) {
 
 	defer CleanupWithLogs(t, profile, cancel)
 
-	legacyVersion := "v1.9.1"
+	legacyVersion := legacyVersion()
 
 	tf, err := installRelease(legacyVersion)
 	if err != nil {


### PR DESCRIPTION
arm64 did not exist in 1.9.1 and we should have used legacyversion per environment