### PR TITLE
site: Remove old vmware driver documentation

### DIFF
--- a/site/content/en/docs/drivers/includes/vmware_macos_usage.inc
+++ b/site/content/en/docs/drivers/includes/vmware_macos_usage.inc
@@ -1,26 +1,6 @@
 ## Requirements
 
-* VMware Fusion
-
-## Driver Installation
-
-If the [Brew Package Manager](https://brew.sh/) is installed, run:
-
-```shell
-brew install docker-machine-driver-vmware
-```
-
-Otherwise:
-
-```shell
-r=https://api.github.com/repos/machine-drivers/docker-machine-driver-vmware
-d=docker-machine-driver-vmware_darwin_amd64
-u=$(curl -s $r/releases/latest | grep -o 'http.*Darwin_amd64.tar.gz' | head -n1)
-mkdir $d \
- && (cd $d && curl -L $u > $d.tar.gz && tar -xf $d.tar.gz) \
- && install $d/docker-machine-driver-vmware /usr/local/bin/docker-machine-driver-vmware \
- && rm -rf $d
-```
+* VMware Fusion 10
 
 ## Usage
 


### PR DESCRIPTION
The driver code is now compiled into minikube, so there is no need to download and install any external program (for amd64) any more.

Add the latest tested version, pending removal of the legacy driver. There is no support for arm64 in the driver, last updated in 2021.

* #10755

*  #21690

