### PR TITLE
site: vfkit: Fix requirements version to MacOS 12

### DIFF
--- a/site/content/en/docs/drivers/vfkit.md
+++ b/site/content/en/docs/drivers/vfkit.md
@@ -13,7 +13,7 @@ container deployment.
 
 ## Requirements
 
-- Requires macOS 13 or later.
+- Requires macOS 12 or later.
 - Requires minikube version 1.36.0 or later.
 
 ## Networking


### PR DESCRIPTION
- vfkit itself mentions it requires MacOS 12 (not 13)
- We did some basic tests of the vfkit minikube driver on a MacOS 12 laptop and it works fine
