### PR TITLE
Update ingress-dns.md

### DIFF
--- a/site/content/en/docs/handbook/addons/ingress-dns.md
+++ b/site/content/en/docs/handbook/addons/ingress-dns.md
@@ -292,8 +292,8 @@ Do not use .local as this is a reserved TLD for mDNS and bind9 DNS servers
 #### mDNS reloading
 Each time a file is created or a change is made to a file in `/etc/resolver` you may need to run the following to reload Mac OS mDNS resolver.
 ```bash
-sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.mDNSResponder.plist
-sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.mDNSResponder.plist
+sudo launchctl disable system/com.apple.mDNSResponder.reloaded
+sudo launchctl enable system/com.apple.mDNSResponder.reloaded
 ```
 
 ## TODO


### PR DESCRIPTION
fixes #19367

updated macOS mDNS reloading commands; launchctl deprecated the load/unload commands in favor or enable/disable commands

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
