### PR TITLE
Disable systemd-binfmt.service in kicbase.

### DIFF
--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -97,6 +97,7 @@ RUN echo "Ensuring scripts are executable ..." \
       nfs-common \
       iputils-ping netcat-openbsd vim-tiny \
     && find /lib/systemd/system/sysinit.target.wants/ -name "systemd-tmpfiles-setup.service" -delete \
+    && find /lib/systemd/system/sysinit.target.wants/ -name "systemd-binfmt.service" -delete \
     && rm -f /lib/systemd/system/multi-user.target.wants/* \
     && rm -f /etc/systemd/system/*.wants/* \
     && rm -f /lib/systemd/system/local-fs.target.wants/* \


### PR DESCRIPTION
Due to minikube running as a priviledged container, binfmt_misc not being namespaced in the kernel and due to kicbase running the systemd-binfmt.service (binfmt.d), the minikube container at startup will reset the registered binfmt interpreters on the host machine.

fixes #18455