### PR TITLE
docs: Document virtiofs mount support introduced in 1.37

### DIFF
--- a/site/content/en/docs/handbook/mount.md
+++ b/site/content/en/docs/handbook/mount.md
@@ -3,84 +3,114 @@ title: "Mounting filesystems"
 date: 2017-01-05
 weight: 12
 description: >
-  How to mount a host directory into the VM
+  How to mount a host directory into a cluster
 aliases:
   - /docs/tasks/mount
 ---
 
-## 9P Mounts
+minikube supports the following methods to mount host directories into a cluster:
 
-9P mounts are flexible and work across all hypervisors, but suffers from performance and reliability issues when used with large folders (>600 files). See **Driver Mounts** as an alternative.
+| Method                                    | Performance                  | Flexibility                |
+|-------------------------------------------|------------------------------|----------------------------|
+| [Mount during start](#mount-during-start) | Near-native with new drivers | Single mount, set at start |
+| [Mount command](#mount-command)           | Limited (9p only)            | Multiple mounts, any time  |
+| [Driver mounts](#driver-mounts)           | Varies                       | Legacy drivers only        |
 
-To mount a directory from the host into the guest using the `mount` subcommand:
+## Mount During Start
 
-```shell
-minikube mount <source directory>:<target directory>
-```
-
-For example, this would mount your home directory to appear as /host within the minikube VM:
-
-```shell
-minikube mount $HOME:/host
-```
-
-This directory may then be referenced from a Kubernetes manifest, for example:
+The recommended way to mount a host directory. Best for directories that should
+be available on every run. Uses the best method supported by the driver —
+virtiofs or container volumes on modern drivers provide near-native performance,
+while legacy drivers fall back to 9p.
 
 ```shell
-{
-  "apiVersion": "v1",
-  "kind": "Pod",
-  "metadata": {
-    "name": "ubuntu"
-  },
-  "spec": {
-    "containers": [
-      {
-        "name": "ubuntu",
-        "image": "ubuntu:18.04",
-        "args": ["bash"],
-        "stdin": true,
-        "stdinOnce": true,
-        "tty": true,
-        "workingDir": "/host",
-        "volumeMounts": [
-          {
-            "mountPath": "/host",
-            "name": "host-mount"
-          }
-        ]
-      }
-    ],
-    "volumes": [
-      {
-        "name": "host-mount",
-        "hostPath": {
-          "path": "/host"
-        }
-      }
-    ]
-  }
-}
+minikube start --mount-string <host directory>:<guest directory>
 ```
+
+For example, this would mount your `~/models` directory to appear as
+`/mnt/models` within the cluster:
+
+```shell
+minikube start --mount-string ~/models:/mnt/models
+```
+
+The directory remains mounted while the cluster is running.
+
+| Driver         | OS      | Method           | Notes                  |
+|----------------|---------|------------------|------------------------|
+| `docker`       | All     | container volume |                        |
+| `podman`       | All     | container volume |                        |
+| `vfkit`        | macOS   | virtiofs         | Since minikube 1.37.0  |
+| `krunkit`      | macOS   | virtiofs         | Since minikube 1.37.0  |
+| `hyperv`       | Windows | 9p               |                        |
+| `kvm`          | Linux   | 9p               |                        |
+| `qemu`         | macOS   | 9p               | Requires socket_vmnet  |
+
+### Notes
+
+- Some drivers do not support mounting (see
+  [unsupported drivers](#unsupported-drivers)).
+- Only a single mount is supported. If you need to mount additional directories,
+  or mount and unmount directories after the cluster was started, use the
+  [mount command](#mount-command).
+
+## Mount Command
+
+Mounts a host directory into a running cluster using the *9p* filesystem. Use
+this when you need to mount multiple directories, or for temporary mounts whose
+lifecycle is shorter than the cluster (e.g. mount a directory during a test run,
+then unmount). Works with most drivers (see [unsupported drivers](#unsupported-drivers))
+but suffers from performance and reliability issues with large directories (>600
+files). Prefer [mount during start](#mount-during-start) when possible.
+
+```shell
+minikube mount <host directory>:<guest directory>
+```
+
+For example:
+
+```shell
+minikube mount ~/models:/mnt/models
+```
+
+The directory remains mounted while the mount command is running. To unmount,
+terminate the command with `Ctrl+C`.
+
+## Unsupported Drivers
+
+The following drivers do not support mounting host directories:
+
+- `none`
+- `qemu` with the builtin network — use `--network=socket_vmnet` (macOS only,
+  selected automatically when socket_vmnet is installed)
 
 ## Driver mounts
 
-Some hypervisors, have built-in host folder sharing. Driver mounts are reliable with good performance, but the paths are not predictable across operating systems or hypervisors:
+Some legacy drivers have built-in host folder sharing. These mounts are
+automatic but the paths are not configurable.
 
-| Driver | OS | HostFolder | VM |
-| --- | --- | --- | --- |
-| VirtualBox | Linux | /home | /hosthome |
-| VirtualBox | macOS | /Users | /Users |
-| VirtualBox | Windows | C://Users | /c/Users |
-| VMware Fusion | macOS | /Users | /mnt/hgfs/Users |
-| KVM | Linux | Unsupported | |
-| HyperKit | macOS | Supported |  |
+{{% alert title="Warning" color="warning" %}}
+Driver mounts expose large host directories (e.g. `/Users`, `/home`) to the
+guest VM by default. This is a security risk — any process in the VM has read
+and write access to your entire home directory. Consider disabling driver mounts
+with `--disable-driver-mounts` and using `--mount-string` to share only the
+specific directories you need.
+{{% /alert %}}
 
-These mounts can be disabled by passing `--disable-driver-mounts` to `minikube start`.
+| Driver         | OS      | Host         | Guest             |
+|----------------|---------|--------------|-------------------|
+| VirtualBox     | Linux   | /home        | /hosthome         |
+| VirtualBox     | macOS   | /Users       | /Users            |
+| VirtualBox     | Windows | C://Users    | /c/Users          |
+| VMware Fusion  | macOS   | /Users       | /mnt/hgfs/Users   |
 
-HyperKit mounts can use the following flags:
-`--nfs-share=[]`: Local folders to share with Guest via NFS mounts
-`--nfs-shares-root='/nfsshares'`: Where to root the NFS Shares, defaults to /nfsshares
+Built-in mounts can be disabled by passing the `--disable-driver-mounts` flag to
+`minikube start`.
+
+The HyperKit driver also supports NFS mounts via start flags:
+- `--nfs-share=[]`: Local folders to share with Guest via NFS mounts
+- `--nfs-shares-root='/nfsshares'`: Where to root the NFS shares, defaults to
+  `/nfsshares`
 
 ## File Sync
 


### PR DESCRIPTION
Rewrite the mount handbook to document virtiofs mounts and guide users
toward the best mounting method for their use case.
    
- Document virtiofs mounts via --mount-string on vfkit/krunkit drivers (near-native performance, shipped in 1.37 but never documented)
- Restructure page: mount during start, mount command, driver mounts (old page buried the recommended approach under legacy 9p details)
- Clarify when to use mount command vs mount during start (multiple mounts, or temporary mounts with shorter lifecycle than cluster)
- Add Windows driver support (hyperv, docker, podman, qemu) (Windows was completely missing from mount documentation)
- Warn about driver mounts exposing entire home directory to the guest (VirtualBox/VMware silently share /Users or /home with full write access)
- Remove Kubernetes Pod manifest example (out of scope, using a mount in a pod is the same as any other cluster)

Preveiw: https://deploy-preview-21346--kubernetes-sigs-minikube.netlify.app/docs/handbook/mount/