### PR TITLE
add support for adding and removing nodes to Minikube clusters started with --no-kubernetes

### DIFF
--- a/cmd/minikube/cmd/node_delete.go
+++ b/cmd/minikube/cmd/node_delete.go
@@ -42,7 +42,7 @@ var nodeDeleteCmd = &cobra.Command{
 		}
 		name := args[0]
 
-		co := mustload.Healthy(ClusterFlagValue())
+		co := mustload.HealthyOrNoKubernetes(ClusterFlagValue())
 		out.Step(style.DeletingHost, "Deleting node {{.name}} from cluster {{.cluster}}", out.V{"name": name, "cluster": co.Config.Name})
 
 		n, err := node.Delete(*co.Config, name)

--- a/pkg/minikube/mustload/mustload.go
+++ b/pkg/minikube/mustload/mustload.go
@@ -139,6 +139,23 @@ func Running(name string) ClusterController {
 	}
 }
 
+// HealthyOrNoKubernetes is a cmd-friendly way to load a healthy cluster
+// also allowing clusters without Kubernetes.
+func HealthyOrNoKubernetes(name string) ClusterController {
+	api, cc := Partial(name)
+
+	// if we're in a cluster that has Kubernetes deployed, expect it to be healthy.
+	if cc.KubernetesConfig.KubernetesVersion != constants.NoKubernetesVersion {
+		return Healthy(name)
+	}
+
+	// otherwise just add a node without Kubernetes.
+	return ClusterController{
+		API:    api,
+		Config: cc,
+	}
+}
+
 // Healthy is a cmd-friendly way to load a healthy cluster
 func Healthy(name string) ClusterController {
 	co := Running(name)

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -311,8 +311,13 @@ func joinCluster(starter Starter, cpBs bootstrapper.Bootstrapper, bs bootstrappe
 	// avoid "error execution phase kubelet-start: a Node with name "<name>" and status "Ready" already exists in the cluster.
 	// You must delete the existing Node or change the name of this new joining Node"
 	if starter.PreExists {
+		n, _, err := Retrieve(*starter.Cfg, starter.Node.Name)
+		if err != nil {
+			return err
+		}
+
 		klog.Infof("removing existing worker node %q before attempting to rejoin cluster: %+v", starter.Node.Name, starter.Node)
-		if _, err := drainNode(*starter.Cfg, starter.Node.Name); err != nil {
+		if err := drainNode(n, *starter.Cfg); err != nil {
 			klog.Errorf("error removing existing worker node before rejoining cluster, will continue anyway: %v", err)
 		}
 		klog.Infof("successfully removed existing worker node %q from cluster: %+v", starter.Node.Name, starter.Node)


### PR DESCRIPTION
Currently, `minikube node add` and `minikube node delete` fail for clusters started with `--no-kubernetes`, this PR fixes  that.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
