### PR TITLE
CI: enable go version update using the check_install_golang script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,9 @@ RPM_REVISION ?= 0
 # used by hack/jenkins/release_build_and_upload.sh and KVM_BUILD_IMAGE, see also BUILD_IMAGE below
 # update this only by running `make update-golang-version`
 GO_VERSION ?= 1.23.4
-# set GOTOOLCHAIN to local to override the toolchain version specified in go.mod and
-# use the one CI hosts has installed (ref: https://go.dev/doc/toolchain#GOTOOLCHAIN)
-export GOTOOLCHAIN := local
+# set GOTOOLCHAIN to GO_VERSION to override any toolchain version specified in
+# go.mod (ref: https://go.dev/doc/toolchain#GOTOOLCHAIN)
+export GOTOOLCHAIN := $(GO_VERSION)
 # update this only by running `make update-golang-version`
 GO_K8S_VERSION_PREFIX ?= v1.33.0
 

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ RPM_REVISION ?= 0
 # used by hack/jenkins/release_build_and_upload.sh and KVM_BUILD_IMAGE, see also BUILD_IMAGE below
 # update this only by running `make update-golang-version`
 GO_VERSION ?= 1.23.4
+# set GOTOOLCHAIN to local to override the toolchain version specified in go.mod and
+# use the one CI hosts has installed (ref: https://go.dev/doc/toolchain#GOTOOLCHAIN)
+export GOTOOLCHAIN := local
 # update this only by running `make update-golang-version`
 GO_K8S_VERSION_PREFIX ?= v1.33.0
 

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ RPM_REVISION ?= 0
 GO_VERSION ?= 1.23.4
 # set GOTOOLCHAIN to GO_VERSION to override any toolchain version specified in
 # go.mod (ref: https://go.dev/doc/toolchain#GOTOOLCHAIN)
-export GOTOOLCHAIN := $(GO_VERSION)
+export GOTOOLCHAIN := go$(GO_VERSION)
 # update this only by running `make update-golang-version`
 GO_K8S_VERSION_PREFIX ?= v1.33.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/minikube
 
-go 1.23.0
+go 1.23.4
 
 require (
 	cloud.google.com/go/storage v1.48.0

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module k8s.io/minikube
 
 go 1.23.0
 
-toolchain go1.23.4
-
 require (
 	cloud.google.com/go/storage v1.48.0
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.14


### PR DESCRIPTION
we've hit an issue with updating the go version on jenkins ci runners, which was required to fix another issue with the `make generate-licenses`, blocking our release

the details are in a rather lengthy slack debugging [thread](https://kubernetes.slack.com/archives/C1F5CT6Q1/p1736980291018629), but here's the tldr:

---

so, the issue is probably in the `toolchain go1.23.4` [line](https://github.com/kubernetes/minikube/blob/dd5d320e41b5451cdf3c01891bc4e13d189586ed/go.mod#L5) that we have set in the `go.mod` file and that's what go uses to respond back on `go version`, **_regardless of the actual go version installed_** (which explains why, when you start another-ssh session, you probably don't go into the minikube source dir, so the `go version` is not affected by the toolchain directive and returns the actually installed go version, and so you were able to update the go version as expected by manually running the script)

the "proof" whilst having `go v1.23.3` installed:
```
$ pwd
/home/prezha/dev/Kubernetes/minikube/github.com/prezha/minikube

$ grep "^go\|^toolchain" go.mod
go 1.23.0
toolchain go1.23.4

$ go env | grep "GOROOT\|GOVERSION"
GOROOT='/home/prezha/dev/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64'
GOVERSION='go1.23.4'

$ go version
go version go1.23.4 linux/amd64
```
going outside the minikube src dir:
```
$ cd

$ pwd
/home/prezha

$ go version
go version go1.23.3 linux/amd64
```
going back to the minikube src and removing the toolchain go1.23.4:
```
$ pwd
/home/prezha/dev/Kubernetes/minikube/github.com/prezha/minikube

$ grep "^go\|^toolchain" go.mod
go 1.23.0

$ go env | grep "GOROOT\|GOVERSION"
GOROOT='/usr/local/go'
GOVERSION='go1.23.3'

$ go version
go version go1.23.3 linux/amd64
```

that's probably "by design", but we oversaw it

---

this pr removes the toolchain directive and also bumps the go version in the go.mod, as for some reason, looks like the other [pr](https://github.com/kubernetes/minikube/pull/20272) did not do it (worth checking separatelly)