### PR TITLE
changed exit codes ExHostUnsupported from 38 to 36 as per code review.

### DIFF
--- a/pkg/minikube/reason/exitcodes.go
+++ b/pkg/minikube/reason/exitcodes.go
@@ -76,7 +76,7 @@ const (
 	ExHostTimeout     = 32
 	ExHostUsage       = 34
 	ExHostNotFound    = 35
-	ExHostUnsupported = 38
+	ExHostUnsupported = 36
 	ExHostPermission  = 37
 	ExHostConfig      = 38
 


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
