### PR TITLE
add auto to --log-colors because llama-server will crashloop in ai playground tutorial

### DIFF
--- a/site/content/en/docs/tutorials/ai-playground.md
+++ b/site/content/en/docs/tutorials/ai-playground.md
@@ -210,6 +210,7 @@ spec:
           --threads, "6",
           --no-warmup,
           --log-colors,
+          auto,
         ]
         resources:
           limits:
@@ -292,6 +293,7 @@ spec:
           --threads, "6",
           --no-warmup,
           --log-colors,
+          auto,
         ]
         resources:
           limits:


### PR DESCRIPTION
Llama-server will crash with
```error while handling argument "--log-colors": expected value for argument

usage:
--log-colors [on|off|auto]              Set colored logging ('on', 'off', or 'auto', default: 'auto')
                                        'auto' enables colors when output is to a terminal
                                        (env: LLAMA_LOG_COLORS)
```

Adding `auto` makes the command valid