### PR TITLE
Addons registry: Update kube-registry-proxy from 0.0.6 to 0.0.7

### DIFF
--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -406,8 +406,8 @@ var Addons = map[string]*Addon{
 			"registry-proxy.yaml",
 			"0640"),
 	}, false, "registry", "minikube", "", "", map[string]string{
+		"KubeRegistryProxy": "k8s-minikube/kube-registry-proxy:0.0.7@sha256:9fd683b2e47c5fded3410c69f414f05cdee737597569f52854347f889b118982",
 		"Registry":          "registry:2.8.3@sha256:ac0192b549007e22998eb74e8d8488dcfe70f1489520c3b144a6047ac5efbe90",
-		"KubeRegistryProxy": "k8s-minikube/kube-registry-proxy:0.0.6@sha256:b3fa0b2df8737fdb85ad5918a7e2652527463e357afff83a5e5bb966bcedc367",
 	}, map[string]string{
 		"KubeRegistryProxy": "gcr.io",
 		"Registry":          "docker.io",


### PR DESCRIPTION
Updating the kube-registry-proxy from 0.0.6 to 0.0.7

To see changes to the Dockerfile see: https://github.com/spowelljr/kube-registry-proxy/commit/a153665dcfafd852f519281b1b8456a25885d1a3

Updated the base image from `nginx:1.25.4` to `nginx:1.27.1-alpine`

This resolves several CVEs

**0.0.6:**
```
65 vulnerabilities found in 28 packages
  UNSPECIFIED  5   
  LOW          42  
  MEDIUM       7   
  HIGH         6   
  CRITICAL     5 
```

**0.0.7:**
```
1 vulnerability found in 1 package
  LOW       0  
  MEDIUM    1  
  HIGH      0  
  CRITICAL  0  
```

This also resulted in a 71.5% reduction in image size

**0.0.6:** 192.02 MB
**0.0.7:** 54.66 MB

Confirmed the new image works:
```
$ kubectl run --rm registry-test --restart=Never --image=gcr.io/k8s-minikube/busybox -it -- sh -c "wget --spider -S http://registry.kube-system.svc.cluster.local"
Connecting to registry.kube-system.svc.cluster.local (10.96.254.17:80)
  HTTP/1.1 200 OK
  Cache-Control: no-cache
  Date: Thu, 26 Sep 2024 23:54:00 GMT
  Content-Length: 0
  Connection: close
  
remote file exists
pod "registry-test" deleted
```