### PR TITLE
ci: get dep version fix

### DIFF
--- a/hack/update/get_version/get_version.go
+++ b/hack/update/get_version/get_version.go
@@ -90,7 +90,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("regexp failed to compile: %v", err)
 	}
-	data, err := os.ReadFile("../../../" + dep.filePath)
+	// because in the Makefile we run it as @(cd hack && go run update/get_version/get_version.go) we need ../
+	data, err := os.ReadFile("../" + dep.filePath)
 	if err != nil {
 		log.Fatalf("failed to read file: %v", err)
 	}


### PR DESCRIPTION
### Before this PR
```
$ DEP=node make get-dependency-version
2025/07/28 14:42:33 failed to read file: open ../../../netlify.toml: no such file or directory
exit status 1
make: *** [get-dependency-version] Error 1
```
example PR https://github.com/kubernetes/minikube/pull/21181


### After this PR
```
$ DEP=node make get-dependency-version
20.19.3
```