### PR TITLE
Rebuild kubeadm constants

### DIFF
--- a/pkg/minikube/constants/constants_kubeadm_images.go
+++ b/pkg/minikube/constants/constants_kubeadm_images.go
@@ -18,11 +18,6 @@ package constants
 
 var (
 	KubeadmImages = map[string]map[string]string{
-		"v1.33.4": {
-			"coredns/coredns": "v1.12.0",
-			"etcd":            "3.5.21-0",
-			"pause":           "3.10",
-		},
 		"v1.32.8": {
 			"coredns/coredns": "v1.11.3",
 			"etcd":            "3.5.16-0",
@@ -33,26 +28,6 @@ var (
 			"etcd":            "3.5.15-0",
 			"pause":           "3.10",
 		},
-		"v1.34.0-rc.1": {
-			"coredns/coredns": "v1.12.1",
-			"etcd":            "3.6.4-0",
-			"pause":           "3.10.1",
-		},
-		"v1.34.0-rc.0": {
-			"coredns/coredns": "v1.12.1",
-			"etcd":            "3.6.4-0",
-			"pause":           "3.10.1",
-		},
-		"v1.34.0-beta.0": {
-			"coredns/coredns": "v1.12.1",
-			"etcd":            "3.6.1-1",
-			"pause":           "3.10",
-		},
-		"v1.33.3": {
-			"coredns/coredns": "v1.12.0",
-			"etcd":            "3.5.21-0",
-			"pause":           "3.10",
-		},
 		"v1.32.7": {
 			"coredns/coredns": "v1.11.3",
 			"etcd":            "3.5.16-0",
@@ -61,21 +36,6 @@ var (
 		"v1.31.11": {
 			"coredns/coredns": "v1.11.3",
 			"etcd":            "3.5.15-0",
-			"pause":           "3.10",
-		},
-		"v1.34.0-alpha.3": {
-			"coredns/coredns": "v1.12.1",
-			"etcd":            "3.5.21-0",
-			"pause":           "3.10",
-		},
-		"v1.34.0-alpha.2": {
-			"coredns/coredns": "v1.12.1",
-			"etcd":            "3.5.21-0",
-			"pause":           "3.10",
-		},
-		"v1.33.2": {
-			"coredns/coredns": "v1.12.0",
-			"etcd":            "3.5.21-0",
 			"pause":           "3.10",
 		},
 		"v1.32.6": {
@@ -93,16 +53,6 @@ var (
 			"etcd":            "3.5.15-0",
 			"pause":           "3.9",
 		},
-		"v1.34.0-alpha.1": {
-			"coredns/coredns": "v1.12.1",
-			"etcd":            "3.5.21-0",
-			"pause":           "3.10",
-		},
-		"v1.33.1": {
-			"coredns/coredns": "v1.12.0",
-			"etcd":            "3.5.21-0",
-			"pause":           "3.10",
-		},
 		"v1.32.5": {
 			"coredns/coredns": "v1.11.3",
 			"etcd":            "3.5.16-0",
@@ -118,11 +68,6 @@ var (
 			"etcd":            "3.5.15-0",
 			"pause":           "3.9",
 		},
-		"v1.33.0": {
-			"coredns/coredns": "v1.12.0",
-			"etcd":            "3.5.21-0",
-			"pause":           "3.10",
-		},
 		"v1.32.4": {
 			"coredns/coredns": "v1.11.3",
 			"etcd":            "3.5.16-0",
@@ -137,21 +82,6 @@ var (
 			"coredns/coredns": "v1.11.3",
 			"etcd":            "3.5.15-0",
 			"pause":           "3.9",
-		},
-		"v1.33.0-rc.1": {
-			"coredns/coredns": "v1.12.0",
-			"etcd":            "3.5.21-0",
-			"pause":           "3.10",
-		},
-		"v1.33.0-rc.0": {
-			"coredns/coredns": "v1.12.0",
-			"etcd":            "3.5.21-0",
-			"pause":           "3.10",
-		},
-		"v1.33.0-beta.0": {
-			"coredns/coredns": "v1.12.0",
-			"etcd":            "3.5.17-0",
-			"pause":           "3.10",
 		},
 		"v1.32.3": {
 			"coredns/coredns": "v1.11.3",
@@ -173,16 +103,6 @@ var (
 			"etcd":            "3.5.16-0",
 			"pause":           "3.9",
 		},
-		"v1.33.0-alpha.3": {
-			"coredns/coredns": "v1.12.0",
-			"etcd":            "3.5.17-0",
-			"pause":           "3.10",
-		},
-		"v1.33.0-alpha.2": {
-			"coredns/coredns": "v1.12.0",
-			"etcd":            "3.5.17-0",
-			"pause":           "3.10",
-		},
 		"v1.32.2": {
 			"coredns/coredns": "v1.11.3",
 			"etcd":            "3.5.16-0",
@@ -202,11 +122,6 @@ var (
 			"coredns/coredns": "v1.11.1",
 			"etcd":            "3.5.16-0",
 			"pause":           "3.9",
-		},
-		"v1.33.0-alpha.1": {
-			"coredns/coredns": "v1.12.0",
-			"etcd":            "3.5.17-0",
-			"pause":           "3.10",
 		},
 		"v1.32.1": {
 			"coredns/coredns": "v1.11.3",

--- a/pkg/minikube/constants/constants_kubeadm_images.go
+++ b/pkg/minikube/constants/constants_kubeadm_images.go
@@ -18,6 +18,96 @@ package constants
 
 var (
 	KubeadmImages = map[string]map[string]string{
+		"v1.34.0-rc.2": {
+			"coredns/coredns": "v1.12.1",
+			"etcd":            "3.6.4-0",
+			"pause":           "3.10.1",
+		},
+		"v1.33.4": {
+			"coredns/coredns": "v1.12.0",
+			"etcd":            "3.5.21-0",
+			"pause":           "3.10",
+		},
+		"v1.34.0-rc.1": {
+			"coredns/coredns": "v1.12.1",
+			"etcd":            "3.6.4-0",
+			"pause":           "3.10.1",
+		},
+		"v1.34.0-rc.0": {
+			"coredns/coredns": "v1.12.1",
+			"etcd":            "3.6.4-0",
+			"pause":           "3.10.1",
+		},
+		"v1.34.0-beta.0": {
+			"coredns/coredns": "v1.12.1",
+			"etcd":            "3.6.1-1",
+			"pause":           "3.10",
+		},
+		"v1.33.3": {
+			"coredns/coredns": "v1.12.0",
+			"etcd":            "3.5.21-0",
+			"pause":           "3.10",
+		},
+		"v1.34.0-alpha.3": {
+			"coredns/coredns": "v1.12.1",
+			"etcd":            "3.6.1-1",
+			"pause":           "3.10",
+		},
+		"v1.34.0-alpha.2": {
+			"coredns/coredns": "v1.12.1",
+			"etcd":            "3.6.0-0",
+			"pause":           "3.10",
+		},
+		"v1.33.2": {
+			"coredns/coredns": "v1.12.0",
+			"etcd":            "3.5.21-0",
+			"pause":           "3.10",
+		},
+		"v1.34.0-alpha.1": {
+			"coredns/coredns": "v1.12.1",
+			"etcd":            "3.6.0-0",
+			"pause":           "3.10",
+		},
+		"v1.33.1": {
+			"coredns/coredns": "v1.12.0",
+			"etcd":            "3.5.21-0",
+			"pause":           "3.10",
+		},
+		"v1.33.0": {
+			"coredns/coredns": "v1.12.0",
+			"etcd":            "3.5.21-0",
+			"pause":           "3.10",
+		},
+		"v1.33.0-rc.1": {
+			"coredns/coredns": "v1.12.0",
+			"etcd":            "3.5.21-0",
+			"pause":           "3.10",
+		},
+		"v1.33.0-rc.0": {
+			"coredns/coredns": "v1.12.0",
+			"etcd":            "3.5.21-0",
+			"pause":           "3.10",
+		},
+		"v1.33.0-beta.0": {
+			"coredns/coredns": "v1.12.0",
+			"etcd":            "3.5.17-0",
+			"pause":           "3.10",
+		},
+		"v1.33.0-alpha.3": {
+			"coredns/coredns": "v1.12.0",
+			"etcd":            "3.5.17-0",
+			"pause":           "3.10",
+		},
+		"v1.33.0-alpha.2": {
+			"coredns/coredns": "v1.12.0",
+			"etcd":            "3.5.17-0",
+			"pause":           "3.10",
+		},
+		"v1.33.0-alpha.1": {
+			"coredns/coredns": "v1.12.0",
+			"etcd":            "3.5.17-0",
+			"pause":           "3.10",
+		},
 		"v1.32.8": {
 			"coredns/coredns": "v1.11.3",
 			"etcd":            "3.5.16-0",


### PR DESCRIPTION
Delete recent constants (1.33.* 1.34.*) and run make update-kubeadm-version to rebuild the version map.