### PR TITLE
Automate installing NVIDIA Container Toolkit --container-runtime

### DIFF
--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -434,6 +434,7 @@ func TestValidateDiskSize(t *testing.T) {
 func TestValidateRuntime(t *testing.T) {
 	var tests = []struct {
 		runtime  string
+		driver   string
 		errorMsg string
 	}{
 		{
@@ -444,15 +445,24 @@ func TestValidateRuntime(t *testing.T) {
 			runtime:  "docker",
 			errorMsg: "",
 		},
-
 		{
 			runtime:  "test",
 			errorMsg: fmt.Sprintf("Invalid Container Runtime: test. Valid runtimes are: %v", cruntime.ValidRuntimes()),
 		},
+		{
+			runtime:  "nvidia-docker",
+			driver:   "docker",
+			errorMsg: "",
+		},
+		{
+			runtime:  "nvidia-docker",
+			driver:   "kvm",
+			errorMsg: "The nvidia-docker container-runtime can only be run with the docker driver",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.runtime, func(t *testing.T) {
-			got := validateRuntime(test.runtime)
+			got := validateRuntime(test.runtime, test.driver)
 			gotError := ""
 			if got != nil {
 				gotError = got.Error()

--- a/deploy/addons/assets.go
+++ b/deploy/addons/assets.go
@@ -163,4 +163,8 @@ var (
 	// CloudSpanner assets for cloud-spanner addon
 	//go:embed cloud-spanner/*.yaml
 	CloudSpanner embed.FS
+
+	// NvidiaDevicePlugin assets for nvidia-device-plugin addon
+	//go:embed nvidia-device-plugin/*.tmpl
+	NvidiaDevicePlugin embed.FS
 )

--- a/deploy/addons/nvidia-device-plugin/nvidia-device-plugin.yaml.tmpl
+++ b/deploy/addons/nvidia-device-plugin/nvidia-device-plugin.yaml.tmpl
@@ -1,0 +1,56 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-device-plugin-daemonset
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      name: nvidia-device-plugin-ds
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: nvidia-device-plugin-ds
+    spec:
+      tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      # Mark this pod as a critical add-on; when enabled, the critical add-on
+      # scheduler reserves resources for critical add-on pods so that they can
+      # be rescheduled after a failure.
+      # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+      priorityClassName: "system-node-critical"
+      containers:
+      - image: {{.CustomRegistries.NvidiaDevicePlugin | default .ImageRepository | default .Registries.NvidiaDevicePlugin}}{{.Images.NvidiaDevicePlugin}}
+        name: nvidia-device-plugin-ctr
+        env:
+          - name: FAIL_ON_INIT_ERROR
+            value: "false"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        volumeMounts:
+        - name: device-plugin
+          mountPath: /var/lib/kubelet/device-plugins
+      volumes:
+      - name: device-plugin
+        hostPath:
+          path: /var/lib/kubelet/device-plugins

--- a/pkg/addons/config.go
+++ b/pkg/addons/config.go
@@ -222,4 +222,9 @@ var Addons = []*Addon{
 		set:       SetBool,
 		callbacks: []setFn{EnableOrDisableAddon},
 	},
+	{
+		name:      "nvidia-device-plugin",
+		set:       SetBool,
+		callbacks: []setFn{EnableOrDisableAddon},
+	},
 }

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -90,6 +90,9 @@ func (d *Driver) Create() error {
 		APIServerPort: d.NodeConfig.APIServerPort,
 	}
 
+	if d.NodeConfig.ContainerRuntime == constants.NvidiaDocker {
+		params.GPUs = true
+	}
 	networkName := d.NodeConfig.Network
 	if networkName == "" {
 		networkName = d.NodeConfig.ClusterName

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -190,6 +190,9 @@ func CreateContainerNode(p CreateParams) error {
 		runArgs = append(runArgs, "--network", p.Network)
 		runArgs = append(runArgs, "--ip", p.IP)
 	}
+	if p.GPUs {
+		runArgs = append(runArgs, "--gpus", "all")
+	}
 
 	memcgSwap := hasMemorySwapCgroup()
 	memcg := HasMemoryCgroup()

--- a/pkg/drivers/kic/oci/types.go
+++ b/pkg/drivers/kic/oci/types.go
@@ -58,7 +58,8 @@ type CreateParams struct {
 	ExtraArgs     []string          // a list of any extra option to pass to oci binary during creation time, for example --expose 8080...
 	OCIBinary     string            // docker or podman
 	Network       string            // network name that the container will attach to
-	IP            string            // static IP to assign for th container in the cluster network
+	IP            string            // static IP to assign the container in the cluster network
+	GPUs          bool              // add GPU devices to the container
 }
 
 // createOpt is an option for Create

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -93,6 +93,11 @@ func (a *Addon) IsEnabledOrDefault(cc *config.ClusterConfig) bool {
 	return a.enabled
 }
 
+// EnableByDefault will enable the addon by default on cluster start
+func (a *Addon) EnableByDefault() {
+	a.enabled = true
+}
+
 // Addons is the list of addons
 // TODO: Make dynamically loadable: move this data to a .yaml file within each addon directory
 var Addons = map[string]*Addon{
@@ -770,6 +775,14 @@ var Addons = map[string]*Addon{
 	}, map[string]string{
 		"CloudSpanner": "gcr.io",
 	}),
+	"nvidia-device-plugin": NewAddon([]*BinAsset{
+		MustBinAsset(addons.NvidiaDevicePlugin, "nvidia-device-plugin/nvidia-device-plugin.yaml.tmpl", vmpath.GuestAddonsDir, "nvidia-device-plugin.yaml", "0640"),
+	}, false, "nvidia-device-plugin", "3rd party (NVIDIA)", "", "",
+		map[string]string{
+			"NvidiaDevicePlugin": "nvidia/k8s-device-plugin:v0.14.1@sha256:15c4280d13a61df703b12d1fd1b5b5eec4658157db3cb4b851d3259502310136",
+		}, map[string]string{
+			"NvidiaDevicePlugin": "nvcr.io",
+		}),
 }
 
 // parseMapString creates a map based on `str` which is encoded as <key1>=<value1>,<key2>=<value2>,...

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -63,6 +63,8 @@ const (
 	CRIO = "crio"
 	// Docker is the default name and spelling for the docker container runtime
 	Docker = "docker"
+	// NvidiaDocker is the default name and spelling for the nvidia-docker container runtime
+	NvidiaDocker = "nvidia-docker"
 	// DefaultContainerRuntime is our default container runtime
 	DefaultContainerRuntime = ""
 

--- a/pkg/minikube/style/style.go
+++ b/pkg/minikube/style/style.go
@@ -139,6 +139,7 @@ var Config = map[Enum]Options{
 	VerifyingNoLine:  {Prefix: "🤔  ", OmitNewline: true},
 	Verifying:        {Prefix: "🤔  "},
 	CNI:              {Prefix: "🔗  "},
+	Toolkit:          {Prefix: "🛠️   "},
 }
 
 // LowPrefix returns a 7-bit compatible prefix for a style

--- a/pkg/minikube/style/style_enum.go
+++ b/pkg/minikube/style/style_enum.go
@@ -105,4 +105,5 @@ const (
 	Warning
 	Workaround
 	CNI
+	Toolkit
 )

--- a/site/content/en/docs/tutorials/nvidia.md
+++ b/site/content/en/docs/tutorials/nvidia.md
@@ -1,6 +1,6 @@
 ---
-title: "Using the Nvidia Addons"
-linkTitle: "Nvidia"
+title: "Using NVIDIA GPUs with minikube"
+linkTitle: "Using NVIDIA GPUs with minikube"
 weight: 1
 date: 2018-01-02
 ---
@@ -8,17 +8,66 @@ date: 2018-01-02
 ## Prerequisites
 
 - Linux
-- kvm2 driver
 - Latest NVIDIA GPU drivers
 
-## Using the KVM2 driver
+## Instructions per driver
 
-When using NVIDIA GPUs with the kvm2 driver, we passthrough spare GPUs on the
+{{% tabs %}}
+{{% tab docker %}}
+## Using the docker driver
+
+- Check if `bpf_jit_harden` is set to `0`
+  ```shell
+  sudo sysctl net.core.bpf_jit_harden
+  ```
+  - If it's not `0` run:
+  ```shell
+  echo "net.core.bpf_jit_harden=0" | sudo tee -a /etc/sysctl.conf
+  sudo sysctl -p
+  ```
+
+- Install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) on your host machine
+
+- Configure Docker:
+  ```shell
+  sudo nvidia-ctk runtime configure --runtime=docker && sudo systemctl restart docker
+  ```
+- Start minikube:
+  ```shell
+  minikube start --driver docker --container-runtime nvidia-docker
+  ```
+{{% /tab %}}
+{{% tab none %}}
+## Using the 'none' driver
+
+NOTE: This approach used to expose GPUs here is different than the approach used
+to expose GPUs with `--driver=kvm`. Please don't mix these instructions.
+
+- Install minikube.
+
+- Install the nvidia driver, nvidia-docker and configure docker with nvidia as
+  the default runtime. See instructions at
+  <https://github.com/NVIDIA/nvidia-docker>
+
+- Start minikube:
+  ```shell
+  minikube start --driver=none --apiserver-ips 127.0.0.1 --apiserver-name localhost
+  ```
+
+- Install NVIDIA's device plugin:
+  ```shell
+  minikube addons enable nvidia-device-plugin
+  ```
+{{% /tab %}}
+{{% tab kvm %}}
+## Using the kvm driver
+
+When using NVIDIA GPUs with the kvm driver, we passthrough spare GPUs on the
 host to the minikube VM. Doing so has a few prerequisites:
 
-- You must install the [kvm2 driver]({{< ref "/docs/drivers/kvm2" >}}) If you already had
+- You must install the [kvm driver]({{< ref "/docs/drivers/kvm2" >}}) If you already had
   this installed make sure that you fetch the latest
-  `docker-machine-driver-kvm2` binary that has GPU support.
+  `docker-machine-driver-kvm` binary that has GPU support.
 
 - Your CPU must support IOMMU. Different vendors have different names for this
   technology. Intel calls it Intel VT-d. AMD calls it AMD-Vi. Your motherboard
@@ -40,9 +89,9 @@ host to the minikube VM. Doing so has a few prerequisites:
   group of these GPUs.
 
 - Once you reboot the system after doing the above, you should be ready to use
-  GPUs with kvm2. Run the following command to start minikube:
+  GPUs with kvm. Run the following command to start minikube:
   ```shell
-  minikube start --driver kvm2 --kvm-gpu
+  minikube start --driver kvm --kvm-gpu
   ```
 
   This command will check if all the above conditions are satisfied and
@@ -68,31 +117,12 @@ host to the minikube VM. Doing so has a few prerequisites:
 See the excellent documentation at
 <https://wiki.archlinux.org/index.php/PCI_passthrough_via_OVMF>
 
-### Why are so many manual steps required to use GPUs with kvm2 on minikube?
+### Why are so many manual steps required to use GPUs with kvm on minikube?
 
 These steps require elevated privileges which minikube doesn't run with and they
 are disruptive to the host, so we decided to not do them automatically.
-
-## Using the 'none' driver
-
-NOTE: This approach used to expose GPUs here is different than the approach used
-to expose GPUs with `--driver=kvm2`. Please don't mix these instructions.
-
-- Install minikube.
-
-- Install the nvidia driver, nvidia-docker and configure docker with nvidia as
-  the default runtime. See instructions at
-  <https://github.com/NVIDIA/nvidia-docker>
-
-- Start minikube:
-  ```shell
-  minikube start --driver=none --apiserver-ips 127.0.0.1 --apiserver-name localhost
-  ```
-
-- Install NVIDIA's device plugin:
-  ```shell
-  kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/master/nvidia-device-plugin.yml
-  ```
+{{% /tab %}}
+{{% /tabs %}}
 
 ## Why does minikube not support NVIDIA GPUs on macOS?
 
@@ -102,7 +132,7 @@ drivers supported by minikube for macOS doesn't support GPU passthrough:
 - [moby/hyperkit#159](https://github.com/moby/hyperkit/issues/159)
 - [VirtualBox docs](https://www.virtualbox.org/manual/ch09.html#pcipassthrough)
 
-Also:
+Also: 
 
 - For quite a while, all Mac hardware (both laptops and desktops) have come with
   Intel or AMD GPUs (and not with NVIDIA GPUs). Recently, Apple added [support

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -906,7 +906,7 @@ func validateLocalPathAddon(ctx context.Context, t *testing.T, profile string) {
 func validateNvidiaDevicePlugin(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 
-	if _, err := PodWait(ctx, t, profile, "kube-system", "nvidia-device-plugin-ds", Minutes(1)); err != nil {
+	if _, err := PodWait(ctx, t, profile, "kube-system", "nvidia-device-plugin-ds", Minutes(6)); err != nil {
 		t.Fatalf("failed waiting for nvidia-device-plugin-ds pod: %v", err)
 	}
 	if rr, err := Run(t, exec.CommandContext(ctx, Target(), "addons", "disable", "nvidia-device-plugin", "-p", profile)); err != nil {

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -79,7 +79,7 @@ func TestAddons(t *testing.T) {
 		// so we override that here to let minikube auto-detect appropriate cgroup driver
 		os.Setenv(constants.MinikubeForceSystemdEnv, "")
 
-		args := append([]string{"start", "-p", profile, "--wait=true", "--memory=4000", "--alsologtostderr", "--addons=registry", "--addons=metrics-server", "--addons=volumesnapshots", "--addons=csi-hostpath-driver", "--addons=gcp-auth", "--addons=cloud-spanner", "--addons=inspektor-gadget", "--addons=storage-provisioner-rancher"}, StartArgs()...)
+		args := append([]string{"start", "-p", profile, "--wait=true", "--memory=4000", "--alsologtostderr", "--addons=registry", "--addons=metrics-server", "--addons=volumesnapshots", "--addons=csi-hostpath-driver", "--addons=gcp-auth", "--addons=cloud-spanner", "--addons=inspektor-gadget", "--addons=storage-provisioner-rancher", "--addons=nvidia-device-plugin"}, StartArgs()...)
 		if !NoneDriver() { // none driver does not support ingress
 			args = append(args, "--addons=ingress", "--addons=ingress-dns")
 		}
@@ -113,6 +113,7 @@ func TestAddons(t *testing.T) {
 			{"Headlamp", validateHeadlampAddon},
 			{"CloudSpanner", validateCloudSpannerAddon},
 			{"LocalPath", validateLocalPathAddon},
+			{"NvidiaDevicePlugin", validateNvidiaDevicePlugin},
 		}
 		for _, tc := range tests {
 			tc := tc
@@ -898,5 +899,17 @@ func validateLocalPathAddon(ctx context.Context, t *testing.T, profile string) {
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "addons", "disable", "storage-provisioner-rancher", "--alsologtostderr", "-v=1"))
 	if err != nil {
 		t.Errorf("failed to disable storage-provisioner-rancher addon: args %q: %v", rr.Command(), err)
+	}
+}
+
+// validateNvidiaDevicePlugin tests the nvidia-device-plugin addon by ensuring the pod comes up and the addon disables
+func validateNvidiaDevicePlugin(ctx context.Context, t *testing.T, profile string) {
+	defer PostMortemLogs(t, profile)
+
+	if _, err := PodWait(ctx, t, profile, "kube-system", "nvidia-device-plugin-ds", Minutes(1)); err != nil {
+		t.Fatalf("failed waiting for nvidia-device-plugin-ds pod: %v", err)
+	}
+	if rr, err := Run(t, exec.CommandContext(ctx, Target(), "addons", "disable", "nvidia-device-plugin", "-p", profile)); err != nil {
+		t.Errorf("failed to disable nvidia-device-plugin: args %q : %v", rr.Command(), err)
 	}
 }

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -906,7 +906,7 @@ func validateLocalPathAddon(ctx context.Context, t *testing.T, profile string) {
 func validateNvidiaDevicePlugin(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 
-	if _, err := PodWait(ctx, t, profile, "kube-system", "nvidia-device-plugin-ds", Minutes(6)); err != nil {
+	if _, err := PodWait(ctx, t, profile, "kube-system", "name=nvidia-device-plugin-ds", Minutes(6)); err != nil {
 		t.Fatalf("failed waiting for nvidia-device-plugin-ds pod: %v", err)
 	}
 	if rr, err := Run(t, exec.CommandContext(ctx, Target(), "addons", "disable", "nvidia-device-plugin", "-p", profile)); err != nil {


### PR DESCRIPTION
```
$ minikube start --container-runtime nvidia-docker
😄  minikube v1.31.2 on Debian rodete
✨  Automatically selected the docker driver
📌  Using Docker driver with root privileges
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=32100MB) ...
🛠️   Installing the NVIDIA Container Toolkit...
🐳  Preparing Kubernetes v1.28.2 on Docker 24.0.6 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔗  Configuring CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image nvcr.io/nvidia/k8s-device-plugin:v0.14.1
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: nvidia-device-plugin, storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default

$ cat << EOF | kubectl create -f -
apiVersion: v1
kind: Pod
metadata:
  name: nvidia-version-check
spec:
  restartPolicy: OnFailure
  containers:
  - name: nvidia-version-check
    image: "nvidia/cuda:11.0.3-base-ubuntu20.04"
    command: ["nvidia-smi"]
    resources:
      limits:
         nvidia.com/gpu: "1"
EOF
pod/nvidia-version-check created

$ kubectl logs nvidia-version-check
Fri Sep 22 18:45:31 2023       
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 525.125.06   Driver Version: 525.125.06   CUDA Version: 12.0     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  Quadro P1000        On   | 00000000:65:00.0 Off |                  N/A |
| 34%   26C    P8    N/A /  47W |     15MiB /  4096MiB |      0%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+
                                                                               
+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
+-----------------------------------------------------------------------------+

$ minikube start --driver kvm --container-runtime nvidia-docker
😄  minikube v1.31.2 on Debian rodete (kvm/amd64)
✨  Using the kvm2 driver based on user configuration

❌  Exiting due to MK_USAGE: The nvidia-docker container-runtime can only be run with the docker driver
```

<img width="813" alt="Screenshot 2023-09-25 at 10 53 49 AM" src="https://github.com/kubernetes/minikube/assets/44844360/60a6a3fc-c0e6-40d5-a2c3-25d2d303fd88">
