### PR TITLE
fix(image-repository): allow subdomains with numbers

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1596,7 +1596,7 @@ func validateRegistryMirror() {
 // args match the format of registry.cn-hangzhou.aliyuncs.com/google_containers
 // also "<hostname>[:<port>]"
 func validateImageRepository(imageRepo string) (validImageRepo string) {
-	expression := regexp.MustCompile(`^(?:(\w+)\:\/\/)?([-a-zA-Z0-9]{1,}(?:\.[-a-zA-Z]{1,}){0,})(?:\:(\d+))?(\/.*)?$`)
+	expression := regexp.MustCompile(`^(?:(\w+)\:\/\/)?([-a-zA-Z0-9]{1,}(?:\.[-a-zA-Z0-9]{1,}){0,})(?:\:(\d+))?(\/.*)?$`)
 
 	if strings.ToLower(imageRepo) == "auto" {
 		imageRepo = "auto"

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -384,6 +384,22 @@ func TestValidateImageRepository(t *testing.T) {
 			imageRepository:      "registry.test.com:6666/google_containers",
 			validImageRepository: "registry.test.com:6666/google_containers",
 		},
+		{
+			imageRepository:      "registry.1test.com:6666/google_containers",
+			validImageRepository: "registry.1test.com:6666/google_containers",
+		},
+		{
+			imageRepository:      "registry.t1est.com:6666/google_containers",
+			validImageRepository: "registry.t1est.com:6666/google_containers",
+		},
+		{
+			imageRepository:      "registry.test1.com:6666/google_containers",
+			validImageRepository: "registry.test1.com:6666/google_containers",
+		},
+		{
+			imageRepository:      "abc.xyz1.example.com",
+			validImageRepository: "abc.xyz1.example.com",
+		},
 	}
 
 	for _, test := range tests {
@@ -395,7 +411,6 @@ func TestValidateImageRepository(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestValidateDiskSize(t *testing.T) {


### PR DESCRIPTION
My company blocks `docker.io` at the network level and there is no proxy solution. Instead they provide an Artifactory registry which mirrors all of docker.io.

Thus I am attempting to run:

```
minikube start --image-repository docker.repo1.uhc.com
```

Which fails with the error:
> E1025 20:07:14.125831   12982 start.go:1541] Provided repository is not a valid URL. Defaulting to "auto"

The URL is indeed valid and so I tracked the issue down to the line of code in this PR which appears to assume that only the bottom level subdomain may contain numbers, which is a bad assumption.

I used regexr.com to validate:

#### before
![Screenshot 2023-10-25 at 8 20 37 PM](https://github.com/kubernetes/minikube/assets/10974/3d14e4a9-024a-44a3-9cf6-04fcfd44d7e3)

#### after
![Screenshot 2023-10-25 at 8 20 46 PM](https://github.com/kubernetes/minikube/assets/10974/0f6b3064-17be-4681-a898-7608b328f151)
