### PR TITLE
Fix no-limit not being respected on restart

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -706,12 +706,12 @@ func upgradeExistingConfig(cmd *cobra.Command, cc *config.ClusterConfig) {
 		klog.Infof("config upgrade: KicBaseImage=%s", cc.KicBaseImage)
 	}
 
-	if cc.CPUs == 0 {
+	if cc.CPUs == 0 && !driver.IsKIC(cc.Driver) {
 		klog.Info("Existing config file was missing cpu. (could be an old minikube config), will use the default value")
 		cc.CPUs = viper.GetInt(cpus)
 	}
 
-	if cc.Memory == 0 {
+	if cc.Memory == 0 && !driver.IsKIC(cc.Driver) {
 		klog.Info("Existing config file was missing memory. (could be an old minikube config), will use the default value")
 		memInMB := getMemorySize(cmd, cc.Driver)
 		cc.Memory = memInMB


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/17597

**Before:**
```
$ minikube start --driver docker --cpus=no-limit --memory=no-limit

$ minikube stop

$ minikube start

$ cat ~/.minikube/profiles/minikube/config.json
"Memory": 4000,
"CPUs": 2,
```

**After:**
```
$ minikube start --driver docker --cpus=no-limit --memory=no-limit

$ minikube stop

$ minikube start

$ cat ~/.minikube/profiles/minikube/config.json
"Memory": 0,
"CPUs": 0,
```