### PR TITLE
fix: decrease runs for benchmark

### DIFF
--- a/hack/benchmark/image-build/publish-chart.sh
+++ b/hack/benchmark/image-build/publish-chart.sh
@@ -27,7 +27,7 @@ run_benchmark() {
         ( cd ./hack/benchmark/image-build/minikube-image-benchmark &&
                 git submodule update --init &&
                 make                        &&
-                ./out/benchmark )
+                ./out/benchmark --runs=4)
 }
 
 generate_chart() {


### PR DESCRIPTION
fix: decrease runs for benchmark
decrease the number of test for each kind of test to 4, so that the test will not exceed 6hr
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
