### PR TITLE
More robust MAC address matching

### DIFF
--- a/pkg/drivers/common_test.go
+++ b/pkg/drivers/common_test.go
@@ -55,6 +55,13 @@ var validLeases = []byte(`{
         lease=0x597e1267
 }
 {
+        name=bootp
+        ip_address=192.168.105.2
+        hw_address=1,8e:1:99:9c:54:b1
+        identifier=1,8e:1:99:9c:54:b1
+        lease=0x597e1268
+}
+{
         name=bar
         ip_address=192.168.64.3
         hw_address=1,a4:b5:c6:d7:e8:f9
@@ -96,6 +103,14 @@ func Test_getIpAddressFromFile(t *testing.T) {
 			"valid",
 			args{"a1:b2:c3:d4:e5:f6", dhcpFile},
 			"1.2.3.4",
+			false,
+		},
+		{
+			// bootp use "%x" format instead of "%02x"
+			// https://openradar.appspot.com/FB15382970
+			"valid-bootp",
+			args{"8e:01:99:9c:54:b1", dhcpFile},
+			"192.168.105.2",
 			false,
 		},
 		{

--- a/pkg/drivers/hyperkit/driver.go
+++ b/pkg/drivers/hyperkit/driver.go
@@ -261,8 +261,6 @@ func (d *Driver) Start() error {
 		return errors.Wrap(err, "getting MAC address from UUID")
 	}
 
-	// Need to strip 0's
-	mac = pkgdrivers.TrimMacAddress(mac)
 	log.Debugf("Generated MAC %s", mac)
 
 	log.Debugf("Starting with cmdline: %s", d.Cmdline)

--- a/pkg/drivers/qemu/qemu.go
+++ b/pkg/drivers/qemu/qemu.go
@@ -505,10 +505,7 @@ func (d *Driver) Start() error {
 	case "socket_vmnet":
 		var err error
 		getIP := func() error {
-			// QEMU requires MAC address with leading 0s
-			// But socket_vmnet writes the MAC address to the dhcp leases file with leading 0s stripped
-			mac := pkgdrivers.TrimMacAddress(d.MACAddress)
-			d.IPAddress, err = pkgdrivers.GetIPAddressByMACAddress(mac)
+			d.IPAddress, err = pkgdrivers.GetIPAddressByMACAddress(d.MACAddress)
 			if err != nil {
 				return errors.Wrap(err, "failed to get IP address")
 			}

--- a/pkg/drivers/vfkit/vfkit.go
+++ b/pkg/drivers/vfkit/vfkit.go
@@ -265,8 +265,6 @@ func (d *Driver) Start() error {
 		return err
 	}
 
-	// Need to strip 0's
-	mac = pkgdrivers.TrimMacAddress(mac)
 	if err := d.setupIP(mac); err != nil {
 		return err
 	}


### PR DESCRIPTION
On darwin bootp uses non-standard MAC address format[1]:
"8e:1:99:9c:54:b1" instead of "8e:01:99:9c:54:b1". We fixed this by
trimming leading "0" in the string before looking up the IP address.
    
There are several issues with the current code:
- Fragile, will break if bootp changes the format (unlikely)
- Fixing the wrong place, the drivers should not care about the MAC
  address format.
- The tests were confusing, showing that we can match standard MAC
  addresses while the actual code could match only non-standard bootp
  addresses.
- Logging wrong MAC address since we trimmed leading zeros before
  logging
    
This change replace trimming leading zeros with parsing MAC address
strings and comparing the bytes. The test includes now both standard and
non-standard MAC addresses.
    
[1] https://openradar.appspot.com/FB15382970