### PR TITLE
Add more links to the kubectl documentation

### DIFF
--- a/site/content/en/docs/handbook/kubectl.md
+++ b/site/content/en/docs/handbook/kubectl.md
@@ -10,6 +10,10 @@ aliases:
 By default, [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) gets configured to access the kubernetes cluster control plane
 inside minikube when the `minikube start` command is executed.
 
+```shell
+kubectl <kubectl commands>
+```
+
 However if `kubectl` is not installed locally, minikube already includes kubectl which can be used like this:
 
 ```shell
@@ -91,6 +95,10 @@ For more help
 ```shell
 minikube kubectl -- --help
 ```
+
+Documentation
+
+<https://kubernetes.io/docs/reference/kubectl/>
 
 ### Shell autocompletion
 

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -510,7 +510,7 @@ If minikube fails to start, see the [drivers page]({{<ref "/docs/drivers">}}) fo
 
 <h2 class="step"><span class="fa-stack fa-1x"><i class="fa fa-circle fa-stack-2x"></i><strong class="fa-stack-1x text-primary">3</strong></span>Interact with your cluster</h2>
 
-If you already have kubectl installed, you can now use it to access your shiny new cluster:
+If you already have kubectl installed (see [documentation](https://kubernetes.io/docs/tasks/tools/install-kubectl/)), you can now use it to access your shiny new cluster:
 
 ```shell
 kubectl get po -A
@@ -521,7 +521,7 @@ Alternatively, minikube can download the appropriate version of kubectl and you 
 ```shell
 minikube kubectl -- get po -A
 ```
-You can also make your life easier by adding the following to your shell config:
+You can also make your life easier by adding the following to your shell config: (for more details see: [kubectl]({{<ref "/docs/handbook/kubectl">}}))
 ```shell
 alias kubectl="minikube kubectl --"
 ```


### PR DESCRIPTION
Apparently finding the kubernetes documentation for kubectl could be a challenge for new users, so try to help out a bit.