### PR TITLE
ci: iso image Only install gcc-multilib on x86_64 arch

### DIFF
--- a/deploy/iso/minikube-iso/Dockerfile
+++ b/deploy/iso/minikube-iso/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update \
 	&& apt-get install -y apt dpkg apt-utils ca-certificates software-properties-common \
 	&& add-apt-repository -y ppa:longsleep/golang-backports \
 	&& apt-get upgrade -y \
+	&& if [ "$(uname -ms)" = "Linux x86_64" ]; then apt-get install -y gcc-multilib; fi \
 	&& apt-get install -y \
 		build-essential \
 		git \
@@ -26,7 +27,7 @@ RUN apt-get update \
 		python \
 		unzip \
 		bc \
-		gcc-multilib \
+		gcc \
 		automake \
 		libtool \
 		gnupg2 \


### PR DESCRIPTION
Use regular gcc instead on aarch64 arch

It doesn't need the i386 compatibility.

----

`make buildroot-image`

https://github.com/buildroot/buildroot/commit/3bc94471ca8a90f331366d9593630952b0e7bb10