### PR TITLE
ISO: Bump Go version from 1.21.6 to 1.23.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ KVM_GO_VERSION ?= $(GO_VERSION:.0=)
 INSTALL_SIZE ?= $(shell du out/minikube-windows-amd64.exe | cut -f1)
 BUILDROOT_BRANCH ?= 2023.02.9
 # the go version on the line below is for the ISO
-GOLANG_OPTIONS = GO_VERSION=1.21.6 GO_HASH_FILE=$(PWD)/deploy/iso/minikube-iso/go.hash
+GOLANG_OPTIONS = GO_VERSION=1.23.2 GO_HASH_FILE=$(PWD)/deploy/iso/minikube-iso/go.hash
 BUILDROOT_OPTIONS = BR2_EXTERNAL=../../deploy/iso/minikube-iso $(GOLANG_OPTIONS)
 REGISTRY ?= gcr.io/k8s-minikube
 


### PR DESCRIPTION
Our Go version in the ISO is too old and preventing us from updating deps (https://github.com/kubernetes/minikube/pull/19891):
`go: go.mod requires go >= 1.22.0 (running go 1.21.6)`