### PR TITLE
gvisor addon: Only allow on clusters that support running amd64 images

### DIFF
--- a/pkg/addons/config.go
+++ b/pkg/addons/config.go
@@ -71,7 +71,7 @@ var Addons = []*Addon{
 	{
 		name:        "gvisor",
 		set:         SetBool,
-		validations: []setFn{IsRuntimeContainerd},
+		validations: []setFn{SupportsAmd64, IsRuntimeContainerd},
 		callbacks:   []setFn{EnableOrDisableAddon, verifyAddonStatus},
 	},
 	{

--- a/pkg/addons/validations.go
+++ b/pkg/addons/validations.go
@@ -18,12 +18,14 @@ package addons
 
 import (
 	"fmt"
+	"runtime"
 	"strconv"
 
 	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/cruntime"
+	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/out"
 )
 
@@ -92,4 +94,16 @@ func contains(slice []string, val string) bool {
 		}
 	}
 	return false
+}
+
+// SupportsAmd64 ensures that the cluster supports running amd64 images
+func SupportsAmd64(cc *config.ClusterConfig, name, _ string) error {
+	// KIC can run amd64 images on a non-amd64 environment
+	if driver.IsKIC(cc.Driver) {
+		return nil
+	}
+	if runtime.GOARCH == "amd64" {
+		return nil
+	}
+	return fmt.Errorf("the %q addon requires a cluster that supports running amd64 images", name)
 }


### PR DESCRIPTION
Added a validation function that checks if cluster can support running amd64 images and added it to the gvisor addons validations.