### PR TITLE
docs: fix md code syntax to prevent issues on documentation rendering

### DIFF
--- a/site/content/en/docs/handbook/addons/custom-images.md
+++ b/site/content/en/docs/handbook/addons/custom-images.md
@@ -14,7 +14,7 @@ We defined and named all images used by an addon, you could view them by command
 minikube addons images efk
 ```
 
-```shell
+```text
     ▪ efk has following images:
 |----------------------|------------------------------|-------------------|
 |      IMAGE NAME      |        DEFAULT IMAGE         | DEFAULT REGISTRY  |

--- a/site/content/en/docs/handbook/addons/custom-images.md
+++ b/site/content/en/docs/handbook/addons/custom-images.md
@@ -44,9 +44,6 @@ The format is `IMAGE_NAME=CUSTOM_VALUE`, separated by commas, where the `IMAGE_N
 
 ```shell
 minikube addons enable efk --images="Kibana=kibana/kibana:5.6.2-custom" --registries="Kibana=,Elasticsearch=192.168.10.2:5555,FluentdElasticsearch=192.168.10.2:5555"
-```
-
-```shell
     ▪ Using image 192.168.10.2:5555/elasticsearch:v5.6.2
     ▪ Using image 192.168.10.2:5555/fluentd-elasticsearch:v2.0.2
     ▪ Using image alpine:3.6

--- a/site/content/en/docs/handbook/addons/custom-images.md
+++ b/site/content/en/docs/handbook/addons/custom-images.md
@@ -14,7 +14,7 @@ We defined and named all images used by an addon, you could view them by command
 minikube addons images efk
 ```
 
-```
+```shell
     ▪ efk has following images:
 |----------------------|------------------------------|-------------------|
 |      IMAGE NAME      |        DEFAULT IMAGE         | DEFAULT REGISTRY  |
@@ -46,7 +46,7 @@ The format is `IMAGE_NAME=CUSTOM_VALUE`, separated by commas, where the `IMAGE_N
 minikube addons enable efk --images="Kibana=kibana/kibana:5.6.2-custom" --registries="Kibana=,Elasticsearch=192.168.10.2:5555,FluentdElasticsearch=192.168.10.2:5555"
 ```
 
-```
+```shell
     ▪ Using image 192.168.10.2:5555/elasticsearch:v5.6.2
     ▪ Using image 192.168.10.2:5555/fluentd-elasticsearch:v2.0.2
     ▪ Using image alpine:3.6

--- a/site/content/en/docs/handbook/addons/gcp-auth.md
+++ b/site/content/en/docs/handbook/addons/gcp-auth.md
@@ -22,9 +22,6 @@ Once the addon is enabled, pods in your cluster will be configured with environm
 
 ```shell
 minikube start
-```
-
-```shell
 😄  minikube v1.12.0 on Darwin 10.15.5
 ✨  Automatically selected the docker driver. Other choices: hyperkit, virtualbox
 👍  Starting control plane node minikube in cluster minikube
@@ -39,9 +36,6 @@ minikube start
 
 ```shell
 minikube addons enable gcp-auth
-```
-
-```shell
 🔎  Verifying gcp-auth addon...
 📌  Your GCP credentials will now be mounted into every pod created in the minikube cluster.
 📌  If you don't want credential mounted into a specific pod, add a label with the `gcp-auth-skip-secret` key to your pod configuration.
@@ -59,9 +53,6 @@ minikube addons enable gcp-auth
 
 ```shell
 kubectl apply -f test.yaml
-```
-
-```shell
 deployment.apps/pytest created
 ```
 

--- a/site/content/en/docs/handbook/addons/gcp-auth.md
+++ b/site/content/en/docs/handbook/addons/gcp-auth.md
@@ -24,7 +24,7 @@ Once the addon is enabled, pods in your cluster will be configured with environm
 minikube start
 ```
 
-```
+```shell
 😄  minikube v1.12.0 on Darwin 10.15.5
 ✨  Automatically selected the docker driver. Other choices: hyperkit, virtualbox
 👍  Starting control plane node minikube in cluster minikube
@@ -41,7 +41,7 @@ minikube start
 minikube addons enable gcp-auth
 ```
 
-```
+```shell
 🔎  Verifying gcp-auth addon...
 📌  Your GCP credentials will now be mounted into every pod created in the minikube cluster.
 📌  If you don't want credential mounted into a specific pod, add a label with the `gcp-auth-skip-secret` key to your pod configuration.
@@ -61,14 +61,15 @@ minikube addons enable gcp-auth
 kubectl apply -f test.yaml
 ```
 
-```
+```shell
 deployment.apps/pytest created
 ```
 
 Everything should work as expected. You can run `kubectl describe` on your pods to see the environment variables we inject.
 
 As explained in the output above, if you have a pod you don't want to inject with your credentials, all you need to do is add the `gcp-auth-skip-secret` label:
-<pre>
+
+```yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -90,7 +91,7 @@ spec:
         image: local-pytest
         ports:
           - containerPort: 80
-</pre>
+```
 
 
 ## Refreshing existing pods

--- a/site/content/en/docs/handbook/addons/gvisor.md
+++ b/site/content/en/docs/handbook/addons/gvisor.md
@@ -20,14 +20,14 @@ $ minikube start --container-runtime=containerd  \
 ### Enabling gVisor
 To enable this addon, simply run:
 
-```
+```shell
 $ minikube addons enable gvisor
 ```
 
 Within one minute, the addon manager should pick up the change and you should
 see the `gvisor` pod and `gvisor` [Runtime Class](https://kubernetes.io/docs/concepts/containers/runtime-class/):
 
-```
+```shell
 $ kubectl get pod,runtimeclass gvisor -n kube-system
 NAME         READY   STATUS    RESTARTS   AGE
 pod/gvisor   1/1     Running   0          2m52s
@@ -43,7 +43,7 @@ Once the pod has status `Running`, gVisor is enabled in minikube.
 To run a pod in gVisor, add the `gvisor` runtime class to the Pod spec in your
 Kubernetes yaml:
 
-```
+```yaml
 runtimeClassName: gvisor
 ```
 
@@ -65,14 +65,14 @@ spec:
 
 To disable gVisor, run:
 
-```
+```shell
 $ minikube addons disable gvisor
 ```
 
 Within one minute, the addon manager should pick up the change.
 Once the `gvisor` pod has status `Terminating`, or has been deleted, the gvisor addon should be disabled.
 
-```
+```shell
 $ kubectl get pod gvisor -n kube-system
 NAME      READY     STATUS        RESTARTS   AGE
 gvisor    1/1       Terminating   0          5m

--- a/site/content/en/docs/handbook/addons/storage-provisioner-gluster.md
+++ b/site/content/en/docs/handbook/addons/storage-provisioner-gluster.md
@@ -18,13 +18,13 @@ $ minikube start
 ### Enabling storage-provisioner-gluster
 To enable this addon, simply run:
 
-```
+```shell
 $ minikube addons enable storage-provisioner-gluster
 ```
 
 Within one minute, the addon manager should pick up the change and you should see several Pods in the `storage-gluster` namespace:
 
-```
+```shell
 $ kubectl -n storage-gluster get pods
 NAME                                      READY     STATUS              RESTARTS   AGE
 glusterfile-provisioner-dbcbf54fc-726vv   1/1       Running             0          1m
@@ -34,7 +34,7 @@ heketi-79997b9d85-42c49                   0/1       ContainerCreating   0       
 
 Some of the Pods need a little more time to get up an running than others, but in a few minutes everything should have been deployed and all Pods should be `READY`:
 
-```
+```shell
 $ kubectl -n storage-gluster get pods
 NAME                                      READY     STATUS    RESTARTS   AGE
 glusterfile-provisioner-dbcbf54fc-726vv   1/1       Running   0          5m
@@ -44,7 +44,7 @@ heketi-79997b9d85-42c49                   1/1       Running   1          4m
 
 Once the Pods have status `Running`, the `glusterfile` StorageClass should have been marked as `default`:
 
-```
+```shell
 $ kubectl get sc
 NAME                    PROVISIONER               AGE
 glusterfile (default)   gluster.org/glusterfile   3m
@@ -55,7 +55,7 @@ The storage in the Gluster environment is limited to 10 GiB. This is because the
 
 The following `yaml` creates a PVC, starts a CentOS developer Pod that generates a website and deploys an NGINX webserver that provides access to the website:
 
-```
+```yaml
 ---
 #
 # Minimal PVC where a developer can build a website.
@@ -128,7 +128,7 @@ Because the PVC has been created with the `ReadWriteMany` accessMode, both Pods 
 
 The above configuration does not expose the website on the Minikube VM. One way to see the contents of the website is to SSH into the Minikube VM and fetch the website there:
 
-```
+```shell
 $ kubectl get pods -o wide
 NAME            READY     STATUS      RESTARTS   AGE       IP           NODE
 centos-webdev   0/1       Completed   0          1m        172.17.0.9   minikube

--- a/site/content/en/docs/handbook/host-access.md
+++ b/site/content/en/docs/handbook/host-access.md
@@ -19,7 +19,7 @@ To make it easier to access your host, minikube v1.10 adds a hostname entry `hos
 
 You can use `minikube ssh` to confirm connectivity:
 
-```
+```sh
                          _             _
             _         _ ( )           ( )
   ___ ___  (_)  ___  (_)| |/')  _   _ | |_      __  

--- a/site/content/en/docs/handbook/troubleshooting.md
+++ b/site/content/en/docs/handbook/troubleshooting.md
@@ -27,7 +27,9 @@ find $TMPDIR -mtime -1 -type f -name "*minikube*" -ls  2>/dev/null
 
 For instance after running `minikube start`, the above command will show:
 
-`-rw-r--r-- 1 user  grp  718 Aug 18 12:40 /var/folders/n1/qxvd9kc/T//minikube_start_dc950831e1a232e0318a6d6ca82aaf4f4a8a048b_0.log`
+```text
+-rw-r--r-- 1 user  grp  718 Aug 18 12:40 /var/folders/n1/qxvd9kc/T//minikube_start_dc950831e1a232e0318a6d6ca82aaf4f4a8a048b_0.log
+```
 
 These are plain text log files: you may rename them to "<filename>.log" and then drag/drop them into a GitHub issue for further analysis by the minikube team. You can quickly inspect the final lines of any of these logs via:
   
@@ -37,7 +39,7 @@ tail -n 10 <filename>
 
 for example, this shows:
 
-```
+```text
 I0818 12:40:17.027317   63501 out.go:197] Setting ErrFile to fd 2...
 I0818 12:40:17.027321   63501 out.go:231] isatty.IsTerminal(2) = true
 I0818 12:40:17.027423   63501 root.go:272] Updating PATH: /Users/tstromberg/.minikube/bin

--- a/site/content/en/docs/tutorials/custom_cert_ingress.md
+++ b/site/content/en/docs/tutorials/custom_cert_ingress.md
@@ -13,24 +13,24 @@ date: 2020-11-30
 ## Tutorial
 
 - Start minikube
-```
+```shell
 $ minikube start
 ```
 
 - Create TLS secret which contains custom certificate and private key
-```
+```shell
 $ kubectl -n kube-system create secret tls mkcert --key key.pem --cert cert.pem
 ```
 
 - Configure ingress addon
-```
+```shell
 $ minikube addons configure ingress
 -- Enter custom cert(format is "namespace/secret"): kube-system/mkcert
 ✅  ingress was successfully configured
 ```
 
 - Enable ingress addon (disable first when already enabled)
-```
+```shell
 $ minikube addons disable ingress
 🌑  "The 'ingress' addon is disabled
 
@@ -39,7 +39,7 @@ $ minikube addons enable ingress
 🌟  The 'ingress' addon is enabled
 ```
 - Verify if custom certificate was enabled
-```
+```shell
 $ kubectl -n ingress-nginx get deployment ingress-nginx-controller -o yaml | grep "kube-system"
 - --default-ssl-certificate=kube-system/mkcert
 ```

--- a/site/content/en/docs/tutorials/local_path_provisioner.md
+++ b/site/content/en/docs/tutorials/local_path_provisioner.md
@@ -26,13 +26,13 @@ $ minikube start -n 2
 
 - Enable `storage-provisioner-rancher` addon:
 
-```
+```shell
 $ minikube addons enable storage-provisioner-rancher
 ```
 
 - You should be able to see Pod in the `local-path-storage` namespace:
 
-```
+```shell
 $ kubectl get pods -n local-path-storage
 NAME                                     READY   STATUS    RESTARTS   AGE
 local-path-provisioner-7f58b4649-hcbk9   1/1     Running   0          38s
@@ -40,7 +40,7 @@ local-path-provisioner-7f58b4649-hcbk9   1/1     Running   0          38s
 
 - The `local-path` StorageClass should be marked as `default`:
 
-```
+```shell
 $ kubectl get sc
 NAME                   PROVISIONER                RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
 local-path (default)   rancher.io/local-path      Delete          WaitForFirstConsumer   false                  107s
@@ -49,7 +49,7 @@ standard               k8s.io/minikube-hostpath   Delete          Immediate     
 
 - The following `yaml` creates PVC and Pod that creates file with content on second node (minikube-m02):
 
-```
+```yaml
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -83,13 +83,13 @@ spec:
         claimName: test-pvc
 ```
 
-```
+```shell
 $ kubectl get pvc
 NAME       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
 test-pvc   Bound    pvc-f07e253b-fea7-433a-b0ac-1bcea3f77076   64Mi       RWO            local-path     5m19s
 ```
 
-```
+```shell
 $ kubectl get pods -o wide
 NAME              READY   STATUS      RESTARTS   AGE     IP           NODE           NOMINATED NODE   READINESS GATES
 test-local-path   0/1     Completed   0          5m19s   10.244.1.5   minikube-m02   <none>           <none>
@@ -97,7 +97,7 @@ test-local-path   0/1     Completed   0          5m19s   10.244.1.5   minikube-m
 
 - On the second node we are able to see created file with content `local-path-provisioner`:
 
-```
+```shell
 $ minikube ssh -n minikube-m02 "cat /opt/local-path-provisioner/pvc-f07e253b-fea7-433a-b0ac-1bcea3f77076_default_test-pvc/file1"
 local-path-provisioner
 ```

--- a/site/content/en/docs/tutorials/multi_control_plane_ha_clusters.md
+++ b/site/content/en/docs/tutorials/multi_control_plane_ha_clusters.md
@@ -39,8 +39,6 @@ While a minikube HA cluster will continue to operate (although in degraded mode)
 
 ```shell
 lsmod | grep ip_vs
-```
-```
 ip_vs_rr               12288  1
 ip_vs                 233472  3 ip_vs_rr
 nf_conntrack          217088  9 xt_conntrack,nf_nat,nf_conntrack_tftp,nft_ct,xt_nat,nf_nat_tftp,nf_conntrack_netlink,xt_MASQUERADE,ip_vs
@@ -52,8 +50,6 @@ libcrc32c              12288  5 nf_conntrack,nf_nat,btrfs,nf_tables,ip_vs
 
 ```shell
 minikube start --ha --driver=docker --container-runtime=containerd --profile ha-demo
-```
-```
 😄  [ha-demo] minikube v1.32.0 on Opensuse-Tumbleweed 20240311
 ✨  Using the docker driver based on user configuration
 📌  Using Docker driver with root privileges
@@ -93,8 +89,6 @@ minikube start --ha --driver=docker --container-runtime=containerd --profile ha-
 
 ```shell
 kubectl get nodes -owide
-```
-```
 NAME          STATUS   ROLES           AGE     VERSION   INTERNAL-IP    EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION    CONTAINER-RUNTIME
 ha-demo       Ready    control-plane   4m21s   v1.28.4   192.168.49.2   <none>        Ubuntu 22.04.4 LTS   6.7.7-1-default   containerd://1.6.28
 ha-demo-m02   Ready    control-plane   4m      v1.28.4   192.168.49.3   <none>        Ubuntu 22.04.4 LTS   6.7.7-1-default   containerd://1.6.28
@@ -105,8 +99,6 @@ ha-demo-m03   Ready    control-plane   3m37s   v1.28.4   192.168.49.4   <none>  
 
 ```shell
 minikube profile list
-```
-```
 |---------|-----------|------------|----------------|------|---------|--------|-------|--------|
 | Profile | VM Driver |  Runtime   |       IP       | Port | Version | Status | Nodes | Active |
 |---------|-----------|------------|----------------|------|---------|--------|-------|--------|
@@ -118,8 +110,6 @@ minikube profile list
 
 ```shell
 minikube status -p ha-demo
-```
-```
 ha-demo
 type: Control Plane
 host: Running
@@ -147,7 +137,7 @@ kubeconfig: Configured
 ```shell
 kubectl config view --context ha-demo
 ```
-```
+```yaml
 apiVersion: v1
 clusters:
 - cluster:
@@ -186,8 +176,6 @@ users:
 
 ```shell
 minikube ssh -p ha-demo -- 'find /var/lib/minikube/binaries -iname kubectl -exec sudo {} --kubeconfig=/var/lib/minikube/kubeconfig logs -n kube-system pod/kube-vip-ha-demo \; -quit'
-```
-```
 time="2024-03-14T21:38:34Z" level=info msg="Starting kube-vip.io [v0.7.1]"
 time="2024-03-14T21:38:34Z" level=info msg="namespace [kube-system], Mode: [ARP], Features(s): Control Plane:[true], Services:[false]"
 time="2024-03-14T21:38:34Z" level=info msg="prometheus HTTP server started"
@@ -206,8 +194,6 @@ time="2024-03-14T21:38:48Z" level=info msg="Added backend for [192.168.49.254:84
 
 ```shell
 minikube ssh -p ha-demo -- 'find /var/lib/minikube/binaries -iname kubectl -exec sudo {} --kubeconfig=/var/lib/minikube/kubeconfig logs -n kube-system pod/kube-vip-ha-demo-m02 \; -quit'
-```
-```
 time="2024-03-14T21:38:25Z" level=info msg="Starting kube-vip.io [v0.7.1]"
 time="2024-03-14T21:38:25Z" level=info msg="namespace [kube-system], Mode: [ARP], Features(s): Control Plane:[true], Services:[false]"
 time="2024-03-14T21:38:25Z" level=info msg="prometheus HTTP server started"
@@ -219,8 +205,6 @@ time="2024-03-14T21:38:34Z" level=info msg="Node [ha-demo] is assuming leadershi
 
 ```shell
 minikube ssh -p ha-demo -- 'find /var/lib/minikube/binaries -iname kubectl -exec sudo {} --kubeconfig=/var/lib/minikube/kubeconfig logs -n kube-system pod/kube-vip-ha-demo-m03 \; -quit'
-```
-```
 time="2024-03-14T21:38:48Z" level=info msg="Starting kube-vip.io [v0.7.1]"
 time="2024-03-14T21:38:48Z" level=info msg="namespace [kube-system], Mode: [ARP], Features(s): Control Plane:[true], Services:[false]"
 time="2024-03-14T21:38:48Z" level=info msg="prometheus HTTP server started"
@@ -234,8 +218,6 @@ time="2024-03-14T21:38:48Z" level=info msg="Node [ha-demo] is assuming leadershi
 
 ```shell
 minikube ssh -p ha-demo -- 'find /var/lib/minikube/binaries -iname kubectl -exec sudo {} --kubeconfig=/var/lib/minikube/kubeconfig exec -ti pod/etcd-ha-demo -n kube-system -- /bin/sh -c "ETCDCTL_API=3 etcdctl member list --write-out=table --cacert=/var/lib/minikube/certs/etcd/ca.crt --cert=/var/lib/minikube/certs/etcd/server.crt --key=/var/lib/minikube/certs/etcd/server.key" \; -quit'
-```
-```
 +------------------+---------+-------------+---------------------------+---------------------------+------------+
 |        ID        | STATUS  |    NAME     |        PEER ADDRS         |       CLIENT ADDRS        | IS LEARNER |
 +------------------+---------+-------------+---------------------------+---------------------------+------------+
@@ -249,8 +231,6 @@ minikube ssh -p ha-demo -- 'find /var/lib/minikube/binaries -iname kubectl -exec
 
 ```shell
 minikube node delete m02 -p ha-demo
-```
-```
 🔥  Deleting node m02 from cluster ha-demo
 ✋  Stopping node "ha-demo-m02"  ...
 🛑  Powering off "ha-demo-m02" via SSH ...
@@ -259,16 +239,12 @@ minikube node delete m02 -p ha-demo
 ```
 ```shell
 kubectl get nodes -owide
-```
-```
 NAME          STATUS   ROLES           AGE     VERSION   INTERNAL-IP    EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION    CONTAINER-RUNTIME
 ha-demo       Ready    control-plane   7m16s   v1.28.4   192.168.49.2   <none>        Ubuntu 22.04.4 LTS   6.7.7-1-default   containerd://1.6.28
 ha-demo-m03   Ready    control-plane   6m32s   v1.28.4   192.168.49.4   <none>        Ubuntu 22.04.4 LTS   6.7.7-1-default   containerd://1.6.28
 ```
 ```shell
 minikube profile list
-```
-```
 |---------|-----------|------------|----------------|------|---------|----------|-------|--------|
 | Profile | VM Driver |  Runtime   |       IP       | Port | Version |  Status  | Nodes | Active |
 |---------|-----------|------------|----------------|------|---------|----------|-------|--------|
@@ -280,8 +256,6 @@ minikube profile list
 
 ```shell
 minikube node add --control-plane -p ha-demo
-```
-```
 😄  Adding node m04 to cluster ha-demo as [worker control-plane]
 👍  Starting "ha-demo-m04" control-plane node in "ha-demo" cluster
 🚜  Pulling base image v0.0.42-1710284843-18375 ...
@@ -290,19 +264,17 @@ minikube node add --control-plane -p ha-demo
 🔎  Verifying Kubernetes components...
 🏄  Successfully added m04 to ha-demo!
 ```
+
 ```shell
 kubectl get nodes -owide
-```
-```
 NAME          STATUS   ROLES           AGE     VERSION   INTERNAL-IP    EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION    CONTAINER-RUNTIME
 ha-demo       Ready    control-plane   8m34s   v1.28.4   192.168.49.2   <none>        Ubuntu 22.04.4 LTS   6.7.7-1-default   containerd://1.6.28
 ha-demo-m03   Ready    control-plane   7m50s   v1.28.4   192.168.49.4   <none>        Ubuntu 22.04.4 LTS   6.7.7-1-default   containerd://1.6.28
 ha-demo-m04   Ready    control-plane   36s     v1.28.4   192.168.49.5   <none>        Ubuntu 22.04.4 LTS   6.7.7-1-default   containerd://1.6.28
 ```
+
 ```shell
 minikube profile list
-```
-```
 |---------|-----------|------------|----------------|------|---------|--------|-------|--------|
 | Profile | VM Driver |  Runtime   |       IP       | Port | Version | Status | Nodes | Active |
 |---------|-----------|------------|----------------|------|---------|--------|-------|--------|
@@ -314,8 +286,6 @@ minikube profile list
 
 ```shell
 minikube node add -p ha-demo
-```
-```
 😄  Adding node m05 to cluster ha-demo as [worker]
 👍  Starting "ha-demo-m05" worker node in "ha-demo" cluster
 🚜  Pulling base image v0.0.42-1710284843-18375 ...
@@ -327,8 +297,6 @@ minikube node add -p ha-demo
 
 ```shell
 kubectl get nodes -owide
-```
-```
 NAME          STATUS   ROLES           AGE     VERSION   INTERNAL-IP    EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION    CONTAINER-RUNTIME
 ha-demo       Ready    control-plane   9m35s   v1.28.4   192.168.49.2   <none>        Ubuntu 22.04.4 LTS   6.7.7-1-default   containerd://1.6.28
 ha-demo-m03   Ready    control-plane   8m51s   v1.28.4   192.168.49.4   <none>        Ubuntu 22.04.4 LTS   6.7.7-1-default   containerd://1.6.28
@@ -388,13 +356,11 @@ spec:
       targetPort: http
 EOF
 ```
-```
+```text
 deployment.apps/hello created
 ```
 ```shell
 kubectl rollout status deployment/hello
-```
-```
 deployment "hello" successfully rolled out
 ```
 
@@ -402,8 +368,6 @@ deployment "hello" successfully rolled out
 
 ```shell
 kubectl get pods -owide
-```
-```
 NAME                     READY   STATUS    RESTARTS   AGE   IP           NODE          NOMINATED NODE   READINESS GATES
 hello-7bf57d9696-64v6m   1/1     Running   0          18s   10.244.3.2   ha-demo-m04   <none>           <none>
 hello-7bf57d9696-7gtlk   1/1     Running   0          18s   10.244.2.2   ha-demo-m03   <none>           <none>
@@ -414,8 +378,6 @@ hello-7bf57d9696-99qsw   1/1     Running   0          18s   10.244.0.4   ha-demo
 
 ```shell
 minikube service list -p ha-demo
-```
-```
 |-------------|------------|--------------|---------------------------|
 |  NAMESPACE  |    NAME    | TARGET PORT  |            URL            |
 |-------------|------------|--------------|---------------------------|
@@ -429,8 +391,6 @@ minikube service list -p ha-demo
 
 ```shell
 curl  http://192.168.49.2:31000
-```
-```
 Hello from hello-7bf57d9696-99qsw (10.244.0.4)
 
 curl  http://192.168.49.2:31000

--- a/site/content/en/docs/tutorials/multi_node.md
+++ b/site/content/en/docs/tutorials/multi_node.md
@@ -24,8 +24,6 @@ Default [host-path volume provisioner]({{< ref "/docs/handbook/persistent_volume
 
 ```shell
 minikube start --nodes 2 -p multinode-demo
-```
-```
 😄  [multinode-demo] minikube v1.18.1 on Opensuse-Tumbleweed
 ✨  Automatically selected the docker driver
 👍  Starting control plane node multinode-demo in cluster multinode-demo
@@ -53,8 +51,6 @@ minikube start --nodes 2 -p multinode-demo
 
 ```shell
 kubectl get nodes
-```
-```
 NAME                 STATUS   ROLES                  AGE   VERSION
 multinode-demo       Ready    control-plane,master   99s   v1.20.2
 multinode-demo-m02   Ready    <none>                 73s   v1.20.2
@@ -64,9 +60,6 @@ multinode-demo-m02   Ready    <none>                 73s   v1.20.2
 
 ```shell
 minikube status -p multinode-demo
-```
-
-```
 multinode-demo
 type: Control Plane
 host: Running
@@ -84,14 +77,10 @@ kubelet: Running
 
 ```shell
 kubectl apply -f hello-deployment.yaml
-```
-```
 deployment.apps/hello created
 ```
 ```shell
 kubectl rollout status deployment/hello
-```
-```
 deployment "hello" successfully rolled out
 ```
 
@@ -99,8 +88,6 @@ deployment "hello" successfully rolled out
 
 ```shell
 kubectl apply -f hello-svc.yaml
-```
-```
 service/hello created
 ```
 
@@ -108,8 +95,6 @@ service/hello created
 
 ```shell
 kubectl get pods -o wide
-```
-```
 NAME                     READY   STATUS    RESTARTS   AGE   IP           NODE                 NOMINATED NODE   READINESS GATES
 hello-695c67cf9c-bzrzk   1/1     Running   0          22s   10.244.1.2   multinode-demo-m02   <none>           <none>
 hello-695c67cf9c-frcvw   1/1     Running   0          22s   10.244.0.3   multinode-demo       <none>           <none>
@@ -119,8 +104,6 @@ hello-695c67cf9c-frcvw   1/1     Running   0          22s   10.244.0.3   multino
 
 ```shell
 minikube service list -p multinode-demo
-```
-```
 |-------------|------------|--------------|---------------------------|
 |  NAMESPACE  |    NAME    | TARGET PORT  |            URL            |
 |-------------|------------|--------------|---------------------------|
@@ -134,8 +117,6 @@ minikube service list -p multinode-demo
 
 ```shell
 curl  http://192.168.49.2:31000
-```
-```
 Hello from hello-695c67cf9c-frcvw (10.244.0.3)
 
 curl  http://192.168.49.2:31000
@@ -154,7 +135,7 @@ Hello from hello-695c67cf9c-frcvw (10.244.0.3)
 {{% tabs %}}
 {{% tab hello-deployment.yaml %}}
 
-```
+```yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -190,7 +171,7 @@ spec:
 ```
 {{% /tab %}}
 {{% tab hello-svc.yaml %}}
-```
+```yaml
 apiVersion: v1
 kind: Service
 metadata:

--- a/site/content/en/docs/tutorials/static_ip.md
+++ b/site/content/en/docs/tutorials/static_ip.md
@@ -29,7 +29,7 @@ Use the `--static-ip` flag on `minikube start` to set the static IP.
 
 **Note:** You cannot add a static IP to an existing cluster, you have to delete and recreate the cluster with the flag.
 
-```
+```shell
 $ minikube start --driver docker --static-ip 192.168.200.200
 😄  minikube v1.28.0 on Darwin 13.1 (arm64)
 ✨  Using the docker driver based on user configuration

--- a/site/content/en/docs/tutorials/user_flag.md
+++ b/site/content/en/docs/tutorials/user_flag.md
@@ -20,7 +20,7 @@ However, there is a global flag `--user` that will set the user who ran the comm
 ## What does the flag do?
 
 Assuming the OS user is `johndoe`, running `minikube start` will add the following to the audit log:
-```
+```text
 |---------------|--------------------------|-----------------------------|--------------|----------------|-------------------------------|-------------------------------|
 |    Command    |          Args            |           Profile           |     User     |    Version     |          Start Time           |           End Time            |
 |---------------|--------------------------|-----------------------------|--------------|----------------|-------------------------------|-------------------------------|
@@ -30,7 +30,7 @@ Assuming the OS user is `johndoe`, running `minikube start` will add the followi
 As you can see, minikube pulled the OS user and listed them as the user for the command.
 
 Running the same command with `--user=mary` appended to the command will add the following to the audit log:
-```
+```text
 |---------------|--------------------------|-----------------------------|--------------|----------------|-------------------------------|-------------------------------|
 |    Command    |          Args            |           Profile           |     User     |    Version     |          Start Time           |           End Time            |
 |---------------|--------------------------|-----------------------------|--------------|----------------|-------------------------------|-------------------------------|
@@ -49,7 +49,7 @@ Here you can see that passing `--user=mary` overwrote the OS user with `mary` as
 If you are using minikube in a script or plugin it is recommended to add `--user=your_script_name` to all operations.
 
 Example:
-```
+```shell
 minikube start --user=plugin_name
 minikube profile list --user=plugin_name
 minikube stop --user=plugin_name


### PR DESCRIPTION
It's hard to read the document right now as the code syntax without any type (yaml, shell, text) does not have any default rendering

I've made the requested changes on several pages to just make it work for now