### PR TITLE
Feature: adding a Dev Container to Minikube, enabling us to launch Mi…

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/kubernetes-helm-minikube
+// Original file source at: https://github.com/devcontainers/templates/blob/main/src/kubernetes-helm-minikube/.devcontainer/devcontainer.json
+{
+	"name": "Kubernetes - Minikube-in-Docker",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
+
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {
+			"enableNonRootDocker": "true",
+			"moby": "true"
+		},
+		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+			"version": "latest",
+			"helm": "latest",
+			"minikube": "latest"
+		}
+	},
+	
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "kubectl version",
+
+	// Use 'postStartCommand' to run commands after the container is created like starting minikube.
+	// "postStartCommand": "nohup bash -c 'minikube start && minikube dashboard --url &' > minikube.log && tail -f minikube.log"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ _testmain.go
 *.test
 *.prof
 *.pprof
+*.log
 
 /deploy/iso/minikube-iso/board/minikube/x86_64/rootfs-overlay/usr/bin/auto-pause
 /deploy/iso/minikube-iso/board/minikube/aarch64/rootfs-overlay/usr/bin/auto-pause

--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ See the [Getting Started Guide](https://minikube.sigs.k8s.io/docs/start/)
 
 :mega: **Please fill out our [fast 5-question survey](https://forms.gle/Gg3hG5ZySw8c1C24A)** so that we can learn how & why you use minikube, and what improvements we should make. Thank you! :dancers:
 
+## Github Codespace
+
+You can run Minikube in a Gihub Codespace by clicking here: 
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/kubernetes/minikube?quickstart=1)
+
+This will launch a Github Codespace. You can then run `minikube start` and `minikube dashboard` - You can then open Minikube Dashboard by clicking opening the link displayed in the terminal.  
+
+You can also run Minikube in a Dev Container locally using your favourit IDE, for more infor mation see Dev Containers https://code.visualstudio.com/docs/devcontainers/containers
+
 ## Documentation
 
 See https://minikube.sigs.k8s.io/docs/


### PR DESCRIPTION
Feature: adding a Dev Container to Minikube, enabling us to launch Minikube in a Github Codespace or in a Dev Container locally 

- Enables us to quickly get Minikube running in a Github Codespace
- Enables us to quickly get Minikube running locally using Dev Containers

Once the Codespace or Dev Container is launched, we can run `minikube start` - Let's open a new Terminal tab 
<img width="1915" height="1032" alt="image" src="https://github.com/user-attachments/assets/272ed211-17dc-4c74-b808-733ebf76cee9" />

Now let's run `minikube start`
<img width="1919" height="1038" alt="image" src="https://github.com/user-attachments/assets/4ef6a98b-c7b9-4824-b74b-e145f0cc02f0" />

Now we should have minikube up and running and we can run `minikube` and  `kubectl` commads 
<img width="1917" height="1038" alt="image" src="https://github.com/user-attachments/assets/8efa24d7-5e22-4df0-826f-f37fe0935857" />

We can even bring up the Minikube Kubernetes Dashboard by running `minikube dashboard --url` 
<img width="1914" height="1036" alt="image" src="https://github.com/user-attachments/assets/0026d4ff-46b5-4ed5-8c2e-a171ee484b24" />

and opening the Minikube Kubernetes Dashboard location on our Github Codespace 
<img width="1918" height="1040" alt="image" src="https://github.com/user-attachments/assets/b19a0dca-58a4-482e-a589-ccc379a69c8b" />

This is to my knowledge the fastest way to launch Minikube on the internet for Development / Demo purposes 







