### PR TITLE
docs: Add vfkit and krunkit options in ISSUE_TEMPLATE (#21604)

### DIFF
--- a/.github/ISSUE_TEMPLATE/__en-US.yaml
+++ b/.github/ISSUE_TEMPLATE/__en-US.yaml
@@ -50,5 +50,7 @@ body:
         - VMware
         - Parallels
         - QEMU
+        - vfkit
+        - krunkit
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/ru.yaml
+++ b/.github/ISSUE_TEMPLATE/ru.yaml
@@ -48,5 +48,7 @@ body:
         - VMware
         - Parallels
         - QEMU
+        - vfkit
+        - krunkit
     validations:
       required: false


### PR DESCRIPTION
### Why are we solving this issue?
Currently, when selecting a driver in the image template, `vfkit` and `krunkit` are not available as options.  
This update ensures that users can also select these drivers, which are already supported in minikube, improving completeness and user experience.

### To address this issue, are there any code changes?
Yes.  
I updated the `.github/ISSUE_TEMPLATE` files to include `vfkit` and `krunkit` in the driver selection list.  
No functional code changes are required since the drivers are already supported; this PR only updates the templates to reflect that.

### What places can the assignee treat as reference points?
- `.github/ISSUE_TEMPLATE/` folder (issue templates definitions)  
- Existing driver options already listed (e.g., `docker`, `podman`, etc.)  

### How can the assignee reach out to you for help?
Feel free to tag me in the PR discussion (`@henry0512`) or comment directly in issue [#21604](https://github.com/kubernetes/minikube/issues/21604).
