### PR TITLE
Added warning for use of --static-ip in  multi-node cluster.

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1956,6 +1956,9 @@ func validateStaticIP(staticIP, drvName, subnet string) error {
 		}
 		return nil
 	}
+	if staticIP != "" && viper.GetInt(nodes) > 1 {
+		out.WarningT("--static-ip is not suppoted in a multi-node cluster.")
+	}
 	if subnet != "" {
 		out.WarningT("--static-ip overrides --subnet, --subnet will be ignored")
 	}


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
## Desciption
Added warning in the validateStaticIP function to notify user in case of --static-ip flag is used in a multi-node cluster.

## Linked Issue
closes #18567 