### PR TITLE
Lower priority for NeedsSudo drivers when no sudo available (#21633)

### DIFF
--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -53,6 +53,8 @@ func init() {
 		Status:   status,
 		Default:  true,
 		Priority: registry.HighlyPreferred,
+		// Docker driver does not require sudo
+		NeedsSudo: false,
 	}); err != nil {
 		panic(fmt.Sprintf("register failed: %v", err))
 	}

--- a/pkg/minikube/registry/drvs/hyperkit/hyperkit.go
+++ b/pkg/minikube/registry/drvs/hyperkit/hyperkit.go
@@ -54,6 +54,8 @@ func init() {
 		Status:   status,
 		Default:  true,
 		Priority: registry.Deprecated,
+		// Hyperkit driver requires sudo
+		NeedsSudo: true,
 	}); err != nil {
 		panic(fmt.Sprintf("register: %v", err))
 	}

--- a/pkg/minikube/registry/drvs/hyperv/hyperv.go
+++ b/pkg/minikube/registry/drvs/hyperv/hyperv.go
@@ -49,6 +49,8 @@ func init() {
 		Status:   status,
 		Default:  true,
 		Priority: registry.Preferred,
+		// Hyper-V driver requires sudo
+		NeedsSudo: true,
 	}); err != nil {
 		panic(fmt.Sprintf("register: %v", err))
 	}

--- a/pkg/minikube/registry/drvs/krunkit/krunkit.go
+++ b/pkg/minikube/registry/drvs/krunkit/krunkit.go
@@ -50,6 +50,8 @@ func init() {
 		Status:   status,
 		Default:  true,
 		Priority: registry.Experimental,
+		// Krunkit driver requires sudo
+		NeedsSudo: true,
 	}); err != nil {
 		panic(fmt.Sprintf("register failed: %v", err))
 	}

--- a/pkg/minikube/registry/drvs/kvm2/kvm2.go
+++ b/pkg/minikube/registry/drvs/kvm2/kvm2.go
@@ -50,6 +50,8 @@ func init() {
 		Status:   status,
 		Default:  true,
 		Priority: registry.Preferred,
+		// KVM2 driver does not require sudo
+		NeedsSudo: false,
 	}); err != nil {
 		panic(fmt.Sprintf("register failed: %v", err))
 	}

--- a/pkg/minikube/registry/drvs/none/none.go
+++ b/pkg/minikube/registry/drvs/none/none.go
@@ -40,6 +40,8 @@ func init() {
 		Status:   status,
 		Default:  false, // no isolation
 		Priority: registry.Discouraged,
+		// None driver requires sudo
+		NeedsSudo: true,
 	}); err != nil {
 		panic(fmt.Sprintf("register failed: %v", err))
 	}

--- a/pkg/minikube/registry/drvs/parallels/parallels.go
+++ b/pkg/minikube/registry/drvs/parallels/parallels.go
@@ -39,6 +39,8 @@ func init() {
 		Default:  true,
 		Priority: registry.Default,
 		Init:     func() drivers.Driver { return parallels.NewDriver("", "") },
+		// Parallels driver requires sudo
+		NeedsSudo: true,
 	})
 	if err != nil {
 		panic(fmt.Sprintf("unable to register: %v", err))

--- a/pkg/minikube/registry/drvs/podman/podman.go
+++ b/pkg/minikube/registry/drvs/podman/podman.go
@@ -61,6 +61,8 @@ func init() {
 		Status:   status,
 		Default:  true,
 		Priority: priority,
+		// Podman driver may require sudo (on linux)
+		NeedsSudo: true,
 	}); err != nil {
 		panic(fmt.Sprintf("register failed: %v", err))
 	}

--- a/pkg/minikube/registry/drvs/qemu2/qemu2.go
+++ b/pkg/minikube/registry/drvs/qemu2/qemu2.go
@@ -53,6 +53,8 @@ func init() {
 		Status:   status,
 		Default:  true,
 		Priority: priority,
+		// QEMU2 driver does not require sudo
+		NeedsSudo: false,
 	}); err != nil {
 		panic(fmt.Sprintf("register failed: %v", err))
 	}

--- a/pkg/minikube/registry/drvs/ssh/ssh.go
+++ b/pkg/minikube/registry/drvs/ssh/ssh.go
@@ -41,6 +41,8 @@ func init() {
 		Default:  false, // requires external VM
 		Priority: registry.Discouraged,
 		Init:     func() drivers.Driver { return ssh.NewDriver(ssh.Config{}) },
+		// SSH driver does not require sudo
+		NeedsSudo: false,
 	})
 	if err != nil {
 		panic(fmt.Sprintf("unable to register: %v", err))

--- a/pkg/minikube/registry/drvs/vfkit/vfkit.go
+++ b/pkg/minikube/registry/drvs/vfkit/vfkit.go
@@ -54,6 +54,8 @@ func init() {
 		Status:   status,
 		Default:  true,
 		Priority: priority,
+		// VFKit driver requires sudo
+		NeedsSudo: true,
 	}); err != nil {
 		panic(fmt.Sprintf("register failed: %v", err))
 	}

--- a/pkg/minikube/registry/drvs/virtualbox/virtualbox.go
+++ b/pkg/minikube/registry/drvs/virtualbox/virtualbox.go
@@ -49,6 +49,8 @@ func init() {
 		Default:  true,
 		Priority: registry.Fallback,
 		Init:     func() drivers.Driver { return virtualbox.NewDriver("", "") },
+		// VirtualBox driver requires sudo
+		NeedsSudo: true,
 	})
 	if err != nil {
 		panic(fmt.Sprintf("unable to register: %v", err))

--- a/pkg/minikube/registry/drvs/vmware/vmware.go
+++ b/pkg/minikube/registry/drvs/vmware/vmware.go
@@ -37,6 +37,8 @@ func init() {
 		Priority: registry.Deprecated,
 		Init:     func() drivers.Driver { return vmware.NewDriver("", "") },
 		Status:   status,
+		// VMware driver requires sudo
+		NeedsSudo: true,
 	})
 	if err != nil {
 		panic(fmt.Sprintf("unable to register: %v", err))

--- a/pkg/minikube/registry/global.go
+++ b/pkg/minikube/registry/global.go
@@ -81,6 +81,8 @@ type DriverState struct {
 	Rejection string
 	// Suggestion is how the user could improve health
 	Suggestion string
+	// New field: whether this driver requires sudo permissions
+	NeedsSudo bool
 }
 
 func (d DriverState) String() string {
@@ -137,7 +139,7 @@ func Available(vm bool) []DriverState {
 		if !s.Healthy {
 			priority = Unhealthy
 		}
-		sts = append(sts, DriverState{Name: d.Name, Default: d.Default, Preference: preference, Priority: priority, State: s})
+		sts = append(sts, DriverState{Name: d.Name, Default: d.Default, Preference: preference, Priority: priority, State: s, NeedsSudo: d.NeedsSudo})
 	}
 
 	// Descending priority for predictability

--- a/pkg/minikube/registry/global_test.go
+++ b/pkg/minikube/registry/global_test.go
@@ -72,20 +72,22 @@ func TestGlobalAvailable(t *testing.T) {
 	}
 
 	bar := DriverDef{
-		Name:     "healthy-bar",
-		Default:  true,
-		Priority: Default,
-		Status:   func() State { return State{Healthy: true} },
+		Name:      "healthy-bar",
+		Default:   true,
+		Priority:  Default,
+		NeedsSudo: false,
+		Status:    func() State { return State{Healthy: true} },
 	}
 	if err := Register(bar); err != nil {
 		t.Errorf("register returned error: %v", err)
 	}
 
 	foo := DriverDef{
-		Name:     "unhealthy-foo",
-		Default:  true,
-		Priority: Default,
-		Status:   func() State { return State{Healthy: false} },
+		Name:      "unhealthy-foo",
+		Default:   true,
+		Priority:  Default,
+		NeedsSudo: false,
+		Status:    func() State { return State{Healthy: false} },
 	}
 	if err := Register(foo); err != nil {
 		t.Errorf("register returned error: %v", err)
@@ -97,6 +99,7 @@ func TestGlobalAvailable(t *testing.T) {
 			Default:    true,
 			Preference: Default,
 			Priority:   Default,
+			NeedsSudo:  false,
 			State:      State{Healthy: true},
 		},
 		{
@@ -104,6 +107,7 @@ func TestGlobalAvailable(t *testing.T) {
 			Default:    true,
 			Preference: Default,
 			Priority:   Unhealthy,
+			NeedsSudo:  false,
 			State:      State{Healthy: false},
 		},
 	}

--- a/pkg/minikube/registry/registry.go
+++ b/pkg/minikube/registry/registry.go
@@ -110,6 +110,9 @@ type DriverDef struct {
 
 	// Priority returns the prioritization for selecting a driver by default.
 	Priority Priority
+
+	// New field: whether this driver requires sudo permissions
+	NeedsSudo bool
 }
 
 // Empty returns true if the driver is nil


### PR DESCRIPTION
Fixes #21633

### What this PR does
When sudo is not available on the host, drivers that require sudo (`NeedsSudo = true`) will have their priority lowered.  
Drivers that do not require sudo remain unaffected. This ensures the `Available()` function returns a properly prioritized driver list depending on the environment.

### How I tested
- Manually verified that a "NeedsSudo" driver gets a lower priority when sudo is unavailable.
- Existing unit tests for driver registration and availability remain unaffected.

