### PR TITLE
cni: Fix regression in auto selection

### DIFF
--- a/pkg/minikube/cni/cni_test.go
+++ b/pkg/minikube/cni/cni_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cni
+
+import (
+	"testing"
+
+	"k8s.io/minikube/pkg/minikube/config"
+)
+
+func TestChooseDefault(t *testing.T) {
+	tests := []struct {
+		driver           string
+		containerRuntime string
+		version          string
+		want             string
+	}{
+		{"docker", "docker", "v1.23.0", "Disabled"},
+		{"docker", "docker", "v1.27.0", "bridge CNI"},
+		{"docker", "containerd", "v1.23.0", "CNI"},
+		{"docker", "containerd", "v1.27.0", "CNI"},
+		{"qemu", "docker", "v1.23.0", "Disabled"},
+		{"qemu", "docker", "v1.27.0", "bridge CNI"},
+		{"qemu", "containerd", "v1.23.0", "bridge CNI"},
+		{"qemu", "containerd", "v1.27.0", "bridge CNI"},
+	}
+	for _, tc := range tests {
+		cc := config.ClusterConfig{
+			Driver: tc.driver,
+			KubernetesConfig: config.KubernetesConfig{
+				ContainerRuntime:  tc.containerRuntime,
+				KubernetesVersion: tc.version,
+			},
+		}
+		got := chooseDefault(cc).String()
+		if got != tc.want {
+			t.Errorf("chooseDefault(%+v) = %s; want = %s", cc, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/16911

**Before:**
```
$ minikube start --driver docker --container-runtime=docker --version=v1.26.6
...
I0718 14:49:13.457621   40145 cni.go:149] "docker" driver + "docker" runtime found, recommending kindnet
...
```

**After:**
```
$ minikube start --driver docker --container-runtime=docker --version=v1.26.6
...
I0718 14:55:13.614039   41957 cni.go:158] "docker" driver + "docker" container runtime found on kubernetes v1.24+, recommending bridge
...
```