### PR TITLE
site: Fix broken link to Kong documentation

### DIFF
--- a/site/content/en/docs/handbook/addons/kong-ingress.md
+++ b/site/content/en/docs/handbook/addons/kong-ingress.md
@@ -200,4 +200,4 @@ With IP address 10.244.0.6.
 ## Next
 
 **Note:** Read more about KIC and different use cases in official
-[documentation](https://docs.konghq.com/kubernetes-ingress-controller/latest/guides/overview/).
+[documentation](https://docs.konghq.com/kubernetes-ingress-controller/latest/).


### PR DESCRIPTION
Guides overview page is 404, link to docs home for Kong latest instead.