### PR TITLE
Update minikube-machine with less code lint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -257,6 +257,6 @@ require (
 
 replace (
 	github.com/Parallels/docker-machine-parallels/v2 => github.com/minikube-machine/machine-driver-parallels/v2 v2.0.2-0.20240730142131-ada9375ea417
-	github.com/docker/machine => github.com/minikube-machine/machine v0.0.0-20251019113207-4663348c9152
+	github.com/docker/machine => github.com/minikube-machine/machine v0.0.0-20251025184326-b9b8849ff4b9
 	github.com/machine-drivers/docker-machine-driver-vmware => github.com/minikube-machine/machine-driver-vmware v0.1.6-0.20230701123042-a391c48b14d5
 )

--- a/go.sum
+++ b/go.sum
@@ -475,8 +475,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/miekg/dns v1.1.29/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
 github.com/miekg/dns v1.1.48 h1:Ucfr7IIVyMBz4lRE8qmGUuZ4Wt3/ZGu9hmcMT3Uu4tQ=
 github.com/miekg/dns v1.1.48/go.mod h1:e3IlAVfNqAllflbibAZEWOXOQ+Ynzk/dDozDxY7XnME=
-github.com/minikube-machine/machine v0.0.0-20251019113207-4663348c9152 h1:f+JSy8Ud5oL7dKB2q6cPWT/ak/fiQCDi1cA+BdHAToY=
-github.com/minikube-machine/machine v0.0.0-20251019113207-4663348c9152/go.mod h1:QTaHUg8rDZXxJQeuRr9F7Lmj/ALCFifdPgtwQnV29Sw=
+github.com/minikube-machine/machine v0.0.0-20251025184326-b9b8849ff4b9 h1:8laesOs7pIEb8iFWW2Fr/LWDPq2haYHU3R5Iph1eLg4=
+github.com/minikube-machine/machine v0.0.0-20251025184326-b9b8849ff4b9/go.mod h1:QTaHUg8rDZXxJQeuRr9F7Lmj/ALCFifdPgtwQnV29Sw=
 github.com/minikube-machine/machine-driver-parallels/v2 v2.0.2-0.20240730142131-ada9375ea417 h1:f+neTRGCtvmW3Tm1V72vWpoTPuNOnXSQsHZdYOryfGM=
 github.com/minikube-machine/machine-driver-parallels/v2 v2.0.2-0.20240730142131-ada9375ea417/go.mod h1:NKwI5KryEmEHMZVj80t9JQcfXWZp4/ZYNBuw4C5sQ9E=
 github.com/minikube-machine/machine-driver-vmware v0.1.6-0.20230701123042-a391c48b14d5 h1:1z7xOzfMO4aBR9+2nYjlhRXX1773fX60HTS0QGpGRPU=


### PR DESCRIPTION
* https://github.com/minikube-machine/machine/issues/16

 ```diff
 replace (
        github.com/Parallels/docker-machine-parallels/v2 => github.com/minikube-machine/machine-driver-parallels/v2 v2.0.2-0.20240730142131-ada9375ea417
-       github.com/docker/machine => github.com/minikube-machine/machine v0.0.0-20240815173309-ffb6b643c381
+       github.com/docker/machine => github.com/minikube-machine/machine v0.0.0-20251025184326-b9b8849ff4b9
        github.com/machine-drivers/docker-machine-driver-vmware => github.com/minikube-machine/machine-driver-vmware v0.1.6-0.20230701123042-a391c48b14d5
 )
```

https://github.com/minikube-machine/machine/compare/ffb6b643c38155071ba5e4c79e94e749b68439c1...b9b8849ff4b9bc8dbf3246e2bb57b1ec3c228fb2

----

```
module github.com/docker/machine

go 1.17
```

golangci-lint has version 1.64.8

```yaml
linters:
  enable:
    - gofmt
    - goimports
    - govet
    - gocyclo
```