### PR TITLE
CI: Remove extra bracket from script

### DIFF
--- a/hack/jenkins/test-flake-chart/sync_tests.sh
+++ b/hack/jenkins/test-flake-chart/sync_tests.sh
@@ -62,7 +62,7 @@ FINISHED_COUNT=$(\
   | wc -l)
 
 if [ ${STARTED_COUNT} -ne ${FINISHED_COUNT} ]; then
-  echo "Started environments are not all finished! Started: ${STARTED_LIST}, Finished: $(cat ${FINISHED_LIST}))"
+  echo "Started environments are not all finished! Started: ${STARTED_LIST}, Finished: $(cat ${FINISHED_LIST})"
   exit 0
 fi
 


### PR DESCRIPTION
```
QEMU_macOS, Finished: Docker_Cloud_Shell)
```