### PR TITLE
iso: Fix console for vfkit/krunkit

### DIFF
--- a/deploy/iso/minikube-iso/board/minikube/aarch64/grub.cfg
+++ b/deploy/iso/minikube-iso/board/minikube/aarch64/grub.cfg
@@ -2,6 +2,9 @@ set default="0"
 set timeout="5"
 
 menuentry "Buildroot" {
-  linux /boot/bzimage console=ttyAMA0 # kernel
+  # The console depends on the driver:
+  # qemu: console=ttyAMA0
+  # vfkit,krunkit: console=hvc0
+  linux /boot/bzimage console=ttyAMA0 console=hvc0
   initrd /boot/initrd # rootfs
 }


### PR DESCRIPTION
iso: Fix console for vfkit/krunkit                                                                                             

The serial console name depends on the driver. We had setting for qemu
that does not work for vfkit and krunkit, breaking boot from minikube
iso.

Fixed by using 2 console= options, one is known to work for qemu, and 
one for vfkit and krunkit. With this we can use the same iso image with
qemu, vfkit, and krunkit.

This will allow simplifying vfkit driver. Previously we had to extract
the kernel and initrd and start it using the legacy --kernel,
--kernel-cmdline and --initrd options.

I tested this by building the iso with this fix and running with
--iso-url.

## Example run with qemu

```console
% minikube start -p qemu --driver qemu --container-runtime containerd \
    --iso-url file://$PWD/minikube-arm64.iso
😄  [qemu] minikube v1.36.0 on Darwin 15.5 (arm64)
✨  Using the qemu2 driver based on user configuration
🌐  Automatically selected the socket_vmnet network
👍  Starting "qemu" primary control-plane node in "qemu" cluster
🔥  Creating qemu2 VM (CPUs=2, Memory=6000MB, Disk=20000MB) ...
📦  Preparing Kubernetes v1.33.1 on containerd 1.7.23 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "qemu" cluster and "default" namespace by default
```

## Example run with krunkit

```console
% minikube start -p krunkit --driver krunkit --container-runtime containerd \
    --iso-url file://$PWD/minikube-arm64.iso
😄  [krunkit] minikube v1.36.0 on Darwin 15.5 (arm64)
✨  Using the krunkit (experimental) driver based on user configuration
👍  Starting "krunkit" primary control-plane node in "krunkit" cluster
🔥  Creating krunkit VM (CPUs=2, Memory=6000MB, Disk=20000MB) ...
📦  Preparing Kubernetes v1.33.1 on containerd 1.7.23 ...
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "krunkit" cluster and "default" namespace by default
```
