### PR TITLE
vmnet: Support running without sudoers configuration

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -519,8 +519,9 @@ func validateVfkitNetwork(n string) string {
 		// always available
 	case "vmnet-shared":
 		// "vment-shared" provides access between machines, with lower performance compared to "nat".
-		if !vmnet.HelperAvailable() {
-			exit.Message(reason.NotFoundVmnetHelper, "\n\n")
+		if err := vmnet.ValidateHelper(); err != nil {
+			vmnetErr := err.(*vmnet.Error)
+			exit.Message(vmnetErr.Kind, "failed to validate {{.network}} network: {{.reason}}", out.V{"network": n, "reason": err})
 		}
 	case "":
 		// Default to nat since it is always available and provides the best performance.

--- a/pkg/drivers/vmnet/vmnet_error.go
+++ b/pkg/drivers/vmnet/vmnet_error.go
@@ -1,7 +1,5 @@
-//go:build !darwin
-
 /*
-Copyright 2024 The Kubernetes Authors All rights reserved.
+Copyright 2025 The Kubernetes Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,13 +16,13 @@ limitations under the License.
 
 package vmnet
 
-import (
-	"fmt"
-	"runtime"
+import "k8s.io/minikube/pkg/minikube/reason"
 
-	"k8s.io/minikube/pkg/minikube/reason"
-)
+type Error struct {
+	Kind reason.Kind
+	Err  error
+}
 
-func ValidateHelper() error {
-	return &Error{Kind: reason.Usage, Err: fmt.Errorf("vmnet-helper is not available on %q", runtime.GOOS)}
+func (e Error) Error() string {
+	return e.Err.Error()
 }

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -554,13 +554,23 @@ var (
 		ExitCode: ExProgramNotFound,
 		Advice: translate.T(`vmnet-helper was not found on the system, resolve by:
 
-		Option 1) Installing vment-helper:
+		Option 1) Installing vmnet-helper:
 
 		  https://github.com/nirs/vmnet-helper#installation
 
 		Option 2) Using the nat network:
 
 		  minikube start{{.profile}} --driver vfkit --network nat`),
+		Style: style.SeeNoEvil,
+	}
+	NotConfiguredVmnetHelper = Kind{
+		ID:       "NOT_CONFIGURED_VMNET_HELPER",
+		ExitCode: ExProgramConfig,
+		Advice: translate.T(`Configure vmnet-helper to run without a password.
+
+		Please install a vmnet-helper sudoers rule using these instructions:
+
+		https://github.com/nirs/vmnet-helper#granting-permission-to-run-vmnet-helper`),
 		Style: style.SeeNoEvil,
 	}
 )


### PR DESCRIPTION
Testing revealed that vment-helper sudoers configuration may be hard to get working for some users, and we need better validation when validating the --network vmnet-shared option.

This change:
- Improve validation, providing suggestions for resolving issues when vmnet-helper sudoers configuration does not work for the user.
- Change vfkit to use vment-helper --socket mode, simplifying sudoers configuration so we don't depend on the --close-from= option (it did not work for @medyagh).
- Switching to --socket also makes it possible to run vmnet-helper without sudoers configuration if we can interact with the user. We fallback to interactive sudo in this case.

With this change the only requirement is being able to run vment-helper with sudo. The sudoers configuration is required only if you want to run minikube with --interactive=false.

## Before

```console
% minikube start --driver vfkit --network vmnet-shared
😄  minikube v1.35.0 on Darwin 15.4.1 (arm64)
✨  Using the vfkit (experimental) driver based on user configuration

🙈  Exiting due to NOT_FOUND_VMNET_HELPER:


💡  Suggestion:

    vmnet-helper was not found on the system, resolve by:

    Option 1) Installing vment-helper:

    https://github.com/nirs/vmnet-helper#installation

    Option 2) Using the nat network:

    minikube start<no value> --driver vfkit --network nat
```

## After

```
% minikube start --driver vfkit --network vmnet-shared
😄  minikube v1.35.0 on Darwin 15.4.1 (arm64)
✨  Using the vfkit (experimental) driver based on user configuration
💡  Unable to run vmnet-helper without a password
    To configure vment-helper to run without a password, please check the documentation:
    https://github.com/nirs/vmnet-helper/#granting-permission-to-run-vmnet-helper
Password:
👍  Starting "minikube" primary control-plane node in "minikube" cluster
🔥  Creating vfkit VM (CPUs=2, Memory=6000MB, Disk=20000MB) ...
🐳  Preparing Kubernetes v1.33.0 on Docker 27.4.0 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```
