### PR TITLE
fix PingHostFrom2Pods integration test by adding NET_RAW capabilities

### DIFF
--- a/test/integration/testdata/multinodes/multinode-pod-dns-test.yaml
+++ b/test/integration/testdata/multinodes/multinode-pod-dns-test.yaml
@@ -25,6 +25,9 @@ spec:
           - sleep
           - "3600"
         imagePullPolicy: IfNotPresent
+        securityContext:
+          capabilities:
+            add: ["NET_RAW"]
       restartPolicy: Always
       affinity:
         # ⬇⬇⬇ This ensures pods will land on separate hosts


### PR DESCRIPTION
some integration tests involving cri-o started to consistently fail - as seen in eg, [TestHA/PingHostFromPods](https://storage.googleapis.com/minikube-builds/logs/17909/32704/Docker_Linux_crio.html#fail_TestHA%2fserial%2fPingHostFromPods)  and 
[TestMultiNode/PingHostFrom2Pods](https://storage.googleapis.com/minikube-builds/logs/17909/32704/Docker_Linux_crio.html#fail_TestMultiNode%2fserial%2fPingHostFrom2Pods)

reason: starting with [v1.18.0](https://cri-o.github.io/cri-o/v1.18.0.html):
> CRI-O now runs containers without NET_RAW and SYS_CHROOT capabilities by default. This can result in permission denied errors when the container tries to do something that would require either of these capabilities. For instance, using ping requires NET_RAW, unless the container is given the sysctl net.ipv4.ip_forward.

this pr adds NET_RAW capability to the test containers, so tests do not fail for this reason

### before

> $ make integration -e TEST_ARGS="-minikube-start-args='--driver=docker --container-runtime=cri-o --alsologtostderr -v=7' -test.run TestMultiNode --cleanup=false"
```
go test -ldflags="-X k8s.io/minikube/pkg/version.version=v1.32.0 -X k8s.io/minikube/pkg/version.isoVersion=v1.32.1-1703784139-17866 -X k8s.io/minikube/pkg/version.gitCommitID="838ea0c7fb16de5a630512cb915c0e88a3dfeff2-dirty" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" -v -test.timeout=90m ./test/integration --tags="integration " -minikube-start-args='--driver=docker --container-runtime=cri-o --alsologtostderr -v=7' -test.run TestMultiNode --cleanup=false 2>&1 | tee "./out/testout_838ea0c7f.txt"
Found 16 cores, limiting parallelism with --test.parallel=9
=== RUN   TestMultiNode
=== RUN   TestMultiNode/serial
=== RUN   TestMultiNode/serial/FreshStart2Nodes
    multinode_test.go:86: (dbg) Run:  out/minikube start -p multinode-280880 --wait=true --memory=2200 --nodes=2 -v=8 --alsologtostderr --driver=docker --container-runtime=cri-o --alsologtostderr -v=7
    multinode_test.go:86: (dbg) Done: out/minikube start -p multinode-280880 --wait=true --memory=2200 --nodes=2 -v=8 --alsologtostderr --driver=docker --container-runtime=cri-o --alsologtostderr -v=7: (2m12.243177036s)
    multinode_test.go:92: (dbg) Run:  out/minikube -p multinode-280880 status --alsologtostderr
=== RUN   TestMultiNode/serial/DeployApp2Nodes
    multinode_test.go:509: (dbg) Run:  out/minikube kubectl -p multinode-280880 -- apply -f ./testdata/multinodes/multinode-pod-dns-test.yaml
    multinode_test.go:509: (dbg) Done: out/minikube kubectl -p multinode-280880 -- apply -f ./testdata/multinodes/multinode-pod-dns-test.yaml: (26.999351987s)
    multinode_test.go:514: (dbg) Run:  out/minikube kubectl -p multinode-280880 -- rollout status deployment/busybox
    multinode_test.go:514: (dbg) Done: out/minikube kubectl -p multinode-280880 -- rollout status deployment/busybox: (7.826477933s)
    multinode_test.go:521: (dbg) Run:  out/minikube kubectl -p multinode-280880 -- get pods -o jsonpath='{.items[*].status.podIP}'
    multinode_test.go:544: (dbg) Run:  out/minikube kubectl -p multinode-280880 -- get pods -o jsonpath='{.items[*].metadata.name}'
    multinode_test.go:552: (dbg) Run:  out/minikube kubectl -p multinode-280880 -- exec busybox-5bc68d56bd-8k459 -- nslookup kubernetes.io
    multinode_test.go:552: (dbg) Run:  out/minikube kubectl -p multinode-280880 -- exec busybox-5bc68d56bd-pkz6c -- nslookup kubernetes.io
    multinode_test.go:562: (dbg) Run:  out/minikube kubectl -p multinode-280880 -- exec busybox-5bc68d56bd-8k459 -- nslookup kubernetes.default
    multinode_test.go:562: (dbg) Run:  out/minikube kubectl -p multinode-280880 -- exec busybox-5bc68d56bd-pkz6c -- nslookup kubernetes.default
    multinode_test.go:570: (dbg) Run:  out/minikube kubectl -p multinode-280880 -- exec busybox-5bc68d56bd-8k459 -- nslookup kubernetes.default.svc.cluster.local
    multinode_test.go:570: (dbg) Run:  out/minikube kubectl -p multinode-280880 -- exec busybox-5bc68d56bd-pkz6c -- nslookup kubernetes.default.svc.cluster.local
=== RUN   TestMultiNode/serial/PingHostFrom2Pods
    multinode_test.go:580: (dbg) Run:  out/minikube kubectl -p multinode-280880 -- get pods -o jsonpath='{.items[*].metadata.name}'
    multinode_test.go:588: (dbg) Run:  out/minikube kubectl -p multinode-280880 -- exec busybox-5bc68d56bd-8k459 -- sh -c "nslookup host.minikube.internal | awk 'NR==5' | cut -d' ' -f3"
    multinode_test.go:599: (dbg) Run:  out/minikube kubectl -p multinode-280880 -- exec busybox-5bc68d56bd-8k459 -- sh -c "ping -c 1 192.168.49.1"
    multinode_test.go:599: (dbg) Non-zero exit: out/minikube kubectl -p multinode-280880 -- exec busybox-5bc68d56bd-8k459 -- sh -c "ping -c 1 192.168.49.1": exit status 1 (131.586278ms)

        -- stdout --
                PING 192.168.49.1 (192.168.49.1): 56 data bytes

        -- /stdout --
        ** stderr **
                ping: permission denied (are you root?)
                command terminated with exit code 1

        ** /stderr **
    multinode_test.go:600: Failed to ping host (192.168.49.1) from pod (busybox-5bc68d56bd-8k459): exit status 1
...
--- FAIL: TestMultiNode (171.59s)
    --- FAIL: TestMultiNode/serial (170.36s)
        --- PASS: TestMultiNode/serial/FreshStart2Nodes (132.57s)
        --- PASS: TestMultiNode/serial/DeployApp2Nodes (35.92s)
        --- FAIL: TestMultiNode/serial/PingHostFrom2Pods (1.87s)
```



### after

> $ make integration -e TEST_ARGS="-minikube-start-args='--driver=docker --container-runtime=cri-o --alsologtostderr -v=7' -test.run TestMultiNode --cleanup=false"
```
go test -ldflags="-X k8s.io/minikube/pkg/version.version=v1.32.0 -X k8s.io/minikube/pkg/version.isoVersion=v1.32.1-1703784139-17866 -X k8s.io/minikube/pkg/version.gitCommitID="838ea0c7fb16de5a630512cb915c0e88a3dfeff2-dirty" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" -v -test.timeout=90m ./test/integration --tags="integration " -minikube-start-args='--driver=docker --container-runtime=cri-o --alsologtostderr -v=7' -test.run TestMultiNode --cleanup=false 2>&1 | tee "./out/testout_838ea0c7f.txt"
Found 16 cores, limiting parallelism with --test.parallel=9
=== RUN   TestMultiNode
=== RUN   TestMultiNode/serial
=== RUN   TestMultiNode/serial/FreshStart2Nodes
    multinode_test.go:86: (dbg) Run:  out/minikube start -p multinode-397435 --wait=true --memory=2200 --nodes=2 -v=8 --alsologtostderr --driver=docker --container-runtime=cri-o --alsologtostderr -v=7
    multinode_test.go:86: (dbg) Done: out/minikube start -p multinode-397435 --wait=true --memory=2200 --nodes=2 -v=8 --alsologtostderr --driver=docker --container-runtime=cri-o --alsologtostderr -v=7: (1m45.256614828s)
    multinode_test.go:92: (dbg) Run:  out/minikube -p multinode-397435 status --alsologtostderr
=== RUN   TestMultiNode/serial/DeployApp2Nodes
    multinode_test.go:509: (dbg) Run:  out/minikube kubectl -p multinode-397435 -- apply -f ./testdata/multinodes/multinode-pod-dns-test.yaml
    multinode_test.go:514: (dbg) Run:  out/minikube kubectl -p multinode-397435 -- rollout status deployment/busybox
    multinode_test.go:514: (dbg) Done: out/minikube kubectl -p multinode-397435 -- rollout status deployment/busybox: (3.697668523s)
    multinode_test.go:521: (dbg) Run:  out/minikube kubectl -p multinode-397435 -- get pods -o jsonpath='{.items[*].status.podIP}'
    multinode_test.go:544: (dbg) Run:  out/minikube kubectl -p multinode-397435 -- get pods -o jsonpath='{.items[*].metadata.name}'
    multinode_test.go:552: (dbg) Run:  out/minikube kubectl -p multinode-397435 -- exec busybox-5b5d89c9d6-49bmk -- nslookup kubernetes.io
    multinode_test.go:552: (dbg) Run:  out/minikube kubectl -p multinode-397435 -- exec busybox-5b5d89c9d6-bmrkc -- nslookup kubernetes.io
    multinode_test.go:562: (dbg) Run:  out/minikube kubectl -p multinode-397435 -- exec busybox-5b5d89c9d6-49bmk -- nslookup kubernetes.default
    multinode_test.go:562: (dbg) Run:  out/minikube kubectl -p multinode-397435 -- exec busybox-5b5d89c9d6-bmrkc -- nslookup kubernetes.default
    multinode_test.go:570: (dbg) Run:  out/minikube kubectl -p multinode-397435 -- exec busybox-5b5d89c9d6-49bmk -- nslookup kubernetes.default.svc.cluster.local
    multinode_test.go:570: (dbg) Run:  out/minikube kubectl -p multinode-397435 -- exec busybox-5b5d89c9d6-bmrkc -- nslookup kubernetes.default.svc.cluster.local
=== RUN   TestMultiNode/serial/PingHostFrom2Pods
    multinode_test.go:580: (dbg) Run:  out/minikube kubectl -p multinode-397435 -- get pods -o jsonpath='{.items[*].metadata.name}'
    multinode_test.go:588: (dbg) Run:  out/minikube kubectl -p multinode-397435 -- exec busybox-5b5d89c9d6-49bmk -- sh -c "nslookup host.minikube.internal | awk 'NR==5' | cut -d' ' -f3"
    multinode_test.go:599: (dbg) Run:  out/minikube kubectl -p multinode-397435 -- exec busybox-5b5d89c9d6-49bmk -- sh -c "ping -c 1 192.168.58.1"
    multinode_test.go:588: (dbg) Run:  out/minikube kubectl -p multinode-397435 -- exec busybox-5b5d89c9d6-bmrkc -- sh -c "nslookup host.minikube.internal | awk 'NR==5' | cut -d' ' -f3"
    multinode_test.go:599: (dbg) Run:  out/minikube kubectl -p multinode-397435 -- exec busybox-5b5d89c9d6-bmrkc -- sh -c "ping -c 1 192.168.58.1"
...
--- PASS: TestMultiNode (111.15s)
    --- PASS: TestMultiNode/serial (111.15s)
        --- PASS: TestMultiNode/serial/FreshStart2Nodes (105.60s)
        --- PASS: TestMultiNode/serial/DeployApp2Nodes (4.94s)
        --- PASS: TestMultiNode/serial/PingHostFrom2Pods (0.61s)
```