### PR TITLE
chore: Harden dependabot go mod tidy workflow

### DIFF
--- a/.github/workflows/dependabot-gomodtidy.yml
+++ b/.github/workflows/dependabot-gomodtidy.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   dependabot-gomodtidy:
-    if: github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == 'kubernetes/minicube'
+    if: github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == 'kubernetes/minikube'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout


### PR DESCRIPTION
This is purely security hardening. As demonstrated in my test #22210, technically, a malicious actor could trigger this action.

However, pull_request.head.ref seems to always attempt to check out a branch with an identical name from kubernetes/minikube, so exploitation attempts should fail in theory.

Still, it's never bad to add additional hardening, and this check ensures the PR source repository is actually kubernetes/minikube.