### PR TITLE
build: fix auto-pause build remove not existing embed

### DIFF
--- a/deploy/addons/assets.go
+++ b/deploy/addons/assets.go
@@ -60,7 +60,7 @@ var (
 	IstioAssets embed.FS
 
 	// InspektorGadgetAssets assets for inspektor-gadget addon
-	//go:embed inspektor-gadget/*.tmpl inspektor-gadget/*.yaml
+	//go:embed inspektor-gadget/*.tmpl
 	InspektorGadgetAssets embed.FS
 
 	// KongAssets assets for kong addon


### PR DESCRIPTION
closes https://github.com/kubernetes/minikube/issues/21853
### before this pr
```
$ make deploy/iso/minikube-iso/board/minikube/aarch64/rootfs-overlay/usr/bin/auto-pause
GOOS=linux GOARCH=arm64 go build -o deploy/iso/minikube-iso/board/minikube/aarch64/rootfs-overlay/usr/bin/auto-pause cmd/auto-pause/auto-pause.go
deploy/addons/assets.go:63:37: pattern inspektor-gadget/*.yaml: no matching files found
make: *** [deploy/iso/minikube-iso/board/minikube/aarch64/rootfs-overlay/usr/bin/auto-pause] Error 1
```

### after this PR
```
$ make deploy/iso/minikube-iso/board/minikube/aarch64/rootfs-overlay/usr/bin/auto-pause
GOOS=linux GOARCH=arm64 go build -o deploy/iso/minikube-iso/board/minikube/aarch64/rootfs-overlay/usr/bin/auto-pause cmd/auto-pause/auto-pause.go

```
