### PR TITLE
Warn user when host is using cgroup v1 in KIC

### DIFF
--- a/pkg/drivers/kic/oci/cgroups_linux.go
+++ b/pkg/drivers/kic/oci/cgroups_linux.go
@@ -80,3 +80,21 @@ func hasMemorySwapCgroup() bool {
 	}
 	return true
 }
+
+// IsCgroupV2 returns true if the host is using cgroup v2
+func IsCgroupV2() bool {
+	_, err := os.Stat("/sys/fs/cgroup/cgroup.controllers")
+	return err == nil
+}
+
+// WarnIfCgroupV1 prints a warning if host is using cgroup v1
+func WarnIfCgroupV1() {
+	if !IsCgroupV2() {
+		klog.Warning(
+			"Host system is using cgroup v1. " +
+				"Minikube will not enable cgroup v2. " +
+				"Some features may not work as expected.",
+		)
+	}
+}
+

--- a/pkg/drivers/kic/oci/cgroups_other.go
+++ b/pkg/drivers/kic/oci/cgroups_other.go
@@ -25,3 +25,8 @@ func HasMemoryCgroup() bool {
 func hasMemorySwapCgroup() bool {
 	return true
 }
+
+// WarnIfCgroupV1 is a no-op on non-Linux systems
+func WarnIfCgroupV1() {
+	// no-op
+}

--- a/pkg/drivers/kic/oci/oci.go
+++ b/pkg/drivers/kic/oci/oci.go
@@ -159,6 +159,10 @@ func CreateContainerNode(p CreateParams) error { //nolint to suppress cyclomatic
 			return errors.Wrap(err, "daemon info")
 		}
 	}
+	if runtime.GOOS == "linux" {
+		WarnIfCgroupV1()
+	}
+
 
 	runArgs := []string{
 		"-d", // run the container detached


### PR DESCRIPTION
### What this PR does
- Detects when the host system is using cgroup v1
- Warns users during KIC (Kubernetes in Docker) node creation

### Why
Minikube may assume cgroup v2 support even when the host is using cgroup v1, which can lead to confusing runtime or test failures. This change adds an early, clear warning so users understand potential limitations before encountering issues.

### Example
On a Linux host using cgroup v1 (for example, older distributions or systems with legacy cgroup configuration), starting Minikube with the KIC driver will now print the following warning during node creation:

WARNING: Host system is using cgroup v1.
Minikube will not enable cgroup v2.
Some features may not work as expected.

This improves user visibility and avoids silent misconfiguration.

### Scope
- Linux only
- KIC driver only

Fixes #22321