### PR TITLE
fix TestValidatePorts

### DIFF
--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -737,7 +737,7 @@ func TestValidatePorts(t *testing.T) {
 			if got != nil {
 				gotError = got.Error()
 			}
-			if gotError != test.errorMsg {
+			if !strings.EqualFold(gotError, test.errorMsg) {
 				t.Errorf("validatePorts(ports=%v): got %v, expected %v", test.ports, got, test.errorMsg)
 			}
 		})


### PR DESCRIPTION
after [bumping](https://github.com/kubernetes/minikube/pull/17898) go-connections, TestValidatePorts unit tests started to fail because of this [commit](https://github.com/docker/go-connections/commit/23efdb1a19c9b06b4281d17e132212e0f3486bf3)

### before
https://github.com/kubernetes/minikube/actions/runs/7424948416/job/20205599333#step:6:23
```
--- FAIL: TestValidatePorts (0.00s)
    --- FAIL: TestValidatePorts/test:8080 (0.00s)
        start_test.go:741: validatePorts(ports=[test:8080]): got Sorry, one of the ports provided with --ports flag is not valid [test:8080] (invalid hostPort: test), expected Sorry, one of the ports provided with --ports flag is not valid [test:8080] (Invalid hostPort: test)
    --- FAIL: TestValidatePorts/65536:80/udp (0.00s)
        start_test.go:741: validatePorts(ports=[65536:80/udp]): got Sorry, one of the ports provided with --ports flag is not valid [65536:80/udp] (invalid hostPort: 65536), expected Sorry, one of the ports provided with --ports flag is not valid [65536:80/udp] (Invalid hostPort: 65536)
    --- FAIL: TestValidatePorts/1000.0.0.1:80:80 (0.00s)
        start_test.go:741: validatePorts(ports=[1000.0.0.1:80:80]): got Sorry, one of the ports provided with --ports flag is not valid [1000.0.0.1:80:80] (invalid IP address: 1000.0.0.1), expected Sorry, one of the ports provided with --ports flag is not valid [1000.0.0.1:80:80] (Invalid ip address: 1000.0.0.1)
    --- FAIL: TestValidatePorts/1[27](https://github.com/kubernetes/minikube/actions/runs/7424948416/job/20205599333#step:6:28).0.0.1:81:65536/tcp (0.00s)
        start_test.go:741: validatePorts(ports=[127.0.0.1:81:65536/tcp]): got Sorry, one of the ports provided with --ports flag is not valid [127.0.0.1:81:65536/tcp] (invalid containerPort: 65536), expected Sorry, one of the ports provided with --ports flag is not valid [127.0.0.1:81:65536/tcp] (Invalid containerPort: 65536)
    --- FAIL: TestValidatePorts/1-65536:80-81/tcp (0.00s)
        start_test.go:741: validatePorts(ports=[1-65536:80-81/tcp]): got Sorry, one of the ports provided with --ports flag is not valid [1-65536:80-81/tcp] (invalid hostPort: 1-65536), expected Sorry, one of the ports provided with --ports flag is not valid [1-65536:80-81/tcp] (Invalid hostPort: 1-65536)
    --- FAIL: TestValidatePorts/1-80:0-81/tcp (0.00s)
        start_test.go:741: validatePorts(ports=[1-80:0-81/tcp]): got Sorry, one of the ports provided with --ports flag is not valid [1-80:0-81/tcp] (invalid ranges specified for container and host Ports: 0-81 and 1-80), expected Sorry, one of the ports provided with --ports flag is not valid [1-80:0-81/tcp] (Invalid ranges specified for container and host Ports: 0-81 and 1-80)
    --- FAIL: TestValidatePorts/1-80:1-65536/tcp (0.00s)
        start_test.go:741: validatePorts(ports=[1-80:1-655[36](https://github.com/kubernetes/minikube/actions/runs/7424948416/job/20205599333#step:6:37)/tcp]): got Sorry, one of the ports provided with --ports flag is not valid [1-80:1-65536/tcp] (invalid containerPort: 1-65536), expected Sorry, one of the ports provided with --ports flag is not valid [1-80:1-65536/tcp] (Invalid containerPort: 1-65536)
```

### after
`$ go test -v -run ^TestValidatePorts$ k8s.io/minikube/cmd/minikube/cmd`
```
=== RUN   TestValidatePorts
=== RUN   TestValidatePorts/8080:80
=== RUN   TestValidatePorts/8080:80/tcp,8080:80/udp
=== RUN   TestValidatePorts/test:8080
=== RUN   TestValidatePorts/0:80
=== RUN   TestValidatePorts/0:80/tcp
=== RUN   TestValidatePorts/65536:80/udp
=== RUN   TestValidatePorts/0-1:80-81/tcp
=== RUN   TestValidatePorts/0-1:80-81/udp
=== RUN   TestValidatePorts/80:80,1023-1025:8023-8025,1023-1025:8023-8025/tcp,1023-1025:8023-8025/udp
=== RUN   TestValidatePorts/80:80
=== RUN   TestValidatePorts/1023-1025:8023-8025
=== RUN   TestValidatePorts/1023-1025:8023-8025/tcp
=== RUN   TestValidatePorts/1023-1025:8023-8025/udp
=== RUN   TestValidatePorts/127.0.0.1:8080:80,127.0.0.1:8081:80/tcp,127.0.0.1:8081:80/udp,127.0.0.1:8082-8083:8082-8083/tcp
=== RUN   TestValidatePorts/1000.0.0.1:80:80
=== RUN   TestValidatePorts/127.0.0.1:80:80,127.0.0.1:81:81/tcp,127.0.0.1:81:81/udp,127.0.0.1:82-83:82-83/tcp,127.0.0.1:82-83:82-83/udp
=== RUN   TestValidatePorts/127.0.0.1:80:80
=== RUN   TestValidatePorts/127.0.0.1:81:81/tcp
=== RUN   TestValidatePorts/127.0.0.1:81:81/udp
=== RUN   TestValidatePorts/127.0.0.1:80-83:80-83/tcp
=== RUN   TestValidatePorts/127.0.0.1:80-83:80-83/udp
=== RUN   TestValidatePorts/80
=== RUN   TestValidatePorts/80,65535,65536
=== RUN   TestValidatePorts/0,80,65535
=== RUN   TestValidatePorts/cats
=== RUN   TestValidatePorts/127.0.0.1:81:0/tcp
=== RUN   TestValidatePorts/127.0.0.1:81:65536/tcp
=== RUN   TestValidatePorts/1-65536:80-81/tcp
=== RUN   TestValidatePorts/1-80:0-81/tcp
=== RUN   TestValidatePorts/1-80:1-65536/tcp
--- PASS: TestValidatePorts (0.00s)
    --- PASS: TestValidatePorts/8080:80 (0.00s)
    --- PASS: TestValidatePorts/8080:80/tcp,8080:80/udp (0.00s)
    --- PASS: TestValidatePorts/test:8080 (0.00s)
    --- PASS: TestValidatePorts/0:80 (0.00s)
    --- PASS: TestValidatePorts/0:80/tcp (0.00s)
    --- PASS: TestValidatePorts/65536:80/udp (0.00s)
    --- PASS: TestValidatePorts/0-1:80-81/tcp (0.00s)
    --- PASS: TestValidatePorts/0-1:80-81/udp (0.00s)
    --- PASS: TestValidatePorts/80:80,1023-1025:8023-8025,1023-1025:8023-8025/tcp,1023-1025:8023-8025/udp (0.00s)
    --- PASS: TestValidatePorts/80:80 (0.00s)
    --- PASS: TestValidatePorts/1023-1025:8023-8025 (0.00s)
    --- PASS: TestValidatePorts/1023-1025:8023-8025/tcp (0.00s)
    --- PASS: TestValidatePorts/1023-1025:8023-8025/udp (0.00s)
    --- PASS: TestValidatePorts/127.0.0.1:8080:80,127.0.0.1:8081:80/tcp,127.0.0.1:8081:80/udp,127.0.0.1:8082-8083:8082-8083/tcp (0.00s)
    --- PASS: TestValidatePorts/1000.0.0.1:80:80 (0.00s)
    --- PASS: TestValidatePorts/127.0.0.1:80:80,127.0.0.1:81:81/tcp,127.0.0.1:81:81/udp,127.0.0.1:82-83:82-83/tcp,127.0.0.1:82-83:82-83/udp (0.00s)
    --- PASS: TestValidatePorts/127.0.0.1:80:80 (0.00s)
    --- PASS: TestValidatePorts/127.0.0.1:81:81/tcp (0.00s)
    --- PASS: TestValidatePorts/127.0.0.1:81:81/udp (0.00s)
    --- PASS: TestValidatePorts/127.0.0.1:80-83:80-83/tcp (0.00s)
    --- PASS: TestValidatePorts/127.0.0.1:80-83:80-83/udp (0.00s)
    --- PASS: TestValidatePorts/80 (0.00s)
    --- PASS: TestValidatePorts/80,65535,65536 (0.00s)
    --- PASS: TestValidatePorts/0,80,65535 (0.00s)
    --- PASS: TestValidatePorts/cats (0.00s)
    --- PASS: TestValidatePorts/127.0.0.1:81:0/tcp (0.00s)
    --- PASS: TestValidatePorts/127.0.0.1:81:65536/tcp (0.00s)
    --- PASS: TestValidatePorts/1-65536:80-81/tcp (0.00s)
    --- PASS: TestValidatePorts/1-80:0-81/tcp (0.00s)
    --- PASS: TestValidatePorts/1-80:1-65536/tcp (0.00s)
PASS
ok      k8s.io/minikube/cmd/minikube/cmd        0.028s
```
