### PR TITLE
fix make by skipping kvm2-arm64 till 19959 is resolved

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,7 +361,7 @@ all: cross drivers e2e-cross cross-tars exotic retro out/gvisor-addon ## Build a
 drivers: ## Build Hyperkit and KVM2 drivers
 drivers: docker-machine-driver-hyperkit \
 	 docker-machine-driver-kvm2 \
-	 out/docker-machine-driver-kvm2-amd64 
+	 out/docker-machine-driver-kvm2-amd64
 
 
 .PHONY: docker-machine-driver-hyperkit
@@ -556,7 +556,7 @@ out/docs/minikube.md: $(shell find "cmd") $(shell find "pkg/minikube/constants")
 debs: out/minikube_$(DEB_VERSION)-$(DEB_REVISION)_amd64.deb \
 	  out/minikube_$(DEB_VERSION)-$(DEB_REVISION)_arm64.deb \
 	  out/docker-machine-driver-kvm2_$(DEB_VERSION).deb \
-	  out/docker-machine-driver-kvm2_$(DEB_VERSION)-$(DEB_REVISION)_amd64.deb 
+	  out/docker-machine-driver-kvm2_$(DEB_VERSION)-$(DEB_REVISION)_amd64.deb
 	#   out/docker-machine-driver-kvm2_$(DEB_VERSION)-$(DEB_REVISION)_arm64.deb
 
 .PHONY: deb_version
@@ -835,8 +835,11 @@ update-yearly-leaderboard:
 	hack/yearly-leaderboard.sh
 
 out/docker-machine-driver-kvm2: out/docker-machine-driver-kvm2-$(GOARCH)
+# skipping kvm2-arm64 till https://github.com/kubernetes/minikube/issues/19959 is fixed
+ifneq ($(GOARCH),arm64)
 	$(if $(quiet),@echo "  CP       $@")
 	$(Q)cp $< $@
+endif
 
 out/docker-machine-driver-kvm2-x86_64: out/docker-machine-driver-kvm2-amd64
 	$(if $(quiet),@echo "  CP       $@")
@@ -900,10 +903,10 @@ kvm_in_docker:
 install-kvm-driver: out/docker-machine-driver-kvm2  ## Install KVM Driver
 	mkdir -p $(GOBIN)
 	cp out/docker-machine-driver-kvm2 $(GOBIN)/docker-machine-driver-kvm2
-	
+
 
 out/docker-machine-driver-kvm2-arm64:
-	echo "not used till https://github.com/kubernetes/minikube/issues/19959"
+	@echo "skipping kvm2-arm64 till https://github.com/kubernetes/minikube/issues/19959 is fixed"
 # ifeq ($(MINIKUBE_BUILD_IN_DOCKER),y)
 # 	docker image inspect -f '{{.Id}} {{.RepoTags}}' $(KVM_BUILD_IMAGE_ARM64) || $(MAKE) kvm-image-arm64
 # 	$(call DOCKER,$(KVM_BUILD_IMAGE_ARM64),/usr/bin/make $@ COMMIT=$(COMMIT))
@@ -938,7 +941,7 @@ endif
 	chmod +X $@
 
 
-site/themes/docsy/assets/vendor/bootstrap/package.js: ## update the website docsy theme git submodule 
+site/themes/docsy/assets/vendor/bootstrap/package.js: ## update the website docsy theme git submodule
 	git submodule update -f --init
 
 .PHONY: out/hugo/hugo
@@ -1007,7 +1010,7 @@ compare: out/mkcmp out/minikube
 	mv out/minikube out/master.minikube
 	git checkout $(CURRENT_GIT_BRANCH)
 	out/mkcmp out/master.minikube out/$(CURRENT_GIT_BRANCH).minikube
-	
+
 
 .PHONY: help
 help:


### PR DESCRIPTION
related: #19959 / #19985

`$ arch`
> arm64

`$ make clean && make && make docker-machine-driver-kvm2 && make test`

### before
```
rm -rf ~/go/src/github.com/prezha/minikube/out
rm -f pkg/minikube/assets/assets.go
rm -f pkg/minikube/translate/translations.go
rm -rf ./vendor
rm -rf /tmp/tmp.*.minikube_*
go build  -tags "" -ldflags="-X k8s.io/minikube/pkg/version.version=v1.34.0 -X k8s.io/minikube/pkg/version.isoVersion=v1.34.0-1730913550-19917 -X k8s.io/minikube/pkg/version.gitCommitID="3b895bd10da35649b9ed192054ac5e418b8c96fc" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" -o out/minikube k8s.io/minikube/cmd/minikube
echo "not used till https://github.com/kubernetes/minikube/issues/19959"
not used till https://github.com/kubernetes/minikube/issues/19959
cp out/docker-machine-driver-kvm2-arm64 out/docker-machine-driver-kvm2
cp: out/docker-machine-driver-kvm2-arm64: No such file or directory
make: *** [out/docker-machine-driver-kvm2] Error 1
```

### after
```
rm -rf ~/go/src/github.com/prezha/minikube/out
rm -f pkg/minikube/assets/assets.go
rm -f pkg/minikube/translate/translations.go
rm -rf ./vendor
rm -rf /tmp/tmp.*.minikube_*
go build  -tags "" -ldflags="-X k8s.io/minikube/pkg/version.version=v1.34.0 -X k8s.io/minikube/pkg/version.isoVersion=v1.34.0-1730913550-19917 -X k8s.io/minikube/pkg/version.gitCommitID="3b895bd10da35649b9ed192054ac5e418b8c96fc-dirty" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" -o out/minikube k8s.io/minikube/cmd/minikube
skipping kvm2-arm64 till https://github.com/kubernetes/minikube/issues/19959 is fixed
MINIKUBE_LDFLAGS="-X k8s.io/minikube/pkg/version.version=v1.34.0 -X k8s.io/minikube/pkg/version.isoVersion=v1.34.0-1730913550-19917 -X k8s.io/minikube/pkg/version.gitCommitID="3b895bd10da35649b9ed192054ac5e418b8c96fc-dirty" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" ./test.sh
= make lint =============================================================
golangci/golangci-lint info checking GitHub for tag 'v1.62.2'
golangci/golangci-lint info found version: 1.62.2 for v1.62.2/darwin/arm64
golangci/golangci-lint info installed out/linters/golangci-lint
ok
= go mod ================================================================
ok
= boilerplate ===========================================================
ok
= schema_check ==========================================================
ok
= go test ===============================================================
ok  	k8s.io/minikube/cmd/minikube/cmd	2.919s	coverage: 20.8% of statements
ok  	k8s.io/minikube/cmd/minikube/cmd/config	1.243s	coverage: 24.7% of statements
ok  	k8s.io/minikube/pkg/addons	4.032s	coverage: 26.7% of statements
ok  	k8s.io/minikube/pkg/drivers	2.973s	coverage: 51.1% of statements
ok  	k8s.io/minikube/pkg/drivers/hyperkit	2.759s	coverage: 3.3% of statements
ok  	k8s.io/minikube/pkg/drivers/kic/oci	1.382s	coverage: 12.8% of statements
ok  	k8s.io/minikube/pkg/drivers/kvm	1.007s	coverage: 83.9% of statements
ok  	k8s.io/minikube/pkg/minikube/assets	4.312s	coverage: 29.0% of statements
ok  	k8s.io/minikube/pkg/minikube/audit	2.572s	coverage: 77.0% of statements
ok  	k8s.io/minikube/pkg/minikube/bootstrapper	6.238s	coverage: 42.1% of statements
ok  	k8s.io/minikube/pkg/minikube/bootstrapper/bsutil	5.122s	coverage: 64.1% of statements
ok  	k8s.io/minikube/pkg/minikube/bootstrapper/bsutil/ktmpl	5.078s	coverage: 100.0% of statements
ok  	k8s.io/minikube/pkg/minikube/bootstrapper/images	4.210s	coverage: 73.8% of statements
ok  	k8s.io/minikube/pkg/minikube/cluster	3.030s	coverage: 6.7% of statements
ok  	k8s.io/minikube/pkg/minikube/cni	4.398s	coverage: 8.7% of statements
ok  	k8s.io/minikube/pkg/minikube/command	3.264s	coverage: 11.7% of statements
ok  	k8s.io/minikube/pkg/minikube/config	3.535s	coverage: 66.9% of statements
ok  	k8s.io/minikube/pkg/minikube/cruntime	5.173s	coverage: 29.2% of statements
ok  	k8s.io/minikube/pkg/minikube/docker	4.324s	coverage: 20.8% of statements
ok  	k8s.io/minikube/pkg/minikube/download	6.075s	coverage: 25.6% of statements
ok  	k8s.io/minikube/pkg/minikube/driver	5.293s	coverage: 42.9% of statements
ok  	k8s.io/minikube/pkg/minikube/driver/auxdriver	4.985s	coverage: 19.0% of statements
ok  	k8s.io/minikube/pkg/minikube/extract	4.412s	coverage: 56.9% of statements
ok  	k8s.io/minikube/pkg/minikube/image	4.549s	coverage: 5.1% of statements
ok  	k8s.io/minikube/pkg/minikube/kubeconfig	4.242s	coverage: 78.3% of statements
ok  	k8s.io/minikube/pkg/minikube/localpath	4.226s	coverage: 48.1% of statements
ok  	k8s.io/minikube/pkg/minikube/logs	3.727s	coverage: 5.2% of statements
ok  	k8s.io/minikube/pkg/minikube/machine	3.175s	coverage: 20.2% of statements
ok  	k8s.io/minikube/pkg/minikube/mustload	3.897s	coverage: 6.4% of statements
ok  	k8s.io/minikube/pkg/minikube/notify	2.441s	coverage: 79.8% of statements
ok  	k8s.io/minikube/pkg/minikube/out	2.738s	coverage: 66.5% of statements
ok  	k8s.io/minikube/pkg/minikube/out/register	3.011s	coverage: 55.4% of statements
ok  	k8s.io/minikube/pkg/minikube/perf	7.936s	coverage: 20.7% of statements
ok  	k8s.io/minikube/pkg/minikube/proxy	3.829s	coverage: 74.0% of statements
ok  	k8s.io/minikube/pkg/minikube/reason	3.930s	coverage: 70.0% of statements
ok  	k8s.io/minikube/pkg/minikube/registry	4.144s	coverage: 78.8% of statements
ok  	k8s.io/minikube/pkg/minikube/registry/drvs/docker	3.775s	coverage: 46.5% of statements
ok  	k8s.io/minikube/pkg/minikube/registry/drvs/hyperkit	3.760s	coverage: 41.5% of statements
ok  	k8s.io/minikube/pkg/minikube/service	7.722s	coverage: 76.6% of statements
ok  	k8s.io/minikube/pkg/minikube/shell	2.241s	coverage: 94.4% of statements
ok  	k8s.io/minikube/pkg/minikube/storageclass	3.453s	coverage: 100.0% of statements
ok  	k8s.io/minikube/pkg/minikube/style	3.502s	coverage: 100.0% of statements
ok  	k8s.io/minikube/pkg/minikube/sysinit	3.952s	coverage: 5.9% of statements
ok  	k8s.io/minikube/pkg/minikube/translate	4.057s	coverage: 27.6% of statements
ok  	k8s.io/minikube/pkg/minikube/tunnel	4.300s	coverage: 57.7% of statements
ok  	k8s.io/minikube/pkg/network	1.584s	coverage: 75.5% of statements
ok  	k8s.io/minikube/pkg/util	2.216s	coverage: 79.9% of statements
ok  	k8s.io/minikube/pkg/util/lock	1.991s	coverage: 10.0% of statements
ok  	k8s.io/minikube/pkg/util/retry	2.842s	coverage: 0.0% of statements
ok
```