### PR TITLE
Ensure ingress-dns pod is scheduled on the primary node

### DIFF
--- a/deploy/addons/ingress-dns/ingress-dns-pod.yaml.tmpl
+++ b/deploy/addons/ingress-dns/ingress-dns-pod.yaml.tmpl
@@ -74,6 +74,12 @@ metadata:
 spec:
   serviceAccountName: minikube-ingress-dns
   hostNetwork: true
+  nodeSelector:
+    minikube.k8s.io/primary: 'true'
+  tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Equal
   containers:
     - name: minikube-ingress-dns
       image: {{.CustomRegistries.IngressDNS | default .ImageRepository | default .Registries.IngressDNS }}{{.Images.IngressDNS}}


### PR DESCRIPTION
Re open of PR https://github.com/kubernetes/minikube/pull/17649

fixes https://github.com/kubernetes/minikube/issues/17648

Add nodeSelector for primary minikube node to ingress-dns pod template.
Add toleration for kubernetes master role.