### PR TITLE
CI: Fix CNI Plugins version variable name

### DIFF
--- a/hack/update/get_version/get_version.go
+++ b/hack/update/get_version/get_version.go
@@ -36,7 +36,7 @@ var dependencies = map[string]dependency{
 	"buildkit":                {"deploy/iso/minikube-iso/arch/x86_64/package/buildkit-bin/buildkit-bin.mk", `BUILDKIT_BIN_VERSION = (.*)`},
 	"calico":                  {"pkg/minikube/bootstrapper/images/images.go", `calicoVersion = "(.*)"`},
 	"cloud-spanner":           {addonsFile, `cloud-spanner-emulator/emulator:(.*)@`},
-	"cni-plugins":             {"deploy/iso/minikube-iso/arch/x86_64/package/cni-plugins-latest/cni-plugins-latest.mk", `CNI_PLUGINS_VERSION = (.*)`},
+	"cni-plugins":             {"deploy/iso/minikube-iso/arch/x86_64/package/cni-plugins-latest/cni-plugins-latest.mk", `CNI_PLUGINS_LATEST_VERSION = (.*)`},
 	"containerd":              {"deploy/iso/minikube-iso/arch/x86_64/package/containerd-bin/containerd-bin.mk", `CONTAINERD_BIN_VERSION = (.*)`},
 	"cri-dockerd":             {dockerfile, `CRI_DOCKERD_VERSION="(.*)"`},
 	"cri-o":                   {"deploy/iso/minikube-iso/package/crio-bin/crio-bin.mk", `CRIO_BIN_VERSION = (.*)`},


### PR DESCRIPTION
`CNI_PLUGINS_VERSION` was changed to `CNI_PLUGINS_LATEST_VERSION` in https://github.com/kubernetes/minikube/pull/18020