### PR TITLE
hack: Fix review comment for failed iso build

### DIFF
--- a/hack/jenkins/build_iso.sh
+++ b/hack/jenkins/build_iso.sh
@@ -66,22 +66,20 @@ else
 fi
 
 if ! make release-iso 2>&1 | tee iso-logs.txt; then
-  # Exit of `make` (PIPESTATUS[0]); fallback to 1 if unavailable
-  ec=${PIPESTATUS[0]:-1}
+    # Exit of `make` (PIPESTATUS[0]); fallback to 1 if unavailable
+    ec=${PIPESTATUS[0]:-1}
 
-  # Only comment on non-release; default release=false if unset
-  if [[ ${release:-false} != "true" ]]; then
-	body="$(cat <<'EOF'
-	Hi ${ghprbPullAuthorLoginMention}, building a new ISO failed for Commit ${ghprbActualCommit}
-	See the logs at:
-	https://storage.cloud.google.com/minikube-builds/logs/${ghprbPullId}/${ghprbActualCommit::7}/iso_build.txt
-	EOF
-	"
-
-	gh pr comment "${ghprbPullId}" --body "$body"
-
-  fi
-  exit "$ec"
+    # Only comment on non-release; default release=false if unset
+    if [[ ${release:-false} != "true" ]]; then
+        body=$(cat << EOF
+Hi ${ghprbPullAuthorLoginMention}, building a new ISO failed for Commit ${ghprbActualCommit}
+See the logs at:
+https://storage.cloud.google.com/minikube-builds/logs/${ghprbPullId}/${ghprbActualCommit::7}/iso_build.txt
+EOF
+)
+	    gh pr comment "${ghprbPullId}" --body "$body"
+    fi
+    exit "$ec"
 fi
 
 git config user.name "minikube-bot"


### PR DESCRIPTION
When we fixed the way we detect failure #21544, we broke the heredoc. The script fails now with[1]:

    ./hack/jenkins/build_iso.sh: line 74: unexpected EOF while looking for matching `)'
    Build step 'Execute shell' marked build as failure

Fixes:
- Use unquoted delimiter (EOF, not 'EOF') to allow variable expansion in the content.
- Fix content indentation to avoid unwanted leading whitespace
- Fix location of the EOF - it must be start of the last line
- Add the missing closing ")"
- Remove the unneeded double quote
- Unify indentation to 4 spaces for consistency with the rest of the file.

[1] https://storage.googleapis.com/minikube-builds/logs/21409/e4af2e4/iso_build.txt

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
