### PR TITLE
test: Minimal fix for TestMiniPath on Windows

### DIFF
--- a/pkg/minikube/localpath/localpath_test.go
+++ b/pkg/minikube/localpath/localpath_test.go
@@ -71,9 +71,9 @@ func TestMiniPath(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.env, func(t *testing.T) {
-			expectedPath := filepath.Join(tc.basePath, ".minikube")
 			t.Setenv(MinikubeHome, tc.env)
-			path := MiniPath()
+			expectedPath := filepath.Clean(filepath.Join(tc.basePath, ".minikube"))
+			path := filepath.Clean(MiniPath())
 			if path != expectedPath {
 				t.Errorf("MiniPath expected to return '%s', but got '%s'", expectedPath, path)
 			}


### PR DESCRIPTION
Following up the discussion during latest office hours,
here is a minimal fix as alternative to PR #21739.

The premise is this:
- Both, backslash `\` and slash `/`, are valid path separators on Windows
- Current implementation of `MiniPath` function is correct
- Path normalisation is needed only at point of direct (string) comparison
  in order to avoid OS-specific separators

Before this fix, the `TestMiniPath` was failing with:

```
--- FAIL: TestMiniPath (0.00s)
    --- FAIL: TestMiniPath//tmp/.minikube (0.00s)
        localpath_test.go:78: MiniPath expected to return '\tmp\.minikube', but got '/tmp/.minikube'
```

That is, before the fix, `expectedPath` was returned as `\tmp\.minikube` as it was turned into Windows-native path by `filepath.Join`, whereas `MiniPath` returned `/tmp/.minikube` as it returned vanilla value of `MINIKUBE_HOME`.