### PR TITLE
ui: fix correct formatting in tunnel service output

### DIFF
--- a/pkg/minikube/tunnel/kic/ssh_conn.go
+++ b/pkg/minikube/tunnel/kic/ssh_conn.go
@@ -159,7 +159,7 @@ func createSSHConnWithRandomPorts(name, sshPort, sshKey string, svc *v1.Service)
 
 func (c *sshConn) startAndWait() error {
 	if !c.suppressStdOut {
-		out.Step(style.Running, "Starting tunnel for service {{.service}}.", out.V{"service": c.service})
+		out.Step(style.StartingSSH, "Starting tunnel for service {{.service}}.", out.V{"service": c.service})
 	}
 
 	r, w := io.Pipe()


### PR DESCRIPTION
## Fix formatting issue in `minikube service` tunnel output

**fixes #22133**

### Problem Description
When running `minikube service <service-name>`, as reported in issue #22133, before this fix, the output `Starting tunnel for service <service-name>.` was incorrectly followed by a `/` character without a line break. The table would start printing immediately on the same line. Furthermore, an extra duplicate line `Starting tunnel for service <service-name>.` would appear after the table. The root cause was a race condition: the spinner attached to the status message via `style.Running` used in `pkg/minikube/tunnel/kic/ssh_conn.go` attempted to refresh in place, but the concurrent output of the table moved the cursor, preventing the spinner from overwriting itself. This resulted in the spinner's final state being appended to the end of the output stream.

<img width="1764" height="576" alt="before" src="https://github.com/user-attachments/assets/2459de26-84cb-4e8d-8f9e-5eeb77b5c3b3" />


### Solution in This PR
This PR removes the unintended `/` character and ensures proper line breaks. The fix works by changing the output style to one without a spinner (`style.StartingSSH`). This guarantees that the status message is printed completely (ending with a newline `\n`) before the table is rendered, eliminating the cursor conflict and the duplicate line. This directly resolves the readability issue described in #22133.

<img width="2710" height="687" alt="after" src="https://github.com/user-attachments/assets/c0c24c36-619e-4212-a817-62a77b90b87b" />


### Verification
- Built and tested locally using: `out/minikube service hello-node`
- The output now correctly shows
- `make test` passed.

### Notes on Future UI Considerations
While this PR is aiming at closing #22133 by fixing the immediate formatting bug, it highlights a potential deeper UI concern: printing the final table *while* tunnels are still starting (a process that can sometimes take over a second) might be suboptimal. A more robust approach could involve either:
1.  Printing the table only after all tunnels have been confirmed established, or
2.  Printing the table first and then dynamically updating it with the connection status of each tunnel.
These enhancements are noted here for future consideration but are outside the scope of this specific formatting fix.

---
**Note to Reviewers**

Hi, this is my first PR to the minikube project. I've tried to follow the contribution guidelines, but I'm sure there might be areas I've overlooked or conventions I'm not yet familiar with. I'd be very grateful for any feedback on the fix itself, the code style, or the PR process. Please don't hesitate to point out anything that could be improved. Thank you!