### PR TITLE
Mark the legacy parallels driver as deprecated

### DIFF
--- a/pkg/minikube/registry/drvs/parallels/parallels.go
+++ b/pkg/minikube/registry/drvs/parallels/parallels.go
@@ -38,7 +38,7 @@ func init() {
 		Config:   configure,
 		Status:   status,
 		Default:  true,
-		Priority: registry.Default,
+		Priority: registry.Deprecated,
 		Init:     func(_ *run.CommandOptions) drivers.Driver { return parallels.NewDriver("", "") },
 	})
 	if err != nil {


### PR DESCRIPTION
Since the driver doesn't work, it should eventually be removed...

See also https://github.com/Parallels/docker-machine-parallels/issues

* #21694 

* #21690