### PR TITLE
test: Remove darwin hardcoded parallel limit

### DIFF
--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -97,14 +97,9 @@ func setMaxParallelism() {
 	// Each "minikube start" consumes up to 2 cores, though the average usage is somewhat lower
 	limit := int(math.Floor(float64(maxp) / 1.75))
 
-	// Windows and MacOS tests were failing from timeouts due to too much parallelism
+	// Windows tests were failing from timeouts due to too much parallelism
 	if runtime.GOOS == "windows" {
 		limit /= 2
-	}
-
-	// Hardcode limit to 2 for macOS
-	if runtime.GOOS == "darwin" {
-		limit = 2
 	}
 
 	fmt.Fprintf(os.Stderr, "Found %d cores, limiting parallelism with --test.parallel=%d\n", maxp, limit)


### PR DESCRIPTION
On darwin parallel was limited to 2 instead of nproc/1.75. Initial testing shows nice speedup from 3698 to 2665 seconds. This does not effect get github tests that have only 4 cpus and run on extremely overloaded machines.

| branch  | driver   | runtime     | time   | failed  | results |
|---------|--------- |-------------|--------|---------|---------|
| master  | vfkit    | docker      |  3698s |         |         |
| this    | vfkit    | docker      |  2665s |  16/342 | [vfkit-docker.tar.gz](https://github.com/user-attachments/files/22105366/vfkit-docker.tar.gz) |

Status:
- test again master vfkit docker to get number of failures
- test with containerd when #21409 is merged
- test with krunkit