### PR TITLE
CI: Update macOS deps via cron

### DIFF
--- a/hack/jenkins/cron/cleanup_and_reboot_Darwin.sh
+++ b/hack/jenkins/cron/cleanup_and_reboot_Darwin.sh
@@ -34,6 +34,9 @@ function check_jenkins() {
         && exit 1
 }
 
+brew upgrade
+gcloud components update -q
+
 check_jenkins
 logger "cleanup_and_reboot running - may shutdown in 60 seconds"
 echo "cleanup_and_reboot running - may shutdown in 60 seconds" | wall


### PR DESCRIPTION
We don't have anything updating `brew` components or `gcloud` on macOS systems, adding this to the cron