### PR TITLE
fix --wait's failure to work on coredns pods

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/kverify/system_pods.go
+++ b/pkg/minikube/bootstrapper/bsutil/kverify/system_pods.go
@@ -76,7 +76,8 @@ func WaitForSystemPods(r cruntime.Manager, bs bootstrapper.Bootstrapper, cfg con
 }
 
 // ExpectAppsRunning returns whether or not all expected k8s-apps are running. (without waiting for them)
-func ExpectAppsRunning(cs *kubernetes.Clientset, expected []string) error {
+func ExpectAppsRunning(cfg *config.ClusterConfig, cs *kubernetes.Clientset, expected []string) error {
+
 	found := map[string]bool{}
 
 	pods, err := cs.CoreV1().Pods("kube-system").List(context.Background(), meta.ListOptions{})
@@ -85,11 +86,30 @@ func ExpectAppsRunning(cs *kubernetes.Clientset, expected []string) error {
 	}
 	klog.Infof("%d kube-system pods found", len(pods.Items))
 
+	for !cfg.DisableOptimizations {
+		// when --disable-optimization is not specified
+		// core dns deployment has been scaled to 1 pods, wait until there is only 1 pod
+		corednsPods, err := cs.CoreV1().Pods("kube-system").List(context.Background(), meta.ListOptions{
+			LabelSelector: "k8s-app=kube-dns",
+		})
+		if err != nil {
+			return err
+		}
+		if len(corednsPods.Items) == 1 {
+			break
+		}
+	}
+
 	for _, pod := range pods.Items {
 		klog.Info(podStatusMsg(pod))
 
 		if pod.Status.Phase != core.PodRunning {
 			continue
+		}
+		for _, cs := range pod.Status.ContainerStatuses {
+			if !cs.Ready {
+				continue
+			}
 		}
 
 		for k, v := range pod.ObjectMeta.Labels {
@@ -112,12 +132,12 @@ func ExpectAppsRunning(cs *kubernetes.Clientset, expected []string) error {
 }
 
 // WaitForAppsRunning waits for expected Apps To be running
-func WaitForAppsRunning(cs *kubernetes.Clientset, expected []string, timeout time.Duration) error {
+func WaitForAppsRunning(cfg *config.ClusterConfig, cs *kubernetes.Clientset, expected []string, timeout time.Duration) error {
 	klog.Info("waiting for k8s-apps to be running ...")
 	start := time.Now()
 
 	checkRunning := func() error {
-		return ExpectAppsRunning(cs, expected)
+		return ExpectAppsRunning(cfg, cs, expected)
 	}
 
 	if err := retry.Local(checkRunning, timeout); err != nil {

--- a/pkg/minikube/bootstrapper/bsutil/kverify/system_pods.go
+++ b/pkg/minikube/bootstrapper/bsutil/kverify/system_pods.go
@@ -86,8 +86,9 @@ func ExpectAppsRunning(cfg *config.ClusterConfig, cs *kubernetes.Clientset, expe
 	}
 	klog.Infof("%d kube-system pods found", len(pods.Items))
 
-	for !cfg.DisableOptimizations {
+	for !config.IsHA(*cfg) && !cfg.DisableOptimizations {
 		// when --disable-optimization is not specified
+		// for non-HA cluster
 		// core dns deployment has been scaled to 1 pods, wait until there is only 1 pod
 		corednsPods, err := cs.CoreV1().Pods("kube-system").List(context.Background(), meta.ListOptions{
 			LabelSelector: "k8s-app=kube-dns",

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -567,7 +567,7 @@ func (k *Bootstrapper) WaitForNode(cfg config.ClusterConfig, n config.Node, time
 		}
 
 		if cfg.VerifyComponents[kverify.AppsRunningKey] {
-			if err := kverify.WaitForAppsRunning(client, kverify.AppsRunningList, timeout); err != nil {
+			if err := kverify.WaitForAppsRunning(&cfg, client, kverify.AppsRunningList, timeout); err != nil {
 				return errors.Wrap(err, "waiting for apps_running")
 			}
 		}


### PR DESCRIPTION
FIX #19288 
Before: `minikube start --wait=all` may end when coredns is not ready
After: `minikube start --wait=all` will be able to wait until coredns is completly ready

The situation mentioned in #19288 was actually introduced by the HA-cluster PR.  By default coredns has a deployment consists 2 coredns pods. However in pkg/minikube/node/start.go:158 it was manyally scaled down to 1. This happens before we start to wait for those essential nodes(minikube waits for nodes at line 236).

When minikube waits for system pods, there were 2 checks  which will check the system pods's status:
- WaitExtra (pkg/minikube/bootstrapper/bsutil/kverify/pod_ready.go) will list all pods with the given labels, and check whether they are ready
- ExpectAppsRunning will list all the pods in kube-system namespace (pkg/minikube/bootstrapper/bsutil/kverify/system_pods.go:91 , in function ExpectAppsRunning), and check whether there are at least 1 running pod for some essential labels. **But the bug is that it only check the running state, and do not check the ready state**

After the HA-cluster PR was introduced, when minikube run WaitExtra funtion(the 1st check), one of the coredns pod's status can be Succeed. WaitExtra don't recognize this state and will print an error and break the checking loop. This logic is written at pkg/minikube/bootstrapper/bsutil/kverify/pod_ready.go line 99 and line 69.

The error I see is 
``` 
E1003 22:37:04.296076   17140 pod_ready.go:66] WaitExtra: waitPodCondition: pod "coredns-7db6d8ff4d-nljst" in "kube-system" namespace has status phase "Succeeded" (skipping!): {Phase:Succeeded Conditions:[{Type:PodReadyToStartContainers Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2024-10-03 22:37:04 +0200 CEST Reason: Message:} {Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2024-10-03 22:36:53 +0200 CEST Reason:PodCompleted Message:} {Type:Ready Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2024-10-03 22:36:53 +0200 CEST Reason:PodCompleted Message:} {Type:ContainersReady Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2024-10-03 22:36:53 +0200 CEST Reason:PodCompleted Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2024-10-03 22:36:53 +0200 CEST Reason: Message:}] Message: Reason: NominatedNodeName: HostIP:192.168.49.2 HostIPs:[{IP:192.168.49.2}] PodIP: PodIPs:[] StartTime:2024-10-03 22:36:53 +0200 CEST InitContainerStatuses:[] ContainerStatuses:[{Name:coredns State:{Waiting:nil Running:nil Terminated:&ContainerStateTerminated{ExitCode:0,Signal:0,Reason:Completed,Message:,StartedAt:2024-10-03 22:36:54 +0200 CEST,FinishedAt:2024-10-03 22:37:04 +0200 CEST,ContainerID:docker://281a8c3106510cdc16a6d3f91ad2e9f5d7aa1609fac4f0e8f7494af67cb8b5d6,}} LastTerminationState:{Waiting:nil Running:nil Terminated:nil} Ready:false RestartCount:0 Image:registry.k8s.io/coredns/coredns:v1.11.1 ImageID:docker-pullable://registry.k8s.io/coredns/coredns@sha256:1eeb4c7316bacb1d4c8ead65571cd92dd21e27359f0d4917f1a5822a73b75db1 ContainerID:docker://281a8c3106510cdc16a6d3f91ad2e9f5d7aa1609fac4f0e8f7494af67cb8b5d6 Started:0x14001e58e00 AllocatedResources:map[] Resources:nil VolumeMounts:[]}] QOSClass:Burstable EphemeralContainerStatuses:[] Resize: ResourceClaimStatuses:[]}
```
The when minikube arrives at ExpectAppsRunning(the 2nd check), it doesn't check the ready state, so it believes that all pods are ok. This causes the #19288 

So the fix is to make ExpectAppsRunning(the 2nd check) check the ready state as well.

(The reason why I didn't make the 1st check function to recognized the Succeed state is that: if for some reason there is a job (e.g. init job for some containers) in kube-system namespace, and we change the WaitExtra's logic to reject Succeed state, there will be problems.)
