### PR TITLE
Site: Disable Beta buttons in "Get started!" documentation if the release is older than the latest Stable release.

### DIFF
--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -38,21 +38,11 @@ All you need is Docker (or similarly compatible) container or a Virtual Machine 
       if (releases && releases.length > 0 && releases[0] && releases[0].tag_name) {
         const isBetaMostRecent = releases[0].tag_name.includes("-beta");
 
-        if (!isBetaMostRecent) {
+        if (isBetaMostRecent) {
           for (architecture of architectures) {
             const betaElement = document.querySelector(`button[data-quiz-id="/${architecture}/Beta"]`);
-            const stableElement = document.querySelector(`button[data-quiz-id="/${architecture}/Stable"]`);
             if (betaElement) {
-              betaElement.disabled = true;
-
-              if (betaElement.classList.contains("active")) {
-                const stableElement = document.querySelector(`button[data-quiz-id="/${architecture}/Stable"]`);
-                if (stableElement) {
-                  stableElement.click();
-                  stableElement.classList.add("active");
-                }
-                betaElement.classList.remove("active");
-              }
+              betaElement.classList.remove("hide");
             }
           }
         }

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -38,7 +38,7 @@ All you need is Docker (or similarly compatible) container or a Virtual Machine 
       if (releases && releases.length > 0 && releases[0] && releases[0].tag_name) {
         const isBetaMostRecent = releases[0].tag_name.includes("-beta");
 
-        if (isBetaMostRecent) {
+        if (!isBetaMostRecent) {
           for (architecture of architectures) {
             const betaElement = document.querySelector(`button[data-quiz-id="/${architecture}/Beta"]`);
             const stableElement = document.querySelector(`button[data-quiz-id="/${architecture}/Stable"]`);

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -74,7 +74,7 @@ Click on the buttons that describe your target platform. For other architectures
 {{% /quiz_row %}}
 
 {{% quiz_row base="/Linux/x86-64" name="Release type" %}}
-{{% quiz_button option="Stable" %}} {{% quiz_button option="Beta" %}}
+{{% quiz_button option="Stable" %}} {{% quiz_button option="Beta" hide="true" %}}
 {{% /quiz_row %}}
 
 {{% quiz_row base="/Linux/x86-64/Stable" name="Installer type" %}}

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -32,9 +32,11 @@ All you need is Docker (or similarly compatible) container or a Virtual Machine 
     "Windows/x86-64"
   ];
 
+  console.time("timerReleaseFetch");
   fetch('https://api.github.com/repos/kubernetes/minikube/releases')
     .then((response) => response.json())
     .then((releases) => {
+      console.timeEnd("timerReleaseFetch");
       if (releases && releases.length > 0 && releases[0] && releases[0].tag_name) {
         const isBetaMostRecent = releases[0].tag_name.includes("-beta");
 

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -20,6 +20,47 @@ All you need is Docker (or similarly compatible) container or a Virtual Machine 
 
 <h2 class="step"><span class="fa-stack fa-1x"><i class="fa fa-circle fa-stack-2x"></i><strong class="fa-stack-1x text-primary">1</strong></span>Installation</h2>
 
+<script language="javascript">
+  const architectures = [
+    "Linux/x86-64",
+    "Linux/ARM64",
+    "Linux/ppc64",
+    "Linux/S390x",
+    "Linux/ARMv7",
+    "macOS/x86-64",
+    "macOS/ARM64",
+    "Windows/x86-64"
+  ];
+
+  fetch('https://api.github.com/repos/kubernetes/minikube/releases')
+    .then((response) => response.json())
+    .then((releases) => {
+      if (releases && releases.length > 0 && releases[0] && releases[0].tag_name) {
+        const isBetaMostRecent = releases[0].tag_name.includes("-beta");
+
+        if (isBetaMostRecent) {
+          for (architecture of architectures) {
+            const betaElement = document.querySelector(`button[data-quiz-id="/${architecture}/Beta"]`);
+            const stableElement = document.querySelector(`button[data-quiz-id="/${architecture}/Stable"]`);
+            if (betaElement) {
+              betaElement.disabled = true;
+
+              if (betaElement.classList.contains("active")) {
+                const stableElement = document.querySelector(`button[data-quiz-id="/${architecture}/Stable"]`);
+                if (stableElement) {
+                  stableElement.click();
+                  stableElement.classList.add("active");
+                }
+                betaElement.classList.remove("active");
+              }
+            }
+          }
+        }
+      }
+    })
+    .catch(console.error);
+</script>
+
 {{% card %}}
 
 Click on the buttons that describe your target platform. For other architectures, see [the release page](https://github.com/kubernetes/minikube/releases/latest) for a complete list of minikube binaries.

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -78,7 +78,7 @@ Click on the buttons that describe your target platform. For other architectures
 {{% /quiz_row %}}
 
 {{% quiz_row base="/Linux/ARM64" name="Release type" %}}
-{{% quiz_button option="Stable" %}} {{% quiz_button option="Beta" %}}
+{{% quiz_button option="Stable" %}} {{% quiz_button option="Beta" hide="true" %}}
 {{% /quiz_row %}}
 
 {{% quiz_row base="/Linux/ARM64/Stable" name="Installer type" %}}
@@ -90,7 +90,7 @@ Click on the buttons that describe your target platform. For other architectures
 {{% /quiz_row %}}
 
 {{% quiz_row base="/Linux/ppc64" name="Release type" %}}
-{{% quiz_button option="Stable" %}} {{% quiz_button option="Beta" %}}
+{{% quiz_button option="Stable" %}} {{% quiz_button option="Beta" hide="true" %}}
 {{% /quiz_row %}}
 
 {{% quiz_row base="/Linux/ppc64/Stable" name="Installer type" %}}
@@ -102,7 +102,7 @@ Click on the buttons that describe your target platform. For other architectures
 {{% /quiz_row %}}
 
 {{% quiz_row base="/Linux/S390x" name="Release type" %}}
-{{% quiz_button option="Stable" %}} {{% quiz_button option="Beta" %}}
+{{% quiz_button option="Stable" %}} {{% quiz_button option="Beta" hide="true" %}}
 {{% /quiz_row %}}
 
 {{% quiz_row base="/Linux/S390x/Stable" name="Installer type" %}}
@@ -114,7 +114,7 @@ Click on the buttons that describe your target platform. For other architectures
 {{% /quiz_row %}}
 
 {{% quiz_row base="/Linux/ARMv7" name="Release type" %}}
-{{% quiz_button option="Stable" %}} {{% quiz_button option="Beta" %}}
+{{% quiz_button option="Stable" %}} {{% quiz_button option="Beta" hide="true" %}}
 {{% /quiz_row %}}
 
 {{% quiz_row base="/Linux/ARMv7/Stable" name="Installer type" %}}
@@ -130,7 +130,7 @@ Click on the buttons that describe your target platform. For other architectures
 {{% /quiz_row %}}
 
 {{% quiz_row base="/macOS/x86-64" name="Release type" %}}
-{{% quiz_button option="Stable" %}} {{% quiz_button option="Beta" %}}
+{{% quiz_button option="Stable" %}} {{% quiz_button option="Beta" hide="true" %}}
 {{% /quiz_row %}}
 
 {{% quiz_row base="/macOS/x86-64/Stable" name="Installer type" %}}
@@ -142,7 +142,7 @@ Click on the buttons that describe your target platform. For other architectures
 {{% /quiz_row %}}
 
 {{% quiz_row base="/macOS/ARM64" name="Release type" %}}
-{{% quiz_button option="Stable" %}} {{% quiz_button option="Beta" %}}
+{{% quiz_button option="Stable" %}} {{% quiz_button option="Beta" hide="true" %}}
 {{% /quiz_row %}}
 
 {{% quiz_row base="/macOS/ARM64/Stable" name="Installer type" %}}
@@ -158,7 +158,7 @@ Click on the buttons that describe your target platform. For other architectures
 {{% /quiz_row %}}
 
 {{% quiz_row base="/Windows/x86-64" name="Release type" %}}
-{{% quiz_button option="Stable" %}} {{% quiz_button option="Beta" %}}
+{{% quiz_button option="Stable" %}} {{% quiz_button option="Beta" hide="true" %}}
 {{% /quiz_row %}}
 
 {{% quiz_row base="/Windows/x86-64/Stable" name="Installer type" %}}

--- a/site/layouts/shortcodes/quiz_button.html
+++ b/site/layouts/shortcodes/quiz_button.html
@@ -1,1 +1,1 @@
-<button data-quiz-id="{{ .Parent.Get "base" }}/{{ .Get "option" }}" type="button" class="btn btn-outline-primary option-button">{{ .Get "option" }}</button>
+<button data-quiz-id="{{ .Parent.Get "base" }}/{{ .Get "option" }}" type="button" class="btn btn-outline-primary option-button{{ if eq (.Get "hide") "true" }} hide{{ end }}">{{ .Get "option" }}</button>


### PR DESCRIPTION
Disabling Beta buttons is not instantaneous. I'm not sure that's the most convenient method to do it.

First it looks for latest release, if it's not a Beta one it'll disable the Beta button and activate the Stable one instead.

fixes #18505