### PR TITLE
test: Fix TestExtractFile unit test windows 

### DIFF
--- a/pkg/drivers/common/iso_test.go
+++ b/pkg/drivers/common/iso_test.go
@@ -66,9 +66,12 @@ func TestExtractFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create TEST1.TXT: %v", err)
 	}
-	defer rw.Close()
+
 	if _, err := rw.Write([]byte("content1")); err != nil {
 		t.Fatalf("failed to write to TEST1.TXT: %v", err)
+	}
+	if err := rw.Close(); err != nil {
+		t.Fatalf("failed to close TEST1.TXT: %v", err)
 	}
 
 	// 2. Nested directory and file
@@ -79,9 +82,12 @@ func TestExtractFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create TEST2/TEST2.TXT: %v", err)
 	}
-	defer rw2.Close()
+
 	if _, err := rw2.Write([]byte("content2")); err != nil {
 		t.Fatalf("failed to write to TEST2.TXT: %v", err)
+	}
+	if err := rw2.Close(); err != nil {
+		t.Fatalf("failed to close TEST2/TEST2.TXT: %v", err)
 	}
 
 	// Finalize ISO


### PR DESCRIPTION
**Cause**

- The test defers `rw.Close()` and `rw2.Close()`, so the file handles remain open when `isoFs.Finalize(...)` runs.
- `Finalize `(go-diskfs/iso9660) needs the filesystem entries fully written/closed so it can copy/pack them into the image. With the files still open the library observes inconsistent state and fails with "copied 8 bytes, expected 0".

**Fix**

- Close each file immediately after writing it (instead of deferring the Close) so that the contents are flushed and the handles are released prior to `isoFs.Finalize(...)`.
- We now replacing the deferred closes with immediate closes right after writing.
- Closing flushes buffers and ensures the filesystem implementation sees stable, readable file contents to pack into the ISO. That prevents the "copied X bytes, expected 0" / copy inconsistency error.

**Test Failures before the fix**
<img width="1145" height="170" alt="before" src="https://github.com/user-attachments/assets/9ff6b369-65a6-46ad-b071-2ac6926e1e70" />


**Test Run with the fix**
<img width="1117" height="110" alt="after" src="https://github.com/user-attachments/assets/a26b948b-a090-4bbc-8cf0-4703bc5fff47" />
