### PR TITLE
set minimum minikube legacy version to v1.26.0 for containerd cri

### DIFF
--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -76,8 +76,9 @@ func legacyVersion() string {
 	// the version containerd in ISO was upgraded to 1.4.2
 	// we need it to use runc.v2 plugin
 	// note: Test*BinaryUpgrade require minikube v1.22+ to satisfy newer containerd config structure
+	// note: TestMissingContainerUpgrade requires minikube v1.26.0+ where we copy over initial containerd config in kicbase via deploy/kicbase/Dockerfile
 	if ContainerRuntime() == "containerd" {
-		version = "v1.22.0"
+		version = "v1.26.0"
 	}
 	return version
 }


### PR DESCRIPTION
fixes #17219

solution is to use at least minikube v1.26.0 for this test to be able to pass

details:

### v1.25.2 (and earlier versions)

```
$ make integration -e TEST_ARGS="-minikube-start-args='--driver=docker --container-runtime=containerd' -test.run TestMissingContainerUpgrade --cleanup=false"
go test -ldflags="-X k8s.io/minikube/pkg/version.version=v1.31.2 -X k8s.io/minikube/pkg/version.isoVersion=v1.31.0-1692872107-17120 -X k8s.io/minikube/pkg/version.gitCommitID="14c9e44bc46f135f12e8131cd386499871695824-dirty" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" -v -test.timeout=90m ./test/integration --tags="integration " -minikube-start-args='--driver=docker --container-runtime=containerd' -test.run TestMissingContainerUpgrade --cleanup=false 2>&1 | tee "./out/testout_14c9e44bc.txt"
Found 16 cores, limiting parallelism with --test.parallel=9
=== RUN   TestMissingContainerUpgrade
=== PAUSE TestMissingContainerUpgrade
=== CONT  TestMissingContainerUpgrade
    version_upgrade_test.go:324: (dbg) Run:  /tmp/minikube-v1.25.2.2226404152.exe start -p missing-upgrade-755862 --memory=2200 --driver=docker --container-runtime=containerd
    version_upgrade_test.go:324: (dbg) Done: /tmp/minikube-v1.25.2.2226404152.exe start -p missing-upgrade-755862 --memory=2200 --driver=docker --container-runtime=containerd: (1m1.945083447s)
    version_upgrade_test.go:333: (dbg) Run:  docker stop missing-upgrade-755862
    version_upgrade_test.go:333: (dbg) Done: docker stop missing-upgrade-755862: (10.54743632s)
    version_upgrade_test.go:338: (dbg) Run:  docker rm missing-upgrade-755862
    version_upgrade_test.go:344: (dbg) Run:  out/minikube start -p missing-upgrade-755862 --memory=2200 --alsologtostderr -v=1 --driver=docker --container-runtime=containerd
    version_upgrade_test.go:344: (dbg) Non-zero exit: out/minikube start -p missing-upgrade-755862 --memory=2200 --alsologtostderr -v=1 --driver=docker --container-runtime=containerd: exit status 90 (1m39.726507602s)
...
                stderr:
                time="2023-09-09T00:17:56Z" level=fatal msg="getting the runtime version: rpc error: code = Unimplemented desc = unknown service runtime.v1alpha2.RuntimeService"
                I0909 01:18:12.622117 2431489 ssh_runner.go:195] Run: sudo /usr/bin/crictl version
                I0909 01:18:12.649987 2431489 out.go:177] 
                W0909 01:18:12.653521 2431489 out.go:239] X Exiting due to RUNTIME_ENABLE: Failed to start container runtime: Temporary Error: sudo /usr/bin/crictl version: Process exited with status 1
                stdout:
...
--- FAIL: TestMissingContainerUpgrade (176.65s)
FAIL
Tests completed in 2m56.645994233s (result code 1)
FAIL    k8s.io/minikube/test/integration        176.685s
FAIL
```

note: `unknown service runtime.v1alpha2.RuntimeService` error indicates that the cri is disabled, and, indeed, there's `disabled_plugins = ["cri"]` from default containerd's config:

```
$ minikube ssh -p missing-upgrade-755862 sudo cat /etc/containerd/config.toml
#   Copyright 2018-2020 Docker Inc.

#   Licensed under the Apache License, Version 2.0 (the "License");
#   you may not use this file except in compliance with the License.
#   You may obtain a copy of the License at

#       http://www.apache.org/licenses/LICENSE-2.0

#   Unless required by applicable law or agreed to in writing, software
#   distributed under the License is distributed on an "AS IS" BASIS,
#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
#   See the License for the specific language governing permissions and
#   limitations under the License.

disabled_plugins = ["cri"]

#root = "/var/lib/containerd"
#state = "/run/containerd"
#subreaper = true
#oom_score = 0

#[grpc]
#  address = "/run/containerd/containerd.sock"
#  uid = 0
#  gid = 0

#[debug]
#  address = "/run/containerd/debug.sock"
#  uid = 0
#  gid = 0
#  level = "info"
```

and so, we cannot [generateContainerdConfig()](https://github.com/kubernetes/minikube/blob/fd7ecd9c4599bef9f04c0986c4a0187f98a4396e/pkg/minikube/cruntime/containerd.go#L131), which then leaves default containerd intact, following with expected failure with the above error

### v1.26.0+

```
$ make integration -e TEST_ARGS="-minikube-start-args='--driver=docker --container-runtime=containerd' -test.run TestMissingContainerUpgrade --cleanup=false"
go test -ldflags="-X k8s.io/minikube/pkg/version.version=v1.31.2 -X k8s.io/minikube/pkg/version.isoVersion=v1.31.0-1692872107-17120 -X k8s.io/minikube/pkg/version.gitCommitID="14c9e44bc46f135f12e8131cd386499871695824-dirty" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" -v -test.timeout=90m ./test/integration --tags="integration " -minikube-start-args='--driver=docker --container-runtime=containerd' -test.run TestMissingContainerUpgrade --cleanup=false 2>&1 | tee "./out/testout_14c9e44bc.txt"
Found 16 cores, limiting parallelism with --test.parallel=9
=== RUN   TestMissingContainerUpgrade
=== PAUSE TestMissingContainerUpgrade
=== CONT  TestMissingContainerUpgrade
    version_upgrade_test.go:324: (dbg) Run:  /tmp/minikube-v1.26.0.1879240289.exe start -p missing-upgrade-233051 --memory=2200 --driver=docker --container-runtime=containerd
    version_upgrade_test.go:324: (dbg) Done: /tmp/minikube-v1.26.0.1879240289.exe start -p missing-upgrade-233051 --memory=2200 --driver=docker --container-runtime=containerd: (1m8.102403871s)
    version_upgrade_test.go:333: (dbg) Run:  docker stop missing-upgrade-233051
    version_upgrade_test.go:333: (dbg) Done: docker stop missing-upgrade-233051: (10.599567423s)
    version_upgrade_test.go:338: (dbg) Run:  docker rm missing-upgrade-233051
    version_upgrade_test.go:344: (dbg) Run:  out/minikube start -p missing-upgrade-233051 --memory=2200 --alsologtostderr -v=1 --driver=docker --container-runtime=containerd
    version_upgrade_test.go:344: (dbg) Done: out/minikube start -p missing-upgrade-233051 --memory=2200 --alsologtostderr -v=1 --driver=docker --container-runtime=containerd: (51.522710075s)
    helpers_test.go:183: skipping cleanup of missing-upgrade-233051 (--cleanup=false)
--- PASS: TestMissingContainerUpgrade (133.79s)
PASS
Tests completed in 2m13.788954604s (result code 0)
ok      k8s.io/minikube/test/integration        133.822s
```

here, thanks to how the kicbase was built (via [Dockerfile](https://github.com/kubernetes/minikube/blob/f4b412861bb746be73053c9f6d2895f12cf78565/deploy/kicbase/Dockerfile#L52)), we have expected containerd config (patched to our needs):

```
$ minikube ssh -p missing-upgrade-233051 sudo cat /etc/containerd/config.toml
version = 2
root = "/var/lib/containerd"                                     
state = "/run/containerd"
oom_score = 0      
# imports

[grpc]
  address = "/run/containerd/containerd.sock"
  uid = 0
  gid = 0
  max_recv_message_size = 16777216
  max_send_message_size = 16777216

[debug]
  address = ""
  uid = 0
  gid = 0
  level = ""

[metrics]
  address = ""
  grpc_histogram = false

[cgroup]
  path = ""

[plugins]
  [plugins."io.containerd.monitor.v1.cgroups"]
    no_prometheus = false
  [plugins."io.containerd.grpc.v1.cri"]
    stream_server_address = ""
    stream_server_port = "10010"
    enable_selinux = false
    sandbox_image = "registry.k8s.io/pause:3.7"
    stats_collect_period = 10
    enable_tls_streaming = false
    max_container_log_line_size = 16384
    restrict_oom_score_adj = false

    [plugins."io.containerd.grpc.v1.cri".containerd]
      discard_unpacked_layers = true
      snapshotter = "overlayfs"
      [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
        runtime_type = "io.containerd.runc.v2"
      [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
        runtime_type = ""
        runtime_engine = ""
        runtime_root = ""
      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
          runtime_type = "io.containerd.runc.v2"
          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
            SystemdCgroup = true

    [plugins."io.containerd.grpc.v1.cri".cni]
      bin_dir = "/opt/cni/bin"
      conf_dir = "/etc/cni/net.d"
      conf_template = ""
    [plugins."io.containerd.grpc.v1.cri".registry]
      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
          endpoint = ["https://registry-1.docker.io"]
  [plugins."io.containerd.service.v1.diff-service"]
    default = ["walking"]
  [plugins."io.containerd.gc.v1.scheduler"]
    pause_threshold = 0.02
    deletion_threshold = 0
    mutation_threshold = 100
    schedule_delay = "0s"
    startup_delay = "100ms"
```
---

note: i was thinking about making minikube more resilient to this and support older versions by changing our code to supply our initial containerd config if we see that the default one is present instead, but since we change which containerd version and then also change the initial config (format & values) we supply over time, that's not a viable option
