### PR TITLE
Use preload image for worker nodes

### DIFF
--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -163,6 +163,9 @@ func Start(starter Starter) (*kubeconfig.Settings, error) { // nolint:gocyclo
 			}()
 		}
 	} else {
+		if err := cr.Preload(*starter.Cfg); err != nil {
+			return nil, errors.Wrap(err, "preload failed")
+		}
 		bs, err = cluster.Bootstrapper(starter.MachineAPI, viper.GetString(cmdcfg.Bootstrapper), *starter.Cfg, starter.Runner)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to get bootstrapper")

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -164,7 +164,7 @@ func Start(starter Starter) (*kubeconfig.Settings, error) { // nolint:gocyclo
 		}
 	} else {
 		if err := cr.Preload(*starter.Cfg); err != nil {
-			return nil, errors.Wrap(err, "preload failed")
+			klog.Warning("preload failed")
 		}
 		bs, err = cluster.Bootstrapper(starter.MachineAPI, viper.GetString(cmdcfg.Bootstrapper), *starter.Cfg, starter.Runner)
 		if err != nil {


### PR DESCRIPTION
Currently when creating a worker node it will not be filled with any container images.
So it will pull the required images from the upstream registry.
This makes it impossible to use a multi node cluster in an offline environment.
This PR will changes the behavior to also copy the preload image to worker nodes.

Log before this patch: [without-preload.log](https://github.com/user-attachments/files/19521917/without-preload.log)
Log after this patch: [with-preload.log](https://github.com/user-attachments/files/19521918/with-preload.log)
