### PR TITLE
CI: Fix RPM build failing when stripping cross compiled binary

### DIFF
--- a/installers/linux/rpm/minikube_rpm_template/minikube.spec
+++ b/installers/linux/rpm/minikube_rpm_template/minikube.spec
@@ -1,3 +1,5 @@
+%define debug_package %{nil}
+%define __strip /bin/true
 Name: minikube
 Version: --VERSION--
 Release: --REVISION--


### PR DESCRIPTION
This fixes RPM building failing during the release process

As per https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/3M5Q2GJMYKJBV2SYSNNU6CS7WNR6XDTO/

Added the following to the top of the `minikube.spec` file
```
%define debug_package %{nil}
%define __strip /bin/true
```

**Before:**
```
$ make out/minikube-1.33.1-0.aarch64.rpm
GOOS="linux" GOARCH="arm64"  \
go build -tags "" -ldflags="-X k8s.io/minikube/pkg/version.version=v1.33.1 -X k8s.io/minikube/pkg/version.isoVersion=v1.33.1 -X k8s.io/minikube/pkg/version.gitCommitID="248d1ec5b3f9be5569977749a725f47b018078ff-dirty" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" -a -o out/minikube-linux-arm64 k8s.io/minikube/cmd/minikube
cp out/minikube-linux-arm64 out/minikube-linux-aarch64
cp -r installers/linux/rpm/minikube_rpm_template/* /tmp/tmp.OYQAe6FKdI.minikube_1.33.1-aarch64-rpm/
sed -E -i 's/--VERSION--/'1.33.1'/g' /tmp/tmp.OYQAe6FKdI.minikube_1.33.1-aarch64-rpm/minikube.spec
sed -E -i 's/--REVISION--/'0'/g' /tmp/tmp.OYQAe6FKdI.minikube_1.33.1-aarch64-rpm/minikube.spec
sed -E -i 's|--OUT--|'/var/lib/jenkins/minikube/out'|g' /tmp/tmp.OYQAe6FKdI.minikube_1.33.1-aarch64-rpm/minikube.spec
rpmbuild -bb -D "_rpmdir /var/lib/jenkins/minikube/out" --target aarch64 \
	 /tmp/tmp.OYQAe6FKdI.minikube_1.33.1-aarch64-rpm/minikube.spec
Building target platforms: aarch64
Building for target aarch64
Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.wwfb2r
+ umask 022
+ cd /var/lib/jenkins/rpmbuild/BUILD
+ mkdir -p minikube-1.33.1
+ cd minikube-1.33.1
+ cp /var/lib/jenkins/minikube/out/minikube-linux-aarch64 minikube
+ RPM_EC=0
+ jobs -p
+ exit 0
Executing(%install): /bin/sh -e /var/tmp/rpm-tmp.rpdkZr
+ umask 022
+ cd /var/lib/jenkins/rpmbuild/BUILD
+ /bin/rm -rf /var/lib/jenkins/rpmbuild/BUILDROOT/minikube-1.33.1-0.aarch64
+ /bin/mkdir -p /var/lib/jenkins/rpmbuild/BUILDROOT
+ /bin/mkdir /var/lib/jenkins/rpmbuild/BUILDROOT/minikube-1.33.1-0.aarch64
+ cd minikube-1.33.1
+ mkdir -p /var/lib/jenkins/rpmbuild/BUILDROOT/minikube-1.33.1-0.aarch64/usr/bin
+ install -m 755 minikube /var/lib/jenkins/rpmbuild/BUILDROOT/minikube-1.33.1-0.aarch64/usr/bin/minikube
+ /usr/lib/rpm/brp-compress /usr
+ /usr/lib/rpm/brp-strip /usr/bin/strip
/usr/bin/strip: Unable to recognise the format of the input file `/var/lib/jenkins/rpmbuild/BUILDROOT/minikube-1.33.1-0.aarch64/usr/bin/minikube'
error: Bad exit status from /var/tmp/rpm-tmp.rpdkZr (%install)


RPM build errors:
    Bad exit status from /var/tmp/rpm-tmp.rpdkZr (%install)
make: *** [Makefile:595: out/minikube-1.33.1-0.aarch64.rpm] Error 1
```

**After:**
```
$ make out/minikube-1.33.1-0.aarch64.rpm
cp -r installers/linux/rpm/minikube_rpm_template/* /tmp/tmp.kcD8tSLxBE.minikube_1.33.1-aarch64-rpm/
sed -E -i 's/--VERSION--/'1.33.1'/g' /tmp/tmp.kcD8tSLxBE.minikube_1.33.1-aarch64-rpm/minikube.spec
sed -E -i 's/--REVISION--/'0'/g' /tmp/tmp.kcD8tSLxBE.minikube_1.33.1-aarch64-rpm/minikube.spec
sed -E -i 's|--OUT--|'/var/lib/jenkins/minikube/out'|g' /tmp/tmp.kcD8tSLxBE.minikube_1.33.1-aarch64-rpm/minikube.spec
rpmbuild -bb -D "_rpmdir /var/lib/jenkins/minikube/out" --target aarch64 \
	 /tmp/tmp.kcD8tSLxBE.minikube_1.33.1-aarch64-rpm/minikube.spec
Building target platforms: aarch64
Building for target aarch64
Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.uYRwTT
+ umask 022
+ cd /var/lib/jenkins/rpmbuild/BUILD
+ mkdir -p minikube-1.33.1
+ cd minikube-1.33.1
+ cp /var/lib/jenkins/minikube/out/minikube-linux-aarch64 minikube
+ RPM_EC=0
+ jobs -p
+ exit 0
Executing(%install): /bin/sh -e /var/tmp/rpm-tmp.LIUckS
+ umask 022
+ cd /var/lib/jenkins/rpmbuild/BUILD
+ /bin/rm -rf /var/lib/jenkins/rpmbuild/BUILDROOT/minikube-1.33.1-0.aarch64
+ /bin/mkdir -p /var/lib/jenkins/rpmbuild/BUILDROOT
+ /bin/mkdir /var/lib/jenkins/rpmbuild/BUILDROOT/minikube-1.33.1-0.aarch64
+ cd minikube-1.33.1
+ mkdir -p /var/lib/jenkins/rpmbuild/BUILDROOT/minikube-1.33.1-0.aarch64/usr/bin
+ install -m 755 minikube /var/lib/jenkins/rpmbuild/BUILDROOT/minikube-1.33.1-0.aarch64/usr/bin/minikube
+ /usr/lib/rpm/brp-compress /usr
+ /usr/lib/rpm/brp-strip /bin/true
+ /usr/lib/rpm/brp-strip-static-archive /bin/true
+ /usr/lib/rpm/brp-strip-comment-note /bin/true /usr/bin/objdump
Processing files: minikube-1.33.1-0.aarch64
warning: Missing build-id in /var/lib/jenkins/rpmbuild/BUILDROOT/minikube-1.33.1-0.aarch64/usr/bin/minikube
Provides: minikube = 1.33.1-0 minikube(aarch-64) = 1.33.1-0
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Checking for unpackaged file(s): /usr/lib/rpm/check-files /var/lib/jenkins/rpmbuild/BUILDROOT/minikube-1.33.1-0.aarch64
Wrote: /var/lib/jenkins/minikube/out/aarch64/minikube-1.33.1-0.aarch64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.nmE0gV
+ umask 022
+ cd /var/lib/jenkins/rpmbuild/BUILD
+ /bin/rm -rf /var/lib/jenkins/rpmbuild/BUILDROOT/minikube-1.33.1-0.aarch64
+ RPM_EC=0
+ jobs -p
+ exit 0
rm -rf /tmp/tmp.kcD8tSLxBE.minikube_1.33.1-aarch64-rpm
```