### PR TITLE
remove virtualbox tests from github actions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -519,115 +519,6 @@ jobs:
           if [ "$numPass" -eq 0 ];then echo "*** 0 Passed! ***";exit 2;fi
           if [ "$numPass" -lt 36 ];then echo "*** Failed to pass at least 36 ! ***";exit 2;fi
           if [ "$numPass" -eq 0 ];then echo "*** Passed! ***";exit 0;fi
-
-  functional_virtualbox_macos:
-    permissions:
-      contents: none
-    needs: [build_minikube_test_binaries]
-    env:
-      TIME_ELAPSED: time
-      JOB_NAME: "functional_virtualbox_macos"
-      GOPOGH_RESULT: ""
-      SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
-    runs-on: macos-12
-    steps:
-      - name: Verify x86_64 architecture 
-        shell: bash
-        run: |
-          if [ $(uname -m) != "x86_64" ] 
-          then 
-              echo "$(uname -m) detected. This test must be run on x86_64"
-              exit -1
-          fi
-          exit 0
-      - name: Install kubectl
-        shell: bash
-        run: |
-          curl -LO "https://dl.k8s.io/release/$(curl -sSL https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl"
-          sudo install kubectl /usr/local/bin/kubectl
-          kubectl version --client=true
-      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
-        with:
-          cache: false
-          go-version: ${{env.GO_VERSION}}
-      - name: Install gopogh
-        shell: bash
-        run: |
-          go install github.com/medyagh/gopogh/cmd/gopogh@v0.27.0
-      - name: Install docker
-        shell: bash
-        run: |
-          brew install docker-machine docker
-          sudo docker --version
-      - name: Info
-        shell: bash
-        run: |
-          hostname
-          VBoxManage --version
-          sysctl hw.physicalcpu hw.logicalcpu
-      - name: Disable firewall
-        run: |
-          sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
-          sudo /usr/libexec/ApplicationFirewall/socketfilterfw -k
-      - name: Download Binaries
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
-        with:
-          name: minikube_binaries
-          path: minikube_binaries
-      - name: Run Integration Test
-        continue-on-error: false
-        # bash {0} to allow test to continue to next step. in case of
-        shell: bash {0}
-        run: |
-          cd minikube_binaries
-          mkdir -p report
-          mkdir -p testhome
-          chmod a+x e2e-*
-          chmod a+x minikube-*
-          MINIKUBE_HOME=$(pwd)/testhome ./minikube-darwin-amd64 delete --all --purge
-          START_TIME=$(date -u +%s)
-          KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-darwin-amd64 -minikube-start-args=--vm-driver=virtualbox  -test.run "TestFunctional" -test.timeout=35m -test.v -timeout-multiplier=1.5 -binary=./minikube-darwin-amd64 2>&1 | tee ./report/testout.txt
-          END_TIME=$(date -u +%s)
-          TIME_ELAPSED=$(($END_TIME-$START_TIME))
-          min=$((${TIME_ELAPSED}/60))
-          sec=$((${TIME_ELAPSED}%60))
-          TIME_ELAPSED="${min} min $sec seconds "
-          echo "TIME_ELAPSED=${TIME_ELAPSED}" >> $GITHUB_ENV
-      - name: Generate HTML Report
-        shell: bash
-        run: |
-          cd minikube_binaries
-          export PATH=${PATH}:`go env GOPATH`/bin
-          go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
-          STAT=$(gopogh -in ./report/testout.json -out_html ./report/testout.html -out_summary ./report/testout_summary.json -name "${JOB_NAME} ${GITHUB_REF}" -repo "${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
-          echo status: ${STAT}
-          FailNum=$(echo $STAT | jq '.NumberOfFail')
-          TestsNum=$(echo $STAT | jq '.NumberOfTests')
-          GOPOGH_RESULT="${JOB_NAME} : completed with ${FailNum} / ${TestsNum} failures in ${TIME_ELAPSED}"
-          echo "GOPOGH_RESULT=${GOPOGH_RESULT}" >> $GITHUB_ENV
-          echo 'STAT<<EOF' >> $GITHUB_ENV
-          echo "${STAT}" >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
-      - uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b
-        with:
-          name: functional_virtualbox_macos
-          path: minikube_binaries/report
-      - name: The End Result functional_virtualbox_macos
-        shell: bash
-        run: |
-          echo ${GOPOGH_RESULT}
-          numFail=$(echo $STAT | jq '.NumberOfFail')
-          numPass=$(echo $STAT | jq '.NumberOfPass')
-          echo "*******************${numPass} Passes :) *******************"
-          echo $STAT | jq '.PassedTests' || true
-          echo "*******************************************************"
-          echo "----------------${numFail} Failures :(----------------------------"
-          echo $STAT | jq '.FailedTests' || true
-          echo "-------------------------------------------------------"
-          if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
-          if [ "$numPass" -eq 0 ];then echo "*** 0 Passed! ***";exit 2;fi
-          if [ "$numPass" -lt 33 ];then echo "*** Failed to pass at least 33 ! ***";exit 2;fi
-          if [ "$numPass" -eq 0 ];then echo "*** Passed! ***";exit 0;fi
   functional_baremetal_ubuntu22_04:
     permissions:
       contents: none
@@ -762,7 +653,6 @@ jobs:
         functional_docker_containerd_ubuntu,
         functional_docker_rootless_containerd_ubuntu,
         functional_podman_ubuntu,
-        functional_virtualbox_macos,
         functional_baremetal_ubuntu22_04,
       ]
     runs-on: ubuntu-22.04
@@ -779,9 +669,7 @@ jobs:
           cp -r ./functional_docker_containerd_ubuntu ./all_reports/
           cp -r ./functional_docker_rootless_containerd_ubuntu ./all_reports/
           cp -r ./functional_podman_ubuntu ./all_reports/
-          cp -r ./functional_virtualbox_macos ./all_reports/
           cp -r ./functional_baremetal_ubuntu22_04 ./all_reports/
-
       - uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b
         with:
           name: all_reports

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -517,115 +517,6 @@ jobs:
           if [ "$numPass" -eq 0 ];then echo "*** 0 Passed! ***";exit 2;fi
           if [ "$numPass" -lt 36 ];then echo "*** Failed to pass at least 36 ! ***";exit 2;fi
           if [ "$numPass" -eq 0 ];then echo "*** Passed! ***";exit 0;fi
-
-  functional_virtualbox_macos:
-    permissions:
-      contents: none
-    needs: [build_minikube_test_binaries]
-    env:
-      TIME_ELAPSED: time
-      JOB_NAME: "functional_virtualbox_macos"
-      GOPOGH_RESULT: ""
-      SHELL: "/bin/bash" # To prevent https://github.com/kubernetes/minikube/issues/6643
-    runs-on: macos-12
-    steps:
-      - name: Verify x86_64 architecture 
-        shell: bash
-        run: |
-          if [ $(uname -m) != "x86_64" ] 
-          then 
-              echo "$(uname -m) detected. This test must be run on x86_64"
-              exit -1
-          fi
-          exit 0
-      - name: Install kubectl
-        shell: bash
-        run: |
-          curl -LO "https://dl.k8s.io/release/$(curl -sSL https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl"
-          sudo install kubectl /usr/local/bin/kubectl
-          kubectl version --client=true
-      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
-        with:
-          cache: false
-          go-version: ${{env.GO_VERSION}}
-      - name: Install gopogh
-        shell: bash
-        run: |
-          go install github.com/medyagh/gopogh/cmd/gopogh@v0.27.0
-      - name: Install docker
-        shell: bash
-        run: |
-          brew install docker-machine docker
-          sudo docker --version
-      - name: Info
-        shell: bash
-        run: |
-          hostname
-          VBoxManage --version
-          sysctl hw.physicalcpu hw.logicalcpu
-      - name: Disable firewall
-        run: |
-          sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
-          sudo /usr/libexec/ApplicationFirewall/socketfilterfw -k
-      - name: Download Binaries
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
-        with:
-          name: minikube_binaries
-          path: minikube_binaries
-      - name: Run Integration Test
-        continue-on-error: false
-        # bash {0} to allow test to continue to next step. in case of
-        shell: bash {0}
-        run: |
-          cd minikube_binaries
-          mkdir -p report
-          mkdir -p testhome
-          chmod a+x e2e-*
-          chmod a+x minikube-*
-          MINIKUBE_HOME=$(pwd)/testhome ./minikube-darwin-amd64 delete --all --purge
-          START_TIME=$(date -u +%s)
-          KUBECONFIG=$(pwd)/testhome/kubeconfig MINIKUBE_HOME=$(pwd)/testhome ./e2e-darwin-amd64 -minikube-start-args=--vm-driver=virtualbox  -test.run "TestFunctional" -test.timeout=35m -test.v -timeout-multiplier=1.5 -binary=./minikube-darwin-amd64 2>&1 | tee ./report/testout.txt
-          END_TIME=$(date -u +%s)
-          TIME_ELAPSED=$(($END_TIME-$START_TIME))
-          min=$((${TIME_ELAPSED}/60))
-          sec=$((${TIME_ELAPSED}%60))
-          TIME_ELAPSED="${min} min $sec seconds "
-          echo "TIME_ELAPSED=${TIME_ELAPSED}" >> $GITHUB_ENV
-      - name: Generate HTML Report
-        shell: bash
-        run: |
-          cd minikube_binaries
-          export PATH=${PATH}:`go env GOPATH`/bin
-          go tool test2json -t < ./report/testout.txt > ./report/testout.json || true
-          STAT=$(gopogh -in ./report/testout.json -out_html ./report/testout.html -out_summary ./report/testout_summary.json -name "${JOB_NAME} ${GITHUB_REF}" -repo "${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  || true
-          echo status: ${STAT}
-          FailNum=$(echo $STAT | jq '.NumberOfFail')
-          TestsNum=$(echo $STAT | jq '.NumberOfTests')
-          GOPOGH_RESULT="${JOB_NAME} : completed with ${FailNum} / ${TestsNum} failures in ${TIME_ELAPSED}"
-          echo "GOPOGH_RESULT=${GOPOGH_RESULT}" >> $GITHUB_ENV
-          echo 'STAT<<EOF' >> $GITHUB_ENV
-          echo "${STAT}" >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
-      - uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b
-        with:
-          name: functional_virtualbox_macos
-          path: minikube_binaries/report
-      - name: The End Result functional_virtualbox_macos
-        shell: bash
-        run: |
-          echo ${GOPOGH_RESULT}
-          numFail=$(echo $STAT | jq '.NumberOfFail')
-          numPass=$(echo $STAT | jq '.NumberOfPass')
-          echo "*******************${numPass} Passes :) *******************"
-          echo $STAT | jq '.PassedTests' || true
-          echo "*******************************************************"
-          echo "----------------${numFail} Failures :(----------------------------"
-          echo $STAT | jq '.FailedTests' || true
-          echo "-------------------------------------------------------"
-          if [ "$numFail" -gt 0 ];then echo "*** $numFail Failed ***";exit 2;fi
-          if [ "$numPass" -eq 0 ];then echo "*** 0 Passed! ***";exit 2;fi
-          if [ "$numPass" -lt 33 ];then echo "*** Failed to pass at least 33 ! ***";exit 2;fi
-          if [ "$numPass" -eq 0 ];then echo "*** Passed! ***";exit 0;fi
   functional_baremetal_ubuntu22_04:
     permissions:
       contents: none
@@ -760,7 +651,6 @@ jobs:
         functional_docker_containerd_ubuntu,
         functional_docker_rootless_containerd_ubuntu,
         functional_podman_ubuntu,
-        functional_virtualbox_macos,
         functional_baremetal_ubuntu22_04,
       ]
     runs-on: ubuntu-22.04
@@ -777,9 +667,7 @@ jobs:
           cp -r ./functional_docker_containerd_ubuntu ./all_reports/
           cp -r ./functional_docker_rootless_containerd_ubuntu ./all_reports/
           cp -r ./functional_podman_ubuntu ./all_reports/
-          cp -r ./functional_virtualbox_macos ./all_reports/
           cp -r ./functional_baremetal_ubuntu22_04 ./all_reports/
-
       - uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b
         with:
           name: all_reports


### PR DESCRIPTION
vbox tests on  macos12  are broken
and minikube does NOT support running on vbox on macos 13+
https://github.com/kubernetes/minikube/issues/15274 

this test was mainly used to try new ISOs on Free Github action agents, alternative would be waiting for macos15 that supports nested virtualization so we could try qemu driver on macos15
https://github.com/kubernetes/minikube/issues/19095

Previous experiments:
https://github.com/kubernetes/minikube/pull/19214
