### PR TITLE
build: add cmake dependency to ISO build script

### DIFF
--- a/hack/jenkins/build_iso.sh
+++ b/hack/jenkins/build_iso.sh
@@ -38,6 +38,13 @@ source ./hack/jenkins/installers/check_install_linux_crons.sh
 sudo apt-get update
 sudo apt-get -y install build-essential unzip rsync bc python3 p7zip-full cmake
 
+# Log Cmake version
+CMAKE_VERSION=$(cmake --version | head -n1 | awk '{print $3}')
+echo "Start of ISO build: CMake version: $CMAKE_VERSION"
+if dpkg --compare-versions "$CMAKE_VERSION" lt "3.20"; then
+	echo "WARNING: CMake version $CMAKE_VERSION is less than 3.20. this will cause a slower build due to rebuidling cmake ..."
+fi
+
 # Let's make sure we have the newest ISO reference
 curl -L https://github.com/kubernetes/minikube/raw/master/Makefile --output Makefile-head
 # ISO tags are of the form VERSION-TIMESTAMP-PR, so this grep finds that TIMESTAMP in the middle


### PR DESCRIPTION
building cmake takes 17 minutes on each iso build
and if the host already has cmake, buildroot will use it and will skip rebuilding it
I checked manually our machines did not have cmake installed on them, this "should' make building iso 17m faster 

https://github.com/kubernetes/minikube/issues/22336#issue-3764385302