### PR TITLE
oci.DaemonHost handle empty hostnames

### DIFF
--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -702,7 +702,9 @@ func DaemonHost(driver string) string {
 		if dh := os.Getenv(constants.DockerHostEnv); dh != "" {
 			if u, err := url.Parse(dh); err == nil {
 				if u.Host != "" {
-					return u.Hostname()
+					if hostname := u.Hostname(); hostname != "" {
+						return u.Hostname()
+					}
 				}
 			}
 		}

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -717,14 +717,14 @@ func IsExternalDaemonHost(driver string) bool {
 	if driver == Podman {
 		if dh := os.Getenv(constants.PodmanContainerHostEnv); dh != "" {
 			if u, err := url.Parse(dh); err == nil {
-				return u.Host != ""
+				return u.Hostname() != ""
 			}
 		}
 	}
 	if driver == Docker {
 		if dh := os.Getenv(constants.DockerHostEnv); dh != "" {
 			if u, err := url.Parse(dh); err == nil {
-				return u.Host != ""
+				return u.Hostname() != ""
 			}
 		}
 	}

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -701,10 +701,8 @@ func DaemonHost(driver string) string {
 	if driver == Docker {
 		if dh := os.Getenv(constants.DockerHostEnv); dh != "" {
 			if u, err := url.Parse(dh); err == nil {
-				if u.Host != "" {
-					if hostname := u.Hostname(); hostname != "" {
-						return u.Hostname()
-					}
+				if u.Hostname() != "" {
+					return u.Hostname()
 				}
 			}
 		}

--- a/pkg/drivers/kic/oci/oci_test.go
+++ b/pkg/drivers/kic/oci/oci_test.go
@@ -130,6 +130,7 @@ func TestDaemonHost(t *testing.T) {
 		{"docker", "", "unix:///var/run/something", "127.0.0.1", false},
 		{"docker", "", "tcp://127.0.0.1/foo", "127.0.0.1", true},
 		{"docker", "", "ssh://127.0.0.1/bar", "127.0.0.1", true},
+		{"docker", "", "tcp://:", "127.0.0.1", true},
 	}
 	for _, test := range tests {
 		t.Setenv("CONTAINER_HOST", test.containerHost)


### PR DESCRIPTION
This handles DOCKER_HOST='tcp://:'




