### PR TITLE
kvm2 driver: Don't delete the "default" libvirt network

### DIFF
--- a/pkg/drivers/kvm/network.go
+++ b/pkg/drivers/kvm/network.go
@@ -244,6 +244,10 @@ func (d *Driver) deleteNetwork() error {
 
 	// network: default
 	// It is assumed that the OS manages this network
+	if d.PrivateNetwork == defaultNetworkName {
+		log.Debugf("Using the default network, skipping deletion")
+		return nil
+	}
 
 	// network: private
 	log.Debugf("Checking if network %s exists...", d.PrivateNetwork)


### PR DESCRIPTION
The special "default" network is created by libvirt and owned by the system admin, but we try to delete it when deleting a profile.

To reproduce the issue, start and delete minikube on a system without any other vm using the libvirt default network:

    minikube start --driver kvm2 --network default
    minikube delete

The default network will be delete, and the next minikube start will fail, complaining about missing libvirt default networking and linking to the complicated instructions how to recreate it.

Now we skip deletion of the special "default" network.

Example run log:

    $ out/minikube delete -v10 --logtostderr 2>delete.log
    * Deleting "minikube" in kvm2 ...
    * Removed all traces of the "minikube" cluster.

    $ cat delete.log
    ...
    I0518 03:41:27.148838 1247331 out.go:177] * Deleting "minikube" in kvm2 ...
    I0518 03:41:27.148857 1247331 main.go:141] libmachine: (minikube) Calling .Remove
    I0518 03:41:27.149156 1247331 main.go:141] libmachine: (minikube) DBG | Removing machine...
    I0518 03:41:27.159000 1247331 main.go:141] libmachine: (minikube) DBG | Trying to delete the networks (if possible)
    I0518 03:41:27.169497 1247331 main.go:141] libmachine: (minikube) DBG | Using the default network, skipping deletion
    I0518 03:41:27.169598 1247331 main.go:141] libmachine: (minikube) Successfully deleted networks
    ...

Fixes #18919