### PR TITLE
site: remove unused users mailing list from community page

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -134,12 +134,6 @@ no = 'Sorry to hear that. Please <a href="https://github.com/kubernetes/minikube
     desc = "Use this invitation link to join Kubernetes Slack workspace"
 
 [[params.links.user]]
-	name = "minikube-users mailing list"
-	url = "https://groups.google.com/forum/#!forum/minikube-users"
-	icon = "fas fa-envelope"
-	desc = "Interact with the minikube users here"
-
-[[params.links.user]]
 	name = "twitter"
 	url = "https://twitter.com/minikube_dev"
 	icon = "fab fa-twitter"


### PR DESCRIPTION
<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
This mailing list is no longer used so the linked is being removed from the website.

Before:

<img width="839" height="830" alt="Screenshot 2025-12-21 at 10 40 43 PM" src="https://github.com/user-attachments/assets/35975bfc-bf7b-4177-9e75-341e6acb58c4" />

After:

<img width="821" height="829" alt="Screenshot 2025-12-21 at 10 41 20 PM" src="https://github.com/user-attachments/assets/9ef2cce5-6987-4b51-8541-7daac8c8ccb6" />
