### PR TITLE
CI: Fix cri-dockerd adding existing hash

### DIFF
--- a/hack/update/cri_dockerd_version/update_cri_dockerd_version.go
+++ b/hack/update/cri_dockerd_version/update_cri_dockerd_version.go
@@ -122,6 +122,14 @@ func updateHashFiles(commit string) error {
 }
 
 func updateHashFile(filePath, commit string, shaSum [sha256.Size]byte) error {
+	b, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to read hash file: %v", err)
+	}
+	if strings.Contains(string(b), commit) {
+		klog.Infof("hash file already contains %q", commit)
+		return nil
+	}
 	f, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to open hash file: %v", err)


### PR DESCRIPTION
Weren't checking if hash already existing in hash file before adding it, resulting in duplicates. Now checks for it before adding and if it already exists skips adding it.