### PR TITLE
fix subcommand cannot be translated

### DIFF
--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -140,7 +140,7 @@ func Execute() {
 		}
 	}
 
-	visitAllCommand(RootCmd, func(c *cobra.Command) {
+	applyToAllCommands(RootCmd, func(c *cobra.Command) {
 		c.Short = translate.T(c.Short)
 		c.Long = translate.T(c.Long)
 		c.Flags().VisitAll(func(f *pflag.Flag) {

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -347,7 +347,7 @@ func applyToAllCommands(cmd *cobra.Command, f func(subCmd *cobra.Command)) {
 	for _, c := range cmd.Commands() {
 		f(c)
 		if c.HasSubCommands() {
-			visitAllCommand(c, f)
+			applyToAllCommands(c, f)
 		}
 	}
 }

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -140,7 +140,7 @@ func Execute() {
 		}
 	}
 
-	for _, c := range RootCmd.Commands() {
+	visitAllCommand(RootCmd, func(c *cobra.Command) {
 		c.Short = translate.T(c.Short)
 		c.Long = translate.T(c.Long)
 		c.Flags().VisitAll(func(f *pflag.Flag) {
@@ -148,7 +148,8 @@ func Execute() {
 		})
 
 		c.SetUsageTemplate(usageTemplate())
-	}
+	})
+
 	RootCmd.Short = translate.T(RootCmd.Short)
 	RootCmd.Long = translate.T(RootCmd.Long)
 	RootCmd.Flags().VisitAll(func(f *pflag.Flag) {
@@ -339,4 +340,14 @@ func addToPath(dir string) {
 
 func validateUsername(name string) bool {
 	return len(name) <= 60
+}
+
+// visitAllCommand visit all command include subCommand
+func visitAllCommand(cmd *cobra.Command, f func(subCmd *cobra.Command)) {
+	for _, c := range cmd.Commands() {
+		f(c)
+		if c.HasSubCommands() {
+			visitAllCommand(c, f)
+		}
+	}
 }

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -342,8 +342,8 @@ func validateUsername(name string) bool {
 	return len(name) <= 60
 }
 
-// visitAllCommand visit all command include subCommand
-func visitAllCommand(cmd *cobra.Command, f func(subCmd *cobra.Command)) {
+// applyToAllCommands applies the provided func to all commands including sub commands
+func applyToAllCommands(cmd *cobra.Command, f func(subCmd *cobra.Command)) {
 	for _, c := range cmd.Commands() {
 		f(c)
 		if c.HasSubCommands() {


### PR DESCRIPTION
Close https://github.com/kubernetes/minikube/issues/16851

**Before:**
```
$ LANG=zh-CN minikube image build -h
Build a container image, using the container runtime.

Examples:
minikube image build .

Options:
    --all=false:
        Build image on all nodes.

    --build-env=[]:
        Environment variables to pass to the build. (format: key=value)

    --build-opt=[]:
        Specify arbitrary flags to pass to the build. (format: key=value)

    -f, --file='':
        Path to the Dockerfile to use (optional)

    -n, --node='':
        The node to build on. Defaults to the primary control plane.

    --push=false:
        Push the new image (requires tag)

    -t, --tag='':
        Tag to apply to the new image (optional)

Usage:
  minikube image build PATH | URL | - [flags] [options]

Use "minikube options" for a list of global command-line options (applies to all commands).
```

**After:**
```
$ LANG=zh-CN minikube image build -h
使用容器运行时构建容器映像。

Examples:
minikube image build .

Options:
    --all=false:
        在所有节点上构建映像。

    --build-env=[]:
        Environment variables to pass to the build. (format: key=value)

    --build-opt=[]:
        Specify arbitrary flags to pass to the build. (format: key=value)

    -f, --file='':
        Path to the Dockerfile to use (optional)

    -n, --node='':
        要构建的节点，默认为主控制平面

    --push=false:
        Push the new image (requires tag)

    -t, --tag='':
        Tag to apply to the new image (optional)

Usage:
  minikube image build PATH | URL | - [flags] [options]

Use "minikube options" for a list of global command-line options (applies to all commands).
```