### PR TITLE
site: Replacing no more existing link for stackdriver

### DIFF
--- a/site/content/en/docs/tutorials/telemetry.md
+++ b/site/content/en/docs/tutorials/telemetry.md
@@ -11,7 +11,7 @@ minikube provides telemetry support via [OpenTelemetry tracing](https://opentele
 
 Currently, minikube supports the following exporters for tracing data:
 
-- [Stackdriver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/stackdriverexporter)
+- [Stackdriver](https://github.com/GoogleCloudPlatform/k8s-stackdriver)
 
 To collect trace data with minikube and the Stackdriver exporter, run:
 


### PR DESCRIPTION
Fixes #21444

I updated the Stackdriver link because the original is no longer available. The OpenTelemetry site does list stackdriver exporters for languages like Rust, .NET, etc... but it’s not clear these last ones directly replaces the old Stackdriver link content for this specific case. The link I propose here points to Google Cloud Operations Suite, which seems to replace Stackdriver.

Please, add your comments or corrections if you found a more suitable reference to replace the original one.

