### PR TITLE
build: Don't install golang-go but use host-go instead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,6 +291,7 @@ minikube-iso-amd64: minikube-iso-x86_64
 minikube-iso-arm64: minikube-iso-aarch64
 
 minikube-iso-%: iso-prepare-% deploy/iso/minikube-iso/board/minikube/%/rootfs-overlay/usr/bin/auto-pause # build minikube iso
+	$(MAKE) -C $(BUILD_DIR)/buildroot $(BUILDROOT_OPTIONS) O=$(BUILD_DIR)/buildroot/output-$* host-go
 	$(MAKE) -C $(BUILD_DIR)/buildroot $(BUILDROOT_OPTIONS) O=$(BUILD_DIR)/buildroot/output-$*
 	# x86_64 ISO is still BIOS rather than EFI because of AppArmor issues for KVM, and Gen 2 issues for Hyper-V
 	if [ "$*" = "aarch64" ]; then \

--- a/deploy/iso/minikube-iso/Dockerfile
+++ b/deploy/iso/minikube-iso/Dockerfile
@@ -16,7 +16,6 @@ FROM ubuntu:22.04
 
 RUN apt-get update \
 	&& apt-get install -y apt dpkg apt-utils ca-certificates software-properties-common \
-	&& add-apt-repository -y ppa:longsleep/golang-backports \
 	&& apt-get upgrade -y \
 	&& if [ "$(uname -ms)" = "Linux x86_64" ]; then apt-get install -y gcc-multilib; fi \
 	&& apt-get install -y \
@@ -36,7 +35,6 @@ RUN apt-get update \
 		rsync \
 		cmake \
 		dumb-init \
-		golang-go \
 		libpcre3-dev \
 		mkisofs \
 	&& rm -rf /var/lib/apt/lists/*
@@ -50,6 +48,9 @@ ENV LANG=en_US.utf8
 # the default ccache dir is "$HOME/.buildroot-ccache"
 ENV BR2_CCACHE_DIR=/var/cache/buildroot/ccache
 RUN mkdir -p /var/cache/buildroot/ccache && chmod 1777 /var/cache/buildroot/ccache
+# the default gocache dir is "$HOME/.cache/go-build"
+ENV GOCACHE=/var/cache/buildroot/gocache
+RUN mkdir -p /var/cache/buildroot/gocache && chmod 1777 /var/cache/buildroot/gocache
 VOLUME ["/var/cache/buildroot"]
 
 # dumb init will allow us to interrupt the build with ^C


### PR DESCRIPTION
Use the go compiler from buildroot for building packages, instead of installing a go compiler in the builder image.

Make sure to build the host-go package and set up GOCACHE, before minikube packages have been fixed to use golang.mk

Now that there host-go-bin, it won't even need bootstrapping (there is still host-go-src, should it ever be needed)

Closes #22228