### PR TITLE
test: Fix TestIsURLExists unit test on windows

### DIFF
--- a/cmd/minikube/cmd/config/validations_test.go
+++ b/cmd/minikube/cmd/config/validations_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package config
 
 import (
+	"net/url"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -126,20 +128,23 @@ func TestValidRuntime(t *testing.T) {
 }
 
 func TestIsURLExists(t *testing.T) {
-
 	self, err := os.Executable()
 	if err != nil {
 		t.Error(err)
 	}
 
+	u := (&url.URL{
+		Scheme: "file",
+		Path:   filepath.ToSlash(self),
+	}).String()
+
 	tests := []validationTest{
 		{
-			value:     "file://" + self,
+			value:     u,
 			shouldErr: false,
 		},
-
 		{
-			value:     "file://" + self + "/subpath-of-file",
+			value:     u + "/subpath-of-file",
 			shouldErr: true,
 		},
 	}


### PR DESCRIPTION
We are failing because the string we are constructing is not a valid RFC 8089 file URL on Windows.

**What we are generating With:**

```
self, _ := os.Executable()
value := "file://" + self
```
**Is:**
`file://C:\Users\xxxx\AppData\Local\Temp\...\config.test.exe`

**That is invalid for two reasons:**

1. Backslashes are not valid URL path separators. URLs must use `/.`
2. The Windows drive letter form requires either:

- file:///C:/Users/.../config.test.exe (local absolute path), or
- file://hostname/C:/Users/... (UNC/host form)

**Fix**: construct a valid file URL using `net/url`

Use `url.URL{Scheme: "file", Path: ...}` with a slashified absolute path.

**Why this works**

- `filepath.ToSlash(self)` converts `C:\Users\...` → `C:/Users/...`
- When you set Path on a file URL, `url.URL.String()` emits the correct triple slash form for absolute drive paths: `file:///C:/...`

**Test Failures before the fix**
```
Running tool: C:\Program Files\Go\bin\go.exe test -timeout 30s -run ^TestIsURLExists$ k8s.io/minikube/cmd/minikube/cmd/config

=== RUN   TestIsURLExists
    c:\dev\minikube\cmd\minikube\cmd\config\validations_test.go:33: file://C:\Users\xxxx\AppData\Local\Temp\go-build4203084580\b001\config.test.exe: file://C:\Users\xxxx\AppData\Local\Temp\go-build4203084580\b001\config.test.exe is not a valid URL
--- FAIL: TestIsURLExists (0.00s)
FAIL
FAIL    k8s.io/minikube/cmd/minikube/cmd/config 1.330s
```

**Test Run with the fix**
```
Running tool: C:\Program Files\Go\bin\go.exe test -timeout 30s -run ^TestIsURLExists$ k8s.io/minikube/cmd/minikube/cmd/config

=== RUN   TestIsURLExists
--- PASS: TestIsURLExists (0.00s)
PASS
ok      k8s.io/minikube/cmd/minikube/cmd/config 8.505s
```