### PR TITLE
Fix bug where cert files cannot have parenthesis in its name

### DIFF
--- a/pkg/minikube/command/ssh_runner.go
+++ b/pkg/minikube/command/ssh_runner.go
@@ -409,7 +409,7 @@ func (s *SSHRunner) Copy(f assets.CopyableFile) error {
 	if err != nil {
 		klog.Infof("error getting modtime for %s: %v", dst, err)
 	} else if mtime != (time.Time{}) {
-		scp += fmt.Sprintf(" && sudo touch -d \"%s\" %s", mtime.Format(layout), dst)
+		scp += fmt.Sprintf(" && sudo touch -d \"%s\" '%s'", mtime.Format(layout), dst)
 	}
 	out, err := sess.CombinedOutput(scp)
 	if err != nil {


### PR DESCRIPTION
I have never once programmed in Go before, but I think this fix should work? I have to compile and run it on my work machine later next week to confirm that this works, but extra quotations can't hurt.
 
fixes #20080