### PR TITLE
CI: Build auto-pause-hook for all architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ SHA512SUM=$(shell command -v sha512sum || echo "shasum -a 512")
 GVISOR_TAG ?= latest
 
 # auto-pause-hook tag to push changes to
-AUTOPAUSE_HOOK_TAG ?= v0.0.4
+AUTOPAUSE_HOOK_TAG ?= v0.0.5
 
 # prow-test tag to push changes to
 PROW_TEST_TAG ?= v0.0.5
@@ -959,9 +959,11 @@ auto-pause-hook-image: deploy/addons/auto-pause/auto-pause-hook ## Build docker 
 	docker build -t $(REGISTRY)/auto-pause-hook:$(AUTOPAUSE_HOOK_TAG) ./deploy/addons/auto-pause
 
 .PHONY: push-auto-pause-hook-image
-push-auto-pause-hook-image: auto-pause-hook-image
+push-auto-pause-hook-image: docker-multi-arch-build
 	docker login gcr.io/k8s-minikube
-	$(MAKE) push-docker IMAGE=$(REGISTRY)/auto-pause-hook:$(AUTOPAUSE_HOOK_TAG)
+	docker buildx create --name multiarch --bootstrap
+	docker buildx build --push --builder multiarch --platform $(KICBASE_ARCH) -t $(REGISTRY)/auto-pause-hook:$(AUTOPAUSE_HOOK_TAG) -f ./deploy/addons/auto-pause/Dockerfile .
+	docker buildx rm multiarch
 
 .PHONY: push-prow-test-image
 push-prow-test-image: docker-multi-arch-build

--- a/deploy/addons/auto-pause/Dockerfile
+++ b/deploy/addons/auto-pause/Dockerfile
@@ -1,2 +1,9 @@
-FROM golang:1.21.5
-ADD auto-pause-hook /auto-pause-hook
+FROM golang:1.21.5 AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY ./ ./
+RUN GOOS=linux CGO_ENABLED=0 go build -a --ldflags '-extldflags "-static"' -tags netgo -installsuffix netgo -o auto-pause-hook cmd/auto-pause/auto-pause-hook/main.go cmd/auto-pause/auto-pause-hook/config.go cmd/auto-pause/auto-pause-hook/certs.go
+
+FROM scratch
+COPY --from=builder /app/auto-pause-hook /auto-pause-hook

--- a/hack/update/golang_version/update_golang_version.go
+++ b/hack/update/golang_version/update_golang_version.go
@@ -67,7 +67,7 @@ var (
 		},
 		"deploy/addons/auto-pause/Dockerfile": {
 			Replace: map[string]string{
-				`golang:.*`: `golang:{{.StableVersion}}`,
+				`golang:.* AS`: `golang:{{.StableVersion}} AS`,
 			},
 		},
 	}


### PR DESCRIPTION
Before, running `make push-auto-pause-hook-image` would only build the auto-pause-hook for the arch of the machine running the command on. Modified the Dockerfile and Makefile target to build an image for each architecture.

Also updated the Dockerfile to a multi-step build so the base image is from scratch instead of golang. Resulting in the image going from 790MB to 45MB, greatly increasing the speed of enabling the addon for people with slow internet speeds.

**Before:**
```
REPOSITORY                            TAG                        IMAGE ID       CREATED          SIZE
gcr.io/k8s-minikube/auto-pause-hook   v0.0.4                     a633c3ce5969   9 months ago     790MB
```

**After:**
```
REPOSITORY                            TAG                        IMAGE ID       CREATED          SIZE
gcr.io/k8s-minikube/auto-pause-hook   v0.0.5                     37295df93934   2 months ago     45MB
```