### PR TITLE
rename nvidia-gpu-device-plugin to kvm-nvidia-gpu

### DIFF
--- a/deploy/addons/aliyun_mirror.json
+++ b/deploy/addons/aliyun_mirror.json
@@ -77,6 +77,7 @@
   "registry.k8s.io/mongodb-install": "registry.cn-hangzhou.aliyuncs.com/google_containers/mongodb-install",
   "registry.k8s.io/nginx-slim": "registry.cn-hangzhou.aliyuncs.com/google_containers/nginx-slim",
   "registry.k8s.io/nvidia-gpu-device-plugin": "registry.cn-hangzhou.aliyuncs.com/google_containers/nvidia-gpu-device-plugin",
+  "registry.k8s.io/kvm-nvidia-gpu": "registry.cn-hangzhou.aliyuncs.com/google_containers/nvidia-gpu-device-plugin",
   "registry.k8s.io/pause": "registry.cn-hangzhou.aliyuncs.com/google_containers/pause",
   "registry.k8s.io/pause-amd64": "registry.cn-hangzhou.aliyuncs.com/google_containers/pause-amd64",
   "registry.k8s.io/spark": "registry.cn-hangzhou.aliyuncs.com/google_containers/spark",

--- a/deploy/addons/assets.go
+++ b/deploy/addons/assets.go
@@ -107,6 +107,10 @@ var (
 	//go:embed gpu/nvidia-gpu-device-plugin.yaml.tmpl
 	NvidiaGpuDevicePluginAssets embed.FS
 
+	// KvmNvidiaGpuAssets assets for kvm-nvidia-gpu addon
+	//go:embed gpu/kvm-nvidia-gpu.yaml.tmpl
+	KvmNvidiaGpuAssets embed.FS
+
 	// LogviewerAssets assets for logviewer addon
 	//go:embed logviewer/*.tmpl logviewer/*.yaml
 	LogviewerAssets embed.FS

--- a/deploy/addons/gpu/kvm-nvidia-gpu.yaml.tmpl
+++ b/deploy/addons/gpu/kvm-nvidia-gpu.yaml.tmpl
@@ -1,0 +1,64 @@
+# Copyright 2018 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kvm-nvidia-gpu
+  namespace: kube-system
+  labels:
+    k8s-app: kvm-nvidia-gpu
+    kubernetes.io/minikube-addons: kvm-nvidia-gpu
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  selector:
+    matchLabels:
+      k8s-app: kvm-nvidia-gpu
+  template:
+    metadata:
+      labels:
+        k8s-app: kvm-nvidia-gpu
+    spec:
+      priorityClassName: system-node-critical
+      tolerations:
+      - operator: "Exists"
+        effect: "NoExecute"
+      - operator: "Exists"
+        effect: "NoSchedule"
+      volumes:
+      - name: device-plugin
+        hostPath:
+          path: /var/lib/kubelet/device-plugins
+      - name: dev
+        hostPath:
+          path: /dev
+      containers:
+      - image: {{.CustomRegistries.NvidiaDevicePlugin  | default .ImageRepository | default .Registries.NvidiaDevicePlugin }}{{.Images.NvidiaDevicePlugin}}
+        command: ["/usr/bin/nvidia-gpu-device-plugin", "-logtostderr"]
+        name: kvm-nvidia-gpu
+        resources:
+          requests:
+            cpu: 50m
+            memory: 10Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        volumeMounts:
+        - name: device-plugin
+          mountPath: /device-plugin
+        - name: dev
+          mountPath: /dev
+  updateStrategy:
+    type: RollingUpdate

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -104,6 +104,8 @@ func preStartMessages(name, value string) {
 		out.Styled(style.Warning, "The ambassador addon has stopped working as of v1.23.0, for more details visit: https://github.com/datawire/ambassador-operator/issues/73")
 	case "olm":
 		out.Styled(style.Warning, "The OLM addon has stopped working, for more details visit: https://github.com/operator-framework/operator-lifecycle-manager/issues/2534")
+	case "nvidia-gpu-device-plugin":
+		out.Styled(style.Warning, "The nvidia-gpu-device-plugin addon is deprecated and will be removed in a future release. Please use the kvm-nvidia-gpu addon instead.for more details visit: https://github.com/kubernetes/minikube/issues/19114")
 	}
 }
 
@@ -163,6 +165,8 @@ func Deprecations(name string) (bool, string, string) {
 		return true, "metrics-server", "using metrics-server addon, heapster is deprecated"
 	case "efk":
 		return true, "", "The current images used in the efk addon contain Log4j vulnerabilities, the addon will be disabled until images are updated, see: https://github.com/kubernetes/minikube/issues/15280"
+	case "nvidia-gpu-device-plugin":
+		return true, "kvm-nvidia-gpu", "The nvidia-gpu-device-plugin addon is deprecated and will be removed in a future release. Please use the kvm-nvidia-gpu addon instead.for more details visit:https://github.com/kubernetes/minikube/issues/19114"
 	}
 	return false, "", ""
 }

--- a/pkg/addons/config.go
+++ b/pkg/addons/config.go
@@ -130,7 +130,13 @@ var Addons = []*Addon{
 		callbacks: []setFn{EnableOrDisableAddon},
 	},
 	{
+		// Deprecated, will be removed in a future release in favor of kvm-nvidia-gpu
 		name:      "nvidia-gpu-device-plugin",
+		set:       SetBool,
+		callbacks: []setFn{EnableOrDisableAddon},
+	},
+	{
+		name:      "kvm-nvidia-gpu",
 		set:       SetBool,
 		callbacks: []setFn{EnableOrDisableAddon},
 	},

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -493,6 +493,17 @@ var Addons = map[string]*Addon{
 	}, map[string]string{
 		"NvidiaDevicePlugin": "registry.k8s.io",
 	}),
+	"kvm-nvidia-gpu": NewAddon([]*BinAsset{
+		MustBinAsset(addons.KvmNvidiaGpuAssets,
+			"gpu/kvm-nvidia-gpu.yaml.tmpl",
+			vmpath.GuestAddonsDir,
+			"kvm-nvidia-gpu.yaml",
+			"0640"),
+	}, false, "kvm-nvidia-gpu", "3rd party (NVIDIA)", "", "https://minikube.sigs.k8s.io/docs/tutorials/nvidia/", map[string]string{
+		"NvidiaDevicePlugin": "nvidia-gpu-device-plugin@sha256:4b036e8844920336fa48f36edeb7d4398f426d6a934ba022848deed2edbf09aa",
+	}, map[string]string{
+		"NvidiaDevicePlugin": "registry.k8s.io",
+	}),
 	"logviewer": NewAddon([]*BinAsset{
 		MustBinAsset(addons.LogviewerAssets,
 			"logviewer/logviewer-dp-and-svc.yaml.tmpl",

--- a/site/content/en/docs/tutorials/nvidia.md
+++ b/site/content/en/docs/tutorials/nvidia.md
@@ -59,8 +59,9 @@ to expose GPUs with `--driver=kvm`. Please don't mix these instructions.
 
 - Install NVIDIA's device plugin:
   ```shell
-  minikube addons enable nvidia-device-plugin
+  minikube addons enable kvm-nvidia-gpu
   ```
+  NOTE: `nvidia-gpu-device-plugin` has been deprecated in favor of `kvm-nvidia-gpu`.
 {{% /tab %}}
 {{% tab kvm %}}
 ## Using the kvm driver
@@ -102,9 +103,10 @@ host to the minikube VM. Doing so has a few prerequisites:
 
   If this succeeded, run the following commands:
   ```shell
-  minikube addons enable nvidia-gpu-device-plugin
+  minikube addons enable kvm-nvidia-gpu
   minikube addons enable nvidia-driver-installer
   ```
+  NOTE: `nvidia-gpu-device-plugin` has been deprecated in favor of `kvm-nvidia-gpu`.
 
   This will install the NVIDIA driver (that works for GeForce/Quadro cards)
   on the VM.


### PR DESCRIPTION
related to : https://github.com/kubernetes/minikube/issues/19114
- deprecated `nvidia-gpu-device-plugin` and added warning message
- Added new addon `kvm-nvidia-gpu` as a replacement of `nvidia-gpu-device-plugin`

Starting minikube with `nvidia-gpu-device-plugin` addon:
```
😄  minikube v1.33.1 on Darwin 12.6
✨  Automatically selected the docker driver. Other choices: virtualbox, ssh
📌  Using Docker Desktop driver with root privileges
👍  Starting "minikube" primary control-plane node in "minikube" cluster
🚜  Pulling base image v0.0.44-1718923403-19112 ...
💾  Downloading Kubernetes v1.30.2 preload ...
    > preloaded-images-k8s-v18-v1...:  319.86 MiB / 319.86 MiB  100.00% 30.60 M
    > index.docker.io/kicbase/bui...:  481.85 MiB / 481.85 MiB  100.00% 20.89 M



❗  minikube was unable to download gcr.io/k8s-minikube/kicbase-builds:v0.0.44-1718923403-19112, but successfully downloaded docker.io/kicbase/build:v0.0.44-1718923403-19112 as a fallback image
🔥  Creating docker container (CPUs=2, Memory=3866MB) ...
🐳  Preparing Kubernetes v1.30.2 on Docker 26.1.4 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
⌛  The nvidia-gpu-device-plugin addon is deprecated and will be removed in a future release. Please use the kvm-nvidia-gpu addon instead.for more details visit:https://github.com/kubernetes/minikube/issues/19114
🔎  Verifying Kubernetes components...
    ▪ Using image registry.k8s.io/nvidia-gpu-device-plugin
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, kvm-nvidia-gpu, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```
Starting `nvidia-gpu-device-plugin` addon after start:
```
 ./out/minikube-darwin-amd64 addons enable nvidia-gpu-device-plugin                                                (27m) 17:24:38 
⌛  The nvidia-gpu-device-plugin addon is deprecated and will be removed in a future release. Please use the kvm-nvidia-gpu addon instead.for more details visit:https://github.com/kubernetes/minikube/issues/19114
❗  kvm-nvidia-gpu is a 3rd party addon and is not maintained or verified by minikube maintainers, enable at your own risk.
❗  kvm-nvidia-gpu does not currently have an associated maintainer.
    ▪ Using image registry.k8s.io/nvidia-gpu-device-plugin
🌟  The 'kvm-nvidia-gpu' addon is enabled

```
Starting minikube with `kvm-nvidia-gpu` addon:
```
./out/minikube-darwin-amd64 start --addons=kvm-nvidia-gpu                                                         (20m) 17:18:00 
😄  minikube v1.33.1 on Darwin 12.6
✨  Using the docker driver based on existing profile
👍  Starting "minikube" primary control-plane node in "minikube" cluster
🚜  Pulling base image v0.0.44-1718923403-19112 ...
🏃  Updating the running docker "minikube" container ...
🐳  Preparing Kubernetes v1.30.2 on Docker 26.1.4 ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
    ▪ Using image registry.k8s.io/nvidia-gpu-device-plugin
🌟  Enabled addons: kvm-nvidia-gpu, storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```
Starting `kvm-nvidia-gpu` addon after start:
```
./out/minikube-darwin-amd64 addons enable kvm-nvidia-gpu                                                          (31m) 17:28:38 
❗  kvm-nvidia-gpu is a 3rd party addon and is not maintained or verified by minikube maintainers, enable at your own risk.
❗  kvm-nvidia-gpu does not currently have an associated maintainer.
    ▪ Using image registry.k8s.io/nvidia-gpu-device-plugin
🌟  The 'kvm-nvidia-gpu' addon is enabled

```
