### PR TITLE
fix: reduce test cases and memory for image benchmark

### DIFF
--- a/hack/benchmark/image-build/publish-chart.sh
+++ b/hack/benchmark/image-build/publish-chart.sh
@@ -27,7 +27,7 @@ run_benchmark() {
         ( cd ./hack/benchmark/image-build/minikube-image-benchmark &&
                 git submodule update --init &&
                 make                        &&
-                ./out/benchmark --runs=4)
+                ./out/benchmark --runs=4 --memory="1800m" --images="buildpacksFewLargeFiles" --iters="iterative" --bench-methods="image load docker,image build docker,docker-env docker,registry docker,image load containerd,image build containerd,registry containerd")
 }
 
 generate_chart() {


### PR DESCRIPTION
When trying to run this benchmark in minikube's github action, some problems occurred. See https://github.com/GoogleContainerTools/minikube-image-benchmark/pull/40

To solve this problem, a PR has been created for minikube-image-benchmark adding some feature to solve the problems.
and, according to the changes introduced by that PR, some small changes also need to be added to minikube's github action, so that we can use the new features

The Before-After comparasion:

After: https://github.com/ComradeProgrammer/minikube/actions/runs/6495925502/job/17641822215
This is a test run on github action. This time image-benchmark can be executed correctly on github action instance.
(The status of this action is still error, it is because of the aws s3 command, from the log you can see the image-benchmark execution was successful)

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
