### PR TITLE
kvm: Unbreak minikube on Fedora/RHEL

### DIFF
--- a/pkg/drivers/kvm/domain.go
+++ b/pkg/drivers/kvm/domain.go
@@ -70,14 +70,7 @@ func closeDomain(dom *libvirt.Domain, conn *libvirt.Connect) error {
 func (d *Driver) defineDomain() (*libvirt.Domain, error) {
 	tmpl := template.Must(template.New("domain").Parse(domainTmpl))
 	var domainXML bytes.Buffer
-	dlog := struct {
-		Driver
-		ConsoleLogPath string
-	}{
-		Driver:         *d,
-		ConsoleLogPath: consoleLogPath(*d),
-	}
-	if err := tmpl.Execute(&domainXML, dlog); err != nil {
+	if err := tmpl.Execute(&domainXML, d); err != nil {
 		return nil, errors.Wrap(err, "executing domain xml")
 	}
 	conn, err := getConnection(d.ConnectionURI)

--- a/pkg/drivers/kvm/domain_definition_x86.go
+++ b/pkg/drivers/kvm/domain_definition_x86.go
@@ -55,7 +55,6 @@ const domainTmpl = `
       <source file='{{.DiskPath}}'/>
       <target dev='hda' bus='virtio'/>
     </disk>
-    <controller type='virtio-serial'/>
     <interface type='network'>
       <source network='{{.PrivateNetwork}}'/>
       <model type='virtio'/>
@@ -66,13 +65,9 @@ const domainTmpl = `
     </interface>
     <serial type='pty'>
       <target port='0'/>
-      <log file='{{.ConsoleLogPath}}' append='on'/>
     </serial>
     <console type='pty'>
       <target type='serial' port='0'/>
-    </console>
-    <console type='pty'>
-      <target type="virtio" port="1"/>
     </console>
     <rng model='virtio'>
       <backend model='random'>/dev/random</backend>


### PR DESCRIPTION
Since #20852 minikube is broken on Fedora/RHEL. We add console.log (~/.minikube/machines/NAME/console.log) for dumping the console logs during startup. Libvirt is blocked by selinux policy:

    $ sudo ausearch -m AVC --start today
    ...
    ----
    time->Sat Sep 13 22:14:10 2025
    type=AVC msg=audit(1757790850.921:4801): avc:  denied  { open } for  pid=215452 comm="virtlogd" path="/home/nsoffer/.minikube/machines/minikube/console.log" dev="vda3" ino=197349579 scontext=system_u:system_r:virtlogd_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:user_home_t:s0 tclass=file permissive=1
    ----

Having better logs in the kvm driver can be helpful but it cannot break basic functionality. Remove the code to create the log file and dump the logs.

This is a manual revert of commit
2b81ce24e3432225cb61c53f2bc447449181f4a9. We cannot do a clean revert since all commits in #20852 were squashed during merge.

Tested using:

    $ make out/docker-machine-driver-kvm2

    $ cp out/docker-machine-driver-kvm2 ~/.minikube/bin/

    $ out/minikube start --driver kvm
    😄  minikube v1.37.0 on Fedora 42 (kvm/amd64)
    ✨  Using the kvm2 driver based on user configuration
    👍  Starting "minikube" primary control-plane node in "minikube" cluster
    🔥  Creating kvm2 VM (CPUs=2, Memory=6144MB, Disk=20000MB) ...
    🐳  Preparing Kubernetes v1.34.0 on Docker 28.4.0 ...
    🔗  Configuring bridge CNI (Container Networking Interface) ...
    🔎  Verifying Kubernetes components...
	▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
    🌟  Enabled addons: storage-provisioner, default-storageclass

    ❗  /usr/local/bin/kubectl is version 1.32.1, which may have incompatibilities with Kubernetes 1.34.0.
	▪ Want kubectl v1.34.0? Try 'minikube kubectl -- get pods -A'
    🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default

Fixes #21548 
Fedora bug https://bugzilla.redhat.com/2394975