### PR TITLE
wip: improve --wait=all to also verifyextra components (such as etcd)

### DIFF
--- a/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
+++ b/pkg/minikube/bootstrapper/kubeadm/kubeadm.go
@@ -576,6 +576,11 @@ func (k *Bootstrapper) WaitForNode(cfg config.ClusterConfig, n config.Node, time
 				return errors.Wrap(err, "waiting for apps_running")
 			}
 		}
+		if cfg.VerifyComponents[kverify.ExtraKey] {
+			if err := kverify.WaitExtra(cfg.Name, kverify.CorePodsLabels, timeout); err != nil {
+				return errors.Wrap(err, "waiting for extra components")
+			}
+		}
 	}
 
 	if cfg.VerifyComponents[kverify.KubeletKey] {


### PR DESCRIPTION
this should improve flakes in the integraiton test when we are Checking if ETCD is READY 
```
=== RUN   TestFunctional/serial/ComponentHealth
functional_test.go:825: (dbg) Run:  kubectl --context functional-576132 get po -l tier=control-plane -n kube-system -o=json
functional_test.go:840: etcd phase: Running
functional_test.go:848: etcd is not Ready: {Phase:Running Conditions:[{Type:PodReadyToStartContainers Status:True} {Type:Initialized Status:True} {Type:Ready Status:False} {Type:ContainersReady Status:False} {Type:PodScheduled Status:True}] Message: Reason: HostIP:192.168.39.90 PodIP:192.168.39.90 StartTime:2026-01-08 19:53:30 +0000 UTC ContainerStatuses:[{Name:etcd State:{Waiting:<nil> Running:0xc001479b30 Terminated:<nil>} LastTerminationState:{Waiting:<nil> Running:<nil> Terminated:0xc00035c620} Ready:false RestartCount:2 Image:registry.k8s.io/etcd:3.6.6-0 ImageID:registry.k8s.io/etcd@sha256:60a30b5d81b2217555e2cfb9537f655b7ba97220b99c39ee2e162a7127225890 ContainerID:containerd://c02eca693015e75f585b42116372b084c016da238ba15de7bca5735bb56b4d5d}]}
functional_test.go:840: kube-apiserver phase: Running
functional_test.go:850: kube-apiserver status: Ready
functional_test.go:840: kube-controller-manager phase: Running
functional_test.go:850: kube-controller-manager status: Ready
functional_test.go:840: kube-scheduler phase: Running
functional_test.go:850: kube-scheduler status: Ready
```

https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/minikube/21647/integration-kvm-containerd-linux-x86/2009348851953045504/artifacts/test.html#fail_TestFunctional%2fserial%2fComponentHealth

