### PR TITLE
testing: Use multi-arch example app image

### DIFF
--- a/deploy/addons/ingress-dns/example/example.yaml
+++ b/deploy/addons/ingress-dns/example/example.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: hello-world-app
-          image: gcr.io/google-samples/hello-app:1.0
+          image: docker.io/kicbase/echo-server:1.0
           ports:
             - containerPort: 8080
 ---

--- a/test/integration/testdata/ingress-dns-example-v1.yaml
+++ b/test/integration/testdata/ingress-dns-example-v1.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: hello-world-app
-        image: gcr.io/google-samples/hello-app:1.0
+        image: docker.io/kicbase/echo-server:1.0
         ports:
         - containerPort: 8080
 ---

--- a/test/integration/testdata/ingress-dns-example-v1beta1.yaml
+++ b/test/integration/testdata/ingress-dns-example-v1beta1.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: hello-world-app
-        image: gcr.io/google-samples/hello-app:1.0
+        image: docker.io/kicbase/echo-server:1.0
         ports:
         - containerPort: 8080
 ---


### PR DESCRIPTION
Part of the fix for getting Ingress Addon tests passing on arm64, other changes are required also