### PR TITLE
feat: check connectivity outside minikube  once it  fails

### DIFF
--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -873,7 +873,7 @@ func tryRegistry(r command.Runner, driverName, imageRepository, ip string) {
 		// now we shall also try whether this registry is reachable outside the machine
 		// so that we can tell in the logs that if the user's computer had any network issue or could it be related to a network module config change in minikbue ISO
 
-		//We should skip the second check if the user is using the none or ssh driver since there is no different
+		// We should skip the second check if the user is using the none or ssh driver since there is no difference
 		// between an "inside" and "outside" check on the none driver, and checking the host on the ssh driver is not helpful.
 		if driver.IsNone(driverName) || driver.IsSSH(driverName) {
 			out.WarningT("Failing to connect to {{.curlTarget}} from inside the minikube {{.type}}", out.V{"curlTarget": curlTarget, "type": driver.MachineType(driverName)})

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -870,11 +870,15 @@ func tryRegistry(r command.Runner, driverName, imageRepository, ip string) {
 		if driver.IsQEMU(driverName) && ip == "127.0.0.1" {
 			out.WarningT("Due to DNS issues your cluster may have problems starting and you may not be able to pull images\nMore details available at: https://minikube.sigs.k8s.io/docs/drivers/qemu/#known-issues")
 		}
-		// now we shall also try whether this registry is reachable outside the machine
-		// so that we can tell in the logs that if the user's computer had any network issue or could it be related to a network module config change in minikbue ISO
+		// now we shall also try whether this registry is reachable     
+		// outside the machine so that we can tell in the logs that if  
+		// the user's computer had any network issue or could it be     
+		// related to a network module config change in minikube ISO    
 
-		// We should skip the second check if the user is using the none or ssh driver since there is no difference
-		// between an "inside" and "outside" check on the none driver, and checking the host on the ssh driver is not helpful.
+		// We should skip the second check if the user is using the none
+		// or ssh driver since there is no difference between an "inside"
+		// and "outside" check on the none driver, and checking the host
+		// on the ssh driver is not helpful.
 		warning := "Failing to connect to {{.curlTarget}} from inside the minikube {{.type}}"
 		if !driver.IsNone(driverName) && !driver.IsSSH(driverName) {
 			if err := cmd.Run(); err != nil {

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -873,14 +873,11 @@ func tryRegistry(r command.Runner, driverName, imageRepository, ip string) {
 		// now we shall also try whether this registry is reachable outside the machine
 		// so that we can tell in the logs that if the user's computer had any network issue or could it be related to a network module config change in minikbue ISO
 		if err := cmd.Run(); err != nil {
-			outside = false
-		}
-		if !outside {
 			// both inside and outside failed
-			out.WarningT("This {{.type}} is also having trouble accessing https://{{.repository}} both inside and outside the minikube ", out.V{"repository": imageRepository, "type": driver.MachineType(driverName)})
+			out.WarningT("Failing to connect to {{.curlTarget}} from both inside the minikube {{.type}} and host machine", out.V{"curlTarget": curlTarget, "type": driver.MachineType(driverName)})
 		} else {
 			// only inside the minikube failed
-			out.WarningT("This {{.type}} is having trouble accessing https://{{.repository}} only inside the minikube", out.V{"repository": imageRepository, "type": driver.MachineType(driverName)})
+			out.WarningT("Failing to connect to {{.curlTarget}} from inside the minikube {{.type}}", out.V{"curlTarget": curlTarget, "type": driver.MachineType(driverName)})
 		}
 		out.ErrT(style.Tip, "To pull new external images, you may need to configure a proxy: https://minikube.sigs.k8s.io/docs/reference/networking/proxy/")
 	}

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -870,10 +870,10 @@ func tryRegistry(r command.Runner, driverName, imageRepository, ip string) {
 		if driver.IsQEMU(driverName) && ip == "127.0.0.1" {
 			out.WarningT("Due to DNS issues your cluster may have problems starting and you may not be able to pull images\nMore details available at: https://minikube.sigs.k8s.io/docs/drivers/qemu/#known-issues")
 		}
-		// now we shall also try whether this registry is reachable     
-		// outside the machine so that we can tell in the logs that if  
-		// the user's computer had any network issue or could it be     
-		// related to a network module config change in minikube ISO    
+		// now we shall also try whether this registry is reachable
+		// outside the machine so that we can tell in the logs that if
+		// the user's computer had any network issue or could it be
+		// related to a network module config change in minikube ISO
 
 		// We should skip the second check if the user is using the none
 		// or ssh driver since there is no difference between an "inside"

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -875,18 +875,14 @@ func tryRegistry(r command.Runner, driverName, imageRepository, ip string) {
 
 		// We should skip the second check if the user is using the none or ssh driver since there is no difference
 		// between an "inside" and "outside" check on the none driver, and checking the host on the ssh driver is not helpful.
-		if driver.IsNone(driverName) || driver.IsSSH(driverName) {
-			out.WarningT("Failing to connect to {{.curlTarget}} from inside the minikube {{.type}}", out.V{"curlTarget": curlTarget, "type": driver.MachineType(driverName)})
-
-		} else {
+		warning := "Failing to connect to {{.curlTarget}} from inside the minikube {{.type}}"
+		if !driver.IsNone(driverName) && !driver.IsSSH(driverName) {
 			if err := cmd.Run(); err != nil {
 				// both inside and outside failed
-				out.WarningT("Failing to connect to {{.curlTarget}} from both inside the minikube {{.type}} and host machine", out.V{"curlTarget": curlTarget, "type": driver.MachineType(driverName)})
-			} else {
-				// only inside the minikube failed
-				out.WarningT("Failing to connect to {{.curlTarget}} from inside the minikube {{.type}}", out.V{"curlTarget": curlTarget, "type": driver.MachineType(driverName)})
+				warning = "Failing to connect to {{.curlTarget}} from both inside the minikube {{.type}} and host machine"
 			}
 		}
+		out.WarningT(warning, out.V{"curlTarget": curlTarget, "type": driver.MachineType(driverName)})
 
 		out.ErrT(style.Tip, "To pull new external images, you may need to configure a proxy: https://minikube.sigs.k8s.io/docs/reference/networking/proxy/")
 	}


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

feat: check connectivity outside minikube  once it  fails

FIX #18754 
After
```
$ ./out/minikube start       
😄  minikube v1.33.0 on Darwin 14.4.1 (arm64)
✨  Automatically selected the docker driver. Other choices: qemu2, ssh
📌  Using Docker Desktop driver with root privileges
👍  Starting "minikube" primary control-plane node in "minikube" cluster
🚜  Pulling base image v0.0.44 ...
🔥  Creating docker container (CPUs=2, Memory=6100MB) ...
❗  This container is having trouble accessing https://registry.k8s.io inside the minikube
💡  To pull new external images, you may need to configure a proxy: https://minikube.sigs.k8s.io/docs/reference/networking/proxy/
❗  This container is also having trouble accessing https://registry.k8s.io outside the minikube 
🐳  Preparing Kubernetes v1.30.0 on Docker 26.1.1 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```
`This container is also having trouble accessing https://registry.k8s.io outside the minikube ` is also printed on the console