### PR TITLE
kicbase: Fix install for cri-o

### DIFF
--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -187,17 +187,6 @@ RUN clean-install podman && \
     echo "d /run/podman 0770 root podman" > /etc/tmpfiles.d/podman.conf && \
     systemd-tmpfiles --create
 
-# install cri-o dependencies:
-RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/') && \
-    sh -c "echo 'deb https://downloadcontent.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_22.04/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list" && \
-    curl -LO https://downloadcontent.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_22.04/Release.key && \
-    apt-key add - < Release.key && \
-    if [ "$ARCH" != "ppc64le" ]; then \
-        clean-install catatonit conmon cri-tools crun; \
-    else \
-        clean-install conmon crun; \
-    fi
-
 # install containernetworking-plugins
 RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/' | sed 's/armhf/arm/') && \
     curl -LO "https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGINS_VERSION}/cni-plugins-linux-$ARCH-${CNI_PLUGINS_VERSION}.tgz" && \
@@ -205,12 +194,14 @@ RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/' | sed 's/
     tar -xf "cni-plugins-linux-$ARCH-${CNI_PLUGINS_VERSION}.tgz" -C /opt/cni/bin && \
     rm "cni-plugins-linux-$ARCH-${CNI_PLUGINS_VERSION}.tgz"
 
-# install cri-o based on https://github.com/cri-o/cri-o/blob/release-1.24/README.md#installing-cri-o
-RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/' | sed 's/armhf/arm-v7/') && \
-    if [ "$ARCH" != "ppc64le" ] && [ "$ARCH" != "arm-v7" ]; then sh -c "echo 'deb https://downloadcontent.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/${CRIO_VERSION}/xUbuntu_22.04/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable:cri-o:${CRIO_VERSION}.list" && \
-    curl -LO https://downloadcontent.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/${CRIO_VERSION}/xUbuntu_22.04/Release.key && \
-    apt-key add - < Release.key && \
-    clean-install cri-o cri-o-runc; fi
+# install cri-o based on https://github.com/cri-o/packaging#distributions-using-deb-packages
+RUN export ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" != "armhf" ] && [ "$ARCH" != "s390x" ]; then \
+        clean-install software-properties-common \
+        && curl -fsSL https://pkgs.k8s.io/addons:/cri-o:/stable:/v${CRIO_VERSION}/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/cri-o-apt-keyring.gpg \
+        && echo "deb [signed-by=/etc/apt/keyrings/cri-o-apt-keyring.gpg] https://pkgs.k8s.io/addons:/cri-o:/stable:/v${CRIO_VERSION}/deb/ /" | tee /etc/apt/sources.list.d/cri-o.list \
+        && clean-install cri-o; \
+    fi
 
 # install NVIDIA container toolkit
 RUN export ARCH=$(dpkg --print-architecture) && \

--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -229,9 +229,13 @@ RUN  chmod +x /var/lib/minikube/scheduled-stop/minikube-scheduled-stop
 
 # disable non-docker runtimes by default
 RUN systemctl disable containerd
+
 # disable crio for archs that support it
-RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/' | sed 's/armhf/arm-v7/') && \
-    if [ "$ARCH" != "ppc64le" ] && [ "$ARCH" != "arm-v7" ]; then systemctl disable crio && rm /etc/crictl.yaml; fi
+RUN export ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" != "armhf" ] && [ "$ARCH" != "s390x" ]; then \
+        systemctl disable crio && rm /etc/crictl.yaml; \
+    fi
+
 # enable podman socket on archs that support it
 RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/') && if [ "$ARCH" != "ppc64le" ]; then systemctl enable podman.socket; fi
 # enable docker which is default

--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -97,7 +97,6 @@ RUN echo "Ensuring scripts are executable ..." \
       bash ca-certificates curl rsync \
       nfs-common \
       iputils-ping netcat-openbsd vim-tiny \
-      software-properties-common \
     && find /lib/systemd/system/sysinit.target.wants/ -name "systemd-tmpfiles-setup.service" -delete \
     && rm -f /lib/systemd/system/multi-user.target.wants/* \
     && rm -f /etc/systemd/system/*.wants/* \
@@ -192,7 +191,8 @@ RUN clean-install podman && \
 # install crictl
 RUN export ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" != "armhf" ]; then \
-        curl -fsSL https://pkgs.k8s.io/core:/stable:/${CRICTL_VERSION}/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/cri-tools-apt-keyring.gpg \
+        clean-install software-properties-common \
+        && curl -fsSL https://pkgs.k8s.io/core:/stable:/${CRICTL_VERSION}/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/cri-tools-apt-keyring.gpg \
         && echo "deb [signed-by=/etc/apt/keyrings/cri-tools-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${CRICTL_VERSION}/deb/ /" | tee /etc/apt/sources.list.d/cri-tools.list \
         && clean-install cri-tools; \
     fi

--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -207,7 +207,7 @@ RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/' | sed 's/
 # install cri-o based on https://github.com/cri-o/packaging#distributions-using-deb-packages
 RUN export ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" != "armhf" ] && [ "$ARCH" != "s390x" ]; then \
-        && curl -fsSL https://pkgs.k8s.io/addons:/cri-o:/stable:/${CRIO_VERSION}/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/cri-o-apt-keyring.gpg \
+        curl -fsSL https://pkgs.k8s.io/addons:/cri-o:/stable:/${CRIO_VERSION}/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/cri-o-apt-keyring.gpg \
         && echo "deb [signed-by=/etc/apt/keyrings/cri-o-apt-keyring.gpg] https://pkgs.k8s.io/addons:/cri-o:/stable:/${CRIO_VERSION}/deb/ /" | tee /etc/apt/sources.list.d/cri-o.list \
         && clean-install cri-o; \
     fi

--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -187,6 +187,15 @@ RUN clean-install podman && \
     echo "d /run/podman 0770 root podman" > /etc/tmpfiles.d/podman.conf && \
     systemd-tmpfiles --create
 
+# install crictl
+RUN export ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" != "ppc64el" ]; then \
+        sh -c "echo 'deb https://downloadcontent.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_22.04/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list" && \
+        curl -LO https://downloadcontent.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_22.04/Release.key && \
+        apt-key add - < Release.key && \
+        clean-install cri-tools; \
+    fi
+
 # install containernetworking-plugins
 RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/' | sed 's/armhf/arm/') && \
     curl -LO "https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGINS_VERSION}/cni-plugins-linux-$ARCH-${CNI_PLUGINS_VERSION}.tgz" && \

--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -42,7 +42,6 @@ RUN if [ "$PREBUILT_AUTO_PAUSE" != "true" ]; then cd ./cmd/auto-pause/ && go bui
 FROM ${UBUNTU_JAMMY_IMAGE} as kicbase
 
 ARG BUILDKIT_VERSION="v0.12.4"
-ARG CRICTL_VERSION="v1.29"
 ARG CRIO_VERSION="v1.29"
 ARG CRI_DOCKERD_VERSION="v0.3.3"
 ARG CRI_DOCKERD_COMMIT="b58acf8f78f9d7bce1241d1cddb0932e7101f278"
@@ -188,13 +187,15 @@ RUN clean-install podman && \
     echo "d /run/podman 0770 root podman" > /etc/tmpfiles.d/podman.conf && \
     systemd-tmpfiles --create
 
-# install crictl
-RUN export ARCH=$(dpkg --print-architecture) && \
-    if [ "$ARCH" != "armhf" ]; then \
-        clean-install software-properties-common \
-        && curl -fsSL https://pkgs.k8s.io/core:/stable:/${CRICTL_VERSION}/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/cri-tools-apt-keyring.gpg \
-        && echo "deb [signed-by=/etc/apt/keyrings/cri-tools-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${CRICTL_VERSION}/deb/ /" | tee /etc/apt/sources.list.d/cri-tools.list \
-        && clean-install cri-tools; \
+# install cri-o dependencies:
+RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/') && \
+    sh -c "echo 'deb https://downloadcontent.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_22.04/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list" && \
+    curl -LO https://downloadcontent.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_22.04/Release.key && \
+    apt-key add - < Release.key && \
+    if [ "$ARCH" != "ppc64le" ]; then \
+        clean-install catatonit conmon cri-tools crun; \
+    else \
+        clean-install conmon crun; \
     fi
 
 # install containernetworking-plugins

--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -42,7 +42,8 @@ RUN if [ "$PREBUILT_AUTO_PAUSE" != "true" ]; then cd ./cmd/auto-pause/ && go bui
 FROM ${UBUNTU_JAMMY_IMAGE} as kicbase
 
 ARG BUILDKIT_VERSION="v0.12.4"
-ARG CRIO_VERSION="1.29"
+ARG CRICTL_VERSION="v1.29"
+ARG CRIO_VERSION="v1.29"
 ARG CRI_DOCKERD_VERSION="v0.3.3"
 ARG CRI_DOCKERD_COMMIT="b58acf8f78f9d7bce1241d1cddb0932e7101f278"
 ARG CNI_PLUGINS_VERSION="v1.4.0"
@@ -96,6 +97,7 @@ RUN echo "Ensuring scripts are executable ..." \
       bash ca-certificates curl rsync \
       nfs-common \
       iputils-ping netcat-openbsd vim-tiny \
+      software-properties-common \
     && find /lib/systemd/system/sysinit.target.wants/ -name "systemd-tmpfiles-setup.service" -delete \
     && rm -f /lib/systemd/system/multi-user.target.wants/* \
     && rm -f /etc/systemd/system/*.wants/* \
@@ -189,11 +191,10 @@ RUN clean-install podman && \
 
 # install crictl
 RUN export ARCH=$(dpkg --print-architecture) && \
-    if [ "$ARCH" != "ppc64el" ]; then \
-        sh -c "echo 'deb https://downloadcontent.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_22.04/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list" && \
-        curl -LO https://downloadcontent.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_22.04/Release.key && \
-        apt-key add - < Release.key && \
-        clean-install cri-tools; \
+    if [ "$ARCH" != "armhf" ]; then \
+        curl -fsSL https://pkgs.k8s.io/core:/stable:/${CRICTL_VERSION}/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/cri-tools-apt-keyring.gpg \
+        && echo "deb [signed-by=/etc/apt/keyrings/cri-tools-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${CRICTL_VERSION}/deb/ /" | tee /etc/apt/sources.list.d/cri-tools.list \
+        && clean-install cri-tools; \
     fi
 
 # install containernetworking-plugins
@@ -206,9 +207,8 @@ RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/' | sed 's/
 # install cri-o based on https://github.com/cri-o/packaging#distributions-using-deb-packages
 RUN export ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" != "armhf" ] && [ "$ARCH" != "s390x" ]; then \
-        clean-install software-properties-common \
-        && curl -fsSL https://pkgs.k8s.io/addons:/cri-o:/stable:/v${CRIO_VERSION}/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/cri-o-apt-keyring.gpg \
-        && echo "deb [signed-by=/etc/apt/keyrings/cri-o-apt-keyring.gpg] https://pkgs.k8s.io/addons:/cri-o:/stable:/v${CRIO_VERSION}/deb/ /" | tee /etc/apt/sources.list.d/cri-o.list \
+        && curl -fsSL https://pkgs.k8s.io/addons:/cri-o:/stable:/${CRIO_VERSION}/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/cri-o-apt-keyring.gpg \
+        && echo "deb [signed-by=/etc/apt/keyrings/cri-o-apt-keyring.gpg] https://pkgs.k8s.io/addons:/cri-o:/stable:/${CRIO_VERSION}/deb/ /" | tee /etc/apt/sources.list.d/cri-o.list \
         && clean-install cri-o; \
     fi
 

--- a/hack/update/cri-o_version/update_cri-o_version.go
+++ b/hack/update/cri-o_version/update_cri-o_version.go
@@ -63,7 +63,7 @@ func main() {
 	if err != nil {
 		klog.Fatalf("Unable to get cri-o stable version: %v", err)
 	}
-	mmVersion := strings.TrimPrefix(semver.MajorMinor(stable.Tag), "v")
+	mmVersion := semver.MajorMinor(stable.Tag)
 
 	data := Data{Version: stable.Tag, MMVersion: mmVersion, Commit: stable.Commit}
 

--- a/hack/update/crictl_version/update_crictl_version.go
+++ b/hack/update/crictl_version/update_crictl_version.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/mod/semver"
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/hack/update"
 )
@@ -57,12 +58,17 @@ var (
 				`CRICTL_VERSION=.*`: `CRICTL_VERSION="{{.Version}}"`,
 			},
 		},
+		"deploy/kicbase/Dockerfile": {
+			Replace: map[string]string{
+				`ARG CRICTL_VERSION=.*`: `ARG CRICTL_VERSION="{{.MMVersion}}"`,
+			},
+		},
 	}
 )
 
 type Data struct {
-	Version string
-	Commit  string
+	Version   string
+	MMVersion string
 }
 
 func main() {
@@ -73,8 +79,9 @@ func main() {
 	if err != nil {
 		klog.Fatalf("Unable to get stable version: %v", err)
 	}
+	mmVersion := semver.MajorMinor(stable.Tag)
 
-	data := Data{Version: stable.Tag}
+	data := Data{Version: stable.Tag, MMVersion: mmVersion}
 
 	update.Apply(schema, data)
 

--- a/hack/update/crictl_version/update_crictl_version.go
+++ b/hack/update/crictl_version/update_crictl_version.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/mod/semver"
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/hack/update"
 )
@@ -58,17 +57,12 @@ var (
 				`CRICTL_VERSION=.*`: `CRICTL_VERSION="{{.Version}}"`,
 			},
 		},
-		"deploy/kicbase/Dockerfile": {
-			Replace: map[string]string{
-				`ARG CRICTL_VERSION=.*`: `ARG CRICTL_VERSION="{{.MMVersion}}"`,
-			},
-		},
 	}
 )
 
 type Data struct {
-	Version   string
-	MMVersion string
+	Version string
+	Commit  string
 }
 
 func main() {
@@ -79,9 +73,8 @@ func main() {
 	if err != nil {
 		klog.Fatalf("Unable to get stable version: %v", err)
 	}
-	mmVersion := semver.MajorMinor(stable.Tag)
 
-	data := Data{Version: stable.Tag, MMVersion: mmVersion}
+	data := Data{Version: stable.Tag}
 
 	update.Apply(schema, data)
 

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -24,10 +24,10 @@ import (
 
 const (
 	// Version is the current version of kic
-	Version = "v0.0.42-1709747546-18294"
+	Version = "v0.0.42-1709852840-18294"
 
 	// SHA of the kic base image
-	baseImageSHA = "c789b83801cae2d02d32f185b7e638497d2663f99052babad6d810a4bba5d89a"
+	baseImageSHA = "b9f74f2f709901ba39934395dd2f0460fbeb548792011c5ed8f5324dda9073c7"
 	// The name of the GCR kicbase repository
 	gcrRepo = "gcr.io/k8s-minikube/kicbase-builds"
 	// The name of the Dockerhub kicbase repository

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -24,10 +24,10 @@ import (
 
 const (
 	// Version is the current version of kic
-	Version = "v0.0.42-1709696059-18294"
+	Version = "v0.0.42-1709747546-18294"
 
 	// SHA of the kic base image
-	baseImageSHA = "2b250466c3b57ad60494887b8997007414d1650f96b664364335a665ce32dcd0"
+	baseImageSHA = "c789b83801cae2d02d32f185b7e638497d2663f99052babad6d810a4bba5d89a"
 	// The name of the GCR kicbase repository
 	gcrRepo = "gcr.io/k8s-minikube/kicbase-builds"
 	// The name of the Dockerhub kicbase repository

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -24,10 +24,10 @@ import (
 
 const (
 	// Version is the current version of kic
-	Version = "v0.0.42-1708944392-18244"
+	Version = "v0.0.42-1709696059-18294"
 
 	// SHA of the kic base image
-	baseImageSHA = "8610dac8144c3f59a6cf50871eb10395cea122e148262744231a04c396033b08"
+	baseImageSHA = "2b250466c3b57ad60494887b8997007414d1650f96b664364335a665ce32dcd0"
 	// The name of the GCR kicbase repository
 	gcrRepo = "gcr.io/k8s-minikube/kicbase-builds"
 	// The name of the Dockerhub kicbase repository

--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -24,10 +24,10 @@ import (
 
 const (
 	// Version is the current version of kic
-	Version = "v0.0.42-1709852840-18294"
+	Version = "v0.0.42-1710197003-18294"
 
 	// SHA of the kic base image
-	baseImageSHA = "b9f74f2f709901ba39934395dd2f0460fbeb548792011c5ed8f5324dda9073c7"
+	baseImageSHA = "5370deeab7f6a0352ecd0e5d6cb7587a77415e4691b94c2f8e9521a32b198c18"
 	// The name of the GCR kicbase repository
 	gcrRepo = "gcr.io/k8s-minikube/kicbase-builds"
 	// The name of the Dockerhub kicbase repository

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -27,7 +27,7 @@ minikube start [flags]
       --apiserver-port int                The apiserver listening port (default 8443)
       --auto-pause-interval duration      Duration of inactivity before the minikube VM is paused (default 1m0s) (default 1m0s)
       --auto-update-drivers               If set, automatically updates drivers to the latest version. Defaults to true. (default true)
-      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.42-1709852840-18294@sha256:b9f74f2f709901ba39934395dd2f0460fbeb548792011c5ed8f5324dda9073c7")
+      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.42-1710197003-18294@sha256:5370deeab7f6a0352ecd0e5d6cb7587a77415e4691b94c2f8e9521a32b198c18")
       --binary-mirror string              Location to fetch kubectl, kubelet, & kubeadm binaries from.
       --cache-images                      If true, cache docker images for the current bootstrapper and load them into the machine. Always false with --driver=none. (default true)
       --cert-expiration duration          Duration until minikube certificate expiration, defaults to three years (26280h). (default 26280h0m0s)

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -27,7 +27,7 @@ minikube start [flags]
       --apiserver-port int                The apiserver listening port (default 8443)
       --auto-pause-interval duration      Duration of inactivity before the minikube VM is paused (default 1m0s) (default 1m0s)
       --auto-update-drivers               If set, automatically updates drivers to the latest version. Defaults to true. (default true)
-      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.42-1709696059-18294@sha256:2b250466c3b57ad60494887b8997007414d1650f96b664364335a665ce32dcd0")
+      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.42-1709747546-18294@sha256:c789b83801cae2d02d32f185b7e638497d2663f99052babad6d810a4bba5d89a")
       --binary-mirror string              Location to fetch kubectl, kubelet, & kubeadm binaries from.
       --cache-images                      If true, cache docker images for the current bootstrapper and load them into the machine. Always false with --driver=none. (default true)
       --cert-expiration duration          Duration until minikube certificate expiration, defaults to three years (26280h). (default 26280h0m0s)

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -27,7 +27,7 @@ minikube start [flags]
       --apiserver-port int                The apiserver listening port (default 8443)
       --auto-pause-interval duration      Duration of inactivity before the minikube VM is paused (default 1m0s) (default 1m0s)
       --auto-update-drivers               If set, automatically updates drivers to the latest version. Defaults to true. (default true)
-      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.42-1708944392-18244@sha256:8610dac8144c3f59a6cf50871eb10395cea122e148262744231a04c396033b08")
+      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.42-1709696059-18294@sha256:2b250466c3b57ad60494887b8997007414d1650f96b664364335a665ce32dcd0")
       --binary-mirror string              Location to fetch kubectl, kubelet, & kubeadm binaries from.
       --cache-images                      If true, cache docker images for the current bootstrapper and load them into the machine. Always false with --driver=none. (default true)
       --cert-expiration duration          Duration until minikube certificate expiration, defaults to three years (26280h). (default 26280h0m0s)

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -27,7 +27,7 @@ minikube start [flags]
       --apiserver-port int                The apiserver listening port (default 8443)
       --auto-pause-interval duration      Duration of inactivity before the minikube VM is paused (default 1m0s) (default 1m0s)
       --auto-update-drivers               If set, automatically updates drivers to the latest version. Defaults to true. (default true)
-      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.42-1709747546-18294@sha256:c789b83801cae2d02d32f185b7e638497d2663f99052babad6d810a4bba5d89a")
+      --base-image string                 The base image to use for docker/podman drivers. Intended for local development. (default "gcr.io/k8s-minikube/kicbase-builds:v0.0.42-1709852840-18294@sha256:b9f74f2f709901ba39934395dd2f0460fbeb548792011c5ed8f5324dda9073c7")
       --binary-mirror string              Location to fetch kubectl, kubelet, & kubeadm binaries from.
       --cache-images                      If true, cache docker images for the current bootstrapper and load them into the machine. Always false with --driver=none. (default true)
       --cert-expiration duration          Duration until minikube certificate expiration, defaults to three years (26280h). (default 26280h0m0s)


### PR DESCRIPTION
**Problem:**
HEAD is failing with the following when trying to build kicbase
```
02:59:09  > [linux/amd64 kicbase 23/47] RUN export ARCH=$(dpkg --print-architecture | sed 's/ppc64el/ppc64le/' | sed 's/armhf/arm-v7/') &&     if [ "$ARCH" != "ppc64le" ] && [ "$ARCH" != "arm-v7" ]; then sh -c "echo 'deb https://downloadcontent.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.29/xUbuntu_22.04/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable:cri-o:1.29.list" &&     curl -LO https://downloadcontent.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.29/xUbuntu_22.04/Release.key &&     apt-key add - < Release.key &&     clean-install cri-o cri-o-runc; fi:
02:59:09 
100   146  100   146    0     0    334      0 --:--:-- --:--:-- --:--:--   335
02:59:09 0.736 Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
02:59:09 0.778 gpg: no valid OpenPGP data found.
```

**Cause:**
They moved cri-o 1.29+ to a new deb repo

cri-o < 1.29: `https://downloadcontent.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/${CRIO_VERSION}/xUbuntu_22.04/`

cri-o 1.29+: `https://pkgs.k8s.io/addons:/cri-o:/stable:/${CRIO_VERSION}/deb/`

**Update crictl repo**
We were previously using the old repo for crictl `https://downloadcontent.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_22.04/`

This repo only has crictl v1.25, so there's a version mismatch from our ISO.

Updated the use the new crictl repo `https://pkgs.k8s.io/core:/stable:/${CRICTL_VERSION}/deb/`

Also pin the crictl version in the kicbase now