### PR TITLE
fix: YAML file escape error problem

### DIFF
--- a/pkg/minikube/assets/vm_assets.go
+++ b/pkg/minikube/assets/vm_assets.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"embed"
 	"fmt"
-	"html/template"
+	"text/template"
 	"io"
 	"os"
 	"path"


### PR DESCRIPTION
**Problem：** faiing test Volcano addon
**log file:** https://storage.googleapis.com/minikube-builds/logs/20889/39905/Docker_Linux.html#fail_TestAddons%2fserial%2fVolcano
**error message:**
`
stderr:
	The CustomResourceDefinition "hypernodes.topology.volcano.sh" is invalid: spec.validation.openAPIV3Schema.properties[spec].properties[members].items.properties[selector].x-kubernetes-validations[1].rule: Invalid value: apiextensions.ValidationRule{Rule:"(has(self.exactMatch) ? 1 : 0) + (has(self.regexMatch) ? 1 : 0) + (has(self.labelMatch) ? 1 : 0) &lt;= 1", Message:"Only one of ExactMatch, RegexMatch, or LabelMatch can be specified", MessageExpression:"", Reason:(*apiextensions.FieldValueErrorReason)(nil), FieldPath:"", OptionalOldSelf:(*bool)(nil)}: compilation failed: ERROR: <input>:1:98: Syntax error: token recognition error at: '&l'
	 | (has(self.exactMatch) ? 1 : 0) + (has(self.regexMatch) ? 1 : 0) + (has(self.labelMatch) ? 1 : 0) &lt;= 1
	 | .................................................................................................^
	ERROR: <input>:1:100: Syntax error: mismatched input 't' expecting <EOF>
	 | (has(self.exactMatch) ? 1 : 0) + (has(self.regexMatch) ? 1 : 0) + (has(self.labelMatch) ? 1 : 0) &lt;= 1
	 | ...................................................................................................^
	ERROR: <input>:1:101: Syntax error: token recognition error at: ';'
	 | (has(self.exactMatch) ? 1 : 0) + (has(self.regexMatch) ? 1 : 0) + (has(self.labelMatch) ? 1 : 0) &lt;= 1
	 | ....................................................................................................^
	ERROR: <input>:1:102: Syntax error: token recognition error at: '= '
	 | (has(self.exactMatch) ? 1 : 0) + (has(self.regexMatch) ? 1 : 0) + (has(self.labelMatch) ? 1 : 0) &lt;= 1
	 | .....................................................................................................^
	I0605 18:32:10.625580   14557 retry.go:31] will retry after 185.613442ms: sudo KUBECONFIG=/var/lib/minikube/kubeconfig /var/lib/minikube/binaries/v1.33.1/kubectl apply -f /etc/kubernetes/addons/volcano-deployment.yaml: Process exited with status 1
`
**Root cause:** Problem with escaping of yaml files inside minikube node.
vi /etc/kubernetes/addons/volcano-deployment.yaml
![image](https://github.com/user-attachments/assets/7fdd38fa-1076-4aea-ac06-a61bb14d0442)

**Repair results:**
![image](https://github.com/user-attachments/assets/9e1bb5c4-965c-482b-943e-5bbf7b4b4915)
![image](https://github.com/user-attachments/assets/ff3b91fb-177a-4e83-9d7d-eec35559f9eb)




