### PR TITLE
build: Skip building hyperkit driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,8 +366,7 @@ all: cross drivers e2e-cross cross-tars exotic retro out/gvisor-addon ## Build a
 # After https://github.com/kubernetes/minikube/issues/19959 is fixed kvm2-arm64 can be added back
 .PHONY: drivers
 drivers: ## Build Hyperkit and KVM2 drivers
-drivers: docker-machine-driver-hyperkit \
-	 docker-machine-driver-kvm2 \
+drivers: docker-machine-driver-kvm2 \
 	 out/docker-machine-driver-kvm2-amd64
 
 


### PR DESCRIPTION
The build is failing now with this error:

    GOOS=darwin CGO_ENABLED=1 go build \
        -ldflags="-X k8s.io/minikube/pkg/drivers/hyperkit.version=v1.36.0 ...   \
        -o out/docker-machine-driver-hyperkit k8s.io/minikube/cmd/drivers/hyperkit
    + failed=2

hyperkit needs the xcgo image which is unmaintained since Sep 2023. We forked it to build hyperkit for minikube 1.36, but this image has now many vulnerabilities.

This change only skip building hyperkit so we can recover it quickly if someone can fix the build.

I tried to build hyperkit in a Linux VM (Fedora 42) and the build works:

```
$ make hyperkit_in_docker
rm -f out/docker-machine-driver-hyperkit
make MINIKUBE_BUILD_IN_DOCKER=y out/docker-machine-driver-hyperkit
make[1]: Entering directory '/home/nsoffer/minikube'
docker run --rm -e GOCACHE=/app/.cache -e IN_DOCKER=1 \
	--user 1000:1000 -w /app \
	-v /home/nsoffer/minikube:/app:Z -v /home/nsoffer/go:/go:Z --init --entrypoint "" \
	quay.io/nirsof/xcgo:jammy /bin/bash -c 'CC=o64-clang CXX=o64-clang++ /usr/bin/make out/docker-machine-driver-hyperkit'
GOOS=darwin CGO_ENABLED=1 go build \
	-ldflags="-X k8s.io/minikube/pkg/drivers/hyperkit.version=v1.36.0 -X k8s.io/minikube/pkg/drivers/hyperkit.gitCommitID="fdc5ef8d05831007f39ab862afe87e8d36a49bf7""   \
	-o out/docker-machine-driver-hyperkit k8s.io/minikube/cmd/drivers/hyperkit
go: downloading github.com/go-logr/logr v1.4.3
make[1]: Leaving directory '/home/nsoffer/minikube'

$ ls out/
docker-machine-driver-hyperkit  minikube
```

This may be an issue on the build host.

See also #21012 