### PR TITLE
Site: fix minikube-linux-amd64 download URL error

### DIFF
--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -171,7 +171,7 @@ Click on the buttons that describe your target platform. For other architectures
 
 {{% quiz_instruction id="/Linux/x86-64/Stable/Binary download" %}}
 ```shell
-curl -LO https://github.com/kubernetes/minikube/releases/latest/download/minikube-linux-amd64/
+curl -LO https://github.com/kubernetes/minikube/releases/latest/download/minikube-linux-amd64
 sudo install minikube-linux-amd64 /usr/local/bin/minikube && rm minikube-linux-amd64
 ```
 {{% /quiz_instruction %}}


### PR DESCRIPTION
the linux amd64 download url error

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
