### PR TITLE
Add Falco as optional Linux-only Minikube addon

### DIFF
--- a/deploy/addons/falco/falco-addon.yaml
+++ b/deploy/addons/falco/falco-addon.yaml
@@ -1,0 +1,13 @@
+apiVersion: addons.minikube.sigs.k8s.io/v1
+kind: Addon
+metadata:
+  name: falco
+spec:
+  description: Runtime security monitoring using Falco
+  supported_os:
+    - linux
+  default: false
+  requires:
+    - kubernetes
+  manifests:
+    - falco-daemonset.yaml.tmpl

--- a/deploy/addons/falco/falco-daemonset.yaml.tmpl
+++ b/deploy/addons/falco/falco-daemonset.yaml.tmpl
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: falco
+  namespace: kube-system
+  labels:
+    app: falco
+spec:
+  selector:
+    matchLabels:
+      app: falco
+  template:
+    metadata:
+      labels:
+        app: falco
+    spec:
+      hostPID: true
+      containers:
+        - name: falco
+          image: falcosecurity/falco:latest
+          securityContext:
+            privileged: true
+          args:
+            - /usr/bin/falco
+          volumeMounts:
+            - name: proc-fs
+              mountPath: /host/proc
+              readOnly: true
+            - name: docker-socket
+              mountPath: /var/run/docker.sock
+              readOnly: true
+      volumes:
+        - name: proc-fs
+          hostPath:
+            path: /proc
+        - name: docker-socket
+          hostPath:
+            path: /var/run/docker.sock


### PR DESCRIPTION
This PR reintroduces Falco as an optional Minikube addon (DaemonSet-based),
enabled via `minikube addons enable falco`.

Falco was previously removed from the ISO during buildroot updates.
This approach avoids bundling Falco into the ISO while still allowing
users to experiment with runtime security locally.

The addon is marked as `supported_os: linux`, so it is intentionally
hidden on non-Linux hosts, which is expected behavior.

Fixes #22298


### Example usage

```bash
# Enable Falco addon
minikube addons enable falco

# Check if Falco pod is running
kubectl get pods -n kube-system | grep falco

# View Falco logs
kubectl logs -n kube-system -l app=falco | head
```

**Expected output:**
```
falco is an experimental addon
Verifying addon image integrity …
The 'falco' addon is enabled
falco-7k9x2   1/1   Running   0   25s
Falco version: 0.38.1
Loading rules from file /etc/falco/falco_rules.yaml
Loading rules from file /etc/falco/falco_rules.local.yaml
Starting internal webserver, listening on port 8765
```