### PR TITLE
Add Parallels driver support for darwin/arm64

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -243,7 +243,7 @@ require (
 
 replace (
 	git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
-	github.com/Parallels/docker-machine-parallels/v2 => github.com/minikube-machine/machine-driver-parallels/v2 v2.0.1
+	github.com/Parallels/docker-machine-parallels/v2 => github.com/minikube-machine/machine-driver-parallels/v2 v2.0.2-0.20240730142131-ada9375ea417
 	github.com/briandowns/spinner => github.com/alonyb/spinner v1.12.7
 	github.com/docker/machine => github.com/minikube-machine/machine v0.0.0-20230814171452-e95650b07516
 	github.com/intel-go/cpuid => github.com/aregm/cpuid v0.0.0-20181003105527-1a4a6f06a1c6

--- a/go.sum
+++ b/go.sum
@@ -1192,8 +1192,8 @@ github.com/miekg/dns v1.1.48/go.mod h1:e3IlAVfNqAllflbibAZEWOXOQ+Ynzk/dDozDxY7Xn
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/minikube-machine/machine v0.0.0-20230814171452-e95650b07516 h1:TdnOOGMei4q3MooTy2xYv+EKnMyKUJE2LFotmBzC1zk=
 github.com/minikube-machine/machine v0.0.0-20230814171452-e95650b07516/go.mod h1:I+HtQRi2cs3knYUuHwiY59H9j52F03+l489Vm6AoMok=
-github.com/minikube-machine/machine-driver-parallels/v2 v2.0.1 h1:eYP7NkEv+tUZeB7BLfJ8PF4UNCW6lVyrbMvcWh1rgMA=
-github.com/minikube-machine/machine-driver-parallels/v2 v2.0.1/go.mod h1:NKwI5KryEmEHMZVj80t9JQcfXWZp4/ZYNBuw4C5sQ9E=
+github.com/minikube-machine/machine-driver-parallels/v2 v2.0.2-0.20240730142131-ada9375ea417 h1:f+neTRGCtvmW3Tm1V72vWpoTPuNOnXSQsHZdYOryfGM=
+github.com/minikube-machine/machine-driver-parallels/v2 v2.0.2-0.20240730142131-ada9375ea417/go.mod h1:NKwI5KryEmEHMZVj80t9JQcfXWZp4/ZYNBuw4C5sQ9E=
 github.com/minikube-machine/machine-driver-vmware v0.1.6-0.20230701123042-a391c48b14d5 h1:1z7xOzfMO4aBR9+2nYjlhRXX1773fX60HTS0QGpGRPU=
 github.com/minikube-machine/machine-driver-vmware v0.1.6-0.20230701123042-a391c48b14d5/go.mod h1:HifYFOWR0bAMN4hWtaSADClogvtPy/jV0aRC5alhrKo=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=

--- a/pkg/minikube/driver/driver_darwin.go
+++ b/pkg/minikube/driver/driver_darwin.go
@@ -28,6 +28,7 @@ var supportedDrivers = func() []string {
 		// on darwin/arm64 only docker and ssh are supported yet
 		return []string{
 			QEMU2,
+			Parallels,
 			Docker,
 			Podman,
 			SSH,


### PR DESCRIPTION
fixes: #11219

<details><summary><code>minikube start --driver=parallels # creating new cluster</code></summary>

```
❯ minikube start --driver=parallels
😄  minikube v1.33.1 on Darwin 14.5 (arm64)
✨  Using the parallels driver based on user configuration
👍  Starting "minikube" primary control-plane node in "minikube" cluster
🔥  Creating parallels VM (CPUs=2, Memory=6000MB, Disk=20000MB) ...
🐳  Preparing Kubernetes v1.30.3 on Docker 27.1.1 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```

</details>

<details><summary><code>minikube status</code></summary>

```
❯ minikube status
minikube
type: Control Plane
host: Running
kubelet: Running
apiserver: Running
kubeconfig: Configured
```
</details>

<details><summary><code>kubectl get nodes -o wide</code></summary>

```
❯ kubectl get nodes -o wide
NAME       STATUS   ROLES           AGE   VERSION   INTERNAL-IP    EXTERNAL-IP   OS-IMAGE              KERNEL-VERSION   CONTAINER-RUNTIME
minikube   Ready    control-plane   18s   v1.30.3   10.211.55.76   <none>        Buildroot 2023.02.9   5.10.207         docker://27.1.1
```
</details>

<details><summary><code>kubectl describe nodes minikube</code></summary>

```
❯ kubectl describe nodes minikube
Name:               minikube
Roles:              control-plane
Labels:             beta.kubernetes.io/arch=arm64
                    beta.kubernetes.io/os=linux
                    kubernetes.io/arch=arm64
                    kubernetes.io/hostname=minikube
                    kubernetes.io/os=linux
                    minikube.k8s.io/commit=732b969929aa87c65157b4450d065c16abacfc41-dirty
                    minikube.k8s.io/name=minikube
                    minikube.k8s.io/primary=true
                    minikube.k8s.io/updated_at=2024_08_04T18_48_25_0700
                    minikube.k8s.io/version=v1.33.1
                    node-role.kubernetes.io/control-plane=
                    node.kubernetes.io/exclude-from-external-load-balancers=
Annotations:        kubeadm.alpha.kubernetes.io/cri-socket: unix:///var/run/cri-dockerd.sock
                    node.alpha.kubernetes.io/ttl: 0
                    volumes.kubernetes.io/controller-managed-attach-detach: true
CreationTimestamp:  Sun, 04 Aug 2024 18:48:22 +0200
Taints:             <none>
Unschedulable:      false
Lease:
  HolderIdentity:  minikube
  AcquireTime:     <unset>
  RenewTime:       Sun, 04 Aug 2024 18:48:44 +0200
Conditions:
  Type             Status  LastHeartbeatTime                 LastTransitionTime                Reason                       Message
  ----             ------  -----------------                 ------------------                ------                       -------
  MemoryPressure   False   Sun, 04 Aug 2024 18:48:45 +0200   Sun, 04 Aug 2024 18:48:21 +0200   KubeletHasSufficientMemory   kubelet has sufficient memory available
  DiskPressure     False   Sun, 04 Aug 2024 18:48:45 +0200   Sun, 04 Aug 2024 18:48:21 +0200   KubeletHasNoDiskPressure     kubelet has no disk pressure
  PIDPressure      False   Sun, 04 Aug 2024 18:48:45 +0200   Sun, 04 Aug 2024 18:48:21 +0200   KubeletHasSufficientPID      kubelet has sufficient PID available
  Ready            True    Sun, 04 Aug 2024 18:48:45 +0200   Sun, 04 Aug 2024 18:48:28 +0200   KubeletReady                 kubelet is posting ready status
Addresses:
  InternalIP:  10.211.55.76
  Hostname:    minikube
Capacity:
  cpu:                2
  ephemeral-storage:  17734596Ki
  hugepages-1Gi:      0
  hugepages-2Mi:      0
  hugepages-32Mi:     0
  hugepages-64Ki:     0
  memory:             5910208Ki
  pods:               110
Allocatable:
  cpu:                2
  ephemeral-storage:  17734596Ki
  hugepages-1Gi:      0
  hugepages-2Mi:      0
  hugepages-32Mi:     0
  hugepages-64Ki:     0
  memory:             5910208Ki
  pods:               110
System Info:
  Machine ID:                 b66cc9e9b275473192aba1fa28ec81ad
  System UUID:                54cb3b06-1738-4af0-8156-a35887ffe37b
  Boot ID:                    29d14d48-9f25-44c6-b124-6d1dcd6ea811
  Kernel Version:             5.10.207
  OS Image:                   Buildroot 2023.02.9
  Operating System:           linux
  Architecture:               arm64
  Container Runtime Version:  docker://27.1.1
  Kubelet Version:            v1.30.3
  Kube-Proxy Version:         v1.30.3
PodCIDR:                      10.244.0.0/24
PodCIDRs:                     10.244.0.0/24
Non-terminated Pods:          (7 in total)
  Namespace                   Name                                CPU Requests  CPU Limits  Memory Requests  Memory Limits  Age
  ---------                   ----                                ------------  ----------  ---------------  -------------  ---
  kube-system                 coredns-7db6d8ff4d-956br            100m (5%)     0 (0%)      70Mi (1%)        170Mi (2%)     14s
  kube-system                 etcd-minikube                       100m (5%)     0 (0%)      100Mi (1%)       0 (0%)         28s
  kube-system                 kube-apiserver-minikube             250m (12%)    0 (0%)      0 (0%)           0 (0%)         28s
  kube-system                 kube-controller-manager-minikube    200m (10%)    0 (0%)      0 (0%)           0 (0%)         28s
  kube-system                 kube-proxy-rxgt2                    0 (0%)        0 (0%)      0 (0%)           0 (0%)         14s
  kube-system                 kube-scheduler-minikube             100m (5%)     0 (0%)      0 (0%)           0 (0%)         29s
  kube-system                 storage-provisioner                 0 (0%)        0 (0%)      0 (0%)           0 (0%)         27s
Allocated resources:
  (Total limits may be over 100 percent, i.e., overcommitted.)
  Resource           Requests    Limits
  --------           --------    ------
  cpu                750m (37%)  0 (0%)
  memory             170Mi (2%)  170Mi (2%)
  ephemeral-storage  0 (0%)      0 (0%)
  hugepages-1Gi      0 (0%)      0 (0%)
  hugepages-2Mi      0 (0%)      0 (0%)
  hugepages-32Mi     0 (0%)      0 (0%)
  hugepages-64Ki     0 (0%)      0 (0%)
Events:
  Type    Reason                   Age   From             Message
  ----    ------                   ----  ----             -------
  Normal  Starting                 12s   kube-proxy
  Normal  NodeHasSufficientMemory  32s   kubelet          Node minikube status is now: NodeHasSufficientMemory
  Normal  Starting                 28s   kubelet          Starting kubelet.
  Normal  NodeAllocatableEnforced  28s   kubelet          Updated Node Allocatable limit across pods
  Normal  NodeHasSufficientMemory  28s   kubelet          Node minikube status is now: NodeHasSufficientMemory
  Normal  NodeHasNoDiskPressure    28s   kubelet          Node minikube status is now: NodeHasNoDiskPressure
  Normal  NodeHasSufficientPID     28s   kubelet          Node minikube status is now: NodeHasSufficientPID
  Normal  NodeReady                24s   kubelet          Node minikube status is now: NodeReady
  Normal  RegisteredNode           15s   node-controller  Node minikube event: Registered Node minikube in Controller
```
</details>

<details><summary><code>minikube --alsologtostderr -v=3 stop # stopping cluster</code></summary>

```
❯ minikube --alsologtostderr -v=3 stop
I0804 18:49:10.157781   74614 out.go:291] Setting OutFile to fd 1 ...
I0804 18:49:10.158322   74614 out.go:343] isatty.IsTerminal(1) = true
I0804 18:49:10.158330   74614 out.go:304] Setting ErrFile to fd 2...
I0804 18:49:10.158335   74614 out.go:343] isatty.IsTerminal(2) = true
I0804 18:49:10.158458   74614 root.go:338] Updating PATH: /Users/abasalaev/.minikube/bin
I0804 18:49:10.158730   74614 out.go:298] Setting JSON to false
I0804 18:49:10.158865   74614 mustload.go:65] Loading cluster: minikube
I0804 18:49:10.159066   74614 config.go:182] Loaded profile config "minikube": Driver=parallels, ContainerRuntime=docker, KubernetesVersion=v1.30.3
I0804 18:49:10.159113   74614 profile.go:143] Saving config to /Users/abasalaev/.minikube/profiles/minikube/config.json ...
I0804 18:49:10.159463   74614 mustload.go:65] Loading cluster: minikube
I0804 18:49:10.159540   74614 config.go:182] Loaded profile config "minikube": Driver=parallels, ContainerRuntime=docker, KubernetesVersion=v1.30.3
I0804 18:49:10.159753   74614 stop.go:39] StopHost: minikube
I0804 18:49:10.165336   74614 out.go:177] ✋  Stopping node "minikube"  ...
✋  Stopping node "minikube"  ...
I0804 18:49:10.173187   74614 machine.go:157] backing up vm config to /var/lib/minikube/backup: [/etc/cni /etc/kubernetes]
I0804 18:49:10.173282   74614 ssh_runner.go:195] Run: sudo mkdir -p /var/lib/minikube/backup
I0804 18:49:10.173528   74614 main.go:141] libmachine: executing: /usr/local/bin/prlctl list minikube --output status --no-header
I0804 18:49:10.295991   74614 main.go:141] libmachine: executing: /usr/local/bin/prlctl list -i minikube
I0804 18:49:10.482311   74614 main.go:141] libmachine: Found lease: 10.211.55.76 for MAC: 001C42FCF2F8, expiring at 1722791878, leased for 1800 s.

I0804 18:49:10.482355   74614 main.go:141] libmachine: Found IP lease: 10.211.55.76 for MAC address 001C42FCF2F8

I0804 18:49:10.482374   74614 sshutil.go:53] new ssh client: &{IP:10.211.55.76 Port:22 SSHKeyPath:/Users/abasalaev/.minikube/machines/minikube/id_rsa Username:docker}
I0804 18:49:10.507939   74614 ssh_runner.go:195] Run: sudo rsync --archive --relative /etc/cni /var/lib/minikube/backup
I0804 18:49:10.552969   74614 ssh_runner.go:195] Run: sudo rsync --archive --relative /etc/kubernetes /var/lib/minikube/backup
I0804 18:49:10.600149   74614 main.go:141] libmachine: Stopping "minikube"...
I0804 18:49:10.600192   74614 main.go:141] libmachine: executing: /usr/local/bin/prlctl list minikube --output status --no-header
I0804 18:49:10.722496   74614 main.go:141] libmachine: executing: /usr/local/bin/prlctl stop minikube
I0804 18:50:09.749292   74614 main.go:141] libmachine: executing: /usr/local/bin/prlctl list minikube --output status --no-header
I0804 18:50:10.822492   74614 main.go:141] libmachine: executing: /usr/local/bin/prlctl list minikube --output status --no-header
I0804 18:50:10.949578   74614 main.go:141] libmachine: Machine "minikube" was stopped.
I0804 18:50:10.949606   74614 stop.go:75] duration metric: took 1m0.775807167s to stop
I0804 18:50:10.952477   74614 lock.go:35] WriteFile acquiring /Users/abasalaev/.kube/config: {Name:mk2511360dcfc3b3142e141744412eed433ed661 Clock:{} Delay:500ms Timeout:1m0s Cancel:<nil>}
I0804 18:50:10.957659   74614 out.go:177] 🛑  1 node stopped.
🛑  1 node stopped.
```
</details>

<details><summary><code>minikube --alsologtostderr -v=3 delete # deleting cluster</code></summary>

```
❯ minikube --alsologtostderr -v=3 delete
I0804 18:51:32.873074   76402 out.go:291] Setting OutFile to fd 1 ...
I0804 18:51:32.873454   76402 out.go:343] isatty.IsTerminal(1) = true
I0804 18:51:32.873462   76402 out.go:304] Setting ErrFile to fd 2...
I0804 18:51:32.873466   76402 out.go:343] isatty.IsTerminal(2) = true
I0804 18:51:32.873586   76402 root.go:338] Updating PATH: /Users/abasalaev/.minikube/bin
I0804 18:51:32.873854   76402 out.go:298] Setting JSON to false
I0804 18:51:32.874039   76402 cli_runner.go:164] Run: docker ps -a --filter label=name.minikube.sigs.k8s.io --format {{.Names}}
I0804 18:51:50.601967   76402 cli_runner.go:217] Completed: docker ps -a --filter label=name.minikube.sigs.k8s.io --format {{.Names}}: (17.72766875s)
I0804 18:51:50.605109   76402 config.go:182] Loaded profile config "bridge-193000": Driver=docker, ContainerRuntime=docker, KubernetesVersion=v1.30.2
I0804 18:51:50.605414   76402 config.go:182] Loaded profile config "flannel-193000": Driver=docker, ContainerRuntime=docker, KubernetesVersion=v1.30.2
I0804 18:51:50.605530   76402 config.go:182] Loaded profile config "minikube": Driver=parallels, ContainerRuntime=docker, KubernetesVersion=v1.30.3
I0804 18:51:50.605664   76402 config.go:182] Loaded profile config "minikube": Driver=parallels, ContainerRuntime=docker, KubernetesVersion=v1.30.3
I0804 18:51:50.605691   76402 delete.go:301] DeleteProfiles
I0804 18:51:50.605702   76402 delete.go:329] Deleting minikube
I0804 18:51:50.605713   76402 delete.go:334] minikube configuration: &{Name:minikube KeepContext:false EmbedCerts:false MinikubeISO:https://storage.googleapis.com/minikube-builds/iso/19339/minikube-v1.33.1-1722248113-19339-arm64.iso KicBaseImage:gcr.io/k8s-minikube/kicbase-builds:v0.0.44-1721902582-19326@sha256:540fb5dc7f38be17ff5276a38dfe6c8a4b1d9ba1c27c62244e6eebd7e37696e7 Memory:6000 CPUs:2 DiskSize:20000 Driver:parallels HyperkitVpnKitSock: HyperkitVSockPorts:[] DockerEnv:[] ContainerVolumeMounts:[] InsecureRegistry:[] RegistryMirror:[] HostOnlyCIDR:192.168.59.1/24 HypervVirtualSwitch: HypervUseExternalSwitch:false HypervExternalAdapter: KVMNetwork:default KVMQemuURI:qemu:///system KVMGPU:false KVMHidden:false KVMNUMACount:1 APIServerPort:8443 DockerOpt:[] DisableDriverMounts:false NFSShare:[] NFSSharesRoot:/nfsshares UUID: NoVTXCheck:false DNSProxy:false HostDNSResolver:true HostOnlyNicType:virtio NatNicType:virtio SSHIPAddress: SSHUser:root SSHKey: SSHPort:22 KubernetesConfig:{KubernetesVersion:v1.30.3 ClusterName:minikube Namespace:default APIServerHAVIP: APIServerName:minikubeCA APIServerNames:[] APIServerIPs:[] DNSDomain:cluster.local ContainerRuntime:docker CRISocket: NetworkPlugin:cni FeatureGates: ServiceCIDR:10.96.0.0/12 ImageRepository: LoadBalancerStartIP: LoadBalancerEndIP: CustomIngressCert: RegistryAliases: ExtraOptions:[] ShouldLoadCachedImages:true EnableDefaultCNI:false CNI:} Nodes:[{Name: IP:10.211.55.76 Port:8443 KubernetesVersion:v1.30.3 ContainerRuntime:docker ControlPlane:true Worker:true}] Addons:map[default-storageclass:true storage-provisioner:true] CustomAddonImages:map[] CustomAddonRegistries:map[] VerifyComponents:map[apiserver:true system_pods:true] StartHostTimeout:6m0s ScheduledStop:<nil> ExposedPorts:[] ListenAddress: Network: Subnet: MultiNodeRequested:false ExtraDisks:0 CertExpiration:26280h0m0s Mount:false MountString:/Users:/minikube-host Mount9PVersion:9p2000.L MountGID:docker MountIP: MountMSize:262144 MountOptions:[] MountPort:0 MountType:9p MountUID:docker BinaryMirror: DisableOptimizations:false DisableMetrics:false CustomQemuFirmwarePath: SocketVMnetClientPath: SocketVMnetPath: StaticIP: SSHAuthSock: SSHAgentPID:0 GPUs: AutoPauseInterval:1m0s}
I0804 18:51:50.605900   76402 config.go:182] Loaded profile config "minikube": Driver=parallels, ContainerRuntime=docker, KubernetesVersion=v1.30.3
I0804 18:51:50.606229   76402 config.go:182] Loaded profile config "minikube": Driver=parallels, ContainerRuntime=docker, KubernetesVersion=v1.30.3
I0804 18:51:50.607063   76402 main.go:141] libmachine: executing: /usr/local/bin/prlctl list minikube --output status --no-header
I0804 18:51:50.738839   76402 out.go:177] 🔥  Deleting "minikube" in parallels ...
🔥  Deleting "minikube" in parallels ...
I0804 18:51:50.744500   76402 main.go:141] libmachine: executing: /usr/local/bin/prlctl list minikube --output status --no-header
I0804 18:51:50.886207   76402 main.go:141] libmachine: executing: /usr/local/bin/prlctl stop minikube --kill
I0804 18:51:52.233598   76402 main.go:141] libmachine: executing: /usr/local/bin/prlctl delete minikube
I0804 18:51:52.371577   76402 lock.go:35] WriteFile acquiring /Users/abasalaev/.kube/config: {Name:mk2511360dcfc3b3142e141744412eed433ed661 Clock:{} Delay:500ms Timeout:1m0s Cancel:<nil>}
I0804 18:51:52.379028   76402 out.go:177] 💀  Removed all traces of the "minikube" cluster.
💀  Removed all traces of the "minikube" cluster.
```
</details>
