### PR TITLE
CI: Simplify build for arm64 functional tests

### DIFF
--- a/.github/workflows/functional_verified.yml
+++ b/.github/workflows/functional_verified.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libvirt-dev
-          MINIKUBE_BUILD_IN_DOCKER=y make cross e2e-cross debs
+          MINIKUBE_BUILD_IN_DOCKER=y make e2e-linux-arm64
           cp -r test/integration/testdata ./out
       - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
         with:


### PR DESCRIPTION
We're running out of space while building our arm64 functional tests, but we're build binaries for every arch/OS but we only need Linux arm64, so simply the build.

<img width="1367" alt="Screenshot 2023-10-02 at 1 22 23 PM" src="https://github.com/kubernetes/minikube/assets/44844360/a3a380e0-f3ab-4f45-b73d-9c984c3ba01b">
