### PR TITLE
Deprecated VirtualBox with warning

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -308,7 +308,7 @@ func provisionWithDriver(cmd *cobra.Command, ds registry.DriverState, existing *
 		klog.Errorf("Error autoSetOptions : %v", err)
 	}
 
-	virtualBoxMacOS13PlusWarning(driverName)
+	virtualBoxDeprecationWarning(driverName)
 	hyperkitDeprecationWarning(driverName)
 	validateFlags(cmd, driverName)
 	validateUser(driverName)
@@ -402,16 +402,17 @@ func provisionWithDriver(cmd *cobra.Command, ds registry.DriverState, existing *
 	}, nil
 }
 
-func virtualBoxMacOS13PlusWarning(driverName string) {
-	if !driver.IsVirtualBox(driverName) || !detect.MacOS13Plus() {
+// virtualBoxDeprecationWarning prints a deprecation warning for the virtualbox driver
+func virtualBoxDeprecationWarning(driverName string) {
+	if !driver.IsVirtualBox(driverName) {
 		return
 	}
-	out.WarningT(`Due to changes in macOS 13+ minikube doesn't currently support VirtualBox. You can use alternative drivers such as 'vfkit', 'qemu', or 'docker'.
+	out.WarningT(`The 'virtualbox' driver is deprecated and will be removed in a future release.
+    You can use alternative drivers such as 'vfkit', 'qemu', or 'docker'.
     https://minikube.sigs.k8s.io/docs/drivers/vfkit/
     https://minikube.sigs.k8s.io/docs/drivers/qemu/
     https://minikube.sigs.k8s.io/docs/drivers/docker/
-    For more details on the issue see: https://github.com/kubernetes/minikube/issues/15274
-`)
+	`)
 }
 
 // hyperkitDeprecationWarning prints a deprecation warning for the hyperkit driver

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -408,11 +408,7 @@ func virtualBoxDeprecationWarning(driverName string) {
 		return
 	}
 	out.WarningT(`The 'virtualbox' driver is deprecated and will be removed in a future release.
-    You can use alternative drivers such as 'vfkit', 'qemu', or 'docker'.
-    https://minikube.sigs.k8s.io/docs/drivers/vfkit/
-    https://minikube.sigs.k8s.io/docs/drivers/qemu/
-    https://minikube.sigs.k8s.io/docs/drivers/docker/
-	`)
+    You can use alternative drivers: {{.drivers}}.`, out.V{"drivers": strings.Join(driver.SupportedDrivers(), ", ")})
 }
 
 // hyperkitDeprecationWarning prints a deprecation warning for the hyperkit driver

--- a/pkg/minikube/registry/drvs/virtualbox/virtualbox.go
+++ b/pkg/minikube/registry/drvs/virtualbox/virtualbox.go
@@ -47,7 +47,7 @@ func init() {
 		Config:   configure,
 		Status:   status,
 		Default:  true,
-		Priority: registry.Fallback,
+		Priority: registry.Deprecated,
 		Init:     func() drivers.Driver { return virtualbox.NewDriver("", "") },
 	})
 	if err != nil {


### PR DESCRIPTION
This PR adds a deprecation warning for the VirtualBox driver, similar to the existing hyperkit deprecation warning. The VirtualBox driver will display a clear warning message to users indicating it will be removed in a future release and suggesting alternative drivers.
Before 

## Before  

```bash
😄 minikube v1.37.0 on Darwin 15.6.1 (arm64)
✨ Using the virtualbox driver based on user configuration
👍 Starting "minikube" primary control-plane node in "minikube" cluster 
```

## After
```bash
divysinghvi@Divys-MacBook-Air minikube % ./out/minikube start --driver=virtualbox
😄  minikube v1.37.0 on Darwin 15.6.1 (arm64)
✨  Using the virtualbox driver based on user configuration
❗  The 'virtualbox' driver is deprecated and will be removed in a future release.
    You can use alternative drivers such as 'vfkit', 'qemu', or 'docker'.
    https://minikube.sigs.k8s.io/docs/drivers/vfkit/
    https://minikube.sigs.k8s.io/docs/drivers/qemu/
    https://minikube.sigs.k8s.io/docs/drivers/docker/
```

After suggested change
```bash
✨  Using the virtualbox driver based on user configuration
❗  The 'virtualbox' driver is deprecated and will be removed in a future release.
    You can use alternative drivers: qemu2, vfkit, krunkit, parallels, docker, podman, ssh.
```

Fixes #21608
