### PR TITLE
Allow turning off the VBox accelerate3d flag

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -99,6 +99,7 @@ const (
 	vsockPorts              = "hyperkit-vsock-ports"
 	embedCerts              = "embed-certs"
 	noVTXCheck              = "no-vtx-check"
+	noAccelerate3DOff       = "no-accelerate3d-off"
 	downloadOnly            = "download-only"
 	dnsProxy                = "dns-proxy"
 	hostDNSResolver         = "host-dns-resolver"
@@ -246,6 +247,7 @@ func initDriverFlags() {
 	startCmd.Flags().Bool(dnsProxy, false, "Enable proxy for NAT DNS requests (virtualbox driver only)")
 	startCmd.Flags().Bool(hostDNSResolver, true, "Enable host resolver for NAT DNS requests (virtualbox driver only)")
 	startCmd.Flags().Bool(noVTXCheck, false, "Disable checking for the availability of hardware virtualization before the vm is started (virtualbox driver only)")
+	startCmd.Flags().Bool(noAccelerate3DOff, false, "Disable turning off the possibly missing 3D graphics acceleration before the vm is started (virtualbox driver only)")
 	startCmd.Flags().String(hostOnlyNicType, "virtio", "NIC Type used for host only network. One of Am79C970A, Am79C973, 82540EM, 82543GC, 82545EM, or virtio (virtualbox driver only)")
 	startCmd.Flags().String(natNicType, "virtio", "NIC Type used for nat network. One of Am79C970A, Am79C973, 82540EM, 82543GC, 82545EM, or virtio (virtualbox driver only)")
 
@@ -557,6 +559,7 @@ func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, rtime str
 		DisableDriverMounts:     viper.GetBool(disableDriverMounts),
 		UUID:                    viper.GetString(uuid),
 		NoVTXCheck:              viper.GetBool(noVTXCheck),
+		NoAccelerate3DOff:       viper.GetBool(noAccelerate3DOff),
 		DNSProxy:                viper.GetBool(dnsProxy),
 		HostDNSResolver:         viper.GetBool(hostDNSResolver),
 		HostOnlyNicType:         viper.GetString(hostOnlyNicType),

--- a/go.mod
+++ b/go.mod
@@ -247,7 +247,7 @@ replace (
 	git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
 	github.com/Parallels/docker-machine-parallels/v2 => github.com/minikube-machine/machine-driver-parallels/v2 v2.0.2-0.20240730142131-ada9375ea417
 	github.com/briandowns/spinner => github.com/alonyb/spinner v1.12.7
-	github.com/docker/machine => github.com/minikube-machine/machine v0.0.0-20240815173309-ffb6b643c381
+	github.com/docker/machine => github.com/minikube-machine/machine v0.0.0-20240929111624-cd9dd9aaf4aa
 	github.com/machine-drivers/docker-machine-driver-vmware => github.com/minikube-machine/machine-driver-vmware v0.1.6-0.20230701123042-a391c48b14d5
 	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.22.4
 )

--- a/go.sum
+++ b/go.sum
@@ -1189,8 +1189,8 @@ github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJys
 github.com/miekg/dns v1.1.48 h1:Ucfr7IIVyMBz4lRE8qmGUuZ4Wt3/ZGu9hmcMT3Uu4tQ=
 github.com/miekg/dns v1.1.48/go.mod h1:e3IlAVfNqAllflbibAZEWOXOQ+Ynzk/dDozDxY7XnME=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
-github.com/minikube-machine/machine v0.0.0-20240815173309-ffb6b643c381 h1:9walvLKjkCrvs9GlFwFO/qvwtZV9O5ujkgqOMAp1nOA=
-github.com/minikube-machine/machine v0.0.0-20240815173309-ffb6b643c381/go.mod h1:rC8K+60rTqfkrL3a6X/UZeQgP5Gz1Y5czIkWDZcvBuQ=
+github.com/minikube-machine/machine v0.0.0-20240929111624-cd9dd9aaf4aa h1:cVHbLVQpRQpHTBc4I7zd5gxTb6GY4YUe9DdB+cY0CiQ=
+github.com/minikube-machine/machine v0.0.0-20240929111624-cd9dd9aaf4aa/go.mod h1:QTaHUg8rDZXxJQeuRr9F7Lmj/ALCFifdPgtwQnV29Sw=
 github.com/minikube-machine/machine-driver-parallels/v2 v2.0.2-0.20240730142131-ada9375ea417 h1:f+neTRGCtvmW3Tm1V72vWpoTPuNOnXSQsHZdYOryfGM=
 github.com/minikube-machine/machine-driver-parallels/v2 v2.0.2-0.20240730142131-ada9375ea417/go.mod h1:NKwI5KryEmEHMZVj80t9JQcfXWZp4/ZYNBuw4C5sQ9E=
 github.com/minikube-machine/machine-driver-vmware v0.1.6-0.20230701123042-a391c48b14d5 h1:1z7xOzfMO4aBR9+2nYjlhRXX1773fX60HTS0QGpGRPU=

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -65,6 +65,7 @@ type ClusterConfig struct {
 	NFSSharesRoot           string
 	UUID                    string // Only used by hyperkit to restore the mac address
 	NoVTXCheck              bool   // Only used by virtualbox
+	NoAccelerate3DOff       bool   // Only used by virtualbox
 	DNSProxy                bool   // Only used by virtualbox
 	HostDNSResolver         bool   // Only used by virtualbox
 	HostOnlyNicType         string // Only used by virtualbox

--- a/pkg/minikube/registry/drvs/virtualbox/virtualbox.go
+++ b/pkg/minikube/registry/drvs/virtualbox/virtualbox.go
@@ -64,6 +64,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 	d.HostOnlyCIDR = cc.HostOnlyCIDR
 	d.NoShare = cc.DisableDriverMounts
 	d.NoVTXCheck = cc.NoVTXCheck
+	d.NoAccelerate3DOff = cc.NoAccelerate3DOff
 	d.NatNicType = cc.NatNicType
 	d.HostOnlyNicType = cc.HostOnlyNicType
 	d.DNSProxy = cc.DNSProxy

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -99,6 +99,7 @@ minikube start [flags]
       --network-plugin string             DEPRECATED: Replaced by --cni
       --nfs-share strings                 Local folders to share with Guest via NFS mounts (hyperkit driver only)
       --nfs-shares-root string            Where to root the NFS Shares, defaults to /nfsshares (hyperkit driver only) (default "/nfsshares")
+      --no-accelerate3d-off               Disable turning off the possibly missing 3D graphics acceleration before the vm is started (virtualbox driver only)
       --no-kubernetes                     If set, minikube VM/container will start without starting or configuring Kubernetes. (only works on new clusters)
       --no-vtx-check                      Disable checking for the availability of hardware virtualization before the vm is started (virtualbox driver only)
   -n, --nodes int                         The total number of nodes to spin up. Defaults to 1. (default 1)

--- a/translations/strings.txt
+++ b/translations/strings.txt
@@ -146,6 +146,7 @@
 	"Directory to output licenses to": "",
 	"Disable checking for the availability of hardware virtualization before the vm is started (virtualbox driver only)": "",
 	"Disable dynamic memory in your VM manager, or pass in a larger --memory value": "",
+	"Disable turning off the possibly missing 3D graphics acceleration before the vm is started (virtualbox driver only)": "",
 	"Disables the addon w/ADDON_NAME within minikube (example: minikube addons disable dashboard). For a list of available addons use: minikube addons list ": "",
 	"Disables the filesystem mounts provided by the hypervisors": "",
 	"Disk size allocated to the minikube VM (format: \u003cnumber\u003e[\u003cunit\u003e], where unit = b, k, m or g).": "",


### PR DESCRIPTION
Oracle VirtualBox version 7.1 seems to have some issues with
the `--accelerate3d` that was used by default with VirtualBox.

```
minikube start --driver=virtualbox --no-accelerate3d-off
```

Closes #19639
