### PR TITLE
CI: Fix automated Kubernetes version updating

### DIFF
--- a/hack/update/kubernetes_version/templates/v1beta4/containerd.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta4/containerd.yaml
@@ -27,11 +27,14 @@ apiServer:
       value: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
-    allocate-node-cidrs: "true"
-    leader-elect: "false"
+    - name: "allocate-node-cidrs"
+      value: "true"
+    - name: "leader-elect"
+      value: "false"
 scheduler:
   extraArgs:
-    leader-elect: "false"
+    - name: "leader-elect"
+      value: "false"
 certificatesDir: /var/lib/minikube/certs
 clusterName: mk
 controlPlaneEndpoint: control-plane.minikube.internal:8443
@@ -39,7 +42,8 @@ etcd:
   local:
     dataDir: /var/lib/minikube/etcd
     extraArgs:
-      proxy-refresh-interval: "70000"
+      - name: "proxy-refresh-interval"
+        value: "70000"
 kubernetesVersion: v1.23.0
 networking:
   dnsDomain: cluster.local

--- a/hack/update/kubernetes_version/templates/v1beta4/crio-options-gates.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta4/crio-options-gates.yaml
@@ -25,19 +25,28 @@ apiServer:
   extraArgs:
     - name: "enable-admission-plugins"
       value: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
-    fail-no-swap: "true"
-    feature-gates: "a=b"
+    - name: "fail-no-swap"
+      value: "true"
+    - name: "feature-gates"
+      value: "a=b"
 controllerManager:
   extraArgs:
-    allocate-node-cidrs: "true"
-    feature-gates: "a=b"
-    kube-api-burst: "32"
-    leader-elect: "false"
+    - name: "allocate-node-cidrs"
+      value: "true"
+    - name: "feature-gates"
+      value: "a=b"
+    - name: "kube-api-burst"
+      value: "32"
+    - name: "leader-elect"
+      value: "false"
 scheduler:
   extraArgs:
-    feature-gates: "a=b"
-    leader-elect: "false"
-    scheduler-name: "mini-scheduler"
+    - name: "feature-gates"
+      value: "a=b"
+    - name: "leader-elect"
+      value: "false"
+    - name: "scheduler-name"
+      value: "mini-scheduler"
 certificatesDir: /var/lib/minikube/certs
 clusterName: mk
 controlPlaneEndpoint: control-plane.minikube.internal:8443
@@ -45,7 +54,8 @@ etcd:
   local:
     dataDir: /var/lib/minikube/etcd
     extraArgs:
-      proxy-refresh-interval: "70000"
+      - name: "proxy-refresh-interval"
+        value: "70000"
 kubernetesVersion: v1.23.0
 networking:
   dnsDomain: cluster.local

--- a/hack/update/kubernetes_version/templates/v1beta4/crio.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta4/crio.yaml
@@ -27,11 +27,14 @@ apiServer:
       value: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
-    allocate-node-cidrs: "true"
-    leader-elect: "false"
+    - name: "allocate-node-cidrs"
+      value: "true"
+    - name: "leader-elect"
+      value: "false"
 scheduler:
   extraArgs:
-    leader-elect: "false"
+    - name: "leader-elect"
+      value: "false"
 certificatesDir: /var/lib/minikube/certs
 clusterName: mk
 controlPlaneEndpoint: control-plane.minikube.internal:8443
@@ -39,7 +42,8 @@ etcd:
   local:
     dataDir: /var/lib/minikube/etcd
     extraArgs:
-      proxy-refresh-interval: "70000"
+      - name: "proxy-refresh-interval"
+        value: "70000"
 kubernetesVersion: v1.23.0
 networking:
   dnsDomain: cluster.local

--- a/hack/update/kubernetes_version/templates/v1beta4/default.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta4/default.yaml
@@ -27,11 +27,14 @@ apiServer:
       value: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
-    allocate-node-cidrs: "true"
-    leader-elect: "false"
+    - name: "allocate-node-cidrs"
+      value: "true"
+    - name: "leader-elect"
+      value: "false"
 scheduler:
   extraArgs:
-    leader-elect: "false"
+    - name: "leader-elect"
+      value: "false"
 certificatesDir: /var/lib/minikube/certs
 clusterName: mk
 controlPlaneEndpoint: control-plane.minikube.internal:8443
@@ -39,7 +42,8 @@ etcd:
   local:
     dataDir: /var/lib/minikube/etcd
     extraArgs:
-      proxy-refresh-interval: "70000"
+      - name: "proxy-refresh-interval"
+        value: "70000"
 kubernetesVersion: v1.23.0
 networking:
   dnsDomain: cluster.local

--- a/hack/update/kubernetes_version/templates/v1beta4/dns.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta4/dns.yaml
@@ -27,11 +27,14 @@ apiServer:
       value: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
-    allocate-node-cidrs: "true"
-    leader-elect: "false"
+    - name: "allocate-node-cidrs"
+      value: "true"
+    - name: "leader-elect"
+      value: "false"
 scheduler:
   extraArgs:
-    leader-elect: "false"
+    - name: "leader-elect"
+      value: "false"
 certificatesDir: /var/lib/minikube/certs
 clusterName: mk
 controlPlaneEndpoint: control-plane.minikube.internal:8443
@@ -39,7 +42,8 @@ etcd:
   local:
     dataDir: /var/lib/minikube/etcd
     extraArgs:
-      proxy-refresh-interval: "70000"
+      - name: "proxy-refresh-interval"
+        value: "70000"
 kubernetesVersion: v1.23.0
 networking:
   dnsDomain: minikube.local

--- a/hack/update/kubernetes_version/templates/v1beta4/image-repository.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta4/image-repository.yaml
@@ -28,11 +28,14 @@ apiServer:
       value: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 controllerManager:
   extraArgs:
-    allocate-node-cidrs: "true"
-    leader-elect: "false"
+    - name: "allocate-node-cidrs"
+      value: "true"
+    - name: "leader-elect"
+      value: "false"
 scheduler:
   extraArgs:
-    leader-elect: "false"
+    - name: "leader-elect"
+      value: "false"
 certificatesDir: /var/lib/minikube/certs
 clusterName: mk
 controlPlaneEndpoint: control-plane.minikube.internal:8443
@@ -40,7 +43,8 @@ etcd:
   local:
     dataDir: /var/lib/minikube/etcd
     extraArgs:
-      proxy-refresh-interval: "70000"
+      - name: "proxy-refresh-interval"
+        value: "70000"
 kubernetesVersion: v1.23.0
 networking:
   dnsDomain: cluster.local

--- a/hack/update/kubernetes_version/update_kubernetes_version.go
+++ b/hack/update/kubernetes_version/update_kubernetes_version.go
@@ -48,55 +48,55 @@ var (
 			},
 		},
 		"pkg/minikube/bootstrapper/bsutil/testdata/{{.LatestVersionMM}}/containerd-api-port.yaml": {
-			Content: update.Loadf("templates/v1beta3/containerd-api-port.yaml"),
+			Content: update.Loadf("templates/v1beta4/containerd-api-port.yaml"),
 			Replace: map[string]string{
 				`kubernetesVersion:.*`: `kubernetesVersion: {{.LatestVersionP0}}`,
 			},
 		},
 		"pkg/minikube/bootstrapper/bsutil/testdata/{{.LatestVersionMM}}/containerd-pod-network-cidr.yaml": {
-			Content: update.Loadf("templates/v1beta3/containerd-pod-network-cidr.yaml"),
+			Content: update.Loadf("templates/v1beta4/containerd-pod-network-cidr.yaml"),
 			Replace: map[string]string{
 				`kubernetesVersion:.*`: `kubernetesVersion: {{.LatestVersionP0}}`,
 			},
 		},
 		"pkg/minikube/bootstrapper/bsutil/testdata/{{.LatestVersionMM}}/containerd.yaml": {
-			Content: update.Loadf("templates/v1beta3/containerd.yaml"),
+			Content: update.Loadf("templates/v1beta4/containerd.yaml"),
 			Replace: map[string]string{
 				`kubernetesVersion:.*`: `kubernetesVersion: {{.LatestVersionP0}}`,
 			},
 		},
 		"pkg/minikube/bootstrapper/bsutil/testdata/{{.LatestVersionMM}}/crio-options-gates.yaml": {
-			Content: update.Loadf("templates/v1beta3/crio-options-gates.yaml"),
+			Content: update.Loadf("templates/v1beta4/crio-options-gates.yaml"),
 			Replace: map[string]string{
 				`kubernetesVersion:.*`: `kubernetesVersion: {{.LatestVersionP0}}`,
 			},
 		},
 		"pkg/minikube/bootstrapper/bsutil/testdata/{{.LatestVersionMM}}/crio.yaml": {
-			Content: update.Loadf("templates/v1beta3/crio.yaml"),
+			Content: update.Loadf("templates/v1beta4/crio.yaml"),
 			Replace: map[string]string{
 				`kubernetesVersion:.*`: `kubernetesVersion: {{.LatestVersionP0}}`,
 			},
 		},
 		"pkg/minikube/bootstrapper/bsutil/testdata/{{.LatestVersionMM}}/default.yaml": {
-			Content: update.Loadf("templates/v1beta3/default.yaml"),
+			Content: update.Loadf("templates/v1beta4/default.yaml"),
 			Replace: map[string]string{
 				`kubernetesVersion:.*`: `kubernetesVersion: {{.LatestVersionP0}}`,
 			},
 		},
 		"pkg/minikube/bootstrapper/bsutil/testdata/{{.LatestVersionMM}}/dns.yaml": {
-			Content: update.Loadf("templates/v1beta3/dns.yaml"),
+			Content: update.Loadf("templates/v1beta4/dns.yaml"),
 			Replace: map[string]string{
 				`kubernetesVersion:.*`: `kubernetesVersion: {{.LatestVersionP0}}`,
 			},
 		},
 		"pkg/minikube/bootstrapper/bsutil/testdata/{{.LatestVersionMM}}/image-repository.yaml": {
-			Content: update.Loadf("templates/v1beta3/image-repository.yaml"),
+			Content: update.Loadf("templates/v1beta4/image-repository.yaml"),
 			Replace: map[string]string{
 				`kubernetesVersion:.*`: `kubernetesVersion: {{.LatestVersionP0}}`,
 			},
 		},
 		"pkg/minikube/bootstrapper/bsutil/testdata/{{.LatestVersionMM}}/options.yaml": {
-			Content: update.Loadf("templates/v1beta3/options.yaml"),
+			Content: update.Loadf("templates/v1beta4/options.yaml"),
 			Replace: map[string]string{
 				`kubernetesVersion:.*`: `kubernetesVersion: {{.LatestVersionP0}}`,
 			},
@@ -169,55 +169,55 @@ func updateCurrentTestDataFiles(latestMM string, data *Data) {
 
 	currentSchema := map[string]update.Item{
 		"pkg/minikube/bootstrapper/bsutil/testdata/{{.CurrentVersionMM}}/containerd-api-port.yaml": {
-			Content: update.Loadf("templates/v1beta3/containerd-api-port.yaml"),
+			Content: update.Loadf("templates/v1beta4/containerd-api-port.yaml"),
 			Replace: map[string]string{
 				`kubernetesVersion:.*`: `kubernetesVersion: {{.CurrentVersionP0}}`,
 			},
 		},
 		"pkg/minikube/bootstrapper/bsutil/testdata/{{.CurrentVersionMM}}/containerd-pod-network-cidr.yaml": {
-			Content: update.Loadf("templates/v1beta3/containerd-pod-network-cidr.yaml"),
+			Content: update.Loadf("templates/v1beta4/containerd-pod-network-cidr.yaml"),
 			Replace: map[string]string{
 				`kubernetesVersion:.*`: `kubernetesVersion: {{.CurrentVersionP0}}`,
 			},
 		},
 		"pkg/minikube/bootstrapper/bsutil/testdata/{{.CurrentVersionMM}}/containerd.yaml": {
-			Content: update.Loadf("templates/v1beta3/containerd.yaml"),
+			Content: update.Loadf("templates/v1beta4/containerd.yaml"),
 			Replace: map[string]string{
 				`kubernetesVersion:.*`: `kubernetesVersion: {{.CurrentVersionP0}}`,
 			},
 		},
 		"pkg/minikube/bootstrapper/bsutil/testdata/{{.CurrentVersionMM}}/crio-options-gates.yaml": {
-			Content: update.Loadf("templates/v1beta3/crio-options-gates.yaml"),
+			Content: update.Loadf("templates/v1beta4/crio-options-gates.yaml"),
 			Replace: map[string]string{
 				`kubernetesVersion:.*`: `kubernetesVersion: {{.CurrentVersionP0}}`,
 			},
 		},
 		"pkg/minikube/bootstrapper/bsutil/testdata/{{.CurrentVersionMM}}/crio.yaml": {
-			Content: update.Loadf("templates/v1beta3/crio.yaml"),
+			Content: update.Loadf("templates/v1beta4/crio.yaml"),
 			Replace: map[string]string{
 				`kubernetesVersion:.*`: `kubernetesVersion: {{.CurrentVersionP0}}`,
 			},
 		},
 		"pkg/minikube/bootstrapper/bsutil/testdata/{{.CurrentVersionMM}}/default.yaml": {
-			Content: update.Loadf("templates/v1beta3/default.yaml"),
+			Content: update.Loadf("templates/v1beta4/default.yaml"),
 			Replace: map[string]string{
 				`kubernetesVersion:.*`: `kubernetesVersion: {{.CurrentVersionP0}}`,
 			},
 		},
 		"pkg/minikube/bootstrapper/bsutil/testdata/{{.CurrentVersionMM}}/dns.yaml": {
-			Content: update.Loadf("templates/v1beta3/dns.yaml"),
+			Content: update.Loadf("templates/v1beta4/dns.yaml"),
 			Replace: map[string]string{
 				`kubernetesVersion:.*`: `kubernetesVersion: {{.CurrentVersionP0}}`,
 			},
 		},
 		"pkg/minikube/bootstrapper/bsutil/testdata/{{.CurrentVersionMM}}/image-repository.yaml": {
-			Content: update.Loadf("templates/v1beta3/image-repository.yaml"),
+			Content: update.Loadf("templates/v1beta4/image-repository.yaml"),
 			Replace: map[string]string{
 				`kubernetesVersion:.*`: `kubernetesVersion: {{.CurrentVersionP0}}`,
 			},
 		},
 		"pkg/minikube/bootstrapper/bsutil/testdata/{{.CurrentVersionMM}}/options.yaml": {
-			Content: update.Loadf("templates/v1beta3/options.yaml"),
+			Content: update.Loadf("templates/v1beta4/options.yaml"),
 			Replace: map[string]string{
 				`kubernetesVersion:.*`: `kubernetesVersion: {{.CurrentVersionP0}}`,
 			},


### PR DESCRIPTION
```
F1021 08:04:27.028254    1964 filesystem.go:69] Unable to load file templates/v1beta3/containerd-api-port.yaml: open templates/v1beta3/containerd-api-port.yaml: no such file or directory
```

In https://github.com/kubernetes/minikube/pull/19790. the templates folder was changed to `v1beta4`, but the code reading the templates wasn't updated, this fixes that.

Also, moving some of the template to use the new extra args format was missed so updating those as well.