### PR TITLE
[20124] - Feature Request: Provide an option for passing a config file for addon configure command. 

### DIFF
--- a/cmd/minikube/cmd/config/configure.go
+++ b/cmd/minikube/cmd/config/configure.go
@@ -105,7 +105,7 @@ var addonsConfigureCmd = &cobra.Command{
 					awsRole = AskForStaticValueOptional("-- (Optional) Enter ARN of AWS role to assume: ")
 				}
 			} else if awsEcrAction == "enable" {
-				out.Ln("Loading AWS ECR configs from: ", AddonConfigFile)
+				out.Ln("Loading AWS ECR configs from: %s", AddonConfigFile)
 				// Then read the configs
 				awsAccessID = getNestedJsonString(configFileData, "awsEcrConfigs", "awsAccessID")
 				awsAccessKey = getNestedJsonString(configFileData, "awsEcrConfigs", "awsAccessKey")


### PR DESCRIPTION
Minor UI Change (Before and After described in the ticket) but tl;dr:

## BEFORE

Currently when configuring addons with the command:

```
minikube addons configure <addon>
```

eg:

```
minikube addons configure registry-creds
```

The user is prompted to input the values one by one, eg:

```
Do you want to enable AWS Elastic Container Registry? [y/n]:
```

and so on.    This makes it hard to store/load values in a scripted environemnt.   Some times it easier to provide a config file containing so that the values can be read from this.  

## AFTER

Add a "-c" local flag to the addon configure command, eg:

```
minikube addons registry-creds -c ~/.minikube/configs/registry-creds-config.json
minikube addons ingress -c ~/.minikube/configs/ingres-config.json
```

etc

