### PR TITLE
Use minikube-machine repository for vmware driver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -239,7 +239,7 @@ replace (
 	github.com/briandowns/spinner => github.com/alonyb/spinner v1.12.7
 	github.com/docker/machine => github.com/minikube-machine/machine v0.0.0-20230814171452-e95650b07516
 	github.com/intel-go/cpuid => github.com/aregm/cpuid v0.0.0-20181003105527-1a4a6f06a1c6
-	github.com/machine-drivers/docker-machine-driver-vmware => github.com/lbogdan/docker-machine-driver-vmware v0.2.0
+	github.com/machine-drivers/docker-machine-driver-vmware => github.com/minikube-machine/machine-driver-vmware v0.1.6-0.20230701123042-a391c48b14d5
 	github.com/samalba/dockerclient => github.com/sayboras/dockerclient v1.0.0
 	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.22.4
 )

--- a/go.sum
+++ b/go.sum
@@ -1750,8 +1750,6 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
-github.com/lbogdan/docker-machine-driver-vmware v0.2.0 h1:ew0GbsB9/TeQjPO3nWgivOmx7EakXeMbS5kvArvddOM=
-github.com/lbogdan/docker-machine-driver-vmware v0.2.0/go.mod h1:HifYFOWR0bAMN4hWtaSADClogvtPy/jV0aRC5alhrKo=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.1.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -1838,6 +1836,8 @@ github.com/minikube-machine/machine v0.0.0-20230814171452-e95650b07516 h1:TdnOOG
 github.com/minikube-machine/machine v0.0.0-20230814171452-e95650b07516/go.mod h1:I+HtQRi2cs3knYUuHwiY59H9j52F03+l489Vm6AoMok=
 github.com/minikube-machine/machine-driver-parallels/v2 v2.0.1 h1:eYP7NkEv+tUZeB7BLfJ8PF4UNCW6lVyrbMvcWh1rgMA=
 github.com/minikube-machine/machine-driver-parallels/v2 v2.0.1/go.mod h1:NKwI5KryEmEHMZVj80t9JQcfXWZp4/ZYNBuw4C5sQ9E=
+github.com/minikube-machine/machine-driver-vmware v0.1.6-0.20230701123042-a391c48b14d5 h1:1z7xOzfMO4aBR9+2nYjlhRXX1773fX60HTS0QGpGRPU=
+github.com/minikube-machine/machine-driver-vmware v0.1.6-0.20230701123042-a391c48b14d5/go.mod h1:HifYFOWR0bAMN4hWtaSADClogvtPy/jV0aRC5alhrKo=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8/go.mod h1:mC1jAcsrzbxHt8iiaC+zU4b1ylILSosueou12R++wfY=
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3/go.mod h1:RagcQ7I8IeTMnF8JTXieKnO4Z6JCsikNEzj0DwauVzE=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=


### PR DESCRIPTION
We don't create new releases when patching, so remove v0.2.0

Go modules will invent a new imaginary release, like v0.1.6

The v0.1.4 was re-released as v0.1.5, so they are both the same:

https://github.com/machine-drivers/docker-machine-driver-vmware/releases/tag/v0.1.5

```
*   a391c48 (HEAD -> master, tag: v0.2.0, minikube-machine/master, lbogdan/master) Merge pull request #1 from lbogdan/feat/minikube-no-password
|\  
| * 8ef47f7 (lbogdan/feat/minikube-no-password) fix: remove failing ssh and vmrun commands and cleanup unused code
| * 358bec4 chore: fix golangci-lint errors
| * 652a505 feat: support new minikube iso, with docker user password disabled
|/  
*   b30963f (origin/master, origin/HEAD) Merge pull request #55 from machine-drivers/dependabot/github_actions/goreleaser/goreleaser-action-2.9.1
|\  
| * 4b34672 Bump goreleaser/goreleaser-action from 2.8.0 to 2.9.1
* |   2e18c38 Merge pull request #57 from machine-drivers/dependabot/github_actions/actions/checkout-3.0.0
|\ \  
| * | 3b3d13f Bump actions/checkout from 2.4.0 to 3.0.0
| |/  
* |   12a0a33 Merge pull request #58 from machine-drivers/dependabot/github_actions/actions/setup-go-3
|\ \  
| |/  
|/|   
| * febd518 Bump actions/setup-go from 2 to 3
|/  
*   d6ef733 Merge pull request #49 from machine-drivers/dependabot/github_actions/actions/checkout-2.4.0
|\  
| * 0fb4236 Bump actions/checkout from 2.3.5 to 2.4.0
|/  
*   faa4b93 (tag: v0.1.5, tag: v0.1.4) Merge pull request #46 from machine-drivers/dependabot/github_actions/actions/checkout-2.3.5

```

Cleanup from:

* https://github.com/kubernetes/minikube/pull/16796

---

Note: there are no code changes here, same commit