### PR TITLE
fix: typos in error message and comments

### DIFF
--- a/pkg/drivers/virtualbox/network.go
+++ b/pkg/drivers/virtualbox/network.go
@@ -37,7 +37,7 @@ const (
 //nolint:staticcheck // ST1005: error strings should not be capitalized
 var (
 	reHostOnlyAdapterCreated         = regexp.MustCompile(`Interface '(.+)' was successfully created`)
-	errNewHostOnlyAdapterNotVisible  = errors.New("The host-only adapter we just created is not visible. This is a well known VirtualBox bug. You might want to uninstall it and reinstall at least version 5.0.12 that is is supposed to fix this issue")
+	errNewHostOnlyAdapterNotVisible  = errors.New("The host-only adapter we just created is not visible. This is a well known VirtualBox bug. You might want to uninstall it and reinstall at least version 5.0.12 that is supposed to fix this issue")
 	errFailedToCreateHostOnlyAdapter = errors.New("Failed to create host-only adapter")
 	errFailedToFindHostOnlyAdapter   = errors.New("Failed to find a new host-only adapter")
 )

--- a/pkg/minikube/out/out_reason.go
+++ b/pkg/minikube/out/out_reason.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/minikube/pkg/minikube/style"
 )
 
-// Error shows an an error reason
+// Error shows an error reason
 func Error(k reason.Kind, format string, a ...V) {
 	if JSON {
 		msg := Fmt(format, a...)

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -142,7 +142,7 @@ func HyperVDriver() bool {
 	return matchDriverFlag("hyperv")
 }
 
-// KVM returns true is is KVM driver
+// KVM returns true if is KVM driver
 func KVMDriver() bool {
 	return matchDriverFlag("kvm", "kvm2")
 }


### PR DESCRIPTION
Fix typos: `is is` → `if is` / `is`, `an an` → `an`