### PR TITLE
`image load`: add warning when loading image with wrong arch

### DIFF
--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -230,7 +230,7 @@ func validateNodeLabels(ctx context.Context, t *testing.T, profile string) {
 
 // tagAndLoadImage is a helper function to pull, tag, load image (decreases cyclomatic complexity for linter).
 func tagAndLoadImage(ctx context.Context, t *testing.T, profile, taggedImage string) {
-	newPulledImage := fmt.Sprintf("%s:%s", echoServerImg, "2.0")
+	newPulledImage := fmt.Sprintf("%s:%s", echoServerImg, "latest")
 	rr, err := Run(t, exec.CommandContext(ctx, "docker", "pull", newPulledImage))
 	if err != nil {
 		t.Fatalf("failed to setup test (pull image): %v\n%s", err, rr.Output())
@@ -337,7 +337,7 @@ func validateImageCommands(ctx context.Context, t *testing.T, profile string) {
 			t.Fatalf("failed to get absolute path of file %q: %v", imageFile, err)
 		}
 
-		pulledImage := fmt.Sprintf("%s:%s", echoServerImg, "2.0")
+		pulledImage := fmt.Sprintf("%s:%s", echoServerImg, "1.0")
 		rr, err := Run(t, exec.CommandContext(ctx, "docker", "pull", pulledImage))
 		if err != nil {
 			t.Fatalf("failed to setup test (pull image): %v\n%s", err, rr.Output())

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -57,7 +57,7 @@ import (
 	"golang.org/x/build/kubernetes/api"
 )
 
-const echoServerImg = "kicbase/echo-server"
+const echoServerImg = "docker.io/kicbase/echo-server"
 
 // validateFunc are for subtests that share a single setup
 type validateFunc func(context.Context, *testing.T, string)

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -57,7 +57,7 @@ import (
 	"golang.org/x/build/kubernetes/api"
 )
 
-const addonResizer = "gcr.io/google-containers/addon-resizer"
+const echoServerImg = "gcr.io/k8s-minikube/kicbase-builds/echo-server"
 
 // validateFunc are for subtests that share a single setup
 type validateFunc func(context.Context, *testing.T, string)
@@ -182,10 +182,10 @@ func cleanupUnwantedImages(ctx context.Context, t *testing.T, profile string) {
 	if err != nil {
 		t.Skipf("docker is not installed, cannot delete docker images")
 	} else {
-		t.Run("delete addon-resizer images", func(t *testing.T) {
-			tags := []string{"1.8.8", profile}
+		t.Run("delete echo-server images", func(t *testing.T) {
+			tags := []string{"1.0", profile}
 			for _, tag := range tags {
-				image := fmt.Sprintf("%s:%s", addonResizer, tag)
+				image := fmt.Sprintf("%s:%s", echoServerImg, tag)
 				rr, err := Run(t, exec.CommandContext(ctx, "docker", "rmi", "-f", image))
 				if err != nil {
 					t.Logf("failed to remove image %q from docker images. args %q: %v", image, rr.Command(), err)
@@ -230,7 +230,7 @@ func validateNodeLabels(ctx context.Context, t *testing.T, profile string) {
 
 // tagAndLoadImage is a helper function to pull, tag, load image (decreases cyclomatic complexity for linter).
 func tagAndLoadImage(ctx context.Context, t *testing.T, profile, taggedImage string) {
-	newPulledImage := fmt.Sprintf("%s:%s", addonResizer, "1.8.9")
+	newPulledImage := fmt.Sprintf("%s:%s", echoServerImg, "1.8.9")
 	rr, err := Run(t, exec.CommandContext(ctx, "docker", "pull", newPulledImage))
 	if err != nil {
 		t.Fatalf("failed to setup test (pull image): %v\n%s", err, rr.Output())
@@ -325,8 +325,8 @@ func validateImageCommands(ctx context.Context, t *testing.T, profile string) {
 		checkImageExists(ctx, t, profile, newImage)
 	})
 
-	taggedImage := fmt.Sprintf("%s:%s", addonResizer, profile)
-	imageFile := "addon-resizer-save.tar"
+	taggedImage := fmt.Sprintf("%s:%s", echoServerImg, profile)
+	imageFile := "echo-server-save.tar"
 	var imagePath string
 	defer os.Remove(imageFile)
 
@@ -337,7 +337,7 @@ func validateImageCommands(ctx context.Context, t *testing.T, profile string) {
 			t.Fatalf("failed to get absolute path of file %q: %v", imageFile, err)
 		}
 
-		pulledImage := fmt.Sprintf("%s:%s", addonResizer, "1.8.8")
+		pulledImage := fmt.Sprintf("%s:%s", echoServerImg, "2.0")
 		rr, err := Run(t, exec.CommandContext(ctx, "docker", "pull", pulledImage))
 		if err != nil {
 			t.Fatalf("failed to setup test (pull image): %v\n%s", err, rr.Output())

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -57,7 +57,7 @@ import (
 	"golang.org/x/build/kubernetes/api"
 )
 
-const echoServerImg = "gcr.io/k8s-minikube/kicbase-builds/echo-server"
+const echoServerImg = "kicbase/echo-server"
 
 // validateFunc are for subtests that share a single setup
 type validateFunc func(context.Context, *testing.T, string)

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -230,7 +230,7 @@ func validateNodeLabels(ctx context.Context, t *testing.T, profile string) {
 
 // tagAndLoadImage is a helper function to pull, tag, load image (decreases cyclomatic complexity for linter).
 func tagAndLoadImage(ctx context.Context, t *testing.T, profile, taggedImage string) {
-	newPulledImage := fmt.Sprintf("%s:%s", echoServerImg, "1.8.9")
+	newPulledImage := fmt.Sprintf("%s:%s", echoServerImg, "2.0")
 	rr, err := Run(t, exec.CommandContext(ctx, "docker", "pull", newPulledImage))
 	if err != nil {
 		t.Fatalf("failed to setup test (pull image): %v\n%s", err, rr.Output())


### PR DESCRIPTION
Per conversation in https://kubernetes.slack.com/archives/C1F5CT6Q1/p1720561197944349
This PR does following:
- Warning user if they load an image that has different arch than container runtime example
- dont spam verbose logs when length of failure or success are empty list
- fix integration test to use a multi arch image  (gcr.io/google-containers/addon-resizer:1.8.8 is only x86 )

### Before this PR
```
$ minikube image load gcr.io/google-containers/addon-resizer:1.8.8 alpine:131313 alpine:latest gcr.io/k8s-minikube/kicbase-builds/echo-server:1.0
❗  The image 'alpine:131313' was not found; unable to add it to cache.
```

### After this PR
```
$ mk image load gcr.io/google-containers/addon-resizer:1.8.8 alpine:131313 alpine:latest gcr.io/k8s-minikube/kicbase-builds/echo-server:1.0
❗  The image 'alpine:131313' was not found; unable to add it to cache.
❗  The image 'gcr.io/google-containers/addon-resizer:1.8.8' does not match arch of the container runtime, use a multi-arch image instead
```