### PR TITLE
feat: Add custom CRI-O storage paths with automatic bind mount

### DIFF
--- a/cmd/minikube/cmd/start_flags.go
+++ b/cmd/minikube/cmd/start_flags.go
@@ -146,6 +146,8 @@ const (
 	staticIP                = "static-ip"
 	gpus                    = "gpus"
 	autoPauseInterval       = "auto-pause-interval"
+	containerStorageRoot    = "container-storage-root"
+	containerStorageRunRoot = "container-storage-runroot"
 )
 
 var (
@@ -211,6 +213,8 @@ func initMinikubeFlags() {
 	startCmd.Flags().String(staticIP, "", "Set a static IP for the minikube cluster, the IP must be: private, IPv4, and the last octet must be between 2 and 254, for example 192.168.200.200 (Docker and Podman drivers only)")
 	startCmd.Flags().StringP(gpus, "g", "", "Allow pods to use your GPUs. Options include: [all,nvidia,amd] (Docker driver with Docker container-runtime only)")
 	startCmd.Flags().Duration(autoPauseInterval, time.Minute*1, "Duration of inactivity before the minikube VM is paused (default 1m0s)")
+	startCmd.Flags().String(containerStorageRoot, "", "Absolute path for container runtime storage root directory (e.g. /host-containers/storage for CRI-O). Works with CRI-O and other compatible runtimes.")
+	startCmd.Flags().String(containerStorageRunRoot, "", "Absolute path for container runtime storage state directory (e.g. /host-containers/storage for CRI-O). Works with CRI-O and other compatible runtimes.")
 }
 
 // initKubernetesFlags inits the commandline flags for Kubernetes related options
@@ -652,11 +656,51 @@ func generateNewConfigFromFlags(cmd *cobra.Command, k8sVersion string, rtime str
 		MultiNodeRequested: viper.GetInt(nodes) > 1 || viper.GetBool(ha),
 		GPUs:               viper.GetString(gpus),
 		AutoPauseInterval:  viper.GetDuration(autoPauseInterval),
+		ContainerStorageRoot:    viper.GetString(containerStorageRoot),
+		ContainerStorageRunRoot: viper.GetString(containerStorageRunRoot),
 	}
 	cc.VerifyComponents = interpretWaitFlag(*cmd)
 
 	if viper.GetString(mountString) != "" && driver.IsKIC(drvName) {
 		cc.ContainerVolumeMounts = []string{viper.GetString(mountString)}
+	}
+
+	// Validate and warn about custom storage paths
+	if cc.ContainerStorageRoot != "" || cc.ContainerStorageRunRoot != "" {
+		// Validate that custom storage paths are only used with supported runtimes
+		if rtime != constants.CRIO && rtime != "cri-o" {
+			out.WarningT("Custom container storage paths (--container-storage-root, --container-storage-runroot) are currently only supported with CRI-O runtime. The specified paths may be ignored.")
+		}
+
+		// Validate paths are absolute
+		if cc.ContainerStorageRoot != "" && !strings.HasPrefix(cc.ContainerStorageRoot, "/") {
+			exit.Message(reason.Usage, "--container-storage-root must be an absolute path, got: {{.path}}", out.V{"path": cc.ContainerStorageRoot})
+		}
+		if cc.ContainerStorageRunRoot != "" && !strings.HasPrefix(cc.ContainerStorageRunRoot, "/") {
+			exit.Message(reason.Usage, "--container-storage-runroot must be an absolute path, got: {{.path}}", out.V{"path": cc.ContainerStorageRunRoot})
+		}
+
+		// Automatically add storage path mounts for KIC drivers
+		if driver.IsKIC(drvName) {
+			if cc.ContainerVolumeMounts == nil {
+				cc.ContainerVolumeMounts = []string{}
+			}
+			if cc.ContainerStorageRoot != "" {
+				// Mount host storage directory to the same path in container
+				cc.ContainerVolumeMounts = append(cc.ContainerVolumeMounts, fmt.Sprintf("%s:%s", cc.ContainerStorageRoot, cc.ContainerStorageRoot))
+			}
+			if cc.ContainerStorageRunRoot != "" {
+				// Mount host runroot directory to the same path in container
+				cc.ContainerVolumeMounts = append(cc.ContainerVolumeMounts, fmt.Sprintf("%s:%s", cc.ContainerStorageRunRoot, cc.ContainerStorageRunRoot))
+			}
+		}
+
+		// Informational message about the feature
+		if rtime == constants.CRIO || rtime == "cri-o" {
+			if driver.IsKIC(drvName) {
+				out.Styled(style.Tip, "Using custom storage paths with {{.runtime}}. Storage directories will be automatically mounted.", out.V{"runtime": rtime})
+			}
+		}
 	}
 
 	if driver.IsKIC(drvName) {
@@ -882,6 +926,8 @@ func updateExistingConfigFromFlags(cmd *cobra.Command, existing *config.ClusterC
 	updateStringFromFlag(cmd, &cc.SocketVMnetClientPath, socketVMnetClientPath)
 	updateStringFromFlag(cmd, &cc.SocketVMnetPath, socketVMnetPath)
 	updateDurationFromFlag(cmd, &cc.AutoPauseInterval, autoPauseInterval)
+	updateStringFromFlag(cmd, &cc.ContainerStorageRoot, containerStorageRoot)
+	updateStringFromFlag(cmd, &cc.ContainerStorageRunRoot, containerStorageRunRoot)
 
 	if cmd.Flags().Changed(kubernetesVersion) {
 		kubeVer, err := getKubernetesVersion(existing)

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -897,6 +897,8 @@ func (k *Bootstrapper) UpdateCluster(cfg config.ClusterConfig) error {
 		Runner:            k.c,
 		Socket:            cfg.KubernetesConfig.CRISocket,
 		KubernetesVersion: ver,
+		StorageRoot:       cfg.ContainerStorageRoot,
+		StorageRunRoot:    cfg.ContainerStorageRunRoot,
 	})
 	if err != nil {
 		return errors.Wrap(err, "runtime")

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -109,6 +109,8 @@ type ClusterConfig struct {
 	SSHAgentPID             int
 	GPUs                    string
 	AutoPauseInterval       time.Duration // Specifies interval of time to wait before checking if cluster should be paused
+	ContainerStorageRoot    string        // Custom storage root directory for container runtime (e.g., CRI-O root path)
+	ContainerStorageRunRoot string        // Custom storage state directory for container runtime (e.g., CRI-O runroot path)
 }
 
 // KubernetesConfig contains the parameters used to configure the VM Kubernetes.

--- a/pkg/minikube/cruntime/cruntime.go
+++ b/pkg/minikube/cruntime/cruntime.go
@@ -157,6 +157,10 @@ type Config struct {
 	InsecureRegistry []string
 	// GPUs add GPU devices to the container
 	GPUs string
+	// StorageRoot custom storage root directory for container runtime
+	StorageRoot string
+	// StorageRunRoot custom storage state directory for container runtime
+	StorageRunRoot string
 }
 
 // ListContainersOptions are the options to use for listing containers
@@ -238,6 +242,8 @@ func New(c Config) (Manager, error) {
 			ImageRepository:   c.ImageRepository,
 			KubernetesVersion: c.KubernetesVersion,
 			Init:              sm,
+			StorageRoot:       c.StorageRoot,
+			StorageRunRoot:    c.StorageRunRoot,
 		}, nil
 	case "containerd":
 		return &Containerd{

--- a/pkg/minikube/node/node.go
+++ b/pkg/minikube/node/node.go
@@ -139,7 +139,14 @@ func teardown(cc config.ClusterConfig, name string, options *run.CommandOptions)
 	kv, kerr = util.ParseKubernetesVersion(cc.KubernetesConfig.KubernetesVersion)
 	if kerr == nil {
 		var crt cruntime.Manager
-		crt, kerr = cruntime.New(cruntime.Config{Type: cc.KubernetesConfig.ContainerRuntime, Runner: r, Socket: cc.KubernetesConfig.CRISocket, KubernetesVersion: kv})
+		crt, kerr = cruntime.New(cruntime.Config{
+			Type:              cc.KubernetesConfig.ContainerRuntime,
+			Runner:            r,
+			Socket:            cc.KubernetesConfig.CRISocket,
+			KubernetesVersion: kv,
+			StorageRoot:       cc.ContainerStorageRoot,
+			StorageRunRoot:    cc.ContainerStorageRunRoot,
+		})
 		if kerr == nil {
 			sp := crt.SocketPath()
 			// avoid warning/error:

--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -263,7 +263,13 @@ func handleNoKubernetes(starter Starter) (bool, error) {
 	if starter.Node.KubernetesVersion == constants.NoKubernetesVersion {
 		// Stop existing Kubernetes node if applicable.
 		if starter.StopK8s {
-			cr, err := cruntime.New(cruntime.Config{Type: starter.Cfg.KubernetesConfig.ContainerRuntime, Runner: starter.Runner, Socket: starter.Cfg.KubernetesConfig.CRISocket})
+			cr, err := cruntime.New(cruntime.Config{
+				Type:           starter.Cfg.KubernetesConfig.ContainerRuntime,
+				Runner:         starter.Runner,
+				Socket:         starter.Cfg.KubernetesConfig.CRISocket,
+				StorageRoot:    starter.Cfg.ContainerStorageRoot,
+				StorageRunRoot: starter.Cfg.ContainerStorageRunRoot,
+			})
 			if err != nil {
 				return false, err
 			}
@@ -418,6 +424,8 @@ func configureRuntimes(runner cruntime.CommandRunner, cc config.ClusterConfig, k
 		ImageRepository:   cc.KubernetesConfig.ImageRepository,
 		KubernetesVersion: kv,
 		InsecureRegistry:  cc.InsecureRegistry,
+		StorageRoot:       cc.ContainerStorageRoot,
+		StorageRunRoot:    cc.ContainerStorageRunRoot,
 	}
 	if cc.GPUs != "" {
 		co.GPUs = cc.GPUs


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->

Add support for custom CRI-O storage paths with automatic bind mounts

Implements automatic sharing of Podman host images with CRI-O in minikube
by allowing users to specify custom storage paths that are automatically
bind-mounted into the container.

This enhancement adds two new flags:
- --container-storage-root: Specifies custom CRI-O storage root path
- --container-storage-runroot: Specifies custom CRI-O runtime root path

When these flags are used with KIC drivers (Podman/Docker) and CRI-O runtime,
the specified directories are automatically:
1. Bind-mounted from host to container at the same paths
2. Configured in CRI-O's configuration file
3. Used by CRI-O for image storage

This eliminates the need for manual kicbase modifications or image loading
when using Podman as the driver with CRI-O runtime.

Fixes #17415