### PR TITLE
Improve getting the correct kubeadm image version for Kubernetes version post release

### DIFF
--- a/pkg/minikube/bootstrapper/images/images.go
+++ b/pkg/minikube/bootstrapper/images/images.go
@@ -24,8 +24,6 @@ import (
 	"runtime"
 	"strings"
 
-	"k8s.io/klog/v2"
-
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/download"
 
@@ -66,21 +64,19 @@ func componentImage(name string, v semver.Version, mirror string) string {
 	return fmt.Sprintf("%s:v%s", path.Join(kubernetesRepo(mirror), name), v)
 }
 
-func tagFromKubeadm(v, name, lastKnownGood string) string {
+// tagFromKubeadm gets the image tag by running kubeadm image list command on the host machine (Linux only)
+func tagFromKubeadm(v, name string) (string, error) {
 	if runtime.GOOS != "linux" {
-		klog.Warningf("can only get tag from kubeadm on Linux")
-		return lastKnownGood
+		return "", fmt.Errorf("can only get tag from kubeadm on Linux")
 	}
 	kubeadm, err := download.Binary("kubeadm", v, "linux", runtime.GOARCH, "")
 	if err != nil {
-		klog.Warningf("failed to download kubeadm binary: %v", err)
-		return lastKnownGood
+		return "", fmt.Errorf("failed to download kubeadm binary: %v", err)
 	}
 	// TODO: Once kubeadm graduates the "-experimental-output" flag to non-experimental should use JSON output here
 	b, err := exec.Command(kubeadm, "config", "images", "list").Output()
 	if err != nil {
-		klog.Warningf("failed getting kubeadm image list: %v", err)
-		return lastKnownGood
+		return "", fmt.Errorf("failed getting kubeadm image list: %v", err)
 	}
 	lines := strings.Split(string(b), "\n")
 	for _, line := range lines {
@@ -89,13 +85,29 @@ func tagFromKubeadm(v, name, lastKnownGood string) string {
 		}
 		parts := strings.Split(line, ":")
 		if len(parts) != 2 {
-			klog.Warningf("unexpected image format: %s", line)
-			return lastKnownGood
+			return "", fmt.Errorf("unexpected image format: %s", line)
 		}
-		return parts[1]
+		return parts[1], nil
 	}
-	klog.Warningf("failed to find %q image in kubeadm image list", name)
-	return lastKnownGood
+	return "", fmt.Errorf("failed to find %q image in kubeadm image list", name)
+}
+
+// tagFromLastMinor finds the last matching minor version in the kubeadm images map and uses its image version
+func tagFromLastMinor(v semver.Version, name, lastKnownGood string) string {
+	majorMinor := fmt.Sprintf("v%d.%d", v.Major, v.Minor)
+	var latestMinorVer string
+	for _, existingVer := range constants.ValidKubernetesVersions {
+		if !strings.HasPrefix(existingVer, majorMinor) {
+			continue
+		}
+		latestMinorVer = existingVer
+		break
+	}
+	tag, ok := constants.KubeadmImages[latestMinorVer][name]
+	if !ok {
+		return lastKnownGood
+	}
+	return tag
 }
 
 // coreDNS returns the images used for CoreDNS
@@ -133,7 +145,10 @@ func imageVersion(v semver.Version, imageName, defaultVersion string) string {
 	if ver, ok := constants.KubeadmImages[versionString][imageName]; ok {
 		return ver
 	}
-	return tagFromKubeadm(versionString, imageName, defaultVersion)
+	if ver, err := tagFromKubeadm(versionString, imageName); err == nil {
+		return ver
+	}
+	return tagFromLastMinor(v, imageName, defaultVersion)
 }
 
 // auxiliary returns images that are helpful for running minikube

--- a/pkg/minikube/bootstrapper/images/images_test.go
+++ b/pkg/minikube/bootstrapper/images/images_test.go
@@ -180,3 +180,28 @@ func TestCNI(t *testing.T) {
 		})
 	}
 }
+
+func TestTagFromLastMinor(t *testing.T) {
+	tests := []struct {
+		verString   string
+		imageName   string
+		expectedTag string
+	}{
+		{"1.16.50", "coredns", "1.6.2"},
+		{"1.16.50", "etcd", "3.3.15-0"},
+		{"1.16.50", "pause", "3.1"},
+		{"1.16.50", "fake", "default"},
+	}
+
+	for _, tc := range tests {
+		v, err := semver.Parse(tc.verString)
+		if err != nil {
+			t.Errorf("failed to parse version to semver: %v", err)
+			continue
+		}
+		got := tagFromLastMinor(v, tc.imageName, "default")
+		if tc.expectedTag != got {
+			t.Errorf("tagFromLastMinor(%s, %s, default) = %s; want = %s", tc.verString, tc.imageName, got, tc.expectedTag)
+		}
+	}
+}


### PR DESCRIPTION
**Before:**
```
$ time minikube start --kubernetes-version v1.25.14 --preload=false
😄  minikube v1.31.2 on Darwin 13.6 (arm64)
✨  Automatically selected the docker driver. Other choices: qemu2, ssh
📌  Using Docker Desktop driver with root privileges
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=4000MB) ...
🐳  Preparing Kubernetes v1.25.14 on Docker 24.0.6 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass

❗  /opt/homebrew/bin/kubectl is version 1.28.2, which may have incompatibilities with Kubernetes 1.25.14.
    ▪ Want kubectl v1.25.14? Try 'minikube kubectl -- get pods -A'
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default

real	0m50.138s
user	0m5.385s
sys	0m7.114s
```

**After:**
```
$ time minikube start --kubernetes-version v1.25.14 --preload=false
😄  minikube v1.31.2 on Darwin 13.6 (arm64)
✨  Automatically selected the docker driver. Other choices: qemu2, ssh
📌  Using Docker Desktop driver with root privileges
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔥  Creating docker container (CPUs=2, Memory=4000MB) ...
🐳  Preparing Kubernetes v1.25.14 on Docker 24.0.6 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass

❗  /opt/homebrew/bin/kubectl is version 1.28.2, which may have incompatibilities with Kubernetes 1.25.14.
    ▪ Want kubectl v1.25.14? Try 'minikube kubectl -- get pods -A'
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default

real	0m39.053s
user	0m5.624s
sys	0m7.008s
```

11 second speedup by not downloading the wrong images the first time. This speed increase is dependent on internet speed, slower internet speeds with see a bigger improvement.