### PR TITLE
CI: Remove VFKit from integration list until job is actually setup

### DIFF
--- a/hack/jenkins/minikube_set_pending.sh
+++ b/hack/jenkins/minikube_set_pending.sh
@@ -43,7 +43,6 @@ jobs=(
      'Docker_Windows'
      'Docker_Cloud_Shell'
      'QEMU_macOS'
-     'VFkit_macOS'
 )
 
 STARTED_LIST_REMOTE="gs://minikube-builds/logs/${ghprbPullId}/${BUILD_NUMBER}/started_environments.txt"


### PR DESCRIPTION
This is preventing the test flake comment from being generated since we don't have the VFKit integration test setup in Jenkins yet. This will be added back once the job is added to Jenkins and in the PR that installs the required dep on M1 Mac machines.