### PR TITLE
Detect and log Docker Hub rate limit errors in image pulls

### DIFF
--- a/pkg/minikube/machine/cache_images.go
+++ b/pkg/minikube/machine/cache_images.go
@@ -596,6 +596,10 @@ func PullImages(images []string, profile *config.Profile) error {
 			err = pullImages(crMgr, images)
 			if err != nil {
 				failed = append(failed, m)
+				// Rate limit check
+				if strings.Contains(err.Error(), "429 Too Many Requests") {
+					klog.Warningf("Docker Hub rate limit reached for profile %s. See: https://www.docker.com/increase-rate-limit", pName)
+				}
 				klog.Warningf("Failed to pull images for profile %s %v", pName, err.Error())
 				continue
 			}


### PR DESCRIPTION
This PR improves error visibility when pulling images fails due to Docker Hub rate limits.

### Changes
- Updated `PullImages` function in `cache_images.go` to detect `429 Too Many Requests` errors.
- Added a warning log with a helpful link: https://www.docker.com/increase-rate-limit
- Ensures users are clearly informed when image pulls fail due to Docker Hub rate limiting.

### Impact
Users will now see a clear log message if image pulls fail because of Docker Hub rate limits, instead of only a generic failure message.

### Testing
- Simulated a `429 Too Many Requests` error in `pullImages`.
- Verified the following log output appears:

Docker Hub rate limit reached for profile minikube. See: https://www.docker.com/increase-rate-limit

Fixes: #21442 
