### PR TITLE
Fix bootpd check on macOS >= 15

### DIFF
--- a/pkg/minikube/firewall/firewall.go
+++ b/pkg/minikube/firewall/firewall.go
@@ -46,6 +46,16 @@ func IsBootpdBlocked(cc config.ClusterConfig) bool {
 	if regexp.MustCompile(`Firewall is disabled`).Match(out) {
 		return false
 	}
+	out, err = exec.Command("/usr/libexec/ApplicationFirewall/socketfilterfw", "--getallowsigned").Output()
+	if err != nil {
+		// macOS < 15 or other issue: need to use --list.
+		klog.Warningf("failed to list firewall allowedsinged option: %v", err)
+	} else {
+		// macOS >= 15: bootpd may be allowed as builtin software.
+		if regexp.MustCompile(`Automatically allow built-in signed software ENABLED`).Match(out) {
+			return false
+		}
+	}
 	out, err = exec.Command("/usr/libexec/ApplicationFirewall/socketfilterfw", "--listapps").Output()
 	if err != nil {
 		klog.Warningf("failed to list firewall apps: %v", err)


### PR DESCRIPTION
On macOS >= 15 bootpd is likely allowed to receive incoming connections as built-in software, and it will not be listed in the allowed applications. In this case we decide that bootpd is blocked and force the user to try to add and unblock it, which will never succeed.

Fixed using the new --getallowedsigned option. If the option is enabled, we know that bootpd is not blocked. If the option is not enabled, or the fails, we fallback to checking the list.

Tested on macOS 15.3.

fixes #20399