### PR TITLE
HA (multi-control plane) docs: use installed kubectl version in examples

### DIFF
--- a/site/content/en/docs/tutorials/multi_control_plane_ha_clusters.md
+++ b/site/content/en/docs/tutorials/multi_control_plane_ha_clusters.md
@@ -185,7 +185,7 @@ users:
 - Overview of the current leader and follower API servers
 
 ```shell
-minikube ssh -p ha-demo -- 'sudo /var/lib/minikube/binaries/v1.28.4/kubectl --kubeconfig=/var/lib/minikube/kubeconfig logs -n kube-system pod/kube-vip-ha-demo'
+minikube ssh -p ha-demo -- 'find /var/lib/minikube/binaries -iname kubectl -exec sudo {} --kubeconfig=/var/lib/minikube/kubeconfig logs -n kube-system pod/kube-vip-ha-demo \; -quit'
 ```
 ```
 time="2024-03-14T21:38:34Z" level=info msg="Starting kube-vip.io [v0.7.1]"
@@ -205,7 +205,7 @@ time="2024-03-14T21:38:48Z" level=info msg="Added backend for [192.168.49.254:84
 ```
 
 ```shell
-minikube ssh -p ha-demo -- 'sudo /var/lib/minikube/binaries/v1.28.4/kubectl --kubeconfig=/var/lib/minikube/kubeconfig logs -n kube-system pod/kube-vip-ha-demo-m02'
+minikube ssh -p ha-demo -- 'find /var/lib/minikube/binaries -iname kubectl -exec sudo {} --kubeconfig=/var/lib/minikube/kubeconfig logs -n kube-system pod/kube-vip-ha-demo-m02 \; -quit'
 ```
 ```
 time="2024-03-14T21:38:25Z" level=info msg="Starting kube-vip.io [v0.7.1]"
@@ -218,7 +218,7 @@ time="2024-03-14T21:38:34Z" level=info msg="Node [ha-demo] is assuming leadershi
 ```
 
 ```shell
-minikube ssh -p ha-demo -- 'sudo /var/lib/minikube/binaries/v1.28.4/kubectl --kubeconfig=/var/lib/minikube/kubeconfig logs -n kube-system pod/kube-vip-ha-demo-m03'
+minikube ssh -p ha-demo -- 'find /var/lib/minikube/binaries -iname kubectl -exec sudo {} --kubeconfig=/var/lib/minikube/kubeconfig logs -n kube-system pod/kube-vip-ha-demo-m03 \; -quit'
 ```
 ```
 time="2024-03-14T21:38:48Z" level=info msg="Starting kube-vip.io [v0.7.1]"
@@ -233,7 +233,7 @@ time="2024-03-14T21:38:48Z" level=info msg="Node [ha-demo] is assuming leadershi
 - Overview of multi-etcd instances
 
 ```shell
-minikube ssh -p ha-demo -- 'sudo /var/lib/minikube/binaries/v1.28.4/kubectl --kubeconfig=/var/lib/minikube/kubeconfig exec -ti pod/etcd-ha-demo -n kube-system -- /bin/sh -c "ETCDCTL_API=3 etcdctl member list --write-out=table --cacert=/var/lib/minikube/certs/etcd/ca.crt --cert=/var/lib/minikube/certs/etcd/server.crt --key=/var/lib/minikube/certs/etcd/server.key"'
+minikube ssh -p ha-demo -- 'find /var/lib/minikube/binaries -iname kubectl -exec sudo {} --kubeconfig=/var/lib/minikube/kubeconfig exec -ti pod/etcd-ha-demo -n kube-system -- /bin/sh -c "ETCDCTL_API=3 etcdctl member list --write-out=table --cacert=/var/lib/minikube/certs/etcd/ca.crt --cert=/var/lib/minikube/certs/etcd/server.crt --key=/var/lib/minikube/certs/etcd/server.key" \; -quit'
 ```
 ```
 +------------------+---------+-------------+---------------------------+---------------------------+------------+


### PR DESCRIPTION
improve the ha docs to prevent users from using the hardcoded (and potentially wrong) kubectl version in examples

fixes #19701
fixes #19635
fixes #19113
