### PR TITLE
build: Use jammy based xcgo image for hyperkit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ $(shell mkdir -p $(BUILD_DIR))
 CURRENT_GIT_BRANCH ?= $(shell git branch | grep \* | cut -d ' ' -f2)
 
 # Use system python if it exists, otherwise use Docker.
-PYTHON := $(shell command -v python || echo "docker run --rm -it -v $(shell pwd):/minikube -w /minikube python python")
+PYTHON := $(shell command -v python || echo "docker run --rm -it -v $(shell pwd):/minikube:Z -w /minikube python python")
 BUILD_OS := $(shell uname -s)
 
 SHA512SUM=$(shell command -v sha512sum || echo "shasum -a 512")
@@ -189,7 +189,7 @@ endef
 
 # $(call DOCKER, image, command)
 define DOCKER
-	docker run --rm -e GOCACHE=/app/.cache -e IN_DOCKER=1 --user $(shell id -u):$(shell id -g) -w /app -v $(PWD):/app -v $(GOPATH):/go --init $(1) /bin/bash -c '$(2)'
+	docker run --rm -e GOCACHE=/app/.cache -e IN_DOCKER=1 --user $(shell id -u):$(shell id -g) -w /app -v $(PWD):/app:Z -v $(GOPATH):/go --init $(1) /bin/bash -c '$(2)'
 endef
 
 ifeq ($(BUILD_IN_DOCKER),y)
@@ -341,13 +341,13 @@ out/minikube-%.iso: $(shell find "deploy/iso/minikube-iso" -type f)
 ifeq ($(IN_DOCKER),1)
 	$(MAKE) minikube-iso-$*
 else
-	docker run --rm --workdir /mnt --volume $(CURDIR):/mnt $(ISO_DOCKER_EXTRA_ARGS) \
+	docker run --rm --workdir /mnt --volume $(CURDIR):/mnt:Z $(ISO_DOCKER_EXTRA_ARGS) \
 		--user $(shell id -u):$(shell id -g) --env HOME=/tmp --env IN_DOCKER=1 \
 		$(ISO_BUILD_IMAGE) /bin/bash -lc '/usr/bin/make minikube-iso-$*'
 endif
 
 iso_in_docker:
-	docker run -it --rm --workdir /mnt --volume $(CURDIR):/mnt $(ISO_DOCKER_EXTRA_ARGS) \
+	docker run -it --rm --workdir /mnt --volume $(CURDIR):/mnt:Z $(ISO_DOCKER_EXTRA_ARGS) \
 		--user $(shell id -u):$(shell id -g) --env HOME=/tmp --env IN_DOCKER=1 \
 		$(ISO_BUILD_IMAGE) /bin/bash
 
@@ -523,7 +523,7 @@ out/linters/golangci-lint-$(GOLINT_VERSION):
 .PHONY: lint
 ifeq ($(MINIKUBE_BUILD_IN_DOCKER),y)
 lint:
-	docker run --rm -v `pwd`:/app -w /app golangci/golangci-lint:$(GOLINT_VERSION) \
+	docker run --rm -v `pwd`:/app:Z -w /app golangci/golangci-lint:$(GOLINT_VERSION) \
 	golangci-lint run ${GOLINT_OPTIONS} ./..." 
 	# --skip-dirs "cmd/drivers/kvm|cmd/drivers/hyperkit|pkg/drivers/kvm|pkg/drivers/hyperkit" 
 	# The "--skip-dirs" parameter is no longer supported in the V2 version. If you need to skip the directory, 
@@ -657,7 +657,7 @@ out/docker-machine-driver-hyperkit:
 ifeq ($(MINIKUBE_BUILD_IN_DOCKER),y)
 	docker run --rm -e GOCACHE=/app/.cache -e IN_DOCKER=1 \
 		--user $(shell id -u):$(shell id -g) -w /app \
-		-v $(PWD):/app -v $(GOPATH):/go --init --entrypoint "" \
+		-v $(PWD):/app:Z -v $(GOPATH):/go:Z --init --entrypoint "" \
 		$(HYPERKIT_BUILD_IMAGE) /bin/bash -c 'CC=o64-clang CXX=o64-clang++ /usr/bin/make $@'
 else
 	$(if $(quiet),@echo "  GO       $@")

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ COMMIT ?= $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO
 COMMIT_SHORT = $(shell git rev-parse --short HEAD 2> /dev/null || true)
 COMMIT_NOQUOTES := $(patsubst "%",%,$(COMMIT))
 # source code for image: https://github.com/neilotoole/xcgo
-HYPERKIT_BUILD_IMAGE ?= gcr.io/k8s-minikube/xcgo:go1.22.2
+HYPERKIT_BUILD_IMAGE ?= quay.io/nirsof/xcgo:jammy
 
 # NOTE: "latest" as of 2021-02-06. kube-cross images aren't updated as often as Kubernetes
 # https://github.com/kubernetes/kubernetes/blob/master/build/build-image/cross/VERSION


### PR DESCRIPTION
Image was built from:
https://github.com/nirs/xcgo

Changes from upstream:
https://github.com/neilotoole/xcgo/compare/master...nirs:xcgo:master

I also posted the change to upstream:
https://github.com/neilotoole/xcgo/pull/13

Maybe we need to add this repo under the minikube organization or
include the code in minikube repo.
    
With this I could build hyperkit using:

```console
$ make hyperkit_in_docker 
rm -f out/docker-machine-driver-hyperkit
make MINIKUBE_BUILD_IN_DOCKER=y out/docker-machine-driver-hyperkit
make[1]: Entering directory '/home/nsoffer/minikube'
docker run --rm -e GOCACHE=/app/.cache -e IN_DOCKER=1 \
	--user 1000:1000 -w /app \
	-v /home/nsoffer/minikube:/app:Z -v /home/nsoffer/go:/go:Z --init --entrypoint "" \
	quay.io/nirsof/xcgo:jammy /bin/bash -c 'CC=o64-clang CXX=o64-clang++ /usr/bin/make out/docker-machine-driver-hyperkit'
GOOS=darwin CGO_ENABLED=1 go build \
	-ldflags="-X k8s.io/minikube/pkg/drivers/hyperkit.version=v1.35.0 -X k8s.io/minikube/pkg/drivers/hyperkit.gitCommitID="ba04fc34350c9efde2c16709fc7b892ac944b623""   \
	-o out/docker-machine-driver-hyperkit k8s.io/minikube/cmd/drivers/hyperkit
make[1]: Leaving directory '/home/nsoffer/minikube'

$ file out/docker-machine-driver-hyperkit
out/docker-machine-driver-hyperkit: Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE>
```