### PR TITLE
Build(deps): Add golang.org group to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
       k8s-dependencies:
         patterns:
           - "k8s.io/*"
+      golang-org:
+        patterns:
+          - "golang.org/*"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
this will make less noise when it opens 5 golang.org prs they will all be in one PR