### PR TITLE
Remove spowelljr from reviewers list

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,7 +3,6 @@
 reviewers:
   - medyagh
   - prezha
-  - spowelljr
   - comradeprogrammer
 approvers:
   - medyagh


### PR DESCRIPTION
Since I'm not actively working on the project, having k8s-ci-robot assign me as a reviewer on PRs isn't useful for anyone. Happy to keep approver to help out when needed though.