### PR TITLE
build: Update xcgo image to v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ COMMIT ?= $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO
 COMMIT_SHORT = $(shell git rev-parse --short HEAD 2> /dev/null || true)
 COMMIT_NOQUOTES := $(patsubst "%",%,$(COMMIT))
 # source code for image: https://github.com/neilotoole/xcgo
-HYPERKIT_BUILD_IMAGE ?= quay.io/nirsof/xcgo:jammy
+HYPERKIT_BUILD_IMAGE ?= quay.io/nirsof/xcgo:jammy-v2
 
 # NOTE: "latest" as of 2021-02-06. kube-cross images aren't updated as often as Kubernetes
 # https://github.com/kubernetes/kubernetes/blob/master/build/build-image/cross/VERSION


### PR DESCRIPTION
Before:

    Quay Security Scanner has detected 607 vulnerabilities.
    Patches are available for 151 vulnerabilities.
     5 Critical-level vulnerabilities.
     12 High-level vulnerabilities.
     180 Medium-level vulnerabilities.
     322 Low-level vulnerabilities.
     34 Negligible-level vulnerabilities.
     54 Unknown-level vulnerabilities.

After:

    Quay Security Scanner has detected 572 vulnerabilities.
    Patches are available for 116 vulnerabilities.
     2 Critical-level vulnerabilities.
     11 High-level vulnerabilities.
     150 Medium-level vulnerabilities.
     319 Low-level vulnerabilities.
     34 Negligible-level vulnerabilities.
     56 Unknown-level vulnerabilities.

Delta:

     -3 Critical-level vulnerabilities.
     -1 High-level vulnerabilities.
     -30 Medium-level vulnerabilities.
     -3 Low-level vulnerabilities.
     +2 Unknown-level vulnerabilities.
