### PR TITLE
CI: Fix missing entries from PR description

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,9 +26,9 @@ jobs:
           make generate-docs
           c=$(git status --porcelain)
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$c" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$c" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         if: ${{ steps.gendocs.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38

--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -25,9 +25,9 @@ jobs:
           make update-leaderboard
           c=$(git status --porcelain)
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$c" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$c" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.MINIKUBE_BOT_PAT }}
       - name: Create PR

--- a/.github/workflows/time-to-k8s.yml
+++ b/.github/workflows/time-to-k8s.yml
@@ -24,7 +24,7 @@ jobs:
         id: timeToK8sBenchmark
         run: |
           ./hack/benchmark/time-to-k8s/time-to-k8s.sh
-          echo "version=$(minikube version --short)" >> $GITHUB_OUTPUT
+          echo "version=$(minikube version --short)" >> "$GITHUB_OUTPUT"
       - name: Create PR
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38
         with:

--- a/.github/workflows/update-buildkit-version.yml
+++ b/.github/workflows/update-buildkit-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump buildkit Version
         id: bumpBuildkit
         run: |
-          echo "OLD_VERSION=$(DEP=buildkit make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=buildkit make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-buildkit-version
-          echo "NEW_VERSION=$(DEP=buildkit make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=buildkit make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         id: createPR
         if: ${{ steps.bumpBuildkit.outputs.changes != '' }}

--- a/.github/workflows/update-calico-version.yml
+++ b/.github/workflows/update-calico-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump calico version
         id: bumpCalico
         run: |
-          echo "OLD_VERSION=$(DEP=calico make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=calico make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-calico-version
-          echo "NEW_VERSION=$(DEP=calico make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=calico make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         if: ${{ steps.bumpCalico.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38

--- a/.github/workflows/update-cloud-spanner-emulator-version.yml
+++ b/.github/workflows/update-cloud-spanner-emulator-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump cloud-spanner-emulator version
         id: bumpCloudSpannerEmulator
         run: |
-          echo "OLD_VERSION=$(DEP=cloud-spanner make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=cloud-spanner make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-cloud-spanner-emulator-version
-          echo "NEW_VERSION=$(DEP=cloud-spanner make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=cloud-spanner make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         if: ${{ steps.bumpCloudSpannerEmulator.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38

--- a/.github/workflows/update-cni-plugins-version.yml
+++ b/.github/workflows/update-cni-plugins-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump cni-plugins Version
         id: bumpCNIPlugins
         run: |
-          echo "OLD_VERSION=$(DEP=cni-plugins make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=cni-plugins make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-cni-plugins-version
-          echo "NEW_VERSION=$(DEP=cni-plugins make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=cni-plugins make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         id: createPR
         if: ${{ steps.bumpCNIPlugins.outputs.changes != '' }}

--- a/.github/workflows/update-containerd-version.yml
+++ b/.github/workflows/update-containerd-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump containerd Version
         id: bumpContainerd
         run: |
-          echo "OLD_VERSION=$(DEP=containerd make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=containerd make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-containerd-version
-          echo "NEW_VERSION=$(DEP=containerd make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=containerd make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         id: createPR
         if: ${{ steps.bumpContainerd.outputs.changes != '' }}

--- a/.github/workflows/update-cri-dockerd-version.yml
+++ b/.github/workflows/update-cri-dockerd-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump cri-dockerd version
         id: bumpCriDockerd
         run: |
-          echo "OLD_VERSION=$(DEP=cri-dockerd make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=cri-dockerd make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-cri-dockerd-version
-          echo "NEW_VERSION=$(DEP=cri-dockerd make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=cri-dockerd make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         id: createPR
         if: ${{ steps.bumpCriDockerd.outputs.changes != '' }}

--- a/.github/workflows/update-cri-o-version.yml
+++ b/.github/workflows/update-cri-o-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump cri-o Version
         id: bumpCrio
         run: |
-          echo "OLD_VERSION=$(DEP=cri-o make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=cri-o make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-cri-o-version
-          echo "NEW_VERSION=$(DEP=cri-o make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=cri-o make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         id: createPR
         if: ${{ steps.bumpCrio.outputs.changes != '' }}

--- a/.github/workflows/update-crictl-version.yml
+++ b/.github/workflows/update-crictl-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump crictl Version
         id: bumpCrictl
         run: |
-          echo "OLD_VERSION=$(DEP=crictl make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=crictl make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-crictl-version
-          echo "NEW_VERSION=$(DEP=crictl make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=crictl make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         id: createPR
         if: ${{ steps.bumpCrictl.outputs.changes != '' }}

--- a/.github/workflows/update-docker-buildx-version.yml
+++ b/.github/workflows/update-docker-buildx-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump docker-buildx Version
         id: bumpDockerBuildx
         run: |
-          echo "OLD_VERSION=$(DEP=docker-buildx make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=docker-buildx make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-docker-buildx-version
-          echo "NEW_VERSION=$(DEP=docker-buildx make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=docker-buildx make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         id: createPR
         if: ${{ steps.bumpDockerBuildx.outputs.changes != '' }}

--- a/.github/workflows/update-docker-version.yml
+++ b/.github/workflows/update-docker-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump docker Version
         id: bumpDocker
         run: |
-          echo "OLD_VERSION=$(DEP=docker make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=docker make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-docker-version
-          echo "NEW_VERSION=$(DEP=docker make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=docker make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         id: createPR
         if: ${{ steps.bumpDocker.outputs.changes != '' }}

--- a/.github/workflows/update-docsy-version.yml
+++ b/.github/workflows/update-docsy-version.yml
@@ -24,9 +24,9 @@ jobs:
         run: |
           make update-docsy-version
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         if: ${{ steps.bumpDocsy.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38

--- a/.github/workflows/update-flannel-version.yml
+++ b/.github/workflows/update-flannel-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump flannel version
         id: bumpFlannel
         run: |
-          echo "OLD_VERSION=$(DEP=flannel make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=flannel make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-flannel-version
-          echo "NEW_VERSION=$(DEP=flannel make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=flannel make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         if: ${{ steps.bumpFlannel.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38

--- a/.github/workflows/update-gcp-auth-version.yml
+++ b/.github/workflows/update-gcp-auth-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump gcp-auth version
         id: bumpGCPAuth
         run: |
-          echo "OLD_VERSION=$(DEP=gcp-auth make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=gcp-auth make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-gcp-auth-version
-          echo "NEW_VERSION=$(DEP=gcp-auth make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=gcp-auth make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         if: ${{ steps.bumpGCPAuth.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38

--- a/.github/workflows/update-gh-version.yml
+++ b/.github/workflows/update-gh-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump gh version
         id: bumpGh
         run: |
-          echo "OLD_VERSION=$(DEP=gh make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=gh make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-gh-version
-          echo "NEW_VERSION=$(DEP=gh make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=gh make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         if: ${{ steps.bumpGh.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38

--- a/.github/workflows/update-go-github-version.yml
+++ b/.github/workflows/update-go-github-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump go-github version
         id: bumpGoGithub
         run: |
-          echo "OLD_VERSION=$(DEP=go-github make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=go-github make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-go-github-version
-          echo "NEW_VERSION=$(DEP=go-github make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=go-github make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         if: ${{ steps.bumpGoGithub.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38

--- a/.github/workflows/update-golang-version.yml
+++ b/.github/workflows/update-golang-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump Golang Versions
         id: bumpGolang
         run: |
-          echo "OLD_VERSION=$(DEP=go make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=go make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-golang-version
-          echo "NEW_VERSION=$(DEP=go make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=go make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         if: ${{ steps.bumpGolang.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38

--- a/.github/workflows/update-golint-version.yml
+++ b/.github/workflows/update-golint-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump Golint Versions
         id: bumpGolint
         run: |
-          echo "OLD_VERSION=$(DEP=golint make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=golint make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-golint-version
-          echo "NEW_VERSION=$(DEP=golint make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=golint make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         if: ${{ steps.bumpGolint.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38

--- a/.github/workflows/update-gopogh-version.yml
+++ b/.github/workflows/update-gopogh-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump gopogh Versions
         id: bumpGopogh
         run: |
-          echo "OLD_VERSION=$(DEP=gopogh make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=gopogh make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-gopogh-version
-          echo "NEW_VERSION=$(DEP=gopogh make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=gopogh make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         if: ${{ steps.bumpGopogh.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38

--- a/.github/workflows/update-gotestsum-version.yml
+++ b/.github/workflows/update-gotestsum-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump Gotestsum Versions
         id: bumpGotestsum
         run: |
-          echo "OLD_VERSION=$(DEP=gotestsum make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=gotestsum make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-gotestsum-version
-          echo "NEW_VERSION=$(DEP=gotestsum make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=gotestsum make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         if: ${{ steps.bumpGotestsum.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38

--- a/.github/workflows/update-hugo-version.yml
+++ b/.github/workflows/update-hugo-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump Hugo version
         id: bumpHugo
         run: |
-          echo "OLD_VERSION=$(DEP=hugo make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=hugo make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-hugo-version
-          echo "NEW_VERSION=$(DEP=hugo make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=hugo make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         if: ${{ steps.bumpHugo.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38

--- a/.github/workflows/update-ingress-version.yml
+++ b/.github/workflows/update-ingress-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump ingress version
         id: bumpIngress
         run: |
-          echo "OLD_VERSION=$(DEP=ingress make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=ingress make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-ingress-version
-          echo "NEW_VERSION=$(DEP=ingress make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=ingress make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         if: ${{ steps.bumpIngress.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38

--- a/.github/workflows/update-inspektor-gadget-version.yml
+++ b/.github/workflows/update-inspektor-gadget-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump inspektor-gadget version
         id: bumpInspektorGadget
         run: |
-          echo "OLD_VERSION=$(DEP=inspektor-gadget make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=inspektor-gadget make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-inspektor-gadget-version
-          echo "NEW_VERSION=$(DEP=inspektor-gadget make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=inspektor-gadget make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         if: ${{ steps.bumpInspektorGadget.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38

--- a/.github/workflows/update-iso-image-versions.yml
+++ b/.github/workflows/update-iso-image-versions.yml
@@ -45,34 +45,36 @@ jobs:
           NEW_NERDCTLD=$(DEP=nerdctld make get-dependency-version)
           NEW_RUNC=$(DEP=runc make get-dependency-version)
           NEW_UBUNTU=$(DEP=ubuntu make get-dependency-version)
+          echo "changelog<<EOF" >> "$GITHUB_OUTPUT"
           if [ "$OLD_BUILDKIT" != "$NEW_BUILDKIT" ]; then
-            echo "changelog=https://github.com/moby/buildkit/releases/tag/$NEW_BUILDKIT" >> $GITHUB_OUTPUT
+            echo "https://github.com/moby/buildkit/releases/tag/$NEW_BUILDKIT" >> "$GITHUB_OUTPUT"
           fi
           if [ "$OLD_CNI_PLUGINS" != "$NEW_CNI_PLUGINS" ]; then
-            echo "changelog=https://github.com/containernetworking/plugins/releases/tag/$NEW_CNI_PLUGINS" >> $GITHUB_OUTPUT
+            echo "https://github.com/containernetworking/plugins/releases/tag/$NEW_CNI_PLUGINS" >> "$GITHUB_OUTPUT"
           fi
           if [ "$OLD_CONTAINERD" != "$NEW_CONTAINERD" ]; then
-            echo "changelog=https://github.com/containerd/containerd/releases/tag/$NEW_CONTAINERD" >> $GITHUB_OUTPUT
+            echo "https://github.com/containerd/containerd/releases/tag/$NEW_CONTAINERD" >> "$GITHUB_OUTPUT"
           fi
           if [ "$OLD_CRICTL" != "$NEW_CRICTL" ]; then
-            echo "changelog=https://github.com/kubernetes-sigs/cri-tools/releases/tag/$NEW_CRICTL" >> $GITHUB_OUTPUT
+            echo "https://github.com/kubernetes-sigs/cri-tools/releases/tag/$NEW_CRICTL" >> "$GITHUB_OUTPUT"
           fi
           if [ "$OLD_DOCKER" != "$NEW_DOCKER" ]; then
-            echo "changelog=https://github.com/moby/moby/releases/tag/v$NEW_DOCKER" >> $GITHUB_OUTPUT
+            echo "https://github.com/moby/moby/releases/tag/v$NEW_DOCKER" >> "$GITHUB_OUTPUT"
           fi
           if [ "$OLD_NERDCTL" != "$NEW_NERDCTL" ]; then
-            echo "changelog=https://github.com/containerd/nerdctl/releases/tag/v$NEW_NERDCTL" >> $GITHUB_OUTPUT
+            echo "https://github.com/containerd/nerdctl/releases/tag/v$NEW_NERDCTL" >> "$GITHUB_OUTPUT"
           fi
           if [ "$OLD_NERDCTLD" != "$NEW_NERDCTLD" ]; then
-            echo "changelog=https://github.com/afbjorklund/nerdctld/releases/tag/v$NEW_NERDCTL" >> $GITHUB_OUTPUT
+            echo "https://github.com/afbjorklund/nerdctld/releases/tag/v$NEW_NERDCTL" >> "$GITHUB_OUTPUT"
           fi
           if [ "$OLD_RUNC" != "$NEW_RUNC" ]; then
-            echo "changelog=https://github.com/opencontainers/runc/releases/tag/$NEW_RUNC" >> $GITHUB_OUTPUT
+            echo "https://github.com/opencontainers/runc/releases/tag/$NEW_RUNC" >> "$GITHUB_OUTPUT"
           fi
+          echo "EOF" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         id: createPR
         if: ${{ steps.bumpVersions.outputs.changes != '' }}

--- a/.github/workflows/update-istio-operator.yml
+++ b/.github/workflows/update-istio-operator.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump istio-operator version
         id: bumpIstioOperator
         run: |
-          echo "OLD_VERSION=$(DEP=istio-operator make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=istio-operator make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-istio-operator-version
-          echo "NEW_VERSION=$(DEP=istio-operator make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=istio-operator make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         if: ${{ steps.bumpIstioOperator.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38

--- a/.github/workflows/update-k8s-versions.yml
+++ b/.github/workflows/update-k8s-versions.yml
@@ -24,12 +24,12 @@ jobs:
         run: |
           t=$(make update-kubernetes-version)
           t=$(echo $t | head -n 1)
-          echo "title=$t" >> $GITHUB_OUTPUT
+          echo "title=$t" >> "$GITHUB_OUTPUT"
           c=$(git status --porcelain)
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$c" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$c" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         if: ${{ steps.bumpk8s.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38

--- a/.github/workflows/update-kindnetd-version.yml
+++ b/.github/workflows/update-kindnetd-version.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Bump kindnetd version
         id: bumpKindnetd
         run: |
-          echo "OLD_VERSION=$(DEP=kindnetd make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=kindnetd make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-kindnetd-version
-          echo "NEW_VERSION=$(DEP=kindnetd make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=kindnetd make get-dependency-version)" >> "$GITHUB_OUTPUT"
           c=$(git status --porcelain)
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$c" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$c" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         id: createPR
         if: ${{ steps.bumpKindnetd.outputs.changes != '' }}

--- a/.github/workflows/update-kong-ingress-controller-version.yml
+++ b/.github/workflows/update-kong-ingress-controller-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump kong-ingress-controller version
         id: bumpKongIngressController
         run: |
-          echo "OLD_VERSION=$(DEP=kong-ingress-controller make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=kong-ingress-controller make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-kong-ingress-controller-version
-          echo "NEW_VERSION=$(DEP=kong-ingress-controller make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=kong-ingress-controller make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         if: ${{ steps.bumpKongIngressController.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38

--- a/.github/workflows/update-kong-version.yml
+++ b/.github/workflows/update-kong-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump kong version
         id: bumpKong
         run: |
-          echo "OLD_VERSION=$(DEP=kong make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=kong make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-kong-version
-          echo "NEW_VERSION=$(DEP=kong make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=kong make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         if: ${{ steps.bumpKong.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38

--- a/.github/workflows/update-kubeadm-constants.yml
+++ b/.github/workflows/update-kubeadm-constants.yml
@@ -25,9 +25,9 @@ jobs:
           make update-kubeadm-constants
           c=$(git status --porcelain)
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$c" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$c" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         if: ${{ steps.bumpKubeadmConsts.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38

--- a/.github/workflows/update-kubernetes-versions-list.yml
+++ b/.github/workflows/update-kubernetes-versions-list.yml
@@ -25,9 +25,9 @@ jobs:
           make update-kubernetes-versions-list
           c=$(git status --porcelain)
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$c" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$c" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         if: ${{ steps.bumpKubernetesVersionsList.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38

--- a/.github/workflows/update-metrics-server-version.yml
+++ b/.github/workflows/update-metrics-server-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump metrics-server version
         id: bumpMetricsServer
         run: |
-          echo "OLD_VERSION=$(DEP=metrics-server make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=metrics-server make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-metrics-server-version
-          echo "NEW_VERSION=$(DEP=metrics-server make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=metrics-server make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         if: ${{ steps.bumpMetricsServer.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38

--- a/.github/workflows/update-nerdctl-version.yml
+++ b/.github/workflows/update-nerdctl-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump nerdctl Version
         id: bumpNerdctl
         run: |
-          echo "OLD_VERSION=$(DEP=nerdctl make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=nerdctl make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-nerdctl-version
-          echo "NEW_VERSION=$(DEP=nerdctl make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=nerdctl make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         id: createPR
         if: ${{ steps.bumpNerdctl.outputs.changes != '' }}

--- a/.github/workflows/update-nerdctld-version.yml
+++ b/.github/workflows/update-nerdctld-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump nerdctld Version
         id: bumpNerdctld
         run: |
-          echo "OLD_VERSION=$(DEP=nerdctld make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=nerdctld make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-nerdctld-version
-          echo "NEW_VERSION=$(DEP=nerdctld make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=nerdctld make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         id: createPR
         if: ${{ steps.bumpNerdctld.outputs.changes != '' }}

--- a/.github/workflows/update-nvidia-device-plugin-version.yml
+++ b/.github/workflows/update-nvidia-device-plugin-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump nvidia-device-plugin version
         id: bumpNvidiaDevicePlugin
         run: |
-          echo "OLD_VERSION=$(DEP=nvidia-device-plugin make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=nvidia-device-plugin make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-nvidia-device-plugin-version
-          echo "NEW_VERSION=$(DEP=nvidia-device-plugin make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=nvidia-device-plugin make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         if: ${{ steps.bumpNvidiaDevicePlugin.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38

--- a/.github/workflows/update-registry-version.yml
+++ b/.github/workflows/update-registry-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump registry version
         id: bumpRegistry
         run: |
-          echo "OLD_VERSION=$(DEP=registry make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=registry make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-registry-version
-          echo "NEW_VERSION=$(DEP=registry make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=registry make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         if: ${{ steps.bumpRegistry.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38

--- a/.github/workflows/update-runc-version.yml
+++ b/.github/workflows/update-runc-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump runc Version
         id: bumpRunc
         run: |
-          echo "OLD_VERSION=$(DEP=runc make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=runc make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-runc-version
-          echo "NEW_VERSION=$(DEP=runc make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=runc make get-dependency-version)" >> "$GITHUB_OUTPUT"
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         id: createPR
         if: ${{ steps.bumpRunc.outputs.changes != '' }}

--- a/.github/workflows/update-ubuntu-version.yml
+++ b/.github/workflows/update-ubuntu-version.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Bump Ubuntu version
         id: bumpUbuntu
         run: |
-          echo "OLD_VERSION=$(DEP=ubuntu make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "OLD_VERSION=$(DEP=ubuntu make get-dependency-version)" >> "$GITHUB_OUTPUT"
           make update-ubuntu-version
-          echo "NEW_VERSION=$(DEP=ubuntu make get-dependency-version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(DEP=ubuntu make get-dependency-version)" >> "$GITHUB_OUTPUT"
           c=$(git status --porcelain)
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$c" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$c" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Create PR
         id: createPR
         if: ${{ steps.bumpUbuntu.outputs.changes != '' }}

--- a/.github/workflows/yearly-leaderboard.yml
+++ b/.github/workflows/yearly-leaderboard.yml
@@ -29,9 +29,9 @@ jobs:
         run: |
           make update-yearly-leaderboard
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git status --porcelain)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$(git status --porcelain)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.MINIKUBE_BOT_PAT }}
       - name: Create PR


### PR DESCRIPTION
Fixed PR description for update all job only containing one changelog entry, not shows all.

Also wrapped `$GITHUB_OUTPUT` in quotes