### PR TITLE
test: Remove duplicate kubernetes versions in preload_images.go

### DIFF
--- a/hack/preload-images/preload_images.go
+++ b/hack/preload-images/preload_images.go
@@ -131,11 +131,18 @@ func collectK8sVers() ([]string, error) {
 		}
 		k8sVersions = recent
 	}
-	versions := append([]string{
+	versions := []string{
+		constants.OldestKubernetesVersion,
 		constants.DefaultKubernetesVersion,
 		constants.NewestKubernetesVersion,
-		constants.OldestKubernetesVersion,
-	}, k8sVersions...)
+	}
+	
+	// Remove duplicate versions if DefaultKubernetesVersion == NewestKubernetesVersion
+	if constants.DefaultKubernetesVersion == constants.NewestKubernetesVersion {
+		versions = versions[:len(versions)-1]
+	}
+	
+	versions = append(versions, k8sVersions...)
 	return util.RemoveDuplicateStrings(versions), nil
 }
 


### PR DESCRIPTION
Fix duplicate Kubernetes version tests (#21483)

Remove duplicate test runs when DefaultKubernetesVersion equals NewestKubernetesVersion by adding deduplication logic to preload_images.go, following the same pattern already implemented in aaa_download_only_test.go.

Currently both constants are set to "v1.34.0", causing unnecessary duplicate test execution.