### PR TITLE
Fix no-limit option for config validation

### DIFF
--- a/cmd/minikube/cmd/config/validations.go
+++ b/cmd/minikube/cmd/config/validations.go
@@ -56,7 +56,7 @@ func IsValidDiskSize(_, disksize string) error {
 
 // IsValidCPUs checks if a string is a valid number of CPUs
 func IsValidCPUs(name, cpus string) error {
-	if cpus == constants.MaxResources {
+	if cpus == constants.MaxResources || cpus == constants.NoLimit {
 		return nil
 	}
 	return IsPositive(name, cpus)
@@ -64,7 +64,7 @@ func IsValidCPUs(name, cpus string) error {
 
 // IsValidMemory checks if a string is a valid memory size
 func IsValidMemory(_, memsize string) error {
-	if memsize == constants.MaxResources {
+	if memsize == constants.MaxResources || memsize == constants.NoLimit {
 		return nil
 	}
 	_, err := units.FromHumanSize(memsize)

--- a/cmd/minikube/cmd/config/validations_test.go
+++ b/cmd/minikube/cmd/config/validations_test.go
@@ -146,3 +146,31 @@ func TestIsURLExists(t *testing.T) {
 
 	runValidations(t, tests, "url", IsURLExists)
 }
+
+func TestIsValidCPUs(t *testing.T) {
+	tests := []validationTest{
+		{"2", false},
+		{"16", false},
+		{"max", false},
+		{"no-limit", false},
+		{"abc", true},
+		{"-2", true},
+		{"", true},
+	}
+
+	runValidations(t, tests, "cpus", IsValidCPUs)
+}
+
+func TestIsValidMemory(t *testing.T) {
+	tests := []validationTest{
+		{"4000mb", false},
+		{"8gb", false},
+		{"max", false},
+		{"no-limit", false},
+		{"-4000", true},
+		{"abc", true},
+		{"", true},
+	}
+
+	runValidations(t, tests, "memory", IsValidMemory)
+}


### PR DESCRIPTION
**Before:**
```
$ minikube config set cpus no-limit

❌  Exiting due to MK_CONFIG_SET: Set failed: run validations for "cpus" with value of "no-limit": [cpus:strconv.Atoi: parsing "no-limit": invalid syntax]

╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                         │
│    😿  If the above advice does not help, please let us know:                                                           │
│    👉  https://github.com/kubernetes/minikube/issues/new/choose                                                         │
│                                                                                                                         │
│    Please run `minikube logs --file=logs.txt` and attach logs.txt to the GitHub issue.                                  │
│    Please also attach the following file to the GitHub issue:                                                           │
│    - /var/folders/9l/6wpxv6wd1b901m1146r579wc00rqw3/T/minikube_config_f2ac5a775a933d63b384f05046e49d1328797158_0.log    │
│                                                                                                                         │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

**After:**
```
$ minikube config set cpus no-limit
❗  These changes will take effect upon a minikube delete and then a minikube start
```
