### PR TITLE
replace mkisofs command with native xorriso commands

### DIFF
--- a/deploy/iso/minikube-iso/board/minikube/aarch64/post-image.sh
+++ b/deploy/iso/minikube-iso/board/minikube/aarch64/post-image.sh
@@ -28,14 +28,14 @@ mkdir -p root/EFI/BOOT
 cp efi-part/EFI/BOOT/* root/EFI/BOOT/
 cp efiboot.img root/EFI/BOOT/
 
-mkisofs \
-   -o boot.iso \
-   -R -J -v -d -N \
-   -hide-rr-moved \
-   -no-emul-boot \
-   -eltorito-platform=efi \
-   -eltorito-boot EFI/BOOT/efiboot.img \
-   -V "EFIBOOTISO" \
-   -A "EFI Boot ISO" \
-   root
+xorriso \
+   -outdev boot.iso \
+   -joliet on \
+   -rockridge on \
+   -volid 'EFIBOOTISO' \
+   -publisher 'EFI Boot ISO' \
+   -map root / \
+   -boot_image any platform_id=0xef \
+   -boot_image any efi_path=EFI/BOOT/efiboot.img \
+   -boot_image any cat_path=/boot.cat
 cd -

--- a/hack/jenkins/build_iso.sh
+++ b/hack/jenkins/build_iso.sh
@@ -60,7 +60,7 @@ source ./hack/jenkins/installers/check_install_linux_crons.sh
 
 # Make sure all required packages are installed
 sudo apt-get update
-sudo apt-get -y install build-essential unzip rsync bc python3 p7zip-full cmake
+sudo apt-get -y install build-essential unzip rsync bc python3 p7zip-full cmake xorriso
 
 # Log Cmake version
 CMAKE_VERSION=$(cmake --version | head -n1 | awk '{print $3}')

--- a/site/content/en/docs/contrib/building/iso.md
+++ b/site/content/en/docs/contrib/building/iso.md
@@ -57,7 +57,6 @@ sudo apt-get install \
     build-essential \
     cpio \
     gcc-multilib \
-    genisoimage \
     git \
     gnupg2 \
     libtool \
@@ -66,6 +65,7 @@ sudo apt-get install \
     python2 \
     unzip \
     wget \
+    xorriso
 ```
 
 Install Go using these instructions:


### PR DESCRIPTION
When building the aarch64 ISO on Fedora, the build failed with:
`xorriso : FAILURE : -as genisofs: Unrecognized option '-eltorito-platform=efi'`

On Fedora, the mkisofs command is actually implemented by xorriso using -as genisofs emulation mode. However, newer versions of xorriso don't support the -eltorito-platform=efi flag when emulating genisofs.

### The Fix
I replaced the mkisofs command in [post-image.sh](vscode-file://vscode-app/c:/Users/vtripathi/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with native xorriso commands.

fixes #22056 
