### PR TITLE
CI: Fix Cloud Shell not writing results to DB

### DIFF
--- a/hack/jenkins/cloud_shell_functional_tests_docker.sh
+++ b/hack/jenkins/cloud_shell_functional_tests_docker.sh
@@ -39,6 +39,9 @@ gcloud cloud-shell ssh --authorize-session << EOF
  EXTRA_BUILD_ARGS=$EXTRA_BUILD_ARGS
  access_token=$access_token
  ROOT_JOB_ID=$ROOT_JOB_ID
+ GOPOGH_DB_BACKEND=$GOPOGH_DB_BACKEND
+ GOPOGH_DB_HOST=$GOPOGH_DB_HOST
+ GOPOGH_DB_PATH=$GOPOGH_DB_PATH
 
  # Prevent cloud-shell is ephemeral warnings on apt-get
  mkdir ~/.cloudshell


### PR DESCRIPTION
The gopogh envs aren't getting set inside Cloud Shell, causing the flags to be empty and it doesn't end up writing the results to a DB. This sets them in Cloud Shell.