### PR TITLE
test: Fix TestMigrateHostV1ToHostV2 unit test windows

### DIFF
--- a/pkg/libmachine/host/migrate_v1_v2_test.go
+++ b/pkg/libmachine/host/migrate_v1_v2_test.go
@@ -99,8 +99,9 @@ var (
 
 func TestMigrateHostV1ToHostV2(t *testing.T) {
 	h := &Host{}
-	expectedGlobalStorePath := "/Users/catbug/.docker/machine"
+	expectedGlobalStorePath := filepath.Clean("/Users/catbug/.docker/machine")
 	expectedCaPrivateKeyPath := "/Users/catbug/.docker/machine/certs/ca-key.pem"
+	expectedCertDir := filepath.Join(expectedGlobalStorePath, "certs")
 	migratedHost, migrationPerformed, err := MigrateHost(h, v1conf)
 	if err != nil {
 		t.Fatalf("Error attempting to migrate host: %s", err)
@@ -110,15 +111,15 @@ func TestMigrateHostV1ToHostV2(t *testing.T) {
 		t.Fatal("Expected a migration to be reported as performed but it was not")
 	}
 
-	if migratedHost.HostOptions.AuthOptions.StorePath != expectedGlobalStorePath {
-		t.Fatalf("Expected %q, got %q for the store path in AuthOptions", migratedHost.HostOptions.AuthOptions.StorePath, expectedGlobalStorePath)
+	if filepath.Clean(migratedHost.HostOptions.AuthOptions.StorePath) != expectedGlobalStorePath {
+		t.Fatalf("Expected %q, got %q for the store path in AuthOptions", expectedGlobalStorePath, filepath.Clean(migratedHost.HostOptions.AuthOptions.StorePath))
 	}
 
 	if migratedHost.HostOptions.AuthOptions.CaPrivateKeyPath != expectedCaPrivateKeyPath {
-		t.Fatalf("Expected %q, got %q for the private key path in AuthOptions", migratedHost.HostOptions.AuthOptions.CaPrivateKeyPath, expectedCaPrivateKeyPath)
+		t.Fatalf("Expected %q, got %q for the private key path in AuthOptions", expectedCaPrivateKeyPath, migratedHost.HostOptions.AuthOptions.CaPrivateKeyPath)
 	}
 
-	if migratedHost.HostOptions.AuthOptions.CertDir != filepath.Join(expectedGlobalStorePath, "certs") {
-		t.Fatalf("Expected %q, got %q for the cert dir in AuthOptions", migratedHost.HostOptions.AuthOptions.CaPrivateKeyPath, expectedGlobalStorePath)
+	if filepath.Clean(migratedHost.HostOptions.AuthOptions.CertDir) != expectedCertDir {
+		t.Fatalf("Expected %q, got %q for the cert dir in AuthOptions", expectedCertDir, filepath.Clean(migratedHost.HostOptions.AuthOptions.CertDir))
 	}
 }


### PR DESCRIPTION
**Cause**
`TestMigrateHostV1ToHostV2 `hard-coded Unix-style expected paths. On Windows, MigrateHost normalizes `AuthOptions.StorePath` (and derived `CertDir`) to use Windows path separators, but `CaPrivateKeyPath `remains unchanged (still the literal Unix-style string from the v1 config). This mismatch caused Windows-only assertion failures.

**Fix**
Update the test to be OS-aware by:

- comparing `StorePath `and `CertDir` using `filepath.Clean(...)` (and building `expectedCertDir `from the cleaned store path), and
- leaving `expectedCaPrivateKeyPath `as the original Unix-style literal and comparing it directly (since migration currently preserves it verbatim).

**Why this works**
The test now matches actual migration behavior:

- fields that are normalized by the migration (`StorePath`, derived `CertDir`) are compared in a platform-correct way, and
- fields that are not normalized (`CaPrivateKeyPath`) are validated exactly as produced.  This preserves test strictness while eliminating spurious platform-dependent failures.

**Test Failures before the fix**
<img width="584" height="122" alt="before" src="https://github.com/user-attachments/assets/a364c534-1f9f-46ea-a500-d82841ae7497" />


**Test Run with the fix**
<img width="578" height="65" alt="after" src="https://github.com/user-attachments/assets/2de0660c-0885-441b-b05f-9b072f17fd64" />

