### PR TITLE
site: status can have 2 values in case the image doesn't exist

### DIFF
--- a/site/content/en/docs/tutorials/kubernetes_101/module6.md
+++ b/site/content/en/docs/tutorials/kubernetes_101/module6.md
@@ -100,7 +100,7 @@ Notice that the output doesn't list the desired number of available Pods. Run th
 kubectl get pods
 ```
 
-Notice that some of the Pods have a status of `ImagePullBackOff`.
+Notice that some of the Pods have a status of `ErrImagePull` or `ImagePullBackOff`.
 
 To get more insight into the problem, run the `describe pods` command:
 


### PR DESCRIPTION
While experimenting this tutorial, I noticed the status can be `ImagePullBackOff` or `ErrImagePull` when the referenced image doesn't exist.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
