### PR TITLE
Skip Kubernetes preloads and binary downloads when --no-kubernetes is… #21107

### DIFF
--- a/pkg/minikube/download/binary.go
+++ b/pkg/minikube/download/binary.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/pkg/errors"
+	"github.com/spf13/viper"
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/minikube/localpath"
 )
@@ -53,6 +54,11 @@ func binaryWithChecksumURL(binaryName, version, osName, archName, binaryURL stri
 
 // Binary will download a binary onto the host
 func Binary(binary, version, osName, archName, binaryURL string) (string, error) {
+	// Prevent Kubernetes binary downloads in --no-kubernetes mode
+	if viper.GetBool("no-kubernetes") {
+		klog.Infof("Skipping Kubernetes binary download due to --no-kubernetes flag")
+		return "", nil
+	}
 	targetDir := localpath.MakeMiniPath("cache", osName, archName, version)
 	targetFilepath := path.Join(targetDir, binary)
 	targetLock := targetFilepath + ".lock"

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -121,6 +121,11 @@ var checkRemotePreloadExists = func(k8sVersion, containerRuntime string) bool {
 
 // PreloadExists returns true if there is a preloaded tarball that can be used
 func PreloadExists(k8sVersion, containerRuntime, driverName string, forcePreload ...bool) bool {
+	// Prevent preload logic in --no-kubernetes mode
+	if viper.GetBool("no-kubernetes") {
+		klog.Infof("Skipping preload logic due to --no-kubernetes flag")
+		return false
+	}
 	// TODO (#8166): Get rid of the need for this and viper at all
 	force := false
 	if len(forcePreload) > 0 {


### PR DESCRIPTION
This PR improves the Binary function in binary.go to better handle Kubernetes binary downloads. It adds logic to skip downloads when the --no-kubernetes flag is set, ensures not downloading unnecessary downloads with version v0.0.0
Before
<img width="1220" height="133" alt="Screenshot 2025-07-25 at 1 05 43 PM" src="https://github.com/user-attachments/assets/10a207e7-7c0d-49a9-8167-4f2b4e6ced2b" />
After
<img width="901" height="154" alt="Screenshot 2025-07-25 at 1 08 30 PM" src="https://github.com/user-attachments/assets/e8179244-3d5c-4199-b31e-befef9dc95e6" />
This pr Fixes the issue #21107
