### PR TITLE
new flag -"-gpu" to enable Nvidia container runtime

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1289,7 +1289,7 @@ func validateFlags(cmd *cobra.Command, drvName string) {
 	}
 
 	if cmd.Flags().Changed(containerRuntime) {
-		err := validateRuntime(viper.GetString(containerRuntime))
+		err := validateRuntime(viper.GetString(containerRuntime), drvName)
 		if err != nil {
 			exit.Message(reason.Usage, "{{.err}}", out.V{"err": err})
 		}
@@ -1406,7 +1406,7 @@ func validateDiskSize(diskSize string) error {
 }
 
 // validateRuntime validates the supplied runtime
-func validateRuntime(rtime string) error {
+func validateRuntime(rtime, driverName string) error {
 	validOptions := cruntime.ValidRuntimes()
 	// `crio` is accepted as an alternative spelling to `cri-o`
 	validOptions = append(validOptions, constants.CRIO)
@@ -1435,6 +1435,11 @@ func validateRuntime(rtime string) error {
 	if !validRuntime {
 		return errors.Errorf("Invalid Container Runtime: %s. Valid runtimes are: %s", rtime, cruntime.ValidRuntimes())
 	}
+
+	if rtime == constants.NvidiaDocker && driverName != constants.Docker {
+		return errors.Errorf("The nvidia-docker container-runtime can only be run with the docker driver")
+	}
+
 	return nil
 }
 
@@ -1802,7 +1807,7 @@ func validateContainerRuntime(old *config.ClusterConfig) {
 		return
 	}
 
-	if err := validateRuntime(old.KubernetesConfig.ContainerRuntime); err != nil {
+	if err := validateRuntime(old.KubernetesConfig.ContainerRuntime, old.Driver); err != nil {
 		klog.Errorf("Error parsing old runtime %q: %v", old.KubernetesConfig.ContainerRuntime, err)
 	}
 }

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1449,7 +1449,7 @@ func validateEnableNvidiaGPUs(gpusEnabled bool, drvName, rtime string) error {
 	if !gpusEnabled {
 		return nil
 	}
-	if drvName == constants.Docker && rtime == constants.Docker {
+	if drvName == constants.Docker && (rtime == constants.Docker || rtime == constants.DefaultContainerRuntime) {
 		return nil
 	}
 	return errors.Errorf("The enable-nvidia-gpus flag can only be run with the docker driver and docker container-runtime")

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1302,8 +1302,8 @@ func validateFlags(cmd *cobra.Command, drvName string) {
 		}
 	}
 
-	if cmd.Flags().Changed(enableNvidiaGPUs) {
-		if err := validateEnableNvidiaGPUs(viper.GetBool(enableNvidiaGPUs), drvName, viper.GetString(containerRuntime)); err != nil {
+	if cmd.Flags().Changed(gpus) {
+		if err := validateGPUs(viper.GetString(gpus), drvName, viper.GetString(containerRuntime)); err != nil {
 			exit.Message(reason.Usage, "{{.err}}", out.V{"err": err})
 		}
 	}
@@ -1444,15 +1444,18 @@ func validateRuntime(rtime string) error {
 	return nil
 }
 
-// validateEnableNvidiaGPUs validates that the nvidia GPU(s) can be used with the given configuration
-func validateEnableNvidiaGPUs(gpusEnabled bool, drvName, rtime string) error {
-	if !gpusEnabled {
+// validateGPUs validates that a valid option was given, and if so, can it be used with the given configuration
+func validateGPUs(value, drvName, rtime string) error {
+	if value == "" {
 		return nil
+	}
+	if value != "nvidia" && value != "all" {
+		return errors.Errorf(`The gpus flag must be passed a value of "nvidia" or "all"`)
 	}
 	if drvName == constants.Docker && (rtime == constants.Docker || rtime == constants.DefaultContainerRuntime) {
 		return nil
 	}
-	return errors.Errorf("The enable-nvidia-gpus flag can only be run with the docker driver and docker container-runtime")
+	return errors.Errorf("The gpus flag can only be used with the docker driver and docker container-runtime")
 }
 
 func getContainerRuntime(old *config.ClusterConfig) string {

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -142,6 +142,7 @@ const (
 	socketVMnetPath         = "socket-vmnet-path"
 	staticIP                = "static-ip"
 	autoPauseInterval       = "auto-pause-interval"
+	enableNvidiaGPUs        = "enable-nvidia-gpus"
 )
 
 var (
@@ -204,6 +205,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().Bool(disableMetrics, false, "If set, disables metrics reporting (CPU and memory usage), this can improve CPU usage. Defaults to false.")
 	startCmd.Flags().String(staticIP, "", "Set a static IP for the minikube cluster, the IP must be: private, IPv4, and the last octet must be between 2 and 254, for example 192.168.200.200 (Docker and Podman drivers only)")
 	startCmd.Flags().Duration(autoPauseInterval, time.Minute*1, "Duration of inactivity before the minikube VM is paused (default 1m0s).  To disable, set to 0s")
+	startCmd.Flags().Bool(enableNvidiaGPUs, false, "If set, allows pods to use your NVIDIA GPU(s) (Docker driver with Docker container-runtime only)")
 }
 
 // initKubernetesFlags inits the commandline flags for Kubernetes related options
@@ -595,6 +597,7 @@ func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, rtime str
 		},
 		MultiNodeRequested: viper.GetInt(nodes) > 1,
 		AutoPauseInterval:  viper.GetDuration(autoPauseInterval),
+		EnableNvidiaGPUs:   viper.GetBool(enableNvidiaGPUs),
 	}
 	cc.VerifyComponents = interpretWaitFlag(*cmd)
 	if viper.GetBool(createMount) && driver.IsKIC(drvName) {

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -205,7 +205,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().Bool(disableMetrics, false, "If set, disables metrics reporting (CPU and memory usage), this can improve CPU usage. Defaults to false.")
 	startCmd.Flags().String(staticIP, "", "Set a static IP for the minikube cluster, the IP must be: private, IPv4, and the last octet must be between 2 and 254, for example 192.168.200.200 (Docker and Podman drivers only)")
 	startCmd.Flags().Duration(autoPauseInterval, time.Minute*1, "Duration of inactivity before the minikube VM is paused (default 1m0s).  To disable, set to 0s")
-	startCmd.Flags().String(gpus, "", "Allow pods to use your NVIDIA GPUs. Options include: [all,nvidia] (Docker driver with Docker container-runtime only)")
+	startCmd.Flags().StringP(gpus, "g", "", "Allow pods to use your NVIDIA GPUs. Options include: [all,nvidia] (Docker driver with Docker container-runtime only)")
 }
 
 // initKubernetesFlags inits the commandline flags for Kubernetes related options

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -142,7 +142,7 @@ const (
 	socketVMnetPath         = "socket-vmnet-path"
 	staticIP                = "static-ip"
 	autoPauseInterval       = "auto-pause-interval"
-	enableNvidiaGPUs        = "enable-nvidia-gpus"
+	gpus                    = "gpus"
 )
 
 var (
@@ -205,7 +205,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().Bool(disableMetrics, false, "If set, disables metrics reporting (CPU and memory usage), this can improve CPU usage. Defaults to false.")
 	startCmd.Flags().String(staticIP, "", "Set a static IP for the minikube cluster, the IP must be: private, IPv4, and the last octet must be between 2 and 254, for example 192.168.200.200 (Docker and Podman drivers only)")
 	startCmd.Flags().Duration(autoPauseInterval, time.Minute*1, "Duration of inactivity before the minikube VM is paused (default 1m0s).  To disable, set to 0s")
-	startCmd.Flags().Bool(enableNvidiaGPUs, false, "If set, allows pods to use your NVIDIA GPU(s) (Docker driver with Docker container-runtime only)")
+	startCmd.Flags().String(gpus, "", "Allow pods to use your NVIDIA GPUs. Options include: [all,nvidia] (Docker driver with Docker container-runtime only)")
 }
 
 // initKubernetesFlags inits the commandline flags for Kubernetes related options
@@ -597,7 +597,7 @@ func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, rtime str
 		},
 		MultiNodeRequested: viper.GetInt(nodes) > 1,
 		AutoPauseInterval:  viper.GetDuration(autoPauseInterval),
-		EnableNvidiaGPUs:   viper.GetBool(enableNvidiaGPUs),
+		GPUs:               viper.GetString(gpus),
 	}
 	cc.VerifyComponents = interpretWaitFlag(*cmd)
 	if viper.GetBool(createMount) && driver.IsKIC(drvName) {

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -859,3 +859,25 @@ func TestImageMatchesBinaryVersion(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateEnableNvidiaGPUs(t *testing.T) {
+	tests := []struct {
+		enableNvidiaGPUs bool
+		drvName          string
+		runtime          string
+		errorMsg         string
+	}{
+		{false, "kvm", "containerd", ""},
+		{true, "docker", "docker", ""},
+		{true, "docker", "", ""},
+		{true, "kvm", "docker", "The nvidia-docker container-runtime can only be run with the docker driver"},
+		{true, "docker", "containerd", "The nvidia-docker container-runtime can only be run with the docker driver"},
+	}
+
+	for _, tc := range tests {
+		got := validateEnableNvidiaGPUs(tc.enableNvidiaGPUs, tc.drvName, tc.runtime)
+		if got.Error() != tc.errorMsg {
+			t.Errorf("validateEnableNvidiaGPUs(%t, %s, %s) = %q; want = %q", tc.enableNvidiaGPUs, tc.drvName, tc.runtime, got, tc.errorMsg)
+		}
+	}
+}

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -434,7 +434,6 @@ func TestValidateDiskSize(t *testing.T) {
 func TestValidateRuntime(t *testing.T) {
 	var tests = []struct {
 		runtime  string
-		driver   string
 		errorMsg string
 	}{
 		{
@@ -449,20 +448,10 @@ func TestValidateRuntime(t *testing.T) {
 			runtime:  "test",
 			errorMsg: fmt.Sprintf("Invalid Container Runtime: test. Valid runtimes are: %v", cruntime.ValidRuntimes()),
 		},
-		{
-			runtime:  "nvidia-docker",
-			driver:   "docker",
-			errorMsg: "",
-		},
-		{
-			runtime:  "nvidia-docker",
-			driver:   "kvm",
-			errorMsg: "The nvidia-docker container-runtime can only be run with the docker driver",
-		},
 	}
 	for _, test := range tests {
 		t.Run(test.runtime, func(t *testing.T) {
-			got := validateRuntime(test.runtime, test.driver)
+			got := validateRuntime(test.runtime)
 			gotError := ""
 			if got != nil {
 				gotError = got.Error()

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -434,6 +434,7 @@ func TestValidateDiskSize(t *testing.T) {
 func TestValidateRuntime(t *testing.T) {
 	var tests = []struct {
 		runtime  string
+		driver   string
 		errorMsg string
 	}{
 		{
@@ -444,15 +445,24 @@ func TestValidateRuntime(t *testing.T) {
 			runtime:  "docker",
 			errorMsg: "",
 		},
-
 		{
 			runtime:  "test",
 			errorMsg: fmt.Sprintf("Invalid Container Runtime: test. Valid runtimes are: %v", cruntime.ValidRuntimes()),
 		},
+		{
+			runtime:  "nvidia-docker",
+			driver:   "docker",
+			errorMsg: "",
+		},
+		{
+			runtime:  "nvidia-docker",
+			driver:   "kvm",
+			errorMsg: "The nvidia-docker container-runtime can only be run with the docker driver",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.runtime, func(t *testing.T) {
-			got := validateRuntime(test.runtime)
+			got := validateRuntime(test.runtime, test.driver)
 			gotError := ""
 			if got != nil {
 				gotError = got.Error()

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -870,13 +870,17 @@ func TestValidateEnableNvidiaGPUs(t *testing.T) {
 		{false, "kvm", "containerd", ""},
 		{true, "docker", "docker", ""},
 		{true, "docker", "", ""},
-		{true, "kvm", "docker", "The nvidia-docker container-runtime can only be run with the docker driver"},
-		{true, "docker", "containerd", "The nvidia-docker container-runtime can only be run with the docker driver"},
+		{true, "kvm", "docker", "The enable-nvidia-gpus flag can only be run with the docker driver and docker container-runtime"},
+		{true, "docker", "containerd", "The enable-nvidia-gpus flag can only be run with the docker driver and docker container-runtime"},
 	}
 
 	for _, tc := range tests {
+		gotError := ""
 		got := validateEnableNvidiaGPUs(tc.enableNvidiaGPUs, tc.drvName, tc.runtime)
-		if got.Error() != tc.errorMsg {
+		if got != nil {
+			gotError = got.Error()
+		}
+		if gotError != tc.errorMsg {
 			t.Errorf("validateEnableNvidiaGPUs(%t, %s, %s) = %q; want = %q", tc.enableNvidiaGPUs, tc.drvName, tc.runtime, got, tc.errorMsg)
 		}
 	}

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -860,28 +860,31 @@ func TestImageMatchesBinaryVersion(t *testing.T) {
 	}
 }
 
-func TestValidateEnableNvidiaGPUs(t *testing.T) {
+func TestValidateGPUs(t *testing.T) {
 	tests := []struct {
-		enableNvidiaGPUs bool
-		drvName          string
-		runtime          string
-		errorMsg         string
+		gpus     string
+		drvName  string
+		runtime  string
+		errorMsg string
 	}{
-		{false, "kvm", "containerd", ""},
-		{true, "docker", "docker", ""},
-		{true, "docker", "", ""},
-		{true, "kvm", "docker", "The enable-nvidia-gpus flag can only be run with the docker driver and docker container-runtime"},
-		{true, "docker", "containerd", "The enable-nvidia-gpus flag can only be run with the docker driver and docker container-runtime"},
+		{"", "kvm", "containerd", ""},
+		{"all", "docker", "docker", ""},
+		{"nvidia", "docker", "docker", ""},
+		{"all", "docker", "", ""},
+		{"nvidia", "docker", "", ""},
+		{"all", "kvm", "docker", "The gpus flag can only be used with the docker driver and docker container-runtime"},
+		{"nvidia", "docker", "containerd", "The gpus flag can only be used with the docker driver and docker container-runtime"},
+		{"cat", "docker", "docker", `The gpus flag must be passed a value of "nvidia" or "all"`},
 	}
 
 	for _, tc := range tests {
 		gotError := ""
-		got := validateEnableNvidiaGPUs(tc.enableNvidiaGPUs, tc.drvName, tc.runtime)
+		got := validateGPUs(tc.gpus, tc.drvName, tc.runtime)
 		if got != nil {
 			gotError = got.Error()
 		}
 		if gotError != tc.errorMsg {
-			t.Errorf("validateEnableNvidiaGPUs(%t, %s, %s) = %q; want = %q", tc.enableNvidiaGPUs, tc.drvName, tc.runtime, got, tc.errorMsg)
+			t.Errorf("validateGPUs(%s, %s, %s) = %q; want = %q", tc.gpus, tc.drvName, tc.runtime, got, tc.errorMsg)
 		}
 	}
 }

--- a/deploy/addons/assets.go
+++ b/deploy/addons/assets.go
@@ -166,4 +166,8 @@ var (
 	// Kubeflow assets for kubeflow addon
 	//go:embed kubeflow/*.yaml
 	Kubeflow embed.FS
+
+	// NvidiaDevicePlugin assets for nvidia-device-plugin addon
+	//go:embed nvidia-device-plugin/*.tmpl
+	NvidiaDevicePlugin embed.FS
 )

--- a/deploy/addons/nvidia-device-plugin/nvidia-device-plugin.yaml.tmpl
+++ b/deploy/addons/nvidia-device-plugin/nvidia-device-plugin.yaml.tmpl
@@ -1,0 +1,56 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-device-plugin-daemonset
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      name: nvidia-device-plugin-ds
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: nvidia-device-plugin-ds
+    spec:
+      tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      # Mark this pod as a critical add-on; when enabled, the critical add-on
+      # scheduler reserves resources for critical add-on pods so that they can
+      # be rescheduled after a failure.
+      # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+      priorityClassName: "system-node-critical"
+      containers:
+      - image: {{.CustomRegistries.NvidiaDevicePlugin | default .ImageRepository | default .Registries.NvidiaDevicePlugin}}{{.Images.NvidiaDevicePlugin}}
+        name: nvidia-device-plugin-ctr
+        env:
+          - name: FAIL_ON_INIT_ERROR
+            value: "false"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        volumeMounts:
+        - name: device-plugin
+          mountPath: /var/lib/kubelet/device-plugins
+      volumes:
+      - name: device-plugin
+        hostPath:
+          path: /var/lib/kubelet/device-plugins

--- a/pkg/addons/config.go
+++ b/pkg/addons/config.go
@@ -227,4 +227,9 @@ var Addons = []*Addon{
 		set:       SetBool,
 		callbacks: []setFn{EnableOrDisableAddon},
 	},
+	{
+		name:      "nvidia-device-plugin",
+		set:       SetBool,
+		callbacks: []setFn{EnableOrDisableAddon},
+	},
 }

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -90,6 +90,9 @@ func (d *Driver) Create() error {
 		APIServerPort: d.NodeConfig.APIServerPort,
 	}
 
+	if d.NodeConfig.ContainerRuntime == constants.NvidiaDocker {
+		params.GPUs = true
+	}
 	networkName := d.NodeConfig.Network
 	if networkName == "" {
 		networkName = d.NodeConfig.ClusterName

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -77,22 +77,20 @@ func NewDriver(c Config) *Driver {
 func (d *Driver) Create() error {
 	ctx := context.Background()
 	params := oci.CreateParams{
-		Mounts:        d.NodeConfig.Mounts,
-		Name:          d.NodeConfig.MachineName,
-		Image:         d.NodeConfig.ImageDigest,
-		ClusterLabel:  oci.ProfileLabelKey + "=" + d.MachineName,
-		NodeLabel:     oci.NodeLabelKey + "=" + d.NodeConfig.MachineName,
-		CPUs:          strconv.Itoa(d.NodeConfig.CPU),
-		Memory:        strconv.Itoa(d.NodeConfig.Memory) + "mb",
-		Envs:          d.NodeConfig.Envs,
-		ExtraArgs:     append([]string{"--expose", fmt.Sprintf("%d", d.NodeConfig.APIServerPort)}, d.NodeConfig.ExtraArgs...),
-		OCIBinary:     d.NodeConfig.OCIBinary,
-		APIServerPort: d.NodeConfig.APIServerPort,
+		Mounts:           d.NodeConfig.Mounts,
+		Name:             d.NodeConfig.MachineName,
+		Image:            d.NodeConfig.ImageDigest,
+		ClusterLabel:     oci.ProfileLabelKey + "=" + d.MachineName,
+		NodeLabel:        oci.NodeLabelKey + "=" + d.NodeConfig.MachineName,
+		CPUs:             strconv.Itoa(d.NodeConfig.CPU),
+		Memory:           strconv.Itoa(d.NodeConfig.Memory) + "mb",
+		Envs:             d.NodeConfig.Envs,
+		ExtraArgs:        append([]string{"--expose", fmt.Sprintf("%d", d.NodeConfig.APIServerPort)}, d.NodeConfig.ExtraArgs...),
+		OCIBinary:        d.NodeConfig.OCIBinary,
+		APIServerPort:    d.NodeConfig.APIServerPort,
+		EnableNvidiaGPUs: d.NodeConfig.EnableNvidiaGPUs,
 	}
 
-	if d.NodeConfig.ContainerRuntime == constants.NvidiaDocker {
-		params.GPUs = true
-	}
 	networkName := d.NodeConfig.Network
 	if networkName == "" {
 		networkName = d.NodeConfig.ClusterName
@@ -455,7 +453,7 @@ func (d *Driver) Stop() error {
 		}
 	}
 
-	runtime, err := cruntime.New(cruntime.Config{Type: d.NodeConfig.ContainerRuntime, Runner: d.exec})
+	runtime, err := cruntime.New(cruntime.Config{Type: d.NodeConfig.ContainerRuntime, Runner: d.exec, EnableNvidiaGPUs: d.NodeConfig.EnableNvidiaGPUs})
 	if err != nil { // won't return error because:
 		// even though we can't stop the cotainers inside, we still wanna stop the minikube container itself
 		klog.Errorf("unable to get container runtime: %v", err)

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -77,18 +77,18 @@ func NewDriver(c Config) *Driver {
 func (d *Driver) Create() error {
 	ctx := context.Background()
 	params := oci.CreateParams{
-		Mounts:           d.NodeConfig.Mounts,
-		Name:             d.NodeConfig.MachineName,
-		Image:            d.NodeConfig.ImageDigest,
-		ClusterLabel:     oci.ProfileLabelKey + "=" + d.MachineName,
-		NodeLabel:        oci.NodeLabelKey + "=" + d.NodeConfig.MachineName,
-		CPUs:             strconv.Itoa(d.NodeConfig.CPU),
-		Memory:           strconv.Itoa(d.NodeConfig.Memory) + "mb",
-		Envs:             d.NodeConfig.Envs,
-		ExtraArgs:        append([]string{"--expose", fmt.Sprintf("%d", d.NodeConfig.APIServerPort)}, d.NodeConfig.ExtraArgs...),
-		OCIBinary:        d.NodeConfig.OCIBinary,
-		APIServerPort:    d.NodeConfig.APIServerPort,
-		EnableNvidiaGPUs: d.NodeConfig.EnableNvidiaGPUs,
+		Mounts:        d.NodeConfig.Mounts,
+		Name:          d.NodeConfig.MachineName,
+		Image:         d.NodeConfig.ImageDigest,
+		ClusterLabel:  oci.ProfileLabelKey + "=" + d.MachineName,
+		NodeLabel:     oci.NodeLabelKey + "=" + d.NodeConfig.MachineName,
+		CPUs:          strconv.Itoa(d.NodeConfig.CPU),
+		Memory:        strconv.Itoa(d.NodeConfig.Memory) + "mb",
+		Envs:          d.NodeConfig.Envs,
+		ExtraArgs:     append([]string{"--expose", fmt.Sprintf("%d", d.NodeConfig.APIServerPort)}, d.NodeConfig.ExtraArgs...),
+		OCIBinary:     d.NodeConfig.OCIBinary,
+		APIServerPort: d.NodeConfig.APIServerPort,
+		GPUs:          d.NodeConfig.GPUs,
 	}
 
 	networkName := d.NodeConfig.Network

--- a/pkg/drivers/kic/kic.go
+++ b/pkg/drivers/kic/kic.go
@@ -453,7 +453,7 @@ func (d *Driver) Stop() error {
 		}
 	}
 
-	runtime, err := cruntime.New(cruntime.Config{Type: d.NodeConfig.ContainerRuntime, Runner: d.exec, EnableNvidiaGPUs: d.NodeConfig.EnableNvidiaGPUs})
+	runtime, err := cruntime.New(cruntime.Config{Type: d.NodeConfig.ContainerRuntime, Runner: d.exec})
 	if err != nil { // won't return error because:
 		// even though we can't stop the cotainers inside, we still wanna stop the minikube container itself
 		klog.Errorf("unable to get container runtime: %v", err)

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -190,7 +190,7 @@ func CreateContainerNode(p CreateParams) error {
 		runArgs = append(runArgs, "--network", p.Network)
 		runArgs = append(runArgs, "--ip", p.IP)
 	}
-	if p.GPUs {
+	if p.EnableNvidiaGPUs {
 		runArgs = append(runArgs, "--gpus", "all")
 	}
 

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -190,7 +190,7 @@ func CreateContainerNode(p CreateParams) error {
 		runArgs = append(runArgs, "--network", p.Network)
 		runArgs = append(runArgs, "--ip", p.IP)
 	}
-	if p.EnableNvidiaGPUs {
+	if p.GPUs != "" {
 		runArgs = append(runArgs, "--gpus", "all")
 	}
 

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -190,6 +190,9 @@ func CreateContainerNode(p CreateParams) error {
 		runArgs = append(runArgs, "--network", p.Network)
 		runArgs = append(runArgs, "--ip", p.IP)
 	}
+	if p.GPUs {
+		runArgs = append(runArgs, "--gpus", "all")
+	}
 
 	memcgSwap := hasMemorySwapCgroup()
 	memcg := HasMemoryCgroup()

--- a/pkg/drivers/kic/oci/types.go
+++ b/pkg/drivers/kic/oci/types.go
@@ -58,7 +58,8 @@ type CreateParams struct {
 	ExtraArgs     []string          // a list of any extra option to pass to oci binary during creation time, for example --expose 8080...
 	OCIBinary     string            // docker or podman
 	Network       string            // network name that the container will attach to
-	IP            string            // static IP to assign for th container in the cluster network
+	IP            string            // static IP to assign the container in the cluster network
+	GPUs          bool              // add GPU devices to the container
 }
 
 // createOpt is an option for Create

--- a/pkg/drivers/kic/oci/types.go
+++ b/pkg/drivers/kic/oci/types.go
@@ -43,23 +43,23 @@ const (
 
 // CreateParams are parameters needed to create a container
 type CreateParams struct {
-	ClusterName      string            // cluster(profile name) that this container belongs to
-	Name             string            // used for container name and hostname
-	Image            string            // container image to use to create the node.
-	ClusterLabel     string            // label the clusters we create using minikube so we can clean up
-	NodeLabel        string            // label the nodes so we can clean up by node name
-	Role             string            // currently only role supported is control-plane
-	Mounts           []Mount           // volume mounts
-	APIServerPort    int               // Kubernetes api server port
-	PortMappings     []PortMapping     // ports to map to container from host
-	CPUs             string            // number of cpu cores assign to container
-	Memory           string            // memory (mbs) to assign to the container
-	Envs             map[string]string // environment variables to pass to the container
-	ExtraArgs        []string          // a list of any extra option to pass to oci binary during creation time, for example --expose 8080...
-	OCIBinary        string            // docker or podman
-	Network          string            // network name that the container will attach to
-	IP               string            // static IP to assign the container in the cluster network
-	EnableNvidiaGPUs bool              // add NVIDIA GPU devices to the container
+	ClusterName   string            // cluster(profile name) that this container belongs to
+	Name          string            // used for container name and hostname
+	Image         string            // container image to use to create the node.
+	ClusterLabel  string            // label the clusters we create using minikube so we can clean up
+	NodeLabel     string            // label the nodes so we can clean up by node name
+	Role          string            // currently only role supported is control-plane
+	Mounts        []Mount           // volume mounts
+	APIServerPort int               // Kubernetes api server port
+	PortMappings  []PortMapping     // ports to map to container from host
+	CPUs          string            // number of cpu cores assign to container
+	Memory        string            // memory (mbs) to assign to the container
+	Envs          map[string]string // environment variables to pass to the container
+	ExtraArgs     []string          // a list of any extra option to pass to oci binary during creation time, for example --expose 8080...
+	OCIBinary     string            // docker or podman
+	Network       string            // network name that the container will attach to
+	IP            string            // static IP to assign the container in the cluster network
+	GPUs          string            // add NVIDIA GPU devices to the container
 }
 
 // createOpt is an option for Create

--- a/pkg/drivers/kic/oci/types.go
+++ b/pkg/drivers/kic/oci/types.go
@@ -43,23 +43,23 @@ const (
 
 // CreateParams are parameters needed to create a container
 type CreateParams struct {
-	ClusterName   string            // cluster(profile name) that this container belongs to
-	Name          string            // used for container name and hostname
-	Image         string            // container image to use to create the node.
-	ClusterLabel  string            // label the clusters we create using minikube so we can clean up
-	NodeLabel     string            // label the nodes so we can clean up by node name
-	Role          string            // currently only role supported is control-plane
-	Mounts        []Mount           // volume mounts
-	APIServerPort int               // Kubernetes api server port
-	PortMappings  []PortMapping     // ports to map to container from host
-	CPUs          string            // number of cpu cores assign to container
-	Memory        string            // memory (mbs) to assign to the container
-	Envs          map[string]string // environment variables to pass to the container
-	ExtraArgs     []string          // a list of any extra option to pass to oci binary during creation time, for example --expose 8080...
-	OCIBinary     string            // docker or podman
-	Network       string            // network name that the container will attach to
-	IP            string            // static IP to assign the container in the cluster network
-	GPUs          bool              // add GPU devices to the container
+	ClusterName      string            // cluster(profile name) that this container belongs to
+	Name             string            // used for container name and hostname
+	Image            string            // container image to use to create the node.
+	ClusterLabel     string            // label the clusters we create using minikube so we can clean up
+	NodeLabel        string            // label the nodes so we can clean up by node name
+	Role             string            // currently only role supported is control-plane
+	Mounts           []Mount           // volume mounts
+	APIServerPort    int               // Kubernetes api server port
+	PortMappings     []PortMapping     // ports to map to container from host
+	CPUs             string            // number of cpu cores assign to container
+	Memory           string            // memory (mbs) to assign to the container
+	Envs             map[string]string // environment variables to pass to the container
+	ExtraArgs        []string          // a list of any extra option to pass to oci binary during creation time, for example --expose 8080...
+	OCIBinary        string            // docker or podman
+	Network          string            // network name that the container will attach to
+	IP               string            // static IP to assign the container in the cluster network
+	EnableNvidiaGPUs bool              // add NVIDIA GPU devices to the container
 }
 
 // createOpt is an option for Create

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -69,5 +69,5 @@ type Config struct {
 	StaticIP          string            // static IP for the kic cluster
 	ExtraArgs         []string          // a list of any extra option to pass to oci binary during creation time, for example --expose 8080...
 	ListenAddress     string            // IP Address to listen to
-	EnableNvidiaGPUs  bool              // add NVIDIA GPU devices to the container
+	GPUs              string            // add NVIDIA GPU devices to the container
 }

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -69,4 +69,5 @@ type Config struct {
 	StaticIP          string            // static IP for the kic cluster
 	ExtraArgs         []string          // a list of any extra option to pass to oci binary during creation time, for example --expose 8080...
 	ListenAddress     string            // IP Address to listen to
+	EnableNvidiaGPUs  bool              // add NVIDIA GPU devices to the container
 }

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -93,6 +93,11 @@ func (a *Addon) IsEnabledOrDefault(cc *config.ClusterConfig) bool {
 	return a.enabled
 }
 
+// EnableByDefault will enable the addon by default on cluster start
+func (a *Addon) EnableByDefault() {
+	a.enabled = true
+}
+
 // Addons is the list of addons
 // TODO: Make dynamically loadable: move this data to a .yaml file within each addon directory
 var Addons = map[string]*Addon{
@@ -774,6 +779,14 @@ var Addons = map[string]*Addon{
 		MustBinAsset(addons.Kubeflow, "kubeflow/kubeflow.yaml", vmpath.GuestAddonsDir, "kubeflow.yaml", "0640"),
 	}, false, "kubeflow", "3rd party", "", "", nil, nil,
 	),
+	"nvidia-device-plugin": NewAddon([]*BinAsset{
+		MustBinAsset(addons.NvidiaDevicePlugin, "nvidia-device-plugin/nvidia-device-plugin.yaml.tmpl", vmpath.GuestAddonsDir, "nvidia-device-plugin.yaml", "0640"),
+	}, false, "nvidia-device-plugin", "3rd party (NVIDIA)", "", "",
+		map[string]string{
+			"NvidiaDevicePlugin": "nvidia/k8s-device-plugin:v0.14.1@sha256:15c4280d13a61df703b12d1fd1b5b5eec4658157db3cb4b851d3259502310136",
+		}, map[string]string{
+			"NvidiaDevicePlugin": "nvcr.io",
+		}),
 }
 
 // parseMapString creates a map based on `str` which is encoded as <key1>=<value1>,<key2>=<value2>,...

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -108,7 +108,7 @@ type ClusterConfig struct {
 	SSHAuthSock             string
 	SSHAgentPID             int
 	AutoPauseInterval       time.Duration // Specifies interval of time to wait before checking if cluster should be paused
-	EnableNvidiaGPUs        bool
+	GPUs                    string
 }
 
 // KubernetesConfig contains the parameters used to configure the VM Kubernetes.

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -108,6 +108,7 @@ type ClusterConfig struct {
 	SSHAuthSock             string
 	SSHAgentPID             int
 	AutoPauseInterval       time.Duration // Specifies interval of time to wait before checking if cluster should be paused
+	EnableNvidiaGPUs        bool
 }
 
 // KubernetesConfig contains the parameters used to configure the VM Kubernetes.

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -63,8 +63,6 @@ const (
 	CRIO = "crio"
 	// Docker is the default name and spelling for the docker container runtime
 	Docker = "docker"
-	// NvidiaDocker is the default name and spelling for the nvidia-docker container runtime
-	NvidiaDocker = "nvidia-docker"
 	// DefaultContainerRuntime is our default container runtime
 	DefaultContainerRuntime = ""
 

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -63,6 +63,8 @@ const (
 	CRIO = "crio"
 	// Docker is the default name and spelling for the docker container runtime
 	Docker = "docker"
+	// NvidiaDocker is the default name and spelling for the nvidia-docker container runtime
+	NvidiaDocker = "nvidia-docker"
 	// DefaultContainerRuntime is our default container runtime
 	DefaultContainerRuntime = ""
 

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -155,8 +155,8 @@ type Config struct {
 	KubernetesVersion semver.Version
 	// InsecureRegistry list of insecure registries
 	InsecureRegistry []string
-	// EnableNvidiaGPUs add GPU devices to the container
-	EnableNvidiaGPUs bool
+	// GPUs add GPU devices to the container
+	GPUs bool
 }
 
 // ListContainersOptions are the options to use for listing containers
@@ -229,7 +229,7 @@ func New(c Config) (Manager, error) {
 			Init:              sm,
 			UseCRI:            (sp != ""), // !dockershim
 			CRIService:        cs,
-			NvidiaGPUs:        c.EnableNvidiaGPUs,
+			GPUs:              c.GPUs,
 		}, nil
 	case "crio", "cri-o":
 		return &CRIO{

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -50,7 +50,7 @@ func (cs ContainerState) String() string {
 
 // ValidRuntimes lists the supported container runtimes
 func ValidRuntimes() []string {
-	return []string{"docker", "nvidia-docker", "cri-o", "containerd"}
+	return []string{"docker", "cri-o", "containerd"}
 }
 
 // CommandRunner is the subset of command.Runner this package consumes
@@ -155,6 +155,8 @@ type Config struct {
 	KubernetesVersion semver.Version
 	// InsecureRegistry list of insecure registries
 	InsecureRegistry []string
+	// EnableNvidiaGPUs add GPU devices to the container
+	EnableNvidiaGPUs bool
 }
 
 // ListContainersOptions are the options to use for listing containers
@@ -210,7 +212,7 @@ func New(c Config) (Manager, error) {
 	sm := sysinit.New(c.Runner)
 
 	switch c.Type {
-	case "", "docker", "nvidia-docker":
+	case "", "docker":
 		sp := c.Socket
 		cs := ""
 		// There is no more dockershim socket, in Kubernetes version 1.24 and beyond
@@ -219,7 +221,6 @@ func New(c Config) (Manager, error) {
 			cs = "cri-docker.socket"
 		}
 		return &Docker{
-			Type:              c.Type,
 			Socket:            sp,
 			Runner:            c.Runner,
 			NetworkPlugin:     c.NetworkPlugin,
@@ -228,6 +229,7 @@ func New(c Config) (Manager, error) {
 			Init:              sm,
 			UseCRI:            (sp != ""), // !dockershim
 			CRIService:        cs,
+			NvidiaGPUs:        c.EnableNvidiaGPUs,
 		}, nil
 	case "crio", "cri-o":
 		return &CRIO{

--- a/pkg/minikube/cruntime/cruntime_test.go
+++ b/pkg/minikube/cruntime/cruntime_test.go
@@ -40,7 +40,6 @@ func TestName(t *testing.T) {
 	}{
 		{"", "Docker"},
 		{"docker", "Docker"},
-		{"nvidia-docker", "Docker"},
 		{"crio", "CRI-O"},
 		{"cri-o", "CRI-O"},
 		{"containerd", "containerd"},
@@ -125,7 +124,6 @@ func TestCGroupDriver(t *testing.T) {
 		want    string
 	}{
 		{"docker", "cgroupfs"},
-		{"nvidia-docker", "cgroupfs"},
 		{"crio", "cgroupfs"},
 		{"containerd", "cgroupfs"},
 	}
@@ -155,12 +153,6 @@ func TestKubeletOptions(t *testing.T) {
 	}{
 		{"docker", "1.23.0", map[string]string{"container-runtime": "docker"}},
 		{"docker", "1.24.0", map[string]string{
-			"container-runtime-endpoint": "unix:///var/run/cri-dockerd.sock",
-		}},
-		{"nvidia-docker", "1.23.0", map[string]string{
-			"container-runtime": "docker",
-		}},
-		{"nvidia-docker", "1.25.0", map[string]string{
 			"container-runtime-endpoint": "unix:///var/run/cri-dockerd.sock",
 		}},
 		{"crio", "1.25.0", map[string]string{
@@ -688,13 +680,6 @@ func TestEnable(t *testing.T) {
 				"crio":          SvcExited,
 				"crio-shutdown": SvcExited,
 			}},
-		{"nvidia-docker", defaultServices,
-			map[string]serviceState{
-				"docker":        SvcRestarted,
-				"containerd":    SvcExited,
-				"crio":          SvcExited,
-				"crio-shutdown": SvcExited,
-			}},
 		{"containerd", defaultServices,
 			map[string]serviceState{
 				"docker":        SvcExited,
@@ -736,7 +721,6 @@ func TestContainerFunctions(t *testing.T) {
 		runtime string
 	}{
 		{"docker"},
-		{"nvidia-docker"},
 		{"crio"},
 		{"containerd"},
 	}
@@ -746,7 +730,7 @@ func TestContainerFunctions(t *testing.T) {
 		t.Run(tc.runtime, func(t *testing.T) {
 			runner := NewFakeRunner(t)
 			prefix := ""
-			if tc.runtime == "docker" || tc.runtime == "nvidia-docker" {
+			if tc.runtime == "docker" {
 				prefix = "k8s_"
 			}
 			runner.containers = map[string]string{

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -76,7 +76,7 @@ type Docker struct {
 	Init              sysinit.Manager
 	UseCRI            bool
 	CRIService        string
-	NvidiaGPUs        bool
+	GPUs              bool
 }
 
 // Name is a human readable name for Docker
@@ -561,7 +561,7 @@ func (r *Docker) configureDocker(driver string) error {
 		},
 		StorageDriver: "overlay2",
 	}
-	if r.NvidiaGPUs {
+	if r.GPUs {
 		if err := r.installNvidiaContainerToolkit(); err != nil {
 			return fmt.Errorf("failed installing the NVIDIA Container Toolkit: %v", err)
 		}

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -582,6 +582,7 @@ func (r *Docker) configureDocker(driver string) error {
 // installNvidiaContainerToolkit installs the NVIDIA Container Toolkit
 // https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
 func (r *Docker) installNvidiaContainerToolkit() error {
+	out.Styled(style.Warning, "Using GPUs with the Docker driver is experimental, if you experience any issues please report them at: https://github.com/kubernetes/minikube/issues/new/choose")
 	out.Styled(style.Toolkit, "Installing the NVIDIA Container Toolkit...")
 	cmds := []string{
 		"curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg",

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -68,7 +68,6 @@ func (e *ErrISOFeature) Error() string {
 
 // Docker contains Docker runtime state
 type Docker struct {
-	Type              string
 	Socket            string
 	Runner            CommandRunner
 	NetworkPlugin     string
@@ -77,6 +76,7 @@ type Docker struct {
 	Init              sysinit.Manager
 	UseCRI            bool
 	CRIService        string
+	NvidiaGPUs        bool
 }
 
 // Name is a human readable name for Docker
@@ -561,7 +561,7 @@ func (r *Docker) configureDocker(driver string) error {
 		},
 		StorageDriver: "overlay2",
 	}
-	if r.Type == constants.NvidiaDocker {
+	if r.NvidiaGPUs {
 		if err := r.installNvidiaContainerToolkit(); err != nil {
 			return fmt.Errorf("failed installing the NVIDIA Container Toolkit: %v", err)
 		}

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -394,7 +394,9 @@ func configureRuntimes(runner cruntime.CommandRunner, cc config.ClusterConfig, k
 		ImageRepository:   cc.KubernetesConfig.ImageRepository,
 		KubernetesVersion: kv,
 		InsecureRegistry:  cc.InsecureRegistry,
-		EnableNvidiaGPUs:  cc.EnableNvidiaGPUs,
+	}
+	if cc.GPUs != "" {
+		co.GPUs = true
 	}
 	cr, err := cruntime.New(co)
 	if err != nil {

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -394,6 +394,7 @@ func configureRuntimes(runner cruntime.CommandRunner, cc config.ClusterConfig, k
 		ImageRepository:   cc.KubernetesConfig.ImageRepository,
 		KubernetesVersion: kv,
 		InsecureRegistry:  cc.InsecureRegistry,
+		EnableNvidiaGPUs:  cc.EnableNvidiaGPUs,
 	}
 	cr, err := cruntime.New(co)
 	if err != nil {

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -90,6 +90,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		Subnet:            cc.Subnet,
 		StaticIP:          cc.StaticIP,
 		ListenAddress:     cc.ListenAddress,
+		EnableNvidiaGPUs:  cc.EnableNvidiaGPUs,
 	}), nil
 }
 

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -90,7 +90,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		Subnet:            cc.Subnet,
 		StaticIP:          cc.StaticIP,
 		ListenAddress:     cc.ListenAddress,
-		EnableNvidiaGPUs:  cc.EnableNvidiaGPUs,
+		GPUs:              cc.GPUs,
 	}), nil
 }
 

--- a/pkg/minikube/style/style.go
+++ b/pkg/minikube/style/style.go
@@ -139,6 +139,7 @@ var Config = map[Enum]Options{
 	VerifyingNoLine:  {Prefix: "🤔  ", OmitNewline: true},
 	Verifying:        {Prefix: "🤔  "},
 	CNI:              {Prefix: "🔗  "},
+	Toolkit:          {Prefix: "🛠️   "},
 }
 
 // LowPrefix returns a 7-bit compatible prefix for a style

--- a/pkg/minikube/style/style_enum.go
+++ b/pkg/minikube/style/style_enum.go
@@ -105,4 +105,5 @@ const (
 	Warning
 	Workaround
 	CNI
+	Toolkit
 )

--- a/site/content/en/docs/tutorials/nvidia.md
+++ b/site/content/en/docs/tutorials/nvidia.md
@@ -34,7 +34,7 @@ date: 2018-01-02
   ```
 - Start minikube:
   ```shell
-  minikube start --driver docker --container-runtime nvidia-docker
+  minikube start --driver docker --container-runtime docker --enable-nvidia-gpus
   ```
 {{% /tab %}}
 {{% tab none %}}

--- a/site/content/en/docs/tutorials/nvidia.md
+++ b/site/content/en/docs/tutorials/nvidia.md
@@ -9,6 +9,7 @@ date: 2018-01-02
 
 - Linux
 - Latest NVIDIA GPU drivers
+- minikube v1.32.0-beta0 or later (docker driver only)
 
 ## Instructions per driver
 

--- a/site/content/en/docs/tutorials/nvidia.md
+++ b/site/content/en/docs/tutorials/nvidia.md
@@ -34,7 +34,7 @@ date: 2018-01-02
   ```
 - Start minikube:
   ```shell
-  minikube start --driver docker --container-runtime docker --enable-nvidia-gpus
+  minikube start --driver docker --container-runtime docker --gpus all
   ```
 {{% /tab %}}
 {{% tab none %}}

--- a/site/content/en/docs/tutorials/nvidia.md
+++ b/site/content/en/docs/tutorials/nvidia.md
@@ -1,6 +1,6 @@
 ---
-title: "Using the Nvidia Addons"
-linkTitle: "Nvidia"
+title: "Using NVIDIA GPUs with minikube"
+linkTitle: "Using NVIDIA GPUs with minikube"
 weight: 1
 date: 2018-01-02
 ---
@@ -8,17 +8,66 @@ date: 2018-01-02
 ## Prerequisites
 
 - Linux
-- kvm2 driver
 - Latest NVIDIA GPU drivers
 
-## Using the KVM2 driver
+## Instructions per driver
 
-When using NVIDIA GPUs with the kvm2 driver, we passthrough spare GPUs on the
+{{% tabs %}}
+{{% tab docker %}}
+## Using the docker driver
+
+- Check if `bpf_jit_harden` is set to `0`
+  ```shell
+  sudo sysctl net.core.bpf_jit_harden
+  ```
+  - If it's not `0` run:
+  ```shell
+  echo "net.core.bpf_jit_harden=0" | sudo tee -a /etc/sysctl.conf
+  sudo sysctl -p
+  ```
+
+- Install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) on your host machine
+
+- Configure Docker:
+  ```shell
+  sudo nvidia-ctk runtime configure --runtime=docker && sudo systemctl restart docker
+  ```
+- Start minikube:
+  ```shell
+  minikube start --driver docker --container-runtime nvidia-docker
+  ```
+{{% /tab %}}
+{{% tab none %}}
+## Using the 'none' driver
+
+NOTE: This approach used to expose GPUs here is different than the approach used
+to expose GPUs with `--driver=kvm`. Please don't mix these instructions.
+
+- Install minikube.
+
+- Install the nvidia driver, nvidia-docker and configure docker with nvidia as
+  the default runtime. See instructions at
+  <https://github.com/NVIDIA/nvidia-docker>
+
+- Start minikube:
+  ```shell
+  minikube start --driver=none --apiserver-ips 127.0.0.1 --apiserver-name localhost
+  ```
+
+- Install NVIDIA's device plugin:
+  ```shell
+  minikube addons enable nvidia-device-plugin
+  ```
+{{% /tab %}}
+{{% tab kvm %}}
+## Using the kvm driver
+
+When using NVIDIA GPUs with the kvm driver, we passthrough spare GPUs on the
 host to the minikube VM. Doing so has a few prerequisites:
 
-- You must install the [kvm2 driver]({{< ref "/docs/drivers/kvm2" >}}) If you already had
+- You must install the [kvm driver]({{< ref "/docs/drivers/kvm2" >}}) If you already had
   this installed make sure that you fetch the latest
-  `docker-machine-driver-kvm2` binary that has GPU support.
+  `docker-machine-driver-kvm` binary that has GPU support.
 
 - Your CPU must support IOMMU. Different vendors have different names for this
   technology. Intel calls it Intel VT-d. AMD calls it AMD-Vi. Your motherboard
@@ -40,9 +89,9 @@ host to the minikube VM. Doing so has a few prerequisites:
   group of these GPUs.
 
 - Once you reboot the system after doing the above, you should be ready to use
-  GPUs with kvm2. Run the following command to start minikube:
+  GPUs with kvm. Run the following command to start minikube:
   ```shell
-  minikube start --driver kvm2 --kvm-gpu
+  minikube start --driver kvm --kvm-gpu
   ```
 
   This command will check if all the above conditions are satisfied and
@@ -68,31 +117,12 @@ host to the minikube VM. Doing so has a few prerequisites:
 See the excellent documentation at
 <https://wiki.archlinux.org/index.php/PCI_passthrough_via_OVMF>
 
-### Why are so many manual steps required to use GPUs with kvm2 on minikube?
+### Why are so many manual steps required to use GPUs with kvm on minikube?
 
 These steps require elevated privileges which minikube doesn't run with and they
 are disruptive to the host, so we decided to not do them automatically.
-
-## Using the 'none' driver
-
-NOTE: This approach used to expose GPUs here is different than the approach used
-to expose GPUs with `--driver=kvm2`. Please don't mix these instructions.
-
-- Install minikube.
-
-- Install the nvidia driver, nvidia-docker and configure docker with nvidia as
-  the default runtime. See instructions at
-  <https://github.com/NVIDIA/nvidia-docker>
-
-- Start minikube:
-  ```shell
-  minikube start --driver=none --apiserver-ips 127.0.0.1 --apiserver-name localhost
-  ```
-
-- Install NVIDIA's device plugin:
-  ```shell
-  kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/master/nvidia-device-plugin.yml
-  ```
+{{% /tab %}}
+{{% /tabs %}}
 
 ## Why does minikube not support NVIDIA GPUs on macOS?
 
@@ -102,7 +132,7 @@ drivers supported by minikube for macOS doesn't support GPU passthrough:
 - [moby/hyperkit#159](https://github.com/moby/hyperkit/issues/159)
 - [VirtualBox docs](https://www.virtualbox.org/manual/ch09.html#pcipassthrough)
 
-Also:
+Also: 
 
 - For quite a while, all Mac hardware (both laptops and desktops) have come with
   Intel or AMD GPUs (and not with NVIDIA GPUs). Recently, Apple added [support

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -948,7 +948,7 @@ func validateDisablingAddonOnNonExistingCluster(ctx context.Context, t *testing.
 func validateNvidiaDevicePlugin(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 
-	if _, err := PodWait(ctx, t, profile, "kube-system", "nvidia-device-plugin-ds", Minutes(6)); err != nil {
+	if _, err := PodWait(ctx, t, profile, "kube-system", "name=nvidia-device-plugin-ds", Minutes(6)); err != nil {
 		t.Fatalf("failed waiting for nvidia-device-plugin-ds pod: %v", err)
 	}
 	if rr, err := Run(t, exec.CommandContext(ctx, Target(), "addons", "disable", "nvidia-device-plugin", "-p", profile)); err != nil {

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -948,7 +948,7 @@ func validateDisablingAddonOnNonExistingCluster(ctx context.Context, t *testing.
 func validateNvidiaDevicePlugin(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 
-	if _, err := PodWait(ctx, t, profile, "kube-system", "nvidia-device-plugin-ds", Minutes(1)); err != nil {
+	if _, err := PodWait(ctx, t, profile, "kube-system", "nvidia-device-plugin-ds", Minutes(6)); err != nil {
 		t.Fatalf("failed waiting for nvidia-device-plugin-ds pod: %v", err)
 	}
 	if rr, err := Run(t, exec.CommandContext(ctx, Target(), "addons", "disable", "nvidia-device-plugin", "-p", profile)); err != nil {

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -99,7 +99,7 @@ func TestAddons(t *testing.T) {
 		// so we override that here to let minikube auto-detect appropriate cgroup driver
 		os.Setenv(constants.MinikubeForceSystemdEnv, "")
 
-		args := append([]string{"start", "-p", profile, "--wait=true", "--memory=4000", "--alsologtostderr", "--addons=registry", "--addons=metrics-server", "--addons=volumesnapshots", "--addons=csi-hostpath-driver", "--addons=gcp-auth", "--addons=cloud-spanner", "--addons=inspektor-gadget", "--addons=storage-provisioner-rancher"}, StartArgs()...)
+		args := append([]string{"start", "-p", profile, "--wait=true", "--memory=4000", "--alsologtostderr", "--addons=registry", "--addons=metrics-server", "--addons=volumesnapshots", "--addons=csi-hostpath-driver", "--addons=gcp-auth", "--addons=cloud-spanner", "--addons=inspektor-gadget", "--addons=storage-provisioner-rancher", "--addons=nvidia-device-plugin"}, StartArgs()...)
 		if !NoneDriver() { // none driver does not support ingress
 			args = append(args, "--addons=ingress", "--addons=ingress-dns")
 		}
@@ -133,6 +133,7 @@ func TestAddons(t *testing.T) {
 			{"Headlamp", validateHeadlampAddon},
 			{"CloudSpanner", validateCloudSpannerAddon},
 			{"LocalPath", validateLocalPathAddon},
+			{"NvidiaDevicePlugin", validateNvidiaDevicePlugin},
 		}
 		for _, tc := range tests {
 			tc := tc
@@ -940,5 +941,17 @@ func validateDisablingAddonOnNonExistingCluster(ctx context.Context, t *testing.
 	}
 	if !strings.Contains(rr.Output(), "To start a cluster, run") {
 		t.Fatalf("unexpected error was returned: %v", err)
+	}
+}
+
+// validateNvidiaDevicePlugin tests the nvidia-device-plugin addon by ensuring the pod comes up and the addon disables
+func validateNvidiaDevicePlugin(ctx context.Context, t *testing.T, profile string) {
+	defer PostMortemLogs(t, profile)
+
+	if _, err := PodWait(ctx, t, profile, "kube-system", "nvidia-device-plugin-ds", Minutes(1)); err != nil {
+		t.Fatalf("failed waiting for nvidia-device-plugin-ds pod: %v", err)
+	}
+	if rr, err := Run(t, exec.CommandContext(ctx, Target(), "addons", "disable", "nvidia-device-plugin", "-p", profile)); err != nil {
+		t.Errorf("failed to disable nvidia-device-plugin: args %q : %v", rr.Command(), err)
 	}
 }


### PR DESCRIPTION
Rework of https://github.com/kubernetes/minikube/pull/17287 that removes the `nvidia-docker` container-runtime and uses the `--gpus` flag instead.

```
$ minikube start --gpus all
😄  minikube v1.31.2 on Debian rodete
✨  Using the docker driver based on user configuration
📌  Using Docker driver with root privileges
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=32100MB) ...
❗  Using GPUs with the Docker driver is experimental, if you experience any issues please report them at: https://github.com/kubernetes/minikube/issues/new/choose
🛠️   Installing the NVIDIA Container Toolkit...
🐳  Preparing Kubernetes v1.28.2 on Docker 24.0.6 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image nvcr.io/nvidia/k8s-device-plugin:v0.14.1
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, nvidia-device-plugin, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default

$ cat << EOF | kubectl create -f -
apiVersion: v1
kind: Pod
metadata:
  name: nvidia-version-check
spec:
  restartPolicy: OnFailure
  containers:
  - name: nvidia-version-check
    image: "nvidia/cuda:11.0.3-base-ubuntu20.04"
    command: ["nvidia-smi"]
    resources:
      limits:
         nvidia.com/gpu: "1"
EOF
pod/nvidia-version-check created

$ kubectl logs nvidia-version-check
Fri Sep 22 18:45:31 2023       
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 525.125.06   Driver Version: 525.125.06   CUDA Version: 12.0     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  Quadro P1000        On   | 00000000:65:00.0 Off |                  N/A |
| 34%   26C    P8    N/A /  47W |     15MiB /  4096MiB |      0%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+
                                                                               
+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
+-----------------------------------------------------------------------------+

$ minikube start --driver kvm --gpus all
😄  minikube v1.31.2 on Debian rodete (kvm/amd64)
✨  Using the kvm2 driver based on user configuration

❌  Exiting due to MK_USAGE: The gpus flag can only be used with the docker driver and docker container-runtime

$ minikube start --gpus cat
😄  minikube v1.31.2 on Debian rodete
✨  Automatically selected the docker driver

❌  Exiting due to MK_USAGE: The gpus flag must be passed a value of "nvidia" or "all"
```

<img width="816" alt="Screenshot 2023-09-27 at 1 40 51 PM" src="https://github.com/kubernetes/minikube/assets/44844360/794009ea-ec79-41fc-9a37-9245adc60763">
