### PR TITLE
CI: Fix Go auto update PR title

### DIFF
--- a/hack/update/get_version/get_version.go
+++ b/hack/update/get_version/get_version.go
@@ -42,7 +42,7 @@ var dependencies = map[string]dependency{
 	"flannel":                 {"pkg/minikube/cni/flannel.yaml", `flannel:(.*)`},
 	"gcp-auth":                {addonsFile, `k8s-minikube/gcp-auth-webhook:(.*)@`},
 	"gh":                      {"hack/jenkins/installers/check_install_gh.sh", `GH_VERSION="(.*)"`},
-	"go":                      {"Makefile", `GO_VERSION \?= (.*)`},
+	"go":                      {"Makefile", `\nGO_VERSION \?= (.*)`},
 	"go-github":               {"go.mod", `github\.com\/google\/go-github\/.* (.*)`},
 	"golint":                  {"Makefile", `GOLINT_VERSION \?= (.*)`},
 	"gopogh":                  {"hack/jenkins/installers/check_install_gopogh.sh", `github.com/medyagh/gopogh/cmd/gopogh@(.*)`},


### PR DESCRIPTION
https://github.com/kubernetes/minikube/pull/17902 added `HUGO_VERSION` to the `Makefile`, the problem is `HUGO_VERSION` contains `GO_VERSION`, resulting in `DEP=go make get-dependency-version` returning `$(shell egrep "HUGO_VERSION = \"" netlify.toml | cut -d \" -f2)`. Updated the regex to get the correct line, now returns `1.21.5`.