### PR TITLE
vmnet: Move download-only check to start command

### DIFF
--- a/pkg/minikube/registry/drvs/krunkit/krunkit.go
+++ b/pkg/minikube/registry/drvs/krunkit/krunkit.go
@@ -98,9 +98,5 @@ func status() registry.State {
 	if _, err := exec.LookPath("krunkit"); err != nil {
 		return registry.State{Error: err, Fix: "Run 'brew tap slp/krunkit && brew install krunkit'", Doc: docURL}
 	}
-	if err := vmnet.ValidateHelper(); err != nil {
-		vmnetErr := err.(*vmnet.Error)
-		return registry.State{Error: vmnetErr.Err, Fix: "Install and configure vment-helper", Doc: docURL}
-	}
 	return registry.State{Installed: true, Healthy: true, Running: true}
 }


### PR DESCRIPTION
Skipping validation in vment.ValidateHelper() was the simplest way to avoid validation when starting with --download-only flag, but it requires accessing viper outside of the commands using strings. This make the code fragile and makes testing harder since we depend on global state.

Fixed by moving vment-helper validation to validateVmnetNetwork() helper in the minikube/cmd package. We skip the call to vment.ValidateHelper() in download-only mode. The helper is called for vfkit and krunkit when validating the --network flag.

For krunkit the validation was part of Driver.Status check, which is good place to validate, but it does not have access to start command flags. Validating in the start command is little bit ugly since krunkit does not use the --network option, and it moves driver logic to the start command, but at least it is consistent with vfkit and qemu, and it avoids the trouble of passing start flags deep inside minikube.

Part-of #21670