### PR TITLE
Get image version from kubeadm

### DIFF
--- a/pkg/minikube/bootstrapper/images/images.go
+++ b/pkg/minikube/bootstrapper/images/images.go
@@ -76,6 +76,7 @@ func tagFromKubeadm(v, name, lastKnownGood string) string {
 		klog.Warningf("failed to download kubeadm binary: %v", err)
 		return lastKnownGood
 	}
+	// TODO: Once kubeadm graduates the "-experimental-output" flag to non-experimental should use JSON output here
 	b, err := exec.Command(kubeadm, "config", "images", "list").Output()
 	if err != nil {
 		klog.Warningf("failed getting kubeadm image list: %v", err)

--- a/pkg/minikube/bootstrapper/images/images.go
+++ b/pkg/minikube/bootstrapper/images/images.go
@@ -18,24 +18,20 @@ limitations under the License.
 package images
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
+	"os/exec"
 	"path"
+	"runtime"
+	"strings"
 
 	"k8s.io/klog/v2"
 
 	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/download"
 
 	"github.com/blang/semver/v4"
 
 	"k8s.io/minikube/pkg/version"
-)
-
-const (
-	// builds a docker v2 repository API call in the format https://registry.k8s.io/v2/coredns/coredns/tags/list
-	tagURLTemplate = "https://%s/v2/%s/tags/list"
 )
 
 // Pause returns the image name to pull for a given Kubernetes version
@@ -45,7 +41,7 @@ func Pause(v semver.Version, mirror string) string {
 	// https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/constants/constants.go
 	// https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/constants/constants_unix.go
 	imageName := "pause"
-	pv := imageVersion(v, mirror, imageName, "3.6")
+	pv := imageVersion(v, imageName, "3.9")
 
 	return fmt.Sprintf("%s:%s", path.Join(kubernetesRepo(mirror), imageName), pv)
 }
@@ -70,38 +66,35 @@ func componentImage(name string, v semver.Version, mirror string) string {
 	return fmt.Sprintf("%s:v%s", path.Join(kubernetesRepo(mirror), name), v)
 }
 
-// fixes 13136 by getting the latest image version from the registry.k8s.io repository instead of hardcoded
-func findLatestTagFromRepository(url string, lastKnownGood string) string {
-	client := &http.Client{}
-	errorMsg := fmt.Sprintf("Failed to get latest image version for %s, reverting to version %s.", url, lastKnownGood)
-
-	resp, err := client.Get(url)
-
-	if err != nil || resp.StatusCode != http.StatusOK {
-		klog.Warningf("%s Error %v", errorMsg, err)
+func tagFromKubeadm(v, name, lastKnownGood string) string {
+	if runtime.GOOS != "linux" {
+		klog.Warningf("can only get tag from kubeadm on Linux")
 		return lastKnownGood
 	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
+	kubeadm, err := download.Binary("kubeadm", v, "linux", runtime.GOARCH, "")
 	if err != nil {
-		klog.Warningf("%s Error %v", errorMsg, err)
+		klog.Warningf("failed to download kubeadm binary: %v", err)
 		return lastKnownGood
 	}
-
-	type TagsResponse struct {
-		Name string   `json:"name"`
-		Tags []string `json:"tags"`
-	}
-
-	tags := TagsResponse{}
-	err = json.Unmarshal(body, &tags)
-	if err != nil || len(tags.Tags) < 1 {
-		klog.Warningf("%s Error %v", errorMsg, err)
+	b, err := exec.Command(kubeadm, "config", "images", "list").Output()
+	if err != nil {
+		klog.Warningf("failed getting kubeadm image list: %v", err)
 		return lastKnownGood
 	}
-	lastTagNum := len(tags.Tags) - 1
-	return tags.Tags[lastTagNum]
+	lines := strings.Split(string(b), "\n")
+	for _, line := range lines {
+		if !strings.Contains(line, name) {
+			continue
+		}
+		parts := strings.Split(line, ":")
+		if len(parts) != 2 {
+			klog.Warningf("unexpected image format: %s", line)
+			return lastKnownGood
+		}
+		return parts[1]
+	}
+	klog.Warningf("failed to find %q image in kubeadm image list", name)
+	return lastKnownGood
 }
 
 // coreDNS returns the images used for CoreDNS
@@ -114,7 +107,7 @@ func coreDNS(v semver.Version, mirror string) string {
 	if semver.MustParseRange("<1.21.0-alpha.1")(v) {
 		imageName = "coredns"
 	}
-	cv := imageVersion(v, mirror, imageName, "v1.8.6")
+	cv := imageVersion(v, imageName, "v1.10.1")
 
 	if mirror == constants.AliyunMirror {
 		imageName = "coredns"
@@ -129,17 +122,17 @@ func etcd(v semver.Version, mirror string) string {
 	// Should match `DefaultEtcdVersion` in:
 	// https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/constants/constants.go
 	imageName := "etcd"
-	ev := imageVersion(v, mirror, imageName, "3.5.0-0")
+	ev := imageVersion(v, imageName, "3.5.7-0")
 
 	return fmt.Sprintf("%s:%s", path.Join(kubernetesRepo(mirror), imageName), ev)
 }
 
-func imageVersion(v semver.Version, mirror, imageName, defaultVersion string) string {
+func imageVersion(v semver.Version, imageName, defaultVersion string) string {
 	versionString := fmt.Sprintf("v%s", v.String())
 	if ver, ok := constants.KubeadmImages[versionString][imageName]; ok {
 		return ver
 	}
-	return findLatestTagFromRepository(fmt.Sprintf(tagURLTemplate, kubernetesRepo(mirror), imageName), defaultVersion)
+	return tagFromKubeadm(versionString, imageName, defaultVersion)
 }
 
 // auxiliary returns images that are helpful for running minikube

--- a/pkg/minikube/bootstrapper/images/images_test.go
+++ b/pkg/minikube/bootstrapper/images/images_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package images
 
 import (
-	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -88,40 +86,6 @@ registry.k8s.io/coredns/coredns:v1.8.4
 			got := essentials("registry.k8s.io", v)
 			if diff := cmp.Diff(want, got); diff != "" {
 				t.Errorf("images mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestGetLatestTag(t *testing.T) {
-	serverResp := "{tags: [\"1.8.7\"]}"
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, err := w.Write([]byte(serverResp))
-		if err != nil {
-			t.Errorf("failed to write https response")
-		}
-	}))
-	defer server.Close()
-
-	var testCases = []struct {
-		name          string
-		url           string
-		lastKnownGood string
-		wsResponse    string
-		expect        string
-	}{
-		{name: "VersionGetSuccess", url: server.URL, lastKnownGood: "v1.8.6", wsResponse: `{"name": "coredns", "tags": ["v1.8.9"]}`, expect: "v1.8.9"},
-		{name: "VersionGetFail", url: server.URL, lastKnownGood: "v1.8.6", wsResponse: `{"name": "nah", "nope": ["v1.8.9"]}`, expect: "v1.8.6"},
-		{name: "VersionGetFailNone", url: server.URL, lastKnownGood: "v1.8.6", wsResponse: ``, expect: "v1.8.6"},
-		{name: "VersionGetSuccessMultiple", url: server.URL, lastKnownGood: "v1.8.6", wsResponse: `{"name": "coredns", "tags": ["1.8.7","v1.8.9"]}`, expect: "v1.8.9"},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			serverResp = tc.wsResponse
-			resp := findLatestTagFromRepository(tc.url, tc.lastKnownGood)
-			if diff := cmp.Diff(tc.expect, resp); diff != "" {
-				t.Errorf("Incorrect response version (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/16823

For the before and after I removed `v1.27.3` from the kubeadm constants file to replicate a future Kubernetes version not being in the kubeadm image map.
https://github.com/kubernetes/minikube/blob/56e816767a4b199e1983448b86a18a03d8bd19a2/pkg/minikube/constants/constants_kubeadm_images.go#L31-L35
**Before:**
```
$ minikube start --kubernetes-version=v1.27.3 --preload=false
😄  minikube v1.31.1 on Darwin 13.4.1 (arm64)
✨  Automatically selected the docker driver. Other choices: qemu2, ssh
📌  Using Docker Desktop driver with root privileges
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=4000MB) ...
🐳  Preparing Kubernetes v1.27.3 on Docker 24.0.4 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
💢  initialization failed, will try again: wait: /bin/bash -c "sudo env PATH="/var/lib/minikube/binaries/v1.27.3:$PATH" kubeadm init --config /var/tmp/minikube/kubeadm.yaml  --ignore-preflight-errors=DirAvailable--etc-kubernetes-manifests,DirAvailable--var-lib-minikube,DirAvailable--var-lib-minikube-etcd,FileAvailable--etc-kubernetes-manifests-kube-scheduler.yaml,FileAvailable--etc-kubernetes-manifests-kube-apiserver.yaml,FileAvailable--etc-kubernetes-manifests-kube-controller-manager.yaml,FileAvailable--etc-kubernetes-manifests-etcd.yaml,Port-10250,Swap,NumCPU,Mem,SystemVerification,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables": Process exited with status 1
stdout:
[init] Using Kubernetes version: v1.27.3
[preflight] Running pre-flight checks
[preflight] Pulling images required for setting up a Kubernetes cluster
[preflight] This might take a minute or two, depending on the speed of your internet connection
[preflight] You can also perform this action in beforehand using 'kubeadm config images pull'
[certs] Using certificateDir folder "/var/lib/minikube/certs"
[certs] Using existing ca certificate authority
[certs] Using existing apiserver certificate and key on disk
[certs] Generating "apiserver-kubelet-client" certificate and key
[certs] Generating "front-proxy-ca" certificate and key
[certs] Generating "front-proxy-client" certificate and key
[certs] Generating "etcd/ca" certificate and key
[certs] Generating "etcd/server" certificate and key
[certs] etcd/server serving cert is signed for DNS names [localhost minikube] and IPs [192.168.49.2 127.0.0.1 ::1]
[certs] Generating "etcd/peer" certificate and key
[certs] etcd/peer serving cert is signed for DNS names [localhost minikube] and IPs [192.168.49.2 127.0.0.1 ::1]
[certs] Generating "etcd/healthcheck-client" certificate and key
[certs] Generating "apiserver-etcd-client" certificate and key
[certs] Generating "sa" key and public key
[kubeconfig] Using kubeconfig folder "/etc/kubernetes"
[kubeconfig] Writing "admin.conf" kubeconfig file
[kubeconfig] Writing "kubelet.conf" kubeconfig file
[kubeconfig] Writing "controller-manager.conf" kubeconfig file
[kubeconfig] Writing "scheduler.conf" kubeconfig file
[kubelet-start] Writing kubelet environment file with flags to file "/var/lib/kubelet/kubeadm-flags.env"
[kubelet-start] Writing kubelet configuration to file "/var/lib/kubelet/config.yaml"
[kubelet-start] Starting the kubelet
[control-plane] Using manifest folder "/etc/kubernetes/manifests"
[control-plane] Creating static Pod manifest for "kube-apiserver"
[control-plane] Creating static Pod manifest for "kube-controller-manager"
[control-plane] Creating static Pod manifest for "kube-scheduler"
[etcd] Creating static Pod manifest for local etcd in "/etc/kubernetes/manifests"
[wait-control-plane] Waiting for the kubelet to boot up the control plane as static Pods from directory "/etc/kubernetes/manifests". This can take up to 4m0s
[kubelet-check] Initial timeout of 40s passed.

Unfortunately, an error has occurred:
	timed out waiting for the condition

This error is likely caused by:
	- The kubelet is not running
	- The kubelet is unhealthy due to a misconfiguration of the node in some way (required cgroups disabled)

If you are on a systemd-powered system, you can try to troubleshoot the error with the following commands:
	- 'systemctl status kubelet'
	- 'journalctl -xeu kubelet'

Additionally, a control plane component may have crashed or exited when started by the container runtime.
To troubleshoot, list all containers using your preferred container runtimes CLI.
Here is one example how you may list all running Kubernetes containers by using crictl:
	- 'crictl --runtime-endpoint unix:///var/run/cri-dockerd.sock ps -a | grep kube | grep -v pause'
	Once you have found the failing container, you can inspect its logs with:
	- 'crictl --runtime-endpoint unix:///var/run/cri-dockerd.sock logs CONTAINERID'

stderr:
	[WARNING Swap]: swap is enabled; production deployments should disable swap unless testing the NodeSwap feature gate of the kubelet
	[WARNING Service-Kubelet]: kubelet service is not enabled, please run 'systemctl enable kubelet.service'
W0721 14:26:14.437835    1946 checks.go:835] detected that the sandbox image "registry.k8s.io/pause:test2" of the container runtime is inconsistent with that used by kubeadm. It is recommended that using "registry.k8s.io/pause:3.9" as the CRI sandbox image.
error execution phase wait-control-plane: couldn't initialize a Kubernetes cluster
To see the stack trace of this error execute with --v=5 or higher

$ minikube image list
registry.k8s.io/pause:test2
registry.k8s.io/pause:3.9
registry.k8s.io/kube-scheduler:v1.27.3
registry.k8s.io/kube-proxy:v1.27.3
registry.k8s.io/kube-controller-manager:v1.27.3
registry.k8s.io/kube-apiserver:v1.27.3
registry.k8s.io/etcd:v3.3.8-0-gke.1
registry.k8s.io/etcd:3.5.7-0
registry.k8s.io/coredns/coredns:v1.9.4
registry.k8s.io/coredns/coredns:v1.10.1
gcr.io/k8s-minikube/storage-provisioner:v5
```

**After:**
```
$ minikube start --kubernetes-version=v1.27.3 --preload=false
😄  minikube v1.31.1 on Darwin 13.4.1 (arm64)
✨  Automatically selected the docker driver. Other choices: qemu2, ssh
📌  Using Docker Desktop driver with root privileges
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=4000MB) ...
🐳  Preparing Kubernetes v1.27.3 on Docker 24.0.4 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🔎  Verifying Kubernetes components...
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default

$ minikube image list
registry.k8s.io/pause:3.9
registry.k8s.io/kube-scheduler:v1.27.3
registry.k8s.io/kube-proxy:v1.27.3
registry.k8s.io/kube-controller-manager:v1.27.3
registry.k8s.io/kube-apiserver:v1.27.3
registry.k8s.io/etcd:3.5.7-0
registry.k8s.io/coredns/coredns:v1.10.1
gcr.io/k8s-minikube/storage-provisioner:v5
```