### PR TITLE
Fix kindnet permission to support network policies 

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -229,7 +229,7 @@ func initKubernetesFlags() {
 
 // initDriverFlags inits the commandline flags for vm drivers
 func initDriverFlags() {
-	startCmd.Flags().String("driver", "", fmt.Sprintf("Driver is one of: %v (defaults to auto-detect)", driver.DisplaySupportedDrivers()))
+	startCmd.Flags().StringP("driver", "d", fmt.Sprintf("Driver is one of: %v (defaults to auto-detect)", driver.DisplaySupportedDrivers()))
 	startCmd.Flags().String("vm-driver", "", "DEPRECATED, use `driver` instead.")
 	startCmd.Flags().Bool(disableDriverMounts, false, "Disables the filesystem mounts provided by the hypervisors")
 	startCmd.Flags().Bool("vm", false, "Filter to use only VM Drivers")

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -229,7 +229,7 @@ func initKubernetesFlags() {
 
 // initDriverFlags inits the commandline flags for vm drivers
 func initDriverFlags() {
-	startCmd.Flags().StringP("driver", "d", fmt.Sprintf("Driver is one of: %v (defaults to auto-detect)", driver.DisplaySupportedDrivers()))
+	startCmd.Flags().StringP("driver", "d", "", fmt.Sprintf("Driver is one of: %v (defaults to auto-detect)", driver.DisplaySupportedDrivers()))
 	startCmd.Flags().String("vm-driver", "", "DEPRECATED, use `driver` instead.")
 	startCmd.Flags().Bool(disableDriverMounts, false, "Disables the filesystem mounts provided by the hypervisors")
 	startCmd.Flags().Bool("vm", false, "Filter to use only VM Drivers")

--- a/pkg/minikube/cni/kindnet.go
+++ b/pkg/minikube/cni/kindnet.go
@@ -45,6 +45,8 @@ rules:
       - ""
     resources:
       - nodes
+      - namespaces
+      - pods
     verbs:
       - list
       - watch
@@ -55,6 +57,14 @@ rules:
       - configmaps
     verbs:
       - get
+  - apiGroups:
+      -  networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This PR gives "list,watch, patch" permissions for "namespaces" and "pods" to kindnet
also  "get, list, watch" for "networkpolicies"

## before this PR
$  kc logs kindnet-9mcm2 -n kube-system
```
 18:22:52.776415       1 reflector.go:547] pkg/mod/k8s.io/client-go@v0.30.2/tools/cache/reflector.go:232: failed to list *v1.Pod: pods is forbidden: User "system:serviceaccount:kube-system:kindnet" cannot list resource "pods" in API group "" at the cluster scope
E0731 18:22:52.776465       1 reflector.go:150] pkg/mod/k8s.io/client-go@v0.30.2/tools/cache/reflector.go:232: Failed to watch *v1.Pod: failed to list *v1.Pod: pods is forbidden: User "system:serviceaccount:kube-system:kindnet" cannot list resource "pods" in API group "" at the cluster scope
W0731 18:22:53.056062       1 reflector.go:547] pkg/mod/k8s.io/client-go@v0.30.2/tools/cache/reflector.go:232: failed to list *v1.NetworkPolicy: networkpolicies.networking.k8s.io is forbidden: User "system:serviceaccount:kube-system:kindnet" cannot list resource "networkpolicies" in API group "networking.k8s.io" at the cluster scope
E0731 18:22:53.056153       1 reflector.go:150] pkg/mod/k8s.io/client-go@v0.30.2/tools/cache/reflector.go:232: Failed to watch *v1.NetworkPolicy: failed to list *v1.NetworkPolicy: networkpolicies.networking.k8s.io is forbidden: User "system:serviceaccount:kube-system:kindnet" cannot list resource "networkpolicies" in API group "networking.k8s.io" at the cluster scope
I0731 18:22:57.041388       1 main.go:295] Handling node with IPs: map[192.168.58.2:{}]
I0731 18:22:57.041505       1 main.go:299] handling current node
I0731 18:23:07.041727       1 main.go:295] Handling node with IPs: map[192.168.58.2:{}]
I0731 18:23:07.041843       1 main.go:299] handling current node
W0731 18:23:08.695269       1 reflector.go:547] pkg/mod/k8s.io/client-go@v0.30.2/tools/cache/reflector.go:232: failed to list *v1.Namespace: namespaces is forbidden: User "system:serviceaccount:kube-system:kindnet" cannot list resource "namespaces" in API group "" at the cluster scope
E0731 18:23:08.695410       1 reflector.go:150] pkg/mod/k8s.io/client-go@v0.30.2/tools/cache/reflector.go:232: Failed to watch *v1.Namespace: failed to list *v1.Namespace: namespaces is forbidden: User "system:serviceaccount:kube-system:kindnet" cannot list resource "namespaces" in API group "" at the cluster scope
```

### After this PR

```
$ kc logs kindnet-ncrmw -n kube-system
I0731 18:20:49.133197       1 main.go:109] connected to apiserver: https://10.96.0.1:443
I0731 18:20:49.133466       1 main.go:139] hostIP = 192.168.76.2
podIP = 192.168.76.2
I0731 18:20:49.133626       1 main.go:148] setting mtu 65535 for CNI 
I0731 18:20:49.133644       1 main.go:178] kindnetd IP family: "ipv4"
I0731 18:20:49.133652       1 main.go:182] noMask IPv4 subnets: [10.244.0.0/16]
I0731 18:20:49.445874       1 controller.go:334] Starting controller kube-network-policies
I0731 18:20:49.445896       1 controller.go:338] Waiting for informer caches to sync
I0731 18:20:49.445902       1 shared_informer.go:313] Waiting for caches to sync for kube-network-policies
I0731 18:20:49.746685       1 shared_informer.go:320] Caches are synced for kube-network-policies
I0731 18:20:49.746731       1 metrics.go:61] Registering metrics
I0731 18:20:49.746821       1 controller.go:374] Syncing nftables rules
I0731 18:20:59.447037       1 main.go:295] Handling node with IPs: map[192.168.76.2:{}]
I0731 18:20:59.447301       1 main.go:299] handling current node
I0731 18:21:09.450421       1 main.go:295] Handling node with IPs: map[192.168.76.2:{}]
I0731 18:21:09.450502       1 main.go:299] handling current node
I0731 18:21:19.454696       1 main.go:295] Handling node with IPs: map[192.168.76.2:{}]
I0731 18:21:19.454788       1 main.go:299] handling current node
I0731 18:21:29.454483       1 main.go:295] Handling node with IPs: map[192.168.76.2:{}]
I0731 18:21:29.454576       1 main.go:299] handling current node
I0731 18:21:39.448905       1 main.go:295] Handling node with IPs: map[192.168.76.2:{}]
I0731 18:21:39.448997       1 main.go:299] handling current node
```

might fix https://github.com/kubernetes/minikube/issues/19357