### PR TITLE
use GITHUB_TOKEN to avoid github rate-limiting during hack/update runs

### DIFF
--- a/hack/update/github.go
+++ b/hack/update/github.go
@@ -19,6 +19,7 @@ package update
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"golang.org/x/mod/semver"
@@ -44,6 +45,9 @@ type Release struct {
 // If latest pre-release version is lower than the current stable release, then it will return current stable release for both.
 func GHReleases(ctx context.Context, owner, repo string) (stable, latest, edge Release, err error) {
 	ghc := github.NewClient(nil)
+	if os.Getenv("GITHUB_TOKEN") != "" {
+		ghc = ghc.WithAuthToken(os.Getenv("GITHUB_TOKEN"))
+	}
 
 	// walk through the paginated list of up to ghSearchLimit newest releases
 	opts := &github.ListOptions{PerPage: ghListPerPage}

--- a/hack/update/ingress_version/update_ingress_version.go
+++ b/hack/update/ingress_version/update_ingress_version.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -87,6 +88,10 @@ func main() {
 func LatestControllerTag(ctx context.Context) (string, error) {
 	latest := "v0.0.0"
 	ghc := github.NewClient(nil)
+	if os.Getenv("GITHUB_TOKEN") != "" {
+		ghc = ghc.WithAuthToken(os.Getenv("GITHUB_TOKEN"))
+	}
+
 	re := regexp.MustCompile(`controller-(.*)`)
 
 	// walk through the paginated list of up to ghSearchLimit newest releases

--- a/hack/update/kubeadm_constants/update_kubeadm_constants.go
+++ b/hack/update/kubeadm_constants/update_kubeadm_constants.go
@@ -63,6 +63,9 @@ func main() {
 	releases := []string{}
 
 	ghc := github.NewClient(nil)
+	if os.Getenv("GITHUB_TOKEN") != "" {
+		ghc = ghc.WithAuthToken(os.Getenv("GITHUB_TOKEN"))
+	}
 
 	opts := &github.ListOptions{PerPage: 100}
 	for {

--- a/hack/update/kubernetes_versions_list/update_kubernetes_versions_list.go
+++ b/hack/update/kubernetes_versions_list/update_kubernetes_versions_list.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"html/template"
+	"os"
 	"sort"
 	"time"
 
@@ -53,6 +54,9 @@ func main() {
 	releases := []string{}
 
 	ghc := github.NewClient(nil)
+	if os.Getenv("GITHUB_TOKEN") != "" {
+		ghc = ghc.WithAuthToken(os.Getenv("GITHUB_TOKEN"))
+	}
 
 	opts := &github.ListOptions{PerPage: 100}
 	for {

--- a/hack/update/site_node_version/update_site_node_version.go
+++ b/hack/update/site_node_version/update_site_node_version.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -67,6 +68,9 @@ func main() {
 
 func latestNodeVersionByMajor(ctx context.Context, major string) (string, error) {
 	ghc := github.NewClient(nil)
+	if os.Getenv("GITHUB_TOKEN") != "" {
+		ghc = ghc.WithAuthToken(os.Getenv("GITHUB_TOKEN"))
+	}
 
 	// walk through the paginated list of up to ghSearchLimit newest releases
 	opts := &github.ListOptions{PerPage: ghListPerPage}


### PR DESCRIPTION
helps https://github.com/kubernetes/minikube/issues/21195

we noticed we're hitting the github rate limit in our github workflow runs with unauthenticated requests (ie, 60 requests per hour, ref: [Primary rate limit for unauthenticated users](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#primary-rate-limit-for-unauthenticated-users))

with this pr, we try to use the auto-generated GITHUB_TOKEN to increase the rate limit to 1,000 requests per hour (ref: [Primary rate limit for GITHUB_TOKEN in GitHub Actions](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#primary-rate-limit-for-github_token-in-github-actions))