### PR TITLE
CI: Fix only writing to root known_hosts

### DIFF
--- a/hack/jenkins/cron/cleanup_and_reboot_Linux.sh
+++ b/hack/jenkins/cron/cleanup_and_reboot_Linux.sh
@@ -54,7 +54,7 @@ function cleanup() {
 		# clear the known_host file (~/.ssh/known_hosts)
 		if test -f /home/${user}/.ssh/known_hosts; then
 			sudo echo "" > /home/${user}/.ssh/known_hosts
-			ssh-keyscan github.com >>~/.ssh/known_hosts
+			ssh-keyscan github.com >> /home/${user}/.ssh/known_hosts
 		fi
 	done
 	# clean docker left overs


### PR DESCRIPTION
Was originally doing `~/.ssh/known_hosts`, but cron jobs run as root, so was only updating root's version of known_hosts, not Jenkins