### PR TITLE
ignore docker rmi fail with container image used by running container

### DIFF
--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -329,6 +329,11 @@ func removeExistingImage(r cruntime.Manager, src string, imgName string) error {
 	}
 
 	errStr := strings.ToLower(err.Error())
+	if strings.Contains(errStr, "is using its referenced image") {
+		klog.Warningf("Image %s is being used by a running container, skipping deletion, it would be replaced later", imgName)
+		return nil
+	}
+
 	if !strings.Contains(errStr, "no such image") {
 		return errors.Wrap(err, "removing image")
 	}


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

fix #16032

I noticed that #16032 could only be reproduced with docker as container runtime.

Because behaviors of "deleting container image which still used by running container" are different `docker` and `crictl`:

- `docker` would be fail to deleted it, with the message like `Error response from daemon: conflict: unable to remove repository reference "nginx:target" (must force) - container f5abe3488a83 is using its referenced image a6bd71f48f68`
- `crictl` would be succeed to untag the container image directly.

So this PR just ignore errors which contains `is using its referenced image`.
