### PR TITLE
Move linux/darwin binaries into cache/binaries folder (#21179)

### DIFF
--- a/pkg/minikube/download/binary.go
+++ b/pkg/minikube/download/binary.go
@@ -19,7 +19,7 @@ package download
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"runtime"
 
 	"github.com/blang/semver/v4"
@@ -53,8 +53,12 @@ func binaryWithChecksumURL(binaryName, version, osName, archName, binaryURL stri
 
 // Binary will download a binary onto the host
 func Binary(binary, version, osName, archName, binaryURL string) (string, error) {
-	targetDir := localpath.MakeMiniPath("cache", osName, archName, version)
-	targetFilepath := path.Join(targetDir, binary)
+	targetFilepath := localpath.CachedBinaryPath(binary, version, osName, archName)
+	targetDir := filepath.Dir(targetFilepath)
+
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		return "", errors.Wrapf(err, "failed to create target dir %s", targetDir)
+	}
 	targetLock := targetFilepath + ".lock"
 
 	url, err := binaryWithChecksumURL(binary, version, osName, archName, binaryURL)

--- a/pkg/minikube/download/download_test.go
+++ b/pkg/minikube/download/download_test.go
@@ -20,11 +20,13 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 
 	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/localpath"
 )
 
 // Force download tests to run in serial.
@@ -240,5 +242,26 @@ func testPreloadWithCachedSizeZero(t *testing.T) {
 
 	if downloadNum != 1 {
 		t.Errorf("Expected only 1 download attempt but got %v!", downloadNum)
+	}
+}
+
+func TestBinaryCreatesBinariesDir(t *testing.T) {
+	// mock download function that creates a fake binary file
+	DownloadMock = func(src, dst string) error {
+		// create a fake binary file at dst
+		return os.WriteFile(dst, []byte("fake-binary"), 0755)
+	}
+
+	_, err := Binary("kubectl", "v1.31.0", "linux", "amd64", "")
+	if err != nil {
+		t.Fatalf("Binary() failed: %v", err)
+	}
+
+	// check that the bin directory was created
+	targetDir := filepath.Join(
+		localpath.MiniPath(), "cache", "bin", "linux", "amd64", "v1.31.0",
+	)
+	if _, err := os.Stat(targetDir); os.IsNotExist(err) {
+		t.Errorf("Expected bin dir %s to exist, but it does not", targetDir)
 	}
 }

--- a/pkg/minikube/localpath/localpath.go
+++ b/pkg/minikube/localpath/localpath.go
@@ -247,3 +247,7 @@ func getWindowsVolumeNameCmd(d string) (string, error) {
 }
 
 var getWindowsVolumeName = getWindowsVolumeNameCmd
+
+func CachedBinaryPath(binary, version, goos, goarch string) string {
+	return filepath.Join(MiniPath(), "cache", "bin", goos, goarch, version, binary)
+}

--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -152,7 +152,7 @@ func TestDownloadOnly(t *testing.T) { // nolint:gocyclo
 				}
 				// checking binaries downloaded (kubelet,kubeadm)
 				for _, bin := range constants.KubernetesReleaseBinaries {
-					fp := filepath.Join(localpath.MiniPath(), "cache", "linux", runtime.GOARCH, v, bin)
+					fp := localpath.CachedBinaryPath(bin, v, "linux", runtime.GOARCH)
 					_, err := os.Stat(fp)
 					if err != nil {
 						t.Errorf("expected the file for binary exist at %q but got error %v", fp, err)


### PR DESCRIPTION
This PR addresses issue #21179 by reorganizing the cache folder structure for binaries.

### Before
- Binaries for Linux and Darwin were placed directly under:
  - `~/.minikube/cache/linux`
  - `~/.minikube/cache/darwin`

### After
- They are now moved into a dedicated `binaries` subfolder:
  - `~/.minikube/cache/bin/linux`
  - `~/.minikube/cache/bin/darwin`

### Why
- This improves organization of the cache directory.
- Aligns binaries with how other cached items (e.g., images, ISO files) are stored.
- No functional behavior is changed, only the storage path for binaries.

Fixes #21179

### Screenshot (Before)
<img width="550" height="123" alt="image" src="https://github.com/user-attachments/assets/5484ee16-5b8c-47d9-a59e-8c3ee9357feb" />


### Screenshot (After)
<img width="572" height="253" alt="image" src="https://github.com/user-attachments/assets/bf80a039-30a6-47af-b057-1a6e4cef6e1f" />

