### PR TITLE
Add Hyper-V memory validation for odd numbers

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1180,7 +1180,7 @@ func validateRequestedMemorySize(req int, drvName string) {
 	}
 
 	if driver.IsHyperV(drvName) && req%2 == 1 {
-		exitIfNotForced(reason.RsrcInvalidHyperVMemory, "Hyper-V requires that memory MB be an even number, {{.memory}}MB was specified", out.V{"memory": req})
+		exitIfNotForced(reason.RsrcInvalidHyperVMemory, "Hyper-V requires that memory MB be an even number, {{.memory}}MB was specified, try passing `--memory {{.suggestMemory}}`", out.V{"memory": req, "suggestMemory": req - 1})
 	}
 }
 

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1178,6 +1178,10 @@ func validateRequestedMemorySize(req int, drvName string) {
 			`The requested memory allocation of {{.requested}}MiB does not leave room for system overhead (total system memory: {{.system_limit}}MiB). You may face stability issues.`,
 			out.V{"requested": req, "system_limit": sysLimit, "advised": advised})
 	}
+
+	if driver.IsHyperV(drvName) && req%2 == 1 {
+		exitIfNotForced(reason.RsrcInvalidHyperVMemory, "Hyper-V requires that memory MB be an even number, {{.memory}}MB was specified", out.V{"memory": req})
+	}
 }
 
 // validateCPUCount validates the cpu count matches the minimum recommended & not exceeding the available cpu count
@@ -1507,7 +1511,12 @@ func noLimitMemory(sysLimit, containerLimit int, drvName string) int {
 		// Because of this allow more system overhead to prevent out of memory issues
 		sysOverhead = 1536
 	}
-	return sysLimit - sysOverhead
+	mem := sysLimit - sysOverhead
+	// Hyper-V requires an even number of MB, so if odd remove one MB
+	if driver.IsHyperV(drvName) && mem%2 == 1 {
+		mem--
+	}
+	return mem
 }
 
 // This function validates if the --registry-mirror

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -198,6 +198,11 @@ func IsVMware(name string) bool {
 	return name == VMware
 }
 
+// IsHyperV check if the driver is Hyper-V
+func IsHyperV(name string) bool {
+	return name == HyperV
+}
+
 // AllowsPreload returns if preload is allowed for the driver
 func AllowsPreload(driverName string) bool {
 	return !BareMetal(driverName) && !IsSSH(driverName)

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -217,6 +217,12 @@ var (
 		Style: style.UnmetRequirement,
 		URL:   "https://docs.docker.com/docker-for-mac/#resources",
 	}
+	// invalid memory value for Hyper-V
+	RsrcInvalidHyperVMemory = Kind{
+		ID:       "RSRC_INVALID_HYPERV_MEMORY",
+		ExitCode: ExResourceError,
+		Style:    style.UnmetRequirement,
+	}
 
 	// insufficient disk storage available to the docker driver
 	RsrcInsufficientDockerStorage = Kind{


### PR DESCRIPTION
Closes https://github.com/kubernetes/minikube/issues/17242

Added logic to ensure that if `--memory max` is passed we don't generate an invalid memory value for Hyper-V and added validation to ensure odd MB memory value isn't passed to Hyper-V.

```
$ minikube start --driver hyperv --memory 6001
...

⛔  Exiting due to RSRC_INVALID_HYPERV_MEMORY: Hyper-V requires that memory MB be an even number, 6001MB was specified, try passing `--memory 6000`
```