### PR TITLE
Allow privileged ports on WSL

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1365,7 +1365,7 @@ func validateFlags(cmd *cobra.Command, drvName string) { //nolint:gocyclo
 	validateInsecureRegistry()
 }
 
-// validatePorts validates that the --ports are not below 1024 for the host and not outside range
+// validatePorts validates that the --ports are not outside range
 func validatePorts(ports []string) error {
 	var exposedPorts, hostPorts, portSpecs []string
 	for _, p := range ports {
@@ -1386,28 +1386,25 @@ func validatePorts(ports []string) error {
 		}
 	}
 	for _, p := range exposedPorts {
-		if err := validatePort(p, false); err != nil {
+		if err := validatePort(p); err != nil {
 			return err
 		}
 	}
 	for _, p := range hostPorts {
-		if err := validatePort(p, true); err != nil {
+		if err := validatePort(p); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func validatePort(port string, isHost bool) error {
+func validatePort(port string) error {
 	p, err := strconv.Atoi(port)
 	if err != nil {
 		return errors.Errorf("Sorry, one of the ports provided with --ports flag is not valid: %s", port)
 	}
 	if p > 65535 || p < 1 {
 		return errors.Errorf("Sorry, one of the ports provided with --ports flag is outside range: %s", port)
-	}
-	if isHost && detect.IsMicrosoftWSL() && p < 1024 {
-		return errors.Errorf("Sorry, you cannot use privileged ports on the host (below 1024): %s", port)
 	}
 	return nil
 }

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -30,7 +30,6 @@ import (
 	cfg "k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/cruntime"
-	"k8s.io/minikube/pkg/minikube/detect"
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/proxy"
 )
@@ -581,171 +580,98 @@ func TestIsTwoDigitSemver(t *testing.T) {
 }
 
 func TestValidatePorts(t *testing.T) {
-	isMicrosoftWSL := detect.IsMicrosoftWSL()
 	type portTest struct {
-		// isTarget indicates whether or not the test case is covered
-		// because validatePorts behaves differently depending on whether process is running in WSL in windows or not.
-		isTarget bool
 		ports    []string
 		errorMsg string
 	}
 	var tests = []portTest{
 		{
-			isTarget: true,
 			ports:    []string{"8080:80"},
 			errorMsg: "",
 		},
 		{
-			isTarget: true,
 			ports:    []string{"8080:80/tcp", "8080:80/udp"},
 			errorMsg: "",
 		},
 		{
-			isTarget: true,
 			ports:    []string{"test:8080"},
 			errorMsg: "Sorry, one of the ports provided with --ports flag is not valid [test:8080] (Invalid hostPort: test)",
 		},
 		{
-			isTarget: true,
 			ports:    []string{"0:80"},
 			errorMsg: "Sorry, one of the ports provided with --ports flag is outside range: 0",
 		},
 		{
-			isTarget: true,
 			ports:    []string{"0:80/tcp"},
 			errorMsg: "Sorry, one of the ports provided with --ports flag is outside range: 0",
 		},
 		{
-			isTarget: true,
 			ports:    []string{"65536:80/udp"},
 			errorMsg: "Sorry, one of the ports provided with --ports flag is not valid [65536:80/udp] (Invalid hostPort: 65536)",
 		},
 		{
-			isTarget: true,
 			ports:    []string{"0-1:80-81/tcp"},
 			errorMsg: "Sorry, one of the ports provided with --ports flag is outside range: 0",
 		},
 		{
-			isTarget: true,
 			ports:    []string{"0-1:80-81/udp"},
 			errorMsg: "Sorry, one of the ports provided with --ports flag is outside range: 0",
 		},
 		{
-			isTarget: !isMicrosoftWSL,
 			ports:    []string{"80:80", "1023-1025:8023-8025", "1023-1025:8023-8025/tcp", "1023-1025:8023-8025/udp"},
 			errorMsg: "",
 		},
 		{
-			isTarget: isMicrosoftWSL,
-			ports:    []string{"80:80"},
-			errorMsg: "Sorry, you cannot use privileged ports on the host (below 1024): 80",
-		},
-		{
-			isTarget: isMicrosoftWSL,
-			ports:    []string{"1023-1025:8023-8025"},
-			errorMsg: "Sorry, you cannot use privileged ports on the host (below 1024): 1023",
-		},
-		{
-			isTarget: isMicrosoftWSL,
-			ports:    []string{"1023-1025:8023-8025/tcp"},
-			errorMsg: "Sorry, you cannot use privileged ports on the host (below 1024): 1023",
-		},
-		{
-			isTarget: isMicrosoftWSL,
-			ports:    []string{"1023-1025:8023-8025/udp"},
-			errorMsg: "Sorry, you cannot use privileged ports on the host (below 1024): 1023",
-		},
-		{
-			isTarget: true,
 			ports:    []string{"127.0.0.1:8080:80", "127.0.0.1:8081:80/tcp", "127.0.0.1:8081:80/udp", "127.0.0.1:8082-8083:8082-8083/tcp"},
 			errorMsg: "",
 		},
 		{
-			isTarget: true,
 			ports:    []string{"1000.0.0.1:80:80"},
 			errorMsg: "Sorry, one of the ports provided with --ports flag is not valid [1000.0.0.1:80:80] (Invalid ip address: 1000.0.0.1)",
 		},
 		{
-			isTarget: !isMicrosoftWSL,
 			ports:    []string{"127.0.0.1:80:80", "127.0.0.1:81:81/tcp", "127.0.0.1:81:81/udp", "127.0.0.1:82-83:82-83/tcp", "127.0.0.1:82-83:82-83/udp"},
 			errorMsg: "",
 		},
 		{
-			isTarget: isMicrosoftWSL,
-			ports:    []string{"127.0.0.1:80:80"},
-			errorMsg: "Sorry, you cannot use privileged ports on the host (below 1024): 80",
-		},
-		{
-			isTarget: isMicrosoftWSL,
-			ports:    []string{"127.0.0.1:81:81/tcp"},
-			errorMsg: "Sorry, you cannot use privileged ports on the host (below 1024): 81",
-		},
-		{
-			isTarget: isMicrosoftWSL,
-			ports:    []string{"127.0.0.1:81:81/udp"},
-			errorMsg: "Sorry, you cannot use privileged ports on the host (below 1024): 81",
-		},
-		{
-			isTarget: isMicrosoftWSL,
-			ports:    []string{"127.0.0.1:80-83:80-83/tcp"},
-			errorMsg: "Sorry, you cannot use privileged ports on the host (below 1024): 80",
-		},
-		{
-			isTarget: isMicrosoftWSL,
-			ports:    []string{"127.0.0.1:80-83:80-83/udp"},
-			errorMsg: "Sorry, you cannot use privileged ports on the host (below 1024): 80",
-		},
-		{
-			isTarget: true,
 			ports:    []string{"80"},
 			errorMsg: "",
 		},
 		{
-			isTarget: true,
 			ports:    []string{"80", "65535", "65536"},
 			errorMsg: "Sorry, one of the ports provided with --ports flag is outside range: 65536",
 		},
 		{
-			isTarget: true,
 			ports:    []string{"0", "80", "65535"},
 			errorMsg: "Sorry, one of the ports provided with --ports flag is outside range: 0",
 		},
 		{
-			isTarget: true,
 			ports:    []string{"cats"},
 			errorMsg: "Sorry, one of the ports provided with --ports flag is not valid: cats",
 		},
 		{
-			isTarget: true,
 			ports:    []string{"127.0.0.1:81:0/tcp"},
 			errorMsg: "Sorry, one of the ports provided with --ports flag is outside range: 0",
 		},
 		{
-			isTarget: true,
 			ports:    []string{"127.0.0.1:81:65536/tcp"},
 			errorMsg: "Sorry, one of the ports provided with --ports flag is not valid [127.0.0.1:81:65536/tcp] (Invalid containerPort: 65536)",
 		},
 		{
-			isTarget: true,
 			ports:    []string{"1-65536:80-81/tcp"},
 			errorMsg: "Sorry, one of the ports provided with --ports flag is not valid [1-65536:80-81/tcp] (Invalid hostPort: 1-65536)",
 		},
 		{
-			isTarget: true,
 			ports:    []string{"1-80:0-81/tcp"},
 			errorMsg: "Sorry, one of the ports provided with --ports flag is not valid [1-80:0-81/tcp] (Invalid ranges specified for container and host Ports: 0-81 and 1-80)",
 		},
 		{
-			isTarget: true,
 			ports:    []string{"1-80:1-65536/tcp"},
 			errorMsg: "Sorry, one of the ports provided with --ports flag is not valid [1-80:1-65536/tcp] (Invalid containerPort: 1-65536)",
 		},
 	}
 	for _, test := range tests {
 		t.Run(strings.Join(test.ports, ","), func(t *testing.T) {
-			if !test.isTarget {
-				return
-			}
 			gotError := ""
 			got := validatePorts(test.ports)
 			if got != nil {


### PR DESCRIPTION
Using ports below 1024 should be allowed on WSL in the same way as on Linux.
It should be left for the OS to decide whether it is allowed, respecting Linux Capabilities (e.g. CAP_NET_BIND_SERVICE), etc.

Going through the git history I got the impression, that it was left out for WSL to err on the safe side, but I don't see any explicit reason it should stay. Correct me if I'm wrong, please.

It doesn't fix any known issue as far as I know, I just noticed it myself and decided to create a new PR

