### PR TITLE
cleanup: Remove unused params

### DIFF
--- a/pkg/minikube/bootstrapper/bootstrapper.go
+++ b/pkg/minikube/bootstrapper/bootstrapper.go
@@ -54,11 +54,11 @@ const (
 )
 
 // GetCachedBinaryList returns the list of binaries
-func GetCachedBinaryList(_ string) []string {
+func GetCachedBinaryList() []string {
 	return constants.KubernetesReleaseBinaries
 }
 
 // GetCachedImageList returns the list of images for a version
-func GetCachedImageList(imageRepository, version, _ string) ([]string, error) {
+func GetCachedImageList(imageRepository, version string) ([]string, error) {
 	return images.Kubeadm(imageRepository, version)
 }

--- a/pkg/minikube/machine/cache_binaries.go
+++ b/pkg/minikube/machine/cache_binaries.go
@@ -43,8 +43,8 @@ func isExcluded(binary string, excludedBinaries []string) bool {
 }
 
 // CacheBinariesForBootstrapper will cache binaries for a bootstrapper
-func CacheBinariesForBootstrapper(version string, clusterBootstrapper string, excludeBinaries []string, binariesURL string) error {
-	binaries := bootstrapper.GetCachedBinaryList(clusterBootstrapper)
+func CacheBinariesForBootstrapper(version string, excludeBinaries []string, binariesURL string) error {
+	binaries := bootstrapper.GetCachedBinaryList()
 
 	var g errgroup.Group
 	for _, bin := range binaries {

--- a/pkg/minikube/machine/cache_binaries_test.go
+++ b/pkg/minikube/machine/cache_binaries_test.go
@@ -87,27 +87,25 @@ func TestCacheBinariesForBootstrapper(t *testing.T) {
 	minikubeHome := t.TempDir()
 
 	var tc = []struct {
-		version, clusterBootstrapper string
-		minikubeHome                 string
-		err                          bool
+		version      string
+		minikubeHome string
+		err          bool
 	}{
 		{
-			version:             "v1.16.0",
-			clusterBootstrapper: bootstrapper.Kubeadm,
-			err:                 false,
-			minikubeHome:        minikubeHome,
+			version:      "v1.16.0",
+			err:          false,
+			minikubeHome: minikubeHome,
 		},
 		{
-			version:             "invalid version",
-			clusterBootstrapper: bootstrapper.Kubeadm,
-			err:                 true,
-			minikubeHome:        minikubeHome,
+			version:      "invalid version",
+			err:          true,
+			minikubeHome: minikubeHome,
 		},
 	}
 	for _, test := range tc {
 		t.Run(test.version, func(t *testing.T) {
 			t.Setenv("MINIKUBE_HOME", test.minikubeHome)
-			err := CacheBinariesForBootstrapper(test.version, test.clusterBootstrapper, nil, "")
+			err := CacheBinariesForBootstrapper(test.version, nil, "")
 			if err != nil && !test.err {
 				t.Fatalf("Got unexpected error %v", err)
 			}
@@ -119,8 +117,7 @@ func TestCacheBinariesForBootstrapper(t *testing.T) {
 }
 
 func TestExcludedBinariesNotDownloaded(t *testing.T) {
-	clusterBootstrapper := bootstrapper.Kubeadm
-	binaryList := bootstrapper.GetCachedBinaryList(clusterBootstrapper)
+	binaryList := bootstrapper.GetCachedBinaryList()
 	binaryToExclude := binaryList[0]
 
 	download.DownloadMock = func(src, dst string) error {
@@ -133,7 +130,7 @@ func TestExcludedBinariesNotDownloaded(t *testing.T) {
 	minikubeHome := t.TempDir()
 	t.Setenv("MINIKUBE_HOME", minikubeHome)
 
-	if err := CacheBinariesForBootstrapper("v1.16.0", clusterBootstrapper, []string{binaryToExclude}, ""); err != nil {
+	if err := CacheBinariesForBootstrapper("v1.16.0", []string{binaryToExclude}, ""); err != nil {
 		t.Errorf("Failed to cache binaries: %v", err)
 	}
 }

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -59,14 +59,14 @@ var loadImageLock sync.Mutex
 var saveRoot = path.Join(vmpath.GuestPersistentDir, "images")
 
 // CacheImagesForBootstrapper will cache images for a bootstrapper
-func CacheImagesForBootstrapper(imageRepository string, version string, clusterBootstrapper string) error {
-	images, err := bootstrapper.GetCachedImageList(imageRepository, version, clusterBootstrapper)
+func CacheImagesForBootstrapper(imageRepository, version string) error {
+	images, err := bootstrapper.GetCachedImageList(imageRepository, version)
 	if err != nil {
 		return errors.Wrap(err, "cached images list")
 	}
 
 	if err := image.SaveToDir(images, detect.ImageCacheDir(), false); err != nil {
-		return errors.Wrapf(err, "Caching images for %s", clusterBootstrapper)
+		return errors.Wrap(err, "Caching images")
 	}
 
 	return nil

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -29,7 +29,6 @@ import (
 	"github.com/spf13/viper"
 	"golang.org/x/sync/errgroup"
 	"k8s.io/klog/v2"
-	cmdcfg "k8s.io/minikube/cmd/minikube/cmd/config"
 	"k8s.io/minikube/pkg/drivers/kic"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
@@ -68,7 +67,7 @@ func beginCacheKubernetesImages(g *errgroup.Group, imageRepository string, k8sVe
 	}
 
 	g.Go(func() error {
-		return machine.CacheImagesForBootstrapper(imageRepository, k8sVersion, viper.GetString(cmdcfg.Bootstrapper))
+		return machine.CacheImagesForBootstrapper(imageRepository, k8sVersion)
 	})
 }
 
@@ -113,7 +112,7 @@ func doCacheBinaries(k8sVersion, containerRuntime, driverName, binariesURL strin
 	if !download.PreloadExists(k8sVersion, containerRuntime, driverName) {
 		existingBinaries = nil
 	}
-	return machine.CacheBinariesForBootstrapper(k8sVersion, viper.GetString(cmdcfg.Bootstrapper), existingBinaries, binariesURL)
+	return machine.CacheBinariesForBootstrapper(k8sVersion, existingBinaries, binariesURL)
 }
 
 // beginDownloadKicBaseImage downloads the kic image


### PR DESCRIPTION
`GetCachedBinaryList` & `GetCachedImageList` had empty args (`_ string`) so removing them