### PR TITLE
Deprecate HyperKit driver with warning

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -406,7 +406,7 @@ func virtualBoxMacOS13PlusWarning(driverName string) {
 	if !driver.IsVirtualBox(driverName) || !detect.MacOS13Plus() {
 		return
 	}
-	suggestedDriver := driver.HyperKit
+	suggestedDriver := driver.VFKit
 	if runtime.GOARCH == "arm64" {
 		suggestedDriver = driver.QEMU
 	}
@@ -424,7 +424,7 @@ func hyperkitDeprecationWarning(driverName string) {
 		return
 	}
 	out.WarningT(`The 'hyperkit' driver is deprecated and will be removed in a future release.
-    Please consider using an alternative driver such as 'docker', 'qemu', or 'vfkit'.`)
+    Please consider using an alternative driver such as vfkit, qemu, or docker`)
 }
 
 func validateBuiltImageVersion(r command.Runner, driverName string) {

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -309,6 +309,7 @@ func provisionWithDriver(cmd *cobra.Command, ds registry.DriverState, existing *
 	}
 
 	virtualBoxMacOS13PlusWarning(driverName)
+	hyperkitDeprecationWarning(driverName)
 	validateFlags(cmd, driverName)
 	validateUser(driverName)
 	if driverName == oci.Docker {
@@ -415,6 +416,15 @@ func virtualBoxMacOS13PlusWarning(driverName string) {
 
     For more details on the issue see: https://github.com/kubernetes/minikube/issues/15274
 `, out.V{"driver": suggestedDriver})
+}
+
+// hyperkitDeprecationWarning prints a deprecation warning for the hyperkit driver
+func hyperkitDeprecationWarning(driverName string) {
+	if !driver.IsHyperKit(driverName) {
+		return
+	}
+	out.WarningT(`The 'hyperkit' driver is deprecated and will be removed in a future release.
+    Please consider using an alternative driver such as 'docker', 'qemu', or 'vfkit'.`)
 }
 
 func validateBuiltImageVersion(r command.Runner, driverName string) {

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -406,16 +406,12 @@ func virtualBoxMacOS13PlusWarning(driverName string) {
 	if !driver.IsVirtualBox(driverName) || !detect.MacOS13Plus() {
 		return
 	}
-	suggestedDriver := driver.VFKit
-	if runtime.GOARCH == "arm64" {
-		suggestedDriver = driver.QEMU
-	}
-	out.WarningT(`Due to changes in macOS 13+ minikube doesn't currently support VirtualBox. You can use alternative drivers such as docker or {{.driver}}.
+	out.WarningT(`Due to changes in macOS 13+ minikube doesn't currently support VirtualBox. You can use alternative drivers such as 'vfkit', 'qemu', or 'docker'.
+    https://minikube.sigs.k8s.io/docs/drivers/vfkit/
+    https://minikube.sigs.k8s.io/docs/drivers/qemu/
     https://minikube.sigs.k8s.io/docs/drivers/docker/
-    https://minikube.sigs.k8s.io/docs/drivers/{{.driver}}/
-
     For more details on the issue see: https://github.com/kubernetes/minikube/issues/15274
-`, out.V{"driver": suggestedDriver})
+`)
 }
 
 // hyperkitDeprecationWarning prints a deprecation warning for the hyperkit driver
@@ -424,7 +420,11 @@ func hyperkitDeprecationWarning(driverName string) {
 		return
 	}
 	out.WarningT(`The 'hyperkit' driver is deprecated and will be removed in a future release.
-    Please consider using an alternative driver such as vfkit, qemu, or docker`)
+    You can use alternative drivers such as 'vfkit', 'qemu', or 'docker'.
+    https://minikube.sigs.k8s.io/docs/drivers/vfkit/
+    https://minikube.sigs.k8s.io/docs/drivers/qemu/
+    https://minikube.sigs.k8s.io/docs/drivers/docker/
+	`)
 }
 
 func validateBuiltImageVersion(r command.Runner, driverName string) {

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -211,6 +211,11 @@ func IsHyperV(name string) bool {
 	return name == HyperV
 }
 
+// IsHyperKit check if the driver is HyperKit
+func IsHyperKit(name string) bool {
+	return name == HyperKit
+}
+
 // SupportsNetworkFlag reutuns if driver supports the --network flag
 func SupportsNetworkFlag(name string) bool {
 	return IsKIC(name) || IsKVM(name) || IsQEMU(name) || IsVFKit(name)

--- a/pkg/minikube/registry/drvs/hyperkit/hyperkit.go
+++ b/pkg/minikube/registry/drvs/hyperkit/hyperkit.go
@@ -53,7 +53,7 @@ func init() {
 		Config:   configure,
 		Status:   status,
 		Default:  true,
-		Priority: registry.Preferred,
+		Priority: registry.Deprecated,
 	}); err != nil {
 		panic(fmt.Sprintf("register: %v", err))
 	}


### PR DESCRIPTION

This PR deprecates the HyperKit driver by displaying a user-facing warning when it is selected via `--driver=hyperkit`.

- Warns users that HyperKit is deprecated and may be removed in future releases.
- Suggests using alternative drivers such as `docker`, `qemu`, or `vfkit`.
- Includes documentation links for migration.

Partially addresses #21012
