### PR TITLE
Testing github.com/ulikunitz/x build failure

### DIFF
--- a/deploy/iso/minikube-iso/README.md
+++ b/deploy/iso/minikube-iso/README.md
@@ -1,1 +1,3 @@
 The documentation for building and hacking on the minikube ISO can be found [here](https://minikube.sigs.k8s.io/docs/contrib/building/iso/).
+
+Testing build for iso change...


### PR DESCRIPTION
Reproducing https://storage.googleapis.com/minikube-builds/logs/21409/build.txt with a minimal change.

```
# github.com/ulikunitz/xz/lzma
/go/pkg/mod/github.com/ulikunitz/xz@v0.5.14/lzma/reader.go:33:15: cannot use 1 << 31 (untyped int constant 2147483648) as int value in assignment (overflows)
# github.com/ulikunitz/xz/lzma
/go/pkg/mod/github.com/ulikunitz/xz@v0.5.14/lzma/reader.go:33:15: cannot use 1 << 31 (untyped int constant 2147483648) as int value in assignment (overflows)
```

This seems to be related to #21446:
