### PR TITLE
docs: Update roadmap footer icon to use map icon

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -165,7 +165,7 @@ no = 'Sorry to hear that. Please <a href="https://github.com/kubernetes/minikube
 [[params.links.developer]]
 	name = "Project Roadmap"
 	url = "https://minikube.sigs.k8s.io/docs/contrib/roadmap/"
-	icon = "fas fa-external-link-alt"
+	icon = "fas fa-map"
 	desc = "Check out the project roadmap"
 
 # minikube meetings


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

## What type of PR is this?

/kind documentation

## What this PR does / why we need it:

Updates the roadmap link icon in the website footer from `fas fa-external-link-alt` to `fas fa-map` for better semantic representation.

## Which issue(s) this PR fixes:

None

## Special notes for your reviewer:

### Before:
The roadmap link used a generic external link icon (↗️) that was shared with the contributing guide link.

<img width="368" height="123" alt="image" src="https://github.com/user-attachments/assets/246417d9-6287-4033-8119-03b3ad7ab679" />


### After: 
The roadmap link now uses a map icon (🗺️) which better represents navigation and direction, while the contributing guide keeps the external link icon.
<img width="353" height="129" alt="image" src="https://github.com/user-attachments/assets/0d28f139-97cf-4a8c-b778-96d1b88bea94" />

## Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

This follows the existing pattern in the footer where different link types use semantically appropriate icons (GitHub uses `fab fa-github`, Slack uses `fab fa-slack`, etc.).
