### PR TITLE
registry-creds: Fix segfault without config file

### DIFF
--- a/cmd/minikube/cmd/config/configure.go
+++ b/cmd/minikube/cmd/config/configure.go
@@ -156,10 +156,9 @@ func loadAddonConfigFile(addon, configFilePath string) (ac *addonConfig) {
 			exit.Message(reason.Kind{ExitCode: reason.ExProgramConfig, Advice: "provide a valid config file"},
 				fmt.Sprintf("error reading config file: %v", err))
 		}
-
-		return &cf.Addons
 	}
-	return nil
+
+	return &cf.Addons
 }
 
 // Processes metallb addon config from configFile if it exists otherwise resorts to default behavior


### PR DESCRIPTION
In #20255 we added an option to use a configuration file instead of interactive mode, but the change broke interactive mode. Current minikube segfaults on start:

    % ./out/minikube addons configure registry-creds
    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x2 addr=0x8 pc=0x1067603dc]

    goroutine 1 [running]:
    k8s.io/minikube/cmd/minikube/cmd/config.processRegistryCredsConfig({0x106858a06, 0x8}, 0x0)
            /Users/nir/src/minikube/cmd/minikube/cmd/config/configure_registry_creds.go:93 +0x2c
    k8s.io/minikube/cmd/minikube/cmd/config.init.func8(0x140001f2b00?, {0x140003a83a0, 0x1, 0x106850650?})
            /Users/nir/src/minikube/cmd/minikube/cmd/config/configure.go:69 +0x24c
    github.com/spf13/cobra.(*Command).execute(0x10a088d40, {0x140003a8350, 0x1, 0x1})
            /Users/nir/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1019 +0x82c
    github.com/spf13/cobra.(*Command).ExecuteC(0x10a084880)
            /Users/nir/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148 +0x384
    github.com/spf13/cobra.(*Command).Execute(...)
            /Users/nir/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071
    k8s.io/minikube/cmd/minikube/cmd.Execute()
            /Users/nir/src/minikube/cmd/minikube/cmd/root.go:174 +0x550
    main.main()
            /Users/nir/src/minikube/cmd/minikube/main.go:95 +0x250

The issue is that loadAddonConfigFile() returns nil if the --config-file flag is not specified, but the code expects non-nil config, handling zero value as interactive mode. Fixed by returning zero value config in this case.

With this change we run the normal interactive flow:

    % ./out/minikube addons configure registry-creds

    Do you want to enable AWS Elastic Container Registry? [y/n]: n

    Do you want to enable Google Container Registry? [y/n]: n

    Do you want to enable Docker Registry? [y/n]: y
    -- Enter docker registry server url: docker.io
    -- Enter docker registry username: nirs
    -- Enter docker registry password:

    Do you want to enable Azure Container Registry? [y/n]: n
    ✅  registry-creds was successfully configured

    % out/minikube addons enable registry-creds
    ❗  registry-creds is a 3rd party addon and is not maintained or verified by minikube maintainers, enable at your own risk.
    ❗  registry-creds does not currently have an associated maintainer.
        ▪ Using image docker.io/upmcenterprises/registry-creds:1.10
    🌟  The 'registry-creds' addon is enabled

Note that this addon does not work on arm64 since we have only amd64 image. The pod fail to start:

    % kubectl logs deploy/registry-creds -n kube-system
    exec /registry-creds: exec format error

Fixes #21783 