### PR TITLE
iso: Disable grub timeout speeding up vm start by 5 seconds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ KIC_VERSION ?= $(shell grep -E "Version =" pkg/drivers/kic/types.go | cut -d \" 
 HUGO_VERSION ?= $(shell grep -E "HUGO_VERSION = \"" netlify.toml | cut -d \" -f2)
 
 # Default to .0 for higher cache hit rates, as build increments typically don't require new ISO versions
-ISO_VERSION ?= v1.36.0-1749066232-20832
+ISO_VERSION ?= v1.36.0-1749153077-20895
 
 # Dashes are valid in semver, but not Linux packaging. Use ~ to delimit alpha/beta
 DEB_VERSION ?= $(subst -,~,$(RAW_VERSION))

--- a/deploy/iso/minikube-iso/board/minikube/aarch64/grub.cfg
+++ b/deploy/iso/minikube-iso/board/minikube/aarch64/grub.cfg
@@ -1,5 +1,5 @@
 set default="0"
-set timeout="5"
+set timeout="0"
 
 menuentry "Buildroot" {
   # The console depends on the driver:

--- a/deploy/iso/minikube-iso/board/minikube/x86_64/grub.cfg
+++ b/deploy/iso/minikube-iso/board/minikube/x86_64/grub.cfg
@@ -1,5 +1,5 @@
 set default="0"
-set timeout="5"
+set timeout="0"
 
 menuentry "Buildroot" {
   linux /boot/bzimage console=tty0 rw # kernel

--- a/pkg/minikube/download/iso.go
+++ b/pkg/minikube/download/iso.go
@@ -41,7 +41,7 @@ const fileScheme = "file"
 // DefaultISOURLs returns a list of ISO URL's to consult by default, in priority order
 func DefaultISOURLs() []string {
 	v := version.GetISOVersion()
-	isoBucket := "minikube-builds/iso/20832"
+	isoBucket := "minikube-builds/iso/20895"
 
 	return []string{
 		fmt.Sprintf("https://storage.googleapis.com/%s/minikube-%s-%s.iso", isoBucket, v, runtime.GOARCH),


### PR DESCRIPTION
This speeds up machine boot by 5 seconds. The timeout may be helpful for 
debugging boot issues but we don't have a way to access the serial
console for debugging currently.

Testing shows about ~5 seconds speedup on arm64 and no difference on amd64.

| os     | arch   | driver     | timeout | start time |                                                                                                                       
|--------|--------|------------|---------|------------|
| macOS  | arm64  | vfkit[1]   |     5.0 |      24.01 |
| macOS  | arm64  | vfkit[1]   |     0.0 |      19.90 |
| macOS  | arm64  | qemu       |     5.0 |      29.46 |
| macOS  | arm64  | qemu       |     0.0 |      24.28 |
| macOS  | arm64  | krunkit[2] |     5.0 |      25.14 |
| macOS  | arm64  | krunkit[2] |     0.0 |      20.51 |
| linux  | amd64  | kvm2       |     5.0 |      43.02 |
| linux  | amd64  | kvm2       |     0.0 |      43.11 |

[1] Tested with #20833, booting using iso instead of direct kernel
    boot. Direct kernel boot is little bit faster (e.g. 18.x).
[2] Tested with #20826