### PR TITLE
minikube cp create non-existing directory instead of failing

### DIFF
--- a/pkg/minikube/command/ssh_runner.go
+++ b/pkg/minikube/command/ssh_runner.go
@@ -406,7 +406,7 @@ func (s *SSHRunner) Copy(f assets.CopyableFile) error {
 		return nil
 	})
 
-	scp := fmt.Sprintf("sudo test -d %s && sudo scp -t %s", f.GetTargetDir(), f.GetTargetDir())
+	scp := fmt.Sprintf("sudo mkdir -p %s && sudo scp -t %s", f.GetTargetDir(), f.GetTargetDir())
 	mtime, err := f.GetModTime()
 	if err != nil {
 		klog.Infof("error getting modtime for %s: %v", dst, err)

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -1774,6 +1774,9 @@ func validateCpCmd(ctx context.Context, t *testing.T, profile string) {
 
 	tmpPath := filepath.Join(tmpDir, "cp-test.txt")
 	testCpCmd(ctx, t, profile, profile, dstPath, "", tmpPath)
+
+	// copy to nonexistent directory structure
+	testCpCmd(ctx, t, profile, "", srcPath, "", "/tmp/does/not/exist/cp-test.txt")
 }
 
 // validateMySQL validates a minimalist MySQL deployment


### PR DESCRIPTION
As per discussion, in #17576 the ssh command was changed from `test -d %s` to `mkdir -p %s`.  

fixes #17576 

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
