### PR TITLE
improve docker service reliability, update docker systemd files

### DIFF
--- a/pkg/minikube/cruntime/cruntime_test.go
+++ b/pkg/minikube/cruntime/cruntime_test.go
@@ -554,7 +554,7 @@ func (f *FakeRunner) systemctl(args []string, root bool) (string, error) { // no
 			f.t.Logf("fake systemctl: SvcRestarted %s", svc)
 		case "is-active":
 			f.t.Logf("fake systemctl: %s is-status: %v", svc, state)
-			if state == SvcRunning {
+			if state == SvcRunning || state == SvcRestarted {
 				return out, nil
 			}
 			return out, fmt.Errorf("%s in state: %v", svc, state)

--- a/pkg/provision/buildroot.go
+++ b/pkg/provision/buildroot.go
@@ -70,14 +70,16 @@ func (p *BuildrootProvisioner) GenerateDockerOptions(dockerPort int) (*provision
 		klog.Infof("root file system type: %s", fstype)
 		noPivot = fstype == "rootfs"
 	}
-
+	/* Template is copied from https://github.com/moby/moby/blob/44bca1adf3c806c4ed6688d67c6f995653b09b26/contrib/init/systemd/docker.service#L2 with the following changes:
+	   After: minikube-automount.service is added
+	   ExecStart: additional flags are added
+	*/
 	engineConfigTmpl := `[Unit]
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
-After=network.target  minikube-automount.service docker.socket
-Requires= minikube-automount.service docker.socket 
-StartLimitBurst=3
-StartLimitIntervalSec=60
+After=network-online.target minikube-automount.service nss-lookup.target docker.socket firewalld.service containerd.service time-set.target
+Wants=network-online.target containerd.service
+Requires=docker.socket
 
 [Service]
 Type=notify
@@ -94,18 +96,15 @@ Environment=DOCKER_RAMDISK=yes
 {{range .EngineOptions.Env}}Environment={{.}}
 {{end}}
 
-# This file is a systemd drop-in unit that inherits from the base dockerd configuration.
-# The base configuration already specifies an 'ExecStart=...' command. The first directive
-# here is to clear out that command inherited from the base configuration. Without this,
-# the command from the base configuration and the command specified here are treated as
-# a sequence of commands, which is not the desired behavior, nor is it valid -- systemd
-# will catch this invalid input and refuse to start the service with an error like:
-#  Service has more than one ExecStart= setting, which is only allowed for Type=oneshot services.
-
-# NOTE: default-ulimit=nofile is set to an arbitrary number for consistency with other
-# container runtimes. If left unlimited, it may result in OOM issues with MySQL.
 ExecStart=
-ExecStart=/usr/bin/dockerd -H tcp://0.0.0.0:2376 -H unix:///var/run/docker.sock --default-ulimit=nofile=1048576:1048576 --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}} {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
+ExecStart=/usr/bin/dockerd -H tcp://0.0.0.0:2376 \
+	-H fd:// --containerd=/run/containerd/containerd.sock \
+	-H unix:///var/run/docker.sock \
+	--default-ulimit=nofile=1048576:1048576 \
+	--tlsverify \
+	--tlscacert {{.AuthOptions.CaCertRemotePath}} \
+	--tlscert {{.AuthOptions.ServerCertRemotePath}} \
+	--tlskey {{.AuthOptions.ServerKeyRemotePath}} {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
 ExecReload=/bin/kill -s HUP \$MAINPID
 
 # Having non-zero Limit*s causes performance problems due to accounting overhead
@@ -117,13 +116,13 @@ LimitCORE=infinity
 # Uncomment TasksMax if your systemd version supports it.
 # Only systemd 226 and above support this version.
 TasksMax=infinity
-TimeoutStartSec=0
 
 # set delegate yes so that systemd does not reset the cgroups of docker containers
 Delegate=yes
 
 # kill only the docker process, not all processes in the cgroup
 KillMode=process
+OOMScoreAdjust=-500
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/provision/buildroot.go
+++ b/pkg/provision/buildroot.go
@@ -80,10 +80,11 @@ Documentation=https://docs.docker.com
 After=network-online.target minikube-automount.service nss-lookup.target docker.socket firewalld.service containerd.service time-set.target
 Wants=network-online.target containerd.service
 Requires=docker.socket
-
+StartLimitBurst=3
+StartLimitIntervalSec=60
 [Service]
 Type=notify
-Restart=on-failure
+Restart=always
 `
 	if noPivot {
 		klog.Warning("Using fundamentally insecure --no-pivot option")

--- a/pkg/provision/ubuntu.go
+++ b/pkg/provision/ubuntu.go
@@ -71,13 +71,18 @@ func (p *UbuntuProvisioner) GenerateDockerOptions(dockerPort int) (*provision.Do
 		klog.Infof("root file system type: %s", fstype)
 		noPivot = fstype == "rootfs"
 	}
+	/* Template is copied from https://github.com/moby/moby/blob/44bca1adf3c806c4ed6688d67c6f995653b09b26/contrib/init/systemd/docker.service#L2 with the following changes:
+	   ExecStart: additional flags are added
 
+	   StartLimitBurst=3 : The service can be restarted up to 3 times within the time window defined by StartLimitIntervalSec.
+
+	   StartLimitIntervalSec=60 : The time window is 60 seconds. If the service fails and restarts more than 3 times in 60 seconds, systemd will stop trying to restart it automatically.
+	*/
 	engineConfigTmpl := `[Unit]
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
-BindsTo=containerd.service
-After=network-online.target firewalld.service containerd.service
-Wants=network-online.target
+After=network-online.target nss-lookup.target docker.socket firewalld.service containerd.service time-set.target
+Wants=network-online.target containerd.service
 Requires=docker.socket
 StartLimitBurst=3
 StartLimitIntervalSec=60
@@ -108,7 +113,14 @@ Environment=DOCKER_RAMDISK=yes
 # NOTE: default-ulimit=nofile is set to an arbitrary number for consistency with other
 # container runtimes. If left unlimited, it may result in OOM issues with MySQL.
 ExecStart=
-ExecStart=/usr/bin/dockerd -H tcp://0.0.0.0:2376 -H unix:///var/run/docker.sock --default-ulimit=nofile=1048576:1048576 --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}} {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
+ExecStart=/usr/bin/dockerd -H tcp://0.0.0.0:2376 \
+	-H fd:// --containerd=/run/containerd/containerd.sock \
+	-H unix:///var/run/docker.sock \
+	--default-ulimit=nofile=1048576:1048576 \
+	--tlsverify \
+	--tlscacert {{.AuthOptions.CaCertRemotePath}} \
+	--tlscert {{.AuthOptions.ServerCertRemotePath}} \
+	--tlskey {{.AuthOptions.ServerKeyRemotePath}} {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
 ExecReload=/bin/kill -s HUP \$MAINPID
 
 # Having non-zero Limit*s causes performance problems due to accounting overhead
@@ -127,6 +139,7 @@ Delegate=yes
 
 # kill only the docker process, not all processes in the cgroup
 KillMode=process
+OOMScoreAdjust=-500
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/provision/ubuntu.go
+++ b/pkg/provision/ubuntu.go
@@ -89,7 +89,7 @@ StartLimitIntervalSec=60
 
 [Service]
 Type=notify
-Restart=on-failure
+Restart=always
 `
 	if noPivot {
 		klog.Warning("Using fundamentally insecure --no-pivot option")


### PR DESCRIPTION
Previous docker.service file generated by minikube is too old, and it does not wait for the containerd. This pr will update the docker.service according to the latest one.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
