### PR TITLE
site: Backfill yearly leaderboard updates

### DIFF
--- a/site/content/en/docs/contrib/leaderboard/2024.html
+++ b/site/content/en/docs/contrib/leaderboard/2024.html
@@ -87,7 +87,7 @@ weight: -99992024
 </head>
 <body>
     <h1>kubernetes/minikube</h1>
-    <div class="subtitle">2024-01-01 &mdash; 2024-06-30</div>
+    <div class="subtitle">2024-01-01 &mdash; 2024-08-31</div>
 
     
         <h2>Reviewers</h2>
@@ -103,18 +103,20 @@ weight: -99992024
                 function drawreviewCounts() {
                     var data = new google.visualization.arrayToDataTable([
                     [{label:'',type:'string'},{label: '# of Merged PRs reviewed', type: 'number'}, { role: 'annotation' }],
-                    ["medyagh", 26, "26"],
-                    ["spowelljr", 17, "17"],
+                    ["medyagh", 40, "40"],
+                    ["spowelljr", 23, "23"],
                     ["afbjorklund", 4, "4"],
+                    ["liangyuanpeng", 3, "3"],
                     ["ComradeProgrammer", 2, "2"],
-                    ["liangyuanpeng", 2, "2"],
-                    ["nirs", 1, "1"],
-                    ["allenhaozi", 1, "1"],
-                    ["Dmarcotrigiano", 1, "1"],
-                    ["llegolas", 1, "1"],
-                    ["Shubham82", 1, "1"],
-                    ["Zhongyi-Lu", 1, "1"],
                     ["Fenrur", 1, "1"],
+                    ["bobsira", 1, "1"],
+                    ["aojea", 1, "1"],
+                    ["Zhongyi-Lu", 1, "1"],
+                    ["allenhaozi", 1, "1"],
+                    ["Shubham82", 1, "1"],
+                    ["Dmarcotrigiano", 1, "1"],
+                    ["nirs", 1, "1"],
+                    ["llegolas", 1, "1"],
                     
                     ]);
 
@@ -147,16 +149,18 @@ weight: -99992024
                 function drawreviewWords() {
                     var data = new google.visualization.arrayToDataTable([
                     [{label:'',type:'string'},{label: '# of words written in merged PRs', type: 'number'}, { role: 'annotation' }],
-                    ["spowelljr", 1478, "1478"],
-                    ["medyagh", 814, "814"],
+                    ["spowelljr", 2099, "2099"],
+                    ["medyagh", 1344, "1344"],
                     ["Dmarcotrigiano", 276, "276"],
                     ["ComradeProgrammer", 246, "246"],
                     ["afbjorklund", 207, "207"],
                     ["nirs", 171, "171"],
-                    ["liangyuanpeng", 107, "107"],
+                    ["liangyuanpeng", 161, "161"],
                     ["Zhongyi-Lu", 97, "97"],
                     ["allenhaozi", 70, "70"],
                     ["Shubham82", 17, "17"],
+                    ["aojea", 12, "12"],
+                    ["bobsira", 12, "12"],
                     ["Fenrur", 7, "7"],
                     ["llegolas", 5, "5"],
                     
@@ -191,18 +195,20 @@ weight: -99992024
                 function drawreviewComments() {
                     var data = new google.visualization.arrayToDataTable([
                     [{label:'',type:'string'},{label: '# of Review Comments in merged PRs', type: 'number'}, { role: 'annotation' }],
-                    ["medyagh", 16, "16"],
-                    ["spowelljr", 9, "9"],
-                    ["liangyuanpeng", 3, "3"],
+                    ["spowelljr", 34, "34"],
+                    ["medyagh", 29, "29"],
+                    ["liangyuanpeng", 5, "5"],
                     ["ComradeProgrammer", 2, "2"],
-                    ["Shubham82", 0, "0"],
-                    ["allenhaozi", 0, "0"],
-                    ["Dmarcotrigiano", 0, "0"],
-                    ["afbjorklund", 0, "0"],
-                    ["Fenrur", 0, "0"],
+                    ["aojea", 1, "1"],
                     ["nirs", 0, "0"],
                     ["llegolas", 0, "0"],
+                    ["bobsira", 0, "0"],
+                    ["Shubham82", 0, "0"],
+                    ["Dmarcotrigiano", 0, "0"],
                     ["Zhongyi-Lu", 0, "0"],
+                    ["allenhaozi", 0, "0"],
+                    ["Fenrur", 0, "0"],
+                    ["afbjorklund", 0, "0"],
                     
                     ]);
 
@@ -239,21 +245,21 @@ weight: -99992024
                 function drawprCounts() {
                     var data = new google.visualization.arrayToDataTable([
                     [{label:'',type:'string'},{label: '# of Pull Requests Merged', type: 'number'}, { role: 'annotation' }],
-                    ["spowelljr", 61, "61"],
+                    ["spowelljr", 83, "83"],
                     ["prezha", 14, "14"],
+                    ["ComradeProgrammer", 10, "10"],
+                    ["medyagh", 10, "10"],
+                    ["afbjorklund", 6, "6"],
+                    ["joaquimrocha", 6, "6"],
                     ["jeffmaury", 6, "6"],
-                    ["ComradeProgrammer", 5, "5"],
-                    ["joaquimrocha", 5, "5"],
+                    ["xcarolan", 5, "5"],
+                    ["uos-ljtian", 5, "5"],
                     ["nirs", 4, "4"],
-                    ["xcarolan", 3, "3"],
-                    ["uos-ljtian", 3, "3"],
                     ["syxunion", 3, "3"],
-                    ["hritesh04", 2, "2"],
+                    ["sandipanpanda", 3, "3"],
                     ["nikitakurakinGit", 2, "2"],
-                    ["travier", 2, "2"],
-                    ["alessandrocapanna", 2, "2"],
                     ["zdxgs", 2, "2"],
-                    ["sandipanpanda", 2, "2"],
+                    ["radeksm", 2, "2"],
                     
                     ]);
 
@@ -286,21 +292,21 @@ weight: -99992024
                 function drawprDeltas() {
                     var data = new google.visualization.arrayToDataTable([
                     [{label:'',type:'string'},{label: 'Lines of code (delta)', type: 'number'}, { role: 'annotation' }],
-                    ["ComradeProgrammer", 9845, "9845"],
+                    ["ComradeProgrammer", 19729, "19729"],
+                    ["spowelljr", 4578, "4578"],
                     ["prezha", 4191, "4191"],
-                    ["spowelljr", 4114, "4114"],
+                    ["medyagh", 643, "643"],
                     ["travier", 586, "586"],
                     ["hritesh04", 496, "496"],
                     ["alessandrocapanna", 260, "260"],
-                    ["sandipanpanda", 95, "95"],
-                    ["xcarolan", 56, "56"],
+                    ["sandipanpanda", 157, "157"],
+                    ["thomasjm", 87, "87"],
+                    ["Razorr1996", 86, "86"],
+                    ["daniel-iwaniec", 85, "85"],
+                    ["afbjorklund", 77, "77"],
+                    ["xcarolan", 73, "73"],
                     ["Sryther", 51, "51"],
                     ["gpelouze", 43, "43"],
-                    ["Skalador", 40, "40"],
-                    ["BodhiHu", 38, "38"],
-                    ["nirs", 21, "21"],
-                    ["danim55", 20, "20"],
-                    ["justinmchase", 19, "19"],
                     
                     ]);
 
@@ -333,21 +339,21 @@ weight: -99992024
                 function drawprSize() {
                     var data = new google.visualization.arrayToDataTable([
                     [{label:'',type:'string'},{label: 'Average PR size (added+changed)', type: 'number'}, { role: 'annotation' }],
-                    ["ComradeProgrammer", 1967, "1967"],
+                    ["ComradeProgrammer", 1461, "1461"],
                     ["prezha", 207, "207"],
                     ["hritesh04", 162, "162"],
                     ["travier", 123, "123"],
                     ["alessandrocapanna", 74, "74"],
-                    ["sandipanpanda", 44, "44"],
-                    ["spowelljr", 42, "42"],
+                    ["sandipanpanda", 50, "50"],
                     ["Sryther", 42, "42"],
+                    ["spowelljr", 35, "35"],
                     ["gpelouze", 35, "35"],
                     ["Skalador", 33, "33"],
+                    ["thomasjm", 32, "32"],
+                    ["medyagh", 30, "30"],
+                    ["IC1101Virgo", 25, "25"],
                     ["BodhiHu", 19, "19"],
-                    ["justinmchase", 17, "17"],
-                    ["xcarolan", 16, "16"],
-                    ["danim55", 10, "10"],
-                    ["afbjorklund", 10, "10"],
+                    ["Razorr1996", 17, "17"],
                     
                     ]);
 
@@ -384,21 +390,21 @@ weight: -99992024
                 function drawcomments() {
                     var data = new google.visualization.arrayToDataTable([
                     [{label:'',type:'string'},{label: '# of comments', type: 'number'}, { role: 'annotation' }],
-                    ["afbjorklund", 82, "82"],
-                    ["T-Lakshmi", 66, "66"],
+                    ["afbjorklund", 107, "107"],
+                    ["T-Lakshmi", 76, "76"],
+                    ["kundan2707", 69, "69"],
+                    ["medyagh", 58, "58"],
                     ["caerulescens", 49, "49"],
-                    ["medyagh", 42, "42"],
-                    ["spowelljr", 31, "31"],
+                    ["spowelljr", 39, "39"],
                     ["Ritikaa96", 27, "27"],
-                    ["kundan2707", 22, "22"],
-                    ["liangyuanpeng", 12, "12"],
-                    ["ComradeProgrammer", 6, "6"],
+                    ["liangyuanpeng", 15, "15"],
+                    ["xcarolan", 11, "11"],
+                    ["ComradeProgrammer", 9, "9"],
+                    ["logopk", 5, "5"],
                     ["prezha", 5, "5"],
-                    ["xcarolan", 5, "5"],
+                    ["AkihiroSuda", 5, "5"],
                     ["cirix", 5, "5"],
                     ["nnzv", 4, "4"],
-                    ["logopk", 4, "4"],
-                    ["JiangJungle", 4, "4"],
                     
                     ]);
 
@@ -431,21 +437,21 @@ weight: -99992024
                 function drawcommentWords() {
                     var data = new google.visualization.arrayToDataTable([
                     [{label:'',type:'string'},{label: '# of words (excludes authored)', type: 'number'}, { role: 'annotation' }],
-                    ["afbjorklund", 3094, "3094"],
-                    ["medyagh", 2619, "2619"],
+                    ["kuanyui", 4510, "4510"],
+                    ["afbjorklund", 4137, "4137"],
+                    ["medyagh", 3153, "3153"],
                     ["caerulescens", 2011, "2011"],
                     ["adrian-moisa", 1688, "1688"],
+                    ["spowelljr", 1470, "1470"],
                     ["karthick-dkk", 1285, "1285"],
-                    ["T-Lakshmi", 1119, "1119"],
-                    ["spowelljr", 997, "997"],
-                    ["kundan2707", 740, "740"],
+                    ["T-Lakshmi", 1243, "1243"],
+                    ["kundan2707", 1040, "1040"],
                     ["viplifes", 684, "684"],
                     ["cirix", 632, "632"],
+                    ["ComradeProgrammer", 567, "567"],
                     ["Ritikaa96", 522, "522"],
+                    ["AkihiroSuda", 418, "418"],
                     ["jusito", 387, "387"],
-                    ["ComradeProgrammer", 348, "348"],
-                    ["JiangJungle", 347, "347"],
-                    ["prezha", 331, "331"],
                     
                     ]);
 
@@ -478,10 +484,11 @@ weight: -99992024
                 function drawissueCloser() {
                     var data = new google.visualization.arrayToDataTable([
                     [{label:'',type:'string'},{label: '# of issues closed (excludes authored)', type: 'number'}, { role: 'annotation' }],
-                    ["spowelljr", 45, "45"],
-                    ["medyagh", 16, "16"],
+                    ["spowelljr", 68, "68"],
+                    ["medyagh", 22, "22"],
+                    ["afbjorklund", 4, "4"],
+                    ["ComradeProgrammer", 1, "1"],
                     ["prezha", 1, "1"],
-                    ["afbjorklund", 1, "1"],
                     
                     ]);
 


### PR DESCRIPTION
Backfilled the updates to the yearly leaderboard due to the script failing after we updated our GitHub Action Runners to Ubuntu 22.04.