### PR TITLE
don't call startKicServiceTunnel for non-kic drivers

### DIFF
--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -159,22 +159,22 @@ You may select another namespace by using 'minikube service {{.service}} -n <nam
 			}
 		}
 
-		noNodePortSvcNames := []string{}
-		for _, svc := range noNodePortServices {
-			noNodePortSvcNames = append(noNodePortSvcNames, fmt.Sprintf("%s/%s", svc.Namespace, svc.Name))
-		}
-		if len(noNodePortServices) != 0 {
-			out.WarningT("Services {{.svc_names}} have type \"ClusterIP\" not meant to be exposed, however for local development minikube allows you to access this !", out.V{"svc_names": noNodePortSvcNames})
-		}
+		if driver.NeedsPortForward(co.Config.Driver) {
+			svcs := services
+			if len(svcs) == 0 && len(noNodePortServices) > 0 {
+				svcs = noNodePortServices
 
-		if driver.NeedsPortForward(co.Config.Driver) && services != nil {
-			startKicServiceTunnel(services, cname, co.Config.Driver)
+				noNodePortSvcNames := []string{}
+				for _, svc := range noNodePortServices {
+					noNodePortSvcNames = append(noNodePortSvcNames, fmt.Sprintf("%s/%s", svc.Namespace, svc.Name))
+				}
+				out.WarningT("Services {{.svc_names}} have type \"ClusterIP\" not meant to be exposed, however for local development minikube allows you to access this !", out.V{"svc_names": noNodePortSvcNames})
+			}
+			if len(svcs) != 0 {
+				startKicServiceTunnel(svcs, cname, co.Config.Driver)
+			}
 		} else if !serviceURLMode {
 			openURLs(data)
-			if len(noNodePortServices) != 0 {
-				startKicServiceTunnel(noNodePortServices, cname, co.Config.Driver)
-			}
-
 		}
 	},
 }


### PR DESCRIPTION
fixes: https://github.com/kubernetes/minikube/issues/18825
fixes: https://github.com/kubernetes/minikube/issues/19878

**_before_**: as described in the issues listed above

## after

```
$ minikube start -p kic --driver docker
$ minikube start -p kvm --driver kvm2
$ minikube profile list
|---------|-----------|---------|----------------|------|---------|--------|-------|----------------|--------------------|
| Profile | VM Driver | Runtime |       IP       | Port | Version | Status | Nodes | Active Profile | Active Kubecontext |
|---------|-----------|---------|----------------|------|---------|--------|-------|----------------|--------------------|
| kic     | docker    | docker  | 192.168.58.2   | 8443 | v1.33.1 | OK     |     1 |                | *                  |
| kvm     | kvm2      | docker  | 192.168.50.204 | 8443 | v1.33.1 | OK     |     1 |                |                    |
|---------|-----------|---------|----------------|------|---------|--------|-------|----------------|--------------------|
```

### docker driver

```
$ minikube service list -p kic
|-------------|------------|--------------|-----|
|  NAMESPACE  |    NAME    | TARGET PORT  | URL |
|-------------|------------|--------------|-----|
| default     | kubernetes | No node port |     |
| kube-system | kube-dns   | No node port |     |
|-------------|------------|--------------|-----|
```
```
$ minikube service --all -p kic
|-----------|------------|-------------|--------------|
| NAMESPACE |    NAME    | TARGET PORT |     URL      |
|-----------|------------|-------------|--------------|
| default   | kubernetes |             | No node port |
|-----------|------------|-------------|--------------|
😿  service default/kubernetes has no node port
```
```
$ minikube service --all --url -p kic
😿  service default/kubernetes has no node port
```
```
$ kubectl --context=kic create deployment hello-minikube1 --image=kicbase/echo-server:1.0
deployment.apps/hello-minikube1 created
$ kubectl --context=kic expose deployment hello-minikube1 --type=NodePort --port=8080
service/hello-minikube1 exposed 
```
```
$ minikube service list -p kic
|-------------|-----------------|--------------|---------------------------|
|  NAMESPACE  |      NAME       | TARGET PORT  |            URL            |
|-------------|-----------------|--------------|---------------------------|
| default     | hello-minikube1 |         8080 | http://192.168.58.2:31243 |
| default     | kubernetes      | No node port |                           |
| kube-system | kube-dns        | No node port |                           |
|-------------|-----------------|--------------|---------------------------|
```
```
minikube service --all -p kic
|-----------|-----------------|-------------|---------------------------|
| NAMESPACE |      NAME       | TARGET PORT |            URL            |
|-----------|-----------------|-------------|---------------------------|
| default   | hello-minikube1 |        8080 | http://192.168.58.2:31243 |
|-----------|-----------------|-------------|---------------------------|
|-----------|------------|-------------|--------------|
| NAMESPACE |    NAME    | TARGET PORT |     URL      |
|-----------|------------|-------------|--------------|
| default   | kubernetes |             | No node port |
|-----------|------------|-------------|--------------|
😿  service default/kubernetes has no node port
🎉  Opening service default/hello-minikube1 in default browser...
```
```
$ minikube service --all --url -p kic
http://192.168.58.2:31243
😿  service default/kubernetes has no node port
```
```
$ minikube service hello-minikube1 --url -p kic
http://192.168.58.2:31243
```
```
$ minikube service hello-minikube1 -p kic
|-----------|-----------------|-------------|---------------------------|
| NAMESPACE |      NAME       | TARGET PORT |            URL            |
|-----------|-----------------|-------------|---------------------------|
| default   | hello-minikube1 |        8080 | http://192.168.58.2:31243 |
|-----------|-----------------|-------------|---------------------------|
🎉  Opening service default/hello-minikube1 in default browser...
```

### kvm driver

```
$ minikube service list -p kvm
|-------------|------------|--------------|-----|
|  NAMESPACE  |    NAME    | TARGET PORT  | URL |
|-------------|------------|--------------|-----|
| default     | kubernetes | No node port |     |
| kube-system | kube-dns   | No node port |     |
|-------------|------------|--------------|-----|
```
```
$ minikube service --all -p kvm
|-----------|------------|-------------|--------------|
| NAMESPACE |    NAME    | TARGET PORT |     URL      |
|-----------|------------|-------------|--------------|
| default   | kubernetes |             | No node port |
|-----------|------------|-------------|--------------|
😿  service default/kubernetes has no node port
```
```
$ minikube service --all --url -p kvm
😿  service default/kubernetes has no node port
```
```
$ kubectl --context=kvm create deployment hello-minikube1 --image=kicbase/echo-server:1.0
deployment.apps/hello-minikube1 created
$ kubectl --context=kvm expose deployment hello-minikube1 --type=NodePort --port=8080
service/hello-minikube1 exposed
```
```
$ minikube service list -p kvm
|-------------|-----------------|--------------|-----------------------------|
|  NAMESPACE  |      NAME       | TARGET PORT  |             URL             |
|-------------|-----------------|--------------|-----------------------------|
| default     | hello-minikube1 |         8080 | http://192.168.50.204:31145 |
| default     | kubernetes      | No node port |                             |
| kube-system | kube-dns        | No node port |                             |
|-------------|-----------------|--------------|-----------------------------|
```
```
minikube service --all -p kvm
|-----------|-----------------|-------------|-----------------------------|
| NAMESPACE |      NAME       | TARGET PORT |             URL             |
|-----------|-----------------|-------------|-----------------------------|
| default   | hello-minikube1 |        8080 | http://192.168.50.204:31145 |
|-----------|-----------------|-------------|-----------------------------|
|-----------|------------|-------------|--------------|
| NAMESPACE |    NAME    | TARGET PORT |     URL      |
|-----------|------------|-------------|--------------|
| default   | kubernetes |             | No node port |
|-----------|------------|-------------|--------------|
😿  service default/kubernetes has no node port
🎉  Opening service default/hello-minikube1 in default browser...
```
```
$ minikube service --all --url -p kvm
http://192.168.50.204:31145
😿  service default/kubernetes has no node port
```
```
$ minikube service hello-minikube1 --url -p kvm
http://192.168.50.204:31145
```
```
$ minikube service hello-minikube1 -p kvm
|-----------|-----------------|-------------|-----------------------------|
| NAMESPACE |      NAME       | TARGET PORT |             URL             |
|-----------|-----------------|-------------|-----------------------------|
| default   | hello-minikube1 |        8080 | http://192.168.50.204:31145 |
|-----------|-----------------|-------------|-----------------------------|
🎉  Opening service default/hello-minikube1 in default browser...
```



<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
