### PR TITLE
site: add docker.io to all echo-server examples

### DIFF
--- a/site/content/en/docs/handbook/accessing.md
+++ b/site/content/en/docs/handbook/accessing.md
@@ -41,7 +41,7 @@ Services of type `NodePort` can be exposed via the `minikube service <service-na
 1. Create a Kubernetes deployment
 
     ```shell
-    kubectl create deployment hello-minikube1 --image=kicbase/echo-server:1.0
+    kubectl create deployment hello-minikube1 --image=docker.io/kicbase/echo-server:1.0
     ```
 
 2. Create a Kubernetes service type NodePort
@@ -159,7 +159,7 @@ Services of type `LoadBalancer` can be exposed via the `minikube tunnel` command
 2. Create a Kubernetes deployment
 
     ```shell
-    kubectl create deployment hello-minikube1 --image=kicbase/echo-server:1.0
+    kubectl create deployment hello-minikube1 --image=docker.io/kicbase/echo-server:1.0
     ```
 
 3. Create a Kubernetes service with type LoadBalancer

--- a/site/content/en/docs/handbook/addons/ambassador.md
+++ b/site/content/en/docs/handbook/addons/ambassador.md
@@ -54,7 +54,7 @@ this [post](https://blog.getambassador.io/new-kubernetes-1-18-extends-ingress-c3
 First, let's create a Kubernetes deployment and service which we will talk to via Ambassador.
 
 ```shell script
-kubectl create deployment hello-minikube --image=kicbase/echo-server:1.0
+kubectl create deployment hello-minikube --image=docker.io/kicbase/echo-server:1.0
 kubectl expose deployment hello-minikube --port=8080
 ```
 
@@ -103,7 +103,7 @@ that maps a target backend service to a given host or prefix.
 
 Let's create another Kubernetes deployment and service that we will expose via Ambassador -
 ```shell script
-kubectl create deployment mapping-minikube --image=kicbase/echo-server:1.0
+kubectl create deployment mapping-minikube --image=docker.io/kicbase/echo-server:1.0
 kubectl expose deployment mapping-minikube --port=8080
 ```
 

--- a/site/content/en/docs/handbook/controls.md
+++ b/site/content/en/docs/handbook/controls.md
@@ -25,7 +25,7 @@ minikube dashboard
 Once started, you can interact with your cluster using `kubectl`, just like any other Kubernetes cluster. For instance, starting a server:
 
 ```shell
-kubectl create deployment hello-minikube --image=kicbase/echo-server:1.0
+kubectl create deployment hello-minikube --image=docker.io/kicbase/echo-server:1.0
 ```
 
 Exposing a service as a NodePort

--- a/site/content/en/docs/handbook/deploying.md
+++ b/site/content/en/docs/handbook/deploying.md
@@ -11,7 +11,7 @@ aliases:
 ## kubectl
 
 ```shell
-kubectl create deployment hello-minikube1 --image=kicbase/echo-server:1.0
+kubectl create deployment hello-minikube1 --image=docker.io/kicbase/echo-server:1.0
 kubectl expose deployment hello-minikube1 --type=LoadBalancer --port=8080
 ```
 

--- a/site/content/en/docs/handbook/kubectl.md
+++ b/site/content/en/docs/handbook/kubectl.md
@@ -81,7 +81,7 @@ minikube kubectl -- get pods
 Creating a deployment inside kubernetes cluster
 
 ```shell
-minikube kubectl -- create deployment hello-minikube --image=kicbase/echo-server:1.0
+minikube kubectl -- create deployment hello-minikube --image=docker.io/kicbase/echo-server:1.0
 ```
 
 Exposing the deployment with a NodePort service

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -572,7 +572,7 @@ minikube dashboard
 Create a sample deployment and expose it on port 8080:
 
 ```shell
-kubectl create deployment hello-minikube --image=kicbase/echo-server:1.0
+kubectl create deployment hello-minikube --image=docker.io/kicbase/echo-server:1.0
 kubectl expose deployment hello-minikube --type=NodePort --port=8080
 ```
 
@@ -602,7 +602,7 @@ You should be able to see the request metadata in the application output. Try ch
 To access a LoadBalancer deployment, use the "minikube tunnel" command. Here is an example deployment:
 
 ```shell
-kubectl create deployment balanced --image=kicbase/echo-server:1.0
+kubectl create deployment balanced --image=docker.io/kicbase/echo-server:1.0
 kubectl expose deployment balanced --type=LoadBalancer --port=8080
 ```
 
@@ -637,7 +637,7 @@ metadata:
 spec:
   containers:
     - name: foo-app
-      image: 'kicbase/echo-server:1.0'
+      image: 'docker.io/kicbase/echo-server:1.0'
 ---
 kind: Service
 apiVersion: v1
@@ -658,7 +658,7 @@ metadata:
 spec:
   containers:
     - name: bar-app
-      image: 'kicbase/echo-server:1.0'
+      image: 'docker.io/kicbase/echo-server:1.0'
 ---
 kind: Service
 apiVersion: v1


### PR DESCRIPTION
on crio not specifying the FQDN for the image name makes crio not be able to pull the image, so better to have it FQDN everywhere.

on crio
### fails
$ kubectl create deployment hello-minikube --image=kicbase/echo-server:1.0
deployment.apps/hello-minikube created
```
default       hello-minikube-5c898d8489-8gh5t    0/1     ImageInspectError   0          15s
```

```
Failed to inspect image "kicbase/echo-server:1.0": rpc error: code = Unknown desc = short-name "kicbase/echo-server:1.0" did not resolve to an alias and no unqualified-search registries are defined in "/etc/containers/registries.conf"
```


### works
$ kubectl create deployment hello-minikube2 --image=docker.io/kicbase/echo-server:1.0
deployment.apps/hello-minikube2 created


### future works

we should consider adding docker.io to /etc/containers/registries.conf so other people dont have the same issue

https://github.com/kubernetes/minikube/issues/19396