### PR TITLE
addon: auto-pause fix github link

### DIFF
--- a/pkg/addons/addons_autopause.go
+++ b/pkg/addons/addons_autopause.go
@@ -39,7 +39,7 @@ func enableOrDisableAutoPause(cc *config.ClusterConfig, name, val string, option
 		return errors.Wrapf(err, "parsing bool: %s", name)
 	}
 	out.Infof("auto-pause addon is an alpha feature and still in early development. Please file issues to help us make it better.")
-	out.Infof("https://github.com/kubernetes/minikube/labels/co/auto-pause")
+	out.Infof("https://github.com/kubernetes/minikube/issues?q=state%3Aopen%20label%3Aco%2Fauto-pause")
 
 	co := mustload.Running(cc.Name, options)
 	if enable {


### PR DESCRIPTION
Fixes #22422  

Fixes the auto-pause label link that is printed after enabling the addon

```
$ minikube addons enable auto-pause -p multinode
💡  auto-pause is an addon maintained by minikube. For any concerns contact minikube on GitHub.
You can view the list of minikube maintainers at: https://github.com/kubernetes/minikube/blob/master/OWNERS
    ▪ Using image gcr.io/k8s-minikube/auto-pause-hook:v0.0.5
    ▪ auto-pause addon is an alpha feature and still in early development. Please file issues to help us make it better.
    ▪ https://github.com/kubernetes/minikube/labels/co/auto-pause
🌟  The 'auto-pause' addon is enabled
```