### PR TITLE
feat: allow preload for overlayfs

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1928,7 +1928,7 @@ func validateDockerStorageDriver(drvName string) {
 		viper.Set(preload, false)
 		return
 	}
-	if si.StorageDriver == "overlay2" {
+	if si.StorageDriver == "overlay2" || si.StorageDriver == "overlayfs" {
 		return
 	}
 	out.WarningT("{{.Driver}} is currently using the {{.StorageDriver}} storage driver, setting preload=false", out.V{"StorageDriver": si.StorageDriver, "Driver": drvName})


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
Before:
```
 $ minikube start                    
😄  minikube v1.32.0 on Darwin 14.2.1 (arm64)
✨  Automatically selected the docker driver
❗  docker is currently using the overlayfs storage driver, setting preload=false
📌  Using Docker Desktop driver with root privileges
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image ...
    > gcr.io/k8s-minikube/kicbase...:  97.25 KiB / 410.58 MiB  0.02% 162.32 Ki
```
After
```
 $ minikube start        
😄  minikube v1.32.0 on Darwin 14.2.1 (arm64)
✨  Automatically selected the docker driver
📌  Using Docker Desktop driver with root privileges
👍  Starting control plane node minikube in cluster minikube
🚜  Pulling base image v0.0.42-1708944392-18244 ...
💾  Downloading Kubernetes v1.28.4 preload ...
    > preloaded-images-k8s-v18-v1...:  341.36 MiB / 341.36 MiB  100.00% 2.22 Mi
    > gcr.io/k8s-minikube/kicbase...:  415.65 MiB / 415.65 MiB  100.00% 2.70 Mi
🔥  Creating docker container (CPUs=2, Memory=6100MB) ...
🐳  Preparing Kubernetes v1.28.4 on Docker 25.0.3 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🔎  Verifying Kubernetes components...
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```