### PR TITLE
add default sysctls to allow privileged ports with no capabilities

### DIFF
--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -90,7 +90,7 @@ func generateCRIOConfig(cr CommandRunner, imageRepository string, kv semver.Vers
 	}
 
 	// add 'net.ipv4.ip_unprivileged_port_start=0' sysctl so that containers that run with non-root user can bind to otherwise privilege ports (like coredns v1.11.0+)
-	// note: 'net.ipv4.ip_unprivileged_port_start' sysctl was marked as safe since kubernetes v1.22 (Aug 4, 2021) (ref: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md#feature-9)
+	// note: 'net.ipv4.ip_unprivileged_port_start' sysctl was marked as safe since Kubernetes v1.22 (Aug 4, 2021) (ref: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md#feature-9)
 	// note: cri-o supports 'default_sysctls' option since v1.12.0 (Oct 19, 2018) (ref: https://github.com/cri-o/cri-o/releases/tag/v1.12.0; https://github.com/cri-o/cri-o/pull/1721)
 	if kv.GTE(semver.Version{Major: 1, Minor: 22}) {
 		// remove any existing 'net.ipv4.ip_unprivileged_port_start' settings

--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -89,6 +89,24 @@ func generateCRIOConfig(cr CommandRunner, imageRepository string, kv semver.Vers
 		klog.Warningf("unable to remove /etc/cni/net.mk directory: %v", err)
 	}
 
+	// add 'net.ipv4.ip_unprivileged_port_start=0' sysctl so that containers that run with non-root user can bind to otherwise privilege ports (like coredns v1.11.0+)
+	// note: 'net.ipv4.ip_unprivileged_port_start' sysctl was marked as safe since kubernetes v1.22 (Aug 4, 2021) (ref: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md#feature-9)
+	// note: cri-o supports 'efault_sysctls' option since v1.12.0 (Oct 19, 2018) (ref: https://github.com/cri-o/cri-o/releases/tag/v1.12.0; https://github.com/cri-o/cri-o/pull/1721)
+	if kv.GTE(semver.Version{Major: 1, Minor: 22}) {
+		// remove any existing 'net.ipv4.ip_unprivileged_port_start' settings
+		if _, err := cr.RunCmd(exec.Command("sh", "-c", fmt.Sprintf(`sudo sed -i '/^ *"net.ipv4.ip_unprivileged_port_start=.*"/d' %s`, crioConfigFile))); err != nil {
+			return errors.Wrap(err, "removing net.ipv4.ip_unprivileged_port_start")
+		}
+		// insert 'default_sysctls' list, if not already present
+		if _, err := cr.RunCmd(exec.Command("sh", "-c", fmt.Sprintf(`sudo grep -q "^ *default_sysctls" %s || sudo sed -i '/conmon_cgroup = .*/a default_sysctls = \[\n\]' %s`, crioConfigFile, crioConfigFile))); err != nil {
+			return errors.Wrap(err, "inserting default_sysctls")
+		}
+		// add 'net.ipv4.ip_unprivileged_port_start' to 'default_sysctls' list
+		if _, err := cr.RunCmd(exec.Command("sh", "-c", fmt.Sprintf(`sudo sed -i -r 's|^default_sysctls *= *\[|&\n  "net.ipv4.ip_unprivileged_port_start=0",|' %s`, crioConfigFile))); err != nil {
+			return errors.Wrap(err, "configuring net.ipv4.ip_unprivileged_port_start")
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -91,7 +91,7 @@ func generateCRIOConfig(cr CommandRunner, imageRepository string, kv semver.Vers
 
 	// add 'net.ipv4.ip_unprivileged_port_start=0' sysctl so that containers that run with non-root user can bind to otherwise privilege ports (like coredns v1.11.0+)
 	// note: 'net.ipv4.ip_unprivileged_port_start' sysctl was marked as safe since kubernetes v1.22 (Aug 4, 2021) (ref: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md#feature-9)
-	// note: cri-o supports 'efault_sysctls' option since v1.12.0 (Oct 19, 2018) (ref: https://github.com/cri-o/cri-o/releases/tag/v1.12.0; https://github.com/cri-o/cri-o/pull/1721)
+	// note: cri-o supports 'default_sysctls' option since v1.12.0 (Oct 19, 2018) (ref: https://github.com/cri-o/cri-o/releases/tag/v1.12.0; https://github.com/cri-o/cri-o/pull/1721)
 	if kv.GTE(semver.Version{Major: 1, Minor: 22}) {
 		// remove any existing 'net.ipv4.ip_unprivileged_port_start' settings
 		if _, err := cr.RunCmd(exec.Command("sh", "-c", fmt.Sprintf(`sudo sed -i '/^ *"net.ipv4.ip_unprivileged_port_start=.*"/d' %s`, crioConfigFile))); err != nil {


### PR DESCRIPTION
this pr adds `net.ipv4.ip_unprivileged_port_start` sysctls as default to `containerd` and `cri-o` container runtimes to allow privileged ports to be used by containers run by a non-root user for `kubernetes v1.22+`

### background

during testing the bump of kubernetes default version to v1.29.2, we discovered that `coredns` would not come up if containerd or cri-o container runtimes are used with the docker driver (example: [conainerd](https://storage.googleapis.com/minikube-builds/logs/17786/33572/Docker_Linux_containerd.html) and [cri-o](https://storage.googleapis.com/minikube-builds/logs/17786/33572/Docker_Linux_crio.html))

the coredns errored with: `Listen: listen tcp :53: bind: permission denied`

kubernetes v1.29.0+ [uses](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.29.md#other-cleanup-or-flake-6) coredns v1.11.1 and from [v1.11.0](https://github.com/coredns/coredns/releases/tag/v1.11.0), coredns [runs as non-root user ](https://github.com/coredns/coredns/pull/5969)

some additional details about the issue also observed elsewhere can be found eg, [here](https://github.com/coredns/coredns/issues/6249) and [here](https://github.com/coredns/coredns/pull/6320)

since starting from kubernetes v1.22, the required net.ipv4.ip_unprivileged_port_start sysctl was [marked as safe](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md#feature-9), but it's up to the container runtime to implement it - [docker](https://github.com/moby/moby/pull/41030) already has it enabled by default, whereas other CRIs have that as option but it's not enabled by default ([containerd](https://github.com/containerd/containerd/pull/6170) and [cri-o](https://github.com/cri-o/cri-o/pull/1721)) and this pr tries to address those two and enable corresponding options