### PR TITLE
Fix enabling & disabling addons with non-existing cluster

### DIFF
--- a/cmd/minikube/cmd/config/disable.go
+++ b/cmd/minikube/cmd/config/disable.go
@@ -35,6 +35,7 @@ var addonsDisableCmd = &cobra.Command{
 		if len(args) != 1 {
 			exit.Message(reason.Usage, "usage: minikube addons disable ADDON_NAME")
 		}
+		_, cc := mustload.Partial(ClusterFlagValue())
 		err := addons.VerifyNotPaused(ClusterFlagValue(), false)
 		if err != nil {
 			exit.Error(reason.InternalAddonDisablePaused, "disable failed", err)
@@ -43,7 +44,6 @@ var addonsDisableCmd = &cobra.Command{
 		if addon == "heapster" {
 			exit.Message(reason.AddonUnsupported, "The heapster addon is depreciated. please try to disable metrics-server instead")
 		}
-		_, cc := mustload.Partial(ClusterFlagValue())
 		validAddon, ok := assets.Addons[addon]
 		if !ok {
 			exit.Message(reason.AddonUnsupported, `"'{{.minikube_addon}}' is not a valid minikube addon`, out.V{"minikube_addon": addon})

--- a/cmd/minikube/cmd/config/enable.go
+++ b/cmd/minikube/cmd/config/enable.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/exit"
+	"k8s.io/minikube/pkg/minikube/mustload"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/reason"
 	"k8s.io/minikube/pkg/minikube/style"
@@ -40,15 +41,12 @@ var addonsEnableCmd = &cobra.Command{
 		if len(args) != 1 {
 			exit.Message(reason.Usage, "usage: minikube addons enable ADDON_NAME")
 		}
-		cc, err := config.Load(ClusterFlagValue())
-		if err != nil && !config.IsNotExist(err) {
-			out.ErrT(style.Sad, `Unable to load config: {{.error}}`, out.V{"error": err})
-		}
+		_, cc := mustload.Partial(ClusterFlagValue())
 		if cc.KubernetesConfig.KubernetesVersion == constants.NoKubernetesVersion {
 			exit.Message(reason.Usage, "You cannot enable addons on a cluster without Kubernetes, to enable Kubernetes on your cluster, run: minikube start --kubernetes-version=stable")
 		}
 
-		err = addons.VerifyNotPaused(ClusterFlagValue(), true)
+		err := addons.VerifyNotPaused(ClusterFlagValue(), true)
 		if err != nil {
 			exit.Error(reason.InternalAddonEnablePaused, "enabled failed", err)
 		}

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -927,7 +927,7 @@ func validateEnablingAddonOnNonExistingCluster(ctx context.Context, t *testing.T
 	if err == nil {
 		t.Fatalf("enabling addon succeeded when it shouldn't have: %s", rr.Output())
 	}
-	if !strings.Contains(err.Error(), "To start a cluster, run") {
+	if !strings.Contains(rr.Output(), "To start a cluster, run") {
 		t.Fatalf("unexpected error was returned: %v", err)
 	}
 }
@@ -938,7 +938,7 @@ func validateDisablingAddonOnNonExistingCluster(ctx context.Context, t *testing.
 	if err == nil {
 		t.Fatalf("disabling addon succeeded when it shouldn't have: %s", rr.Output())
 	}
-	if !strings.Contains(err.Error(), "To start a cluster, run") {
+	if !strings.Contains(rr.Output(), "To start a cluster, run") {
 		t.Fatalf("unexpected error was returned: %v", err)
 	}
 }

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -50,6 +50,26 @@ func TestAddons(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), Minutes(40))
 	defer Cleanup(t, profile, cancel)
 
+	t.Run("PreSetupTests", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			validator validateFunc
+		}{
+			{"EnablingAddonOnNonExistingCluster", validateEnablingAddonOnNonExistingCluster},
+			{"DisablingAddonOnNonExistingCluster", validateDisablingAddonOnNonExistingCluster},
+		}
+		for _, tc := range tests {
+			tc := tc
+			if ctx.Err() == context.DeadlineExceeded {
+				t.Fatalf("Unable to run more tests (deadline exceeded)")
+			}
+			t.Run(tc.name, func(t *testing.T) {
+				MaybeParallel(t)
+				tc.validator(ctx, t, profile)
+			})
+		}
+	})
+
 	setupSucceeded := t.Run("Setup", func(t *testing.T) {
 		// Set an env var to point to our dummy credentials file
 		// don't use t.Setenv because we sometimes manually unset the env var later manually
@@ -898,5 +918,27 @@ func validateLocalPathAddon(ctx context.Context, t *testing.T, profile string) {
 	rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "addons", "disable", "storage-provisioner-rancher", "--alsologtostderr", "-v=1"))
 	if err != nil {
 		t.Errorf("failed to disable storage-provisioner-rancher addon: args %q: %v", rr.Command(), err)
+	}
+}
+
+// validateEnablingAddonOnNonExistingCluster tests enabling an addon on a non-existing cluster
+func validateEnablingAddonOnNonExistingCluster(ctx context.Context, t *testing.T, profile string) {
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), "addons", "enable", "dashboard", "-p", profile))
+	if err == nil {
+		t.Fatalf("enabling addon succeeded when it shouldn't have: %s", rr.Output())
+	}
+	if !strings.Contains(err.Error(), "To start a cluster, run") {
+		t.Fatalf("unexpected error was returned: %v", err)
+	}
+}
+
+// validateDisablingAddonOnNonExistingCluster tests disabling an addon on a non-existing cluster
+func validateDisablingAddonOnNonExistingCluster(ctx context.Context, t *testing.T, profile string) {
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), "addons", "disable", "dashboard", "-p", profile))
+	if err == nil {
+		t.Fatalf("disabling addon succeeded when it shouldn't have: %s", rr.Output())
+	}
+	if !strings.Contains(err.Error(), "To start a cluster, run") {
+		t.Fatalf("unexpected error was returned: %v", err)
 	}
 }

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -50,7 +50,7 @@ func TestAddons(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), Minutes(40))
 	defer Cleanup(t, profile, cancel)
 
-	t.Run("PreSetupTests", func(t *testing.T) {
+	t.Run("PreSetup", func(t *testing.T) {
 		tests := []struct {
 			name      string
 			validator validateFunc


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/17317

### Enabling Addon
**Before:**
```
$ minikube addons enable dashboard
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x228 pc=0x102386bb8]

goroutine 1 [running]:
k8s.io/minikube/cmd/minikube/cmd/config.glob..func11(0x14000168f00?, {0x14000110eb0, 0x1, 0x102425f1c?})
        /Users/powellsteven/repo/minikube/cmd/minikube/cmd/config/enable.go:47 +0x198
github.com/spf13/cobra.(*Command).execute(0x1044f9920, {0x14000110e50, 0x1, 0x1})
        /Users/powellsteven/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:944 +0x640
github.com/spf13/cobra.(*Command).ExecuteC(0x1044f4b80)
        /Users/powellsteven/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x320
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/powellsteven/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
k8s.io/minikube/cmd/minikube/cmd.Execute()
        /Users/powellsteven/repo/minikube/cmd/minikube/cmd/root.go:174 +0x54c
main.main()
        /Users/powellsteven/repo/minikube/cmd/minikube/main.go:95 +0x258
```

**After:**
```
$ minikube addons enable dashboard
🤷  Profile "minikube" not found. Run "minikube profile list" to view all profiles.
👉  To start a cluster, run: "minikube start"
```

### Disabling Addon
**Before:**
```
$ minikube addons disable dashboard

❌  Exiting due to MK_ADDON_DISABLE_PAUSED: disable failed: loading profile: cluster "minikube" does not exist

╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                         │
│    😿  If the above advice does not help, please let us know:                                                           │
│    👉  https://github.com/kubernetes/minikube/issues/new/choose                                                         │
│                                                                                                                         │
│    Please run `minikube logs --file=logs.txt` and attach logs.txt to the GitHub issue.                                  │
│    Please also attach the following file to the GitHub issue:                                                           │
│    - /var/folders/9l/6wpxv6wd1b901m1146r579wc00rqw3/T/minikube_addons_42a1f787df8d0157be2dce836a5f91db2b8ab26d_0.log    │
│                                                                                                                         │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

**After:**
```
$ minikube addons disable dashboard
🤷  Profile "minikube" not found. Run "minikube profile list" to view all profiles.
👉  To start a cluster, run: "minikube start"
```