### PR TITLE
Auto detect OS Architecture in Installation doc

### DIFF
--- a/site/static/js/quiz.js
+++ b/site/static/js/quiz.js
@@ -63,7 +63,7 @@ async function initQuiz() {
       // currently compatible with these browsers: https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/getHighEntropyValues#browser_compatibility
       const architecture = await navigator.userAgentData.getHighEntropyValues(['architecture'])
       switch (architecture.architecture) {
-        case "arm"
+        case "arm":
           arch = "arm64"
           break
         case "x86":

--- a/site/static/js/quiz.js
+++ b/site/static/js/quiz.js
@@ -61,18 +61,16 @@ async function initQuiz() {
     let arch = null;
     try {
       // currently compatible with these browsers: https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/getHighEntropyValues#browser_compatibility
-      let architecture = await navigator.userAgentData.getHighEntropyValues(['architecture'])
-      switch( architecture.architecture ){
-        case "arm" :{
+      const architecture = await navigator.userAgentData.getHighEntropyValues(['architecture'])
+      switch (architecture.architecture) {
+        case "arm"
           arch = "arm64"
           break
-        }
-        case "x86" :{
+        case "x86":
           arch = "x86-64"
           break
-        }
       }
-    }catch(e){
+    } catch(e) {
       console.log(e)
     }
     $(".option-row[data-level=0]").removeClass("hide");
@@ -105,7 +103,7 @@ async function initQuiz() {
       btn.addClass("active");
       selectQuizOption(btn.attr("data-quiz-id"));
       // auto-select OS arch for user
-      if (arch){
+      if (arch) {
         const btn = $(".option-button[data-quiz-id='/" + userOS + "/" + arch + "']").first();
         // disacitve all buttons of the row first
         const row = $(".option-row[data-quiz-id='/" + userOS + "']").first()


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

Fixes #19031 

![Screenshot 2024-07-13 at 2 45 07 PM](https://github.com/user-attachments/assets/31fde423-fc7e-4e19-aae6-5eec77eea2ed)

Auto detecting OS architecture using `await navigator.userAgentData.getHighEntropyValues(['architecture'])`. ([reference](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/getHighEntropyValues)). This is a cleaner approach and other approaches seem too hacky. 

This function is still in experimental stage, only supported for following [browsers](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/getHighEntropyValues#browser_compatibility). I have tested this in **Google Chrome** and its working fine, but on **Safari** it doesn't detect ARM and auto-selects X86 by default. 

_**This change is backward compatible and wouldn't affect anything if OS architecture is not found for some browsers and the doc would display in the same way as it use to.**_ 

Since it's my first open-source contribution kindly guide me how to make this fix better and any suggestions are welcomed. 