### PR TITLE
Add warn about using the ignored --mount option

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -268,6 +268,10 @@ func runStart(cmd *cobra.Command, _ []string) {
 
 	validateBuiltImageVersion(starter.Runner, ds.Name)
 
+	if viper.GetBool(createMount) {
+		warnAboutMountFlag()
+	}
+
 	if existing != nil && driver.IsKIC(existing.Driver) && viper.GetString(mountString) != "" {
 		old := ""
 		if len(existing.ContainerVolumeMounts) > 0 {
@@ -2108,4 +2112,23 @@ func contains(sl []string, s string) bool {
 
 	}
 	return false
+}
+
+func warnAboutMountFlag() {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		out.WarningT("Failed to get home directory: {{.err}}", out.V{"err": err})
+	}
+
+	// Detect usage of --mount without --mount-string
+	if viper.Get(mountString) == "" {
+		out.WarningT("The --mount flag is ignored.")
+		out.Styled(style.Tip, "To mount a host folder, please use the --mount-string flag.")
+		out.Styled(style.Option, "Example: minikube start --mount-string=\"{{.home}}/shared:/mnt/shared\"", out.V{"home": homeDir})
+	}
+
+	// Detect usage of --mount with --mount-string
+	if viper.Get(mountString) != "" {
+		out.WarningT("The --mount flag is ignored when --mount-string is specified and is not needed.")
+	}
 }


### PR DESCRIPTION
fix #21291

We have 2 cases:

- `--mount`: user expects to have HOME mounted in the guest. This does nothing and we want to show an example how to mount a specific directory in the guest.
- `--mount --mount-string ...`: warn that the `--mount` flag is ignored and can be removed

### After:
First Case:
<img width="615" height="373" alt="image" src="https://github.com/user-attachments/assets/fa140d6a-8d8f-4365-8007-4177d2de7ea9" />

Second Case:
<img width="666" height="378" alt="image" src="https://github.com/user-attachments/assets/49e86b6c-bb9e-41b7-8e6f-8ddc52afc350" />

