### PR TITLE
fix dirty commit version 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ test/integration/testdata/minikube-linux-amd64-latest-stable
 hack/legacy_fill_db/gopogh_filldb_log.txt
 hack/legacy_fill_db/out/output_summary.json
 hack/legacy_fill_db/out/output.html
+hack/go-licenses

--- a/hack/jenkins/release_build_and_upload.sh
+++ b/hack/jenkins/release_build_and_upload.sh
@@ -77,15 +77,20 @@ env BUILD_IN_DOCKER=y \
   "out/docker-machine-driver-kvm2-${RPM_VERSION}-${RPM_REVISION}.x86_64.rpm"
 
 # check if 'commit: <commit-id>' line contains '-dirty' commit suffix
-BUILT_VERSION=$("out/minikube-$(go env GOOS)-$(go env GOARCH)" version)
-echo ${BUILT_VERSION}
+BUILT_VERSION="$(out/minikube-$(go env GOOS)-$(go env GOARCH) version)"
+echo "$BUILT_VERSION"
+# Extract commit hash from the correct line
+COMMIT=$(echo "$BUILT_VERSION" | grep '^commit:' | awk '{print $2}')
 
-COMMIT=$(echo ${BUILT_VERSION} | grep 'commit:' | awk '{print $2}')
-if (echo ${COMMIT} | grep -q dirty); then
-  echo "'minikube version' reports dirty commit: ${COMMIT}"
+if echo "$COMMIT" | grep -q dirty; then
+  echo "'minikube version' reports dirty commit: $COMMIT"
+  echo ""
+  echo "The following uncommitted changes are causing the build to be dirty:"
+  git status --porcelain
+  echo ""
+  echo "To fix this, commit or stash the above changes."
   exit 1
 fi
-
 # Don't upload temporary copies, avoid unused duplicate files in the release storage
 rm -f out/minikube-linux-x86_64
 rm -f out/minikube-linux-i686

--- a/hack/jenkins/release_build_and_upload.sh
+++ b/hack/jenkins/release_build_and_upload.sh
@@ -84,10 +84,10 @@ COMMIT=$(echo "$BUILT_VERSION" | grep '^commit:' | awk '{print $2}')
 
 if echo "$COMMIT" | grep -q dirty; then
   echo "'minikube version' reports dirty commit: $COMMIT"
-  echo ""
+  echo "------------------------------------------------------------------------"
   echo "The following uncommitted changes are causing the build to be dirty:"
   git status --porcelain
-  echo ""
+  echo "------------------------------------------------------------------------"
   echo "To fix this, commit or stash the above changes."
   exit 1
 fi


### PR DESCRIPTION
## Before This PR (doesnt fail)
```
$ ./dirt.sh 
minikube version: v1.36.0 commit: 81c6d3b625553d20e310b911b70eafd781fbf708-dirty
```
## After this PR
```
minikube version: v1.36.0
commit: 81c6d3b625553d20e310b911b70eafd781fbf708-dirty
'minikube version' reports dirty commit: 81c6d3b625553d20e310b911b70eafd781fbf708-dirty
------------------------------------------------------------------------
The following uncommitted changes are causing the build to be dirty:
 M hack/jenkins/release_build_and_upload.sh
?? dirt.sh
------------------------------------------------------------------------
To fix this, commit or stash the above changes.
```
closes https://github.com/kubernetes/minikube/issues/20930
