### PR TITLE
CI: Fix LegacyKeyValueFormat warning when building images

### DIFF
--- a/deploy/iso/minikube-iso/Dockerfile
+++ b/deploy/iso/minikube-iso/Dockerfile
@@ -43,7 +43,7 @@ RUN mkdir /app
 RUN chmod 777 /app
 
 RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
-ENV LANG en_US.utf8
+ENV LANG=en_US.utf8
 
 # dumb init will allow us to interrupt the build with ^C
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/deploy/kicbase/Dockerfile
+++ b/deploy/kicbase/Dockerfile
@@ -278,7 +278,7 @@ COPY --from=kicbase / /
 EXPOSE 22
 # tell systemd that it is in docker (it will check for the container env)
 # https://systemd.io/CONTAINER_INTERFACE/
-ENV container docker
+ENV container=docker
 # systemd exits on SIGRTMIN+3, not SIGTERM (which re-executes it)
 # https://bugzilla.redhat.com/show_bug.cgi?id=1201657
 STOPSIGNAL SIGRTMIN+3

--- a/installers/linux/kvm/Dockerfile.amd64
+++ b/installers/linux/kvm/Dockerfile.amd64
@@ -28,5 +28,5 @@ ARG GO_VERSION
 
 RUN curl -sSL https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 
-ENV GOPATH /go
+ENV GOPATH=/go
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/go/bin

--- a/installers/linux/kvm/Dockerfile.arm64
+++ b/installers/linux/kvm/Dockerfile.arm64
@@ -29,5 +29,5 @@ ARG GO_VERSION
 
 RUN curl -sSL https://go.dev/dl/go${GO_VERSION}.linux-arm64.tar.gz | tar -C /usr/local -xzf -
 
-ENV GOPATH /go
+ENV GOPATH=/go
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/go/bin


### PR DESCRIPTION
Warning: `LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format`

https://docs.docker.com/reference/build-checks/legacy-key-value-format/