### PR TITLE
Improvements for using x86 binary on arm64 machine

### DIFF
--- a/pkg/minikube/detect/detect.go
+++ b/pkg/minikube/detect/detect.go
@@ -83,15 +83,6 @@ func IsAmd64M1Emulation() bool {
 	return runtime.GOARCH == "amd64" && strings.HasPrefix(cpuid.CPU.BrandName, "VirtualApple")
 }
 
-// EffectiveArch return architecture to use in minikube VM/container
-// may differ from host arch
-func EffectiveArch() string {
-	if IsAmd64M1Emulation() {
-		return "arm64"
-	}
-	return runtime.GOARCH
-}
-
 // MinikubeInstalledViaSnap returns true if the minikube binary path includes "snap".
 func MinikubeInstalledViaSnap() bool {
 	ex, err := os.Executable()

--- a/pkg/minikube/download/binary.go
+++ b/pkg/minikube/download/binary.go
@@ -22,8 +22,6 @@ import (
 	"path"
 	"runtime"
 
-	"k8s.io/minikube/pkg/minikube/detect"
-
 	"github.com/blang/semver/v4"
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
@@ -81,7 +79,7 @@ func Binary(binary, version, osName, archName, binaryURL string) (string, error)
 		return "", errors.Wrapf(err, "download failed: %s", url)
 	}
 
-	if osName == runtime.GOOS && archName == detect.EffectiveArch() {
+	if osName == runtime.GOOS && archName == runtime.GOARCH {
 		if err = os.Chmod(targetFilepath, 0755); err != nil {
 			return "", errors.Wrapf(err, "chmod +x %s", targetFilepath)
 		}

--- a/pkg/minikube/download/image.go
+++ b/pkg/minikube/download/image.go
@@ -99,7 +99,8 @@ func ImageExistsInDaemon(img string) bool {
 	return true
 }
 
-// isImageCorrectArch is needed to resolve
+// isImageCorrectArch returns true if the image arch is the same as the binary
+// arch. This is needed to resolve
 // https://github.com/kubernetes/minikube/pull/19205
 func isImageCorrectArch(img string) (bool, error) {
 	ref, err := name.ParseReference(img)

--- a/pkg/minikube/download/image.go
+++ b/pkg/minikube/download/image.go
@@ -266,7 +266,8 @@ func CacheToDaemon(img string) (string, error) {
 		return "", err
 	}
 
-	cmd := exec.Command("docker", "pull", "--quiet", img)
+	platform := fmt.Sprintf("linux/%s", runtime.GOARCH)
+	cmd := exec.Command("docker", "pull", "--platform", platform, "--quiet", img)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		klog.Warningf("failed to pull image digest (expected if offline): %s: %v", output, err)
 		img = image.Tag(img)

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -25,11 +25,11 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/option"
-	"k8s.io/minikube/pkg/minikube/detect"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
@@ -64,8 +64,7 @@ func TarballName(k8sVersion, containerRuntime string) string {
 	} else {
 		storageDriver = "overlay2"
 	}
-	arch := detect.EffectiveArch()
-	return fmt.Sprintf("preloaded-images-k8s-%s-%s-%s-%s-%s.tar.lz4", PreloadVersion, k8sVersion, containerRuntime, storageDriver, arch)
+	return fmt.Sprintf("preloaded-images-k8s-%s-%s-%s-%s-%s.tar.lz4", PreloadVersion, k8sVersion, containerRuntime, storageDriver, runtime.GOARCH)
 }
 
 // returns the name of the checksum file

--- a/pkg/minikube/machine/cache_binaries.go
+++ b/pkg/minikube/machine/cache_binaries.go
@@ -18,6 +18,7 @@ package machine
 
 import (
 	"path"
+	"runtime"
 
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
@@ -25,7 +26,6 @@ import (
 	"k8s.io/minikube/pkg/minikube/assets"
 	"k8s.io/minikube/pkg/minikube/bootstrapper"
 	"k8s.io/minikube/pkg/minikube/command"
-	"k8s.io/minikube/pkg/minikube/detect"
 	"k8s.io/minikube/pkg/minikube/download"
 )
 
@@ -53,7 +53,7 @@ func CacheBinariesForBootstrapper(version string, excludeBinaries []string, bina
 		}
 		bin := bin // https://go.dev/doc/faq#closures_and_goroutines
 		g.Go(func() error {
-			if _, err := download.Binary(bin, version, "linux", detect.EffectiveArch(), binariesURL); err != nil {
+			if _, err := download.Binary(bin, version, "linux", runtime.GOARCH, binariesURL); err != nil {
 				return errors.Wrapf(err, "caching binary %s", bin)
 			}
 			return nil

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -103,7 +103,7 @@ func CacheKubectlBinary(k8sVersion, binaryURL string) (string, error) {
 		binary = "kubectl.exe"
 	}
 
-	return download.Binary(binary, k8sVersion, runtime.GOOS, detect.EffectiveArch(), binaryURL)
+	return download.Binary(binary, k8sVersion, runtime.GOOS, runtime.GOARCH, binaryURL)
 }
 
 // doCacheBinaries caches Kubernetes binaries in the foreground


### PR DESCRIPTION
Related https://github.com/kubernetes/minikube/issues/19110 https://github.com/kubernetes/minikube/issues/18895 https://github.com/kubernetes/minikube/issues/12274

## Improvement 1
**Issue:**
If a user desired to run an x86 cluster on an arm64 machine, they would use an x86 minikube binary. However, due to our logic we would use an x86 ISO, but we would then download arm64 preload and K8s binaries, resulting in arch mismatches between the cluster and the K8s binaries, resulting in minikube failing to start.

**Fix:**
We now download the preloads and K8s binary strictly based on the minikube binary arch, resulting in the proper K8s binaries being downloaded.

## Improvement 2

**Issue:**
When starting minikube using an x86 binary on an arm64 machine and using the Docker driver, we would incorrectly download both the x86 and arm64 kicbase images, and use the arm64 image for running the container. This was due to running a `docker pull` without the `--platform` flag, using the host machines default arch, being arm64.

**Fix:**
We now specify the `--platform` flag on the `docker pull`, resulting in correctly only pulling the x86 kicbase image.

## Improvement 3

**Issue:**
After resolving the above two issues I was able to attempt to to start an x86 kicbase with x86 K8s binaries on an arm64 machine, this resulted in the failure `could not detect clock speed from output` from `kubelet`. And as per https://github.com/kubernetes-sigs/kind/issues/3621#issuecomment-2120918280, `Docker's "cross platform images" only use partial emulation that cannot run a workload like Kubernetes.`

**Fix:**
Hard fail if a user attempts to start an x86 cluster on arm64 with the Docker driver.

```
$ minikube-darwin-amd64 start --driver docker
╭──────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                          │
│    You are trying to run the amd64 binary on an M1 system.                                               │
│    Please consider running the darwin/arm64 binary instead.                                              │
│    Download at https://github.com/kubernetes/minikube/releases/download/v1.33.1/minikube-darwin-arm64    │
│                                                                                                          │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────╯
😄  minikube v1.33.1 on Darwin 14.5
✨  Using the docker driver based on user configuration

💣  Exiting due to PROVIDER_DOCKER_INCORRECT_ARCH: Cannot use amd64 minikube binary to start minikube cluster with Docker driver on arm64 machine
💡  Suggestion: Download and use arm64 version of the minikube binary
📘  Documentation: https://minikube.sigs.k8s.io/docs/start/
```

## Improvement 4

**Issue:**
Users have run into an issue where they try starting minikube with the x86 binary, which downloads the x86 kicbase, they then download and use the arm64 binary, but due to kicbase having identical tags uses the existing x86 version but then uses arm64 preload and K8s binaries, resulting in arch mismatches, and causing minikube to fail to start.

**Fix:**
Our previous check just did `docker images` and then checked for the existence of the expected tag. Improved the check to ensure the image matches the expected arch, if it doesn't it downloads the correct one.
