### PR TITLE
CI: Fix yearly leaderboard updates failures

### DIFF
--- a/.github/workflows/yearly-leaderboard.yml
+++ b/.github/workflows/yearly-leaderboard.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Update Yearly Leaderboard
         id: yearlyLeaderboard
         run: |
+          sudo apt install ncal
           make update-yearly-leaderboard
           # The following is to support multiline with GITHUB_OUTPUT, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
           echo "changes<<EOF" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Ubuntu 22.04 removed the `cal` command as a default installed package. We rely on this command for updating the yearly leaderboard, so installing `ncal` to resolve this issue.