### PR TITLE
chore: remove unused parseLines helper from Hyper-V Powershell file

### DIFF
--- a/pkg/minikube/registry/drvs/hyperv/powershell.go
+++ b/pkg/minikube/registry/drvs/hyperv/powershell.go
@@ -19,7 +19,6 @@ limitations under the License.
 package hyperv
 
 import (
-	"bufio"
 	"bytes"
 	"os/exec"
 	"strings"
@@ -53,18 +52,4 @@ func cmdOut(args ...string) (string, error) {
 func cmd(args ...string) error {
 	_, err := cmdOut(args...)
 	return err
-}
-
-func parseLines(stdout string) []string {
-	var resp []string
-
-	s := bufio.NewScanner(strings.NewReader(stdout))
-	for s.Scan() {
-		resp = append(resp, s.Text())
-	}
-	if err := s.Err(); err != nil {
-		klog.Warningf("failed to read stdout: %v", err)
-	}
-
-	return resp
 }


### PR DESCRIPTION
parseLines is not used anywhere, we can remove it for now

<img width="769" height="326" alt="parseLines" src="https://github.com/user-attachments/assets/4f43664c-9e54-4078-8a15-687c01dea33c" />


