### PR TITLE
Update OIDC tutorial auth modes

### DIFF
--- a/site/content/en/docs/tutorials/openid_connect_auth.md
+++ b/site/content/en/docs/tutorials/openid_connect_auth.md
@@ -19,7 +19,7 @@ The following example configures your Minikube cluster to support RBAC and OIDC:
 
 ```shell
 minikube start \
-  --extra-config=apiserver.authorization-mode=RBAC \
+  --extra-config=apiserver.authorization-mode=Node,RBAC \
   --extra-config=apiserver.oidc-issuer-url=https://example.com \
   --extra-config=apiserver.oidc-username-claim=email \
   --extra-config=apiserver.oidc-client-id=kubernetes-local


### PR DESCRIPTION
Make docs reflect needed apiserver auth modes

For context see #17456 and #6061


