### PR TITLE
feat: allow delete-on-faliure in setupKubeAdm

### DIFF
--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -271,7 +271,10 @@ func handleAPIServer(starter Starter, cr cruntime.Manager, hostIP net.IP) (*kube
 	}
 
 	// Setup kubeadm (must come after setupKubeconfig).
-	bs := setupKubeAdm(starter.MachineAPI, *starter.Cfg, *starter.Node, starter.Runner)
+	bs, err := setupKubeAdm(starter.MachineAPI, *starter.Cfg, *starter.Node, starter.Runner)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "Failed to setup kubeadm")
+	}
 	err = bs.StartCluster(*starter.Cfg)
 	if err != nil {
 		ExitIfFatal(err, false)
@@ -554,10 +557,15 @@ func waitForCRIVersion(runner cruntime.CommandRunner, socket string, wait int, i
 }
 
 // setupKubeAdm adds any requested files into the VM before Kubernetes is started
-func setupKubeAdm(mAPI libmachine.API, cfg config.ClusterConfig, n config.Node, r command.Runner) bootstrapper.Bootstrapper {
+func setupKubeAdm(mAPI libmachine.API, cfg config.ClusterConfig, n config.Node, r command.Runner) (bootstrapper.Bootstrapper, error) {
+	deleteOnFailure := viper.GetBool("delete-on-failure")
 	bs, err := cluster.Bootstrapper(mAPI, viper.GetString(cmdcfg.Bootstrapper), cfg, r)
 	if err != nil {
-		exit.Error(reason.InternalBootstrapper, "Failed to get bootstrapper", err)
+		klog.Errorf("Failed to get bootstrapper: %v", err)
+		if !deleteOnFailure {
+			exit.Error(reason.InternalBootstrapper, "Failed to get bootstrapper", err)
+		}
+		return nil, err
 	}
 	for _, eo := range cfg.KubernetesConfig.ExtraOptions {
 		out.Infof("{{.extra_option_component_name}}.{{.key}}={{.value}}", out.V{"extra_option_component_name": eo.Component, "key": eo.Key, "value": eo.Value})
@@ -566,17 +574,25 @@ func setupKubeAdm(mAPI libmachine.API, cfg config.ClusterConfig, n config.Node, 
 	// update cluster and set up certs
 
 	if err := bs.UpdateCluster(cfg); err != nil {
-		if errors.Is(err, cruntime.ErrContainerRuntimeNotRunning) {
-			exit.Error(reason.KubernetesInstallFailedRuntimeNotRunning, "Failed to update cluster", err)
+		if !deleteOnFailure {
+			if errors.Is(err, cruntime.ErrContainerRuntimeNotRunning) {
+				exit.Error(reason.KubernetesInstallFailedRuntimeNotRunning, "Failed to update cluster", err)
+			}
+			exit.Error(reason.KubernetesInstallFailed, "Failed to update cluster", err)
 		}
-		exit.Error(reason.KubernetesInstallFailed, "Failed to update cluster", err)
+		klog.Errorf("Failed to update cluster: %v", err)
+		return nil, err
 	}
 
 	if err := bs.SetupCerts(cfg, n); err != nil {
-		exit.Error(reason.GuestCert, "Failed to setup certs", err)
+		if !deleteOnFailure {
+			exit.Error(reason.GuestCert, "Failed to setup certs", err)
+		}
+		klog.Errorf("Failed to setup certs: %v", err)
+		return nil, err
 	}
 
-	return bs
+	return bs, nil
 }
 
 func setupKubeconfig(h *host.Host, cc *config.ClusterConfig, n *config.Node, clusterName string) *kubeconfig.Settings {


### PR DESCRIPTION
feat: allow delete-on-faliure in setupKubeAdm
fix #16682 

If we generate an error in setupKubeAdm deliberately, then:

Before:
```
tjm@tjm:~/workspace/minikube/out$ ./minikube start  --delete-on-failure
😄  minikube v1.30.1 on Ubuntu 22.04 (amd64)
✨  Automatically selected the docker driver
📌  Using Docker driver with root privileges
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
💾  Downloading Kubernetes v1.27.3 preload ...
    > preloaded-images-k8s-v18-v1...:  393.19 MiB / 393.19 MiB  100.00% 12.13 M
    > index.docker.io/kicbase/bui...:  430.77 MiB / 430.77 MiB  100.00% 8.91 Mi
❗  minikube was unable to download gcr.io/k8s-minikube/kicbase-builds:v0.0.39-1687538068-16731, but successfully downloaded docker.io/kicbase/build:v0.0.39-1687538068-16731 as a fallback image
🔥  Creating docker container (CPUs=2, Memory=2200MB) ...
🐳  Preparing Kubernetes v1.27.3 on Docker 24.0.2 ...

❌  Exiting due to K8S_INSTALL_FAILED: Failed to update cluster: This error is expected

╭───────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                           │
│    😿  If the above advice does not help, please let us know:                             │
│    👉  https://github.com/kubernetes/minikube/issues/new/choose                           │
│                                                                                           │
│    Please run `minikube logs --file=logs.txt` and attach logs.txt to the GitHub issue.    │
│                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────╯
```
When this error happens, minikube exits at once.


After: 
```
tjm@tjm:~/workspace/minikube/out$ ./minikube start --delete-on-failure
😄  minikube v1.30.1 on Ubuntu 22.04 (amd64)
✨  Using the docker driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🏃  Updating the running docker "minikube" container ...
🐳  Preparing Kubernetes v1.27.3 on Docker 24.0.2 .../ E0715 19:19:41.660942   29807 start.go:583] Failed to update cluster: This error is expected

❗  Node  failed to start, deleting and trying again.
🔥  Deleting "minikube" in docker ...
🔥  Deleting container "minikube" ...
🔥  Removing /home/tjm/.minikube/machines/minikube ...
💀  Removed all traces of the "minikube" cluster.
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=2200MB) ...- ^C
```
When this error happens, it trys to delete the cluster and retry



<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->


