### PR TITLE
set sysctl params for inotify, to avoid 'too many open files' errors

### DIFF
--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -89,6 +89,13 @@ if [ "$(uname)" = "Darwin" ]; then
   fi
 fi
 
+## set sysctl params for inotify, to avoid "too many open files" errors
+## ref: https://cloud.google.com/kubernetes-engine/distributed-cloud/bare-metal/docs/installing/configure-os/ubuntu
+if [ "$OS" == "linux" ]; then
+  sudo sysctl -w fs.inotify.max_user_instances=8192
+  sudo sysctl -w fs.inotify.max_user_watches=524288
+fi
+
 # We need pstree for the restart cronjobs
 if [ "$(uname)" != "Darwin" ]; then
   sudo apt-get -y install lsof psmisc dnsutils


### PR DESCRIPTION
we noticed that [TestMultiControlPlane/serial/AddWorkerNode](https://gopogh-server-tts3vkcpgq-uc.a.run.app/?env=Docker_Linux&test=TestMultiControlPlane/serial/AddWorkerNode) has started failing persistently since we switched the ci runners to use ubuntu 22.04 ([gopogh flake chart](https://gopogh-server-tts3vkcpgq-uc.a.run.app/?env=Docker_Linux&test=TestMultiControlPlane/serial/AddWorkerNode))

example ci job log: https://storage.googleapis.com/minikube-builds/logs/master/41465/Docker_Linux.html

the issue is: `Failed to create control group inotify object: Too many open files`, and this pr sets the sysctl params for inotify on the ci runner, to avoid these errors