### PR TITLE
test: Fix TestMiniPath unit test on windows

### DIFF
--- a/pkg/minikube/localpath/localpath.go
+++ b/pkg/minikube/localpath/localpath.go
@@ -44,13 +44,15 @@ func ConfigFile() string {
 func MiniPath() string {
 	minikubeHomeEnv := os.Getenv(MinikubeHome)
 	if minikubeHomeEnv == "" {
-		return filepath.Join(homedir.HomeDir(), ".minikube")
+		return filepath.Join(filepath.Clean(homedir.HomeDir()), ".minikube")
 	}
-	if filepath.Base(minikubeHomeEnv) == ".minikube" {
-		// Normalize to platform-specific separators for consistency on Windows.
-		return filepath.Clean(filepath.FromSlash(minikubeHomeEnv))
+
+	norm := filepath.Clean(minikubeHomeEnv)
+
+	if filepath.Base(norm) == ".minikube" {
+		return norm
 	}
-	return filepath.Join(minikubeHomeEnv, ".minikube")
+	return filepath.Join(norm, ".minikube")
 }
 
 // MakeMiniPath is a utility to calculate a relative path to our directory.


### PR DESCRIPTION
**Test Failures before the fix**

Running tool: C:\Program Files\Go\bin\go.exe test -timeout 30s -run ^TestMiniPath$ k8s.io/minikube/pkg/minikube/localpath

```
=== RUN   TestMiniPath
=== RUN   TestMiniPath//tmp/.minikube
    c:\dev\minikube\pkg\minikube\localpath\localpath_test.go:78: MiniPath expected to return '\tmp\.minikube', but got '/tmp/.minikube'
--- FAIL: TestMiniPath//tmp/.minikube (0.00s)
=== RUN   TestMiniPath//tmp/
--- PASS: TestMiniPath//tmp/ (0.00s)
=== RUN   TestMiniPath/#00
--- PASS: TestMiniPath/#00 (0.00s)
--- FAIL: TestMiniPath (0.00s)
FAIL
FAIL    k8s.io/minikube/pkg/minikube/localpath  4.151s
```

**Test Run with the fix**

```
Running tool: C:\Program Files\Go\bin\go.exe test -timeout 30s -run ^TestMiniPath$ k8s.io/minikube/pkg/minikube/localpath

=== RUN   TestMiniPath
=== RUN   TestMiniPath//tmp/.minikube
--- PASS: TestMiniPath//tmp/.minikube (0.00s)
=== RUN   TestMiniPath//tmp/
--- PASS: TestMiniPath//tmp/ (0.00s)
=== RUN   TestMiniPath/#00
--- PASS: TestMiniPath/#00 (0.00s)
--- PASS: TestMiniPath (0.00s)
PASS
ok      k8s.io/minikube/pkg/minikube/localpath  (cached)
```
