### PR TITLE
build: address all go static checks warned by lint-max

### DIFF
--- a/cmd/minikube/cmd/config/config_test.go
+++ b/cmd/minikube/cmd/config/config_test.go
@@ -38,7 +38,7 @@ func TestHiddenPrint(t *testing.T) {
 	}
 	for _, test := range testCases {
 		b := new(bytes.Buffer)
-		_, err := b.WriteString(fmt.Sprintf("%s\r\n", test.TestString)) // you need the \r!
+		_, err := fmt.Fprintf(b, "%s\r\n", test.TestString) // you need the \r!
 		if err != nil {
 			t.Errorf("Could not prepare bytestring")
 		}

--- a/cmd/minikube/cmd/config/open.go
+++ b/cmd/minikube/cmd/config/open.go
@@ -91,7 +91,7 @@ minikube addons enable {{.name}}`, out.V{"name": addonName})
 You can add one by annotating a service with the label {{.labelName}}:{{.addonName}}`, out.V{"labelName": key, "addonName": addonName})
 		}
 		for i := range serviceList.Items {
-			svc := serviceList.Items[i].ObjectMeta.Name
+			svc := serviceList.Items[i].Name
 			var urlString []string
 
 			if urlString, err = service.WaitForService(co.API, co.Config.Name, namespace, svc, addonsURLTemplate, addonsURLMode, https, wait, interval); err != nil {

--- a/cmd/minikube/cmd/docker-env_test.go
+++ b/cmd/minikube/cmd/docker-env_test.go
@@ -429,7 +429,7 @@ SSH_AGENT_PID: "29228"
 	}
 	for _, tc := range tests {
 		t.Run(tc.config.profile, func(t *testing.T) {
-			tc.config.EnvConfig.Shell = tc.shell
+			tc.config.Shell = tc.shell
 			// set global variable
 			outputFormat = tc.output
 			defaultNoProxyGetter = tc.noProxyGetter

--- a/cmd/minikube/cmd/podman-env_test.go
+++ b/cmd/minikube/cmd/podman-env_test.go
@@ -71,7 +71,7 @@ unset MINIKUBE_ACTIVE_PODMAN;
 	}
 	for _, tc := range tests {
 		t.Run(tc.config.profile, func(t *testing.T) {
-			tc.config.EnvConfig.Shell = tc.shell
+			tc.config.Shell = tc.shell
 			defaultNoProxyGetter = tc.noProxyGetter
 			var b []byte
 			buf := bytes.NewBuffer(b)

--- a/pkg/addons/helm.go
+++ b/pkg/addons/helm.go
@@ -84,7 +84,7 @@ func helmInstallBinary(addon *assets.Addon, runner command.Runner) error {
 			}
 		}
 
-		installCmd := fmt.Sprint("curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && chmod 700 get_helm.sh && ./get_helm.sh")
+		installCmd := "curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && chmod 700 get_helm.sh && ./get_helm.sh"
 		_, err = runner.RunCmd(exec.Command("sudo", "bash", "-c", installCmd))
 		if err != nil {
 			return errors.Wrap(err, "downloading helm")

--- a/pkg/drivers/none/none.go
+++ b/pkg/drivers/none/none.go
@@ -125,7 +125,7 @@ func (d *Driver) GetURL() (string, error) {
 
 // GetState returns the state that the host is in (running, stopped, etc)
 func (d *Driver) GetState() (state.State, error) {
-	hostname, port, err := kubeconfig.Endpoint(d.BaseDriver.MachineName, "")
+	hostname, port, err := kubeconfig.Endpoint(d.MachineName, "")
 	if err != nil {
 		klog.Warningf("unable to get port: %v", err)
 		port = constants.APIServerPort

--- a/pkg/minikube/assets/vm_assets.go
+++ b/pkg/minikube/assets/vm_assets.go
@@ -354,12 +354,12 @@ func defaultValue(defValue string, val interface{}) string {
 }
 
 func (m *BinAsset) loadData() error {
-	contents, err := m.FS.ReadFile(m.SourcePath)
+	contents, err := m.ReadFile(m.SourcePath)
 	if err != nil {
 		return err
 	}
 
-	if strings.HasSuffix(m.BaseAsset.SourcePath, ".tmpl") {
+	if strings.HasSuffix(m.SourcePath, ".tmpl") {
 		tpl, err := template.New(m.SourcePath).Funcs(template.FuncMap{"default": defaultValue}).Parse(string(contents))
 		if err != nil {
 			return err

--- a/pkg/minikube/bootstrapper/bsutil/kverify/system_pods.go
+++ b/pkg/minikube/bootstrapper/bsutil/kverify/system_pods.go
@@ -92,7 +92,7 @@ func ExpectAppsRunning(cs *kubernetes.Clientset, expected []string) error {
 			continue
 		}
 
-		for k, v := range pod.ObjectMeta.Labels {
+		for k, v := range pod.Labels {
 			if k == "component" || k == "k8s-app" {
 				found[v] = true
 			}
@@ -130,7 +130,7 @@ func WaitForAppsRunning(cs *kubernetes.Clientset, expected []string, timeout tim
 // podStatusMsg returns a human-readable pod status, for generating debug status
 func podStatusMsg(pod core.Pod) string {
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("%q [%s] %s", pod.ObjectMeta.GetName(), pod.ObjectMeta.GetUID(), pod.Status.Phase))
+	sb.WriteString(fmt.Sprintf("%q [%s] %s", pod.GetName(), pod.GetUID(), pod.Status.Phase))
 	for i, c := range pod.Status.Conditions {
 		if c.Reason != "" {
 			if i == 0 {

--- a/pkg/minikube/machine/machine.go
+++ b/pkg/minikube/machine/machine.go
@@ -50,19 +50,19 @@ func (h *Machine) IsValid() bool {
 		return false
 	}
 
-	if h.Host.Name == "" {
+	if h.Name == "" {
 		return false
 	}
 
-	if h.Host.Driver == nil {
+	if h.Driver == nil {
 		return false
 	}
 
-	if h.Host.HostOptions == nil {
+	if h.HostOptions == nil {
 		return false
 	}
 
-	if h.Host.RawDriver == nil {
+	if h.RawDriver == nil {
 		return false
 	}
 	return true

--- a/pkg/minikube/out/out.go
+++ b/pkg/minikube/out/out.go
@@ -120,7 +120,7 @@ func Styled(st style.Enum, format string, a ...V) {
 func boxedCommon(printFunc func(format string, a ...interface{}), cfg box.Config, title string, format string, a ...V) {
 	b := box.New(cfg)
 	if !useColor {
-		b.Config.Color = nil
+		b.Color = nil
 	}
 	str := Sprintf(style.None, format, a...)
 	printFunc(b.String(title, strings.TrimSpace(str)))

--- a/pkg/minikube/proxy/proxy_test.go
+++ b/pkg/minikube/proxy/proxy_test.go
@@ -64,10 +64,7 @@ func TestIsInBlock(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%s in %s Want: %t WantAErr: %t", tc.ip, tc.block, tc.want, tc.wanntAErr), func(t *testing.T) {
 			got, err := isInBlock(tc.ip, tc.block)
-			gotErr := false
-			if err != nil {
-				gotErr = true
-			}
+			gotErr := err != nil
 			if gotErr != tc.wanntAErr {
 				t.Errorf("isInBlock(%v,%v) got error is %v ; want error is %v", tc.ip, tc.block, gotErr, tc.wanntAErr)
 			}

--- a/pkg/minikube/service/service_test.go
+++ b/pkg/minikube/service/service_test.go
@@ -350,7 +350,7 @@ func (s *MockServiceInterface) List(_ context.Context, opts meta.ListOptions) (*
 
 func (s *MockServiceInterface) Get(_ context.Context, name string, _ meta.GetOptions) (*core.Service, error) {
 	for _, svc := range s.ServiceList.Items {
-		if svc.ObjectMeta.Name == name {
+		if svc.Name == name {
 			return &svc, nil
 		}
 	}

--- a/pkg/minikube/tests/driver_mock.go
+++ b/pkg/minikube/tests/driver_mock.go
@@ -68,8 +68,8 @@ func (d *MockDriver) GetIP() (string, error) {
 	if d.IP != "" {
 		return d.IP, nil
 	}
-	if d.BaseDriver.IPAddress != "" {
-		return d.BaseDriver.IPAddress, nil
+	if d.IPAddress != "" {
+		return d.IPAddress, nil
 	}
 	return "127.0.0.1", nil
 }
@@ -94,7 +94,7 @@ func (d *MockDriver) GetSSHHostname() (string, error) {
 
 // GetSSHKeyPath returns the key path for SSH
 func (d *MockDriver) GetSSHKeyPath() string {
-	return d.BaseDriver.SSHKeyPath
+	return d.SSHKeyPath
 }
 
 // GetState returns the state of the driver

--- a/pkg/minikube/tunnel/tunnel_test.go
+++ b/pkg/minikube/tunnel/tunnel_test.go
@@ -37,9 +37,10 @@ const NotRunningPid = 1236
 const NotRunningPid2 = 1237
 
 func mockPidChecker(pid int) (bool, error) {
-	if pid == NotRunningPid || pid == NotRunningPid2 {
+	switch pid {
+	case NotRunningPid, NotRunningPid2:
 		return false, nil
-	} else if pid == RunningPid1 || pid == RunningPid2 {
+	case RunningPid1, RunningPid2:
 		return true, nil
 	}
 	return false, fmt.Errorf("fake pid checker does not recognize %d", pid)

--- a/pkg/perf/monitor/github.go
+++ b/pkg/perf/monitor/github.go
@@ -62,7 +62,7 @@ func (g *Client) CommentOnPR(pr int, message string) error {
 	}
 
 	log.Printf("Creating comment on PR %d: %s", pr, message)
-	_, _, err := g.Client.Issues.CreateComment(g.ctx, g.owner, g.repo, pr, comment)
+	_, _, err := g.Issues.CreateComment(g.ctx, g.owner, g.repo, pr, comment)
 	if err != nil {
 		return errors.Wrap(err, "creating github comment")
 	}
@@ -73,7 +73,7 @@ func (g *Client) CommentOnPR(pr int, message string) error {
 // ListOpenPRsWithLabel returns all open PRs with the specified label
 func (g *Client) ListOpenPRsWithLabel(label string) ([]int, error) {
 	validPrs := []int{}
-	prs, _, err := g.Client.PullRequests.List(g.ctx, g.owner, g.repo, &github.PullRequestListOptions{})
+	prs, _, err := g.PullRequests.List(g.ctx, g.owner, g.repo, &github.PullRequestListOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "listing pull requests")
 	}
@@ -117,7 +117,7 @@ func (g *Client) timeOfLastCommit(pr int) (time.Time, error) {
 	page := 0
 	resultsPerPage := 30
 	for {
-		c, _, err := g.Client.PullRequests.ListCommits(g.ctx, g.owner, g.repo, pr, &github.ListOptions{
+		c, _, err := g.PullRequests.ListCommits(g.ctx, g.owner, g.repo, pr, &github.ListOptions{
 			Page:    page,
 			PerPage: resultsPerPage,
 		})
@@ -146,7 +146,7 @@ func (g *Client) timeOfLastComment(pr int, login string) (time.Time, error) {
 	page := 0
 	resultsPerPage := 30
 	for {
-		c, _, err := g.Client.Issues.ListComments(g.ctx, g.owner, g.repo, pr, &github.IssueListCommentsOptions{
+		c, _, err := g.Issues.ListComments(g.ctx, g.owner, g.repo, pr, &github.IssueListCommentsOptions{
 			ListOptions: github.ListOptions{
 				Page:    page,
 				PerPage: resultsPerPage,

--- a/pkg/storage/storage_provisioner.go
+++ b/pkg/storage/storage_provisioner.go
@@ -104,7 +104,7 @@ func (p *hostPathProvisioner) Delete(_ context.Context, volume *core.PersistentV
 		return &controller.IgnoredError{Reason: "identity annotation on PV does not match ours"}
 	}
 
-	if err := os.RemoveAll(volume.Spec.PersistentVolumeSource.HostPath.Path); err != nil {
+	if err := os.RemoveAll(volume.Spec.HostPath.Path); err != nil {
 		return errors.Wrap(err, "removing hostpath PV")
 	}
 

--- a/pkg/trace/gcp.go
+++ b/pkg/trace/gcp.go
@@ -49,7 +49,7 @@ type gcpTracer struct {
 // StartSpan starts a span for the next step of
 // `minikube start` via the GCP tracer
 func (t *gcpTracer) StartSpan(name string) {
-	_, span := t.Tracer.Start(t.parentCtx, name)
+	_, span := t.Start(t.parentCtx, name)
 	t.spans[name] = span
 }
 

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -21,7 +21,6 @@ package util
 import (
 	"os"
 	"os/user"
-	"runtime"
 	"syscall"
 	"testing"
 
@@ -125,10 +124,8 @@ func TestChownR(t *testing.T) {
 	}
 }
 
+// this test runs on non-windows because of the build tag at the top of the file
 func TestMaybeChownDirRecursiveToMinikubeUser(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows")
-	}
 
 	testDir := t.TempDir()
 	if _, err := os.Create(testDir + "/TestChownR"); nil != err {

--- a/test/integration/aaa_download_only_test.go
+++ b/test/integration/aaa_download_only_test.go
@@ -260,7 +260,7 @@ func createSha256File(filePath string) error {
 	}
 	defer f.Close()
 
-	_, err = f.WriteString(fmt.Sprintf("%x", sum[:]))
+	_, err = fmt.Fprintf(f, "%x", sum[:])
 	if err != nil {
 		return err
 	}

--- a/test/integration/addons_test.go
+++ b/test/integration/addons_test.go
@@ -1031,7 +1031,7 @@ func validateNvidiaDevicePlugin(ctx context.Context, t *testing.T, profile strin
 
 // validateAmdGpuDevicePlugin tests the amd-gpu-device-plugin addon by ensuring the pod comes up and the addon disables
 func validateAmdGpuDevicePlugin(ctx context.Context, t *testing.T, profile string) {
-	if !(DockerDriver() && amd64Platform()) {
+	if !DockerDriver() || !amd64Platform() {
 		t.Skipf("skip amd gpu test on all but docker driver and amd64 platform")
 	}
 	defer disableAddon(t, "amd-gpu-device-plugin", profile)

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -298,7 +298,7 @@ func PostMortemLogs(t *testing.T, profile string, multinode ...bool) {
 // podStatusMsg returns a human-readable pod status, for generating debug status
 func podStatusMsg(pod core.Pod) string {
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("%q [%s] %s", pod.ObjectMeta.GetName(), pod.ObjectMeta.GetUID(), pod.Status.Phase))
+	sb.WriteString(fmt.Sprintf("%q [%s] %s", pod.GetName(), pod.GetUID(), pod.Status.Phase))
 	for i, c := range pod.Status.Conditions {
 		if c.Reason != "" {
 			if i == 0 {
@@ -346,7 +346,7 @@ func PodWait(ctx context.Context, t *testing.T, profile string, ns string, selec
 		}
 
 		for _, pod := range pods.Items {
-			foundNames[pod.ObjectMeta.Name] = true
+			foundNames[pod.Name] = true
 			msg := podStatusMsg(pod)
 			// Prevent spamming logs with identical messages
 			if msg != lastMsg {


### PR DESCRIPTION
address all the Static Checks by `make lint-max`
this PR only handles static checks  follow up PR will fix others (such as errcheck or  others)
```
./out/linters/golangci-lint-v2.7.1 run --max-issues-per-linter 0 --max-same-issues 0 --build-tags "integration libvirt_dlopen" --config .golangci.min.yaml  --config .golangci.max.yaml ./...

cmd/minikube/cmd/config/config_test.go:41:13: QF1012: Use fmt.Fprintf(...) instead of WriteString(fmt.Sprintf(...)) (staticcheck)
		_, err := b.WriteString(fmt.Sprintf("%s\r\n", test.TestString)) // you need the \r!
		          ^
cmd/minikube/cmd/config/open.go:94:32: QF1008: could remove embedded field "ObjectMeta" from selector (staticcheck)
			svc := serviceList.Items[i].ObjectMeta.Name
			                            ^
cmd/minikube/cmd/docker-env_test.go:432:14: QF1008: could remove embedded field "EnvConfig" from selector (staticcheck)
			tc.config.EnvConfig.Shell = tc.shell
			          ^
cmd/minikube/cmd/podman-env_test.go:74:14: QF1008: could remove embedded field "EnvConfig" from selector (staticcheck)
			tc.config.EnvConfig.Shell = tc.shell
			          ^
pkg/addons/helm.go:87:17: S1039: unnecessary use of fmt.Sprint (staticcheck)
		installCmd := fmt.Sprint("curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && chmod 700 get_helm.sh && ./get_helm.sh")
		              ^
pkg/drivers/none/none.go:128:47: QF1008: could remove embedded field "BaseDriver" from selector (staticcheck)
	hostname, port, err := kubeconfig.Endpoint(d.BaseDriver.MachineName, "")
	                                             ^
pkg/minikube/assets/vm_assets.go:357:21: QF1008: could remove embedded field "FS" from selector (staticcheck)
	contents, err := m.FS.ReadFile(m.SourcePath)
	                   ^
pkg/minikube/assets/vm_assets.go:362:25: QF1008: could remove embedded field "BaseAsset" from selector (staticcheck)
	if strings.HasSuffix(m.BaseAsset.SourcePath, ".tmpl") {
	                       ^
pkg/minikube/bootstrapper/bsutil/kverify/system_pods.go:95:25: QF1008: could remove embedded field "ObjectMeta" from selector (staticcheck)
		for k, v := range pod.ObjectMeta.Labels {
		                      ^
pkg/minikube/bootstrapper/bsutil/kverify/system_pods.go:133:47: QF1008: could remove embedded field "ObjectMeta" from selector (staticcheck)
	sb.WriteString(fmt.Sprintf("%q [%s] %s", pod.ObjectMeta.GetName(), pod.ObjectMeta.GetUID(), pod.Status.Phase))
	                                             ^
pkg/minikube/machine/machine.go:53:7: QF1008: could remove embedded field "Host" from selector (staticcheck)
	if h.Host.Name == "" {
	     ^
pkg/minikube/machine/machine.go:57:7: QF1008: could remove embedded field "Host" from selector (staticcheck)
	if h.Host.Driver == nil {
	     ^
pkg/minikube/machine/machine.go:61:7: QF1008: could remove embedded field "Host" from selector (staticcheck)
	if h.Host.HostOptions == nil {
	     ^
pkg/minikube/machine/machine.go:65:7: QF1008: could remove embedded field "Host" from selector (staticcheck)
	if h.Host.RawDriver == nil {
	     ^
pkg/minikube/out/out.go:123:5: QF1008: could remove embedded field "Config" from selector (staticcheck)
		b.Config.Color = nil
		  ^
pkg/minikube/proxy/proxy_test.go:67:4: QF1007: could merge conditional assignment into variable declaration (staticcheck)
			gotErr := false
			^
pkg/minikube/service/service_test.go:353:10: QF1008: could remove embedded field "ObjectMeta" from selector (staticcheck)
		if svc.ObjectMeta.Name == name {
		       ^
pkg/minikube/tests/driver_mock.go:71:7: QF1008: could remove embedded field "BaseDriver" from selector (staticcheck)
	if d.BaseDriver.IPAddress != "" {
	     ^
pkg/minikube/tests/driver_mock.go:72:12: QF1008: could remove embedded field "BaseDriver" from selector (staticcheck)
		return d.BaseDriver.IPAddress, nil
		         ^
pkg/minikube/tests/driver_mock.go:97:11: QF1008: could remove embedded field "BaseDriver" from selector (staticcheck)
	return d.BaseDriver.SSHKeyPath
	         ^
pkg/minikube/tunnel/tunnel_test.go:40:2: QF1003: could use tagged switch on pid (staticcheck)
	if pid == NotRunningPid || pid == NotRunningPid2 {
	^
pkg/perf/monitor/github.go:65:17: QF1008: could remove embedded field "Client" from selector (staticcheck)
	_, _, err := g.Client.Issues.CreateComment(g.ctx, g.owner, g.repo, pr, comment)
	               ^
pkg/perf/monitor/github.go:76:19: QF1008: could remove embedded field "Client" from selector (staticcheck)
	prs, _, err := g.Client.PullRequests.List(g.ctx, g.owner, g.repo, &github.PullRequestListOptions{})
	                 ^
pkg/perf/monitor/github.go:120:18: QF1008: could remove embedded field "Client" from selector (staticcheck)
		c, _, err := g.Client.PullRequests.ListCommits(g.ctx, g.owner, g.repo, pr, &github.ListOptions{
		               ^
pkg/perf/monitor/github.go:149:18: QF1008: could remove embedded field "Client" from selector (staticcheck)
		c, _, err := g.Client.Issues.ListComments(g.ctx, g.owner, g.repo, pr, &github.IssueListCommentsOptions{
		               ^
pkg/storage/storage_provisioner.go:107:37: QF1008: could remove embedded field "PersistentVolumeSource" from selector (staticcheck)
	if err := os.RemoveAll(volume.Spec.PersistentVolumeSource.HostPath.Path); err != nil {
	                                   ^
pkg/trace/gcp.go:52:15: QF1008: could remove embedded field "Tracer" from selector (staticcheck)
	_, span := t.Tracer.Start(t.parentCtx, name)
	             ^
pkg/util/utils_test.go:129:5: SA4032: due to the file's build constraints, runtime.GOOS will never equal "windows" (staticcheck)
	if runtime.GOOS == "windows" {
	   ^
test/integration/aaa_download_only_test.go:263:11: QF1012: Use fmt.Fprintf(...) instead of WriteString(fmt.Sprintf(...)) (staticcheck)
	_, err = f.WriteString(fmt.Sprintf("%x", sum[:]))
	         ^
test/integration/addons_test.go:1034:5: QF1001: could apply De Morgan's law (staticcheck)
	if !(DockerDriver() && amd64Platform()) {
	   ^
test/integration/helpers_test.go:301:47: QF1008: could remove embedded field "ObjectMeta" from selector (staticcheck)
	sb.WriteString(fmt.Sprintf("%q [%s] %s", pod.ObjectMeta.GetName(), pod.ObjectMeta.GetUID(), pod.Status.Phase))
	                                             ^
test/integration/helpers_test.go:349:19: QF1008: could remove embedded field "ObjectMeta" from selector (staticcheck)
			foundNames[pod.ObjectMeta.Name] = true
			               ^

```