### PR TITLE
CI: Fix Cloud Shell not saving to DB

### DIFF
--- a/hack/jenkins/cloud_shell_functional_tests_docker.sh
+++ b/hack/jenkins/cloud_shell_functional_tests_docker.sh
@@ -34,14 +34,14 @@ gcloud cloud-shell ssh --authorize-session << EOF
  EXTRA_TEST_ARGS="-test.run (TestFunctional|TestAddons|TestStartStop)"
 
  # Need to set these in cloud-shell or will not be present in common.sh
- MINIKUBE_LOCATION=$MINIKUBE_LOCATION
- COMMIT=$COMMIT
- EXTRA_BUILD_ARGS=$EXTRA_BUILD_ARGS
- access_token=$access_token
- ROOT_JOB_ID=$ROOT_JOB_ID
- GOPOGH_DB_BACKEND=$GOPOGH_DB_BACKEND
- GOPOGH_DB_HOST=$GOPOGH_DB_HOST
- GOPOGH_DB_PATH=$GOPOGH_DB_PATH
+ MINIKUBE_LOCATION="$MINIKUBE_LOCATION"
+ COMMIT="$COMMIT"
+ EXTRA_BUILD_ARGS="$EXTRA_BUILD_ARGS"
+ access_token="$access_token"
+ ROOT_JOB_ID="$ROOT_JOB_ID"
+ GOPOGH_DB_BACKEND="$GOPOGH_DB_BACKEND"
+ GOPOGH_DB_HOST="$GOPOGH_DB_HOST"
+ GOPOGH_DB_PATH="$GOPOGH_DB_PATH"
 
  # Prevent cloud-shell is ephemeral warnings on apt-get
  mkdir ~/.cloudshell


### PR DESCRIPTION
`GOPOGH_DB_PATH` is of the form `user=abcde database=12345`, without wrapping the assignment in quotes everything after the space gets removed and causes an error. Wrapping all the assignments in quotes to fix the issue.