### PR TITLE
ci: fix preload makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -716,17 +716,13 @@ endif
 # in order to be able to publish them as github assets 
 PRELOAD_GENERATOR_REPO ?= https://github.com/kubernetes-sigs/minikube-preloads.git
 PRELOAD_GENERATOR_DIR := $(BUILD_DIR)/preload-generator-src
-PRELOAD_GENERATOR_BIN := $(BUILD_DIR)/preload-generator
 
 $(PRELOAD_GENERATOR_DIR):
 	rm -rf $(PRELOAD_GENERATOR_DIR)
 	git clone --depth=1 --branch main $(PRELOAD_GENERATOR_REPO) $(PRELOAD_GENERATOR_DIR)
 
-$(PRELOAD_GENERATOR_BIN): $(PRELOAD_GENERATOR_DIR)
+out/preload-generator: $(PRELOAD_GENERATOR_DIR)
 	cd $(PRELOAD_GENERATOR_DIR) && GOWORK=off GOBIN=$(BUILD_DIR) go install ./cmd/preload-generator
-
-out/preload-generator: $(PRELOAD_GENERATOR_BIN)
-	cp $(PRELOAD_GENERATOR_BIN) $@
 
 .PHONY: upload-preloaded-images-tar
 upload-preloaded-images-tar: out/minikube out/preload-generator ## Upload the preloaded images for oldest supported, newest supported, and default kubernetes versions to GCS.


### PR DESCRIPTION
internal jenkins error: 
```
15:41:32 + make update-kubeadm-constants
15:41:33 cd hack && go run update/kubeadm_constants/kubeadm_constants.go
15:41:38 gofmt -w pkg/minikube/constants/constants_kubeadm_images.go
15:41:38 + make upload-preloaded-images-tar
15:41:38 go build  -tags "libvirt_dlopen" -ldflags="-X k8s.io/minikube/pkg/version.version=v1.37.0 -X k8s.io/minikube/pkg/version.isoVersion=v1.37.0-1765151505-21409 -X k8s.io/minikube/pkg/version.gitCommitID="8934dd16e2a7c2b18a40fccb44f32c776262c249" -X k8s.io/minikube/pkg/version.storageProvisionerVersion=v5" -o out/minikube k8s.io/minikube/cmd/minikube
15:42:00 rm -rf /home/jenkins/workspace/Preload-Generation-x86/out/preload-generator-src
15:42:00 git clone --depth=1 --branch main https://github.com/kubernetes-sigs/minikube-preloads.git /home/jenkins/workspace/Preload-Generation-x86/out/preload-generator-src
15:42:00 Cloning into '/home/jenkins/workspace/Preload-Generation-x86/out/preload-generator-src'...
15:42:00 cd /home/jenkins/workspace/Preload-Generation-x86/out/preload-generator-src && GOWORK=off GOBIN=/home/jenkins/workspace/Preload-Generation-x86/out go install ./cmd/preload-generator
15:42:00 go: downloading github.com/spf13/viper v1.21.0
15:42:00 go: downloading k8s.io/minikube v1.37.0
15:42:06 go: downloading github.com/fsnotify/fsnotify v1.9.0
15:42:06 go: downloading github.com/sagikazarmark/locafero v0.11.0
15:42:06 go: downloading github.com/spf13/afero v1.15.0
15:42:06 go: downloading github.com/spf13/cast v1.10.0
15:42:06 go: downloading github.com/spf13/pflag v1.0.10
15:42:06 go: downloading github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8
15:42:06 go: downloading github.com/pelletier/go-toml/v2 v2.2.4
15:42:06 go: downloading go.yaml.in/yaml/v3 v3.0.4
15:42:46 cp /home/jenkins/workspace/Preload-Generation-x86/out/preload-generator out/preload-generator
15:42:46 cp: '/home/jenkins/workspace/Preload-Generation-x86/out/preload-generator' and 'out/preload-generator' are the same file
15:42:46 make: *** [Makefile:729: out/preload-generator] Error 1
```