### PR TITLE
Revert "fix --wait's failure to work on coredns pods"

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -567,7 +567,7 @@ func (k *Bootstrapper) WaitForNode(cfg config.ClusterConfig, n config.Node, time
 		}
 
 		if cfg.VerifyComponents[kverify.AppsRunningKey] {
-			if err := kverify.WaitForAppsRunning(&cfg, client, kverify.AppsRunningList, timeout); err != nil {
+			if err := kverify.WaitForAppsRunning(client, kverify.AppsRunningList, timeout); err != nil {
 				return errors.Wrap(err, "waiting for apps_running")
 			}
 		}


### PR DESCRIPTION
Reverts kubernetes/minikube#19748

pr #19748 causes issues we saw in [TestStartStop tests failures](https://gopogh-server-tts3vkcpgq-uc.a.run.app/?env=KVM_Linux_containerd&test=TestStartStop/group/no-preload/serial/SecondStart) - namely, continuously calling CoreV1().Pods("kube-system").List() in a [for loop without any pause](https://github.com/kubernetes/minikube/pull/19748/files#diff-9424bfdb3d84e24c64adeb25b93c68440a7ddecd0a522c68f759b6ac45b748e0R89-R102) in between might overwhelm the kube api and container runtime

locally, i've successfully replicated the issue and reverting these changes fixed it

we should fix the original issue #19288 (ie, properly wait for a coredns to become ready) in a different way (one potential option suggested in https://github.com/kubernetes/minikube/pull/19748#issuecomment-2395576559)

---

note: folloup pr: https://github.com/kubernetes/minikube/pull/20315