### PR TITLE
UI: remove  confusing message  related to podman

### DIFF
--- a/pkg/minikube/node/cache.go
+++ b/pkg/minikube/node/cache.go
@@ -170,7 +170,8 @@ func beginDownloadKicBaseImage(g *errgroup.Group, cc *config.ClusterConfig, down
 			}
 
 			if cc.Driver == driver.Podman {
-				return fmt.Errorf("not yet implemented, see issue #8426")
+				klog.Warningf("skipping image load from cache: not implemented for podman. see issue #8426")
+				return nil
 			}
 			if driver.IsDocker(cc.Driver) && err == nil {
 				klog.Infof("Loading %s from local cache", img)


### PR DESCRIPTION
Image loading from chache  is not implemented and  `minikube start -d podman`always issued a confusing and unhelpful error message. 

This change removes  the confusing and unhelpful message, replacing it with a log message. 

This is intended as a replacement for PR #21932  without pretending to implement the cache handling.

The outputs  of `minikube start -d podman` on current Fedora Linux 43 are provided with and without this patch illustrate the changed behavior:


# without the patch

```console

$ # on current master:
$ ./out/minikube delete --all
🔥  Deleting "minikube" in podman ...
🔥  Removing /home/obnox/.minikube/machines/minikube ...
💀  Removed all traces of the "minikube" cluster.
🔥  Successfully deleted all profiles


$ time ./out/minikube start -d podman 
😄  minikube v1.37.0 on Fedora 43
✨  Using the podman driver based on user configuration
📌  Using Podman driver with root privileges
👍  Starting "minikube" primary control-plane node in "minikube" cluster
🚜  Pulling base image v0.0.48-1764169655-21974 ...
E1203 11:02:21.355429   86335 cache.go:238] Error downloading kic artifacts:  not yet implemented, see issue #8426
🔥  Creating podman container (CPUs=2, Memory=7900MB) ...
🐳  Preparing Kubernetes v1.34.2 on Docker 29.0.4 ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default

real    0m29.764s
user    0m1.816s
sys     0m0.963s
$ echo $?
0
$


```
# with the patch

```console
$ # on obnoxxx/kicbase-simplify-image-load :
$ make clean && make
$ ./out/minikube  delete --all --purge
$ time ./out/minikube start -d podman 😄  minikube v1.37.0 on Fedora 43
✨  Using the podman driver based on user configuration
📌  Using Podman driver with root privileges
👍  Starting "minikube" primary control-plane node in "minikube" cluster
🚜  Pulling base image v0.0.48-1765275396-22083 ...
🔥  Creating podman container (CPUs=2, Memory=7900MB) ...
🐳  Preparing Kubernetes v1.34.2 on Docker 29.1.2 ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
🔎  Verifying Kubernetes components...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🌟  Enabled addons: storage-provisioner, default-storageclass
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default

real    0m30.899s
user    0m1.452s
sys     0m1.009s
$ echo $?
0
$ 
```
