### PR TITLE
site: Build improvements to the site

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ VERSION ?= v$(RAW_VERSION)
 
 KUBERNETES_VERSION ?= $(shell egrep "DefaultKubernetesVersion =" pkg/minikube/constants/constants.go | cut -d \" -f2)
 KIC_VERSION ?= $(shell egrep "Version =" pkg/drivers/kic/types.go | cut -d \" -f2)
+HUGO_VERSION ?= $(shell egrep "HUGO_VERSION = \"" netlify.toml | cut -d \" -f2)
 
 # Default to .0 for higher cache hit rates, as build increments typically don't require new ISO versions
 ISO_VERSION ?= v1.32.1-1702708929-17806
@@ -928,7 +929,7 @@ out/hugo/hugo:
 	mkdir -p out
 	(cd site/themes/docsy && npm install)
 	test -d out/hugo || git clone https://github.com/gohugoio/hugo.git out/hugo
-	(cd out/hugo && go build --tags extended)
+	(cd out/hugo && git fetch origin && git checkout $(HUGO_VERSION) && go build --tags extended)
 
 .PHONY: site
 site: site/themes/docsy/assets/vendor/bootstrap/package.js out/hugo/hugo ## Serve the documentation site to localhost

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ publish = "site/public/"
 command = "pwd && cd themes/docsy && npm install && git submodule update -f --init && cd ../.. && hugo"
 
 [build.environment]
-NODE_VERSION = "14.21.1"
+NODE_VERSION = "20.10.0"
 HUGO_VERSION = "v0.121.2"
 
 [context.production.environment]

--- a/site/config.toml
+++ b/site/config.toml
@@ -15,7 +15,7 @@ defaultContentLanguageInSubdir = false
 # Useful when translating.
 enableMissingTranslationPlaceholders = true
 
-disableKinds = ["taxonomy", "taxonomyTerm"]
+disableKinds = ["taxonomy"]
 
 # Highlighting config
 pygmentsCodeFences = true
@@ -65,9 +65,10 @@ id = "G-JPP6RFM2BP"
 [languages]
 [languages.en]
 title = "minikube"
-description = "minikube is local Kubernetes"
 languageName = "English"
 weight = 1
+[languages.en.params]
+description = "minikube is local Kubernetes"
 
 [params]
 copyright = "The Kubernetes Authors -- "


### PR DESCRIPTION
Fixed the following warnings on site build:
```
WARN  config: languages.en.description: custom params on the language top level is deprecated and will be removed in a future release. Put the value below [languages.en.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120

WARN  DEPRECATED: Kind "taxonomyterm" used in disableKinds is deprecated, use "taxonomy" instead.
```

Fixed running `make site` using the main branch of Hugo. Added `HUGO_VERSION` variable to Makefile which is pulled from the netlify.toml file. Now when `make site` is run it does `git checkout $(HUGO_VERSION)`.

Updated Node version from 14 to 20 as Node 14 has been EOL since April 2023