### PR TITLE
skip boilerplate check for minikube-image-benchmark submodule

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -45,7 +45,7 @@ then
     readonly BDIR="${ROOT_DIR}/hack/boilerplate"
     pushd . >/dev/null
     cd ${BDIR}
-    missing="$(go run boilerplate.go -rootdir ${ROOT_DIR} -boilerplate-dir ${BDIR} | grep -E -v '/assets.go|/translations.go|/site/themes/|/site/node_modules|\./out|/hugo/|hack/benchmark/time-to-k8s/time-to-k8s-repo' || true)"
+    missing="$(go run boilerplate.go -rootdir ${ROOT_DIR} -boilerplate-dir ${BDIR} | grep -E -v '/assets.go|/translations.go|/site/themes/|/site/node_modules|\./out|/hugo/|hack/benchmark/time-to-k8s/time-to-k8s-repo|hack/benchmark/image-build/minikube-image-benchmark' || true)"
     if [[ -n "${missing}" ]]; then
         echo "boilerplate missing: $missing"
         echo "consider running: ${BDIR}/fix.sh"


### PR DESCRIPTION
to avoid `make test` errors, we should skip checking minikube-image-benchmark submodule for missing boilerplate

### before

```
$ make clean && make test
rm -rf /home/prezha/dev/Kubernetes/minikube/github.com/prezha/minikube/out
rm -f pkg/minikube/assets/assets.go
rm -f pkg/minikube/translate/translations.go
rm -rf ./vendor
rm -rf /tmp/tmp.*.minikube_*
MINIKUBE_LDFLAGS="-X k8s.io/minikube/pkg/version.version=v1.33.1 -X k8s.io/minikube/pkg/version.isoVersion=v1.33.1-1715968808-18896 -X k8s.io/minikube/pkg/version.gitCommitID="f72619a476a802bfd1827e0b75623bcc42cb0e14" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" ./test.sh
= make lint =============================================================
golangci/golangci-lint info checking GitHub for tag 'v1.58.2'
golangci/golangci-lint info found version: 1.58.2 for v1.58.2/linux/amd64
golangci/golangci-lint info installed out/linters/golangci-lint
WARN [config_reader] The configuration option `linters.errcheck.ignore` is deprecated, please use `linters.errcheck.exclude-functions`.
ok
= go mod ================================================================
ok
= boilerplate ===========================================================
boilerplate missing: /home/prezha/dev/Kubernetes/minikube/github.com/prezha/minikube/hack/benchmark/image-build/minikube-image-benchmark/cmd/benchmark.go
/home/prezha/dev/Kubernetes/minikube/github.com/prezha/minikube/hack/benchmark/image-build/minikube-image-benchmark/pkg/benchmark/benchmark.go
/home/prezha/dev/Kubernetes/minikube/github.com/prezha/minikube/hack/benchmark/image-build/minikube-image-benchmark/pkg/command/command.go
/home/prezha/dev/Kubernetes/minikube/github.com/prezha/minikube/hack/benchmark/image-build/minikube-image-benchmark/pkg/command/docker.go
/home/prezha/dev/Kubernetes/minikube/github.com/prezha/minikube/hack/benchmark/image-build/minikube-image-benchmark/pkg/command/dockerenv.go
/home/prezha/dev/Kubernetes/minikube/github.com/prezha/minikube/hack/benchmark/image-build/minikube-image-benchmark/pkg/command/dockerregistry.go
/home/prezha/dev/Kubernetes/minikube/github.com/prezha/minikube/hack/benchmark/image-build/minikube-image-benchmark/pkg/command/imagebuild.go
/home/prezha/dev/Kubernetes/minikube/github.com/prezha/minikube/hack/benchmark/image-build/minikube-image-benchmark/pkg/command/imageload.go
/home/prezha/dev/Kubernetes/minikube/github.com/prezha/minikube/hack/benchmark/image-build/minikube-image-benchmark/pkg/command/k3d.go
/home/prezha/dev/Kubernetes/minikube/github.com/prezha/minikube/hack/benchmark/image-build/minikube-image-benchmark/pkg/command/kind.go
/home/prezha/dev/Kubernetes/minikube/github.com/prezha/minikube/hack/benchmark/image-build/minikube-image-benchmark/pkg/command/microk8s.go
/home/prezha/dev/Kubernetes/minikube/github.com/prezha/minikube/hack/benchmark/image-build/minikube-image-benchmark/pkg/command/minikube.go
/home/prezha/dev/Kubernetes/minikube/github.com/prezha/minikube/hack/benchmark/image-build/minikube-image-benchmark/pkg/command/registry.go
/home/prezha/dev/Kubernetes/minikube/github.com/prezha/minikube/hack/benchmark/image-build/minikube-image-benchmark/pkg/csv/csv.go
/home/prezha/dev/Kubernetes/minikube/github.com/prezha/minikube/hack/benchmark/image-build/minikube-image-benchmark/pkg/download/download.go
/home/prezha/dev/Kubernetes/minikube/github.com/prezha/minikube/hack/benchmark/image-build/minikube-image-benchmark/pkg/download/minikube.go
/home/prezha/dev/Kubernetes/minikube/github.com/prezha/minikube/hack/benchmark/image-build/minikube-image-benchmark/testdata/exampleApp/main.go
consider running: /home/prezha/dev/Kubernetes/minikube/github.com/prezha/minikube/hack/boilerplate/fix.sh
= schema_check ==========================================================
ok
= go test ===============================================================
ok      k8s.io/minikube/cmd/minikube/cmd        0.107s  coverage: 20.0% of statements
ok      k8s.io/minikube/cmd/minikube/cmd/config 0.116s  coverage: 23.6% of statements
ok      k8s.io/minikube/pkg/addons      0.063s  coverage: 26.1% of statements
ok      k8s.io/minikube/pkg/drivers     0.006s  coverage: 42.3% of statements
ok      k8s.io/minikube/pkg/drivers/hyperkit    0.003s  coverage: 77.3% of statements
ok      k8s.io/minikube/pkg/drivers/kic/oci     6.027s  coverage: 19.1% of statements
ok      k8s.io/minikube/pkg/drivers/kvm 0.050s  coverage: 4.1% of statements
ok      k8s.io/minikube/pkg/minikube/assets     0.028s  coverage: 29.0% of statements
ok      k8s.io/minikube/pkg/minikube/audit      0.016s  coverage: 77.0% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper       1.188s  coverage: 42.1% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper/bsutil        0.062s  coverage: 63.9% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper/bsutil/ktmpl  0.003s  coverage: 100.0% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper/images        0.025s  coverage: 73.8% of statements
ok      k8s.io/minikube/pkg/minikube/cluster    0.049s  coverage: 12.0% of statements
ok      k8s.io/minikube/pkg/minikube/cni        0.036s  coverage: 8.7% of statements
ok      k8s.io/minikube/pkg/minikube/command    0.017s  coverage: 11.7% of statements
ok      k8s.io/minikube/pkg/minikube/config     0.016s  coverage: 67.0% of statements
ok      k8s.io/minikube/pkg/minikube/cruntime   0.038s  coverage: 29.3% of statements
ok      k8s.io/minikube/pkg/minikube/docker     0.017s  coverage: 20.8% of statements
ok      k8s.io/minikube/pkg/minikube/download   1.024s  coverage: 27.2% of statements
ok      k8s.io/minikube/pkg/minikube/driver     0.015s  coverage: 44.2% of statements
ok      k8s.io/minikube/pkg/minikube/driver/auxdriver   0.017s  coverage: 19.0% of statements
ok      k8s.io/minikube/pkg/minikube/extract    0.003s  coverage: 56.9% of statements
ok      k8s.io/minikube/pkg/minikube/image      0.013s  coverage: 5.4% of statements
ok      k8s.io/minikube/pkg/minikube/kubeconfig 0.020s  coverage: 78.3% of statements
ok      k8s.io/minikube/pkg/minikube/localpath  0.003s  coverage: 47.4% of statements
ok      k8s.io/minikube/pkg/minikube/logs       0.028s  coverage: 5.4% of statements
ok      k8s.io/minikube/pkg/minikube/machine    0.040s  coverage: 20.3% of statements
ok      k8s.io/minikube/pkg/minikube/mustload   0.037s  coverage: 6.4% of statements
ok      k8s.io/minikube/pkg/minikube/notify     0.103s  coverage: 79.8% of statements
ok      k8s.io/minikube/pkg/minikube/out        0.023s  coverage: 68.2% of statements
ok      k8s.io/minikube/pkg/minikube/out/register       0.010s  coverage: 55.4% of statements
ok      k8s.io/minikube/pkg/minikube/perf       4.016s  coverage: 20.7% of statements
ok      k8s.io/minikube/pkg/minikube/proxy      0.012s  coverage: 74.0% of statements
ok      k8s.io/minikube/pkg/minikube/reason     0.007s  coverage: 70.0% of statements
ok      k8s.io/minikube/pkg/minikube/registry   0.012s  coverage: 78.8% of statements
ok      k8s.io/minikube/pkg/minikube/registry/drvs/docker       0.026s  coverage: 50.4% of statements
ok      k8s.io/minikube/pkg/minikube/service    5.272s  coverage: 76.6% of statements
ok      k8s.io/minikube/pkg/minikube/shell      0.005s  coverage: 94.4% of statements
ok      k8s.io/minikube/pkg/minikube/storageclass       0.019s  coverage: 100.0% of statements
ok      k8s.io/minikube/pkg/minikube/style      0.002s  coverage: 100.0% of statements
ok      k8s.io/minikube/pkg/minikube/sysinit    0.013s  coverage: 5.9% of statements
ok      k8s.io/minikube/pkg/minikube/translate  0.044s  coverage: 27.6% of statements
ok      k8s.io/minikube/pkg/minikube/tunnel     1.440s  coverage: 63.8% of statements
ok      k8s.io/minikube/pkg/network     0.003s  coverage: 75.5% of statements
ok      k8s.io/minikube/pkg/util        0.655s  coverage: 79.9% of statements
ok      k8s.io/minikube/pkg/util/lock   0.002s  coverage: 10.0% of statements
ok      k8s.io/minikube/pkg/util/retry  0.002s  coverage: 0.0% of statements
ok
make: *** [Makefile:400: test] Error 8
```

### after

```
$ make clean && make test
rm -rf /home/prezha/dev/Kubernetes/minikube/github.com/prezha/minikube/out
rm -f pkg/minikube/assets/assets.go
rm -f pkg/minikube/translate/translations.go
rm -rf ./vendor
rm -rf /tmp/tmp.*.minikube_*
MINIKUBE_LDFLAGS="-X k8s.io/minikube/pkg/version.version=v1.33.1 -X k8s.io/minikube/pkg/version.isoVersion=v1.33.1-1715968808-18896 -X k8s.io/minikube/pkg/version.gitCommitID="f72619a476a802bfd1827e0b75623bcc42cb0e14-dirty" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" ./test.sh
= make lint =============================================================
golangci/golangci-lint info checking GitHub for tag 'v1.58.2'
golangci/golangci-lint info found version: 1.58.2 for v1.58.2/linux/amd64
golangci/golangci-lint info installed out/linters/golangci-lint
WARN [config_reader] The configuration option `linters.errcheck.ignore` is deprecated, please use `linters.errcheck.exclude-functions`.
ok
= go mod ================================================================
ok
= boilerplate ===========================================================
ok
= schema_check ==========================================================
ok
= go test ===============================================================
ok      k8s.io/minikube/cmd/minikube/cmd        0.092s  coverage: 20.0% of statements
ok      k8s.io/minikube/cmd/minikube/cmd/config 0.094s  coverage: 23.6% of statements
ok      k8s.io/minikube/pkg/addons      0.056s  coverage: 26.1% of statements
ok      k8s.io/minikube/pkg/drivers     0.005s  coverage: 42.3% of statements
ok      k8s.io/minikube/pkg/drivers/hyperkit    0.003s  coverage: 77.3% of statements
ok      k8s.io/minikube/pkg/drivers/kic/oci     6.021s  coverage: 19.1% of statements
ok      k8s.io/minikube/pkg/drivers/kvm 0.050s  coverage: 4.1% of statements
ok      k8s.io/minikube/pkg/minikube/assets     0.020s  coverage: 29.0% of statements
ok      k8s.io/minikube/pkg/minikube/audit      0.013s  coverage: 77.0% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper       0.561s  coverage: 42.1% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper/bsutil        0.064s  coverage: 63.9% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper/bsutil/ktmpl  0.003s  coverage: 100.0% of statements
ok      k8s.io/minikube/pkg/minikube/bootstrapper/images        0.023s  coverage: 73.8% of statements
ok      k8s.io/minikube/pkg/minikube/cluster    0.024s  coverage: 12.0% of statements
ok      k8s.io/minikube/pkg/minikube/cni        0.024s  coverage: 8.7% of statements
ok      k8s.io/minikube/pkg/minikube/command    0.022s  coverage: 11.7% of statements
ok      k8s.io/minikube/pkg/minikube/config     0.013s  coverage: 67.0% of statements
ok      k8s.io/minikube/pkg/minikube/cruntime   0.035s  coverage: 29.3% of statements
ok      k8s.io/minikube/pkg/minikube/docker     0.018s  coverage: 20.8% of statements
ok      k8s.io/minikube/pkg/minikube/download   1.030s  coverage: 27.2% of statements
ok      k8s.io/minikube/pkg/minikube/driver     0.010s  coverage: 44.2% of statements
ok      k8s.io/minikube/pkg/minikube/driver/auxdriver   0.019s  coverage: 19.0% of statements
ok      k8s.io/minikube/pkg/minikube/extract    0.003s  coverage: 56.9% of statements
ok      k8s.io/minikube/pkg/minikube/image      0.013s  coverage: 5.4% of statements
ok      k8s.io/minikube/pkg/minikube/kubeconfig 0.028s  coverage: 78.3% of statements
ok      k8s.io/minikube/pkg/minikube/localpath  0.003s  coverage: 47.4% of statements
ok      k8s.io/minikube/pkg/minikube/logs       0.032s  coverage: 5.4% of statements
ok      k8s.io/minikube/pkg/minikube/machine    0.060s  coverage: 20.3% of statements
ok      k8s.io/minikube/pkg/minikube/mustload   0.041s  coverage: 6.4% of statements
ok      k8s.io/minikube/pkg/minikube/notify     0.100s  coverage: 79.8% of statements
ok      k8s.io/minikube/pkg/minikube/out        0.019s  coverage: 68.2% of statements
ok      k8s.io/minikube/pkg/minikube/out/register       0.011s  coverage: 55.4% of statements
ok      k8s.io/minikube/pkg/minikube/perf       4.020s  coverage: 20.7% of statements
ok      k8s.io/minikube/pkg/minikube/proxy      0.010s  coverage: 74.0% of statements
ok      k8s.io/minikube/pkg/minikube/reason     0.008s  coverage: 70.0% of statements
ok      k8s.io/minikube/pkg/minikube/registry   0.011s  coverage: 78.8% of statements
ok      k8s.io/minikube/pkg/minikube/registry/drvs/docker       0.021s  coverage: 50.4% of statements
ok      k8s.io/minikube/pkg/minikube/service    3.679s  coverage: 76.6% of statements
ok      k8s.io/minikube/pkg/minikube/shell      0.004s  coverage: 94.4% of statements
ok      k8s.io/minikube/pkg/minikube/storageclass       0.017s  coverage: 100.0% of statements
ok      k8s.io/minikube/pkg/minikube/style      0.001s  coverage: 100.0% of statements
ok      k8s.io/minikube/pkg/minikube/sysinit    0.014s  coverage: 5.9% of statements
ok      k8s.io/minikube/pkg/minikube/translate  0.053s  coverage: 27.6% of statements
ok      k8s.io/minikube/pkg/minikube/tunnel     1.456s  coverage: 63.8% of statements
ok      k8s.io/minikube/pkg/network     0.003s  coverage: 75.5% of statements
ok      k8s.io/minikube/pkg/util        0.207s  coverage: 79.9% of statements
ok      k8s.io/minikube/pkg/util/lock   0.002s  coverage: 10.0% of statements
ok      k8s.io/minikube/pkg/util/retry  0.002s  coverage: 0.0% of statements
ok
```