### PR TITLE
Support multi mount-string

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -269,17 +269,17 @@ func runStart(cmd *cobra.Command, _ []string) {
 	validateBuiltImageVersion(starter.Runner, ds.Name)
 
 	if existing != nil && driver.IsKIC(existing.Driver) && viper.GetBool(createMount) {
-		isSameMount := func(old, new []string) bool {
-			if len(old) != len(new) {
+		isSameMount := func(oldm, newm []string) bool {
+			if len(oldm) != len(newm) {
 				return false
 			}
 
 			mountmap := make(map[string]int)
-			for _, item := range old {
+			for _, item := range oldm {
 				mountmap[item]++
 			}
 
-			for _, item := range new {
+			for _, item := range newm {
 				cnt, exists := mountmap[item]
 				if !exists || cnt == 0 {
 					return false
@@ -290,13 +290,13 @@ func runStart(cmd *cobra.Command, _ []string) {
 			return true
 		}
 
-		old := existing.ContainerVolumeMounts
-		new := getMountStrings()
-		if !isSameMount(old, new) {
+		oldMounts := existing.ContainerVolumeMounts
+		newMounts := getMountStrings()
+		if !isSameMount(oldMounts, newMounts) {
 			exit.Message(reason.GuestMountConflict, "Sorry, {{.driver}} does not allow mounts to be changed after container creation (previous mount: '{{.old}}', new mount: '{{.new}})'", out.V{
 				"driver": existing.Driver,
-				"new":    new,
-				"old":    old,
+				"new":    newMounts,
+				"old":    oldMounts,
 			})
 		}
 	}

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -173,7 +173,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().Bool(embedCerts, false, "if true, will embed the certs in kubeconfig.")
 	startCmd.Flags().StringP(containerRuntime, "c", constants.DefaultContainerRuntime, fmt.Sprintf("The container runtime to be used. Valid options: %s (default: auto)", strings.Join(cruntime.ValidRuntimes(), ", ")))
 	startCmd.Flags().Bool(createMount, false, "This will start the mount daemon and automatically mount files into minikube.")
-	startCmd.Flags().String(mountString, constants.DefaultMountDir+":/minikube-host", "The argument to pass the minikube mount command on start, in a semicolon-separated format(eg. /foo:/foo;/bar:/bar:Z,rshared).")
+	startCmd.Flags().String(mountString, constants.DefaultMountDir+":/minikube-host", "The argument to pass the minikube mount command on start, in a semicolon-separated format. (eg. /foo:/foo;/bar:/bar:Z,rshared)")
 	startCmd.Flags().String(mount9PVersion, defaultMount9PVersion, mount9PVersionDescription)
 	startCmd.Flags().String(mountGID, defaultMountGID, mountGIDDescription)
 	startCmd.Flags().String(mountIPFlag, defaultMountIP, mountIPDescription)

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -173,7 +173,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().Bool(embedCerts, false, "if true, will embed the certs in kubeconfig.")
 	startCmd.Flags().StringP(containerRuntime, "c", constants.DefaultContainerRuntime, fmt.Sprintf("The container runtime to be used. Valid options: %s (default: auto)", strings.Join(cruntime.ValidRuntimes(), ", ")))
 	startCmd.Flags().Bool(createMount, false, "This will start the mount daemon and automatically mount files into minikube.")
-	startCmd.Flags().String(mountString, constants.DefaultMountDir+":/minikube-host", "The argument to pass the minikube mount command on start, in a semicolon-separated format.")
+	startCmd.Flags().String(mountString, constants.DefaultMountDir+":/minikube-host", "The argument to pass the minikube mount command on start, in a semicolon-separated format(eg. /foo:/foo;/bar:/bar:Z,rshared).")
 	startCmd.Flags().String(mount9PVersion, defaultMount9PVersion, mount9PVersionDescription)
 	startCmd.Flags().String(mountGID, defaultMountGID, mountGIDDescription)
 	startCmd.Flags().String(mountIPFlag, defaultMountIP, mountIPDescription)

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -173,7 +173,7 @@ func initMinikubeFlags() {
 	startCmd.Flags().Bool(embedCerts, false, "if true, will embed the certs in kubeconfig.")
 	startCmd.Flags().StringP(containerRuntime, "c", constants.DefaultContainerRuntime, fmt.Sprintf("The container runtime to be used. Valid options: %s (default: auto)", strings.Join(cruntime.ValidRuntimes(), ", ")))
 	startCmd.Flags().Bool(createMount, false, "This will start the mount daemon and automatically mount files into minikube.")
-	startCmd.Flags().String(mountString, constants.DefaultMountDir+":/minikube-host", "The argument to pass the minikube mount command on start.")
+	startCmd.Flags().String(mountString, constants.DefaultMountDir+":/minikube-host", "The argument to pass the minikube mount command on start, in a semicolon-separated format.")
 	startCmd.Flags().String(mount9PVersion, defaultMount9PVersion, mount9PVersionDescription)
 	startCmd.Flags().String(mountGID, defaultMountGID, mountGIDDescription)
 	startCmd.Flags().String(mountIPFlag, defaultMountIP, mountIPDescription)
@@ -492,6 +492,15 @@ func getNetwork(driverName string) string {
 	return n
 }
 
+func getMountStrings() []string {
+	mountStrings := strings.Split(viper.GetString(mountString), ";")
+	if !validateMountStrings(mountStrings) {
+		exit.Message(reason.Usage, "The mount-string contains duplicate items.")
+	}
+
+	return mountStrings
+}
+
 func validateQemuNetwork(n string) string {
 	switch n {
 	case "socket_vmnet":
@@ -544,6 +553,17 @@ func validateVfkitNetwork(n string) string {
 		exit.Message(reason.Usage, "--network with vfkit must be 'nat' or 'vmnet-shared'")
 	}
 	return n
+}
+
+func validateMountStrings(mountStrings []string) bool {
+	mountmap := make(map[string]bool)
+	for _, mountstring := range mountStrings {
+		if _, exists := mountmap[mountstring]; exists {
+			return false
+		}
+		mountmap[mountstring] = true
+	}
+	return true
 }
 
 // generateNewConfigFromFlags generate a config.ClusterConfig based on flags
@@ -613,7 +633,7 @@ func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, rtime str
 		ExtraDisks:              viper.GetInt(extraDisks),
 		CertExpiration:          viper.GetDuration(certExpiration),
 		Mount:                   viper.GetBool(createMount),
-		MountString:             viper.GetString(mountString),
+		MountStrings:            getMountStrings(),
 		Mount9PVersion:          viper.GetString(mount9PVersion),
 		MountGID:                viper.GetString(mountGID),
 		MountIP:                 viper.GetString(mountIPFlag),
@@ -653,7 +673,7 @@ func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, rtime str
 	}
 	cc.VerifyComponents = interpretWaitFlag(*cmd)
 	if viper.GetBool(createMount) && driver.IsKIC(drvName) {
-		cc.ContainerVolumeMounts = []string{viper.GetString(mountString)}
+		cc.ContainerVolumeMounts = getMountStrings()
 	}
 
 	if driver.IsKIC(drvName) {
@@ -692,6 +712,10 @@ func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, rtime str
 		if runtime.GOOS == "linux" && si.DockerOS == "Docker Desktop" {
 			out.WarningT("For an improved experience it's recommended to use Docker Engine instead of Docker Desktop.\nDocker Engine installation instructions: https://docs.docker.com/engine/install/#server")
 		}
+	}
+
+	if cmd.Flags().Changed(mountString) {
+		cc.MountStrings = getMountStrings()
 	}
 
 	return cc
@@ -865,7 +889,6 @@ func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterC
 	updateBoolFromFlag(cmd, &cc.KubernetesConfig.ShouldLoadCachedImages, cacheImages)
 	updateDurationFromFlag(cmd, &cc.CertExpiration, certExpiration)
 	updateBoolFromFlag(cmd, &cc.Mount, createMount)
-	updateStringFromFlag(cmd, &cc.MountString, mountString)
 	updateStringFromFlag(cmd, &cc.Mount9PVersion, mount9PVersion)
 	updateStringFromFlag(cmd, &cc.MountGID, mountGID)
 	updateStringFromFlag(cmd, &cc.MountIP, mountIPFlag)

--- a/pkg/drivers/kic/oci/types_test.go
+++ b/pkg/drivers/kic/oci/types_test.go
@@ -23,23 +23,23 @@ import (
 func TestParseMountString(t *testing.T) {
 	testCases := []struct {
 		Name          string
-		MountString   string
+		MountStrings  []string
 		ExpectErr     bool
 		ExpectedMount Mount
 	}{
 		{
-			Name:        "basic linux",
-			MountString: "/foo:/bar",
-			ExpectErr:   false,
+			Name:         "basic linux",
+			MountStrings: []string{"/foo:/bar"},
+			ExpectErr:    false,
 			ExpectedMount: Mount{
 				HostPath:      "/foo",
 				ContainerPath: "/bar",
 			},
 		},
 		{
-			Name:        "linux read only",
-			MountString: "/foo:/bar:ro",
-			ExpectErr:   false,
+			Name:         "linux read only",
+			MountStrings: []string{"/foo:/bar:ro"},
+			ExpectErr:    false,
 			ExpectedMount: Mount{
 				HostPath:      "/foo",
 				ContainerPath: "/bar",
@@ -47,18 +47,18 @@ func TestParseMountString(t *testing.T) {
 			},
 		},
 		{
-			Name:        "windows style",
-			MountString: "C:\\Windows\\Path:/foo",
-			ExpectErr:   false,
+			Name:         "windows style",
+			MountStrings: []string{"C:\\Windows\\Path:/foo"},
+			ExpectErr:    false,
 			ExpectedMount: Mount{
 				HostPath:      "C:\\Windows\\Path",
 				ContainerPath: "/foo",
 			},
 		},
 		{
-			Name:        "windows style read/write",
-			MountString: "C:\\Windows\\Path:/foo:rw",
-			ExpectErr:   false,
+			Name:         "windows style read/write",
+			MountStrings: []string{"C:\\Windows\\Path:/foo:rw"},
+			ExpectErr:    false,
 			ExpectedMount: Mount{
 				HostPath:      "C:\\Windows\\Path",
 				ContainerPath: "/foo",
@@ -66,17 +66,17 @@ func TestParseMountString(t *testing.T) {
 			},
 		},
 		{
-			Name:        "container only",
-			MountString: "/foo",
-			ExpectErr:   false,
+			Name:         "container only",
+			MountStrings: []string{"/foo"},
+			ExpectErr:    false,
 			ExpectedMount: Mount{
 				ContainerPath: "/foo",
 			},
 		},
 		{
-			Name:        "selinux relabel & bidirectional propagation",
-			MountString: "/foo:/bar/baz:Z,rshared",
-			ExpectErr:   false,
+			Name:         "selinux relabel & bidirectional propagation",
+			MountStrings: []string{"/foo:/bar/baz:Z,rshared"},
+			ExpectErr:    false,
 			ExpectedMount: Mount{
 				HostPath:       "/foo",
 				ContainerPath:  "/bar/baz",
@@ -85,9 +85,9 @@ func TestParseMountString(t *testing.T) {
 			},
 		},
 		{
-			Name:        "invalid mount option",
-			MountString: "/foo:/bar:Z,bat",
-			ExpectErr:   true,
+			Name:         "invalid mount option",
+			MountStrings: []string{"/foo:/bar:Z,bat"},
+			ExpectErr:    true,
 			ExpectedMount: Mount{
 				HostPath:       "/foo",
 				ContainerPath:  "/bar",
@@ -96,14 +96,14 @@ func TestParseMountString(t *testing.T) {
 		},
 		{
 			Name:          "empty spec",
-			MountString:   "",
+			MountStrings:  []string{""},
 			ExpectErr:     false,
 			ExpectedMount: Mount{},
 		},
 		{
-			Name:        "relative container path",
-			MountString: "/foo/bar:baz/bat:private",
-			ExpectErr:   true,
+			Name:         "relative container path",
+			MountStrings: []string{"/foo/bar:baz/bat:private"},
+			ExpectErr:    true,
 			ExpectedMount: Mount{
 				HostPath:      "/foo/bar",
 				ContainerPath: "baz/bat",
@@ -113,15 +113,17 @@ func TestParseMountString(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		mount, err := ParseMountString(tc.MountString)
-		if err != nil && !tc.ExpectErr {
-			t.Errorf("Unexpected error for \"%s\": %v", tc.Name, err)
-		}
-		if err == nil && tc.ExpectErr {
-			t.Errorf("Expected error for \"%s\" but didn't get any: %v %v", tc.Name, mount, err)
-		}
-		if mount != tc.ExpectedMount {
-			t.Errorf("Unexpected mount for \"%s\":\n expected %+v\ngot %+v", tc.Name, tc.ExpectedMount, mount)
+		for _, mountString := range tc.MountStrings {
+			mount, err := ParseMountString(mountString)
+			if err != nil && !tc.ExpectErr {
+				t.Errorf("Unexpected error for \"%s\": %v", tc.Name, err)
+			}
+			if err == nil && tc.ExpectErr {
+				t.Errorf("Expected error for \"%s\" but didn't get any: %v %v", tc.Name, mount, err)
+			}
+			if mount != tc.ExpectedMount {
+				t.Errorf("Unexpected mount for \"%s\":\n expected %+v\ngot %+v", tc.Name, tc.ExpectedMount, mount)
+			}
 		}
 	}
 }

--- a/pkg/generate/rewrite.go
+++ b/pkg/generate/rewrite.go
@@ -54,7 +54,7 @@ func rewriteFlags(command *cobra.Command) error {
 			usage: "Used to specify the driver to run Kubernetes in. The list of available drivers depends on operating system.",
 		}, {
 			flag:  "mount-string",
-			usage: "The argument to pass the minikube mount command on start.",
+			usage: "The argument to pass the minikube mount command on start, in a semicolon-separated format. (eg. /foo:/foo;/bar:/bar:Z,rshared)",
 		}, {
 			flag:       "iso-url",
 			usage:      "Locations to fetch the minikube ISO from. The list depends on the machine architecture.",

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -89,7 +89,7 @@ type ClusterConfig struct {
 	ExtraDisks              int // currently only implemented for hyperkit and kvm2
 	CertExpiration          time.Duration
 	Mount                   bool
-	MountString             string
+	MountStrings            []string
 	Mount9PVersion          string
 	MountGID                string
 	MountIP                 string

--- a/pkg/minikube/node/config.go
+++ b/pkg/minikube/node/config.go
@@ -77,7 +77,7 @@ func configureMounts(wg *sync.WaitGroup, cc config.ClusterConfig) {
 		return
 	}
 
-	out.Step(style.Mounting, "Creating mount {{.name}} ...", out.V{"name": cc.MountString})
+	out.Step(style.Mounting, "Creating mount {{.name}} ...", out.V{"name": cc.MountStrings})
 	path := os.Args[0]
 	profile := viper.GetString("profile")
 

--- a/pkg/minikube/node/config.go
+++ b/pkg/minikube/node/config.go
@@ -102,7 +102,8 @@ func generateMountArgs(profile string, cc config.ClusterConfig) []string {
 		mountDebugVal = 1
 	}
 
-	args := []string{"mount", cc.MountString}
+	args := []string{"mount"}
+	args = append(args, cc.MountStrings...)
 	flags := []struct {
 		name  string
 		value string

--- a/site/content/en/docs/commands/mount.md
+++ b/site/content/en/docs/commands/mount.md
@@ -14,7 +14,11 @@ Mounts the specified directory into minikube
 Mounts the specified directory into minikube.
 
 ```shell
-minikube mount [flags] <source directory>:<target directory>
+minikube mount [flags] <source directory>:<target directory>[;<source directory>:<target directory>;...]
+
+Example:
+   minikube mount /hostdir1:/vmdir1
+   minikube mount "/hostdir1:/vmdir1;/hostdir2:/vmdir2"
 ```
 
 ### Options

--- a/site/content/en/docs/commands/start.md
+++ b/site/content/en/docs/commands/start.md
@@ -88,7 +88,7 @@ minikube start [flags]
       --mount-msize int                   The number of bytes to use for 9p packet payload (default 262144)
       --mount-options strings             Additional mount options, such as cache=fscache
       --mount-port uint16                 Specify the port that the mount should be setup on, where 0 means any free port.
-      --mount-string string               The argument to pass the minikube mount command on start.
+      --mount-string string               The argument to pass the minikube mount command on start, in a semicolon-separated format. (eg. /foo:/foo;/bar:/bar:Z,rshared)
       --mount-type string                 Specify the mount filesystem type (supported types: 9p) (default "9p")
       --mount-uid string                  Default user id used for the mount (default "docker")
       --namespace string                  The named space to activate after start (default "default")

--- a/third_party/go9p/srv_srv.go
+++ b/third_party/go9p/srv_srv.go
@@ -33,6 +33,7 @@ var Ebadoffset error = &Error{"bad offset in directory read", EINVAL}
 var Edirchange error = &Error{"cannot convert between files and directories", EINVAL}
 var Enouser error = &Error{"unknown user", EINVAL}
 var Enotimpl error = &Error{"not implemented", EINVAL}
+var Einvalidrootid error = &Error{"invalid root index", EINVAL}
 
 // Authentication operations. The file server should implement them if
 // it requires user authentication. The authentication in 9P2000 is

--- a/third_party/go9p/ufs/ufs.go
+++ b/third_party/go9p/ufs/ufs.go
@@ -11,11 +11,12 @@ import (
 	"k8s.io/minikube/third_party/go9p"
 )
 
-func StartServer(addrVal string, debugVal int, rootVal string) {
+func StartServer(addrVal string, debugVal int, rootVals []string) {
 	ufs := new(go9p.Ufs)
 	ufs.Dotu = true
 	ufs.Id = "ufs"
-	ufs.Root = rootVal
+	ufs.Root = rootVals
+	ufs.RootIdx = 0
 	ufs.Debuglevel = debugVal
 	ufs.Start(ufs)
 

--- a/third_party/go9p/ufs_darwin.go
+++ b/third_party/go9p/ufs_darwin.go
@@ -185,7 +185,7 @@ func (u *Ufs) Wstat(req *SrvReq) {
 		// cwd.
 		var destpath string
 		if dir.Name[0] == '/' {
-			destpath = path.Join(u.Root, dir.Name)
+			destpath = path.Join(fid.root, dir.Name)
 			fmt.Printf("/ results in %s\n", destpath)
 		} else {
 			fiddir, _ := path.Split(fid.path)

--- a/third_party/go9p/ufs_freebsd.go
+++ b/third_party/go9p/ufs_freebsd.go
@@ -185,7 +185,7 @@ func (u *Ufs) Wstat(req *SrvReq) {
 		// cwd.
 		var destpath string
 		if dir.Name[0] == '/' {
-			destpath = path.Join(u.Root, dir.Name)
+			destpath = path.Join(fid.root, dir.Name)
 			fmt.Printf("/ results in %s\n", destpath)
 		} else {
 			fiddir, _ := path.Split(fid.path)

--- a/third_party/go9p/ufs_linux.go
+++ b/third_party/go9p/ufs_linux.go
@@ -181,7 +181,7 @@ func (u *Ufs) Wstat(req *SrvReq) {
 		// cwd.
 		var destpath string
 		if dir.Name[0] == '/' {
-			destpath = path.Join(u.Root, dir.Name)
+			destpath = path.Join(fid.root, dir.Name)
 			fmt.Printf("/ results in %s\n", destpath)
 		} else {
 			fiddir, _ := path.Split(fid.path)

--- a/third_party/go9p/ufs_windows.go
+++ b/third_party/go9p/ufs_windows.go
@@ -197,7 +197,7 @@ func (u *Ufs) Wstat(req *SrvReq) {
 		// cwd.
 		var destpath string
 		if dir.Name[0] == '/' {
-			destpath = path.Join(u.Root, dir.Name)
+			destpath = path.Join(fid.root, dir.Name)
 			fmt.Printf("/ results in %s\n", destpath)
 		} else {
 			fiddir, _ := path.Split(fid.path)


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

When using `minikube start`, we can pass in multiple paths that we want to mount inside the container through the `mount-string` parameter, for example:

```bash
minikube start --mount --mount-string="/data01:/data01;/data02:/data02:Z,rshared"
```
