### PR TITLE
fix: incorrect finalImg affecting downloading kic form github assets

### DIFF
--- a/pkg/minikube/download/image.go
+++ b/pkg/minikube/download/image.go
@@ -226,10 +226,11 @@ func ImageToCache(img string) error {
 	}
 }
 
-// GHImageTarballToCache try to download the tarball of kicbase from github release.
+// GHKicbaseTarballToCache try to download the tarball of kicbase from github release.
 // This is the last resort, in case of all docker registry is not available.
-func GHImageTarballToCache(img, imgVersion string) (string, error) {
-	f := imagePathInCache(img)
+func GHKicbaseTarballToCache(kicBaseVersion string) (string, error) {
+	imageName := fmt.Sprintf("kicbase/stable:%s", kicBaseVersion)
+	f := imagePathInCache(imageName)
 	fileLock := f + ".lock"
 
 	kicbaseArch := runtime.GOARCH
@@ -244,9 +245,9 @@ func GHImageTarballToCache(img, imgVersion string) (string, error) {
 	if releaser != nil {
 		defer releaser.Release()
 	}
-	downloadURL := fmt.Sprintf("https://github.com/kubernetes/minikube/releases/download/%s/%s-%s-%s.tar",
+	downloadURL := fmt.Sprintf("https://github.com/kubernetes/minikube/releases/download/%s/kicbase-%s-%s.tar",
 		version.GetVersion(),
-		img, imgVersion, kicbaseArch)
+		kicBaseVersion, kicbaseArch)
 
 	// we don't want the tarball to be decompressed
 	// so we pass client options to suppress this behavior

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -188,15 +188,18 @@ func beginDownloadKicBaseImage(g *errgroup.Group, cc *config.ClusterConfig, down
 		out.Ln("")
 
 		kicbaseVersion := strings.Split(kic.Version, "-")[0]
-		finalImg, err = download.GHImageTarballToCache("kicbase", kicbaseVersion)
+		_, err = download.GHKicbaseTarballToCache(kicbaseVersion)
 		if err != nil {
-			klog.Infof("failed to download %s", finalImg)
+			klog.Infof("failed to download kicbase from github")
 			return fmt.Errorf("failed to download kic base image or any fallback image")
 		}
-		klog.Infof("successfully downloaded %s as fall back image", finalImg)
+
+		klog.Infof("successfully downloaded kicbase as fall back image from github")
 		if !downloadOnly && driver.IsDocker(cc.Driver) {
-			if finalImg, err = download.CacheToDaemon("kicbase"); err == nil {
+			if finalImg, err = download.CacheToDaemon(fmt.Sprintf("kicbase/stable:%s", kicbaseVersion)); err == nil {
 				klog.Infof("successfully loaded and using kicbase from tarball on github")
+			} else {
+				return fmt.Errorf("failed to load kic base image into docker: %v", err)
 			}
 		}
 		return nil


### PR DESCRIPTION
fix: fix incorrect finalImg in cache.go

When testing the new "download kicbase image from github release" feature, I found that it cannot work. This PR fixes the bugs and make it work now.

Before:
```
😄  minikube v1.35.0 on Darwin 14.6.1 (arm64)
✨  Automatically selected the docker driver. Other choices: qemu2, ssh
📌  Using Docker Desktop driver with root privileges
👍  Starting "minikube" primary control-plane node in "minikube" cluster
🚜  Pulling base image v0.0.46 ...
💾  Downloading Kubernetes v1.32.0 preload ...
❗  minikube cannot pull kicbase image from any docker registry, and is trying to download kicbase tarball from github release page via HTTP.
❗  It's very likely that you have an internet issue. Please ensure that you can access the internet at least via HTTP, directly or with proxy. Currently your proxy configure is:

    > preloaded-images-k8s-v18-v1...:  314.92 MiB / 314.92 MiB  100.00% 32.58 M
    > kicbase-v0.0.46-arm64.tar:  1.14 GiB / 1.14 GiB  100.00% 43.47 MiB p/s 27
E0127 00:43:34.001999   56798 cache.go:233] Error downloading kic artifacts:  failed to load kic base image into docker: tarball: tag kicbase not found in tarball
🔥  Creating docker container (CPUs=2, Memory=6100MB) ...
🤦  StartHost failed, but will try again: creating host: create: creating: setting up container node: preparing volume for minikube container: docker run --rm --name minikube-preload-sidecar --label created_by.minikube.sigs.k8s.io=true --label name.minikube.sigs.k8s.io=minikube --entrypoint /usr/bin/test -v minikube:/var gcr.io/k8s-minikube/kicbase:v0.0.46@sha256:fd2d445ddcc33ebc5c6b68a17e6219ea207ce63c005095ea1525296da2d1a279 -d /var/lib: exit status 125
stdout:

stderr:
Unable to find image 'gcr.io/k8s-minikube/kicbase:v0.0.46@sha256:fd2d445ddcc33ebc5c6b68a17e6219ea207ce63c005095ea1525296da2d1a279' locally
docker: Error response from daemon: Get "https://gcr.io/v2/": dialing gcr.io:443 with direct connection: connecting to 0.0.0.1:443: dial tcp 0.0.0.1:443: connect: no route to host.
See 'docker run --help'.
```

After:
```
./out/minikube start         
😄  minikube v1.35.0 on Darwin 14.6.1 (arm64)
✨  Automatically selected the docker driver. Other choices: qemu2, ssh
📌  Using Docker Desktop driver with root privileges
👍  Starting "minikube" primary control-plane node in "minikube" cluster
🚜  Pulling base image v0.0.46 ...
💾  Downloading Kubernetes v1.32.0 preload ...
❗  minikube cannot pull kicbase image from any docker registry, and is trying to download kicbase tarball from github release page via HTTP.
❗  It's very likely that you have an internet issue. Please ensure that you can access the internet at least via HTTP, directly or with proxy. Currently your proxy configure is:

    > preloaded-images-k8s-v18-v1...:  314.92 MiB / 314.92 MiB  100.00% 35.88 M
    > kicbase-v0.0.46-arm64.tar:  1.14 GiB / 1.14 GiB  100.00% 33.31 MiB p/s 35
❗  minikube was unable to download gcr.io/k8s-minikube/kicbase:v0.0.46, but successfully downloaded kicbase/stable:v0.0.46 as a fallback image
🔥  Creating docker container (CPUs=2, Memory=6100MB) ...
🐳  Preparing Kubernetes v1.32.0 on Docker 27.4.1 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass

🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```