### PR TITLE
site: Remove dangling link to deleted documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ minikube runs the latest stable release of Kubernetes, with support for standard
 * Multi-cluster - using `minikube start -p <name>`
 * [NodePorts](https://minikube.sigs.k8s.io/docs/handbook/accessing/#nodeport-access) - using `minikube service`
 * [Persistent Volumes](https://minikube.sigs.k8s.io/docs/handbook/persistent_volumes/)
-* [Ingress](https://kubernetes.io/docs/tasks/access-application-cluster/ingress-minikube/)
 * [Dashboard](https://minikube.sigs.k8s.io/docs/handbook/dashboard/) - `minikube dashboard`
 * [Container runtimes](https://minikube.sigs.k8s.io/docs/handbook/config/#runtime-configuration) - `minikube start --container-runtime`
 * [Configure apiserver and kubelet options](https://minikube.sigs.k8s.io/docs/handbook/config/#modifying-kubernetes-defaults) via command-line flags

--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -257,7 +257,7 @@ var Addons = map[string]*Addon{
 			vmpath.GuestAddonsDir,
 			"ingress-deploy.yaml",
 			"0640"),
-	}, false, "ingress", "Kubernetes", "", "https://kubernetes.io/docs/tasks/access-application-cluster/ingress-minikube/", map[string]string{
+	}, false, "ingress", "Kubernetes", "", "https://github.com/kubernetes/ingress-nginx", map[string]string{
 		// https://github.com/kubernetes/ingress-nginx/blob/3476232f5c38383dd157ddaff3b4c7cebd57284e/deploy/static/provider/kind/deploy.yaml#L445
 		"IngressController": "ingress-nginx/controller:v1.14.1@sha256:f95a79b85fb93ac3de752c71a5c27d5ceae10a18b61904dec224c1c6a4581e47",
 		// https://github.com/kubernetes/ingress-nginx/blob/3476232f5c38383dd157ddaff3b4c7cebd57284e/deploy/static/provider/kind/deploy.yaml#L552

--- a/site/content/en/docs/tutorials/nginx_tcp_udp_ingress.md
+++ b/site/content/en/docs/tutorials/nginx_tcp_udp_ingress.md
@@ -238,5 +238,4 @@ for the latest info on these potential changes.
 
 ## Related articles
 
-- [Set up Ingress on Minikube with the NGINX Ingress Controller](https://kubernetes.io/docs/tasks/access-application-cluster/ingress-minikube/)
 - [Use port forwarding to access applications in a cluster](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/)


### PR DESCRIPTION
The upstream documentation was removed without a replacement:

https://github.com/kubernetes/website/commit/2308870fb544ae82fe9917c4737ee0c633016e21

Refer to the git repository, which will soon be retired too.

https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/

----

"We don't want to recomment ingress-nginx any more.

Also, we don't really want to recommend Ingress any more, so we're not going to replace this with anything else."

* https://github.com/kubernetes/minikube/issues/22030

~~https://kubernetes.io/docs/tasks/access-application-cluster/ingress-minikube/~~