### PR TITLE
wip: Fix image loading with podman driver 

### DIFF
--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -164,22 +164,19 @@ func beginDownloadKicBaseImage(g *errgroup.Group, cc *config.ClusterConfig, down
 			err = download.ImageToCache(img)
 			if err == nil {
 				klog.Infof("successfully saved %s as a tarball", img)
-			}
-			if downloadOnly && err == nil {
-				return nil
-			}
-
-			if cc.Driver == driver.Podman {
-				return fmt.Errorf("not yet implemented, see issue #8426")
-			}
-			if driver.IsDocker(cc.Driver) && err == nil {
-				klog.Infof("Loading %s from local cache", img)
-				if finalImg, err = download.CacheToDaemon(img); err == nil {
-					klog.Infof("successfully loaded and using %s from cached tarball", img)
+				if downloadOnly {
 					return nil
 				}
+
+				if driver.IsKIC(cc.Driver) {
+					klog.Infof("Loading %s from local cache", img)
+					if finalImg, err = download.CacheToDaemon(img); err == nil {
+						klog.Infof("successfully loaded and using %s from cached tarball", img)
+						return nil
+					}
+				}
+				klog.Infof("failed to download %s, will try fallback image if available: %v", img, err)
 			}
-			klog.Infof("failed to download %s, will try fallback image if available: %v", img, err)
 		}
 		// second if we failed to download any fallback image
 		// that means probably all registries are blocked by network issues


### PR DESCRIPTION
This fixes the image loading for the podman driver removing the annoying message

Resolves: #8426 


## without this patch

```console
$ git branch --show-current
master
$ git fetch origin
...
$  git reset --hard origin/master
HEAD is now at bac7021992 Merge pull request #21933 from medyagh/fix_update_golang
$ make clean && make
$ ./out/minikube  profile list
┌───────────────────┬────────┬─────────┬──────────────┬─────────┬─────────┬───────┬────────────────┬────────────────────┐
│      PROFILE      │ DRIVER │ RUNTIME │      IP      │ VERSION │ STATUS  │ NODES │ ACTIVE PROFILE │ ACTIVE KUBECONTEXT │
├───────────────────┼────────┼─────────┼──────────────┼─────────┼─────────┼───────┼────────────────┼────────────────────┤
│ functional-865055 │ docker │ crio    │ 192.168.49.2 │ v1.34.1 │ Stopped │ 1     │                │                    │
│ functional-981737 │ docker │ crio    │ 192.168.58.2 │ v1.34.1 │ Stopped │ 1     │                │                    │
│ minikube          │ kvm2   │ docker  │              │ v1.33.0 │ Stopped │ 1     │ *              │                    │
└───────────────────┴────────┴─────────┴──────────────┴─────────┴─────────┴───────┴────────────────┴────────────────────┘
11:21:42 obnox@cone minikube ±|master ✗|→ ./out/minikube delete --all
🔥  Deleting "functional-865055" in docker ...
🔥  Removing /home/obnox/.minikube/machines/functional-865055 ...
💀  Removed all traces of the "functional-865055" cluster.
🔥  Deleting "functional-981737" in docker ...
🔥  Removing /home/obnox/.minikube/machines/functional-981737 ...
💀  Removed all traces of the "functional-981737" cluster.
🔥  Deleting "minikube" in kvm2 ...
💀  Removed all traces of the "minikube" cluster.
🔥  Successfully deleted all profiles
 $ time ./out/minikube start -d podman 
😄  minikube v1.37.0 on Fedora 43
✨  Using the podman driver based on user configuration
📌  Using Podman driver with root privileges
👍  Starting "minikube" primary control-plane node in "minikube" cluster
🚜  Pulling base image v0.0.48-1763507788-21924 ...
💾  Downloading Kubernetes v1.34.1 preload ...
    > preloaded-images-k8s-v18-v1...:  337.01 MiB / 337.01 MiB  100.00% 20.71 M
    > gcr.io/k8s-minikube/kicbase...:  496.38 MiB / 496.38 MiB  100.00% 6.45 Mi
E1120 11:24:14.124011   40829 cache.go:238] Error downloading kic artifacts:  not yet implemented, see issue #8426
🔥  Creating podman container (CPUs=2, Memory=7900MB) ...
🐳  Preparing Kubernetes v1.34.1 on Docker 29.0.2 ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default

real    2m25.750s
user    0m10.176s
sys     0m4.657s
$  echo $?
0
$ ./out/minikube  profile list
┌──────────┬────────┬─────────┬──────────────┬─────────┬────────┬───────┬────────────────┬────────────────────┐
│ PROFILE  │ DRIVER │ RUNTIME │      IP      │ VERSION │ STATUS │ NODES │ ACTIVE PROFILE │ ACTIVE KUBECONTEXT │
├──────────┼────────┼─────────┼──────────────┼─────────┼────────┼───────┼────────────────┼────────────────────┤
│ minikube │ podman │ docker  │ 192.168.49.2 │ v1.34.1 │ OK     │ 1     │ *              │ *                  │
└──────────┴────────┴─────────┴──────────────┴─────────┴────────┴───────┴────────────────┴────────────────────┘
$ kubectl get no
NAME       STATUS   ROLES           AGE   VERSION
minikube   Ready    control-plane   96s   v1.34.1
$ kubectl get ns
NAME              STATUS   AGE
default           Active   99s
kube-node-lease   Active   99s
kube-public       Active   99s
kube-system       Active   99s


```

so there is the error message but it seems to have succeeded.


## with the patch

```console
$ git fetch obnox 
From github.com:obnoxxx/minikube
 * [new branch]            podman-fix-image-load -> obnox/podman-fix-image-load
$ git checkout podman-fix-image-load 
branch 'podman-fix-image-load' set up to track 'obnox/podman-fix-image-load'.
Switched to a new branch 'podman-fix-image-load'
$ make clean && make
$ ./out/minikube  profile list
┌──────────┬────────┬─────────┬──────────────┬─────────┬────────┬───────┬────────────────┬────────────────────┐
│ PROFILE  │ DRIVER │ RUNTIME │      IP      │ VERSION │ STATUS │ NODES │ ACTIVE PROFILE │ ACTIVE KUBECONTEXT │
├──────────┼────────┼─────────┼──────────────┼─────────┼────────┼───────┼────────────────┼────────────────────┤
│ minikube │ podman │ docker  │ 192.168.49.2 │ v1.34.1 │ OK     │ 1     │ *              │ *                  │
└──────────┴────────┴─────────┴──────────────┴─────────┴────────┴───────┴────────────────┴────────────────────┘
$ ./out/minikube  delete --all
🔥  Deleting "minikube" in podman ...
🔥  Removing /home/obnox/.minikube/machines/minikube ...
💀  Removed all traces of the "minikube" cluster.
🔥  Successfully deleted all profiles
$ time ./out/minikube start -d podman 
😄  minikube v1.37.0 on Fedora 43
✨  Using the podman driver based on user configuration
📌  Using Podman driver with root privileges
👍  Starting "minikube" primary control-plane node in "minikube" cluster
🚜  Pulling base image v0.0.48-1761985721-21837 ...
🔥  Creating podman container (CPUs=2, Memory=7900MB) ...
🐳  Preparing Kubernetes v1.34.1 on Docker 28.5.1 ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default

real    0m35.878s
user    0m3.116s
sys     0m1.015s
$ echo $?
0
$ ./out/minikube  profile list
┌──────────┬────────┬─────────┬──────────────┬─────────┬────────┬───────┬────────────────┬────────────────────┐
│ PROFILE  │ DRIVER │ RUNTIME │      IP      │ VERSION │ STATUS │ NODES │ ACTIVE PROFILE │ ACTIVE KUBECONTEXT │
├──────────┼────────┼─────────┼──────────────┼─────────┼────────┼───────┼────────────────┼────────────────────┤
│ minikube │ podman │ docker  │ 192.168.49.2 │ v1.34.1 │ OK     │ 1     │ *              │ *                  │
└──────────┴────────┴─────────┴──────────────┴─────────┴────────┴───────┴────────────────┴────────────────────┘
$ kubectl get no
NAME       STATUS   ROLES           AGE    VERSION
minikube   Ready    control-plane   113s   v1.34.1
$ kubectl get ns
NAME              STATUS   AGE
default           Active   117s
kube-node-lease   Active   117s
kube-public       Active   117s
kube-system       Active   117s

```

So this is working fine.



