### PR TITLE
ci: go mod tidy after updating golang version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -936,7 +936,7 @@ time-to-k8s-benchmark:
 .PHONY: update-golang-version
 update-golang-version:
 	 cd hack && go run update/golang_version/golang_version.go
-
+	 make gomodtidy
 .PHONY: update-kubernetes-version
 update-kubernetes-version:
 	 @(cd hack && go run update/kubernetes_version/kubernetes_version.go)


### PR DESCRIPTION
when trying to update go to 1.25 it did change the go mod causing a lint error.
it is a good practice to go mod tidy after bumping go mod version