### PR TITLE
kvm2 driver: Use scsi cdrom for arm64 to fix Linux on Apple Silicone 

### DIFF
--- a/pkg/drivers/kvm/domain_definition_arm64.go
+++ b/pkg/drivers/kvm/domain_definition_arm64.go
@@ -49,7 +49,7 @@ const domainTmpl = `
   <devices>
     <disk type='file' device='cdrom'>
       <source file='{{.ISO}}'/>
-      <target dev='sdc' bus='sata'/>
+      <target dev='sdc' bus='scsi'/>
       <readonly/>
     </disk>
     <disk type='file' device='disk'>
@@ -57,6 +57,8 @@ const domainTmpl = `
       <source file='{{.DiskPath}}'/>
       <target dev='hda' bus='virtio'/>
     </disk>
+    <controller type='scsi' index='0' model='virtio-scsi'>
+    </controller>
     <interface type='network'>
       <source network='{{.PrivateNetwork}}'/>
       <model type='virtio'/>


### PR DESCRIPTION
On linux/aarch64 (e.g. Asahi Linux on MacBook M*) booting from SATA cdrom is broken and the VM drops into the UEFI shell.

It seems that linux/aarch64 supports only virtio and scsi devices[1]. Replace with scsi cdrom (like the x86 version) and addd a virtio-scsi controller since the default scsi controller does not boot as well.

[1] https://kubevirt.io/user-guide/virtual_machines/virtual_machines_on_Arm64/#disks-and-volumes

Fixes #18238

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
