### PR TITLE
Integration Test: Refactor TestDownloadOnly

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -119,6 +119,7 @@ const (
 	ha                      = "ha"
 	nodes                   = "nodes"
 	preload                 = "preload"
+	preloadURL              = "preload-url"
 	deleteOnFailure         = "delete-on-failure"
 	forceSystemd            = "force-systemd"
 	kicBaseImage            = "base-image"
@@ -196,6 +197,13 @@ func initMinikubeFlags() {
 	startCmd.Flags().Bool(ha, false, "Create Highly Available Multi-Control Plane Cluster with a minimum of three control-plane nodes that will also be marked for work.")
 	startCmd.Flags().IntP(nodes, "n", 1, "The total number of nodes to spin up. Defaults to 1.")
 	startCmd.Flags().Bool(preload, true, "If set, download tarball of preloaded images if available to improve start time. Defaults to true.")
+	startCmd.Flags().String(preloadURL, "", "override preload download URL (testing only)")
+	if err := viper.BindPFlag("preload-url", startCmd.Flags().Lookup(preloadURL)); err != nil {
+		klog.Fatalf("Failed to bind flag: %v", err)
+	}
+	if err := startCmd.Flags().MarkHidden("preload-url"); err != nil {
+		klog.Warningf("Failed to hide %s flag: %v\n", "preload-url", err)
+	}
 	startCmd.Flags().Bool(noKubernetes, false, "If set, minikube VM/container will start without starting or configuring Kubernetes. (only works on new clusters)")
 	startCmd.Flags().Bool(deleteOnFailure, false, "If set, delete the current cluster if start fails and try again. Defaults to false.")
 	startCmd.Flags().Bool(forceSystemd, false, "If set, force the container runtime to use systemd as cgroup manager. Defaults to false.")

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -104,6 +104,11 @@ func remoteTarballURLGitHub(k8sVersion, containerRuntime string) string {
 }
 
 func remoteTarballURL(k8sVersion, containerRuntime string, source preloadSource) string {
+	overrideURL := viper.GetString("preload-url")
+	if overrideURL != "" {
+		klog.V(2).Infof("Using override preload URL: %s", overrideURL)
+		return overrideURL
+	}
 	switch source {
 	case preloadSourceGitHub:
 		return remoteTarballURLGitHub(k8sVersion, containerRuntime)
@@ -246,7 +251,15 @@ func Preload(k8sVersion, containerRuntime, driverName string) error {
 	if ok && state.source != preloadSourceNone {
 		source = state.source
 	}
+
 	url := remoteTarballURL(k8sVersion, containerRuntime, source)
+	// override URL if flag is set
+	customURL := viper.GetString("preload-url")
+	if customURL != "" {
+		klog.Infof("Using custom preload tarball URL: %s", customURL)
+		url = customURL
+	}
+
 	var checksum []byte
 	var chksErr error
 	checksum, chksErr = getChecksum(source, k8sVersion, containerRuntime)


### PR DESCRIPTION
Fixes #21805

This PR implements the following changes:

- Updates the integration test `TestDownloadOnly` to handle preload scenarios.
- Deletes cached images, preload state, and binaries for test isolation. (TODO)
- In the case of "Preload exists, no fallback," uses `remoteTarballURL` to fetch the preload for the latest release, as it is assumed to always exist. (TODO)

### After:
```
=== RUN   TestDownloadOnly/v1.28.0/preload-failed
    aaa_download_only_test.go:152: (dbg) Run:  out/minikube start -p download-only-698211 --download-only --alsologtostderr
    aaa_download_only_test.go:156: start with invalid preload-url expected to fail, but succeeded: "out/minikube start -p download-only-698211 --download-only --alsologtostderr"
I1029 23:16:30.494132  745649 aaa_download_only_test.go:159] preload-url: http://invalid-url/preload.tar.gz
=== RUN   TestDownloadOnly/v1.28.0/preload-false
    aaa_download_only_test.go:190: (dbg) Run:  out/minikube start -p download-only-698211 --alsologtostderr --preload=false
    aaa_download_only_test.go:190: (dbg) Done: out/minikube start -p download-only-698211 --alsologtostderr --preload=false: (25.049841993s)
```

`start --preloadUR ...`
[start.txt](https://github.com/user-attachments/files/23217215/log.txt)

`restart`
[restart.txt](https://github.com/user-attachments/files/23217405/log.txt)
