### PR TITLE
Path Changes in Documentation for Minikube Installation in Windows

### DIFF
--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -442,8 +442,9 @@ choco install minikube
 <br>
     Or if using `PowerShell`, use this command:
     ```powershell
-    New-Item -Path 'c:\' -Name 'minikube' -ItemType Directory -Force
-    Invoke-WebRequest -OutFile 'c:\minikube\minikube.exe' -Uri 'https://github.com/kubernetes/minikube/releases/latest/download/minikube-windows-amd64.exe' -UseBasicParsing
+    New-Item -Path 'C:\Program Files' -Name 'Kubernetes' -ItemType Directory -Force
+    New-Item -Path 'C:\Program Files\Kubernetes' -Name 'Minikube' -ItemType Directory -Force
+    Invoke-WebRequest -OutFile 'C:\Program Files\Kubernetes\Minikube\minikube.exe' -Uri 'https://github.com/kubernetes/minikube/releases/latest/download/minikube-windows-amd64.exe' -UseBasicParsing
     ```
 
 2. Add the `minikube.exe` binary to your `PATH`.
@@ -451,8 +452,8 @@ choco install minikube
     _Make sure to run PowerShell as Administrator._
     ```powershell
     $oldPath = [Environment]::GetEnvironmentVariable('Path', [EnvironmentVariableTarget]::Machine)
-    if ($oldPath.Split(';') -inotcontains 'C:\minikube'){
-      [Environment]::SetEnvironmentVariable('Path', $('{0};C:\minikube' -f $oldPath), [EnvironmentVariableTarget]::Machine)
+    if ($oldPath.Split(';') -inotcontains 'C:\Program Files\Kubernetes\Minikube'){
+      [Environment]::SetEnvironmentVariable('Path', $('{0};C:\Program Files\Kubernetes\Minikube' -f $oldPath), [EnvironmentVariableTarget]::Machine)
     }
     ```
     <span style="color:blue">


### PR DESCRIPTION

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

Fixes #18291 

Changes the installation path given below from 'c:\minekube' to 'C:\Program Files\Minekube' because thats where the Windows installer installs it
<img width="590" alt="image" src="https://github.com/kubernetes/minikube/assets/102252920/366171d6-8a45-4f29-b806-57f0707cad67">
