### PR TITLE
test: use alpine for gvsior image in testdata

### DIFF
--- a/test/integration/testdata/gvisor-addon-Dockerfile
+++ b/test/integration/testdata/gvisor-addon-Dockerfile
@@ -15,6 +15,5 @@
 # Need an image with chroot
 FROM alpine:3
 RUN apk -U add ca-certificates
-COPY --from=builder /app/gvisor-addon /gvisor-addon
 COPY gvisor-addon /gvisor-addon
 CMD ["/gvisor-addon"]

--- a/test/integration/testdata/gvisor-addon-Dockerfile
+++ b/test/integration/testdata/gvisor-addon-Dockerfile
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:18.04
-RUN apt-get update && \
-    apt-get install -y kmod gcc wget xz-utils libc6-dev bc libelf-dev bison flex openssl libssl-dev libidn2-0 sudo libcap2 && \
-    rm -rf /var/lib/apt/lists/*
+# Need an image with chroot
+FROM alpine:3
+RUN apk -U add ca-certificates
+COPY --from=builder /app/gvisor-addon /gvisor-addon
 COPY gvisor-addon /gvisor-addon
 CMD ["/gvisor-addon"]


### PR DESCRIPTION
the original gvisor image uses alpine but in our test data we build it using ubuntu every single time, will speed up the test 