### PR TITLE
Update _index.md

### DIFF
--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -758,7 +758,7 @@ minikube addons list
 Create a second cluster running an older Kubernetes release:
 
 ```shell
-minikube start -p aged --kubernetes-version=v1.16.1
+minikube start -p aged --kubernetes-version=v1.20.0
 ```
 
 Delete all of the minikube clusters:


### PR DESCRIPTION
change version for below error
~ % minikube start -p aged --kubernetes-version=v1.16.1 😄  [aged] minikube v1.36.0 on Darwin 15.3.1 (arm64) ❗  Specified Kubernetes version 1.16.1 is less than the oldest supported version: v1.20.0. Use `minikube config defaults kubernetes-version` for details. ❗  You can force an unsupported Kubernetes version via the --force flag

❌  Exiting due to K8S_OLD_UNSUPPORTED: Kubernetes 1.16.1 is not supported by this release of minikube

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
