### PR TITLE
Move errors getting logs into log output itself

### DIFF
--- a/cmd/minikube/cmd/logs.go
+++ b/cmd/minikube/cmd/logs.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/minikube/pkg/minikube/logs"
 	"k8s.io/minikube/pkg/minikube/machine"
 	"k8s.io/minikube/pkg/minikube/mustload"
-	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/reason"
 )
 
@@ -120,11 +119,7 @@ var logsCmd = &cobra.Command{
 			logs.OutputProblems(problems, numberOfProblems, logOutput)
 			return
 		}
-		err = logs.Output(cr, bs, *co.Config, co.CP.Runner, numberOfLines, logOutput)
-		if err != nil {
-			out.Ln("")
-			out.WarningT("{{.error}}", out.V{"error": err})
-		}
+		logs.Output(cr, bs, *co.Config, co.CP.Runner, numberOfLines, logOutput)
 	},
 }
 

--- a/cmd/minikube/cmd/logs.go
+++ b/cmd/minikube/cmd/logs.go
@@ -31,7 +31,9 @@ import (
 	"k8s.io/minikube/pkg/minikube/logs"
 	"k8s.io/minikube/pkg/minikube/machine"
 	"k8s.io/minikube/pkg/minikube/mustload"
+	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/reason"
+	"k8s.io/minikube/pkg/minikube/style"
 )
 
 const (
@@ -120,6 +122,9 @@ var logsCmd = &cobra.Command{
 			return
 		}
 		logs.Output(cr, bs, *co.Config, co.CP.Runner, numberOfLines, logOutput)
+		if fileOutput != "" {
+			out.Styled(style.Success, "Logs file created ({{.logPath}}), remember to include it when reporting issues!", out.V{"logPath": fileOutput})
+		}
 	},
 }
 

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -1247,9 +1247,6 @@ func validateLogsFileCmd(ctx context.Context, t *testing.T, profile string) {
 	if err != nil {
 		t.Errorf("%s failed: %v", rr.Command(), err)
 	}
-	if rr.Stdout.String() != "" {
-		t.Errorf("expected empty minikube logs output, but got: \n***%s***\n", rr.Output())
-	}
 
 	logs, err := os.ReadFile(logFileName)
 	if err != nil {


### PR DESCRIPTION
**Rationale:**
Currently if we fail to retrieve logs from a pod or something else, we output the error to the user themselves, which can often confuse the user and make them thing the `minikube logs` command failed. Also, because this information isn't included in the logs, those triaging issues have no idea about the failure to retrieve logs.

For the before and after below I hard-coded a failure.

**Before - the user:**
```
$ minikube logs --file=logs.txt
E0119 16:08:44.907221   93053 logs.go:196] command /bin/bash -c "this is a fake command that will error" failed with error: /bin/bash -c "this is a fake command that will error": Process exited with status 127
stdout:

stderr:
/bin/bash: line 1: this: command not found
 output: "\n** stderr ** \n/bin/bash: line 1: this: command not found\n\n** /stderr **"

❗  unable to fetch logs for: forced-error
```
Note how to above could easily make the user think they failed to generate a logs file

**Before - the generated file (debugging)**
```
{"level":"info","ts":"2024-01-20T00:05:14.574Z","caller":"mvcc/hash.go:137","msg":"storing new hash","hash":325874407,"revision":3943,"compact-revision":3704}


==> forced-error <==                             

==> kernel <==
 00:08:44 up  3:12,  0 users,  load average: 0.49, 0.35, 0.31 
Linux minikube 6.5.11-linuxkit #1 SMP PREEMPT Wed Dec  6 17:08:31 UTC 2023 aarch64 aarch64 aarch64 GNU/Linux 
PRETTY_NAME="Ubuntu 22.04.3 LTS"
```
Note the empty output for forced error which would be confusing for someone trying to debug the users issue

**After - the user**
```
$ minikube logs --file=logs.txt
✅  Logs file created (logs.txt), remember to include it when reporting issues!
```
No error output and new message included to inform the user that the file was created

**After - the generated file (debugging)**
```
{"level":"info","ts":"2024-01-20T00:10:14.590Z","caller":"mvcc/hash.go:137","msg":"storing new hash","hash":2871990605,"revision":4182,"compact-revision":3943}


==> forced-error <==                             
command /bin/bash -c "this is a fake command that will error" failed with error: /bin/bash -c "this is a fake command that will error": Process exited with status 127
stdout:   

stderr:   
/bin/bash: line 1: this: command not found


==> kernel <==
 00:12:17 up  3:16,  0 users,  load average: 0.14, 0.25, 0.27 
Linux minikube 6.5.11-linuxkit #1 SMP PREEMPT Wed Dec  6 17:08:31 UTC 2023 aarch64 aarch64 aarch64 GNU/Linux 
PRETTY_NAME="Ubuntu 22.04.3 LTS"  
```
The debugger can now see what caused the logs to not be reported