### PR TITLE
Remove viper calls outside of cmd - part2

### DIFF
--- a/cmd/minikube/cmd/config/addons_list.go
+++ b/cmd/minikube/cmd/config/addons_list.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/mustload"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/reason"
+	"k8s.io/minikube/pkg/minikube/run"
 	"k8s.io/minikube/pkg/minikube/style"
 )
 
@@ -63,7 +64,7 @@ var addonsListCmd = &cobra.Command{
 		}
 		switch strings.ToLower(addonListOutput) {
 		case "list":
-			printAddonsList(cc, addonPrintDocs)
+			printAddonsList(cc, addonPrintDocs, options)
 		case "json":
 			printAddonsJSON(cc)
 		default:
@@ -92,7 +93,7 @@ var stringFromStatus = func(addonStatus bool) string {
 	return "disabled"
 }
 
-var printAddonsList = func(cc *config.ClusterConfig, printDocs bool) {
+var printAddonsList = func(cc *config.ClusterConfig, printDocs bool, options *run.CommandOptions) {
 	addonNames := slices.Sorted(maps.Keys(assets.Addons))
 	table := tablewriter.NewWriter(os.Stdout)
 
@@ -142,7 +143,7 @@ var printAddonsList = func(cc *config.ClusterConfig, printDocs bool) {
 	if err := table.Render(); err != nil {
 		klog.Error("Error rendering table", err)
 	}
-	v, _, err := config.ListProfiles()
+	v, _, err := config.ListProfiles(options)
 	if err != nil {
 		klog.Errorf("list profiles returned error: %v", err)
 	}

--- a/cmd/minikube/cmd/config/addons_list_test.go
+++ b/cmd/minikube/cmd/config/addons_list_test.go
@@ -23,10 +23,14 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/out"
+	"k8s.io/minikube/pkg/minikube/run"
 )
 
 func TestAddonsList(t *testing.T) {
+	options := &run.CommandOptions{ProfileName: constants.DefaultClusterName}
+
 	tests := []struct {
 		name      string
 		printDocs bool
@@ -45,7 +49,7 @@ func TestAddonsList(t *testing.T) {
 			old := os.Stdout
 			defer func() { os.Stdout = old }()
 			os.Stdout = w
-			printAddonsList(nil, tt.printDocs)
+			printAddonsList(nil, tt.printDocs, options)
 			if err := w.Close(); err != nil {
 				t.Fatalf("failed to close pipe: %v", err)
 			}

--- a/cmd/minikube/cmd/config/profile.go
+++ b/cmd/minikube/cmd/config/profile.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"k8s.io/minikube/cmd/minikube/cmd/flags"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/exit"
 	"k8s.io/minikube/pkg/minikube/kubeconfig"
@@ -45,6 +46,7 @@ var ProfileCmd = &cobra.Command{
 			exit.Message(reason.Usage, "usage: minikube profile [MINIKUBE_PROFILE_NAME]")
 		}
 
+		options := flags.CommandOptions()
 		profile := args[0]
 		// Check whether the profile name is container friendly
 		if !config.ProfileNameValid(profile) {
@@ -63,7 +65,7 @@ var ProfileCmd = &cobra.Command{
 			profile = "minikube"
 		} else {
 			// not validating when it is default profile
-			errProfile, ok := ValidateProfile(profile)
+			errProfile, ok := ValidateProfile(profile, options)
 			if !ok && errProfile != nil {
 				out.FailureT(errProfile.Msg)
 			}

--- a/cmd/minikube/cmd/config/profile_list.go
+++ b/cmd/minikube/cmd/config/profile_list.go
@@ -70,18 +70,18 @@ var profileListCmd = &cobra.Command{
 	},
 }
 
-func listProfiles() (validProfiles, invalidProfiles []*config.Profile, err error) {
+func listProfiles(options *run.CommandOptions) (validProfiles, invalidProfiles []*config.Profile, err error) {
 	if isLight {
-		validProfiles, err = config.ListValidProfiles()
+		validProfiles, err = config.ListValidProfiles(options)
 	} else {
-		validProfiles, invalidProfiles, err = config.ListProfiles()
+		validProfiles, invalidProfiles, err = config.ListProfiles(options)
 	}
 
 	return validProfiles, invalidProfiles, err
 }
 
 func printProfilesTable(options *run.CommandOptions) {
-	validProfiles, invalidProfiles, err := listProfiles()
+	validProfiles, invalidProfiles, err := listProfiles(options)
 
 	if err != nil {
 		klog.Warningf("error loading profiles: %v", err)
@@ -209,7 +209,7 @@ func warnInvalidProfiles(invalidProfiles []*config.Profile) {
 }
 
 func printProfilesJSON(options *run.CommandOptions) {
-	validProfiles, invalidProfiles, err := listProfiles()
+	validProfiles, invalidProfiles, err := listProfiles(options)
 	updateProfilesStatus(validProfiles, options)
 
 	var body = map[string]interface{}{}

--- a/cmd/minikube/cmd/config/util.go
+++ b/cmd/minikube/cmd/config/util.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/out"
+	"k8s.io/minikube/pkg/minikube/run"
 )
 
 // Invoke all the validation or callback functions and collects errors
@@ -105,9 +106,9 @@ func (e ErrValidateProfile) Error() string {
 }
 
 // ValidateProfile checks if the profile user is trying to switch exists, else throws error
-func ValidateProfile(profile string) (*ErrValidateProfile, bool) {
+func ValidateProfile(profile string, options *run.CommandOptions) (*ErrValidateProfile, bool) {
 
-	validProfiles, invalidProfiles, err := config.ListProfiles()
+	validProfiles, invalidProfiles, err := config.ListProfiles(options)
 	if err != nil {
 		out.FailureT(err.Error())
 	}

--- a/cmd/minikube/cmd/config/util_test.go
+++ b/cmd/minikube/cmd/config/util_test.go
@@ -21,7 +21,9 @@ import (
 	"testing"
 
 	config "k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/driver"
+	"k8s.io/minikube/pkg/minikube/run"
 )
 
 var minikubeConfig = config.MinikubeConfig{
@@ -83,10 +85,11 @@ func TestSetBool(t *testing.T) {
 }
 
 func TestValidateProfile(t *testing.T) {
+	options := &run.CommandOptions{ProfileName: constants.DefaultClusterName}
 	testCases := []string{"82374328742_2974224498", "validate_test"}
 	for _, name := range testCases {
 		expected := fmt.Sprintf("profile %q not found", name)
-		err, ok := ValidateProfile(name)
+		err, ok := ValidateProfile(name, options)
 		if !ok && err.Error() != expected {
 			t.Errorf("got error %q, expected %q", err, expected)
 		}

--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -218,7 +218,7 @@ func runDelete(_ *cobra.Command, args []string) {
 	out.SetJSON(outputFormat == "json")
 	register.Reg.SetStep(register.Deleting)
 	download.CleanUpOlderPreloads()
-	validProfiles, invalidProfiles, err := config.ListProfiles()
+	validProfiles, invalidProfiles, err := config.ListProfiles(options)
 	if err != nil {
 		klog.Warningf("'error loading profiles in minikube home %q: %v", localpath.MiniPath(), err)
 	}
@@ -333,7 +333,6 @@ func deleteProfile(ctx context.Context, profile *config.Profile, options *run.Co
 	klog.Infof("Deleting %s", profile.Name)
 	register.Reg.SetStep(register.Deleting)
 
-	viper.Set(config.ProfileName, profile.Name)
 	if profile.Config != nil {
 		klog.Infof("%s configuration: %+v", profile.Name, profile.Config)
 

--- a/cmd/minikube/cmd/flags/flags.go
+++ b/cmd/minikube/cmd/flags/flags.go
@@ -18,6 +18,7 @@ package flags
 
 import (
 	"github.com/spf13/viper"
+	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/run"
 )
 
@@ -34,5 +35,6 @@ func CommandOptions() *run.CommandOptions {
 	return &run.CommandOptions{
 		NonInteractive: !viper.GetBool(Interactive),
 		DownloadOnly:   viper.GetBool(DownloadOnly),
+		ProfileName:    viper.GetString(config.ProfileName),
 	}
 }

--- a/cmd/minikube/cmd/flags/flags.go
+++ b/cmd/minikube/cmd/flags/flags.go
@@ -26,6 +26,7 @@ import (
 const (
 	Interactive  = "interactive"
 	DownloadOnly = "download-only"
+	Force        = "force"
 )
 
 // CommandOptions returns minikube runtime options from command line flags.
@@ -36,5 +37,6 @@ func CommandOptions() *run.CommandOptions {
 		NonInteractive: !viper.GetBool(Interactive),
 		DownloadOnly:   viper.GetBool(DownloadOnly),
 		ProfileName:    viper.GetString(config.ProfileName),
+		Force:          viper.GetBool(Force),
 	}
 }

--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -246,7 +246,7 @@ var mountCmd = &cobra.Command{
 			}
 		}()
 
-		err = cluster.Mount(co.CP.Runner, ip.String(), vmPath, cfg, pid)
+		err = cluster.Mount(co.CP.Runner, ip.String(), vmPath, cfg, pid, options)
 		if err != nil {
 			if rtErr, ok := err.(*cluster.MountError); ok && rtErr.ErrorType == cluster.MountErrorConnect {
 				exit.Error(reason.GuestMountCouldNotConnect, "mount could not connect", rtErr)

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/util/templates"
 	configCmd "k8s.io/minikube/cmd/minikube/cmd/config"
+	"k8s.io/minikube/cmd/minikube/cmd/flags"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/audit"
 	"k8s.io/minikube/pkg/minikube/config"
@@ -64,6 +65,7 @@ var RootCmd = &cobra.Command{
 	Short: "minikube quickly sets up a local Kubernetes cluster",
 	Long:  `minikube provisions and manages local Kubernetes clusters optimized for development workflows.`,
 	PersistentPreRun: func(_ *cobra.Command, _ []string) {
+		options := flags.CommandOptions()
 		for _, path := range dirs {
 			if err := os.MkdirAll(path, 0777); err != nil {
 				exit.Error(reason.HostHomeMkdir, "Error creating minikube directory", err)
@@ -75,7 +77,7 @@ var RootCmd = &cobra.Command{
 			exit.Message(reason.Usage, "User name must be 60 chars or less.")
 		}
 		var err error
-		auditID, err = audit.LogCommandStart()
+		auditID, err = audit.LogCommandStart(options)
 		if err != nil {
 			klog.Warningf("failed to log command start to audit: %v", err)
 		}

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -204,7 +204,7 @@ func runStart(cmd *cobra.Command, _ []string) {
 	if existing != nil {
 		upgradeExistingConfig(cmd, existing)
 	} else {
-		validateProfileName()
+		validateProfileName(options)
 	}
 
 	validateSpecifiedDriver(existing, options)
@@ -846,8 +846,8 @@ func hostDriver(existing *config.ClusterConfig, options *run.CommandOptions) str
 }
 
 // validateProfileName makes sure that new profile name not duplicated with any of machine names in existing multi-node clusters.
-func validateProfileName() {
-	profiles, err := config.ListValidProfiles()
+func validateProfileName(options *run.CommandOptions) {
+	profiles, err := config.ListValidProfiles(options)
 	if err != nil {
 		exit.Message(reason.InternalListConfig, "Unable to list profiles: {{.error}}", out.V{"error": err})
 	}

--- a/cmd/minikube/cmd/stop.go
+++ b/cmd/minikube/cmd/stop.go
@@ -84,7 +84,7 @@ func runStop(_ *cobra.Command, _ []string) {
 	// new code
 	var profilesToStop []string
 	if stopAll {
-		validProfiles, _, err := config.ListProfiles()
+		validProfiles, _, err := config.ListProfiles(options)
 		if err != nil {
 			klog.Warningf("'error loading profiles in minikube home %q: %v", localpath.MiniPath(), err)
 		}

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -31,7 +31,6 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/docker/machine/libmachine/state"
 	"github.com/pkg/errors"
-	"github.com/spf13/viper"
 
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
@@ -270,7 +269,7 @@ func EnableOrDisableAddon(cc *config.ClusterConfig, name string, val string, opt
 	}
 
 	// Persist images even if the machine is running so starting gets the correct images.
-	images, customRegistries, err := assets.SelectAndPersistImages(addon, cc)
+	images, customRegistries, err := assets.SelectAndPersistImages(addon, cc, options)
 	if err != nil {
 		exit.Error(reason.HostSaveProfile, "Failed to persist images", err)
 	}
@@ -476,7 +475,7 @@ func verifyAddonStatus(cc *config.ClusterConfig, name string, val string, option
 	return verifyAddonStatusInternal(cc, name, val, ns, options)
 }
 
-func verifyAddonStatusInternal(cc *config.ClusterConfig, name string, val string, ns string, _ *run.CommandOptions) error {
+func verifyAddonStatusInternal(cc *config.ClusterConfig, name string, val string, ns string, options *run.CommandOptions) error {
 	klog.Infof("Verifying addon %s=%s in %q", name, val, cc.Name)
 	enable, err := strconv.ParseBool(val)
 	if err != nil {
@@ -486,7 +485,7 @@ func verifyAddonStatusInternal(cc *config.ClusterConfig, name string, val string
 	label, ok := addonPodLabels[name]
 	if ok && enable {
 		out.Step(style.HealthCheck, "Verifying {{.addon_name}} addon...", out.V{"addon_name": name})
-		client, err := kapi.Client(viper.GetString(config.ProfileName))
+		client, err := kapi.Client(options.ProfileName)
 		if err != nil {
 			return errors.Wrapf(err, "get kube-client to validate %s addon: %v", name, err)
 		}

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/minikube/deploy/addons"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/out"
+	"k8s.io/minikube/pkg/minikube/run"
 	"k8s.io/minikube/pkg/minikube/vmpath"
 	"k8s.io/minikube/pkg/util"
 	"k8s.io/minikube/pkg/version"
@@ -831,7 +832,7 @@ func overrideDefaults(def, override map[string]string) map[string]string {
 }
 
 // SelectAndPersistImages selects which images to use based on addon default images, previously persisted images, and newly requested images - which are then persisted for future enables.
-func SelectAndPersistImages(addon *Addon, cc *config.ClusterConfig) (images, customRegistries map[string]string, _ error) {
+func SelectAndPersistImages(addon *Addon, cc *config.ClusterConfig, options *run.CommandOptions) (images, customRegistries map[string]string, _ error) {
 	addonDefaultImages := addon.Images
 	if addonDefaultImages == nil {
 		addonDefaultImages = make(map[string]string)
@@ -880,7 +881,7 @@ func SelectAndPersistImages(addon *Addon, cc *config.ClusterConfig) (images, cus
 	if viper.IsSet(config.AddonImages) || viper.IsSet(config.AddonRegistries) {
 		// Since these values are only set when a user enables an addon, it is safe to refer to the profile name.
 		// Whether err is nil or not we still return here.
-		return images, customRegistries, config.Write(viper.GetString(config.ProfileName), cc)
+		return images, customRegistries, config.Write(options.ProfileName, cc)
 	}
 	return images, customRegistries, nil
 }

--- a/pkg/minikube/assets/addons_test.go
+++ b/pkg/minikube/assets/addons_test.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/run"
 	"k8s.io/minikube/pkg/minikube/tests"
 )
 
@@ -45,7 +47,7 @@ func mapsEqual(a, b map[string]string) bool {
 
 func TestParseMapString(t *testing.T) {
 	cases := map[string]map[string]string{
-		"Aardvark=1,B=2,Cantaloupe=3":         {"Aardvark": "1", "B": "2", "Cantaloupe": "3"},
+		"Aardvark=1,B=2,Cantaloupe=3":        {"Aardvark": "1", "B": "2", "Cantaloupe": "3"},
 		"A=,B=2,C=":                          {"A": "", "B": "2", "C": ""},
 		"":                                   {},
 		"malformed,good=howdy,manyequals==,": {"good": "howdy"},
@@ -156,9 +158,10 @@ func TestSelectAndPersistImages(t *testing.T) {
 	gcpAuth := Addons["gcp-auth"]
 	gcpAuthImages := gcpAuth.Images
 
+	options := &run.CommandOptions{ProfileName: constants.DefaultClusterName}
 	// this test will write to ~/.minikube/profiles/minikube/config.json so need to create the file
 	home := tests.MakeTempDir(t)
-	profilePath := filepath.Join(home, "profiles", "minikube")
+	profilePath := filepath.Join(home, "profiles", options.ProfileName)
 	if err := os.MkdirAll(profilePath, 0777); err != nil {
 		t.Fatalf("failed to create profile directory: %v", err)
 	}
@@ -176,7 +179,7 @@ func TestSelectAndPersistImages(t *testing.T) {
 	}
 
 	test := func(t *testing.T, cc *config.ClusterConfig, e expected) (images, registries map[string]string) {
-		images, registries, err := SelectAndPersistImages(gcpAuth, cc)
+		images, registries, err := SelectAndPersistImages(gcpAuth, cc, options)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/minikube/audit/audit.go
+++ b/pkg/minikube/audit/audit.go
@@ -30,6 +30,7 @@ import (
 	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/run"
 	"k8s.io/minikube/pkg/version"
 )
 
@@ -56,12 +57,12 @@ func args() string {
 }
 
 // Log details about the executed command.
-func LogCommandStart() (string, error) {
+func LogCommandStart(options *run.CommandOptions) (string, error) {
 	if !shouldLog() {
 		return "", nil
 	}
 	id := uuid.New().String()
-	r := newRow(pflag.Arg(0), args(), userName(), version.GetVersion(), time.Now(), id)
+	r := newRow(pflag.Arg(0), args(), userName(), version.GetVersion(), time.Now(), id, options)
 	if err := appendToLog(r); err != nil {
 		return "", err
 	}

--- a/pkg/minikube/audit/audit_test.go
+++ b/pkg/minikube/audit/audit_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/config"
+	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/run"
 )
 
 func TestAudit(t *testing.T) {
@@ -202,6 +204,7 @@ func TestAudit(t *testing.T) {
 
 	// Check if logging with limited args causes a panic
 	t.Run("LogCommandStart", func(t *testing.T) {
+		options := &run.CommandOptions{ProfileName: constants.DefaultClusterName}
 		oldArgs := os.Args
 		defer func() { os.Args = oldArgs }()
 		os.Args = []string{"minikube", "start"}
@@ -212,7 +215,7 @@ func TestAudit(t *testing.T) {
 			pflag.Parse()
 		}()
 		mockArgs(t, os.Args)
-		auditID, err := LogCommandStart()
+		auditID, err := LogCommandStart(options)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -222,6 +225,7 @@ func TestAudit(t *testing.T) {
 	})
 
 	t.Run("LogCommandEnd", func(t *testing.T) {
+		options := &run.CommandOptions{ProfileName: constants.DefaultClusterName}
 		oldArgs := os.Args
 		defer func() { os.Args = oldArgs }()
 		os.Args = []string{"minikube", "start"}
@@ -233,7 +237,7 @@ func TestAudit(t *testing.T) {
 			pflag.Parse()
 		}()
 		mockArgs(t, os.Args)
-		auditID, err := LogCommandStart()
+		auditID, err := LogCommandStart(options)
 		if err != nil {
 			t.Fatalf("start failed: %v", err)
 		}

--- a/pkg/minikube/audit/logFile_test.go
+++ b/pkg/minikube/audit/logFile_test.go
@@ -24,7 +24,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/localpath"
+	"k8s.io/minikube/pkg/minikube/run"
 )
 
 func TestLogFile(t *testing.T) {
@@ -40,6 +42,7 @@ func TestLogFile(t *testing.T) {
 	})
 
 	t.Run("AppendToLog", func(t *testing.T) {
+		options := &run.CommandOptions{ProfileName: constants.DefaultClusterName}
 		f, err := os.CreateTemp("", "audit.json")
 		if err != nil {
 			t.Fatalf("Error creating temporary file: %v", err)
@@ -49,7 +52,7 @@ func TestLogFile(t *testing.T) {
 		currentLogFile = f
 		defer closeAuditLog()
 
-		r := newRow("start", "-v", "user1", "v0.17.1", time.Now(), uuid.New().String())
+		r := newRow("start", "-v", "user1", "v0.17.1", time.Now(), uuid.New().String(), options)
 		if err := appendToLog(r); err != nil {
 			t.Fatalf("Error appendingToLog: %v", err)
 		}

--- a/pkg/minikube/audit/row.go
+++ b/pkg/minikube/audit/row.go
@@ -24,9 +24,8 @@ import (
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/olekukonko/tablewriter/tw"
-	"github.com/spf13/viper"
-	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/run"
 )
 
 // row is the log of a single command.
@@ -81,15 +80,11 @@ func (e *row) toMap() map[string]string {
 }
 
 // newRow creates a new audit row.
-func newRow(command string, args string, user string, version string, startTime time.Time, id string, profile ...string) *row {
-	p := viper.GetString(config.ProfileName)
-	if len(profile) > 0 {
-		p = profile[0]
-	}
+func newRow(command string, args string, user string, version string, startTime time.Time, id string, options *run.CommandOptions) *row {
 	return &row{
 		args:      args,
 		command:   command,
-		profile:   p,
+		profile:   options.ProfileName,
 		startTime: startTime.Format(constants.TimeFormat),
 		user:      user,
 		version:   version,

--- a/pkg/minikube/audit/row_test.go
+++ b/pkg/minikube/audit/row_test.go
@@ -25,12 +25,14 @@ import (
 
 	"github.com/google/uuid"
 	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/run"
 )
 
 func TestRow(t *testing.T) {
+	options := &run.CommandOptions{ProfileName: constants.DefaultClusterName}
+
 	c := "start"
 	a := "--alsologtostderr"
-	p := "profile1"
 	u := "user1"
 	v := "v0.17.1"
 	st := time.Now()
@@ -39,7 +41,7 @@ func TestRow(t *testing.T) {
 	etFormatted := et.Format(constants.TimeFormat)
 	id := uuid.New().String()
 
-	r := newRow(c, a, u, v, st, id, p)
+	r := newRow(c, a, u, v, st, id, options)
 	r.endTime = etFormatted
 
 	t.Run("NewRow", func(t *testing.T) {
@@ -50,7 +52,7 @@ func TestRow(t *testing.T) {
 		}{
 			{"command", r.command, c},
 			{"args", r.args, a},
-			{"profile", r.profile, p},
+			{"profile", r.profile, options.ProfileName},
 			{"user", r.user, u},
 			{"version", r.version, v},
 			{"startTime", r.startTime, stFormatted},
@@ -82,7 +84,7 @@ func TestRow(t *testing.T) {
 		}{
 			{"command", c},
 			{"args", a},
-			{"profile", p},
+			{"profile", options.ProfileName},
 			{"user", u},
 			{"version", v},
 			{"startTime", stFormatted},
@@ -100,7 +102,7 @@ func TestRow(t *testing.T) {
 	t.Run("toFields", func(t *testing.T) {
 		got := r.toFields()
 		gotString := strings.Join(got, ",")
-		want := []string{c, a, p, u, v, stFormatted, etFormatted}
+		want := []string{c, a, options.ProfileName, u, v, stFormatted, etFormatted}
 		wantString := strings.Join(want, ",")
 
 		if gotString != wantString {
@@ -109,7 +111,9 @@ func TestRow(t *testing.T) {
 	})
 
 	t.Run("assignFields", func(t *testing.T) {
-		l := fmt.Sprintf(`{"data":{"args":"%s","command":"%s","id":"%s","profile":"%s","startTime":"%s","user":"%s","version":"v0.17.1"},"datacontenttype":"application/json","id":"bc6ec9d4-0d08-4b57-ac3b-db8d67774768","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.audit"}`, a, c, id, p, stFormatted, u)
+		l := fmt.Sprintf(
+			`{"data":{"args":"%s","command":"%s","id":"%s","profile":"%s","startTime":"%s","user":"%s","version":"v0.17.1"},"datacontenttype":"application/json","id":"bc6ec9d4-0d08-4b57-ac3b-db8d67774768","source":"https://minikube.sigs.k8s.io/","specversion":"1.0","type":"io.k8s.sigs.minikube.audit"}`,
+			a, c, id, options.ProfileName, stFormatted, u)
 
 		r := &row{}
 		if err := json.Unmarshal([]byte(l), r); err != nil {
@@ -125,7 +129,7 @@ func TestRow(t *testing.T) {
 		}{
 			{"command", r.command, c},
 			{"args", r.args, a},
-			{"profile", r.profile, p},
+			{"profile", r.profile, options.ProfileName},
 			{"user", r.user, u},
 			{"version", r.version, v},
 			{"startTime", r.startTime, stFormatted},

--- a/pkg/minikube/config/profile_test.go
+++ b/pkg/minikube/config/profile_test.go
@@ -20,11 +20,14 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/spf13/viper"
+	"k8s.io/minikube/pkg/minikube/constants"
+	"k8s.io/minikube/pkg/minikube/run"
 )
 
 // TestListProfiles uses a different MINIKUBE_HOME with rest of tests since it relies on file list index
 func TestListProfiles(t *testing.T) {
+	options := &run.CommandOptions{ProfileName: constants.DefaultClusterName}
+
 	miniDir, err := filepath.Abs("./testdata/profile/.minikube")
 	if err != nil {
 		t.Errorf("error getting dir path for ./testdata/.minikube : %v", err)
@@ -53,7 +56,7 @@ func TestListProfiles(t *testing.T) {
 	DockerContainers = func() ([]string, error) {
 		return []string{}, nil
 	}
-	val, inv, err := ListProfiles(miniDir)
+	val, inv, err := ListProfiles(options, miniDir)
 
 	num := len(testCasesValidProfs) + len(testCasesInValidProfs)
 	if num != len(val)+len(inv) {
@@ -288,8 +291,6 @@ func TestGetPrimaryControlPlane(t *testing.T) {
 				t.Fatalf("Failed to load config for %s", tc.description)
 			}
 
-			// get control-plane node
-			viper.Set(ProfileName, tc.profile)
 			n, err := ControlPlane(*cc)
 			if err != nil {
 				t.Fatalf("Unexpected error getting primary control plane: %v", err)

--- a/pkg/minikube/machine/fix.go
+++ b/pkg/minikube/machine/fix.go
@@ -61,7 +61,7 @@ func fixHost(api libmachine.API, cc *config.ClusterConfig, n *config.Node, optio
 	if err != nil {
 		return h, errors.Wrap(err, "error loading existing host. Please try running [minikube delete], then run [minikube start] again")
 	}
-	defer postStartValidations(h, cc.Driver)
+	defer postStartValidations(h, cc.Driver, options)
 
 	driverName := h.Driver.DriverName()
 

--- a/pkg/minikube/machine/fix.go
+++ b/pkg/minikube/machine/fix.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/driver"
 	"k8s.io/minikube/pkg/minikube/out"
 	"k8s.io/minikube/pkg/minikube/out/register"
+	"k8s.io/minikube/pkg/minikube/run"
 	"k8s.io/minikube/pkg/minikube/style"
 )
 
@@ -49,7 +50,7 @@ const (
 )
 
 // fixHost fixes up a previously configured VM so that it is ready to run Kubernetes
-func fixHost(api libmachine.API, cc *config.ClusterConfig, n *config.Node) (*host.Host, error) {
+func fixHost(api libmachine.API, cc *config.ClusterConfig, n *config.Node, options *run.CommandOptions) (*host.Host, error) {
 	start := time.Now()
 	klog.Infof("fixHost starting: %s", n.Name)
 	defer func() {
@@ -67,7 +68,7 @@ func fixHost(api libmachine.API, cc *config.ClusterConfig, n *config.Node) (*hos
 	// check if need to re-run docker-env
 	maybeWarnAboutEvalEnv(driverName, cc.Name)
 
-	h, err = recreateIfNeeded(api, cc, n, h)
+	h, err = recreateIfNeeded(api, cc, n, h, options)
 	if err != nil {
 		return h, err
 	}
@@ -103,7 +104,7 @@ func fixHost(api libmachine.API, cc *config.ClusterConfig, n *config.Node) (*hos
 	return h, nil
 }
 
-func recreateIfNeeded(api libmachine.API, cc *config.ClusterConfig, n *config.Node, h *host.Host) (*host.Host, error) {
+func recreateIfNeeded(api libmachine.API, cc *config.ClusterConfig, n *config.Node, h *host.Host, options *run.CommandOptions) (*host.Host, error) {
 	machineName := config.MachineName(*cc, *n)
 	machineType := driver.MachineType(cc.Driver)
 	recreated := false
@@ -124,7 +125,7 @@ func recreateIfNeeded(api libmachine.API, cc *config.ClusterConfig, n *config.No
 			klog.Infof("Sleeping 1 second for extra luck!")
 			time.Sleep(1 * time.Second)
 
-			h, err = createHost(api, cc, n)
+			h, err = createHost(api, cc, n, options)
 			if err != nil {
 				return nil, errors.Wrap(err, "recreate")
 			}
@@ -153,7 +154,7 @@ func recreateIfNeeded(api libmachine.API, cc *config.ClusterConfig, n *config.No
 		MaybeDisplayAdvice(err, h.DriverName)
 		return h, errors.Wrap(err, "driver start")
 	}
-	if err := saveHost(api, h, cc, n); err != nil {
+	if err := saveHost(api, h, cc, n, options); err != nil {
 		return h, err
 	}
 

--- a/pkg/minikube/machine/machine.go
+++ b/pkg/minikube/machine/machine.go
@@ -133,7 +133,7 @@ func fastDetectProvisioner(h *host.Host) (libprovision.Provisioner, error) {
 }
 
 // saveHost is a wrapper around libmachine's Save function to proactively update the node's IP whenever a host is saved
-func saveHost(api libmachine.API, h *host.Host, cfg *config.ClusterConfig, n *config.Node) error {
+func saveHost(api libmachine.API, h *host.Host, cfg *config.ClusterConfig, n *config.Node, options *run.CommandOptions) error {
 	if err := api.Save(h); err != nil {
 		return errors.Wrap(err, "save")
 	}
@@ -147,7 +147,7 @@ func saveHost(api libmachine.API, h *host.Host, cfg *config.ClusterConfig, n *co
 		ip = "10.0.2.15"
 	}
 	n.IP = ip
-	return config.SaveNode(cfg, n)
+	return config.SaveNode(cfg, n, options)
 }
 
 // backup copies critical ephemeral vm config files from tmpfs to persistent storage under /var/lib/minikube/backup,

--- a/pkg/minikube/machine/start.go
+++ b/pkg/minikube/machine/start.go
@@ -35,7 +35,6 @@ import (
 	"github.com/docker/machine/libmachine/host"
 	"github.com/juju/mutex/v2"
 	"github.com/pkg/errors"
-	"github.com/spf13/viper"
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
 	"k8s.io/minikube/pkg/minikube/command"
@@ -150,7 +149,7 @@ func createHost(api libmachine.API, cfg *config.ClusterConfig, n *config.Node, o
 	if err != nil {
 		return nil, errors.Wrap(err, "new host")
 	}
-	defer postStartValidations(h, cfg.Driver)
+	defer postStartValidations(h, cfg.Driver, options)
 
 	h.HostOptions.AuthOptions.CertDir = localpath.MiniPath()
 	h.HostOptions.AuthOptions.StorePath = localpath.MiniPath()
@@ -202,7 +201,7 @@ func timedCreateHost(h *host.Host, api libmachine.API, t time.Duration) error {
 
 // postStartValidations are validations against the host after it is created
 // TODO: Add validations for VM drivers as well, see issue #9035
-func postStartValidations(h *host.Host, drvName string) {
+func postStartValidations(h *host.Host, drvName string, options *run.CommandOptions) {
 	if !driver.IsKIC(drvName) {
 		return
 	}
@@ -226,7 +225,7 @@ func postStartValidations(h *host.Host, drvName string) {
 		return
 	}
 
-	if viper.GetBool("force") {
+	if options.Force {
 		return
 	}
 

--- a/pkg/minikube/machine/start.go
+++ b/pkg/minikube/machine/start.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/proxy"
 	"k8s.io/minikube/pkg/minikube/reason"
 	"k8s.io/minikube/pkg/minikube/registry"
+	"k8s.io/minikube/pkg/minikube/run"
 	"k8s.io/minikube/pkg/minikube/style"
 	"k8s.io/minikube/pkg/minikube/vmpath"
 	"k8s.io/minikube/pkg/util"
@@ -70,7 +71,7 @@ var requiredDirectories = []string{
 }
 
 // StartHost starts a host VM.
-func StartHost(api libmachine.API, cfg *config.ClusterConfig, n *config.Node) (*host.Host, bool, error) {
+func StartHost(api libmachine.API, cfg *config.ClusterConfig, n *config.Node, options *run.CommandOptions) (*host.Host, bool, error) {
 	machineName := config.MachineName(*cfg, *n)
 
 	// Prevent machine-driver boot races, as well as our own certificate race
@@ -91,10 +92,10 @@ func StartHost(api libmachine.API, cfg *config.ClusterConfig, n *config.Node) (*
 	var h *host.Host
 	if !exists {
 		klog.Infof("Provisioning new machine with config: %+v %+v", cfg, n)
-		h, err = createHost(api, cfg, n)
+		h, err = createHost(api, cfg, n, options)
 	} else {
 		klog.Infoln("Skipping create...Using existing machine configuration")
-		h, err = fixHost(api, cfg, n)
+		h, err = fixHost(api, cfg, n, options)
 	}
 	if err != nil {
 		return h, exists, err
@@ -121,7 +122,7 @@ func engineOptions(cfg config.ClusterConfig) *engine.Options {
 	return &o
 }
 
-func createHost(api libmachine.API, cfg *config.ClusterConfig, n *config.Node) (*host.Host, error) {
+func createHost(api libmachine.API, cfg *config.ClusterConfig, n *config.Node, options *run.CommandOptions) (*host.Host, error) {
 	klog.Infof("createHost starting for %q (driver=%q)", n.Name, cfg.Driver)
 	start := time.Now()
 	defer func() {
@@ -173,7 +174,7 @@ func createHost(api libmachine.API, cfg *config.ClusterConfig, n *config.Node) (
 		return h, errors.Wrap(err, "post-start")
 	}
 
-	if err := saveHost(api, h, cfg, n); err != nil {
+	if err := saveHost(api, h, cfg, n, options); err != nil {
 		return h, err
 	}
 	return h, nil

--- a/pkg/minikube/node/config.go
+++ b/pkg/minikube/node/config.go
@@ -24,7 +24,6 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/spf13/viper"
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
@@ -36,6 +35,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/out/register"
 	"k8s.io/minikube/pkg/minikube/proxy"
 	"k8s.io/minikube/pkg/minikube/reason"
+	"k8s.io/minikube/pkg/minikube/run"
 	"k8s.io/minikube/pkg/minikube/style"
 	"k8s.io/minikube/pkg/util/lock"
 )
@@ -69,7 +69,7 @@ func showNoK8sVersionInfo(cr cruntime.Manager) {
 }
 
 // configureMounts configures any requested filesystem mounts
-func configureMounts(wg *sync.WaitGroup, cc config.ClusterConfig) {
+func configureMounts(wg *sync.WaitGroup, cc config.ClusterConfig, options *run.CommandOptions) {
 	wg.Add(1)
 	defer wg.Done()
 
@@ -79,7 +79,7 @@ func configureMounts(wg *sync.WaitGroup, cc config.ClusterConfig) {
 
 	out.Step(style.Mounting, "Creating mount {{.name}} ...", out.V{"name": cc.MountString})
 	path := os.Args[0]
-	profile := viper.GetString("profile")
+	profile := options.ProfileName
 
 	args := generateMountArgs(profile, cc)
 	mountCmd := exec.Command(path, args...)

--- a/pkg/minikube/node/node.go
+++ b/pkg/minikube/node/node.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/pkg/errors"
-	"github.com/spf13/viper"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
@@ -44,7 +43,7 @@ import (
 
 // Add adds a new node config to an existing cluster.
 func Add(cc *config.ClusterConfig, n config.Node, delOnFail bool, options *run.CommandOptions) error {
-	profiles, err := config.ListValidProfiles()
+	profiles, err := config.ListValidProfiles(options)
 	if err != nil {
 		return err
 	}
@@ -66,7 +65,7 @@ func Add(cc *config.ClusterConfig, n config.Node, delOnFail bool, options *run.C
 		n.Port = cc.APIServerPort
 	}
 
-	if err := config.SaveNode(cc, &n); err != nil {
+	if err := config.SaveNode(cc, &n, options); err != nil {
 		return errors.Wrap(err, "save node")
 	}
 
@@ -207,7 +206,7 @@ func Delete(cc config.ClusterConfig, name string, options *run.CommandOptions) (
 	}
 
 	cc.Nodes = append(cc.Nodes[:index], cc.Nodes[index+1:]...)
-	return n, config.SaveProfile(viper.GetString(config.ProfileName), &cc)
+	return n, config.SaveProfile(options.ProfileName, &cc)
 }
 
 // Retrieve finds the node by name in the given cluster
@@ -228,7 +227,7 @@ func Retrieve(cc config.ClusterConfig, name string) (*config.Node, int, error) {
 }
 
 // Save saves a node to a cluster
-func Save(cfg *config.ClusterConfig, node *config.Node) error {
+func Save(cfg *config.ClusterConfig, node *config.Node, options *run.CommandOptions) error {
 	update := false
 	for i, n := range cfg.Nodes {
 		if n.Name == node.Name {
@@ -241,7 +240,7 @@ func Save(cfg *config.ClusterConfig, node *config.Node) error {
 	if !update {
 		cfg.Nodes = append(cfg.Nodes, *node)
 	}
-	return config.SaveProfile(viper.GetString(config.ProfileName), cfg)
+	return config.SaveProfile(options.ProfileName, cfg)
 }
 
 // Name returns the appropriate name for the node given the node index.

--- a/pkg/minikube/registry/drvs/docker/docker.go
+++ b/pkg/minikube/registry/drvs/docker/docker.go
@@ -28,7 +28,6 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/pkg/errors"
-	"github.com/spf13/viper"
 	"k8s.io/klog/v2"
 	"k8s.io/minikube/pkg/drivers/kic"
 	"k8s.io/minikube/pkg/drivers/kic/oci"
@@ -96,7 +95,7 @@ func configure(cc config.ClusterConfig, n config.Node) (interface{}, error) {
 	}), nil
 }
 
-func status(_ *run.CommandOptions) (retState registry.State) {
+func status(options *run.CommandOptions) (retState registry.State) {
 	version, state := dockerVersionOrState()
 	if state.Error != nil {
 		return state
@@ -122,7 +121,7 @@ func status(_ *run.CommandOptions) (retState registry.State) {
 	dockerEngineVersion := versions[0]
 	dockerPlatformVersion := versions[1]
 	klog.Infof("docker version: %s", version)
-	if !viper.GetBool("force") {
+	if !options.Force {
 		if s := checkDockerDesktopVersion(dockerPlatformVersion); s.Error != nil {
 			return s
 		}

--- a/pkg/minikube/run/options.go
+++ b/pkg/minikube/run/options.go
@@ -30,4 +30,8 @@ type CommandOptions struct {
 	// ProfileName is set if the minikube command run with the --profile flag, using
 	// specific minikube instance.
 	ProfileName string
+
+	// Force is true if the minikube command run with the --force flag and can
+	// perform possibly dangerous operations.
+	Force bool
 }

--- a/pkg/minikube/run/options.go
+++ b/pkg/minikube/run/options.go
@@ -26,4 +26,8 @@ type CommandOptions struct {
 	// flag and we should If only download and cache files for later use and
 	// don't install or start anything.
 	DownloadOnly bool
+
+	// ProfileName is set if the minikube command run with the --profile flag, using
+	// specific minikube instance.
+	ProfileName string
 }

--- a/pkg/minikube/service/service_test.go
+++ b/pkg/minikube/service/service_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/pkg/errors"
-	"github.com/spf13/viper"
 	core "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,7 +42,6 @@ import (
 	typed_discovery "k8s.io/client-go/kubernetes/typed/discovery/v1"
 	"k8s.io/client-go/rest"
 	testing_fake "k8s.io/client-go/testing"
-	"k8s.io/minikube/pkg/minikube/config"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/tests"
 )
@@ -558,7 +556,6 @@ func TestGetServiceURLs(t *testing.T) {
 		},
 	}
 	defaultTemplate := template.Must(template.New("svc-template").Parse("http://{{.IP}}:{{.Port}}"))
-	viper.Set(config.ProfileName, constants.DefaultClusterName)
 
 	var tests = []struct {
 		description string
@@ -634,7 +631,6 @@ func TestGetServiceURLsForService(t *testing.T) {
 		},
 	}
 	defaultTemplate := template.Must(template.New("svc-template").Parse("http://{{.IP}}:{{.Port}}"))
-	viper.Set(config.ProfileName, constants.DefaultClusterName)
 
 	var tests = []struct {
 		description string

--- a/pkg/minikube/tests/api_mock.go
+++ b/pkg/minikube/tests/api_mock.go
@@ -19,14 +19,12 @@ package tests
 import (
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"testing"
 
 	"github.com/docker/machine/libmachine/auth"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/swarm"
 	"github.com/pkg/errors"
-	"github.com/spf13/viper"
 
 	"k8s.io/klog/v2"
 )
@@ -78,16 +76,13 @@ func (api *MockAPI) NewHost(drvName string, rawDriver []byte) (*host.Host, error
 	h := &host.Host{
 		DriverName: drvName,
 		RawDriver:  rawDriver,
-		Driver:     &MockDriver{},
-		Name:       fmt.Sprintf("mock-machine-%.8f", rand.Float64()),
+		Driver:     &driver,
+		Name:       driver.GetMachineName(),
 		HostOptions: &host.Options{
 			AuthOptions:  &auth.Options{},
 			SwarmOptions: &swarm.Options{},
 		},
 	}
-
-	api.Logf("MockAPI.NewHost: Setting profile=%q", h.Name)
-	viper.Set("profile", h.Name)
 
 	api.Logf("MockAPI.NewHost: %+v", h)
 	return h, nil

--- a/pkg/minikube/tests/driver_mock.go
+++ b/pkg/minikube/tests/driver_mock.go
@@ -68,8 +68,8 @@ func (d *MockDriver) GetIP() (string, error) {
 	if d.IP != "" {
 		return d.IP, nil
 	}
-	if d.BaseDriver.IPAddress != "" {
-		return d.BaseDriver.IPAddress, nil
+	if d.IPAddress != "" {
+		return d.IPAddress, nil
 	}
 	return "127.0.0.1", nil
 }
@@ -94,7 +94,7 @@ func (d *MockDriver) GetSSHHostname() (string, error) {
 
 // GetSSHKeyPath returns the key path for SSH
 func (d *MockDriver) GetSSHKeyPath() string {
-	return d.BaseDriver.SSHKeyPath
+	return d.SSHKeyPath
 }
 
 // GetState returns the state of the driver


### PR DESCRIPTION
This is the second part, removing more viper calls outside of cmd and replacing some viper calls that use a string instead of the constant.

## profile
- viper.GetString("profile")
- viper.GetString(config.ProfileName)
- viper.GetString(ProfileName)
- viper.Set("profile", ...)
- viper.Set(config.ProfileName, ...)
- viper.Set(ProfileName, ...)

## force
- viper.GetBool(force) outside of cmd package
- viper.GetBool("force") in cmd package

## Remaning viper calls in pkg

### viper.Get*

```console
% git grep viper.Get pkg        
pkg/addons/validations.go:      addonList := viper.GetStringSlice(config.AddonListFlag)
pkg/minikube/assets/addons.go:          newImages := parseMapString(viper.GetString(config.AddonImages))
pkg/minikube/assets/addons.go:          newRegistries := parseMapString(viper.GetString(config.AddonRegistries))
pkg/minikube/audit/audit.go:    u := viper.GetString(config.UserFlag)
pkg/minikube/audit/audit.go:            maxEntries = viper.GetInt(config.MaxAuditEntries)
pkg/minikube/audit/audit.go:    if viper.GetBool(config.SkipAuditFlag) {
pkg/minikube/audit/audit.go:    return pflag.Arg(0) == "delete" && viper.GetBool("purge")
pkg/minikube/config/config.go:  return viper.GetInt("nodes") > 1
pkg/minikube/config/config.go:  return viper.GetBool("ha")
pkg/minikube/detect/detect.go:  p := viper.GetString("socket-vmnet-path")
pkg/minikube/detect/detect.go:  p := viper.GetString("socket-vmnet-client-path")
pkg/minikube/download/preload.go:       if !driver.AllowsPreload(driverName) || !viper.GetBool("preload") && !force {
pkg/minikube/node/cache.go:     if !viper.GetBool(cacheImages) {
pkg/minikube/node/cache.go:     binariesURL := viper.GetString("binary-mirror")
pkg/minikube/node/cache.go:     if !viper.GetBool(cacheImages) {
pkg/minikube/node/start.go:             bs, err = cluster.Bootstrapper(starter.MachineAPI, viper.GetString(cmdcfg.Bootstrapper), *starter.Cfg, starter.Runner)
pkg/minikube/node/start.go:                     pcpBs, err := cluster.ControlPlaneBootstrapper(starter.MachineAPI, starter.Cfg, viper.GetString(cmdcfg.Bootstrapper))
pkg/minikube/node/start.go:     addonList := viper.GetStringSlice(config.AddonListFlag)
pkg/minikube/node/start.go:     if starter.Cfg.Driver == driver.VirtualBox && viper.GetBool(config.WantVirtualBoxDriverWarning) {
pkg/minikube/node/start.go:             klog.Infof("Will wait %s for node %+v", viper.GetDuration(waitTimeout), starter.Node)
pkg/minikube/node/start.go:             if err := bs.WaitForNode(*starter.Cfg, *starter.Node, viper.GetDuration(waitTimeout)); err != nil {
pkg/minikube/node/start.go:                     return nil, errors.Wrapf(err, "wait %s for node", viper.GetDuration(waitTimeout))
pkg/minikube/node/start.go:     if viper.GetBool("force-systemd") {
pkg/minikube/node/start.go:     deleteOnFailure := viper.GetBool("delete-on-failure")
pkg/minikube/node/start.go:     bs, err := cluster.Bootstrapper(mAPI, viper.GetString(cmdcfg.Bootstrapper), cfg, r)
pkg/minikube/node/start.go:     if viper.GetBool(config.WantNoneDriverWarning) {
pkg/minikube/notify/notify.go:  if !viper.GetBool(config.WantUpdateNotification) {
pkg/minikube/notify/notify.go:  return time.Since(lastUpdateTime).Hours() >= viper.GetFloat64(config.ReminderWaitPeriodInHours)
pkg/minikube/notify/notify.go:  if !viper.GetBool(config.WantBetaUpdateNotification) {
pkg/minikube/registry/drvs/qemu2/qemu2.go:      qemuFirmware, err := qemuFirmwarePath(viper.GetString("qemu-firmware-path"))
pkg/provision/buildroot.go:             viper.GetString(config.ProfileName),
pkg/provision/ubuntu.go:                        viper.GetString(config.ProfileName),
```

### viper.Set

```console
% git grep viper.Set pkg
pkg/minikube/assets/addons_test.go:     viper.Set(name, fmt.Sprintf("%s=%s", k, v))
pkg/minikube/audit/audit_test.go:                       viper.Set(config.UserFlag, test.userFlag)
pkg/minikube/audit/audit_test.go:               viper.Set(config.MaxAuditEntries, 3)
pkg/minikube/notify/notify_test.go:     viper.Set(config.WantUpdateNotification, false)
pkg/minikube/notify/notify_test.go:     viper.Set(config.WantUpdateNotification, true)
pkg/minikube/notify/notify_test.go:     viper.Set(config.ReminderWaitPeriodInHours, 24)
pkg/minikube/notify/notify_test.go:     viper.Set("interactive", true)
pkg/minikube/notify/notify_test.go:     viper.Set(config.WantUpdateNotification, true)
pkg/minikube/notify/notify_test.go:     viper.Set(config.WantBetaUpdateNotification, false)
pkg/minikube/notify/notify_test.go:     viper.Set(config.WantBetaUpdateNotification, true)
pkg/minikube/notify/notify_test.go:     viper.Set(config.ReminderWaitPeriodInHours, 24)
pkg/minikube/notify/notify_test.go:                     viper.Set(config.WantUpdateNotification, tt.wantUpdateNotification)
pkg/minikube/notify/notify_test.go:                     viper.Set(config.WantBetaUpdateNotification, tt.wantBetaUpdateNotification)
```