### PR TITLE
wip: bump github action macos machines to 13

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -429,6 +429,12 @@ jobs:
         run: |
           brew install docker-machine docker
           sudo docker --version
+      - name: Install vbox
+        shell: bash
+        run: |
+          brew install --cask virtualbox 
+          brew install --cask virtualbox-extension-pack
+          sudo spctl --master-disable
       - name: Info
         shell: bash
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -409,7 +409,7 @@ jobs:
       JOB_NAME: "functional_virtualbox_macos"
       GOPOGH_RESULT: ""
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Install kubectl
         shell: bash
@@ -455,7 +455,7 @@ jobs:
           chmod a+x e2e-*
           chmod a+x minikube-*
           START_TIME=$(date -u +%s)
-          KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-darwin-amd64 -minikube-start-args=--vm-driver=virtualbox  -test.run "TestFunctional" -test.timeout=35m -test.v -timeout-multiplier=1.5 -binary=./minikube-darwin-amd64 2>&1 | tee ./report/testout.txt
+          KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-darwin-amd64 -minikube-start-args=--vm-driver=virtualbox  -test.run "TestFunctional" -test.timeout=55m -test.v -timeout-multiplier=1.8 -binary=./minikube-darwin-amd64 2>&1 | tee ./report/testout.txt
           END_TIME=$(date -u +%s)
           TIME_ELAPSED=$(($END_TIME-$START_TIME))
           min=$((${TIME_ELAPSED}/60))

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -432,9 +432,9 @@ jobs:
       - name: Install vbox
         shell: bash
         run: |
+          sudo spctl --master-disable
           brew install --cask virtualbox 
           brew install --cask virtualbox-extension-pack
-          sudo spctl --master-disable
       - name: Info
         shell: bash
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -547,6 +547,12 @@ jobs:
         run: |
           brew install docker-machine docker
           sudo docker --version
+      - name: Install vbox
+        shell: bash
+        run: |
+          brew install --cask virtualbox 
+          brew install --cask virtualbox-extension-pack
+          sudo spctl --master-disable
       - name: Info
         shell: bash
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -527,7 +527,7 @@ jobs:
       JOB_NAME: "functional_virtualbox_macos"
       GOPOGH_RESULT: ""
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Install kubectl
         shell: bash
@@ -555,8 +555,8 @@ jobs:
           sudo spctl --master-disable
           brew install --cask virtualbox 
           curl -O -L "https://download.virtualbox.org/virtualbox/7.0.14/Oracle_VM_VirtualBox_Extension_Pack-7.0.14.vbox-extpack"
-          # Get SHAs from https://www.virtualbox.org/download/hashes/7.0.14/SHA256SUMS
-          echo "y" | sudo VBoxManage extpack install Oracle_VM_VirtualBox_Extension_Pack-7.0.14.vbox-extpack || true
+          # Get SHAs from installing it manually once and then it will spit out the SHA for batch installation
+          echo "y" | sudo VBoxManage extpack install Oracle_VM_VirtualBox_Extension_Pack-7.0.14.vbox-extpack --accept-license=33d7284dc4a0ece381196fda3cfe2ed0e1e8e7ed7f27b9a9ebc4ee22e24bd23c
       - name: Info
         shell: bash
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -527,7 +527,7 @@ jobs:
       JOB_NAME: "functional_virtualbox_macos"
       GOPOGH_RESULT: ""
       SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Install kubectl
         shell: bash
@@ -574,7 +574,7 @@ jobs:
           chmod a+x minikube-*
           MINIKUBE_HOME=$(pwd)/testhome ./minikube-darwin-amd64 delete --all --purge
           START_TIME=$(date -u +%s)
-          KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-darwin-amd64 -minikube-start-args=--vm-driver=virtualbox  -test.run "TestFunctional" -test.timeout=35m -test.v -timeout-multiplier=1.5 -binary=./minikube-darwin-amd64 2>&1 | tee ./report/testout.txt
+          KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-darwin-amd64 -minikube-start-args=--vm-driver=virtualbox  -test.run "TestFunctional" -test.timeout=55m -test.v -timeout-multiplier=1.8 -binary=./minikube-darwin-amd64 2>&1 | tee ./report/testout.txt
           END_TIME=$(date -u +%s)
           TIME_ELAPSED=$(($END_TIME-$START_TIME))
           min=$((${TIME_ELAPSED}/60))

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -555,9 +555,8 @@ jobs:
           sudo spctl --master-disable
           brew install --cask virtualbox 
           curl -O -L "https://download.virtualbox.org/virtualbox/7.0.14/Oracle_VM_VirtualBox_Extension_Pack-7.0.14.vbox-extpack"
-          sha256sum Oracle_VM_VirtualBox_Extension_Pack-7.0.14.vbox-extpack || true
           # Get SHAs from https://www.virtualbox.org/download/hashes/7.0.14/SHA256SUMS
-          sudo VBoxManage extpack install Oracle_VM_VirtualBox_Extension_Pack-7.0.14.vbox-extpack --accept-license=42cb36fbf439a9ed28c95d2bbc718a0eac902225eb579c884c549af2e94be633
+          echo "y" | sudo VBoxManage extpack install Oracle_VM_VirtualBox_Extension_Pack-7.0.14.vbox-extpack || true
       - name: Info
         shell: bash
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -550,9 +550,12 @@ jobs:
       - name: Install vbox
         shell: bash
         run: |
+          brew update
+          brew search virtualbox
           sudo spctl --master-disable
-          brew install --cask virtualbox 
-          brew install --cask virtualbox-extension-pack          
+          brew install --cask virtualbox || true
+          curl -O -L "https://download.virtualbox.org/virtualbox/7.0.14/Oracle_VM_VirtualBox_Extension_Pack-7.0.14.vbox-extpack"
+          sudo VBoxManage extpack install Oracle_VM_VirtualBox_Extension_Pack-7.0.14.vbox-extpack
       - name: Info
         shell: bash
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -550,9 +550,9 @@ jobs:
       - name: Install vbox
         shell: bash
         run: |
-          brew install --cask virtualbox 
-          brew install --cask virtualbox-extension-pack
           sudo spctl --master-disable
+          brew install --cask virtualbox 
+          brew install --cask virtualbox-extension-pack          
       - name: Info
         shell: bash
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -553,9 +553,11 @@ jobs:
           brew update
           brew search virtualbox
           sudo spctl --master-disable
-          brew install --cask virtualbox || true
+          brew install --cask virtualbox 
           curl -O -L "https://download.virtualbox.org/virtualbox/7.0.14/Oracle_VM_VirtualBox_Extension_Pack-7.0.14.vbox-extpack"
-          sudo VBoxManage extpack install Oracle_VM_VirtualBox_Extension_Pack-7.0.14.vbox-extpack
+          sha256sum Oracle_VM_VirtualBox_Extension_Pack-7.0.14.vbox-extpack || true
+          # Get SHAs from https://www.virtualbox.org/download/hashes/7.0.14/SHA256SUMS
+          sudo VBoxManage extpack install Oracle_VM_VirtualBox_Extension_Pack-7.0.14.vbox-extpack --accept-license=42cb36fbf439a9ed28c95d2bbc718a0eac902225eb579c884c549af2e94be633
       - name: Info
         shell: bash
         run: |

--- a/.github/workflows/time-to-k8s-public-chart.yml
+++ b/.github/workflows/time-to-k8s-public-chart.yml
@@ -32,7 +32,7 @@ jobs:
           ./hack/benchmark/time-to-k8s/public-chart/public-chart.sh docker containerd
   time-to-k8s-public-chart-virtualbox:
     if: github.repository == 'kubernetes/minikube'
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
recently the github action macos virtualbox been failing on github actions 
- bumping the macos to 13
- increasing time out to 55m
- increasing time out multiplier to 1.8

- Macos13 image does Not have vbox pre-installed this will install vbox thats bumps the vbox from 6.1.38r153438 to 7