### PR TITLE
Fix ingress-dns.md instructions

### DIFF
--- a/site/content/en/docs/handbook/addons/ingress-dns.md
+++ b/site/content/en/docs/handbook/addons/ingress-dns.md
@@ -104,7 +104,7 @@ Configure dnsmasq to handle .test domain
 
 ```bash
 sudo mkdir /etc/NetworkManager/dnsmasq.d/
-echo "server=/test/$(minikube ip)" >/etc/NetworkManager/dnsmasq.d/minikube.conf
+echo "server=/test/$(minikube ip)" | sudo tee /etc/NetworkManager/dnsmasq.d/minikube.conf
 ```
 
 Restart Network Manager


### PR DESCRIPTION
current instruction is incorrect because that file requires sudo, but `minikube ip` under sudo will not give anything meaningful
