### PR TITLE
Addons: Only template `.tmpl` files

### DIFF
--- a/pkg/minikube/assets/vm_assets.go
+++ b/pkg/minikube/assets/vm_assets.go
@@ -26,6 +26,7 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -358,12 +359,14 @@ func (m *BinAsset) loadData() error {
 		return err
 	}
 
-	tpl, err := template.New(m.SourcePath).Funcs(template.FuncMap{"default": defaultValue}).Parse(string(contents))
-	if err != nil {
-		return err
-	}
+	if strings.HasSuffix(m.BaseAsset.SourcePath, ".tmpl") {
+		tpl, err := template.New(m.SourcePath).Funcs(template.FuncMap{"default": defaultValue}).Parse(string(contents))
+		if err != nil {
+			return err
+		}
 
-	m.template = tpl
+		m.template = tpl
+	}
 
 	m.length = len(contents)
 	m.reader = bytes.NewReader(contents)


### PR DESCRIPTION
Closes https://github.com/kubernetes/minikube/issues/18784

The full explanation for this can be found in https://github.com/kubernetes/minikube/issues/18784, but the short is that we're templating all addon files on load. This hasn't caused an issue until now, but when trying to update the kubeflow addon they added templating that acts as version validation on runtime, but we're templating on load, resulting in:
```
panic: Failed to define asset kubeflow/kubeflow.yaml: template: kubeflow/kubeflow.yaml:118901: function "Template_Version_And_Istio_Version_Mismatched_Check_Installation" not defined

goroutine 1 [running]:
k8s.io/minikube/pkg/minikube/assets.MustBinAsset({0x10317f7e0?}, {0x101f2a8ec, 0x16}, {0x101f29d94?, 0x1?}, {0x101f1131e?, 0x14000593928?}, {0x101efea1b?, 0x10?})
	/Users/powellsteven/repo/minikube/pkg/minikube/assets/vm_assets.go:323 +0xb8
k8s.io/minikube/pkg/minikube/assets.init()
	/Users/powellsteven/repo/minikube/pkg/minikube/assets/addons.go:780 +0x687c
```

Since we strictly add `.tmpl` to the filename of files that need templating, check for that suffix to decide if the file needs to be templated or not.