### PR TITLE
calico: support kubeadm.pod-network-cidr

### DIFF
--- a/hack/update/calico_version/update_calico_version.go
+++ b/hack/update/calico_version/update_calico_version.go
@@ -72,9 +72,6 @@ func updateYAML(version string) {
 		`docker\.io\/calico\/cni:.*`:              "{{ .BinaryImageName }}",
 		`docker\.io\/calico\/node:.*`:             "{{ .DaemonSetImageName }}",
 		`docker\.io\/calico\/kube-controllers:.*`: "{{ .DeploymentImageName }}",
-		`192\.168\.0\.0\/16"`: `192.168.0.0/16"
-            - name: CALICO_IPV4POOL_CIDR
-              value: {{ .PodCIDR }}`,
 	}
 	for re, repl := range replacements {
 		yaml = regexp.MustCompile(re).ReplaceAll(yaml, []byte(repl))

--- a/pkg/minikube/cni/calico.yaml
+++ b/pkg/minikube/cni/calico.yaml
@@ -4930,8 +4930,6 @@ spec:
             # no effect. This should fall within `--cluster-cidr`.
             # - name: CALICO_IPV4POOL_CIDR
             #   value: "192.168.0.0/16"
-            - name: CALICO_IPV4POOL_CIDR
-              value: {{ .PodCIDR }}
             # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"


### PR DESCRIPTION
Prior to this commit the Calico CNI ignored the setting of kubeadm.pod-network-cidr, because we set CALICO_IPV4POOL_CIDR to the DefaultPodCIDR. However, this is no longer necessary as Calico's pod cidr will be set to the default when we initialize kubeadm in pkg/minikube/bootstrapper/bsutil/kubeadm.go.
