### PR TITLE
test: Fix guest_env_test.go

### DIFF
--- a/test/integration/iso_test.go
+++ b/test/integration/iso_test.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"os/exec"
 	"runtime"
-	"strings"
 	"testing"
 
 	"k8s.io/minikube/pkg/minikube/vmpath"
@@ -42,14 +41,10 @@ func TestISOImage(t *testing.T) {
 	defer CleanupWithLogs(t, profile, cancel)
 
 	t.Run("Setup", func(t *testing.T) {
-		args := append([]string{"start", "-p", profile, "--install-addons=false", "--memory=3072", "--wait=false", "--disable-metrics=true"}, StartArgs()...)
+		args := append([]string{"start", "-p", profile, "--no-kubernetes"}, StartArgs()...)
 		rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 		if err != nil {
 			t.Errorf("failed to start minikube: args %q: %v", rr.Command(), err)
-		}
-
-		if strings.Contains(rr.Stderr.String(), "kubelet.housekeeping-interval=5m") {
-			t.Error("--disable-metrics=true is not working, housekeeping interval not increased")
 		}
 	})
 


### PR DESCRIPTION
The test used `go:build iso` so it was not included in the integration tests. Change to `go:build integration` so we test in the CI.

- Fix the test for arm64, since virtualbox programs are not included in the iso.
- The test is 2.45 times faster now using --no-kubernetes
- Rename the file and the test name to make it more clear that this test is about the iso image.
- Skip the test for non vm-driver, since this tests is about the iso image.

We may need to add a similar test or adapt this test so it can be used also with the kicbase image.

This test will be useful to validate #21800, avoiding regressions such as #21788.

## Example run

```console
% go test -v ./test/integration -run TestISO -tags integration -count 1
...
--- PASS: TestISOImage (5.77s)
    --- PASS: TestISOImage/Setup (5.30s)
    --- PASS: TestISOImage/Binaries (0.00s)
        --- PASS: TestISOImage/Binaries/wget (0.09s)
        --- PASS: TestISOImage/Binaries/socat (0.09s)
        --- PASS: TestISOImage/Binaries/iptables (0.10s)
        --- PASS: TestISOImage/Binaries/podman (0.10s)
        --- PASS: TestISOImage/Binaries/crictl (0.11s)
        --- PASS: TestISOImage/Binaries/git (0.11s)
        --- PASS: TestISOImage/Binaries/rsync (0.07s)
        --- PASS: TestISOImage/Binaries/docker (0.08s)
        --- PASS: TestISOImage/Binaries/curl (0.08s)
    --- PASS: TestISOImage/PersistentMounts (0.00s)
        --- PASS: TestISOImage/PersistentMounts//var/lib/toolbox (0.08s)
        --- PASS: TestISOImage/PersistentMounts//var/lib/boot2docker (0.09s)
        --- PASS: TestISOImage/PersistentMounts//var/lib/cni (0.09s)
        --- PASS: TestISOImage/PersistentMounts//var/lib/minikube (0.10s)
        --- PASS: TestISOImage/PersistentMounts//data (0.10s)
        --- PASS: TestISOImage/PersistentMounts//var/lib/docker (0.11s)
        --- PASS: TestISOImage/PersistentMounts//var/lib/kubelet (0.07s)
PASS
Tests completed in 5.7657725s (result code 0)
ok  	k8s.io/minikube/test/integration	6.974s
```