### PR TITLE
test: Fix TestDownload unit test on windows

### DIFF
--- a/pkg/minikube/download/download.go
+++ b/pkg/minikube/download/download.go
@@ -56,12 +56,18 @@ func SetAliyunMirror() {
 
 // CreateDstDownloadMock is the default mock implementation of download.
 func CreateDstDownloadMock(_, dst string) error {
-	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 		return errors.Wrap(err, "mkdir")
 	}
 
-	_, err := os.Create(dst)
-	return err
+	f, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return nil
 }
 
 // download is a well-configured atomic download function

--- a/pkg/minikube/download/preload.go
+++ b/pkg/minikube/download/preload.go
@@ -280,6 +280,9 @@ func Preload(k8sVersion, containerRuntime, driverName string) error {
 			return errors.Wrap(err, "tempfile")
 		}
 		targetPath = tmp.Name()
+		if err := tmp.Close(); err != nil {
+			return errors.Wrap(err, "tempfile close")
+		}
 	} else if checksum != nil { // add URL parameter for go-getter to automatically verify the checksum
 		url = addChecksumToURL(url, source, checksum)
 	}


### PR DESCRIPTION
**The following failing tests are fixed by this change**: 

1. [func TestDownload(t *testing.T)](https://github.com/kubernetes/minikube/blob/f6e9269466b163855eb96770d8773b7051bcafa5/pkg/minikube/download/download_test.go#L32)
2. [TestCacheBinariesForBootstrapper](https://github.com/kubernetes/minikube/blob/f6e9269466b163855eb96770d8773b7051bcafa5/pkg/minikube/machine/cache_binaries_test.go#L27)
3. [TestExcludedBinariesNotDownloaded](https://github.com/kubernetes/minikube/blob/f6e9269466b163855eb96770d8773b7051bcafa5/pkg/minikube/machine/cache_binaries_test.go#L62)

**Symptom**: Parallel download tests on Windows fail with rename/unlink errors like "The process cannot access the file because it is being used by another process." Test cleanup `(TempDir RemoveAll)` and `os.Rename` fail intermittently.

**Root cause**: tests (and the mock downloader) left open file handles on temporary files:

- `CreateDstDownloadMock `used `os.Create(dst)` and returned without closing the created file.
- `Preload()` created a temp file with `os.CreateTemp(...)` and assigned `targetPath = tmp.Name(`) but did not close `tmp`.
- On Windows an open handle prevents `os.Rename / os.Remove / `unlink operations, causing the observed failures.

**Fix**: close the files immediately after creation so no handle is left open:

- Close the mock-created file in `CreateDstDownloadMock` (in download.go) explicitly with `f.Close()`.
- Close the `os.CreateTemp` result in `Preload()` (in preload.go) right after getting` tmp.Name()`.

Windows requires file handles to be closed before rename/unlink; closing releases locks so `os.Rename` and test cleanup succeed.

**Test Failures before the fix**
```
Running tool: C:\Program Files\Go\bin\go.exe test -timeout 30s -run ^TestDownload$ k8s.io/minikube/pkg/minikube/download

=== RUN TestDownload
=== RUN TestDownload/BinaryDownloadPreventsMultipleDownload
I1220 19:36:12.309674 6620 download.go:99] Mock download: https://dl.k8s.io/release/v1.20.2/bin/linux/amd64/kubectl?checksum=file:https://dl.k8s.io/release/v1.20.2/bin/linux/amd64/kubectl.sha256 -> C:\Users\bosira\AppData\Local\Temp\TestDownloadBinaryDownloadPreventsMultipleDownload4264195978\001.minikube\cache\linux\amd64\v1.20.2/kubectl
W1220 19:36:12.407941 6620 out.go:248] [unset outFile]: * Another minikube instance is downloading dependencies...
I1220 19:36:12.511606 6620 binary.go:80] Not caching binary, using https://dl.k8s.io/release/v1.20.2/bin/linux/amd64/kubectl?checksum=file:https://dl.k8s.io/release/v1.20.2/bin/linux/amd64/kubectl.sha256
c:\dev\minikube\pkg\minikube\download\testing.go:1369: TempDir RemoveAll cleanup: unlinkat C:\Users\bosira\AppData\Local\Temp\TestDownloadBinaryDownloadPreventsMultipleDownload4264195978\001.minikube\cache\linux\amd64\v1.20.2\kubectl: The process cannot access the file because it is being used by another process.
--- FAIL: TestDownload/BinaryDownloadPreventsMultipleDownload (1.92s)
=== RUN TestDownload/PreloadDownloadPreventsMultipleDownload
W1220 19:36:14.233418 6620 out.go:176] [unset outFile]: * Downloading Kubernetes v1.34.3 preload ...
I1220 19:36:14.233418 6620 preload.go:269] Downloading preload from
W1220 19:36:14.233418 6620 preload.go:276] No checksum for preloaded tarball for k8s version v1.34.3: unknown preload source:
I1220 19:36:14.234269 6620 download.go:99] Mock download: -> C:\Users\bosira\AppData\Local\Temp\TestDownloadPreloadDownloadPreventsMultipleDownload1528527276\001.minikube\cache\preloaded-tarball\preloaded-images-k8s-v18-v1.34.3-docker-overlay2-amd64.tar.lz4.2630682673
W1220 19:36:14.333095 6620 out.go:248] [unset outFile]: * Another minikube instance is downloading dependencies...
I1220 19:36:14.434410 6620 preload.go:293] renaming tempfile to preloaded-images-k8s-v18-v1.34.3-docker-overlay2-amd64.tar.lz4 ...
c:\dev\minikube\pkg\minikube\download\download_test.go:132: Failed to download preload: rename C:\Users\bosira\AppData\Local\Temp\TestDownloadPreloadDownloadPreventsMultipleDownload1528527276\001.minikube\cache\preloaded-tarball\preloaded-images-k8s-v18-v1.34.3-docker-overlay2-amd64.tar.lz4.2630682673 C:\Users\bosira\AppData\Local\Temp\TestDownloadPreloadDownloadPreventsMultipleDownload1528527276\001.minikube\cache\preloaded-tarball\preloaded-images-k8s-v18-v1.34.3-docker-overlay2-amd64.tar.lz4: The process cannot access the file because it is being used by another process.
rename
k8s.io/minikube/pkg/minikube/download.Preload
c:/dev/minikube/pkg/minikube/download/preload.go:296
k8s.io/minikube/pkg/minikube/download.testPreloadDownloadPreventsMultipleDownload.func4
c:/dev/minikube/pkg/minikube/download/download_test.go:131
runtime.goexit
C:/Users/bosira/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.windows-amd64/src/runtime/asm_amd64.s:1693 (may be ok)
I1220 19:36:14.434966 6620 preload.go:251] Found C:\Users\bosira\AppData\Local\Temp\TestDownloadPreloadDownloadPreventsMultipleDownload1528527276\001.minikube\cache\preloaded-tarball\preloaded-images-k8s-v18-v1.34.3-docker-overlay2-amd64.tar.lz4 in cache, skipping download
c:\dev\minikube\pkg\minikube\download\testing.go:1369: TempDir RemoveAll cleanup: unlinkat C:\Users\bosira\AppData\Local\Temp\TestDownloadPreloadDownloadPreventsMultipleDownload1528527276\001.minikube\cache\preloaded-tarball\preloaded-images-k8s-v18-v1.34.3-docker-overlay2-amd64.tar.lz4.2630682673: The process cannot access the file because it is being used by another process.
--- FAIL: TestDownload/PreloadDownloadPreventsMultipleDownload (2.09s)
=== RUN TestDownload/ImageToCache
I1220 19:36:16.324331 6620 localpath.go:148] windows sanitize: C:\Users\bosira\AppData\Local\Temp\TestDownloadImageToCache1843866436\001.minikube\cache\kic\amd64\testimg.tar -> C:\Users\bosira\AppData\Local\Temp\TestDownloadImageToCache1843866436\001.minikube\cache\kic\amd64\testimg.tar
I1220 19:36:16.324331 6620 localpath.go:148] windows sanitize: C:\Users\bosira\AppData\Local\Temp\TestDownloadImageToCache1843866436\001.minikube\cache\kic\amd64\testimg.tar -> C:\Users\bosira\AppData\Local\Temp\TestDownloadImageToCache1843866436\001.minikube\cache\kic\amd64\testimg.tar
I1220 19:36:16.325614 6620 image.go:146] Mock download: testimg -> C:\Users\bosira\AppData\Local\Temp\TestDownloadImageToCache1843866436\001.minikube\cache\kic\amd64\testimg.tar
W1220 19:36:16.424793 6620 out.go:248] [unset outFile]: * Another minikube instance is downloading dependencies...
I1220 19:36:16.527188 6620 image.go:137] testimg exists in cache, skipping pull
c:\dev\minikube\pkg\minikube\download\testing.go:1369: TempDir RemoveAll cleanup: unlinkat C:\Users\bosira\AppData\Local\Temp\TestDownloadImageToCache1843866436\001.minikube\cache\kic\amd64\testimg.tar: The process cannot access the file because it is being used by another process.
--- FAIL: TestDownload/ImageToCache (1.94s)
=== RUN TestDownload/PreloadNotExists
I1220 19:36:18.260501 6620 preload.go:257] Preloaded tarball for k8s version v1.34.3 does not exist
--- PASS: TestDownload/PreloadNotExists (0.01s)
=== RUN TestDownload/PreloadExistsCaching
I1220 19:36:18.266022 6620 preload.go:188] Checking if preload exists for k8s version v1 and runtime c1
I1220 19:36:18.266022 6620 preload.go:188] Checking if preload exists for k8s version v1 and runtime c1
I1220 19:36:18.266022 6620 preload.go:188] Checking if preload exists for k8s version v2 and runtime c1
I1220 19:36:18.266022 6620 preload.go:188] Checking if preload exists for k8s version v2 and runtime c2
I1220 19:36:18.266022 6620 preload.go:188] Checking if preload exists for k8s version v2 and runtime c2
--- PASS: TestDownload/PreloadExistsCaching (0.01s)
=== RUN TestDownload/PreloadWithCachedSizeZero
W1220 19:36:18.272901 6620 out.go:176] [unset outFile]: * Downloading Kubernetes v1.34.3 preload ...
I1220 19:36:18.272901 6620 preload.go:269] Downloading preload from
W1220 19:36:18.272901 6620 preload.go:276] No checksum for preloaded tarball for k8s version v1.34.3: unknown preload source:
I1220 19:36:18.273507 6620 download.go:99] Mock download: -> C:\Users\bosira\AppData\Local\Temp\TestDownloadPreloadWithCachedSizeZero3738422357\001.minikube\cache\preloaded-tarball\preloaded-images-k8s-v18-v1.34.3-docker-overlay2-amd64.tar.lz4.2914613882
I1220 19:36:18.474524 6620 preload.go:293] renaming tempfile to preloaded-images-k8s-v18-v1.34.3-docker-overlay2-amd64.tar.lz4 ...
c:\dev\minikube\pkg\minikube\download\download_test.go:271: Expected no error with cached preload of size zero
c:\dev\minikube\pkg\minikube\download\testing.go:1369: TempDir RemoveAll cleanup: unlinkat C:\Users\bosira\AppData\Local\Temp\TestDownloadPreloadWithCachedSizeZero3738422357\001.minikube\cache\preloaded-tarball\preloaded-images-k8s-v18-v1.34.3-docker-overlay2-amd64.tar.lz4.2914613882: The process cannot access the file because it is being used by another process.
--- FAIL: TestDownload/PreloadWithCachedSizeZero (1.76s)
--- FAIL: TestDownload (7.73s)
FAIL
FAIL k8s.io/minikube/pkg/minikube/download 13.823s
```

**Test Run with the fix**
```
Running tool: C:\Program Files\Go\bin\go.exe test -timeout 30s -run ^TestDownload$ k8s.io/minikube/pkg/minikube/download

=== RUN   TestDownload
=== RUN   TestDownload/BinaryDownloadPreventsMultipleDownload
I1220 19:57:46.324196    5984 download.go:105] Mock download: https://dl.k8s.io/release/v1.20.2/bin/linux/amd64/kubectl?checksum=file:https://dl.k8s.io/release/v1.20.2/bin/linux/amd64/kubectl.sha256 -> C:\Users\bosira\AppData\Local\Temp\TestDownloadBinaryDownloadPreventsMultipleDownload554470654\001\.minikube\cache\linux\amd64\v1.20.2/kubectl
W1220 19:57:46.422597    5984 out.go:248] [unset outFile]: * Another minikube instance is downloading dependencies...
I1220 19:57:46.525583    5984 binary.go:80] Not caching binary, using https://dl.k8s.io/release/v1.20.2/bin/linux/amd64/kubectl?checksum=file:https://dl.k8s.io/release/v1.20.2/bin/linux/amd64/kubectl.sha256
--- PASS: TestDownload/BinaryDownloadPreventsMultipleDownload (0.21s)
=== RUN   TestDownload/PreloadDownloadPreventsMultipleDownload
W1220 19:57:46.533718    5984 out.go:176] [unset outFile]: * Downloading Kubernetes v1.34.3 preload ...
I1220 19:57:46.533718    5984 preload.go:269] Downloading preload from
W1220 19:57:46.533718    5984 preload.go:276] No checksum for preloaded tarball for k8s version v1.34.3: unknown preload source:
I1220 19:57:46.534903    5984 download.go:105] Mock download:  -> C:\Users\bosira\AppData\Local\Temp\TestDownloadPreloadDownloadPreventsMultipleDownload940084673\001\.minikube\cache\preloaded-tarball\preloaded-images-k8s-v18-v1.34.3-docker-overlay2-amd64.tar.lz4.345412730
W1220 19:57:46.634176    5984 out.go:248] [unset outFile]: * Another minikube instance is downloading dependencies...
I1220 19:57:46.740124    5984 preload.go:296] renaming tempfile to preloaded-images-k8s-v18-v1.34.3-docker-overlay2-amd64.tar.lz4 ...
I1220 19:57:46.785254    5984 preload.go:251] Found C:\Users\bosira\AppData\Local\Temp\TestDownloadPreloadDownloadPreventsMultipleDownload940084673\001\.minikube\cache\preloaded-tarball\preloaded-images-k8s-v18-v1.34.3-docker-overlay2-amd64.tar.lz4 in cache, skipping download
--- PASS: TestDownload/PreloadDownloadPreventsMultipleDownload (0.26s)
=== RUN   TestDownload/ImageToCache
I1220 19:57:46.797505    5984 localpath.go:148] windows sanitize: C:\Users\bosira\AppData\Local\Temp\TestDownloadImageToCache3959328792\001\.minikube\cache\kic\amd64\testimg.tar -> C:\Users\bosira\AppData\Local\Temp\TestDownloadImageToCache3959328792\001\.minikube\cache\kic\amd64\testimg.tar
I1220 19:57:46.797505    5984 localpath.go:148] windows sanitize: C:\Users\bosira\AppData\Local\Temp\TestDownloadImageToCache3959328792\001\.minikube\cache\kic\amd64\testimg.tar -> C:\Users\bosira\AppData\Local\Temp\TestDownloadImageToCache3959328792\001\.minikube\cache\kic\amd64\testimg.tar
I1220 19:57:46.799337    5984 image.go:146] Mock download: testimg -> C:\Users\bosira\AppData\Local\Temp\TestDownloadImageToCache3959328792\001\.minikube\cache\kic\amd64\testimg.tar
W1220 19:57:46.897737    5984 out.go:248] [unset outFile]: * Another minikube instance is downloading dependencies...
I1220 19:57:47.001186    5984 image.go:137] testimg exists in cache, skipping pull
--- PASS: TestDownload/ImageToCache (0.21s)
=== RUN   TestDownload/PreloadNotExists
I1220 19:57:47.010860    5984 preload.go:257] Preloaded tarball for k8s version v1.34.3 does not exist
--- PASS: TestDownload/PreloadNotExists (0.01s)
=== RUN   TestDownload/PreloadExistsCaching
I1220 19:57:47.019854    5984 preload.go:188] Checking if preload exists for k8s version v1 and runtime c1
I1220 19:57:47.019854    5984 preload.go:188] Checking if preload exists for k8s version v1 and runtime c1
I1220 19:57:47.019854    5984 preload.go:188] Checking if preload exists for k8s version v2 and runtime c1
I1220 19:57:47.019854    5984 preload.go:188] Checking if preload exists for k8s version v2 and runtime c2
I1220 19:57:47.019854    5984 preload.go:188] Checking if preload exists for k8s version v2 and runtime c2
--- PASS: TestDownload/PreloadExistsCaching (0.01s)
=== RUN   TestDownload/PreloadWithCachedSizeZero
W1220 19:57:47.027388    5984 out.go:176] [unset outFile]: * Downloading Kubernetes v1.34.3 preload ...
I1220 19:57:47.027388    5984 preload.go:269] Downloading preload from
W1220 19:57:47.027388    5984 preload.go:276] No checksum for preloaded tarball for k8s version v1.34.3: unknown preload source:
I1220 19:57:47.029288    5984 download.go:105] Mock download:  -> C:\Users\bosira\AppData\Local\Temp\TestDownloadPreloadWithCachedSizeZero2168446761\001\.minikube\cache\preloaded-tarball\preloaded-images-k8s-v18-v1.34.3-docker-overlay2-amd64.tar.lz4.27498233
I1220 19:57:47.231794    5984 preload.go:296] renaming tempfile to preloaded-images-k8s-v18-v1.34.3-docker-overlay2-amd64.tar.lz4 ...
--- PASS: TestDownload/PreloadWithCachedSizeZero (0.22s)
--- PASS: TestDownload (0.92s)
PASS
ok      k8s.io/minikube/pkg/minikube/download   6.488s

```

**Test Failures before the fix**
```
Running tool: C:\Program Files\Go\bin\go.exe test -timeout 30s -run ^TestExcludedBinariesNotDownloaded$ k8s.io/minikube/pkg/minikube/machine

=== RUN   TestExcludedBinariesNotDownloaded
I1220 21:09:57.044127    4632 download.go:99] Mock download: https://dl.k8s.io/release/v1.16.0/bin/linux/amd64/kubeadm?checksum=file:https://dl.k8s.io/release/v1.16.0/bin/linux/amd64/kubeadm.sha1 -> C:\Users\bosira\AppData\Local\Temp\TestExcludedBinariesNotDownloaded939290441\001\.minikube\cache\linux\amd64\v1.16.0/kubeadm
I1220 21:09:57.044127    4632 download.go:99] Mock download: https://dl.k8s.io/release/v1.16.0/bin/linux/amd64/kubectl?checksum=file:https://dl.k8s.io/release/v1.16.0/bin/linux/amd64/kubectl.sha1 -> C:\Users\bosira\AppData\Local\Temp\TestExcludedBinariesNotDownloaded939290441\001\.minikube\cache\linux\amd64\v1.16.0/kubectl
    c:\dev\minikube\pkg\minikube\machine\testing.go:1369: TempDir RemoveAll cleanup: unlinkat C:\Users\bosira\AppData\Local\Temp\TestExcludedBinariesNotDownloaded939290441\001\.minikube\cache\linux\amd64\v1.16.0\kubeadm: The process cannot access the file because it is being used by another process.
--- FAIL: TestExcludedBinariesNotDownloaded (1.96s)
FAIL
FAIL    k8s.io/minikube/pkg/minikube/machine    4.192s
```

**Test Run with the fix**
```
Running tool: C:\Program Files\Go\bin\go.exe test -timeout 30s -run ^TestExcludedBinariesNotDownloaded$ k8s.io/minikube/pkg/minikube/machine

=== RUN   TestExcludedBinariesNotDownloaded
I1220 21:06:13.008553   25232 download.go:105] Mock download: https://dl.k8s.io/release/v1.16.0/bin/linux/amd64/kubeadm?checksum=file:https://dl.k8s.io/release/v1.16.0/bin/linux/amd64/kubeadm.sha1 -> C:\Users\bosira\AppData\Local\Temp\TestExcludedBinariesNotDownloaded1471332524\001\.minikube\cache\linux\amd64\v1.16.0/kubeadm
I1220 21:06:13.008553   25232 download.go:105] Mock download: https://dl.k8s.io/release/v1.16.0/bin/linux/amd64/kubectl?checksum=file:https://dl.k8s.io/release/v1.16.0/bin/linux/amd64/kubectl.sha1 -> C:\Users\bosira\AppData\Local\Temp\TestExcludedBinariesNotDownloaded1471332524\001\.minikube\cache\linux\amd64\v1.16.0/kubectl
--- PASS: TestExcludedBinariesNotDownloaded (0.01s)
PASS
ok      k8s.io/minikube/pkg/minikube/machine    2.760s
```


**Test Failures before the fix**
```
Running tool: C:\Program Files\Go\bin\go.exe test -timeout 30s -run ^TestCacheBinariesForBootstrapper$ k8s.io/minikube/pkg/minikube/machine

=== RUN   TestCacheBinariesForBootstrapper/v1.16.0
I1220 21:09:09.145420    8264 download.go:99] Mock download: https://dl.k8s.io/release/v1.16.0/bin/linux/amd64/kubectl?checksum=file:https://dl.k8s.io/release/v1.16.0/bin/linux/amd64/kubectl.sha1 -> C:\Users\bosira\AppData\Local\Temp\TestCacheBinariesForBootstrapper3475047084\001\.minikube\cache\linux\amd64\v1.16.0/kubectl
I1220 21:09:09.146515    8264 download.go:99] Mock download: https://dl.k8s.io/release/v1.16.0/bin/linux/amd64/kubelet?checksum=file:https://dl.k8s.io/release/v1.16.0/bin/linux/amd64/kubelet.sha1 -> C:\Users\bosira\AppData\Local\Temp\TestCacheBinariesForBootstrapper3475047084\001\.minikube\cache\linux\amd64\v1.16.0/kubelet
I1220 21:09:09.146515    8264 download.go:99] Mock download: https://dl.k8s.io/release/v1.16.0/bin/linux/amd64/kubeadm?checksum=file:https://dl.k8s.io/release/v1.16.0/bin/linux/amd64/kubeadm.sha1 -> C:\Users\bosira\AppData\Local\Temp\TestCacheBinariesForBootstrapper3475047084\001\.minikube\cache\linux\amd64\v1.16.0/kubeadm
--- PASS: TestCacheBinariesForBootstrapper/v1.16.0 (0.01s)
=== RUN   TestCacheBinariesForBootstrapper/invalid_version
--- PASS: TestCacheBinariesForBootstrapper/invalid_version (0.00s)
    c:\dev\minikube\pkg\minikube\machine\testing.go:1369: TempDir RemoveAll cleanup: unlinkat C:\Users\bosira\AppData\Local\Temp\TestCacheBinariesForBootstrapper3475047084\001\.minikube\cache\linux\amd64\v1.16.0\kubeadm: The process cannot access the file because it is being used by another process.
--- FAIL: TestCacheBinariesForBootstrapper (1.97s)
FAIL
FAIL    k8s.io/minikube/pkg/minikube/machine    5.174s
```


**Test Run with the fix**
```
Running tool: C:\Program Files\Go\bin\go.exe test -timeout 30s -run ^TestCacheBinariesForBootstrapper$ k8s.io/minikube/pkg/minikube/machine

=== RUN   TestCacheBinariesForBootstrapper
=== RUN   TestCacheBinariesForBootstrapper/v1.16.0
I1220 21:04:03.546491   22404 download.go:105] Mock download: https://dl.k8s.io/release/v1.16.0/bin/linux/amd64/kubelet?checksum=file:https://dl.k8s.io/release/v1.16.0/bin/linux/amd64/kubelet.sha1 -> C:\Users\bosira\AppData\Local\Temp\TestCacheBinariesForBootstrapper684032382\001\.minikube\cache\linux\amd64\v1.16.0/kubelet
I1220 21:04:03.546491   22404 download.go:105] Mock download: https://dl.k8s.io/release/v1.16.0/bin/linux/amd64/kubectl?checksum=file:https://dl.k8s.io/release/v1.16.0/bin/linux/amd64/kubectl.sha1 -> C:\Users\bosira\AppData\Local\Temp\TestCacheBinariesForBootstrapper684032382\001\.minikube\cache\linux\amd64\v1.16.0/kubectl
I1220 21:04:03.546491   22404 download.go:105] Mock download: https://dl.k8s.io/release/v1.16.0/bin/linux/amd64/kubeadm?checksum=file:https://dl.k8s.io/release/v1.16.0/bin/linux/amd64/kubeadm.sha1 -> C:\Users\bosira\AppData\Local\Temp\TestCacheBinariesForBootstrapper684032382\001\.minikube\cache\linux\amd64\v1.16.0/kubeadm
--- PASS: TestCacheBinariesForBootstrapper/v1.16.0 (0.01s)
=== RUN   TestCacheBinariesForBootstrapper/invalid_version
--- PASS: TestCacheBinariesForBootstrapper/invalid_version (0.00s)
--- PASS: TestCacheBinariesForBootstrapper (0.01s)
PASS
ok      k8s.io/minikube/pkg/minikube/machine    (cached)
```