### PR TITLE
optimize memory usage in image load with Docker client integration

### DIFF
--- a/pkg/minikube/image/image.go
+++ b/pkg/minikube/image/image.go
@@ -169,7 +169,7 @@ func retrieveImage(ref name.Reference, imgName string) (v1.Image, string, error)
 }
 
 func retrieveDaemon(ref name.Reference) (v1.Image, error) {
-	img, err := daemon.Image(ref)
+	img, err := daemon.Image(ref) // uses bufferedOpener, which may consume a significant amount of memory
 	if err == nil {
 		klog.Infof("found %s locally: %+v", ref.Name(), img)
 		return img, nil


### PR DESCRIPTION
Fix: #17785

Because bufferedOpener attempts to load the entire layer into memory, this issue occurs. See https://github.com/google/go-containerregistry/blob/main/pkg/v1/daemon/image.go#L71

This PR addresses high memory consumption issues during minikube image load operations by using docker client directly.

### Comparative Analysis: Minikube Image Load Performance


#### **Performance Metrics Summary**  
| **Metric**                  | **Original Method** (`minikube image load`) | **Modified Method** (`./out/minikube-linux-amd64`) | **Split Method** (`docker save` + `minikube image load`) |  
|-----------------------------|--------------------------------------------|--------------------------------------------------|--------------------------------------------------------|  
| **Total Elapsed Time**      | 104.91 s                                   | 23.37 s (↓77.7%)                                 | **18.25 s** (↓82.6%)                                   |  
| **User CPU Time**           | 81.23 s                                    | 1.12 s (↓98.6%)                                  | 1.18 s (↓98.5%)                                        |  
| **System CPU Time**         | 5.29 s                                     | 4.32 s (↓18.3%)                                  | 4.44 s (↓16.1%)                                        |  
| **Peak Memory (RSS)**       | 2,844 MB                                   | 90 MB (↓96.8%)                                   | 117 MB (↓95.9%)                                        |  
| **File System Outputs**     | 1,486,840 blocks                           | 2,678,848 blocks (↑80.2%)                        | 2,678,856 blocks (↑80.2%)                              |  
| **Minor Page Faults**       | 809,957                                    | 14,010 (↓98.3%)                                  | 17,001 (↓97.9%)                                        |  
| **Voluntary Context Switches** | 235,386                                 | 121,542 (↓48.4%)                                 | 165,825 (↓29.5%)                                       |  


---

```
Original :

/usr/bin/time -v -o output1.log minikube image load elasticsearch:9.0.3  --daemon=true

root@gpu-3090:~# cat  output1.log
        Command being timed: "minikube image load elasticsearch:9.0.3 --daemon=true"
        User time (seconds): 81.23
        System time (seconds): 5.29
        Percent of CPU this job got: 82%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 1:44.91
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 2844216
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 34
        Minor (reclaiming a frame) page faults: 809957
        Voluntary context switches: 235386
        Involuntary context switches: 356
        Swaps: 0
        File system inputs: 5848
        File system outputs: 1486840
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0

Modified 

	Command being timed: "./out/minikube-linux-amd64 image load elasticsearch:9.0.3 --daemon=true"
	User time (seconds): 1.12
	System time (seconds): 4.32
	Percent of CPU this job got: 23%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:23.37
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 90328
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 0
	Minor (reclaiming a frame) page faults: 14010
	Voluntary context switches: 121542
	Involuntary context switches: 120
	Swaps: 0
	File system inputs: 0
	File system outputs: 2678848
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
	
Split Command:

/usr/bin/time -v -o output1.log docker save elasticsearch:9.0.3 -o image.tar

        Command being timed: "docker save elasticsearch:9.0.3 -o image.tar"
        User time (seconds): 0.20
        System time (seconds): 2.86
        Percent of CPU this job got: 22%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:13.77
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 29464
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 2860
        Voluntary context switches: 106670
        Involuntary context switches: 11
        Swaps: 0
        File system inputs: 8
        File system outputs: 2678696
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0

 /usr/bin/time -v -o output2.log minikube image load image.tar
         Command being timed: "minikube image load image.tar"
        User time (seconds): 0.98
        System time (seconds): 1.58
        Percent of CPU this job got: 57%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:04.48
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 87716
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 1
        Minor (reclaiming a frame) page faults: 14141
        Voluntary context switches: 59155
        Involuntary context switches: 96
        Swaps: 0
        File system inputs: 0
        File system outputs: 160
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```
