### PR TITLE
test: Fix TestWriteConfig  unit test on windows

### DIFF
--- a/pkg/minikube/config/config_test.go
+++ b/pkg/minikube/config/config_test.go
@@ -143,9 +143,13 @@ func TestReadConfig(t *testing.T) {
 }
 
 func TestWriteConfig(t *testing.T) {
-	configFile, err := os.CreateTemp("/tmp", "configTest")
+	tmpDir := t.TempDir()
+	configFile, err := os.CreateTemp(tmpDir, "configTest")
 	if err != nil {
 		t.Fatalf("Error not expected but got %v", err)
+	}
+	if err := configFile.Close(); err != nil {
+		t.Fatalf("failed to close temp file: %v", err)
 	}
 
 	cfg := map[string]interface{}{
@@ -160,7 +164,6 @@ func TestWriteConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error not expected but got %v", err)
 	}
-	defer os.Remove(configFile.Name())
 
 	mkConfig, err := ReadConfig(configFile.Name())
 	if err != nil {


### PR DESCRIPTION
**What's happening**

- The test calls `os.CreateTemp("/tmp", "configTest")`. On Windows the literal path `"/tmp"` does not exist, so `CreateTemp` fails with "The system cannot find the path specified."
- `"/tmp"` is a Unix convention; on Windows we must use the OS temp directory (e.g.` C:\Users\<you>\AppData\Local\Temp`) or let Go pick it for us.

**Fix**

Use` t.TempDir()` and create the file inside that directory:

```
tmpDir := t.TempDir()
configFile, err := os.CreateTemp(tmpDir, "configTest")
```

-` t.TempDir()` creates a temp directory and Go will automatically remove it when the test ends, which is cleaner than manual `os.Remove`.

**Extra fix** 
- Close the file handle after creating it (call `configFile.Close()` or `defer configFile.Close(`)).
- If we use `t.TempDir()`  we can drop the manual defer `os.Remove(configFile.Name()`).


**Test Failures before the fix:**

```
Running tool: C:\Program Files\Go\bin\go.exe test -timeout 30s -run ^TestWriteConfig$ k8s.io/minikube/pkg/minikube/config

=== RUN   TestWriteConfig
    c:\dev\minikube\pkg\minikube\config\config_test.go:148: Error not expected but got open /tmp\configTest3204704396: The system cannot find the path specified.
--- FAIL: TestWriteConfig (0.00s)
FAIL
FAIL    k8s.io/minikube/pkg/minikube/config     3.609s
```

**Test Run with the fix:**
```
Running tool: C:\Program Files\Go\bin\go.exe test -timeout 30s -run ^TestWriteConfig$ k8s.io/minikube/pkg/minikube/config

=== RUN   TestWriteConfig
--- PASS: TestWriteConfig (0.02s)
PASS
ok      k8s.io/minikube/pkg/minikube/config     4.066s
```
