### PR TITLE
ISO: Add 50-fs-inotify.conf to increase limits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ KIC_VERSION ?= $(shell grep -E "Version =" pkg/drivers/kic/types.go | cut -d \" 
 HUGO_VERSION ?= $(shell grep -E "HUGO_VERSION = \"" netlify.toml | cut -d \" -f2)
 
 # Default to .0 for higher cache hit rates, as build increments typically don't require new ISO versions
-ISO_VERSION ?= v1.33.0-1714498396-18779
+ISO_VERSION ?= v1.33.0-1715127532-18832
 
 # Dashes are valid in semver, but not Linux packaging. Use ~ to delimit alpha/beta
 DEB_VERSION ?= $(subst -,~,$(RAW_VERSION))

--- a/deploy/iso/minikube-iso/board/minikube/aarch64/rootfs-overlay/etc/sysctl.d/50-fs-inotify.conf
+++ b/deploy/iso/minikube-iso/board/minikube/aarch64/rootfs-overlay/etc/sysctl.d/50-fs-inotify.conf
@@ -1,0 +1,4 @@
+# Avoid failures with kubevirt vms
+# https://github.com/kubernetes/minikube/issues/18831
+fs.inotify.max_user_instances = 8192
+fs.inotify.max_user_watches = 65536

--- a/deploy/iso/minikube-iso/board/minikube/x86_64/rootfs-overlay/etc/sysctl.d/50-fs-inotify.conf
+++ b/deploy/iso/minikube-iso/board/minikube/x86_64/rootfs-overlay/etc/sysctl.d/50-fs-inotify.conf
@@ -1,0 +1,4 @@
+# Avoid failures with kubevirt vms
+# https://github.com/kubernetes/minikube/issues/18831
+fs.inotify.max_user_instances = 8192
+fs.inotify.max_user_watches = 65536

--- a/pkg/minikube/download/iso.go
+++ b/pkg/minikube/download/iso.go
@@ -41,7 +41,7 @@ const fileScheme = "file"
 // DefaultISOURLs returns a list of ISO URL's to consult by default, in priority order
 func DefaultISOURLs() []string {
 	v := version.GetISOVersion()
-	isoBucket := "minikube-builds/iso/18779"
+	isoBucket := "minikube-builds/iso/18832"
 
 	return []string{
 		fmt.Sprintf("https://storage.googleapis.com/%s/minikube-%s-%s.iso", isoBucket, v, runtime.GOARCH),


### PR DESCRIPTION
This avoids random failures starting kubevirt VMs like:

    {"component":"virt-handler","level":"error","msg":"Error starting vhost-net device
    plugin","pos":"device_controller.go:70","reason":"failed to creating a fsnotify
    watcher: too many open files","timestamp":"2024-05-06T12:59:30.009620Z"}

Fixes #18831