### PR TITLE
Fix Podman mount on macOS by adding host.containers.internal support

### DIFF
--- a/pkg/drivers/kic/oci/network.go
+++ b/pkg/drivers/kic/oci/network.go
@@ -81,8 +81,12 @@ func RoutableHostIPFromInside(ociBin string, clusterName string, containerName s
 	if runtime.GOOS == "linux" {
 		return containerGatewayIP(ociBin, containerName)
 	}
-
-	return nil, fmt.Errorf("RoutableHostIPFromInside is currently only implemented for linux")
+	// Podman on macOS and Windows can run inside a VM; host.containers.internal
+	// is the supported DNS entry for host access (similar to host.docker.internal for Docker)
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		return digDNS(ociBin, containerName, "host.containers.internal")
+	}
+	return nil, fmt.Errorf("RoutableHostIPFromInside not implemented for podman on %s", runtime.GOOS)
 }
 
 // digDNS will get the IP record for a dns


### PR DESCRIPTION
### What this PR does / why we need it
Fixes `minikube mount` failure on macOS when using Podman driver by adding DNS resolution support via `host.containers.internal`.
### Which issue(s) this PR fixes
Fixes #22390
### Before and After
**Before:**
❌ Exiting due to IF_HOST_IP: RoutableHostIPFromInside is currently only implemented for linux

**After:**
📁 Mounting host path ./:/app ... 🎉 Successfully mounted ./:/app

### Changes
- Added darwin-specific handling in [RoutableHostIPFromInside](cci:1://file:///Users/abhigyanshekhar/ivorylog/minikube/pkg/drivers/kic/oci/network.go:33:0-89:1)
- Uses `host.containers.internal` DNS (Podman's equivalent to Docker's `host.docker.internal`)
- Improved error message for unsupported platforms
### Testing
- ✅ Build passes
- ✅ Unit tests pass  
- ✅ Linter clean