### PR TITLE
test: Fix TestSetCurrentContext unit test on windows

### DIFF
--- a/pkg/minikube/kubeconfig/context_test.go
+++ b/pkg/minikube/kubeconfig/context_test.go
@@ -49,11 +49,14 @@ func TestDeleteContext(t *testing.T) {
 }
 
 func TestSetCurrentContext(t *testing.T) {
-	f, err := os.CreateTemp("/tmp", "kubeconfig")
+	tmpDir := t.TempDir()
+	f, err := os.CreateTemp(tmpDir, "kubeconfig")
 	if err != nil {
 		t.Fatalf("Error not expected but got %v", err)
 	}
-	defer os.Remove(f.Name())
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close tmp file: %v", err)
+	}
 
 	kcfg, err := readOrNew(f.Name())
 	if err != nil {


### PR DESCRIPTION
**Cause**: The test calls `os.CreateTemp("/tmp", "kubeconfig")`. On Windows the directory `"/tmp"` does not exist, so `os.CreateTemp` fails with "The system cannot find the path specified." That is why the test errors at the create-temp step.
**Why it showed that path**: Passing a literal `"/tmp"` (a Unix-style path) leads to an invalid Windows path like` /tmp\kubeconfig...` and `CreateFile `fails.

**Fix**
Use the Go test helper `t.TempDir()` (works cross-platform and is auto-cleaned) and create the temp file inside it. 

**Test Failures before the fix**
```
Running tool: C:\Program Files\Go\bin\go.exe test -timeout 30s -run ^TestSetCurrentContext$ k8s.io/minikube/pkg/minikube/kubeconfig

=== RUN   TestSetCurrentContext
    c:\dev\minikube\pkg\minikube\kubeconfig\context_test.go:54: Error not expected but got open /tmp\kubeconfig1137175331: The system cannot find the path specified.
--- FAIL: TestSetCurrentContext (0.00s)
FAIL
FAIL    k8s.io/minikube/pkg/minikube/kubeconfig 2.859s

Running tool: C:\Program Files\Go\bin\go.exe test -timeout 30s -run ^TestSetCurrentContext$ k8s.io/minikube/pkg/minikube/kubeconfig

```
**Test Run with the fix**
```
=== RUN   TestSetCurrentContext
I1220 02:18:51.812841   20948 lock.go:35] WriteFile acquiring C:\Users\bosira\AppData\Local\Temp\TestSetCurrentContext2595305691\001\kubeconfig2268584484: {Name:mk8ba14d6ba19d493b5cc534e3b9502fab28ba6d Clock:{} Delay:500ms Timeout:1m0s Cancel:<nil>}
I1220 02:18:51.828720   20948 lock.go:35] WriteFile acquiring C:\Users\bosira\AppData\Local\Temp\TestSetCurrentContext2595305691\001\kubeconfig2268584484: {Name:mk8ba14d6ba19d493b5cc534e3b9502fab28ba6d Clock:{} Delay:500ms Timeout:1m0s Cancel:<nil>}
--- PASS: TestSetCurrentContext (0.02s)
PASS
ok      k8s.io/minikube/pkg/minikube/kubeconfig 3.040s
```