### PR TITLE
Fix calling appendKnownHelper when not needed

### DIFF
--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -414,8 +414,10 @@ docker-cli install instructions: https://minikube.sigs.k8s.io/docs/tutorials/doc
 			}
 			cmd := exec.Command(path, d.GetSSHKeyPath())
 			cmd.Stderr = os.Stderr
-			cmd.Env = append(cmd.Env, fmt.Sprintf("SSH_AUTH_SOCK=%s", co.Config.SSHAuthSock))
-			cmd.Env = append(cmd.Env, fmt.Sprintf("SSH_AGENT_PID=%d", co.Config.SSHAgentPID))
+			if cr == constants.Containerd {
+				cmd.Env = append(cmd.Env, fmt.Sprintf("SSH_AUTH_SOCK=%s", co.Config.SSHAuthSock))
+				cmd.Env = append(cmd.Env, fmt.Sprintf("SSH_AGENT_PID=%d", co.Config.SSHAgentPID))
+			}
 			err = cmd.Run()
 			if err != nil {
 				exit.Error(reason.IfSSHClient, "Error with ssh-add", err)

--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -414,6 +414,8 @@ docker-cli install instructions: https://minikube.sigs.k8s.io/docs/tutorials/doc
 			}
 			cmd := exec.Command(path, d.GetSSHKeyPath())
 			cmd.Stderr = os.Stderr
+
+			// TODO: refactor to work with docker, temp fix to resolve regression
 			if cr == constants.Containerd {
 				cmd.Env = append(cmd.Env, fmt.Sprintf("SSH_AUTH_SOCK=%s", co.Config.SSHAuthSock))
 				cmd.Env = append(cmd.Env, fmt.Sprintf("SSH_AGENT_PID=%d", co.Config.SSHAgentPID))
@@ -423,8 +425,11 @@ docker-cli install instructions: https://minikube.sigs.k8s.io/docs/tutorials/doc
 				exit.Error(reason.IfSSHClient, "Error with ssh-add", err)
 			}
 
-			// eventually, run something similar to ssh --append-known
-			appendKnownHelper(nodeName, true)
+			// TODO: refactor to work with docker, temp fix to resolve regression
+			if cr == constants.Containerd {
+				// eventually, run something similar to ssh --append-known
+				appendKnownHelper(nodeName, true)
+			}
 		}
 	},
 }

--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -420,10 +420,10 @@ docker-cli install instructions: https://minikube.sigs.k8s.io/docs/tutorials/doc
 			if err != nil {
 				exit.Error(reason.IfSSHClient, "Error with ssh-add", err)
 			}
-		}
 
-		// eventually, run something similar to ssh --append-known
-		appendKnownHelper(nodeName, true)
+			// eventually, run something similar to ssh --append-known
+			appendKnownHelper(nodeName, true)
+		}
 	},
 }
 


### PR DESCRIPTION
Related https://github.com/kubernetes/minikube/issues/16933 https://github.com/kubernetes/minikube/pull/15452

`appendKnownHelper` was being called when `ssdAdd` was not requested, causing https://github.com/kubernetes/minikube/issues/16933 to affect all docker-env commands, not just containerd usages.

Also fixed adding envs to a command that might be empty

**Before:**
```
$ minikube docker-env
export DOCKER_TLS_VERIFY="1"
export DOCKER_HOST="tcp://192.168.49.2:2376"
export DOCKER_CERT_PATH="/home/test/.minikube/certs"
export MINIKUBE_ACTIVE_DOCKERD="minikube"

# To point your shell to minikube's docker-daemon, run:
# eval $(minikube -p minikube docker-env)
Host added: /home/test/.ssh/known_hosts ([127.0.0.1]:32777)
OpenFile: open /home/test/.ssh/known_hosts: no such file or directory

$ echo $?
1
```

**After:**
```
$ minikube docker-env
export DOCKER_TLS_VERIFY="1"
export DOCKER_HOST="tcp://192.168.49.2:2376"
export DOCKER_CERT_PATH="/home/test/.minikube/certs"
export MINIKUBE_ACTIVE_DOCKERD="minikube"

# To point your shell to minikube's docker-daemon, run:
# eval $(minikube -p minikube docker-env)

$ echo $?
0
```