### PR TITLE
doc: Fix tunnel desc link

### DIFF
--- a/cmd/minikube/cmd/tunnel.go
+++ b/cmd/minikube/cmd/tunnel.go
@@ -53,7 +53,7 @@ var lockHandle *fslock.Lock
 var tunnelCmd = &cobra.Command{
 	Use:   "tunnel",
 	Short: "Connect to LoadBalancer services",
-	Long:  `tunnel creates a route to services deployed with type LoadBalancer and sets their Ingress to their ClusterIP. for a detailed example see https://minikube.sigs.k8s.io/docs/tasks/loadbalancer`,
+	Long:  `tunnel creates a route to services deployed with type LoadBalancer and sets their Ingress to their ClusterIP. For a detailed example see https://minikube.sigs.k8s.io/docs/handbook/accessing`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		RootCmd.PersistentPreRun(cmd, args)
 	},


### PR DESCRIPTION
Fixed broken link to load balancer documentation in long description for tunnel command.
