### PR TITLE
ci: login to docker in downstream jobs

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -116,7 +116,8 @@ fi
 # let's just clean all docker artifacts up
 docker system prune -a --volumes -f || true
 docker system df || true
-
+# read only token, never expires
+docker login -u minikubebot -p "$DOCKERHUB_READONLY_TOKEN"
 echo ">> Starting at $(date)"
 echo ""
 echo "arch:      ${OS_ARCH}"


### PR DESCRIPTION
The Jobs failing 

```
gvisor-addon-Dockerfile:15
--------------------
  13 |     # limitations under the License.
  14 |     
  15 | >>> FROM ubuntu:18.04
  16 |     RUN apt-get update && \
  17 |         apt-get install -y kmod gcc wget xz-utils libc6-dev bc libelf-dev bison flex openssl libssl-dev libidn2-0 sudo libcap2 && \
--------------------
ERROR: failed to solve: ubuntu:18.04: failed to resolve source metadata for docker.io/library/ubuntu:18.04: failed to authorize: failed to fetch oauth token: unexpected status from GET request to https://auth.docker.io/token?scope=repository%3Alibrary%2Fubuntu%3Apull&service=registry.docker.io: 401 Unauthorized
Build step 'Execute shell' marked build as failure
```