### PR TITLE
lint: Improve go mod tidy lint step

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,17 +60,17 @@ jobs:
           with:
             go-version: ${{env.GO_VERSION}}
             cache: true  
-        - name: Verify gomod tidy
+        - name: Verify go mod tidy
           timeout-minutes: 2
           continue-on-error: false
           run: |
+            echo "::group::go mod tidy"
             make gomodtidy
-            if ! git diff --quiet; then
-              echo "::error::Please run 'make gomodtidy' and commit the changes"
-              echo "=== files ==="
-              git diff --name-only
-              echo "=== diff ==="
-              git diff -
+            echo "::endgroup::"
+            if ! git diff-index --quiet HEAD; then
+              echo "::group::diff"
+              git --no-pager diff
+              echo "::endgroup::"
+              echo "::notice::Please run 'make gomodtidy' and commit the changes"
               exit 1
             fi
-


### PR DESCRIPTION
- Fix incorrect usage of git diff
- Use git diff-index to detect changes
- Show full diff to show the required change
- Move the fix suggestion to the end to make it easier to find
- Group log line with ::group:: workflow command[1]
- Use ::notice workflow command[2] for the fix suggestion so we don't get multiple errors annotations

## Example failed job

<img width="1374" height="808" alt="Screenshot 2025-08-22 at 19 46 29" src="https://github.com/user-attachments/assets/f4cf61fc-8764-48ca-bd12-20dc113e2bd2" />

[1] https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#grouping-log-lines
[2] https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-a-notice-message