### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/cmd/minikube/cmd/config/defaults_test.go
+++ b/cmd/minikube/cmd/config/defaults_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"slices"
 	"testing"
 
 	"k8s.io/minikube/pkg/minikube/out"
@@ -49,10 +50,8 @@ func TestGetDefaults(t *testing.T) {
 			if tc.shouldErr {
 				return
 			}
-			for _, d := range defaults {
-				if d == tc.expectedContents {
-					return
-				}
+			if slices.Contains(defaults, tc.expectedContents) {
+				return
 			}
 			t.Fatalf("defaults didn't contain expected default. Actual: %v\nExpected: %v\n", defaults, tc.expectedContents)
 		})

--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -174,11 +175,9 @@ func kicbaseImages(ctx context.Context, ociBin string) ([]string, error) {
 
 	var result []string
 	for _, img := range allImages {
-		for _, kicImg := range kicImagesRepo {
-			if kicImg == strings.Split(img, ":")[0] {
-				result = append(result, img)
-				break
-			}
+		imgName := strings.Split(img, ":")[0]
+		if slices.Contains(kicImagesRepo, imgName) {
+			result = append(result, img)
 		}
 	}
 	return result, nil

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -98,14 +99,7 @@ var RootCmd = &cobra.Command{
 func Execute() {
 	// Check whether this is a windows binary (.exe) running inisde WSL.
 	if runtime.GOOS == "windows" && detect.IsMicrosoftWSL() {
-		var found = false
-		for _, a := range os.Args {
-			if a == "--force" {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if !slices.Contains(os.Args, "--force") {
 			exit.Message(reason.WrongBinaryWSL, "You are trying to run a windows .exe binary inside WSL. For better integration please use a Linux binary instead (Download at https://minikube.sigs.k8s.io/docs/start/.). Otherwise if you still want to do this, you can do it using --force")
 		}
 	}

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -28,6 +28,7 @@ import (
 	"os/user"
 	"regexp"
 	"runtime"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -1806,7 +1807,7 @@ func validateKubernetesVersion(old *config.ClusterConfig) {
 	}
 	if nvs.GT(newestVersion) {
 		out.WarningT("Specified Kubernetes version {{.specified}} is newer than the newest supported version: {{.newest}}. Use `minikube config defaults kubernetes-version` for details.", out.V{"specified": nvs, "newest": constants.NewestKubernetesVersion})
-		if contains(constants.ValidKubernetesVersions, kubernetesVer) {
+		if slices.Contains(constants.ValidKubernetesVersions, kubernetesVer) {
 			out.Styled(style.Check, "Kubernetes version {{.specified}} found in version list", out.V{"specified": nvs})
 		} else {
 			out.WarningT("Specified Kubernetes version {{.specified}} not found in Kubernetes version list", out.V{"specified": nvs})
@@ -2091,15 +2092,4 @@ func startNerdctld() {
 	if rest, err := runner.RunCmd(envSetupCommand); err != nil {
 		exit.Error(reason.StartNerdctld, fmt.Sprintf("Failed to set up DOCKER_HOST: %s", rest.Output()), err)
 	}
-}
-
-// contains checks whether the parameter slice contains the parameter string
-func contains(sl []string, s string) bool {
-	for _, k := range sl {
-		if s == k {
-			return true
-		}
-
-	}
-	return false
 }

--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"fmt"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
@@ -1016,14 +1017,7 @@ func checkExtraDiskOptions(cmd *cobra.Command, driverName string) {
 	supportedDrivers := []string{driver.HyperKit, driver.KVM2, driver.QEMU2, driver.VFKit, driver.Krunkit}
 
 	if cmd.Flags().Changed(extraDisks) {
-		supported := false
-		for _, driver := range supportedDrivers {
-			if driverName == driver {
-				supported = true
-				break
-			}
-		}
-		if !supported {
+		if !slices.Contains(supportedDrivers, driverName) {
 			out.WarningT("Specifying extra disks is currently only supported for the following drivers: {{.supported_drivers}}. If you can contribute to add this feature, please create a PR.", out.V{"supported_drivers": supportedDrivers})
 		}
 	}

--- a/cmd/minikube/cmd/start_test.go
+++ b/cmd/minikube/cmd/start_test.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -253,14 +254,7 @@ func TestGenerateCfgFromFlagsHTTPProxyHandling(t *testing.T) {
 					}
 				} else {
 					// proxy must in config
-					found := false
-					for _, v := range config.DockerEnv {
-						if v == proxyEnv {
-							found = true
-							break
-						}
-					}
-					if !found {
+					if !slices.Contains(config.DockerEnv, proxyEnv) {
 						t.Fatalf("Value %s expected in dockerEnv but not occurred", test.proxy)
 					}
 				}

--- a/pkg/addons/validations.go
+++ b/pkg/addons/validations.go
@@ -19,6 +19,7 @@ package addons
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 
 	"github.com/spf13/viper"
@@ -96,10 +97,5 @@ func isAddonValid(name string) (*Addon, bool) {
 }
 
 func contains(slice []string, val string) bool {
-	for _, item := range slice {
-		if item == val {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(slice, val)
 }

--- a/pkg/minikube/audit/audit.go
+++ b/pkg/minikube/audit/audit.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"os/user"
+	"slices"
 	"strings"
 	"time"
 
@@ -151,12 +152,7 @@ func shouldLog() bool {
 	// commands that should not be logged.
 	no := []string{"status", "version", "logs", "generate-docs", "profile"}
 	a := pflag.Arg(0)
-	for _, c := range no {
-		if a == c {
-			return false
-		}
-	}
-	return true
+	return !slices.Contains(no, a)
 }
 
 // isDeletePurge return true if command is delete with purge flag.

--- a/pkg/minikube/cluster/pause.go
+++ b/pkg/minikube/cluster/pause.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cluster
 
 import (
+	"slices"
 	"time"
 
 	"github.com/pkg/errors"
@@ -136,10 +137,5 @@ func doesNamespaceContainKubeSystem(namespaces []string) bool {
 	if namespaces == nil {
 		return true
 	}
-	for _, ns := range namespaces {
-		if ns == "kube-system" {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(namespaces, "kube-system")
 }

--- a/pkg/minikube/config/extra_options.go
+++ b/pkg/minikube/config/extra_options.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"k8s.io/klog/v2"
@@ -144,12 +145,7 @@ func (cm ComponentExtraOptionMap) Get(component string) map[string]string {
 // ContainsParam checks if a given slice of strings contains the provided string.
 // If a modifier func is provided, it is called with the slice item before the comparison.
 func ContainsParam(slice []string, s string) bool {
-	for _, item := range slice {
-		if item == s {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(slice, s)
 }
 
 // NewUnversionedOption returns a VersionedExtraOption that applies to all versions.

--- a/pkg/minikube/driver/driver.go
+++ b/pkg/minikube/driver/driver.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -108,12 +109,7 @@ func DisplaySupportedDrivers() string {
 
 // Supported returns if the driver is supported on this host.
 func Supported(name string) bool {
-	for _, d := range SupportedDrivers() {
-		if name == d {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(SupportedDrivers(), name)
 }
 
 // MachineType returns appropriate machine name for the driver
@@ -408,12 +404,7 @@ func Status(name string) registry.DriverState {
 // IsAlias checks if an alias belongs to provided driver by name.
 func IsAlias(name, alias string) bool {
 	d := registry.Driver(name)
-	for _, da := range d.Alias {
-		if da == alias {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(d.Alias, alias)
 }
 
 // SetLibvirtURI sets the URI to perform libvirt health checks against

--- a/pkg/minikube/extract/extract.go
+++ b/pkg/minikube/extract/extract.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -349,10 +350,8 @@ func checkString(s string) string {
 	}
 
 	// Don't translate excluded strings
-	for _, e := range exclude {
-		if e == stringToTranslate {
-			return ""
-		}
+	if slices.Contains(exclude, stringToTranslate) {
+		return ""
 	}
 
 	// Remove unnecessary backslashes

--- a/pkg/minikube/logs/logs_test.go
+++ b/pkg/minikube/logs/logs_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package logs
 
 import (
+	"slices"
 	"testing"
 
 	"k8s.io/minikube/pkg/minikube/config"
@@ -77,14 +78,7 @@ func TestEnabledAddonPods(t *testing.T) {
 	got := enabledAddonPods(cfg)
 	expectedPods := []string{"kubernetes-dashboard", "gcp-auth", "controller_ingress", "storage-provisioner"}
 	for _, expectedPod := range expectedPods {
-		found := false
-		for _, pod := range got {
-			if expectedPod == pod {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if !slices.Contains(got, expectedPod) {
 			t.Errorf("%q was not found; got = %s", expectedPod, got)
 		}
 	}

--- a/pkg/minikube/machine/cache_binaries.go
+++ b/pkg/minikube/machine/cache_binaries.go
@@ -19,6 +19,7 @@ package machine
 import (
 	"path"
 	"runtime"
+	"slices"
 
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
@@ -34,12 +35,7 @@ func isExcluded(binary string, excludedBinaries []string) bool {
 	if excludedBinaries == nil {
 		return false
 	}
-	for _, excludedBinary := range excludedBinaries {
-		if binary == excludedBinary {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(excludedBinaries, binary)
 }
 
 // CacheBinariesForBootstrapper will cache binaries for a bootstrapper

--- a/pkg/minikube/proxy/proxy.go
+++ b/pkg/minikube/proxy/proxy.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -129,12 +130,7 @@ func checkEnv(ip string, env string) bool {
 
 // isValidEnv checks if the env for proxy settings
 func isValidEnv(env string) bool {
-	for _, e := range EnvVars {
-		if e == env {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(EnvVars, env)
 }
 
 // UpdateTransport takes a k8s client *rest.config and returns a config without a proxy.

--- a/pkg/minikube/reason/k8s.go
+++ b/pkg/minikube/reason/k8s.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package reason
 
-import "github.com/blang/semver/v4"
+import (
+	"slices"
+
+	"github.com/blang/semver/v4"
+)
 
 // K8sIssue represents a known issue with a particular version of Kubernetes
 type K8sIssue struct {
@@ -58,10 +62,8 @@ var k8sIssues = []K8sIssue{
 // ProblematicK8sVersion checks for the supplied Kubernetes version and checks if there's a known issue with it.
 func ProblematicK8sVersion(v semver.Version) *K8sIssue {
 	for _, issue := range k8sIssues {
-		for _, va := range issue.VersionsAffected {
-			if va == v.String() {
-				return &issue
-			}
+		if slices.Contains(issue.VersionsAffected, v.String()) {
+			return &issue
 		}
 	}
 	return nil

--- a/pkg/minikube/reason/match.go
+++ b/pkg/minikube/reason/match.go
@@ -18,6 +18,7 @@ package reason
 
 import (
 	"regexp"
+	"slices"
 
 	"k8s.io/klog/v2"
 )
@@ -72,10 +73,8 @@ func MatchKnownIssue(r Kind, err error, goos string) *Kind {
 
 		// Does this match require an OS matchup?
 		if len(ki.GOOS) > 0 {
-			for _, o := range ki.GOOS {
-				if o == goos {
-					return &ki.Kind
-				}
+			if slices.Contains(ki.GOOS, goos) {
+				return &ki.Kind
 			}
 		}
 		if genericMatch == nil {

--- a/pkg/perf/monitor/github.go
+++ b/pkg/perf/monitor/github.go
@@ -86,15 +86,9 @@ func (g *Client) ListOpenPRsWithLabel(label string) ([]int, error) {
 }
 
 func prContainsLabel(labels []*github.Label, label string) bool {
-	for _, l := range labels {
-		if l == nil {
-			continue
-		}
-		if l.GetName() == label {
-			return true
-		}
-	}
-	return false
+    return slices.ContainsFunc(labels, func(l *github.Label) bool {
+        return l != nil && l.GetName() == label
+    })
 }
 
 // NewCommitsExist checks if new commits exist since minikube-pr-bot


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.