### PR TITLE
Addon inspektor-gadget: Update inspektor-gadget image from v0.45.0 to v0.46.0

### DIFF
--- a/deploy/addons/inspektor-gadget/ig-crd.yaml
+++ b/deploy/addons/inspektor-gadget/ig-crd.yaml
@@ -1,1 +1,0 @@
-404: Not Found

--- a/hack/update/inspektor_gadget_version/inspektor_gadget_version.go
+++ b/hack/update/inspektor_gadget_version/inspektor_gadget_version.go
@@ -63,7 +63,6 @@ func main() {
 
 	update.Apply(schema, data)
 	updateDeploymentYAML(stable)
-	updateCRDYAML(stable)
 }
 
 func updateDeploymentYAML(version string) {
@@ -83,21 +82,6 @@ func updateDeploymentYAML(version string) {
 		yaml = regexp.MustCompile(re).ReplaceAll(yaml, []byte(repl))
 	}
 	if err := os.WriteFile("../deploy/addons/inspektor-gadget/ig-deployment.yaml.tmpl", yaml, 0644); err != nil {
-		klog.Fatalf("failed to write to YAML file: %v", err)
-	}
-}
-
-func updateCRDYAML(version string) {
-	res, err := http.Get(fmt.Sprintf("https://raw.githubusercontent.com/inspektor-gadget/inspektor-gadget/refs/tags/%s/pkg/resources/crd/bases/gadget.kinvolk.io_traces.yaml", version))
-	if err != nil {
-		klog.Fatalf("failed to get yaml file: %v", err)
-	}
-	defer res.Body.Close()
-	yaml, err := io.ReadAll(res.Body)
-	if err != nil {
-		klog.Fatalf("failed to read body: %v", err)
-	}
-	if err := os.WriteFile("../deploy/addons/inspektor-gadget/ig-crd.yaml", yaml, 0644); err != nil {
 		klog.Fatalf("failed to write to YAML file: %v", err)
 	}
 }

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -280,7 +280,7 @@ var Addons = map[string]*Addon{
 		MustBinAsset(addons.InspektorGadgetAssets, "inspektor-gadget/ig-deployment.yaml.tmpl", vmpath.GuestAddonsDir, "ig-deployment.yaml", "0640"),
 	}, false, "inspektor-gadget", "3rd party (inspektor-gadget.io)", "https://github.com/orgs/inspektor-gadget/people", "https://minikube.sigs.k8s.io/docs/handbook/addons/inspektor-gadget/",
 		map[string]string{
-			"InspektorGadget": "inspektor-gadget/inspektor-gadget:v0.45.0@sha256:df0516c4c988694d65b19400d0990f129d5fd68f211cc826e7fdad55140626fd",
+			"InspektorGadget": "inspektor-gadget/inspektor-gadget:v0.46.0@sha256:a4b4360159036e9d1eea4e03a935d3b621bcd6487a70e770dd4642e84af5a6d1",
 		}, map[string]string{
 			"InspektorGadget": "ghcr.io",
 		}),


### PR DESCRIPTION
This was done by running:
```
make update-inspektor-gadget-version
```

ig-crd.yaml is removed because this was removed by Inspektor Gadget in v0.42.0 (released in July).
See:
- https://github.com/inspektor-gadget/inspektor-gadget/commit/1d81a613124812ad8efa74056518b538e058c304
- https://github.com/inspektor-gadget/inspektor-gadget/pull/4655

Fixes: 42823b8ba17232e0e32634ad0e83376c1af908a0 ("Addon inspektor-gadget: Update inspektor-gadget image from v0.41.0 to v0.42.0") #21038
