### PR TITLE
CI: Cleanup Cloud Shell instance

### DIFF
--- a/hack/jenkins/cloud_shell_functional_tests_docker.sh
+++ b/hack/jenkins/cloud_shell_functional_tests_docker.sh
@@ -25,6 +25,7 @@
 set -x
 
 gcloud cloud-shell ssh --authorize-session << EOF
+ sudo rm -rf .cache .kube out testdata go
  OS="linux"
  ARCH="amd64"
  DRIVER="docker"


### PR DESCRIPTION
Our Cloud Shell functional tests are failing to run because the instance is full (4.8 GB). On every start clear out directories that gather significant sizes.
