### PR TITLE
krunkit: Disable offloading for faster networking

### DIFF
--- a/pkg/drivers/krunkit/krunkit.go
+++ b/pkg/drivers/krunkit/krunkit.go
@@ -229,7 +229,8 @@ func (d *Driver) startKrunkit(socketPath string) error {
 		"--memory", fmt.Sprintf("%d", d.Memory),
 		"--cpus", fmt.Sprintf("%d", d.CPU),
 		"--restful-uri", d.restfulURI(),
-		"--device", fmt.Sprintf("virtio-net,unixSocketPath=%s,mac=%s", socketPath, d.MACAddress),
+		"--device", fmt.Sprintf("virtio-net,type=unixgram,path=%s,mac=%s,offloading=%t",
+			socketPath, d.MACAddress, d.VmnetHelper.Offloading),
 		"--device", fmt.Sprintf("virtio-serial,logFilePath=%s", d.serialPath()),
 		"--krun-log-level", logLevelInfo,
 

--- a/pkg/minikube/registry/drvs/krunkit/krunkit.go
+++ b/pkg/minikube/registry/drvs/krunkit/krunkit.go
@@ -86,8 +86,6 @@ func configure(cfg config.ClusterConfig, n config.Node) (interface{}, error) {
 		VmnetHelper: vmnet.Helper{
 			MachineDir:  filepath.Join(storePath, "machines", machineName),
 			InterfaceID: u,
-			// Required Until https://github.com/containers/libkrun/issues/264 is fixed.
-			Offloading: true,
 		},
 	}, nil
 }

--- a/site/content/en/docs/drivers/krunkit.md
+++ b/site/content/en/docs/drivers/krunkit.md
@@ -16,7 +16,7 @@ workloads.
 - Available only on Apple silicon.
 - Requires macOS 13 or later.
 - Requires minikube version 1.37.0 or later.
-- Requires krunkit version 0.2.2 or later.
+- Requires krunkit version 1.0.0 or later.
 - Requires [vmnet-helper](https://github.com/nirs/vmnet-helper).
 
 ## Installing krunkit


### PR DESCRIPTION
krunkit-1.0.0[1] allows disabling offloading for faster networking. Keep the Offloading option in case offloading is improved in future versions or we want to add a flag to use int for specific workload.

Testing shows 6.7 times faster network performance, and 9p mount is 3 times faster.

Starting cluster:

    % minikube start --driver krunkit --container-runtime containerd
    😄  minikube v1.36.0 on Darwin 15.6 (arm64)
    ✨  Using the krunkit (experimental) driver based on user configuration
    👍  Starting "minikube" primary control-plane node in "minikube" cluster
    🔥  Creating krunkit VM (CPUs=2, Memory=6144MB, Disk=20000MB) ...
    📦  Preparing Kubernetes v1.33.2 on containerd 1.7.23 ...
    🔗  Configuring bridge CNI (Container Networking Interface) ...
    🔎  Verifying Kubernetes components...
        ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
    🌟  Enabled addons: default-storageclass, storage-provisioner
    🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default

Testing iperf3:

    % kubectl apply -f iper3-server.yaml
    deployment.apps/iperf3 created
    service/iperf3 created

    % kubectl get deploy iperf3
    NAME     READY   UP-TO-DATE   AVAILABLE   AGE
    iperf3   1/1     1            1           9s

    % kubectl get service iperf3
    NAME     TYPE       CLUSTER-IP       EXTERNAL-IP   PORT(S)          AGE
    iperf3   NodePort   10.105.127.180   <none>        5201:30201/TCP   17s

    % iperf3 -c $(minikube ip) -p 30201
    Connecting to host 192.168.105.10, port 30201
    [  5] local 192.168.105.1 port 50630 connected to 192.168.105.10 port 30201
    [ ID] Interval           Transfer     Bitrate
    [  5]   0.00-1.00   sec  1.05 GBytes  9.03 Gbits/sec
    [  5]   1.00-2.01   sec  1.09 GBytes  9.29 Gbits/sec
    [  5]   2.01-3.01   sec  1.06 GBytes  9.09 Gbits/sec
    [  5]   3.01-4.00   sec  1.08 GBytes  9.33 Gbits/sec
    [  5]   4.00-5.00   sec  1.08 GBytes  9.31 Gbits/sec
    [  5]   5.00-6.00   sec  1.07 GBytes  9.23 Gbits/sec
    [  5]   6.00-7.00   sec  1.09 GBytes  9.35 Gbits/sec
    [  5]   7.00-8.01   sec  1.08 GBytes  9.20 Gbits/sec
    [  5]   8.01-9.00   sec  1.07 GBytes  9.18 Gbits/sec
    [  5]   9.00-10.01  sec  1.08 GBytes  9.28 Gbits/sec
    - - - - - - - - - - - - - - - - - - - - - - - - -
    [ ID] Interval           Transfer     Bitrate
    [  5]   0.00-10.01  sec  10.7 GBytes  9.23 Gbits/sec                  sender
    [  5]   0.00-10.01  sec  10.7 GBytes  9.23 Gbits/sec                  receiver

Testing 9p mount:

    % minikube mount ~/models:/mnt/models
    📁  Mounting host path /Users/nir/models into VM as /mnt/models ...
        ▪ Mount type:   9p
        ▪ User ID:      docker
        ▪ Group ID:     docker
        ▪ Version:      9p2000.L
        ▪ Message Size: 262144
        ▪ Options:      map[]
        ▪ Bind Address: 192.168.105.1:50614
    🚀  Userspace file server:
    ufs starting
    ✅  Successfully mounted /Users/nir/models to /mnt/models

    📌  NOTE: This process must stay alive for the mount to be accessible ...

    $ time cat /mnt/models/DeepSeek-R1-0528-Qwen3-8B-Q4_K_M.gguf >/dev/null

    real    0m10.219s
    user    0m0.007s
    sys     0m0.263s

[1] https://github.com/containers/krunkit/releases/tag/v1.0.0