### PR TITLE
Output error for `Unable to load the current Docker config from`

### DIFF
--- a/cmd/minikube/main.go
+++ b/cmd/minikube/main.go
@@ -273,7 +273,7 @@ func propagateDockerContextToEnv() {
 		}
 		cf, err := dconfig.Load(dockerConfigDir)
 		if err != nil {
-			klog.Warningf("Unable to load the current Docker config from %q", dockerConfigDir)
+			klog.Warningf("Unable to load the current Docker config from %q: %v", dockerConfigDir, err)
 			return
 		}
 		currentContext = cf.CurrentContext


### PR DESCRIPTION
Related https://github.com/kubernetes/minikube/issues/19148

We're outputting the message that we failed to load the current Docker config, but we're not logging the error itself, which makes this very hard to debug. Adding the error message itself to the message.