### PR TITLE
site: update all minikube command descriptions with links to documentation

### DIFF
--- a/cmd/minikube/cmd/cache.go
+++ b/cmd/minikube/cmd/cache.go
@@ -40,7 +40,7 @@ const allFlag = "all"
 var cacheCmd = &cobra.Command{
 	Use:   "cache",
 	Short: "Manage cache for images",
-	Long:  "Add an image into minikube as a local cache, or delete, reload the cached images",
+	Long:  "Add an image into minikube as a local cache, or delete, reload the cached images. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/cache",
 }
 
 // addCacheCmd represents the cache add command

--- a/cmd/minikube/cmd/cache_list.go
+++ b/cmd/minikube/cmd/cache_list.go
@@ -39,7 +39,7 @@ type CacheListTemplate struct {
 var listCacheCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all available images from the local cache.",
-	Long:  "List all available images from the local cache.",
+	Long:  "List all available images from the local cache. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/cache/#minikube-cache-list",
 	Run: func(_ *cobra.Command, _ []string) {
 		images, err := cmdConfig.ListConfigMap(cacheImageConfigKey)
 		if err != nil {

--- a/cmd/minikube/cmd/completion.go
+++ b/cmd/minikube/cmd/completion.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/reason"
 )
 
-const longDescription = `Outputs minikube shell completion for the given shell (bash, zsh, fish or powershell)
+const longDescription = `Outputs minikube shell completion for the given shell (bash, zsh, fish or powershell). For a detailed example see https://minikube.sigs.k8s.io/docs/commands/completion
 
 	This depends on the bash-completion binary.  Example installation instructions:
 	OS X:

--- a/cmd/minikube/cmd/config/addons.go
+++ b/cmd/minikube/cmd/config/addons.go
@@ -26,7 +26,7 @@ import (
 var AddonsCmd = &cobra.Command{
 	Use:   "addons SUBCOMMAND [flags]",
 	Short: "Enable or disable a minikube addon",
-	Long:  `addons modifies minikube addons files using subcommands like "minikube addons enable dashboard"`,
+	Long:  `addons modifies minikube addons files using subcommands like "minikube addons enable dashboard". For a detailed example see https://minikube.sigs.k8s.io/docs/commands/addons`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		if err := cmd.Help(); err != nil {
 			klog.Errorf("help: %v", err)

--- a/cmd/minikube/cmd/config/addons_list.go
+++ b/cmd/minikube/cmd/config/addons_list.go
@@ -50,7 +50,7 @@ type AddonListTemplate struct {
 var addonsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "Lists all available minikube addons as well as their current statuses (enabled/disabled)",
-	Long:  "Lists all available minikube addons as well as their current statuses (enabled/disabled)",
+	Long:  `Lists all available minikube addons as well as their current statuses (enabled/disabled). For a detailed example see https://minikube.sigs.k8s.io/docs/commands/addons/#minikube-addons-list`,
 	Run: func(_ *cobra.Command, args []string) {
 		if len(args) != 0 {
 			exit.Message(reason.Usage, "usage: minikube addons list")

--- a/cmd/minikube/cmd/config/config.go
+++ b/cmd/minikube/cmd/config/config.go
@@ -178,8 +178,8 @@ var settings = []Setting{
 var ConfigCmd = &cobra.Command{
 	Use:   "config SUBCOMMAND [flags]",
 	Short: "Modify persistent configuration values",
-	Long: `config modifies minikube config files using subcommands like "minikube config set driver kvm2"
-Configurable fields: ` + "\n\n" + configurableFields(),
+	Long: `config modifies minikube config files using subcommands like "minikube config set driver kvm2". For a detailed example see https://minikube.sigs.k8s.io/docs/commands/config` +
+		"\n\n" + `Configurable fields: ` + "\n\n" + configurableFields(),
 	Run: func(cmd *cobra.Command, _ []string) {
 		if err := cmd.Help(); err != nil {
 			klog.ErrorS(err, "help")

--- a/cmd/minikube/cmd/config/configure.go
+++ b/cmd/minikube/cmd/config/configure.go
@@ -55,7 +55,7 @@ type addonConfig struct {
 var addonsConfigureCmd = &cobra.Command{
 	Use:   "configure ADDON_NAME",
 	Short: "Configures the addon w/ADDON_NAME within minikube (example: minikube addons configure registry-creds). For a list of available addons use: minikube addons list",
-	Long:  "Configures the addon w/ADDON_NAME within minikube (example: minikube addons configure registry-creds). For a list of available addons use: minikube addons list",
+	Long:  "Configures the addon w/ADDON_NAME within minikube (example: minikube addons configure registry-creds). For a list of available addons use: minikube addons list. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/addons/#minikube-addons-configure",
 	Run: func(_ *cobra.Command, args []string) {
 		if len(args) != 1 {
 			exit.Message(reason.Usage, "usage: minikube addons configure ADDON_NAME")

--- a/cmd/minikube/cmd/config/defaults.go
+++ b/cmd/minikube/cmd/config/defaults.go
@@ -34,7 +34,6 @@ var configDefaultsCommand = &cobra.Command{
 	Use:   "defaults PROPERTY_NAME",
 	Short: "Lists all valid default values for PROPERTY_NAME",
 	Long:  `list displays all valid default settings for PROPERTY_NAME. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/config/#minikube-config-defaults` + "\n\n" + `Acceptable fields: ` + "\n\n" + fieldsWithDefaults(),
-	// not working locally for some reason
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 1 {
 			cmd.SilenceErrors = true

--- a/cmd/minikube/cmd/config/defaults.go
+++ b/cmd/minikube/cmd/config/defaults.go
@@ -33,8 +33,8 @@ var defaultsOutput string
 var configDefaultsCommand = &cobra.Command{
 	Use:   "defaults PROPERTY_NAME",
 	Short: "Lists all valid default values for PROPERTY_NAME",
-	Long: `list displays all valid default settings for PROPERTY_NAME
-Acceptable fields: ` + "\n\n" + fieldsWithDefaults(),
+	Long:  `list displays all valid default settings for PROPERTY_NAME. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/config/#minikube-config-defaults` + "\n\n" + `Acceptable fields: ` + "\n\n" + fieldsWithDefaults(),
+	// not working locally for some reason
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 1 {
 			cmd.SilenceErrors = true

--- a/cmd/minikube/cmd/config/disable.go
+++ b/cmd/minikube/cmd/config/disable.go
@@ -31,7 +31,7 @@ import (
 var addonsDisableCmd = &cobra.Command{
 	Use:   "disable ADDON_NAME",
 	Short: "Disables the addon w/ADDON_NAME within minikube (example: minikube addons disable dashboard). For a list of available addons use: minikube addons list ",
-	Long:  "Disables the addon w/ADDON_NAME within minikube (example: minikube addons disable dashboard). For a list of available addons use: minikube addons list ",
+	Long:  "Disables the addon w/ADDON_NAME within minikube (example: minikube addons disable dashboard). For a detailed example see https://minikube.sigs.k8s.io/docs/commands/addons/#minikube-addons-disable",
 	Run: func(_ *cobra.Command, args []string) {
 		if len(args) != 1 {
 			exit.Message(reason.Usage, "usage: minikube addons disable ADDON_NAME")

--- a/cmd/minikube/cmd/config/enable.go
+++ b/cmd/minikube/cmd/config/enable.go
@@ -36,7 +36,7 @@ import (
 var addonsEnableCmd = &cobra.Command{
 	Use:     "enable ADDON_NAME",
 	Short:   "Enables the addon w/ADDON_NAME within minikube. For a list of available addons use: minikube addons list ",
-	Long:    "Enables the addon w/ADDON_NAME within minikube. For a list of available addons use: minikube addons list ",
+	Long:    "Enables the addon w/ADDON_NAME within minikube. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/addons/#minikube-addons-enable",
 	Example: "minikube addons enable dashboard",
 	Run: func(_ *cobra.Command, args []string) {
 		if len(args) != 1 {

--- a/cmd/minikube/cmd/config/get.go
+++ b/cmd/minikube/cmd/config/get.go
@@ -28,7 +28,7 @@ import (
 var configGetCmd = &cobra.Command{
 	Use:   "get PROPERTY_NAME",
 	Short: "Gets the value of PROPERTY_NAME from the minikube config file",
-	Long:  "Returns the value of PROPERTY_NAME from the minikube config file.  Can be overwritten at runtime by flags or environmental variables.",
+	Long:  "Returns the value of PROPERTY_NAME from the minikube config file. Can be overwritten at runtime by flags or environmental variables. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/config/#minikube-config-get",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			cmd.SilenceErrors = true

--- a/cmd/minikube/cmd/config/images.go
+++ b/cmd/minikube/cmd/config/images.go
@@ -37,7 +37,7 @@ var addonImagesOutput string
 var addonsImagesCmd = &cobra.Command{
 	Use:     "images ADDON_NAME",
 	Short:   "List image names the addon w/ADDON_NAME used. For a list of available addons use: minikube addons list",
-	Long:    "List image names the addon w/ADDON_NAME used. For a list of available addons use: minikube addons list",
+	Long:    "List image names the addon w/ADDON_NAME used. For a list of available addons use: minikube addons list. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/addons/#minikube-addons-images",
 	Example: "minikube addons images ingress",
 	Run: func(_ *cobra.Command, args []string) {
 		if len(args) != 1 {

--- a/cmd/minikube/cmd/config/open.go
+++ b/cmd/minikube/cmd/config/open.go
@@ -46,7 +46,7 @@ const defaultAddonsFormatTemplate = "http://{{.IP}}:{{.Port}}"
 var addonsOpenCmd = &cobra.Command{
 	Use:   "open ADDON_NAME",
 	Short: "Opens the addon w/ADDON_NAME within minikube (example: minikube addons open dashboard). For a list of available addons use: minikube addons list ",
-	Long:  "Opens the addon w/ADDON_NAME within minikube (example: minikube addons open dashboard). For a list of available addons use: minikube addons list ",
+	Long:  "Opens the addon w/ADDON_NAME within minikube (example: minikube addons open dashboard). For a detailed example see https://minikube.sigs.k8s.io/docs/commands/addons/#minikube-addons-open",
 	PreRun: func(_ *cobra.Command, _ []string) {
 		t, err := template.New("addonsURL").Parse(addonsURLFormat)
 		if err != nil {

--- a/cmd/minikube/cmd/config/profile.go
+++ b/cmd/minikube/cmd/config/profile.go
@@ -33,7 +33,7 @@ import (
 var ProfileCmd = &cobra.Command{
 	Use:   "profile [MINIKUBE_PROFILE_NAME].  You can return to the default minikube profile by running `minikube profile default`",
 	Short: "Get or list the current profiles (clusters)",
-	Long:  "profile sets the current minikube profile, or gets the current profile if no arguments are provided.  This is used to run and manage multiple minikube instance.  You can return to the default minikube profile by running `minikube profile default`",
+	Long:  "profile sets the current minikube profile, or gets the current profile if no arguments are provided. This is used to run and manage multiple minikube instances.  Return to the default minikube profile by running `minikube profile default`. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/profile",
 	Run: func(_ *cobra.Command, args []string) {
 		if len(args) == 0 {
 			profile := ClusterFlagValue()

--- a/cmd/minikube/cmd/config/profile_list.go
+++ b/cmd/minikube/cmd/config/profile_list.go
@@ -52,7 +52,7 @@ var (
 var profileListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "Lists all minikube profiles.",
-	Long:  "Lists all valid minikube profiles and detects all possible invalid profiles.",
+	Long:  "Lists all valid minikube profiles and detects all possible invalid profiles. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/profile/#minikube-profile-list",
 	Run: func(_ *cobra.Command, _ []string) {
 		options := flags.CommandOptions()
 		output := strings.ToLower(profileOutput)

--- a/cmd/minikube/cmd/config/set.go
+++ b/cmd/minikube/cmd/config/set.go
@@ -30,7 +30,7 @@ var configSetCmd = &cobra.Command{
 	Use:   "set PROPERTY_NAME PROPERTY_VALUE",
 	Short: "Sets an individual value in a minikube config file",
 	Long: `Sets the PROPERTY_NAME config value to PROPERTY_VALUE
-	These values can be overwritten by flags or environment variables at runtime.`,
+	These values can be overwritten by flags or environment variables at runtime. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/config/#minikube-config-set`,
 	Run: func(_ *cobra.Command, args []string) {
 		if len(args) < 2 {
 			exit.Message(reason.Usage, "not enough arguments ({{.ArgCount}}).\nusage: minikube config set PROPERTY_NAME PROPERTY_VALUE", out.V{"ArgCount": len(args)})

--- a/cmd/minikube/cmd/config/unset.go
+++ b/cmd/minikube/cmd/config/unset.go
@@ -27,7 +27,7 @@ import (
 var configUnsetCmd = &cobra.Command{
 	Use:   "unset PROPERTY_NAME",
 	Short: "unsets an individual value in a minikube config file",
-	Long:  "unsets PROPERTY_NAME from the minikube config file.  Can be overwritten by flags or environmental variables",
+	Long:  "unsets PROPERTY_NAME from the minikube config file. Can be overwritten by flags or environmental variables. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/config/#minikube-config-unset",
 	Run: func(_ *cobra.Command, args []string) {
 		if len(args) != 1 {
 			exit.Message(reason.Usage, "usage: minikube config unset PROPERTY_NAME")

--- a/cmd/minikube/cmd/config/view.go
+++ b/cmd/minikube/cmd/config/view.go
@@ -42,7 +42,7 @@ var configViewCmd = &cobra.Command{
 	Short: "Display values currently set in the minikube config file",
 	Long: `Display values currently set in the minikube config file.
 	The output format can be customized using the --format flag, which accepts a Go template. 
-	The config file is typically located at "~/.minikube/config/config.json".`,
+	The config file is typically located at "~/.minikube/config/config.json". For a detailed example see https://minikube.sigs.k8s.io/docs/commands/config/#minikube-config-view`,
 	Run: func(_ *cobra.Command, _ []string) {
 		err := View()
 		if err != nil {

--- a/cmd/minikube/cmd/cp.go
+++ b/cmd/minikube/cmd/cp.go
@@ -48,7 +48,7 @@ var cpCmd = &cobra.Command{
 	Use:   "cp <source node name>:<source file path> <target node name>:<target file absolute path>",
 	Short: "Copy the specified file into minikube",
 	Long: `Copy the specified file into minikube, it will be saved at path <target file absolute path> in your minikube.
-Default target node controlplane and If <source node name> is omitted, It will trying to copy from host.
+Default target node controlplane and If <source node name> is omitted, It will trying to copy from host. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/cp
 
 Example Command : "minikube cp a.txt /home/docker/b.txt" +
                   "minikube cp a.txt minikube-m02:/home/docker/b.txt"

--- a/cmd/minikube/cmd/dashboard.go
+++ b/cmd/minikube/cmd/dashboard.go
@@ -57,7 +57,7 @@ var (
 var dashboardCmd = &cobra.Command{
 	Use:   "dashboard",
 	Short: "Access the Kubernetes dashboard running within the minikube cluster",
-	Long:  `Access the Kubernetes dashboard running within the minikube cluster`,
+	Long:  `Access the Kubernetes dashboard running within the minikube cluster. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/dashboard`,
 	Run: func(_ *cobra.Command, _ []string) {
 		options := flags.CommandOptions()
 		cname := ClusterFlagValue()

--- a/cmd/minikube/cmd/delete.go
+++ b/cmd/minikube/cmd/delete.go
@@ -67,7 +67,7 @@ var deleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "Deletes a local Kubernetes cluster",
 	Long: `Deletes a local Kubernetes cluster. This command deletes the VM, and removes all
-associated files.`,
+associated files. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/delete`,
 	Run: runDelete,
 }
 

--- a/cmd/minikube/cmd/docker-env.go
+++ b/cmd/minikube/cmd/docker-env.go
@@ -263,7 +263,7 @@ func waitForAPIServerProcess(cr command.Runner, start time.Time, timeout time.Du
 var dockerEnvCmd = &cobra.Command{
 	Use:   "docker-env",
 	Short: "Provides instructions to point your terminal's docker-cli to the Docker Engine inside minikube. (Useful for building docker images directly inside minikube)",
-	Long: `Provides instructions to point your terminal's docker-cli to the Docker Engine inside minikube. (Useful for building docker images directly inside minikube)
+	Long: `Provides instructions to point your terminal's docker-cli to the Docker Engine inside minikube. (Useful for building docker images directly inside minikube). For a detailed example see https://minikube.sigs.k8s.io/docs/commands/docker-env
 
 For example, you can do all docker operations such as docker build, docker run, and docker ps directly on the docker inside minikube.
 

--- a/cmd/minikube/cmd/image.go
+++ b/cmd/minikube/cmd/image.go
@@ -79,7 +79,7 @@ func saveFile(r io.Reader) (string, error) {
 var loadImageCmd = &cobra.Command{
 	Use:     "load IMAGE | ARCHIVE | -",
 	Short:   "Load an image into minikube",
-	Long:    "Load an image into minikube",
+	Long:    "Load an image into minikube. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/image",
 	Example: "minikube image load image\nminikube image load image.tar",
 	Run: func(_ *cobra.Command, args []string) {
 		if len(args) == 0 {

--- a/cmd/minikube/cmd/ip.go
+++ b/cmd/minikube/cmd/ip.go
@@ -30,7 +30,7 @@ import (
 var ipCmd = &cobra.Command{
 	Use:   "ip",
 	Short: "Retrieves the IP address of the specified node",
-	Long:  `Retrieves the IP address of the specified node, and writes it to STDOUT.`,
+	Long:  `Retrieves the IP address of the specified node, and writes it to STDOUT. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/ip`,
 	Run: func(_ *cobra.Command, _ []string) {
 		options := flags.CommandOptions()
 		co := mustload.Running(ClusterFlagValue(), options)

--- a/cmd/minikube/cmd/kubectl.go
+++ b/cmd/minikube/cmd/kubectl.go
@@ -52,7 +52,8 @@ This will run the Kubernetes client (kubectl) with the same version as the clust
 Normally it will download a binary matching the host operating system and architecture,
 but optionally you can also run it directly on the control plane over the ssh connection.
 This can be useful if you cannot run kubectl locally for some reason, like unsupported
-host. Please be aware that when using --ssh all paths will apply to the remote machine.`,
+host. Please be aware that when using --ssh all paths will apply to the remote machine. For a detailed 
+example see https://minikube.sigs.k8s.io/docs/commands/kubectl`,
 	Example: "minikube kubectl -- --help\nminikube kubectl -- get pods --namespace kube-system",
 	Run: func(_ *cobra.Command, args []string) {
 		options := flags.CommandOptions()

--- a/cmd/minikube/cmd/license.go
+++ b/cmd/minikube/cmd/license.go
@@ -29,7 +29,7 @@ var dir string
 var licenseCmd = &cobra.Command{
 	Use:   "license",
 	Short: "Outputs the licenses of dependencies to a directory",
-	Long:  "Outputs the licenses of dependencies to a directory",
+	Long:  "Outputs the licenses of dependencies to a directory. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/license",
 	Run: func(_ *cobra.Command, _ []string) {
 		if err := download.Licenses(dir); err != nil {
 			exit.Error(reason.InetLicenses, "Failed to download licenses", err)

--- a/cmd/minikube/cmd/logs.go
+++ b/cmd/minikube/cmd/logs.go
@@ -63,7 +63,7 @@ var (
 var logsCmd = &cobra.Command{
 	Use:   "logs",
 	Short: "Returns logs to debug a local Kubernetes cluster",
-	Long:  `Gets the logs of the running instance, used for debugging minikube, not user code.`,
+	Long:  `Gets the logs of the running instance, used for debugging minikube, not user code. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/logs`,
 	Run: func(_ *cobra.Command, _ []string) {
 		options := flags.CommandOptions()
 		logOutput := os.Stdout

--- a/cmd/minikube/cmd/mount.go
+++ b/cmd/minikube/cmd/mount.go
@@ -91,7 +91,7 @@ var supportedFilesystems = map[string]bool{nineP: true}
 var mountCmd = &cobra.Command{
 	Use:   "mount [flags] <source directory>:<target directory>",
 	Short: "Mounts the specified directory into minikube",
-	Long:  `Mounts the specified directory into minikube.`,
+	Long:  `Mounts the specified directory into minikube. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/mount`,
 	Run: func(_ *cobra.Command, args []string) {
 		if isKill {
 			if err := killMountProcess(); err != nil {

--- a/cmd/minikube/cmd/node.go
+++ b/cmd/minikube/cmd/node.go
@@ -26,7 +26,7 @@ import (
 var nodeCmd = &cobra.Command{
 	Use:   "node",
 	Short: "Add, remove, or list additional nodes",
-	Long:  "Operations on nodes",
+	Long:  "Operations on nodes. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/node",
 	Run: func(_ *cobra.Command, _ []string) {
 		exit.Message(reason.Usage, "Usage: minikube node [add|start|stop|delete|list]")
 	},

--- a/cmd/minikube/cmd/node_add.go
+++ b/cmd/minikube/cmd/node_add.go
@@ -42,7 +42,7 @@ var (
 var nodeAddCmd = &cobra.Command{
 	Use:   "add",
 	Short: "Adds a node to the given cluster.",
-	Long:  "Adds a node to the given cluster config, and starts it.",
+	Long:  "Adds a node to the given cluster config, and starts it. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/node/#minikube-node-add",
 	Run: func(cmd *cobra.Command, _ []string) {
 		options := flags.CommandOptions()
 

--- a/cmd/minikube/cmd/node_delete.go
+++ b/cmd/minikube/cmd/node_delete.go
@@ -36,7 +36,7 @@ import (
 var nodeDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "Deletes a node from a cluster.",
-	Long:  "Deletes a node from a cluster.",
+	Long:  "Deletes a node from a cluster. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/node/#minikube-node-delete",
 	Run: func(_ *cobra.Command, args []string) {
 		if len(args) == 0 {
 			exit.Message(reason.Usage, "Usage: minikube node delete [name]")

--- a/cmd/minikube/cmd/node_list.go
+++ b/cmd/minikube/cmd/node_list.go
@@ -32,7 +32,7 @@ import (
 var nodeListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List nodes.",
-	Long:  "List existing minikube nodes.",
+	Long:  "List existing minikube nodes. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/node/#minikube-node-list",
 	Run: func(_ *cobra.Command, args []string) {
 		if len(args) != 0 {
 			exit.Message(reason.Usage, "Usage: minikube node list")

--- a/cmd/minikube/cmd/node_start.go
+++ b/cmd/minikube/cmd/node_start.go
@@ -36,7 +36,7 @@ import (
 var nodeStartCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Starts a node.",
-	Long:  "Starts an existing stopped node in a cluster.",
+	Long:  "Starts an existing stopped node in a cluster. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/node/#minikube-node-start",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			exit.Message(reason.Usage, "Usage: minikube node start [name]")

--- a/cmd/minikube/cmd/node_stop.go
+++ b/cmd/minikube/cmd/node_stop.go
@@ -34,7 +34,7 @@ import (
 var nodeStopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stops a node in a cluster.",
-	Long:  "Stops a node in a cluster.",
+	Long:  "Stops a node in a cluster. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/node/#minikube-node-stop",
 	Run: func(_ *cobra.Command, args []string) {
 		if len(args) == 0 {
 			exit.Message(reason.Usage, "Usage: minikube node stop [name]")

--- a/cmd/minikube/cmd/options.go
+++ b/cmd/minikube/cmd/options.go
@@ -30,7 +30,7 @@ import (
 var optionsCmd = &cobra.Command{
 	Use:    "options",
 	Short:  "Show a list of global command-line options (applies to all commands).",
-	Long:   "Show a list of global command-line options (applies to all commands).",
+	Long:   "Show a list of global command-line options (applies to all commands). For a detailed example see https://minikube.sigs.k8s.io/docs/commands/options",
 	Hidden: false,
 	Run:    runOptions,
 }

--- a/cmd/minikube/cmd/pause.go
+++ b/cmd/minikube/cmd/pause.go
@@ -46,7 +46,7 @@ var (
 // pauseCmd represents the docker-pause command
 var pauseCmd = &cobra.Command{
 	Use:   "pause",
-	Short: "pause Kubernetes",
+	Short: "pause Kubernetes. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/pause",
 	Run:   runPause,
 }
 

--- a/cmd/minikube/cmd/podman-env.go
+++ b/cmd/minikube/cmd/podman-env.go
@@ -138,7 +138,7 @@ func createExternalSSHClient(d drivers.Driver) (*ssh.ExternalClient, error) {
 var podmanEnvCmd = &cobra.Command{
 	Use:   "podman-env",
 	Short: "Configure environment to use minikube's Podman service",
-	Long:  `Sets up podman env variables; similar to '$(podman-machine env)'.`,
+	Long:  `Sets up podman env variables; similar to '$(podman-machine env)'. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/podman-env`,
 	Run: func(_ *cobra.Command, _ []string) {
 		options := flags.CommandOptions()
 		sh := shell.EnvConfig{

--- a/cmd/minikube/cmd/root.go
+++ b/cmd/minikube/cmd/root.go
@@ -62,7 +62,7 @@ var (
 var RootCmd = &cobra.Command{
 	Use:   "minikube",
 	Short: "minikube quickly sets up a local Kubernetes cluster",
-	Long:  `minikube provisions and manages local Kubernetes clusters optimized for development workflows.`,
+	Long:  `minikube provisions and manages local Kubernetes clusters optimized for development workflows. For a detailed example see https://minikube.sigs.k8s.io/docs/start`,
 	PersistentPreRun: func(_ *cobra.Command, _ []string) {
 		for _, path := range dirs {
 			if err := os.MkdirAll(path, 0777); err != nil {

--- a/cmd/minikube/cmd/service.go
+++ b/cmd/minikube/cmd/service.go
@@ -65,7 +65,7 @@ var (
 var serviceCmd = &cobra.Command{
 	Use:   "service [flags] SERVICE",
 	Short: "Returns a URL to connect to a service",
-	Long:  `Returns the Kubernetes URL(s) for service(s) in your local cluster. In the case of multiple URLs they will be printed one at a time.`,
+	Long:  `Returns the Kubernetes URL(s) for service(s) in your local cluster. In the case of multiple URLs they will be printed one at a time. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/service`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		t, err := template.New("serviceURL").Parse(serviceURLFormat)
 		if err != nil {

--- a/cmd/minikube/cmd/service_list.go
+++ b/cmd/minikube/cmd/service_list.go
@@ -41,7 +41,7 @@ var profileOutput string
 var serviceListCmd = &cobra.Command{
 	Use:   "list [flags]",
 	Short: "Lists the URLs for the services in your local cluster",
-	Long:  `Lists the URLs for the services in your local cluster`,
+	Long:  `Lists the URLs for the services in your local cluster. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/service/#minikube-service-list`,
 	Run: func(_ *cobra.Command, _ []string) {
 		options := flags.CommandOptions()
 		co := mustload.Healthy(ClusterFlagValue(), options)

--- a/cmd/minikube/cmd/ssh-host.go
+++ b/cmd/minikube/cmd/ssh-host.go
@@ -44,7 +44,7 @@ var (
 var sshHostCmd = &cobra.Command{
 	Use:   "ssh-host",
 	Short: "Retrieve the ssh host key of the specified node",
-	Long:  "Retrieve the ssh host key of the specified node.",
+	Long:  "Retrieve the ssh host key of the specified node. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/ssh-host",
 	Run: func(_ *cobra.Command, _ []string) {
 		appendKnownHelper(nodeName, appendKnown)
 	},

--- a/cmd/minikube/cmd/ssh-key.go
+++ b/cmd/minikube/cmd/ssh-key.go
@@ -34,7 +34,7 @@ import (
 var sshKeyCmd = &cobra.Command{
 	Use:   "ssh-key",
 	Short: "Retrieve the ssh identity key path of the specified node",
-	Long:  "Retrieve the ssh identity key path of the specified node, and writes it to STDOUT.",
+	Long:  "Retrieve the ssh identity key path of the specified node, and writes it to STDOUT. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/ssh-key",
 	Run: func(_ *cobra.Command, _ []string) {
 		options := flags.CommandOptions()
 		_, cc := mustload.Partial(ClusterFlagValue(), options)

--- a/cmd/minikube/cmd/ssh.go
+++ b/cmd/minikube/cmd/ssh.go
@@ -38,7 +38,7 @@ var nativeSSHClient bool
 var sshCmd = &cobra.Command{
 	Use:   "ssh",
 	Short: "Log into the minikube environment (for debugging)",
-	Long:  "Log into or run a command on a machine with SSH; similar to 'docker-machine ssh'.",
+	Long:  "Log into or run a command on a machine with SSH; similar to 'docker-machine ssh'. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/ssh",
 	Run: func(_ *cobra.Command, args []string) {
 		options := flags.CommandOptions()
 		cname := ClusterFlagValue()

--- a/cmd/minikube/cmd/start.go
+++ b/cmd/minikube/cmd/start.go
@@ -118,7 +118,7 @@ func init() {
 var startCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Starts a local Kubernetes cluster",
-	Long:  "Starts a local Kubernetes cluster",
+	Long:  "Starts a local Kubernetes cluster. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/start",
 	Run:   runStart,
 }
 

--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -82,8 +82,10 @@ var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Gets the status of a local Kubernetes cluster",
 	Long: `Gets the status of a local Kubernetes cluster.
-	Exit status contains the status of minikube's VM, cluster and Kubernetes encoded on it's bits in this order from right to left.
-	Eg: 7 meaning: 1 (for minikube NOK) + 2 (for cluster NOK) + 4 (for Kubernetes NOK)`,
+	
+Exit status contains the status of minikube's VM, cluster and Kubernetes encoded on it's bits in this order from right to left. Eg: 7 meaning: 1 (for minikube NOK) + 2 (for cluster NOK) + 4 (for Kubernetes NOK). 
+	
+For a detailed example see https://minikube.sigs.k8s.io/docs/commands/status`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		output = strings.ToLower(output)
 		if output != "text" && statusFormat != defaultStatusFormat {

--- a/cmd/minikube/cmd/stop.go
+++ b/cmd/minikube/cmd/stop.go
@@ -54,7 +54,7 @@ var (
 var stopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stops a running local Kubernetes cluster",
-	Long:  `Stops a local Kubernetes cluster. This command stops the underlying VM or container, but keeps user data intact. The cluster can be started again with the "start" command.`,
+	Long:  `Stops a local Kubernetes cluster. This command stops the underlying VM or container, but keeps user data intact. The cluster can be started again with the "start" command. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/stop`,
 	Run:   runStop,
 }
 

--- a/cmd/minikube/cmd/unpause.go
+++ b/cmd/minikube/cmd/unpause.go
@@ -43,6 +43,7 @@ var unpauseCmd = &cobra.Command{
 	Use:     "unpause",
 	Aliases: []string{"resume"},
 	Short:   "unpause Kubernetes",
+	Long:    "unpause Kubernetes. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/unpause",
 	Run: func(_ *cobra.Command, _ []string) {
 		options := flags.CommandOptions()
 		cname := ClusterFlagValue()

--- a/cmd/minikube/cmd/update-check.go
+++ b/cmd/minikube/cmd/update-check.go
@@ -28,7 +28,7 @@ import (
 var updateCheckCmd = &cobra.Command{
 	Use:   "update-check",
 	Short: "Print current and latest version number",
-	Long:  `Print current and latest version number`,
+	Long:  `Print current and latest version number. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/update-check`,
 	Run: func(_ *cobra.Command, _ []string) {
 		url := notify.GithubMinikubeReleasesURL
 		r, err := notify.AllVersionsFromURL(url)

--- a/cmd/minikube/cmd/update-context.go
+++ b/cmd/minikube/cmd/update-context.go
@@ -31,8 +31,7 @@ import (
 var updateContextCmd = &cobra.Command{
 	Use:   "update-context",
 	Short: "Update kubeconfig in case of an IP or port change",
-	Long: `Retrieves the IP address of the running cluster, checks it
-			with IP in kubeconfig, and corrects kubeconfig if incorrect.`,
+	Long:  `Retrieves the IP address of the running cluster, checks it with IP in kubeconfig, and corrects kubeconfig if incorrect. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/update-context`,
 	Run: func(_ *cobra.Command, _ []string) {
 		options := flags.CommandOptions()
 		cname := ClusterFlagValue()

--- a/cmd/minikube/cmd/version.go
+++ b/cmd/minikube/cmd/version.go
@@ -43,7 +43,7 @@ var (
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version of minikube",
-	Long:  `Print the version of minikube.`,
+	Long:  `Print the version of minikube. For a detailed example see https://minikube.sigs.k8s.io/docs/commands/version`,
 	Run: func(_ *cobra.Command, _ []string) {
 		options := flags.CommandOptions()
 		minikubeVersion := version.GetVersion()


### PR DESCRIPTION
Updated long description strings for regular and configuration based commands:
- Fixed typos, spacing, and wording where needed
- Added links to respective doc page

Instructions:

`./minikube [command] --help`