### PR TITLE
Change the wording of the docker storage warning

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1845,7 +1845,7 @@ func validateDockerStorageDriver(drvName string) {
 	if si.StorageDriver == "overlay2" {
 		return
 	}
-	out.WarningT("{{.Driver}} is currently using the {{.StorageDriver}} storage driver, consider switching to overlay2 for better performance", out.V{"StorageDriver": si.StorageDriver, "Driver": drvName})
+	out.WarningT("{{.Driver}} is currently using the {{.StorageDriver}} storage driver, setting preload=false", out.V{"StorageDriver": si.StorageDriver, "Driver": drvName})
 	viper.Set(preload, false)
 }
 


### PR DESCRIPTION
The preload is currently only available for overlay2, so when using another storage driver it will not be used.

It says nothing about the runtime performance of the finished cluster, especially not when compared with stargz

Closes #16960
