### PR TITLE
CI: Fix golang install

### DIFF
--- a/hack/jenkins/test-flake-chart/process_last_90/process_last_90.sh
+++ b/hack/jenkins/test-flake-chart/process_last_90/process_last_90.sh
@@ -19,7 +19,7 @@ set -eux -o pipefail
 # Get directory of script.
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-"${DIR}/../../installers/check_install_golang.sh" || true
+"${DIR}/../../installers/check_install_golang.sh" "/usr/local" || true
 
 DATA_CSV=$(mktemp)
 DATA_LAST_90_CSV=$(mktemp)


### PR DESCRIPTION
```
+ echo 'ERROR: given ! (0) parameters but expected 1.'
ERROR: given ! (0) parameters but expected 1.
+ echo 'USAGE: ./check_install_golang.sh INSTALL_PATH'
USAGE: ./check_install_golang.sh INSTALL_PATH
+ exit 1
+ true
```