### PR TITLE
test: Remove duplicate kubernetes versions in tests

### DIFF
--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/download"
 	"k8s.io/minikube/pkg/minikube/localpath"
+	"k8s.io/minikube/pkg/util"
 )
 
 // TestDownloadOnly makes sure the --download-only parameter in minikube start caches the appropriate images and tarballs.
@@ -58,16 +59,11 @@ func TestDownloadOnly(t *testing.T) { // nolint:gocyclo
 
 	containerRuntime := ContainerRuntime()
 
-	versions := []string{
+	versions := util.RemoveDuplicateStrings([]string{
 		constants.OldestKubernetesVersion,
 		constants.DefaultKubernetesVersion,
 		constants.NewestKubernetesVersion,
-	}
-
-	// Small optimization, don't run the exact same set of tests twice
-	if constants.DefaultKubernetesVersion == constants.NewestKubernetesVersion {
-		versions = versions[:len(versions)-1]
-	}
+	})
 
 	for _, v := range versions {
 		t.Run(v, func(t *testing.T) {


### PR DESCRIPTION
## Description

This PR addresses issue #21483 by removing duplicate Kubernetes versions in test execution.

## Problem

Currently, some tests use multiple Kubernetes versions in arrays like:
```go
versions := []string{
    constants.OldestKubernetesVersion,
    constants.DefaultKubernetesVersion,
    constants.NewestKubernetesVersion,
}
```

Since `DefaultKubernetesVersion` and `NewestKubernetesVersion` are both set to "v1.34.0", tests run twice for the same version, leading to unnecessary test execution time and resource usage.

## Solution

Replaced the manual deduplication logic in `test/integration/aaa_download_only_test.go` with the existing `util.RemoveDuplicateStrings()` function, which:

- Provides more robust deduplication
- Maintains consistency with other parts of the codebase (e.g., `hack/preload-images/preload_images.go`)
- Reduces code complexity and improves maintainability
- Eliminates the need for manual version equality checks

## Changes Made

- Added import for `k8s.io/minikube/pkg/util` package
- Replaced manual array creation and conditional deduplication with `util.RemoveDuplicateStrings()`
- Removed manual check: `if constants.DefaultKubernetesVersion == constants.NewestKubernetesVersion`
- Simplified the code from 9 lines to 4 lines

## Testing

The change maintains the same functional behavior while eliminating duplicate test runs. The `util.RemoveDuplicateStrings()` function is already well-tested and used throughout the codebase.

## Before/After

**Before:**
```go
versions := []string{
    constants.OldestKubernetesVersion,
    constants.DefaultKubernetesVersion,
    constants.NewestKubernetesVersion,
}

// Small optimization, don't run the exact same set of tests twice
if constants.DefaultKubernetesVersion == constants.NewestKubernetesVersion {
    versions = versions[:len(versions)-1]
}
```

**After:**
```go
versions := util.RemoveDuplicateStrings([]string{
    constants.OldestKubernetesVersion,
    constants.DefaultKubernetesVersion,
    constants.NewestKubernetesVersion,
})
```

Fixes #21483