### PR TITLE
Schedule ingress-dns pod on the minikube primary node in multi node cluster.

### DIFF
--- a/deploy/addons/ingress-dns/ingress-dns-pod.yaml.tmpl
+++ b/deploy/addons/ingress-dns/ingress-dns-pod.yaml.tmpl
@@ -75,7 +75,6 @@ spec:
   serviceAccountName: minikube-ingress-dns
   hostNetwork: true
   nodeSelector:
-    kubernetes.io/os: linux
     minikube.k8s.io/primary: 'true'
   tolerations:
       - effect: NoSchedule

--- a/deploy/addons/ingress-dns/ingress-dns-pod.yaml.tmpl
+++ b/deploy/addons/ingress-dns/ingress-dns-pod.yaml.tmpl
@@ -74,6 +74,13 @@ metadata:
 spec:
   serviceAccountName: minikube-ingress-dns
   hostNetwork: true
+  nodeSelector:
+    kubernetes.io/os: linux
+    minikube.k8s.io/primary: 'true'
+  tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Equal
   containers:
     - name: minikube-ingress-dns
       image: {{.CustomRegistries.IngressDNS | default .ImageRepository | default .Registries.IngressDNS }}{{.Images.IngressDNS}}


### PR DESCRIPTION
fixes #17648

- Add nodeSelector for primary minikube node to ingress-dns pod template.
- Add toleration for kubernetes master role.
