### PR TITLE
ci: fix upater get version

### DIFF
--- a/hack/update/get_version/get_version.go
+++ b/hack/update/get_version/get_version.go
@@ -135,7 +135,15 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to read file: %v", err)
 	}
-	submatches := re.FindSubmatch(data)
+
+  // this handles cases where multiple versions exist (e.g., old and new versions in go.mod)
+	allMatches := re.FindAllSubmatch(data, -1)
+	if len(allMatches) == 0 {
+		log.Fatalf("no matches found")
+	}
+
+	// Take the last match (most recent version)
+	submatches := allMatches[len(allMatches)-1]
 	if len(submatches) < 2 {
 		log.Fatalf("less than 2 submatches found")
 	}


### PR DESCRIPTION
Fixes #21970

The get_version.go tool was using FindSubmatch which returns only the
first match. When go.mod contains multiple versions of the same
dependency (e.g., v74 and v79 for go-github), it would always return
the first (older) version.

This caused automated update PRs to show incorrect titles like:
'CI: update go-github from v74.0.0 to v74.0.0'


