### PR TITLE
gitignore: Ignore test/integration/licenses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,8 @@ deploy/iso/minikube-iso/board/minikube/aarch64/rootfs-overlay/version.json
 
 /.vscode
 
-test/integration/testdata/minikube-linux-amd64-latest-stable
+/test/integration/testdata/minikube-linux-amd64-latest-stable
+/test/integration/licenses
 
 # hugo
 /public

--- a/Makefile
+++ b/Makefile
@@ -490,6 +490,7 @@ clean: ## Clean build
 	rm -f pkg/minikube/translate/translations.go
 	rm -rf ./vendor
 	rm -rf /tmp/tmp.*.minikube_*
+	rm -rf test/integration/licenses
 
 .PHONY: gendocs
 gendocs: out/docs/minikube.md  ## Generate documentation


### PR DESCRIPTION
Running the function tests creates a licenses directory and checks out the "github.com/hooklift/iso9660" module, which imports "github.com/c4milo/gotoolkit".

    % git status
    ...

    Untracked files:
      (use "git add <file>..." to include in what will be committed)
            test/integration/licenses/

At this point running go mod tidy will add the gotoolkit module:

    % go mod tidy --diff
    diff current/go.mod tidy/go.mod
    --- current/go.mod
    +++ tidy/go.mod
    @@ -13,6 +13,7 @@
            github.com/Xuanwo/go-locale v1.1.3
            github.com/blang/semver/v4 v4.0.0
            github.com/briandowns/spinner v1.23.2
    +	    github.com/c4milo/gotoolkit v0.0.0-20190525173301-67483a18c17a
            github.com/cenkalti/backoff/v4 v4.3.0
            github.com/cheggaaa/pb/v3 v3.1.7
            github.com/cloudevents/sdk-go/v2 v2.16.0
    ...

"github.com/hooklift/iso9660" does not have a go.mod file, so `go mod tidy` treats is as part of the main module and update go.mod.

We should find a better place to check out the licenses, maybe a test temporary directory, but let's start with quick fix: ignore the license directory, and include it in `make clean`.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
