### PR TITLE
Fix delete if container-runtime doesn't exist

### DIFF
--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -407,7 +407,7 @@ func unpauseIfNeeded(profile *config.Profile) error {
 
 	cr, err := cruntime.New(cruntime.Config{Type: crName, Runner: r})
 	if err != nil {
-		exit.Error(reason.InternalNewRuntime, "Failed to create runtime", err)
+		return err
 	}
 
 	paused, err := cluster.CheckIfPaused(cr, nil)


### PR DESCRIPTION
**Before:**
```
$ minikube delete

❌  Exiting due to MK_NEW_RUNTIME: Failed to create runtime: unknown runtime type: "nvidia-docker"

╭───────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                           │
│    😿  If the above advice does not help, please let us know:                             │
│    👉  https://github.com/kubernetes/minikube/issues/new/choose                           │
│                                                                                           │
│    Please run `minikube logs --file=logs.txt` and attach logs.txt to the GitHub issue.    │
│    Please also attach the following file to the GitHub issue:                             │
│    - /tmp/minikube_delete_8e4d16ba2ead342287e31d85ea41bad14bfe469f_0.log                  │
│                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────╯
```

**After:**
```
$ minikube delete
🔥  Deleting "minikube" in docker ...
🔥  Deleting container "minikube" ...
🔥  Removing /usr/local/google/home/powellsteven/.minikube/machines/minikube ...
💀  Removed all traces of the "minikube" cluster.
```