### PR TITLE
UI: improve config flag long description

### DIFF
--- a/cmd/minikube/cmd/config/view.go
+++ b/cmd/minikube/cmd/config/view.go
@@ -40,9 +40,9 @@ type ViewTemplate struct {
 var configViewCmd = &cobra.Command{
 	Use:   "view",
 	Short: "Display values currently set in the minikube config file",
-	Long:  "`Display values currently set in the minikube config file. 
+	Long:  `Display values currently set in the minikube config file. 
 	The output format can be customized using the --format flag, which accepts a Go template. 
-	The config file is typically located at "~/.minikube/config/config.json".`,",
+	The config file is typically located at "~/.minikube/config/config.json".`,
 	Run: func(_ *cobra.Command, _ []string) {
 		err := View()
 		if err != nil {


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

### Refers to #21468 

### comments 🥝
I've addressed the issue where the `Short` and `Long` descriptions for the `configViewCmd` in `view.go` were nearly identical, differing only by a single period. I have improved the `Long` description by adding more specific details about how to use the command, including how to customize the output with the `--format` flag and the typical location of the configuration file. This change helps to clearly differentiate the `Long` description from the `Short` one, making the command's help text more useful for users.
thank you :)