### PR TITLE
Remove unnecessary dependency for build on Fedora

### DIFF
--- a/site/content/en/docs/contrib/building/binaries.md
+++ b/site/content/en/docs/contrib/building/binaries.md
@@ -11,12 +11,6 @@ weight: 2
 * If you are on Windows, you'll need Docker to be installed.
 * 4GB of RAM
 
-Additionally, if you are on Fedora, you will need to install `glibc-static`:
-
-```shell
-sudo dnf install -y glibc-static
-```
-
 ## Downloading the source
 
 ```shell

--- a/site/content/en/docs/contrib/building/iso.md
+++ b/site/content/en/docs/contrib/building/iso.md
@@ -49,12 +49,6 @@ sudo apt-get install build-essential gnupg2 p7zip-full git wget cpio python \
     unzip bc gcc-multilib automake libtool locales
 ```
 
-Additionally, if you are on Fedora, you will need to install `glibc-static`:
-
-```shell
-sudo dnf install -y glibc-static
-```
-
 ## Using a local ISO image
 
 ```shell


### PR DESCRIPTION
glibc-static is not required to be pre-installed on Fedora 40 and 41 any longer, even for static compilation with CGO_ENABLED=0.