### PR TITLE
Automated generic deprecation warning

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -308,6 +308,7 @@ func provisionWithDriver(cmd *cobra.Command, ds registry.DriverState, existing *
 		klog.Errorf("Error autoSetOptions : %v", err)
 	}
 
+	virtualBoxMacOS13PlusWarning(driverName)
 	warnDriverDeprecated(driverName)
 	validateFlags(cmd, driverName)
 	validateUser(driverName)
@@ -399,6 +400,18 @@ func provisionWithDriver(cmd *cobra.Command, ds registry.DriverState, existing *
 		Cfg:            &cc,
 		Node:           &n,
 	}, nil
+}
+
+func virtualBoxMacOS13PlusWarning(driverName string) {
+	if !driver.IsVirtualBox(driverName) || !detect.MacOS13Plus() {
+		return
+	}
+	out.WarningT(`Due to changes in macOS 13+ minikube doesn't currently support VirtualBox. You can use alternative drivers such as 'vfkit', 'qemu', or 'docker'.
+    https://minikube.sigs.k8s.io/docs/drivers/vfkit/
+    https://minikube.sigs.k8s.io/docs/drivers/qemu/
+    https://minikube.sigs.k8s.io/docs/drivers/docker/
+    For more details on the issue see: https://github.com/kubernetes/minikube/issues/15274
+`)
 }
 
 // warnDriverDeprecated prints a small deprecation warning if the selected driver is deprecated


### PR DESCRIPTION
We were previously were creating warnings for each driver deprecated driver which was causing too much repetative code 
warnDriverDeprecated() function automatically warns if the current driver is marked deprecated
## Before  

```bash
func hyperkitDeprecationWarning(driverName string) {
	if !driver.IsHyperKit(driverName) {
		return
	}
	out.WarningT(`The 'hyperkit' driver is deprecated and will be removed in a future release.
    You can use alternative drivers such as 'vfkit', 'qemu', or 'docker'.
    https://minikube.sigs.k8s.io/docs/drivers/vfkit/
    https://minikube.sigs.k8s.io/docs/drivers/qemu/
    https://minikube.sigs.k8s.io/docs/drivers/docker/
	`)
}
```
we had to create new function for each deprecated driver 

## After
```bash
❗  The 'hyperkit' driver is deprecated and will be removed in a future release.
    You can use alternative drivers: qemu2, vfkit, krunkit, parallels, docker, podman, ssh, hyperkit, virtualbox.
```
automated warning for deprecated drivers 
adds to #21631