### PR TITLE
inspektor-gadget addon: remove deleted asset

### DIFF
--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -276,7 +276,6 @@ var Addons = map[string]*Addon{
 			"0640"),
 	}, false, "istio", "3rd party (Istio)", "", "https://istio.io/latest/docs/setup/platform-setup/minikube/", nil, nil),
 	"inspektor-gadget": NewAddon([]*BinAsset{
-		MustBinAsset(addons.InspektorGadgetAssets, "inspektor-gadget/ig-crd.yaml", vmpath.GuestAddonsDir, "ig-crd.yaml", "0640"),
 		MustBinAsset(addons.InspektorGadgetAssets, "inspektor-gadget/ig-deployment.yaml.tmpl", vmpath.GuestAddonsDir, "ig-deployment.yaml", "0640"),
 	}, false, "inspektor-gadget", "3rd party (inspektor-gadget.io)", "https://github.com/orgs/inspektor-gadget/people", "https://minikube.sigs.k8s.io/docs/handbook/addons/inspektor-gadget/",
 		map[string]string{


### PR DESCRIPTION
follow up after 
- https://github.com/kubernetes/minikube/pull/21843
- https://github.com/kubernetes/minikube/pull/21852

### before
```
$ make generate-docs
go run cmd/extract/extract.go
Compiling translation strings...
Writing to de.json (1011 translated, 63 untranslated)
Writing to el.json (670 translated, 404 untranslated)
Writing to es.json (219 translated, 855 untranslated)
Writing to fr.json (1067 translated, 7 untranslated)
Writing to id.json (1011 translated, 63 untranslated)
Writing to ja.json (939 translated, 135 untranslated)
Writing to ko.json (321 translated, 753 untranslated)
Writing to pl.json (205 translated, 869 untranslated)
Writing to ru.json (23 translated, 1051 untranslated)
Writing to uk.json (1057 translated, 17 untranslated)
Writing to zh-CN.json (1011 translated, 63 untranslated)
Done!
go build  -tags "libvirt_dlopen" -ldflags="-X k8s.io/minikube/pkg/version.version=v1.37.0 -X k8s.io/minikube/pkg/version.isoVersion=v1.37.0-1762018871-21834 -X k8s.io/minikube/pkg/version.gitCommitID="708d28856db10c333bdbb88dc50e3c94ee95a434" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" -o out/minikube k8s.io/minikube/cmd/minikube
# github.com/shoenig/go-m1cpu
../../go/pkg/mod/github.com/shoenig/go-m1cpu@v0.1.6/cpu.go:75:17: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
../../go/pkg/mod/github.com/shoenig/go-m1cpu@v0.1.6/cpu.go:77:16: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
out/minikube generate-docs --path ./site/content/en/docs/commands/ --test-path ./site/content/en/docs/contrib/tests.en.md --code-path ./site/content/en/docs/contrib/errorcodes.en.md
panic: Failed to define asset inspektor-gadget/ig-crd.yaml: open inspektor-gadget/ig-crd.yaml: file does not exist

goroutine 1 [running]:
k8s.io/minikube/pkg/minikube/assets.MustBinAsset({0x104740380?}, {0x103302e4c, 0x1c}, {0x1032ecf5a?, 0x1?}, {0x1032c98cc?, 0xe?}, {0x1032b96a8?, 0x10498eb00?})
        /Users/medya/workspace/minikube/pkg/minikube/assets/vm_assets.go:324 +0xb8
k8s.io/minikube/pkg/minikube/assets.init()
        /Users/medya/workspace/minikube/pkg/minikube/assets/addons.go:279 +0x1c14
make: *** [generate-docs] Error 2
```
### after

```
$ make generate-docs
go run cmd/extract/extract.go
Compiling translation strings...
Writing to de.json (1011 translated, 63 untranslated)
Writing to el.json (670 translated, 404 untranslated)
Writing to es.json (219 translated, 855 untranslated)
Writing to fr.json (1067 translated, 7 untranslated)
Writing to id.json (1011 translated, 63 untranslated)
Writing to ja.json (939 translated, 135 untranslated)
Writing to ko.json (321 translated, 753 untranslated)
Writing to pl.json (205 translated, 869 untranslated)
Writing to ru.json (23 translated, 1051 untranslated)
Writing to uk.json (1057 translated, 17 untranslated)
Writing to zh-CN.json (1011 translated, 63 untranslated)
Done!
go build  -tags "libvirt_dlopen" -ldflags="-X k8s.io/minikube/pkg/version.version=v1.37.0 -X k8s.io/minikube/pkg/version.isoVersion=v1.37.0-1762018871-21834 -X k8s.io/minikube/pkg/version.gitCommitID="708d28856db10c333bdbb88dc50e3c94ee95a434-dirty" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" -o out/minikube k8s.io/minikube/cmd/minikube
# github.com/shoenig/go-m1cpu
../../go/pkg/mod/github.com/shoenig/go-m1cpu@v0.1.6/cpu.go:75:17: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
../../go/pkg/mod/github.com/shoenig/go-m1cpu@v0.1.6/cpu.go:77:16: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
out/minikube generate-docs --path ./site/content/en/docs/commands/ --test-path ./site/content/en/docs/contrib/tests.en.md --code-path ./site/content/en/docs/contrib/errorcodes.en.md
📘  Docs have been saved at - ./site/content/en/docs/commands/
📘  Test docs have been saved at - ./site/content/en/docs/contrib/tests.en.md
📘  Error code docs have been saved at - ./site/content/en/docs/contrib/errorcodes.en.md
```