### PR TITLE
Update qemu.md docs for homebrew/services decommission

### DIFF
--- a/site/content/en/docs/drivers/qemu.md
+++ b/site/content/en/docs/drivers/qemu.md
@@ -43,7 +43,6 @@ Requires macOS 10.15 or later and [socket_vmnet](https://github.com/lima-vm/sock
 ### Install socket_vmnet via [brew](https://brew.sh/)
 ```shell
 brew install socket_vmnet
-brew tap homebrew/services
 HOMEBREW=$(which brew) && sudo ${HOMEBREW} services start socket_vmnet
 ```
 


### PR DESCRIPTION
## `brew tap homebrew/services` is now unnecessary.

## Decommissioned Tap
https://github.com/Homebrew/homebrew-services was decommissioned on March 20, 2025.

## Services Command Relocated
`brew services` still works since it is now included with brew by default https://github.com/Homebrew/brew/tree/master/Library/Homebrew/services.

