### PR TITLE
Upgrade buildroot image to ubuntu:22.04

### DIFF
--- a/deploy/iso/minikube-iso/Dockerfile
+++ b/deploy/iso/minikube-iso/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 RUN apt-get update \
 	&& apt-get install -y apt dpkg apt-utils ca-certificates software-properties-common \
@@ -23,7 +23,7 @@ RUN apt-get update \
 		git \
 		wget \
 		cpio \
-		python \
+		python3 \
 		unzip \
 		bc \
 		gcc-multilib \


### PR DESCRIPTION
And change package from python to python3

* #22144

----

Ubuntu 20.04 is EOL (and like Debian 11)

Ubuntu 22.04 is more similar to Debian 12