### PR TITLE
Fix long lines in lastStart.txt not outputting in log outputs

### DIFF
--- a/pkg/minikube/logs/logs.go
+++ b/pkg/minikube/logs/logs.go
@@ -234,15 +234,21 @@ func OutputLastStart() error {
 	}
 	defer f.Close()
 	l := ""
-	s := bufio.NewScanner(f)
-	for s.Scan() {
-		l += s.Text() + "\n"
+	r := bufio.NewReader(f)
+	var s string
+	for {
+		s, err = r.ReadString('\n')
+		if err != nil {
+			break
+		}
+		l += s
 	}
 	out.Styled(style.None, l)
-	if err := s.Err(); err != nil {
-		return fmt.Errorf("failed to read file %s: %v", fp, err)
+	if err == io.EOF {
+		return nil
 	}
-	return nil
+
+	return fmt.Errorf("failed to read file %s: %v", fp, err)
 }
 
 // OutputOffline outputs logs that don't need a running cluster.


### PR DESCRIPTION
### Problem

`bufio.NewScanner` has a max token length of 64KB [link](https://cs.opensource.google/go/go/+/refs/tags/go1.23.2:src/bufio/scan.go;l=82), `sudo runc list -f json` was sometimes generating an output greater than 64KB, causing the following error when running `minikube logs`:

`failed to output last start logs: failed to read file /home/jenkins/minikube-integration/19736-7672/.minikube/logs/lastStart.txt: bufio.Scanner: token too long`

Changed to `bufio.NewReader` to handle reading the `lastStart.txt` file as there is no max token size.

Thanks to @prezha for helping debug!