### PR TITLE
test: Fix TestMigrateHost unit test windows 

### DIFF
--- a/pkg/libmachine/host/migrate_test.go
+++ b/pkg/libmachine/host/migrate_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package host
 
 import (
+	"encoding/json"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,6 +27,21 @@ import (
 )
 
 func TestMigrateHost(t *testing.T) {
+	mustMarshal := func(v any) []byte {
+		t.Helper()
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("failed to marshal expected JSON: %v", err)
+		}
+		return b
+	}
+
+	v2MigratedStorePath := filepath.Clean("/Users/nathanleclaire/.docker/machine")
+	v2MigratedDriverData := mustMarshal(map[string]string{
+		"MachineName": "default",
+		"StorePath":   v2MigratedStorePath,
+	})
+
 	testCases := []struct {
 		description                string
 		hostBefore                 *Host
@@ -175,10 +192,10 @@ func TestMigrateHost(t *testing.T) {
 				},
 				Name:       "default",
 				DriverName: "virtualbox",
-				RawDriver:  []byte(`{"MachineName":"default","StorePath":"/Users/nathanleclaire/.docker/machine"}`),
+				RawDriver:  v2MigratedDriverData,
 				Driver: &RawDataDriver{
-					Data:   []byte(`{"MachineName":"default","StorePath":"/Users/nathanleclaire/.docker/machine"}`),
-					Driver: nodriver.NewDriver("default", "/Users/nathanleclaire/.docker/machine"),
+					Data:   v2MigratedDriverData,
+					Driver: nodriver.NewDriver("default", v2MigratedStorePath),
 				},
 			},
 			expectedMigrationPerformed: true,


### PR DESCRIPTION
**Cause**
`TestMigrateHost `compared hard-coded, Unix-style paths embedded in JSON against values produced on Windows, where path separators are normalized to backslashes. This caused byte-level mismatches in `StorePath `and `RawDriver `despite the migration logic being functionally correct.

**Fix**
- Normalize the expected migrated `StorePath `using `filepath.Clean` and generate the expected `RawDriver `payload via `json.Marshal`, ensuring platform-correct paths and serialization.
- This makes the test OS-agnostic while preserving its original intent and strictness, preventing spurious Windows-only failures without changing production behavior.



**Test Failures before the fix**

<img width="1714" height="977" alt="before" src="https://github.com/user-attachments/assets/c224135c-1251-41f2-9449-057b67267ae9" />


**Test Run with the fix**

<img width="1114" height="148" alt="after" src="https://github.com/user-attachments/assets/f8d8c761-0f36-4ae8-9579-c73d4fba43c4" />


