### PR TITLE
ci: Add vfkit smoke test

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -88,9 +88,9 @@ jobs:
           HOMEBREW=$(which brew) && sudo ${HOMEBREW} services start socket_vmnet
       - name: Minikube Download only (iso/image)
         run:
-          ./out/minikube start --download-only --driver=${{ matrix.driver }}
+          ./out/minikube start --download-only --driver ${{ matrix.driver }}
       - name: Start minikube (1st boot)
-        run: ./out/minikube start --driver=${{ matrix.driver }} ${{ matrix.network_flag }} --memory 4gb --no-kubernetes --alsologtostderr
+        run: ./out/minikube start --driver ${{ matrix.driver }} ${{ matrix.network_flag }} --memory 4gb --no-kubernetes --alsologtostderr
       - name: Stop minikube
         run: ./out/minikube stop
       - name: Start minikube again (2nd boot)

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -68,8 +68,8 @@ jobs:
         run: go mod download
       - name: Build Binaries
         run: make
-      - name: Ensure bootpd is enabled
-        if: contains(matrix.os, 'macos')
+      - name: Ensure bootpd is enabled (macos)
+        if: matrix.os == 'macos-13'
         shell: bash
         run: |
           set -x
@@ -77,12 +77,11 @@ jobs:
           sudo $fw --remove /usr/libexec/bootpd
           sudo $fw --add /usr/libexec/bootpd
           sudo $fw --unblock /usr/libexec/bootpd
-      - name: brew update
-        if: contains(matrix.os, 'macos')
-        run:
-          brew update
+      - name: Update brew (macos)
+        if: matrix.os == 'macosi-13'
+        run: brew update
       - name: Install qemu and socket_vmnet (macos)
-        if: contains(matrix.os, 'macos') && matrix.driver == 'qemu'
+        if: matrix.os == 'macos-13' && matrix.driver == 'qemu'
         run: |
           brew install qemu socket_vmnet
           HOMEBREW=$(which brew) && sudo ${HOMEBREW} services start socket_vmnet

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -85,15 +85,15 @@ jobs:
         if: contains(matrix.os, 'macos') && matrix.driver == 'qemu'
         run: |
           brew install qemu socket_vmnet
-          HOMEBREW=$(which brew) && sudo ${HOMEBREW} services start socket_vmnet          
+          HOMEBREW=$(which brew) && sudo ${HOMEBREW} services start socket_vmnet
       - name: Minikube Download only (iso/image)
         run:
-          ./out/minikube start --download-only --driver=${{ matrix.driver }} 
+          ./out/minikube start --download-only --driver=${{ matrix.driver }}
       - name: Start minikube (1st boot)
-        run: ./out/minikube start --driver=${{ matrix.driver }} ${{ matrix.network_flag }} --memory 4gb --no-kubernetes --alsologtostderr 
+        run: ./out/minikube start --driver=${{ matrix.driver }} ${{ matrix.network_flag }} --memory 4gb --no-kubernetes --alsologtostderr
       - name: Stop minikube
         run: ./out/minikube stop
       - name: Start minikube again (2nd boot)
         run: ./out/minikube start --alsologtostderr
-      - name: delete minikube 
+      - name: delete minikube
         run: ./out/minikube delete --alsologtostderr

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -20,6 +20,9 @@ jobs:
           - driver: qemu
             os: macos-13
             network_flag: --network socket_vmnet
+          - driver: vfkit
+            os: macos-13
+            network_flag: --network vmnet-shared
           - driver: docker
             os: ubuntu-24.04
             network_flag: ""
@@ -83,6 +86,15 @@ jobs:
       - name: Install tools (macos)
         if: matrix.os == 'macos-13'
         run: brew install tree
+      - name: Install vfkit and vmnet-helper (macos)
+        if: matrix.driver == 'vfkit'
+        run: |
+          brew install vfkit
+          machine="$(uname -m)"
+          archive="vmnet-helper-$machine.tar.gz"
+          curl -LOf "https://github.com/nirs/vmnet-helper/releases/latest/download/$archive"
+          sudo tar xvf "$archive" -C / opt/vmnet-helper
+          sudo install -m 0640 /opt/vmnet-helper/share/doc/vmnet-helper/sudoers.d/vmnet-helper /etc/sudoers.d/
       - name: Install qemu and socket_vmnet (macos)
         if: matrix.os == 'macos-13' && matrix.driver == 'qemu'
         run: |

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -101,11 +101,14 @@ jobs:
         run: |
           brew install qemu socket_vmnet
           HOMEBREW=$(which brew) && sudo ${HOMEBREW} services start socket_vmnet
-      - name: Minikube Download only (iso/image)
-        run:
-          ./out/minikube start --download-only --driver ${{ matrix.driver }} ${{ env.LOG_ARGS }}
       - name: Start minikube (1st boot)
-        run: ./out/minikube start --driver ${{ matrix.driver }} ${{ matrix.network_flag }} --memory 4gb --no-kubernetes ${{ env.LOG_ARGS }}
+        run: |
+          ./out/minikube start \
+              --no-kubernetes \
+              --memory 4gb \
+              --driver ${{ matrix.driver }} \
+              ${{ matrix.network_flag }} \
+              ${{ env.LOG_ARGS }}
       - name: Inspect minikube
         if: always()
         run: |
@@ -121,5 +124,5 @@ jobs:
         run: ./out/minikube stop ${{ env.LOG_ARGS }}
       - name: Start minikube again (2nd boot)
         run: ./out/minikube start ${{ env.LOG_ARGS }}
-      - name: delete minikube
+      - name: Delete minikube
         run: ./out/minikube delete ${{ env.LOG_ARGS }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -78,8 +78,11 @@ jobs:
           sudo $fw --add /usr/libexec/bootpd
           sudo $fw --unblock /usr/libexec/bootpd
       - name: Update brew (macos)
-        if: matrix.os == 'macosi-13'
+        if: matrix.os == 'macos-13'
         run: brew update
+      - name: Install tools (macos)
+        if: matrix.os == 'macos-13'
+        run: brew install tree
       - name: Install qemu and socket_vmnet (macos)
         if: matrix.os == 'macos-13' && matrix.driver == 'qemu'
         run: |
@@ -90,6 +93,17 @@ jobs:
           ./out/minikube start --download-only --driver ${{ matrix.driver }}
       - name: Start minikube (1st boot)
         run: ./out/minikube start --driver ${{ matrix.driver }} ${{ matrix.network_flag }} --memory 4gb --no-kubernetes --alsologtostderr
+      - name: Inspect minikube
+        if: always()
+        run: |
+          tree -h ~/.minikube
+          machine="$HOME/.minikube/machines/minikube"
+          machine_logs=$(find "$machine" -name "*.log")
+          minikube_logs="$HOME/.minikube/logs/lastStart.txt"
+          for f in $machine_logs $minikube_logs /var/db/dhcpd_leases; do
+            echo "==> $f <=="
+            head -n 1000 "$f" || true
+          done
       - name: Stop minikube
         run: ./out/minikube stop
       - name: Start minikube again (2nd boot)

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 env:
   GOPROXY: https://proxy.golang.org
+  LOG_ARGS: --v=8 --alsologtostderr
   permissions:
   contents: read
 jobs:
@@ -102,9 +103,9 @@ jobs:
           HOMEBREW=$(which brew) && sudo ${HOMEBREW} services start socket_vmnet
       - name: Minikube Download only (iso/image)
         run:
-          ./out/minikube start --download-only --driver ${{ matrix.driver }}
+          ./out/minikube start --download-only --driver ${{ matrix.driver }} ${{ env.LOG_ARGS }}
       - name: Start minikube (1st boot)
-        run: ./out/minikube start --driver ${{ matrix.driver }} ${{ matrix.network_flag }} --memory 4gb --no-kubernetes --alsologtostderr
+        run: ./out/minikube start --driver ${{ matrix.driver }} ${{ matrix.network_flag }} --memory 4gb --no-kubernetes ${{ env.LOG_ARGS }}
       - name: Inspect minikube
         if: always()
         run: |
@@ -117,8 +118,8 @@ jobs:
             head -n 1000 "$f" || true
           done
       - name: Stop minikube
-        run: ./out/minikube stop
+        run: ./out/minikube stop ${{ env.LOG_ARGS }}
       - name: Start minikube again (2nd boot)
-        run: ./out/minikube start --alsologtostderr
+        run: ./out/minikube start ${{ env.LOG_ARGS }}
       - name: delete minikube
-        run: ./out/minikube delete --alsologtostderr
+        run: ./out/minikube delete ${{ env.LOG_ARGS }}


### PR DESCRIPTION
Clean up the smoke test workflow a little bit and add a new vfkit smoke test.

The test is about much slower than running vfkit with Ubuntu 24.10 image in GitHub runners (as part of vmnet-helper integration tests), but it works most of the time, and it is much faster than the qemu test.

Example build: https://github.com/nirs/minikube/actions/runs/16405189904