### PR TITLE
Fix update kubeadm constants

### DIFF
--- a/hack/update/kubeadm_constants/kubeadm_constants.go
+++ b/hack/update/kubeadm_constants/kubeadm_constants.go
@@ -120,7 +120,7 @@ func getKubeadmImagesMapString(version string) (string, error) {
 	}
 
 	kubeadmCommand := fmt.Sprintf("./%s", fileName)
-	args := []string{"config", "images", "list"}
+	args := []string{"config", "images", "list", "--kubernetes-version", version}
 	imageListString, err := executeCommand(kubeadmCommand, args...)
 	if err != nil {
 		klog.Errorf("failed to execute kubeadm command %s", kubeadmCommand)


### PR DESCRIPTION
helps https://github.com/kubernetes/minikube/issues/21261

---

note: after merging this pr and https://github.com/kubernetes/minikube/pull/21278, we should let automation kick in to update all appropriate files, eg, https://github.com/kubernetes/minikube/pull/21223

---

we need to specify the `--kubernetes-version` flag with appropriate k8s version when using kubeadm to get a list of images, or we might not get correct values - eg, for etcd:

```
$ kubeadm version -o short
v1.34.0-beta.0
```
```
$ kubeadm config images list
registry.k8s.io/kube-apiserver:v1.33.3
registry.k8s.io/kube-controller-manager:v1.33.3
registry.k8s.io/kube-scheduler:v1.33.3
registry.k8s.io/kube-proxy:v1.33.3
registry.k8s.io/coredns/coredns:v1.12.1
registry.k8s.io/pause:3.10
registry.k8s.io/etcd:3.5.21-0
```
whereas if we specify ` --kubernetes-version v1.34.0-beta.0`, we get the correct version:
```
$ kubeadm config images list --kubernetes-version v1.34.0-beta.0
registry.k8s.io/kube-apiserver:v1.34.0-beta.0
registry.k8s.io/kube-controller-manager:v1.34.0-beta.0
registry.k8s.io/kube-scheduler:v1.34.0-beta.0
registry.k8s.io/kube-proxy:v1.34.0-beta.0
registry.k8s.io/coredns/coredns:v1.12.1
registry.k8s.io/pause:3.10
registry.k8s.io/etcd:3.6.1-1
```

test run:
```
$ cd ./hack
$ go run update/kubeadm_constants/kubeadm_constants.go
I0810 23:44:32.603808  238642 update.go:91] The Plan:
{
  "pkg/minikube/constants/constants_kubeadm_images.go": {
    "Content": null,
    "Replace": {
      "KubeadmImages = .*": "KubeadmImages = map[string]map[string]string{ \n\t\t\"v1.34.0-beta.0\": {\n\t\t\t\"coredns/coredns\": \"v1.12.1\",\n\t\t\t\"etcd\": \"3.6.1-1\",\n\t\t\t\"pause\": \"3.10\",\n\t\t},"
    }
  }
}
I0810 23:44:32.605023  238642 update.go:100] Local repo successfully updated
I0810 23:44:42.412565  238642 update.go:91] The Plan:
{
  "pkg/minikube/constants/constants_kubeadm_images.go": {
    "Content": null,
    "Replace": {
      "KubeadmImages = .*": "KubeadmImages = map[string]map[string]string{ \n\t\t\"v1.34.0-rc.0\": {\n\t\t\t\"coredns/coredns\": \"v1.12.1\",\n\t\t\t\"etcd\": \"3.6.4-0\",\n\t\t\t\"pause\": \"3.10.1\",\n\t\t},"
    }
  }
}
I0810 23:44:42.412836  238642 update.go:100] Local repo successfully updated
I0810 23:44:52.983901  238642 update.go:91] The Plan:
{
  "pkg/minikube/constants/constants_kubeadm_images.go": {
    "Content": null,
    "Replace": {
      "KubeadmImages = .*": "KubeadmImages = map[string]map[string]string{ \n\t\t\"v1.34.0-rc.1\": {\n\t\t\t\"coredns/coredns\": \"v1.12.1\",\n\t\t\t\"etcd\": \"3.6.4-0\",\n\t\t\t\"pause\": \"3.10.1\",\n\t\t},"
    }
  }
}
I0810 23:44:52.984466  238642 update.go:100] Local repo successfully updated
```