### PR TITLE
download crictl at preload and runtime

### DIFF
--- a/hack/preload-images/generate.go
+++ b/hack/preload-images/generate.go
@@ -127,6 +127,11 @@ func generateTarball(kubernetesVersion, containerRuntime, tarballFilename string
 	if err := bsutil.TransferBinaries(kcfg, runner, sm, ""); err != nil {
 		return errors.Wrap(err, "transferring k8s binaries")
 	}
+	// download crictl if needed
+
+	if err := bsutil.TransferCrictl(kcfg, runner); err != nil {
+		return errors.Wrap(err, "transferring crictl")
+	}
 	// Create image tarball
 	if err := createImageTarball(tarballFilename, containerRuntime); err != nil {
 		return errors.Wrap(err, "create tarball")

--- a/hack/preload-images/generate.go
+++ b/hack/preload-images/generate.go
@@ -128,7 +128,6 @@ func generateTarball(kubernetesVersion, containerRuntime, tarballFilename string
 		return errors.Wrap(err, "transferring k8s binaries")
 	}
 	// download crictl if needed
-
 	if err := bsutil.TransferCrictl(kcfg, runner); err != nil {
 		return errors.Wrap(err, "transferring crictl")
 	}

--- a/hack/preload-images/generate.go
+++ b/hack/preload-images/generate.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"k8s.io/klog/v2"
 	"k8s.io/minikube/hack/update"
 	"k8s.io/minikube/pkg/drivers/kic"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
@@ -136,7 +137,9 @@ func generateTarball(kubernetesVersion, containerRuntime, tarballFilename string
 		k8sVer, _ := util.ParseKubernetesVersion(kubernetesVersion)
 		crictlVer, _ := util.ParseKubernetesVersion(crictlVersion)
 		return k8sVer.Major == crictlVer.Major && k8sVer.Minor == crictlVer.Minor
-	}); err == nil {
+	}); err != nil {
+		klog.Error("failed to get the newest version tag pf crictl from github")
+	} else {
 		crictlVersion = stable.Tag
 	}
 

--- a/hack/update/github.go
+++ b/hack/update/github.go
@@ -46,8 +46,11 @@ func GHReleases(ctx context.Context, owner, repo string) (stable, latest, edge R
 	return GHReleasesWithCondition(ctx, owner, repo, nil)
 }
 
-// GHReleasesWithCondition returns greatest current stable release and greatest latest rc or beta pre-release from GitHub owner/repo repository whose version number satisfy the condition given in the parameter, and any error occurred.
-// If latest pre-release version is lower than the current stable release, then it will return current stable release for both.
+// GHReleasesWithCondition returns greatest current stable release and greatest 
+// latest rc or beta pre-release from GitHub owner/repo repository whose version
+// number satisfy the condition given in the parameter, and any error occurred. 
+// If latest pre-release version is lower than the current stable release, then 
+// it will return current stable release for both.
 func GHReleasesWithCondition(ctx context.Context, owner, repo string, condition func(string) bool) (stable, latest, edge Release, err error) {
 	ghc := github.NewClient(nil)
 

--- a/pkg/minikube/bootstrapper/bsutil/binaries.go
+++ b/pkg/minikube/bootstrapper/bsutil/binaries.go
@@ -37,6 +37,19 @@ import (
 	"k8s.io/minikube/pkg/minikube/vmpath"
 )
 
+// TransferCrictl transfers the crictl binary to the machine to replace /usr/bin/crictl
+func TransferCrictl(cfg config.KubernetesConfig, c command.Runner) error {
+	src, err := download.DownloadCrictlBinary(cfg.KubernetesVersion)
+	if err != nil {
+		return errors.Wrapf(err, "downloading crictl")
+	}
+	dst := "/usr/bin/crictl"
+	if err := machine.CopyBinary(c, src, dst); err != nil {
+		return errors.Wrapf(err, "copybinary %s -> %s", src, dst)
+	}
+	return nil
+}
+
 // TransferBinaries transfers all required Kubernetes binaries
 func TransferBinaries(cfg config.KubernetesConfig, c command.Runner, sm sysinit.Manager, binariesURL string) error {
 	ok, err := binariesExist(cfg, c)

--- a/pkg/minikube/bootstrapper/bsutil/binaries.go
+++ b/pkg/minikube/bootstrapper/bsutil/binaries.go
@@ -41,6 +41,10 @@ import (
 func TransferCrictl(cfg config.KubernetesConfig, c command.Runner) error {
 	src, err := download.CrictlBinary(cfg.KubernetesVersion)
 	if err != nil {
+		if strings.Contains(err.Error(), "response code: 404") {
+			klog.Info("Failed to download crictl with matching version. Using whatever version is already on the image")
+			return nil
+		}
 		return errors.Wrapf(err, "downloading crictl")
 	}
 	dst := "/usr/bin/crictl"

--- a/pkg/minikube/bootstrapper/bsutil/binaries.go
+++ b/pkg/minikube/bootstrapper/bsutil/binaries.go
@@ -38,8 +38,8 @@ import (
 )
 
 // TransferCrictl transfers the crictl binary to the machine to replace /usr/bin/crictl
-func TransferCrictl(cfg config.KubernetesConfig, c command.Runner) error {
-	src, err := download.CrictlBinary(cfg.KubernetesVersion)
+func TransferCrictl(cfg config.KubernetesConfig, c command.Runner, crictlVersion string) error {
+	src, err := download.CrictlBinary(cfg.KubernetesVersion, crictlVersion)
 	if err != nil {
 		if strings.Contains(err.Error(), "response code: 404") {
 			klog.Info("Failed to download crictl with matching version. Using whatever version is already on the image")

--- a/pkg/minikube/bootstrapper/bsutil/binaries.go
+++ b/pkg/minikube/bootstrapper/bsutil/binaries.go
@@ -39,7 +39,7 @@ import (
 
 // TransferCrictl transfers the crictl binary to the machine to replace /usr/bin/crictl
 func TransferCrictl(cfg config.KubernetesConfig, c command.Runner) error {
-	src, err := download.DownloadCrictlBinary(cfg.KubernetesVersion)
+	src, err := download.CrictlBinary(cfg.KubernetesVersion)
 	if err != nil {
 		return errors.Wrapf(err, "downloading crictl")
 	}

--- a/pkg/minikube/bootstrapper/bsutil/binaries.go
+++ b/pkg/minikube/bootstrapper/bsutil/binaries.go
@@ -42,7 +42,7 @@ func TransferCrictl(cfg config.KubernetesConfig, c command.Runner, crictlVersion
 	src, err := download.CrictlBinary(cfg.KubernetesVersion, crictlVersion)
 	if err != nil {
 		if strings.Contains(err.Error(), "response code: 404") {
-			klog.Info("Failed to download crictl with matching version. Using whatever version is already on the image")
+			klog.Warning("Failed to download crictl with matching version. Using whatever version is already on the image")
 			return nil
 		}
 		return errors.Wrapf(err, "downloading crictl")

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -952,7 +952,7 @@ func (k *Bootstrapper) UpdateNode(cfg config.ClusterConfig, n config.Node, r cru
 		return errors.Wrap(err, "downloading binaries")
 	}
 	// download crictl if needed.
-	// since kubernetes v1.29 we need to have matching crictl and kubernetes version.
+	// since Kubernetes v1.29 we need to have matching crictl and Kubernetes version.
 	version, err := util.ParseKubernetesVersion(cfg.KubernetesConfig.KubernetesVersion)
 	if err != nil {
 		return errors.Wrap(err, "parsing Kubernetes version")

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -959,7 +959,7 @@ func (k *Bootstrapper) UpdateNode(cfg config.ClusterConfig, n config.Node, r cru
 	}
 	crictlVersion, err := cruntime.CrictlVersion(k.c)
 	// when preload is enabled
-	// if we failed to get the crictl version or the version does not match the k8s version
+	// if we failed to get the crictl version or the version does not match the K8s version
 	// then we download it
 	if !viper.GetBool("preload") && (err != nil || crictlVersion.Major != version.Major || crictlVersion.Minor != version.Minor) {
 		if err := bsutil.TransferCrictl(cfg.KubernetesConfig, k.c, ""); err != nil {

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -962,7 +962,7 @@ func (k *Bootstrapper) UpdateNode(cfg config.ClusterConfig, n config.Node, r cru
 	// if we failed to get the crictl version or the version does not match the k8s version
 	// then we download it
 	if !viper.GetBool("preload") && (err != nil || crictlVersion.Major != version.Major || crictlVersion.Minor != version.Minor) {
-		if err := bsutil.TransferCrictl(cfg.KubernetesConfig, k.c); err != nil {
+		if err := bsutil.TransferCrictl(cfg.KubernetesConfig, k.c, ""); err != nil {
 			return errors.Wrap(err, "transferring crictl")
 		}
 	}

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -37,6 +37,7 @@ import (
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/state"
 	"github.com/pkg/errors"
+	"github.com/spf13/viper"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -945,6 +946,27 @@ func (k *Bootstrapper) UpdateNode(cfg config.ClusterConfig, n config.Node, r cru
 
 	klog.Infof("kubelet %s config:\n%+v", kubeletCfg, cfg.KubernetesConfig)
 
+	sm := sysinit.New(k.c)
+
+	if err := bsutil.TransferBinaries(cfg.KubernetesConfig, k.c, sm, cfg.BinaryMirror); err != nil {
+		return errors.Wrap(err, "downloading binaries")
+	}
+	// download crictl if needed.
+	// since kubernetes v1.29 we need to have matching crictl and kubernetes version.
+	version, err := util.ParseKubernetesVersion(cfg.KubernetesConfig.KubernetesVersion)
+	if err != nil {
+		return errors.Wrap(err, "parsing Kubernetes version")
+	}
+	crictlVersion, err := cruntime.CrictlVersion(k.c)
+	// when preload is enabled
+	// if we failed to get the crictl version or the version does not match the k8s version
+	// then we download it
+	if !viper.GetBool("preload") && (err != nil || crictlVersion.Major != version.Major || crictlVersion.Minor != version.Minor) {
+		if err := bsutil.TransferCrictl(cfg.KubernetesConfig, k.c); err != nil {
+			return errors.Wrap(err, "transferring crictl")
+		}
+	}
+
 	files := []assets.CopyableFile{
 		assets.NewMemoryAssetTarget(kubeletCfg, bsutil.KubeletSystemdConfFile, "0644"),
 		assets.NewMemoryAssetTarget(kubeletService, bsutil.KubeletServiceFile, "0644"),
@@ -980,8 +1002,7 @@ func (k *Bootstrapper) UpdateNode(cfg config.ClusterConfig, n config.Node, r cru
 		}
 	}
 
-	sm := sysinit.New(k.c)
-
+	sm = sysinit.New(k.c)
 	if err := bsutil.TransferBinaries(cfg.KubernetesConfig, k.c, sm, cfg.BinaryMirror); err != nil {
 		return errors.Wrap(err, "downloading binaries")
 	}

--- a/pkg/minikube/cruntime/cri.go
+++ b/pkg/minikube/cruntime/cri.go
@@ -58,11 +58,11 @@ func CrictlVersion(c CommandRunner) (*semver.Version, error) {
 	}
 	stdout := rr.Stdout.String()
 	reg := regexp.MustCompile(`crictl\s*version\s*(v\d*\.\d*.\d*)`)
-	subMatches := reg.FindSubmatch([]byte(stdout))
+	subMatches := reg.FindStringSubmatch(stdout)
 	if len(subMatches) < 2 {
 		return nil, fmt.Errorf("failed to find the crictl version")
 	}
-	version, err := util.ParseKubernetesVersion(string(subMatches[1]))
+	version, err := util.ParseKubernetesVersion(subMatches[1])
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/minikube/cruntime/cri.go
+++ b/pkg/minikube/cruntime/cri.go
@@ -24,12 +24,14 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"regexp"
 	"strings"
 
 	"github.com/blang/semver/v4"
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/minikube/command"
+	"k8s.io/minikube/pkg/util"
 )
 
 // container maps to 'runc list -f json'
@@ -47,6 +49,24 @@ type crictlImages struct {
 		UID         interface{} `json:"uid"`
 		Username    string      `json:"username"`
 	} `json:"images"`
+}
+
+func CrictlVersion(c CommandRunner) (*semver.Version, error) {
+	rr, err := c.RunCmd(exec.Command("sudo", "crictl", "--version"))
+	if err != nil {
+		return nil, err
+	}
+	stdout := rr.Stdout.String()
+	reg := regexp.MustCompile(`crictl\s*version\s*(v\d*\.\d*.\d*)`)
+	subMatches := reg.FindSubmatch([]byte(stdout))
+	if len(subMatches) < 2 {
+		return nil, fmt.Errorf("failed to find the crictl version")
+	}
+	version, err := util.ParseKubernetesVersion(string(subMatches[1]))
+	if err != nil {
+		return nil, err
+	}
+	return &version, nil
 }
 
 // crictlList returns the output of 'crictl ps' in an efficient manner

--- a/pkg/minikube/cruntime/cri.go
+++ b/pkg/minikube/cruntime/cri.go
@@ -57,7 +57,7 @@ func CrictlVersion(c CommandRunner) (*semver.Version, error) {
 		return nil, err
 	}
 	stdout := rr.Stdout.String()
-	reg := regexp.MustCompile(`crictl\s*version\s*(v\d*\.\d*.\d*)`)
+	reg := regexp.MustCompile(`crictl\s*version\s*(v\d+\.\d+.\d+)`)
 	subMatches := reg.FindStringSubmatch(stdout)
 	if len(subMatches) < 2 {
 		return nil, fmt.Errorf("failed to find the crictl version")

--- a/pkg/minikube/download/binary.go
+++ b/pkg/minikube/download/binary.go
@@ -22,11 +22,11 @@ import (
 	"path"
 	"runtime"
 
-	"k8s.io/minikube/pkg/util"
 	"github.com/blang/semver/v4"
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/minikube/localpath"
+	"k8s.io/minikube/pkg/util"
 )
 
 // DefaultKubeBinariesURL returns a URL to kube binaries
@@ -97,13 +97,14 @@ func CrictlBinary(k8sversion string, crictlVersion string) (string, error) {
 		klog.Infof("crictl found in cache: %s", targetPath)
 		return targetPath, nil
 	}
-	v, err := util.ParseKubernetesVersion(k8sversion)
-	if err != nil {
-		return "", err
-	}
+
 	// if we don't know the exact patch number of crictl then use 0.
 	// This definitely exists
 	if crictlVersion == "" {
+		v, err := util.ParseKubernetesVersion(k8sversion)
+		if err != nil {
+			return "", err
+		}
 		crictlVersion = fmt.Sprintf("v%d.%d.0", v.Major, v.Minor)
 	}
 	url := fmt.Sprintf(

--- a/pkg/minikube/download/binary.go
+++ b/pkg/minikube/download/binary.go
@@ -88,8 +88,8 @@ func Binary(binary, version, osName, archName, binaryURL string) (string, error)
 	return targetFilepath, nil
 }
 
-// DownloadCrictlBinary download the crictl tar archive to the cache folder and untar it
-func DownloadCrictlBinary(k8sversion string) (string, error) {
+// CrictlBinary download the crictl tar archive to the cache folder and untar it
+func CrictlBinary(k8sversion string) (string, error) {
 	// first we check whether crictl exists
 	targetDir := localpath.MakeMiniPath("cache", "linux", runtime.GOARCH, k8sversion)
 	targetPath := path.Join(targetDir, "crictl")

--- a/pkg/minikube/download/binary.go
+++ b/pkg/minikube/download/binary.go
@@ -89,7 +89,7 @@ func Binary(binary, version, osName, archName, binaryURL string) (string, error)
 }
 
 // CrictlBinary download the crictl tar archive to the cache folder and untar it
-func CrictlBinary(k8sversion string) (string, error) {
+func CrictlBinary(k8sversion string, crictlVersion string) (string, error) {
 	// first we check whether crictl exists
 	targetDir := localpath.MakeMiniPath("cache", "linux", runtime.GOARCH, k8sversion)
 	targetPath := path.Join(targetDir, "crictl")
@@ -101,7 +101,11 @@ func CrictlBinary(k8sversion string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	crictlVersion := fmt.Sprintf("v%d.%d.0", v.Major, v.Minor)
+	// if we don't know the exact patch number of crictl then use 0.
+	// This definitely exists
+	if crictlVersion == "" {
+		crictlVersion = fmt.Sprintf("v%d.%d.%s", v.Major, v.Minor, crictlVersion)
+	}
 	url := fmt.Sprintf(
 		"https://github.com/kubernetes-sigs/cri-tools/releases/download/%s/crictl-%s-linux-%s.tar.gz",
 		crictlVersion, crictlVersion, runtime.GOARCH)

--- a/pkg/minikube/download/binary.go
+++ b/pkg/minikube/download/binary.go
@@ -104,7 +104,7 @@ func CrictlBinary(k8sversion string, crictlVersion string) (string, error) {
 	// if we don't know the exact patch number of crictl then use 0.
 	// This definitely exists
 	if crictlVersion == "" {
-		crictlVersion = fmt.Sprintf("v%d.%d.%s", v.Major, v.Minor, crictlVersion)
+		crictlVersion = fmt.Sprintf("v%d.%d.0", v.Major, v.Minor)
 	}
 	url := fmt.Sprintf(
 		"https://github.com/kubernetes-sigs/cri-tools/releases/download/%s/crictl-%s-linux-%s.tar.gz",


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

FIX #18359 

Before:

minikube use the crictl installed in the kic image

After:
1. `sudo crictl --version` is executed on the host to check whether the version of crictl corresponds to k8s version
2. when starting the minikubeif  preload is false, and the crictl version is not correct, we download the crictl and replace the original crictl in the host. **When k8s verison is v1.a.b, then crictl v1.a.0 will be downloaded**.  When generating the preload, we shall detect the latest matching version of crictl and download it.
3. if crictl has been downloaded before and found in the cache in `~/.minikube` then the cached binary will be used
4. crictl is also downloaded and transfered in the preload, in the same way as kubectl and kubelet
 e.g. under such circumstance, after starting minikube cluster, use minikube ssh and we can see that
```

docker@minikube:$ sudo crictl --version
crictl version v1.28.0
docker@minikube:$ sudo crictl  ps
CONTAINER           IMAGE                                                                                                CREATED             STATE               NAME                      ATTEMPT             POD ID              POD
8eae2728f85d3       97e04611ad43405a2e5863ae17c6f1bc9181bdefdaa78627c432ef754a4eb108                                     46 minutes ago      Running             coredns                   0                   0a580df21c36b       coredns-5dd5756b68-bc2dw
dbe2b7b442f48       66749159455b3f08c8318fe0233122f54d0f5889f9c5fdfb73c3fd9d99895b51                                     46 minutes ago      Running             storage-provisioner       0                   5e63873caa6c9       storage-provisioner
53383548192c3       docker.io/kindest/kindnetd@sha256:61f9956af8019caf6dcc4d39b31857b868aaab80521432ddcc216b805c4f7988   46 minutes ago      Running             kindnet-cni               0                   7e29f779adce9       kindnet-fg6j2
905443e23b753       3ca3ca488cf13fde14cfc4b3ffde0c53a8c161b030f4a444a797fba6aef38c39                                     47 minutes ago      Running             kube-proxy                0                   b521393332a9e       kube-proxy-c5wxp
1825671293c0f       9961cbceaf234d59b7dcf8a197a024f3e3ce4b7fe2b67c2378efd3d209ca994b                                     47 minutes ago      Running             kube-controller-manager   0                   aa296e1d2ffe9       kube-controller-manager-minikube
8489b99abcd33       04b4c447bb9d4840af3bf7e836397379d65df87c86e55dcd27f31a8d11df2419                                     47 minutes ago      Running             kube-apiserver            0                   d90bf0f26db9f       kube-apiserver-minikube
50b93cafff067       05c284c929889d88306fdb3dd14ee2d0132543740f9e247685243214fc3d2c54                                     47 minutes ago      Running             kube-scheduler            0                   852b3009621c4       kube-scheduler-minikube
dbc57b61ae284       9cdd6470f48c8b127530b7ce6ea4b3524137984481e48bcde619735890840ace                                     47 minutes ago      Running             etcd                      0                   75c186d1ea62b       etcd-minikube

```




@spowelljr  @medyagh  
