### PR TITLE
test: normalize newline handling in kubeadm YAML

### DIFF
--- a/pkg/minikube/bootstrapper/bsutil/kubeadm_test.go
+++ b/pkg/minikube/bootstrapper/bsutil/kubeadm_test.go
@@ -124,8 +124,18 @@ func recentReleases(n int) ([]string, error) {
 
 // normalizeNewlines converts CRLF -> LF and enforces a single trailing newline.
 func normalizeNewlines(s string) string {
-	s = strings.ReplaceAll(s, "\r\n", "\n")
-	return strings.TrimRight(s, "\n") + "\n"
+	return strings.ReplaceAll(s, "\r\n", "\n")
+}
+
+func logNewlineDiagnostics(t *testing.T, label string, s string) {
+	b := []byte(s)
+	start := 0
+	if len(b) > 20 {
+		start = len(b) - 20
+	}
+	hasCRLF := strings.HasSuffix(s, "\r\n")
+	crlfCount := strings.Count(s, "\r\n")
+	t.Logf("%s: tail20=% x | hasCRLF=%t | crlfCount=%d", label, b[start:], hasCRLF, crlfCount)
 }
 
 /*
@@ -199,8 +209,13 @@ func TestGenerateKubeadmYAMLDNS(t *testing.T) {
 				if err != nil {
 					t.Fatalf("unable to read testdata: %v", err)
 				}
-				normalizedExpected := normalizeNewlines(string(expected))
-				normalizedGot := normalizeNewlines(string(got))
+				expectStr := string(expected)
+				gotStr := string(got)
+				logNewlineDiagnostics(t, "expected", expectStr)
+				logNewlineDiagnostics(t, "got", gotStr)
+
+				normalizedExpected := expectStr
+				normalizedGot := normalizeNewlines(gotStr)
 				diff, err := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
 					A:        difflib.SplitLines(normalizedExpected),
 					B:        difflib.SplitLines(normalizedGot),
@@ -305,8 +320,13 @@ func TestGenerateKubeadmYAML(t *testing.T) {
 				if err != nil {
 					t.Fatalf("unable to read testdata: %v", err)
 				}
-				normalizedExpected := normalizeNewlines(string(expected))
-				normalizedGot := normalizeNewlines(string(got))
+				expectStr := string(expected)
+				gotStr := string(got)
+				logNewlineDiagnostics(t, "expected", expectStr)
+				logNewlineDiagnostics(t, "got", gotStr)
+
+				normalizedExpected := expectStr
+				normalizedGot := normalizeNewlines(gotStr)
 				diff, err := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
 					A:        difflib.SplitLines(normalizedExpected),
 					B:        difflib.SplitLines(normalizedGot),


### PR DESCRIPTION
**Problem — Windows CI golden diffs failing**

The kubeadm unit tests are failing in the Windows-2022 GitHub Actions job because YAML golden-file assertions do raw string diffs, and the golden files are checked out with CRLF (`\r\n`) line endings while the generated YAML uses LF (`\n`).

**Diagnostics that exposed the root cause**

We verified this by dumping raw trailing bytes of both sides using the diagnostic helper:
```
func logNewlineDiagnostics(t *testing.T, label string, s string) {
    b := []byte(s)
    start := 0
    if len(b) > 20 {
        start = len(b) - 20
    }
    hasCRLF := strings.HasSuffix(s, "\r\n")
    crlfCount := strings.Count(s, "\r\n")
    t.Logf("%s: tail20=% x | hasCRLF=%t | crlfCount=%d", label, b[start:], hasCRLF, crlfCount)
}
```

This produced the following proof:

```
--- FAIL: TestGenerateKubeadmYAMLDNS (0.09s)
    --- FAIL: TestGenerateKubeadmYAMLDNS/dns_v1.35 (0.01s)
        kubeadm_test.go:138: expected: tail20=6f 73 65 57 61 69 74 54 69 6d 65 6f 75 74 3a 20 30 73 0d 0a | hasCRLF=true | crlfCount=78
        kubeadm_test.go:138: got: tail20=6c 6f 73 65 57 61 69 74 54 69 6d 65 6f 75 74 3a 20 30 73 0a | hasCRLF=false | crlfCount=0
        kubeadm_test.go:230: unexpected diff:
            --- Expected
            +++ Got
```

**Interpretation:**

- `0d 0a` at file tail → expected ends in CRLF.
- `0a `at file tail → got ends in LF.
- `CRLF count = 78` → every line in the golden file is CRLF.
- `Generated = LF only` → Go is producing correct YAML, just not CRLF.

So the YAML is correct — only the newlines differ.

Link to the [GitHub Action Runner with the failures](https://github.com/kubernetes/minikube/actions/runs/19862024538/job/56916404037)

**_There are 54 tests in total that we aim to fix with this change:_**

**kubeadm DNS tests (6)**
- TestGenerateKubeadmYAMLDNS/dns_v1.34
- TestGenerateKubeadmYAMLDNS/dns_v1.33
- TestGenerateKubeadmYAMLDNS/dns_v1.32
- TestGenerateKubeadmYAMLDNS/dns_v1.31
- TestGenerateKubeadmYAMLDNS/dns_v1.30
- TestGenerateKubeadmYAMLDNS/dns_v1.29

**kubeadm YAML tests (48)**
For v1.34
- TestGenerateKubeadmYAML/default_v1.34
- TestGenerateKubeadmYAML/containerd_v1.34
- TestGenerateKubeadmYAML/crio_v1.34
- TestGenerateKubeadmYAML/options_v1.34
- TestGenerateKubeadmYAML/crio-options-gates_v1.34
- TestGenerateKubeadmYAML/containerd-api-port_v1.34
- TestGenerateKubeadmYAML/containerd-pod-network-cidr_v1.34
- TestGenerateKubeadmYAML/image-repository_v1.34

For v1.33
- TestGenerateKubeadmYAML/default_v1.33
- TestGenerateKubeadmYAML/containerd_v1.33
- TestGenerateKubeadmYAML/crio_v1.33
- TestGenerateKubeadmYAML/options_v1.33
- TestGenerateKubeadmYAML/crio-options-gates_v1.33
- TestGenerateKubeadmYAML/containerd-api-port_v1.33
- TestGenerateKubeadmYAML/containerd-pod-network-cidr_v1.33
- TestGenerateKubeadmYAML/image-repository_v1.33

For v1.32
- TestGenerateKubeadmYAML/default_v1.32
- TestGenerateKubeadmYAML/containerd_v1.32
- TestGenerateKubeadmYAML/crio_v1.32
- TestGenerateKubeadmYAML/options_v1.32
- TestGenerateKubeadmYAML/crio-options-gates_v1.32
- TestGenerateKubeadmYAML/containerd-api-port_v1.32
- TestGenerateKubeadmYAML/containerd-pod-network-cidr_v1.32
- TestGenerateKubeadmYAML/image-repository_v1.32

For v1.31
- TestGenerateKubeadmYAML/default_v1.31
- TestGenerateKubeadmYAML/containerd_v1.31
- TestGenerateKubeadmYAML/crio_v1.31
- TestGenerateKubeadmYAML/options_v1.31
- TestGenerateKubeadmYAML/crio-options-gates_v1.31
- TestGenerateKubeadmYAML/containerd-api-port_v1.31
- TestGenerateKubeadmYAML/containerd-pod-network-cidr_v1.31
- TestGenerateKubeadmYAML/image-repository_v1.31

For v1.30
- TestGenerateKubeadmYAML/default_v1.30
- TestGenerateKubeadmYAML/containerd_v1.30
- TestGenerateKubeadmYAML/crio_v1.30
- TestGenerateKubeadmYAML/options_v1.30
- TestGenerateKubeadmYAML/crio-options-gates_v1.30
- TestGenerateKubeadmYAML/containerd-api-port_v1.30
- TestGenerateKubeadmYAML/containerd-pod-network-cidr_v1.30
- TestGenerateKubeadmYAML/image-repository_v1.30

For v1.29
- TestGenerateKubeadmYAML/default_v1.29
- TestGenerateKubeadmYAML/containerd_v1.29
- TestGenerateKubeadmYAML/crio_v1.29
- TestGenerateKubeadmYAML/options_v1.29
- TestGenerateKubeadmYAML/crio-options-gates_v1.29
- TestGenerateKubeadmYAML/containerd-api-port_v1.29
- TestGenerateKubeadmYAML/containerd-pod-network-cidr_v1.29
- TestGenerateKubeadmYAML/image-repository_v1.29