### PR TITLE
remove deprecated proxy-refresh-interval v2 etcd flag

### DIFF
--- a/hack/update/kubernetes_version/templates/v1beta4/containerd-api-port.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta4/containerd-api-port.yaml
@@ -41,9 +41,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:12345
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.23.0
 networking:
   dnsDomain: cluster.local

--- a/hack/update/kubernetes_version/templates/v1beta4/containerd-pod-network-cidr.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta4/containerd-pod-network-cidr.yaml
@@ -41,9 +41,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.23.0
 networking:
   dnsDomain: cluster.local

--- a/hack/update/kubernetes_version/templates/v1beta4/containerd.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta4/containerd.yaml
@@ -41,9 +41,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.23.0
 networking:
   dnsDomain: cluster.local

--- a/hack/update/kubernetes_version/templates/v1beta4/crio-options-gates.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta4/crio-options-gates.yaml
@@ -53,9 +53,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.23.0
 networking:
   dnsDomain: cluster.local

--- a/hack/update/kubernetes_version/templates/v1beta4/crio.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta4/crio.yaml
@@ -41,9 +41,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.23.0
 networking:
   dnsDomain: cluster.local

--- a/hack/update/kubernetes_version/templates/v1beta4/default.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta4/default.yaml
@@ -41,9 +41,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.23.0
 networking:
   dnsDomain: cluster.local

--- a/hack/update/kubernetes_version/templates/v1beta4/dns.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta4/dns.yaml
@@ -41,9 +41,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.23.0
 networking:
   dnsDomain: minikube.local

--- a/hack/update/kubernetes_version/templates/v1beta4/image-repository.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta4/image-repository.yaml
@@ -42,9 +42,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.23.0
 networking:
   dnsDomain: cluster.local

--- a/hack/update/kubernetes_version/templates/v1beta4/options.yaml
+++ b/hack/update/kubernetes_version/templates/v1beta4/options.yaml
@@ -47,9 +47,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.23.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta4.go
+++ b/pkg/minikube/bootstrapper/bsutil/ktmpl/v1beta4.go
@@ -63,12 +63,11 @@ controlPlaneEndpoint: {{.ControlPlaneAddress}}:{{.APIServerPort}}
 etcd:
   local:
     dataDir: {{.EtcdDataDir}}
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
+{{- if .EtcdExtraArgs}}    extraArgs:
 {{- range $key, $val := .EtcdExtraArgs }}
       - name: "{{$key}}"
         value: "{{$val}}"
+{{- end}}
 {{- end}}
 kubernetesVersion: {{.KubernetesVersion}}
 networking:

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.31/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.31/containerd-api-port.yaml
@@ -41,9 +41,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:12345
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.31.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.31/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.31/containerd-pod-network-cidr.yaml
@@ -41,9 +41,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.31.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.31/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.31/containerd.yaml
@@ -41,9 +41,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.31.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.31/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.31/crio-options-gates.yaml
@@ -53,9 +53,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.31.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.31/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.31/crio.yaml
@@ -41,9 +41,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.31.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.31/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.31/default.yaml
@@ -41,9 +41,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.31.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.31/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.31/dns.yaml
@@ -41,9 +41,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.31.0
 networking:
   dnsDomain: minikube.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.31/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.31/image-repository.yaml
@@ -42,9 +42,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.31.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.31/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.31/options.yaml
@@ -47,9 +47,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.31.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.32/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.32/containerd-api-port.yaml
@@ -41,9 +41,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:12345
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.32.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.32/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.32/containerd-pod-network-cidr.yaml
@@ -41,9 +41,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.32.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.32/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.32/containerd.yaml
@@ -41,9 +41,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.32.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.32/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.32/crio-options-gates.yaml
@@ -53,9 +53,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.32.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.32/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.32/crio.yaml
@@ -41,9 +41,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.32.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.32/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.32/default.yaml
@@ -41,9 +41,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.32.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.32/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.32/dns.yaml
@@ -41,9 +41,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.32.0
 networking:
   dnsDomain: minikube.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.32/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.32/image-repository.yaml
@@ -42,9 +42,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.32.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.32/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.32/options.yaml
@@ -47,9 +47,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.32.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.33/containerd-api-port.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.33/containerd-api-port.yaml
@@ -41,9 +41,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:12345
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.33.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.33/containerd-pod-network-cidr.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.33/containerd-pod-network-cidr.yaml
@@ -41,9 +41,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.33.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.33/containerd.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.33/containerd.yaml
@@ -41,9 +41,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.33.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.33/crio-options-gates.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.33/crio-options-gates.yaml
@@ -53,9 +53,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.33.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.33/crio.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.33/crio.yaml
@@ -41,9 +41,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.33.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.33/default.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.33/default.yaml
@@ -41,9 +41,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.33.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.33/dns.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.33/dns.yaml
@@ -41,9 +41,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.33.0
 networking:
   dnsDomain: minikube.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.33/image-repository.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.33/image-repository.yaml
@@ -42,9 +42,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.33.0
 networking:
   dnsDomain: cluster.local

--- a/pkg/minikube/bootstrapper/bsutil/testdata/v1.33/options.yaml
+++ b/pkg/minikube/bootstrapper/bsutil/testdata/v1.33/options.yaml
@@ -47,9 +47,6 @@ controlPlaneEndpoint: control-plane.minikube.internal:8443
 etcd:
   local:
     dataDir: /var/lib/minikube/etcd
-    extraArgs:
-      - name: "proxy-refresh-interval"
-        value: "70000"
 kubernetesVersion: v1.33.0
 networking:
   dnsDomain: cluster.local


### PR DESCRIPTION
fixes https://github.com/kubernetes/minikube/issues/21261
prereq https://github.com/kubernetes/minikube/pull/21277
closes https://github.com/kubernetes/minikube/pull/21223

---
notes:
- we should merge https://github.com/kubernetes/minikube/pull/21277 first
- we should rebuild the iso/kicbase, to preload proper etcd version image - see the `Unable to load cached images...etcd_3.6.1-1` in examples below
---

kubernetes v1.34.0 **_actually_** (see https://github.com/kubernetes/minikube/pull/21277 for details) uses etcd v3.6 that deprecated some v2 options, specifically related to the [v2 Proxy](https://etcd.io/docs/v3.6/op-guide/configuration/#v2-proxy):
> Note: flags will be deprecated in v3.6.

we used to pass the `proxy-refresh-interval` etcd extra arg in kubeadm.k8s.io/v1beta4 ClusterConfiguration (probably a copy/paste from pre-v1beta4 templates), and that will make etcd fail, hence also fail to start k8s v1.34.0+ cluster:
```
$ crictl ps --all
CONTAINER           IMAGE               CREATED             STATE               NAME                      ATTEMPT             POD ID              POD
35e8f1f7104dc       9ad783615e1bc       15 seconds ago      Exited              kube-controller-manager   3                   39283ba1a45c3       kube-controller-manager-newk8s
2df9c5f0a9fe7       d85eea91cc41d       34 seconds ago      Exited              kube-apiserver            3                   812a476800c12       kube-apiserver-newk8s
54407d5833120       1e30c0b1e9b99       39 seconds ago      Exited              etcd                      4                   7bbfa794a453f       etcd-newk8s
76024bbca6408       21d34a2aeacf5       2 minutes ago       Running             kube-scheduler            0                   4fca823415531       kube-scheduler-newk8s
```
```
$ crictl logs 54407d5833120
flag provided but not defined: -proxy-refresh-interval
Usage:

  etcd [flags]
    Start an etcd server.

  etcd --version
    Show the version of etcd.

  etcd -h | --help
    Show the help information about etcd.

  etcd --config-file
    Path to the server configuration file. Note that if a configuration file is provided, other command line flags and environment variables will be ignored.

  etcd gateway
    Run the stateless pass-through etcd TCP connection forwarding proxy.

  etcd grpc-proxy
    Run the stateless etcd v3 gRPC L7 reverse proxy.
```


### after

#### kvm driver
```
minikube start -p newk8s --kubernetes-version=v1.34.0-beta.0
😄  [newk8s] minikube v1.36.0 on Opensuse-Tumbleweed 20250809
❗  Specified Kubernetes version 1.34.0-beta.0 is newer than the newest supported version: v1.33.2. Use `minikube config defaults kubernetes-version` for details.
✅  Kubernetes version 1.34.0-beta.0 found in version list
✨  Automatically selected the kvm2 driver. Other choices: podman, qemu2, virtualbox, ssh
👍  Starting "newk8s" primary control-plane node in "newk8s" cluster
🔥  Creating kvm2 VM (CPUs=2, Memory=6144MB, Disk=20000MB) ...
🐳  Preparing Kubernetes v1.34.0-beta.0 on Docker 28.3.2 ...
❌  Unable to load cached images: LoadCachedImages: stat /home/prezha/.minikube/cache/images/amd64/registry.k8s.io/etcd_3.6.1-1: no such file or directory
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "newk8s" cluster and "default" namespace by default
```

##### docker driver
```
$ minikube start -p newk8s --kubernetes-version=v1.34.0-beta.0
😄  [newk8s] minikube v1.36.0 on Opensuse-Tumbleweed 20250809
❗  Specified Kubernetes version 1.34.0-beta.0 is newer than the newest supported version: v1.33.2. Use `minikube config defaults kubernetes-version` for details.
✅  Kubernetes version 1.34.0-beta.0 found in version list
✨  Automatically selected the docker driver. Other choices: kvm2, qemu2, podman, virtualbox, ssh
📌  Using Docker driver with root privileges
👍  Starting "newk8s" primary control-plane node in "newk8s" cluster
🚜  Pulling base image v0.0.47-1754427148-21248 ...
    > gcr.io/k8s-minikube/kicbase...:  486.12 MiB / 486.12 MiB  100.00% 14.82 M
🔥  Creating docker container (CPUs=2, Memory=16000MB) ...
🐳  Preparing Kubernetes v1.34.0-beta.0 on Docker 28.3.3 ...
❌  Unable to load cached images: LoadCachedImages: stat /home/prezha/.minikube/cache/images/amd64/registry.k8s.io/etcd_3.6.1-1: no such file or directory
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "newk8s" cluster and "default" namespace by default
```