### PR TITLE
Upgrade kubetail addon to version 0.13.3

### DIFF
--- a/deploy/addons/kubetail/kubetail-cli.yaml
+++ b/deploy/addons/kubetail/kubetail-cli.yaml
@@ -7,7 +7,7 @@ metadata:
     kubernetes.io/minikube-addons: kubetail
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: kubetail
-    app.kubernetes.io/version: "0.11.5"
+    app.kubernetes.io/version: "0.13.3"
     app.kubernetes.io/instance: kubetail
     app.kubernetes.io/component: cli
 ---
@@ -19,7 +19,7 @@ metadata:
     kubernetes.io/minikube-addons: kubetail
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: kubetail
-    app.kubernetes.io/version: "0.11.5"
+    app.kubernetes.io/version: "0.13.3"
     app.kubernetes.io/instance: kubetail
     app.kubernetes.io/component: cli
 rules:
@@ -41,7 +41,7 @@ metadata:
     kubernetes.io/minikube-addons: kubetail
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: kubetail
-    app.kubernetes.io/version: "0.11.5"
+    app.kubernetes.io/version: "0.13.3"
     app.kubernetes.io/instance: kubetail
     app.kubernetes.io/component: cli
 roleRef:

--- a/deploy/addons/kubetail/kubetail-cluster-agent.yaml.tmpl
+++ b/deploy/addons/kubetail/kubetail-cluster-agent.yaml.tmpl
@@ -7,7 +7,7 @@ metadata:
     kubernetes.io/minikube-addons: kubetail
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: kubetail
-    app.kubernetes.io/version: "0.11.5"
+    app.kubernetes.io/version: "0.13.3"
     app.kubernetes.io/instance: kubetail
     app.kubernetes.io/component: cluster-agent
 data:
@@ -33,7 +33,7 @@ metadata:
     kubernetes.io/minikube-addons: kubetail
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: kubetail
-    app.kubernetes.io/version: "0.11.5"
+    app.kubernetes.io/version: "0.13.3"
     app.kubernetes.io/instance: kubetail
     app.kubernetes.io/component: cluster-agent
 ---
@@ -46,7 +46,7 @@ metadata:
     kubernetes.io/minikube-addons: kubetail
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: kubetail
-    app.kubernetes.io/version: "0.11.5"
+    app.kubernetes.io/version: "0.13.3"
     app.kubernetes.io/instance: kubetail
     app.kubernetes.io/component: cluster-agent
 spec:
@@ -59,7 +59,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: kubetail
-        app.kubernetes.io/version: "0.11.5"
+        app.kubernetes.io/version: "0.13.3"
         app.kubernetes.io/instance: kubetail
         app.kubernetes.io/component: cluster-agent
     spec:
@@ -138,7 +138,7 @@ metadata:
     kubernetes.io/minikube-addons: kubetail
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: kubetail
-    app.kubernetes.io/version: "0.11.5"
+    app.kubernetes.io/version: "0.13.3"
     app.kubernetes.io/instance: kubetail
     app.kubernetes.io/component: cluster-agent
 spec:
@@ -157,7 +157,7 @@ metadata:
     kubernetes.io/minikube-addons: kubetail
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: kubetail
-    app.kubernetes.io/version: "0.11.5"
+    app.kubernetes.io/version: "0.13.3"
     app.kubernetes.io/instance: kubetail
     app.kubernetes.io/component: cluster-agent
 spec:

--- a/deploy/addons/kubetail/kubetail-cluster-api.yaml.tmpl
+++ b/deploy/addons/kubetail/kubetail-cluster-api.yaml.tmpl
@@ -7,27 +7,18 @@ metadata:
     kubernetes.io/minikube-addons: kubetail
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: kubetail
-    app.kubernetes.io/version: "0.11.5"
+    app.kubernetes.io/version: "0.13.3"
     app.kubernetes.io/instance: kubetail
     app.kubernetes.io/component: cluster-api
 data:
   config.yaml: |
     cluster-api:
       addr: :8080
-      cluster-agent-dispatch-url: "kubernetes://kubetail-cluster-agent:50051"
       base-path: /
+      cluster-agent:
+        dispatch-url: "kubernetes://kubetail-cluster-agent:50051"
       csrf:
-        cookie:
-          domain: null
-          http-only: true
-          max-age: 43200
-          name: kubetail_cluster_api_csrf
-          path: /
-          same-site: strict
-          secure: false
         enabled: true
-        field-name: csrf_token
-        secret: ${KUBETAIL_CLUSTER_API_CSRF_SECRET}
       gin-mode: release
       logging:
         access-log:
@@ -51,7 +42,7 @@ metadata:
     kubernetes.io/minikube-addons: kubetail
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: kubetail
-    app.kubernetes.io/version: "0.11.5"
+    app.kubernetes.io/version: "0.13.3"
     app.kubernetes.io/instance: "kubetail"
     app.kubernetes.io/component: "cluster-api"
 ---
@@ -63,7 +54,7 @@ metadata:
     kubernetes.io/minikube-addons: kubetail
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: kubetail
-    app.kubernetes.io/version: "0.11.5"
+    app.kubernetes.io/version: "0.13.3"
     app.kubernetes.io/instance: kubetail
     app.kubernetes.io/component: cluster-api
 rules:
@@ -82,7 +73,7 @@ metadata:
     kubernetes.io/minikube-addons: kubetail
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: kubetail
-    app.kubernetes.io/version: "0.11.5"
+    app.kubernetes.io/version: "0.13.3"
     app.kubernetes.io/instance: kubetail
     app.kubernetes.io/component: cluster-api
 roleRef:
@@ -103,7 +94,7 @@ metadata:
     kubernetes.io/minikube-addons: kubetail
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: kubetail
-    app.kubernetes.io/version: "0.11.5"
+    app.kubernetes.io/version: "0.13.3"
     app.kubernetes.io/instance: kubetail
     app.kubernetes.io/component: cluster-api
 rules:
@@ -120,7 +111,7 @@ metadata:
     kubernetes.io/minikube-addons: kubetail
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: kubetail
-    app.kubernetes.io/version: "0.11.5"
+    app.kubernetes.io/version: "0.13.3"
     app.kubernetes.io/instance: kubetail
     app.kubernetes.io/component: cluster-api
 roleRef:
@@ -141,7 +132,7 @@ metadata:
     kubernetes.io/minikube-addons: kubetail
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: kubetail
-    app.kubernetes.io/version: "0.11.5"
+    app.kubernetes.io/version: "0.13.3"
     app.kubernetes.io/instance: kubetail
     app.kubernetes.io/component: cluster-api
 spec:
@@ -158,7 +149,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: kubetail
-        app.kubernetes.io/version: "0.11.5"
+        app.kubernetes.io/version: "0.13.3"
         app.kubernetes.io/instance: kubetail
         app.kubernetes.io/component: cluster-api
     spec:
@@ -176,9 +167,6 @@ spec:
           runAsGroup: 1000
           runAsUser: 1000
         imagePullPolicy: IfNotPresent
-        env:
-        - name: KUBETAIL_CLUSTER_API_CSRF_SECRET
-          value: "DUMMY"
         args:
         - --config=/etc/kubetail/config.yaml
         ports:
@@ -221,7 +209,7 @@ metadata:
     kubernetes.io/minikube-addons: kubetail
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: kubetail
-    app.kubernetes.io/version: "0.11.5"
+    app.kubernetes.io/version: "0.13.3"
     app.kubernetes.io/instance: kubetail
     app.kubernetes.io/component: cluster-api
 spec:

--- a/deploy/addons/kubetail/kubetail-dashboard.yaml.tmpl
+++ b/deploy/addons/kubetail/kubetail-dashboard.yaml.tmpl
@@ -7,7 +7,7 @@ metadata:
     kubernetes.io/minikube-addons: kubetail
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: kubetail
-    app.kubernetes.io/version: "0.11.5"
+    app.kubernetes.io/version: "0.13.3"
     app.kubernetes.io/instance: kubetail
     app.kubernetes.io/component: dashboard
 data:
@@ -21,17 +21,7 @@ data:
         cluster-api-enabled: true
       base-path: /
       csrf:
-        cookie:
-          domain: null
-          http-only: true
-          max-age: 43200
-          name: kubetail_dashhboard_csrf
-          path: /
-          same-site: strict
-          secure: false
         enabled: true
-        field-name: csrf_token
-        secret: ${KUBETAIL_DASHBOARD_CSRF_SECRET}
       gin-mode: release
       logging:
         access-log:
@@ -65,7 +55,7 @@ metadata:
     kubernetes.io/minikube-addons: kubetail
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: kubetail
-    app.kubernetes.io/version: "0.11.5"
+    app.kubernetes.io/version: "0.13.3"
     app.kubernetes.io/instance: kubetail
     app.kubernetes.io/component: dashboard
 ---
@@ -77,7 +67,7 @@ metadata:
     kubernetes.io/minikube-addons: kubetail
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: kubetail
-    app.kubernetes.io/version: "0.11.5"
+    app.kubernetes.io/version: "0.13.3"
     app.kubernetes.io/instance: kubetail
     app.kubernetes.io/component: dashboard
 rules:
@@ -96,7 +86,7 @@ metadata:
     kubernetes.io/minikube-addons: kubetail
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: kubetail
-    app.kubernetes.io/version: "0.11.5"
+    app.kubernetes.io/version: "0.13.3"
     app.kubernetes.io/instance: kubetail
     app.kubernetes.io/component: dashboard
 roleRef:
@@ -117,7 +107,7 @@ metadata:
     kubernetes.io/minikube-addons: kubetail
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: kubetail
-    app.kubernetes.io/version: "0.11.5"
+    app.kubernetes.io/version: "0.13.3"
     app.kubernetes.io/instance: kubetail
     app.kubernetes.io/component: dashboard
 rules:
@@ -134,7 +124,7 @@ metadata:
     kubernetes.io/minikube-addons: kubetail
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: kubetail
-    app.kubernetes.io/version: "0.11.5"
+    app.kubernetes.io/version: "0.13.3"
     app.kubernetes.io/instance: kubetail
     app.kubernetes.io/component: dashboard
 roleRef:
@@ -155,7 +145,7 @@ metadata:
     kubernetes.io/minikube-addons: kubetail
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: kubetail
-    app.kubernetes.io/version: "0.11.5"
+    app.kubernetes.io/version: "0.13.3"
     app.kubernetes.io/instance: kubetail
     app.kubernetes.io/component: dashboard
 spec:
@@ -172,7 +162,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: kubetail
-        app.kubernetes.io/version: "0.11.5"
+        app.kubernetes.io/version: "0.13.3"
         app.kubernetes.io/instance: kubetail
         app.kubernetes.io/component: dashboard
     spec:
@@ -190,11 +180,6 @@ spec:
           runAsGroup: 1000
           runAsUser: 1000
         imagePullPolicy: IfNotPresent
-        env:
-        - name: KUBETAIL_DASHBOARD_CSRF_SECRET
-          value: "DUMMY"
-        - name: KUBETAIL_DASHBOARD_SESSION_SECRET
-          value: "DUMMY"
         args:
         - --config=/etc/kubetail/config.yaml
         ports:
@@ -237,7 +222,7 @@ metadata:
     kubernetes.io/minikube-addons: kubetail
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: kubetail
-    app.kubernetes.io/version: "0.11.5"
+    app.kubernetes.io/version: "0.13.3"
     app.kubernetes.io/instance: kubetail
     app.kubernetes.io/component: dashboard
 spec:

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -806,9 +806,9 @@ var Addons = map[string]*Addon{
 		MustBinAsset(addons.KubetailAssets, "kubetail/kubetail-cli.yaml", vmpath.GuestAddonsDir, "kubetail-cli.yaml", "0640"),
 	}, false, "kubetail", "3rd party (kubetail.com)", "amorey", "https://minikube.sigs.k8s.io/docs/handbook/addons/kubetail/",
 		map[string]string{
-			"KubetailDashboard":    "kubetail/kubetail-dashboard:0.6.0@sha256:fc8d01805c09f2ad3f5a2c94016e399ece4c03ff7275dc007a213281087490ac",
-			"KubetailClusterAPI":   "kubetail/kubetail-cluster-api:0.4.0@sha256:fec3154c589a31493f14ca5ecbbc48d3ad7bab6b5e30dcddabc2457bd297dae7",
-			"KubetailClusterAgent": "kubetail/kubetail-cluster-agent:0.4.0@sha256:5363ca1a5394943aa6bf4c160860a8dc616c3e939d2006cfa902f8863e182bae",
+			"KubetailDashboard":    "kubetail/kubetail-dashboard:0.6.3@sha256:0350addb95c0b135422cf766ef7ed31dd110b1fb87aa74a600fc10508c782cfa",
+			"KubetailClusterAPI":   "kubetail/kubetail-cluster-api:0.4.2@sha256:67ebae5543164147d21045bff3f77607914b9408d82526866a90c664814b7316",
+			"KubetailClusterAgent": "kubetail/kubetail-cluster-agent:0.4.2@sha256:09f72d4ae63ed6e105298a2a72d276f97a2c9954e2adaffe18389fc1a02353bf",
 		},
 		map[string]string{
 			"Kubetail": "docker.io",


### PR DESCRIPTION
This PR upgrades the kubetail addon consistent with the kubetail-0.13.3 helm release:
https://github.com/kubetail-org/helm-charts/releases/tag/kubetail-0.13.3

Among other smaller improvements this upgrade fixes an issue with the grep/search code that was panicking when it encountered multiple identical matching lines.