### PR TITLE
Add `--disable-coredns-log` flag

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -139,6 +139,7 @@ const (
 	binaryMirror            = "binary-mirror"
 	disableOptimizations    = "disable-optimizations"
 	disableMetrics          = "disable-metrics"
+	disableCoreDNSLog       = "disable-coredns-log"
 	qemuFirmwarePath        = "qemu-firmware-path"
 	socketVMnetClientPath   = "socket-vmnet-client-path"
 	socketVMnetPath         = "socket-vmnet-path"
@@ -206,6 +207,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().String(binaryMirror, "", "Location to fetch kubectl, kubelet, & kubeadm binaries from.")
 	startCmd.Flags().Bool(disableOptimizations, false, "If set, disables optimizations that are set for local Kubernetes. Including decreasing CoreDNS replicas from 2 to 1. Defaults to false.")
 	startCmd.Flags().Bool(disableMetrics, false, "If set, disables metrics reporting (CPU and memory usage), this can improve CPU usage. Defaults to false.")
+	startCmd.Flags().Bool(disableCoreDNSLog, false, "If set, disable CoreDNS verbose logging. Defaults to false.")
 	startCmd.Flags().String(staticIP, "", "Set a static IP for the minikube cluster, the IP must be: private, IPv4, and the last octet must be between 2 and 254, for example 192.168.200.200 (Docker and Podman drivers only)")
 	startCmd.Flags().StringP(gpus, "g", "", "Allow pods to use your GPUs. Options include: [all,nvidia,amd] (Docker driver with Docker container-runtime only)")
 	startCmd.Flags().Duration(autoPauseInterval, time.Minute*1, "Duration of inactivity before the minikube VM is paused (default 1m0s)")
@@ -625,6 +627,7 @@ func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, rtime str
 		BinaryMirror:            viper.GetString(binaryMirror),
 		DisableOptimizations:    viper.GetBool(disableOptimizations),
 		DisableMetrics:          viper.GetBool(disableMetrics),
+		DisableCoreDNSLog:       viper.GetBool(disableCoreDNSLog),
 		CustomQemuFirmwarePath:  viper.GetString(qemuFirmwarePath),
 		SocketVMnetClientPath:   detect.SocketVMNetClientPath(),
 		SocketVMnetPath:         detect.SocketVMNetPath(),

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -101,6 +101,7 @@ type ClusterConfig struct {
 	BinaryMirror            string // Mirror location for kube binaries (kubectl, kubelet, & kubeadm)
 	DisableOptimizations    bool
 	DisableMetrics          bool
+	DisableCoreDNSLog       bool
 	CustomQemuFirmwarePath  string
 	SocketVMnetClientPath   string
 	SocketVMnetPath         string

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -956,11 +956,15 @@ func addCoreDNSEntry(runner command.Runner, name, ip string, cc config.ClusterCo
 		sed = fmt.Sprintf("sed -e '/^        hosts {.*/a \\           %s %s'", ip, name)
 	}
 
-	// check if logging is already enabled (via log plugin) in coredns configmap, so not to duplicate it
-	regex := regexp.MustCompile(`(?smU)^ *log *$`)
-	if !regex.MatchString(cm) {
-		// inject log plugin into coredns configmap
-		sed = fmt.Sprintf("%s -e '/^        errors *$/i \\        log'", sed)
+	if cc.DisableCoreDNSLog {
+		sed = fmt.Sprintf("%s -e '/^        log *$/d'", sed)
+	} else {
+		// check if logging is already enabled (via log plugin) in coredns configmap, so not to duplicate it
+		regex := regexp.MustCompile(`(?smU)^ *log *$`)
+		if !regex.MatchString(cm) {
+			// inject log plugin into coredns configmap
+			sed = fmt.Sprintf("%s -e '/^        errors *$/i \\        log'", sed)
+		}
 	}
 
 	// replace coredns configmap via kubectl


### PR DESCRIPTION
fixes #19757

Adds the `--disable-coredns-log` option to cluster startup. When enabled, this option removes the `log` plugin from the CoreDNS ConfigMap, preventing query logs from being output to the Pod logs.

---

**before (default)**

```
docker@minikube:~$ sudo ls -alh /var/lib/docker/containers/cae72a53aeead8e6cdc48846c46c3703eece0960e25e2119b40ce3453c9db585/cae72a53aeead8e6cdc48846c46c3703eece0960e25e2119b40ce
3453c9db585-json.log
-rw-r----- 1 root root 263K Jun 29 17:39 /var/lib/docker/containers/cae72a53aeead8e6cdc48846c46c3703eece0960e25e2119b40ce3453c9db585/cae72a53aeead8e6cdc48846c46c3703eece0960e25e2119b40ce3453c9db585-json.log
docker@minikube:~$ sudo head -n 10 /var/lib/docker/containers/cae72a53aeead8e6cdc48846c46c3703eece0960e25e2119b40ce3453c9db585/cae72a53aeead8e6cdc48846c46c3703eece0960e25e2119b4
0ce3453c9db585-json.log
{"log":".:53\n","stream":"stdout","time":"2025-06-29T17:37:16.911204731Z"}
{"log":"[INFO] plugin/reload: Running configuration SHA512 = 05e3eaddc414b2d71a69b2e2bc6f2681fc1f4d04bcdd3acc1a41457bb7db518208b95ddfc4c9fffedc59c25a8faf458be1af4915a4a3c0d6777cb7a346bc5d86\n","stream":"stdout","time":"2025-06-29T17:37:16.911254738Z"}
{"log":"CoreDNS-1.9.3\n","stream":"stdout","time":"2025-06-29T17:37:16.911263032Z"}
{"log":"linux/amd64, go1.18.2, 45b0a11\n","stream":"stdout","time":"2025-06-29T17:37:16.911265472Z"}
{"log":"[INFO] 127.0.0.1:50578 - 11501 \"HINFO IN 8305876105755474021.8070635482691607969. udp 57 false 512\" NXDOMAIN qr,rd,ra 132 0.006369538s\n","stream":"stdout","time":"2025-06-29T17:37:16.917272287Z"}
{"log":"[INFO] 10.244.0.2:60114 - 40402 \"A IN metadata.google.internal.elastic-system.svc.cluster.local. udp 86 false 1232\" NXDOMAIN qr,aa,rd 168 0.000292824s\n","stream":"stdout","time":"2025-06-29T17:37:30.657746089Z"}
{"log":"[INFO] 10.244.0.2:57182 - 21348 \"AAAA IN metadata.google.internal.elastic-system.svc.cluster.local. udp 86 false 1232\" NXDOMAIN qr,aa,rd 168 0.000354242s\n","stream":"stdout","time":"2025-06-29T17:37:30.657778154Z"}
{"log":"[INFO] 10.244.0.2:41830 - 48782 \"A IN metadata.google.internal.svc.cluster.local. udp 71 false 1232\" NXDOMAIN qr,aa,rd 153 0.000152372s\n","stream":"stdout","time":"2025-06-29T17:37:30.657780955Z"}
{"log":"[INFO] 10.244.0.2:40259 - 35747 \"AAAA IN metadata.google.internal.svc.cluster.local. udp 71 false 1232\" NXDOMAIN qr,aa,rd 153 0.00017997s\n","stream":"stdout","time":"2025-06-29T17:37:30.657783213Z"}
{"log":"[INFO] 10.244.0.2:33894 - 8445 \"A IN metadata.google.internal.cluster.local. udp 67 false 1232\" NXDOMAIN qr,aa,rd 149 0.000131425s\n","stream":"stdout","time":"2025-06-29T17:37:30.65825304Z"}
```

**after (--disable-coredns-log)**

```
$ kubectl logs -n kube-system -l k8s-app=kube-dns -f
.:53
[INFO] plugin/reload: Running configuration SHA512 = eff20e86b4fd2b9878e9c34205d7ba141ff41613cbdadb71e63d4a8be6caff7d1fbccef3edfe618baf8958049a58d98ae28ea781e3e7cdf1cc90820da8e01a6d
CoreDNS-1.9.3
linux/amd64, go1.18.2, 45b0a11
```