### PR TITLE
docs: Fix spelling errors with codespell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Run AI workloads on Macbook's GPU in Kubernetes using the new `krunkit driver`. 
 * Don't call startKicServiceTunnel for non-kic drivers (#20863)
 * krunkit: Disable offloading for faster networking (#21341)
 
-## Deprication
+## Deprecation
 
 * Deprecate HyperKit driver with warning (#21024)
 
@@ -379,7 +379,7 @@ Improvements:
 * Improved error message when enabling KVM addons on non-KVM cluster [#19195](https://github.com/kubernetes/minikube/pull/19195)
 * Added warning when loading image with wrong arch [#19229](https://github.com/kubernetes/minikube/pull/19229)
 * `profile list --output json` handle empty config folder  [#16900](https://github.com/kubernetes/minikube/pull/16900)
-* Check connectivity outside minikube when connectivity issuse [#18859](https://github.com/kubernetes/minikube/pull/18859)
+* Check connectivity outside minikube when connectivity issues [#18859](https://github.com/kubernetes/minikube/pull/18859)
 
 Bugs:
 
@@ -813,7 +813,7 @@ Minor Improvements:
 * Hyper-V: Add memory validation for odd numbers [#17325](https://github.com/kubernetes/minikube/pull/17325)
 * QEMU: Improve cpu type and IP detection [#17217](https://github.com/kubernetes/minikube/pull/17217)
 * Mask http(s)_proxy password from startup output [#17116](https://github.com/kubernetes/minikube/pull/17116)
-* `--delete-on-faliure` also recreates cluster for kubeadm failures [#16890](https://github.com/kubernetes/minikube/pull/16890)
+* `--delete-on-failure` also recreates cluster for kubeadm failures [#16890](https://github.com/kubernetes/minikube/pull/16890)
 * Addon auto-pause: Configure intervals using `--auto-pause-interval` [#17070](https://github.com/kubernetes/minikube/pull/17070)
 * `--kubernetes-version` checks GitHub for version validation and improved error output for invalid versions [#16865](https://github.com/kubernetes/minikube/pull/16865)
 
@@ -1588,7 +1588,7 @@ Minor Improvements:
 * Limit number of audit entries [#14695](https://github.com/kubernetes/minikube/pull/14695)
 * Optimize audit logging [#14596](https://github.com/kubernetes/minikube/pull/14596)
 * Show the container runtime when running without kubernetes #13432  [#14200](https://github.com/kubernetes/minikube/pull/14200)
-* Add warning when enabling thrid-party addons [#14499](https://github.com/kubernetes/minikube/pull/14499)
+* Add warning when enabling third-party addons [#14499](https://github.com/kubernetes/minikube/pull/14499)
 
 Bug fixes:
 
@@ -3730,7 +3730,7 @@ Minor Improvements:
 * docker-env: restart dockerd inside minikube on failure [#8239](https://github.com/kubernetes/minikube/pull/8239)
 * wait for kubernetes components on soft start [#8199](https://github.com/kubernetes/minikube/pull/8199)
 * improve minikube status display for one node [#8238](https://github.com/kubernetes/minikube/pull/8238)
-* improve solution message for wrong kuberentes-version format [#8118](https://github.com/kubernetes/minikube/pull/8118)
+* improve solution message for wrong kubernetes-version format [#8118](https://github.com/kubernetes/minikube/pull/8118)
 
 Bug fixes:
 
@@ -4024,7 +4024,7 @@ New features & improvements
 
 Bug Fixes
 
-* Re-initalize failed Kubernetes clusters [#7234](https://github.com/kubernetes/minikube/pull/7234)
+* Re-initialize failed Kubernetes clusters [#7234](https://github.com/kubernetes/minikube/pull/7234)
 * do not override hostname if extraConfig is specified [#7238](https://github.com/kubernetes/minikube/pull/7238)
 * Enable HW_RANDOM_VIRTIO to fix sshd startup delays [#7208](https://github.com/kubernetes/minikube/pull/7208)
 * hyperv Delete: call StopHost before removing VM [#7160](https://github.com/kubernetes/minikube/pull/7160)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -335,7 +335,7 @@ Run AI workloads on Macbook's GPU in Kubernetes using the new `krunkit driver`. 
 * Don't call startKicServiceTunnel for non-kic drivers (#20863)
 * krunkit: Disable offloading for faster networking (#21341)
 
-## Deprication
+## Deprecation
 
 * Deprecate HyperKit driver with warning (#21024)
 
@@ -685,7 +685,7 @@ Improvements:
 * Improved error message when enabling KVM addons on non-KVM cluster [#19195](https://github.com/kubernetes/minikube/pull/19195)
 * Added warning when loading image with wrong arch [#19229](https://github.com/kubernetes/minikube/pull/19229)
 * `profile list --output json` handle empty config folder  [#16900](https://github.com/kubernetes/minikube/pull/16900)
-* Check connectivity outside minikube when connectivity issuse [#18859](https://github.com/kubernetes/minikube/pull/18859)
+* Check connectivity outside minikube when connectivity issues [#18859](https://github.com/kubernetes/minikube/pull/18859)
 
 Bugs:
 
@@ -1119,7 +1119,7 @@ Minor Improvements:
 * Hyper-V: Add memory validation for odd numbers [#17325](https://github.com/kubernetes/minikube/pull/17325)
 * QEMU: Improve cpu type and IP detection [#17217](https://github.com/kubernetes/minikube/pull/17217)
 * Mask http(s)_proxy password from startup output [#17116](https://github.com/kubernetes/minikube/pull/17116)
-* `--delete-on-faliure` also recreates cluster for kubeadm failures [#16890](https://github.com/kubernetes/minikube/pull/16890)
+* `--delete-on-failure` also recreates cluster for kubeadm failures [#16890](https://github.com/kubernetes/minikube/pull/16890)
 * Addon auto-pause: Configure intervals using `--auto-pause-interval` [#17070](https://github.com/kubernetes/minikube/pull/17070)
 * `--kubernetes-version` checks GitHub for version validation and improved error output for invalid versions [#16865](https://github.com/kubernetes/minikube/pull/16865)
 
@@ -1894,7 +1894,7 @@ Minor Improvements:
 * Limit number of audit entries [#14695](https://github.com/kubernetes/minikube/pull/14695)
 * Optimize audit logging [#14596](https://github.com/kubernetes/minikube/pull/14596)
 * Show the container runtime when running without kubernetes #13432  [#14200](https://github.com/kubernetes/minikube/pull/14200)
-* Add warning when enabling thrid-party addons [#14499](https://github.com/kubernetes/minikube/pull/14499)
+* Add warning when enabling third-party addons [#14499](https://github.com/kubernetes/minikube/pull/14499)
 
 Bug fixes:
 
@@ -4036,7 +4036,7 @@ Minor Improvements:
 * docker-env: restart dockerd inside minikube on failure [#8239](https://github.com/kubernetes/minikube/pull/8239)
 * wait for kubernetes components on soft start [#8199](https://github.com/kubernetes/minikube/pull/8199)
 * improve minikube status display for one node [#8238](https://github.com/kubernetes/minikube/pull/8238)
-* improve solution message for wrong kuberentes-version format [#8118](https://github.com/kubernetes/minikube/pull/8118)
+* improve solution message for wrong kubernetes-version format [#8118](https://github.com/kubernetes/minikube/pull/8118)
 
 Bug fixes:
 
@@ -4330,7 +4330,7 @@ New features & improvements
 
 Bug Fixes
 
-* Re-initalize failed Kubernetes clusters [#7234](https://github.com/kubernetes/minikube/pull/7234)
+* Re-initialize failed Kubernetes clusters [#7234](https://github.com/kubernetes/minikube/pull/7234)
 * do not override hostname if extraConfig is specified [#7238](https://github.com/kubernetes/minikube/pull/7238)
 * Enable HW_RANDOM_VIRTIO to fix sshd startup delays [#7208](https://github.com/kubernetes/minikube/pull/7208)
 * hyperv Delete: call StopHost before removing VM [#7160](https://github.com/kubernetes/minikube/pull/7160)

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ MARKDOWNLINT ?= markdownlint
 MINIKUBE_MARKDOWN_FILES := README.md CONTRIBUTING.md CHANGELOG.md
 
 # The `libvirt_dlopen` build tag is used only linux to avoid linking with
-# libvirt shared library. This is not documnted but can be found in the source.
+# libvirt shared library. This is not documented but can be found in the source.
 # https://gitlab.com/libvirt/libvirt-go-module/-/blob/f7cdeba9979dd248582901d2aaf7ab1f2d27cbe0/domain.go#L30
 MINIKUBE_BUILD_TAGS := libvirt_dlopen
 
@@ -1067,7 +1067,7 @@ update-portainer-version:
 
 # used by update- Targets to get before/after versions of tools it updates
 # example usage echo "OLD_VERSION=$(DEP=node make get-dependency-version)" >> "$GITHUB_OUTPUT"
-.PHONY: get-dependency-verison
+.PHONY: get-dependency-version
 get-dependency-version:
 	@(cd hack && go run update/get_version/get_version.go)
 

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ MARKDOWNLINT ?= markdownlint
 MINIKUBE_MARKDOWN_FILES := README.md CONTRIBUTING.md CHANGELOG.md
 
 # The `libvirt_dlopen` build tag is used only linux to avoid linking with
-# libvirt shared library. This is not documnted but can be found in the source.
+# libvirt shared library. This is not documented but can be found in the source.
 # https://gitlab.com/libvirt/libvirt-go-module/-/blob/f7cdeba9979dd248582901d2aaf7ab1f2d27cbe0/domain.go#L30
 MINIKUBE_BUILD_TAGS := libvirt_dlopen
 
@@ -1092,7 +1092,7 @@ update-portainer-version:
 
 # used by update- Targets to get before/after versions of tools it updates
 # example usage echo "OLD_VERSION=$(DEP=node make get-dependency-version)" >> "$GITHUB_OUTPUT"
-.PHONY: get-dependency-verison
+.PHONY: get-dependency-version
 get-dependency-version:
 	@(cd hack && go run update/get_version/get_version.go)
 

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,11 @@ MINIKUBE_TEST_FILES := ./cmd/... ./pkg/...
 # npm install -g markdownlint-cli
 MARKDOWNLINT ?= markdownlint
 
+# pip install codespell
+CODESPELL ?= codespell
+# brew install typos-cli
+TYPOS ?= typos
+
 
 MINIKUBE_MARKDOWN_FILES := README.md CONTRIBUTING.md CHANGELOG.md
 
@@ -483,6 +488,16 @@ golint: ## Run golint
 .PHONY: gocyclo
 gocyclo: ## Run gocyclo (calculates cyclomatic complexities)
 	@gocyclo -over 15 `find $(SOURCE_DIRS) -type f -name "*.go"`
+
+.PHONY: spellcheck
+spellcheck: ## Check for spelling errors
+	@codespell_exit=0; \
+	$(CODESPELL) --skip '*.yaml,*.tmpl,*.json,*.html,*.patch,go.sum,./third_party' || codespell_exit=$$?; \
+	typos_exit=0; \
+	$(TYPOS) --exclude '*.yaml' --exclude '*.tmpl' --exclude '*.json' --exclude '*.html' --exclude '*.patch' --exclude 'go.sum' --exclude 'third_party/**' || typos_exit=$$?; \
+	if [ "$$codespell_exit" -ne 0 ] || [ "$$typos_exit" -ne 0 ]; then \
+		exit 1; \
+	fi
 
 out/linters/golangci-lint-$(GOLINT_VERSION):
 	mkdir -p out/linters

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -80,7 +80,7 @@ var RootCmd = &cobra.Command{
 			klog.Warningf("failed to log command start to audit: %v", err)
 		}
 		// viper maps $MINIKUBE_ROOTLESS to "rootless" property automatically, but it does not do vice versa,
-		// so we map "rootless" property to $MINIKUBE_ROOTLESS expliclity here.
+		// so we map "rootless" property to $MINIKUBE_ROOTLESS explicitly here.
 		// $MINIKUBE_ROOTLESS is referred by KIC runner, which is decoupled from viper.
 		if viper.GetBool(config.Rootless) {
 			os.Setenv(constants.MinikubeRootlessEnv, "true")

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -81,7 +81,7 @@ var RootCmd = &cobra.Command{
 			klog.Warningf("failed to log command start to audit: %v", err)
 		}
 		// viper maps $MINIKUBE_ROOTLESS to "rootless" property automatically, but it does not do vice versa,
-		// so we map "rootless" property to $MINIKUBE_ROOTLESS expliclity here.
+		// so we map "rootless" property to $MINIKUBE_ROOTLESS explicitly here.
 		// $MINIKUBE_ROOTLESS is referred by KIC runner, which is decoupled from viper.
 		if viper.GetBool(config.Rootless) {
 			os.Setenv(constants.MinikubeRootlessEnv, "true")

--- a/cmd/minikube/cmd/update-context.go
+++ b/cmd/minikube/cmd/update-context.go
@@ -37,7 +37,7 @@ var updateContextCmd = &cobra.Command{
 		options := flags.CommandOptions()
 		cname := ClusterFlagValue()
 		co := mustload.Running(cname, options)
-		//	cluster extension metada for kubeconfig
+		//	cluster extension metadata for kubeconfig
 
 		updated, err := kubeconfig.UpdateEndpoint(cname, co.CP.Hostname, co.CP.Port, kubeconfig.PathFromEnv(), kubeconfig.NewExtension())
 		if err != nil {

--- a/deploy/addons/registry-aliases/README.md
+++ b/deploy/addons/registry-aliases/README.md
@@ -1,6 +1,6 @@
 # Minikube Registry Aliases Addon
 
-An addon to minikube that can help push and pull from the minikube registry using custom domain names. The custom domain names will be made resolveable from with in cluster and at minikube node.
+An addon to minikube that can help push and pull from the minikube registry using custom domain names. The custom domain names will be made resolveble from with in cluster and at minikube node.
 
 ## How to use ?
 

--- a/deploy/kicbase/entrypoint
+++ b/deploy/kicbase/entrypoint
@@ -60,7 +60,7 @@ validate_userns() {
   fi
 }
 
-overlayfs_preferrable() {
+overlayfs_preferable() {
   if [[ -z "$userns" ]]; then
     # If we are outside userns, we can always assume overlayfs is preferable
     return 0
@@ -108,7 +108,7 @@ configure_containerd() {
     # enable restrict_oom_score_adj
     sed -i 's/restrict_oom_score_adj = false/restrict_oom_score_adj = true/' /etc/containerd/config.toml
     # Use fuse-overlayfs if overlayfs is not preferable: https://github.com/kubernetes-sigs/kind/issues/2275
-    if [[ -z "$snapshotter" ]] && ! overlayfs_preferrable; then
+    if [[ -z "$snapshotter" ]] && ! overlayfs_preferable; then
       snapshotter="fuse-overlayfs"
     fi
   fi

--- a/hack/benchmark/image-build/generate-chart.go
+++ b/hack/benchmark/image-build/generate-chart.go
@@ -79,14 +79,14 @@ var RuntimeMethods = map[string][]string{
 }
 
 const (
-	INTERATIVE    = "Iterative"
-	NONINTERATIVE = "NonIterative"
+	ITERATIVE    = "Iterative"
+	NONITERATIVE = "NonIterative"
 )
 
 var Itrs = []string{
-	INTERATIVE,
-	// to simplify the output, non-interative is omitted
-	// NONINTERATIVE,
+	ITERATIVE,
+	// to simplify the output, non-iterative is omitted
+	// NONITERATIVE,
 }
 
 // method name-> test result
@@ -134,8 +134,8 @@ func readInLatestTestResult(latestBenchmarkPath string) ItrTestResults {
 	var res = ItrTestResults{
 		Results: make(map[string]ImageTestResults),
 	}
-	res.Results[INTERATIVE] = make(ImageTestResults)
-	res.Results[NONINTERATIVE] = make(ImageTestResults)
+	res.Results[ITERATIVE] = make(ImageTestResults)
+	res.Results[NONITERATIVE] = make(ImageTestResults)
 
 	f, err := os.Open(latestBenchmarkPath)
 	if err != nil {
@@ -157,43 +157,43 @@ func readInLatestTestResult(latestBenchmarkPath string) ItrTestResults {
 			continue
 		}
 
-		valuesInterative := []float64{}
-		valuesNonInterative := []float64{}
-		// interative test results of each env are stored in the following columns
-		indicesInterative := []int{1, 5, 9, 13, 17, 21, 25, 29, 33, 37, 41, 45, 49, 53}
-		// non-interative test results of each env are stored in the following columns
-		indicesNonInterative := []int{3, 7, 11, 15, 19, 23, 27, 31, 35, 39, 43, 47, 51, 55}
+		valuesIterative := []float64{}
+		valuesNonIterative := []float64{}
+		// iterative test results of each env are stored in the following columns
+		indicesIterative := []int{1, 5, 9, 13, 17, 21, 25, 29, 33, 37, 41, 45, 49, 53}
+		// non-iterative test results of each env are stored in the following columns
+		indicesNonIterative := []int{3, 7, 11, 15, 19, 23, 27, 31, 35, 39, 43, 47, 51, 55}
 
-		for _, i := range indicesInterative {
+		for _, i := range indicesIterative {
 			if line[i] == "NaN" {
 				// we use -1 as invalid value
-				valuesInterative = append(valuesInterative, -1)
+				valuesIterative = append(valuesIterative, -1)
 				continue
 			}
 			v, err := strconv.ParseFloat(line[i], 64)
 			if err != nil {
 				log.Fatal(err)
 			}
-			valuesInterative = append(valuesInterative, v)
+			valuesIterative = append(valuesIterative, v)
 		}
 
-		for _, i := range indicesNonInterative {
+		for _, i := range indicesNonIterative {
 			if line[i] == "NaN" {
 				// we use -1 as invalid value
-				valuesNonInterative = append(valuesNonInterative, -1)
+				valuesNonIterative = append(valuesNonIterative, -1)
 				continue
 			}
 			v, err := strconv.ParseFloat(line[i], 64)
 			if err != nil {
 				log.Fatal(err)
 			}
-			valuesNonInterative = append(valuesNonInterative, v)
+			valuesNonIterative = append(valuesNonIterative, v)
 		}
 
 		imageName := line[0]
 
-		res.Results[INTERATIVE][imageName] = NewTestResult(valuesInterative)
-		res.Results[NONINTERATIVE][imageName] = NewTestResult(valuesNonInterative)
+		res.Results[ITERATIVE][imageName] = NewTestResult(valuesIterative)
+		res.Results[NONITERATIVE][imageName] = NewTestResult(valuesNonIterative)
 
 	}
 

--- a/hack/benchmark/time-to-k8s/page.go
+++ b/hack/benchmark/time-to-k8s/page.go
@@ -70,7 +70,7 @@ func main() {
 	apps := make(map[string]runs)
 
 	if err := readInCSV(*csvPath, apps); err != nil {
-		log.Fatalf("fail to readin cvs file with err %s", err)
+		log.Fatalf("fail to read in cvs file with err %s", err)
 	}
 
 	runningTime, cpuMdPlot, cpuChartPlot, totals, names := values(apps)

--- a/hack/jenkins/build_iso.sh
+++ b/hack/jenkins/build_iso.sh
@@ -42,7 +42,7 @@ sudo apt-get -y install build-essential unzip rsync bc python3 p7zip-full cmake
 CMAKE_VERSION=$(cmake --version | head -n1 | awk '{print $3}')
 echo "Start of ISO build: CMake version: $CMAKE_VERSION"
 if dpkg --compare-versions "$CMAKE_VERSION" lt "3.20"; then
-	echo "WARNING: CMake version $CMAKE_VERSION is less than 3.20. this will cause a slower build due to rebuidling cmake ..."
+	echo "WARNING: CMake version $CMAKE_VERSION is less than 3.20. this will cause a slower build due to rebuilding cmake ..."
 fi
 
 # Let's make sure we have the newest ISO reference

--- a/hack/jenkins/build_iso.sh
+++ b/hack/jenkins/build_iso.sh
@@ -66,7 +66,7 @@ sudo apt-get -y install build-essential unzip rsync bc python3 p7zip-full cmake
 CMAKE_VERSION=$(cmake --version | head -n1 | awk '{print $3}')
 echo "Start of ISO build: CMake version: $CMAKE_VERSION"
 if dpkg --compare-versions "$CMAKE_VERSION" lt "3.20"; then
-	echo "WARNING: CMake version $CMAKE_VERSION is less than 3.20. this will cause a slower build due to rebuidling cmake ..."
+	echo "WARNING: CMake version $CMAKE_VERSION is less than 3.20. this will cause a slower build due to rebuilding cmake ..."
 fi
 
 # Let's make sure we have the newest ISO reference

--- a/hack/prow/minitest/deployer/boskos_deployer.go
+++ b/hack/prow/minitest/deployer/boskos_deployer.go
@@ -53,7 +53,7 @@ type MiniTestBosKosDeployer struct {
 	sshAddr          string
 
 	boskosClient *client.Client
-	// this channel serves as a signal channel for the hearbeat goroutine
+	// this channel serves as a signal channel for the heartbeat goroutine
 	// so that it can be explicitly closed
 	boskosHeartbeatClose chan struct{}
 }
@@ -104,7 +104,7 @@ func (m *MiniTestBosKosDeployer) Up() error {
 		return err
 	}
 	if err := sshConnectionCheck(m.ctx, m.remoteUserName, m.sshAddr, nil); err != nil {
-		klog.Errorf("Failed to conntect via ssh: %v", err)
+		klog.Errorf("Failed to connect via ssh: %v", err)
 		return err
 	}
 

--- a/hack/prow/minitest/deployer/docker_deployer.go
+++ b/hack/prow/minitest/deployer/docker_deployer.go
@@ -164,8 +164,8 @@ func (m *MiniTestDockerDeployer) Up() error {
 
 	// check ssh connectivity
 	if err := sshConnectionCheck(m.ctx, m.remoteUserName, "localhost", m.sshAdditionalArgs()); err != nil {
-		klog.Errorf("Failed to conntect via ssh: %v", err)
-		return fmt.Errorf("Failed to conntect via ssh: %v", err)
+		klog.Errorf("Failed to connect via ssh: %v", err)
+		return fmt.Errorf("Failed to connect via ssh: %v", err)
 	}
 
 	m.isUp = true

--- a/pkg/drivers/common/common.go
+++ b/pkg/drivers/common/common.go
@@ -287,7 +287,7 @@ func parseDHCPdLeasesFile(file io.Reader) ([]DHCPEntry, error) {
 }
 
 // parseMAC parse both standard fixed size MAC address "%02x:..." and the
-// variable size MAC address on drawin "%x:...".
+// variable size MAC address on Darwin "%x:...".
 func parseMAC(mac string) (net.HardwareAddr, error) {
 	hw := make(net.HardwareAddr, 6)
 	n, err := fmt.Sscanf(mac, "%x:%x:%x:%x:%x:%x",

--- a/pkg/drivers/common/common.go
+++ b/pkg/drivers/common/common.go
@@ -17,10 +17,14 @@ limitations under the License.
 package common
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"k8s.io/minikube/pkg/libmachine/drivers"
@@ -183,4 +187,113 @@ func fixMachinePermissions(path string) error {
 		}
 	}
 	return nil
+}
+
+// DHCPEntry holds a parsed DNS entry
+type DHCPEntry struct {
+	Name      string
+	IPAddress string
+	HWAddress net.HardwareAddr
+	ID        string
+	Lease     string
+}
+
+// GetIPAddressByMACAddress gets the IP address of a MAC address
+func GetIPAddressByMACAddress(mac string) (string, error) {
+	return getIPAddressFromFile(mac, LeasesPath)
+}
+
+func getIPAddressFromFile(mac, path string) (string, error) {
+	// Due to https://openradar.appspot.com/FB15382970 we need to parse the MAC
+	// address and compare the bytes.
+	macAddress, err := parseMAC(mac)
+	if err != nil {
+		return "", err
+	}
+
+	log.Debugf("Searching for %s in %s ...", mac, path)
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	dhcpEntries, err := parseDHCPdLeasesFile(file)
+	if err != nil {
+		return "", err
+	}
+	log.Debugf("Found %d entries in %s!", len(dhcpEntries), path)
+	for _, dhcpEntry := range dhcpEntries {
+		log.Debugf("dhcp entry: %+v", dhcpEntry)
+		if dhcpEntry.HWAddress == nil {
+			continue
+		}
+		if bytes.Equal(dhcpEntry.HWAddress, macAddress) {
+			log.Debugf("Found match: %s", mac)
+			return dhcpEntry.IPAddress, nil
+		}
+	}
+	return "", fmt.Errorf("could not find an IP address for %s", mac)
+}
+
+func parseDHCPdLeasesFile(file io.Reader) ([]DHCPEntry, error) {
+	var (
+		dhcpEntry   *DHCPEntry
+		dhcpEntries []DHCPEntry
+	)
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "{" {
+			dhcpEntry = new(DHCPEntry)
+			continue
+		} else if line == "}" {
+			dhcpEntries = append(dhcpEntries, *dhcpEntry)
+			continue
+		}
+
+		split := strings.SplitN(line, "=", 2)
+		if len(split) != 2 {
+			return nil, fmt.Errorf("invalid line in dhcp leases file: %s", line)
+		}
+		key, val := split[0], split[1]
+		switch key {
+		case "name":
+			dhcpEntry.Name = val
+		case "ip_address":
+			dhcpEntry.IPAddress = val
+		case "hw_address":
+			// The mac addresses have a '1,' at the start.
+			macAddress, err := parseMAC(val[2:])
+			if err != nil {
+				log.Warnf("unable to parse hw_address in dhcp leases file: %q: %s",
+					val[2:], err)
+				continue
+			}
+			dhcpEntry.HWAddress = macAddress
+		case "identifier":
+			dhcpEntry.ID = val
+		case "lease":
+			dhcpEntry.Lease = val
+		default:
+			return dhcpEntries, fmt.Errorf("unable to parse line: %s", line)
+		}
+	}
+	return dhcpEntries, scanner.Err()
+}
+
+// parseMAC parse both standard fixed size MAC address "%02x:..." and the
+// variable size MAC address on drawin "%x:...".
+func parseMAC(mac string) (net.HardwareAddr, error) {
+	hw := make(net.HardwareAddr, 6)
+	n, err := fmt.Sscanf(mac, "%x:%x:%x:%x:%x:%x",
+		&hw[0], &hw[1], &hw[2], &hw[3], &hw[4], &hw[5])
+	if n != len(hw) {
+		return nil, fmt.Errorf("invalid MAC address: %q", mac)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse MAC address: %q: %s", mac, err)
+	}
+	return hw, nil
 }

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -172,7 +172,7 @@ func CreateContainerNode(p CreateParams) error { //nolint to suppress cyclomatic
 		"--security-opt", "seccomp=unconfined", //  ignore seccomp
 		"--tmpfs", "/tmp", // various things depend on working /tmp
 		"--tmpfs", "/run", // systemd wants a writable /run
-		// logs,pods be stroed on  filesystem vs inside container,
+		// logs,pods be stored on  filesystem vs inside container,
 		// some k8s things want /lib/modules
 		"-v", fmt.Sprintf("%s:/lib/modules:ro", kernelModulesPath()),
 		"--hostname", p.Name, // make hostname match container name

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -171,7 +171,7 @@ func CreateContainerNode(p CreateParams) error { //nolint to suppress cyclomatic
 		"--security-opt", "seccomp=unconfined", //  ignore seccomp
 		"--tmpfs", "/tmp", // various things depend on working /tmp
 		"--tmpfs", "/run", // systemd wants a writable /run
-		// logs,pods be stroed on  filesystem vs inside container,
+		// logs,pods be stored on  filesystem vs inside container,
 		// some k8s things want /lib/modules
 		"-v", fmt.Sprintf("%s:/lib/modules:ro", kernelModulesPath()),
 		"--hostname", p.Name, // make hostname match container name

--- a/pkg/drivers/krunkit/krunkit.go
+++ b/pkg/drivers/krunkit/krunkit.go
@@ -409,7 +409,7 @@ func (d *Driver) stopKrunkit() error {
 			// No pidfile.
 			return nil
 		}
-		log.Debugf("Terminte krunkit (pid=%d)", pid)
+		log.Debugf("Terminate krunkit (pid=%d)", pid)
 		if err := process.Terminate(pid, driverName); err != nil {
 			if err != os.ErrProcessDone {
 				return err

--- a/pkg/drivers/krunkit/krunkit.go
+++ b/pkg/drivers/krunkit/krunkit.go
@@ -389,7 +389,7 @@ func (d *Driver) stopKrunkit() error {
 			// No pidfile.
 			return nil
 		}
-		log.Debugf("Terminte krunkit (pid=%d)", pid)
+		log.Debugf("Terminate krunkit (pid=%d)", pid)
 		if err := process.Terminate(pid, driverName); err != nil {
 			if err != os.ErrProcessDone {
 				return err

--- a/pkg/drivers/parallels/parallels_darwin.go
+++ b/pkg/drivers/parallels/parallels_darwin.go
@@ -518,7 +518,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		},
 		mcnflag.BoolFlag{
 			Name:  "parallels-nested-virtualization",
-			Usage: "Enable nested virutalization",
+			Usage: "Enable nested virtualization",
 		},
 	}
 }

--- a/pkg/drivers/virtualbox/network_test.go
+++ b/pkg/drivers/virtualbox/network_test.go
@@ -161,7 +161,7 @@ func TestGetHostOnlyNetworkNotFound(t *testing.T) {
 }
 
 // Tests a special case where Virtualbox creates the host only network
-// successfully but mis-reports the netmask.
+// successfully but miss-reports the netmask.
 func TestGetHostOnlyNetworkWindows10Bug(t *testing.T) {
 	cidr := "192.168.99.0/24"
 	ip, ipnet, err := net.ParseCIDR(cidr)

--- a/pkg/minikube/assets/addons_test.go
+++ b/pkg/minikube/assets/addons_test.go
@@ -122,7 +122,7 @@ func TestFilterKeySpace(t *testing.T) {
 	}
 }
 
-func TestOverrideDefautls(t *testing.T) {
+func TestOverrideDefaults(t *testing.T) {
 	type TestCase struct {
 		defaultMap  map[string]string
 		overrideMap map[string]string

--- a/pkg/minikube/assets/vm_assets.go
+++ b/pkg/minikube/assets/vm_assets.go
@@ -247,7 +247,7 @@ func (f *FileAsset) Seek(offset int64, whence int) (int64, error) {
 	return f.reader.Seek(offset, whence)
 }
 
-// Close closes the opend file.
+// Close closes the opened file.
 func (f *FileAsset) Close() error {
 	if f.file == nil {
 		return nil

--- a/pkg/minikube/bootstrapper/certs.go
+++ b/pkg/minikube/bootstrapper/certs.go
@@ -111,7 +111,7 @@ func SetupCerts(k8s config.ClusterConfig, n config.Node, pcpCmd command.Runner, 
 	}
 
 	for src, dst := range caCerts {
-		// note: these are all public certs, so should be world-readeable
+		// note: these are all public certs, so should be world-readable
 		// note: src is user os' path, dst is kic/iso (linux) path
 		certFile, err := assets.NewFileAsset(src, path.Dir(dst), path.Base(dst), "0644")
 		if err != nil {

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -715,7 +715,7 @@ func (k *Bootstrapper) restartPrimaryControlPlane(cfg config.ClusterConfig) erro
 		return err
 	}
 	if err = retry.Expo(addonPhase, 100*time.Microsecond, 30*time.Second); err != nil {
-		klog.Warningf("addon install failed, wil retry: %v", err)
+		klog.Warningf("addon install failed, will retry: %v", err)
 		return fmt.Errorf("addons: %w", err)
 	}
 

--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -711,7 +711,7 @@ func (k *Bootstrapper) restartPrimaryControlPlane(cfg config.ClusterConfig) erro
 		return err
 	}
 	if err = retry.Expo(addonPhase, 100*time.Microsecond, 30*time.Second); err != nil {
-		klog.Warningf("addon install failed, wil retry: %v", err)
+		klog.Warningf("addon install failed, will retry: %v", err)
 		return fmt.Errorf("addons: %w", err)
 	}
 

--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -436,7 +436,7 @@ func (r *CRIO) Preload(cc config.ClusterConfig) error {
 	// Double check if there are any images in the runtime to avoid data loss on restart
 	// The crio preload tarball is a filesystem dump that overwrites /var
 	// we backup and restore any existing images
-	// simmilar to  docker runtime implemented in pkg/minikube/cruntime/docker.go.
+	// similar to  docker runtime implemented in pkg/minikube/cruntime/docker.go.
 	// It uses a special helper (pkg/minikube/docker/store.go) to explicitly save and merge the repositories.json file (Docker's image index)
 	// before and after the tarball extraction.
 	allImages, err := r.ListImages(ListImagesOptions{})

--- a/pkg/minikube/download/gh/gh.go
+++ b/pkg/minikube/download/gh/gh.go
@@ -29,7 +29,7 @@ import (
 )
 
 // ReleaseAssets retrieves a GitHub release by tag from org/project.
-// Try to not call this too often. preferably cache and re-use. to avoid rate limits.
+// Try to not call this too often. preferably cache and reuse. to avoid rate limits.
 func ReleaseAssets(org, project, tag string) ([]*github.ReleaseAsset, error) {
 	ctx := context.Background()
 	// Use an authenticated client when GITHUB_TOKEN is set to avoid low rate limits.

--- a/pkg/minikube/mustload/mustload.go
+++ b/pkg/minikube/mustload/mustload.go
@@ -53,7 +53,7 @@ type ControlPlane struct {
 	Node *config.Node
 	// Runner provides command execution
 	Runner command.Runner
-	// Hostname is the host-accesible target for the apiserver
+	// Hostname is the host-accessible target for the apiserver
 	Hostname string
 	// Port is the host-accessible port for the apiserver
 	Port int

--- a/pkg/minikube/out/out_style_test.go
+++ b/pkg/minikube/out/out_style_test.go
@@ -92,7 +92,7 @@ func TestApplyStyle(t *testing.T) {
 	}
 }
 
-func TestApplyTemplateFormating(t *testing.T) {
+func TestApplyTemplateFormatting(t *testing.T) {
 	tests := []struct {
 		expected    string
 		description string

--- a/pkg/minikube/registry/drvs/kvm2/kvm2.go
+++ b/pkg/minikube/registry/drvs/kvm2/kvm2.go
@@ -47,7 +47,7 @@ const (
 
 // The driver is implemented for amd64 and arm64, but we cannot build the arm64
 // version yet: https://github.com/kubernetes/minikube/issues/19959.
-var supportedArchictures = []string{"amd64"}
+var supportedArchitectures = []string{"amd64"}
 
 func init() {
 	if err := registry.Register(registry.DriverDef{
@@ -105,10 +105,10 @@ func defaultURI() string {
 }
 
 func status(_ *run.CommandOptions) registry.State {
-	if !slices.Contains(supportedArchictures, runtime.GOARCH) {
+	if !slices.Contains(supportedArchitectures, runtime.GOARCH) {
 		rs := registry.State{
 			Error: fmt.Errorf("KVM is not supported on %q, contributions are welcome", runtime.GOARCH),
-			Fix:   fmt.Sprintf("you can use the KVM driver on %s", strings.Join(supportedArchictures, ",")),
+			Fix:   fmt.Sprintf("you can use the KVM driver on %s", strings.Join(supportedArchitectures, ",")),
 		}
 		// The driver is implemented but we cannot build it yet.
 		if runtime.GOARCH == "arm64" {

--- a/pkg/minikube/registry/drvs/kvm2/kvm2.go
+++ b/pkg/minikube/registry/drvs/kvm2/kvm2.go
@@ -50,7 +50,7 @@ const (
 
 // The driver is implemented for amd64 and arm64, but we cannot build the arm64
 // version yet: https://github.com/kubernetes/minikube/issues/19959.
-var supportedArchictures = []string{"amd64"}
+var supportedArchitectures = []string{"amd64"}
 
 func init() {
 	if err := registry.Register(registry.DriverDef{
@@ -114,10 +114,10 @@ func defaultURI() string {
 }
 
 func status(_ *run.CommandOptions) registry.State {
-	if !slices.Contains(supportedArchictures, runtime.GOARCH) {
+	if !slices.Contains(supportedArchitectures, runtime.GOARCH) {
 		rs := registry.State{
 			Error: fmt.Errorf("KVM is not supported on %q, contributions are welcome", runtime.GOARCH),
-			Fix:   fmt.Sprintf("you can use the KVM driver on %s", strings.Join(supportedArchictures, ",")),
+			Fix:   fmt.Sprintf("you can use the KVM driver on %s", strings.Join(supportedArchitectures, ",")),
 		}
 		// The driver is implemented but we cannot build it yet.
 		if runtime.GOARCH == "arm64" {

--- a/pkg/minikube/service/service_test.go
+++ b/pkg/minikube/service/service_test.go
@@ -1096,7 +1096,7 @@ func TestWaitAndMaybeOpenService(t *testing.T) {
 	}
 }
 
-func TestWaitAndMaybeOpenServiceForNotDefaultNamspace(t *testing.T) {
+func TestWaitAndMaybeOpenServiceForNotDefaultNamespace(t *testing.T) {
 	initializeMockObjects()
 
 	defaultAPI := &tests.MockAPI{

--- a/pkg/minikube/service/service_test.go
+++ b/pkg/minikube/service/service_test.go
@@ -1092,7 +1092,7 @@ func TestWaitAndMaybeOpenService(t *testing.T) {
 	}
 }
 
-func TestWaitAndMaybeOpenServiceForNotDefaultNamspace(t *testing.T) {
+func TestWaitAndMaybeOpenServiceForNotDefaultNamespace(t *testing.T) {
 	initializeMockObjects()
 
 	defaultAPI := &tests.MockAPI{

--- a/pkg/minikube/shell/shell_test.go
+++ b/pkg/minikube/shell/shell_test.go
@@ -149,6 +149,6 @@ func TestSetScript(t *testing.T) {
 		t.Fatalf("Unexpected error: '%v' during Setting script", err)
 	}
 	if w.String() != "foo" {
-		t.Fatalf("Expected foo writed by SetScript, but got '%v'", w.String())
+		t.Fatalf("Expected foo written by SetScript, but got '%v'", w.String())
 	}
 }

--- a/pkg/minikube/shell/shell_test.go
+++ b/pkg/minikube/shell/shell_test.go
@@ -146,6 +146,6 @@ func TestSetScript(t *testing.T) {
 		t.Fatalf("Unexpected error: '%v' during Setting script", err)
 	}
 	if w.String() != "foo" {
-		t.Fatalf("Expected foo writed by SetScript, but got '%v'", w.String())
+		t.Fatalf("Expected foo written by SetScript, but got '%v'", w.String())
 	}
 }

--- a/pkg/minikube/sysinit/systemd.go
+++ b/pkg/minikube/sysinit/systemd.go
@@ -116,7 +116,7 @@ func (s *Systemd) Restart(svc string) error {
 }
 
 // run systemctl reset-failed for a service
-// some services declare a realitive small restart-limit in their .service configuration
+// some services declare a relative small restart-limit in their .service configuration
 // so we reset reset-failed counter to override the limit
 func (s *Systemd) ResetFailed(svc string) error {
 	_, err := s.r.RunCmd(exec.Command("sudo", "systemctl", "reset-failed", svc))

--- a/pkg/minikube/tunnel/cluster_inspector_test.go
+++ b/pkg/minikube/tunnel/cluster_inspector_test.go
@@ -103,7 +103,7 @@ func TestMinikubeCheckReturnsHostInformation(t *testing.T) {
 	}
 }
 
-func TestUnparseableCIDR(t *testing.T) {
+func TestUnparsableCIDR(t *testing.T) {
 	cfg := config.ClusterConfig{
 		KubernetesConfig: config.KubernetesConfig{
 			ServiceCIDR: "bad.cidr.0.0/12",

--- a/pkg/minikube/tunnel/route_darwin_test.go
+++ b/pkg/minikube/tunnel/route_darwin_test.go
@@ -74,7 +74,7 @@ func TestDarwinRouteIdempotentIntegrationTest(t *testing.T) {
 	cleanRoute(t, cfg)
 }
 
-func TestDarwinRouteCleanupIdempontentIntegrationTest(t *testing.T) {
+func TestDarwinRouteCleanupIdempotentIntegrationTest(t *testing.T) {
 
 	cfg := &Route{
 		Gateway: net.IPv4(192, 168, 1, 1),

--- a/pkg/minikube/tunnel/route_linux_test.go
+++ b/pkg/minikube/tunnel/route_linux_test.go
@@ -65,7 +65,7 @@ func TestLinuxRouteIdempotentIntegrationTest(t *testing.T) {
 	cleanRoute(t, "10.96.0.0/12")
 }
 
-func TestLinuxRouteCleanupIdempontentIntegrationTest(t *testing.T) {
+func TestLinuxRouteCleanupIdempotentIntegrationTest(t *testing.T) {
 
 	r := &osRouter{}
 	route := &Route{

--- a/pkg/minikube/tunnel/route_windows_test.go
+++ b/pkg/minikube/tunnel/route_windows_test.go
@@ -72,7 +72,7 @@ func TestWindowsRouteIdempotentIntegrationTest(t *testing.T) {
 	cleanRoute(t, "10.96.0.0")
 }
 
-func TestWindowsRouteCleanupIdempontentIntegrationTest(t *testing.T) {
+func TestWindowsRouteCleanupIdempotentIntegrationTest(t *testing.T) {
 	route := &Route{
 		Gateway: net.IPv4(1, 2, 3, 4),
 		DestCIDR: &net.IPNet{

--- a/site/content/en/docs/contrib/tests.en.md
+++ b/site/content/en/docs/contrib/tests.en.md
@@ -246,7 +246,7 @@ asserts that all Kubernetes components are healthy
 NOTE: It expects all components to be Ready, so it makes sense to run it close after only those tests that include '--wait=all' start flag
 
 Steps:
-- Run `kubectl get po po -l tier=control-plane -n kube-system -o=json` to get all the Kubernetes conponents
+- Run `kubectl get po po -l tier=control-plane -n kube-system -o=json` to get all the Kubernetes components
 - For each component, make sure the pod status is `Running`
 
 #### validateStatusCmd
@@ -439,7 +439,7 @@ for the platforms that support it, we're testing:
 #### validatePersistentVolumeClaim
 makes sure PVCs work properly
 verifies at least one StorageClass exists
-Applies a PVC manifest (pvc.yaml) and verfies PVC named myclaim reaches phase Bound.
+Applies a PVC manifest (pvc.yaml) and verifies PVC named myclaim reaches phase Bound.
 Creates a test pod (sp-pod) that mounts the claim (via createPVTestPod).
 Writes a file foo to the mounted volume at /tmp/mount/foo.
 Deletes the pod, recreates it, and verifies the file foo still exists by listing /tmp/mount, proving data persists across pod restarts.

--- a/site/content/en/docs/contrib/tests.en.md
+++ b/site/content/en/docs/contrib/tests.en.md
@@ -261,7 +261,7 @@ asserts that all Kubernetes components are healthy
 NOTE: It expects all components to be Ready, so it makes sense to run it close after only those tests that include '--wait=all' start flag
 
 Steps:
-- Run `kubectl get po po -l tier=control-plane -n kube-system -o=json` to get all the Kubernetes conponents
+- Run `kubectl get po po -l tier=control-plane -n kube-system -o=json` to get all the Kubernetes components
 - For each component, make sure the pod status is `Running`
 
 #### validateStatusCmd
@@ -454,7 +454,7 @@ for the platforms that support it, we're testing:
 #### validatePersistentVolumeClaim
 makes sure PVCs work properly
 verifies at least one StorageClass exists
-Applies a PVC manifest (pvc.yaml) and verfies PVC named myclaim reaches phase Bound.
+Applies a PVC manifest (pvc.yaml) and verifies PVC named myclaim reaches phase Bound.
 Creates a test pod (sp-pod) that mounts the claim (via createPVTestPod).
 Writes a file foo to the mounted volume at /tmp/mount/foo.
 Deletes the pod, recreates it, and verifies the file foo still exists by listing /tmp/mount, proving data persists across pod restarts.

--- a/site/content/en/docs/handbook/addons/registry-aliases.md
+++ b/site/content/en/docs/handbook/addons/registry-aliases.md
@@ -7,7 +7,7 @@ date: 2020-03-07
 
 ## Registry Aliases Addon
 
-An addon to minikube that can help push and pull from the minikube registry using custom domain names. The custom domain names will be made resolveable from with in cluster and at minikube node.
+An addon to minikube that can help push and pull from the minikube registry using custom domain names. The custom domain names will be made resolvable from with in cluster and at minikube node.
 
 ## How to use ?
 

--- a/site/content/en/docs/tutorials/ai-playground.md
+++ b/site/content/en/docs/tutorials/ai-playground.md
@@ -30,7 +30,7 @@ brew install krunkit
 krunkit --version
 ```
 
-Instal latest vmnet-helper:
+Install latest vmnet-helper:
 
 ```shell
 curl -fsSL https://github.com/minikube-machine/vmnet-helper/releases/latest/download/install.sh | bash
@@ -406,7 +406,7 @@ EOF
 
 We configured our llama-server OpenAI compatible API endpoints using the
 `OPENAI_API_BASE_URLS` environment variable.
-Check [Open WebUI documenation](https://docs.openwebui.com) to learn how to
+Check [Open WebUI documentation](https://docs.openwebui.com) to learn how to
 configure it using the Admin Panel.
 
 Wait until the deployment is available:

--- a/site/content/en/docs/tutorials/multi_control_plane_ha_clusters.md
+++ b/site/content/en/docs/tutorials/multi_control_plane_ha_clusters.md
@@ -142,7 +142,7 @@ apiserver: Running
 kubeconfig: Configured
 ```
 
-- For a HA cluster, kubeconfig points to the Virual Kubernetes API Server IP
+- For a HA cluster, kubeconfig points to the Virtual Kubernetes API Server IP
 
 ```shell
 kubectl config view --context ha-demo

--- a/test/integration/error_spam_test.go
+++ b/test/integration/error_spam_test.go
@@ -75,7 +75,7 @@ func TestErrorSpam(t *testing.T) {
 
 	t.Run("setup", func(t *testing.T) {
 		// This should likely use multi-node once it's ready
-		// use `--log_dir` flag to run isolated and avoid race condition - ie, failing to clean up (locked) log files created by other concurently-run tests, or counting them in results
+		// use `--log_dir` flag to run isolated and avoid race condition - ie, failing to clean up (locked) log files created by other concurrently-run tests, or counting them in results
 		args := append([]string{"start", "-p", profile, "-n=1", "--memory=3072", "--wait=false", fmt.Sprintf("--log_dir=%s", logDir)}, StartArgs()...)
 
 		rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))

--- a/test/integration/error_spam_test.go
+++ b/test/integration/error_spam_test.go
@@ -82,7 +82,7 @@ func TestErrorSpam(t *testing.T) {
 
 	t.Run("setup", func(t *testing.T) {
 		// This should likely use multi-node once it's ready
-		// use `--log_dir` flag to run isolated and avoid race condition - ie, failing to clean up (locked) log files created by other concurently-run tests, or counting them in results
+		// use `--log_dir` flag to run isolated and avoid race condition - ie, failing to clean up (locked) log files created by other concurrently-run tests, or counting them in results
 		args := append([]string{"start", "-p", profile, "-n=1", "--memory=3072", "--wait=false", fmt.Sprintf("--log_dir=%s", logDir)}, StartArgs()...)
 
 		rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -824,7 +824,7 @@ func validateComponentHealth(ctx context.Context, t *testing.T, profile string) 
 		"kube-scheduler":          false,
 	}
 
-	// docs: Run `kubectl get po po -l tier=control-plane -n kube-system -o=json` to get all the Kubernetes conponents
+	// docs: Run `kubectl get po po -l tier=control-plane -n kube-system -o=json` to get all the Kubernetes components
 	rr, err := Run(t, exec.CommandContext(ctx, KubectlBinary(), "--context", profile, "get", "po", "-l", "tier=control-plane", "-n", "kube-system", "-o=json"))
 	if err != nil {
 		t.Fatalf("failed to get components. args %q: %v", rr.Command(), err)

--- a/test/integration/functional_test.go
+++ b/test/integration/functional_test.go
@@ -934,7 +934,7 @@ func validateComponentHealth(ctx context.Context, t *testing.T, profile string) 
 		"kube-scheduler":          false,
 	}
 
-	// docs: Run `kubectl get po po -l tier=control-plane -n kube-system -o=json` to get all the Kubernetes conponents
+	// docs: Run `kubectl get po po -l tier=control-plane -n kube-system -o=json` to get all the Kubernetes components
 	rr, err := Run(t, exec.CommandContext(ctx, KubectlBinary(), "--context", profile, "get", "po", "-l", "tier=control-plane", "-n", "kube-system", "-o=json"))
 	if err != nil {
 		t.Fatalf("failed to get components. args %q: %v", rr.Command(), err)

--- a/test/integration/functional_test_pvc_test.go
+++ b/test/integration/functional_test_pvc_test.go
@@ -37,7 +37,7 @@ import (
 
 // validatePersistentVolumeClaim makes sure PVCs work properly
 // verifies at least one StorageClass exists
-// Applies a PVC manifest (pvc.yaml) and verfies PVC named myclaim reaches phase Bound.
+// Applies a PVC manifest (pvc.yaml) and verifies PVC named myclaim reaches phase Bound.
 // Creates a test pod (sp-pod) that mounts the claim (via createPVTestPod).
 // Writes a file foo to the mounted volume at /tmp/mount/foo.
 // Deletes the pod, recreates it, and verifies the file foo still exists by listing /tmp/mount, proving data persists across pod restarts.


### PR DESCRIPTION
This PR introduces another round of spellchecking, similar to #21273.

While #21273 proposes adding a codespell step to CI, I would currently advise against doing so. The number of false positives is still too high, and there is no clean way to generically exclude them. Additionally, the majority of the identified issues require manual decisions between multiple valid alternatives.

For reference, these are the commands I used to identify most of the changes in this PR:

```
codespell --skip '*.yaml,*.tmpl,*.json,*.html,*.patch,go.sum,./third_party' -i 3 -w

typos   --exclude '*.yaml'   --exclude '*.tmpl'   --exclude '*.json'   --exclude '*.html'   --exclude '*.patch'   --exclude 'go.sum'   --exclude 'third_party/**'
```