### PR TITLE
CI: Fix setup-go warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Download Dependencies
         run: go mod download
       - name: Build Binaries
@@ -51,7 +50,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Install libvirt
         run: |
           sudo apt-get update
@@ -70,7 +68,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Install libvirt
         run: |
           sudo apt-get update

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Generate Docs
         id: gendocs
         run: |

--- a/.github/workflows/functional_verified.yml
+++ b/.github/workflows/functional_verified.yml
@@ -38,7 +38,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Download Dependencies
         run: go mod download
       - name: Build Binaries
@@ -64,6 +63,7 @@ jobs:
     steps:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
+          cache: false
           go-version: ${{env.GO_VERSION}}
       - name: Install tools
         shell: bash

--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Update Leaderboard
         id: leaderboard
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -28,7 +28,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Download Dependencies
         run: go mod download
       - name: Build Binaries
@@ -54,7 +53,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Download Dependencies
         run: go mod download
       - name: Build Binaries
@@ -68,7 +66,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Install libvirt
         run: |
           sudo apt-get update
@@ -87,7 +84,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Install libvirt
         run: |
           sudo apt-get update
@@ -134,6 +130,7 @@ jobs:
           echo "--------------------------"
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
+          cache: false
           go-version: ${{env.GO_VERSION}}
       - name: Install gopogh
         shell: bash
@@ -232,6 +229,7 @@ jobs:
           echo "--------------------------"
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
+          cache: false
           go-version: ${{env.GO_VERSION}}
       - name: Install gopogh
         shell: bash
@@ -334,6 +332,7 @@ jobs:
           echo "--------------------------"
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
+          cache: false
           go-version: ${{env.GO_VERSION}}
       - name: Install gopogh
         shell: bash
@@ -419,6 +418,7 @@ jobs:
           kubectl version --client=true
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
+          cache: false
           go-version: ${{env.GO_VERSION}}
       - name: Install gopogh
         shell: bash
@@ -516,6 +516,7 @@ jobs:
           kubectl version --client=true
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
+          cache: false
           go-version: ${{env.GO_VERSION}}
       # conntrack is required for kubernetes 1.18 and higher
       # socat is required for kubectl port forward which is used in some tests such as validateHelmTillerAddon

--- a/.github/workflows/minikube-image-benchmark.yml
+++ b/.github/workflows/minikube-image-benchmark.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Run Benchmark
         run: |
           ./hack/benchmark/image-build/publish-chart.sh

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Download Dependencies
         run: go mod download
       - name: Build Binaries
@@ -52,7 +51,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Download Dependencies
         run: go mod download
       - name: Build Binaries
@@ -66,7 +64,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Install libvirt
         run: |
           sudo apt-get update
@@ -85,7 +82,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Install libvirt
         run: |
           sudo apt-get update
@@ -132,6 +128,7 @@ jobs:
           echo "--------------------------"
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
+          cache: false
           go-version: ${{env.GO_VERSION}}
       - name: Install gopogh
         shell: bash
@@ -231,6 +228,7 @@ jobs:
           echo "--------------------------"
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
+          cache: false
           go-version: ${{env.GO_VERSION}}
       - name: Install gopogh
         shell: bash
@@ -348,6 +346,7 @@ jobs:
           echo "--------------------------"
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
+          cache: false
           go-version: ${{env.GO_VERSION}}
       - name: Install gopogh
         shell: bash
@@ -451,6 +450,7 @@ jobs:
           echo "--------------------------"
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
+          cache: false
           go-version: ${{env.GO_VERSION}}
       - name: Install gopogh
         shell: bash
@@ -537,6 +537,7 @@ jobs:
           kubectl version --client=true
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
+          cache: false
           go-version: ${{env.GO_VERSION}}
       - name: Install gopogh
         shell: bash
@@ -635,6 +636,7 @@ jobs:
           kubectl version --client=true
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
+          cache: false
           go-version: ${{env.GO_VERSION}}
       # conntrack is required for kubernetes 1.18 and higher
       # socat is required for kubectl port forward which is used in some tests such as validateHelmTillerAddon

--- a/.github/workflows/sync-minikube.yml
+++ b/.github/workflows/sync-minikube.yml
@@ -26,8 +26,6 @@ jobs:
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
-
       - name: Build
         run: make
 

--- a/.github/workflows/time-to-k8s-public-chart.yml
+++ b/.github/workflows/time-to-k8s-public-chart.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Benchmark time-to-k8s for Docker driver with Docker runtime
         run: |
           ./hack/benchmark/time-to-k8s/public-chart/public-chart.sh docker docker
@@ -48,7 +47,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Disable firewall
         run: |
           sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off

--- a/.github/workflows/time-to-k8s.yml
+++ b/.github/workflows/time-to-k8s.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: time-to-k8s Benchmark
         id: timeToK8sBenchmark
         run: |

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Install libvirt
         run: |
           sudo apt-get update

--- a/.github/workflows/update-buildkit-version.yml
+++ b/.github/workflows/update-buildkit-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump buildkit Version
         id: bumpBuildkit
         run: |

--- a/.github/workflows/update-calico-version.yml
+++ b/.github/workflows/update-calico-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump calico version
         id: bumpCalico
         run: |

--- a/.github/workflows/update-cloud-spanner-emulator-version.yml
+++ b/.github/workflows/update-cloud-spanner-emulator-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump cloud-spanner-emulator version
         id: bumpCloudSpannerEmulator
         run: |

--- a/.github/workflows/update-cni-plugins-version.yml
+++ b/.github/workflows/update-cni-plugins-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump cni-plugins Version
         id: bumpCNIPlugins
         run: |

--- a/.github/workflows/update-containerd-version.yml
+++ b/.github/workflows/update-containerd-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump containerd Version
         id: bumpContainerd
         run: |

--- a/.github/workflows/update-cri-dockerd-version.yml
+++ b/.github/workflows/update-cri-dockerd-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump cri-dockerd version
         id: bumpCriDockerd
         run: |

--- a/.github/workflows/update-cri-o-version.yml
+++ b/.github/workflows/update-cri-o-version.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump cri-o Version
         id: bumpCrio
         run: |

--- a/.github/workflows/update-crictl-version.yml
+++ b/.github/workflows/update-crictl-version.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump crictl Version
         id: bumpCrictl
         run: |

--- a/.github/workflows/update-crun-version.yml
+++ b/.github/workflows/update-crun-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump crun Version
         id: bumpCrun
         run: |

--- a/.github/workflows/update-docker-buildx-version.yml
+++ b/.github/workflows/update-docker-buildx-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump docker-buildx Version
         id: bumpDockerBuildx
         run: |

--- a/.github/workflows/update-docker-version.yml
+++ b/.github/workflows/update-docker-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump docker Version
         id: bumpDocker
         run: |

--- a/.github/workflows/update-docsy-version.yml
+++ b/.github/workflows/update-docsy-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump Docsy version
         id: bumpDocsy
         run: |

--- a/.github/workflows/update-flannel-version.yml
+++ b/.github/workflows/update-flannel-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump flannel version
         id: bumpFlannel
         run: |

--- a/.github/workflows/update-gcp-auth-version.yml
+++ b/.github/workflows/update-gcp-auth-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump gcp-auth version
         id: bumpGCPAuth
         run: |

--- a/.github/workflows/update-gh-version.yml
+++ b/.github/workflows/update-gh-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump gh version
         id: bumpGh
         run: |

--- a/.github/workflows/update-go-github-version.yml
+++ b/.github/workflows/update-go-github-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump go-github version
         id: bumpGoGithub
         run: |

--- a/.github/workflows/update-golang-version.yml
+++ b/.github/workflows/update-golang-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump Golang Versions
         id: bumpGolang
         run: |

--- a/.github/workflows/update-golint-version.yml
+++ b/.github/workflows/update-golint-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump Golint Versions
         id: bumpGolint
         run: |

--- a/.github/workflows/update-gopogh-version.yml
+++ b/.github/workflows/update-gopogh-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump gopogh Versions
         id: bumpGopogh
         run: |

--- a/.github/workflows/update-gotestsum-version.yml
+++ b/.github/workflows/update-gotestsum-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump Gotestsum Versions
         id: bumpGotestsum
         run: |

--- a/.github/workflows/update-hugo-version.yml
+++ b/.github/workflows/update-hugo-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump Hugo version
         id: bumpHugo
         run: |

--- a/.github/workflows/update-ingress-version.yml
+++ b/.github/workflows/update-ingress-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump ingress version
         id: bumpIngress
         run: |

--- a/.github/workflows/update-inspektor-gadget-version.yml
+++ b/.github/workflows/update-inspektor-gadget-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump inspektor-gadget version
         id: bumpInspektorGadget
         run: |

--- a/.github/workflows/update-iso-image-versions.yml
+++ b/.github/workflows/update-iso-image-versions.yml
@@ -14,7 +14,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump versions
         id: bumpVersions
         run: |

--- a/.github/workflows/update-istio-operator.yml
+++ b/.github/workflows/update-istio-operator.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump istio-operator version
         id: bumpIstioOperator
         run: |

--- a/.github/workflows/update-k8s-versions.yml
+++ b/.github/workflows/update-k8s-versions.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump Kubernetes Versions
         id: bumpk8s
         run: |

--- a/.github/workflows/update-kindnetd-version.yml
+++ b/.github/workflows/update-kindnetd-version.yml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump kindnetd version
         id: bumpKindnetd
         run: |

--- a/.github/workflows/update-kong-ingress-controller-version.yml
+++ b/.github/workflows/update-kong-ingress-controller-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump kong-ingress-controller version
         id: bumpKongIngressController
         run: |

--- a/.github/workflows/update-kong-version.yml
+++ b/.github/workflows/update-kong-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump kong version
         id: bumpKong
         run: |

--- a/.github/workflows/update-kubeadm-constants.yml
+++ b/.github/workflows/update-kubeadm-constants.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump Kubeadm Constants for Kubernetes Images
         id: bumpKubeadmConsts
         run: |

--- a/.github/workflows/update-kubectl-version.yml
+++ b/.github/workflows/update-kubectl-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump Kubectl version
         id: bumpKubectl
         run: |

--- a/.github/workflows/update-kubernetes-versions-list.yml
+++ b/.github/workflows/update-kubernetes-versions-list.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump Kubernetes versions list
         id: bumpKubernetesVersionsList
         run: |

--- a/.github/workflows/update-metrics-server-version.yml
+++ b/.github/workflows/update-metrics-server-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump metrics-server version
         id: bumpMetricsServer
         run: |

--- a/.github/workflows/update-nerdctl-version.yml
+++ b/.github/workflows/update-nerdctl-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump nerdctl Version
         id: bumpNerdctl
         run: |

--- a/.github/workflows/update-nerdctld-version.yml
+++ b/.github/workflows/update-nerdctld-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump nerdctld Version
         id: bumpNerdctld
         run: |

--- a/.github/workflows/update-nvidia-device-plugin-version.yml
+++ b/.github/workflows/update-nvidia-device-plugin-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump nvidia-device-plugin version
         id: bumpNvidiaDevicePlugin
         run: |

--- a/.github/workflows/update-registry-version.yml
+++ b/.github/workflows/update-registry-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump registry version
         id: bumpRegistry
         run: |

--- a/.github/workflows/update-runc-version.yml
+++ b/.github/workflows/update-runc-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump runc Version
         id: bumpRunc
         run: |

--- a/.github/workflows/update-site-node-version.yml
+++ b/.github/workflows/update-site-node-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump site node version
         id: bumpSiteNode
         run: |

--- a/.github/workflows/update-ubuntu-version.yml
+++ b/.github/workflows/update-ubuntu-version.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Bump Ubuntu version
         id: bumpUbuntu
         run: |

--- a/.github/workflows/yearly-leaderboard.yml
+++ b/.github/workflows/yearly-leaderboard.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: ${{env.GO_VERSION}}
-          cache-dependency-path: ./go.sum
       - name: Update Yearly Leaderboard
         id: yearlyLeaderboard
         run: |


### PR DESCRIPTION
<img width="999" alt="Screenshot 2024-04-17 at 6 10 49 PM" src="https://github.com/kubernetes/minikube/assets/44844360/3599d24a-08a0-4fff-b93f-f6cc5934f4ee">

For cases where we run `setup-go` but don't run `checkout` before hand, there is no `go.sum` file, so disable cache to resolve warnings. Also removed unnecessary `cache-dependency-path` as cache path defaults to default location.