### PR TITLE
config.go: invoke the MaskProxyPasswordWithKey function to hide the e…

### DIFF
--- a/pkg/minikube/node/config.go
+++ b/pkg/minikube/node/config.go
@@ -49,6 +49,7 @@ func showVersionInfo(k8sVersion string, cr cruntime.Manager) {
 		out.Infof("opt {{.docker_option}}", out.V{"docker_option": v})
 	}
 	for _, v := range config.DockerEnv {
+		v = util.MaskProxyPasswordWithKey(v)
 		out.Infof("env {{.docker_env}}", out.V{"docker_env": v})
 	}
 }


### PR DESCRIPTION
…nvironment variable

When the HTTP_PROXY variable is set in the environment, Minikube hides the password when showing the network options, but displays it when showing the (env) variable.
 
The "showVersionInfo" function has been changed to hide the variable's password as well.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
