### PR TITLE
avoid preload-tool flags conflict

### DIFF
--- a/hack/preload-images/preload_images.go
+++ b/hack/preload-images/preload_images.go
@@ -46,7 +46,7 @@ var (
 	podmanStorageDriver   = "overlay"
 	containerRuntimes     = []string{"docker", "containerd", "cri-o"}
 	k8sVersions           []string
-	k8sVersion            = flag.String("kubernetes-version", "", "desired Kubernetes version, for example `v1.17.2`")
+	k8sVersion            = flag.String("k8s-version", "", "desired Kubernetes version, for example `v1.17.2`")
 	noUpload              = flag.Bool("no-upload", false, "Do not upload tarballs to GCS")
 	force                 = flag.Bool("force", false, "Generate the preload tarball even if it's already exists")
 	limit                 = flag.Int("limit", 0, "Limit the number of tarballs to generate")


### PR DESCRIPTION
fixes https://github.com/kubernetes/minikube/issues/21306

in https://github.com/kubernetes/minikube/pull/21189 we imported the [k8s.io/minikube/hack/update](https://github.com/kubernetes/minikube/pull/21189/files#diff-204de019e5fae0aeb15449442348a5e2b7cf6907da5b26f78ad8e02cfc697457R26) package that has [kubernetes-version](https://github.com/kubernetes/minikube/blob/ddc50cb6ad10f544e8d690951431cdf012997587/hack/update/update.go#L52) flag defined, conflicting with the one that was already present in the preload-tool

i checked and the "kubernetes-version" flag is not used with the preload-tool anywhere, but decided to rename it, instead of completely removing it, to resolve the conflict

## after

> $ cd hack && go build -ldflags="-X k8s.io/minikube/pkg/version.version=v1.36.0 -X k8s.io/minikube/pkg/version.isoVersion=v1.36.0-1753487480-21147 -X k8s.io/minikube/pkg/version.gitCommitID="04ddaa17bcf0ae2d7f720c693d97daad522d0744" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" -o ../out/preload-tool preload-images/*.go && cd -

`$ ./out/preload-tool`

```
* Removed all traces of the "generate-preloaded-images-tar" cluster.
I0812 22:22:50.519819   83566 kubernetes.go:45] "Got releases" releases=["v1.34.0-rc.1","v1.34.0-rc.0","v1.34.0-beta.0","v1.33.3","v1.32.7","v1.31.11","v1.33.2","v1.32.6","v1.31.10","v1.30.14","v1.33.1","v1.32.5","v1.31.9","v1.30.13","v1.33.0","v1.32.4","v1.31.8","v1.30.12","v1.33.0-rc.1","v1.33.0-rc.0","v1.33.0-beta.0","v1.32.3","v1.31.7","v1.30.11","v1.29.15","v1.32.2","v1.31.6","v1.30.10","v1.29.14","v1.32.1","v1.31.5","v1.30.9","v1.29.13","v1.32.0","v1.31.4","v1.30.8","v1.29.12","v1.32.0-rc.2","v1.32.0-rc.1","v1.32.0-rc.0","v1.29.11","v1.31.3","v1.30.7","v1.32.0-beta.0","v1.31.2","v1.30.6","v1.29.10","v1.28.15","v1.30.5","v1.31.1","v1.29.9","v1.28.14","v1.30.4","v1.29.8","v1.28.13","v1.31.0","v1.31.0-rc.1","v1.31.0-rc.0","v1.27.16","v1.31.0-beta.0","v1.30.3","v1.29.7","v1.28.12","v1.30.2","v1.29.6","v1.28.11","v1.27.15","v1.30.1","v1.29.5","v1.28.10","v1.27.14","v1.30.0","v1.29.4","v1.28.9","v1.27.13","v1.30.0-rc.2","v1.30.0-rc.1","v1.30.0-rc.0","v1.28.8","v1.27.12","v1.29.3","v1.26.15","v1.30.0-beta.0","v1.29.2","v1.28.7","v1.27.11","v1.26.14"]
I0812 22:22:50.520260   83566 preload.go:131] Checking if preload exists for k8s version v1.33.2 and runtime docker
I0812 22:22:50.674916   83566 preload.go:118] Found remote preload: https://storage.googleapis.com/minikube-preloaded-volume-tarballs/v18/v1.33.2/preloaded-images-k8s-v18-v1.33.2-docker-overlay2-amd64.tar.lz4
A preloaded tarball for k8s version v1.33.2 - runtime "docker" already exists, skipping generation.
...
```