### PR TITLE
CI: fix PR update titles missing version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1240,6 +1240,7 @@ update-kube-vip-version:
 	cd hack && go run update/kube_vip_version/update_kube_vip_version.go
 
 # used by update- Targets to get before/after versions of tools it updates
+# example usage echo "OLD_VERSION=$(DEP=node make get-dependency-version)" >> "$GITHUB_OUTPUT"
 .PHONY: get-dependency-verison
 get-dependency-version:
-	cd hack && go run update/get_version/get_version.go
+	@(cd hack && go run update/get_version/get_version.go)


### PR DESCRIPTION
to fix PRs like this
https://github.com/kubernetes/minikube/pull/21173

which the title was "the command"
```
site: Update node from cd hack && go run update/get_version/get_version.go to cd hack && go run update/get_version/get_version.go #21173
```