### PR TITLE
WIP:Update volcano-development.yaml.tmpl

### DIFF
--- a/deploy/addons/volcano/volcano-development.yaml.tmpl
+++ b/deploy/addons/volcano/volcano-development.yaml.tmpl
@@ -5425,8 +5425,7 @@ spec:
                         rule: has(self.exactMatch) || has(self.regexMatch) || has(self.labelMatch)
                       - message: Only one of ExactMatch, RegexMatch, or LabelMatch
                           can be specified
-                        rule: '(has(self.exactMatch) ? 1 : 0) + (has(self.regexMatch)
-                          ? 1 : 0) + (has(self.labelMatch) ? 1 : 0) <= 1'
+                        rule: (has(self.exactMatch) ? 1 : 0) + (has(self.regexMatch) ? 1 : 0) + (has(self.labelMatch) ? 1 : 0) <= 1
                     type:
                       description: Type specifies the member type.
                       enum:


### PR DESCRIPTION
 fix Test-TestAddons
 logfile: https://storage.googleapis.com/minikube-builds/logs/20889/39905/Docker_Linux.html#fail_TestAddons%2fserial%2fVolcano 

err info:
`
stderr:
	The CustomResourceDefinition "hypernodes.topology.volcano.sh" is invalid: spec.validation.openAPIV3Schema.properties[spec].properties[members].items.properties[selector].x-kubernetes-validations[1].rule: Invalid value: apiextensions.ValidationRule{Rule:"(has(self.exactMatch) ? 1 : 0) + (has(self.regexMatch) ? 1 : 0) + (has(self.labelMatch) ? 1 : 0) &lt;= 1", Message:"Only one of ExactMatch, RegexMatch, or LabelMatch can be specified", MessageExpression:"", Reason:(*apiextensions.FieldValueErrorReason)(nil), FieldPath:"", OptionalOldSelf:(*bool)(nil)}: compilation failed: ERROR: <input>:1:98: Syntax error: token recognition error at: '&l'
	 | (has(self.exactMatch) ? 1 : 0) + (has(self.regexMatch) ? 1 : 0) + (has(self.labelMatch) ? 1 : 0) &lt;= 1
	 | .................................................................................................^
	ERROR: <input>:1:100: Syntax error: mismatched input 't' expecting <EOF>
	 | (has(self.exactMatch) ? 1 : 0) + (has(self.regexMatch) ? 1 : 0) + (has(self.labelMatch) ? 1 : 0) &lt;= 1
	 | ...................................................................................................^
	ERROR: <input>:1:101: Syntax error: token recognition error at: ';'
	 | (has(self.exactMatch) ? 1 : 0) + (has(self.regexMatch) ? 1 : 0) + (has(self.labelMatch) ? 1 : 0) &lt;= 1
	 | ....................................................................................................^
	ERROR: <input>:1:102: Syntax error: token recognition error at: '= '
	 | (has(self.exactMatch) ? 1 : 0) + (has(self.regexMatch) ? 1 : 0) + (has(self.labelMatch) ? 1 : 0) &lt;= 1
	 | .....................................................................................................^
	I0605 18:32:10.625580   14557 retry.go:31] will retry after 185.613442ms: sudo KUBECONFIG=/var/lib/minikube/kubeconfig /var/lib/minikube/binaries/v1.33.1/kubectl apply -f /etc/kubernetes/addons/volcano-deployment.yaml: Process exited with status 1
`
