### PR TITLE
ci: use authenticated github when possible

### DIFF
--- a/hack/preload-images/kubernetes.go
+++ b/hack/preload-images/kubernetes.go
@@ -23,13 +23,14 @@ import (
 	"github.com/google/go-github/v73/github"
 
 	"k8s.io/klog/v2"
+	"k8s.io/minikube/hack/update"
 )
 
 // recentK8sVersions returns the most recent k8s version, usually around 100.
 func recentK8sVersions() ([]string, error) {
 	const k8s = "kubernetes"
-	client := github.NewClient(nil)
-	list, _, err := client.Repositories.ListReleases(context.Background(), k8s, k8s, &github.ListOptions{PerPage: 100})
+	ghc := update.GHClient()
+	list, _, err := ghc.Repositories.ListReleases(context.Background(), k8s, k8s, &github.ListOptions{PerPage: 100})
 	if err != nil {
 		return nil, err
 	}

--- a/hack/update/github.go
+++ b/hack/update/github.go
@@ -19,6 +19,7 @@ package update
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"golang.org/x/mod/semver"
@@ -43,7 +44,7 @@ type Release struct {
 // GHReleases returns greatest current stable release and greatest latest rc or beta pre-release from GitHub owner/repo repository, and any error occurred.
 // If latest pre-release version is lower than the current stable release, then it will return current stable release for both.
 func GHReleases(ctx context.Context, owner, repo string) (stable, latest, edge Release, err error) {
-	ghc := github.NewClient(nil)
+	ghc := GHClient()
 
 	// walk through the paginated list of up to ghSearchLimit newest releases
 	opts := &github.ListOptions{PerPage: ghListPerPage}
@@ -106,4 +107,13 @@ func StableVersion(ctx context.Context, owner, repo string) (string, error) {
 		return "", err
 	}
 	return stable.Tag, nil
+}
+
+// GHClient returns a GitHub client regardless of whether the GITHUB_TOKEN is set or not.
+func GHClient() *github.Client {
+	if os.Getenv("GITHUB_TOKEN") == "" {
+		return github.NewClient(nil)
+	}
+	return github.NewClient(nil).WithAuthToken(os.Getenv("GITHUB_TOKEN"))
+
 }

--- a/hack/update/go_github_version/update_go_github_version.go
+++ b/hack/update/go_github_version/update_go_github_version.go
@@ -57,6 +57,14 @@ func main() {
 	if err := exec.Command("go", "mod", "tidy").Run(); err != nil {
 		klog.Fatalf("failed to run go mod tidy: %v", err)
 	}
+
+	// we need to run go mod tidy in the root folder too (since both minikube and hack use go-github)
+	cmd := exec.Command("go", "mod", "tidy")
+	cmd.Dir = ".."
+	if err := cmd.Run(); err != nil {
+		klog.Fatalf("failed to run go mod tidy in parent folder: %v", err)
+	}
+
 }
 
 func generateSchema() map[string]update.Item {

--- a/hack/update/ingress_version/update_ingress_version.go
+++ b/hack/update/ingress_version/update_ingress_version.go
@@ -86,7 +86,7 @@ func main() {
 
 func LatestControllerTag(ctx context.Context) (string, error) {
 	latest := "v0.0.0"
-	ghc := github.NewClient(nil)
+	ghc := update.GHClient()
 	re := regexp.MustCompile(`controller-(.*)`)
 
 	// walk through the paginated list of up to ghSearchLimit newest releases

--- a/hack/update/kubeadm_constants/update_kubeadm_constants.go
+++ b/hack/update/kubeadm_constants/update_kubeadm_constants.go
@@ -62,7 +62,7 @@ func main() {
 
 	releases := []string{}
 
-	ghc := github.NewClient(nil)
+	ghc := update.GHClient()
 
 	opts := &github.ListOptions{PerPage: 100}
 	for {

--- a/hack/update/kubernetes_versions_list/update_kubernetes_versions_list.go
+++ b/hack/update/kubernetes_versions_list/update_kubernetes_versions_list.go
@@ -52,7 +52,7 @@ type Data struct {
 func main() {
 	releases := []string{}
 
-	ghc := github.NewClient(nil)
+	ghc := update.GHClient()
 
 	opts := &github.ListOptions{PerPage: 100}
 	for {

--- a/hack/update/site_node_version/update_site_node_version.go
+++ b/hack/update/site_node_version/update_site_node_version.go
@@ -66,7 +66,7 @@ func main() {
 }
 
 func latestNodeVersionByMajor(ctx context.Context, major string) (string, error) {
-	ghc := github.NewClient(nil)
+	ghc := update.GHClient()
 
 	// walk through the paginated list of up to ghSearchLimit newest releases
 	opts := &github.ListOptions{PerPage: ghListPerPage}


### PR DESCRIPTION
I saw in github actions we hit Github's rate limit in update jobs sometimes:

```
F0728 23:38:04.704151   13024 update_docker_version.go:59] Unable to get docker stable version: GET https://api.github.com/repos/moby/moby/tags?per_page=100: 403 API rate limit exceeded for 172.184.173.240. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) [rate reset in 14m02s]
```
Example https://github.com/medyagh/minikube/actions/runs/16582700589/job/46901976114

I replaced all github.NewClient(nil) to an authenticated one (in hack folder and not minikube itself)
