### PR TITLE
fix: fix empty tarball when generating image save

### DIFF
--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -265,7 +265,7 @@ func (r *Containerd) Disable() error {
 // ImageExists checks if image exists based on image name and optionally image sha
 func (r *Containerd) ImageExists(name string, sha string) bool {
 	klog.Infof("Checking existence of image with name %q and sha %q", name, sha)
-	c := exec.Command("sudo", "ctr", "-n=k8s.io", "images", "check")
+	c := exec.Command("sudo", "ctr", "-n=k8s.io", "images", "ls", fmt.Sprintf("name==%s", name))
 	// note: image name and image id's sha can be on different lines in ctr output
 	if rr, err := r.Runner.RunCmd(c); err != nil ||
 		!strings.Contains(rr.Output(), name) ||

--- a/pkg/minikube/cruntime/cri.go
+++ b/pkg/minikube/cruntime/cri.go
@@ -220,10 +220,28 @@ func removeCRIImage(cr CommandRunner, name string) error {
 	crictl := getCrictlPath(cr)
 	args := append([]string{crictl, "rmi"}, name)
 	c := exec.Command("sudo", args...)
-	if _, err := cr.RunCmd(c); err != nil {
-		return errors.Wrap(err, "crictl")
+	var err error
+	if _, err = cr.RunCmd(c); err == nil {
+		return nil
 	}
-	return nil
+	// the reason why we are doing this is that
+	// unlike other tool, podman assume the image has a localhost registry (not docker.io)
+	// if the image is loaded with a tarball without a registry specified in tag
+	// see https://github.com/containers/podman/issues/15974
+
+	// then retry with dockerio prefix
+	if _, err := cr.RunCmd(exec.Command("sudo", crictl, "rmi", AddDockerIO(name))); err == nil {
+		return nil
+	}
+
+	// then retry with localhost prefix
+	if _, err := cr.RunCmd(exec.Command("sudo", crictl, "rmi", AddLocalhostPrefix(name))); err == nil {
+
+		return nil
+	}
+
+	// if all of above failed, return original error
+	return errors.Wrap(err, "crictl")
 }
 
 // stopCRIContainers stops containers using crictl
@@ -357,4 +375,9 @@ func checkCNIPlugins(kubernetesVersion semver.Version) error {
 	}
 	_, err := os.Stat("/opt/cni/bin")
 	return err
+}
+
+// Add localhost prefix if the registry part is missing
+func AddLocalhostPrefix(name string) string {
+	return addRegistryPreix(name, "localhost")
 }

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -292,7 +292,7 @@ func (r *Docker) ListImages(ListImagesOptions) ([]ListImage, error) {
 		result = append(result, ListImage{
 			ID:          strings.TrimPrefix(jsonImage.ID, "sha256:"),
 			RepoDigests: []string{},
-			RepoTags:    []string{addDockerIO(repoTag)},
+			RepoTags:    []string{AddDockerIO(repoTag)},
 			Size:        fmt.Sprintf("%d", size),
 		})
 	}
@@ -696,14 +696,22 @@ func dockerImagesPreloaded(runner command.Runner, images []string) bool {
 }
 
 // Add docker.io prefix
-func addDockerIO(name string) string {
+func AddDockerIO(name string) string {
+	return addRegistryPreix(name, "docker.io")
+}
+func addRegistryPreix(name string, prefix string) string {
+	// we seperate the image name following this logic
+	// https://pkg.go.dev/github.com/distribution/reference#ParseNormalizedNamed
 	var reg, usr, img string
 	p := strings.SplitN(name, "/", 2)
-	if len(p) > 1 && strings.Contains(p[0], ".") {
+	// containing . means that it is a valid url for registry(e.g. xxx.io)
+	// containing : means it contains some port number (e.g. xxx:5432)
+	// it may also start with localhost, which is also regarded as a valid registry
+	if len(p) > 1 && (strings.ContainsAny(p[0], ".:") || strings.Contains(p[0], "localhost")) {
 		reg = p[0]
 		img = p[1]
 	} else {
-		reg = "docker.io"
+		reg = prefix
 		img = name
 		p = strings.SplitN(img, "/", 2)
 		if len(p) > 1 {

--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -335,7 +335,7 @@ func removeExistingImage(r cruntime.Manager, src string, imgName string) error {
 	}
 
 	errStr := strings.ToLower(err.Error())
-	if !strings.Contains(errStr, "no such image") {
+	if !strings.Contains(errStr, "no such image") && !strings.Contains(errStr, "unable to remove the image") {
 		return errors.Wrap(err, "removing image")
 	}
 
@@ -472,9 +472,22 @@ func transferAndSaveImage(cr command.Runner, k8s config.KubernetesConfig, dst st
 	if err != nil {
 		return errors.Wrap(err, "runtime")
 	}
+	found := false
+	// the reason why we are doing this is that
+	// unlike other tool, podman assume the image has a localhost registry (not docker.io)
+	// if the image is loaded with a tarball without a registry specified in tag
+	// see https://github.com/containers/podman/issues/15974
+	tryImageExist := []string{imgName, cruntime.AddDockerIO(imgName), cruntime.AddLocalhostPrefix(imgName)}
+	for _, imgName = range tryImageExist {
+		if r.ImageExists(imgName, "") {
+			found = true
+			break
+		}
+	}
 
-	if !r.ImageExists(imgName, "") {
-		return errors.Errorf("image %s not found", imgName)
+	if !found {
+		// if all of this failed, return the original error
+		return fmt.Errorf("image not found %s", imgName)
 	}
 
 	klog.Infof("Saving image to: %s", dst)


### PR DESCRIPTION
FIX #19233
### What happened: 
1. The direct reason why medya had to prefix docker.io in integration test was: When using contained runtime for minikube, if we try to look for an image `kicbase/echo-server:latest` without prefix `docker.io`, minikube will not fail. Instead, it will generate an empty tarball.

You can use the following instructions to reproduce this bug:
```shell
./out/minikube image load kicbase/echo-server #load the image into minikube
./out/minikube image save kicbase/echo-server:latest ech2
 du -h ech2
```
You will find that the size of tarball is 0

2. The actual reason why this happened is the flawed implementation of `func (r *Containerd) ImageExists(name string, sha string) bool` in `pkg/minikube/cruntime/containerd.go`

Original `ImageExists` use `ctr images check` to list all images, and then **check whether the given image name appears in the stdout**.  However, the output for command `ctr -n "k8s.io" image check` is something like this
```
docker@minikube:~$ sudo ctr -n=k8s.io images list
REF                                                                                                             TYPE                                                      DIGEST                                                                  SIZE      PLATFORMS                                                                    LABELS
docker.io/kicbase/echo-server:latest                                                                            application/vnd.oci.image.manifest.v1+json                sha256:b9f1cd6bd0f1e9e4de9e9fb198be91f9f6e78e61d5d40e85c2c5165ae1d67075 4.6 MiB   linux/arm64                                                                  io.cri-containerd.image=managed

...

```
That means both `ImageExists("docker.io/kicbase/echo-server:latest")` and `ImageExists("kicbase/echo-server:latest")` will return true, even we expect the latter one to return a false

3. According to the official reply in github discussion of contained (https://github.com/containerd/containerd/discussions/5334), The correct way to check the existence of the image is using `ctr -n "k8s.io" image list "name=xxxxxxxxxxxxxx"`. So I revised this function to do so.

4. Now `ImageExists("kicbase/echo-server:latest")` will return a false. However, we want `minikube image save kicbase/echo-server:latest ech2` to success. So I reused existing logic to add docker.io prefix and retry if no registry is specified.


5. After making the modification above, crio tests are still found to be broken. The reason is that when the image does not exist, and it does not start with "docker.io", crictl treats it  as localhost and returns, crictl returns 
 ```
docker@minikube:~$ sudo crictl rmi kicbase/echo-server:latest
E0728 22:18:38.259737    3975 remote_image.go:187] "Get ImageStatus from image service failed" err="rpc error: code = Unknown desc = short-name \"kicbase/echo-server:latest\" did not resolve to an alias and no unqualified-search registries are defined in \"/etc/containers/registries.conf\"" image="kicbase/echo-server:latest"
ERRO[0000] image status request for "kicbase/echo-server:latest" failed: rpc error: code = Unknown desc = short-name "kicbase/echo-server:latest" did not resolve to an alias and no unqualified-search registries are defined in "/etc/containers/registries.conf" 
FATA[0000] unable to remove the image(s)   
```
so the logic in `func removeExistingImage(r cruntime.Manager, src string, imgName string) error` of `pkg/minikube/machine/cache_images.go` is incomplete, and it return nil even if the image does not exist Then the image (without docker.io prefix) is regarded as existing image, and the load process abort.



### Before&After:  
Before: 
- `./out/minikube image save kicbase/echo-server:latest ech2` generates an empty tarball
```
 ./out/minikube image load kicbase/echo-server #load the image into minikube
./out/minikube image save kicbase/echo-server:latest ech2
 du -h ech2
0B    ech2
```
- cannot pass integration test with `const echoServerImg = "kicbase/echo-server"`


After:
- `./out/minikube image save kicbase/echo-server:latest ech2` generates correct tarball
```
 ./out/minikube image load kicbase/echo-server #load the image into minikube
./out/minikube image save kicbase/echo-server:latest ech2
 du -h ech2
2.1M    ech2
```
- can pass integration test with `const echoServerImg = "kicbase/echo-server"`

