### PR TITLE
Include full command for `minikube kubectl get pods -A`

### DIFF
--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -513,15 +513,15 @@ If minikube fails to start, see the [drivers page]({{<ref "/docs/drivers">}}) fo
 If you already have kubectl installed, you can now use it to access your shiny new cluster:
 
 ```shell
-kubectl get po -A
+kubectl get pods -A
 ```
 
 Alternatively, minikube can download the appropriate version of kubectl and you should be able to use it like this:
 
 ```shell
-minikube kubectl -- get po -A
+minikube kubectl -- get pods -A
 ```
-You can also make your life easier by adding the following to your shell config:
+Make your life easier by adding this to your shell config (such as `~/.bashrc`):
 ```shell
 alias kubectl="minikube kubectl --"
 ```


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

On Debian, the abbreviated version of the command appeared not to work. Either way, I think including the full command is more useful than an abbreviated version, because the abbreviated `po` provides no context for what exactly the user is getting. The word `pods` is self-descriptive, and helps the user understand what they are doing by running that command.
