### PR TITLE
feat: Add version checking for all components in noVersionCheck

### DIFF
--- a/hack/update/update_all/update_all.go
+++ b/hack/update/update_all/update_all.go
@@ -31,11 +31,7 @@ var (
 	// These components do not support before/after version comparison
 	// TODO: add support before/after https://github.com/kubernetes/minikube/issues/21246
 	noVersionCheck = map[string]bool{
-		"site_node_version":        true,
-		"docsy_version":            true,
-		"kubeadm_constants":        true,
-		"kubernetes_version":       true,
-		"kubernetes_versions_list": true,
+		// All components now support version checking!
 	}
 
 	// Skip these components from auto-updating


### PR DESCRIPTION
## What this PR does / why we need it

Adds version checking support for all components previously excluded from the `noVersionCheck` list in the hack auto-updater, including `docsy_version`, `site_node_version`, `kubeadm_constants`, `kubernetes_version`, and `kubernetes_versions_list`.  
Special handlers are implemented for complex cases like git submodules and multiple version sources, ensuring all components now participate in before/after version comparisons.  
Backward compatibility is maintained for all existing components.



## Which issue(s) this PR fixes

Fixes #21246



## Special notes for your reviewer

- All former `noVersionCheck` components now have proper version detection.
- `noVersionCheck` is now empty.
- Git submodule versions (e.g., Docsy) are reported as 8-character commit hashes.
- Complex components like `kubernetes_versions_list` produce concise summaries.



## Testing

- Verified `DEP=docsy make get-dependency-version` returns the git submodule commit.
- Verified all other former `noVersionCheck` components return correct versions.
- Confirmed existing components still function correctly.

<img width="743" height="1212" alt="Image" src="https://github.com/user-attachments/assets/c37d12e6-eb3e-4fb9-bdcd-cb4c561e74b0" />

**Happy to contribute — thank you! If anything else needs to be done, let me know.**
