### PR TITLE
GPUs: Check for existing NVIDIA container toolkit install

### DIFF
--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -583,6 +583,10 @@ func (r *Docker) configureDocker(driver string) error {
 // https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
 func (r *Docker) installNvidiaContainerToolkit() error {
 	out.Styled(style.Warning, "Using GPUs with the Docker driver is experimental, if you experience any issues please report them at: https://github.com/kubernetes/minikube/issues/new/choose")
+	if _, err := r.Runner.RunCmd(exec.Command("dpkg", "-l", "nvidia-container-toolkit")); err == nil {
+		klog.Info("nvidia-container-toolkit is already installed, skipping install")
+		return nil
+	}
 	out.Styled(style.Toolkit, "Installing the NVIDIA Container Toolkit...")
 	cmds := []string{
 		"curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg",


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/17405

**Before:**
```
$ minikube start --gpus all
...

$ minikube stop
...

$ minikube start
😄  minikube v1.31.2 on Debian rodete
✨  Using the docker driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔄  Restarting existing docker container for "minikube" ...
❗  Using GPUs with the Docker driver is experimental, if you experience any issues please report them at: https://github.com/kubernetes/minikube/issues/new/choose
🛠️   Installing the NVIDIA Container Toolkit...

❌  Exiting due to RUNTIME_ENABLE: Failed to enable container runtime: failed installing the NVIDIA Container Toolkit: /bin/bash -c "curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg": Process exited with status 2
stdout:

stderr:
gpg: cannot open '/dev/tty': No such device or address
curl: (23) Failed writing body


╭───────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                           │
│    😿  If the above advice does not help, please let us know:                             │
│    👉  https://github.com/kubernetes/minikube/issues/new/choose                           │
│                                                                                           │
│    Please run `minikube logs --file=logs.txt` and attach logs.txt to the GitHub issue.    │
│                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────╯
```

**After:**
```
$ minikube start --gpus all
...

$ minikube stop
...

$ minikube start
😄  minikube v1.31.2 on Debian rodete
✨  Using the docker driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
🔄  Restarting existing docker container for "minikube" ...
❗  Using GPUs with the Docker driver is experimental, if you experience any issues please report them at: https://github.com/kubernetes/minikube/issues/new/choose
🐳  Preparing Kubernetes v1.28.3 on Docker 24.0.6 ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
    ▪ Using image nvcr.io/nvidia/k8s-device-plugin:v0.14.1
🌟  Enabled addons: nvidia-device-plugin, storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```