### PR TITLE
Remove "docker.io/" prefixing when listing Docker images

### DIFF
--- a/pkg/minikube/download/image.go
+++ b/pkg/minikube/download/image.go
@@ -83,7 +83,7 @@ func ImageExistsInDaemon(img string) bool {
 		klog.Warningf("failed to list docker images: %v", err)
 		return false
 	}
-	if !strings.Contains(string(output), image.TrimDockerIO(img)) {
+	if !strings.Contains(string(output), img) {
 		return false
 	}
 	correctArch, err := isImageCorrectArch(img)

--- a/pkg/minikube/image/image.go
+++ b/pkg/minikube/image/image.go
@@ -319,9 +319,3 @@ func normalizeTagName(image string) string {
 	}
 	return base + ":" + tag
 }
-
-// Remove docker.io prefix since it won't be included in image names
-// when we call `docker images`.
-func TrimDockerIO(name string) string {
-	return strings.TrimPrefix(name, "docker.io/")
-}


### PR DESCRIPTION
This PR removes the use of the `addDockerIO` / `TrimDockerIO` functions when working with Docker images, in order to address #19343.

closes https://github.com/kubernetes/minikube/issues/19343