### PR TITLE
Fix version mismatch error

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -432,21 +432,24 @@ func validateBuiltImageVersion(r command.Runner, driverName string) {
 }
 
 func imageMatchesBinaryVersion(imageVersion, binaryVersion string) bool {
+	if binaryVersion == imageVersion {
+		return true
+	}
+
 	// the map below is used to map the binary version to the version the image expects
 	// this is usually done when a patch version is released but a new ISO/Kicbase is not needed
 	// that way a version mismatch warning won't be thrown
 	//
 	// ex.
 	// the v1.31.0 and v1.31.1 minikube binaries both use v1.31.0 ISO & Kicbase
-	// to prevent the v1.31.1 binary from throwing a version mismatch warning we use the map to use change the binary version used in the comparison
+	// to prevent the v1.31.1 binary from throwing a version mismatch warning we use the map to change the binary version used in the comparison
 
 	mappedVersions := map[string]string{
 		"v1.31.1": "v1.31.0",
 	}
-	if v, ok := mappedVersions[binaryVersion]; ok {
-		binaryVersion = v
-	}
-	return binaryVersion == imageVersion
+	binaryVersion, ok := mappedVersions[binaryVersion]
+
+	return ok && binaryVersion == imageVersion
 }
 
 func startWithDriver(cmd *cobra.Command, starter node.Starter, existing *config.ClusterConfig) (*kubeconfig.Settings, error) {


### PR DESCRIPTION
**Background**
 The issue arose from https://github.com/kubernetes/minikube/pull/16915 when I added an image comparison function. The purpose of the function was to prevent the `❗  Image was not built for the current minikube version.` from outputting when there's an expected version mismatch. An example of this is the v1.31.0 and v1.31.1 release. There was a regression with the v1.31.0 release, so we did a v1.31.1 release, but there were no changes between the two releases to the Kicbase or ISO, so to expedite the patch release we reused the v1.31.0 versions of the Kicbase and ISO. However, the Kicbase and ISO are baked with a `version.json` file that contains the version of the minikube binary they expect. Without my function, when a user started minikube with v1.31.1 they'd get a version mismatch message as it will use the v1.31.0 Kicbase or ISO, which is baked to expect the minikube binary to be v1.31.0. My function added the ability to map the expected version if we expected it. In this case we mapped if the binary is v1.31.1 to expect a Kicbase or ISO of v1.31.0 to not output the version mismatch version. 

**Problem**
We started seeing `❗  Image was not built for the current minikube version. To resolve this you can delete and recreate your minikube cluster using the latest images. Expected minikube version: v1.31.1 -> Actual minikube version: v1.31.1` when building Kicbase and ISO images post release. The problem is the v1.31.1 version of minikube was mapped to always expect a v1.31.0 Kicbase and ISO version. However, PRs build the Kicbase and ISO using the current minikube version, so they were marked as v1.31.1 but the binary was expecting v1.31.0, hence why the message was being output.

**Solution**
To resolve this, I added a check to the top of the image comparison function that does the comparison before the mapping, and if it matches it returns true.

**Before**
```
$ minikube start
😄  minikube v1.31.1 on Darwin 13.5 (arm64)
✨  Automatically selected the docker driver. Other choices: qemu2, ssh
📌  Using Docker Desktop driver with root privileges
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=4000MB) ...
❗  Image was not built for the current minikube version. To resolve this you can delete and recreate your minikube cluster using the latest images. Expected minikube version: v1.31.1 -> Actual minikube version: v1.31.1
🐳  Preparing Kubernetes v1.27.3 on Docker 24.0.5 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```

**After**
```
$ minikube start
😄  minikube v1.31.1 on Darwin 13.5 (arm64)
✨  Automatically selected the docker driver. Other choices: qemu2, ssh
📌  Using Docker Desktop driver with root privileges
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=4000MB) ...
🐳  Preparing Kubernetes v1.27.3 on Docker 24.0.5 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```