### PR TITLE
fix containerd ImageExists to look for image name and image id sha

### DIFF
--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -250,8 +250,7 @@ func (r *Containerd) Disable() error {
 func (r *Containerd) ImageExists(name string, sha string) bool {
 	klog.Infof("Checking existence of image with name %q and sha %q", name, sha)
 	c := exec.Command("sudo", "ctr", "-n=k8s.io", "images", "check")
-	rr, err := r.Runner.RunCmd(c)
-	if err != nil ||
+	if rr, err := r.Runner.RunCmd(c); err != nil ||
 		!strings.Contains(rr.Output(), name) ||
 		(sha != "" && !strings.Contains(rr.Output(), sha)) {
 		return false

--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -248,12 +248,12 @@ func (r *Containerd) Disable() error {
 
 // ImageExists checks if image exists based on image name and optionally image sha
 func (r *Containerd) ImageExists(name string, sha string) bool {
-	c := exec.Command("/bin/bash", "-c", fmt.Sprintf("sudo ctr -n=k8s.io images check | grep %s", name))
+	klog.Infof("Checking existence of image with name %q and sha %q", name, sha)
+	c := exec.Command("sudo", "ctr", "-n=k8s.io", "images", "check")
 	rr, err := r.Runner.RunCmd(c)
-	if err != nil {
-		return false
-	}
-	if sha != "" && !strings.Contains(rr.Output(), sha) {
+	if err != nil ||
+		!strings.Contains(rr.Output(), name) ||
+		(sha != "" && !strings.Contains(rr.Output(), sha)) {
 		return false
 	}
 	return true

--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -250,6 +250,7 @@ func (r *Containerd) Disable() error {
 func (r *Containerd) ImageExists(name string, sha string) bool {
 	klog.Infof("Checking existence of image with name %q and sha %q", name, sha)
 	c := exec.Command("sudo", "ctr", "-n=k8s.io", "images", "check")
+	// note: image name and image id's sha can be on different lines in ctr output
 	if rr, err := r.Runner.RunCmd(c); err != nil ||
 		!strings.Contains(rr.Output(), name) ||
 		(sha != "" && !strings.Contains(rr.Output(), sha)) {


### PR DESCRIPTION
pls see details in the comment: https://github.com/kubernetes/minikube/pull/17658#issuecomment-1828807988

this pr addresses the problem of (how we handle/expect) the `ctr` output - from logs:
```
I1126 22:25:11.544084   26459 cache_images.go:88] LoadImages start: [registry.k8s.io/kube-apiserver:v1.28.4 registry.k8s.io/kube-controller-manager:v1.28.4 registry.k8s.io/kube-scheduler:v1.28.4 registry.k8s.io/kube-proxy:v1.28.4 registry.k8s.io/pause:3.9 registry.k8s.io/etcd:3.5.9-0 registry.k8s.io/coredns/coredns:v1.10.1 gcr.io/k8s-minikube/storage-provisioner:v5]
...
I1126 22:25:11.544147   26459 image.go:134] retrieving image: registry.k8s.io/kube-proxy:v1.28.4
...
I1126 22:25:11.547965   26459 image.go:177] daemon lookup for registry.k8s.io/kube-proxy:v1.28.4: Error response from daemon: No such image: registry.k8s.io/kube-proxy:v1.28.4
...
I1126 22:25:11.963349   26459 ssh_runner.go:195] Run: /bin/bash -c "sudo ctr -n=k8s.io images check | grep registry.k8s.io/kube-proxy:v1.28.4"
...
I1126 22:25:12.937500   26459 cache_images.go:116] "registry.k8s.io/kube-proxy:v1.28.4" needs transfer: "registry.k8s.io/kube-proxy:v1.28.4" does not exist at hash "83f6cc407eed88d214aad97f3539bde5c8e485ff14424cd021a3a2899304398e" in container runtime
...
I1126 22:25:12.937543   26459 cri.go:218] Removing image: registry.k8s.io/kube-proxy:v1.28.4
...
I1126 22:25:13.509165   26459 ssh_runner.go:195] Run: sudo /usr/bin/crictl rmi registry.k8s.io/kube-proxy:v1.28.4
...
I1126 22:25:14.276116   26459 cache_images.go:286] Loading image from: /home/prezha/.minikube/cache/images/amd64/registry.k8s.io/kube-proxy_v1.28.4
...
W1126 22:25:14.361961   26459 out.go:239] ❌  Unable to load cached images: loading cached images: stat /home/prezha/.minikube/cache/images/amd64/registry.k8s.io/kube-proxy_v1.28.4: no such file or directory
❌  Unable to load cached images: loading cached images: stat /home/prezha/.minikube/cache/images/amd64/registry.k8s.io/kube-proxy_v1.28.4: no such file or directory
...
```
so, the above underlying error:
>I1126 22:25:12.937500   26459 cache_images.go:116] "registry.k8s.io/kube-proxy:v1.28.4" needs transfer: "registry.k8s.io/kube-proxy:v1.28.4" does not exist at hash "83f6cc407eed88d214aad97f3539bde5c8e485ff14424cd021a3a2899304398e" in container runtime

comes from [this](https://github.com/kubernetes/minikube/blob/b1c5d95745e0c01b04ab55c5bf7f874332a219f3/pkg/minikube/machine/cache_images.go#L117) line, and that effectively come from this [block](https://github.com/kubernetes/minikube/blob/b1c5d95745e0c01b04ab55c5bf7f874332a219f3/pkg/minikube/cruntime/containerd.go#L251-L258)

looking at the crt output, we have:
```
$ sudo ctr -n=k8s.io images list
REF                                                                                                             TYPE                                                      DIGEST                                                                  SIZE      PLATFORMS                                                                     LABELS
...
registry.k8s.io/kube-proxy:v1.28.4                                                                              application/vnd.docker.distribution.manifest.list.v2+json sha256:e63408a0f5068a7e9d4b34fd72b4a2b0e5512509b53cd2123a37fc991b0ef532 23.4 MiB  linux/amd64,linux/arm64,linux/ppc64le,linux/s390x                             io.cri-containerd.image=managed
...
registry.k8s.io/kube-proxy@sha256:e63408a0f5068a7e9d4b34fd72b4a2b0e5512509b53cd2123a37fc991b0ef532              application/vnd.docker.distribution.manifest.list.v2+json sha256:e63408a0f5068a7e9d4b34fd72b4a2b0e5512509b53cd2123a37fc991b0ef532 23.4 MiB  linux/amd64,linux/arm64,linux/ppc64le,linux/s390x                             io.cri-containerd.image=managed
...
sha256:83f6cc407eed88d214aad97f3539bde5c8e485ff14424cd021a3a2899304398e                                         application/vnd.docker.distribution.manifest.list.v2+json sha256:e63408a0f5068a7e9d4b34fd72b4a2b0e5512509b53cd2123a37fc991b0ef532 23.4 MiB  linux/amd64,linux/arm64,linux/ppc64le,linux/s390x                             io.cri-containerd.image=managed
...
```
which has image `ref` and image `digest` sha in each line, whereas we want image ref and image `id` sha on the same line, and hence that fails (as there's image id on a separate "line")

to prove the point, `cricrl` gives both image ref and id on the same line (from the same minikube cluster):
```
$ sudo crictl images --no-trunc --digests
IMAGE                                     TAG                  DIGEST                                                                    IMAGE ID                                                                  SIZE
...
registry.k8s.io/kube-proxy                v1.28.4              sha256:e63408a0f5068a7e9d4b34fd72b4a2b0e5512509b53cd2123a37fc991b0ef532   sha256:83f6cc407eed88d214aad97f3539bde5c8e485ff14424cd021a3a2899304398e   24.6MB
...
```
## test:
> $ time minikube start --driver kvm --container-runtime containerd --alsologtostderr -v=7

### before:
```
real    0m58.370s
user    0m1.498s
sys     0m0.620s
```

### after:
```
real    0m33.686s
user    0m1.356s
sys     0m0.404s
```
test output:
```
I1127 23:06:49.993578  115508 cache_images.go:88] LoadImages start: [registry.k8s.io/kube-apiserver:v1.28.4 registry.k8s.io/kube-controller-manager:v1.28.4 registry.k8s.io/kube-scheduler:v1.28.4 registry.k8s.io/kube-proxy:v1.28.4 registry.k8s.io/pause:3.9 registry.k8s.io/etcd:3.5.9-0 registry.k8s.io/coredns/coredns:v1.10.1 gcr.io/k8s-minikube/storage-provisioner:v5]
...
I1127 23:06:49.993720  115508 image.go:134] retrieving image: registry.k8s.io/kube-proxy:v1.28.4
...
I1127 23:06:49.994852  115508 image.go:177] daemon lookup for registry.k8s.io/kube-proxy:v1.28.4: Error response from daemon: No such image: registry.k8s.io/kube-proxy:v1.28.4
...
I1127 23:06:50.401707  115508 ssh_runner.go:195] Run: sudo ctr -n=k8s.io images check
...
I1127 23:06:50.906378  115508 cache_images.go:123] Successfully loaded all cached images
...
```