### PR TITLE
Add a default cluster dns name config

### DIFF
--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -172,6 +172,10 @@ var settings = []Setting{
 		name: config.MaxAuditEntries,
 		set:  SetInt,
 	},
+	{
+		name: config.DefaultDNSDomain,
+		set:  SetString,
+	},
 }
 
 // ConfigCmd represents the config command

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -331,6 +331,7 @@ func setupViper() {
 	viper.SetDefault(config.WantVirtualBoxDriverWarning, true)
 	viper.SetDefault(config.MaxAuditEntries, 1000)
 	viper.SetDefault(config.SkipAuditFlag, false)
+	viper.SetDefault(config.DefaultDNSDomain, constants.DefaultDNSDomain)
 }
 
 func addToPath(dir string) {

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -225,7 +225,7 @@ func initKubernetesFlags() {
 		Valid components are: kubelet, kubeadm, apiserver, controller-manager, etcd, proxy, scheduler
 		Valid kubeadm parameters: `+fmt.Sprintf("%s, %s", strings.Join(bsutil.KubeadmExtraArgsAllowed[bsutil.KubeadmCmdParam], ", "), strings.Join(bsutil.KubeadmExtraArgsAllowed[bsutil.KubeadmConfigParam], ",")))
 	startCmd.Flags().String(featureGates, "", "A set of key=value pairs that describe feature gates for alpha/experimental features.")
-	startCmd.Flags().String(dnsDomain, constants.ClusterDNSDomain, "The cluster dns domain name used in the Kubernetes cluster")
+	startCmd.Flags().String(dnsDomain, constants.DefaultDNSDomain, "The cluster dns domain name used in the Kubernetes cluster")
 	startCmd.Flags().Int(apiServerPort, constants.APIServerPort, "The apiserver listening port")
 	startCmd.Flags().String(apiServerName, constants.APIServerName, "The authoritative apiserver hostname for apiserver certificates and connectivity. This can be used if you want to make the apiserver available from outside the machine")
 	startCmd.Flags().StringSliceVar(&apiServerNames, "apiserver-names", nil, "A set of apiserver names which are used in the generated certificate for kubernetes.  This can be used if you want to make the apiserver available from outside the machine")
@@ -586,6 +586,9 @@ func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, rtime str
 		out.WarningT("--network flag is only valid with the docker/podman, qemu, kvm, and vfkit drivers, it will be ignored")
 	}
 
+	clusterDNSDomain := viper.GetString(config.DefaultDNSDomain)
+	updateStringFromFlag(cmd, &clusterDNSDomain, dnsDomain)
+
 	validateHANodeCount(cmd)
 
 	checkNumaCount(k8sVersion)
@@ -662,7 +665,7 @@ func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, rtime str
 			APIServerName:          viper.GetString(apiServerName),
 			APIServerNames:         apiServerNames,
 			APIServerIPs:           apiServerIPs,
-			DNSDomain:              viper.GetString(dnsDomain),
+			DNSDomain:              clusterDNSDomain,
 			FeatureGates:           viper.GetString(featureGates),
 			ContainerRuntime:       rtime,
 			CRISocket:              viper.GetString(criSocket),

--- a/pkg/minikube/bootstrapper/certs_test.go
+++ b/pkg/minikube/bootstrapper/certs_test.go
@@ -37,7 +37,7 @@ func TestSetupCerts(t *testing.T) {
 		CertExpiration: constants.DefaultCertExpiration,
 		KubernetesConfig: config.KubernetesConfig{
 			APIServerName: constants.APIServerName,
-			DNSDomain:     constants.ClusterDNSDomain,
+			DNSDomain:     constants.DefaultDNSDomain,
 			ServiceCIDR:   constants.DefaultServiceCIDR,
 		},
 	}

--- a/pkg/minikube/config/config.go
+++ b/pkg/minikube/config/config.go
@@ -59,6 +59,9 @@ const (
 	EmbedCerts = "EmbedCerts"
 	// MaxAuditEntries is the maximum number of audit entries to retain
 	MaxAuditEntries = "MaxAuditEntries"
+	// DefaultDnsDomain is the key for the default dns domain name when creating
+	// a cluster
+	DefaultDNSDomain = "default-dns-domain"
 )
 
 var (

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -79,7 +79,7 @@ const (
 	// APIServerName is the default API server name
 	APIServerName = "minikubeCA"
 	// ClusterDNSDomain is the default DNS domain
-	ClusterDNSDomain = "cluster.local"
+	DefaultDNSDomain = "cluster.local"
 	// DefaultServiceCIDR is The CIDR to be used for service cluster IPs
 	DefaultServiceCIDR = "10.96.0.0/12"
 	// HostAlias is a DNS alias to the container/VM host IP

--- a/site/content/en/docs/commands/config.md
+++ b/site/content/en/docs/commands/config.md
@@ -41,7 +41,7 @@ Configurable fields:
  * native-ssh
  * rootless
  * MaxAuditEntries
-
+ * default-dns-domain - the default cluster top-level domain name (default "cluster.local")
 ```shell
 minikube config SUBCOMMAND [flags]
 ```
@@ -49,8 +49,7 @@ minikube config SUBCOMMAND [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
+      --add_dir_header                   If true, adds the file directory to the header of the lo      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -b, --bootstrapper string              The name of the cluster bootstrapper that will set up the Kubernetes cluster. (default "kubeadm")
   -h, --help                             
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
@@ -69,6 +68,17 @@ minikube config SUBCOMMAND [flags]
   -v, --v Level                          number for the log level verbosity
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
 ```
+
+### What the config fields mean
+
+#### default-dns-domain - the default cluster top-level domain name
+
+The default is "cluster.local". This configuration field will only affect a newly started cluster.
+When restarting a cluster with the `start` subcommand, this configuration field will not change a domain
+name for that cluster.
+
+You can override this setting by using the `--dns-domain` flagfor the `start` subcommand. The `--dns-domain`
+can also change the domain name when restarting a cluster.
 
 ## minikube config defaults
 
@@ -306,4 +316,3 @@ minikube config view [flags]
   -v, --v Level                          number for the log level verbosity
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
 ```
-

--- a/test/integration/domain_test.go
+++ b/test/integration/domain_test.go
@@ -1,0 +1,178 @@
+//go:build integration && linux
+
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+)
+
+// Test to make sure the default domain works as intended
+func TestDefaultDomainName(t *testing.T) {
+	// MaybeParallel(t)
+
+	profile := UniqueProfileName("domain-default")
+	ctx, cancel := context.WithTimeout(context.Background(), Minutes(10))
+	defer CleanupWithLogs(t, profile, cancel)
+
+	startArgs := append([]string{Target(), "start", "-p", profile, "--wait=apiserver,system_pods,default_sa"}, StartArgs()...)
+	rr, err := Run(t, exec.CommandContext(ctx, "/usr/bin/env", startArgs...))
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Command(), err)
+	}
+
+	rr, err = Run(t, exec.CommandContext(ctx, KubectlBinary(), "--context", profile, "run", "busybox", "--rm", "--restart=Never", "--image=gcr.io/k8s-minikube/busybox", "-it", "--", "/bin/sh", "-c", "awk '$1 == \"search\" {print $2; if ($2 !~ /\\.cluster\\.local$/) { print $2;exit 1}}' /etc/resolv.conf"))
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Command(), err)
+		t.Errorf("Output: %s", rr.Output())
+	}
+}
+
+// Test to make sure using dns-domain flag with no default-dns-domain config works as intended.
+func TestDnsDomainFlag(t *testing.T) {
+	// MaybeParallel(t)
+
+	profile := UniqueProfileName("domain-flag")
+	ctx, cancel := context.WithTimeout(context.Background(), Minutes(10))
+	defer CleanupWithLogs(t, profile, cancel)
+
+	startArgs := append([]string{Target(), "start", "-p", profile, "--dns-domain=flagcluster.example.com", "--wait=apiserver,system_pods,default_sa"}, StartArgs()...)
+	rr, err := Run(t, exec.CommandContext(ctx, "/usr/bin/env", startArgs...))
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Command(), err)
+	}
+
+	rr, err = Run(t, exec.CommandContext(ctx, KubectlBinary(), "--context", profile, "run", "busybox", "--rm", "--restart=Never", "--image=gcr.io/k8s-minikube/busybox", "-it", "--", "/bin/sh", "-c", "awk '$1 == \"search\" {print $2; if ($2 !~ /\\.flagcluster\\.example\\.com$/) { print $2;exit 1}}' /etc/resolv.conf"))
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Command(), err)
+		t.Errorf("Output: %s", rr.Output())
+	}
+
+	StopCluster(t, ctx, profile)
+
+	// make sure the dns domain doesn't change when no flag is given on subsequent start
+	startArgs = append([]string{Target(), "start", "-p", profile}, StartArgs()...)
+	rr, err = Run(t, exec.CommandContext(ctx, "/usr/bin/env", startArgs...))
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Command(), err)
+	}
+
+	rr, err = Run(t, exec.CommandContext(ctx, KubectlBinary(), "--context", profile, "run", "busybox", "--rm", "--restart=Never", "--image=gcr.io/k8s-minikube/busybox", "-it", "--", "/bin/sh", "-c", "awk '$1 == \"search\" {print $2; if ($2 !~ /\\.flagcluster\\.example\\.com$/) { print $2;exit 1}}' /etc/resolv.conf"))
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Command(), err)
+		t.Errorf("Output: %s", rr.Output())
+	}
+
+	StopCluster(t, ctx, profile)
+
+	// make sure the dns domain changes when a new flag is passed
+	startArgs = append([]string{Target(), "start", "-p", profile, "--dns-domain=flagcluster2.example.com"}, StartArgs()...)
+	rr, err = Run(t, exec.CommandContext(ctx, "/usr/bin/env", startArgs...))
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Command(), err)
+	}
+
+	rr, err = Run(t, exec.CommandContext(ctx, KubectlBinary(), "--context", profile, "run", "busybox", "--rm", "--restart=Never", "--image=gcr.io/k8s-minikube/busybox", "-it", "--", "/bin/sh", "-c", "awk '$1 == \"search\" {print $2; if ($2 !~ /\\.flagcluster2\\.example\\.com$/) { print $2;exit 1}}' /etc/resolv.conf"))
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Command(), err)
+		t.Errorf("Output: %s", rr.Output())
+	}
+
+}
+
+// Test to make sure using default-dns-domain config with no dns-domain flag works as intended.
+func TestDnsDomainConfig(t *testing.T) {
+	// MaybeParallel(t)
+
+	profile := UniqueProfileName("domain-config")
+	ctx, cancel := context.WithTimeout(context.Background(), Minutes(10))
+	defer CleanupWithLogs(t, profile, cancel)
+	defer CleanupConfig(t, ctx, "default-dns-domain")
+
+	SetConfig(t, ctx, "default-dns-domain", "configcluster.example.com")
+
+	startArgs := append([]string{Target(), "start", "-p", profile, "--wait=apiserver,system_pods,default_sa"}, StartArgs()...)
+	rr, err := Run(t, exec.CommandContext(ctx, "/usr/bin/env", startArgs...))
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Command(), err)
+	}
+
+	rr, err = Run(t, exec.CommandContext(ctx, KubectlBinary(), "--context", profile, "run", "busybox", "--rm", "--restart=Never", "--image=gcr.io/k8s-minikube/busybox", "-it", "--", "/bin/sh", "-c", "awk '$1 == \"search\" {print $2; if ($2 !~ /\\.configcluster\\.example\\.com$/) { print $2;exit 1}}' /etc/resolv.conf"))
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Command(), err)
+		t.Errorf("Output: %s", rr.Output())
+	}
+
+	StopCluster(t, ctx, profile)
+
+	// changing config doesn't change dns domain of restarted cluster
+	SetConfig(t, ctx, "default-dns-domain", "configcluster2.example.com")
+
+	startArgs = append([]string{Target(), "start", "-p", profile}, StartArgs()...)
+	rr, err = Run(t, exec.CommandContext(ctx, "/usr/bin/env", startArgs...))
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Command(), err)
+	}
+
+	rr, err = Run(t, exec.CommandContext(ctx, KubectlBinary(), "--context", profile, "run", "busybox", "--rm", "--restart=Never", "--image=gcr.io/k8s-minikube/busybox", "-it", "--", "/bin/sh", "-c", "awk '$1 == \"search\" {print $2; if ($2 !~ /\\.configcluster\\.example\\.com$/) { print $2;exit 1}}' /etc/resolv.conf"))
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Command(), err)
+		t.Errorf("Output: %s", rr.Output())
+	}
+
+	StopCluster(t, ctx, profile)
+
+	//should not change when removing the config
+	CleanupConfig(t, ctx, "default-dns-domain")
+
+	startArgs = append([]string{Target(), "start", "-p", profile}, StartArgs()...)
+	rr, err = Run(t, exec.CommandContext(ctx, "/usr/bin/env", startArgs...))
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Command(), err)
+	}
+
+	rr, err = Run(t, exec.CommandContext(ctx, KubectlBinary(), "--context", profile, "run", "busybox", "--rm", "--restart=Never", "--image=gcr.io/k8s-minikube/busybox", "-it", "--", "/bin/sh", "-c", "awk '$1 == \"search\" {print $2; if ($2 !~ /\\.configcluster\\.example\\.com$/) { print $2;exit 1}}' /etc/resolv.conf"))
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Command(), err)
+		t.Errorf("Output: %s", rr.Output())
+	}
+}
+
+// Test to make sure using dns-domain flash with default-dns-domain config works as intended.
+func TestDnsDomainFlagAndDefaultDnsDomainConfig(t *testing.T) {
+	profile := UniqueProfileName("domain-flag-and-config")
+	ctx, cancel := context.WithTimeout(context.Background(), Minutes(10))
+	defer CleanupWithLogs(t, profile, cancel)
+	defer CleanupConfig(t, ctx, "default-dns-domain")
+
+	SetConfig(t, ctx, "default-dns-domain", "configcluster.example.com")
+
+	startArgs := append([]string{Target(), "start", "-p", profile, "--wait=apiserver,system_pods,default_sa", "--dns-domain=flagcluster.example.com"}, StartArgs()...)
+	rr, err := Run(t, exec.CommandContext(ctx, "/usr/bin/env", startArgs...))
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Command(), err)
+	}
+
+	rr, err = Run(t, exec.CommandContext(ctx, KubectlBinary(), "--context", profile, "run", "busybox", "--rm", "--restart=Never", "--image=gcr.io/k8s-minikube/busybox", "-it", "--", "/bin/sh", "-c", "awk '$1 == \"search\" {print $2; if ($2 !~ /\\.flagcluster\\.example\\.com$/) { print $2;exit 1}}' /etc/resolv.conf"))
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Command(), err)
+		t.Errorf("Output: %s", rr.Output())
+	}
+}

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -728,3 +728,32 @@ func FailFastDockerHubRateLimited(t *testing.T) {
 		t.Fatalf("failing fast: Docker Hub rate limit reached (remaining=%d)", remaining)
 	}
 }
+
+// Unset config setting
+func CleanupConfig(t *testing.T, ctx context.Context, config string) {
+	unsetConfigArgs := []string{Target(), "config", "unset", config}
+	rr, err := Run(t, exec.CommandContext(ctx, "/usr/bin/env", unsetConfigArgs...))
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Command(), err)
+	}
+
+}
+
+// Set config setting
+func SetConfig(t *testing.T, ctx context.Context, config string, value string) {
+	setConfigArgs := []string{Target(), "config", "set", config, value}
+	rr, err := Run(t, exec.CommandContext(ctx, "/usr/bin/env", setConfigArgs...))
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Command(), err)
+	}
+
+}
+
+// Stop cluster.
+func StopCluster(t *testing.T, ctx context.Context, profile string) {
+	stopArgs := []string{Target(), "stop", "-p", profile}
+	rr, err := Run(t, exec.CommandContext(ctx, "/usr/bin/env", stopArgs...))
+	if err != nil {
+		t.Errorf("%s failed: %v", rr.Command(), err)
+	}
+}


### PR DESCRIPTION
Add a default cluster DNS name config

It is very handy to be able to store the default cluster DNS name so
that I can fire up and teardown clusters easily without losing that
setting. You can think of this as a default value for the
`start --dns-domain <val>` flag, but only when starting a new cluster.

In my particular case, I would like to set my default cluster dna domain
to a subdomain under a domain that I control. E.g.
`cluster.wt.user.dev.example.com`. I want to do this to make it easier
to manage TLS certs for my dev cluster.

For context, the `start --dns-domain <val>` flag works like this:
  If you fire up a new cluster with that flag, you will get a new cluster
  with the domain name base. If you start an existing cluster, the
  config will be updated to the new domain name base and then started.

This config will work a little differently. The change implements a
config that will only affect newly started cluster. Here are some
examples to show that difference:

Newly started cluster example:
```
$ minikube config set DefaultDNSDomain cluster2.local
$ minikube start
...
```

Stop and starting the cluster with `--dns-domain` flag:
```
$ minikube stop
...
$ minikub start --dns-domain cluster3.local
...
```

Stopping and starting a new cluster with a non-default domain name and
without the `--dns-domain` flag:
```
$ minikube stop
...
$ minikub start
...
```

The reason for this behavior is that I am not configuring the name of a
cluster. That is a cluster configuration option. I am setting the
default for that.

If I manually overrode the name of a cluster when started previously, I
don't want a default option to override my cluster configuration.

Before:
  User cannot cannot change the default DNS domain name for a cluster
  to something other than cluster.local.

  On cluster creation/start:
    If a user runs `minikube start` without a `--dnsDomain` flag, the
    cluster will have the dns domain "cluster.local". A cluster setting
    is persisted.

    If a user runs 'minikube start --dnsDomain cluster.example.com`, the
    cluster will hae the dns domain "cluster.example.com". A cluster
    setting is persisted.

  On cluster restart:
    If a user run `minikube start`, the cluster's existing dns domain
    (pulled from the persisted cluster config) dns domain will be used.

    If a user runs `minikube start --dnsDomain cluster.example.com`, the
    cluster's persisted dns name will be updated to the new name and the
    cluster will be started with the new domain ("cluster.example.com").

  Example command sequence:
  ```
  $ minikube start --dnsDomain=cluster.example.com
  # cluster now has dns domain "cluster.example.com"
  $ minikube delete
  $ minikube start
  # cluster now has dns domain "cluster.local"
  ```

After:
  The behavior of the minikube start flag `--dns-domain` does not
  change at all. When the new configuration value is not set, all of the
  behaviors from the "Before" section above will not change.

  User can set the default cluster domain name to whatever they want
  via the config option DefaultDNSDomain. E.g.:
  `minikube config set DefaultDNSDomain cluster.wt.users.dev.example.com`

  Since the case with no configuration is the same as before, here is a
  description of what happens only with the new configuration set like
  above.

  On cluster creation/start:
    If a user runs `minikube start` without a `--dnsDomain` flag, the
    cluster will have the dns domain "cluster.wt.users.dev.example.com".
    A cluster setting is persisted. This is the only thing that changes
    with the configuration option set.

    If a user runs 'minikube start --dnsDomain cluster.example.com`, the
    cluster will hae the dns domain "cluster.example.com". A cluster
    setting is persisted.

  On cluster restart:
    If a user run `minikube start`, the cluster's existing dns domain
    (pulled from the persisted cluster config not from the new config)
    dns domain will be used.

    If a user runs `minikube start --dnsDomain cluster.example.com`, the
    cluster's persisted dns name will be updated to the new name and the
    cluster will be started with the new domain ("cluster.example.com").

  Notice that the only case that changes with the new setting defined is
  the case of starting a new cluster. Setting the config will change the
  behavior of the "Before -> Example command sequence" section as
  described:

  Example command sequence:
  ```
  $ minikube config set DefaultDNSDomain cluster.wt.users.dev.example.com
  $ minikube start --dnsDomain=cluster.example.com
  # cluster now has dns domain "cluster.example.com"
  $ minikube delete
  $ minikube start
  # cluster now has dns domain "cluster.wt.users.dev.example.com"
  ```

  The important piece here is that I can now change the default
  dnsDomain so that I don't have to specify it explicitly. This is
  useful when I am starting and deleting a single cluster where I want
  the top-level domain default to be a subdomain of a domain I control.