### PR TITLE
vfkit: More robust state management

### DIFF
--- a/pkg/drivers/vfkit/vfkit.go
+++ b/pkg/drivers/vfkit/vfkit.go
@@ -158,17 +158,7 @@ func (d *Driver) GetState() (state.State, error) {
 		os.Remove(pidfile)
 		return state.Stopped, nil
 	}
-	ret, err := d.GetVFKitState()
-	if err != nil {
-		return state.Error, err
-	}
-	switch ret {
-	case "running", "VirtualMachineStateRunning":
-		return state.Running, nil
-	case "stopped", "VirtualMachineStateStopped":
-		return state.Stopped, nil
-	}
-	return state.None, nil
+	return state.Running, nil
 }
 
 func (d *Driver) Create() error {
@@ -322,11 +312,6 @@ func (d *Driver) Remove() error {
 	if s == state.Running {
 		if err := d.Kill(); err != nil {
 			return errors.Wrap(err, "kill")
-		}
-	}
-	if s != state.Stopped {
-		if err := d.SetVFKitState("Stop"); err != nil {
-			return errors.Wrap(err, "quit")
 		}
 	}
 	return nil

--- a/pkg/minikube/process/process.go
+++ b/pkg/minikube/process/process.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2025 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package process
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/mitchellh/go-ps"
+)
+
+const pidfileMode = 0o600
+
+// WritePidfile writes pid to path.
+func WritePidfile(path string, pid int) error {
+	data := fmt.Sprintf("%d", pid)
+	return os.WriteFile(path, []byte(data), pidfileMode)
+}
+
+// ReadPid reads a pid from path.
+func ReadPidfile(path string) (int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		// Pass os.ErrNotExist
+		return -1, err
+	}
+	s := strings.TrimSpace(string(data))
+	pid, err := strconv.Atoi(s)
+	if err != nil {
+		return -1, fmt.Errorf("invalid pid %q: %s", s, err)
+	}
+	return pid, nil
+}
+
+// Exists tells if a process matching pid and executable name exist. Executable is
+// not the path to the executable.
+func Exists(pid int, executable string) (bool, error) {
+	// Fast path if pid does not exist.
+	exists, err := pidExists(pid)
+	if err != nil {
+		return true, err
+	}
+	if !exists {
+		return false, nil
+	}
+
+	// Slow path if pid exist, depending on the platform. On windows and darwin
+	// this fetch all processes from the krenel and find a process with pid. On
+	// linux this reads /proc/pid/stat
+	entry, err := ps.FindProcess(pid)
+	if err != nil {
+		return true, err
+	}
+	if entry == nil {
+		return false, nil
+	}
+	return entry.Executable() == executable, nil
+}
+
+// Terminate a process with pid and matching name. Returns os.ErrProcessDone if
+// the process does not exist, or nil if termiation was requested. Caller need
+// to wait until the process disappears.
+func Terminate(pid int, executable string) error {
+	exists, err := Exists(pid, executable)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return os.ErrProcessDone
+	}
+	return terminatePid(pid)
+}
+
+// Kill a process with pid matching executable name. Returns os.ErrProcessDone
+// if the process does not exist or nil the kill was requested. Caller need to
+// wait until the process disappears.
+func Kill(pid int, executable string) error {
+	exists, err := Exists(pid, executable)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return os.ErrProcessDone
+	}
+	return killPid(pid)
+}

--- a/pkg/minikube/process/process_other.go
+++ b/pkg/minikube/process/process_other.go
@@ -1,0 +1,53 @@
+//go:build !windows
+
+/*
+Copyright 2025 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package process
+
+import (
+	"os"
+	"syscall"
+)
+
+func pidExists(pid int) (bool, error) {
+	// Never fails and we get a process in "done" state that returns
+	// os.ErrProcessDone from Signal or Wait.
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return true, err
+	}
+	if process.Signal(syscall.Signal(0)) == os.ErrProcessDone {
+		return false, nil
+	}
+	return true, nil
+}
+
+func terminatePid(pid int) error {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return p.Signal(syscall.SIGTERM)
+}
+
+func killPid(pid int) error {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return p.Kill()
+}

--- a/pkg/minikube/process/process_test.go
+++ b/pkg/minikube/process/process_test.go
@@ -1,0 +1,238 @@
+/*
+Copyright 2025 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package process
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+var waitTimeout = 250 * time.Millisecond
+
+func TestPidfile(t *testing.T) {
+	pidfile := filepath.Join(t.TempDir(), "pid")
+	if err := WritePidfile(pidfile, 42); err != nil {
+		t.Fatal(err)
+	}
+	pid, err := ReadPidfile(pidfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pid != 42 {
+		t.Fatalf("expected 42, got %d", pid)
+	}
+}
+
+func TestPidfileMissing(t *testing.T) {
+	pidfile := filepath.Join(t.TempDir(), "pid")
+	_, err := ReadPidfile(pidfile)
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+func TestPidfileInvalid(t *testing.T) {
+	pidfile := filepath.Join(t.TempDir(), "pid")
+	if err := os.WriteFile(pidfile, []byte("invalid"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ReadPidfile(pidfile)
+	if err == nil {
+		t.Fatal("parsing invalid pidfile did not fail")
+	}
+}
+
+func TestProcess(t *testing.T) {
+	sleep, err := build(t, "sleep")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	noterm, err := build(t, "noterm")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("exists", func(t *testing.T) {
+		cmd := startProcess(t, sleep)
+		exists, err := Exists(cmd.Process.Pid, filepath.Base(sleep))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !exists {
+			t.Fatal("existing process not found")
+		}
+		exists, err = Exists(0xfffffffc, filepath.Base(sleep))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if exists {
+			t.Fatal("process with non-existing pid found")
+		}
+		exists, err = Exists(cmd.Process.Pid, "no-such-executable")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if exists {
+			t.Fatal("process with non-existing executable found")
+		}
+	})
+
+	t.Run("terminate", func(t *testing.T) {
+		cmd := startProcess(t, sleep)
+		err := Terminate(cmd.Process.Pid, filepath.Base(sleep))
+		if err != nil {
+			t.Fatal(err)
+		}
+		waitForTermination(t, cmd)
+		exists, err := Exists(cmd.Process.Pid, filepath.Base(sleep))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if exists {
+			t.Fatalf("reaped process exists")
+		}
+	})
+
+	t.Run("terminate name mismatch", func(t *testing.T) {
+		cmd := startProcess(t, sleep)
+		err := Terminate(cmd.Process.Pid, "no-such-process")
+		if err == nil {
+			t.Fatalf("Signaled unrelated process")
+		}
+		if err != os.ErrProcessDone {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+	})
+
+	t.Run("terminate ignored", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("no way to ignore termination on windows")
+		}
+		cmd := startProcess(t, noterm)
+		err := Terminate(cmd.Process.Pid, filepath.Base(noterm))
+		if err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(waitTimeout)
+		exists, err := Exists(cmd.Process.Pid, filepath.Base(noterm))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !exists {
+			t.Fatalf("process terminated")
+		}
+	})
+
+	t.Run("kill", func(t *testing.T) {
+		cmd := startProcess(t, noterm)
+		err := Kill(cmd.Process.Pid, filepath.Base(noterm))
+		if err != nil {
+			t.Fatal(err)
+		}
+		waitForTermination(t, cmd)
+		exists, err := Exists(cmd.Process.Pid, filepath.Base(noterm))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if exists {
+			t.Fatalf("reaped process exists")
+		}
+	})
+
+	t.Run("kill name mismatch", func(t *testing.T) {
+		cmd := startProcess(t, noterm)
+		err := Kill(cmd.Process.Pid, "no-such-process")
+		if err == nil {
+			t.Fatalf("Killed unrelated process")
+		}
+		if err != os.ErrProcessDone {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+	})
+}
+
+func startProcess(t *testing.T, cmd string) *exec.Cmd {
+	name := filepath.Base(cmd)
+	c := exec.Command(cmd)
+	stdout, err := c.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	if err := c.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Started process %q (pid=%v)", name, c.Process.Pid)
+
+	t.Cleanup(func() {
+		_ = c.Process.Kill()
+		_ = c.Wait()
+	})
+
+	// Synchronize with the process to ensure it set up signal handlers before
+	// we send a signal.
+	r := bufio.NewReader(stdout)
+	line, err := r.ReadString('\n')
+	if err != nil {
+		t.Fatal(err)
+	}
+	if line != "READY\n" {
+		t.Fatalf("Unexpected response: %q", line)
+	}
+	t.Logf("Process %q ready in %.6f seconds", name, time.Since(start).Seconds())
+
+	return c
+}
+
+func waitForTermination(t *testing.T, cmd *exec.Cmd) {
+	name := filepath.Base(cmd.Path)
+	timer := time.AfterFunc(waitTimeout, func() {
+		t.Fatalf("Timeout waiting for %q", name)
+	})
+	defer timer.Stop()
+	start := time.Now()
+	err := cmd.Wait()
+	t.Logf("Process %q terminated in %.6f seconds: %s", name, time.Since(start).Seconds(), err)
+}
+
+func build(t *testing.T, name string) (string, error) {
+	source := fmt.Sprintf("testdata/%s.go", name)
+
+	out := filepath.Join(t.TempDir(), name)
+	if runtime.GOOS == "windows" {
+		out += ".exe"
+	}
+
+	t.Logf("Building %q", name)
+	cmd := exec.Command("go", "build", "-o", out, source)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}

--- a/pkg/minikube/process/process_windows.go
+++ b/pkg/minikube/process/process_windows.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2025 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package process
+
+import (
+	"os"
+)
+
+func pidExists(pid int) (bool, error) {
+	// Fails with "OpenProcess: The parameter is incorrect" if the process does
+	// not exist.
+	_, err := os.FindProcess(pid)
+	return err == nil, nil
+}
+
+func terminatePid(pid int) error {
+	return killPid(pid)
+}
+
+func killPid(pid int) error {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return os.ErrProcessDone
+	}
+	return p.Kill()
+}

--- a/pkg/minikube/process/testdata/noterm.go
+++ b/pkg/minikube/process/testdata/noterm.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2025 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+func main() {
+	signal.Ignore(syscall.SIGTERM)
+	fmt.Println("READY") // Synchronize with parent
+	time.Sleep(10 * time.Second)
+}

--- a/pkg/minikube/process/testdata/sleep.go
+++ b/pkg/minikube/process/testdata/sleep.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2025 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	fmt.Println("READY") // Synchronize with parent
+	time.Sleep(10 * time.Second)
+}


### PR DESCRIPTION
We get and set vfkit state using the HTTP API. This is not very robust since the API is provided by the process we are terminating:

- Setting the state to `HardStop` typically fails when vfkit is terminated, leading to unneeded retries and delays.
- Setting the state to `Stop` may fail if vfkit is already stopped or shutting down, or does not listen to the socket.
- Getting the state is racy, since vfkit may be shutting down or terminate right after checking the pid (time of check, time of use).
- The pidfile was not removed in all cases, or removed too late.

This change fixes the issues by using vfkit API only for setting state, and falling back to process package pid management functions if the API fails.