### PR TITLE
VM: Enable cgroup v2 by using "systemd cgroup driver"  for Kubernetes…

### DIFF
--- a/pkg/minikube/node/start.go
+++ b/pkg/minikube/node/start.go
@@ -508,8 +508,12 @@ func cgroupDriver(cc config.ClusterConfig) string {
 		return constants.SystemdCgroupDriver
 	}
 
-	// vm driver uses iso that boots with cgroupfs cgroup driver by default atm (keep in sync!)
+	// VM driver supports both cgroup v1 and v2.
+	// On systemd-based systems (like Minikube ISO), systemd manages the single unified cgroup v2 hierarchy.
+	// Using cgroupfs with v2 would cause conflicts as two entities (systemd and runtime) try to manage the same hierarchy.
+	// Therefore, we default to the systemd driver for v2 to ensure stability and avoid conflicts.
 	if driver.IsVM(cc.Driver) {
+		// TODO, if system doesnt support cgroup v2, then use cgroupfs #22321
 		if ver, err := util.ParseKubernetesVersion(cc.KubernetesConfig.KubernetesVersion); err == nil {
 			if ver.GTE(semver.MustParse("1.22.0")) {
 				klog.Infof("Kubernetes %s+ detected, using %q cgroup driver", ver.String(), constants.SystemdCgroupDriver)


### PR DESCRIPTION
## Before this PR
only VM drivers were using cgroup v1
appearantly cgroup v2 delegates operates under systemd, so to enable cgroup v2 we need systemd cgroup driver
```
# ------------------------------
# Checking Containerd configs
# ------------------------------
$ sudo crictl info | grep SystemdCgroup
            "SystemdCgroup": false
$ grep SystemdCgroup /etc/containerd/config.toml
            SystemdCgroup = false
```

# After this PR
```
$ stat -f -c %T /sys/fs/cgroup
cgroup2fs
$ sudo crictl info | grep SystemdCgroup
            "SystemdCgroup": true
$ grep SystemdCgroup /etc/containerd/config.toml
            SystemdCgroup = true
```
https://github.com/kubernetes/minikube/issues/22318



### odd things to to decide in the future
we are still deciding "func cgroupVersion() string {
return "v1"
" for all non-linux but that gets overwritten later... we might need to just assume cgroup v2 ? but that should be a separete PR and needs testing with macos and windows

```
pkg/minikube/detect/detect_nonlinux.go
// cgroupVersion returns cgroups v1 for non-linux OS host machine (where minikube runs).
func cgroupVersion() string {
return "v1"
}
```