### PR TITLE
Support running x86 QEMU on arm64

### DIFF
--- a/pkg/drivers/qemu/qemu.go
+++ b/pkg/drivers/qemu/qemu.go
@@ -415,6 +415,7 @@ func (d *Driver) Start() error {
 	// hardware acceleration is important, it increases performance by 10x
 	accel := hardwareAcceleration()
 	if accel != "" {
+		klog.Infof("Using %s for hardware acceleration", accel)
 		startCmd = append(startCmd,
 			"-accel", accel)
 	}

--- a/pkg/minikube/registry/drvs/qemu2/qemu2.go
+++ b/pkg/minikube/registry/drvs/qemu2/qemu2.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/minikube/pkg/drivers/qemu"
 
 	"k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/detect"
 	"k8s.io/minikube/pkg/minikube/download"
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/localpath"
@@ -75,6 +76,9 @@ func qemuFirmwarePath(customPath string) (string, error) {
 	}
 	if runtime.GOOS == "windows" {
 		return "C:\\Program Files\\qemu\\share\\edk2-x86_64-code.fd", nil
+	}
+	if detect.IsAmd64M1Emulation() {
+		return "/opt/homebrew/opt/qemu/share/qemu/edk2-x86_64-code.fd", nil
 	}
 	arch := runtime.GOARCH
 	// For macOS, find the correct brew installation path for qemu firmware


### PR DESCRIPTION
Closes https://github.com/kubernetes/minikube/issues/18895

Depends on https://github.com/kubernetes/minikube/pull/19205 being merged

Support running x86 QEMU cluster on arm64 with no additional flags.
