### PR TITLE
docs: Clarify container runtime choice

### DIFF
--- a/site/content/en/docs/handbook/config.md
+++ b/site/content/en/docs/handbook/config.md
@@ -89,13 +89,17 @@ minikube start --extra-config=kubeadm.ignore-preflight-errors=SystemVerification
 
 ## Runtime configuration
 
-The default container runtime in minikube varies. You can select one explicitly by using:
+The default container runtime in minikube is [Docker]({{<ref "/docs/runtimes/docker">}}).
+
+Depending on specific factors like the driver you choose, there may be recommendations of a preferred container runtime, see [drivers page]({{<ref "/docs/drivers">}}) for details.
+
+You can select container runtime explicitly by using:
 
 ```shell
 minikube start --container-runtime=docker
 ```
 
-Options available are:
+The available options are:
 
 * [containerd]({{<ref "/docs/runtimes/containerd">}})
 * [cri-o]({{<ref "/docs/runtimes/cri-o">}})


### PR DESCRIPTION
Improve the originally laconic guidance clarifying the default runtime
and explaining that specific drivers may require or recommend alternative.

The updated guidance should also help users understand the choice of
container runtime is not clear-cut and may require consideration
depending on the use case.

----

Digression: As a still inexperienced Minikube user, I was looking into #22390 and `minikube start --driver=podman --container-runtime=cri-o` made me wonder, why `cri-o`? Can/Shall I try different runtime? Based on what, OS of my host, driver? ;)

The runtimes pages do not seem to mention conditions of their choice, but some drivers do, like podman:

> It’s recommended to run minikube with the podman driver and CRI-O container runtime (except when using Rootless Podman): (...) For Rootless Podman, it is recommended to set --container-runtime to containerd

but the original section updated in this PR did not seem to suggest users should look for answers on pages of drivers.