### PR TITLE
addons: Update Inspektor Gadget entrypoint and cleanup.

### DIFF
--- a/deploy/addons/inspektor-gadget/ig-daemonset.yaml.tmpl
+++ b/deploy/addons/inspektor-gadget/ig-daemonset.yaml.tmpl
@@ -32,12 +32,12 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         image: {{.CustomRegistries.InspektorGadget  | default .ImageRepository | default .Registries.InspektorGadget }}{{.Images.InspektorGadget}}
         imagePullPolicy: "Always"
-        command: [ "/entrypoint.sh" ]
+        command: [ "/entrypoint" ]
         lifecycle:
           preStop:
             exec:
               command:
-                - "/cleanup.sh"
+                - "/cleanup"
         readinessProbe:
           periodSeconds: 5
           timeoutSeconds: 2

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -315,7 +315,7 @@ var Addons = map[string]*Addon{
 		MustBinAsset(addons.InspektorGadgetAssets, "inspektor-gadget/ig-daemonset.yaml.tmpl", vmpath.GuestAddonsDir, "ig-daemonset.yaml", "0640"),
 	}, false, "inspektor-gadget", "3rd party (inspektor-gadget.io)", "https://github.com/orgs/inspektor-gadget/people", "https://minikube.sigs.k8s.io/docs/handbook/addons/inspektor-gadget/",
 		map[string]string{
-			"InspektorGadget": "inspektor-gadget/inspektor-gadget:v0.22.0@sha256:9272c2be979a9857971fc8b6f7226e609cadec8352f97e9769081930121ef27f",
+			"InspektorGadget": "inspektor-gadget/inspektor-gadget:v0.23.1@sha256:c77d8eb2b3dc6e9d60767f824b296e42d6d4fdc2f17f507492a2c981933db931",
 		}, map[string]string{
 			"InspektorGadget": "ghcr.io",
 		}),


### PR DESCRIPTION
Hi!


Inspektor Gadget container entrypoint and cleanup programs were translated from
bash to golang [1, 2].
Upstream YAML file used to deploy was updated to reflect this change [3].

Sadly, it was not the case for the YAML used to deploy the minikube addon which
leaded to troubles [4, 5, 6].

The present commit updates the minikube addon YAML to use the correct programs
as entrypoint and cleanup.


Best regards.

---
```
[1]: https://github.com/inspektor-gadget/inspektor-gadget/commit/b268d38758cfc175a9fc7bddea82c937e9668542
[2]: https://github.com/inspektor-gadget/inspektor-gadget/commit/3dba83f2ebe8cb8d08dbe1b81ab0cb24531fe5b0
[3]: https://github.com/inspektor-gadget/inspektor-gadget/commit/992399f2ddd3392615860b75d6251ac3e1706231#diff-0927404b80a3c13f63de64a0c7af1833ba3dfd4b4e1dd07b09cb8216c7f033fcR46
[4]: https://storage.googleapis.com/minikube-builds/logs/17731/32161/Docker_Linux_crio_arm64.html#fail_TestAddons/parallel/InspektorGadget
[5]: https://storage.googleapis.com/minikube-builds/logs/17731/32161/Docker_Linux_crio.html#fail_TestAddons/parallel/InspektorGadget
[6]: https://storage.googleapis.com/minikube-builds/logs/17731/32161/KVM_Linux_crio.html#fail_TestAddons/parallel/InspektorGadget
```