### PR TITLE
csi-hostpath-driver: increase timeout/period for hostpath container

### DIFF
--- a/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-plugin.yaml.tmpl
+++ b/deploy/addons/csi-hostpath-driver/deploy/csi-hostpath-plugin.yaml.tmpl
@@ -107,13 +107,13 @@ spec:
             name: healthz
             protocol: TCP
           livenessProbe:
-            failureThreshold: 5
+            failureThreshold: 6
             httpGet:
               path: /healthz
               port: healthz
             initialDelaySeconds: 10
-            timeoutSeconds: 3
-            periodSeconds: 2
+            timeoutSeconds: 10
+            periodSeconds: 10
           volumeMounts:
             - mountPath: /csi
               name: socket-dir


### PR DESCRIPTION
Background
=========
I've been using minikube for some i/o heavy continuous integration testing. About one or two times per week, I get a timeout on the hostpath container within the csi-hostpathplugin pod. When this happens, all my pods using volumes restart, which interrupts testing.

Specifically, this is the error in the status for the csi-hostpathplugin pod is this (port 9898 is definitely the hostpath container).
```
  Warning  Unhealthy  24m (x7 over 22h)    kubelet  Liveness probe failed: Get
  "http://10.244.0.4:9898/healthz": context deadline exceeded (Client.Timeout
  exceeded while awaiting headers)
```

I haven't identified the root cause of why the 3 second timeout is not enough. To solve the problem I've been patching the daemonset in my script which deploys my minikube cluster.
```
  minikube kubectl -- patch ds csi-hostpathplugin --patch-file='/dev/stdin' --namespace='kube-system' << EOF
spec:
  template:
    spec:
      containers:
      - name: hostpath
        livenessProbe:
          failureThreshold: 6
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 10
EOF
```

I'm using minikube v1.31.1 with kube v1.27.4.
```
  minikube start \
    --kubernetes-version='v1.27.4' \
    --driver='docker' \
    --container-runtime='containerd' \
    --cpus='max' \
    --addons='csi-hostpath-driver,metallb,registry' \
    --insecure-registry='192.168.49.2:5000' \
    --mount \
    --mount-string="${HOME}/cluster:/mnt/cluster"
```

Testing
======
So far, I've been running with the increased timeout for 6d10h.

TODO(sbunce): Probably wait until we get to 2 weeks. We've never gone 2 weeks without a timeout before this change.
