### PR TITLE
Revert "Change MINIKUBE_HOME logic"

### DIFF
--- a/pkg/minikube/kubeconfig/kubeconfig_test.go
+++ b/pkg/minikube/kubeconfig/kubeconfig_test.go
@@ -456,7 +456,7 @@ func TestUpdateIP(t *testing.T) {
 		},
 	}
 
-	t.Setenv(localpath.MinikubeHome, "/home/la-croix/.minikube")
+	t.Setenv(localpath.MinikubeHome, "/home/la-croix")
 
 	for _, test := range tests {
 		test := test
@@ -492,7 +492,7 @@ func TestUpdateIP(t *testing.T) {
 }
 
 func TestMissingContext(t *testing.T) {
-	t.Setenv(localpath.MinikubeHome, "/home/la-croix/.minikube")
+	t.Setenv(localpath.MinikubeHome, "/home/la-croix")
 	configFilename := tempFile(t, kubeConfigMissingContext)
 	defer os.Remove(configFilename)
 	if _, err := UpdateEndpoint("minikube", "192.168.10.100", 8080, configFilename, nil); err != nil {

--- a/pkg/minikube/localpath/localpath.go
+++ b/pkg/minikube/localpath/localpath.go
@@ -47,12 +47,7 @@ func MiniPath() string {
 	if filepath.Base(minikubeHomeEnv) == ".minikube" {
 		return minikubeHomeEnv
 	}
-
-	legacyMinikubeHome := filepath.Join(minikubeHomeEnv, ".minikube")
-	if _, err := os.Stat(legacyMinikubeHome); !os.IsNotExist(err) {
-		return legacyMinikubeHome
-	}
-	return filepath.Clean(minikubeHomeEnv)
+	return filepath.Join(minikubeHomeEnv, ".minikube")
 }
 
 // MakeMiniPath is a utility to calculate a relative path to our directory.

--- a/pkg/minikube/localpath/localpath_test.go
+++ b/pkg/minikube/localpath/localpath_test.go
@@ -63,18 +63,19 @@ func TestHasWindowsDriveLetter(t *testing.T) {
 
 func TestMiniPath(t *testing.T) {
 	var testCases = []struct {
-		env, expectedPath string
+		env, basePath string
 	}{
-		{"/tmp/.minikube", "/tmp/.minikube"},
-		{"/tmp", "/tmp"},
-		{"", filepath.Join(homedir.HomeDir(), ".minikube")},
+		{"/tmp/.minikube", "/tmp/"},
+		{"/tmp/", "/tmp"},
+		{"", homedir.HomeDir()},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.env, func(t *testing.T) {
+			expectedPath := filepath.Join(tc.basePath, ".minikube")
 			t.Setenv(MinikubeHome, tc.env)
 			path := MiniPath()
-			if path != tc.expectedPath {
-				t.Errorf("MiniPath expected to return '%s', but got '%s'", tc.expectedPath, path)
+			if path != expectedPath {
+				t.Errorf("MiniPath expected to return '%s', but got '%s'", expectedPath, path)
 			}
 		})
 	}


### PR DESCRIPTION
This reverts commit 6f036752c236a3cf712d8bfe2336e1b6009c34a5 from "Update MINIKUBE_HOME usage" (pr #18648)

fixes: #19769
replaces: #19771

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
