### PR TITLE
Disallow using Docker Desktop 4.34.0 on macos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Breaking Changes:
 * Bump minimum podman version to 4.9.0 [#19457](https://github.com/kubernetes/minikube/pull/19457)
-
+* Disallow using Docker Desktop 4.34.0 
 Features:
 * Bump default Kubernetes version to v1.31.0 [#19435](https://github.com/kubernetes/minikube/pull/19435)
 * Add new driver for macOS: vfkit [#19423](https://github.com/kubernetes/minikube/pull/19423)

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -533,7 +533,7 @@ func withPortMappings(portMappings []PortMapping) createOpt {
 
 // ListContainersByLabel returns all the container names with a specified label
 func ListContainersByLabel(ctx context.Context, ociBin string, label string, warnSlow ...bool) ([]string, error) {
-	rr, err := runCmd(exec.CommandContext(ctx, ociBin, "ps", "-a", "--filter", fmt.Sprintf("label=%s", label), "--format", "{{.Names}}"), warnSlow...)
+	rr, err := runCmd(exec.Command(ociBin, "ps", "-a", "--filter", fmt.Sprintf("label=%s", label), "--format", "{{.Names}}"), warnSlow...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -533,7 +533,7 @@ func withPortMappings(portMappings []PortMapping) createOpt {
 
 // ListContainersByLabel returns all the container names with a specified label
 func ListContainersByLabel(ctx context.Context, ociBin string, label string, warnSlow ...bool) ([]string, error) {
-	rr, err := runCmd(exec.Command(ociBin, "ps", "-a", "--filter", fmt.Sprintf("label=%s", label), "--format", "{{.Names}}"), warnSlow...)
+	rr, err := runCmd(exec.CommandContext(ctx, ociBin, "ps", "-a", "--filter", fmt.Sprintf("label=%s", label), "--format", "{{.Names}}"), warnSlow...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -191,7 +191,6 @@ var dockerVersionOrState = func() (string, registry.State) {
 }
 
 func checkDockerEngineVersion(o string) registry.State {
-	fmt.Println("**********------------------------------------********", o)
 	parts := strings.SplitN(o, "-", 2)
 	if len(parts) != 2 {
 		return registry.State{

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -191,6 +191,7 @@ var dockerVersionOrState = func() (string, registry.State) {
 }
 
 func checkDockerEngineVersion(o string) registry.State {
+	fmt.Println("**********------------------------------------********", o)
 	parts := strings.SplitN(o, "-", 2)
 	if len(parts) != 2 {
 		return registry.State{
@@ -289,6 +290,17 @@ func checkDockerDesktopVersion(version string) (s registry.State) {
 			Fix:       "Update Docker Desktop to 4.16.1 or greater",
 		}
 	}
+
+	if runtime.GOOS == "darwin" && currSemver.EQ(semver.MustParse("4.34.0")) {
+		return registry.State{
+			Reason:    "PROVIDER_DOCKER_DESKTOP_VERSION_BAD",
+			Running:   true,
+			Error:     errors.New("Docker Desktop 4.34.0 has a regression that prevents minikube from listing the containers"),
+			Installed: true,
+			Fix:       "Use a different Docker desktop version, more info at https://github.com/docker/cli/issues/5412",
+		}
+	}
+
 	return s
 }
 


### PR DESCRIPTION
because https://github.com/docker/for-mac/issues/7412


# after this PR
```
$ mk start -d docker
😄  minikube v1.34.0 on Darwin 14.6.1 (arm64)
✨  Using the docker driver based on user configuration

💣  Exiting due to PROVIDER_DOCKER_DESKTOP_VERSION_BAD: Docker Desktop 4.34.0 has a regression that prevents minikube from listing the containers
💡  Suggestion: Use a different Docker desktop version, more info at https://github.com/docker/for-mac/issues/7412
```