### PR TITLE
Updated tutorial steps

### DIFF
--- a/site/content/en/docs/tutorials/kubernetes_101/module5.md
+++ b/site/content/en/docs/tutorials/kubernetes_101/module5.md
@@ -10,13 +10,7 @@ The goal of this scenario is to scale a deployment with kubectl scale and to see
 
 ## Step 1 - Scaling a deployment
 
-First, let's recreate the Deployment we deleted in the previous module:
-
-```shell
-kubectl expose deployment/kubernetes-bootcamp --type="NodePort" --port 8080
-```
-
-To list your deployments use the `get deployment` command:
+First, let's list the deployments using the `get deployment` command:
 
 ```shell
 kubectl get deployments

--- a/site/content/en/docs/tutorials/kubernetes_101/module5.md
+++ b/site/content/en/docs/tutorials/kubernetes_101/module5.md
@@ -87,7 +87,7 @@ export NODE_PORT=$(kubectl get services/kubernetes-bootcamp -o go-template='{{(i
 echo NODE_PORT=$NODE_PORT
 ```
 
-Next, we'll do a `curl` to the exposed IP and port. Execute the command mulitple times:
+Next, we'll do a `curl` to the exposed IP and port. Execute the command multiple times:
 
 ```shell
 curl $(minikube ip):$NODE_PORT


### PR DESCRIPTION
- Removed unnecessary command  to recreate deployment
- Fixed typo 

The previous module didn't actually include a step to delete the deployment, so this could be confusing to users following the guide.

For context, [here](https://github.com/kubernetes/minikube/blob/8e81f8de25324c7bf6d9e9dbbbc301022610f1f3/site/content/en/docs/tutorials/kubernetes_101/module4.md#step-3---deleting-a-service) is the last step of the previous module.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
3. If the PR fixes an issue, add "fixes #<issue number>" to the description.
4. If the PR is a user interface change, please include a "before" and "after" example.
5. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
