### PR TITLE
fix: return non-zero exit code when status unavailable

### DIFF
--- a/cmd/minikube/cmd/status.go
+++ b/cmd/minikube/cmd/status.go
@@ -159,6 +159,9 @@ func writeStatusesAtInterval(duration time.Duration, api libmachine.API, cc *con
 
 // exitCode calculates the appropriate exit code given a set of status messages
 func exitCode(statuses []*cluster.Status) int {
+	if len(statuses) == 0 {
+		return minikubeNotRunningStatusFlag | clusterNotRunningStatusFlag | k8sNotRunningStatusFlag
+	}
 	c := 0
 	for _, st := range statuses {
 		if st.Host != state.Running.String() {

--- a/cmd/minikube/cmd/status_test.go
+++ b/cmd/minikube/cmd/status_test.go
@@ -43,6 +43,22 @@ func TestExitCode(t *testing.T) {
 			}
 		})
 	}
+
+	// When GetStatus fails, statuses will be nil and should return non-zero exit code
+	t.Run("nil", func(t *testing.T) {
+		got := exitCode(nil)
+		if got != 7 {
+			t.Errorf("exitCode(nil) = %d, want: 7", got)
+		}
+	})
+
+	// Empty slice should also return non-zero exit code
+	t.Run("empty", func(t *testing.T) {
+		got := exitCode([]*cluster.Status{})
+		if got != 7 {
+			t.Errorf("exitCode([]) = %d, want: 7", got)
+		}
+	})
 }
 
 func TestStatusText(t *testing.T) {


### PR DESCRIPTION
**What this PR does**

Fixes `minikube status` returning exit code 0 when the Docker container does not exist.

**Root cause**: When `cluster.GetStatus()` fails, it returns `nil` statuses. The `exitCode()` function's for-loop doesn't execute for nil/empty slices, returning 0.

**Fix**: Add nil/empty check at the start of `exitCode()` to return 7 (all components not running).

**Changes**
- `cmd/minikube/cmd/status.go`: Add nil check in `exitCode()` (+3 lines)
- `cmd/minikube/cmd/status_test.go`: Add test cases for nil and empty statuses (+16 lines)

**Verification**
- `exitCode()` function: 100% test coverage
- All unit tests pass
- Lint passes (0 issues)
- Manual test: exit code = 7 when container missing

Fixes #22466