### PR TITLE
fix: allow 1 CPU with --no-kubernetes flag

### DIFF
--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -1238,7 +1238,8 @@ func validateCPUCount(drvName string) {
 		availableCPUs = ci
 	}
 
-	if availableCPUs < 2 {
+	// Skip Kubernetes-specific CPU availability check when --no-kubernetes is set
+	if availableCPUs < 2 && !viper.GetBool(noKubernetes) {
 		if drvName == oci.Docker && runtime.GOOS == "darwin" {
 			exitIfNotForced(reason.RsrcInsufficientDarwinDockerCores, "Docker Desktop has less than 2 CPUs configured, but Kubernetes requires at least 2 to be available")
 		} else if drvName == oci.Docker && runtime.GOOS == "windows" {
@@ -1253,7 +1254,8 @@ func validateCPUCount(drvName string) {
 		return
 	}
 
-	if cpuCount < minimumCPUS {
+	// Skip minimum CPU check when --no-kubernetes is set since Kubernetes is not being run
+	if cpuCount < minimumCPUS && !viper.GetBool(noKubernetes) {
 		exitIfNotForced(reason.RsrcInsufficientCores, "Requested cpu count {{.requested_cpus}} is less than the minimum allowed of {{.minimum_cpus}}", out.V{"requested_cpus": cpuCount, "minimum_cpus": minimumCPUS})
 	}
 

--- a/test/integration/no_kubernetes_test.go
+++ b/test/integration/no_kubernetes_test.go
@@ -157,7 +157,8 @@ func validateStartNoK8S(ctx context.Context, t *testing.T, profile string) {
 	defer PostMortemLogs(t, profile)
 
 	// docs: start minikube with no Kubernetes.
-	args := append([]string{"start", "-p", profile, "--no-kubernetes", "--memory=3072", "--alsologtostderr", "-v=5"}, StartArgs()...)
+	// Use --cpus=1 to verify that the 2 CPU minimum is not enforced when --no-kubernetes is set.
+	args := append([]string{"start", "-p", profile, "--no-kubernetes", "--cpus=1", "--memory=3072", "--alsologtostderr", "-v=5"}, StartArgs()...)
 	rr, err := Run(t, exec.CommandContext(ctx, Target(), args...))
 	if err != nil {
 		t.Fatalf("failed to start minikube with args: %q : %v", rr.Command(), err)


### PR DESCRIPTION
## Summary
Skip the minimum CPU validation (requires 2 CPUs) when `--no-kubernetes` is set, since Kubernetes is not being run.

## Changes
 - Added `&& !viper.GetBool(noKubernetes)` to both CPU validation checks in `validateCPUCount()`
 - Added `--cpus=1` to existing `--no-kubernetes` integration test to verify this behavior
 
## Why
The 2 CPU minimum is a Kubernetes requirement (error messages say "Kubernetes requires at least 2"). When `--no kubernetes` is used, this requirement shouldn't apply.

Fixes #22152