### PR TITLE
qemu2 default ssh user - point to host one to be able to ssh to colima without docker desktop

### DIFF
--- a/pkg/drivers/qemu/qemu.go
+++ b/pkg/drivers/qemu/qemu.go
@@ -45,6 +45,7 @@ import (
 
 	"k8s.io/klog/v2"
 	pkgdrivers "k8s.io/minikube/pkg/drivers"
+	"k8s.io/minikube/pkg/drivers/kic"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/firewall"
 	"k8s.io/minikube/pkg/minikube/out"
@@ -205,7 +206,7 @@ func (d *Driver) GetURL() (string, error) {
 	return fmt.Sprintf("tcp://%s:%d", ip, port), nil
 }
 
-func NewDriver(hostName, storePath string) drivers.Driver {
+func NewDriver(hostName, storePath string, kcfg kic.Config) drivers.Driver {
 	return &Driver{
 		BIOS:           runtime.GOARCH != "arm64",
 		PrivateNetwork: privateNetworkName,

--- a/pkg/minikube/registry/drvs/qemu2/qemu2.go
+++ b/pkg/minikube/registry/drvs/qemu2/qemu2.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -37,7 +38,11 @@ import (
 	"k8s.io/minikube/pkg/minikube/registry"
 )
 
-const docURL = "https://minikube.sigs.k8s.io/docs/reference/drivers/qemu/"
+const (
+	docURL = "https://minikube.sigs.k8s.io/docs/reference/drivers/qemu/"
+
+	defaultSSHUser = "docker"
+)
 
 func init() {
 	priority := registry.Default
@@ -163,7 +168,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		BaseDriver: &drivers.BaseDriver{
 			MachineName: name,
 			StorePath:   localpath.MiniPath(),
-			SSHUser:     "docker",
+			SSHUser:     getuser(),
 		},
 		Boot2DockerURL:        download.LocalISOResource(cc.MinikubeISO),
 		DiskSize:              cc.DiskSize,
@@ -186,6 +191,15 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 		SocketVMNetClientPath: cc.SocketVMnetClientPath,
 		ExtraDisks:            cc.ExtraDisks,
 	}, nil
+}
+
+func getuser() string {
+	us, err := user.Current()
+	if err != nil {
+		return defaultSSHUser
+	}
+
+	return us.Username
 }
 
 func status() registry.State {

--- a/pkg/minikube/tunnel/route_windows_test.go
+++ b/pkg/minikube/tunnel/route_windows_test.go
@@ -139,7 +139,7 @@ Persistent Routes:
 	expectedRt := routingTable{
 		routingTableLine{
 			route: unsafeParseRoute("127.0.0.1", "10.96.0.0/12"),
-			line: " 	    10.96.0.0      255.240.0.0        127.0.0.1        127.0.0.1    281",
+			line:  " 	    10.96.0.0      255.240.0.0        127.0.0.1        127.0.0.1    281",
 		},
 		routingTableLine{
 			route: unsafeParseRoute("192.168.1.2", "10.211.55.0/24"),


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
When launching Colima with containerd and then trying to run Minikube with containerd and vmnet without docker desktop, the ssh fails to work when Minikube is about to start because username is hardcoded to docker. It cannot be edited or modified in config.json file, so in result Minikube hangs at 
`I1112 00:58:28.139890   46879 main.go:141] libmachine: Found match: a:71:bd:74:67:db
I1112 00:58:28.139897   46879 main.go:141] libmachine: IP: 127.0.0.1
I1112 00:58:28.139901   46879 main.go:141] libmachine: Waiting for VM to start (ssh -p 49590 **docker**@127.0.0.1)...`

setup: socket_vmnet / bridge
colima with lima and ForwardAgent Yes (ssh-add) and mount of ~/. to get *.sock files in place
vmnet command defined in Lima
colima with containerd
minikube with containerd
no docker installed