### PR TITLE
isolate k8s version testruns and fix images cache path

### DIFF
--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -191,8 +191,6 @@ func TestDownloadOnly(t *testing.T) { // nolint:gocyclo
 
 			// This is a weird place to test profile deletion, but this test is serial, and we have a profile to delete!
 			t.Run("DeleteAll", func(t *testing.T) {
-				defer PostMortemLogs(t, profile)
-
 				if !CanCleanup() {
 					t.Skip("skipping, as cleanup is disabled")
 				}
@@ -204,8 +202,6 @@ func TestDownloadOnly(t *testing.T) { // nolint:gocyclo
 
 			// Delete should always succeed, even if previously partially or fully deleted.
 			t.Run("DeleteAlwaysSucceeds", func(t *testing.T) {
-				defer PostMortemLogs(t, profile)
-
 				if !CanCleanup() {
 					t.Skip("skipping, as cleanup is disabled")
 				}

--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -42,10 +42,20 @@ import (
 )
 
 // TestDownloadOnly makes sure the --download-only parameter in minikube start caches the appropriate images and tarballs.
-func TestDownloadOnly(t *testing.T) {
-	profile := UniqueProfileName("download-only")
+func TestDownloadOnly(t *testing.T) { // nolint:gocyclo
 	ctx, cancel := context.WithTimeout(context.Background(), Minutes(30))
-	defer Cleanup(t, profile, cancel)
+
+	// separate each k8s version testrun into individual profiles to avoid ending up with subsequently mixed up configs like:
+	// {Name:download-only-062906 ... KubernetesConfig:{KubernetesVersion:v1.28.4 ...} Nodes:[{Name: IP: Port:8443 KubernetesVersion:v1.16.0 ...}] ...}
+	// that will then get artifacts for node's not cluster's KubernetesVersion and fail checks thereafter
+	// at the end, cleanup all profiles
+	profiles := []string{}
+	defer func() {
+		for _, profile := range profiles {
+			Cleanup(t, profile, cancel)
+		}
+	}()
+
 	containerRuntime := ContainerRuntime()
 
 	versions := []string{
@@ -61,6 +71,8 @@ func TestDownloadOnly(t *testing.T) {
 
 	for _, v := range versions {
 		t.Run(v, func(t *testing.T) {
+			profile := UniqueProfileName("download-only")
+			profiles = append(profiles, profile)
 			defer PostMortemLogs(t, profile)
 
 			t.Run("json-events", func(t *testing.T) {
@@ -122,7 +134,7 @@ func TestDownloadOnly(t *testing.T) {
 				}
 
 				for _, img := range imgs {
-					pathToImage := []string{localpath.MiniPath(), "cache", "images", runtime.GOOS}
+					pathToImage := []string{localpath.MiniPath(), "cache", "images", runtime.GOARCH}
 					img = strings.Replace(img, ":", "_", 1) // for example kube-scheduler:v1.15.2 --> kube-scheduler_v1.15.2
 					imagePath := strings.Split(img, "/")    // changes "gcr.io/k8s-minikube/storage-provisioner_v5" into ["gcr.io", "k8s-minikube", "storage-provisioner_v5"] to match cache folder structure
 					pathToImage = append(pathToImage, imagePath...)
@@ -177,34 +189,33 @@ func TestDownloadOnly(t *testing.T) {
 				}
 			})
 
+			// This is a weird place to test profile deletion, but this test is serial, and we have a profile to delete!
+			t.Run("DeleteAll", func(t *testing.T) {
+				defer PostMortemLogs(t, profile)
+
+				if !CanCleanup() {
+					t.Skip("skipping, as cleanup is disabled")
+				}
+				rr, err := Run(t, exec.CommandContext(ctx, Target(), "delete", "--all"))
+				if err != nil {
+					t.Errorf("failed to delete all. args: %q : %v", rr.Command(), err)
+				}
+			})
+
+			// Delete should always succeed, even if previously partially or fully deleted.
+			t.Run("DeleteAlwaysSucceeds", func(t *testing.T) {
+				defer PostMortemLogs(t, profile)
+
+				if !CanCleanup() {
+					t.Skip("skipping, as cleanup is disabled")
+				}
+				rr, err := Run(t, exec.CommandContext(ctx, Target(), "delete", "-p", profile))
+				if err != nil {
+					t.Errorf("failed to delete. args: %q: %v", rr.Command(), err)
+				}
+			})
 		})
 	}
-
-	// This is a weird place to test profile deletion, but this test is serial, and we have a profile to delete!
-	t.Run("DeleteAll", func(t *testing.T) {
-		defer PostMortemLogs(t, profile)
-
-		if !CanCleanup() {
-			t.Skip("skipping, as cleanup is disabled")
-		}
-		rr, err := Run(t, exec.CommandContext(ctx, Target(), "delete", "--all"))
-		if err != nil {
-			t.Errorf("failed to delete all. args: %q : %v", rr.Command(), err)
-		}
-	})
-	// Delete should always succeed, even if previously partially or fully deleted.
-	t.Run("DeleteAlwaysSucceeds", func(t *testing.T) {
-		defer PostMortemLogs(t, profile)
-
-		if !CanCleanup() {
-			t.Skip("skipping, as cleanup is disabled")
-		}
-		rr, err := Run(t, exec.CommandContext(ctx, Target(), "delete", "-p", profile))
-		if err != nil {
-			t.Errorf("failed to delete. args: %q: %v", rr.Command(), err)
-		}
-	})
-
 }
 
 // TestDownloadOnlyKic makes sure --download-only caches the docker driver images as well.


### PR DESCRIPTION
fixes #17933

separating each k8s version testrun into individual profiles avoids ending up with subsequently mixed-up configs like:

> {Name:download-only-062906 KeepContext:false EmbedCerts:false MinikubeISO: KicBaseImage:gcr.io/k8s-minikube/kicbase-builds:v0.0.42-1704759386-17866@sha256:8c3c33047f9bc285e1f5f2a5aa14744a2fe04c58478f02f77b06169dea8dd3f0 Memory:15800 CPUs:2 DiskSize:20000 Driver:docker HyperkitVpnKitSock: HyperkitVSockPorts:[] DockerEnv:[] ContainerVolumeMounts:[] InsecureRegistry:[] RegistryMirror:[] HostOnlyCIDR:192.168.59.1/24 HypervVirtualSwitch: HypervUseExternalSwitch:false HypervExternalAdapter: KVMNetwork:default KVMQemuURI:qemu:///system KVMGPU:false KVMHidden:false KVMNUMACount:1 APIServerPort:8443 DockerOpt:[] DisableDriverMounts:false NFSShare:[] NFSSharesRoot:/nfsshares UUID: NoVTXCheck:false DNSProxy:false HostDNSResolver:true HostOnlyNicType:virtio NatNicType:virtio SSHIPAddress: SSHUser:root SSHKey: SSHPort:22 `KubernetesConfig`:{`KubernetesVersion:v1.28.4` ClusterName:download-only-062906 Namespace:default APIServerHAVIP: APIServerName:minikubeCA APIServerNames:[] APIServerIPs:[] DNSDomain:cluster.local ContainerRuntime:docker CRISocket: NetworkPlugin: FeatureGates: ServiceCIDR:10.96.0.0/12 ImageRepository: LoadBalancerStartIP: LoadBalancerEndIP: CustomIngressCert: RegistryAliases: ExtraOptions:[] ShouldLoadCachedImages:true EnableDefaultCNI:false CNI:} `Nodes`:[{Name: IP: Port:8443 `KubernetesVersion:v1.16.0` ContainerRuntime:docker ControlPlane:true Worker:true}] Addons:map[] CustomAddonImages:map[] CustomAddonRegistries:map[] VerifyComponents:map[apiserver:true system_pods:true] StartHostTimeout:6m0s ScheduledStop:<nil> ExposedPorts:[] ListenAddress: Network: Subnet: MultiNodeRequested:false ExtraDisks:0 CertExpiration:26280h0m0s Mount:false MountString:/home/prezha:/minikube-host Mount9PVersion:9p2000.L MountGID:docker MountIP: MountMSize:262144 MountOptions:[] MountPort:0 MountType:9p MountUID:docker BinaryMirror: DisableOptimizations:false DisableMetrics:false CustomQemuFirmwarePath: SocketVMnetClientPath: SocketVMnetPath: StaticIP: SSHAuthSock: SSHAgentPID:0 GPUs:}

that will then get artifacts for node's not cluster's KubernetesVersion and fail checks thereafter

also, fixing image cache path - previously, we had, eg:
> === RUN   TestDownloadOnly/v1.29.0-rc.2/cached-images
aaa_download_only_test.go:132: expected image file exist at "/home/jenkins/minikube-integration/17909-558908/.minikube/cache/images/linux/registry.k8s.io/kube-apiserver_v1.29.0-rc.2" but got error: stat /home/jenkins/minikube-integration/17909-558908/.minikube/cache/images/linux/registry.k8s.io/kube-apiserver_v1.29.0-rc.2: no such file or directory

correct path should be: https://github.com/kubernetes/minikube/blob/46d9b51eeed9853d3cbf05418650d273696bdb88/pkg/minikube/detect/detect.go#L123-L126