### PR TITLE
Upgrade Cilium to v1.15.1 for k8s 1.28 compatibility

### DIFF
--- a/pkg/minikube/cni/cilium.go
+++ b/pkg/minikube/cni/cilium.go
@@ -524,7 +524,7 @@ spec:
               key: custom-cni-conf
               name: cilium-config
               optional: true
-        image: "quay.io/cilium/cilium:v1.12.3@sha256:30de50c4dc0a1e1077e9e7917a54d5cab253058b3f779822aec00f5c817ca826"
+        image: "quay.io/cilium/cilium:v1.15.1@sha256:351d6685dc6f6ffbcd5451043167cfa8842c6decf80d8c8e426a417c73fb56d4"
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -586,7 +586,7 @@ spec:
           # same directory where we install cilium cni plugin so that exec permissions
           # are available.
           - 'cp /usr/bin/cilium-mount /hostbin/cilium-mount && nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT; rm /hostbin/cilium-mount'
-        image: "quay.io/cilium/cilium:v1.12.3@sha256:30de50c4dc0a1e1077e9e7917a54d5cab253058b3f779822aec00f5c817ca826"
+        image: "quay.io/cilium/cilium:v1.15.1@sha256:351d6685dc6f6ffbcd5451043167cfa8842c6decf80d8c8e426a417c73fb56d4"
         imagePullPolicy: IfNotPresent
         volumeMounts:
           - mountPath: /hostproc


### PR DESCRIPTION
### Context
<hr>
The Cilium version deployed by minikube is incompatible with version 1.28 of Kubernetes and is no longer supported by the Cilium project. 

This PR updates Cilium to version 1.15.1, the latest available.

### Implementation
<hr>
Update Kubernetes template in minikube/pkg/cni/cilium.go to version 1.15.1 in the image sections.
No significant changes were needed in the template which are breaking at this time.

### Testing
<hr>
Limited testing was done, on a Mac M1, using Docker v4.27.2 and minikube v1.32.0.

```
❯ ./out/minikube start --cni=cilium
😄  minikube v1.32.0 on Darwin 14.3.1 (arm64)
🆕  Kubernetes 1.28.4 is now available. If you would like to upgrade, specify: --kubernetes-version=v1.28.4
✨  Using the docker driver based on existing profile
❗  docker is currently using the stargz storage driver, setting preload=false
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image v0.0.42-1708008208-17936 ...
🏃  Updating the running docker "minikube" container ...
🐳  Preparing Kubernetes v1.28.3 on Docker 24.0.7 ...
🔎  Verifying Kubernetes components...
    ▪ Using image registry.k8s.io/metrics-server/metrics-server:v0.7.0
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
    ▪ Using image docker.io/kubernetesui/dashboard:v2.7.0
    ▪ Using image docker.io/kubernetesui/metrics-scraper:v1.0.8
💡  Some dashboard features require the metrics-server addon. To enable all features please run:

	minikube addons enable metrics-server

🌟  Enabled addons: storage-provisioner, metrics-server, default-storageclass, dashboard
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
❯ cilium status
    /¯¯\
 /¯¯\__/¯¯\    Cilium:             OK
 \__/¯¯\__/    Operator:           OK
 /¯¯\__/¯¯\    Envoy DaemonSet:    disabled (using embedded mode)
 \__/¯¯\__/    Hubble Relay:       disabled
    \__/       ClusterMesh:        disabled

Deployment             cilium-operator    Desired: 1, Ready: 1/1, Available: 1/1
DaemonSet              cilium             Desired: 1, Ready: 1/1, Available: 1/1
Containers:            cilium             Running: 1
                       cilium-operator    Running: 1
Cluster Pods:          7/7 managed by Cilium
Helm chart version:    
Image versions         cilium             quay.io/cilium/cilium:v1.12.3@sha256:30de50c4dc0a1e1077e9e7917a54d5cab253058b3f779822aec00f5c817ca826: 1
                       cilium-operator    quay.io/cilium/operator-generic:v1.12.3@sha256:816ec1da586139b595eeb31932c61a7c13b07fb4a0255341c0e0f18608e84eff: 1
```
*Note* This was heavily based off the earlier commit by @rastaman in #15242 
