### PR TITLE
CI: Build RPM builds concurrently

### DIFF
--- a/hack/jenkins/release_build_and_upload.sh
+++ b/hack/jenkins/release_build_and_upload.sh
@@ -61,13 +61,16 @@ env BUILD_IN_DOCKER=y \
   "out/minikube_${DEB_VERSION}-${DEB_REVISION}_armhf.deb" \
   "out/minikube_${DEB_VERSION}-${DEB_REVISION}_ppc64el.deb" \
   "out/minikube_${DEB_VERSION}-${DEB_REVISION}_s390x.deb" \
+  "out/docker-machine-driver-kvm2_${DEB_VERSION}-${DEB_REVISION}_amd64.deb" \
+  "out/docker-machine-driver-kvm2_${DEB_VERSION}-${DEB_REVISION}_arm64.deb"
+
+env BUILD_IN_DOCKER=y
+  make \
   "out/minikube-${RPM_VERSION}-${RPM_REVISION}.x86_64.rpm" \
   "out/minikube-${RPM_VERSION}-${RPM_REVISION}.aarch64.rpm" \
   "out/minikube-${RPM_VERSION}-${RPM_REVISION}.armv7hl.rpm" \
   "out/minikube-${RPM_VERSION}-${RPM_REVISION}.ppc64le.rpm" \
   "out/minikube-${RPM_VERSION}-${RPM_REVISION}.s390x.rpm" \
-  "out/docker-machine-driver-kvm2_${DEB_VERSION}-${DEB_REVISION}_amd64.deb" \
-  "out/docker-machine-driver-kvm2_${DEB_VERSION}-${DEB_REVISION}_arm64.deb" \
   "out/docker-machine-driver-kvm2-${RPM_VERSION}-${RPM_REVISION}.x86_64.rpm"
 
 # check if 'commit: <commit-id>' line contains '-dirty' commit suffix


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/minikube/issues/18947

Running into concurrency issues when building RPM, running the RPM builds one at a time.