### PR TITLE
QEMU: Unblock bootpd if start fails to due to blocking

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -47,6 +47,7 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 	"k8s.io/minikube/pkg/minikube/command"
+	"k8s.io/minikube/pkg/minikube/firewall"
 	netutil "k8s.io/minikube/pkg/network"
 
 	"k8s.io/klog/v2"
@@ -339,7 +340,11 @@ func provisionWithDriver(cmd *cobra.Command, ds registry.DriverState, existing *
 		return node.Starter{}, errors.Wrap(err, "Failed to generate config")
 	}
 
-	unblockBootpdFirewall(cc)
+	if firewall.IsBootpdBlocked(cc) {
+		if err := firewall.UnblockBootpd(); err != nil {
+			klog.Warningf("failed unblocking bootpd from firewall: %v", err)
+		}
+	}
 
 	if driver.IsVM(cc.Driver) && runtime.GOARCH == "arm64" && cc.KubernetesConfig.ContainerRuntime == "crio" {
 		exit.Message(reason.Unimplemented, "arm64 VM drivers do not currently support the crio container runtime. See https://github.com/kubernetes/minikube/issues/14146 for details.")
@@ -414,64 +419,6 @@ func vmwareUnsupported(driverName string) {
 
     We are accepting community contributions to fix this, for more details on the issue see: https://github.com/kubernetes/minikube/issues/16221
 `)
-}
-
-// isBootpdBlocked returns true if the built-in macOS firewall is on and bootpd is not unblocked
-func isBootpdBlocked(cc config.ClusterConfig) bool {
-	// only applies to qemu, on macOS, with socket_vmnet
-	if cc.Driver != driver.QEMU2 || runtime.GOOS != "darwin" || cc.Network != "socket_vmnet" {
-		return false
-	}
-	out, err := exec.Command("/usr/libexec/ApplicationFirewall/socketfilterfw", "--getglobalstate").Output()
-	if err != nil {
-		klog.Warningf("failed to get firewall state: %v", err)
-		return false
-	}
-	if regexp.MustCompile(`Firewall is disabled`).Match(out) {
-		return false
-	}
-	out, err = exec.Command("/usr/libexec/ApplicationFirewall/socketfilterfw", "--listapps").Output()
-	if err != nil {
-		klog.Warningf("failed to list firewall apps: %v", err)
-		return false
-	}
-	return !regexp.MustCompile(`\/usr\/libexec\/bootpd.*\n.*\( Allow`).Match(out)
-}
-
-// unblockBootpdFirewall adds bootpd to the built-in macOS firewall and then unblocks it
-func unblockBootpdFirewall(cc config.ClusterConfig) {
-	if !isBootpdBlocked(cc) {
-		return
-	}
-
-	cmds := []*exec.Cmd{
-		exec.Command("sudo", "/usr/libexec/ApplicationFirewall/socketfilterfw", "--add", "/usr/libexec/bootpd"),
-		exec.Command("sudo", "/usr/libexec/ApplicationFirewall/socketfilterfw", "--unblock", "/usr/libexec/bootpd"),
-	}
-
-	var cmdString strings.Builder
-	for _, c := range cmds {
-		cmdString.WriteString(fmt.Sprintf("    $ %s \n", strings.Join(c.Args, " ")))
-	}
-
-	out.Styled(style.Permissions, "Your firewall is blocking bootpd which is required for socket_vmnet. The following commands will be executed to unblock bootpd:\n\n{{.commands}}\n", out.V{"commands": cmdString.String()})
-
-	for _, c := range cmds {
-		testArgs := append([]string{"-n"}, c.Args[1:]...)
-		test := exec.Command("sudo", testArgs...)
-		klog.Infof("testing: %s", test.Args)
-		if err := test.Run(); err != nil {
-			klog.Infof("%v may require a password: %v", c.Args, err)
-			if !viper.GetBool("interactive") {
-				klog.Warningf("%s requires a password, and --interactive=false", c.Args)
-			}
-		}
-		klog.Infof("running: %s", c.Args)
-		err := c.Run()
-		if err != nil {
-			klog.Warningf("running %s failed: %v", c.Args, err)
-		}
-	}
 }
 
 func validateBuiltImageVersion(r command.Runner, driverName string) {

--- a/pkg/drivers/qemu/qemu.go
+++ b/pkg/drivers/qemu/qemu.go
@@ -44,7 +44,9 @@ import (
 	pkgdrivers "k8s.io/minikube/pkg/drivers"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/firewall"
+	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/reason"
+	"k8s.io/minikube/pkg/minikube/style"
 	"k8s.io/minikube/pkg/network"
 )
 
@@ -528,7 +530,8 @@ func (d *Driver) Start() error {
 			klog.Errorf("failed unblocking bootpd from firewall: %v", unblockErr)
 			exit.Error(reason.IfBootpdFirewall, "ip not found", err)
 		}
-		return fmt.Errorf("bootpd process is unblocked, will retry")
+		out.Styled(style.Restarting, "Sucessfully unblocked bootpd process from firewall, retrying")
+		return fmt.Errorf("ip not found: %v", err)
 	}
 
 	log.Infof("Waiting for VM to start (ssh -p %d docker@%s)...", d.SSHPort, d.IPAddress)

--- a/pkg/drivers/qemu/qemu.go
+++ b/pkg/drivers/qemu/qemu.go
@@ -530,7 +530,7 @@ func (d *Driver) Start() error {
 			klog.Errorf("failed unblocking bootpd from firewall: %v", unblockErr)
 			exit.Error(reason.IfBootpdFirewall, "ip not found", err)
 		}
-		out.Styled(style.Restarting, "Sucessfully unblocked bootpd process from firewall, retrying")
+		out.Styled(style.Restarting, "Successfully unblocked bootpd process from firewall, retrying")
 		return fmt.Errorf("ip not found: %v", err)
 	}
 

--- a/pkg/minikube/firewall/firewall.go
+++ b/pkg/minikube/firewall/firewall.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2023 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package firewall
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/viper"
+	"k8s.io/klog/v2"
+	"k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/driver"
+	"k8s.io/minikube/pkg/minikube/out"
+	"k8s.io/minikube/pkg/minikube/style"
+)
+
+// IsBootpdBlocked checks if the bootpd process is blocked by the macOS builtin firewall
+func IsBootpdBlocked(cc config.ClusterConfig) bool {
+	// only applies to qemu, on macOS, with socket_vmnet
+	if cc.Driver != driver.QEMU2 || runtime.GOOS != "darwin" || cc.Network != "socket_vmnet" {
+		return false
+	}
+	out, err := exec.Command("/usr/libexec/ApplicationFirewall/socketfilterfw", "--getglobalstate").Output()
+	if err != nil {
+		klog.Warningf("failed to get firewall state: %v", err)
+		return false
+	}
+	if regexp.MustCompile(`Firewall is disabled`).Match(out) {
+		return false
+	}
+	out, err = exec.Command("/usr/libexec/ApplicationFirewall/socketfilterfw", "--listapps").Output()
+	if err != nil {
+		klog.Warningf("failed to list firewall apps: %v", err)
+		return false
+	}
+	return !regexp.MustCompile(`\/usr\/libexec\/bootpd.*\n.*\( Allow`).Match(out)
+}
+
+// UnblockBootpd adds bootpd to the built-in macOS firewall and then unblocks it
+func UnblockBootpd() error {
+	cmds := []*exec.Cmd{
+		exec.Command("sudo", "/usr/libexec/ApplicationFirewall/socketfilterfw", "--add", "/usr/libexec/bootpd"),
+		exec.Command("sudo", "/usr/libexec/ApplicationFirewall/socketfilterfw", "--unblock", "/usr/libexec/bootpd"),
+	}
+
+	var cmdString strings.Builder
+	for _, c := range cmds {
+		cmdString.WriteString(fmt.Sprintf("    $ %s \n", strings.Join(c.Args, " ")))
+	}
+
+	out.Styled(style.Permissions, "Your firewall is blocking bootpd which is required for socket_vmnet. The following commands will be executed to unblock bootpd:\n\n{{.commands}}\n", out.V{"commands": cmdString.String()})
+
+	for _, c := range cmds {
+		testArgs := append([]string{"-n"}, c.Args[1:]...)
+		test := exec.Command("sudo", testArgs...)
+		klog.Infof("testing: %s", test.Args)
+		if err := test.Run(); err != nil {
+			klog.Infof("%v may require a password: %v", c.Args, err)
+			if !viper.GetBool("interactive") {
+				klog.Warningf("%s requires a password, and --interactive=false", c.Args)
+			}
+		}
+		klog.Infof("running: %s", c.Args)
+		err := c.Run()
+		if err != nil {
+			return fmt.Errorf("running %s failed: %v", c.Args, err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Closes https://github.com/kubernetes/minikube/issues/16776

Even if you have bootpd unblocked in the builtin macOS firewall, you can run into the situation where it's still being blocked. To resolve it you have to run the unblock command again.

This PR checks the output of a start failure on QEMU, and if it's due to bootpd being blocked runs the unblock command and retries the start again.

**Before:**
```
$ minikube start --driver qemu
😄  minikube v1.30.1 on Darwin 13.4.1 (arm64)
✨  Using the qemu2 driver based on user configuration
🌐  Automatically selected the socket_vmnet network
👍  Starting control plane node minikube in cluster minikube
🔥  Creating qemu2 VM (CPUs=2, Memory=4000MB, Disk=20000MB) ...

❌  Exiting due to IF_BOOTPD_FIREWALL: ip not found: failed to get IP address: could not find an IP address for fe:70:96:84:47:94
💡  Suggestion: 

    Your firewall is likely blocking bootpd, to unblock it run:
    sudo /usr/libexec/ApplicationFirewall/socketfilterfw --add /usr/libexec/bootpd
    sudo /usr/libexec/ApplicationFirewall/socketfilterfw --unblock /usr/libexec/bootpd

╭───────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                           │
│    😿  If the above advice does not help, please let us know:                             │
│    👉  https://github.com/kubernetes/minikube/issues/new/choose                           │
│                                                                                           │
│    Please run `minikube logs --file=logs.txt` and attach logs.txt to the GitHub issue.    │
│                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────╯
```

**After:**
```
minikube start --driver qemu
😄  minikube v1.30.1 on Darwin 13.4.1 (arm64)
✨  Using the qemu2 driver based on user configuration
🌐  Automatically selected the socket_vmnet network
👍  Starting control plane node minikube in cluster minikube
🔥  Creating qemu2 VM (CPUs=2, Memory=4000MB, Disk=20000MB) ...
🔑  Your firewall is blocking bootpd which is required for socket_vmnet. The following commands will be executed to unblock bootpd:

    $ sudo /usr/libexec/ApplicationFirewall/socketfilterfw --add /usr/libexec/bootpd 
    $ sudo /usr/libexec/ApplicationFirewall/socketfilterfw --unblock /usr/libexec/bootpd 


Password: 
🔄  Sucessfully unblocked bootpd process from firewall, retrying
🔥  Deleting "minikube" in qemu2 ...
🤦  StartHost failed, but will try again: creating host: create: creating: ip not found: failed to get IP address: could not find an IP address for 52:cd:17:52:c9:4d
🔥  Creating qemu2 VM (CPUs=2, Memory=4000MB, Disk=20000MB) ...
🐳  Preparing Kubernetes v1.27.3 on Docker 24.0.2 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🔎  Verifying Kubernetes components...
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```