### PR TITLE
Remove unnecessary '-z' flag from gsutil tar extraction

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -148,7 +148,7 @@ mkdir -p out/ testdata/
 if ! type -P gsutil >/dev/null; then
   if [[ ! -x "out/gsutil/gsutil" ]]; then
     echo "Installing gsutil to $(pwd)/out ..."
-    curl -s https://storage.googleapis.com/pub/gsutil.tar.gz | tar -C out/ -zxf -
+    curl -s https://storage.googleapis.com/pub/gsutil.tar.gz | tar -C out/ -xf -
   fi
   PATH="$(pwd)/out/gsutil:$PATH"
 fi


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
This change removes the unnecessary `-z` flag from the 'tar' command used to extract the `gsutil.tar.gz` archive. 
The `-z` flag is typically used to specify gzip compression, but in this case, the archive is uncompressed. 
Removing the `-z` flag makes the command more concise and aligns it with the actual archive format.