### PR TITLE
Update Kubernetes versions

### DIFF
--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -39,7 +39,9 @@ const (
 	// NOTE: You may need to update coreDNS & etcd versions in pkg/minikube/bootstrapper/images/images.go
 	NewestKubernetesVersion = "v1.34.0"
 	// OldestKubernetesVersion is the oldest Kubernetes version to test against
-	OldestKubernetesVersion = "v1.20.0"
+	// TODO: upodate to 6 releases before from DefaultKubernetesVersion
+	OldestKubernetesVersion = "v1.28.0"
+
 	// NoKubernetesVersion is the version used when users does NOT want to install kubernetes
 	NoKubernetesVersion = "v0.0.0"
 

--- a/site/content/en/docs/drivers/none.md
+++ b/site/content/en/docs/drivers/none.md
@@ -68,7 +68,7 @@ As Kubernetes has full access to both your filesystem as well as your docker ima
 * Many `minikube` commands are not supported, such as: `dashboard`, `mount`, `ssh`
 * minikube with the `none` driver has a confusing permissions model, as some commands need to be run as root ("start"), and others by a regular user ("dashboard")
 * CoreDNS detects resolver loop, goes into CrashLoopBackOff - [#3511](https://github.com/kubernetes/minikube/issues/3511)
-* Some versions of Linux have a version of docker that is newer than what Kubernetes expects. To overwrite this, run minikube with the following parameters: `minikube start --driver=none --kubernetes-version v1.11.8 --extra-config kubeadm.ignore-preflight-errors=SystemVerification`
+* Some versions of Linux have a version of docker that is newer than what Kubernetes expects. To overwrite this, run minikube with the following parameters: `minikube start --driver=none --kubernetes-version v1.34.0 --extra-config kubeadm.ignore-preflight-errors=SystemVerification`
 
 * [Full list of open 'none' driver issues](https://github.com/kubernetes/minikube/labels/co%2Fnone-driver)
 

--- a/site/content/en/docs/faq/_index.md
+++ b/site/content/en/docs/faq/_index.md
@@ -15,7 +15,7 @@ You can create a Kubernetes cluster with any version you desire using `--kuberne
 Example:
 
 ```bash
-minikube start --kubernetes-version=v1.15.0
+minikube start --kubernetes-version=v1.34.0
 ```
 
 ## How can I create more than one cluster with minikube?
@@ -40,7 +40,7 @@ Yes! If you want to use minikube only as a Docker Desktop replacement without st
 minikube start --container-runtime=docker --no-kubernetes
 ```
 
-Alternatively, if you want to temporarily turn off Kubernetes, you can pause and later unpause Kubernetes 
+Alternatively, if you want to temporarily turn off Kubernetes, you can pause and later unpause Kubernetes
 ```
 minikube pause
 ```
@@ -65,7 +65,7 @@ minikube start --force-systemd=true
 
 ## How can I run minikube with the Docker driver if I have an existing cluster with a VM driver?
 
-First please ensure your Docker service is running. Then you need to either:  
+First please ensure your Docker service is running. Then you need to either:
 
 (a) Delete the existing cluster and create a new one
 
@@ -77,7 +77,7 @@ minikube start --driver=docker
 Alternatively, (b) Create a second cluster with a different profile name:
 
 ```bash
-minikube start -p p1 --driver=docker 
+minikube start -p p1 --driver=docker
 ```
 
 ## Does minikube support IPv6?
@@ -88,7 +88,7 @@ minikube currently doesn't support IPv6. However, it is on the [roadmap]({{< ref
 
 The easiest approach is to use the `docker` driver, as the backend service always runs as `root`.
 
-`none` users may want to try `CHANGE_MINIKUBE_NONE_USER=true`, where kubectl and such will work without `sudo`. See [environment variables]({{< ref "/docs/handbook/config.md#environment-variables" >}}) for more details.  
+`none` users may want to try `CHANGE_MINIKUBE_NONE_USER=true`, where kubectl and such will work without `sudo`. See [environment variables]({{< ref "/docs/handbook/config.md#environment-variables" >}}) for more details.
 
 Alternatively, you can configure `sudo` to never prompt for commands issued by minikube.
 
@@ -178,15 +178,15 @@ This is not recommended, but for some users who are willing to accept potential 
 
 After executing `minikube start`, minikube will try to pulling images from `gcr.io` or Docker Hub. However, it has been confirmed that Chinese (mainland) users may not have access to `gcr.io` or Docker Hub. So in China mainland, it is very likely that `minikube start` will fail.
 
-For Chinese users, the reason is that China mainland government has set up GFW firewall to block any access to `gcr.io` or Docker Hub from China mainland. 
+For Chinese users, the reason is that China mainland government has set up GFW firewall to block any access to `gcr.io` or Docker Hub from China mainland.
 
 Minikube is an open community and we are always willing to help users from any corner of the world to use our open-source software, and provide possible assistance when possible. Here are 3 possible ways to resolve the blockade.
 
-1. Use `minikube start --image-mirror-country='cn'` instead. Aliyun (a Chinese corporation) provides a mirror repository (`registry.cn-hangzhou.aliyuncs.com/google_containers`) for those images, to which Chinese users have access. By using `--image-mirror-country='cn'` flag, minikube will try to pull the image from Aliyun mirror site as first priority. <br/><br/> *Note: when a new image is published on gcr.io, it may take several days for the image to be synchronized to Aliyun mirror repo. However, minikube will always try to pull the newest image by default, which will cause a failure of pulling image. Under this circumstance, you HAVE TO use `--kubernetes-version` flag AS WELL to tell minikube to use an older version image which is available on Aliyun repo.* <br/><br/> *For example, `minikube start --image-mirror-country='cn'  --kubernetes-version=v1.23.8` will tell minikube to pull v1.23.8 k8s image from Aliyun.*
+1. Use `minikube start --image-mirror-country='cn'` instead. Aliyun (a Chinese corporation) provides a mirror repository (`registry.cn-hangzhou.aliyuncs.com/google_containers`) for those images, to which Chinese users have access. By using `--image-mirror-country='cn'` flag, minikube will try to pull the image from Aliyun mirror site as first priority. <br/><br/> *Note: when a new image is published on gcr.io, it may take several days for the image to be synchronized to Aliyun mirror repo. However, minikube will always try to pull the newest image by default, which will cause a failure of pulling image. Under this circumstance, you HAVE TO use `--kubernetes-version` flag AS WELL to tell minikube to use an older version image which is available on Aliyun repo.* <br/><br/> *For example, `minikube start --image-mirror-country='cn'  --kubernetes-version=v1.34.0` will tell minikube to pull v1.34.0 k8s image from Aliyun.*
 
-2. If you have a private mirror repository provided by your own cloud provider, you can specify that via `--image-repository` flag. For example, using `minikube start --image-repository='registry.cn-hangzhou.aliyuncs.com/google_containers'` will tell minikube to try to pull images from `registry.cn-hangzhou.aliyuncs.com/google_containers` mirror repository as first priority. 
-  
-3. Use a proxy server/VPN, if you have one. <br/> *Note: please obey the local laws. In some area, using an unauthorized proxy server/VPN is ILLEGAL* 
+2. If you have a private mirror repository provided by your own cloud provider, you can specify that via `--image-repository` flag. For example, using `minikube start --image-repository='registry.cn-hangzhou.aliyuncs.com/google_containers'` will tell minikube to try to pull images from `registry.cn-hangzhou.aliyuncs.com/google_containers` mirror repository as first priority.
+
+3. Use a proxy server/VPN, if you have one. <br/> *Note: please obey the local laws. In some area, using an unauthorized proxy server/VPN is ILLEGAL*
 
 ## How do I install containernetworking-plugins for none driver?
 

--- a/site/content/en/docs/handbook/config.md
+++ b/site/content/en/docs/handbook/config.md
@@ -2,7 +2,7 @@
 title: "Configuration"
 weight: 4
 description: >
-  Configuring your cluster 
+  Configuring your cluster
 aliases:
   - /docs/reference/environment_variables/
   - /docs/reference/configuration/kubernetes/
@@ -50,9 +50,9 @@ This flag is repeated, so you can pass it several times with several different v
 By default, minikube installs the latest stable version of Kubernetes that was available at the time of the minikube release. You may select a different Kubernetes release by using the `--kubernetes-version` flag, for example:
 
 ```shell
-minikube start --kubernetes-version=v1.11.10
+minikube start --kubernetes-version=v1.34.0
 ```
-  
+
 minikube follows the [Kubernetes Version and Version Skew Support Policy](https://kubernetes.io/docs/setup/version-skew-policy/), so we guarantee support for the latest build for the last 3 minor Kubernetes releases. When practical, minikube aims to support older releases as well so that users can emulate legacy environments.
 
 For up to date information on supported versions, see `OldestKubernetesVersion` and `NewestKubernetesVersion` in [constants.go](https://github.com/kubernetes/minikube/blob/master/pkg/minikube/constants/constants.go)

--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -758,7 +758,7 @@ minikube addons list
 Create a second cluster running an older Kubernetes release:
 
 ```shell
-minikube start -p aged --kubernetes-version=v1.16.1
+minikube start -p aged --kubernetes-version=v1.34.0
 ```
 
 Delete all of the minikube clusters:

--- a/site/content/en/docs/tutorials/volume_snapshots_and_csi.md
+++ b/site/content/en/docs/tutorials/volume_snapshots_and_csi.md
@@ -14,7 +14,7 @@ This tutorial explains how to set up the CSI Hostpath Driver in minikube and cre
 ## Prerequisites
 
 - latest version of minikube
-- kubernetes v1.20 or later
+- kubernetes v1.28 or later
 
 ## What you’ll need
 

--- a/test/integration/no_kubernetes_test.go
+++ b/test/integration/no_kubernetes_test.go
@@ -25,6 +25,8 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+
+	"k8s.io/minikube/pkg/minikube/constants"
 )
 
 // TestNoKubernetes tests starting minikube without Kubernetes,
@@ -79,7 +81,7 @@ func validateStartNoK8sWithVersion(ctx context.Context, t *testing.T, profile st
 	defer PostMortemLogs(t, profile)
 
 	// docs: start minikube with no kubernetes.
-	args := append([]string{"start", "-p", profile, "--no-kubernetes", "--kubernetes-version=1.20"}, StartArgs()...)
+	args := append([]string{"start", "-p", profile, "--no-kubernetes", "--kubernetes-version=" + constants.OldestKubernetesVersion}, StartArgs()...)
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err == nil {
 		t.Fatalf("expected an error but none was thrown with args: %q", rr.Command())

--- a/test/integration/preload_test.go
+++ b/test/integration/preload_test.go
@@ -38,8 +38,7 @@ func TestPreload(t *testing.T) {
 
 	startArgs := []string{"start", "-p", profile, "--memory=3072", "--alsologtostderr", "--wait=true", "--preload=false"}
 	startArgs = append(startArgs, StartArgs()...)
-	k8sVersion := "v1.24.4"
-	startArgs = append(startArgs, fmt.Sprintf("--kubernetes-version=%s", k8sVersion))
+	startArgs = append(startArgs, fmt.Sprintf("--kubernetes-version=%s", legacyVersion()))
 
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), startArgs...))
 	if err != nil {

--- a/test/integration/version_upgrade_test.go
+++ b/test/integration/version_upgrade_test.go
@@ -66,7 +66,7 @@ func legacyVersion() string {
 	// Should be a version from the last 6 months
 	// note: Test*BinaryUpgrade require minikube v1.22+ to satisfy newer containerd config structure
 	// note: TestMissingContainerUpgrade requires minikube v1.26.0+ where we copy over initial containerd config in kicbase via deploy/kicbase/Dockerfile
-	version := "v1.26.0" // 2022-06-23
+	version := "v1.32.0" // Dec 11, 2024
 	return version
 }
 


### PR DESCRIPTION
We use constants.OldestKubernetesVersion for testing the oldest version and limiting --kubernetes-version when starting the clusters. Our tradition is testing 6 releases back from current version, but we were testing 14 release back (1.20.0).

For upgrading containerd to latest version (v2.1.4) we need to upgrade to a newer release. Upgrade constants.OldestKubernetesVersion to 1.28.0 which seems to pass all tests.

legacyVersion() used in version_upgrade_test.go was 1.26.0. The comment in file mention that this should be release from the last 6 month. We do see failures in the relevant tests (TestRunningBinaryUpgrade) in many builds so I bumped it as well to 1.32.0 (2 releases back from current).

In preload_test.go we tested --kubernetes-version=1.24.4 which is not compatible with containerd v2. Use legacyVersion() instead so we don't need to maintain another version.

We had many example of --kubernetes-version in the docs using older version which are not supported. Replace all example with current version to minimize future maintenance. We need to automated this later so updating the version in minikube will also update the examples.

With this change we have 2 places to update kubernetes versions:
- constants.*KubernetesVersion
- legacyVersion()

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
