### PR TITLE
docs: fix code highlight syntax to use text

### DIFF
--- a/site/content/en/docs/benchmarks/imageBuild/benchmarkingprocess.md
+++ b/site/content/en/docs/benchmarks/imageBuild/benchmarkingprocess.md
@@ -40,7 +40,7 @@ Between runs the cache and existing image is left alone, only the Go binary is c
 
 
 ## How are the benchmarks conducted?
-```
+```text
 // Pseudo code of running docker-env benchmark
 
 startMinikube() // minikube start --container-runtime=docker

--- a/site/content/en/docs/commands/addons.md
+++ b/site/content/en/docs/commands/addons.md
@@ -19,7 +19,7 @@ minikube addons SUBCOMMAND [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -61,7 +61,7 @@ minikube addons configure ADDON_NAME [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -97,7 +97,7 @@ minikube addons disable ADDON_NAME [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -139,7 +139,7 @@ minikube addons enable dashboard
 
 ### Options
 
-```
+```text
       --force               If true, will perform potentially dangerous operations. Use with discretion.
       --images string       Images used by this addon. Separated by commas.
       --refresh             If true, pods might get deleted and restarted on addon enable
@@ -148,7 +148,7 @@ minikube addons enable dashboard
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -185,7 +185,7 @@ minikube addons help [command] [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -227,13 +227,13 @@ minikube addons images ingress
 
 ### Options
 
-```
+```text
   -o, --output string   minikube addons images ADDON_NAME --output OUTPUT. table, json (default "table")
 ```
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -269,14 +269,14 @@ minikube addons list [flags]
 
 ### Options
 
-```
+```text
   -d, --docs            If true, print web links to addons' documentation if using --output=list (default).
   -o, --output string   minikube addons list --output OUTPUT. json, list (default "list")
 ```
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -312,7 +312,7 @@ minikube addons open ADDON_NAME [flags]
 
 ### Options
 
-```
+```text
       --format string   Format to output addons URL in.  This format will be applied to each url individually and they will be printed one at a time. (default "http://{{.IP}}:{{.Port}}")
       --https           Open the addons URL with https instead of http
       --interval int    The time interval for each check that wait performs in seconds (default 1)
@@ -322,7 +322,7 @@ minikube addons open ADDON_NAME [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/cache.md
+++ b/site/content/en/docs/commands/cache.md
@@ -15,7 +15,7 @@ Add an image into minikube as a local cache, or delete, reload the cached images
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -51,13 +51,13 @@ minikube cache add [flags]
 
 ### Options
 
-```
+```text
       --all   Add image to cache for all running minikube clusters
 ```
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -93,7 +93,7 @@ minikube cache delete [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -130,7 +130,7 @@ minikube cache help [command] [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -166,14 +166,14 @@ minikube cache list [flags]
 
 ### Options
 
-```
+```text
       --format string   Go template format string for the cache list output.  The format for Go templates can be found here: https://pkg.go.dev/text/template
                         For the list of accessible variables for the template, see the struct values here: https://pkg.go.dev/k8s.io/minikube/cmd/minikube/cmd#CacheListTemplate (default "{{.CacheImage}}\n")
 ```
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -209,7 +209,7 @@ minikube cache reload [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/completion.md
+++ b/site/content/en/docs/commands/completion.md
@@ -50,7 +50,7 @@ minikube completion SHELL [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -86,7 +86,7 @@ minikube completion bash [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -122,7 +122,7 @@ minikube completion fish [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -159,7 +159,7 @@ minikube completion help [command] [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -195,7 +195,7 @@ minikube completion powershell [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -231,7 +231,7 @@ minikube completion zsh [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/config.md
+++ b/site/content/en/docs/commands/config.md
@@ -48,7 +48,7 @@ minikube config SUBCOMMAND [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -88,13 +88,13 @@ minikube config defaults PROPERTY_NAME [flags]
 
 ### Options
 
-```
+```text
   -o, --output string   Output format. Accepted values: [json, yaml]
 ```
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -130,7 +130,7 @@ minikube config get PROPERTY_NAME [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -167,7 +167,7 @@ minikube config help [command] [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -204,7 +204,7 @@ minikube config set PROPERTY_NAME PROPERTY_VALUE [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -240,7 +240,7 @@ minikube config unset PROPERTY_NAME [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -276,14 +276,14 @@ minikube config view [flags]
 
 ### Options
 
-```
+```text
       --format string   Go template format string for the config view output.  The format for Go templates can be found here: https://pkg.go.dev/text/template
                         For the list of accessible variables for the template, see the struct values here: https://pkg.go.dev/k8s.io/minikube/cmd/minikube/cmd/config#ConfigViewTemplate (default "- {{.ConfigKey}}: {{.ConfigValue}}\n")
 ```
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/cp.md
+++ b/site/content/en/docs/commands/cp.md
@@ -24,7 +24,7 @@ minikube cp <source node name>:<source file path> <target node name>:<target fil
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/dashboard.md
+++ b/site/content/en/docs/commands/dashboard.md
@@ -19,14 +19,14 @@ minikube dashboard [flags]
 
 ### Options
 
-```
+```text
       --port int   Exposed port of the proxyfied dashboard. Set to 0 to pick a random port.
       --url        Display dashboard URL instead of opening a browser
 ```
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/delete.md
+++ b/site/content/en/docs/commands/delete.md
@@ -20,7 +20,7 @@ minikube delete [flags]
 
 ### Options
 
-```
+```text
       --all             Set flag to delete all profiles
   -o, --output string   Format to print stdout in. Options include: [text,json] (default "text")
       --purge           Set this flag to delete the '.minikube' folder from your user directory.
@@ -28,7 +28,7 @@ minikube delete [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/docker-env.md
+++ b/site/content/en/docs/commands/docker-env.md
@@ -24,7 +24,7 @@ minikube docker-env [flags]
 
 ### Options
 
-```
+```text
       --no-proxy        Add machine IP to NO_PROXY environment variable
   -o, --output string   One of 'text', 'yaml' or 'json'.
       --shell string    Force environment to be configured for a specified shell: [fish, cmd, powershell, tcsh, bash, zsh], default is auto-detect
@@ -35,7 +35,7 @@ minikube docker-env [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/help.md
+++ b/site/content/en/docs/commands/help.md
@@ -20,7 +20,7 @@ minikube help [command] [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/image.md
+++ b/site/content/en/docs/commands/image.md
@@ -15,7 +15,7 @@ Manage images
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -57,7 +57,7 @@ minikube image build .
 
 ### Options
 
-```
+```text
       --all                     Build image on all nodes.
       --build-env stringArray   Environment variables to pass to the build. (format: key=value)
       --build-opt stringArray   Specify arbitrary flags to pass to the build. (format: key=value)
@@ -69,7 +69,7 @@ minikube image build .
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -106,7 +106,7 @@ minikube image help [command] [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -149,7 +149,7 @@ minikube image load image.tar
 
 ### Options
 
-```
+```text
       --daemon      Cache image from docker daemon
       --overwrite   Overwrite image even if same image:tag name exists (default true)
       --pull        Pull the remote image (no caching)
@@ -158,7 +158,7 @@ minikube image load image.tar
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -206,13 +206,13 @@ $ minikube image ls
 
 ### Options
 
-```
+```text
       --format string   Format output. One of: short|table|json|yaml (default "short")
 ```
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -256,7 +256,7 @@ $ minikube image pull busybox
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -300,7 +300,7 @@ $ minikube image push busybox
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -350,7 +350,7 @@ $ minikube image unload image busybox
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -393,14 +393,14 @@ minikube image save image image.tar
 
 ### Options
 
-```
+```text
       --daemon   Cache image to docker daemon
       --remote   Cache image to remote registry
 ```
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -448,7 +448,7 @@ $ minikube image tag source target
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/ip.md
+++ b/site/content/en/docs/commands/ip.md
@@ -19,13 +19,13 @@ minikube ip [flags]
 
 ### Options
 
-```
+```text
   -n, --node string   The node to get IP. Defaults to the primary control plane.
 ```
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/kubectl.md
+++ b/site/content/en/docs/commands/kubectl.md
@@ -33,13 +33,13 @@ minikube kubectl -- get pods --namespace kube-system
 
 ### Options
 
-```
+```text
       --ssh   Use SSH for running kubernetes client on the node
 ```
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/license.md
+++ b/site/content/en/docs/commands/license.md
@@ -19,13 +19,13 @@ minikube license [flags]
 
 ### Options
 
-```
+```text
   -d, --dir string   Directory to output licenses to (default ".")
 ```
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/node.md
+++ b/site/content/en/docs/commands/node.md
@@ -19,7 +19,7 @@ minikube node [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -55,7 +55,7 @@ minikube node add [flags]
 
 ### Options
 
-```
+```text
       --control-plane       If set, added node will become a control-plane. Defaults to false. Currently only supported for existing HA (multi-control plane) clusters.
       --delete-on-failure   If set, delete the current cluster if start fails and try again. Defaults to false.
       --worker              If set, added node will be available as worker. Defaults to true. (default true)
@@ -63,7 +63,7 @@ minikube node add [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -99,7 +99,7 @@ minikube node delete [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -136,7 +136,7 @@ minikube node help [command] [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -172,7 +172,7 @@ minikube node list [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -208,13 +208,13 @@ minikube node start [flags]
 
 ### Options
 
-```
+```text
       --delete-on-failure   If set, delete the current cluster if start fails and try again. Defaults to false.
 ```
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -250,7 +250,7 @@ minikube node stop [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/options.md
+++ b/site/content/en/docs/commands/options.md
@@ -19,7 +19,7 @@ minikube options [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/pause.md
+++ b/site/content/en/docs/commands/pause.md
@@ -19,7 +19,7 @@ minikube pause [flags]
 
 ### Options
 
-```
+```text
   -A, --all-namespaces       If set, pause all namespaces
   -n, --namespaces strings   namespaces to pause (default [kube-system,kubernetes-dashboard,storage-gluster,istio-operator])
   -o, --output string        Format to print stdout in. Options include: [text,json] (default "text")
@@ -27,7 +27,7 @@ minikube pause [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/podman-env.md
+++ b/site/content/en/docs/commands/podman-env.md
@@ -19,14 +19,14 @@ minikube podman-env [flags]
 
 ### Options
 
-```
+```text
       --shell string   Force environment to be configured for a specified shell: [fish, cmd, powershell, tcsh, bash, zsh], default is auto-detect
   -u, --unset          Unset variables instead of setting them
 ```
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/profile.md
+++ b/site/content/en/docs/commands/profile.md
@@ -19,7 +19,7 @@ minikube profile [MINIKUBE_PROFILE_NAME].  You can return to the default minikub
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -56,7 +56,7 @@ minikube profile help [command] [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -92,14 +92,14 @@ minikube profile list [flags]
 
 ### Options
 
-```
+```text
   -l, --light           If true, returns list of profiles faster by skipping validating the status of the cluster.
   -o, --output string   The output format. One of 'json', 'table' (default "table")
 ```
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/service.md
+++ b/site/content/en/docs/commands/service.md
@@ -19,7 +19,7 @@ minikube service [flags] SERVICE
 
 ### Options
 
-```
+```text
       --all                Forwards all services in a namespace (defaults to "false")
       --format string      Format to output service URL in. This format will be applied to each url individually and they will be printed one at a time. (default "http://{{.IP}}:{{.Port}}")
       --https              Open the service URL with https instead of http (defaults to "false")
@@ -31,7 +31,7 @@ minikube service [flags] SERVICE
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -68,7 +68,7 @@ minikube service help [command] [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
@@ -105,14 +105,14 @@ minikube service list [flags]
 
 ### Options
 
-```
+```text
   -n, --namespace string   The services namespace
   -o, --output string      The output format. One of 'json', 'table' (default "table")
 ```
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/ssh-host.md
+++ b/site/content/en/docs/commands/ssh-host.md
@@ -19,14 +19,14 @@ minikube ssh-host [flags]
 
 ### Options
 
-```
+```text
       --append-known   Add host key to SSH known_hosts file
   -n, --node string    The node to ssh into. Defaults to the primary control plane.
 ```
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/ssh-key.md
+++ b/site/content/en/docs/commands/ssh-key.md
@@ -19,13 +19,13 @@ minikube ssh-key [flags]
 
 ### Options
 
-```
+```text
   -n, --node string   The node to get ssh-key path. Defaults to the primary control plane.
 ```
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/ssh.md
+++ b/site/content/en/docs/commands/ssh.md
@@ -19,14 +19,14 @@ minikube ssh [flags]
 
 ### Options
 
-```
+```text
       --native-ssh    Use native Golang SSH client (default true). Set to 'false' to use the command line 'ssh' command when accessing the docker machine. Useful for the machine drivers when they will not start with 'Waiting for SSH'. (default true)
   -n, --node string   The node to ssh into. Defaults to the primary control plane.
 ```
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -19,7 +19,7 @@ minikube start [flags]
 
 ### Options
 
-```
+```text
       --addons minikube addons list       Enable addons. see minikube addons list for a list of valid addon names.
       --apiserver-ips ipSlice             A set of apiserver IP Addresses which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine (default [])
       --apiserver-name string             The authoritative apiserver hostname for apiserver certificates and connectivity. This can be used if you want to make the apiserver available from outside the machine (default "minikubeCA")
@@ -126,7 +126,7 @@ minikube start [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/status.md
+++ b/site/content/en/docs/commands/status.md
@@ -21,7 +21,7 @@ minikube status [flags]
 
 ### Options
 
-```
+```text
   -f, --format string         Go template format string for the status output.  The format for Go templates can be found here: https://pkg.go.dev/text/template
                               For the list accessible variables for the template, see the struct values here: https://pkg.go.dev/k8s.io/minikube/cmd/minikube/cmd#Status (default "{{.Name}}\ntype: Control Plane\nhost: {{.Host}}\nkubelet: {{.Kubelet}}\napiserver: {{.APIServer}}\nkubeconfig: {{.Kubeconfig}}\n{{- if .TimeToStop }}\ntimeToStop: {{.TimeToStop}}\n{{- end }}\n{{- if .DockerEnv }}\ndocker-env: {{.DockerEnv}}\n{{- end }}\n{{- if .PodManEnv }}\npodman-env: {{.PodManEnv}}\n{{- end }}\n\n")
   -l, --layout string         output layout (EXPERIMENTAL, JSON only): 'nodes' or 'cluster' (default "nodes")
@@ -32,7 +32,7 @@ minikube status [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/stop.md
+++ b/site/content/en/docs/commands/stop.md
@@ -19,7 +19,7 @@ minikube stop [flags]
 
 ### Options
 
-```
+```text
       --all                   Set flag to stop all profiles (clusters)
       --cancel-scheduled      cancel any existing scheduled stop requests
       --keep-context-active   keep the kube-context active after cluster is stopped. Defaults to false.
@@ -29,7 +29,7 @@ minikube stop [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/tunnel.md
+++ b/site/content/en/docs/commands/tunnel.md
@@ -19,14 +19,14 @@ minikube tunnel [flags]
 
 ### Options
 
-```
+```text
       --bind-address string   set tunnel bind address, empty or '*' indicates the tunnel should be available for all interfaces
   -c, --cleanup               call with cleanup=true to remove old tunnels (default true)
 ```
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/unpause.md
+++ b/site/content/en/docs/commands/unpause.md
@@ -23,7 +23,7 @@ minikube unpause [flags]
 
 ### Options
 
-```
+```text
   -A, --all-namespaces       If set, unpause all namespaces
   -n, --namespaces strings   namespaces to unpause (default [kube-system,kubernetes-dashboard,storage-gluster,istio-operator])
   -o, --output string        Format to print stdout in. Options include: [text,json] (default "text")
@@ -31,7 +31,7 @@ minikube unpause [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/update-check.md
+++ b/site/content/en/docs/commands/update-check.md
@@ -19,7 +19,7 @@ minikube update-check [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/update-context.md
+++ b/site/content/en/docs/commands/update-context.md
@@ -20,7 +20,7 @@ minikube update-context [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")

--- a/site/content/en/docs/commands/version.md
+++ b/site/content/en/docs/commands/version.md
@@ -19,7 +19,7 @@ minikube version [flags]
 
 ### Options
 
-```
+```text
       --components      list versions of all components included with minikube. (the cluster must be running)
   -o, --output string   One of 'yaml' or 'json'.
       --short           Print just the version number.
@@ -27,7 +27,7 @@ minikube version [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --add_dir_header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")


### PR DESCRIPTION
Here is a new MR that fixes the code highlight issue on the minikube documentation.

I've made this MR pretty easy to review, as it's the same pattern everytime.


> With "text" coloration : <img alt="image" width="891" src="https://private-user-images.githubusercontent.com/2767218/445631066-f030bc9f-1f09-4d5a-a595-f973c5686ddd.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDc3NTExNTAsIm5iZiI6MTc0Nzc1MDg1MCwicGF0aCI6Ii8yNzY3MjE4LzQ0NTYzMTA2Ni1mMDMwYmM5Zi0xZjA5LTRkNWEtYTU5NS1mOTczYzU2ODZkZGQucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI1MDUyMCUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNTA1MjBUMTQyMDUwWiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9YTk5YzBmN2ZkNjIzZGJiYTFlMWRiYTc1MDg2YzBjOTIwNzY0NmM5NjQ3MjhiZWFjMWFlYmVkMDEzZjgyY2JlNyZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.pbvFqvBpHFdr6OXSjHCq18LJrA8cLbIkJC1DhWj5unw">
> 
> Without this MR : <img alt="image" width="874" src="https://private-user-images.githubusercontent.com/2767218/445630454-78122fbf-d1eb-456d-83f5-ec551b512239.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDc3NTExNTAsIm5iZiI6MTc0Nzc1MDg1MCwicGF0aCI6Ii8yNzY3MjE4LzQ0NTYzMDQ1NC03ODEyMmZiZi1kMWViLTQ1NmQtODNmNS1lYzU1MWI1MTIyMzkucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI1MDUyMCUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNTA1MjBUMTQyMDUwWiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9NTBkNWM0YWFjYWI2ZTJiMjNjNzI2N2ViNjMzODlmNWZhODkwOTg5YmNiNGZjZDg1NmQ0MzhiZDc1ODg5ZTgwYSZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.dVAbonUGkJaMzeFXiO8TMAOni-GyZ79iszrv7jlOL6A">

