### PR TITLE
ci: changelog script paginate through more than 250 commits

### DIFF
--- a/hack/changelog/changelog.go
+++ b/hack/changelog/changelog.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -138,12 +138,22 @@ func resolveStartRef(ctx context.Context, gh *github.Client, owner, repo, start 
 // pullRequestsBetween finds all pull requests merged between start and end by
 // walking the commit comparison and querying PRs for each commit.
 func pullRequestsBetween(ctx context.Context, gh *github.Client, owner, repo, start, end string) map[int]*github.PullRequest {
-	cmp, _, err := gh.Repositories.CompareCommits(ctx, owner, repo, start, end, nil)
-	if err != nil {
-		log.Fatalf("compare commits: %v", err)
+	var allCommits []*github.RepositoryCommit
+	opts := &github.ListOptions{PerPage: 100}
+	for {
+		cmp, resp, err := gh.Repositories.CompareCommits(ctx, owner, repo, start, end, opts)
+		if err != nil {
+			log.Fatalf("compare commits: %v", err)
+		}
+		allCommits = append(allCommits, cmp.Commits...)
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
 	}
+
 	prsMap := make(map[int]*github.PullRequest)
-	for _, c := range cmp.Commits {
+	for _, c := range allCommits {
 		prs, _, err := gh.PullRequests.ListPullRequestsWithCommit(ctx, owner, repo, c.GetSHA(), nil)
 		if err != nil {
 			log.Printf("list PRs for commit %s: %v", c.GetSHA(), err)


### PR DESCRIPTION
### Before this PR
```
go run hack/changelog/changelog.go
Generating changelog, this might take a few minutes ...
## Addons
* Addon cloud-spanner: Update cloud-spanner-emulator/emulator image from 1.5.37 to 1.5.38 (#21243)
* Addon cloud-spanner: Update cloud-spanner-emulator/emulator image from 1.5.38 to 1.5.39 (#21287)
* Addon cloud-spanner: Update cloud-spanner-emulator/emulator image from 1.5.39 to 1.5.40 (#21359)
* Addon cloud-spanner: Update cloud-spanner-emulator/emulator image from 1.5.40 to 1.5.41 (#21512)
* Addon Headlamp: Update Headlamp image from v0.28.0 to v0.34.0 (#21238)
* Addon Headlamp: Update Headlamp image from v0.34.0 to v0.35.0 (#21508)
* Addon ingress: Update ingress-nginx/controller image from v1.12.3 to v1.13.0 (#21232)
* Addon ingress: Update ingress-nginx/controller image from v1.13.0 to v1.13.1 (#21353)
* Addon ingress: Update ingress-nginx/controller image from v1.13.1 to v1.13.2 (#21458)
* Addon inspektor-gadget: Update comments (#21358)
* Addon inspektor-gadget: Update inspektor-gadget image from v0.42.0 to v0.43.0 (#21240)
* Addon inspektor-gadget: Update inspektor-gadget image from v0.43.0 to v0.44.0 (#21462)
* Addon inspektor-gadget: Update inspektor-gadget image from v0.44.0 to v0.44.1 (#21510)
* Addon kong: Update kong image from 3.9.1 to 3.9.1 (#21229)
* Addon kong: Update kong image from 3.9.1 to 3.9.1 (#21350)
* Addon kong: Update kong image from 3.9.1 to 3.9.1 (#21503)
* Addon kong: Update kong/kubernetes-ingress-controller image from 3.5.0 to 3.5.1 (#21282)
* Addon kubevirt: Update bitnami/kubectl image from 1.33.1 to 1.33.3 (#21235)
* Addon kubevirt: Update bitnami/kubectl image from 1.33.3 to 1.33.3 (#21283)
* Addon kubevirt: Update bitnami/kubectl image from 1.33.3 to 1.33.4 (#21414)
* Addon nvidia-device-plugin: Update nvidia/k8s-device-plugin image from v0.17.2 to v0.17.3 (#21225)
* Addon registry: Update registry image from 3.0.0 to 3.0.0 (#21242)
* Addon Volcano: Update volcano images from v1.12.1 to v1.12.2 (#21351)
* addon: improve ingress-dns addon for windows and bump to v0.0.4  (#21449)

## Base image versions
* iso: Enable VirtioFS for x86_64 and aarch64 (#21147)
* Kicbase/ISO: Update cni-plugins from v1.7.1 to v1.8.0 (#21517)
* Kicbase/ISO: Update crun from 1.19 to 1.23 (#21198)
* Kicbase/ISO: Update crun from 1.23 to 1.23.1 (#21330)
* Kicbase/ISO: Update docker from 28.3.2 to 28.3.3 (#21248)
* Kicbase/ISO: Update docker from 28.3.3 to 28.4.0 (#21488)
* Kicbase: Bump ubuntu:jammy from 20250415.1 to 20250714 (#21233)
* Kicbase: Bump ubuntu:jammy from 20250714 to 20250730 (#21413)
* Kicbase: Bump ubuntu:jammy from 20250730 to 20250819 (#21505)

## Bug fixes
* fix k8s v1.34.0-beta.0 etcd image version (#21337)
* Fix minikube image load on windows (#20529) (#20921)
* fix preload tool build (#21367)
* Fix update kubeadm constants (#21277)
* spelling: Fix spelling errors with codespell (#21273)

## CNI
* CNI: Update calico from v3.30.2 to v3.30.3 (#21416)
* CNI: Update cilium from v1.17.5 to v1.18.0 (#21226)
* CNI: Update cilium from v1.18.0 to v1.18.1 (#21349)
* CNI: Update flannel from v0.27.0 to v0.27.2 (#21230)
* CNI: Update flannel from v0.27.2 to v0.27.3 (#21504)

## Drivers
* drivers: Add support for Virtiofs mounts for vfkit and krunkit (#21149)
* drivers: Extract drivers/common package (#21266)
* krunkit: Disable offloading for faster networking (#21341)
* krunkit: Fix linter issues (#21133)
* vfkit: Extract isoPath() helper (#21111)

## Improvements
* improve docker service reliability, update docker systemd files (#21174)
* lint: Improve go mod tidy lint step (#21399)
* UI: improve config flag long description (#21515)

## UI
* Fix french translation (#21156)
* UI: Add more Korean translations (#21467)
* ui: add more translations for korean (#21465)
* UI: improve French translation (#21514)
* UI: Improve french translations (#21372)
* Update auto-generated docs and translations (#21202)
* Update auto-generated docs and translations (#21260)
* Update auto-generated docs and translations (#21276)
* Update auto-generated docs and translations (#21298)
* Update auto-generated docs and translations (#21364)

## kind/feature
* Bump Kubernetes version default: v1.34.0 and latest: v1.34.0 (#21439)

## other
* Add `--disable-coredns-log` flag (#20992)
* Add support to docker runtime for OCI access to NVIDIA GPUs (#20959)
* avoid preload-tool flags conflict (#21327)
* Build(deps-dev): Bump braces from 3.0.2 to 3.0.3 in /site (#21318)
* Bump kubeadm constants for kubernetes images (#21221)
* Bump kubeadm constants for kubernetes images (#21307)
* Bump kubeadm constants for kubernetes images (#21347)
* deps: Update github.com/ulikunitz/xz to v0.5.15 (#21466)
* Don't require both --mount for using --mount-string and remove default mount-string (#21250)
* feat: Add version checking for all components in noVersionCheck (#21265)
* github action: dont define both path and path-ignore (#21322)
* gitignore: Ignore also .zed directory (#21270)
* gitignore: Ignore test/integration/licenses (#21267)
* go mod tidy (#21305)
* go mod tidy (#21319)
* go mod tidy (#21323)
* go mod tidy (#21384)
* gomod: remove replace for k8s.io/cluster-bootstrap (#21187)
* HA (multi-control plane): Update kube-vip from v0.9.2 to v1.0.0 (#21228)
* license: don't fail if output dir doesn't exist & download  from github assets first (#21206)
* optimize memory usage in image load with Docker client integration (#21103)
* Refactor spinner library & hide sub steps after spinning (#21215)
* refactor: change to slices.Collect instead of append loops (#21430)
* Release: Update ISO to v1.37.0 (#21524)
* Release: Update kicbase to v0.0.48 (#21526)
* remove deprecated proxy-refresh-interval v2 etcd flag (#21278)
* Rename hack module (#21141)
* replace spinner lib to upstream (#21115)
* Revert "optimize memory usage in image load with Docker client integration" (#21146)
* Separate hack module (#21094)
* skip tests not relevant for windows (#21329)
* UI: do not show "create github issue" twice if kubeadm init fails (#21263)
* Update go from 1.24.0 to 1.24.6 (#21348)
* Update go-github from v73.0.0 to v74.0.0 (#21234)
* Update Headlamp's workflow go version (#21136)
* Update Kubernetes versions list (#21222)
* Update Kubernetes versions list (#21280)
* Update Kubernetes versions list (#21334)
* Update oldest supported Kubernetes versions (#21490)
* update url for vmnet-helper (#21492)
* Update Yearly Leaderboard (#21216)
* Updated site/readme.md outdated documentation (#21209)
* Upgrade kubetail addon to version 0.13.3 (#21244)

```


## After this PR (doesnt miss the krunklit GPU PR)

