### PR TITLE
refactor: change to slices.Collect instead of append loops

### DIFF
--- a/cmd/minikube/cmd/config/addons_list.go
+++ b/cmd/minikube/cmd/config/addons_list.go
@@ -19,8 +19,9 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/olekukonko/tablewriter"
@@ -90,12 +91,7 @@ var stringFromStatus = func(addonStatus bool) string {
 }
 
 var printAddonsList = func(cc *config.ClusterConfig, printDocs bool) {
-	addonNames := make([]string, 0, len(assets.Addons))
-	for addonName := range assets.Addons {
-		addonNames = append(addonNames, addonName)
-	}
-	sort.Strings(addonNames)
-
+	addonNames := slices.Sorted(maps.Keys(assets.Addons))
 	table := tablewriter.NewWriter(os.Stdout)
 
 	table.Options(
@@ -154,12 +150,7 @@ var printAddonsList = func(cc *config.ClusterConfig, printDocs bool) {
 }
 
 var printAddonsJSON = func(cc *config.ClusterConfig) {
-	addonNames := make([]string, 0, len(assets.Addons))
-	for addonName := range assets.Addons {
-		addonNames = append(addonNames, addonName)
-	}
-	sort.Strings(addonNames)
-
+	addonNames := slices.Sorted(maps.Keys(assets.Addons))
 	addonsMap := map[string]map[string]interface{}{}
 
 	for _, addonName := range addonNames {

--- a/cmd/minikube/cmd/version.go
+++ b/cmd/minikube/cmd/version.go
@@ -18,8 +18,9 @@ package cmd
 
 import (
 	"encoding/json"
+	"maps"
 	"os/exec"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -89,11 +90,7 @@ var versionCmd = &cobra.Command{
 				if gitCommitID != "" {
 					out.Ln("commit: %v", gitCommitID)
 				}
-				keys := make([]string, 0, len(data))
-				for k := range data {
-					keys = append(keys, k)
-				}
-				sort.Strings(keys)
+				keys := slices.Sorted(maps.Keys(data))
 				for _, k := range keys {
 					v := data[k]
 					// for backward compatibility we keep displaying the old way for these two

--- a/hack/changelog/changelog.go
+++ b/hack/changelog/changelog.go
@@ -21,8 +21,10 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"maps"
 	"net/http"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 
@@ -198,10 +200,7 @@ func classify(pr *github.PullRequest, cfg Config, allowed map[string]struct{}) (
 	// Then look for substring matches. Iterate in a deterministic order so
 	// overlapping keywords behave predictably. Longer substrings are checked
 	// first to favor more specific matches.
-	subs := make([]string, 0, len(cfg.ContainGroups))
-	for sub := range cfg.ContainGroups {
-		subs = append(subs, sub)
-	}
+	subs := slices.Collect(maps.Keys(cfg.ContainGroups))
 	sort.Slice(subs, func(i, j int) bool {
 		if len(subs[i]) == len(subs[j]) {
 			return subs[i] < subs[j]

--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -18,9 +18,11 @@ package node
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path"
 	"runtime"
+	"slices"
 	"strings"
 
 	"k8s.io/minikube/pkg/minikube/detect"
@@ -272,10 +274,9 @@ func imagesInConfigFile() ([]string, error) {
 		return nil, errors.Wrap(err, "read")
 	}
 	if values, ok := configFile[cacheImageConfigKey]; ok {
-		var images []string
-		for key := range values.(map[string]interface{}) {
-			images = append(images, key)
-		}
+		// Type assertion needed because config values are stored as interface{}
+		m := values.(map[string]interface{})
+		images := slices.Collect(maps.Keys(m))
 		return images, nil
 	}
 	return []string{}, nil

--- a/pkg/minikube/registry/registry.go
+++ b/pkg/minikube/registry/registry.go
@@ -18,6 +18,8 @@ package registry
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"sync"
 
 	"github.com/docker/machine/libmachine/drivers"
@@ -157,11 +159,7 @@ func (r *driverRegistry) List() []DriverDef {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 
-	result := make([]DriverDef, 0, len(r.drivers))
-
-	for _, def := range r.drivers {
-		result = append(result, def)
-	}
+	result := slices.Collect(maps.Values(r.drivers))
 
 	return result
 }


### PR DESCRIPTION
Fixes #21428 

Replace traditional append-in-loop patterns with modern Go functions slices.Sorted(), slices.Collect(), and maps.Keys()/maps.Values()

## Changes made:
- cmd/minikube/cmd/config/addons_list.go: Use slices.Sorted(maps.Keys())
- cmd/minikube/cmd/version.go: Use slices.Sorted(maps.Keys())
- hack/changelog/changelog.go: Use slices.Collect(maps.Keys())
- pkg/minikube/node/cache.go: Use slices.Collect(maps.Keys())
- pkg/minikube/registry/registry.go: Use slices.Collect(maps.Values())

## Files skipped due to complexity:
- pkg/drivers/kic/oci/oci.go
- pkg/drivers/hyperkit/driver.go
- pkg/drivers/kvm/gpu.go
- pkg/drivers/kvm/numa.go [Unrelated slice optimization possible, can be addressed along with other similar code]
- pkg/minikube/tunnel/kic/*
- cmd/minikube/cmd/service.go
- hack/legacy_fill_db/filldb.go


The above cases require more sophisticated transformation logic that might be better addressed in separate issue/PR