### PR TITLE
fix TestMachineType failing on macOS

### DIFF
--- a/pkg/minikube/driver/driver_test.go
+++ b/pkg/minikube/driver/driver_test.go
@@ -68,6 +68,7 @@ func TestMachineType(t *testing.T) {
 		KVM2:       "VM",
 		QEMU2:      "VM",
 		QEMU:       "VM",
+		VFKit:      "VM",
 		VirtualBox: "VM",
 		HyperKit:   "VM",
 		VMware:     "VM",


### PR DESCRIPTION
adding VFKit type to the table test

### before
```
go test ./pkg/minikube/driver -run TestMachineType -v
=== RUN   TestMachineType
    driver_test.go:83: mismatched machine type for driver vfkit: want =  got = VM
--- FAIL: TestMachineType (0.00s)
FAIL
FAIL	k8s.io/minikube/pkg/minikube/driver	0.761s
FAIL
```

### after
```
go test ./pkg/minikube/driver -run TestMachineType -v
=== RUN   TestMachineType
--- PASS: TestMachineType (0.00s)
PASS
ok  	k8s.io/minikube/pkg/minikube/driver	0.759s
```