### PR TITLE
Add YAKD - Kubernetes Dashboard addon

### DIFF
--- a/deploy/addons/assets.go
+++ b/deploy/addons/assets.go
@@ -170,4 +170,8 @@ var (
 	// NvidiaDevicePlugin assets for nvidia-device-plugin addon
 	//go:embed nvidia-device-plugin/*.tmpl
 	NvidiaDevicePlugin embed.FS
+
+	// YakdAssets assets for yakd addon
+	//go:embed yakd/*.yaml yakd/*.tmpl
+	YakdAssets embed.FS
 )

--- a/deploy/addons/yakd/yakd-crb.yaml
+++ b/deploy/addons/yakd/yakd-crb.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: yakd-dashboard
+  labels:
+    app.kubernetes.io/name: yakd-dashboard
+    kubernetes.io/minikube-addons: yakd-dashboard
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: yakd-dashboard
+  namespace: yakd-dashboard

--- a/deploy/addons/yakd/yakd-dp.yaml.tmpl
+++ b/deploy/addons/yakd/yakd-dp.yaml.tmpl
@@ -1,0 +1,69 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    app.kubernetes.io/name: yakd-dashboard
+    app.kubernetes.io/instance: yakd-dashboard
+    kubernetes.io/minikube-addons: yakd-dashboard
+    addonmanager.kubernetes.io/mode: Reconcile
+  name: yakd-dashboard
+  namespace: yakd-dashboard
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: yakd-dashboard
+      app.kubernetes.io/instance: yakd-dashboard
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: yakd-dashboard
+        app.kubernetes.io/instance: yakd-dashboard
+        gcp-auth-skip-secret: "true"
+    spec:
+      containers:
+        - name: yakd
+          image: {{.CustomRegistries.Yakd  | default .ImageRepository | default .Registries.Yakd }}{{.Images.Yakd}}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            runAsUser: 1001
+            runAsGroup: 2001
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
+      restartPolicy: Always
+      serviceAccountName: yakd-dashboard
+      nodeSelector:
+        "kubernetes.io/os": linux

--- a/deploy/addons/yakd/yakd-ns.yaml
+++ b/deploy/addons/yakd/yakd-ns.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: yakd-dashboard
+  labels:
+    kubernetes.io/minikube-addons: yakd-dashboard
+    addonmanager.kubernetes.io/mode: Reconcile

--- a/deploy/addons/yakd/yakd-sa.yaml
+++ b/deploy/addons/yakd/yakd-sa.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: yakd-dashboard
+    kubernetes.io/minikube-addons: yakd-dashboard
+    addonmanager.kubernetes.io/mode: Reconcile
+  name: yakd-dashboard
+  namespace: yakd-dashboard

--- a/deploy/addons/yakd/yakd-svc.yaml
+++ b/deploy/addons/yakd/yakd-svc.yaml
@@ -1,0 +1,17 @@
+kind: Service
+apiVersion: v1
+metadata:
+  labels:
+    app.kubernetes.io/name: yakd-dashboard
+    kubernetes.io/minikube-addons: yakd-dashboard
+    addonmanager.kubernetes.io/mode: Reconcile
+  name: yakd-dashboard
+  namespace: yakd-dashboard
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/name: yakd-dashboard
+    app.kubernetes.io/instance: yakd-dashboard

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -150,6 +150,12 @@ kubectl get secret $SECRET --namespace headlamp --template=\{\{.data.token\}\} |
 minikube{{.profileArg}} addons enable metrics-server	
 
 `, out.V{"profileArg": tipProfileArg})
+	case "yakd":
+		out.Styled(style.Tip, `To access YAKD - Kubernetes Dashboard, wait for Pod to be ready and run the following command:
+
+	minikube service yakd-dashboard -n yakd-dashboard
+
+`)
 	}
 }
 

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -153,9 +153,9 @@ minikube{{.profileArg}} addons enable metrics-server
 	case "yakd":
 		out.Styled(style.Tip, `To access YAKD - Kubernetes Dashboard, wait for Pod to be ready and run the following command:
 
-	minikube service yakd-dashboard -n yakd-dashboard
+	minikube{{.profileArg}} service yakd-dashboard -n yakd-dashboard
 
-`)
+`, out.V{"profileArg": tipProfileArg})
 	}
 }
 

--- a/pkg/addons/config.go
+++ b/pkg/addons/config.go
@@ -232,4 +232,9 @@ var Addons = []*Addon{
 		set:       SetBool,
 		callbacks: []setFn{EnableOrDisableAddon},
 	},
+	{
+		name:      "yakd",
+		set:       SetBool,
+		callbacks: []setFn{EnableOrDisableAddon},
+	},
 }

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -787,6 +787,19 @@ var Addons = map[string]*Addon{
 		}, map[string]string{
 			"NvidiaDevicePlugin": "nvcr.io",
 		}),
+	"yakd": NewAddon([]*BinAsset{
+		MustBinAsset(addons.YakdAssets, "yakd/yakd-ns.yaml", vmpath.GuestAddonsDir, "yakd-ns.yaml", "0640"),
+		MustBinAsset(addons.YakdAssets, "yakd/yakd-sa.yaml", vmpath.GuestAddonsDir, "yakd-sa.yaml", "0640"),
+		MustBinAsset(addons.YakdAssets, "yakd/yakd-crb.yaml", vmpath.GuestAddonsDir, "yakd-crb.yaml", "0640"),
+		MustBinAsset(addons.YakdAssets, "yakd/yakd-svc.yaml", vmpath.GuestAddonsDir, "yakd-svc.yaml", "0640"),
+		MustBinAsset(addons.YakdAssets, "yakd/yakd-dp.yaml.tmpl", vmpath.GuestAddonsDir, "yakd-dp.yaml", "0640"),
+	}, false, "yakd", "3rd party (marcnuri.com)", "manusa", "https://minikube.sigs.k8s.io/docs/handbook/addons/yakd/",
+		map[string]string{
+			"Yakd": "marcnuri/yakd:0.0.3@sha256:ebb5a2378be98b0674e5fb123b37812c5f2108791bfe3a1f579bf71718eac63b",
+		},
+		map[string]string{
+			"Yakd": "docker.io",
+		}),
 }
 
 // parseMapString creates a map based on `str` which is encoded as <key1>=<value1>,<key2>=<value2>,...

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -795,7 +795,7 @@ var Addons = map[string]*Addon{
 		MustBinAsset(addons.YakdAssets, "yakd/yakd-dp.yaml.tmpl", vmpath.GuestAddonsDir, "yakd-dp.yaml", "0640"),
 	}, false, "yakd", "3rd party (marcnuri.com)", "manusa", "https://minikube.sigs.k8s.io/docs/handbook/addons/yakd/",
 		map[string]string{
-			"Yakd": "marcnuri/yakd:0.0.3@sha256:ebb5a2378be98b0674e5fb123b37812c5f2108791bfe3a1f579bf71718eac63b",
+			"Yakd": "marcnuri/yakd:0.0.4@sha256:a3f540278e4c11373e15605311851dd9c64d208f4d63e727bccc0e39f9329310",
 		},
 		map[string]string{
 			"Yakd": "docker.io",

--- a/site/content/en/docs/handbook/addons/yakd-kubernetes-dashboard.md
+++ b/site/content/en/docs/handbook/addons/yakd-kubernetes-dashboard.md
@@ -1,0 +1,42 @@
+---
+title: "Using the YAKD - Kubernetes Dashboard Addon"
+linkTitle: "YAKD - Kubernetes Dashboard"
+weight: 1
+date: 2023-12-12
+---
+
+## YAKD - Kubernetes Dashboard Addon
+
+[YAKD - Kubernetes Dashboard](https://github.com/manusa/yakd) is a full-featured web-based Kubernetes Dashboard with special functionality for Minikube.
+
+The dashboard features a real-time Search pane that allows you to search for Kubernetes resources and see them update in real-time as you type.
+
+### Enable YAKD - Kubernetes Dashboard on minikube
+
+To enable this addon, simply run:
+
+```shell script
+minikube addons enable yakd
+```
+
+Once the addon is enabled, you can access the YAKD - Kubernetes Dashboard's web UI using the following command.
+
+```shell script
+minikube service yakd-dashboard -n yakd-dashboard
+```
+
+There dashboard will open in a new browser window and you should be able to start using it with no further hassle.
+
+YAKD - Kubernetes Dashboard is also compatible with metrics-server. To install it, run:
+
+```shell script
+minikube addons enable metrics-server	
+```
+
+### Disable YAKD - Kubernetes Dashboard
+
+To disable this addon, simply run:
+
+```shell script
+minikube addons disable yakd
+```

--- a/site/content/en/docs/handbook/addons/yakd-kubernetes-dashboard.md
+++ b/site/content/en/docs/handbook/addons/yakd-kubernetes-dashboard.md
@@ -7,7 +7,7 @@ date: 2023-12-12
 
 ## YAKD - Kubernetes Dashboard Addon
 
-[YAKD - Kubernetes Dashboard](https://github.com/manusa/yakd) is a full-featured web-based Kubernetes Dashboard with special functionality for Minikube.
+[YAKD - Kubernetes Dashboard](https://github.com/manusa/yakd) is a full-featured web-based Kubernetes Dashboard with special functionality for minikube.
 
 The dashboard features a real-time Search pane that allows you to search for Kubernetes resources and see them update in real-time as you type.
 

--- a/site/content/en/docs/handbook/addons/yakd-kubernetes-dashboard.md
+++ b/site/content/en/docs/handbook/addons/yakd-kubernetes-dashboard.md
@@ -25,7 +25,7 @@ Once the addon is enabled, you can access the YAKD - Kubernetes Dashboard's web 
 minikube service yakd-dashboard -n yakd-dashboard
 ```
 
-There dashboard will open in a new browser window and you should be able to start using it with no further hassle.
+The dashboard will open in a new browser window and you should be able to start using it with no further hassle.
 
 YAKD - Kubernetes Dashboard is also compatible with metrics-server. To install it, run:
 

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -134,6 +134,7 @@ func TestAddons(t *testing.T) {
 			{"CloudSpanner", validateCloudSpannerAddon},
 			{"LocalPath", validateLocalPathAddon},
 			{"NvidiaDevicePlugin", validateNvidiaDevicePlugin},
+			{"Yakd", validateYakdAddon},
 		}
 		for _, tc := range tests {
 			tc := tc
@@ -953,5 +954,18 @@ func validateNvidiaDevicePlugin(ctx context.Context, t *testing.T, profile strin
 	}
 	if rr, err := Run(t, exec.CommandContext(ctx, Target(), "addons", "disable", "nvidia-device-plugin", "-p", profile)); err != nil {
 		t.Errorf("failed to disable nvidia-device-plugin: args %q : %v", rr.Command(), err)
+	}
+}
+
+func validateYakdAddon(ctx context.Context, t *testing.T, profile string) {
+	defer PostMortemLogs(t, profile)
+
+	rr, err := Run(t, exec.CommandContext(ctx, Target(), "addons", "enable", "yakd", "-p", profile, "--alsologtostderr", "-v=1"))
+	if err != nil {
+		t.Fatalf("failed to enable yakd addon: args: %q: %v", rr.Command(), err)
+	}
+
+	if _, err := PodWait(ctx, t, profile, "yakd-dashboard", "app.kubernetes.io/name=yakd-dashboard", Minutes(2)); err != nil {
+		t.Fatalf("failed waiting for YAKD - Kubernetes Dashboard pod: %v", err)
 	}
 }

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -99,7 +99,7 @@ func TestAddons(t *testing.T) {
 		// so we override that here to let minikube auto-detect appropriate cgroup driver
 		os.Setenv(constants.MinikubeForceSystemdEnv, "")
 
-		args := append([]string{"start", "-p", profile, "--wait=true", "--memory=4000", "--alsologtostderr", "--addons=registry", "--addons=metrics-server", "--addons=volumesnapshots", "--addons=csi-hostpath-driver", "--addons=gcp-auth", "--addons=cloud-spanner", "--addons=inspektor-gadget", "--addons=storage-provisioner-rancher", "--addons=nvidia-device-plugin"}, StartArgs()...)
+		args := append([]string{"start", "-p", profile, "--wait=true", "--memory=4000", "--alsologtostderr", "--addons=registry", "--addons=metrics-server", "--addons=volumesnapshots", "--addons=csi-hostpath-driver", "--addons=gcp-auth", "--addons=cloud-spanner", "--addons=inspektor-gadget", "--addons=storage-provisioner-rancher", "--addons=nvidia-device-plugin", "--addons=yakd"}, StartArgs()...)
 		if !NoneDriver() { // none driver does not support ingress
 			args = append(args, "--addons=ingress", "--addons=ingress-dns")
 		}
@@ -959,11 +959,6 @@ func validateNvidiaDevicePlugin(ctx context.Context, t *testing.T, profile strin
 
 func validateYakdAddon(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
-
-	rr, err := Run(t, exec.CommandContext(ctx, Target(), "addons", "enable", "yakd", "-p", profile, "--alsologtostderr", "-v=1"))
-	if err != nil {
-		t.Fatalf("failed to enable yakd addon: args: %q: %v", rr.Command(), err)
-	}
 
 	if _, err := PodWait(ctx, t, profile, "yakd-dashboard", "app.kubernetes.io/name=yakd-dashboard", Minutes(2)); err != nil {
 		t.Fatalf("failed waiting for YAKD - Kubernetes Dashboard pod: %v", err)


### PR DESCRIPTION
This PR adds an addon for automatically setting up [YAKD (Yet Another Kubernetes Dashboard)](https://github.com/manusa/yakd).

This is an alternative Kubernetes Dashboard with special support for Minikube, OpenShift, and other flavors of Kubernetes.

It was originally started as an example project for [YAKC (Yet Another Kubernetes Client)](https://github.com/manusa/yakc) but it was recently spun off as a separate project.

Regarding Minikube, it offers specific functionality such as cluster detection, support for opening `NodePort` services from the interface, and more.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
