### PR TITLE
ci: skip boilerplate for git submodules

### DIFF
--- a/hack/boilerplate/boilerplate.go
+++ b/hack/boilerplate/boilerplate.go
@@ -31,7 +31,7 @@ var (
 	boilerplatedir = flag.String("boilerplate-dir", ".", "Boilerplate directory for boilerplate files")
 	rootdir        = flag.String("rootdir", "../../", "Root directory to examine")
 	verbose        = flag.Bool("v", false, "Verbose")
-	skippedPaths   = regexp.MustCompile(`Godeps|third_party|_gopath|_output|\.git|cluster/env.sh|vendor|test/e2e/generated/bindata.go|site/themes/docsy|test/integration/testdata`)
+	skippedPaths   = regexp.MustCompile(`Godeps|third_party|_gopath|_output|\.git|cluster/env.sh|vendor|test/e2e/generated/bindata.go|site/themes/docsy|test/integration/testdata|hack/benchmark/image-build/minikube-image-benchmark|hack/benchmark/time-to-k8s/time-to-k8s-repo`)
 	windowdNewLine = regexp.MustCompile(`\r`)
 	txtExtension   = regexp.MustCompile(`\.txt`)
 	goBuildTag     = regexp.MustCompile(`(?m)^(//go:build.*\n)+\n`)
@@ -41,6 +41,7 @@ var (
 )
 
 func main() {
+	flag.Parse()
 	refs, err := extensionToBoilerplate(*boilerplatedir)
 	if err != nil {
 		log.Fatal(err)

--- a/hack/boilerplate/boilerplate.go
+++ b/hack/boilerplate/boilerplate.go
@@ -40,51 +40,7 @@ var (
 	copyrightReal  = regexp.MustCompile(`Copyright \d{4}`)
 )
 
-// gitSubmodulePaths returns all paths defined in the .gitmodules file if it exists.
-// to prevent adding boilerplate for submouldes not part of minikube
-func gitSubmodulePaths(path string) ([]string, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	var out []string
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "path =") || strings.HasPrefix(line, "path=") {
-			parts := strings.SplitN(line, "=", 2)
-			if len(parts) == 2 {
-				p := strings.TrimSpace(parts[1])
-				if p != "" {
-					out = append(out, p)
-				}
-			}
-		}
-	}
-	return out, nil
-}
-
-// updateSkippedPaths appends git submodule paths to the skippedPaths regexp.
-func updateSkippedPaths() {
-	paths, err := gitSubmodulePaths(filepath.Join(*rootdir, ".gitmodules"))
-	if err != nil {
-		if *verbose {
-			log.Printf("unable to read .gitmodules: %v", err)
-		}
-		return
-	}
-	if len(paths) == 0 {
-		return
-	}
-	pattern := skippedPaths.String()
-	for _, p := range paths {
-		pattern += "|" + regexp.QuoteMeta(p)
-	}
-	skippedPaths = regexp.MustCompile(pattern)
-}
-
 func main() {
-	flag.Parse()
-	updateSkippedPaths()
 	refs, err := extensionToBoilerplate(*boilerplatedir)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
## Before this PR (would try to add boiler plate to submodules)
```

$ git s
On branch master
Your branch is up to date with 'upstream/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
  (commit or discard the untracked or modified content in submodules)
        modified:   hack/benchmark/image-build/minikube-image-benchmark (modified content)
        modified:   hack/benchmark/time-to-k8s/time-to-k8s-repo (modified content)

```
## after this PR
skip git submodules listed in in our .gitmouldes
