### PR TITLE
Use the stable path for brew installed qemu firmware in machine config

### DIFF
--- a/pkg/minikube/registry/drvs/qemu2/qemu2.go
+++ b/pkg/minikube/registry/drvs/qemu2/qemu2.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -80,26 +79,13 @@ func qemuFirmwarePath(customPath string) (string, error) {
 	arch := runtime.GOARCH
 	// For macOS, find the correct brew installation path for qemu firmware
 	if runtime.GOOS == "darwin" {
-		var p, fw string
 		switch arch {
 		case "amd64":
-			p = "/usr/local/Cellar/qemu"
-			fw = "share/qemu/edk2-x86_64-code.fd"
+			return "/usr/local/opt/qemu/share/qemu/edk2-x86_64-code.fd", nil
 		case "arm64":
-			p = "/opt/homebrew/Cellar/qemu"
-			fw = "share/qemu/edk2-aarch64-code.fd"
+			return "/opt/homebrew/opt/qemu/share/qemu/edk2-aarch64-code.fd", nil
 		default:
 			return "", fmt.Errorf("unknown arch: %s", arch)
-		}
-
-		v, err := os.ReadDir(p)
-		if err != nil {
-			return "", fmt.Errorf("lookup qemu: %v", err)
-		}
-		for _, version := range v {
-			if version.IsDir() {
-				return path.Join(p, version.Name(), fw), nil
-			}
 		}
 	}
 


### PR DESCRIPTION
Previously, machine config had hard coded the homebrew cellar path with the patch version of qemu available at the time of machine creation, and was prone to breaking anytime qemu was updated and the machine is restarted. 

For example
```
❯ minikube start
😄  minikube v1.30.1 on Darwin 13.4.1 (arm64)
✨  Using the qemu2 driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
🔄  Restarting existing qemu2 VM for "minikube" ...
OUTPUT:
ERROR: qemu-system-aarch64: -drive file=/opt/homebrew/Cellar/qemu/8.0.0/share/qemu/edk2-aarch64-code.fd,readonly=on,format=raw,if=pflash: Could not open '/opt/homebrew/Cellar/qemu/8.0.0/share/qemu/edk2-aarch64-code.fd': No such file or directory
```

This change replaces the firmware path on machine creation to use the prefix as reported by `brew --prefix qemu` (e.g. `/opt/homebrew/opt/qemu` on M1) which is a symlink the the latest installed version of qemu (e.g. `/opt/homebrew/Cellar/qemu/<x.y.z>`).

This will not attempt to repair the path of machine with existing config. Two workarounds are to either 
* edit the config file manually, for example
  ```
  /usr/bin/sed -E -i ".$(date +'%F@%T')~" 's,/Cellar/qemu/[^/]+,/opt/qemu,' \
    "$HOME/.minikube/machines/$(minikube profile)/config.json"
  ```
* or delete the machine with `minikube delete` and recreate machine.



<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
