### PR TITLE
build: Install tar in the builder image to avoid host-tar

### DIFF
--- a/deploy/iso/minikube-iso/Dockerfile
+++ b/deploy/iso/minikube-iso/Dockerfile
@@ -48,14 +48,15 @@ RUN mkdir /app
 RUN chmod 777 /app
 
 # Build host-tar
-RUN wget -nv -O - https://ftpmirror.gnu.org/tar/tar-${TAR_VERSION}.tar.xz | \
-    tar -Jx -C /tmp && \
+RUN wget -nv -O /tmp/tar-${TAR_VERSION}.tar.xz https://ftpmirror.gnu.org/tar/tar-${TAR_VERSION}.tar.xz && \
+    echo "4d62ff37342ec7aed748535323930c7cf94acf71c3591882b26a7ea50f3edc16  /tmp/tar-1.35.tar.xz" | sha256sum -c - && \
+    tar -Jx -C /tmp -f /tmp/tar-${TAR_VERSION}.tar.xz && \
     cd /tmp/tar-${TAR_VERSION} && \
     FORCE_UNSAFE_CONFIGURE=1 ./configure \
         --disable-year2038 && \
-    make && \
+    make -j`nproc` && \
     make install && \
-    rm -rf /tmp/tar-${TAR_VERSION}
+    rm -rf /tmp/tar-${TAR_VERSION} /tmp/tar-${TAR_VERSION}.tar.xz
 
 RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG=en_US.utf8


### PR DESCRIPTION
Need a newer version of tar, then what is available in the package repositories for debian:12 and ubuntu:22.04

Build one in /usr/local/bin, while using the older tar in /usr/bin to unpack the source tarball for tar itself.

Ported from buildroot image, but using wget instead of curl.

https://github.com/buildroot/buildroot/blob/2025.02.x/support/docker/Dockerfile

See package/tar/tar.mk for the original (the real "host-tar")

https://github.com/buildroot/buildroot/tree/2025.02.x/package/tar