### PR TITLE
fix zh-CN translation

### DIFF
--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -171,7 +171,7 @@
 	"Creating {{.driver_name}} {{.machine_type}} (CPUs={{.number_of_cpus}}, Memory={{.memory_size}}MB) ...": "正在创建 {{.driver_name}} {{.machine_type}}（CPUs={{.number_of_cpus}}，内存={{.memory_size}}MB）...",
 	"Creating {{.driver_name}} {{.machine_type}} (CPUs={{.number_of_cpus}}, Memory={{.memory_size}}MB, Disk={{.disk_size}}MB) ...": "正在创建 {{.driver_name}} {{.machine_type}}（CPUs={{.number_of_cpus}}，内存={{.memory_size}}MB，磁盘={{.disk_size}}MB）...",
 	"Creating {{.driver_name}} {{.machine_type}} (CPUs={{if not .number_of_cpus}}no-limit{{else}}{{.number_of_cpus}}{{end}}, Memory={{if not .memory_size}}no-limit{{else}}{{.memory_size}}MB{{end}}) ...": "",
-	"Current context is \"{{.context}}\"": "当前的上下文为 \"{{.context}}\"创建 {{.driver_name}} {{.machine_type}}（CPU={{if not .number_of_cpus}}无限制{{else}}{{.number_of_cpus}}{{end}}，内存={{if not .memory_size}}无限制{{else}}{{.memory_size}}MB{{end}}）...",
+	"Current context is \"{{.context}}\"": "当前的上下文为 \"{{.context}}\"",
 	"DEPRECATED, use `driver` instead.": "已弃用，请改用 `driver`。",
 	"DEPRECATED: Replaced by --cni": "已弃用，改用 --cni 来代替",
 	"DEPRECATED: Replaced by --cni=bridge": "已弃用，改用 --cni=bridge",


### PR DESCRIPTION
looks like there were additional fileds [added](https://github.com/kubernetes/minikube/pull/19508/files#diff-020f35a8a2429da42a4a7472c7e767b4ff3c50cdfa843a816db3ef7535e77dbbR174) unintentionally in pr #19508, which makes the tests fail

@uos-ljtian  can you please check and confirm

### before
`go test ./pkg/minikube/translate -run TestTranslationFilesValid -v`
```
=== RUN   TestTranslationFilesValid
=== RUN   TestTranslationFilesValid/de.json
=== RUN   TestTranslationFilesValid/es.json
=== RUN   TestTranslationFilesValid/fr.json
=== RUN   TestTranslationFilesValid/ja.json
=== RUN   TestTranslationFilesValid/ko.json
=== RUN   TestTranslationFilesValid/pl.json
=== RUN   TestTranslationFilesValid/ru.json
=== RUN   TestTranslationFilesValid/zh-CN.json
    translate_test.go:117: line "Current context is \"{{.context}}\"": "当前的上下文为 \"{{.context}}\"创建 {{.driver_name}} {{.machine_type}}（CPU={{if not .number_of_cpus}}无限制{{else}}{{.number_of_cpus}}{{end}}，内存={{if not .memory_size}}无限制{{else}}{{.memory_size}}MB{{end}}）..." has mismatching number of variables
        original string variables: [{{.context}}]; translated variables: [{{.context}} {{.driver_name}} {{.machine_type}} {{.memory_size}} {{.number_of_cpus}}]
--- FAIL: TestTranslationFilesValid (0.12s)
    --- PASS: TestTranslationFilesValid/de.json (0.01s)
    --- PASS: TestTranslationFilesValid/es.json (0.01s)
    --- PASS: TestTranslationFilesValid/fr.json (0.04s)
    --- PASS: TestTranslationFilesValid/ja.json (0.03s)
    --- PASS: TestTranslationFilesValid/ko.json (0.01s)
    --- PASS: TestTranslationFilesValid/pl.json (0.00s)
    --- PASS: TestTranslationFilesValid/ru.json (0.00s)
    --- FAIL: TestTranslationFilesValid/zh-CN.json (0.01s)
FAIL
FAIL	k8s.io/minikube/pkg/minikube/translate	0.129s
FAIL
```

### after
`go test ./pkg/minikube/translate -run TestTranslationFilesValid -v`
```
=== RUN   TestTranslationFilesValid
=== RUN   TestTranslationFilesValid/de.json
=== RUN   TestTranslationFilesValid/es.json
=== RUN   TestTranslationFilesValid/fr.json
=== RUN   TestTranslationFilesValid/ja.json
=== RUN   TestTranslationFilesValid/ko.json
=== RUN   TestTranslationFilesValid/pl.json
=== RUN   TestTranslationFilesValid/ru.json
=== RUN   TestTranslationFilesValid/zh-CN.json
--- PASS: TestTranslationFilesValid (0.11s)
    --- PASS: TestTranslationFilesValid/de.json (0.02s)
    --- PASS: TestTranslationFilesValid/es.json (0.01s)
    --- PASS: TestTranslationFilesValid/fr.json (0.04s)
    --- PASS: TestTranslationFilesValid/ja.json (0.02s)
    --- PASS: TestTranslationFilesValid/ko.json (0.01s)
    --- PASS: TestTranslationFilesValid/pl.json (0.01s)
    --- PASS: TestTranslationFilesValid/ru.json (0.00s)
    --- PASS: TestTranslationFilesValid/zh-CN.json (0.01s)
PASS
ok  	k8s.io/minikube/pkg/minikube/translate	0.122s
```