### PR TITLE
discuss: Fix CI build scripts to dynamically detect fork repository names

### DIFF
--- a/hack/jenkins/build_iso.sh
+++ b/hack/jenkins/build_iso.sh
@@ -88,7 +88,12 @@ git config user.email "minikube-bot@google.com"
 if [ "$release" = false ]; then
 	# Update the user's PR with newly build ISO
 
-	git remote add ${ghprbPullAuthorLogin} git@github.com:${ghprbPullAuthorLogin}/minikube.git
+	# Dynamically determine the fork repository name from the PR URL or git remote
+	FORK_REPO_NAME=$(gh pr view ${ghprbPullId} --json headRepository --jq '.headRepository.name' 2>/dev/null || echo "minikube")
+	
+	# Try SSH first, fallback to HTTPS if SSH fails
+	git remote add ${ghprbPullAuthorLogin} git@github.com:${ghprbPullAuthorLogin}/${FORK_REPO_NAME}.git || \
+	git remote add ${ghprbPullAuthorLogin} https://github.com/${ghprbPullAuthorLogin}/${FORK_REPO_NAME}.git
 	git fetch ${ghprbPullAuthorLogin}
 	git checkout -b ${ghprbPullAuthorLogin}-${ghprbSourceBranch} ${ghprbPullAuthorLogin}/${ghprbSourceBranch}
 

--- a/hack/jenkins/kicbase_auto_build.sh
+++ b/hack/jenkins/kicbase_auto_build.sh
@@ -106,7 +106,12 @@ git config user.email "minikube-bot@google.com"
 if [ "$release" = false ]; then
 	# Update the user's PR with the newly built kicbase image.
 
-	git remote add ${ghprbPullAuthorLogin} git@github.com:${ghprbPullAuthorLogin}/minikube.git
+	# Dynamically determine the fork repository name from the PR URL or git remote
+	FORK_REPO_NAME=$(gh pr view ${ghprbPullId} --json headRepository --jq '.headRepository.name' 2>/dev/null || echo "minikube")
+	
+	# Try SSH first, fallback to HTTPS if SSH fails
+	git remote add ${ghprbPullAuthorLogin} git@github.com:${ghprbPullAuthorLogin}/${FORK_REPO_NAME}.git || \
+	git remote add ${ghprbPullAuthorLogin} https://github.com/${ghprbPullAuthorLogin}/${FORK_REPO_NAME}.git
 	git fetch ${ghprbPullAuthorLogin}
 	git checkout -b ${ghprbPullAuthorLogin}-${ghprbSourceBranch} ${ghprbPullAuthorLogin}/${ghprbSourceBranch}
 


### PR DESCRIPTION
The build_iso.sh and kicbase_auto_build.sh scripts were hardcoding
repository names as "minikube", causing failures when contributors
have differently named forks. This change:

- Uses GitHub CLI to dynamically fetch the actual fork repository name
- Adds fallback to "minikube" for backward compatibility
- Includes SSH/HTTPS protocol fallback for better connectivity
- Resolves "Repository not found" errors in CI builds

Fixes  issues where PRs from forks like "minikube-fork" would fail
during the automated ISO and kicbase build processes.

Fixes #22018