### PR TITLE
vfkit: Bump to Preferred driver on macOs

### DIFF
--- a/pkg/minikube/registry/drvs/vfkit/vfkit.go
+++ b/pkg/minikube/registry/drvs/vfkit/vfkit.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/google/uuid"
@@ -41,13 +42,17 @@ const (
 )
 
 func init() {
+	priority := registry.Unknown
+	if runtime.GOOS == "darwin" {
+		priority = registry.Preferred
+	}
 	if err := registry.Register(registry.DriverDef{
 		Name:     driver.VFKit,
 		Init:     func() drivers.Driver { return vfkit.NewDriver("", "") },
 		Config:   configure,
 		Status:   status,
 		Default:  true,
-		Priority: registry.Experimental,
+		Priority: priority,
 	}); err != nil {
 		panic(fmt.Sprintf("register failed: %v", err))
 	}
@@ -104,7 +109,7 @@ func configure(cfg config.ClusterConfig, n config.Node) (interface{}, error) {
 func status() registry.State {
 	_, err := exec.LookPath("vfkit")
 	if err != nil {
-		return registry.State{Error: err, Fix: "Run 'brew tap cfergeau/crc && brew install vfkit'", Doc: docURL}
+		return registry.State{Error: err, Fix: "Run 'brew install vfkit'", Doc: docURL}
 	}
 	return registry.State{Installed: true, Healthy: true, Running: true}
 }


### PR DESCRIPTION
vfkit is using the native virtualization framework, provides good best performance and all the features needed by minikube. It is also well maintained and used by other projects like podman.

This fixes the automatic driver selection. When we start minikube on a system with both vfkit and qemu, vfkit is selected:

    % minikube start
    😄  minikube v1.35.0 on Darwin 15.5 (arm64)
    ✨  Automatically selected the vfkit driver. Other choices: qemu2, ssh, podman (experimental)
    👍  Starting "minikube" primary control-plane node in "minikube" cluster
    🔥  Creating vfkit VM (CPUs=2, Memory=6000MB, Disk=20000MB) ...
    🐳  Preparing Kubernetes v1.33.1 on Docker 28.0.4 ...
        ▪ Generating certificates and keys ...
        ▪ Booting up control plane ...
        ▪ Configuring RBAC rules ...
    🔗  Configuring bridge CNI (Container Networking Interface) ...
    🔎  Verifying Kubernetes components...
        ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
    🌟  Enabled addons: default-storageclass, storage-provisioner
    🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default

Fixes #20807