### PR TITLE
feat: refactor minikube test bot message

### DIFF
--- a/hack/jenkins/test-flake-chart/report_flakes/main.go
+++ b/hack/jenkins/test-flake-chart/report_flakes/main.go
@@ -33,7 +33,7 @@ const (
 // $2 is the ROOT_JOB
 // $3 is the file containing a list of finished environments, one item per line
 func main() {
-	client, err := storage.NewClient(context.TODO())
+	client, err := storage.NewClient(context.Background())
 	if err != nil {
 		fmt.Printf("failed to connect to gcp: %v\n", err)
 		os.Exit(1)

--- a/hack/jenkins/test-flake-chart/report_flakes/main.go
+++ b/hack/jenkins/test-flake-chart/report_flakes/main.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	MaxItemEnv = 10
+	maxItemEnv = 10
 )
 
 // This program requires three arguments
@@ -41,31 +41,31 @@ func main() {
 	}
 	// parse the command line arguments
 	if len(os.Args) != 4 {
-		fmt.Println("Wrong number of arguments. Usage: go run report_flakes.go  <PR number> <Root job id> <environment list file>")
+		fmt.Println("Wrong number of arguments. Usage: go run . <PR number> <Root job id> <environment list file>")
 
 		os.Exit(1)
 	}
 	pr := os.Args[1]
 	rootJob := os.Args[2]
 	// read the environment names
-	envList, err := ParseEnvironmentList(os.Args[3])
+	envList, err := parseEnvironmentList(os.Args[3])
 	if err != nil {
 		fmt.Printf("failed to read %s, err: %v\n", os.Args[3], err)
 		os.Exit(1)
 	}
 	// fetch the test results
-	testSummaries, err := TestSummariesFromGCP(ctx, pr, rootJob, envList, client)
+	testSummaries, err := testSummariesFromGCP(ctx, pr, rootJob, envList, client)
 	if err != nil {
 		fmt.Printf("failed to load summaries: %v\n", err)
 		os.Exit(1)
 	}
 	// fetch the pre-calculated flake rates
-	flakeRates, err := GetFlakeRate(ctx, client)
+	flakeRates, err := flakeRate(ctx, client)
 	if err != nil {
 		fmt.Printf("failed to load flake rates: %v\n", err)
 		os.Exit(1)
 	}
 	// generate and send the message
-	msg := GenerateCommentMessage(testSummaries, flakeRates, pr, rootJob)
+	msg := generateCommentMessage(testSummaries, flakeRates, pr, rootJob)
 	fmt.Println(msg)
 }

--- a/hack/jenkins/test-flake-chart/report_flakes/main.go
+++ b/hack/jenkins/test-flake-chart/report_flakes/main.go
@@ -58,7 +58,6 @@ func main() {
 	if err != nil {
 		fmt.Printf("failed to load summaries: %v\n", err)
 		os.Exit(1)
-
 	}
 	// fetch the pre-calculated flake rates
 	flakeRates, err := GetFlakeRate(client)

--- a/hack/jenkins/test-flake-chart/report_flakes/main.go
+++ b/hack/jenkins/test-flake-chart/report_flakes/main.go
@@ -43,7 +43,6 @@ func main() {
 		fmt.Println("Wrong number of arguments. Usage: go run report_flakes.go  <PR number> <Root job id> <environment list file>")
 
 		os.Exit(1)
-
 	}
 	pr := os.Args[1]
 	rootJob := os.Args[2]

--- a/hack/jenkins/test-flake-chart/report_flakes/main.go
+++ b/hack/jenkins/test-flake-chart/report_flakes/main.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	MAX_ITEM_ENV = 10
+	MaxItemEnv = 10
 )
 
 // This program requires three arguments
@@ -33,6 +33,7 @@ const (
 // $2 is the ROOT_JOB
 // $3 is the file containing a list of finished environments, one item per line
 func main() {
+	ctx := context.Background()
 	client, err := storage.NewClient(context.Background())
 	if err != nil {
 		fmt.Printf("failed to connect to gcp: %v\n", err)
@@ -53,15 +54,15 @@ func main() {
 		os.Exit(1)
 	}
 	// fetch the test results
-	testSummaries, err := GetTestSummariesFromGcp(pr, rootJob, envList, client)
+	testSummaries, err := TestSummariesFromGCP(ctx, pr, rootJob, envList, client)
 	if err != nil {
 		fmt.Printf("failed to load summaries: %v\n", err)
 		os.Exit(1)
 	}
 	// fetch the pre-calculated flake rates
-	flakeRates, err := GetFlakeRate(client)
+	flakeRates, err := GetFlakeRate(ctx, client)
 	if err != nil {
-		fmt.Println("failed to load flake rates: %v", err)
+		fmt.Printf("failed to load flake rates: %v\n", err)
 		os.Exit(1)
 	}
 	// generate and send the message

--- a/hack/jenkins/test-flake-chart/report_flakes/main.go
+++ b/hack/jenkins/test-flake-chart/report_flakes/main.go
@@ -34,7 +34,6 @@ const (
 // $3 is the file containing a list of finished environments, one item per line
 func main() {
 	client, err := storage.NewClient(context.TODO())
-
 	if err != nil {
 		fmt.Printf("failed to connect to gcp: %v\n", err)
 		os.Exit(1)

--- a/hack/jenkins/test-flake-chart/report_flakes/main.go
+++ b/hack/jenkins/test-flake-chart/report_flakes/main.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2024 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"cloud.google.com/go/storage"
+)
+
+const (
+	MAX_ITEM_ENV = 10
+)
+
+// This program requires three arguments
+// $1 is the Pr Number
+// $2 is the ROOT_JOB
+// $3 is the file containing a list of finished environments, one item per line
+func main() {
+	client, err := storage.NewClient(context.TODO())
+
+	if err != nil {
+		fmt.Printf("failed to connect to gcp: %v\n", err)
+		os.Exit(1)
+	}
+	// parse the command line arguments
+	if len(os.Args) != 4 {
+		fmt.Println("Wrong number of arguments. Usage: go run report_flakes.go  <PR number> <Root job id> <environment list file>")
+
+		os.Exit(1)
+
+	}
+	pr := os.Args[1]
+	rootJob := os.Args[2]
+	// read the environment names
+	envList, err := ParseEnvironmentList(os.Args[3])
+	if err != nil {
+		fmt.Printf("failed to read %s, err: %v\n", os.Args[3], err)
+		os.Exit(1)
+	}
+	// fetch the test results
+	testSummaries, err := GetTestSummariesFromGcp(pr, rootJob, envList, client)
+	if err != nil {
+		fmt.Printf("failed to load summaries: %v\n", err)
+		os.Exit(1)
+
+	}
+	// fetch the pre-calculated flake rates
+	flakeRates, err := GetFlakeRate(client)
+	if err != nil {
+		fmt.Println("failed to load flake rates: %v", err)
+		os.Exit(1)
+	}
+	// generate and send the message
+	msg := GenerateCommentMessage(testSummaries, flakeRates, pr, rootJob)
+	fmt.Println(msg)
+}

--- a/hack/jenkins/test-flake-chart/report_flakes/report_flake.go
+++ b/hack/jenkins/test-flake-chart/report_flakes/report_flake.go
@@ -231,7 +231,8 @@ func gopoghMDLink(pr, rootJob, env, testName string) string {
 	return fmt.Sprintf("[(gopogh)](https://storage.googleapis.com/minikube-builds/logs/%s/%s/%s.html#%s)", pr, rootJob, env, testName)
 }
 
-// generateMarkdownTable convert 2d string slice into markdown table. The first string slice is the header of the table
+// generateMarkdownTable convert 2d string slice into markdown table. The first
+// string slice is the header of the table
 func generateMarkdownTable(table [][]string) string {
 	builder := strings.Builder{}
 	for i, group := range table {

--- a/hack/jenkins/test-flake-chart/report_flakes/report_flake.go
+++ b/hack/jenkins/test-flake-chart/report_flakes/report_flake.go
@@ -185,9 +185,9 @@ func generateCommentMessage(summaries map[string]*shortSummary, flakeRates map[s
 		for i, item := range list {
 			if item.flakeRate > 50 {
 				if i == 0 {
-					// if this is the first failed test
-					// that means each tests in this env
-					// has a flakerate>50% and all of them will
+					// if this is the first failed test that
+					// means each tests in this env has a
+					// flakerate>50% and all of them will
 					// not be shown in the table
 					foldedFailures = append(foldedFailures, env)
 				}

--- a/hack/jenkins/test-flake-chart/report_flakes/report_flake.go
+++ b/hack/jenkins/test-flake-chart/report_flakes/report_flake.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2024 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"cloud.google.com/go/storage"
+)
+
+type ShortSummary struct {
+	NumberOfTests int
+	NumberOfFail  int
+	NumberOfPass  int
+	NumberOfSkip  int
+	FailedTests   []string
+	PassedTests   []string
+	SkippedTests  []string
+	Durations     map[string]float64
+	TotalDuration float64
+	GopoghVersion string
+	GopoghBuild   string
+	Detail        struct {
+		Name     string
+		Details  string
+		PR       string
+		RepoName string
+	}
+}
+
+// ParseEnvironmentList read the existing environments from the file
+func ParseEnvironmentList(listFile string) ([]string, error) {
+	data, err := os.ReadFile(listFile)
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(strings.TrimSpace(string(data)), "\n"), nil
+}
+
+func GetTestSummariesFromGcp(pr, rootJob string, envList []string, client *storage.Client) (map[string]*ShortSummary, error) {
+	envToSummaries := map[string]*ShortSummary{}
+	for _, env := range envList {
+		if summary, err := getTestSummaryFromGCP(pr, rootJob, env, client); err == nil {
+			if summary != nil {
+				// if the summary is nil(missing) we just skip it
+				envToSummaries[env] = summary
+			}
+		} else {
+			return nil, fmt.Errorf("failed to fetch %s test summary from gcp, err: %v", env, err)
+		}
+	}
+	return envToSummaries, nil
+}
+
+// getFromSummary get the summary of a test on the specified env from the specified summary.
+func getTestSummaryFromGCP(pr, rootJob, env string, client *storage.Client) (*ShortSummary, error) {
+	ctx := context.TODO()
+
+	btk := client.Bucket("minikube-builds")
+	obj := btk.Object(fmt.Sprintf("logs/%s/%s/%s_summary.json", pr, rootJob, env))
+
+	reader, err := obj.NewReader(ctx)
+	if err != nil {
+		if err == storage.ErrObjectNotExist {
+			// if this file does not exist, just skip it
+			return nil, nil
+		}
+		return nil, err
+	}
+	// read the file
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	var summary ShortSummary
+	if err = json.Unmarshal(data, &summary); err != nil {
+		return nil, fmt.Errorf("failed to deserialize the file: %v", err)
+	}
+	return &summary, nil
+
+}
+
+// GetFlakeRate downloaded recent flake rate from gcs, and return the map{env->map{testname->flake rate}}
+func GetFlakeRate(client *storage.Client) (map[string]map[string]float64, error) {
+	btk := client.Bucket("minikube-flake-rate")
+	obj := btk.Object("flake_rates.csv")
+	reader, err := obj.NewReader(context.TODO())
+	if err != nil {
+		return nil, fmt.Errorf("failed to read the flake rate file: %v", err)
+	}
+	// parse the csv file to the map
+	records, err := csv.NewReader(reader).ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read and parse the flake rate file: %v", err)
+	}
+	result := map[string]map[string]float64{}
+	for i := 1; i < len(records); i++ {
+		// for each line in csv we extract env, test name and flake rate
+		env := records[i][0]
+		test := records[i][1]
+		flakeRate, err := strconv.ParseFloat(records[i][2], 64)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse the flake rate file at line %d: %v", i+1, err)
+		}
+		if _, ok := result[env]; !ok {
+			result[env] = make(map[string]float64, 0)
+		}
+		result[env][test] = flakeRate
+	}
+	return result, nil
+}
+
+func GenerateCommentMessage(summaries map[string]*ShortSummary, flakeRates map[string]map[string]float64, pr, rootJob string) string {
+	//builder := strings.Builder{}
+	type failedTest struct {
+		flakeRate float64
+		env       string
+		testName  string
+	}
+	// for each environment, we sort failed tests according to the flake rate of that test on master branch
+	envFailedTestList := map[string][]failedTest{}
+	for env, summary := range summaries {
+		failedTestList := []failedTest{}
+		for _, test := range summary.FailedTests {
+			// if we cannot find the test, we assign the flake rate as -1, meaning N/A
+			var flakerate float64 = -1.0
+			if _, ok := flakeRates[env]; ok {
+				if v, ok := flakeRates[env][test]; ok {
+					flakerate = v
+				}
+			}
+			failedTestList = append(failedTestList,
+				failedTest{
+					flakeRate: flakerate,
+					env:       env,
+					testName:  test,
+				})
+		}
+
+		sort.Slice(failedTestList, func(i, j int) bool {
+			return failedTestList[i].flakeRate < failedTestList[j].flakeRate
+		})
+		envFailedTestList[env] = failedTestList
+	}
+	// we convert the result into a 2d string slice representing a markdown table,
+	// whose each line represents a line of the table
+	table := [][]string{
+		// title of the table
+		{"Environment", "Test Name", "Flake Rate"},
+	}
+	// if an env has too much failures we will just skip it and print a message in the end
+	tooMuchFailure := []string{}
+	for env, list := range envFailedTestList {
+		if len(list) > MAX_ITEM_ENV {
+			tooMuchFailure = append(tooMuchFailure, env)
+			continue
+		}
+		for _, item := range list {
+			flakeRateString := fmt.Sprintf("%.2f%% %s", item.flakeRate, testFlakeChartMDLink(env, item.testName))
+			if item.flakeRate < 0 {
+				flakeRateString = "Unknown"
+			}
+			table = append(table, []string{
+				envChartMDLink(env, len(list)),
+				item.testName + gopoghMDLink(pr, rootJob, env, item.testName),
+				flakeRateString,
+			})
+		}
+	}
+
+	builder := strings.Builder{}
+	builder.WriteString(
+		fmt.Sprintf("Here are the number of top %d failed tests in each environments with lowest flake rate.\n\n", MAX_ITEM_ENV))
+	builder.WriteString(generateMarkdownTable(table))
+	if len(tooMuchFailure) > 0 {
+
+		builder.WriteString("\n\n Besides the following environments have too much failed tests:")
+		for _, env := range tooMuchFailure {
+			builder.WriteString(fmt.Sprintf("\n\n - %s: %d failed", env, len(envFailedTestList[env])))
+		}
+	}
+	builder.WriteString("\n\nTo see the flake rates of all tests by environment, click [here](https://minikube.sigs.k8s.io/docs/contrib/test_flakes/).")
+	return builder.String()
+}
+func envChartMDLink(env string, failedTestNumber int) string {
+	return fmt.Sprintf("[%s (%d failed)](https://gopogh-server-tts3vkcpgq-uc.a.run.app/?env=%s)", env, failedTestNumber, env)
+}
+
+func testFlakeChartMDLink(env string, testName string) string {
+	return fmt.Sprintf("[(chart)](https://gopogh-server-tts3vkcpgq-uc.a.run.app/?env=%s&test=%s)", env, testName)
+}
+
+func gopoghMDLink(pr, rootJob, env, testName string) string {
+	return fmt.Sprintf("[(gopogh)](https://storage.googleapis.com/minikube-builds/logs/%s/%s/%s.html#%s)", pr, rootJob, env, testName)
+}
+
+// generateMarkdownTable convert 2d string slice into markdown table. The first string slice is the header of the table
+func generateMarkdownTable(table [][]string) string {
+	builder := strings.Builder{}
+	for i, group := range table {
+		builder.WriteString("|")
+		for j := 0; j < len(group); j++ {
+			builder.WriteString(group[j])
+			builder.WriteString("|")
+		}
+		builder.WriteString("\n")
+
+		if i == 0 {
+			// generate the hyphens seperator
+			builder.WriteString("|")
+			for j := 0; j < len(group); j++ {
+				builder.WriteString(" ---- |")
+			}
+			builder.WriteString("\n")
+		}
+	}
+	builder.WriteString("\n\n")
+	return builder.String()
+
+}

--- a/hack/jenkins/test-flake-chart/report_flakes/report_flake.go
+++ b/hack/jenkins/test-flake-chart/report_flakes/report_flake.go
@@ -146,7 +146,7 @@ func GenerateCommentMessage(summaries map[string]*ShortSummary, flakeRates map[s
 		failedTestList := []failedTest{}
 		for _, test := range summary.FailedTests {
 			// if we cannot find the test, we assign the flake rate as -1, meaning N/A
-			var flakerate float64 = -1.0
+			flakerate := -1.0
 			if _, ok := flakeRates[env]; ok {
 				if v, ok := flakeRates[env][test]; ok {
 					flakerate = v

--- a/hack/jenkins/test-flake-chart/report_flakes/report_flake.go
+++ b/hack/jenkins/test-flake-chart/report_flakes/report_flake.go
@@ -150,7 +150,8 @@ func generateCommentMessage(summaries map[string]*shortSummary, flakeRates map[s
 	for env, summary := range summaries {
 		failedTestList := []failedTest{}
 		for _, test := range summary.FailedTests {
-			// if we cannot find the test, we assign the flake rate as -1, meaning N/A
+			// if we cannot find the test, we assign the flake rate
+			// as -1, meaning N/A
 			flakerate := unknown
 			if v, ok := flakeRates[env][test]; ok {
 				flakerate = v

--- a/hack/jenkins/test-flake-chart/report_flakes/report_flake.go
+++ b/hack/jenkins/test-flake-chart/report_flakes/report_flake.go
@@ -59,7 +59,7 @@ func ParseEnvironmentList(listFile string) ([]string, error) {
 	return strings.Split(strings.TrimSpace(string(data)), "\n"), nil
 }
 
-func GetTestSummariesFromGcp(pr, rootJob string, envList []string, client *storage.Client) (map[string]*ShortSummary, error) {
+func TestSummariesFromGCP(pr, rootJob string, envList []string, client *storage.Client) (map[string]*ShortSummary, error) {
 	envToSummaries := map[string]*ShortSummary{}
 	for _, env := range envList {
 		if summary, err := getTestSummaryFromGCP(pr, rootJob, env, client); err == nil {

--- a/hack/jenkins/test-flake-chart/report_flakes/report_flake.go
+++ b/hack/jenkins/test-flake-chart/report_flakes/report_flake.go
@@ -174,8 +174,9 @@ func generateCommentMessage(summaries map[string]*shortSummary, flakeRates map[s
 		// title of the table
 		{"Environment", "Test Name", "Flake Rate"},
 	}
-	// if an env has too much failures we will just skip it and print a message in the end
-	// if the failed tests have high flake rates(over 50% for all), it will also be skipped in the table
+	// if an env has too many failures we will just skip it and print a
+	// message in the end if the failed tests have high flake rates (over
+	// 50% for all), it will also be skipped in the table
 	foldedFailures := []string{}
 	for env, list := range envFailedTestList {
 		if len(list) > maxItemEnv {

--- a/hack/jenkins/test-flake-chart/report_flakes/report_flake.go
+++ b/hack/jenkins/test-flake-chart/report_flakes/report_flake.go
@@ -107,7 +107,7 @@ func getTestSummaryFromGCP(pr, rootJob, env string, client *storage.Client) (*Sh
 func GetFlakeRate(client *storage.Client) (map[string]map[string]float64, error) {
 	btk := client.Bucket("minikube-flake-rate")
 	obj := btk.Object("flake_rates.csv")
-	reader, err := obj.NewReader(context.TODO())
+	reader, err := obj.NewReader(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("failed to read the flake rate file: %v", err)
 	}

--- a/hack/jenkins/test-flake-chart/report_flakes/report_flake.go
+++ b/hack/jenkins/test-flake-chart/report_flakes/report_flake.go
@@ -228,14 +228,15 @@ func generateMarkdownTable(table [][]string) string {
 		}
 		builder.WriteString("\n")
 
-		if i == 0 {
-			// generate the hyphens seperator
-			builder.WriteString("|")
-			for j := 0; j < len(group); j++ {
-				builder.WriteString(" ---- |")
-			}
-			builder.WriteString("\n")
+		if i != 0 {
+			continue
 		}
+		// generate the hyphens seperator
+		builder.WriteString("|")
+		for j := 0; j < len(group); j++ {
+			builder.WriteString(" ---- |")
+		}
+		builder.WriteString("\n")
 	}
 	builder.WriteString("\n\n")
 	return builder.String()

--- a/hack/jenkins/test-flake-chart/report_flakes/report_flake.go
+++ b/hack/jenkins/test-flake-chart/report_flakes/report_flake.go
@@ -168,8 +168,8 @@ func generateCommentMessage(summaries map[string]*shortSummary, flakeRates map[s
 		})
 		envFailedTestList[env] = failedTestList
 	}
-	// we convert the result into a 2d string slice representing a markdown table,
-	// whose each line represents a line of the table
+	// we convert the result into a 2d string slice representing a markdown
+	// table, whose each line represents a line of the table
 	table := [][]string{
 		// title of the table
 		{"Environment", "Test Name", "Flake Rate"},

--- a/hack/jenkins/test-flake-chart/sync_tests.sh
+++ b/hack/jenkins/test-flake-chart/sync_tests.sh
@@ -85,7 +85,11 @@ if [[ "${MINIKUBE_LOCATION}" == "master" ]]; then
   done
   "${DIR}/process_last_90/process_last_90.sh"
 else
-  "${DIR}/report_flakes.sh" "${MINIKUBE_LOCATION}" "${ROOT_JOB_ID}" "${FINISHED_LIST}"
+  TMP_COMMENT=$(mktemp)
+  go run "${DIR}/report_flakes" "${MINIKUBE_LOCATION}" "${ROOT_JOB_ID}" "${FINISHED_LIST}"  > "$TMP_COMMENT"
+  # install gh if not present
+  "$DIR/../installers/check_install_gh.sh"
+  gh pr comment "https://github.com/kubernetes/minikube/pull/$MINIKUBE_LOCATION" --body "$(cat $TMP_COMMENT)"
 fi
 
 gsutil rm "${BUCKET_PATH}/finished_environments.txt"


### PR DESCRIPTION

After:

Here are the number of top 10 failed tests in each environments with lowest flake rate.

|Environment|Test Name|Flake Rate|
| ---- | ---- | ---- |
|[Docker_Linux_crio_arm64 (3 failed)](https://gopogh-server-tts3vkcpgq-uc.a.run.app/?env=Docker_Linux_crio_arm64)|TestMultiControlPlane/serial/RestartCluster[(gopogh)](https://storage.googleapis.com/minikube-builds/logs/18896/34526/Docker_Linux_crio_arm64.html#TestMultiControlPlane/serial/RestartCluster)|11.56% [(chart)](https://gopogh-server-tts3vkcpgq-uc.a.run.app/?env=Docker_Linux_crio_arm64&test=TestMultiControlPlane/serial/RestartCluster)|




 Besides the following environments also have failed tests:

 - Docker_Windows: 3 failed [(gopogh)](https://storage.googleapis.com/minikube-builds/logs/18896/34526/Docker_Windows.html#) 

 - Docker_Linux_containerd_arm64: 6 failed [(gopogh)](https://storage.googleapis.com/minikube-builds/logs/18896/34526/Docker_Linux_containerd_arm64.html#) 

 - Hyper-V_Windows: 14 failed [(gopogh)](https://storage.googleapis.com/minikube-builds/logs/18896/34526/Hyper-V_Windows.html#) 

 - Docker_Linux_docker_arm64: 1 failed [(gopogh)](https://storage.googleapis.com/minikube-builds/logs/18896/34526/Docker_Linux_docker_arm64.html#) 

 - Docker_Linux_crio: 2 failed [(gopogh)](https://storage.googleapis.com/minikube-builds/logs/18896/34526/Docker_Linux_crio.html#) 

 - QEMU_macOS: 156 failed [(gopogh)](https://storage.googleapis.com/minikube-builds/logs/18896/34526/QEMU_macOS.html#) 

 - Docker_macOS: 1 failed [(gopogh)](https://storage.googleapis.com/minikube-builds/logs/18896/34526/Docker_macOS.html#) 

 - KVM_Linux_crio: 31 failed [(gopogh)](https://storage.googleapis.com/minikube-builds/logs/18896/34526/KVM_Linux_crio.html#) 

To see the flake rates of all tests by environment, click [here](https://minikube.sigs.k8s.io/docs/contrib/test_flakes/).
