### PR TITLE
Fix French translation for stopping node message

### DIFF
--- a/translations/fr.json
+++ b/translations/fr.json
@@ -700,7 +700,7 @@
 	"Starts an existing stopped node in a cluster.": "Démarre un nœud arrêté existant dans un cluster.",
 	"Startup with {{.old_driver}} driver failed, trying with alternate driver {{.new_driver}}: {{.error}}": "Échec du démarrage avec le pilote {{.old_driver}}, essai avec un autre pilote {{.new_driver}} : {{.error}}",
 	"Stopped tunnel for service {{.service}}.": "Tunnel arrêté pour le service {{.service}}.",
-	"Stopping node \"{{.name}}\"  ...": "Nœud d'arrêt \"{{.name}}\" ...",
+	"Stopping node \"{{.name}}\"  ...": "Arrêt du nœud  \"{{.name}}\" ...",
 	"Stopping tunnel for service {{.service}}.": "Tunnel d'arrêt pour le service {{.service}}.",
 	"Stops a local Kubernetes cluster. This command stops the underlying VM or container, but keeps user data intact. The cluster can be started again with the \"start\" command.": "Arrête un cluster Kubernetes local. Cette commande arrête la VM ou le conteneur sous-jacent, mais conserve les données utilisateur intactes. Le cluster peut être redémarré avec la commande \"start\".",
 	"Stops a node in a cluster.": "Arrête un nœud dans un cluster.",


### PR DESCRIPTION
This PR doesn’t introduce any functional changes.
It only fixes a French translation issue.

The current translation of “Stopping node <node>” is “Noeud d’arrêt”, which is misleading in French and sounds like a noun rather than an action.

The translation has been updated to “Arrêt du nœud”, which correctly conveys the intended meaning (the action of stopping a node).