### PR TITLE
vmnet: Skip validation in download-only mode

### DIFF
--- a/pkg/drivers/common/vmnet/vmnet.go
+++ b/pkg/drivers/common/vmnet/vmnet.go
@@ -72,6 +72,14 @@ type interfaceInfo struct {
 // The returned error.Kind can be used to provide a suggestion for resolving the
 // issue.
 func ValidateHelper() error {
+	// Ideally minikube will not try to validate in download-only mode, but this
+	// is called from different places in different drivers, so the easier way
+	// to skip validation is to skip it here.
+	if viper.GetBool("download-only") {
+		log.Debug("Skipping vmnet-helper validation in download-only mode")
+		return nil
+	}
+
 	// Is it installed?
 	if _, err := os.Stat(executablePath); err != nil {
 		if errors.Is(err, os.ErrNotExist) {


### PR DESCRIPTION
In this mode we don't start anything so we don't need to validate vmnet-helper. This avoids unwanted interaction if the user does not have sudoers configuration.

Test with vfkit:

    % out/minikube start --driver vfkit --network vmnet-shared --download-only
    😄  minikube v1.37.0 on Darwin 15.7 (arm64)
    ✨  Using the vfkit driver based on user configuration
    👍  Starting "minikube" primary control-plane node in "minikube" cluster
    ✅  Download complete!

    % out/minikube logs | grep vmnet-helper
    I0925 16:52:08.601139   78267 main.go:141] libmachine: Skipping vmnet-helper validation in download-only mode

Test with krunkit:

    % out/minikube start --driver krunkit --download-only
    😄  minikube v1.37.0 on Darwin 15.7 (arm64)
    ✨  Using the krunkit (experimental) driver based on user configuration
    👍  Starting "minikube" primary control-plane node in "minikube" cluster
    ✅  Download complete!

    % out/minikube logs | grep vmnet-helper
    I0925 16:52:49.570566   78405 main.go:141] libmachine: Skipping vmnet-helper validation in download-only mode

Fixes #21634 