### PR TITLE
testing: Add defer to disable addon to start of each addon test

### DIFF
--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -100,9 +100,9 @@ func TestAddons(t *testing.T) {
 		// so we override that here to let minikube auto-detect appropriate cgroup driver
 		os.Setenv(constants.MinikubeForceSystemdEnv, "")
 
-		args := append([]string{"start", "-p", profile, "--wait=true", "--memory=4000", "--alsologtostderr", "--addons=registry", "--addons=metrics-server", "--addons=volumesnapshots", "--addons=csi-hostpath-driver", "--addons=gcp-auth", "--addons=cloud-spanner", "--addons=inspektor-gadget", "--addons=storage-provisioner-rancher", "--addons=nvidia-device-plugin", "--addons=yakd", "--addons=volcano"}, StartArgs()...)
-		if !NoneDriver() { // none driver does not support ingress
-			args = append(args, "--addons=ingress", "--addons=ingress-dns")
+		args := append([]string{"start", "-p", profile, "--wait=true", "--memory=4000", "--alsologtostderr", "--addons=registry", "--addons=metrics-server", "--addons=volumesnapshots", "--addons=csi-hostpath-driver", "--addons=gcp-auth", "--addons=cloud-spanner", "--addons=inspektor-gadget", "--addons=nvidia-device-plugin", "--addons=yakd", "--addons=volcano"}, StartArgs()...)
+		if !NoneDriver() {
+			args = append(args, "--addons=ingress", "--addons=ingress-dns", "--addons=storage-provisioner-rancher")
 		}
 		rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 		if err != nil {
@@ -189,12 +189,12 @@ func TestAddons(t *testing.T) {
 
 // validateIngressAddon tests the ingress addon by deploying a default nginx pod
 func validateIngressAddon(ctx context.Context, t *testing.T, profile string) {
-	defer disableAddon(t, "ingress", profile)
-	defer disableAddon(t, "ingress-dns", profile)
-	defer PostMortemLogs(t, profile)
 	if NoneDriver() {
 		t.Skipf("skipping: ingress not supported")
 	}
+	defer disableAddon(t, "ingress", profile)
+	defer disableAddon(t, "ingress-dns", profile)
+	defer PostMortemLogs(t, profile)
 
 	client, err := kapi.Client(profile)
 	if err != nil {


### PR DESCRIPTION
https://github.com/kubernetes/minikube/issues/19714

Add defer to disable addon to start of each addon test. In relation to https://github.com/kubernetes/minikube/issues/19714, this will prevent GCP-Auth addon mock issue from affecting the registry test.

This PR should fix the registry test for all environments.