### PR TITLE
site: Update tutorial images to support all architectures

### DIFF
--- a/site/content/en/docs/tutorials/kubernetes_101/module2.md
+++ b/site/content/en/docs/tutorials/kubernetes_101/module2.md
@@ -33,7 +33,7 @@ Here we see the available nodes (1 in our case). Kubernetes will choose where to
 Let's deploy our first app on Kubernetes with the `kubectl create deployment` command. We need to provide the deployment name and app image location (include the full repository url for images hosted outside Docker Hub).
 
 ```shell
-kubectl create deployment kubernetes-bootcamp --image=gcr.io/google-samples/kubernetes-bootcamp:v1
+kubectl create deployment kubernetes-bootcamp --image=gcr.io/k8s-minikube/kubernetes-bootcamp:v1
 ```
 
 Great! You just deployed your first application by creating a deployment. This performed a few things for you:

--- a/site/content/en/docs/tutorials/kubernetes_101/module6.md
+++ b/site/content/en/docs/tutorials/kubernetes_101/module6.md
@@ -31,7 +31,7 @@ kubectl describe pods
 To update the image of the application to version 2, use the `set image` command, followed by the deployment name and the new image version:
 
 ```shell
-kubectl set image deployments/kubernetes-bootcamp kubernetes-bootcamp=jocatalin/kubernetes-bootcamp:v2
+kubectl set image deployments/kubernetes-bootcamp kubernetes-bootcamp=gcr.io/k8s-minikube/kubernetes-bootcamp:v2
 ```
 
 The command notified the Deployment to use a different image for your app and initiated a rolling update. Check the status of the new Pods, and view the old one terminating with the `get pods` command:
@@ -85,7 +85,7 @@ In the `Image` field of the output, verify that you are running the latest image
 Let's perform another update, and deploy an image tagged with `v10`:
 
 ```shell
-kubectl set image deployments/kubernetes-bootcamp kubernetes-bootcamp=gcr.io/google-samples/kubernetes-bootcamp:v10
+kubectl set image deployments/kubernetes-bootcamp kubernetes-bootcamp=gcr.io/k8s-minikube/kubernetes-bootcamp:v10
 ```
 
 Use `get deployments` to see the status of the deployment:


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/18726

Rebuilt the images used in the Kubernetes 101 tutorial since the existing images were only built for amd64.

Source code: https://github.com/spowelljr/kubernetes-bootcamp

Output of `v1`:
```
root@kubernetes-bootcamp-58ddc4d76b-qfq9l:/# curl localhost:8080
Hello Kubernetes bootcamp! | Running on: kubernetes-bootcamp-58ddc4d76b-qfq9l | v=1
```

Output of `v2`:
```
root@kubernetes-bootcamp-v2-7df94fd86-85jbg:/# curl localhost:8080
Hello Kubernetes bootcamp! | Hostname: kubernetes-bootcamp-v2-7df94fd86-85jbg | v=2
```