### PR TITLE
rootless: support `--container-runtime=docker`

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -619,9 +619,6 @@ func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, rtime str
 		}
 		if si.Rootless {
 			out.Styled(style.Notice, "Using rootless {{.driver_name}} driver", out.V{"driver_name": driver.FullName(drvName)})
-			if cc.KubernetesConfig.ContainerRuntime == constants.Docker {
-				exit.Message(reason.Usage, "--container-runtime must be set to \"containerd\" or \"cri-o\" for rootless")
-			}
 			// KubeletInUserNamespace feature gate is essential for rootless driver.
 			// See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-in-userns/
 			cc.KubernetesConfig.FeatureGates = addFeatureGate(cc.KubernetesConfig.FeatureGates, "KubeletInUserNamespace=true")

--- a/site/content/en/docs/drivers/docker.md
+++ b/site/content/en/docs/drivers/docker.md
@@ -49,7 +49,7 @@ minikube start --driver=docker --container-runtime=containerd
 Unlike Podman driver, it is not necessary to set the `rootless` property of minikube (`minikube config set rootless true`).
 When the `rootless` property is explicitly set but the current Docker host is not rootless, minikube fails with an error.
 
-The `--container-runtime` flag must be set to "containerd" or "cri-o". "containerd" is recommended.
+It is recommended to set the `--container-runtime` flag to "containerd".
 {{% /tab %}}
 {{% /tabs %}}
 


### PR DESCRIPTION
This allows running Kubernetes with (CRI-)Dockerd in Rootless Docker:
```
minikube start --rootless --driver=docker --container-runtime=docker
```

It is still recommended to use `--container-runtime=containerd`.

fixes #17322

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
