### PR TITLE
testing: Remove requesting full CPU for nginx test pod

### DIFF
--- a/test/integration/testdata/vcjob.yaml
+++ b/test/integration/testdata/vcjob.yaml
@@ -40,9 +40,4 @@ spec:
               - 10m
               image: nginx:latest
               name: nginx
-              resources:
-                requests:
-                  cpu: 1
-                limits:
-                  cpu: 1
           restartPolicy: Never


### PR DESCRIPTION
Looking at Docker Linux container arm64 tests the Volcano addon test is consistently failing, looking at the logs I see the following:
```
Warning  FailedScheduling  2m59s  volcano  0/1 nodes are unavailable: 1 Insufficient cpu.
```

Looking into the pod, it's a nginx pod that's used in the Volcano addon test that requests a full CPU. All we do is check if the pod comes up before deleting it, so removing this high request.