### PR TITLE
Fix `make site` not picking up new hugo updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -926,6 +926,7 @@ endif
 site/themes/docsy/assets/vendor/bootstrap/package.js: ## update the website docsy theme git submodule 
 	git submodule update -f --init
 
+.PHONY: out/hugo/hugo
 out/hugo/hugo:
 	mkdir -p out
 	(cd site/themes/docsy && npm install)


### PR DESCRIPTION
The problem is if you ran `make site` previously when hugo was on an older version, you'd forever be locked into that hugo version because the `out/hugo/hugo` target was getting overridden by the `out/hugo/hugo` file itself. The `out/hugo/hugo` target holds the code for updating the local hugo version, which was getting skipped on all subsequent `make site` commands. Fixed this by adding a `PHONY` for the `out/hugo/hugo` target.