### PR TITLE
Update kubectl.md Windows cmd alias

### DIFF
--- a/site/content/en/docs/handbook/kubectl.md
+++ b/site/content/en/docs/handbook/kubectl.md
@@ -60,7 +60,7 @@ function kubectl { minikube kubectl -- $args }
 Command Prompt.
 
 ```shell
-doskey kubectl=minikube kubectl $*
+doskey kubectl=minikube kubectl -- $*
 ```
 
 


### PR DESCRIPTION
Add missing double dash for the cmd alias.