### PR TITLE
Replace ReplicationController with Deployment in addons

### DIFF
--- a/deploy/addons/efk/elasticsearch-rc.yaml.tmpl
+++ b/deploy/addons/efk/elasticsearch-rc.yaml.tmpl
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: elasticsearch-logging
   namespace: kube-system
@@ -24,12 +24,15 @@ metadata:
 spec:
   replicas: 1
   selector:
-    k8s-app: elasticsearch-logging
-    addonmanager.kubernetes.io/mode: Reconcile
+    matchLabels:
+      k8s-app: elasticsearch-logging
+      kubernetes.io/minikube-addons: efk
+      addonmanager.kubernetes.io/mode: Reconcile
   template:
     metadata:
       labels:
         k8s-app: elasticsearch-logging
+        kubernetes.io/minikube-addons: efk
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:

--- a/deploy/addons/efk/fluentd-es-rc.yaml.tmpl
+++ b/deploy/addons/efk/fluentd-es-rc.yaml.tmpl
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: fluentd-es
   namespace: kube-system
@@ -23,10 +23,16 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: fluentd-es
+      kubernetes.io/minikube-addons: efk
+      addonmanager.kubernetes.io/mode: Reconcile
   template:
     metadata:
       labels:
         k8s-app: fluentd-es
+        kubernetes.io/minikube-addons: efk
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:

--- a/deploy/addons/efk/kibana-rc.yaml.tmpl
+++ b/deploy/addons/efk/kibana-rc.yaml.tmpl
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: kibana-logging
   namespace: kube-system
@@ -24,12 +24,15 @@ metadata:
 spec:
   replicas: 1
   selector:
+    matchLabels:
       k8s-app: kibana-logging
+      kubernetes.io/minikube-addons: efk
       addonmanager.kubernetes.io/mode: Reconcile
   template:
     metadata:
       labels:
         k8s-app: kibana-logging
+        kubernetes.io/minikube-addons: efk
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:

--- a/deploy/addons/freshpod/freshpod-rc.yaml.tmpl
+++ b/deploy/addons/freshpod/freshpod-rc.yaml.tmpl
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: freshpod
   namespace: kube-system
@@ -24,12 +24,15 @@ metadata:
 spec:
   replicas: 1
   selector:
-    k8s-app: freshpod
-    addonmanager.kubernetes.io/mode: Reconcile
+    matchLabels:
+      k8s-app: freshpod
+      kubernetes.io/minikube-addons: freshpod
+      addonmanager.kubernetes.io/mode: Reconcile
   template:
     metadata:
       labels:
         k8s-app: freshpod
+        kubernetes.io/minikube-addons: freshpod
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:

--- a/deploy/addons/registry/registry-rc.yaml.tmpl
+++ b/deploy/addons/registry/registry-rc.yaml.tmpl
@@ -1,5 +1,5 @@
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   labels:
     kubernetes.io/minikube-addons: registry
@@ -9,7 +9,9 @@ metadata:
 spec:
   replicas: 1
   selector:
-    kubernetes.io/minikube-addons: registry
+    matchLabels:
+      kubernetes.io/minikube-addons: registry
+      addonmanager.kubernetes.io/mode: Reconcile
   template:
     metadata:
       labels:

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -326,8 +326,8 @@ func validateRegistryAddon(ctx context.Context, t *testing.T, profile string) {
 	}
 
 	start := time.Now()
-	if err := kapi.WaitForRCToStabilize(client, "kube-system", "registry", Minutes(6)); err != nil {
-		t.Errorf("failed waiting for registry replicacontroller to stabilize: %v", err)
+	if err := kapi.WaitForDeploymentToStabilize(client, "kube-system", "registry", Minutes(6)); err != nil {
+		t.Errorf("failed waiting for registry deployment to stabilize: %v", err)
 	}
 	t.Logf("registry stabilized in %s", time.Since(start))
 


### PR DESCRIPTION
fixes #18954 


Minikube outputs:
Creating minikube cluster:
```
❯ ./out/minikube-darwin-arm64 -v=2 start
😄  minikube v1.33.1 on Darwin 14.5 (arm64)
✨  Automatically selected the docker driver. Other choices: parallels, ssh
📌  Using Docker Desktop driver with root privileges
👍  Starting "minikube" primary control-plane node in "minikube" cluster
🚜  Pulling base image v0.0.44-1720578864-19219 ...
❗  minikube was unable to download gcr.io/k8s-minikube/kicbase-builds:v0.0.44-1720578864-19219, but successfully downloaded docker.io/kicbase/build:v0.0.44-1720578864-19219 as a fallback image
🔥  Creating docker container (CPUs=2, Memory=7892MB) ...
🐳  Preparing Kubernetes v1.30.2 on Docker 27.0.3 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```

Enabling `registry` addon:
```
❯ ./out/minikube-darwin-arm64 -v=2 addons enable registry
💡  registry is an addon maintained by minikube. For any concerns contact minikube on GitHub.
You can view the list of minikube maintainers at: https://github.com/kubernetes/minikube/blob/master/OWNERS
╭──────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                      │
│    Registry addon with docker driver uses port 56089 please use that instead of default port 5000    │
│                                                                                                      │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────╯
📘  For more information see: https://minikube.sigs.k8s.io/docs/drivers/docker
    ▪ Using image docker.io/registry:2.8.3
    ▪ Using image gcr.io/k8s-minikube/kube-registry-proxy:0.0.6
🔎  Verifying registry addon...
🌟  The 'registry' addon is enabled
```

Describe `registry` deployment:
```
❯ kubectl -n kube-system describe deployments.apps registry
Name:                   registry
Namespace:              kube-system
CreationTimestamp:      Tue, 16 Jul 2024 22:13:23 +0200
Labels:                 addonmanager.kubernetes.io/mode=Reconcile
                        kubernetes.io/minikube-addons=registry
Annotations:            deployment.kubernetes.io/revision: 1
Selector:               addonmanager.kubernetes.io/mode=Reconcile,kubernetes.io/minikube-addons=registry
Replicas:               1 desired | 1 updated | 1 total | 1 available | 0 unavailable
StrategyType:           RollingUpdate
MinReadySeconds:        0
RollingUpdateStrategy:  25% max unavailable, 25% max surge
Pod Template:
  Labels:  actual-registry=true
           addonmanager.kubernetes.io/mode=Reconcile
           kubernetes.io/minikube-addons=registry
  Containers:
   registry:
    Image:      docker.io/registry:2.8.3@sha256:79b29591e1601a73f03fcd413e655b72b9abfae5a23f1ad2e883d4942fbb4351
    Port:       5000/TCP
    Host Port:  0/TCP
    Environment:
      REGISTRY_STORAGE_DELETE_ENABLED:  true
    Mounts:                             <none>
  Volumes:                              <none>
  Node-Selectors:                       <none>
  Tolerations:                          <none>
Conditions:
  Type           Status  Reason
  ----           ------  ------
  Available      True    MinimumReplicasAvailable
  Progressing    True    NewReplicaSetAvailable
OldReplicaSets:  <none>
NewReplicaSet:   registry-656c9c8d9c (1/1 replicas created)
Events:
  Type    Reason             Age   From                   Message
  ----    ------             ----  ----                   -------
  Normal  ScalingReplicaSet  54s   deployment-controller  Scaled up replica set registry-656c9c8d9c to 1
```

Describe `registry` service:
```
❯ kubectl -n kube-system describe svc registry
Name:              registry
Namespace:         kube-system
Labels:            addonmanager.kubernetes.io/mode=Reconcile
                   kubernetes.io/minikube-addons=registry
Annotations:       <none>
Selector:          actual-registry=true,kubernetes.io/minikube-addons=registry
Type:              ClusterIP
IP Family Policy:  SingleStack
IP Families:       IPv4
IP:                10.102.137.10
IPs:               10.102.137.10
Port:              http  80/TCP
TargetPort:        5000/TCP
Endpoints:         10.244.0.3:5000
Port:              https  443/TCP
TargetPort:        443/TCP
Endpoints:         10.244.0.3:443
Session Affinity:  None
Events:            <none>
```

Enabling `efk` addon:
```
❯ ./out/minikube-darwin-arm64 -v=2 addons enable efk

❌  Exiting due to MK_ADDON_ENABLE: The current images used in the efk addon contain Log4j vulnerabilities, the addon will be disabled until images are updated, see: https://github.com/kubernetes/minikube/issues/15280
```

Enabling `freshpod` addon:
```
❯ ./out/minikube-darwin-arm64 -v=2 addons enable freshpod
💡  freshpod is an addon maintained by Google. For any concerns contact minikube on GitHub.
You can view the list of minikube maintainers at: https://github.com/kubernetes/minikube/blob/master/OWNERS
    ▪ Using image gcr.io/google-samples/freshpod:v0.0.1
🌟  The 'freshpod' addon is enabled
```

Describe `freshpod` service:
```
❯ kubectl -n kube-system describe deployments.apps freshpod
Name:                   freshpod
Namespace:              kube-system
CreationTimestamp:      Tue, 16 Jul 2024 22:16:34 +0200
Labels:                 addonmanager.kubernetes.io/mode=Reconcile
                        k8s-app=freshpod
                        kubernetes.io/minikube-addons=freshpod
Annotations:            deployment.kubernetes.io/revision: 1
Selector:               addonmanager.kubernetes.io/mode=Reconcile,k8s-app=freshpod,kubernetes.io/minikube-addons=freshpod
Replicas:               1 desired | 1 updated | 1 total | 1 available | 0 unavailable
StrategyType:           RollingUpdate
MinReadySeconds:        0
RollingUpdateStrategy:  25% max unavailable, 25% max surge
Pod Template:
  Labels:  addonmanager.kubernetes.io/mode=Reconcile
           k8s-app=freshpod
           kubernetes.io/minikube-addons=freshpod
  Containers:
   freshpod:
    Image:        gcr.io/google-samples/freshpod:v0.0.1@sha256:b9efde5b509da3fd2959519c4147b653d0c5cefe8a00314e2888e35ecbcb46f9
    Port:         <none>
    Host Port:    <none>
    Environment:  <none>
    Mounts:
      /var/run/docker.sock from docker (rw)
  Volumes:
   docker:
    Type:          HostPath (bare host directory volume)
    Path:          /var/run/docker.sock
    HostPathType:  Socket
  Node-Selectors:  <none>
  Tolerations:     <none>
Conditions:
  Type           Status  Reason
  ----           ------  ------
  Available      True    MinimumReplicasAvailable
  Progressing    True    NewReplicaSetAvailable
OldReplicaSets:  <none>
NewReplicaSet:   freshpod-78fc8bbbf4 (1/1 replicas created)
Events:
  Type    Reason             Age   From                   Message
  ----    ------             ----  ----                   -------
  Normal  ScalingReplicaSet  74s   deployment-controller  Scaled up replica set freshpod-78fc8bbbf4 to 1
```