### PR TITLE
CI: Add id to create PR step

### DIFF
--- a/.github/workflows/update-cri-dockerd-version.yml
+++ b/.github/workflows/update-cri-dockerd-version.yml
@@ -30,6 +30,7 @@ jobs:
           echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
       - name: Create PR
+        id: createPR
         if: ${{ steps.bumpCriDockerd.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38
         with:


### PR DESCRIPTION
The step after to comment `ok-to-build-iso` uses the ID of `createPR`, but the ID. wasn't set