### PR TITLE
wip: Remove depdendency on crictl for listing containers

### DIFF
--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -491,17 +491,17 @@ func (r *Containerd) KubeletOptions() map[string]string {
 
 // ListContainers returns a list of managed by this container runtime
 func (r *Containerd) ListContainers(o ListContainersOptions) ([]string, error) {
-	return listCRIContainers(r.Runner, containerdNamespaceRoot, o)
+	return listCRIContainers(r.Runner, "runc", containerdNamespaceRoot, o)
 }
 
 // PauseContainers pauses a running container based on ID
 func (r *Containerd) PauseContainers(ids []string) error {
-	return pauseCRIContainers(r.Runner, containerdNamespaceRoot, ids)
+	return pauseCRIContainers(r.Runner, "runc", containerdNamespaceRoot, ids)
 }
 
 // UnpauseContainers unpauses a running container based on ID
 func (r *Containerd) UnpauseContainers(ids []string) error {
-	return unpauseCRIContainers(r.Runner, containerdNamespaceRoot, ids)
+	return unpauseCRIContainers(r.Runner, "runc", containerdNamespaceRoot, ids)
 }
 
 // KillContainers removes containers based on ID

--- a/pkg/minikube/cruntime/containerd.go
+++ b/pkg/minikube/cruntime/containerd.go
@@ -491,17 +491,17 @@ func (r *Containerd) KubeletOptions() map[string]string {
 
 // ListContainers returns a list of managed by this container runtime
 func (r *Containerd) ListContainers(o ListContainersOptions) ([]string, error) {
-	return listCRIContainers(r.Runner, "runc", containerdNamespaceRoot, o)
+	return listCRIContainers(r.Runner, runcBinaryName, containerdNamespaceRoot, o)
 }
 
 // PauseContainers pauses a running container based on ID
 func (r *Containerd) PauseContainers(ids []string) error {
-	return pauseCRIContainers(r.Runner, "runc", containerdNamespaceRoot, ids)
+	return pauseCRIContainers(r.Runner, runcBinaryName, containerdNamespaceRoot, ids)
 }
 
 // UnpauseContainers unpauses a running container based on ID
 func (r *Containerd) UnpauseContainers(ids []string) error {
-	return unpauseCRIContainers(r.Runner, "runc", containerdNamespaceRoot, ids)
+	return unpauseCRIContainers(r.Runner, runcBinaryName, containerdNamespaceRoot, ids)
 }
 
 // KillContainers removes containers based on ID

--- a/pkg/minikube/cruntime/cri.go
+++ b/pkg/minikube/cruntime/cri.go
@@ -71,7 +71,7 @@ func listCRIContainers(cr CommandRunner, runtime string, root string, o ListCont
 	if err != nil {
 		return nil, errors.Wrap(err, runtime)
 	}
-	
+
 	var cs []container
 	if err := json.Unmarshal(rr.Stdout.Bytes(), &cs); err != nil {
 		return nil, errors.Wrapf(err, "unmarshal %s list", runtime)

--- a/pkg/minikube/cruntime/cri.go
+++ b/pkg/minikube/cruntime/cri.go
@@ -56,10 +56,13 @@ type crictlImages struct {
 // timeoutOverride flag overrides the default 2s timeout for crictl commands
 const timeoutOverrideFlag = "--timeout=10s"
 
+// runcBinaryName is the default binary name for runc
+const runcBinaryName = "runc"
+
 // listCRIContainers returns a list of containers
 func listCRIContainers(cr CommandRunner, runtime string, root string, o ListContainersOptions) ([]string, error) {
 	if runtime == "" {
-		runtime = "runc"
+		runtime = runcBinaryName
 	}
 	args := []string{runtime}
 	if root != "" {
@@ -119,7 +122,7 @@ func listCRIContainers(cr CommandRunner, runtime string, root string, o ListCont
 // pauseCRIContainers pauses a list of containers
 func pauseCRIContainers(cr CommandRunner, runtime string, root string, ids []string) error {
 	if runtime == "" {
-		runtime = "runc"
+		runtime = runcBinaryName
 	}
 	baseArgs := []string{runtime}
 	if root != "" {
@@ -149,7 +152,7 @@ func getCrictlPath(cr CommandRunner) string {
 // unpauseCRIContainers pauses a list of containers
 func unpauseCRIContainers(cr CommandRunner, runtime string, root string, ids []string) error {
 	if runtime == "" {
-		runtime = "runc"
+		runtime = runcBinaryName
 	}
 	args := []string{runtime}
 	if root != "" {

--- a/pkg/minikube/cruntime/crio.go
+++ b/pkg/minikube/cruntime/crio.go
@@ -413,7 +413,7 @@ func (r *CRIO) ociRuntime() (string, string) {
 	runtime, root, err := crioOCIInfo(r.Runner)
 	if err != nil {
 		klog.Warningf("failed to get oci runtime: %v", err)
-		return "runc", ""
+		return runcBinaryName, ""
 	}
 	return runtime, root
 }
@@ -426,7 +426,7 @@ func crioOCIInfo(cr CommandRunner) (string, string, error) {
 	}
 	// simple line parser using string manipulation
 	lines := strings.Split(rr.Stdout.String(), "\n")
-	defaultRuntime := "runc"
+	defaultRuntime := runcBinaryName
 	runtimeRoot := ""
 
 	// first pass: find default_runtime

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -427,7 +427,7 @@ func (r *Docker) KubeletOptions() map[string]string {
 // ListContainers returns a list of containers
 func (r *Docker) ListContainers(o ListContainersOptions) ([]string, error) {
 	if r.UseCRI {
-		return listCRIContainers(r.Runner, "", o)
+		return listCRIContainers(r.Runner, "runc", "", o)
 	}
 	args := []string{"ps"}
 	switch o.State {
@@ -496,7 +496,7 @@ func (r *Docker) StopContainers(ids []string) error {
 // PauseContainers pauses a running container based on ID
 func (r *Docker) PauseContainers(ids []string) error {
 	if r.UseCRI {
-		return pauseCRIContainers(r.Runner, "", ids)
+		return pauseCRIContainers(r.Runner, "runc", "", ids)
 	}
 	if len(ids) == 0 {
 		return nil
@@ -513,7 +513,7 @@ func (r *Docker) PauseContainers(ids []string) error {
 // UnpauseContainers unpauses a container based on ID
 func (r *Docker) UnpauseContainers(ids []string) error {
 	if r.UseCRI {
-		return unpauseCRIContainers(r.Runner, "", ids)
+		return unpauseCRIContainers(r.Runner, "runc", "", ids)
 	}
 	if len(ids) == 0 {
 		return nil

--- a/pkg/minikube/cruntime/docker.go
+++ b/pkg/minikube/cruntime/docker.go
@@ -427,7 +427,7 @@ func (r *Docker) KubeletOptions() map[string]string {
 // ListContainers returns a list of containers
 func (r *Docker) ListContainers(o ListContainersOptions) ([]string, error) {
 	if r.UseCRI {
-		return listCRIContainers(r.Runner, "runc", "", o)
+		return listCRIContainers(r.Runner, runcBinaryName, "", o)
 	}
 	args := []string{"ps"}
 	switch o.State {
@@ -496,7 +496,7 @@ func (r *Docker) StopContainers(ids []string) error {
 // PauseContainers pauses a running container based on ID
 func (r *Docker) PauseContainers(ids []string) error {
 	if r.UseCRI {
-		return pauseCRIContainers(r.Runner, "runc", "", ids)
+		return pauseCRIContainers(r.Runner, runcBinaryName, "", ids)
 	}
 	if len(ids) == 0 {
 		return nil
@@ -513,7 +513,7 @@ func (r *Docker) PauseContainers(ids []string) error {
 // UnpauseContainers unpauses a container based on ID
 func (r *Docker) UnpauseContainers(ids []string) error {
 	if r.UseCRI {
-		return unpauseCRIContainers(r.Runner, "runc", "", ids)
+		return unpauseCRIContainers(r.Runner, runcBinaryName, "", ids)
 	}
 	if len(ids) == 0 {
 		return nil


### PR DESCRIPTION
- Remove depdendency on crictl for listing containers
- also Dynamically Detecting runtime_root for crio  because CRIO on VM and KIC different in config https://github.com/kubernetes/minikube/issues/22326 

The  crictl dependency for listing containers has been removed in favor of direct OCI runtime calls, which provides a more reliable "ground truth" of running containers. as discussed here
https://github.com/kubernetes/minikube/issues/22264

