### PR TITLE
ci: move gvisor addon to registry.k8s.io

### DIFF
--- a/pkg/minikube/assets/addons.go
+++ b/pkg/minikube/assets/addons.go
@@ -506,7 +506,7 @@ var Addons = map[string]*Addon{
 			"gvisor-runtimeclass.yaml",
 			"0640"),
 	}, false, "gvisor", "minikube", "", "https://minikube.sigs.k8s.io/docs/handbook/addons/gvisor/", map[string]string{
-		"GvisorAddon": "registry.k8s.io/minikube/gvisor:v0.0.3@sha256:2cc0438e89691ed5eab3fce6b68fce6982e5de189418ebfc97a0932cda9bc080",
+		"GvisorAddon": "minikube/gvisor:v0.0.3@sha256:2cc0438e89691ed5eab3fce6b68fce6982e5de189418ebfc97a0932cda9bc080",
 	}, map[string]string{
 		"GvisorAddon": "registry.k8s.io",
 	}, nil),


### PR DESCRIPTION
tested manually
```
18:09:30 minikube.c.googlers.com medya/workspace/minikube bump_gvisor_addon_image •1 
$ mk addons enable gvisor
💡  gvisor is an addon maintained by minikube. For any concerns contact minikube on GitHub.
You can view the list of minikube maintainers at: https://github.com/kubernetes/minikube/blob/master/OWNERS
    ▪ Using image registry.k8s.io/minikube/gvisor:v0.0.3
🔎  Verifying gvisor addon...
🌟  The 'gvisor' addon is enabled
18:09:47 minikube.c.googlers.com medya/workspace/minikube bump_gvisor_addon_image •1 
$ kc get pods -A
NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE
kube-system   coredns-7d764666f9-r7p8n           1/1     Running   0          6m38s
kube-system   etcd-minikube                      1/1     Running   0          6m45s
kube-system   gvisor                             1/1     Running   0          6m31s
kube-system   kindnet-f75ln                      1/1     Running   0          6m38s
kube-system   kube-apiserver-minikube            1/1     Running   0          6m43s
kube-system   kube-controller-manager-minikube   1/1     Running   0          6m43s
kube-system   kube-proxy-2t46q                   1/1     Running   0          6m38s
kube-system   kube-scheduler-minikube            1/1     Running   0          6m43s
kube-system   storage-provisioner                1/1     Running   0          6m41s
18:09:51 minikube.c.googlers.com medya/workspace/minikube bump_gvisor_addon_image •1 
$ kubectl get pod,runtimeclass gvisor -n kube-system
NAME         READY   STATUS    RESTARTS   AGE
pod/gvisor   1/1     Running   0          6m45s

NAME                              HANDLER   AGE
runtimeclass.node.k8s.io/gvisor   runsc     6m45s
```

https://github.com/kubernetes/minikube/issues/22404