### PR TITLE
CI: Go auto update improvements

### DIFF
--- a/.github/workflows/update-golang-version.yml
+++ b/.github/workflows/update-golang-version.yml
@@ -55,5 +55,5 @@ jobs:
               issue_number: ${{ steps.createPR.outputs.pull-request-number }},
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'ok-to-build-iso'
+              body: 'ok-to-build-image'
             })

--- a/hack/update/golang_version/update_golang_version.go
+++ b/hack/update/golang_version/update_golang_version.go
@@ -73,9 +73,8 @@ var (
 
 // Data holds stable Golang version - in full and in <major>.<minor> format
 type Data struct {
-	StableVersion   string
-	StableVersionMM string // go.mod wants go version in <major>.<minor> format
-	K8SVersion      string // as of v1.23.0 Kubernetes uses k8s version in golang image name because: https://github.com/kubernetes/kubernetes/pull/103692#issuecomment-908659826
+	StableVersion string
+	K8SVersion    string // as of v1.23.0 Kubernetes uses k8s version in golang image name because: https://github.com/kubernetes/kubernetes/pull/103692#issuecomment-908659826
 
 }
 
@@ -83,7 +82,7 @@ func main() {
 	addGitHubWorkflowFiles()
 
 	// get Golang stable version
-	stable, stableMM, k8sVersion, err := goVersions()
+	stable, _, k8sVersion, err := goVersions()
 	if err != nil || stable == "" || stableMM == "" {
 		klog.Fatalf("Unable to get Golang stable version: %v", err)
 	}
@@ -92,7 +91,7 @@ func main() {
 		klog.Warningf("Golang stable version is a release candidate, skipping: %s", stable)
 		return
 	}
-	data := Data{StableVersion: stable, StableVersionMM: stableMM, K8SVersion: k8sVersion}
+	data := Data{StableVersion: stable, K8SVersion: k8sVersion}
 	klog.Infof("Golang stable version: %s", data.StableVersion)
 
 	update.Apply(schema, data)

--- a/hack/update/golang_version/update_golang_version.go
+++ b/hack/update/golang_version/update_golang_version.go
@@ -83,7 +83,7 @@ func main() {
 
 	// get Golang stable version
 	stable, _, k8sVersion, err := goVersions()
-	if err != nil || stable == "" || stableMM == "" {
+	if err != nil || stable == "" {
 		klog.Fatalf("Unable to get Golang stable version: %v", err)
 	}
 	// skip rc versions

--- a/hack/update/golang_version/update_golang_version.go
+++ b/hack/update/golang_version/update_golang_version.go
@@ -36,11 +36,6 @@ var (
 	}
 
 	schema = map[string]update.Item{
-		"go.mod": {
-			Replace: map[string]string{
-				`(?m)^go .*`: `go {{.StableVersionMM}}`,
-			},
-		},
 		"Makefile": {
 			Replace: map[string]string{
 				// searching for 1.* so it does NOT match "KVM_GO_VERSION ?= $(GO_VERSION:.0=)" in the Makefile

--- a/hack/update/golang_version/update_golang_version.go
+++ b/hack/update/golang_version/update_golang_version.go
@@ -82,7 +82,7 @@ func main() {
 	addGitHubWorkflowFiles()
 
 	// get Golang stable version
-	stable, _, k8sVersion, err := goVersions()
+	stable, k8sVersion, err := goVersions()
 	if err != nil || stable == "" {
 		klog.Fatalf("Unable to get Golang stable version: %v", err)
 	}
@@ -102,24 +102,22 @@ func main() {
 }
 
 // goVersions returns Golang stable version.
-func goVersions() (stable, stableMM, k8sVersion string, err error) {
+func goVersions() (stable, k8sVersion string, err error) {
 	// will update to the same image that kubernetes project uses
 	resp, err := http.Get("https://raw.githubusercontent.com/kubernetes/kubernetes/master/build/build-image/cross/VERSION")
 	if err != nil {
-		return "", "", "", err
+		return "", "", err
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", "", "", err
+		return "", "", err
 	}
 	// example response: v1.23.0-go1.17-buster.0
 	stable = string(body)
 	k8sVersion = strings.Split(stable, "-")[0]
 	stable = strings.Split(stable, "-")[1]
 	stable = strings.Replace(stable, "go", "", 1)
-	mmp := strings.SplitN(stable, ".", 3)
-	stableMM = strings.Join(mmp[0:2], ".") // <major>.<minor> version
-	return stable, stableMM, k8sVersion, nil
+	return stable, k8sVersion, nil
 }
 
 func updateGoHashFile(version string) error {


### PR DESCRIPTION
Auto build kicbase image instead of ISO since we're not modifying the ISO in Go update PR anymore

Also remove updating `go.mod` because the potential formats of the Go version has changed, plus we don't need to bump it manually, modules that require it will auto update it.