### PR TITLE
CI: Exclude vedantmgoyal2009/winget-releaser from dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,6 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-        interval: "weekly"
+      interval: "weekly"
+    ignore:
+      - dependency-name: "vedantmgoyal2009/winget-releaser"


### PR DESCRIPTION
`vedantmgoyal2009/winget-releaser` has the commit under the tag constantly being rewritten after every commit.
Release: February 12
Release commit: July 4

This results in constant dependabot PRs to update the commit. 

https://github.com/kubernetes/minikube/pull/16812
https://github.com/kubernetes/minikube/pull/16818
https://github.com/kubernetes/minikube/pull/16829

So excluding it and from dependabot to reduce noise