### PR TITLE
vfkit: Add Rosetta support for deploying amd64 images on Apple silicon

### DIFF
--- a/pkg/drivers/vfkit/vfkit.go
+++ b/pkg/drivers/vfkit/vfkit.go
@@ -63,6 +63,10 @@ const (
 	logFileName    = "vfkit.log"
 	serialFileName = "serial.log"
 	defaultSSHUser = "docker"
+
+	// Rosetta mount in the guest.
+	rosettaMountTag   = "minikube-rosetta"
+	rosettaMountPoint = "/mnt/minikube-rosetta"
 )
 
 // Driver is the machine driver for vfkit (Virtualization.framework)
@@ -78,6 +82,7 @@ type Driver struct {
 	Network        string        // "", "nat", "vmnet-shared"
 	MACAddress     string        // For network=nat, network=""
 	VmnetHelper    *vmnet.Helper // For network=vmnet-shared
+	Rosetta        bool          // Enable rosetta support
 }
 
 func NewDriver(hostName, storePath string, options *run.CommandOptions) drivers.Driver {
@@ -259,6 +264,12 @@ func (d *Driver) Start() error {
 		return err
 	}
 
+	if d.Rosetta {
+		if err := d.setupRosetta(); err != nil {
+			return err
+		}
+	}
+
 	if len(d.VirtiofsMounts) > 0 {
 		log.Infof("Setup virtiofs mounts ...")
 		if err := virtiofs.SetupMounts(d, d.VirtiofsMounts); err != nil {
@@ -329,6 +340,10 @@ func (d *Driver) startVfkit(socketPath string) error {
 
 	}
 
+	if d.Rosetta {
+		startCmd = append(startCmd, d.rosettaOptions()...)
+	}
+
 	log.Debugf("executing: vfkit %s", strings.Join(startCmd, " "))
 	os.Remove(d.sockfilePath())
 	cmd := exec.Command("vfkit", startCmd...)
@@ -348,6 +363,58 @@ func (d *Driver) startVfkit(socketPath string) error {
 		return err
 	}
 	return process.WritePidfile(d.pidfilePath(), cmd.Process.Pid)
+}
+
+// rosettaOptions returns the vfkit command line options for Rosetta support.
+func (d *Driver) rosettaOptions() []string {
+	options := []string{
+		"rosetta",
+		"mountTag=" + rosettaMountTag,
+	}
+
+	// Try to install rosetta automatically for best user experience. The
+	// installation requires user interaction so we must skip it in
+	// non-interactive mode. If Rosetta is not installed vfkit will fail.
+	// For more info see https://support.apple.com/en-us/102527
+	if !d.CommandOptions.NonInteractive {
+		options = append(options, "install")
+	}
+
+	return []string{"--device", strings.Join(options, ",")}
+}
+
+func (d *Driver) setupRosetta() error {
+	// See https://docs.kernel.org/admin-guide/binfmt-misc.html
+	binfmt := strings.Join([]string{
+		// name
+		":rosetta",
+		// type: M (magic number matching), E (extension matching)
+		":M",
+		// offset (default 0)
+		":",
+		// magic
+		`:\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x3e\x00`,
+		// mask
+		`:\xff\xff\xff\xff\xff\xfe\xfe\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff`,
+		// interpreter
+		":" + filepath.Join(rosettaMountPoint, "rosetta"),
+		// flags: F (fix binary), C (credentials), or O (open binary)
+		":F",
+	}, "")
+
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "set -e\n")
+	fmt.Fprintf(&b, "sudo mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc\n")
+	fmt.Fprintf(&b, "sudo mkdir -p %s\n", rosettaMountPoint)
+	fmt.Fprintf(&b, "sudo mount -t virtiofs %s %s\n", rosettaMountTag, rosettaMountPoint)
+	fmt.Fprintf(&b, "echo '%s' | sudo tee /proc/sys/fs/binfmt_misc/register\n", binfmt)
+
+	if _, err := drivers.RunSSHCommandFromDriver(d, b.String()); err != nil {
+		return fmt.Errorf("failed to setup rosetta: %w", err)
+	}
+
+	return nil
 }
 
 func (d *Driver) setupIP(mac string) error {

--- a/pkg/minikube/config/types.go
+++ b/pkg/minikube/config/types.go
@@ -109,6 +109,7 @@ type ClusterConfig struct {
 	SSHAgentPID             int
 	GPUs                    string
 	AutoPauseInterval       time.Duration // Specifies interval of time to wait before checking if cluster should be paused
+	Rosetta                 bool          // Only used by vfkit driver
 }
 
 // KubernetesConfig contains the parameters used to configure the VM Kubernetes.

--- a/pkg/minikube/registry/drvs/vfkit/vfkit.go
+++ b/pkg/minikube/registry/drvs/vfkit/vfkit.go
@@ -112,6 +112,7 @@ func configure(cfg config.ClusterConfig, n config.Node) (interface{}, error) {
 		Network:        cfg.Network,
 		MACAddress:     mac,
 		VmnetHelper:    helper,
+		Rosetta:        cfg.Rosetta,
 	}, nil
 }
 


### PR DESCRIPTION
Add --rosetta flag enabling Rosetta[1] for running apps built for Intel processor on Mac with Apple silicon. An example use case is deploying open-cluster-management that do not provide arm64 builds yet.

If Rosetta is not installed on the host, it will be installed on the first time starting a cluster. When running in non-interactive mode automatic install is disabled and if Rosetta is not installed start will fail.

The --rosetta flag is ignored with a warning if enabled on Mac with Intel processor.

## Testing amd64 executable on Apple silicon

```console
% cat rosetta/test.go 
package main

import (
        "bytes"
        "fmt"
        "os/exec"
        "runtime"
)

func main() {
        uname, _ := exec.Command("uname", "-a").Output()
        fmt.Printf("✅ Running %s binary on %s\n", runtime.GOARCH, bytes.TrimSpace(uname))
}

% GOARCH=amd64 GOOS=linux go build -o rosetta/test rosetta/test.go

% file rosetta/test
rosetta/test: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, BuildID[sha1]=9743ccad9a20c7d535a9794cc7b22ed1147c89d8, with debug_info, not stripped

% out/minikube start --driver vfkit --rosetta --mount-string $PWD/rosetta:/mnt/rosetta --no-kubernetes
😄  minikube v1.37.0 on Darwin 26.1 (arm64)
✨  Using the vfkit driver based on user configuration
👍  Starting minikube without Kubernetes in cluster minikube
🔥  Creating vfkit VM (CPUs=2, Memory=6144MB, Disk=20000MB) ...
🐳  Preparing Docker 28.5.2 ...
🏄  Done! minikube is ready without Kubernetes!

% minikube ssh /mnt/rosetta/test                                  
✅ Running amd64 binary on Linux minikube 6.6.95 #1 SMP PREEMPT Thu Dec 11 21:09:52 UTC 2025 aarch64 GNU/Linux
```

## Testing with container images

I tested the PR with ramen regional DR environment, using containerd runtime. We deploy several adm64 only container images like open-cluster-management and ramen.
https://github.com/RamenDR/ramen/pull/2356

---

[1] https://developer.apple.com/documentation/virtualization/running-intel-binaries-in-linux-vms-with-rosetta

Fixes #20559