### PR TITLE
test: Fix vmnet-helper installation in the CI

### DIFF
--- a/.github/workflows/functional_test.yml
+++ b/.github/workflows/functional_test.yml
@@ -377,7 +377,7 @@ jobs:
         if: matrix.os == 'macos-13' && matrix.driver == 'vfkit'
         run: |
           brew install vfkit
-          curl -fsSL https://github.com/minikube-machine/vmnet-helper/releases/latest/download/install.sh | bash -s
+          curl -fsSL https://github.com/minikube-machine/vmnet-helper/releases/latest/download/install.sh | sudo VMNET_INTERACTIVE=0 bash
       - name: Download Test Binaries
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         with:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -112,7 +112,7 @@ jobs:
         if: matrix.driver == 'vfkit'
         run: |
           brew install vfkit
-          curl -fsSL https://github.com/minikube-machine/vmnet-helper/releases/latest/download/install.sh | bash -s
+          curl -fsSL https://github.com/minikube-machine/vmnet-helper/releases/latest/download/install.sh | sudo VMNET_INTERACTIVE=0 bash
       - name: Install qemu and socket_vmnet (macos)
         if: matrix.os == 'macos-13' && matrix.driver == 'qemu'
         run: |


### PR DESCRIPTION
The step was using wrong command that used to work with the older install script from v0.6.0. Update to use the curent install script arguemnts.

The installtion fails with:

    Installation requires your password to install vmnet-helper as root
    bash: line 39: /dev/tty: Device not configured

Example failures:
- https://github.com/kubernetes/minikube/actions/runs/17867731846/job/50814361418?pr=21594
- https://github.com/kubernetes/minikube/actions/runs/17867731834/job/50814026715?pr=21594