### PR TITLE
vfkit: Graceful shutdown on Stop()

### DIFF
--- a/pkg/drivers/vfkit/vfkit.go
+++ b/pkg/drivers/vfkit/vfkit.go
@@ -313,7 +313,7 @@ func isBootpdError(err error) bool {
 }
 
 func (d *Driver) Stop() error {
-	if err := d.SetVFKitState("HardStop"); err != nil {
+	if err := d.SetVFKitState("Stop"); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
We use `HardStop` which seems to do a forced shutdown instead of graceful shutdown, and to make things worse, always fails with:

    I0309 15:00:42.452986   13723 stop.go:66] stop err: Post "http://_/vm/state": EOF

Which leads to unneeded retry and pointless backup attempt timing out after 135 seconds because vkfit was stopped.

With this change we do a graceful shutdown, and the time to stop the cluster decreased from 135 seconds to 3 seconds (45 times faster).

Example stop log:

    I0309 15:34:33.104429   14440 main.go:141] libmachine: Stopping "minikube"...
    I0309 15:34:33.105225   14440 main.go:141] libmachine: get state: {State:VirtualMachineStateRunning}
    I0309 15:34:33.105799   14440 main.go:141] libmachine: set state: {State:Stop}
    I0309 15:34:33.106099   14440 main.go:141] libmachine: get state: {State:VirtualMachineStateRunning}
    I0309 15:34:36.109380   14440 main.go:141] libmachine: Machine "minikube" was stopped.

Fixes #20503