### PR TITLE
Detect slow docker when deleting containers and profile

### DIFF
--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -45,7 +45,8 @@ import (
 func DeleteContainersByLabel(ociBin string, label string) []error {
 	var deleteErrs []error
 	ctx := context.Background()
-	cs, err := ListContainersByLabel(ctx, ociBin, label)
+	//set warnSlow to true to give a warning for slow dockers
+	cs, err := ListContainersByLabel(ctx, ociBin, label, true)
 	if err != nil {
 		return []error{fmt.Errorf("listing containers by label %q", label)}
 	}

--- a/pkg/minikube/delete/delete.go
+++ b/pkg/minikube/delete/delete.go
@@ -47,7 +47,8 @@ func PossibleLeftOvers(ctx context.Context, cname string, driverName string) {
 
 	klog.Infof("deleting possible leftovers for %s (driver=%s) ...", cname, driverName)
 	delLabel := fmt.Sprintf("%s=%s", oci.ProfileLabelKey, cname)
-	cs, err := oci.ListContainersByLabel(ctx, bin, delLabel)
+	//set warnSlow to true to enable slow docker warning
+	cs, err := oci.ListContainersByLabel(ctx, bin, delLabel, true)
 	if err == nil && len(cs) > 0 {
 		for _, c := range cs {
 			out.Step(style.DeletingHost, `Deleting container "{{.name}}" ...`, out.V{"name": cname})


### PR DESCRIPTION
Set warnSlow flag to try when deleting a profile and in Delete ContainersByLabel.

Fixes #19577 

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
