### PR TITLE
Fixed not creating API server tunnel

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -444,6 +444,8 @@ func (k *Bootstrapper) tunnelToAPIServer(cfg config.ClusterConfig) error {
 	if cfg.APIServerPort == 0 {
 		return fmt.Errorf("apiserver port not set")
 	}
+	// An API server tunnel is only needed for QEMU w/ builtin network, for
+	// everything else return
 	if !driver.IsQEMU(cfg.Driver) || !network.IsBuiltinQEMU(cfg.Network) {
 		return nil
 	}

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -440,7 +440,7 @@ func (k *Bootstrapper) StartCluster(cfg config.ClusterConfig) error {
 
 // tunnelToAPIServer creates ssh tunnel between apiserver:port inside control-plane node and host on port 8443.
 func (k *Bootstrapper) tunnelToAPIServer(cfg config.ClusterConfig) error {
-	if cfg.APIServerPort != 0 {
+	if cfg.APIServerPort == 0 {
 		return fmt.Errorf("apiserver port not set")
 	}
 

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -64,6 +64,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/style"
 	"k8s.io/minikube/pkg/minikube/sysinit"
 	"k8s.io/minikube/pkg/minikube/vmpath"
+	"k8s.io/minikube/pkg/network"
 	"k8s.io/minikube/pkg/util"
 	"k8s.io/minikube/pkg/util/retry"
 	"k8s.io/minikube/pkg/version"
@@ -442,6 +443,9 @@ func (k *Bootstrapper) StartCluster(cfg config.ClusterConfig) error {
 func (k *Bootstrapper) tunnelToAPIServer(cfg config.ClusterConfig) error {
 	if cfg.APIServerPort == 0 {
 		return fmt.Errorf("apiserver port not set")
+	}
+	if !driver.IsQEMU(cfg.Driver) || !network.IsBuiltinQEMU(cfg.Network) {
+		return nil
 	}
 
 	m, err := machine.NewAPIClient()


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/19173

**Before:**
```
$ minikube start --driver qemu --network builtin
😄  minikube v1.33.1 on Darwin 14.5 (arm64)
✨  Using the qemu2 driver based on user configuration
❗  You are using the QEMU driver without a dedicated network, which doesn't support `minikube service` & `minikube tunnel` commands.
To try the dedicated network see: https://minikube.sigs.k8s.io/docs/drivers/qemu/#networking
👍  Starting "minikube" primary control-plane node in "minikube" cluster
🔥  Creating qemu2 VM (CPUs=2, Memory=4000MB, Disk=20000MB) ...
❗  This VM is having trouble accessing https://registry.k8s.io
💡  To pull new external images, you may need to configure a proxy: https://minikube.sigs.k8s.io/docs/reference/networking/proxy/
❗  Due to DNS issues your cluster may have problems starting and you may not be able to pull images
More details available at: https://minikube.sigs.k8s.io/docs/drivers/qemu/#known-issues
🐳  Preparing Kubernetes v1.30.2 on Docker 27.0.3 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
E0703 14:15:40.236604   71562 start.go:159] Unable to scale down deployment "coredns" in namespace "kube-system" to 1 replica: non-retryable failure while getting "coredns" deployment scale: Get "https://localhost:54274/apis/apps/v1/namespaces/kube-system/deployments/coredns/scale": dial tcp 127.0.0.1:54274: connect: connection refused
❗  Enabling 'default-storageclass' returned an error: running callbacks: [Error making standard the default storage class: Error listing StorageClasses: Get "https://localhost:54274/apis/storage.k8s.io/v1/storageclasses": dial tcp 127.0.0.1:54274: connect: connection refused]
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner

❌  Exiting due to GUEST_START: failed to start node: wait 6m0s for node: wait for healthy API server: apiserver healthz never reported healthy: context deadline exceeded

╭───────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                           │
│    😿  If the above advice does not help, please let us know:                             │
│    👉  https://github.com/kubernetes/minikube/issues/new/choose                           │
│                                                                                           │
│    Please run `minikube logs --file=logs.txt` and attach logs.txt to the GitHub issue.    │
│                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────╯
```

**After:**
```
$ minikube start --driver qemu --network builtin
😄  minikube v1.33.1 on Darwin 14.5 (arm64)
✨  Using the qemu2 driver based on user configuration
❗  You are using the QEMU driver without a dedicated network, which doesn't support `minikube service` & `minikube tunnel` commands.
To try the dedicated network see: https://minikube.sigs.k8s.io/docs/drivers/qemu/#networking
👍  Starting "minikube" primary control-plane node in "minikube" cluster
🔥  Creating qemu2 VM (CPUs=2, Memory=4000MB, Disk=20000MB) ...
❗  This VM is having trouble accessing https://registry.k8s.io
💡  To pull new external images, you may need to configure a proxy: https://minikube.sigs.k8s.io/docs/reference/networking/proxy/
❗  Due to DNS issues your cluster may have problems starting and you may not be able to pull images
More details available at: https://minikube.sigs.k8s.io/docs/drivers/qemu/#known-issues
🐳  Preparing Kubernetes v1.30.2 on Docker 27.0.3 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```
