### PR TITLE
addon: improve ingress-dns addon for windows and bump to v0.0.4 

### DIFF
--- a/deploy/addons/aliyun_mirror.json
+++ b/deploy/addons/aliyun_mirror.json
@@ -10,6 +10,7 @@
   "docker.io/nvidia/k8s-device-plugin": "registry.cn-hangzhou.aliyuncs.com/google_containers/k8s-device-plugin",
   "docker.io/ivans3/minikube-log-viewer": "registry.cn-hangzhou.aliyuncs.com/google_containers/minikube-log-viewer",
   "docker.io/cryptexlabs/minikube-ingress-dns": "registry.cn-hangzhou.aliyuncs.com/google_containers/minikube-ingress-dns",
+  "docker.io/kicbase/minikube-ingress-dns": "registry.cn-hangzhou.aliyuncs.com/google_containers/minikube-ingress-dns",
   "quay.io/datawire/ambassador-operator": "registry.cn-hangzhou.aliyuncs.com/google_containers/ambassador-operator",
   "docker.io/jettech/kube-webhook-certgen": "registry.cn-hangzhou.aliyuncs.com/google_containers/kube-webhook-certgen",
   "gcr.io/k8s-minikube/gcp-auth-webhook": "registry.cn-hangzhou.aliyuncs.com/google_containers/gcp-auth-webhook",

--- a/deploy/addons/ingress-dns/ingress-dns-pod.yaml.tmpl
+++ b/deploy/addons/ingress-dns/ingress-dns-pod.yaml.tmpl
@@ -80,6 +80,7 @@ spec:
       imagePullPolicy: IfNotPresent
       ports:
         - containerPort: 53
+          hostPort: 53
           protocol: UDP
       env:
         - name: DNS_PORT
@@ -88,3 +89,21 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+      volumeMounts:
+        - mountPath: /config
+          name: minikube-ingress-dns-config-volume
+  volumes:
+    - name: minikube-ingress-dns-config-volume
+      configMap:
+        name: minikube-ingress-dns
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: minikube-ingress-dns
+  namespace: kube-system
+  labels:
+    app: minikube-ingress-dns
+    app.kubernetes.io/part-of: kube-system
+data:
+  dns-nodata-delay-ms: "20"

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -537,9 +537,9 @@ var Addons = map[string]*Addon{
 			"ingress-dns-pod.yaml",
 			"0640"),
 	}, false, "ingress-dns", "minikube", "", "https://minikube.sigs.k8s.io/docs/handbook/addons/ingress-dns/", map[string]string{
-		"IngressDNS": "k8s-minikube/minikube-ingress-dns:0.0.3@sha256:4211a1de532376c881851542238121b26792225faa36a7b02dccad88fd05797c",
+		"IngressDNS": "kicbase/minikube-ingress-dns:0.0.4@sha256:d7c3fd25a0ea8fa62d4096eda202b3fc69d994b01ed6ab431def629f16ba1a89",
 	}, map[string]string{
-		"IngressDNS": "gcr.io",
+		"IngressDNS": "docker.io",
 	}),
 	"metallb": NewAddon([]*BinAsset{
 		MustBinAsset(addons.MetallbAssets,


### PR DESCRIPTION
Updated ingress-dns addon Pod template to align with current
  deployment requirements:
  * Added hostPort mapping for UDP 53
  * Mounted ConfigMap for configurable DNS settings
  * Introduced dns-nodata-delay-ms option via ConfigMap

- Switched default ingress-dns image reference from gcr.io/k8s-minikube/minikube-ingress-dns to kicbase/minikube-ingress-dns (multi-arch build available on Docker Hub).

- Left legacy image mapping in aliyun_mirror.json for backward compatibility, while adding new kicbase mapping.
