### PR TITLE
docs: GNU Make prerequisite on Windows

### DIFF
--- a/site/content/en/docs/contrib/building/binaries.md
+++ b/site/content/en/docs/contrib/building/binaries.md
@@ -8,7 +8,9 @@ weight: 2
 ## Prerequisites
 
 * A recent Go distribution (>=1.22.0)
-* If you are on Windows, you'll need Docker to be installed.
+* If you are on Windows, you'll need to have installed
+  * Docker
+  * GNU Make e.g. `winget install GnuWin32.make`, then add `C:\Program Files (x86)\GnuWin32\bin` to `PATH`
 * 4GB of RAM
 
 ## Downloading the source


### PR DESCRIPTION
The building documentation already guides to use Git Bash
to run `make` but since Git Bash does not come with GNU Make,
users may appreciate a no-brainer instruction how to get `make`.

------

Alternative way to get `make` is to use `choco install make`, but it requires installation of the Chocolatey.
The WinGet is Windows-native pre-installed package manager.

