### PR TITLE
vmnet: Improve --network vmnet-shared validation

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 	"strings"
 	"time"
@@ -519,8 +520,12 @@ func validateVfkitNetwork(n string) string {
 		// always available
 	case "vmnet-shared":
 		// "vment-shared" provides access between machines, with lower performance compared to "nat".
-		if !vmnet.HelperAvailable() {
-			exit.Message(reason.NotFoundVmnetHelper, "\n\n")
+		if err := vmnet.ValidateHelper(); err != nil {
+			klog.Errorf("Failed to validate %q network: %s", n, err)
+			if errors.Is(err, os.ErrNotExist) {
+				exit.Message(reason.NotFoundVmnetHelper, "\n\n")
+			}
+			exit.Message(reason.NotConfiguredVmnetHelper, "\n\n")
 		}
 	case "":
 		// Default to nat since it is always available and provides the best performance.

--- a/pkg/drivers/vmnet/vmnet_stub.go
+++ b/pkg/drivers/vmnet/vmnet_stub.go
@@ -18,6 +18,11 @@ limitations under the License.
 
 package vmnet
 
-func HelperAvailable() bool {
-	return false
+import (
+	"fmt"
+	"runtime"
+)
+
+func ValidateHelper() error {
+	return fmt.Errorf("vmnet-helper is not available on %q", runtime.GOOS)
 }

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -563,4 +563,14 @@ var (
 		  minikube start{{.profile}} --driver vfkit --network nat`),
 		Style: style.SeeNoEvil,
 	}
+	NotConfiguredVmnetHelper = Kind{
+		ID:       "NOT_CONFIGURED_VMNET_HELPER",
+		ExitCode: ExProgramConfig,
+		Advice: translate.T(`vmnet-helper is not configured correctly.
+
+		Please install a vmnnet-helper sudoers rule using these instructions:
+
+		https://github.com/nirs/vmnet-helper#granting-permission-to-run-vmnet-helper`),
+		Style: style.SeeNoEvil,
+	}
 )


### PR DESCRIPTION
Previously we did not check that the helper can run with the --close-from=4 option, so the command could succeed when incorrect sudoers configuration. For example a user with liberal NOPASSWD rule, but without the closefrom_override option.

When the check failed, we log unhelpful log:

    libmachine: Failed to run vmnet-helper:
    %!w(*exec.ExitError=&{0x14000135e30 [115 117 100 111 58 32 97 ... 101 100 10]})

And we returned a bool, so the caller could not tell if the helper is not installed or not configured properly.

Fix by:

- Rename vment.HelperAvaialble to vment.ValidateHelper
- Return an error describing the issue, that can be handled with errors.Is()
- Include the ExitError.Stderr int the error. This includes helpful error messages from sudo.
- Add new reason.NotConfiguredVmnetHelper error
- Improve validation when vment.ValidateHelper() succeeded

Example error flow - vment-helper not installed:

    % minikube start --driver vfkit --network vmnet-shared
    😄  minikube v1.35.0 on Darwin 15.4.1 (arm64)
    ✨  Using the vfkit (experimental) driver based on user configuration
    E0502 00:57:51.009031   19098 start_flags.go:524] Failed to validate "vmnet-shared" network:
    stat /opt/vmnet-helper/bin/vmnet-helper: no such file or directory

    🙈  Exiting due to NOT_FOUND_VMNET_HELPER:

    💡  Suggestion:

        vmnet-helper was not found on the system, resolve by:

        Option 1) Installing vment-helper:

        https://github.com/nirs/vmnet-helper#installation

        Option 2) Using the nat network:

        minikube start<no value> --driver vfkit --network nat

If resolved the issue by installing vmnet-helper but I did not configured the sudoers rule:

    % minikube start --driver vfkit --network vmnet-shared
    😄  minikube v1.35.0 on Darwin 15.4.1 (arm64)
    ✨  Using the vfkit (experimental) driver based on user configuration
    E0502 00:59:03.501549   19127 start_flags.go:524] Failed to validate "vmnet-shared" network:
    failed to run vmnet-helper via sudo: exit status 1: sudo: you are not permitted to use the -C
    option

    🙈  Exiting due to NOT_CONFIGURED_VMNET_HELPER:

    💡  Suggestion:

        vmnet-helper is not configured correctly.

        Please install a vmnnet-helper sudoers rule using these instructions:

        https://github.com/nirs/vmnet-helper#granting-permission-to-run-vmnet-helper

After installing the sudoers rule, minikube could start with --network
vmnet-shared. In the log we can see:
    
        % minikube logs | grep vmnet-helper
        I0502 01:29:55.500206   22131 main.go:141] libmachine: Validated vmnet-helper version "v0.5.0"
        I0502 01:29:56.218530   22131 main.go:141] libmachine: Started vmnet-helper (pid=22138)