### PR TITLE
Add mkdir for `~/.ssh` directory.

### DIFF
--- a/cmd/minikube/cmd/ssh-host.go
+++ b/cmd/minikube/cmd/ssh-host.go
@@ -88,9 +88,16 @@ func appendKnownHelper(nodeName string, appendKnown bool) {
 		if port != 22 {
 			host = fmt.Sprintf("[%s]:%d", addr, port)
 		}
-		knownHosts := filepath.Join(homedir.HomeDir(), ".ssh", "known_hosts")
 
-		fmt.Fprintf(os.Stderr, "Host added: %s (%s)\n", knownHosts, host)
+		sshDir := filepath.Join(homedir.HomeDir(), ".ssh")
+		err = os.MkdirAll(sshDir, os.FileMode(0700)) // drwx------, to match ssh-keygen behavior
+		if err != nil {
+			out.ErrLn("MkdirAll: %v", err)
+			os.Exit(1)
+		}
+
+		knownHosts := filepath.Join(sshDir, "known_hosts")
+
 		if sshutil.KnownHost(host, knownHosts) {
 			return
 		}
@@ -112,6 +119,8 @@ func appendKnownHelper(nodeName string, appendKnown bool) {
 			out.ErrLn("Close: %v", err)
 			os.Exit(1)
 		}
+
+		fmt.Fprintf(os.Stderr, "Host added: %s (%s)\n", knownHosts, host)
 
 		return
 	}


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
## Description

fixes #16933

## What approach did you use?

I looked at how `ssh-keygen` creates the `~/.ssh directory` if it doesn't exist, and tried to match that behavior.
