### PR TITLE
add short hand -m for --memory

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -61,8 +61,8 @@ const (
 	hostOnlyCIDR            = "host-only-cidr"
 	containerRuntime        = "container-runtime"
 	criSocket               = "cri-socket"
-	networkPlugin           = "network-plugin"
-	enableDefaultCNI        = "enable-default-cni"
+	networkPlugin           = "network-plugin"     // deprecated, use --cni instead
+	enableDefaultCNI        = "enable-default-cni" // deprecated, use --cni=bridge instead
 	cniFlag                 = "cni"
 	hypervVirtualSwitch     = "hyperv-virtual-switch"
 	hypervUseExternalSwitch = "hyperv-use-external-switch"
@@ -236,6 +236,16 @@ func initDriverFlags() {
 	if err := startCmd.Flags().MarkHidden("vm-driver"); err != nil {
 		klog.Warningf("Failed to hide vm-driver flag: %v\n", err)
 	}
+	// Hide the deprecated flag from help text so new users dont use it (still will be processed)
+	if err := startCmd.Flags().MarkHidden(enableDefaultCNI); err != nil {
+		klog.Warningf("Failed to hide %s flag: %v\n", enableDefaultCNI, err)
+	}
+
+	// Hide the deprecated flag from help text so new users dont use it (still will be processed)
+	if err := startCmd.Flags().MarkHidden(networkPlugin); err != nil {
+		klog.Warningf("Failed to hide %s flag: %v\n", networkPlugin, err)
+	}
+
 	startCmd.Flags().Bool(disableDriverMounts, false, "Disables the filesystem mounts provided by the hypervisors")
 	startCmd.Flags().Bool("vm", false, "Filter to use only VM Drivers")
 


### PR DESCRIPTION
also hides the deperecated flags 
### before this PR

```
$ minikube start --help | grep vm-driver
    --vm-driver='':
```

### After this PR 
```
$ mk start --help | grep network-plugin
$ mk start --help | grep vm-driver
$ mk start --help | grep enable-default-cni
```

also 

```
$ mk start -d vfkit -m 12gb --cpus 6
😄  minikube v1.36.0 on Darwin 15.5 (arm64)
✨  Using the vfkit driver based on user configuration
👍  Starting "minikube" primary control-plane node in "minikube" cluster
🔥  Creating vfkit VM (CPUs=6, Memory=12288MB, Disk=20000MB) ...
```

closes https://github.com/kubernetes/minikube/issues/20853