### PR TITLE
site: kvm2: Remove old part about needing to reboot

### DIFF
--- a/site/content/en/docs/drivers/kvm2.md
+++ b/site/content/en/docs/drivers/kvm2.md
@@ -34,7 +34,6 @@ The `minikube start` command supports 5 additional KVM specific flags:
 * `Machine didn't return an IP after 120 seconds` when firewall prevents VM network access [#3566](https://github.com/kubernetes/minikube/issues/3566)
 * `unable to set user and group to '65534:992` when `dynamic ownership = 1` in `qemu.conf` [#4467](https://github.com/kubernetes/minikube/issues/4467)
 * KVM VM's cannot be used simultaneously with VirtualBox  [#4913](https://github.com/kubernetes/minikube/issues/4913)
-* On some distributions, libvirt bridge networking may fail until the host reboots
 
 Also see [co/kvm2-driver open issues](https://github.com/kubernetes/minikube/labels/co%2Fkvm2-driver).
 


### PR DESCRIPTION
This note in the kvm2 driver docs about possibly needing to reboot I think is not true anymore.

- There is no linked issue
- Can't find any issues mentioning this issue
- It's from 2019
- I can't reproduce on Ubuntu 24.04, and others tried on Ubuntu 22.04, Debian testing and Gentoo
