### PR TITLE
CI: GitHub Actions only build required test binaries

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -19,8 +19,34 @@ permissions:
   contents: read
 
 jobs:
-  # Runs before all other jobs
-  # builds the minikube binaries
+  # Runs before before the functional tests
+  # builds the binaries required for testing
+  build_minikube_test_binaries:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
+        with:
+          go-version: ${{env.GO_VERSION}}
+          cache-dependency-path: ./go.sum
+      - name: Download Dependencies
+        run: go mod download
+      - name: Build Binaries
+        run: |
+          make e2e-linux-amd64 e2e-darwin-amd64
+          cp -r test/integration/testdata ./out
+          whoami
+          echo github ref $GITHUB_REF
+          echo workflow $GITHUB_WORKFLOW
+          echo home $HOME
+          echo event name $GITHUB_EVENT_NAME
+          echo workspace $GITHUB_WORKSPACE
+          echo "end of debug stuff"
+          echo $(which jq)
+      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        with:
+          name: minikube_binaries
+          path: out
   build_minikube:
     runs-on: ubuntu-20.04
     steps:
@@ -35,19 +61,6 @@ jobs:
         run: |
           make cross
           make e2e-cross
-          cp -r test/integration/testdata ./out
-          whoami
-          echo github ref $GITHUB_REF
-          echo workflow $GITHUB_WORKFLOW
-          echo home $HOME
-          echo event name $GITHUB_EVENT_NAME
-          echo workspace $GITHUB_WORKSPACE
-          echo "end of debug stuff"
-          echo $(which jq)
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
-        with:
-          name: minikube_binaries
-          path: out
   lint:
     runs-on: ubuntu-20.04
     steps:
@@ -91,7 +104,7 @@ jobs:
   functional_docker_ubuntu:
     permissions:
       contents: none
-    needs: [build_minikube]
+    needs: [build_minikube_test_binaries]
     env:
       TIME_ELAPSED: time
       JOB_NAME: "functional_docker_ubuntu"
@@ -189,7 +202,7 @@ jobs:
   functional_docker_containerd_ubuntu:
     permissions:
       contents: none
-    needs: [build_minikube]
+    needs: [build_minikube_test_binaries]
     env:
       TIME_ELAPSED: time
       JOB_NAME: "functional_docker_containerd_ubuntu"
@@ -288,7 +301,7 @@ jobs:
   functional_podman_ubuntu:
     permissions:
       contents: none
-    needs: [ build_minikube ]
+    needs: [build_minikube_test_binaries]
     env:
       TIME_ELAPSED: time
       JOB_NAME: functional_podman_ubuntu
@@ -390,7 +403,7 @@ jobs:
   functional_virtualbox_macos:
     permissions:
       contents: none
-    needs: [build_minikube]
+    needs: [build_minikube_test_binaries]
     env:
       TIME_ELAPSED: time
       JOB_NAME: "functional_virtualbox_macos"
@@ -487,7 +500,7 @@ jobs:
   functional_baremetal_ubuntu20_04:
     permissions:
       contents: none
-    needs: [build_minikube]
+    needs: [build_minikube_test_binaries]
     env:
       TIME_ELAPSED: time
       JOB_NAME: "functional_baremetal_ubuntu20_04"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,8 +17,34 @@ permissions:
   contents: read
 
 jobs:
-  # Runs before all other jobs
-  # builds the minikube binaries
+  # Runs before before the functional tests
+  # builds the binaries required for testing
+  build_minikube_test_binaries:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
+        with:
+          go-version: ${{env.GO_VERSION}}
+          cache-dependency-path: ./go.sum
+      - name: Download Dependencies
+        run: go mod download
+      - name: Build Binaries
+        run: |
+          make e2e-linux-amd64 e2e-darwin-amd64
+          cp -r test/integration/testdata ./out
+          whoami
+          echo github ref $GITHUB_REF
+          echo workflow $GITHUB_WORKFLOW
+          echo home $HOME
+          echo event name $GITHUB_EVENT_NAME
+          echo workspace $GITHUB_WORKSPACE
+          echo "end of debug stuff"
+          echo $(which jq)
+      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        with:
+          name: minikube_binaries
+          path: out
   build_minikube:
     runs-on: ubuntu-20.04
     steps:
@@ -33,19 +59,6 @@ jobs:
         run: |
           make cross
           make e2e-cross
-          cp -r test/integration/testdata ./out
-          whoami
-          echo github ref $GITHUB_REF
-          echo workflow $GITHUB_WORKFLOW
-          echo home $HOME
-          echo event name $GITHUB_EVENT_NAME
-          echo workspace $GITHUB_WORKSPACE
-          echo "end of debug stuff"
-          echo $(which jq)
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
-        with:
-          name: minikube_binaries
-          path: out
   lint:
     runs-on: ubuntu-20.04
     steps:
@@ -89,7 +102,7 @@ jobs:
   functional_docker_ubuntu:
     permissions:
       contents: none
-    needs: [build_minikube]
+    needs: [build_minikube_test_binaries]
     env:
       TIME_ELAPSED: time
       JOB_NAME: "functional_docker_ubuntu"
@@ -188,7 +201,7 @@ jobs:
   functional_docker_containerd_ubuntu:
     permissions:
       contents: none
-    needs: [build_minikube]
+    needs: [build_minikube_test_binaries]
     env:
       TIME_ELAPSED: time
       JOB_NAME: "functional_docker_containerd_ubuntu"
@@ -288,7 +301,7 @@ jobs:
   functional_docker_rootless_containerd_ubuntu:
     permissions:
       contents: none
-    needs: [build_minikube]
+    needs: [build_minikube_test_binaries]
     env:
       TIME_ELAPSED: time
       JOB_NAME: "functional_docker_rootless_containerd_ubuntu"
@@ -405,7 +418,7 @@ jobs:
   functional_podman_ubuntu:
     permissions:
       contents: none
-    needs: [ build_minikube ]
+    needs: [build_minikube_test_binaries]
     env:
       TIME_ELAPSED: time
       JOB_NAME: functional_podman_ubuntu
@@ -508,7 +521,7 @@ jobs:
   functional_virtualbox_macos:
     permissions:
       contents: none
-    needs: [build_minikube]
+    needs: [build_minikube_test_binaries]
     env:
       TIME_ELAPSED: time
       JOB_NAME: "functional_virtualbox_macos"
@@ -606,7 +619,7 @@ jobs:
   functional_baremetal_ubuntu20_04:
     permissions:
       contents: none
-    needs: [build_minikube]
+    needs: [build_minikube_test_binaries]
     env:
       TIME_ELAPSED: time
       JOB_NAME: "functional_baremetal_ubuntu20_04"


### PR DESCRIPTION
When building the binaries for the functional tests we build every possible combination, but we only run Linux & Darwin amd64 tests. To speed up the functional tests getting kicked off I made a new job that only builds Linux & Darwin amd64 test binaries and once it's done the functional tests start, it speed up from 19 minutes to 6.5 minutes. I still left the build_binaries job as we still want to make sure everything builds, but the functional tests don't rely on it before starting.

**Before 19 mins:**
<img width="666" alt="Screenshot 2023-10-10 at 3 32 25 PM" src="https://github.com/kubernetes/minikube/assets/44844360/d6b3562f-2938-47ba-bb5b-6d64d43c710a">

**After: 6.5 mins**
<img width="653" alt="Screenshot 2023-10-10 at 3 32 31 PM" src="https://github.com/kubernetes/minikube/assets/44844360/80d2f0e6-7556-4130-af80-870ca7294ddd">
