### PR TITLE
CI: Stop auto updating ISO Go version

### DIFF
--- a/hack/update/golang_version/update_golang_version.go
+++ b/hack/update/golang_version/update_golang_version.go
@@ -46,7 +46,6 @@ var (
 				// searching for 1.* so it does NOT match "KVM_GO_VERSION ?= $(GO_VERSION:.0=)" in the Makefile
 				`GO_VERSION \?= 1.*`:             `GO_VERSION ?= {{.StableVersion}}`,
 				`GO_K8S_VERSION_PREFIX \?= v1.*`: `GO_K8S_VERSION_PREFIX ?= {{.K8SVersion}}`,
-				`GO_VERSION=[0-9.]+`:             `GO_VERSION={{.StableVersion}}`,
 			},
 		},
 		"hack/jenkins/installers/check_install_golang.sh": {


### PR DESCRIPTION
Our current Buildroot versions doesn't support Go 1.22 so remove updating ISO Go version.