### PR TITLE
kvm2 driver: Remove uneeded nvram element

### DIFF
--- a/pkg/drivers/kvm/domain_definition_arm64.go
+++ b/pkg/drivers/kvm/domain_definition_arm64.go
@@ -41,7 +41,6 @@ const domainTmpl = `
   <os>
     <type machine='virt-4.2' arch='aarch64'>hvm</type>
     <loader readonly='yes' type='pflash'>/usr/share/AAVMF/AAVMF_CODE.fd</loader>
-    <nvram>/usr/share/AAVMF/AAVMF_VARS.fd</nvram>
     <boot dev='cdrom'/>
     <boot dev='hd'/>
     <bootmenu enable='no'/>


### PR DESCRIPTION
The curent domain xml template includes static nvram image using the shared template image:

    <nvram>/usr/share/AAVMF/AAVMF_VARS.fd</nvram>

This "works" when starting sinlge profile, but when starting a second profile this breaks with:

    virError(Code=55, Domain=24, Message='Requested operation is not
    valid: Setting different SELinux label on /usr/share/AAVMF/AAVMF_VARS.fd
    which is already in use

Which tells us that we are doing the wrong thing.

If we remove the nvram element, a new per-vm nvram is created dynamially:

    $ virsh -c qemu:///system dumpxml ex1 | grep nvram
    <nvram template='/usr/share/AAVMF/AAVMF_VARS.fd'>/var/lib/libvirt/qemu/nvram/ex1_VARS.fd</nvram>

    $ virsh -c qemu:///system dumpxml ex2 | grep nvram
    <nvram template='/usr/share/AAVMF/AAVMF_VARS.fd'>/var/lib/libvirt/qemu/nvram/ex2_VARS.fd</nvram>

Tested on top of #18239

Fixes #18240 