### PR TITLE
Addon gvisor: Add building arm64 image

### DIFF
--- a/deploy/gvisor/Dockerfile
+++ b/deploy/gvisor/Dockerfile
@@ -12,8 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+FROM golang:1.22.1 AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY ./ ./
+RUN GOOS=linux CGO_ENABLED=0 go build -o gvisor-addon cmd/gvisor/gvisor.go
+
 # Need an image with chroot
 FROM alpine:3
 RUN apk -U add ca-certificates
-COPY out/gvisor-addon /gvisor-addon
+COPY --from=builder /app/gvisor-addon /gvisor-addon
 CMD ["/gvisor-addon"]

--- a/hack/update/golang_version/update_golang_version.go
+++ b/hack/update/golang_version/update_golang_version.go
@@ -69,6 +69,11 @@ var (
 				`golang:.* AS`: `golang:{{.StableVersion}} AS`,
 			},
 		},
+		"deploy/gvisor/Dockerfile": {
+			Replace: map[string]string{
+				`golang:.* AS`: `golang:{{.StableVersion}} AS`,
+			},
+		},
 	}
 )
 

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -521,7 +521,7 @@ var Addons = map[string]*Addon{
 			"gvisor-runtimeclass.yaml",
 			"0640"),
 	}, false, "gvisor", "minikube", "", "https://github.com/kubernetes/minikube/blob/master/deploy/addons/gvisor/README.md", map[string]string{
-		"GvisorAddon": "k8s-minikube/gvisor-addon:4@sha256:4bdc0bec3f36a32e534d9da98552810c832dd58fd0a361e5c0b836606b164bc2",
+		"GvisorAddon": "k8s-minikube/gvisor-addon:v0.0.1@sha256:d29adbddc7a44dab4c675c0eaea398907fe1f33f5f723274b0d40195b3076cae",
 	}, map[string]string{
 		"GvisorAddon": "gcr.io",
 	}),


### PR DESCRIPTION
`make push-gvisor-addon-image` now builds for amd64 & arm64

Also changed the image tag to match the same format as the rest of the images, `4` -> `v0.0.1`

New build also fixes many CVES:

**Before:**
```
16 vulnerabilities found in 3 packages
  UNSPECIFIED  1   
  LOW          0   
  MEDIUM       12  
  HIGH         2   
  CRITICAL     1   
```

**After:**
```
  No vulnerable packages detected
```
