### PR TITLE
Fix panic when no services in namespace with --all specified

### DIFF
--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -112,7 +112,10 @@ var serviceCmd = &cobra.Command{
 			services = newServices
 		}
 
-		if len(services) == 0 {
+		if len(services) == 0 && all {
+			exit.Message(reason.SvcNotFound, `No services were found in the '{{.namespace}}' namespace.
+You may select another namespace by using 'minikube service --all -n <namespace>'`, out.V{"namespace": namespace})
+		} else if len(services) == 0 {
 			exit.Message(reason.SvcNotFound, `Service '{{.service}}' was not found in '{{.namespace}}' namespace.
 You may select another namespace by using 'minikube service {{.service}} -n <namespace>'. Or list out all the services using 'minikube service list'`, out.V{"service": args[0], "namespace": namespace})
 		}


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/minikube/issues/19933

**Before:**
```
$ minikube service --all -n some-namespace-that-doesnt-exists
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
k8s.io/minikube/cmd/minikube/cmd.init.func35(0x10818caa0?, {0x14000984930, 0x0, 0x3?})
	/Users/powellsteven/repo/minikube/cmd/minikube/cmd/service.go:117 +0x1208
github.com/spf13/cobra.(*Command).execute(0x10818caa0, {0x14000984840, 0x3, 0x3})
	/Users/powellsteven/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:989 +0x81c
github.com/spf13/cobra.(*Command).ExecuteC(0x10818c4e0)
	/Users/powellsteven/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/powellsteven/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041
k8s.io/minikube/cmd/minikube/cmd.Execute()
	/Users/powellsteven/repo/minikube/cmd/minikube/cmd/root.go:174 +0x550
main.main()
	/Users/powellsteven/repo/minikube/cmd/minikube/main.go:95 +0x250
```

**After:**
```
$ minikube service --all -n some-namespace-that-doesnt-exists

❌  Exiting due to SVC_NOT_FOUND: No services were found in the 'some-namespace-that-doesnt-exists' namespace.
You may select another namespace by using 'minikube service --all -n <namespace>'
```