### PR TITLE
bump oldest kubernetes version to v1.19.0

### DIFF
--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -39,7 +39,7 @@ const (
 	// NOTE: You may need to update coreDNS & etcd versions in pkg/minikube/bootstrapper/images/images.go
 	NewestKubernetesVersion = "v1.28.2"
 	// OldestKubernetesVersion is the oldest Kubernetes version to test against
-	OldestKubernetesVersion = "v1.16.0"
+	OldestKubernetesVersion = "v1.19.0"
 	// NoKubernetesVersion is the version used when users does NOT want to install kubernetes
 	NoKubernetesVersion = "v0.0.0"
 


### PR DESCRIPTION
v.1.16 is very old

and new cri-dockerd APIs wont pass the test
https://storage.googleapis.com/minikube-builds/logs/17055/31367/KVM_Linux.html#fail_TestStartStop%2fgroup%2fold-k8s-version%2fserial%2fVerifyKubernetesImages