### PR TITLE
addons: Use configmap for inspektor-gadget

### DIFF
--- a/deploy/addons/inspektor-gadget/ig-configmap.yaml
+++ b/deploy/addons/inspektor-gadget/ig-configmap.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gadget
+  namespace: gadget
+data:
+  config.yaml: |-
+    hook-mode: auto
+    fallback-pod-informer: true
+    events-buffer-length: 16384
+    containerd-socketpath: /run/containerd/containerd.sock
+    crio-socketpath: /run/crio/crio.sock
+    docker-socketpath: /run/docker.sock
+    podman-socketpath: /run/podman/podman.sock
+    operator:
+      oci:
+        verify-image: true
+        public-keys:
+          - |
+            -----BEGIN PUBLIC KEY-----
+            MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEoDOC0gYSxZTopenGmX3ZFvQ1DSfh
+            Ir4EKRt5jC+mXaJ7c7J+oREskYMn/SfZdRHNSOjLTZUMDm60zpXGhkFecg==
+            -----END PUBLIC KEY-----
+        allowed-gadgets:
+          []
+        disallow-pulling: false

--- a/deploy/addons/inspektor-gadget/ig-daemonset.yaml.tmpl
+++ b/deploy/addons/inspektor-gadget/ig-daemonset.yaml.tmpl
@@ -173,7 +173,15 @@ spec:
           mountPath: /sys/fs/cgroup
         - name: bpffs
           mountPath: /sys/fs/bpf
-      tolerations:
+        # We need to add a dedicated volume to store OCI image otherwise it
+        # will fail as the container root filesystem is read only.
+        # For this, we use an emptyDir without size limit.
+        - mountPath: /var/lib/ig
+          name: oci
+        - mountPath: /etc/ig
+          name: config
+          readOnly: true
+      tolerations: 
       - effect: NoSchedule
         operator: Exists
       - effect: NoExecute
@@ -196,4 +204,10 @@ spec:
           path: /sys/fs/bpf
       - name: debugfs
         hostPath:
-          path: /sys/kernel/debug 
+          path: /sys/kernel/debug
+      - name: oci
+        emptyDir:
+      - name: config
+        configMap:
+          name: gadget
+          defaultMode: 0o400

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -312,6 +312,7 @@ var Addons = map[string]*Addon{
 		MustBinAsset(addons.InspektorGadgetAssets, "inspektor-gadget/ig-rolebinding.yaml", vmpath.GuestAddonsDir, "ig-rolebinding.yaml", "0640"),
 		MustBinAsset(addons.InspektorGadgetAssets, "inspektor-gadget/ig-clusterrole.yaml", vmpath.GuestAddonsDir, "ig-clusterrole.yaml", "0640"),
 		MustBinAsset(addons.InspektorGadgetAssets, "inspektor-gadget/ig-clusterrolebinding.yaml", vmpath.GuestAddonsDir, "ig-clusterrolebinding.yaml", "0640"),
+		MustBinAsset(addons.InspektorGadgetAssets, "inspektor-gadget/ig-configmap.yaml", vmpath.GuestAddonsDir, "ig-configmap.yaml", "0640"),
 		MustBinAsset(addons.InspektorGadgetAssets, "inspektor-gadget/ig-crd.yaml", vmpath.GuestAddonsDir, "ig-crd.yaml", "0640"),
 		MustBinAsset(addons.InspektorGadgetAssets, "inspektor-gadget/ig-daemonset.yaml.tmpl", vmpath.GuestAddonsDir, "ig-daemonset.yaml", "0640"),
 	}, false, "inspektor-gadget", "3rd party (inspektor-gadget.io)", "https://github.com/orgs/inspektor-gadget/people", "https://minikube.sigs.k8s.io/docs/handbook/addons/inspektor-gadget/",


### PR DESCRIPTION
Use configmap for inspektor-gadget addon.

fixes: https://github.com/kubernetes/minikube/issues/19710

## Testing Done

### Before

```
$ go run ./cmd/minikube/ start --addons=inspektor-gadget
...
🌟  Enabled addons: default-storageclass, inspektor-gadget

❗  /usr/local/bin/kubectl is version 1.26.3, which may have incompatibilities with Kubernetes 1.31.1.
    ▪ Want kubectl v1.31.1? Try 'minikube kubectl -- get pods -A'
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
$ kubectl get pods -n gadget
NAME           READY   STATUS             RESTARTS     AGE
gadget-dnkdd   0/1     CrashLoopBackOff   4 (3s ago)   112s
```

### After 

```
$ go run ./cmd/minikube/ start --addons=inspektor-gadget
...
🌟  Enabled addons: default-storageclass, inspektor-gadget

❗  /usr/local/bin/kubectl is version 1.26.3, which may have incompatibilities with Kubernetes 1.31.1.
    ▪ Want kubectl v1.31.1? Try 'minikube kubectl -- get pods -A'
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
$ kubectl get pods -n gadget
NAME           READY   STATUS    RESTARTS   AGE
gadget-jfkrb   1/1     Running   0          2m24s
```

cc: @eiffel-fl 