### PR TITLE
preload: download from github when gcs not available

### DIFF
--- a/pkg/minikube/download/download_test.go
+++ b/pkg/minikube/download/download_test.go
@@ -184,7 +184,13 @@ func testImageToCache(t *testing.T) {
 }
 
 // Validates that preload existence checks correctly caches values retrieved by remote checks.
-// Validates that preload existence checks correctly caches values retrieved by remote checks.
+// testPreloadExistsCaching verifies the caching semantics of PreloadExists when
+// the local cache is absent and remote existence checks are required.
+// In summary, this test enforces that:
+// - PreloadExists performs remote checks only on cache misses.
+// - Negative and positive results are cached per (k8sVersion, containerVersion, runtime) key.
+// - GitHub is only consulted when GCS reports the preload as not existing.
+// - Global state is correctly restored after the test.
 func testPreloadExistsCaching(t *testing.T) {
 	checkCache = func(_ string) (fs.FileInfo, error) {
 		return nil, fmt.Errorf("cache not found")

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -122,13 +122,23 @@ func remoteTarballURL(k8sVersion, containerRuntime string, source preloadSource)
 	}
 }
 
-func setPreloadState(k8sVersion, containerRuntime string, value bool) {
+func setPreloadState(k8sVersion, containerRuntime string, state preloadState) {
 	cRuntimes, ok := preloadStates[k8sVersion]
 	if !ok {
-		cRuntimes = make(map[string]bool)
+		cRuntimes = make(map[string]preloadState)
 		preloadStates[k8sVersion] = cRuntimes
 	}
-	cRuntimes[containerRuntime] = value
+	cRuntimes[containerRuntime] = state
+}
+
+func getPreloadState(k8sVersion, containerRuntime string) (preloadState, bool) {
+	if cRuntimes, ok := preloadStates[k8sVersion]; ok {
+		state, ok := cRuntimes[containerRuntime]
+		if ok {
+			return state, true
+		}
+	}
+	return preloadState{}, false
 }
 
 var checkRemotePreloadExists = func(k8sVersion, containerRuntime string) bool {

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -103,9 +103,14 @@ func TarballPath(k8sVersion, containerRuntime string) string {
 	return filepath.Join(targetDir(), TarballName(k8sVersion, containerRuntime))
 }
 
-// remoteTarballURL returns the URL for the remote tarball in GCS
-func remoteTarballURL(k8sVersion, containerRuntime string) string {
+// remoteTarballURLGCS returns the URL for the remote tarball in GCS
+func remoteTarballURLGCS(k8sVersion, containerRuntime string) string {
 	return fmt.Sprintf("https://%s/%s/%s/%s/%s", downloadHost, PreloadBucket, PreloadVersion, k8sVersion, TarballName(k8sVersion, containerRuntime))
+}
+
+// remoteTarballURLGitHub returns the URL for the remote tarball hosted on GitHub releases
+func remoteTarballURLGitHub(k8sVersion, containerRuntime string) string {
+	return fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", PreloadGitHubRepo, PreloadVersion, TarballName(k8sVersion, containerRuntime))
 }
 
 func setPreloadState(k8sVersion, containerRuntime string, value bool) {

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -113,6 +113,15 @@ func remoteTarballURLGitHub(k8sVersion, containerRuntime string) string {
 	return fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", PreloadGitHubRepo, PreloadVersion, TarballName(k8sVersion, containerRuntime))
 }
 
+func remoteTarballURL(k8sVersion, containerRuntime string, source preloadSource) string {
+	switch source {
+	case preloadSourceGitHub:
+		return remoteTarballURLGitHub(k8sVersion, containerRuntime)
+	default:
+		return remoteTarballURLGCS(k8sVersion, containerRuntime)
+	}
+}
+
 func setPreloadState(k8sVersion, containerRuntime string, value bool) {
 	cRuntimes, ok := preloadStates[k8sVersion]
 	if !ok {

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -168,6 +168,16 @@ var checkRemotePreloadExistsGitHub = func(k8sVersion, containerRuntime string) b
 	return remotePreloadExists(url)
 }
 
+// PreloadExistsGCS returns true if there is a preloaded tarball in GCS that can be used
+func PreloadExistsGCS(k8sVersion, containerRuntime string) bool {
+	return checkRemotePreloadExistsGCS(k8sVersion, containerRuntime)
+}
+
+// PreloadExistsGH returns true if there is a preloaded tarball in GitHub releases that can be used
+func PreloadExistsGH(k8sVersion, containerRuntime string) bool {
+	return checkRemotePreloadExistsGitHub(k8sVersion, containerRuntime)
+}
+
 // PreloadExists returns true if there is a preloaded tarball that can be used
 func PreloadExists(k8sVersion, containerRuntime, driverName string, forcePreload ...bool) bool {
 	// TODO (#8166): Get rid of the need for this and viper at all

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -141,8 +141,7 @@ func getPreloadState(k8sVersion, containerRuntime string) (preloadState, bool) {
 	return preloadState{}, false
 }
 
-var checkRemotePreloadExists = func(k8sVersion, containerRuntime string) bool {
-	url := remoteTarballURL(k8sVersion, containerRuntime)
+func remotePreloadExists(url string) bool {
 	resp, err := http.Head(url)
 	if err != nil {
 		klog.Warningf("%s fetch error: %v", url, err)
@@ -157,6 +156,16 @@ var checkRemotePreloadExists = func(k8sVersion, containerRuntime string) bool {
 
 	klog.Infof("Found remote preload: %s", url)
 	return true
+}
+
+var checkRemotePreloadExistsGCS = func(k8sVersion, containerRuntime string) bool {
+	url := remoteTarballURLGCS(k8sVersion, containerRuntime)
+	return remotePreloadExists(url)
+}
+
+var checkRemotePreloadExistsGitHub = func(k8sVersion, containerRuntime string) bool {
+	url := remoteTarballURLGitHub(k8sVersion, containerRuntime)
+	return remotePreloadExists(url)
 }
 
 // PreloadExists returns true if there is a preloaded tarball that can be used

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -47,10 +47,26 @@ const (
 	PreloadVersion = "v18"
 	// PreloadBucket is the name of the GCS bucket where preloaded volume tarballs exist
 	PreloadBucket = "minikube-preloaded-volume-tarballs"
+	// PreloadGitHubRepo is the GitHub repo that hosts the preload artifacts
+	PreloadGitHubRepo = "kubernetes/minikube-preloads"
 )
 
+type preloadSource string
+
+const (
+	preloadSourceNone   preloadSource = ""
+	preloadSourceLocal  preloadSource = "local"
+	preloadSourceGCS    preloadSource = "gcs"
+	preloadSourceGitHub preloadSource = "github"
+)
+
+type preloadState struct {
+	exists bool
+	source preloadSource
+}
+
 var (
-	preloadStates = make(map[string]map[string]bool)
+	preloadStates = make(map[string]map[string]preloadState)
 )
 
 // TarballName returns name of the tarball


### PR DESCRIPTION
- **add a struct for preload state with option to have preload source set**
- **break down remote tar url funcs to gcs and github**
- **make a helper to choose remote url based on source type gh or gcs**
- **add helpers for getting and setting preload state**
- **break down check preload exists two to funcs**
- **add exported funcs to check existance of preload to be called by outside minikube**
- **add github as fail over to gcs in preload check for minikube**
- **update Preload func to use new implemnetations**
- **fix unit test**
- **add comments for unit test**

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
