### PR TITLE
verify aux drivers installed correctly and exit nicely if not

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -535,10 +535,10 @@ func updateDriver(driverName string) {
 		out.WarningT("Error parsing minikube version: {{.error}}", out.V{"error": err})
 	} else if err := auxdriver.InstallOrUpdate(driverName, localpath.MakeMiniPath("bin"), v, viper.GetBool(interactive), viper.GetBool(autoUpdate)); err != nil {
 		if errors.Is(err, auxdriver.ErrAuxDriverVersionCommandFailed) {
-			exit.Error(reason.DrvAuxNotHealthy, "Aux driver failed for:"+driverName, err)
+			exit.Error(reason.DrvAuxNotHealthy, "Aux driver "+driverName, err)
 		}
 		if errors.Is(err, auxdriver.ErrAuxDriverVersionNotinPath) {
-			exit.Error(reason.DrvAuxNotHealthy, "Aux driver not found in path "+driverName, err)
+			exit.Error(reason.DrvAuxNotHealthy, "Aux driver"+driverName, err)
 		} //if failed to update but not a fatal error, log it and continue (old version might still work)
 		out.WarningT("Unable to update {{.driver}} driver: {{.error}}", out.V{"driver": driverName, "error": err})
 	}

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -534,6 +534,12 @@ func updateDriver(driverName string) {
 	if err != nil {
 		out.WarningT("Error parsing minikube version: {{.error}}", out.V{"error": err})
 	} else if err := auxdriver.InstallOrUpdate(driverName, localpath.MakeMiniPath("bin"), v, viper.GetBool(interactive), viper.GetBool(autoUpdate)); err != nil {
+		if errors.Is(err, auxdriver.ErrAuxDriverVersionCommandFailed) {
+			exit.Error(reason.DrvAuxNotHealthy, "Aux driver failed for:"+driverName, err)
+		}
+		if errors.Is(err, auxdriver.ErrAuxDriverVersionNotinPath) {
+			exit.Error(reason.DrvAuxNotHealthy, "Aux driver not found in path "+driverName, err)
+		} //if failed to update but not a fatal error, log it and continue (old version might still work)
 		out.WarningT("Unable to update {{.driver}} driver: {{.error}}", out.V{"driver": driverName, "error": err})
 	}
 }

--- a/pkg/minikube/driver/auxdriver/install.go
+++ b/pkg/minikube/driver/auxdriver/install.go
@@ -93,7 +93,7 @@ func verifyExecutes(name string) error {
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		details := strings.TrimSpace(string(output))
-		klog.Errorf("%s failed: %v: %s", strings.Join(cmd.Args, " "), err, details)
+		klog.Warningf("%s failed: %v: %s", strings.Join(cmd.Args, " "), err, details)
 		return ErrAuxDriverVersionCommandFailed
 	}
 

--- a/pkg/minikube/driver/auxdriver/install.go
+++ b/pkg/minikube/driver/auxdriver/install.go
@@ -146,7 +146,7 @@ func validateDriver(executable string, v semver.Version) (string, error) {
 	cmd := exec.Command(path, "version")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		klog.Warningf("%s failed: %v: %s", strings.Join(cmd.Args, " "), err, output)
+		klog.Warningf("%s failed: %v: %s", cmd, err, output)
 		ErrAuxDriverVersionCommandFailed = newAuxUnthealthyError(path)
 		return path, ErrAuxDriverVersionCommandFailed
 	}

--- a/pkg/minikube/driver/auxdriver/install.go
+++ b/pkg/minikube/driver/auxdriver/install.go
@@ -39,11 +39,11 @@ import (
 )
 
 func newAuxUnthealthyError(path string) error {
-	return errors.New(fmt.Sprintf(`failed to execute auxiliary version command "%s --version"`, path))
+	return fmt.Errorf(`failed to execute auxiliary version command "%s --version"`, path)
 }
 
-func newAuxNotFoundError(path string) error {
-	return errors.New(fmt.Sprintf("auxiliary driver not found in path command %s", path))
+func newAuxNotFoundError(name, path string) error {
+	return fmt.Errorf("auxiliary driver %s not found in path %s", name, path)
 }
 
 // ErrAuxDriverVersionCommandFailed indicates the aux driver 'version' command failed to run
@@ -139,7 +139,7 @@ func validateDriver(executable string, v semver.Version) (string, error) {
 	path, err := exec.LookPath(executable)
 	if err != nil {
 		klog.Warningf("driver not in path : %s, %v", path, err.Error())
-		ErrAuxDriverVersionNotinPath = newAuxNotFoundError(path)
+		ErrAuxDriverVersionNotinPath = newAuxNotFoundError(executable, path)
 		return path, ErrAuxDriverVersionNotinPath
 	}
 

--- a/pkg/minikube/driver/auxdriver/install.go
+++ b/pkg/minikube/driver/auxdriver/install.go
@@ -43,7 +43,7 @@ func newAuxUnthealthyError(path string) error {
 }
 
 func newAuxNotFoundError(path string) error {
-	return errors.New(fmt.Sprintf("auxiliary not pound in path command %s", path))
+	return errors.New(fmt.Sprintf("auxiliary driver not found in path command %s", path))
 }
 
 // ErrAuxDriverVersionCommandFailed indicates the aux driver 'version' command failed to run

--- a/pkg/minikube/reason/reason.go
+++ b/pkg/minikube/reason/reason.go
@@ -318,6 +318,10 @@ var (
 	DrvNotFound = Kind{ID: "DRV_NOT_FOUND", ExitCode: ExDriverNotFound}
 	// minikube could not find a valid driver
 	DrvNotDetected = Kind{ID: "DRV_NOT_DETECTED", ExitCode: ExDriverNotFound}
+	// aux drivers (kvm or hyperkit) were not found
+	DrvAuxNotNotFound = Kind{ID: "DRV_AUX_NOT_FOUND", ExitCode: ExDriverNotFound}
+	// aux drivers (kvm or hyperkit) were found but not healthy
+	DrvAuxNotHealthy = Kind{ID: "DRV_AUX_NOT_HEALTHY", ExitCode: ExDriverError}
 	// minikube found drivers but none were ready to use
 	DrvNotHealthy = Kind{ID: "DRV_NOT_HEALTHY", ExitCode: ExDriverNotFound}
 	// minikube found the docker driver but the docker service was not running

--- a/test/integration/driver_install_or_update_test.go
+++ b/test/integration/driver_install_or_update_test.go
@@ -51,7 +51,6 @@ func TestKVMDriverInstallOrUpdate(t *testing.T) {
 		name string
 		path string
 	}{
-		{name: "driver-without-version-support", path: filepath.Join(*testdataDir, "kvm2-driver-without-version")},
 		{name: "driver-with-older-version", path: filepath.Join(*testdataDir, "kvm2-driver-older-version")},
 	}
 
@@ -82,7 +81,7 @@ func TestKVMDriverInstallOrUpdate(t *testing.T) {
 		os.Setenv("PATH", fmt.Sprintf("%s:%s", path, originalPath))
 
 		// NOTE: This should be a real version, as it impacts the downloaded URL
-		newerVersion, err := semver.Make("1.3.0")
+		newerVersion, err := semver.Make("1.37.0")
 		if err != nil {
 			t.Fatalf("Expected new semver. test: %v, got: %v", tc.name, err)
 		}

--- a/test/integration/driver_install_or_update_test.go
+++ b/test/integration/driver_install_or_update_test.go
@@ -58,7 +58,7 @@ func TestKVMDriverInstallOrUpdate(t *testing.T) {
 	defer os.Setenv("PATH", originalPath)
 
 	for _, tc := range tests {
-		dir := t.TempDir()
+		tempDLDir := t.TempDir()
 
 		pwd, err := os.Getwd()
 		if err != nil {
@@ -78,7 +78,7 @@ func TestKVMDriverInstallOrUpdate(t *testing.T) {
 			t.Fatalf("Expected not expected when changing driver permission. test: %s, got: %v", tc.name, err)
 		}
 
-		os.Setenv("PATH", fmt.Sprintf("%s:%s", path, originalPath))
+		os.Setenv("PATH", fmt.Sprintf("%s:%s:%s", tempDLDir, path, originalPath))
 
 		// NOTE: This should be a real version, as it impacts the downloaded URL
 		newerVersion, err := semver.Make("1.37.0")
@@ -86,12 +86,12 @@ func TestKVMDriverInstallOrUpdate(t *testing.T) {
 			t.Fatalf("Expected new semver. test: %v, got: %v", tc.name, err)
 		}
 
-		err = auxdriver.InstallOrUpdate("kvm2", dir, newerVersion, true, true)
+		err = auxdriver.InstallOrUpdate("kvm2", tempDLDir, newerVersion, true, true)
 		if err != nil {
 			t.Fatalf("Failed to update driver to %v. test: %s, got: %v", newerVersion, tc.name, err)
 		}
 
-		_, err = os.Stat(filepath.Join(dir, "docker-machine-driver-kvm2"))
+		_, err = os.Stat(filepath.Join(tempDLDir, "docker-machine-driver-kvm2"))
 		if err != nil {
 			t.Fatalf("Expected driver to be download. test: %s, got: %v", tc.name, err)
 		}

--- a/test/integration/driver_install_or_update_test.go
+++ b/test/integration/driver_install_or_update_test.go
@@ -69,8 +69,18 @@ func TestKVMDriverInstallOrUpdate(t *testing.T) {
 
 		_, err = os.Stat(filepath.Join(path, "docker-machine-driver-kvm2"))
 		if err != nil {
-			t.Fatalf("Expected driver to exist. test: %s, got: %v", tc.name, err)
+			t.Fatalf("Expected test data driver to exist. test: %s, got: %v", tc.name, err)
 		}
+
+		// copy test data driver into the temp download dir so we can point PATH to it for before/after install
+		src := filepath.Join(path, "docker-machine-driver-kvm2")
+		dst := filepath.Join(tempDLDir, "docker-machine-driver-kvm2")
+		if err = CopyFile(src, dst, false); err != nil {
+			t.Fatalf("Failed to copy test data driver to temp dir. test: %s, got: %v", tc.name, err)
+		}
+
+		// point to the copied driver for the rest of the test
+		path = tempDLDir
 
 		// change permission to allow driver to be executable
 		err = os.Chmod(filepath.Join(path, "docker-machine-driver-kvm2"), 0700)
@@ -78,7 +88,7 @@ func TestKVMDriverInstallOrUpdate(t *testing.T) {
 			t.Fatalf("Expected not expected when changing driver permission. test: %s, got: %v", tc.name, err)
 		}
 
-		os.Setenv("PATH", fmt.Sprintf("%s:%s:%s", tempDLDir, path, originalPath))
+		os.Setenv("PATH", fmt.Sprintf("%s:%s", path, originalPath))
 
 		// NOTE: This should be a real version, as it impacts the downloaded URL
 		newerVersion, err := semver.Make("1.37.0")


### PR DESCRIPTION
improve user experince for  When our aux driver is doesnt run
```

jenkins@ubuntu-20-agent-3:~/workspace/minikube$ docker-machine-driver-kvm2 --version
docker-machine-driver-kvm2: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by docker-machine-driver-kvm2)
docker-machine-driver-kvm2: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by docker-machine-driver-kvm2)
docker-machine-driver-kvm2: /lib/x86_64-linux-gnu/libvirt.so.0: version `LIBVIRT_7.1.0' not found (required by docker-machine-driver-kvm2)
docker-machine-driver-kvm2: /lib/x86_64-linux-gnu/libvirt.so.0: version `LIBVIRT_7.7.0' not found (required by docker-machine-driver-kvm2)
docker-machine-driver-kvm2: /lib/x86_64-linux-gnu/libvirt.so.0: version `LIBVIRT_8.0.0' not found (required by docker-machine-driver-kvm2)
docker-machine-driver-kvm2: /lib/x86_64-linux-gnu/libvirt.so.0: version `LIBVIRT_7.8.0' not found (required by docker-machine-driver-kvm2)
docker-machine-driver-kvm2: /lib/x86_64-linux-gnu/libvirt.so.0: version `LIBVIRT_7.2.0' not found (required by docker-machine-driver-kvm2)
docker-machine-driver-kvm2: /lib/x86_64-linux-gnu/libvirt.so.0: version `LIBVIRT_6.10.0' not found (required by docker-machine-driver-kvm2)
docker-machine-driver-kvm2: /lib/x86_64-linux-gnu/libvirt.so.0: version `LIBVIRT_7.3.0' not found (required by docker-machine-driver-kvm2)
```

## before this PR
```
jenkins@ubuntu-20-agent-3:~$ minikube start -d kvm
😄  minikube v1.37.0 on Ubuntu 20.04 (kvm/amd64)
✨  Using the kvm2 driver based on user configuration
💾  Downloading driver docker-machine-driver-kvm2:
    > docker-machine-driver-kvm2-...:  65 B / 65 B [---------] 100.00% ? p/s 0s
    > docker-machine-driver-kvm2-...:  15.22 MiB / 15.22 MiB  100.00% ? p/s 100
💿  Downloading VM boot image ...
    > minikube-v1.37.0-amd64.iso....:  65 B / 65 B [---------] 100.00% ? p/s 0s
    > minikube-v1.37.0-amd64.iso:  370.78 MiB / 370.78 MiB  100.00% 185.23 MiB 
👍  Starting "minikube" primary control-plane node in "minikube" cluster
🔥  Creating kvm2 VM (CPUs=2, Memory=6144MB, Disk=20000MB) ...
🤦  StartHost failed, but will try again: new host: dial tcp: missing address
🔥  Creating kvm2 VM (CPUs=2, Memory=6144MB, Disk=20000MB) ...
😿  Failed to start kvm2 VM. Running "minikube delete" may fix it: new host: dial tcp: missing address

❌  Exiting due to DRV_MISSING_ADDRESS: Failed to start host: new host: dial tcp: missing address
💡  Suggestion: The machine-driver specified is failing to start. Try running 'docker-machine-driver-<type> version'
🍿  Related issues:
    ▪ https://github.com/kubernetes/minikube/issues/6023
    ▪ https://github.com/kubernetes/minikube/issues/4679

╭───────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                           │
│    😿  If the above advice does not help, please let us know:                             │
│    👉  https://github.com/kubernetes/minikube/issues/new/choose                           │
│                                                                                           │
│    Please run `minikube logs --file=logs.txt` and attach logs.txt to the GitHub issue.    │
│                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────╯
```


## After this PR

```
jenkins@ubuntu-20-agent-3:~/workspace/minikube$ ./out/minikube start -d kvm
😄  minikube v1.37.0 on Ubuntu 20.04 (kvm/amd64)
✨  Using the kvm2 driver based on user configuration
💾  Downloading driver docker-machine-driver-kvm2:
    > docker-machine-driver-kvm2-...:  65 B / 65 B [---------] 100.00% ? p/s 0s
    > docker-machine-driver-kvm2-...:  15.22 MiB / 15.22 MiB  100.00% ? p/s 100

❌  Exiting due to DRV_AUX_NOT_HEALTHY: Aux driver kvm2: failed to execute auxiliary version command "/home/jenkins/.minikube/bin/docker-machine-driver-kvm2 --version"

╭───────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                           │
│    😿  If the above advice does not help, please let us know:                             │
│    👉  https://github.com/kubernetes/minikube/issues/new/choose                           │
│                                                                                           │
│    Please run `minikube logs --file=logs.txt` and attach logs.txt to the GitHub issue.    │
│                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────╯
```