### PR TITLE
addons ingress-dns: Update image to support multi-arch

### DIFF
--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -555,7 +555,7 @@ var Addons = map[string]*Addon{
 			"ingress-dns-pod.yaml",
 			"0640"),
 	}, false, "ingress-dns", "minikube", "", "https://minikube.sigs.k8s.io/docs/handbook/addons/ingress-dns/", map[string]string{
-		"IngressDNS": "k8s-minikube/minikube-ingress-dns:0.0.2@sha256:4abe27f9fc03fedab1d655e2020e6b165faf3bf6de1088ce6cf215a75b78f05f",
+		"IngressDNS": "k8s-minikube/minikube-ingress-dns:0.0.3@sha256:4211a1de532376c881851542238121b26792225faa36a7b02dccad88fd05797c",
 	}, map[string]string{
 		"IngressDNS": "gcr.io",
 	}),


### PR DESCRIPTION
ingress-dns image now supports all archs except `s390x` (image never finished building)

**amd64:**
```
$ arch
x86_64

$ nslookup hello-john.test $(minikube ip)
Server:		192.168.49.2
Address:	192.168.49.2#53

Non-authoritative answer:
Name:	hello-john.test
Address: 192.168.49.2
Name:	hello-john.test
Address: 192.168.49.2
```

**arm64:**
```
$ arch
aarch64

$ nslookup hello-john.test $(minikube ip)
Server:         192.168.49.2
Address:        192.168.49.2#53

Non-authoritative answer:
Name:   hello-john.test
Address: 192.168.49.2
Name:   hello-john.test
Address: 192.168.49.2
```