### PR TITLE
enable loadbalancer for ha

### DIFF
--- a/pkg/minikube/cluster/ha/kube-vip/kube-vip.go
+++ b/pkg/minikube/cluster/ha/kube-vip/kube-vip.go
@@ -72,6 +72,10 @@ spec:
       value: {{ .VIP }}
     - name: prometheus_server
       value: :2112
+    - name : lb_enable
+      value: "true"
+    - name: lb_port
+      value: "{{ .Port }}"
     image: ghcr.io/kube-vip/kube-vip:v0.7.1
     imagePullPolicy: IfNotPresent
     name: kube-vip


### PR DESCRIPTION
enable kube-vip loadbalancer for multi-control plane api servers

note - kube-vip current limitation / [known issue](https://kube-vip.io/docs/about/architecture/#known-issues):
> lb with ipvs mode won't work with kubeproxy that is configured with ipvs mode

ref: https://github.com/kube-vip/kube-vip/issues/454

_we **currently** don't configure kube-proxy with ipvs mode and therefore should not be affected by this_
