### PR TITLE
kubeconfig: normalize generated cert paths to forward slashes

### DIFF
--- a/pkg/minikube/kubeconfig/kubeconfig.go
+++ b/pkg/minikube/kubeconfig/kubeconfig.go
@@ -157,8 +157,8 @@ func configIssues(cfg *api.Config, contextName string, address string) []error {
 
 // populateCerts retains certs already defined in kubeconfig or sets default ones for those missing.
 func populateCerts(kcs *Settings, cfg api.Config, contextName string) {
-	lp := localpath.Profile(contextName)
-	gp := localpath.MiniPath()
+	gp := filepath.ToSlash(localpath.MiniPath())
+	lp := filepath.ToSlash(localpath.Profile(contextName))
 
 	kcs.CertificateAuthority = path.Join(gp, "ca.crt")
 	if cluster, ok := cfg.Clusters[contextName]; ok {


### PR DESCRIPTION
This PR normalizes generated kubeconfig certificate paths by converting any Windows backslashes to forward slashes when building new entries in` populateCerts (kubeconfig.go`). Prior logic mixed `filepath.Join` (producing \ on Windows) with` path.Join` (always /), creating hybrid paths like` \home\user\.minikube\profiles\minikube/client.crt`. The tests (`TestUpdateIP` and `TestMissingContext`) compare kubeconfig objects via raw string equality (`configEquals`), so those mixed separators caused mismatches only on Windows.

It Fixes These Two Tests:

- `TestUpdateIP`: When adding or updating the minikube cluster/user entries, normalized paths now match the forward‑slash fixtures (`kubeConfigWithoutHTTPSUpdated`, etc.), eliminating false diffs.
- `TestMissingContext`: Rewriting the missing context also regenerates cluster/user entries; normalized paths prevent separator differences from triggering a failure.

Scope:

- Only affects path formatting for newly written certificate/key/CA paths.
- No change to embedded cert data or other kubeconfig fields.
- Cross‑platform safe (forward slashes are valid in kubeconfig on all OSes).


https://github.com/kubernetes/minikube/blob/87ccec354dd39bf498e1d196847a021a6ac4fdc2/pkg/minikube/kubeconfig/kubeconfig_test.go#L399

https://github.com/kubernetes/minikube/blob/87ccec354dd39bf498e1d196847a021a6ac4fdc2/pkg/minikube/kubeconfig/kubeconfig_test.go#L494

**Test Failures before the fix**
```
Running tool: C:\Program Files\Go\bin\go.exe test -timeout 30s -run ^TestMissingContext$ k8s.io/minikube/pkg/minikube/kubeconfig

=== RUN   TestMissingContext
I1222 19:10:34.504213   10508 kubeconfig.go:125] found "minikube" server: "https://192.168.10.100:8080"
I1222 19:10:34.504334   10508 kubeconfig.go:62] C:\Users\bosira\AppData\Local\Temp\kubeconfig4043014751 needs updating (will repair): [kubeconfig missing "minikube" context setting]
I1222 19:10:34.505556   10508 lock.go:35] WriteFile acquiring C:\Users\bosira\AppData\Local\Temp\kubeconfig4043014751: {Name:mk3d767f4e9dbd596166beda865b760954bb2baa Clock:{} Delay:500ms Timeout:1m0s Cancel:<nil>}
    c:\dev\minikube\pkg\minikube\kubeconfig\kubeconfig_test.go:511: configs did not match: Actual:
        &{Kind: APIVersion: Preferences:{Colors:false Extensions:map[]} Clusters:map[la-croix:0xc0002ae080 minikube:0xc0002ae100] AuthInfos:map[la-croix:0xc0002c8000 minikube:0xc0002c8100] Contexts:map[la-croix:0xc0002b43c0 minikube:0xc0002b4410] CurrentContext:minikube Extensions:map[]}
         Expected:
        &{Kind: APIVersion: Preferences:{Colors:false Extensions:map[]} Clusters:map[la-croix:0xc0002ae200 minikube:0xc0002ae280] AuthInfos:map[la-croix:0xc0002c8200 minikube:0xc0002c8300] Contexts:map[la-croix:0xc0002b4820 minikube:0xc0002b4870] CurrentContext:minikube Extensions:map[]}
--- FAIL: TestMissingContext (0.04s)
FAIL
FAIL    k8s.io/minikube/pkg/minikube/kubeconfig 1.125s
```

**Test Run with the fix**
```
Running tool: C:\Program Files\Go\bin\go.exe test -timeout 30s -run ^TestMissingContext$ k8s.io/minikube/pkg/minikube/kubeconfig

=== RUN   TestMissingContext
I1222 19:14:07.585088   31720 kubeconfig.go:125] found "minikube" server: "https://192.168.10.100:8080"
I1222 19:14:07.585699   31720 kubeconfig.go:62] C:\Users\bosira\AppData\Local\Temp\kubeconfig3696084053 needs updating (will repair): [kubeconfig missing "minikube" context setting]
I1222 19:14:07.585699   31720 lock.go:35] WriteFile acquiring C:\Users\bosira\AppData\Local\Temp\kubeconfig3696084053: {Name:mk94f06b27f1459a5a4ce5fd96e50767ea3059b0 Clock:{} Delay:500ms Timeout:1m0s Cancel:<nil>}
--- PASS: TestMissingContext (0.03s)
PASS
ok      k8s.io/minikube/pkg/minikube/kubeconfig 0.186s
```

**Test Failures before the fix**
```
Running tool: C:\Program Files\Go\bin\go.exe test -timeout 30s -run ^TestUpdateIP$ k8s.io/minikube/pkg/minikube/kubeconfig

=== RUN   TestUpdateIP
=== RUN   TestUpdateIP/empty_hostname
=== PAUSE TestUpdateIP/empty_hostname
=== RUN   TestUpdateIP/no_minikube_cluster
=== PAUSE TestUpdateIP/no_minikube_cluster
=== RUN   TestUpdateIP/same_IP
=== PAUSE TestUpdateIP/same_IP
=== RUN   TestUpdateIP/different_IP
=== PAUSE TestUpdateIP/different_IP
=== RUN   TestUpdateIP/different_port
=== PAUSE TestUpdateIP/different_port
=== RUN   TestUpdateIP/no_clusters
=== PAUSE TestUpdateIP/no_clusters
=== CONT  TestUpdateIP/empty_hostname
=== CONT  TestUpdateIP/different_IP
=== CONT  TestUpdateIP/same_IP
=== CONT  TestUpdateIP/no_clusters
=== CONT  TestUpdateIP/different_port
=== CONT  TestUpdateIP/no_minikube_cluster
I1222 19:09:29.117769   10740 kubeconfig.go:47] verify endpoint returned: get endpoint: "minikube" does not appear in C:\Users\bosira\AppData\Local\Temp\kubeconfig1287614674
I1222 19:09:29.117769   10740 kubeconfig.go:47] verify endpoint returned: get endpoint: "minikube" does not appear in C:\Users\bosira\AppData\Local\Temp\kubeconfig279835480
I1222 19:09:29.117769   10740 kubeconfig.go:125] found "minikube" server: "https://192.168.10.100:8443"
I1222 19:09:29.117769   10740 kubeconfig.go:62] C:\Users\bosira\AppData\Local\Temp\kubeconfig279835480 needs updating (will repair): [kubeconfig missing "minikube" cluster setting kubeconfig missing "minikube" context setting]
I1222 19:09:29.117769   10740 kubeconfig.go:62] C:\Users\bosira\AppData\Local\Temp\kubeconfig1287614674 needs updating (will repair): [kubeconfig missing "minikube" cluster setting kubeconfig missing "minikube" context setting]
I1222 19:09:29.119039   10740 kubeconfig.go:125] found "minikube" server: "https://192.168.10.100:8443"
I1222 19:09:29.119039   10740 kubeconfig.go:47] verify endpoint returned: got: 192.168.10.100:8443, want: 127.0.0.1:8443
I1222 19:09:29.119039   10740 lock.go:35] WriteFile acquiring C:\Users\bosira\AppData\Local\Temp\kubeconfig279835480: {Name:mk4862ae375f9ff17ed377d81e84f43e10bd6649 Clock:{} Delay:500ms Timeout:1m0s Cancel:<nil>}
--- PASS: TestUpdateIP/same_IP (0.02s)
I1222 19:09:29.119316   10740 lock.go:35] WriteFile acquiring C:\Users\bosira\AppData\Local\Temp\kubeconfig1287614674: {Name:mk44f91932205321be77ebc3f54f3150c8ac2298 Clock:{} Delay:500ms Timeout:1m0s Cancel:<nil>}
I1222 19:09:29.119374   10740 kubeconfig.go:125] found "minikube" server: "https://127.0.0.1:8443"
I1222 19:09:29.119374   10740 kubeconfig.go:47] verify endpoint returned: got: 127.0.0.1:8443, want: 127.0.0.1:12345
--- PASS: TestUpdateIP/empty_hostname (0.02s)
I1222 19:09:29.119374   10740 kubeconfig.go:62] C:\Users\bosira\AppData\Local\Temp\kubeconfig3632604974 needs updating (will repair): [kubeconfig needs server address update]
I1222 19:09:29.120679   10740 kubeconfig.go:62] C:\Users\bosira\AppData\Local\Temp\kubeconfig2884787821 needs updating (will repair): [kubeconfig needs server address update]
I1222 19:09:29.120679   10740 lock.go:35] WriteFile acquiring C:\Users\bosira\AppData\Local\Temp\kubeconfig3632604974: {Name:mk818f85e05923c683e1a1a772cba04b06283e4f Clock:{} Delay:500ms Timeout:1m0s Cancel:<nil>}
I1222 19:09:29.121322   10740 lock.go:35] WriteFile acquiring C:\Users\bosira\AppData\Local\Temp\kubeconfig2884787821: {Name:mkaf5f04de78b90a83792de9fc379151da718fe3 Clock:{} Delay:500ms Timeout:1m0s Cancel:<nil>}
    c:\dev\minikube\pkg\minikube\kubeconfig\kubeconfig_test.go:488: configs did not match: Actual:
        &{Kind: APIVersion: Preferences:{Colors:false Extensions:map[]} Clusters:map[minikube:0xc00013e280] AuthInfos:map[minikube:0xc00018a100] Contexts:map[minikube:0xc0002c4230] CurrentContext:minikube Extensions:map[]}
         Expected:
        &{Kind: APIVersion: Preferences:{Colors:false Extensions:map[]} Clusters:map[minikube:0xc00013e380] AuthInfos:map[minikube:0xc00018a300] Contexts:map[minikube:0xc0002c4460] CurrentContext:minikube Extensions:map[]}
    c:\dev\minikube\pkg\minikube\kubeconfig\kubeconfig_test.go:488: configs did not match: Actual:
        &{Kind: APIVersion: Preferences:{Colors:false Extensions:map[]} Clusters:map[la-croix:0xc0002be080 minikube:0xc0002be100] AuthInfos:map[la-croix:0xc0005ba000 minikube:0xc0005ba200] Contexts:map[la-croix:0xc0005ae410 minikube:0xc0005ae460] CurrentContext:minikube Extensions:map[]}
         Expected:
        &{Kind: APIVersion: Preferences:{Colors:false Extensions:map[]} Clusters:map[la-croix:0xc0002be200 minikube:0xc0002be280] AuthInfos:map[la-croix:0xc0005ba300 minikube:0xc0005ba400] Contexts:map[la-croix:0xc0005ae870 minikube:0xc0005ae8c0] CurrentContext:minikube Extensions:map[]}
--- FAIL: TestUpdateIP/no_clusters (0.04s)
--- PASS: TestUpdateIP/different_port (0.04s)
--- FAIL: TestUpdateIP/no_minikube_cluster (0.04s)
--- PASS: TestUpdateIP/different_IP (0.04s)
--- FAIL: TestUpdateIP (0.00s)
FAIL
FAIL    k8s.io/minikube/pkg/minikube/kubeconfig 3.264s
```



**Test Run with the fix**
```
Running tool: C:\Program Files\Go\bin\go.exe test -timeout 30s -run ^TestUpdateIP$ k8s.io/minikube/pkg/minikube/kubeconfig

=== RUN   TestUpdateIP
=== RUN   TestUpdateIP/empty_hostname
=== PAUSE TestUpdateIP/empty_hostname
=== RUN   TestUpdateIP/no_minikube_cluster
=== PAUSE TestUpdateIP/no_minikube_cluster
=== RUN   TestUpdateIP/same_IP
=== PAUSE TestUpdateIP/same_IP
=== RUN   TestUpdateIP/different_IP
=== PAUSE TestUpdateIP/different_IP
=== RUN   TestUpdateIP/different_port
=== PAUSE TestUpdateIP/different_port
=== RUN   TestUpdateIP/no_clusters
=== PAUSE TestUpdateIP/no_clusters
=== CONT  TestUpdateIP/empty_hostname
=== CONT  TestUpdateIP/different_IP
=== CONT  TestUpdateIP/same_IP
=== CONT  TestUpdateIP/no_clusters
=== CONT  TestUpdateIP/different_port
=== CONT  TestUpdateIP/no_minikube_cluster
I1222 19:12:59.207603   27256 kubeconfig.go:125] found "minikube" server: "https://127.0.0.1:8443"
I1222 19:12:59.207603   27256 kubeconfig.go:47] verify endpoint returned: get endpoint: "minikube" does not appear in C:\Users\bosira\AppData\Local\Temp\kubeconfig1784042150
I1222 19:12:59.207829   27256 kubeconfig.go:47] verify endpoint returned: got: 127.0.0.1:8443, want: 127.0.0.1:12345
I1222 19:12:59.207603   27256 kubeconfig.go:47] verify endpoint returned: get endpoint: "minikube" does not appear in C:\Users\bosira\AppData\Local\Temp\kubeconfig2608812668
I1222 19:12:59.207603   27256 kubeconfig.go:125] found "minikube" server: "https://192.168.10.100:8443"
I1222 19:12:59.207829   27256 kubeconfig.go:125] found "minikube" server: "https://192.168.10.100:8443"
I1222 19:12:59.207829   27256 kubeconfig.go:47] verify endpoint returned: got: 192.168.10.100:8443, want: 127.0.0.1:8443
--- PASS: TestUpdateIP/empty_hostname (0.02s)
I1222 19:12:59.207829   27256 kubeconfig.go:62] C:\Users\bosira\AppData\Local\Temp\kubeconfig1784042150 needs updating (will repair): [kubeconfig missing "minikube" cluster setting kubeconfig missing "minikube" context setting]
I1222 19:12:59.207829   27256 kubeconfig.go:62] C:\Users\bosira\AppData\Local\Temp\kubeconfig2608812668 needs updating (will repair): [kubeconfig missing "minikube" cluster setting kubeconfig missing "minikube" context setting]
I1222 19:12:59.208422   27256 kubeconfig.go:62] C:\Users\bosira\AppData\Local\Temp\kubeconfig4058323542 needs updating (will repair): [kubeconfig needs server address update]
I1222 19:12:59.208422   27256 kubeconfig.go:62] C:\Users\bosira\AppData\Local\Temp\kubeconfig4276076689 needs updating (will repair): [kubeconfig needs server address update]
--- PASS: TestUpdateIP/same_IP (0.02s)
I1222 19:12:59.209645   27256 lock.go:35] WriteFile acquiring C:\Users\bosira\AppData\Local\Temp\kubeconfig1784042150: {Name:mkc597991b04891205c91c8c54284ef77ee37b86 Clock:{} Delay:500ms Timeout:1m0s Cancel:<nil>}
I1222 19:12:59.209715   27256 lock.go:35] WriteFile acquiring C:\Users\bosira\AppData\Local\Temp\kubeconfig4276076689: {Name:mk92942aa493acfcfdeee2c6d1401f3aa86fc6a5 Clock:{} Delay:500ms Timeout:1m0s Cancel:<nil>}
I1222 19:12:59.209645   27256 lock.go:35] WriteFile acquiring C:\Users\bosira\AppData\Local\Temp\kubeconfig4058323542: {Name:mk1f85e49df5dc30f86d42de0c08b39a1184a334 Clock:{} Delay:500ms Timeout:1m0s Cancel:<nil>}
I1222 19:12:59.210867   27256 lock.go:35] WriteFile acquiring C:\Users\bosira\AppData\Local\Temp\kubeconfig2608812668: {Name:mka6828efa15b4c1fa39462a5301186d9d8e7862 Clock:{} Delay:500ms Timeout:1m0s Cancel:<nil>}
--- PASS: TestUpdateIP/different_IP (0.04s)
--- PASS: TestUpdateIP/no_clusters (0.04s)
--- PASS: TestUpdateIP/different_port (0.04s)
--- PASS: TestUpdateIP/no_minikube_cluster (0.04s)
--- PASS: TestUpdateIP (0.00s)
PASS
ok      k8s.io/minikube/pkg/minikube/kubeconfig 1.450s
```

