### PR TITLE
test: allow running functional tests for different k8s versions

### DIFF
--- a/pkg/minikube/tunnel/registry.go
+++ b/pkg/minikube/tunnel/registry.go
@@ -87,9 +87,10 @@ func (r *persistentRegistry) Register(tunnel *ID) (rerr error) {
 
 	alreadyExists := false
 	for i, t := range tunnels {
-		// it is allowed for multiple minikube clusters to have multiple tunnels simultaneously
-		// it is possible that an old tunnel from an old profile has duplicated route information
-		// so we need to check both machine name and route information
+		// It is allowed for multiple minikube clusters to have multiple
+		// tunnels simultaneously. It is possible that an old tunnel
+		// from an old profile has duplicated route information so we
+		// need to check both machine name and route information.
 		if tunnel.MachineName == t.MachineName && t.Route.Equal(tunnel.Route) {
 			isRunning, err := checkIfRunning(t.Pid)
 			if err != nil {

--- a/pkg/minikube/tunnel/registry.go
+++ b/pkg/minikube/tunnel/registry.go
@@ -87,7 +87,10 @@ func (r *persistentRegistry) Register(tunnel *ID) (rerr error) {
 
 	alreadyExists := false
 	for i, t := range tunnels {
-		if t.Route.Equal(tunnel.Route) {
+		// it is allowed for multiple minikube clusters to have multiple tunnels simultaneously
+		// it is possible that an old tunnel from an old profile has duplicated route information
+		// so we need to check both machine name and route information
+		if tunnel.MachineName == t.MachineName && t.Route.Equal(tunnel.Route) {
 			isRunning, err := checkIfRunning(t.Pid)
 			if err != nil {
 				return fmt.Errorf("error checking whether conflicting tunnel (%v) is running: %s", t, err)

--- a/site/content/en/docs/contrib/tests.en.md
+++ b/site/content/en/docs/contrib/tests.en.md
@@ -111,6 +111,9 @@ asserts that there are no unexpected errors displayed in minikube command output
 ## TestFunctional
 are functionality tests which can safely share a profile in parallel
 
+## TestFunctionalNewestKubernetes
+are functionality run functional tests using NewestKubernetesVersion
+
 #### validateNodeLabels
 checks if minikube cluster is created with correct kubernetes's node label
 

--- a/site/content/en/docs/contrib/tests.en.md
+++ b/site/content/en/docs/contrib/tests.en.md
@@ -112,7 +112,8 @@ asserts that there are no unexpected errors displayed in minikube command output
 are functionality tests which can safely share a profile in parallel
 
 ## TestFunctionalNewestKubernetes
-are functionality run functional tests using NewestKubernetesVersion
+are functionality run functional tests using
+NewestKubernetesVersion
 
 #### validateNodeLabels
 checks if minikube cluster is created with correct kubernetes's node label

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -76,7 +76,8 @@ func TestFunctional(t *testing.T) {
 	testFunctional(t, "")
 }
 
-// TestFunctionalNewestKubernetes are functionality run functional tests using NewestKubernetesVersion
+// TestFunctionalNewestKubernetes are functionality run functional tests using
+// NewestKubernetesVersion
 func TestFunctionalNewestKubernetes(t *testing.T) {
 	if strings.Contains(*startArgs, "--kubernetes-version") || constants.NewestKubernetesVersion == constants.DefaultKubernetesVersion {
 		t.Skip()

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -78,7 +78,7 @@ func TestFunctional(t *testing.T) {
 
 // TestFunctionalNewestKubernetes are functionality run functional tests using NewestKubernetesVersion
 func TestFunctionalNewestKubernetes(t *testing.T) {
-	if strings.Contains(*startArgs, "--kubernetes-version") {
+	if strings.Contains(*startArgs, "--kubernetes-version") || constants.NewestKubernetesVersion == constants.DefaultKubernetesVersion {
 		t.Skip()
 	}
 	k8sVersionString := constants.NewestKubernetesVersion
@@ -90,7 +90,7 @@ func TestFunctionalNewestKubernetes(t *testing.T) {
 
 func testFunctional(t *testing.T, k8sVersion string) {
 	profile := UniqueProfileName("functional")
-	ctx := context.WithValue(context.Background(), "k8sVersion", k8sVersion)
+	ctx := context.WithValue(context.Background(), ContextKey("k8sVersion"), k8sVersion)
 	ctx, cancel := context.WithTimeout(ctx, Minutes(40))
 	defer func() {
 		if !*cleanup {

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -42,6 +42,7 @@ import (
 
 	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/detect"
 	"k8s.io/minikube/pkg/minikube/localpath"
 	"k8s.io/minikube/pkg/minikube/reason"
@@ -72,9 +73,25 @@ var runCorpProxy = detect.GithubActionRunner() && runtime.GOOS == "linux" && !ar
 
 // TestFunctional are functionality tests which can safely share a profile in parallel
 func TestFunctional(t *testing.T) {
+	testFunctional(t, "")
+}
 
+// TestFunctionalNewestKubernetes are functionality run functional tests using NewestKubernetesVersion
+func TestFunctionalNewestKubernetes(t *testing.T) {
+	if strings.Contains(*startArgs, "--kubernetes-version") {
+		t.Skip()
+	}
+	k8sVersionString := constants.NewestKubernetesVersion
+	t.Run("Version"+k8sVersionString, func(t *testing.T) {
+		testFunctional(t, k8sVersionString)
+	})
+
+}
+
+func testFunctional(t *testing.T, k8sVersion string) {
 	profile := UniqueProfileName("functional")
-	ctx, cancel := context.WithTimeout(context.Background(), Minutes(40))
+	ctx := context.WithValue(context.Background(), "k8sVersion", k8sVersion)
+	ctx, cancel := context.WithTimeout(ctx, Minutes(40))
 	defer func() {
 		if !*cleanup {
 			return
@@ -86,7 +103,6 @@ func TestFunctional(t *testing.T) {
 
 		Cleanup(t, profile, cancel)
 	}()
-
 	// Serial tests
 	t.Run("serial", func(t *testing.T) {
 		tests := []struct {
@@ -965,7 +981,7 @@ func validateDryRun(ctx context.Context, t *testing.T, profile string) {
 
 	// docs: Run `minikube start --dry-run --memory 250MB`
 	// Too little memory!
-	startArgs := append([]string{"start", "-p", profile, "--dry-run", "--memory", "250MB", "--alsologtostderr"}, StartArgs()...)
+	startArgs := append([]string{"start", "-p", profile, "--dry-run", "--memory", "250MB", "--alsologtostderr"}, StartArgsWithContext(ctx)...)
 	c := exec.CommandContext(mctx, Target(), startArgs...)
 	rr, err := Run(t, c)
 
@@ -982,7 +998,7 @@ func validateDryRun(ctx context.Context, t *testing.T, profile string) {
 	dctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	// docs: Run `minikube start --dry-run`
-	startArgs = append([]string{"start", "-p", profile, "--dry-run", "--alsologtostderr", "-v=1"}, StartArgs()...)
+	startArgs = append([]string{"start", "-p", profile, "--dry-run", "--alsologtostderr", "-v=1"}, StartArgsWithContext(ctx)...)
 	c = exec.CommandContext(dctx, Target(), startArgs...)
 	rr, err = Run(t, c)
 	// docs: Make sure the command doesn't raise any error
@@ -1007,7 +1023,7 @@ func validateInternationalLanguage(ctx context.Context, t *testing.T, profile st
 	defer cancel()
 
 	// Too little memory!
-	startArgs := append([]string{"start", "-p", profile, "--dry-run", "--memory", "250MB", "--alsologtostderr"}, StartArgs()...)
+	startArgs := append([]string{"start", "-p", profile, "--dry-run", "--memory", "250MB", "--alsologtostderr"}, StartArgsWithContext(ctx)...)
 	c := exec.CommandContext(mctx, Target(), startArgs...)
 	// docs: Set environment variable `LC_ALL=fr` to enable minikube translation to French
 	c.Env = append(os.Environ(), "LC_ALL=fr")
@@ -2221,7 +2237,7 @@ func startMinikubeWithProxy(ctx context.Context, t *testing.T, profile string, p
 		memoryFlag = "--memory=6000"
 	}
 	// passing --api-server-port so later verify it didn't change in soft start.
-	startArgs := append([]string{"start", "-p", profile, memoryFlag, fmt.Sprintf("--apiserver-port=%d", apiPortTest), "--wait=all"}, StartArgs()...)
+	startArgs := append([]string{"start", "-p", profile, memoryFlag, fmt.Sprintf("--apiserver-port=%d", apiPortTest), "--wait=all"}, StartArgsWithContext(ctx)...)
 	c := exec.CommandContext(ctx, Target(), startArgs...)
 	env := os.Environ()
 	env = append(env, fmt.Sprintf("%s=%s", proxyEnv, addr))

--- a/test/integration/functional_test_tunnel_test.go
+++ b/test/integration/functional_test_tunnel_test.go
@@ -432,4 +432,9 @@ func validateTunnelDelete(_ context.Context, t *testing.T, _ string) {
 	checkRoutePassword(t)
 	// Stop tunnel
 	tunnelSession.Stop(t)
+	// prevent the child process from becoming a defunct zombie process
+	if err := tunnelSession.cmd.Wait(); err != nil {
+		t.Logf("failed to stop process: %v", err)
+		return
+	}
 }

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -119,9 +119,11 @@ func StartArgs() []string {
 	return strings.Split(*startArgs, " ")
 }
 
+type ContextKey string
+
 func StartArgsWithContext(ctx context.Context) []string {
 	res := strings.Split(*startArgs, " ")
-	value := ctx.Value("k8sVersion")
+	value := ctx.Value(ContextKey("k8sVersion"))
 	if value != nil && value != "" {
 		res = append(res, fmt.Sprintf("--kubernetes-version=%s", value))
 	}

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -119,6 +119,15 @@ func StartArgs() []string {
 	return strings.Split(*startArgs, " ")
 }
 
+func StartArgsWithContext(ctx context.Context) []string {
+	res := strings.Split(*startArgs, " ")
+	value := ctx.Value("k8sVersion")
+	if value != nil && value != "" {
+		res = append(res, fmt.Sprintf("--kubernetes-version=%s", value))
+	}
+	return res
+}
+
 // Target returns where the minikube binary can be found
 func Target() string {
 	return *binaryPath


### PR DESCRIPTION
FIX #18508
test: allow running functional tests for different k8s versions
It also fix a small bug in minikube tunnel. Now we also check the machine name stored in the tunnel.json when preventing establishing duplicated tunnel.

Before: functional test can only be run for default specified k8s version

After: 
- When running the whold functional test, now functional tests can be run for multiple k8s version(default, newest).
- Functional tests for non-default k8s versions are named as " TestFunctionalNewestKuberentes/Versionxxx/parallel/xxx", while tests for default versions remains unchanged. 

Here are the example outputs(most tests are disabled for simplification)
```
make functional
go build  -tags "" -ldflags="-X k8s.io/minikube/pkg/version.version=v1.33.0-beta.0 -X k8s.io/minikube/pkg/version.isoVersion=v1.33.0-1711559712-18485 -X k8s.io/minikube/pkg/version.gitCommitID="2d03356f4cfd5e00101854f26afd0711a65bd178-dirty" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" -o out/minikube k8s.io/minikube/cmd/minikube
go test -ldflags="-X k8s.io/minikube/pkg/version.version=v1.33.0-beta.0 -X k8s.io/minikube/pkg/version.isoVersion=v1.33.0-1711559712-18485 -X k8s.io/minikube/pkg/version.gitCommitID="2d03356f4cfd5e00101854f26afd0711a65bd178-dirty" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" -v -test.timeout=20m ./test/integration --tags="integration "  -test.run TestFunctional 2>&1 | tee "./out/testout_2d03356f4.txt"
Found 8 cores, limiting parallelism with --test.parallel=2
=== RUN   TestFunctional
=== RUN   TestFunctional/serial
=== RUN   TestFunctional/serial/CopySyncFile
    functional_test.go:1869: local sync path: /Users/tjm/.minikube/files/etc/test/nested/copy/14959/hosts
=== RUN   TestFunctional/serial/StartWithProxy
    functional_test.go:2248: (dbg) Run:  out/minikube start -p functional-270000 --memory=4000 --apiserver-port=8441 --wait=all 
    functional_test.go:2248: (dbg) Done: out/minikube start -p functional-270000 --memory=4000 --apiserver-port=8441 --wait=all : (34.611209708s)
=== RUN   TestFunctional/parallel
=== RUN   TestFunctional/delete_addon-resizer_images
    functional_test.go:207: (dbg) Run:  docker rmi -f gcr.io/google-containers/addon-resizer:1.8.8
    functional_test.go:207: (dbg) Run:  docker rmi -f gcr.io/google-containers/addon-resizer:functional-270000
=== RUN   TestFunctional/delete_my-image_image
    functional_test.go:215: (dbg) Run:  docker rmi -f localhost/my-image:functional-270000
=== RUN   TestFunctional/delete_minikube_cached_images
    functional_test.go:223: (dbg) Run:  docker rmi -f minikube-local-cache-test:functional-270000
=== NAME  TestFunctional
    helpers_test.go:175: Cleaning up "functional-270000" profile ...
    helpers_test.go:178: (dbg) Run:  out/minikube delete -p functional-270000
    helpers_test.go:178: (dbg) Done: out/minikube delete -p functional-270000: (1.969108417s)
--- PASS: TestFunctional (36.75s)
    --- PASS: TestFunctional/serial (34.61s)
        --- PASS: TestFunctional/serial/CopySyncFile (0.00s)
        --- PASS: TestFunctional/serial/StartWithProxy (34.61s)
    --- PASS: TestFunctional/parallel (0.00s)
    --- PASS: TestFunctional/delete_addon-resizer_images (0.08s)
    --- PASS: TestFunctional/delete_my-image_image (0.04s)
    --- PASS: TestFunctional/delete_minikube_cached_images (0.04s)
=== RUN   TestFunctionalNewestKuberentes
=== RUN   TestFunctionalNewestKuberentes/Versionv1.30.0-beta.0
=== RUN   TestFunctionalNewestKuberentes/Versionv1.30.0-beta.0/serial
=== RUN   TestFunctionalNewestKuberentes/Versionv1.30.0-beta.0/serial/CopySyncFile
    functional_test.go:1869: local sync path: /Users/tjm/.minikube/files/etc/test/nested/copy/14959/hosts
=== RUN   TestFunctionalNewestKuberentes/Versionv1.30.0-beta.0/serial/StartWithProxy
    functional_test.go:2248: (dbg) Run:  out/minikube start -p functional-400000 --memory=4000 --apiserver-port=8441 --wait=all  --kubernetes-version=v1.30.0-beta.0
    functional_test.go:2248: (dbg) Done: out/minikube start -p functional-400000 --memory=4000 --apiserver-port=8441 --wait=all  --kubernetes-version=v1.30.0-beta.0: (33.801479542s)
=== RUN   TestFunctionalNewestKuberentes/Versionv1.30.0-beta.0/parallel
=== RUN   TestFunctionalNewestKuberentes/Versionv1.30.0-beta.0/delete_addon-resizer_images
    functional_test.go:207: (dbg) Run:  docker rmi -f gcr.io/google-containers/addon-resizer:1.8.8
    functional_test.go:207: (dbg) Run:  docker rmi -f gcr.io/google-containers/addon-resizer:functional-400000
=== RUN   TestFunctionalNewestKuberentes/Versionv1.30.0-beta.0/delete_my-image_image
    functional_test.go:215: (dbg) Run:  docker rmi -f localhost/my-image:functional-400000
=== RUN   TestFunctionalNewestKuberentes/Versionv1.30.0-beta.0/delete_minikube_cached_images
    functional_test.go:223: (dbg) Run:  docker rmi -f minikube-local-cache-test:functional-400000
=== NAME  TestFunctionalNewestKuberentes/Versionv1.30.0-beta.0
    helpers_test.go:175: Cleaning up "functional-400000" profile ...
    helpers_test.go:178: (dbg) Run:  out/minikube delete -p functional-400000
    helpers_test.go:178: (dbg) Done: out/minikube delete -p functional-400000: (1.919934375s)
--- PASS: TestFunctionalNewestKuberentes (35.88s)
    --- PASS: TestFunctionalNewestKuberentes/Versionv1.30.0-beta.0 (35.88s)
        --- PASS: TestFunctionalNewestKuberentes/Versionv1.30.0-beta.0/serial (33.80s)
            --- PASS: TestFunctionalNewestKuberentes/Versionv1.30.0-beta.0/serial/CopySyncFile (0.00s)
            --- PASS: TestFunctionalNewestKuberentes/Versionv1.30.0-beta.0/serial/StartWithProxy (33.80s)
        --- PASS: TestFunctionalNewestKuberentes/Versionv1.30.0-beta.0/parallel (0.00s)
        --- PASS: TestFunctionalNewestKuberentes/Versionv1.30.0-beta.0/delete_addon-resizer_images (0.08s)
        --- PASS: TestFunctionalNewestKuberentes/Versionv1.30.0-beta.0/delete_my-image_image (0.04s)
        --- PASS: TestFunctionalNewestKuberentes/Versionv1.30.0-beta.0/delete_minikube_cached_images (0.04s)
PASS
Tests completed in 1m12.628801166s (result code 0)
ok      k8s.io/minikube/test/integration        73.292s
```


