### PR TITLE
crio: verify images are deleted after "image rm"

### DIFF
--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -307,7 +307,7 @@ func (r *Containerd) SaveImage(name string, destPath string) error {
 
 // RemoveImage removes a image
 func (r *Containerd) RemoveImage(name string) error {
-	return removeCRIImage(r.Runner, name)
+	return removeCRIImage(r.Runner, name, false)
 }
 
 // TagImage tags an image in this runtime

--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -297,7 +297,7 @@ func (r *CRIO) SaveImage(name string, destPath string) error {
 
 // RemoveImage removes a image
 func (r *CRIO) RemoveImage(name string) error {
-	return removeCRIImage(r.Runner, name)
+	return removeCRIImage(r.Runner, name, true)
 }
 
 // TagImage tags an image in this runtime

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -337,7 +337,7 @@ func (r *Docker) SaveImage(name string, imagePath string) error {
 func (r *Docker) RemoveImage(name string) error {
 	klog.Infof("Removing image: %s", name)
 	if r.UseCRI {
-		return removeCRIImage(r.Runner, name)
+		return removeCRIImage(r.Runner, name, false)
 	}
 	c := exec.Command("docker", "rmi", name)
 	if _, err := r.Runner.RunCmd(c); err != nil {


### PR DESCRIPTION
To fix  TestFunctional/parallel/ImageCommands/ImageRemove 
closes https://github.com/kubernetes/minikube/issues/22242