### PR TITLE
fix cannot enter cgroupv2 "/sys/fs/cgroup/docker" with domain controllers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ GVISOR_TAG ?= latest
 AUTOPAUSE_HOOK_TAG ?= v0.0.4
 
 # prow-test tag to push changes to
-PROW_TEST_TAG ?= v0.0.4
+PROW_TEST_TAG ?= v0.0.5
 
 BUILDX_BUILDER ?= multiarch
 


### PR DESCRIPTION
fixes: #17031

containerd had similar issue: https://github.com/containerd/containerd/issues/6659

proposed solution: https://github.com/containerd/containerd/issues/6659#issuecomment-1064754423

based on `dind`: https://github.com/moby/moby/blob/89b542b421f439b3c703098f7f1c29f661e430bb/hack/dind#L28-L38

test (using locally built prow-test image):
```
FROM prow-test
RUN apt-get update && apt-get install -y curl
RUN curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && \
    install minikube-linux-amd64 /usr/local/bin/minikube
```

```
[prezha@codex nested]$ docker build -t nested-minikube .
[+] Building 6.9s (7/7) FINISHED                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 docker:default
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       0.0s
 => => transferring dockerfile: 252B                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       0.0s
 => [internal] load metadata for docker.io/library/prow-test:latest                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        0.0s
 => [1/3] FROM docker.io/library/prow-test                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 0.1s
 => [2/3] RUN apt-get update && apt-get install -y curl                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    2.7s
 => [3/3] RUN curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 &&     install minikube-linux-amd64 /usr/local/bin/minikube                                                                                                                                                                                                                                                                                                                                                                                            3.3s
 => exporting to image                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     0.6s
 => => exporting layers                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    0.6s
 => => writing image sha256:8df5eb6813cbe1c4df3207713658212918bd430beb0afbdb617473d0d69d4db4                                                                                                                                                                                                                                                                                                                                                                                                                                                               0.0s
 => => naming to docker.io/library/nested-minikube                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         0.0s
[prezha@codex nested]$
[prezha@codex nested]$
[prezha@codex nested]$ docker run -d -t --privileged --name minikube nested-minikube
2b4f011d6756b66e4c45431c14c9f8208df64ed257e04a55d791fee3234c87c8
[prezha@codex nested]$
[prezha@codex nested]$
[prezha@codex nested]$ docker exec minikube /bin/bash -c "minikube start --force && kubectl get pods -A"
* minikube v1.31.1 on Debian 11.7 (docker/amd64)
! minikube skips various validations when --force is supplied; this may lead to unexpected behavior
* Automatically selected the docker driver. Other choices: none, ssh
* The "docker" driver should not be used with root privileges. If you wish to continue as root, use --force.
* If you are running minikube within a VM, consider using --driver=none:
*   https://minikube.sigs.k8s.io/docs/reference/drivers/none/
* Using Docker driver with root privileges
* Starting control plane node minikube in cluster minikube
* Pulling base image ...
* Downloading Kubernetes v1.27.3 preload ...
    > gcr.io/k8s-minikube/kicbase...:  2.08 KiB / 447.62 MiB [>_] 0.00% ? p/s ?    > gcr.io/k8s-minikube/kicbase...:  2.08 KiB / 447.62 MiB [>_] 0.00% ? p/s ?    > gcr.io/k8s-minikube/kicbase...:  49.82 KiB / 447.62 MiB [>] 0.01% ? p/s ?    > gcr.io/k8s-minikube/kicbase...:  209.81 KiB / 447.62 MiB  0.05% 346.32 Ki    > gcr.io/k8s-minikube/kicbase...:  1.13 MiB / 447.62 MiB  0.25% 346.32 KiB     > gcr.io/k8s-minikube/kicbase...:  4.94 MiB / 447.62 MiB  1.10% 346.32 KiB     > gcr.io/k8s-minikube/kicbase...:  10.02 MiB / 447.62 MiB  2.24% 1.37 MiB p    > gcr.io/k8s-minikube/kicbase...:  14.28 MiB / 447.62 MiB  3.19% 1.37 MiB p    > gcr.io/k8s-minikube/kicbase...:  17.81 MiB / 447.62 MiB  3.98% 1.37 MiB p    > gcr.io/k8s-minikube/kicbase...:  21.59 MiB / 447.62 MiB  4.82% 2.53 MiB p    > gcr.io/k8s-minikube/kicbase...:  25.56 MiB / 447.62 MiB  5.71% 2.53 MiB p    > gcr.io/k8s-minikube/kicbase...:  29.94 MiB / 447.62 MiB  6.69% 2.53 MiB p    > gcr.io/k8s-minikube/kicbase...:  35.47 MiB / 447.62 MiB  7.92% 3.85 MiB p    > gcr.io/k8s-minikube/kicbase...:  41.03 MiB / 447.62 MiB  9.17% 3.85 MiB p    > gcr.io/k8s-minikube/kicbase...:  46.13 MiB / 447.62 MiB  10.30% 3.85 MiB     > gcr.io/k8s-minikube/kicbase...:  51.19 MiB / 447.62 MiB  11.44% 5.30 MiB     > gcr.io/k8s-minikube/kicbase...:  56.28 MiB / 447.62 MiB  12.57% 5.30 MiB     > gcr.io/k8s-minikube/kicbase...:  62.03 MiB / 447.62 MiB  13.86% 5.30 MiB     > gcr.io/k8s-minikube/kicbase...:  72.86 MiB / 447.62 MiB  16.28% 7.29 MiB     > gcr.io/k8s-minikube/kicbase...:  81.23 MiB / 447.62 MiB  18.15% 7.29 MiB     > gcr.io/k8s-minikube/kicbase...:  89.87 MiB / 447.62 MiB  20.08% 7.29 MiB     > gcr.io/k8s-minikube/kicbase...:  97.39 MiB / 447.62 MiB  21.76% 9.45 MiB     > gcr.io/k8s-minikube/kicbase...:  104.51 MiB / 447.62 MiB  23.35% 9.45 MiB    > gcr.io/k8s-minikube/kicbase...:  111.57 MiB / 447.62 MiB  24.93% 9.45 MiB    > gcr.io/k8s-minikube/kicbase...:  119.23 MiB / 447.62 MiB  26.64% 11.19 Mi    > gcr.io/k8s-minikube/kicbase...:  126.01 MiB / 447.62 MiB  28.15% 11.19 Mi    > gcr.io/k8s-minikube/kicbase...:  129.35 MiB / 447.62 MiB  28.90% 11.19 Mi    > gcr.io/k8s-minikube/kicbase...:  139.63 MiB / 447.62 MiB  31.20% 12.67 Mi    > gcr.io/k8s-minikube/kicbase...:  147.15 MiB / 447.62 MiB  32.87% 12.67 Mi    > gcr.io/k8s-minikube/kicbase...:  154.74 MiB / 447.62 MiB  34.57% 12.67 Mi    > gcr.io/k8s-minikube/kicbase...:  162.40 MiB / 447.62 MiB  36.28% 14.30 Mi    > gcr.io/k8s-minikube/kicbase...:  170.09 MiB / 447.62 MiB  38.00% 14.30 Mi    > gcr.io/k8s-minikube/kicbase...:  176.74 MiB / 447.62 MiB  39.49% 14.30 Mi    > gcr.io/k8s-minikube/kicbase...:  180.02 MiB / 447.62 MiB  40.22% 15.27 Mi    > gcr.io/k8s-minikube/kicbase...:  184.41 MiB / 447.62 MiB  41.20% 15.27 Mi    > gcr.io/k8s-minikube/kicbase...:  190.52 MiB / 447.62 MiB  42.56% 15.27 Mi    > gcr.io/k8s-minikube/kicbase...:  196.55 MiB / 447.62 MiB  43.91% 16.06 Mi    > gcr.io/k8s-minikube/kicbase...:  202.58 MiB / 447.62 MiB  45.26% 16.06 Mi    > gcr.io/k8s-minikube/kicbase...:  208.62 MiB / 447.62 MiB  46.61% 16.06 Mi    > gcr.io/k8s-minikube/kicbase...:  215.21 MiB / 447.62 MiB  48.08% 17.03 Mi    > gcr.io/k8s-minikube/kicbase...:  222.43 MiB / 447.62 MiB  49.69% 17.03 Mi    > gcr.io/k8s-minikube/kicbase...:  229.05 MiB / 447.62 MiB  51.17% 17.03 Mi    > gcr.io/k8s-minikube/kicbase...:  235.71 MiB / 447.62 MiB  52.66% 18.14 Mi    > gcr.io/k8s-minikube/kicbase...:  242.30 MiB / 447.62 MiB  54.13% 18.14 Mi    > gcr.io/k8s-minikube/kicbase...:  248.80 MiB / 447.62 MiB  55.58% 18.14 Mi    > gcr.io/k8s-minikube/kicbase...:  256.01 MiB / 447.62 MiB  57.19% 19.15 Mi    > gcr.io/k8s-minikube/kicbase...:  262.65 MiB / 447.62 MiB  58.68% 19.15 Mi    > gcr.io/k8s-minikube/kicbase...:  269.25 MiB / 447.62 MiB  60.15% 19.15 Mi    > gcr.io/k8s-minikube/kicbase...:  276.22 MiB / 447.62 MiB  61.71% 20.08 Mi    > gcr.io/k8s-minikube/kicbase...:  283.06 MiB / 447.62 MiB  63.24% 20.08 Mi    > gcr.io/k8s-minikube/kicbase...:  289.84 MiB / 447.62 MiB  64.75% 20.08 Mi    > gcr.io/k8s-minikube/kicbase...:  296.90 MiB / 447.62 MiB  66.33% 21.02 Mi    > gcr.io/k8s-minikube/kicbase...:  299.37 MiB / 447.62 MiB  66.88% 21.02 Mi    > gcr.io/k8s-minikube/kicbase...:  304.62 MiB / 447.62 MiB  68.05% 21.02 Mi    > gcr.io/k8s-minikube/kicbase...:  310.22 MiB / 447.62 MiB  69.30% 21.09 Mi    > gcr.io/k8s-minikube/kicbase...:  316.03 MiB / 447.62 MiB  70.60% 21.09 Mi    > gcr.io/k8s-minikube/kicbase...:  321.59 MiB / 447.62 MiB  71.84% 21.09 Mi    > gcr.io/k8s-minikube/kicbase...:  327.06 MiB / 447.62 MiB  73.07% 21.54 Mi    > gcr.io/k8s-minikube/kicbase...:  332.78 MiB / 447.62 MiB  74.34% 21.54 Mi    > gcr.io/k8s-minikube/kicbase...:  341.11 MiB / 447.62 MiB  76.20% 21.54 Mi    > gcr.io/k8s-minikube/kicbase...:  347.44 MiB / 447.62 MiB  77.62% 22.34 Mi    > gcr.io/k8s-minikube/kicbase...:  353.35 MiB / 447.62 MiB  78.94% 22.34 Mi    > gcr.io/k8s-minikube/kicbase...:  359.44 MiB / 447.62 MiB  80.30% 22.34 Mi    > gcr.io/k8s-minikube/kicbase...:  365.13 MiB / 447.62 MiB  81.57% 22.81 Mi    > gcr.io/k8s-minikube/kicbase...:  371.01 MiB / 447.62 MiB  82.88% 22.81 Mi    > gcr.io/k8s-minikube/kicbase...:  377.07 MiB / 447.62 MiB  84.24% 22.81 Mi    > gcr.io/k8s-minikube/kicbase...:  382.97 MiB / 447.62 MiB  85.56% 23.25 Mi    > gcr.io/k8s-minikube/kicbase...:  388.82 MiB / 447.62 MiB  86.86% 23.25 Mi    > gcr.io/k8s-minikube/kicbase...:  394.88 MiB / 447.62 MiB  88.22% 23.25 Mi    > gcr.io/k8s-minikube/kicbase...:  400.94 MiB / 447.62 MiB  89.57% 23.68 Mi    > gcr.io/k8s-minikube/kicbase...:  406.82 MiB / 447.62 MiB  90.89% 23.68 Mi    > gcr.io/k8s-minikube/kicbase...:  411.97 MiB / 447.62 MiB  92.04% 23.68 Mi    > gcr.io/k8s-minikube/kicbase...:  417.01 MiB / 447.62 MiB  93.16% 23.88 Mi    > gcr.io/k8s-minikube/kicbase...:  422.29 MiB / 447.62 MiB  94.34% 23.88 Mi    > gcr.io/k8s-minikube/kicbase...:  427.13 MiB / 447.62 MiB  95.42% 23.88 Mi    > gcr.io/k8s-minikube/kicbase...:  432.38 MiB / 447.62 MiB  96.60% 23.99 Mi    > gcr.io/k8s-minikube/kicbase...:  439.54 MiB / 447.62 MiB  98.19% 23.99 Mi    > gcr.io/k8s-minikube/kicbase...:  447.61 MiB / 447.62 MiB  100.00% 29.18 M* Creating docker container (CPUs=2, Memory=15800MB) ...
* Preparing Kubernetes v1.27.3 on Docker 24.0.4 ...
  - Generating certificates and keys ...
  - Booting up control plane ...
  - Configuring RBAC rules ...
* Configuring bridge CNI (Container Networking Interface) ...
  - Using image gcr.io/k8s-minikube/storage-provisioner:v5
* Verifying Kubernetes components...
* Enabled addons: storage-provisioner, default-storageclass
* Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE
kube-system   etcd-minikube                      0/1     Pending   0          2s
kube-system   kube-apiserver-minikube            0/1     Pending   0          2s
kube-system   kube-controller-manager-minikube   0/1     Pending   0          2s
kube-system   kube-scheduler-minikube            0/1     Pending   0          1s
kube-system   storage-provisioner                0/1     Pending   0          1s
[prezha@codex nested]$
[prezha@codex nested]$
[prezha@codex nested]$
[prezha@codex nested]$ docker exec minikube /bin/bash -c "kubectl get pods -A"
NAMESPACE     NAME                               READY   STATUS    RESTARTS      AGE
kube-system   coredns-5d78c9869d-fs6k8           1/1     Running   0             56s
kube-system   etcd-minikube                      1/1     Running   0             70s
kube-system   kube-apiserver-minikube            1/1     Running   0             70s
kube-system   kube-controller-manager-minikube   1/1     Running   0             70s
kube-system   kube-proxy-8gqbt                   1/1     Running   0             56s
kube-system   kube-scheduler-minikube            1/1     Running   0             69s
kube-system   storage-provisioner                1/1     Running   1 (25s ago)   69s
```
