### PR TITLE
Refactor Ivoking Kubeadm command to prepare for debian 12

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/binaries.go
+++ b/pkg/minikube/bootstrapper/bsutil/binaries.go
@@ -46,7 +46,7 @@ func TransferBinaries(cfg config.KubernetesConfig, c command.Runner, sm sysinit.
 	}
 	klog.Infof("Didn't find k8s binaries: %v\nInitiating transfer...", err)
 
-	dir := binRoot(cfg.KubernetesVersion)
+	dir := BinRoot(cfg.KubernetesVersion)
 	_, err = c.RunCmd(exec.Command("sudo", "mkdir", "-p", dir))
 	if err != nil {
 		return err
@@ -79,7 +79,7 @@ func TransferBinaries(cfg config.KubernetesConfig, c command.Runner, sm sysinit.
 
 // binariesExist returns true if the binaries already exist
 func binariesExist(cfg config.KubernetesConfig, c command.Runner) (bool, error) {
-	dir := binRoot(cfg.KubernetesVersion)
+	dir := BinRoot(cfg.KubernetesVersion)
 	rr, err := c.RunCmd(exec.Command("sudo", "ls", dir))
 	if err != nil {
 		return false, err
@@ -97,7 +97,7 @@ func binariesExist(cfg config.KubernetesConfig, c command.Runner) (bool, error) 
 	return true, nil
 }
 
-// binRoot returns the persistent path binaries are stored in
-func binRoot(version string) string {
+// BinRoot returns the persistent path binaries are stored in
+func BinRoot(version string) string {
 	return path.Join(vmpath.GuestPersistentDir, "binaries", version)
 }

--- a/pkg/minikube/bootstrapper/bsutil/kubeadm.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubeadm.go
@@ -222,7 +222,7 @@ var KubeadmExtraConfigOpts = []string{
 
 // InvokeKubeadm returns the invocation command for Kubeadm
 func InvokeKubeadm(version string) string {
-	return fmt.Sprintf("sudo env PATH=\"%s:$PATH\" kubeadm", binRoot(version))
+	return fmt.Sprintf("sudo env PATH=\"%s:$PATH\" kubeadm", BinRoot(version))
 }
 
 // EtcdDataDir is where etcd data is stored.

--- a/pkg/minikube/bootstrapper/bsutil/kubeadm.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubeadm.go
@@ -220,9 +220,12 @@ var KubeadmExtraConfigOpts = []string{
 	Kubeproxy,
 }
 
-// InvokeKubeadm returns the invocation command for Kubeadm
-func InvokeKubeadm(version string) string {
-	return fmt.Sprintf("sudo env PATH=\"%s:$PATH\" kubeadm", BinRoot(version))
+// KubeadmCmdWithPath returns the invocation command for Kubeadm
+// NOTE: The command must run with the a root shell to expand PATH to the
+// root PATH. On Debian 12 user PATH does not contain /usr/sbin which breaks
+// kubeadm since https://github.com/kubernetes/kubernetes/pull/129450.
+func KubeadmCmdWithPath(version string) string {
+	return fmt.Sprintf("env PATH=\"%s:$PATH\" kubeadm", BinRoot(version))
 }
 
 // EtcdDataDir is where etcd data is stored.

--- a/pkg/minikube/bootstrapper/bsutil/kubelet.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubelet.go
@@ -140,7 +140,7 @@ func NewKubeletConfig(mc config.ClusterConfig, nc config.Node, r cruntime.Manage
 	}{
 		ExtraOptions:     convertToFlags(extraOpts),
 		ContainerRuntime: k8s.ContainerRuntime,
-		KubeletPath:      path.Join(binRoot(k8s.KubernetesVersion), "kubelet"),
+		KubeletPath:      path.Join(BinRoot(k8s.KubernetesVersion), "kubelet"),
 	}
 	if err := ktmpl.KubeletSystemdTemplate.Execute(&b, opts); err != nil {
 		return nil, err
@@ -152,7 +152,7 @@ func NewKubeletConfig(mc config.ClusterConfig, nc config.Node, r cruntime.Manage
 // NewKubeletService returns a generated systemd unit file for the kubelet
 func NewKubeletService(cfg config.KubernetesConfig) ([]byte, error) {
 	var b bytes.Buffer
-	opts := struct{ KubeletPath string }{KubeletPath: path.Join(binRoot(cfg.KubernetesVersion), "kubelet")}
+	opts := struct{ KubeletPath string }{KubeletPath: path.Join(BinRoot(cfg.KubernetesVersion), "kubelet")}
 	if err := ktmpl.KubeletServiceTemplate.Execute(&b, opts); err != nil {
 		return nil, errors.Wrap(err, "template execute")
 	}

--- a/pkg/minikube/node/node.go
+++ b/pkg/minikube/node/node.go
@@ -149,8 +149,8 @@ func teardown(cc config.ClusterConfig, name string) (*config.Node, error) {
 				sp = "unix://" + sp
 			}
 
-			cmd := exec.Command("/bin/bash", "-c", fmt.Sprintf("KUBECONFIG=/var/lib/minikube/kubeconfig %s reset --force --ignore-preflight-errors=all --cri-socket=%s",
-				bsutil.InvokeKubeadm(cc.KubernetesConfig.KubernetesVersion), sp))
+			cmd := exec.Command("sudo", "/bin/bash", "-c", fmt.Sprintf("KUBECONFIG=/var/lib/minikube/kubeconfig %s reset --force --ignore-preflight-errors=all --cri-socket=%s",
+				bsutil.KubeadmCmdWithPath(cc.KubernetesConfig.KubernetesVersion), sp))
 			if _, kerr = r.RunCmd(cmd); kerr == nil {
 				klog.Infof("successfully reset node %q", m)
 			}

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -346,7 +346,7 @@ func joinCluster(starter Starter, cpBs bootstrapper.Bootstrapper, bs bootstrappe
 
 			// reset node to revert any changes made by previous kubeadm init/join
 			klog.Infof("resetting %s node %q before attempting to rejoin cluster...", role, starter.Node.Name)
-			if _, err := starter.Runner.RunCmd(exec.Command("/bin/bash", "-c", fmt.Sprintf("%s reset --force", bsutil.InvokeKubeadm(starter.Cfg.KubernetesConfig.KubernetesVersion)))); err != nil {
+			if _, err := starter.Runner.RunCmd(exec.Command("sudo", "/bin/bash", "-c", fmt.Sprintf("%s reset --force", bsutil.KubeadmCmdWithPath(starter.Cfg.KubernetesConfig.KubernetesVersion)))); err != nil {
 				klog.Infof("kubeadm reset failed, continuing anyway: %v", err)
 			} else {
 				klog.Infof("successfully reset %s node %q", role, starter.Node.Name)


### PR DESCRIPTION
- **bootstrapper: Export bsutil.binRoot**
- **bootstraper: Fix kubeadm init PATH on Debian 12**
- **bootstrapper: rename func to  KubeadmCmdWithPath**
- **move sudo before bash -c everywhere we invoke kubeadms to ensure gets the correct path**

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
