### PR TITLE
fix newest-cni tests: remove deprecated flag and removed feature gate

### DIFF
--- a/test/integration/start_stop_delete_test.go
+++ b/test/integration/start_stop_delete_test.go
@@ -58,8 +58,6 @@ func TestStartStop(t *testing.T) {
 				"--keep-context=false",
 			}},
 			{"newest-cni", constants.NewestKubernetesVersion, []string{
-				"--feature-gates",
-				"ServerSideApply=true",
 				"--network-plugin=cni",
 				"--extra-config=kubeadm.pod-network-cidr=10.42.0.0/16",
 			}},


### PR DESCRIPTION
Fixes issues with newest-cni tests and Kubernetes v1.32+ as seen in https://github.com/kubernetes/minikube/pull/20054

details:

`ServerSideApply` feature gate was GAed in Kubernetes v1.22 and removed in v1.32
refs:
 - Kubernetes v1.32 [Changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#other-cleanup-or-flake):
> Removed the GAed feature gates for ServerSideApply and ServerSideFieldValidation. ([#127058](https://github.com/kubernetes/kubernetes/pull/127058), @carlory)

 - [Feature gates that are removed](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates-removed/) doc/table

Kubernetes `v1.31.4` kubelet logs:
```
Dec 12 13:38:29 newest-cni-063619 kubelet[1106]: Flag --feature-gates has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Dec 12 13:38:29 newest-cni-063619 kubelet[1106]: W1212 13:38:29.737340    1106 feature_gate.go:354] Setting GA feature gate ServerSideApply=true. It will be removed in a future release.
Dec 12 13:38:29 newest-cni-063619 kubelet[1106]: W1212 13:38:29.738816    1106 feature_gate.go:354] Setting GA feature gate ServerSideApply=true. It will be removed in a future release.
Dec 12 13:38:29 newest-cni-063619 kubelet[1106]: W1212 13:38:29.738936    1106 feature_gate.go:354] Setting GA feature gate ServerSideApply=true. It will be removed in a future release.
Dec 12 13:38:30 newest-cni-063619 kubelet[1106]: I1212 13:38:30.037883    1106 server.go:491] "Kubelet version" kubeletVersion="v1.31.4"
```

Kubernetes `v1.32.0` kubelete logs:
```
Dec 12 13:59:22 newest-cni-063619-1320 kubelet[881]: Flag --feature-gates has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Dec 12 13:59:22 newest-cni-063619-1320 kubelet[881]: E1212 13:59:22.114351     881 run.go:72] "command failed" err="failed to set feature gates from initial flags-based config: unrecognized feature gate: ServerSideApply"
Dec 12 13:59:22 newest-cni-063619-1320 systemd[1]: kubelet.service: Main process exited, code=exited, status=1/FAILURE
```
