### PR TITLE
Adding the active kubecontext to minikube profile list command

### DIFF
--- a/cmd/minikube/cmd/config/profile_list.go
+++ b/cmd/minikube/cmd/config/profile_list.go
@@ -190,7 +190,7 @@ func profileStatus(p *config.Profile, api libmachine.API) string {
 
 func renderProfilesTable(ps [][]string) {
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"Profile", "VM Driver", "Runtime", "IP", "Port", "Version", "Status", "Nodes", "Active"})
+	table.SetHeader([]string{"Profile", "VM Driver", "Runtime", "IP", "Port", "Version", "Status", "Nodes", "Active Kubecontext"})
 	table.SetAutoFormatHeaders(false)
 	table.SetBorders(tablewriter.Border{Left: true, Top: true, Right: true, Bottom: true})
 	table.SetCenterSeparator("|")
@@ -217,11 +217,14 @@ func profilesToTableData(profiles []*config.Profile) [][]string {
 		if k8sVersion == constants.NoKubernetesVersion { // for --no-kubernetes flag
 			k8sVersion = "N/A"
 		}
-		var c string
+		var c, k string
 		if p.Name == currentProfile {
 			c = "*"
 		}
-		data = append(data, []string{p.Name, p.Config.Driver, p.Config.KubernetesConfig.ContainerRuntime, cpIP, strconv.Itoa(cpPort), k8sVersion, p.Status, strconv.Itoa(len(p.Config.Nodes)), c})
+		if p.ActiveKubeContext {
+			k = "*"
+		}
+		data = append(data, []string{p.Name, p.Config.Driver, p.Config.KubernetesConfig.ContainerRuntime, cpIP, strconv.Itoa(cpPort), k8sVersion, p.Status, strconv.Itoa(len(p.Config.Nodes)), c, k})
 	}
 	return data
 }

--- a/cmd/minikube/cmd/config/profile_list.go
+++ b/cmd/minikube/cmd/config/profile_list.go
@@ -190,7 +190,7 @@ func profileStatus(p *config.Profile, api libmachine.API) string {
 
 func renderProfilesTable(ps [][]string) {
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"Profile", "VM Driver", "Runtime", "IP", "Port", "Version", "Status", "Nodes", "Active Kubecontext"})
+	table.SetHeader([]string{"Profile", "VM Driver", "Runtime", "IP", "Port", "Version", "Status", "Nodes", "Active Profile", "Active Kubecontext"})
 	table.SetAutoFormatHeaders(false)
 	table.SetBorders(tablewriter.Border{Left: true, Top: true, Right: true, Bottom: true})
 	table.SetCenterSeparator("|")

--- a/pkg/minikube/config/profile.go
+++ b/pkg/minikube/config/profile.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/localpath"
+	"k8s.io/minikube/pkg/minikube/kubeconfig"
 	"k8s.io/minikube/pkg/util/lock"
 )
 
@@ -200,6 +201,10 @@ func ListProfiles(miniHome ...string) (validPs []*Profile, inValidPs []*Profile,
 		pDirs = append(pDirs, cs...)
 	}
 
+	activeKubeContext, err := kubeconfig.GetCurrentContext(kubeconfig.PathFromEnv())
+	if err != nil {
+		return nil, nil, err
+	}
 	nodeNames := map[string]bool{}
 	for _, n := range removeDupes(pDirs) {
 		p, err := LoadProfile(n, miniHome...)
@@ -214,6 +219,9 @@ func ListProfiles(miniHome ...string) (validPs []*Profile, inValidPs []*Profile,
 		validPs = append(validPs, p)
 		if p.Name == activeP {
 			p.Active = true
+		}
+		if p.Name == activeKubeContext {
+			p.ActiveKubeContext = true
 		}
 		for _, child := range p.Config.Nodes {
 			nodeNames[MachineName(*p.Config, child)] = true

--- a/pkg/minikube/config/profile.go
+++ b/pkg/minikube/config/profile.go
@@ -27,8 +27,8 @@ import (
 	"github.com/spf13/viper"
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
-	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/minikube/kubeconfig"
+	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/util/lock"
 )
 

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -29,6 +29,7 @@ type Profile struct {
 	Status string // running, stopped, paused, unknown
 	Config *ClusterConfig
 	Active bool
+	ActiveKubeContext bool
 }
 
 // ClusterConfig contains the parameters used to start a cluster.

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -25,10 +25,10 @@ import (
 
 // Profile represents a minikube profile
 type Profile struct {
-	Name   string
-	Status string // running, stopped, paused, unknown
-	Config *ClusterConfig
-	Active bool
+	Name              string
+	Status            string // running, stopped, paused, unknown
+	Config            *ClusterConfig
+	Active            bool
 	ActiveKubeContext bool
 }
 

--- a/pkg/minikube/kubeconfig/context.go
+++ b/pkg/minikube/kubeconfig/context.go
@@ -45,6 +45,20 @@ func UnsetCurrentContext(machineName string, configPath ...string) error {
 	return nil
 }
 
+// GetCurrentContext gets the kubectl's current-context
+func GetCurrentContext(configPath ...string) (string, error) {
+	fPath := PathFromEnv()
+	if configPath != nil {
+		fPath = configPath[0]
+	}
+	kcfg, err := readOrNew(fPath)
+	if err != nil {
+		return "", errors.Wrap(err, "Error getting kubeconfig status")
+	}
+
+	return kcfg.CurrentContext, err
+}
+
 // SetCurrentContext sets the kubectl's current-context
 func SetCurrentContext(name string, configPath ...string) error {
 	fPath := PathFromEnv()


### PR DESCRIPTION
The `minikube profile list` does not show the active kubecontext as pointed out in #16604. The active kubecontext was added to the profiles as `ActiveKubeContext` similar to the `Active` property of the existing implementation. This allows older version, which rely on the json field `Active`, to still work and additionally obtain the information about `ActiveKubeContext`. The table representation for the minikube profile list command was updated as well. Active minikube profiles are highlighted in the `Profile` column. The Active column was replaced with an Active Kubecontext column.

Table representation before PR:
```shell
minikube profile list
|-----------|-----------|---------|--------------|------|---------|---------|-------|--------------------|
|  Profile  | VM Driver | Runtime |      IP      | Port | Version | Status  | Nodes | Active             |
|-----------|-----------|---------|--------------|------|---------|---------|-------|--------------------|
| minikube  | docker    | docker  | 192.168.49.2 | 8443 | v1.28.4 | Running |     1 |                    |
| minikube2 | docker    | docker  | 192.168.58.2 | 8443 | v1.28.4 | Running |     1 | *                  |
|-----------|-----------|---------|--------------|------|---------|---------|-------|--------------------|
```

Table representation after PR:
```shell
minikube profile list -o table
|-----------|-----------|---------|--------------|------|---------|---------|-------|--------------------|
|  Profile  | VM Driver | Runtime |      IP      | Port | Version | Status  | Nodes | Active Kubecontext |
|-----------|-----------|---------|--------------|------|---------|---------|-------|--------------------|
| *minikube | docker    | docker  | 192.168.49.2 | 8443 | v1.28.4 | Running |     1 |                    |
| minikube2 | docker    | docker  | 192.168.58.2 | 8443 | v1.28.4 | Running |     1 | *                  |
|-----------|-----------|---------|--------------|------|---------|---------|-------|--------------------|
```
JSON representation before PR:
```shell
minikube profile list -o json | jq
{
  "invalid": [],
  "valid": [
    {
      "Name": "minikube",
      "Status": "Running",
...output omitted...
      "Active": true
    },
    {
      "Name": "minikube2",
      "Status": "Running",
...output omitted...
      "Active": false
    }
  ]
}
```

JSON representation after PR:
```shell
minikube profile list -o json | jq
{
  "invalid": [],
  "valid": [
    {
      "Name": "minikube",
      "Status": "Running",
...output omitted...
      "Active": true,
      "ActiveKubeContext": false
    },
    {
      "Name": "minikube2",
      "Status": "Running",
...output omitted...
      "Active": false,
      "ActiveKubeContext": true
    }
  ]
}
```

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
