### PR TITLE
Base ISO cache file name on the full ISO URL

### DIFF
--- a/pkg/minikube/download/iso.go
+++ b/pkg/minikube/download/iso.go
@@ -17,6 +17,7 @@ limitations under the License.
 package download
 
 import (
+	"crypto/sha1"
 	"fmt"
 	"net/url"
 	"os"
@@ -77,7 +78,10 @@ func localISOPath(u *url.URL) string {
 		return u.String()
 	}
 
-	return filepath.Join(detect.ISOCacheDir(), path.Base(u.Path))
+	urlHash := sha1.Sum([]byte(u.String()))
+	fileName := fmt.Sprintf("%s-%040x", path.Base(u.Path), urlHash)
+
+	return filepath.Join(detect.ISOCacheDir(), fileName)
 }
 
 // ISO downloads and returns the path to the downloaded ISO


### PR DESCRIPTION
Currently, only the basename of the URL path is used, which can be the same for different URLs.

Base the cache file name on the full URL instead, encoding it using Go's base64.URLEncoding so it can be used as a file name on all platforms.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
