### PR TITLE
site: community page add button for joining dev-group

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -145,17 +145,14 @@ no = 'Sorry to hear that. Please <a href="https://github.com/kubernetes/minikube
 	name = "GitHub"
 	url = "https://github.com/kubernetes/minikube"
 	icon = "fab fa-github"
-        desc = "Development takes place here!"
-[[params.links.developer]]
-	name = "minikube-dev mailing list"
-	url = "https://groups.google.com/forum/#!forum/minikube-dev"
-	icon = "fa fa-envelope"
-	desc = "Contact the minikube developers here"
+    desc = "Development takes place here!"
+
 [[params.links.developer]]
 	name = "Contributing Guide"
 	url = "https://minikube.sigs.k8s.io/docs/contrib/"
 	icon = "fas fa-external-link-alt"
 	desc = "Check out the contributing guide"
+	
 [[params.links.developer]]
 	name = "Project Roadmap"
 	url = "https://minikube.sigs.k8s.io/docs/contrib/roadmap/"
@@ -168,16 +165,25 @@ no = 'Sorry to hear that. Please <a href="https://github.com/kubernetes/minikube
 	url = "https://tinyurl.com/minikube-oh"
 	icon = "fas fa-comments"
 	desc = "Bi-weekly office hours, Mondays @ 11am PST"
+	
 [[params.links.meetings]]
 	name = "Triage Party"
 	url = "https://minikube.sigs.k8s.io/docs/contrib/triage/"
 	icon = "fas fa-comments"
 	desc = "All community members are welcome and encouraged to join and help us triage minikube!"
+
 [[params.links.meetings]]
 	name = "Kanban board"
 	url = "http://tinyurl.com/minikube-kanban"
 	icon = "fas fa-comments"
 	desc = "Kanban visualization of the next milestone"
+
+# calendar rsvp 
+[params.rsvp]
+name = "RSVP"
+url = "https://groups.google.com/g/minikube-dev"
+icon = "fa-regular fa-calendar"
+desc = "Subscribe to the Minikube development calendar."
 
 
 # Related pages - does not appear to work yet

--- a/site/layouts/partials/community_links.html
+++ b/site/layouts/partials/community_links.html
@@ -15,6 +15,9 @@
 {{ with index $links "developer"}}
 {{ template "community-links-list"  . }}
 {{ end }}
+
+{{ partial "rsvp_button.html" . }}
+
 <p>You can find out how to contribute to these docs in our <a href="/docs/contribution-guidelines/">Contribution Guidelines</a>.
 <h2>Join our meetings</h2>
 {{ with index $links "meetings"}}

--- a/site/layouts/partials/rsvp_button.html
+++ b/site/layouts/partials/rsvp_button.html
@@ -1,0 +1,11 @@
+{{ $rsvp := .Site.Params.rsvp }}
+
+<a
+  href="{{ $rsvp.url }}"
+  class="rsvp module-button {{ $rsvp.icon }}"
+  title="{{ $rsvp.desc }}"
+  target="_blank"
+  rel="noopener"
+>
+ {{ $rsvp.name }}
+</a>

--- a/site/static/css/button.css
+++ b/site/static/css/button.css
@@ -11,3 +11,14 @@
 .module-button:hover {
   background: #164cb2;
 }
+
+a.rsvp{
+  height: 48px;
+  width: 152px;
+  margin: 0 0 2rem 2rem;
+  font-size: 1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem; 
+}


### PR DESCRIPTION
Relaced dev mailing list bullet with RSVP button to link users to event and meeting sign up:

- Newlines between param link definitions for readability
- Added toml table for calendar rsvp button related variables
- Created partial for rsvp
- CSS styling for new partial

(Screenshot doesn't show mouse cursor)
<img width="942" height="842" alt="Screenshot 2025-12-31 at 10 55 02 AM" src="https://github.com/user-attachments/assets/8739fa02-fec0-47f8-93e1-e02645051342" />

