### PR TITLE
test: Fix image tests on macOS

### DIFF
--- a/test/integration/constats_test.go
+++ b/test/integration/constats_test.go
@@ -20,4 +20,5 @@ package integration
 
 const (
 	echoServerImage = "docker.io/kicbase/echo-server"
+	pauseImageName  = "registry.k8s.io/pause"
 )

--- a/test/integration/constats_test.go
+++ b/test/integration/constats_test.go
@@ -19,5 +19,5 @@ limitations under the License.
 package integration
 
 const (
-	echoServerImage = "kicbase/echo-server"
+	echoServerImage = "docker.io/kicbase/echo-server"
 )

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -328,7 +328,7 @@ func validateImageCommands(ctx context.Context, t *testing.T, profile string) {
 		checkImageExists(ctx, t, profile, newImage)
 	})
 
-	taggedImage := fmt.Sprintf("%s:%s", echoServerImage, profile)
+	daemonTestImage := fmt.Sprintf("%s:%s", echoServerImage, profile)
 
 	t.Run("SetupDaemon", func(t *testing.T) {
 		var err error
@@ -343,7 +343,7 @@ func validateImageCommands(ctx context.Context, t *testing.T, profile string) {
 			t.Fatalf("failed to setup test (pull image): %v\n%s", err, rr.Output())
 		}
 
-		rr, err = Run(t, exec.CommandContext(ctx, "docker", "tag", pulledImage, taggedImage))
+		rr, err = Run(t, exec.CommandContext(ctx, "docker", "tag", pulledImage, daemonTestImage))
 		if err != nil {
 			t.Fatalf("failed to setup test (tag image) : %v\n%s", err, rr.Output())
 		}
@@ -355,12 +355,12 @@ func validateImageCommands(ctx context.Context, t *testing.T, profile string) {
 			t.Skip("docker daemon is not available on this host")
 		}
 
-		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "image", "load", "--daemon", taggedImage, "--alsologtostderr"))
+		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "image", "load", "--daemon", daemonTestImage, "--alsologtostderr"))
 		if err != nil {
 			t.Fatalf("loading image into minikube from daemon: %v\n%s", err, rr.Output())
 		}
 
-		checkImageExists(ctx, t, profile, taggedImage)
+		checkImageExists(ctx, t, profile, daemonTestImage)
 	})
 
 	// docs: Try to load image already loaded and make sure `minikube image load --daemon` works
@@ -369,12 +369,12 @@ func validateImageCommands(ctx context.Context, t *testing.T, profile string) {
 			t.Skip("docker daemon is not available on this host")
 		}
 
-		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "image", "load", "--daemon", taggedImage, "--alsologtostderr"))
+		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "image", "load", "--daemon", daemonTestImage, "--alsologtostderr"))
 		if err != nil {
 			t.Fatalf("loading image into minikube from daemon: %v\n%s", err, rr.Output())
 		}
 
-		checkImageExists(ctx, t, profile, taggedImage)
+		checkImageExists(ctx, t, profile, daemonTestImage)
 	})
 
 	// docs: Make sure a new updated tag works by `minikube image load --daemon`
@@ -389,17 +389,17 @@ func validateImageCommands(ctx context.Context, t *testing.T, profile string) {
 			t.Fatalf("failed to setup test (pull image): %v\n%s", err, rr.Output())
 		}
 
-		rr, err = Run(t, exec.CommandContext(ctx, "docker", "tag", newPulledImage, taggedImage))
+		rr, err = Run(t, exec.CommandContext(ctx, "docker", "tag", newPulledImage, daemonTestImage))
 		if err != nil {
 			t.Fatalf("failed to setup test (tag image) : %v\n%s", err, rr.Output())
 		}
 
-		rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "image", "load", "--daemon", taggedImage, "--alsologtostderr"))
+		rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "image", "load", "--daemon", daemonTestImage, "--alsologtostderr"))
 		if err != nil {
 			t.Fatalf("loading image into minikube from daemon: %v\n%s", err, rr.Output())
 		}
 
-		checkImageExists(ctx, t, profile, taggedImage)
+		checkImageExists(ctx, t, profile, daemonTestImage)
 	})
 
 	// docs: Make sure image saving to Docker daemon works by `minikube image save --daemon`
@@ -408,16 +408,16 @@ func validateImageCommands(ctx context.Context, t *testing.T, profile string) {
 			t.Skip("docker daemon is not available on this host")
 		}
 
-		rr, err := Run(t, exec.CommandContext(ctx, "docker", "rmi", taggedImage))
+		rr, err := Run(t, exec.CommandContext(ctx, "docker", "rmi", daemonTestImage))
 		if err != nil {
 			t.Fatalf("failed to remove image from docker: %v\n%s", err, rr.Output())
 		}
 
-		rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "image", "save", "--daemon", taggedImage, "--alsologtostderr"))
+		rr, err = Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "image", "save", "--daemon", daemonTestImage, "--alsologtostderr"))
 		if err != nil {
 			t.Fatalf("saving image from minikube to daemon: %v\n%s", err, rr.Output())
 		}
-		imageToDelete := taggedImage
+		imageToDelete := daemonTestImage
 		if ContainerRuntime() == "crio" {
 			imageToDelete = cruntime.AddLocalhostPrefix(imageToDelete)
 		}

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -367,7 +367,7 @@ func validateImageCommands(ctx context.Context, t *testing.T, profile string) {
 	})
 
 	// docs: Make sure image loading from Docker daemon works by `minikube image load --daemon`
-	t.Run("ImageLoadDaemon", func(t *testing.T) {
+	t.Run("ImageLoadFromDaemon", func(t *testing.T) {
 		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "image", "load", "--daemon", taggedImage, "--alsologtostderr"))
 		if err != nil {
 			t.Fatalf("loading image into minikube from daemon: %v\n%s", err, rr.Output())
@@ -377,7 +377,7 @@ func validateImageCommands(ctx context.Context, t *testing.T, profile string) {
 	})
 
 	// docs: Try to load image already loaded and make sure `minikube image load --daemon` works
-	t.Run("ImageReloadDaemon", func(t *testing.T) {
+	t.Run("ImageReloadFromDaemon", func(t *testing.T) {
 		rr, err := Run(t, exec.CommandContext(ctx, Target(), "-p", profile, "image", "load", "--daemon", taggedImage, "--alsologtostderr"))
 		if err != nil {
 			t.Fatalf("loading image into minikube from daemon: %v\n%s", err, rr.Output())
@@ -387,7 +387,7 @@ func validateImageCommands(ctx context.Context, t *testing.T, profile string) {
 	})
 
 	// docs: Make sure a new updated tag works by `minikube image load --daemon`
-	t.Run("ImageTagAndLoadDaemon", func(t *testing.T) {
+	t.Run("ImageTagAndLoadFromDaemon", func(t *testing.T) {
 		tagAndLoadImage(ctx, t, profile, taggedImage)
 	})
 
@@ -424,7 +424,7 @@ func validateImageCommands(ctx context.Context, t *testing.T, profile string) {
 	})
 
 	// docs: Make sure image saving to Docker daemon works by `minikube image load`
-	t.Run("ImageSaveDaemon", func(t *testing.T) {
+	t.Run("ImageSaveToDaemon", func(t *testing.T) {
 		rr, err := Run(t, exec.CommandContext(ctx, "docker", "rmi", taggedImage))
 		if err != nil {
 			t.Fatalf("failed to remove image from docker: %v\n%s", err, rr.Output())

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -454,6 +454,11 @@ func validateImageCommands(ctx context.Context, t *testing.T, profile string) {
 
 	// docs: Make sure image saving works by `minikube image load --daemon`
 	t.Run("ImageSaveToFile", func(t *testing.T) {
+		if ContainerRuntime() == "containerd" {
+			// https://github.com/kubernetes/minikube/issues/21408
+			t.Skip("image save is broken with containerd runtime")
+		}
+
 		pauseImage := findPauseImage(ctx, t, profile)
 		testPath := filepath.Join(t.TempDir(), "test.tar")
 
@@ -463,6 +468,11 @@ func validateImageCommands(ctx context.Context, t *testing.T, profile string) {
 
 	// docs: Make sure image loading from file works by `minikube image load`
 	t.Run("ImageLoadFromFile", func(t *testing.T) {
+		if ContainerRuntime() == "containerd" {
+			// https://github.com/kubernetes/minikube/issues/21408
+			t.Skip("image save is broken with containerd runtime")
+		}
+
 		pauseImage := findPauseImage(ctx, t, profile)
 		testImage := "localhost/image-load-from-file:test"
 		testPath := filepath.Join(t.TempDir(), "test.tar")

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/detect"
 )
@@ -184,6 +185,15 @@ func ContainerRuntime() string {
 		}
 	}
 	return constants.Docker
+}
+
+// HaveDockerDaemon return true if docker daemon is accessble on the host. Can
+// be used to skip tests depending on docker daemon.
+func HaveDockerDaemon() bool {
+	if _, err := oci.CachedDaemonInfo(oci.Docker); err == nil {
+		return true
+	}
+	return false
 }
 
 // arm64Platform returns true if running on arm64/* platform


### PR DESCRIPTION
Fix image tests on macOS:

- Rewrite the tests that do not need docker daemon to use the container runtime in minikube.
- Check saved image, revealing #21408
- Add test for `image tag`
- Skip tests that require docker daemon if one is not available on the host.
- Improve image list tests to do proper parsing and image name lookup
- Improve image existence checks

Example run:

```
--- PASS: TestFunctional/parallel/ImageCommands (1.62s)
    --- PASS: TestFunctional/parallel/ImageCommands/ImageListShort (0.07s)
    --- PASS: TestFunctional/parallel/ImageCommands/ImageListTable (0.07s)
    --- PASS: TestFunctional/parallel/ImageCommands/ImageListJSON (0.07s)
    --- PASS: TestFunctional/parallel/ImageCommands/ImageListYAML (0.07s)
    --- SKIP: TestFunctional/parallel/ImageCommands/SetupDaemon (0.00s)
    --- SKIP: TestFunctional/parallel/ImageCommands/ImageLoadFromDaemon (0.00s)
    --- SKIP: TestFunctional/parallel/ImageCommands/ImageReloadFromDaemon (0.00s)
    --- SKIP: TestFunctional/parallel/ImageCommands/ImageTagAndLoadFromDaemon (0.00s)
    --- SKIP: TestFunctional/parallel/ImageCommands/ImageSaveToDaemon (0.00s)
    --- PASS: TestFunctional/parallel/ImageCommands/ImageTag (0.30s)
    --- PASS: TestFunctional/parallel/ImageCommands/ImageRemove (0.29s)
    --- PASS: TestFunctional/parallel/ImageCommands/ImageSaveToFile (0.17s)
    --- PASS: TestFunctional/parallel/ImageCommands/ImageLoadFromFile (0.58s)
    --- PASS: TestFunctional/parallel/ImageCommands/ImageBuild (4.21s)
```

## Issues

- Testing with pause image does not work because of #21408
- Test with "docker.io/kicbase/echo-server:1.0" instead so we don't have to skip tests
- `image pull` not tested
- `image push` not tested but we need local registry to test it