### PR TITLE
Fix wrongly detecting kicbase arch as incorrect

### DIFF
--- a/pkg/minikube/download/image.go
+++ b/pkg/minikube/download/image.go
@@ -115,7 +115,7 @@ func isImageCorrectArch(img string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("failed to get config for %s: %v", img, err)
 	}
-	return cfg.Architecture == runtime.GOOS, nil
+	return cfg.Architecture == runtime.GOARCH, nil
 }
 
 // ImageToCache downloads img (if not present in cache) and writes it to the local cache directory


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/19661

**Before:**
```
I0918 11:16:50.708602   70765 lock.go:35] WriteFile acquiring /Users/powellsteven/.minikube/profiles/minikube/config.json: {Name:mk548e658760cea9905fde423ef4a820c80d6811 Clock:{} Delay:500ms Timeout:1m0s Cancel:<nil>}
W0918 11:16:50.729279   70765 image.go:95] image gcr.io/k8s-minikube/kicbase-builds:v0.0.45-1726589491-19662@sha256:6370b9fec173944088c2d87d44b01819c0ec611a83d9e2f38d36352dff8121a4 is of wrong architecture
I0918 11:16:50.729293   70765 cache.go:149] Downloading gcr.io/k8s-minikube/kicbase-builds:v0.0.45-1726589491-19662@sha256:6370b9fec173944088c2d87d44b01819c0ec611a83d9e2f38d36352dff8121a4 to local cache
I0918 11:16:50.729420   70765 image.go:63] Checking for gcr.io/k8s-minikube/kicbase-builds:v0.0.45-1726589491-19662@sha256:6370b9fec173944088c2d87d44b01819c0ec611a83d9e2f38d36352dff8121a4 in local cache directory
I0918 11:16:50.729436   70765 image.go:66] Found gcr.io/k8s-minikube/kicbase-builds:v0.0.45-1726589491-19662@sha256:6370b9fec173944088c2d87d44b01819c0ec611a83d9e2f38d36352dff8121a4 in local cache directory, skipping pull
I0918 11:16:50.729441   70765 image.go:135] gcr.io/k8s-minikube/kicbase-builds:v0.0.45-1726589491-19662@sha256:6370b9fec173944088c2d87d44b01819c0ec611a83d9e2f38d36352dff8121a4 exists in cache, skipping pull
I0918 11:16:50.729456   70765 cache.go:152] successfully saved gcr.io/k8s-minikube/kicbase-builds:v0.0.45-1726589491-19662@sha256:6370b9fec173944088c2d87d44b01819c0ec611a83d9e2f38d36352dff8121a4 as a tarball
I0918 11:16:50.729460   70765 cache.go:162] Loading gcr.io/k8s-minikube/kicbase-builds:v0.0.45-1726589491-19662@sha256:6370b9fec173944088c2d87d44b01819c0ec611a83d9e2f38d36352dff8121a4 from local cache
I0918 11:16:51.443393   70765 cache.go:164] successfully loaded and using gcr.io/k8s-minikube/kicbase-builds:v0.0.45-1726589491-19662@sha256:6370b9fec173944088c2d87d44b01819c0ec611a83d9e2f38d36352dff8121a4 from cached tarball
```

Specifically: `image gcr.io/k8s-minikube/kicbase-builds:v0.0.45-1726589491-19662@sha256:6370b9fec173944088c2d87d44b01819c0ec611a83d9e2f38d36352dff8121a4 is of wrong architecture`

**After:**
```
0918 11:23:01.722701   71923 image.go:79] Checking for gcr.io/k8s-minikube/kicbase-builds:v0.0.45-1726589491-19662@sha256:6370b9fec173944088c2d87d44b01819c0ec611a83d9e2f38d36352dff8121a4 in local docker daemon
I0918 11:23:01.722719   71923 preload.go:146] Found local preload: /Users/powellsteven/.minikube/cache/preloaded-tarball/preloaded-images-k8s-v18-v1.31.1-docker-overlay2-arm64.tar.lz4
I0918 11:23:01.722728   71923 cache.go:56] Caching tarball of preloaded images
I0918 11:23:01.722837   71923 preload.go:172] Found /Users/powellsteven/.minikube/cache/preloaded-tarball/preloaded-images-k8s-v18-v1.31.1-docker-overlay2-arm64.tar.lz4 in cache, skipping download
I0918 11:23:01.722850   71923 cache.go:59] Finished verifying existence of preloaded tar for v1.31.1 on docker
I0918 11:23:01.723433   71923 profile.go:143] Saving config to /Users/powellsteven/.minikube/profiles/minikube/config.json ...
I0918 11:23:01.723494   71923 lock.go:35] WriteFile acquiring /Users/powellsteven/.minikube/profiles/minikube/config.json: {Name:mk548e658760cea9905fde423ef4a820c80d6811 Clock:{} Delay:500ms Timeout:1m0s Cancel:<nil>}
I0918 11:23:01.750081   71923 image.go:98] Found gcr.io/k8s-minikube/kicbase-builds:v0.0.45-1726589491-19662@sha256:6370b9fec173944088c2d87d44b01819c0ec611a83d9e2f38d36352dff8121a4 in local docker daemon, skipping pull
I0918 11:23:01.750101   71923 cache.go:144] gcr.io/k8s-minikube/kicbase-builds:v0.0.45-1726589491-19662@sha256:6370b9fec173944088c2d87d44b01819c0ec611a83d9e2f38d36352dff8121a4 exists in daemon, skipping load
I0918 11:23:01.750117   71923 cache.go:194] Successfully downloaded all kic artifacts
```

No reloading of kicabse image from cache, saves about 0.6 seconds on start.