### PR TITLE
CI: Bump Go version in auto-update workflow

### DIFF
--- a/.github/workflows/update-volcano-version.yml
+++ b/.github/workflows/update-volcano-version.yml
@@ -6,7 +6,7 @@ on:
     - cron: "0 10 * * 1"
 env:
   GOPROXY: https://proxy.golang.org
-  GO_VERSION: '1.22.1'
+  GO_VERSION: '1.22.3'
 permissions:
   contents: read
 


### PR DESCRIPTION
An old PR was merged, resulting in the Go version being old, simply updating it to match the rest.