### PR TITLE
CI: Reenable building docker-machine-driver-kvm2-arm64 deb package

### DIFF
--- a/hack/jenkins/minikube_cross_build_and_upload.sh
+++ b/hack/jenkins/minikube_cross_build_and_upload.sh
@@ -48,6 +48,7 @@ make -j 16 \
   out/minikube_${DEB_VER}_arm64.deb \
   out/docker-machine-driver-kvm2_$(make deb_version_base).deb \
   out/docker-machine-driver-kvm2_${DEB_VER}_amd64.deb \
+  out/docker-machine-driver-kvm2_${DEB_VER}_arm64.deb \
 && failed=$? || failed=$?
 
 BUILT_VERSION=$("out/minikube-$(go env GOOS)-$(go env GOARCH)" version)


### PR DESCRIPTION
Reverting the changes in https://github.com/kubernetes/minikube/pull/19827 & https://github.com/kubernetes/minikube/pull/19829 now that the build issue seems to be resolved.