### PR TITLE
qemu: better cpu type and IP detection

### DIFF
--- a/pkg/drivers/qemu/qemu.go
+++ b/pkg/drivers/qemu/qemu.go
@@ -510,7 +510,7 @@ func (d *Driver) Start() error {
 			return nil
 		}
 		// Implement a retry loop because IP address isn't added to dhcp leases file immediately
-		for i := 0; i < 30; i++ {
+		for i := 0; i < 60; i++ {
 			log.Debugf("Attempt %d", i)
 			err = getIP()
 			if err == nil {

--- a/pkg/minikube/registry/drvs/qemu2/qemu2.go
+++ b/pkg/minikube/registry/drvs/qemu2/qemu2.go
@@ -125,7 +125,9 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 	switch runtime.GOARCH {
 	case "amd64":
 		qemuMachine = "" // default
-		qemuCPU = ""     // default
+		// set cpu type to max to enable higher microarchitecture levels
+		// see https://lists.gnu.org/archive/html/qemu-devel/2022-08/msg04066.html for details
+		qemuCPU = "max"
 	case "arm64":
 		qemuMachine = "virt"
 		qemuCPU = "cortex-a72"


### PR DESCRIPTION
This PR has two commits.

1. We increase the timeout for detecting the IP address of the qemu VM.
2. The microarchitecture level of the qemu VM is bumped up to enable RHEL9 and related variants. This is required to support container images that are built using ubi9.
