### PR TITLE
Fix go vet issues

### DIFF
--- a/third_party/go9p/ufs_darwin.go
+++ b/third_party/go9p/ufs_darwin.go
@@ -44,11 +44,11 @@ func dir2Qid(d os.FileInfo) *Qid {
 func dir2Dir(path string, d os.FileInfo, dotu bool, upool Users) (*Dir, error) {
 	if r := recover(); r != nil {
 		fmt.Print("stat failed: ", r)
-		return nil, &os.PathError{"dir2Dir", path, nil}
+		return nil, &os.PathError{Op: "dir2Dir", Path: path, Err: nil}
 	}
 	sysif := d.Sys()
 	if sysif == nil {
-		return nil, &os.PathError{"dir2Dir: sysif is nil", path, nil}
+		return nil, &os.PathError{Op: "dir2Dir: sysif is nil", Path: path, Err: nil}
 	}
 	sysMode := sysif.(*syscall.Stat_t)
 


### PR DESCRIPTION
```
$ go vet ./...
# k8s.io/minikube/third_party/go9p
third_party/go9p/ufs_darwin.go:47:16: io/fs.PathError struct literal uses unkeyed fields
third_party/go9p/ufs_darwin.go:51:16: io/fs.PathError struct literal uses unkeyed fields
```