### PR TITLE
treewide: Replace 'egrep' with 'grep -E'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,9 @@ VERSION_BUILD ?= 0
 RAW_VERSION=$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_BUILD)
 VERSION ?= v$(RAW_VERSION)
 
-KUBERNETES_VERSION ?= $(shell egrep "DefaultKubernetesVersion =" pkg/minikube/constants/constants.go | cut -d \" -f2)
-KIC_VERSION ?= $(shell egrep "Version =" pkg/drivers/kic/types.go | cut -d \" -f2)
-HUGO_VERSION ?= $(shell egrep "HUGO_VERSION = \"" netlify.toml | cut -d \" -f2)
+KUBERNETES_VERSION ?= $(shell grep -E "DefaultKubernetesVersion =" pkg/minikube/constants/constants.go | cut -d \" -f2)
+KIC_VERSION ?= $(shell grep -E "Version =" pkg/drivers/kic/types.go | cut -d \" -f2)
+HUGO_VERSION ?= $(shell grep -E "HUGO_VERSION = \"" netlify.toml | cut -d \" -f2)
 
 # Default to .0 for higher cache hit rates, as build increments typically don't require new ISO versions
 ISO_VERSION ?= v1.32.1-1703784139-17866

--- a/deploy/addons/kubevirt/pod.yaml.tmpl
+++ b/deploy/addons/kubevirt/pod.yaml.tmpl
@@ -23,7 +23,7 @@ data:
     curl -Ls "https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml" -o /manifests/kubevirt-operator.yaml
     kubectl create -f /manifests/kubevirt-operator.yaml
 
-    HARDWARE_EMULATION=$(egrep 'svm|vmx' /proc/cpuinfo)
+    HARDWARE_EMULATION=$(grep -E 'svm|vmx' /proc/cpuinfo)
     if [ -z "$HARDWARE_EMULATION" ]; then
       echo "Using software emulation"
 

--- a/hack/jenkins/build_iso.sh
+++ b/hack/jenkins/build_iso.sh
@@ -42,8 +42,8 @@ sudo apt-get -y install build-essential unzip rsync bc python3 p7zip-full
 curl -L https://github.com/kubernetes/minikube/raw/master/Makefile --output Makefile-head
 # ISO tags are of the form VERSION-TIMESTAMP-PR, so this grep finds that TIMESTAMP in the middle
 # if it doesn't exist, it will just return VERSION, which is covered in the if statement below
-HEAD_ISO_TIMESTAMP=$(egrep "ISO_VERSION \?= " Makefile-head | cut -d \" -f 2 | cut -d "-" -f 2)
-CURRENT_ISO_TS=$(egrep "ISO_VERSION \?= " Makefile | cut -d \" -f 2 | cut -d "-" -f 2)
+HEAD_ISO_TIMESTAMP=$(grep -E "ISO_VERSION \?= " Makefile-head | cut -d \" -f 2 | cut -d "-" -f 2)
+CURRENT_ISO_TS=$(grep -E "ISO_VERSION \?= " Makefile | cut -d \" -f 2 | cut -d "-" -f 2)
 if [[ $HEAD_ISO_TIMESTAMP != v* ]]; then
 	diff=$((CURRENT_ISO_TS-HEAD_ISO_TIMESTAMP))
 	if [[ $CURRENT_ISO_TS == v* ]] || [ $diff -lt 0 ]; then
@@ -55,7 +55,7 @@ rm Makefile-head
 
 if [[ -z $ISO_VERSION ]]; then
 	release=false
-	IV=$(egrep "ISO_VERSION \?=" Makefile | cut -d " " -f 3 | cut -d "-" -f 1)
+	IV=$(grep -E "ISO_VERSION \?=" Makefile | cut -d " " -f 3 | cut -d "-" -f 1)
 	now=$(date +%s)
 	export ISO_VERSION=$IV-$now-$ghprbPullId
 	export ISO_BUCKET=minikube-builds/iso/$ghprbPullId

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -345,7 +345,7 @@ if [ "$(uname)" != "Darwin" ]; then
   docker build -t gcr.io/k8s-minikube/gvisor-addon:2 -f testdata/gvisor-addon-Dockerfile ./testdata
 fi
 
-readonly LOAD=$(uptime | egrep -o "load average.*: [0-9]+" | cut -d" " -f3)
+readonly LOAD=$(uptime | grep -E -o "load average.*: [0-9]+" | cut -d" " -f3)
 if [[ "${LOAD}" -gt 2 ]]; then
   echo ""
   echo "********************** LOAD WARNING ********************************"

--- a/hack/jenkins/cron/cleanup_and_reboot_Linux.sh
+++ b/hack/jenkins/cron/cleanup_and_reboot_Linux.sh
@@ -21,7 +21,7 @@ function check_jenkins() {
           return
   fi
   pstree "${jenkins_pid}" \
-        | egrep -i 'bash|integration|e2e|minikube' \
+        | grep -E -i 'bash|integration|e2e|minikube' \
         && echo "tests are running on pid ${jenkins_pid} ..." \
         && exit 1
 }

--- a/hack/jenkins/kicbase_auto_build.sh
+++ b/hack/jenkins/kicbase_auto_build.sh
@@ -39,8 +39,8 @@ export PATH=$PATH:$GOBIN
 curl -L https://github.com/kubernetes/minikube/raw/master/pkg/drivers/kic/types.go --output types-head.go
 # kicbase tags are of the form VERSION-TIMESTAMP-PR, so this grep finds that TIMESTAMP in the middle
 # if it doesn't exist, it will just return VERSION, which is covered in the if statement below
-HEAD_KIC_TIMESTAMP=$(egrep "Version =" types-head.go | cut -d \" -f 2 | cut -d "-" -f 2)
-CURRENT_KIC_TS=$(egrep "Version =" pkg/drivers/kic/types.go | cut -d \" -f 2 | cut -d "-" -f 2)
+HEAD_KIC_TIMESTAMP=$(grep -E "Version =" types-head.go | cut -d \" -f 2 | cut -d "-" -f 2)
+CURRENT_KIC_TS=$(grep -E "Version =" pkg/drivers/kic/types.go | cut -d \" -f 2 | cut -d "-" -f 2)
 if [[ $HEAD_KIC_TIMESTAMP != v* ]]; then
 	diff=$((CURRENT_KIC_TS-HEAD_KIC_TIMESTAMP))
 	if [[ $CURRENT_KIC_TS == v* ]] || [ $diff -lt 0 ]; then
@@ -55,7 +55,7 @@ if [[ -z $KIC_VERSION ]]; then
 	# Testing PRs here
 	release=false
 	now=$(date +%s)
-	KV=$(egrep "Version =" pkg/drivers/kic/types.go | cut -d \" -f 2 | cut -d "-" -f 1)
+	KV=$(grep -E "Version =" pkg/drivers/kic/types.go | cut -d \" -f 2 | cut -d "-" -f 1)
 	GCR_REPO=gcr.io/k8s-minikube/kicbase-builds
 	DH_REPO=docker.io/kicbase/build
 	export KIC_VERSION=$KV-$now-$ghprbPullId

--- a/hack/jenkins/storage_provisioner.sh
+++ b/hack/jenkins/storage_provisioner.sh
@@ -44,7 +44,7 @@ if [ $ec -gt 0 ]; then
 fi
 
 # Bump the preload version
-PLV=$(egrep "PreloadVersion =" pkg/minikube/download/preload.go | cut -d \" -f 2)
+PLV=$(grep -E "PreloadVersion =" pkg/minikube/download/preload.go | cut -d \" -f 2)
 RAW=${PLV:1}
 RAW=$((RAW+1))
 PLV=v${RAW}

--- a/hack/update/cri_dockerd_version/build_and_upload_cri_dockerd_binaries.sh
+++ b/hack/update/cri_dockerd_version/build_and_upload_cri_dockerd_binaries.sh
@@ -21,8 +21,8 @@ if [ "$#" -ne 1 ]; then
   exit 1
 fi
 
-readonly version=$(egrep "CRI_DOCKERD_VERSION=" ../../../deploy/kicbase/Dockerfile | cut -d \" -f2)
-readonly commit=$(egrep "CRI_DOCKERD_COMMIT=" ../../../deploy/kicbase/Dockerfile | cut -d \" -f2)
+readonly version=$(grep -E "CRI_DOCKERD_VERSION=" ../../../deploy/kicbase/Dockerfile | cut -d \" -f2)
+readonly commit=$(grep -E "CRI_DOCKERD_COMMIT=" ../../../deploy/kicbase/Dockerfile | cut -d \" -f2)
 archlist=$1
 
 IFS=, read -a archarray <<< "$archlist"

--- a/pkg/minikube/sysinit/openrc.go
+++ b/pkg/minikube/sysinit/openrc.go
@@ -38,7 +38,7 @@ readonly UNIT_PATH=$1
 
 while true; do
   if [[ -f "${UNIT_PATH}" ]]; then
-	eval $(egrep "^ExecStart=" "${UNIT_PATH}" | cut -d"=" -f2-)
+	eval $(grep -E "^ExecStart=" "${UNIT_PATH}" | cut -d"=" -f2-)
   fi
   sleep 1
 done

--- a/site/content/en/docs/drivers/includes/check_virtualization_linux.inc
+++ b/site/content/en/docs/drivers/includes/check_virtualization_linux.inc
@@ -1,7 +1,7 @@
 To use VM drivers, verify that your system has virtualization support enabled:
 
 ```shell
-egrep -q 'vmx|svm' /proc/cpuinfo && echo yes || echo no
+grep -E -q 'vmx|svm' /proc/cpuinfo && echo yes || echo no
 ```
 
 If the above command outputs "no":

--- a/test.sh
+++ b/test.sh
@@ -45,7 +45,7 @@ then
     readonly BDIR="${ROOT_DIR}/hack/boilerplate"
     pushd . >/dev/null
     cd ${BDIR}
-    missing="$(go run boilerplate.go -rootdir ${ROOT_DIR} -boilerplate-dir ${BDIR} | egrep -v '/assets.go|/translations.go|/site/themes/|/site/node_modules|\./out|/hugo/|hack/benchmark/time-to-k8s/time-to-k8s-repo' || true)"
+    missing="$(go run boilerplate.go -rootdir ${ROOT_DIR} -boilerplate-dir ${BDIR} | grep -E -v '/assets.go|/translations.go|/site/themes/|/site/node_modules|\./out|/hugo/|hack/benchmark/time-to-k8s/time-to-k8s-repo' || true)"
     if [[ -n "${missing}" ]]; then
         echo "boilerplate missing: $missing"
         echo "consider running: ${BDIR}/fix.sh"


### PR DESCRIPTION
Fixes the following warning:
```
egrep: warning: egrep is obsolescent; using grep -E
```