### PR TITLE
Fix misleading error messages in TestCopyBinary

### DIFF
--- a/pkg/minikube/machine/cache_binaries_test.go
+++ b/pkg/minikube/machine/cache_binaries_test.go
@@ -72,10 +72,10 @@ func TestCopyBinary(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			err := CopyBinary(test.runner, test.src, test.dst)
 			if err != nil && !test.err {
-				t.Fatalf("Error %v expected but not occurred", err)
+				t.Fatalf("Got unexpected error %v", err)
 			}
 			if err == nil && test.err {
-				t.Fatal("Unexpected error")
+				t.Fatal("Expected error but got nil")
 			}
 		})
 	}


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
The error messages under func TestCopyBinary(t *testing.T) in cache_binaries_test.go for unexpected and expected error cases are mixed up.
