### PR TITLE
build: Don't need to build host-python3 package iso

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ KIC_VERSION ?= $(shell grep -E "Version =" pkg/drivers/kic/types.go | cut -d \" 
 HUGO_VERSION ?= $(shell grep -E "HUGO_VERSION = \"" netlify.toml | cut -d \" -f2)
 
 # Default to .0 for higher cache hit rates, as build increments typically don't require new ISO versions
-ISO_VERSION ?= v1.37.0-1765965980-22186
+ISO_VERSION ?= v1.37.0-1766254259-22261
 
 # Dashes are valid in semver, but not Linux packaging. Use ~ to delimit alpha/beta
 DEB_VERSION ?= $(subst -,~,$(RAW_VERSION))

--- a/pkg/minikube/download/iso.go
+++ b/pkg/minikube/download/iso.go
@@ -41,7 +41,7 @@ const fileScheme = "file"
 // DefaultISOURLs returns a list of ISO URL's to consult by default, in priority order
 func DefaultISOURLs() []string {
 	v := version.GetISOVersion()
-	isoBucket := "minikube-builds/iso/22186"
+	isoBucket := "minikube-builds/iso/22261"
 
 	return []string{
 		fmt.Sprintf("https://storage.googleapis.com/%s/minikube-%s-%s.iso", isoBucket, v, runtime.GOARCH),


### PR DESCRIPTION
It was a workaround for the htop package

But it is not needed, since version 3.0.3

Fixes #22219