### PR TITLE
CI: Fix sonobuoy not outputting detailed e2e.log

### DIFF
--- a/hack/conformance_tests.sh
+++ b/hack/conformance_tests.sh
@@ -47,7 +47,7 @@ curl -LO $sonobuoy
 tarball=$(echo $sonobuoy | awk -F "/" '{print $(NF)}')
 tar -xzf $tarball
 
-./sonobuoy run --mode=certified-conformance --wait --alsologtostderr
+./sonobuoy run --plugin-env=e2e.E2E_EXTRA_ARGS="--ginkgo.v" --mode=certified-conformance --wait --alsologtostderr
 outdir="$(mktemp -d)"
 ./sonobuoy retrieve "${outdir}"
 


### PR DESCRIPTION
Running into the same issue as https://github.com/vmware-tanzu/sonobuoy/issues/1907

Using the fix from https://github.com/vmware-tanzu/sonobuoy/issues/1907#issuecomment-1541317208
