### PR TITLE
Makefile, fix update-nerdctld-version spelling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1229,7 +1229,7 @@ update-amd-gpu-device-plugin-version:
 	(cd hack/update/amd_device_plugin_version && \
 	 go run update_amd_device_plugin_version.go)
 
-.PHONY: update-nerctld-version
+.PHONY: update-nerdctld-version
 update-nerdctld-version:
 	(cd hack/update/nerdctld_version && \
 	 go run update_nerdctld_version.go)


### PR DESCRIPTION
It is missing a 'd'.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
