### PR TITLE
test: Fix TestGetKubeConfigPath unit test on windows

### DIFF
--- a/pkg/minikube/kubeconfig/kubeconfig_test.go
+++ b/pkg/minikube/kubeconfig/kubeconfig_test.go
@@ -778,7 +778,7 @@ func TestGetKubeConfigPath(t *testing.T) {
 	// Ensure $HOME expands sensibly on Windows where HOME may be unset.
 	if runtime.GOOS == "windows" && os.Getenv("HOME") == "" {
 		if h, err := os.UserHomeDir(); err == nil && h != "" {
-			_ = os.Setenv("HOME", h)
+			t.Setenv("HOME", h)
 		}
 	}
 


### PR DESCRIPTION
Original failures were due to these mismatches:

- Windows treated "/home/fake/.kube/.kubeconfig:/home/fake2/.kubeconfig" as a single path (since : isn’t a list separator there), so the function returned the entire unsplit string, failing expectations.
- A lone ":" wasn’t recognized as “empty entries,” again because Windows expects ; as the separator.
- Default path comparison failed because the test expected a Unix-style $HOME/.kube/config while PathFromEnv() returned a native Windows path with backslashes.
- No normalization meant / vs \ differences caused equality failures.

By:

- Using os.PathListSeparator, multi-path input now splits correctly on all platforms.
- Normalizing separators and cleaning paths before comparing, platform-specific formatting differences no longer cause false negatives.
- Expanding $HOME after setting it (including fallback) guarantees consistent expected path construction.
- Leaving PathFromEnv() unchanged avoids breaking drive-letter semantics—splitting on : would corrupt  paths.

**Test failures before the fix:**
```
Running tool: C:\Program Files\Go\bin\go.exe test -timeout 30s -run ^TestGetKubeConfigPath$ k8s.io/minikube/pkg/minikube/kubeconfig

=== RUN   TestGetKubeConfigPath
    c:\dev\minikube\pkg\minikube\kubeconfig\kubeconfig_test.go:800: Expected first split chunk, got: /home/fake/.kube/.kubeconfig:/home/fake2/.kubeconfig
    c:\dev\minikube\pkg\minikube\kubeconfig\kubeconfig_test.go:800: Expected first split chunk, got: :/home/fake/.kube/.kubeconfig:/home/fake2/.kubeconfig
    c:\dev\minikube\pkg\minikube\kubeconfig\kubeconfig_test.go:800: Expected first split chunk, got: :
    c:\dev\minikube\pkg\minikube\kubeconfig\kubeconfig_test.go:800: Expected first split chunk, got: C:\Users\bosira\.kube\config
--- FAIL: TestGetKubeConfigPath (0.00s)
FAIL
FAIL    k8s.io/minikube/pkg/minikube/kubeconfig 4.401s
```

**Test run with the fix**
```
Running tool: C:\Program Files\Go\bin\go.exe test -timeout 30s -run ^TestGetKubeConfigPath$ k8s.io/minikube/pkg/minikube/kubeconfig

=== RUN   TestGetKubeConfigPath
I1219 01:37:58.374431   10740 kubeconfig.go:277] Ignoring empty entry in KUBECONFIG env var
I1219 01:37:58.374431   10740 kubeconfig.go:277] Ignoring empty entry in KUBECONFIG env var
I1219 01:37:58.374431   10740 kubeconfig.go:277] Ignoring empty entry in KUBECONFIG env var
--- PASS: TestGetKubeConfigPath (0.00s)
PASS
ok      k8s.io/minikube/pkg/minikube/kubeconfig 2.843s
```